### PR TITLE
fix(axvisor): update riscv64-qemu-virt-hv references in source

### DIFF
--- a/os/axvisor/src/hal/arch/riscv64/api.rs
+++ b/os/axvisor/src/hal/arch/riscv64/api.rs
@@ -1,7 +1,7 @@
 struct VmInterruptIfImpl;
 
 #[ax_crate_interface::impl_interface]
-impl ax_plat_riscv64_qemu_virt::irq::InjectIrqIf for VmInterruptIfImpl {
+impl riscv64_qemu_virt_hv::irq::InjectIrqIf for VmInterruptIfImpl {
     fn inject_virtual_interrupt(irq: usize) {
         crate::hal::arch::inject_interrupt(irq);
     }

--- a/os/axvisor/src/hal/arch/riscv64/mod.rs
+++ b/os/axvisor/src/hal/arch/riscv64/mod.rs
@@ -2,9 +2,9 @@ mod api;
 pub mod cache;
 
 use crate::vmm::vm_list::get_vm_by_id;
-use ax_plat_riscv64_qemu_virt::config::devices::PLIC_PADDR;
 use axaddrspace::{GuestPhysAddr, device::AccessWidth};
 use axvisor_api::vmm::current_vm_id;
+use riscv64_qemu_virt_hv::config::devices::PLIC_PADDR;
 
 pub fn hardware_check() {
     // TODO: implement hardware checks for RISC-V64


### PR DESCRIPTION
Commit [fix: update dependencies and rename ax-plat-riscv64-qemu-virt to riscv64-qemu-virt-hv](https://github.com/rcore-os/tgoskits/commit/824bc3cd5ba4471bd3f9dfd931aa0994f8c4e29f) renamed the dependency from `ax-plat-riscv64-qemu-virt` to `riscv64-qemu-virt-hv`, but the related source references in AxVisor were not updated at the same time.

This PR updates the source to use the new name.