### PR TITLE
fix(starry): pass 18/18 linux-compatible-testsuit (27 syscall bugs) 

### DIFF
--- a/components/axmm_crates/memory_set/src/area.rs
+++ b/components/axmm_crates/memory_set/src/area.rs
@@ -93,8 +93,12 @@ impl<B: MappingBackend> MemoryArea<B> {
         new_flags: B::Flags,
         page_table: &mut B::PageTable,
     ) -> MappingResult {
-        self.backend
-            .protect(self.start(), self.size(), new_flags, page_table);
+        if !self
+            .backend
+            .protect(self.start(), self.size(), new_flags, page_table)
+        {
+            return Err(MappingError::BadState);
+        }
         Ok(())
     }
 

--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -79,6 +79,13 @@ pub fn metadata_to_kstat(metadata: &Metadata) -> Kstat {
     let ty = metadata.node_type as u8;
     let perm = metadata.mode.bits() as u32;
     let mode = ((ty as u32) << 12) | perm;
+    // Linux always reports a non-zero st_blksize (typically the FS preferred
+    // I/O block size). Fall back to one 4K page when the FS reports 0.
+    let blksize = if metadata.block_size == 0 {
+        4096
+    } else {
+        metadata.block_size as _
+    };
     Kstat {
         dev: metadata.device,
         ino: metadata.inode,
@@ -87,7 +94,7 @@ pub fn metadata_to_kstat(metadata: &Metadata) -> Kstat {
         uid: metadata.uid,
         gid: metadata.gid,
         size: metadata.size,
-        blksize: metadata.block_size as _,
+        blksize,
         blocks: metadata.blocks,
         rdev: metadata.rdev,
         atime: metadata.atime,

--- a/os/StarryOS/kernel/src/file/mod.rs
+++ b/os/StarryOS/kernel/src/file/mod.rs
@@ -93,8 +93,25 @@ impl From<Kstat> for stat {
 
 impl From<Kstat> for statx {
     fn from(value: Kstat) -> Self {
+        use linux_raw_sys::general::{
+            STATX_ATIME, STATX_BLOCKS, STATX_BTIME, STATX_CTIME, STATX_GID, STATX_INO, STATX_MODE,
+            STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE, STATX_UID,
+        };
         // SAFETY: valid for statx
         let mut statx: statx = unsafe { core::mem::zeroed() };
+        // Indicate which fields we have populated.
+        statx.stx_mask = STATX_TYPE
+            | STATX_MODE
+            | STATX_NLINK
+            | STATX_UID
+            | STATX_GID
+            | STATX_INO
+            | STATX_SIZE
+            | STATX_BLOCKS
+            | STATX_ATIME
+            | STATX_MTIME
+            | STATX_CTIME;
+        let _ = STATX_BTIME; // not populated
         statx.stx_blksize = value.blksize as _;
         statx.stx_attributes = value.mode as _;
         statx.stx_nlink = value.nlink as _;

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -252,6 +252,35 @@ impl AddrSpace {
     pub fn protect(&mut self, start: VirtAddr, size: usize, flags: MappingFlags) -> AxResult {
         self.validate_region(start, size)?;
 
+        // Reject mprotect on completely unmapped ranges (Linux ENOMEM).
+        let range = VirtAddrRange::from_start_size(start, size);
+        let r_start = range.start.as_usize();
+        let r_end = range.end.as_usize();
+        let mut any_covered = false;
+        for area in self.areas.iter() {
+            let a_start = area.start().as_usize();
+            let a_end = area.end().as_usize();
+            if a_end <= r_start || a_start >= r_end {
+                continue;
+            }
+            any_covered = true;
+            break;
+        }
+        if !any_covered {
+            ax_bail!(NoMemory, "range is not mapped");
+        }
+
+        // Pre-validate: ask each affected area's backend whether the new flags
+        // are allowed (e.g. PROT_WRITE on a read-only file mapping must fail
+        // with EACCES, not silently succeed).
+        for area in self.areas.iter() {
+            if area.end() <= range.start || area.start() >= range.end {
+                continue;
+            }
+            let mut cursor = self.pt.cursor();
+            BackendOps::on_protect(area.backend(), range, flags, &mut cursor)?;
+        }
+
         self.areas
             .protect(start, size, |_| Some(flags), &mut self.pt)?;
 

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -99,6 +99,36 @@ pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize
     })
 }
 
+/// `mknodat(dirfd, path, mode, dev)`. Currently supports regular files
+/// (S_IFREG, when type bits are zero) and FIFOs (S_IFIFO).
+pub fn sys_mknodat(dirfd: i32, path: *const c_char, mode: u32, _dev: u64) -> AxResult<isize> {
+    use linux_raw_sys::general::{S_IFIFO, S_IFMT, S_IFREG};
+
+    let path = vm_load_string(path)?;
+    debug!("sys_mknodat <= dirfd: {dirfd}, path: {path}, mode: {mode:#o}");
+
+    let umask = current().as_thread().proc_data.umask();
+    let perm = NodePermission::from_bits_truncate((mode & !umask) as u16);
+    let ty = mode & S_IFMT;
+    let node_type = match ty {
+        0 | S_IFREG => NodeType::RegularFile,
+        S_IFIFO => NodeType::Fifo,
+        _ => return Err(AxError::OperationNotSupported),
+    };
+
+    with_fs(dirfd, |fs| {
+        let (dir, name) = fs.resolve_nonexistent(Path::new(path.as_str()))?;
+        dir.create(name, node_type, perm)?;
+        Ok(0)
+    })
+}
+
+#[cfg(target_arch = "x86_64")]
+pub fn sys_mknod(path: *const c_char, mode: u32, dev: u64) -> AxResult<isize> {
+    use linux_raw_sys::general::AT_FDCWD;
+    sys_mknodat(AT_FDCWD as _, path, mode, dev)
+}
+
 // Directory buffer for getdents64 syscall
 struct DirBuffer {
     buf: Vec<u8>,

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -210,8 +210,9 @@ fn dup_fd(old_fd: c_int, cloexec: bool) -> AxResult<isize> {
 
 /// Duplicate `old_fd` to the first available descriptor >= `minfd` (F_DUPFD/F_DUPFD_CLOEXEC).
 fn dup_fd_with_minfd(old_fd: c_int, minfd: usize, cloexec: bool) -> AxResult<isize> {
-    use crate::{file::FileDescriptor, task::AX_FILE_LIMIT};
     use linux_raw_sys::general::RLIMIT_NOFILE;
+
+    use crate::{file::FileDescriptor, task::AX_FILE_LIMIT};
     let f = get_file_like(old_fd)?;
     let max_nofile = current().as_thread().proc_data.rlim.read()[RLIMIT_NOFILE].current;
     let mut table = FD_TABLE.write();

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -292,12 +292,22 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
             }
             dup_fd_with_minfd(fd, arg as usize, true)
         }
-        F_SETLK | F_SETLKW => Ok(0),
-        F_OFD_SETLK | F_OFD_SETLKW => Ok(0),
-        F_GETLK | F_OFD_GETLK => {
+        F_SETLK | F_OFD_SETLK => {
+            let file = get_file_like(fd)?;
             let arg = UserPtr::<flock64>::from(arg);
-            arg.get_as_mut()?.l_type = F_UNLCK as _;
-            Ok(0)
+            let flk = *arg.get_as_mut()?;
+            super::lock::fcntl_setlk(&file, &flk, false)
+        }
+        F_SETLKW | F_OFD_SETLKW => {
+            let file = get_file_like(fd)?;
+            let arg = UserPtr::<flock64>::from(arg);
+            let flk = *arg.get_as_mut()?;
+            super::lock::fcntl_setlk(&file, &flk, true)
+        }
+        F_GETLK | F_OFD_GETLK => {
+            let file = get_file_like(fd)?;
+            let arg = UserPtr::<flock64>::from(arg);
+            super::lock::fcntl_getlk(&file, arg.get_as_mut()?)
         }
         F_SETFL => {
             let f = get_file_like(fd)?;
@@ -375,6 +385,6 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
 
 pub fn sys_flock(fd: c_int, operation: c_int) -> AxResult<isize> {
     debug!("flock <= fd: {fd}, operation: {operation}");
-    // TODO: flock
-    Ok(0)
+    let f = get_file_like(fd)?;
+    super::lock::flock_op(&f, operation)
 }

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -123,6 +123,10 @@ pub fn sys_openat(
     let path = vm_load_string(path)?;
     debug!("sys_openat <= {dirfd} {path:?} {flags:#o} {mode:#o}");
 
+    if path.is_empty() {
+        return Err(AxError::NotFound);
+    }
+
     let mode = mode & !current().as_thread().proc_data.umask();
 
     let options = flags_to_options(flags, mode, (sys_geteuid()? as _, sys_getegid()? as _));

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -6,7 +6,7 @@ use core::{
 };
 
 use ax_errno::{AxError, AxResult};
-use ax_fs::{FS_CONTEXT, FileBackend, OpenOptions, OpenResult};
+use ax_fs::{FS_CONTEXT, FileBackend, FileFlags, OpenOptions, OpenResult};
 use ax_task::current;
 use axfs_ng_vfs::{DirEntry, FileNode, Location, NodePermission, NodeType, Reference};
 use bitflags::bitflags;
@@ -300,7 +300,11 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
             Ok(0)
         }
         F_SETFL => {
-            get_file_like(fd)?.set_nonblocking(arg & (O_NONBLOCK as usize) > 0)?;
+            let f = get_file_like(fd)?;
+            f.set_nonblocking(arg & (O_NONBLOCK as usize) > 0)?;
+            if let Some(file) = f.as_any().downcast_ref::<File>() {
+                file.inner().set_append(arg & (O_APPEND as usize) > 0);
+            }
             Ok(0)
         }
         F_GETFL => {
@@ -310,13 +314,27 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
             if f.nonblocking() {
                 ret |= O_NONBLOCK;
             }
-
-            let perm = NodePermission::from_bits_truncate(f.stat()?.mode as _);
-            if perm.contains(NodePermission::OWNER_WRITE) {
-                if perm.contains(NodePermission::OWNER_READ) {
+            // Reflect file access mode and O_APPEND from the underlying File.
+            if let Some(file) = f.as_any().downcast_ref::<File>() {
+                let flags = file.inner().flags();
+                let read = flags.contains(FileFlags::READ);
+                let write = flags.contains(FileFlags::WRITE);
+                if read && write {
                     ret |= O_RDWR;
-                } else {
+                } else if write {
                     ret |= O_WRONLY;
+                } // else O_RDONLY == 0
+                if flags.contains(FileFlags::APPEND) {
+                    ret |= O_APPEND;
+                }
+            } else {
+                let perm = NodePermission::from_bits_truncate(f.stat()?.mode as _);
+                if perm.contains(NodePermission::OWNER_WRITE) {
+                    if perm.contains(NodePermission::OWNER_READ) {
+                        ret |= O_RDWR;
+                    } else {
+                        ret |= O_WRONLY;
+                    }
                 }
             }
 

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -130,9 +130,21 @@ pub fn sys_openat(
     let mode = mode & !current().as_thread().proc_data.umask();
 
     let options = flags_to_options(flags, mode, (sys_geteuid()? as _, sys_getegid()? as _));
-    with_fs(dirfd, |fs| options.open(fs, path))
-        .and_then(|it| add_to_fd(it, flags as _))
-        .map(|fd| fd as isize)
+    let uflags = flags as u32;
+    let access = uflags & 0b11;
+    let result = with_fs(dirfd, |fs| options.open(fs, path)).map_err(|e| {
+        // O_DIRECTORY on a non-directory should report ENOTDIR, not EISDIR.
+        if uflags & O_DIRECTORY != 0 && e == AxError::IsADirectory {
+            AxError::NotADirectory
+        } else {
+            e
+        }
+    })?;
+    // Reject write modes when the target is a directory.
+    if matches!(result, OpenResult::Dir(_)) && (access == O_WRONLY || access == O_RDWR) {
+        return Err(AxError::IsADirectory);
+    }
+    add_to_fd(result, flags as _).map(|fd| fd as isize)
 }
 
 /// Open a file by `filename` and insert it into the file descriptor table.

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -208,6 +208,30 @@ fn dup_fd(old_fd: c_int, cloexec: bool) -> AxResult<isize> {
     Ok(new_fd as _)
 }
 
+/// Duplicate `old_fd` to the first available descriptor >= `minfd` (F_DUPFD/F_DUPFD_CLOEXEC).
+fn dup_fd_with_minfd(old_fd: c_int, minfd: usize, cloexec: bool) -> AxResult<isize> {
+    use crate::{file::FileDescriptor, task::AX_FILE_LIMIT};
+    use linux_raw_sys::general::RLIMIT_NOFILE;
+    let f = get_file_like(old_fd)?;
+    let max_nofile = current().as_thread().proc_data.rlim.read()[RLIMIT_NOFILE].current;
+    let mut table = FD_TABLE.write();
+    if table.count() as u64 >= max_nofile {
+        return Err(AxError::TooManyOpenFiles);
+    }
+    let mut fd = minfd;
+    while fd < AX_FILE_LIMIT && table.is_assigned(fd) {
+        fd += 1;
+    }
+    if fd >= AX_FILE_LIMIT {
+        return Err(AxError::TooManyOpenFiles);
+    }
+    let entry = FileDescriptor { inner: f, cloexec };
+    table
+        .add_at(fd, entry)
+        .map_err(|_| AxError::TooManyOpenFiles)?;
+    Ok(fd as isize)
+}
+
 pub fn sys_dup(old_fd: c_int) -> AxResult<isize> {
     debug!("sys_dup <= {old_fd}");
     dup_fd(old_fd, false)
@@ -260,13 +284,13 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
             if (arg as i32) < 0 {
                 return Err(AxError::InvalidInput);
             }
-            dup_fd(fd, false)
+            dup_fd_with_minfd(fd, arg as usize, false)
         }
         F_DUPFD_CLOEXEC => {
             if (arg as i32) < 0 {
                 return Err(AxError::InvalidInput);
             }
-            dup_fd(fd, true)
+            dup_fd_with_minfd(fd, arg as usize, true)
         }
         F_SETLK | F_SETLKW => Ok(0),
         F_OFD_SETLK | F_OFD_SETLKW => Ok(0),

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -240,8 +240,18 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
     debug!("sys_fcntl <= fd: {fd} cmd: {cmd} arg: {arg}");
 
     match cmd as u32 {
-        F_DUPFD => dup_fd(fd, false),
-        F_DUPFD_CLOEXEC => dup_fd(fd, true),
+        F_DUPFD => {
+            if (arg as i32) < 0 {
+                return Err(AxError::InvalidInput);
+            }
+            dup_fd(fd, false)
+        }
+        F_DUPFD_CLOEXEC => {
+            if (arg as i32) < 0 {
+                return Err(AxError::InvalidInput);
+            }
+            dup_fd(fd, true)
+        }
         F_SETLK | F_SETLKW => Ok(0),
         F_OFD_SETLK | F_OFD_SETLKW => Ok(0),
         F_GETLK | F_OFD_GETLK => {
@@ -299,8 +309,8 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
             Ok(0)
         }
         _ => {
-            warn!("unsupported fcntl parameters: cmd: {cmd}");
-            Ok(0)
+            warn!("unsupported fcntl cmd: {cmd}");
+            Err(AxError::InvalidInput)
         }
     }
 }

--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -4,7 +4,7 @@ use core::{
     task::Context,
 };
 
-use ax_errno::{AxError, AxResult};
+use ax_errno::{AxError, AxResult, LinuxError};
 use ax_fs::{FS_CONTEXT, FileFlags, OpenOptions};
 use ax_io::{Seek, SeekFrom};
 use ax_task::current;
@@ -75,11 +75,20 @@ pub fn sys_writev(fd: i32, iov: *const IoVec, iovcnt: usize) -> AxResult<isize> 
 pub fn sys_lseek(fd: c_int, offset: __kernel_off_t, whence: c_int) -> AxResult<isize> {
     debug!("sys_lseek <= {fd} {offset} {whence}");
     let pos = match whence {
-        0 => SeekFrom::Start(offset as _),
-        1 => SeekFrom::Current(offset as _),
-        2 => SeekFrom::End(offset as _),
+        0 => {
+            if offset < 0 {
+                return Err(AxError::InvalidInput);
+            }
+            SeekFrom::Start(offset as u64)
+        }
+        1 => SeekFrom::Current(offset),
+        2 => SeekFrom::End(offset),
         _ => return Err(AxError::InvalidInput),
     };
+    // Pipes are not seekable; return ESPIPE rather than EBADF/EPIPE.
+    if get_file_like(fd)?.as_any().is::<Pipe>() {
+        return Err(LinuxError::ESPIPE.into());
+    }
     let off = File::from_fd(fd)?.inner().seek(pos)?;
     Ok(off as _)
 }

--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -355,7 +355,7 @@ pub fn sys_copy_file_range(
     fd_out: c_int,
     off_out: *mut u64,
     len: usize,
-    _flags: u32,
+    flags: u32,
 ) -> AxResult<isize> {
     debug!(
         "sys_copy_file_range <= fd_in: {}, off_in: {}, fd_out: {}, off_out: {}, len: {}, flags: {}",
@@ -364,21 +364,47 @@ pub fn sys_copy_file_range(
         fd_out,
         !off_out.is_null(),
         len,
-        _flags
+        flags
     );
 
-    // TODO: check flags
-    // TODO: check both regular files
-    // TODO: check same file and overlap
+    // Linux reserves all flags; non-zero is invalid (Linux man copy_file_range(2)).
+    if flags != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
+    // Both fds must refer to regular files (reject pipes/sockets/dirs).
+    let src_file = File::from_fd(fd_in).map_err(|_| AxError::InvalidInput)?;
+    let dst_file = File::from_fd(fd_out).map_err(|_| AxError::InvalidInput)?;
+
+    // Same-file overlap: forbidden when the source and destination ranges
+    // within the same file overlap.
+    if Arc::ptr_eq(&src_file, &dst_file) {
+        // Determine effective source and destination start offsets.
+        let src_start = if !off_in.is_null() {
+            unsafe { off_in.vm_read_uninit()?.assume_init() }
+        } else {
+            0
+        };
+        let dst_start = if !off_out.is_null() {
+            unsafe { off_out.vm_read_uninit()?.assume_init() }
+        } else {
+            0
+        };
+        let end = |start: u64| start.saturating_add(len as u64);
+        let overlap = src_start < end(dst_start) && dst_start < end(src_start);
+        if overlap {
+            return Err(AxError::InvalidInput);
+        }
+    }
 
     let src = if !off_in.is_null() {
-        SendFile::Offset(File::from_fd(fd_in)?, off_in)
+        SendFile::Offset(src_file, off_in)
     } else {
         SendFile::Direct(get_file_like(fd_in)?)
     };
 
     let dst = if !off_out.is_null() {
-        SendFile::Offset(File::from_fd(fd_out)?, off_out)
+        SendFile::Offset(dst_file, off_out)
     } else {
         SendFile::Direct(get_file_like(fd_out)?)
     };

--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -109,6 +109,9 @@ pub fn sys_truncate(path: UserConstPtr<c_char>, length: __kernel_off_t) -> AxRes
 
 pub fn sys_ftruncate(fd: c_int, length: __kernel_off_t) -> AxResult<isize> {
     debug!("sys_ftruncate <= {fd} {length}");
+    if length < 0 {
+        return Err(AxError::InvalidInput);
+    }
     let f = File::from_fd(fd)?;
     f.inner().access(FileFlags::WRITE)?.set_len(length as _)?;
     Ok(0)
@@ -176,6 +179,9 @@ pub fn sys_pwrite64(
     len: usize,
     offset: __kernel_off_t,
 ) -> AxResult<isize> {
+    if offset < 0 {
+        return Err(AxError::InvalidInput);
+    }
     if len == 0 {
         return Ok(0);
     }

--- a/os/StarryOS/kernel/src/syscall/fs/lock.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/lock.rs
@@ -1,0 +1,346 @@
+//! File lock implementations for `flock(2)` and `fcntl(2)` POSIX record locks.
+//!
+//! A single global table is keyed by `(dev, ino)`. Each entry tracks:
+//! - `flocks`: `flock(2)` holders, identified by their open-file description
+//!   (the `Arc<dyn FileLike>` pointer).
+//! - `posix`: `fcntl(2)` range locks, owned by a PID.
+//! - `wake`: a [`PollSet`] used by blocking callers (`flock` without `LOCK_NB`
+//!   and `fcntl F_SETLKW`) to wait until a conflicting lock is released.
+
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
+use core::{ffi::c_int, future::poll_fn, task::Poll};
+
+use ax_errno::{AxError, AxResult};
+use ax_sync::Mutex;
+use ax_task::{
+    current,
+    future::{block_on, interruptible},
+};
+use axpoll::PollSet;
+use linux_raw_sys::general::{
+    F_RDLCK, F_UNLCK, F_WRLCK, LOCK_EX, LOCK_NB, LOCK_SH, LOCK_UN, SEEK_CUR, SEEK_END, SEEK_SET,
+    flock64,
+};
+use starry_process::Pid;
+
+use crate::{file::FileLike, task::AsThread};
+
+type InodeKey = (u64, u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LockKind {
+    Shared,
+    Exclusive,
+}
+
+#[derive(Debug)]
+struct FlockEntry {
+    ofd: usize,
+    kind: LockKind,
+}
+
+#[derive(Debug, Clone)]
+struct PosixLock {
+    pid: Pid,
+    kind: LockKind,
+    start: u64,
+    /// Exclusive upper bound. `u64::MAX` represents "to end of file".
+    end: u64,
+}
+
+#[derive(Default)]
+struct LockState {
+    flocks: Vec<FlockEntry>,
+    posix: Vec<PosixLock>,
+    wake: Arc<PollSet>,
+}
+
+static LOCK_TABLE: Mutex<BTreeMap<InodeKey, LockState>> = Mutex::new(BTreeMap::new());
+
+fn inode_key(f: &Arc<dyn FileLike>) -> AxResult<InodeKey> {
+    let st = f.stat()?;
+    Ok((st.dev, st.ino))
+}
+
+fn ofd_id(f: &Arc<dyn FileLike>) -> usize {
+    // `Arc::as_ptr` returns a fat pointer to the trait object; casting
+    // it to a thin pointer yields the address of the underlying allocation,
+    // which is unique per open-file description.
+    Arc::as_ptr(f) as *const u8 as usize
+}
+
+fn current_pid() -> Pid {
+    current().as_thread().proc_data.proc.pid()
+}
+
+fn ranges_overlap(a_start: u64, a_end: u64, b_start: u64, b_end: u64) -> bool {
+    a_start < b_end && b_start < a_end
+}
+
+/// Compute (start, end) in absolute file offsets from a `flock64` struct.
+fn resolve_range(f: &Arc<dyn FileLike>, flk: &flock64) -> AxResult<(u64, u64)> {
+    let base = match flk.l_whence as u32 {
+        SEEK_SET => 0i64,
+        SEEK_CUR => 0i64, // current file offset isn't tracked at this layer
+        SEEK_END => f.stat()?.size as i64,
+        _ => return Err(AxError::InvalidInput),
+    };
+    let start = base.checked_add(flk.l_start).ok_or(AxError::InvalidInput)?;
+    if start < 0 {
+        return Err(AxError::InvalidInput);
+    }
+    let start = start as u64;
+    let end = if flk.l_len == 0 {
+        u64::MAX
+    } else if flk.l_len > 0 {
+        start
+            .checked_add(flk.l_len as u64)
+            .ok_or(AxError::InvalidInput)?
+    } else {
+        // Negative length: range is [start + len, start).
+        let new_start = (start as i64)
+            .checked_add(flk.l_len)
+            .ok_or(AxError::InvalidInput)?;
+        if new_start < 0 {
+            return Err(AxError::InvalidInput);
+        }
+        let old = start;
+        let start = new_start as u64;
+        return Ok((start, old));
+    };
+    Ok((start, end))
+}
+
+fn posix_kind(l_type: i16) -> AxResult<Option<LockKind>> {
+    match l_type as u32 {
+        F_RDLCK => Ok(Some(LockKind::Shared)),
+        F_WRLCK => Ok(Some(LockKind::Exclusive)),
+        F_UNLCK => Ok(None),
+        _ => Err(AxError::InvalidInput),
+    }
+}
+
+/// Find the first POSIX lock held by a *different* process that conflicts
+/// with the requested range and kind. Same-PID holders never conflict with
+/// themselves (POSIX F_GETLK semantics).
+fn find_posix_conflict<'a>(
+    st: &'a LockState,
+    pid: Pid,
+    kind: LockKind,
+    start: u64,
+    end: u64,
+) -> Option<&'a PosixLock> {
+    st.posix.iter().find(|l| {
+        l.pid != pid
+            && ranges_overlap(l.start, l.end, start, end)
+            && (kind == LockKind::Exclusive || l.kind == LockKind::Exclusive)
+    })
+}
+
+/// `flock(2)` implementation.
+pub fn flock_op(f: &Arc<dyn FileLike>, operation: c_int) -> AxResult<isize> {
+    let nb = (operation & LOCK_NB as c_int) != 0;
+    let op = (operation & !(LOCK_NB as c_int)) as u32;
+    let ofd = ofd_id(f);
+    let key = inode_key(f)?;
+
+    if op == LOCK_UN {
+        let mut table = LOCK_TABLE.lock();
+        if let Some(st) = table.get_mut(&key) {
+            st.flocks.retain(|e| e.ofd != ofd);
+            st.wake.wake();
+            if st.flocks.is_empty() && st.posix.is_empty() {
+                table.remove(&key);
+            }
+        }
+        return Ok(0);
+    }
+
+    let want = match op {
+        LOCK_SH => LockKind::Shared,
+        LOCK_EX => LockKind::Exclusive,
+        _ => return Err(AxError::InvalidInput),
+    };
+
+    let wake = LOCK_TABLE.lock().entry(key).or_default().wake.clone();
+    let r = block_on(interruptible(poll_fn(|cx| {
+        // Register first so a concurrent `wake()` cannot be lost between the
+        // conflict check below and going to sleep.
+        wake.register(cx.waker());
+
+        let mut table = LOCK_TABLE.lock();
+        let st = table.entry(key).or_default();
+        let conflict = st.flocks.iter().any(|e| {
+            e.ofd != ofd && (want == LockKind::Exclusive || e.kind == LockKind::Exclusive)
+        });
+        if !conflict {
+            if let Some(existing) = st.flocks.iter_mut().find(|e| e.ofd == ofd) {
+                existing.kind = want;
+            } else {
+                st.flocks.push(FlockEntry { ofd, kind: want });
+            }
+            return Poll::Ready(Ok(0));
+        }
+        if nb {
+            return Poll::Ready(Err(AxError::WouldBlock));
+        }
+        Poll::Pending
+    })));
+    match r {
+        Ok(res) => res,
+        Err(_) => Err(AxError::Interrupted),
+    }
+}
+
+/// Drop flock entries owned by an OFD when the last reference to the file
+/// is closed.
+pub fn flock_release_ofd(f: &Arc<dyn FileLike>) {
+    let Ok(key) = inode_key(f) else {
+        return;
+    };
+    let ofd = ofd_id(f);
+    let mut table = LOCK_TABLE.lock();
+    if let Some(st) = table.get_mut(&key) {
+        st.flocks.retain(|e| e.ofd != ofd);
+        st.wake.wake();
+        if st.flocks.is_empty() && st.posix.is_empty() {
+            table.remove(&key);
+        }
+    }
+}
+
+/// Replace the range `[start, end)` among same-PID POSIX locks.
+///
+/// This is a simplified split/merge: locks that fall entirely inside the
+/// target range are removed; locks that straddle a boundary are truncated.
+fn remove_posix_range(st: &mut LockState, pid: Pid, start: u64, end: u64) {
+    let mut new = Vec::with_capacity(st.posix.len());
+    for l in st.posix.drain(..) {
+        if l.pid != pid || !ranges_overlap(l.start, l.end, start, end) {
+            new.push(l);
+            continue;
+        }
+        // Keep portion before `start`.
+        if l.start < start {
+            new.push(PosixLock {
+                pid: l.pid,
+                kind: l.kind,
+                start: l.start,
+                end: start,
+            });
+        }
+        // Keep portion after `end`.
+        if l.end > end {
+            new.push(PosixLock {
+                pid: l.pid,
+                kind: l.kind,
+                start: end,
+                end: l.end,
+            });
+        }
+    }
+    st.posix = new;
+}
+
+/// `fcntl(fd, F_GETLK, flk)` — fill `flk.l_type = F_UNLCK` if the request
+/// would succeed, otherwise describe the conflicting lock.
+pub fn fcntl_getlk(f: &Arc<dyn FileLike>, flk: &mut flock64) -> AxResult<isize> {
+    let Some(want) = posix_kind(flk.l_type)? else {
+        return Err(AxError::InvalidInput);
+    };
+    let (start, end) = resolve_range(f, flk)?;
+    let key = inode_key(f)?;
+    let pid = current_pid();
+
+    let table = LOCK_TABLE.lock();
+    if let Some(st) = table.get(&key)
+        && let Some(conflict) = find_posix_conflict(st, pid, want, start, end)
+    {
+        flk.l_type = match conflict.kind {
+            LockKind::Shared => F_RDLCK as _,
+            LockKind::Exclusive => F_WRLCK as _,
+        };
+        flk.l_whence = SEEK_SET as _;
+        flk.l_start = conflict.start as i64;
+        flk.l_len = if conflict.end == u64::MAX {
+            0
+        } else {
+            (conflict.end - conflict.start) as i64
+        };
+        flk.l_pid = conflict.pid as _;
+    } else {
+        flk.l_type = F_UNLCK as _;
+    }
+    Ok(0)
+}
+
+/// `fcntl(fd, F_SETLK|F_SETLKW, flk)`.
+pub fn fcntl_setlk(f: &Arc<dyn FileLike>, flk: &flock64, blocking: bool) -> AxResult<isize> {
+    let kind = posix_kind(flk.l_type)?;
+    let (start, end) = resolve_range(f, flk)?;
+    let key = inode_key(f)?;
+    let pid = current_pid();
+
+    match kind {
+        None => {
+            let mut table = LOCK_TABLE.lock();
+            if let Some(st) = table.get_mut(&key) {
+                remove_posix_range(st, pid, start, end);
+                st.wake.wake();
+                if st.flocks.is_empty() && st.posix.is_empty() {
+                    table.remove(&key);
+                }
+            }
+            Ok(0)
+        }
+        Some(want) => {
+            let wake = LOCK_TABLE.lock().entry(key).or_default().wake.clone();
+            let r = block_on(interruptible(poll_fn(|cx| {
+                // Register the waker before inspecting the table so a
+                // concurrent `wake()` cannot slip through.
+                wake.register(cx.waker());
+
+                let mut table = LOCK_TABLE.lock();
+                let st = table.entry(key).or_default();
+                if find_posix_conflict(st, pid, want, start, end).is_none() {
+                    remove_posix_range(st, pid, start, end);
+                    st.posix.push(PosixLock {
+                        pid,
+                        kind: want,
+                        start,
+                        end,
+                    });
+                    return Poll::Ready(Ok(0));
+                }
+                if !blocking {
+                    return Poll::Ready(Err(AxError::WouldBlock));
+                }
+                Poll::Pending
+            })));
+            match r {
+                Ok(res) => res,
+                Err(_) => Err(AxError::Interrupted),
+            }
+        }
+    }
+}
+
+/// Release all POSIX locks owned by the given PID (called on process exit).
+#[allow(dead_code)]
+pub fn release_posix_locks_for_pid(pid: Pid) {
+    let mut table = LOCK_TABLE.lock();
+    let mut empty_keys = Vec::new();
+    for (key, st) in table.iter_mut() {
+        let before = st.posix.len();
+        st.posix.retain(|l| l.pid != pid);
+        if st.posix.len() != before {
+            st.wake.wake();
+        }
+        if st.flocks.is_empty() && st.posix.is_empty() {
+            empty_keys.push(*key);
+        }
+    }
+    for k in empty_keys {
+        table.remove(&k);
+    }
+}

--- a/os/StarryOS/kernel/src/syscall/fs/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mod.rs
@@ -2,6 +2,7 @@ mod ctl;
 mod event;
 mod fd_ops;
 mod io;
+mod lock;
 mod memfd;
 mod mount;
 mod pidfd;

--- a/os/StarryOS/kernel/src/syscall/fs/pipe.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/pipe.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_int;
 
-use ax_errno::AxResult;
+use ax_errno::{AxError, AxResult};
 use bitflags::bitflags;
 use linux_raw_sys::general::{O_CLOEXEC, O_NONBLOCK};
 use starry_vm::VmMutPtr;
@@ -19,13 +19,7 @@ bitflags! {
 }
 
 pub fn sys_pipe2(fds: *mut [c_int; 2], flags: u32) -> AxResult<isize> {
-    let flags = {
-        let new_flags = PipeFlags::from_bits_truncate(flags);
-        if new_flags.bits() != flags {
-            warn!("sys_pipe2 <= unrecognized flags: {flags}");
-        }
-        new_flags
-    };
+    let flags = PipeFlags::from_bits(flags).ok_or(AxError::InvalidInput)?;
 
     let cloexec = flags.contains(PipeFlags::CLOEXEC);
     let (read_end, write_end) = Pipe::new();

--- a/os/StarryOS/kernel/src/syscall/fs/stat.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/stat.rs
@@ -4,7 +4,8 @@ use ax_errno::{AxError, AxResult};
 use ax_fs::FS_CONTEXT;
 use axfs_ng_vfs::{Location, NodePermission};
 use linux_raw_sys::general::{
-    __kernel_fsid_t, AT_EMPTY_PATH, R_OK, W_OK, X_OK, stat, statfs, statx,
+    __kernel_fsid_t, AT_EMPTY_PATH, AT_NO_AUTOMOUNT, AT_SYMLINK_NOFOLLOW, R_OK, W_OK, X_OK, stat,
+    statfs, statx,
 };
 use starry_vm::{VmMutPtr, VmPtr};
 
@@ -50,6 +51,12 @@ pub fn sys_fstatat(
 
     debug!("sys_fstatat <= dirfd: {dirfd}, path: {path:?}, flags: {flags}");
 
+    // Reject unknown bits (Linux fstatat returns EINVAL).
+    const KNOWN: u32 = AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH | AT_NO_AUTOMOUNT;
+    if flags & !KNOWN != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
     let loc = resolve_at(dirfd, path.as_deref(), flags)?;
     statbuf.vm_write(loc.stat()?.into())?;
 
@@ -60,9 +67,14 @@ pub fn sys_statx(
     dirfd: c_int,
     path: *const c_char,
     flags: u32,
-    _mask: u32,
+    mask: u32,
     statxbuf: *mut statx,
 ) -> AxResult<isize> {
+    use linux_raw_sys::general::STATX__RESERVED;
+    // Reserved bit in the mask must be zero (Linux statx ABI).
+    if mask & STATX__RESERVED != 0 {
+        return Err(AxError::InvalidInput);
+    }
     // `statx()` uses pathname, dirfd, and flags to identify the target
     // file in one of the following ways:
 

--- a/os/StarryOS/kernel/src/syscall/mm/brk.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/brk.rs
@@ -2,6 +2,7 @@ use ax_errno::AxResult;
 use ax_hal::paging::{MappingFlags, PageSize};
 use ax_memory_addr::{VirtAddr, align_up_4k};
 use ax_task::current;
+use linux_raw_sys::general::RLIMIT_DATA;
 
 use crate::{
     config::{USER_HEAP_BASE, USER_HEAP_SIZE, USER_HEAP_SIZE_MAX},
@@ -13,7 +14,14 @@ pub fn sys_brk(addr: usize) -> AxResult<isize> {
     let curr = current();
     let proc_data = &curr.as_thread().proc_data;
     let current_top = proc_data.get_heap_top() as usize;
-    let heap_limit = USER_HEAP_BASE + USER_HEAP_SIZE_MAX;
+    // Honor RLIMIT_DATA in addition to the compile-time heap cap.
+    let rlim_data = proc_data.rlim.read()[RLIMIT_DATA].current as usize;
+    let heap_size_cap = if rlim_data == 0 {
+        USER_HEAP_SIZE_MAX
+    } else {
+        rlim_data.min(USER_HEAP_SIZE_MAX)
+    };
+    let heap_limit = USER_HEAP_BASE + heap_size_cap;
 
     if addr == 0 {
         return Ok(current_top as isize);

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -307,42 +307,156 @@ pub fn sys_mprotect(addr: usize, length: usize, prot: u32) -> AxResult<isize> {
     Ok(0)
 }
 
-pub fn sys_mremap(addr: usize, old_size: usize, new_size: usize, flags: u32) -> AxResult<isize> {
+pub fn sys_mremap(
+    addr: usize,
+    old_size: usize,
+    new_size: usize,
+    flags: u32,
+    new_addr: usize,
+) -> AxResult<isize> {
+    const MREMAP_MAYMOVE: u32 = 1;
+    const MREMAP_FIXED: u32 = 2;
+    const MREMAP_DONTUNMAP: u32 = 4;
+    const MREMAP_VALID: u32 = MREMAP_MAYMOVE | MREMAP_FIXED | MREMAP_DONTUNMAP;
+
     debug!(
         "sys_mremap <= addr: {addr:#x}, old_size: {old_size:x}, new_size: {new_size:x}, flags: \
-         {flags:#x}"
+         {flags:#x}, new_addr: {new_addr:#x}"
     );
 
-    // TODO: full implementation
-
-    if !addr.is_multiple_of(PageSize::Size4K as usize) {
+    if flags & !MREMAP_VALID != 0 {
         return Err(AxError::InvalidInput);
     }
-    let addr = VirtAddr::from(addr);
+    let may_move = flags & MREMAP_MAYMOVE != 0;
+    let fixed = flags & MREMAP_FIXED != 0;
+    let dontunmap = flags & MREMAP_DONTUNMAP != 0;
+    if fixed && !may_move {
+        return Err(AxError::InvalidInput);
+    }
+    if dontunmap && !may_move {
+        return Err(AxError::InvalidInput);
+    }
+    if dontunmap && old_size != new_size {
+        return Err(AxError::InvalidInput);
+    }
+
+    let page = PageSize::Size4K as usize;
+    if !addr.is_multiple_of(page) {
+        return Err(AxError::InvalidInput);
+    }
+    if new_size == 0 {
+        return Err(AxError::InvalidInput);
+    }
+    // `old_size == 0` is only valid for shared mappings (to create an extra
+    // alias). We don't support that case; reject it with EINVAL.
+    if old_size == 0 {
+        return Err(AxError::InvalidInput);
+    }
+    if fixed && !new_addr.is_multiple_of(page) {
+        return Err(AxError::InvalidInput);
+    }
+
+    let old_size_up = align_up_4k(old_size);
+    let new_size_up = align_up_4k(new_size);
+
+    if fixed {
+        // Old and new ranges must not overlap.
+        let o_end = addr.checked_add(old_size_up).ok_or(AxError::InvalidInput)?;
+        let n_end = new_addr
+            .checked_add(new_size_up)
+            .ok_or(AxError::InvalidInput)?;
+        if addr < n_end && new_addr < o_end {
+            return Err(AxError::InvalidInput);
+        }
+    }
 
     let curr = current();
-    let aspace = curr.as_thread().proc_data.aspace.lock();
-    let old_size = align_up_4k(old_size);
-    let new_size = align_up_4k(new_size);
+    let mapping_flags = {
+        let aspace = curr.as_thread().proc_data.aspace.lock();
+        let vma = aspace
+            .find_area(VirtAddr::from(addr))
+            .ok_or(AxError::BadAddress)?;
+        if VirtAddr::from(addr + old_size_up) > vma.end() {
+            return Err(AxError::BadAddress);
+        }
+        vma.flags()
+    };
+    let prot = mapping_flags.bits() as u32;
 
-    let flags = aspace.find_area(addr).ok_or(AxError::NoMemory)?.flags();
-    drop(aspace);
-    let new_addr = sys_mmap(
-        addr.as_usize(),
-        new_size,
-        flags.bits() as _,
-        MmapFlags::PRIVATE.bits(),
-        -1,
-        0,
-    )? as usize;
+    // No-op: same size, no relocation requested.
+    if !fixed && !dontunmap && old_size_up == new_size_up {
+        return Ok(addr as isize);
+    }
 
-    let copy_len = new_size.min(old_size);
-    let data = vm_load(addr.as_ptr(), copy_len)?;
-    vm_write_slice(new_addr as *mut u8, &data)?;
+    // Shrink in place.
+    if !fixed && !dontunmap && new_size_up < old_size_up {
+        sys_munmap(addr + new_size_up, old_size_up - new_size_up)?;
+        return Ok(addr as isize);
+    }
 
-    sys_munmap(addr.as_usize(), old_size)?;
+    // Grow request.
+    //
+    // Without MREMAP_MAYMOVE / MREMAP_FIXED / MREMAP_DONTUNMAP the expansion
+    // must happen in place: we look for a free gap immediately after the
+    // existing VMA and map it with the same protection.
+    if !may_move && !fixed && !dontunmap {
+        let extra = new_size_up - old_size_up;
+        let extra_start = VirtAddr::from(addr + old_size_up);
+        let free = {
+            let aspace = curr.as_thread().proc_data.aspace.lock();
+            aspace.find_free_area(
+                extra_start,
+                extra,
+                VirtAddrRange::new(aspace.base(), aspace.end()),
+                page,
+            )
+        };
+        if free == Some(extra_start) {
+            sys_mmap(
+                extra_start.as_usize(),
+                extra,
+                prot,
+                (MmapFlags::PRIVATE | MmapFlags::ANONYMOUS | MmapFlags::FIXED).bits(),
+                -1,
+                0,
+            )?;
+            return Ok(addr as isize);
+        }
+        return Err(AxError::NoMemory);
+    }
 
-    Ok(new_addr as isize)
+    // MREMAP_MAYMOVE (optionally with MREMAP_FIXED / MREMAP_DONTUNMAP): move
+    // the mapping by allocating a fresh anonymous region, copying data, then
+    // (unless DONTUNMAP) unmapping the original.
+    let target = if fixed {
+        sys_mmap(
+            new_addr,
+            new_size_up,
+            prot,
+            (MmapFlags::PRIVATE | MmapFlags::ANONYMOUS | MmapFlags::FIXED).bits(),
+            -1,
+            0,
+        )? as usize
+    } else {
+        sys_mmap(
+            0,
+            new_size_up,
+            prot,
+            (MmapFlags::PRIVATE | MmapFlags::ANONYMOUS).bits(),
+            -1,
+            0,
+        )? as usize
+    };
+
+    let copy_len = old_size_up.min(new_size_up);
+    let data = vm_load(addr as *const u8, copy_len)?;
+    vm_write_slice(target as *mut u8, &data)?;
+
+    if !dontunmap {
+        sys_munmap(addr, old_size_up)?;
+    }
+
+    Ok(target as isize)
 }
 
 pub fn sys_madvise(addr: usize, length: usize, advice: i32) -> AxResult<isize> {

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -294,6 +294,10 @@ pub fn sys_mprotect(addr: usize, length: usize, prot: u32) -> AxResult<isize> {
         return Err(AxError::InvalidInput);
     }
 
+    // Linux mprotect requires page-aligned addr (returns EINVAL otherwise).
+    if !addr.is_multiple_of(PageSize::Size4K as usize) {
+        return Err(AxError::InvalidInput);
+    }
     let curr = current();
     let mut aspace = curr.as_thread().proc_data.aspace.lock();
     let length = align_up_4k(length);

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use ax_errno::{AxError, AxResult};
-use ax_fs::FileBackend;
+use ax_fs::{FileBackend, FileFlags};
 use ax_hal::paging::{MappingFlags, PageSize};
 use ax_memory_addr::{MemoryAddr, VirtAddr, VirtAddrRange, align_up_4k};
 use ax_task::current;
@@ -174,11 +174,33 @@ pub fn sys_mmap(
             .ok_or(AxError::NoMemory)?
     };
 
-    let file = if fd > 0 {
-        Some(File::from_fd(fd)?)
+    let file = if !map_flags.contains(MmapFlags::ANONYMOUS) {
+        // mmap on a directory should report ENODEV (Linux semantics).
+        Some(File::from_fd(fd).map_err(|e| {
+            if e == AxError::IsADirectory {
+                AxError::NoSuchDevice
+            } else {
+                e
+            }
+        })?)
     } else {
         None
     };
+
+    // Linux: file mapping requires fd to be open for reading;
+    // MAP_SHARED with PROT_WRITE additionally requires write access.
+    if let Some(ref f) = file {
+        let flags = f.inner().flags();
+        if !flags.contains(FileFlags::READ) {
+            return Err(AxError::PermissionDenied);
+        }
+        if permission_flags.contains(MmapProt::WRITE)
+            && map_type.contains(MmapFlags::SHARED)
+            && !flags.contains(FileFlags::WRITE)
+        {
+            return Err(AxError::PermissionDenied);
+        }
+    }
 
     let backend = match map_type {
         MmapFlags::SHARED | MmapFlags::SHARED_VALIDATE => {

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -120,11 +120,13 @@ pub fn sys_mmap(
     ) {
         return Err(AxError::InvalidInput);
     }
-    if map_flags.contains(MmapFlags::ANONYMOUS) != (fd <= 0) {
-        return Err(AxError::InvalidInput);
-    }
-    if fd <= 0 && offset != 0 {
-        return Err(AxError::InvalidInput);
+    if map_flags.contains(MmapFlags::ANONYMOUS) {
+        if offset != 0 {
+            return Err(AxError::InvalidInput);
+        }
+    } else if fd < 0 {
+        // Non-anonymous mapping requires a valid file descriptor.
+        return Err(AxError::BadFileDescriptor);
     }
     let offset: usize = offset.try_into().map_err(|_| AxError::InvalidInput)?;
     if !PageSize::Size4K.is_aligned(offset) {

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -366,6 +366,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg1() as _,
             uctx.arg2() as _,
             uctx.arg3() as _,
+            uctx.arg4() as _,
         ),
         Sysno::madvise => sys_madvise(uctx.arg0(), uctx.arg1() as _, uctx.arg2() as _),
         Sysno::msync => sys_msync(uctx.arg0(), uctx.arg1() as _, uctx.arg2() as _),

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -528,6 +528,10 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::clock_getres => sys_clock_getres(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::getitimer => sys_getitimer(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::setitimer => sys_setitimer(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::alarm => sys_alarm(uctx.arg0() as _),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::pause => sys_pause(uctx),
 
         // msg
         Sysno::msgget => sys_msgget(uctx.arg0() as _, uctx.arg1() as _),

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -37,6 +37,14 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         #[cfg(target_arch = "x86_64")]
         Sysno::mkdir => sys_mkdir(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::mkdirat => sys_mkdirat(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::mknod => sys_mknod(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
+        Sysno::mknodat => sys_mknodat(
+            uctx.arg0() as _,
+            uctx.arg1() as _,
+            uctx.arg2() as _,
+            uctx.arg3() as _,
+        ),
         Sysno::getdents64 => sys_getdents64(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         #[cfg(target_arch = "x86_64")]
         Sysno::link => sys_link(uctx.arg0() as _, uctx.arg1() as _),

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -410,6 +410,10 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg2() as _,
             uctx.arg3() as _,
         ),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::getrlimit => sys_getrlimit(uctx.arg0() as _, uctx.arg1() as _),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::setrlimit => sys_setrlimit(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::capget => sys_capget(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::capset => sys_capset(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::umask => sys_umask(uctx.arg0() as _),

--- a/os/StarryOS/kernel/src/syscall/resources.rs
+++ b/os/StarryOS/kernel/src/syscall/resources.rs
@@ -10,6 +10,16 @@ use crate::{
     time::TimeValueLike,
 };
 
+/// Equivalent to `prlimit64(0, resource, NULL, old_limit)`.
+pub fn sys_getrlimit(resource: u32, old_limit: *mut rlimit64) -> AxResult<isize> {
+    sys_prlimit64(0, resource, core::ptr::null(), old_limit)
+}
+
+/// Equivalent to `prlimit64(0, resource, new_limit, NULL)`.
+pub fn sys_setrlimit(resource: u32, new_limit: *const rlimit64) -> AxResult<isize> {
+    sys_prlimit64(0, resource, new_limit, core::ptr::null_mut())
+}
+
 pub fn sys_prlimit64(
     pid: Pid,
     resource: u32,
@@ -37,14 +47,11 @@ pub fn sys_prlimit64(
         }
 
         let limit = &mut proc_data.rlim.write()[resource];
-        if new_limit.rlim_max <= limit.max {
-            limit.max = new_limit.rlim_max;
-        } else {
-            // TODO: patch resources
-            // return Err(AxError::OperationNotPermitted);
-            return Ok(0);
+        // Unprivileged processes may only lower the hard limit.
+        if new_limit.rlim_max > limit.max {
+            return Err(AxError::OperationNotPermitted);
         }
-
+        limit.max = new_limit.rlim_max;
         limit.current = new_limit.rlim_cur;
     }
 

--- a/os/StarryOS/kernel/src/syscall/signal.rs
+++ b/os/StarryOS/kernel/src/syscall/signal.rs
@@ -290,6 +290,24 @@ pub fn sys_rt_sigsuspend(
     Err(AxError::Interrupted)
 }
 
+/// Sleep until any signal is delivered, then return -EINTR.
+pub fn sys_pause(uctx: &mut UserContext) -> AxResult<isize> {
+    let curr = current();
+    let thr = curr.as_thread();
+
+    uctx.set_retval(-LinuxError::EINTR.code() as usize);
+
+    block_on(poll_fn(|cx| {
+        if check_signals(thr, uctx, None) {
+            return Poll::Ready(());
+        }
+        let _ = curr.poll_interrupt(cx);
+        Poll::Pending
+    }));
+
+    Err(AxError::Interrupted)
+}
+
 pub fn sys_sigaltstack(ss: *const SignalStack, old_ss: *mut SignalStack) -> AxResult<isize> {
     let curr = current();
     let sig = &curr.as_thread().signal;

--- a/os/StarryOS/kernel/src/syscall/signal.rs
+++ b/os/StarryOS/kernel/src/syscall/signal.rs
@@ -300,7 +300,8 @@ pub fn sys_sigaltstack(ss: *const SignalStack, old_ss: *mut SignalStack) -> AxRe
 
     if let Some(ss) = ss.nullable() {
         let ss = unsafe { ss.vm_read_uninit()?.assume_init() };
-        if ss.size <= MINSIGSTKSZ as usize {
+        // SS_DISABLE bypasses size check (the stack is being disabled).
+        if !ss.disabled() && ss.size < MINSIGSTKSZ as usize {
             return Err(AxError::NoMemory);
         }
         sig.set_stack(ss);

--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -101,7 +101,11 @@ pub fn sys_getrandom(buf: *mut u8, len: usize, flags: u32) -> AxResult<isize> {
     if len == 0 {
         return Ok(0);
     }
-    let flags = GetRandomFlags::from_bits_retain(flags);
+    let flags = GetRandomFlags::from_bits(flags).ok_or(AxError::InvalidInput)?;
+    // GRND_INSECURE and GRND_RANDOM are mutually exclusive (Linux man getrandom(2)).
+    if flags.contains(GetRandomFlags::INSECURE | GetRandomFlags::RANDOM) {
+        return Err(AxError::InvalidInput);
+    }
 
     debug!("sys_getrandom <= buf: {buf:p}, len: {len}, flags: {flags:?}");
 

--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -40,11 +40,13 @@ pub fn sys_setgid(_gid: u32) -> AxResult<isize> {
 
 pub fn sys_getgroups(size: usize, list: *mut u32) -> AxResult<isize> {
     debug!("sys_getgroups <= size: {size}");
-    if size < 1 {
+    // We do not yet track per-process supplementary groups; report empty.
+    // size == 0 is a query: return the count without writing to the buffer.
+    let count: isize = 0;
+    if size != 0 && (size as isize) < count {
         return Err(AxError::InvalidInput);
     }
-    vm_write_slice(list, &[0])?;
-    Ok(1)
+    Ok(count)
 }
 
 pub fn sys_setgroups(_size: usize, _list: *const u32) -> AxResult<isize> {

--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -13,7 +13,7 @@ use linux_raw_sys::general::{
 use starry_process::{Pid, Process};
 use starry_vm::{VmMutPtr, VmPtr};
 
-use crate::task::AsThread;
+use crate::task::{AsThread, get_process_data};
 
 bitflags! {
     #[derive(Debug)]
@@ -90,6 +90,33 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
     }
 
     let check_children = || {
+        // First check for a pending stopped/continued notification from any
+        // child whose status the caller asked for. WUNTRACED surfaces stopped
+        // children, WCONTINUED surfaces continued children.
+        for child in &children {
+            let Ok(child_data) = get_process_data(child.pid()) else {
+                continue;
+            };
+            let status = child_data.peek_stop_status();
+            if status == 0 {
+                continue;
+            }
+            let is_stopped = (status & 0xFF) == 0x7F;
+            let is_continued = status == 0xFFFF;
+            let report = (is_stopped && options.contains(WaitOptions::WUNTRACED))
+                || (is_continued && options.contains(WaitOptions::WCONTINUED));
+            if !report {
+                continue;
+            }
+            if !options.contains(WaitOptions::WNOWAIT) {
+                child_data.take_stop_status();
+            }
+            if let Some(exit_code) = exit_code.nullable() {
+                exit_code.vm_write(status)?;
+            }
+            return Ok(Some(child.pid() as _));
+        }
+
         if let Some(child) = children.iter().find(|child| child.is_zombie()) {
             if !options.contains(WaitOptions::WNOWAIT) {
                 child.free();

--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -61,7 +61,7 @@ impl WaitPid {
 }
 
 pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isize> {
-    let options = WaitOptions::from_bits_truncate(options);
+    let options = WaitOptions::from_bits(options).ok_or(AxError::InvalidInput)?;
     info!("sys_waitpid <= pid: {pid:?}, options: {options:?}");
 
     let curr = current();

--- a/os/StarryOS/kernel/src/syscall/time.rs
+++ b/os/StarryOS/kernel/src/syscall/time.rs
@@ -25,8 +25,7 @@ pub fn sys_clock_gettime(clock_id: __kernel_clockid_t, ts: *mut timespec) -> AxR
         }
         _ => {
             warn!("Called sys_clock_gettime for unsupported clock {clock_id}");
-            wall_time()
-            // return Err(AxError::EINVAL);
+            return Err(AxError::InvalidInput);
         }
     };
     ts.vm_write(timespec::from_time_value(now))?;

--- a/os/StarryOS/kernel/src/syscall/time.rs
+++ b/os/StarryOS/kernel/src/syscall/time.rs
@@ -119,3 +119,16 @@ pub fn sys_setitimer(
     }
     Ok(0)
 }
+
+/// Schedule a SIGALRM after `seconds` seconds. Returns remaining seconds of
+/// the previous alarm (rounded up), or 0 if no alarm was scheduled.
+pub fn sys_alarm(seconds: u32) -> AxResult<isize> {
+    let new_remained = (seconds as usize).saturating_mul(1_000_000_000);
+    let old = current()
+        .as_thread()
+        .time
+        .borrow_mut()
+        .set_itimer(ITimerType::Real, 0, new_remained);
+    let prev_secs = (old.1.as_nanos() as u64).div_ceil(1_000_000_000);
+    Ok(prev_secs as isize)
+}

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -214,6 +214,14 @@ pub struct ProcessData {
     /// The exit signal of the thread
     pub exit_signal: Option<Signo>,
 
+    /// Pending stopped/continued status reported to the parent via wait4.
+    ///
+    /// Encoding follows the Linux W* macros:
+    /// `0` = no pending notification;
+    /// `(sig << 8) | 0x7F` = stopped by signal `sig` (WIFSTOPPED);
+    /// `0xFFFF` = continued from a job-control stop (WIFCONTINUED).
+    stop_status: AtomicI32,
+
     /// The process signal manager
     pub signal: Arc<ProcessSignalManager>,
 
@@ -247,6 +255,8 @@ impl ProcessData {
             child_exit_event: Arc::default(),
             exit_event: Arc::default(),
             exit_signal,
+
+            stop_status: AtomicI32::new(0),
 
             signal: Arc::new(ProcessSignalManager::new(
                 signal_actions,
@@ -288,5 +298,20 @@ impl ProcessData {
     /// Set the umask and return the old value.
     pub fn replace_umask(&self, umask: u32) -> u32 {
         self.umask.swap(umask, Ordering::SeqCst)
+    }
+
+    /// Record a pending stopped/continued notification for wait4.
+    pub fn set_stop_status(&self, status: i32) {
+        self.stop_status.store(status, Ordering::Release);
+    }
+
+    /// Returns the pending stopped/continued status without clearing it.
+    pub fn peek_stop_status(&self) -> i32 {
+        self.stop_status.load(Ordering::Acquire)
+    }
+
+    /// Consumes the pending stopped/continued status, returning its value.
+    pub fn take_stop_status(&self) -> i32 {
+        self.stop_status.swap(0, Ordering::AcqRel)
     }
 }

--- a/os/StarryOS/kernel/src/task/resources.rs
+++ b/os/StarryOS/kernel/src/task/resources.rs
@@ -2,7 +2,7 @@
 
 use core::ops::{Index, IndexMut};
 
-use linux_raw_sys::general::{RLIM_NLIMITS, RLIMIT_NOFILE, RLIMIT_STACK};
+use linux_raw_sys::general::{RLIM_INFINITY, RLIM_NLIMITS, RLIMIT_NOFILE, RLIMIT_STACK};
 
 /// The maximum number of open files
 pub const AX_FILE_LIMIT: usize = 1024;
@@ -40,10 +40,14 @@ pub struct Rlimits([Rlimit; RLIM_NLIMITS as usize]);
 
 impl Default for Rlimits {
     fn default() -> Self {
-        let mut result = Self(Default::default());
-        result[RLIMIT_STACK] = (crate::config::USER_STACK_SIZE as u64).into();
-        result[RLIMIT_NOFILE] = (AX_FILE_LIMIT as u64).into();
-        result
+        // Default all resources to RLIM_INFINITY (Linux behavior). Specific
+        // resources (stack size, fd table) override below with concrete caps.
+        let inf = RLIM_INFINITY as u64;
+        let mut arr: [Rlimit; RLIM_NLIMITS as usize] =
+            core::array::from_fn(|_| Rlimit::new(inf, inf));
+        arr[RLIMIT_STACK as usize] = (crate::config::USER_STACK_SIZE as u64).into();
+        arr[RLIMIT_NOFILE as usize] = (AX_FILE_LIMIT as u64).into();
+        Self(arr)
     }
 }
 

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -1,12 +1,25 @@
-use core::sync::atomic::Ordering;
+use core::{future::poll_fn, sync::atomic::Ordering, task::Poll};
 
 use ax_errno::{AxError, AxResult};
 use ax_hal::uspace::UserContext;
-use ax_task::{TaskInner, current};
+use ax_task::{
+    TaskInner, current,
+    future::{block_on, interruptible},
+};
 use starry_process::Pid;
-use starry_signal::{SignalInfo, SignalOSAction, SignalSet};
+use starry_signal::{SignalInfo, SignalOSAction, SignalSet, Signo};
 
 use super::{AsThread, Thread, do_exit, get_process_data, get_process_group, get_task};
+
+/// Notify the parent (via `child_exit_event`) that a child of theirs changed
+/// state (stopped or continued). Used by wait4 with WUNTRACED/WCONTINUED.
+fn notify_parent_state_change(thr: &Thread) {
+    if let Some(parent) = thr.proc_data.proc.parent()
+        && let Ok(parent_data) = get_process_data(parent.pid())
+    {
+        parent_data.child_exit_event.wake();
+    }
+}
 
 pub fn check_signals(
     thr: &Thread,
@@ -27,11 +40,32 @@ pub fn check_signals(
             do_exit(128 + signo as i32, true);
         }
         SignalOSAction::Stop => {
-            // TODO: implement stop
-            do_exit(1, true);
+            // Encode WIFSTOPPED status: (stop_signal << 8) | 0x7F.
+            let status = ((signo as u32 as i32) << 8) | 0x7F;
+            thr.proc_data.set_stop_status(status);
+            notify_parent_state_change(thr);
+
+            // Block until SIGCONT or a fatal signal (SIGKILL) becomes pending.
+            // SIGCONT always resumes a stopped process, even if it is in the
+            // thread's blocked mask — `send_signal_to_process` falls back to
+            // waking any blocked thread so we still see it in the pending set.
+            let mut wake_mask = SignalSet::default();
+            wake_mask.add(Signo::SIGCONT);
+            wake_mask.add(Signo::SIGKILL);
+            loop {
+                if !(thr.signal.pending() & wake_mask).is_empty() {
+                    break;
+                }
+                // `interruptible` resolves with `Err(Interrupted)` whenever
+                // `task.interrupt()` is called — signal delivery always does
+                // this, so any incoming signal wakes us to re-check.
+                let _ = block_on(interruptible(poll_fn::<(), _>(|_cx| Poll::Pending)));
+            }
         }
         SignalOSAction::Continue => {
-            // TODO: implement continue
+            // Encode WIFCONTINUED status: magic value 0xFFFF.
+            thr.proc_data.set_stop_status(0xFFFF);
+            notify_parent_state_change(thr);
         }
         SignalOSAction::Handler => {
             // do nothing
@@ -98,10 +132,26 @@ pub fn send_signal_to_process(pid: Pid, sig: Option<SignalInfo>) -> AxResult<()>
     if let Some(sig) = sig {
         let signo = sig.signo();
         info!("Send signal {signo:?} to process {pid}");
+
+        // Pre-compute whether the signal is ignored so we can decide after
+        // `send_signal` whether to fall back to waking blocked threads.
+        let ignored = proc_data.signal.actions.lock()[signo].is_ignore(signo);
+
         if let Some(tid) = proc_data.signal.send_signal(sig)
             && let Ok(task) = get_task(tid)
         {
             task.interrupt();
+        } else if !ignored {
+            // The signal is queued but no thread is eligible for immediate
+            // delivery (all threads block it). Interrupt every thread so any
+            // task blocked in-kernel (e.g. a stopped task waiting on SIGCONT
+            // while musl's `raise` has all app signals masked) can re-check
+            // its pending set.
+            for t in proc_data.proc.threads() {
+                if let Ok(task) = get_task(t) {
+                    task.interrupt();
+                }
+            }
         }
     }
 

--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -3,8 +3,12 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use core::sync::atomic::{AtomicU8, Ordering};
-use core::{num::NonZeroUsize, ops::Range, task::Context};
+use core::{
+    num::NonZeroUsize,
+    ops::Range,
+    sync::atomic::{AtomicU8, Ordering},
+    task::Context,
+};
 
 use ax_alloc::{UsageKind, global_allocator};
 use ax_hal::mem::{PhysAddr, VirtAddr, virt_to_phys};

--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -526,11 +526,16 @@ impl CachedFile {
             }
         }
 
-        // Page not in cache, read it
+        // Page not in cache, read it.
+        //
+        // `PageCache::new` hands back an uninitialised physical page. We must
+        // zero it first so that bytes beyond the file's current length — or
+        // inside a sparse hole that the underlying filesystem has not
+        // allocated yet — read back as zero rather than whatever the page
+        // allocator last had there.
         let mut page = PageCache::new()?;
-        if self.in_memory {
-            page.data().fill(0);
-        } else {
+        page.data().fill(0);
+        if !self.in_memory {
             file.read_at(page.data(), pn as u64 * PAGE_SIZE as u64)?;
         }
         cache.put(pn, page);
@@ -604,14 +609,16 @@ impl CachedFile {
 
     fn write_at_locked(&self, mut buf: impl Read + IoBuf, offset: u64) -> VfsResult<usize> {
         let end = offset + buf.remaining() as u64;
+        // Extend through `CachedFile::set_len` (not the raw `FileNode::set_len`)
+        // so that the page cache zero-fills the hole between the old EOF and
+        // the write offset. Otherwise a later read of the hole returns stale
+        // allocator memory or disk contents instead of zeros.
+        if end > self.inner.len()? {
+            self.set_len(end)?;
+        }
         self.with_pages(
             offset..end,
-            |file| {
-                if end > file.len()? {
-                    file.set_len(end)?;
-                }
-                Ok(0)
-            },
+            |_file| Ok(0),
             |written, page, range| {
                 let len = range.end - range.start;
                 buf.read(&mut page.data()[range.start..range.end])?;

--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -3,7 +3,6 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-#[cfg(feature = "times")]
 use core::sync::atomic::{AtomicU8, Ordering};
 use core::{num::NonZeroUsize, ops::Range, task::Context};
 
@@ -298,9 +297,8 @@ impl OpenOptions {
                 }
             }
             (_, true) => {
-                if self.truncate && !self.create_new {
-                    return false;
-                }
+                // O_APPEND with O_TRUNC is unusual but legal on Linux
+                // (truncate at open, then append on every write).
             }
         }
         true
@@ -802,7 +800,7 @@ impl FileBackend {
 /// Provides `std::fs::File`-like interface.
 pub struct File {
     inner: FileBackend,
-    flags: FileFlags,
+    flags: AtomicU8,
     position: Option<Mutex<u64>>,
     #[cfg(feature = "times")]
     access_flags: AtomicU8,
@@ -822,7 +820,7 @@ impl File {
         };
         Self {
             inner,
-            flags,
+            flags: AtomicU8::new(flags.bits()),
             position,
             #[cfg(feature = "times")]
             access_flags: AtomicU8::new(0),
@@ -850,7 +848,7 @@ impl File {
 
     /// Checks that the file has the required `flags` and returns the backend.
     pub fn access(&self, flags: FileFlags) -> VfsResult<&FileBackend> {
-        if self.flags.contains(flags) && !self.is_path() {
+        if self.flags().contains(flags) && !self.is_path() {
             Ok(&self.inner)
         } else {
             Err(VfsError::BadFileDescriptor)
@@ -859,12 +857,31 @@ impl File {
 
     /// Returns `true` if this is a path-only handle (no I/O permitted).
     pub fn is_path(&self) -> bool {
-        self.flags.contains(FileFlags::PATH)
+        self.flags().contains(FileFlags::PATH)
     }
 
     /// Returns the access flags this file was opened with.
     pub fn flags(&self) -> FileFlags {
-        self.flags
+        FileFlags::from_bits_truncate(self.flags.load(Ordering::Acquire))
+    }
+
+    /// Toggle [`FileFlags::APPEND`] on the open file (used by F_SETFL).
+    pub fn set_append(&self, append: bool) {
+        loop {
+            let cur = self.flags.load(Ordering::Acquire);
+            let new = if append {
+                cur | FileFlags::APPEND.bits()
+            } else {
+                cur & !FileFlags::APPEND.bits()
+            };
+            if self
+                .flags
+                .compare_exchange(cur, new, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                break;
+            }
+        }
     }
 
     /// Returns a reference to the underlying [`FileBackend`].


### PR DESCRIPTION
## Summary

Takes StarryOS from **2/18 → 18/18** on the linux-compatible-testsuit Phase 2 (StarryOS x86_64 QEMU) by fixing 27 syscall bugs across 18 commits. All test cases now match the Linux qemu-system reference (Phase 1.5).

测试环境：x86_64, StarryOS (`fixbug-based-dev`), linux-compatible-testsuit (`dev`)。

## 验证命令

```bash
cd linux-compatible-testsuit
./run_all_tests.sh --linux-system \
    --linux-system-kernel linux-guest-assets/x86_64/bzImage \
    --tgoskits ../tgoskits
# Phase 1.5 (Linux 基准) 18/18  +  Phase 2 (StarryOS) 18/18，逐项 match
```

## 测例 ↔ commit 对照表

| 测例 | 此前状态 | 修复 commit（按时间从早到晚） | 涉及改动 |
|------|----------|--------------------------------|-----------|
| `test_basic_io` | FAIL rc=1 | `97ab797c` · `45f2426f` | lseek 负偏移返回 EINVAL、管道 fd 返回 ESPIPE；axfs-ng 页缓存对 lseek-past-EOF 产生的空洞正确填零 |
| `test_brk` | FAIL rc=134 | `afa253f8` | 实现 setrlimit/getrlimit；brk 遵守运行时 RLIMIT_DATA |
| `test_clock_gettime` | FAIL rc=1 | `587c1f15` | 非法 clock_id 返回 EINVAL（原先静默返回 wall_time） |
| `test_copy_file_range` | FAIL rc=1 | `797ca6e5` | 校验 flags、同文件重叠、非常规 fd（管道等）→ 返回 EINVAL |
| `test_dup_v2` | FAIL rc=1 | `f1c914c2` · `01f99a68` · `f7101318` · `6c0ad9e3` | fcntl F_DUPFD 负数/未知 cmd 返回 EINVAL；F_DUPFD 遵守 minfd 参数；fcntl/openat 支持 O_APPEND；新增按 (dev, ino) 的 flock + POSIX 记录锁 |
| `test_file_io_edge` | FAIL rc=1 | `587c1f15` | ftruncate 负 length、pwrite64 负 offset → 返回 EINVAL |
| `test_fork_v2` | FAIL rc=1 | `1e503bb5` · `ff678342` | wait4 未知 options 位返回 EINVAL；真正实现 SIGSTOP/SIGCONT 语义，wait4(WUNTRACED/WCONTINUED) 报告停止/继续状态 |
| `test_getgroups` | FAIL rc=1 | `797ca6e5` | `getgroups(0, NULL)` 作为查询语义返回当前附加组数 |
| `test_getrandom` | FAIL rc=1 | `587c1f15` | 未知 flags 或 `GRND_INSECURE|GRND_RANDOM` 互斥 → EINVAL |
| `test_mmap` | FAIL rc=134 | `9e828fec` · `9e0ca419` | 非 MAP_ANONYMOUS 的无效 fd 返回 EBADF；补全 mmap 权限与目录检查 |
| `test_mremap` | FAIL rc=1 | `548a9b35` | 重写 mremap（5 参数 ABI），支持 no-op / shrink / grow-in-place / MAYMOVE / FIXED / DONTUNMAP 及完整参数校验 |
| `test_openat` | FAIL rc=1 | `1e503bb5` · `f7101318` · `9e828fec` | 空路径返回 ENOENT、目录 O_WRONLY 返回 EISDIR；O_APPEND 全链路生效；O_DIRECTORY 非目录返回 ENOTDIR |
| `test_pipe2` | FAIL rc=1 | `1e503bb5` | pipe2 未知 flags 位返回 EINVAL |
| `test_pwritev2` | PASS | — | 基线已通过 |
| `test_shm_deadlock` | PASS | — | 基线已通过 |
| `test_sigaltstack` | FAIL rc=1 | `6107e699` | 栈恰好等于 MINSIGSTKSZ 时允许设置；SS_DISABLE 时豁免大小校验 |
| `test_signal` | FAIL rc=1 | `e00bbaf2` | 实现 alarm / pause（x86_64），SIGALRM 能唤醒 pause |
| `test_stat` | FAIL rc=134 | `55b0d358` | 实现 mknod/mknodat（支持 mkfifo）；修正 stat 的 blksize、mask 与 fstatat flags |

> 另有一个横切改动 `78efed20`（mprotect 错误传播 + 映射校验），不绑定单一测例，但与 mmap/mremap 路径协同。

## 四个关键重写（最近 4 个 commit）

- **`ff678342` — wait4 WUNTRACED/WCONTINUED**
  在 `ProcessData` 上用 `AtomicI32` 记录停止/继续状态字（`(sig<<8)|0x7F` / `0xFFFF`），Stop 分支阻塞于 `block_on(interruptible(...))`，等待 SIGCONT / SIGKILL 进入 pending 集合；Continue 分支写 `0xFFFF` 并唤起父进程的 `child_exit_event`。
  `send_signal_to_process` 在所有线程都 block 该信号时，对非 ignored 信号 fallback 调用所有线程的 `task.interrupt()`，绕过 musl `raise()` 屏蔽所有 app 信号造成的死锁。
  `sys_waitpid` 的子进程扫描增加 stop_status 检查，按 WUNTRACED/WCONTINUED 选项返回 pid 并清状态。

- **`6c0ad9e3` — flock + fcntl POSIX 记录锁**
  新增 `syscall/fs/lock.rs`：全局锁表按 `(dev, ino)` 索引；flock 条目按 OFD（`Arc<dyn FileLike>` 裸指针）身份跟踪，兼容 dup / fork 继承；POSIX 锁按 PID 管理范围，同 PID 自锁不冲突（F_GETLK 返回 F_UNLCK），跨 PID 按写锁覆盖语义检测冲突。
  非阻塞路径（`LOCK_NB` / `F_SETLK`）返回 EWOULDBLOCK / EAGAIN；阻塞路径（`flock LOCK_EX` / `F_SETLKW`）通过 PollSet + interruptible 等待锁释放。

- **`45f2426f` — axfs-ng 空洞零填充**
  `PageCache::new` 原本返回未初始化物理页，磁盘 `read_at` 只覆盖文件现有字节，页尾保留分配器脏数据；修复为新页先 `fill(0)` 再读盘。
  `write_at_locked` 原先调用底层 `FileNode::set_len`，绕过了 `CachedFile::set_len` 的页缓存零填充；改为在进入 `with_pages` 前统一走 `self.set_len(end)`，让 lseek-past-EOF 产生的空洞页被正确清零。

- **`548a9b35` — mremap 完整实现**
  重写为 5 参数版本，统一处理：same-size no-op / 尾部 munmap 收缩 / 就地扩展（查找紧随 VMA 后的空闲区）/ MAYMOVE 拷贝迁移 / FIXED 指定目标 / DONTUNMAP 保留源映射。
  补全参数校验：未知 flags、未对齐地址、new_size = 0、old_size = 0、FIXED/DONTUNMAP 无 MAYMOVE、DONTUNMAP 尺寸必须相等、FIXED 新旧范围不得重叠；`find_area` 越界返回 EFAULT（对齐 Linux 语义）。同步修改 syscall 分发器，把 `uctx.arg4()` 作为 `new_addr` 传入。

## 全部修复类别速览

| 分类 | 数量 | 示例 |
|------|------|------|
| errno 错误 | 4 | lseek EINVAL/ESPIPE、openat ENOTDIR、mmap EBADF |
| 参数校验缺失 | 11 | fcntl/pipe2/wait4 flags、clock_id、ftruncate/pwrite 负值、getrandom flags |
| 语义差异 / 部分实现 | 6 | F_DUPFD minfd、O_APPEND、getgroups 查询语义、sigaltstack 边界、文件空洞填零、mprotect 错误传播 |
| 未实现（ENOSYS / stub） | 6 | alarm、mknod、setrlimit、flock、F_SETLK、mremap 补全 |
| WUNTRACED/WCONTINUED | 1 | 真正的 SIGSTOP/SIGCONT 语义 |

## 最终测试输出

```
──── StarryOS vs Linux/qemu-system Reference ────

   OK   test_basic_io matches Linux reference (pass)
   OK   test_brk matches Linux reference (pass)
   OK   test_clock_gettime matches Linux reference (pass)
   OK   test_copy_file_range matches Linux reference (pass)
   OK   test_dup_v2 matches Linux reference (pass)
   OK   test_file_io_edge matches Linux reference (pass)
   OK   test_fork_v2 matches Linux reference (pass)
   OK   test_getgroups matches Linux reference (pass)
   OK   test_getrandom matches Linux reference (pass)
   OK   test_mmap matches Linux reference (pass)
   OK   test_mremap matches Linux reference (pass)
   OK   test_openat matches Linux reference (pass)
   OK   test_pipe2 matches Linux reference (pass)
   OK   test_pwritev2 matches Linux reference (pass)
   OK   test_shm_deadlock matches Linux reference (pass)
   OK   test_sigaltstack matches Linux reference (pass)
   OK   test_signal matches Linux reference (pass)
   OK   test_stat matches Linux reference (pass)

══════════════════════════════════════════════════
  Test Summary
══════════════════════════════════════════════════

Phase 1.5 — Linux QEMU-System Reference (x86_64):
  x86_64:      18 passed, 0 skipped

Phase 2 — StarryOS Tests (x86_64):
  x86_64:      18 passed, 0 skipped
  Compatibility: matched Linux/qemu-system reference
```

