### PR TITLE
fix(file): reject O_WRONLY/O_RDWR on directories with EISDIR

### DIFF
--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -198,9 +198,6 @@ impl OpenOptions {
         let flags = self.to_flags()?;
 
         if self.directory {
-            if flags.contains(FileFlags::WRITE) {
-                return Err(VfsError::IsADirectory);
-            }
             loc.check_is_dir()?;
         }
         if self.truncate {
@@ -208,6 +205,9 @@ impl OpenOptions {
         }
 
         Ok(if loc.is_dir() {
+            if flags.contains(FileFlags::WRITE) {
+                return Err(VfsError::IsADirectory);
+            }
             OpenResult::Dir(loc)
         } else {
             // TODO(mivik): is this correct?

--- a/test-suit/starryos/normal/bug-open-dir-wronly/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-open-dir-wronly/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-open-dir-wronly C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-open-dir-wronly src/main.c)
+target_compile_options(bug-open-dir-wronly PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-open-dir-wronly RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-open-dir-wronly/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-open-dir-wronly/c/prebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-open-dir-wronly/c/src/main.c
+++ b/test-suit/starryos/normal/bug-open-dir-wronly/c/src/main.c
@@ -1,0 +1,37 @@
+/*
+ * bug-open-dir-wronly: Opening a directory with O_WRONLY should fail with EISDIR.
+ *
+ * Linux behavior: open("/tmp", O_WRONLY) returns -1 with errno=EISDIR.
+ * StarryOS bug: Returns a valid fd instead of failing.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void)
+{
+    printf("=== bug-open-dir-wronly ===\n");
+    printf("Expected: open(\"/tmp\", O_WRONLY) fails with EISDIR\n\n");
+
+    errno = 0;
+    int fd = open("/tmp", O_WRONLY);
+
+    if (fd == -1 && errno == EISDIR) {
+        printf("PASS: open returned -1, errno=EISDIR (%d)\n", errno);
+        printf("TEST PASSED\n");
+        return 0;
+    }
+
+    if (fd >= 0) {
+        printf("FAIL: open returned fd=%d (should have failed)\n", fd);
+        close(fd);
+    } else {
+        printf("FAIL: open returned -1 but errno=%d (%s), expected EISDIR (%d)\n",
+               errno, strerror(errno), EISDIR);
+    }
+    printf("TEST FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/bug-open-dir-wronly/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-open-dir-wronly/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-open-dir-wronly"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-open-dir-wronly/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-open-dir-wronly/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-open-dir-wronly"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-open-dir-wronly/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-open-dir-wronly/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-open-dir-wronly"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-open-dir-wronly/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-open-dir-wronly/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-open-dir-wronly"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30


### PR DESCRIPTION
## Bug Description

`open("/tmp", O_WRONLY)` succeeds and returns a valid file descriptor on StarryOS, instead of failing with `EISDIR` (errno 21) as POSIX mandates. Any directory opened with `O_WRONLY` or `O_RDWR` should be rejected — directories are not writable via `read()`/`write()` syscalls.

## Root Cause

In `os/arceos/modules/axfs-ng/src/highlevel/file.rs`, the `_open()` method only checks for write access on directories when the `O_DIRECTORY` flag is explicitly set:

```rust
if self.directory {                    // only true when O_DIRECTORY is passed
    if flags.contains(FileFlags::WRITE) {
        return Err(VfsError::IsADirectory);
    }
    loc.check_is_dir()?;
}
```

When a user opens a path that happens to be a directory without `O_DIRECTORY` (e.g., `open("/tmp", O_WRONLY)`), the code skips the EISDIR check entirely, falls through to `loc.is_dir()`, and happily returns `OpenResult::Dir`.

## Fix

Move the write-on-directory rejection out of the `if self.directory` block and into the `loc.is_dir()` branch that already exists:

```rust
if self.directory {
    loc.check_is_dir()?;
}
if self.truncate {
    loc.entry().as_file()?.set_len(0)?;
}

Ok(if loc.is_dir() {
    if flags.contains(FileFlags::WRITE) {
        return Err(VfsError::IsADirectory);  // <-- moved here
    }
    OpenResult::Dir(loc)
} else {
    // ... file path unchanged
})
```

This ensures that any directory — whether reached via `O_DIRECTORY` or by simply naming a directory path — is rejected when opened for writing.

## Test Plan

1. Call `open("/tmp", O_WRONLY)`
2. Verify the return value is -1 with errno = EISDIR (21)
3. Confirm `open("/tmp", O_RDONLY)` still succeeds

A test case is included in `test-suit/starryos/normal/bug-open-dir-wronly/` with configs for all 4 architectures.