### PR TITLE
test(postgres): add PostgreSQL 17 stress test

### DIFF
--- a/test-suit/starryos/stress/postgresql/qemu-aarch64.toml
+++ b/test-suit/starryos/stress/postgresql/qemu-aarch64.toml
@@ -1,0 +1,40 @@
+args = [
+    "-nographic", "-machine", "virt,gic-version=2",
+    "-cpu", "cortex-a53",
+    "-m", "512M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+{ \
+apk update >/dev/null 2>&1 && apk add postgresql17 2>&1 && \
+mkdir /tmp/pgdata /tmp/pgrun && chmod 0700 /tmp/pgdata /tmp/pgrun && chown postgres:postgres /tmp/pgdata /tmp/pgrun && \
+PG=/usr/libexec/postgresql17; \
+su -s /bin/sh postgres -c "$PG/initdb -D /tmp/pgdata --no-locale --username=postgres" 2>&1 && \
+echo "INITDB_OK" && \
+su -s /bin/sh postgres -c "$PG/pg_ctl -D /tmp/pgdata -l /tmp/pg.log start -w -t 120 -o '-c max_connections=10 -c shared_buffers=16MB -c unix_socket_directories=/tmp/pgrun -c fsync=off'" 2>&1 && \
+echo "PGCTL_START_OK" && \
+RESULT=$(su -s /bin/sh postgres -c "$PG/psql -h /tmp/pgrun -d postgres -t -A -c 'SELECT 1'" 2>&1) && \
+echo "SELECT_RESULT=[$RESULT]" && \
+test "$RESULT" = "1" && \
+su -s /bin/sh postgres -c "$PG/psql -h /tmp/pgrun -d postgres -c 'CREATE TABLE t (id int); INSERT INTO t VALUES (1),(2),(3); SELECT count(*) FROM t'" 2>&1 && \
+echo "QUERIES_DONE" && \
+PM_PID=$(cat /tmp/pgdata/postmaster.pid 2>/dev/null | head -1) && \
+test -n "$PM_PID" && \
+echo "POSTMASTER_PID=$PM_PID"
+} || { echo "PG_TEST_FAILED"; echo "=== pg.log tail ==="; tail -30 /tmp/pg.log 2>&1; echo "=== end ==="; exit 1; }; \
+echo "KILLING_POSTMASTER=$PM_PID"; \
+kill -9 "$PM_PID" 2>&1; sleep 1; \
+pkill -9 postgres 2>&1; sleep 1; \
+echo "KILL_DONE"; \
+echo "=== pg.log tail ==="; tail -30 /tmp/pg.log 2>&1; echo "=== end ==="; \
+echo "PG_TEST_DONE=$(date +%s)"
+'''
+success_regex = ["(?m)^PG_TEST_DONE=\\d+\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?i)\b(PG_TEST_FAILED|ERROR|FATAL|failed)\b']
+timeout = 5400

--- a/test-suit/starryos/stress/postgresql/qemu-loongarch64.toml
+++ b/test-suit/starryos/stress/postgresql/qemu-loongarch64.toml
@@ -1,0 +1,41 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic",
+    "-m", "512M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+{ \
+apk update >/dev/null 2>&1 && apk add postgresql17 2>&1 && \
+mkdir /tmp/pgdata /tmp/pgrun && chmod 0700 /tmp/pgdata /tmp/pgrun && chown postgres:postgres /tmp/pgdata /tmp/pgrun && \
+PG=/usr/libexec/postgresql17; \
+su -s /bin/sh postgres -c "$PG/initdb -D /tmp/pgdata --no-locale --username=postgres" 2>&1 && \
+echo "INITDB_OK" && \
+su -s /bin/sh postgres -c "$PG/pg_ctl -D /tmp/pgdata -l /tmp/pg.log start -w -t 600 -o '-c max_connections=10 -c shared_buffers=16MB -c unix_socket_directories=/tmp/pgrun -c fsync=off'" 2>&1 && \
+echo "PGCTL_START_OK" && \
+RESULT=$(su -s /bin/sh postgres -c "$PG/psql -h /tmp/pgrun -d postgres -t -A -c 'SELECT 1'" 2>&1) && \
+echo "SELECT_RESULT=[$RESULT]" && \
+test "$RESULT" = "1" && \
+su -s /bin/sh postgres -c "$PG/psql -h /tmp/pgrun -d postgres -c 'CREATE TABLE t (id int); INSERT INTO t VALUES (1),(2),(3); SELECT count(*) FROM t'" 2>&1 && \
+echo "QUERIES_DONE" && \
+PM_PID=$(cat /tmp/pgdata/postmaster.pid 2>/dev/null | head -1) && \
+test -n "$PM_PID" && \
+echo "POSTMASTER_PID=$PM_PID"
+} || { echo "PG_TEST_FAILED"; echo "=== pg.log tail ==="; tail -30 /tmp/pg.log 2>&1; echo "=== end ==="; exit 1; }; \
+echo "KILLING_POSTMASTER=$PM_PID"; \
+kill -9 "$PM_PID" 2>&1; sleep 1; \
+pkill -9 postgres 2>&1; sleep 1; \
+echo "KILL_DONE"; \
+echo "=== pg.log tail ==="; tail -30 /tmp/pg.log 2>&1; echo "=== end ==="; \
+echo "PG_TEST_DONE=$(date +%s)"
+'''
+success_regex = ["(?m)^PG_TEST_DONE=\\d+\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?i)\b(PG_TEST_FAILED|ERROR|FATAL|failed)\b']
+timeout = 5400

--- a/test-suit/starryos/stress/postgresql/qemu-riscv64.toml
+++ b/test-suit/starryos/stress/postgresql/qemu-riscv64.toml
@@ -1,0 +1,39 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-m", "512M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+{ \
+apk update >/dev/null 2>&1 && apk add postgresql17 2>&1 && \
+mkdir /tmp/pgdata /tmp/pgrun && chmod 0700 /tmp/pgdata /tmp/pgrun && chown postgres:postgres /tmp/pgdata /tmp/pgrun && \
+PG=/usr/libexec/postgresql17; \
+su -s /bin/sh postgres -c "$PG/initdb -D /tmp/pgdata --no-locale --username=postgres" 2>&1 && \
+echo "INITDB_OK" && \
+su -s /bin/sh postgres -c "$PG/pg_ctl -D /tmp/pgdata -l /tmp/pg.log start -w -t 120 -o '-c max_connections=10 -c shared_buffers=16MB -c unix_socket_directories=/tmp/pgrun -c fsync=off'" 2>&1 && \
+echo "PGCTL_START_OK" && \
+RESULT=$(su -s /bin/sh postgres -c "$PG/psql -h /tmp/pgrun -d postgres -t -A -c 'SELECT 1'" 2>&1) && \
+echo "SELECT_RESULT=[$RESULT]" && \
+test "$RESULT" = "1" && \
+su -s /bin/sh postgres -c "$PG/psql -h /tmp/pgrun -d postgres -c 'CREATE TABLE t (id int); INSERT INTO t VALUES (1),(2),(3); SELECT count(*) FROM t'" 2>&1 && \
+echo "QUERIES_DONE" && \
+PM_PID=$(cat /tmp/pgdata/postmaster.pid 2>/dev/null | head -1) && \
+test -n "$PM_PID" && \
+echo "POSTMASTER_PID=$PM_PID"
+} || { echo "PG_TEST_FAILED"; echo "=== pg.log tail ==="; tail -30 /tmp/pg.log 2>&1; echo "=== end ==="; exit 1; }; \
+echo "KILLING_POSTMASTER=$PM_PID"; \
+kill -9 "$PM_PID" 2>&1; sleep 1; \
+pkill -9 postgres 2>&1; sleep 1; \
+echo "KILL_DONE"; \
+echo "=== pg.log tail ==="; tail -30 /tmp/pg.log 2>&1; echo "=== end ==="; \
+echo "PG_TEST_DONE=$(date +%s)"
+'''
+success_regex = ["(?m)^PG_TEST_DONE=\\d+\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?i)\b(PG_TEST_FAILED|ERROR|FATAL|failed)\b']
+timeout = 5400

--- a/test-suit/starryos/stress/postgresql/qemu-x86_64.toml
+++ b/test-suit/starryos/stress/postgresql/qemu-x86_64.toml
@@ -1,0 +1,39 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+{ \
+apk update >/dev/null 2>&1 && apk add postgresql17 2>&1 && \
+mkdir /tmp/pgdata /tmp/pgrun && chmod 0700 /tmp/pgdata /tmp/pgrun && chown postgres:postgres /tmp/pgdata /tmp/pgrun && \
+PG=/usr/libexec/postgresql17; \
+su -s /bin/sh postgres -c "$PG/initdb -D /tmp/pgdata --no-locale --username=postgres" 2>&1 && \
+echo "INITDB_OK" && \
+su -s /bin/sh postgres -c "$PG/pg_ctl -D /tmp/pgdata -l /tmp/pg.log start -w -t 60 -o '-c max_connections=10 -c shared_buffers=16MB -c unix_socket_directories=/tmp/pgrun -c fsync=off'" 2>&1 && \
+echo "PGCTL_START_OK" && \
+RESULT=$(su -s /bin/sh postgres -c "$PG/psql -h /tmp/pgrun -d postgres -t -A -c 'SELECT 1'" 2>&1) && \
+echo "SELECT_RESULT=[$RESULT]" && \
+test "$RESULT" = "1" && \
+su -s /bin/sh postgres -c "$PG/psql -h /tmp/pgrun -d postgres -c 'CREATE TABLE t (id int); INSERT INTO t VALUES (1),(2),(3); SELECT count(*) FROM t'" 2>&1 && \
+echo "QUERIES_DONE" && \
+PM_PID=$(cat /tmp/pgdata/postmaster.pid 2>/dev/null | head -1) && \
+test -n "$PM_PID" && \
+echo "POSTMASTER_PID=$PM_PID"
+} || { echo "PG_TEST_FAILED"; echo "=== pg.log tail ==="; tail -30 /tmp/pg.log 2>&1; echo "=== end ==="; exit 1; }; \
+echo "KILLING_POSTMASTER=$PM_PID"; \
+kill -9 "$PM_PID" 2>&1; sleep 1; \
+pkill -9 postgres 2>&1; sleep 1; \
+echo "KILL_DONE"; \
+echo "=== pg.log tail ==="; tail -30 /tmp/pg.log 2>&1; echo "=== end ==="; \
+echo "PG_TEST_DONE=$(date +%s)"
+'''
+success_regex = ["(?m)^PG_TEST_DONE=\\d+\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?i)\b(PG_TEST_FAILED|ERROR|FATAL|failed)\b']
+timeout = 5400


### PR DESCRIPTION
## 背景

PostgreSQL 17 是类 Unix 平台上部署最广泛的关系数据库，其启动和运行路径密集覆盖了 StarryOS 的多个核心子系统：进程管理与信号处理（fork、waitpid、SA_RESTART、SIGCHLD）、System V 共享内存（shmget/shmat/shmctl）、AF_UNIX 域套接字（postmaster 监听与 backend 连接）、epoll/pselect（WaitEventSet）、文件系统操作（WAL 写入、fsync、目录同步）、credentials 子系统（setuid 切换到 postgres 用户）、资源限制（prlimit64 提高 RLIMIT_NOFILE）。能驱动 PG 17 完整走完 initdb、启动、执行 SQL 并干净退出，验证了上述子系统在组合场景下的正确性。

本 PR 在 test-suit/starryos/stress/postgresql/ 下新增四个 TOML 配置，覆盖全部四个架构。

## 测试内容

四个 TOML 分别对应 qemu-riscv64.toml、qemu-aarch64.toml、qemu-x86_64.toml、qemu-loongarch64.toml，测试流程通过 shell_init_cmd 在 Alpine rootfs 内顺序执行：

apk add postgresql17 安装 PG 17 及依赖；initdb 初始化数据集群，打印 INITDB_OK 作为确认点；pg_ctl start -w 拉起 postmaster，打印 PGCTL_START_OK 作为确认点；psql 执行 SELECT 1 验证基本查询通路；CREATE TABLE、INSERT、SELECT count 验证完整读写流程；kill -9 终止 postmaster，打印 PG_TEST_DONE 加时间戳。

## 部分前置依赖

以下为尚未合入 dev 的 PR：

已提交，open：
- https://github.com/rcore-os/tgoskits/pull/205
- https://github.com/rcore-os/tgoskits/pull/207
- https://github.com/rcore-os/tgoskits/pull/209
- https://github.com/rcore-os/tgoskits/pull/210
- https://github.com/rcore-os/tgoskits/pull/211
- https://github.com/rcore-os/tgoskits/pull/311
- https://github.com/rcore-os/tgoskits/pull/312
- https://github.com/rcore-os/tgoskits/pull/313
- https://github.com/rcore-os/tgoskits/pull/314
- https://github.com/rcore-os/tgoskits/pull/315
- https://github.com/rcore-os/tgoskits/pull/316
- https://github.com/rcore-os/tgoskits/pull/317
- https://github.com/rcore-os/tgoskits/pull/318
- https://github.com/rcore-os/tgoskits/pull/319
- https://github.com/rcore-os/tgoskits/pull/320

已提交至 fixbug-based-dev，尚未合入 dev：
- https://github.com/rcore-os/tgoskits/pull/203
