### PR TITLE
fix(net): chown unix socket file to binding credentials

### DIFF
--- a/os/StarryOS/kernel/src/syscall/net/socket.rs
+++ b/os/StarryOS/kernel/src/syscall/net/socket.rs
@@ -1,12 +1,14 @@
 use ax_errno::{AxError, AxResult, LinuxError};
+use ax_fs::FS_CONTEXT;
 use ax_task::current;
+use axfs_ng_vfs::{MetadataUpdate, NodeType};
 #[cfg(feature = "vsock")]
 use axnet::vsock::{VsockSocket, VsockStreamTransport};
 use axnet::{
     Shutdown, Socket as SocketInner, SocketAddrEx, SocketOps,
     tcp::TcpSocket,
     udp::UdpSocket,
-    unix::{DgramTransport, StreamTransport, UnixSocket},
+    unix::{DgramTransport, StreamTransport, UnixSocket, UnixSocketAddr},
 };
 use linux_raw_sys::{
     general::{O_CLOEXEC, O_NONBLOCK},
@@ -69,7 +71,31 @@ pub fn sys_bind(fd: i32, addr: UserConstPtr<sockaddr>, addrlen: u32) -> AxResult
     let addr = SocketAddrEx::read_from_user(addr, addrlen)?;
     debug!("sys_bind <= fd: {fd}, addr: {addr:?}");
 
+    let unix_path = match &addr {
+        SocketAddrEx::Unix(UnixSocketAddr::Path(path)) => Some(path.clone()),
+        _ => None,
+    };
+    let cred = current().as_thread().cred();
+
     Socket::from_fd(fd)?.bind(addr)?;
+
+    if let Some(path) = unix_path {
+        if let Err(err) = FS_CONTEXT
+            .lock()
+            .resolve_no_follow(path.as_ref())
+            .and_then(|loc| {
+                if loc.metadata()?.node_type == NodeType::Socket {
+                    loc.update_metadata(MetadataUpdate {
+                        owner: Some((cred.fsuid, cred.fsgid)),
+                        ..Default::default()
+                    })?;
+                }
+                Ok(())
+            })
+        {
+            warn!("failed to update AF_UNIX socket owner for {path}: {err:?}");
+        }
+    }
 
     Ok(0)
 }

--- a/test-suit/starryos/normal/test-unix-bind-chown/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/test-unix-bind-chown/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-unix-bind-chown C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-unix-bind-chown src/main.c)
+target_compile_options(test-unix-bind-chown PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-unix-bind-chown RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/test-unix-bind-chown/c/src/main.c
+++ b/test-suit/starryos/normal/test-unix-bind-chown/c/src/main.c
@@ -1,0 +1,80 @@
+/*
+ * test-unix-bind-chown
+ *
+ * Verifies that an AF_UNIX pathname socket created by bind(2) is owned by
+ * the binding process's fsuid/fsgid, matching Linux semantics.
+ *
+ * Bug: sys_bind created the socket file without a credential context, so the
+ * inode owner was always root (uid 0 / gid 0). A non-root process could not
+ * then fchmodat its own socket -- EPERM from VFS uid check.
+ *
+ * Test procedure:
+ *   Fork a child that drops to uid/gid 1000 via setresuid/setresgid, then
+ *   bind an AF_UNIX path socket at a known path, and exits without unlinking.
+ *   The parent (still uid 0) stats the socket file and verifies st_uid == 1000.
+ */
+
+#include "test_framework.h"
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define SOCK_PATH "/tmp/test-b19-bind.sock"
+#define TEST_UID  1000
+#define TEST_GID  1000
+
+int main(void)
+{
+    TEST_START("unix bind(2) chowns socket to caller fsuid/fsgid");
+
+    unlink(SOCK_PATH);
+
+    pid_t pid = fork();
+    CHECK(pid >= 0, "fork");
+    if (pid == 0) {
+        if (setresgid(TEST_GID, TEST_GID, TEST_GID) != 0)
+            _exit(2);
+        if (setresuid(TEST_UID, TEST_UID, TEST_UID) != 0)
+            _exit(3);
+
+        int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+        if (sock < 0)
+            _exit(4);
+
+        struct sockaddr_un addr = {0};
+        addr.sun_family = AF_UNIX;
+        __builtin_strncpy(addr.sun_path, SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+        if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) != 0)
+            _exit(5);
+
+        close(sock);
+        _exit(0);
+    }
+
+    int status = 0;
+    pid_t w;
+    do {
+        w = waitpid(pid, &status, 0);
+    } while (w == -1 && errno == EINTR);
+    CHECK(w == pid, "waitpid child");
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0,
+          "child bind succeeded");
+
+    struct stat st;
+    int sr = stat(SOCK_PATH, &st);
+    CHECK(sr == 0, "stat socket path");
+    if (sr == 0) {
+        CHECK((st.st_mode & S_IFMT) == S_IFSOCK, "inode is a socket");
+        CHECK((uid_t)st.st_uid == (uid_t)TEST_UID,
+              "socket owner uid == TEST_UID (1000)");
+        CHECK((gid_t)st.st_gid == (gid_t)TEST_GID,
+              "socket owner gid == TEST_GID (1000)");
+    }
+
+    unlink(SOCK_PATH);
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/test-unix-bind-chown/c/src/test_framework.h
+++ b/test-suit/starryos/normal/test-unix-bind-chown/c/src/test_framework.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                      \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);              \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/test-unix-bind-chown/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/test-unix-bind-chown/qemu-aarch64.toml
@@ -1,0 +1,15 @@
+args = [
+    "-nographic",
+    "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-unix-bind-chown"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30

--- a/test-suit/starryos/normal/test-unix-bind-chown/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/test-unix-bind-chown/qemu-loongarch64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic",
+    "-m", "128M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-unix-bind-chown"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30

--- a/test-suit/starryos/normal/test-unix-bind-chown/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/test-unix-bind-chown/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-unix-bind-chown"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30

--- a/test-suit/starryos/normal/test-unix-bind-chown/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/test-unix-bind-chown/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-unix-bind-chown"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30


### PR DESCRIPTION
## 问题

非 root 进程对 AF_UNIX pathname 套接字调用 bind() 后，立即对该套接字文件调用 chmod() 收到 EPERM。PostgreSQL postmaster 以 uid 70 的 postgres 用户身份运行，bind() 之后调用 chmod(0777) 设置 socket 权限，EPERM 导致启动直接失败并打印 "could not set permissions of file /tmp/.s.PGSQL.5432" 以及 "could not create any Unix-domain sockets"。

## 根本原因

os/StarryOS/kernel/src/syscall/net/socket.rs 的 sys_bind 在处理 AF_UNIX pathname 地址时，会在文件系统中创建一个 socket 文件。axnet-ng 底层的 bind 路径创建这个文件时没有携带调用者的 credential 上下文，导致 inode 的 owner 始终是 uid 0 和 gid 0。非 root 进程随后对这个文件调用 fchmodat 时，VFS 检查发现 fsuid 与 inode 的 uid 不符，返回 EPERM。Linux 的行为是 bind() 创建的 socket 文件 owner 取当前任务的 fsuid 和 fsgid。

## 修复

在 sys*bind 调用底层 bind() 成功之后，对 SocketAddrEx::Unix(UnixSocketAddr::Path(..)) 分支额外执行一步 chown。通过 FS_CONTEXT 解析 socket 文件路径，调用 update_metadata 把 uid 和 gid 改为当前线程 cred 的 fsuid 和 fsgid。路径解析失败或 update_metadata 失败均视为非致命情况，用 let * 忽略，不影响 bind() 本身的返回值。改动只覆盖 AF_UNIX pathname 这一条路径，abstract 和 unnamed 套接字以及其他协议族均不受影响。

## 测试

新增回归测试 test-suit/starryos/normal/test-unix-bind-chown。测试程序 fork 出子进程，子进程通过 setresuid 和 setresgid 切换到 uid 和 gid 均为 1000，然后 bind() 一个 AF_UNIX pathname 套接字后退出。父进程等待子进程结束后 stat() 该套接字文件，校验 st_uid 和 st_gid 均等于 1000，以及 inode 类型为 S_IFSOCK。