### PR TITLE
test(starryos): strengthen random and rlimit boundary coverage

### DIFF
--- a/STARRY_SYSCALL_BOUNDARY_TESTS.md
+++ b/STARRY_SYSCALL_BOUNDARY_TESTS.md
@@ -1,0 +1,93 @@
+# StarryOS syscall boundary tests
+
+This document records the boundary-test logic for the StarryOS `getrandom`,
+`getrlimit`, and `setrlimit` syscall paths.
+
+These tests are designed to catch implementation bugs, not just exercise the
+happy path. A test suite cannot prove that a syscall is bug-free for every
+future implementation, but the cases below cover the Linux-visible boundary
+semantics used by applications and the error paths that are most likely to
+regress in StarryOS.
+
+## Test cases
+
+- `test-suit/starryos/normal/test-getrandom`
+- `test-suit/starryos/normal/test-prlimit64`
+
+Run on `riscv64`:
+
+```bash
+cargo xtask starry test qemu --arch riscv64 -c test-getrandom
+cargo xtask starry test qemu --arch riscv64 -c test-prlimit64
+```
+
+When running from macOS, use the project Docker environment so Linux host tools
+such as `debugfs` and `qemu-riscv64-static` are available:
+
+```bash
+docker exec tgoskits-work sh -lc 'cd /workspace && cargo xtask starry test qemu --arch riscv64 -c test-getrandom'
+docker exec tgoskits-work sh -lc 'cd /workspace && cargo xtask starry test qemu --arch riscv64 -c test-prlimit64'
+```
+
+## `getrandom`
+
+The `test-getrandom` case calls `SYS_getrandom` directly through `syscall()` to
+avoid hiding kernel behavior behind libc wrappers.
+
+Covered boundaries:
+
+- Basic successful read: non-zero buffer length returns the exact requested
+  length and changes the output buffer.
+- Zero-length reads: `len == 0` returns `0` and does not touch the user buffer,
+  even when `buf` is `NULL` or an invalid address.
+- All valid flag combinations:
+  `0`, `GRND_NONBLOCK`, `GRND_RANDOM`, `GRND_RANDOM | GRND_NONBLOCK`,
+  `GRND_INSECURE`, and `GRND_INSECURE | GRND_NONBLOCK`.
+- Invalid flag bits: unknown bits return `EINVAL` and leave the user buffer
+  unchanged.
+- Mutually exclusive flags: `GRND_RANDOM | GRND_INSECURE` returns `EINVAL` and
+  leaves the user buffer unchanged.
+- Bad user pointers: non-zero reads to `NULL` or an invalid address return
+  `EFAULT`.
+- Error priority: invalid flags return `EINVAL` before the kernel attempts to
+  write to a bad user pointer.
+- Larger request: a 4096-byte request returns the full length and fills the
+  buffer, catching implementations that only handle small reads.
+
+## `getrlimit` and `setrlimit`
+
+On the tested musl/riscv64 userspace, `getrlimit` and `setrlimit` use the
+`prlimit64` syscall path. The `test-prlimit64` case therefore verifies both the
+raw `prlimit64` behavior and the libc `getrlimit`/`setrlimit` entry points that
+applications call.
+
+Covered boundaries:
+
+- `getrlimit(RLIMIT_NOFILE)` and `getrlimit(RLIMIT_STACK)` succeed and report
+  `soft <= hard`.
+- Invalid resource IDs return `EINVAL` for both `getrlimit` and `setrlimit`.
+- Raw `prlimit64` bad user pointers return `EFAULT` for both `old_limit` writes
+  and `new_limit` reads.
+- `getrlimit`/`setrlimit` with a `NULL` libc wrapper pointer are documented as
+  a no-op in this test because the current Linux/glibc path maps them to
+  `prlimit64(..., NULL, NULL)` and returns success. The test verifies that this
+  no-op does not change the stored limits.
+- `setrlimit` rejects `rlim_cur > rlim_max` with `EINVAL`.
+- Lowering only the soft limit succeeds, and a following `getrlimit` observes
+  the new soft limit while the hard limit remains unchanged.
+- Setting `rlim_cur == rlim_max` succeeds and is visible through `getrlimit`.
+- Lowering the hard limit succeeds, and both soft and hard values observed by
+  `getrlimit` match the requested values.
+- Restoring a previously lowered hard limit succeeds and is visible through
+  `getrlimit`; this catches silent no-op bugs where the syscall returns success
+  without applying the new hard limit.
+- The existing `prlimit64` checks also cover reading old limits, lowering hard
+  limits, raising hard limits, setting and getting atomically, `soft > hard`,
+  invalid resources, and `getrusage` sanity checks.
+
+## Remaining assumptions
+
+- These tests validate Linux-compatible user-visible behavior for the current
+  StarryOS `riscv64` QEMU environment.
+- Passing the tests means the covered syscall boundaries match expectations; it
+  does not replace code review, fuzzing, or tests on other architectures.

--- a/test-suit/starryos/normal/riscv64-regression/test-prlimit64/c/src/main.c
+++ b/test-suit/starryos/normal/riscv64-regression/test-prlimit64/c/src/main.c
@@ -11,6 +11,18 @@
  *   4. old_limit 先读后写顺序
  *   5. 错误路径 (soft > hard, 无效 resource)
  *   6. getrusage 基本功能
+ *   7. getrlimit/setrlimit libc 接口路径
+ *
+ * getrlimit/setrlimit 测试逻辑:
+ *   - 通过 getrlimit 读取 RLIMIT_NOFILE/RLIMIT_STACK, 确认 soft <= hard。
+ *   - raw prlimit64 的坏用户指针必须返回 EFAULT。
+ *   - 无效 resource 和 cur > max 必须返回 EINVAL。
+ *   - getrlimit/setrlimit 的 NULL libc wrapper 路径按当前 Linux 行为作为 no-op。
+ *   - 降低 soft limit 后, 再用 getrlimit 确认 soft 生效、hard 不变。
+ *   - 降低 hard limit、设置 cur == max、再恢复原 hard limit, 确认成功返回不会静默丢弃修改。
+ *
+ * 在 riscv64/musl 上, getrlimit/setrlimit 会走 prlimit64 syscall,
+ * 因此这里覆盖的是应用常用 libc API 到 StarryOS prlimit64 实现的路径。
  */
 
 #include "test_framework.h"
@@ -172,7 +184,101 @@ int main(void) {
                   "invalid resource rejected");
     }
 
-    /* 10. getrusage RUSAGE_SELF 基本功能 */
+    /* 10. raw prlimit64 用户地址错误路径 */
+    {
+        CHECK_ERR(my_prlimit(0, RLIMIT_NOFILE, NULL, (struct rlimit *)1), EFAULT,
+                  "bad old_limit pointer rejected");
+        CHECK_ERR(my_prlimit(0, RLIMIT_NOFILE, (const struct rlimit *)1, NULL), EFAULT,
+                  "bad new_limit pointer rejected");
+    }
+
+    /* 11. getrlimit/setrlimit libc 接口路径 */
+    {
+        struct rlimit saved, stack, check;
+        struct rlimit *null_limit = NULL;
+        CHECK_RET(getrlimit(RLIMIT_NOFILE, &saved), 0,
+                  "getrlimit reads original NOFILE");
+        CHECK(saved.rlim_cur <= saved.rlim_max,
+              "getrlimit reports soft <= hard");
+        CHECK_RET(getrlimit(RLIMIT_STACK, &stack), 0,
+                  "getrlimit reads STACK");
+        CHECK(stack.rlim_cur <= stack.rlim_max,
+              "getrlimit STACK reports soft <= hard");
+
+        CHECK_ERR(getrlimit(-1, &check), EINVAL,
+                  "getrlimit invalid resource rejected");
+        CHECK_RET(getrlimit(RLIMIT_NOFILE, null_limit), 0,
+                  "getrlimit NULL wrapper path is a no-op");
+
+        struct rlimit invalid = {
+            .rlim_cur = 2,
+            .rlim_max = 1,
+        };
+        CHECK_ERR(setrlimit(RLIMIT_NOFILE, &invalid), EINVAL,
+                  "setrlimit rejects soft > hard");
+        CHECK_ERR(setrlimit(-1, &saved), EINVAL,
+                  "setrlimit invalid resource rejected");
+        CHECK_RET(setrlimit(RLIMIT_NOFILE, null_limit), 0,
+                  "setrlimit NULL wrapper path is a no-op");
+        CHECK_RET(getrlimit(RLIMIT_NOFILE, &check), 0,
+                  "getrlimit after setrlimit NULL no-op");
+        CHECK(check.rlim_cur == saved.rlim_cur && check.rlim_max == saved.rlim_max,
+              "setrlimit NULL leaves limits unchanged");
+
+        if (saved.rlim_cur > 1) {
+            struct rlimit lowered_soft = {
+                .rlim_cur = saved.rlim_cur - 1,
+                .rlim_max = saved.rlim_max,
+            };
+            CHECK_RET(setrlimit(RLIMIT_NOFILE, &lowered_soft), 0,
+                      "setrlimit lowers soft limit");
+            CHECK_RET(getrlimit(RLIMIT_NOFILE, &check), 0,
+                      "getrlimit after lowering soft");
+            CHECK(check.rlim_cur == lowered_soft.rlim_cur,
+                  "getrlimit observes lowered soft");
+            CHECK(check.rlim_max == saved.rlim_max,
+                  "lowering soft keeps hard unchanged");
+            CHECK_RET(setrlimit(RLIMIT_NOFILE, &saved), 0,
+                      "restore after lowering soft");
+        }
+
+        if (saved.rlim_max > 2 && saved.rlim_max < RLIM_INFINITY) {
+            struct rlimit equal_limits = {
+                .rlim_cur = saved.rlim_max - 1,
+                .rlim_max = saved.rlim_max - 1,
+            };
+            struct rlimit lowered_hard = {
+                .rlim_cur = saved.rlim_max - 2,
+                .rlim_max = saved.rlim_max - 1,
+            };
+            CHECK_RET(setrlimit(RLIMIT_NOFILE, &equal_limits), 0,
+                      "setrlimit accepts soft == hard");
+            CHECK_RET(getrlimit(RLIMIT_NOFILE, &check), 0,
+                      "getrlimit after setting soft == hard");
+            CHECK(check.rlim_cur == equal_limits.rlim_cur,
+                  "getrlimit observes soft == hard soft value");
+            CHECK(check.rlim_max == equal_limits.rlim_max,
+                  "getrlimit observes soft == hard max value");
+            CHECK_RET(setrlimit(RLIMIT_NOFILE, &lowered_hard), 0,
+                      "setrlimit lowers hard limit");
+            CHECK_RET(getrlimit(RLIMIT_NOFILE, &check), 0,
+                      "getrlimit after lowering hard");
+            CHECK(check.rlim_cur == lowered_hard.rlim_cur,
+                  "getrlimit observes lowered soft with hard");
+            CHECK(check.rlim_max == lowered_hard.rlim_max,
+                  "getrlimit observes lowered hard");
+            CHECK_RET(setrlimit(RLIMIT_NOFILE, &saved), 0,
+                      "restore hard limit after lowering");
+            CHECK_RET(getrlimit(RLIMIT_NOFILE, &check), 0,
+                      "getrlimit after restoring hard");
+            CHECK(check.rlim_cur == saved.rlim_cur,
+                  "restored soft limit is visible");
+            CHECK(check.rlim_max == saved.rlim_max,
+                  "restored hard limit is visible");
+        }
+    }
+
+    /* 12. getrusage RUSAGE_SELF 基本功能 */
     {
         struct rusage usage;
         CHECK_RET(getrusage(RUSAGE_SELF, &usage), 0,
@@ -181,7 +287,7 @@ int main(void) {
         CHECK(usage.ru_stime.tv_sec >= 0, "stime >= 0");
     }
 
-    /* 11. getrusage 无效 who 应返回 EINVAL */
+    /* 13. getrusage 无效 who 应返回 EINVAL */
     {
         struct rusage usage;
         CHECK_ERR(getrusage(42, &usage), EINVAL,

--- a/test-suit/starryos/normal/syscall/test-getrandom/c/src/main.c
+++ b/test-suit/starryos/normal/syscall/test-getrandom/c/src/main.c
@@ -1,12 +1,16 @@
 /*
- * test_getrandom.c — 验证 getrandom 系统调用的 flags 校验及基本功能。
+ * test_getrandom.c — 验证 getrandom 系统调用的 flags 校验、地址校验及边界语义。
  *
  * 覆盖场景：
- *   1. 基本随机数填充
- *   2. len=0 返回 0
- *   3. GRND_RANDOM flag 正常工作
- *   4. 无效 flags（含未知位）返回 EINVAL
- *   5. GRND_INSECURE 与 GRND_RANDOM 互斥，同时传入返回 EINVAL
+ *   1. 基本随机数填充，返回长度必须等于请求长度。
+ *   2. len=0 直接返回 0，包括 buf 为 NULL 或明显坏地址的情况。
+ *   3. 覆盖所有 Linux 有效 flag 组合：
+ *      0、GRND_NONBLOCK、GRND_RANDOM、GRND_RANDOM|GRND_NONBLOCK、
+ *      GRND_INSECURE、GRND_INSECURE|GRND_NONBLOCK。
+ *   4. 无效 flags（未知位）和互斥组合（GRND_RANDOM|GRND_INSECURE）
+ *      必须返回 EINVAL，且不能改写用户缓冲区。
+ *   5. 非零长度的 NULL/坏地址必须返回 EFAULT。
+ *   6. 错误优先级：无效 flags 应先于用户地址写入检查返回 EINVAL。
  */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -18,54 +22,113 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#ifndef GRND_INSECURE
+#define GRND_INSECURE 0x0004
+#endif
+
+#define UNKNOWN_GETRANDOM_FLAG 0x80000000U
+
 /* 通过 syscall() 直接调用 getrandom，避免 glibc 封装差异 */
 static ssize_t my_getrandom(void *buf, size_t len, unsigned int flags) {
     return syscall(SYS_getrandom, buf, len, flags);
 }
 
+static int all_bytes_equal(const unsigned char *buf, size_t len, unsigned char value) {
+    for (size_t i = 0; i < len; i++) {
+        if (buf[i] != value) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static void check_full_random_read(unsigned int flags, const char *name) {
+    unsigned char buf[32];
+    memset(buf, 0, sizeof(buf));
+    CHECK_RET(my_getrandom(buf, sizeof(buf), flags), (ssize_t)sizeof(buf), name);
+    CHECK(!all_bytes_equal(buf, sizeof(buf), 0), "buffer should not remain all zero");
+}
+
+static void check_random_nonblock(unsigned int flags, const char *name) {
+    unsigned char buf[32];
+    memset(buf, 0, sizeof(buf));
+    errno = 0;
+    ssize_t n = my_getrandom(buf, sizeof(buf), flags);
+    CHECK(n == (ssize_t)sizeof(buf) || (n == -1 && errno == EAGAIN), name);
+    if (n == (ssize_t)sizeof(buf)) {
+        CHECK(!all_bytes_equal(buf, sizeof(buf), 0), "successful random read fills buffer");
+    }
+}
+
 int main(void) {
     TEST_START("getrandom");
 
-    /* 基本功能：填充 32 字节，返回值应为 32 */
+    /* 1. 基本功能：填充 32 字节，返回值应为 32 */
     {
-        unsigned char buf[32];
-        memset(buf, 0, sizeof(buf));
-        CHECK_RET(my_getrandom(buf, sizeof(buf), 0), 32, "基本填充返回32字节");
-
-        /* 全零概率极低，用于粗略验证随机性 */
-        int all_zero = 1;
-        for (int i = 0; i < 32; i++) {
-            if (buf[i] != 0) { all_zero = 0; break; }
-        }
-        CHECK(!all_zero, "缓冲区不应全为零");
+        check_full_random_read(0, "basic fill returns requested length");
     }
 
-    /* len=0 时直接返回 0，不做任何操作 */
+    /* 2. len=0 时直接返回 0，不做任何用户地址访问 */
     {
         unsigned char buf[1];
-        CHECK_RET(my_getrandom(buf, 0, 0), 0, "len=0 返回0");
+        CHECK_RET(my_getrandom(buf, 0, 0), 0, "len=0 returns 0");
+        CHECK_RET(my_getrandom(NULL, 0, 0), 0, "len=0 accepts NULL buffer");
+        CHECK_RET(my_getrandom((void *)1, 0, 0), 0, "len=0 accepts bad buffer");
     }
 
-    /* GRND_RANDOM flag：从 /dev/random 读取。
-     * 使用 GRND_NONBLOCK 避免在低熵环境（QEMU/早期启动）下阻塞。 */
+    /* 3. 所有有效 flag 组合 */
     {
-        unsigned char buf[16];
-        ssize_t n = my_getrandom(buf, sizeof(buf), GRND_RANDOM | GRND_NONBLOCK);
-        CHECK(n > 0 || (n == -1 && errno == EAGAIN),
-              "GRND_RANDOM|GRND_NONBLOCK: 返回数据或 EAGAIN");
+        check_full_random_read(GRND_NONBLOCK, "GRND_NONBLOCK is accepted");
+        check_full_random_read(GRND_RANDOM, "GRND_RANDOM is accepted");
+        check_random_nonblock(GRND_RANDOM | GRND_NONBLOCK,
+                              "GRND_RANDOM|GRND_NONBLOCK returns data or EAGAIN");
+        check_full_random_read(GRND_INSECURE, "GRND_INSECURE is accepted");
+        check_full_random_read(GRND_INSECURE | GRND_NONBLOCK,
+                               "GRND_INSECURE|GRND_NONBLOCK is accepted");
     }
 
-    /* 无效 flags：0xFF 含有未定义位，Linux 内核拒绝并返回 EINVAL */
+    /* 4. 无效 flags：未知位必须返回 EINVAL，且不能改写用户缓冲区 */
     {
         unsigned char buf[16];
-        CHECK_ERR(my_getrandom(buf, sizeof(buf), 0xFF), EINVAL, "未知 flags 返回 EINVAL");
+        memset(buf, 0xA5, sizeof(buf));
+        CHECK_ERR(my_getrandom(buf, sizeof(buf), UNKNOWN_GETRANDOM_FLAG), EINVAL,
+                  "unknown flag returns EINVAL");
+        CHECK(all_bytes_equal(buf, sizeof(buf), 0xA5),
+              "unknown flag leaves buffer unchanged");
     }
 
-    /* GRND_INSECURE 与 GRND_RANDOM 互斥，同时使用返回 EINVAL */
+    /* 5. GRND_INSECURE 与 GRND_RANDOM 互斥，同时使用返回 EINVAL */
     {
         unsigned char buf[16];
+        memset(buf, 0x5A, sizeof(buf));
         CHECK_ERR(my_getrandom(buf, sizeof(buf), GRND_INSECURE | GRND_RANDOM), EINVAL,
                   "GRND_INSECURE|GRND_RANDOM 互斥返回 EINVAL");
+        CHECK(all_bytes_equal(buf, sizeof(buf), 0x5A),
+              "mutually-exclusive flags leave buffer unchanged");
+    }
+
+    /* 6. 非零长度的坏地址必须返回 EFAULT */
+    {
+        CHECK_ERR(my_getrandom(NULL, 1, 0), EFAULT, "NULL buffer with len>0 returns EFAULT");
+        CHECK_ERR(my_getrandom((void *)1, 1, 0), EFAULT, "bad buffer with len>0 returns EFAULT");
+    }
+
+    /* 7. 错误优先级：无效 flags 应先于用户地址检查 */
+    {
+        CHECK_ERR(my_getrandom((void *)1, 16, UNKNOWN_GETRANDOM_FLAG), EINVAL,
+                  "invalid flags take precedence over bad address");
+        CHECK_ERR(my_getrandom(NULL, 16, GRND_INSECURE | GRND_RANDOM), EINVAL,
+                  "mutually-exclusive flags take precedence over NULL address");
+    }
+
+    /* 8. 较大但仍合理的请求长度，避免只实现了小 buffer 的假阳性 */
+    {
+        unsigned char buf[4096];
+        memset(buf, 0, sizeof(buf));
+        CHECK_RET(my_getrandom(buf, sizeof(buf), 0), (ssize_t)sizeof(buf),
+                  "large 4096-byte request returns full length");
+        CHECK(!all_bytes_equal(buf, sizeof(buf), 0),
+              "large request fills buffer");
     }
 
     TEST_DONE();


### PR DESCRIPTION
## Summary
- Expand `getrandom` boundary coverage for valid flags, invalid flags, bad pointers, and larger buffers.
- Expand `prlimit64` / `getrlimit` / `setrlimit` coverage for libc wrapper behavior and raw syscall error paths.
- Document the tested boundary cases in `STARRY_SYSCALL_BOUNDARY_TESTS.md`.

## Notes
This PR is test/documentation coverage. The tests encode observed Linux/glibc behavior, including libc `getrlimit(NULL)` / `setrlimit(NULL)` wrapper behavior and raw `prlimit64` bad-pointer handling.

## Test plan
- `cargo xtask starry test qemu --arch riscv64 -c test-getrandom`
- `cargo xtask starry test qemu --arch riscv64 -c test-prlimit64`


Made with [Cursor](https://cursor.com)