### PR TITLE
fix(file): write on directory fd returns EBADF instead of EISDIR

### DIFF
--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -227,7 +227,10 @@ impl FileLike for Directory {
     }
 
     fn write(&self, _src: &mut IoSrc) -> AxResult<usize> {
-        Err(AxError::IsADirectory)
+        // Directories cannot be opened for writing, so any write attempt
+        // means the fd is not open for writing → EBADF.
+        // Linux VFS checks FMODE_WRITE before reaching the filesystem layer.
+        Err(AxError::BadFileDescriptor)
     }
 
     fn stat(&self) -> AxResult<Kstat> {

--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -31,6 +31,18 @@ fn file_or_espipe(fd: c_int) -> AxResult<Arc<File>> {
     })
 }
 
+/// Like `file_or_espipe`, but for write operations: converts IsADirectory
+/// to BadFileDescriptor because directories cannot be opened for writing.
+fn file_or_espipe_write(fd: c_int) -> AxResult<Arc<File>> {
+    file_or_espipe(fd).map_err(|e| {
+        if e == AxError::IsADirectory {
+            AxError::BadFileDescriptor
+        } else {
+            e
+        }
+    })
+}
+
 struct DummyFd;
 impl FileLike for DummyFd {
     fn path(&self) -> Cow<'_, str> {
@@ -215,7 +227,7 @@ pub fn sys_pwrite64(
     if len == 0 {
         return Ok(0);
     }
-    let f = file_or_espipe(fd)?;
+    let f = file_or_espipe_write(fd)?;
     let write = f.inner().write_at(VmBytes::new(buf, len), offset as _)?;
     Ok(write as _)
 }
@@ -266,7 +278,7 @@ pub fn sys_pwritev2(
     if offset < 0 {
         return Err(AxError::InvalidInput);
     }
-    let f = file_or_espipe(fd)?;
+    let f = file_or_espipe_write(fd)?;
     f.inner()
         .write_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)
         .map(|n| n as _)

--- a/test-suit/starryos/normal/bug-writev-dir-ebadf/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-writev-dir-ebadf/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-writev-dir-ebadf C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-writev-dir-ebadf src/main.c)
+target_compile_options(bug-writev-dir-ebadf PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-writev-dir-ebadf RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-writev-dir-ebadf/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-writev-dir-ebadf/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-writev-dir-ebadf/c/src/main.c
+++ b/test-suit/starryos/normal/bug-writev-dir-ebadf/c/src/main.c
@@ -1,0 +1,79 @@
+/*
+ * bug-writev-dir-ebadf: Reproduction test for writev/pwrite on directory errno
+ *
+ * Bug: StarryOS returns EISDIR(21) instead of EBADF(9) when writev/pwrite
+ * is called on a directory fd opened O_RDONLY|O_DIRECTORY.
+ *
+ * Per Linux kernel (vfs_writev in fs/read_write.c), the FMODE_WRITE check
+ * happens first at the VFS layer, returning EBADF before any filesystem
+ * operation that could return EISDIR.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/uio.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do { \
+    if (cond) { \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg); \
+        __pass++; \
+    } else { \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, errno, strerror(errno)); \
+        __fail++; \
+    } \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do { \
+    errno = 0; \
+    long _r = (long)(call); \
+    if (_r == -1 && errno == (exp_errno)) { \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n", \
+               __FILE__, __LINE__, msg, errno); \
+        __pass++; \
+    } else { \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno)); \
+        __fail++; \
+    } \
+} while(0)
+
+int main(void)
+{
+    printf("================================================\n");
+    printf("  TEST: bug-writev-dir-ebadf\n");
+    printf("================================================\n");
+
+    char dummy[] = "test";
+    struct iovec iov[1];
+    iov[0].iov_base = dummy;
+    iov[0].iov_len = 4;
+
+    /* 1. writev on O_RDONLY directory => EBADF (not EISDIR) */
+    int fd = open("/tmp", O_RDONLY | O_DIRECTORY);
+    CHECK(fd >= 0, "open /tmp as O_RDONLY|O_DIRECTORY");
+    CHECK_ERR(writev(fd, iov, 1), EBADF, "writev on directory => EBADF");
+    close(fd);
+
+    /* 2. pwrite64 on O_RDONLY directory => EBADF (not EISDIR) */
+    fd = open("/tmp", O_RDONLY | O_DIRECTORY);
+    CHECK(fd >= 0, "open /tmp as O_RDONLY|O_DIRECTORY (2)");
+    CHECK_ERR(pwrite(fd, dummy, 4, 0), EBADF, "pwrite64 on directory => EBADF");
+    close(fd);
+
+    printf("------------------------------------------------\n");
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);
+    printf("================================================\n");
+    if (__fail == 0) printf("ALL TESTS PASSED\n");
+    return __fail > 0 ? 1 : 0;
+}

--- a/test-suit/starryos/normal/bug-writev-dir-ebadf/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-writev-dir-ebadf/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-writev-dir-ebadf"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 15

--- a/test-suit/starryos/normal/bug-writev-dir-ebadf/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-writev-dir-ebadf/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-writev-dir-ebadf"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 15

--- a/test-suit/starryos/normal/bug-writev-dir-ebadf/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-writev-dir-ebadf/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-writev-dir-ebadf"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 15

--- a/test-suit/starryos/normal/bug-writev-dir-ebadf/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-writev-dir-ebadf/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-writev-dir-ebadf"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 15


### PR DESCRIPTION
# Fix writev/pwrite on directory returning EISDIR instead of EBADF

## Summary

`writev()` and `pwrite64()` on a directory fd opened with `O_RDONLY | O_DIRECTORY` returned `EISDIR` (errno 21) instead of `EBADF` (errno 9). Linux checks write permission at the VFS layer before any filesystem-specific checks.

## Root Cause

Two issues:

1. `Directory::write()` in `kernel/src/file/fs.rs` returned `AxError::IsADirectory`. Since directories cannot be opened for writing, any write attempt on a directory fd means the fd is not open for writing, which should be `EBADF`.

2. `sys_pwrite64` and `sys_pwritev2` used `file_or_espipe()` which passes through `IsADirectory` errors. Write-path syscalls need to convert this to `EBADF`.

## Fix

1. Changed `Directory::write()` to return `AxError::BadFileDescriptor` (EBADF) instead of `AxError::IsADirectory` (EISDIR). This fixes `writev()` and `write()` on directory fds.

2. Added `file_or_espipe_write()` helper that wraps `file_or_espipe()` and converts `IsADirectory` to `BadFileDescriptor`. Used by `sys_pwrite64`, `sys_pwritev`, and `sys_pwritev2`.

## Testing

Reproduction test `bug-writev-dir-ebadf`:
1. Open `/tmp` with `O_RDONLY | O_DIRECTORY`
2. Call `writev()` → verify errno == EBADF
3. Call `pwrite64()` → verify errno == EBADF

## Architecture Notes

All 4 architectures pass: riscv64, x86_64, aarch64, loongarch64. The fix is architecture-independent.
