### PR TITLE
fix(arm_vcpu): restore host irq state around guest run

### DIFF
--- a/components/arm_vcpu/src/vcpu.rs
+++ b/components/arm_vcpu/src/vcpu.rs
@@ -117,6 +117,10 @@ impl axvcpu::AxArchVCpu for Aarch64VCpu {
     }
 
     fn run(&mut self) -> AxResult<AxVCpuExitReason> {
+        unsafe {
+            core::arch::asm!("msr daifset, #2");
+        }
+
         // Run guest.
         let exit_reson = unsafe {
             // Save host SP_EL0 to the ctx becase it's used as current task ptr.
@@ -125,6 +129,10 @@ impl axvcpu::AxArchVCpu for Aarch64VCpu {
             self.restore_vm_system_regs();
             self.run_guest()
         };
+
+        unsafe {
+            core::arch::asm!("msr daifclr, #2");
+        }
 
         let trap_kind = TrapKind::try_from(exit_reson as u8).expect("Invalid TrapKind");
         self.vmexit_handler(trap_kind)


### PR DESCRIPTION
AArch64 guest entry/exit did not explicitly maintain the host IRQ mask state. After VM-exit, host execution could continue with IRQs still masked. This became visible after the `axtask::might_sleep()` check introduced in #152, where host task-exit paths may panic in IRQ-disabled context.

This change makes the transition explicit, following the existing `riscv_vcpu` handling:
- mask host IRQs before entering the guest
- restore host IRQs after VM-exit
This keeps guest entry protected as a critical section and ensures host execution resumes with the expected IRQ state