### PR TITLE
fix: respect pid in sched affinity syscalls

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/schedule.rs
+++ b/os/StarryOS/kernel/src/syscall/task/schedule.rs
@@ -11,7 +11,7 @@ use linux_raw_sys::general::{
 use starry_vm::{VmMutPtr, VmPtr, vm_load, vm_write_slice};
 
 use crate::{
-    task::{get_process_data, get_process_group},
+    task::{get_process_data, get_process_group, get_task},
     time::TimeValueLike,
 };
 
@@ -93,12 +93,8 @@ pub fn sys_sched_getaffinity(pid: i32, cpusetsize: usize, user_mask: *mut u8) ->
         return Err(AxError::InvalidInput);
     }
 
-    // TODO: support other threads
-    if pid != 0 {
-        return Err(AxError::OperationNotPermitted);
-    }
-
-    let mask = current().cpumask();
+    let task = get_task_by_sched_pid(pid)?;
+    let mask = task.cpumask();
     let mask_bytes = mask.as_bytes();
 
     vm_write_slice(user_mask, mask_bytes)?;
@@ -106,11 +102,7 @@ pub fn sys_sched_getaffinity(pid: i32, cpusetsize: usize, user_mask: *mut u8) ->
     Ok(mask_bytes.len() as _)
 }
 
-pub fn sys_sched_setaffinity(
-    _pid: i32,
-    cpusetsize: usize,
-    user_mask: *const u8,
-) -> AxResult<isize> {
+pub fn sys_sched_setaffinity(pid: i32, cpusetsize: usize, user_mask: *const u8) -> AxResult<isize> {
     let size = cpusetsize.min(ax_hal::cpu_num().div_ceil(8));
     let user_mask = vm_load(user_mask, size)?;
     let mut cpu_mask = AxCpuMask::new();
@@ -121,10 +113,26 @@ pub fn sys_sched_setaffinity(
         }
     }
 
-    // TODO: support other threads
-    ax_task::set_current_affinity(cpu_mask);
+    if cpu_mask.is_empty() {
+        return Err(AxError::InvalidInput);
+    }
+
+    let task = get_task_by_sched_pid(pid)?;
+    if task.id() == current().id() {
+        ax_task::set_current_affinity(cpu_mask);
+    } else {
+        task.set_cpumask(cpu_mask);
+        task.interrupt();
+    }
 
     Ok(0)
+}
+
+fn get_task_by_sched_pid(pid: i32) -> AxResult<ax_task::AxTaskRef> {
+    if pid < 0 {
+        return Err(AxError::InvalidInput);
+    }
+    get_task(pid as _)
 }
 
 pub fn sys_sched_getscheduler(_pid: i32) -> AxResult<isize> {

--- a/test-suit/starryos/normal/bug-sched-affinity-pid/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-sched-affinity-pid/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-sched-affinity-pid C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-sched-affinity-pid src/main.c)
+target_compile_options(bug-sched-affinity-pid PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-sched-affinity-pid RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-sched-affinity-pid/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-sched-affinity-pid/c/prebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-sched-affinity-pid/c/src/main.c
+++ b/test-suit/starryos/normal/bug-sched-affinity-pid/c/src/main.c
@@ -1,0 +1,87 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void fail(const char *msg)
+{
+    printf("TEST FAILED: %s: %s\n", msg, strerror(errno));
+    fflush(stdout);
+    abort();
+}
+
+static cpu_set_t single_cpu(int cpu)
+{
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(cpu, &set);
+    return set;
+}
+
+static void require_only_cpu(const cpu_set_t *set, int cpu, const char *msg)
+{
+    for (int i = 0; i < CPU_SETSIZE; i++) {
+        int actual = CPU_ISSET(i, set) ? 1 : 0;
+        int expected = i == cpu ? 1 : 0;
+        if (actual != expected) {
+            printf("TEST FAILED: %s\n", msg);
+            abort();
+        }
+    }
+}
+
+int main(void)
+{
+    setbuf(stdout, NULL);
+    printf("TEST START: sched affinity respects pid\n");
+
+    cpu_set_t parent_cpu0 = single_cpu(0);
+    if (sched_setaffinity(0, sizeof(parent_cpu0), &parent_cpu0) != 0) {
+        fail("set parent affinity to CPU0");
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        fail("fork");
+    }
+    if (child == 0) {
+        for (;;) {
+            sched_yield();
+        }
+        _exit(0);
+    }
+
+    cpu_set_t child_cpu1 = single_cpu(1);
+    if (sched_setaffinity(child, sizeof(child_cpu1), &child_cpu1) != 0) {
+        kill(child, SIGKILL);
+        fail("set child affinity to CPU1");
+    }
+
+    cpu_set_t observed_child;
+    CPU_ZERO(&observed_child);
+    if (sched_getaffinity(child, sizeof(observed_child), &observed_child) != 0) {
+        kill(child, SIGKILL);
+        fail("get child affinity");
+    }
+    require_only_cpu(&observed_child, 1, "child affinity should be CPU1");
+
+    cpu_set_t observed_parent;
+    CPU_ZERO(&observed_parent);
+    if (sched_getaffinity(0, sizeof(observed_parent), &observed_parent) != 0) {
+        kill(child, SIGKILL);
+        fail("get parent affinity");
+    }
+    require_only_cpu(&observed_parent, 0, "parent affinity should stay CPU0");
+
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
+
+    printf("TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/bug-sched-affinity-pid/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-sched-affinity-pid/qemu-x86_64.toml
@@ -1,0 +1,15 @@
+args = [
+    "-nographic",
+    "-smp", "4",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-sched-affinity-pid"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED:']
+timeout = 30


### PR DESCRIPTION
## 变更说明

修复 StarryOS 中 `sched_getaffinity()` / `sched_setaffinity()` 没有正确处理 `pid` 参数的问题。

原实现存在两个问题：

- `sched_getaffinity(pid != 0)` 直接返回错误，无法查询其他任务的 CPU affinity
- `sched_setaffinity(pid)` 忽略传入的 `pid`，总是修改当前任务的 affinity

本次修改：

- 根据 `pid` 查找目标任务，`pid == 0` 仍表示当前任务
- `sched_getaffinity()` 返回目标任务真实 `cpumask`
- `sched_setaffinity()` 将非空 CPU mask 设置到目标任务
- 对当前任务仍使用 `set_current_affinity()` 保留迁移逻辑
- 对其他任务更新其 `cpumask` 并触发 `interrupt()`

## 测例说明

新增用户态测例：

`test-suit/starryos/normal/bug-sched-affinity-pid`

测例会：

- 将 parent 绑定到 CPU0
- fork 一个 child
- 对 child 调用 `sched_setaffinity(child, CPU1)`
- 通过 `sched_getaffinity(child)` 检查 child 已绑定到 CPU1
- 再检查 parent 仍保持在 CPU0，确保没有被错误修改

旧实现下，同一测例会失败：`sched_getaffinity(child)` 返回 `Operation not permitted`。修复后测例通过。

## 验证情况

已在 `starryos-dev:ubuntu-qemu10.2.1` 中完成：

- `cargo fmt --manifest-path Cargo.toml --all`
- `cargo check -p starry-kernel --all-targets`
- 旧实现下运行 `cargo xtask starry test qemu -t x86_64 -c bug-sched-affinity-pid`，测例失败并打印 `TEST FAILED: get child affinity: Operation not permitted`
- 修复后运行 `cargo xtask starry test qemu -t x86_64 -c bug-sched-affinity-pid`，测例通过并打印 `TEST PASSED`

说明：

- `cargo xtask clippy --package starry-kernel` 仍被仓库已有的无关 clippy 问题阻塞，主要位于 `components/axcpu` 和 `components/rsext4`，不是本次改动引入的问题。
