### PR TITLE
fix(file): return correct errno for pipe fds instead of EPIPE

### DIFF
--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -180,7 +180,7 @@ impl FileLike for File {
             if any.is::<Directory>() {
                 AxError::IsADirectory
             } else {
-                AxError::BrokenPipe
+                AxError::InvalidInput
             }
         })
     }

--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -4,7 +4,7 @@ use core::{
     task::Context,
 };
 
-use ax_errno::{AxError, AxResult};
+use ax_errno::{AxError, AxResult, LinuxError};
 use ax_fs::{FS_CONTEXT, FileFlags, OpenOptions};
 use ax_io::{Seek, SeekFrom};
 use ax_task::current;
@@ -17,6 +17,19 @@ use crate::{
     file::{File, FileLike, Pipe, get_file_like},
     mm::{IoVec, IoVectorBuf, UserConstPtr, VmBytes, VmBytesMut},
 };
+
+/// Get a [`File`] from fd, converting type-mismatch errors to ESPIPE.
+/// Use this for syscalls that require a regular file fd and should return
+/// ESPIPE for pipes/sockets (lseek, pread, pwrite, fallocate, etc.).
+fn file_or_espipe(fd: c_int) -> AxResult<Arc<File>> {
+    File::from_fd(fd).map_err(|e| {
+        if e == AxError::IsADirectory || e == AxError::BadFileDescriptor {
+            e
+        } else {
+            AxError::from(LinuxError::ESPIPE)
+        }
+    })
+}
 
 struct DummyFd;
 impl FileLike for DummyFd {
@@ -80,7 +93,7 @@ pub fn sys_lseek(fd: c_int, offset: __kernel_off_t, whence: c_int) -> AxResult<i
         2 => SeekFrom::End(offset as _),
         _ => return Err(AxError::InvalidInput),
     };
-    let off = File::from_fd(fd)?.inner().seek(pos)?;
+    let off = file_or_espipe(fd)?.inner().seek(pos)?;
     Ok(off as _)
 }
 
@@ -115,7 +128,7 @@ pub fn sys_fallocate(
     if mode != 0 {
         return Err(AxError::InvalidInput);
     }
-    let f = File::from_fd(fd)?;
+    let f = file_or_espipe(fd)?;
     let inner = f.inner();
     let file = inner.access(FileFlags::WRITE)?;
     file.set_len(file.location().len()?.max(offset as u64 + len as u64))?;
@@ -144,7 +157,7 @@ pub fn sys_fadvise64(
 ) -> AxResult<isize> {
     debug!("sys_fadvise64 <= fd: {fd}, offset: {offset}, len: {len}, advice: {advice}");
     if Pipe::from_fd(fd).is_ok() {
-        return Err(AxError::BrokenPipe);
+        return Err(AxError::from(LinuxError::ESPIPE));
     }
     if advice > 5 {
         return Err(AxError::InvalidInput);
@@ -153,7 +166,7 @@ pub fn sys_fadvise64(
 }
 
 pub fn sys_pread64(fd: c_int, buf: *mut u8, len: usize, offset: __kernel_off_t) -> AxResult<isize> {
-    let f = File::from_fd(fd)?;
+    let f = file_or_espipe(fd)?;
     if offset < 0 {
         return Err(AxError::InvalidInput);
     }
@@ -170,7 +183,7 @@ pub fn sys_pwrite64(
     if len == 0 {
         return Ok(0);
     }
-    let f = File::from_fd(fd)?;
+    let f = file_or_espipe(fd)?;
     let write = f.inner().write_at(VmBytes::new(buf, len), offset as _)?;
     Ok(write as _)
 }
@@ -201,7 +214,7 @@ pub fn sys_preadv2(
     _flags: u32,
 ) -> AxResult<isize> {
     debug!("sys_preadv2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {_flags}");
-    let f = File::from_fd(fd)?;
+    let f = file_or_espipe(fd)?;
     f.inner()
         .read_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)
         .map(|n| n as _)
@@ -215,7 +228,7 @@ pub fn sys_pwritev2(
     _flags: u32,
 ) -> AxResult<isize> {
     debug!("sys_pwritev2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {_flags}");
-    let f = File::from_fd(fd)?;
+    let f = file_or_espipe(fd)?;
     f.inner()
         .read_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)
         .map(|n| n as _)

--- a/test-suit/starryos/normal/bug-pipe-fd-errno/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-pipe-fd-errno/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-pipe-fd-errno C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-pipe-fd-errno src/main.c)
+target_compile_options(bug-pipe-fd-errno PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-pipe-fd-errno RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-pipe-fd-errno/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-pipe-fd-errno/c/prebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-pipe-fd-errno/c/src/main.c
+++ b/test-suit/starryos/normal/bug-pipe-fd-errno/c/src/main.c
@@ -1,0 +1,121 @@
+/*
+ * bug-pipe-fd-errno: Verify that syscalls which require a regular file fd
+ * return the correct errno when given a pipe fd instead.
+ *
+ * Linux behavior:
+ *   - lseek on pipe       → ESPIPE
+ *   - pread on pipe       → ESPIPE
+ *   - pwrite on pipe      → ESPIPE
+ *   - ftruncate on pipe   → EINVAL
+ *   - fsync on pipe       → EINVAL
+ *   - fdatasync on pipe   → EINVAL
+ *   - fadvise on pipe     → ESPIPE
+ *
+ * StarryOS bug: File::from_fd() returns AxError::BrokenPipe (EPIPE)
+ * for all of these instead of the correct per-syscall errno.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/uio.h>
+
+static int passed = 0;
+static int failed = 0;
+
+#define TEST_ERRNO(name, call, expected_errno) do {                    \
+    errno = 0;                                                         \
+    long _r = (long)(call);                                            \
+    if (_r == -1 && errno == (expected_errno)) {                       \
+        printf("  PASS: %s (errno=%d %s)\n",                          \
+               name, errno, strerror(errno));                          \
+        passed++;                                                      \
+    } else {                                                           \
+        printf("  FAIL: %s (ret=%ld errno=%d %s, expected errno=%d %s)\n", \
+               name, _r, errno, strerror(errno),                      \
+               (expected_errno), strerror(expected_errno));            \
+        failed++;                                                      \
+    }                                                                  \
+} while (0)
+
+int main(void)
+{
+    printf("=== bug-pipe-fd-errno ===\n");
+    printf("Test: syscalls on pipe fds return correct errno\n\n");
+
+    int pfd[2];
+    if (pipe(pfd) != 0) {
+        printf("FAIL: pipe() failed: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        return 1;
+    }
+    int rfd = pfd[0]; /* read end */
+    int wfd = pfd[1]; /* write end */
+    char buf[16];
+
+    /* ── ESPIPE group: seek-like operations on pipes ── */
+    printf("[ESPIPE: seek operations on pipe]\n");
+
+    TEST_ERRNO("lseek(pipe_rd, 0, SEEK_SET)",
+               lseek(rfd, 0, SEEK_SET), ESPIPE);
+
+    TEST_ERRNO("lseek(pipe_wr, 0, SEEK_CUR)",
+               lseek(wfd, 0, SEEK_CUR), ESPIPE);
+
+    TEST_ERRNO("lseek(pipe_rd, 0, SEEK_END)",
+               lseek(rfd, 0, SEEK_END), ESPIPE);
+
+    TEST_ERRNO("pread(pipe_rd, buf, 1, 0)",
+               pread(rfd, buf, 1, 0), ESPIPE);
+
+    TEST_ERRNO("pwrite(pipe_wr, \"x\", 1, 0)",
+               pwrite(wfd, "x", 1, 0), ESPIPE);
+
+    /* preadv/pwritev with offset also require seekable fd */
+    struct iovec iov = { .iov_base = buf, .iov_len = 1 };
+    TEST_ERRNO("preadv(pipe_rd, &iov, 1, 0)",
+               preadv(rfd, &iov, 1, 0), ESPIPE);
+
+    TEST_ERRNO("pwritev(pipe_wr, &iov, 1, 0)",
+               pwritev(wfd, &iov, 1, 0), ESPIPE);
+
+    /* fadvise on pipe → ESPIPE
+     * Note: posix_fadvise returns the error code directly, not via errno */
+    {
+        int rc = posix_fadvise(rfd, 0, 0, POSIX_FADV_NORMAL);
+        if (rc == ESPIPE) {
+            printf("  PASS: posix_fadvise(pipe) returned ESPIPE (%d)\n", rc);
+            passed++;
+        } else {
+            printf("  FAIL: posix_fadvise(pipe) returned %d (%s), expected ESPIPE (%d)\n",
+                   rc, strerror(rc), ESPIPE);
+            failed++;
+        }
+    }
+
+    /* ── EINVAL group: operations that need a regular file ── */
+    printf("\n[EINVAL: file operations on pipe]\n");
+
+    TEST_ERRNO("ftruncate(pipe_wr, 0)",
+               ftruncate(wfd, 0), EINVAL);
+
+    TEST_ERRNO("fsync(pipe_wr)",
+               fsync(wfd), EINVAL);
+
+    TEST_ERRNO("fdatasync(pipe_wr)",
+               fdatasync(wfd), EINVAL);
+
+    close(rfd);
+    close(wfd);
+
+    printf("\n=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    } else {
+        printf("SOME TESTS FAILED\n");
+        return 1;
+    }
+}

--- a/test-suit/starryos/normal/bug-pipe-fd-errno/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-pipe-fd-errno/qemu-aarch64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-pipe-fd-errno"
+success_regex = ["(?m)^ALL TESTS PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^SOME TESTS FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-pipe-fd-errno/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-pipe-fd-errno/qemu-loongarch64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic", "-m", "128M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-pipe-fd-errno"
+success_regex = ["(?m)^ALL TESTS PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^SOME TESTS FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-pipe-fd-errno/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-pipe-fd-errno/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-pipe-fd-errno"
+success_regex = ["(?m)^ALL TESTS PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^SOME TESTS FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-pipe-fd-errno/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-pipe-fd-errno/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-pipe-fd-errno"
+success_regex = ["(?m)^ALL TESTS PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^SOME TESTS FAILED\s*$']
+timeout = 30


### PR DESCRIPTION
### Bug Description

Multiple syscalls returned `EPIPE` (errno 32) when called on pipe file descriptors, instead of the POSIX-mandated errno. For example, `lseek()` on a pipe should return `ESPIPE` (errno 29, "Illegal seek"), and `ftruncate()` on a pipe should return `EINVAL` (errno 22). The pipe is not broken — the operation is simply not supported for that fd type.

Affected syscalls and their expected vs actual errno:

| Syscall | Expected | Actual (before fix) |
|---------|----------|-------------------|
| lseek | ESPIPE | EPIPE |
| pread/pwrite | ESPIPE | EPIPE |
| preadv/pwritev | ESPIPE | EPIPE |
| fallocate | ESPIPE | EPIPE |
| fadvise | ESPIPE | EPIPE |
| ftruncate | EINVAL | EPIPE |
| fsync | EINVAL | EPIPE |
| fdatasync | EINVAL | EPIPE |

### Root Cause

`File::from_fd()` in `kernel/src/file/fs.rs` used `AxError::BrokenPipe` as a catch-all error when the fd could not be downcast to a `File` (i.e., the fd is a pipe, socket, or other non-file object). This error maps to `EPIPE`, which is semantically incorrect — the pipe isn't broken, it's just not a regular file. Each calling syscall then propagated this wrong error directly to userspace.

### Fix

1. Changed `File::from_fd()` to return `AxError::InvalidInput` instead of `AxError::BrokenPipe` for non-File, non-Directory fds. This is a neutral "wrong type" error.

2. Added a `file_or_espipe()` helper in `kernel/src/syscall/fs/io.rs` that wraps `File::from_fd()` and converts the type-mismatch error to `ESPIPE`, while preserving `EISDIR` and `EBADF` as-is. Used by: `sys_lseek`, `sys_pread64`, `sys_pwrite64`, `sys_preadv2`, `sys_pwritev2`, `sys_fallocate`.

3. Fixed `sys_fadvise64` to return `LinuxError::ESPIPE` instead of `AxError::BrokenPipe` for its existing pipe check.

4. `sys_ftruncate`, `sys_fsync`, `sys_fdatasync` now correctly get `EINVAL` from the `InvalidInput` error without any additional changes.

### Test Plan

A test case is included at `test-suit/starryos/normal/bug-pipe-fd-errno/` with configs for all 4 architectures. It creates a pipe and calls each affected syscall on the pipe fd, verifying the correct errno:

- 8 ESPIPE checks: lseek (×3 whence), pread, pwrite, preadv, pwritev, posix_fadvise
- 3 EINVAL checks: ftruncate, fsync, fdatasync

All 11 checks pass on host Linux.