### PR TITLE
feat(axbuild): add first-phase sync-lint checks for atomic ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,14 @@ jobs:
             container_image: ghcr.io/${{ github.repository }}-container:latest
             required_repository_owner: ""
             main_pr_only: false
+          - name: Run sync-lint
+            use_container: true
+            runs_on: '["ubuntu-latest"]'
+            command: cargo xtask sync-lint
+            cache_key: sync-lint
+            container_image: ghcr.io/${{ github.repository }}-container:latest
+            required_repository_owner: ""
+            main_pr_only: false
           - name: Test with std
             use_container: true
             runs_on: '["ubuntu-latest"]'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,12 +1546,14 @@ dependencies = [
  "log",
  "object 0.38.1",
  "ostool",
+ "proc-macro2",
  "regex",
  "reqwest 0.13.2",
  "schemars",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "syn 2.0.117",
  "tar",
  "tempfile",
  "tokio",
@@ -1559,6 +1561,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "walkdir",
  "xz2",
 ]
 

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -48,6 +48,7 @@ sidebar_label: "贡献指南"
 - 遵循 [Rust 官方代码风格](https://rust-lang.github.io/api-guidelines/)
 - 使用 `cargo fmt` 格式化代码
 - 使用 `cargo clippy` 检查代码质量
+- 提交前建议额外运行 `cargo xtask sync-lint`，检查可疑的原子同步内存序用法；如果被该检查阻止，可参考[同步内存序检查](/community/sync-lint)
 - 对系统构建、运行和测试，优先使用 `cargo xtask` 提供的统一入口
 - 为公共 API 编写文档注释
 - 为新功能添加测试

--- a/docs/community/sync-lint.md
+++ b/docs/community/sync-lint.md
@@ -1,0 +1,251 @@
+---
+sidebar_position: 4
+sidebar_label: "同步内存序检查"
+---
+
+# 同步内存序检查
+
+`sync-lint` 是仓库里的一个静态检查工具，入口命令是：
+
+```bash
+cargo xtask sync-lint
+```
+
+它的目标是：检查Atomic原子变量的使用，抓那些**承担同步语义**、但仍然写成了 `Relaxed` 的用法。
+
+典型情况包括：
+
+- 这个原子变量是不是在决定“别的线程/任务/CPU 能不能继续执行”
+- 它是不是在负责“发布状态，再唤醒别人”
+
+如果是，那么用 `Relaxed` 就有可能过弱，尤其是在 AArch64、RISC-V 这类弱内存序架构上。
+
+## 当前检查范围
+
+### 1. 在等待条件里使用 `Relaxed`
+
+当前实现主要检查两种高置信等待场景：
+
+- `wait_until` / `wait_timeout_until` / `wait_while` 这类等待接口的条件闭包
+- 带有明显阻塞或让出动作的 `while` 循环条件，例如循环体里出现 `thread::yield_now()`、`thread::sleep(...)`、`spin_loop()` 或 `park()`
+
+这类代码会被报告：
+
+```rust
+WQ.wait_until(|| COUNTER.load(Ordering::Relaxed) == NUM_TASKS);
+
+while !READY.load(Ordering::Relaxed) {
+    thread::yield_now();
+}
+```
+
+原因是这里的原子变量不是“看一眼统计值”，而是在决定：
+
+- 当前线程是否继续等待
+- 当前阶段是否已经完成
+- 另一个执行流是否已经把状态准备好
+
+### 2. 用 `Relaxed` 写状态后立刻 `notify` / `wake`
+
+这类代码也会被报告：
+
+```rust
+COUNTER.fetch_add(1, Ordering::Relaxed);
+WQ.notify_one(true);
+
+GO.store(true, Ordering::Relaxed);
+WQ.notify_all(true);
+```
+
+这种模式通常表示：
+
+1. 先发布状态
+2. 再唤醒等待者去观察这个状态
+
+如果发布动作还是 `Relaxed`，等待者就可能虽然被唤醒了，但看不到你刚刚写入的最新状态。
+
+## 当前不检查什么
+
+为了避免误报，第一阶段刻意没有做“大而全”的规则。
+
+目前不会主动检查这些情况：
+
+- 纯统计/计数用途的原子变量；但如果一个“计数器”本身参与阶段同步、等待条件或唤醒流程，它仍然可能被报告
+- `Acquire` / `Release` 是否成对匹配
+- `AcqRel` 或 `SeqCst` 是否过强
+- 更复杂的跨函数发布模式
+- lock-free 算法内部的状态机细节
+
+也就是说，当前规则是一个**保守版、低误报**检查器。
+
+## 典型提示长什么样
+
+提示格式是：
+
+```text
+<path>:<line>:<column>: <message> [<rule>]
+```
+
+例如：
+
+```text
+test-suit/arceos/rust/task/wait_queue/src/main.rs:44:13:
+Relaxed atomic write is immediately followed by a wake/notify operation
+[suspicious_relaxed_publish_before_notify]
+```
+
+或者：
+
+```text
+test-suit/arceos/rust/task/parallel/src/main.rs:40:12:
+Relaxed atomic load is used in a wait condition
+[suspicious_relaxed_wait_condition]
+```
+
+## 这些提示分别是什么意思
+
+### `suspicious_relaxed_wait_condition`
+
+意思是：
+
+- 某个 `Atomic*` 的 `load(Ordering::Relaxed)` 被拿来做等待/阻塞/自旋条件
+- 这个值不再只是“统计信息”
+- 而是在决定当前执行流能不能往前推进
+
+一般应考虑把这类读改成：
+
+- `Ordering::Acquire`
+
+对应的写一侧如果也承担发布语义，通常要改成：
+
+- `Ordering::Release`
+
+### `suspicious_relaxed_publish_before_notify`
+
+意思是：
+
+- 你刚刚对原子变量做了 `Relaxed` 写入
+- 然后马上 `notify_one` / `notify_all` / `wake`
+
+这通常是在“告诉别人状态已经准备好”。  
+这类写一般应考虑改成：
+
+- `Ordering::Release`
+
+## 一般怎么修
+
+一个简单的经验法则是：
+
+- **读侧**如果在“等待某个状态成立”，优先考虑 `Acquire`
+- **写侧**如果在“发布这个状态，然后唤醒别人”，优先考虑 `Release`
+
+最常见的修法是把：
+
+```rust
+flag.store(true, Ordering::Relaxed);
+```
+
+改成：
+
+```rust
+flag.store(true, Ordering::Release);
+```
+
+把：
+
+```rust
+while !flag.load(Ordering::Relaxed) {
+    thread::yield_now();
+}
+```
+
+改成：
+
+```rust
+while !flag.load(Ordering::Acquire) {
+    thread::yield_now();
+}
+```
+
+## 一个完整例子
+
+下面这个模式很典型：
+
+```rust
+COUNTER.fetch_add(1, Ordering::Relaxed);
+WQ1.notify_one(true);
+
+WQ1.wait_until(|| COUNTER.load(Ordering::Relaxed) == NUM_TASKS);
+```
+
+它的问题不是“`COUNTER` 是计数器，所以一定错”，而是：
+
+- 这个计数器不只是统计用途
+- 它实际上承担了“阶段同步”的职责
+- 主线程靠它判断是否所有 worker 都到齐了
+- worker 在更新它之后立刻唤醒等待者
+
+因此它更像“同步变量”，而不是普通计数器。
+
+更合适的写法是：
+
+```rust
+COUNTER.fetch_add(1, Ordering::Release);
+WQ1.notify_one(true);
+
+WQ1.wait_until(|| COUNTER.load(Ordering::Acquire) == NUM_TASKS);
+```
+
+这里的含义是：
+
+- `Release`：发布“我已经到达这个阶段”
+- `Acquire`：观察者在判断阶段完成时，要看到这个发布过的状态
+
+## 如果你认为这是误报
+
+第一阶段规则已经比较保守，但仍然保留了显式忽略入口。
+
+可以在代码上方写：
+
+```rust
+// sync-lint: ignore suspicious_relaxed_wait_condition
+```
+
+或者：
+
+```rust
+// sync-lint: ignore suspicious_relaxed_publish_before_notify
+```
+
+如果你确实要忽略，建议把理由写清楚，例如：
+
+```rust
+// sync-lint: ignore suspicious_relaxed_wait_condition
+// stats-only counter, not used for synchronization
+```
+
+请注意，只有在你能明确说明“这个原子变量不承担同步语义”时，才建议这样做。
+
+## 提交前建议
+
+如果你改动了并发、任务、等待队列、唤醒、原子状态机等相关逻辑，建议在本地先跑一遍：
+
+```bash
+cargo xtask sync-lint
+```
+
+这样能比 CI 更早发现问题，也更方便你在本地直接跳到报错位置修改。
+
+## 结论
+
+可以把 `sync-lint` 理解为一个简单的问题筛子：
+
+- 它不试图判断所有原子变量
+- 它只抓那些“看起来像同步变量，但用了过弱内存序”的高置信模式
+
+如果你的代码被它挡住，先不要把它理解成“工具不允许用 `Relaxed`”，而应该先问自己：
+
+- 这个原子变量是不是在控制别的线程/任务/CPU 的推进时机？
+- 它是不是在发布一个会被别人观察到的阶段状态？
+
+如果答案是“是”，那么优先考虑把它改成 `Acquire/Release` 风格的同步。

--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -37,6 +37,9 @@ tracing = "0.1"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt", "std", "time"] }
 xz2 = "0.1"
+proc-macro2 = { version = "1", features = ["span-locations"] }
+syn = { version = "2", features = ["full", "visit"] }
+walkdir = "2"
 
 [features]
 clap = ["dep:clap", "dep:tokio"]

--- a/scripts/axbuild/src/lib.rs
+++ b/scripts/axbuild/src/lib.rs
@@ -21,6 +21,7 @@ mod download;
 mod logging;
 pub mod process;
 pub mod starry;
+mod sync_lint;
 mod test_qemu;
 mod test_std;
 
@@ -46,6 +47,8 @@ enum Commands {
     Test,
     /// Run clippy for the maintained whitelist by default
     Clippy(ClippyArgs),
+    /// Run high-confidence atomic ordering checks for suspicious `Relaxed` synchronization
+    SyncLint,
     /// Remote board management via ostool-server
     Board {
         #[command(subcommand)]
@@ -77,6 +80,7 @@ async fn run_root_cli(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Commands::Test => test_std::run_std_test_command(),
         Commands::Clippy(args) => clippy::run_workspace_clippy_command(&args),
+        Commands::SyncLint => sync_lint::run_sync_lint_command(),
         Commands::Board { command } => board::execute(command).await,
         Commands::Axvisor { command } => Axvisor::new()?.execute(command).await,
         Commands::Arceos { command } => ArceOS::new()?.execute(command).await,

--- a/scripts/axbuild/src/sync_lint.rs
+++ b/scripts/axbuild/src/sync_lint.rs
@@ -8,7 +8,8 @@ use anyhow::Context;
 use cargo_metadata::{Metadata, Package};
 use proc_macro2::Span;
 use syn::{
-    Block, Expr, ExprCall, ExprClosure, ExprMethodCall, ExprPath, ExprWhile, File, Ident, Stmt,
+    Block, Expr, ExprCall, ExprClosure, ExprMethodCall, ExprPath, ExprWhile, File, Ident,
+    ItemMacro, Stmt,
     spanned::Spanned,
     visit::{self, Visit},
 };
@@ -225,6 +226,20 @@ impl<'a> Analyzer<'a> {
 }
 
 impl Visit<'_> for Analyzer<'_> {
+    fn visit_item_macro(&mut self, node: &ItemMacro) {
+        if node
+            .mac
+            .path
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == "app")
+            && let Ok(file) = syn::parse2::<File>(node.mac.tokens.clone())
+        {
+            self.visit_file(&file);
+        }
+        visit::visit_item_macro(self, node);
+    }
+
     fn visit_expr_call(&mut self, node: &ExprCall) {
         if is_wait_function(node) {
             for arg in &node.args {

--- a/scripts/axbuild/src/sync_lint.rs
+++ b/scripts/axbuild/src/sync_lint.rs
@@ -1,0 +1,523 @@
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+use cargo_metadata::{Metadata, Package};
+use proc_macro2::Span;
+use syn::{
+    Block, Expr, ExprCall, ExprClosure, ExprMethodCall, ExprPath, ExprWhile, File, Ident, Stmt,
+    spanned::Spanned,
+    visit::{self, Visit},
+};
+use walkdir::WalkDir;
+
+pub(crate) fn run_sync_lint_command() -> anyhow::Result<()> {
+    let workspace_manifest = crate::context::workspace_manifest_path()?;
+    let metadata = crate::context::workspace_metadata_root_manifest(&workspace_manifest)
+        .context("failed to load cargo metadata")?;
+    let workspace_root = metadata.workspace_root.clone().into_std_path_buf();
+    let packages = workspace_packages(&metadata);
+
+    println!(
+        "running sync-lint for {} workspace package(s) from {}",
+        packages.len(),
+        workspace_root.display()
+    );
+
+    let mut findings = Vec::new();
+    for package in &packages {
+        findings.extend(package_findings(package)?);
+    }
+
+    if findings.is_empty() {
+        println!("all sync-lint checks passed");
+        return Ok(());
+    }
+
+    println!(
+        "sync-lint found {} issue(s) across {} file(s):",
+        findings.len(),
+        findings
+            .iter()
+            .map(|finding| finding.path.clone())
+            .collect::<HashSet<_>>()
+            .len()
+    );
+    for finding in &findings {
+        println!(
+            "{}:{}:{}: {} [{}]",
+            finding.path.display(),
+            finding.line,
+            finding.column,
+            finding.message,
+            finding.rule.label()
+        );
+    }
+
+    bail!("sync-lint found {} issue(s)", findings.len())
+}
+
+fn workspace_packages(metadata: &Metadata) -> Vec<Package> {
+    let workspace_members: HashSet<_> = metadata.workspace_members.iter().cloned().collect();
+    let mut packages: Vec<_> = metadata
+        .packages
+        .iter()
+        .filter(|pkg| workspace_members.contains(&pkg.id))
+        .cloned()
+        .collect();
+    packages.sort_by(|left, right| left.name.cmp(&right.name));
+    packages
+}
+
+fn package_findings(package: &Package) -> anyhow::Result<Vec<Finding>> {
+    let package_dir = package
+        .manifest_path
+        .clone()
+        .into_std_path_buf()
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| anyhow!("invalid manifest path for package `{}`", package.name))?;
+
+    let mut findings = Vec::new();
+    for source_path in rust_source_files(&package_dir) {
+        findings.extend(file_findings(&source_path)?);
+    }
+    Ok(findings)
+}
+
+fn rust_source_files(package_dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(package_dir)
+        .into_iter()
+        .filter_entry(|entry| entry.file_name() != "target")
+        .filter_map(Result::ok)
+    {
+        let path = entry.path();
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path.to_path_buf());
+        }
+    }
+    files.sort();
+    files
+}
+
+fn file_findings(path: &Path) -> anyhow::Result<Vec<Finding>> {
+    let source =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let syntax = syn::parse_file(&source)
+        .with_context(|| format!("failed to parse Rust file {}", path.display()))?;
+    Ok(analyze_file(path, &source, &syntax))
+}
+
+fn analyze_file(path: &Path, source: &str, syntax: &File) -> Vec<Finding> {
+    let mut analyzer = Analyzer::new(path, source);
+    analyzer.visit_file(syntax);
+    analyzer.findings
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Rule {
+    SuspiciousRelaxedWaitCondition,
+    SuspiciousRelaxedPublishBeforeNotify,
+}
+
+impl Rule {
+    fn label(self) -> &'static str {
+        match self {
+            Self::SuspiciousRelaxedWaitCondition => "suspicious_relaxed_wait_condition",
+            Self::SuspiciousRelaxedPublishBeforeNotify => {
+                "suspicious_relaxed_publish_before_notify"
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Finding {
+    path: PathBuf,
+    line: usize,
+    column: usize,
+    rule: Rule,
+    message: String,
+}
+
+struct Analyzer<'a> {
+    path: &'a Path,
+    lines: Vec<&'a str>,
+    findings: Vec<Finding>,
+}
+
+impl<'a> Analyzer<'a> {
+    fn new(path: &'a Path, source: &'a str) -> Self {
+        Self {
+            path,
+            lines: source.lines().collect(),
+            findings: Vec::new(),
+        }
+    }
+
+    fn report(&mut self, span: Span, rule: Rule, message: &'static str) {
+        let start = span.start();
+        if self.is_ignored(rule, start.line) {
+            return;
+        }
+
+        self.findings.push(Finding {
+            path: self.path.to_path_buf(),
+            line: start.line,
+            column: start.column + 1,
+            rule,
+            message: message.to_string(),
+        });
+    }
+
+    fn is_ignored(&self, rule: Rule, line: usize) -> bool {
+        let line_indexes = [
+            line.saturating_sub(1),
+            line.saturating_sub(2),
+            line.saturating_sub(3),
+        ];
+        line_indexes.into_iter().any(|line_no| {
+            if line_no == 0 {
+                return false;
+            }
+            self.lines.get(line_no - 1).is_some_and(|line| {
+                line.contains("sync-lint: ignore")
+                    && (line.contains(rule.label()) || !line.contains("suspicious_relaxed_"))
+            })
+        })
+    }
+
+    fn check_wait_closure(&mut self, closure: &ExprClosure) {
+        if let Some(span) = first_relaxed_load(&closure.body) {
+            self.report(
+                span,
+                Rule::SuspiciousRelaxedWaitCondition,
+                "Relaxed atomic load is used in a wait condition",
+            );
+        }
+    }
+
+    fn check_block_for_publish_before_notify(&mut self, block: &Block) {
+        let statements = block
+            .stmts
+            .iter()
+            .filter_map(statement_expr)
+            .collect::<Vec<_>>();
+        for pair in statements.windows(2) {
+            let [first, second] = pair else {
+                continue;
+            };
+            if let Some(span) = relaxed_write_span(first)
+                && is_notify_expr(second)
+            {
+                self.report(
+                    span,
+                    Rule::SuspiciousRelaxedPublishBeforeNotify,
+                    "Relaxed atomic write is immediately followed by a wake/notify operation",
+                );
+            }
+        }
+    }
+}
+
+impl Visit<'_> for Analyzer<'_> {
+    fn visit_expr_call(&mut self, node: &ExprCall) {
+        if is_wait_function(node) {
+            for arg in &node.args {
+                if let Expr::Closure(closure) = arg {
+                    self.check_wait_closure(closure);
+                }
+            }
+        }
+        visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &ExprMethodCall) {
+        if is_wait_method(node.method.clone()) {
+            for arg in &node.args {
+                if let Expr::Closure(closure) = arg {
+                    self.check_wait_closure(closure);
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+
+    fn visit_expr_while(&mut self, node: &ExprWhile) {
+        if let Some(span) = first_relaxed_load(&node.cond)
+            && block_contains_blocking_call(&node.body)
+        {
+            self.report(
+                span,
+                Rule::SuspiciousRelaxedWaitCondition,
+                "Relaxed atomic load is used in a blocking loop condition",
+            );
+        }
+        visit::visit_expr_while(self, node);
+    }
+
+    fn visit_block(&mut self, node: &Block) {
+        self.check_block_for_publish_before_notify(node);
+        visit::visit_block(self, node);
+    }
+}
+
+fn statement_expr(stmt: &Stmt) -> Option<&Expr> {
+    match stmt {
+        Stmt::Expr(expr, _) => Some(expr),
+        _ => None,
+    }
+}
+
+fn is_wait_function(node: &ExprCall) -> bool {
+    function_name(&node.func).is_some_and(|name| {
+        matches!(
+            name.as_str(),
+            "ax_wait_queue_wait_until" | "ax_wait_queue_wait_timeout_until"
+        )
+    })
+}
+
+fn is_wait_method(method: Ident) -> bool {
+    matches!(
+        method.to_string().as_str(),
+        "wait_until" | "wait_timeout_until" | "wait_while"
+    )
+}
+
+fn function_name(expr: &Expr) -> Option<String> {
+    let Expr::Path(ExprPath { path, .. }) = expr else {
+        return None;
+    };
+    path.segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+}
+
+fn is_notify_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(method) => matches!(
+            method.method.to_string().as_str(),
+            "notify_one" | "notify_all" | "wake" | "wake_one" | "wake_all" | "unpark"
+        ),
+        Expr::Call(call) => function_name(&call.func).is_some_and(|name| {
+            matches!(
+                name.as_str(),
+                "ax_wait_queue_wake"
+                    | "notify_one"
+                    | "notify_all"
+                    | "wake"
+                    | "wake_one"
+                    | "wake_all"
+                    | "unpark"
+            )
+        }),
+        _ => false,
+    }
+}
+
+fn relaxed_write_span(expr: &Expr) -> Option<Span> {
+    let Expr::MethodCall(method) = expr else {
+        return None;
+    };
+    if !matches!(
+        method.method.to_string().as_str(),
+        "store"
+            | "swap"
+            | "fetch_add"
+            | "fetch_sub"
+            | "fetch_or"
+            | "fetch_and"
+            | "fetch_xor"
+            | "fetch_max"
+            | "fetch_min"
+    ) {
+        return None;
+    }
+    method
+        .args
+        .last()
+        .filter(|ordering| is_relaxed_ordering(ordering))
+        .map(|_| method.span())
+}
+
+fn first_relaxed_load(expr: &Expr) -> Option<Span> {
+    let mut finder = RelaxedLoadFinder { span: None };
+    finder.visit_expr(expr);
+    finder.span
+}
+
+struct RelaxedLoadFinder {
+    span: Option<Span>,
+}
+
+impl Visit<'_> for RelaxedLoadFinder {
+    fn visit_expr_method_call(&mut self, node: &ExprMethodCall) {
+        if self.span.is_none()
+            && node.method == "load"
+            && node.args.len() == 1
+            && is_relaxed_ordering(&node.args[0])
+        {
+            self.span = Some(node.span());
+            return;
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn is_relaxed_ordering(expr: &Expr) -> bool {
+    let Expr::Path(path) = expr else {
+        return false;
+    };
+    path.path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "Relaxed")
+}
+
+fn block_contains_blocking_call(block: &Block) -> bool {
+    let mut finder = BlockingCallFinder { found: false };
+    finder.visit_block(block);
+    finder.found
+}
+
+struct BlockingCallFinder {
+    found: bool,
+}
+
+impl Visit<'_> for BlockingCallFinder {
+    fn visit_expr_call(&mut self, node: &ExprCall) {
+        if self.found {
+            return;
+        }
+        if function_name(&node.func).is_some_and(|name| {
+            matches!(
+                name.as_str(),
+                "spin_loop" | "yield_now" | "sleep" | "park" | "wait" | "wait_timeout"
+            )
+        }) {
+            self.found = true;
+            return;
+        }
+        visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &ExprMethodCall) {
+        if self.found {
+            return;
+        }
+        if matches!(
+            node.method.to_string().as_str(),
+            "yield_now" | "sleep" | "wait" | "wait_timeout" | "park"
+        ) {
+            self.found = true;
+            return;
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn findings(source: &str) -> Vec<Finding> {
+        let syntax = syn::parse_file(source).unwrap();
+        analyze_file(Path::new("test.rs"), source, &syntax)
+    }
+
+    #[test]
+    fn reports_relaxed_wait_condition_in_wait_until() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+fn demo(wq: WaitQueue, counter: &AtomicUsize) {
+    wq.wait_until(|| counter.load(Ordering::Relaxed) == 1);
+}
+"#,
+        );
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.rule == Rule::SuspiciousRelaxedWaitCondition)
+        );
+    }
+
+    #[test]
+    fn reports_relaxed_wait_condition_in_blocking_loop() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicBool, Ordering};
+
+fn demo(flag: &AtomicBool) {
+    while !flag.load(Ordering::Relaxed) {
+        core::hint::spin_loop();
+    }
+}
+"#,
+        );
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.rule == Rule::SuspiciousRelaxedWaitCondition)
+        );
+    }
+
+    #[test]
+    fn reports_relaxed_publish_before_notify() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicBool, Ordering};
+
+fn demo(flag: &AtomicBool, wq: WaitQueue) {
+    flag.store(true, Ordering::Relaxed);
+    wq.notify_all(true);
+}
+"#,
+        );
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.rule == Rule::SuspiciousRelaxedPublishBeforeNotify)
+        );
+    }
+
+    #[test]
+    fn ignores_release_wait_conditions() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+fn demo(wq: WaitQueue, counter: &AtomicUsize) {
+    wq.wait_until(|| counter.load(Ordering::Acquire) == 1);
+}
+"#,
+        );
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn respects_ignore_comment() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+fn demo(wq: WaitQueue, counter: &AtomicUsize) {
+    // sync-lint: ignore suspicious_relaxed_wait_condition
+    wq.wait_until(|| counter.load(Ordering::Relaxed) == 1);
+}
+"#,
+        );
+
+        assert!(findings.is_empty());
+    }
+}

--- a/test-suit/arceos/rust/task/affinity/src/main.rs
+++ b/test-suit/arceos/rust/task/affinity/src/main.rs
@@ -84,11 +84,11 @@ fn main() {
                     thread::yield_now();
                 }
             }
-            let _ = FINISHED_TASKS.fetch_add(1, Ordering::Relaxed);
+            let _ = FINISHED_TASKS.fetch_add(1, Ordering::Release);
         });
     }
 
-    while FINISHED_TASKS.load(Ordering::Relaxed) < NUM_TASKS {
+    while FINISHED_TASKS.load(Ordering::Acquire) < NUM_TASKS {
         thread::yield_now();
     }
     println!("All tests passed!");

--- a/test-suit/arceos/rust/task/parallel/src/main.rs
+++ b/test-suit/arceos/rust/task/parallel/src/main.rs
@@ -34,10 +34,10 @@ fn barrier() {
     static BARRIER_WQ: AxWaitQueueHandle = AxWaitQueueHandle::new();
     static BARRIER_COUNT: AtomicUsize = AtomicUsize::new(0);
 
-    BARRIER_COUNT.fetch_add(1, Ordering::Relaxed);
+    BARRIER_COUNT.fetch_add(1, Ordering::Release);
     api::ax_wait_queue_wait_until(
         &BARRIER_WQ,
-        || BARRIER_COUNT.load(Ordering::Relaxed) == NUM_TASKS,
+        || BARRIER_COUNT.load(Ordering::Acquire) == NUM_TASKS,
         None,
     );
     api::ax_wait_queue_wake(&BARRIER_WQ, u32::MAX); // wakeup all

--- a/test-suit/arceos/rust/task/sleep/src/main.rs
+++ b/test-suit/arceos/rust/task/sleep/src/main.rs
@@ -56,11 +56,11 @@ fn main() {
                 let elapsed = now.elapsed();
                 println!("task {} actual sleep {:?} seconds ({}).", i, elapsed, j);
             }
-            FINISHED_TASKS.fetch_add(1, Ordering::Relaxed);
+            FINISHED_TASKS.fetch_add(1, Ordering::Release);
         });
     }
 
-    while FINISHED_TASKS.load(Ordering::Relaxed) < NUM_TASKS {
+    while FINISHED_TASKS.load(Ordering::Acquire) < NUM_TASKS {
         thread::sleep(Duration::from_millis(10));
     }
     println!("All tests passed!");

--- a/test-suit/arceos/rust/task/wait_queue/src/main.rs
+++ b/test-suit/arceos/rust/task/wait_queue/src/main.rs
@@ -41,23 +41,23 @@ fn test_wait() {
 
     for _ in 0..NUM_TASKS {
         thread::spawn(move || {
-            COUNTER.fetch_add(1, Ordering::Relaxed);
+            COUNTER.fetch_add(1, Ordering::Release);
             api::ax_wait_queue_wake(&WQ1, 1); // WQ1.wait_until()
             api::ax_wait_queue_wait_until(&WQ2, || GO.load(Ordering::Acquire), None);
 
-            COUNTER.fetch_sub(1, Ordering::Relaxed);
+            COUNTER.fetch_sub(1, Ordering::Release);
             api::ax_wait_queue_wake(&WQ1, 1); // WQ1.wait_until()
         });
     }
 
-    api::ax_wait_queue_wait_until(&WQ1, || COUNTER.load(Ordering::Relaxed) == NUM_TASKS, None);
-    assert_eq!(COUNTER.load(Ordering::Relaxed), NUM_TASKS);
+    api::ax_wait_queue_wait_until(&WQ1, || COUNTER.load(Ordering::Acquire) == NUM_TASKS, None);
+    assert_eq!(COUNTER.load(Ordering::Acquire), NUM_TASKS);
 
     GO.store(true, Ordering::Release);
     api::ax_wait_queue_wake(&WQ2, u32::MAX); // WQ2.wait_until()
 
-    api::ax_wait_queue_wait_until(&WQ1, || COUNTER.load(Ordering::Relaxed) == 0, None);
-    assert_eq!(COUNTER.load(Ordering::Relaxed), 0);
+    api::ax_wait_queue_wait_until(&WQ1, || COUNTER.load(Ordering::Acquire) == 0, None);
+    assert_eq!(COUNTER.load(Ordering::Acquire), 0);
 
     println!("wait_queue: test_wait() OK!");
 }
@@ -88,7 +88,7 @@ fn test_wait_timeout_until() {
                 Some(Duration::from_secs(time_to_wait_in_seconds)),
             );
             assert!(!timeout, "It should not be woken up by timeout");
-            COUNTER2.fetch_add(1, Ordering::Relaxed);
+            COUNTER2.fetch_add(1, Ordering::Release);
             // Notify the main task who waits on WQ4 that this task is finished.
             api::ax_wait_queue_wake(&WQ4, 1);
         });
@@ -103,8 +103,8 @@ fn test_wait_timeout_until() {
     // Wake up all tasks who are waiting for timeout.
     api::ax_wait_queue_wake(&WQ3, u32::MAX);
     // Wait for all tasks to finish (woken up by notification).
-    api::ax_wait_queue_wait_until(&WQ4, || COUNTER2.load(Ordering::Relaxed) == NUM_TASKS, None);
-    assert_eq!(COUNTER2.load(Ordering::Relaxed), NUM_TASKS);
+    api::ax_wait_queue_wait_until(&WQ4, || COUNTER2.load(Ordering::Acquire) == NUM_TASKS, None);
+    assert_eq!(COUNTER2.load(Ordering::Acquire), NUM_TASKS);
 
     println!("wait_timeout_until: tasks woken up by notification test OK!");
 
@@ -126,7 +126,7 @@ fn test_wait_timeout_until() {
                 Some(Duration::from_millis(time_to_wait_in_millis)),
             );
             assert!(timeout, "It should be woken up by timeout");
-            COUNTER2.fetch_sub(1, Ordering::Relaxed);
+            COUNTER2.fetch_sub(1, Ordering::Release);
 
             // Notify the main task who waits on WQ4 that this task is finished.
             api::ax_wait_queue_wake(&WQ4, 1);
@@ -135,8 +135,8 @@ fn test_wait_timeout_until() {
 
     println!("wait_timeout_until: wait for all tasks to finish");
     // Wait for all tasks to finish (woken up by timeout).
-    api::ax_wait_queue_wait_until(&WQ4, || COUNTER2.load(Ordering::Relaxed) == 0, None);
-    assert_eq!(COUNTER2.load(Ordering::Relaxed), 0);
+    api::ax_wait_queue_wait_until(&WQ4, || COUNTER2.load(Ordering::Acquire) == 0, None);
+    assert_eq!(COUNTER2.load(Ordering::Acquire), 0);
 
     println!("wait_timeout_until: tasks woken up by timeout test OK!");
 
@@ -153,7 +153,7 @@ fn test_wait_timeout_until() {
         thread::spawn(move || {
             let timeout = api::ax_wait_queue_wait_until(
                 &WQ3,
-                || CONDITION.load(Ordering::Relaxed),
+                || CONDITION.load(Ordering::Acquire),
                 // equals to sleep(0.1s)
                 Some(Duration::from_millis(time_to_wait_in_millis)),
             );
@@ -162,7 +162,7 @@ fn test_wait_timeout_until() {
                 thread::current().id(),
                 if timeout { "timeout" } else { "notification" }
             );
-            COUNTER2.fetch_add(1, Ordering::Relaxed);
+            COUNTER2.fetch_add(1, Ordering::Release);
 
             // Notify the main task who waits on WQ4 that this task is finished.
             api::ax_wait_queue_wake(&WQ4, 1);
@@ -172,13 +172,13 @@ fn test_wait_timeout_until() {
     // Sleep for 100ms to let all tasks start and wait for timeout.
     thread::sleep(Duration::from_millis(time_to_wait_in_millis - 10));
     // Set condition to true to wake up all tasks who call `ax_wait_queue_wait_until`.
-    CONDITION.store(true, Ordering::Relaxed);
+    CONDITION.store(true, Ordering::Release);
     // Wake up all tasks who are waiting for timeout.
     api::ax_wait_queue_wake(&WQ3, u32::MAX);
 
     // Wait for all tasks to finish (woken up by timeout).
-    api::ax_wait_queue_wait_until(&WQ4, || COUNTER2.load(Ordering::Relaxed) == NUM_TASKS, None);
-    assert_eq!(COUNTER2.load(Ordering::Relaxed), NUM_TASKS);
+    api::ax_wait_queue_wait_until(&WQ4, || COUNTER2.load(Ordering::Acquire) == NUM_TASKS, None);
+    assert_eq!(COUNTER2.load(Ordering::Acquire), NUM_TASKS);
 
     println!("wait_timeout_until: test tasks woken up by notification or timeout, test OK!");
 }

--- a/test-suit/arceos/rust/task/yield/src/main.rs
+++ b/test-suit/arceos/rust/task/yield/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
             #[cfg(all(not(feature = "sched-rr"), not(feature = "sched-cfs")))]
             thread::yield_now();
 
-            let _order = FINISHED_TASKS.fetch_add(1, Ordering::Relaxed);
+            let _order = FINISHED_TASKS.fetch_add(1, Ordering::Release);
             #[cfg(feature = "ax-std")]
             if cfg!(not(feature = "sched-cfs"))
                 && thread::available_parallelism().unwrap().get() == 1
@@ -46,7 +46,7 @@ fn main() {
         });
     }
     println!("Hello, main task!");
-    while FINISHED_TASKS.load(Ordering::Relaxed) < NUM_TASKS {
+    while FINISHED_TASKS.load(Ordering::Acquire) < NUM_TASKS {
         #[cfg(all(not(feature = "sched-rr"), not(feature = "sched-cfs")))]
         thread::yield_now();
     }


### PR DESCRIPTION
 ## Summary

  This PR adds a first-phase sync-lint check to catch high-confidence uses of Ordering::Relaxed in synchronization paths.

  The new check focuses on two patterns:

  - Relaxed loads used in wait or blocking conditions
  - Relaxed stores/RMW operations immediately followed by wake or notify operations

  To make the check effective on the current tree, this PR also:

  - teaches sync-lint to inspect Rust code wrapped by the app! { ... } macro used in ArceOS test-suit crates
  - tightens several ArceOS task regression tests from Relaxed to Acquire/Release where the atomics are acting as phase/
    barrier synchronization variables rather than statistics counters
  - wires cargo xtask sync-lint into CI
  - adds contributor-facing documentation explaining what the check covers, what its diagnostics mean, and how to address
    findings

  ## Changes

  - add cargo xtask sync-lint in axbuild
  - implement first-phase rules:
      - suspicious_relaxed_wait_condition
      - suspicious_relaxed_publish_before_notify
  - fix existing ArceOS task tests that matched these rules
  - run sync-lint in CI post-format checks
  - document the check for contributors in docs/community/sync-lint.md
 
  ## Notes

  - This is an intentionally conservative first phase aimed at low false-positive rates.
  - The current implementation only checks high-confidence synchronization patterns and does not yet try to validate all
    atomic ordering combinations.
