### PR TITLE
fix(net): return EOF on unix stream recv when peer sender dropped

### DIFF
--- a/os/arceos/modules/axnet-ng/src/unix/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/stream.rs
@@ -272,6 +272,11 @@ impl TransportOps for StreamTransport {
             if count > 0 {
                 chan.poll_update.wake();
                 Ok(count)
+            } else if !chan.rx.write_is_held() {
+                // Peer dropped its sender end and the ring is empty: EOF.
+                // Returning WouldBlock here would park the caller forever
+                // waiting for data that will never arrive.
+                Ok(0)
             } else {
                 Err(AxError::WouldBlock)
             }

--- a/test-suit/starryos/normal/test-unix-stream-eof/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/test-unix-stream-eof/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-unix-stream-eof C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-unix-stream-eof src/main.c)
+target_compile_options(test-unix-stream-eof PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-unix-stream-eof RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/test-unix-stream-eof/c/src/main.c
+++ b/test-suit/starryos/normal/test-unix-stream-eof/c/src/main.c
@@ -1,0 +1,57 @@
+/*
+ * test-unix-stream-eof
+ *
+ * Exercises the EOF path for AF_UNIX SOCK_STREAM recv when the sender closes.
+ *
+ * Bug: StreamTransport::recv returned WouldBlock even after the remote write
+ * end was dropped and the ring buffer was empty. The caller treated WouldBlock
+ * as "more data may arrive" and parked forever on the socket.
+ *
+ * Fix: After reading 0 bytes from the ring buffer, check write_is_held(). If
+ * the sender has dropped, return Ok(0) (EOF) instead of WouldBlock.
+ *
+ * Test:
+ *   socketpair(AF_UNIX, SOCK_STREAM) gives sv[0] (reader) and sv[1] (sender).
+ *   1. Write 5 bytes through sv[1].
+ *   2. Close sv[1] -- sender side dropped.
+ *   3. recv on sv[0] must return 5 (the buffered data).
+ *   4. Set sv[0] non-blocking. recv again must return 0 (EOF), not -1/EAGAIN.
+ *      If the bug is present the second recv returns EAGAIN because
+ *      WouldBlock is returned before checking write_is_held.
+ */
+
+#include "test_framework.h"
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static const char MSG[] = "hello";
+#define MSG_LEN ((int)(sizeof(MSG) - 1))
+
+int main(void)
+{
+    TEST_START("unix stream recv returns 0 (EOF) after sender close");
+
+    int sv[2];
+    CHECK_RET(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, "socketpair");
+
+    CHECK_RET((int)write(sv[1], MSG, MSG_LEN), MSG_LEN,
+              "write to sender side");
+    close(sv[1]);
+
+    char buf[64] = {0};
+    int n1 = (int)recv(sv[0], buf, sizeof(buf), 0);
+    CHECK(n1 == MSG_LEN, "first recv returns buffered bytes");
+
+    int flags = fcntl(sv[0], F_GETFL, 0);
+    CHECK(flags >= 0, "fcntl F_GETFL");
+    CHECK_RET(fcntl(sv[0], F_SETFL, flags | O_NONBLOCK), 0, "set O_NONBLOCK");
+
+    int n2 = (int)recv(sv[0], buf, sizeof(buf), 0);
+    CHECK(n2 == 0, "second recv returns 0 (EOF) -- not -1/EAGAIN");
+
+    close(sv[0]);
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/test-unix-stream-eof/c/src/test_framework.h
+++ b/test-suit/starryos/normal/test-unix-stream-eof/c/src/test_framework.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                      \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);              \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/test-unix-stream-eof/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/test-unix-stream-eof/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-unix-stream-eof"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30


### PR DESCRIPTION
## 问题

AF_UNIX SOCK_STREAM 套接字在对端写端关闭、ring buffer 内数据全部读完之后，recv() 返回 EAGAIN。调用方把 EAGAIN 理解为暂时无数据需继续等待，于是永远阻塞在该套接字上。Linux 的语义在写端关闭且缓冲区为空时应当返回 0 表示 EOF，让调用方知道连接已经结束。

## 根本原因

os/arceos/modules/axnet-ng/src/unix/stream.rs 的 StreamTransport::recv 从 ring buffer 读出字节数为 0 时，直接返回 AxError::WouldBlock，没有先判断写端是否仍然存活。写端已经 drop 的情况下，ring buffer 不会再收到任何数据，WouldBlock 此时语义错误。正确做法是在读出 0 字节时，通过 chan.rx.write_is_held() 判断写端状态，写端已释放则返回 Ok(0) 表示 EOF。

## 修复

在读字节数为 0 的分支里，先调用 chan.rx.write_is_held()。write_is_held() 返回 false 时说明写端已 drop，返回 Ok(0)；write_is_held() 返回 true 时说明写端还在，才返回 WouldBlock。改动只影响读出零字节这一个路径，对正常数据读取和 WouldBlock 的语义本身无影响。

## 测试

新增回归测试 test-suit/starryos/normal/test-unix-stream-eof。测试程序通过 socketpair() 建立 AF_UNIX SOCK_STREAM 连接对，向发送端写入 5 字节后关闭发送端，在接收端先阻塞式读出 5 字节，再设置 O_NONBLOCK 后调用 recv。bug 存在时第二次 recv 返回 EAGAIN；修复后第二次 recv 返回 0 表示 EOF。