### PR TITLE
fix(starry-kernel): 修复 futex 等待中的用户态内存访问

### DIFF
--- a/os/StarryOS/kernel/src/task/futex.rs
+++ b/os/StarryOS/kernel/src/task/futex.rs
@@ -9,6 +9,7 @@ use core::{
     cmp::Ordering,
     future::poll_fn,
     ops::Deref,
+    ptr::addr_of,
     sync::atomic::AtomicBool,
     task::{Poll, Waker},
     time::Duration,
@@ -102,35 +103,27 @@ impl WaitQueue {
     }
 
     /// Requeue at most `count` tasks to the target wait queue.
-    pub fn requeue(&self, mut count: usize, target: &WaitQueue) -> usize {
-        let self_addr = self as *const Self as usize;
-        let target_addr = target as *const Self as usize;
-        if self_addr == target_addr {
-            return 0;
-        }
+    pub fn requeue(&self, count: usize, target: &WaitQueue) -> usize {
+        let requeue_locked =
+            |src: &mut VecDeque<(Waker, u32)>, dst: &mut VecDeque<(Waker, u32)>, count: usize| {
+                let count = count.min(src.len());
+                dst.extend(src.drain(..*count));
+                count
+            };
 
-        let requeue_locked = |src: &mut VecDeque<(Waker, u32)>,
-                              dst: &mut VecDeque<(Waker, u32)>,
-                              count: &mut usize| {
-            *count = (*count).min(src.len());
-            dst.extend(src.drain(..*count));
-        };
-
-        match self_addr.cmp(&target_addr) {
+        match addr_of!(self).cmp(&addr_of!(target)) {
             Ordering::Less => {
                 let mut src = self.queue.lock();
                 let mut dst = target.queue.lock();
-                requeue_locked(&mut src, &mut dst, &mut count);
+                requeue_locked(&mut src, &mut dst, count)
             }
             Ordering::Greater => {
                 let mut dst = target.queue.lock();
                 let mut src = self.queue.lock();
-                requeue_locked(&mut src, &mut dst, &mut count);
+                requeue_locked(&mut src, &mut dst, count)
             }
-            Ordering::Equal => return 0,
+            Ordering::Equal => 0,
         }
-
-        count
     }
 }
 

--- a/os/StarryOS/kernel/src/task/futex.rs
+++ b/os/StarryOS/kernel/src/task/futex.rs
@@ -6,6 +6,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{
+    cmp::Ordering,
     future::poll_fn,
     ops::Deref,
     sync::atomic::AtomicBool,
@@ -75,18 +76,16 @@ impl WaitQueue {
     pub fn wake(&self, count: usize, mask: u32) -> usize {
         let wakers = {
             let mut queue = self.queue.lock();
-            let mut retained = VecDeque::with_capacity(queue.len());
             let mut wakers = Vec::new();
 
-            while let Some((waker, bitset)) = queue.pop_front() {
+            queue.retain(|(waker, bitset)| {
                 if wakers.len() >= count || (bitset & mask) == 0 {
-                    retained.push_back((waker, bitset));
+                    true
                 } else {
-                    wakers.push(waker);
+                    wakers.push(waker.clone());
+                    false
                 }
-            }
-
-            *queue = retained;
+            });
             wakers
         };
 
@@ -114,18 +113,21 @@ impl WaitQueue {
                               dst: &mut VecDeque<(Waker, u32)>,
                               count: &mut usize| {
             *count = (*count).min(src.len());
-            let tasks: Vec<_> = src.drain(..*count).collect();
-            dst.extend(tasks);
+            dst.extend(src.drain(..*count));
         };
 
-        if self_addr < target_addr {
-            let mut src = self.queue.lock();
-            let mut dst = target.queue.lock();
-            requeue_locked(&mut src, &mut dst, &mut count);
-        } else {
-            let mut dst = target.queue.lock();
-            let mut src = self.queue.lock();
-            requeue_locked(&mut src, &mut dst, &mut count);
+        match self_addr.cmp(&target_addr) {
+            Ordering::Less => {
+                let mut src = self.queue.lock();
+                let mut dst = target.queue.lock();
+                requeue_locked(&mut src, &mut dst, &mut count);
+            }
+            Ordering::Greater => {
+                let mut dst = target.queue.lock();
+                let mut src = self.queue.lock();
+                requeue_locked(&mut src, &mut dst, &mut count);
+            }
+            Ordering::Equal => return 0,
         }
 
         count

--- a/os/StarryOS/kernel/src/task/futex.rs
+++ b/os/StarryOS/kernel/src/task/futex.rs
@@ -14,7 +14,6 @@ use core::{
 };
 
 use ax_errno::AxResult;
-use ax_kspin::SpinNoIrq;
 use ax_memory_addr::VirtAddr;
 use ax_sync::Mutex;
 use ax_task::{
@@ -31,7 +30,10 @@ use crate::{
 /// Wait queue used by futex.
 #[derive(Default)]
 pub struct WaitQueue {
-    queue: SpinNoIrq<VecDeque<(Waker, u32)>>,
+    // Futex waits must re-check the user value while serializing with wakeups.
+    // That re-check may fault and sleep, so this queue cannot use a no-IRQ
+    // spinlock.
+    queue: Mutex<VecDeque<(Waker, u32)>>,
 }
 impl WaitQueue {
     /// Creates a new `WaitQueue`.
@@ -71,16 +73,27 @@ impl WaitQueue {
     /// Wakes up at most `count` tasks whose bitset intersects with the given
     /// bitmask.
     pub fn wake(&self, count: usize, mask: u32) -> usize {
-        let mut woke = 0;
-        self.queue.lock().retain(|(waker, bitset)| {
-            if woke >= count || (bitset & mask) == 0 {
-                true
-            } else {
-                waker.wake_by_ref();
-                woke += 1;
-                false
+        let wakers = {
+            let mut queue = self.queue.lock();
+            let mut retained = VecDeque::with_capacity(queue.len());
+            let mut wakers = Vec::new();
+
+            while let Some((waker, bitset)) = queue.pop_front() {
+                if wakers.len() >= count || (bitset & mask) == 0 {
+                    retained.push_back((waker, bitset));
+                } else {
+                    wakers.push(waker);
+                }
             }
-        });
+
+            *queue = retained;
+            wakers
+        };
+
+        let woke = wakers.len();
+        for waker in wakers {
+            waker.wake();
+        }
         woke
     }
 
@@ -91,15 +104,30 @@ impl WaitQueue {
 
     /// Requeue at most `count` tasks to the target wait queue.
     pub fn requeue(&self, mut count: usize, target: &WaitQueue) -> usize {
-        let tasks: Vec<_> = {
-            let mut wq = self.queue.lock();
-            count = count.min(wq.len());
-            wq.drain(..count).collect()
-        };
-        if !tasks.is_empty() {
-            let mut wq = target.queue.lock();
-            wq.extend(tasks);
+        let self_addr = self as *const Self as usize;
+        let target_addr = target as *const Self as usize;
+        if self_addr == target_addr {
+            return 0;
         }
+
+        let requeue_locked = |src: &mut VecDeque<(Waker, u32)>,
+                              dst: &mut VecDeque<(Waker, u32)>,
+                              count: &mut usize| {
+            *count = (*count).min(src.len());
+            let tasks: Vec<_> = src.drain(..*count).collect();
+            dst.extend(tasks);
+        };
+
+        if self_addr < target_addr {
+            let mut src = self.queue.lock();
+            let mut dst = target.queue.lock();
+            requeue_locked(&mut src, &mut dst, &mut count);
+        } else {
+            let mut dst = target.queue.lock();
+            let mut src = self.queue.lock();
+            requeue_locked(&mut src, &mut dst, &mut count);
+        }
+
         count
     }
 }

--- a/os/StarryOS/kernel/src/task/futex.rs
+++ b/os/StarryOS/kernel/src/task/futex.rs
@@ -9,7 +9,6 @@ use core::{
     cmp::Ordering,
     future::poll_fn,
     ops::Deref,
-    ptr::addr_of,
     sync::atomic::AtomicBool,
     task::{Poll, Waker},
     time::Duration,
@@ -114,7 +113,7 @@ impl WaitQueue {
             count
         }
 
-        match addr_of!(self).cmp(&addr_of!(target)) {
+        match core::ptr::from_ref(self).cmp(&core::ptr::from_ref(target)) {
             Ordering::Less => {
                 let mut src = self.queue.lock();
                 let mut dst = target.queue.lock();

--- a/os/StarryOS/kernel/src/task/futex.rs
+++ b/os/StarryOS/kernel/src/task/futex.rs
@@ -104,12 +104,15 @@ impl WaitQueue {
 
     /// Requeue at most `count` tasks to the target wait queue.
     pub fn requeue(&self, count: usize, target: &WaitQueue) -> usize {
-        let requeue_locked =
-            |src: &mut VecDeque<(Waker, u32)>, dst: &mut VecDeque<(Waker, u32)>, count: usize| {
-                let count = count.min(src.len());
-                dst.extend(src.drain(..*count));
-                count
-            };
+        fn requeue_locked(
+            src: &mut VecDeque<(Waker, u32)>,
+            dst: &mut VecDeque<(Waker, u32)>,
+            count: usize,
+        ) -> usize {
+            let count = count.min(src.len());
+            dst.extend(src.drain(..count));
+            count
+        }
 
         match addr_of!(self).cmp(&addr_of!(target)) {
             Ordering::Less => {

--- a/test-suit/starryos/normal/bug-futex-wait-wake/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-futex-wait-wake/c/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-futex-wait-wake C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+find_package(Threads REQUIRED)
+
+add_executable(bug-futex-wait-wake src/main.c)
+target_compile_options(bug-futex-wait-wake PRIVATE -Wall -Wextra -Werror)
+target_link_libraries(bug-futex-wait-wake PRIVATE Threads::Threads)
+
+install(TARGETS bug-futex-wait-wake RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-futex-wait-wake/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-futex-wait-wake/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-futex-wait-wake/c/src/main.c
+++ b/test-suit/starryos/normal/bug-futex-wait-wake/c/src/main.c
@@ -1,0 +1,145 @@
+/*
+ * bug-futex-wait-wake: cover the futex wait regression fixed in
+ * os/StarryOS/kernel/src/task/futex.rs.
+ *
+ * Old behavior: FUTEX_WAIT re-checked the user futex word while holding a
+ * no-IRQ spinlock, so the kernel tried to perform faultable user-memory access
+ * with IRQs disabled and panicked.
+ *
+ * Fixed behavior: the re-check is serialized with a sleepable lock, so a
+ * waiting thread can block and then be woken normally.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef FUTEX_WAIT
+#define FUTEX_WAIT 0
+#endif
+
+#ifndef FUTEX_WAKE
+#define FUTEX_WAKE 1
+#endif
+
+#ifndef FUTEX_PRIVATE_FLAG
+#define FUTEX_PRIVATE_FLAG 128
+#endif
+
+static _Atomic uint32_t futex_word = 0;
+static _Atomic int waiter_ready = 0;
+
+static int futex_wait(uint32_t *uaddr, uint32_t expected, const struct timespec *timeout)
+{
+    errno = 0;
+    long ret = syscall(
+        SYS_futex,
+        uaddr,
+        FUTEX_WAIT | FUTEX_PRIVATE_FLAG,
+        expected,
+        timeout,
+        NULL,
+        0
+    );
+    if (ret == 0) {
+        return 0;
+    }
+    return -errno;
+}
+
+static int futex_wake(uint32_t *uaddr, int count)
+{
+    errno = 0;
+    long ret = syscall(
+        SYS_futex,
+        uaddr,
+        FUTEX_WAKE | FUTEX_PRIVATE_FLAG,
+        count,
+        NULL,
+        NULL,
+        0
+    );
+    if (ret >= 0) {
+        return (int)ret;
+    }
+    return -errno;
+}
+
+static void *waiter_thread(void *arg)
+{
+    (void)arg;
+
+    const struct timespec timeout = {
+        .tv_sec = 5,
+        .tv_nsec = 0,
+    };
+    atomic_store_explicit(&waiter_ready, 1, memory_order_release);
+    return (void *)(intptr_t)futex_wait((uint32_t *)&futex_word, 0, &timeout);
+}
+
+static int test_futex_wait_wake(void)
+{
+    pthread_t waiter;
+    atomic_store_explicit(&futex_word, 0, memory_order_relaxed);
+    atomic_store_explicit(&waiter_ready, 0, memory_order_relaxed);
+
+    int err = pthread_create(&waiter, NULL, waiter_thread, NULL);
+    if (err != 0) {
+        printf("pthread_create failed: errno=%d (%s)\n", err, strerror(err));
+        return 1;
+    }
+
+    while (atomic_load_explicit(&waiter_ready, memory_order_acquire) == 0) {
+        sched_yield();
+    }
+
+    const struct timespec settle = {
+        .tv_sec = 0,
+        .tv_nsec = 50 * 1000 * 1000,
+    };
+    nanosleep(&settle, NULL);
+
+    atomic_store_explicit(&futex_word, 1, memory_order_release);
+    int woke = futex_wake((uint32_t *)&futex_word, 1);
+    if (woke != 1) {
+        printf("expected futex_wake to wake 1 waiter, got %d\n", woke);
+        return 1;
+    }
+
+    void *thread_result = NULL;
+    err = pthread_join(waiter, &thread_result);
+    if (err != 0) {
+        printf("pthread_join failed: errno=%d (%s)\n", err, strerror(err));
+        return 1;
+    }
+
+    int wait_ret = (int)(intptr_t)thread_result;
+    if (wait_ret != 0) {
+        printf("futex wait returned %d instead of 0\n", wait_ret);
+        return 1;
+    }
+
+    printf("futex waiter blocked and was woken successfully\n");
+    return 0;
+}
+
+int main(void)
+{
+    printf("=== bug-futex-wait-wake ===\n");
+    printf("Starting a waiter thread and waking it with FUTEX_WAKE...\n");
+
+    if (test_futex_wait_wake() != 0) {
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    printf("TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/bug-futex-wait-wake/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-futex-wait-wake/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+  "-nographic",
+  "-cpu",
+  "cortex-a53",
+  "-device",
+  "virtio-blk-pci,drive=disk0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+  "-device",
+  "virtio-net-pci,netdev=net0",
+  "-netdev",
+  "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-futex-wait-wake"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED']
+timeout = 20

--- a/test-suit/starryos/normal/bug-futex-wait-wake/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-futex-wait-wake/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-futex-wait-wake"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED']
+timeout = 20

--- a/test-suit/starryos/normal/bug-futex-wait-wake/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-futex-wait-wake/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-futex-wait-wake"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED']
+timeout = 15

--- a/test-suit/starryos/normal/bug-futex-wait-wake/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-futex-wait-wake/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-futex-wait-wake"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED']
+timeout = 20


### PR DESCRIPTION
## 概述
- 新增一个 Starry 回归测例，通过真实的 waiter/waker 流程复现 futex wait panic
- 为 `bug-futex-wait-wake` 补齐 aarch64、loongarch64、riscv64、x86_64 四个架构的 QEMU 配置
- 将 futex 等待队列改为可睡眠的实现，避免在无中断自旋锁保护下重新检查用户态 futex 字
- 明确 `wake` 和 `requeue` 的行为：在释放锁后唤醒任务，并在 requeue 时使用稳定的加锁顺序

## 根因
`FUTEX_WAIT` 在与唤醒路径串行化时，会在 `SpinNoIrq` 等待队列锁保护下重新读取用户态 futex 字。这个重新读取使用了可能缺页、可能睡眠的用户态内存访问（`vm_read()`）。旧实现中，这条路径会在 IRQ 关闭的情况下访问用户内存，并触发 `faultable user memory access requires IRQs enabled` panic。

## Commit 拆分
1. `test(starry): add futex wait/wake regression case` (`7a3b2bc0d`)
   - 新增 `test-suit/starryos/normal/bug-futex-wait-wake`
   - 补齐 aarch64、loongarch64、riscv64、x86_64 的 QEMU 用例配置
   - 本 commit 上的验证：
     - `cargo xtask starry test qemu -t aarch64-unknown-none-softfloat -c bug-futex-wait-wake`
     - 结果：失败，并命中内核 panic
2. `fix(starry-kernel): make futex waits use a sleepable queue` (`fe008342f`)
   - 将 futex 等待队列从 `SpinNoIrq` 改为 `ax_sync::Mutex`
   - 在释放锁后唤醒排队任务
   - 在 `requeue` 时使用稳定的加锁顺序，避免死锁
   - 本 commit 上的验证：
     - `cargo xtask starry test qemu -t aarch64-unknown-none-softfloat -c bug-futex-wait-wake`
     - `cargo xtask starry test qemu -t loongarch64-unknown-none-softfloat -c bug-futex-wait-wake`
     - `cargo xtask starry test qemu -t riscv64gc-unknown-none-elf -c bug-futex-wait-wake`
     - `cargo xtask starry test qemu -t x86_64-unknown-none -c bug-futex-wait-wake`
     - 结果：全部通过

## 影响
- 修复多线程用户态程序使用 futex wait 的内核路径
- 消除 futex 慢路径中“IRQ 关闭时进行 faultable 用户态内存访问”的问题
- 为该回归新增一个聚焦的独立测例，并覆盖 Starry 当前支持的四个 QEMU 架构

## 验证
- 失败验证
  - `cargo xtask starry test qemu -t aarch64-unknown-none-softfloat -c bug-futex-wait-wake`
  - 在 `7a3b2bc0d` 上：失败，报错 `faultable user memory access requires IRQs enabled`
- 通过验证
  - `cargo xtask starry test qemu -t aarch64-unknown-none-softfloat -c bug-futex-wait-wake`
  - `cargo xtask starry test qemu -t loongarch64-unknown-none-softfloat -c bug-futex-wait-wake`
  - `cargo xtask starry test qemu -t riscv64gc-unknown-none-elf -c bug-futex-wait-wake`
  - `cargo xtask starry test qemu -t x86_64-unknown-none -c bug-futex-wait-wake`
  - 在 `fe008342f` 上：全部通过