### PR TITLE
fix(starryos): validate pwrite64 fd before zero-length return

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -34,14 +34,17 @@ fn file_or_espipe(fd: c_int) -> AxResult<Arc<File>> {
 
 /// Like `file_or_espipe`, but for write operations: converts IsADirectory
 /// to BadFileDescriptor because directories cannot be opened for writing.
+/// and verifies that the file descriptor is writable.
 fn file_or_espipe_write(fd: c_int) -> AxResult<Arc<File>> {
-    file_or_espipe(fd).map_err(|e| {
+    let f = file_or_espipe(fd).map_err(|e| {
         if e == AxError::IsADirectory {
             AxError::BadFileDescriptor
         } else {
             e
         }
-    })
+    })?;
+    let _ = f.inner().access(FileFlags::WRITE)?;
+    Ok(f)
 }
 
 struct DummyFd;
@@ -230,10 +233,10 @@ pub fn sys_pwrite64(
     if offset < 0 {
         return Err(AxError::InvalidInput);
     }
+    let f = file_or_espipe_write(fd)?;
     if len == 0 {
         return Ok(0);
     }
-    let f = file_or_espipe_write(fd)?;
     let write = f.inner().write_at(VmBytes::new(buf, len), offset as _)?;
     Ok(write as _)
 }


### PR DESCRIPTION
## Summary

Fix `pwrite64` zero-length handling on non-seekable file descriptors.

In `sys_pwrite64()`, the `len == 0` fast path previously returned success
before validating whether the fd supported positional writes. This caused
calls on non-seekable descriptors such as `eventfd` and pipes to return
success where Linux returns `ESPIPE`.

This change moves fd validation ahead of the zero-length early return so
that `pwrite64` preserves Linux-compatible seekability checks even when no
data is written.

## References

- Linux `pread(2)` / `pwrite(2)` manual:
  https://man7.org/linux/man-pages/man2/pwrite.2.html

- Linux kernel source (`fs/read_write.c`):
  https://github.com/torvalds/linux/blob/master/fs/read_write.c#L784
