### PR TITLE
fix(axruntime): arm the first one-shot timer to prevent timer stall

### DIFF
--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -376,6 +376,10 @@ fn init_interrupt() {
         ax_ipi::ipi_handler();
     });
 
+    // Arm the first one-shot timer on the primary CPU. Otherwise the timer
+    // handler may never get the first chance to re-program subsequent ticks.
+    update_timer();
+
     // Enable IRQs before starting app
     ax_hal::asm::enable_irqs();
 }


### PR DESCRIPTION
one-shot 定时器需要手动初始化。如果在启用 IRQ 之前不调用update_timer()，定时器处理程序将永远无法获得第一次重新编程后续 ticks 的机会，导致调度器停滞。

这修复了 AxVisor 在客户机 VM 退出后由于缺少定时器中断而导致 shell 无响应的问题。