### PR TITLE
fix(ci): adjust token for release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,7 +38,8 @@ jobs:
           command: release-pr
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # Use PAT to allow downstream workflows triggered by release-plz commits/PRs.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
   release-plz-release:
     name: Publish releases
@@ -64,5 +65,6 @@ jobs:
           config: release-plz.toml
           token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # Use PAT to allow downstream workflows triggered by release-plz commits/PRs.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
仅更新了 .github/workflows/release-plz.yml 文件。

调整 release-plz 工作流的 token 使用
确保行为符合预期的工作流触发策略
不包括 virtio-snd / axdriver 代码的更改

范围故意限制在 CI 工作流配置方面。