### PR TITLE
feat(axvisor): support Phytium Pi and RK3568 boards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
  "rdrive",
  "regex",
  "reqwest 0.13.2",
+ "rk3568_clk",
  "rk3588-clk",
  "rockchip-pm",
  "schemars",
@@ -5858,6 +5859,19 @@ dependencies = [
  "log",
  "riscv-h",
  "spin 0.10.0",
+]
+
+[[package]]
+name = "rk3568_clk"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9786b01d79acb045652d4cb451b049b26a509171d4afe5c19767d06a366585"
+dependencies = [
+ "aarch64-cpu 10.0.0",
+ "bare-test-macros",
+ "fdt-parser",
+ "kspin",
+ "log",
 ]
 
 [[package]]

--- a/components/arm_vcpu/src/lib.rs
+++ b/components/arm_vcpu/src/lib.rs
@@ -36,6 +36,15 @@ pub use self::{
 /// context frame for aarch64
 pub type TrapFrame = context_frame::Aarch64ContextFrame;
 
+/// Returns the maximum guest page table levels supported by the hardware.
+///
+/// This is determined by the physical address size:
+/// - 44+ bit PA → 4 levels (48-bit IPA)
+/// - < 44 bit PA → 3 levels (39-bit IPA)
+pub fn max_guest_page_table_levels() -> usize {
+    vcpu::max_gpt_level(vcpu::pa_bits())
+}
+
 /// Return if current platform support virtualization extension.
 pub fn has_hardware_support() -> bool {
     // Hint:

--- a/components/axvm/src/vcpu.rs
+++ b/components/axvm/src/vcpu.rs
@@ -22,6 +22,9 @@ cfg_if::cfg_if! {
         #[allow(dead_code)]
         pub type AxVCpuCreateConfig = ();
 
+        /// x86_64 EPT always uses 4-level page tables.
+        pub fn max_guest_page_table_levels() -> usize { 4 }
+
         // Note:
         // According to the requirements of `x86_vcpu`,
         // users of the `x86_vcpu` crate need to implement the `PhysFrameIf` trait for it with the help of `crate_interface`.
@@ -33,12 +36,17 @@ cfg_if::cfg_if! {
         pub use riscv_vcpu::RISCVPerCpu as AxVMArchPerCpuImpl;
         pub use riscv_vcpu::RISCVVCpuCreateConfig as AxVCpuCreateConfig;
         pub use riscv_vcpu::has_hardware_support;
+
+        /// RISC-V uses Sv39 (3 levels) or Sv48 (4 levels) for guest page tables.
+        /// Default to 4 levels (Sv48) for maximum address space.
+        pub fn max_guest_page_table_levels() -> usize { 4 }
     } else if #[cfg(target_arch = "aarch64")] {
         pub use arm_vcpu::Aarch64VCpu as AxArchVCpuImpl;
         pub use arm_vcpu::Aarch64PerCpu as AxVMArchPerCpuImpl;
         pub use arm_vcpu::Aarch64VCpuCreateConfig as AxVCpuCreateConfig;
         pub use arm_vcpu::Aarch64VCpuSetupConfig as AxVCpuSetupConfig;
         pub use arm_vcpu::has_hardware_support;
+        pub use arm_vcpu::max_guest_page_table_levels;
 
         pub use arm_vgic::vtimer::get_sysreg_device;
     }

--- a/components/axvm/src/vm.rs
+++ b/components/axvm/src/vm.rs
@@ -153,8 +153,7 @@ impl AxVM {
     /// The VM is not started until `boot` is called.
     pub fn new(config: AxVMConfig) -> AxResult<AxVMRef> {
         let address_space =
-            // TODO: read level from config
-            AddrSpace::new_empty(4, GuestPhysAddr::from(VM_ASPACE_BASE), VM_ASPACE_SIZE)?;
+            AddrSpace::new_empty(crate::vcpu::max_guest_page_table_levels(), GuestPhysAddr::from(VM_ASPACE_BASE), VM_ASPACE_SIZE)?;
 
         let result = Arc::new(Self {
             id: config.id(),

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -39,6 +39,7 @@ fs = ["axstd/fs"]
 dyn-plat = ["axstd/plat-dyn"]
 # Driver features (from former driver crate)
 rk3588-clk = ["dep:rk3588-clk"]
+rk3568-clk = ["dep:rk3568_clk"]
 sdmmc = ["dep:sdmmc"]
 rockchip-pm = ["dep:rockchip-pm"]
 phytium-blk = ["dep:phytium-mci"]
@@ -100,6 +101,7 @@ pcie = "0.5.0"
 # Optional driver dependencies
 sdmmc = { version = "0.1", default-features = false, features = ["pio"], optional = true }
 rk3588-clk = { version = "0.1", optional = true }
+rk3568_clk = { version = "0.1", optional = true }
 rockchip-pm = { version = "0.4", optional = true }
 phytium-mci = { version = "0.1", default-features = false, features = ["pio"], optional = true }
 


### PR DESCRIPTION
- Add rk3568_clk driver as optional dependency for RK3568 clock support
- Dynamically determine guest page table levels based on physical address size (3 levels for 44-bit PA like Phytium Pi, 4 levels otherwise)
- Export max_guest_page_table_levels() in arm_vcpu and axvm