### PR TITLE
fix(starry): membarrier use fence instead of compiler_fence

### DIFF
--- a/os/StarryOS/kernel/src/syscall/sync/membarrier.rs
+++ b/os/StarryOS/kernel/src/syscall/sync/membarrier.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{Ordering, compiler_fence};
+use core::sync::atomic::{Ordering, fence};
 
 use ax_errno::{AxError, AxResult};
 
@@ -26,7 +26,7 @@ pub fn sys_membarrier(cmd: i32, flags: u32, _cpu_id: i32) -> AxResult<isize> {
     match cmd {
         MEMBARRIER_CMD_QUERY => Ok(SUPPORTED_COMMANDS as isize),
         _ => {
-            compiler_fence(Ordering::SeqCst);
+            fence(Ordering::SeqCst);
             Ok(0)
         }
     }


### PR DESCRIPTION
## Description

`sys_membarrier` uses `compiler_fence(SeqCst)` which only prevents compiler reordering but generates **no CPU memory barrier instruction**. On SMP systems, this breaks cross-core memory visibility for user-space synchronization (RCU, hazard pointers, jemalloc).

This is a bug in existing code — membarrier is fully wired up with QUERY and flag validation, but the barrier primitive itself is wrong.

## Implementation

Changed `compiler_fence(Ordering::SeqCst)` to `fence(Ordering::SeqCst)`, which emits:
- riscv64: `fence iorw,iorw`
- aarch64: `dmb ish`
- x86_64: `mfence`

## Test

Test program available at [rcore-os/linux-compatible-testsuit](https://github.com/rcore-os/linux-compatible-testsuit).

```c
// Verify membarrier QUERY returns supported commands
long r = syscall(SYS_membarrier, MEMBARRIER_CMD_QUERY, 0, 0);
assert(r >= 0);

// Verify GLOBAL barrier succeeds
r = syscall(SYS_membarrier, MEMBARRIER_CMD_GLOBAL, 0, 0);
assert(r == 0);

// Verify invalid cmd returns EINVAL
r = syscall(SYS_membarrier, 0x80000000, 0, 0);
assert(r == -1 && errno == EINVAL);
```