### PR TITLE
feat(axbuild): extend sync-lint mixed-ordering checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,6 +1548,7 @@ dependencies = [
  "object 0.38.1",
  "ostool",
  "proc-macro2",
+ "quote",
  "regex",
  "reqwest 0.13.2",
  "schemars",

--- a/docs/community/sync-lint.md
+++ b/docs/community/sync-lint.md
@@ -64,9 +64,44 @@ WQ.notify_all(true);
 
 如果发布动作还是 `Relaxed`，等待者就可能虽然被唤醒了，但看不到你刚刚写入的最新状态。
 
+### 3. 同一个同步原子混用了强序和 `Relaxed`
+
+如果某个原子已经被检查器认定为“同步变量”，比如：
+
+- 它出现在等待条件里
+- 它承担了“写状态后唤醒别人”的职责
+
+那么检查器还会继续看这个原子在同一文件里的其他访问。
+
+如果它一边用了：
+
+- `Acquire`
+- `Release`
+- `AcqRel`
+- `SeqCst`
+
+另一边又用了：
+
+- `Relaxed`
+
+那么这些 `Relaxed` 访问也会被报告。
+
+例如：
+
+```rust
+READY.store(true, Ordering::Release);
+WQ.notify_all(true);
+
+if READY.load(Ordering::Relaxed) {
+    do_work();
+}
+```
+
+这类情况通常说明：这个原子已经明显承担同步语义，但仍然有一部分访问保留在 `Relaxed`，需要重新确认是否真的足够。
+
 ## 当前不检查什么
 
-为了避免误报，第一阶段刻意没有做“大而全”的规则。
+为了避免误报，当前实现依然刻意没有做“大而全”的规则。
 
 目前不会主动检查这些情况：
 
@@ -74,6 +109,7 @@ WQ.notify_all(true);
 - `Acquire` / `Release` 是否成对匹配
 - `AcqRel` 或 `SeqCst` 是否过强
 - 更复杂的跨函数发布模式
+- 基于任意控制流和任意数据结构的通用 dataflow 推理
 - lock-free 算法内部的状态机细节
 
 也就是说，当前规则是一个**保守版、低误报**检查器。
@@ -100,6 +136,14 @@ Relaxed atomic write is immediately followed by a wake/notify operation
 test-suit/arceos/rust/task/parallel/src/main.rs:40:12:
 Relaxed atomic load is used in a wait condition
 [suspicious_relaxed_wait_condition]
+```
+
+也可能看到：
+
+```text
+some/path.rs:27:8:
+Relaxed atomic access is mixed with stronger orderings on the same synchronization variable
+[suspicious_relaxed_mixed_ordering]
 ```
 
 ## 这些提示分别是什么意思
@@ -131,6 +175,20 @@ Relaxed atomic load is used in a wait condition
 这类写一般应考虑改成：
 
 - `Ordering::Release`
+
+### `suspicious_relaxed_mixed_ordering`
+
+意思是：
+
+- 同一个原子在同一文件里既出现了强序访问，也出现了 `Relaxed` 访问
+- 并且这个原子已经有足够证据表明自己是同步变量，而不是纯统计值
+
+这类提示通常不是单独成立的“文本匹配”，而是结合了前面的等待/唤醒语义一起判断出来的。
+
+一般应先回头看这个原子的职责，再决定是否把相关 `Relaxed` 访问也统一成：
+
+- 读侧 `Ordering::Acquire`
+- 写侧 `Ordering::Release`
 
 ## 一般怎么修
 
@@ -216,6 +274,49 @@ WQ1.wait_until(|| COUNTER.load(Ordering::Acquire) == NUM_TASKS);
 ```rust
 // sync-lint: ignore suspicious_relaxed_publish_before_notify
 ```
+
+或者：
+
+```rust
+// sync-lint: ignore suspicious_relaxed_mixed_ordering
+```
+
+也可以写成通用忽略：
+
+```rust
+// sync-lint: ignore
+```
+
+当前实现的匹配规则要点是：
+
+- 注释里必须至少包含 `sync-lint: ignore`
+- 如果后面再带具体规则名，就只忽略那一条规则
+- 如果不带具体规则名，就会把当前 `sync-lint` 的规则都忽略掉
+- 只写 `// sync-lint:` 这种前缀并不会生效
+- 忽略注释必须位于被报告代码上方的 1 到 3 行内
+
+例如：
+
+```rust
+// sync-lint: ignore suspicious_relaxed_wait_condition
+wq.wait_until(|| counter.load(Ordering::Relaxed) == 1);
+```
+
+表示只忽略 `suspicious_relaxed_wait_condition`。
+
+```rust
+// sync-lint: ignore
+wq.wait_until(|| counter.load(Ordering::Relaxed) == 1);
+```
+
+表示通用忽略。
+
+```rust
+// sync-lint:
+wq.wait_until(|| counter.load(Ordering::Relaxed) == 1);
+```
+
+这不会被识别成忽略注释。
 
 如果你确实要忽略，建议把理由写清楚，例如：
 

--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -38,6 +38,7 @@ tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt", "std", "time"] }
 xz2 = "0.1"
 proc-macro2 = { version = "1", features = ["span-locations"] }
+quote = "1"
 syn = { version = "2", features = ["full", "visit"] }
 walkdir = "2"
 

--- a/scripts/axbuild/src/sync_lint.rs
+++ b/scripts/axbuild/src/sync_lint.rs
@@ -9,8 +9,8 @@ use cargo_metadata::{Metadata, Package};
 use proc_macro2::Span;
 use quote::ToTokens;
 use syn::{
-    Block, Expr, ExprCall, ExprClosure, ExprMethodCall, ExprPath, ExprWhile, File, Ident,
-    ItemMacro, Stmt,
+    Block, Expr, ExprCall, ExprClosure, ExprForLoop, ExprMethodCall, ExprPath, ExprWhile, File,
+    FnArg, Ident, ImplItemFn, ItemFn, ItemMacro, Local, Member, Pat, Stmt,
     spanned::Spanned,
     visit::{self, Visit},
 };
@@ -172,6 +172,7 @@ struct Analyzer<'a> {
     accesses: Vec<AtomicAccess>,
     sync_intent_keys: HashSet<String>,
     findings: Vec<Finding>,
+    bindings: BindingContext,
 }
 
 impl<'a> Analyzer<'a> {
@@ -182,6 +183,7 @@ impl<'a> Analyzer<'a> {
             accesses: Vec::new(),
             sync_intent_keys: HashSet::new(),
             findings: Vec::new(),
+            bindings: BindingContext::default(),
         }
     }
 
@@ -251,7 +253,7 @@ impl<'a> Analyzer<'a> {
     }
 
     fn mark_sync_intent_expr(&mut self, expr: &Expr) {
-        for access in atomic_accesses_in_expr(expr) {
+        for access in atomic_accesses_in_expr(expr, &self.bindings) {
             self.sync_intent_keys.insert(access.key);
         }
     }
@@ -277,7 +279,7 @@ impl<'a> Analyzer<'a> {
             let [first, second] = pair else {
                 continue;
             };
-            if let Some(access) = atomic_write_access(first)
+            if let Some(access) = atomic_write_access(first, &self.bindings)
                 && is_notify_expr(second)
             {
                 self.sync_intent_keys.insert(access.key);
@@ -294,6 +296,20 @@ impl<'a> Analyzer<'a> {
 }
 
 impl Visit<'_> for Analyzer<'_> {
+    fn visit_item_fn(&mut self, node: &ItemFn) {
+        self.bindings.push_scope();
+        self.bindings.bind_fn_inputs(&node.sig.inputs);
+        visit::visit_block(self, &node.block);
+        self.bindings.pop_scope();
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &ImplItemFn) {
+        self.bindings.push_scope();
+        self.bindings.bind_fn_inputs(&node.sig.inputs);
+        visit::visit_block(self, &node.block);
+        self.bindings.pop_scope();
+    }
+
     fn visit_item_macro(&mut self, node: &ItemMacro) {
         if node
             .mac
@@ -308,6 +324,15 @@ impl Visit<'_> for Analyzer<'_> {
         visit::visit_item_macro(self, node);
     }
 
+    fn visit_expr_closure(&mut self, node: &ExprClosure) {
+        self.bindings.push_scope();
+        for input in &node.inputs {
+            self.bindings.bind_pat(input);
+        }
+        visit::visit_expr(self, &node.body);
+        self.bindings.pop_scope();
+    }
+
     fn visit_expr_call(&mut self, node: &ExprCall) {
         if is_wait_function(node) {
             for arg in &node.args {
@@ -320,7 +345,7 @@ impl Visit<'_> for Analyzer<'_> {
     }
 
     fn visit_expr_method_call(&mut self, node: &ExprMethodCall) {
-        if let Some(access) = atomic_access_from_method_call(node) {
+        if let Some(access) = atomic_access_from_method_call(node, &self.bindings) {
             self.accesses.push(access);
         }
         if is_wait_method(node.method.clone()) {
@@ -331,6 +356,14 @@ impl Visit<'_> for Analyzer<'_> {
             }
         }
         visit::visit_expr_method_call(self, node);
+    }
+
+    fn visit_expr_for_loop(&mut self, node: &ExprForLoop) {
+        self.visit_expr(&node.expr);
+        self.bindings.push_scope();
+        self.bindings.bind_pat(&node.pat);
+        visit::visit_block(self, &node.body);
+        self.bindings.pop_scope();
     }
 
     fn visit_expr_while(&mut self, node: &ExprWhile) {
@@ -350,8 +383,101 @@ impl Visit<'_> for Analyzer<'_> {
     }
 
     fn visit_block(&mut self, node: &Block) {
+        self.bindings.push_scope();
         self.check_block_for_publish_before_notify(node);
         visit::visit_block(self, node);
+        self.bindings.pop_scope();
+    }
+
+    fn visit_local(&mut self, node: &Local) {
+        if let Some(init) = &node.init {
+            self.visit_expr(&init.expr);
+            if let Some((_, diverge)) = &init.diverge {
+                self.visit_expr(diverge);
+            }
+        }
+        self.bindings.bind_pat(&node.pat);
+    }
+}
+
+#[derive(Debug, Default)]
+struct BindingContext {
+    scopes: Vec<HashMap<String, usize>>,
+    next_binding_id: usize,
+}
+
+impl BindingContext {
+    fn push_scope(&mut self) {
+        self.scopes.push(HashMap::new());
+    }
+
+    fn pop_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    fn bind_fn_inputs(&mut self, inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>) {
+        for input in inputs {
+            match input {
+                FnArg::Receiver(_) => self.bind_name("self"),
+                FnArg::Typed(pat_type) => self.bind_pat(&pat_type.pat),
+            }
+        }
+    }
+
+    fn bind_name(&mut self, name: &str) {
+        if let Some(scope) = self.scopes.last_mut() {
+            let id = self.next_binding_id;
+            self.next_binding_id += 1;
+            scope.insert(name.to_string(), id);
+        }
+    }
+
+    fn bind_pat(&mut self, pat: &Pat) {
+        match pat {
+            Pat::Ident(pat_ident) => {
+                self.bind_name(&pat_ident.ident.to_string());
+                if let Some((_at, subpat)) = &pat_ident.subpat {
+                    self.bind_pat(subpat);
+                }
+            }
+            Pat::Or(pat_or) => {
+                for case in &pat_or.cases {
+                    self.bind_pat(case);
+                }
+            }
+            Pat::Paren(pat_paren) => self.bind_pat(&pat_paren.pat),
+            Pat::Reference(pat_reference) => self.bind_pat(&pat_reference.pat),
+            Pat::Slice(pat_slice) => {
+                for elem in &pat_slice.elems {
+                    self.bind_pat(elem);
+                }
+            }
+            Pat::Struct(pat_struct) => {
+                for field in &pat_struct.fields {
+                    self.bind_pat(&field.pat);
+                }
+            }
+            Pat::Tuple(pat_tuple) => {
+                for elem in &pat_tuple.elems {
+                    self.bind_pat(elem);
+                }
+            }
+            Pat::TupleStruct(pat_tuple_struct) => {
+                for elem in &pat_tuple_struct.elems {
+                    self.bind_pat(elem);
+                }
+            }
+            Pat::Type(pat_type) => self.bind_pat(&pat_type.pat),
+            _ => {}
+        }
+    }
+
+    fn resolve_ident(&self, ident: &Ident) -> Option<usize> {
+        let name = ident.to_string();
+        self.scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.get(&name).copied())
     }
 }
 
@@ -409,7 +535,7 @@ fn is_notify_expr(expr: &Expr) -> bool {
     }
 }
 
-fn atomic_write_access(expr: &Expr) -> Option<AtomicAccess> {
+fn atomic_write_access(expr: &Expr, bindings: &BindingContext) -> Option<AtomicAccess> {
     let Expr::MethodCall(method) = expr else {
         return None;
     };
@@ -427,7 +553,7 @@ fn atomic_write_access(expr: &Expr) -> Option<AtomicAccess> {
     ) {
         return None;
     }
-    atomic_access_from_method_call(method)
+    atomic_access_from_method_call(method, bindings)
 }
 
 fn first_relaxed_load(expr: &Expr) -> Option<Span> {
@@ -454,28 +580,33 @@ impl Visit<'_> for RelaxedLoadFinder {
     }
 }
 
-fn atomic_accesses_in_expr(expr: &Expr) -> Vec<AtomicAccess> {
+fn atomic_accesses_in_expr(expr: &Expr, bindings: &BindingContext) -> Vec<AtomicAccess> {
     let mut finder = AtomicAccessFinder {
         accesses: Vec::new(),
+        bindings,
     };
     finder.visit_expr(expr);
     finder.accesses
 }
 
-struct AtomicAccessFinder {
+struct AtomicAccessFinder<'a> {
     accesses: Vec<AtomicAccess>,
+    bindings: &'a BindingContext,
 }
 
-impl Visit<'_> for AtomicAccessFinder {
+impl Visit<'_> for AtomicAccessFinder<'_> {
     fn visit_expr_method_call(&mut self, node: &ExprMethodCall) {
-        if let Some(access) = atomic_access_from_method_call(node) {
+        if let Some(access) = atomic_access_from_method_call(node, self.bindings) {
             self.accesses.push(access);
         }
         visit::visit_expr_method_call(self, node);
     }
 }
 
-fn atomic_access_from_method_call(node: &ExprMethodCall) -> Option<AtomicAccess> {
+fn atomic_access_from_method_call(
+    node: &ExprMethodCall,
+    bindings: &BindingContext,
+) -> Option<AtomicAccess> {
     let ordering = match node.method.to_string().as_str() {
         "load" if node.args.len() == 1 => atomic_ordering(&node.args[0])?,
         "store" if node.args.len() == 2 => atomic_ordering(&node.args[1])?,
@@ -493,14 +624,58 @@ fn atomic_access_from_method_call(node: &ExprMethodCall) -> Option<AtomicAccess>
     };
 
     Some(AtomicAccess {
-        key: receiver_key(&node.receiver),
+        key: receiver_key(&node.receiver, bindings),
         span: node.span(),
         ordering,
     })
 }
 
-fn receiver_key(expr: &Expr) -> String {
-    expr.to_token_stream().to_string()
+fn receiver_key(expr: &Expr, bindings: &BindingContext) -> String {
+    receiver_key_parts(expr, bindings).unwrap_or_else(|| format!("expr:{}", expr.to_token_stream()))
+}
+
+fn receiver_key_parts(expr: &Expr, bindings: &BindingContext) -> Option<String> {
+    match expr {
+        Expr::Field(field) => {
+            let mut base = receiver_key_parts(&field.base, bindings)?;
+            base.push('.');
+            base.push_str(&member_key(&field.member));
+            Some(base)
+        }
+        Expr::Index(index) => {
+            let mut base = receiver_key_parts(&index.expr, bindings)?;
+            base.push_str("[_]");
+            Some(base)
+        }
+        Expr::Group(group) => receiver_key_parts(&group.expr, bindings),
+        Expr::Paren(paren) => receiver_key_parts(&paren.expr, bindings),
+        Expr::Reference(reference) => receiver_key_parts(&reference.expr, bindings),
+        Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Deref(_)) => {
+            receiver_key_parts(&unary.expr, bindings)
+        }
+        Expr::Path(path) => Some(path_key(path, bindings)),
+        _ => None,
+    }
+}
+
+fn path_key(expr: &ExprPath, bindings: &BindingContext) -> String {
+    if expr.qself.is_none()
+        && expr.path.leading_colon.is_none()
+        && expr.path.segments.len() == 1
+        && let Some(segment) = expr.path.segments.first()
+        && let Some(binding_id) = bindings.resolve_ident(&segment.ident)
+    {
+        return format!("binding#{binding_id}");
+    }
+
+    format!("path:{}", expr.path.to_token_stream())
+}
+
+fn member_key(member: &Member) -> String {
+    match member {
+        Member::Named(ident) => ident.to_string(),
+        Member::Unnamed(index) => index.index.to_string(),
+    }
 }
 
 fn atomic_ordering(expr: &Expr) -> Option<AccessOrdering> {
@@ -700,6 +875,77 @@ fn demo(flag: &AtomicBool, wq: WaitQueue) {
                 .iter()
                 .any(|finding| finding.rule == Rule::MixedOrdering)
         );
+    }
+
+    #[test]
+    fn reports_relaxed_mixed_ordering_for_parenthesized_receiver() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicBool, Ordering};
+
+fn demo(flag: &AtomicBool, wq: WaitQueue) {
+    flag.store(true, Ordering::Relaxed);
+    wq.wait_until(|| (flag).load(Ordering::Acquire));
+}
+"#,
+        );
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.rule == Rule::MixedOrdering)
+        );
+    }
+
+    #[test]
+    fn ignores_mixed_ordering_for_different_function_bindings_with_same_name() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicBool, Ordering};
+
+fn sync_path(flag: &AtomicBool, wq: WaitQueue) {
+    flag.store(true, Ordering::Relaxed);
+    wq.wait_until(|| flag.load(Ordering::Acquire));
+}
+
+fn stats_path(flag: &AtomicBool) {
+    let _ = flag.load(Ordering::Relaxed);
+}
+"#,
+        );
+
+        let mixed = findings
+            .iter()
+            .filter(|finding| finding.rule == Rule::MixedOrdering)
+            .collect::<Vec<_>>();
+
+        assert_eq!(mixed.len(), 1);
+    }
+
+    #[test]
+    fn ignores_mixed_ordering_for_shadowed_binding_in_inner_scope() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicBool, Ordering};
+
+fn demo(flag: &AtomicBool, wq: WaitQueue) {
+    flag.store(true, Ordering::Relaxed);
+    wq.wait_until(|| flag.load(Ordering::Acquire));
+
+    {
+        let flag = AtomicBool::new(false);
+        let _ = flag.load(Ordering::Relaxed);
+    }
+}
+"#,
+        );
+
+        let mixed = findings
+            .iter()
+            .filter(|finding| finding.rule == Rule::MixedOrdering)
+            .collect::<Vec<_>>();
+
+        assert_eq!(mixed.len(), 1);
     }
 
     #[test]

--- a/scripts/axbuild/src/sync_lint.rs
+++ b/scripts/axbuild/src/sync_lint.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -7,6 +7,7 @@ use std::{
 use anyhow::Context;
 use cargo_metadata::{Metadata, Package};
 use proc_macro2::Span;
+use quote::ToTokens;
 use syn::{
     Block, Expr, ExprCall, ExprClosure, ExprMethodCall, ExprPath, ExprWhile, File, Ident,
     ItemMacro, Stmt,
@@ -116,24 +117,44 @@ fn file_findings(path: &Path) -> anyhow::Result<Vec<Finding>> {
 fn analyze_file(path: &Path, source: &str, syntax: &File) -> Vec<Finding> {
     let mut analyzer = Analyzer::new(path, source);
     analyzer.visit_file(syntax);
+    analyzer.finish();
     analyzer.findings
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Rule {
-    SuspiciousRelaxedWaitCondition,
-    SuspiciousRelaxedPublishBeforeNotify,
+    WaitCondition,
+    PublishBeforeNotify,
+    MixedOrdering,
 }
 
 impl Rule {
     fn label(self) -> &'static str {
         match self {
-            Self::SuspiciousRelaxedWaitCondition => "suspicious_relaxed_wait_condition",
-            Self::SuspiciousRelaxedPublishBeforeNotify => {
-                "suspicious_relaxed_publish_before_notify"
-            }
+            Self::WaitCondition => "suspicious_relaxed_wait_condition",
+            Self::PublishBeforeNotify => "suspicious_relaxed_publish_before_notify",
+            Self::MixedOrdering => "suspicious_relaxed_mixed_ordering",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AccessOrdering {
+    Relaxed,
+    Strong,
+}
+
+#[derive(Debug, Clone)]
+struct AtomicAccess {
+    key: String,
+    span: Span,
+    ordering: AccessOrdering,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct AccessSummary {
+    has_relaxed: bool,
+    has_strong: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -148,6 +169,8 @@ struct Finding {
 struct Analyzer<'a> {
     path: &'a Path,
     lines: Vec<&'a str>,
+    accesses: Vec<AtomicAccess>,
+    sync_intent_keys: HashSet<String>,
     findings: Vec<Finding>,
 }
 
@@ -156,7 +179,42 @@ impl<'a> Analyzer<'a> {
         Self {
             path,
             lines: source.lines().collect(),
+            accesses: Vec::new(),
+            sync_intent_keys: HashSet::new(),
             findings: Vec::new(),
+        }
+    }
+
+    fn finish(&mut self) {
+        let mut summaries: HashMap<String, AccessSummary> = HashMap::new();
+        for access in &self.accesses {
+            let summary = summaries.entry(access.key.clone()).or_default();
+            match access.ordering {
+                AccessOrdering::Relaxed => summary.has_relaxed = true,
+                AccessOrdering::Strong => summary.has_strong = true,
+            }
+        }
+
+        let spans = self
+            .accesses
+            .iter()
+            .filter(|access| access.ordering == AccessOrdering::Relaxed)
+            .filter(|access| self.sync_intent_keys.contains(&access.key))
+            .filter(|access| {
+                summaries
+                    .get(&access.key)
+                    .is_some_and(|summary| summary.has_relaxed && summary.has_strong)
+            })
+            .map(|access| access.span)
+            .collect::<Vec<_>>();
+
+        for span in spans {
+            self.report(
+                span,
+                Rule::MixedOrdering,
+                "Relaxed atomic access is mixed with stronger orderings on the same \
+                 synchronization variable",
+            );
         }
     }
 
@@ -192,11 +250,18 @@ impl<'a> Analyzer<'a> {
         })
     }
 
+    fn mark_sync_intent_expr(&mut self, expr: &Expr) {
+        for access in atomic_accesses_in_expr(expr) {
+            self.sync_intent_keys.insert(access.key);
+        }
+    }
+
     fn check_wait_closure(&mut self, closure: &ExprClosure) {
+        self.mark_sync_intent_expr(&closure.body);
         if let Some(span) = first_relaxed_load(&closure.body) {
             self.report(
                 span,
-                Rule::SuspiciousRelaxedWaitCondition,
+                Rule::WaitCondition,
                 "Relaxed atomic load is used in a wait condition",
             );
         }
@@ -212,14 +277,17 @@ impl<'a> Analyzer<'a> {
             let [first, second] = pair else {
                 continue;
             };
-            if let Some(span) = relaxed_write_span(first)
+            if let Some(access) = atomic_write_access(first)
                 && is_notify_expr(second)
             {
-                self.report(
-                    span,
-                    Rule::SuspiciousRelaxedPublishBeforeNotify,
-                    "Relaxed atomic write is immediately followed by a wake/notify operation",
-                );
+                self.sync_intent_keys.insert(access.key);
+                if access.ordering == AccessOrdering::Relaxed {
+                    self.report(
+                        access.span,
+                        Rule::PublishBeforeNotify,
+                        "Relaxed atomic write is immediately followed by a wake/notify operation",
+                    );
+                }
             }
         }
     }
@@ -252,6 +320,9 @@ impl Visit<'_> for Analyzer<'_> {
     }
 
     fn visit_expr_method_call(&mut self, node: &ExprMethodCall) {
+        if let Some(access) = atomic_access_from_method_call(node) {
+            self.accesses.push(access);
+        }
         if is_wait_method(node.method.clone()) {
             for arg in &node.args {
                 if let Expr::Closure(closure) = arg {
@@ -266,11 +337,14 @@ impl Visit<'_> for Analyzer<'_> {
         if let Some(span) = first_relaxed_load(&node.cond)
             && block_contains_blocking_call(&node.body)
         {
+            self.mark_sync_intent_expr(&node.cond);
             self.report(
                 span,
-                Rule::SuspiciousRelaxedWaitCondition,
+                Rule::WaitCondition,
                 "Relaxed atomic load is used in a blocking loop condition",
             );
+        } else if block_contains_blocking_call(&node.body) {
+            self.mark_sync_intent_expr(&node.cond);
         }
         visit::visit_expr_while(self, node);
     }
@@ -335,7 +409,7 @@ fn is_notify_expr(expr: &Expr) -> bool {
     }
 }
 
-fn relaxed_write_span(expr: &Expr) -> Option<Span> {
+fn atomic_write_access(expr: &Expr) -> Option<AtomicAccess> {
     let Expr::MethodCall(method) = expr else {
         return None;
     };
@@ -353,11 +427,7 @@ fn relaxed_write_span(expr: &Expr) -> Option<Span> {
     ) {
         return None;
     }
-    method
-        .args
-        .last()
-        .filter(|ordering| is_relaxed_ordering(ordering))
-        .map(|_| method.span())
+    atomic_access_from_method_call(method)
 }
 
 fn first_relaxed_load(expr: &Expr) -> Option<Span> {
@@ -384,14 +454,69 @@ impl Visit<'_> for RelaxedLoadFinder {
     }
 }
 
-fn is_relaxed_ordering(expr: &Expr) -> bool {
-    let Expr::Path(path) = expr else {
-        return false;
+fn atomic_accesses_in_expr(expr: &Expr) -> Vec<AtomicAccess> {
+    let mut finder = AtomicAccessFinder {
+        accesses: Vec::new(),
     };
-    path.path
-        .segments
-        .last()
-        .is_some_and(|segment| segment.ident == "Relaxed")
+    finder.visit_expr(expr);
+    finder.accesses
+}
+
+struct AtomicAccessFinder {
+    accesses: Vec<AtomicAccess>,
+}
+
+impl Visit<'_> for AtomicAccessFinder {
+    fn visit_expr_method_call(&mut self, node: &ExprMethodCall) {
+        if let Some(access) = atomic_access_from_method_call(node) {
+            self.accesses.push(access);
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn atomic_access_from_method_call(node: &ExprMethodCall) -> Option<AtomicAccess> {
+    let ordering = match node.method.to_string().as_str() {
+        "load" if node.args.len() == 1 => atomic_ordering(&node.args[0])?,
+        "store" if node.args.len() == 2 => atomic_ordering(&node.args[1])?,
+        "swap" | "fetch_add" | "fetch_sub" | "fetch_or" | "fetch_and" | "fetch_xor"
+        | "fetch_max" | "fetch_min"
+            if !node.args.is_empty() =>
+        {
+            atomic_ordering(node.args.last()?)?
+        }
+        "compare_exchange" | "compare_exchange_weak" if node.args.len() == 4 => {
+            atomic_ordering(&node.args[2])?
+        }
+        "fetch_update" if node.args.len() == 3 => atomic_ordering(&node.args[0])?,
+        _ => return None,
+    };
+
+    Some(AtomicAccess {
+        key: receiver_key(&node.receiver),
+        span: node.span(),
+        ordering,
+    })
+}
+
+fn receiver_key(expr: &Expr) -> String {
+    expr.to_token_stream().to_string()
+}
+
+fn atomic_ordering(expr: &Expr) -> Option<AccessOrdering> {
+    let Expr::Path(path) = expr else {
+        return None;
+    };
+
+    match path.path.segments.last()?.ident.to_string().as_str() {
+        "Relaxed" => Some(AccessOrdering::Relaxed),
+        "Acquire" | "Release" | "AcqRel" | "SeqCst" => Some(AccessOrdering::Strong),
+        _ => None,
+    }
+}
+
+fn is_relaxed_ordering(expr: &Expr) -> bool {
+    atomic_ordering(expr).is_some_and(|ordering| ordering == AccessOrdering::Relaxed)
 }
 
 fn block_contains_blocking_call(block: &Block) -> bool {
@@ -460,7 +585,7 @@ fn demo(wq: WaitQueue, counter: &AtomicUsize) {
         assert!(
             findings
                 .iter()
-                .any(|finding| finding.rule == Rule::SuspiciousRelaxedWaitCondition)
+                .any(|finding| finding.rule == Rule::WaitCondition)
         );
     }
 
@@ -481,7 +606,7 @@ fn demo(flag: &AtomicBool) {
         assert!(
             findings
                 .iter()
-                .any(|finding| finding.rule == Rule::SuspiciousRelaxedWaitCondition)
+                .any(|finding| finding.rule == Rule::WaitCondition)
         );
     }
 
@@ -501,7 +626,7 @@ fn demo(flag: &AtomicBool, wq: WaitQueue) {
         assert!(
             findings
                 .iter()
-                .any(|finding| finding.rule == Rule::SuspiciousRelaxedPublishBeforeNotify)
+                .any(|finding| finding.rule == Rule::PublishBeforeNotify)
         );
     }
 
@@ -529,6 +654,91 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 fn demo(wq: WaitQueue, counter: &AtomicUsize) {
     // sync-lint: ignore suspicious_relaxed_wait_condition
     wq.wait_until(|| counter.load(Ordering::Relaxed) == 1);
+}
+"#,
+        );
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn reports_relaxed_mixed_ordering_for_sync_wait_variable() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicBool, Ordering};
+
+fn demo(flag: &AtomicBool, wq: WaitQueue) {
+    flag.store(true, Ordering::Relaxed);
+    wq.wait_until(|| flag.load(Ordering::Acquire));
+}
+"#,
+        );
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.rule == Rule::MixedOrdering)
+        );
+    }
+
+    #[test]
+    fn reports_relaxed_mixed_ordering_after_publish_notify() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicBool, Ordering};
+
+fn demo(flag: &AtomicBool, wq: WaitQueue) {
+    flag.store(true, Ordering::Release);
+    wq.notify_all(true);
+    let _ = flag.load(Ordering::Relaxed);
+}
+"#,
+        );
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.rule == Rule::MixedOrdering)
+        );
+    }
+
+    #[test]
+    fn ignores_mixed_ordering_without_sync_intent() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicU64, Ordering};
+
+struct PollFrequencyController {
+    consecutive_idle: AtomicU64,
+}
+
+impl PollFrequencyController {
+    fn current_interval(&self) -> u64 {
+        self.consecutive_idle.load(Ordering::Relaxed)
+    }
+
+    fn on_event(&self) {
+        self.consecutive_idle.store(0, Ordering::Release);
+    }
+}
+"#,
+        );
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_compare_exchange_failure_ordering() {
+        let findings = findings(
+            r#"
+use core::sync::atomic::{AtomicBool, Ordering};
+
+fn demo(flag: &AtomicBool) {
+    while flag.load(Ordering::Acquire) {
+        core::hint::spin_loop();
+    }
+
+    let _ = flag.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed);
 }
 "#,
         );


### PR DESCRIPTION
  - extend `sync-lint` to report suspicious mixed strong/relaxed ordering on the same synchronization atomic
  - keep false positives low by only elevating mixed-ordering findings after a variable is already recognized as having
  synchronization intent
  - avoid flagging compare-exchange failure orderings as mixed-ordering violations
  - clarify explicit ignore syntax in `docs/community/sync-lint.md`, including rule-specific ignore vs generic ignore
