### PR TITLE
fix(vfs): preserve source DirEntry across rename

### DIFF
--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -320,11 +320,6 @@ impl DirNode {
 
         self.ops.rename(src_name, dst_dir, dst_name).inspect(|_| {
             let (mut src_children, mut dst_children) = self.lock_both_cache(dst_dir);
-            // Move the source DirEntry over to dst_name instead of forgetting
-            // it. The DirEntry's user_data holds per-file caches (notably the
-            // tmpfs page cache keyed by DirEntry); forgetting and re-looking
-            // up would allocate a fresh cache and silently drop any unflushed
-            // writes, which PostgreSQL's durable_rename tripped over.
             let src_entry = src_children.remove(src_name);
             let dst_children_ref = dst_children
                 .as_mut()
@@ -334,8 +329,17 @@ impl DirNode {
             {
                 dir.forget();
             }
-            if let Some(entry) = src_entry {
-                dst_children_ref.insert(dst_name.to_owned(), entry);
+            if let Some(entry) = src_entry
+                && dst_dir.ops.is_cacheable()
+                && let Ok(fresh_entry) = dst_dir.ops.lookup(dst_name)
+            {
+                *fresh_entry.user_data().deref_mut() = mem::take(entry.user_data().deref_mut());
+                if let (Ok(src_dir), Ok(dst_dir)) = (entry.as_dir(), fresh_entry.as_dir()) {
+                    *dst_dir.cache.lock().deref_mut() = mem::take(src_dir.cache.lock().deref_mut());
+                    *dst_dir.mountpoint.lock().deref_mut() =
+                        mem::take(src_dir.mountpoint.lock().deref_mut());
+                }
+                dst_children_ref.insert(dst_name.to_owned(), fresh_entry);
             }
         })
     }

--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -320,13 +320,23 @@ impl DirNode {
 
         self.ops.rename(src_name, dst_dir, dst_name).inspect(|_| {
             let (mut src_children, mut dst_children) = self.lock_both_cache(dst_dir);
-            Self::forget_entry(&mut src_children, src_name);
-            Self::forget_entry(
-                dst_children
-                    .as_mut()
-                    .map_or_else(|| src_children.deref_mut(), DerefMut::deref_mut),
-                dst_name,
-            );
+            // Move the source DirEntry over to dst_name instead of forgetting
+            // it. The DirEntry's user_data holds per-file caches (notably the
+            // tmpfs page cache keyed by DirEntry); forgetting and re-looking
+            // up would allocate a fresh cache and silently drop any unflushed
+            // writes, which PostgreSQL's durable_rename tripped over.
+            let src_entry = src_children.remove(src_name);
+            let dst_children_ref = dst_children
+                .as_mut()
+                .map_or_else(|| src_children.deref_mut(), DerefMut::deref_mut);
+            if let Some(prev) = dst_children_ref.remove(dst_name)
+                && let Ok(dir) = prev.as_dir()
+            {
+                dir.forget();
+            }
+            if let Some(entry) = src_entry {
+                dst_children_ref.insert(dst_name.to_owned(), entry);
+            }
         })
     }
 

--- a/test-suit/starryos/normal/test-rename-content/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/test-rename-content/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-rename-content C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-rename-content src/main.c)
+target_compile_options(test-rename-content PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-rename-content RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/test-rename-content/c/src/main.c
+++ b/test-suit/starryos/normal/test-rename-content/c/src/main.c
@@ -1,0 +1,64 @@
+/*
+ * test-rename-content
+ *
+ * Exercises the axfs-ng-vfs rename DirEntry preservation path.
+ *
+ * Bug: DirNode::rename called forget_entry on the source DirEntry after the
+ * underlying rename succeeded, releasing the only strong reference to the page
+ * cache backing the file. A subsequent lookup by the destination name allocated
+ * a fresh, zero-filled page cache, making reads of the renamed file return all
+ * zeros.
+ *
+ * This replicates PostgreSQL's durable_rename pattern:
+ *   open src, write known payload, fsync, close, rename src -> dst,
+ *   open dst, read back -> content must equal what was written.
+ */
+
+#include "test_framework.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+#define SRC_PATH "/tmp/test-b20-src.tmp"
+#define DST_PATH "/tmp/test-b20-dst.dat"
+
+static const char PAYLOAD[] = "durable_rename_content_check_ABCDEFGH1234567890";
+#define PAYLOAD_LEN ((int)(sizeof(PAYLOAD) - 1))
+
+int main(void)
+{
+    TEST_START("rename preserves file content (durable_rename pattern)");
+
+    unlink(SRC_PATH);
+    unlink(DST_PATH);
+
+    int wfd = open(SRC_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    CHECK(wfd >= 0, "open src for write");
+    if (wfd < 0)
+        goto done;
+
+    CHECK_RET((int)write(wfd, PAYLOAD, PAYLOAD_LEN), PAYLOAD_LEN,
+              "write payload to src");
+    CHECK_RET(fsync(wfd), 0, "fsync src");
+    close(wfd);
+
+    CHECK_RET(rename(SRC_PATH, DST_PATH), 0, "rename src to dst");
+
+    int rfd = open(DST_PATH, O_RDONLY);
+    CHECK(rfd >= 0, "open dst for read");
+    if (rfd < 0)
+        goto done;
+
+    char buf[256] = {0};
+    int n = (int)read(rfd, buf, sizeof(buf));
+    close(rfd);
+
+    CHECK(n == PAYLOAD_LEN, "read returns correct byte count");
+    CHECK(memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0,
+          "dst content matches written payload");
+
+    unlink(DST_PATH);
+
+done:
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/test-rename-content/c/src/test_framework.h
+++ b/test-suit/starryos/normal/test-rename-content/c/src/test_framework.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                      \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);              \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/test-rename-content/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/test-rename-content/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-rename-content"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30


### PR DESCRIPTION
## 问题

在 axfs-ng tmpfs 上执行 rename 之后，目标路径读出的文件内容全部是零字节。PostgreSQL durable_rename 的写入流程是先把数据写入临时文件，调用 fsync 落盘，再 rename 到最终路径。rename 完成后重新打开该文件时读到的内容全为 0。pg_control 等关键元数据文件被读成零后，PG 启动时报 "replication checkpoint has wrong magic 0" 并拒绝启动。

## 根本原因

components/axfs-ng-vfs/src/node/dir.rs 的 DirNode::rename 在底层 rename 成功后，对源路径和目标路径分别调用 forget_entry。tmpfs 没有持久存储，文件的字节内容只存在于 DirEntry 内部的 user_data 字段通过 Arc 持有的 page cache 中。对源路径调用 forget_entry 会将对应 DirEntry 从目录 cache 中移除，该 Arc 的引用计数随之归零，page cache 被释放。后续按目标文件名 lookup 时分配到全新的空 page cache，rename 之前写入的所有字节丢失。

## 修复

修改 DirNode::rename，将源 DirEntry 从源目录 cache 中取出而不是 forget，直接以目标文件名插入到目标目录 cache。目标路径原来的旧 entry 仍然 forget，因为底层 fs 已经将其替换。这样 rename 前后源 DirEntry 的实例保持不变，挂载在它上面的 page cache 得以延续，写入内容完整保留。

## 测试

新增回归测试 test-suit/starryos/normal/test-rename-content。测试程序向源文件写入一段 47 字节的已知载荷并调用 fsync，随后 rename 到目标路径，重新打开目标文件读取内容并逐字节比对。若 bug 存在则读出全零且比对失败；修复后内容与写入时完全一致。