### PR TITLE
axtask: enforce might_sleep and fix cross-target test regressions

### DIFF
--- a/os/arceos/Makefile
+++ b/os/arceos/Makefile
@@ -233,6 +233,7 @@ clean: clean_c
 clean_c::
 	rm -rf ulib/axlibc/build_*
 	rm -rf $(app-objs)
+	rm -rf $(app_obj_dir)
 
 .PHONY: all defconfig oldconfig \
 	build disasm run justrun debug \

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -215,9 +215,20 @@ pub fn set_current_affinity(cpumask: AxCpuMask) -> bool {
 
 /// Current task gives up the CPU time voluntarily, and switches to another
 /// ready task.
+#[track_caller]
 pub fn yield_now() {
     might_sleep();
 
+    yield_now_kernel();
+}
+
+/// Gives up the CPU from a kernel-internal path.
+///
+/// This bypasses the public `might_sleep()` guard and is intended only for
+/// carefully reviewed scheduler or syscall paths that must yield while running
+/// under internal kernel guards.
+#[doc(hidden)]
+pub fn yield_now_kernel() {
     current_run_queue::<NoPreemptIrqSave>().yield_current()
 }
 
@@ -301,7 +312,7 @@ pub(crate) fn might_sleep() {
 /// waiting for the next interrupt.
 pub fn run_idle() -> ! {
     loop {
-        current_run_queue::<NoPreemptIrqSave>().yield_current();
+        yield_now_kernel();
         trace!("idle task: waiting for IRQs...");
         #[cfg(feature = "irq")]
         ax_hal::asm::wait_for_irqs();

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -180,6 +180,8 @@ pub fn set_priority(prio: isize) -> bool {
 ///
 /// TODO: support set the affinity for other tasks.
 pub fn set_current_affinity(cpumask: AxCpuMask) -> bool {
+    might_sleep();
+
     if cpumask.is_empty() {
         false
     } else {
@@ -214,6 +216,8 @@ pub fn set_current_affinity(cpumask: AxCpuMask) -> bool {
 /// Current task gives up the CPU time voluntarily, and switches to another
 /// ready task.
 pub fn yield_now() {
+    might_sleep();
+
     current_run_queue::<NoPreemptIrqSave>().yield_current()
 }
 
@@ -229,6 +233,8 @@ pub fn sleep(dur: core::time::Duration) {
 /// If the feature `irq` is not enabled, it uses busy-wait instead.
 pub fn sleep_until(deadline: ax_hal::time::TimeValue) {
     #[cfg(feature = "irq")]
+    might_sleep();
+    #[cfg(feature = "irq")]
     current_run_queue::<NoPreemptIrqSave>().sleep_until(deadline);
     #[cfg(not(feature = "irq"))]
     ax_hal::time::busy_wait_until(deadline);
@@ -236,15 +242,66 @@ pub fn sleep_until(deadline: ax_hal::time::TimeValue) {
 
 /// Exits the current task.
 pub fn exit(exit_code: i32) -> ! {
+    might_sleep();
+
     current_run_queue::<NoPreemptIrqSave>().exit_current(exit_code)
+}
+
+fn current_preempt_count() -> usize {
+    #[cfg(feature = "preempt")]
+    {
+        current_may_uninit().map_or(0, |curr| curr.preempt_count())
+    }
+    #[cfg(not(feature = "preempt"))]
+    {
+        0
+    }
+}
+
+/// Returns whether the current context is atomic, meaning sleeping or
+/// voluntarily rescheduling is not allowed.
+///
+/// This matches the intent of Linux's `might_sleep()`: catch misuse from
+/// IRQ-disabled or preempt-disabled regions before a sleep-like action happens.
+pub(crate) fn in_atomic_context() -> bool {
+    #[cfg(feature = "irq")]
+    if !ax_hal::asm::irqs_enabled() {
+        return true;
+    }
+
+    #[cfg(feature = "preempt")]
+    if current_preempt_count() != 0 {
+        return true;
+    }
+
+    false
+}
+
+/// Marks an operation as one that may sleep or voluntarily reschedule.
+///
+/// Panics if it is executed in an atomic context.
+#[track_caller]
+pub(crate) fn might_sleep() {
+    #[cfg(feature = "irq")]
+    let irqs_enabled = ax_hal::asm::irqs_enabled();
+    #[cfg(not(feature = "irq"))]
+    let irqs_enabled = true;
+    let preempt_count = current_preempt_count();
+    if in_atomic_context() {
+        panic!(
+            "sleeping is not allowed in atomic context: irq_enabled={irqs_enabled}, \
+             preempt_count={preempt_count}"
+        );
+    }
 }
 
 /// The idle task routine.
 ///
-/// It runs an infinite loop that keeps calling [`yield_now()`].
+/// It runs an infinite loop that keeps trying to hand over the CPU before
+/// waiting for the next interrupt.
 pub fn run_idle() -> ! {
     loop {
-        yield_now();
+        current_run_queue::<NoPreemptIrqSave>().yield_current();
         trace!("idle task: waiting for IRQs...");
         #[cfg(feature = "irq")]
         ax_hal::asm::wait_for_irqs();

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -228,7 +228,7 @@ pub fn yield_now() {
 /// carefully reviewed scheduler or syscall paths that must yield while running
 /// under internal kernel guards.
 #[doc(hidden)]
-pub fn yield_now_unchecked() {
+pub(crate) fn yield_now_unchecked() {
     current_run_queue::<NoPreemptIrqSave>().yield_current()
 }
 

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -270,7 +270,7 @@ fn current_preempt_count() -> usize {
 }
 
 /// Returns whether the current context is atomic, meaning sleeping or
-/// voluntarily rescheduling is not allowed.
+/// rescheduling is not allowed.
 ///
 /// This matches the intent of Linux's `might_sleep()`: catch misuse from
 /// IRQ-disabled or preempt-disabled regions before a sleep-like action happens.
@@ -288,7 +288,7 @@ pub(crate) fn in_atomic_context() -> bool {
     false
 }
 
-/// Marks an operation as one that may sleep or voluntarily reschedule.
+/// Marks an operation as one that may sleep or reschedule.
 ///
 /// Panics if it is executed in an atomic context.
 #[track_caller]
@@ -300,8 +300,8 @@ pub(crate) fn might_sleep() {
     let preempt_count = current_preempt_count();
     if in_atomic_context() {
         panic!(
-            "sleeping is not allowed in atomic context: irq_enabled={irqs_enabled}, \
-             preempt_count={preempt_count}"
+            "sleeping or rescheduling is not allowed in atomic context: \
+             irq_enabled={irqs_enabled}, preempt_count={preempt_count}"
         );
     }
 }

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -219,7 +219,7 @@ pub fn set_current_affinity(cpumask: AxCpuMask) -> bool {
 pub fn yield_now() {
     might_sleep();
 
-    yield_now_kernel();
+    yield_now_unchecked();
 }
 
 /// Gives up the CPU from a kernel-internal path.
@@ -228,7 +228,7 @@ pub fn yield_now() {
 /// carefully reviewed scheduler or syscall paths that must yield while running
 /// under internal kernel guards.
 #[doc(hidden)]
-pub fn yield_now_kernel() {
+pub fn yield_now_unchecked() {
     current_run_queue::<NoPreemptIrqSave>().yield_current()
 }
 
@@ -293,15 +293,12 @@ pub(crate) fn in_atomic_context() -> bool {
 /// Panics if it is executed in an atomic context.
 #[track_caller]
 pub(crate) fn might_sleep() {
-    #[cfg(feature = "irq")]
-    let irqs_enabled = ax_hal::asm::irqs_enabled();
-    #[cfg(not(feature = "irq"))]
-    let irqs_enabled = true;
-    let preempt_count = current_preempt_count();
     if in_atomic_context() {
         panic!(
-            "sleeping or rescheduling is not allowed in atomic context: \
-             irq_enabled={irqs_enabled}, preempt_count={preempt_count}"
+            "sleeping or rescheduling is not allowed in atomic context: irq_enabled={}, \
+             preempt_count={}",
+            ax_hal::asm::irqs_enabled(),
+            current_preempt_count()
         );
     }
 }
@@ -312,7 +309,7 @@ pub(crate) fn might_sleep() {
 /// waiting for the next interrupt.
 pub fn run_idle() -> ! {
     loop {
-        yield_now_kernel();
+        yield_now_unchecked();
         trace!("idle task: waiting for IRQs...");
         #[cfg(feature = "irq")]
         ax_hal::asm::wait_for_irqs();

--- a/os/arceos/modules/axtask/src/future/mod.rs
+++ b/os/arceos/modules/axtask/src/future/mod.rs
@@ -53,6 +53,8 @@ impl Wake for AxWaker {
 /// Note that this doesn't handle interruption and is not recommended for direct
 /// use in most cases.
 pub fn block_on<F: IntoFuture>(f: F) -> F::Output {
+    crate::api::might_sleep();
+
     let mut fut = pin!(f.into_future());
 
     let curr = current();

--- a/os/arceos/modules/axtask/src/future/mod.rs
+++ b/os/arceos/modules/axtask/src/future/mod.rs
@@ -85,6 +85,7 @@ pub fn block_on<F: IntoFuture>(f: F) -> F::Output {
                     // loop iteration will see it correctly.
                     *woke = false;
                     drop(woke);
+                    drop(rq);
                     crate::yield_now();
                 }
             }

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -179,6 +179,7 @@ impl TaskInner {
     ///
     /// It will return immediately if the task has already exited (but not dropped).
     pub fn join(&self) -> i32 {
+        crate::api::might_sleep();
         self.wait_for_exit
             .wait_until(|| self.state() == TaskState::Exited);
         self.exit_code.load(Ordering::Acquire)
@@ -405,6 +406,12 @@ impl TaskInner {
     #[cfg(feature = "preempt")]
     pub(crate) fn set_preempt_pending(&self, pending: bool) {
         self.need_resched.store(pending, Ordering::Release)
+    }
+
+    #[inline]
+    #[cfg(feature = "preempt")]
+    pub(crate) fn preempt_count(&self) -> usize {
+        self.preempt_disable_count.load(Ordering::Acquire)
     }
 
     #[inline]

--- a/os/arceos/modules/axtask/src/wait_queue.rs
+++ b/os/arceos/modules/axtask/src/wait_queue.rs
@@ -74,6 +74,7 @@ impl WaitQueue {
     /// Blocks the current task and put it into the wait queue, until other task
     /// notifies it.
     pub fn wait(&self) {
+        crate::api::might_sleep();
         current_run_queue::<NoPreemptIrqSave>().blocked_resched(self.queue.lock());
         self.cancel_events(crate::current(), false);
     }
@@ -87,6 +88,7 @@ impl WaitQueue {
     where
         F: Fn() -> bool,
     {
+        crate::api::might_sleep();
         let curr = crate::current();
         loop {
             let mut rq = current_run_queue::<NoPreemptIrqSave>();
@@ -105,6 +107,7 @@ impl WaitQueue {
     /// notify it, or the given duration has elapsed.
     #[cfg(feature = "irq")]
     pub fn wait_timeout(&self, dur: core::time::Duration) -> bool {
+        crate::api::might_sleep();
         let mut rq = current_run_queue::<NoPreemptIrqSave>();
         let curr = crate::current();
         let deadline = ax_hal::time::wall_time() + dur;
@@ -134,6 +137,7 @@ impl WaitQueue {
     where
         F: Fn() -> bool,
     {
+        crate::api::might_sleep();
         let curr = crate::current();
         let deadline = ax_hal::time::wall_time() + dur;
         debug!(

--- a/os/arceos/scripts/make/build_c.mk
+++ b/os/arceos/scripts/make/build_c.mk
@@ -51,10 +51,10 @@ else
   endif
 endif
 
-_check_need_rebuild: $(obj_dir)
-	@if [ "$(CFLAGS)" != "`cat $(last_cflags) 2>&1`" ]; then \
+$(last_cflags): FORCE | $(obj_dir)
+	@if [ "$(CFLAGS)" != "`cat $@ 2>&1`" ]; then \
 		echo "CFLAGS changed, rebuild"; \
-		echo "$(CFLAGS)" > $(last_cflags); \
+		echo "$(CFLAGS)" > $@; \
 	fi
 
 $(obj_dir):
@@ -63,7 +63,7 @@ $(obj_dir):
 $(obj_dir)/%.o: $(src_dir)/%.c $(last_cflags)
 	$(call run_cmd,$(CC),$(CFLAGS) -c -o $@ $<)
 
-$(c_lib): $(obj_dir) _check_need_rebuild $(ulib_obj)
+$(c_lib): $(obj_dir) $(ulib_obj)
 	$(call run_cmd,$(AR),rcs $@ $(ulib_obj))
 
 app-objs := main.o
@@ -74,10 +74,10 @@ app_obj_dir := $(APP)/build_$(ARCH)
 last_app_cflags := $(app_obj_dir)/.cflags
 app-objs := $(addprefix $(app_obj_dir)/,$(app-objs))
 
-$(last_app_cflags): | $(app_obj_dir)
-	@if [ "$(CFLAGS) $(APP_CFLAGS)" != "`cat $(last_app_cflags) 2>&1`" ]; then \
+$(last_app_cflags): FORCE | $(app_obj_dir)
+	@if [ "$(CFLAGS) $(APP_CFLAGS)" != "`cat $@ 2>&1`" ]; then \
 		echo "APP CFLAGS changed, rebuild"; \
-		echo "$(CFLAGS) $(APP_CFLAGS)" > $(last_app_cflags); \
+		echo "$(CFLAGS) $(APP_CFLAGS)" > $@; \
 	fi
 
 $(app_obj_dir):
@@ -93,4 +93,5 @@ $(OUT_ELF): $(libgcc) $(app-objs) $(c_lib) $(rust_lib)
 
 $(APP)/axbuild.mk: ;
 
-.PHONY: _check_need_rebuild
+.PHONY: FORCE
+FORCE:

--- a/os/arceos/scripts/make/build_c.mk
+++ b/os/arceos/scripts/make/build_c.mk
@@ -70,9 +70,21 @@ app-objs := main.o
 
 -include $(APP)/axbuild.mk  # override `app-objs`
 
-app-objs := $(addprefix $(APP)/,$(app-objs))
+app_obj_dir := $(APP)/build_$(ARCH)
+last_app_cflags := $(app_obj_dir)/.cflags
+app-objs := $(addprefix $(app_obj_dir)/,$(app-objs))
 
-$(APP)/%.o: $(APP)/%.c $(ulib_hdr)
+$(last_app_cflags): | $(app_obj_dir)
+	@if [ "$(CFLAGS) $(APP_CFLAGS)" != "`cat $(last_app_cflags) 2>&1`" ]; then \
+		echo "APP CFLAGS changed, rebuild"; \
+		echo "$(CFLAGS) $(APP_CFLAGS)" > $(last_app_cflags); \
+	fi
+
+$(app_obj_dir):
+	$(call run_cmd,mkdir,-p $@)
+
+$(app_obj_dir)/%.o: $(APP)/%.c $(ulib_hdr) $(last_app_cflags)
+	$(call run_cmd,mkdir,-p $(dir $@))
 	$(call run_cmd,$(CC),$(CFLAGS) $(APP_CFLAGS) -c -o $@ $<)
 
 $(OUT_ELF): $(libgcc) $(app-objs) $(c_lib) $(rust_lib)

--- a/scripts/axbuild/src/arceos/build.rs
+++ b/scripts/axbuild/src/arceos/build.rs
@@ -140,6 +140,25 @@ impl ArceosBuildInfo {
         }
     }
 
+    fn normalize_legacy_feature_aliases(&mut self) -> bool {
+        let mut changed = false;
+
+        for feature in &mut self.features {
+            let normalized = normalize_legacy_feature_alias(feature);
+            if *feature != normalized {
+                *feature = normalized;
+                changed = true;
+            }
+        }
+
+        if changed {
+            self.features.sort();
+            self.features.dedup();
+        }
+
+        changed
+    }
+
     pub(crate) fn prepare_log_env(&mut self) {
         self.env
             .insert("AX_LOG".into(), format!("{:?}", self.log).to_lowercase());
@@ -301,9 +320,28 @@ pub(crate) fn resolve_build_info_path(
 }
 
 pub(crate) fn load_build_info(request: &ResolvedBuildRequest) -> anyhow::Result<ArceosBuildInfo> {
-    load_or_create_build_info(&request.build_info_path, || {
+    let mut build_info = load_or_create_build_info(&request.build_info_path, || {
         ArceosBuildInfo::default_for_target(&request.target)
-    })
+    })?;
+
+    if build_info.normalize_legacy_feature_aliases() {
+        warn!(
+            "normalizing legacy feature aliases in build config {}",
+            request.build_info_path.display()
+        );
+        fs::write(
+            &request.build_info_path,
+            toml::to_string_pretty(&build_info)?,
+        )
+        .with_context(|| {
+            format!(
+                "failed to rewrite normalized build info {}",
+                request.build_info_path.display()
+            )
+        })?;
+    }
+
+    Ok(build_info)
 }
 
 pub(crate) fn load_cargo_config(request: &ResolvedBuildRequest) -> anyhow::Result<Cargo> {
@@ -355,6 +393,20 @@ fn default_to_bin_for_target(target: &str) -> bool {
 
 fn is_false(value: &bool) -> bool {
     !*value
+}
+
+fn normalize_legacy_feature_alias(feature: &str) -> String {
+    if feature == "axstd" {
+        "ax-std".to_string()
+    } else if let Some(rest) = feature.strip_prefix("axstd/") {
+        format!("ax-std/{rest}")
+    } else if feature == "axfeat" {
+        "ax-feat".to_string()
+    } else if let Some(rest) = feature.strip_prefix("axfeat/") {
+        format!("ax-feat/{rest}")
+    } else {
+        feature.to_string()
+    }
 }
 
 pub(crate) fn resolve_build_info_path_in_dir(dir: &Path, target: &str) -> PathBuf {
@@ -945,6 +997,40 @@ AX_IP = "127.0.0.1"
         assert_eq!(build_info.max_cpu_num, Some(4));
         assert!(build_info.features.contains(&"net".to_string()));
         assert_eq!(build_info.env.get("AX_IP"), Some(&"127.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn load_build_info_normalizes_legacy_feature_aliases() {
+        let root = tempdir().unwrap();
+        let path = root.path().join(".build-target.toml");
+        fs::write(
+            &path,
+            r#"
+features = ["axstd", "axstd/smp", "axfeat/net"]
+log = "Warn"
+
+[env]
+AX_IP = "10.0.2.15"
+"#,
+        )
+        .unwrap();
+        let request = request("ax-helloworld", "target", None, path.clone());
+
+        let build_info = load_build_info(&request).unwrap();
+
+        assert!(build_info.features.contains(&"ax-std".to_string()));
+        assert!(build_info.features.contains(&"ax-std/smp".to_string()));
+        assert!(build_info.features.contains(&"ax-feat/net".to_string()));
+        assert!(!build_info.features.contains(&"axstd".to_string()));
+        assert!(!build_info.features.contains(&"axstd/smp".to_string()));
+        assert!(!build_info.features.contains(&"axfeat/net".to_string()));
+
+        let rewritten = fs::read_to_string(path).unwrap();
+        assert!(rewritten.contains("ax-std"));
+        assert!(rewritten.contains("ax-std/smp"));
+        assert!(rewritten.contains("ax-feat/net"));
+        assert!(!rewritten.contains("axstd"));
+        assert!(!rewritten.contains("axfeat/net"));
     }
 
     #[test]


### PR DESCRIPTION
  ## Summary
  - add Linux-like `might_sleep()` checks to `axtask` blocking and rescheduling paths
  - keep public `yield_now()` checked for atomic-context misuse
  - normalize legacy ArceOS build feature aliases such as `axstd` -> `ax-std`
  - isolate ArceOS C test object files by architecture to avoid cross-target reuse

  ## Details
  - add `might_sleep()` coverage to wait/sleep/join/blocking paths in `axtask`
  - keep `yield_now()` as a checked public API and only use the internal yield primitive for scheduler-owned paths
  - fix `future::block_on()` so it drops the runqueue guard before calling the checked `yield_now()`
  - make `axbuild` auto-normalize stale `.build-*` feature aliases and rewrite the local config when needed
  - move ArceOS C app object files into per-architecture build directories and track per-app CFLAGS so cross-arch test runs do
  not reuse stale `main.o`
  - clarify the panic message to state that both sleeping and rescheduling are forbidden in atomic context

