### PR TITLE
fix(axfs-ng-vfs): preserve page cache across DirNode rename

### DIFF
--- a/test-suit/starryos/normal/bug-rename-replace/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-rename-replace/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-rename-replace C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-rename-replace src/main.c)
+target_compile_options(bug-rename-replace PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-rename-replace RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-rename-replace/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-rename-replace/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-rename-replace/c/src/main.c
+++ b/test-suit/starryos/normal/bug-rename-replace/c/src/main.c
@@ -1,0 +1,227 @@
+/*
+ * bug-rename-replace.c — rename(2) 替换已存在文件的行为验证
+ *
+ * Bug 背景：
+ *   GNU sed -i (in-place 编辑) 在 StarryOS 上产生空文件。
+ *   例如: echo "hello" > /tmp/f; sed -i 's/hello/world/' /tmp/f
+ *   预期: /tmp/f 内容为 "world"
+ *   实际: /tmp/f 内容为空字符串
+ *
+ * 根因分析：
+ *   GNU sed 实现 -i 的步骤:
+ *     1. open(原文件, O_RDONLY)                — 读取原始内容
+ *     2. mkstemp(同目录临时文件)                — 创建临时文件
+ *     3. 将修改后内容 write 到临时文件
+ *     4. close 临时文件
+ *     5. rename(临时文件路径, 原文件路径)        — 原子替换
+ *
+ *   POSIX rename(2) 语义: 当 newpath 已存在时，原子性地用 oldpath
+ *   替换 newpath（oldpath 消失，newpath 指向原 oldpath 的内容）。
+ *
+ *   在 StarryOS 上，rename 替换已存在文件时，原文件的目录项被移除，
+ *   但临时文件的内容未能正确链接到原路径，导致原文件变为空文件。
+ *
+ * 触发条件：
+ *   rename(新文件, 已存在文件) — newpath 必须已存在才会触发此 bug
+ *   rename(新文件, 不存在路径) — 正常工作
+ *
+ * 测试覆盖：
+ *   1. rename(temp, existing)          — 基本替换，验证内容
+ *   2. rename(temp, existing) + fd 打开 — 模拟 sed 同时持有原文件 fd
+ *   3. 完整 sed -i 模拟                — write temp → close → rename → verify
+ *   4. 交叉大小验证                    — 确认替换后文件大小来自 temp
+ *   5. rename(temp, nonexist)          — 对照组：目标不存在时是否正常
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* ========== 测试框架 ========== */
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define CHECK(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            printf("  [FAIL] %s (errno=%d %s)\n", (msg), errno, strerror(errno)); \
+            test_failed++; \
+        } else { \
+            printf("  [OK] %s\n", (msg)); \
+            test_passed++; \
+        } \
+    } while(0)
+
+/* ========== 辅助函数 ========== */
+
+static int write_file(const char *path, const char *data)
+{
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) return -1;
+    size_t len = strlen(data);
+    ssize_t w = write(fd, data, len);
+    close(fd);
+    return (w == (ssize_t)len) ? 0 : -1;
+}
+
+static int read_file(const char *path, char *buf, int bufsz)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) return -1;
+    int n = (int)read(fd, buf, bufsz - 1);
+    close(fd);
+    if (n < 0) return -1;
+    buf[n] = '\0';
+    return n;
+}
+
+int main(void)
+{
+    printf("[TEST] rename: replacing an existing file (sed -i pattern)\n\n");
+
+    const char *original = "/tmp/bug_rename_original.txt";
+    const char *tempfile  = "/tmp/bug_rename_temp.txt";
+    const char *target3   = "/tmp/bug_rename_nonexist.txt";
+
+    /* 预清理 */
+    unlink(original);
+    unlink(tempfile);
+    unlink(target3);
+
+    /* ---- Test 1: 基本 rename 替换 ---- */
+    printf("== Test 1: rename(temp, existing) — basic replace ==\n");
+    {
+        write_file(original, "OLD CONTENT\n");
+        write_file(tempfile,  "NEW CONTENT\n");
+
+        errno = 0;
+        int rc = rename(tempfile, original);
+        CHECK(rc == 0, "rename(temp, original) returns 0");
+
+        char buf[256] = {0};
+        int n = read_file(original, buf, sizeof(buf));
+        CHECK(n > 0, "original file is not empty after rename");
+        CHECK(strcmp(buf, "NEW CONTENT\n") == 0,
+              "original file has new content (NEW CONTENT)");
+
+        CHECK(access(tempfile, F_OK) != 0 && errno == ENOENT,
+              "temp file no longer exists (ENOENT)");
+    }
+
+    /* ---- Test 2: rename 时原文件 fd 仍打开 (模拟 sed 读原文件) ---- */
+    printf("\n== Test 2: rename with original fd open (sed read pattern) ==\n");
+    {
+        write_file(original, "BEFORE\n");
+        write_file(tempfile,  "AFTER\n");
+
+        /* sed 打开原文件读取 */
+        int fd_orig = open(original, O_RDONLY);
+        CHECK(fd_orig >= 0, "open original for reading");
+
+        char buf_before[64] = {0};
+        read(fd_orig, buf_before, sizeof(buf_before));
+        CHECK(strcmp(buf_before, "BEFORE\n") == 0,
+              "original content readable via open fd");
+
+        /* sed 写临时文件 */
+        write_file(tempfile, "AFTER\n");
+
+        /* sed 执行 rename */
+        errno = 0;
+        int rc = rename(tempfile, original);
+        CHECK(rc == 0, "rename(temp, original) with fd open returns 0");
+
+        /* 通过路径读取 — 应看到新内容 */
+        char buf_after[64] = {0};
+        int n = read_file(original, buf_after, sizeof(buf_after));
+        CHECK(n > 0, "original path is not empty after rename");
+        CHECK(strcmp(buf_after, "AFTER\n") == 0,
+              "original path has new content (AFTER)");
+
+        close(fd_orig);
+
+        /* 关闭 fd 后再验证一次 */
+        char buf_final[64] = {0};
+        read_file(original, buf_final, sizeof(buf_final));
+        CHECK(strcmp(buf_final, "AFTER\n") == 0,
+              "content persists after closing original fd");
+    }
+
+    /* ---- Test 3: 完整 sed -i 模拟 ---- */
+    printf("\n== Test 3: full sed -i simulation ==\n");
+    {
+        write_file(original, "foo bar baz\n");
+
+        /* 模拟 sed: 在同目录创建临时文件, 写入替换后内容 */
+        write_file(tempfile, "foo replaced baz\n");
+
+        errno = 0;
+        int rc = rename(tempfile, original);
+        CHECK(rc == 0, "rename returns 0");
+
+        char buf[256] = {0};
+        read_file(original, buf, sizeof(buf));
+        CHECK(strcmp(buf, "foo replaced baz\n") == 0,
+              "file has replaced content (foo replaced baz)");
+        CHECK(strstr(buf, "bar") == NULL,
+              "old substring 'bar' no longer present");
+    }
+
+    /* ---- Test 4: 交叉大小验证 ---- */
+    printf("\n== Test 4: file size after rename (cross-size) ==\n");
+    {
+        write_file(original, "AAAAAAAAAA\n");  /* 11 bytes */
+        write_file(tempfile,  "BBB\n");         /*  4 bytes */
+
+        errno = 0;
+        int rc = rename(tempfile, original);
+        CHECK(rc == 0, "rename returns 0");
+
+        struct stat st;
+        CHECK(stat(original, &st) == 0, "stat succeeds");
+        CHECK(st.st_size == 4,
+              "file size is 4 (from temp), not 11 (from original)");
+
+        char buf[64] = {0};
+        read_file(original, buf, sizeof(buf));
+        CHECK(strcmp(buf, "BBB\n") == 0,
+              "content is BBB (from temp), not AAAA (from original)");
+    }
+
+    /* ---- Test 5: 对照组 — 目标不存在时 rename ---- */
+    printf("\n== Test 5: rename(temp, nonexist) — control group ==\n");
+    {
+        write_file(tempfile, "CONTROL\n");
+        unlink(target3);  /* 确保目标不存在 */
+
+        errno = 0;
+        int rc = rename(tempfile, target3);
+        CHECK(rc == 0, "rename(temp, nonexist) returns 0");
+
+        char buf[64] = {0};
+        read_file(target3, buf, sizeof(buf));
+        CHECK(strcmp(buf, "CONTROL\n") == 0,
+              "target file has temp content (CONTROL)");
+
+        CHECK(access(tempfile, F_OK) != 0,
+              "source file no longer exists");
+    }
+
+    /* 清理 */
+    unlink(original);
+    unlink(tempfile);
+    unlink(target3);
+
+    printf("\n=== 结果: %d 通过, %d 失败 ===\n", test_passed, test_failed);
+    if (test_failed == 0) {
+        printf("TEST PASSED\n");
+        return EXIT_SUCCESS;
+    }
+    return EXIT_FAILURE;
+}

--- a/test-suit/starryos/normal/bug-rename-replace/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-rename-replace/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-rename-replace"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/bug-rename-replace/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-rename-replace/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+shell_init_cmd = "/usr/bin/bug-rename-replace"
+shell_prefix = "root@starry:"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+to_bin = true
+uefi = false
+timeout = 15

--- a/test-suit/starryos/normal/bug-rename-replace/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-rename-replace/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-rename-replace"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/bug-rename-replace/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-rename-replace/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-rename-replace"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 15

--- a/test-suit/starryos/normal/grep/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/grep/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(grep-sed-awk-test C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(grep-sed-awk-test src/main.c)
+target_compile_options(grep-sed-awk-test PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS grep-sed-awk-test RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/grep/c/prebuild.sh
+++ b/test-suit/starryos/normal/grep/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add grep sed gawk binutils gcc musl-dev

--- a/test-suit/starryos/normal/grep/c/src/main.c
+++ b/test-suit/starryos/normal/grep/c/src/main.c
@@ -1,0 +1,309 @@
+/*
+ * grep-sed-awk-test.c -- grep 4.x / sed 4.x / awk 5.x (gawk) 联合验证
+ *
+ * 关键依赖: regex, mmap, pipe
+ * 验收标准:
+ *   - grep -r "pattern" /etc
+ *   - sed -i 基本替换
+ *   - awk 基本字段处理 + pattern action
+ *   - 三者管道联合: grep | sed | awk
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+static int run(const char *cmd)
+{
+    int ret = system(cmd);
+    if (WIFEXITED(ret))
+        return WEXITSTATUS(ret);
+    return -1;
+}
+
+/* 读文件首行到 buf, 返回长度 */
+static int read_first_line(const char *path, char *buf, int bufsz)
+{
+    FILE *f = fopen(path, "r");
+    if (!f) return -1;
+    if (!fgets(buf, bufsz, f)) { fclose(f); return -1; }
+    int len = (int)strlen(buf);
+    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+        buf[--len] = '\0';
+    fclose(f);
+    return len;
+}
+
+/* 写文件 */
+static int write_file(const char *path, const char *data)
+{
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0) return -1;
+    size_t len = strlen(data);
+    ssize_t w = write(fd, data, len);
+    close(fd);
+    return (w == (ssize_t)len) ? 0 : -1;
+}
+
+int main(void)
+{
+    int pass = 0, fail = 0;
+    const char *tmp = "/tmp/gsa_test.txt";
+
+    printf("=== grep/sed/awk combined test ===\n");
+
+    /* ================================================================
+     *  grep 4.x
+     * ================================================================ */
+
+    /* 1. pipe grep: 匹配 → exit 0 */
+    {
+        int rc = run("echo 'hello world' | grep -q 'hello'");
+        if (rc == 0) { printf("  PASS | grep pipe match\n"); pass++; }
+        else         { printf("  FAIL | grep pipe match (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 2. pipe grep: 不匹配 → exit 1 */
+    {
+        int rc = run("echo 'foo bar' | grep -q 'baz'");
+        if (rc == 1) { printf("  PASS | grep pipe no-match\n"); pass++; }
+        else         { printf("  FAIL | grep pipe no-match (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 3. grep -r 递归搜索 /etc */
+    {
+        int rc = run("grep -rq 'root' /etc");
+        if (rc == 0) { printf("  PASS | grep -r 'root' /etc\n"); pass++; }
+        else         { printf("  FAIL | grep -r 'root' /etc (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 4. grep -r 不存在的字符串 → exit 1 */
+    {
+        int rc = run("grep -rq 'ZZZ_NO_SUCH_12345' /etc 2>/dev/null");
+        if (rc == 1) { printf("  PASS | grep -r no-match\n"); pass++; }
+        else         { printf("  FAIL | grep -r no-match (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 5. grep regex */
+    {
+        int rc = run("echo 'abc123' | grep -q '[0-9]\\{3\\}'");
+        if (rc == 0) { printf("  PASS | grep regex\n"); pass++; }
+        else         { printf("  FAIL | grep regex (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 6. grep -i 忽略大小写 */
+    {
+        int rc = run("echo 'Hello' | grep -qi 'hello'");
+        if (rc == 0) { printf("  PASS | grep -i\n"); pass++; }
+        else         { printf("  FAIL | grep -i (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 7. grep -v 反向匹配 */
+    {
+        int rc = run("echo -e 'aaa\\nbbb' | grep -v 'aaa' | grep -q 'bbb'");
+        if (rc == 0) { printf("  PASS | grep -v\n"); pass++; }
+        else         { printf("  FAIL | grep -v (rc=%d)\n", rc); fail++; }
+    }
+
+    /* ================================================================
+     *  sed 4.x
+     * ================================================================ */
+
+    /* 8. pipe sed s/// 替换 */
+    {
+        int rc = run("echo 'hello world' | sed 's/hello/hi/' | grep -q '^hi world$'");
+        if (rc == 0) { printf("  PASS | sed pipe s///\n"); pass++; }
+        else         { printf("  FAIL | sed pipe s/// (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 9. pipe sed s///g 全局替换 */
+    {
+        int rc = run("echo 'aaa bbb aaa' | sed 's/aaa/xxx/g' | grep -q '^xxx bbb xxx$'");
+        if (rc == 0) { printf("  PASS | sed s///g\n"); pass++; }
+        else         { printf("  FAIL | sed s///g (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 10. sed -i 基本替换 (验收标准) */
+    {
+        write_file(tmp, "foo bar baz\n");
+        int rc = run("sed -i 's/bar/replaced/' /tmp/gsa_test.txt");
+        if (rc == 0) {
+            char buf[256] = {0};
+            read_first_line(tmp, buf, sizeof(buf));
+            if (strcmp(buf, "foo replaced baz") == 0) {
+                printf("  PASS | sed -i s///\n"); pass++;
+            } else {
+                printf("  FAIL | sed -i s/// (got '%s')\n", buf); fail++;
+            }
+        } else {
+            printf("  FAIL | sed -i s/// (rc=%d)\n", rc); fail++;
+        }
+        unlink(tmp);
+    }
+
+    /* 11. sed -i 删除行 */
+    {
+        write_file(tmp, "keep\ndelete\nkeep2\n");
+        int rc = run("sed -i '/delete/d' /tmp/gsa_test.txt");
+        if (rc == 0) {
+            rc = run("grep -q 'delete' /tmp/gsa_test.txt");
+            if (rc != 0) {
+                rc = run("grep -q 'keep' /tmp/gsa_test.txt");
+                if (rc == 0) { printf("  PASS | sed -i /d\n"); pass++; }
+                else         { printf("  FAIL | sed -i /d (keep lines lost)\n"); fail++; }
+            } else {
+                printf("  FAIL | sed -i /d (line not deleted)\n"); fail++;
+            }
+        } else {
+            printf("  FAIL | sed -i /d (rc=%d)\n", rc); fail++;
+        }
+        unlink(tmp);
+    }
+
+    /* 12. sed -i -e 多次替换 */
+    {
+        write_file(tmp, "one two three\n");
+        int rc = run("sed -i -e 's/one/1/' -e 's/two/2/' -e 's/three/3/' /tmp/gsa_test.txt");
+        if (rc == 0) {
+            char buf[256] = {0};
+            read_first_line(tmp, buf, sizeof(buf));
+            if (strcmp(buf, "1 2 3") == 0) {
+                printf("  PASS | sed -i -e multi\n"); pass++;
+            } else {
+                printf("  FAIL | sed -i -e multi (got '%s')\n", buf); fail++;
+            }
+        } else {
+            printf("  FAIL | sed -i -e multi (rc=%d)\n", rc); fail++;
+        }
+        unlink(tmp);
+    }
+
+    /* 13. sed -n '2p' 打印指定行 */
+    {
+        int rc = run("echo -e 'line1\\nline2\\nline3' | sed -n '2p' | grep -q '^line2$'");
+        if (rc == 0) { printf("  PASS | sed -n 2p\n"); pass++; }
+        else         { printf("  FAIL | sed -n 2p (rc=%d)\n", rc); fail++; }
+    }
+
+    /* ================================================================
+     *  awk 5.x (gawk)
+     * ================================================================ */
+
+    /* 14. awk 基本字段 $1 $2 */
+    {
+        int rc = run("echo 'hello world' | awk '{print $2}' | grep -q '^world$'");
+        if (rc == 0) { printf("  PASS | awk field $2\n"); pass++; }
+        else         { printf("  FAIL | awk field $2 (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 15. awk NR 行号 */
+    {
+        int rc = run("echo -e 'aa\\nbb\\ncc' | awk 'END{print NR}' | grep -q '^3$'");
+        if (rc == 0) { printf("  PASS | awk NR\n"); pass++; }
+        else         { printf("  FAIL | awk NR (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 16. awk BEGIN/END */
+    {
+        int rc = run("echo 'data' | awk 'BEGIN{print \"START\"} {print} END{print \"END\"}' "
+                      "| grep -qc 'START'");
+        if (rc == 0) { printf("  PASS | awk BEGIN/END\n"); pass++; }
+        else         { printf("  FAIL | awk BEGIN/END (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 17. awk 条件匹配 */
+    {
+        int rc = run("echo -e '1\\n2\\n3\\n4\\n5' | awk '$1>3{print}' "
+                      "| grep -c '^[4-5]$' | grep -q '^2$'");
+        if (rc == 0) { printf("  PASS | awk condition\n"); pass++; }
+        else         { printf("  FAIL | awk condition (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 18. awk 算术 + printf */
+    {
+        int rc = run("echo '10 20' | awk '{printf \"%d\\n\", $1+$2}' | grep -q '^30$'");
+        if (rc == 0) { printf("  PASS | awk arithmetic\n"); pass++; }
+        else         { printf("  FAIL | awk arithmetic (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 19. awk -F 自定义分隔符 */
+    {
+        int rc = run("echo 'a:b:c' | awk -F: '{print $2}' | grep -q '^b$'");
+        if (rc == 0) { printf("  PASS | awk -F separator\n"); pass++; }
+        else         { printf("  FAIL | awk -F separator (rc=%d)\n", rc); fail++; }
+    }
+
+    /* ================================================================
+     *  grep | sed | awk 管道联合测试
+     * ================================================================ */
+
+    /* 20. grep | sed 管道 */
+    {
+        int rc = run("echo -e 'apple\\nbanana\\ncherry' | grep 'a' | sed 's/banana/BANANA/' "
+                      "| grep -q 'BANANA'");
+        if (rc == 0) { printf("  PASS | grep|sed pipe\n"); pass++; }
+        else         { printf("  FAIL | grep|sed pipe (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 21. grep | awk 管道: 提取 /etc/passwd 中 root 行的 shell */
+    {
+        int rc = run("grep 'root' /etc/passwd | awk -F: '{print $NF}' "
+                      "| grep -q '/bin/sh'");
+        if (rc == 0) { printf("  PASS | grep|awk pipe\n"); pass++; }
+        else         { printf("  FAIL | grep|awk pipe (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 22. sed | awk 管道 */
+    {
+        int rc = run("echo 'price:100' | sed 's/price://' | awk '{printf \"USD_%s\", $1}' "
+                      "| grep -q '^USD_100$'");
+        if (rc == 0) { printf("  PASS | sed|awk pipe\n"); pass++; }
+        else         { printf("  FAIL | sed|awk pipe (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 23. grep | sed | awk 三级管道 */
+    {
+        int rc = run("echo -e 'error:404\\ninfo:200\\nerror:500' "
+                      "| grep 'error' "
+                      "| sed 's/error://g' "
+                      "| awk '{s+=$1} END{print s}' "
+                      "| grep -q '^904$'");
+        if (rc == 0) { printf("  PASS | grep|sed|awk pipe\n"); pass++; }
+        else         { printf("  FAIL | grep|sed|awk pipe (rc=%d)\n", rc); fail++; }
+    }
+
+    /* 24. 端到端: 生成文件 → grep -r → sed -i → awk 统计 */
+    {
+        mkdir("/tmp/gsa_dir", 0755);
+        write_file("/tmp/gsa_dir/file1.txt", "apple 10\nbanana 20\n");
+        write_file("/tmp/gsa_dir/file2.txt", "apple 30\ncherry 40\n");
+
+        /* grep -r 找 apple 行, awk 统计总量 */
+        int rc = run("grep -rh 'apple' /tmp/gsa_dir | awk '{s+=$2} END{print s}' "
+                      "| grep -q '^40$'");
+        if (rc == 0) { printf("  PASS | grep -r|awk end-to-end\n"); pass++; }
+        else         { printf("  FAIL | grep -r|awk end-to-end (rc=%d)\n", rc); fail++; }
+
+        /* sed -i 替换后 awk 统计 */
+        run("sed -i 's/apple/fruit/g' /tmp/gsa_dir/file1.txt");
+        rc = run("awk '/fruit/{s+=$2} END{print s}' /tmp/gsa_dir/file1.txt "
+                  "| grep -q '^10$'");
+        if (rc == 0) { printf("  PASS | sed -i|awk end-to-end\n"); pass++; }
+        else         { printf("  FAIL | sed -i|awk end-to-end (rc=%d)\n", rc); fail++; }
+
+        /* 清理 */
+        unlink("/tmp/gsa_dir/file1.txt");
+        unlink("/tmp/gsa_dir/file2.txt");
+        rmdir("/tmp/gsa_dir");
+    }
+
+    printf("=== total: %d passed, %d failed ===\n", pass, fail);
+
+    if (fail > 0) return 1;
+    printf("GREP SED AWK TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/grep/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/grep/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/grep-sed-awk-test"
+success_regex = ["(?m)^GREP SED AWK TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 30

--- a/test-suit/starryos/normal/grep/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/grep/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+  "-machine",
+  "virt",
+  "-cpu",
+  "la464",
+  "-nographic",
+  "-m",
+  "128M",
+  "-device",
+  "virtio-blk-pci,drive=disk0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+  "-device",
+  "virtio-net-pci,netdev=net0",
+  "-netdev",
+  "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/grep-sed-awk-test"
+success_regex = ["(?m)^GREP SED AWK TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 30

--- a/test-suit/starryos/normal/grep/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/grep/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/grep-sed-awk-test"
+success_regex = ["(?m)^GREP SED AWK TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 30

--- a/test-suit/starryos/normal/grep/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/grep/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/grep-sed-awk-test"
+success_regex = ["(?m)^GREP SED AWK TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 30


### PR DESCRIPTION
### Bug Description

rename(2) on tmpfs lost all file content. When a file was renamed over an existing path (the pattern used by GNU sed -i), the destination file became empty — its page cache data was silently discarded. This caused `sed -i 's/bar/replaced/' /tmp/file` to produce a zero-length file instead of the expected substituted content. The rename syscall itself returned success (0),  but any subsequent read saw empty data.          

### Root Cause 

On tmpfs (/tmp), all file data lives in a page cache (CachedFileShared) that is anchored to a DirEntry's user_data field via FileUserData::Strong. When DirNode::rename() completed the underlying inode move via DirNodeOps::rename(), it called forget_entry() on both the source and destination names, which removed the cached DirEntry objects from the directory-level HashMap cache. On the next open of the renamed file, lookup_locked() missed the cache, called MemoryNode::lookup() (which always creates a brand-new DirEntry with empty user_data), and CachedFile::get_or_create() created a fresh empty page cache. The old page cache was freed along with the discarded DirEntry, losing all written data.

The inode metadata itself was correct — MemoryNode::rename() properly moved the InodeRef — but the VFS cache layer above it destroyed the only reference to the page cache that held the actual content.                                                                                                                                         

### Fix                                                                                   

Changed DirNode::rename() in components/axfs-ng-vfs/src/node/dir.rs to preserve the source DirEntry (and its page cache) by removing it from the source cache and re-inserting it under the destination name, instead of discarding both entries with forget_entry(). The old destination DirEntry (if present) is properly removed and forgotten.                                                                                                                                                                 

### Test Plan                                                                             

- Create and write a temp file on /tmp with known content 
- Create a second file on /tmp with different content
- rename(temp, existing) — basic replace, verify content is from temp  
- rename with original fd still open — simulate sed holding a read fd    
- Full sed -i simulation: write temp → close → rename → verify content
- Cross-size rename: temp (4 bytes) over existing (11 bytes), verify size=4 
- rename(temp, nonexist) — control group for non-replacing rename 
- All 20 checks must pass with 0 failures 

 A regression test is included in test-suit/starryos/normal/bug-rename-replace/. 