### PR TITLE
feat(starry): add findutils test case for all filesystems

### DIFF
--- a/test-suit/starryos/normal/findutils/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/findutils/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(findutils-test C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(findutils-test src/main.c)
+target_compile_options(findutils-test PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS findutils-test RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/findutils/c/prebuild.sh
+++ b/test-suit/starryos/normal/findutils/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add findutils binutils gcc musl-dev

--- a/test-suit/starryos/normal/findutils/c/src/main.c
+++ b/test-suit/starryos/normal/findutils/c/src/main.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <dirent.h>
+
+static int run_find(const char *path) {
+    pid_t pid = fork();
+    if (pid < 0) return 1;
+    if (pid == 0) {
+        int fd = open("/dev/null", O_WRONLY);
+        if (fd < 0) _exit(1);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        close(fd);
+        execl("/usr/bin/find", "find", path, "-maxdepth", "2", NULL);
+        _exit(1);
+    }
+    int status;
+    if (waitpid(pid, &status, 0) < 0) return 1;
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) return 1;
+    return 0;
+}
+
+static int check_dir(const char *path) {
+    DIR *d = opendir(path);
+    if (!d) return 1;
+    int count = 0;
+    struct dirent *ent;
+    while ((ent = readdir(d)) != NULL) {
+        if (ent->d_name[0] == '.') continue;
+        count++;
+    }
+    closedir(d);
+    return count > 0 ? 0 : 1;
+}
+
+int main(void) {
+    /* Test ext4 rootfs */
+    printf("Testing / (ext4) ...\n");
+    if (run_find("/etc") != 0) return 1;
+
+    /* Test devfs */
+    printf("Testing /dev (devfs) ...\n");
+    if (check_dir("/dev") != 0) return 1;
+    if (run_find("/dev") != 0) return 1;
+
+    /* Test procfs */
+    printf("Testing /proc (procfs) ...\n");
+    if (check_dir("/proc") != 0) return 1;
+    if (run_find("/proc") != 0) return 1;
+
+    /* Test tmpfs */
+    printf("Testing /tmp (tmpfs) ...\n");
+    if (run_find("/tmp") != 0) return 1;
+
+    /* Test sysfs (tmpfs-backed) */
+    printf("Testing /sys (tmpfs) ...\n");
+    if (run_find("/sys") != 0) return 1;
+
+    printf("FINDUTILS TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/findutils/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/findutils/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/findutils-test"
+success_regex = ["(?m)^FINDUTILS TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/findutils/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/findutils/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+  "-machine",
+  "virt",
+  "-cpu",
+  "la464",
+  "-nographic",
+  "-m",
+  "128M",
+  "-device",
+  "virtio-blk-pci,drive=disk0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+  "-device",
+  "virtio-net-pci,netdev=net0",
+  "-netdev",
+  "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/findutils-test"
+success_regex = ["(?m)^FINDUTILS TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/findutils/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/findutils/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/findutils-test"
+success_regex = ["(?m)^FINDUTILS TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/findutils/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/findutils/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/findutils-test"
+success_regex = ["(?m)^FINDUTILS TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15


### PR DESCRIPTION
## 改动说明

新增 test-suit/starryos/normal/findutils/ 测试用例，验证 find 命令在 StarryOS 全部 5 种文件系统上的功能支持：ext4(/etc)、devfs (/dev)、procfs (/proc)、tmpfs (/tmp)、sysfs-backed (/sys)。
测试通过 fork() + exec() 执行 find -maxdepth 2，检查退出码判定通过/失败。

## 改动范围

- 新增 test-suit/starryos/normal/findutils/（7 个文件）
    - c/src/main.c — 测试程序
    - c/CMakeLists.txt — 构建配置
    - c/prebuild.sh — 依赖安装脚本
    - qemu-loongarch64.toml、qemu-x86_64.toml、qemu-aarch64.toml、qemu-riscv64.toml — 4 架构 QEMU 配置

## 测试

- cargo xtask starry test qemu --target loongarch64 -c findutils — 通过（36s）
- cargo xtask starry test qemu --target x86_64 -c findutils — 通过
- cargo xtask starry test qemu --target aarch64 -c findutils — 通过
- cargo xtask starry test qemu --target riscv64 -c findutils — 通过