### PR TITLE
fix(axfs-ng-vfs): preserve hardlink user data

### DIFF
--- a/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-tmpfs-hardlink-cache C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-tmpfs-hardlink-cache src/main.c)
+target_compile_options(bug-tmpfs-hardlink-cache PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-tmpfs-hardlink-cache RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/c/prebuild.sh
+++ b/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/c/prebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/c/src/main.c
+++ b/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/c/src/main.c
@@ -1,0 +1,89 @@
+/*
+ * bug-tmpfs-hardlink-cache: hard-linked tmpfs paths must share cached content.
+ *
+ * StarryOS tmpfs stores regular file data in the axfs-ng page cache. A hard
+ * link creates a second DirEntry for the same inode, so the new DirEntry must
+ * inherit the source DirEntry's user_data/cache. Otherwise the new path sees
+ * the correct inode, nlink, and size but reads zero-filled data.
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int fail_errno(const char *msg)
+{
+    printf("FAIL: %s errno=%d (%s)\n", msg, errno, strerror(errno));
+    printf("TEST FAILED\n");
+    return 1;
+}
+
+static int fail_msg(const char *msg)
+{
+    printf("FAIL: %s\n", msg);
+    printf("TEST FAILED\n");
+    return 1;
+}
+
+int main(void)
+{
+    static const char payload[] = "hi\n";
+    char buf[sizeof(payload)] = {0};
+    const char *a = "/tmp/bug_tmpfs_hardlink_a";
+    const char *b = "/tmp/bug_tmpfs_hardlink_b";
+
+    printf("=== bug-tmpfs-hardlink-cache ===\n");
+
+    unlink(a);
+    unlink(b);
+
+    int fd = open(a, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        return fail_errno("open source");
+    }
+    ssize_t written = write(fd, payload, sizeof(payload) - 1);
+    if (written != (ssize_t)sizeof(payload) - 1) {
+        close(fd);
+        return fail_msg("short write to source");
+    }
+    close(fd);
+
+    if (link(a, b) != 0) {
+        return fail_errno("link source to destination");
+    }
+
+    struct stat sa;
+    struct stat sb;
+    if (stat(a, &sa) != 0 || stat(b, &sb) != 0) {
+        return fail_errno("stat hardlink pair");
+    }
+    if (sa.st_ino != sb.st_ino || sa.st_nlink != 2 || sb.st_nlink != 2) {
+        printf("FAIL: hardlink metadata mismatch ino=(%lu,%lu) nlink=(%lu,%lu)\n",
+               (unsigned long)sa.st_ino, (unsigned long)sb.st_ino,
+               (unsigned long)sa.st_nlink, (unsigned long)sb.st_nlink);
+        printf("TEST FAILED\n");
+        return 1;
+    }
+    printf("PASS: hardlink metadata is shared\n");
+
+    fd = open(b, O_RDONLY);
+    if (fd < 0) {
+        return fail_errno("open hardlink destination");
+    }
+    ssize_t readn = read(fd, buf, sizeof(payload) - 1);
+    close(fd);
+    if (readn != (ssize_t)sizeof(payload) - 1 || memcmp(buf, payload, sizeof(payload) - 1) != 0) {
+        printf("FAIL: destination content mismatch: read=%zd bytes=%02x %02x %02x\n", readn,
+               (unsigned char)buf[0], (unsigned char)buf[1], (unsigned char)buf[2]);
+        printf("TEST FAILED\n");
+        return 1;
+    }
+    printf("PASS: hardlink destination reads source content\n");
+
+    unlink(b);
+    unlink(a);
+    printf("TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-tmpfs-hardlink-cache"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-tmpfs-hardlink-cache"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-tmpfs-hardlink-cache"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\\s*$']
+timeout = 30

--- a/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/bug-tmpfs-hardlink-cache/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-tmpfs-hardlink-cache"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\\s*$']
+timeout = 30


### PR DESCRIPTION
## Summary
- Preserve `DirEntry` user data when creating hard links.
- Add `bug-tmpfs-hardlink-cache` regression coverage for x86_64, riscv64, aarch64, and loongarch64.

## Root Cause
StarryOS tmpfs stores regular file contents in axfs-ng page cache user data. A hard link creates a second `DirEntry` for the same inode; without inheriting the source entry's user data, the new path sees the correct inode/nlink/size but reads zero-filled data.

## Test plan
- `cargo xtask clippy --package axfs-ng-vfs`
- `cargo xtask starry test qemu --arch riscv64 -c bug-tmpfs-hardlink-cache`


Made with [Cursor](https://cursor.com)