### PR TITLE
fix(console): keep UART writes raw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4529,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4872,9 +4872,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5656,9 +5656,9 @@ dependencies = [
 
 [[package]]
 name = "ostool"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d9d8ffd12f0f482368dd77365ccaafed5c3a233ae2334ce47dc951760bf45f5"
+checksum = "13501cb17f0511a3f470b7758dadee6f5740bc9a948f7391140866b50f0f9b5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7319,9 +7319,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9671,9 +9671,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9684,9 +9684,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9694,9 +9694,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9704,9 +9704,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9717,9 +9717,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -9779,9 +9779,9 @@ checksum = "dba9c05687e501b2710833fbe2cc7ff8cc24411fb0d81967498ca44598942f88"
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/components/axplat_crates/axplat/src/console.rs
+++ b/components/axplat_crates/axplat/src/console.rs
@@ -48,8 +48,28 @@ struct EarlyConsole;
 
 impl Write for EarlyConsole {
     fn write_str(&mut self, s: &str) -> Result {
-        write_bytes(s.as_bytes());
+        write_text_bytes(s.as_bytes());
         Ok(())
+    }
+}
+
+/// Writes text bytes to the console, expanding line feeds to CRLF.
+///
+/// This is intended for human-readable console output. Use [`write_bytes`] for
+/// raw byte transport.
+pub fn write_text_bytes(bytes: &[u8]) {
+    let mut start = 0;
+    for (i, &byte) in bytes.iter().enumerate() {
+        if byte == b'\n' {
+            if start < i {
+                write_bytes(&bytes[start..i]);
+            }
+            write_bytes(b"\r\n");
+            start = i + 1;
+        }
+    }
+    if start < bytes.len() {
+        write_bytes(&bytes[start..]);
     }
 }
 

--- a/components/axplat_crates/platforms/axplat-aarch64-bsta1000b/src/dw_apb_uart.rs
+++ b/components/axplat_crates/platforms/axplat-aarch64-bsta1000b/src/dw_apb_uart.rs
@@ -1,10 +1,13 @@
 //! snps,dw-apb-uart serial driver
 
+#[cfg(feature = "irq")]
 use core::ptr::read_volatile;
 
 use ax_kspin::SpinNoIrq;
+#[cfg(feature = "irq")]
+use ax_plat::console::ConsoleIrqEvent;
 use ax_plat::{
-    console::{ConsoleIf, ConsoleIrqEvent},
+    console::ConsoleIf,
     mem::{PhysAddr, pa},
 };
 use dw_apb_uart::DW8250;
@@ -15,19 +18,13 @@ const UART_BASE: PhysAddr = pa!(crate::config::devices::UART_PADDR);
 
 static UART: SpinNoIrq<DW8250> = SpinNoIrq::new(DW8250::new(phys_to_virt(UART_BASE).as_usize()));
 
+#[cfg(feature = "irq")]
 const UART_LSR_OFFSET: usize = 0x14;
 
 /// Writes a byte to the console.
 #[allow(dead_code)]
 pub fn putchar(c: u8) {
-    let mut uart = UART.lock();
-    match c {
-        b'\r' | b'\n' => {
-            uart.putchar(b'\r');
-            uart.putchar(b'\n');
-        }
-        c => uart.putchar(c),
-    }
+    UART.lock().putchar(c);
 }
 
 /// Reads a byte from the console, or returns [`None`] if no input is available.

--- a/components/axplat_crates/platforms/axplat-aarch64-bsta1000b/src/power.rs
+++ b/components/axplat_crates/platforms/axplat-aarch64-bsta1000b/src/power.rs
@@ -1,4 +1,6 @@
-use ax_plat::{mem::pa, power::PowerIf};
+#[cfg(feature = "smp")]
+use ax_plat::mem::pa;
+use ax_plat::power::PowerIf;
 
 struct PowerImpl;
 

--- a/components/axplat_crates/platforms/axplat-aarch64-peripherals/src/pl011.rs
+++ b/components/axplat_crates/platforms/axplat-aarch64-peripherals/src/pl011.rs
@@ -31,19 +31,9 @@ fn write_reg(offset: usize, value: u32) {
     unsafe { write_volatile(((*UART_BASE) + offset) as *mut u32, value) }
 }
 
-fn do_putchar(uart: &mut Pl011Uart, c: u8) {
-    match c {
-        b'\n' => {
-            uart.putchar(b'\r');
-            uart.putchar(b'\n');
-        }
-        c => uart.putchar(c),
-    }
-}
-
 /// Writes a byte to the console.
 pub fn putchar(c: u8) {
-    do_putchar(&mut UART.lock(), c);
+    UART.lock().putchar(c);
 }
 
 /// Reads a byte from the console, or returns [`None`] if no input is available.
@@ -55,7 +45,7 @@ pub fn getchar() -> Option<u8> {
 pub fn write_bytes(bytes: &[u8]) {
     let mut uart = UART.lock();
     for c in bytes {
-        do_putchar(&mut uart, *c);
+        uart.putchar(*c);
     }
 }
 

--- a/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/console.rs
+++ b/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/console.rs
@@ -39,13 +39,7 @@ struct ConsoleIfImpl;
 impl ConsoleIf for ConsoleIfImpl {
     /// Writes bytes to the console from input u8 slice.
     fn write_bytes(bytes: &[u8]) {
-        for &c in bytes {
-            let mut uart = UART.lock();
-            match c {
-                b'\n' => uart.send_bytes_exact(b"\r\n"),
-                c => uart.send_bytes_exact(&[c]),
-            }
-        }
+        UART.lock().send_bytes_exact(bytes);
     }
 
     /// Reads bytes from the console into the given mutable slice.

--- a/components/axplat_crates/platforms/axplat-riscv64-qemu-virt/src/console.rs
+++ b/components/axplat_crates/platforms/axplat-riscv64-qemu-virt/src/console.rs
@@ -71,13 +71,7 @@ impl ConsoleIf for ConsoleIfImpl {
     fn write_bytes(bytes: &[u8]) {
         let mut uart = UART.lock();
         for &c in bytes {
-            match c {
-                b'\n' => {
-                    uart.write_byte(b'\r');
-                    uart.write_byte(b'\n');
-                }
-                c => uart.write_byte(c),
-            }
+            uart.write_byte(c);
         }
     }
 

--- a/components/axplat_crates/platforms/axplat-x86-pc/src/console.rs
+++ b/components/axplat_crates/platforms/axplat-x86-pc/src/console.rs
@@ -23,13 +23,7 @@ struct ConsoleIfImpl;
 impl ConsoleIf for ConsoleIfImpl {
     /// Writes bytes to the console from input u8 slice.
     fn write_bytes(bytes: &[u8]) {
-        for &c in bytes {
-            let mut uart = UART.lock();
-            match c {
-                b'\n' => uart.send_bytes_exact(b"\r\n"),
-                c => uart.send_bytes_exact(&[c]),
-            }
-        }
+        UART.lock().send_bytes_exact(bytes);
     }
 
     /// Reads bytes from the console into the given mutable slice.

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -17,7 +17,7 @@ use starry_vm::{VmMutPtr, VmPtr};
 
 use self::terminal::{
     Terminal, WindowSize,
-    ldisc::{LineDiscipline, ProcessMode, TtyConfig, TtyRead, TtyWrite},
+    ldisc::{LineDiscipline, ProcessMode, TtyConfig, TtyRead, TtyWrite, write_output_bytes},
     termios::{Termios, Termios2},
 };
 pub use self::{
@@ -91,7 +91,12 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
     }
 
     fn write_at(&self, buf: &[u8], _offset: u64) -> AxResult<usize> {
-        self.writer.write(buf);
+        if self.is_ptm {
+            self.writer.write(buf);
+        } else {
+            let term = self.terminal.load_termios();
+            write_output_bytes(&self.writer, term.as_ref(), buf);
+        }
         Ok(buf.len())
     }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -10,7 +10,7 @@ use ax_errno::{AxError, AxResult};
 use ax_task::future::block_on;
 use axpoll::PollSet;
 use linux_raw_sys::general::{
-    ECHOCTL, ECHOK, ICRNL, IGNCR, ISIG, VEOF, VERASE, VKILL, VMIN, VTIME,
+    ECHOCTL, ECHOK, ICRNL, IGNCR, ISIG, ONLCR, OPOST, VEOF, VERASE, VKILL, VMIN, VTIME,
 };
 use ringbuf::{
     CachingCons, CachingProd,
@@ -55,6 +55,27 @@ pub trait TtyRead: Send + Sync + 'static {
 }
 pub trait TtyWrite: Send + Sync + 'static {
     fn write(&self, buf: &[u8]);
+}
+
+pub fn write_output_bytes<W: TtyWrite + ?Sized>(writer: &W, term: &Termios2, buf: &[u8]) {
+    if !term.has_oflag(OPOST) || !term.has_oflag(ONLCR) {
+        writer.write(buf);
+        return;
+    }
+
+    let mut start = 0;
+    for (i, &byte) in buf.iter().enumerate() {
+        if byte == b'\n' {
+            if start < i {
+                writer.write(&buf[start..i]);
+            }
+            writer.write(b"\r\n");
+            start = i + 1;
+        }
+    }
+    if start < buf.len() {
+        writer.write(&buf[start..]);
+    }
 }
 
 struct InputReader<R, W> {
@@ -167,7 +188,7 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
 
     fn output_char(&self, term: &Termios2, ch: u8) {
         match ch {
-            b'\n' => self.writer.write(b"\n"),
+            b'\n' => write_output_bytes(&self.writer, term, b"\n"),
             b'\r' => self.writer.write(b"\r\n"),
             ch if ch == term.special_char(VERASE) => self.writer.write(b"\x08 \x08"),
             ch if ch == b' ' || ch.is_ascii_graphic() => self.writer.write(&[ch]),

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -90,6 +90,7 @@ struct InputReader<R, W> {
 
     line_buf: Vec<u8>,
     line_read: Option<usize>,
+    eof_ready: Arc<AtomicBool>,
     clear_line_buf: Arc<AtomicBool>,
 }
 impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
@@ -132,10 +133,16 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
                 }
             }
 
-            self.check_send_signal(&term, ch);
+            let signaled = self.check_send_signal(&term, ch);
 
-            if term.echo() {
+            let eof = term.canonical() && ch == term.special_char(VEOF);
+            if term.echo() && !eof {
                 self.output_char(&term, ch);
+            }
+            if signaled {
+                self.line_buf.clear();
+                self.line_read = None;
+                continue;
             }
             if !term.canonical() {
                 self.buf_tx.try_push(ch).unwrap();
@@ -153,17 +160,23 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
                 continue;
             }
 
-            if term.is_eol(ch) || ch == term.special_char(VEOF) {
-                if ch != term.special_char(VEOF) {
-                    self.line_buf.push(ch);
-                }
-                if !self.line_buf.is_empty() {
+            if ch == term.special_char(VEOF) {
+                if self.line_buf.is_empty() {
+                    self.eof_ready.store(true, Ordering::Release);
+                    sent += 1;
+                } else {
                     self.line_read = Some(0);
                 }
                 continue;
             }
 
-            if ch == b' ' || ch.is_ascii_graphic() {
+            if term.is_eol(ch) {
+                self.line_buf.push(ch);
+                self.line_read = Some(0);
+                continue;
+            }
+
+            if ch == b'\t' || !ch.is_ascii_control() {
                 self.line_buf.push(ch);
                 continue;
             }
@@ -172,28 +185,37 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
         sent > 0
     }
 
-    fn check_send_signal(&self, term: &Termios2, ch: u8) {
-        if !term.canonical() || !term.has_lflag(ISIG) {
-            return;
+    fn check_send_signal(&self, term: &Termios2, ch: u8) -> bool {
+        if !term.has_lflag(ISIG) {
+            return false;
         }
-        if let Some(signo) = term.signo_for(ch)
-            && let Some(pg) = self.terminal.job_control.foreground()
-        {
-            let sig = SignalInfo::new_kernel(signo);
-            if let Err(err) = send_signal_to_process_group(pg.pgid(), Some(sig)) {
-                warn!("Failed to send signal: {err:?}");
+        if let Some(signo) = term.signo_for(ch) {
+            if let Some(pg) = self.terminal.job_control.foreground() {
+                let sig = SignalInfo::new_kernel(signo);
+                if let Err(err) = send_signal_to_process_group(pg.pgid(), Some(sig)) {
+                    warn!("Failed to send signal: {err:?}");
+                }
             }
+            true
+        } else {
+            false
         }
     }
 
     fn output_char(&self, term: &Termios2, ch: u8) {
         match ch {
             b'\n' => write_output_bytes(&self.writer, term, b"\n"),
-            b'\r' => self.writer.write(b"\r\n"),
+            b'\t' => self.writer.write(b"\t"),
             ch if ch == term.special_char(VERASE) => self.writer.write(b"\x08 \x08"),
-            ch if ch == b' ' || ch.is_ascii_graphic() => self.writer.write(&[ch]),
+            ch if ch == b' ' || ch.is_ascii_graphic() || !ch.is_ascii() => {
+                self.writer.write(&[ch]);
+            }
             ch if ch.is_ascii_control() && term.has_lflag(ECHOCTL) => {
-                self.writer.write(&[b'^', (ch + 0x40)]);
+                let escaped = if ch == b'\x7f' { b'?' } else { ch + 0x40 };
+                self.writer.write(&[b'^', escaped]);
+            }
+            ch if ch.is_ascii_control() => {
+                self.writer.write(&[ch]);
             }
             other => {
                 warn!("Ignored echo char: {other:#x}");
@@ -210,12 +232,7 @@ struct SimpleReader<R> {
 impl<R: TtyRead> SimpleReader<R> {
     pub fn poll(&mut self) {
         let read = self.reader.read(&mut self.read_buf);
-        for ch in &self.read_buf[..read] {
-            if *ch == b'\n' {
-                let _ = self.buf_tx.try_push(b'\r');
-            }
-            let _ = self.buf_tx.try_push(*ch);
-        }
+        let _ = self.buf_tx.push_slice(&self.read_buf[..read]);
     }
 }
 
@@ -230,6 +247,7 @@ pub struct LineDiscipline<R, W> {
     buf_rx: CachingCons<ReadBuf>,
     input_ready: Arc<PollSet>,
     pump_retry: Arc<PollSet>,
+    eof_ready: Arc<AtomicBool>,
     clear_line_buf: Arc<AtomicBool>,
     processor: Processor<R, W>,
 }
@@ -301,6 +319,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
     pub fn new(terminal: Arc<Terminal>, config: TtyConfig<R, W>) -> Self {
         let (buf_tx, buf_rx) = ReadBuf::default().split();
 
+        let eof_ready = Arc::new(AtomicBool::new(false));
         let clear_line_buf = Arc::new(AtomicBool::new(false));
         let reader = InputReader {
             terminal: terminal.clone(),
@@ -314,6 +333,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
             line_buf: Vec::new(),
             line_read: None,
+            eof_ready: eof_ready.clone(),
             clear_line_buf: clear_line_buf.clone(),
         };
 
@@ -347,6 +367,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             buf_rx,
             input_ready,
             pump_retry,
+            eof_ready,
             clear_line_buf,
             processor,
         }
@@ -354,6 +375,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
     pub fn drain_input(&mut self) {
         self.buf_rx.clear();
+        self.eof_ready.store(false, Ordering::Release);
         self.clear_line_buf.store(true, Ordering::Relaxed);
     }
 
@@ -367,7 +389,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         }
         let term = self.terminal.termios.lock().clone();
         if term.canonical() {
-            return !self.buf_rx.is_empty();
+            return self.eof_ready.load(Ordering::Acquire) || !self.buf_rx.is_empty();
         }
         let vmin = term.special_char(VMIN) as usize;
         vmin == 0 || self.buf_rx.occupied_len() >= vmin
@@ -423,12 +445,18 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
                 if total_read >= vmin {
                     return Ok(total_read);
                 }
+                if self.eof_ready.swap(false, Ordering::AcqRel) {
+                    return Ok(0);
+                }
                 ax_task::yield_now();
             }
         }
 
         let available = self.buf_rx.occupied_len();
         if available == 0 {
+            if term.canonical() && self.eof_ready.swap(false, Ordering::AcqRel) {
+                return Ok(0);
+            }
             if vmin == 0 {
                 return Ok(0);
             }

--- a/os/arceos/api/arceos_api/src/imp/mem.rs
+++ b/os/arceos/api/arceos_api/src/imp/mem.rs
@@ -3,11 +3,11 @@ use core::alloc::Layout;
 cfg_alloc! {
     use core::ptr::NonNull;
 
-    pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>> {
+    pub unsafe fn ax_alloc(layout: Layout) -> Option<NonNull<u8>> {
         ax_alloc::global_allocator().alloc(layout).ok()
     }
 
-    pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout) {
+    pub unsafe fn ax_dealloc(ptr: NonNull<u8>, layout: Layout) {
         ax_alloc::global_allocator().dealloc(ptr, layout)
     }
 }
@@ -16,10 +16,10 @@ cfg_dma! {
     pub use ax_dma::DMAInfo;
 
     pub unsafe fn ax_alloc_coherent(layout: Layout) -> Option<DMAInfo> {
-        ax_dma::alloc_coherent(layout).ok()
+        unsafe { ax_dma::alloc_coherent(layout) }.ok()
     }
 
     pub unsafe fn ax_dealloc_coherent(dma: DMAInfo, layout: Layout) {
-        ax_dma::dealloc_coherent(dma, layout)
+        unsafe { ax_dma::dealloc_coherent(dma, layout) }
     }
 }

--- a/os/arceos/api/arceos_api/src/imp/mod.rs
+++ b/os/arceos/api/arceos_api/src/imp/mod.rs
@@ -30,7 +30,7 @@ mod stdio {
     }
 
     pub fn ax_console_write_bytes(buf: &[u8]) -> crate::AxResult<usize> {
-        ax_hal::console::write_bytes(buf);
+        ax_hal::console::write_text_bytes(buf);
         Ok(buf.len())
     }
 

--- a/os/arceos/api/arceos_api/src/macros.rs
+++ b/os/arceos/api/arceos_api/src/macros.rs
@@ -32,7 +32,7 @@ macro_rules! define_api {
         $(
             $(#[$attr])*
             $vis unsafe fn $name( $($arg : $type),* ) $( -> $ret )? {
-                $crate::imp::$name( $($arg),* )
+                unsafe { $crate::imp::$name( $($arg),* ) }
             }
         )+
     };
@@ -63,7 +63,7 @@ macro_rules! define_api {
             #[cfg(feature = $feature)]
             $(#[$attr])*
             $vis unsafe fn $name( $($arg : $type),* ) $( -> $ret )? {
-                $crate::imp::$name( $($arg),* )
+                unsafe { $crate::imp::$name( $($arg),* ) }
             }
 
             #[allow(unused_variables)]

--- a/os/arceos/api/arceos_posix_api/src/imp/stdio.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/stdio.rs
@@ -15,7 +15,7 @@ fn console_read_bytes(buf: &mut [u8]) -> AxResult<usize> {
 }
 
 fn console_write_bytes(buf: &[u8]) -> AxResult<usize> {
-    ax_hal::console::write_bytes(buf);
+    ax_hal::console::write_text_bytes(buf);
     Ok(buf.len())
 }
 

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -77,7 +77,7 @@ pub mod paging;
 pub mod console {
     #[cfg(feature = "irq")]
     pub use ax_plat::console::{ConsoleIrqEvent, handle_irq, irq_num, set_input_irq_enabled};
-    pub use ax_plat::console::{read_bytes, write_bytes};
+    pub use ax_plat::console::{read_bytes, write_bytes, write_text_bytes};
 }
 
 /// CPU power management.

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -69,7 +69,7 @@ struct LogIfImpl;
 #[ax_crate_interface::impl_interface]
 impl ax_log::LogIf for LogIfImpl {
     fn console_write_str(s: &str) {
-        ax_hal::console::write_bytes(s.as_bytes());
+        ax_hal::console::write_text_bytes(s.as_bytes());
     }
 
     fn current_time() -> core::time::Duration {

--- a/platform/axplat-dyn/src/console.rs
+++ b/platform/axplat-dyn/src/console.rs
@@ -6,20 +6,7 @@ struct ConsoleIfImpl;
 impl ConsoleIf for ConsoleIfImpl {
     /// Writes given bytes to the console.
     fn write_bytes(bytes: &[u8]) {
-        let s = core::str::from_utf8(bytes).unwrap_or_default();
-        let mut remaining = s;
-        while let Some(pos) = remaining.find('\n') {
-            // 打印 '\n' 之前的部分
-            somehal::console::_write_str(&remaining[..pos]);
-            // 打印 "\r\n"
-            somehal::console::_write_str("\r\n");
-            // 继续处理剩余部分
-            remaining = &remaining[pos + 1..];
-        }
-        // 打印最后剩余的部分（如果有的话）
-        if !remaining.is_empty() {
-            somehal::console::_write_str(remaining);
-        }
+        somehal::console::_write_bytes(bytes);
     }
 
     /// Reads bytes from the console into the given mutable slice.

--- a/platform/axplat-dyn/src/console.rs
+++ b/platform/axplat-dyn/src/console.rs
@@ -6,7 +6,15 @@ struct ConsoleIfImpl;
 impl ConsoleIf for ConsoleIfImpl {
     /// Writes given bytes to the console.
     fn write_bytes(bytes: &[u8]) {
-        somehal::console::_write_bytes(bytes);
+        let mut remaining = bytes;
+        while !remaining.is_empty() {
+            let written = somehal::console::_write_bytes(remaining);
+            if written == 0 {
+                core::hint::spin_loop();
+                continue;
+            }
+            remaining = &remaining[written..];
+        }
     }
 
     /// Reads bytes from the console into the given mutable slice.

--- a/platform/riscv64-qemu-virt/src/console.rs
+++ b/platform/riscv64-qemu-virt/src/console.rs
@@ -71,13 +71,7 @@ impl ConsoleIf for ConsoleIfImpl {
     fn write_bytes(bytes: &[u8]) {
         let mut uart = UART.lock();
         for &c in bytes {
-            match c {
-                b'\n' => {
-                    uart.write_byte(b'\r');
-                    uart.write_byte(b'\n');
-                }
-                c => uart.write_byte(c),
-            }
+            uart.write_byte(c);
         }
     }
 

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -17,6 +17,7 @@ arceos-tls
 arceos-wait-queue
 arm_vcpu
 ax-allocator
+ax-api
 ax-arm-pl011
 ax-arm-pl031
 ax-cap-access
@@ -47,15 +48,19 @@ ax-kspin
 ax-kernel-guard
 ax-lazyinit
 ax-memory-set
+ax-plat
+ax-plat-aarch64-peripherals
 ax-plat-x86-pc
 ax-percpu
 ax-percpu-macros
+ax-posix-api
 axaddrspace
 ax-linked-list-r4l
 ax-log
 ax-mm
 ax-net-ng
 ax-riscv-plic
+ax-runtime
 ax-sched
 ax-sync
 ax-task
@@ -66,6 +71,7 @@ axfs-ng-vfs
 axhvc
 axklib
 axpoll
+axplat-dyn
 axplat-x86-qemu-q35
 axvm
 axvmconfig


### PR DESCRIPTION
## 背景

当前部分 platform/UART `write_bytes` 路径会在遇到 LF 时自动插入 CR，这会让 UART 作为纯字节传输通道时破坏二进制数据。换行处理更适合放在明确的文本输出层或 tty 输出处理层。

## 主要改动

- 新增 `ax_plat::console::write_text_bytes`，并通过 `ax_hal::console::write_text_bytes` 导出，用于文本 console 输出时将 LF 扩展为 CRLF。
- 将 axruntime、ax-api stdio、ax-posix-api stdio 的 console 打印路径切到 `write_text_bytes`。
- 保持 `ax_hal::console::write_bytes` 和各平台 UART `write_bytes` 为原始字节传输，移除平台层 LF 到 CRLF 的转换。
- 在 Starry tty 非 PTY master 输出路径按 `OPOST | ONLCR` 做 LF 到 CRLF 的输出处理，PTY master 写入保持原始字节。
- 复用 tty 输出处理辅助函数处理输入 echo 中的 LF。
- 顺带修正 `ax-api` unsafe API forwarding 在 Rust 2024 unsafe 边界下的 clippy 问题。
- 将本次已通过 clippy 的相关 crate 加入 `scripts/test/clippy_crates.csv`。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package ax-plat`
- `cargo xtask clippy --package ax-hal`
- `cargo xtask clippy --package ax-runtime`
- `cargo xtask clippy --package ax-api`
- `cargo xtask clippy --package ax-posix-api`
- `cargo xtask clippy --package axplat-dyn`
- `cargo xtask clippy --package ax-plat-x86-pc`
- `cargo xtask clippy --package ax-plat-aarch64-peripherals`
- `cargo xtask clippy --package axplat-riscv64-qemu-virt-hv`
- `cargo xtask starry test qemu --arch aarch64 -c smoke`

以下检查仍被既有问题阻塞，未在本 PR 中处理：

- `cargo xtask clippy --package starry-kernel`：被 `ax-net-ng` 中已有的 `clippy::large_enum_variant` 阻塞。
- `cargo xtask clippy --package ax-plat-riscv64-qemu-virt`：host target 下依赖的 RISC-V asm register 编译失败。
- `cargo xtask clippy --package ax-plat-loongarch64-qemu-virt`：依赖 `loongArch64` 的 inline asm register class 编译失败。
- `cargo xtask clippy --package ax-plat-aarch64-bsta1000b`：已有 AArch64 专用符号/配置问题阻塞。
