### PR TITLE
axbuild(starry): Add timeout and multi-line shell command support

### DIFF
--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{fs, path::Path, path::PathBuf};
 
 use anyhow::Context;
 use clap::{Args, Subcommand};
@@ -86,6 +86,10 @@ pub enum TestCommand {
 pub struct ArgsTestQemu {
     #[arg(long, alias = "arch", value_name = "ARCH")]
     pub target: String,
+    #[arg(long, value_name = "CMD_OR_FILE")]
+    pub shell_init_cmd: Option<String>,
+    #[arg(long, value_name = "SECONDS", help = "Test timeout in seconds (0 to disable timeout)")]
+    pub timeout: Option<u64>,
 }
 
 #[derive(Args, Debug, Clone, Default)]
@@ -157,6 +161,29 @@ impl Starry {
         self.run_uboot_request(request).await
     }
 
+    fn resolve_shell_init_cmd(input: Option<String>) -> anyhow::Result<Option<String>> {
+        match input {
+            None => Ok(None),
+            Some(value) => {
+                let path = Path::new(&value);
+                if path.exists() {
+                    let content = fs::read_to_string(&path)
+                        .with_context(|| format!("failed to read shell init cmd file: {}", path.display()))?;
+                    // Join multiple commands with &&
+                    let content = content
+                        .lines()
+                        .map(|line| line.trim())
+                        .filter(|line| !line.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" && ");
+                    Ok(Some(content))
+                } else {
+                    Ok(Some(value))
+                }
+            }
+        }
+    }
+
     async fn test(&mut self, args: ArgsTest) -> anyhow::Result<()> {
         match args.command {
             TestCommand::Qemu(args) => self.test_qemu(args).await,
@@ -185,11 +212,15 @@ impl Starry {
             self.app.workspace_root(),
             &request,
             &self.test_qemu_config_path(arch),
+            args.timeout,
         )
         .await?;
 
+        // Parse shell_init_cmd: if file path, read content
+        let shell_init_cmd = Self::resolve_shell_init_cmd(args.shell_init_cmd)?;
+
         match self
-            .run_test_qemu_request(request, qemu_config)
+            .run_test_qemu_request(request, qemu_config, shell_init_cmd)
             .await
             .with_context(|| "starry qemu test failed")
         {
@@ -279,14 +310,27 @@ impl Starry {
         &mut self,
         request: ResolvedStarryRequest,
         qemu_config: PathBuf,
+        shell_init_cmd_override: Option<String>,
     ) -> anyhow::Result<()> {
         let cargo = build::load_cargo_config(&request)?;
+
+        // Use override_args if shell_init_cmd is provided
+        let override_args = if let Some(cmd) = shell_init_cmd_override {
+            CargoQemuOverrideArgs {
+                shell_init_cmd: Some(cmd),
+                ..Default::default()
+            }
+        } else {
+            CargoQemuOverrideArgs::default()
+        };
+
         self.app
             .qemu(
                 cargo,
                 request.build_info_path,
                 QemuRunConfig {
                     qemu_config: Some(qemu_config),
+                    override_args,
                     ..Default::default()
                 },
             )
@@ -311,6 +355,7 @@ impl Default for Starry {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use tempfile::tempdir;
 
     use super::*;
 
@@ -350,5 +395,61 @@ mod tests {
             },
             _ => panic!("expected test command"),
         }
+    }
+
+    #[test]
+    fn command_parses_test_qemu_with_shell_init_cmd() {
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: Command,
+        }
+
+        let cli = Cli::try_parse_from([
+            "starry",
+            "test",
+            "qemu",
+            "--target",
+            "x86_64",
+            "--shell-init-cmd",
+            "echo 'test'",
+            "--timeout",
+            "10",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Test(args) => match args.command {
+                TestCommand::Qemu(args) => {
+                    assert_eq!(args.target, "x86_64");
+                    assert_eq!(args.shell_init_cmd, Some("echo 'test'".to_string()));
+                    assert_eq!(args.timeout, Some(10));
+                }
+                _ => panic!("expected qemu test command"),
+            },
+            _ => panic!("expected test command"),
+        }
+    }
+
+    #[test]
+    fn resolve_shell_init_cmd_returns_none_for_none_input() {
+        let result = Starry::resolve_shell_init_cmd(None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_shell_init_cmd_returns_value_for_nonexistent_path() {
+        let result = Starry::resolve_shell_init_cmd(Some("echo 'direct command'".to_string())).unwrap();
+        assert_eq!(result, Some("echo 'direct command'".to_string()));
+    }
+
+    #[test]
+    fn resolve_shell_init_cmd_reads_file_content() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test-cmd.txt");
+        fs::write(&file, "echo 'from file'\nls -la\n").unwrap();
+
+        let result = Starry::resolve_shell_init_cmd(Some(file.display().to_string())).unwrap();
+        assert_eq!(result, Some("echo 'from file' && ls -la".to_string()));
     }
 }

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -17,6 +17,40 @@ use crate::{
 
 const ROOTFS_URL: &str = "https://github.com/Starry-OS/rootfs/releases/download/20260214";
 
+/// Remove the timeout field from the configuration file
+fn remove_timeout_field(config: &str) -> String {
+    // Check if config contains timeout line
+    if !config.contains("timeout") {
+        return config.to_string();
+    }
+    // Remove timeout line while preserving original format
+    config.lines()
+        .filter(|line| !line.trim().starts_with("timeout"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Update the timeout field in the configuration file to the specified value
+fn update_timeout_field(config: &str, timeout_seconds: u64) -> String {
+    let timeout_line = format!("timeout = {}", timeout_seconds);
+    if config.contains("timeout") {
+        // Replace existing timeout line
+        config.lines()
+            .map(|line| {
+                if line.trim().starts_with("timeout") {
+                    timeout_line.clone()
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        // Add timeout field
+        format!("{}\n{}", config, timeout_line)
+    }
+}
+
 pub(crate) fn rootfs_image_name(arch: &str) -> anyhow::Result<String> {
     let _ = starry_target_for_arch_checked(arch)?;
     Ok(format!("rootfs-{arch}.img"))
@@ -80,6 +114,7 @@ pub(crate) async fn prepare_test_qemu_config(
     workspace_root: &Path,
     request: &ResolvedStarryRequest,
     template_path: &Path,
+    timeout_override: Option<u64>,
 ) -> anyhow::Result<PathBuf> {
     let base_disk_img =
         ensure_rootfs_in_target_dir(workspace_root, &request.arch, &request.target).await?;
@@ -99,6 +134,16 @@ pub(crate) async fn prepare_test_qemu_config(
         .await
         .with_context(|| format!("failed to read {}", template_path.display()))?;
     let config = config.replace(&shared_disk, &isolated_disk_img.display().to_string());
+
+    // Handle timeout override
+    let config = match timeout_override {
+        None => config, // Keep timeout from config file
+        Some(0) => remove_timeout_field(&config), // 0 means disable timeout
+        Some(seconds) => {
+            // Set the specified timeout value
+            update_timeout_field(&config, seconds)
+        }
+    };
 
     let generated_config = std::env::temp_dir().join(format!(
         "starry-test-qemu-{}-{}-{}.toml",
@@ -275,7 +320,7 @@ shell_prefix = "starry:~#"
             uboot_config: None,
         };
 
-        let generated = prepare_test_qemu_config(root.path(), &request, &template)
+        let generated = prepare_test_qemu_config(root.path(), &request, &template, None)
             .await
             .unwrap();
         let content = fs::read_to_string(generated).unwrap();
@@ -283,5 +328,58 @@ shell_prefix = "starry:~#"
         assert!(content.contains("disk-test-"));
         assert!(!content.contains("${workspace}/target/x86_64-unknown-none/disk.img"));
         assert!(content.contains("shell_prefix = \"starry:~#\""));
+    }
+
+    #[test]
+    fn remove_timeout_field_removes_timeout_line() {
+        let config = r#"args = ["-nographic"]
+shell_prefix = "starry:~#"
+timeout = 3
+"#;
+        let result = remove_timeout_field(config);
+        assert!(!result.contains("timeout"));
+        assert!(result.contains("args = [\"-nographic\"]"));
+        assert!(result.contains("shell_prefix = \"starry:~#\""));
+    }
+
+    #[test]
+    fn remove_timeout_field_handles_config_without_timeout() {
+        let config = r#"args = ["-nographic"]
+shell_prefix = "starry:~#"
+"#;
+        let result = remove_timeout_field(config);
+        assert_eq!(result, config);
+    }
+
+    #[test]
+    fn update_timeout_field_replaces_existing_timeout() {
+        let config = r#"args = ["-nographic"]
+shell_prefix = "starry:~#"
+timeout = 3
+"#;
+        let result = update_timeout_field(config, 10);
+        assert!(result.contains("timeout = 10"));
+        assert!(!result.contains("timeout = 3"));
+    }
+
+    #[test]
+    fn update_timeout_field_adds_timeout_when_not_present() {
+        let config = r#"args = ["-nographic"]
+shell_prefix = "starry:~#"
+"#;
+        let result = update_timeout_field(config, 30);
+        assert!(result.contains("timeout = 30"));
+        assert!(result.contains("args = [\"-nographic\"]"));
+        assert!(result.contains("shell_prefix = \"starry:~#\""));
+    }
+
+    #[test]
+    fn update_timeout_field_with_zero_disables_timeout() {
+        let config = r#"args = ["-nographic"]
+shell_prefix = "starry:~#"
+timeout = 3
+"#;
+        let result = remove_timeout_field(config);
+        assert!(!result.contains("timeout"));
     }
 }

--- a/test-suit/starryos/testcases/stress-ng-0
+++ b/test-suit/starryos/testcases/stress-ng-0
@@ -1,0 +1,6 @@
+apk update
+apk add stress-ng
+stress-ng --cpu 8 --timeout 10s
+stress-ng --sigsegv 8 --sigsegv-ops 1000
+pwd
+echo 'All tests passed!'


### PR DESCRIPTION
This PR adds support for controlling timeout and providing multi-line shell commands for Starry QEMU tests.

  Changes

  - --timeout parameter: Add optional timeout control to ArgsTestQemu
    - Not specified: Keep timeout from config file (default: 3 seconds)
    - 0: Disable timeout (no timeout limit)
    - N: Set custom timeout in seconds
  - --shell-init-cmd parameter: Accept command string or file path
    - If file path: Read content and join multiple lines with &&
    - If not a path: Use the command string directly

  Example Usage

  # Use multi-line shell commands file
  cargo xtask starry test qemu --target riscv64 \
      --shell-init-cmd test-suit/starryos/testcases/stress-ng-0 \
      --timeout 0

  Other examples

  # Run with default timeout
  cargo xtask starry test qemu --target riscv64

  # Disable timeout (run indefinitely)
  cargo xtask starry test qemu --target riscv64 --timeout 0

  # Use custom timeout (30 seconds)
  cargo xtask starry test qemu --target riscv64 --timeout 30

  # Combine both
  cargo xtask starry test qemu --target riscv64 \
      --shell-init-cmd "pwd && ls -la && echo 'test'" \
      --timeout 10

  Files Changed

  - scripts/axbuild/src/starry/mod.rs - Add timeout parameter and resolve logic
  - scripts/axbuild/src/starry/rootfs.rs - Add timeout override helpers
  - test-suit/starryos/testcases/stress-ng-0 - Example shell commands file
