### PR TITLE
fix(starry): per-thread `skip_next_signal_check`

### DIFF
--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -78,6 +78,9 @@ pub struct Thread {
     /// Indicates whether the thread is currently accessing user memory.
     accessing_user_memory: AtomicBool,
 
+    /// Skip the next `check_signals` pass (per-thread; used around signal setup syscalls).
+    pub skip_next_signal_check: AtomicBool,
+
     /// Self exit event
     pub exit_event: Arc<PollSet>,
 }
@@ -94,6 +97,7 @@ impl Thread {
             exit: Arc::new(AtomicBool::new(false)),
             oom_score_adj: AtomicI32::new(200),
             accessing_user_memory: AtomicBool::new(false),
+            skip_next_signal_check: AtomicBool::new(false),
             exit_event: Arc::default(),
         })
     }

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::Ordering;
 
 use ax_errno::{AxError, AxResult};
 use ax_hal::uspace::UserContext;
@@ -40,14 +40,18 @@ pub fn check_signals(
     true
 }
 
-static BLOCK_NEXT_SIGNAL_CHECK: AtomicBool = AtomicBool::new(false);
-
 pub fn block_next_signal() {
-    BLOCK_NEXT_SIGNAL_CHECK.store(true, Ordering::SeqCst);
+    current()
+        .as_thread()
+        .skip_next_signal_check
+        .store(true, Ordering::SeqCst);
 }
 
 pub fn unblock_next_signal() -> bool {
-    BLOCK_NEXT_SIGNAL_CHECK.swap(false, Ordering::SeqCst)
+    current()
+        .as_thread()
+        .skip_next_signal_check
+        .swap(false, Ordering::SeqCst)
 }
 
 pub fn with_blocked_signals<R>(


### PR DESCRIPTION
## Description

`BLOCK_NEXT_SIGNAL_CHECK` is a **global static `AtomicBool`** used by `rt_sigreturn` to skip one signal check. On SMP, CPU-A's `block_next_signal()` can be consumed by CPU-B's `unblock_next_signal()`, causing:
- Thread B incorrectly skips signal check (may miss pending signal)
- Thread A does not skip (may corrupt signal frame restoration)

The signal skip mechanism is fully functional — the bug is that its scope is global instead of per-thread.

## Implementation

Moved the flag into `Thread` struct as `skip_next_signal_check: AtomicBool`. `block_next_signal()` and `unblock_next_signal()` now access `current().as_thread().skip_next_signal_check`.

## Test

Test program available at [rcore-os/linux-compatible-testsuit](https://github.com/rcore-os/linux-compatible-testsuit).

```c
// Two threads each raise 100 signals concurrently
// With global flag: one thread consumes the other's skip → signal loss
// After fix: both threads receive all 100 signals independently
pthread_create(&ta, NULL, thread_a, NULL);  // raises SIGUSR1 x100
pthread_create(&tb, NULL, thread_b, NULL);  // raises SIGUSR2 x100
assert(sig_count_a >= 95 && sig_count_b >= 95);
```