### PR TITLE
fix(starry): accept4 should return peer address

### DIFF
--- a/os/StarryOS/kernel/src/syscall/net/socket.rs
+++ b/os/StarryOS/kernel/src/syscall/net/socket.rs
@@ -125,7 +125,7 @@ pub fn sys_accept4(
         socket.set_nonblocking(true)?;
     }
 
-    let remote_addr = socket.local_addr()?;
+    let remote_addr = socket.peer_addr()?;
     let fd = socket.add_to_fd_table(cloexec).map(|fd| fd as isize)?;
     debug!("sys_accept => fd: {fd}, addr: {remote_addr:?}");
 


### PR DESCRIPTION
## Description

`sys_accept4` line 128:
```rust
let remote_addr = socket.local_addr()?;  // BUG
```

Returns the **server's own listening address** to the user's `addr` parameter, instead of the **client's (peer) address**. This is a typo — `local_addr()` should be `peer_addr()`.

**Impact:** Programs that check "who connected" (logging, ACL, reverse proxy) get the wrong address. `accept()` and `getpeername()` return inconsistent results.

## Implementation

```diff
-    let remote_addr = socket.local_addr()?;
+    let remote_addr = socket.peer_addr()?;
```

## Test

Test program available at [rcore-os/linux-compatible-testsuit](https://github.com/rcore-os/linux-compatible-testsuit).

```c
// Server binds 127.0.0.1:19876, client connects
struct sockaddr_in accepted_addr;
int cli = accept(srv, (struct sockaddr*)&accepted_addr, &len);

struct sockaddr_in peer_addr;
getpeername(cli, (struct sockaddr*)&peer_addr, &plen);

// After fix: accepted_addr == peer_addr (both are client addr)
assert(accepted_addr.sin_port == peer_addr.sin_port);
// accepted_addr.sin_port != 19876 (not server port)

// Before fix: accepted_addr.sin_port == 19876 (server addr, wrong)
```