### PR TITLE
feat(runtime): extend IRQ, RTC, and tty event support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ __pycache__/
 .axvisor*
 .board*
 .codex
+.image.toml

--- a/.image.toml
+++ b/.image.toml
@@ -1,4 +1,0 @@
-local_storage = "/tmp/.axvisor-images"
-registry = "https://raw.githubusercontent.com/arceos-hypervisor/axvisor-guest/refs/heads/main/registry/default.toml"
-auto_sync = true
-auto_sync_threshold = 604800

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
 name = "axpoll"
 version = "0.3.8"
 dependencies = [
+ "ax-kspin",
  "bitflags 2.11.1",
  "futures",
  "linux-raw-sys 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,7 @@ name = "ax-driver-net"
 version = "0.3.11"
 dependencies = [
  "ax-driver-base",
+ "bitflags 2.11.1",
  "fxmac_rs",
  "ixgbe-driver",
  "log",
@@ -1654,6 +1655,7 @@ dependencies = [
  "ax-driver-net",
  "ax-driver-virtio",
  "ax-errno",
+ "ax-kspin",
  "ax-memory-addr",
  "ax-percpu",
  "ax-plat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,6 +1648,7 @@ version = "0.5.12"
 dependencies = [
  "anyhow",
  "ax-alloc",
+ "ax-arm-pl031",
  "ax-config-macros",
  "ax-cpu",
  "ax-driver-base",

--- a/components/axcpu/src/loongarch64/unaligned.rs
+++ b/components/axcpu/src/loongarch64/unaligned.rs
@@ -555,7 +555,7 @@ impl TrapFrame {
         let mut value: u64 = 0;
 
         let badv = badv::read().vaddr() as u64;
-        let badi = core::ptr::read(self.era as *const u32);
+        let badi = unsafe { core::ptr::read(self.era as *const u32) };
         let rd = (badi & 0x1f) as usize;
 
         let regs = unsafe {

--- a/components/axdriver_crates/axdriver_net/Cargo.toml
+++ b/components/axdriver_crates/axdriver_net/Cargo.toml
@@ -22,6 +22,7 @@ ixgbe = ["dep:ixgbe-driver"]
 
 [dependencies]
 ax-driver-base = { workspace = true }
+bitflags = "2.9"
 fxmac_rs = { workspace = true, optional = true }
 ixgbe-driver = { version = "0.1.1-preview.1", optional = true }
 log = { workspace = true }

--- a/components/axdriver_crates/axdriver_net/src/lib.rs
+++ b/components/axdriver_crates/axdriver_net/src/lib.rs
@@ -5,6 +5,8 @@
 
 extern crate alloc;
 
+use bitflags::bitflags;
+
 #[cfg(feature = "fxmac")]
 /// fxmac driver for PhytiumPi
 pub mod fxmac;
@@ -20,6 +22,21 @@ pub use self::net_buf::{NetBuf, NetBufBox, NetBufPool, NetBufPtr};
 
 /// The ethernet address of the NIC (MAC address).
 pub struct EthernetAddress(pub [u8; 6]);
+
+bitflags! {
+    /// Network IRQ events reported by NIC drivers.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct NetIrqEvent: u32 {
+        /// The device has receive data ready.
+        const RX_READY = 1 << 0;
+        /// The device completed one or more transmit operations.
+        const TX_DONE = 1 << 1;
+        /// The device reported a receive-side error.
+        const RX_ERROR = 1 << 2;
+        /// The interrupt was not relevant to this NIC.
+        const SPURIOUS = 1 << 31;
+    }
+}
 
 /// Operations that require a network device (NIC) driver to implement.
 pub trait NetDriverOps: BaseDriverOps {
@@ -65,4 +82,9 @@ pub trait NetDriverOps: BaseDriverOps {
     /// Allocate a memory buffer of a specified size for network transmission,
     /// returns [`DevResult`]
     fn alloc_tx_buffer(&mut self, size: usize) -> DevResult<NetBufPtr>;
+
+    /// Handles a NIC interrupt and returns the device events it observed.
+    fn handle_irq(&mut self) -> NetIrqEvent {
+        NetIrqEvent::SPURIOUS
+    }
 }

--- a/components/axdriver_crates/axdriver_virtio/src/blk.rs
+++ b/components/axdriver_crates/axdriver_virtio/src/blk.rs
@@ -16,9 +16,9 @@ impl<H: Hal, T: Transport> VirtIoBlkDev<H, T> {
     /// Creates a new driver instance and initializes the device, or returns
     /// an error if any step fails.
     pub fn try_new(transport: T) -> DevResult<Self> {
-        Ok(Self {
-            inner: InnerDev::new(transport).map_err(as_dev_err)?,
-        })
+        let mut inner = InnerDev::new(transport).map_err(as_dev_err)?;
+        inner.disable_interrupts();
+        Ok(Self { inner })
     }
 }
 

--- a/components/axdriver_crates/axdriver_virtio/src/input.rs
+++ b/components/axdriver_crates/axdriver_virtio/src/input.rs
@@ -76,7 +76,6 @@ impl<H: Hal, T: Transport> InputDriverOps for VirtIoInputDev<H, T> {
     }
 
     fn read_event(&mut self) -> DevResult<Event> {
-        self.inner.ack_interrupt();
         self.inner
             .pop_pending_event()
             .map(|e| Event {

--- a/components/axdriver_crates/axdriver_virtio/src/net.rs
+++ b/components/axdriver_crates/axdriver_virtio/src/net.rs
@@ -1,7 +1,9 @@
 use alloc::{sync::Arc, vec::Vec};
 
 use ax_driver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
-use ax_driver_net::{EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps};
+use ax_driver_net::{
+    EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps, NetIrqEvent,
+};
 use virtio_drivers::{Hal, device::net::VirtIONetRaw as InnerDev, transport::Transport};
 
 use crate::as_dev_err;
@@ -163,7 +165,6 @@ impl<H: Hal, T: Transport, const QS: usize> NetDriverOps for VirtIoNetDev<H, T, 
     }
 
     fn receive(&mut self) -> DevResult<NetBufPtr> {
-        self.inner.ack_interrupt();
         if let Some(token) = self.inner.poll_receive() {
             let mut rx_buf = self.rx_buffers[token as usize]
                 .take()
@@ -197,5 +198,20 @@ impl<H: Hal, T: Transport, const QS: usize> NetDriverOps for VirtIoNetDev<H, T, 
 
         // 2. Return the buffer.
         Ok(net_buf.into_buf_ptr())
+    }
+
+    fn handle_irq(&mut self) -> NetIrqEvent {
+        self.inner.ack_interrupt();
+
+        let mut events = NetIrqEvent::empty();
+        if self.inner.poll_receive().is_some() {
+            events |= NetIrqEvent::RX_READY;
+        }
+
+        if events.is_empty() {
+            NetIrqEvent::SPURIOUS
+        } else {
+            events
+        }
     }
 }

--- a/components/axdriver_crates/axdriver_virtio/src/net.rs
+++ b/components/axdriver_crates/axdriver_virtio/src/net.rs
@@ -72,6 +72,10 @@ impl<H: Hal, T: Transport, const QS: usize> VirtIoNetDev<H, T, QS> {
             dev.free_tx_bufs.push(tx_buf);
         }
 
+        if irq.is_some() {
+            dev.inner.enable_interrupts();
+        }
+
         // 3. Return the driver instance.
         Ok(dev)
     }

--- a/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/build.rs
+++ b/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=AX_CONFIG_PATH");
+    if let Ok(config_path) = std::env::var("AX_CONFIG_PATH") {
+        println!("cargo:rerun-if-changed={config_path}");
+    }
+}

--- a/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/console.rs
+++ b/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/console.rs
@@ -12,13 +12,14 @@ use crate::config::{devices::UART_PADDR, plat::PHYS_VIRT_OFFSET};
 static UART: LazyInit<SpinNoIrq<Uart16550<MmioBackend>>> = LazyInit::new();
 
 fn uart_config(input_irq_enabled: bool) -> Config {
-    let mut config = Config::default();
-    config.interrupts = if input_irq_enabled {
-        IER::DATA_READY | IER::RECEIVER_LINE_STATUS
-    } else {
-        IER::empty()
-    };
-    config
+    Config {
+        interrupts: if input_irq_enabled {
+            IER::DATA_READY | IER::RECEIVER_LINE_STATUS
+        } else {
+            IER::empty()
+        },
+        ..Default::default()
+    }
 }
 
 pub(crate) fn init_early() {

--- a/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/irq.rs
+++ b/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/irq.rs
@@ -14,7 +14,7 @@ mod eiointc;
 mod pch_pic;
 
 /// The maximum number of IRQs.
-pub const MAX_IRQ_COUNT: usize = 13;
+pub const MAX_IRQ_COUNT: usize = 256;
 const IOCSR_IPI_SEND_CPU_SHIFT: u32 = 16;
 const IOCSR_IPI_SEND_BLOCKING: u32 = 1 << 31;
 

--- a/components/axplat_crates/platforms/axplat-x86-pc/src/apic.rs
+++ b/components/axplat_crates/platforms/axplat-x86-pc/src/apic.rs
@@ -6,7 +6,7 @@ use ax_kspin::SpinNoIrq;
 use ax_lazyinit::LazyInit;
 use ax_plat::mem::{PhysAddr, pa, phys_to_virt};
 use x2apic::{
-    ioapic::IoApic,
+    ioapic::{IoApic, IrqFlags},
     lapic::{LocalApic, LocalApicBuilder, xapic_base},
 };
 use x86_64::instructions::port::Port;
@@ -20,6 +20,7 @@ pub(super) mod vectors {
 }
 
 const IO_APIC_BASE: PhysAddr = pa!(0xFEC0_0000);
+const IO_APIC_VECTOR_OFFSET: u8 = 0x20;
 
 static mut LOCAL_APIC: MaybeUninit<LocalApic> = MaybeUninit::uninit();
 static mut IS_X2APIC: bool = false;
@@ -28,16 +29,28 @@ static IO_APIC: LazyInit<SpinNoIrq<IoApic>> = LazyInit::new();
 /// Enables or disables the given IRQ.
 #[cfg(feature = "irq")]
 pub fn set_enable(vector: usize, enabled: bool) {
-    // should not affect LAPIC interrupts
-    if vector < APIC_TIMER_VECTOR as _ {
+    if let Some(irq) = vector_to_io_apic_irq(vector) {
         unsafe {
+            let mut io_apic = IO_APIC.lock();
+            if irq > io_apic.max_table_entry() {
+                warn!("IO APIC IRQ {irq} is out of range for vector {vector:#x}");
+                return;
+            }
             if enabled {
-                IO_APIC.lock().enable_irq(vector as u8);
+                io_apic.enable_irq(irq);
             } else {
-                IO_APIC.lock().disable_irq(vector as u8);
+                io_apic.disable_irq(irq);
             }
         }
     }
+}
+
+#[cfg(feature = "irq")]
+fn vector_to_io_apic_irq(vector: usize) -> Option<u8> {
+    if vector < IO_APIC_VECTOR_OFFSET as usize || vector >= APIC_TIMER_VECTOR as usize {
+        return None;
+    }
+    Some((vector - IO_APIC_VECTOR_OFFSET as usize) as u8)
 }
 
 #[cfg(any(feature = "smp", feature = "irq"))]
@@ -95,7 +108,20 @@ pub fn init_primary() {
     }
 
     info!("Initialize IO APIC...");
-    let io_apic = unsafe { IoApic::new(phys_to_virt(IO_APIC_BASE).as_usize() as u64) };
+    let mut io_apic = unsafe { IoApic::new(phys_to_virt(IO_APIC_BASE).as_usize() as u64) };
+    unsafe {
+        io_apic.init(IO_APIC_VECTOR_OFFSET);
+        let max_entry = io_apic.max_table_entry();
+        for irq in 0..=max_entry {
+            let mut entry = io_apic.table_entry(irq);
+            entry.set_flags(entry.flags() | IrqFlags::MASKED);
+            io_apic.set_table_entry(irq, entry);
+        }
+        debug!(
+            "IO APIC initialized with vector offset {:#x}, entries 0..={}",
+            IO_APIC_VECTOR_OFFSET, max_entry
+        );
+    }
     IO_APIC.init_once(SpinNoIrq::new(io_apic));
 }
 

--- a/components/axpoll/Cargo.toml
+++ b/components/axpoll/Cargo.toml
@@ -13,6 +13,7 @@ alloc = []          # Deprecated
 default = ["alloc"]
 
 [dependencies]
+ax-kspin = { workspace = true }
 bitflags = { version = "2.10", default-features = false }
 linux-raw-sys = { version = "0.12", default-features = false, features = [
     "no_std",

--- a/components/axpoll/src/lib.rs
+++ b/components/axpoll/src/lib.rs
@@ -11,9 +11,10 @@ use core::{
     task::{Context, Waker},
 };
 
+use ax_kspin::SpinNoIrq;
 use bitflags::bitflags;
 use linux_raw_sys::general::*;
-use spin::{Lazy, Mutex};
+use spin::Lazy;
 
 bitflags! {
     /// I/O events.
@@ -110,7 +111,7 @@ impl Drop for Inner {
 }
 
 /// A data structure for waking up tasks that are waiting for I/O events.
-pub struct PollSet(Lazy<Mutex<Inner>>);
+pub struct PollSet(Lazy<SpinNoIrq<Inner>>);
 
 impl Default for PollSet {
     fn default() -> Self {
@@ -121,7 +122,7 @@ impl Default for PollSet {
 impl PollSet {
     /// Creates a new empty [`PollSet`].
     pub const fn new() -> Self {
-        Self(Lazy::new(|| Mutex::new(Inner::new())))
+        Self(Lazy::new(|| SpinNoIrq::new(Inner::new())))
     }
 
     /// Registers a waker.

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -74,13 +74,8 @@ pub fn init(args: &[String], envs: &[String]) {
     // TODO: wait for all processes to finish
     let exit_code = task.join();
     info!("Init process exited with code: {exit_code:?}");
-
-    let cx = FS_CONTEXT.lock();
-    cx.root_dir()
-        .unmount_all()
-        .expect("Failed to unmount all filesystems");
-    cx.root_dir()
-        .filesystem()
-        .flush()
-        .expect("Failed to flush rootfs");
+    // `task.join()` resumes on the exit wakeup path, where IRQs and preemption
+    // are still disabled for the current kernel task. Avoid taking blocking
+    // mutexes such as `FS_CONTEXT.lock()` here and shut down directly.
+    ax_hal::power::system_off();
 }

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -74,8 +74,13 @@ pub fn init(args: &[String], envs: &[String]) {
     // TODO: wait for all processes to finish
     let exit_code = task.join();
     info!("Init process exited with code: {exit_code:?}");
-    // `task.join()` resumes on the exit wakeup path, where IRQs and preemption
-    // are still disabled for the current kernel task. Avoid taking blocking
-    // mutexes such as `FS_CONTEXT.lock()` here and shut down directly.
-    ax_hal::power::system_off();
+
+    let cx = FS_CONTEXT.lock();
+    cx.root_dir()
+        .unmount_all()
+        .expect("Failed to unmount all filesystems");
+    cx.root_dir()
+        .filesystem()
+        .flush()
+        .expect("Failed to flush rootfs");
 }

--- a/os/StarryOS/kernel/src/pseudofs/fs.rs
+++ b/os/StarryOS/kernel/src/pseudofs/fs.rs
@@ -2,7 +2,6 @@ use alloc::{string::String, sync::Arc};
 use core::{any::Any, time::Duration};
 
 use ax_kspin::SpinNoIrq;
-use ax_sync::Mutex;
 use axfs_ng_vfs::{
     DeviceId, DirEntry, DirNode, Filesystem, FilesystemOps, Metadata, MetadataUpdate, NodeOps,
     NodePermission, NodeType, Reference, StatFs, VfsResult, path::MAX_NAME_LEN,
@@ -33,8 +32,8 @@ pub fn dummy_stat_fs(fs_type: u32) -> StatFs {
 pub struct SimpleFs {
     name: String,
     fs_type: u32,
-    inodes: Mutex<Slab<()>>,
-    root: Mutex<Option<DirEntry>>,
+    inodes: SpinNoIrq<Slab<()>>,
+    root: SpinNoIrq<Option<DirEntry>>,
 }
 
 impl SimpleFs {
@@ -47,8 +46,8 @@ impl SimpleFs {
         let fs = Arc::new(Self {
             name,
             fs_type,
-            inodes: Mutex::new(Slab::new()),
-            root: Mutex::new(None),
+            inodes: SpinNoIrq::new(Slab::new()),
+            root: SpinNoIrq::new(None),
         });
         let root = root(fs.clone());
         fs.set_root(DirEntry::new_dir(

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -268,7 +268,6 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
         }
 
         thr.proc_data.exit_event.wake();
-
         crate::syscall::clear_proc_shm(process.pid(), &thr.proc_data.aspace);
     }
     thr.exit_event.wake();

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -268,6 +268,7 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
         }
 
         thr.proc_data.exit_event.wake();
+
         crate::syscall::clear_proc_shm(process.pid(), &thr.proc_data.aspace);
     }
     thr.exit_event.wake();

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -18,10 +18,12 @@ default = []
 qemu = [
   "ax-feat/defplat",
   "ax-feat/irq",
+  "ax-feat/rtc",
   "ax-feat/bus-pci",
   "ax-feat/display",
   "starry-kernel/input",
   "starry-kernel/vsock", # auxilary features
+  "axplat-dyn?/rtc",
   "axplat-dyn?/intel-net",
   "axplat-dyn?/virtio-net-pci",
 ]

--- a/os/arceos/modules/axdriver/src/bus/pci.rs
+++ b/os/arceos/modules/axdriver/src/bus/pci.rs
@@ -83,7 +83,8 @@ fn config_pci_device<C: ConfigurationAccess>(
     let (_status, cmd) = root.get_status_command(bdf);
     root.set_command(
         bdf,
-        cmd | Command::IO_SPACE | Command::MEMORY_SPACE | Command::BUS_MASTER,
+        (cmd | Command::IO_SPACE | Command::MEMORY_SPACE | Command::BUS_MASTER)
+            & !Command::INTERRUPT_DISABLE,
     );
     Ok(())
 }

--- a/os/arceos/modules/axdriver/src/prelude.rs
+++ b/os/arceos/modules/axdriver/src/prelude.rs
@@ -25,7 +25,7 @@ pub use {
 #[cfg(feature = "net")]
 pub use {
     crate::structs::AxNetDevice,
-    ax_driver_net::{NetBufPtr, NetDriverOps},
+    ax_driver_net::{NetBufPtr, NetDriverOps, NetIrqEvent},
 };
 #[cfg(feature = "vsock")]
 pub use {

--- a/os/arceos/modules/axdriver/src/virtio.rs
+++ b/os/arceos/modules/axdriver/src/virtio.rs
@@ -151,6 +151,7 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
             ax_driver_virtio::probe_pci_device::<VirtIoHalImpl, C>(root, bdf, dev_info)
             && ty == D::DEVICE_TYPE
         {
+            let irq = pci_irq_vector(bdf, irq);
             match D::try_new(transport, Some(irq)) {
                 Ok(dev) => return Some(dev),
                 Err(e) => {
@@ -161,6 +162,36 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
         }
         None
     }
+}
+
+#[cfg(all(bus = "pci", target_arch = "x86_64"))]
+fn pci_irq_vector(bdf: DeviceFunction, fallback: usize) -> usize {
+    const PCI_INTERRUPT_REG: usize = 0x3c;
+    const IO_APIC_VECTOR_OFFSET: usize = 0x20;
+
+    let config_offset = ((bdf.bus as usize) << 20)
+        | ((bdf.device as usize) << 15)
+        | ((bdf.function as usize) << 12)
+        | PCI_INTERRUPT_REG;
+    let config_addr = ax_config::devices::PCI_ECAM_BASE + config_offset;
+    let int_reg =
+        unsafe { (phys_to_virt(config_addr.into()).as_usize() as *const u32).read_volatile() };
+    let line = (int_reg & 0xff) as usize;
+    let pin = ((int_reg >> 8) & 0xff) as usize;
+
+    if (1..0x20).contains(&line) && pin != 0 {
+        let vector = IO_APIC_VECTOR_OFFSET + line;
+        debug!("PCI {bdf} INTx line {line}, pin {pin} -> vector {vector:#x}");
+        vector
+    } else {
+        debug!("PCI {bdf} has INTx line {line}, pin {pin}; using fallback vector {fallback:#x}");
+        fallback
+    }
+}
+
+#[cfg(all(bus = "pci", not(target_arch = "x86_64")))]
+fn pci_irq_vector(_bdf: DeviceFunction, fallback: usize) -> usize {
+    fallback
 }
 
 pub struct VirtIoHalImpl;

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -37,6 +37,7 @@ rtc = [
     "ax-plat-aarch64-qemu-virt?/rtc",
     "ax-plat-riscv64-qemu-virt?/rtc",
     "ax-plat-loongarch64-qemu-virt?/rtc",
+    "axplat-dyn?/rtc",
 ]
 paging = [
     "dep:ax-alloc",

--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -1,8 +1,13 @@
-use alloc::{string::String, vec};
+use alloc::{
+    string::String,
+    sync::{Arc, Weak},
+    vec,
+};
 use core::task::Waker;
 
 use ax_driver::prelude::*;
-use ax_task::future::register_irq_waker;
+use ax_sync::spin::SpinNoIrq;
+use axpoll::PollSet;
 use hashbrown::HashMap;
 use smoltcp::{
     storage::{PacketBuffer, PacketMetadata},
@@ -12,6 +17,7 @@ use smoltcp::{
         EthernetRepr, IpAddress, Ipv4Cidr,
     },
 };
+use spin::Mutex;
 
 use crate::{
     consts::{ETHERNET_MAX_PENDING_PACKETS, STANDARD_MTU},
@@ -19,24 +25,62 @@ use crate::{
 };
 
 const EMPTY_MAC: EthernetAddress = EthernetAddress([0; 6]);
+static IRQ_SOURCE: Mutex<Option<Weak<EthernetIrqState>>> = Mutex::new(None);
 
 struct Neighbor {
     hardware_address: EthernetAddress,
     expires_at: Instant,
 }
 
+struct EthernetIrqState {
+    irq_num: Option<usize>,
+    driver: SpinNoIrq<AxNetDevice>,
+    poll_ready: PollSet,
+}
+
+impl EthernetIrqState {
+    fn handle_irq(&self) -> NetIrqEvent {
+        self.driver.lock().handle_irq()
+    }
+}
+
 pub struct EthernetDevice {
     name: String,
-    inner: AxNetDevice,
+    inner: Arc<EthernetIrqState>,
     neighbors: HashMap<IpAddress, Option<Neighbor>>,
     ip: Ipv4Cidr,
 
     pending_packets: PacketBuffer<'static, IpAddress>,
 }
+
+fn handle_ethernet_irq() {
+    let Some(state) = IRQ_SOURCE.lock().as_ref().and_then(Weak::upgrade) else {
+        return;
+    };
+
+    let events = state.handle_irq();
+    if events.intersects(NetIrqEvent::RX_READY | NetIrqEvent::RX_ERROR) {
+        state.poll_ready.wake();
+    }
+}
+
 impl EthernetDevice {
     const NEIGHBOR_TTL: Duration = Duration::from_secs(60);
 
     pub fn new(name: String, inner: AxNetDevice, ip: Ipv4Cidr) -> Self {
+        let irq_num = inner.irq_num();
+        let inner = Arc::new(EthernetIrqState {
+            irq_num,
+            driver: SpinNoIrq::new(inner),
+            poll_ready: PollSet::new(),
+        });
+        if let Some(irq) = inner.irq_num {
+            *IRQ_SOURCE.lock() = Some(Arc::downgrade(&inner));
+            if !ax_hal::irq::register(irq, handle_ethernet_irq) {
+                warn!("failed to register ethernet irq handler for irq {irq}");
+            }
+        }
+
         let pending_packets = PacketBuffer::new(
             vec![PacketMetadata::EMPTY; ETHERNET_MAX_PENDING_PACKETS],
             vec![
@@ -57,7 +101,7 @@ impl EthernetDevice {
 
     #[inline]
     fn hardware_address(&self) -> EthernetAddress {
-        EthernetAddress(self.inner.mac_address().0)
+        EthernetAddress(self.inner.driver.lock().mac_address().0)
     }
 
     fn send_to<F>(
@@ -149,8 +193,9 @@ impl EthernetDevice {
             target_protocol_addr: target_ipv4,
         };
 
+        let mut inner = self.inner.driver.lock();
         Self::send_to(
-            &mut self.inner,
+            &mut inner,
             EthernetAddress::BROADCAST,
             arp_repr.buffer_len(),
             |buf| arp_repr.emit(&mut ArpPacket::new_unchecked(buf)),
@@ -215,8 +260,9 @@ impl EthernetDevice {
                     target_protocol_addr: source_protocol_addr,
                 };
 
+                let mut inner = self.inner.driver.lock();
                 Self::send_to(
-                    &mut self.inner,
+                    &mut inner,
                     source_hardware_addr,
                     response.buffer_len(),
                     |buf| response.emit(&mut ArpPacket::new_unchecked(buf)),
@@ -242,8 +288,9 @@ impl EthernetDevice {
                         break;
                     }
 
+                    let mut inner = self.inner.driver.lock();
                     Self::send_to(
-                        &mut self.inner,
+                        &mut inner,
                         neighbor.hardware_address,
                         buf.len(),
                         |b| b.copy_from_slice(buf),
@@ -263,13 +310,16 @@ impl Device for EthernetDevice {
 
     fn recv(&mut self, buffer: &mut PacketBuffer<()>, timestamp: Instant) -> bool {
         loop {
-            let rx_buf = match self.inner.receive() {
-                Ok(buf) => buf,
-                Err(err) => {
-                    if !matches!(err, DevError::Again) {
-                        warn!("receive failed: {:?}", err);
+            let rx_buf = {
+                let mut inner = self.inner.driver.lock();
+                match inner.receive() {
+                    Ok(buf) => buf,
+                    Err(err) => {
+                        if !matches!(err, DevError::Again) {
+                            warn!("receive failed: {:?}", err);
+                        }
+                        return false;
                     }
-                    return false;
                 }
             };
             trace!(
@@ -279,7 +329,7 @@ impl Device for EthernetDevice {
             );
 
             let result = self.handle_frame(rx_buf.packet(), buffer, timestamp);
-            self.inner.recycle_rx_buffer(rx_buf).unwrap();
+            self.inner.driver.lock().recycle_rx_buffer(rx_buf).unwrap();
             if result {
                 return true;
             }
@@ -288,8 +338,9 @@ impl Device for EthernetDevice {
 
     fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> bool {
         if next_hop.is_broadcast() || self.ip.broadcast().map(IpAddress::Ipv4) == Some(next_hop) {
+            let mut inner = self.inner.driver.lock();
             Self::send_to(
-                &mut self.inner,
+                &mut inner,
                 EthernetAddress::BROADCAST,
                 packet.len(),
                 |buf| buf.copy_from_slice(packet),
@@ -299,15 +350,20 @@ impl Device for EthernetDevice {
         }
 
         let need_request = match self.neighbors.get(&next_hop) {
-            Some(Some(neighbor)) if neighbor.expires_at > timestamp => {
-                Self::send_to(
-                    &mut self.inner,
-                    neighbor.hardware_address,
-                    packet.len(),
-                    |buf| buf.copy_from_slice(packet),
-                    EthernetProtocol::Ipv4,
-                );
-                return false;
+            Some(Some(neighbor)) => {
+                if neighbor.expires_at > timestamp {
+                    let mut inner = self.inner.driver.lock();
+                    Self::send_to(
+                        &mut inner,
+                        neighbor.hardware_address,
+                        packet.len(),
+                        |buf| buf.copy_from_slice(packet),
+                        EthernetProtocol::Ipv4,
+                    );
+                    return false;
+                } else {
+                    true
+                }
             }
             // Request already sent
             Some(None) => false,
@@ -315,7 +371,30 @@ impl Device for EthernetDevice {
         };
         // Only send ARP request if we haven't already requested it
         if need_request {
-            self.request_arp(next_hop);
+            let IpAddress::Ipv4(target_ipv4) = next_hop else {
+                warn!("IPv6 address ARP is not supported: {}", next_hop);
+                return false;
+            };
+            debug!("Requesting ARP for {}", target_ipv4);
+
+            let arp_repr = ArpRepr::EthernetIpv4 {
+                operation: ArpOperation::Request,
+                source_hardware_addr: self.hardware_address(),
+                source_protocol_addr: self.ip.address(),
+                target_hardware_addr: EthernetAddress::BROADCAST,
+                target_protocol_addr: target_ipv4,
+            };
+
+            let mut inner = self.inner.driver.lock();
+            Self::send_to(
+                &mut inner,
+                EthernetAddress::BROADCAST,
+                arp_repr.buffer_len(),
+                |buf| arp_repr.emit(&mut ArpPacket::new_unchecked(buf)),
+                EthernetProtocol::Arp,
+            );
+
+            self.neighbors.insert(next_hop, None);
         }
         if self.pending_packets.is_full() {
             warn!("Pending packets buffer is full, dropping packet");
@@ -330,8 +409,8 @@ impl Device for EthernetDevice {
     }
 
     fn register_waker(&self, waker: &Waker) {
-        if let Some(irq) = self.inner.irq_num() {
-            register_irq_waker(irq, waker);
+        if self.inner.irq_num.is_some() {
+            self.inner.poll_ready.register(waker);
         }
     }
 }

--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -24,7 +24,9 @@ use crate::{
 };
 
 const EMPTY_MAC: EthernetAddress = EthernetAddress([0; 6]);
-static IRQ_SOURCE: SpinNoIrq<Option<Weak<EthernetIrqState>>> = SpinNoIrq::new(None);
+const ETHERNET_IRQ_SLOTS: usize = 16;
+static IRQ_SOURCES: [SpinNoIrq<Option<Weak<EthernetIrqState>>>; ETHERNET_IRQ_SLOTS] =
+    [const { SpinNoIrq::new(None) }; ETHERNET_IRQ_SLOTS];
 
 struct Neighbor {
     hardware_address: EthernetAddress,
@@ -52,14 +54,60 @@ pub struct EthernetDevice {
     pending_packets: PacketBuffer<'static, IpAddress>,
 }
 
-fn handle_ethernet_irq() {
-    let Some(state) = IRQ_SOURCE.lock().as_ref().and_then(Weak::upgrade) else {
+fn handle_ethernet_irq(slot: usize) {
+    let Some(state) = IRQ_SOURCES[slot].lock().as_ref().and_then(Weak::upgrade) else {
         return;
     };
 
     let events = state.handle_irq();
     if events.intersects(NetIrqEvent::RX_READY | NetIrqEvent::RX_ERROR) {
         state.poll_ready.wake();
+    }
+}
+
+fn handle_ethernet_irq_slot<const SLOT: usize>() {
+    handle_ethernet_irq(SLOT);
+}
+
+const ETHERNET_IRQ_HANDLERS: [fn(); ETHERNET_IRQ_SLOTS] = [
+    handle_ethernet_irq_slot::<0>,
+    handle_ethernet_irq_slot::<1>,
+    handle_ethernet_irq_slot::<2>,
+    handle_ethernet_irq_slot::<3>,
+    handle_ethernet_irq_slot::<4>,
+    handle_ethernet_irq_slot::<5>,
+    handle_ethernet_irq_slot::<6>,
+    handle_ethernet_irq_slot::<7>,
+    handle_ethernet_irq_slot::<8>,
+    handle_ethernet_irq_slot::<9>,
+    handle_ethernet_irq_slot::<10>,
+    handle_ethernet_irq_slot::<11>,
+    handle_ethernet_irq_slot::<12>,
+    handle_ethernet_irq_slot::<13>,
+    handle_ethernet_irq_slot::<14>,
+    handle_ethernet_irq_slot::<15>,
+];
+
+fn reserve_ethernet_irq_slot(state: &Arc<EthernetIrqState>) -> Option<usize> {
+    for (slot, source) in IRQ_SOURCES.iter().enumerate() {
+        let mut source = source.lock();
+        if source.as_ref().and_then(Weak::upgrade).is_none() {
+            *source = Some(Arc::downgrade(state));
+            return Some(slot);
+        }
+    }
+
+    None
+}
+
+fn release_ethernet_irq_slot(slot: usize, state: &Arc<EthernetIrqState>) {
+    let mut source = IRQ_SOURCES[slot].lock();
+    if source
+        .as_ref()
+        .and_then(Weak::upgrade)
+        .is_some_and(|registered| Arc::ptr_eq(&registered, state))
+    {
+        *source = None;
     }
 }
 
@@ -73,13 +121,6 @@ impl EthernetDevice {
             driver: SpinNoIrq::new(inner),
             poll_ready: PollSet::new(),
         });
-        if let Some(irq) = inner.irq_num {
-            *IRQ_SOURCE.lock() = Some(Arc::downgrade(&inner));
-            if !ax_hal::irq::register(irq, handle_ethernet_irq) {
-                warn!("failed to register ethernet irq handler for irq {irq}");
-            }
-        }
-
         let pending_packets = PacketBuffer::new(
             vec![PacketMetadata::EMPTY; ETHERNET_MAX_PENDING_PACKETS],
             vec![
@@ -88,6 +129,24 @@ impl EthernetDevice {
                     * ETHERNET_MAX_PENDING_PACKETS
             ],
         );
+        if let Some(irq) = inner.irq_num {
+            let Some(slot) = reserve_ethernet_irq_slot(&inner) else {
+                warn!("no free ethernet irq source slot for irq {irq}");
+                return Self {
+                    name,
+                    inner,
+                    neighbors: HashMap::new(),
+                    ip,
+                    pending_packets,
+                };
+            };
+
+            if !ax_hal::irq::register(irq, ETHERNET_IRQ_HANDLERS[slot]) {
+                release_ethernet_irq_slot(slot, &inner);
+                warn!("failed to register ethernet irq handler for irq {irq}");
+            }
+        }
+
         Self {
             name,
             inner,

--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -17,7 +17,6 @@ use smoltcp::{
         EthernetRepr, IpAddress, Ipv4Cidr,
     },
 };
-use spin::Mutex;
 
 use crate::{
     consts::{ETHERNET_MAX_PENDING_PACKETS, STANDARD_MTU},
@@ -25,7 +24,7 @@ use crate::{
 };
 
 const EMPTY_MAC: EthernetAddress = EthernetAddress([0; 6]);
-static IRQ_SOURCE: Mutex<Option<Weak<EthernetIrqState>>> = Mutex::new(None);
+static IRQ_SOURCE: SpinNoIrq<Option<Weak<EthernetIrqState>>> = SpinNoIrq::new(None);
 
 struct Neighbor {
     hardware_address: EthernetAddress,
@@ -178,10 +177,10 @@ impl EthernetDevice {
         false
     }
 
-    fn request_arp(&mut self, target_ip: IpAddress) {
+    fn request_arp(&mut self, target_ip: IpAddress) -> bool {
         let IpAddress::Ipv4(target_ipv4) = target_ip else {
             warn!("IPv6 address ARP is not supported: {}", target_ip);
-            return;
+            return false;
         };
         debug!("Requesting ARP for {}", target_ipv4);
 
@@ -203,6 +202,7 @@ impl EthernetDevice {
         );
 
         self.neighbors.insert(target_ip, None);
+        true
     }
 
     fn process_arp(&mut self, payload: &[u8], now: Instant) {
@@ -284,7 +284,7 @@ impl EthernetDevice {
                     };
                     if neighbor.expires_at <= now {
                         // Neighbor is expired, we need to request ARP again
-                        self.request_arp(next_hop);
+                        let _ = self.request_arp(next_hop);
                         break;
                     }
 
@@ -350,51 +350,24 @@ impl Device for EthernetDevice {
         }
 
         let need_request = match self.neighbors.get(&next_hop) {
-            Some(Some(neighbor)) => {
-                if neighbor.expires_at > timestamp {
-                    let mut inner = self.inner.driver.lock();
-                    Self::send_to(
-                        &mut inner,
-                        neighbor.hardware_address,
-                        packet.len(),
-                        |buf| buf.copy_from_slice(packet),
-                        EthernetProtocol::Ipv4,
-                    );
-                    return false;
-                } else {
-                    true
-                }
+            Some(Some(neighbor)) if neighbor.expires_at > timestamp => {
+                let mut inner = self.inner.driver.lock();
+                Self::send_to(
+                    &mut inner,
+                    neighbor.hardware_address,
+                    packet.len(),
+                    |buf| buf.copy_from_slice(packet),
+                    EthernetProtocol::Ipv4,
+                );
+                return false;
             }
             // Request already sent
             Some(None) => false,
-            _ => true,
+            Some(Some(_)) | None => true,
         };
         // Only send ARP request if we haven't already requested it
-        if need_request {
-            let IpAddress::Ipv4(target_ipv4) = next_hop else {
-                warn!("IPv6 address ARP is not supported: {}", next_hop);
-                return false;
-            };
-            debug!("Requesting ARP for {}", target_ipv4);
-
-            let arp_repr = ArpRepr::EthernetIpv4 {
-                operation: ArpOperation::Request,
-                source_hardware_addr: self.hardware_address(),
-                source_protocol_addr: self.ip.address(),
-                target_hardware_addr: EthernetAddress::BROADCAST,
-                target_protocol_addr: target_ipv4,
-            };
-
-            let mut inner = self.inner.driver.lock();
-            Self::send_to(
-                &mut inner,
-                EthernetAddress::BROADCAST,
-                arp_repr.buffer_len(),
-                |buf| arp_repr.emit(&mut ArpPacket::new_unchecked(buf)),
-                EthernetProtocol::Arp,
-            );
-
-            self.neighbors.insert(next_hop, None);
+        if need_request && !self.request_arp(next_hop) {
+            return false;
         }
         if self.pending_packets.is_full() {
             warn!("Pending packets buffer is full, dropping packet");

--- a/os/arceos/modules/axnet-ng/src/vsock/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/vsock/stream.rs
@@ -342,10 +342,8 @@ impl Pollable for VsockStreamTransport {
         if let Ok(conn) = self.get_connection() {
             let mut conn = conn.lock();
             match conn.state() {
-                ConnectionState::Listening => {
-                    if events.contains(IoEvents::IN) {
-                        conn.register_accept_poll(context);
-                    }
+                ConnectionState::Listening if events.contains(IoEvents::IN) => {
+                    conn.register_accept_poll(context);
                 }
                 ConnectionState::Connected => {
                     if events.contains(IoEvents::IN) {
@@ -357,10 +355,8 @@ impl Pollable for VsockStreamTransport {
                         );
                     }
                 }
-                ConnectionState::Connecting => {
-                    if events.contains(IoEvents::OUT) {
-                        conn.register_connect_poll(context);
-                    }
+                ConnectionState::Connecting if events.contains(IoEvents::OUT) => {
+                    conn.register_connect_poll(context);
                 }
                 _ => {}
             }

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -42,8 +42,8 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
 /// Registers a waker for the given IRQ number.
 ///
 /// This is a generic transition helper for IRQ-driven async wakeups. New
-/// console/TTY and Starry NIC code should prefer platform-specific IRQ
-/// handlers over this bridge.
+/// Starry NIC code should prefer platform-specific IRQ handlers over this
+/// bridge.
 pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
     use alloc::collections::BTreeMap;
 

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -40,6 +40,10 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
 
 #[cfg(feature = "irq")]
 /// Registers a waker for the given IRQ number.
+///
+/// This is a generic transition helper for IRQ-driven async wakeups. New
+/// console/TTY code should prefer platform-specific IRQ handlers over this
+/// bridge.
 pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
     use alloc::collections::BTreeMap;
 

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -42,8 +42,8 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
 /// Registers a waker for the given IRQ number.
 ///
 /// This is a generic transition helper for IRQ-driven async wakeups. New
-/// console/TTY code should prefer platform-specific IRQ handlers over this
-/// bridge.
+/// console/TTY and Starry NIC code should prefer platform-specific IRQ
+/// handlers over this bridge.
 pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
     use alloc::collections::BTreeMap;
 

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -37,6 +37,7 @@ ax-driver-block.workspace = true
 ax-driver-net = { workspace = true, optional = true }
 ax-driver-virtio = { workspace = true, features = ["block", "net"] }
 ax-errno.workspace = true
+ax-kspin.workspace = true
 axklib.workspace = true
 ax-plat.workspace = true
 dma-api.workspace = true

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 default = ["smp", "irq" ]
 smp = ["ax-plat/smp"]
 irq = ["ax-plat/irq"]
+rtc = ["dep:ax-arm-pl031"]
 fp-simd = ["ax-cpu/fp-simd"]
 uspace = ["somehal/uspace"]
 hv = ["somehal/hv", "ax-cpu/arm-el2"]
@@ -36,6 +37,7 @@ ax-driver-base.workspace = true
 ax-driver-block.workspace = true
 ax-driver-net = { workspace = true, optional = true }
 ax-driver-virtio = { workspace = true, features = ["block", "net"] }
+ax-arm-pl031 = { workspace = true, optional = true }
 ax-errno.workspace = true
 ax-kspin.workspace = true
 axklib.workspace = true

--- a/platform/axplat-dyn/src/drivers/mod.rs
+++ b/platform/axplat-dyn/src/drivers/mod.rs
@@ -19,6 +19,8 @@ mod rknpu;
 #[cfg(feature = "serial")]
 mod serial;
 mod soc;
+#[cfg(feature = "rtc")]
+mod time;
 mod virtio;
 
 pub mod blk;

--- a/platform/axplat-dyn/src/drivers/net/mod.rs
+++ b/platform/axplat-dyn/src/drivers/net/mod.rs
@@ -3,10 +3,12 @@ extern crate alloc;
 use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
 
 use ax_driver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
-use ax_driver_net::{EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps};
+use ax_driver_net::{
+    EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps, NetIrqEvent,
+};
+use ax_kspin::SpinNoIrq;
 use rd_net::{Interface, NetError};
 use rdrive::{Device, DriverGeneric};
-use spin::Mutex;
 
 use super::DmaImpl;
 
@@ -60,7 +62,8 @@ pub struct Net {
     mac: [u8; 6],
     irq_num: Option<usize>,
     buf_pool: Arc<NetBufPool>,
-    state: Mutex<NetState>,
+    irq_handler: Option<rd_net::IrqHandler>,
+    state: SpinNoIrq<NetState>,
 }
 
 impl TryFrom<Device<PlatformNetDevice>> for Net {
@@ -73,6 +76,7 @@ impl TryFrom<Device<PlatformNetDevice>> for Net {
         let irq_num = dev.irq_num;
         let tx_queue = dev.net.create_tx_queue().map_err(map_net_err_to_dev_err)?;
         let rx_queue = dev.net.create_rx_queue().map_err(map_net_err_to_dev_err)?;
+        let irq_handler = irq_num.map(|_| dev.net.irq_handler());
         drop(dev);
 
         Ok(Self {
@@ -80,7 +84,8 @@ impl TryFrom<Device<PlatformNetDevice>> for Net {
             mac,
             irq_num,
             buf_pool: NetBufPool::new(NET_BUF_POOL_CAPACITY, NET_BUF_LEN)?,
-            state: Mutex::new(NetState {
+            irq_handler,
+            state: SpinNoIrq::new(NetState {
                 tx_queue,
                 rx_queue,
                 pending_rx: VecDeque::with_capacity(RX_PREFETCH_TARGET),
@@ -230,6 +235,33 @@ impl NetDriverOps for Net {
         net_buf.set_header_len(0);
         net_buf.set_packet_len(size);
         Ok(net_buf.into_buf_ptr())
+    }
+
+    fn handle_irq(&mut self) -> NetIrqEvent {
+        let Some(handler) = &self.irq_handler else {
+            return NetIrqEvent::SPURIOUS;
+        };
+
+        handler.handle();
+
+        let mut events = NetIrqEvent::empty();
+        let mut state = self.state.lock();
+        if let Err(err) = self.prefetch_rx_packets(&mut state, RX_PREFETCH_TARGET) {
+            warn!(
+                "failed to prefetch rx packets for {} during irq: {err:?}",
+                self.name
+            );
+            events |= NetIrqEvent::RX_ERROR;
+        }
+        if !state.pending_rx.is_empty() {
+            events |= NetIrqEvent::RX_READY;
+        }
+
+        if events.is_empty() {
+            NetIrqEvent::SPURIOUS
+        } else {
+            events
+        }
     }
 }
 

--- a/platform/axplat-dyn/src/drivers/time/mod.rs
+++ b/platform/axplat-dyn/src/drivers/time/mod.rs
@@ -1,0 +1,47 @@
+use ax_arm_pl031::Rtc;
+use rdrive::{PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo};
+
+use crate::drivers::iomap;
+
+module_driver!(
+    name: "pl031 rtc",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["arm,pl031"],
+        on_probe: probe
+    }],
+);
+
+fn probe(info: FdtInfo<'_>, _plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let regs = info.node.regs();
+    let Some(base_reg) = regs.first() else {
+        return Err(OnProbeError::other(alloc::format!(
+            "[{}] has no reg",
+            info.node.name()
+        )));
+    };
+
+    let mmio_size = base_reg.size.unwrap_or(0x1000);
+    let mmio_base = iomap((base_reg.address as usize).into(), mmio_size as usize)?;
+    let rtc = unsafe { Rtc::new(mmio_base.as_ptr().cast()) };
+    let unix_timestamp = rtc.get_unix_timestamp();
+    if unix_timestamp == 0 {
+        return Err(OnProbeError::other(alloc::format!(
+            "[{}] returned zero unix timestamp",
+            info.node.name()
+        )));
+    }
+
+    let epoch_time_nanos = u64::from(unix_timestamp) * 1_000_000_000;
+    if crate::generic_timer::try_init_epoch_offset(epoch_time_nanos) {
+        info!("Initialized wall clock from {}", info.node.name());
+    } else {
+        debug!(
+            "Skipping RTC {} because epoch offset is already initialized",
+            info.node.name()
+        );
+    }
+
+    Ok(())
+}

--- a/platform/axplat-dyn/src/generic_timer.rs
+++ b/platform/axplat-dyn/src/generic_timer.rs
@@ -1,36 +1,68 @@
 //! ARM Generic Timer.
 
+use core::sync::atomic::{AtomicU64, Ordering};
+
+const UNINIT_EPOCH_OFFSET_NANOS: u64 = u64::MAX;
+static EPOCH_OFFSET_NANOS: AtomicU64 = AtomicU64::new(UNINIT_EPOCH_OFFSET_NANOS);
+
+pub(crate) fn current_ticks() -> u64 {
+    somehal::timer::ticks() as _
+}
+
+pub(crate) fn ticks_to_nanos(ticks: u64) -> u64 {
+    let freq = somehal::timer::freq() as u64;
+    if freq == 0 {
+        return 0;
+    }
+    (ticks * ax_plat::time::NANOS_PER_SEC) / freq
+}
+
+pub(crate) fn nanos_to_ticks(nanos: u64) -> u64 {
+    let freq = somehal::timer::freq() as u64;
+    if freq == 0 {
+        return 0;
+    }
+    (nanos * freq) / ax_plat::time::NANOS_PER_SEC
+}
+
+pub(crate) fn try_init_epoch_offset(epoch_time_nanos: u64) -> bool {
+    let boot_offset = epoch_time_nanos.saturating_sub(ticks_to_nanos(current_ticks()));
+    EPOCH_OFFSET_NANOS
+        .compare_exchange(
+            UNINIT_EPOCH_OFFSET_NANOS,
+            boot_offset,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        )
+        .is_ok()
+}
+
 struct GenericTimer;
 
 #[impl_plat_interface]
 impl ax_plat::time::TimeIf for GenericTimer {
     /// Returns the current clock time in hardware ticks.
     fn current_ticks() -> u64 {
-        somehal::timer::ticks() as _
+        current_ticks()
     }
 
     /// Converts hardware ticks to nanoseconds.
     fn ticks_to_nanos(ticks: u64) -> u64 {
-        let freq = somehal::timer::freq() as u64;
-        if freq == 0 {
-            return 0;
-        }
-        (ticks * ax_plat::time::NANOS_PER_SEC) / freq
+        ticks_to_nanos(ticks)
     }
 
     /// Converts nanoseconds to hardware ticks.
     fn nanos_to_ticks(nanos: u64) -> u64 {
-        let freq = somehal::timer::freq() as u64;
-        if freq == 0 {
-            return 0;
-        }
-        (nanos * freq) / ax_plat::time::NANOS_PER_SEC
+        nanos_to_ticks(nanos)
     }
 
     /// Return epoch offset in nanoseconds (wall time offset to monotonic
     /// clock start).
     fn epochoffset_nanos() -> u64 {
-        0
+        match EPOCH_OFFSET_NANOS.load(Ordering::Acquire) {
+            UNINIT_EPOCH_OFFSET_NANOS => 0,
+            offset => offset,
+        }
     }
     /// Returns the IRQ number for the timer interrupt.
     #[cfg(feature = "irq")]

--- a/scripts/axbuild/src/rootfs/inject.rs
+++ b/scripts/axbuild/src/rootfs/inject.rs
@@ -17,6 +17,79 @@ use std::{
 
 use anyhow::{Context, bail, ensure};
 
+/// Reads a text file from a rootfs image with `debugfs`.
+///
+/// Returns `Ok(None)` when the image is readable but the guest path does not
+/// exist, allowing distro-specific files to be optional.
+pub(crate) fn read_text_file(
+    rootfs_img: &Path,
+    guest_path: &str,
+) -> anyhow::Result<Option<String>> {
+    ensure!(
+        guest_path.starts_with('/'),
+        "guest path must be absolute: `{guest_path}`"
+    );
+
+    let output = Command::new("debugfs")
+        .arg("-R")
+        .arg(format!("cat {guest_path}"))
+        .arg(rootfs_img)
+        .output()
+        .with_context(|| format!("failed to spawn debugfs for {}", rootfs_img.display()))?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !output.status.success() {
+        bail!(
+            "failed to read {guest_path} from {}: {}",
+            rootfs_img.display(),
+            stderr.trim()
+        );
+    }
+    if output.stdout.is_empty() && stderr.contains("File not found") {
+        return Ok(None);
+    }
+
+    String::from_utf8(output.stdout)
+        .map(Some)
+        .with_context(|| format!("{}:{guest_path} is not valid UTF-8", rootfs_img.display()))
+}
+
+/// Replaces one regular file inside a rootfs image with a host file.
+pub(crate) fn replace_file(
+    rootfs_img: &Path,
+    guest_path: &str,
+    source_path: &Path,
+) -> anyhow::Result<()> {
+    ensure!(
+        guest_path.starts_with('/'),
+        "guest path must be absolute: `{guest_path}`"
+    );
+
+    let mut commands = vec![
+        format!("rm {guest_path}"),
+        format!("write {} {guest_path}", source_path.display()),
+    ];
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(source_path)
+            .with_context(|| format!("failed to stat {}", source_path.display()))?
+            .permissions()
+            .mode();
+        commands.push(format!("sif {guest_path} mode 0{mode:o}"));
+    }
+
+    run_debugfs_script(
+        rootfs_img,
+        &commands,
+        &format!(
+            "failed to replace {guest_path} in {} with {}",
+            rootfs_img.display(),
+            source_path.display()
+        ),
+    )
+}
+
 /// Extracts the contents of a rootfs image into a host staging directory.
 pub(crate) fn extract_rootfs(rootfs_img: &Path, output_dir: &Path) -> anyhow::Result<()> {
     Command::new("debugfs")

--- a/scripts/axbuild/src/starry/apk.rs
+++ b/scripts/axbuild/src/starry/apk.rs
@@ -1,0 +1,185 @@
+//! APK mirror region helpers shared by Starry prebuild and runtime rootfs flows.
+
+use std::{fs, path::Path};
+
+use anyhow::{Context, bail};
+
+pub(crate) const STARRY_APK_REGION_VAR: &str = "STARRY_APK_REGION";
+const CHINA_ALPINE_MIRROR: &str = "https://mirrors.cernet.edu.cn/alpine";
+const US_ALPINE_MIRROR: &str = "https://dl-cdn.alpinelinux.org/alpine";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApkRegion {
+    China,
+    Us,
+}
+
+impl ApkRegion {
+    pub(crate) fn canonical_name(self) -> &'static str {
+        match self {
+            Self::China => "china",
+            Self::Us => "us",
+        }
+    }
+
+    fn mirror_base(self) -> &'static str {
+        match self {
+            Self::China => CHINA_ALPINE_MIRROR,
+            Self::Us => US_ALPINE_MIRROR,
+        }
+    }
+}
+
+pub(crate) fn apk_region_from_env() -> anyhow::Result<ApkRegion> {
+    let value = std::env::var(STARRY_APK_REGION_VAR).ok();
+    parse_apk_region(value.as_deref())
+}
+
+pub(crate) fn parse_apk_region(value: Option<&str>) -> anyhow::Result<ApkRegion> {
+    match value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase)
+    {
+        None => Ok(ApkRegion::China),
+        Some(value) if matches!(value.as_str(), "china" | "cn") => Ok(ApkRegion::China),
+        Some(value) if matches!(value.as_str(), "us" | "usa") => Ok(ApkRegion::Us),
+        Some(value) => bail!(
+            "unsupported {STARRY_APK_REGION_VAR} `{value}`; supported values are: china, cn, us, \
+             usa"
+        ),
+    }
+}
+
+pub(crate) fn rewrite_apk_repositories_for_region(
+    staging_root: &Path,
+    region: ApkRegion,
+) -> anyhow::Result<()> {
+    let path = staging_root.join("etc/apk/repositories");
+    let original =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let rewritten = rewrite_apk_repositories_content(&original, region);
+
+    fs::write(&path, rewritten).with_context(|| format!("failed to write {}", path.display()))
+}
+
+pub(crate) fn rewrite_apk_repositories_content(original: &str, region: ApkRegion) -> String {
+    let ends_with_newline = original.ends_with('\n');
+    let rewritten = original
+        .lines()
+        .map(|line| rewrite_apk_repository_line(line, region))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if ends_with_newline {
+        rewritten + "\n"
+    } else {
+        rewritten
+    }
+}
+
+fn rewrite_apk_repository_line(line: &str, region: ApkRegion) -> String {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return line.to_string();
+    }
+
+    let Some((_, suffix)) = trimmed.split_once("/alpine/") else {
+        return line.to_string();
+    };
+
+    let leading_len = line.len() - line.trim_start().len();
+    let trailing_len = line.len() - line.trim_end().len();
+    let trailing = if trailing_len == 0 {
+        ""
+    } else {
+        &line[line.len() - trailing_len..]
+    };
+
+    format!(
+        "{}{}/{}{}",
+        &line[..leading_len],
+        region.mirror_base(),
+        suffix,
+        trailing
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn parse_apk_region_defaults_to_china() {
+        assert_eq!(parse_apk_region(None).unwrap(), ApkRegion::China);
+        assert_eq!(parse_apk_region(Some("")).unwrap(), ApkRegion::China);
+    }
+
+    #[test]
+    fn parse_apk_region_accepts_supported_aliases() {
+        assert_eq!(parse_apk_region(Some("china")).unwrap(), ApkRegion::China);
+        assert_eq!(parse_apk_region(Some("cn")).unwrap(), ApkRegion::China);
+        assert_eq!(parse_apk_region(Some("us")).unwrap(), ApkRegion::Us);
+        assert_eq!(parse_apk_region(Some("usa")).unwrap(), ApkRegion::Us);
+    }
+
+    #[test]
+    fn parse_apk_region_rejects_unknown_value() {
+        let err = parse_apk_region(Some("europe")).unwrap_err().to_string();
+        assert!(err.contains(STARRY_APK_REGION_VAR));
+        assert!(err.contains("china, cn, us, usa"));
+    }
+
+    #[test]
+    fn rewrite_apk_repositories_switches_to_us_mirror() {
+        let input = "https://mirrors.cernet.edu.cn/alpine/v3.23/main\nhttps://mirrors.cernet.edu.cn/alpine/v3.23/community\n";
+
+        assert_eq!(
+            rewrite_apk_repositories_content(input, ApkRegion::Us),
+            "https://dl-cdn.alpinelinux.org/alpine/v3.23/main\nhttps://dl-cdn.alpinelinux.org/alpine/v3.23/community\n"
+        );
+    }
+
+    #[test]
+    fn rewrite_apk_repositories_switches_to_china_mirror() {
+        let input = "https://dl-cdn.alpinelinux.org/alpine/v3.23/main\nhttps://dl-cdn.alpinelinux.org/alpine/v3.23/community\n";
+
+        assert_eq!(
+            rewrite_apk_repositories_content(input, ApkRegion::China),
+            "https://mirrors.cernet.edu.cn/alpine/v3.23/main\nhttps://mirrors.cernet.edu.cn/alpine/v3.23/community\n"
+        );
+    }
+
+    #[test]
+    fn rewrite_apk_repositories_preserves_comments_blank_lines_and_other_urls() {
+        let input = "\n# keep me\n  https://example.com/not-alpine/main  \nhttps://mirror.nyist.edu.cn/alpine/v3.23/main\n";
+
+        assert_eq!(
+            rewrite_apk_repositories_content(input, ApkRegion::Us),
+            "\n# keep me\n  https://example.com/not-alpine/main  \nhttps://dl-cdn.alpinelinux.org/alpine/v3.23/main\n"
+        );
+    }
+
+    #[test]
+    fn rewrite_apk_repositories_for_region_updates_file() {
+        let root = tempdir().unwrap();
+        let repositories = root.path().join("etc/apk/repositories");
+        fs::create_dir_all(repositories.parent().unwrap()).unwrap();
+        fs::write(
+            &repositories,
+            "https://mirrors.cernet.edu.cn/alpine/v3.23/main\nhttps://mirrors.cernet.edu.cn/alpine/v3.23/community\n",
+        )
+        .unwrap();
+
+        rewrite_apk_repositories_for_region(root.path(), ApkRegion::Us).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&repositories).unwrap(),
+            "https://dl-cdn.alpinelinux.org/alpine/v3.23/main\nhttps://dl-cdn.alpinelinux.org/alpine/v3.23/community\n"
+        );
+    }
+}

--- a/scripts/axbuild/src/starry/case_build.rs
+++ b/scripts/axbuild/src/starry/case_build.rs
@@ -9,7 +9,6 @@
 use std::{
     collections::BTreeMap,
     fs,
-    net::IpAddr,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -17,7 +16,7 @@ use std::{
 use anyhow::{Context, bail, ensure};
 
 use super::{
-    case_assets,
+    apk, case_assets, resolver,
     test_suit::{StarryQemuCase, StarryQemuSubcase, StarryQemuSubcaseKind},
 };
 use crate::process::ProcessExt;
@@ -25,21 +24,15 @@ use crate::process::ProcessExt;
 const CASE_C_DIR_NAME: &str = "c";
 const CASE_PREBUILD_SCRIPT_NAME: &str = "prebuild.sh";
 const CASE_CMAKE_FILE_NAME: &str = "CMakeLists.txt";
-pub(crate) const STARRY_APK_REGION_VAR: &str = "STARRY_APK_REGION";
 pub(crate) const STARRY_STAGING_ROOT_VAR: &str = "STARRY_STAGING_ROOT";
 pub(crate) const STARRY_CASE_DIR_VAR: &str = "STARRY_CASE_DIR";
 pub(crate) const STARRY_CASE_C_DIR_VAR: &str = "STARRY_CASE_C_DIR";
 pub(crate) const STARRY_CASE_WORK_DIR_VAR: &str = "STARRY_CASE_WORK_DIR";
 pub(crate) const STARRY_CASE_BUILD_DIR_VAR: &str = "STARRY_CASE_BUILD_DIR";
 pub(crate) const STARRY_CASE_OVERLAY_DIR_VAR: &str = "STARRY_CASE_OVERLAY_DIR";
-const HOST_RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
-const HOST_RESOLVED_CONF_PATH: &str = "/run/systemd/resolve/resolv.conf";
-const DEFAULT_DNS_SERVERS: &[&str] = &["1.1.1.1", "8.8.8.8"];
 const CROSS_BINUTILS: &[&str] = &[
     "ld", "as", "ar", "ranlib", "strip", "nm", "objcopy", "objdump", "readelf",
 ];
-const CHINA_ALPINE_MIRROR: &str = "https://mirrors.cernet.edu.cn/alpine";
-const US_ALPINE_MIRROR: &str = "https://dl-cdn.alpinelinux.org/alpine";
 
 #[derive(Debug, Clone)]
 pub(crate) struct HostCrossBuildEnv {
@@ -62,28 +55,6 @@ pub(crate) struct CrossCompileSpec {
 pub(crate) struct GuestPrebuildEnv {
     qemu_runner: PathBuf,
     script_envs: Vec<(String, String)>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ApkRegion {
-    China,
-    Us,
-}
-
-impl ApkRegion {
-    fn canonical_name(self) -> &'static str {
-        match self {
-            Self::China => "china",
-            Self::Us => "us",
-        }
-    }
-
-    fn mirror_base(self) -> &'static str {
-        match self {
-            Self::China => CHINA_ALPINE_MIRROR,
-            Self::Us => US_ALPINE_MIRROR,
-        }
-    }
 }
 
 /// Returns the C source directory for a Starry test case.
@@ -120,11 +91,11 @@ pub(crate) fn prepare_c_case_assets_sync(
         .with_context(|| format!("failed to create {}", layout.apk_cache_dir.display()))?;
 
     crate::rootfs::inject::extract_rootfs(case_rootfs, &layout.staging_root)?;
-    write_host_resolver_config(&layout.staging_root)?;
+    resolver::write_host_resolver_config(&layout.staging_root)?;
     let prebuild_script = case_prebuild_script_path(case);
     if prebuild_script.is_file() {
-        let apk_region = apk_region_from_env()?;
-        rewrite_apk_repositories_for_region(&layout.staging_root, apk_region)?;
+        let apk_region = apk::apk_region_from_env()?;
+        apk::rewrite_apk_repositories_for_region(&layout.staging_root, apk_region)?;
         log_apk_prebuild_context(&layout.staging_root, apk_region)?;
         let prebuild_env = prepare_guest_prebuild_env(arch, case, layout, apk_region)?;
         let mut command = build_prebuild_command(case, &prebuild_script, layout, &prebuild_env)?;
@@ -182,7 +153,7 @@ pub(crate) fn prepare_grouped_case_assets_sync(
         .with_context(|| format!("failed to create {}", layout.apk_cache_dir.display()))?;
 
     crate::rootfs::inject::extract_rootfs(case_rootfs, &layout.staging_root)?;
-    write_host_resolver_config(&layout.staging_root)?;
+    resolver::write_host_resolver_config(&layout.staging_root)?;
 
     let c_subcases = case
         .subcases
@@ -211,8 +182,8 @@ fn prepare_grouped_c_subcases_sync(
         .iter()
         .any(|subcase| case_prebuild_script_path(&subcase_as_case(case, subcase)).is_file())
     {
-        let apk_region = apk_region_from_env()?;
-        rewrite_apk_repositories_for_region(&layout.staging_root, apk_region)?;
+        let apk_region = apk::apk_region_from_env()?;
+        apk::rewrite_apk_repositories_for_region(&layout.staging_root, apk_region)?;
         log_apk_prebuild_context(&layout.staging_root, apk_region)?;
 
         for subcase in subcases {
@@ -329,11 +300,11 @@ pub(crate) fn prepare_python_case_assets_sync(
 
     // Extract rootfs into staging
     crate::rootfs::inject::extract_rootfs(case_rootfs, &layout.staging_root)?;
-    write_host_resolver_config(&layout.staging_root)?;
+    resolver::write_host_resolver_config(&layout.staging_root)?;
 
     // Prepare guest prebuild environment and install python3
-    let apk_region = apk_region_from_env()?;
-    rewrite_apk_repositories_for_region(&layout.staging_root, apk_region)?;
+    let apk_region = apk::apk_region_from_env()?;
+    apk::rewrite_apk_repositories_for_region(&layout.staging_root, apk_region)?;
     log_apk_prebuild_context(&layout.staging_root, apk_region)?;
 
     let qemu_runner = find_host_binary_candidates(qemu_user_binary_names(arch)?)?;
@@ -522,134 +493,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path, allowed_root: &Path) -> anyhow::Re
     Ok(())
 }
 
-fn write_host_resolver_config(staging_root: &Path) -> anyhow::Result<()> {
-    let resolv_conf = preferred_host_resolver_config()?;
-    let output_path = staging_root.join("etc/resolv.conf");
-    fs::write(&output_path, resolv_conf)
-        .with_context(|| format!("failed to write {}", output_path.display()))
-}
-
-fn preferred_host_resolver_config() -> anyhow::Result<String> {
-    if let Some(content) = read_usable_resolver_file(Path::new(HOST_RESOLVED_CONF_PATH))? {
-        return Ok(content);
-    }
-    if let Some(content) = read_usable_resolver_file(Path::new(HOST_RESOLV_CONF_PATH))? {
-        return Ok(content);
-    }
-
-    Ok(DEFAULT_DNS_SERVERS
-        .iter()
-        .map(|server| format!("nameserver {server}"))
-        .collect::<Vec<_>>()
-        .join("\n")
-        + "\n")
-}
-
-fn read_usable_resolver_file(path: &Path) -> anyhow::Result<Option<String>> {
-    if !path.is_file() {
-        return Ok(None);
-    }
-
-    let content =
-        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let usable = content
-        .lines()
-        .filter_map(parse_nameserver_line)
-        .filter(|addr| !addr.is_loopback() && *addr != IpAddr::from([10, 0, 2, 3]))
-        .map(|addr| format!("nameserver {addr}"))
-        .collect::<Vec<_>>();
-
-    if usable.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(usable.join("\n") + "\n"))
-    }
-}
-
-pub(crate) fn parse_nameserver_line(line: &str) -> Option<IpAddr> {
-    let trimmed = line.trim();
-    if trimmed.is_empty() || trimmed.starts_with('#') {
-        return None;
-    }
-
-    let mut parts = trimmed.split_whitespace();
-    match (parts.next(), parts.next(), parts.next()) {
-        (Some("nameserver"), Some(value), None) => value.parse().ok(),
-        _ => None,
-    }
-}
-
-fn apk_region_from_env() -> anyhow::Result<ApkRegion> {
-    let value = std::env::var(STARRY_APK_REGION_VAR).ok();
-    parse_apk_region(value.as_deref())
-}
-
-pub(crate) fn parse_apk_region(value: Option<&str>) -> anyhow::Result<ApkRegion> {
-    match value
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_ascii_lowercase)
-    {
-        None => Ok(ApkRegion::China),
-        Some(value) if matches!(value.as_str(), "china" | "cn") => Ok(ApkRegion::China),
-        Some(value) if matches!(value.as_str(), "us" | "usa") => Ok(ApkRegion::Us),
-        Some(value) => bail!(
-            "unsupported {STARRY_APK_REGION_VAR} `{value}`; supported values are: china, cn, us, \
-             usa"
-        ),
-    }
-}
-
-fn rewrite_apk_repositories_for_region(
-    staging_root: &Path,
-    region: ApkRegion,
-) -> anyhow::Result<()> {
-    let path = staging_root.join("etc/apk/repositories");
-    let original =
-        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
-    let ends_with_newline = original.ends_with('\n');
-    let rewritten = original
-        .lines()
-        .map(|line| rewrite_apk_repository_line(line, region))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let mut output = rewritten;
-    if ends_with_newline {
-        output.push('\n');
-    }
-
-    fs::write(&path, output).with_context(|| format!("failed to write {}", path.display()))
-}
-
-fn rewrite_apk_repository_line(line: &str, region: ApkRegion) -> String {
-    let trimmed = line.trim();
-    if trimmed.is_empty() || trimmed.starts_with('#') {
-        return line.to_string();
-    }
-
-    let Some((_, suffix)) = trimmed.split_once("/alpine/") else {
-        return line.to_string();
-    };
-
-    let leading_len = line.len() - line.trim_start().len();
-    let trailing_len = line.len() - line.trim_end().len();
-    let trailing = if trailing_len == 0 {
-        ""
-    } else {
-        &line[line.len() - trailing_len..]
-    };
-
-    format!(
-        "{}{}/{}{}",
-        &line[..leading_len],
-        region.mirror_base(),
-        suffix,
-        trailing
-    )
-}
-
-fn log_apk_prebuild_context(staging_root: &Path, region: ApkRegion) -> anyhow::Result<()> {
+fn log_apk_prebuild_context(staging_root: &Path, region: apk::ApkRegion) -> anyhow::Result<()> {
     let repositories_path = staging_root.join("etc/apk/repositories");
     let repositories = fs::read_to_string(&repositories_path)
         .with_context(|| format!("failed to read {}", repositories_path.display()))?;
@@ -668,14 +512,14 @@ fn prepare_guest_prebuild_env(
     arch: &str,
     case: &StarryQemuCase,
     layout: &case_assets::CaseAssetLayout,
-    apk_region: ApkRegion,
+    apk_region: apk::ApkRegion,
 ) -> anyhow::Result<GuestPrebuildEnv> {
     let qemu_runner = find_host_binary_candidates(qemu_user_binary_names(arch)?)?;
     write_guest_command_wrappers(layout, &qemu_runner)?;
 
     let mut script_envs = case_script_envs(case, layout);
     script_envs.push((
-        STARRY_APK_REGION_VAR.to_string(),
+        apk::STARRY_APK_REGION_VAR.to_string(),
         apk_region.canonical_name().to_string(),
     ));
 
@@ -1226,7 +1070,7 @@ mod tests {
             qemu_runner: PathBuf::from("/usr/bin/qemu-aarch64-static"),
             script_envs: {
                 let mut envs = case_script_envs(&case, &layout);
-                envs.push((STARRY_APK_REGION_VAR.to_string(), "us".to_string()));
+                envs.push((apk::STARRY_APK_REGION_VAR.to_string(), "us".to_string()));
                 envs
             },
         };
@@ -1263,7 +1107,7 @@ mod tests {
             Some(layout.overlay_dir.display().to_string())
         );
         assert_eq!(
-            command_env(&command, STARRY_APK_REGION_VAR),
+            command_env(&command, apk::STARRY_APK_REGION_VAR),
             Some("us".to_string())
         );
     }
@@ -1409,18 +1253,6 @@ mod tests {
     }
 
     #[test]
-    fn preferred_resolver_filters_loopback_and_slirp_addresses() {
-        let content = "nameserver 127.0.0.53\nnameserver 10.0.2.3\nnameserver 8.8.8.8\n";
-        let usable = content
-            .lines()
-            .filter_map(parse_nameserver_line)
-            .filter(|addr| !addr.is_loopback() && *addr != IpAddr::from([10, 0, 2, 3]))
-            .map(|addr| format!("nameserver {addr}"))
-            .collect::<Vec<_>>();
-        assert_eq!(usable, vec!["nameserver 8.8.8.8".to_string()]);
-    }
-
-    #[test]
     fn case_script_envs_include_expected_paths() {
         let root = tempdir().unwrap();
         let case = fake_case(root.path(), "usb");
@@ -1438,76 +1270,6 @@ mod tests {
             STARRY_CASE_BUILD_DIR_VAR.to_string(),
             layout.build_dir.display().to_string()
         )));
-    }
-
-    #[test]
-    fn parse_apk_region_defaults_to_china() {
-        assert_eq!(parse_apk_region(None).unwrap(), ApkRegion::China);
-        assert_eq!(parse_apk_region(Some("")).unwrap(), ApkRegion::China);
-    }
-
-    #[test]
-    fn parse_apk_region_accepts_supported_aliases() {
-        assert_eq!(parse_apk_region(Some("china")).unwrap(), ApkRegion::China);
-        assert_eq!(parse_apk_region(Some("cn")).unwrap(), ApkRegion::China);
-        assert_eq!(parse_apk_region(Some("us")).unwrap(), ApkRegion::Us);
-        assert_eq!(parse_apk_region(Some("usa")).unwrap(), ApkRegion::Us);
-    }
-
-    #[test]
-    fn parse_apk_region_rejects_unknown_value() {
-        let err = parse_apk_region(Some("europe")).unwrap_err().to_string();
-        assert!(err.contains(STARRY_APK_REGION_VAR));
-        assert!(err.contains("china, cn, us, usa"));
-    }
-
-    #[test]
-    fn rewrite_apk_repositories_switches_to_us_mirror() {
-        let input = "https://mirrors.cernet.edu.cn/alpine/v3.23/main\nhttps://mirrors.cernet.edu.cn/alpine/v3.23/community\n";
-        let output = input
-            .lines()
-            .map(|line| rewrite_apk_repository_line(line, ApkRegion::Us))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert_eq!(
-            output,
-            "https://dl-cdn.alpinelinux.org/alpine/v3.23/main\nhttps://dl-cdn.alpinelinux.org/alpine/v3.23/community"
-        );
-    }
-
-    #[test]
-    fn rewrite_apk_repositories_switches_to_china_mirror() {
-        let input = "https://dl-cdn.alpinelinux.org/alpine/v3.23/main\nhttps://dl-cdn.alpinelinux.org/alpine/v3.23/community\n";
-        let output = input
-            .lines()
-            .map(|line| rewrite_apk_repository_line(line, ApkRegion::China))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert_eq!(
-            output,
-            "https://mirrors.cernet.edu.cn/alpine/v3.23/main\nhttps://mirrors.cernet.edu.cn/alpine/v3.23/community"
-        );
-    }
-
-    #[test]
-    fn rewrite_apk_repositories_for_region_updates_file() {
-        let root = tempdir().unwrap();
-        let repositories = root.path().join("etc/apk/repositories");
-        fs::create_dir_all(repositories.parent().unwrap()).unwrap();
-        fs::write(
-            &repositories,
-            "https://mirrors.cernet.edu.cn/alpine/v3.23/main\nhttps://mirrors.cernet.edu.cn/alpine/v3.23/community\n",
-        )
-        .unwrap();
-
-        rewrite_apk_repositories_for_region(root.path(), ApkRegion::Us).unwrap();
-
-        assert_eq!(
-            fs::read_to_string(&repositories).unwrap(),
-            "https://dl-cdn.alpinelinux.org/alpine/v3.23/main\nhttps://dl-cdn.alpinelinux.org/alpine/v3.23/community\n"
-        );
     }
 
     #[test]

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -20,12 +20,14 @@ use crate::{
     test_qemu,
 };
 
+pub(crate) mod apk;
 pub mod board;
 pub mod build;
 pub mod case_assets;
 pub mod case_build;
 pub mod config;
 pub mod quick_start;
+pub(crate) mod resolver;
 pub mod rootfs;
 pub mod test_suit;
 
@@ -257,8 +259,9 @@ impl Starry {
             let rootfs =
                 rootfs_store::resolve_rootfs_path(self.app.workspace_root(), &request.arch, rootfs);
             // If the path resolves into the unified rootfs dir, ensure the
-            // tarball has been extracted (keyword paths need this).
-            rootfs_store::ensure_managed_rootfs(self.app.workspace_root(), &request.arch, &rootfs)
+            // tarball has been extracted and the managed image uses the
+            // requested APK region (keyword paths need this).
+            rootfs::ensure_managed_rootfs(self.app.workspace_root(), &request.arch, &rootfs)
                 .await?;
             self.app.set_debug_mode(request.debug)?;
             let cargo = build::load_cargo_config(&request)?;

--- a/scripts/axbuild/src/starry/resolver.rs
+++ b/scripts/axbuild/src/starry/resolver.rs
@@ -1,0 +1,85 @@
+//! Resolver helpers for Starry guest prebuild staging roots.
+
+use std::{fs, net::IpAddr, path::Path};
+
+use anyhow::Context;
+
+const HOST_RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
+const HOST_RESOLVED_CONF_PATH: &str = "/run/systemd/resolve/resolv.conf";
+const DEFAULT_DNS_SERVERS: &[&str] = &["1.1.1.1", "8.8.8.8"];
+
+pub(crate) fn write_host_resolver_config(staging_root: &Path) -> anyhow::Result<()> {
+    let resolv_conf = preferred_host_resolver_config()?;
+    let output_path = staging_root.join("etc/resolv.conf");
+    fs::write(&output_path, resolv_conf)
+        .with_context(|| format!("failed to write {}", output_path.display()))
+}
+
+pub(crate) fn preferred_host_resolver_config() -> anyhow::Result<String> {
+    if let Some(content) = read_usable_resolver_file(Path::new(HOST_RESOLVED_CONF_PATH))? {
+        return Ok(content);
+    }
+    if let Some(content) = read_usable_resolver_file(Path::new(HOST_RESOLV_CONF_PATH))? {
+        return Ok(content);
+    }
+
+    Ok(DEFAULT_DNS_SERVERS
+        .iter()
+        .map(|server| format!("nameserver {server}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n")
+}
+
+fn read_usable_resolver_file(path: &Path) -> anyhow::Result<Option<String>> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let usable = content
+        .lines()
+        .filter_map(parse_nameserver_line)
+        .filter(|addr| !addr.is_loopback() && *addr != IpAddr::from([10, 0, 2, 3]))
+        .map(|addr| format!("nameserver {addr}"))
+        .collect::<Vec<_>>();
+
+    if usable.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(usable.join("\n") + "\n"))
+    }
+}
+
+pub(crate) fn parse_nameserver_line(line: &str) -> Option<IpAddr> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some("nameserver"), Some(value), None) => value.parse().ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use super::*;
+
+    #[test]
+    fn preferred_resolver_filters_loopback_and_slirp_addresses() {
+        let content = "nameserver 127.0.0.53\nnameserver 10.0.2.3\nnameserver 8.8.8.8\n";
+        let usable = content
+            .lines()
+            .filter_map(parse_nameserver_line)
+            .filter(|addr| !addr.is_loopback() && *addr != IpAddr::from([10, 0, 2, 3]))
+            .map(|addr| format!("nameserver {addr}"))
+            .collect::<Vec<_>>();
+        assert_eq!(usable, vec!["nameserver 8.8.8.8".to_string()]);
+    }
+}

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -7,16 +7,27 @@
 //! - Orchestrate staging roots, overlays, runtime dependency sync, and helper
 //!   tooling around rootfs content injection
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    io::{Read, Seek, SeekFrom},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
-use anyhow::bail;
+use anyhow::{Context, bail};
 use ostool::run::qemu::QemuConfig;
 
+use super::apk;
 pub(crate) use crate::rootfs::qemu::{RootfsPatchMode, patch_rootfs};
 use crate::{
     context::{ResolvedStarryRequest, starry_target_for_arch_checked},
-    rootfs::store,
+    rootfs::{inject, store},
 };
+
+const APK_REPOSITORIES_PATH: &str = "/etc/apk/repositories";
+const QEMU_SLIRP_RESOLV_CONF: &str = "nameserver 10.0.2.3\n";
+const EXT_SUPER_MAGIC_OFFSET: u64 = 1080;
+const EXT_SUPER_MAGIC: [u8; 2] = [0x53, 0xef];
 
 /// Ensures the default managed rootfs for a Starry arch/target is available.
 pub(crate) async fn ensure_rootfs_in_target_dir(
@@ -29,7 +40,113 @@ pub(crate) async fn ensure_rootfs_in_target_dir(
         bail!("Starry arch `{arch}` maps to target `{expected_target}`, but got `{target}`");
     }
 
-    store::ensure_rootfs_for_arch(workspace_root, arch).await
+    let rootfs = store::ensure_rootfs_for_arch(workspace_root, arch).await?;
+    ensure_apk_region_in_rootfs(&rootfs)?;
+    Ok(rootfs)
+}
+
+/// Ensures a user-requested rootfs path exists and patches it when managed.
+pub(crate) async fn ensure_managed_rootfs(
+    workspace_root: &Path,
+    arch: &str,
+    path: &Path,
+) -> anyhow::Result<()> {
+    store::ensure_managed_rootfs(workspace_root, arch, path).await?;
+    if is_managed_rootfs_path(workspace_root, arch, path) && path.exists() {
+        ensure_apk_region_in_rootfs(path)?;
+    }
+    Ok(())
+}
+
+fn is_managed_rootfs_path(workspace_root: &Path, arch: &str, path: &Path) -> bool {
+    path.starts_with(store::rootfs_dir(workspace_root))
+        && store::default_rootfs_image(arch).is_some()
+}
+
+fn ensure_apk_region_in_rootfs(rootfs_img: &Path) -> anyhow::Result<()> {
+    if !looks_like_ext_image(rootfs_img)? {
+        return Ok(());
+    }
+
+    let Some(original) = inject::read_text_file(rootfs_img, APK_REPOSITORIES_PATH)? else {
+        sync_qemu_slirp_resolver_in_rootfs(rootfs_img)?;
+        return Ok(());
+    };
+    let region = apk::apk_region_from_env()?;
+    let rewritten = apk::rewrite_apk_repositories_content(&original, region);
+    replace_rootfs_text_file_if_changed(rootfs_img, APK_REPOSITORIES_PATH, &rewritten)?;
+    sync_qemu_slirp_resolver_in_rootfs(rootfs_img)
+}
+
+fn sync_qemu_slirp_resolver_in_rootfs(rootfs_img: &Path) -> anyhow::Result<()> {
+    replace_rootfs_text_file_if_changed(rootfs_img, "/etc/resolv.conf", QEMU_SLIRP_RESOLV_CONF)
+}
+
+fn replace_rootfs_text_file_if_changed(
+    rootfs_img: &Path,
+    guest_path: &str,
+    content: &str,
+) -> anyhow::Result<()> {
+    if inject::read_text_file(rootfs_img, guest_path)?.as_deref() == Some(content) {
+        return Ok(());
+    }
+
+    let temp_purpose = guest_path.trim_start_matches('/').replace('/', "-");
+    let temp_path = unique_temp_file_path(rootfs_img, &temp_purpose)?;
+    fs::write(&temp_path, content)
+        .with_context(|| format!("failed to write {}", temp_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o644))
+            .with_context(|| format!("failed to chmod {}", temp_path.display()))?;
+    }
+    let replace_result = inject::replace_file(rootfs_img, guest_path, &temp_path);
+    let cleanup_result = fs::remove_file(&temp_path)
+        .with_context(|| format!("failed to remove {}", temp_path.display()));
+
+    replace_result?;
+    cleanup_result?;
+    Ok(())
+}
+
+fn looks_like_ext_image(path: &Path) -> anyhow::Result<bool> {
+    let mut file =
+        fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    if file
+        .metadata()
+        .with_context(|| format!("failed to stat {}", path.display()))?
+        .len()
+        < EXT_SUPER_MAGIC_OFFSET + EXT_SUPER_MAGIC.len() as u64
+    {
+        return Ok(false);
+    }
+
+    let mut magic = [0_u8; 2];
+    file.seek(SeekFrom::Start(EXT_SUPER_MAGIC_OFFSET))
+        .with_context(|| format!("failed to seek {}", path.display()))?;
+    file.read_exact(&mut magic)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    Ok(magic == EXT_SUPER_MAGIC)
+}
+
+fn unique_temp_file_path(rootfs_img: &Path, purpose: &str) -> anyhow::Result<PathBuf> {
+    let dir = rootfs_img
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("rootfs image has no parent: {}", rootfs_img.display()))?;
+    let image_name = rootfs_img
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow::anyhow!("invalid rootfs image path: {}", rootfs_img.display()))?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before UNIX_EPOCH")?
+        .as_nanos();
+    Ok(dir.join(format!(
+        ".{image_name}.{purpose}.{}.{}.tmp",
+        std::process::id(),
+        nanos
+    )))
 }
 
 /// Applies the default Starry rootfs-backed QEMU arguments for a request.

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -28,6 +28,7 @@ ax-crate-interface-lite
 ax-display
 ax-dma
 ax-driver-display
+ax-driver-virtio
 ax-errno
 ax-fs
 ax-hal
@@ -46,6 +47,7 @@ ax-kspin
 ax-kernel-guard
 ax-lazyinit
 ax-memory-set
+ax-plat-x86-pc
 ax-percpu
 ax-percpu-macros
 axaddrspace

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -64,6 +64,7 @@ axfs-ng-vfs
 axhvc
 axklib
 axpoll
+ax-plat
 axplat-x86-qemu-q35
 axvm
 axvmconfig

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -52,6 +52,7 @@ axaddrspace
 ax-linked-list-r4l
 ax-log
 ax-mm
+ax-net-ng
 ax-riscv-plic
 ax-sched
 ax-sync

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -28,7 +28,6 @@ ax-crate-interface-lite
 ax-display
 ax-dma
 ax-driver-display
-ax-driver-net
 ax-errno
 ax-fs
 ax-hal
@@ -64,7 +63,6 @@ axfs-ng-vfs
 axhvc
 axklib
 axpoll
-ax-plat
 axplat-x86-qemu-q35
 axvm
 axvmconfig

--- a/test-suit/starryos/normal/apk-curl/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/apk-curl/qemu-aarch64.toml
@@ -24,4 +24,4 @@ echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 180
+timeout = 600

--- a/test-suit/starryos/normal/apk-curl/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/apk-curl/qemu-aarch64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+apk update && \
+apk add curl && \
+curl --version && \
+curl -i https://baidu.com && \
+echo 'APK_CURL_TEST_PASSED' || \
+echo 'APK_CURL_TEST_FAILED'
+'''
+success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
+timeout = 180

--- a/test-suit/starryos/normal/apk-curl/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/apk-curl/qemu-loongarch64.toml
@@ -1,0 +1,34 @@
+args = [
+  "-machine",
+  "virt",
+  "-cpu",
+  "la464",
+  "-nographic",
+  "-m",
+  "512M",
+  "-device",
+  "virtio-blk-pci,drive=disk0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+  "-device",
+  "virtio-net-pci,netdev=net0",
+  "-netdev",
+  "user,id=net0",
+]
+to_bin = true
+uefi = false
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+printf '%s\n' '120.194.101.75 mirror.nyist.edu.cn' '124.237.177.164 baidu.com' >> /etc/hosts && \
+sed -i 's|https://mirrors.cernet.edu.cn/alpine|https://mirror.nyist.edu.cn/alpine|g' /etc/apk/repositories && \
+sed -i 's|https://dl-cdn.alpinelinux.org/alpine|https://mirror.nyist.edu.cn/alpine|g' /etc/apk/repositories && \
+apk update && \
+apk add curl && \
+curl --version && \
+curl -i https://baidu.com && \
+echo 'APK_CURL_TEST_PASSED' || \
+echo 'APK_CURL_TEST_FAILED'
+'''
+success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
+timeout = 600

--- a/test-suit/starryos/normal/apk-curl/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/apk-curl/qemu-loongarch64.toml
@@ -19,9 +19,6 @@ to_bin = true
 uefi = false
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
-printf '%s\n' '120.194.101.75 mirror.nyist.edu.cn' '124.237.177.164 baidu.com' >> /etc/hosts && \
-sed -i 's|https://mirrors.cernet.edu.cn/alpine|https://mirror.nyist.edu.cn/alpine|g' /etc/apk/repositories && \
-sed -i 's|https://dl-cdn.alpinelinux.org/alpine|https://mirror.nyist.edu.cn/alpine|g' /etc/apk/repositories && \
 apk update && \
 apk add curl && \
 curl --version && \

--- a/test-suit/starryos/normal/apk-curl/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/apk-curl/qemu-riscv64.toml
@@ -24,4 +24,4 @@ echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 180
+timeout = 600

--- a/test-suit/starryos/normal/apk-curl/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/apk-curl/qemu-riscv64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+apk update && \
+apk add curl && \
+curl --version && \
+curl -i https://baidu.com && \
+echo 'APK_CURL_TEST_PASSED' || \
+echo 'APK_CURL_TEST_FAILED'
+'''
+success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
+timeout = 180

--- a/test-suit/starryos/normal/apk-curl/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/apk-curl/qemu-x86_64.toml
@@ -1,0 +1,32 @@
+args = [
+    "-machine",
+    "q35",
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+printf '%s\n' '120.194.101.75 mirror.nyist.edu.cn' '124.237.177.164 baidu.com' >> /etc/hosts && \
+sed -i 's|https://mirrors.cernet.edu.cn/alpine|https://mirror.nyist.edu.cn/alpine|g' /etc/apk/repositories && \
+sed -i 's|https://dl-cdn.alpinelinux.org/alpine|https://mirror.nyist.edu.cn/alpine|g' /etc/apk/repositories && \
+apk update && \
+apk add curl && \
+curl --version && \
+curl -i https://baidu.com && \
+echo 'APK_CURL_TEST_PASSED' || \
+echo 'APK_CURL_TEST_FAILED'
+'''
+success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
+timeout = 600

--- a/test-suit/starryos/normal/apk-curl/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/apk-curl/qemu-x86_64.toml
@@ -17,9 +17,6 @@ uefi = false
 to_bin = false
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
-printf '%s\n' '120.194.101.75 mirror.nyist.edu.cn' '124.237.177.164 baidu.com' >> /etc/hosts && \
-sed -i 's|https://mirrors.cernet.edu.cn/alpine|https://mirror.nyist.edu.cn/alpine|g' /etc/apk/repositories && \
-sed -i 's|https://dl-cdn.alpinelinux.org/alpine|https://mirror.nyist.edu.cn/alpine|g' /etc/apk/repositories && \
 apk update && \
 apk add curl && \
 curl --version && \


### PR DESCRIPTION
## Summary

本 PR 聚焦 Starry/ArceOS 的设备事件链路。console/tty 相关改动已经拆出后，本 PR 当前主要覆盖网络 IRQ、动态平台 RTC，以及用于验证真实网络收包路径的 StarryOS `apk-curl` 回归测试。

- 为网卡驱动增加 `NetIrqEvent` 和 `NetDriverOps::handle_irq()`，让驱动可以在中断上下文中 ack 设备中断并报告 `RX_READY` / `TX_DONE` / `RX_ERROR`。
- 将 virtio-net、`axnet-ng` 和 `axplat-dyn` 的网络路径接入 IRQ 事件模型；`axnet-ng` 通过 IRQ handler 唤醒 `PollSet`，避免依赖周期性轮询兜底。
- 将 `PollSet` 和 StarryOS pseudofs 中断相邻路径上的共享状态改为 `SpinNoIrq`，避免在 IRQ/关中断相关路径使用 sleeping lock。
- 为 `axplat-dyn` 增加 PL031 RTC 探测，并用 RTC 初始化 generic timer 的 epoch offset。
- 修复 x86_64 QEMU virtio PCI INTx 到 IOAPIC 的路由问题。
- 修复 loongarch64 外部 IRQ handler table 过小导致 virtio-net IRQ 注册失败的问题。
- 新增 StarryOS `normal/apk-curl` QEMU 测试，覆盖 `apk update && apk add curl && curl --version && curl -i https://baidu.com`。

## Bugs Fixed

1. 网络接收事件可能无法唤醒等待者。

   根因是驱动层没有统一的网卡 IRQ 事件接口，`axnet-ng` 也没有从真实 NIC IRQ 到 `PollSet` waker 的稳定路径。修复后，NIC driver 通过 `handle_irq()` 返回事件，`axnet-ng` 在 `RX_READY` / `RX_ERROR` 时唤醒等待者。

2. virtio-net 中断不能作为可靠的收包唤醒源。

   根因是 virtio-net 的 interrupt enable、ack 和事件判断没有形成独立的 IRQ handling 语义。修复后，有 IRQ 的 virtio-net 会显式启用设备中断，并在 `handle_irq()` 中 ack interrupt、检查 RX readiness。virtio-blk 当前仍是同步轮询 I/O，因此初始化后关闭 block interrupt，避免 legacy INTx 共享线路上的无关中断干扰网络路径。

3. x86_64 QEMU 下 virtio 网络外部收包路径不稳定。

   根因是 PCI interrupt line、IOAPIC pin/GSI 和 CPU interrupt vector 被混用了：原逻辑按 BDF 猜 vector，没有读取 PCI config space 的 interrupt line；IOAPIC redirection entries 没有初始化；`set_enable()` 还把 CPU vector 当成 IOAPIC entry index 使用。修复后，x86_64 会读取 PCI interrupt line，映射到 `0x20 + line`，初始化并 mask IOAPIC RTE，再按 `vector - 0x20` enable 对应 IOAPIC entry，同时清掉 PCI command 的 `INTERRUPT_DISABLE`。

4. loongarch64 virtio-net IRQ handler 注册失败。

   根因是平台 IRQ handler table 只有 13 项，而 QEMU loongarch64 virtio-net 使用 IRQ 18，注册时越界失败。修复后表容量扩到 256，IRQ 18 可以正常注册和分发。

5. 动态平台有 RTC 设备时仍无法提供有效 wall-clock epoch offset。

   根因是 `axplat-dyn` 没有 PL031 RTC probe 路径，generic timer 的 epoch offset 始终回落为 0。修复后通过 FDT 探测 `arm,pl031`，读取 unix timestamp 并一次性初始化 epoch offset。

## Validation

- `cargo fmt`
- `cargo xtask clippy --package ax-plat-x86-pc --package ax-driver-virtio`
- `cargo clippy -p ax-driver --features virtio-blk,virtio-net -- -D warnings`
- `cargo xtask starry test qemu --arch x86_64 -c apk-curl`
- `cargo xtask starry test qemu --arch loongarch64 -c apk-curl`
- `cargo xtask starry test qemu --arch aarch64 -c apk-curl`
- `cargo xtask starry test qemu --arch riscv64 -c apk-curl`

Known pre-existing validation gaps:

- Full `cargo xtask clippy --package ax-driver` still hits existing `ahci` and no-default-features matrix issues outside the Starry virtio-blk/net path validated above.
- `ax-plat-loongarch64-qemu-virt` clippy is still blocked by existing loongarch dependency / `ax-cpu` target warnings, while the Starry loongarch64 QEMU test path passes.

Fixes #192
