### PR TITLE
fix: restrict dev-dependencies to non-bare-metal targets and add no_std test support

### DIFF
--- a/components/axallocator/Cargo.toml
+++ b/components/axallocator/Cargo.toml
@@ -38,7 +38,7 @@ buddy_system_allocator = { version = "0.10", default-features = false, optional 
 ax_slab_allocator = { version = "0.4", optional = true }
 bitmap-allocator = { version = "0.4.1", optional = true }
 
-[dev-dependencies]
+[target.'cfg(not(target_os = "none"))'.dev-dependencies]
 ax-allocator = { path = ".", features = ["full"] }
 rand = { version = "0.8", features = ["small_rng"] }
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/os/arceos/modules/axlog/Cargo.toml
+++ b/os/arceos/modules/axlog/Cargo.toml
@@ -18,5 +18,6 @@ ax-crate-interface.workspace = true
 ax-kspin.workspace = true
 log.workspace = true
 
-[dev-dependencies]
+# [dev-dependencies]
+[target.'cfg(not(target_os="none"))'.dev-dependencies]
 ax-log = { path = ".", features = ["std"] }

--- a/os/arceos/modules/axsync/Cargo.toml
+++ b/os/arceos/modules/axsync/Cargo.toml
@@ -16,7 +16,7 @@ ax-task.workspace = true
 ax-kspin.workspace = true
 lock_api.workspace = true
 
-[dev-dependencies]
+[target.'cfg(not(target_os = "none"))'.dev-dependencies]
 ax-sync = { path = ".", features = ["multitask"] }
 ax-task = { workspace = true, features = ["test"] }
 # FIXME: `rand` crate can not be used since https://github.com/google/zerocopy/pull/2574

--- a/os/arceos/modules/axsync/src/lib.rs
+++ b/os/arceos/modules/axsync/src/lib.rs
@@ -11,10 +11,35 @@
 //!   not enabled, [`Mutex`] will be an alias of [`spin::SpinNoIrq`]. This
 //!   feature is enabled by default.
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(any(not(test), target_os = "none"), no_std)]
+#![cfg_attr(all(test, target_os = "none"), no_main)]
+#![cfg_attr(all(test, target_os = "none"), feature(custom_test_frameworks))]
 #![cfg_attr(doc, feature(doc_cfg))]
+#![cfg_attr(
+    all(test, target_os = "none"),
+    test_runner(crate::bare_metal_test_runner)
+)]
 
 pub use ax_kspin as spin;
+
+#[cfg(all(test, target_os = "none"))]
+fn bare_metal_test_runner(_tests: &[&dyn Fn()]) {}
+
+#[cfg(all(test, target_os = "none"))]
+#[unsafe(no_mangle)]
+extern "C" fn _start() -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+#[cfg(all(test, target_os = "none"))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}
 
 #[cfg(feature = "multitask")]
 mod mutex;

--- a/os/arceos/modules/axsync/src/mutex.rs
+++ b/os/arceos/modules/axsync/src/mutex.rs
@@ -114,7 +114,7 @@ pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
 /// An alias of [`lock_api::MutexGuard`].
 pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawMutex, T>;
 
-#[cfg(test)]
+#[cfg(all(test, not(target_os = "none")))]
 mod tests {
     use std::sync::Once;
 

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -1,64 +1,64 @@
 [package]
-name = "ax-task"
-version.workspace = true
-repository = "https://github.com/rcore-os/tgoskits"
-edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]
 description = "ArceOS task management module"
+edition.workspace = true
 license.workspace = true
+name = "ax-task"
+repository = "https://github.com/rcore-os/tgoskits"
+version.workspace = true
 
 [features]
 default = []
 
-multitask = [
-    "dep:ax-config",
-    "dep:axpoll",
-    "dep:ax-sched",
-    "dep:ax-cpumask",
-    "dep:ax-crate-interface",
-    "dep:futures-util",
-    "dep:ax-kernel-guard",
-    "dep:ax-kspin",
-    "dep:ax-lazyinit",
-    "dep:ax-memory-addr",
-    "dep:ax-percpu",
-    "dep:spin",
-]
-task-ext = ["dep:extern-trait"]
 irq = ["ax-hal/irq", "dep:ax-timer-list"]
-tls = ["ax-hal/tls"]
+multitask = [
+  "dep:ax-config",
+  "dep:axpoll",
+  "dep:ax-sched",
+  "dep:ax-cpumask",
+  "dep:ax-crate-interface",
+  "dep:futures-util",
+  "dep:ax-kernel-guard",
+  "dep:ax-kspin",
+  "dep:ax-lazyinit",
+  "dep:ax-memory-addr",
+  "dep:ax-percpu",
+  "dep:spin",
+]
 preempt = ["irq", "ax-percpu?/preempt", "ax-kernel-guard/preempt"]
 smp = ["ax-kspin/smp"]
+task-ext = ["dep:extern-trait"]
+tls = ["ax-hal/tls"]
 
+sched-cfs = ["multitask", "preempt"]
 sched-fifo = ["multitask"]
 sched-rr = ["multitask", "preempt"]
-sched-cfs = ["multitask", "preempt"]
 
 test = ["ax-percpu?/sp-naive"]
 
 [dependencies]
-ax-config = { workspace = true, optional = true }
+ax-config = {workspace = true, optional = true}
+ax-cpumask = {version = "0.3.0", optional = true}
+ax-crate-interface = {workspace = true, optional = true}
 ax-errno.workspace = true
 ax-hal.workspace = true
-axpoll = { workspace = true, optional = true }
-ax-sched = { version = "0.5.1", optional = true }
+ax-kernel-guard = {workspace = true, optional = true}
+ax-kspin = {workspace = true, optional = true}
+ax-lazyinit = {workspace = true, optional = true}
+ax-memory-addr = {workspace = true, optional = true}
+ax-percpu = {workspace = true, optional = true}
+ax-sched = {version = "0.5.1", optional = true}
+ax-timer-list = {workspace = true, optional = true}
+axpoll = {workspace = true, optional = true}
 cfg-if.workspace = true
-ax-cpumask = { version = "0.3.0", optional = true }
-ax-crate-interface = { workspace = true, optional = true }
-extern-trait = { version = "0.4", optional = true }
-futures-util = { version = "0.3", default-features = false, optional = true, features = [
-    "alloc",
-    "async-await-macro",
-] }
-ax-kernel-guard = { workspace = true, optional = true }
-ax-kspin = { workspace = true, optional = true }
-ax-lazyinit = { workspace = true, optional = true }
+extern-trait = {version = "0.4", optional = true}
+futures-util = {version = "0.3", default-features = false, optional = true, features = [
+  "alloc",
+  "async-await-macro",
+]}
 log.workspace = true
-ax-memory-addr = { workspace = true, optional = true }
-ax-percpu = { workspace = true, optional = true }
-spin = { workspace = true, optional = true }
-ax-timer-list = { workspace = true, optional = true }
+spin = {workspace = true, optional = true}
 
-[dev-dependencies]
+[target.'cfg(not(target_os = "none"))'.dev-dependencies]
 ax-hal = { workspace = true, features = ["fp-simd"] }
 ax-task = { path = ".", package = "ax-task", features = ["test", "multitask"] }

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -25,11 +25,36 @@
 //! [2]: ax_sched::RRScheduler
 //! [3]: ax_sched::CFScheduler
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(any(not(test), target_os = "none"), no_std)]
+#![cfg_attr(all(test, target_os = "none"), no_main)]
+#![cfg_attr(all(test, target_os = "none"), feature(custom_test_frameworks))]
 #![cfg_attr(doc, feature(doc_cfg))]
+#![cfg_attr(
+    all(test, target_os = "none"),
+    test_runner(crate::bare_metal_test_runner)
+)]
 
-#[cfg(test)]
+#[cfg(all(test, not(target_os = "none")))]
 mod tests;
+
+#[cfg(all(test, target_os = "none"))]
+fn bare_metal_test_runner(_tests: &[&dyn Fn()]) {}
+
+#[cfg(all(test, target_os = "none"))]
+#[unsafe(no_mangle)]
+extern "C" fn _start() -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+#[cfg(all(test, target_os = "none"))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "multitask")] {


### PR DESCRIPTION
## Summary
- restrict `dev-dependencies` in `ax-allocator`, `ax-log`, `ax-sync`, and `ax-task` to non-bare-metal targets
- add minimal bare-metal test harness stubs for `ax-sync` and `ax-task`, while keeping std-only tests behind `not(target_os = "none")`

## Why
Bare-metal test and clippy flows were still pulling in std-only dev-dependencies and test entrypoints, which breaks `no_std` validation paths.

## Impact
- bare-metal builds no longer resolve host-only dev-dependencies for these crates
- host-side std tests remain available on non-`target_os = "none"` targets

## Validation
- `cargo fmt --all --check`
- `cargo xtask clippy --package ax-allocator --package ax-log --package ax-sync --package ax-task`
  - passed for `ax-allocator`, `ax-log`, and `ax-sync`
  - `ax-task` still fails on `feature: smp` because of pre-existing `ax-kspin` clippy errors in `components/kspin/src/base.rs` (unchanged in this branch)
