### PR TITLE
适配硬件平台sg2002

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ __pycache__/
 *.img
 !.claude/skills/*
 /tmp/*
+*.vi
 
 .arceos*
 .starry*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
     "components/axplat_crates/platforms/axplat-aarch64-raspi",
     "components/axplat_crates/platforms/axplat-loongarch64-qemu-virt",
     "components/axplat_crates/platforms/axplat-riscv64-qemu-virt",
+    "components/axplat_crates/platforms/axplat-riscv64-sg2002",
     "components/axplat_crates/platforms/axplat-x86-pc",
     "components/axpoll",
     "components/axsched",
@@ -263,6 +264,7 @@ ax-plat-aarch64-raspi = { version = "0.5.7", path = "components/axplat_crates/pl
 ax-plat-loongarch64-qemu-virt = { version = "0.5.7", path = "components/axplat_crates/platforms/axplat-loongarch64-qemu-virt" }
 ax-plat-macros = { version = "0.3.5", path = "components/axplat_crates/axplat-macros" }
 ax-plat-riscv64-qemu-virt = { version = "0.5.6", path = "components/axplat_crates/platforms/axplat-riscv64-qemu-virt" }
+ax-plat-riscv64-sg2002 = { version = "0.3.1", path = "components/axplat_crates/platforms/axplat-riscv64-sg2002" }
 ax-plat-x86-pc = { version = "0.5.7", path = "components/axplat_crates/platforms/axplat-x86-pc" }
 ax-posix-api = { version = "0.5.12", path = "os/arceos/api/arceos_posix_api" }
 ax-riscv-plic = { version = "0.4.4", path = "components/riscv_plic" }

--- a/components/axcpu/Cargo.toml
+++ b/components/axcpu/Cargo.toml
@@ -26,6 +26,7 @@ fp-simd = []
 tls = []
 uspace = []
 arm-el2 = ["ax-page-table-entry/arm-el2"]
+xuantie-c9xx = ["ax-page-table-entry/xuantie-c9xx"]
 
 [dependencies]
 axbacktrace = { workspace = true }

--- a/components/axcpu/src/riscv/uspace.rs
+++ b/components/axcpu/src/riscv/uspace.rs
@@ -31,6 +31,10 @@ impl UserContext {
         #[cfg(feature = "fp-simd")]
         sstatus.set_fs(FS::Initial); // set the FPU to initial state
 
+        #[cfg(feature = "xuantie-c9xx")]
+        // enable vector status bits of sstatus
+        Self::set_sstatus(&mut sstatus, 0x3 << 23, false);
+
         Self(TrapFrame {
             regs: GeneralRegisters {
                 a0: arg0,
@@ -52,6 +56,9 @@ impl UserContext {
         unsafe extern "C" {
             fn enter_user(uctx: &mut UserContext);
         }
+
+        // Refresh all instruction caches before entering the user program space to resolve user program errors
+        riscv::asm::fence_i();
 
         crate::asm::disable_irqs();
         unsafe { enter_user(self) };
@@ -87,6 +94,24 @@ impl UserContext {
 
         crate::asm::enable_irqs();
         ret
+    }
+
+    /// Sets the sstatus register.
+    /// Due to the restriction of Sstatus struct, some bits of the sstatus register cannot be effectively set,
+    /// So this function can effectively set the required bits of sstatus.
+    pub fn set_sstatus(sstatus: &mut Sstatus, bits: usize, is_clear: bool) {
+        if bits == 0 {
+            log::error!("Invalid parameter: {:x}", bits);
+            return;
+        }
+        unsafe {
+            let sstatus_ptr = sstatus as *mut Sstatus as *mut usize;
+            if is_clear {
+                *sstatus_ptr &= !bits;
+            } else {
+                *sstatus_ptr |= bits;
+            }
+        }
     }
 }
 

--- a/components/axdriver_crates/axdriver_block/Cargo.toml
+++ b/components/axdriver_crates/axdriver_block/Cargo.toml
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 ramdisk = []
 ramdisk-static = []
 sdmmc = ["dep:simple-sdmmc"]
+cvsd = ["dep:sg200x-bsp"]
 ahci = ["dep:simple-ahci"]
 bcm2835-sdhci = ["dep:bcm2835-sdhci"]
 
@@ -24,3 +25,4 @@ log = { workspace = true }
 simple-sdmmc = { workspace = true, optional = true }
 simple-ahci = { version = "0.1.1-preview.1", optional = true }
 bcm2835-sdhci = { version = "0.1.1-preview.1", optional = true }
+sg200x-bsp = { version = "0.4.0", optional = true }

--- a/components/axdriver_crates/axdriver_block/Cargo.toml
+++ b/components/axdriver_crates/axdriver_block/Cargo.toml
@@ -25,4 +25,4 @@ log = { workspace = true }
 simple-sdmmc = { workspace = true, optional = true }
 simple-ahci = { version = "0.1.1-preview.1", optional = true }
 bcm2835-sdhci = { version = "0.1.1-preview.1", optional = true }
-sg200x-bsp = { version = "0.4.0", optional = true }
+sg200x-bsp = { version = "0.5.4", optional = true }

--- a/components/axdriver_crates/axdriver_block/src/cvsd.rs
+++ b/components/axdriver_crates/axdriver_block/src/cvsd.rs
@@ -35,8 +35,7 @@ impl BaseDriverOps for CvsdDriver {
 
 impl BlockDriverOps for CvsdDriver {
     fn num_blocks(&self) -> u64 {
-        // Capacity info is not exposed by sg200x-bsp sdmmc yet.
-        67108864 // Fake capacity info: 32G
+        self.0.card_capacity_blocks()
     }
 
     fn block_size(&self) -> usize {

--- a/components/axdriver_crates/axdriver_block/src/cvsd.rs
+++ b/components/axdriver_crates/axdriver_block/src/cvsd.rs
@@ -1,0 +1,81 @@
+//! A SD Card driver for cv181x-sd device
+
+use ax_driver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
+use sg200x_bsp::sdmmc::Sdmmc;
+
+use crate::BlockDriverOps;
+
+const BLOCK_SIZE: usize = 512;
+
+/// CVSD driver based on SG200x BSP SD/MMC.
+pub struct CvsdDriver(Sdmmc);
+
+unsafe impl Send for CvsdDriver {}
+unsafe impl Sync for CvsdDriver {}
+
+impl CvsdDriver {
+    /// Initializes SD/MMC and creates a new [`CvsdDriver`].
+    pub fn new(sdmmc: usize, syscon: usize) -> DevResult<Self> {
+        let sdmmc = unsafe { Sdmmc::from_base_addresses(sdmmc, syscon) };
+        sdmmc.init().map_err(|_| DevError::Io)?;
+        sdmmc.clk_en(true);
+        Ok(Self(sdmmc))
+    }
+}
+
+impl BaseDriverOps for CvsdDriver {
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Block
+    }
+
+    fn device_name(&self) -> &str {
+        "cvsd"
+    }
+}
+
+impl BlockDriverOps for CvsdDriver {
+    fn num_blocks(&self) -> u64 {
+        // Capacity info is not exposed by sg200x-bsp sdmmc yet.
+        67108864 // Fake capacity info: 32G
+    }
+
+    fn block_size(&self) -> usize {
+        BLOCK_SIZE
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> DevResult {
+        let (blocks, remainder) = buf.as_chunks_mut::<{ BLOCK_SIZE }>();
+
+        if !remainder.is_empty() {
+            return Err(DevError::InvalidParam);
+        }
+
+        for (i, block) in blocks.iter_mut().enumerate() {
+            self.0
+                .read_block(block_id as u32 + i as u32, block)
+                .map_err(|_| DevError::Io)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> DevResult {
+        let (blocks, remainder) = buf.as_chunks::<{ BLOCK_SIZE }>();
+
+        if !remainder.is_empty() {
+            return Err(DevError::InvalidParam);
+        }
+
+        for (i, block) in blocks.iter().enumerate() {
+            self.0
+                .write_block(block_id as u32 + i as u32, block)
+                .map_err(|_| DevError::Io)?;
+        }
+
+        Ok(())
+    }
+
+    fn flush(&mut self) -> DevResult {
+        Ok(())
+    }
+}

--- a/components/axdriver_crates/axdriver_block/src/lib.rs
+++ b/components/axdriver_crates/axdriver_block/src/lib.rs
@@ -10,6 +10,9 @@ use alloc::boxed::Box;
 #[cfg(feature = "bcm2835-sdhci")]
 pub mod bcm2835sdhci;
 
+#[cfg(feature = "cvsd")]
+pub mod cvsd;
+
 #[cfg(feature = "ramdisk")]
 pub mod ramdisk;
 

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/Cargo.toml
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "ax-plat-riscv64-sg2002"
+version = "0.3.1"
+authors = [
+    "Luoyuan Xiao <xiaoluoyuan@163.com>",
+    "Zechen Peng <927068267@qq.com>",
+    "yfblock <321353225@qq.com>",
+]
+description = "Implementation of `axplat` hardware abstraction layer for SG2002 board."
+documentation = "https://docs.rs/axplat-riscv64-sg2002"
+keywords = ["arceos", "os", "hal", "embedded", "riscv"]
+categories = ["embedded", "no-std", "hardware-support", "os"]
+repository = "https://github.com/elliott10/axplat-riscv64-sg2002"
+license = "Apache-2.0"
+edition = "2024"
+
+[features]
+fp-simd = ["ax-cpu/fp-simd"]
+irq = ["ax-plat/irq", "dep:ax-riscv-plic"]
+rtc = []
+smp = ["ax-plat/smp"]
+
+[dependencies]
+ax-kspin = "0.3.1"
+ax-lazyinit = "0.4.2"
+log = "0.4"
+riscv = "0.16"
+dw_uart_rs = "0.2.0"
+ax-config-macros = "0.4.1"
+sbi-rt = { version = "0.0.3", features = ["legacy"] }
+ax-riscv-plic = { version = "0.4.0", optional = true }
+
+ax-cpu = { workspace = true, features = ["xuantie-c9xx"] }
+ax-plat = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["riscv64gc-unknown-none-elf"]

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/README.md
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/README.md
@@ -1,0 +1,56 @@
+# axplat-riscv64-sg2002
+
+Implementation of [axplat](https://github.com/arceos-org/axplat_crates/tree/main/axplat) hardware abstraction layer for SG2002 board.
+
+## Install
+
+```bash
+cargo +nightly add axplat axplat-riscv64-sg2002
+```
+
+## Usage
+### How to build
+```
+git clone https://github.com/elliott10/axplat-riscv64-sg2002 -b sg2002-apache
+cd axplat-riscv64-sg2002
+cargo build --target riscv64gc-unknown-none-elf
+```
+
+### Startup on SG2002
+```
+make ARCH=riscv64 APP_FEATURES=sg2002 MYPLAT=axplat-riscv64-sg2002 LOG=debug BUS=mmio UIMAGE=y build
+
+```
+
+----
+#### 1. Write your kernel code
+
+```rust
+#[axplat::main]
+fn kernel_main(cpu_id: usize, arg: usize) -> ! {
+    // Initialize trap, console, time.
+    axplat::init::init_early(cpu_id, arg);
+    // Initialize platform peripherals (not used in this example).
+    axplat::init::init_later(cpu_id, arg);
+
+    // Write your kernel code here.
+    axplat::console_println!("Hello, ArceOS!");
+
+    // Power off the system.
+    axplat::power::system_off();
+}
+```
+
+#### 2. Link your kernel with this package
+
+```rust
+// Can be located at any dependency crate.
+extern crate axplat_riscv64_sg2002;
+```
+
+#### 3. Use a linker script like the following
+
+Some sections are required to be defined in the linker script, listed as below:
+- `.text.boot`: Kernel boot code.
+- `.bss.stack`: Stack for kernel booting.
+

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/axconfig.toml
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/axconfig.toml
@@ -1,0 +1,77 @@
+# Architecture identifier.
+arch = "riscv64"                                # str
+# Platform identifier.
+platform = "riscv64-sg2002"                     # str
+# Platform package.
+package = "ax-plat-riscv64-sg2002"              # str
+
+#
+# Platform configs
+#
+[plat]
+# Number of CPUs.
+max-cpu-num = 1                     # uint
+# Base address of the whole physical memory.
+phys-memory-base = 0x8000_0000      # uint
+# Size of the whole physical memory. (0x8000_0000..0x8fe0_0000)
+phys-memory-size = 0x0fe0_0000      # uint
+# Base physical address of the kernel image.
+kernel-base-paddr = 0x8020_0000     # uint
+# Base virtual address of the kernel image.
+kernel-base-vaddr = "0xffff_ffc0_8020_0000"     # uint
+# Linear mapping offset, for quick conversions between physical and virtual
+# addresses.
+phys-virt-offset = "0xffff_ffc0_0000_0000"      # uint
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = 0                             # uint
+# Kernel address space base.
+kernel-aspace-base = "0xffff_ffc0_0000_0000"    # uint
+# Kernel address space size.
+kernel-aspace-size = "0x0000_003f_ffff_f000"    # uint
+# Stack size on bootstrapping. (256K)
+boot-stack-size = 0x40000                       # uint
+
+#
+# Device specifications
+#
+[devices]
+# MMIO ranges with format (`base_paddr`, `size`).
+mmio-ranges = [
+    [0x0300_0000, 0x8000],          # SYSCON
+    [0x0414_0000, 0x1000],          # UART0
+    [0x0431_0000, 0x1000],          # cv sdmmc
+    [0x0502_6000, 0x1000],          # RTC
+    [0x0c10_0000, 0x2000],          # TPU
+    [0x7000_0000, 0x0400_0000],     # PLIC
+    [0x7400_0000, 0x1_0000],        # CLINT
+]                                   # [(uint, uint)]
+virtio-mmio-ranges = [] # [(uint, uint)]
+
+# Timer interrupt frequency in Hz.
+timer-frequency = 25_000_000        # uint
+# Timer interrupt num.
+timer-irq = "0x8000_0000_0000_0005" # uint
+# IPI interrupt num
+ipi-irq = "0x8000_0000_0000_0001"   # uint
+
+rtc-paddr = 0x0502_6000             # uint
+
+# interrupt-controller@70000000 {
+#     reg = <0x00 0x70000000 0x00 0x4000000>;
+#     compatible = "riscv,plic0";
+# };
+plic-paddr = 0x7000_0000            # uint
+
+# serial@04140000 {
+#     interrupts = <0x2c 0x04>;
+#     interrupt-parent = <0x04>;
+#     reg = <0x00 0x4140000 0x00 0x1000>;
+#     compatible = "snps,dw-apb-uart";
+# };
+uart-paddr = 0x0414_0000            # uint
+uart-irq = 0x2c                     # uint
+
+syscon-paddr = 0x0300_0000          # uint
+cvsd-paddr = 0x0431_0000            # uint
+root-partition-name = "rootfs"      # str

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/build.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=AX_CONFIG_PATH");
+    if let Ok(config_path) = std::env::var("AX_CONFIG_PATH") {
+        println!("cargo:rerun-if-changed={config_path}");
+    }
+}

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/rust-toolchain.toml
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+profile = "minimal"
+channel = "nightly-2025-05-20"
+components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
+targets = [
+    "riscv64gc-unknown-none-elf",
+]

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/boot.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/boot.rs
@@ -1,0 +1,114 @@
+use ax_plat::mem::{Aligned4K, pa};
+
+use crate::config::plat::{BOOT_STACK_SIZE, PHYS_VIRT_OFFSET};
+
+#[unsafe(link_section = ".bss.stack")]
+static mut BOOT_STACK: [u8; BOOT_STACK_SIZE] = [0; BOOT_STACK_SIZE];
+
+#[unsafe(link_section = ".data")]
+static mut BOOT_PT_SV39: Aligned4K<[u64; 512]> = Aligned4K::new([0; 512]);
+
+#[allow(clippy::identity_op)] // (0x0 << 10) here makes sense because it's an address
+unsafe fn init_boot_page_table() {
+    unsafe {
+        const PTE_FLAGS: u64 = 0xef; // VRWX_GAD
+        const PTE_SO: u64 = 1u64 << 63;
+        const PTE_CACHE: u64 = 1u64 << 62;
+        const PTE_BUF: u64 = 1u64 << 61;
+        const PTE_SHARE: u64 = 1u64 << 60;
+
+        const KERNEL_FLAGS: u64 = PTE_FLAGS | PTE_CACHE | PTE_BUF | PTE_SHARE;
+        const IOREMAP_FLAGS: u64 = PTE_FLAGS | PTE_SO | PTE_SHARE;
+
+        // 0x0000_0000..0x4000_0000, device/MMIO, 1G block
+        BOOT_PT_SV39[0] = (0x0 << 10) | IOREMAP_FLAGS;
+        // 0x4000_0000..0x8000_0000, device/MMIO, 1G block
+        BOOT_PT_SV39[1] = (0x40000 << 10) | IOREMAP_FLAGS;
+        // 0x8000_0000..0xc000_0000, kernel memory, 1G block
+        BOOT_PT_SV39[2] = (0x80000 << 10) | KERNEL_FLAGS;
+        // 0xffff_ffc0_0000_0000..0xffff_ffc0_4000_0000, device/MMIO, 1G block
+        BOOT_PT_SV39[0x100] = (0x0 << 10) | IOREMAP_FLAGS;
+        // 0xffff_ffc0_4000_0000..0xffff_ffc0_8000_0000, device/MMIO, 1G block
+        BOOT_PT_SV39[0x101] = (0x40000 << 10) | IOREMAP_FLAGS;
+        // 0xffff_ffc0_8000_0000..0xffff_ffc0_c000_0000, kernel memory, 1G block
+        BOOT_PT_SV39[0x102] = (0x80000 << 10) | KERNEL_FLAGS;
+    }
+}
+
+unsafe fn init_mmu() {
+    unsafe {
+        ax_cpu::asm::write_kernel_page_table(pa!(&raw const BOOT_PT_SV39 as usize));
+        ax_cpu::asm::flush_tlb(None);
+    }
+}
+
+/// The earliest entry point for the primary CPU.
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = ".text.boot")]
+unsafe extern "C" fn _start() -> ! {
+    // PC = 0x8020_0000
+    // a0 = hartid
+    // a1 = dtb
+    core::arch::naked_asm!("
+        mv      s0, a0                  // save hartid
+        mv      s1, a1                  // save DTB pointer
+        la      sp, {boot_stack}
+        li      t0, {boot_stack_size}
+        add     sp, sp, t0              // setup boot stack
+
+        # Print: <id>\n
+        li a7, 1
+        addi a0, a0, 48
+        ecall
+        li a7, 1
+        li a0, 10
+        ecall
+
+        call    {init_boot_page_table}
+        call    {init_mmu}              // setup boot page table and enabel MMU
+
+        li      s2, {phys_virt_offset}  // fix up virtual high address
+        add     sp, sp, s2
+
+        mv      a0, s0
+        mv      a1, s1
+        la      a2, {entry}
+        add     a2, a2, s2
+        jalr    a2                      // call_main(cpu_id, dtb)
+        j       .",
+        phys_virt_offset = const PHYS_VIRT_OFFSET,
+        boot_stack_size = const BOOT_STACK_SIZE,
+        boot_stack = sym BOOT_STACK,
+        init_boot_page_table = sym init_boot_page_table,
+        init_mmu = sym init_mmu,
+        entry = sym ax_plat::call_main,
+    )
+}
+
+/// The earliest entry point for secondary CPUs.
+#[cfg(feature = "smp")]
+#[unsafe(naked)]
+pub(crate) unsafe extern "C" fn _start_secondary() -> ! {
+    // a0 = hartid
+    // a1 = SP
+    core::arch::naked_asm!("
+        mv      s0, a0                  // save hartid
+        mv      sp, a1                  // set SP
+
+        call    {init_mmu}              // setup boot page table and enabel MMU
+
+        li      s1, {phys_virt_offset}  // fix up virtual high address
+        add     a1, a1, s1
+        add     sp, sp, s1
+
+        mv      a0, s0
+        la      a1, {entry}
+        add     a1, a1, s1
+        jalr    a1                      // call_secondary_main(cpu_id)
+        j       .",
+        phys_virt_offset = const PHYS_VIRT_OFFSET,
+        init_mmu = sym init_mmu,
+        entry = sym ax_plat::call_secondary_main,
+    )
+}

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/console.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/console.rs
@@ -1,0 +1,64 @@
+use ax_kspin::SpinNoIrq;
+use ax_lazyinit::LazyInit;
+use ax_plat::console::{ConsoleIf, ConsoleIrqEvent};
+use dw_uart_rs::DW8250;
+
+use crate::config::{devices::UART_PADDR, plat::PHYS_VIRT_OFFSET};
+
+static UART: LazyInit<SpinNoIrq<DW8250>> = LazyInit::new();
+
+pub(crate) fn init_early() {
+    UART.init_once({
+        let mut uart = DW8250::new(UART_PADDR + PHYS_VIRT_OFFSET);
+        // SG2002 uses dw-apb-uart with 25MHz clock, 115200 baud.
+        uart.ns16550_init(25_000_000, 115200);
+        SpinNoIrq::new(uart)
+    });
+}
+
+struct ConsoleIfImpl;
+
+#[impl_plat_interface]
+impl ConsoleIf for ConsoleIfImpl {
+    /// Writes bytes to the console from input u8 slice.
+    fn write_bytes(bytes: &[u8]) {
+        for &c in bytes {
+            let mut uart = UART.lock();
+            match c {
+                b'\n' => {
+                    uart.putchar(b'\r');
+                    uart.putchar(b'\n');
+                }
+                c => uart.putchar(c),
+            }
+        }
+    }
+
+    /// Reads bytes from the console into the given mutable slice.
+    /// Returns the number of bytes read.
+    fn read_bytes(bytes: &mut [u8]) -> usize {
+        let mut uart = UART.lock();
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            match uart.getchar() {
+                Some(c) => *byte = c,
+                None => return i,
+            }
+        }
+        bytes.len()
+    }
+
+    /// Returns the IRQ number for the console, if applicable.
+    #[cfg(feature = "irq")]
+    fn irq_num() -> Option<usize> {
+        // Some(crate::config::devices::UART_IRQ)
+        None
+    }
+
+    #[cfg(feature = "irq")]
+    fn set_input_irq_enabled(_enabled: bool) {}
+
+    #[cfg(feature = "irq")]
+    fn handle_irq() -> ConsoleIrqEvent {
+        ConsoleIrqEvent::empty()
+    }
+}

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/init.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/init.rs
@@ -1,0 +1,40 @@
+use ax_plat::init::InitIf;
+
+struct InitIfImpl;
+
+#[impl_plat_interface]
+impl InitIf for InitIfImpl {
+    /// This function should be called immediately after the kernel has booted,
+    /// and performed earliest platform configuration and initialization (e.g.,
+    /// early console, clocking).
+    fn init_early(_cpu_id: usize, _mbi: usize) {
+        ax_cpu::init::init_trap();
+        crate::console::init_early();
+        crate::time::init_early();
+    }
+
+    /// Initializes the platform at the early stage for secondary cores.
+    #[cfg(feature = "smp")]
+    fn init_early_secondary(_cpu_id: usize) {
+        ax_cpu::init::init_trap();
+    }
+
+    /// Initializes the platform at the later stage for the primary core.
+    ///
+    /// This function should be called after the kernel has done part of its
+    /// initialization (e.g, logging, memory management), and finalized the rest of
+    /// platform configuration and initialization.
+    fn init_later(_cpu_id: usize, _arg: usize) {
+        #[cfg(feature = "irq")]
+        crate::irq::init_percpu();
+        crate::time::init_percpu();
+    }
+
+    /// Initializes the platform at the later stage for secondary cores.
+    #[cfg(feature = "smp")]
+    fn init_later_secondary(_cpu_id: usize) {
+        #[cfg(feature = "irq")]
+        crate::irq::init_percpu();
+        crate::time::init_percpu();
+    }
+}

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/irq.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/irq.rs
@@ -1,0 +1,254 @@
+use core::{
+    num::NonZeroU32,
+    ptr::NonNull,
+    sync::atomic::{AtomicPtr, Ordering},
+};
+
+use ax_kspin::SpinNoIrq;
+use ax_plat::{
+    irq::{HandlerTable, IpiTarget, IrqHandler, IrqIf},
+    percpu::this_cpu_id,
+};
+use ax_riscv_plic::Plic;
+use riscv::register::sie;
+use sbi_rt::HartMask;
+
+use crate::config::{devices::PLIC_PADDR, plat::PHYS_VIRT_OFFSET};
+
+/// `Interrupt` bit in `scause`
+pub(super) const INTC_IRQ_BASE: usize = 1 << (usize::BITS - 1);
+
+/// Supervisor software interrupt in `scause`
+#[allow(unused)]
+pub(super) const S_SOFT: usize = INTC_IRQ_BASE + 1;
+
+/// Supervisor timer interrupt in `scause`
+pub(super) const S_TIMER: usize = INTC_IRQ_BASE + 5;
+
+/// Supervisor external interrupt in `scause`
+pub(super) const S_EXT: usize = INTC_IRQ_BASE + 9;
+
+static TIMER_HANDLER: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+
+static IPI_HANDLER: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+
+/// The maximum number of IRQs.
+pub const MAX_IRQ_COUNT: usize = 1024;
+
+static IRQ_HANDLER_TABLE: HandlerTable<MAX_IRQ_COUNT> = HandlerTable::new();
+
+static PLIC: SpinNoIrq<Plic> = SpinNoIrq::new(unsafe {
+    Plic::new(NonNull::new((PHYS_VIRT_OFFSET + PLIC_PADDR) as *mut _).unwrap())
+});
+
+fn this_context() -> usize {
+    let hart_id = this_cpu_id();
+    hart_id * 2 + 1 // supervisor context
+}
+
+pub(super) fn init_percpu() {
+    // enable soft interrupts, timer interrupts, and external interrupts
+    unsafe {
+        sie::set_ssoft();
+        sie::set_stimer();
+        sie::set_sext();
+    }
+    PLIC.lock().init_by_context(this_context());
+}
+
+macro_rules! with_cause {
+    (
+        $cause:expr, @S_TIMER =>
+        $timer_op:expr, @S_SOFT =>
+        $ipi_op:expr, @S_EXT =>
+        $ext_op:expr, @EX_IRQ =>
+        $plic_op:expr $(,)?
+    ) => {
+        match $cause {
+            S_TIMER => $timer_op,
+            S_SOFT => $ipi_op,
+            S_EXT => $ext_op,
+            other => {
+                if other & INTC_IRQ_BASE == 0 {
+                    // Device-side interrupts read from PLIC
+                    $plic_op
+                } else {
+                    // Other CPU-side interrupts
+                    panic!("Unknown IRQ cause: {other}");
+                }
+            }
+        }
+    };
+}
+
+struct IrqIfImpl;
+
+#[impl_plat_interface]
+impl IrqIf for IrqIfImpl {
+    /// Enables or disables the given IRQ.
+    fn set_enable(irq: usize, enabled: bool) {
+        with_cause!(
+            irq,
+            @S_TIMER => {
+                unsafe {
+                    if enabled {
+                        sie::set_stimer();
+                    } else {
+                        sie::clear_stimer();
+                    }
+                }
+            },
+            @S_SOFT => {},
+            @S_EXT => {},
+            @EX_IRQ => {
+                let Some(irq) = NonZeroU32::new(irq as _) else {
+                    return;
+                };
+                trace!("PLIC set enable: {irq} {enabled}");
+                let mut plic = PLIC.lock();
+                if enabled {
+                    plic.set_priority(irq, 6);
+                    plic.enable(irq, this_context());
+                } else {
+                    plic.disable(irq, this_context());
+                }
+            }
+        );
+    }
+
+    /// Registers an IRQ handler for the given IRQ.
+    ///
+    /// It also enables the IRQ if the registration succeeds. It returns `false` if
+    /// the registration failed.
+    ///
+    /// The `irq` parameter has the following semantics
+    /// 1. If its highest bit is 1, it means it is an interrupt on the CPU side. Its
+    /// value comes from `scause`, where [`S_SOFT`] represents software interrupt
+    /// and [`S_TIMER`] represents timer interrupt. If its value is [`S_EXT`], it
+    /// means it is an external interrupt, and the real IRQ number needs to
+    /// be obtained from PLIC.
+    /// 2. If its highest bit is 0, it means it is an interrupt on the device side,
+    /// and its value is equal to the IRQ number provided by PLIC.
+    fn register(irq: usize, handler: IrqHandler) -> bool {
+        with_cause!(
+            irq,
+            @S_TIMER => TIMER_HANDLER.compare_exchange(core::ptr::null_mut(), handler as *mut _, Ordering::AcqRel, Ordering::Acquire).is_ok(),
+            @S_SOFT => IPI_HANDLER.compare_exchange(core::ptr::null_mut(), handler as *mut _, Ordering::AcqRel, Ordering::Acquire).is_ok(),
+            @S_EXT => {
+                warn!("External IRQ should be got from PLIC, not scause");
+                false
+            },
+            @EX_IRQ => {
+                if IRQ_HANDLER_TABLE.register_handler(irq, handler) {
+                    Self::set_enable(irq, true);
+                    true
+                } else {
+                    warn!("register handler for External IRQ {irq} failed");
+                    false
+                }
+            }
+        )
+    }
+
+    /// Unregisters the IRQ handler for the given IRQ.
+    ///
+    /// It also disables the IRQ if the unregistration succeeds. It returns the
+    /// existing handler if it is registered, `None` otherwise.
+    fn unregister(irq: usize) -> Option<IrqHandler> {
+        with_cause!(
+            irq,
+            @S_TIMER => {
+                let handler = TIMER_HANDLER.swap(core::ptr::null_mut(), Ordering::AcqRel);
+                if !handler.is_null() {
+                    Some(unsafe { core::mem::transmute::<*mut (), IrqHandler>(handler) })
+                } else {
+                    None
+                }
+            },
+            @S_SOFT => {
+                let handler = IPI_HANDLER.swap(core::ptr::null_mut(), Ordering::AcqRel);
+                if !handler.is_null() {
+                    Some(unsafe { core::mem::transmute::<*mut (), IrqHandler>(handler) })
+                } else {
+                    None
+                }
+            },
+            @S_EXT => {
+                warn!("External IRQ should be got from PLIC, not scause");
+                None
+            },
+            @EX_IRQ => IRQ_HANDLER_TABLE.unregister_handler(irq).inspect(|_| Self::set_enable(irq, false))
+        )
+    }
+
+    /// Handles the IRQ.
+    ///
+    /// It is called by the common interrupt handler. It should look up in the
+    /// IRQ handler table and calls the corresponding handler. If necessary, it
+    /// also acknowledges the interrupt controller after handling.
+    fn handle(irq: usize) -> Option<usize> {
+        with_cause!(
+            irq,
+            @S_TIMER => {
+                trace!("IRQ: timer");
+                let handler = TIMER_HANDLER.load(Ordering::Acquire);
+                if !handler.is_null() {
+                    // SAFETY: The handler is guaranteed to be a valid function pointer.
+                    unsafe { core::mem::transmute::<*mut (), IrqHandler>(handler)() };
+                }
+                Some(irq)
+            },
+            @S_SOFT => {
+                trace!("IRQ: IPI");
+                let handler = IPI_HANDLER.load(Ordering::Acquire);
+                if !handler.is_null() {
+                    // SAFETY: The handler is guaranteed to be a valid function pointer.
+                    unsafe { core::mem::transmute::<*mut (), IrqHandler>(handler)() };
+                }
+                Some(irq)
+            },
+            @S_EXT => {
+                let mut plic = PLIC.lock();
+                let Some(irq) = plic.claim(this_context()) else {
+                    debug!("Spurious external IRQ");
+                    return None;
+                };
+                trace!("IRQ: external {irq}");
+                IRQ_HANDLER_TABLE.handle(irq.get() as usize);
+                plic.complete(this_context(), irq);
+                Some(irq.get() as usize)
+            },
+            @EX_IRQ => {
+                unreachable!("Device-side IRQs should be handled by triggering the External Interrupt.");
+            }
+        )
+    }
+
+    /// Sends an inter-processor interrupt (IPI) to the specified target CPU or all CPUs.
+    fn send_ipi(_irq_num: usize, target: IpiTarget) {
+        match target {
+            IpiTarget::Current { cpu_id } => {
+                let res = sbi_rt::send_ipi(HartMask::from_mask_base(1 << cpu_id, 0));
+                if res.is_err() {
+                    warn!("send_ipi failed: {res:?}");
+                }
+            }
+            IpiTarget::Other { cpu_id } => {
+                let res = sbi_rt::send_ipi(HartMask::from_mask_base(1 << cpu_id, 0));
+                if res.is_err() {
+                    warn!("send_ipi failed: {res:?}");
+                }
+            }
+            IpiTarget::AllExceptCurrent { cpu_id, cpu_num } => {
+                for i in 0..cpu_num {
+                    if i != cpu_id {
+                        let res = sbi_rt::send_ipi(HartMask::from_mask_base(1 << i, 0));
+                        if res.is_err() {
+                            warn!("send_ipi_all_others failed: {res:?}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/lib.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/lib.rs
@@ -1,0 +1,31 @@
+#![no_std]
+
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate ax_plat;
+
+mod boot;
+mod console;
+mod init;
+#[cfg(feature = "irq")]
+mod irq;
+mod mem;
+mod power;
+mod time;
+
+pub mod config {
+    //! Platform configuration module.
+    //!
+    //! If the `AX_CONFIG_PATH` environment variable is set, it will load the configuration from the specified path.
+    //! Otherwise, it will fall back to the `axconfig.toml` file in the current directory and generate the default configuration.
+    //!
+    //! If the `PACKAGE` field in the configuration does not match the package name, it will panic with an error message.
+    ax_config_macros::include_configs!(path_env = "AX_CONFIG_PATH", fallback = "axconfig.toml");
+    assert_str_eq!(
+        PACKAGE,
+        env!("CARGO_PKG_NAME"),
+        "`PACKAGE` field in the configuration does not match the Package name. Please check your \
+         configuration file."
+    );
+}

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/mem.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/mem.rs
@@ -1,0 +1,58 @@
+use ax_plat::mem::{MemIf, PhysAddr, RawRange, VirtAddr, pa, va};
+
+use crate::config::{
+    devices::MMIO_RANGES,
+    plat::{KERNEL_BASE_PADDR, PHYS_MEMORY_BASE, PHYS_MEMORY_SIZE, PHYS_VIRT_OFFSET},
+};
+
+struct MemIfImpl;
+
+#[impl_plat_interface]
+impl MemIf for MemIfImpl {
+    /// Returns all physical memory (RAM) ranges on the platform.
+    ///
+    /// All memory ranges except reserved ranges (including the kernel loaded
+    /// range) are free for allocation.
+    fn phys_ram_ranges() -> &'static [RawRange] {
+        // TODO: paser dtb to get the available memory ranges
+        // We can't directly use `PHYS_MEMORY_BASE` here, because it may has been used by sbi.
+        &[(
+            KERNEL_BASE_PADDR,
+            PHYS_MEMORY_BASE + PHYS_MEMORY_SIZE - KERNEL_BASE_PADDR,
+        )]
+    }
+
+    /// Returns all reserved physical memory ranges on the platform.
+    ///
+    /// Reserved memory can be contained in [`phys_ram_ranges`], they are not
+    /// allocatable but should be mapped to kernel's address space.
+    ///
+    /// Note that the ranges returned should not include the range where the
+    /// kernel is loaded.
+    fn reserved_phys_ram_ranges() -> &'static [RawRange] {
+        &[]
+    }
+
+    /// Returns all device memory (MMIO) ranges on the platform.
+    fn mmio_ranges() -> &'static [RawRange] {
+        &MMIO_RANGES
+    }
+
+    /// Translates a physical address to a virtual address.
+    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+        va!(paddr.as_usize() + PHYS_VIRT_OFFSET)
+    }
+
+    /// Translates a virtual address to a physical address.
+    fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+        pa!(vaddr.as_usize() - PHYS_VIRT_OFFSET)
+    }
+
+    /// Returns the kernel address space base virtual address and size.
+    fn kernel_aspace() -> (VirtAddr, usize) {
+        (
+            va!(crate::config::plat::KERNEL_ASPACE_BASE),
+            crate::config::plat::KERNEL_ASPACE_SIZE,
+        )
+    }
+}

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/power.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/power.rs
@@ -1,0 +1,36 @@
+use ax_plat::power::PowerIf;
+
+struct PowerImpl;
+
+#[impl_plat_interface]
+impl PowerIf for PowerImpl {
+    /// Bootstraps the given CPU core with the given initial stack (in physical
+    /// address).
+    ///
+    /// Where `cpu_id` is the logical CPU ID (0, 1, ..., N-1, N is the number of
+    /// CPU cores on the platform).
+    #[cfg(feature = "smp")]
+    fn cpu_boot(cpu_id: usize, stack_top_paddr: usize) {
+        use ax_plat::mem::{va, virt_to_phys};
+        if sbi_rt::probe_extension(sbi_rt::Hsm).is_unavailable() {
+            warn!("HSM SBI extension is not supported for current SEE.");
+            return;
+        }
+        let entry = virt_to_phys(va!(crate::boot::_start_secondary as *const () as usize));
+        sbi_rt::hart_start(cpu_id, entry.as_usize(), stack_top_paddr);
+    }
+
+    /// Shutdown the whole system.
+    fn system_off() -> ! {
+        info!("Shutting down...");
+        sbi_rt::system_reset(sbi_rt::Shutdown, sbi_rt::NoReason);
+        warn!("It should shutdown!");
+        loop {
+            ax_cpu::asm::halt();
+        }
+    }
+
+    fn cpu_num() -> usize {
+        crate::config::plat::MAX_CPU_NUM
+    }
+}

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/time.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/src/time.rs
@@ -1,0 +1,90 @@
+use ax_plat::time::{NANOS_PER_SEC, TimeIf};
+use riscv::register::time;
+
+const NANOS_PER_TICK: u64 = NANOS_PER_SEC / crate::config::devices::TIMER_FREQUENCY as u64;
+/// RTC wall time offset in nanoseconds at monotonic time base.
+static mut RTC_EPOCHOFFSET_NANOS: u64 = 0;
+
+pub(super) fn init_early() {
+    #[cfg(feature = "rtc")]
+    use crate::config::devices::RTC_PADDR;
+
+    #[cfg(feature = "rtc")]
+    if RTC_PADDR != 0 {
+        use ax_plat::mem::{pa, phys_to_virt};
+
+        // Get the current time in seconds since the epoch (1970-01-01) from the SG2002 RTC.
+        // Subtract the timer ticks to get the actual time when ArceOS was booted.
+        let epoch_time_nanos =
+            read_sg2002_rtc_seconds(phys_to_virt(pa!(RTC_PADDR)).as_usize()) * 1_000_000_000;
+
+        unsafe {
+            RTC_EPOCHOFFSET_NANOS =
+                epoch_time_nanos - TimeIfImpl::ticks_to_nanos(TimeIfImpl::current_ticks());
+        }
+    }
+}
+
+#[cfg(feature = "rtc")]
+fn read_sg2002_rtc_seconds(base_vaddr: usize) -> u64 {
+    const CVI_RTC_SEC_CNTR_VALUE: usize = 0x18;
+    const RTC_MACRO_RO_T: usize = 0x4A8;
+    const VALID_TIME_THRESHOLD: u32 = 0x3000_0000;
+
+    let rtc_base = base_vaddr as *const u8;
+    let sec =
+        unsafe { core::ptr::read_volatile(rtc_base.add(CVI_RTC_SEC_CNTR_VALUE) as *const u32) };
+    let sec_ro_t = unsafe { core::ptr::read_volatile(rtc_base.add(RTC_MACRO_RO_T) as *const u32) };
+
+    let sec = if sec_ro_t > VALID_TIME_THRESHOLD {
+        sec_ro_t
+    } else {
+        sec
+    };
+
+    sec as u64
+}
+
+pub(super) fn init_percpu() {
+    #[cfg(feature = "irq")]
+    sbi_rt::set_timer(0);
+}
+
+struct TimeIfImpl;
+
+#[impl_plat_interface]
+impl TimeIf for TimeIfImpl {
+    /// Returns the current clock time in hardware ticks.
+    fn current_ticks() -> u64 {
+        time::read() as u64
+    }
+
+    /// Converts hardware ticks to nanoseconds.
+    fn ticks_to_nanos(ticks: u64) -> u64 {
+        ticks * NANOS_PER_TICK
+    }
+
+    /// Converts nanoseconds to hardware ticks.
+    fn nanos_to_ticks(nanos: u64) -> u64 {
+        nanos / NANOS_PER_TICK
+    }
+
+    /// Return epoch offset in nanoseconds (wall time offset to monotonic clock start).
+    fn epochoffset_nanos() -> u64 {
+        unsafe { RTC_EPOCHOFFSET_NANOS }
+    }
+
+    /// Returns the IRQ number for the timer interrupt.
+    #[cfg(feature = "irq")]
+    fn irq_num() -> usize {
+        crate::config::devices::TIMER_IRQ
+    }
+
+    /// Set a one-shot timer.
+    ///
+    /// A timer interrupt will be triggered at the specified monotonic time deadline (in nanoseconds).
+    #[cfg(feature = "irq")]
+    fn set_oneshot_timer(deadline_ns: u64) {
+        sbi_rt::set_timer(Self::nanos_to_ticks(deadline_ns));
+    }
+}

--- a/components/page_table_multiarch/page_table_entry/src/arch/riscv.rs
+++ b/components/page_table_multiarch/page_table_entry/src/arch/riscv.rs
@@ -22,34 +22,33 @@ bitflags::bitflags! {
         const U =   1 << 4;
         /// Designates a global mapping.
         const G =   1 << 5;
-        /// Indicates the virtual page has been read, written, or fetched from
-        /// since the last time the A bit was cleared.
+        /// Indicates the virtual page has been read, written, or fetched from since the last time the A bit was cleared.
+        /// When A is set 1, indicates the virtual page accessable. When A is set 0, accessing causes a page fault.
         const A =   1 << 6;
-        /// Indicates the virtual page has been written since the last time the
-        /// D bit was cleared.
+        /// Indicates the virtual page has been written since the last time the D bit was cleared.
+        /// When D is set 0, writing will cause a Page Fault (Store).
         const D =   1 << 7;
-        // xuantie-c9xx specific flags
-        // SO, C, B defined both in XuanTie-Openc910 and XuanTie-C906
-        // SH only defined in XuanTie-Openc910
-        /// SO – Strong ordered memory (1 << 63)
-        #[cfg(feature = "xuantie-c9xx")]
-        const SO =  (1 << 63);
-        /// C – Cacheable  (1 << 62)
-        #[cfg(feature = "xuantie-c9xx")]
-        const C =   (1 << 62);
-        /// B – Bufferable (1 << 61)
-        #[cfg(feature = "xuantie-c9xx")]
-        const B =   (1 << 61);
-        /// SH – Shareable  (1 << 60)
-        #[cfg(feature = "xuantie-c9xx")]
-        const SH =  (1 << 60);
 
-        /// xuantie-c9xx device memory flags
+        /// CPU T-Head XUANTIE-C9xx extended flags
+        /// Reference datasheet:
+        /// https://github.com/XUANTIE-RV/openc910/blob/main/doc/%E7%8E%84%E9%93%81C910%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C_20240627.pdf
+        ///
         #[cfg(feature = "xuantie-c9xx")]
-        const XUANTIE_C9XX_DEVICE = Self::SO.bits() | Self::B.bits();
-        /// xuantie-c9xx normal memory flags
+        /// Trustable
+        const SEC =   1 << 59;
         #[cfg(feature = "xuantie-c9xx")]
-        const XUANTIE_C9XX_NORMAL = Self::C.bits() | Self::B.bits() | Self::SH.bits();
+        /// Shareable
+        const  SH =   1 << 60;
+        #[cfg(feature = "xuantie-c9xx")]
+        /// Bufferable
+        const   B =   1 << 61;
+        #[cfg(feature = "xuantie-c9xx")]
+        /// Cacheable
+        const   C =   1 << 62;
+        #[cfg(feature = "xuantie-c9xx")]
+        /// Strong order (Device)
+        const  SO =   1 << 63;
+
     }
 }
 
@@ -80,7 +79,7 @@ impl From<MappingFlags> for PTEFlags {
         if f.is_empty() {
             return Self::empty();
         }
-        let mut ret = Self::V | Self::A | Self::D;
+        let mut ret = Self::V;
         if f.contains(MappingFlags::READ) {
             ret |= Self::R;
         }
@@ -93,14 +92,6 @@ impl From<MappingFlags> for PTEFlags {
         if f.contains(MappingFlags::USER) {
             ret |= Self::U;
         }
-
-        #[cfg(feature = "xuantie-c9xx")]
-        if f.contains(MappingFlags::DEVICE) {
-            ret |= Self::XUANTIE_C9XX_DEVICE;
-        } else {
-            ret |= Self::XUANTIE_C9XX_NORMAL;
-        }
-
         ret
     }
 }
@@ -118,17 +109,43 @@ impl Rv64PTE {
     pub const fn empty() -> Self {
         Self(0)
     }
+
+    /// Set CPU PTE extension flags
+    /// mflags is current PTE MappingFlags
+    /// extended_flags are all the extended flag bits that need to be set
+    #[allow(unused)]
+    pub fn set_extended_flags(&mut self, mflags: MappingFlags, extended_flags: u64) -> PTEFlags {
+        #[cfg(feature = "xuantie-c9xx")]
+        {
+            // CPU T-Head XUANTIE-C9xx extended flags:
+            // Memory: Shareable, Bufferable, Cacheable, Non-strong-order
+            // Device: Shareable, Non-bufferable, Non-cacheable, Strong-order
+            if mflags.contains(MappingFlags::DEVICE) {
+                self.0 |= (PTEFlags::SH | PTEFlags::SO).bits() as u64;
+            } else {
+                self.0 |= (PTEFlags::SH | PTEFlags::B | PTEFlags::C).bits() as u64;
+            }
+            if mflags.contains(MappingFlags::UNCACHED) {
+                self.0 &= !((PTEFlags::B | PTEFlags::C).bits() as u64);
+            }
+        }
+        self.0 |= (extended_flags & !Self::PHYS_ADDR_MASK);
+        PTEFlags::from_bits_truncate(self.0 as usize)
+    }
 }
 
 impl GenericPTE for Rv64PTE {
     fn new_page(paddr: PhysAddr, mflags: MappingFlags, _is_huge: bool) -> Self {
-        let flags = PTEFlags::from(mflags);
-        debug_assert!(flags.intersects(PTEFlags::R | PTEFlags::X));
-        Self(flags.bits() as u64 | ((paddr.as_usize() >> 2) as u64 & Self::PHYS_ADDR_MASK))
+        let mut page = Self((paddr.as_usize() >> 2) as u64 & Self::PHYS_ADDR_MASK);
+        page.set_flags(mflags, _is_huge);
+        page
     }
 
     fn new_table(paddr: PhysAddr) -> Self {
-        Self(PTEFlags::V.bits() as u64 | ((paddr.as_usize() >> 2) as u64 & Self::PHYS_ADDR_MASK))
+        let mut table = Self::new_page(paddr, MappingFlags::empty(), false);
+        // Default table flags: PTEFlags::V
+        table.0 = (table.0 & !0x3ff) | PTEFlags::V.bits() as u64;
+        table
     }
 
     fn paddr(&self) -> PhysAddr {
@@ -144,10 +161,11 @@ impl GenericPTE for Rv64PTE {
             | ((paddr.as_usize() as u64 >> 2) & Self::PHYS_ADDR_MASK);
     }
 
-    fn set_flags(&mut self, flags: MappingFlags, _is_huge: bool) {
-        let flags = PTEFlags::from(flags);
+    fn set_flags(&mut self, mflags: MappingFlags, _is_huge: bool) {
+        let flags = PTEFlags::from(mflags) | PTEFlags::A | PTEFlags::D;
         debug_assert!(flags.intersects(PTEFlags::R | PTEFlags::X));
         self.0 = (self.0 & Self::PHYS_ADDR_MASK) | flags.bits() as u64;
+        self.set_extended_flags(mflags, 0);
     }
 
     fn bits(self) -> usize {

--- a/os/StarryOS/Makefile
+++ b/os/StarryOS/Makefile
@@ -1,0 +1,64 @@
+# Build Options
+export ARCH := riscv64
+export LOG := warn
+export DWARF := y
+export MEMTRACK := n
+
+# QEMU Options
+export BLK := y
+export NET := y
+export VSOCK := n
+export MEM := 1G
+export ICOUNT := n
+export DISK_IMG := rootfs-$(ARCH).img
+
+# Generated Options
+export A := $(CURDIR)/starryos
+export NO_AXSTD := y
+export AX_LIB := ax-feat
+export APP_FEATURES := qemu
+
+ifeq ($(MEMTRACK), y)
+	APP_FEATURES += starry-api/memtrack
+endif
+
+default: build
+
+ROOTFS_URL = https://github.com/Starry-OS/rootfs/releases/download/20260214
+ROOTFS_IMG = rootfs-$(ARCH).img
+
+rootfs:
+	@if [ ! -f $(ROOTFS_IMG) ]; then \
+		echo "Image not found, downloading..."; \
+		curl -f -L $(ROOTFS_URL)/$(ROOTFS_IMG).xz -O; \
+		xz -d $(ROOTFS_IMG).xz; \
+	fi
+	@ln -sf $(CURDIR)/$(ROOTFS_IMG) $(CURDIR)/../arceos/rootfs-$(ARCH).img
+
+img:
+	@echo -e "\033[33mWARN: The 'img' target is deprecated. Please use 'rootfs' instead.\033[0m"
+	@$(MAKE) --no-print-directory rootfs
+
+defconfig justrun clean:
+	@$(MAKE) -C $(CURDIR)/../arceos $@
+
+build run debug disasm: rootfs defconfig
+	@$(MAKE) -C $(CURDIR)/../arceos $@
+
+ci-test:
+	./scripts/ci-test.py $(ARCH)
+
+# Aliases
+rv:
+	$(MAKE) ARCH=riscv64 run
+
+la:
+	$(MAKE) ARCH=loongarch64 run
+
+vf2:
+	$(MAKE) ARCH=riscv64 APP_FEATURES=vf2 MYPLAT=axplat-riscv64-visionfive2 BUS=mmio build
+
+sg2002:
+	$(MAKE) ARCH=riscv64 APP_FEATURES=sg2002 MYPLAT=axplat-riscv64-sg2002 BUS=mmio SMP=1 UIMAGE=y LOG=info build
+
+.PHONY: build run justrun debug disasm clean

--- a/os/StarryOS/Makefile
+++ b/os/StarryOS/Makefile
@@ -59,6 +59,6 @@ vf2:
 	$(MAKE) ARCH=riscv64 APP_FEATURES=vf2 MYPLAT=axplat-riscv64-visionfive2 BUS=mmio build
 
 sg2002:
-	$(MAKE) ARCH=riscv64 APP_FEATURES=sg2002 MYPLAT=axplat-riscv64-sg2002 BUS=mmio SMP=1 UIMAGE=y LOG=info build
+	$(MAKE) ARCH=riscv64 APP_FEATURES=sg2002 MYPLAT=ax-plat-riscv64-sg2002 BUS=mmio SMP=1 UIMAGE=y LOG=info build
 
 .PHONY: build run justrun debug disasm clean

--- a/os/StarryOS/configs/board/sg2002-riscv64.toml
+++ b/os/StarryOS/configs/board/sg2002-riscv64.toml
@@ -1,5 +1,5 @@
 env = { UIMAGE = "y" }
-features = ["sg2002", "myplat", "ax-feat/bus-mmio"]
+features = ["sg2002", "myplat", "ax-feat/bus-mmio", "ax-feat/driver-cvsd"]
 log = "Info"
 plat_dyn = false
 target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/configs/board/sg2002-riscv64.toml
+++ b/os/StarryOS/configs/board/sg2002-riscv64.toml
@@ -1,0 +1,5 @@
+env = { UIMAGE = "y" }
+features = ["sg2002", "myplat", "ax-feat/bus-mmio"]
+log = "Info"
+plat_dyn = false
+target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -29,7 +29,7 @@ qemu = [
 ]
 smp = ["ax-feat/smp", "axplat-dyn?/smp"]
 
-sg2002 = ["dep:ax-plat-riscv64-sg2002"]
+sg2002 = ["dep:ax-plat-riscv64-sg2002", "ax-feat/driver-cvsd"]
 
 rknpu = ["dep:axplat-dyn", "starry-kernel/rknpu", "axplat-dyn/rknpu"]
 

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -29,6 +29,8 @@ qemu = [
 ]
 smp = ["ax-feat/smp", "axplat-dyn?/smp"]
 
+sg2002 = ["dep:ax-plat-riscv64-sg2002"]
+
 rknpu = ["dep:axplat-dyn", "starry-kernel/rknpu", "axplat-dyn/rknpu"]
 
 [[bin]]
@@ -43,6 +45,12 @@ path = "xtask/main.rs"
 ax-feat = { workspace = true, features = ["fs-ng-times", "irq"] }
 axplat-dyn = { workspace = true, optional = true }
 starry-kernel = { workspace = true, features = ["dev-log"] }
+
+[dependencies.ax-plat-riscv64-sg2002]
+workspace = true
+features = ["fp-simd", "irq", "rtc"]
+version = "0.3.1"
+optional = true
 
 [target.'cfg(any(windows,unix))'.dependencies]
 anyhow = "1.0"

--- a/os/StarryOS/starryos/src/main.rs
+++ b/os/StarryOS/starryos/src/main.rs
@@ -19,3 +19,6 @@ fn main() {
 
     starry_kernel::entry::init(&args, &envs);
 }
+
+#[cfg(feature = "sg2002")]
+extern crate ax_plat_riscv64_sg2002;

--- a/os/arceos/Makefile
+++ b/os/arceos/Makefile
@@ -228,7 +228,7 @@ endif
 
 clean: clean_c
 	rm -rf $(APP)/*.bin $(APP)/*.elf $(OUT_CONFIG)
-	cargo clean
+	cargo clean --target-dir $(TARGET_DIR)
 
 clean_c::
 	rm -rf ulib/axlibc/build_*

--- a/os/arceos/api/axfeat/Cargo.toml
+++ b/os/arceos/api/axfeat/Cargo.toml
@@ -102,6 +102,7 @@ bus-mmio = ["ax-driver?/bus-mmio"]
 bus-pci = ["ax-driver?/bus-pci"]
 driver-ramdisk = ["ax-driver?/ramdisk", "ax-fs?/use-ramdisk"]
 driver-sdmmc = ["ax-driver?/sdmmc"]
+driver-cvsd = ["ax-driver?/cvsd"]
 driver-ixgbe = ["ax-driver?/ixgbe"]
 driver-fxmac = ["ax-driver?/fxmac"]                          # fxmac ethernet driver for PhytiumPi
 driver-bcm2835-sdhci = ["ax-driver?/bcm2835-sdhci"]

--- a/os/arceos/modules/axdriver/Cargo.toml
+++ b/os/arceos/modules/axdriver/Cargo.toml
@@ -31,6 +31,8 @@ virtio-socket = ["vsock", "virtio", "ax-driver-virtio/socket"]
 ramdisk = ["block", "ax-driver-block/ramdisk"]
 bcm2835-sdhci = ["block", "ax-driver-block/bcm2835-sdhci"]
 sdmmc = ["block", "ax-driver-block/sdmmc", "dep:ax-hal", "dep:ax-config"]
+cvsd = ["block", "mbr", "ax-driver-block/cvsd", "dep:ax-hal", "dep:ax-config"]
+mbr = ["dep:gpt_disk_io"]
 ahci = ["block", "ax-driver-block/ahci", "dep:ax-hal", "dep:ax-config"]
 ixgbe = ["net", "ax-driver-net/ixgbe", "dep:ax-alloc", "dep:ax-hal", "dep:ax-dma"]
 fxmac = ["net", "ax-driver-net/fxmac", "dep:ax-alloc", "dep:ax-hal", "dep:ax-dma"]
@@ -60,3 +62,4 @@ ax-crate-interface.workspace = true
 log.workspace = true
 smallvec = { version = "1.15", features = ["const_generics", "union"] }
 axplat-dyn = { workspace = true, optional = true }
+gpt_disk_io = { version = "0.16.2", default-features = false, optional = true }

--- a/os/arceos/modules/axdriver/build.rs
+++ b/os/arceos/modules/axdriver/build.rs
@@ -1,5 +1,5 @@
 const NET_DEV_FEATURES: &[&str] = &["fxmac", "ixgbe", "virtio-net"];
-const BLOCK_DEV_FEATURES: &[&str] = &["ramdisk", "sdmmc", "bcm2835-sdhci", "virtio-blk"];
+const BLOCK_DEV_FEATURES: &[&str] = &["ramdisk", "sdmmc", "cvsd", "bcm2835-sdhci", "virtio-blk"];
 const DISPLAY_DEV_FEATURES: &[&str] = &["virtio-gpu"];
 const INPUT_DEV_FEATURES: &[&str] = &["virtio-input"];
 const VSOCK_DEV_FEATURES: &[&str] = &["virtio-socket"];

--- a/os/arceos/modules/axdriver/src/drivers.rs
+++ b/os/arceos/modules/axdriver/src/drivers.rs
@@ -96,6 +96,29 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
+    if #[cfg(block_dev = "cvsd")] {
+        use ax_hal::mem::phys_to_virt;
+        use ax_driver_block::cvsd::CvsdDriver;
+        use super::mbr::MbrPartitionDev;
+
+        pub struct CvsdMmc;
+        register_block_driver!(CvsdMmc, MbrPartitionDev<CvsdDriver>);
+
+        impl DriverProbe for CvsdMmc {
+            fn probe_global() -> Option<AxDeviceEnum> {
+                info!("Probe CV SD Bootable Part @ {:#x}", ax_config::devices::CVSD_PADDR);
+
+                let sdmmc = CvsdDriver::new(
+                    phys_to_virt(ax_config::devices::CVSD_PADDR.into()).into(),
+                    phys_to_virt(ax_config::devices::SYSCON_PADDR.into()).into(),
+                    ).expect("CVSD init failed");
+                MbrPartitionDev::new(sdmmc).ok().map(AxDeviceEnum::from_block)
+            }
+        }
+    }
+}
+
+cfg_if::cfg_if! {
     if #[cfg(block_dev = "bcm2835-sdhci")]{
         pub struct BcmSdhciDriver;
         register_block_driver!(BcmSdhciDriver, ax_driver_block::bcm2835sdhci::SDHCIDriver);

--- a/os/arceos/modules/axdriver/src/lib.rs
+++ b/os/arceos/modules/axdriver/src/lib.rs
@@ -81,6 +81,9 @@ mod ixgbe;
 #[cfg(feature = "dyn")]
 mod dyn_drivers;
 
+#[cfg(feature = "mbr")]
+mod mbr;
+
 pub mod prelude;
 
 #[cfg(feature = "block")]

--- a/os/arceos/modules/axdriver/src/macros.rs
+++ b/os/arceos/modules/axdriver/src/macros.rs
@@ -85,6 +85,11 @@ macro_rules! for_each_drivers {
             type $drv_type = crate::drivers::SdMmcDriver;
             $code
         }
+        #[cfg(block_dev = "cvsd")]
+        {
+            type $drv_type = crate::drivers::CvsdMmc;
+            $code
+        }
         #[cfg(block_dev = "bcm2835-sdhci")]
         {
             type $drv_type = crate::drivers::BcmSdhciDriver;

--- a/os/arceos/modules/axdriver/src/mbr.rs
+++ b/os/arceos/modules/axdriver/src/mbr.rs
@@ -1,0 +1,165 @@
+extern crate alloc;
+
+use gpt_disk_io::{
+    BlockIo,
+    gpt_disk_types::{BlockSize, Lba, LbaRangeInclusive, MasterBootRecord},
+};
+use log::{debug, info};
+
+use super::prelude::*;
+
+struct BlockDriverAdapter<'a, T>(&'a mut T);
+
+impl<T: BlockDriverOps> BlockIo for BlockDriverAdapter<'_, T> {
+    type Error = DevError;
+
+    fn block_size(&self) -> BlockSize {
+        BlockSize::from_usize(self.0.block_size()).unwrap()
+    }
+
+    fn num_blocks(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.0.num_blocks())
+    }
+
+    fn read_blocks(&mut self, start_lba: Lba, dst: &mut [u8]) -> Result<(), Self::Error> {
+        self.block_size().assert_valid_block_buffer(dst);
+        for (i, chunk) in dst.chunks_exact_mut(self.0.block_size()).enumerate() {
+            self.0.read_block(start_lba.to_u64() + i as u64, chunk)?;
+        }
+        Ok(())
+    }
+
+    fn write_blocks(&mut self, start_lba: Lba, src: &[u8]) -> Result<(), Self::Error> {
+        self.block_size().assert_valid_block_buffer(src);
+        for (i, chunk) in src.chunks_exact(self.0.block_size()).enumerate() {
+            self.0.write_block(start_lba.to_u64() + i as u64, chunk)?;
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.0.flush()
+    }
+}
+
+/// A Mbr partition.
+pub struct MbrPartitionDev<T> {
+    inner: T,
+    range: LbaRangeInclusive,
+}
+
+impl<T: BlockDriverOps> MbrPartitionDev<T> {
+    /// Creates a new Mbr partition device from the given block storage device driver.
+    /// Will use the first bootable partition
+    pub fn new(mut inner: T) -> DevResult<Self> {
+        let mut block_io = BlockDriverAdapter(&mut inner);
+
+        let bs = BlockSize::BS_512;
+        let mut mbr_block_buf = alloc::vec![0u8; bs.to_usize().unwrap()];
+
+        block_io.read_blocks(Lba(0), &mut mbr_block_buf)?;
+        let mbr_ptr = mbr_block_buf.as_ptr() as *const MasterBootRecord;
+        let mbr = unsafe { *mbr_ptr };
+
+        if mbr.signature == [0x55, 0xaa] {
+            debug!("Found MBR: {:x?}", mbr);
+
+            let mut starting_lba = Lba(u64::MAX);
+            let mut ending_lba = Lba(0);
+            for i in 0..4 {
+                match mbr.partitions[i].os_indicator {
+                    0x07 => {
+                        debug!("Found a NTFS/exFAT MBR partition[{}]", i);
+                    }
+                    0x0c => {
+                        info!("Found a FAT32 MBR partition[{}]", i);
+                    }
+                    0x0f => {
+                        debug!("Found an Extended partition[{}].", i);
+                    }
+                    0x83 => {
+                        info!("Found a Linux (ext2/3/4) MBR partition[{}].", i);
+                        if mbr.partitions[i].size_in_lba.to_u32() != 0
+                            && mbr.partitions[i].boot_indicator == 0x80
+                        {
+                            starting_lba = Lba(mbr.partitions[i].starting_lba.to_u32() as u64);
+                            ending_lba = Lba(mbr.partitions[i].starting_lba.to_u32() as u64
+                                + mbr.partitions[i].size_in_lba.to_u32() as u64
+                                - 1);
+                            info!(
+                                "Selecting this bootable partition[{}] {}M @ {:#x} ~ {:#x} as the \
+                                 rootfs",
+                                i,
+                                (mbr.partitions[i].size_in_lba.to_u32() as u64 * bs.to_u64())
+                                    / (1024 * 1024),
+                                starting_lba.to_u64(),
+                                ending_lba.to_u64()
+                            );
+                            break;
+                        }
+                    }
+                    0xee => {
+                        debug!("Found GPT protective partition[{}].", i);
+                    }
+                    0xef => {
+                        debug!("Found (ESP) EFI system partition[{}].", i);
+                    }
+                    _ => {
+                        debug!(
+                            "Unknown MBR partition[{}] type: {:#x}",
+                            i, mbr.partitions[i].os_indicator
+                        );
+                    }
+                }
+            }
+
+            drop(block_io);
+
+            let range = LbaRangeInclusive::new(starting_lba, ending_lba)
+                .expect("Invalid MBR partition range.");
+            Ok(Self { inner, range })
+        } else {
+            Err(DevError::Unsupported)
+        }
+    }
+}
+
+impl<T: BlockDriverOps> BaseDriverOps for MbrPartitionDev<T> {
+    fn device_name(&self) -> &str {
+        self.inner.device_name()
+    }
+
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Block
+    }
+}
+
+impl<T: BlockDriverOps> BlockDriverOps for MbrPartitionDev<T> {
+    fn num_blocks(&self) -> u64 {
+        self.range.num_blocks()
+    }
+
+    fn block_size(&self) -> usize {
+        self.inner.block_size()
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> DevResult {
+        if block_id > (self.range.end().to_u64() - self.range.start().to_u64()) {
+            return Err(DevError::InvalidParam);
+        }
+        self.inner
+            .read_block(self.range.start().to_u64() + block_id, buf)
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> DevResult {
+        if block_id > (self.range.end().to_u64() - self.range.start().to_u64()) {
+            return Err(DevError::InvalidParam);
+        }
+        self.inner
+            .write_block(self.range.start().to_u64() + block_id, buf)
+    }
+
+    fn flush(&mut self) -> DevResult {
+        self.inner.flush()
+    }
+}

--- a/os/arceos/modules/axdriver/src/mbr.rs
+++ b/os/arceos/modules/axdriver/src/mbr.rs
@@ -114,10 +114,14 @@ impl<T: BlockDriverOps> MbrPartitionDev<T> {
             }
 
             drop(block_io);
-
-            let range = LbaRangeInclusive::new(starting_lba, ending_lba)
-                .expect("Invalid MBR partition range.");
-            Ok(Self { inner, range })
+            let is_range = LbaRangeInclusive::new(starting_lba, ending_lba);
+            match is_range {
+                Some(range) => Ok(Self { inner, range }),
+                None => {
+                    error!("Invalid MBR partition range.");
+                    Err(DevError::Unsupported)
+                }
+            }
         } else {
             Err(DevError::Unsupported)
         }

--- a/os/arceos/scripts/make/build.mk
+++ b/os/arceos/scripts/make/build.mk
@@ -5,7 +5,7 @@ include scripts/make/cargo.mk
 ifeq ($(APP_TYPE), c)
   include scripts/make/build_c.mk
 else
-  rust_package := $(shell cat $(APP)/Cargo.toml | sed -n 's/^name = "\([a-z0-9A-Z_\-]*\)"/\1/p')
+  rust_package := $(shell cat $(APP)/Cargo.toml | sed -n 's/^name = "\([a-z0-9A-Z_\-]*\)"/\1/p' | head -1)
   rust_elf := $(TARGET_DIR)/$(TARGET)/$(MODE)/$(rust_package)
 endif
 

--- a/scripts/axbuild/src/arceos/build.rs
+++ b/scripts/axbuild/src/arceos/build.rs
@@ -702,10 +702,15 @@ fn myplat_dependency_matches_arch(dep_name: &str, arch: &str) -> bool {
 
 fn myplat_dependency_prefixes_for_arch(arch: &str) -> &'static [&'static str] {
     match arch {
-        "x86_64" => &["axplat-x86-", "axplat-x86_64-"],
-        "aarch64" => &["axplat-aarch64-"],
-        "riscv64" => &["axplat-riscv64-"],
-        "loongarch64" => &["axplat-loongarch64-"],
+        "x86_64" => &[
+            "axplat-x86-",
+            "axplat-x86_64-",
+            "ax-plat-x86-",
+            "ax-plat-x86_64-",
+        ],
+        "aarch64" => &["axplat-aarch64-", "ax-plat-aarch64-"],
+        "riscv64" => &["axplat-riscv64-", "ax-plat-riscv64-"],
+        "loongarch64" => &["axplat-loongarch64-", "ax-plat-loongarch64-"],
         _ => &[],
     }
 }

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -104,6 +104,35 @@ fn patch_starry_cargo_config(
             .or_insert_with(|| platform.to_string());
     }
 
+    if cargo.env.get("UIMAGE").map(|v| v.as_str()) == Some("y") {
+        inject_uimage_post_build_cmd(cargo, &request.arch)?;
+    }
+
+    Ok(())
+}
+
+fn uimg_arch_for(arch: &str) -> String {
+    match arch {
+        "aarch64" => "arm64".to_string(),
+        "riscv64" => "riscv".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn inject_uimage_post_build_cmd(cargo: &mut Cargo, arch: &str) -> anyhow::Result<()> {
+    let uimg_arch = uimg_arch_for(arch);
+    let config_path = cargo
+        .env
+        .get("AX_CONFIG_PATH")
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("AX_CONFIG_PATH is required for UIMAGE generation"))?;
+
+    let cmd = format!(
+        "paddr=$(ax-config-gen {config_path} -r plat.kernel-base-paddr | tr -d _) && \
+         bin=${{KERNEL_ELF%.elf}}.bin && mkimage -A {uimg_arch} -O linux -T kernel -C none -a \
+         \"$paddr\" -d \"$bin\" \"${{bin%.bin}}.uimg\""
+    );
+    cargo.post_build_cmds.push(cmd);
     Ok(())
 }
 


### PR DESCRIPTION
适配硬件平台sg2002，支持starry引导sg2002板子进入了shell及操作文件系统存储设备。包括：

- 添加了sg2002硬件平台支持包及串口驱动;
- 添加axcpu的寄存器拓展属性;
- page_table页表属性;
- axdriver_block组件添加CVSD的块设备的存储驱动;
- axdriver组件添加`MBR分区表`识别功能;
- 支持了两种编译形式：
  * 基于make: `cd os/StarryOS/ && make sg2002`，生成的内核镜像文件： os/StarryOS/starryos/starryos_riscv64-sg2002.uimg
  * 基于xtask，`cargo starry defconfig sg2002-riscv64 && cargo starry build`，并在编译脚本axbuild中添加一个生成uboot可引导镜像的功能，对原arceos参数UIMAGE=y识别，设置了则通过`mkimage`生成uboot可引导的内核镜像target/xx/starryos.uimg

Todo: tpu/ion驱动集成，摄像头等驱动的集成；