### PR TITLE
feat(mm): track backend split metadata and generate real /proc maps output

### DIFF
--- a/components/axaddrspace/src/address_space/backend/mod.rs
+++ b/components/axaddrspace/src/address_space/backend/mod.rs
@@ -100,6 +100,19 @@ impl<H: PagingHandler> MappingBackend for Backend<H> {
     ) -> bool {
         page_table.protect_region(start, size, new_flags)
     }
+
+    fn split(&mut self, _align_diff: usize) -> Option<Self> {
+        // backend can be trivially split since it does not have any state.
+        Some(self.clone())
+    }
+
+    fn shrink_left(&mut self, _shrink_size: usize) {
+        // backend can be trivially shrunk since it does not have any state.
+    }
+
+    fn shrink_right(&mut self, _shrink_size: usize) {
+        // backend can be trivially shrunk since it does not have any state.
+    }
 }
 
 impl<H: PagingHandler> Backend<H> {

--- a/components/axerrno/src/lib.rs
+++ b/components/axerrno/src/lib.rs
@@ -394,6 +394,12 @@ impl TryFrom<i32> for AxError {
     }
 }
 
+impl From<core::fmt::Error> for AxError {
+    fn from(_: core::fmt::Error) -> Self {
+        AxError::new_ax(AxErrorKind::InvalidInput)
+    }
+}
+
 impl fmt::Debug for AxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.data() {

--- a/components/axfs-ng-vfs/src/node/file.rs
+++ b/components/axfs-ng-vfs/src/node/file.rs
@@ -29,6 +29,12 @@ pub trait FileNodeOps: NodeOps + Pollable {
     fn ioctl(&self, _cmd: u32, _arg: usize) -> VfsResult<usize> {
         Err(VfsError::NotATty)
     }
+
+    /// A hint to the backend that the file position has changed.
+    /// This is used for operations like resetting file content in proc/sys.
+    fn seek_to(&self, _pos: u64) -> VfsResult<()> {
+        Ok(())
+    }
 }
 
 #[repr(transparent)]

--- a/components/axmm_crates/memory_set/src/area.rs
+++ b/components/axmm_crates/memory_set/src/area.rs
@@ -100,8 +100,10 @@ impl<B: MappingBackend> MemoryArea<B> {
 
     /// Shrinks the memory area at the left side.
     ///
-    /// The start address of the memory area is increased by `new_size`. The
-    /// shrunk part is unmapped.
+    /// The memory area is shrunk to `new_size`, and the left-side part is
+    /// unmapped.
+    ///
+    /// The start address is increased by `old_size - new_size`.
     ///
     /// `new_size` must be greater than 0 and less than the current size.
     pub(crate) fn shrink_left(
@@ -121,13 +123,16 @@ impl<B: MappingBackend> MemoryArea<B> {
         // Safety: `unmap_size` is less than the current size, so it will never
         // overflow.
         self.va_range.start = self.va_range.start.wrapping_add(unmap_size);
+        self.backend.shrink_left(unmap_size);
         Ok(())
     }
 
     /// Shrinks the memory area at the right side.
     ///
-    /// The end address of the memory area is decreased by `new_size`. The
-    /// shrunk part is unmapped.
+    /// The memory area is shrunk to `new_size`, and the right-side part is
+    /// unmapped.
+    ///
+    /// The end address is decreased by `old_size - new_size`.
     ///
     /// `new_size` must be greater than 0 and less than the current size.
     pub(crate) fn shrink_right(
@@ -149,6 +154,7 @@ impl<B: MappingBackend> MemoryArea<B> {
 
         // Use wrapping_sub to avoid overflow check, same as above.
         self.va_range.end = self.va_range.end.wrapping_sub(unmap_size);
+        self.backend.shrink_right(unmap_size);
         Ok(())
     }
 
@@ -161,13 +167,20 @@ impl<B: MappingBackend> MemoryArea<B> {
     /// of the parts is empty after splitting.
     pub(crate) fn split(&mut self, pos: B::Addr) -> Option<Self> {
         if self.start() < pos && pos < self.end() {
+            let align_diff = pos.sub_addr(self.start());
+
+            let right = self
+                .backend
+                .split(align_diff)
+                .expect("backend should be splittable");
+
             let new_area = Self::new(
                 pos,
                 // Use wrapping_sub_addr to avoid overflow check. It is safe because
                 // `pos` is within the memory area.
                 self.end().wrapping_sub_addr(pos),
                 self.flags,
-                self.backend.clone(),
+                right,
             );
             self.va_range.end = pos;
             Some(new_area)

--- a/components/axmm_crates/memory_set/src/area.rs
+++ b/components/axmm_crates/memory_set/src/area.rs
@@ -66,11 +66,6 @@ impl<B: MappingBackend> MemoryArea<B> {
         self.flags = new_flags;
     }
 
-    /// Changes the end address of the memory area.
-    pub(crate) fn set_end(&mut self, new_end: B::Addr) {
-        self.va_range.end = new_end;
-    }
-
     /// Maps the whole memory area in the page table.
     pub(crate) fn map_area(&self, page_table: &mut B::PageTable) -> MappingResult {
         self.backend

--- a/components/axmm_crates/memory_set/src/backend.rs
+++ b/components/axmm_crates/memory_set/src/backend.rs
@@ -35,4 +35,17 @@ pub trait MappingBackend: Clone {
         new_flags: Self::Flags,
         page_table: &mut Self::PageTable,
     ) -> bool;
+
+    /// Splits the backend into two backends at the given alignment difference.
+    fn split(&mut self, align_diff: usize) -> Option<Self>;
+
+    /// Shrinks the backend from the left by the given size.
+    ///
+    /// The backend start address is increased by `shrink_size`.
+    fn shrink_left(&mut self, _shrink_size: usize) {}
+
+    /// Shrinks the backend from the right by the given size.
+    ///
+    /// The backend end address is decreased by `shrink_size`.
+    fn shrink_right(&mut self, _shrink_size: usize) {}
 }

--- a/components/axmm_crates/memory_set/src/set.rs
+++ b/components/axmm_crates/memory_set/src/set.rs
@@ -242,11 +242,9 @@ impl<B: MappingBackend> MemorySet<B> {
                 } else if area_start < start && area_end > end {
                     //        [ prot ]
                     // [ left | area | right ]
-                    let right_part = area.split(end).unwrap();
-                    area.set_end(start);
+                    let mut middle_part = area.split(start).unwrap();
+                    let right_part = middle_part.split(end).unwrap();
 
-                    let mut middle_part =
-                        MemoryArea::new(start, size, area.flags(), area.backend().clone());
                     middle_part.protect_area(new_flags, page_table)?;
                     middle_part.set_flags(new_flags);
 

--- a/components/axmm_crates/memory_set/src/tests.rs
+++ b/components/axmm_crates/memory_set/src/tests.rs
@@ -52,6 +52,14 @@ impl MappingBackend for MockBackend {
         }
         true
     }
+
+    fn split(&mut self, _align_diff: usize) -> Option<Self> {
+        Some(self.clone())
+    }
+
+    fn shrink_left(&mut self, _shrink_size: usize) {}
+
+    fn shrink_right(&mut self, _shrink_size: usize) {}
 }
 
 macro_rules! assert_ok {

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -1,4 +1,8 @@
-use alloc::{collections::BTreeMap, sync::Arc};
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    sync::Arc,
+};
 use core::slice;
 
 use ax_errno::{AxError, AxResult};
@@ -8,7 +12,7 @@ use ax_hal::{
     paging::{MappingFlags, PageSize, PageTableCursor, PagingError},
 };
 use ax_kspin::SpinNoIrq;
-use ax_memory_addr::{PhysAddr, VirtAddr, VirtAddrRange};
+use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr, VirtAddrRange, align_down_4k};
 use ax_sync::Mutex;
 
 use super::{
@@ -81,6 +85,8 @@ pub struct CowBackend {
     start: VirtAddr,
     size: PageSize,
     file: Option<(FileBackend, u64, Option<u64>)>,
+    name: Option<String>,
+    shared: bool,
 }
 
 impl CowBackend {
@@ -155,6 +161,23 @@ impl CowBackend {
         }
 
         Ok(())
+    }
+
+    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, bool)> {
+        let loc = self
+            .file
+            .as_ref()
+            .map(|(file, offset, ..)| (file.location(), *offset));
+        if let Some((loc, offset)) = loc {
+            let path = loc.absolute_path().map(|pb| pb.to_string())?;
+            let inode = loc.inode();
+            let offset = align_down_4k(offset as usize) as u64;
+            return Ok((path, Some(offset), Some(inode), self.shared));
+        }
+        if let Some(name) = &self.name {
+            return Ok((name.clone(), None, None, self.shared));
+        }
+        Err(AxError::InvalidInput)
     }
 }
 
@@ -264,6 +287,31 @@ impl BackendOps for CowBackend {
 
         Ok(Backend::Cow(self.clone()))
     }
+
+    fn split(&mut self, align_diff: usize) -> Option<Backend> {
+        assert!(align_diff.is_multiple_of(PAGE_SIZE_4K));
+        if align_diff == 0 {
+            return None;
+        }
+        let mut right = self.clone();
+        right.start = self.start + align_diff;
+
+        if let Some((_, file_start, _)) = right.file.as_mut() {
+            *file_start += align_diff as u64;
+        }
+        Some(Backend::Cow(right))
+    }
+
+    fn shrink_left(&mut self, shrink_size: usize) {
+        assert!(shrink_size.is_multiple_of(PAGE_SIZE_4K));
+        self.start += shrink_size;
+        self.file.as_mut().map(|(_, file_start, _)| {
+            *file_start += shrink_size as u64;
+            Some(())
+        });
+    }
+
+    fn shrink_right(&mut self, _shrink_size: usize) {}
 }
 
 impl Backend {
@@ -273,19 +321,24 @@ impl Backend {
         file: FileBackend,
         file_start: u64,
         file_end: Option<u64>,
+        shared: bool,
     ) -> Self {
         Self::Cow(CowBackend {
             start,
             size,
             file: Some((file, file_start, file_end)),
+            name: None,
+            shared,
         })
     }
 
-    pub fn new_alloc(start: VirtAddr, size: PageSize) -> Self {
+    pub fn new_alloc(start: VirtAddr, size: PageSize, name: &str) -> Self {
         Self::Cow(CowBackend {
             start,
             size,
             file: None,
+            name: Some(name.to_string()),
+            shared: false,
         })
     }
 }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -12,7 +12,7 @@ use ax_hal::{
     paging::{MappingFlags, PageSize, PageTableCursor, PagingError},
 };
 use ax_kspin::SpinNoIrq;
-use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr, VirtAddrRange, align_down_4k};
+use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, PhysAddr, VirtAddr, VirtAddrRange, align_down_4k};
 use ax_sync::Mutex;
 
 use super::{
@@ -82,9 +82,11 @@ static FRAME_TABLE: SpinNoIrq<FrameTableRefCount> = SpinNoIrq::new(FrameTableRef
 /// This corresponds to the `MAP_PRIVATE` flag.
 #[derive(Clone)]
 pub struct CowBackend {
+    // The start address of the memory area.
     start: VirtAddr,
     size: PageSize,
-    file: Option<(FileBackend, u64, Option<u64>)>,
+    // file: (file, file_vaddr_base, file_offset_base, file_offset_end)
+    file: Option<(FileBackend, VirtAddr, u64, Option<u64>)>,
     name: Option<String>,
     shared: bool,
 }
@@ -104,22 +106,22 @@ impl CowBackend {
     ) -> AxResult {
         let frame = self.alloc_new_frame(true)?;
 
-        if let Some((file, file_start, file_end)) = &self.file {
+        if let Some((file, file_vaddr_base, file_start, file_end)) = &self.file {
             let buf = unsafe {
                 slice::from_raw_parts_mut(phys_to_virt(frame).as_mut_ptr(), self.size as _)
             };
-            // vaddr can be smaller than self.start (at most 1 page) due to
-            // non-aligned mappings, we need to keep the gap clean.
-            let start = self.start.as_usize().saturating_sub(vaddr.as_usize());
+            // vaddr can be smaller than file_vaddr_base (at most 1 page) due to
+            // non-aligned mappings; compute page-internal write offset accordingly.
+            let start = file_vaddr_base.as_usize().saturating_sub(vaddr.as_usize());
             assert!(start < self.size as _);
 
-            let file_start =
-                *file_start + vaddr.as_usize().saturating_sub(self.start.as_usize()) as u64;
+            let file_read_offset =
+                file_start + vaddr.as_usize().saturating_sub(file_vaddr_base.as_usize()) as u64;
             let max_read = file_end
-                .map_or(u64::MAX, |end| end.saturating_sub(file_start))
+                .map_or(u64::MAX, |end| end.saturating_sub(file_read_offset))
                 .min((buf.len() - start) as u64) as usize;
 
-            file.read_at(&mut &mut buf[start..start + max_read], file_start)?;
+            file.read_at(&mut &mut buf[start..start + max_read], file_read_offset)?;
         }
         pt.map(vaddr, frame, self.size, flags)?;
         Ok(())
@@ -167,11 +169,18 @@ impl CowBackend {
         let loc = self
             .file
             .as_ref()
-            .map(|(file, offset, ..)| (file.location(), *offset));
-        if let Some((loc, offset)) = loc {
+            .map(|(file, file_vaddr_base, file_start, ..)| {
+                (file.location(), *file_vaddr_base, *file_start)
+            });
+        if let Some((loc, file_vaddr_base, file_start)) = loc {
             let path = loc.absolute_path().map(|pb| pb.to_string())?;
             let inode = loc.inode();
             let dev = loc.metadata()?.device;
+            let offset = file_start
+                + self
+                    .start
+                    .as_usize()
+                    .saturating_sub(file_vaddr_base.as_usize()) as u64;
             let offset = align_down_4k(offset as usize) as u64;
             return Ok((path, Some(offset), Some(inode), Some(dev), self.shared));
         }
@@ -296,20 +305,12 @@ impl BackendOps for CowBackend {
         }
         let mut right = self.clone();
         right.start = self.start + align_diff;
-
-        if let Some((_, file_start, _)) = right.file.as_mut() {
-            *file_start += align_diff as u64;
-        }
         Some(Backend::Cow(right))
     }
 
     fn shrink_left(&mut self, shrink_size: usize) {
         assert!(shrink_size.is_multiple_of(PAGE_SIZE_4K));
         self.start += shrink_size;
-        self.file.as_mut().map(|(_, file_start, _)| {
-            *file_start += shrink_size as u64;
-            Some(())
-        });
     }
 
     fn shrink_right(&mut self, _shrink_size: usize) {}
@@ -325,9 +326,9 @@ impl Backend {
         shared: bool,
     ) -> Self {
         Self::Cow(CowBackend {
-            start,
+            start: start.align_down_4k(),
             size,
-            file: Some((file, file_start, file_end)),
+            file: Some((file, start, file_start, file_end)),
             name: None,
             shared,
         })
@@ -335,7 +336,7 @@ impl Backend {
 
     pub fn new_alloc(start: VirtAddr, size: PageSize, name: &str) -> Self {
         Self::Cow(CowBackend {
-            start,
+            start: start.align_down_4k(),
             size,
             file: None,
             name: Some(name.to_string()),

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -163,7 +163,7 @@ impl CowBackend {
         Ok(())
     }
 
-    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, bool)> {
+    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, Option<u64>, bool)> {
         let loc = self
             .file
             .as_ref()
@@ -171,11 +171,12 @@ impl CowBackend {
         if let Some((loc, offset)) = loc {
             let path = loc.absolute_path().map(|pb| pb.to_string())?;
             let inode = loc.inode();
+            let dev = loc.metadata()?.device;
             let offset = align_down_4k(offset as usize) as u64;
-            return Ok((path, Some(offset), Some(inode), self.shared));
+            return Ok((path, Some(offset), Some(inode), Some(dev), self.shared));
         }
         if let Some(name) = &self.name {
-            return Ok((name.clone(), None, None, self.shared));
+            return Ok((name.clone(), None, None, None, self.shared));
         }
         Err(AxError::InvalidInput)
     }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -16,7 +16,8 @@ use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, PhysAddr, VirtAddr, VirtAddrRange
 use ax_sync::Mutex;
 
 use super::{
-    AddrSpace, Backend, BackendOps, PopulateCallback, alloc_frame, dealloc_frame, pages_in,
+    AddrSpace, Backend, BackendFileInfo, BackendOps, PopulateCallback, alloc_frame, dealloc_frame,
+    pages_in,
 };
 
 struct FrameRefCnt(u8);
@@ -165,7 +166,7 @@ impl CowBackend {
         Ok(())
     }
 
-    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, Option<u64>, bool)> {
+    pub fn file_info(&self) -> AxResult<BackendFileInfo> {
         let loc = self
             .file
             .as_ref()
@@ -182,10 +183,22 @@ impl CowBackend {
                     .as_usize()
                     .saturating_sub(file_vaddr_base.as_usize()) as u64;
             let offset = align_down_4k(offset as usize) as u64;
-            return Ok((path, Some(offset), Some(inode), Some(dev), self.shared));
+            return Ok(BackendFileInfo {
+                path,
+                offset: Some(offset),
+                inode: Some(inode),
+                dev: Some(dev),
+                shared: self.shared,
+            });
         }
         if let Some(name) = &self.name {
-            return Ok((name.clone(), None, None, None, self.shared));
+            return Ok(BackendFileInfo {
+                path: name.clone(),
+                offset: None,
+                inode: None,
+                dev: None,
+                shared: self.shared,
+            });
         }
         Err(AxError::InvalidInput)
     }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/file.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/file.rs
@@ -1,5 +1,6 @@
 use alloc::{
     boxed::Box,
+    string::{String, ToString},
     sync::{Arc, Weak},
     vec::Vec,
 };
@@ -10,18 +11,26 @@ use ax_fs::{CachedFile, FileFlags};
 use ax_hal::paging::{MappingFlags, PageSize, PageTableCursor, PagingError};
 use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr, VirtAddrRange};
 use ax_sync::Mutex;
+use weak_map::StrongRef;
 
 use super::{AddrSpace, Backend, BackendOps, PopulateCallback, pages_in};
 
 #[doc(hidden)]
 pub struct FileBackendInner {
-    start: VirtAddr,
+    shared: bool,
+    file_data: Mutex<FileBackendInnerData>,
     cache: CachedFile,
     flags: FileFlags,
-    offset_page: u32,
     handle: AtomicUsize,
     futex_handle: Arc<()>,
 }
+
+#[derive(Clone)]
+struct FileBackendInnerData {
+    start: VirtAddr,
+    offset_page: u32,
+}
+
 impl Drop for FileBackendInner {
     fn drop(&mut self) {
         let handle = self.handle.load(Ordering::Acquire);
@@ -61,10 +70,11 @@ impl FileBackendInner {
     }
 
     fn on_evict(self: &Arc<Self>, pn: u32, aspace: &mut AddrSpace) {
-        let Some(pn) = pn.checked_sub(self.offset_page) else {
+        let file_data = self.file_data.lock();
+        let Some(pn) = pn.checked_sub(file_data.offset_page) else {
             return;
         };
-        let vaddr = self.start + pn as usize * PageSize::Size4K as usize;
+        let vaddr = file_data.start + pn as usize * PageSize::Size4K as usize;
         if !aspace.find_area(vaddr).is_some_and(
             |it| matches!(it.backend(), Backend::File(file) if Arc::ptr_eq(&file.0, self)),
         ) {
@@ -84,7 +94,7 @@ impl FileBackendInner {
 
 /// File-backed mapping backend.
 #[derive(Clone)]
-pub struct FileBackend(Arc<FileBackendInner>);
+pub struct FileBackend(Arc<FileBackendInner>, Weak<Mutex<AddrSpace>>);
 impl FileBackend {
     fn check_flags(&self, flags: MappingFlags) -> AxResult {
         let mut required_flags = FileFlags::empty();
@@ -103,6 +113,14 @@ impl FileBackend {
 
     pub fn futex_handle(&self) -> Weak<()> {
         Arc::downgrade(&self.0.futex_handle)
+    }
+
+    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, bool)> {
+        let loc = self.0.cache.location();
+        let name = loc.absolute_path().map(|pb| pb.to_string())?;
+        let offset = (self.0.file_data.lock().offset_page as u64) * PAGE_SIZE_4K as u64;
+        let inode = loc.inode();
+        Ok((name, Some(offset), Some(inode), self.0.shared))
     }
 }
 
@@ -151,7 +169,9 @@ impl BackendOps for FileBackend {
     ) -> AxResult<(usize, Option<PopulateCallback>)> {
         let mut pages = 0;
         let mut to_be_evicted = Vec::new();
-        let start_page = ((range.start - self.0.start) / PAGE_SIZE_4K) as u32 + self.0.offset_page;
+        let file_data = self.0.file_data.lock();
+        let start_page =
+            ((range.start - file_data.start) / PAGE_SIZE_4K) as u32 + file_data.offset_page;
         for (i, addr) in pages_in(range, PageSize::Size4K)?.enumerate() {
             let pn = start_page + i as u32;
             match pt.query(addr) {
@@ -218,15 +238,53 @@ impl BackendOps for FileBackend {
         new_aspace: &Arc<Mutex<AddrSpace>>,
     ) -> AxResult<Backend> {
         let inner = Arc::new(FileBackendInner {
-            start: self.0.start,
+            shared: self.0.shared,
+            file_data: Mutex::new(self.0.file_data.lock().clone()),
             cache: self.0.cache.clone(),
             flags: self.0.flags,
-            offset_page: self.0.offset_page,
             handle: AtomicUsize::new(0),
             futex_handle: self.0.futex_handle.clone(),
         });
         inner.register_listener(new_aspace);
-        Ok(Backend::File(FileBackend(inner)))
+        Ok(Backend::File(FileBackend(inner, new_aspace.downgrade())))
+    }
+
+    fn split(&mut self, align_diff: usize) -> Option<Backend> {
+        assert!(align_diff.is_multiple_of(PAGE_SIZE_4K));
+        if align_diff == 0 {
+            return None;
+        }
+        let file_data = self.0.file_data.lock();
+        let inner = Arc::new(FileBackendInner {
+            shared: self.0.shared,
+            file_data: Mutex::new(FileBackendInnerData {
+                start: file_data.start + align_diff,
+                offset_page: file_data.offset_page + (align_diff / PAGE_SIZE_4K) as u32,
+            }),
+            cache: self.0.cache.clone(),
+            flags: self.0.flags,
+            handle: AtomicUsize::new(0),
+            futex_handle: self.0.futex_handle.clone(),
+        });
+
+        if let Some(aspace) = self.1.upgrade() {
+            inner.register_listener(&aspace);
+        } else {
+            return None;
+        }
+        Some(Backend::File(FileBackend(inner, self.1.clone())))
+    }
+
+    fn shrink_left(&mut self, shrink_size: usize) {
+        assert!(shrink_size.is_multiple_of(PAGE_SIZE_4K));
+
+        let mut file_data = self.0.file_data.lock();
+        file_data.start += shrink_size;
+        file_data.offset_page += (shrink_size / PAGE_SIZE_4K) as u32;
+    }
+
+    fn shrink_right(&mut self, _shrink_size: usize) {
+        // shrinking right does not require any action since the file backend does not have any state
     }
 }
 
@@ -237,17 +295,18 @@ impl Backend {
         flags: FileFlags,
         offset: usize,
         aspace: &Arc<Mutex<AddrSpace>>,
+        shared: bool,
     ) -> Self {
         let offset_page = (offset / PAGE_SIZE_4K) as u32;
         let inner = Arc::new(FileBackendInner {
-            start,
+            shared,
+            file_data: Mutex::new(FileBackendInnerData { start, offset_page }),
             cache,
             flags,
-            offset_page,
             handle: AtomicUsize::new(0),
             futex_handle: Arc::new(()),
         });
         inner.register_listener(aspace);
-        Self::File(FileBackend(inner))
+        Self::File(FileBackend(inner, aspace.downgrade()))
     }
 }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/file.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/file.rs
@@ -115,12 +115,13 @@ impl FileBackend {
         Arc::downgrade(&self.0.futex_handle)
     }
 
-    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, bool)> {
+    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, Option<u64>, bool)> {
         let loc = self.0.cache.location();
         let name = loc.absolute_path().map(|pb| pb.to_string())?;
         let offset = (self.0.file_data.lock().offset_page as u64) * PAGE_SIZE_4K as u64;
         let inode = loc.inode();
-        Ok((name, Some(offset), Some(inode), self.0.shared))
+        let dev = loc.metadata()?.device;
+        Ok((name, Some(offset), Some(inode), Some(dev), self.0.shared))
     }
 }
 

--- a/os/StarryOS/kernel/src/mm/aspace/backend/file.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/file.rs
@@ -1,6 +1,6 @@
 use alloc::{
     boxed::Box,
-    string::{String, ToString},
+    string::ToString,
     sync::{Arc, Weak},
     vec::Vec,
 };
@@ -13,7 +13,7 @@ use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr, VirtAddrRange};
 use ax_sync::Mutex;
 use weak_map::StrongRef;
 
-use super::{AddrSpace, Backend, BackendOps, PopulateCallback, pages_in};
+use super::{AddrSpace, Backend, BackendFileInfo, BackendOps, PopulateCallback, pages_in};
 
 #[doc(hidden)]
 pub struct FileBackendInner {
@@ -115,13 +115,19 @@ impl FileBackend {
         Arc::downgrade(&self.0.futex_handle)
     }
 
-    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, Option<u64>, bool)> {
+    pub fn file_info(&self) -> AxResult<BackendFileInfo> {
         let loc = self.0.cache.location();
         let name = loc.absolute_path().map(|pb| pb.to_string())?;
         let offset = (self.0.file_data.lock().offset_page as u64) * PAGE_SIZE_4K as u64;
         let inode = loc.inode();
         let dev = loc.metadata()?.device;
-        Ok((name, Some(offset), Some(inode), Some(dev), self.0.shared))
+        Ok(BackendFileInfo {
+            path: name,
+            offset: Some(offset),
+            inode: Some(inode),
+            dev: Some(dev),
+            shared: self.0.shared,
+        })
     }
 }
 
@@ -268,11 +274,11 @@ impl BackendOps for FileBackend {
             futex_handle: self.0.futex_handle.clone(),
         });
 
-        if let Some(aspace) = self.1.upgrade() {
+        {
+            let aspace = self.1.upgrade()?;
             inner.register_listener(&aspace);
-        } else {
-            return None;
         }
+
         Some(Backend::File(FileBackend(inner, self.1.clone())))
     }
 

--- a/os/StarryOS/kernel/src/mm/aspace/backend/linear.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/linear.rs
@@ -15,11 +15,16 @@ use super::{AddrSpace, Backend, BackendOps};
 #[derive(Clone)]
 pub struct LinearBackend {
     offset: isize,
+    shared: bool,
 }
 
 impl LinearBackend {
     fn pa(&self, va: VirtAddr) -> PhysAddr {
         PhysAddr::from((va.as_usize() as isize - self.offset) as usize)
+    }
+
+    pub const fn is_shared(&self) -> bool {
+        self.shared
     }
 }
 
@@ -52,10 +57,23 @@ impl BackendOps for LinearBackend {
     ) -> AxResult<Backend> {
         Ok(Backend::Linear(self.clone()))
     }
+
+    fn split(&mut self, _align_diff: usize) -> Option<Backend> {
+        // linear backend can be trivially split since it does not have any state.
+        Some(Backend::Linear(self.clone()))
+    }
+
+    fn shrink_left(&mut self, _shrink_size: usize) {
+        // linear backend can be trivially shrunk since it does not have any state.
+    }
+
+    fn shrink_right(&mut self, _shrink_size: usize) {
+        // linear backend can be trivially shrunk since it does not have any state.
+    }
 }
 
 impl Backend {
-    pub fn new_linear(offset: isize) -> Self {
-        Self::Linear(LinearBackend { offset })
+    pub fn new_linear(offset: isize, shared: bool) -> Self {
+        Self::Linear(LinearBackend { offset, shared })
     }
 }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
@@ -1,5 +1,9 @@
 //! Memory mapping backends.
-use alloc::{boxed::Box, sync::Arc};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    sync::Arc,
+};
 
 use ax_alloc::{UsageKind, global_allocator};
 use ax_errno::{AxError, AxResult};
@@ -104,6 +108,20 @@ pub trait BackendOps {
         new_pt: &mut PageTableCursor,
         new_aspace: &Arc<Mutex<AddrSpace>>,
     ) -> AxResult<Backend>;
+
+    /// Splits the backend into two at the given position, and returns the backend for the upper part.
+    ///
+    /// The original backend is shrunk to the lower part.
+    ///
+    /// Returns `None` if the given position is not in the memory area, or one
+    /// of the parts is empty after splitting.
+    fn split(&mut self, align_diff: usize) -> Option<Backend>;
+
+    /// Shrinks the backend from the left by the given size.
+    fn shrink_left(&mut self, _shrink_size: usize);
+
+    /// Shrinks the backend from the right by the given size.
+    fn shrink_right(&mut self, _shrink_size: usize);
 }
 
 /// A unified enum type for different memory mapping backends.
@@ -114,6 +132,20 @@ pub enum Backend {
     Cow(cow::CowBackend),
     Shared(shared::SharedBackend),
     File(file::FileBackend),
+}
+
+impl Backend {
+    /// Returns the file information if this is a file-backed mapping, or `None` otherwise.
+    ///
+    /// The returned tuple contains the file name, offset, inode and whether the mapping is shared.
+    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, bool)> {
+        match self {
+            Backend::Cow(b) => b.file_info(),
+            Backend::Linear(b) => Ok(("".to_string(), None, None, b.is_shared())),
+            Backend::Shared(_) => Ok(("".to_string(), None, None, true)),
+            Backend::File(b) => b.file_info(),
+        }
+    }
 }
 
 impl MappingBackend for Backend {
@@ -155,5 +187,17 @@ impl MappingBackend for Backend {
             return false;
         }
         cursor.protect_region(start, size, new_flags).is_ok()
+    }
+
+    fn split(&mut self, align_diff: usize) -> Option<Self> {
+        BackendOps::split(self, align_diff)
+    }
+
+    fn shrink_left(&mut self, shrink_size: usize) {
+        BackendOps::shrink_left(self, shrink_size)
+    }
+
+    fn shrink_right(&mut self, shrink_size: usize) {
+        BackendOps::shrink_right(self, shrink_size)
     }
 }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
@@ -138,11 +138,11 @@ impl Backend {
     /// Returns the file information if this is a file-backed mapping, or `None` otherwise.
     ///
     /// The returned tuple contains the file name, offset, inode and whether the mapping is shared.
-    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, bool)> {
+    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, Option<u64>, bool)> {
         match self {
             Backend::Cow(b) => b.file_info(),
-            Backend::Linear(b) => Ok(("".to_string(), None, None, b.is_shared())),
-            Backend::Shared(_) => Ok(("".to_string(), None, None, true)),
+            Backend::Linear(b) => Ok(("".to_string(), None, None, None, b.is_shared())),
+            Backend::Shared(_) => Ok(("".to_string(), None, None, None, true)),
             Backend::File(b) => b.file_info(),
         }
     }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
@@ -134,15 +134,35 @@ pub enum Backend {
     File(file::FileBackend),
 }
 
+pub struct BackendFileInfo {
+    pub path: String,
+    pub offset: Option<u64>,
+    pub inode: Option<u64>,
+    pub dev: Option<u64>,
+    pub shared: bool,
+}
+
 impl Backend {
     /// Returns the file information if this is a file-backed mapping, or `None` otherwise.
     ///
     /// The returned tuple contains the file name, offset, inode and whether the mapping is shared.
-    pub fn file_info(&self) -> AxResult<(String, Option<u64>, Option<u64>, Option<u64>, bool)> {
+    pub fn file_info(&self) -> AxResult<BackendFileInfo> {
         match self {
             Backend::Cow(b) => b.file_info(),
-            Backend::Linear(b) => Ok(("".to_string(), None, None, None, b.is_shared())),
-            Backend::Shared(_) => Ok(("".to_string(), None, None, None, true)),
+            Backend::Linear(b) => Ok(BackendFileInfo {
+                path: "".to_string(),
+                offset: None,
+                inode: None,
+                dev: None,
+                shared: b.is_shared(),
+            }),
+            Backend::Shared(_) => Ok(BackendFileInfo {
+                path: "".to_string(),
+                offset: None,
+                inode: None,
+                dev: None,
+                shared: true,
+            }),
             Backend::File(b) => b.file_info(),
         }
     }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/shared.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/shared.rs
@@ -55,6 +55,7 @@ impl Drop for SharedPages {
 pub struct SharedBackend {
     start: VirtAddr,
     pages: Arc<SharedPages>,
+    page_offset: usize,
 }
 impl SharedBackend {
     pub fn pages(&self) -> &Arc<SharedPages> {
@@ -63,7 +64,7 @@ impl SharedBackend {
 
     fn pages_starting_from(&self, start: VirtAddr) -> &[PhysAddr] {
         debug_assert!(start.is_aligned(self.pages.size));
-        let start_index = divide_page(start - self.start, self.pages.size);
+        let start_index = self.page_offset + divide_page(start - self.start, self.pages.size);
         &self.pages[start_index..]
     }
 }
@@ -101,10 +102,32 @@ impl BackendOps for SharedBackend {
     ) -> AxResult<Backend> {
         Ok(Backend::Shared(self.clone()))
     }
+
+    fn split(&mut self, align_diff: usize) -> Option<Backend> {
+        if align_diff == 0 {
+            return None;
+        }
+        Some(Backend::Shared(SharedBackend {
+            start: self.start + align_diff,
+            pages: self.pages.clone(),
+            page_offset: self.page_offset + divide_page(align_diff, self.pages.size),
+        }))
+    }
+
+    fn shrink_left(&mut self, shrink_size: usize) {
+        self.start += shrink_size;
+        self.page_offset += divide_page(shrink_size, self.pages.size);
+    }
+
+    fn shrink_right(&mut self, _shrink_size: usize) {}
 }
 
 impl Backend {
     pub fn new_shared(start: VirtAddr, pages: Arc<SharedPages>) -> Self {
-        Self::Shared(SharedBackend { start, pages })
+        Self::Shared(SharedBackend {
+            start,
+            pages,
+            page_offset: 0,
+        })
     }
 }

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -122,7 +122,7 @@ impl AddrSpace {
         }
 
         let offset = start_vaddr.as_usize() as isize - start_paddr.as_usize() as isize;
-        let area = MemoryArea::new(start_vaddr, size, flags, Backend::new_linear(offset));
+        let area = MemoryArea::new(start_vaddr, size, flags, Backend::new_linear(offset, false));
         self.areas.map(area, &mut self.pt, false)?;
         Ok(())
     }

--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -115,6 +115,7 @@ fn map_elf<'a>(
             FileBackend::Cached(cache.clone()),
             ph.offset,
             Some(ph.offset + ph.file_size),
+            false,
         );
         uspace.map(
             seg_start.align_down_4k(),
@@ -328,7 +329,7 @@ pub fn load_user_app(
         ustack_size,
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
         false,
-        Backend::new_alloc(ustack_start, PageSize::Size4K),
+        Backend::new_alloc(ustack_start, PageSize::Size4K, "[stack]"),
     )?;
 
     let stack_data = app_stack_region(args, envs, &auxv, ustack_top.into());
@@ -348,7 +349,7 @@ pub fn load_user_app(
         heap_size,
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
         true,
-        Backend::new_alloc(heap_start, PageSize::Size4K),
+        Backend::new_alloc(heap_start, PageSize::Size4K, "[heap]"),
     )?;
 
     Ok((entry, user_sp))

--- a/os/StarryOS/kernel/src/pseudofs/file.rs
+++ b/os/StarryOS/kernel/src/pseudofs/file.rs
@@ -1,6 +1,7 @@
 use alloc::{borrow::Cow, sync::Arc, vec::Vec};
 use core::{any::Any, cmp::Ordering, task::Context};
 
+use ax_sync::Mutex;
 use axfs_ng_vfs::{
     FileNodeOps, FilesystemOps, Metadata, MetadataUpdate, NodeFlags, NodeOps, NodePermission,
     NodeType, VfsError, VfsResult,
@@ -172,6 +173,132 @@ impl FileNodeOps for SimpleFile {
 impl Pollable for SimpleFile {
     fn poll(&self) -> IoEvents {
         IoEvents::IN | IoEvents::OUT
+    }
+
+    fn register(&self, _context: &mut Context<'_>, _events: IoEvents) {}
+}
+
+/// A Sequential file, which only supports reading all content. It is used for procfs and sysfs.
+pub struct SeqFile {
+    node: SimpleFsNode,
+    ops: Arc<dyn SeqFileOps>,
+    content_cache: Mutex<Option<Vec<u8>>>,
+}
+
+impl SeqFile {
+    /// Creates a sequential file from given file operations.
+    pub fn new(fs: Arc<SimpleFs>, ty: NodeType, ops: impl SeqFileOps) -> Arc<Self> {
+        let node = SimpleFsNode::new(fs, ty, NodePermission::default());
+        Arc::new(Self {
+            node,
+            ops: Arc::new(ops),
+            content_cache: Mutex::new(None),
+        })
+    }
+
+    /// Creates a sequential file from given file operations.
+    pub fn new_regular(fs: Arc<SimpleFs>, ops: impl SeqFileOps) -> Arc<Self> {
+        Self::new(fs, NodeType::RegularFile, ops)
+    }
+}
+
+// TODO: create a linux like seq file that supports iterating content in chunks instead of reading all content at once, to avoid large memory usage for large files.
+/// Operations for a sequential file.
+pub trait SeqFileOps: Send + Sync + 'static {
+    /// Reads all content in the file.
+    fn read_all(&self) -> VfsResult<Cow<'_, [u8]>>;
+}
+
+impl<F, R> SeqFileOps for F
+where
+    F: Fn() -> VfsResult<R> + Send + Sync + 'static,
+    R: Into<Vec<u8>>,
+{
+    fn read_all(&self) -> VfsResult<Cow<'_, [u8]>> {
+        (self)().map(|it| Cow::Owned(it.into()))
+    }
+}
+
+#[inherit_methods(from = "self.node")]
+impl NodeOps for SeqFile {
+    fn inode(&self) -> u64;
+
+    fn metadata(&self) -> VfsResult<Metadata>;
+
+    fn update_metadata(&self, update: MetadataUpdate) -> VfsResult<()>;
+
+    fn filesystem(&self) -> &dyn FilesystemOps;
+
+    fn sync(&self, data_only: bool) -> VfsResult<()>;
+
+    fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
+    }
+
+    fn len(&self) -> VfsResult<u64> {
+        // Cache the content to avoid repeated generation.
+        let mut cache = self.content_cache.lock();
+        if let Some(content) = cache.as_ref() {
+            Ok(content.len() as u64)
+        } else {
+            let content = self.ops.read_all()?;
+            let len = content.len() as u64;
+            *cache = Some(content.into_owned());
+            Ok(len)
+        }
+    }
+
+    fn flags(&self) -> NodeFlags {
+        NodeFlags::NON_CACHEABLE
+    }
+}
+
+impl FileNodeOps for SeqFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> VfsResult<usize> {
+        let mut cache = self.content_cache.lock();
+        if cache.is_none() {
+            let content = self.ops.read_all()?;
+            *cache = Some(content.into_owned());
+        }
+
+        let data = cache.as_ref().unwrap();
+        if offset >= data.len() as u64 {
+            return Ok(0);
+        }
+        let data = &data[offset as usize..];
+        let read = data.len().min(buf.len());
+        buf[..read].copy_from_slice(&data[..read]);
+        Ok(read)
+    }
+
+    fn seek_to(&self, pos: u64) -> VfsResult<()> {
+        if pos == 0 {
+            // Clear the cache to reset the file content.
+            let mut cache = self.content_cache.lock();
+            *cache = None;
+        }
+        Ok(())
+    }
+
+    fn write_at(&self, _buf: &[u8], _offset: u64) -> VfsResult<usize> {
+        Err(VfsError::OperationNotPermitted)
+    }
+    fn append(&self, _buf: &[u8]) -> VfsResult<(usize, u64)> {
+        Err(VfsError::OperationNotPermitted)
+    }
+
+    fn set_len(&self, _len: u64) -> VfsResult<()> {
+        Err(VfsError::OperationNotPermitted)
+    }
+
+    fn set_symlink(&self, _target: &str) -> VfsResult<()> {
+        Err(VfsError::OperationNotPermitted)
+    }
+}
+
+impl Pollable for SeqFile {
+    fn poll(&self) -> IoEvents {
+        IoEvents::IN
     }
 
     fn register(&self, _context: &mut Context<'_>, _events: IoEvents) {}

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -9,10 +9,12 @@ use alloc::{
 };
 use core::{
     ffi::CStr,
+    fmt::Write,
     iter,
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use ax_hal::paging::MappingFlags;
 use ax_task::{AxCpuMask, AxTaskRef, WeakAxTaskRef, current};
 use axfs_ng_vfs::{Filesystem, NodeType, VfsError, VfsResult};
 use indoc::indoc;
@@ -292,6 +294,68 @@ struct ThreadDir {
     task: WeakAxTaskRef,
 }
 
+impl ThreadDir {
+    fn thread_maps(&self) -> VfsResult<String> {
+        let mut output = String::new();
+
+        let task = match self.task.upgrade() {
+            Some(t) => t,
+            None => return Ok(output),
+        };
+
+        let mm = task.as_thread().proc_data.aspace.lock();
+
+        for area in mm.areas() {
+            let start = area.start();
+            let end = area.end();
+            let backend = area.backend();
+            let (path, file_offset, inode, is_shared) = backend.file_info()?;
+
+            let flag_end = if is_shared { 's' } else { 'p' };
+            let flags = area.flags();
+            let perms = {
+                let r = if flags.contains(MappingFlags::READ) {
+                    'r'
+                } else {
+                    '-'
+                };
+                let w = if flags.contains(MappingFlags::WRITE) {
+                    'w'
+                } else {
+                    '-'
+                };
+                let x = if flags.contains(MappingFlags::EXECUTE) {
+                    'x'
+                } else {
+                    '-'
+                };
+                format!("{}{}{}{}", r, w, x, flag_end)
+            };
+            const MAPS_COL_WIDTH: usize = 25 + core::mem::size_of::<usize>() * 6 - 1;
+            let mut writer = SeqWriter::new(&mut output);
+            write!(
+                &mut writer,
+                "{:08x}-{:08x} {} {:08x} {:02x}:{:02x} {}",
+                start.as_usize(),
+                end.as_usize(),
+                perms,
+                file_offset.unwrap_or(0),
+                0,
+                0,
+                inode.unwrap_or(0),
+            )
+            .map_err(|_| VfsError::InvalidInput)?;
+            writer.pad_to(MAPS_COL_WIDTH)?;
+            if !path.is_empty() {
+                writer.write_str(&path)?;
+            }
+            writer.newline()?;
+        }
+
+        Ok(output)
+    }
+}
+
 impl SimpleDirOps for ThreadDir {
     fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
         Box::new(
@@ -348,15 +412,10 @@ impl SimpleDirOps for ThreadDir {
                 }),
             )
             .into(),
-            "maps" => SimpleFile::new_regular(fs, move || {
-                Ok(indoc! {"
-                    7f000000-7f001000 r--p 00000000 00:00 0          [vdso]
-                    7f001000-7f003000 r-xp 00001000 00:00 0          [vdso]
-                    7f003000-7f005000 r--p 00003000 00:00 0          [vdso]
-                    7f005000-7f007000 rw-p 00005000 00:00 0          [vdso]
-                "})
-            })
-            .into(),
+            "maps" => {
+                let maps = self.thread_maps()?;
+                SimpleFile::new_regular(fs, move || Ok(maps.clone())).into()
+            }
             "mounts" => SimpleFile::new_regular(fs, move || {
                 Ok("proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\n")
             })
@@ -523,6 +582,54 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
     SimpleDir::new_maker(fs, Arc::new(proc_dir.chain(root)))
 }
 
+pub struct SeqWriter<W: core::fmt::Write> {
+    inner: W,
+    col: usize,
+}
+
+impl<W: core::fmt::Write> SeqWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self { inner, col: 0 }
+    }
+}
+
+impl<W: core::fmt::Write> SeqWriter<W> {
+    fn write_str(&mut self, s: &str) -> VfsResult<()> {
+        self.col += s.len();
+        self.inner.write_str(s)?;
+        Ok(())
+    }
+
+    #[allow(unused)]
+    fn write_char(&mut self, c: char) -> VfsResult<()> {
+        self.col += c.len_utf8();
+        self.inner.write_char(c)?;
+        Ok(())
+    }
+
+    fn pad_to(&mut self, target: usize) -> VfsResult<()> {
+        if self.col < target {
+            let pad = target - self.col;
+            for _ in 0..pad {
+                self.inner.write_char(' ')?;
+            }
+            self.col = target;
+        }
+        Ok(())
+    }
+
+    fn newline(&mut self) -> VfsResult<()> {
+        self.inner.write_char('\n')?;
+        self.col = 0;
+        Ok(())
+    }
+}
+
+impl<W: core::fmt::Write> core::fmt::Write for SeqWriter<W> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write_str(s).map_err(|_| core::fmt::Error)
+    }
+}
 #[cfg(test)]
 mod tests {
     use alloc::{format, string::String};

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -15,7 +15,7 @@ use core::{
 };
 
 use ax_hal::paging::MappingFlags;
-use ax_task::{AxCpuMask, AxTaskRef, TaskInner, WeakAxTaskRef, current};
+use ax_task::{AxCpuMask, AxTaskRef, WeakAxTaskRef, current};
 use axfs_ng_vfs::{DeviceId, Filesystem, NodeType, VfsError, VfsResult};
 use indoc::indoc;
 use starry_process::Process;
@@ -23,7 +23,7 @@ use starry_process::Process;
 use crate::{
     file::FD_TABLE,
     pseudofs::{
-        DirMaker, DirMapping, NodeOpsMux, RwFile, SimpleDir, SimpleDirOps, SimpleFile,
+        DirMaker, DirMapping, NodeOpsMux, RwFile, SeqFile, SimpleDir, SimpleDirOps, SimpleFile,
         SimpleFileOperation, SimpleFs,
     },
     task::{AsThread, TaskStat, get_task, tasks},
@@ -345,8 +345,8 @@ impl ThreadDir {
                 end.as_usize(),
                 perms,
                 file_offset.unwrap_or(0),
-                dev.map(|(major, minor)| major).unwrap_or(0),
-                dev.map(|(major, minor)| minor).unwrap_or(0),
+                dev.map(|(major, _)| major).unwrap_or(0),
+                dev.map(|(_, minor)| minor).unwrap_or(0),
                 inode.unwrap_or(0),
             )
             .map_err(|_| VfsError::InvalidInput)?;
@@ -419,7 +419,7 @@ impl SimpleDirOps for ThreadDir {
             .into(),
             "maps" => {
                 let maps = self.thread_maps()?;
-                SimpleFile::new_regular(fs, move || Ok(maps.clone())).into()
+                SeqFile::new_regular(fs, move || Ok(maps.clone())).into()
             }
             "mounts" => SimpleFile::new_regular(fs, move || {
                 Ok("proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\n")

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -22,6 +22,7 @@ use starry_process::Process;
 
 use crate::{
     file::FD_TABLE,
+    mm::BackendFileInfo,
     pseudofs::{
         DirMaker, DirMapping, NodeOpsMux, RwFile, SeqFile, SimpleDir, SimpleDirOps, SimpleFile,
         SimpleFileOperation, SimpleFs,
@@ -308,7 +309,13 @@ fn render_thread_maps(task: &WeakAxTaskRef) -> VfsResult<String> {
         let start = area.start();
         let end = area.end();
         let backend = area.backend();
-        let (path, file_offset, inode, dev, is_shared) = backend.file_info()?;
+        let BackendFileInfo {
+            path,
+            offset: file_offset,
+            inode,
+            dev,
+            shared: is_shared,
+        } = backend.file_info()?;
 
         let flag_end = if is_shared { 's' } else { 'p' };
         let flags = area.flags();
@@ -333,9 +340,7 @@ fn render_thread_maps(task: &WeakAxTaskRef) -> VfsResult<String> {
         const MAPS_COL_WIDTH: usize = 25 + core::mem::size_of::<usize>() * 6 - 1;
         let mut writer = SeqWriter::new(&mut output);
 
-        let dev = dev
-            .map(|dev| DeviceId(dev))
-            .map(|dev| (dev.major(), dev.minor()));
+        let dev = dev.map(DeviceId).map(|dev| (dev.major(), dev.minor()));
 
         write!(
             &mut writer,

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -15,8 +15,8 @@ use core::{
 };
 
 use ax_hal::paging::MappingFlags;
-use ax_task::{AxCpuMask, AxTaskRef, WeakAxTaskRef, current};
-use axfs_ng_vfs::{Filesystem, NodeType, VfsError, VfsResult};
+use ax_task::{AxCpuMask, AxTaskRef, TaskInner, WeakAxTaskRef, current};
+use axfs_ng_vfs::{DeviceId, Filesystem, NodeType, VfsError, VfsResult};
 use indoc::indoc;
 use starry_process::Process;
 
@@ -309,7 +309,7 @@ impl ThreadDir {
             let start = area.start();
             let end = area.end();
             let backend = area.backend();
-            let (path, file_offset, inode, is_shared) = backend.file_info()?;
+            let (path, file_offset, inode, dev, is_shared) = backend.file_info()?;
 
             let flag_end = if is_shared { 's' } else { 'p' };
             let flags = area.flags();
@@ -333,6 +333,11 @@ impl ThreadDir {
             };
             const MAPS_COL_WIDTH: usize = 25 + core::mem::size_of::<usize>() * 6 - 1;
             let mut writer = SeqWriter::new(&mut output);
+
+            let dev = dev
+                .map(|dev| DeviceId(dev))
+                .map(|dev| (dev.major(), dev.minor()));
+
             write!(
                 &mut writer,
                 "{:08x}-{:08x} {} {:08x} {:02x}:{:02x} {}",
@@ -340,8 +345,8 @@ impl ThreadDir {
                 end.as_usize(),
                 perms,
                 file_offset.unwrap_or(0),
-                0,
-                0,
+                dev.map(|(major, minor)| major).unwrap_or(0),
+                dev.map(|(major, minor)| minor).unwrap_or(0),
                 inode.unwrap_or(0),
             )
             .map_err(|_| VfsError::InvalidInput)?;

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -294,71 +294,69 @@ struct ThreadDir {
     task: WeakAxTaskRef,
 }
 
-impl ThreadDir {
-    fn thread_maps(&self) -> VfsResult<String> {
-        let mut output = String::new();
+fn render_thread_maps(task: &WeakAxTaskRef) -> VfsResult<String> {
+    let mut output = String::new();
 
-        let task = match self.task.upgrade() {
-            Some(t) => t,
-            None => return Ok(output),
-        };
+    let task = match task.upgrade() {
+        Some(t) => t,
+        None => return Ok(output),
+    };
 
-        let mm = task.as_thread().proc_data.aspace.lock();
+    let mm = task.as_thread().proc_data.aspace.lock();
 
-        for area in mm.areas() {
-            let start = area.start();
-            let end = area.end();
-            let backend = area.backend();
-            let (path, file_offset, inode, dev, is_shared) = backend.file_info()?;
+    for area in mm.areas() {
+        let start = area.start();
+        let end = area.end();
+        let backend = area.backend();
+        let (path, file_offset, inode, dev, is_shared) = backend.file_info()?;
 
-            let flag_end = if is_shared { 's' } else { 'p' };
-            let flags = area.flags();
-            let perms = {
-                let r = if flags.contains(MappingFlags::READ) {
-                    'r'
-                } else {
-                    '-'
-                };
-                let w = if flags.contains(MappingFlags::WRITE) {
-                    'w'
-                } else {
-                    '-'
-                };
-                let x = if flags.contains(MappingFlags::EXECUTE) {
-                    'x'
-                } else {
-                    '-'
-                };
-                format!("{}{}{}{}", r, w, x, flag_end)
+        let flag_end = if is_shared { 's' } else { 'p' };
+        let flags = area.flags();
+        let perms = {
+            let r = if flags.contains(MappingFlags::READ) {
+                'r'
+            } else {
+                '-'
             };
-            const MAPS_COL_WIDTH: usize = 25 + core::mem::size_of::<usize>() * 6 - 1;
-            let mut writer = SeqWriter::new(&mut output);
+            let w = if flags.contains(MappingFlags::WRITE) {
+                'w'
+            } else {
+                '-'
+            };
+            let x = if flags.contains(MappingFlags::EXECUTE) {
+                'x'
+            } else {
+                '-'
+            };
+            format!("{}{}{}{}", r, w, x, flag_end)
+        };
+        const MAPS_COL_WIDTH: usize = 25 + core::mem::size_of::<usize>() * 6 - 1;
+        let mut writer = SeqWriter::new(&mut output);
 
-            let dev = dev
-                .map(|dev| DeviceId(dev))
-                .map(|dev| (dev.major(), dev.minor()));
+        let dev = dev
+            .map(|dev| DeviceId(dev))
+            .map(|dev| (dev.major(), dev.minor()));
 
-            write!(
-                &mut writer,
-                "{:08x}-{:08x} {} {:08x} {:02x}:{:02x} {}",
-                start.as_usize(),
-                end.as_usize(),
-                perms,
-                file_offset.unwrap_or(0),
-                dev.map(|(major, _)| major).unwrap_or(0),
-                dev.map(|(_, minor)| minor).unwrap_or(0),
-                inode.unwrap_or(0),
-            )
-            .map_err(|_| VfsError::InvalidInput)?;
-            writer.pad_to(MAPS_COL_WIDTH)?;
-            if !path.is_empty() {
-                writer.write_str(&path)?;
-            }
-            writer.newline()?;
+        write!(
+            &mut writer,
+            "{:08x}-{:08x} {} {:08x} {:02x}:{:02x} {}",
+            start.as_usize(),
+            end.as_usize(),
+            perms,
+            file_offset.unwrap_or(0),
+            dev.map(|(major, _)| major).unwrap_or(0),
+            dev.map(|(_, minor)| minor).unwrap_or(0),
+            inode.unwrap_or(0),
+        )
+        .map_err(|_| VfsError::InvalidInput)?;
+        writer.pad_to(MAPS_COL_WIDTH)?;
+        if !path.is_empty() {
+            writer.write_str(&path)?;
         }
-
-        Ok(output)
+        writer.newline()?;
     }
+
+    Ok(output)
 }
 
 impl SimpleDirOps for ThreadDir {
@@ -418,8 +416,8 @@ impl SimpleDirOps for ThreadDir {
             )
             .into(),
             "maps" => {
-                let maps = self.thread_maps()?;
-                SeqFile::new_regular(fs, move || Ok(maps.clone())).into()
+                let task = self.task.clone();
+                SeqFile::new_regular(fs, move || render_thread_maps(&task)).into()
             }
             "mounts" => SimpleFile::new_regular(fs, move || {
                 Ok("proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\n")

--- a/os/StarryOS/kernel/src/syscall/mm/brk.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/brk.rs
@@ -43,7 +43,7 @@ pub fn sys_brk(addr: usize) -> AxResult<isize> {
                     expand_size,
                     MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
                     false,
-                    Backend::new_alloc(expand_start, PageSize::Size4K),
+                    Backend::new_alloc(expand_start, PageSize::Size4K, "[heap]"),
                 )
                 .is_err()
         {

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -198,6 +198,7 @@ pub fn sys_mmap(
                             length = length.min(range.size().align_down(page_size));
                             Backend::new_linear(
                                 start.as_usize() as isize - range.start.as_usize() as isize,
+                                true,
                             );
                         }
                         DeviceMmap::None => return Err(AxError::NoSuchDevice),
@@ -225,6 +226,7 @@ pub fn sys_mmap(
                             flags,
                             offset,
                             &curr.as_thread().proc_data.aspace,
+                            true,
                         )
                     }
                     FileBackend::Direct(loc) => {
@@ -244,6 +246,7 @@ pub fn sys_mmap(
                                 length = capped_device_map_len(length, range.size(), page_size);
                                 Backend::new_linear(
                                     start.as_usize() as isize - range.start.as_usize() as isize,
+                                    true,
                                 )
                             }
                             DeviceMmap::Cache(cache) => Backend::new_file(
@@ -252,6 +255,7 @@ pub fn sys_mmap(
                                 flags,
                                 offset,
                                 &curr.as_thread().proc_data.aspace,
+                                true,
                             ),
                         }
                     }
@@ -270,9 +274,9 @@ pub fn sys_mmap(
                 if !file_flags.contains(FileFlags::READ) {
                     return Err(AxError::PermissionDenied);
                 }
-                Backend::new_cow(start, page_size, backend, offset as u64, None)
+                Backend::new_cow(start, page_size, backend, offset as u64, None, false)
             } else {
-                Backend::new_alloc(start, page_size)
+                Backend::new_alloc(start, page_size, "")
             }
         }
         _ => return Err(AxError::InvalidInput),

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -187,76 +187,78 @@ pub fn sys_mmap(
     let backend = match map_type {
         MmapFlags::SHARED | MmapFlags::SHARED_VALIDATE => {
             if let Some(ref file) = file {
-                // Try device mmap first (ExportedGemBuffer, etc.)
-                if let Ok(device_mmap) = file.device_mmap(offset as u64) {
-                    match device_mmap {
-                        DeviceMmap::Physical(mut range) => {
-                            range.start += offset;
-                            if range.is_empty() {
-                                return Err(AxError::InvalidInput);
-                            }
-                            length = length.min(range.size().align_down(page_size));
-                            Backend::new_linear(
-                                start.as_usize() as isize - range.start.as_usize() as isize,
-                                true,
-                            );
+                match file.device_mmap(offset as u64) {
+                    Ok(DeviceMmap::Physical(mut range)) => {
+                        range.start += offset;
+                        if range.is_empty() {
+                            return Err(AxError::InvalidInput);
                         }
-                        DeviceMmap::None => return Err(AxError::NoSuchDevice),
-                        _ => return Err(AxError::InvalidInput),
-                    }
-                }
-
-                // Fall through to file-backed mmap
-                let (backend, flags) = file.file_mmap()?;
-                // man 2 mmap EACCES: a file mapping requires the fd to be
-                // open for reading, and MAP_SHARED+PROT_WRITE additionally
-                // requires the fd to be open for writing.
-                if !flags.contains(FileFlags::READ) {
-                    return Err(AxError::PermissionDenied);
-                }
-                if permission_flags.contains(MmapProt::WRITE) && !flags.contains(FileFlags::WRITE) {
-                    return Err(AxError::PermissionDenied);
-                }
-                match backend.clone() {
-                    FileBackend::Cached(cache) => {
-                        // TODO(mivik): file mmap page size
-                        Backend::new_file(
-                            start,
-                            cache,
-                            flags,
-                            offset,
-                            &curr.as_thread().proc_data.aspace,
+                        length = length.min(range.size().align_down(page_size));
+                        Backend::new_linear(
+                            start.as_usize() as isize - range.start.as_usize() as isize,
                             true,
                         )
                     }
-                    FileBackend::Direct(loc) => {
-                        let device = loc
-                            .entry()
-                            .downcast::<Device>()
-                            .map_err(|_| AxError::NoSuchDevice)?;
-
-                        match device.mmap(offset as u64) {
-                            DeviceMmap::None => {
-                                return Err(AxError::NoSuchDevice);
-                            }
-                            DeviceMmap::Physical(range) => {
-                                if range.is_empty() {
-                                    return Err(AxError::InvalidInput);
-                                }
-                                length = capped_device_map_len(length, range.size(), page_size);
-                                Backend::new_linear(
-                                    start.as_usize() as isize - range.start.as_usize() as isize,
+                    Ok(DeviceMmap::None) => return Err(AxError::NoSuchDevice),
+                    Ok(_) => return Err(AxError::InvalidInput),
+                    Err(_) => {
+                        // Fall through to file-backed mmap
+                        let (backend, flags) = file.file_mmap()?;
+                        // man 2 mmap EACCES: a file mapping requires the fd to be
+                        // open for reading, and MAP_SHARED+PROT_WRITE additionally
+                        // requires the fd to be open for writing.
+                        if !flags.contains(FileFlags::READ) {
+                            return Err(AxError::PermissionDenied);
+                        }
+                        if permission_flags.contains(MmapProt::WRITE)
+                            && !flags.contains(FileFlags::WRITE)
+                        {
+                            return Err(AxError::PermissionDenied);
+                        }
+                        match backend.clone() {
+                            FileBackend::Cached(cache) => {
+                                // TODO(mivik): file mmap page size
+                                Backend::new_file(
+                                    start,
+                                    cache,
+                                    flags,
+                                    offset,
+                                    &curr.as_thread().proc_data.aspace,
                                     true,
                                 )
                             }
-                            DeviceMmap::Cache(cache) => Backend::new_file(
-                                start,
-                                cache,
-                                flags,
-                                offset,
-                                &curr.as_thread().proc_data.aspace,
-                                true,
-                            ),
+                            FileBackend::Direct(loc) => {
+                                let device = loc
+                                    .entry()
+                                    .downcast::<Device>()
+                                    .map_err(|_| AxError::NoSuchDevice)?;
+
+                                match device.mmap(offset as u64) {
+                                    DeviceMmap::None => {
+                                        return Err(AxError::NoSuchDevice);
+                                    }
+                                    DeviceMmap::Physical(range) => {
+                                        if range.is_empty() {
+                                            return Err(AxError::InvalidInput);
+                                        }
+                                        length =
+                                            capped_device_map_len(length, range.size(), page_size);
+                                        Backend::new_linear(
+                                            start.as_usize() as isize
+                                                - range.start.as_usize() as isize,
+                                            true,
+                                        )
+                                    }
+                                    DeviceMmap::Cache(cache) => Backend::new_file(
+                                        start,
+                                        cache,
+                                        flags,
+                                        offset,
+                                        &curr.as_thread().proc_data.aspace,
+                                        true,
+                                    ),
+                                }
+                            }
                         }
                     }
                 }

--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -466,6 +466,12 @@ impl CachedFile {
         self.in_memory
     }
 
+    /// A hint to the backend that the file position has changed.
+    /// This is used for operations like resetting file content in proc/sys.
+    pub fn seek_to(&self, pos: u64) -> VfsResult<()> {
+        self.inner.entry().as_file()?.seek_to(pos)
+    }
+
     /// Registers a listener that is called when a page is evicted from cache.
     ///
     /// Returns a handle that can later be passed to
@@ -730,6 +736,15 @@ impl FileBackend {
         Self::Cached(CachedFile::get_or_create(location))
     }
 
+    /// A hint to the backend that the file position has changed.
+    /// This is used for operations like resetting file content in proc/sys.
+    pub fn seek_to(&self, pos: u64) -> VfsResult<()> {
+        match self {
+            Self::Cached(cached) => cached.seek_to(pos),
+            Self::Direct(loc) => loc.entry().as_file()?.seek_to(pos),
+        }
+    }
+
     /// Reads data from the file at `offset` into `dst`.
     pub fn read_at(&self, mut dst: impl Write + IoBufMut, mut offset: u64) -> VfsResult<usize> {
         match self {
@@ -968,7 +983,7 @@ impl Seek for &File {
             let new_pos = match pos {
                 SeekFrom::Start(pos) => pos,
                 SeekFrom::End(off) => {
-                    let size = self.access(FileFlags::empty())?.location().len()?;
+                    let size = self.inner.location().len()?;
                     size.checked_add_signed(off).ok_or(VfsError::InvalidInput)?
                 }
                 SeekFrom::Current(off) => guard
@@ -976,6 +991,10 @@ impl Seek for &File {
                     .ok_or(VfsError::InvalidInput)?,
             };
             *guard = new_pos;
+            // Seeking doesn't actually require any action on the backend since we
+            // track the position in the `File` struct, but we can hint to the backend
+            // about it for potential operations like resetting file content(proc/sys).
+            self.inner.seek_to(new_pos)?;
             Ok(new_pos)
         } else {
             Ok(0)

--- a/os/arceos/modules/axmm/src/backend/mod.rs
+++ b/os/arceos/modules/axmm/src/backend/mod.rs
@@ -68,6 +68,19 @@ impl MappingBackend for Backend {
             .protect_region(start, size, new_flags)
             .is_ok()
     }
+
+    fn split(&mut self, _align_diff: usize) -> Option<Self> {
+        // backend can be trivially split since it does not have any state.
+        Some(self.clone())
+    }
+
+    fn shrink_left(&mut self, _shrink_size: usize) {
+        // backend can be trivially shrunk since it does not have any state.
+    }
+
+    fn shrink_right(&mut self, _shrink_size: usize) {
+        // backend can be trivially shrunk since it does not have any state.
+    }
 }
 
 impl Backend {

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-proc-maps-lseek-refresh/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-proc-maps-lseek-refresh/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-proc-maps-lseek-refresh C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-proc-maps-lseek-refresh src/main.c)
+target_compile_options(bug-proc-maps-lseek-refresh PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-proc-maps-lseek-refresh RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-proc-maps-lseek-refresh/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-proc-maps-lseek-refresh/c/src/main.c
@@ -1,0 +1,289 @@
+/*
+ * bug-proc-maps-lseek-refresh: /proc/self/maps should reflect the latest VMA
+ * layout when the same fd is rewound with lseek(fd, 0, SEEK_SET) and read
+ * again after mmap/mprotect/munmap.
+ *
+ * The test primes the seq-file cache by reading /proc/self/maps once, then
+ * performs:
+ *   1. mmap() a guarded 3-page RW range
+ *   2. mprotect() the middle page to force a VMA split
+ *   3. munmap() the middle page to create a hole
+ *
+ * Each step reuses the same opened maps fd, seeks back to 0, and verifies that
+ * the refreshed contents reflect the new VMA boundaries and permissions.
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+enum {
+    MAPS_BUF_SIZE = 128 * 1024,
+    TEST_PAGES = 3,
+    GUARD_PAGES = 2,
+};
+
+static ssize_t read_all_current(int fd, char *buf, size_t buf_size)
+{
+    size_t total = 0;
+
+    while (total + 1 < buf_size) {
+        ssize_t read_size = read(fd, buf + total, buf_size - 1 - total);
+        if (read_size < 0) {
+            return -1;
+        }
+        if (read_size == 0) {
+            buf[total] = '\0';
+            return (ssize_t)total;
+        }
+        total += (size_t)read_size;
+    }
+
+    errno = ENOSPC;
+    return -1;
+}
+
+static ssize_t reread_from_start(int fd, char *buf, size_t buf_size)
+{
+    if (lseek(fd, 0, SEEK_SET) != 0) {
+        return -1;
+    }
+    return read_all_current(fd, buf, buf_size);
+}
+
+static int has_vma_prefix(
+    const char *maps,
+    uintptr_t start,
+    uintptr_t end,
+    const char *perms
+)
+{
+    char needle[64];
+    const int needle_len = snprintf(
+        needle,
+        sizeof(needle),
+        "%08lx-%08lx %s",
+        (unsigned long)start,
+        (unsigned long)end,
+        perms
+    );
+    const char *line = maps;
+
+    if (needle_len <= 0 || (size_t)needle_len >= sizeof(needle)) {
+        return 0;
+    }
+
+    while (*line != '\0') {
+        const char *newline = strchr(line, '\n');
+        size_t line_len = newline ? (size_t)(newline - line) : strlen(line);
+
+        if (line_len >= (size_t)needle_len &&
+            memcmp(line, needle, (size_t)needle_len) == 0) {
+            return 1;
+        }
+
+        if (newline == NULL) {
+            break;
+        }
+        line = newline + 1;
+    }
+
+    return 0;
+}
+
+static void print_maps_on_failure(const char *maps)
+{
+    printf("---- /proc/self/maps ----\n%s", maps);
+    if (maps[0] != '\0' && maps[strlen(maps) - 1] != '\n') {
+        putchar('\n');
+    }
+    printf("-------------------------\n");
+}
+
+int main(void)
+{
+    static char maps_buf[MAPS_BUF_SIZE];
+
+    const long page_size = sysconf(_SC_PAGESIZE);
+    const size_t total_pages = TEST_PAGES + GUARD_PAGES;
+    const size_t total_size = (size_t)page_size * total_pages;
+    int maps_fd = -1;
+    void *reserved = MAP_FAILED;
+    unsigned char *mapping;
+    unsigned char *middle;
+    unsigned char *right;
+
+    printf("=== bug-proc-maps-lseek-refresh ===\n");
+    printf("Expected: one opened /proc/self/maps fd is refreshed by lseek(0)\n");
+    printf("          after mmap/mprotect/munmap change the VMA layout.\n\n");
+
+    if (page_size != 4096) {
+        printf("FAIL: unexpected page size %ld, expected 4096\n", page_size);
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    maps_fd = open("/proc/self/maps", O_RDONLY);
+    if (maps_fd < 0) {
+        printf("FAIL: open(/proc/self/maps): %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    if (read_all_current(maps_fd, maps_buf, sizeof(maps_buf)) < 0) {
+        printf("FAIL: initial read(/proc/self/maps): %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    reserved = mmap(NULL, total_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (reserved == MAP_FAILED) {
+        printf("FAIL: reserve guard region: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    mapping = mmap(
+        (unsigned char *)reserved + page_size,
+        (size_t)page_size * TEST_PAGES,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
+        -1,
+        0
+    );
+    if (mapping == MAP_FAILED || mapping != (unsigned char *)reserved + page_size) {
+        printf("FAIL: mmap test range: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    middle = mapping + page_size;
+    right = middle + page_size;
+    mapping[0] = 0x11;
+    middle[0] = 0x22;
+    right[0] = 0x33;
+
+    if (reread_from_start(maps_fd, maps_buf, sizeof(maps_buf)) < 0) {
+        printf("FAIL: reread maps after mmap: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+    if (!has_vma_prefix(
+            maps_buf,
+            (uintptr_t)mapping,
+            (uintptr_t)(mapping + page_size * TEST_PAGES),
+            "rw-p")) {
+        printf("FAIL: mmap result not reflected on same maps fd after lseek\n");
+        print_maps_on_failure(maps_buf);
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    if (mprotect(middle, (size_t)page_size, PROT_READ) != 0) {
+        printf("FAIL: mprotect middle page: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    if (reread_from_start(maps_fd, maps_buf, sizeof(maps_buf)) < 0) {
+        printf("FAIL: reread maps after mprotect: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+    if (!has_vma_prefix(maps_buf, (uintptr_t)mapping, (uintptr_t)middle, "rw-p") ||
+        !has_vma_prefix(
+            maps_buf,
+            (uintptr_t)middle,
+            (uintptr_t)(middle + page_size),
+            "r--p") ||
+        !has_vma_prefix(
+            maps_buf,
+            (uintptr_t)right,
+            (uintptr_t)(right + page_size),
+            "rw-p") ||
+        has_vma_prefix(
+            maps_buf,
+            (uintptr_t)mapping,
+            (uintptr_t)(mapping + page_size * TEST_PAGES),
+            "rw-p")) {
+        printf("FAIL: mprotect split not reflected on same maps fd after lseek\n");
+        print_maps_on_failure(maps_buf);
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    if (munmap(middle, (size_t)page_size) != 0) {
+        printf("FAIL: munmap middle page: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    if (reread_from_start(maps_fd, maps_buf, sizeof(maps_buf)) < 0) {
+        printf("FAIL: reread maps after munmap: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+    if (!has_vma_prefix(maps_buf, (uintptr_t)mapping, (uintptr_t)middle, "rw-p") ||
+        !has_vma_prefix(
+            maps_buf,
+            (uintptr_t)right,
+            (uintptr_t)(right + page_size),
+            "rw-p") ||
+        has_vma_prefix(
+            maps_buf,
+            (uintptr_t)middle,
+            (uintptr_t)(middle + page_size),
+            "r--p")) {
+        printf("FAIL: munmap result not reflected on same maps fd after lseek\n");
+        print_maps_on_failure(maps_buf);
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    if (munmap(mapping, (size_t)page_size) != 0 || munmap(right, (size_t)page_size) != 0) {
+        printf("FAIL: munmap remaining test pages: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    if (reread_from_start(maps_fd, maps_buf, sizeof(maps_buf)) < 0) {
+        printf("FAIL: reread maps after full cleanup: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+    if (has_vma_prefix(maps_buf, (uintptr_t)mapping, (uintptr_t)middle, "rw-p") ||
+        has_vma_prefix(
+            maps_buf,
+            (uintptr_t)right,
+            (uintptr_t)(right + page_size),
+            "rw-p")) {
+        printf("FAIL: cleaned-up VMAs still visible on same maps fd after lseek\n");
+        print_maps_on_failure(maps_buf);
+        printf("TEST FAILED\n");
+        close(maps_fd);
+        return 1;
+    }
+
+    close(maps_fd);
+    printf("PASS: same /proc/self/maps fd refreshed after mmap/mprotect/munmap\n");
+    printf("TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-unaligned-cow-split/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-unaligned-cow-split/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-unaligned-cow-split C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-unaligned-cow-split src/main.c)
+target_compile_options(bug-unaligned-cow-split PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-unaligned-cow-split RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-unaligned-cow-split/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-unaligned-cow-split/c/src/main.c
@@ -1,0 +1,127 @@
+/*
+ * bug-unaligned-cow-split: an ELF file-backed private segment with an
+ * unaligned p_vaddr/p_offset pair should still fault in the correct file page
+ * after mprotect() splits the VMA.
+ *
+ * The test embeds three file-backed pages in the RW PT_LOAD segment:
+ *   page 0 -> 'A'
+ *   page 1 -> 'B'
+ *   page 2 -> 'C'
+ *
+ * We then mprotect() the middle page to force a left/middle/right split and
+ * read from the untouched right page. A buggy COW split backend tends to leave
+ * a zeroed gap or read the wrong file offset for that right-half fault.
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+enum {
+    TEST_PAGE_SIZE = 4096,
+    TEST_BLOB_PAGES = 3,
+};
+
+__asm__(
+    ".pushsection .data\n"
+    ".balign 4096\n"
+    ".global bug_unaligned_cow_blob\n"
+    "bug_unaligned_cow_blob:\n"
+    ".fill 4096,1,0x41\n"
+    ".fill 4096,1,0x42\n"
+    ".fill 4096,1,0x43\n"
+    ".global bug_unaligned_cow_blob_end\n"
+    "bug_unaligned_cow_blob_end:\n"
+    ".popsection\n");
+
+extern unsigned char bug_unaligned_cow_blob[];
+extern unsigned char bug_unaligned_cow_blob_end[];
+
+static unsigned char read_byte(const volatile unsigned char *ptr)
+{
+    return *ptr;
+}
+
+int main(void)
+{
+    const long page_size = sysconf(_SC_PAGESIZE);
+    const size_t blob_size = (size_t)(bug_unaligned_cow_blob_end - bug_unaligned_cow_blob);
+    unsigned char *const middle_page = bug_unaligned_cow_blob + TEST_PAGE_SIZE;
+    unsigned char *const right_page = bug_unaligned_cow_blob + TEST_PAGE_SIZE * 2;
+
+    printf("=== bug-unaligned-cow-split ===\n");
+    printf("Expected: file-backed private ELF segment still reads the correct\n");
+    printf("          right-half page after mprotect() splits the VMA.\n\n");
+
+    if (page_size != TEST_PAGE_SIZE) {
+        printf("FAIL: unexpected page size %ld, expected %d\n",
+               page_size, TEST_PAGE_SIZE);
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    if (blob_size < TEST_PAGE_SIZE * TEST_BLOB_PAGES) {
+        printf("FAIL: embedded blob too small: %zu bytes\n", blob_size);
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    printf("blob=%p blob_size=%zu middle=%p right=%p\n",
+           (void *)bug_unaligned_cow_blob, blob_size,
+           (void *)middle_page, (void *)right_page);
+
+    if (read_byte(bug_unaligned_cow_blob) != 'A') {
+        printf("FAIL: first file-backed page mismatch before split\n");
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    if (mprotect(middle_page, TEST_PAGE_SIZE, PROT_READ) != 0) {
+        printf("FAIL: mprotect middle page to PROT_READ: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    if (read_byte(middle_page + 123) != 'B') {
+        printf("FAIL: middle page content changed after split\n");
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    if (read_byte(right_page) != 'C' ||
+        read_byte(right_page + 137) != 'C' ||
+        read_byte(right_page + TEST_PAGE_SIZE - 1) != 'C') {
+        printf("FAIL: right page content mismatch after split\n");
+        printf("      got bytes: [%u, %u, %u], expected all %u ('C')\n",
+               read_byte(right_page),
+               read_byte(right_page + 137),
+               read_byte(right_page + TEST_PAGE_SIZE - 1),
+               (unsigned int)'C');
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    if (mprotect(middle_page, TEST_PAGE_SIZE, PROT_READ | PROT_WRITE) != 0) {
+        printf("FAIL: restore middle page to PROT_READ|PROT_WRITE: %s\n",
+               strerror(errno));
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    middle_page[0] = 'b';
+    if (read_byte(middle_page) != 'b' ||
+        read_byte(right_page) != 'C' ||
+        read_byte(bug_unaligned_cow_blob) != 'A') {
+        printf("FAIL: page contents not isolated after restore/write\n");
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    printf("PASS: right-half page retained correct file data after COW split\n");
+    printf("TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -29,6 +29,8 @@ test_commands = [
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",
+    "/usr/bin/bug-unaligned-cow-split",
+    "/usr/bin/bug-proc-maps-lseek-refresh",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -31,6 +31,8 @@ test_commands = [
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",
+    "/usr/bin/bug-unaligned-cow-split",
+    "/usr/bin/bug-proc-maps-lseek-refresh",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -29,6 +29,8 @@ test_commands = [
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",
+    "/usr/bin/bug-unaligned-cow-split",
+    "/usr/bin/bug-proc-maps-lseek-refresh",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -27,6 +27,8 @@ test_commands = [
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",
+    "/usr/bin/bug-unaligned-cow-split",
+    "/usr/bin/bug-proc-maps-lseek-refresh",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']


### PR DESCRIPTION
Extend MappingBackend/BackendOps with split and shrink hooks so memory areas can preserve backend-specific state during unmap and protect splits.

Teach mm backends to keep file offsets, shared/private state, and anonymous mapping names across splits, and implement real /proc/[pid]/maps output from the current address-space layout.

Wire the new behavior through mmap/brk/loader paths, add the needed error conversion helper, and update memory_set tests for the expanded backend trait.
