### PR TITLE
fix(axvisor): wake sleeping vcpus during shutdown

### DIFF
--- a/os/axvisor/src/shell/command/vm.rs
+++ b/os/axvisor/src/shell/command/vm.rs
@@ -319,7 +319,11 @@ fn stop_vm_by_id(vm_id: usize, force: bool) {
 
         // Call shutdown
         match vm.shutdown() {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                // Notify all vCPUs to wake up to check the shutdown flag
+                vcpus::notify_all_vcpus(vm_id);
+                Ok(())
+            }
             Err(_err) => {
                 // Revert status on failure
                 Err("Failed to shutdown VM")
@@ -671,6 +675,8 @@ fn delete_vm_by_id(vm_id: usize, keep_data: bool) {
                 );
                 vm.set_vm_status(VMStatus::Stopping);
                 let _ = vm.shutdown();
+                // Notify all vCPUs to wake up to check the shutdown flag
+                vcpus::notify_all_vcpus(vm_id);
             }
             VMStatus::Loaded => {
                 // Transition from Loaded to Stopped

--- a/os/axvisor/src/vmm/vcpus.rs
+++ b/os/axvisor/src/vmm/vcpus.rs
@@ -530,6 +530,8 @@ fn vcpu_run() {
                 AxVCpuExitReason::SystemDown => {
                     warn!("VM[{vm_id}] run VCpu[{vcpu_id}] SystemDown");
                     vm.shutdown().expect("VM shutdown failed");
+                    // Notify all vCPUs to wake up to check the shutdown flag
+                    notify_all_vcpus(vm_id);
                 }
                 AxVCpuExitReason::SendIPI {
                     target_cpu,
@@ -563,6 +565,8 @@ fn vcpu_run() {
                 error!("VM[{vm_id}] run VCpu[{vcpu_id}] get error {err:?}");
                 // wait(vm_id)
                 vm.shutdown().expect("VM shutdown failed");
+                // Notify all vCPUs to wake up to check the shutdown flag
+                notify_all_vcpus(vm_id);
             }
         }
 


### PR DESCRIPTION
Notify all vCPUs on shutdown paths so they can wake up and check the shutdown flag.