### PR TITLE
fix(aarch64/plat-dyn): correct huge PTE detection and enable early fp/simd init

### DIFF
--- a/components/axaddrspace/src/npt/arch/aarch64.rs
+++ b/components/axaddrspace/src/npt/arch/aarch64.rs
@@ -207,7 +207,8 @@ impl GenericPTE for A64PTEHV {
         DescriptorAttr::from_bits_truncate(self.0).contains(DescriptorAttr::VALID)
     }
     fn is_huge(&self) -> bool {
-        !DescriptorAttr::from_bits_truncate(self.0).contains(DescriptorAttr::NON_BLOCK)
+        self.is_present()
+            && !DescriptorAttr::from_bits_truncate(self.0).contains(DescriptorAttr::NON_BLOCK)
     }
     fn clear(&mut self) {
         self.0 = 0

--- a/components/page_table_multiarch/page_table_entry/src/arch/aarch64.rs
+++ b/components/page_table_multiarch/page_table_entry/src/arch/aarch64.rs
@@ -255,7 +255,8 @@ impl GenericPTE for A64PTE {
     }
 
     fn is_huge(&self) -> bool {
-        !DescriptorAttr::from_bits_truncate(self.0).contains(DescriptorAttr::NON_BLOCK)
+        self.is_present()
+            && !DescriptorAttr::from_bits_truncate(self.0).contains(DescriptorAttr::NON_BLOCK)
     }
 
     fn clear(&mut self) {

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -30,6 +30,7 @@ fp-simd = [
     "ax-plat-aarch64-qemu-virt?/fp-simd",
     "ax-plat-riscv64-qemu-virt?/fp-simd",
     "ax-plat-loongarch64-qemu-virt?/fp-simd",
+    "axplat-dyn?/fp-simd",
 ]
 rtc = [
     "ax-plat-x86-pc?/rtc",

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 default = ["smp", "irq"]
 smp = ["ax-plat/smp"]
 irq = ["ax-plat/irq"]
+fp-simd = ["ax-cpu/fp-simd"]
 uspace = ["somehal/uspace"]
 hv = ["somehal/hv", "ax-cpu/arm-el2"]
 rk3588-clk = ["dep:rk3588-clk"]

--- a/platform/axplat-dyn/link.ld
+++ b/platform/axplat-dyn/link.ld
@@ -11,6 +11,13 @@ SECTIONS {
 INSERT AFTER .tbss;
 
 SECTIONS {
+    __scope_local_end_marker : {
+        __bss_start = .;
+    }
+}
+INSERT AFTER scope_local;
+
+SECTIONS {
     debug_abbrev : { . += SIZEOF(.debug_abbrev); }
     debug_addr : { . += SIZEOF(.debug_addr); }
     debug_aranges : { . += SIZEOF(.debug_aranges); }

--- a/platform/axplat-dyn/src/init.rs
+++ b/platform/axplat-dyn/src/init.rs
@@ -11,6 +11,11 @@ impl InitIf for InitIfImpl {
     /// early console, clocking).
     fn init_early(_cpu_id: usize, _dtb: usize) {
         ax_cpu::init::init_trap();
+        #[cfg(all(target_arch = "aarch64", feature = "fp-simd"))]
+        {
+            ax_cpu::asm::enable_fp();
+            debug!("axplat-dyn: fp/simd enabled");
+        }
         somehal::timer::enable();
     }
 
@@ -18,6 +23,11 @@ impl InitIf for InitIfImpl {
     #[cfg(feature = "smp")]
     fn init_early_secondary(_cpu_id: usize) {
         ax_cpu::init::init_trap();
+        #[cfg(all(target_arch = "aarch64", feature = "fp-simd"))]
+        {
+            ax_cpu::asm::enable_fp();
+            debug!("axplat-dyn: secondary fp/simd enabled");
+        }
         somehal::timer::enable();
     }
 


### PR DESCRIPTION
- 修正 AArch64 页表项 is_huge() 语义，避免无效项被误识别为 huge entry。
- 为 axplat-dyn 的链接脚本补齐 __bss_start，在 scope_local 段后增加结束标记，确保后续 BSS 边界计算正确。
- 补齐 axplat-dyn 在 AArch64 下的 FP/SIMD 早期初始化。