### PR TITLE
fix(starry): clamp clone3 user struct read length

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/clone3.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone3.rs
@@ -81,10 +81,11 @@ pub fn sys_clone3(uctx: &UserContext, args: *const u8, size: usize) -> AxResult<
     }
 
     let mut buffer = [0u8; core::mem::size_of::<Clone3Args>()];
+    let read_len = size.min(buffer.len());
     // SAFETY: MaybeUninit<T> is compatible with T, and we're filling in the
     // buffer with bytes read from the user
     vm_read_slice(args, unsafe {
-        mem::transmute::<&mut [u8], &mut [MaybeUninit<u8>]>(&mut buffer[..size])
+        mem::transmute::<&mut [u8], &mut [MaybeUninit<u8>]>(&mut buffer[..read_len])
     })?;
     let clone3_args: Clone3Args =
         bytemuck::try_pod_read_unaligned(&buffer).map_err(|_| AxError::InvalidInput)?;

--- a/test-suit/starryos/normal/clone3-badsize/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/clone3-badsize/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(clone3-badsize C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(clone3-badsize src/main.c)
+target_compile_options(clone3-badsize PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS clone3-badsize RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/clone3-badsize/c/prebuild.sh
+++ b/test-suit/starryos/normal/clone3-badsize/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/clone3-badsize/c/src/main.c
+++ b/test-suit/starryos/normal/clone3-badsize/c/src/main.c
@@ -1,0 +1,80 @@
+/*
+ * clone3-badsize: trigger the StarryOS clone3 size handling bug.
+ *
+ * Linux-compatible behavior: clone3 should ignore unknown trailing bytes in
+ * the user-supplied struct and either succeed or return a normal errno.
+ * StarryOS bug: a size larger than struct clone_args overflows the kernel
+ * buffer slice and can panic the kernel.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef SYS_clone3
+#define SYS_clone3 435
+#endif
+
+struct clone_args {
+    uint64_t flags;
+    uint64_t pidfd;
+    uint64_t child_tid;
+    uint64_t parent_tid;
+    uint64_t exit_signal;
+    uint64_t stack;
+    uint64_t stack_size;
+    uint64_t tls;
+    uint64_t set_tid;
+    uint64_t set_tid_size;
+    uint64_t cgroup;
+};
+
+static int do_clone3_overlong(void)
+{
+    struct clone_args args;
+    memset(&args, 0, sizeof(args));
+    args.exit_signal = SIGCHLD;
+
+    size_t size = sizeof(args) + 8;
+    long ret = syscall(SYS_clone3, &args, size);
+    if (ret < 0) {
+        printf("clone3 returned errno=%d (%s)\n", errno, strerror(errno));
+        return 1;
+    }
+
+    if (ret == 0) {
+        _exit(0);
+    }
+
+    int status = 0;
+    if (waitpid((pid_t)ret, &status, 0) < 0) {
+        printf("waitpid failed: errno=%d (%s)\n", errno, strerror(errno));
+        return 1;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        printf("child exited abnormally: status=0x%x\n", status);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    printf("=== clone3-badsize ===\n");
+    printf("Calling clone3 with size larger than struct clone_args...\n");
+
+    if (do_clone3_overlong() != 0) {
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    printf("TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/clone3-badsize/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/clone3-badsize/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/clone3-badsize"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED']
+timeout = 20

--- a/test-suit/starryos/normal/clone3-badsize/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/clone3-badsize/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/clone3-badsize"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED']
+timeout = 20

--- a/test-suit/starryos/normal/clone3-badsize/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/clone3-badsize/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/clone3-badsize"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED']
+timeout = 15

--- a/test-suit/starryos/normal/clone3-badsize/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/clone3-badsize/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/clone3-badsize"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED']
+timeout = 20


### PR DESCRIPTION
修复 StarryOS 的 clone3 参数读取边界问题。当前实现会在用户传入的 size 大于 clone_args 结构体大小时，直接对固定缓冲区做超范围切片，触发内核 panic。修复后会把读取长度限制为缓冲区实际大小，保持对超长参数的兼容性，避免内核崩溃。

