### PR TITLE
fix(tty): improve termios handling and ensure safety in locking mecha…

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -116,15 +116,19 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
             }
             TCSETS | TCSETSF | TCSETSW => {
                 // TODO: drain output?
-                *self.terminal.termios.lock() =
-                    Arc::new(Termios2::new((arg as *const Termios).vm_read()?));
+                // Note: vm_read() must complete before acquiring the SpinNoPreempt lock.
+                // Faultable user memory access inside an atomic context (preemption
+                // disabled) will call might_sleep() in handle_page_fault and panic.
+                let termios = Arc::new(Termios2::new((arg as *const Termios).vm_read()?));
+                *self.terminal.termios.lock() = termios;
                 if cmd == TCSETSF {
                     self.ldisc.lock().drain_input();
                 }
             }
             TCSETS2 | TCSETSF2 | TCSETSW2 => {
                 // TODO: drain output?
-                *self.terminal.termios.lock() = Arc::new((arg as *const Termios2).vm_read()?);
+                let termios = Arc::new((arg as *const Termios2).vm_read()?);
+                *self.terminal.termios.lock() = termios;
                 if cmd == TCSETSF2 {
                     self.ldisc.lock().drain_input();
                 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -109,10 +109,12 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
         use linux_raw_sys::ioctl::*;
         match cmd {
             TCGETS => {
-                (arg as *mut Termios).vm_write(*self.terminal.termios.lock().as_ref().deref())?;
+                let termios = *self.terminal.termios.lock().as_ref().deref();
+                (arg as *mut Termios).vm_write(termios)?;
             }
             TCGETS2 => {
-                (arg as *mut Termios2).vm_write(*self.terminal.termios.lock().as_ref())?;
+                let termios = *self.terminal.termios.lock().as_ref();
+                (arg as *mut Termios2).vm_write(termios)?;
             }
             TCSETS | TCSETSF | TCSETSW => {
                 // TODO: drain output?
@@ -147,10 +149,12 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 self.terminal.job_control.set_foreground(&pg)?;
             }
             TIOCGWINSZ => {
-                (arg as *mut WindowSize).vm_write(*self.terminal.window_size.lock())?;
+                let window_size = *self.terminal.window_size.lock();
+                (arg as *mut WindowSize).vm_write(window_size)?;
             }
             TIOCSWINSZ => {
-                *self.terminal.window_size.lock() = (arg as *const WindowSize).vm_read()?;
+                let window_size = (arg as *const WindowSize).vm_read()?;
+                *self.terminal.window_size.lock() = window_size;
             }
             TIOCSPTLCK => {}
             TIOCGPTN => {

--- a/os/StarryOS/kernel/src/pseudofs/fs.rs
+++ b/os/StarryOS/kernel/src/pseudofs/fs.rs
@@ -1,6 +1,7 @@
 use alloc::{string::String, sync::Arc};
 use core::{any::Any, time::Duration};
 
+use ax_kspin::SpinNoIrq;
 use ax_sync::Mutex;
 use axfs_ng_vfs::{
     DeviceId, DirEntry, DirNode, Filesystem, FilesystemOps, Metadata, MetadataUpdate, NodeOps,
@@ -88,7 +89,10 @@ impl FilesystemOps for SimpleFs {
 pub struct SimpleFsNode {
     fs: Arc<SimpleFs>,
     ino: u64,
-    pub(crate) metadata: Mutex<Metadata>,
+    // SpinNoIrq instead of Mutex: metadata may be read/updated on paths that
+    // are already in atomic context (IRQs disabled), so a blocking mutex would
+    // trigger a might_sleep() panic.
+    pub(crate) metadata: SpinNoIrq<Metadata>,
 }
 
 impl SimpleFsNode {
@@ -114,7 +118,7 @@ impl SimpleFsNode {
         Self {
             fs,
             ino,
-            metadata: Mutex::new(metadata),
+            metadata: SpinNoIrq::new(metadata),
         }
     }
 }


### PR DESCRIPTION
## 背景

### `might_sleep()` 检测机制

`might_sleep()` 定义在
`os/arceos/modules/axtask/src/api.rs`：

```rust
pub fn might_sleep() {
    if in_atomic_context() {
        panic!(
            "sleeping or rescheduling is not allowed in atomic context: \
             irq_enabled={}, preempt_count={}",
            ax_hal::asm::irqs_enabled(),
            current_preempt_count()
        );
    }
}

pub(crate) fn in_atomic_context() -> bool {
    #[cfg(feature = "irq")]
    if !ax_hal::asm::irqs_enabled() { return true; }  // IRQ 已禁用
    #[cfg(feature = "preempt")]
    if current_preempt_count() != 0 { return true; }  // 抢占已禁用
    false
}
```

`ax_sync::Mutex::lock()`（`os/arceos/modules/axsync/src/mutex.rs`）进入时**第一件事**就是调用 `might_sleep()`。因此，任何在 `in_atomic_context()` 为真（IRQ 已禁用或 `preempt_count != 0`）的上下文中调用 `Mutex::lock()` 的代码都会 panic。

---

## Bug 1：`TCSETS*` 路径中用户内存读取与抢占禁用区间交错

**文件**：`os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs`

### 风险点

`terminal.termios` 的类型是 `SpinNoPreempt<Arc<Termios2>>`（`os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/mod.rs`）：

```rust
pub struct Terminal {
    pub termios: SpinNoPreempt<Arc<termios::Termios2>>,
    ...
}
```

`SpinNoPreempt::lock()` 加锁后 `preempt_count` 递增，使当前执行上下文进入原子区间。在这一区间内，任何可能触发缺页的用户内存访问都会经过 `handle_page_fault`，该函数调用 `might_sleep()`，从而 panic。

原始代码把可能 fault 的 `vm_read()` 调用与 `termios.lock()` 的持锁阶段交错在同一表达式里，存在 `vm_read()` 在抢占禁用区间内执行的风险：

```rust
TCSETS | TCSETSF | TCSETSW => {
    *self.terminal.termios.lock() =            // SpinNoPreempt 加锁，进入原子区间
        Arc::new(Termios2::new(
            (arg as *const Termios).vm_read()? // 可能 fault 的用户内存读，仍在锁内
        ));                                    // guard 析构，退出原子区间
    if cmd == TCSETSF {
        self.ldisc.lock().drain_input();
    }
}
```

### 触发路径

若 `vm_read()` 访问用户内存时发生缺页，内核进入 `os/StarryOS/kernel/src/mm/access.rs` 的 `handle_page_fault`：

```rust
#[page_fault_handler]
fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
    ...
    might_sleep();  // ← preempt_count != 0 → panic
    thr.proc_data.aspace.lock().handle_page_fault(vaddr, access_flags)
}
```

此外 `access_user_memory` 还 assert IRQ 已启用，若调用路径上存在 `SpinNoIrq`持锁（IRQ 已禁用）时则会更早 panic：

```rust
pub fn access_user_memory<R>(f: impl FnOnce() -> R) -> R {
    assert!(
        ax_hal::asm::irqs_enabled(),
        "faultable user memory access requires IRQs enabled"
    );
    ...
}
```

### 修正后代码

```rust
TCSETS | TCSETSF | TCSETSW => {
    // Note: vm_read() must complete before acquiring the SpinNoPreempt lock.
    // Faultable user memory access inside an atomic context (preemption disabled)
    // will call might_sleep() in handle_page_fault and panic.
    let termios = Arc::new(Termios2::new(
        (arg as *const Termios).vm_read()?   // 在锁外完成用户内存读
    ));
    *self.terminal.termios.lock() = termios; // 锁内只做纯内存写，无 fault 风险
    if cmd == TCSETSF {
        self.ldisc.lock().drain_input();     // guard 已在上一行末析构
    }
}
```

**修正要点**：将 `vm_read()` 提前到 `lock()` 之前，绑定到局部变量，使得整个持锁区间内不再有任何可能触发缺页的操作。
`*self.terminal.termios.lock() = termios` 这一语句里，guard 是临时量，在 `;` 处析构，`preempt_count` 归零，后续 `ldisc.lock()` 已处于普通上下文。

`TCSETS2 | TCSETSF2 | TCSETSW2` 分支存在同样的风险，以相同方式修正：

```rust
TCSETS2 | TCSETSF2 | TCSETSW2 => {
    let termios = Arc::new((arg as *const Termios2).vm_read()?);
    *self.terminal.termios.lock() = termios;
    if cmd == TCSETSF2 {
        self.ldisc.lock().drain_input();
    }
}
```

---

## Bug 2：`SimpleFsNode::metadata` 使用了阻塞 `Mutex`

**文件**：`os/StarryOS/kernel/src/pseudofs/fs.rs`

### 原始代码

```rust
pub struct SimpleFsNode {
    fs: Arc<SimpleFs>,
    ino: u64,
    pub(crate) metadata: Mutex<Metadata>,  // ← 阻塞锁
}
```

### 触发路径

伪文件系统节点在文件关闭、进程退出等路径上会调用 `update_metadata`更新时间戳：

```rust
impl NodeOps for SimpleFsNode {
    fn update_metadata(&self, update: MetadataUpdate) -> VfsResult<()> {
        let mut metadata = self.metadata.lock();  // ← Mutex::lock() → might_sleep()
        ...
    }
}
```

这些调用路径可能已经处于持有 `SpinNoIrq` 锁的原子上下文中（`irq_enabled=false`）。一旦进入 `Mutex::lock()` 就触发：

```
sleeping or rescheduling is not allowed in atomic context:
irq_enabled=false, preempt_count=1
```

### 修正后代码

```rust
use ax_kspin::SpinNoIrq;

pub struct SimpleFsNode {
    fs: Arc<SimpleFs>,
    ino: u64,
    // SpinNoIrq instead of Mutex: metadata may be read/updated on paths that
    // are already in atomic context (IRQs disabled), so a blocking mutex would
    // trigger a might_sleep() panic.
    pub(crate) metadata: SpinNoIrq<Metadata>,
}

// 构造时：
metadata: SpinNoIrq::new(metadata),
```

`SpinNoIrq` 对应 `ax_kspin` 里的 `BaseSpinLock<NoPreemptIrqSave, T>`
（`components/kspin/src/lib.rs`）：

```rust
/// A spin lock that disables kernel preemption and local IRQs while trying to
/// lock, and re-enables it after unlocking.
///
/// It can be used in the IRQ-enabled context.
pub type SpinNoIrq<T> = BaseSpinLock<NoPreemptIrqSave, T>;
```

获取锁时保存并禁用 IRQ，释放时还原。整个临界区都在原子上下文里，不调用 `might_sleep()`，与 `Metadata` 这种纯内存短临界区的用途完全匹配。

---

## 两处修改的对比

| | Bug 根因 | panic 触发点 | panic 消息特征 | 修正手段 |
|---|---|---|---|---|
| `tty/mod.rs` | `vm_read()` 在 `SpinNoPreempt` 持有期间调用，缺页路径调 `might_sleep()` | `handle_page_fault` 里的 `might_sleep()` | `irq_enabled=true, preempt_count=1` | 把 `vm_read()` 提到 `lock()` 之前 |
| `fs.rs` | `Mutex<Metadata>` 在 IRQ 已禁用的调用路径上被锁 | `Mutex::lock()` 开头的 `might_sleep()` | `irq_enabled=false, preempt_count=1` | 改为 `SpinNoIrq<Metadata>` |
