### PR TITLE
fix(starry): fix preadv/pwritev/preadv2/pwritev2 syscall abi to match linux

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -175,31 +175,49 @@ pub fn sys_pwrite64(
     Ok(write as _)
 }
 
+/// Combine pos_l and pos_h into a single offset, matching Linux
+/// `pos_from_hilo`. On 64-bit, pos_h is unused since the full
+/// offset fits in a single register-width argument.
+fn pos_from_hilo(pos_h: usize, pos_l: usize) -> __kernel_off_t {
+    #[cfg(target_pointer_width = "64")]
+    {
+        pos_l as __kernel_off_t
+    }
+    #[cfg(target_pointer_width = "32")]
+    {
+        (((pos_h as i64) << 32) | (pos_l as i64)) as __kernel_off_t
+    }
+}
+
 pub fn sys_preadv(
     fd: c_int,
     iov: *const IoVec,
     iovcnt: usize,
-    offset: __kernel_off_t,
+    pos_l: usize,
+    pos_h: usize,
 ) -> AxResult<isize> {
-    sys_preadv2(fd, iov, iovcnt, offset, 0)
+    sys_preadv2(fd, iov, iovcnt, pos_l, pos_h, 0)
 }
 
 pub fn sys_pwritev(
     fd: c_int,
     iov: *const IoVec,
     iovcnt: usize,
-    offset: __kernel_off_t,
+    pos_l: usize,
+    pos_h: usize,
 ) -> AxResult<isize> {
-    sys_pwritev2(fd, iov, iovcnt, offset, 0)
+    sys_pwritev2(fd, iov, iovcnt, pos_l, pos_h, 0)
 }
 
 pub fn sys_preadv2(
     fd: c_int,
     iov: *const IoVec,
     iovcnt: usize,
-    offset: __kernel_off_t,
+    pos_l: usize,
+    pos_h: usize,
     _flags: u32,
 ) -> AxResult<isize> {
+    let offset = pos_from_hilo(pos_h, pos_l);
     debug!("sys_preadv2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {_flags}");
     let f = File::from_fd(fd)?;
     f.inner()
@@ -211,13 +229,15 @@ pub fn sys_pwritev2(
     fd: c_int,
     iov: *const IoVec,
     iovcnt: usize,
-    offset: __kernel_off_t,
+    pos_l: usize,
+    pos_h: usize,
     _flags: u32,
 ) -> AxResult<isize> {
+    let offset = pos_from_hilo(pos_h, pos_l);
     debug!("sys_pwritev2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {_flags}");
     let f = File::from_fd(fd)?;
     f.inner()
-        .read_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)
+        .write_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)
         .map(|n| n as _)
 }
 

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -173,12 +173,14 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg1() as _,
             uctx.arg2() as _,
             uctx.arg3() as _,
+            uctx.arg4() as _,
         ),
         Sysno::pwritev => sys_pwritev(
             uctx.arg0() as _,
             uctx.arg1() as _,
             uctx.arg2() as _,
             uctx.arg3() as _,
+            uctx.arg4() as _,
         ),
         Sysno::preadv2 => sys_preadv2(
             uctx.arg0() as _,
@@ -186,6 +188,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg2() as _,
             uctx.arg3() as _,
             uctx.arg4() as _,
+            uctx.arg5() as _,
         ),
         Sysno::pwritev2 => sys_pwritev2(
             uctx.arg0() as _,
@@ -193,6 +196,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg2() as _,
             uctx.arg3() as _,
             uctx.arg4() as _,
+            uctx.arg5() as _,
         ),
         Sysno::sendfile => sys_sendfile(
             uctx.arg0() as _,


### PR DESCRIPTION
1. `sys_pwritev2` 的实现从 `sys_preadv2` 复制过来后，内部调用仍然是 `.read_at()`，导致 pwritev/pwritev2 写入数据被丢弃但返回成功。改为 `.write_at()`。
2. preadv/pwritev/preadv2/pwritev2 的 syscall dispatch 参数数量和 Linux 内核不一致。Linux 内核中 preadv/pwritev 是 `SYSCALL_DEFINE5`（fd, vec, vlen, pos_l, pos_h），preadv2/pwritev2 是 `SYSCALL_DEFINE6`（fd, vec, vlen, pos_l, pos_h, flags）。StarryOS 之前 preadv/pwritev 只读了 4 个参数，preadv2/pwritev2 只读了 5 个参数，导致 flags 读取的寄存器位置错误。