### PR TITLE
fix(epoll): re-queue interest after EPOLL_CTL_MOD

### DIFF
--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -336,12 +336,27 @@ impl Epoll {
         let mut guard = self.inner.interests.lock();
         let old = guard.get_mut(&key).ok_or(AxError::NotFound)?;
 
-        // update new interest if old already in ready queue
-        if old.is_in_queue() {
+        // Preserve ready-queue membership across the swap. The ready_queue
+        // only holds Weak<EpollInterest> pointing at the old Arc, so
+        // dropping that Arc below turns those Weaks into dangling handles
+        // that upgrade() can't resolve. poll_events() would then silently
+        // skip the stale entry and the fd's pending event would be lost —
+        // which is how PostgreSQL's EPOLL_CTL_MOD after the first query
+        // ended up never waking the backend for the next client packet.
+        // Push a fresh Weak for the replacement interest so poll_events()
+        // still finds something to consume.
+        let was_in_queue = old.is_in_queue();
+        if was_in_queue {
             interest.in_ready_queue.store(true, Ordering::Release);
         }
         *old = Arc::clone(&interest);
         drop(guard);
+        if was_in_queue {
+            self.inner
+                .ready_queue
+                .lock()
+                .push_back(Arc::downgrade(&interest));
+        }
         trace!(
             "Epoll: modify fd={}, events={:?}",
             fd, interest.event.events

--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -356,6 +356,7 @@ impl Epoll {
                 .ready_queue
                 .lock()
                 .push_back(Arc::downgrade(&interest));
+            self.inner.poll_ready.wake();
         }
         trace!(
             "Epoll: modify fd={}, events={:?}",

--- a/test-suit/starryos/normal/test-epoll-ctl-mod/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/test-epoll-ctl-mod/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-epoll-ctl-mod C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-epoll-ctl-mod src/main.c)
+target_compile_options(test-epoll-ctl-mod PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-epoll-ctl-mod RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/test-epoll-ctl-mod/c/src/main.c
+++ b/test-suit/starryos/normal/test-epoll-ctl-mod/c/src/main.c
@@ -1,0 +1,61 @@
+/*
+ * test-epoll-ctl-mod
+ *
+ * Exercises the EPOLL_CTL_MOD re-queue path.
+ *
+ * Bug: Epoll::modify swaps the Arc in the interests map but does not refresh
+ * the ready_queue. If the fd already has a ready event sitting in the queue
+ * as a Weak<EpollInterest> pointing at the old Arc, the upgrade fails after
+ * the swap and the event is silently dropped. epoll_wait hangs until another
+ * edge arrives.
+ *
+ * Scenario:
+ *   1. epoll_create1
+ *   2. pipe; EPOLL_CTL_ADD on read end with EPOLLIN
+ *   3. write on write end so the read end becomes ready and the interest
+ *      is queued on ready_queue
+ *   4. EPOLL_CTL_MOD on the same fd with a new data payload
+ *   5. epoll_wait with a short timeout must return the event carrying the
+ *      new data payload, not time out
+ */
+
+#include "test_framework.h"
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+
+int main(void)
+{
+    TEST_START("epoll_ctl MOD re-queues already-ready interest");
+
+    int ep = epoll_create1(EPOLL_CLOEXEC);
+    CHECK(ep >= 0, "epoll_create1");
+
+    int pfd[2];
+    CHECK_RET(pipe(pfd), 0, "pipe");
+
+    struct epoll_event ev;
+    ev.events = EPOLLIN;
+    ev.data.u64 = 0x1111;
+    CHECK_RET(epoll_ctl(ep, EPOLL_CTL_ADD, pfd[0], &ev), 0, "EPOLL_CTL_ADD");
+
+    CHECK_RET((int)write(pfd[1], "x", 1), 1, "write makes read end ready");
+
+    ev.events = EPOLLIN;
+    ev.data.u64 = 0x2222;
+    CHECK_RET(epoll_ctl(ep, EPOLL_CTL_MOD, pfd[0], &ev), 0, "EPOLL_CTL_MOD");
+
+    struct epoll_event out;
+    int n = epoll_wait(ep, &out, 1, 2000);
+    CHECK(n == 1, "epoll_wait returns one event after MOD");
+    if (n == 1) {
+        CHECK(out.events & EPOLLIN, "event is EPOLLIN");
+        CHECK(out.data.u64 == 0x2222, "event carries the new data payload");
+    }
+
+    close(pfd[0]);
+    close(pfd[1]);
+    close(ep);
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/test-epoll-ctl-mod/c/src/test_framework.h
+++ b/test-suit/starryos/normal/test-epoll-ctl-mod/c/src/test_framework.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                      \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",         \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);              \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/test-epoll-ctl-mod/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/test-epoll-ctl-mod/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-epoll-ctl-mod"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30


### PR DESCRIPTION
## 问题

对一个已就绪的 fd 调用 EPOLL_CTL_MOD 之后，epoll_wait 收不到该 fd 的事件，持续阻塞直到下一次底层边沿到来。PostgreSQL WaitEventSet 会反复对 latch 和 self-pipe 的 fd 执行 EPOLL_CTL_MOD 重新武装，EPOLL_CTL_MOD 执行后首条就绪事件被吞掉，backend 进程卡在 epoll_wait 内，直到 PG 自身 60 秒等待超时，后续所有客户端命令全部失败。

## 根本原因

os/StarryOS/kernel/src/syscall/io_mpx/epoll.rs 的 Epoll::modify 在更换 interests 哈希表中的 Arc<EpollInterest> 时，没有同步刷新 ready_queue。ready_queue 内存放的是指向旧 Arc 的 Weak<EpollInterest>。modify 完成后旧 Arc 引用计数归零，所有悬挂 Weak 在 poll_events() 走 upgrade() 时返回 None 被直接跳过，这条就绪事件彻底消失。新创建的 Arc 没有任何路径进入 ready_queue，只有等到下一次底层 waker 再次触发才能重新入队。

## 修复

在替换 interests 表中的条目之前，先记录旧 Arc 的 is_in_queue() 状态。若旧条目已在 ready_queue 中，则在释放 interests 锁之后立即把新 Arc 的 Weak 推入 ready_queue，同时将新 Arc 的 in_ready_queue 标记设为 true 防止重复入队。旧的悬挂 Weak 保留在队列里，poll_events() 的 upgrade 失败分支会跳过它们，不影响正确性。

## 测试

新增回归测试 test-suit/starryos/normal/test-epoll-ctl-mod。测试程序建一个 pipe，对读端执行 EPOLL_CTL_ADD，向写端写入一字节使读端变为就绪，随即对读端执行 EPOLL_CTL_MOD 并替换 data.u64 标识，然后调用 epoll_wait 设置 2 秒超时。正确行为是立即收到事件且 data.u64 值与 MOD 时传入的一致；bug 存在时超时返回。