### PR TITLE
fix(ax-net-ng): improve board routing and polling

### DIFF
--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -168,12 +168,13 @@ impl EthernetDevice {
         size: usize,
         f: F,
         proto: EthernetProtocol,
-    ) where
+    ) -> bool
+    where
         F: FnOnce(&mut [u8]),
     {
         if let Err(err) = inner.recycle_tx_buffers() {
             warn!("recycle_tx_buffers failed: {:?}", err);
-            return;
+            return false;
         }
 
         let repr = EthernetRepr {
@@ -186,7 +187,7 @@ impl EthernetDevice {
             Ok(buf) => buf,
             Err(err) => {
                 warn!("alloc_tx_buffer failed: {:?}", err);
-                return;
+                return false;
             }
         };
         let mut frame = EthernetFrame::new_unchecked(tx_buf.packet_mut());
@@ -198,7 +199,14 @@ impl EthernetDevice {
             tx_buf.packet()
         );
         if let Err(err) = inner.transmit(tx_buf) {
-            warn!("transmit failed: {:?}", err);
+            if matches!(err, DevError::Again) {
+                debug!("transmit not ready: {:?}", err);
+            } else {
+                warn!("transmit failed: {:?}", err);
+            }
+            false
+        } else {
+            true
         }
     }
 
@@ -252,7 +260,7 @@ impl EthernetDevice {
         };
 
         let mut inner = self.inner.driver.lock();
-        Self::send_to(
+        let submitted = Self::send_to(
             &mut inner,
             EthernetAddress::BROADCAST,
             arp_repr.buffer_len(),
@@ -260,8 +268,10 @@ impl EthernetDevice {
             EthernetProtocol::Arp,
         );
 
-        self.neighbors.insert(target_ip, None);
-        true
+        if submitted {
+            self.neighbors.insert(target_ip, None);
+        }
+        submitted
     }
 
     fn process_arp(&mut self, payload: &[u8], now: Instant) {

--- a/os/arceos/modules/axnet-ng/src/lib.rs
+++ b/os/arceos/modules/axnet-ng/src/lib.rs
@@ -95,6 +95,12 @@ pub fn init_network(mut net_devs: AxDeviceContainer<AxNetDevice>) {
         )));
 
         router.add_rule(Rule::new(
+            eth0_ip.network().into(),
+            None,
+            eth0_dev,
+            eth0_ip.address().into(),
+        ));
+        router.add_rule(Rule::new(
             Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0).into(),
             Some(GATEWAY.parse().expect("Invalid gateway address")),
             eth0_dev,

--- a/os/arceos/modules/axnet-ng/src/router.rs
+++ b/os/arceos/modules/axnet-ng/src/router.rs
@@ -47,8 +47,9 @@ impl RouteTable {
     pub fn add_rule(&mut self, rule: Rule) {
         let idx = self
             .rules
-            .binary_search_by(|it| rule.filter.prefix_len().cmp(&it.filter.prefix_len()))
-            .unwrap_or_else(|idx| idx);
+            .iter()
+            .position(|it| it.filter.prefix_len() < rule.filter.prefix_len())
+            .unwrap_or(self.rules.len());
         self.rules.insert(idx, rule);
     }
 

--- a/os/arceos/modules/axnet-ng/src/service.rs
+++ b/os/arceos/modules/axnet-ng/src/service.rs
@@ -8,7 +8,7 @@ use ax_hal::time::{NANOS_PER_MICROS, TimeValue, wall_time_nanos};
 use ax_task::future::sleep_until;
 use smoltcp::{
     iface::{Interface, SocketSet},
-    time::Instant,
+    time::{Duration, Instant},
     wire::{HardwareAddress, IpAddress, IpListenEndpoint},
 };
 
@@ -17,6 +17,8 @@ use crate::{SOCKET_SET, router::Router};
 fn now() -> Instant {
     Instant::from_micros_const((wall_time_nanos() / NANOS_PER_MICROS) as i64)
 }
+
+const DEVICE_POLL_FALLBACK_INTERVAL: Duration = Duration::from_millis(10);
 
 pub struct Service {
     pub iface: Interface,
@@ -62,7 +64,15 @@ impl Service {
     }
 
     pub fn register_waker(&mut self, mask: u32, waker: &Waker) {
-        let next = self.iface.poll_at(now(), &SOCKET_SET.inner.lock());
+        let timestamp = now();
+        let next = self.iface.poll_at(timestamp, &SOCKET_SET.inner.lock());
+        let fallback = (mask != 0).then(|| timestamp + DEVICE_POLL_FALLBACK_INTERVAL);
+        let next = match (next, fallback) {
+            (Some(next), Some(fallback)) => Some(next.min(fallback)),
+            (Some(next), None) => Some(next),
+            (None, Some(fallback)) => Some(fallback),
+            (None, None) => None,
+        };
 
         if let Some(t) = next {
             let next = TimeValue::from_micros(t.total_micros() as _);


### PR DESCRIPTION
## 背景

OrangePi 板测中发现真实网卡场景下，同网段目的地址需要优先走直连路由；同时部分板级 IRQ 唤醒路径不稳定时，网络服务可能缺少后续 poll 推进。

## 改动

- 为 `eth0` 添加直连网段路由规则，避免同网段目标被默认网关抢走。
- 调整路由表插入顺序，按最长前缀优先匹配。
- 在设备事件 mask 非空时添加 10ms fallback poll，提升真实设备路径的推进稳定性。
- 让 Ethernet 发送路径返回是否真正提交成功，ARP 请求只有提交成功后才进入 pending 状态。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package ax-net-ng`
