### PR TITLE
add virtio-net-pci support and align StarryOS qemu features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@
 - Run `cargo fmt` after code edits.
 - For ArceOS, StarryOS, and Axvisor builds/tests/runs, prefer the `cargo xtask` command family instead of raw `cargo build`, `cargo test`, or `cargo run`.
 - If `cargo xtask` cannot satisfy a special configuration, inspect the `xtask` flow first and only then fall back to native Cargo commands with manually matched arguments.
+- For PRs, issues, review replies, discussions, and similar project-facing submissions, keep the language neutral and project-focused.
+- Do not insert agent-related labels, signatures, branding, or other advertisement-style wording such as `codex`, `agent`, `AI`, or similar self-promotional tags unless the user explicitly requests it.
 
 - `update-std-tests`: project-local skill at `.claude/skills/update-std-tests/SKILL.md`
 - Use `update-std-tests` when the user wants to audit or update `scripts/test/std_crates.csv`, compare workspace packages against the std test whitelist, or confirm which new std-test candidates should be added.

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -26,10 +26,11 @@ qemu = [
   "ax-feat/display",
   "starry-kernel/input",
   "starry-kernel/vsock", # auxilary features
-  "axplat-dyn/intel-net",
-  "axplat-dyn/virtio-net-pci",
+  "axplat-dyn?/irq",
+  "axplat-dyn?/intel-net",
+  "axplat-dyn?/virtio-net-pci",
 ]
-smp = ["ax-feat/smp", "axplat-riscv64-visionfive2?/smp"]
+smp = ["ax-feat/smp", "axplat-dyn/smp", "axplat-riscv64-visionfive2?/smp"]
 
 vf2 = ["common", "dep:axplat-riscv64-visionfive2", "ax-feat/driver-sdmmc"]
 

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -27,6 +27,7 @@ qemu = [
   "starry-kernel/input",
   "starry-kernel/vsock", # auxilary features
   "axplat-dyn/intel-net",
+  "axplat-dyn/virtio-net-pci",
 ]
 smp = ["ax-feat/smp", "axplat-riscv64-visionfive2?/smp"]
 

--- a/os/arceos/modules/axdriver/Cargo.toml
+++ b/os/arceos/modules/axdriver/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 [features]
 bus-mmio = []
 bus-pci = ["dep:ax-driver-pci", "dep:ax-hal", "dep:ax-config"]
-net = ["dep:ax-driver-net", "axplat-dyn?/intel-net"]
+net = ["dep:ax-driver-net", "axplat-dyn?/net"]
 block = ["dep:ax-driver-block"]
 display = ["dep:ax-driver-display"]
 input = ["dep:ax-driver-input"]

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -22,7 +22,9 @@ sdmmc = ["dep:sdmmc"]
 rockchip-pm = ["dep:rockchip-pm"]
 phytium-blk = ["dep:phytium-mci"]
 serial = ["dep:some-serial"]
-intel-net = ["dep:ax-driver-net", "dep:eth-intel", "dep:pcie", "dep:rd-net"]
+net = ["dep:ax-driver-net", "dep:rd-net"]
+intel-net = ["net", "dep:eth-intel", "dep:pcie"]
+virtio-net-pci = ["net"]
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
@@ -32,7 +34,7 @@ ax-cpu.workspace = true
 ax-driver-base.workspace = true
 ax-driver-block.workspace = true
 ax-driver-net = { workspace = true, optional = true }
-ax-driver-virtio = { workspace = true, features = ["block"] }
+ax-driver-virtio = { workspace = true, features = ["block", "net"] }
 ax-errno.workspace = true
 axklib.workspace = true
 ax-plat.workspace = true

--- a/platform/axplat-dyn/src/drivers/blk/virtio.rs
+++ b/platform/axplat-dyn/src/drivers/blk/virtio.rs
@@ -1,19 +1,17 @@
 extern crate alloc;
 
 use alloc::format;
-use core::{marker::PhantomData, ptr::NonNull};
 
-use ax_alloc::{UsageKind, global_allocator};
 use ax_driver_base::DeviceType;
 use ax_driver_block::BlockDriverOps;
-use ax_driver_virtio::{BufferDirection, PhysAddr as VirtIoPhysAddr, Transport, VirtIoHal};
+use ax_driver_virtio::Transport;
 use ax_plat::mem::PhysAddr;
 use rdrive::{
     DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
 };
 
 use super::PlatformDeviceBlock;
-use crate::drivers::iomap;
+use crate::drivers::{iomap, virtio::VirtIoHalImpl};
 
 pub(super) type VirtIoBlkDevice<T> = ax_driver_virtio::VirtIoBlkDev<VirtIoHalImpl, T>;
 
@@ -171,41 +169,5 @@ fn map_dev_err_to_blk_err(err: ax_driver_base::DevError) -> rd_block::BlkError {
         ax_driver_base::DevError::NoMemory => rd_block::BlkError::NoMemory,
         ax_driver_base::DevError::ResourceBusy => rd_block::BlkError::Other("Resource busy".into()),
         ax_driver_base::DevError::Unsupported => rd_block::BlkError::NotSupported,
-    }
-}
-
-pub(super) struct VirtIoHalImpl(PhantomData<()>);
-
-unsafe impl VirtIoHal for VirtIoHalImpl {
-    fn dma_alloc(pages: usize, _direction: BufferDirection) -> (VirtIoPhysAddr, NonNull<u8>) {
-        let vaddr = if let Ok(vaddr) = global_allocator().alloc_pages(pages, 0x1000, UsageKind::Dma)
-        {
-            vaddr
-        } else {
-            return (0, NonNull::dangling());
-        };
-        let paddr = somehal::mem::virt_to_phys(vaddr as *mut u8) as VirtIoPhysAddr;
-        let ptr = NonNull::new(vaddr as _).unwrap();
-        (paddr, ptr)
-    }
-
-    unsafe fn dma_dealloc(_paddr: VirtIoPhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
-        global_allocator().dealloc_pages(vaddr.as_ptr() as usize, pages, UsageKind::Dma);
-        0
-    }
-
-    #[inline]
-    unsafe fn mmio_phys_to_virt(paddr: VirtIoPhysAddr, size: usize) -> NonNull<u8> {
-        iomap((paddr as usize).into(), size).expect("failed to map virtio MMIO region")
-    }
-
-    #[inline]
-    unsafe fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> VirtIoPhysAddr {
-        let vaddr = buffer.as_ptr() as *mut u8 as usize;
-        somehal::mem::virt_to_phys(vaddr as *mut u8) as VirtIoPhysAddr
-    }
-
-    #[inline]
-    unsafe fn unshare(_paddr: VirtIoPhysAddr, _buffer: NonNull<[u8]>, _direction: BufferDirection) {
     }
 }

--- a/platform/axplat-dyn/src/drivers/mod.rs
+++ b/platform/axplat-dyn/src/drivers/mod.rs
@@ -4,7 +4,7 @@ use alloc::boxed::Box;
 use core::{alloc::Layout, ptr::NonNull};
 
 use ax_driver_block::BlockDriverOps;
-#[cfg(feature = "intel-net")]
+#[cfg(feature = "net")]
 use ax_driver_net::NetDriverOps;
 use ax_errno::AxError;
 use ax_memory_addr::PAGE_SIZE_4K;
@@ -17,21 +17,22 @@ mod pci;
 #[cfg(feature = "serial")]
 mod serial;
 mod soc;
+mod virtio;
 
 pub mod blk;
-#[cfg(feature = "intel-net")]
+#[cfg(feature = "net")]
 pub mod net;
 
 const MAX_BLOCK_DEVICES: usize = 16;
-#[cfg(feature = "intel-net")]
+#[cfg(feature = "net")]
 const MAX_NET_DEVICES: usize = 16;
 
 pub type DynBlockDevice = Box<dyn BlockDriverOps>;
-#[cfg(feature = "intel-net")]
+#[cfg(feature = "net")]
 pub type DynNetDevice = Box<dyn NetDriverOps>;
 
 static BLOCK_DEVICES: Mutex<Vec<DynBlockDevice, MAX_BLOCK_DEVICES>> = Mutex::new(Vec::new());
-#[cfg(feature = "intel-net")]
+#[cfg(feature = "net")]
 static NET_DEVICES: Mutex<Vec<DynNetDevice, MAX_NET_DEVICES>> = Mutex::new(Vec::new());
 
 pub fn clear_block_devices() {
@@ -47,17 +48,17 @@ pub fn take_block_devices() -> Vec<DynBlockDevice, MAX_BLOCK_DEVICES> {
     core::mem::take(&mut *devices)
 }
 
-#[cfg(feature = "intel-net")]
+#[cfg(feature = "net")]
 pub fn clear_net_devices() {
     NET_DEVICES.lock().clear();
 }
 
-#[cfg(feature = "intel-net")]
+#[cfg(feature = "net")]
 pub fn register_net_device(device: DynNetDevice) -> Result<(), DynNetDevice> {
     NET_DEVICES.lock().push(device)
 }
 
-#[cfg(feature = "intel-net")]
+#[cfg(feature = "net")]
 pub fn take_net_devices() -> Vec<DynNetDevice, MAX_NET_DEVICES> {
     let mut devices = NET_DEVICES.lock();
     core::mem::take(&mut *devices)
@@ -75,7 +76,7 @@ pub(crate) fn iomap(addr: PhysAddr, size: usize) -> Result<NonNull<u8>, OnProbeE
 
 pub fn probe_all_devices() -> Result<(), AxError> {
     clear_block_devices();
-    #[cfg(feature = "intel-net")]
+    #[cfg(feature = "net")]
     clear_net_devices();
     rdrive::probe_all(true).map_err(|_| AxError::BadState)?;
 
@@ -86,13 +87,24 @@ pub fn probe_all_devices() -> Result<(), AxError> {
         }
     }
 
-    #[cfg(feature = "intel-net")]
+    #[cfg(feature = "net")]
     for dev in rdrive::get_list::<net::PlatformNetDevice>() {
         let net = net::Net::try_from(dev).map_err(|err| match err {
             ax_driver_base::DevError::NoMemory => AxError::NoMemory,
             _ => AxError::BadState,
         })?;
         if register_net_device(Box::new(net)).is_err() {
+            return Err(AxError::NoMemory);
+        }
+    }
+
+    #[cfg(feature = "net")]
+    for dev in rdrive::get_list::<net::PlatformNetDriver>() {
+        let net = net::take_net_driver(dev).map_err(|err| match err {
+            ax_driver_base::DevError::NoMemory => AxError::NoMemory,
+            _ => AxError::BadState,
+        })?;
+        if register_net_device(net).is_err() {
             return Err(AxError::NoMemory);
         }
     }

--- a/platform/axplat-dyn/src/drivers/net/intel.rs
+++ b/platform/axplat-dyn/src/drivers/net/intel.rs
@@ -8,8 +8,10 @@ use rdrive::{
     },
 };
 
-use super::{DRIVER_NAME, PlatformDeviceNet};
+use super::PlatformDeviceNet;
 use crate::{boot::Kernel, drivers::DmaImpl};
+
+const DRIVER_NAME: &str = "eth-intel-e1000";
 
 module_driver!(
     name: "Intel E1000 PCI Network",

--- a/platform/axplat-dyn/src/drivers/net/mod.rs
+++ b/platform/axplat-dyn/src/drivers/net/mod.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use alloc::{collections::VecDeque, sync::Arc};
+use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
 
 use ax_driver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 use ax_driver_net::{EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps};
@@ -12,8 +12,9 @@ use super::DmaImpl;
 
 #[cfg(feature = "intel-net")]
 mod intel;
+#[cfg(feature = "virtio-net-pci")]
+mod virtio_pci;
 
-const DRIVER_NAME: &str = "eth-intel-e1000";
 const NET_BUF_LEN: usize = 2048;
 const NET_BUF_POOL_CAPACITY: usize = 512;
 const NET_QUEUE_SIZE: usize = 256;
@@ -31,6 +32,17 @@ impl PlatformNetDevice {
 }
 
 impl DriverGeneric for PlatformNetDevice {
+    fn name(&self) -> &str {
+        self.name
+    }
+}
+
+pub struct PlatformNetDriver {
+    name: &'static str,
+    dev: Option<Box<dyn NetDriverOps>>,
+}
+
+impl DriverGeneric for PlatformNetDriver {
     fn name(&self) -> &str {
         self.name
     }
@@ -219,6 +231,31 @@ impl PlatformDeviceNet for rdrive::PlatformDevice {
     }
 }
 
+pub trait PlatformDeviceNetDriver {
+    fn register_net_driver<T>(self, name: &'static str, dev: T)
+    where
+        T: NetDriverOps + 'static;
+}
+
+impl PlatformDeviceNetDriver for rdrive::PlatformDevice {
+    fn register_net_driver<T>(self, name: &'static str, dev: T)
+    where
+        T: NetDriverOps + 'static,
+    {
+        self.register(PlatformNetDriver {
+            name,
+            dev: Some(Box::new(dev)),
+        });
+    }
+}
+
+pub(super) fn take_net_driver(
+    device: Device<PlatformNetDriver>,
+) -> Result<Box<dyn NetDriverOps>, DevError> {
+    let mut dev = device.lock().map_err(map_device_err_to_dev_err)?;
+    dev.dev.take().ok_or(DevError::BadState)
+}
+
 fn map_net_err_to_dev_err(err: NetError) -> DevError {
     match err {
         NetError::Retry => DevError::Again,
@@ -231,6 +268,3 @@ fn map_net_err_to_dev_err(err: NetError) -> DevError {
 fn map_device_err_to_dev_err(_err: rdrive::GetDeviceError) -> DevError {
     DevError::BadState
 }
-
-#[allow(dead_code)]
-const _: &str = DRIVER_NAME;

--- a/platform/axplat-dyn/src/drivers/net/virtio_pci.rs
+++ b/platform/axplat-dyn/src/drivers/net/virtio_pci.rs
@@ -15,11 +15,14 @@ use rdrive::{
 };
 use spin::Mutex;
 
-use super::virtio::{VirtIoBlkDevice, register_virtio_block};
+use super::PlatformDeviceNetDriver;
 use crate::drivers::virtio::VirtIoHalImpl;
 
+const DRIVER_NAME: &str = "virtio-net-pci";
+type VirtIoNetDevice<T> = ax_driver_virtio::VirtIoNetDev<VirtIoHalImpl, T, 64>;
+
 module_driver!(
-    name: "Virtio PCI Block",
+    name: "Virtio PCI Network",
     level: ProbeLevel::PostKernel,
     priority: ProbePriority::DEFAULT,
     probe_kinds: &[ProbeKind::Pci { on_probe: probe }],
@@ -27,7 +30,7 @@ module_driver!(
 
 fn probe(endpoint: &mut EndpointRc, plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
     match (endpoint.vendor_id(), endpoint.device_id()) {
-        (0x1af4, 0x1001 | 0x1042) => {}
+        (0x1af4, 0x1000 | 0x1041) => {}
         _ => return Err(OnProbeError::NotMatch),
     }
 
@@ -35,22 +38,22 @@ fn probe(endpoint: &mut EndpointRc, plat_dev: PlatformDevice) -> Result<(), OnPr
     let dev_info = as_device_function_info(endpoint);
     let mut root = PciRoot::new(EndpointConfigAccess::new(bdf, endpoint.take()));
 
-    let (ty, transport, _irq) =
+    let (ty, transport, irq) =
         ax_driver_virtio::probe_pci_device::<VirtIoHalImpl, _>(&mut root, bdf, &dev_info)
             .ok_or(OnProbeError::NotMatch)?;
 
-    if ty != DeviceType::Block {
+    if ty != DeviceType::Net {
         return Err(OnProbeError::NotMatch);
     }
 
-    let dev = VirtIoBlkDevice::try_new(transport).map_err(|err| {
+    let dev = VirtIoNetDevice::try_new(transport, Some(irq)).map_err(|err| {
         OnProbeError::other(format!(
-            "failed to initialize Virtio PCI block device at {bdf}: {err:?}"
+            "failed to initialize Virtio PCI network device at {bdf}: {err:?}"
         ))
     })?;
 
-    register_virtio_block(plat_dev, dev);
-    debug!("virtio PCI block device registered successfully at {bdf}");
+    plat_dev.register_net_driver(DRIVER_NAME, dev);
+    debug!("virtio PCI network device registered successfully at {bdf}");
     Ok(())
 }
 

--- a/platform/axplat-dyn/src/drivers/virtio.rs
+++ b/platform/axplat-dyn/src/drivers/virtio.rs
@@ -1,0 +1,42 @@
+use core::{marker::PhantomData, ptr::NonNull};
+
+use ax_alloc::{UsageKind, global_allocator};
+use ax_driver_virtio::{BufferDirection, PhysAddr as VirtIoPhysAddr, VirtIoHal};
+
+use crate::drivers::iomap;
+
+pub(crate) struct VirtIoHalImpl(PhantomData<()>);
+
+unsafe impl VirtIoHal for VirtIoHalImpl {
+    fn dma_alloc(pages: usize, _direction: BufferDirection) -> (VirtIoPhysAddr, NonNull<u8>) {
+        let vaddr = if let Ok(vaddr) = global_allocator().alloc_pages(pages, 0x1000, UsageKind::Dma)
+        {
+            vaddr
+        } else {
+            return (0, NonNull::dangling());
+        };
+        let paddr = somehal::mem::virt_to_phys(vaddr as *mut u8) as VirtIoPhysAddr;
+        let ptr = NonNull::new(vaddr as _).unwrap();
+        (paddr, ptr)
+    }
+
+    unsafe fn dma_dealloc(_paddr: VirtIoPhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
+        global_allocator().dealloc_pages(vaddr.as_ptr() as usize, pages, UsageKind::Dma);
+        0
+    }
+
+    #[inline]
+    unsafe fn mmio_phys_to_virt(paddr: VirtIoPhysAddr, size: usize) -> NonNull<u8> {
+        iomap((paddr as usize).into(), size).expect("failed to map virtio MMIO region")
+    }
+
+    #[inline]
+    unsafe fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> VirtIoPhysAddr {
+        let vaddr = buffer.as_ptr() as *mut u8 as usize;
+        somehal::mem::virt_to_phys(vaddr as *mut u8) as VirtIoPhysAddr
+    }
+
+    #[inline]
+    unsafe fn unshare(_paddr: VirtIoPhysAddr, _buffer: NonNull<[u8]>, _direction: BufferDirection) {
+    }
+}

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -171,7 +171,7 @@ fn qemu_args_for_disk_image(disk_img: PathBuf) -> anyhow::Result<Vec<String>> {
         "-drive".to_string(),
         format!("id=disk0,if=none,format=raw,file={}", disk_img.display()),
         "-device".to_string(),
-        "e1000,netdev=net0".to_string(),
+        "virtio-net-pci,netdev=net0".to_string(),
         "-netdev".to_string(),
         "user,id=net0".to_string(),
     ])
@@ -286,7 +286,7 @@ mod tests {
                         .display()
                 ),
                 "-device".to_string(),
-                "e1000,netdev=net0".to_string(),
+                "virtio-net-pci,netdev=net0".to_string(),
                 "-netdev".to_string(),
                 "user,id=net0".to_string(),
             ]

--- a/test-suit/starryos/qemu-aarch64.toml
+++ b/test-suit/starryos/qemu-aarch64.toml
@@ -7,7 +7,7 @@ args = [
     "-drive",
     "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
     "-device",
-    "e1000,netdev=net0",
+    "virtio-net-pci,netdev=net0",
     "-netdev",
     "user,id=net0",
 ]


### PR DESCRIPTION
## What changed

This PR adds `virtio-net-pci` support for `axplat-dyn` and switches the default StarryOS QEMU network configuration back to VirtIO.

It also aligns StarryOS feature wiring so `axplat-dyn` receives the expected `irq` and `smp` features under the `aarch64-unknown-none-softfloat` QEMU configuration.

## Why

There were two related issues:

1. `axplat-dyn` only had Intel PCI NIC support in the dynamic platform path, while the test and QEMU defaults were moving back to `virtio-net-pci`.
2. Rust Analyzer / `cargo check` on `aarch64-unknown-none-softfloat` exposed a feature mismatch where `ax_plat`'s IRQ-related trait requirements were enabled, but the direct `axplat-dyn` dependency in StarryOS had not enabled its local `irq` feature.

## Impact

- `axplat-dyn` can now probe and register `virtio-net-pci` devices.
- StarryOS QEMU defaults use `virtio-net-pci` again.
- The previous `ConsoleIf` / `TimeIf` trait-item-missing diagnostics for the aarch64 QEMU target are resolved by feature alignment.

## Root cause

The root cause of the Rust Analyzer / `cargo check` issue was feature misalignment on the direct `axplat-dyn` dependency in StarryOS. The implementation already existed in `axplat-dyn`; the necessary local feature was simply not being enabled from the StarryOS side.

## Validation

- `cargo fmt --all`
- `cargo clippy -p axplat-dyn --target x86_64-unknown-none --features "intel-net,virtio-net-pci"`
- `cargo clippy -p axplat-dyn --target aarch64-unknown-none-softfloat --features "intel-net,virtio-net-pci"`
- `cargo clippy -p axbuild`
- `cargo test -p axbuild default_qemu_args_include_rootfs_and_network_defaults`
- `cargo tree -p starryos --target aarch64-unknown-none-softfloat --features qemu -e features -i axplat-dyn`

Additional note:

- `cargo check -p starryos --target aarch64-unknown-none-softfloat --features qemu`
  no longer fails on the earlier `ConsoleIf` / `TimeIf` trait-item-missing errors. It now proceeds to a separate downstream blocker: `#[ax_alloc_virt_to_phys_impl] required, but not found`.
