### PR TITLE
fix(mm): allow NULL pointer with zero-length in get_as_mut_slice/get_…

### DIFF
--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -150,6 +150,9 @@ impl<T> UserPtr<T> {
     }
 
     pub fn get_as_mut_slice(self, len: usize) -> AxResult<&'static mut [T]> {
+        if len == 0 {
+            return Ok(&mut []);
+        }
         check_region(
             self.address(),
             Layout::array::<T>(len).unwrap(),
@@ -211,6 +214,9 @@ impl<T> UserConstPtr<T> {
     }
 
     pub fn get_as_slice(self, len: usize) -> AxResult<&'static [T]> {
+        if len == 0 {
+            return Ok(&[]);
+        }
         check_region(
             self.address(),
             Layout::array::<T>(len).unwrap(),

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -225,6 +225,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
 
         // io mpx
         #[cfg(target_arch = "x86_64")]
+        Sysno::pause => sys_ppoll(0usize.into(), 0, 0usize.into(), 0usize.into(), 0),
+        #[cfg(target_arch = "x86_64")]
         Sysno::poll => sys_poll(uctx.arg0().into(), uctx.arg1() as _, uctx.arg2() as _),
         Sysno::ppoll => sys_ppoll(
             uctx.arg0().into(),

--- a/test-suit/starryos/normal/bug-signal-to-child/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-signal-to-child/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-signal-to-child C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-signal-to-child src/main.c)
+target_compile_options(bug-signal-to-child PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-signal-to-child RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-signal-to-child/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-signal-to-child/c/prebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-signal-to-child/c/src/main.c
+++ b/test-suit/starryos/normal/bug-signal-to-child/c/src/main.c
@@ -1,0 +1,107 @@
+/*
+ * bug-signal-to-child: Parent sends SIGUSR1 to child via kill(),
+ * child should receive it and wake from pause().
+ *
+ * Uses a pipe for synchronization: child writes "ready" before calling
+ * pause(), parent reads it before sending the signal.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got_signal = 0;
+static void handler(int sig) { (void)sig; got_signal = 1; }
+
+int main(void)
+{
+    printf("=== bug-signal-to-child ===\n");
+    printf("Expected: parent kill(child, SIGUSR1) wakes child from pause()\n\n");
+
+    int sync_pipe[2];
+    if (pipe(sync_pipe) != 0) {
+        printf("FAIL: pipe: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        printf("FAIL: fork: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    if (pid == 0) {
+        /* child */
+        close(sync_pipe[0]); /* close read end */
+
+        struct sigaction sa = {0};
+        sa.sa_handler = handler;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGUSR1, &sa, NULL);
+        got_signal = 0;
+
+        /* tell parent we're ready */
+        write(sync_pipe[1], "R", 1);
+        close(sync_pipe[1]);
+
+        /* wait for signal */
+        int pr = pause();
+        /* if we get here, pause returned */
+        _exit(got_signal == 1 ? 0 : 2 + (pr == -1 ? errno : 100 + pr));
+    }
+
+    /* parent */
+    close(sync_pipe[1]); /* close write end */
+
+    /* wait for child to be ready */
+    char buf;
+    read(sync_pipe[0], &buf, 1);
+    close(sync_pipe[0]);
+
+    /* check if child is still alive */
+    int status_check = 0;
+    pid_t w_check = waitpid(pid, &status_check, WNOHANG);
+    if (w_check == 0) {
+        printf("parent: child is still running (good)\n");
+    } else if (w_check == pid) {
+        printf("parent: child already exited with code %d BEFORE signal!\n",
+               WIFEXITED(status_check) ? WEXITSTATUS(status_check) : -1);
+        printf("TEST FAILED\n");
+        return 1;
+    } else {
+        printf("parent: waitpid(WNOHANG) returned %d errno=%d\n", w_check, errno);
+    }
+
+    /* small extra delay to ensure child is in pause() */
+    struct timespec ts = {0, 100000000}; /* 100ms */
+    nanosleep(&ts, NULL);
+
+    printf("parent: sending SIGUSR1 to child %d\n", pid);
+    int kr = kill(pid, SIGUSR1);
+    printf("parent: kill returned %d (errno=%d)\n", kr, errno);
+
+    int status = 0;
+    pid_t w = waitpid(pid, &status, 0);
+
+    if (w == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        printf("PASS: child received signal and exited 0\n");
+        printf("TEST PASSED\n");
+        return 0;
+    }
+
+    if (w != pid) {
+        printf("FAIL: waitpid returned %d, expected %d (errno=%d)\n", w, pid, errno);
+    } else if (!WIFEXITED(status)) {
+        printf("FAIL: child killed by signal %d\n", WTERMSIG(status));
+    } else {
+        printf("FAIL: child exited with code %d (expected 0)\n", WEXITSTATUS(status));
+    }
+    printf("TEST FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/bug-signal-to-child/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-signal-to-child/qemu-aarch64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-signal-to-child"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-signal-to-child/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-signal-to-child/qemu-loongarch64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic", "-m", "128M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-signal-to-child"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-signal-to-child/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-signal-to-child/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-signal-to-child"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-signal-to-child/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-signal-to-child/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-signal-to-child"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30


### PR DESCRIPTION
## fix(mm): allow NULL pointer with zero-length in get_as_mut_slice/get_as_slice

## Bug Description

`pause()` returns immediately on StarryOS instead of blocking until a signal is delivered. This breaks the fundamental POSIX contract:

> **pause(2):** pause() causes the calling process (or thread) to sleep until a signal is delivered that either terminates the process or causes the invocation of a signal-catching function.

On riscv64, musl libc implements `pause()` via `ppoll(NULL, 0, NULL, NULL)`, which should block indefinitely until interrupted by a signal:

> **ppoll(2):** The call will block until either:
> - a file descriptor becomes ready;
> - the call is interrupted by a signal handler; or
> - the timeout expires.

With `nfds=0` and `timeout=NULL`, only the second condition can trigger — a signal. Instead, StarryOS returned `EFAULT` (errno 14, "Bad address"), causing `pause()` to return immediately. This made parent-to-child signal delivery via `kill()` + `pause()` completely broken: the child exited before the parent could send the signal.

## Root Cause

`UserPtr::get_as_mut_slice(len)` in `kernel/src/mm/access.rs` called `check_region()` unconditionally, even when `len=0`. For `ppoll(NULL, 0, ...)`, this meant validating address `0x0` (NULL) with size 0. Since address 0 is not mapped in the process address space, `check_region` returned `AxError::BadAddress` (EFAULT).

This is incorrect — POSIX allows NULL pointers when the associated count is 0. Linux accepts `ppoll(NULL, 0, ...)`, `read(fd, NULL, 0)`, `poll(NULL, 0, ...)`, etc. A zero-length access touches no memory, so the pointer value is irrelevant.

The same issue existed in `UserConstPtr::get_as_slice`.

## Fix

1. In `UserPtr::get_as_mut_slice`: return `&mut []` immediately when `len == 0`, skipping pointer validation.
2. In `UserConstPtr::get_as_slice`: return `&[]` immediately when `len == 0`, same logic.

This matches Linux kernel behavior where zero-length `copy_from_user` / `copy_to_user` succeed regardless of the pointer value.

### Additional fix: x86_64 `pause` syscall not implemented

On x86_64, musl uses the native `pause` syscall (nr 34) instead of `ppoll`. StarryOS had no handler for it, returning `ENOSYS`. The child exited with code 40 (2 + ENOSYS=38).

Added `Sysno::pause` dispatch on x86_64, forwarding to `sys_ppoll(0, 0, 0, 0, 0)` which is semantically identical — block with no fds and no timeout until a signal arrives.

This matches the Linux implementation where `pause()` is defined as:

```c
SYSCALL_DEFINE0(pause)
{
    while (!signal_pending(current)) {
        __set_current_state(TASK_INTERRUPTIBLE);
        schedule();
    }
    return -ERESTARTNOHAND;
}
```

Our `ppoll(NULL, 0, NULL, NULL)` achieves the same effect through the existing poll infrastructure.

## Test Plan

1. Parent forks a child process
2. Child sets up a `SIGUSR1` handler, signals readiness via pipe, then calls `pause()`
3. Parent waits for readiness, then calls `kill(child_pid, SIGUSR1)`
4. Verify child wakes from `pause()`, handler sets flag, child exits 0

Before fix: child exits immediately with code 16 (2 + EFAULT), parent's `kill()` returns ESRCH because child is already gone.

After fix: child blocks in `pause()`, receives signal, handler runs, exits 0.

A test case is included at `test-suit/starryos/normal/bug-signal-to-child/`.