### PR TITLE
add axplat-dyn intel-net support and update dma-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,8 @@ dependencies = [
 [[package]]
 name = "dma-api"
 version = "0.7.2"
-source = "git+https://github.com/drivercraft/sparreal-os?rev=decd04e2beaad11af62e2af39ceaf83a162cec39#decd04e2beaad11af62e2af39ceaf83a162cec39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2136c1ae5dd8dfddada92cc005f8518ad47b00619781b361a17104fb8a44b3e8"
 dependencies = [
  "aarch64-cpu-ext",
  "cfg-if",
@@ -4069,15 +4070,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -4576,9 +4576,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5617,9 +5617,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -5818,7 +5818,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -5884,9 +5884,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5894,9 +5894,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "rand_core 0.10.0",
 ]
@@ -6700,9 +6700,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6765,9 +6765,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7489,7 +7489,7 @@ dependencies = [
  "lock_api",
  "num_enum",
  "ouroboros",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ringbuf",
  "riscv 0.16.0",
  "scope-local",
@@ -8307,7 +8307,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
@@ -8725,9 +8725,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8738,9 +8738,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8748,9 +8748,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8758,9 +8758,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8771,9 +8771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -8833,9 +8833,9 @@ checksum = "dba9c05687e501b2710833fbe2cc7ff8cc24411fb0d81967498ca44598942f88"
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,18 +1668,22 @@ dependencies = [
  "ax-cpu",
  "ax-driver-base",
  "ax-driver-block",
+ "ax-driver-net",
  "ax-driver-virtio",
  "ax-errno",
  "ax-memory-addr",
  "ax-percpu",
  "ax-plat",
  "axklib",
- "dma-api 0.7.1",
+ "dma-api 0.7.2",
+ "eth-intel",
  "fdt-edit",
  "heapless 0.9.2",
  "log",
+ "pcie",
  "phytium-mci",
  "rd-block",
+ "rd-net",
  "rdif-clk",
  "rdrive",
  "rk3568_clk",
@@ -2276,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3164,9 +3168,8 @@ dependencies = [
 
 [[package]]
 name = "dma-api"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e9ce2657334f873c12845789d5a4f1b34bef91fe531437284b8387d77bd925"
+version = "0.7.2"
+source = "git+https://github.com/drivercraft/sparreal-os?rev=decd04e2beaad11af62e2af39ceaf83a162cec39#decd04e2beaad11af62e2af39ceaf83a162cec39"
 dependencies = [
  "aarch64-cpu-ext",
  "cfg-if",
@@ -3428,6 +3431,19 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "eth-intel"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b96b9533745d08195782202f454d9b455ee7317d061bf2d72e01f00cd8571d"
+dependencies = [
+ "dma-api 0.7.2",
+ "log",
+ "mmio-api",
+ "rdif-eth",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6072,10 +6088,21 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c20952f27dc5aaf853e8c00026ba7f2633e149ce47f9a58115704b342756307"
 dependencies = [
- "dma-api 0.7.1",
+ "dma-api 0.7.2",
  "futures",
  "rdif-block",
  "spin_on",
+]
+
+[[package]]
+name = "rd-net"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb6a7322383a02dcffa7f04134257cd74e7f593bd8753084b391775e93b61eb"
+dependencies = [
+ "dma-api 0.7.2",
+ "futures",
+ "rdif-eth",
 ]
 
 [[package]]
@@ -6110,7 +6137,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2a2573c1fb0af5daf596a32b9e10284f1fc018adfd0413e2213f35151ebff1"
 dependencies = [
- "dma-api 0.7.1",
+ "dma-api 0.7.2",
  "rdif-base 0.8.0",
  "thiserror 2.0.18",
 ]
@@ -6130,6 +6157,17 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e44a12e44c2f439be06af72a3e03d4e57f6c79211a68058158a02670e63853c"
 dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rdif-eth"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900e3772647fe21c5208ab52fc1b15e3a62c8a7e64eb83e0c32d95767565caf"
+dependencies = [
+ "dma-api 0.7.2",
+ "rdif-base 0.8.0",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,6 +215,7 @@ ax-driver-pci = { path = "components/axdriver_crates/axdriver_pci" }
 ax-driver-virtio = { path = "components/axdriver_crates/axdriver_virtio" }
 ax-driver-input = { path = "components/axdriver_crates/axdriver_input" }
 ax-driver-vsock = { path = "components/axdriver_crates/axdriver_vsock" }
+dma-api = { git = "https://github.com/drivercraft/sparreal-os", rev = "decd04e2beaad11af62e2af39ceaf83a162cec39" }
 
 # === ax-percpu ===
 ax-percpu = { path = "components/percpu/percpu" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,6 @@ ax-driver-pci = { path = "components/axdriver_crates/axdriver_pci" }
 ax-driver-virtio = { path = "components/axdriver_crates/axdriver_virtio" }
 ax-driver-input = { path = "components/axdriver_crates/axdriver_input" }
 ax-driver-vsock = { path = "components/axdriver_crates/axdriver_vsock" }
-dma-api = { git = "https://github.com/drivercraft/sparreal-os", rev = "decd04e2beaad11af62e2af39ceaf83a162cec39" }
 
 # === ax-percpu ===
 ax-percpu = { path = "components/percpu/percpu" }
@@ -380,6 +379,7 @@ ax-kspin = { version = "0.3.1", path = "components/kspin" }
 ax-lazyinit = { version = "0.4.2", path = "components/ax-lazyinit" }
 schemars = "1.2.1"
 toml = "1"
+dma-api = { version = "0.7.2" }
 
 # === starry-* ===
 starry-process = { version = "0.4.0", path = "components/starry-process" }

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -25,7 +25,8 @@ qemu = [
   "ax-feat/bus-pci",
   "ax-feat/display",
   "starry-kernel/input",
-  "starry-kernel/vsock",
+  "starry-kernel/vsock", # auxilary features
+  "axplat-dyn/intel-net",
 ]
 smp = ["ax-feat/smp", "axplat-riscv64-visionfive2?/smp"]
 

--- a/os/arceos/modules/axdriver/Cargo.toml
+++ b/os/arceos/modules/axdriver/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 [features]
 bus-mmio = []
 bus-pci = ["dep:ax-driver-pci", "dep:ax-hal", "dep:ax-config"]
-net = ["dep:ax-driver-net"]
+net = ["dep:ax-driver-net", "axplat-dyn?/intel-net"]
 block = ["dep:ax-driver-block"]
 display = ["dep:ax-driver-display"]
 input = ["dep:ax-driver-input"]

--- a/os/arceos/modules/axdriver/src/dyn_drivers/mod.rs
+++ b/os/arceos/modules/axdriver/src/dyn_drivers/mod.rs
@@ -16,6 +16,11 @@ pub fn probe_all_devices() -> Vec<super::AxDeviceEnum> {
             devices.push(super::AxDeviceEnum::Block(dev));
         }
 
+        #[cfg(feature = "net")]
+        for dev in axplat_dyn::drivers::take_net_devices() {
+            devices.push(super::AxDeviceEnum::Net(dev));
+        }
+
         devices
     }
     #[cfg(not(target_os = "none"))]

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["smp", "irq"]
+default = ["smp", "irq" ]
 smp = ["ax-plat/smp"]
 irq = ["ax-plat/irq"]
 fp-simd = ["ax-cpu/fp-simd"]
@@ -22,6 +22,7 @@ sdmmc = ["dep:sdmmc"]
 rockchip-pm = ["dep:rockchip-pm"]
 phytium-blk = ["dep:phytium-mci"]
 serial = ["dep:some-serial"]
+intel-net = ["dep:ax-driver-net", "dep:eth-intel", "dep:pcie", "dep:rd-net"]
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
@@ -30,17 +31,21 @@ ax-config-macros = "0.4.1"
 ax-cpu.workspace = true
 ax-driver-base.workspace = true
 ax-driver-block.workspace = true
+ax-driver-net = { workspace = true, optional = true }
 ax-driver-virtio = { workspace = true, features = ["block"] }
 ax-errno.workspace = true
 axklib.workspace = true
 ax-plat.workspace = true
 dma-api = "0.7"
+eth-intel = { version = "0.1", optional = true }
 fdt-edit = "0.2"
 heapless = "0.9"
 log.workspace = true
 ax-memory-addr.workspace = true
 ax-percpu = { workspace = true, features = ["custom-base"] }
+pcie = { version = "0.6", optional = true }
 rd-block = "0.1"
+rd-net = { version = "0.1", optional = true }
 rdif-clk = "0.5"
 rdrive = "0.20"
 rk3568_clk = { version = "0.1", optional = true }

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -36,7 +36,7 @@ ax-driver-virtio = { workspace = true, features = ["block"] }
 ax-errno.workspace = true
 axklib.workspace = true
 ax-plat.workspace = true
-dma-api = "0.7"
+dma-api.workspace = true
 eth-intel = { version = "0.1", optional = true }
 fdt-edit = "0.2"
 heapless = "0.9"

--- a/platform/axplat-dyn/src/drivers/mod.rs
+++ b/platform/axplat-dyn/src/drivers/mod.rs
@@ -4,6 +4,8 @@ use alloc::boxed::Box;
 use core::{alloc::Layout, ptr::NonNull};
 
 use ax_driver_block::BlockDriverOps;
+#[cfg(feature = "intel-net")]
+use ax_driver_net::NetDriverOps;
 use ax_errno::AxError;
 use ax_memory_addr::PAGE_SIZE_4K;
 use ax_plat::mem::PhysAddr;
@@ -17,12 +19,20 @@ mod serial;
 mod soc;
 
 pub mod blk;
+#[cfg(feature = "intel-net")]
+pub mod net;
 
 const MAX_BLOCK_DEVICES: usize = 16;
+#[cfg(feature = "intel-net")]
+const MAX_NET_DEVICES: usize = 16;
 
 pub type DynBlockDevice = Box<dyn BlockDriverOps>;
+#[cfg(feature = "intel-net")]
+pub type DynNetDevice = Box<dyn NetDriverOps>;
 
 static BLOCK_DEVICES: Mutex<Vec<DynBlockDevice, MAX_BLOCK_DEVICES>> = Mutex::new(Vec::new());
+#[cfg(feature = "intel-net")]
+static NET_DEVICES: Mutex<Vec<DynNetDevice, MAX_NET_DEVICES>> = Mutex::new(Vec::new());
 
 pub fn clear_block_devices() {
     BLOCK_DEVICES.lock().clear();
@@ -34,6 +44,22 @@ pub fn register_block_device(device: DynBlockDevice) -> Result<(), DynBlockDevic
 
 pub fn take_block_devices() -> Vec<DynBlockDevice, MAX_BLOCK_DEVICES> {
     let mut devices = BLOCK_DEVICES.lock();
+    core::mem::take(&mut *devices)
+}
+
+#[cfg(feature = "intel-net")]
+pub fn clear_net_devices() {
+    NET_DEVICES.lock().clear();
+}
+
+#[cfg(feature = "intel-net")]
+pub fn register_net_device(device: DynNetDevice) -> Result<(), DynNetDevice> {
+    NET_DEVICES.lock().push(device)
+}
+
+#[cfg(feature = "intel-net")]
+pub fn take_net_devices() -> Vec<DynNetDevice, MAX_NET_DEVICES> {
+    let mut devices = NET_DEVICES.lock();
     core::mem::take(&mut *devices)
 }
 
@@ -49,11 +75,24 @@ pub(crate) fn iomap(addr: PhysAddr, size: usize) -> Result<NonNull<u8>, OnProbeE
 
 pub fn probe_all_devices() -> Result<(), AxError> {
     clear_block_devices();
+    #[cfg(feature = "intel-net")]
+    clear_net_devices();
     rdrive::probe_all(true).map_err(|_| AxError::BadState)?;
 
     for dev in rdrive::get_list::<rd_block::Block>() {
         let block = Box::new(blk::Block::from(dev));
         if register_block_device(block).is_err() {
+            return Err(AxError::NoMemory);
+        }
+    }
+
+    #[cfg(feature = "intel-net")]
+    for dev in rdrive::get_list::<net::PlatformNetDevice>() {
+        let net = net::Net::try_from(dev).map_err(|err| match err {
+            ax_driver_base::DevError::NoMemory => AxError::NoMemory,
+            _ => AxError::BadState,
+        })?;
+        if register_net_device(Box::new(net)).is_err() {
             return Err(AxError::NoMemory);
         }
     }

--- a/platform/axplat-dyn/src/drivers/net/intel.rs
+++ b/platform/axplat-dyn/src/drivers/net/intel.rs
@@ -1,0 +1,46 @@
+use eth_intel::E1000;
+use pcie::CommandRegister;
+use rdrive::{
+    PlatformDevice, module_driver,
+    probe::{
+        OnProbeError,
+        pci::{EndpointRc, FnOnProbe},
+    },
+};
+
+use super::{DRIVER_NAME, PlatformDeviceNet};
+use crate::{boot::Kernel, drivers::DmaImpl};
+
+module_driver!(
+    name: "Intel E1000 PCI Network",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Pci {
+        on_probe: probe as FnOnProbe
+    }],
+);
+
+fn probe(endpoint: &mut EndpointRc, plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
+    if !E1000::check_vid_did(endpoint.vendor_id(), endpoint.device_id()) {
+        return Err(OnProbeError::NotMatch);
+    }
+
+    let Some(bar) = endpoint.bar_mmio(0) else {
+        return Err(OnProbeError::other("E1000 BAR0 MMIO region missing"));
+    };
+
+    endpoint.update_command(|mut cmd| {
+        cmd.insert(CommandRegister::MEMORY_ENABLE | CommandRegister::BUS_MASTER_ENABLE);
+        cmd
+    });
+
+    let dev = E1000::new(bar.start as u64, bar.count(), u64::MAX, &DmaImpl, &Kernel)
+        .map_err(|err| OnProbeError::other(alloc::format!("failed to create e1000: {err:?}")))?;
+
+    plat_dev.register_net(DRIVER_NAME, dev);
+    debug!(
+        "intel e1000 PCI device registered successfully at {}",
+        endpoint.address()
+    );
+    Ok(())
+}

--- a/platform/axplat-dyn/src/drivers/net/mod.rs
+++ b/platform/axplat-dyn/src/drivers/net/mod.rs
@@ -1,0 +1,236 @@
+extern crate alloc;
+
+use alloc::{collections::VecDeque, sync::Arc};
+
+use ax_driver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
+use ax_driver_net::{EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps};
+use rd_net::{Interface, NetError};
+use rdrive::{Device, DriverGeneric};
+use spin::Mutex;
+
+use super::DmaImpl;
+
+#[cfg(feature = "intel-net")]
+mod intel;
+
+const DRIVER_NAME: &str = "eth-intel-e1000";
+const NET_BUF_LEN: usize = 2048;
+const NET_BUF_POOL_CAPACITY: usize = 512;
+const NET_QUEUE_SIZE: usize = 256;
+const RX_PREFETCH_TARGET: usize = 1;
+
+pub struct PlatformNetDevice {
+    name: &'static str,
+    net: rd_net::Net,
+}
+
+impl PlatformNetDevice {
+    fn new(name: &'static str, net: rd_net::Net) -> Self {
+        Self { name, net }
+    }
+}
+
+impl DriverGeneric for PlatformNetDevice {
+    fn name(&self) -> &str {
+        self.name
+    }
+}
+
+struct NetState {
+    tx_queue: rd_net::TxQueue,
+    rx_queue: rd_net::RxQueue,
+    pending_rx: VecDeque<NetBufBox>,
+}
+
+pub struct Net {
+    name: &'static str,
+    mac: [u8; 6],
+    buf_pool: Arc<NetBufPool>,
+    state: Mutex<NetState>,
+}
+
+impl TryFrom<Device<PlatformNetDevice>> for Net {
+    type Error = DevError;
+
+    fn try_from(device: Device<PlatformNetDevice>) -> Result<Self, Self::Error> {
+        let mut dev = device.lock().map_err(map_device_err_to_dev_err)?;
+        let name = dev.name;
+        let mac = dev.net.mac_address();
+        let tx_queue = dev.net.create_tx_queue().map_err(map_net_err_to_dev_err)?;
+        let rx_queue = dev.net.create_rx_queue().map_err(map_net_err_to_dev_err)?;
+        drop(dev);
+
+        Ok(Self {
+            name,
+            mac,
+            buf_pool: NetBufPool::new(NET_BUF_POOL_CAPACITY, NET_BUF_LEN)?,
+            state: Mutex::new(NetState {
+                tx_queue,
+                rx_queue,
+                pending_rx: VecDeque::with_capacity(RX_PREFETCH_TARGET),
+            }),
+        })
+    }
+}
+
+impl Net {
+    fn prefetch_rx_packets(&self, state: &mut NetState, target: usize) -> DevResult {
+        while state.pending_rx.len() < target {
+            let Some(result) = state.rx_queue.receive(|packet| {
+                let Some(mut net_buf) = self.buf_pool.alloc_boxed() else {
+                    return Err(DevError::NoMemory);
+                };
+
+                if packet.len() > net_buf.capacity() {
+                    warn!(
+                        "dropping oversized rx packet for {}: {} bytes",
+                        self.name,
+                        packet.len()
+                    );
+                    return Err(DevError::InvalidParam);
+                }
+
+                net_buf.set_header_len(0);
+                net_buf.set_packet_len(packet.len());
+                net_buf.packet_mut().copy_from_slice(packet);
+                Ok(net_buf)
+            }) else {
+                break;
+            };
+
+            match result {
+                Ok(net_buf) => state.pending_rx.push_back(net_buf),
+                Err(DevError::InvalidParam) => continue,
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl BaseDriverOps for Net {
+    fn device_name(&self) -> &str {
+        self.name
+    }
+
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Net
+    }
+
+    fn irq_num(&self) -> Option<usize> {
+        None
+    }
+}
+
+impl NetDriverOps for Net {
+    fn mac_address(&self) -> EthernetAddress {
+        EthernetAddress(self.mac)
+    }
+
+    fn can_transmit(&self) -> bool {
+        let mut state = self.state.lock();
+        match state.tx_queue.prepare_send(0, |_| ()) {
+            Ok((_ret, _pending)) => true,
+            Err(NetError::Retry) => false,
+            Err(err) => {
+                warn!("failed to test tx readiness for {}: {err:?}", self.name);
+                false
+            }
+        }
+    }
+
+    fn can_receive(&self) -> bool {
+        let mut state = self.state.lock();
+        if let Err(err) = self.prefetch_rx_packets(&mut state, RX_PREFETCH_TARGET) {
+            warn!("failed to prefetch rx packets for {}: {err:?}", self.name);
+        }
+        !state.pending_rx.is_empty()
+    }
+
+    fn rx_queue_size(&self) -> usize {
+        NET_QUEUE_SIZE
+    }
+
+    fn tx_queue_size(&self) -> usize {
+        NET_QUEUE_SIZE
+    }
+
+    fn recycle_rx_buffer(&mut self, rx_buf: NetBufPtr) -> DevResult {
+        drop(unsafe { NetBuf::from_buf_ptr(rx_buf) });
+        Ok(())
+    }
+
+    fn recycle_tx_buffers(&mut self) -> DevResult {
+        Ok(())
+    }
+
+    fn transmit(&mut self, tx_buf: NetBufPtr) -> DevResult {
+        let tx_buf = unsafe { NetBuf::from_buf_ptr(tx_buf) };
+        let packet = tx_buf.packet();
+
+        let mut state = self.state.lock();
+        let (_ret, mut pending) = state
+            .tx_queue
+            .prepare_send(packet.len(), |buffer| {
+                buffer[..packet.len()].copy_from_slice(packet);
+            })
+            .map_err(map_net_err_to_dev_err)?;
+        pending.try_submit().map_err(map_net_err_to_dev_err)?;
+        drop(tx_buf);
+        Ok(())
+    }
+
+    fn receive(&mut self) -> DevResult<NetBufPtr> {
+        let mut state = self.state.lock();
+        self.prefetch_rx_packets(&mut state, RX_PREFETCH_TARGET)?;
+        state
+            .pending_rx
+            .pop_front()
+            .map(NetBuf::into_buf_ptr)
+            .ok_or(DevError::Again)
+    }
+
+    fn alloc_tx_buffer(&mut self, size: usize) -> DevResult<NetBufPtr> {
+        let mut net_buf = self.buf_pool.alloc_boxed().ok_or(DevError::NoMemory)?;
+        if size > net_buf.capacity() {
+            return Err(DevError::InvalidParam);
+        }
+
+        net_buf.set_header_len(0);
+        net_buf.set_packet_len(size);
+        Ok(net_buf.into_buf_ptr())
+    }
+}
+
+pub trait PlatformDeviceNet {
+    fn register_net<T>(self, name: &'static str, dev: T)
+    where
+        T: Interface + 'static;
+}
+
+impl PlatformDeviceNet for rdrive::PlatformDevice {
+    fn register_net<T>(self, name: &'static str, dev: T)
+    where
+        T: Interface + 'static,
+    {
+        let net = rd_net::Net::new(dev, &DmaImpl);
+        self.register(PlatformNetDevice::new(name, net));
+    }
+}
+
+fn map_net_err_to_dev_err(err: NetError) -> DevError {
+    match err {
+        NetError::Retry => DevError::Again,
+        NetError::NoMemory => DevError::NoMemory,
+        NetError::NotSupported => DevError::Unsupported,
+        NetError::LinkDown | NetError::Other(_) => DevError::Io,
+    }
+}
+
+fn map_device_err_to_dev_err(_err: rdrive::GetDeviceError) -> DevError {
+    DevError::BadState
+}
+
+#[allow(dead_code)]
+const _: &str = DRIVER_NAME;

--- a/scripts/axbuild/src/arceos/build.rs
+++ b/scripts/axbuild/src/arceos/build.rs
@@ -6,13 +6,15 @@ use std::{
 };
 
 use anyhow::{Context, bail};
-use cargo_metadata::MetadataCommand;
 use ostool::build::config::Cargo;
 pub use ostool::build::config::LogLevel;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::{context::ResolvedBuildRequest, process::ProcessExt};
+use crate::{
+    context::{ResolvedBuildRequest, workspace_manifest_path, workspace_metadata_root_manifest},
+    process::ProcessExt,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AxFeaturePrefixFamily {
@@ -441,15 +443,13 @@ fn feature_family_from_existing_features(features: &[String]) -> Option<AxFeatur
 
 fn detect_ax_feature_prefix_family(
     package: &str,
-    manifest_path: Option<&Path>,
+    workspace_manifest: Option<&Path>,
 ) -> anyhow::Result<AxFeaturePrefixFamily> {
-    let mut command = MetadataCommand::new();
-    command.no_deps();
-    if let Some(manifest_path) = manifest_path {
-        command.manifest_path(manifest_path);
-    }
-
-    let metadata = command.exec()?;
+    let manifest_path = workspace_manifest
+        .map(Path::to_path_buf)
+        .map(Ok)
+        .unwrap_or_else(workspace_manifest_path)?;
+    let metadata = workspace_metadata_root_manifest(&manifest_path)?;
     let workspace_members: std::collections::HashSet<_> =
         metadata.workspace_members.iter().cloned().collect();
     let package_info = metadata
@@ -478,15 +478,13 @@ fn detect_ax_feature_prefix_family(
 
 pub(crate) fn resolve_package_manifest_path(
     package: &str,
-    manifest_path: Option<&Path>,
+    workspace_manifest: Option<&Path>,
 ) -> anyhow::Result<PathBuf> {
-    let mut command = MetadataCommand::new();
-    command.no_deps();
-    if let Some(manifest_path) = manifest_path {
-        command.manifest_path(manifest_path);
-    }
-
-    let metadata = command.exec()?;
+    let manifest_path = workspace_manifest
+        .map(Path::to_path_buf)
+        .map(Ok)
+        .unwrap_or_else(workspace_manifest_path)?;
+    let metadata = workspace_metadata_root_manifest(&manifest_path)?;
     let workspace_members: std::collections::HashSet<_> =
         metadata.workspace_members.iter().cloned().collect();
     metadata
@@ -503,14 +501,12 @@ fn resolve_platform_package(
     features: &[String],
 ) -> anyhow::Result<String> {
     let arch = target_arch_name(target)?;
-    let manifest_path = resolve_package_manifest_path(package, None)?;
-    let mut command = MetadataCommand::new();
-    command.no_deps().manifest_path(&manifest_path);
-    let metadata = command.exec()?;
+    let workspace_manifest = workspace_manifest_path()?;
+    let metadata = workspace_metadata_root_manifest(&workspace_manifest)?;
     let package_info = metadata
         .packages
         .iter()
-        .find(|pkg| pkg.name == package)
+        .find(|pkg| metadata.workspace_members.contains(&pkg.id) && pkg.name == package)
         .ok_or_else(|| anyhow!("workspace package `{package}` not found"))?;
 
     let explicit_platform_features: Vec<_> = features

--- a/scripts/axbuild/src/clippy.rs
+++ b/scripts/axbuild/src/clippy.rs
@@ -5,13 +5,12 @@ use std::{
 };
 
 use anyhow::Context;
-use cargo_metadata::{Metadata, MetadataCommand, Package};
+use cargo_metadata::{Metadata, Package};
 use serde_json::Value;
 
 pub(crate) fn run_workspace_clippy_command() -> anyhow::Result<()> {
-    let metadata = MetadataCommand::new()
-        .no_deps()
-        .exec()
+    let workspace_manifest = crate::context::workspace_manifest_path()?;
+    let metadata = crate::context::workspace_metadata_root_manifest(&workspace_manifest)
         .context("failed to load cargo metadata")?;
     let workspace_root = metadata.workspace_root.clone().into_std_path_buf();
     let packages = workspace_packages(&metadata);

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -30,7 +30,8 @@ pub use types::{
     StarryUbootSnapshot,
 };
 pub(crate) use workspace::{
-    find_workspace_root, workspace_member_dir, workspace_member_dir_in, workspace_root_path,
+    find_workspace_root, workspace_manifest_path, workspace_member_dir, workspace_member_dir_in,
+    workspace_metadata_root_manifest, workspace_root_path,
 };
 
 pub struct AppContext {

--- a/scripts/axbuild/src/context/workspace.rs
+++ b/scripts/axbuild/src/context/workspace.rs
@@ -6,12 +6,11 @@ use std::{
 use anyhow::{Context, anyhow};
 
 pub(crate) fn workspace_root_path() -> anyhow::Result<PathBuf> {
-    let current_dir = std::env::current_dir().context("failed to get current directory")?;
-    let cargo = workspace_metadata(&current_dir)?;
-
-    cargo
-        .workspace_root
-        .canonicalize()
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .context("failed to locate workspace root from axbuild crate")?;
+    root.canonicalize()
         .context("failed to canonicalize workspace root")
 }
 
@@ -34,6 +33,29 @@ pub(crate) fn find_workspace_root() -> PathBuf {
     workspace_root_path().expect("failed to resolve workspace root")
 }
 
+pub(crate) fn workspace_manifest_path() -> anyhow::Result<PathBuf> {
+    Ok(workspace_root_path()?.join("Cargo.toml"))
+}
+
+pub(crate) fn workspace_manifest_path_in(workspace_root: &Path) -> PathBuf {
+    workspace_root.join("Cargo.toml")
+}
+
+pub(crate) fn workspace_metadata_root_manifest(
+    workspace_manifest_path: &Path,
+) -> anyhow::Result<cargo_metadata::Metadata> {
+    cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .manifest_path(workspace_manifest_path)
+        .exec()
+        .with_context(|| {
+            format!(
+                "failed to get cargo metadata for workspace root {}",
+                workspace_manifest_path.display()
+            )
+        })
+}
+
 fn workspace_member_manifest_path(workspace_root: &Path, package: &str) -> anyhow::Result<PathBuf> {
     let metadata = workspace_metadata(workspace_root)?;
     let workspace_members: HashSet<_> = metadata.workspace_members.iter().cloned().collect();
@@ -46,9 +68,5 @@ fn workspace_member_manifest_path(workspace_root: &Path, package: &str) -> anyho
 }
 
 fn workspace_metadata(workspace_root: &Path) -> anyhow::Result<cargo_metadata::Metadata> {
-    cargo_metadata::MetadataCommand::new()
-        .no_deps()
-        .current_dir(workspace_root)
-        .exec()
-        .context("failed to get cargo metadata")
+    workspace_metadata_root_manifest(&workspace_manifest_path_in(workspace_root))
 }

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
 
-use cargo_metadata::MetadataCommand;
 use ostool::build::config::Cargo;
 
 pub type StarryBuildInfo = crate::arceos::build::ArceosBuildInfo;
 pub use crate::arceos::build::LogLevel;
 use crate::context::{
-    ResolvedStarryRequest, STARRY_PACKAGE, starry_arch_for_target_checked, workspace_member_dir_in,
+    ResolvedStarryRequest, STARRY_PACKAGE, starry_arch_for_target_checked, workspace_manifest_path,
+    workspace_member_dir_in, workspace_metadata_root_manifest,
 };
 
 impl StarryBuildInfo {
@@ -126,14 +126,12 @@ fn ensure_starry_bin_arg(args: &mut Vec<String>, package: &str) -> anyhow::Resul
 }
 
 fn package_has_bin_named(package: &str, bin_name: &str) -> anyhow::Result<bool> {
-    let manifest_path = crate::arceos::build::resolve_package_manifest_path(package, None)?;
-    let mut command = MetadataCommand::new();
-    command.no_deps().manifest_path(&manifest_path);
-    let metadata = command.exec()?;
+    let workspace_manifest = workspace_manifest_path()?;
+    let metadata = workspace_metadata_root_manifest(&workspace_manifest)?;
     let package_info = metadata
         .packages
         .iter()
-        .find(|pkg| pkg.name == package)
+        .find(|pkg| metadata.workspace_members.contains(&pkg.id) && pkg.name == package)
         .ok_or_else(|| anyhow::anyhow!("workspace package `{package}` not found"))?;
 
     Ok(package_info.targets.iter().any(|target| {

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -318,7 +318,7 @@ HELLO = "world"
 
         assert_eq!(cargo.package, STARRY_PACKAGE);
         assert_eq!(cargo.target, "aarch64-unknown-none-softfloat");
-        assert_eq!(cargo.features, vec!["net".to_string(), "qemu".to_string()]);
+        assert_eq!(cargo.features, vec!["net".to_string()]);
         assert_eq!(
             cargo.env.get("AX_ARCH").map(String::as_str),
             Some("aarch64")
@@ -327,10 +327,7 @@ HELLO = "world"
             cargo.env.get("AX_TARGET").map(String::as_str),
             Some("aarch64-unknown-none-softfloat")
         );
-        assert_eq!(
-            cargo.env.get("AX_PLATFORM").map(String::as_str),
-            Some("aarch64-qemu-virt")
-        );
+        assert_eq!(cargo.env.get("AX_PLATFORM").map(String::as_str), None);
         assert_eq!(cargo.env.get("AX_LOG").map(String::as_str), Some("info"));
         assert_eq!(cargo.env.get("CUSTOM").map(String::as_str), Some("1"));
         assert!(cargo.to_bin);

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -171,7 +171,7 @@ fn qemu_args_for_disk_image(disk_img: PathBuf) -> anyhow::Result<Vec<String>> {
         "-drive".to_string(),
         format!("id=disk0,if=none,format=raw,file={}", disk_img.display()),
         "-device".to_string(),
-        "virtio-net-pci,netdev=net0".to_string(),
+        "e1000,netdev=net0".to_string(),
         "-netdev".to_string(),
         "user,id=net0".to_string(),
     ])

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -286,7 +286,7 @@ mod tests {
                         .display()
                 ),
                 "-device".to_string(),
-                "virtio-net-pci,netdev=net0".to_string(),
+                "e1000,netdev=net0".to_string(),
                 "-netdev".to_string(),
                 "user,id=net0".to_string(),
             ]

--- a/scripts/axbuild/src/test_std.rs
+++ b/scripts/axbuild/src/test_std.rs
@@ -1,14 +1,13 @@
 use std::{collections::HashSet, fs, path::Path, process::Command};
 
 use anyhow::Context;
-use cargo_metadata::{Metadata, MetadataCommand};
+use cargo_metadata::Metadata;
 
 const STD_CRATES_CSV: &str = "scripts/test/std_crates.csv";
 
 pub(crate) fn run_std_test_command() -> anyhow::Result<()> {
-    let metadata = MetadataCommand::new()
-        .no_deps()
-        .exec()
+    let workspace_manifest = crate::context::workspace_manifest_path()?;
+    let metadata = crate::context::workspace_metadata_root_manifest(&workspace_manifest)
         .context("failed to load cargo metadata")?;
     let workspace_root = metadata.workspace_root.clone().into_std_path_buf();
     let known_packages = workspace_package_names(&metadata);
@@ -229,7 +228,10 @@ mod tests {
 
     #[test]
     fn workspace_package_name_extraction_reads_current_workspace() {
-        let metadata = MetadataCommand::new().no_deps().exec().unwrap();
+        let metadata = cargo_metadata::MetadataCommand::new()
+            .no_deps()
+            .exec()
+            .unwrap();
         let names = workspace_package_names(&metadata);
 
         assert!(names.contains("axbuild"));

--- a/scripts/axbuild/src/test_std.rs
+++ b/scripts/axbuild/src/test_std.rs
@@ -182,7 +182,8 @@ mod tests {
 
     #[test]
     fn parses_valid_std_csv() {
-        let packages = parse_std_crates_csv("package\naxfeat\naxhal\n", &known_packages()).unwrap();
+        let packages =
+            parse_std_crates_csv("package\nax-feat\nax-hal\n", &known_packages()).unwrap();
 
         assert_eq!(packages, vec!["ax-feat".to_string(), "ax-hal".to_string()]);
     }
@@ -190,7 +191,7 @@ mod tests {
     #[test]
     fn parses_std_csv_with_blank_lines() {
         let packages =
-            parse_std_crates_csv("\npackage\n\naxfeat\n\naxhal\n", &known_packages()).unwrap();
+            parse_std_crates_csv("\npackage\n\nax-feat\n\nax-hal\n", &known_packages()).unwrap();
 
         assert_eq!(packages, vec!["ax-feat".to_string(), "ax-hal".to_string()]);
     }
@@ -204,7 +205,7 @@ mod tests {
 
     #[test]
     fn rejects_invalid_header() {
-        let err = parse_std_crates_csv("crate\naxfeat\n", &known_packages()).unwrap_err();
+        let err = parse_std_crates_csv("crate\nax-feat\n", &known_packages()).unwrap_err();
 
         assert!(err.to_string().contains("invalid header"));
     }
@@ -221,7 +222,8 @@ mod tests {
 
     #[test]
     fn rejects_duplicate_package() {
-        let err = parse_std_crates_csv("package\naxfeat\naxfeat\n", &known_packages()).unwrap_err();
+        let err =
+            parse_std_crates_csv("package\nax-feat\nax-feat\n", &known_packages()).unwrap_err();
 
         assert!(err.to_string().contains("duplicate package `ax-feat`"));
     }

--- a/test-suit/starryos/qemu-aarch64.toml
+++ b/test-suit/starryos/qemu-aarch64.toml
@@ -7,7 +7,7 @@ args = [
     "-drive",
     "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
     "-device",
-    "virtio-net-pci,netdev=net0",
+    "e1000,netdev=net0",
     "-netdev",
     "user,id=net0",
 ]


### PR DESCRIPTION
## Summary
- add and wire `axplat-dyn` support into the workspace and Starry build flow
- switch the network device path toward Intel `e1000`/`intel-net` support where this branch expects it
- update the workspace `dma-api` dependency to `0.7.2` and align related build/test expectations

## Why
This branch combines the `axplat-dyn` integration work with the network driver updates it depends on, then follows through with the `dma-api` upgrade and the corresponding workspace/build-script adjustments. Rebasing onto the latest `dev` also required refreshing the `axbuild` tests so the branch validates against the current defaults.

## Impact
- Starry and `axbuild` now understand the updated feature/layout expected by this branch.
- `axplat-dyn` gains the Intel network driver path introduced here.
- The root workspace resolves the intended `dma-api` version on the main dependency path.

## Validation
- `cargo fmt --check`
- `cargo clippy -p axbuild --all-features -- -D warnings`
- `cargo clippy -p axplat-dyn --features intel-net --target x86_64-unknown-none --no-deps -- -D warnings`
- `cargo test -p axbuild --all-features`
