### PR TITLE
fix(starry): reject invalid unlinkat flag bits with EINVAL

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -270,8 +270,15 @@ pub fn sys_unlinkat(dirfd: i32, path: *const c_char, flags: usize) -> AxResult<i
 
     debug!("sys_unlinkat <= dirfd: {dirfd}, path: {path:?}, flags: {flags}");
 
+    // Linux kernel (fs/namei.c) rejects any flag bit other than AT_REMOVEDIR
+    // with EINVAL. Silently ignoring unknown bits would mask caller bugs and
+    // diverge from POSIX semantics (see man 2 unlinkat).
+    if flags & !(AT_REMOVEDIR as usize) != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
     with_fs(dirfd, |fs| {
-        if flags == AT_REMOVEDIR as _ {
+        if flags & AT_REMOVEDIR as usize != 0 {
             fs.remove_dir(path)?;
         } else {
             fs.remove_file(path)?;

--- a/test-suit/starryos/normal/bug-unlinkat-einval/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-unlinkat-einval/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-unlinkat-einval C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-unlinkat-einval src/main.c)
+target_compile_options(bug-unlinkat-einval PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-unlinkat-einval RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-unlinkat-einval/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-unlinkat-einval/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-unlinkat-einval/c/src/main.c
+++ b/test-suit/starryos/normal/bug-unlinkat-einval/c/src/main.c
@@ -1,0 +1,133 @@
+/*
+ * bug-unlinkat-einval.c — unlinkat flags validation
+ *
+ * Bug：StarryOS 的 sys_unlinkat 不校验 flags，任何非 AT_REMOVEDIR 的比特位都被
+ * 默默吞掉，与 Linux 行为不符：man 2 unlinkat 明确 "EINVAL  An invalid flag
+ * value was specified in flags."，内核源码 fs/namei.c 中有
+ * `if (flag & ~AT_REMOVEDIR) return -EINVAL;`。
+ *
+ * 影响：
+ *   - unlinkat(path, 0x1) 这类带非法 flag 的调用本应失败，却会把文件删掉；
+ *   - unlinkat(dir, AT_REMOVEDIR|0x1) 应当 EINVAL，现在会走 remove_file 分支。
+ *
+ * 测试覆盖：
+ *   负向：flags=0x1                 对普通文件 → EINVAL，文件仍存在
+ *   负向：flags=AT_SYMLINK_NOFOLLOW 对普通文件 → EINVAL，文件仍存在
+ *   负向：flags=AT_REMOVEDIR|0x1    对目录     → EINVAL，目录仍存在
+ *   正向：flags=0                   对普通文件 → 成功删除
+ *   正向：flags=AT_REMOVEDIR        对目录     → 成功删除
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* ========== 内联测试框架 ========== */
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define TEST_START(name) \
+    do { \
+        printf("[TEST] %s\n", (name)); \
+        test_passed = 0; \
+        test_failed = 0; \
+    } while(0)
+
+#define CHECK(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            printf("  [FAIL] %s (errno=%d %s)\n", (msg), errno, strerror(errno)); \
+            test_failed++; \
+        } else { \
+            printf("  [OK] %s\n", (msg)); \
+            test_passed++; \
+        } \
+    } while(0)
+
+#define TEST_DONE() \
+    do { \
+        printf("\n=== 结果: %d 通过, %d 失败 ===\n", test_passed, test_failed); \
+        if (test_failed == 0) { printf("TEST PASSED\n"); } \
+        return (test_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE; \
+    } while(0)
+
+/* ========== 测试代码 ========== */
+
+static int create_regular_file(const char *path)
+{
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        return -1;
+    }
+    close(fd);
+    return 0;
+}
+
+int main(void)
+{
+    TEST_START("unlinkat: reject invalid flag bits with EINVAL");
+
+    const char *file_path = "/tmp/bug_unlinkat_einval_file";
+    const char *dir_path  = "/tmp/bug_unlinkat_einval_dir";
+
+    /* 预清理，防止上次运行残留 */
+    unlink(file_path);
+    rmdir(dir_path);
+
+    /* -------- 普通文件：非法 flags -------- */
+
+    CHECK(create_regular_file(file_path) == 0, "创建测试文件");
+
+    /* 1. flags=0x1 (bit 0 未定义) 必须 EINVAL */
+    errno = 0;
+    int r = unlinkat(AT_FDCWD, file_path, 0x1);
+    CHECK(r == -1 && errno == EINVAL,
+          "unlinkat(file, 0x1) 返回 -1 且 errno=EINVAL");
+
+    struct stat st;
+    CHECK(stat(file_path, &st) == 0,
+          "非法 flags 后文件仍然存在");
+
+    /* 2. flags=AT_SYMLINK_NOFOLLOW (0x100) 对 unlinkat 无效 */
+    errno = 0;
+    r = unlinkat(AT_FDCWD, file_path, AT_SYMLINK_NOFOLLOW);
+    CHECK(r == -1 && errno == EINVAL,
+          "unlinkat(file, AT_SYMLINK_NOFOLLOW) 返回 -1 且 errno=EINVAL");
+    CHECK(stat(file_path, &st) == 0,
+          "AT_SYMLINK_NOFOLLOW 后文件仍然存在");
+
+    /* 3. 正向：flags=0 成功删除 */
+    errno = 0;
+    r = unlinkat(AT_FDCWD, file_path, 0);
+    CHECK(r == 0, "unlinkat(file, 0) 正常删除返回 0");
+    CHECK(stat(file_path, &st) == -1 && errno == ENOENT,
+          "文件已被删除 (ENOENT)");
+
+    /* -------- 目录：非法 flags 组合 -------- */
+
+    CHECK(mkdir(dir_path, 0700) == 0, "创建测试目录");
+
+    /* 4. flags=AT_REMOVEDIR|0x1 含非法位 → EINVAL */
+    errno = 0;
+    r = unlinkat(AT_FDCWD, dir_path, AT_REMOVEDIR | 0x1);
+    CHECK(r == -1 && errno == EINVAL,
+          "unlinkat(dir, AT_REMOVEDIR|0x1) 返回 -1 且 errno=EINVAL");
+    CHECK(stat(dir_path, &st) == 0,
+          "非法 flags 后目录仍然存在");
+
+    /* 5. 正向：flags=AT_REMOVEDIR 正确删除目录 */
+    errno = 0;
+    r = unlinkat(AT_FDCWD, dir_path, AT_REMOVEDIR);
+    CHECK(r == 0, "unlinkat(dir, AT_REMOVEDIR) 正常删除返回 0");
+    CHECK(stat(dir_path, &st) == -1 && errno == ENOENT,
+          "目录已被删除 (ENOENT)");
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/bug-unlinkat-einval/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-unlinkat-einval/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-unlinkat-einval"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/bug-unlinkat-einval/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-unlinkat-einval/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+shell_init_cmd = "/usr/bin/bug-unlinkat-einval"
+shell_prefix = "root@starry:"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+to_bin = true
+uefi = false
+timeout = 15

--- a/test-suit/starryos/normal/bug-unlinkat-einval/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-unlinkat-einval/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-unlinkat-einval"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/bug-unlinkat-einval/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-unlinkat-einval/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-unlinkat-einval"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15


### PR DESCRIPTION

## Bug 描述

`sys_unlinkat` 没有校验 `flags` 参数。除 `AT_REMOVEDIR` 以外的任何比特位都会被静默忽略，导致：

- `unlinkat(AT_FDCWD, path, 0x1)` 期望 `-EINVAL`，实际把文件删掉并返回 0。
- `unlinkat(AT_FDCWD, path, AT_SYMLINK_NOFOLLOW)` 期望 `-EINVAL`（`AT_SYMLINK_NOFOLLOW` 对 unlinkat 无意义），实际把文件删掉并返回 0。
- `unlinkat(AT_FDCWD, dir, AT_REMOVEDIR | 0x1)` 期望 `-EINVAL`，实际走 `remove_file` 分支，对一个目录返回非预期错误，破坏 `rm -r` 一类调用方的错误处理逻辑。

参考：

- `man 2 unlinkat`：`EINVAL  An invalid flag value was specified in flags.`
- Linux 内核 `fs/namei.c` 的 `do_unlinkat` 入口：`if (flag & ~AT_REMOVEDIR) return -EINVAL;`

## 根本原因

`os/StarryOS/kernel/src/syscall/fs/ctl.rs` 中原实现：

```rust
if flags == AT_REMOVEDIR as _ {
    fs.remove_dir(path)?;
} else {
    fs.remove_file(path)?;
}
```

两个问题：

1. 用 `==` 判断 `AT_REMOVEDIR` 而非 `&` 位测试，导致 `AT_REMOVEDIR | <其它任意位>` 不会走 `remove_dir`；
2. 完全没有对非法比特位做拒绝。

## Fix 描述

- 在进入 `with_fs` 之前显式拒绝 `flags & !AT_REMOVEDIR != 0` 的情况，返回 `AxError::InvalidInput`（映射到 `EINVAL`）。
- 把 `==` 改为 `flags & AT_REMOVEDIR != 0`，这样将来如果有新加的合法位，`AT_REMOVEDIR` 这条路径仍然正确。
- 改动 2 行有效逻辑，附注释说明 Linux 参考行为，避免后续 review 者误判"静默忽略"是有意为之。

## 测例

新增 `test-suit/starryos/normal/bug-unlinkat-einval/`，C 用户态测例覆盖 5 个场景、12 条断言：

| 方向 | 调用 | 期望 |
|---|---|---|
| 负向 | `unlinkat(file, 0x1)` | `-1`, `errno=EINVAL`，文件仍在 |
| 负向 | `unlinkat(file, AT_SYMLINK_NOFOLLOW)` | `-1`, `errno=EINVAL`，文件仍在 |
| 正向 | `unlinkat(file, 0)` | `0`，文件被删 |
| 负向 | `unlinkat(dir, AT_REMOVEDIR \| 0x1)` | `-1`, `errno=EINVAL`，目录仍在 |
| 正向 | `unlinkat(dir, AT_REMOVEDIR)` | `0`，目录被删 |

目录命名沿用 `bug-xxx` 风格（与 `bug-open-dir-wronly`、`bug-pipe-fd-errno` 一致）。

## Test Plan

在 `ghcr.io/rcore-os/tgoskits-container:latest` 容器内执行：

```bash
cargo fmt --all -- --check
cargo xtask starry test qemu -t riscv64     -c bug-unlinkat-einval
cargo xtask starry test qemu -t aarch64     -c bug-unlinkat-einval
cargo xtask starry test qemu -t x86_64      -c bug-unlinkat-einval
cargo xtask starry test qemu -t loongarch64 -c bug-unlinkat-einval
```

结果：

| 架构 | 结果 | 耗时 |
|---|---|---|
| riscv64     | TEST PASSED | 248.59s |
| aarch64     | TEST PASSED | 179.98s |
| x86_64      | TEST PASSED | 260.49s |
| loongarch64 | TEST PASSED | 218.37s |

`cargo fmt --all -- --check` 无输出（格式干净）。


