### PR TITLE
fix(file): lseek should return EINVAL for negative offset with SEEK_SET

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -88,7 +88,12 @@ pub fn sys_writev(fd: i32, iov: *const IoVec, iovcnt: usize) -> AxResult<isize> 
 pub fn sys_lseek(fd: c_int, offset: __kernel_off_t, whence: c_int) -> AxResult<isize> {
     debug!("sys_lseek <= {fd} {offset} {whence}");
     let pos = match whence {
-        0 => SeekFrom::Start(offset as _),
+        0 => {
+            if offset < 0 {
+                return Err(AxError::InvalidInput);
+            }
+            SeekFrom::Start(offset as _)
+        }
         1 => SeekFrom::Current(offset as _),
         2 => SeekFrom::End(offset as _),
         _ => return Err(AxError::InvalidInput),

--- a/test-suit/starryos/normal/bug-lseek-negative-einval/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-lseek-negative-einval/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-lseek-negative-einval C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-lseek-negative-einval src/main.c)
+target_compile_options(bug-lseek-negative-einval PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-lseek-negative-einval RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-lseek-negative-einval/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-lseek-negative-einval/c/prebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-lseek-negative-einval/c/src/main.c
+++ b/test-suit/starryos/normal/bug-lseek-negative-einval/c/src/main.c
@@ -1,0 +1,48 @@
+/*
+ * bug-lseek-negative-einval: lseek with negative offset from SEEK_SET
+ * should fail with EINVAL.
+ *
+ * Linux behavior: lseek(fd, -1, SEEK_SET) returns -1 with errno=EINVAL.
+ * StarryOS bug: Returns -1 but sets errno=EPERM (1) instead of EINVAL (22).
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void)
+{
+    printf("=== bug-lseek-negative-einval ===\n");
+    printf("Expected: lseek(fd, -1, SEEK_SET) fails with EINVAL\n\n");
+
+    int fd = open("/tmp/lseek_test", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0) {
+        printf("FAIL: cannot create test file: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        return 1;
+    }
+    write(fd, "data", 4);
+
+    errno = 0;
+    off_t pos = lseek(fd, -1, SEEK_SET);
+
+    close(fd);
+    unlink("/tmp/lseek_test");
+
+    if (pos == (off_t)-1 && errno == EINVAL) {
+        printf("PASS: lseek returned -1, errno=EINVAL (%d)\n", errno);
+        printf("TEST PASSED\n");
+        return 0;
+    }
+
+    if (pos != (off_t)-1) {
+        printf("FAIL: lseek returned %ld (should have failed)\n", (long)pos);
+    } else {
+        printf("FAIL: lseek returned -1 but errno=%d (%s), expected EINVAL (%d)\n",
+               errno, strerror(errno), EINVAL);
+    }
+    printf("TEST FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/bug-lseek-negative-einval/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-lseek-negative-einval/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-lseek-negative-einval"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-lseek-negative-einval/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-lseek-negative-einval/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-lseek-negative-einval"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-lseek-negative-einval/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-lseek-negative-einval/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-lseek-negative-einval"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-lseek-negative-einval/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-lseek-negative-einval/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-lseek-negative-einval"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30


### PR DESCRIPTION
## Bug

`lseek(fd, -1, SEEK_SET)` should fail with `EINVAL` per POSIX (`man 2 lseek`: "the resulting file offset would be negative"). StarryOS instead accepted the call silently — the negative `off_t` was cast to `u64::MAX` via `offset as _`, which `SeekFrom::Start(u64)` happily stored as a valid position.

## Root Cause

In `sys_lseek`, the `SEEK_SET` branch did:

```rust
0 => SeekFrom::Start(offset as _),
```

`offset` is `__kernel_off_t` (signed). The `as _` cast converts `-1i64` to `u64::MAX` without any check. `SeekFrom::Start` takes `u64` by design (absolute positions can't be negative), so the type system can't catch this — the validation has to happen at the syscall boundary before the cast.

## Fix

Added an explicit guard in `sys_lseek`: if `whence == SEEK_SET` and `offset < 0`, return `AxError::InvalidInput` (maps to `EINVAL`) immediately, before the signed-to-unsigned conversion.

```rust
0 => {
    if offset < 0 {
        return Err(AxError::InvalidInput);
    }
    SeekFrom::Start(offset as _)
}
```

## Test

`test-suit/starryos/normal/bug-lseek-negative-einval/` — opens a file, calls `lseek(fd, -1, SEEK_SET)`, verifies the call returns `-1` with `errno == EINVAL`. QEMU configs added for all four arches (x86_64, aarch64, riscv64, loongarch64).