### PR TITLE
feat(loongarch64): bring axvisor integration onto latest dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9646,27 +9646,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "ax-crate-interface-lite"
-version = "0.3.0"
-
-[[patch.unused]]
-name = "define-simple-traits"
-version = "0.3.0"
-
-[[patch.unused]]
-name = "define-weak-traits"
-version = "0.3.0"
-
-[[patch.unused]]
-name = "impl-simple-traits"
-version = "0.3.0"
-
-[[patch.unused]]
-name = "impl-weak-partial"
-version = "0.3.0"
-
-[[patch.unused]]
-name = "impl-weak-traits"
-version = "0.3.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,6 +1841,7 @@ dependencies = [
  "ax-page-table-entry",
  "ax-page-table-multiarch",
  "ax-percpu",
+ "ax-plat-loongarch64-qemu-virt",
  "ax-plat-riscv64-qemu-virt 0.5.0",
  "ax-std",
  "ax-timer-list",
@@ -1917,6 +1918,7 @@ dependencies = [
  "axvmconfig",
  "cfg-if",
  "log",
+ "loongarch_vcpu",
  "riscv_vcpu",
  "spin 0.10.0",
  "x86_vcpu",
@@ -4842,6 +4844,18 @@ checksum = "7c9f0d275c70310e2a9d2fc23250c5ac826a73fa828a5f256401f85c5c554283"
 dependencies = [
  "bit_field",
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "loongarch_vcpu"
+version = "0.5.0"
+dependencies = [
+ "ax-errno",
+ "ax-percpu",
+ "axaddrspace",
+ "axvcpu",
+ "log",
+ "spin 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,6 @@ ax-page-table-multiarch = { path = "components/page_table_multiarch/page_table_m
 
 # === crate_interface ===
 ax-crate-interface = { path = "components/crate_interface" }
-ax-crate-interface-lite = { path = "components/crate_interface/crate_interface_lite" }
 
 # === ax-ctor-bare ===
 ax-ctor-bare = { path = "components/ctor_bare/ctor_bare" }
@@ -288,11 +287,6 @@ ax-config-macros = { path = "components/axconfig-gen/axconfig-macros" }
 # === drivers ===
 # fxmac_rs = { path = "components/fxmac_rs", version = "0.2.1" }
 
-define-simple-traits = { path = "components/crate_interface/test_crates/define-simple-traits" }
-define-weak-traits = { path = "components/crate_interface/test_crates/define-weak-traits" }
-impl-simple-traits = { path = "components/crate_interface/test_crates/impl-simple-traits" }
-impl-weak-partial = { path = "components/crate_interface/test_crates/impl-weak-partial" }
-impl-weak-traits = { path = "components/crate_interface/test_crates/impl-weak-traits" }
 [workspace.dependencies]
 # === os/arceos crates (0.3.0-preview.3) ===
 # ulib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ members = [
 exclude = [
     # workspace directories
     "components/axplat_crates",
+    "components/loongarch_vcpu",
     "os/arceos",
     "os/StarryOS",
     "components/percpu",
@@ -203,6 +204,7 @@ ax-plat-loongarch64-qemu-virt = { path = "components/axplat_crates/platforms/axp
 ax-plat-riscv64-qemu-virt = { path = "components/axplat_crates/platforms/axplat-riscv64-qemu-virt" }
 ax-plat-x86-pc = { path = "components/axplat_crates/platforms/axplat-x86-pc" }
 axplat-x86-qemu-q35 = { path = "platform/x86-qemu-q35" }
+loongarch_vcpu = { path = "components/loongarch_vcpu" }
 
 axplat-dyn = { path = "platform/axplat-dyn" }
 

--- a/components/axaddrspace/src/npt/arch/loongarch64.rs
+++ b/components/axaddrspace/src/npt/arch/loongarch64.rs
@@ -1,0 +1,184 @@
+use core::{arch::asm, fmt};
+
+use ax_page_table_entry::{GenericPTE, MappingFlags};
+use ax_page_table_multiarch::PagingMetaData;
+
+use crate::{GuestPhysAddr, HostPhysAddr};
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct LoongArchPTE(u64);
+
+impl LoongArchPTE {
+    const PHYS_ADDR_MASK: u64 = 0x0000_ffff_ffff_f000;
+
+    const VALID: u64 = 1 << 0;
+    const DIRTY: u64 = 1 << 1;
+    const PLV_MASK: u64 = 0b11 << 3;
+    const MAT_SHIFT: u64 = 5;
+    const MAT_MASK: u64 = 0b11 << 5;
+    const GLOBAL: u64 = 1 << 7;
+    const PS_SHIFT: u64 = 8;
+    const PS_MASK: u64 = 0b111 << 8;
+
+    const MAT_STRONG_UNORDERED: u64 = 0b00 << Self::MAT_SHIFT;
+    const MAT_COHERENT_CACHED: u64 = 0b01 << Self::MAT_SHIFT;
+    const MAT_WEAK_UNORDERED: u64 = 0b10 << Self::MAT_SHIFT;
+    const MAT_WEAK_UNORDERED_EXEC: u64 = 0b11 << Self::MAT_SHIFT;
+
+    const PS_4K: u64 = 0b000 << Self::PS_SHIFT;
+    const PS_1M: u64 = 0b100 << Self::PS_SHIFT;
+}
+
+impl GenericPTE for LoongArchPTE {
+    fn bits(self) -> usize {
+        self.0 as usize
+    }
+
+    fn new_page(paddr: HostPhysAddr, flags: MappingFlags, is_huge: bool) -> Self {
+        let mut pte_value = paddr.as_usize() as u64 & Self::PHYS_ADDR_MASK;
+        pte_value |= Self::VALID;
+        pte_value |= Self::PLV_MASK;
+        pte_value |= Self::GLOBAL;
+
+        if flags.contains(MappingFlags::WRITE) {
+            pte_value |= Self::DIRTY;
+        }
+
+        if flags.contains(MappingFlags::DEVICE) {
+            pte_value |= Self::MAT_STRONG_UNORDERED;
+        } else if flags.contains(MappingFlags::UNCACHED) {
+            pte_value |= Self::MAT_WEAK_UNORDERED;
+        } else {
+            pte_value |= Self::MAT_COHERENT_CACHED;
+        }
+
+        pte_value |= if is_huge { Self::PS_1M } else { Self::PS_4K };
+
+        if flags.contains(MappingFlags::EXECUTE)
+            && (pte_value & Self::MAT_MASK) == Self::MAT_STRONG_UNORDERED
+        {
+            pte_value = (pte_value & !Self::MAT_MASK) | Self::MAT_WEAK_UNORDERED_EXEC;
+        }
+
+        Self(pte_value)
+    }
+
+    fn new_table(paddr: HostPhysAddr) -> Self {
+        Self(
+            (paddr.as_usize() as u64 & Self::PHYS_ADDR_MASK)
+                | Self::VALID
+                | Self::DIRTY
+                | Self::PLV_MASK
+                | Self::GLOBAL
+                | Self::MAT_COHERENT_CACHED
+                | Self::PS_4K,
+        )
+    }
+
+    fn paddr(&self) -> HostPhysAddr {
+        HostPhysAddr::from((self.0 & Self::PHYS_ADDR_MASK) as usize)
+    }
+
+    fn flags(&self) -> MappingFlags {
+        let mut flags = MappingFlags::empty();
+
+        if self.0 & Self::VALID != 0 {
+            flags |= MappingFlags::READ;
+        }
+        if self.0 & Self::DIRTY != 0 {
+            flags |= MappingFlags::WRITE;
+        }
+
+        let mat = self.0 & Self::MAT_MASK;
+        if mat == Self::MAT_COHERENT_CACHED || mat == Self::MAT_WEAK_UNORDERED_EXEC {
+            flags |= MappingFlags::EXECUTE;
+        }
+        if mat == Self::MAT_STRONG_UNORDERED {
+            flags |= MappingFlags::DEVICE;
+        }
+        if mat == Self::MAT_WEAK_UNORDERED {
+            flags |= MappingFlags::UNCACHED;
+        }
+
+        flags
+    }
+
+    fn set_paddr(&mut self, paddr: HostPhysAddr) {
+        self.0 =
+            (self.0 & !Self::PHYS_ADDR_MASK) | (paddr.as_usize() as u64 & Self::PHYS_ADDR_MASK);
+    }
+
+    fn set_flags(&mut self, flags: MappingFlags, is_huge: bool) {
+        let paddr = self.0 & Self::PHYS_ADDR_MASK;
+        *self = Self::new_page(HostPhysAddr::from(paddr as usize), flags, is_huge);
+    }
+
+    fn is_unused(&self) -> bool {
+        self.0 == 0
+    }
+
+    fn is_present(&self) -> bool {
+        self.0 & Self::VALID != 0
+    }
+
+    fn is_huge(&self) -> bool {
+        (self.0 & Self::PS_MASK) >= Self::PS_1M
+    }
+
+    fn clear(&mut self) {
+        self.0 = 0;
+    }
+}
+
+impl fmt::Debug for LoongArchPTE {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut f = f.debug_struct("LoongArchPTE");
+        f.field("raw", &self.0)
+            .field("paddr", &self.paddr())
+            .field("flags", &self.flags())
+            .field("is_huge", &self.is_huge())
+            .finish()
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct LoongArchPagingMetaDataL3;
+
+impl PagingMetaData for LoongArchPagingMetaDataL3 {
+    const LEVELS: usize = 3;
+    const VA_MAX_BITS: usize = 39;
+    const PA_MAX_BITS: usize = 48;
+
+    type VirtAddr = GuestPhysAddr;
+
+    fn flush_tlb(vaddr: Option<Self::VirtAddr>) {
+        unsafe {
+            let gstat: usize;
+            asm!("csrrd {}, 0x50", out(reg) gstat);
+            let gid = (gstat >> 16) & 0xff;
+
+            if let Some(vaddr) = vaddr {
+                asm!("invtlb 0x7, {0}, {1}", in(reg) gid, in(reg) vaddr.as_usize());
+            } else {
+                asm!("invtlb 0x6, {0}, $r0", in(reg) gid);
+            }
+            asm!("dbar 0");
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct LoongArchPagingMetaDataL4;
+
+impl PagingMetaData for LoongArchPagingMetaDataL4 {
+    const LEVELS: usize = 4;
+    const VA_MAX_BITS: usize = 48;
+    const PA_MAX_BITS: usize = 48;
+
+    type VirtAddr = GuestPhysAddr;
+
+    fn flush_tlb(vaddr: Option<Self::VirtAddr>) {
+        LoongArchPagingMetaDataL3::flush_tlb(vaddr);
+    }
+}

--- a/components/axaddrspace/src/npt/arch/mod.rs
+++ b/components/axaddrspace/src/npt/arch/mod.rs
@@ -24,5 +24,8 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))] {
         mod riscv;
         pub use self::riscv::*;
+    } else if #[cfg(target_arch = "loongarch64")] {
+        mod loongarch64;
+        pub use self::loongarch64::*;
     }
 }

--- a/components/axaddrspace/src/npt/mod.rs
+++ b/components/axaddrspace/src/npt/mod.rs
@@ -35,6 +35,12 @@ cfg_if::cfg_if! {
 
         /// AArch64 Level 4 nested page table type alias.
         pub type NestedPageTableL4<H> = ax_page_table_multiarch::PageTable64<arch::A64HVPagingMetaDataL4, arch::A64PTEHV, H>;
+    } else if #[cfg(target_arch = "loongarch64")] {
+        /// LoongArch Level 3 nested page table type alias.
+        pub type NestedPageTableL3<H> = ax_page_table_multiarch::PageTable64<arch::LoongArchPagingMetaDataL3, arch::LoongArchPTE, H>;
+
+        /// LoongArch Level 4 nested page table type alias.
+        pub type NestedPageTableL4<H> = ax_page_table_multiarch::PageTable64<arch::LoongArchPagingMetaDataL4, arch::LoongArchPTE, H>;
     }
 }
 

--- a/components/axcpu/src/lib.rs
+++ b/components/axcpu/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![feature(extern_item_impls)]
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 

--- a/components/axcpu/src/loongarch64/init.rs
+++ b/components/axcpu/src/loongarch64/init.rs
@@ -2,7 +2,7 @@
 
 use ax_memory_addr::PhysAddr;
 use ax_page_table_multiarch::loongarch64::LA64MetaData;
-use loongArch64::register::{crmd, stlbps, tlbidx, tlbrehi, tlbrentry};
+use loongArch64::register::{MemoryAccessType, crmd, stlbps, tlbidx, tlbrehi, tlbrentry};
 
 /// Initializes TLB and MMU related registers on the current CPU.
 ///
@@ -32,7 +32,9 @@ pub fn init_mmu(root_paddr: PhysAddr, phys_virt_offset: usize) {
     }
     crate::asm::flush_tlb(None);
 
-    // Enable mapped address translation mode
+    crmd::set_da(false);
+    crmd::set_datf(MemoryAccessType::CoherentCached);
+    crmd::set_datm(MemoryAccessType::CoherentCached);
     crmd::set_pg(true);
 }
 

--- a/components/axcpu/src/loongarch64/trap.S
+++ b/components/axcpu/src/loongarch64/trap.S
@@ -86,33 +86,11 @@ handle_tlb_refill:
     csrrd   $t0, LA_CSR_PGD
 
     lddir   $t0, $t0, 3
-    beqz    $t0, .Ltlb_invalid
-
     lddir   $t0, $t0, 2
-    beqz    $t0, .Ltlb_invalid
-
     lddir   $t0, $t0, 1
-    beqz    $t0, .Ltlb_invalid
 
     ldpte   $t0, 0
     ldpte   $t0, 1
-
-    b       .Ltlb_refill
-
-.Ltlb_invalid:
-    csrrd   $t0, LA_CSR_TLBREHI
-    ori     $t0, $t0, 0xC   // 4 KiB
-    csrwr   $t0, LA_CSR_TLBREHI
-
-    rotri.d $t0, $t0, 61
-    ori     $t0, $t0, 3     // NR NX
-    rotri.d $t0, $t0, 3
-
-    csrwr   $t0, LA_CSR_TLBRELO0
-    csrrd   $t0, LA_CSR_TLBRELO0
-    csrwr   $t0, LA_CSR_TLBRELO1
-
-.Ltlb_refill:
     tlbfill
     csrrd   $t0, LA_CSR_TLBRSAVE
     ertn

--- a/components/axcpu/src/trap.rs
+++ b/components/axcpu/src/trap.rs
@@ -1,20 +1,73 @@
 //! Trap handling.
 
+use core::sync::atomic::{AtomicUsize, Ordering};
+
 use ax_memory_addr::VirtAddr;
 pub use ax_page_table_entry::MappingFlags as PageFaultFlags;
 
 pub use crate::TrapFrame;
 
-/// IRQ handler.
-#[eii]
-pub fn irq_handler(irq: usize) -> bool {
+/// IRQ trap hook type.
+pub type IrqHandler = fn(usize) -> bool;
+
+/// Page-fault trap hook type.
+pub type PageFaultHandler = fn(VirtAddr, PageFaultFlags) -> bool;
+
+fn default_irq_handler(irq: usize) -> bool {
     trace!("IRQ {} triggered", irq);
     false
 }
 
-/// Page fault handler.
-#[eii]
-pub fn page_fault_handler(addr: VirtAddr, flags: PageFaultFlags) -> bool {
+fn default_page_fault_handler(addr: VirtAddr, flags: PageFaultFlags) -> bool {
     warn!("Page fault at {:#x} with flags {:?}", addr, flags);
     false
+}
+
+static IRQ_HANDLER: AtomicUsize = AtomicUsize::new(0);
+static PAGE_FAULT_HANDLER: AtomicUsize = AtomicUsize::new(0);
+
+/// Installs the global IRQ trap hook and returns the previous one.
+pub fn set_irq_handler(handler: IrqHandler) -> IrqHandler {
+    let old = IRQ_HANDLER.swap(handler as usize, Ordering::AcqRel);
+    if old == 0 {
+        default_irq_handler
+    } else {
+        // SAFETY: the atomic only stores function pointers of type `IrqHandler`.
+        unsafe { core::mem::transmute::<usize, IrqHandler>(old) }
+    }
+}
+
+/// Installs the global page-fault trap hook and returns the previous one.
+pub fn set_page_fault_handler(handler: PageFaultHandler) -> PageFaultHandler {
+    let old = PAGE_FAULT_HANDLER.swap(handler as usize, Ordering::AcqRel);
+    if old == 0 {
+        default_page_fault_handler
+    } else {
+        // SAFETY: the atomic only stores function pointers of type `PageFaultHandler`.
+        unsafe { core::mem::transmute::<usize, PageFaultHandler>(old) }
+    }
+}
+
+/// IRQ handler.
+pub fn irq_handler(irq: usize) -> bool {
+    let handler = IRQ_HANDLER.load(Ordering::Acquire);
+    let handler = if handler == 0 {
+        default_irq_handler
+    } else {
+        // SAFETY: the atomic only stores function pointers of type `IrqHandler`.
+        unsafe { core::mem::transmute::<usize, IrqHandler>(handler) }
+    };
+    handler(irq)
+}
+
+/// Page fault handler.
+pub fn page_fault_handler(addr: VirtAddr, flags: PageFaultFlags) -> bool {
+    let handler = PAGE_FAULT_HANDLER.load(Ordering::Acquire);
+    let handler = if handler == 0 {
+        default_page_fault_handler
+    } else {
+        // SAFETY: the atomic only stores function pointers of type `PageFaultHandler`.
+        unsafe { core::mem::transmute::<usize, PageFaultHandler>(handler) }
+    };
+    handler(addr, flags)
 }

--- a/components/axplat_crates/examples/irq-kernel/src/irq.rs
+++ b/components/axplat_crates/examples/irq-kernel/src/irq.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{
     Ordering::{Acquire, Release},
 };
 
-use ax_cpu::trap::irq_handler;
+use ax_cpu::trap::set_irq_handler;
 
 const TICKS_PER_SEC: u64 = 100;
 
@@ -13,13 +13,14 @@ pub fn irq_count() -> u64 {
     IRQ_COUNTER.load(Acquire)
 }
 
-#[irq_handler]
 fn handle_irq(vector: usize) -> bool {
     ax_plat::irq::handle(vector);
     true
 }
 
 pub fn init_irq() {
+    let _ = set_irq_handler(handle_irq);
+
     fn update_timer() {
         static PERIODIC_INTERVAL_NANOS: u64 = ax_plat::time::NANOS_PER_SEC / TICKS_PER_SEC;
 

--- a/components/axplat_crates/examples/smp-kernel/src/irq.rs
+++ b/components/axplat_crates/examples/smp-kernel/src/irq.rs
@@ -1,12 +1,13 @@
-use ax_cpu::trap::irq_handler;
+use ax_cpu::trap::set_irq_handler;
 
-#[irq_handler]
 fn handle_irq(vector: usize) -> bool {
     ax_plat::irq::handle(vector);
     true
 }
 
 pub fn init_irq() {
+    let _ = set_irq_handler(handle_irq);
+
     fn update_timer() {
         // One timer interrupt per second.
         static PERIODIC_INTERVAL_NANOS: u64 = ax_plat::time::NANOS_PER_SEC;

--- a/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/boot.rs
+++ b/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/boot.rs
@@ -104,6 +104,8 @@ unsafe extern "C" fn _start() -> ! {
         bl          {enable_fp_simd}    # enable FP/SIMD instructions
         bl          {init_boot_page_table}
         bl          {init_mmu}          # setup boot page table and enable MMU
+        dbar        0
+        ibar        0
 
         # Adjust stack pointer
         li.d        $t0, {boot_to_virt}

--- a/components/axvm/Cargo.toml
+++ b/components/axvm/Cargo.toml
@@ -43,7 +43,7 @@ x86_vcpu = "0.5.0"
 riscv_vcpu = "0.5.0"
 
 [target.'cfg(target_arch = "loongarch64")'.dependencies]
-loongarch_vcpu = { git = "https://github.com/numpy1314/loongarch_vcpu.git", branch = "main" }
+loongarch_vcpu = "0.5.0"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arm_vcpu = "0.5.0"

--- a/components/axvm/Cargo.toml
+++ b/components/axvm/Cargo.toml
@@ -42,6 +42,9 @@ x86_vcpu = "0.5.0"
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 riscv_vcpu = "0.5.0"
 
+[target.'cfg(target_arch = "loongarch64")'.dependencies]
+loongarch_vcpu = { git = "https://github.com/numpy1314/loongarch_vcpu.git", branch = "main" }
+
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arm_vcpu = "0.5.0"
 arm_vgic = { version = "0.4.2", features = ["vgicv3"] }

--- a/components/axvm/src/vcpu.rs
+++ b/components/axvm/src/vcpu.rs
@@ -40,6 +40,14 @@ cfg_if::cfg_if! {
         /// RISC-V uses Sv39 (3 levels) or Sv48 (4 levels) for guest page tables.
         /// Default to 4 levels (Sv48) for maximum address space.
         pub fn max_guest_page_table_levels() -> usize { 4 }
+    } else if #[cfg(target_arch = "loongarch64")] {
+        pub use loongarch_vcpu::LoongArchPerCpu as AxVMArchPerCpuImpl;
+        pub use loongarch_vcpu::LoongArchVCpu as AxArchVCpuImpl;
+        pub use loongarch_vcpu::LoongArchVCpuCreateConfig as AxVCpuCreateConfig;
+        pub use loongarch_vcpu::has_hardware_support;
+
+        /// LoongArch guests currently use 4-level page tables.
+        pub fn max_guest_page_table_levels() -> usize { 4 }
     } else if #[cfg(target_arch = "aarch64")] {
         pub use arm_vcpu::Aarch64VCpu as AxArchVCpuImpl;
         pub use arm_vcpu::Aarch64PerCpu as AxVMArchPerCpuImpl;

--- a/components/axvm/src/vm.rs
+++ b/components/axvm/src/vm.rs
@@ -202,6 +202,11 @@ impl AxVM {
                 hart_id: vcpu_id as _,
                 dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
             };
+            #[cfg(target_arch = "loongarch64")]
+            let arch_config = AxVCpuCreateConfig {
+                cpu_id: vcpu_id,
+                dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
+            };
 
             // FIXME: VCpu is neither `Send` nor `Sync` by design, check whether
             // 1. we should make it `Send` and `Sync`, or
@@ -213,6 +218,8 @@ impl AxVM {
                 0, // Currently not used.
                 phys_cpu_set,
                 #[cfg(target_arch = "aarch64")]
+                arch_config,
+                #[cfg(target_arch = "loongarch64")]
                 arch_config,
                 #[cfg(target_arch = "riscv64")]
                 arch_config,

--- a/components/loongarch_vcpu/Cargo.toml
+++ b/components/loongarch_vcpu/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "loongarch_vcpu"
+version = "0.5.0"
+edition = "2024"
+authors = [
+  "ZuJun Xie <zujunxie1@gmail.com>",
+]
+description = "LoongArch VCPU implementation for ArceOS Hypervisor"
+repository = "https://github.com/arceos-hypervisor/loongarch_vcpu"
+categories = ["embedded", "no-std"]
+keywords = ["hypervisor", "loongarch", "vcpu"]
+license = "Apache-2.0"
+
+[package.metadata.docs.rs]
+targets = ["loongarch64-unknown-none-softfloat"]
+
+[dependencies]
+log = "0.4"
+spin = "0.10"
+
+ax-errno = "0.4.2"
+ax-percpu = "0.4.3"
+
+axaddrspace = "0.5.0"
+axvcpu = "0.5.0"

--- a/components/loongarch_vcpu/src/context_frame.rs
+++ b/components/loongarch_vcpu/src/context_frame.rs
@@ -1,0 +1,198 @@
+use core::fmt::Formatter;
+
+#[allow(dead_code)]
+#[allow(missing_docs)]
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GprIndex {
+    R0 = 0,
+    R1,
+    R2,
+    R3,
+    R4,
+    R5,
+    R6,
+    R7,
+    R8,
+    R9,
+    R10,
+    R11,
+    R12,
+    R13,
+    R14,
+    R15,
+    R16,
+    R17,
+    R18,
+    R19,
+    R20,
+    R21,
+    R22,
+    R23,
+    R24,
+    R25,
+    R26,
+    R27,
+    R28,
+    R29,
+    R30,
+    R31,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct LoongArchContextFrame {
+    pub x: [usize; 32],
+    pub sepc: usize,
+    pub crmd: usize,
+    pub prmd: usize,
+    pub estat: usize,
+}
+
+impl Default for LoongArchContextFrame {
+    fn default() -> Self {
+        Self {
+            x: [0; 32],
+            sepc: 0,
+            crmd: 0,
+            prmd: 0,
+            estat: 0,
+        }
+    }
+}
+
+impl core::fmt::Display for LoongArchContextFrame {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
+        for i in 0..32 {
+            write!(f, "x{:02}: {:016x}   ", i, self.x[i])?;
+            if (i + 1) % 2 == 0 {
+                writeln!(f)?;
+            }
+        }
+        writeln!(f, "sepc: {:016x}", self.sepc)?;
+        writeln!(f, "crmd: {:016x}", self.crmd)?;
+        writeln!(f, "prmd: {:016x}", self.prmd)?;
+        write!(f, "estat: {:016x}", self.estat)
+    }
+}
+
+impl LoongArchContextFrame {
+    pub fn set_argument(&mut self, arg: usize) {
+        self.x[4] = arg;
+    }
+
+    pub fn set_gpr(&mut self, index: usize, val: usize) {
+        match index {
+            0 => {}
+            1..=31 => self.x[index] = val,
+            _ => panic!("Invalid general-purpose register index {index}"),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn gpr(&self, index: usize) -> usize {
+        match index {
+            0 => 0,
+            1..=31 => self.x[index],
+            _ => panic!("Invalid general-purpose register index {index}"),
+        }
+    }
+
+    pub fn get_a0(&self) -> usize {
+        self.x[4]
+    }
+
+    pub fn get_a1(&self) -> usize {
+        self.x[5]
+    }
+
+    pub fn get_a2(&self) -> usize {
+        self.x[6]
+    }
+
+    pub fn get_a3(&self) -> usize {
+        self.x[7]
+    }
+
+    pub fn get_a4(&self) -> usize {
+        self.x[8]
+    }
+
+    pub fn get_a5(&self) -> usize {
+        self.x[9]
+    }
+
+    pub fn get_a6(&self) -> usize {
+        self.x[10]
+    }
+
+    pub fn set_a0(&mut self, val: usize) {
+        self.x[4] = val;
+    }
+}
+
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LoongArchGuestSystemRegisters {
+    pub gpgd: usize,
+    pub gpgdl: usize,
+    pub gpgdh: usize,
+    pub gasid: usize,
+    pub gtcfg: usize,
+    pub gtval: usize,
+    pub gticlr: usize,
+    pub gtlbehi: usize,
+    pub gtlbello0: usize,
+    pub gtlbello1: usize,
+    pub gtlbidx: usize,
+    pub gstat: usize,
+    pub gctl: usize,
+    pub geentry: usize,
+    pub gera: usize,
+    pub gbadv: usize,
+    pub gbadi: usize,
+}
+
+impl LoongArchGuestSystemRegisters {
+    pub unsafe fn store(&mut self) {
+        use crate::registers::*;
+
+        self.gpgd = gcsr_read::<GCSR_PGD>();
+        self.gpgdl = gcsr_read::<GCSR_PGDL>();
+        self.gpgdh = gcsr_read::<GCSR_PGDH>();
+        self.gasid = gcsr_read::<GCSR_ASID>();
+        self.gtcfg = gcsr_read::<GCSR_TCFG>();
+        self.gtval = gcsr_read::<GCSR_TVAL>();
+        self.gticlr = gcsr_read::<GCSR_TICLR>();
+        self.gtlbehi = gcsr_read::<GCSR_TLBEHI>();
+        self.gtlbello0 = gcsr_read::<GCSR_TLBELO0>();
+        self.gtlbello1 = gcsr_read::<GCSR_TLBELO1>();
+        self.gtlbidx = gcsr_read::<GCSR_TLBIDX>();
+        self.gstat = gstat_read();
+        self.gera = gcsr_read::<GCSR_ERA>();
+        self.geentry = gcsr_read::<GCSR_EENTRY>();
+        self.gbadv = gcsr_read::<GCSR_BADV>();
+        self.gbadi = gcsr_read::<GCSR_BADI>();
+        self.gctl = csr_read::<CSR_GCTL>();
+    }
+
+    pub unsafe fn restore(&self) {
+        use crate::registers::*;
+
+        gcsr_write::<GCSR_PGD>(self.gpgd);
+        gcsr_write::<GCSR_PGDL>(self.gpgdl);
+        gcsr_write::<GCSR_PGDH>(self.gpgdh);
+        gcsr_write::<GCSR_ASID>(self.gasid);
+        gcsr_write::<GCSR_TCFG>(self.gtcfg);
+        gcsr_write::<GCSR_TVAL>(self.gtval);
+        gcsr_write::<GCSR_TICLR>(self.gticlr);
+        gcsr_write::<GCSR_TLBEHI>(self.gtlbehi);
+        gcsr_write::<GCSR_TLBELO0>(self.gtlbello0);
+        gcsr_write::<GCSR_TLBELO1>(self.gtlbello1);
+        gcsr_write::<GCSR_TLBIDX>(self.gtlbidx);
+        gcsr_write::<GCSR_ERA>(self.gera);
+        gcsr_write::<GCSR_EENTRY>(self.geentry);
+        csr_write::<CSR_GCTL>(self.gctl);
+    }
+}

--- a/components/loongarch_vcpu/src/exception.S
+++ b/components/loongarch_vcpu/src/exception.S
@@ -1,0 +1,177 @@
+.section .text
+
+.macro SAVE_GUEST_REGS
+    st.d    $r0, $sp, 0
+    st.d    $r1, $sp, 8
+    st.d    $r2, $sp, 16
+    st.d    $r3, $sp, 24
+    st.d    $r4, $sp, 32
+    st.d    $r5, $sp, 40
+    st.d    $r6, $sp, 48
+    st.d    $r7, $sp, 56
+    st.d    $r8, $sp, 64
+    st.d    $r9, $sp, 72
+    st.d    $r10, $sp, 80
+    st.d    $r11, $sp, 88
+    st.d    $r12, $sp, 96
+    st.d    $r13, $sp, 104
+    st.d    $r14, $sp, 112
+    st.d    $r15, $sp, 120
+    st.d    $r16, $sp, 128
+    st.d    $r17, $sp, 136
+    st.d    $r18, $sp, 144
+    st.d    $r19, $sp, 152
+    st.d    $r20, $sp, 160
+    st.d    $r21, $sp, 168
+    st.d    $r22, $sp, 176
+    st.d    $r23, $sp, 184
+    st.d    $r24, $sp, 192
+    st.d    $r25, $sp, 200
+    st.d    $r26, $sp, 208
+    st.d    $r27, $sp, 216
+    st.d    $r28, $sp, 224
+    st.d    $r29, $sp, 232
+    st.d    $r30, $sp, 240
+    st.d    $r31, $sp, 248
+
+    gcsrrd  $t0, 0x6
+    st.d    $t0, $sp, 256
+    gcsrrd  $t0, 0x0
+    st.d    $t0, $sp, 264
+    gcsrrd  $t0, 0x1
+    st.d    $t0, $sp, 272
+    gcsrrd  $t0, 0x5
+    st.d    $t0, $sp, 280
+.endm
+
+.macro RESTORE_GUEST_REGS
+    ld.d    $t0, $sp, 256
+    gcsrwr  $t0, 0x6
+    ld.d    $t0, $sp, 264
+    gcsrwr  $t0, 0x0
+    ld.d    $t0, $sp, 272
+    gcsrwr  $t0, 0x1
+    ld.d    $t0, $sp, 280
+    gcsrwr  $t0, 0x5
+
+    ld.d    $r1, $sp, 8
+    ld.d    $r2, $sp, 16
+    ld.d    $r3, $sp, 24
+    ld.d    $r4, $sp, 32
+    ld.d    $r5, $sp, 40
+    ld.d    $r6, $sp, 48
+    ld.d    $r7, $sp, 56
+    ld.d    $r8, $sp, 64
+    ld.d    $r9, $sp, 72
+    ld.d    $r10, $sp, 80
+    ld.d    $r11, $sp, 88
+    ld.d    $r12, $sp, 96
+    ld.d    $r13, $sp, 104
+    ld.d    $r14, $sp, 112
+    ld.d    $r15, $sp, 120
+    ld.d    $r16, $sp, 128
+    ld.d    $r17, $sp, 136
+    ld.d    $r18, $sp, 144
+    ld.d    $r19, $sp, 152
+    ld.d    $r20, $sp, 160
+    ld.d    $r21, $sp, 168
+    ld.d    $r22, $sp, 176
+    ld.d    $r23, $sp, 184
+    ld.d    $r24, $sp, 192
+    ld.d    $r25, $sp, 200
+    ld.d    $r26, $sp, 208
+    ld.d    $r27, $sp, 216
+    ld.d    $r28, $sp, 224
+    ld.d    $r29, $sp, 232
+    ld.d    $r30, $sp, 240
+    ld.d    $r31, $sp, 248
+    ld.d    $r0, $sp, 0
+.endm
+
+.global _run_guest
+_run_guest:
+    move    $t1, $ra
+    csrwr   $a0, 0x33
+    move    $sp, $a0
+    RESTORE_GUEST_REGS
+    ertn
+    jr      $t1
+
+.global _guest_exit
+_guest_exit:
+    b       vmexit_trampoline
+
+.section .vectors, "ax"
+.align 12
+.global _exception_vectors
+_exception_vectors:
+    .org 0x0
+    b       _irq_handler_vector
+    .org 0x80
+    b       _sync_handler_vector
+    .org 0x100
+    b       _sync_handler_vector
+    .org 0x180
+    b       _sync_handler_vector
+    .org 0x200
+    b       _sync_handler_vector
+    .org 0x280
+    b       _sync_handler_vector
+    .org 0x400
+    b       _sync_handler_vector
+    .org 0x480
+    b       _sync_handler_vector
+    .org 0x500
+    b       _sync_handler_vector
+    .org 0x580
+    b       _sync_handler_vector
+    .org 0x600
+    b       _sync_handler_vector
+    .org 0x680
+    b       _sync_handler_vector
+    .org 0x700
+    b       _sync_handler_vector
+    .org 0x780
+    b       _sync_handler_vector
+    .org 0x800
+    b       _sync_handler_vector
+    .org 0x880
+    b       _sync_handler_vector
+    .org 0x900
+    b       _sync_handler_vector
+    .org 0x980
+    b       _sync_handler_vector
+    .org 0xa00
+    b       _sync_handler_vector
+    .org 0xa80
+    b       _sync_handler_vector
+    .org 0xb00
+    b       _hvc_handler_vector
+    .org 0xb80
+    b       _sync_handler_vector
+    .org 0xc00
+    b       _sync_handler_vector
+    .org 0xc80
+    b       _sync_handler_vector
+    .org 0xd00
+    b       _sync_handler_vector
+    .org 0xd80
+    b       _sync_handler_vector
+
+_irq_handler_vector:
+    csrrd   $sp, 0x33
+    SAVE_GUEST_REGS
+    li.d    $a0, 1
+    b       _guest_exit
+
+_sync_handler_vector:
+    csrrd   $sp, 0x33
+    SAVE_GUEST_REGS
+    li.d    $a0, 0
+    b       _guest_exit
+
+_hvc_handler_vector:
+    csrrd   $sp, 0x33
+    SAVE_GUEST_REGS
+    li.d    $a0, 0
+    b       _guest_exit

--- a/components/loongarch_vcpu/src/exception.rs
+++ b/components/loongarch_vcpu/src/exception.rs
@@ -1,0 +1,140 @@
+use ax_errno::AxResult;
+use axaddrspace::{GuestPhysAddr, MappingFlags};
+use axvcpu::AxVCpuExitReason;
+
+use crate::{
+    context_frame::LoongArchContextFrame,
+    registers::{GCSR_BADI, GCSR_BADV, GCSR_ESTAT, gcsr_read},
+};
+
+const ECODE_HVC: usize = 0x17;
+const ECODE_PIL: usize = 0x1;
+const ECODE_PIS: usize = 0x2;
+const ECODE_PIF: usize = 0x3;
+const ECODE_PME: usize = 0x4;
+const ECODE_PPI: usize = 0x5;
+const ECODE_TLBR: usize = 0x8;
+const ECODE_RSE: usize = 0x10;
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrapKind {
+    Synchronous = 0,
+    Irq         = 1,
+}
+
+impl TryFrom<u8> for TrapKind {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Synchronous),
+            1 => Ok(Self::Irq),
+            _ => Err(()),
+        }
+    }
+}
+
+fn get_exception_code() -> usize {
+    let estat = unsafe { gcsr_read::<GCSR_ESTAT>() };
+    (estat >> 16) & 0x3f
+}
+
+fn get_exception_subcode() -> usize {
+    let estat = unsafe { gcsr_read::<GCSR_ESTAT>() };
+    (estat >> 22) & 0x1ff
+}
+
+fn get_badv() -> usize {
+    unsafe { gcsr_read::<GCSR_BADV>() }
+}
+
+fn get_badi() -> usize {
+    unsafe { gcsr_read::<GCSR_BADI>() }
+}
+
+pub fn handle_exception_sync(ctx: &mut LoongArchContextFrame) -> AxResult<AxVCpuExitReason> {
+    let ecode = get_exception_code();
+    let esubcode = get_exception_subcode();
+
+    trace!(
+        "LoongArch handle_exception_sync: ecode={:#x}, esubcode={:#x}, sepc={:#x}",
+        ecode, esubcode, ctx.sepc
+    );
+
+    match ecode {
+        ECODE_HVC => {
+            let nr = ctx.get_a0() as u64;
+            let args = [
+                ctx.get_a1() as u64,
+                ctx.get_a2() as u64,
+                ctx.get_a3() as u64,
+                ctx.get_a4() as u64,
+                ctx.get_a5() as u64,
+                ctx.get_a6() as u64,
+            ];
+            ctx.sepc += 4;
+            Ok(AxVCpuExitReason::Hypercall { nr, args })
+        }
+        ECODE_PIL | ECODE_PIS | ECODE_PIF | ECODE_PME | ECODE_PPI => {
+            let badv = get_badv();
+            let mut access_flags = MappingFlags::empty();
+            if matches!(ecode, ECODE_PIS | ECODE_PME) {
+                access_flags |= MappingFlags::WRITE;
+            } else if ecode == ECODE_PIF {
+                access_flags |= MappingFlags::EXECUTE;
+            } else {
+                access_flags |= MappingFlags::READ;
+            }
+            Ok(AxVCpuExitReason::NestedPageFault {
+                addr: GuestPhysAddr::from(badv),
+                access_flags,
+            })
+        }
+        ECODE_TLBR => Ok(AxVCpuExitReason::NestedPageFault {
+            addr: GuestPhysAddr::from(get_badv()),
+            access_flags: MappingFlags::READ,
+        }),
+        ECODE_RSE => Ok(AxVCpuExitReason::Halt),
+        _ => panic!(
+            "Unhandled synchronous exception: ecode={:#x}, esubcode={:#x}, sepc={:#x}, \
+             badv={:#x}, badi={:#x}",
+            ecode,
+            esubcode,
+            ctx.sepc,
+            get_badv(),
+            get_badi()
+        ),
+    }
+}
+
+pub fn handle_exception_irq(_ctx: &mut LoongArchContextFrame) -> AxResult<AxVCpuExitReason> {
+    Ok(AxVCpuExitReason::ExternalInterrupt { vector: 0 })
+}
+
+core::arch::global_asm!(include_str!("exception.S"));
+
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+unsafe extern "C" fn vmexit_trampoline() -> ! {
+    core::arch::naked_asm!(
+        "addi.d $t0, $sp, 288",
+        "ld.d $t1, $t0, 0",
+        "move $sp, $t1",
+        "ld.d $ra, $sp, 0",
+        "ld.d $s0, $sp, 8",
+        "ld.d $s1, $sp, 16",
+        "ld.d $s2, $sp, 24",
+        "ld.d $s3, $sp, 32",
+        "ld.d $s4, $sp, 40",
+        "ld.d $s5, $sp, 48",
+        "ld.d $s6, $sp, 56",
+        "ld.d $s7, $sp, 64",
+        "ld.d $s8, $sp, 72",
+        "ld.d $fp, $sp, 80",
+        "ld.d $tp, $sp, 88",
+        "ld.d $r21, $sp, 96",
+        "addi.d $sp, $sp, 14 * 8",
+        "jr $ra",
+    )
+}

--- a/components/loongarch_vcpu/src/lib.rs
+++ b/components/loongarch_vcpu/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![cfg(target_arch = "loongarch64")]
+#![allow(unsafe_op_in_unsafe_fn)]
+
+#[macro_use]
+extern crate log;
+
+mod context_frame;
+mod exception;
+mod pcpu;
+mod registers;
+mod vcpu;
+
+pub use self::{
+    pcpu::LoongArchPerCpu,
+    registers::*,
+    vcpu::{LoongArchVCpu, LoongArchVCpuCreateConfig},
+};
+
+pub fn has_hardware_support() -> bool {
+    let cpucfg2: u64;
+    unsafe {
+        core::arch::asm!("cpucfg {}, {}", out(reg) cpucfg2, in(reg) 2);
+    }
+    (cpucfg2 & (1 << 10)) != 0
+}

--- a/components/loongarch_vcpu/src/pcpu.rs
+++ b/components/loongarch_vcpu/src/pcpu.rs
@@ -1,0 +1,70 @@
+use ax_errno::AxResult;
+use axvcpu::AxArchPerCpu;
+
+use crate::registers::{
+    CSR_EENTRY, csr_read, csr_write, gcsr_eentry_read, gcsr_eentry_write, gstat_read, gstat_write,
+};
+
+unsafe extern "C" {
+    static _exception_vectors: u8;
+}
+
+#[repr(C)]
+#[repr(align(4096))]
+pub struct LoongArchPerCpu {
+    pub cpu_id: usize,
+    pub original_eentry: usize,
+    pub original_gstat: usize,
+    pub original_gcsr_eentry: usize,
+    pub enabled: bool,
+}
+
+impl AxArchPerCpu for LoongArchPerCpu {
+    fn new(cpu_id: usize) -> AxResult<Self> {
+        Ok(Self {
+            cpu_id,
+            original_eentry: 0,
+            original_gstat: 0,
+            original_gcsr_eentry: 0,
+            enabled: false,
+        })
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn hardware_enable(&mut self) -> AxResult {
+        self.original_eentry = unsafe { csr_read::<CSR_EENTRY>() };
+        self.original_gstat = gstat_read();
+        self.original_gcsr_eentry = gcsr_eentry_read();
+
+        unsafe {
+            gcsr_eentry_write(core::ptr::addr_of!(_exception_vectors) as usize);
+        }
+        self.enabled = true;
+
+        debug!(
+            "LoongArch virtualization enabled for CPU {}, GCSR_EENTRY={:#x}",
+            self.cpu_id,
+            core::ptr::addr_of!(_exception_vectors) as usize
+        );
+        Ok(())
+    }
+
+    fn hardware_disable(&mut self) -> AxResult {
+        unsafe {
+            gstat_write(self.original_gstat);
+            gcsr_eentry_write(self.original_gcsr_eentry);
+            csr_write::<CSR_EENTRY>(self.original_eentry);
+        }
+        self.enabled = false;
+
+        debug!("LoongArch virtualization disabled for CPU {}", self.cpu_id);
+        Ok(())
+    }
+
+    fn max_guest_page_table_levels(&self) -> usize {
+        4
+    }
+}

--- a/components/loongarch_vcpu/src/registers.rs
+++ b/components/loongarch_vcpu/src/registers.rs
@@ -1,0 +1,123 @@
+use spin::Mutex;
+
+pub const CSR_GSTAT: u16 = 0x50;
+pub const CSR_GTLBC: u16 = 0x15;
+pub const CSR_GCTL: u16 = 0x51;
+pub const CSR_GINTC: u16 = 0x52;
+pub const CSR_EENTRY: u16 = 0x0c;
+
+pub const GCSR_CRMD: usize = 0x0;
+pub const GCSR_PRMD: usize = 0x1;
+pub const GCSR_ESTAT: usize = 0x5;
+pub const GCSR_ERA: usize = 0x6;
+pub const GCSR_BADV: usize = 0x7;
+pub const GCSR_BADI: usize = 0x8;
+pub const GCSR_EENTRY: usize = 0x0c;
+pub const GCSR_TLBIDX: usize = 0x10;
+pub const GCSR_TLBEHI: usize = 0x11;
+pub const GCSR_TLBELO0: usize = 0x12;
+pub const GCSR_TLBELO1: usize = 0x13;
+pub const GCSR_ASID: usize = 0x18;
+pub const GCSR_PGDL: usize = 0x19;
+pub const GCSR_PGDH: usize = 0x1a;
+pub const GCSR_PGD: usize = 0x1b;
+pub const GCSR_TCFG: usize = 0x41;
+pub const GCSR_TVAL: usize = 0x42;
+pub const GCSR_TICLR: usize = 0x44;
+
+pub const GSTAT_PGM: usize = 1 << 1;
+pub const GINTC_HWIS_MASK: usize = 0xff;
+pub const GINTC_HWIS_SHIFT: usize = 0;
+
+pub const INT_HWI0: usize = 2;
+pub const INT_HWI7: usize = 9;
+pub const INT_IPI: usize = 12;
+
+static INJECT_INT_LOCK: Mutex<()> = Mutex::new(());
+
+#[inline(always)]
+pub unsafe fn csr_read<const CSR_NUM: u16>() -> usize {
+    let value: usize;
+    core::arch::asm!("csrrd {}, {}", out(reg) value, const CSR_NUM);
+    value
+}
+
+#[inline(always)]
+pub unsafe fn csr_write<const CSR_NUM: u16>(value: usize) {
+    core::arch::asm!("csrwr {}, {}", in(reg) value, const CSR_NUM);
+}
+
+#[inline(always)]
+pub unsafe fn gcsr_read<const GCSR_NUM: usize>() -> usize {
+    let value: usize;
+    core::arch::asm!("gcsrrd {}, {}", out(reg) value, const GCSR_NUM);
+    value
+}
+
+#[inline(always)]
+pub unsafe fn gcsr_write<const GCSR_NUM: usize>(value: usize) {
+    core::arch::asm!("gcsrwr {}, {}", in(reg) value, const GCSR_NUM);
+}
+
+#[inline(always)]
+pub fn gstat_read() -> usize {
+    unsafe { csr_read::<CSR_GSTAT>() }
+}
+
+#[inline(always)]
+pub unsafe fn gstat_write(value: usize) {
+    csr_write::<CSR_GSTAT>(value);
+}
+
+#[inline(always)]
+pub fn gcsr_eentry_read() -> usize {
+    unsafe { gcsr_read::<GCSR_EENTRY>() }
+}
+
+#[inline(always)]
+pub unsafe fn gcsr_eentry_write(value: usize) {
+    gcsr_write::<GCSR_EENTRY>(value);
+}
+
+pub fn is_guest_mode_enabled() -> bool {
+    (gstat_read() & GSTAT_PGM) != 0
+}
+
+pub unsafe fn enable_guest_mode() {
+    gstat_write(gstat_read() | GSTAT_PGM);
+}
+
+pub unsafe fn disable_guest_mode() {
+    gstat_write(gstat_read() & !GSTAT_PGM);
+}
+
+fn read_gintc() -> usize {
+    unsafe { csr_read::<CSR_GINTC>() }
+}
+
+unsafe fn write_gintc(value: usize) {
+    csr_write::<CSR_GINTC>(value);
+}
+
+pub fn inject_interrupt(vector: usize) {
+    if vector > INT_IPI {
+        warn!("LoongArch64: invalid interrupt vector {vector}");
+        return;
+    }
+
+    let _guard = INJECT_INT_LOCK.lock();
+
+    unsafe {
+        if (INT_HWI0..=INT_HWI7).contains(&vector) {
+            let hwis_bit = 1 << (vector - INT_HWI0);
+            let current_hwis = (read_gintc() & GINTC_HWIS_MASK) >> GINTC_HWIS_SHIFT;
+            let mut gintc = read_gintc();
+            gintc &= !GINTC_HWIS_MASK;
+            gintc |= ((current_hwis | hwis_bit) << GINTC_HWIS_SHIFT) & GINTC_HWIS_MASK;
+            write_gintc(gintc);
+        } else {
+            let estat = gcsr_read::<GCSR_ESTAT>();
+            gcsr_write::<GCSR_ESTAT>(estat | (1usize << vector));
+        }
+    }
+}

--- a/components/loongarch_vcpu/src/vcpu.rs
+++ b/components/loongarch_vcpu/src/vcpu.rs
@@ -1,0 +1,179 @@
+use ax_errno::AxResult;
+use axaddrspace::{GuestPhysAddr, HostPhysAddr};
+use axvcpu::{AxArchVCpu, AxVCpuExitReason};
+
+use crate::{
+    context_frame::{LoongArchContextFrame, LoongArchGuestSystemRegisters},
+    exception::{TrapKind, handle_exception_irq, handle_exception_sync},
+};
+
+unsafe extern "C" {
+    fn _run_guest(ctx: *mut LoongArchContextFrame) -> !;
+}
+
+#[ax_percpu::def_percpu]
+static HOST_SP: usize = 0;
+
+unsafe fn save_host_sp() {
+    let sp: usize;
+    core::arch::asm!("move {0}, $sp", out(reg) sp);
+    HOST_SP.write_current_raw(sp);
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct LoongArchVCpu {
+    ctx: LoongArchContextFrame,
+    host_stack_top: usize,
+    guest_system_regs: LoongArchGuestSystemRegisters,
+    cpu_id: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LoongArchVCpuCreateConfig {
+    pub cpu_id: usize,
+    pub dtb_addr: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LoongArchVCpuSetupConfig {
+    pub passthrough_interrupt: bool,
+    pub passthrough_timer: bool,
+}
+
+impl AxArchVCpu for LoongArchVCpu {
+    type CreateConfig = LoongArchVCpuCreateConfig;
+    type SetupConfig = LoongArchVCpuSetupConfig;
+
+    fn new(_vm_id: usize, _vcpu_id: usize, config: Self::CreateConfig) -> AxResult<Self> {
+        let mut ctx = LoongArchContextFrame::default();
+        ctx.set_argument(config.dtb_addr);
+
+        Ok(Self {
+            ctx,
+            host_stack_top: 0,
+            guest_system_regs: LoongArchGuestSystemRegisters::default(),
+            cpu_id: config.cpu_id,
+        })
+    }
+
+    fn setup(&mut self, config: Self::SetupConfig) -> AxResult {
+        self.init_hv(config);
+        Ok(())
+    }
+
+    fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
+        self.ctx.sepc = entry.as_usize();
+        Ok(())
+    }
+
+    fn set_ept_root(&mut self, ept_root: HostPhysAddr) -> AxResult {
+        self.guest_system_regs.gpgd = ept_root.as_usize();
+        Ok(())
+    }
+
+    fn run(&mut self) -> AxResult<AxVCpuExitReason> {
+        let exit_reason = unsafe {
+            save_host_sp();
+            self.restore_vm_system_regs();
+            self.run_guest()
+        };
+
+        let trap_kind = TrapKind::try_from(exit_reason as u8).expect("Invalid TrapKind");
+        self.vmexit_handler(trap_kind)
+    }
+
+    fn bind(&mut self) -> AxResult {
+        let _ = self.cpu_id;
+        Ok(())
+    }
+
+    fn unbind(&mut self) -> AxResult {
+        Ok(())
+    }
+
+    fn set_gpr(&mut self, idx: usize, val: usize) {
+        self.ctx.set_gpr(idx, val);
+    }
+
+    fn inject_interrupt(&mut self, vector: usize) -> AxResult {
+        crate::registers::inject_interrupt(vector);
+        Ok(())
+    }
+
+    fn set_return_value(&mut self, val: usize) {
+        self.ctx.set_a0(val);
+    }
+}
+
+impl LoongArchVCpu {
+    fn init_hv(&mut self, config: LoongArchVCpuSetupConfig) {
+        self.init_vm_context(config);
+    }
+
+    fn init_vm_context(&mut self, config: LoongArchVCpuSetupConfig) {
+        self.ctx.crmd = 0x5;
+        self.ctx.prmd = 0;
+        self.ctx.estat = 0;
+
+        if config.passthrough_timer {
+            self.guest_system_regs.gtcfg = 0x1;
+        }
+
+        if config.passthrough_interrupt {
+            trace!("LoongArch passthrough interrupt mode enabled");
+        }
+
+        self.guest_system_regs.gpgdl = 0;
+        self.guest_system_regs.gpgdh = 0;
+        self.guest_system_regs.geentry = 0;
+    }
+
+    #[unsafe(naked)]
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn run_guest(&mut self) -> usize {
+        core::arch::naked_asm!(
+            "addi.d $sp, $sp, -14 * 8",
+            "st.d $ra, $sp, 0",
+            "st.d $s0, $sp, 8",
+            "st.d $s1, $sp, 16",
+            "st.d $s2, $sp, 24",
+            "st.d $s3, $sp, 32",
+            "st.d $s4, $sp, 40",
+            "st.d $s5, $sp, 48",
+            "st.d $s6, $sp, 56",
+            "st.d $s7, $sp, 64",
+            "st.d $s8, $sp, 72",
+            "st.d $fp, $sp, 80",
+            "st.d $tp, $sp, 88",
+            "st.d $r21, $sp, 96",
+            "move $t0, $sp",
+            "addi.d $t1, $a0, {host_stack_top_offset}",
+            "st.d $t0, $t1, 0",
+            "bl {run_guest_asm}",
+            "bl {run_guest_panic}",
+            host_stack_top_offset = const core::mem::size_of::<crate::context_frame::LoongArchContextFrame>(),
+            run_guest_asm = sym _run_guest,
+            run_guest_panic = sym Self::run_guest_panic,
+        );
+    }
+
+    unsafe fn run_guest_panic() -> ! {
+        panic!("run_guest_panic: control returned to run_guest");
+    }
+
+    unsafe fn restore_vm_system_regs(&mut self) {
+        self.guest_system_regs.restore();
+    }
+
+    fn vmexit_handler(&mut self, exit_reason: TrapKind) -> AxResult<AxVCpuExitReason> {
+        unsafe {
+            self.guest_system_regs.store();
+        }
+
+        match exit_reason {
+            TrapKind::Synchronous => handle_exception_sync(&mut self.ctx),
+            TrapKind::Irq => handle_exception_irq(&mut self.ctx),
+        }
+    }
+}

--- a/components/starry-smoltcp/Cargo.toml
+++ b/components/starry-smoltcp/Cargo.toml
@@ -337,6 +337,3 @@ required-features = ["std", "medium-ieee802154", "phy-raw_socket", "proto-sixlow
 [[example]]
 name = "dns"
 required-features = ["std", "medium-ethernet", "medium-ip", "phy-tuntap_interface", "proto-ipv4", "socket-dns"]
-
-[profile.release]
-debug = 2

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -5,10 +5,15 @@ use core::{
     hint::unlikely,
     mem::{MaybeUninit, transmute},
     ptr, slice, str,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use ax_errno::{AxError, AxResult};
-use ax_hal::{asm::user_copy, paging::MappingFlags, trap::page_fault_handler};
+use ax_hal::{
+    asm::user_copy,
+    paging::MappingFlags,
+    trap::{page_fault_handler, set_page_fault_handler},
+};
 use ax_io::prelude::*;
 use ax_kernel_guard::IrqSave;
 use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
@@ -21,9 +26,22 @@ use crate::{
     task::AsThread,
 };
 
+static PAGE_FAULT_HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+fn ensure_page_fault_handler_installed() {
+    if PAGE_FAULT_HANDLER_INSTALLED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+    {
+        let _ = set_page_fault_handler(handle_page_fault);
+    }
+}
+
 /// Enables scoped access into user memory, allowing page faults to occur inside
 /// kernel.
 pub fn access_user_memory<R>(f: impl FnOnce() -> R) -> R {
+    ensure_page_fault_handler_installed();
+
     let curr = current();
     let Some(thr) = curr.try_as_thread() else {
         panic!("access_user_memory called outside of thread context");
@@ -251,7 +269,6 @@ macro_rules! nullable {
 
 pub(crate) use nullable;
 
-#[page_fault_handler]
 fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
     debug!("Page fault at {vaddr:#x}, access_flags: {access_flags:#x?}");
 

--- a/os/arceos/modules/axhal/build.rs
+++ b/os/arceos/modules/axhal/build.rs
@@ -20,6 +20,7 @@ fn main() {
 }
 
 fn gen_linker_script(arch: &str, platform: &str) -> Result<()> {
+    let is_loongarch_qemu_virt = arch == "loongarch64" && platform == "loongarch64-qemu-virt";
     let legacy_fname = format!("linker_{platform}.lds");
     let output_arch = if arch == "x86_64" {
         "i386:x86-64"
@@ -28,11 +29,139 @@ fn gen_linker_script(arch: &str, platform: &str) -> Result<()> {
     } else {
         arch
     };
+    let linker_constants = if is_loongarch_qemu_virt {
+        format!(
+            "PHYS_VIRT_OFFSET = {:#x};\nKERNEL_BASE_PADDR = {:#x};",
+            ax_config::plat::PHYS_VIRT_OFFSET,
+            ax_config::plat::KERNEL_BASE_PADDR
+        )
+    } else {
+        String::new()
+    };
+    let entry_directive = if is_loongarch_qemu_virt {
+        format!(
+            "EXTERN(_start)\nENTRY({:#x})",
+            ax_config::plat::KERNEL_BASE_PADDR + 0x40
+        )
+    } else {
+        "ENTRY(_start)".to_string()
+    };
     let ld_content = std::fs::read_to_string("linker.lds.S")?;
     let ld_content = ld_content.replace("%ARCH%", output_arch);
     let ld_content = ld_content.replace(
         "%KERNEL_BASE%",
         &format!("{:#x}", ax_config::plat::KERNEL_BASE_VADDR),
+    );
+    let ld_content = ld_content.replace("%LINKER_CONSTANTS%", &linker_constants);
+    let ld_content = ld_content.replace("%ENTRY_DIRECTIVE%", &entry_directive);
+    let ld_content = ld_content.replace(
+        "%TEXT_AT%",
+        if is_loongarch_qemu_virt {
+            " : AT(ADDR(.text) - PHYS_VIRT_OFFSET)"
+        } else {
+            ""
+        },
+    );
+    let ld_content = ld_content.replace(
+        "%RODATA_AT%",
+        if is_loongarch_qemu_virt {
+            " : AT(ADDR(.rodata) - PHYS_VIRT_OFFSET)"
+        } else {
+            ""
+        },
+    );
+    let ld_content = ld_content.replace(
+        "%INIT_ARRAY_AT%",
+        if is_loongarch_qemu_virt {
+            " : AT(ADDR(.init_array) - PHYS_VIRT_OFFSET)"
+        } else {
+            ""
+        },
+    );
+    let ld_content = ld_content.replace(
+        "%DATA_AT%",
+        if is_loongarch_qemu_virt {
+            " : AT(ADDR(.data) - PHYS_VIRT_OFFSET)"
+        } else {
+            ""
+        },
+    );
+    let ld_content = ld_content.replace(
+        "%LINKME_SECTION%",
+        if is_loongarch_qemu_virt {
+            r#"
+    /*
+     * Keep trap-handler slices in the higher-half image. If the linker leaves
+     * them orphaned at VMA 0, the LoongArch trap dispatcher can jump to 0x0
+     * after interrupts are enabled.
+     */
+    . = ALIGN(8);
+    .linkme : AT(ADDR(.linkme) - PHYS_VIRT_OFFSET) {
+        __start_linkme_PAGE_FAULT = .;
+        KEEP(*(linkme_PAGE_FAULT))
+        __stop_linkme_PAGE_FAULT = .;
+        __start_linkme_IRQ = .;
+        KEEP(*(linkme_IRQ))
+        __stop_linkme_IRQ = .;
+    }
+"#
+        } else {
+            ""
+        },
+    );
+    let ld_content = ld_content.replace(
+        "%TDATA_AT%",
+        if is_loongarch_qemu_virt {
+            " : AT(ADDR(.tdata) - PHYS_VIRT_OFFSET)"
+        } else {
+            ""
+        },
+    );
+    let ld_content = ld_content.replace(
+        "%TBSS_AT%",
+        if is_loongarch_qemu_virt {
+            " : AT(ADDR(.tbss) - PHYS_VIRT_OFFSET)"
+        } else {
+            ""
+        },
+    );
+    let ld_content = ld_content.replace(
+        "%PERCPU_SECTION%",
+        if is_loongarch_qemu_virt {
+            r#"    . = ALIGN(64);
+    /*
+     * LoongArch QEMU direct boot derives PT_LOAD copy addresses from the VMA
+     * rather than p_paddr, so `.percpu` must keep a higher-half VMA here.
+     */
+    .percpu : AT(ADDR(.percpu) - PHYS_VIRT_OFFSET) {
+        _percpu_start = .;
+        _percpu_load_start = .;
+        *(.percpu .percpu.*)
+        _percpu_load_end = .;
+        _percpu_load_end_aligned = ALIGN(64);
+        . = _percpu_start + (_percpu_load_end_aligned - _percpu_load_start) * %CPU_NUM%;
+    }
+    _percpu_end = .;"#
+        } else {
+            r#"    . = ALIGN(4K);
+    _percpu_start = .;
+    _percpu_end = _percpu_start + SIZEOF(.percpu);
+    .percpu 0x0 : AT(_percpu_start) {
+        _percpu_load_start = .;
+        *(.percpu .percpu.*)
+        _percpu_load_end = .;
+        . = _percpu_load_start + ALIGN(64) * %CPU_NUM%;
+    }
+    . = _percpu_end;"#
+        },
+    );
+    let ld_content = ld_content.replace(
+        "%BSS_AT%",
+        if is_loongarch_qemu_virt {
+            " : AT(ADDR(.bss) - PHYS_VIRT_OFFSET)"
+        } else {
+            " : AT(.)"
+        },
     );
     let ld_content = ld_content.replace("%CPU_NUM%", &format!("{}", ax_config::plat::MAX_CPU_NUM));
     let ld_content = ld_content.replace(

--- a/os/arceos/modules/axhal/linker.lds.S
+++ b/os/arceos/modules/axhal/linker.lds.S
@@ -1,29 +1,30 @@
 OUTPUT_ARCH(%ARCH%)
 
 BASE_ADDRESS = %KERNEL_BASE%;
+%LINKER_CONSTANTS%
 
-ENTRY(_start)
+%ENTRY_DIRECTIVE%
 SECTIONS
 {
     . = BASE_ADDRESS;
     _skernel = .;
 
-    .text : ALIGN(4K) {
+    .text%TEXT_AT% ALIGN(4K) {
         _stext = .;
-        *(.text.boot)
+        KEEP(*(.text.boot))
         *(.text .text.*)
         . = ALIGN(4K);
         _etext = .;
     }
 
     _srodata = .;
-    .rodata : ALIGN(4K) {
+    .rodata%RODATA_AT% ALIGN(4K) {
         *(.rodata .rodata.*)
         *(.srodata .srodata.*)
         *(.sdata2 .sdata2.*)
     }
 
-    .init_array : ALIGN(0x10) {
+    .init_array%INIT_ARRAY_AT% ALIGN(0x10) {
         __init_array_start = .;
         *(.init_array .init_array.*)
         __init_array_end = .;
@@ -34,7 +35,7 @@ SECTIONS
     . = ALIGN(4K);
     _erodata = .;
 
-    .data : ALIGN(4K) {
+    .data%DATA_AT% ALIGN(4K) {
         _sdata = .;
         *(.data.boot_page_table)
         . = ALIGN(4K);
@@ -53,34 +54,27 @@ SECTIONS
         _ex_table_end = .;
     }
 
-    .tdata : ALIGN(0x10) {
+%LINKME_SECTION%
+
+    .tdata%TDATA_AT% ALIGN(0x10) {
         _stdata = .;
         *(.tdata .tdata.*)
         _etdata = .;
     }
 
-    .tbss : ALIGN(0x10) {
+    .tbss%TBSS_AT% ALIGN(0x10) {
         _stbss = .;
         *(.tbss .tbss.*)
         *(.tcommon)
         _etbss = .;
     }
 
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * %CPU_NUM%;
-    }
-    . = _percpu_end;
+%PERCPU_SECTION%
 
     . = ALIGN(4K);
     _edata = .;
 
-    .bss : AT(.) ALIGN(4K) {
+    .bss%BSS_AT% ALIGN(4K) {
         boot_stack = .;
         *(.bss.stack)
         . = ALIGN(4K);

--- a/os/arceos/modules/axhal/src/irq.rs
+++ b/os/arceos/modules/axhal/src/irq.rs
@@ -4,7 +4,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(feature = "ipi")]
 pub use ax_config::devices::IPI_IRQ;
-use ax_cpu::trap::irq_handler;
+use ax_cpu::trap::set_irq_handler;
 #[cfg(feature = "ipi")]
 pub use ax_plat::irq::{IpiTarget, send_ipi};
 pub use ax_plat::irq::{handle, register, set_enable, unregister};
@@ -32,7 +32,6 @@ pub fn register_irq_hook(hook: fn(usize)) -> bool {
 /// # Warn
 ///
 /// Make sure called in an interrupt context or hypervisor VM exit handler.
-#[irq_handler]
 pub fn handle_irq(vector: usize) -> bool {
     let guard = ax_kernel_guard::NoPreempt::new();
 
@@ -46,4 +45,9 @@ pub fn handle_irq(vector: usize) -> bool {
 
     drop(guard); // rescheduling may occur when preemption is re-enabled.
     true
+}
+
+/// Installs the default ArceOS IRQ dispatcher into `ax-cpu`.
+pub fn init_common_irq_handler() {
+    let _ = set_irq_handler(handle_irq);
 }

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -89,7 +89,9 @@ pub mod power {
 
 /// Trap handling.
 pub mod trap {
-    pub use ax_cpu::trap::{PageFaultFlags, irq_handler, page_fault_handler};
+    pub use ax_cpu::trap::{
+        PageFaultFlags, irq_handler, page_fault_handler, set_irq_handler, set_page_fault_handler,
+    };
 }
 
 /// CPU register states for context switching.
@@ -113,6 +115,8 @@ pub use ax_plat::init::{init_early_secondary, init_later_secondary};
 /// This function should be called as early as possible.
 pub fn init_early(cpu_id: usize, arg: usize) {
     dtb::init(arg);
+    #[cfg(feature = "irq")]
+    irq::init_common_irq_handler();
     ax_plat::init::init_early(cpu_id, arg);
 }
 

--- a/os/axvisor/.github/workflows/qemu-loongarch64.toml
+++ b/os/axvisor/.github/workflows/qemu-loongarch64.toml
@@ -1,0 +1,21 @@
+args = [
+  "-machine",
+  "virt",
+  "-cpu",
+  "la464",
+  "-m",
+  "2G",
+  "-smp",
+  "1",
+  "-nographic",
+  "-serial",
+  "mon:stdio",
+  "-no-reboot",
+]
+fail_regex = ["panicked at"]
+success_regex = [
+  "Welcome to AxVisor Shell!",
+  "axvisor:\\$",
+]
+to_bin = false
+uefi = false

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -63,6 +63,7 @@ hashbrown = "0.14"
 
 # System dependent modules provided by ArceOS.
 ax-std = { version = "0.5.0", features = [
+  "myplat",
   "paging",
   "irq",
   "multitask",
@@ -70,7 +71,7 @@ ax-std = { version = "0.5.0", features = [
   "smp",
   "hv",
 ]}
-ax-hal = { version = "0.5.0", features = ["paging", "irq", "smp", "hv"] }
+ax-hal = { version = "0.5.0", features = ["myplat", "paging", "irq", "smp", "hv"] }
 
 # System dependent modules provided by ArceOS-Hypervisor (bare-metal only)
 axaddrspace = "0.5.0"
@@ -93,7 +94,7 @@ fdt-parser = "0.4"
 ax-memory-addr = "0.6.1"
 ax-page-table-entry = { version = "0.8.1", features = ["arm-el2"] }
 ax-page-table-multiarch = "0.8.1"
-ax-percpu = { version = "0.4.3", features = ["arm-el2"] }
+ax-percpu = { version = "0.4.3", features = ["arm-el2", "non-zero-vma"] }
 
 rdif-intc = "0.14"
 rdrive = "0.20"
@@ -110,6 +111,9 @@ ax-config = { version = "0.5.0", features = ["plat-dyn"] }
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu-ext = "0.1"
 arm-gic-driver = {version = "0.17", features = ["rdif"]}
+
+[target.'cfg(target_arch = "loongarch64")'.dependencies]
+ax-plat-loongarch64-qemu-virt = { version = "0.5.0", default-features = false, features = ["irq", "smp"] }
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 ax-plat-riscv64-qemu-virt = { path = "platform/riscv64-qemu-virt" }

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -25,9 +25,6 @@ include = [
     "LICENSE*",
 ]
 
-[profile.release]
-lto = true
-
 [[bin]]
 name = "axvisor"
 path = "src/main.rs"

--- a/os/axvisor/build.rs
+++ b/os/axvisor/build.rs
@@ -258,6 +258,8 @@ fn main() -> anyhow::Result<()> {
 
     let platform = if arch == "aarch64" {
         "aarch64-generic".to_string()
+    } else if arch == "loongarch64" {
+        "loongarch64-qemu-virt".to_string()
     } else if arch == "x86_64" {
         "x86-qemu-q35".to_string()
     } else if arch == "riscv64" {

--- a/os/axvisor/configs/board/qemu-loongarch64.toml
+++ b/os/axvisor/configs/board/qemu-loongarch64.toml
@@ -1,0 +1,9 @@
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+features = [
+    "ax-std/bus-mmio",
+    "ept-level-4",
+]
+log = "Info"
+target = "loongarch64-unknown-none-softfloat"
+vm_configs = []
+max_cpu_num = 1

--- a/os/axvisor/rust-toolchain.toml
+++ b/os/axvisor/rust-toolchain.toml
@@ -2,4 +2,4 @@
 profile = "minimal"
 channel = "nightly-2025-12-12"
 components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
-targets = ["x86_64-unknown-none", "riscv64gc-unknown-none-elf", "aarch64-unknown-none-softfloat"]
+targets = ["x86_64-unknown-none", "riscv64gc-unknown-none-elf", "aarch64-unknown-none-softfloat", "loongarch64-unknown-none-softfloat"]

--- a/os/axvisor/scripts/ostool/qemu-loongarch64.toml
+++ b/os/axvisor/scripts/ostool/qemu-loongarch64.toml
@@ -1,0 +1,18 @@
+args = [
+  "-machine",
+  "virt",
+  "-cpu",
+  "la464",
+  "-m",
+  "2G",
+  "-smp",
+  "1",
+  "-nographic",
+  "-serial",
+  "mon:stdio",
+  "-no-reboot",
+]
+fail_regex = []
+success_regex = []
+to_bin = false
+uefi = false

--- a/os/axvisor/src/hal/arch/loongarch64/api.rs
+++ b/os/axvisor/src/hal/arch/loongarch64/api.rs
@@ -1,0 +1,4 @@
+struct ArchIfImpl;
+
+#[axvisor_api::api_impl]
+impl axvisor_api::arch::ArchIf for ArchIfImpl {}

--- a/os/axvisor/src/hal/arch/loongarch64/cache.rs
+++ b/os/axvisor/src/hal/arch/loongarch64/cache.rs
@@ -1,0 +1,48 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use ax_memory_addr::VirtAddr;
+
+use crate::hal::CacheOp;
+
+const CACHE_LINE_SIZE: usize = 64;
+const ICACHE_INV: u8 = 0x08;
+const DCACHE_INV: u8 = 0x18;
+const DCACHE_WB: u8 = 0x19;
+const DCACHE_WB_INV: u8 = 0x1B;
+
+unsafe fn cache_range<const OP: u8>(addr: VirtAddr, size: usize) {
+    let start = addr.as_usize() & !(CACHE_LINE_SIZE - 1);
+    let end = addr.as_usize() + size;
+    let mut current = start;
+
+    while current < end {
+        core::arch::asm!("cacop {0}, {1}, 0", const OP, in(reg) current);
+        current += CACHE_LINE_SIZE;
+    }
+}
+
+pub fn dcache_range(op: CacheOp, addr: VirtAddr, size: usize) {
+    if size == 0 {
+        return;
+    }
+
+    unsafe {
+        match op {
+            CacheOp::Clean => cache_range::<DCACHE_WB>(addr, size),
+            CacheOp::Invalidate => cache_range::<DCACHE_INV>(addr, size),
+            CacheOp::CleanAndInvalidate => cache_range::<DCACHE_WB_INV>(addr, size),
+        }
+        core::arch::asm!("dbar 0");
+    }
+}
+
+pub fn icache_range(addr: VirtAddr, size: usize) {
+    if size == 0 {
+        return;
+    }
+
+    unsafe {
+        cache_range::<ICACHE_INV>(addr, size);
+        core::arch::asm!("ibar 0");
+    }
+}

--- a/os/axvisor/src/hal/arch/loongarch64/mod.rs
+++ b/os/axvisor/src/hal/arch/loongarch64/mod.rs
@@ -1,0 +1,150 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
+mod api;
+pub mod cache;
+
+use spin::Mutex;
+
+const CSR_GSTAT: u16 = 0x50;
+const CSR_GINTC: u16 = 0x52;
+
+const GCSR_ESTAT: usize = 0x5;
+
+const GSTAT_PGM: usize = 1 << 1;
+const GSTAT_GIDBITS_MASK: usize = 0x3f << 4;
+const GSTAT_GIDBITS_SHIFT: usize = 4;
+const GSTAT_GID_MASK: usize = 0xff << 16;
+const GSTAT_GID_SHIFT: usize = 16;
+
+const GINTC_HWIS_MASK: usize = 0xff;
+const GINTC_HWIS_SHIFT: usize = 0;
+
+const INT_HWI0: usize = 2;
+const INT_HWI7: usize = 9;
+const INT_IPI: usize = 12;
+
+static INJECT_INT_LOCK: Mutex<()> = Mutex::new(());
+
+#[inline(always)]
+unsafe fn csr_read<const CSR_NUM: u16>() -> usize {
+    let value: usize;
+    core::arch::asm!("csrrd {}, {}", out(reg) value, const CSR_NUM);
+    value
+}
+
+#[inline(always)]
+unsafe fn csr_write<const CSR_NUM: u16>(value: usize) {
+    core::arch::asm!("csrwr {}, {}", in(reg) value, const CSR_NUM);
+}
+
+#[inline(always)]
+unsafe fn gcsr_read<const GCSR_NUM: usize>() -> usize {
+    let value: usize;
+    core::arch::asm!("gcsrrd {}, {}", out(reg) value, const GCSR_NUM);
+    value
+}
+
+#[inline(always)]
+unsafe fn gcsr_write<const GCSR_NUM: usize>(value: usize) {
+    core::arch::asm!("gcsrwr {}, {}", in(reg) value, const GCSR_NUM);
+}
+
+#[inline(always)]
+fn read_gstat() -> usize {
+    unsafe { csr_read::<CSR_GSTAT>() }
+}
+
+#[inline(always)]
+fn read_gintc() -> usize {
+    unsafe { csr_read::<CSR_GINTC>() }
+}
+
+#[inline(always)]
+unsafe fn write_gintc(value: usize) {
+    csr_write::<CSR_GINTC>(value);
+}
+
+#[inline(always)]
+fn read_gcsr_estat() -> usize {
+    unsafe { gcsr_read::<GCSR_ESTAT>() }
+}
+
+#[inline(always)]
+unsafe fn write_gcsr_estat(value: usize) {
+    gcsr_write::<GCSR_ESTAT>(value);
+}
+
+#[inline(always)]
+unsafe fn cpucfg_read(reg: u32) -> u32 {
+    let value: u32;
+    core::arch::asm!("cpucfg {}, {}", out(reg) value, in(reg) reg);
+    value
+}
+
+fn has_virtualization_support() -> bool {
+    let cpucfg2 = unsafe { cpucfg_read(2) };
+    (cpucfg2 & (1 << 10)) != 0
+}
+
+fn get_gidbits() -> usize {
+    (read_gstat() & GSTAT_GIDBITS_MASK) >> GSTAT_GIDBITS_SHIFT
+}
+
+fn max_gid() -> usize {
+    let gidbits = get_gidbits();
+    if gidbits == 0 { 0 } else { (1 << gidbits) - 1 }
+}
+
+fn current_gid() -> usize {
+    (read_gstat() & GSTAT_GID_MASK) >> GSTAT_GID_SHIFT
+}
+
+fn current_hwis() -> usize {
+    (read_gintc() & GINTC_HWIS_MASK) >> GINTC_HWIS_SHIFT
+}
+
+pub fn hardware_check() {
+    let gstat = read_gstat();
+    info!("CSR.GSTAT = 0x{gstat:x}");
+
+    if has_virtualization_support() {
+        info!("LoongArch virtualization extensions supported (CPUCFG.2.LVZ[10]=1)");
+    } else {
+        warn!("LoongArch virtualization extensions not supported (CPUCFG.2.LVZ[10]=0)");
+    }
+
+    if (gstat & GSTAT_PGM) != 0 {
+        info!("Guest mode currently enabled (PGM=1)");
+    } else {
+        info!("Guest mode currently disabled (PGM=0)");
+    }
+
+    let gidbits = get_gidbits();
+    info!(
+        "GIDBITS value: {gidbits} (supports {} GIDs)",
+        1usize << gidbits
+    );
+    info!("Maximum GID value: {}", max_gid());
+    info!("Current GID value: {}", current_gid());
+}
+
+pub fn inject_interrupt(vector: usize) {
+    if vector > INT_IPI {
+        warn!("LoongArch64: invalid interrupt vector {vector}");
+        return;
+    }
+
+    let _guard = INJECT_INT_LOCK.lock();
+
+    unsafe {
+        if (INT_HWI0..=INT_HWI7).contains(&vector) {
+            let hwis_bit = 1 << (vector - INT_HWI0);
+            let mut gintc = read_gintc();
+            gintc &= !GINTC_HWIS_MASK;
+            gintc |= ((current_hwis() | hwis_bit) << GINTC_HWIS_SHIFT) & GINTC_HWIS_MASK;
+            write_gintc(gintc);
+        } else {
+            write_gcsr_estat(read_gcsr_estat() | (1usize << vector));
+        }
+    }
+}

--- a/os/axvisor/src/hal/impl_vmm.rs
+++ b/os/axvisor/src/hal/impl_vmm.rs
@@ -1,43 +1,9 @@
-use std::os::arceos::modules::{ax_hal, ax_task};
-
-use ax_errno::{AxResult, ax_err_type};
-use axaddrspace::{HostPhysAddr, HostVirtAddr};
-use axvisor_api::vmm::{InterruptVector, VCpuId, VCpuSet, VMId, VmmIf};
+use std::os::arceos::modules::ax_task;
 
 use crate::{task::AsVCpuTask, vmm};
+use axvisor_api::vmm::{InterruptVector, VCpuId, VCpuSet, VMId, VmmIf};
 
 struct VmmImpl;
-
-fn virt_to_phys(vaddr: HostVirtAddr) -> HostPhysAddr {
-    ax_hal::mem::virt_to_phys(vaddr)
-}
-
-fn current_time_nanos() -> u64 {
-    ax_hal::time::monotonic_time_nanos()
-}
-
-fn current_vm_id() -> usize {
-    ax_task::current().as_vcpu_task().vm().id()
-}
-
-fn current_vcpu_id() -> usize {
-    ax_task::current().as_vcpu_task().vcpu.id()
-}
-
-fn current_pcpu_id() -> usize {
-    ax_hal::percpu::this_cpu_id()
-}
-
-fn vcpu_resides_on(vm_id: usize, vcpu_id: usize) -> AxResult<usize> {
-    vmm::with_vcpu_task(vm_id, vcpu_id, |task| task.cpu_id() as usize)
-        .ok_or_else(|| ax_err_type!(NotFound))
-}
-
-fn inject_irq_to_vcpu(vm_id: usize, vcpu_id: usize, irq: usize) -> AxResult {
-    vmm::with_vm_and_vcpu_on_pcpu(vm_id, vcpu_id, move |_, vcpu| {
-        vcpu.inject_interrupt(irq).unwrap();
-    })
-}
 
 #[axvisor_api::api_impl]
 impl VmmIf for VmmImpl {

--- a/os/axvisor/src/hal/mod.rs
+++ b/os/axvisor/src/hal/mod.rs
@@ -20,6 +20,7 @@ use axaddrspace::{AxMmHal, HostPhysAddr, HostVirtAddr};
 use axvm::AxVMPerCpu;
 
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/mod.rs")]
+#[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch64/mod.rs")]
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86_64/mod.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv64/mod.rs")]
 pub mod arch;

--- a/os/axvisor/src/main.rs
+++ b/os/axvisor/src/main.rs
@@ -29,6 +29,8 @@ extern crate alloc;
 
 extern crate ax_std as std;
 
+#[cfg(target_arch = "loongarch64")]
+extern crate ax_plat_loongarch64_qemu_virt;
 #[cfg(target_arch = "x86_64")]
 extern crate axplat_x86_qemu_q35;
 
@@ -43,7 +45,18 @@ fn main() {
     logo::print_logo();
 
     info!("Starting virtualization...");
-    info!("Hardware support: {:?}", axvm::has_hardware_support());
+    let hardware_support = axvm::has_hardware_support();
+    info!("Hardware support: {:?}", hardware_support);
+
+    #[cfg(target_arch = "loongarch64")]
+    if !hardware_support {
+        warn!(
+            "LoongArch LVZ virtualization is not available on this platform. Skipping hypervisor enable/VMM startup and entering the shell."
+        );
+        shell::console_init();
+        return;
+    }
+
     hal::enable_virtualization();
 
     vmm::init();

--- a/os/axvisor/src/vmm/config.rs
+++ b/os/axvisor/src/vmm/config.rs
@@ -22,7 +22,11 @@ use core::alloc::Layout;
 
 use crate::vmm::{VM, images::ImageLoader, vm_list::push_vm};
 
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "loongarch64",
+    target_arch = "riscv64"
+))]
 use crate::vmm::fdt::*;
 
 use alloc::sync::Arc;
@@ -128,7 +132,11 @@ pub mod config {
 }
 
 pub fn get_vm_dtb_arc(_vm_cfg: &AxVMConfig) -> Option<Arc<[u8]>> {
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "riscv64"
+    ))]
     {
         let cache_lock = dtb_cache().lock();
         if let Some(dtb) = cache_lock.get(&_vm_cfg.id()) {
@@ -140,7 +148,11 @@ pub fn get_vm_dtb_arc(_vm_cfg: &AxVMConfig) -> Option<Arc<[u8]>> {
 
 pub fn init_guest_vms() {
     // Initialize the DTB cache in the fdt module
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "riscv64"
+    ))]
     {
         init_dtb_cache();
     }
@@ -180,14 +192,26 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
         );
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "riscv64"
+    ))]
     let mut vm_config = AxVMConfig::from(vm_create_config.clone());
 
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "riscv64"
+    )))]
     let vm_config = AxVMConfig::from(vm_create_config.clone());
 
     // Handle FDT-related operations for architectures that boot guests with DTB.
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "riscv64"
+    ))]
     handle_fdt_operations(&mut vm_config, &vm_create_config);
 
     // info!("after parse_vm_interrupt, crate VM[{}] with config: {:#?}", vm_config.id(), vm_config);

--- a/os/axvisor/src/vmm/fdt/create.rs
+++ b/os/axvisor/src/vmm/fdt/create.rs
@@ -16,14 +16,20 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+#[cfg(target_arch = "aarch64")]
 use core::ptr::NonNull;
 
 use super::vm_fdt::{FdtWriter, FdtWriterNode};
+#[cfg(target_arch = "aarch64")]
 use ax_memory_addr::MemoryAddr;
+#[cfg(any(target_arch = "aarch64", test))]
 use axaddrspace::GuestPhysAddr;
-use axvm::{VMMemoryRegion, config::AxVMCrateConfig};
+#[cfg(any(target_arch = "aarch64", test))]
+use axvm::VMMemoryRegion;
+use axvm::config::AxVMCrateConfig;
 use fdt_parser::{Fdt, Node};
 
+#[cfg(target_arch = "aarch64")]
 use crate::vmm::{VMRef, images::load_vm_image_from_memory};
 
 // use crate::vmm::fdt::print::{print_fdt, print_guest_fdt};
@@ -267,6 +273,7 @@ fn need_cpu_node(phys_cpu_ids: &[usize], node: &Node, node_path: &str) -> bool {
     should_include_node
 }
 
+#[cfg(any(target_arch = "aarch64", test))]
 /// Add memory node
 fn add_memory_node(new_memory: &[VMMemoryRegion], new_fdt: &mut FdtWriter) {
     let mut new_value: Vec<u32> = Vec::new();
@@ -285,6 +292,7 @@ fn add_memory_node(new_memory: &[VMMemoryRegion], new_fdt: &mut FdtWriter) {
     new_fdt.property_string("device_type", "memory").unwrap();
 }
 
+#[cfg(any(target_arch = "aarch64", test))]
 fn initrd_range_from_image_config(
     ramdisk: Option<&axvm::config::RamdiskInfo>,
 ) -> Option<(u64, u64)> {
@@ -294,6 +302,7 @@ fn initrd_range_from_image_config(
     Some((start, start + size))
 }
 
+#[cfg(target_arch = "aarch64")]
 pub fn update_fdt(fdt_src: NonNull<u8>, dtb_size: usize, vm: VMRef) {
     let mut new_fdt = FdtWriter::new().unwrap();
     let mut previous_node_level = 0;
@@ -438,6 +447,7 @@ mod tests {
     }
 }
 
+#[cfg(target_arch = "aarch64")]
 fn calculate_dtb_load_addr(vm: VMRef, fdt_size: usize) -> GuestPhysAddr {
     const MB: usize = 1024 * 1024;
 
@@ -468,6 +478,7 @@ fn calculate_dtb_load_addr(vm: VMRef, fdt_size: usize) -> GuestPhysAddr {
     })
 }
 
+#[cfg(target_arch = "aarch64")]
 pub fn update_cpu_node(fdt: &Fdt, host_fdt: &Fdt, crate_config: &AxVMCrateConfig) -> Vec<u8> {
     let mut new_fdt = FdtWriter::new().unwrap();
     let mut previous_node_level = 0;

--- a/os/axvisor/src/vmm/fdt/mod.rs
+++ b/os/axvisor/src/vmm/fdt/mod.rs
@@ -60,7 +60,7 @@ pub fn crate_guest_fdt_with_cache(dtb_data: Vec<u8>, crate_config: &AxVMCrateCon
     cache_lock.insert(crate_config.base.id, dtb_data);
 }
 
-/// Handle all FDT-related operations for aarch64 architecture
+/// Handle all FDT-related operations for guest architectures that boot with DTB.
 pub fn handle_fdt_operations(vm_config: &mut AxVMConfig, vm_create_config: &AxVMCrateConfig) {
     let host_fdt_bytes = get_host_fdt();
     let host_fdt = Fdt::from_bytes(host_fdt_bytes)
@@ -83,6 +83,7 @@ pub fn handle_fdt_operations(vm_config: &mut AxVMConfig, vm_create_config: &AxVM
     if let Some(dtb_arc) = get_vm_dtb_arc(vm_config) {
         let dtb = dtb_arc.as_ref();
         parse_passthrough_devices_address(vm_config, dtb);
+        #[cfg(target_arch = "aarch64")]
         parse_vm_interrupt(vm_config, dtb);
     } else {
         error!(

--- a/os/axvisor/src/vmm/fdt/parser.rs
+++ b/os/axvisor/src/vmm/fdt/parser.rs
@@ -20,7 +20,7 @@ use axvm::config::{AxVMConfig, AxVMCrateConfig, PassThroughDeviceConfig};
 use fdt_parser::{Fdt, FdtHeader, PciRange, PciSpace};
 
 use crate::vmm::fdt::crate_guest_fdt_with_cache;
-#[cfg(not(target_arch = "riscv64"))]
+#[cfg(target_arch = "aarch64")]
 use crate::vmm::fdt::create::update_cpu_node;
 
 pub fn get_host_fdt() -> &'static [u8] {
@@ -405,13 +405,13 @@ pub fn parse_vm_interrupt(vm_cfg: &mut AxVMConfig, dtb: &[u8]) {
 }
 
 pub fn update_provided_fdt(provided_dtb: &[u8], host_dtb: &[u8], crate_config: &AxVMCrateConfig) {
-    #[cfg(target_arch = "riscv64")]
+    #[cfg(any(target_arch = "loongarch64", target_arch = "riscv64"))]
     {
         let _ = host_dtb;
         crate_guest_fdt_with_cache(provided_dtb.to_vec(), crate_config);
     }
 
-    #[cfg(not(target_arch = "riscv64"))]
+    #[cfg(target_arch = "aarch64")]
     {
         let provided_fdt = Fdt::from_bytes(provided_dtb)
             .expect("Failed to parse DTB image, perhaps the DTB is invalid or corrupted");

--- a/os/axvisor/src/vmm/fdt/parser.rs
+++ b/os/axvisor/src/vmm/fdt/parser.rs
@@ -16,7 +16,9 @@
 
 use alloc::{string::ToString, vec::Vec};
 use ax_hal::{dtb, mem};
-use axvm::config::{AxVMConfig, AxVMCrateConfig, PassThroughDeviceConfig};
+#[cfg(target_arch = "aarch64")]
+use axvm::config::PassThroughDeviceConfig;
+use axvm::config::{AxVMConfig, AxVMCrateConfig};
 use fdt_parser::{Fdt, FdtHeader, PciRange, PciSpace};
 
 use crate::vmm::fdt::crate_guest_fdt_with_cache;
@@ -321,6 +323,7 @@ pub fn parse_passthrough_devices_address(vm_cfg: &mut AxVMConfig, dtb: &[u8]) {
     }
 }
 
+#[cfg(target_arch = "aarch64")]
 pub fn parse_vm_interrupt(vm_cfg: &mut AxVMConfig, dtb: &[u8]) {
     const GIC_PHANDLE: usize = 1;
     let fdt = Fdt::from_bytes(dtb)

--- a/os/axvisor/src/vmm/fdt/vm_fdt/writer.rs
+++ b/os/axvisor/src/vmm/fdt/vm_fdt/writer.rs
@@ -438,6 +438,7 @@ impl FdtWriter {
     }
 
     /// Write a string property.
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
     pub fn property_string(&mut self, name: &str, val: &str) -> Result<()> {
         let cstr_value = CString::new(val).map_err(|_| Error::InvalidString)?;
         self.property(name, cstr_value.to_bytes_with_nul())
@@ -467,6 +468,7 @@ impl FdtWriter {
     }
 
     /// Write a property containing an array of 32-bit unsigned integers.
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
     pub fn property_array_u32(&mut self, name: &str, cells: &[u32]) -> Result<()> {
         let mut arr = Vec::with_capacity(size_of_val(cells));
         for &c in cells {

--- a/os/axvisor/src/vmm/images/mod.rs
+++ b/os/axvisor/src/vmm/images/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ax_errno::{AxResult, ax_err_type};
+use ax_errno::AxResult;
 use axaddrspace::GuestPhysAddr;
 
 use axvm::VMMemoryRegion;

--- a/os/axvisor/src/vmm/images/mod.rs
+++ b/os/axvisor/src/vmm/images/mod.rs
@@ -127,12 +127,12 @@ impl ImageLoader {
                 _dtb_slice.len(),
                 self.vm.clone(),
             );
-            #[cfg(target_arch = "riscv64")]
+            #[cfg(any(target_arch = "loongarch64", target_arch = "riscv64"))]
             load_vm_image_from_memory(_dtb_slice, self.dtb_load_gpa.unwrap(), self.vm.clone())
                 .expect("Failed to load DTB images");
         } else {
             if let Some(buffer) = vm_imags.dtb {
-                #[cfg(target_arch = "riscv64")]
+                #[cfg(any(target_arch = "loongarch64", target_arch = "riscv64"))]
                 load_vm_image_from_memory(buffer, self.dtb_load_gpa.unwrap(), self.vm.clone())
                     .expect("Failed to load DTB images");
             } else {
@@ -308,7 +308,7 @@ pub mod fs {
                 _dtb_slice.len(),
                 loader.vm.clone(),
             );
-            #[cfg(target_arch = "riscv64")]
+            #[cfg(any(target_arch = "loongarch64", target_arch = "riscv64"))]
             load_vm_image_from_memory(_dtb_slice, loader.dtb_load_gpa.unwrap(), loader.vm.clone())
                 .expect("Failed to load DTB images");
         }

--- a/os/axvisor/src/vmm/mod.rs
+++ b/os/axvisor/src/vmm/mod.rs
@@ -21,7 +21,11 @@ pub mod timer;
 pub mod vcpus;
 pub mod vm_list;
 
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "loongarch64",
+    target_arch = "riscv64"
+))]
 pub mod fdt;
 
 use core::sync::atomic::{AtomicUsize, Ordering};

--- a/scripts/axbuild/src/axvisor/build.rs
+++ b/scripts/axbuild/src/axvisor/build.rs
@@ -121,6 +121,7 @@ fn patch_axvisor_cargo_config(
 ) -> anyhow::Result<()> {
     cargo.package = request.package.clone();
     cargo.target = request.target.clone();
+    cargo.to_bin = default_axvisor_to_bin(&request.arch);
     ensure_axvisor_bin_arg(&mut cargo.args);
     cargo
         .env
@@ -142,6 +143,10 @@ fn patch_axvisor_cargo_config(
     cargo.features.sort();
     cargo.features.dedup();
     Ok(())
+}
+
+fn default_axvisor_to_bin(arch: &str) -> bool {
+    !matches!(arch, "x86_64" | "loongarch64")
 }
 
 fn ensure_axvisor_bin_arg(args: &mut Vec<String>) {
@@ -278,7 +283,6 @@ mod tests {
             arch: arch.to_string(),
             target: target.to_string(),
             plat_dyn: None,
-            debug: false,
             build_info_path: path,
             qemu_config: None,
             uboot_config: None,
@@ -387,7 +391,6 @@ plat_dyn = true
             arch: "aarch64".to_string(),
             target: "aarch64-unknown-none-softfloat".to_string(),
             plat_dyn: Some(true),
-            debug: false,
             build_info_path: config_path,
             qemu_config: None,
             uboot_config: None,
@@ -470,7 +473,6 @@ vm_configs = []
             arch: "x86_64".to_string(),
             target: "x86_64-unknown-none".to_string(),
             plat_dyn: None,
-            debug: false,
             build_info_path: path.clone(),
             qemu_config: None,
             uboot_config: None,
@@ -511,7 +513,6 @@ plat_dyn = false
             arch: "aarch64".to_string(),
             target: "aarch64-unknown-none-softfloat".to_string(),
             plat_dyn: Some(false),
-            debug: false,
             build_info_path: config_path,
             qemu_config: None,
             uboot_config: None,
@@ -521,5 +522,67 @@ plat_dyn = false
 
         assert!(!cargo.features.contains(&"ax-std/defplat".to_string()));
         assert!(cargo.features.contains(&"ax-std/myplat".to_string()));
+    }
+
+    #[test]
+    fn load_cargo_config_keeps_loongarch64_elf_as_runtime_artifact() {
+        let root = tempdir().unwrap();
+        let config_path = root.path().join(".build.toml");
+        fs::write(
+            &config_path,
+            r#"
+env = {}
+features = ["ax-std", "ept-level-4"]
+log = "Info"
+plat_dyn = false
+"#,
+        )
+        .unwrap();
+
+        let cargo = load_cargo_config(&ResolvedAxvisorRequest {
+            package: AXVISOR_PACKAGE.to_string(),
+            axvisor_dir: root.path().join("os/axvisor"),
+            arch: "loongarch64".to_string(),
+            target: "loongarch64-unknown-none-softfloat".to_string(),
+            plat_dyn: Some(false),
+            build_info_path: config_path,
+            qemu_config: None,
+            uboot_config: None,
+            vmconfigs: vec![],
+        })
+        .unwrap();
+
+        assert!(!cargo.to_bin);
+    }
+
+    #[test]
+    fn load_cargo_config_keeps_aarch64_bin_conversion() {
+        let root = tempdir().unwrap();
+        let config_path = root.path().join(".build.toml");
+        fs::write(
+            &config_path,
+            r#"
+env = {}
+features = ["ax-std"]
+log = "Info"
+plat_dyn = false
+"#,
+        )
+        .unwrap();
+
+        let cargo = load_cargo_config(&ResolvedAxvisorRequest {
+            package: AXVISOR_PACKAGE.to_string(),
+            axvisor_dir: root.path().join("os/axvisor"),
+            arch: "aarch64".to_string(),
+            target: "aarch64-unknown-none-softfloat".to_string(),
+            plat_dyn: Some(false),
+            build_info_path: config_path,
+            qemu_config: None,
+            uboot_config: None,
+            vmconfigs: vec![],
+        })
+        .unwrap();
+
+        assert!(cargo.to_bin);
     }
 }

--- a/scripts/axbuild/src/axvisor/qemu.rs
+++ b/scripts/axbuild/src/axvisor/qemu.rs
@@ -59,7 +59,8 @@ pub(crate) fn qemu_override_args_from_template(
 
 fn default_qemu_to_bin(arch: &str) -> anyhow::Result<bool> {
     match arch {
-        "aarch64" | "riscv64" | "loongarch64" => Ok(true),
+        "aarch64" | "riscv64" => Ok(true),
+        "loongarch64" => Ok(false),
         "x86_64" => Ok(false),
         _ => anyhow::bail!(
             "unsupported Axvisor architecture `{arch}`; expected one of aarch64, x86_64, riscv64, \
@@ -217,7 +218,6 @@ mod tests {
             arch: arch.to_string(),
             target: target.to_string(),
             plat_dyn: None,
-            debug: false,
             build_info_path: path,
             qemu_config: None,
             uboot_config: None,
@@ -272,6 +272,18 @@ kernel_path = "{}"
     }
 
     #[test]
+    fn loongarch64_default_qemu_run_config_keeps_elf_kernel() {
+        let request = request(
+            PathBuf::from("os/axvisor/.build-loongarch64-unknown-none-softfloat.toml"),
+            "loongarch64",
+            "loongarch64-unknown-none-softfloat",
+        );
+        let run_config = default_qemu_run_config(&request).unwrap();
+
+        assert_eq!(run_config.default_args.to_bin, Some(false));
+    }
+
+    #[test]
     fn default_qemu_run_config_overrides_rootfs_when_vmconfig_provides_one() {
         let root = tempdir().unwrap();
         let image_dir = root.path().join("image");
@@ -297,7 +309,6 @@ kernel_path = "{}"
             arch: "aarch64".to_string(),
             target: "aarch64-unknown-none-softfloat".to_string(),
             plat_dyn: None,
-            debug: false,
             build_info_path: root.path().join(".build.toml"),
             qemu_config: None,
             uboot_config: None,
@@ -339,7 +350,6 @@ uefi = false
                 arch: "aarch64".to_string(),
                 target: "aarch64-unknown-none-softfloat".to_string(),
                 plat_dyn: None,
-                debug: false,
                 build_info_path: axvisor_dir.join(".build.toml"),
                 qemu_config: Some(qemu_config.clone()),
                 uboot_config: None,

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -1,4 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use ostool::{
     Tool, ToolConfig,
@@ -46,6 +51,7 @@ impl AppContext {
     pub(crate) fn new() -> anyhow::Result<Self> {
         let workspace_root = find_workspace_root();
         crate::logging::init_logging(&workspace_root)?;
+        configure_loongarch_qemu_path(&workspace_root)?;
 
         info!("Workspace root: {}", workspace_root.display());
 
@@ -82,7 +88,11 @@ impl AppContext {
         build_config_path: PathBuf,
     ) -> anyhow::Result<()> {
         self.set_build_config_path(build_config_path);
-        self.tool.cargo_build(&cargo).await
+        self.tool.cargo_build(&cargo).await?;
+        if !cargo.to_bin {
+            self.remove_stale_bin_artifact()?;
+        }
+        Ok(())
     }
 
     pub(crate) async fn qemu(
@@ -155,10 +165,98 @@ impl AppContext {
         self.build_config_path = Some(path.clone());
         self.tool.ctx_mut().build_config_path = Some(path);
     }
+
+    fn remove_stale_bin_artifact(&mut self) -> anyhow::Result<()> {
+        let Some(elf_path) = self.tool.ctx().artifacts.elf.as_ref() else {
+            return Ok(());
+        };
+
+        let Some(stem) = elf_path.file_stem() else {
+            return Ok(());
+        };
+
+        let bin_path = elf_path.with_file_name(format!("{}.bin", stem.to_string_lossy()));
+        match fs::remove_file(&bin_path) {
+            Ok(()) => {
+                info!(
+                    "Removed stale BIN artifact for ELF-first build: {}",
+                    bin_path.display()
+                );
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(anyhow::anyhow!(
+                    "failed to remove stale BIN artifact {}: {err}",
+                    bin_path.display()
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Default for AppContext {
     fn default() -> Self {
         Self::new().expect("failed to initialize AppContext")
     }
+}
+
+fn configure_loongarch_qemu_path(workspace_root: &Path) -> anyhow::Result<()> {
+    let Some(qemu_dir) = find_loongarch_qemu_dir(workspace_root) else {
+        return Ok(());
+    };
+
+    prepend_dir_to_path(&qemu_dir)?;
+    info!(
+        "Using LoongArch QEMU from PATH-prepended directory: {}",
+        qemu_dir.display()
+    );
+    Ok(())
+}
+
+fn find_loongarch_qemu_dir(workspace_root: &Path) -> Option<PathBuf> {
+    let env_executable = env::var_os("AXBUILD_QEMU_SYSTEM_LOONGARCH64")
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+        .and_then(|path| path.parent().map(Path::to_path_buf));
+
+    if let Some(dir) = env_executable.filter(|dir| dir.join("qemu-system-loongarch64").exists()) {
+        return Some(dir);
+    }
+
+    let env_dir = env::var_os("AXBUILD_QEMU_DIR")
+        .map(PathBuf::from)
+        .filter(|dir| dir.join("qemu-system-loongarch64").exists());
+
+    if env_dir.is_some() {
+        return env_dir;
+    }
+
+    for ancestor in workspace_root.ancestors() {
+        for suffix in ["QEMU-LVZ/build", "qemu-lvz/build"] {
+            let dir = ancestor.join(suffix);
+            if dir.join("qemu-system-loongarch64").exists() {
+                return Some(dir);
+            }
+        }
+    }
+
+    None
+}
+
+fn prepend_dir_to_path(dir: &Path) -> anyhow::Result<()> {
+    let current = env::var_os("PATH").unwrap_or_default();
+    let mut paths: Vec<PathBuf> = env::split_paths(&current).collect();
+    if paths.iter().any(|path| path == dir) {
+        return Ok(());
+    }
+
+    paths.insert(0, dir.to_path_buf());
+    let joined = env::join_paths(paths.iter())
+        .map_err(|err| anyhow::anyhow!("failed to update PATH with {}: {err}", dir.display()))?;
+
+    unsafe {
+        env::set_var("PATH", OsString::from(joined));
+    }
+    Ok(())
 }

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -14,7 +14,6 @@ fn test_app_context(root: &Path) -> AppContext {
         build_config_path: None,
         root: root.to_path_buf(),
         axvisor_dir: Some(root.join("os/axvisor")),
-        debug: false,
     }
 }
 
@@ -38,6 +37,25 @@ fn prepare_starry_workspace(root: &Path) {
         "[workspace]\nmembers = [\"os/StarryOS/starryos\"]\n",
     )
     .unwrap();
+}
+
+#[test]
+fn remove_stale_bin_artifact_deletes_sibling_bin_for_elf_first_build() {
+    let root = tempdir().unwrap();
+    let mut app = test_app_context(root.path());
+    let artifact_dir = root.path().join("target");
+    fs::create_dir_all(&artifact_dir).unwrap();
+
+    let elf_path = artifact_dir.join("axvisor");
+    let bin_path = artifact_dir.join("axvisor.bin");
+    fs::write(&elf_path, b"elf").unwrap();
+    fs::write(&bin_path, b"bin").unwrap();
+
+    app.tool.ctx_mut().artifacts.elf = Some(elf_path);
+
+    app.remove_stale_bin_artifact().unwrap();
+
+    assert!(!bin_path.exists());
 }
 
 #[test]
@@ -131,7 +149,6 @@ uboot_config = "configs/snapshot-uboot.toml"
                 arch: Some("aarch64".into()),
                 target: Some(DEFAULT_ARCEOS_TARGET.into()),
                 plat_dyn: Some(true),
-                debug: true,
             },
             Some(PathBuf::from("/tmp/qemu.toml")),
             None,
@@ -141,7 +158,6 @@ uboot_config = "configs/snapshot-uboot.toml"
     assert_eq!(request.package, "from-cli");
     assert_eq!(request.target, DEFAULT_ARCEOS_TARGET);
     assert_eq!(request.plat_dyn, Some(true));
-    assert!(request.debug);
     assert_eq!(
         request.build_info_path,
         PathBuf::from("/tmp/custom-build.toml")
@@ -218,7 +234,6 @@ fn prepare_request_resolves_arceos_target_from_arch() {
                 arch: Some("x86_64".into()),
                 target: None,
                 plat_dyn: None,
-                debug: false,
             },
             None,
             None,
@@ -261,7 +276,6 @@ uboot_config = "configs/snapshot-uboot.toml"
                 arch: Some("aarch64".into()),
                 target: Some(DEFAULT_AXVISOR_TARGET.into()),
                 plat_dyn: Some(true),
-                debug: true,
                 vmconfigs: vec![
                     PathBuf::from("/tmp/vm1.toml"),
                     PathBuf::from("/tmp/vm2.toml"),
@@ -276,7 +290,6 @@ uboot_config = "configs/snapshot-uboot.toml"
     assert_eq!(request.arch, DEFAULT_AXVISOR_ARCH);
     assert_eq!(request.target, DEFAULT_AXVISOR_TARGET);
     assert_eq!(request.plat_dyn, Some(true));
-    assert!(request.debug);
     assert_eq!(
         request.build_info_path,
         PathBuf::from("/tmp/custom-build.toml")
@@ -393,7 +406,6 @@ fn prepare_axvisor_request_resolves_target_from_arch() {
                 arch: Some("x86_64".into()),
                 target: None,
                 plat_dyn: None,
-                debug: false,
                 vmconfigs: vec![],
             },
             None,
@@ -502,7 +514,6 @@ uboot_config = "configs/snapshot-uboot.toml"
                 arch: Some("aarch64".into()),
                 target: Some(DEFAULT_STARRY_TARGET.into()),
                 plat_dyn: Some(true),
-                debug: true,
             },
             Some(PathBuf::from("/tmp/qemu.toml")),
             None,
@@ -513,7 +524,6 @@ uboot_config = "configs/snapshot-uboot.toml"
     assert_eq!(request.arch, DEFAULT_STARRY_ARCH);
     assert_eq!(request.target, DEFAULT_STARRY_TARGET);
     assert_eq!(request.plat_dyn, Some(true));
-    assert!(request.debug);
     assert_eq!(
         request.build_info_path,
         PathBuf::from("/tmp/starry-build.toml")
@@ -577,7 +587,6 @@ fn prepare_starry_request_rejects_mismatched_arch_and_target() {
                 arch: Some("aarch64".into()),
                 target: Some("x86_64-unknown-none".into()),
                 plat_dyn: None,
-                debug: false,
             },
             None,
             None,
@@ -609,7 +618,6 @@ target = "aarch64-unknown-none-softfloat"
                 arch: Some("riscv64".into()),
                 target: None,
                 plat_dyn: None,
-                debug: false,
             },
             None,
             None,
@@ -647,7 +655,6 @@ target = "aarch64-unknown-none-softfloat"
                 arch: None,
                 target: Some("x86_64-unknown-none".into()),
                 plat_dyn: None,
-                debug: false,
             },
             None,
             None,

--- a/scripts/link_loongarch64_qemu.x
+++ b/scripts/link_loongarch64_qemu.x
@@ -1,0 +1,135 @@
+/* LoongArch64 QEMU linker script for direct cargo builds. */
+
+OUTPUT_ARCH(loongarch64)
+
+/*
+ * Keep this aligned with axplat-loongarch64-qemu-virt's axconfig.toml:
+ *   kernel-base-vaddr = 0xffff_8000_0020_0000
+ *   kernel-base-paddr = 0x0000_0000_0020_0000
+ *   max-cpu-num = 1
+ */
+BASE_ADDRESS = 0xffff800000200000;
+PHYS_VIRT_OFFSET = 0xffff800000000000;
+PHYS_BASE_ADDRESS = 0x0000000000200000;
+CPU_NUM = 1;
+
+EXTERN(_start)
+/*
+ * QEMU LoongArch direct kernel boot keeps ELF e_entry as-is, so it must point
+ * at the low physical entry even though the linked VMA lives in the higher
+ * half.
+ */
+ENTRY(0x0000000000200040)
+
+SECTIONS
+{
+    . = BASE_ADDRESS;
+    _skernel = .;
+
+    _stext = .;
+    .text : AT(ADDR(.text) - PHYS_VIRT_OFFSET) ALIGN(4K) {
+        /*
+         * The axplat LoongArch boot stub starts with a 64-byte Linux/EFI
+         * boot header. Keep `.text.boot`, but make the ELF entry point land on
+         * the first real instruction after the header.
+         */
+        KEEP(*(.text.boot))
+        _start_actual = _start + 0x40;
+        *(.text .text.*)
+        . = ALIGN(4K);
+    }
+    _etext = .;
+
+    _srodata = .;
+    .rodata : AT(ADDR(.rodata) - PHYS_VIRT_OFFSET) ALIGN(4K) {
+        *(.rodata .rodata.*)
+        *(.srodata .srodata.*)
+    }
+    _erodata = .;
+
+    . = ALIGN(4K);
+    .data : AT(ADDR(.data) - PHYS_VIRT_OFFSET) ALIGN(4K) {
+        _sdata = .;
+        *(.data .data.*)
+        *(.sdata .sdata.*)
+
+        __sdriver_register = .;
+        KEEP(*(.driver.register*))
+        __edriver_register = .;
+    }
+
+    /*
+     * Trap handler slices emitted by `linkme` must live in the regular
+     * higher-half image. If left orphaned, ld can place them at VMA 0, which
+     * makes the trap dispatcher load a NULL handler pointer from the low
+     * linear map and jump to 0x0 once IRQs are enabled.
+     */
+    . = ALIGN(8);
+    .linkme : AT(ADDR(.linkme) - PHYS_VIRT_OFFSET) {
+        __start_linkme_PAGE_FAULT = .;
+        KEEP(*(linkme_PAGE_FAULT))
+        __stop_linkme_PAGE_FAULT = .;
+        __start_linkme_IRQ = .;
+        KEEP(*(linkme_IRQ))
+        __stop_linkme_IRQ = .;
+    }
+
+    .tdata : AT(ADDR(.tdata) - PHYS_VIRT_OFFSET) ALIGN(0x10) {
+        _stdata = .;
+        *(.tdata .tdata.*)
+        _etdata = .;
+    }
+
+    .tbss : AT(ADDR(.tbss) - PHYS_VIRT_OFFSET) ALIGN(0x10) {
+        _stbss = .;
+        *(.tbss .tbss.*)
+        *(.tcommon)
+        _etbss = .;
+    }
+
+    . = ALIGN(64);
+    /*
+     * QEMU LoongArch direct boot loads ELF PT_LOAD segments by translating the
+     * segment VMA through `cpu_loongarch_virt_to_phys()`, not by using
+     * `p_paddr`. Therefore `.percpu` must keep a higher-half VMA here;
+     * otherwise a VMA of 0 would be copied to physical 0x0 instead of the
+     * runtime percpu area at `_percpu_start`.
+     */
+    .percpu : AT(ADDR(.percpu) - PHYS_VIRT_OFFSET) {
+        _percpu_start = .;
+        _percpu_load_start = .;
+        *(.percpu .percpu.*)
+        _percpu_load_end = .;
+        _percpu_load_end_aligned = ALIGN(64);
+        . = _percpu_start
+          + (_percpu_load_end_aligned - _percpu_load_start) * CPU_NUM;
+    }
+    _percpu_end = .;
+
+    . = ALIGN(4K);
+    _edata = .;
+
+    _sbss = .;
+    .bss : AT(ADDR(.bss) - PHYS_VIRT_OFFSET) ALIGN(4K) {
+        boot_stack = .;
+        *(.bss.stack)
+        . = ALIGN(4K);
+        boot_stack_top = .;
+
+        _sbss = .;
+        *(.bss .bss.*)
+        *(.sbss .sbss.*)
+        *(COMMON)
+        . = ALIGN(4K);
+        _ebss = .;
+    }
+
+    _ekernel = .;
+
+    /DISCARD/ : {
+        *(.eh_frame)
+        *(.comment)
+        *(.note)
+        *(.note.gnu.build-id)
+    }
+}

--- a/test-suit/arceos/rust/exception/src/main.rs
+++ b/test-suit/arceos/rust/exception/src/main.rs
@@ -24,9 +24,12 @@ fn raise_break_exception() {
 fn raise_page_fault() {
     use std::os::arceos::modules::ax_hal;
 
-    use ax_hal::{mem::VirtAddr, paging::MappingFlags, trap::page_fault_handler};
+    use ax_hal::{
+        mem::VirtAddr,
+        paging::MappingFlags,
+        trap::{page_fault_handler, set_page_fault_handler},
+    };
 
-    #[page_fault_handler]
     fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
         println!(
             "Page fault @ {:#x}, access_flags: {:?}",
@@ -35,6 +38,8 @@ fn raise_page_fault() {
         println!("Page fault test OK!");
         ax_hal::power::system_off();
     }
+
+    let _ = set_page_fault_handler(handle_page_fault);
 
     let fault_addr = 0xdeadbeef as *mut u8;
     unsafe {


### PR DESCRIPTION
## Summary
- rebase the LoongArch AxVisor integration onto the latest `dev` branch
- inline `loongarch_vcpu` into `components/loongarch_vcpu` instead of using an external git dependency
- update the LoongArch build/link flow and QEMU launch path for ELF-first boot on QEMU-LVZ
- switch trap hook registration to the runtime hook API required by the newer upstream

## Validation
- `cargo run -p tg-xtask -- axvisor build --arch loongarch64 --target loongarch64-unknown-none-softfloat --config os/axvisor/configs/board/qemu-loongarch64.toml`
- `cargo run -p tg-xtask -- axvisor qemu --arch loongarch64 --target loongarch64-unknown-none-softfloat --config os/axvisor/configs/board/qemu-loongarch64.toml --qemu-config os/axvisor/scripts/ostool/qemu-loongarch64.toml`
- verified boot reaches the `axvisor:$` shell on `/home/bullet1517/QEMU-LVZ/build/qemu-system-loongarch64`
