### PR TITLE
fix(starry): correct openat path errno semantics

### DIFF
--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -198,16 +198,19 @@ impl OpenOptions {
         let flags = self.to_flags()?;
 
         if self.directory {
-            if flags.contains(FileFlags::WRITE) {
+            loc.check_is_dir()?;
+            if flags.contains(FileFlags::WRITE) && !self.path {
                 return Err(VfsError::IsADirectory);
             }
-            loc.check_is_dir()?;
         }
         if self.truncate {
             loc.entry().as_file()?.set_len(0)?;
         }
 
         Ok(if loc.is_dir() {
+            if flags.contains(FileFlags::WRITE) && !self.path {
+                return Err(VfsError::IsADirectory);
+            }
             OpenResult::Dir(loc)
         } else {
             // TODO(mivik): is this correct?
@@ -242,8 +245,12 @@ impl OpenOptions {
         if !self.is_valid() {
             return Err(VfsError::InvalidInput);
         }
+        let path = path.as_ref();
+        if path.as_str().is_empty() {
+            return Err(VfsError::NotFound);
+        }
 
-        let loc = match context.resolve_parent(path.as_ref()) {
+        let loc = match context.resolve_parent(path) {
             Ok((parent, name)) => {
                 let mut loc = parent.open_file(
                     &name,


### PR DESCRIPTION
## 问题
`open/openat` 有 3 处路径名或文件类型相关的 errno 语义不匹配：
- 对普通文件使用 `O_WRONLY | O_DIRECTORY` 时返回了错误的 errno；
- 空路径被错误当作根目录场景处理；
- 对目录申请写权限时可能错误地打开成功。
## 修复
- 调整共享的 `axfs-ng` 打开路径逻辑，使 `O_DIRECTORY` 场景先检查目标是否为目录，再处理写权限限制；
- 对空路径尽早返回 `ENOENT`；
- 对目录的写打开请求在非 path-only 场景下返回 `EISDIR`。
## 通过测例
- `tests/test_openat.c:355`“`openat O_WRONLY+O_DIRECTORY` 打开普通文件 → `ENOTDIR`”
- `tests/test_openat.c:391`“`openat` 空路径 → `ENOENT`”
- `tests/test_openat.c:406`“`open` 目录做 `O_WRONLY` 打开 → `EISDIR`”。