### PR TITLE
fix(task): process pending futex entry in exit_robust_list

### DIFF
--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -194,6 +194,11 @@ pub fn exit_robust_list(head: *const RobustListHead) -> AxResult<()> {
         ax_task::yield_now();
     }
 
+    // Process the pending entry that was skipped in the loop
+    if !pending.is_null() {
+        handle_futex_death(pending, offset)?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Bug Analysis

When a thread exits while holding a robust mutex (futex), the kernel walks the robust list via `exit_robust_list()` to release all held futexes. However, the `list_op_pending` entry — which records the in-progress operation at thread-exit time — was skipped during the main loop and never processed. This caused a futex resource leak: the pending robust mutex remained locked after the owning thread died, blocking other threads forever.

## Fix

After the main loop in `exit_robust_list()`, process the pending entry that was intentionally skipped:

```rust
if !pending.is_null() {
    handle_futex_death(pending, offset)?;
}
```

**Changed file:** `os/StarryOS/kernel/src/task/ops.rs`

## Test Code & Expected Results

Test case: Thread A locks a robust mutex, then exits (dies) while the mutex is in the pending state. Thread B then attempts to acquire the same mutex.

| Scenario | Before (bug) | After (fix) |
|----------|-------------|-------------|
| Thread A dies holding robust mutex | Mutex stays locked forever; Thread B hangs | Mutex is released by kernel; Thread B acquires it with `EOWNERDEAD` |