### PR TITLE
fix(ci): use default github token for release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,7 +38,7 @@ jobs:
           command: release-pr
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
   release-plz-release:
     name: Publish releases
@@ -64,5 +64,5 @@ jobs:
           config: release-plz.toml
           token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- switch both release-plz jobs to use the default GitHub Actions token
- avoid overriding the action environment with an empty `RELEASE_PLZ_TOKEN` secret

## Root Cause

The workflow bound `GITHUB_TOKEN` to `secrets.RELEASE_PLZ_TOKEN`, but that secret resolved to an empty value on `main`. This overrode the default token provided by GitHub Actions, so both `release-pr` and `release` failed before doing any release work.

## Validation

- `git diff --check -- .github/workflows/release-plz.yml`
- local workflow diff review

## Notes

- `actionlint` is not installed in this environment, so I did not run schema-level workflow linting locally.
