### PR TITLE
fix(syscall): support preadv2/pwritev2 offset=-1 and reject unsupported flags

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -238,21 +238,36 @@ pub fn sys_pwritev(
     sys_pwritev2(fd, iov, iovcnt, offset, 0)
 }
 
+/// Validate preadv2/pwritev2 flags.
+/// Currently no RWF_* flags are supported; any non-zero value is rejected.
+fn validate_rwf_flags(flags: u32) -> AxResult<()> {
+    if flags != 0 {
+        return Err(AxError::OperationNotSupported);
+    }
+    Ok(())
+}
+
 pub fn sys_preadv2(
     fd: c_int,
     iov: *const IoVec,
     iovcnt: usize,
     offset: __kernel_off_t,
-    _flags: u32,
+    flags: u32,
 ) -> AxResult<isize> {
-    debug!("sys_preadv2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {_flags}");
-    if offset < 0 {
+    debug!("sys_preadv2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {flags}");
+    validate_rwf_flags(flags)?;
+    if offset < -1 {
         return Err(AxError::InvalidInput);
     }
-    let f = file_or_espipe(fd)?;
-    f.inner()
-        .read_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)
-        .map(|n| n as _)
+    let mut io_buf = IoVectorBuf::new(iov, iovcnt)?.into_io();
+    if offset == -1 {
+        // offset == -1: use current file position (like readv)
+        let f = get_file_like(fd)?;
+        f.read(&mut io_buf).map(|n| n as _)
+    } else {
+        let f = file_or_espipe(fd)?;
+        f.inner().read_at(io_buf, offset as _).map(|n| n as _)
+    }
 }
 
 pub fn sys_pwritev2(
@@ -260,16 +275,22 @@ pub fn sys_pwritev2(
     iov: *const IoVec,
     iovcnt: usize,
     offset: __kernel_off_t,
-    _flags: u32,
+    flags: u32,
 ) -> AxResult<isize> {
-    debug!("sys_pwritev2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {_flags}");
-    if offset < 0 {
+    debug!("sys_pwritev2 <= fd: {fd}, iovcnt: {iovcnt}, offset: {offset}, flags: {flags}");
+    validate_rwf_flags(flags)?;
+    if offset < -1 {
         return Err(AxError::InvalidInput);
     }
-    let f = file_or_espipe(fd)?;
-    f.inner()
-        .write_at(IoVectorBuf::new(iov, iovcnt)?.into_io(), offset as _)
-        .map(|n| n as _)
+    let mut io_buf = IoVectorBuf::new(iov, iovcnt)?.into_io();
+    if offset == -1 {
+        // offset == -1: use current file position (like writev)
+        let f = get_file_like(fd)?;
+        f.write(&mut io_buf).map(|n| n as _)
+    } else {
+        let f = file_or_espipe(fd)?;
+        f.inner().write_at(io_buf, offset as _).map(|n| n as _)
+    }
 }
 
 enum SendFile {

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -192,19 +192,21 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg2() as _,
             uctx.arg3() as _,
         ),
+        // Kernel ABI: SYSCALL_DEFINE6(preadv2, fd, vec, vlen, pos_l, pos_h, flags)
+        // arg4 is pos_h (high 32 bits of offset, always 0 on 64-bit); flags is arg5.
         Sysno::preadv2 => sys_preadv2(
-            uctx.arg0() as _,
-            uctx.arg1() as _,
-            uctx.arg2() as _,
-            uctx.arg3() as _,
-            uctx.arg4() as _,
+            uctx.arg0() as _, // fd
+            uctx.arg1() as _, // iov
+            uctx.arg2() as _, // iovcnt
+            uctx.arg3() as _, // offset (pos_l)
+            uctx.arg5() as _, // flags (arg4=pos_h is skipped)
         ),
         Sysno::pwritev2 => sys_pwritev2(
-            uctx.arg0() as _,
-            uctx.arg1() as _,
-            uctx.arg2() as _,
-            uctx.arg3() as _,
-            uctx.arg4() as _,
+            uctx.arg0() as _, // fd
+            uctx.arg1() as _, // iov
+            uctx.arg2() as _, // iovcnt
+            uctx.arg3() as _, // offset (pos_l)
+            uctx.arg5() as _, // flags (arg4=pos_h is skipped)
         ),
         Sysno::sendfile => sys_sendfile(
             uctx.arg0() as _,

--- a/test-suit/starryos/normal/bug-preadv2-invalid-flags/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-preadv2-invalid-flags/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-preadv2-invalid-flags C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-preadv2-invalid-flags src/main.c)
+target_compile_options(bug-preadv2-invalid-flags PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-preadv2-invalid-flags RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-preadv2-invalid-flags/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-preadv2-invalid-flags/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-preadv2-invalid-flags/c/src/main.c
+++ b/test-suit/starryos/normal/bug-preadv2-invalid-flags/c/src/main.c
@@ -1,0 +1,88 @@
+/*
+ * bug-preadv2-invalid-flags: preadv2/pwritev2 accept invalid RWF_* flags
+ *
+ * Bug: StarryOS silently accepts invalid flags (e.g. 0x80) for preadv2
+ * and pwritev2 instead of returning EOPNOTSUPP.
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/uio.h>
+#include <sys/syscall.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do { \
+    if (cond) { \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg); \
+        __pass++; \
+    } else { \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, errno, strerror(errno)); \
+        __fail++; \
+    } \
+} while(0)
+
+#define TMPFILE "/tmp/starry_bug_invalid_flags"
+
+static ssize_t my_preadv2(int fd, const struct iovec *iov, int iovcnt,
+                           off_t offset, int flags)
+{
+    return syscall(SYS_preadv2, fd, iov, iovcnt,
+                   (unsigned long)offset, (unsigned long)0, flags);
+}
+
+static ssize_t my_pwritev2(int fd, const struct iovec *iov, int iovcnt,
+                            off_t offset, int flags)
+{
+    return syscall(SYS_pwritev2, fd, iov, iovcnt,
+                   (unsigned long)offset, (unsigned long)0, flags);
+}
+
+int main(void)
+{
+    printf("================================================\n");
+    printf("  TEST: bug-preadv2-invalid-flags\n");
+    printf("================================================\n");
+
+    char buf[32];
+    struct iovec iov[1];
+    ssize_t n;
+    int bad_flags = 0x80; /* not a valid RWF_* flag */
+
+    int fd = open(TMPFILE, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    CHECK(fd >= 0, "create temp file");
+    write(fd, "ABCD", 4);
+
+    /* preadv2 with invalid flags => EOPNOTSUPP */
+    iov[0].iov_base = buf;
+    iov[0].iov_len = 4;
+    errno = 0;
+    n = my_preadv2(fd, iov, 1, 0, bad_flags);
+    CHECK(n == -1 && (errno == EOPNOTSUPP || errno == EINVAL),
+          "preadv2 invalid flags => EOPNOTSUPP or EINVAL");
+
+    /* pwritev2 with invalid flags => EOPNOTSUPP */
+    char wdata[] = "XXXX";
+    iov[0].iov_base = wdata;
+    iov[0].iov_len = 4;
+    errno = 0;
+    n = my_pwritev2(fd, iov, 1, 0, bad_flags);
+    CHECK(n == -1 && (errno == EOPNOTSUPP || errno == EINVAL),
+          "pwritev2 invalid flags => EOPNOTSUPP or EINVAL");
+
+    close(fd);
+    unlink(TMPFILE);
+
+    printf("------------------------------------------------\n");
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);
+    printf("================================================\n");
+    if (__fail == 0) printf("ALL TESTS PASSED\n");
+    return __fail > 0 ? 1 : 0;
+}

--- a/test-suit/starryos/normal/bug-preadv2-invalid-flags/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-preadv2-invalid-flags/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-preadv2-invalid-flags"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 15

--- a/test-suit/starryos/normal/bug-preadv2-invalid-flags/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-preadv2-invalid-flags/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-preadv2-invalid-flags"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 15

--- a/test-suit/starryos/normal/bug-preadv2-invalid-flags/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-preadv2-invalid-flags/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-preadv2-invalid-flags"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 15

--- a/test-suit/starryos/normal/bug-preadv2-invalid-flags/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-preadv2-invalid-flags/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-preadv2-invalid-flags"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 15

--- a/test-suit/starryos/normal/bug-preadv2-offset-neg1/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-preadv2-offset-neg1/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-preadv2-offset-neg1 C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-preadv2-offset-neg1 src/main.c)
+target_compile_options(bug-preadv2-offset-neg1 PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-preadv2-offset-neg1 RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-preadv2-offset-neg1/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-preadv2-offset-neg1/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-preadv2-offset-neg1/c/src/main.c
+++ b/test-suit/starryos/normal/bug-preadv2-offset-neg1/c/src/main.c
@@ -1,0 +1,134 @@
+/*
+ * bug-preadv2-offset-neg1: Reproduction test for preadv2/pwritev2 offset=-1
+ *
+ * Bug: StarryOS does not support offset=-1 for preadv2/pwritev2.
+ * Per Linux man page, offset=-1 means "use the current file position"
+ * (like readv/writev). StarryOS returns -1 with errno=0.
+ *
+ * Covers: preadv2 offset=-1 on file, pwritev2 offset=-1 on file,
+ *         preadv2 offset=-1 on pipe, pwritev2 offset=-1 on pipe.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/uio.h>
+#include <sys/syscall.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do { \
+    if (cond) { \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg); \
+        __pass++; \
+    } else { \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, errno, strerror(errno)); \
+        __fail++; \
+    } \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do { \
+    errno = 0; \
+    long _r = (long)(call); \
+    long _e = (long)(expected); \
+    if (_r == _e) { \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n", \
+               __FILE__, __LINE__, msg, _r); \
+        __pass++; \
+    } else { \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno)); \
+        __fail++; \
+    } \
+} while(0)
+
+#define TMPFILE "/tmp/starry_bug_preadv2_neg1"
+
+static ssize_t my_preadv2(int fd, const struct iovec *iov, int iovcnt,
+                           off_t offset, int flags)
+{
+    return syscall(SYS_preadv2, fd, iov, iovcnt,
+                   (unsigned long)offset, (unsigned long)0, flags);
+}
+
+static ssize_t my_pwritev2(int fd, const struct iovec *iov, int iovcnt,
+                            off_t offset, int flags)
+{
+    return syscall(SYS_pwritev2, fd, iov, iovcnt,
+                   (unsigned long)offset, (unsigned long)0, flags);
+}
+
+int main(void)
+{
+    printf("================================================\n");
+    printf("  TEST: bug-preadv2-offset-neg1\n");
+    printf("================================================\n");
+
+    char buf[32];
+    struct iovec iov[1];
+    ssize_t n;
+
+    /* 1. preadv2 offset=-1 on regular file: reads from current position */
+    int fd = open(TMPFILE, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    CHECK(fd >= 0, "create temp file");
+    write(fd, "ABCDEFGH", 8);
+    lseek(fd, 4, SEEK_SET);
+
+    memset(buf, 0, sizeof(buf));
+    iov[0].iov_base = buf;
+    iov[0].iov_len = 4;
+    n = my_preadv2(fd, iov, 1, -1, 0);
+    CHECK_RET(n, 4, "preadv2 offset=-1 on file reads from pos 4");
+    CHECK(memcmp(buf, "EFGH", 4) == 0, "preadv2 offset=-1 data = EFGH");
+
+    /* 2. pwritev2 offset=-1 on regular file: writes at current position */
+    lseek(fd, 2, SEEK_SET);
+    char wdata[] = "QQ";
+    iov[0].iov_base = wdata;
+    iov[0].iov_len = 2;
+    n = my_pwritev2(fd, iov, 1, -1, 0);
+    CHECK_RET(n, 2, "pwritev2 offset=-1 on file writes at pos 2");
+
+    memset(buf, 0, sizeof(buf));
+    pread(fd, buf, 8, 0);
+    CHECK(memcmp(buf, "ABQQEFGH", 8) == 0, "pwritev2 offset=-1 data correct");
+    close(fd);
+
+    /* 3. preadv2 offset=-1 on pipe: reads like readv */
+    int pipefd[2];
+    CHECK(pipe(pipefd) == 0, "create pipe");
+    write(pipefd[1], "PIPE", 4);
+
+    memset(buf, 0, sizeof(buf));
+    iov[0].iov_base = buf;
+    iov[0].iov_len = 4;
+    n = my_preadv2(pipefd[0], iov, 1, -1, 0);
+    CHECK_RET(n, 4, "preadv2 offset=-1 on pipe reads OK");
+    CHECK(memcmp(buf, "PIPE", 4) == 0, "preadv2 pipe data = PIPE");
+
+    /* 4. pwritev2 offset=-1 on pipe: writes like writev */
+    char pdata[] = "WRIT";
+    iov[0].iov_base = pdata;
+    iov[0].iov_len = 4;
+    n = my_pwritev2(pipefd[1], iov, 1, -1, 0);
+    CHECK_RET(n, 4, "pwritev2 offset=-1 on pipe writes OK");
+
+    close(pipefd[0]);
+    close(pipefd[1]);
+    unlink(TMPFILE);
+
+    printf("------------------------------------------------\n");
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);
+    printf("================================================\n");
+    if (__fail == 0) printf("ALL TESTS PASSED\n");
+    return __fail > 0 ? 1 : 0;
+}

--- a/test-suit/starryos/normal/bug-preadv2-offset-neg1/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-preadv2-offset-neg1/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-preadv2-offset-neg1"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 30

--- a/test-suit/starryos/normal/bug-preadv2-offset-neg1/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-preadv2-offset-neg1/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-preadv2-offset-neg1"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 30

--- a/test-suit/starryos/normal/bug-preadv2-offset-neg1/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-preadv2-offset-neg1/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-preadv2-offset-neg1"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 30

--- a/test-suit/starryos/normal/bug-preadv2-offset-neg1/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-preadv2-offset-neg1/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-preadv2-offset-neg1"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b|FAIL\s*\|']
+timeout = 30

--- a/test-suit/starryos/normal/bug-pwritev2-read-at/c/src/main.c
+++ b/test-suit/starryos/normal/bug-pwritev2-read-at/c/src/main.c
@@ -52,8 +52,13 @@ int main(void)
     iov[1].iov_base = buf2;
     iov[1].iov_len = sizeof(buf2) - 1;
 
+    /* pwritev2 kernel ABI: fd, iov, iovcnt, pos_l, pos_h, flags
+     * On 64-bit, pos_h is always 0 but the slot must still be passed. */
     errno = 0;
-    ssize_t ret = syscall(SYS_pwritev2, fd, iov, 2, 0, 0);
+    ssize_t ret = syscall(SYS_pwritev2, fd, iov, 2,
+                          (unsigned long)0,  /* pos_l */
+                          (unsigned long)0,  /* pos_h */
+                          0);                /* flags */
 
     printf("pwritev2 returned: %zd\n", ret);
     printf("Expected: %zu (total bytes written)\n\n", iov[0].iov_len + iov[1].iov_len);


### PR DESCRIPTION
# Fix preadv2/pwritev2: offset=-1 support and flag validation

## Summary

Two bugs in `sys_preadv2`/`sys_pwritev2` where the implementation was incomplete compared to the Linux specification:

1. `offset=-1` was rejected with EINVAL instead of being treated as "use current file position" (like readv/writev)
2. All `RWF_*` flags (including invalid ones like `0x80`) were silently accepted instead of returning EOPNOTSUPP

## Root Cause

In `kernel/src/syscall/fs/io.rs`, both `sys_preadv2` and `sys_pwritev2` had:
- `if offset < 0 { return Err(InvalidInput); }` — rejecting ALL negative offsets, including the special `-1` value
- `_flags: u32` — the flags parameter was prefixed with `_` and completely unused

Per the Linux `preadv2(2)` man page:
- `offset == -1` means "use the current file offset, and update it" (equivalent to readv/writev)
- Only `offset < -1` should return EINVAL
- Unsupported flags must return EOPNOTSUPP

## Fix

1. Changed offset validation from `offset < 0` to `offset < -1`
2. When `offset == -1`, dispatch to `get_file_like(fd).read()`/`.write()` which uses the current file position — this also correctly handles pipes (which support readv/writev but not preadv/pwritev with explicit offsets)
3. Added `validate_rwf_flags()` that returns EOPNOTSUPP for any non-zero flags value. StarryOS does not yet support any RWF_* flags (RWF_APPEND, RWF_DSYNC, etc.), so all flags are rejected explicitly rather than silently ignored.

## ⚠️ Existing test fix included

The flag validation change exposed a latent bug in the existing `bug-pwritev2-read-at` test: it called `syscall(SYS_pwritev2, fd, iov, 2, 0, 0)` with only 5 arguments. The kernel ABI requires 6 (`fd, vec, vlen, pos_l, pos_h, flags`), so the missing `flags` argument was whatever garbage happened to be in the register. Previously harmless because flags were ignored; now triggers EOPNOTSUPP. Fixed by adding the explicit `flags=0` sixth argument.

## Testing

Reproduction tests (all pass after fix, all fail before):
- `bug-preadv2-offset-neg1`: Tests offset=-1 on regular files and pipes for both preadv2 and pwritev2
- `bug-preadv2-invalid-flags`: Tests that invalid flags (0x80) return EOPNOTSUPP

## Architecture Notes

All 4 architectures pass: riscv64, x86_64, aarch64, loongarch64. The fix is architecture-independent (pure syscall handler logic).
