### PR TITLE
fix(ipc): replace unwrap with error handling in sys_shmat

### DIFF
--- a/os/StarryOS/kernel/src/syscall/ipc/shm.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/shm.rs
@@ -420,7 +420,9 @@ pub fn sys_shmget(key: i32, size: usize, shmflg: usize) -> AxResult<isize> {
 pub fn sys_shmat(shmid: i32, addr: usize, shmflg: u32) -> AxResult<isize> {
     let shm_inner = {
         let shm_manager = SHM_MANAGER.lock();
-        shm_manager.get_inner_by_shmid(shmid).unwrap()
+        shm_manager
+            .get_inner_by_shmid(shmid)
+            .ok_or(AxError::InvalidInput)?
     };
     let mut shm_inner = shm_inner.lock();
     let mut mapping_flags = shm_inner.mapping_flags;


### PR DESCRIPTION
## Bug Analysis

`sys_shmat()` called `shm_manager.get_inner_by_shmid(shmid).unwrap()` when looking up the shared memory segment by ID. If an invalid `shmid` is passed (e.g., a shmid that was never allocated or has been destroyed), the `.unwrap()` panics the entire kernel. Linux returns `EINVAL` for invalid shmid arguments.

## Fix

Replace `.unwrap()` with `.ok_or(AxError::InvalidInput)?` to gracefully return an error instead of panicking.

**Changed file:** `os/StarryOS/kernel/src/syscall/ipc/shm.rs`

## Test Code & Expected Results

Test case: call `shmat()` with a garbage shmid value (e.g., `99999`) that was never created via `shmget()`.

| Operation | Before (bug) | After (fix) |
|-----------|-------------|-------------|
| `shmat(99999, NULL, 0)` | **Kernel panic** (`unwrap` on `None`) | Returns `(void*)-1`, `errno=EINVAL` |