### PR TITLE
[codex] Update CI workflow checks

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -2,8 +2,13 @@ name: Publish Container Image
 
 on:
   push:
-    tags:
-      - "container-*"
+    branches:
+      - main
+      - dev
+    paths:
+      - ".github/workflows/container-publish.yml"
+      - "container/Dockerfile"
+      - "rust-toolchain.toml"
 
 permissions: {}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - run: rustc --version
+      - run: cargo fmt --all -- --check
+
   test_std:
     name: Test with std
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions job to run `cargo fmt --all -- --check`
- limit container image publishing to pushes on `main` and `dev` when container-related files change
- keep CI workflow changes scoped to the files that affect the container image and formatting checks

## Why
The test workflow should fail early when Rust formatting drifts. The container publish workflow should rebuild only when files that affect the image or its consumers change, which reduces unnecessary image publishes.

## Impact
CI now enforces formatting in pull requests and pushes. Container image publishing becomes less noisy and only runs for relevant changes on the main development branches.

## Validation
- reviewed the staged workflow diff
- verified the updated trigger configuration in `.github/workflows/container-publish.yml`
