### PR TITLE
chore(repo): split non-USB clippy cleanups

### DIFF
--- a/components/arm_vcpu/src/exception.rs
+++ b/components/arm_vcpu/src/exception.rs
@@ -222,7 +222,7 @@ fn handle_system_register(context_frame: &mut TrapFrame) -> AxResult<AxVCpuExitR
     if write {
         return Ok(AxVCpuExitReason::SysRegWrite {
             addr: SysRegAddr::new(addr),
-            value: context_frame.gpr(reg as usize) as u64,
+            value: context_frame.gpr(reg) as u64,
         });
     }
     Ok(AxVCpuExitReason::SysRegRead {

--- a/components/arm_vcpu/src/vcpu.rs
+++ b/components/arm_vcpu/src/vcpu.rs
@@ -41,6 +41,7 @@ unsafe fn restore_host_sp_el0() {
 /// between VMs.
 #[repr(C)]
 #[derive(Clone, Debug, Copy, Default)]
+#[allow(dead_code)]
 pub struct VmCpuRegisters {
     /// guest trap context
     pub trap_context_regs: TrapFrame,

--- a/components/axcpu/src/uspace_common.rs
+++ b/components/axcpu/src/uspace_common.rs
@@ -53,7 +53,7 @@ impl ExceptionTableEntry {
         #[cfg(target_arch = "aarch64")]
         {
             let base = (&self.from as *const i32) as isize;
-            return (base + self.from as isize) as usize;
+            (base + self.from as isize) as usize
         }
 
         #[cfg(not(target_arch = "aarch64"))]
@@ -67,7 +67,7 @@ impl ExceptionTableEntry {
         #[cfg(target_arch = "aarch64")]
         {
             let base = (&self.to as *const i32) as isize;
-            return (base + self.to as isize) as usize;
+            (base + self.to as isize) as usize
         }
 
         #[cfg(not(target_arch = "aarch64"))]

--- a/components/fxmac_rs/src/fxmac.rs
+++ b/components/fxmac_rs/src/fxmac.rs
@@ -616,7 +616,7 @@ fn FXmacDmaReset(instance_p: &mut FXmac) {
     // let dma_brust_length = 16;
 
     let mut rx_buf_size: u32 = max_frame_size / FXMAC_RX_BUF_UNIT;
-    rx_buf_size += if (max_frame_size % FXMAC_RX_BUF_UNIT) != 0 {
+    rx_buf_size += if !max_frame_size.is_multiple_of(FXMAC_RX_BUF_UNIT) {
         1
     } else {
         0
@@ -942,7 +942,7 @@ fn FXmacSetOptions(instance_p: &mut FXmac, options: u32, queue_num: u32) -> u32 
                 reg &= !FXMAC_DMACR_RXBUF_MASK;
 
                 rx_buf_size = instance_p.max_frame_size / FXMAC_RX_BUF_UNIT;
-                rx_buf_size += if (instance_p.max_frame_size % FXMAC_RX_BUF_UNIT) != 0 {
+                rx_buf_size += if !instance_p.max_frame_size.is_multiple_of(FXMAC_RX_BUF_UNIT) {
                     1
                 } else {
                     0
@@ -953,7 +953,7 @@ fn FXmacSetOptions(instance_p: &mut FXmac, options: u32, queue_num: u32) -> u32 
             } else if queue_num < instance_p.config.max_queue_num {
                 let mut rx_buf_size: u32 = 0;
                 rx_buf_size = instance_p.max_frame_size / FXMAC_RX_BUF_UNIT;
-                rx_buf_size += if (instance_p.max_frame_size % FXMAC_RX_BUF_UNIT) != 0 {
+                rx_buf_size += if !instance_p.max_frame_size.is_multiple_of(FXMAC_RX_BUF_UNIT) {
                     1
                 } else {
                     0
@@ -1118,7 +1118,7 @@ fn FXmacClearOptions(instance_p: &mut FXmac, options: u32, queue_num: u32) -> u3
                 reg &= !FXMAC_DMACR_RXBUF_MASK;
 
                 rx_buf_size = instance_p.max_frame_size / FXMAC_RX_BUF_UNIT;
-                rx_buf_size += if instance_p.max_frame_size % FXMAC_RX_BUF_UNIT != 0 {
+                rx_buf_size += if !instance_p.max_frame_size.is_multiple_of(FXMAC_RX_BUF_UNIT) {
                     1
                 } else {
                     0
@@ -1130,7 +1130,7 @@ fn FXmacClearOptions(instance_p: &mut FXmac, options: u32, queue_num: u32) -> u3
             } else if (queue_num < instance_p.config.max_queue_num) {
                 let mut rx_buf_size: u32 = 0;
                 rx_buf_size = instance_p.max_frame_size / FXMAC_RX_BUF_UNIT;
-                rx_buf_size += if (instance_p.max_frame_size % FXMAC_RX_BUF_UNIT) != 0 {
+                rx_buf_size += if !instance_p.max_frame_size.is_multiple_of(FXMAC_RX_BUF_UNIT) {
                     1
                 } else {
                     0

--- a/components/fxmac_rs/src/fxmac_const.rs
+++ b/components/fxmac_rs/src/fxmac_const.rs
@@ -13,7 +13,6 @@ pub(crate) const FXMAC_MAX_TXBD: u32 = 128; /* Size of TX buffer descriptor queu
 pub(crate) const FXMAC_MAX_HASH_BITS: u32 = 64; /* Maximum value for hash bits. 2**6 */
 
 /// ************************ Constant Definitions ****************************
-
 pub(crate) const FXMAC_MAX_MAC_ADDR: u32 = 4; /* Maxmum number of mac address supported */
 pub(crate) const FXMAC_MAX_TYPE_ID: u32 = 4; /* Maxmum number of type id supported */
 

--- a/components/fxmac_rs/src/fxmac_dma.rs
+++ b/components/fxmac_rs/src/fxmac_dma.rs
@@ -527,7 +527,7 @@ pub fn FXmacBdRingCreate(
     ring_ptr.post_cnt = 0;
 
     // 该地址必须对齐alignment=128
-    assert!((virt_addr_loc % alignment) == 0);
+    assert!(virt_addr_loc.is_multiple_of(alignment));
     assert!(bd_count > 0);
 
     // 相邻BD之间隔多少bytes
@@ -628,7 +628,7 @@ pub fn FXmacBdRingAlloc(
             "free_head {:#x} seekahead to {:#x}",
             b as usize, ring_ptr.free_head as usize
         );
-        assert!(b as usize != ring_ptr.free_head as usize);
+        assert!(!core::ptr::eq(b, ring_ptr.free_head as *const _));
 
         ring_ptr.free_cnt -= num_bd;
         ring_ptr.pre_cnt += num_bd;
@@ -1321,7 +1321,7 @@ pub fn FXmacProcessSentBds(instance_p: &mut FXmac) {
 
             let b = curbdpntr;
             curbdpntr = FXMAC_BD_RING_NEXT(txring, curbdpntr);
-            assert!(curbdpntr as usize != b as usize);
+            assert!(!core::ptr::eq(curbdpntr, b));
 
             n_pbufs_freed -= 1;
             crate::utils::DSB();

--- a/components/fxmac_rs/src/fxmac_phy.rs
+++ b/components/fxmac_rs/src/fxmac_phy.rs
@@ -217,7 +217,7 @@ pub fn FXmacPhyRead(
 ///
 /// * `instance_p` - Mutable reference to the FXMAC instance.
 /// * `reset_flag` - Set to `XMAC_PHY_RESET_ENABLE` to perform a PHY reset
-///                  before configuration, or `XMAC_PHY_RESET_DISABLE` to skip.
+///   before configuration, or `XMAC_PHY_RESET_DISABLE` to skip.
 ///
 /// # Returns
 ///

--- a/components/rsext4/src/crc32c/arm64.rs
+++ b/components/rsext4/src/crc32c/arm64.rs
@@ -62,7 +62,7 @@ pub unsafe fn crc32c_hardware(mut crc: u32, data: &[u8]) -> u32 {
         let mut len = data.len();
 
         // 1. Consume the unaligned prefix so the hot loop can use 64-bit loads.
-        while len > 0 && (p as usize) % 8 != 0 {
+        while len > 0 && !(p as usize).is_multiple_of(8) {
             crc = __crc32cb(crc, *p);
             p = p.add(1);
             len -= 1;

--- a/os/arceos/modules/axfs/src/partition.rs
+++ b/os/arceos/modules/axfs/src/partition.rs
@@ -204,11 +204,10 @@ fn parse_gpt_partitions(disk: &mut Disk) -> AxResult<Vec<PartitionInfo>> {
 
             // Read partition name as UTF-16LE
             let mut partition_name = [0u16; 36];
-            for j in 0..36 {
+            for (j, pn) in partition_name.iter_mut().enumerate() {
                 let offset = 56 + j * 2;
                 if offset + 1 < entry_data.len() {
-                    partition_name[j] =
-                        u16::from_le_bytes([entry_data[offset], entry_data[offset + 1]]);
+                    *pn = u16::from_le_bytes([entry_data[offset], entry_data[offset + 1]]);
                 }
             }
 
@@ -237,18 +236,13 @@ fn parse_gpt_partitions(disk: &mut Disk) -> AxResult<Vec<PartitionInfo>> {
         let name_str = {
             // First, copy the partition name to a local array to avoid packed field reference
             let mut name_utf16 = [0u16; 36];
+            #[allow(clippy::manual_memcpy)]
             for j in 0..36 {
                 name_utf16[j] = entry.partition_name[j];
             }
 
             // Find the null terminator
-            let mut name_len = 36;
-            for j in 0..36 {
-                if name_utf16[j] == 0 {
-                    name_len = j;
-                    break;
-                }
-            }
+            let name_len = name_utf16.iter().position(|&c| c == 0).unwrap_or(36);
 
             // Convert only the valid portion
             let name_slice = &name_utf16[..name_len];

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -15,6 +15,7 @@ arceos-priority
 arceos-sleep
 arceos-tls
 arceos-wait-queue
+arm_vcpu
 ax-allocator
 ax-arm-pl011
 ax-arm-pl031
@@ -25,6 +26,7 @@ ax-cpumask
 ax-display
 ax-dma
 ax-errno
+ax-fs
 ax-hal
 ax-fs-devfs
 ax-fs-ng
@@ -59,6 +61,7 @@ axplat-x86-qemu-q35
 axvm
 axvmconfig
 bitmap-allocator
+fxmac_rs
 loongarch_vcpu
 range-alloc-arceos
 axplat-riscv64-qemu-virt-hv

--- a/test-suit/arceos/rust/task/tls/src/main.rs
+++ b/test-suit/arceos/rust/task/tls/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(any(feature = "ax-std", target_os = "none"), no_std)]
 #![cfg_attr(any(feature = "ax-std", target_os = "none"), no_main)]
 #![feature(thread_local)]
+#![allow(unused_features)]
 #![allow(unused_unsafe)]
 
 #[cfg(any(not(target_os = "none"), feature = "ax-std"))]


### PR DESCRIPTION
## 变更内容

- 从 USB 支持分支中拆分与 USB 功能无关的 crate 代码风格/Clippy 清理。
- 覆盖 arm_vcpu、ax-cpu、fxmac_rs、rsext4、ax-fs 和 arceos-tls 中的轻量清理。
- 将已验证通过的 arm_vcpu、ax-fs、fxmac_rs 补充到 scripts/test/clippy_crates.csv。

## 影响

- 降低 USB 支持 PR 中的无关 diff 噪音。
- 扩展 clippy 覆盖范围，便于后续持续检查这些 crate。

## 验证

- cargo fmt --check
- cargo xtask clippy --package ax-cpu
- cargo xtask clippy --package rsext4
- cargo xtask clippy --package arceos-tls
- cargo xtask clippy --package arm_vcpu
- cargo xtask clippy --package fxmac_rs
- cargo xtask clippy --package ax-fs
