### PR TITLE
Refactor board and QEMU test configuration flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b763acdc1d85c36d61acf97a59938f23202d0e8efe45e8759de10c02db242744"
 dependencies = [
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "log",
  "pci_types",
@@ -353,7 +353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1ce13c5a40e028c7cb68b839880903d97db90fb78065c4f972ffbefbe83dae"
 dependencies = [
  "aarch64-cpu 11.2.0",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "enum_dispatch",
  "log",
  "paste",
@@ -367,7 +367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dda00d35b3c85f4e994746587c4579e63c0ba350b843fca96d6531b609292ae"
 dependencies = [
  "aarch64-cpu 11.2.0",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "enum_dispatch",
  "log",
  "paste",
@@ -579,7 +579,7 @@ dependencies = [
 name = "ax-cap-access"
 version = "0.3.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -850,7 +850,7 @@ dependencies = [
  "ax-sync",
  "axfs-ng-vfs",
  "axpoll",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "chrono",
  "intrusive-collections",
@@ -877,7 +877,7 @@ name = "ax-fs-vfs"
 version = "0.3.2"
 dependencies = [
  "ax-errno",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "log",
 ]
 
@@ -1089,7 +1089,7 @@ dependencies = [
  "ax-task",
  "axfs-ng-vfs",
  "axpoll",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "enum_dispatch",
  "event-listener",
@@ -1107,7 +1107,7 @@ version = "0.8.1"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "ax-memory-addr",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "x86_64",
 ]
 
@@ -1156,7 +1156,7 @@ dependencies = [
  "ax-memory-addr",
  "ax-percpu",
  "ax-plat-macros",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "const-str",
 ]
 
@@ -1300,7 +1300,7 @@ dependencies = [
  "ax-lazyinit",
  "ax-percpu",
  "ax-plat",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "heapless 0.9.2",
  "log",
  "multiboot",
@@ -1461,7 +1461,7 @@ dependencies = [
  "ax-page-table-multiarch",
  "axin",
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "lazy_static",
  "log",
@@ -1595,7 +1595,7 @@ version = "0.1.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf1c27753a96a0f835cca49e6fb354912107d018c905d13c7eff39be757eb5a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "log",
 ]
 
@@ -1605,7 +1605,7 @@ version = "0.3.1"
 dependencies = [
  "ax-errno",
  "axpoll",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "hashbrown 0.16.1",
  "inherit-methods-macro",
@@ -1649,7 +1649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29d8d929fe41fcb361cf784819041f942aba4bcd2d26b9a26305df84e26b206b"
 dependencies = [
  "axplat-macros",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "const-str",
  "crate_interface 0.3.0",
  "handler_table",
@@ -1736,7 +1736,7 @@ dependencies = [
  "ax-lazyinit",
  "ax-percpu",
  "ax-plat",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "heapless 0.9.2",
  "log",
  "multiboot",
@@ -1752,7 +1752,7 @@ dependencies = [
 name = "axpoll"
 version = "0.3.2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "futures",
  "linux-raw-sys 0.12.1",
  "spin 0.10.0",
@@ -1855,7 +1855,7 @@ dependencies = [
  "axvcpu",
  "axvisor_api",
  "axvm",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byte-unit",
  "cfg-if",
  "clap",
@@ -1990,7 +1990,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2062,9 +2062,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitmap-allocator"
@@ -2721,7 +2721,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -2737,7 +2737,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -3578,6 +3578,8 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 [[package]]
 name = "fitimage"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb4d07a1e7a76a7ac4b6b754d45670b1a82c8a0484d80cceeb30c99ad65ce1d"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4068,9 +4070,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -4500,7 +4502,9 @@ dependencies = [
 
 [[package]]
 name = "jkconfig"
-version = "0.2.2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8746ebf553e6e9d0620a918072432b44aa9563f6f19d17432b613828df708a1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4725,7 +4729,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -4768,7 +4772,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4837,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "236e72a07bb26b68662f7cc9dcb58cea50cf5e3d8b698e1b51ff7c36d633dd92"
 dependencies = [
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5073,7 +5077,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5276,7 +5280,9 @@ dependencies = [
 
 [[package]]
 name = "ostool"
-version = "0.12.4"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fdfd25ed01889322bc5a0df562329e5b95481f8beab85043f52875116a031e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5290,7 +5296,7 @@ dependencies = [
  "fitimage",
  "futures",
  "indicatif",
- "jkconfig 0.2.2",
+ "jkconfig 0.2.3",
  "log",
  "lzma-rs",
  "network-interface",
@@ -5345,7 +5351,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "062719187d8cadefaabc0c07c12bd486f8e88760fc02b756da3053f42dff0b4d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "heapless 0.9.2",
  "log",
  "num-align",
@@ -5359,7 +5365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9a63b9b86d32f64c3874a90936939281d045ef1751d0aca3d82d5e4e06b2ef"
 dependencies = [
  "aarch64-cpu 11.2.0",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "memory_addr",
  "x86_64",
 ]
@@ -5414,7 +5420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c2a105c657261a938ff68ee231c199a3d80eef33976004829de761ef5b1a9b"
 dependencies = [
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5424,7 +5430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8b092a434cb4a9dff1321bc486f0d324ce2425f217eb1fe43d34b1d21b03294"
 dependencies = [
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "log",
  "mmio-api",
  "pci_types",
@@ -5586,7 +5592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca870f654bd7302211a92507bd8301f66f83d1e5c97236de79dab7a6d41fcbf1"
 dependencies = [
  "bare-test-macros",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "dma-api 0.2.2",
  "lazy_static",
@@ -5973,7 +5979,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str 0.9.0",
  "hashbrown 0.16.1",
  "indoc",
@@ -6025,7 +6031,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -6053,7 +6059,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6192,7 +6198,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6668610226177053d66d9d3e55436cfa44f6428a5b755b9d7593288b738e3f12"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "futures",
  "heapless 0.9.2",
  "rdif-base 0.7.0",
@@ -6236,7 +6242,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6245,7 +6251,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6420,7 +6426,7 @@ version = "0.4.0"
 dependencies = [
  "bare-metal",
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "log",
  "riscv 0.14.0",
 ]
@@ -6486,7 +6492,7 @@ dependencies = [
  "axvcpu",
  "axvisor_api",
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "log",
  "memoffset",
@@ -6597,7 +6603,7 @@ dependencies = [
 name = "rsext4"
 version = "0.3.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "lazy_static",
  "log",
 ]
@@ -6672,7 +6678,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6685,7 +6691,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -6759,9 +6765,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6903,7 +6909,7 @@ dependencies = [
  "aarch64-cpu 10.0.0",
  "arm_pl011",
  "bare-test-macros",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "dma-api 0.3.1",
  "fdt-parser",
@@ -6926,7 +6932,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7056,7 +7062,7 @@ version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -7281,7 +7287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20ad586f110c679176859fe111f2c3dd176b95bbe731e9b4c3d1c6382cb301c9"
 dependencies = [
  "bare-test-macros",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "dma-api 0.5.2",
  "enum_dispatch",
  "heapless 0.9.2",
@@ -7307,7 +7313,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "buddy_system_allocator 0.12.0",
  "byte-unit",
  "byteorder",
@@ -7430,7 +7436,7 @@ version = "0.4.1-preview.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d994a3a25a5cc4a895b200bd00d8e757515f21f9c21647bd4e9a8e572a326f1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "log",
 ]
 
@@ -7463,7 +7469,7 @@ dependencies = [
  "axbacktrace",
  "axfs-ng-vfs",
  "axpoll",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bitmaps",
  "bytemuck",
  "cfg-if",
@@ -7518,7 +7524,7 @@ dependencies = [
  "ax-cpu",
  "ax-errno",
  "ax-kspin",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "derive_more",
  "event-listener",
@@ -7700,7 +7706,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7783,7 +7789,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -7973,9 +7979,9 @@ checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -8170,7 +8176,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8323,7 +8329,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d293f51425981fdb1b766beae254dbb711a17e8c4b549dc69b9b7ee0d478d5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "rustversion",
  "x86",
 ]
@@ -8334,12 +8340,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cceed8939ba6ebde9d1e8a603b3c7f1a239a3db22e1ff465ed71ddca7a7d66"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uboot-shell"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b3d5d2959cc2e9a28cb2c4ad30f99a33f6831f4f159b08c696604b9494b672"
 dependencies = [
  "colored",
  "futures",
@@ -8368,7 +8376,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe9058b73ee2b6559524af9e33199c13b2485ddbf3ad1181b68051cdc50c17"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "log",
  "ptr_meta 0.3.1",
@@ -8395,7 +8403,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f64fe59e11af447d12fd60a403c74106eb104309f34b4c6dbce6e927d97da9d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "uguid",
 ]
 
@@ -8609,7 +8617,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdc1c628cdd8ce7c3b9e65a8ed550d0338e9ef9f911e729666f1cce097de2f7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "enumn",
  "log",
  "safe-mmio",
@@ -8803,7 +8811,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -9333,7 +9341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -9415,7 +9423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7841fa0098ceb15c567d93d3fae292c49e10a7662b4936d5f6a9728594555ba"
 dependencies = [
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "const_fn",
  "rustversion",
  "volatile 0.4.6",
@@ -9444,7 +9452,7 @@ dependencies = [
  "axvcpu",
  "axvisor_api",
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "log",
  "numeric-enum-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -3578,8 +3578,6 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 [[package]]
 name = "fitimage"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb4d07a1e7a76a7ac4b6b754d45670b1a82c8a0484d80cceeb30c99ad65ce1d"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4503,8 +4501,6 @@ dependencies = [
 [[package]]
 name = "jkconfig"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2488617c3f2fc80740b7a1d4933f58fc0256ba38f4252ff00c71b3aeaa22b1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4836,9 +4832,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loongArch64"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9f0d275c70310e2a9d2fc23250c5ac826a73fa828a5f256401f85c5c554283"
+checksum = "236e72a07bb26b68662f7cc9dcb58cea50cf5e3d8b698e1b51ff7c36d633dd92"
 dependencies = [
  "bit_field",
  "bitflags 2.11.0",
@@ -5281,8 +5277,6 @@ dependencies = [
 [[package]]
 name = "ostool"
 version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94a25414eb69bddeac0caec8c2c394b1e1be792da36476e272a738ac217e14e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8346,8 +8340,6 @@ dependencies = [
 [[package]]
 name = "uboot-shell"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b3d5d2959cc2e9a28cb2c4ad30f99a33f6831f4f159b08c696604b9494b672"
 dependencies = [
  "colored",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,4 +391,4 @@ ax-page-table-multiarch = { version = "0.8.1", features = ["ax-errno"], path = "
 ax-percpu = { version = "0.4.3", path = "components/percpu/percpu" }
 scope-local = { version = "0.3.2", path = "components/scope-local" }
 spin = "0.10"
-ostool = { version = "0.12" }
+ostool = { version = "0.14" }

--- a/os/axvisor/.cargo/config.toml
+++ b/os/axvisor/.cargo/config.toml
@@ -1,3 +1,5 @@
+include = [{path = "../../../.cargo/.config-local.toml", optional = true}]
+
 [net]
 # 使用系统 git 拉取依赖，可利用已配置的 git 凭证（如 gh auth、credential helper）
 git-fetch-with-cli = true

--- a/os/axvisor/configs/board-test/orangepi-5-plus-linux.toml
+++ b/os/axvisor/configs/board-test/orangepi-5-plus-linux.toml
@@ -5,3 +5,4 @@ shell_prefix = "orangepi@orangepi5plus:~"
 success_regex = [
   "(?m)^test pass\\s*$",
 ]
+timeout = 300

--- a/os/axvisor/configs/board-test/phytiumpi-linux.toml
+++ b/os/axvisor/configs/board-test/phytiumpi-linux.toml
@@ -10,3 +10,4 @@ shell_prefix = "login:"
 success_regex = [
   "(?m)^root@.*#\\s*$",
 ]
+timeout = 300

--- a/os/axvisor/configs/board-test/roc-rk3568-pc-linux.toml
+++ b/os/axvisor/configs/board-test/roc-rk3568-pc-linux.toml
@@ -5,3 +5,4 @@ shell_prefix = "root@firefly:~#"
 success_regex = [
   "(?m)^test pass\\s*$",
 ]
+timeout = 300

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -620,7 +620,8 @@ impl ArceOS {
         match request.qemu_config.as_deref() {
             Some(path) => self
                 .app
-                .load_qemu_config_from_path(cargo, &request.build_info_path, path)
+                .tool_mut()
+                .read_qemu_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some),
             None => Ok(None),
@@ -635,7 +636,8 @@ impl ArceOS {
         match request.uboot_config.as_deref() {
             Some(path) => self
                 .app
-                .load_uboot_config_from_path(cargo, &request.build_info_path, path)
+                .tool_mut()
+                .read_uboot_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some),
             None => Ok(None),

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -6,11 +6,12 @@ use std::{
 
 use anyhow::{Context, bail};
 use clap::{Args, Subcommand};
+use ostool::build::config::Cargo;
 use regex::Regex;
 
 use crate::{
     command_flow::{self, SnapshotPersistence},
-    context::{AppContext, BuildCliArgs, QemuRunConfig, ResolvedBuildRequest},
+    context::{AppContext, BuildCliArgs, ResolvedBuildRequest},
     process::ProcessExt,
     test_qemu,
 };
@@ -575,14 +576,13 @@ impl ArceOS {
         uboot_config: Option<PathBuf>,
         persistence: SnapshotPersistence,
     ) -> anyhow::Result<ResolvedBuildRequest> {
-        command_flow::resolve_request(
-            persistence,
-            || {
-                self.app
-                    .prepare_arceos_request(args, qemu_config, uboot_config)
-            },
-            |snapshot| self.app.store_arceos_snapshot(snapshot),
-        )
+        let (request, snapshot) =
+            self.app
+                .prepare_arceos_request(args, qemu_config, uboot_config)?;
+        if matches!(persistence, SnapshotPersistence::Store) {
+            self.app.store_arceos_snapshot(&snapshot)?;
+        }
+        Ok(request)
     }
 
     fn test_build_args(package: &str, target: &str) -> BuildCliArgs {
@@ -612,21 +612,41 @@ impl ArceOS {
         }
     }
 
-    fn qemu_run_config(request: &ResolvedBuildRequest) -> anyhow::Result<QemuRunConfig> {
-        Ok(QemuRunConfig {
-            qemu_config: request.qemu_config.clone(),
-            ..Default::default()
-        })
+    async fn load_qemu_config(
+        &mut self,
+        request: &ResolvedBuildRequest,
+        cargo: &Cargo,
+    ) -> anyhow::Result<Option<ostool::run::qemu::QemuConfig>> {
+        match request.qemu_config.as_deref() {
+            Some(path) => self
+                .app
+                .load_qemu_config_from_path(cargo, &request.build_info_path, path)
+                .await
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    async fn load_uboot_config(
+        &mut self,
+        request: &ResolvedBuildRequest,
+        cargo: &Cargo,
+    ) -> anyhow::Result<Option<ostool::run::uboot::UbootConfig>> {
+        match request.uboot_config.as_deref() {
+            Some(path) => self
+                .app
+                .load_uboot_config_from_path(cargo, &request.build_info_path, path)
+                .await
+                .map(Some),
+            None => Ok(None),
+        }
     }
 
     async fn run_qemu_request(&mut self, request: ResolvedBuildRequest) -> anyhow::Result<()> {
-        command_flow::run_qemu(
-            &mut self.app,
-            request,
-            build::load_cargo_config,
-            Self::qemu_run_config,
-        )
-        .await
+        self.app.set_debug_mode(request.debug)?;
+        let cargo = build::load_cargo_config(&request)?;
+        let qemu = self.load_qemu_config(&request, &cargo).await?;
+        self.app.qemu(cargo, request.build_info_path, qemu).await
     }
 
     async fn run_build_request(&mut self, request: ResolvedBuildRequest) -> anyhow::Result<()> {
@@ -634,7 +654,10 @@ impl ArceOS {
     }
 
     async fn run_uboot_request(&mut self, request: ResolvedBuildRequest) -> anyhow::Result<()> {
-        command_flow::run_uboot(&mut self.app, request, build::load_cargo_config).await
+        self.app.set_debug_mode(request.debug)?;
+        let cargo = build::load_cargo_config(&request)?;
+        let uboot = self.load_uboot_config(&request, &cargo).await?;
+        self.app.uboot(cargo, request.build_info_path, uboot).await
     }
 }
 

--- a/scripts/axbuild/src/axvisor/mod.rs
+++ b/scripts/axbuild/src/axvisor/mod.rs
@@ -87,7 +87,7 @@ impl Axvisor {
         self.app.set_debug_mode(request.debug)?;
         let cargo = build::load_cargo_config(&request)?;
         let board_config = self
-            .load_board_config(&request, &cargo, args.board_config.as_deref())
+            .load_board_config(&cargo, args.board_config.as_deref())
             .await?;
         self.app
             .board(
@@ -258,7 +258,7 @@ impl Axvisor {
                 )?;
                 let cargo = build::load_cargo_config(&request)?;
                 let board_config = self
-                    .load_board_config(&request, &cargo, Some(board_test_config.as_path()))
+                    .load_board_config(&cargo, Some(board_test_config.as_path()))
                     .await?;
                 self.app
                     .board(
@@ -323,7 +323,8 @@ impl Axvisor {
         });
         let mut qemu = self
             .app
-            .load_qemu_config_from_path(cargo, &request.build_info_path, &config_path)
+            .tool_mut()
+            .read_qemu_config_from_path_for_cargo(cargo, &config_path)
             .await?;
         qemu::apply_rootfs_path(&mut qemu, request)?;
         Ok(qemu)
@@ -337,7 +338,8 @@ impl Axvisor {
         match request.uboot_config.as_deref() {
             Some(path) => self
                 .app
-                .load_uboot_config_from_path(cargo, &request.build_info_path, path)
+                .tool_mut()
+                .read_uboot_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some),
             None => Ok(None),
@@ -346,24 +348,21 @@ impl Axvisor {
 
     async fn load_board_config(
         &mut self,
-        request: &ResolvedAxvisorRequest,
         cargo: &Cargo,
         board_config_path: Option<&Path>,
     ) -> anyhow::Result<BoardRunConfig> {
         match board_config_path {
             Some(path) => {
                 self.app
-                    .load_board_run_config_from_path(cargo, &request.build_info_path, path)
+                    .tool_mut()
+                    .read_board_run_config_from_path_for_cargo(cargo, path)
                     .await
             }
             None => {
                 let workspace_root = self.app.workspace_root().to_path_buf();
                 self.app
-                    .load_board_run_config_from_dir(
-                        cargo,
-                        &request.build_info_path,
-                        &workspace_root,
-                    )
+                    .tool_mut()
+                    .ensure_board_run_config_in_dir_for_cargo(cargo, &workspace_root)
                     .await
             }
         }

--- a/scripts/axbuild/src/axvisor/mod.rs
+++ b/scripts/axbuild/src/axvisor/mod.rs
@@ -1,12 +1,15 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use ostool::board::RunBoardArgs;
+use ostool::{
+    board::{RunBoardOptions, config::BoardRunConfig},
+    build::config::Cargo,
+};
 
 use crate::{
     axvisor::context::AxvisorContext,
     command_flow::{self, SnapshotPersistence},
-    context::{AppContext, AxvisorCliArgs, QemuRunConfig, ResolvedAxvisorRequest},
+    context::{AppContext, AxvisorCliArgs, ResolvedAxvisorRequest},
     test_qemu,
 };
 
@@ -83,13 +86,15 @@ impl Axvisor {
             self.prepare_request((&args.build).into(), None, None, SnapshotPersistence::Store)?;
         self.app.set_debug_mode(request.debug)?;
         let cargo = build::load_cargo_config(&request)?;
+        let board_config = self
+            .load_board_config(&request, &cargo, args.board_config.as_deref())
+            .await?;
         self.app
             .board(
                 cargo,
                 request.build_info_path,
-                RunBoardArgs {
-                    config: None,
-                    board_config: args.board_config,
+                board_config,
+                RunBoardOptions {
                     board_type: args.board_type,
                     server: args.server,
                     port: args.port,
@@ -153,21 +158,13 @@ impl Axvisor {
             None,
             SnapshotPersistence::Discard,
         )?;
-        let qemu_config =
-            qemu::default_qemu_config_template_path(&request.axvisor_dir, &request.arch);
         let shell = test_qemu::axvisor_test_shell_config(arch)?;
-        let override_args = qemu_test::shell_autoinit_qemu_override_args(&request, &shell)?;
+        let cargo = build::load_cargo_config(&request)?;
+        let mut qemu_config = self.load_qemu_config(&request, &cargo).await?;
+        qemu_test::apply_shell_autoinit_config(&mut qemu_config, &shell);
 
         self.app
-            .qemu(
-                build::load_cargo_config(&request)?,
-                request.build_info_path,
-                QemuRunConfig {
-                    qemu_config: Some(qemu_config),
-                    override_args,
-                    ..Default::default()
-                },
-            )
+            .qemu(cargo, request.build_info_path, Some(qemu_config))
             .await
             .with_context(|| "axvisor qemu test failed")
     }
@@ -203,8 +200,9 @@ impl Axvisor {
         request.uboot_config = explicit_uboot_config;
 
         let cargo = build::load_cargo_config(&request)?;
+        let uboot = self.load_uboot_config(&request, &cargo).await?;
         self.app
-            .uboot(cargo, request.build_info_path, request.uboot_config)
+            .uboot(cargo, request.build_info_path, uboot)
             .await
             .with_context(|| {
                 format!(
@@ -259,13 +257,15 @@ impl Axvisor {
                     SnapshotPersistence::Discard,
                 )?;
                 let cargo = build::load_cargo_config(&request)?;
+                let board_config = self
+                    .load_board_config(&request, &cargo, Some(board_test_config.as_path()))
+                    .await?;
                 self.app
                     .board(
                         cargo,
                         request.build_info_path,
-                        RunBoardArgs {
-                            config: None,
-                            board_config: Some(board_test_config.clone()),
+                        board_config,
+                        RunBoardOptions {
                             board_type: args.board_type.clone(),
                             server: args.server.clone(),
                             port: args.port,
@@ -313,27 +313,69 @@ impl Axvisor {
         Ok(request)
     }
 
-    fn qemu_run_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<QemuRunConfig> {
-        if let Some(path) = request.qemu_config.clone() {
-            let override_args = qemu::qemu_override_args_from_template(&path, request)?;
-            Ok(QemuRunConfig {
-                qemu_config: Some(path),
-                override_args,
-                ..Default::default()
-            })
-        } else {
-            qemu::default_qemu_run_config(request)
+    async fn load_qemu_config(
+        &mut self,
+        request: &ResolvedAxvisorRequest,
+        cargo: &Cargo,
+    ) -> anyhow::Result<ostool::run::qemu::QemuConfig> {
+        let config_path = request.qemu_config.clone().unwrap_or_else(|| {
+            qemu::default_qemu_config_template_path(&request.axvisor_dir, &request.arch)
+        });
+        let mut qemu = self
+            .app
+            .load_qemu_config_from_path(cargo, &request.build_info_path, &config_path)
+            .await?;
+        qemu::apply_rootfs_path(&mut qemu, request)?;
+        Ok(qemu)
+    }
+
+    async fn load_uboot_config(
+        &mut self,
+        request: &ResolvedAxvisorRequest,
+        cargo: &Cargo,
+    ) -> anyhow::Result<Option<ostool::run::uboot::UbootConfig>> {
+        match request.uboot_config.as_deref() {
+            Some(path) => self
+                .app
+                .load_uboot_config_from_path(cargo, &request.build_info_path, path)
+                .await
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    async fn load_board_config(
+        &mut self,
+        request: &ResolvedAxvisorRequest,
+        cargo: &Cargo,
+        board_config_path: Option<&Path>,
+    ) -> anyhow::Result<BoardRunConfig> {
+        match board_config_path {
+            Some(path) => {
+                self.app
+                    .load_board_run_config_from_path(cargo, &request.build_info_path, path)
+                    .await
+            }
+            None => {
+                let workspace_root = self.app.workspace_root().to_path_buf();
+                self.app
+                    .load_board_run_config_from_dir(
+                        cargo,
+                        &request.build_info_path,
+                        &workspace_root,
+                    )
+                    .await
+            }
         }
     }
 
     async fn run_qemu_request(&mut self, request: ResolvedAxvisorRequest) -> anyhow::Result<()> {
-        command_flow::run_qemu(
-            &mut self.app,
-            request,
-            build::load_cargo_config,
-            Self::qemu_run_config,
-        )
-        .await
+        self.app.set_debug_mode(request.debug)?;
+        let cargo = build::load_cargo_config(&request)?;
+        let qemu = self.load_qemu_config(&request, &cargo).await?;
+        self.app
+            .qemu(cargo, request.build_info_path, Some(qemu))
+            .await
     }
 
     async fn run_build_request(&mut self, request: ResolvedAxvisorRequest) -> anyhow::Result<()> {
@@ -341,7 +383,10 @@ impl Axvisor {
     }
 
     async fn run_uboot_request(&mut self, request: ResolvedAxvisorRequest) -> anyhow::Result<()> {
-        command_flow::run_uboot(&mut self.app, request, build::load_cargo_config).await
+        self.app.set_debug_mode(request.debug)?;
+        let cargo = build::load_cargo_config(&request)?;
+        let uboot = self.load_uboot_config(&request, &cargo).await?;
+        self.app.uboot(cargo, request.build_info_path, uboot).await
     }
 }
 
@@ -354,7 +399,7 @@ impl Default for Axvisor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::{ResolvedAxvisorRequest, workspace_member_dir, workspace_root_path};
+    use crate::context::{workspace_member_dir, workspace_root_path};
 
     #[test]
     fn context_resolves_workspace_root() {
@@ -372,22 +417,12 @@ mod tests {
     }
 
     #[test]
-    fn default_qemu_run_config_lets_ostool_resolve_default_path() {
-        let run_config = qemu::default_qemu_run_config(&ResolvedAxvisorRequest {
-            package: "axvisor".to_string(),
-            axvisor_dir: PathBuf::from("os/axvisor"),
-            arch: "aarch64".to_string(),
-            target: "aarch64-unknown-none-softfloat".to_string(),
-            plat_dyn: None,
-            debug: false,
-            build_info_path: PathBuf::from("os/axvisor/.build-aarch64-unknown-none-softfloat.toml"),
-            qemu_config: None,
-            uboot_config: None,
-            vmconfigs: vec![],
-        })
-        .unwrap();
+    fn default_qemu_template_path_uses_axvisor_script_location() {
+        let path = qemu::default_qemu_config_template_path(Path::new("os/axvisor"), "aarch64");
 
-        assert_eq!(run_config.qemu_config, None);
-        assert!(run_config.default_args.args.is_some());
+        assert_eq!(
+            path,
+            PathBuf::from("os/axvisor/scripts/ostool/qemu-aarch64.toml")
+        );
     }
 }

--- a/scripts/axbuild/src/axvisor/qemu.rs
+++ b/scripts/axbuild/src/axvisor/qemu.rs
@@ -3,9 +3,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ostool::{build::CargoQemuOverrideArgs, run::qemu::QemuConfig};
+use ostool::run::qemu::QemuConfig;
 
-use crate::context::{QemuRunConfig, ResolvedAxvisorRequest};
+use crate::context::ResolvedAxvisorRequest;
 
 const LEGACY_DEFAULT_ROOTFS: &str = "${workspaceFolder}/tmp/rootfs.img";
 const AXVISOR_DEFAULT_ROOTFS: &str = "${workspaceFolder}/os/axvisor/tmp/rootfs.img";
@@ -14,134 +14,14 @@ pub(crate) fn default_qemu_config_template_path(axvisor_dir: &Path, arch: &str) 
     axvisor_dir.join(format!("scripts/ostool/qemu-{arch}.toml"))
 }
 
-pub(crate) fn default_qemu_run_config(
+pub(crate) fn apply_rootfs_path(
+    config: &mut QemuConfig,
     request: &ResolvedAxvisorRequest,
-) -> anyhow::Result<QemuRunConfig> {
-    let default_rootfs = default_rootfs_path(&request.axvisor_dir);
-    let default_args = CargoQemuOverrideArgs {
-        to_bin: Some(default_qemu_to_bin(&request.arch)?),
-        args: Some(default_runtime_qemu_args(
-            &request.arch,
-            Some(&default_rootfs),
-        )),
-        ..Default::default()
-    };
-
-    let override_args = infer_rootfs_path(&request.vmconfigs)?.and_then(|rootfs_path| {
-        (rootfs_path != default_rootfs).then_some(CargoQemuOverrideArgs {
-            args: Some(default_runtime_qemu_args(&request.arch, Some(&rootfs_path))),
-            ..Default::default()
-        })
-    });
-
-    Ok(QemuRunConfig {
-        qemu_config: None,
-        default_args,
-        override_args: override_args.unwrap_or_default(),
-        ..Default::default()
-    })
-}
-
-pub(crate) fn qemu_override_args_from_template(
-    template_path: &Path,
-    request: &ResolvedAxvisorRequest,
-) -> anyhow::Result<CargoQemuOverrideArgs> {
-    let mut config = load_qemu_config(template_path)?;
+) -> anyhow::Result<()> {
     let rootfs_path = infer_rootfs_path(&request.vmconfigs)?
         .unwrap_or_else(|| default_rootfs_path(&request.axvisor_dir));
-    replace_rootfs_arg(&mut config.args, &rootfs_path);
-
-    Ok(CargoQemuOverrideArgs {
-        args: Some(config.args),
-        ..Default::default()
-    })
-}
-
-fn default_qemu_to_bin(arch: &str) -> anyhow::Result<bool> {
-    match arch {
-        "aarch64" | "riscv64" | "loongarch64" => Ok(true),
-        "x86_64" => Ok(false),
-        _ => anyhow::bail!(
-            "unsupported Axvisor architecture `{arch}`; expected one of aarch64, x86_64, riscv64, \
-             loongarch64"
-        ),
-    }
-}
-
-fn default_runtime_qemu_args(arch: &str, rootfs_path: Option<&Path>) -> Vec<String> {
-    let rootfs = rootfs_path
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|| AXVISOR_DEFAULT_ROOTFS.to_string());
-
-    match arch {
-        "aarch64" => vec![
-            "-nographic".to_string(),
-            "-cpu".to_string(),
-            "cortex-a72".to_string(),
-            "-machine".to_string(),
-            "virt,virtualization=on,gic-version=3".to_string(),
-            "-smp".to_string(),
-            "4".to_string(),
-            "-device".to_string(),
-            "virtio-blk-device,drive=disk0".to_string(),
-            "-drive".to_string(),
-            format!("id=disk0,if=none,format=raw,file={rootfs}"),
-            "-append".to_string(),
-            "root=/dev/vda rw init=/init".to_string(),
-            "-m".to_string(),
-            "8g".to_string(),
-        ],
-        "riscv64" => vec![
-            "-nographic".to_string(),
-            "-cpu".to_string(),
-            "rv64".to_string(),
-            "-machine".to_string(),
-            "virt".to_string(),
-            "-bios".to_string(),
-            "default".to_string(),
-            "-smp".to_string(),
-            "4".to_string(),
-            "-device".to_string(),
-            "virtio-blk-device,drive=disk0".to_string(),
-            "-drive".to_string(),
-            format!("id=disk0,if=none,format=raw,file={rootfs}"),
-            "-append".to_string(),
-            "root=/dev/vda rw init=/init".to_string(),
-            "-m".to_string(),
-            "4g".to_string(),
-        ],
-        "x86_64" => vec![
-            "-nographic".to_string(),
-            "-cpu".to_string(),
-            "host".to_string(),
-            "-machine".to_string(),
-            "q35".to_string(),
-            "-smp".to_string(),
-            "1".to_string(),
-            "-accel".to_string(),
-            "kvm".to_string(),
-            "-device".to_string(),
-            "virtio-blk-pci,drive=disk0".to_string(),
-            "-drive".to_string(),
-            format!("id=disk0,if=none,format=raw,file={rootfs}"),
-            "-m".to_string(),
-            "128M".to_string(),
-        ],
-        "loongarch64" => vec![
-            "-nographic".to_string(),
-            "-smp".to_string(),
-            "4".to_string(),
-            "-device".to_string(),
-            "virtio-blk-device,drive=disk0".to_string(),
-            "-drive".to_string(),
-            format!("id=disk0,if=none,format=raw,file={rootfs}"),
-            "-append".to_string(),
-            "root=/dev/vda rw init=/init".to_string(),
-            "-m".to_string(),
-            "4g".to_string(),
-        ],
-        _ => vec![],
-    }
+    ensure_rootfs_drive_arg(&mut config.args, &rootfs_path);
+    Ok(())
 }
 
 fn default_rootfs_path(axvisor_dir: &Path) -> PathBuf {
@@ -173,6 +53,7 @@ pub(crate) fn infer_rootfs_path(vmconfigs: &[PathBuf]) -> anyhow::Result<Option<
     Ok(None)
 }
 
+#[cfg(test)]
 fn load_qemu_config(path: &Path) -> anyhow::Result<QemuConfig> {
     let content = fs::read_to_string(path).map_err(|e| {
         anyhow!(
@@ -188,16 +69,39 @@ fn load_qemu_config(path: &Path) -> anyhow::Result<QemuConfig> {
     })
 }
 
-fn replace_rootfs_arg(args: &mut Vec<String>, rootfs_path: &Path) {
+fn ensure_rootfs_drive_arg(args: &mut Vec<String>, rootfs_path: &Path) {
     let rootfs_path = rootfs_path.display().to_string();
+    let replacement = format!("id=disk0,if=none,format=raw,file={rootfs_path}");
+    let mut replaced = false;
 
-    for arg in args {
+    for arg in args.iter_mut() {
         if arg.contains(LEGACY_DEFAULT_ROOTFS) {
             *arg = arg.replace(LEGACY_DEFAULT_ROOTFS, &rootfs_path);
+            replaced = true;
         }
         if arg.contains(AXVISOR_DEFAULT_ROOTFS) {
             *arg = arg.replace(AXVISOR_DEFAULT_ROOTFS, &rootfs_path);
+            replaced = true;
         }
+        if arg.starts_with("id=disk0,if=none,format=raw,file=") {
+            *arg = replacement.clone();
+            replaced = true;
+        }
+    }
+
+    if replaced {
+        return;
+    }
+
+    if let Some(device_pos) = args.iter().position(|arg| {
+        matches!(
+            arg.as_str(),
+            "virtio-blk-device,drive=disk0" | "virtio-blk-pci,drive=disk0"
+        )
+    }) {
+        let insert_pos = device_pos + 1;
+        args.insert(insert_pos, "-drive".to_string());
+        args.insert(insert_pos + 1, replacement);
     }
 }
 
@@ -206,24 +110,6 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-
-    fn request(path: PathBuf, arch: &str, target: &str) -> ResolvedAxvisorRequest {
-        ResolvedAxvisorRequest {
-            package: crate::axvisor::build::AXVISOR_PACKAGE.to_string(),
-            axvisor_dir: path
-                .parent()
-                .map(Path::to_path_buf)
-                .unwrap_or_else(|| PathBuf::from("os/axvisor")),
-            arch: arch.to_string(),
-            target: target.to_string(),
-            plat_dyn: None,
-            debug: false,
-            build_info_path: path,
-            qemu_config: None,
-            uboot_config: None,
-            vmconfigs: vec![],
-        }
-    }
 
     #[test]
     fn infer_rootfs_path_uses_vmconfig_kernel_sibling() {
@@ -251,28 +137,7 @@ kernel_path = "{}"
     }
 
     #[test]
-    fn default_qemu_run_config_uses_ostool_default_path_resolution() {
-        let request = request(
-            PathBuf::from("os/axvisor/.build-aarch64-unknown-none-softfloat.toml"),
-            "aarch64",
-            "aarch64-unknown-none-softfloat",
-        );
-        let run_config = default_qemu_run_config(&request).unwrap();
-
-        assert!(run_config.qemu_config.is_none());
-        assert_eq!(run_config.default_args.to_bin, Some(true));
-        assert_eq!(
-            run_config.default_args.args,
-            Some(default_runtime_qemu_args(
-                "aarch64",
-                Some(&default_rootfs_path(&request.axvisor_dir))
-            ))
-        );
-        assert!(run_config.override_args.args.is_none());
-    }
-
-    #[test]
-    fn default_qemu_run_config_overrides_rootfs_when_vmconfig_provides_one() {
+    fn apply_rootfs_path_overrides_rootfs_when_vmconfig_provides_one() {
         let root = tempdir().unwrap();
         let image_dir = root.path().join("image");
         fs::create_dir_all(&image_dir).unwrap();
@@ -291,48 +156,51 @@ kernel_path = "{}"
         )
         .unwrap();
 
-        let run_config = default_qemu_run_config(&ResolvedAxvisorRequest {
-            package: crate::axvisor::build::AXVISOR_PACKAGE.to_string(),
-            axvisor_dir: root.path().join("os/axvisor"),
-            arch: "aarch64".to_string(),
-            target: "aarch64-unknown-none-softfloat".to_string(),
-            plat_dyn: None,
-            debug: false,
-            build_info_path: root.path().join(".build.toml"),
-            qemu_config: None,
-            uboot_config: None,
-            vmconfigs: vec![vmconfig],
-        })
+        let mut qemu = QemuConfig {
+            args: vec![format!(
+                "id=disk0,if=none,format=raw,file={AXVISOR_DEFAULT_ROOTFS}"
+            )],
+            ..Default::default()
+        };
+        apply_rootfs_path(
+            &mut qemu,
+            &ResolvedAxvisorRequest {
+                package: crate::axvisor::build::AXVISOR_PACKAGE.to_string(),
+                axvisor_dir: root.path().join("os/axvisor"),
+                arch: "aarch64".to_string(),
+                target: "aarch64-unknown-none-softfloat".to_string(),
+                plat_dyn: None,
+                debug: false,
+                build_info_path: root.path().join(".build.toml"),
+                qemu_config: None,
+                uboot_config: None,
+                vmconfigs: vec![vmconfig],
+            },
+        )
         .unwrap();
 
         assert_eq!(
-            run_config.override_args.args,
-            Some(default_runtime_qemu_args("aarch64", Some(&rootfs_path)))
+            qemu.args,
+            vec![format!(
+                "id=disk0,if=none,format=raw,file={}",
+                rootfs_path.display()
+            )]
         );
     }
 
     #[test]
-    fn qemu_override_args_from_template_uses_axvisor_tmp_rootfs_by_default() {
+    fn apply_rootfs_path_uses_axvisor_tmp_rootfs_by_default() {
         let root = tempdir().unwrap();
         let axvisor_dir = root.path().join("os/axvisor");
-        let qemu_config = root.path().join("qemu-aarch64.toml");
-        fs::create_dir_all(axvisor_dir.join("tmp")).unwrap();
-        fs::write(
-            &qemu_config,
-            format!(
-                r#"
-args = ["-drive", "id=disk0,if=none,format=raw,file={AXVISOR_DEFAULT_ROOTFS}"]
-success_regex = []
-fail_regex = []
-to_bin = true
-uefi = false
-"#
-            ),
-        )
-        .unwrap();
+        let mut qemu = QemuConfig {
+            args: vec![format!(
+                "id=disk0,if=none,format=raw,file={AXVISOR_DEFAULT_ROOTFS}"
+            )],
+            ..Default::default()
+        };
 
-        let overrides = qemu_override_args_from_template(
-            &qemu_config,
+        apply_rootfs_path(
+            &mut qemu,
             &ResolvedAxvisorRequest {
                 package: crate::axvisor::build::AXVISOR_PACKAGE.to_string(),
                 axvisor_dir: axvisor_dir.clone(),
@@ -341,7 +209,7 @@ uefi = false
                 plat_dyn: None,
                 debug: false,
                 build_info_path: axvisor_dir.join(".build.toml"),
-                qemu_config: Some(qemu_config.clone()),
+                qemu_config: None,
                 uboot_config: None,
                 vmconfigs: vec![],
             },
@@ -349,14 +217,80 @@ uefi = false
         .unwrap();
 
         assert_eq!(
-            overrides.args,
-            Some(vec![
+            qemu.args,
+            vec![format!(
+                "id=disk0,if=none,format=raw,file={}",
+                axvisor_dir.join("tmp/rootfs.img").display()
+            )]
+        );
+    }
+
+    #[test]
+    fn apply_rootfs_path_inserts_drive_arg_when_template_omits_it() {
+        let root = tempdir().unwrap();
+        let axvisor_dir = root.path().join("os/axvisor");
+        let mut qemu = QemuConfig {
+            args: vec![
+                "-device".to_string(),
+                "virtio-blk-device,drive=disk0".to_string(),
+                "-append".to_string(),
+                "root=/dev/vda rw init=/init".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        apply_rootfs_path(
+            &mut qemu,
+            &ResolvedAxvisorRequest {
+                package: crate::axvisor::build::AXVISOR_PACKAGE.to_string(),
+                axvisor_dir: axvisor_dir.clone(),
+                arch: "aarch64".to_string(),
+                target: "aarch64-unknown-none-softfloat".to_string(),
+                plat_dyn: None,
+                debug: false,
+                build_info_path: axvisor_dir.join(".build.toml"),
+                qemu_config: None,
+                uboot_config: None,
+                vmconfigs: vec![],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            qemu.args,
+            vec![
+                "-device".to_string(),
+                "virtio-blk-device,drive=disk0".to_string(),
                 "-drive".to_string(),
                 format!(
                     "id=disk0,if=none,format=raw,file={}",
                     axvisor_dir.join("tmp/rootfs.img").display()
-                )
-            ])
+                ),
+                "-append".to_string(),
+                "root=/dev/vda rw init=/init".to_string(),
+            ]
         );
+    }
+
+    #[test]
+    fn load_qemu_config_parses_template_file() {
+        let root = tempdir().unwrap();
+        let qemu_config = root.path().join("qemu-aarch64.toml");
+        fs::write(
+            &qemu_config,
+            r#"
+args = ["-nographic"]
+success_regex = []
+fail_regex = []
+to_bin = true
+uefi = false
+"#,
+        )
+        .unwrap();
+
+        let qemu = load_qemu_config(&qemu_config).unwrap();
+
+        assert_eq!(qemu.args, vec!["-nographic".to_string()]);
+        assert!(qemu.to_bin);
     }
 }

--- a/scripts/axbuild/src/axvisor/qemu_test.rs
+++ b/scripts/axbuild/src/axvisor/qemu_test.rs
@@ -4,15 +4,14 @@ use std::{
 };
 
 use anyhow::Context;
-use ostool::build::CargoQemuOverrideArgs;
+use ostool::run::qemu::QemuConfig;
 
 use crate::{
     axvisor::{
         context::AxvisorContext,
         image::{config::ImageConfig, spec::ImageSpecRef, storage::Storage},
-        qemu::{default_qemu_config_template_path, qemu_override_args_from_template},
     },
-    context::{AxvisorCliArgs, ResolvedAxvisorRequest},
+    context::AxvisorCliArgs,
 };
 
 pub const LINUX_AARCH64_IMAGE_SPEC: &str = "qemu_aarch64_linux";
@@ -109,17 +108,11 @@ pub(crate) async fn prepare_nimbos_x86_64_guest_vmconfig(
     Ok(ctx.workspace_root().join(NIMBOS_X86_64_VMCONFIG))
 }
 
-pub(crate) fn shell_autoinit_qemu_override_args(
-    request: &ResolvedAxvisorRequest,
-    shell: &ShellAutoInitConfig,
-) -> anyhow::Result<CargoQemuOverrideArgs> {
-    let template_path = default_qemu_config_template_path(&request.axvisor_dir, &request.arch);
-    let mut overrides = qemu_override_args_from_template(&template_path, request)?;
-    overrides.success_regex = Some(shell.success_regex.clone());
-    overrides.fail_regex = Some(shell.fail_regex.clone());
-    overrides.shell_prefix = Some(shell.shell_prefix.clone());
-    overrides.shell_init_cmd = Some(shell.shell_init_cmd.clone());
-    Ok(overrides)
+pub(crate) fn apply_shell_autoinit_config(config: &mut QemuConfig, shell: &ShellAutoInitConfig) {
+    config.success_regex = shell.success_regex.clone();
+    config.fail_regex = shell.fail_regex.clone();
+    config.shell_prefix = Some(shell.shell_prefix.clone());
+    config.shell_init_cmd = Some(shell.shell_init_cmd.clone());
 }
 
 fn generate_linux_vmconfig(
@@ -293,56 +286,29 @@ entry_point = 1
     }
 
     #[test]
-    fn shell_autoinit_qemu_override_args_preserves_existing_args() {
-        let dir = tempdir().unwrap();
-        let qemu_config = dir
-            .path()
-            .join("os/axvisor/scripts/ostool/qemu-aarch64.toml");
-        fs::create_dir_all(qemu_config.parent().unwrap()).unwrap();
-        fs::write(
-            &qemu_config,
-            r#"
-args = ["-nographic"]
-success_regex = []
-fail_regex = []
-to_bin = true
-uefi = false
-"#,
-        )
-        .unwrap();
+    fn apply_shell_autoinit_config_preserves_existing_args() {
+        let mut qemu = QemuConfig {
+            args: vec!["-nographic".to_string()],
+            ..Default::default()
+        };
 
-        let overrides = shell_autoinit_qemu_override_args(
-            &ResolvedAxvisorRequest {
-                package: "axvisor".to_string(),
-                axvisor_dir: dir.path().join("os/axvisor"),
-                arch: "aarch64".to_string(),
-                target: "aarch64-unknown-none-softfloat".to_string(),
-                plat_dyn: None,
-                debug: false,
-                build_info_path: dir.path().join(".build.toml"),
-                qemu_config: None,
-                uboot_config: None,
-                vmconfigs: vec![],
-            },
+        apply_shell_autoinit_config(
+            &mut qemu,
             &ShellAutoInitConfig {
                 shell_prefix: "~ #".to_string(),
                 shell_init_cmd: "pwd && echo 'test pass!'".to_string(),
                 success_regex: vec!["^test pass!$".to_string()],
                 fail_regex: vec!["(?i)panic".to_string()],
             },
-        )
-        .unwrap();
+        );
 
-        assert_eq!(overrides.args.unwrap(), vec!["-nographic".to_string()]);
-        assert_eq!(overrides.shell_prefix.as_deref(), Some("~ #"));
+        assert_eq!(qemu.args, vec!["-nographic".to_string()]);
+        assert_eq!(qemu.shell_prefix.as_deref(), Some("~ #"));
         assert_eq!(
-            overrides.shell_init_cmd.as_deref(),
+            qemu.shell_init_cmd.as_deref(),
             Some("pwd && echo 'test pass!'")
         );
-        assert_eq!(
-            overrides.success_regex.unwrap(),
-            vec!["^test pass!$".to_string()]
-        );
+        assert_eq!(qemu.success_regex, vec!["^test pass!$".to_string()]);
     }
 
     #[test]

--- a/scripts/axbuild/src/command_flow.rs
+++ b/scripts/axbuild/src/command_flow.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use ostool::build::config::Cargo;
 
 use crate::context::{
-    AppContext, QemuRunConfig, ResolvedAxvisorRequest, ResolvedBuildRequest, ResolvedStarryRequest,
+    AppContext, ResolvedAxvisorRequest, ResolvedBuildRequest, ResolvedStarryRequest,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14,17 +14,12 @@ pub(crate) enum SnapshotPersistence {
 
 pub(crate) trait CommandRequest {
     fn build_info_path(&self) -> PathBuf;
-    fn uboot_config(&self) -> Option<PathBuf>;
     fn debug(&self) -> bool;
 }
 
 impl CommandRequest for ResolvedBuildRequest {
     fn build_info_path(&self) -> PathBuf {
         self.build_info_path.clone()
-    }
-
-    fn uboot_config(&self) -> Option<PathBuf> {
-        self.uboot_config.clone()
     }
 
     fn debug(&self) -> bool {
@@ -37,10 +32,6 @@ impl CommandRequest for ResolvedStarryRequest {
         self.build_info_path.clone()
     }
 
-    fn uboot_config(&self) -> Option<PathBuf> {
-        self.uboot_config.clone()
-    }
-
     fn debug(&self) -> bool {
         self.debug
     }
@@ -51,29 +42,9 @@ impl CommandRequest for ResolvedAxvisorRequest {
         self.build_info_path.clone()
     }
 
-    fn uboot_config(&self) -> Option<PathBuf> {
-        self.uboot_config.clone()
-    }
-
     fn debug(&self) -> bool {
         self.debug
     }
-}
-
-pub(crate) fn resolve_request<R, S, Prepare, Store>(
-    persistence: SnapshotPersistence,
-    prepare: Prepare,
-    store: Store,
-) -> anyhow::Result<R>
-where
-    Prepare: FnOnce() -> anyhow::Result<(R, S)>,
-    Store: FnOnce(&S) -> anyhow::Result<PathBuf>,
-{
-    let (request, snapshot) = prepare()?;
-    if matches!(persistence, SnapshotPersistence::Store) {
-        store(&snapshot)?;
-    }
-    Ok(request)
 }
 
 pub(crate) async fn run_build<R, LoadCargo>(
@@ -88,36 +59,4 @@ where
     app.set_debug_mode(request.debug())?;
     let cargo = load_cargo(&request)?;
     app.build(cargo, request.build_info_path()).await
-}
-
-pub(crate) async fn run_qemu<R, LoadCargo, LoadQemu>(
-    app: &mut AppContext,
-    request: R,
-    load_cargo: LoadCargo,
-    load_qemu: LoadQemu,
-) -> anyhow::Result<()>
-where
-    R: CommandRequest,
-    LoadCargo: FnOnce(&R) -> anyhow::Result<Cargo>,
-    LoadQemu: FnOnce(&R) -> anyhow::Result<QemuRunConfig>,
-{
-    app.set_debug_mode(request.debug())?;
-    let cargo = load_cargo(&request)?;
-    let qemu = load_qemu(&request)?;
-    app.qemu(cargo, request.build_info_path(), qemu).await
-}
-
-pub(crate) async fn run_uboot<R, LoadCargo>(
-    app: &mut AppContext,
-    request: R,
-    load_cargo: LoadCargo,
-) -> anyhow::Result<()>
-where
-    R: CommandRequest,
-    LoadCargo: FnOnce(&R) -> anyhow::Result<Cargo>,
-{
-    app.set_debug_mode(request.debug())?;
-    let cargo = load_cargo(&request)?;
-    app.uboot(cargo, request.build_info_path(), request.uboot_config())
-        .await
 }

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -2,8 +2,12 @@ use std::path::{Path, PathBuf};
 
 use ostool::{
     Tool, ToolConfig,
-    board::RunBoardArgs,
-    build::{CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs, config::Cargo},
+    board::{RunBoardOptions, config::BoardRunConfig},
+    build::{
+        CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs,
+        config::{BuildConfig, BuildSystem, Cargo},
+    },
+    run::{qemu::QemuConfig, uboot::UbootConfig},
 };
 
 mod arch;
@@ -25,8 +29,8 @@ pub use types::{
     ArceosUbootSnapshot, AxvisorCliArgs, AxvisorCommandSnapshot, AxvisorQemuSnapshot,
     AxvisorUbootSnapshot, BuildCliArgs, DEFAULT_ARCEOS_ARCH, DEFAULT_ARCEOS_TARGET,
     DEFAULT_AXVISOR_ARCH, DEFAULT_AXVISOR_TARGET, DEFAULT_STARRY_ARCH, DEFAULT_STARRY_TARGET,
-    QemuRunConfig, ResolvedAxvisorRequest, ResolvedBuildRequest, ResolvedStarryRequest,
-    STARRY_PACKAGE, STARRY_SNAPSHOT_FILE, StarryCliArgs, StarryCommandSnapshot, StarryQemuSnapshot,
+    ResolvedAxvisorRequest, ResolvedBuildRequest, ResolvedStarryRequest, STARRY_PACKAGE,
+    STARRY_SNAPSHOT_FILE, StarryCliArgs, StarryCommandSnapshot, StarryQemuSnapshot,
     StarryUbootSnapshot,
 };
 pub(crate) use workspace::{
@@ -81,29 +85,30 @@ impl AppContext {
         cargo: Cargo,
         build_config_path: PathBuf,
     ) -> anyhow::Result<()> {
-        self.set_build_config_path(build_config_path);
-        self.tool.cargo_build(&cargo).await
+        self.seed_cargo_tool_context(&cargo, &build_config_path);
+        self.tool
+            .build_with_config(&BuildConfig {
+                system: BuildSystem::Cargo(cargo),
+            })
+            .await
     }
 
     pub(crate) async fn qemu(
         &mut self,
         cargo: Cargo,
         build_config_path: PathBuf,
-        mut qemu: QemuRunConfig,
+        qemu: Option<QemuConfig>,
     ) -> anyhow::Result<()> {
-        self.set_build_config_path(build_config_path);
-        qemu.default_args.to_bin.get_or_insert(cargo.to_bin);
+        self.seed_cargo_tool_context(&cargo, &build_config_path);
         self.tool
             .cargo_run(
                 &cargo,
-                &CargoRunnerKind::Qemu(Box::new(CargoQemuRunnerArgs {
-                    qemu_config: qemu.qemu_config,
+                &CargoRunnerKind::Qemu(CargoQemuRunnerArgs {
+                    qemu,
                     debug: self.debug,
                     dtb_dump: false,
-                    default_args: qemu.default_args,
-                    append_args: qemu.append_args,
-                    override_args: qemu.override_args,
-                })),
+                    show_output: true,
+                }),
             )
             .await
     }
@@ -112,13 +117,16 @@ impl AppContext {
         &mut self,
         cargo: Cargo,
         build_config_path: PathBuf,
-        uboot_config: Option<PathBuf>,
+        uboot: Option<UbootConfig>,
     ) -> anyhow::Result<()> {
-        self.set_build_config_path(build_config_path);
+        self.seed_cargo_tool_context(&cargo, &build_config_path);
         self.tool
             .cargo_run(
                 &cargo,
-                &CargoRunnerKind::Uboot(CargoUbootRunnerArgs { uboot_config }),
+                &CargoRunnerKind::Uboot(CargoUbootRunnerArgs {
+                    uboot,
+                    show_output: true,
+                }),
             )
             .await
     }
@@ -127,10 +135,19 @@ impl AppContext {
         &mut self,
         cargo: Cargo,
         build_config_path: PathBuf,
-        board_args: RunBoardArgs,
+        board_config: BoardRunConfig,
+        options: RunBoardOptions,
     ) -> anyhow::Result<()> {
-        self.set_build_config_path(build_config_path);
-        self.tool.cargo_run_board(&cargo, board_args).await
+        self.seed_cargo_tool_context(&cargo, &build_config_path);
+        self.tool
+            .run_board(
+                &BuildConfig {
+                    system: BuildSystem::Cargo(cargo),
+                },
+                &board_config,
+                options,
+            )
+            .await
     }
 
     pub(crate) fn set_debug_mode(&mut self, debug: bool) -> anyhow::Result<()> {
@@ -149,6 +166,67 @@ impl AppContext {
         }
 
         Ok(())
+    }
+
+    pub(crate) async fn load_qemu_config_for_cargo(
+        &mut self,
+        cargo: &Cargo,
+        build_config_path: &Path,
+    ) -> anyhow::Result<QemuConfig> {
+        self.seed_cargo_tool_context(cargo, build_config_path);
+        self.tool.load_qemu_config_for_cargo(cargo).await
+    }
+
+    pub(crate) async fn load_qemu_config_from_path(
+        &mut self,
+        cargo: &Cargo,
+        build_config_path: &Path,
+        qemu_config_path: &Path,
+    ) -> anyhow::Result<QemuConfig> {
+        self.seed_cargo_tool_context(cargo, build_config_path);
+        self.tool.load_qemu_config_from_path(qemu_config_path).await
+    }
+
+    pub(crate) async fn load_uboot_config_from_path(
+        &mut self,
+        cargo: &Cargo,
+        build_config_path: &Path,
+        uboot_config_path: &Path,
+    ) -> anyhow::Result<UbootConfig> {
+        self.seed_cargo_tool_context(cargo, build_config_path);
+        self.tool
+            .load_uboot_config_from_path(uboot_config_path)
+            .await
+    }
+
+    pub(crate) async fn load_board_run_config_from_dir(
+        &mut self,
+        cargo: &Cargo,
+        build_config_path: &Path,
+        dir: &Path,
+    ) -> anyhow::Result<BoardRunConfig> {
+        self.seed_cargo_tool_context(cargo, build_config_path);
+        self.tool.load_board_run_config_from_dir(dir).await
+    }
+
+    pub(crate) async fn load_board_run_config_from_path(
+        &mut self,
+        cargo: &Cargo,
+        build_config_path: &Path,
+        board_config_path: &Path,
+    ) -> anyhow::Result<BoardRunConfig> {
+        self.seed_cargo_tool_context(cargo, build_config_path);
+        self.tool
+            .load_board_run_config_from_path(board_config_path)
+            .await
+    }
+
+    fn seed_cargo_tool_context(&mut self, cargo: &Cargo, path: &Path) {
+        let build_config = BuildConfig {
+            system: BuildSystem::Cargo(cargo.clone()),
+        };
+        self.set_build_config_path(path.to_path_buf());
+        self.tool.ctx_mut().build_config = Some(build_config);
     }
 
     fn set_build_config_path(&mut self, path: PathBuf) {

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -3,10 +3,7 @@ use std::path::{Path, PathBuf};
 use ostool::{
     Tool, ToolConfig,
     board::{RunBoardOptions, config::BoardRunConfig},
-    build::{
-        CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs,
-        config::{BuildConfig, BuildSystem, Cargo},
-    },
+    build::{CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs, config::Cargo},
     run::{qemu::QemuConfig, uboot::UbootConfig},
 };
 
@@ -67,6 +64,10 @@ impl AppContext {
         &self.root
     }
 
+    pub(crate) fn tool_mut(&mut self) -> &mut Tool {
+        &mut self.tool
+    }
+
     pub(crate) fn axvisor_dir(&mut self) -> anyhow::Result<&Path> {
         if self.axvisor_dir.is_none() {
             let axvisor_dir = workspace_member_dir(crate::axvisor::build::AXVISOR_PACKAGE)?;
@@ -85,12 +86,8 @@ impl AppContext {
         cargo: Cargo,
         build_config_path: PathBuf,
     ) -> anyhow::Result<()> {
-        self.seed_cargo_tool_context(&cargo, &build_config_path);
-        self.tool
-            .build_with_config(&BuildConfig {
-                system: BuildSystem::Cargo(cargo),
-            })
-            .await
+        self.set_build_config_path(build_config_path);
+        self.tool.cargo_build(&cargo).await
     }
 
     pub(crate) async fn qemu(
@@ -99,7 +96,7 @@ impl AppContext {
         build_config_path: PathBuf,
         qemu: Option<QemuConfig>,
     ) -> anyhow::Result<()> {
-        self.seed_cargo_tool_context(&cargo, &build_config_path);
+        self.set_build_config_path(build_config_path);
         self.tool
             .cargo_run(
                 &cargo,
@@ -119,7 +116,7 @@ impl AppContext {
         build_config_path: PathBuf,
         uboot: Option<UbootConfig>,
     ) -> anyhow::Result<()> {
-        self.seed_cargo_tool_context(&cargo, &build_config_path);
+        self.set_build_config_path(build_config_path);
         self.tool
             .cargo_run(
                 &cargo,
@@ -138,15 +135,9 @@ impl AppContext {
         board_config: BoardRunConfig,
         options: RunBoardOptions,
     ) -> anyhow::Result<()> {
-        self.seed_cargo_tool_context(&cargo, &build_config_path);
+        self.set_build_config_path(build_config_path);
         self.tool
-            .run_board(
-                &BuildConfig {
-                    system: BuildSystem::Cargo(cargo),
-                },
-                &board_config,
-                options,
-            )
+            .cargo_run_board(&cargo, &board_config, options)
             .await
     }
 
@@ -161,77 +152,15 @@ impl AppContext {
         })?;
         self.debug = debug;
 
-        if let Some(path) = self.build_config_path.clone() {
-            self.tool.ctx_mut().build_config_path = Some(path);
-        }
+        self.tool
+            .set_build_config_path(self.build_config_path.clone());
 
         Ok(())
     }
 
-    pub(crate) async fn load_qemu_config_for_cargo(
-        &mut self,
-        cargo: &Cargo,
-        build_config_path: &Path,
-    ) -> anyhow::Result<QemuConfig> {
-        self.seed_cargo_tool_context(cargo, build_config_path);
-        self.tool.load_qemu_config_for_cargo(cargo).await
-    }
-
-    pub(crate) async fn load_qemu_config_from_path(
-        &mut self,
-        cargo: &Cargo,
-        build_config_path: &Path,
-        qemu_config_path: &Path,
-    ) -> anyhow::Result<QemuConfig> {
-        self.seed_cargo_tool_context(cargo, build_config_path);
-        self.tool.load_qemu_config_from_path(qemu_config_path).await
-    }
-
-    pub(crate) async fn load_uboot_config_from_path(
-        &mut self,
-        cargo: &Cargo,
-        build_config_path: &Path,
-        uboot_config_path: &Path,
-    ) -> anyhow::Result<UbootConfig> {
-        self.seed_cargo_tool_context(cargo, build_config_path);
-        self.tool
-            .load_uboot_config_from_path(uboot_config_path)
-            .await
-    }
-
-    pub(crate) async fn load_board_run_config_from_dir(
-        &mut self,
-        cargo: &Cargo,
-        build_config_path: &Path,
-        dir: &Path,
-    ) -> anyhow::Result<BoardRunConfig> {
-        self.seed_cargo_tool_context(cargo, build_config_path);
-        self.tool.load_board_run_config_from_dir(dir).await
-    }
-
-    pub(crate) async fn load_board_run_config_from_path(
-        &mut self,
-        cargo: &Cargo,
-        build_config_path: &Path,
-        board_config_path: &Path,
-    ) -> anyhow::Result<BoardRunConfig> {
-        self.seed_cargo_tool_context(cargo, build_config_path);
-        self.tool
-            .load_board_run_config_from_path(board_config_path)
-            .await
-    }
-
-    fn seed_cargo_tool_context(&mut self, cargo: &Cargo, path: &Path) {
-        let build_config = BuildConfig {
-            system: BuildSystem::Cargo(cargo.clone()),
-        };
-        self.set_build_config_path(path.to_path_buf());
-        self.tool.ctx_mut().build_config = Some(build_config);
-    }
-
     fn set_build_config_path(&mut self, path: PathBuf) {
         self.build_config_path = Some(path.clone());
-        self.tool.ctx_mut().build_config_path = Some(path);
+        self.tool.set_build_config_path(Some(path));
     }
 }
 

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -100,12 +100,12 @@ impl AppContext {
         self.tool
             .cargo_run(
                 &cargo,
-                &CargoRunnerKind::Qemu(CargoQemuRunnerArgs {
+                &CargoRunnerKind::Qemu(Box::new(CargoQemuRunnerArgs {
                     qemu,
                     debug: self.debug,
                     dtb_dump: false,
                     show_output: true,
-                }),
+                })),
             )
             .await
     }
@@ -120,10 +120,10 @@ impl AppContext {
         self.tool
             .cargo_run(
                 &cargo,
-                &CargoRunnerKind::Uboot(CargoUbootRunnerArgs {
+                &CargoRunnerKind::Uboot(Box::new(CargoUbootRunnerArgs {
                     uboot,
                     show_output: true,
-                }),
+                })),
             )
             .await
     }

--- a/scripts/axbuild/src/context/resolve.rs
+++ b/scripts/axbuild/src/context/resolve.rs
@@ -52,11 +52,21 @@ impl AppContext {
         });
         let (arch, target) = resolve_arceos_arch_and_target(effective_arch, effective_target)?;
         let plat_dyn = cli.plat_dyn.or(snapshot.plat_dyn);
+        let inherit_snapshot_runtime =
+            cli.package.is_none() && cli.arch.is_none() && cli.target.is_none();
         let runtime_paths = self.resolve_runtime_paths(
             qemu_config,
-            snapshot.qemu.qemu_config.as_ref(),
+            if inherit_snapshot_runtime {
+                snapshot.qemu.qemu_config.as_ref()
+            } else {
+                None
+            },
             uboot_config,
-            snapshot.uboot.uboot_config.as_ref(),
+            if inherit_snapshot_runtime {
+                snapshot.uboot.uboot_config.as_ref()
+            } else {
+                None
+            },
         );
         let build_info_path =
             crate::arceos::build::resolve_build_info_path(&package, &target, cli.config.clone())?;
@@ -94,17 +104,6 @@ impl AppContext {
         Ok((request, snapshot))
     }
 
-    pub fn prepare_and_store_arceos_request(
-        &self,
-        cli: BuildCliArgs,
-        qemu_config: Option<PathBuf>,
-        uboot_config: Option<PathBuf>,
-    ) -> anyhow::Result<ResolvedBuildRequest> {
-        let (request, snapshot) = self.prepare_arceos_request(cli, qemu_config, uboot_config)?;
-        self.store_arceos_snapshot(&snapshot)?;
-        Ok(request)
-    }
-
     pub fn store_arceos_snapshot(
         &self,
         snapshot: &ArceosCommandSnapshot,
@@ -134,11 +133,20 @@ impl AppContext {
             }
         });
         let (arch, target) = resolve_starry_arch_and_target(effective_arch, effective_target)?;
+        let inherit_snapshot_runtime = cli.arch.is_none() && cli.target.is_none();
         let runtime_paths = self.resolve_runtime_paths(
             qemu_config,
-            snapshot.qemu.qemu_config.as_ref(),
+            if inherit_snapshot_runtime {
+                snapshot.qemu.qemu_config.as_ref()
+            } else {
+                None
+            },
             uboot_config,
-            snapshot.uboot.uboot_config.as_ref(),
+            if inherit_snapshot_runtime {
+                snapshot.uboot.uboot_config.as_ref()
+            } else {
+                None
+            },
         );
         let build_info_path =
             crate::starry::build::resolve_build_info_path(&self.root, &target, cli.config)?;
@@ -173,17 +181,6 @@ impl AppContext {
         };
 
         Ok((request, snapshot))
-    }
-
-    pub fn prepare_and_store_starry_request(
-        &self,
-        cli: StarryCliArgs,
-        qemu_config: Option<PathBuf>,
-        uboot_config: Option<PathBuf>,
-    ) -> anyhow::Result<ResolvedStarryRequest> {
-        let (request, snapshot) = self.prepare_starry_request(cli, qemu_config, uboot_config)?;
-        self.store_starry_snapshot(&snapshot)?;
-        Ok(request)
     }
 
     pub fn store_starry_snapshot(
@@ -234,11 +231,23 @@ impl AppContext {
         let plat_dyn = cli.plat_dyn.or(snapshot.plat_dyn);
         let build_info_path =
             crate::axvisor::build::resolve_build_info_path(&axvisor_dir, &target, explicit_config)?;
+        let inherit_snapshot_runtime = cli.arch.is_none()
+            && cli.target.is_none()
+            && cli.config.is_none()
+            && cli.vmconfigs.is_empty();
         let runtime_paths = self.resolve_runtime_paths(
             qemu_config,
-            snapshot.qemu.qemu_config.as_ref(),
+            if inherit_snapshot_runtime {
+                snapshot.qemu.qemu_config.as_ref()
+            } else {
+                None
+            },
             uboot_config,
-            snapshot.uboot.uboot_config.as_ref(),
+            if inherit_snapshot_runtime {
+                snapshot.uboot.uboot_config.as_ref()
+            } else {
+                None
+            },
         );
         let vmconfigs = if cli.vmconfigs.is_empty() {
             self.resolve_workspace_paths(snapshot.vmconfigs.iter())
@@ -283,17 +292,6 @@ impl AppContext {
         };
 
         Ok((request, snapshot))
-    }
-
-    pub fn prepare_and_store_axvisor_request(
-        &mut self,
-        cli: AxvisorCliArgs,
-        qemu_config: Option<PathBuf>,
-        uboot_config: Option<PathBuf>,
-    ) -> anyhow::Result<ResolvedAxvisorRequest> {
-        let (request, snapshot) = self.prepare_axvisor_request(cli, qemu_config, uboot_config)?;
-        self.store_axvisor_snapshot(&snapshot)?;
-        Ok(request)
     }
 
     pub fn store_axvisor_snapshot(

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -147,10 +147,7 @@ uboot_config = "configs/snapshot-uboot.toml"
         PathBuf::from("/tmp/custom-build.toml")
     );
     assert_eq!(request.qemu_config, Some(PathBuf::from("/tmp/qemu.toml")));
-    assert_eq!(
-        request.uboot_config,
-        Some(root.path().join("configs/snapshot-uboot.toml"))
-    );
+    assert_eq!(request.uboot_config, None);
     assert_eq!(snapshot.package.as_deref(), Some("from-cli"));
     assert_eq!(snapshot.arch.as_deref(), Some("aarch64"));
     assert_eq!(snapshot.target.as_deref(), Some(DEFAULT_ARCEOS_TARGET));
@@ -159,6 +156,7 @@ uboot_config = "configs/snapshot-uboot.toml"
         snapshot.qemu.qemu_config,
         Some(PathBuf::from("/tmp/qemu.toml"))
     );
+    assert_eq!(snapshot.uboot.uboot_config, None);
 }
 
 #[test]
@@ -229,6 +227,50 @@ fn prepare_request_resolves_arceos_target_from_arch() {
     assert_eq!(request.target, "x86_64-unknown-none");
     assert_eq!(snapshot.arch.as_deref(), Some("x86_64"));
     assert_eq!(snapshot.target.as_deref(), Some("x86_64-unknown-none"));
+}
+
+#[test]
+fn prepare_request_cli_target_drops_stale_arceos_runtime_paths() {
+    let root = tempdir().unwrap();
+    fs::write(
+        root.path().join(ARCEOS_SNAPSHOT_FILE),
+        r#"
+package = "ax-helloworld"
+arch = "aarch64"
+target = "aarch64-unknown-none-softfloat"
+
+[qemu]
+qemu_config = "configs/qemu-aarch64.toml"
+
+[uboot]
+uboot_config = "configs/uboot-aarch64.toml"
+"#,
+    )
+    .unwrap();
+
+    let app = test_app_context(root.path());
+
+    let (request, snapshot) = app
+        .prepare_arceos_request(
+            BuildCliArgs {
+                config: None,
+                package: None,
+                arch: None,
+                target: Some("riscv64gc-unknown-none-elf".into()),
+                plat_dyn: None,
+                debug: false,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(request.arch, "riscv64");
+    assert_eq!(request.target, "riscv64gc-unknown-none-elf");
+    assert_eq!(request.qemu_config, None);
+    assert_eq!(request.uboot_config, None);
+    assert_eq!(snapshot.qemu.qemu_config, None);
+    assert_eq!(snapshot.uboot.uboot_config, None);
 }
 
 #[test]
@@ -413,6 +455,51 @@ fn prepare_axvisor_request_resolves_target_from_arch() {
 }
 
 #[test]
+fn prepare_axvisor_request_cli_arch_drops_stale_runtime_paths() {
+    let root = tempdir().unwrap();
+    fs::write(
+        root.path().join(AXVISOR_SNAPSHOT_FILE),
+        r#"
+config = "os/axvisor/.build.toml"
+arch = "aarch64"
+target = "aarch64-unknown-none-softfloat"
+vmconfigs = ["tmp/snapshot-vm.toml"]
+
+[qemu]
+qemu_config = "configs/qemu-aarch64.toml"
+
+[uboot]
+uboot_config = "configs/uboot-aarch64.toml"
+"#,
+    )
+    .unwrap();
+
+    let mut app = test_app_context(root.path());
+
+    let (request, snapshot) = app
+        .prepare_axvisor_request(
+            AxvisorCliArgs {
+                config: None,
+                arch: Some("x86_64".into()),
+                target: None,
+                plat_dyn: None,
+                debug: false,
+                vmconfigs: vec![],
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(request.arch, "x86_64");
+    assert_eq!(request.target, "x86_64-unknown-none");
+    assert_eq!(request.qemu_config, None);
+    assert_eq!(request.uboot_config, None);
+    assert_eq!(snapshot.qemu.qemu_config, None);
+    assert_eq!(snapshot.uboot.uboot_config, None);
+}
+
+#[test]
 fn prepare_axvisor_request_rewrites_stale_generated_snapshot_config_path() {
     let root = tempdir().unwrap();
     fs::write(
@@ -516,15 +603,17 @@ uboot_config = "configs/snapshot-uboot.toml"
         PathBuf::from("/tmp/starry-build.toml")
     );
     assert_eq!(request.qemu_config, Some(PathBuf::from("/tmp/qemu.toml")));
-    assert_eq!(
-        request.uboot_config,
-        Some(root.path().join("configs/snapshot-uboot.toml"))
-    );
+    assert_eq!(request.uboot_config, None);
     assert_eq!(snapshot.arch.as_deref(), Some("aarch64"));
     assert_eq!(
         snapshot.target.as_deref(),
         Some("aarch64-unknown-none-softfloat")
     );
+    assert_eq!(
+        snapshot.qemu.qemu_config,
+        Some(PathBuf::from("/tmp/qemu.toml"))
+    );
+    assert_eq!(snapshot.uboot.uboot_config, None);
 }
 
 #[test]
@@ -654,6 +743,48 @@ target = "aarch64-unknown-none-softfloat"
     assert_eq!(request.target, "x86_64-unknown-none");
     assert_eq!(snapshot.arch.as_deref(), Some("x86_64"));
     assert_eq!(snapshot.target.as_deref(), Some("x86_64-unknown-none"));
+}
+
+#[test]
+fn prepare_starry_request_cli_arch_drops_stale_snapshot_runtime_paths() {
+    let root = tempdir().unwrap();
+    prepare_starry_workspace(root.path());
+    fs::write(
+        root.path().join(STARRY_SNAPSHOT_FILE),
+        r#"
+arch = "aarch64"
+target = "aarch64-unknown-none-softfloat"
+
+[qemu]
+qemu_config = "os/StarryOS/starryos/.qemu-aarch64.toml"
+
+[uboot]
+uboot_config = "configs/uboot-aarch64.toml"
+"#,
+    )
+    .unwrap();
+
+    let app = test_app_context(root.path());
+
+    let (request, snapshot) = app
+        .prepare_starry_request(
+            StarryCliArgs {
+                config: None,
+                arch: Some("riscv64".into()),
+                target: None,
+                debug: false,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(request.arch, "riscv64");
+    assert_eq!(request.target, "riscv64gc-unknown-none-elf");
+    assert_eq!(request.qemu_config, None);
+    assert_eq!(request.uboot_config, None);
+    assert_eq!(snapshot.qemu.qemu_config, None);
+    assert_eq!(snapshot.uboot.uboot_config, None);
 }
 
 #[test]

--- a/scripts/axbuild/src/context/types.rs
+++ b/scripts/axbuild/src/context/types.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use ostool::build::{CargoQemuAppendArgs, CargoQemuOverrideArgs};
 use serde::{Deserialize, Serialize};
 
 use super::snapshot::{CommandSnapshotFile, load_snapshot, store_snapshot};
@@ -164,14 +163,6 @@ pub struct ResolvedStarryRequest {
     pub build_info_override: Option<ArceosBuildInfo>,
     pub qemu_config: Option<PathBuf>,
     pub uboot_config: Option<PathBuf>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct QemuRunConfig {
-    pub qemu_config: Option<PathBuf>,
-    pub default_args: CargoQemuOverrideArgs,
-    pub append_args: CargoQemuAppendArgs,
-    pub override_args: CargoQemuOverrideArgs,
 }
 
 impl ArceosQemuSnapshot {

--- a/scripts/axbuild/src/logging.rs
+++ b/scripts/axbuild/src/logging.rs
@@ -1,17 +1,3 @@
-// Copyright 2026 The tgoskits Team
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 use std::path::Path;
 
 use anyhow::Result;

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -373,12 +373,14 @@ impl Starry {
         let mut qemu = match request.qemu_config.as_deref() {
             Some(path) => {
                 self.app
-                    .load_qemu_config_from_path(cargo, &request.build_info_path, path)
+                    .tool_mut()
+                    .read_qemu_config_from_path_for_cargo(cargo, path)
                     .await?
             }
             None => {
                 self.app
-                    .load_qemu_config_for_cargo(cargo, &request.build_info_path)
+                    .tool_mut()
+                    .ensure_qemu_config_for_cargo(cargo)
                     .await?
             }
         };
@@ -398,7 +400,8 @@ impl Starry {
         match request.uboot_config.as_deref() {
             Some(path) => self
                 .app
-                .load_uboot_config_from_path(cargo, &request.build_info_path, path)
+                .tool_mut()
+                .read_uboot_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some),
             None => Ok(None),
@@ -413,7 +416,8 @@ impl Starry {
     ) -> anyhow::Result<()> {
         let qemu = self
             .app
-            .load_qemu_config_from_path(cargo, &request.build_info_path, &qemu_config_path)
+            .tool_mut()
+            .read_qemu_config_from_path_for_cargo(cargo, &qemu_config_path)
             .await?;
         self.app
             .qemu(cargo.clone(), request.build_info_path.clone(), Some(qemu))

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -2,12 +2,12 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use clap::{Args, Subcommand};
-use ostool::build::CargoQemuOverrideArgs;
+use ostool::build::config::Cargo;
 
 use crate::{
     command_flow::{self, SnapshotPersistence},
     context::{
-        AppContext, DEFAULT_STARRY_ARCH, QemuRunConfig, ResolvedStarryRequest, StarryCliArgs,
+        AppContext, DEFAULT_STARRY_ARCH, ResolvedStarryRequest, StarryCliArgs,
         starry_target_for_arch_checked,
     },
     test_qemu,
@@ -311,12 +311,7 @@ impl Starry {
             println!("[{}/{}] starry qemu {}", index + 1, total, case.name);
 
             match self
-                .app
-                .qemu(
-                    cargo.clone(),
-                    request.build_info_path.clone(),
-                    Self::test_qemu_run_config(case.qemu_config_path.clone()),
-                )
+                .run_qemu_case(&request, &cargo, case.qemu_config_path.clone())
                 .await
                 .with_context(|| format!("starry qemu test failed for case `{}`", case.name))
             {
@@ -342,14 +337,13 @@ impl Starry {
         uboot_config: Option<PathBuf>,
         persistence: SnapshotPersistence,
     ) -> anyhow::Result<ResolvedStarryRequest> {
-        command_flow::resolve_request(
-            persistence,
-            || {
-                self.app
-                    .prepare_starry_request(args, qemu_config, uboot_config)
-            },
-            |snapshot| self.app.store_starry_snapshot(snapshot),
-        )
+        let (request, snapshot) =
+            self.app
+                .prepare_starry_request(args, qemu_config, uboot_config)?;
+        if matches!(persistence, SnapshotPersistence::Store) {
+            self.app.store_starry_snapshot(&snapshot)?;
+        }
+        Ok(request)
     }
 
     fn test_build_args(arch: &str) -> StarryCliArgs {
@@ -370,44 +364,69 @@ impl Starry {
         }
     }
 
-    fn qemu_run_config(
-        qemu_config: Option<PathBuf>,
-        qemu_args: Vec<String>,
-    ) -> anyhow::Result<QemuRunConfig> {
-        Ok(QemuRunConfig {
-            qemu_config,
-            default_args: CargoQemuOverrideArgs {
-                args: Some(qemu_args),
-                ..Default::default()
-            },
-            ..Default::default()
-        })
+    async fn load_qemu_config(
+        &mut self,
+        request: &ResolvedStarryRequest,
+        cargo: &Cargo,
+        apply_default_args: bool,
+    ) -> anyhow::Result<ostool::run::qemu::QemuConfig> {
+        let mut qemu = match request.qemu_config.as_deref() {
+            Some(path) => {
+                self.app
+                    .load_qemu_config_from_path(cargo, &request.build_info_path, path)
+                    .await?
+            }
+            None => {
+                self.app
+                    .load_qemu_config_for_cargo(cargo, &request.build_info_path)
+                    .await?
+            }
+        };
+
+        if request.qemu_config.is_none() && apply_default_args {
+            rootfs::apply_default_qemu_args(self.app.workspace_root(), request, &mut qemu).await?;
+        }
+
+        Ok(qemu)
     }
 
-    fn test_qemu_run_config(qemu_config: PathBuf) -> QemuRunConfig {
-        QemuRunConfig {
-            qemu_config: Some(qemu_config),
-            ..Default::default()
+    async fn load_uboot_config(
+        &mut self,
+        request: &ResolvedStarryRequest,
+        cargo: &Cargo,
+    ) -> anyhow::Result<Option<ostool::run::uboot::UbootConfig>> {
+        match request.uboot_config.as_deref() {
+            Some(path) => self
+                .app
+                .load_uboot_config_from_path(cargo, &request.build_info_path, path)
+                .await
+                .map(Some),
+            None => Ok(None),
         }
     }
 
-    async fn run_qemu_request(&mut self, request: ResolvedStarryRequest) -> anyhow::Result<()> {
-        let qemu_args = rootfs::default_qemu_args(self.app.workspace_root(), &request).await?;
-        self.run_qemu_request_with_args(request, qemu_args).await
+    async fn run_qemu_case(
+        &mut self,
+        request: &ResolvedStarryRequest,
+        cargo: &Cargo,
+        qemu_config_path: PathBuf,
+    ) -> anyhow::Result<()> {
+        let qemu = self
+            .app
+            .load_qemu_config_from_path(cargo, &request.build_info_path, &qemu_config_path)
+            .await?;
+        self.app
+            .qemu(cargo.clone(), request.build_info_path.clone(), Some(qemu))
+            .await
     }
 
-    async fn run_qemu_request_with_args(
-        &mut self,
-        request: ResolvedStarryRequest,
-        qemu_args: Vec<String>,
-    ) -> anyhow::Result<()> {
-        command_flow::run_qemu(
-            &mut self.app,
-            request,
-            build::load_cargo_config,
-            move |request| Self::qemu_run_config(request.qemu_config.clone(), qemu_args),
-        )
-        .await
+    async fn run_qemu_request(&mut self, request: ResolvedStarryRequest) -> anyhow::Result<()> {
+        self.app.set_debug_mode(request.debug)?;
+        let cargo = build::load_cargo_config(&request)?;
+        let qemu = self.load_qemu_config(&request, &cargo, true).await?;
+        self.app
+            .qemu(cargo, request.build_info_path, Some(qemu))
+            .await
     }
 
     async fn run_build_request(&mut self, request: ResolvedStarryRequest) -> anyhow::Result<()> {
@@ -415,7 +434,10 @@ impl Starry {
     }
 
     async fn run_uboot_request(&mut self, request: ResolvedStarryRequest) -> anyhow::Result<()> {
-        command_flow::run_uboot(&mut self.app, request, build::load_cargo_config).await
+        self.app.set_debug_mode(request.debug)?;
+        let cargo = build::load_cargo_config(&request)?;
+        let uboot = self.load_uboot_config(&request, &cargo).await?;
+        self.app.uboot(cargo, request.build_info_path, uboot).await
     }
 
     async fn quick_start_qemu(
@@ -661,14 +683,6 @@ mod tests {
             ])
             .is_err()
         );
-    }
-
-    #[test]
-    fn test_qemu_run_config_uses_case_path_verbatim() {
-        let path = PathBuf::from("test-suit/starryos/normal/smoke/qemu-riscv64.toml");
-        let config = Starry::test_qemu_run_config(path.clone());
-
-        assert_eq!(config.qemu_config, Some(path));
     }
 
     #[test]

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -2,8 +2,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Args, Subcommand};
-use ostool::board::{RunBoardOptions, config::BoardRunConfig};
-use ostool::build::config::Cargo;
+use ostool::{
+    board::{RunBoardOptions, config::BoardRunConfig},
+    build::config::Cargo,
+};
 
 use crate::{
     command_flow::{self, SnapshotPersistence},
@@ -892,10 +894,7 @@ mod tests {
         match cli.command {
             Command::Board(args) => {
                 assert_eq!(args.build.arch.as_deref(), Some("aarch64"));
-                assert_eq!(
-                    args.board_config,
-                    Some(PathBuf::from("remote.board.toml"))
-                );
+                assert_eq!(args.board_config, Some(PathBuf::from("remote.board.toml")));
                 assert_eq!(args.board_type.as_deref(), Some("rk3568"));
                 assert_eq!(args.server.as_deref(), Some("10.0.0.2"));
                 assert_eq!(args.port, Some(9000));

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -1,7 +1,8 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Args, Subcommand};
+use ostool::board::{RunBoardOptions, config::BoardRunConfig};
 use ostool::build::config::Cargo;
 
 use crate::{
@@ -40,6 +41,8 @@ pub enum Command {
     QuickStart(quick_start::ArgsQuickStart),
     /// Build and run StarryOS application with U-Boot
     Uboot(ArgsUboot),
+    /// Build and run StarryOS on a remote board
+    Board(ArgsBoard),
 }
 
 #[derive(Args, Clone)]
@@ -71,6 +74,24 @@ pub struct ArgsUboot {
 
     #[arg(long)]
     pub uboot_config: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct ArgsBoard {
+    #[command(flatten)]
+    pub build: ArgsBuild,
+
+    #[arg(long = "board-config")]
+    pub board_config: Option<PathBuf>,
+
+    #[arg(short = 'b', long)]
+    pub board_type: Option<String>,
+
+    #[arg(long)]
+    pub server: Option<String>,
+
+    #[arg(long)]
+    pub port: Option<u16>,
 }
 
 #[derive(Args)]
@@ -153,6 +174,7 @@ impl Starry {
             Command::Rootfs(args) => self.rootfs(args).await,
             Command::QuickStart(args) => self.quick_start(args).await,
             Command::Uboot(args) => self.uboot(args).await,
+            Command::Board(args) => self.board(args).await,
             Command::Test(args) => self.test(args).await,
         }
     }
@@ -218,6 +240,28 @@ impl Starry {
             SnapshotPersistence::Store,
         )?;
         self.run_uboot_request(request).await
+    }
+
+    async fn board(&mut self, args: ArgsBoard) -> anyhow::Result<()> {
+        let request =
+            self.prepare_request((&args.build).into(), None, None, SnapshotPersistence::Store)?;
+        self.app.set_debug_mode(request.debug)?;
+        let cargo = build::load_cargo_config(&request)?;
+        let board_config = self
+            .load_board_config(&cargo, args.board_config.as_deref())
+            .await?;
+        self.app
+            .board(
+                cargo,
+                request.build_info_path,
+                board_config,
+                RunBoardOptions {
+                    board_type: args.board_type,
+                    server: args.server,
+                    port: args.port,
+                },
+            )
+            .await
     }
 
     async fn quick_start(&mut self, args: quick_start::ArgsQuickStart) -> anyhow::Result<()> {
@@ -311,7 +355,7 @@ impl Starry {
             println!("[{}/{}] starry qemu {}", index + 1, total, case.name);
 
             match self
-                .run_qemu_case(&request, &cargo, case.qemu_config_path.clone())
+                .run_qemu_case(&request, &cargo, &case.name, case.qemu_config_path.clone())
                 .await
                 .with_context(|| format!("starry qemu test failed for case `{}`", case.name))
             {
@@ -408,17 +452,50 @@ impl Starry {
         }
     }
 
+    async fn load_board_config(
+        &mut self,
+        cargo: &Cargo,
+        board_config_path: Option<&Path>,
+    ) -> anyhow::Result<BoardRunConfig> {
+        match board_config_path {
+            Some(path) => {
+                self.app
+                    .tool_mut()
+                    .read_board_run_config_from_path_for_cargo(cargo, path)
+                    .await
+            }
+            None => {
+                let workspace_root = self.app.workspace_root().to_path_buf();
+                self.app
+                    .tool_mut()
+                    .ensure_board_run_config_in_dir_for_cargo(cargo, &workspace_root)
+                    .await
+            }
+        }
+    }
+
     async fn run_qemu_case(
         &mut self,
         request: &ResolvedStarryRequest,
         cargo: &Cargo,
+        case_name: &str,
         qemu_config_path: PathBuf,
     ) -> anyhow::Result<()> {
-        let qemu = self
+        let mut qemu = self
             .app
             .tool_mut()
             .read_qemu_config_from_path_for_cargo(cargo, &qemu_config_path)
             .await?;
+
+        let case_rootfs = rootfs::prepare_per_case_rootfs(
+            self.app.workspace_root(),
+            &request.arch,
+            &request.target,
+            case_name,
+        )
+        .await?;
+        rootfs::apply_disk_image_qemu_args(&mut qemu, case_rootfs);
+
         self.app
             .qemu(cargo.clone(), request.build_info_path.clone(), Some(qemu))
             .await
@@ -785,6 +862,45 @@ mod tests {
                 _ => panic!("expected orangepi quick-start command"),
             },
             _ => panic!("expected quick-start command"),
+        }
+    }
+
+    #[test]
+    fn command_parses_board() {
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: Command,
+        }
+
+        let cli = Cli::try_parse_from([
+            "starry",
+            "board",
+            "--arch",
+            "aarch64",
+            "--board-config",
+            "remote.board.toml",
+            "-b",
+            "rk3568",
+            "--server",
+            "10.0.0.2",
+            "--port",
+            "9000",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Board(args) => {
+                assert_eq!(args.build.arch.as_deref(), Some("aarch64"));
+                assert_eq!(
+                    args.board_config,
+                    Some(PathBuf::from("remote.board.toml"))
+                );
+                assert_eq!(args.board_type.as_deref(), Some("rk3568"));
+                assert_eq!(args.server.as_deref(), Some("10.0.0.2"));
+                assert_eq!(args.port, Some(9000));
+            }
+            _ => panic!("expected board command"),
         }
     }
 }

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -82,9 +82,12 @@ pub(crate) async fn prepare_per_case_rootfs(
 
     // Clean up old per-case copy from a previous run
     if case_rootfs.exists() {
-        tokio_fs::remove_file(&case_rootfs)
-            .await
-            .with_context(|| format!("failed to remove old per-case rootfs {}", case_rootfs.display()))?;
+        tokio_fs::remove_file(&case_rootfs).await.with_context(|| {
+            format!(
+                "failed to remove old per-case rootfs {}",
+                case_rootfs.display()
+            )
+        })?;
     }
 
     // Copy base rootfs to per-case path

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -61,6 +61,46 @@ pub(crate) async fn ensure_rootfs_in_target_dir(
     Ok(rootfs_img)
 }
 
+fn per_case_rootfs_path(
+    workspace_root: &Path,
+    arch: &str,
+    target: &str,
+    case_name: &str,
+) -> anyhow::Result<PathBuf> {
+    let target_dir = resolve_target_dir(workspace_root, target)?;
+    Ok(target_dir.join(format!("rootfs-{arch}-{case_name}.img")))
+}
+
+pub(crate) async fn prepare_per_case_rootfs(
+    workspace_root: &Path,
+    arch: &str,
+    target: &str,
+    case_name: &str,
+) -> anyhow::Result<PathBuf> {
+    let base = rootfs_image_path(workspace_root, arch, target)?;
+    let case_rootfs = per_case_rootfs_path(workspace_root, arch, target, case_name)?;
+
+    // Clean up old per-case copy from a previous run
+    if case_rootfs.exists() {
+        tokio_fs::remove_file(&case_rootfs)
+            .await
+            .with_context(|| format!("failed to remove old per-case rootfs {}", case_rootfs.display()))?;
+    }
+
+    // Copy base rootfs to per-case path
+    let src = base.clone();
+    let dst = case_rootfs.clone();
+    tokio::task::spawn_blocking(move || {
+        std::fs::copy(&src, &dst)
+            .with_context(|| format!("failed to copy {} to {}", src.display(), dst.display()))?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .context("rootfs copy task failed")??;
+
+    Ok(case_rootfs)
+}
+
 pub(crate) async fn apply_default_qemu_args(
     workspace_root: &Path,
     request: &ResolvedStarryRequest,
@@ -72,7 +112,7 @@ pub(crate) async fn apply_default_qemu_args(
     Ok(())
 }
 
-fn apply_disk_image_qemu_args(qemu: &mut QemuConfig, disk_img: PathBuf) {
+pub(crate) fn apply_disk_image_qemu_args(qemu: &mut QemuConfig, disk_img: PathBuf) {
     let disk_value = format!("id=disk0,if=none,format=raw,file={}", disk_img.display());
     let args = &mut qemu.args;
 

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::{Context, bail};
 use indicatif::ProgressBar;
+use ostool::run::qemu::QemuConfig;
 use tokio::fs as tokio_fs;
 use xz2::read::XzDecoder;
 
@@ -60,26 +61,73 @@ pub(crate) async fn ensure_rootfs_in_target_dir(
     Ok(rootfs_img)
 }
 
-pub(crate) async fn default_qemu_args(
+pub(crate) async fn apply_default_qemu_args(
     workspace_root: &Path,
     request: &ResolvedStarryRequest,
-) -> anyhow::Result<Vec<String>> {
+    qemu: &mut QemuConfig,
+) -> anyhow::Result<()> {
     let disk_img =
         ensure_rootfs_in_target_dir(workspace_root, &request.arch, &request.target).await?;
-    qemu_args_for_disk_image(disk_img)
+    apply_disk_image_qemu_args(qemu, disk_img);
+    Ok(())
 }
 
-fn qemu_args_for_disk_image(disk_img: PathBuf) -> anyhow::Result<Vec<String>> {
-    Ok(vec![
-        "-device".to_string(),
-        "virtio-blk-pci,drive=disk0".to_string(),
-        "-drive".to_string(),
-        format!("id=disk0,if=none,format=raw,file={}", disk_img.display()),
-        "-device".to_string(),
-        "virtio-net-pci,netdev=net0".to_string(),
-        "-netdev".to_string(),
-        "user,id=net0".to_string(),
-    ])
+fn apply_disk_image_qemu_args(qemu: &mut QemuConfig, disk_img: PathBuf) {
+    let disk_value = format!("id=disk0,if=none,format=raw,file={}", disk_img.display());
+    let args = &mut qemu.args;
+
+    let mut has_blk_device = false;
+    let mut has_drive = false;
+    let mut has_net_device = false;
+    let mut has_netdev = false;
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "-device" if index + 1 < args.len() => {
+                let value = &mut args[index + 1];
+                if value == "virtio-blk-pci,drive=disk0" {
+                    has_blk_device = true;
+                } else if value == "virtio-net-pci,netdev=net0" {
+                    has_net_device = true;
+                }
+                index += 2;
+            }
+            "-drive" if index + 1 < args.len() => {
+                let value = &mut args[index + 1];
+                if value.starts_with("id=disk0,if=none,format=raw,file=") {
+                    *value = disk_value.clone();
+                    has_drive = true;
+                }
+                index += 2;
+            }
+            "-netdev" if index + 1 < args.len() => {
+                let value = &mut args[index + 1];
+                if value == "user,id=net0" {
+                    has_netdev = true;
+                }
+                index += 2;
+            }
+            _ => index += 1,
+        }
+    }
+
+    if !has_blk_device {
+        args.push("-device".to_string());
+        args.push("virtio-blk-pci,drive=disk0".to_string());
+    }
+    if !has_drive {
+        args.push("-drive".to_string());
+        args.push(disk_value);
+    }
+    if !has_net_device {
+        args.push("-device".to_string());
+        args.push("virtio-net-pci,netdev=net0".to_string());
+    }
+    if !has_netdev {
+        args.push("-netdev".to_string());
+        args.push("user,id=net0".to_string());
+    }
 }
 
 async fn download_with_progress(url: &str, output_path: &Path) -> anyhow::Result<()> {
@@ -148,7 +196,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_qemu_args_include_rootfs_and_network_defaults() {
+    async fn apply_default_qemu_args_includes_rootfs_and_network_defaults() {
         let root = tempdir().unwrap();
         let target_dir = root.path().join("target/x86_64-unknown-none");
         fs::create_dir_all(&target_dir).unwrap();
@@ -165,11 +213,14 @@ mod tests {
             qemu_config: None,
             uboot_config: None,
         };
+        let mut qemu = QemuConfig::default();
 
-        let args = default_qemu_args(root.path(), &request).await.unwrap();
+        apply_default_qemu_args(root.path(), &request, &mut qemu)
+            .await
+            .unwrap();
 
         assert_eq!(
-            args,
+            qemu.args,
             vec![
                 "-device".to_string(),
                 "virtio-blk-pci,drive=disk0".to_string(),
@@ -193,6 +244,64 @@ mod tests {
             )
             .unwrap(),
             b"rootfs"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_default_qemu_args_preserves_existing_base_args() {
+        let root = tempdir().unwrap();
+        let target_dir = root.path().join("target/riscv64gc-unknown-none-elf");
+        fs::create_dir_all(&target_dir).unwrap();
+        fs::write(target_dir.join("rootfs-riscv64.img"), b"rootfs").unwrap();
+
+        let request = ResolvedStarryRequest {
+            package: "starryos".to_string(),
+            arch: "riscv64".to_string(),
+            target: "riscv64gc-unknown-none-elf".to_string(),
+            plat_dyn: None,
+            debug: false,
+            build_info_path: PathBuf::from("/tmp/.build.toml"),
+            build_info_override: None,
+            qemu_config: None,
+            uboot_config: None,
+        };
+        let mut qemu = QemuConfig {
+            args: vec![
+                "-nographic".to_string(),
+                "-cpu".to_string(),
+                "rv64".to_string(),
+                "-machine".to_string(),
+                "virt".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        apply_default_qemu_args(root.path(), &request, &mut qemu)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            qemu.args,
+            vec![
+                "-nographic".to_string(),
+                "-cpu".to_string(),
+                "rv64".to_string(),
+                "-machine".to_string(),
+                "virt".to_string(),
+                "-device".to_string(),
+                "virtio-blk-pci,drive=disk0".to_string(),
+                "-drive".to_string(),
+                format!(
+                    "id=disk0,if=none,format=raw,file={}",
+                    root.path()
+                        .join("target/riscv64gc-unknown-none-elf/rootfs-riscv64.img")
+                        .display()
+                ),
+                "-device".to_string(),
+                "virtio-net-pci,netdev=net0".to_string(),
+                "-netdev".to_string(),
+                "user,id=net0".to_string(),
+            ]
         );
     }
 }

--- a/scripts/axbuild/src/starry/test_suit.rs
+++ b/scripts/axbuild/src/starry/test_suit.rs
@@ -7,7 +7,10 @@ use std::{
 use anyhow::{Context, bail};
 
 use super::board;
-use crate::context::{arch_for_target_checked, starry_target_for_arch_checked};
+use crate::{
+    context::{arch_for_target_checked, starry_target_for_arch_checked},
+    test_qemu::validate_supported_target,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StarryTestGroup {
@@ -157,25 +160,6 @@ pub(crate) fn finalize_qemu_case_run(
             group.as_str(),
             failed.len(),
             failed.join(", ")
-        )
-    }
-}
-
-fn validate_supported_target(
-    target: &str,
-    suite_name: &str,
-    supported_kind: &str,
-    supported: &[&str],
-) -> anyhow::Result<()> {
-    if supported.contains(&target) {
-        Ok(())
-    } else {
-        bail!(
-            "unsupported target `{}` for {}. Supported {} are: {}",
-            target,
-            suite_name,
-            supported_kind,
-            supported.join(", ")
         )
     }
 }

--- a/scripts/axbuild/src/test_qemu.rs
+++ b/scripts/axbuild/src/test_qemu.rs
@@ -189,7 +189,7 @@ pub(crate) fn axvisor_test_shell_config(arch: &str) -> anyhow::Result<ShellAutoI
     }
 }
 
-fn validate_supported_target(
+pub(crate) fn validate_supported_target(
     target: &str,
     suite_name: &str,
     supported_kind: &str,


### PR DESCRIPTION
## Summary
- refactor board, QEMU, and U-Boot configuration handling in `scripts/axbuild`
- isolate StarryOS QEMU test rootfs per case and adjust test validation flow
- add a 5-minute timeout to Axvisor board-test configurations

## Why
- simplify configuration loading and target validation across ArceOS, Axvisor, and StarryOS flows
- avoid cross-test interference from shared rootfs state in StarryOS QEMU cases
- prevent Axvisor board tests from waiting indefinitely on board-side execution

## Impact
- board and QEMU test flows now use the updated configuration resolution path
- StarryOS test-suit runs get per-case rootfs isolation
- Axvisor board-test configs for OrangePi 5 Plus, ROC-RK3568-PC, and Phytiumpi now time out after 300 seconds

## Validation
- local checks were not rerun as part of this PR creation step
