### PR TITLE
test+fix(starry): add ioctl FIONBIO test and fix int parsing bug

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -30,10 +30,7 @@ pub fn sys_ioctl(fd: i32, cmd: u32, arg: usize) -> AxResult<isize> {
     debug!("sys_ioctl <= fd: {fd}, cmd: {cmd}, arg: {arg}");
     let f = get_file_like(fd)?;
     if cmd == FIONBIO {
-        let val = (arg as *const u8).vm_read()?;
-        if val != 0 && val != 1 {
-            return Err(AxError::InvalidInput);
-        }
+        let val: i32 = (arg as *const i32).vm_read()?;
         f.set_nonblocking(val != 0)?;
         return Ok(0);
     }

--- a/test-suit/starryos/normal/test_ioctl_fionbio_int/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/test_ioctl_fionbio_int/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(test_ioctl_fionbio_int C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test_ioctl_fionbio_int src/main.c)
+target_compile_options(test_ioctl_fionbio_int PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test_ioctl_fionbio_int RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/test_ioctl_fionbio_int/c/prebuild.sh
+++ b/test-suit/starryos/normal/test_ioctl_fionbio_int/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/test_ioctl_fionbio_int/c/src/main.c
+++ b/test-suit/starryos/normal/test_ioctl_fionbio_int/c/src/main.c
@@ -1,0 +1,136 @@
+/*
+ * test_ioctl_fionbio_int.c — ioctl FIONBIO
+ *
+ * 测试策略：验证 ioctl(FIONBIO) 按整型解释 arg（非单字节），且任意非零均开启 O_NONBLOCK
+ *
+ * 覆盖范围：
+ *   正向：*arg=2（非零 int，低字节非 0/1）应成功开启非阻塞
+ *   正向：*arg=256（非零 int，低字节为 0）应成功开启非阻塞
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+/* ========== 内联测试框架 ========== */
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define TEST_START(name) \
+    do { \
+        printf("[TEST] %s\n", (name)); \
+        test_passed = 0; \
+        test_failed = 0; \
+    } while(0)
+
+#define CHECK(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            printf("  [FAIL] %s\n", (msg)); \
+            test_failed++; \
+        } else { \
+            printf("  [OK] %s\n", (msg)); \
+            test_passed++; \
+        } \
+    } while(0)
+
+#define CHECK_RET(val, expected, msg) \
+    do { \
+        long long _v = (long long)(val); \
+        long long _e = (long long)(expected); \
+        if (_v != _e) { \
+            printf("  [FAIL] %s (got %lld, expected %lld)\n", (msg), _v, _e); \
+            test_failed++; \
+        } else { \
+            printf("  [OK] %s (= %lld)\n", (msg), _v); \
+            test_passed++; \
+        } \
+    } while(0)
+
+#define TEST_DONE() \
+    do { \
+        printf("\n=== 结果: %d 通过, %d 失败 ===\n", test_passed, test_failed); \
+        if (test_failed == 0) { printf("TEST PASSED\n"); } \
+        return (test_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE; \
+    } while(0)
+
+/* ========== 测试代码 ========== */
+
+int main(void)
+{
+    TEST_START("ioctl: FIONBIO reads full int value");
+
+    /* 1. FIONBIO with *arg=2 */
+    {
+        int p[2];
+        int r = pipe(p);
+        CHECK(r == 0, "pipe 创建成功");
+        if (r != 0) { TEST_DONE(); }
+
+        int v = 2;
+        errno = 0;
+        r = ioctl(p[0], FIONBIO, &v);
+        CHECK(r == 0, "FIONBIO *arg=2 成功");
+
+        /* 验证 O_NONBLOCK 确实被设置 */
+        int flags = fcntl(p[0], F_GETFL);
+        CHECK(flags >= 0, "F_GETFL 成功");
+        CHECK((flags & O_NONBLOCK) != 0, "O_NONBLOCK 已设置 (*arg=2)");
+
+        close(p[0]);
+        close(p[1]);
+    }
+
+    /* 2. FIONBIO with *arg=256 (低字节为 0，但 int 整体非零) */
+    {
+        int p[2];
+        int r = pipe(p);
+        CHECK(r == 0, "pipe 创建成功 (256 测试)");
+        if (r != 0) { TEST_DONE(); }
+
+        int v = 256;
+        errno = 0;
+        r = ioctl(p[0], FIONBIO, &v);
+        CHECK(r == 0, "FIONBIO *arg=256 成功");
+
+        int flags = fcntl(p[0], F_GETFL);
+        CHECK(flags >= 0, "F_GETFL 成功 (256 测试)");
+        CHECK((flags & O_NONBLOCK) != 0, "O_NONBLOCK 已设置 (*arg=256)");
+
+        close(p[0]);
+        close(p[1]);
+    }
+
+    /* 3. FIONBIO with *arg=0 关闭非阻塞 */
+    {
+        int p[2];
+        int r = pipe(p);
+        CHECK(r == 0, "pipe 创建成功 (关闭测试)");
+        if (r != 0) { TEST_DONE(); }
+
+        /* 先开启 */
+        int v = 1;
+        ioctl(p[0], FIONBIO, &v);
+
+        /* 再关闭 */
+        v = 0;
+        errno = 0;
+        r = ioctl(p[0], FIONBIO, &v);
+        CHECK(r == 0, "FIONBIO *arg=0 关闭成功");
+
+        int flags = fcntl(p[0], F_GETFL);
+        CHECK(flags >= 0, "F_GETFL 成功 (关闭测试)");
+        CHECK((flags & O_NONBLOCK) == 0, "O_NONBLOCK 已关闭 (*arg=0)");
+
+        close(p[0]);
+        close(p[1]);
+    }
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/test_ioctl_fionbio_int/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/test_ioctl_fionbio_int/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test_ioctl_fionbio_int"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/test_ioctl_fionbio_int/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/test_ioctl_fionbio_int/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+shell_init_cmd = "/usr/bin/test_ioctl_fionbio_int"
+shell_prefix = "root@starry:"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+to_bin = true
+uefi = false
+timeout = 15

--- a/test-suit/starryos/normal/test_ioctl_fionbio_int/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/test_ioctl_fionbio_int/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test_ioctl_fionbio_int"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/test_ioctl_fionbio_int/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/test_ioctl_fionbio_int/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test_ioctl_fionbio_int"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15


### PR DESCRIPTION
Add test_ioctl_fionbio_int test case verifying that ioctl(FIONBIO) correctly interprets the full int value (not just a single byte), and that any non-zero int enables O_NONBLOCK (values 2, 256 tested).

Fix: sys_ioctl FIONBIO handler was reading arg as u8* (1 byte) instead of int* (4 bytes). Values like 256 (low byte 0) were incorrectly treated as "blocking off". Removed unnecessary 0/1-only restriction.

Tested on riscv64 QEMU: TEST PASSED.