### PR TITLE
fix(axbuild): sync qemu rootfs tests with interface changes

### DIFF
--- a/scripts/axbuild/src/axvisor/qemu.rs
+++ b/scripts/axbuild/src/axvisor/qemu.rs
@@ -174,6 +174,7 @@ kernel_path = "{}"
                 vmconfigs: vec![vmconfig],
             },
             root.path(),
+            None,
         )
         .unwrap();
 
@@ -211,6 +212,7 @@ kernel_path = "{}"
                 vmconfigs: vec![],
             },
             root.path(),
+            None,
         )
         .unwrap();
 
@@ -255,6 +257,7 @@ kernel_path = "{}"
                 vmconfigs: vec![],
             },
             root.path(),
+            None,
         )
         .unwrap();
 


### PR DESCRIPTION
Fixes the unit tests in `scripts/axbuild/src/axvisor/qemu.rs` so they match the updated `apply_rootfs_path` interface by #281.