### PR TITLE
fix(starry): stabilize shm deadlock regression

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -2,7 +2,6 @@ use alloc::vec::Vec;
 use core::{future::poll_fn, task::Poll};
 
 use ax_errno::{AxError, AxResult, LinuxError};
-use ax_hal::time::TimeValue;
 use ax_task::{
     current,
     future::{block_on, interruptible},
@@ -67,7 +66,6 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
 
     let curr = current();
     let proc = &curr.as_thread().proc_data.proc;
-    let proc_data = curr.as_thread().proc_data.clone();
 
     let pid = if pid == -1 {
         WaitPid::Any
@@ -120,7 +118,13 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
             Some(res) => Poll::Ready(res),
             None => {
                 proc_data.child_exit_event.register(cx.waker());
-                Poll::Pending
+                // A child may exit between the check above and waker
+                // registration. Recheck after registering so that wakeup is
+                // not lost in that race window.
+                match check_children().transpose() {
+                    Some(res) => Poll::Ready(res),
+                    None => Poll::Pending,
+                }
             }
         }
     })))?

--- a/os/arceos/modules/axalloc/src/buddy_slab.rs
+++ b/os/arceos/modules/axalloc/src/buddy_slab.rs
@@ -25,16 +25,16 @@ pub type DefaultByteAllocator = buddy_slab_allocator::SlabAllocator<PAGE_SIZE>;
 const PAGE_SIZE: usize = 0x1000;
 
 #[ax_percpu::def_percpu]
-static PRECPU_SLAB: PrecpuSlab<PAGE_SIZE> = PrecpuSlab::new_uninit();
+static PERCPU_SLAB: PercpuSlab<PAGE_SIZE> = PercpuSlab::new_uninit();
 
 static SLAB_POOL: SlabPool = SlabPool;
 
-struct PrecpuSlab<const PAGE_SIZE: usize = 0x1000> {
+struct PercpuSlab<const PAGE_SIZE: usize = 0x1000> {
     cpu_id: Option<u16>,
     inner: SpinNoIrq<SlabAllocator<PAGE_SIZE>>,
 }
 
-impl<const PAGE_SIZE: usize> PrecpuSlab<PAGE_SIZE> {
+impl<const PAGE_SIZE: usize> PercpuSlab<PAGE_SIZE> {
     const fn new_uninit() -> Self {
         Self {
             cpu_id: None,
@@ -58,7 +58,7 @@ impl<const PAGE_SIZE: usize> PrecpuSlab<PAGE_SIZE> {
     }
 }
 
-impl<const PAGE_SIZE: usize> SlabTrait for PrecpuSlab<PAGE_SIZE> {
+impl<const PAGE_SIZE: usize> SlabTrait for PercpuSlab<PAGE_SIZE> {
     fn cpu_id(&self) -> usize {
         self.cpu_id_checked() as usize
     }
@@ -82,27 +82,27 @@ impl<const PAGE_SIZE: usize> SlabTrait for PrecpuSlab<PAGE_SIZE> {
     }
 }
 
-fn current_precpu_slab() -> &'static PrecpuSlab<PAGE_SIZE> {
+fn current_percpu_slab() -> &'static PercpuSlab<PAGE_SIZE> {
     // Safety: the outer allocator lock disables local IRQs/preemption before
     // upstream buddy-slab-allocator calls this hook.
-    unsafe { PRECPU_SLAB.current_ref_raw() }
+    unsafe { PERCPU_SLAB.current_ref_raw() }
 }
 
-fn remote_precpu_slab(cpu_idx: usize) -> &'static PrecpuSlab<PAGE_SIZE> {
+fn remote_percpu_slab(cpu_idx: usize) -> &'static PercpuSlab<PAGE_SIZE> {
     // Safety: the owner CPU id comes from slab metadata and references a valid
     // per-CPU slab that was initialized during CPU bring-up.
-    unsafe { PRECPU_SLAB.remote_ref_raw(cpu_idx) }
+    unsafe { PERCPU_SLAB.remote_ref_raw(cpu_idx) }
 }
 
 struct SlabPool;
 
 impl SlabPoolTrait for SlabPool {
     fn current_slab(&self) -> &dyn SlabTrait {
-        current_precpu_slab()
+        current_percpu_slab()
     }
 
     fn owner_slab(&self, cpu_idx: usize) -> &dyn SlabTrait {
-        remote_precpu_slab(cpu_idx)
+        remote_percpu_slab(cpu_idx)
     }
 }
 
@@ -346,8 +346,8 @@ pub fn global_allocator() -> &'static GlobalAllocator {
 }
 
 /// Initializes the per-CPU slab for the current CPU.
-pub fn init_precpu_slab(cpu_id: usize) {
-    PRECPU_SLAB.with_current(|slab| slab.init(cpu_id));
+pub fn init_percpu_slab(cpu_id: usize) {
+    PERCPU_SLAB.with_current(|slab| slab.init(cpu_id));
 }
 
 /// Initializes the global allocator with the given memory region.

--- a/os/arceos/modules/axalloc/src/lib.rs
+++ b/os/arceos/modules/axalloc/src/lib.rs
@@ -195,7 +195,7 @@ mod default_impl;
 #[cfg(not(feature = "buddy-slab"))]
 use default_impl as imp;
 #[cfg(feature = "buddy-slab")]
-pub use imp::init_precpu_slab;
+pub use imp::init_percpu_slab;
 pub use imp::{DefaultByteAllocator, GlobalAllocator, global_add_memory, global_init};
 
 /// Returns the reference to the global allocator.

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -137,7 +137,7 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
     };
     ax_hal::percpu::init_primary(cpu_id);
     #[cfg(all(feature = "alloc", feature = "buddy-slab"))]
-    ax_alloc::init_precpu_slab(cpu_id);
+    ax_alloc::init_percpu_slab(cpu_id);
     ax_hal::init_early(cpu_id, arg);
     let log_level = option_env!("AX_LOG").unwrap_or("info");
 

--- a/os/arceos/modules/axruntime/src/mp.rs
+++ b/os/arceos/modules/axruntime/src/mp.rs
@@ -51,7 +51,7 @@ pub fn start_secondary_cpus(primary_cpu_id: usize) {
 pub fn rust_main_secondary(cpu_id: usize) -> ! {
     ax_hal::percpu::init_secondary(cpu_id);
     #[cfg(all(feature = "alloc", feature = "buddy-slab"))]
-    ax_alloc::init_precpu_slab(cpu_id);
+    ax_alloc::init_percpu_slab(cpu_id);
     ax_hal::init_early_secondary(cpu_id);
 
     ENTERED_CPUS.fetch_add(1, Ordering::Release);

--- a/test-suit/starryos/normal/test-shm-deadlock/c/src/main.c
+++ b/test-suit/starryos/normal/test-shm-deadlock/c/src/main.c
@@ -1,18 +1,18 @@
 /*
- * test_shm_deadlock.c — Stress test for SHM_MANAGER/shm_inner lock ordering.
+ * test_shm_deadlock.c - Stress test for SHM_MANAGER/shm_inner lock ordering.
  *
  * BUG-021: sys_shmget holds SHM_MANAGER then locks shm_inner.
- *          sys_shmat/sys_shmdt hold shm_inner then lock SHM_MANAGER.
- *          Under concurrent execution, this is an AB/BA deadlock.
+ *          The buggy sys_shmat/sys_shmdt path held shm_inner first and then
+ *          tried to lock SHM_MANAGER. Under SMP this forms an AB/BA deadlock.
  *
- * Strategy: Spawn two threads doing concurrent shmget and shmat/shmdt
- * on the same key. If the deadlock triggers, the threads hang and
- * alarm() fires, reporting FAIL. If they complete, PASS (but the bug
- * may still exist — deadlocks are probabilistic).
+ * Strategy: start the shmat/shmdt worker first and make it attach a larger
+ * segment on x86_64, so it keeps shm_inner long enough for the shmget worker
+ * to grab SHM_MANAGER. The old lock order deadlocks reliably; the fixed lock
+ * order serializes the two paths and the workers exit cleanly.
  *
- * This test uses clone() directly since musl pthreads may or may not
- * work on StarryOS. clone(CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND)
- * creates a thread sharing the address space.
+ * This test uses clone() directly since musl pthreads may or may not work on
+ * StarryOS. clone(CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND) creates
+ * a thread sharing the address space.
  */
 #define _GNU_SOURCE
 #include "test_framework.h"
@@ -22,25 +22,25 @@
 #include <sys/wait.h>
 #include <sched.h>
 #include <unistd.h>
-#include <signal.h>
-#include <sys/syscall.h>
 
 /* Shared state between threads */
 static volatile int g_running = 1;
 static volatile int g_shmid = -1;
 static volatile int g_deadlock_detected = 0;
+static volatile int g_shmat_started = 0;
 
 /* Thread stack size */
 #define STACK_SIZE (64 * 1024)
 
-static void alarm_handler(int sig) {
-    (void)sig;
-    g_deadlock_detected = 1;
-    /* Force exit — if we got here, threads are deadlocked */
-    printf("  FAIL | test_shm_deadlock.c | concurrent_shmget_shmat"
-           " (TIMEOUT after 3s — probable deadlock in SHM lock ordering)\n");
-    _exit(1);
-}
+#if defined(__x86_64__)
+#define SHM_TEST_SIZE (32 * 1024 * 1024)
+#define SHM_RACE_USEC 1500000
+#define SHM_ALARM_SEC 10
+#else
+#define SHM_TEST_SIZE 4096
+#define SHM_RACE_USEC 1000000
+#define SHM_ALARM_SEC 3
+#endif
 
 /*
  * Thread 1: repeatedly call shmget with the same key.
@@ -48,12 +48,16 @@ static void alarm_handler(int sig) {
  */
 static int shmget_thread(void *arg) {
     (void)arg;
+
+    while (g_running && !g_shmat_started) {
+        sched_yield();
+    }
+
     while (g_running) {
-        int id = shmget(42, 4096, IPC_CREAT | 0666);
+        int id = shmget(42, SHM_TEST_SIZE, IPC_CREAT | 0666);
         if (id >= 0) {
             g_shmid = id;
         }
-        /* Yield to give the other thread a chance */
         sched_yield();
     }
     return 0;
@@ -61,14 +65,16 @@ static int shmget_thread(void *arg) {
 
 /*
  * Thread 2: repeatedly call shmat/shmdt.
- * This acquires shm_inner -> SHM_MANAGER in the buggy version (the "reverse"
- * order), which causes an AB/BA deadlock with sys_shmget.
+ * The buggy version acquired shm_inner before SHM_MANAGER. Starting this
+ * worker first biases the race toward the old AB/BA lock order.
  */
 static int shmat_thread(void *arg) {
     (void)arg;
+
     while (g_running) {
         int id = g_shmid;
         if (id >= 0) {
+            g_shmat_started = 1;
             void *p = shmat(id, NULL, 0);
             if (p != (void *)-1) {
                 shmdt(p);
@@ -79,22 +85,32 @@ static int shmat_thread(void *arg) {
     return 0;
 }
 
+static int watchdog_thread(void *arg) {
+    (void)arg;
+
+    for (int i = 0; i < SHM_ALARM_SEC * 10; i++) {
+        usleep(100000);
+        if (!g_running) {
+            return 0;
+        }
+    }
+
+    g_deadlock_detected = 1;
+    printf("  FAIL | test_shm_deadlock.c | concurrent_shmget_shmat"
+           " (TIMEOUT after %ds - probable deadlock in SHM lock ordering)\n",
+           SHM_ALARM_SEC);
+    _exit(1);
+}
+
 int main(void)
 {
+    setvbuf(stdout, NULL, _IONBF, 0);
     TEST_START("shm_deadlock");
 
     /* --- concurrent_shmget_shmat --- */
     {
-        /* Set alarm for deadlock detection */
-        struct sigaction sa;
-        sa.sa_handler = alarm_handler;
-        sa.sa_flags = 0;
-        sigemptyset(&sa.sa_mask);
-        sigaction(SIGALRM, &sa, NULL);
-        alarm(3);
-
         /* Create initial segment so both threads have something to work with */
-        g_shmid = shmget(42, 4096, IPC_CREAT | 0666);
+        g_shmid = shmget(42, SHM_TEST_SIZE, IPC_CREAT | 0666);
         CHECK(g_shmid >= 0, "initial shmget");
 
         if (g_shmid >= 0) {
@@ -103,46 +119,57 @@ int main(void)
                                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
             void *stack2 = mmap(NULL, STACK_SIZE, PROT_READ | PROT_WRITE,
                                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            void *stack3 = mmap(NULL, STACK_SIZE, PROT_READ | PROT_WRITE,
+                                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
             CHECK(stack1 != MAP_FAILED, "stack1 mmap");
             CHECK(stack2 != MAP_FAILED, "stack2 mmap");
+            CHECK(stack3 != MAP_FAILED, "stack3 mmap");
 
-            if (stack1 != MAP_FAILED && stack2 != MAP_FAILED) {
+            if (stack1 != MAP_FAILED && stack2 != MAP_FAILED &&
+                stack3 != MAP_FAILED) {
                 int flags = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND;
 
                 /* clone() takes top of stack (stack grows down) */
-                int tid1 = clone(shmget_thread, (char *)stack1 + STACK_SIZE,
+                int tid3 = clone(watchdog_thread, (char *)stack3 + STACK_SIZE,
                                  flags, NULL);
+                CHECK(tid3 >= 0, "clone watchdog_thread");
+
                 int tid2 = clone(shmat_thread, (char *)stack2 + STACK_SIZE,
                                  flags, NULL);
-
-                CHECK(tid1 >= 0, "clone shmget_thread");
                 CHECK(tid2 >= 0, "clone shmat_thread");
 
-                if (tid1 >= 0 && tid2 >= 0) {
+                while (tid2 >= 0 && !g_shmat_started) {
+                    sched_yield();
+                }
+
+                int tid1 = clone(shmget_thread, (char *)stack1 + STACK_SIZE,
+                                 flags, NULL);
+                CHECK(tid1 >= 0, "clone shmget_thread");
+
+                if (tid1 >= 0 && tid2 >= 0 && tid3 >= 0) {
                     /*
-                     * Let the threads race for ~1 second.
-                     * If a deadlock occurs, alarm(3) will fire.
+                     * Let the threads race. If a deadlock occurs,
+                     * the watchdog worker will print FAIL.
                      */
-                    usleep(1000000); /* 1 second */
+                    usleep(SHM_RACE_USEC);
                     g_running = 0;
 
                     /* Wait for threads to finish */
                     int status;
                     waitpid(tid1, &status, __WALL);
                     waitpid(tid2, &status, __WALL);
+                    waitpid(tid3, &status, __WALL);
 
                     CHECK(!g_deadlock_detected, "no deadlock detected");
                 } else {
                     g_running = 0;
                 }
 
-                /* Cancel alarm */
-                alarm(0);
-
                 /* Cleanup */
                 if (stack1 != MAP_FAILED) munmap(stack1, STACK_SIZE);
                 if (stack2 != MAP_FAILED) munmap(stack2, STACK_SIZE);
+                if (stack3 != MAP_FAILED) munmap(stack3, STACK_SIZE);
             }
 
             /* Remove the shared memory segment */

--- a/test-suit/starryos/normal/test-shm-deadlock/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/test-shm-deadlock/qemu-x86_64.toml
@@ -1,5 +1,6 @@
 args = [
     "-nographic",
+    "-m", "512M",
     "-smp", "4",
     "-device", "virtio-blk-pci,drive=disk0",
     "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
@@ -12,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-shm-deadlock"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 60


### PR DESCRIPTION
## 背景

`test-shm-deadlock` 在 x86_64 QEMU 上偶发超时。原测例依赖概率性竞态，失败时也可能没有来得及输出 `FAIL`，最终只表现为外层 QEMU timeout。

## 修改内容

- 增强 `test-shm-deadlock`：x86_64 使用更大的 SHM 段，先启动 `shmat/shmdt` worker，再启动 `shmget` worker，扩大旧锁顺序下的 AB/BA 死锁窗口；同时开启 stdout 无缓冲输出。
- 将 x86_64 case 的 QEMU 内存调到 512M，并把 case timeout 缩短到 60s，让修复前更快稳定暴露问题，修复后正常通过。
- 修复 `sys_waitpid` 在检查子进程状态和注册 waker 之间可能丢失子进程退出唤醒的问题：注册 waker 后再次检查子进程状态。
- 修正 `ax-alloc` buddy-slab 路径中 `precpu` 的拼写为 `percpu`，并同步调用点。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo xtask starry test qemu --arch x86_64 -c test-shm-deadlock`：通过，`DONE: 8 pass, 0 fail`
- 使用临时 worktree 回退 SHM 锁顺序修复后，同一增强测例稳定卡住并触发 QEMU timeout，验证修复前可复现
- `cargo xtask clippy --package ax-alloc`：与本次 buddy-slab 相关的 `base`、`buddy`、`buddy-slab`、`slab`、`tlsf` 检查通过；完整检查仍被既有 `page-alloc-*`/`tracking` feature 配置问题阻断
- `cargo xtask clippy --package ax-runtime`、`cargo xtask clippy --package starry-kernel`：仍被既有 `ax-fs`、`ax-net-ng`、`rockchip-npu` 等 clippy warning 阻断，本次改动未引入新的对应报错
