### PR TITLE
ax-task: move notify_one_with callbacks out of the wait-queue lock

### DIFF
--- a/os/arceos/modules/axtask/src/wait_queue.rs
+++ b/os/arceos/modules/axtask/src/wait_queue.rs
@@ -178,24 +178,27 @@ impl WaitQueue {
 
     /// Wakes up one task in the wait queue and runs a callback on it.
     ///
-    /// The callback `func` is invoked while holding the wait-queue lock and
+    /// The callback `func` is invoked after releasing the wait-queue lock and
     /// before the selected task is unblocked. It receives the task's ID as a
     /// `u64` when a task is available, or `0` if the wait queue is empty.
     /// This can be used for lock handoff or other bookkeeping associated with
-    /// the waking task.
+    /// the waking task without extending the spinlock critical section.
     ///
     /// If `resched` is true, the current task will be preempted when the
     /// preemption is enabled.
     pub fn notify_one_with<F>(&self, resched: bool, func: F) -> bool
     where
-        F: Fn(u64),
+        F: FnOnce(u64),
     {
         let mut wq = self.queue.lock();
         if let Some(task) = wq.pop_front() {
-            func(task.id().as_u64());
+            let task_id = task.id().as_u64();
+            drop(wq);
+            func(task_id);
             unblock_one_task(task, resched);
             true
         } else {
+            drop(wq);
             func(0);
             false
         }


### PR DESCRIPTION

## Summary

- change `WaitQueue::notify_one_with` so its callback runs after the wait-queue lock is released
- tighten the callback bound from `Fn` to `FnOnce`, which matches the single-call behavior
- keep the callback ordered before task unblock while shortening the spinlock critical section

## Why

The previous implementation executed an arbitrary external callback while holding the wait-queue
`SpinNoIrq` lock. That expands the spinlock critical section to user-provided code and makes it too
easy to introduce blocking, lock-order, or I/O problems in a path that should stay minimal.

Running the callback after releasing the queue lock preserves the intended handoff/bookkeeping hook
without keeping the spinlock held across external code.
