### PR TITLE
Handles absent entries with default page size

### DIFF
--- a/components/page_table_multiarch/page_table_multiarch/src/bits32.rs
+++ b/components/page_table_multiarch/page_table_multiarch/src/bits32.rs
@@ -468,10 +468,10 @@ impl<'a, M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable32Cursor
                     if !entry.is_unused() {
                         entry.set_flags(flags, page_size.is_huge());
                         self.push(vaddr);
-                    }
-                    // ignore if not present
-
-                    page_size
+                        page_size
+                    } else {
+                        PageSize::Size4K
+                    } // ignore if unused
                 }
                 Err(PagingError::NotMapped) => PageSize::Size4K,
                 Err(e) => {

--- a/components/page_table_multiarch/page_table_multiarch/src/bits64.rs
+++ b/components/page_table_multiarch/page_table_multiarch/src/bits64.rs
@@ -548,13 +548,13 @@ impl<'a, M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64Cursor
             let vaddr = vaddr_usize.into();
             let page_size = match self.inner.get_entry_mut(vaddr) {
                 Ok((entry, page_size)) => {
-                    if entry.is_present() {
+                    if !entry.is_unused() {
                         entry.set_flags(flags, page_size.is_huge());
                         self.push(vaddr);
-                    }
-                    // ignore if not present
-
-                    page_size
+                        page_size
+                    } else {
+                        PageSize::Size4K
+                    } // ignore if unused
                 }
                 Err(PagingError::NotMapped) => PageSize::Size4K,
                 Err(e) => {


### PR DESCRIPTION
Ensures that a default 4K page size is returned when an entry is not present, avoiding potential underflow when the page size exceeds the remaining region.

Updates logic to set entry flags based on whether a page table entry is unused rather than only present, allowing correct handling of entries that may have been previously allocated but not yet marked as present.