### PR TITLE
fix(starryos): Fix eventfd read and write semantics in StarryOS.

### DIFF
--- a/os/StarryOS/kernel/src/file/event.rs
+++ b/os/StarryOS/kernel/src/file/event.rs
@@ -62,7 +62,7 @@ impl FileLike for EventFd {
     }
 
     fn write(&self, src: &mut IoSrc) -> ax_io::Result<usize> {
-        if src.remaining() < size_of::<u64>() {
+        if src.remaining() != size_of::<u64>() {
             return Err(AxError::InvalidInput);
         }
 

--- a/os/StarryOS/kernel/src/file/event.rs
+++ b/os/StarryOS/kernel/src/file/event.rs
@@ -51,7 +51,8 @@ impl FileLike for EventFd {
                 });
             match result {
                 Ok(count) => {
-                    dst.write(&count.to_ne_bytes())?;
+                    let value = if self.semaphore { 1 } else { count };
+                    dst.write(&value.to_ne_bytes())?;
                     self.poll_tx.wake();
                     Ok(size_of::<u64>())
                 }


### PR DESCRIPTION
## Summary

Fix eventfd read and write semantics in StarryOS.

`EventFd::read()` previously returned the old counter value from
`AtomicU64::fetch_update()` in all cases. This was incorrect for
`EFD_SEMAPHORE`, where Linux requires each successful read to return `1`
while decrementing the counter by `1`.

`EventFd::write()` also accepted buffers larger than 8 bytes and consumed
only the first 8 bytes. Linux requires eventfd writes to be exactly 8
bytes, otherwise the write must fail with `EINVAL`.

## Validation
``` bash
cargo fmt --all
cargo clippy -p starry-kernel
cargo check -p starry-kernel
```

## Reference
### commit1
[eventfd(2) - Linux manual page](https://man7.org/linux/man-pages/man2/eventfd.2.html)
[linux/fs/eventfd.c at master · torvalds/linux](https://github.com/torvalds/linux/blob/master/fs/eventfd.c#L176)

### commit2
[linux/fs/eventfd.c at master · torvalds/linux](https://github.com/torvalds/linux/blob/master/fs/eventfd.c#L247)