### PR TITLE
feat(ax-sync): add mutex lockdep and fix Starry atomic-context violations

### DIFF
--- a/components/axcpu/src/aarch64/trap.rs
+++ b/components/axcpu/src/aarch64/trap.rs
@@ -79,7 +79,11 @@ fn handle_breakpoint(tf: &mut TrapFrame) {
 
 fn handle_page_fault(tf: &mut TrapFrame, access_flags: PageFaultFlags) {
     let vaddr = va!(fault_addr());
-    if crate::trap::page_fault_handler(vaddr, access_flags) {
+    if crate::trap::call_page_fault_handler_with_parent_irqs(
+        vaddr,
+        access_flags,
+        tf.spsr & (1 << 7) == 0,
+    ) {
         return;
     }
     #[cfg(feature = "uspace")]

--- a/components/axcpu/src/loongarch64/trap.rs
+++ b/components/axcpu/src/loongarch64/trap.rs
@@ -22,7 +22,11 @@ fn handle_breakpoint(tf: &mut TrapFrame) {
 
 fn handle_page_fault(tf: &mut TrapFrame, access_flags: PageFaultFlags) {
     let vaddr = va!(badv::read().vaddr());
-    if crate::trap::page_fault_handler(vaddr, access_flags) {
+    if crate::trap::call_page_fault_handler_with_parent_irqs(
+        vaddr,
+        access_flags,
+        tf.prmd & (1 << 2) != 0,
+    ) {
         return;
     }
     #[cfg(feature = "uspace")]

--- a/components/axcpu/src/riscv/trap.rs
+++ b/components/axcpu/src/riscv/trap.rs
@@ -27,7 +27,8 @@ fn handle_breakpoint(tf: &mut TrapFrame) {
 
 fn handle_page_fault(tf: &mut TrapFrame, access_flags: PageFaultFlags) {
     let vaddr = va!(stval::read());
-    if crate::trap::page_fault_handler(vaddr, access_flags) {
+    if crate::trap::call_page_fault_handler_with_parent_irqs(vaddr, access_flags, tf.sstatus.spie())
+    {
         return;
     }
     #[cfg(feature = "uspace")]

--- a/components/axcpu/src/trap.rs
+++ b/components/axcpu/src/trap.rs
@@ -19,6 +19,24 @@ pub fn page_fault_handler(addr: VirtAddr, flags: PageFaultFlags) -> bool {
     false
 }
 
+/// Invoke the page-fault slow path with the IRQ state restored to the
+/// faulting context.
+#[inline]
+pub(crate) fn call_page_fault_handler_with_parent_irqs(
+    addr: VirtAddr,
+    flags: PageFaultFlags,
+    parent_irqs_enabled: bool,
+) -> bool {
+    if parent_irqs_enabled {
+        crate::asm::enable_irqs();
+    }
+    let handled = page_fault_handler(addr, flags);
+    if parent_irqs_enabled {
+        crate::asm::disable_irqs();
+    }
+    handled
+}
+
 /// Breakpoint handler.
 ///
 /// The handler is invoked with a mutable reference to the trapped [`TrapFrame`]

--- a/components/axcpu/src/x86_64/trap.rs
+++ b/components/axcpu/src/x86_64/trap.rs
@@ -1,5 +1,5 @@
 use x86::{controlregs::cr2, irq::*};
-use x86_64::structures::idt::PageFaultErrorCode;
+use x86_64::{registers::rflags::RFlags, structures::idt::PageFaultErrorCode};
 
 use super::{TrapFrame, gdt};
 use crate::trap::PageFaultFlags;
@@ -20,7 +20,11 @@ fn handle_page_fault(tf: &mut TrapFrame) {
     let access_flags = err_code_to_flags(tf.error_code)
         .unwrap_or_else(|e| panic!("Invalid #PF error code: {:#x}", e));
     let vaddr = va!(unsafe { cr2() });
-    if crate::trap::page_fault_handler(vaddr, access_flags) {
+    if crate::trap::call_page_fault_handler_with_parent_irqs(
+        vaddr,
+        access_flags,
+        RFlags::from_bits_truncate(tf.rflags).contains(RFlags::INTERRUPT_FLAG),
+    ) {
         return;
     }
     #[cfg(feature = "uspace")]

--- a/components/kspin/src/base.rs
+++ b/components/kspin/src/base.rs
@@ -120,19 +120,17 @@ impl<G: BaseGuard, T> BaseSpinLock<G, T> {
 impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
     #[inline(always)]
     #[cfg(not(feature = "smp"))]
-    fn finish_lockdep_with_irqsave(lockdep: LockdepAcquire) {
+    fn finish_lockdep_with_irqsave(_lockdep: LockdepAcquire) {
         #[cfg(feature = "lockdep")]
         {
             let _lockdep_irq_guard = IrqSave::new();
-            lockdep.finish();
+            _lockdep.finish();
         }
-        #[cfg(not(feature = "lockdep"))]
-        let _ = lockdep;
     }
 
     #[inline(always)]
     #[cfg(feature = "smp")]
-    fn acquire_once_weak(&self, lockdep: LockdepAcquire) -> bool {
+    fn acquire_once_weak(&self, _lockdep: LockdepAcquire) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(feature = "lockdep")] {
                 let _lockdep_irq_guard = IrqSave::new();
@@ -141,7 +139,7 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
                     .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
                     .is_ok();
                 if acquired {
-                    lockdep.finish();
+                    _lockdep.finish();
                 }
                 acquired
             } else {
@@ -155,7 +153,7 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
 
     #[inline(always)]
     #[cfg(feature = "smp")]
-    fn acquire_once_strong(&self, lockdep: LockdepAcquire) -> bool {
+    fn acquire_once_strong(&self, _lockdep: LockdepAcquire) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(feature = "lockdep")] {
                 let _lockdep_irq_guard = IrqSave::new();
@@ -164,7 +162,7 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
                     .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
                     .is_ok();
                 if acquired {
-                    lockdep.finish();
+                    _lockdep.finish();
                 }
                 acquired
             } else {

--- a/components/kspin/src/base.rs
+++ b/components/kspin/src/base.rs
@@ -143,7 +143,7 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
                 }
                 acquired
             } else {
-                let _ = lockdep;
+                let _ = _lockdep;
                 self.lock
                     .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
                     .is_ok()
@@ -166,7 +166,7 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
                 }
                 acquired
             } else {
-                let _ = lockdep;
+                let _ = _lockdep;
                 self.lock
                     .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
                     .is_ok()

--- a/components/starry-signal/src/action.rs
+++ b/components/starry-signal/src/action.rs
@@ -25,9 +25,14 @@ pub enum DefaultSignalAction {
     Continue,
 }
 
-/// Signal action that should be properly handled by the OS.
+/// Result of delivering a pending signal.
 ///
-/// See [`SignalManager::check_signals`] for details.
+/// Indicates how the OS should continue handling the signal after one pending
+/// signal has been delivered. Some variants request further kernel action,
+/// while [`SignalOSAction::NoFurtherAction`] means delivery is already complete
+/// and execution can return to user space.
+///
+/// See [`ThreadSignalManager::check_signals`] for details.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SignalOSAction {
     /// Terminate the process.
@@ -38,9 +43,9 @@ pub enum SignalOSAction {
     Stop,
     /// Continue the process if stopped.
     Continue,
-    /// A signal handler is pushed into the signal stack. The OS doesn't need to
-    /// do anything.
-    Handler,
+    /// The user signal handler frame is installed. No further kernel action is
+    /// needed before returning to user space.
+    NoFurtherAction,
 }
 
 bitflags! {

--- a/components/starry-signal/src/api/process.rs
+++ b/components/starry-signal/src/api/process.rs
@@ -126,14 +126,25 @@ impl ProcessSignalManager {
         act: *const kernel_sigaction,
         oldact: *mut kernel_sigaction,
     ) -> AxResult<isize> {
-        let mut actions = self.actions.lock();
-        if let Some(oldact) = oldact.nullable() {
-            oldact.vm_write(actions[signo].clone().into())?;
-        }
-        if let Some(act) = act.nullable() {
+        let new_action = if let Some(act) = act.nullable() {
             let act = unsafe { act.vm_read_uninit()?.assume_init() }.into();
             debug!("sys_rt_sigaction <= signo: {signo:?}, act: {act:?}");
-            actions[signo] = act;
+            Some(act)
+        } else {
+            None
+        };
+
+        let old_action = {
+            let mut actions = self.actions.lock();
+            let old = actions[signo].clone();
+            if let Some(act) = new_action {
+                actions[signo] = act;
+            }
+            old
+        };
+
+        if let Some(oldact) = oldact.nullable() {
+            oldact.vm_write(old_action.into())?;
         }
         Ok(0)
     }

--- a/components/starry-signal/src/api/thread.rs
+++ b/components/starry-signal/src/api/thread.rs
@@ -35,7 +35,7 @@ struct PreparedSignalHandler {
     handler: usize,
     restorer: usize,
     add_blocked: SignalSet,
-    aligned_sp: usize,
+    use_sigaltstack: bool,
 }
 
 /// Thread-level signal manager.
@@ -83,10 +83,9 @@ impl ThreadSignalManager {
 
     fn prepare_signal(
         &self,
-        uctx: &UserContext,
         restore_blocked: SignalSet,
         sig: &SignalInfo,
-    ) -> PreparedSignal {
+    ) -> (bool, PreparedSignal) {
         let signo = sig.signo();
         debug!("Handle signal: {signo:?}");
         let action = {
@@ -97,27 +96,27 @@ impl ThreadSignalManager {
             }
             action
         };
+        let restartable = action.is_restartable();
 
         match action.disposition {
-            SignalDisposition::Default => match signo.default_action() {
-                DefaultSignalAction::Terminate => PreparedSignal::Action(SignalOSAction::Terminate),
-                DefaultSignalAction::CoreDump => PreparedSignal::Action(SignalOSAction::CoreDump),
-                DefaultSignalAction::Stop => PreparedSignal::Action(SignalOSAction::Stop),
-                DefaultSignalAction::Ignore => PreparedSignal::Ignore,
-                DefaultSignalAction::Continue => PreparedSignal::Action(SignalOSAction::Continue),
-            },
-            SignalDisposition::Ignore => PreparedSignal::Ignore,
+            SignalDisposition::Default => (
+                restartable,
+                match signo.default_action() {
+                    DefaultSignalAction::Terminate => {
+                        PreparedSignal::Action(SignalOSAction::Terminate)
+                    }
+                    DefaultSignalAction::CoreDump => {
+                        PreparedSignal::Action(SignalOSAction::CoreDump)
+                    }
+                    DefaultSignalAction::Stop => PreparedSignal::Action(SignalOSAction::Stop),
+                    DefaultSignalAction::Ignore => PreparedSignal::Ignore,
+                    DefaultSignalAction::Continue => {
+                        PreparedSignal::Action(SignalOSAction::Continue)
+                    }
+                },
+            ),
+            SignalDisposition::Ignore => (restartable, PreparedSignal::Ignore),
             SignalDisposition::Handler(handler) => {
-                let layout = Layout::new::<SignalFrame>();
-                let stack = self.stack.lock();
-                let sp = if stack.disabled() || !action.flags.contains(SignalActionFlags::ONSTACK) {
-                    uctx.sp()
-                } else {
-                    stack.sp + stack.size
-                };
-                drop(stack);
-
-                let aligned_sp = (sp - layout.size()) & !(layout.align() - 1);
                 let restorer = action
                     .restorer
                     .map_or(self.proc.default_restorer, |f| f as _);
@@ -126,15 +125,18 @@ impl ThreadSignalManager {
                     add_blocked.add(signo);
                 }
 
-                PreparedSignal::Handler(PreparedSignalHandler {
-                    signo,
-                    siginfo: sig.clone(),
-                    restore_blocked,
-                    handler: handler as usize,
-                    restorer,
-                    add_blocked,
-                    aligned_sp,
-                })
+                (
+                    restartable,
+                    PreparedSignal::Handler(PreparedSignalHandler {
+                        signo,
+                        siginfo: sig.clone(),
+                        restore_blocked,
+                        handler: handler as usize,
+                        restorer,
+                        add_blocked,
+                        use_sigaltstack: action.flags.contains(SignalActionFlags::ONSTACK),
+                    }),
+                )
             }
         }
     }
@@ -144,7 +146,19 @@ impl ThreadSignalManager {
         uctx: &mut UserContext,
         prepared: PreparedSignalHandler,
     ) -> SignalOSAction {
-        let frame_ptr = prepared.aligned_sp as *mut SignalFrame;
+        let layout = Layout::new::<SignalFrame>();
+        let sp = if prepared.use_sigaltstack {
+            let stack = self.stack.lock();
+            if stack.disabled() {
+                uctx.sp()
+            } else {
+                stack.sp + stack.size
+            }
+        } else {
+            uctx.sp()
+        };
+        let aligned_sp = (sp - layout.size()) & !(layout.align() - 1);
+        let frame_ptr = aligned_sp as *mut SignalFrame;
         if frame_ptr
             .vm_write(SignalFrame {
                 ucontext: UContext::new(uctx, prepared.restore_blocked),
@@ -157,10 +171,10 @@ impl ThreadSignalManager {
         }
 
         uctx.set_ip(prepared.handler);
-        uctx.set_sp(prepared.aligned_sp);
+        uctx.set_sp(aligned_sp);
         uctx.set_arg0(prepared.signo as _);
-        uctx.set_arg1(prepared.aligned_sp + offset_of!(SignalFrame, siginfo));
-        uctx.set_arg2(prepared.aligned_sp + offset_of!(SignalFrame, ucontext));
+        uctx.set_arg1(aligned_sp + offset_of!(SignalFrame, siginfo));
+        uctx.set_arg2(aligned_sp + offset_of!(SignalFrame, ucontext));
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -178,11 +192,15 @@ impl ThreadSignalManager {
     }
 
     #[cold]
-    fn check_signals_slow(
+    fn check_signals_slow_with<F>(
         &self,
         uctx: &mut UserContext,
         restore_blocked: Option<SignalSet>,
-    ) -> Option<(SignalInfo, SignalOSAction)> {
+        before_deliver: &mut F,
+    ) -> Option<(SignalInfo, SignalOSAction)>
+    where
+        F: FnMut(&mut UserContext, &SignalInfo, bool),
+    {
         let blocked = self.blocked.lock();
         let mask = !*blocked;
         let restore_blocked = restore_blocked.unwrap_or_else(|| *blocked);
@@ -196,15 +214,43 @@ impl ThreadSignalManager {
                     self.proc.dequeue_signal(&mask)
                 }
             }?;
-            match self.prepare_signal(uctx, restore_blocked, &sig) {
+            let (restartable, prepared) = self.prepare_signal(restore_blocked, &sig);
+            match prepared {
                 PreparedSignal::Ignore => continue,
-                PreparedSignal::Action(os_action) => break Some((sig, os_action)),
+                PreparedSignal::Action(os_action) => {
+                    before_deliver(uctx, &sig, restartable);
+                    break Some((sig, os_action));
+                }
                 PreparedSignal::Handler(prepared) => {
+                    before_deliver(uctx, &sig, restartable);
                     let os_action = self.install_signal_handler(uctx, prepared);
                     break Some((sig, os_action));
                 }
             }
         }
+    }
+
+    /// Checks pending signals and delivers one if possible.
+    ///
+    /// Calls `before_deliver` immediately before the selected signal is
+    /// delivered. The callback receives the user context, the delivered signal,
+    /// and whether its disposition is restartable.
+    pub fn check_signals_with<F>(
+        &self,
+        uctx: &mut UserContext,
+        restore_blocked: Option<SignalSet>,
+        mut before_deliver: F,
+    ) -> Option<(SignalInfo, SignalOSAction)>
+    where
+        F: FnMut(&mut UserContext, &SignalInfo, bool),
+    {
+        // Fast path
+        if !self.possibly_has_signal.load(Ordering::Acquire)
+            && !self.proc.possibly_has_signal.load(Ordering::Acquire)
+        {
+            return None;
+        }
+        self.check_signals_slow_with(uctx, restore_blocked, &mut before_deliver)
     }
 
     /// Checks pending signals and delivers one if possible.
@@ -215,13 +261,7 @@ impl ThreadSignalManager {
         uctx: &mut UserContext,
         restore_blocked: Option<SignalSet>,
     ) -> Option<(SignalInfo, SignalOSAction)> {
-        // Fast path
-        if !self.possibly_has_signal.load(Ordering::Acquire)
-            && !self.proc.possibly_has_signal.load(Ordering::Acquire)
-        {
-            return None;
-        }
-        self.check_signals_slow(uctx, restore_blocked)
+        self.check_signals_with(uctx, restore_blocked, |_, _, _| {})
     }
 
     /// Restores the signal frame. Called by `sigreturn`.

--- a/components/starry-signal/src/api/thread.rs
+++ b/components/starry-signal/src/api/thread.rs
@@ -174,7 +174,7 @@ impl ThreadSignalManager {
         uctx.set_ra(prepared.restorer);
 
         *self.blocked.lock() |= prepared.add_blocked;
-        SignalOSAction::Handler
+        SignalOSAction::NoFurtherAction
     }
 
     #[cold]
@@ -207,9 +207,9 @@ impl ThreadSignalManager {
         }
     }
 
-    /// Checks pending signals and handle them.
+    /// Checks pending signals and delivers one if possible.
     ///
-    /// Returns the signal number and the action the OS should take, if any.
+    /// Returns the delivered signal and its delivery result, if any.
     pub fn check_signals(
         &self,
         uctx: &mut UserContext,

--- a/components/starry-signal/src/api/thread.rs
+++ b/components/starry-signal/src/api/thread.rs
@@ -13,13 +13,29 @@ use starry_vm::{VmMutPtr, VmPtr};
 use super::ProcessSignalManager;
 use crate::{
     DefaultSignalAction, PendingSignals, SignalAction, SignalActionFlags, SignalDisposition,
-    SignalInfo, SignalOSAction, SignalSet, SignalStack, Signo, api::SignalActions, arch::UContext,
+    SignalInfo, SignalOSAction, SignalSet, SignalStack, Signo, arch::UContext,
 };
 
 struct SignalFrame {
     ucontext: UContext,
     siginfo: SignalInfo,
     uctx: UserContext,
+}
+
+enum PreparedSignal {
+    Ignore,
+    Action(SignalOSAction),
+    Handler(PreparedSignalHandler),
+}
+
+struct PreparedSignalHandler {
+    signo: Signo,
+    siginfo: SignalInfo,
+    restore_blocked: SignalSet,
+    handler: usize,
+    restorer: usize,
+    add_blocked: SignalSet,
+    aligned_sp: usize,
 }
 
 /// Thread-level signal manager.
@@ -65,25 +81,32 @@ impl ThreadSignalManager {
         &self.proc
     }
 
-    pub fn handle_signal(
+    fn prepare_signal(
         &self,
-        uctx: &mut UserContext,
+        uctx: &UserContext,
         restore_blocked: SignalSet,
         sig: &SignalInfo,
-        action: &SignalAction,
-        actions: &mut SignalActions,
-    ) -> Option<SignalOSAction> {
+    ) -> PreparedSignal {
         let signo = sig.signo();
         debug!("Handle signal: {signo:?}");
+        let action = {
+            let mut actions = self.proc.actions.lock();
+            let action = actions[signo].clone();
+            if action.flags.contains(SignalActionFlags::RESETHAND) {
+                actions[signo] = SignalAction::default();
+            }
+            action
+        };
+
         match action.disposition {
             SignalDisposition::Default => match signo.default_action() {
-                DefaultSignalAction::Terminate => Some(SignalOSAction::Terminate),
-                DefaultSignalAction::CoreDump => Some(SignalOSAction::CoreDump),
-                DefaultSignalAction::Stop => Some(SignalOSAction::Stop),
-                DefaultSignalAction::Ignore => None,
-                DefaultSignalAction::Continue => Some(SignalOSAction::Continue),
+                DefaultSignalAction::Terminate => PreparedSignal::Action(SignalOSAction::Terminate),
+                DefaultSignalAction::CoreDump => PreparedSignal::Action(SignalOSAction::CoreDump),
+                DefaultSignalAction::Stop => PreparedSignal::Action(SignalOSAction::Stop),
+                DefaultSignalAction::Ignore => PreparedSignal::Ignore,
+                DefaultSignalAction::Continue => PreparedSignal::Action(SignalOSAction::Continue),
             },
-            SignalDisposition::Ignore => None,
+            SignalDisposition::Ignore => PreparedSignal::Ignore,
             SignalDisposition::Handler(handler) => {
                 let layout = Layout::new::<SignalFrame>();
                 let stack = self.stack.lock();
@@ -95,51 +118,63 @@ impl ThreadSignalManager {
                 drop(stack);
 
                 let aligned_sp = (sp - layout.size()) & !(layout.align() - 1);
-
-                let frame_ptr = aligned_sp as *mut SignalFrame;
-                if frame_ptr
-                    .vm_write(SignalFrame {
-                        ucontext: UContext::new(uctx, restore_blocked),
-                        siginfo: sig.clone(),
-                        uctx: *uctx,
-                    })
-                    .is_err()
-                {
-                    return Some(SignalOSAction::CoreDump);
-                }
-
-                uctx.set_ip(handler as usize);
-                uctx.set_sp(aligned_sp);
-                uctx.set_arg0(signo as _);
-                uctx.set_arg1(aligned_sp + offset_of!(SignalFrame, siginfo));
-                uctx.set_arg2(aligned_sp + offset_of!(SignalFrame, ucontext));
-
                 let restorer = action
                     .restorer
                     .map_or(self.proc.default_restorer, |f| f as _);
-                #[cfg(target_arch = "x86_64")]
-                {
-                    let new_sp = uctx.sp() - 8;
-                    if (new_sp as *mut usize).vm_write(restorer).is_err() {
-                        return Some(SignalOSAction::CoreDump);
-                    }
-                    uctx.set_sp(new_sp);
-                }
-                #[cfg(not(target_arch = "x86_64"))]
-                uctx.set_ra(restorer);
-
                 let mut add_blocked = action.mask;
                 if !action.flags.contains(SignalActionFlags::NODEFER) {
                     add_blocked.add(signo);
                 }
 
-                if action.flags.contains(SignalActionFlags::RESETHAND) {
-                    actions[signo] = SignalAction::default();
-                }
-                *self.blocked.lock() |= add_blocked;
-                Some(SignalOSAction::Handler)
+                PreparedSignal::Handler(PreparedSignalHandler {
+                    signo,
+                    siginfo: sig.clone(),
+                    restore_blocked,
+                    handler: handler as usize,
+                    restorer,
+                    add_blocked,
+                    aligned_sp,
+                })
             }
         }
+    }
+
+    fn install_signal_handler(
+        &self,
+        uctx: &mut UserContext,
+        prepared: PreparedSignalHandler,
+    ) -> SignalOSAction {
+        let frame_ptr = prepared.aligned_sp as *mut SignalFrame;
+        if frame_ptr
+            .vm_write(SignalFrame {
+                ucontext: UContext::new(uctx, prepared.restore_blocked),
+                siginfo: prepared.siginfo,
+                uctx: *uctx,
+            })
+            .is_err()
+        {
+            return SignalOSAction::CoreDump;
+        }
+
+        uctx.set_ip(prepared.handler);
+        uctx.set_sp(prepared.aligned_sp);
+        uctx.set_arg0(prepared.signo as _);
+        uctx.set_arg1(prepared.aligned_sp + offset_of!(SignalFrame, siginfo));
+        uctx.set_arg2(prepared.aligned_sp + offset_of!(SignalFrame, ucontext));
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            let new_sp = uctx.sp() - 8;
+            if (new_sp as *mut usize).vm_write(prepared.restorer).is_err() {
+                return SignalOSAction::CoreDump;
+            }
+            uctx.set_sp(new_sp);
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        uctx.set_ra(prepared.restorer);
+
+        *self.blocked.lock() |= prepared.add_blocked;
+        SignalOSAction::Handler
     }
 
     #[cold]
@@ -147,7 +182,6 @@ impl ThreadSignalManager {
         &self,
         uctx: &mut UserContext,
         restore_blocked: Option<SignalSet>,
-        actions: &mut SignalActions,
     ) -> Option<(SignalInfo, SignalOSAction)> {
         let blocked = self.blocked.lock();
         let mask = !*blocked;
@@ -162,12 +196,13 @@ impl ThreadSignalManager {
                     self.proc.dequeue_signal(&mask)
                 }
             }?;
-            let action = actions[sig.signo()].clone();
-
-            if let Some(os_action) =
-                self.handle_signal(uctx, restore_blocked, &sig, &action, actions)
-            {
-                break Some((sig, os_action));
+            match self.prepare_signal(uctx, restore_blocked, &sig) {
+                PreparedSignal::Ignore => continue,
+                PreparedSignal::Action(os_action) => break Some((sig, os_action)),
+                PreparedSignal::Handler(prepared) => {
+                    let os_action = self.install_signal_handler(uctx, prepared);
+                    break Some((sig, os_action));
+                }
             }
         }
     }
@@ -180,16 +215,13 @@ impl ThreadSignalManager {
         uctx: &mut UserContext,
         restore_blocked: Option<SignalSet>,
     ) -> Option<(SignalInfo, SignalOSAction)> {
-        // Lock by `actions`
-        let mut actions = self.proc.actions.lock();
-
         // Fast path
         if !self.possibly_has_signal.load(Ordering::Acquire)
             && !self.proc.possibly_has_signal.load(Ordering::Acquire)
         {
             return None;
         }
-        self.check_signals_slow(uctx, restore_blocked, &mut actions)
+        self.check_signals_slow(uctx, restore_blocked)
     }
 
     /// Restores the signal frame. Called by `sigreturn`.

--- a/components/starry-signal/tests/api_thread.rs
+++ b/components/starry-signal/tests/api_thread.rs
@@ -33,17 +33,10 @@ fn handle_signal() {
     let initial = UserContext::new(0, initial_sp().into(), 0);
 
     let mut uctx = initial;
-    let restore_blocked = thr.blocked();
-    let action = proc.actions.lock()[signo].clone();
-    let result = thr.handle_signal(
-        &mut uctx,
-        restore_blocked,
-        &sig,
-        &action,
-        &mut proc.actions.lock(),
-    );
+    assert!(thr.send_signal(sig.clone()));
+    let (_si, result) = thr.check_signals(&mut uctx, None).unwrap();
 
-    assert_eq!(result, Some(SignalOSAction::Handler));
+    assert_eq!(result, SignalOSAction::Handler);
     assert_eq!(uctx.ip(), test_handler as *const () as usize);
     assert!(uctx.sp() < initial.sp());
     assert_eq!(uctx.arg0(), signo as usize);
@@ -112,15 +105,9 @@ fn restore() {
     let initial = UserContext::new(0x219, initial_sp().into(), 0);
 
     let mut uctx = initial;
-    let restore_blocked = thr.blocked();
-    let action = proc.actions.lock()[sig.signo()].clone();
-    thr.handle_signal(
-        &mut uctx,
-        restore_blocked,
-        &sig,
-        &action,
-        &mut proc.actions.lock(),
-    );
+    assert!(thr.send_signal(sig.clone()));
+    let (_si, action) = thr.check_signals(&mut uctx, None).unwrap();
+    assert_eq!(action, SignalOSAction::Handler);
 
     let new_sp = uctx.sp() + 8;
     uctx.set_sp(new_sp);

--- a/components/starry-signal/tests/api_thread.rs
+++ b/components/starry-signal/tests/api_thread.rs
@@ -36,7 +36,7 @@ fn handle_signal() {
     assert!(thr.send_signal(sig.clone()));
     let (_si, result) = thr.check_signals(&mut uctx, None).unwrap();
 
-    assert_eq!(result, SignalOSAction::Handler);
+    assert_eq!(result, SignalOSAction::NoFurtherAction);
     assert_eq!(uctx.ip(), test_handler as *const () as usize);
     assert!(uctx.sp() < initial.sp());
     assert_eq!(uctx.arg0(), signo as usize);
@@ -107,7 +107,7 @@ fn restore() {
     let mut uctx = initial;
     assert!(thr.send_signal(sig.clone()));
     let (_si, action) = thr.check_signals(&mut uctx, None).unwrap();
-    assert_eq!(action, SignalOSAction::Handler);
+    assert_eq!(action, SignalOSAction::NoFurtherAction);
 
     let new_sp = uctx.sp() + 8;
     uctx.set_sp(new_sp);

--- a/components/starry-signal/tests/api_thread.rs
+++ b/components/starry-signal/tests/api_thread.rs
@@ -1,5 +1,7 @@
 use ax_cpu::uspace::UserContext;
-use starry_signal::{SignalDisposition, SignalInfo, SignalOSAction, SignalSet, Signo};
+use starry_signal::{
+    SignalActionFlags, SignalDisposition, SignalInfo, SignalOSAction, SignalSet, Signo,
+};
 
 mod common;
 use common::*;
@@ -78,7 +80,7 @@ fn block_ignore_send_signal() {
 fn check_signals() {
     let (proc, thr) = new_test_env();
 
-    let mut uctx = UserContext::new(0, 0.into(), 0);
+    let mut uctx = UserContext::new(0, initial_sp().into(), 0);
 
     let signo = Signo::SIGTERM;
     let sig = SignalInfo::new_user(signo, 0, 1);
@@ -90,6 +92,34 @@ fn check_signals() {
     assert!(thr.send_signal(sig.clone()));
     let (si, _os_action) = thr.check_signals(&mut uctx, None).unwrap();
     assert_eq!(si.signo(), signo);
+}
+
+#[test]
+fn check_signals_with_reports_restartable_delivery() {
+    let (proc, thr) = new_test_env();
+
+    let mut uctx = UserContext::new(0, initial_sp().into(), 0);
+    let signo = Signo::SIGTERM;
+    let sig = SignalInfo::new_user(signo, 0, 1);
+    unsafe extern "C" fn test_handler(_: i32) {}
+
+    {
+        let mut actions = proc.actions.lock();
+        actions[signo].disposition = SignalDisposition::Handler(test_handler);
+        actions[signo].flags = SignalActionFlags::RESTART;
+    }
+
+    assert!(thr.send_signal(sig));
+    let mut observed = None;
+    let (si, os_action) = thr
+        .check_signals_with(&mut uctx, None, |_, delivered, restartable| {
+            observed = Some((delivered.signo(), restartable));
+        })
+        .unwrap();
+
+    assert_eq!(si.signo(), signo);
+    assert_eq!(os_action, SignalOSAction::NoFurtherAction);
+    assert_eq!(observed, Some((signo, true)));
 }
 
 #[test]

--- a/components/starry-signal/tests/concurrent.rs
+++ b/components/starry-signal/tests/concurrent.rs
@@ -97,7 +97,7 @@ fn concurrent_check_signals() {
 
     let (si, action) = thr.check_signals(&mut uctx, None).unwrap();
     assert_eq!(si.signo(), Signo::SIGTERM);
-    assert_eq!(action, SignalOSAction::Handler);
+    assert_eq!(action, SignalOSAction::NoFurtherAction);
     assert!(thr.signal_blocked(Signo::SIGTERM));
 
     thread::spawn({

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -10,9 +10,8 @@ use core::{
 use ax_errno::{AxError, AxResult};
 use ax_hal::{asm::user_copy, paging::MappingFlags, trap::page_fault_handler};
 use ax_io::prelude::*;
-use ax_kernel_guard::IrqSave;
 use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
-use ax_task::current;
+use ax_task::{current, might_sleep};
 use extern_trait::extern_trait;
 use starry_vm::{VmError, VmIo, VmResult, vm_load_until_nul, vm_read_slice, vm_write_slice};
 
@@ -23,7 +22,13 @@ use crate::{
 
 /// Enables scoped access into user memory, allowing page faults to occur inside
 /// kernel.
+#[track_caller]
 pub fn access_user_memory<R>(f: impl FnOnce() -> R) -> R {
+    assert!(
+        ax_hal::asm::irqs_enabled(),
+        "faultable user memory access requires IRQs enabled"
+    );
+
     let curr = current();
     let Some(thr) = curr.try_as_thread() else {
         panic!("access_user_memory called outside of thread context");
@@ -264,6 +269,7 @@ fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
         return false;
     }
 
+    might_sleep();
     thr.proc_data
         .aspace
         .lock()
@@ -276,8 +282,7 @@ pub fn vm_load_string(ptr: *const c_char) -> AxResult<String> {
     String::from_utf8(bytes).map_err(|_| AxError::IllegalBytes)
 }
 
-#[allow(dead_code)]
-struct Vm(IrqSave);
+struct Vm;
 
 /// Briefly checks if the given memory region is valid user memory.
 pub fn check_access(start: usize, len: usize) -> VmResult {
@@ -293,7 +298,7 @@ pub fn check_access(start: usize, len: usize) -> VmResult {
 #[extern_trait]
 unsafe impl VmIo for Vm {
     fn new() -> Self {
-        Self(IrqSave::new())
+        Self
     }
 
     fn read(&mut self, start: usize, buf: &mut [MaybeUninit<u8>]) -> VmResult {

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -74,7 +74,7 @@ pub fn check_signals(
         SignalOSAction::CoreDump => do_exit(128 + signo as i32, true),
         SignalOSAction::Stop => do_exit(1, true),
         SignalOSAction::Continue => {}
-        SignalOSAction::Handler => {}
+        SignalOSAction::NoFurtherAction => {}
     }
     true
 }

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -4,7 +4,7 @@ use ax_errno::{AxError, AxResult};
 use ax_hal::uspace::UserContext;
 use ax_task::{TaskInner, current};
 use starry_process::Pid;
-use starry_signal::{SignalActionFlags, SignalInfo, SignalOSAction, SignalSet};
+use starry_signal::{SignalInfo, SignalOSAction, SignalSet};
 
 use super::{
     AsThread, SYSCALL_INSN_LEN, Thread, do_exit, get_process_data, get_process_group, get_task,
@@ -26,48 +26,36 @@ pub fn check_signals(
     restore_blocked: Option<SignalSet>,
     restart_info: Option<&SyscallRestartInfo>,
 ) -> bool {
-    let blocked = thr.signal.blocked();
-    let mask = !blocked;
-    let restore_blocked = restore_blocked.unwrap_or(blocked);
-
-    let Some(sig) = thr.signal.dequeue_signal(&mask) else {
+    let Some((sig, os_action)) =
+        thr.signal
+            .check_signals_with(uctx, restore_blocked, |uctx, _sig, restartable| {
+                // Apply the SA_RESTART decision once per interrupted syscall.
+                // Callers pass `Some(info)` only for the first delivered signal;
+                // later iterations pass `None`, so the restart adjustment remains
+                // single-shot.
+                if let Some(info) = restart_info
+                    && (uctx.retval() as isize) == -(ax_errno::LinuxError::EINTR.code() as isize)
+                    && restartable
+                {
+                    let new_ip = uctx.ip() - SYSCALL_INSN_LEN;
+                    uctx.set_ip(new_ip);
+                    uctx.set_arg0(info.saved_a0);
+                    // On x86_64, rax holds both the syscall number and the return
+                    // value, so the syscall entry path clobbered sysno with -EINTR.
+                    // Restore it before the syscall instruction re-executes. On
+                    // RISC-V/AArch64/LoongArch64 sysno lives in a separate register
+                    // (a7/x8/a7) that was not touched, so no restore is needed.
+                    #[cfg(target_arch = "x86_64")]
+                    uctx.set_sysno(info.saved_sysno);
+                    #[cfg(not(target_arch = "x86_64"))]
+                    let _ = info.saved_sysno;
+                }
+            })
+    else {
         return false;
     };
 
     let signo = sig.signo();
-    let mut actions = thr.signal.process().actions.lock();
-    let action = actions[signo].clone();
-
-    // Apply the SA_RESTART decision once per interrupted syscall. Callers
-    // pass `Some(info)` only for the first signal delivered; for later
-    // iterations they pass `None` so a second signal cannot reapply the
-    // decision. When SA_RESTART is not set we leave retval at -EINTR so
-    // handle_signal captures it into the signal frame and sigreturn
-    // restores -EINTR to user space (non-restart semantics).
-    if let Some(info) = restart_info
-        && (uctx.retval() as isize) == -(ax_errno::LinuxError::EINTR.code() as isize)
-        && action.flags.contains(SignalActionFlags::RESTART)
-    {
-        let new_ip = uctx.ip() - SYSCALL_INSN_LEN;
-        uctx.set_ip(new_ip);
-        uctx.set_arg0(info.saved_a0);
-        // On x86_64, rax holds both the syscall number and the return
-        // value, so the syscall entry path clobbered sysno with -EINTR.
-        // Restore it before the syscall instruction re-executes. On
-        // RISC-V/AArch64/LoongArch64 sysno lives in a separate register
-        // (a7/x8/a7) that was not touched, so no restore is needed.
-        #[cfg(target_arch = "x86_64")]
-        uctx.set_sysno(info.saved_sysno);
-        #[cfg(not(target_arch = "x86_64"))]
-        let _ = info.saved_sysno;
-    }
-
-    let Some(os_action) =
-        thr.signal
-            .handle_signal(uctx, restore_blocked, &sig, &action, &mut actions)
-    else {
-        return true;
-    };
 
     match os_action {
         SignalOSAction::Terminate => do_exit(signo as i32, true),

--- a/os/arceos/modules/axsync/Cargo.toml
+++ b/os/arceos/modules/axsync/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [features]
 multitask = ["ax-task/multitask"]
+lockdep = ["multitask", "ax-task/lockdep"]
 default = []
 
 [dependencies]

--- a/os/arceos/modules/axsync/src/lib.rs
+++ b/os/arceos/modules/axsync/src/lib.rs
@@ -42,6 +42,10 @@ fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
 }
 
 #[cfg(feature = "multitask")]
+#[cfg(feature = "lockdep")]
+mod lockdep;
+
+#[cfg(feature = "multitask")]
 mod mutex;
 
 #[cfg(not(feature = "multitask"))]

--- a/os/arceos/modules/axsync/src/lockdep.rs
+++ b/os/arceos/modules/axsync/src/lockdep.rs
@@ -1,0 +1,263 @@
+use core::{
+    cell::UnsafeCell,
+    panic::Location,
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+};
+
+use ax_task::HeldLock;
+
+use crate::mutex::RawMutex;
+
+const MAX_LOCKS: usize = 1024;
+const WORDS_PER_ROW: usize = MAX_LOCKS.div_ceil(64);
+type LockdepState = (u32, &'static Location<'static>);
+
+pub(crate) struct LockdepMap {
+    id: AtomicU32,
+}
+
+impl LockdepMap {
+    pub(crate) const fn new() -> Self {
+        Self {
+            id: AtomicU32::new(0),
+        }
+    }
+
+    pub(crate) fn lock_id(&self) -> Option<u32> {
+        match self.id.load(Ordering::Acquire) {
+            0 => None,
+            id => Some(id),
+        }
+    }
+}
+
+impl Default for LockdepMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct LockGraph {
+    // Reachability encodes the observed "A before B" mutex ordering graph.
+    reachability: [[u64; WORDS_PER_ROW]; MAX_LOCKS],
+}
+
+impl LockGraph {
+    const fn new() -> Self {
+        Self {
+            reachability: [[0; WORDS_PER_ROW]; MAX_LOCKS],
+        }
+    }
+
+    fn reaches(&self, from: u32, to: u32) -> bool {
+        let Some(row) = self.reachability.get(from as usize) else {
+            return false;
+        };
+        let word = (to as usize) / 64;
+        let bit = (to as usize) % 64;
+        row.get(word)
+            .is_some_and(|entry| (*entry & (1u64 << bit)) != 0)
+    }
+
+    fn add_order(&mut self, before: u32, after: u32, max_id: u32) {
+        let mut closure = self.reachability[after as usize];
+        let word = (after as usize) / 64;
+        let bit = (after as usize) % 64;
+        closure[word] |= 1u64 << bit;
+
+        for row in 1..max_id {
+            if row == before || self.reaches(row, before) {
+                for (slot, extra) in self.reachability[row as usize].iter_mut().zip(closure) {
+                    *slot |= extra;
+                }
+            }
+        }
+    }
+
+    fn assert_can_acquire(
+        &self,
+        held_locks: &ax_task::HeldLockStack,
+        lock_id: u32,
+        addr: usize,
+        caller: &'static Location<'static>,
+    ) {
+        // Sleeping locks are tracked per task, not per CPU: the owner may be
+        // rescheduled or migrated while still holding the mutex.
+        assert!(
+            !held_locks.contains(lock_id),
+            "lockdep: recursive mutex acquisition detected for id={} addr={:#x} at {} with held \
+             stack {:?}",
+            lock_id,
+            addr,
+            caller,
+            held_locks
+        );
+
+        for held in held_locks.iter() {
+            assert!(
+                !self.reaches(lock_id, held.id),
+                "lockdep: lock order inversion detected while acquiring id={} addr={:#x} at {}; \
+                 held lock {:?}; stack {:?}",
+                lock_id,
+                addr,
+                caller,
+                held,
+                held_locks
+            );
+        }
+    }
+
+    fn record_acquire(
+        &mut self,
+        held_locks: &mut ax_task::HeldLockStack,
+        lock_id: u32,
+        addr: usize,
+        caller: &'static Location<'static>,
+        max_id: u32,
+    ) {
+        // Snapshot the currently held mutexes before pushing the new one so we
+        // record edges from the previous lock set to this acquisition.
+        let snapshot = *held_locks;
+        for held in snapshot.iter() {
+            self.add_order(held.id, lock_id, max_id);
+        }
+
+        held_locks.push(HeldLock {
+            id: lock_id,
+            addr,
+            caller,
+        });
+    }
+}
+
+struct GraphState {
+    lock: AtomicBool,
+    graph: UnsafeCell<LockGraph>,
+}
+
+unsafe impl Sync for GraphState {}
+
+struct GraphGuard;
+
+impl GraphGuard {
+    fn acquire() -> Self {
+        while GRAPH_STATE
+            .lock
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            while GRAPH_STATE.lock.load(Ordering::Acquire) {
+                core::hint::spin_loop();
+            }
+        }
+        Self
+    }
+}
+
+impl Drop for GraphGuard {
+    fn drop(&mut self) {
+        GRAPH_STATE.lock.store(false, Ordering::Release);
+    }
+}
+
+static NEXT_LOCK_ID: AtomicU32 = AtomicU32::new(1);
+
+static GRAPH_STATE: GraphState = GraphState {
+    lock: AtomicBool::new(false),
+    graph: UnsafeCell::new(LockGraph::new()),
+};
+
+fn with_graph<R>(f: impl FnOnce(&mut LockGraph) -> R) -> R {
+    let _guard = GraphGuard::acquire();
+
+    // SAFETY: protected by the global graph spinlock above.
+    let graph = unsafe { &mut *GRAPH_STATE.graph.get() };
+    f(graph)
+}
+
+fn current_max_lock_id() -> u32 {
+    NEXT_LOCK_ID.load(Ordering::Acquire).min(MAX_LOCKS as u32)
+}
+
+fn ensure_lock_id(map: &LockdepMap) -> u32 {
+    let existing = map.id.load(Ordering::Acquire);
+    if existing != 0 {
+        return existing;
+    }
+
+    let _guard = GraphGuard::acquire();
+
+    let existing = map.id.load(Ordering::Acquire);
+    if existing != 0 {
+        return existing;
+    }
+
+    let new_id = NEXT_LOCK_ID.fetch_add(1, Ordering::AcqRel);
+    assert!(
+        (new_id as usize) < MAX_LOCKS,
+        "lockdep: exceeded maximum tracked mutex instances ({MAX_LOCKS})"
+    );
+
+    map.id.store(new_id, Ordering::Release);
+    new_id
+}
+
+fn prepare_acquire(
+    map: &LockdepMap,
+    addr: usize,
+    caller: &'static Location<'static>,
+) -> LockdepState {
+    let lock_id = ensure_lock_id(map);
+
+    with_graph(|graph| {
+        // Validate against the task-local held-lock stack before the mutex is
+        // actually acquired so failed acquisitions do not mutate lockdep state.
+        ax_task::with_current_lockdep_stack(|stack| {
+            graph.assert_can_acquire(stack, lock_id, addr, caller)
+        });
+    });
+
+    (lock_id, caller)
+}
+
+fn finish_acquire(lockdep: LockdepState, addr: usize) {
+    let (lock_id, caller) = lockdep;
+    let max_id = current_max_lock_id();
+
+    with_graph(|graph| {
+        ax_task::with_current_lockdep_stack(|stack| {
+            graph.record_acquire(stack, lock_id, addr, caller, max_id);
+        });
+    });
+}
+
+pub(crate) struct LockdepAcquire {
+    addr: usize,
+    state: LockdepState,
+}
+
+impl LockdepAcquire {
+    #[inline(always)]
+    #[track_caller]
+    pub(crate) fn prepare(lock: &RawMutex) -> Self {
+        let addr = lock as *const _ as *const () as usize;
+        let state = prepare_acquire(&lock.lockdep, addr, Location::caller());
+        Self { addr, state }
+    }
+
+    #[inline(always)]
+    pub(crate) fn finish(self) {
+        finish_acquire(self.state, self.addr);
+    }
+}
+
+#[inline(always)]
+pub(crate) fn release(lock: &RawMutex) {
+    let Some(lock_id) = lock.lockdep.lock_id() else {
+        return;
+    };
+
+    // RawMutex is non-recursive and ownership is task-based, so release is a
+    // simple pop from the current task's held-lock stack.
+    ax_task::with_current_lockdep_stack(|stack| stack.pop_checked(lock_id));
+}

--- a/os/arceos/modules/axsync/src/mutex.rs
+++ b/os/arceos/modules/axsync/src/mutex.rs
@@ -2,7 +2,7 @@
 
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use ax_task::{WaitQueue, current};
+use ax_task::{WaitQueue, current, might_sleep};
 
 /// A [`lock_api::RawMutex`] implementation.
 ///
@@ -13,6 +13,8 @@ use ax_task::{WaitQueue, current};
 pub struct RawMutex {
     wq: WaitQueue,
     owner_id: AtomicU64,
+    #[cfg(feature = "lockdep")]
+    pub(crate) lockdep: crate::lockdep::LockdepMap,
 }
 
 impl RawMutex {
@@ -22,6 +24,8 @@ impl RawMutex {
         Self {
             wq: WaitQueue::new(),
             owner_id: AtomicU64::new(0),
+            #[cfg(feature = "lockdep")]
+            lockdep: crate::lockdep::LockdepMap::new(),
         }
     }
 
@@ -50,7 +54,10 @@ unsafe impl lock_api::RawMutex for RawMutex {
 
     #[inline(always)]
     fn lock(&self) {
+        might_sleep();
         let current_id = current().id().as_u64();
+        #[cfg(feature = "lockdep")]
+        let lockdep = crate::lockdep::LockdepAcquire::prepare(self);
 
         loop {
             // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
@@ -77,16 +84,28 @@ unsafe impl lock_api::RawMutex for RawMutex {
                 }
             }
         }
+
+        #[cfg(feature = "lockdep")]
+        lockdep.finish();
     }
 
     #[inline(always)]
     fn try_lock(&self) -> bool {
+        might_sleep();
         let current_id = current().id().as_u64();
+        #[cfg(feature = "lockdep")]
+        let lockdep = crate::lockdep::LockdepAcquire::prepare(self);
         // The reason for using a strong compare_exchange is explained here:
         // https://github.com/Amanieu/parking_lot/pull/207#issuecomment-575869107
-        self.owner_id
+        let acquired = self
+            .owner_id
             .compare_exchange(0, current_id, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
+            .is_ok();
+        #[cfg(feature = "lockdep")]
+        if acquired {
+            lockdep.finish();
+        }
+        acquired
     }
 
     #[inline(always)]
@@ -101,6 +120,8 @@ unsafe impl lock_api::RawMutex for RawMutex {
         self.wq.notify_one_with(true, |id: u64| {
             self.owner_id.swap(id, Ordering::Release);
         });
+        #[cfg(feature = "lockdep")]
+        crate::lockdep::release(self);
     }
 
     #[inline(always)]
@@ -116,13 +137,31 @@ pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawMutex, T>;
 
 #[cfg(all(test, not(target_os = "none")))]
 mod tests {
-    use std::sync::Once;
+    use std::sync::{Mutex as StdMutex, Once, OnceLock};
 
     use ax_task as thread;
 
     use crate::Mutex;
 
     static INIT: Once = Once::new();
+    static TEST_LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+
+    fn init_test_scheduler() {
+        INIT.call_once(thread::init_scheduler);
+    }
+
+    fn lock_test_context() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK
+            .get_or_init(|| StdMutex::new(()))
+            .lock()
+            .expect("test serialization mutex poisoned")
+    }
+
+    fn with_test_context<R>(f: impl FnOnce() -> R) -> R {
+        let _test_guard = lock_test_context();
+        init_test_scheduler();
+        f()
+    }
 
     fn may_interrupt() {
         // simulate interrupts
@@ -133,39 +172,110 @@ mod tests {
 
     #[test]
     fn lots_and_lots() {
-        INIT.call_once(thread::init_scheduler);
+        with_test_context(|| {
+            const NUM_TASKS: u32 = 10;
+            const NUM_ITERS: u32 = 10_000;
+            static M: Mutex<u32> = Mutex::new(0);
 
-        const NUM_TASKS: u32 = 10;
-        const NUM_ITERS: u32 = 10_000;
-        static M: Mutex<u32> = Mutex::new(0);
+            fn inc(delta: u32) {
+                for _ in 0..NUM_ITERS {
+                    let mut val = M.lock();
+                    *val += delta;
+                    may_interrupt();
+                    drop(val);
+                    may_interrupt();
+                }
+            }
 
-        fn inc(delta: u32) {
-            for _ in 0..NUM_ITERS {
-                let mut val = M.lock();
-                *val += delta;
+            for _ in 0..NUM_TASKS {
+                thread::spawn(|| inc(1));
+                thread::spawn(|| inc(2));
+            }
+
+            println!("spawn OK");
+            loop {
+                let val = M.lock();
+                if *val == NUM_ITERS * NUM_TASKS * 3 {
+                    break;
+                }
                 may_interrupt();
                 drop(val);
                 may_interrupt();
             }
+
+            assert_eq!(*M.lock(), NUM_ITERS * NUM_TASKS * 3);
+            println!("Mutex test OK");
+        });
+    }
+
+    #[cfg(feature = "lockdep")]
+    mod lockdep_tests {
+        use core::mem::ManuallyDrop;
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        use super::*;
+
+        fn reset_lockdep_stack() {
+            thread::with_current_lockdep_stack(|stack| *stack = thread::HeldLockStack::new());
         }
 
-        for _ in 0..NUM_TASKS {
-            thread::spawn(|| inc(1));
-            thread::spawn(|| inc(2));
+        fn with_lockdep_test<R>(f: impl FnOnce() -> R) -> R {
+            with_test_context(|| {
+                reset_lockdep_stack();
+                let result = f();
+                reset_lockdep_stack();
+                result
+            })
         }
 
-        println!("spawn OK");
-        loop {
-            let val = M.lock();
-            if *val == NUM_ITERS * NUM_TASKS * 3 {
-                break;
-            }
-            may_interrupt();
-            drop(val);
-            may_interrupt();
+        fn assert_lockdep_failure(f: impl FnOnce()) {
+            let result = catch_unwind(AssertUnwindSafe(f));
+            assert!(result.is_err());
+            reset_lockdep_stack();
         }
 
-        assert_eq!(*M.lock(), NUM_ITERS * NUM_TASKS * 3);
-        println!("Mutex test OK");
+        #[test]
+        fn rejects_recursive_acquire() {
+            with_lockdep_test(|| {
+                let lock = Mutex::new(0usize);
+                assert_lockdep_failure(|| {
+                    let _guard = lock.lock();
+                    let _guard2 = lock.lock();
+                });
+            });
+        }
+
+        #[test]
+        fn rejects_order_inversion() {
+            with_lockdep_test(|| {
+                let lock_a = Mutex::new(0usize);
+                let lock_b = Mutex::new(0usize);
+
+                {
+                    let _guard_a = lock_a.lock();
+                    let _guard_b = lock_b.lock();
+                }
+
+                let guard_b = ManuallyDrop::new(lock_b.lock());
+                assert_lockdep_failure(|| {
+                    let _guard_a = lock_a.lock();
+                });
+                core::mem::forget(guard_b);
+            });
+        }
+
+        #[test]
+        fn rejects_out_of_order_unlock() {
+            with_lockdep_test(|| {
+                let lock_a = Mutex::new(0usize);
+                let lock_b = Mutex::new(0usize);
+
+                let guard_a = lock_a.lock();
+                let guard_b = ManuallyDrop::new(lock_b.lock());
+
+                assert_lockdep_failure(|| drop(guard_a));
+                core::mem::forget(guard_b);
+            });
+        }
     }
 }

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -27,6 +27,7 @@ multitask = [
 ]
 preempt = ["irq", "ax-percpu?/preempt", "ax-kernel-guard/preempt"]
 smp = ["ax-kspin/smp"]
+lockdep = ["multitask"]
 task-ext = ["dep:extern-trait"]
 tls = ["ax-hal/tls"]
 

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -7,6 +7,8 @@ use alloc::{
 
 use ax_kernel_guard::NoPreemptIrqSave;
 
+#[cfg(feature = "lockdep")]
+pub use crate::lockdep::{HeldLock, HeldLockStack};
 pub(crate) use crate::run_queue::{current_run_queue, select_run_queue};
 #[cfg_attr(doc, doc(cfg(all(feature = "multitask", feature = "task-ext"))))]
 #[cfg(feature = "task-ext")]
@@ -76,6 +78,11 @@ pub fn current_may_uninit() -> Option<CurrentTask> {
 /// Panics if the current task is not initialized.
 pub fn current() -> CurrentTask {
     CurrentTask::get()
+}
+
+#[cfg(feature = "lockdep")]
+pub fn with_current_lockdep_stack<R>(f: impl FnOnce(&mut HeldLockStack) -> R) -> R {
+    current().with_held_locks(f)
 }
 
 /// Initializes the task scheduler (for the primary CPU).
@@ -292,7 +299,7 @@ pub(crate) fn in_atomic_context() -> bool {
 ///
 /// Panics if it is executed in an atomic context.
 #[track_caller]
-pub(crate) fn might_sleep() {
+pub fn might_sleep() {
     if in_atomic_context() {
         panic!(
             "sleeping or rescheduling is not allowed in atomic context: irq_enabled={}, \

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -66,6 +66,8 @@ cfg_if::cfg_if! {
         mod run_queue;
         mod task;
         mod api;
+        #[cfg(feature = "lockdep")]
+        mod lockdep;
         mod wait_queue;
 
         #[cfg(feature = "irq")]

--- a/os/arceos/modules/axtask/src/lockdep.rs
+++ b/os/arceos/modules/axtask/src/lockdep.rs
@@ -1,0 +1,87 @@
+use core::{fmt, panic::Location};
+
+const MAX_HELD_LOCKS: usize = 32;
+
+#[derive(Clone, Copy)]
+pub struct HeldLock {
+    pub id: u32,
+    pub addr: usize,
+    pub caller: &'static Location<'static>,
+}
+
+impl fmt::Debug for HeldLock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HeldLock")
+            .field("id", &self.id)
+            .field("addr", &format_args!("{:#x}", self.addr))
+            .field("caller", &self.caller)
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct HeldLockStack {
+    len: usize,
+    entries: [Option<HeldLock>; MAX_HELD_LOCKS],
+}
+
+impl HeldLockStack {
+    pub const fn new() -> Self {
+        Self {
+            len: 0,
+            entries: [None; MAX_HELD_LOCKS],
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = HeldLock> + '_ {
+        self.entries[..self.len]
+            .iter()
+            .map(|slot| slot.expect("held lock stack contains empty slot"))
+    }
+
+    pub fn contains(&self, id: u32) -> bool {
+        self.iter().any(|held| held.id == id)
+    }
+
+    pub fn push(&mut self, held: HeldLock) {
+        assert!(
+            self.len < MAX_HELD_LOCKS,
+            "lockdep: held lock stack overflow while acquiring {:?}",
+            held
+        );
+        self.entries[self.len] = Some(held);
+        self.len += 1;
+    }
+
+    pub fn pop_checked(&mut self, id: u32) {
+        assert!(
+            self.len != 0,
+            "lockdep: releasing lock {id} with empty held lock stack"
+        );
+        let top = self.entries[self.len - 1]
+            .expect("held lock stack top unexpectedly empty during release");
+        assert_eq!(
+            top.id, id,
+            "lockdep: unlock order violation, releasing id={} while top of stack is {:?}",
+            id, top
+        );
+        self.entries[self.len - 1] = None;
+        self.len -= 1;
+    }
+}
+
+impl Default for HeldLockStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for HeldLockStack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut list = f.debug_list();
+        for held in self.iter() {
+            list.entry(&held);
+        }
+        list.finish()
+    }
+}

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -19,6 +19,8 @@ use ax_kspin::SpinNoIrq;
 use ax_memory_addr::{VirtAddr, align_up_4k};
 use futures_util::task::AtomicWaker;
 
+#[cfg(feature = "lockdep")]
+use crate::lockdep::HeldLockStack;
 use crate::{AxCpuMask, AxTask, AxTaskRef, WaitQueue};
 
 /// A unique identifier for a thread.
@@ -94,6 +96,8 @@ pub struct TaskInner {
 
     kstack: Option<TaskStack>,
     ctx: UnsafeCell<TaskContext>,
+    #[cfg(feature = "lockdep")]
+    held_locks: UnsafeCell<HeldLockStack>,
 
     #[cfg(feature = "task-ext")]
     task_ext: Option<AxTaskExt>,
@@ -203,6 +207,13 @@ impl TaskInner {
         self.ctx.get_mut()
     }
 
+    #[cfg(feature = "lockdep")]
+    pub(crate) fn with_held_locks<R>(&self, f: impl FnOnce(&mut HeldLockStack) -> R) -> R {
+        // SAFETY: the held-lock stack belongs to the current task and is only
+        // mutated by the current task while lockdep tracking is active.
+        f(unsafe { &mut *self.held_locks.get() })
+    }
+
     /// Returns the top address of the kernel stack.
     #[inline]
     pub const fn kernel_stack_top(&self) -> Option<VirtAddr> {
@@ -290,6 +301,8 @@ impl TaskInner {
             wait_for_exit: WaitQueue::new(),
             kstack: None,
             ctx: UnsafeCell::new(TaskContext::new()),
+            #[cfg(feature = "lockdep")]
+            held_locks: UnsafeCell::new(HeldLockStack::new()),
             #[cfg(feature = "task-ext")]
             task_ext: None,
             #[cfg(feature = "tls")]

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -44,6 +44,7 @@ ax-mm
 ax-riscv-plic
 ax-sched
 ax-sync
+ax-task
 ax-timer-list
 axbacktrace
 axbuild

--- a/test-suit/arceos/rust/task/irq/src/main.rs
+++ b/test-suit/arceos/rust/task/irq/src/main.rs
@@ -44,11 +44,11 @@ fn test_yielding() {
                 assert_irq_enabled_and_disabled();
             }
 
-            let _ = YIELDING_FINISHED_TASKS.fetch_add(1, Ordering::Relaxed);
+            let _ = YIELDING_FINISHED_TASKS.fetch_add(1, Ordering::Release);
         });
     }
 
-    while YIELDING_FINISHED_TASKS.load(Ordering::Relaxed) < NUM_TASKS {
+    while YIELDING_FINISHED_TASKS.load(Ordering::Acquire) < NUM_TASKS {
         thread::yield_now();
         assert_irq_enabled_and_disabled();
     }
@@ -85,11 +85,11 @@ fn test_sleep() {
                 thread::sleep(Duration::from_secs(sec as _));
                 assert_irq_enabled_and_disabled();
             }
-            SLEEP_FINISHED_TASKS.fetch_add(1, Ordering::Relaxed);
+            SLEEP_FINISHED_TASKS.fetch_add(1, Ordering::Release);
         });
     }
 
-    while SLEEP_FINISHED_TASKS.load(Ordering::Relaxed) < NUM_TASKS {
+    while SLEEP_FINISHED_TASKS.load(Ordering::Acquire) < NUM_TASKS {
         thread::sleep(Duration::from_millis(10));
     }
     println!("IRQ state tests on task sleep run OK!");
@@ -117,31 +117,33 @@ fn test_wait_queue() {
             WQ3.wait_timeout_until(std::time::Duration::from_millis(100), || false);
             assert_irq_enabled_and_disabled();
 
-            COUNTER.fetch_add(1, Ordering::Relaxed);
+            // Use release/acquire synchronization here because the wait-queue
+            // handshake runs across CPUs on weakly ordered architectures.
+            COUNTER.fetch_add(1, Ordering::Release);
             WQ1.notify_one(true); // WQ1.wait_until()
             assert_irq_enabled();
             WQ2.wait_until(|| GO.load(Ordering::Acquire));
 
             assert_irq_enabled_and_disabled();
 
-            COUNTER.fetch_sub(1, Ordering::Relaxed);
+            COUNTER.fetch_sub(1, Ordering::Release);
             WQ1.notify_one(true); // WQ1.wait_until()
         });
     }
     assert_irq_enabled();
 
-    WQ1.wait_until(|| COUNTER.load(Ordering::Relaxed) == NUM_TASKS);
+    WQ1.wait_until(|| COUNTER.load(Ordering::Acquire) == NUM_TASKS);
 
     assert_irq_enabled_and_disabled();
 
-    assert_eq!(COUNTER.load(Ordering::Relaxed), NUM_TASKS);
+    assert_eq!(COUNTER.load(Ordering::Acquire), NUM_TASKS);
     GO.store(true, Ordering::Release);
     WQ2.notify_all(true); // WQ2.wait_until()
 
     assert_irq_enabled();
-    WQ1.wait_until(|| COUNTER.load(Ordering::Relaxed) == 0);
+    WQ1.wait_until(|| COUNTER.load(Ordering::Acquire) == 0);
     assert_irq_enabled_and_disabled();
-    assert_eq!(COUNTER.load(Ordering::Relaxed), 0);
+    assert_eq!(COUNTER.load(Ordering::Acquire), 0);
 
     println!("IRQ state tests on task wait run OK!");
 }

--- a/test-suit/starryos/stress/stress-ng-0/qemu-riscv64.toml
+++ b/test-suit/starryos/stress/stress-ng-0/qemu-riscv64.toml
@@ -13,7 +13,7 @@ args = [
 ]
 uefi = false
 to_bin = true
-shell_prefix = "starry:~#"
+shell_prefix = "root@starry:"
 shell_init_cmd = '''
 apk update && \
 apk add stress-ng && \


### PR DESCRIPTION
## Summary

Enabling mutex lockdep exposed several Starry paths that mixed sleepable locks or faultable user-memory accesses with atomic contexts.

  The follow-up commits address six concrete issues:

  1. The Starry user page-fault slow path could run under the wrong IRQ state instead of the IRQ state of the faulting
     context.
  2. starry-signal was refactored to avoid touching user memory while holding spin locks, which changed the signal delivery
     flow and required kernel-side consumers to adapt.
  3. The riscv64 Starry stress test expected the wrong shell prompt, causing a false test failure.
  4. Several lockdep and signal-related tests no longer built cleanly after the lockdep and signal changes landed.
  5. The no-op signal delivery result in starry-signal was renamed to make its meaning explicit.
  6. After the signal API/refactor changes above, the Starry kernel signal path still tried to use the old integration path,
     which broke Starry builds in the test flow; this PR restores that integration while preserving SA_RESTART handling.

