### PR TITLE
feat：Fix SMP cross-core wakeup and IPI delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ name = "axplat-dyn"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "arm-gic-driver 0.17.0",
  "axalloc",
  "axconfig-macros 0.4.1",
  "axcpu 0.5.0",
@@ -1371,6 +1372,7 @@ dependencies = [
  "memory_addr 0.6.1",
  "percpu 0.4.3",
  "rd-block",
+ "rdif-intc",
  "rdrive",
  "somehal",
  "spin 0.10.0",

--- a/os/arceos/api/axfeat/Cargo.toml
+++ b/os/arceos/api/axfeat/Cargo.toml
@@ -23,7 +23,7 @@ hv = ["axhal/hv"]
 
 # Interrupts
 irq = ["axhal/irq", "axruntime/irq", "axtask?/irq", "axdriver?/irq"]
-ipi = ["irq", "dep:axipi", "axhal/ipi", "axruntime/ipi"]
+ipi = ["irq", "dep:axipi", "axhal/ipi", "axruntime/ipi", "axtask?/ipi"]
 
 # Custom or default platforms
 myplat = ["axhal/myplat"]

--- a/os/arceos/modules/axconfig/src/driver_dyn_config.rs
+++ b/os/arceos/modules/axconfig/src/driver_dyn_config.rs
@@ -30,7 +30,7 @@ pub mod devices {
     #[doc = " Timer interrupt num (PPI, physical timer)."]
     pub const TIMER_IRQ: usize = 0xf0;
     #[doc = " IPI interrupt num."]
-    pub const IPI_IRQ: usize = 0;
+    pub const IPI_IRQ: usize = 1;
     #[doc = " VirtIO MMIO regions with format (`base_paddr`, `size`)."]
     pub const VIRTIO_MMIO_REGIONS: &[(usize, usize)] = &[];
     #[doc = " SDMMC controller physical address."]

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -216,6 +216,9 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
     #[cfg(feature = "multitask")]
     axtask::init_scheduler();
 
+    #[cfg(feature = "ipi")]
+    axipi::init();
+
     #[cfg(feature = "axdriver")]
     {
         #[allow(unused_variables)]

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -27,6 +27,7 @@ multitask = [
 ]
 task-ext = ["dep:extern-trait"]
 irq = ["axhal/irq", "dep:timer_list"]
+ipi = ["irq", "axhal/ipi"]
 tls = ["axhal/tls"]
 preempt = ["irq", "percpu?/preempt", "kernel_guard/preempt"]
 smp = ["kspin/smp"]

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -3,6 +3,8 @@ use alloc::sync::Weak;
 use alloc::{collections::VecDeque, sync::Arc};
 use core::mem::MaybeUninit;
 
+#[cfg(feature = "ipi")]
+use axhal::irq::{IPI_IRQ, IpiTarget, send_ipi};
 use axhal::percpu::this_cpu_id;
 use axsched::BaseScheduler;
 use kernel_guard::BaseGuard;
@@ -254,11 +256,16 @@ impl<G: BaseGuard> AxRunQueueRef<'_, G> {
             // Since now, the task to be unblocked is in the `Ready` state.
             let cpu_id = self.inner.cpu_id;
             debug!("task unblock: {task_id_name} on run_queue {cpu_id}");
-            // Note: when the task is unblocked on another CPU's run queue,
-            // we just ignore the `resched` flag.
-            if resched && cpu_id == this_cpu_id() {
-                #[cfg(feature = "preempt")]
-                crate::current().set_preempt_pending(true);
+            if resched {
+                if cpu_id == this_cpu_id() {
+                    #[cfg(feature = "preempt")]
+                    crate::current().set_preempt_pending(true);
+                } else {
+                    #[cfg(feature = "ipi")]
+                    {
+                        send_ipi(IPI_IRQ, IpiTarget::Other { cpu_id });
+                    }
+                }
             }
         }
     }

--- a/os/axvisor/configs/board/phytiumpi.toml
+++ b/os/axvisor/configs/board/phytiumpi.toml
@@ -1,6 +1,7 @@
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = [
     "axstd/bus-mmio",
+    "axstd/ipi",
     "fs",
     "sdmmc",
     "phytium-blk",

--- a/os/axvisor/configs/board/qemu-aarch64.toml
+++ b/os/axvisor/configs/board/qemu-aarch64.toml
@@ -2,6 +2,7 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = [
     "ept-level-4",
     "axstd/bus-mmio",
+    "axstd/ipi",
 ]
 log = "Info"
 plat_dyn = true

--- a/os/axvisor/configs/board/roc-rk3568-pc.toml
+++ b/os/axvisor/configs/board/roc-rk3568-pc.toml
@@ -1,6 +1,7 @@
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = [
     "axstd/bus-mmio",
+    "axstd/ipi",
     "fs",
     "sdmmc",
     "rk3568-clk",

--- a/os/axvisor/scripts/quick-start.sh
+++ b/os/axvisor/scripts/quick-start.sh
@@ -176,6 +176,8 @@ setup_qemu_aarch64() {
     run_cmd cp .github/workflows/qemu-aarch64.toml tmp/configs/qemu-aarch64-runtime.toml
 
     ROOTFS_PATH="$(pwd)/tmp/images/qemu_aarch64_linux/rootfs.img"
+    run_cmd sed -i 's|^  # "-drive",$|  "-drive",|g' tmp/configs/qemu-aarch64-runtime.toml
+    run_cmd sed -i 's|^  # "id=disk0,if=none,format=raw,file=|  "id=disk0,if=none,format=raw,file=|g' tmp/configs/qemu-aarch64-runtime.toml
     run_cmd sed -i 's|file=${workspaceFolder}/tmp/rootfs.img|file='"$ROOTFS_PATH"'|g' tmp/configs/qemu-aarch64-runtime.toml
     run_cmd sed -i '/success_regex = \[/,/\]/c\success_regex = []' tmp/configs/qemu-aarch64-runtime.toml
 
@@ -230,7 +232,9 @@ setup_qemu_riscv64() {
 
     info "Preparing QEMU config file..."
     run_cmd cp .github/workflows/qemu-riscv64.toml tmp/configs/qemu-riscv64-runtime.toml
-    run_cmd cp tmp/images/qemu_riscv64_arceos/rootfs.img tmp/rootfs.img
+
+    ROOTFS_PATH="$(pwd)/tmp/images/qemu_riscv64_arceos/rootfs.img"
+    run_cmd sed -i 's|file=${workspaceFolder}/tmp/rootfs.img|file='"$ROOTFS_PATH"'|g' tmp/configs/qemu-riscv64-runtime.toml
 
     info "=== QEMU RISC-V64 Preparation Complete ==="
 }
@@ -238,45 +242,9 @@ setup_qemu_riscv64() {
 run_qemu_riscv64_arceos() {
     info "=== Launching QEMU RISC-V64 ArceOS Guest ==="
     run_axvisor_qemu \
-        --build-config tmp/configs/qemu-riscv64.toml \
-        --qemu-config tmp/configs/qemu-riscv64-runtime.toml \
-        --vmconfigs tmp/configs/arceos-riscv64-qemu-smp1.toml
-}
-
-# ============================================================================
-# QEMU RISC-V64 Architecture Setup
-# ============================================================================
-
-setup_qemu_riscv64() {
-    info "=== QEMU RISC-V64 Preparation ==="
-
-    run_cmd mkdir -p tmp/{configs,images}
-
-    info "Downloading ArceOS image..."
-    run_cmd cargo axvisor image pull qemu_riscv64_arceos --output-dir tmp/images
-
-    info "Preparing board config file..."
-    run_cmd cp configs/board/qemu-riscv64.toml tmp/configs/
-
-    info "Preparing guest config file..."
-    run_cmd cp configs/vms/arceos-riscv64-qemu-smp1.toml tmp/configs/
-
-    run_cmd sed -i 's|^kernel_path = .*|kernel_path = "../images/qemu_riscv64_arceos/qemu-riscv64"|g' tmp/configs/arceos-riscv64-qemu-smp1.toml
-    run_cmd sed -i 's|^image_location = "fs"|image_location = "memory"|g' tmp/configs/arceos-riscv64-qemu-smp1.toml
-
-    info "Preparing QEMU config file..."
-    run_cmd cp .github/workflows/qemu-riscv64.toml tmp/configs/qemu-riscv64-runtime.toml
-    run_cmd cp tmp/images/qemu_riscv64_arceos/rootfs.img tmp/rootfs.img
-
-    info "=== QEMU RISC-V64 Preparation Complete ==="
-}
-
-run_qemu_riscv64_arceos() {
-    info "=== Launching QEMU RISC-V64 ArceOS Guest ==="
-    run_axvisor_qemu \
-        --build-config tmp/configs/qemu-riscv64.toml \
-        --qemu-config tmp/configs/qemu-riscv64-runtime.toml \
-        --vmconfigs tmp/configs/arceos-riscv64-qemu-smp1.toml
+        --config "$(pwd)/tmp/configs/qemu-riscv64.toml" \
+        --qemu-config "$(pwd)/tmp/configs/qemu-riscv64-runtime.toml" \
+        --vmconfigs "$(pwd)/tmp/configs/arceos-riscv64-qemu-smp1.toml"
 }
 
 # ============================================================================

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -34,6 +34,10 @@ log.workspace = true
 memory_addr.workspace = true
 percpu = { workspace = true, features = ["custom-base"] }
 rd-block = "0.1"
+rdif-intc = "0.14"
 rdrive = "0.20"
 somehal = "0.6"
 spin = "0.10"
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+arm-gic-driver = { version = "0.17", features = ["rdif"] }

--- a/platform/axplat-dyn/src/irq.rs
+++ b/platform/axplat-dyn/src/irq.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 use axplat::irq::{HandlerTable, IrqHandler, IrqIf};
 use somehal::irq_handler;
 
@@ -51,6 +53,84 @@ impl IrqIf for IrqIfImpl {
     }
 
     fn send_ipi(_id: usize, _target: axplat::irq::IpiTarget) {
+        #[cfg(target_arch = "aarch64")]
+        {
+            let mut gic = rdrive::get_one::<rdif_intc::Intc>()
+                .expect("Failed to get GIC driver")
+                .lock()
+                .unwrap();
+
+            if let Some(gic) = gic.typed_mut::<arm_gic_driver::v2::Gic>() {
+                use arm_gic_driver::{
+                    IntId,
+                    v2::{SGITarget, TargetList},
+                };
+
+                match _target {
+                    axplat::irq::IpiTarget::Current { cpu_id: _ } => {
+                        gic.send_sgi(IntId::sgi(_id as u32), SGITarget::Current);
+                    }
+                    axplat::irq::IpiTarget::Other { cpu_id } => {
+                        let target_list = TargetList::new(&mut [cpu_id].into_iter());
+                        gic.send_sgi(IntId::sgi(_id as u32), SGITarget::TargetList(target_list));
+                    }
+                    axplat::irq::IpiTarget::AllExceptCurrent {
+                        cpu_id: _,
+                        cpu_num: _,
+                    } => {
+                        gic.send_sgi(IntId::sgi(_id as u32), SGITarget::AllOther);
+                    }
+                }
+                return;
+            }
+
+            if let Some(_gic) = gic.typed_mut::<arm_gic_driver::v3::Gic>() {
+                use arm_gic_driver::{
+                    IntId,
+                    v3::{Affinity, SGITarget},
+                };
+
+                let cpu_affinity = |cpu_idx: usize| {
+                    let meta = somehal::smp::cpu_meta(cpu_idx)
+                        .unwrap_or_else(|| panic!("invalid cpu idx for ipi target: {cpu_idx}"));
+                    Affinity::from_mpidr(meta.cpu_id as u64)
+                };
+
+                match _target {
+                    axplat::irq::IpiTarget::Current { cpu_id } => {
+                        let aff = cpu_affinity(cpu_id);
+                        arm_gic_driver::v3::send_sgi(
+                            IntId::sgi(_id as u32),
+                            SGITarget::list([aff]),
+                        );
+                    }
+                    axplat::irq::IpiTarget::Other { cpu_id } => {
+                        let aff = cpu_affinity(cpu_id);
+                        arm_gic_driver::v3::send_sgi(
+                            IntId::sgi(_id as u32),
+                            SGITarget::list([aff]),
+                        );
+                    }
+                    axplat::irq::IpiTarget::AllExceptCurrent { cpu_id, cpu_num } => {
+                        let mut targets = alloc::vec::Vec::new();
+                        for i in 0..cpu_num {
+                            if i != cpu_id {
+                                targets.push(cpu_affinity(i));
+                            }
+                        }
+                        arm_gic_driver::v3::send_sgi(
+                            IntId::sgi(_id as u32),
+                            SGITarget::list(targets),
+                        );
+                    }
+                }
+                return;
+            }
+
+            panic!("no gic driver found")
+        }
+
+        #[cfg(not(target_arch = "aarch64"))]
         todo!()
     }
 }


### PR DESCRIPTION
## 问题

在多核场景下，当一个 CPU 上的线程等待事件，而另一个 CPU 上的线程负责唤醒它时，唤醒链路不完整，导致等待线程不能稳定恢复执行。

该问题在的表现：

RK3568 ，Phytium 等平台axvisor客户机退出后无法进入shell

## 原因

根因主要有两层：

1. `axtask` 的新 `WaitQueue + run_queue` 机制在跨 CPU 唤醒场景下，只把等待任务放回目标 CPU 的 run queue，但没有可靠地触发目标 CPU 立即重新调度。

2. `plat_dyn` 路径下的 AArch64 IPI 支撑不完整，包括：
   - 主核未初始化 `axipi`
   - `send_ipi()` 未实现
   - `IPI_IRQ` 配置错误
   - GICv3 下错误地假设 `logical cpu_id == aff0`

## 修复方法

本 PR 从任务层、运行时层和平台层补齐了跨核唤醒链路：

- 在 `axtask::run_queue::unblock_task()` 中，为跨 CPU 唤醒补充远端 resched 的 IPI 触发
- 为 `axtask` 打通 `ipi` feature 链路
- 在 `axruntime` 主核初始化路径中补充 `axipi::init()`
- 在 `axplat-dyn` 中实现 AArch64 的 `send_ipi()`
- 修正 dyn 平台的 `IPI_IRQ`
- 在 GICv3 下根据真实 MPIDR 计算目标 CPU affinity，而不是直接使用逻辑 CPU 编号
- 在相关 AArch64 board config 上启用 `axstd/ipi`

## 结果

修复后，多轮测试中：

- RK3568 平台能够稳定恢复
- Phytium 平台也恢复稳定

本 PR 解决的是多核场景下的跨核消息唤醒问题。