### PR TITLE
fix(tty): read pgid from user arg in TIOCSPGRP handler

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -31,7 +31,7 @@ pub use self::{
 };
 use crate::{
     pseudofs::{DeviceOps, SimpleFs},
-    task::AsThread,
+    task::{AsThread, get_process_group},
 };
 
 pub fn create_pty_master(fs: Arc<SimpleFs>) -> AxResult<Arc<PtyDriver>> {
@@ -138,10 +138,9 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 (arg as *mut u32).vm_write(foreground.pgid())?;
             }
             TIOCSPGRP => {
-                let curr = current();
-                self.terminal
-                    .job_control
-                    .set_foreground(&curr.as_thread().proc_data.proc.group())?;
+                let pgid: u32 = (arg as *const u32).vm_read()?;
+                let pg = get_process_group(pgid)?;
+                self.terminal.job_control.set_foreground(&pg)?;
             }
             TIOCGWINSZ => {
                 (arg as *mut WindowSize).vm_write(*self.terminal.window_size.lock())?;

--- a/os/StarryOS/kernel/src/syscall/task/job.rs
+++ b/os/StarryOS/kernel/src/syscall/task/job.rs
@@ -2,7 +2,9 @@ use ax_errno::{AxError, AxResult};
 use ax_task::current;
 use starry_process::Pid;
 
-use crate::task::{AsThread, get_process_data, get_process_group};
+use crate::task::{
+    AsThread, get_process_data, get_process_group, register_process_group, register_session,
+};
 
 pub fn sys_getsid(pid: Pid) -> AxResult<isize> {
     Ok(get_process_data(pid)?.proc.group().session().sid() as _)
@@ -15,7 +17,9 @@ pub fn sys_setsid() -> AxResult<isize> {
         return Err(AxError::OperationNotPermitted);
     }
 
-    if let Some((session, _)) = proc.create_session() {
+    if let Some((session, pg)) = proc.create_session() {
+        register_session(&session);
+        register_process_group(&pg);
         Ok(session.sid() as _)
     } else {
         Ok(proc.pid() as _)
@@ -29,8 +33,10 @@ pub fn sys_getpgid(pid: Pid) -> AxResult<isize> {
 pub fn sys_setpgid(pid: Pid, pgid: Pid) -> AxResult<isize> {
     let proc = &get_process_data(pid)?.proc;
 
-    if pgid == 0 {
-        proc.create_group();
+    if pgid == 0 || pgid == proc.pid() {
+        if let Some(pg) = proc.create_group() {
+            register_process_group(&pg);
+        }
     } else if !proc.move_to_group(&get_process_group(pgid)?) {
         return Err(AxError::OperationNotPermitted);
     }

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -104,6 +104,18 @@ pub fn get_process_group(pgid: Pid) -> AxResult<Arc<ProcessGroup>> {
         .ok_or(AxError::NoSuchProcess)
 }
 
+/// Registers a process group in the global table.
+pub fn register_process_group(pg: &Arc<ProcessGroup>) {
+    let mut pg_table = PROCESS_GROUP_TABLE.write();
+    pg_table.insert(pg.pgid(), pg);
+}
+
+/// Registers a session in the global table.
+pub fn register_session(session: &Arc<Session>) {
+    let mut session_table = SESSION_TABLE.write();
+    session_table.insert(session.sid(), session);
+}
+
 /// Finds the session with the given SID.
 pub fn get_session(sid: Pid) -> AxResult<Arc<Session>> {
     SESSION_TABLE.read().get(&sid).ok_or(AxError::NoSuchProcess)


### PR DESCRIPTION
## Bug Analysis

Three related bugs in job control (TIOCSPGRP, setsid, setpgid):

1. **TIOCSPGRP reads wrong pgid**: The `TIOCSPGRP` ioctl handler used the current process's group (`curr.as_thread().proc_data.proc.group()`) instead of reading the pgid from the user-space argument. This means `tcsetpgrp()` always sets the foreground group to the caller's own group, ignoring the requested pgid.

2. **New process groups not registered globally**: `sys_setsid()` and `sys_setpgid()` create new sessions/process groups but never register them in the global `PROCESS_GROUP_TABLE` / `SESSION_TABLE`. Subsequent lookups via `get_process_group()` or `get_session()` fail with `ESRCH`, breaking shell job control.

3. **`setpgid(pid, pid)` not handled**: When `pgid == 0`, the code creates a new group. But Linux also allows `setpgid(pid, pid)` where `pgid == pid` to create/join a group. BusyBox `ash` uses `setpgid(pid, pid)` and would fail without this.

## Fix

1. TIOCSPGRP: read pgid from user arg via `(arg as *const u32).vm_read()`, then look up with `get_process_group(pgid)`.
2. Add `register_process_group()` and `register_session()` functions; call them in `sys_setsid()` and `sys_setpgid()`.
3. Handle `pgid == proc.pid()` the same as `pgid == 0`.

**Changed files:**
- `os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs` — fix TIOCSPGRP to read user pgid
- `os/StarryOS/kernel/src/syscall/task/job.rs` — register groups/sessions in setsid/setpgid
- `os/StarryOS/kernel/src/task/ops.rs` — add `register_process_group`, `register_session`

## Test Code & Expected Results

Test case: a shell (`busybox ash`) sets the foreground process group via `tcsetpgrp()` after `setpgid(pid, pid)`.

| Scenario | Before (bug) | After (fix) |
|----------|-------------|-------------|
| `tcsetpgrp(fd, child_pgid)` via TIOCSPGRP | Sets foreground to caller's own pgid (wrong group) | Sets foreground to requested `child_pgid` |
| `setpgid(pid, pid)` | Returns `ESRCH` (new group not in global table) | Returns `0` (success) |
| `setsid()` followed by `getpgid(0)` | `getpgid(0)` may fail (session group unregistered) | `getpgid(0)` returns the new pgid |
| BusyBox `ash` shell job control | Broken: `setpgid` / `tcsetpgrp` fail | Working: foreground/background jobs function correctly |