### PR TITLE
axalloc: unify allocator backend and add per-CPU buddy slab support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,15 +1470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axallocator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894f6027940d4b013f1d1f9e2e61b47a9e4a7dbf1a0ba10dd33e7bb265ea733"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "axbacktrace"
 version = "0.3.2"
 dependencies = [
@@ -2139,12 +2130,12 @@ dependencies = [
 
 [[package]]
 name = "buddy-slab-allocator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e10a1b61411589daf2647252449679e12ae5a07adef75d9f3eac1978b7d9986"
+checksum = "edaafb583fd8524fc17c03145de026d03162b3bf381c0b985d1d709e1c508350"
 dependencies = [
- "axallocator",
- "cfg-if",
+ "log",
+ "spin 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,7 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "buddy-slab-allocator"
-version = "0.3.1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a844607dec426282e05649372acdc1170b08ba57879be9d3216184ed6dbfd3b"
 dependencies = [
  "log",
  "spin 0.10.0",
@@ -3910,6 +3912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,12 +4269,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4700,14 +4708,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -6200,9 +6208,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,9 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "buddy-slab-allocator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaafb583fd8524fc17c03145de026d03162b3bf381c0b985d1d709e1c508350"
+version = "0.3.1"
 dependencies = [
  "log",
  "spin 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,7 +369,7 @@ ax-crate-interface = {version = "0.5.0", path = "components/crate_interface" }
 # === Other external crates ===
 anyhow = "1.0"
 bindgen = "0.72"
-buddy-slab-allocator = "0.2"
+buddy-slab-allocator = "0.3"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false }
 ax-ctor-bare = { version = "0.4.1", path = "components/ctor_bare/ctor_bare" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,7 +369,7 @@ ax-crate-interface = {version = "0.5.0", path = "components/crate_interface" }
 # === Other external crates ===
 anyhow = "1.0"
 bindgen = "0.72"
-buddy-slab-allocator = "0.3"
+buddy-slab-allocator = "0.4"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false }
 ax-ctor-bare = { version = "0.4.1", path = "components/ctor_bare/ctor_bare" }

--- a/components/arm_vgic/src/v3/gits.rs
+++ b/components/arm_vgic/src/v3/gits.rs
@@ -255,7 +255,8 @@ pub const QWORD_PER_CMD: usize = BYTES_PER_CMD >> 3; // 8 bytes per qword
 
 impl Cmdq {
     fn new(host_gits_base: HostPhysAddr) -> Self {
-        let phy_addr = axvisor_api::memory::alloc_contiguous_frames(16, 0).unwrap();
+        let phy_addr =
+            axvisor_api::memory::alloc_contiguous_frames(16, ax_memory_addr::PAGE_SIZE_4K).unwrap();
         trace!("Cmdq alloc 16 frames: {phy_addr:?}");
         let mut r = Self {
             phy_addr,
@@ -305,8 +306,12 @@ impl Cmdq {
             let ct_baser = ptr::read_volatile(ct_baser_ptr);
 
             // alloc 64 KiB (16 * 4-KiB frames) each for dt and ct
-            let dt_addr = axvisor_api::memory::alloc_contiguous_frames(16, 4).unwrap();
-            let ct_addr = axvisor_api::memory::alloc_contiguous_frames(16, 4).unwrap();
+            let dt_addr =
+                axvisor_api::memory::alloc_contiguous_frames(16, ax_memory_addr::PAGE_SIZE_4K << 4)
+                    .unwrap();
+            let ct_addr =
+                axvisor_api::memory::alloc_contiguous_frames(16, ax_memory_addr::PAGE_SIZE_4K << 4)
+                    .unwrap();
 
             let dt_baser = dt_baser
                 | (dt_addr.as_usize() as u64 & 0x0000_ffff_ffff_f000)

--- a/components/arm_vgic/src/v3/vgicr.rs
+++ b/components/arm_vgic/src/v3/vgicr.rs
@@ -251,8 +251,9 @@ impl LpiPropTable {
              {size_per_gicr}"
         );
 
-        let f = axvisor_api::memory::alloc_contiguous_frames(page_num, 0)
-            .expect("Failed to allocate contiguous frames for LPI prop table");
+        let f =
+            axvisor_api::memory::alloc_contiguous_frames(page_num, ax_memory_addr::PAGE_SIZE_4K)
+                .expect("Failed to allocate contiguous frames for LPI prop table");
         let propreg = f.as_usize() | 0x78f;
         for id in 0..cpu_num {
             let propbaser = host_gicr_base + id * size_per_gicr + GICR_PROPBASER;

--- a/components/axallocator/src/bitmap.rs
+++ b/components/axallocator/src/bitmap.rs
@@ -97,19 +97,19 @@ impl<const PAGE_SIZE: usize> BaseAllocator for BitmapPageAllocator<PAGE_SIZE> {
 impl<const PAGE_SIZE: usize> PageAllocator for BitmapPageAllocator<PAGE_SIZE> {
     const PAGE_SIZE: usize = PAGE_SIZE;
 
-    fn alloc_pages(&mut self, num_pages: usize, align_pow2: usize) -> AllocResult<usize> {
-        // Check if the alignment is valid.
-        if align_pow2 > MAX_ALIGN_1GB || !crate::is_aligned(align_pow2, PAGE_SIZE) {
+    fn alloc_pages(&mut self, num_pages: usize, align: usize) -> AllocResult<usize> {
+        // Check if the byte alignment is valid.
+        if align > MAX_ALIGN_1GB || !crate::is_aligned(align, PAGE_SIZE) {
             return Err(AllocError::InvalidParam);
         }
-        let align_pow2 = align_pow2 / PAGE_SIZE;
-        if !align_pow2.is_power_of_two() {
+        let align_pages = align / PAGE_SIZE;
+        if !align_pages.is_power_of_two() {
             return Err(AllocError::InvalidParam);
         }
         if num_pages > self.available_pages() {
             return Err(AllocError::NoMemory);
         }
-        let align_log2 = align_pow2.trailing_zeros() as usize;
+        let align_log2 = align_pages.trailing_zeros() as usize;
         match num_pages.cmp(&1) {
             core::cmp::Ordering::Equal => self.inner.alloc().map(|idx| idx * PAGE_SIZE + self.base),
             core::cmp::Ordering::Greater => self
@@ -127,22 +127,22 @@ impl<const PAGE_SIZE: usize> PageAllocator for BitmapPageAllocator<PAGE_SIZE> {
         &mut self,
         base: usize,
         num_pages: usize,
-        align_pow2: usize,
+        align: usize,
     ) -> AllocResult<usize> {
-        // Check if the alignment is valid,
+        // Check if the byte alignment is valid,
         // and the base address is aligned to the given alignment.
-        if align_pow2 > MAX_ALIGN_1GB
-            || !crate::is_aligned(align_pow2, PAGE_SIZE)
-            || !crate::is_aligned(base, align_pow2)
+        if align > MAX_ALIGN_1GB
+            || !crate::is_aligned(align, PAGE_SIZE)
+            || !crate::is_aligned(base, align)
         {
             return Err(AllocError::InvalidParam);
         }
 
-        let align_pow2 = align_pow2 / PAGE_SIZE;
-        if !align_pow2.is_power_of_two() {
+        let align_pages = align / PAGE_SIZE;
+        if !align_pages.is_power_of_two() {
             return Err(AllocError::InvalidParam);
         }
-        let align_log2 = align_pow2.trailing_zeros() as usize;
+        let align_log2 = align_pages.trailing_zeros() as usize;
 
         let idx = (base - self.base) / PAGE_SIZE;
 

--- a/components/axallocator/src/lib.rs
+++ b/components/axallocator/src/lib.rs
@@ -38,7 +38,7 @@ pub use tlsf::TlsfByteAllocator;
 /// The error type used for allocation.
 #[derive(Debug)]
 pub enum AllocError {
-    /// Invalid `size` or `align_pow2`. (e.g. unaligned)
+    /// Invalid `size` or alignment. (e.g. unaligned)
     InvalidParam,
     /// Memory added by `add_memory` overlapped with existed memory.
     MemoryOverlap,
@@ -93,19 +93,19 @@ pub trait PageAllocator: BaseAllocator {
     /// The size of a memory page.
     const PAGE_SIZE: usize;
 
-    /// Allocate contiguous memory pages with given count and alignment.
-    fn alloc_pages(&mut self, num_pages: usize, align_pow2: usize) -> AllocResult<usize>;
+    /// Allocate contiguous memory pages with given count and byte alignment.
+    ///
+    /// `align` is the requested alignment in bytes, not a log2/exponent.
+    fn alloc_pages(&mut self, num_pages: usize, align: usize) -> AllocResult<usize>;
 
     /// Deallocate contiguous memory pages with given position and count.
     fn dealloc_pages(&mut self, pos: usize, num_pages: usize);
 
-    /// Allocate contiguous memory pages with given base address, count and alignment.
-    fn alloc_pages_at(
-        &mut self,
-        base: usize,
-        num_pages: usize,
-        align_pow2: usize,
-    ) -> AllocResult<usize>;
+    /// Allocate contiguous memory pages with given base address, count and byte alignment.
+    ///
+    /// `align` is the requested alignment in bytes, not a log2/exponent.
+    fn alloc_pages_at(&mut self, base: usize, num_pages: usize, align: usize)
+    -> AllocResult<usize>;
 
     /// Returns the total number of memory pages.
     fn total_pages(&self) -> usize;

--- a/components/axvisor_api/src/memory.rs
+++ b/components/axvisor_api/src/memory.rs
@@ -88,14 +88,14 @@ pub trait MemoryIf {
     /// # Arguments
     ///
     /// * `num_frames` - The number of contiguous frames to allocate.
-    /// * `frame_align_pow2` - The alignment requirement as a power of 2
-    ///   (e.g., 0 for 4KB alignment, 1 for 8KB alignment).
+    /// * `frame_align` - The alignment requirement in bytes.
+    ///   This is a direct alignment value, not a log2/exponent.
     ///
     /// # Returns
     ///
     /// - `Some(PhysAddr)` - The physical address of the first allocated frame.
     /// - `None` - If allocation fails.
-    fn alloc_contiguous_frames(num_frames: usize, frame_align_pow2: usize) -> Option<PhysAddr>;
+    fn alloc_contiguous_frames(num_frames: usize, frame_align: usize) -> Option<PhysAddr>;
 
     /// Deallocate a frame previously allocated by [`alloc_frame`].
     ///

--- a/components/axvisor_api/src/test.rs
+++ b/components/axvisor_api/src/test.rs
@@ -38,10 +38,7 @@ mod memory_impl {
             Some(pa!(value * 0x1000))
         }
 
-        fn alloc_contiguous_frames(
-            _num_frames: usize,
-            _frame_align_pow2: usize,
-        ) -> Option<PhysAddr> {
+        fn alloc_contiguous_frames(_num_frames: usize, _frame_align: usize) -> Option<PhysAddr> {
             unimplemented!();
         }
 

--- a/components/axvm/src/hal.rs
+++ b/components/axvm/src/hal.rs
@@ -19,19 +19,15 @@ pub struct PagingHandlerImpl;
 
 impl PagingHandler for PagingHandlerImpl {
     fn alloc_frames(num: usize, align: usize) -> Option<PhysAddr> {
-        let align_frames = if align.is_multiple_of(PAGE_SIZE_4K) {
-            align / PAGE_SIZE_4K
-        } else {
+        if !align.is_multiple_of(PAGE_SIZE_4K) {
             panic!("align must be multiple of PAGE_SIZE_4K")
-        };
+        }
 
-        let align_frames_pow2 = if align_frames.is_power_of_two() {
-            align_frames.trailing_zeros()
-        } else {
+        if !align.is_power_of_two() {
             panic!("align must be a power of 2")
-        };
+        }
 
-        axvisor_api::memory::alloc_contiguous_frames(num, align_frames_pow2 as _)
+        axvisor_api::memory::alloc_contiguous_frames(num, align)
     }
 
     fn dealloc_frames(paddr: PhysAddr, num: usize) {

--- a/components/x86_vcpu/src/test_utils.rs
+++ b/components/x86_vcpu/src/test_utils.rs
@@ -59,10 +59,7 @@ pub mod mock {
         }
 
         /// Allocate a number of contiguous frames, with a specified alignment.
-        fn alloc_contiguous_frames(
-            _num_frames: usize,
-            _frame_align_pow2: usize,
-        ) -> Option<PhysAddr> {
+        fn alloc_contiguous_frames(_num_frames: usize, _frame_align: usize) -> Option<PhysAddr> {
             unimplemented!()
         }
 

--- a/os/arceos/Cargo.lock
+++ b/os/arceos/Cargo.lock
@@ -1252,12 +1252,12 @@ dependencies = [
 
 [[package]]
 name = "buddy-slab-allocator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e10a1b61411589daf2647252449679e12ae5a07adef75d9f3eac1978b7d9986"
+checksum = "edaafb583fd8524fc17c03145de026d03162b3bf381c0b985d1d709e1c508350"
 dependencies = [
- "axallocator",
- "cfg-if",
+ "log",
+ "spin 0.10.0",
 ]
 
 [[package]]

--- a/os/arceos/Cargo.lock
+++ b/os/arceos/Cargo.lock
@@ -234,12 +234,12 @@ dependencies = [
  "ax-allocator",
  "ax-errno",
  "ax-kspin",
+ "ax-memory-addr",
  "ax-percpu",
  "axbacktrace",
  "buddy-slab-allocator",
  "cfg-if",
  "log",
- "memory_addr",
  "strum",
 ]
 
@@ -293,6 +293,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ax-cap-access"
+version = "0.3.0"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "ax-config"
 version = "0.5.0"
 dependencies = [
@@ -323,16 +330,15 @@ name = "ax-cpu"
 version = "0.5.0"
 dependencies = [
  "aarch64-cpu 11.2.0",
+ "ax-lazyinit",
+ "ax-memory-addr",
  "ax-page-table-entry",
  "ax-page-table-multiarch",
  "ax-percpu",
  "axbacktrace",
  "cfg-if",
- "lazyinit",
- "linkme",
  "log",
  "loongArch64",
- "memory_addr",
  "riscv",
  "tock-registers 0.10.1",
  "x86",
@@ -340,12 +346,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ax-cpumask"
+version = "0.3.0"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
+name = "ax-crate-interface"
+version = "0.5.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ax-ctor-bare"
+version = "0.4.1"
+dependencies = [
+ "ax-ctor-bare-macros",
+]
+
+[[package]]
+name = "ax-ctor-bare-macros"
+version = "0.4.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ax-display"
 version = "0.5.0"
 dependencies = [
  "ax-driver",
+ "ax-lazyinit",
  "ax-sync",
- "lazyinit",
  "log",
 ]
 
@@ -358,10 +396,10 @@ dependencies = [
  "ax-config",
  "ax-hal",
  "ax-kspin",
+ "ax-memory-addr",
  "ax-mm",
  "buddy-slab-allocator",
  "log",
- "memory_addr",
 ]
 
 [[package]]
@@ -370,6 +408,7 @@ version = "0.5.0"
 dependencies = [
  "ax-alloc",
  "ax-config",
+ "ax-crate-interface",
  "ax-dma",
  "ax-driver-base",
  "ax-driver-block",
@@ -383,7 +422,6 @@ dependencies = [
  "ax-hal",
  "axplat-dyn",
  "cfg-if",
- "crate_interface",
  "log",
  "smallvec",
 ]
@@ -492,6 +530,7 @@ dependencies = [
 name = "ax-fs"
 version = "0.5.0"
 dependencies = [
+ "ax-cap-access",
  "ax-driver",
  "ax-errno",
  "ax-fs-devfs",
@@ -499,9 +538,8 @@ dependencies = [
  "ax-fs-vfs",
  "ax-hal",
  "ax-io",
+ "ax-lazyinit",
  "axfatfs",
- "cap_access",
- "lazyinit",
  "log",
  "rsext4",
  "spin 0.10.0",
@@ -567,6 +605,8 @@ dependencies = [
  "ax-alloc",
  "ax-config",
  "ax-cpu",
+ "ax-kernel-guard",
+ "ax-memory-addr",
  "ax-page-table-multiarch",
  "ax-percpu",
  "ax-plat",
@@ -578,12 +618,13 @@ dependencies = [
  "cfg-if",
  "fdt-parser",
  "heapless 0.9.2",
- "kernel_guard",
- "linkme",
  "log",
- "memory_addr",
  "spin 0.10.0",
 ]
+
+[[package]]
+name = "ax-handler-table"
+version = "0.3.2"
 
 [[package]]
 name = "ax-helloworld"
@@ -626,10 +667,14 @@ name = "ax-input"
 version = "0.5.0"
 dependencies = [
  "ax-driver",
+ "ax-lazyinit",
  "ax-sync",
- "lazyinit",
  "log",
 ]
+
+[[package]]
+name = "ax-int-ratio"
+version = "0.3.2"
 
 [[package]]
 name = "ax-io"
@@ -648,18 +693,30 @@ dependencies = [
  "ax-config",
  "ax-hal",
  "ax-kspin",
+ "ax-lazyinit",
  "ax-percpu",
- "lazyinit",
  "log",
+]
+
+[[package]]
+name = "ax-kernel-guard"
+version = "0.3.3"
+dependencies = [
+ "ax-crate-interface",
+ "cfg-if",
 ]
 
 [[package]]
 name = "ax-kspin"
 version = "0.3.1"
 dependencies = [
+ "ax-kernel-guard",
  "cfg-if",
- "kernel_guard",
 ]
+
+[[package]]
+name = "ax-lazyinit"
+version = "0.4.2"
 
 [[package]]
 name = "ax-libc"
@@ -673,15 +730,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ax-linked-list-r4l"
+version = "0.5.0"
+
+[[package]]
 name = "ax-log"
 version = "0.5.0"
 dependencies = [
+ "ax-crate-interface",
  "ax-kspin",
  "ax-log",
  "cfg-if",
  "chrono",
- "crate_interface",
  "log",
+]
+
+[[package]]
+name = "ax-memory-addr"
+version = "0.6.1"
+
+[[package]]
+name = "ax-memory-set"
+version = "0.6.1"
+dependencies = [
+ "ax-errno",
+ "ax-memory-addr",
 ]
 
 [[package]]
@@ -692,11 +765,11 @@ dependencies = [
  "ax-errno",
  "ax-hal",
  "ax-kspin",
- "ax-page-table-multiarch",
- "lazyinit",
- "log",
- "memory_addr",
+ "ax-lazyinit",
+ "ax-memory-addr",
  "ax-memory-set",
+ "ax-page-table-multiarch",
+ "log",
 ]
 
 [[package]]
@@ -707,10 +780,10 @@ dependencies = [
  "ax-errno",
  "ax-hal",
  "ax-io",
+ "ax-lazyinit",
  "ax-sync",
  "ax-task",
  "cfg-if",
- "lazyinit",
  "log",
  "spin 0.10.0",
  "starry-smoltcp",
@@ -749,8 +822,8 @@ name = "ax-page-table-entry"
 version = "0.8.1"
 dependencies = [
  "aarch64-cpu 11.2.0",
+ "ax-memory-addr",
  "bitflags 2.11.0",
- "memory_addr",
  "x86_64",
 ]
 
@@ -760,10 +833,10 @@ version = "0.8.1"
 dependencies = [
  "arrayvec",
  "ax-errno",
+ "ax-memory-addr",
  "ax-page-table-entry",
  "bitmaps",
  "log",
- "memory_addr",
  "riscv",
  "x86",
 ]
@@ -772,25 +845,35 @@ dependencies = [
 name = "ax-percpu"
 version = "0.4.3"
 dependencies = [
+ "ax-kernel-guard",
  "ax-percpu-macros",
  "cfg-if",
- "kernel_guard",
  "spin 0.10.0",
  "x86",
+]
+
+[[package]]
+name = "ax-percpu-macros"
+version = "0.4.3"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "ax-plat"
 version = "0.5.1"
 dependencies = [
+ "ax-crate-interface",
+ "ax-handler-table",
  "ax-kspin",
+ "ax-memory-addr",
  "ax-percpu",
  "ax-plat-macros",
  "bitflags 2.11.0",
  "const-str",
- "crate_interface",
- "handler_table",
- "memory_addr",
 ]
 
 [[package]]
@@ -816,10 +899,10 @@ dependencies = [
  "ax-arm-pl011",
  "ax-arm-pl031",
  "ax-cpu",
- "ax-kspin",
- "ax-plat",
  "ax-int-ratio",
- "lazyinit",
+ "ax-kspin",
+ "ax-lazyinit",
+ "ax-plat",
  "log",
  "spin 0.10.0",
 ]
@@ -868,10 +951,10 @@ dependencies = [
  "ax-config-macros",
  "ax-cpu",
  "ax-kspin",
+ "ax-lazyinit",
  "ax-page-table-entry",
  "ax-plat",
  "chrono",
- "lazyinit",
  "log",
  "loongArch64",
  "uart_16550",
@@ -893,12 +976,12 @@ dependencies = [
  "ax-config-macros",
  "ax-cpu",
  "ax-kspin",
+ "ax-lazyinit",
  "ax-plat",
- "lazyinit",
+ "ax-riscv-plic",
  "log",
  "riscv",
  "riscv_goldfish",
- "riscv_plic",
  "sbi-rt",
  "uart_16550",
 ]
@@ -909,13 +992,13 @@ version = "0.5.1"
 dependencies = [
  "ax-config-macros",
  "ax-cpu",
+ "ax-int-ratio",
  "ax-kspin",
+ "ax-lazyinit",
  "ax-percpu",
  "ax-plat",
  "bitflags 2.11.0",
  "heapless 0.9.2",
- "ax-int-ratio",
- "lazyinit",
  "log",
  "multiboot",
  "raw-cpuid 11.6.0",
@@ -950,11 +1033,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ax-riscv-plic"
+version = "0.4.0"
+dependencies = [
+ "tock-registers 0.10.1",
+]
+
+[[package]]
 name = "ax-runtime"
 version = "0.5.0"
 dependencies = [
  "ax-alloc",
  "ax-config",
+ "ax-crate-interface",
+ "ax-ctor-bare",
  "ax-display",
  "ax-driver",
  "ax-fs",
@@ -973,8 +1065,6 @@ dependencies = [
  "axklib",
  "cfg-if",
  "chrono",
- "crate_interface",
- "ctor_bare",
  "indoc",
 ]
 
@@ -1001,7 +1091,7 @@ dependencies = [
  "ax-feat",
  "ax-io",
  "ax-kspin",
- "lazyinit",
+ "ax-lazyinit",
  "lock_api",
  "spin 0.10.0",
 ]
@@ -1022,25 +1112,29 @@ name = "ax-task"
 version = "0.5.0"
 dependencies = [
  "ax-config",
+ "ax-cpumask",
+ "ax-crate-interface",
  "ax-errno",
  "ax-hal",
+ "ax-kernel-guard",
  "ax-kspin",
+ "ax-lazyinit",
+ "ax-memory-addr",
  "ax-percpu",
  "ax-sched",
  "ax-task",
+ "ax-timer-list",
  "axpoll",
  "cfg-if",
- "cpumask",
- "crate_interface",
  "extern-trait",
  "futures-util",
- "kernel_guard",
- "lazyinit",
  "log",
- "memory_addr",
  "spin 0.10.0",
- "timer_list",
 ]
+
+[[package]]
+name = "ax-timer-list"
+version = "0.3.0"
 
 [[package]]
 name = "ax_slab_allocator"
@@ -1049,15 +1143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a04dda49054845b496a16f62a58614b1935ed2b4df0b91f9eea4179a5820f08"
 dependencies = [
  "buddy_system_allocator 0.12.0",
-]
-
-[[package]]
-name = "axallocator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894f6027940d4b013f1d1f9e2e61b47a9e4a7dbf1a0ba10dd33e7bb265ea733"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1102,7 +1187,7 @@ name = "axklib"
 version = "0.5.0"
 dependencies = [
  "ax-errno",
- "memory_addr",
+ "ax-memory-addr",
  "trait-ffi",
 ]
 
@@ -1118,6 +1203,7 @@ dependencies = [
  "ax-driver-block",
  "ax-driver-virtio",
  "ax-errno",
+ "ax-memory-addr",
  "ax-percpu",
  "ax-plat",
  "axklib",
@@ -1125,8 +1211,8 @@ dependencies = [
  "fdt-edit",
  "heapless 0.9.2",
  "log",
- "memory_addr",
  "rd-block",
+ "rdif-clk",
  "rdrive",
  "somehal",
  "spin 0.10.0",
@@ -1252,9 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "buddy-slab-allocator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaafb583fd8524fc17c03145de026d03162b3bf381c0b985d1d709e1c508350"
+version = "0.4.0"
 dependencies = [
  "log",
  "spin 0.10.0",
@@ -1302,13 +1386,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "cap_access"
-version = "0.3.0"
-dependencies = [
- "bitflags 2.11.0",
-]
 
 [[package]]
 name = "cc"
@@ -1472,22 +1549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpumask"
-version = "0.3.0"
-dependencies = [
- "bitmaps",
-]
-
-[[package]]
-name = "crate_interface"
-version = "0.5.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,22 +1559,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "ctor_bare"
-version = "0.4.1"
-dependencies = [
- "ctor_bare_macros",
-]
-
-[[package]]
-name = "ctor_bare_macros"
-version = "0.4.1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "darling"
@@ -1947,7 +1992,7 @@ name = "fxmac_rs"
 version = "0.4.1"
 dependencies = [
  "aarch64-cpu 10.0.0",
- "crate_interface",
+ "ax-crate-interface",
  "log",
 ]
 
@@ -1965,10 +2010,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "handler_table"
-version = "0.3.2"
 
 [[package]]
 name = "hash32"
@@ -2078,10 +2119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ax-int-ratio"
-version = "0.3.2"
-
-[[package]]
 name = "intrusive-collections"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,14 +2178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel_guard"
-version = "0.3.3"
-dependencies = [
- "cfg-if",
- "crate_interface",
-]
-
-[[package]]
 name = "kernutil"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,10 +2196,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
-
-[[package]]
-name = "lazyinit"
-version = "0.4.2"
 
 [[package]]
 name = "lenient_semver"
@@ -2215,30 +2240,6 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
-]
-
-[[package]]
-name = "ax-linked-list-r4l"
-version = "0.5.0"
-
-[[package]]
-name = "linkme"
-version = "0.3.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.3.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2316,18 +2317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "memory_addr"
-version = "0.6.1"
-
-[[package]]
-name = "ax-memory-set"
-version = "0.6.1"
-dependencies = [
- "ax-errno",
- "memory_addr",
 ]
 
 [[package]]
@@ -2440,16 +2429,6 @@ dependencies = [
  "pci_types",
  "rdif-pcie",
  "thiserror",
-]
-
-[[package]]
-name = "ax-percpu-macros"
-version = "0.4.3"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2633,6 +2612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdif-clk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b043140cf3c809e5904b5205f7b7205283867da44a44a29820916df08abc362"
+dependencies = [
+ "rdif-base 0.8.0",
+]
+
+[[package]]
 name = "rdif-def"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,13 +2777,6 @@ name = "riscv_goldfish"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07aac72f95e774476db82916d79f2d303191310393830573c1ab5c821b21660a"
-
-[[package]]
-name = "riscv_plic"
-version = "0.4.0"
-dependencies = [
- "tock-registers 0.10.1",
-]
 
 [[package]]
 name = "rlsf"
@@ -3225,10 +3206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "timer_list"
-version = "0.3.0"
-
-[[package]]
 name = "tock-registers"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3642,6 +3619,10 @@ name = "arm_vgic"
 version = "0.4.2"
 
 [[patch.unused]]
+name = "ax-crate-interface-lite"
+version = "0.3.0"
+
+[[patch.unused]]
 name = "axaddrspace"
 version = "0.5.0"
 
@@ -3684,10 +3665,6 @@ version = "0.5.0"
 [[patch.unused]]
 name = "axvmconfig"
 version = "0.4.2"
-
-[[patch.unused]]
-name = "ax-crate-interface-lite"
-version = "0.3.0"
 
 [[patch.unused]]
 name = "define-simple-traits"

--- a/os/arceos/Cargo.toml
+++ b/os/arceos/Cargo.toml
@@ -123,7 +123,7 @@ ax-plat-x86-pc = "0.5.1"
 axpoll = "0.3.2"
 ax-timer-list = "0.3.0"
 bindgen = "0.72"
-buddy-slab-allocator = "0.2"
+buddy-slab-allocator = "0.3"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false }
 ax-crate-interface = "0.5.0"

--- a/os/arceos/Cargo.toml
+++ b/os/arceos/Cargo.toml
@@ -123,7 +123,7 @@ ax-plat-x86-pc = "0.5.1"
 axpoll = "0.3.2"
 ax-timer-list = "0.3.0"
 bindgen = "0.72"
-buddy-slab-allocator = "0.3"
+buddy-slab-allocator = "0.4"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false }
 ax-crate-interface = "0.5.0"

--- a/os/arceos/api/axfeat/Cargo.toml
+++ b/os/arceos/api/axfeat/Cargo.toml
@@ -40,7 +40,6 @@ alloc = ["ax-alloc", "ax-runtime/alloc"]
 alloc-tlsf = ["ax-alloc/tlsf"]
 alloc-slab = ["ax-alloc/slab"]
 alloc-buddy = ["ax-alloc/buddy"]
-alloc-level-1 = ["ax-alloc/level-1", "alloc"]
 page-alloc-64g = ["ax-alloc/page-alloc-64g"]                  # up to 64G memory capacity
 page-alloc-4g = ["ax-alloc/page-alloc-4g"]                    # up to 4G memory capacity
 paging = ["alloc", "ax-hal/paging", "ax-runtime/paging"]

--- a/os/arceos/modules/axalloc/Cargo.toml
+++ b/os/arceos/modules/axalloc/Cargo.toml
@@ -14,7 +14,6 @@ buddy-slab = ["dep:buddy-slab-allocator"]
 buddy = ["dep:ax-allocator", "ax-allocator/buddy"]
 slab = ["dep:ax-allocator", "ax-allocator/slab"]
 tlsf = ["dep:ax-allocator", "ax-allocator/tlsf"]
-level-1 = []
 page-alloc-4g = [
     "dep:ax-allocator",
     "ax-allocator/page-alloc-4g",

--- a/os/arceos/modules/axalloc/Cargo.toml
+++ b/os/arceos/modules/axalloc/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/arceos-org/arceos/tree/main/modules/axalloc"
 
 [features]
 default = ["tlsf", "ax-allocator/page-alloc-256m"]
-buddy-slab = ["dep:buddy-slab-allocator"]
+buddy-slab = ["dep:buddy-slab-allocator", "dep:ax-percpu"]
 buddy = ["dep:ax-allocator", "ax-allocator/buddy"]
 slab = ["dep:ax-allocator", "ax-allocator/slab"]
 tlsf = ["dep:ax-allocator", "ax-allocator/tlsf"]

--- a/os/arceos/modules/axalloc/src/buddy_slab.rs
+++ b/os/arceos/modules/axalloc/src/buddy_slab.rs
@@ -206,29 +206,29 @@ impl AllocatorOps for GlobalAllocator {
     fn alloc_pages(
         &self,
         num_pages: usize,
-        align_pow2: usize,
+        alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        GlobalAllocator::alloc_pages(self, num_pages, align_pow2, kind)
+        GlobalAllocator::alloc_pages(self, num_pages, alignment, kind)
     }
 
     fn alloc_dma32_pages(
         &self,
         num_pages: usize,
-        align_pow2: usize,
+        alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        GlobalAllocator::alloc_dma32_pages(self, num_pages, align_pow2, kind)
+        GlobalAllocator::alloc_dma32_pages(self, num_pages, alignment, kind)
     }
 
     fn alloc_pages_at(
         &self,
         start: usize,
         num_pages: usize,
-        align_pow2: usize,
+        alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        GlobalAllocator::alloc_pages_at(self, start, num_pages, align_pow2, kind)
+        GlobalAllocator::alloc_pages_at(self, start, num_pages, alignment, kind)
     }
 
     fn dealloc_pages(&self, pos: usize, num_pages: usize, kind: UsageKind) {
@@ -339,5 +339,18 @@ unsafe impl GlobalAlloc for GlobalAllocator {
 
         #[cfg(not(feature = "tracking"))]
         inner();
+    }
+}
+
+impl From<buddy_slab_allocator::AllocError> for super::AllocError {
+    fn from(value: buddy_slab_allocator::AllocError) -> Self {
+        match value {
+            buddy_slab_allocator::AllocError::InvalidParam => Self::InvalidParam,
+            buddy_slab_allocator::AllocError::MemoryOverlap => Self::MemoryOverlap,
+            buddy_slab_allocator::AllocError::NoMemory => Self::NoMemory,
+            buddy_slab_allocator::AllocError::NotAllocated => Self::NotAllocated,
+            buddy_slab_allocator::AllocError::NotInitialized => Self::NotInitialized,
+            buddy_slab_allocator::AllocError::NotFound => Self::NotFound,
+        }
     }
 }

--- a/os/arceos/modules/axalloc/src/buddy_slab.rs
+++ b/os/arceos/modules/axalloc/src/buddy_slab.rs
@@ -1,35 +1,28 @@
-//! Axvisor-specific memory allocator implementation using buddy-slab-allocator crate.
-//!
-//! This implementation is designed for virtualization scenarios and provides
-//! address translation support.
+//! Memory allocator implementation backed by `buddy-slab-allocator`.
 
 use core::{
     alloc::{GlobalAlloc, Layout},
     ptr::NonNull,
+    slice,
 };
 
 use ax_kspin::SpinNoIrq;
-use buddy_slab_allocator::{AllocResult, PageAllocator, SlabByteAllocator};
+use buddy_slab_allocator::{GlobalAllocator as InnerAllocator, OsImpl};
 
-use super::{UsageKind, Usages};
+use super::{AllocResult, AllocatorOps, UsageKind, Usages};
 
-/// The global allocator instance for axvisor mode.
+/// The global allocator instance for buddy-slab mode.
 #[cfg_attr(all(target_os = "none", not(test)), global_allocator)]
 static GLOBAL_ALLOCATOR: GlobalAllocator = GlobalAllocator::new();
 
-pub use buddy_slab_allocator::AddrTranslator;
-
-/// The default byte allocator for axvisor mode.
-pub type DefaultByteAllocator = SlabByteAllocator;
+/// The default byte allocator for buddy-slab mode.
+pub type DefaultByteAllocator = buddy_slab_allocator::SlabAllocator<PAGE_SIZE>;
 
 const PAGE_SIZE: usize = 0x1000;
 
-/// The global allocator used by ArceOS for axvisor.
-///
-/// This is an adapter around the buddy_slab_allocator::GlobalAllocator that provides
-/// compatibility with the original ax-alloc API and address translation support.
+/// The global allocator used by ArceOS when `buddy-slab` is enabled.
 pub struct GlobalAllocator {
-    inner: SpinNoIrq<buddy_slab_allocator::GlobalAllocator<PAGE_SIZE>>,
+    inner: SpinNoIrq<InnerAllocator<PAGE_SIZE>>,
     usages: SpinNoIrq<Usages>,
 }
 
@@ -43,7 +36,7 @@ impl GlobalAllocator {
     /// Creates an empty [`GlobalAllocator`].
     pub const fn new() -> Self {
         Self {
-            inner: SpinNoIrq::new(buddy_slab_allocator::GlobalAllocator::<PAGE_SIZE>::new()),
+            inner: SpinNoIrq::new(InnerAllocator::<PAGE_SIZE>::new()),
             usages: SpinNoIrq::new(Usages::new()),
         }
     }
@@ -54,19 +47,19 @@ impl GlobalAllocator {
     }
 
     /// Initializes the allocator with the given region.
-    pub fn init(&self, start_vaddr: usize, size: usize) {
+    pub fn init(
+        &self,
+        start_vaddr: usize,
+        size: usize,
+        cpu_count: usize,
+        os: &'static dyn OsImpl,
+    ) -> AllocResult {
         info!(
             "Initialize global memory allocator, start_vaddr: {:#x}, size: {:#x}",
             start_vaddr, size
         );
-        if let Err(e) = self.inner.lock().init(start_vaddr, size) {
-            panic!("Failed to initialize allocator: {:?}", e);
-        }
-    }
-
-    /// Set the address translator for the allocator.
-    pub fn set_addr_translator(&self, translator: &'static dyn AddrTranslator) {
-        self.inner.lock().set_addr_translator(translator);
+        let region = unsafe { slice::from_raw_parts_mut(start_vaddr as *mut u8, size) };
+        unsafe { self.inner.lock().init(region, cpu_count, os) }.map_err(Into::into)
     }
 
     /// Add the given region to the allocator.
@@ -75,14 +68,19 @@ impl GlobalAllocator {
             "Add memory region, start_vaddr: {:#x}, size: {:#x}",
             start_vaddr, size
         );
-        self.inner.lock().add_memory(start_vaddr, size)
+        let region = unsafe { slice::from_raw_parts_mut(start_vaddr as *mut u8, size) };
+        unsafe { self.inner.lock().add_region(region) }.map_err(Into::into)
     }
 
     /// Allocate arbitrary number of bytes. Returns the left bound of the
     /// allocated region.
     pub fn alloc(&self, layout: Layout) -> AllocResult<NonNull<u8>> {
-        let result = self.inner.lock().alloc(layout);
-        if let Ok(_ptr) = result {
+        let result = self
+            .inner
+            .lock()
+            .alloc(layout)
+            .map_err(crate::AllocError::from);
+        if result.is_ok() {
             self.usages.lock().alloc(UsageKind::RustHeap, layout.size());
         }
         result
@@ -93,7 +91,7 @@ impl GlobalAllocator {
         self.usages
             .lock()
             .dealloc(UsageKind::RustHeap, layout.size());
-        self.inner.lock().dealloc(pos, layout);
+        unsafe { self.inner.lock().dealloc(pos, layout) };
     }
 
     /// Allocates contiguous pages.
@@ -103,33 +101,20 @@ impl GlobalAllocator {
         alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        let result = self.inner.lock().alloc_pages(num_pages, alignment);
-        if let Ok(_addr) = result {
-            let size = num_pages * PAGE_SIZE;
-            self.usages.lock().alloc(kind, size);
+        let result = self
+            .inner
+            .lock()
+            .alloc_pages(num_pages, alignment)
+            .map_err(crate::AllocError::from);
+        if result.is_ok() {
+            self.usages.lock().alloc(kind, num_pages * PAGE_SIZE);
         }
         result
     }
 
-    /// Allocates contiguous low-memory pages (physical address < 4GiB).
+    /// Allocates contiguous low-memory pages (physical address < 4 GiB).
     pub fn alloc_dma32_pages(
         &self,
-        num_pages: usize,
-        alignment: usize,
-        kind: UsageKind,
-    ) -> AllocResult<usize> {
-        let result = self.inner.lock().alloc_dma32_pages(num_pages, alignment);
-        if let Ok(_addr) = result {
-            let size = num_pages * PAGE_SIZE;
-            self.usages.lock().alloc(kind, size);
-        }
-        result
-    }
-
-    /// Allocates contiguous pages starting from the given address.
-    pub fn alloc_pages_at(
-        &self,
-        start: usize,
         num_pages: usize,
         alignment: usize,
         kind: UsageKind,
@@ -137,76 +122,137 @@ impl GlobalAllocator {
         let result = self
             .inner
             .lock()
-            .alloc_pages_at(start, num_pages, alignment);
-        if let Ok(_addr) = result {
-            let size = num_pages * PAGE_SIZE;
-            self.usages.lock().alloc(kind, size);
+            .alloc_pages_lowmem(num_pages, alignment)
+            .map_err(crate::AllocError::from);
+        if result.is_ok() {
+            self.usages.lock().alloc(kind, num_pages * PAGE_SIZE);
         }
         result
     }
 
+    /// Allocates contiguous pages starting from the given address.
+    pub fn alloc_pages_at(
+        &self,
+        _start: usize,
+        _num_pages: usize,
+        _alignment: usize,
+        _kind: UsageKind,
+    ) -> AllocResult<usize> {
+        unimplemented!("buddy-slab allocator does not support alloc_pages_at")
+    }
+
     /// Gives back the allocated pages starts from `pos` to the page allocator.
     pub fn dealloc_pages(&self, pos: usize, num_pages: usize, kind: UsageKind) {
-        let size = num_pages * PAGE_SIZE;
-        self.usages.lock().dealloc(kind, size);
+        self.usages.lock().dealloc(kind, num_pages * PAGE_SIZE);
         self.inner.lock().dealloc_pages(pos, num_pages);
     }
 
-    /// Returns the number of allocated bytes in the byte allocator.
-    #[cfg(feature = "tracking")]
+    /// Returns the number of allocated bytes in the allocator backend.
     pub fn used_bytes(&self) -> usize {
-        // The buddy-slab-allocator doesn't provide a way to get stats
-        0
+        self.inner.lock().allocated_bytes()
     }
 
-    /// Returns the number of available bytes in the byte allocator.
-    #[cfg(feature = "tracking")]
+    /// Returns the number of available bytes in the allocator backend.
     pub fn available_bytes(&self) -> usize {
-        // The buddy-slab-allocator doesn't provide a way to get stats
-        0
+        let inner = self.inner.lock();
+        inner
+            .managed_bytes()
+            .saturating_sub(inner.allocated_bytes())
     }
 
-    /// Returns the number of allocated pages in the page allocator.
-    #[cfg(feature = "tracking")]
+    /// Returns the number of allocated pages in the allocator backend.
     pub fn used_pages(&self) -> usize {
-        // The buddy-slab-allocator doesn't provide a way to get stats
-        0
+        self.used_bytes() / PAGE_SIZE
     }
 
-    /// Returns the number of available pages in the page allocator.
-    #[cfg(feature = "tracking")]
+    /// Returns the number of available pages in the allocator backend.
     pub fn available_pages(&self) -> usize {
-        // The buddy-slab-allocator doesn't provide a way to get stats
-        0
-    }
-
-    /// Returns the number of allocated bytes in the byte allocator.
-    #[cfg(not(feature = "tracking"))]
-    pub fn used_bytes(&self) -> usize {
-        0
-    }
-
-    /// Returns the number of available bytes in the byte allocator.
-    #[cfg(not(feature = "tracking"))]
-    pub fn available_bytes(&self) -> usize {
-        0
-    }
-
-    /// Returns the number of allocated pages in the page allocator.
-    #[cfg(not(feature = "tracking"))]
-    pub fn used_pages(&self) -> usize {
-        0
-    }
-
-    /// Returns the number of available pages in the page allocator.
-    #[cfg(not(feature = "tracking"))]
-    pub fn available_pages(&self) -> usize {
-        0
+        self.available_bytes() / PAGE_SIZE
     }
 
     /// Returns the usage statistics of the allocator.
     pub fn usages(&self) -> Usages {
         *self.usages.lock()
+    }
+}
+
+impl AllocatorOps for GlobalAllocator {
+    fn name(&self) -> &'static str {
+        GlobalAllocator::name(self)
+    }
+
+    fn init(
+        &self,
+        start_vaddr: usize,
+        size: usize,
+        cpu_count: usize,
+        os: &'static dyn OsImpl,
+    ) -> AllocResult {
+        GlobalAllocator::init(self, start_vaddr, size, cpu_count, os)
+    }
+
+    fn add_memory(&self, start_vaddr: usize, size: usize) -> AllocResult {
+        GlobalAllocator::add_memory(self, start_vaddr, size)
+    }
+
+    fn alloc(&self, layout: Layout) -> AllocResult<NonNull<u8>> {
+        GlobalAllocator::alloc(self, layout)
+    }
+
+    fn dealloc(&self, pos: NonNull<u8>, layout: Layout) {
+        GlobalAllocator::dealloc(self, pos, layout)
+    }
+
+    fn alloc_pages(
+        &self,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize> {
+        GlobalAllocator::alloc_pages(self, num_pages, align_pow2, kind)
+    }
+
+    fn alloc_dma32_pages(
+        &self,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize> {
+        GlobalAllocator::alloc_dma32_pages(self, num_pages, align_pow2, kind)
+    }
+
+    fn alloc_pages_at(
+        &self,
+        start: usize,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize> {
+        GlobalAllocator::alloc_pages_at(self, start, num_pages, align_pow2, kind)
+    }
+
+    fn dealloc_pages(&self, pos: usize, num_pages: usize, kind: UsageKind) {
+        GlobalAllocator::dealloc_pages(self, pos, num_pages, kind)
+    }
+
+    fn used_bytes(&self) -> usize {
+        GlobalAllocator::used_bytes(self)
+    }
+
+    fn available_bytes(&self) -> usize {
+        GlobalAllocator::available_bytes(self)
+    }
+
+    fn used_pages(&self) -> usize {
+        GlobalAllocator::used_pages(self)
+    }
+
+    fn available_pages(&self) -> usize {
+        GlobalAllocator::available_pages(self)
+    }
+
+    fn usages(&self) -> Usages {
+        GlobalAllocator::usages(self)
     }
 }
 
@@ -216,41 +262,23 @@ pub fn global_allocator() -> &'static GlobalAllocator {
 }
 
 /// Initializes the global allocator with the given memory region.
-///
-/// Note that the memory region bounds are just numbers, and the allocator
-/// does not actually access the region. Users should ensure that the region
-/// is valid and not being used by others, so that the allocated memory is also
-/// valid.
-///
-/// This function should be called only once, and before any allocation.
-///
-/// # Arguments
-///
-/// - `start_vaddr`: The starting virtual address of the memory region.
-/// - `size`: The size of the memory region in bytes.
-/// - `translator`: The address translator for virtualization.
-pub fn global_init(start_vaddr: usize, size: usize, translator: &'static dyn AddrTranslator) {
+pub fn global_init(
+    start_vaddr: usize,
+    size: usize,
+    cpu_count: usize,
+    os: &'static dyn OsImpl,
+) -> AllocResult {
     debug!(
         "initialize global allocator at: [{:#x}, {:#x})",
         start_vaddr,
         start_vaddr + size
     );
-    GLOBAL_ALLOCATOR.init(start_vaddr, size);
-    GLOBAL_ALLOCATOR.set_addr_translator(translator);
+    GLOBAL_ALLOCATOR.init(start_vaddr, size, cpu_count, os)?;
     info!("global allocator initialized");
+    Ok(())
 }
 
 /// Add the given memory region to the global allocator.
-///
-/// Users should ensure that the region is valid and not being used by others,
-/// so that the allocated memory is also valid.
-///
-/// It's similar to [`global_init`], but can be called multiple times.
-///
-/// # Arguments
-///
-/// - `start_vaddr`: The starting virtual address of the memory region.
-/// - `size`: The size of the memory region in bytes.
 pub fn global_add_memory(start_vaddr: usize, size: usize) -> AllocResult {
     debug!(
         "add a memory region to global allocator: [{:#x}, {:#x})",

--- a/os/arceos/modules/axalloc/src/buddy_slab.rs
+++ b/os/arceos/modules/axalloc/src/buddy_slab.rs
@@ -7,7 +7,11 @@ use core::{
 };
 
 use ax_kspin::SpinNoIrq;
-use buddy_slab_allocator::{GlobalAllocator as InnerAllocator, OsImpl};
+use buddy_slab_allocator::{
+    GlobalAllocator as InnerAllocator, SizeClass, SlabAllocResult, SlabAllocator,
+    SlabDeallocResult, SlabPoolTrait, SlabTrait,
+    eii::{slab_pool_impl, virt_to_phys_impl},
+};
 
 use super::{AllocResult, AllocatorOps, UsageKind, Usages};
 
@@ -19,6 +23,98 @@ static GLOBAL_ALLOCATOR: GlobalAllocator = GlobalAllocator::new();
 pub type DefaultByteAllocator = buddy_slab_allocator::SlabAllocator<PAGE_SIZE>;
 
 const PAGE_SIZE: usize = 0x1000;
+
+#[ax_percpu::def_percpu]
+static PRECPU_SLAB: PrecpuSlab<PAGE_SIZE> = PrecpuSlab::new_uninit();
+
+static SLAB_POOL: SlabPool = SlabPool;
+
+struct PrecpuSlab<const PAGE_SIZE: usize = 0x1000> {
+    cpu_id: Option<u16>,
+    inner: SpinNoIrq<SlabAllocator<PAGE_SIZE>>,
+}
+
+impl<const PAGE_SIZE: usize> PrecpuSlab<PAGE_SIZE> {
+    const fn new_uninit() -> Self {
+        Self {
+            cpu_id: None,
+            inner: SpinNoIrq::new(SlabAllocator::new()),
+        }
+    }
+
+    fn init(&mut self, cpu_id: usize) {
+        let cpu_id = u16::try_from(cpu_id).expect("CPU id exceeds per-CPU slab range");
+        assert!(
+            self.cpu_id.is_none(),
+            "per-CPU slab is already initialized on this CPU",
+        );
+        self.cpu_id = Some(cpu_id);
+        *self.inner.lock() = SlabAllocator::new();
+    }
+
+    fn cpu_id_checked(&self) -> u16 {
+        self.cpu_id
+            .expect("per-CPU slab is not initialized on this CPU")
+    }
+}
+
+impl<const PAGE_SIZE: usize> SlabTrait for PrecpuSlab<PAGE_SIZE> {
+    fn cpu_id(&self) -> usize {
+        self.cpu_id_checked() as usize
+    }
+
+    fn page_size(&self) -> usize {
+        PAGE_SIZE
+    }
+
+    fn alloc(&self, layout: Layout) -> buddy_slab_allocator::AllocResult<SlabAllocResult> {
+        self.inner.lock().alloc(layout)
+    }
+
+    fn add_slab(&self, size_class: SizeClass, base: usize, bytes: usize) {
+        self.inner
+            .lock()
+            .add_slab(size_class, base, bytes, self.cpu_id_checked());
+    }
+
+    fn dealloc_local(&self, ptr: NonNull<u8>, layout: Layout) -> SlabDeallocResult {
+        self.inner.lock().dealloc(ptr, layout)
+    }
+}
+
+fn current_precpu_slab() -> &'static PrecpuSlab<PAGE_SIZE> {
+    // Safety: the outer allocator lock disables local IRQs/preemption before
+    // upstream buddy-slab-allocator calls this hook.
+    unsafe { PRECPU_SLAB.current_ref_raw() }
+}
+
+fn remote_precpu_slab(cpu_idx: usize) -> &'static PrecpuSlab<PAGE_SIZE> {
+    // Safety: the owner CPU id comes from slab metadata and references a valid
+    // per-CPU slab that was initialized during CPU bring-up.
+    unsafe { PRECPU_SLAB.remote_ref_raw(cpu_idx) }
+}
+
+struct SlabPool;
+
+impl SlabPoolTrait for SlabPool {
+    fn current_slab(&self) -> &dyn SlabTrait {
+        current_precpu_slab()
+    }
+
+    fn owner_slab(&self, cpu_idx: usize) -> &dyn SlabTrait {
+        remote_precpu_slab(cpu_idx)
+    }
+}
+
+#[slab_pool_impl]
+fn slab_pool() -> &'static dyn SlabPoolTrait {
+    &SLAB_POOL
+}
+
+#[virt_to_phys_impl]
+fn virt_to_phys(vaddr: usize) -> usize {
+    crate::eii::virt_to_phys(vaddr)
+}
 
 /// The global allocator used by ArceOS when `buddy-slab` is enabled.
 pub struct GlobalAllocator {
@@ -47,19 +143,13 @@ impl GlobalAllocator {
     }
 
     /// Initializes the allocator with the given region.
-    pub fn init(
-        &self,
-        start_vaddr: usize,
-        size: usize,
-        cpu_count: usize,
-        os: &'static dyn OsImpl,
-    ) -> AllocResult {
+    pub fn init(&self, start_vaddr: usize, size: usize) -> AllocResult {
         info!(
             "Initialize global memory allocator, start_vaddr: {:#x}, size: {:#x}",
             start_vaddr, size
         );
         let region = unsafe { slice::from_raw_parts_mut(start_vaddr as *mut u8, size) };
-        unsafe { self.inner.lock().init(region, cpu_count, os) }.map_err(Into::into)
+        unsafe { self.inner.lock().init(region) }.map_err(Into::into)
     }
 
     /// Add the given region to the allocator.
@@ -181,14 +271,8 @@ impl AllocatorOps for GlobalAllocator {
         GlobalAllocator::name(self)
     }
 
-    fn init(
-        &self,
-        start_vaddr: usize,
-        size: usize,
-        cpu_count: usize,
-        os: &'static dyn OsImpl,
-    ) -> AllocResult {
-        GlobalAllocator::init(self, start_vaddr, size, cpu_count, os)
+    fn init(&self, start_vaddr: usize, size: usize) -> AllocResult {
+        GlobalAllocator::init(self, start_vaddr, size)
     }
 
     fn add_memory(&self, start_vaddr: usize, size: usize) -> AllocResult {
@@ -261,19 +345,19 @@ pub fn global_allocator() -> &'static GlobalAllocator {
     &GLOBAL_ALLOCATOR
 }
 
+/// Initializes the per-CPU slab for the current CPU.
+pub fn init_precpu_slab(cpu_id: usize) {
+    PRECPU_SLAB.with_current(|slab| slab.init(cpu_id));
+}
+
 /// Initializes the global allocator with the given memory region.
-pub fn global_init(
-    start_vaddr: usize,
-    size: usize,
-    cpu_count: usize,
-    os: &'static dyn OsImpl,
-) -> AllocResult {
+pub fn global_init(start_vaddr: usize, size: usize) -> AllocResult {
     debug!(
         "initialize global allocator at: [{:#x}, {:#x})",
         start_vaddr,
         start_vaddr + size
     );
-    GLOBAL_ALLOCATOR.init(start_vaddr, size, cpu_count, os)?;
+    GLOBAL_ALLOCATOR.init(start_vaddr, size)?;
     info!("global allocator initialized");
     Ok(())
 }
@@ -346,6 +430,7 @@ impl From<buddy_slab_allocator::AllocError> for super::AllocError {
     fn from(value: buddy_slab_allocator::AllocError) -> Self {
         match value {
             buddy_slab_allocator::AllocError::InvalidParam => Self::InvalidParam,
+            buddy_slab_allocator::AllocError::AlreadyInitialized => Self::AlreadyInitialized,
             buddy_slab_allocator::AllocError::MemoryOverlap => Self::MemoryOverlap,
             buddy_slab_allocator::AllocError::NoMemory => Self::NoMemory,
             buddy_slab_allocator::AllocError::NotAllocated => Self::NotAllocated,

--- a/os/arceos/modules/axalloc/src/default_impl.rs
+++ b/os/arceos/modules/axalloc/src/default_impl.rs
@@ -11,10 +11,10 @@ use core::{
     ptr::NonNull,
 };
 
-use ax_allocator::{AllocResult, BaseAllocator, BitmapPageAllocator, ByteAllocator, PageAllocator};
+use ax_allocator::{BaseAllocator, BitmapPageAllocator, ByteAllocator, PageAllocator};
 use ax_kspin::SpinNoIrq;
 
-use super::{UsageKind, Usages};
+use super::{AllocResult, AllocatorOps, OsImpl, UsageKind, Usages};
 
 /// The global allocator instance for standard mode.
 #[cfg_attr(all(target_os = "none", not(test)), global_allocator)]
@@ -44,7 +44,6 @@ cfg_if::cfg_if! {
 /// the byte allocator.
 pub struct GlobalAllocator {
     balloc: SpinNoIrq<DefaultByteAllocator>,
-    #[cfg(not(feature = "level-1"))]
     palloc: SpinNoIrq<BitmapPageAllocator<PAGE_SIZE>>,
     usages: SpinNoIrq<Usages>,
 }
@@ -60,7 +59,6 @@ impl GlobalAllocator {
     pub const fn new() -> Self {
         Self {
             balloc: SpinNoIrq::new(DefaultByteAllocator::new()),
-            #[cfg(not(feature = "level-1"))]
             palloc: SpinNoIrq::new(BitmapPageAllocator::new()),
             usages: SpinNoIrq::new(Usages::new()),
         }
@@ -86,29 +84,33 @@ impl GlobalAllocator {
     /// It firstly adds the whole region to the page allocator, then allocates
     /// a small region (32 KB) to initialize the byte allocator. Therefore,
     /// the given region must be larger than 32 KB.
-    pub fn init(&self, start_vaddr: usize, size: usize) {
-        assert!(size > MIN_HEAP_SIZE);
-        #[cfg(not(feature = "level-1"))]
-        {
-            let init_heap_size = MIN_HEAP_SIZE;
-            self.palloc.lock().init(start_vaddr, size);
-            let heap_ptr = self
-                .alloc_pages(init_heap_size / PAGE_SIZE, PAGE_SIZE, UsageKind::RustHeap)
-                .unwrap();
+    pub fn init(
+        &self,
+        start_vaddr: usize,
+        size: usize,
+        _cpu_count: usize,
+        _os: &'static dyn OsImpl,
+    ) -> AllocResult {
+        if size <= MIN_HEAP_SIZE {
+            return Err(crate::AllocError::InvalidParam);
+        }
+        let init_heap_size = MIN_HEAP_SIZE;
+        self.palloc.lock().init(start_vaddr, size);
+        let heap_ptr =
+            self.alloc_pages(init_heap_size / PAGE_SIZE, PAGE_SIZE, UsageKind::RustHeap)?;
 
-            self.balloc.lock().init(heap_ptr, init_heap_size);
-        }
-        #[cfg(feature = "level-1")]
-        {
-            self.balloc.lock().init(start_vaddr, size);
-        }
+        self.balloc.lock().init(heap_ptr, init_heap_size);
+        Ok(())
     }
 
     /// Add the given region to the allocator.
     ///
     /// It will add the whole region to the byte allocator.
     pub fn add_memory(&self, start_vaddr: usize, size: usize) -> AllocResult {
-        self.balloc.lock().add_memory(start_vaddr, size)
+        self.balloc
+            .lock()
+            .add_memory(start_vaddr, size)
+            .map_err(Into::into)
     }
 
     /// Allocate arbitrary number of bytes. Returns the left bound of the
@@ -118,27 +120,6 @@ impl GlobalAllocator {
     /// memory, it asks the page allocator for more memory and adds it to the
     /// byte allocator.
     pub fn alloc(&self, layout: Layout) -> AllocResult<NonNull<u8>> {
-        #[cfg(feature = "level-1")]
-        {
-            self.alloc_level1(layout)
-        }
-        #[cfg(not(feature = "level-1"))]
-        {
-            self.alloc_level2(layout)
-        }
-    }
-
-    #[cfg(feature = "level-1")]
-    fn alloc_level1(&self, layout: Layout) -> AllocResult<NonNull<u8>> {
-        // single-level allocator: only use the byte allocator.
-        let mut balloc = self.balloc.lock();
-        let ptr = balloc.alloc(layout)?;
-        self.usages.lock().alloc(UsageKind::RustHeap, layout.size());
-        Ok(ptr)
-    }
-
-    #[cfg(not(feature = "level-1"))]
-    fn alloc_level2(&self, layout: Layout) -> AllocResult<NonNull<u8>> {
         // simple two-level allocator: if no heap memory, allocate from the page allocator.
         let mut balloc = self.balloc.lock();
         loop {
@@ -174,7 +155,9 @@ impl GlobalAllocator {
                         heap_ptr,
                         heap_ptr + try_size
                     );
-                    balloc.add_memory(heap_ptr, try_size)?;
+                    balloc
+                        .add_memory(heap_ptr, try_size)
+                        .map_err(crate::AllocError::from)?;
                     break;
                 }
             }
@@ -205,23 +188,25 @@ impl GlobalAllocator {
         align_pow2: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        #[cfg(feature = "level-1")]
-        {
-            // single-level allocator: allocate from the byte allocator.
-            let mut balloc = self.balloc.lock();
-            let layout = Layout::from_size_align(num_pages * PAGE_SIZE, align_pow2).unwrap();
-            let ptr = balloc.alloc(layout)?;
+        let addr = self
+            .palloc
+            .lock()
+            .alloc_pages(num_pages, align_pow2)
+            .map_err(crate::AllocError::from)?;
+        if !matches!(kind, UsageKind::RustHeap) {
             self.usages.lock().alloc(kind, num_pages * PAGE_SIZE);
-            Ok(ptr.as_ptr() as usize)
         }
-        #[cfg(not(feature = "level-1"))]
-        {
-            let addr = self.palloc.lock().alloc_pages(num_pages, align_pow2)?;
-            if !matches!(kind, UsageKind::RustHeap) {
-                self.usages.lock().alloc(kind, num_pages * PAGE_SIZE);
-            }
-            Ok(addr)
-        }
+        Ok(addr)
+    }
+
+    /// Allocates contiguous low-memory pages (physical address < 4 GiB).
+    pub fn alloc_dma32_pages(
+        &self,
+        _num_pages: usize,
+        _align_pow2: usize,
+        _kind: UsageKind,
+    ) -> AllocResult<usize> {
+        unimplemented!("default allocator does not support alloc_dma32_pages")
     }
 
     /// Allocates contiguous pages starting from the given address.
@@ -238,22 +223,15 @@ impl GlobalAllocator {
         align_pow2: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        #[cfg(feature = "level-1")]
-        {
-            let _ = (start, num_pages, align_pow2, kind);
-            unimplemented!("level-1 allocator does not support alloc_pages_at")
+        let addr = self
+            .palloc
+            .lock()
+            .alloc_pages_at(start, num_pages, align_pow2)
+            .map_err(crate::AllocError::from)?;
+        if !matches!(kind, UsageKind::RustHeap) {
+            self.usages.lock().alloc(kind, num_pages * PAGE_SIZE);
         }
-        #[cfg(not(feature = "level-1"))]
-        {
-            let addr = self
-                .palloc
-                .lock()
-                .alloc_pages_at(start, num_pages, align_pow2)?;
-            if !matches!(kind, UsageKind::RustHeap) {
-                self.usages.lock().alloc(kind, num_pages * PAGE_SIZE);
-            }
-            Ok(addr)
-        }
+        Ok(addr)
     }
 
     /// Gives back the allocated pages starts from `pos` to the page allocator.
@@ -263,15 +241,6 @@ impl GlobalAllocator {
     /// behavior is undefined.
     pub fn dealloc_pages(&self, pos: usize, num_pages: usize, kind: UsageKind) {
         self.usages.lock().dealloc(kind, num_pages * PAGE_SIZE);
-        #[cfg(feature = "level-1")]
-        {
-            // single-level allocator: deallocate to the byte allocator.
-            let mut balloc = self.balloc.lock();
-            let layout = Layout::from_size_align(num_pages * PAGE_SIZE, PAGE_SIZE).unwrap();
-            let ptr = NonNull::new(pos as *mut u8).unwrap();
-            balloc.dealloc(ptr, layout);
-        }
-        #[cfg(not(feature = "level-1"))]
         self.palloc.lock().dealloc_pages(pos, num_pages);
     }
 
@@ -287,29 +256,97 @@ impl GlobalAllocator {
 
     /// Returns the number of allocated pages in the page allocator.
     pub fn used_pages(&self) -> usize {
-        #[cfg(feature = "level-1")]
-        {
-            self.used_bytes().div_ceil(PAGE_SIZE)
-        }
-        #[cfg(not(feature = "level-1"))]
-        {
-            self.palloc.lock().used_pages()
-        }
+        self.palloc.lock().used_pages()
     }
 
     /// Returns the number of available pages in the page allocator.
     pub fn available_pages(&self) -> usize {
-        #[cfg(feature = "level-1")]
-        {
-            self.available_bytes().div_ceil(PAGE_SIZE)
-        }
-        #[cfg(not(feature = "level-1"))]
         self.palloc.lock().available_pages()
     }
 
     /// Returns the usage statistics of the allocator.
     pub fn usages(&self) -> Usages {
         *self.usages.lock()
+    }
+}
+
+impl AllocatorOps for GlobalAllocator {
+    fn name(&self) -> &'static str {
+        GlobalAllocator::name(self)
+    }
+
+    fn init(
+        &self,
+        start_vaddr: usize,
+        size: usize,
+        cpu_count: usize,
+        os: &'static dyn OsImpl,
+    ) -> AllocResult {
+        GlobalAllocator::init(self, start_vaddr, size, cpu_count, os)
+    }
+
+    fn add_memory(&self, start_vaddr: usize, size: usize) -> AllocResult {
+        GlobalAllocator::add_memory(self, start_vaddr, size)
+    }
+
+    fn alloc(&self, layout: Layout) -> AllocResult<NonNull<u8>> {
+        GlobalAllocator::alloc(self, layout)
+    }
+
+    fn dealloc(&self, pos: NonNull<u8>, layout: Layout) {
+        GlobalAllocator::dealloc(self, pos, layout)
+    }
+
+    fn alloc_pages(
+        &self,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize> {
+        GlobalAllocator::alloc_pages(self, num_pages, align_pow2, kind)
+    }
+
+    fn alloc_dma32_pages(
+        &self,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize> {
+        GlobalAllocator::alloc_dma32_pages(self, num_pages, align_pow2, kind)
+    }
+
+    fn alloc_pages_at(
+        &self,
+        start: usize,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize> {
+        GlobalAllocator::alloc_pages_at(self, start, num_pages, align_pow2, kind)
+    }
+
+    fn dealloc_pages(&self, pos: usize, num_pages: usize, kind: UsageKind) {
+        GlobalAllocator::dealloc_pages(self, pos, num_pages, kind)
+    }
+
+    fn used_bytes(&self) -> usize {
+        GlobalAllocator::used_bytes(self)
+    }
+
+    fn available_bytes(&self) -> usize {
+        GlobalAllocator::available_bytes(self)
+    }
+
+    fn used_pages(&self) -> usize {
+        GlobalAllocator::used_pages(self)
+    }
+
+    fn available_pages(&self) -> usize {
+        GlobalAllocator::available_pages(self)
+    }
+
+    fn usages(&self) -> Usages {
+        GlobalAllocator::usages(self)
     }
 }
 
@@ -331,13 +368,18 @@ pub fn global_allocator() -> &'static GlobalAllocator {
 ///
 /// - `start_vaddr`: The starting virtual address of the memory region.
 /// - `size`: The size of the memory region in bytes.
-pub fn global_init(start_vaddr: usize, size: usize) {
+pub fn global_init(
+    start_vaddr: usize,
+    size: usize,
+    cpu_count: usize,
+    os: &'static dyn OsImpl,
+) -> AllocResult {
     debug!(
         "initialize global allocator at: [{:#x}, {:#x})",
         start_vaddr,
         start_vaddr + size
     );
-    GLOBAL_ALLOCATOR.init(start_vaddr, size);
+    GLOBAL_ALLOCATOR.init(start_vaddr, size, cpu_count, os)
 }
 
 /// Add the given memory region to the global allocator.

--- a/os/arceos/modules/axalloc/src/default_impl.rs
+++ b/os/arceos/modules/axalloc/src/default_impl.rs
@@ -166,9 +166,8 @@ impl GlobalAllocator {
 
     /// Gives back the allocated region to the byte allocator.
     ///
-    /// The region should be allocated by [`alloc`], and `align_pow2` should be
-    /// the same as the one used in [`alloc`]. Otherwise, the behavior is
-    /// undefined.
+    /// The region should be allocated by [`alloc`] with the same `layout`.
+    /// Otherwise, the behavior is undefined.
     pub fn dealloc(&self, pos: NonNull<u8>, layout: Layout) {
         self.usages
             .lock()
@@ -180,18 +179,18 @@ impl GlobalAllocator {
     ///
     /// It allocates `num_pages` pages from the page allocator.
     ///
-    /// `align_pow2` must be a power of 2, and the returned region bound will be
-    /// aligned to it.
+    /// `align` is the requested alignment in bytes, not a log2/exponent.
+    /// It must be a power-of-two byte alignment accepted by the page allocator.
     pub fn alloc_pages(
         &self,
         num_pages: usize,
-        align_pow2: usize,
+        alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
         let addr = self
             .palloc
             .lock()
-            .alloc_pages(num_pages, align_pow2)
+            .alloc_pages(num_pages, alignment)
             .map_err(crate::AllocError::from)?;
         if !matches!(kind, UsageKind::RustHeap) {
             self.usages.lock().alloc(kind, num_pages * PAGE_SIZE);
@@ -203,7 +202,7 @@ impl GlobalAllocator {
     pub fn alloc_dma32_pages(
         &self,
         _num_pages: usize,
-        _align_pow2: usize,
+        _alignment: usize,
         _kind: UsageKind,
     ) -> AllocResult<usize> {
         unimplemented!("default allocator does not support alloc_dma32_pages")
@@ -214,19 +213,19 @@ impl GlobalAllocator {
     /// It allocates `num_pages` pages from the page allocator starting from the
     /// given address.
     ///
-    /// `align_pow2` must be a power of 2, and the returned region bound will be
-    /// aligned to it.
+    /// `align` is the requested alignment in bytes, not a log2/exponent.
+    /// It must be a power-of-two byte alignment accepted by the page allocator.
     pub fn alloc_pages_at(
         &self,
         start: usize,
         num_pages: usize,
-        align_pow2: usize,
+        alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
         let addr = self
             .palloc
             .lock()
-            .alloc_pages_at(start, num_pages, align_pow2)
+            .alloc_pages_at(start, num_pages, alignment)
             .map_err(crate::AllocError::from)?;
         if !matches!(kind, UsageKind::RustHeap) {
             self.usages.lock().alloc(kind, num_pages * PAGE_SIZE);
@@ -236,9 +235,8 @@ impl GlobalAllocator {
 
     /// Gives back the allocated pages starts from `pos` to the page allocator.
     ///
-    /// The pages should be allocated by [`alloc_pages`], and `align_pow2`
-    /// should be the same as the one used in [`alloc_pages`]. Otherwise, the
-    /// behavior is undefined.
+    /// The pages should be allocated by [`alloc_pages`] or [`alloc_pages_at`].
+    /// Otherwise, the behavior is undefined.
     pub fn dealloc_pages(&self, pos: usize, num_pages: usize, kind: UsageKind) {
         self.usages.lock().dealloc(kind, num_pages * PAGE_SIZE);
         self.palloc.lock().dealloc_pages(pos, num_pages);
@@ -300,29 +298,29 @@ impl AllocatorOps for GlobalAllocator {
     fn alloc_pages(
         &self,
         num_pages: usize,
-        align_pow2: usize,
+        alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        GlobalAllocator::alloc_pages(self, num_pages, align_pow2, kind)
+        GlobalAllocator::alloc_pages(self, num_pages, alignment, kind)
     }
 
     fn alloc_dma32_pages(
         &self,
         num_pages: usize,
-        align_pow2: usize,
+        alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        GlobalAllocator::alloc_dma32_pages(self, num_pages, align_pow2, kind)
+        GlobalAllocator::alloc_dma32_pages(self, num_pages, alignment, kind)
     }
 
     fn alloc_pages_at(
         &self,
         start: usize,
         num_pages: usize,
-        align_pow2: usize,
+        alignment: usize,
         kind: UsageKind,
     ) -> AllocResult<usize> {
-        GlobalAllocator::alloc_pages_at(self, start, num_pages, align_pow2, kind)
+        GlobalAllocator::alloc_pages_at(self, start, num_pages, alignment, kind)
     }
 
     fn dealloc_pages(&self, pos: usize, num_pages: usize, kind: UsageKind) {
@@ -453,5 +451,16 @@ unsafe impl GlobalAlloc for GlobalAllocator {
 
         #[cfg(not(feature = "tracking"))]
         inner();
+    }
+}
+
+impl From<ax_allocator::AllocError> for super::AllocError {
+    fn from(value: ax_allocator::AllocError) -> Self {
+        match value {
+            ax_allocator::AllocError::InvalidParam => Self::InvalidParam,
+            ax_allocator::AllocError::MemoryOverlap => Self::MemoryOverlap,
+            ax_allocator::AllocError::NoMemory => Self::NoMemory,
+            ax_allocator::AllocError::NotAllocated => Self::NotAllocated,
+        }
     }
 }

--- a/os/arceos/modules/axalloc/src/default_impl.rs
+++ b/os/arceos/modules/axalloc/src/default_impl.rs
@@ -14,7 +14,7 @@ use core::{
 use ax_allocator::{BaseAllocator, BitmapPageAllocator, ByteAllocator, PageAllocator};
 use ax_kspin::SpinNoIrq;
 
-use super::{AllocResult, AllocatorOps, OsImpl, UsageKind, Usages};
+use super::{AllocResult, AllocatorOps, UsageKind, Usages};
 
 /// The global allocator instance for standard mode.
 #[cfg_attr(all(target_os = "none", not(test)), global_allocator)]
@@ -84,13 +84,7 @@ impl GlobalAllocator {
     /// It firstly adds the whole region to the page allocator, then allocates
     /// a small region (32 KB) to initialize the byte allocator. Therefore,
     /// the given region must be larger than 32 KB.
-    pub fn init(
-        &self,
-        start_vaddr: usize,
-        size: usize,
-        _cpu_count: usize,
-        _os: &'static dyn OsImpl,
-    ) -> AllocResult {
+    pub fn init(&self, start_vaddr: usize, size: usize) -> AllocResult {
         if size <= MIN_HEAP_SIZE {
             return Err(crate::AllocError::InvalidParam);
         }
@@ -273,14 +267,8 @@ impl AllocatorOps for GlobalAllocator {
         GlobalAllocator::name(self)
     }
 
-    fn init(
-        &self,
-        start_vaddr: usize,
-        size: usize,
-        cpu_count: usize,
-        os: &'static dyn OsImpl,
-    ) -> AllocResult {
-        GlobalAllocator::init(self, start_vaddr, size, cpu_count, os)
+    fn init(&self, start_vaddr: usize, size: usize) -> AllocResult {
+        GlobalAllocator::init(self, start_vaddr, size)
     }
 
     fn add_memory(&self, start_vaddr: usize, size: usize) -> AllocResult {
@@ -366,18 +354,13 @@ pub fn global_allocator() -> &'static GlobalAllocator {
 ///
 /// - `start_vaddr`: The starting virtual address of the memory region.
 /// - `size`: The size of the memory region in bytes.
-pub fn global_init(
-    start_vaddr: usize,
-    size: usize,
-    cpu_count: usize,
-    os: &'static dyn OsImpl,
-) -> AllocResult {
+pub fn global_init(start_vaddr: usize, size: usize) -> AllocResult {
     debug!(
         "initialize global allocator at: [{:#x}, {:#x})",
         start_vaddr,
         start_vaddr + size
     );
-    GLOBAL_ALLOCATOR.init(start_vaddr, size, cpu_count, os)
+    GLOBAL_ALLOCATOR.init(start_vaddr, size)
 }
 
 /// Add the given memory region to the global allocator.

--- a/os/arceos/modules/axalloc/src/lib.rs
+++ b/os/arceos/modules/axalloc/src/lib.rs
@@ -108,32 +108,6 @@ impl From<AllocError> for AxError {
     }
 }
 
-#[cfg(not(feature = "buddy-slab"))]
-impl From<ax_allocator::AllocError> for AllocError {
-    fn from(value: ax_allocator::AllocError) -> Self {
-        match value {
-            ax_allocator::AllocError::InvalidParam => Self::InvalidParam,
-            ax_allocator::AllocError::MemoryOverlap => Self::MemoryOverlap,
-            ax_allocator::AllocError::NoMemory => Self::NoMemory,
-            ax_allocator::AllocError::NotAllocated => Self::NotAllocated,
-        }
-    }
-}
-
-#[cfg(feature = "buddy-slab")]
-impl From<buddy_slab_allocator::AllocError> for AllocError {
-    fn from(value: buddy_slab_allocator::AllocError) -> Self {
-        match value {
-            buddy_slab_allocator::AllocError::InvalidParam => Self::InvalidParam,
-            buddy_slab_allocator::AllocError::MemoryOverlap => Self::MemoryOverlap,
-            buddy_slab_allocator::AllocError::NoMemory => Self::NoMemory,
-            buddy_slab_allocator::AllocError::NotAllocated => Self::NotAllocated,
-            buddy_slab_allocator::AllocError::NotInitialized => Self::NotInitialized,
-            buddy_slab_allocator::AllocError::NotFound => Self::NotFound,
-        }
-    }
-}
-
 #[cfg(feature = "buddy-slab")]
 pub use buddy_slab_allocator::OsImpl;
 
@@ -170,27 +144,31 @@ pub trait AllocatorOps {
     fn dealloc(&self, pos: NonNull<u8>, layout: Layout);
 
     /// Allocates contiguous pages.
-    fn alloc_pages(
-        &self,
-        num_pages: usize,
-        align_pow2: usize,
-        kind: UsageKind,
-    ) -> AllocResult<usize>;
+    ///
+    /// `align` is the requested byte alignment, not a log2/exponent.
+    /// It must be a power-of-two byte alignment accepted by the backend page allocator.
+    fn alloc_pages(&self, num_pages: usize, align: usize, kind: UsageKind) -> AllocResult<usize>;
 
     /// Allocates contiguous DMA32 pages.
+    ///
+    /// `align` is the requested byte alignment, not a log2/exponent.
+    /// It must be a power-of-two byte alignment accepted by the backend page allocator.
     fn alloc_dma32_pages(
         &self,
         num_pages: usize,
-        align_pow2: usize,
+        align: usize,
         kind: UsageKind,
     ) -> AllocResult<usize>;
 
     /// Allocates contiguous pages starting from the given address.
+    ///
+    /// `align` is the requested byte alignment, not a log2/exponent.
+    /// It must be a power-of-two byte alignment accepted by the backend page allocator.
     fn alloc_pages_at(
         &self,
         start: usize,
         num_pages: usize,
-        align_pow2: usize,
+        align: usize,
         kind: UsageKind,
     ) -> AllocResult<usize>;
 

--- a/os/arceos/modules/axalloc/src/lib.rs
+++ b/os/arceos/modules/axalloc/src/lib.rs
@@ -11,8 +11,9 @@
 extern crate log;
 extern crate alloc;
 
-use core::fmt;
+use core::{alloc::Layout, fmt, ptr::NonNull};
 
+use ax_errno::AxError;
 use strum::{IntoStaticStr, VariantArray};
 
 const PAGE_SIZE: usize = 0x1000;
@@ -75,25 +76,154 @@ impl fmt::Debug for Usages {
     }
 }
 
-// Select implementation based on features
-// When axvisor is enabled, use axvisor_impl (axallocator features are ignored)
-#[cfg(feature = "buddy-slab")]
-mod axvisor_impl;
-#[cfg(feature = "buddy-slab")]
-use axvisor_impl as imp;
+/// The error type used for allocation operations in `ax-alloc`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllocError {
+    /// Invalid size, alignment, or other input parameter.
+    InvalidParam,
+    /// A region overlaps with an existing managed region.
+    MemoryOverlap,
+    /// Not enough memory is available to satisfy the request.
+    NoMemory,
+    /// Attempted to deallocate memory that was not allocated.
+    NotAllocated,
+    /// The allocator has not been initialized.
+    NotInitialized,
+    /// The requested address or entity was not found.
+    NotFound,
+}
 
-// When axvisor is not enabled, use default_impl with axallocator
+/// A [`Result`] alias with [`AllocError`] as the error type.
+pub type AllocResult<T = ()> = Result<T, AllocError>;
+
+impl From<AllocError> for AxError {
+    fn from(value: AllocError) -> Self {
+        match value {
+            AllocError::NoMemory => AxError::NoMemory,
+            AllocError::NotFound => AxError::NotFound,
+            AllocError::NotInitialized => AxError::BadState,
+            AllocError::MemoryOverlap => AxError::AlreadyExists,
+            AllocError::InvalidParam | AllocError::NotAllocated => AxError::InvalidInput,
+        }
+    }
+}
+
+#[cfg(not(feature = "buddy-slab"))]
+impl From<ax_allocator::AllocError> for AllocError {
+    fn from(value: ax_allocator::AllocError) -> Self {
+        match value {
+            ax_allocator::AllocError::InvalidParam => Self::InvalidParam,
+            ax_allocator::AllocError::MemoryOverlap => Self::MemoryOverlap,
+            ax_allocator::AllocError::NoMemory => Self::NoMemory,
+            ax_allocator::AllocError::NotAllocated => Self::NotAllocated,
+        }
+    }
+}
+
+#[cfg(feature = "buddy-slab")]
+impl From<buddy_slab_allocator::AllocError> for AllocError {
+    fn from(value: buddy_slab_allocator::AllocError) -> Self {
+        match value {
+            buddy_slab_allocator::AllocError::InvalidParam => Self::InvalidParam,
+            buddy_slab_allocator::AllocError::MemoryOverlap => Self::MemoryOverlap,
+            buddy_slab_allocator::AllocError::NoMemory => Self::NoMemory,
+            buddy_slab_allocator::AllocError::NotAllocated => Self::NotAllocated,
+            buddy_slab_allocator::AllocError::NotInitialized => Self::NotInitialized,
+            buddy_slab_allocator::AllocError::NotFound => Self::NotFound,
+        }
+    }
+}
+
+#[cfg(feature = "buddy-slab")]
+pub use buddy_slab_allocator::OsImpl;
+
+#[cfg(not(feature = "buddy-slab"))]
+pub trait OsImpl: Sync + Send {
+    /// Return the index of the current CPU (0-based).
+    fn current_cpu_idx(&self) -> usize;
+
+    /// Translate a virtual address to a physical address.
+    fn virt_to_phys(&self, vaddr: usize) -> usize;
+}
+
+/// Unified allocator operations provided by all `ax-alloc` backends.
+pub trait AllocatorOps {
+    /// Returns the allocator name.
+    fn name(&self) -> &'static str;
+
+    /// Initializes the allocator with the given region.
+    fn init(
+        &self,
+        start_vaddr: usize,
+        size: usize,
+        cpu_count: usize,
+        os: &'static dyn OsImpl,
+    ) -> AllocResult;
+
+    /// Adds an extra memory region to the allocator.
+    fn add_memory(&self, start_vaddr: usize, size: usize) -> AllocResult;
+
+    /// Allocates arbitrary bytes.
+    fn alloc(&self, layout: Layout) -> AllocResult<NonNull<u8>>;
+
+    /// Deallocates a prior byte allocation.
+    fn dealloc(&self, pos: NonNull<u8>, layout: Layout);
+
+    /// Allocates contiguous pages.
+    fn alloc_pages(
+        &self,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize>;
+
+    /// Allocates contiguous DMA32 pages.
+    fn alloc_dma32_pages(
+        &self,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize>;
+
+    /// Allocates contiguous pages starting from the given address.
+    fn alloc_pages_at(
+        &self,
+        start: usize,
+        num_pages: usize,
+        align_pow2: usize,
+        kind: UsageKind,
+    ) -> AllocResult<usize>;
+
+    /// Deallocates a prior page allocation.
+    fn dealloc_pages(&self, pos: usize, num_pages: usize, kind: UsageKind);
+
+    /// Returns used byte count.
+    fn used_bytes(&self) -> usize;
+
+    /// Returns available byte count.
+    fn available_bytes(&self) -> usize;
+
+    /// Returns used page count.
+    fn used_pages(&self) -> usize;
+
+    /// Returns available page count.
+    fn available_pages(&self) -> usize;
+
+    /// Returns usage statistics.
+    fn usages(&self) -> Usages;
+}
+
+// Select implementation based on features.
+#[cfg(feature = "buddy-slab")]
+mod buddy_slab;
+#[cfg(feature = "buddy-slab")]
+use buddy_slab as imp;
+
 #[cfg(not(feature = "buddy-slab"))]
 mod default_impl;
 #[cfg(not(feature = "buddy-slab"))]
 use default_impl as imp;
-// Re-export AddrTranslator when using buddy-slab implementation
-#[cfg(feature = "buddy-slab")]
-pub use imp::AddrTranslator;
-// Re-export DefaultByteAllocator from both implementations
-pub use imp::DefaultByteAllocator;
-// Re-export types and functions from the implementation
-pub use imp::{GlobalAllocator, global_add_memory, global_init};
+pub use imp::{DefaultByteAllocator, GlobalAllocator, global_add_memory, global_init};
 
 /// Returns the reference to the global allocator.
 pub fn global_allocator() -> &'static GlobalAllocator {

--- a/os/arceos/modules/axalloc/src/lib.rs
+++ b/os/arceos/modules/axalloc/src/lib.rs
@@ -6,6 +6,7 @@
 //! be registered as the standard library's default allocator.
 
 #![no_std]
+#![cfg_attr(feature = "buddy-slab", feature(extern_item_impls))]
 
 #[macro_use]
 extern crate log;
@@ -81,6 +82,8 @@ impl fmt::Debug for Usages {
 pub enum AllocError {
     /// Invalid size, alignment, or other input parameter.
     InvalidParam,
+    /// The allocator has already been initialized.
+    AlreadyInitialized,
     /// A region overlaps with an existing managed region.
     MemoryOverlap,
     /// Not enough memory is available to satisfy the request.
@@ -101,7 +104,7 @@ impl From<AllocError> for AxError {
         match value {
             AllocError::NoMemory => AxError::NoMemory,
             AllocError::NotFound => AxError::NotFound,
-            AllocError::NotInitialized => AxError::BadState,
+            AllocError::NotInitialized | AllocError::AlreadyInitialized => AxError::BadState,
             AllocError::MemoryOverlap => AxError::AlreadyExists,
             AllocError::InvalidParam | AllocError::NotAllocated => AxError::InvalidInput,
         }
@@ -109,15 +112,11 @@ impl From<AllocError> for AxError {
 }
 
 #[cfg(feature = "buddy-slab")]
-pub use buddy_slab_allocator::OsImpl;
-
-#[cfg(not(feature = "buddy-slab"))]
-pub trait OsImpl: Sync + Send {
-    /// Return the index of the current CPU (0-based).
-    fn current_cpu_idx(&self) -> usize;
-
+/// Platform hooks required by the buddy-slab backend.
+pub mod eii {
     /// Translate a virtual address to a physical address.
-    fn virt_to_phys(&self, vaddr: usize) -> usize;
+    #[eii(ax_alloc_virt_to_phys_impl)]
+    pub fn virt_to_phys(vaddr: usize) -> usize;
 }
 
 /// Unified allocator operations provided by all `ax-alloc` backends.
@@ -126,13 +125,7 @@ pub trait AllocatorOps {
     fn name(&self) -> &'static str;
 
     /// Initializes the allocator with the given region.
-    fn init(
-        &self,
-        start_vaddr: usize,
-        size: usize,
-        cpu_count: usize,
-        os: &'static dyn OsImpl,
-    ) -> AllocResult;
+    fn init(&self, start_vaddr: usize, size: usize) -> AllocResult;
 
     /// Adds an extra memory region to the allocator.
     fn add_memory(&self, start_vaddr: usize, size: usize) -> AllocResult;
@@ -201,6 +194,8 @@ use buddy_slab as imp;
 mod default_impl;
 #[cfg(not(feature = "buddy-slab"))]
 use default_impl as imp;
+#[cfg(feature = "buddy-slab")]
+pub use imp::init_precpu_slab;
 pub use imp::{DefaultByteAllocator, GlobalAllocator, global_add_memory, global_init};
 
 /// Returns the reference to the global allocator.

--- a/os/arceos/modules/axdma/Cargo.toml
+++ b/os/arceos/modules/axdma/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/arceos-org/arceos/tree/main/modules/axdma"
 
 [features]
 default = []
-buddy-slab = ["dep:buddy-slab-allocator"]
+buddy-slab = ["dep:buddy-slab-allocator", "ax-alloc/buddy-slab"]
 
 [dependencies]
 ax-alloc.workspace = true

--- a/os/arceos/modules/axdma/src/dma.rs
+++ b/os/arceos/modules/axdma/src/dma.rs
@@ -1,26 +1,30 @@
 use core::{alloc::Layout, ptr::NonNull};
 
-use ax_alloc::{DefaultByteAllocator, UsageKind, global_allocator};
 #[cfg(not(feature = "buddy-slab"))]
-use ax_allocator::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
+use ax_alloc::DefaultByteAllocator;
+use ax_alloc::{AllocError, AllocResult, UsageKind, global_allocator};
+#[cfg(not(feature = "buddy-slab"))]
+use ax_allocator::{BaseAllocator, ByteAllocator};
 use ax_hal::{mem::virt_to_phys, paging::MappingFlags};
 use ax_kspin::SpinNoIrq;
 use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr, va};
-#[cfg(feature = "buddy-slab")]
-use buddy_slab_allocator::{AllocError, AllocResult, ByteAllocator};
-use log::{debug, error};
+#[cfg(not(feature = "buddy-slab"))]
+use log::debug;
+use log::error;
 
 use crate::{BusAddr, DMAInfo, phys_to_bus};
 
 pub(crate) static ALLOCATOR: SpinNoIrq<DmaAllocator> = SpinNoIrq::new(DmaAllocator::new());
 
 pub(crate) struct DmaAllocator {
+    #[cfg(not(feature = "buddy-slab"))]
     alloc: DefaultByteAllocator,
 }
 
 impl DmaAllocator {
     pub const fn new() -> Self {
         Self {
+            #[cfg(not(feature = "buddy-slab"))]
             alloc: DefaultByteAllocator::new(),
         }
     }
@@ -32,6 +36,12 @@ impl DmaAllocator {
     /// memory, it asks the global page allocator for more memory and adds it to the
     /// byte allocator.
     pub unsafe fn alloc_coherent(&mut self, layout: Layout) -> AllocResult<DMAInfo> {
+        #[cfg(feature = "buddy-slab")]
+        {
+            self.alloc_coherent_pages(layout)
+        }
+
+        #[cfg(not(feature = "buddy-slab"))]
         if layout.size() >= PAGE_SIZE_4K {
             self.alloc_coherent_pages(layout)
         } else {
@@ -39,52 +49,38 @@ impl DmaAllocator {
         }
     }
 
+    #[cfg(not(feature = "buddy-slab"))]
     fn alloc_coherent_bytes(&mut self, layout: Layout) -> AllocResult<DMAInfo> {
-        #[cfg(feature = "buddy-slab")]
-        {
-            // In buddy-slab mode, SlabByteAllocator doesn't support add_memory
-            // Try alloc directly, fail if no memory
-            self.alloc.alloc(layout).map(|data| {
+        let mut is_expanded = false;
+        loop {
+            if let Ok(data) = self.alloc.alloc(layout) {
                 let cpu_addr = va!(data.as_ptr() as usize);
-                DMAInfo {
+                return Ok(DMAInfo {
                     cpu_addr: data,
                     bus_addr: virt_to_bus(cpu_addr),
+                });
+            } else {
+                if is_expanded {
+                    return Err(AllocError::NoMemory);
                 }
-            })
-        }
-
-        #[cfg(not(feature = "buddy-slab"))]
-        {
-            let mut is_expanded = false;
-            loop {
-                if let Ok(data) = self.alloc.alloc(layout) {
-                    let cpu_addr = va!(data.as_ptr() as usize);
-                    return Ok(DMAInfo {
-                        cpu_addr: data,
-                        bus_addr: virt_to_bus(cpu_addr),
-                    });
-                } else {
-                    if is_expanded {
-                        return Err(AllocError::NoMemory);
-                    }
-                    is_expanded = true;
-                    let available_pages = global_allocator().available_pages();
-                    // 4 pages or available pages.
-                    let num_pages = 4.min(available_pages);
-                    let expand_size = num_pages * PAGE_SIZE_4K;
-                    let vaddr_raw =
-                        global_allocator().alloc_pages(num_pages, PAGE_SIZE_4K, UsageKind::Dma)?;
-                    let vaddr = va!(vaddr_raw);
-                    self.update_flags(
-                        vaddr,
-                        num_pages,
-                        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::UNCACHED,
-                    )?;
-                    self.alloc
-                        .add_memory(vaddr_raw, expand_size)
-                        .inspect_err(|e| error!("add memory fail: {e:?}"))?;
-                    debug!("expand memory @{vaddr:#X}, size: {expand_size:#X} bytes");
-                }
+                is_expanded = true;
+                let available_pages = global_allocator().available_pages();
+                // 4 pages or available pages.
+                let num_pages = 4.min(available_pages);
+                let expand_size = num_pages * PAGE_SIZE_4K;
+                let vaddr_raw =
+                    global_allocator().alloc_pages(num_pages, PAGE_SIZE_4K, UsageKind::Dma)?;
+                let vaddr = va!(vaddr_raw);
+                self.update_flags(
+                    vaddr,
+                    num_pages,
+                    MappingFlags::READ | MappingFlags::WRITE | MappingFlags::UNCACHED,
+                )?;
+                self.alloc
+                    .add_memory(vaddr_raw, expand_size)
+                    .map_err(AllocError::from)
+                    .inspect_err(|e| error!("add memory fail: {e:?}"))?;
+                debug!("expand memory @{vaddr:#X}, size: {expand_size:#X} bytes");
             }
         }
     }
@@ -126,6 +122,19 @@ impl DmaAllocator {
 
     /// Gives back the allocated region to the byte allocator.
     pub unsafe fn dealloc_coherent(&mut self, dma: DMAInfo, layout: Layout) {
+        #[cfg(feature = "buddy-slab")]
+        {
+            let num_pages = layout_pages(&layout);
+            let virt_raw = dma.cpu_addr.as_ptr() as usize;
+            global_allocator().dealloc_pages(virt_raw, num_pages, UsageKind::Dma);
+            let _ = self.update_flags(
+                va!(virt_raw),
+                num_pages,
+                MappingFlags::READ | MappingFlags::WRITE,
+            );
+        }
+
+        #[cfg(not(feature = "buddy-slab"))]
         if layout.size() >= PAGE_SIZE_4K {
             let num_pages = layout_pages(&layout);
             let virt_raw = dma.cpu_addr.as_ptr() as usize;

--- a/os/arceos/modules/axdma/src/lib.rs
+++ b/os/arceos/modules/axdma/src/lib.rs
@@ -8,11 +8,8 @@ mod dma;
 
 use core::{alloc::Layout, ptr::NonNull};
 
-#[cfg(not(feature = "buddy-slab"))]
-use ax_allocator::AllocResult;
+use ax_alloc::AllocResult;
 use ax_memory_addr::PhysAddr;
-#[cfg(feature = "buddy-slab")]
-use buddy_slab_allocator::AllocResult;
 
 use self::dma::ALLOCATOR;
 

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 
 alloc = ["dep:ax-alloc"]
 dma = ["paging"]
-buddy-slab = ["ax-alloc/buddy-slab"]
+buddy-slab = ["alloc", "ax-alloc/buddy-slab"]
 ipi = ["dep:ax-ipi"]
 irq = ["ax-hal/irq", "ax-task?/irq", "dep:ax-percpu"]
 multitask = ["ax-task/multitask"]

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -308,32 +308,30 @@ fn init_allocator() {
         }
     }
 
-    #[cfg(feature = "buddy-slab")]
-    {
-        struct AddrTranslatorImpl;
-        impl ax_alloc::AddrTranslator for AddrTranslatorImpl {
-            fn virt_to_phys(&self, va: usize) -> Option<usize> {
-                Some(ax_hal::mem::virt_to_phys(va.into()).as_usize())
-            }
+    struct AllocatorOs;
+
+    impl ax_alloc::OsImpl for AllocatorOs {
+        fn current_cpu_idx(&self) -> usize {
+            ax_hal::percpu::this_cpu_id()
         }
 
-        static TRANSLATOR: AddrTranslatorImpl = AddrTranslatorImpl;
-
-        for r in memory_regions() {
-            if r.flags.contains(MemRegionFlags::FREE) && r.paddr == max_region_paddr {
-                ax_alloc::global_init(phys_to_virt(r.paddr).as_usize(), r.size, &TRANSLATOR);
-                break;
-            }
+        fn virt_to_phys(&self, vaddr: usize) -> usize {
+            ax_hal::mem::virt_to_phys(vaddr.into()).as_usize()
         }
     }
 
-    #[cfg(not(feature = "buddy-slab"))]
-    {
-        for r in memory_regions() {
-            if r.flags.contains(MemRegionFlags::FREE) && r.paddr == max_region_paddr {
-                ax_alloc::global_init(phys_to_virt(r.paddr).as_usize(), r.size);
-                break;
-            }
+    static OS: AllocatorOs = AllocatorOs;
+
+    for r in memory_regions() {
+        if r.flags.contains(MemRegionFlags::FREE) && r.paddr == max_region_paddr {
+            ax_alloc::global_init(
+                phys_to_virt(r.paddr).as_usize(),
+                r.size,
+                ax_hal::cpu_num(),
+                &OS,
+            )
+            .expect("initialize global allocator failed");
+            break;
         }
     }
 

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -45,6 +45,9 @@ mod mp;
 #[cfg(feature = "paging")]
 mod klib;
 
+#[cfg(feature = "buddy-slab")]
+use ax_alloc::eii::ax_alloc_virt_to_phys_impl;
+
 #[cfg(feature = "smp")]
 pub use self::mp::rust_main_secondary;
 
@@ -62,6 +65,12 @@ d88P     888 888      "Y8888P  "Y8888   "Y88888P"   "Y8888P"
 unsafe extern "C" {
     /// Application's entry point.
     fn main();
+}
+
+#[cfg(feature = "buddy-slab")]
+#[ax_alloc_virt_to_phys_impl]
+fn ax_alloc_virt_to_phys(vaddr: usize) -> usize {
+    ax_hal::mem::virt_to_phys(vaddr.into()).as_usize()
 }
 
 struct LogIfImpl;
@@ -127,6 +136,8 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
         ax_hal::mem::clear_bss()
     };
     ax_hal::percpu::init_primary(cpu_id);
+    #[cfg(all(feature = "alloc", feature = "buddy-slab"))]
+    ax_alloc::init_precpu_slab(cpu_id);
     ax_hal::init_early(cpu_id, arg);
     let log_level = option_env!("AX_LOG").unwrap_or("info");
 
@@ -308,29 +319,10 @@ fn init_allocator() {
         }
     }
 
-    struct AllocatorOs;
-
-    impl ax_alloc::OsImpl for AllocatorOs {
-        fn current_cpu_idx(&self) -> usize {
-            ax_hal::percpu::this_cpu_id()
-        }
-
-        fn virt_to_phys(&self, vaddr: usize) -> usize {
-            ax_hal::mem::virt_to_phys(vaddr.into()).as_usize()
-        }
-    }
-
-    static OS: AllocatorOs = AllocatorOs;
-
     for r in memory_regions() {
         if r.flags.contains(MemRegionFlags::FREE) && r.paddr == max_region_paddr {
-            ax_alloc::global_init(
-                phys_to_virt(r.paddr).as_usize(),
-                r.size,
-                ax_hal::cpu_num(),
-                &OS,
-            )
-            .expect("initialize global allocator failed");
+            ax_alloc::global_init(phys_to_virt(r.paddr).as_usize(), r.size)
+                .expect("initialize global allocator failed");
             break;
         }
     }

--- a/os/arceos/modules/axruntime/src/mp.rs
+++ b/os/arceos/modules/axruntime/src/mp.rs
@@ -50,6 +50,8 @@ pub fn start_secondary_cpus(primary_cpu_id: usize) {
 #[ax_plat::secondary_main]
 pub fn rust_main_secondary(cpu_id: usize) -> ! {
     ax_hal::percpu::init_secondary(cpu_id);
+    #[cfg(all(feature = "alloc", feature = "buddy-slab"))]
+    ax_alloc::init_precpu_slab(cpu_id);
     ax_hal::init_early_secondary(cpu_id);
 
     ENTERED_CPUS.fetch_add(1, Ordering::Release);

--- a/os/arceos/ulib/axstd/Cargo.toml
+++ b/os/arceos/ulib/axstd/Cargo.toml
@@ -44,7 +44,6 @@ alloc = ["ax-api/alloc", "ax-feat/alloc", "ax-io/alloc"]
 alloc-tlsf = ["ax-feat/alloc-tlsf"]
 alloc-slab = ["ax-feat/alloc-slab"]
 alloc-buddy = ["ax-feat/alloc-buddy"]
-alloc-level-1 = ["ax-feat/alloc-level-1", "alloc"]
 page-alloc-64g = ["ax-feat/page-alloc-64g"]                 # Support up to 64G memory capacity
 page-alloc-4g = ["ax-feat/page-alloc-4g"]                   # Support up to 4G memory capacity
 paging = ["ax-feat/paging"]

--- a/os/arceos/ulib/axstd/Cargo.toml
+++ b/os/arceos/ulib/axstd/Cargo.toml
@@ -46,7 +46,7 @@ alloc-slab = ["ax-feat/alloc-slab"]
 alloc-buddy = ["ax-feat/alloc-buddy"]
 page-alloc-64g = ["ax-feat/page-alloc-64g"]                 # Support up to 64G memory capacity
 page-alloc-4g = ["ax-feat/page-alloc-4g"]                   # Support up to 4G memory capacity
-paging = ["ax-feat/paging"]
+paging = ["ax-feat/paging", "alloc"]
 dma = ["ax-api/dma", "ax-feat/dma"]
 tls = ["ax-feat/tls"]
 

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -63,7 +63,6 @@ hashbrown = "0.14"
 
 # System dependent modules provided by ArceOS.
 ax-std = { version = "0.5.0", features = [
-  "alloc-level-1",
   "paging",
   "irq",
   "multitask",

--- a/os/axvisor/src/hal/impl_memory.rs
+++ b/os/axvisor/src/hal/impl_memory.rs
@@ -16,16 +16,13 @@ impl MemoryIf for MemoryImpl {
         <AxMmHalImpl as AxMmHal>::alloc_frame()
     }
 
-    fn alloc_contiguous_frames(num_frames: usize, frame_align_pow2: usize) -> Option<HostPhysAddr> {
+    fn alloc_contiguous_frames(num_frames: usize, frame_align: usize) -> Option<HostPhysAddr> {
         arceos::modules::ax_alloc::global_allocator()
             .alloc(
-                Layout::from_size_align(
-                    num_frames * PAGE_SIZE_4K,
-                    PAGE_SIZE_4K << frame_align_pow2,
-                )
-                .unwrap(),
+                Layout::from_size_align(num_frames * PAGE_SIZE_4K, frame_align.max(PAGE_SIZE_4K))
+                    .unwrap(),
             )
-            // .alloc_pages(num_frames, PAGE_SIZE_4K << frame_align_pow2)
+            // .alloc_pages(num_frames, frame_align.max(PAGE_SIZE_4K))
             // .map(|vaddr| <AxMmHalImpl as AxMmHal>::virt_to_phys(vaddr.into()))
             .map(|vaddr| HostPhysAddr::from(vaddr.as_ptr() as usize))
             .ok()

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -24,7 +24,7 @@ serial = ["dep:some-serial"]
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-ax-alloc.workspace = true
+ax-alloc = { version = "0.5.0", path = "../../os/arceos/modules/axalloc", default-features = false, features = ["buddy-slab"] }
 ax-config-macros = "0.4.1"
 ax-cpu.workspace = true
 ax-driver-base.workspace = true

--- a/platform/axplat-dyn/src/drivers/mod.rs
+++ b/platform/axplat-dyn/src/drivers/mod.rs
@@ -1,10 +1,7 @@
 extern crate alloc;
 
-use alloc::{
-    alloc::{alloc, alloc_zeroed, dealloc},
-    boxed::Box,
-};
-use core::ptr::NonNull;
+use alloc::boxed::Box;
+use core::{alloc::Layout, ptr::NonNull};
 
 use ax_driver_block::BlockDriverOps;
 use ax_errno::AxError;
@@ -66,6 +63,73 @@ pub fn probe_all_devices() -> Result<(), AxError> {
 
 pub(crate) struct DmaImpl;
 
+struct DmaPages {
+    cpu_addr: NonNull<u8>,
+    dma_addr: u64,
+}
+
+impl DmaPages {
+    fn layout_pages(layout: Layout) -> usize {
+        layout.size().div_ceil(PAGE_SIZE_4K)
+    }
+
+    fn layout_align(layout: Layout) -> usize {
+        layout.align().max(PAGE_SIZE_4K)
+    }
+
+    unsafe fn alloc_for_layout(dma_mask: u64, layout: Layout) -> Result<Self, dma_api::DmaError> {
+        if layout.size() == 0 {
+            return Ok(Self {
+                cpu_addr: NonNull::dangling(),
+                dma_addr: 0,
+            });
+        }
+
+        let num_pages = Self::layout_pages(layout);
+        let align = Self::layout_align(layout);
+        let cpu_vaddr = if dma_mask <= u32::MAX as u64 {
+            ax_alloc::global_allocator().alloc_dma32_pages(
+                num_pages,
+                align,
+                ax_alloc::UsageKind::Dma,
+            )
+        } else {
+            ax_alloc::global_allocator().alloc_pages(num_pages, align, ax_alloc::UsageKind::Dma)
+        }
+        .map_err(|_| dma_api::DmaError::NoMemory)?;
+
+        let cpu_addr = NonNull::new(cpu_vaddr as *mut u8).ok_or(dma_api::DmaError::NoMemory)?;
+        let dma_addr = dma_addr_from_ptr(cpu_addr);
+        if !dma_range_fits_mask(dma_addr, layout.size(), dma_mask) {
+            unsafe { Self::dealloc_pages(cpu_addr, num_pages) };
+            return Err(dma_api::DmaError::DmaMaskNotMatch {
+                addr: dma_addr.into(),
+                mask: dma_mask,
+            });
+        }
+        if !dma_addr_is_aligned(dma_addr, layout.align()) {
+            unsafe { Self::dealloc_pages(cpu_addr, num_pages) };
+            return Err(dma_api::DmaError::AlignMismatch {
+                required: layout.align(),
+                address: dma_addr.into(),
+            });
+        }
+
+        Ok(Self { cpu_addr, dma_addr })
+    }
+
+    unsafe fn dealloc_pages(cpu_addr: NonNull<u8>, num_pages: usize) {
+        if num_pages == 0 {
+            return;
+        }
+        ax_alloc::global_allocator().dealloc_pages(
+            cpu_addr.as_ptr() as usize,
+            num_pages,
+            ax_alloc::UsageKind::Dma,
+        );
+    }
+}
+
 #[inline]
 fn dma_addr_from_ptr(ptr: NonNull<u8>) -> u64 {
     somehal::mem::virt_to_phys(ptr.as_ptr()) as u64
@@ -101,7 +165,7 @@ impl dma_api::DmaOp for DmaImpl {
         align: usize,
         direction: dma_api::DmaDirection,
     ) -> Result<dma_api::DmaMapHandle, dma_api::DmaError> {
-        let layout = core::alloc::Layout::from_size_align(size.get(), align)?;
+        let layout = Layout::from_size_align(size.get(), align)?;
         let dma_addr = dma_addr_from_ptr(addr);
 
         if dma_range_fits_mask(dma_addr, size.get(), dma_mask)
@@ -110,8 +174,8 @@ impl dma_api::DmaOp for DmaImpl {
             return Ok(unsafe { dma_api::DmaMapHandle::new(addr, dma_addr.into(), layout, None) });
         }
 
-        let map_ptr = unsafe { alloc(layout) };
-        let map_virt = NonNull::new(map_ptr).ok_or(dma_api::DmaError::NoMemory)?;
+        let map_pages = unsafe { DmaPages::alloc_for_layout(dma_mask, layout)? };
+        let map_virt = map_pages.cpu_addr;
 
         if matches!(
             direction,
@@ -124,55 +188,29 @@ impl dma_api::DmaOp for DmaImpl {
             }
         }
 
-        let map_dma_addr = dma_addr_from_ptr(map_virt);
-        if !dma_range_fits_mask(map_dma_addr, size.get(), dma_mask) {
-            unsafe { dealloc(map_virt.as_ptr(), layout) };
-            return Err(dma_api::DmaError::DmaMaskNotMatch {
-                addr: map_dma_addr.into(),
-                mask: dma_mask,
-            });
-        }
-        if !dma_addr_is_aligned(map_dma_addr, align) {
-            unsafe { dealloc(map_virt.as_ptr(), layout) };
-            return Err(dma_api::DmaError::AlignMismatch {
-                required: align,
-                address: map_dma_addr.into(),
-            });
-        }
-
-        Ok(
-            unsafe {
-                dma_api::DmaMapHandle::new(addr, map_dma_addr.into(), layout, Some(map_virt))
-            },
-        )
+        Ok(unsafe {
+            dma_api::DmaMapHandle::new(addr, map_pages.dma_addr.into(), layout, Some(map_virt))
+        })
     }
 
     unsafe fn unmap_single(&self, handle: dma_api::DmaMapHandle) {
         if let Some(map_virt) = handle.alloc_virt() {
-            unsafe { dealloc(map_virt.as_ptr(), handle.layout()) };
+            let num_pages = DmaPages::layout_pages(handle.layout());
+            unsafe { DmaPages::dealloc_pages(map_virt, num_pages) };
         }
     }
 
-    unsafe fn alloc_coherent(
-        &self,
-        dma_mask: u64,
-        layout: core::alloc::Layout,
-    ) -> Option<dma_api::DmaHandle> {
-        let ptr = unsafe { alloc_zeroed(layout) };
-        let cpu_addr = NonNull::new(ptr)?;
-
-        let dma_addr = dma_addr_from_ptr(cpu_addr);
-        if !dma_range_fits_mask(dma_addr, layout.size(), dma_mask)
-            || !dma_addr_is_aligned(dma_addr, layout.align())
-        {
-            unsafe { dealloc(cpu_addr.as_ptr(), layout) };
-            return None;
+    unsafe fn alloc_coherent(&self, dma_mask: u64, layout: Layout) -> Option<dma_api::DmaHandle> {
+        let pages = unsafe { DmaPages::alloc_for_layout(dma_mask, layout).ok()? };
+        unsafe {
+            pages.cpu_addr.as_ptr().write_bytes(0, layout.size());
         }
 
-        Some(unsafe { dma_api::DmaHandle::new(cpu_addr, dma_addr.into(), layout) })
+        Some(unsafe { dma_api::DmaHandle::new(pages.cpu_addr, pages.dma_addr.into(), layout) })
     }
 
     unsafe fn dealloc_coherent(&self, handle: dma_api::DmaHandle) {
-        unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) };
+        let num_pages = DmaPages::layout_pages(handle.layout());
+        unsafe { DmaPages::dealloc_pages(handle.as_ptr(), num_pages) };
     }
 }

--- a/test-suit/arceos/rust/memtest/Cargo.toml
+++ b/test-suit/arceos/rust/memtest/Cargo.toml
@@ -8,4 +8,4 @@ authors = ["Yuekai Jia <equation618@gmail.com>"]
 
 [dependencies]
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
-ax-std = { workspace = true, features = ["alloc"], optional = true }
+ax-std = { workspace = true, features = ["alloc", "multitask"], optional = true }

--- a/test-suit/arceos/rust/memtest/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/rust/memtest/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,7 @@
+features = ["ax-std"]
+log = "Info"
+max_cpu_num = 4
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/memtest/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/rust/memtest/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,7 @@
+features = ["ax-std"]
+log = "Warn"
+max_cpu_num = 4
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/memtest/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/arceos/rust/memtest/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,7 @@
+features = ["ax-std"]
+log = "Warn"
+max_cpu_num = 4
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/memtest/build-x86_64-unknown-none.toml
+++ b/test-suit/arceos/rust/memtest/build-x86_64-unknown-none.toml
@@ -1,0 +1,7 @@
+features = ["ax-std"]
+log = "Warn"
+max_cpu_num = 4
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/memtest/src/main.rs
+++ b/test-suit/arceos/rust/memtest/src/main.rs
@@ -5,37 +5,318 @@
 #[cfg(feature = "ax-std")]
 extern crate ax_std as std;
 
+use core::{
+    alloc::Layout,
+    ptr::{self, NonNull},
+    slice,
+};
+#[cfg(feature = "ax-std")]
+use std::os::arceos::{
+    api::{
+        mem::{ax_alloc, ax_dealloc},
+        task::{AxCpuMask, ax_set_current_affinity},
+    },
+    modules::ax_hal::percpu::this_cpu_id,
+};
+#[cfg(feature = "ax-std")]
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+#[cfg(feature = "ax-std")]
+use std::thread;
 use std::{collections::BTreeMap, vec::Vec};
 
 use rand::{RngCore, SeedableRng, rngs::SmallRng};
 
+#[cfg(feature = "ax-std")]
+const SLAB_LAYOUT_CASES: [LayoutCase; 9] = [
+    LayoutCase::new(1, 1),
+    LayoutCase::new(1, 8),
+    LayoutCase::new(24, 8),
+    LayoutCase::new(63, 64),
+    LayoutCase::new(96, 32),
+    LayoutCase::new(255, 128),
+    LayoutCase::new(511, 256),
+    LayoutCase::new(1024, 512),
+    LayoutCase::new(2048, 2048),
+];
+
+const ALIGN_LAYOUT_CASES: [LayoutCase; 13] = [
+    LayoutCase::new(1, 1),
+    LayoutCase::new(1, 8),
+    LayoutCase::new(3, 2),
+    LayoutCase::new(7, 4),
+    LayoutCase::new(15, 16),
+    LayoutCase::new(24, 8),
+    LayoutCase::new(63, 64),
+    LayoutCase::new(255, 128),
+    LayoutCase::new(511, 256),
+    LayoutCase::new(1024, 512),
+    LayoutCase::new(2048, 2048),
+    LayoutCase::new(2049, 2048),
+    LayoutCase::new(4097, 4096),
+];
+
+const VEC_LEN: usize = 3_000_000;
+const BTREE_MAP_LEN: usize = 50_000;
+const ALIGN_TEST_ROUNDS: usize = 3;
+
+#[cfg(feature = "ax-std")]
+const PARALLEL_ALLOC_ROUNDS: usize = 8;
+#[cfg(feature = "ax-std")]
+const REMOTE_FREE_ROUNDS: usize = 32;
+
+#[derive(Clone, Copy, Debug)]
+struct LayoutCase {
+    size: usize,
+    align: usize,
+}
+
+impl LayoutCase {
+    const fn new(size: usize, align: usize) -> Self {
+        Self { size, align }
+    }
+
+    fn layout(self) -> Layout {
+        Layout::from_size_align(self.size, self.align).unwrap()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Allocation {
+    ptr: usize,
+    size: usize,
+    align: usize,
+    pattern: u8,
+}
+
+impl Allocation {
+    fn layout(&self) -> Layout {
+        Layout::from_size_align(self.size, self.align).unwrap()
+    }
+
+    fn as_non_null(&self) -> NonNull<u8> {
+        NonNull::new(self.ptr as *mut u8).unwrap()
+    }
+}
+
+#[cfg(feature = "ax-std")]
+unsafe fn alloc_raw(layout: Layout) -> NonNull<u8> {
+    unsafe { ax_alloc(layout) }.unwrap_or_else(|| panic!("allocation failed for {layout:?}"))
+}
+
+#[cfg(not(feature = "ax-std"))]
+unsafe fn alloc_raw(layout: Layout) -> NonNull<u8> {
+    let ptr = unsafe { std::alloc::alloc(layout) };
+    NonNull::new(ptr).unwrap_or_else(|| std::alloc::handle_alloc_error(layout))
+}
+
+#[cfg(feature = "ax-std")]
+unsafe fn dealloc_raw(ptr: NonNull<u8>, layout: Layout) {
+    unsafe { ax_dealloc(ptr, layout) };
+}
+
+#[cfg(not(feature = "ax-std"))]
+unsafe fn dealloc_raw(ptr: NonNull<u8>, layout: Layout) {
+    unsafe { std::alloc::dealloc(ptr.as_ptr(), layout) };
+}
+
+fn allocation_pattern(index: usize, round: usize) -> u8 {
+    (((index * 37) + (round * 17)) as u8).wrapping_add(1)
+}
+
+fn alloc_and_fill(case: LayoutCase, pattern: u8) -> Allocation {
+    let layout = case.layout();
+    let ptr = unsafe { alloc_raw(layout) };
+    assert_eq!(
+        ptr.as_ptr() as usize & (case.align - 1),
+        0,
+        "allocation is not aligned to {} bytes",
+        case.align
+    );
+    unsafe { ptr::write_bytes(ptr.as_ptr(), pattern, case.size) };
+    Allocation {
+        ptr: ptr.as_ptr() as usize,
+        size: case.size,
+        align: case.align,
+        pattern,
+    }
+}
+
+fn verify_block(block: &Allocation) {
+    let bytes = unsafe { slice::from_raw_parts(block.ptr as *const u8, block.size) };
+    for &byte in bytes {
+        assert_eq!(byte, block.pattern, "allocation payload corrupted");
+    }
+}
+
+unsafe fn free_block(block: Allocation) {
+    unsafe { dealloc_raw(block.as_non_null(), block.layout()) };
+}
+
 fn test_vec(rng: &mut impl RngCore) {
-    const N: usize = 3_000_000;
-    let mut v = Vec::with_capacity(N);
-    for _ in 0..N {
+    let mut v = Vec::with_capacity(VEC_LEN);
+    for _ in 0..VEC_LEN {
         v.push(rng.next_u32());
     }
     v.sort();
-    for i in 0..N - 1 {
+    for i in 0..VEC_LEN - 1 {
         assert!(v[i] <= v[i + 1]);
     }
     println!("test_vec() OK!");
 }
 
 fn test_btree_map(rng: &mut impl RngCore) {
-    const N: usize = 50_000;
     let mut m = BTreeMap::new();
-    for _ in 0..N {
+    for _ in 0..BTREE_MAP_LEN {
         let value = rng.next_u32();
         let key = format!("key_{value}");
         m.insert(key, value);
     }
-    for (k, v) in m.iter() {
+    for (k, v) in &m {
         if let Some(k) = k.strip_prefix("key_") {
             assert_eq!(k.parse::<u32>().unwrap(), *v);
         }
     }
     println!("test_btree_map() OK!");
+}
+
+fn test_aligned_allocations() {
+    for round in 0..ALIGN_TEST_ROUNDS {
+        let mut allocations = Vec::with_capacity(ALIGN_LAYOUT_CASES.len());
+        for (index, case) in ALIGN_LAYOUT_CASES.iter().enumerate() {
+            let block = alloc_and_fill(*case, allocation_pattern(index, round));
+            verify_block(&block);
+            allocations.push(block);
+        }
+
+        while let Some(block) = allocations.pop() {
+            verify_block(&block);
+            unsafe { free_block(block) };
+        }
+    }
+    println!("test_aligned_allocations() OK!");
+}
+
+#[cfg(feature = "ax-std")]
+fn pin_current_to_cpu(cpu_id: usize) {
+    assert!(
+        ax_set_current_affinity(AxCpuMask::one_shot(cpu_id)).is_ok(),
+        "failed to pin current task to CPU {cpu_id}"
+    );
+    for _ in 0..256 {
+        if this_cpu_id() == cpu_id {
+            return;
+        }
+        thread::yield_now();
+    }
+    assert_eq!(
+        this_cpu_id(),
+        cpu_id,
+        "task did not migrate to CPU {cpu_id}"
+    );
+}
+
+#[cfg(feature = "ax-std")]
+fn test_parallel_allocations() {
+    let cpu_num = thread::available_parallelism().unwrap().get();
+    if cpu_num < 2 {
+        println!("test_parallel_allocations() skipped: single CPU");
+        return;
+    }
+
+    let worker_count = cpu_num * 2;
+    let ready = Arc::new(AtomicUsize::new(0));
+    let mut tasks = Vec::with_capacity(worker_count);
+
+    for worker_id in 0..worker_count {
+        let ready = ready.clone();
+        tasks.push(thread::spawn(move || {
+            let cpu_id = worker_id % cpu_num;
+            pin_current_to_cpu(cpu_id);
+
+            ready.fetch_add(1, Ordering::AcqRel);
+            while ready.load(Ordering::Acquire) < worker_count {
+                thread::yield_now();
+            }
+
+            for round in 0..PARALLEL_ALLOC_ROUNDS {
+                let mut blocks = Vec::with_capacity(SLAB_LAYOUT_CASES.len());
+                for (index, case) in SLAB_LAYOUT_CASES.iter().enumerate() {
+                    let pattern = allocation_pattern(worker_id + index, round);
+                    blocks.push(alloc_and_fill(*case, pattern));
+                    if index % 3 == 0 {
+                        thread::yield_now();
+                    }
+                }
+
+                while let Some(block) = blocks.pop() {
+                    verify_block(&block);
+                    unsafe { free_block(block) };
+                }
+            }
+        }));
+    }
+
+    for task in tasks {
+        task.join().unwrap();
+    }
+    println!("test_parallel_allocations() OK!");
+}
+
+#[cfg(feature = "ax-std")]
+fn test_cross_cpu_free() {
+    let cpu_num = thread::available_parallelism().unwrap().get();
+    if cpu_num < 2 {
+        println!("test_cross_cpu_free() skipped: single CPU");
+        return;
+    }
+
+    let owner_cpu = 0;
+    let remote_cpu = cpu_num - 1;
+    pin_current_to_cpu(owner_cpu);
+
+    let mut remote_blocks = Vec::with_capacity(SLAB_LAYOUT_CASES.len() * REMOTE_FREE_ROUNDS);
+    for round in 0..REMOTE_FREE_ROUNDS {
+        for (index, case) in SLAB_LAYOUT_CASES.iter().enumerate() {
+            let pattern = allocation_pattern(index + SLAB_LAYOUT_CASES.len(), round);
+            remote_blocks.push(alloc_and_fill(*case, pattern));
+        }
+        thread::yield_now();
+    }
+
+    let remote_worker = thread::spawn(move || {
+        pin_current_to_cpu(remote_cpu);
+        assert_eq!(this_cpu_id(), remote_cpu);
+
+        for (index, block) in remote_blocks.into_iter().enumerate() {
+            verify_block(&block);
+            unsafe { free_block(block) };
+            if index % 8 == 0 {
+                thread::yield_now();
+            }
+        }
+    });
+    remote_worker.join().unwrap();
+
+    // Reallocate on the owner CPU to force draining the remote-free list and
+    // validate that those objects are reusable after cross-CPU deallocation.
+    pin_current_to_cpu(owner_cpu);
+    let mut recycled = Vec::with_capacity(SLAB_LAYOUT_CASES.len() * REMOTE_FREE_ROUNDS);
+    for round in 0..REMOTE_FREE_ROUNDS {
+        for (index, case) in SLAB_LAYOUT_CASES.iter().enumerate() {
+            let pattern = allocation_pattern(index + 2 * SLAB_LAYOUT_CASES.len(), round);
+            recycled.push(alloc_and_fill(*case, pattern));
+        }
+        thread::yield_now();
+    }
+
+    while let Some(block) = recycled.pop() {
+        verify_block(&block);
+        unsafe { free_block(block) };
+    }
+    println!("test_cross_cpu_free() OK!");
 }
 
 #[cfg_attr(feature = "ax-std", unsafe(no_mangle))]
@@ -45,6 +326,13 @@ fn main() {
     let mut rng = SmallRng::seed_from_u64(0xdead_beef);
     test_vec(&mut rng);
     test_btree_map(&mut rng);
+    test_aligned_allocations();
+
+    #[cfg(feature = "ax-std")]
+    test_parallel_allocations();
+
+    #[cfg(feature = "ax-std")]
+    test_cross_cpu_free();
 
     println!("All tests passed!");
 }


### PR DESCRIPTION
## Summary
- unify the axalloc backend interface and remove the old split between allocator implementations
- update buddy-slab-allocator to 0.4 and add per-CPU slab support in ArceOS
- switch allocation alignment handling to byte-based APIs and update affected callers
- extend memtest coverage and target configs across aarch64, loongarch64, riscv64, and x86_64

## Why
The allocator paths had diverged between components and OS layers, which made it harder to adopt newer buddy-slab functionality consistently. This change brings the interface back together while enabling per-CPU slab support and a clearer byte-alignment contract.

## Impact
- allocator and DMA/runtime call sites now use byte alignment semantics
- ArceOS memory allocation paths use the newer buddy-slab-allocator behavior
- lockfiles and test configs are updated to match the new allocator stack

## Validation
- `cargo xtask clippy`
  - currently fails in existing workspace crates unrelated to this branch:
  - `components/kernel_guard` (`clippy::doc_overindented_list_items`, `clippy::new_without_default`)
  - `components/axbacktrace` (`dead_code` promoted to error by `-D warnings`)
  - `components/linked_list_r4l` (`clippy::new_without_default`, `clippy::missing_safety_doc`)
