### PR TITLE
fix(vfs): hard links on tmpfs return empty data — propagate page cache on link

### DIFF
--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -217,6 +217,15 @@ impl DirNode {
         verify_entry_name(name)?;
 
         self.ops.link(name, node).inspect(|entry| {
+            // Hard links must share the same page cache (user_data) as the
+            // source node.  Without this, in-memory filesystems like tmpfs
+            // would create a new empty page cache for the link, losing the
+            // file content.
+            {
+                let src = node.user_data();
+                let mut dst = entry.user_data();
+                *dst = src.clone();
+            }
             self.cache.lock().insert(name.to_owned(), entry.clone());
         })
     }

--- a/components/axfs-ng-vfs/src/node/mod.rs
+++ b/components/axfs-ng-vfs/src/node/mod.rs
@@ -149,7 +149,7 @@ impl Reference {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct TypeMap(SmallVec<[(TypeId, Arc<dyn Any + Send + Sync>); 2]>);
 impl TypeMap {
     pub fn new() -> Self {

--- a/test-suit/starryos/normal/busybox/sh/busybox-tests.sh
+++ b/test-suit/starryos/normal/busybox/sh/busybox-tests.sh
@@ -786,6 +786,11 @@ if echo "$_t" | grep -qF "gg_"; then echo "PASS: addgroup"; PASS=$((PASS+1)); el
 # Custom test: adduser
 _t=$({ timeout 10 sh -c "U=\$(date +%s); busybox deluser \"uu_\$U\" 2>/dev/null; busybox adduser -D -H \"uu_\$U\" 2>&1 && busybox grep -F \"uu_\$U:\" /etc/passwd 2>&1; busybox deluser \"uu_\$U\" 2>/dev/null"; } 2>&1)
 if echo "$_t" | grep -qF "uu_"; then echo "PASS: adduser"; PASS=$((PASS+1)); else echo "FAIL: adduser"; FAIL=$((FAIL+1)); fi
+
+# busybox_link — create hard link on tmpfs and verify content is shared
+_t=$({ timeout 10 sh -c 'busybox rm -f /tmp/bb_link_a /tmp/bb_link_b; busybox echo link_data > /tmp/bb_link_a && busybox link /tmp/bb_link_a /tmp/bb_link_b && busybox cat /tmp/bb_link_b'; } 2>&1)
+if echo "$_t" | grep -qF "link_data"; then echo "PASS: busybox_link"; PASS=$((PASS+1)); else echo "FAIL: busybox_link"; FAIL=$((FAIL+1)); fi
+
 echo "=== BusyBox Test Summary ==="
 echo "PASS: $PASS  FAIL: $FAIL  TOTAL: $((PASS+FAIL))"
 _m1="Test"; _m2="run"; _m3="completed"; echo "$_m1 $_m2 $_m3"


### PR DESCRIPTION
**fix(vfs): hard links on tmpfs return empty data — propagate page cache on link**

**Depends on:** https://github.com/rcore-os/tgoskits/pull/377 (must be merged first)

### Problem

`busybox link` (hard link) on tmpfs creates a file that reads back as empty:

```
echo hello > /tmp/a
link /tmp/a /tmp/b
cat /tmp/b        # empty!
```

### Root cause

`DirNode::link()` delegates to the filesystem's `link()` which returns a new `DirEntry`. This new entry has an empty `user_data` (`TypeMap`). For tmpfs, the page cache — which *is* the file content — is stored in `user_data` as `FileUserData(Arc<CachedFileShared>)`. When the hard link is later opened, `CachedFile::get_or_create` finds no existing cache in the new entry's `user_data` and creates a fresh empty one, so all reads return zero bytes.

### Fix

After the filesystem-level `link()` creates the new `DirEntry`, clone the source node's `user_data` into it. Since `TypeMap` stores `Arc` values, cloning shares the same underlying page cache rather than copying data.

Changes:
- `components/axfs-ng-vfs/src/node/dir.rs`: propagate `user_data` from source to new entry in `DirNode::link()`
- `components/axfs-ng-vfs/src/node/mod.rs`: derive `Clone` for `TypeMap`
- `test-suit/starryos/normal/busybox/sh/busybox-tests.sh`: add `busybox_link` test case

Tested on riscv64 (tmpfs) and x86_64 (ext4 + tmpfs).