### PR TITLE
fix(test): align loongarch64 smoke QEMU memory size with axconfig

### DIFF
--- a/test-suit/starryos/normal/smoke/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/smoke/qemu-loongarch64.toml
@@ -5,7 +5,7 @@ args = [
   "la464",
   "-nographic",
   "-m",
-  "128M",
+  "512M",
   "-device",
   "virtio-blk-pci,drive=disk0",
   "-drive",


### PR DESCRIPTION
## 问题

loongarch64 冒烟测试启动后立即 panic，内核无法进入用户态：

    Unhandled trap Exception(MemoryAccessAddressError) @ 0xffff80000026fab8

异常发生在内核早期初始化阶段，陷入处理程序没有对应 MemoryAccessAddressError 的恢复路径，直接 panic。

## 根本原因

test-suit/starryos/normal/smoke/qemu-loongarch64.toml 给 QEMU 传递的 -m 128M，而 components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/axconfig.toml 声明 phys-memory-size 为 0x2000_0000（512M），high-memory-base 为 0x8000_0000（2GB 起始）。内核在初始化阶段访问 high-memory-base 处的物理地址 0x80000000，但 QEMU 只分配了 128M 物理 RAM，这段地址没有对应的 RAM 页，CPU 抛出访存地址错误异常。其他三个架构的冒烟配置均为 512M，loongarch64 是唯一遗漏的。

内核 phys-memory-size 必须与 QEMU -m 参数一致。在内核里加 DTB 内存探测并不能解决这个问题，因为 QEMU 配置文件里的内存大小决定了有多少物理 RAM 可用，而内核已按照 axconfig 中的声明访问那些地址。

## 修复

将 test-suit/starryos/normal/smoke/qemu-loongarch64.toml 中的 -m 128M 改为 -m 512M，与其他三个架构的冒烟配置以及 axconfig 声明的物理内存大小对齐。