### PR TITLE
fix(syscall): add negative offset validation in sys_pwrite64 and pwritev

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -180,6 +180,9 @@ pub fn sys_pwrite64(
     len: usize,
     offset: __kernel_off_t,
 ) -> AxResult<isize> {
+    if offset < 0 {
+        return Err(AxError::InvalidInput);
+    }
     if len == 0 {
         return Ok(0);
     }
@@ -214,6 +217,9 @@ pub fn sys_preadv2(
     _flags: u32,
 ) -> AxResult<isize> {
     debug!("sys_preadv2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {_flags}");
+    if offset < 0 {
+        return Err(AxError::InvalidInput);
+    }
     let f = file_or_espipe(fd)?;
     f.inner()
         .read_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)
@@ -228,6 +234,9 @@ pub fn sys_pwritev2(
     _flags: u32,
 ) -> AxResult<isize> {
     debug!("sys_pwritev2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {_flags}");
+    if offset < 0 {
+        return Err(AxError::InvalidInput);
+    }
     let f = file_or_espipe(fd)?;
     f.inner()
         .read_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)


### PR DESCRIPTION
## Bug Analysis

`sys_pwrite64`, `sys_preadv2`, and `sys_pwritev2` accepted negative offsets without validation. On riscv64, the offset parameter is passed as split hi/lo parts and can wrap around silently, producing unexpected behavior. Linux returns `EINVAL` for negative offsets in these syscalls.

## Fix

Add `offset < 0` check at the entry of `sys_pwrite64`, `sys_preadv2`, and `sys_pwritev2`, returning `EINVAL` (`AxError::InvalidInput`) before any further processing.

**Changed file:** `os/StarryOS/kernel/src/syscall/fs/io.rs`

## Test Code & Expected Results

Test case: call `pwrite64()` / `preadv2()` / `pwritev2()` with a negative offset (e.g. `-1`).

| Syscall | Before (bug) | After (fix) |
|---------|-------------|-------------|
| `pwrite64(fd, buf, len, -1)` | Undefined (offset wraps to large positive) | Returns `-1`, `errno=EINVAL` |
| `preadv2(fd, iov, cnt, -1, 0)` | Undefined (offset wraps to large positive) | Returns `-1`, `errno=EINVAL` |
| `pwritev2(fd, iov, cnt, -1, 0)` | Undefined (offset wraps to large positive) | Returns `-1`, `errno=EINVAL` |