### PR TITLE
fix(file): return EISDIR instead of EBADF for directory read/write

### DIFF
--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -217,11 +217,11 @@ impl Directory {
 
 impl FileLike for Directory {
     fn read(&self, _dst: &mut IoDst) -> AxResult<usize> {
-        Err(AxError::BadFileDescriptor)
+        Err(AxError::IsADirectory)
     }
 
     fn write(&self, _src: &mut IoSrc) -> AxResult<usize> {
-        Err(AxError::BadFileDescriptor)
+        Err(AxError::IsADirectory)
     }
 
     fn stat(&self) -> AxResult<Kstat> {


### PR DESCRIPTION
## Bug Analysis

When `read()` or `write()` is called on a directory file descriptor, `Directory::read()` and `Directory::write()` returned `EBADF` (`AxError::BadFileDescriptor`). According to POSIX and Linux kernel behavior, the correct errno for I/O on a directory fd is `EISDIR`. This discrepancy causes user-space programs that check for `EISDIR` to miss the directory case entirely.

This is separate from the `open()` case (returning `EISDIR` for `O_WRONLY` on directories), which was already fixed in #253.

## Fix

Change the error variant in `Directory::read()` and `Directory::write()` from `AxError::BadFileDescriptor` to `AxError::IsADirectory`.

**Changed file:** `os/StarryOS/kernel/src/file/fs.rs`

## Test Code

Located at `test-suit/starryos/normal/bug-open-dir-wronly/c/src/main.c`. The test opens `/tmp` as a directory and verifies the correct errno behavior:

```c
int fd = open("/tmp", O_RDONLY);  // open dir succeeds
char buf[16];
ssize_t r = read(fd, buf, sizeof(buf));  // should fail with EISDIR
```

## Expected Results

| Operation | Before (bug) | After (fix) |
|-----------|-------------|-------------|
| `read()` on directory fd | Returns `-1`, `errno=EBADF` (9) | Returns `-1`, `errno=EISDIR` (21) |
| `write()` on directory fd | Returns `-1`, `errno=EBADF` (9) | Returns `-1`, `errno=EISDIR` (21) |