### PR TITLE
Upgrade virtio-drivers and add axplat-dyn virtio PCI blk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3854,7 +3854,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4600,7 +4600,7 @@ checksum = "3f1495ab3ea0a7cee31d14901a858a732e282c139b3d17d3f935aebeeefcc34a"
 dependencies = [
  "xmas-elf",
  "zero",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5665,7 +5665,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6780,6 +6780,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe-mmio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4813ee49326057f105d6d8ca3d8f9265095f26aa7b42094e487028403a594f4c"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7456,7 +7465,7 @@ dependencies = [
  "weak-map",
  "x86",
  "xmas-elf",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -8572,14 +8581,16 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtio-drivers"
-version = "0.7.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a39747311dabb3d37807037ed1c3c38d39f99198d091b5b79ecd5c8d82f799"
+checksum = "cfdc1c628cdd8ce7c3b9e65a8ed550d0338e9ef9f911e729666f1cce097de2f7"
 dependencies = [
  "bitflags 2.11.0",
  "enumn",
  "log",
- "zerocopy 0.7.35",
+ "safe-mmio",
+ "thiserror 2.0.18",
+ "zerocopy",
 ]
 
 [[package]]
@@ -9508,32 +9519,11 @@ checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive 0.8.48",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/components/axdriver_crates/axdriver_pci/Cargo.toml
+++ b/components/axdriver_crates/axdriver_pci/Cargo.toml
@@ -11,4 +11,4 @@ readme = "README.md"
 license.workspace = true
 
 [dependencies]
-virtio-drivers = "0.7.4"
+virtio-drivers = { version = "0.13.0", default-features = false }

--- a/components/axdriver_crates/axdriver_pci/src/lib.rs
+++ b/components/axdriver_crates/axdriver_pci/src/lib.rs
@@ -9,8 +9,8 @@
 #![no_std]
 
 pub use virtio_drivers::transport::pci::bus::{
-    BarInfo, Cam, CapabilityInfo, Command, DeviceFunction, DeviceFunctionInfo, HeaderType,
-    MemoryBarType, PciError, PciRoot, Status,
+    BarInfo, Cam, CapabilityInfo, Command, ConfigurationAccess, DeviceFunction,
+    DeviceFunctionInfo, HeaderType, MemoryBarType, MmioCam, PciError, PciRoot, Status,
 };
 
 /// Used to allocate MMIO regions for PCI BARs.

--- a/components/axdriver_crates/axdriver_pci/src/lib.rs
+++ b/components/axdriver_crates/axdriver_pci/src/lib.rs
@@ -9,8 +9,8 @@
 #![no_std]
 
 pub use virtio_drivers::transport::pci::bus::{
-    BarInfo, Cam, CapabilityInfo, Command, ConfigurationAccess, DeviceFunction,
-    DeviceFunctionInfo, HeaderType, MemoryBarType, MmioCam, PciError, PciRoot, Status,
+    BarInfo, Cam, CapabilityInfo, Command, ConfigurationAccess, DeviceFunction, DeviceFunctionInfo,
+    HeaderType, MemoryBarType, MmioCam, PciError, PciRoot, Status,
 };
 
 /// Used to allocate MMIO regions for PCI BARs.

--- a/components/axdriver_crates/axdriver_virtio/Cargo.toml
+++ b/components/axdriver_crates/axdriver_virtio/Cargo.toml
@@ -26,4 +26,4 @@ ax-driver-input = { version = "0.3.4", optional = true }
 ax-driver-net = { version = "0.3.4", optional = true }
 ax-driver-vsock = { version = "0.3.4", optional = true }
 log = { workspace = true }
-virtio-drivers = { version = "0.7.4", default-features = false }
+virtio-drivers = { version = "0.13.0", default-features = false }

--- a/components/axdriver_crates/axdriver_virtio/src/input.rs
+++ b/components/axdriver_crates/axdriver_virtio/src/input.rs
@@ -70,7 +70,8 @@ impl<H: Hal, T: Transport> InputDriverOps for VirtIoInputDev<H, T> {
     fn get_event_bits(&mut self, ty: EventType, out: &mut [u8]) -> DevResult<bool> {
         let read = self
             .inner
-            .query_config_select(InputConfigSelect::EvBits, ty as u8, out);
+            .query_config_select(InputConfigSelect::EvBits, ty as u8, out)
+            .map_err(as_dev_err)?;
         Ok(read != 0)
     }
 

--- a/components/axdriver_crates/axdriver_virtio/src/lib.rs
+++ b/components/axdriver_crates/axdriver_virtio/src/lib.rs
@@ -128,9 +128,7 @@ const fn as_dev_err(e: virtio_drivers::Error) -> DevError {
             NotConnected => DevError::BadState,
             InvalidOperation | InvalidNumber | UnknownOperation(_) => DevError::InvalidParam,
             OutputBufferTooShort(_) | BufferTooShort | BufferTooLong(..) => DevError::InvalidParam,
-            UnexpectedDataInPacket | PeerSocketShutdown => {
-                DevError::Io
-            }
+            UnexpectedDataInPacket | PeerSocketShutdown => DevError::Io,
             InsufficientBufferSpaceInPeer => DevError::Again,
             RecycledWrongBuffer => DevError::BadState,
         },

--- a/components/axdriver_crates/axdriver_virtio/src/lib.rs
+++ b/components/axdriver_crates/axdriver_virtio/src/lib.rs
@@ -44,12 +44,12 @@ pub use virtio_drivers::{
     BufferDirection, Hal as VirtIoHal, PhysAddr,
     transport::{
         Transport,
-        mmio::MmioTransport,
         pci::{PciTransport, bus as pci},
     },
 };
+pub type MmioTransport = virtio_drivers::transport::mmio::MmioTransport<'static>;
 
-use self::pci::{DeviceFunction, DeviceFunctionInfo, PciRoot};
+use self::pci::{ConfigurationAccess, DeviceFunction, DeviceFunctionInfo, PciRoot};
 #[cfg(feature = "socket")]
 pub use self::socket::VirtIoSocketDev;
 
@@ -59,14 +59,14 @@ pub use self::socket::VirtIoSocketDev;
 /// for later operations. Otherwise, returns [`None`].
 pub fn probe_mmio_device(
     reg_base: *mut u8,
-    _reg_size: usize,
+    reg_size: usize,
 ) -> Option<(DeviceType, MmioTransport)> {
     use core::ptr::NonNull;
 
     use virtio_drivers::transport::mmio::VirtIOHeader;
 
     let header = NonNull::new(reg_base as *mut VirtIOHeader).unwrap();
-    let transport = unsafe { MmioTransport::new(header) }.ok()?;
+    let transport = unsafe { MmioTransport::new(header, reg_size) }.ok()?;
     let dev_type = as_dev_type(transport.device_type())?;
     Some((dev_type, transport))
 }
@@ -75,8 +75,8 @@ pub fn probe_mmio_device(
 ///
 /// If the device is recognized, returns the device type and a transport object
 /// for later operations. Otherwise, returns [`None`].
-pub fn probe_pci_device<H: VirtIoHal>(
-    root: &mut PciRoot,
+pub fn probe_pci_device<H: VirtIoHal, C: ConfigurationAccess>(
+    root: &mut PciRoot<C>,
     bdf: DeviceFunction,
     dev_info: &DeviceFunctionInfo,
 ) -> Option<(DeviceType, PciTransport, usize)> {
@@ -92,7 +92,7 @@ pub fn probe_pci_device<H: VirtIoHal>(
     const PCI_IRQ_BASE: usize = 0x23;
 
     let dev_type = virtio_device_type(dev_info).and_then(as_dev_type)?;
-    let transport = PciTransport::new::<H>(root, bdf).ok()?;
+    let transport = PciTransport::new::<H, C>(root, bdf).ok()?;
     let irq = PCI_IRQ_BASE + (bdf.device & 3) as usize;
     Some((dev_type, transport, irq))
 }
@@ -128,7 +128,7 @@ const fn as_dev_err(e: virtio_drivers::Error) -> DevError {
             NotConnected => DevError::BadState,
             InvalidOperation | InvalidNumber | UnknownOperation(_) => DevError::InvalidParam,
             OutputBufferTooShort(_) | BufferTooShort | BufferTooLong(..) => DevError::InvalidParam,
-            UnexpectedDataInPacket | PeerSocketShutdown | NoResponseReceived | ConnectionFailed => {
+            UnexpectedDataInPacket | PeerSocketShutdown => {
                 DevError::Io
             }
             InsufficientBufferSpaceInPeer => DevError::Again,

--- a/os/arceos/modules/axdriver/src/bus/pci.rs
+++ b/os/arceos/modules/axdriver/src/bus/pci.rs
@@ -1,5 +1,6 @@
 use ax_driver_pci::{
-    BarInfo, Cam, Command, DeviceFunction, HeaderType, MemoryBarType, PciRangeAllocator, PciRoot,
+    BarInfo, Cam, Command, ConfigurationAccess, DeviceFunction, HeaderType, MemoryBarType, MmioCam,
+    PciRangeAllocator, PciRoot,
 };
 use ax_hal::mem::phys_to_virt;
 
@@ -7,8 +8,8 @@ use crate::{AllDevices, prelude::*};
 
 const PCI_BAR_NUM: u8 = 6;
 
-fn config_pci_device(
-    root: &mut PciRoot,
+fn config_pci_device<C: ConfigurationAccess>(
+    root: &mut PciRoot<C>,
     bdf: DeviceFunction,
     allocator: &mut Option<PciRangeAllocator>,
 ) -> DevResult {
@@ -18,12 +19,12 @@ fn config_pci_device(
             warn!("failed to read PCI BAR {bar} info for {bdf}: {err:?}");
             DevError::Io
         })?;
-        if let BarInfo::Memory {
+        if let Some(BarInfo::Memory {
             address_type,
             address,
             size,
             ..
-        } = info
+        }) = info
         {
             // if the BAR address is not assigned, call the allocator and assign it.
             if size > 0 && address == 0 {
@@ -46,36 +47,34 @@ fn config_pci_device(
             DevError::Io
         })?;
         match info {
-            BarInfo::IO { address, size } => {
-                if address > 0 && size > 0 {
-                    debug!("  BAR {}: IO  [{:#x}, {:#x})", bar, address, address + size);
-                }
+            Some(BarInfo::IO { address, size }) if address > 0 && size > 0 => {
+                debug!("  BAR {}: IO  [{:#x}, {:#x})", bar, address, address + size);
             }
-            BarInfo::Memory {
+            Some(BarInfo::Memory {
                 address_type,
                 prefetchable,
                 address,
                 size,
-            } => {
-                if address > 0 && size > 0 {
-                    debug!(
-                        "  BAR {}: MEM [{:#x}, {:#x}){}{}",
-                        bar,
-                        address,
-                        address + size as u64,
-                        if address_type == MemoryBarType::Width64 {
-                            " 64bit"
-                        } else {
-                            ""
-                        },
-                        if prefetchable { " pref" } else { "" },
-                    );
-                }
+            }) if address > 0 && size > 0 => {
+                debug!(
+                    "  BAR {}: MEM [{:#x}, {:#x}){}{}",
+                    bar,
+                    address,
+                    address + size,
+                    if address_type == MemoryBarType::Width64 {
+                        " 64bit"
+                    } else {
+                        ""
+                    },
+                    if prefetchable { " pref" } else { "" },
+                );
             }
+            None => {}
+            Some(_) => {}
         }
 
         bar += 1;
-        if info.takes_two_entries() {
+        if info.as_ref().is_some_and(BarInfo::takes_two_entries) {
             bar += 1;
         }
     }
@@ -92,7 +91,7 @@ fn config_pci_device(
 impl AllDevices {
     pub(crate) fn probe_bus_devices(&mut self) {
         let base_vaddr = phys_to_virt(ax_config::devices::PCI_ECAM_BASE.into());
-        let mut root = unsafe { PciRoot::new(base_vaddr.as_mut_ptr(), Cam::Ecam) };
+        let mut root = PciRoot::new(unsafe { MmioCam::new(base_vaddr.as_mut_ptr(), Cam::Ecam) });
 
         // PCI 32-bit MMIO space
         let mut allocator = ax_config::devices::PCI_RANGES

--- a/os/arceos/modules/axdriver/src/drivers.rs
+++ b/os/arceos/modules/axdriver/src/drivers.rs
@@ -4,7 +4,7 @@
 
 use ax_driver_base::DeviceType;
 #[cfg(feature = "bus-pci")]
-use ax_driver_pci::{DeviceFunction, DeviceFunctionInfo, PciRoot};
+use ax_driver_pci::{ConfigurationAccess, DeviceFunction, DeviceFunctionInfo, PciRoot};
 
 pub use super::dummy::*;
 use crate::AxDeviceEnum;
@@ -22,8 +22,8 @@ pub trait DriverProbe {
     }
 
     #[cfg(bus = "pci")]
-    fn probe_pci(
-        _root: &mut PciRoot,
+    fn probe_pci<C: ConfigurationAccess>(
+        _root: &mut PciRoot<C>,
         _bdf: DeviceFunction,
         _dev_info: &DeviceFunctionInfo,
     ) -> Option<AxDeviceEnum> {
@@ -118,8 +118,8 @@ cfg_if::cfg_if! {
         register_net_driver!(IxgbeDriver, ax_driver_net::ixgbe::IxgbeNic<IxgbeHalImpl, 1024, 1>);
         impl DriverProbe for IxgbeDriver {
             #[cfg(bus = "pci")]
-            fn probe_pci(
-                root: &mut ax_driver_pci::PciRoot,
+            fn probe_pci<C: ax_driver_pci::ConfigurationAccess>(
+                root: &mut ax_driver_pci::PciRoot<C>,
                 bdf: ax_driver_pci::DeviceFunction,
                 dev_info: &ax_driver_pci::DeviceFunctionInfo,
             ) -> Option<crate::AxDeviceEnum> {

--- a/os/arceos/modules/axdriver/src/virtio.rs
+++ b/os/arceos/modules/axdriver/src/virtio.rs
@@ -10,7 +10,7 @@ use crate::{AxDeviceEnum, drivers::DriverProbe};
 
 cfg_if! {
     if #[cfg(bus = "pci")] {
-        use ax_driver_pci::{PciRoot, DeviceFunction, DeviceFunctionInfo};
+        use ax_driver_pci::{ConfigurationAccess, DeviceFunction, DeviceFunctionInfo, PciRoot};
         type VirtIoTransport = ax_driver_virtio::PciTransport;
     } else if #[cfg(bus =  "mmio")] {
         type VirtIoTransport = ax_driver_virtio::MmioTransport;
@@ -130,8 +130,8 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
     }
 
     #[cfg(bus = "pci")]
-    fn probe_pci(
-        root: &mut PciRoot,
+    fn probe_pci<C: ConfigurationAccess>(
+        root: &mut PciRoot<C>,
         bdf: DeviceFunction,
         dev_info: &DeviceFunctionInfo,
     ) -> Option<AxDeviceEnum> {
@@ -148,7 +148,7 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
         }
 
         if let Some((ty, transport, irq)) =
-            ax_driver_virtio::probe_pci_device::<VirtIoHalImpl>(root, bdf, dev_info)
+            ax_driver_virtio::probe_pci_device::<VirtIoHalImpl, C>(root, bdf, dev_info)
             && ty == D::DEVICE_TYPE
         {
             match D::try_new(transport, Some(irq)) {
@@ -175,7 +175,7 @@ unsafe impl VirtIoHal for VirtIoHalImpl {
         };
         let paddr = virt_to_phys(vaddr.into());
         let ptr = NonNull::new(vaddr as _).unwrap();
-        (paddr.as_usize(), ptr)
+        (paddr.as_usize() as PhysAddr, ptr)
     }
 
     unsafe fn dma_dealloc(_paddr: PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
@@ -185,13 +185,13 @@ unsafe impl VirtIoHal for VirtIoHalImpl {
 
     #[inline]
     unsafe fn mmio_phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
-        NonNull::new(phys_to_virt(paddr.into()).as_mut_ptr()).unwrap()
+        NonNull::new(phys_to_virt((paddr as usize).into()).as_mut_ptr()).unwrap()
     }
 
     #[inline]
     unsafe fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> PhysAddr {
         let vaddr = buffer.as_ptr() as *mut u8 as usize;
-        virt_to_phys(vaddr.into()).into()
+        virt_to_phys(vaddr.into()).as_usize() as PhysAddr
     }
 
     #[inline]

--- a/platform/axplat-dyn/link.ld
+++ b/platform/axplat-dyn/link.ld
@@ -17,6 +17,7 @@ SECTIONS {
 }
 INSERT AFTER scope_local;
 
+
 SECTIONS {
     debug_abbrev : { . += SIZEOF(.debug_abbrev); }
     debug_addr : { . += SIZEOF(.debug_addr); }

--- a/platform/axplat-dyn/src/drivers/blk/mod.rs
+++ b/platform/axplat-dyn/src/drivers/blk/mod.rs
@@ -11,6 +11,7 @@ mod phytium;
 #[cfg(feature = "sdmmc")]
 mod rockchip;
 mod virtio;
+mod virtio_pci;
 
 pub struct Block {
     dev: Device<rd_block::Block>,

--- a/platform/axplat-dyn/src/drivers/blk/virtio.rs
+++ b/platform/axplat-dyn/src/drivers/blk/virtio.rs
@@ -6,8 +6,8 @@ use core::{marker::PhantomData, ptr::NonNull};
 use ax_alloc::{UsageKind, global_allocator};
 use ax_driver_base::DeviceType;
 use ax_driver_block::BlockDriverOps;
-use ax_driver_virtio::{BufferDirection, MmioTransport, PhysAddr as VirtIoPhysAddr, VirtIoHal};
-use ax_plat::mem::{PhysAddr, phys_to_virt};
+use ax_driver_virtio::{BufferDirection, PhysAddr as VirtIoPhysAddr, Transport, VirtIoHal};
+use ax_plat::mem::PhysAddr;
 use rdrive::{
     DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
 };
@@ -15,7 +15,7 @@ use rdrive::{
 use super::PlatformDeviceBlock;
 use crate::drivers::iomap;
 
-type Device<T> = ax_driver_virtio::VirtIoBlkDev<VirtIoHalImpl, T>;
+pub(super) type VirtIoBlkDevice<T> = ax_driver_virtio::VirtIoBlkDev<VirtIoHalImpl, T>;
 
 module_driver!(
     name: "Virtio Block",
@@ -52,33 +52,39 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
         return Err(OnProbeError::NotMatch);
     }
 
-    let dev = Device::try_new(transport).map_err(|e| {
+    let dev = VirtIoBlkDevice::try_new(transport).map_err(|e| {
         OnProbeError::other(format!(
             "failed to initialize Virtio Block device at [PA:{mmio_base:?},): {e:?}"
         ))
     })?;
 
-    let dev = BlockDivce { dev: Some(dev) };
-    plat_dev.register_block(dev);
+    register_virtio_block(plat_dev, dev);
     debug!("virtio block device registered successfully");
     Ok(())
 }
 
-struct BlockDivce {
-    dev: Option<Device<MmioTransport>>,
+pub(super) fn register_virtio_block<T: Transport + 'static>(
+    plat_dev: PlatformDevice,
+    dev: VirtIoBlkDevice<T>,
+) {
+    plat_dev.register_block(BlockDevice { dev: Some(dev) });
 }
 
-struct BlockQueue {
-    raw: Device<MmioTransport>,
+struct BlockDevice<T: Transport + 'static> {
+    dev: Option<VirtIoBlkDevice<T>>,
 }
 
-impl DriverGeneric for BlockDivce {
+struct BlockQueue<T: Transport + 'static> {
+    raw: VirtIoBlkDevice<T>,
+}
+
+impl<T: Transport + 'static> DriverGeneric for BlockDevice<T> {
     fn name(&self) -> &str {
         "virtio-blk"
     }
 }
 
-impl rd_block::Interface for BlockDivce {
+impl<T: Transport + 'static> rd_block::Interface for BlockDevice<T> {
     fn create_queue(&mut self) -> Option<alloc::boxed::Box<dyn rd_block::IQueue>> {
         self.dev
             .take()
@@ -102,7 +108,7 @@ impl rd_block::Interface for BlockDivce {
     }
 }
 
-impl rd_block::IQueue for BlockQueue {
+impl<T: Transport + 'static> rd_block::IQueue for BlockQueue<T> {
     fn num_blocks(&self) -> usize {
         self.raw.num_blocks() as _
     }
@@ -132,13 +138,13 @@ impl rd_block::IQueue for BlockQueue {
             rd_block::RequestKind::Read(mut buffer) => {
                 self.raw
                     .read_block(id as _, &mut buffer)
-                    .map_err(maping_dev_err_to_blk_err)?;
+                    .map_err(map_dev_err_to_blk_err)?;
                 Ok(rd_block::RequestId::new(0))
             }
             rd_block::RequestKind::Write(items) => {
                 self.raw
                     .write_block(id as _, items)
-                    .map_err(maping_dev_err_to_blk_err)?;
+                    .map_err(map_dev_err_to_blk_err)?;
                 Ok(rd_block::RequestId::new(0))
             }
         }
@@ -149,7 +155,7 @@ impl rd_block::IQueue for BlockQueue {
     }
 }
 
-fn maping_dev_err_to_blk_err(err: ax_driver_base::DevError) -> rd_block::BlkError {
+fn map_dev_err_to_blk_err(err: ax_driver_base::DevError) -> rd_block::BlkError {
     match err {
         ax_driver_base::DevError::Again => rd_block::BlkError::Retry,
         ax_driver_base::DevError::AlreadyExists => {
@@ -168,7 +174,7 @@ fn maping_dev_err_to_blk_err(err: ax_driver_base::DevError) -> rd_block::BlkErro
     }
 }
 
-struct VirtIoHalImpl(PhantomData<()>);
+pub(super) struct VirtIoHalImpl(PhantomData<()>);
 
 unsafe impl VirtIoHal for VirtIoHalImpl {
     fn dma_alloc(pages: usize, _direction: BufferDirection) -> (VirtIoPhysAddr, NonNull<u8>) {
@@ -189,8 +195,8 @@ unsafe impl VirtIoHal for VirtIoHalImpl {
     }
 
     #[inline]
-    unsafe fn mmio_phys_to_virt(paddr: VirtIoPhysAddr, _size: usize) -> NonNull<u8> {
-        NonNull::new(phys_to_virt(paddr.into()).as_mut_ptr()).unwrap()
+    unsafe fn mmio_phys_to_virt(paddr: VirtIoPhysAddr, size: usize) -> NonNull<u8> {
+        iomap((paddr as usize).into(), size).expect("failed to map virtio MMIO region")
     }
 
     #[inline]

--- a/platform/axplat-dyn/src/drivers/blk/virtio_pci.rs
+++ b/platform/axplat-dyn/src/drivers/blk/virtio_pci.rs
@@ -1,0 +1,113 @@
+extern crate alloc;
+
+use alloc::{format, sync::Arc};
+
+use ax_driver_base::DeviceType;
+use ax_driver_virtio::pci::{
+    ConfigurationAccess, DeviceFunction, DeviceFunctionInfo, HeaderType, PciRoot,
+};
+use rdrive::{
+    PlatformDevice, module_driver,
+    probe::{
+        OnProbeError,
+        pci::{Endpoint, EndpointRc},
+    },
+};
+use spin::Mutex;
+
+use super::virtio::{VirtIoBlkDevice, VirtIoHalImpl, register_virtio_block};
+
+module_driver!(
+    name: "Virtio PCI Block",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Pci { on_probe: probe }],
+);
+
+fn probe(endpoint: &mut EndpointRc, plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
+    match (endpoint.vendor_id(), endpoint.device_id()) {
+        (0x1af4, 0x1001 | 0x1042) => {}
+        _ => return Err(OnProbeError::NotMatch),
+    }
+
+    let bdf = as_device_function(endpoint.address());
+    let dev_info = as_device_function_info(endpoint);
+    let mut root = PciRoot::new(EndpointConfigAccess::new(bdf, endpoint.take()));
+
+    let (ty, transport, _irq) =
+        ax_driver_virtio::probe_pci_device::<VirtIoHalImpl, _>(&mut root, bdf, &dev_info)
+            .ok_or(OnProbeError::NotMatch)?;
+
+    if ty != DeviceType::Block {
+        return Err(OnProbeError::NotMatch);
+    }
+
+    let dev = VirtIoBlkDevice::try_new(transport).map_err(|err| {
+        OnProbeError::other(format!(
+            "failed to initialize Virtio PCI block device at {bdf}: {err:?}"
+        ))
+    })?;
+
+    register_virtio_block(plat_dev, dev);
+    debug!("virtio PCI block device registered successfully at {bdf}");
+    Ok(())
+}
+
+fn as_device_function(address: rdrive::probe::pci::PciAddress) -> DeviceFunction {
+    DeviceFunction {
+        bus: address.bus(),
+        device: address.device(),
+        function: address.function(),
+    }
+}
+
+fn as_device_function_info(endpoint: &Endpoint) -> DeviceFunctionInfo {
+    let class_info = endpoint.revision_and_class();
+    let header_type = HeaderType::from(((endpoint.read(0x0c) >> 16) as u8) & 0x7f);
+    DeviceFunctionInfo {
+        vendor_id: endpoint.vendor_id(),
+        device_id: endpoint.device_id(),
+        class: class_info.base_class,
+        subclass: class_info.sub_class,
+        prog_if: class_info.interface,
+        revision: class_info.revision_id,
+        header_type,
+    }
+}
+
+struct EndpointConfigAccess {
+    bdf: DeviceFunction,
+    endpoint: Arc<Mutex<Endpoint>>,
+}
+
+impl EndpointConfigAccess {
+    fn new(bdf: DeviceFunction, endpoint: Endpoint) -> Self {
+        Self {
+            bdf,
+            endpoint: Arc::new(Mutex::new(endpoint)),
+        }
+    }
+
+    fn assert_same_function(&self, device_function: DeviceFunction) {
+        assert_eq!(device_function, self.bdf);
+    }
+}
+
+impl ConfigurationAccess for EndpointConfigAccess {
+    fn read_word(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
+        self.assert_same_function(device_function);
+        self.endpoint.lock().read(register_offset.into())
+    }
+
+    fn write_word(&mut self, device_function: DeviceFunction, register_offset: u8, data: u32) {
+        self.assert_same_function(device_function);
+        self.endpoint.lock().write(register_offset.into(), data);
+    }
+
+    unsafe fn unsafe_clone(&self) -> Self {
+        Self {
+            bdf: self.bdf,
+            endpoint: Arc::clone(&self.endpoint),
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- upgrade the local virtio wrapper stack to `virtio-drivers 0.13.0`
- adapt `ax-driver-pci` and `ax-driver-virtio` to the new generic PCI configuration backend API
- update the ArceOS static PCI probe path to construct `PciRoot` with `MmioCam`
- add `platform/axplat-dyn/src/drivers/blk/virtio_pci.rs` to probe PCI virtio block devices through `rdrive` and initialize them with `ax_driver_virtio`
- factor shared virtio block registration/HAL glue in `axplat-dyn` so MMIO and PCI paths reuse the same block wrapper

## Why
`axplat-dyn` previously only supported the FDT/MMIO virtio block path. This change adds a PCI virtio-blk path while keeping device discovery in the current project, and updates the wrapper stack to use the newer `virtio-drivers` PCI abstraction model.

## Impact
- dyn-platform StarryOS can now discover and initialize `virtio-blk-pci`
- the wrapper crates now target `virtio-drivers 0.13.0`
- the older static PCI path in `ax-driver` still builds with the new PCI root API

## Validation
- `cargo fmt`
- `cargo clippy --no-deps -p ax-driver-virtio -p ax-driver-pci -- -D warnings`
- `cargo clippy --no-deps -p axplat-dyn --target aarch64-unknown-none-softfloat -- -D warnings`
- `cargo check -p ax-driver --features bus-pci,virtio,virtio-blk,virtio-net,virtio-gpu,virtio-input,virtio-socket`
- `cargo run -p tg-xtask -- starry qemu --arch aarch64 --plat-dyn true --qemu-config os/StarryOS/starryos/.qemu-aarch64.toml`

## Current status / follow-up
- verified that `virtio-blk-pci` is detected and mounted by `ax_fs_ng`
- verified that the new block driver does not claim the `virtio-net-pci` device
- StarryOS dyn-platform boot still hits a later page-fault in `ax_fs_ng::highlevel::fs::FsContext::resolve_components` during `Initialize pseudofs...`
- keeping this PR as draft because that later runtime issue still needs follow-up and does not appear to be in the virtio PCI probe path itself
