### PR TITLE
chore(ci): publish axvisor-lvz container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
       pull-requests: read
     outputs:
       ci_checks: ${{ steps.filter.outputs.ci_checks }}
-      container_publish: ${{ steps.filter.outputs.container_publish }}
+      base_container_publish: ${{ steps.filter.outputs.base_container_publish }}
+      axvisor_lvz_container_publish: ${{ steps.filter.outputs.axvisor_lvz_container_publish }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -64,10 +65,14 @@ jobs:
               - "scripts/**"
               - "test-suit/**"
               - "xtask/**"
-            container_publish:
+            base_container_publish:
               - ".github/workflows/ci.yml"
               - ".github/workflows/container-publish.yml"
               - "container/Dockerfile"
+              - "rust-toolchain.toml"
+            axvisor_lvz_container_publish:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/container-publish.yml"
               - "container/Dockerfile.axvisor-lvz"
               - "rust-toolchain.toml"
 
@@ -285,17 +290,42 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Changed files do not match the test-relevant path set, so fmt and follow-up checks were skipped." >> "$GITHUB_STEP_SUMMARY"
 
-  container_publish:
-    name: Publish container image
+  publish_base_container:
+    name: Publish base container image
     if: >-
       ${{
         github.event_name == 'push'
         && (github.ref_name == 'main' || github.ref_name == 'dev')
-        && needs.detect_changes.outputs.container_publish == 'true'
+        && needs.detect_changes.outputs.base_container_publish == 'true'
       }}
     needs:
       - detect_changes
     uses: ./.github/workflows/container-publish.yml
+    with:
+      image_name: ghcr.io/${{ github.repository }}-container
+      dockerfile: container/Dockerfile
+      cache_scope: container
+    permissions:
+      contents: read
+      packages: write
+
+  publish_axvisor_lvz_container:
+    name: Publish axvisor-lvz container image
+    if: >-
+      ${{
+        github.event_name == 'push'
+        && (github.ref_name == 'main' || github.ref_name == 'dev')
+        && needs.detect_changes.outputs.axvisor_lvz_container_publish == 'true'
+      }}
+    needs:
+      - detect_changes
+    uses: ./.github/workflows/container-publish.yml
+    with:
+      image_name: ghcr.io/${{ github.repository }}-container-axvisor-lvz
+      dockerfile: container/Dockerfile.axvisor-lvz
+      cache_scope: container-axvisor-lvz
+      build_args: |
+        BASE_IMAGE=ghcr.io/${{ github.repository }}-container:latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
               - ".github/workflows/ci.yml"
               - ".github/workflows/container-publish.yml"
               - "container/Dockerfile"
+              - "container/Dockerfile.axvisor-lvz"
               - "rust-toolchain.toml"
 
   fmt:

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -2,16 +2,32 @@ name: Reusable Container Publish
 
 on:
   workflow_call:
+    inputs:
+      image_name:
+        description: Full image name to publish.
+        required: true
+        type: string
+      dockerfile:
+        description: Dockerfile path relative to the repository root.
+        required: true
+        type: string
+      cache_scope:
+        description: GHA cache scope for docker build cache.
+        required: true
+        type: string
+      build_args:
+        description: Optional docker build args block.
+        required: false
+        default: ""
+        type: string
 
 jobs:
-  publish_base:
-    name: Publish base container image
+  publish:
+    name: Publish container image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    outputs:
-      image: ${{ steps.prep.outputs.image }}
 
     steps:
       - name: Checkout
@@ -20,7 +36,7 @@ jobs:
       - name: Prepare image name
         id: prep
         run: |
-          echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-container" >> "$GITHUB_OUTPUT"
+          echo "image=${{ inputs.image_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -45,58 +61,10 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: container/Dockerfile
+          file: ${{ inputs.dockerfile }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=container
-          cache-to: type=gha,mode=max,scope=container
-
-  publish_axvisor_lvz:
-    name: Publish axvisor-lvz container image
-    needs: publish_base
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Prepare image name
-        id: prep
-        run: |
-          echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-container-axvisor-lvz" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ steps.prep.outputs.image }}
-          tags: |
-            type=ref,event=tag
-            type=raw,value=latest
-
-      - name: Build and push container image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: container/Dockerfile.axvisor-lvz
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BASE_IMAGE=${{ needs.publish_base.outputs.image }}:latest
-          cache-from: type=gha,scope=container-axvisor-lvz
-          cache-to: type=gha,mode=max,scope=container-axvisor-lvz
+          build-args: ${{ inputs.build_args }}
+          cache-from: type=gha,scope=${{ inputs.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.cache_scope }}

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -4,11 +4,14 @@ on:
   workflow_call:
 
 jobs:
-  publish:
+  publish_base:
+    name: Publish base container image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      image: ${{ steps.prep.outputs.image }}
 
     steps:
       - name: Checkout
@@ -46,5 +49,54 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=container
+          cache-to: type=gha,mode=max,scope=container
+
+  publish_axvisor_lvz:
+    name: Publish axvisor-lvz container image
+    needs: publish_base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Prepare image name
+        id: prep
+        run: |
+          echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-container-axvisor-lvz" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.prep.outputs.image }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: container/Dockerfile.axvisor-lvz
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=${{ needs.publish_base.outputs.image }}:latest
+          cache-from: type=gha,scope=container-axvisor-lvz
+          cache-to: type=gha,mode=max,scope=container-axvisor-lvz

--- a/container/Dockerfile.axvisor-lvz
+++ b/container/Dockerfile.axvisor-lvz
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=ghcr.io/rcore-os/tgoskits-container:latest
 FROM ${BASE_IMAGE}
 
+# Pin the external source revision so container rebuilds stay reproducible.
 ARG QEMU_LVZ_REPO=https://github.com/numpy1314/QEMU-LVZ
 ARG QEMU_LVZ_REF=f82f6aee0da1cd1ee86e455a799f07057f477dee
 ARG QEMU_TARGET_LIST=loongarch64-softmmu

--- a/container/Dockerfile.axvisor-lvz
+++ b/container/Dockerfile.axvisor-lvz
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE=ghcr.io/rcore-os/tgoskits-container:latest
+FROM ${BASE_IMAGE}
+
+ARG QEMU_LVZ_REPO=https://github.com/numpy1314/QEMU-LVZ
+ARG QEMU_LVZ_REF=f82f6aee0da1cd1ee86e455a799f07057f477dee
+ARG QEMU_TARGET_LIST=loongarch64-softmmu
+
+ENV AXBUILD_QEMU_SYSTEM_LOONGARCH64=/opt/qemu-lvz/bin/qemu-system-loongarch64 \
+    PATH=/opt/qemu-lvz/bin:${PATH}
+
+RUN set -eux; \
+    mkdir -p /tmp/qemu-lvz-src; \
+    curl -L "${QEMU_LVZ_REPO}/archive/${QEMU_LVZ_REF}.tar.gz" -o /tmp/qemu-lvz.tar.gz; \
+    tar -xzf /tmp/qemu-lvz.tar.gz --strip-components=1 -C /tmp/qemu-lvz-src; \
+    cd /tmp/qemu-lvz-src; \
+    ./configure \
+      --prefix=/opt/qemu-lvz \
+      --target-list="${QEMU_TARGET_LIST}" \
+      --disable-werror \
+      --disable-kvm \
+      --enable-slirp \
+      --disable-docs \
+      --disable-gtk \
+      --disable-sdl \
+      --disable-vte; \
+    make -j"$(nproc)"; \
+    make install; \
+    rm -rf /tmp/qemu-lvz-src /tmp/qemu-lvz.tar.gz
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This PR prepares a repository-managed container image for AxVisor LoongArch64 QEMU testing.

  It adds an AxVisor-specific `axvisor-lvz` container image definition to `tgoskits` and extends the existing container publish workflow to build and publish that
  image alongside the current base CI container.

  The new image is still built from `numpy1314/QEMU-LVZ` at a fixed revision for now, but the image definition and publishing flow are moved into this repository
  so the container can be maintained from `tgoskits`.

  ## Changes

  - add `container/Dockerfile.axvisor-lvz`
  - extend `.github/workflows/container-publish.yml` to publish:
    - `ghcr.io/<repo>-container`
    - `ghcr.io/<repo>-container-axvisor-lvz`
  - update `.github/workflows/ci.yml` path detection so changes to `container/Dockerfile.axvisor-lvz` trigger the container publish flow

  ## Notes

  This PR only prepares the repository-managed container image and publish path.

  It does not switch the AxVisor LoongArch64 CI job yet. The follow-up PR will update that job to consume the published repository image after this container path
  is available.

  For now, the `QEMU-LVZ` source is still fetched from `numpy1314/QEMU-LVZ`, pinned to a fixed revision to keep the container build reproducible.