### PR TITLE
refactor(axtask): replace wait queue boolean wake flags with explicit policy

### DIFF
--- a/os/arceos/api/arceos_api/src/imp/task.rs
+++ b/os/arceos/api/arceos_api/src/imp/task.rs
@@ -136,10 +136,10 @@ cfg_task! {
 
     pub fn ax_wait_queue_wake(wq: &AxWaitQueueHandle, count: u32) {
         if count == u32::MAX {
-            wq.0.notify_all(true);
+            wq.0.notify_all_with(axtask::ReschedPolicy::YieldCurrent);
         } else {
             for _ in 0..count {
-                wq.0.notify_one(true);
+                wq.0.notify_one_with(axtask::ReschedPolicy::YieldCurrent);
             }
         }
     }

--- a/os/arceos/modules/axnet-ng/src/vsock/connection_manager.rs
+++ b/os/arceos/modules/axnet-ng/src/vsock/connection_manager.rs
@@ -141,7 +141,8 @@ impl Connection {
 
     #[inline]
     pub fn tx_wait_queue_notify(&mut self) {
-        self.tx_wait_queue.notify_all(true);
+        self.tx_wait_queue
+            .notify_all_with(axtask::ReschedPolicy::YieldCurrent);
     }
 
     #[inline]

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -17,7 +17,7 @@ pub use crate::timers::register_timer_callback;
 #[doc(cfg(feature = "multitask"))]
 pub use crate::{
     task::{CurrentTask, TaskId, TaskInner, TaskState},
-    wait_queue::WaitQueue,
+    wait_queue::{ReschedPolicy, WaitQueue},
 };
 
 /// The reference type of a task.

--- a/os/arceos/modules/axtask/src/tests.rs
+++ b/os/arceos/modules/axtask/src/tests.rs
@@ -1,7 +1,7 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, Once};
 
-use crate::{WaitQueue, api as axtask, current};
+use crate::{ReschedPolicy, WaitQueue, api as axtask, current};
 
 static INIT: Once = Once::new();
 static SERIAL: Mutex<()> = Mutex::new(());
@@ -78,12 +78,12 @@ fn test_wait_queue() {
         axtask::spawn(move || {
             COUNTER.fetch_add(1, Ordering::Release);
             println!("wait_queue: task {:?} started", current().id());
-            WQ1.notify_one(true); // WQ1.wait_until()
+            WQ1.notify_one_with(ReschedPolicy::YieldCurrent); // WQ1.wait_until()
             WQ2.wait();
 
             COUNTER.fetch_sub(1, Ordering::Release);
             println!("wait_queue: task {:?} finished", current().id());
-            WQ1.notify_one(true); // WQ1.wait_until()
+            WQ1.notify_one_with(ReschedPolicy::YieldCurrent); // WQ1.wait_until()
         });
     }
 
@@ -91,7 +91,7 @@ fn test_wait_queue() {
     WQ1.wait_until(|| COUNTER.load(Ordering::Acquire) == NUM_TASKS);
     axtask::yield_now();
     assert_eq!(COUNTER.load(Ordering::Acquire), NUM_TASKS);
-    WQ2.notify_all(true); // WQ2.wait()
+    WQ2.notify_all_with(ReschedPolicy::YieldCurrent); // WQ2.wait()
 
     println!(
         "task {:?} is waiting for tasks to finish...",

--- a/os/arceos/modules/axtask/src/wait_queue.rs
+++ b/os/arceos/modules/axtask/src/wait_queue.rs
@@ -5,6 +5,33 @@ use event_listener::{Event, listener};
 
 use crate::future::{block_on, timeout_at};
 
+/// Controls whether notifying a wait queue should immediately yield the CPU.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReschedPolicy {
+    /// Keep running after the notification.
+    KeepCurrent,
+    /// Yield the current task after the notification.
+    YieldCurrent,
+}
+
+impl ReschedPolicy {
+    #[inline]
+    fn apply(self) {
+        if matches!(self, Self::YieldCurrent) {
+            crate::yield_now();
+        }
+    }
+
+    #[inline]
+    const fn from_compat(resched: bool) -> Self {
+        if resched {
+            Self::YieldCurrent
+        } else {
+            Self::KeepCurrent
+        }
+    }
+}
+
 /// A queue to store sleeping tasks.
 ///
 /// # Examples
@@ -12,7 +39,7 @@ use crate::future::{block_on, timeout_at};
 /// ```
 /// use core::sync::atomic::{AtomicU32, Ordering};
 ///
-/// use axtask::WaitQueue;
+/// use axtask::{ReschedPolicy, WaitQueue};
 ///
 /// static VALUE: AtomicU32 = AtomicU32::new(0);
 /// static WQ: WaitQueue = WaitQueue::new();
@@ -22,7 +49,7 @@ use crate::future::{block_on, timeout_at};
 /// axtask::spawn(|| {
 ///     assert_eq!(VALUE.load(Ordering::Acquire), 0);
 ///     VALUE.fetch_add(1, Ordering::Release);
-///     WQ.notify_one(true); // wake up the main task
+///     WQ.notify_one_with(ReschedPolicy::YieldCurrent); // wake up the main task
 /// });
 ///
 /// WQ.wait(); // block until `notify()` is called
@@ -113,26 +140,50 @@ impl WaitQueue {
     /// Wakes up one task in the wait queue, usually the first one.
     /// This function should not be called in a loop, use `notify_many` instead.
     ///
+    /// Prefer [`notify_one_with`](Self::notify_one_with) in new code so the
+    /// call site makes the rescheduling behavior explicit.
+    ///
     /// If `resched` is true, the current task will yield.
     pub fn notify_one(&self, resched: bool) -> bool {
-        self.notify_many(1, resched) == 1
+        self.notify_one_with(ReschedPolicy::from_compat(resched))
+    }
+
+    /// Wakes up one task in the wait queue, usually the first one.
+    /// This function should not be called in a loop, use
+    /// [`notify_many_with`](Self::notify_many_with) instead.
+    pub fn notify_one_with(&self, policy: ReschedPolicy) -> bool {
+        self.notify_many_with(1, policy) == 1
     }
 
     /// Wakes up to `count` tasks in the wait queue.
     ///
+    /// Prefer [`notify_many_with`](Self::notify_many_with) in new code so the
+    /// call site makes the rescheduling behavior explicit.
+    ///
     /// If `resched` is true, the current task will yield.
     pub fn notify_many(&self, count: usize, resched: bool) -> usize {
+        self.notify_many_with(count, ReschedPolicy::from_compat(resched))
+    }
+
+    /// Wakes up to `count` tasks in the wait queue.
+    pub fn notify_many_with(&self, count: usize, policy: ReschedPolicy) -> usize {
         let n = self.event.notify(count);
-        if resched {
-            crate::yield_now();
-        }
+        policy.apply();
         n
     }
 
     /// Wakes all tasks in the wait queue.
     ///
+    /// Prefer [`notify_all_with`](Self::notify_all_with) in new code so the
+    /// call site makes the rescheduling behavior explicit.
+    ///
     /// If `resched` is true, the current task will yield.
     pub fn notify_all(&self, resched: bool) {
-        self.notify_many(usize::MAX, resched);
+        self.notify_all_with(ReschedPolicy::from_compat(resched));
+    }
+
+    /// Wakes all tasks in the wait queue.
+    pub fn notify_all_with(&self, policy: ReschedPolicy) {
+        self.notify_many_with(usize::MAX, policy);
     }
 }


### PR DESCRIPTION
## Summary
- add `ReschedPolicy` for wait queue wake operations
- add `notify_one_with`, `notify_many_with`, and `notify_all_with`
- keep existing boolean-based APIs as compatibility wrappers
- migrate internal call sites and examples to the explicit API

## Why
- boolean arguments like `notify_one(true)` are not self-explanatory
- this keeps behavior unchanged while making new call sites clearer

## Validation
- updated existing wait queue test call sites to use the new API
- reviewed compatibility wrappers to ensure old behavior is preserved

## Risk
- low
- the old APIs are still present and forward to the new implementation
