### PR TITLE
fix(file): store open flags in File struct for correct F_GETFL

### DIFF
--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -99,13 +99,15 @@ pub fn metadata_to_kstat(metadata: &Metadata) -> Kstat {
 /// File wrapper for `ax_fs::fops::File`.
 pub struct File {
     inner: ax_fs::File,
+    open_flags: u32,
     nonblock: AtomicBool,
 }
 
 impl File {
-    pub fn new(inner: ax_fs::File) -> Self {
+    pub fn new(inner: ax_fs::File, open_flags: u32) -> Self {
         Self {
             inner,
+            open_flags,
             nonblock: AtomicBool::new(false),
         }
     }
@@ -166,6 +168,10 @@ impl FileLike for File {
 
     fn nonblocking(&self) -> bool {
         self.nonblock.load(Ordering::Acquire)
+    }
+
+    fn open_flags(&self) -> u32 {
+        self.open_flags
     }
 
     fn path(&self) -> Cow<'_, str> {

--- a/os/StarryOS/kernel/src/file/mod.rs
+++ b/os/StarryOS/kernel/src/file/mod.rs
@@ -17,7 +17,7 @@ use axfs_ng_vfs::DeviceId;
 use axpoll::Pollable;
 use downcast_rs::{DowncastSync, impl_downcast};
 use flatten_objects::FlattenObjects;
-use linux_raw_sys::general::{RLIMIT_NOFILE, stat, statx, statx_timestamp};
+use linux_raw_sys::general::{O_RDONLY, O_WRONLY, RLIMIT_NOFILE, stat, statx, statx_timestamp};
 use spin::RwLock;
 
 pub use self::{
@@ -164,6 +164,10 @@ pub trait FileLike: Pollable + DowncastSync {
         Err(AxError::NotATty)
     }
 
+    fn open_flags(&self) -> u32 {
+        0
+    }
+
     fn nonblocking(&self) -> bool {
         false
     }
@@ -234,14 +238,15 @@ pub fn close_file_like(fd: c_int) -> AxResult {
 pub fn add_stdio(fd_table: &mut FlattenObjects<FileDescriptor, AX_FILE_LIMIT>) -> AxResult<()> {
     assert_eq!(fd_table.count(), 0);
     let cx = FS_CONTEXT.lock();
-    let open = |options: &mut OpenOptions| {
+    let open = |options: &mut OpenOptions, flags| {
         AxResult::Ok(Arc::new(File::new(
             options.open(&cx, "/dev/console")?.into_file()?,
+            flags,
         )))
     };
 
-    let tty_in = open(OpenOptions::new().read(true).write(false))?;
-    let tty_out = open(OpenOptions::new().read(false).write(true))?;
+    let tty_in = open(OpenOptions::new().read(true).write(false), O_RDONLY as _)?;
+    let tty_out = open(OpenOptions::new().read(false).write(true), O_WRONLY as _)?;
     fd_table
         .add(FileDescriptor {
             inner: tty_in,

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -8,7 +8,7 @@ use core::{
 use ax_errno::{AxError, AxResult};
 use ax_fs::{FS_CONTEXT, FileBackend, OpenOptions, OpenResult};
 use ax_task::current;
-use axfs_ng_vfs::{DirEntry, FileNode, Location, NodePermission, NodeType, Reference};
+use axfs_ng_vfs::{DirEntry, FileNode, Location, NodeType, Reference};
 use bitflags::bitflags;
 use linux_raw_sys::general::*;
 
@@ -98,7 +98,7 @@ fn add_to_fd(result: OpenResult, flags: u32) -> AxResult<i32> {
                     file = ax_fs::File::new(FileBackend::Direct(loc), file.flags());
                 }
             }
-            Arc::new(File::new(file))
+            Arc::new(File::new(file, flags))
         }
         OpenResult::Dir(dir) => Arc::new(Directory::new(dir)),
     };
@@ -256,18 +256,9 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
         F_GETFL => {
             let f = get_file_like(fd)?;
 
-            let mut ret = 0;
+            let mut ret = f.open_flags();
             if f.nonblocking() {
-                ret |= O_NONBLOCK;
-            }
-
-            let perm = NodePermission::from_bits_truncate(f.stat()?.mode as _);
-            if perm.contains(NodePermission::OWNER_WRITE) {
-                if perm.contains(NodePermission::OWNER_READ) {
-                    ret |= O_RDWR;
-                } else {
-                    ret |= O_WRONLY;
-                }
+                ret |= O_NONBLOCK as u32;
             }
 
             Ok(ret as _)

--- a/os/StarryOS/kernel/src/syscall/fs/memfd.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/memfd.rs
@@ -3,7 +3,7 @@ use core::ffi::c_char;
 
 use ax_errno::{AxError, AxResult};
 use ax_fs::{FS_CONTEXT, OpenOptions};
-use linux_raw_sys::general::MFD_CLOEXEC;
+use linux_raw_sys::general::{MFD_CLOEXEC, O_RDWR};
 
 use crate::{
     file::{File, FileLike},
@@ -25,7 +25,9 @@ pub fn sys_memfd_create(_name: UserConstPtr<c_char>, flags: u32) -> AxResult<isi
                 .open(&fs, &name)?
                 .into_file()?;
             let cloexec = flags & MFD_CLOEXEC != 0;
-            return File::new(file).add_to_fd_table(cloexec).map(|fd| fd as _);
+            return File::new(file, O_RDWR)
+                .add_to_fd_table(cloexec)
+                .map(|fd| fd as _);
         }
     }
     Err(AxError::TooManyOpenFiles)

--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -288,12 +288,12 @@ impl OpenOptions {
 
     pub(crate) fn is_valid(&self) -> bool {
         if !self.read && !self.write && !self.append {
-            return true;
+            return false;
         }
         match (self.write, self.append) {
             (true, false) => {}
             (false, false) => {
-                if self.truncate || self.create || self.create_new {
+                if self.truncate {
                     return false;
                 }
             }


### PR DESCRIPTION
## Bug Analysis

Two related bugs in `fcntl(F_GETFL)` and `OpenOptions::is_valid()`:

1. **F_GETFL returns wrong access mode**: `fcntl(fd, F_GETFL)` inferred `O_RDONLY`/`O_WRONLY`/`O_RDWR` by reading the file's permission bits via `stat()`, then checking `OWNER_READ`/`OWNER_WRITE`. This is completely wrong — Linux returns the flags passed at `open()` time, not the inode permissions. For example, a file with mode `0666` opened as `O_RDONLY` should return `O_RDONLY` (0), not `O_RDWR`.

2. **`OpenOptions::is_valid()` rejects valid combinations**: When `read=false, write=false, append=false`, the function returned `true` (allowing the invalid combination through). It also rejected `O_CREAT | O_RDONLY` (which is valid on Linux) because `self.create` was checked in the read-only branch.

## Fix

1. Store the open flags (`flags` from `sys_openat`) in the `File` struct and return them directly in `F_GETFL`. Add `open_flags()` to the `FileLike` trait (defaulting to 0).

2. Fix `OpenOptions::is_valid()`: return `false` when no access mode is set; remove `self.create` / `self.create_new` from the read-only rejection check.

**Changed files:**
- `os/StarryOS/kernel/src/file/fs.rs` — add `open_flags` field to `File`
- `os/StarryOS/kernel/src/file/mod.rs` — add `open_flags()` trait default, update `add_stdio`
- `os/StarryOS/kernel/src/syscall/fs/fd_ops.rs` — pass flags to `File::new`, rewrite `F_GETFL`
- `os/StarryOS/kernel/src/syscall/fs/memfd.rs` — pass `O_RDWR` for memfd files
- `os/arceos/modules/axfs-ng/src/highlevel/file.rs` — fix `is_valid()`

## Test Code & Expected Results

```c
int fd = open("/tmp/test.txt", O_CREAT | O_RDONLY, 0666);
int flags = fcntl(fd, F_GETFL);
```

| Operation | Before (bug) | After (fix) |
|-----------|-------------|-------------|
| `fcntl(fd, F_GETFL)` after `open(..., O_RDONLY)` | Returns `O_RDWR` (2) — wrong, inferred from mode 0666 | Returns `O_RDONLY` (0) — correct |
| `fcntl(fd, F_GETFL)` after `open(..., O_WRONLY)` | Returns `O_WRONLY` (1) — correct by accident | Returns `O_WRONLY` (1) — correct |
| `open("/tmp/test", O_CREAT \| O_RDONLY, 0666)` | Returns `-1`, `errno=EINVAL` — wrong | Returns valid fd — correct |