### PR TITLE
fix(mm): preserve mapping sharing type in sys_mremap

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -318,13 +318,20 @@ pub fn sys_mremap(addr: usize, old_size: usize, new_size: usize, flags: u32) -> 
     let old_size = align_up_4k(old_size);
     let new_size = align_up_4k(new_size);
 
-    let flags = aspace.find_area(addr).ok_or(AxError::NoMemory)?.flags();
+    let area = aspace.find_area(addr).ok_or(AxError::NoMemory)?;
+    let flags = area.flags();
+    // Determine the sharing type from the backend: Shared/File backends are
+    // MAP_SHARED, Cow/Linear backends are MAP_PRIVATE.
+    let mmap_flags = match area.backend() {
+        Backend::Shared(_) | Backend::File(_) => MmapFlags::SHARED | MmapFlags::ANONYMOUS,
+        Backend::Cow(_) | Backend::Linear(_) => MmapFlags::PRIVATE | MmapFlags::ANONYMOUS,
+    };
     drop(aspace);
     let new_addr = sys_mmap(
         addr.as_usize(),
         new_size,
         flags.bits() as _,
-        MmapFlags::PRIVATE.bits(),
+        mmap_flags.bits(),
         -1,
         0,
     )? as usize;


### PR DESCRIPTION
## Bug Analysis

`sys_mremap()` always used `MmapFlags::PRIVATE` when remapping, regardless of the original mapping's sharing type. If the original mapping was `MAP_SHARED`, the remapped region would silently become `MAP_PRIVATE` (copy-on-write). This means writes to the remapped shared memory region are no longer visible to other processes mapping the same shared memory — the entire purpose of `MAP_SHARED` is defeated.

## Fix

Before remapping, inspect the existing area's backend type to determine the correct sharing flags:

- `Backend::Shared(_)` or `Backend::File(_)` → `MmapFlags::SHARED | MmapFlags::ANONYMOUS`
- `Backend::Cow(_)` or `Backend::Linear(_)` → `MmapFlags::PRIVATE | MmapFlags::ANONYMOUS`

Then pass the correct `mmap_flags` to `sys_mmap()` instead of hardcoded `PRIVATE`.

**Changed file:** `os/StarryOS/kernel/src/syscall/mm/mmap.rs`

## Test Code & Expected Results

Test case: Process A creates shared memory via `shmget()` + `shmat()`, then calls `mremap()` to resize. Process B is attached to the same shared memory segment.

| Scenario | Before (bug) | After (fix) |
|----------|-------------|-------------|
| Process A writes to remapped shared memory | Process B does **not** see the write (MAP_PRIVATE) | Process B **sees** the write (MAP_SHARED preserved) |
| `mremap` on a private (MAP_PRIVATE) mapping | Works correctly (PRIVATE → PRIVATE) | Works correctly (PRIVATE → PRIVATE) |
| `mremap` on a shared (MAP_SHARED) mapping | Silently downgraded to MAP_PRIVATE | Stays MAP_SHARED |