### PR TITLE
fix(axtask): register interrupt waker before flag swap

### DIFF
--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -251,10 +251,14 @@ impl TaskInner {
     /// Polls whether the task has been interrupted.
     #[inline]
     pub fn poll_interrupt(&self, cx: &Context) -> Poll<()> {
+        // Register the waker BEFORE rechecking the flag. Under preemptive
+        // scheduling a timer IRQ between an initial swap and register could
+        // allow `interrupt()` to run and call `wake()` on an empty waker
+        // slot — the wake is lost. Registering first closes the window.
+        self.interrupt_waker.register(cx.waker());
         if self.interrupted.swap(false, Ordering::AcqRel) {
             Poll::Ready(())
         } else {
-            self.interrupt_waker.register(cx.waker());
             Poll::Pending
         }
     }


### PR DESCRIPTION
## 问题

在抢占式调度下，TaskInner::poll_interrupt 存在一个窗口，使得 interrupt() 的唤醒信号被丢失，被 await 的任务永远停在等待中。表现与 PR b15 和 PR b17 的症状相似：某次信号或唤醒事件到达后进程仍然挂起，没有任何进展。

## 根本原因

os/arceos/modules/axtask/src/task.rs 的 poll_interrupt 原实现先执行 interrupted.swap(false, AcqRel)，只有在观察到 true 时才 Poll::Ready，观察到 false 时才去注册 waker 到 interrupt_waker 槽。在 swap 与 register 之间存在一个竞态窗口：若时钟中断在这个窗口内触发调度，另一个任务调用 interrupt() 对当前任务发起唤醒，interrupt() 在 interrupt_waker 槽还是空的状态下调用 wake()，唤醒信号找不到目标被丢弃。随后 poll_interrupt 把 waker 挂上，但 interrupted 标志已经被清零，再也没有人触发这个 waker，任务永久挂起。

## 修复

把 interrupt_waker.register(cx.waker()) 移到 interrupted.swap(false, AcqRel) 之前，确保 waker 就位后再读取 interrupted 的状态。移动之后：如果 swap 观察到 true，说明在注册前已有中断到达，直接返回 Poll::Ready；如果 swap 观察到 false，说明此时还没有中断，waker 已注册，后续任何 interrupt() 调用都能找到 waker 并唤醒任务。这和 b17 中 sys_waitpid 的修复以及 b15 中信号路径的修复遵循同一个 register-then-check 模式。

## 测试

这个竞态依赖精确的调度时机，构造一个必然且确定复现的用户态测例不现实，因此没有添加 normal/ 回归用例。