### PR TITLE
fix: report real cpu affinity in proc status

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -13,7 +13,7 @@ use core::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use ax_task::{AxTaskRef, WeakAxTaskRef, current};
+use ax_task::{AxCpuMask, AxTaskRef, WeakAxTaskRef, current};
 use axfs_ng_vfs::{Filesystem, NodeType, VfsError, VfsResult};
 use indoc::indoc;
 use starry_process::Process;
@@ -133,18 +133,109 @@ impl SimpleDirOps for ProcessTaskDir {
 
 #[rustfmt::skip]
 fn task_status(task: &AxTaskRef) -> String {
+    render_task_status(
+        task.as_thread().proc_data.proc.pid(),
+        task.id().as_u64(),
+        task.cpumask(),
+        ax_hal::cpu_num(),
+    )
+}
+
+#[rustfmt::skip]
+fn render_task_status(tgid: u32, pid: u64, cpumask: AxCpuMask, cpu_num: usize) -> String {
+    let cpus_allowed = format_cpumask_hex(cpumask, cpu_num);
+    let cpus_allowed_list = format_cpumask_list(cpumask, cpu_num);
+
+    render_task_status_fields(tgid, pid, &cpus_allowed, &cpus_allowed_list)
+}
+
+#[rustfmt::skip]
+fn render_task_status_fields(
+    tgid: u32,
+    pid: u64,
+    cpus_allowed: &str,
+    cpus_allowed_list: &str,
+) -> String {
     format!(
         "Tgid:\t{}\n\
         Pid:\t{}\n\
         Uid:\t0 0 0 0\n\
         Gid:\t0 0 0 0\n\
-        Cpus_allowed:\t1\n\
-        Cpus_allowed_list:\t0\n\
+        Cpus_allowed:\t{cpus_allowed}\n\
+        Cpus_allowed_list:\t{cpus_allowed_list}\n\
         Mems_allowed:\t1\n\
         Mems_allowed_list:\t0",
-        task.as_thread().proc_data.proc.pid(),
-        task.id().as_u64()
+        tgid,
+        pid
     )
+}
+
+fn format_cpumask_hex(cpumask: AxCpuMask, cpu_num: usize) -> String {
+    format_cpu_presence_hex(&collect_cpu_presence(&cpumask, cpu_num))
+}
+
+fn format_cpu_presence_hex(cpu_presence: &[bool]) -> String {
+    let word_count = cpu_presence.len().div_ceil(32).max(1);
+    let mut words = vec![0u32; word_count];
+
+    for (cpu, allowed) in cpu_presence.iter().copied().enumerate() {
+        if allowed {
+            words[cpu / 32] |= 1u32 << (cpu % 32);
+        }
+    }
+
+    words
+        .iter()
+        .rev()
+        .map(|word| format!("{word:08x}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn format_cpumask_list(cpumask: AxCpuMask, cpu_num: usize) -> String {
+    format_cpu_presence_list(&collect_cpu_presence(&cpumask, cpu_num))
+}
+
+fn format_cpu_presence_list(cpu_presence: &[bool]) -> String {
+    let mut ranges = Vec::new();
+    let mut cpu = 0;
+
+    while cpu < cpu_presence.len() {
+        if !cpu_presence[cpu] {
+            cpu += 1;
+            continue;
+        }
+
+        let start = cpu;
+        let mut end = cpu;
+        while end + 1 < cpu_presence.len() && cpu_presence[end + 1] {
+            end += 1;
+        }
+
+        ranges.push(if start == end {
+            start.to_string()
+        } else {
+            format!("{start}-{end}")
+        });
+        cpu = end + 1;
+    }
+
+    ranges.join(",")
+}
+
+fn collect_cpu_presence<I>(cpus: I, cpu_num: usize) -> Vec<bool>
+where
+    I: IntoIterator<Item = usize>,
+{
+    let mut cpu_presence = vec![false; cpu_num];
+
+    for cpu in cpus {
+        if cpu < cpu_num {
+            cpu_presence[cpu] = true;
+        }
+    }
+
+    cpu_presence
 }
 
 /// The /proc/[pid]/fd directory
@@ -422,4 +513,71 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
 
     let proc_dir = ProcFsHandler(fs.clone());
     SimpleDir::new_maker(fs, Arc::new(proc_dir.chain(root)))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, string::String};
+
+    use super::{
+        collect_cpu_presence, format_cpu_presence_hex, format_cpu_presence_list,
+        render_task_status_fields,
+    };
+
+    fn legacy_render_task_status(tgid: u32, pid: u64) -> String {
+        format!(
+            "Tgid:\t{}\nPid:\t{}\nUid:\t0 0 0 0\nGid:\t0 0 0 \
+             0\nCpus_allowed:\t1\nCpus_allowed_list:\t0\nMems_allowed:\t1\nMems_allowed_list:\t0",
+            tgid, pid
+        )
+    }
+
+    fn render_task_status_from_cpus(tgid: u32, pid: u64, cpus: &[usize], cpu_num: usize) -> String {
+        let cpu_presence = collect_cpu_presence(cpus.iter().copied(), cpu_num);
+        let cpus_allowed = format_cpu_presence_hex(&cpu_presence);
+        let cpus_allowed_list = format_cpu_presence_list(&cpu_presence);
+
+        render_task_status_fields(tgid, pid, &cpus_allowed, &cpus_allowed_list)
+    }
+
+    #[test]
+    fn old_hardcoded_status_lies_about_non_cpu0_affinity() {
+        let legacy = legacy_render_task_status(42, 84);
+
+        assert!(legacy.contains("Cpus_allowed:\t1\n"));
+        assert!(legacy.contains("Cpus_allowed_list:\t0\n"));
+        assert!(!legacy.contains("Cpus_allowed:\t0000000a\n"));
+        assert!(!legacy.contains("Cpus_allowed_list:\t1,3\n"));
+    }
+
+    #[test]
+    fn cpus_allowed_hex_matches_actual_affinity_bits() {
+        let cpu_presence = collect_cpu_presence([1, 3], 4);
+
+        assert_eq!(format_cpu_presence_hex(&cpu_presence), "0000000a");
+    }
+
+    #[test]
+    fn cpus_allowed_hex_orders_32bit_words_from_high_to_low() {
+        let cpu_presence = collect_cpu_presence([0, 1, 32, 63], 64);
+
+        assert_eq!(format_cpu_presence_hex(&cpu_presence), "80000001,00000003");
+    }
+
+    #[test]
+    fn cpus_allowed_list_compacts_contiguous_ranges() {
+        let cpu_presence = collect_cpu_presence([0, 2, 3, 4, 7, 9, 10, 11], 12);
+
+        assert_eq!(format_cpu_presence_list(&cpu_presence), "0,2-4,7,9-11");
+    }
+
+    #[test]
+    fn task_status_reports_real_affinity_instead_of_cpu0_only() {
+        let status = render_task_status_from_cpus(42, 84, &[1, 3], 4);
+
+        assert!(status.contains("Tgid:\t42\n"));
+        assert!(status.contains("Pid:\t84\n"));
+        assert!(status.contains("Cpus_allowed:\t0000000a\n"));
+        assert!(status.contains("Cpus_allowed_list:\t1,3\n"));
+    }
 }

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -621,25 +621,35 @@ impl Starry {
         cargo: &Cargo,
         case: &test_suit::StarryQemuCase,
     ) -> anyhow::Result<()> {
+        let mut case_request = request.clone();
         let mut qemu = self
             .app
             .tool_mut()
             .read_qemu_config_from_path_for_cargo(cargo, &case.qemu_config_path)
             .await?;
 
+        if case_request.smp.is_none() {
+            case_request.smp = rootfs::smp_from_qemu_arg(&qemu);
+        }
+        let cargo = if case_request.smp != request.smp {
+            build::load_cargo_config(&case_request)?
+        } else {
+            cargo.clone()
+        };
+
         let case_assets = rootfs::prepare_case_assets(
             self.app.workspace_root(),
-            &request.arch,
-            &request.target,
+            &case_request.arch,
+            &case_request.target,
             case,
         )
         .await?;
         rootfs::apply_disk_image_qemu_args(&mut qemu, case_assets.rootfs_path);
         qemu.args.extend(case_assets.extra_qemu_args);
-        rootfs::apply_smp_qemu_arg(&mut qemu, request.smp);
+        rootfs::apply_smp_qemu_arg(&mut qemu, case_request.smp);
 
         self.app
-            .qemu(cargo.clone(), request.build_info_path.clone(), Some(qemu))
+            .qemu(cargo, case_request.build_info_path, Some(qemu))
             .await
     }
 

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -267,6 +267,24 @@ pub(crate) fn apply_smp_qemu_arg(qemu: &mut QemuConfig, smp: Option<usize>) {
     qemu.args.push(cpu_num.to_string());
 }
 
+pub(crate) fn smp_from_qemu_arg(qemu: &QemuConfig) -> Option<usize> {
+    let index = qemu.args.iter().position(|arg| arg == "-smp")?;
+    let value = qemu.args.get(index + 1)?;
+    parse_smp_qemu_value(value)
+}
+
+fn parse_smp_qemu_value(value: &str) -> Option<usize> {
+    let first = value.split(',').next()?;
+    if let Ok(cpu_num) = first.parse() {
+        return Some(cpu_num);
+    }
+
+    value.split(',').find_map(|part| {
+        let cpu_num = part.strip_prefix("cpus=")?;
+        cpu_num.parse().ok()
+    })
+}
+
 pub(crate) fn apply_disk_image_qemu_args(qemu: &mut QemuConfig, disk_img: PathBuf) {
     let disk_value = format!("id=disk0,if=none,format=raw,file={}", disk_img.display());
     let args = &mut qemu.args;
@@ -1605,6 +1623,46 @@ mod tests {
                 "4".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn smp_from_qemu_arg_reads_plain_cpu_count() {
+        let qemu = QemuConfig {
+            args: vec![
+                "-machine".to_string(),
+                "virt".to_string(),
+                "-smp".to_string(),
+                "4".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(smp_from_qemu_arg(&qemu), Some(4));
+    }
+
+    #[test]
+    fn smp_from_qemu_arg_reads_cpus_key_value_syntax() {
+        let qemu = QemuConfig {
+            args: vec![
+                "-machine".to_string(),
+                "q35".to_string(),
+                "-smp".to_string(),
+                "cpus=3,sockets=1,cores=3,threads=1".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(smp_from_qemu_arg(&qemu), Some(3));
+    }
+
+    #[test]
+    fn smp_from_qemu_arg_returns_none_when_missing() {
+        let qemu = QemuConfig {
+            args: vec!["-machine".to_string(), "q35".to_string()],
+            ..Default::default()
+        };
+
+        assert_eq!(smp_from_qemu_arg(&qemu), None);
     }
 
     #[tokio::test]

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -110,6 +110,10 @@ shell_init_cmd = "/usr/bin/mytest"
 
 QEMU 参数可以从已有用例复制（如 `smoke/qemu-<arch>.toml`），按需调整。
 
+如果某个用例需要多核环境，可以直接在 `qemu-<arch>.toml` 的 `args` 中加入
+`"-smp", "<N>"`。StarryOS 的测试运行器会自动用同样的 CPU 数重新配置内核构建，
+避免出现 QEMU 是多核而内核仍按单核模式编译的问题。
+
 ### 5. 支持的架构
 
 | 架构         | Target                              | QEMU CPU  |

--- a/test-suit/starryos/normal/bug-proc-status-affinity/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-proc-status-affinity/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(test_proc_status_affinity C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test_proc_status_affinity src/main.c)
+target_compile_options(test_proc_status_affinity PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test_proc_status_affinity RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-proc-status-affinity/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-proc-status-affinity/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-proc-status-affinity/c/src/main.c
+++ b/test-suit/starryos/normal/bug-proc-status-affinity/c/src/main.c
@@ -1,0 +1,75 @@
+#define _GNU_SOURCE
+
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void expect(int condition, const char *message) {
+    if (!condition) {
+        fputs(message, stderr);
+        fputc('\n', stderr);
+        abort();
+    }
+}
+
+static void trim_newline(char *text) {
+    size_t len = strlen(text);
+    if (len > 0 && text[len - 1] == '\n') {
+        text[len - 1] = '\0';
+    }
+}
+
+static void read_affinity_lines(char *allowed, size_t allowed_size, char *allowed_list,
+                                size_t allowed_list_size) {
+    FILE *fp = fopen("/proc/self/status", "r");
+    expect(fp != NULL, "failed to open /proc/self/status");
+
+    char line[256];
+    int found_allowed = 0;
+    int found_allowed_list = 0;
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        if (strncmp(line, "Cpus_allowed:\t", 14) == 0) {
+            snprintf(allowed, allowed_size, "%s", line + 14);
+            trim_newline(allowed);
+            found_allowed = 1;
+        } else if (strncmp(line, "Cpus_allowed_list:\t", 19) == 0) {
+            snprintf(allowed_list, allowed_list_size, "%s", line + 19);
+            trim_newline(allowed_list);
+            found_allowed_list = 1;
+        }
+    }
+
+    fclose(fp);
+    expect(found_allowed, "missing Cpus_allowed in /proc/self/status");
+    expect(found_allowed_list, "missing Cpus_allowed_list in /proc/self/status");
+}
+
+int main(void) {
+    long cpu_num = sysconf(_SC_NPROCESSORS_ONLN);
+    expect(cpu_num >= 2, "expected at least 2 online CPUs");
+
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    CPU_SET(1, &mask);
+    expect(sched_setaffinity(0, sizeof(mask), &mask) == 0, "sched_setaffinity failed");
+
+    cpu_set_t current_mask;
+    CPU_ZERO(&current_mask);
+    expect(sched_getaffinity(0, sizeof(current_mask), &current_mask) == 0,
+           "sched_getaffinity failed");
+    expect(CPU_ISSET(1, &current_mask), "CPU1 not present in current affinity");
+    expect(CPU_COUNT(&current_mask) == 1, "current affinity should contain exactly one CPU");
+
+    char allowed[64];
+    char allowed_list[64];
+    read_affinity_lines(allowed, sizeof(allowed), allowed_list, sizeof(allowed_list));
+
+    expect(strcmp(allowed, "00000002") == 0, "unexpected Cpus_allowed");
+    expect(strcmp(allowed_list, "1") == 0, "unexpected Cpus_allowed_list");
+
+    puts("TEST PASSED");
+    return 0;
+}

--- a/test-suit/starryos/normal/bug-proc-status-affinity/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-proc-status-affinity/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-smp",
+    "4",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test_proc_status_affinity"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\\b(assert|panic(?:ked)?|failed|aborted)\\b']
+timeout = 20


### PR DESCRIPTION
## 变更说明

修复了 StarryOS 中 `/proc/[pid]/status` 的一个 CPU affinity 语义错误。

原来的 `task_status()` 会把下面两个字段写死：

- `Cpus_allowed:\t1`
- `Cpus_allowed_list:\t0`

这会导致无论线程真实的 affinity 是什么，用户态看到的结果都像“只能在 CPU0 上运行”，与内核内部真实状态不一致。

本次修改：

- 在 `os/StarryOS/kernel/src/pseudofs/proc.rs` 中根据线程真实 `cpumask` 动态生成 `Cpus_allowed` 和 `Cpus_allowed_list`
- 在 `test-suit/starryos/normal/bug-proc-status-affinity` 中补充了对应的用户态 C 测例
- 在 `scripts/axbuild` 中补充了 Starry normal case 对 `qemu-<arch>.toml` 里 `-smp` 参数的同步支持，使该测例可以通过标准 `cargo xtask starry test qemu` 入口运行

## 根因分析

`/proc/[pid]/status` 的实现没有读取线程的真实 CPU affinity，而是返回了固定的 CPU0 掩码，导致内核内部状态与用户态可见结果不一致。

## 测例说明

新增测例会：

- 调用 `sched_setaffinity()` 将当前线程绑定到 CPU1
- 调用 `sched_getaffinity()` 确认绑定确实生效
- 读取 `/proc/self/status`
- 检查 `Cpus_allowed` 是否为 `00000002`
- 检查 `Cpus_allowed_list` 是否为 `1`

旧实现下该测例会失败；修复后测例通过。

## 验证情况

已完成以下验证：

- `cargo fmt --manifest-path Cargo.toml --all`
- `cargo test -p axbuild smp_from_qemu_arg -- --nocapture`
- `cargo test -p axbuild apply_smp_qemu_arg_ -- --nocapture`
- `cargo test -p starry-kernel old_hardcoded_status_lies_about_non_cpu0_affinity -- --nocapture`
- `cargo test -p starry-kernel task_status_reports_real_affinity_instead_of_cpu0_only -- --nocapture`
- `cargo test -p starry-kernel cpus_allowed_hex_matches_actual_affinity_bits -- --nocapture`
- `cargo test -p starry-kernel cpus_allowed_hex_orders_32bit_words_from_high_to_low -- --nocapture`
- `cargo test -p starry-kernel cpus_allowed_list_compacts_contiguous_ranges -- --nocapture`
- `cargo check -p starry-kernel --all-targets`
- `cargo xtask clippy --package axbuild`
- `cargo xtask starry test qemu -t x86_64 -c bug-proc-status-affinity`

另外，旧实现下已确认该用户态测例会失败，能够稳定复现该 bug。

说明：

- `cargo xtask clippy --package starry-kernel` 目前仍会被仓库已有的无关 clippy 问题挡住，主要位于 `components/axcpu` 和 `components/rsext4`，不是本次改动引入的问题。