### PR TITLE
fix(starry): reject invalid pipe2 flags

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/pipe.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/pipe.rs
@@ -19,13 +19,10 @@ bitflags! {
 }
 
 pub fn sys_pipe2(fds: *mut [c_int; 2], flags: u32) -> AxResult<isize> {
-    let flags = {
-        let new_flags = PipeFlags::from_bits_truncate(flags);
-        if new_flags.bits() != flags {
-            warn!("sys_pipe2 <= unrecognized flags: {flags}");
-        }
-        new_flags
-    };
+    let flags = PipeFlags::from_bits(flags).ok_or_else(|| {
+        warn!("sys_pipe2 <= unrecognized flags: {flags}");
+        ax_errno::AxError::InvalidInput
+    })?;
 
     let cloexec = flags.contains(PipeFlags::CLOEXEC);
     let (read_end, write_end) = Pipe::new();


### PR DESCRIPTION
## 问题
  `pipe2()` 会静默截断未知标志位并继续创建管道，导致 `pipe2(fds, 0xFFFF)` 错误地执行成功，而不是返回 `EINVAL`。
## 修复
  将 `sys_pipe2()` 改为使用 `PipeFlags::from_bits(flags)` 做严格校验；只要存在不支持的标志位，就立即返回 `AxError::InvalidInput`。
## 通过测例
`test_pipe2.c:253`，检查项为“`pipe2` 无效 flags 应返回 `EINVAL`”。