### PR TITLE
axbuild: show and stream process output

### DIFF
--- a/scripts/axbuild/src/arceos/build.rs
+++ b/scripts/axbuild/src/arceos/build.rs
@@ -20,12 +20,15 @@ use std::{
 
 use anyhow::{Context, Result};
 
-use crate::arceos::{
-    config::{AXCONFIG_FILE_NAME, ArceosConfig},
-    context::AxContext,
-    features::FeatureResolver,
-    ostool as ostool_bridge,
-    platform::PlatformResolver,
+use crate::{
+    arceos::{
+        config::{AXCONFIG_FILE_NAME, ArceosConfig},
+        context::AxContext,
+        features::FeatureResolver,
+        ostool as ostool_bridge,
+        platform::PlatformResolver,
+    },
+    process::{run_output, run_status},
 };
 
 const DEFAULT_DEFCONFIG_CONTENT: &str = r#"# Stack size of each task.
@@ -102,15 +105,9 @@ impl Builder {
             self.ctx.manifest_dir().display()
         );
 
-        let status = Command::new("cargo")
-            .current_dir(self.ctx.manifest_dir())
-            .arg("clean")
-            .status()
-            .context("Failed to run cargo clean")?;
-
-        if !status.success() {
-            anyhow::bail!("cargo clean failed with status: {}", status);
-        }
+        let mut command = Command::new("cargo");
+        command.current_dir(self.ctx.manifest_dir()).arg("clean");
+        run_status(&mut command, "cargo clean")?;
 
         for file in cleanup_files(self.ctx.manifest_dir(), self.ctx.app_dir()) {
             if file.exists() {
@@ -259,15 +256,9 @@ impl ArtifactPreparer {
             args.push(format!("plat.max-cpu-num={}", smp));
         }
 
-        let status = Command::new("axconfig-gen")
-            .current_dir(&self.manifest_dir)
-            .args(&args)
-            .status()
-            .context("Failed to run axconfig-gen")?;
-
-        if !status.success() {
-            anyhow::bail!("axconfig-gen failed with status: {}", status);
-        }
+        let mut command = Command::new("axconfig-gen");
+        command.current_dir(&self.manifest_dir).args(&args);
+        run_status(&mut command, "axconfig-gen")?;
 
         Ok(())
     }
@@ -285,31 +276,20 @@ impl ArtifactPreparer {
         app_dir: &Path,
         platform_package: &str,
     ) -> Result<PathBuf> {
-        let output = Command::new("cargo")
+        let desc = format!(
+            "cargo axplat info -C {} -c {}",
+            app_dir.display(),
+            platform_package
+        );
+        let mut command = Command::new("cargo");
+        command
             .arg("axplat")
             .arg("info")
             .arg("-C")
             .arg(app_dir)
             .arg("-c")
-            .arg(platform_package)
-            .output()
-            .with_context(|| {
-                format!(
-                    "Failed to run `cargo axplat info -C {} -c {}`",
-                    app_dir.display(),
-                    platform_package
-                )
-            })?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "cargo axplat info failed for package `{}`: {}\nstderr:\n{}",
-                platform_package,
-                output.status,
-                stderr
-            );
-        }
+            .arg(platform_package);
+        let output = run_output(&mut command, &desc)?;
 
         let config_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if config_path.is_empty() {
@@ -339,20 +319,10 @@ impl ArtifactPreparer {
 
     fn parse_mem_size(&self, mem: &str) -> Result<String> {
         let script = resolve_strtosz_script_path(&self.manifest_dir)?;
-        let output = Command::new(&script)
-            .arg(mem)
-            .output()
-            .with_context(|| format!("Failed to run {}", script.display()))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "failed to parse memory size `{}` via {}: {}",
-                mem,
-                script.display(),
-                stderr.trim()
-            );
-        }
+        let desc = format!("{} {}", script.display(), mem);
+        let mut command = Command::new(&script);
+        command.arg(mem);
+        let output = run_output(&mut command, &desc)?;
 
         let parsed = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if parsed.is_empty() {

--- a/scripts/axbuild/src/arceos/platform.rs
+++ b/scripts/axbuild/src/arceos/platform.rs
@@ -17,10 +17,13 @@ use std::{
     process::Command,
 };
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::arceos::{ArceosConfig, Arch};
+use crate::{
+    arceos::{ArceosConfig, Arch},
+    process::run_output,
+};
 
 /// Platform resolver
 pub struct PlatformResolver {
@@ -78,17 +81,7 @@ impl PlatformResolver {
             cmd.arg("--platform").arg(plat);
         }
 
-        let output = cmd.output().context("Failed to run cargo-axplat info")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "cargo-axplat info failed: {}\nstderr: {}",
-                output.status,
-                stderr
-            );
-        }
-
+        let output = run_output(&mut cmd, "cargo axplat info")?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         self.parse_axplat_output(&stdout)
     }

--- a/scripts/axbuild/src/axvisor/clippy.rs
+++ b/scripts/axbuild/src/axvisor/clippy.rs
@@ -20,6 +20,7 @@ use colored::*;
 
 // Import ClippyArgs from main.rs
 use super::ClippyArgs;
+use crate::process::run_output;
 
 /// Static target array configuration
 const TARGETS: &[&str] = &["x86_64-unknown-none", "aarch64-unknown-none-softfloat"];
@@ -358,66 +359,32 @@ fn run_single_clippy(
     // Set environment variable for stricter checking
     cmd.env("RUSTFLAGS", "-D warnings");
 
-    let fix_str = if fix { " --fix" } else { "" };
-    let allow_dirty_str = if fix && allow_dirty {
-        " --allow-dirty"
-    } else {
-        ""
-    };
-    println!(
-        "    Executing: {}",
-        format!(
-            "cargo clippy --target {} -p {}{}{}{}",
-            target,
-            package,
-            if features.is_empty() {
-                String::new()
-            } else {
-                format!(" --features {}", features.join(","))
-            },
-            fix_str,
-            allow_dirty_str
-        )
-        .dimmed()
-    );
-
-    let output = cmd.output().context(format!(
-        "Failed to execute cargo clippy: target={target}, package={package}, features={features:?}"
-    ))?;
-
-    if output.status.success() {
-        // Even if successful, check if there's output (sometimes clippy has warnings but still returns success)
-        if !output.stderr.is_empty() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("warning:") || stderr.contains("error:") {
-                return Err(anyhow!("Clippy output warnings or errors:\n{stderr}"));
+    let desc = format!("cargo clippy: target={target}, package={package}, features={features:?}");
+    let output = match run_output(&mut cmd, &desc) {
+        Ok(output) => output,
+        Err(err) => {
+            if continue_on_error {
+                eprintln!("    {}", format!("⚠️  Error (continuing): {err}").yellow());
+                return Ok(());
             }
+            return Err(err.context("Clippy check failed"));
         }
-        println!("    {}", "✅ Passed".green());
-        Ok(())
-    } else {
+    };
+
+    // Even if successful, check if there's output (sometimes clippy has warnings but still returns success)
+    if !output.stderr.is_empty() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        let error_msg = if !stderr.is_empty() {
-            stderr.to_string()
-        } else if !stdout.is_empty() {
-            stdout.to_string()
-        } else {
-            format!(
-                "clippy check failed, exit code: {}",
-                output.status.code().unwrap_or(-1)
-            )
-        };
-
-        if continue_on_error {
-            eprintln!(
-                "    {}",
-                format!("⚠️  Error (continuing):\n{error_msg}").yellow()
+        if stderr.contains("warning:") || stderr.contains("error:") {
+            let err = anyhow!(
+                "Clippy output contains warnings or errors for target={target}, package={package}"
             );
-            Ok(())
-        } else {
-            Err(anyhow!("Clippy check failed:\n{error_msg}"))
+            if continue_on_error {
+                eprintln!("    {}", format!("⚠️  Error (continuing): {err}").yellow());
+                return Ok(());
+            }
+            return Err(err);
         }
     }
+    println!("    {}", "✅ Passed".green());
+    Ok(())
 }

--- a/scripts/axbuild/src/axvisor/devspace.rs
+++ b/scripts/axbuild/src/axvisor/devspace.rs
@@ -23,6 +23,8 @@ use anyhow::{Context, Result, anyhow};
 use cargo_metadata::{Metadata, MetadataCommand, Package};
 use serde::{Deserialize, Serialize};
 
+use crate::process::run_status;
+
 const STATE_DIR: &str = ".devspace";
 const STATE_FILE: &str = ".devspace/state.json";
 const PATCH_BEGIN_MARKER: &str = "# >>> devspace patches >>>";
@@ -450,15 +452,10 @@ fn to_unix_path(path: &Path) -> String {
 }
 
 fn run_git(args: &[&str]) -> Result<()> {
-    let status = Command::new("git")
-        .current_dir(workspace_root()?)
-        .args(args)
-        .status()
-        .with_context(|| format!("Failed to run git {}", args.join(" ")))?;
-    if !status.success() {
-        return Err(anyhow!("git command failed: git {}", args.join(" ")));
-    }
-    Ok(())
+    let desc = format!("git {}", args.join(" "));
+    let mut command = Command::new("git");
+    command.current_dir(workspace_root()?).args(args);
+    run_status(&mut command, &desc)
 }
 
 fn workspace_root() -> Result<PathBuf> {

--- a/scripts/axbuild/src/lib.rs
+++ b/scripts/axbuild/src/lib.rs
@@ -23,6 +23,7 @@ extern crate anyhow;
 
 pub mod arceos;
 pub mod axvisor;
+pub(crate) mod process;
 
 pub use arceos::{
     build::{BuildOutput, Builder, PreparedArtifacts, prepare_artifacts},

--- a/scripts/axbuild/src/process.rs
+++ b/scripts/axbuild/src/process.rs
@@ -1,0 +1,265 @@
+// Copyright 2025 The tgoskits Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    ffi::OsStr,
+    io::{self, Read, Write},
+    path::Path,
+    process::{Command, ExitStatus, Stdio},
+    thread,
+};
+
+use anyhow::{Context, Result, anyhow};
+use colored::Colorize;
+
+#[derive(Debug)]
+pub(crate) struct CapturedOutput {
+    pub(crate) stdout: Vec<u8>,
+    pub(crate) stderr: Vec<u8>,
+}
+
+pub(crate) fn run_status(command: &mut Command, desc: impl AsRef<str>) -> Result<()> {
+    let desc = desc.as_ref();
+    print_command(command);
+    let status = command
+        .status()
+        .with_context(|| format!("Failed to run {desc}"))?;
+    ensure_success(status, desc)
+}
+
+pub(crate) fn run_output(command: &mut Command, desc: impl AsRef<str>) -> Result<CapturedOutput> {
+    let desc = desc.as_ref();
+    prepare_output_command(command);
+    print_command(command);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("Failed to run {desc}"))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .with_context(|| format!("Failed to capture stdout for {desc}"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .with_context(|| format!("Failed to capture stderr for {desc}"))?;
+
+    let stdout_handle = spawn_forwarder(stdout, Stream::Stdout);
+    let stderr_handle = spawn_forwarder(stderr, Stream::Stderr);
+
+    let status = child
+        .wait()
+        .with_context(|| format!("Failed to wait for {desc}"))?;
+    let stdout = join_forwarder(stdout_handle, desc, "stdout")?;
+    let stderr = join_forwarder(stderr_handle, desc, "stderr")?;
+
+    ensure_success(status, desc)?;
+    Ok(CapturedOutput { stdout, stderr })
+}
+
+fn ensure_success(status: ExitStatus, desc: &str) -> Result<()> {
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("{desc} failed with status: {status}"))
+    }
+}
+
+fn spawn_forwarder<R>(reader: R, stream: Stream) -> thread::JoinHandle<io::Result<Vec<u8>>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || forward_and_capture(reader, stream))
+}
+
+fn join_forwarder(
+    handle: thread::JoinHandle<io::Result<Vec<u8>>>,
+    desc: &str,
+    stream_name: &str,
+) -> Result<Vec<u8>> {
+    handle
+        .join()
+        .map_err(|_| anyhow!("Output forwarder thread for {desc} panicked"))?
+        .with_context(|| format!("Failed to forward {stream_name} for {desc}"))
+}
+
+fn forward_and_capture<R>(mut reader: R, stream: Stream) -> io::Result<Vec<u8>>
+where
+    R: Read,
+{
+    let mut captured = Vec::new();
+    let mut buf = [0u8; 8192];
+
+    match stream {
+        Stream::Stdout => {
+            let stdout = io::stdout();
+            let mut writer = stdout.lock();
+            loop {
+                let read = reader.read(&mut buf)?;
+                if read == 0 {
+                    writer.flush()?;
+                    return Ok(captured);
+                }
+                writer.write_all(&buf[..read])?;
+                writer.flush()?;
+                captured.extend_from_slice(&buf[..read]);
+            }
+        }
+        Stream::Stderr => {
+            let stderr = io::stderr();
+            let mut writer = stderr.lock();
+            loop {
+                let read = reader.read(&mut buf)?;
+                if read == 0 {
+                    writer.flush()?;
+                    return Ok(captured);
+                }
+                writer.write_all(&buf[..read])?;
+                writer.flush()?;
+                captured.extend_from_slice(&buf[..read]);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Stream {
+    Stdout,
+    Stderr,
+}
+
+fn prepare_output_command(command: &mut Command) {
+    command.env_remove("NO_COLOR");
+    maybe_set_env(command, "CLICOLOR_FORCE", "1");
+    if matches!(command_name(command).as_deref(), Some("cargo")) {
+        maybe_set_env(command, "CARGO_TERM_COLOR", "always");
+    }
+}
+
+fn maybe_set_env(command: &mut Command, key: &str, value: &str) {
+    if !command
+        .get_envs()
+        .any(|(existing_key, _)| existing_key == OsStr::new(key))
+    {
+        command.env(key, value);
+    }
+}
+
+fn print_command(command: &Command) {
+    eprintln!(
+        "{}",
+        format!("Running: {}", format_command(command)).purple()
+    );
+}
+
+fn format_command(command: &Command) -> String {
+    let mut parts = Vec::new();
+    parts.push(format_arg(command.get_program()));
+    parts.extend(command.get_args().map(format_arg));
+    parts.join(" ")
+}
+
+fn format_arg(arg: &OsStr) -> String {
+    let rendered = arg.to_string_lossy();
+    if rendered.is_empty()
+        || rendered
+            .chars()
+            .any(|c| c.is_whitespace() || c == '"' || c == '\'')
+    {
+        format!("{rendered:?}")
+    } else {
+        rendered.into_owned()
+    }
+}
+
+fn command_name(command: &Command) -> Option<String> {
+    Path::new(command.get_program())
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::{command_name, format_command, prepare_output_command, run_output, run_status};
+
+    #[cfg(unix)]
+    fn shell_command(script: &str) -> Command {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(script);
+        command
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_output_captures_stdout_and_stderr() {
+        let mut command = shell_command("printf 'out'; printf 'err' >&2");
+        let output = run_output(&mut command, "test command").expect("command should succeed");
+
+        assert_eq!(output.stdout, b"out");
+        assert_eq!(output.stderr, b"err");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_status_reports_non_zero_exit() {
+        let mut command = shell_command("exit 7");
+        let err = run_status(&mut command, "failing command").expect_err("command should fail");
+
+        assert!(
+            err.to_string()
+                .contains("failing command failed with status")
+        );
+    }
+
+    #[test]
+    fn format_command_quotes_whitespace_arguments() {
+        let mut command = Command::new("cargo");
+        command.arg("axplat").arg("info").arg("hello world");
+
+        assert_eq!(
+            format_command(&command),
+            r#"cargo axplat info "hello world""#
+        );
+    }
+
+    #[test]
+    fn prepare_output_command_forces_color_for_cargo() {
+        let mut command = Command::new("cargo");
+        prepare_output_command(&mut command);
+
+        let envs = command
+            .get_envs()
+            .map(|(key, value)| {
+                (
+                    key.to_string_lossy().into_owned(),
+                    value.map(|value| value.to_string_lossy().into_owned()),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(command_name(&command).as_deref(), Some("cargo"));
+        assert!(
+            envs.iter()
+                .any(|(key, value)| key == "CLICOLOR_FORCE" && value.as_deref() == Some("1"))
+        );
+        assert!(
+            envs.iter()
+                .any(|(key, value)| key == "CARGO_TERM_COLOR" && value.as_deref() == Some("always"))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared axbuild process helper that streams child stdout/stderr while still capturing output when needed
- print each external command in purple before execution and preserve colorized cargo output for piped commands
- switch arceos and axvisor process call sites to the shared helper and keep clippy continue-on-error behavior

## Testing
- cargo test -p axbuild
