### PR TITLE
feat(riscv64): add virtual PMU support and enhance with performance counters

### DIFF
--- a/components/riscv_vcpu/src/detect.rs
+++ b/components/riscv_vcpu/src/detect.rs
@@ -118,7 +118,7 @@ unsafe fn init_detect_trap(param: usize) -> (bool, Stvec, usize) {
     }
     // use detect trap handler to handle exceptions
     let stored_stvec = stvec::read();
-    let mut trap_addr = on_detect_trap as usize;
+    let mut trap_addr = on_detect_trap as *const () as usize;
     if trap_addr & 0b1 != 0 {
         trap_addr += 0b1;
     }

--- a/components/riscv_vcpu/src/lib.rs
+++ b/components/riscv_vcpu/src/lib.rs
@@ -30,6 +30,7 @@ mod regs;
 mod sbi_console;
 mod trap;
 mod vcpu;
+mod vpmu;
 
 pub use detect::detect_h_extension as has_hardware_support;
 pub use regs::GprIndex;

--- a/components/riscv_vcpu/src/vcpu.rs
+++ b/components/riscv_vcpu/src/vcpu.rs
@@ -59,10 +59,6 @@ fn instr_is_pseudo(ins: u32) -> bool {
     ins == TINST_PSEUDO_STORE || ins == TINST_PSEUDO_LOAD
 }
 
-/// The architecture dependent configuration of a `AxArchVCpu`.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct VCpuConfig {}
-
 #[derive(Default)]
 /// A virtual CPU within a guest
 pub struct RISCVVCpu {
@@ -220,10 +216,12 @@ impl axvcpu::AxArchVCpu for RISCVVCpu {
             );
             core::arch::riscv64::hfence_gvma_all();
         }
+        self.sbi.pmu.backend_bind();
         Ok(())
     }
 
     fn unbind(&mut self) -> AxResult {
+        self.sbi.pmu.backend_unbind();
         // Store the vCPU's CSRs to the stored state.
         unsafe {
             self.regs.vs_csrs.vsatp = vsatp::read().bits();

--- a/components/riscv_vcpu/src/vcpu.rs
+++ b/components/riscv_vcpu/src/vcpu.rs
@@ -34,10 +34,11 @@ use riscv_h::register::{
     vstvec::{self, Vstvec},
 };
 use rustsbi::{Forward, RustSBI};
-use sbi_spec::{hsm, legacy, srst};
+use sbi_spec::{hsm, legacy, pmu, rfnc, srst};
 
 use crate::{
     EID_HVC, RISCVVCpuCreateConfig, consts::traps::irq::S_EXT, guest_mem, regs::*, sbi_console::*,
+    vpmu::VirtualPmu,
 };
 
 unsafe extern "C" {
@@ -71,14 +72,19 @@ pub struct RISCVVCpu {
 
 #[derive(RustSBI)]
 struct RISCVVCpuSbi {
-    #[rustsbi(console, pmu, fence, reset, info, hsm, timer)]
+    #[rustsbi(pmu)]
+    pmu: VirtualPmu,
+    #[rustsbi(console, fence, reset, info, hsm, timer)]
     forward: Forward,
 }
 
 impl Default for RISCVVCpuSbi {
     #[inline]
     fn default() -> Self {
-        Self { forward: Forward }
+        Self {
+            pmu: VirtualPmu::default(),
+            forward: Forward,
+        }
     }
 }
 
@@ -371,6 +377,7 @@ impl RISCVVCpu {
                     legacy::LEGACY_SET_TIMER..=legacy::LEGACY_SHUTDOWN => match extension_id {
                         legacy::LEGACY_SET_TIMER => {
                             // info!("set timer: {}", param[0]);
+                            self.sbi.pmu.record_set_timer();
                             self.program_guest_timer(param[0]);
 
                             self.set_gpr_from_gpr_index(GprIndex::A0, 0);
@@ -395,6 +402,7 @@ impl RISCVVCpu {
                     },
                     EID_TIME => match function_id {
                         FID_SET_TIMER => {
+                            self.sbi.pmu.record_set_timer();
                             self.program_guest_timer(param[0]);
                             self.sbi_return(RET_SUCCESS, 0);
                             return Ok(AxVCpuExitReason::Nothing);
@@ -528,6 +536,32 @@ impl RISCVVCpu {
                             return Ok(AxVCpuExitReason::Nothing);
                         }
                     },
+                    pmu::EID_PMU => {
+                        let ret = self.sbi.handle_ecall(extension_id, function_id, param);
+                        self.set_gpr_from_gpr_index(GprIndex::A0, ret.error);
+                        self.set_gpr_from_gpr_index(GprIndex::A1, ret.value);
+                    }
+                    rfnc::EID_RFNC => {
+                        match function_id {
+                            rfnc::REMOTE_FENCE_I => self.sbi.pmu.record_fence_i_sent(),
+                            rfnc::REMOTE_SFENCE_VMA => self.sbi.pmu.record_sfence_vma_sent(),
+                            rfnc::REMOTE_SFENCE_VMA_ASID => {
+                                self.sbi.pmu.record_sfence_vma_asid_sent();
+                            }
+                            rfnc::REMOTE_HFENCE_GVMA => self.sbi.pmu.record_hfence_gvma_sent(),
+                            rfnc::REMOTE_HFENCE_GVMA_VMID => {
+                                self.sbi.pmu.record_hfence_gvma_vmid_sent();
+                            }
+                            rfnc::REMOTE_HFENCE_VVMA => self.sbi.pmu.record_hfence_vvma_sent(),
+                            rfnc::REMOTE_HFENCE_VVMA_ASID => {
+                                self.sbi.pmu.record_hfence_vvma_asid_sent();
+                            }
+                            _ => {}
+                        }
+                        let ret = self.sbi.handle_ecall(extension_id, function_id, param);
+                        self.set_gpr_from_gpr_index(GprIndex::A0, ret.error);
+                        self.set_gpr_from_gpr_index(GprIndex::A1, ret.value);
+                    }
                     // By default, forward the SBI call to the RustSBI implementation.
                     // See [`RISCVVCpuSbi`].
                     _ => {
@@ -605,6 +639,7 @@ impl RISCVVCpu {
         let csr = ((instr >> 20) & 0xfff) as u16;
 
         if csr != CSR_STIMECMP {
+            self.sbi.pmu.record_illegal_insn();
             return Err(ax_errno::ax_err_type!(
                 Unsupported,
                 alloc::format!(
@@ -657,6 +692,7 @@ impl RISCVVCpu {
                 }
             }
             _ => {
+                self.sbi.pmu.record_illegal_insn();
                 return Err(ax_errno::ax_err_type!(
                     Unsupported,
                     alloc::format!(
@@ -686,6 +722,7 @@ impl RISCVVCpu {
 
     #[cfg(not(feature = "sstc"))]
     fn handle_virtual_instruction(&mut self) -> AxResult<AxVCpuExitReason> {
+        self.sbi.pmu.record_illegal_insn();
         Err(ax_errno::ax_err_type!(
             Unsupported,
             alloc::format!(
@@ -858,14 +895,18 @@ impl RISCVVCpu {
                 i,
                 width,
                 signed_ext,
-            } => AxVCpuExitReason::MmioRead {
-                addr: fault_addr,
-                width,
-                reg: i.rd() as _,
-                reg_width: AccessWidth::Qword,
-                signed_ext,
-            },
+            } => {
+                self.sbi.pmu.record_access_load();
+                AxVCpuExitReason::MmioRead {
+                    addr: fault_addr,
+                    width,
+                    reg: i.rd() as _,
+                    reg_width: AccessWidth::Qword,
+                    signed_ext,
+                }
+            }
             Write { s, width } => {
+                self.sbi.pmu.record_access_store();
                 let source_reg = s.rs2();
                 let value = self.get_gpr(unsafe {
                     // SAFETY: `source_reg` is guaranteed to be in [0, 31]

--- a/components/riscv_vcpu/src/vpmu.rs
+++ b/components/riscv_vcpu/src/vpmu.rs
@@ -1,0 +1,864 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Non-passthrough virtual SBI PMU support for a RISC-V guest vCPU.
+//!
+//! The physical PMU is not an independently assignable device. Its counters,
+//! event selector CSRs, inhibit bits, and overflow state are shared per hart or
+//! per core, and programming them from one guest can affect host execution and
+//! other guests. A passthrough implementation would therefore expose global
+//! machine state through the SBI PMU extension and make ownership of
+//! `mhpmevent*`, `hpmcounter*`, and overflow interrupts ambiguous.
+//!
+//! This module provides a conservative virtual PMU facade instead. Each vCPU
+//! owns a small virtual counter bank, and guest SBI PMU calls update that
+//! virtual state instead of programming the host PMU. Fixed PMU counters
+//! (`cycle` and `instret`) are represented as virtual values plus a hardware
+//! baseline captured at `START` time. Firmware counters are incremented
+//! explicitly by the vCPU when the corresponding hypervisor-visible action is
+//! performed. The architectural `time` CSR is intentionally not exposed as an
+//! SBI PMU counter because the SBI PMU event list has no standard event that
+//! maps to wall-clock time.
+//!
+//! The current design intentionally favors isolation and predictable guest ABI
+//! behavior over complete hardware profiling fidelity. Unsupported PMU event
+//! classes return SBI errors instead of falling back to passthrough.
+//!
+//! Implemented:
+//! - SBI PMU dispatch for `NUM_COUNTERS`, `COUNTER_GET_INFO`,
+//!   `COUNTER_CONFIG_MATCHING`, `COUNTER_START`, `COUNTER_STOP`,
+//!   `COUNTER_FW_READ`, and `COUNTER_FW_READ_HI`.
+//! - Per-vCPU virtual counter state (`configured`, `started`, selected event,
+//!   virtual value, and fixed-counter hardware baseline).
+//! - Fixed PMU counter discovery and internal virtual value tracking for
+//!   `cycle` and `instret`.
+//! - Conservative flag handling for `SKIP_MATCH`, `CLEAR_VALUE`, `AUTO_START`,
+//!   `START_SET_INIT_VALUE`, and `STOP_RESET`.
+//! - Firmware counters for hypervisor-observable events: `SET_TIMER`,
+//!   `ILLEGAL_INSN`, `ACCESS_LOAD`, `ACCESS_STORE`, and the RFENCE/HFENCE
+//!   "sent" events that pass through this vCPU's SBI path.
+//!
+//! Not implemented yet:
+//! - Guest CSR reads of `cycle`, `time`, and `instret` still observe the
+//!   hardware view until the vCPU traps and emulates those CSR reads using this
+//!   module's virtual fixed-counter values or a separate virtual time source.
+//! - Virtual `hpmcounter3..31` and `mhpmevent3..31` state, cache/raw/platform
+//!   hardware events, and host PMU scheduling or multiplexing.
+//! - PMU overflow detection, overflow interrupt injection, and overflow
+//!   pending state.
+//! - SBI PMU snapshot shared memory (`SNAPSHOT_SET_SHMEM`).
+//! - Privilege-mode filter enforcement for the `VUINH`/`VSINH`/`UINH`/
+//!   `SINH`/`MINH` configuration flags.
+//! - Firmware counters that do not currently pass through this vCPU path, such
+//!   as received RFENCE/HFENCE events, IPI counters, and platform-specific
+//!   counters.
+
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+
+use rustsbi::Pmu;
+use sbi_spec::{binary::SbiRet, pmu};
+
+/// Per-vCPU virtual implementation of the SBI PMU extension.
+///
+/// A `VirtualPmu` instance is embedded in the SBI object owned by one virtual
+/// CPU. The instance stores all guest-visible PMU state locally and never
+/// programs host PMU selector CSRs. This keeps guest PMU operations isolated
+/// from other guests even when the surrounding virtualization model forwards
+/// many other SBI calls to the host firmware.
+///
+/// Counter layout:
+///
+/// - Counter 0 exposes the architectural fixed `cycle` counter.
+/// - Counter 1 exposes the architectural fixed `instret` counter.
+/// - Counters 2 and above expose selected SBI firmware counters whose events
+///   can be observed by this vCPU implementation.
+///
+/// Fixed PMU counters use a virtual offset model. When a fixed counter is
+/// started, the current hardware CSR value is captured as `hardware_base`.
+/// While the counter remains running, the guest-visible value is
+/// `value + (hardware_now - hardware_base)`. When the counter is stopped
+/// without `STOP_RESET`, the current delta is folded back into `value`,
+/// allowing later starts to continue from the same guest-visible value or from
+/// a supplied initial value.
+pub(crate) struct VirtualPmu {
+    /// Guest-visible counter state indexed by virtual counter number.
+    counters: [VirtualPmuCounter; Self::NUM_COUNTERS],
+}
+
+/// Mutable state for one virtual PMU counter.
+///
+/// The fields are atomic because SBI calls and event recording hooks may be
+/// reached through different execution paths. The current vCPU model normally
+/// serializes access per vCPU, so relaxed ordering is sufficient: the atomics
+/// provide race-free storage without imposing cross-counter synchronization
+/// semantics that the virtual PMU does not require.
+#[derive(Default)]
+struct VirtualPmuCounter {
+    /// SBI event index currently bound to this counter.
+    ///
+    /// The value is `UNCONFIGURED_EVENT` until `COUNTER_CONFIG_MATCHING`
+    /// successfully associates the counter with a supported event.
+    event_idx: AtomicUsize,
+    /// Whether the counter has been configured for a guest-visible event.
+    ///
+    /// A counter must be configured before it can be started or read through
+    /// SBI PMU operations.
+    configured: AtomicBool,
+    /// Whether the counter is currently counting.
+    ///
+    /// Firmware counters only increment while this flag is set. Fixed PMU
+    /// counters use it to decide whether `hardware_base` should be applied to
+    /// the stored virtual value.
+    started: AtomicBool,
+    /// Stored virtual counter value.
+    ///
+    /// For firmware counters this is the complete counter value. For fixed PMU
+    /// counters this is the accumulated guest-visible value at the last clear,
+    /// explicit initialization, or stop point; while running, the live hardware
+    /// delta is added on top.
+    value: AtomicU64,
+    /// Hardware CSR baseline for a running fixed PMU counter.
+    ///
+    /// This field is meaningful only for `cycle` and `instret` while `started`
+    /// is true. It is reset to zero when a fixed counter is stopped or cleared.
+    hardware_base: AtomicU64,
+}
+
+impl VirtualPmu {
+    /// Number of virtual counters exposed to the guest through SBI PMU.
+    const NUM_COUNTERS: usize = 13;
+    /// Virtual counter index for the architectural `cycle` CSR.
+    const CYCLE_COUNTER: usize = 0;
+    /// Virtual counter index for the architectural `instret` CSR.
+    const INSTRET_COUNTER: usize = 1;
+    /// Firmware counter index for `SBI_PMU_FW_SET_TIMER`.
+    const FW_SET_TIMER_COUNTER: usize = 2;
+    /// Firmware counter index for `SBI_PMU_FW_ILLEGAL_INSN`.
+    const FW_ILLEGAL_INSN_COUNTER: usize = 3;
+    /// Firmware counter index for `SBI_PMU_FW_ACCESS_LOAD`.
+    const FW_ACCESS_LOAD_COUNTER: usize = 4;
+    /// Firmware counter index for `SBI_PMU_FW_ACCESS_STORE`.
+    const FW_ACCESS_STORE_COUNTER: usize = 5;
+    /// Firmware counter index for `SBI_PMU_FW_FENCE_I_SENT`.
+    const FW_FENCE_I_SENT_COUNTER: usize = 6;
+    /// Firmware counter index for `SBI_PMU_FW_SFENCE_VMA_SENT`.
+    const FW_SFENCE_VMA_SENT_COUNTER: usize = 7;
+    /// Firmware counter index for `SBI_PMU_FW_SFENCE_VMA_ASID_SENT`.
+    const FW_SFENCE_VMA_ASID_SENT_COUNTER: usize = 8;
+    /// Firmware counter index for `SBI_PMU_FW_HFENCE_GVMA_SENT`.
+    const FW_HFENCE_GVMA_SENT_COUNTER: usize = 9;
+    /// Firmware counter index for `SBI_PMU_FW_HFENCE_GVMA_VMID_SENT`.
+    const FW_HFENCE_GVMA_VMID_SENT_COUNTER: usize = 10;
+    /// Firmware counter index for `SBI_PMU_FW_HFENCE_VVMA_SENT`.
+    const FW_HFENCE_VVMA_SENT_COUNTER: usize = 11;
+    /// Firmware counter index for `SBI_PMU_FW_HFENCE_VVMA_ASID_SENT`.
+    const FW_HFENCE_VVMA_ASID_SENT_COUNTER: usize = 12;
+    /// Reported fixed-counter width encoded in SBI `COUNTER_GET_INFO`.
+    ///
+    /// SBI encodes the width as the most significant valid bit index rather
+    /// than the number of bits. `usize::BITS - 1` matches the architectural CSR
+    /// width used by this target.
+    const COUNTER_WIDTH: usize = usize::BITS as usize - 1;
+    /// CSR number for the architectural `cycle` counter.
+    const CSR_CYCLE: usize = 0xc00;
+    /// CSR number for the architectural `instret` counter.
+    const CSR_INSTRET: usize = 0xc02;
+    /// SBI counter-info marker for a firmware counter.
+    const FIRMWARE_COUNTER_TYPE: usize = 1 << (usize::BITS as usize - 1);
+    /// Sentinel event index stored in counters that have not been configured.
+    const UNCONFIGURED_EVENT: usize = usize::MAX;
+
+    /// `COUNTER_CONFIG_MATCHING` flag requesting direct use of the supplied set.
+    const CFG_FLAG_SKIP_MATCH: usize = 1 << 0;
+    /// `COUNTER_CONFIG_MATCHING` flag requesting that the counter value be reset.
+    const CFG_FLAG_CLEAR_VALUE: usize = 1 << 1;
+    /// `COUNTER_CONFIG_MATCHING` flag requesting that the counter start immediately.
+    const CFG_FLAG_AUTO_START: usize = 1 << 2;
+    /// Mask of configuration flags accepted by this implementation.
+    ///
+    /// The SBI PMU specification currently defines mode-inhibit bits in the
+    /// low flag byte as well. They are accepted for ABI compatibility, although
+    /// this virtual PMU does not yet enforce privilege-mode filtering.
+    const CFG_VALID_FLAGS: usize = 0xff;
+    /// `COUNTER_START` flag requesting initialization to `initial_value`.
+    const START_FLAG_SET_INIT_VALUE: usize = 1 << 0;
+    /// `COUNTER_STOP` flag requesting that the counter be reset after stopping.
+    const STOP_FLAG_RESET: usize = 1 << 0;
+
+    /// Build SBI `COUNTER_GET_INFO` metadata for a CSR-backed fixed PMU counter.
+    ///
+    /// The SBI return value combines the CSR number with the reported counter
+    /// width. Fixed PMU counters are advertised as direct CSR counters so a
+    /// guest can discover the architectural CSR associated with each virtual
+    /// counter.
+    #[inline]
+    fn counter_info(csr: usize) -> usize {
+        csr | (Self::COUNTER_WIDTH << 12)
+    }
+
+    /// Test whether `counter_idx` is selected by an SBI counter set.
+    ///
+    /// SBI PMU calls address a set of counters with `(counter_idx_base,
+    /// counter_idx_mask)`. Bit `n` in the mask selects counter
+    /// `counter_idx_base + n`. This helper performs the bounds arithmetic
+    /// defensively so overflow or negative offsets never wrap into a match.
+    #[inline]
+    fn counter_in_set(
+        counter_idx: usize,
+        counter_idx_base: usize,
+        counter_idx_mask: usize,
+    ) -> bool {
+        let Some(offset) = counter_idx.checked_sub(counter_idx_base) else {
+            return false;
+        };
+
+        offset < usize::BITS as usize && (counter_idx_mask & (1usize << offset)) != 0
+    }
+
+    /// Validate that a guest-supplied counter set is non-empty and in range.
+    ///
+    /// The method checks every selected bit in the mask. A set is invalid if it
+    /// selects no counters, overflows while adding the base, or refers to a
+    /// counter beyond the virtual bank exposed by `NUM_COUNTERS`.
+    #[inline]
+    fn validate_counter_set(counter_idx_base: usize, counter_idx_mask: usize) -> SbiRet {
+        if counter_idx_mask == 0 {
+            return SbiRet::invalid_param();
+        }
+
+        for offset in 0..usize::BITS as usize {
+            if (counter_idx_mask & (1usize << offset)) == 0 {
+                continue;
+            }
+
+            let Some(counter_idx) = counter_idx_base.checked_add(offset) else {
+                return SbiRet::invalid_param();
+            };
+            if counter_idx >= Self::NUM_COUNTERS {
+                return SbiRet::invalid_param();
+            }
+        }
+
+        SbiRet::success(0)
+    }
+
+    /// Return the first virtual counter selected by an SBI counter set.
+    ///
+    /// This is used for `SKIP_MATCH`, where the guest asks the implementation
+    /// to use the selected counter directly rather than searching for a counter
+    /// that supports the event.
+    #[inline]
+    fn first_counter_in_set(counter_idx_base: usize, counter_idx_mask: usize) -> Option<usize> {
+        (0..Self::NUM_COUNTERS).find(|&counter_idx| {
+            Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask)
+        })
+    }
+
+    /// Map an SBI PMU event index to the virtual counter that can count it.
+    ///
+    /// Only events that can be represented without host PMU passthrough are
+    /// mapped. General hardware events are limited to architectural fixed
+    /// counters, and firmware events are limited to actions that this vCPU
+    /// implementation can observe directly. Unsupported hardware, cache, raw,
+    /// and platform events return `None` so the SBI call can report
+    /// `SBI_ERR_NOT_SUPPORTED`.
+    #[inline]
+    fn event_counter(event_idx: usize) -> Option<usize> {
+        let event_type = event_idx >> 16;
+        let event_code = event_idx & 0xffff;
+
+        match (event_type, event_code) {
+            (pmu::event_type::HARDWARE_GENERAL, pmu::hardware_event::CPU_CYCLES) => {
+                Some(Self::CYCLE_COUNTER)
+            }
+            (pmu::event_type::HARDWARE_GENERAL, pmu::hardware_event::INSTRUCTIONS) => {
+                Some(Self::INSTRET_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::SET_TIMER) => {
+                Some(Self::FW_SET_TIMER_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::ILLEGAL_INSN) => {
+                Some(Self::FW_ILLEGAL_INSN_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::ACCESS_LOAD) => {
+                Some(Self::FW_ACCESS_LOAD_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::ACCESS_STORE) => {
+                Some(Self::FW_ACCESS_STORE_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::FENCE_I_SENT) => {
+                Some(Self::FW_FENCE_I_SENT_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::SFENCE_VMA_SENT) => {
+                Some(Self::FW_SFENCE_VMA_SENT_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::SFENCE_VMA_ASID_SENT) => {
+                Some(Self::FW_SFENCE_VMA_ASID_SENT_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::HFENCE_GVMA_SENT) => {
+                Some(Self::FW_HFENCE_GVMA_SENT_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::HFENCE_GVMA_VMID_SENT) => {
+                Some(Self::FW_HFENCE_GVMA_VMID_SENT_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::HFENCE_VVMA_SENT) => {
+                Some(Self::FW_HFENCE_VVMA_SENT_COUNTER)
+            }
+            (pmu::event_type::FIRMWARE, pmu::firmware_event::HFENCE_VVMA_ASID_SENT) => {
+                Some(Self::FW_HFENCE_VVMA_ASID_SENT_COUNTER)
+            }
+            _ => None,
+        }
+    }
+
+    /// Check whether a specific virtual counter can count `event_idx`.
+    ///
+    /// This helper is used by the `SKIP_MATCH` configuration path. Even when
+    /// the guest asks to skip matching, the chosen counter still has to be
+    /// compatible with the requested event.
+    #[inline]
+    fn counter_supports_event(counter_idx: usize, event_idx: usize) -> bool {
+        Self::event_counter(event_idx) == Some(counter_idx)
+    }
+
+    /// Return whether a counter is one of the virtual firmware counters.
+    ///
+    /// Firmware counters are read through `COUNTER_FW_READ` rather than direct
+    /// CSR reads. They are incremented by explicit hooks in the vCPU code when
+    /// the corresponding SBI or trap-handling operation occurs.
+    #[inline]
+    fn counter_is_firmware(counter_idx: usize) -> bool {
+        (Self::FW_SET_TIMER_COUNTER..Self::NUM_COUNTERS).contains(&counter_idx)
+    }
+
+    /// Return whether a counter is one of the fixed CSR-backed PMU counters.
+    ///
+    /// Fixed PMU counters use the offset/baseline model implemented by
+    /// `fixed_virtual_value` instead of explicit event increments.
+    #[inline]
+    fn counter_is_fixed(counter_idx: usize) -> bool {
+        counter_idx <= Self::INSTRET_COUNTER
+    }
+
+    /// Read the current host hardware value for a fixed architectural counter.
+    ///
+    /// The returned value is used only as a delta source for virtual fixed
+    /// counters. It is not exposed directly as the guest-visible value unless
+    /// the guest has started the virtual counter with a zero offset and no
+    /// later stop/clear/init operation.
+    ///
+    /// Returns zero for non-fixed counter indices; callers normally guard with
+    /// `counter_is_fixed` before invoking this method.
+    #[inline]
+    fn fixed_hardware_value(counter_idx: usize) -> u64 {
+        let value: usize;
+        match counter_idx {
+            Self::CYCLE_COUNTER => unsafe {
+                core::arch::asm!("csrr {value}, cycle", value = out(reg) value);
+            },
+            Self::INSTRET_COUNTER => unsafe {
+                core::arch::asm!("csrr {value}, instret", value = out(reg) value);
+            },
+            _ => return 0,
+        }
+        value as u64
+    }
+
+    /// Compute the guest-visible value for a fixed PMU counter.
+    ///
+    /// If the counter is stopped, the stored virtual value is already complete.
+    /// If it is running, the method adds the elapsed hardware-counter delta
+    /// since the last start to the stored virtual value. Wrapping arithmetic is
+    /// used to preserve architectural counter behavior across hardware counter
+    /// wraparound.
+    #[inline]
+    fn fixed_virtual_value(&self, counter_idx: usize) -> u64 {
+        let counter = &self.counters[counter_idx];
+        let value = counter.value.load(Ordering::Relaxed);
+        if !counter.started.load(Ordering::Relaxed) {
+            return value;
+        }
+
+        let hardware_base = counter.hardware_base.load(Ordering::Relaxed);
+        let hardware_now = Self::fixed_hardware_value(counter_idx);
+        value.wrapping_add(hardware_now.wrapping_sub(hardware_base))
+    }
+
+    /// Reset a counter to the unconfigured state.
+    ///
+    /// This implements the reset side effect requested by `COUNTER_STOP` with
+    /// `STOP_RESET`. The selected event, configured/start state, virtual value,
+    /// and fixed-counter baseline are all cleared.
+    #[inline]
+    fn reset_counter(&self, counter_idx: usize) {
+        let counter = &self.counters[counter_idx];
+        counter
+            .event_idx
+            .store(Self::UNCONFIGURED_EVENT, Ordering::Relaxed);
+        counter.configured.store(false, Ordering::Relaxed);
+        counter.started.store(false, Ordering::Relaxed);
+        counter.value.store(0, Ordering::Relaxed);
+        counter.hardware_base.store(0, Ordering::Relaxed);
+    }
+}
+
+impl Default for VirtualPmu {
+    /// Create an empty virtual PMU counter bank.
+    ///
+    /// All counters start unconfigured and stopped. Firmware counters begin at
+    /// zero, and fixed PMU counters have no hardware baseline until they are
+    /// started by the guest.
+    fn default() -> Self {
+        let counters = core::array::from_fn(|_| VirtualPmuCounter {
+            event_idx: AtomicUsize::new(Self::UNCONFIGURED_EVENT),
+            configured: AtomicBool::new(false),
+            started: AtomicBool::new(false),
+            value: AtomicU64::new(0),
+            hardware_base: AtomicU64::new(0),
+        });
+
+        Self { counters }
+    }
+}
+
+impl VirtualPmu {
+    /// Record one guest-visible `SET_TIMER` firmware event.
+    ///
+    /// The vCPU should call this when it handles or forwards a guest timer SBI
+    /// request. The event is counted only if the guest configured and started
+    /// the corresponding firmware counter.
+    #[inline]
+    pub(crate) fn record_set_timer(&self) {
+        self.record_firmware_event(Self::FW_SET_TIMER_COUNTER);
+    }
+
+    /// Record one guest-visible illegal-instruction firmware event.
+    ///
+    /// This tracks illegal instruction traps that are observed by the vCPU
+    /// emulation path. It does not count illegal instructions handled entirely
+    /// outside this vCPU path.
+    #[inline]
+    pub(crate) fn record_illegal_insn(&self) {
+        self.record_firmware_event(Self::FW_ILLEGAL_INSN_COUNTER);
+    }
+
+    /// Record one guest-visible access-load firmware event.
+    ///
+    /// This is intended for guest load access faults that are handled by the
+    /// hypervisor, such as MMIO emulation paths.
+    #[inline]
+    pub(crate) fn record_access_load(&self) {
+        self.record_firmware_event(Self::FW_ACCESS_LOAD_COUNTER);
+    }
+
+    /// Record one guest-visible access-store firmware event.
+    ///
+    /// This is intended for guest store or AMO access faults that are handled
+    /// by the hypervisor, such as MMIO emulation paths.
+    #[inline]
+    pub(crate) fn record_access_store(&self) {
+        self.record_firmware_event(Self::FW_ACCESS_STORE_COUNTER);
+    }
+
+    /// Record one guest-visible sent `FENCE.I` firmware event.
+    ///
+    /// The event corresponds to an RFENCE-style operation initiated by this
+    /// vCPU path. Received remote fence events are not currently modeled.
+    #[inline]
+    pub(crate) fn record_fence_i_sent(&self) {
+        self.record_firmware_event(Self::FW_FENCE_I_SENT_COUNTER);
+    }
+
+    /// Record one guest-visible sent `SFENCE.VMA` firmware event.
+    ///
+    /// This counts sent remote TLB flush requests that do not include an ASID
+    /// qualifier.
+    #[inline]
+    pub(crate) fn record_sfence_vma_sent(&self) {
+        self.record_firmware_event(Self::FW_SFENCE_VMA_SENT_COUNTER);
+    }
+
+    /// Record one guest-visible sent `SFENCE.VMA` with ASID firmware event.
+    ///
+    /// This counts sent remote TLB flush requests that include an ASID
+    /// qualifier.
+    #[inline]
+    pub(crate) fn record_sfence_vma_asid_sent(&self) {
+        self.record_firmware_event(Self::FW_SFENCE_VMA_ASID_SENT_COUNTER);
+    }
+
+    /// Record one guest-visible sent `HFENCE.GVMA` firmware event.
+    ///
+    /// This counts sent hypervisor guest-physical TLB flush requests that do
+    /// not include a VMID qualifier.
+    #[inline]
+    pub(crate) fn record_hfence_gvma_sent(&self) {
+        self.record_firmware_event(Self::FW_HFENCE_GVMA_SENT_COUNTER);
+    }
+
+    /// Record one guest-visible sent `HFENCE.GVMA` with VMID firmware event.
+    ///
+    /// This counts sent hypervisor guest-physical TLB flush requests that
+    /// include a VMID qualifier.
+    #[inline]
+    pub(crate) fn record_hfence_gvma_vmid_sent(&self) {
+        self.record_firmware_event(Self::FW_HFENCE_GVMA_VMID_SENT_COUNTER);
+    }
+
+    /// Record one guest-visible sent `HFENCE.VVMA` firmware event.
+    ///
+    /// This counts sent virtual-address TLB flush requests for a guest virtual
+    /// machine that do not include an ASID qualifier.
+    #[inline]
+    pub(crate) fn record_hfence_vvma_sent(&self) {
+        self.record_firmware_event(Self::FW_HFENCE_VVMA_SENT_COUNTER);
+    }
+
+    /// Record one guest-visible sent `HFENCE.VVMA` with ASID firmware event.
+    ///
+    /// This counts sent virtual-address TLB flush requests for a guest virtual
+    /// machine that include an ASID qualifier.
+    #[inline]
+    pub(crate) fn record_hfence_vvma_asid_sent(&self) {
+        self.record_firmware_event(Self::FW_HFENCE_VVMA_ASID_SENT_COUNTER);
+    }
+
+    /// Read the virtual `cycle` fixed PMU counter.
+    ///
+    /// This helper is intended for a future CSR emulation path. It returns the
+    /// virtual value maintained by this PMU rather than the raw hardware CSR.
+    /// The counter must have been configured by the guest through SBI PMU.
+    #[inline]
+    pub(crate) fn read_cycle(&self) -> SbiRet {
+        self.read_fixed_counter(Self::CYCLE_COUNTER)
+    }
+
+    /// Read the virtual `instret` fixed PMU counter.
+    ///
+    /// This helper is intended for a future CSR emulation path. Until CSR reads
+    /// are trapped and redirected here, a guest direct CSR read may still see
+    /// the underlying hardware value.
+    #[inline]
+    pub(crate) fn read_instret(&self) -> SbiRet {
+        self.read_fixed_counter(Self::INSTRET_COUNTER)
+    }
+
+    /// Read a configured fixed PMU counter by virtual counter index.
+    ///
+    /// Returns `SBI_ERR_INVALID_PARAM` if the counter has not been configured.
+    /// This matches the conservative behavior used for firmware-counter reads:
+    /// guest code should configure a counter before consuming its value through
+    /// the PMU interface.
+    #[inline]
+    fn read_fixed_counter(&self, counter_idx: usize) -> SbiRet {
+        let counter = &self.counters[counter_idx];
+        if !counter.configured.load(Ordering::Relaxed) {
+            return SbiRet::invalid_param();
+        }
+
+        SbiRet::success(self.fixed_virtual_value(counter_idx) as usize)
+    }
+
+    /// Increment a firmware counter if it is currently active.
+    ///
+    /// Firmware counters are purely virtual; they advance only when the vCPU
+    /// explicitly observes the matching event. Unconfigured or stopped counters
+    /// ignore events so start/stop windows behave as the guest requested.
+    #[inline]
+    fn record_firmware_event(&self, counter_idx: usize) {
+        let counter = &self.counters[counter_idx];
+        if counter.configured.load(Ordering::Relaxed) && counter.started.load(Ordering::Relaxed) {
+            counter.value.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+impl Pmu for VirtualPmu {
+    /// Return the number of virtual counters exposed by this PMU instance.
+    #[inline]
+    fn num_counters(&self) -> usize {
+        Self::NUM_COUNTERS
+    }
+
+    /// Return SBI metadata for a virtual counter.
+    ///
+    /// Fixed PMU counters are reported as CSR-backed counters with their
+    /// architectural CSR numbers. Firmware counters are reported as firmware
+    /// counters. Any index outside the virtual counter bank is rejected.
+    #[inline]
+    fn counter_get_info(&self, counter_idx: usize) -> SbiRet {
+        match counter_idx {
+            Self::CYCLE_COUNTER => SbiRet::success(Self::counter_info(Self::CSR_CYCLE)),
+            Self::INSTRET_COUNTER => SbiRet::success(Self::counter_info(Self::CSR_INSTRET)),
+            Self::FW_SET_TIMER_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_ILLEGAL_INSN_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_ACCESS_LOAD_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_ACCESS_STORE_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_FENCE_I_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_SFENCE_VMA_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_SFENCE_VMA_ASID_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_HFENCE_GVMA_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_HFENCE_GVMA_VMID_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_HFENCE_VVMA_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            Self::FW_HFENCE_VVMA_ASID_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            _ => SbiRet::invalid_param(),
+        }
+    }
+
+    /// Configure a virtual counter for an SBI PMU event.
+    ///
+    /// The implementation supports only events that can be represented by the
+    /// fixed PMU counters or by vCPU-observable firmware hooks. When
+    /// `SKIP_MATCH` is set, the first selected counter is used only if it
+    /// supports the requested event. Otherwise the event is mapped to its
+    /// dedicated virtual counter and then checked against the guest-supplied
+    /// counter set.
+    ///
+    /// `CLEAR_VALUE` resets the stored virtual value, and `AUTO_START` starts
+    /// the counter immediately. For fixed PMU counters, auto-start also
+    /// captures the current hardware CSR value as the baseline for future
+    /// virtual delta calculation. A stopped, already-configured counter may be
+    /// reconfigured for another supported event. A running counter is rejected
+    /// with `SBI_ERR_ALREADY_STARTED` even if `AUTO_START` is not set, matching
+    /// the SBI PMU lifecycle rule for `COUNTER_CONFIG_MATCHING`.
+    #[inline]
+    fn counter_config_matching(
+        &self,
+        counter_idx_base: usize,
+        counter_idx_mask: usize,
+        config_flags: usize,
+        event_idx: usize,
+        _event_data: u64,
+    ) -> SbiRet {
+        if (config_flags & !Self::CFG_VALID_FLAGS) != 0 {
+            return SbiRet::invalid_param();
+        }
+        let ret = Self::validate_counter_set(counter_idx_base, counter_idx_mask);
+        if ret.is_err() {
+            return ret;
+        }
+
+        let counter_idx = if (config_flags & Self::CFG_FLAG_SKIP_MATCH) != 0 {
+            let Some(counter_idx) = Self::first_counter_in_set(counter_idx_base, counter_idx_mask)
+            else {
+                return SbiRet::invalid_param();
+            };
+            if !Self::counter_supports_event(counter_idx, event_idx) {
+                return SbiRet::not_supported();
+            }
+            counter_idx
+        } else {
+            let Some(counter_idx) = Self::event_counter(event_idx) else {
+                return SbiRet::not_supported();
+            };
+            if !Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
+                return SbiRet::not_supported();
+            }
+            counter_idx
+        };
+
+        let counter = &self.counters[counter_idx];
+        if counter.started.load(Ordering::Relaxed) {
+            return SbiRet::already_started();
+        }
+
+        counter.event_idx.store(event_idx, Ordering::Relaxed);
+        counter.configured.store(true, Ordering::Relaxed);
+        if (config_flags & Self::CFG_FLAG_CLEAR_VALUE) != 0 {
+            counter.value.store(0, Ordering::Relaxed);
+            counter.hardware_base.store(0, Ordering::Relaxed);
+        }
+        if (config_flags & Self::CFG_FLAG_AUTO_START) != 0 {
+            if Self::counter_is_fixed(counter_idx) {
+                counter
+                    .hardware_base
+                    .store(Self::fixed_hardware_value(counter_idx), Ordering::Relaxed);
+            }
+            counter.started.store(true, Ordering::Relaxed);
+        }
+        SbiRet::success(counter_idx)
+    }
+
+    /// Start one or more configured virtual counters.
+    ///
+    /// All selected counters are validated before any counter is modified. This
+    /// keeps the operation atomic from the guest's perspective: if one selected
+    /// counter is unconfigured or already running, no selected counter is
+    /// started. When `START_SET_INIT_VALUE` is present, each selected counter's
+    /// stored virtual value is replaced with `initial_value` before counting
+    /// begins. Fixed PMU counters capture a fresh hardware baseline at start
+    /// time.
+    #[inline]
+    fn counter_start(
+        &self,
+        counter_idx_base: usize,
+        counter_idx_mask: usize,
+        start_flags: usize,
+        initial_value: u64,
+    ) -> SbiRet {
+        if (start_flags & !Self::START_FLAG_SET_INIT_VALUE) != 0 {
+            return SbiRet::invalid_param();
+        }
+        let ret = Self::validate_counter_set(counter_idx_base, counter_idx_mask);
+        if ret.is_err() {
+            return ret;
+        }
+        for counter_idx in 0..Self::NUM_COUNTERS {
+            if !Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
+                continue;
+            }
+
+            let counter = &self.counters[counter_idx];
+            if !counter.configured.load(Ordering::Relaxed) {
+                return SbiRet::invalid_param();
+            }
+            if counter.started.load(Ordering::Relaxed) {
+                return SbiRet::already_started();
+            }
+        }
+
+        for counter_idx in 0..Self::NUM_COUNTERS {
+            if Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
+                if (start_flags & Self::START_FLAG_SET_INIT_VALUE) != 0 {
+                    self.counters[counter_idx]
+                        .value
+                        .store(initial_value, Ordering::Relaxed);
+                }
+                if Self::counter_is_fixed(counter_idx) {
+                    self.counters[counter_idx]
+                        .hardware_base
+                        .store(Self::fixed_hardware_value(counter_idx), Ordering::Relaxed);
+                }
+                self.counters[counter_idx]
+                    .started
+                    .store(true, Ordering::Relaxed);
+            }
+        }
+
+        SbiRet::success(0)
+    }
+
+    /// Stop one or more running virtual counters.
+    ///
+    /// As with `counter_start`, validation is performed for the entire selected
+    /// set before mutating any counter. Stopping a fixed PMU counter without
+    /// `STOP_RESET` folds the live hardware delta into the stored virtual value
+    /// so a later read or restart sees a stable guest-visible value. If
+    /// `STOP_RESET` is supplied, the counter is returned to the unconfigured
+    /// state directly and the fixed-counter fold is skipped because the stored
+    /// value would be discarded.
+    ///
+    /// This implementation intentionally returns `SBI_ERR_INVALID_PARAM` when
+    /// the selected counter has never been configured. The SBI PMU
+    /// specification defines invalid-parameter errors for invalid counter
+    /// indices, while a never-configured counter is also stopped in the narrow
+    /// state-machine sense. Returning `ALREADY_STOPPED` for that case would be
+    /// spec-compatible, but the stricter error makes guest lifecycle mistakes
+    /// easier to diagnose.
+    #[inline]
+    fn counter_stop(
+        &self,
+        counter_idx_base: usize,
+        counter_idx_mask: usize,
+        stop_flags: usize,
+    ) -> SbiRet {
+        if (stop_flags & !Self::STOP_FLAG_RESET) != 0 {
+            return SbiRet::invalid_param();
+        }
+        let ret = Self::validate_counter_set(counter_idx_base, counter_idx_mask);
+        if ret.is_err() {
+            return ret;
+        }
+
+        for counter_idx in 0..Self::NUM_COUNTERS {
+            if !Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
+                continue;
+            }
+
+            let counter = &self.counters[counter_idx];
+            if !counter.configured.load(Ordering::Relaxed) {
+                return SbiRet::invalid_param();
+            }
+            if !counter.started.load(Ordering::Relaxed) {
+                return SbiRet::already_stopped();
+            }
+        }
+
+        for counter_idx in 0..Self::NUM_COUNTERS {
+            if !Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
+                continue;
+            }
+
+            let counter = &self.counters[counter_idx];
+            if (stop_flags & Self::STOP_FLAG_RESET) != 0 {
+                self.reset_counter(counter_idx);
+                continue;
+            }
+            if Self::counter_is_fixed(counter_idx) {
+                counter
+                    .value
+                    .store(self.fixed_virtual_value(counter_idx), Ordering::Relaxed);
+                counter.hardware_base.store(0, Ordering::Relaxed);
+            }
+            counter.started.store(false, Ordering::Relaxed);
+        }
+
+        SbiRet::success(0)
+    }
+
+    /// Read the low word of a configured firmware counter.
+    ///
+    /// SBI PMU exposes firmware-counter values through explicit read calls
+    /// rather than direct CSR access. This method rejects fixed PMU counters and
+    /// unconfigured firmware counters.
+    #[inline]
+    fn counter_fw_read(&self, counter_idx: usize) -> SbiRet {
+        if !Self::counter_is_firmware(counter_idx) {
+            return SbiRet::invalid_param();
+        }
+
+        let counter = &self.counters[counter_idx];
+        if !counter.configured.load(Ordering::Relaxed) {
+            return SbiRet::invalid_param();
+        }
+
+        SbiRet::success(counter.value.load(Ordering::Relaxed) as usize)
+    }
+
+    /// Read the high word of a configured firmware counter.
+    ///
+    /// On RV32, the high 32 bits are returned so a guest can reconstruct the
+    /// full 64-bit firmware counter value. On RV64, SBI specifies that the high
+    /// read returns zero because the low read already carries the full value.
+    #[inline]
+    fn counter_fw_read_hi(&self, counter_idx: usize) -> SbiRet {
+        if !Self::counter_is_firmware(counter_idx) {
+            return SbiRet::invalid_param();
+        }
+
+        let counter = &self.counters[counter_idx];
+        if !counter.configured.load(Ordering::Relaxed) {
+            return SbiRet::invalid_param();
+        }
+
+        #[cfg(target_pointer_width = "32")]
+        {
+            SbiRet::success((counter.value.load(Ordering::Relaxed) >> 32) as usize)
+        }
+        #[cfg(not(target_pointer_width = "32"))]
+        {
+            SbiRet::success(0)
+        }
+    }
+}

--- a/components/riscv_vcpu/src/vpmu.rs
+++ b/components/riscv_vcpu/src/vpmu.rs
@@ -81,19 +81,151 @@ use sbi_spec::{binary::SbiRet, pmu};
 ///
 /// - Counter 0 exposes the architectural fixed `cycle` counter.
 /// - Counter 1 exposes the architectural fixed `instret` counter.
-/// - Counters 2 and above expose selected SBI firmware counters whose events
+/// - Counters 2..=12 expose selected SBI firmware counters whose events
 ///   can be observed by this vCPU implementation.
+/// - Counters 13 and above are hardware performance counters (HPM) dynamically
+///   allocated by the backend. The number of HPM slots equals
+///   `PmuBackend::num_hpm_counters()` and may be zero (default for QEMU).
 ///
-/// Fixed PMU counters use a virtual offset model. When a fixed counter is
-/// started, the current hardware CSR value is captured as `hardware_base`.
-/// While the counter remains running, the guest-visible value is
-/// `value + (hardware_now - hardware_base)`. When the counter is stopped
-/// without `STOP_RESET`, the current delta is folded back into `value`,
-/// allowing later starts to continue from the same guest-visible value or from
-/// a supplied initial value.
-pub(crate) struct VirtualPmu {
+/// Fixed and HPM counters use a virtual offset model. When a hardware-backed
+/// counter is started, the current hardware value is captured as
+/// `hardware_base`. While running, the guest-visible value is
+/// `value + (hardware_now - hardware_base)`. When stopped without `STOP_RESET`,
+/// the current delta is folded back into `value`.
+pub(crate) struct VirtualPmu<B = QemuPmuBackend>
+where
+    B: PmuBackend,
+{
     /// Guest-visible counter state indexed by virtual counter number.
-    counters: [VirtualPmuCounter; Self::NUM_COUNTERS],
+    ///
+    /// Length is `FIXED_COUNTERS + FIRMWARE_COUNTERS + backend.num_hpm_counters()`
+    /// and is fixed for the lifetime of this instance.
+    counters: alloc::vec::Vec<VirtualPmuCounter>,
+    /// Backend used as the source for physical or emulated PMU values.
+    backend: B,
+}
+
+/// Backend boundary between guest-visible vPMU state and the underlying
+/// hardware PMU source.
+///
+/// `VirtualPmu` owns the SBI PMU ABI, guest-visible counter lifecycle, and
+/// per-vCPU virtual values. The backend supplies:
+///
+/// - reads from architectural fixed counter CSRs (`cycle`, `instret`),
+/// - optional hardware performance counter (`hpmcounter3..31`) allocation,
+///   programming, reading, and release,
+/// - vCPU lifecycle hooks (`on_bind`, `on_unbind`) for saving/restoring
+///   physical PMU state across vCPU context switches.
+///
+/// The default implementation (`QemuPmuBackend`) only reads local CSRs and
+/// exposes no HPM counters. A board-specific implementation can override
+/// every method to schedule real hardware counters with full isolation.
+pub(crate) trait PmuBackend {
+    /// Read the underlying source for the architectural `cycle` counter.
+    fn read_cycle(&self) -> u64;
+
+    /// Read the underlying source for the architectural `instret` counter.
+    fn read_instret(&self) -> u64;
+
+    /// Number of additional hardware PMU counters this backend can expose.
+    ///
+    /// These slots are appended to the virtual bank after the fixed and
+    /// firmware counters. Returning zero means no hardware performance counters
+    /// beyond `cycle` and `instret` are available. The value must remain
+    /// constant for the lifetime of the backend.
+    fn num_hpm_counters(&self) -> usize;
+
+    /// Check whether the backend can count the given SBI event index.
+    ///
+    /// Used by the `SKIP_MATCH` configuration path to test event compatibility
+    /// without performing an allocation. A backend returning `true` here must
+    /// be able to produce an `allocate_hpm` success for the same event, subject
+    /// only to counter availability.
+    fn can_handle_event(&self, event_idx: usize) -> bool;
+
+    /// Allocate a hardware performance counter for the given SBI event.
+    ///
+    /// On success, returns an opaque hardware slot identifier. The caller
+    /// stores the slot in the virtual counter and releases it via `release_hpm`
+    /// when the virtual counter is reset. Returns `None` if the event is
+    /// unsupported or no physical counter is currently free.
+    fn allocate_hpm(&self, event_idx: usize, event_data: u64) -> Option<usize>;
+
+    /// Release a hardware performance counter previously allocated with
+    /// `allocate_hpm`. The slot identifier must not be used after this call.
+    fn release_hpm(&self, hw_slot: usize);
+
+    /// Read the current value of an allocated hardware performance counter.
+    fn read_hpm(&self, hw_slot: usize) -> u64;
+
+    /// Called immediately after the owning vCPU is bound to a hart.
+    ///
+    /// A real-hardware backend should restore `mhpmevent*` and `hpmcounter*`
+    /// state so the guest sees its own counters.
+    fn on_bind(&self);
+
+    /// Called immediately before the owning vCPU is unbound from a hart.
+    ///
+    /// A real-hardware backend should save `mhpmevent*` and `hpmcounter*`
+    /// state so it can be restored by the next `on_bind` call.
+    fn on_unbind(&self);
+}
+
+/// Default PMU backend used by the QEMU-oriented software vPMU.
+///
+/// Reads architectural fixed counter CSRs directly for use as delta sources.
+/// Exposes no HPM counters. All lifecycle hooks are no-ops. Sufficient for
+/// virtual-only counter tracking on QEMU and other software-emulated platforms.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct QemuPmuBackend;
+
+impl PmuBackend for QemuPmuBackend {
+    #[inline]
+    fn read_cycle(&self) -> u64 {
+        let value: usize;
+        unsafe {
+            core::arch::asm!("csrr {value}, cycle", value = out(reg) value);
+        }
+        value as u64
+    }
+
+    #[inline]
+    fn read_instret(&self) -> u64 {
+        let value: usize;
+        unsafe {
+            core::arch::asm!("csrr {value}, instret", value = out(reg) value);
+        }
+        value as u64
+    }
+
+    #[inline]
+    fn num_hpm_counters(&self) -> usize {
+        0
+    }
+
+    #[inline]
+    fn can_handle_event(&self, _event_idx: usize) -> bool {
+        false
+    }
+
+    #[inline]
+    fn allocate_hpm(&self, _event_idx: usize, _event_data: u64) -> Option<usize> {
+        None
+    }
+
+    #[inline]
+    fn release_hpm(&self, _hw_slot: usize) {}
+
+    #[inline]
+    fn read_hpm(&self, _hw_slot: usize) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn on_bind(&self) {}
+
+    #[inline]
+    fn on_unbind(&self) {}
 }
 
 /// Mutable state for one virtual PMU counter.
@@ -103,7 +235,6 @@ pub(crate) struct VirtualPmu {
 /// serializes access per vCPU, so relaxed ordering is sufficient: the atomics
 /// provide race-free storage without imposing cross-counter synchronization
 /// semantics that the virtual PMU does not require.
-#[derive(Default)]
 struct VirtualPmuCounter {
     /// SBI event index currently bound to this counter.
     ///
@@ -117,27 +248,40 @@ struct VirtualPmuCounter {
     configured: AtomicBool,
     /// Whether the counter is currently counting.
     ///
-    /// Firmware counters only increment while this flag is set. Fixed PMU
-    /// counters use it to decide whether `hardware_base` should be applied to
-    /// the stored virtual value.
+    /// Firmware counters only increment while this flag is set. Hardware-backed
+    /// counters (fixed and HPM) use it to decide whether `hardware_base` should
+    /// be applied to the stored virtual value.
     started: AtomicBool,
     /// Stored virtual counter value.
     ///
-    /// For firmware counters this is the complete counter value. For fixed PMU
-    /// counters this is the accumulated guest-visible value at the last clear,
-    /// explicit initialization, or stop point; while running, the live hardware
-    /// delta is added on top.
+    /// For firmware counters this is the complete counter value. For
+    /// hardware-backed counters this is the accumulated guest-visible value at
+    /// the last clear, explicit initialization, or stop point; while running,
+    /// the live hardware delta is added on top.
     value: AtomicU64,
-    /// Hardware CSR baseline for a running fixed PMU counter.
+    /// Hardware counter baseline captured at start time.
     ///
-    /// This field is meaningful only for `cycle` and `instret` while `started`
-    /// is true. It is reset to zero when a fixed counter is stopped or cleared.
+    /// Meaningful only for hardware-backed counters (`cycle`, `instret`, HPM)
+    /// while `started` is true. Reset to zero when the counter is stopped or
+    /// cleared.
     hardware_base: AtomicU64,
+    /// Opaque hardware slot identifier allocated by the backend.
+    ///
+    /// Set to `HW_SLOT_NONE` for unconfigured counters, firmware counters
+    /// (which are always purely virtual), and fixed counters (`cycle`,
+    /// `instret`). For HPM counters it holds the slot returned by
+    /// `PmuBackend::allocate_hpm` and is released via `release_hpm` on reset.
+    hw_slot: AtomicUsize,
 }
 
-impl VirtualPmu {
-    /// Number of virtual counters exposed to the guest through SBI PMU.
-    const NUM_COUNTERS: usize = 13;
+impl<B> VirtualPmu<B>
+where
+    B: PmuBackend,
+{
+    /// Number of fixed CSR-backed PMU counters (cycle and instret).
+    const FIXED_COUNTERS: usize = 2;
+    /// Number of virtual firmware counters in the static counter bank.
+    const FIRMWARE_COUNTERS: usize = 11;
     /// Virtual counter index for the architectural `cycle` CSR.
     const CYCLE_COUNTER: usize = 0;
     /// Virtual counter index for the architectural `instret` CSR.
@@ -164,7 +308,7 @@ impl VirtualPmu {
     const FW_HFENCE_VVMA_SENT_COUNTER: usize = 11;
     /// Firmware counter index for `SBI_PMU_FW_HFENCE_VVMA_ASID_SENT`.
     const FW_HFENCE_VVMA_ASID_SENT_COUNTER: usize = 12;
-    /// Reported fixed-counter width encoded in SBI `COUNTER_GET_INFO`.
+    /// Reported counter width encoded in SBI `COUNTER_GET_INFO`.
     ///
     /// SBI encodes the width as the most significant valid bit index rather
     /// than the number of bits. `usize::BITS - 1` matches the architectural CSR
@@ -174,10 +318,14 @@ impl VirtualPmu {
     const CSR_CYCLE: usize = 0xc00;
     /// CSR number for the architectural `instret` counter.
     const CSR_INSTRET: usize = 0xc02;
+    /// Base CSR number for hardware performance counters (`hpmcounter3`).
+    const CSR_HPM_BASE: usize = 0xc03;
     /// SBI counter-info marker for a firmware counter.
     const FIRMWARE_COUNTER_TYPE: usize = 1 << (usize::BITS as usize - 1);
     /// Sentinel event index stored in counters that have not been configured.
     const UNCONFIGURED_EVENT: usize = usize::MAX;
+    /// Sentinel `hw_slot` value meaning no hardware slot is currently allocated.
+    const HW_SLOT_NONE: usize = usize::MAX;
 
     /// `COUNTER_CONFIG_MATCHING` flag requesting direct use of the supplied set.
     const CFG_FLAG_SKIP_MATCH: usize = 1 << 0;
@@ -196,12 +344,11 @@ impl VirtualPmu {
     /// `COUNTER_STOP` flag requesting that the counter be reset after stopping.
     const STOP_FLAG_RESET: usize = 1 << 0;
 
-    /// Build SBI `COUNTER_GET_INFO` metadata for a CSR-backed fixed PMU counter.
+    /// Build SBI `COUNTER_GET_INFO` metadata for a CSR-backed counter.
     ///
     /// The SBI return value combines the CSR number with the reported counter
-    /// width. Fixed PMU counters are advertised as direct CSR counters so a
-    /// guest can discover the architectural CSR associated with each virtual
-    /// counter.
+    /// width. Both fixed PMU counters and HPM counters are advertised as direct
+    /// CSR counters so a guest can discover the architectural CSR.
     #[inline]
     fn counter_info(csr: usize) -> usize {
         csr | (Self::COUNTER_WIDTH << 12)
@@ -230,9 +377,9 @@ impl VirtualPmu {
     ///
     /// The method checks every selected bit in the mask. A set is invalid if it
     /// selects no counters, overflows while adding the base, or refers to a
-    /// counter beyond the virtual bank exposed by `NUM_COUNTERS`.
+    /// counter beyond the live virtual bank.
     #[inline]
-    fn validate_counter_set(counter_idx_base: usize, counter_idx_mask: usize) -> SbiRet {
+    fn validate_counter_set(&self, counter_idx_base: usize, counter_idx_mask: usize) -> SbiRet {
         if counter_idx_mask == 0 {
             return SbiRet::invalid_param();
         }
@@ -245,7 +392,7 @@ impl VirtualPmu {
             let Some(counter_idx) = counter_idx_base.checked_add(offset) else {
                 return SbiRet::invalid_param();
             };
-            if counter_idx >= Self::NUM_COUNTERS {
+            if counter_idx >= self.counters.len() {
                 return SbiRet::invalid_param();
             }
         }
@@ -255,26 +402,26 @@ impl VirtualPmu {
 
     /// Return the first virtual counter selected by an SBI counter set.
     ///
-    /// This is used for `SKIP_MATCH`, where the guest asks the implementation
-    /// to use the selected counter directly rather than searching for a counter
-    /// that supports the event.
+    /// Used for `SKIP_MATCH` where the guest selects the counter directly.
     #[inline]
-    fn first_counter_in_set(counter_idx_base: usize, counter_idx_mask: usize) -> Option<usize> {
-        (0..Self::NUM_COUNTERS).find(|&counter_idx| {
+    fn first_counter_in_set(
+        &self,
+        counter_idx_base: usize,
+        counter_idx_mask: usize,
+    ) -> Option<usize> {
+        (0..self.counters.len()).find(|&counter_idx| {
             Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask)
         })
     }
 
-    /// Map an SBI PMU event index to the virtual counter that can count it.
+    /// Map an SBI PMU event to the fixed or firmware virtual counter for it.
     ///
-    /// Only events that can be represented without host PMU passthrough are
-    /// mapped. General hardware events are limited to architectural fixed
-    /// counters, and firmware events are limited to actions that this vCPU
-    /// implementation can observe directly. Unsupported hardware, cache, raw,
-    /// and platform events return `None` so the SBI call can report
-    /// `SBI_ERR_NOT_SUPPORTED`.
+    /// Returns the dedicated virtual counter index for events covered by the
+    /// static counter bank (`cycle`, `instret`, and the eleven firmware events).
+    /// Returns `None` for any other event, including hardware cache/raw/platform
+    /// events that must be routed through the HPM backend path.
     #[inline]
-    fn event_counter(event_idx: usize) -> Option<usize> {
+    fn event_counter_static(event_idx: usize) -> Option<usize> {
         let event_type = event_idx >> 16;
         let event_code = event_idx & 0xffff;
 
@@ -324,66 +471,72 @@ impl VirtualPmu {
 
     /// Check whether a specific virtual counter can count `event_idx`.
     ///
-    /// This helper is used by the `SKIP_MATCH` configuration path. Even when
-    /// the guest asks to skip matching, the chosen counter still has to be
-    /// compatible with the requested event.
+    /// For fixed and firmware counters the check is a direct static-mapping
+    /// lookup. For HPM virtual slots the backend is queried via
+    /// `can_handle_event` without performing any allocation.
     #[inline]
-    fn counter_supports_event(counter_idx: usize, event_idx: usize) -> bool {
-        Self::event_counter(event_idx) == Some(counter_idx)
+    fn counter_supports_event(&self, counter_idx: usize, event_idx: usize) -> bool {
+        if Self::event_counter_static(event_idx) == Some(counter_idx) {
+            return true;
+        }
+        self.counter_is_hpm(counter_idx) && self.backend.can_handle_event(event_idx)
     }
 
     /// Return whether a counter is one of the virtual firmware counters.
     ///
     /// Firmware counters are read through `COUNTER_FW_READ` rather than direct
-    /// CSR reads. They are incremented by explicit hooks in the vCPU code when
-    /// the corresponding SBI or trap-handling operation occurs.
+    /// CSR reads.
     #[inline]
     fn counter_is_firmware(counter_idx: usize) -> bool {
-        (Self::FW_SET_TIMER_COUNTER..Self::NUM_COUNTERS).contains(&counter_idx)
+        let fw_end = Self::FIXED_COUNTERS + Self::FIRMWARE_COUNTERS;
+        counter_idx >= Self::FIXED_COUNTERS && counter_idx < fw_end
     }
 
-    /// Return whether a counter is one of the fixed CSR-backed PMU counters.
-    ///
-    /// Fixed PMU counters use the offset/baseline model implemented by
-    /// `fixed_virtual_value` instead of explicit event increments.
+    /// Return whether a counter is an HPM virtual slot backed by the backend.
     #[inline]
-    fn counter_is_fixed(counter_idx: usize) -> bool {
-        counter_idx <= Self::INSTRET_COUNTER
+    fn counter_is_hpm(&self, counter_idx: usize) -> bool {
+        let hpm_start = Self::FIXED_COUNTERS + Self::FIRMWARE_COUNTERS;
+        counter_idx >= hpm_start && counter_idx < self.counters.len()
     }
 
-    /// Read the current host hardware value for a fixed architectural counter.
+    /// Return whether a counter uses the hardware baseline/delta model.
     ///
-    /// The returned value is used only as a delta source for virtual fixed
-    /// counters. It is not exposed directly as the guest-visible value unless
-    /// the guest has started the virtual counter with a zero offset and no
-    /// later stop/clear/init operation.
-    ///
-    /// Returns zero for non-fixed counter indices; callers normally guard with
-    /// `counter_is_fixed` before invoking this method.
+    /// Both fixed counters and HPM counters capture `hardware_base` at start
+    /// and accumulate a delta; only firmware counters use direct increment.
     #[inline]
-    fn fixed_hardware_value(counter_idx: usize) -> u64 {
-        let value: usize;
+    fn counter_is_hardware_backed(&self, counter_idx: usize) -> bool {
+        !Self::counter_is_firmware(counter_idx)
+    }
+
+    /// Read the current hardware value for a hardware-backed counter.
+    ///
+    /// For fixed counters this reads the architectural CSR via the backend.
+    /// For HPM counters it delegates to `backend.read_hpm`. Returns zero for
+    /// firmware counter indices or HPM counters with no allocated slot.
+    #[inline]
+    fn hardware_value(&self, counter_idx: usize) -> u64 {
         match counter_idx {
-            Self::CYCLE_COUNTER => unsafe {
-                core::arch::asm!("csrr {value}, cycle", value = out(reg) value);
-            },
-            Self::INSTRET_COUNTER => unsafe {
-                core::arch::asm!("csrr {value}, instret", value = out(reg) value);
-            },
-            _ => return 0,
+            Self::CYCLE_COUNTER => self.backend.read_cycle(),
+            Self::INSTRET_COUNTER => self.backend.read_instret(),
+            idx if self.counter_is_hpm(idx) => {
+                let hw_slot = self.counters[idx].hw_slot.load(Ordering::Relaxed);
+                if hw_slot != Self::HW_SLOT_NONE {
+                    self.backend.read_hpm(hw_slot)
+                } else {
+                    0
+                }
+            }
+            _ => 0,
         }
-        value as u64
     }
 
-    /// Compute the guest-visible value for a fixed PMU counter.
+    /// Compute the guest-visible value for a hardware-backed counter.
     ///
     /// If the counter is stopped, the stored virtual value is already complete.
-    /// If it is running, the method adds the elapsed hardware-counter delta
-    /// since the last start to the stored virtual value. Wrapping arithmetic is
-    /// used to preserve architectural counter behavior across hardware counter
-    /// wraparound.
+    /// If it is running, the live hardware delta since the last start is added
+    /// on top. Wrapping arithmetic preserves architectural wraparound behavior.
     #[inline]
-    fn fixed_virtual_value(&self, counter_idx: usize) -> u64 {
+    fn hardware_virtual_value(&self, counter_idx: usize) -> u64 {
         let counter = &self.counters[counter_idx];
         let value = counter.value.load(Ordering::Relaxed);
         if !counter.started.load(Ordering::Relaxed) {
@@ -391,18 +544,22 @@ impl VirtualPmu {
         }
 
         let hardware_base = counter.hardware_base.load(Ordering::Relaxed);
-        let hardware_now = Self::fixed_hardware_value(counter_idx);
+        let hardware_now = self.hardware_value(counter_idx);
         value.wrapping_add(hardware_now.wrapping_sub(hardware_base))
     }
 
     /// Reset a counter to the unconfigured state.
     ///
-    /// This implements the reset side effect requested by `COUNTER_STOP` with
-    /// `STOP_RESET`. The selected event, configured/start state, virtual value,
-    /// and fixed-counter baseline are all cleared.
+    /// Releases any allocated HPM slot back to the backend, then clears all
+    /// counter fields. This is the only code path that calls `release_hpm`.
     #[inline]
     fn reset_counter(&self, counter_idx: usize) {
         let counter = &self.counters[counter_idx];
+        // Release any allocated HPM slot before clearing the rest of the state.
+        let hw_slot = counter.hw_slot.swap(Self::HW_SLOT_NONE, Ordering::Relaxed);
+        if hw_slot != Self::HW_SLOT_NONE {
+            self.backend.release_hpm(hw_slot);
+        }
         counter
             .event_idx
             .store(Self::UNCONFIGURED_EVENT, Ordering::Relaxed);
@@ -413,26 +570,40 @@ impl VirtualPmu {
     }
 }
 
-impl Default for VirtualPmu {
-    /// Create an empty virtual PMU counter bank.
+impl<B> Default for VirtualPmu<B>
+where
+    B: PmuBackend + Default,
+{
+    fn default() -> Self {
+        Self::new(B::default())
+    }
+}
+
+impl<B> VirtualPmu<B>
+where
+    B: PmuBackend,
+{
+    /// Create an empty virtual PMU counter bank with an explicit backend.
     ///
     /// All counters start unconfigured and stopped. Firmware counters begin at
     /// zero, and fixed PMU counters have no hardware baseline until they are
     /// started by the guest.
-    fn default() -> Self {
-        let counters = core::array::from_fn(|_| VirtualPmuCounter {
-            event_idx: AtomicUsize::new(Self::UNCONFIGURED_EVENT),
-            configured: AtomicBool::new(false),
-            started: AtomicBool::new(false),
-            value: AtomicU64::new(0),
-            hardware_base: AtomicU64::new(0),
-        });
+    pub(crate) fn new(backend: B) -> Self {
+        let total = Self::FIXED_COUNTERS + Self::FIRMWARE_COUNTERS + backend.num_hpm_counters();
+        let counters = (0..total)
+            .map(|_| VirtualPmuCounter {
+                event_idx: AtomicUsize::new(Self::UNCONFIGURED_EVENT),
+                configured: AtomicBool::new(false),
+                started: AtomicBool::new(false),
+                value: AtomicU64::new(0),
+                hardware_base: AtomicU64::new(0),
+                hw_slot: AtomicUsize::new(Self::HW_SLOT_NONE),
+            })
+            .collect();
 
-        Self { counters }
+        Self { counters, backend }
     }
-}
 
-impl VirtualPmu {
     /// Record one guest-visible `SET_TIMER` firmware event.
     ///
     /// The vCPU should call this when it handles or forwards a guest timer SBI
@@ -534,42 +705,6 @@ impl VirtualPmu {
         self.record_firmware_event(Self::FW_HFENCE_VVMA_ASID_SENT_COUNTER);
     }
 
-    /// Read the virtual `cycle` fixed PMU counter.
-    ///
-    /// This helper is intended for a future CSR emulation path. It returns the
-    /// virtual value maintained by this PMU rather than the raw hardware CSR.
-    /// The counter must have been configured by the guest through SBI PMU.
-    #[inline]
-    pub(crate) fn read_cycle(&self) -> SbiRet {
-        self.read_fixed_counter(Self::CYCLE_COUNTER)
-    }
-
-    /// Read the virtual `instret` fixed PMU counter.
-    ///
-    /// This helper is intended for a future CSR emulation path. Until CSR reads
-    /// are trapped and redirected here, a guest direct CSR read may still see
-    /// the underlying hardware value.
-    #[inline]
-    pub(crate) fn read_instret(&self) -> SbiRet {
-        self.read_fixed_counter(Self::INSTRET_COUNTER)
-    }
-
-    /// Read a configured fixed PMU counter by virtual counter index.
-    ///
-    /// Returns `SBI_ERR_INVALID_PARAM` if the counter has not been configured.
-    /// This matches the conservative behavior used for firmware-counter reads:
-    /// guest code should configure a counter before consuming its value through
-    /// the PMU interface.
-    #[inline]
-    fn read_fixed_counter(&self, counter_idx: usize) -> SbiRet {
-        let counter = &self.counters[counter_idx];
-        if !counter.configured.load(Ordering::Relaxed) {
-            return SbiRet::invalid_param();
-        }
-
-        SbiRet::success(self.fixed_virtual_value(counter_idx) as usize)
-    }
-
     /// Increment a firmware counter if it is currently active.
     ///
     /// Firmware counters are purely virtual; they advance only when the vCPU
@@ -582,20 +717,49 @@ impl VirtualPmu {
             counter.value.fetch_add(1, Ordering::Relaxed);
         }
     }
+
+    /// Notify the backend that the owning vCPU is being bound to a hart.
+    ///
+    /// Must be called at the end of `AxArchVCpu::bind()` after all VS-mode
+    /// CSRs have been restored. A real-hardware backend uses this hook to
+    /// restore `mhpmevent*` and `hpmcounter*` state so the guest counter view
+    /// is consistent on the newly scheduled hart.
+    #[inline]
+    pub(crate) fn backend_bind(&self) {
+        self.backend.on_bind();
+    }
+
+    /// Notify the backend that the owning vCPU is being unbound from a hart.
+    ///
+    /// Must be called at the beginning of `AxArchVCpu::unbind()` before
+    /// VS-mode CSRs are saved. A real-hardware backend uses this hook to save
+    /// `mhpmevent*` and `hpmcounter*` state so it can be restored by the next
+    /// `backend_bind` call.
+    #[inline]
+    pub(crate) fn backend_unbind(&self) {
+        self.backend.on_unbind();
+    }
 }
 
-impl Pmu for VirtualPmu {
+impl<B> Pmu for VirtualPmu<B>
+where
+    B: PmuBackend,
+{
     /// Return the number of virtual counters exposed by this PMU instance.
+    ///
+    /// The total is the number of counters in the live bank, which equals
+    /// `FIXED_COUNTERS + FIRMWARE_COUNTERS + backend.num_hpm_counters()`.
     #[inline]
     fn num_counters(&self) -> usize {
-        Self::NUM_COUNTERS
+        self.counters.len()
     }
 
     /// Return SBI metadata for a virtual counter.
     ///
-    /// Fixed PMU counters are reported as CSR-backed counters with their
-    /// architectural CSR numbers. Firmware counters are reported as firmware
-    /// counters. Any index outside the virtual counter bank is rejected.
+    /// Fixed PMU counters and HPM counters are reported as CSR-backed counters
+    /// with their architectural CSR numbers. Firmware counters are reported as
+    /// firmware counters. Any index outside the virtual counter bank is
+    /// rejected.
     #[inline]
     fn counter_get_info(&self, counter_idx: usize) -> SbiRet {
         match counter_idx {
@@ -612,26 +776,27 @@ impl Pmu for VirtualPmu {
             Self::FW_HFENCE_GVMA_VMID_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
             Self::FW_HFENCE_VVMA_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
             Self::FW_HFENCE_VVMA_ASID_SENT_COUNTER => SbiRet::success(Self::FIRMWARE_COUNTER_TYPE),
+            idx if self.counter_is_hpm(idx) => {
+                // Report the architectural `hpmcounterN` CSR for this HPM slot.
+                let hpm_local = idx - (Self::FIXED_COUNTERS + Self::FIRMWARE_COUNTERS);
+                SbiRet::success(Self::counter_info(Self::CSR_HPM_BASE + hpm_local))
+            }
             _ => SbiRet::invalid_param(),
         }
     }
 
     /// Configure a virtual counter for an SBI PMU event.
     ///
-    /// The implementation supports only events that can be represented by the
-    /// fixed PMU counters or by vCPU-observable firmware hooks. When
-    /// `SKIP_MATCH` is set, the first selected counter is used only if it
-    /// supports the requested event. Otherwise the event is mapped to its
-    /// dedicated virtual counter and then checked against the guest-supplied
-    /// counter set.
+    /// For fixed and firmware events the dedicated static virtual slot is used.
+    /// For all other events the backend is asked to allocate a hardware slot
+    /// and a free HPM virtual slot is assigned. `SKIP_MATCH` forces selection
+    /// of a specific counter without the event-to-slot search; for HPM slots
+    /// the backend's `can_handle_event` is checked first, then an HPM slot is
+    /// allocated.
     ///
-    /// `CLEAR_VALUE` resets the stored virtual value, and `AUTO_START` starts
-    /// the counter immediately. For fixed PMU counters, auto-start also
-    /// captures the current hardware CSR value as the baseline for future
-    /// virtual delta calculation. A stopped, already-configured counter may be
-    /// reconfigured for another supported event. A running counter is rejected
-    /// with `SBI_ERR_ALREADY_STARTED` even if `AUTO_START` is not set, matching
-    /// the SBI PMU lifecycle rule for `COUNTER_CONFIG_MATCHING`.
+    /// `CLEAR_VALUE` resets the stored virtual value. `AUTO_START` starts the
+    /// counter immediately and captures a hardware baseline. Running counters
+    /// are rejected with `SBI_ERR_ALREADY_STARTED`.
     #[inline]
     fn counter_config_matching(
         &self,
@@ -639,33 +804,78 @@ impl Pmu for VirtualPmu {
         counter_idx_mask: usize,
         config_flags: usize,
         event_idx: usize,
-        _event_data: u64,
+        event_data: u64,
     ) -> SbiRet {
         if (config_flags & !Self::CFG_VALID_FLAGS) != 0 {
             return SbiRet::invalid_param();
         }
-        let ret = Self::validate_counter_set(counter_idx_base, counter_idx_mask);
+        let ret = self.validate_counter_set(counter_idx_base, counter_idx_mask);
         if ret.is_err() {
             return ret;
         }
 
         let counter_idx = if (config_flags & Self::CFG_FLAG_SKIP_MATCH) != 0 {
-            let Some(counter_idx) = Self::first_counter_in_set(counter_idx_base, counter_idx_mask)
-            else {
+            let Some(idx) = self.first_counter_in_set(counter_idx_base, counter_idx_mask) else {
                 return SbiRet::invalid_param();
             };
-            if !Self::counter_supports_event(counter_idx, event_idx) {
+            if !self.counter_supports_event(idx, event_idx) {
                 return SbiRet::not_supported();
             }
-            counter_idx
+            // For HPM slots via SKIP_MATCH: check not-started before allocating
+            // to avoid a needless backend roundtrip.
+            if self.counter_is_hpm(idx) {
+                if self.counters[idx].started.load(Ordering::Relaxed) {
+                    return SbiRet::already_started();
+                }
+                // Release any existing hw_slot (reconfiguration of a stopped
+                // HPM counter for a different event).
+                let old = self.counters[idx]
+                    .hw_slot
+                    .swap(Self::HW_SLOT_NONE, Ordering::Relaxed);
+                if old != Self::HW_SLOT_NONE {
+                    self.backend.release_hpm(old);
+                }
+                match self.backend.allocate_hpm(event_idx, event_data) {
+                    Some(hw_slot) => {
+                        self.counters[idx].hw_slot.store(hw_slot, Ordering::Relaxed);
+                    }
+                    None => return SbiRet::not_supported(),
+                }
+            }
+            idx
         } else {
-            let Some(counter_idx) = Self::event_counter(event_idx) else {
-                return SbiRet::not_supported();
-            };
-            if !Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
-                return SbiRet::not_supported();
+            // Try the static event→slot mapping first (cycle, instret, firmware).
+            if let Some(idx) = Self::event_counter_static(event_idx) {
+                if !Self::counter_in_set(idx, counter_idx_base, counter_idx_mask) {
+                    return SbiRet::not_supported();
+                }
+                idx
+            } else {
+                // Route to an HPM virtual slot via backend allocation.
+                let hw_slot = match self.backend.allocate_hpm(event_idx, event_data) {
+                    Some(s) => s,
+                    None => return SbiRet::not_supported(),
+                };
+                let hpm_start = Self::FIXED_COUNTERS + Self::FIRMWARE_COUNTERS;
+                let mut found = None;
+                for idx in hpm_start..self.counters.len() {
+                    if !Self::counter_in_set(idx, counter_idx_base, counter_idx_mask) {
+                        continue;
+                    }
+                    if !self.counters[idx].configured.load(Ordering::Relaxed) {
+                        self.counters[idx].hw_slot.store(hw_slot, Ordering::Relaxed);
+                        found = Some(idx);
+                        break;
+                    }
+                }
+                match found {
+                    Some(idx) => idx,
+                    None => {
+                        self.backend.release_hpm(hw_slot);
+                        return SbiRet::not_supported();
+                    }
+                }
             }
-            counter_idx
         };
 
         let counter = &self.counters[counter_idx];
@@ -680,10 +890,10 @@ impl Pmu for VirtualPmu {
             counter.hardware_base.store(0, Ordering::Relaxed);
         }
         if (config_flags & Self::CFG_FLAG_AUTO_START) != 0 {
-            if Self::counter_is_fixed(counter_idx) {
+            if self.counter_is_hardware_backed(counter_idx) {
                 counter
                     .hardware_base
-                    .store(Self::fixed_hardware_value(counter_idx), Ordering::Relaxed);
+                    .store(self.hardware_value(counter_idx), Ordering::Relaxed);
             }
             counter.started.store(true, Ordering::Relaxed);
         }
@@ -692,13 +902,11 @@ impl Pmu for VirtualPmu {
 
     /// Start one or more configured virtual counters.
     ///
-    /// All selected counters are validated before any counter is modified. This
-    /// keeps the operation atomic from the guest's perspective: if one selected
-    /// counter is unconfigured or already running, no selected counter is
-    /// started. When `START_SET_INIT_VALUE` is present, each selected counter's
-    /// stored virtual value is replaced with `initial_value` before counting
-    /// begins. Fixed PMU counters capture a fresh hardware baseline at start
-    /// time.
+    /// All selected counters are validated before any counter is modified. If
+    /// one selected counter is unconfigured or already running, no counter is
+    /// started. When `START_SET_INIT_VALUE` is present, each counter's stored
+    /// virtual value is replaced with `initial_value` before counting begins.
+    /// Hardware-backed counters (fixed and HPM) capture a fresh baseline.
     #[inline]
     fn counter_start(
         &self,
@@ -710,11 +918,11 @@ impl Pmu for VirtualPmu {
         if (start_flags & !Self::START_FLAG_SET_INIT_VALUE) != 0 {
             return SbiRet::invalid_param();
         }
-        let ret = Self::validate_counter_set(counter_idx_base, counter_idx_mask);
+        let ret = self.validate_counter_set(counter_idx_base, counter_idx_mask);
         if ret.is_err() {
             return ret;
         }
-        for counter_idx in 0..Self::NUM_COUNTERS {
+        for counter_idx in 0..self.counters.len() {
             if !Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
                 continue;
             }
@@ -728,17 +936,17 @@ impl Pmu for VirtualPmu {
             }
         }
 
-        for counter_idx in 0..Self::NUM_COUNTERS {
+        for counter_idx in 0..self.counters.len() {
             if Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
                 if (start_flags & Self::START_FLAG_SET_INIT_VALUE) != 0 {
                     self.counters[counter_idx]
                         .value
                         .store(initial_value, Ordering::Relaxed);
                 }
-                if Self::counter_is_fixed(counter_idx) {
+                if self.counter_is_hardware_backed(counter_idx) {
                     self.counters[counter_idx]
                         .hardware_base
-                        .store(Self::fixed_hardware_value(counter_idx), Ordering::Relaxed);
+                        .store(self.hardware_value(counter_idx), Ordering::Relaxed);
                 }
                 self.counters[counter_idx]
                     .started
@@ -751,21 +959,15 @@ impl Pmu for VirtualPmu {
 
     /// Stop one or more running virtual counters.
     ///
-    /// As with `counter_start`, validation is performed for the entire selected
-    /// set before mutating any counter. Stopping a fixed PMU counter without
-    /// `STOP_RESET` folds the live hardware delta into the stored virtual value
-    /// so a later read or restart sees a stable guest-visible value. If
-    /// `STOP_RESET` is supplied, the counter is returned to the unconfigured
-    /// state directly and the fixed-counter fold is skipped because the stored
-    /// value would be discarded.
+    /// Validation is performed for the entire selected set before mutating any
+    /// counter. Stopping a hardware-backed counter without `STOP_RESET` folds
+    /// the live delta into the stored virtual value. With `STOP_RESET` the
+    /// counter is returned to the unconfigured state directly: the fold is
+    /// skipped and any HPM slot is released via `reset_counter`.
     ///
-    /// This implementation intentionally returns `SBI_ERR_INVALID_PARAM` when
-    /// the selected counter has never been configured. The SBI PMU
-    /// specification defines invalid-parameter errors for invalid counter
-    /// indices, while a never-configured counter is also stopped in the narrow
-    /// state-machine sense. Returning `ALREADY_STOPPED` for that case would be
-    /// spec-compatible, but the stricter error makes guest lifecycle mistakes
-    /// easier to diagnose.
+    /// Returns `SBI_ERR_INVALID_PARAM` for never-configured counters to
+    /// distinguish stop-before-configure lifecycle errors from the normal
+    /// already-stopped case.
     #[inline]
     fn counter_stop(
         &self,
@@ -776,12 +978,12 @@ impl Pmu for VirtualPmu {
         if (stop_flags & !Self::STOP_FLAG_RESET) != 0 {
             return SbiRet::invalid_param();
         }
-        let ret = Self::validate_counter_set(counter_idx_base, counter_idx_mask);
+        let ret = self.validate_counter_set(counter_idx_base, counter_idx_mask);
         if ret.is_err() {
             return ret;
         }
 
-        for counter_idx in 0..Self::NUM_COUNTERS {
+        for counter_idx in 0..self.counters.len() {
             if !Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
                 continue;
             }
@@ -795,20 +997,21 @@ impl Pmu for VirtualPmu {
             }
         }
 
-        for counter_idx in 0..Self::NUM_COUNTERS {
+        for counter_idx in 0..self.counters.len() {
             if !Self::counter_in_set(counter_idx, counter_idx_base, counter_idx_mask) {
                 continue;
             }
 
             let counter = &self.counters[counter_idx];
             if (stop_flags & Self::STOP_FLAG_RESET) != 0 {
+                // reset_counter releases any HPM slot and clears all fields.
                 self.reset_counter(counter_idx);
                 continue;
             }
-            if Self::counter_is_fixed(counter_idx) {
+            if self.counter_is_hardware_backed(counter_idx) {
                 counter
                     .value
-                    .store(self.fixed_virtual_value(counter_idx), Ordering::Relaxed);
+                    .store(self.hardware_virtual_value(counter_idx), Ordering::Relaxed);
                 counter.hardware_base.store(0, Ordering::Relaxed);
             }
             counter.started.store(false, Ordering::Relaxed);
@@ -820,8 +1023,8 @@ impl Pmu for VirtualPmu {
     /// Read the low word of a configured firmware counter.
     ///
     /// SBI PMU exposes firmware-counter values through explicit read calls
-    /// rather than direct CSR access. This method rejects fixed PMU counters and
-    /// unconfigured firmware counters.
+    /// rather than direct CSR access. This method rejects fixed PMU counters,
+    /// HPM counters, and unconfigured firmware counters.
     #[inline]
     fn counter_fw_read(&self, counter_idx: usize) -> SbiRet {
         if !Self::counter_is_firmware(counter_idx) {


### PR DESCRIPTION
# RISC-V SBI PMU Virtualization

## 背景

RISC-V Linux 客户机启动时会探测 SBI PMU，并发起 counter 配置、启动、停止和读取请求。若 PMU 请求落入默认 SBI forward 路径，可能出现：

```text
forward ecall eid 0x504d55 fid 0x2 param [
    0x0,
    0x7fffffffd,
    0x0,
    0x1001a,
    0x0,
    0x0,
] err 0xfffffffffffffffe value 0x0
```

`eid 0x504d55` 是 SBI PMU extension，也就是 ASCII `"PMU"`。常见 function ID：

- `fid 0x2`: `COUNTER_CONFIG_MATCHING`
- `fid 0x3`: `COUNTER_START`
- `fid 0x4`: `COUNTER_STOP`
- `fid 0x5`: `COUNTER_FW_READ`

上面的 `fid 0x2` 参数含义为：

```text
a0: counter_idx_base
a1: counter_idx_mask
a2: config_flags
a3: event_idx
a4-a5: event_data
```

示例中的 `event_idx = 0x1001a`。返回值 `0xfffffffffffffffe` 是 `SBI_ERR_NOT_SUPPORTED`，表示当前 SBI 实现没有为该 event 提供匹配 counter，或者虚拟化层没有接管 PMU 请求。

## 根因

`riscv_vcpu` 的 SBI 处理整体偏 passthrough，但 PMU 不适合直通。物理 PMU 通常包含：

- `cycle`、`instret` 等 PMU 固定 counter
- `time` 等需要单独虚拟化的时间源 CSR
- `hpmcounter3..31` 等硬件性能 counter
- `mhpmevent3..31` 等事件选择寄存器
- counter inhibit、overflow pending、overflow interrupt 等状态

这些状态往往是 per-hart、per-core 或 platform-global。若直接交给 guest 配置，多个 VM 与 host 会共享同一组物理 PMU 状态，counter 所有权、事件过滤、overflow 中断归属都不清晰。

因此 PMU 请求应由 hypervisor 提供 per-vCPU virtual PMU，而不是转发到底层 RustSBI/宿主固件。

## 规范依据

- RISC-V SBI 规范定义 PMU extension ID 为 `0x504D55`，并定义 `COUNTER_CONFIG_MATCHING`、`COUNTER_START`、`COUNTER_STOP`、`COUNTER_FW_READ` 等 ABI。参考 [RISC-V SBI Specification v2.0, PMU extension](https://docs.riscv.org/reference/platform-software/sbi/v2.0/_attachments/riscv-sbi.pdf)。
- RISC-V ISA 将 `cycle`、`time`、`instret` 归入 Zicntr counters/timers。其中 `time` 是 real-time clock，不是标准 SBI PMU hardware event。参考 [RISC-V Unprivileged ISA, Zicntr/Zihpm counters](https://docs.riscv.org/reference/isa/unpriv/counters.html)。
- RISC-V privileged 规范通过 `mcounteren` 控制 S/U 模式对 `cycle`、`time`、`instret`、`hpmcounter` 的访问，但访问控制不等于 per-VM PMU 状态隔离。参考 [RISC-V Privileged ISA, Machine-Level ISA](https://docs.riscv.org/reference/isa/priv/machine.html)。
- overflow 和 privilege-mode filtering 涉及 `mhpmevent`、`hpmcounter` 以及本地中断，不能多个 VM 共享同一份物理状态。参考 [Sscofpmf extension](https://docs.riscv.org/reference/isa/priv/sscofpmf.html)。
- RustSBI 的 `Pmu` trait 正好对应 SBI PMU ABI：`num_counters()`、`counter_get_info()`、`counter_config_matching()`、`counter_start()`、`counter_stop()`、`counter_fw_read()` 等。参考 [RustSBI Pmu trait source](https://docs.rs/rustsbi/latest/src/rustsbi/pmu.rs.html) 和 [sbi-spec pmu module](https://docs.rs/sbi-spec/latest/sbi_spec/pmu/index.html)。

- SBI 3.0 对 PMU 是增量扩展，没有改变上述基础 function ID。当前 `VirtualPmu` 实现的是 SBI PMU v2.0 基础子集；若 guest 使用 SBI 3.0 新增 PMU function，应返回 unsupported，后续再按需补齐。

- EMU 官方文档写得很明确：RISC-V virt / sifive_u 机器如果没有指定 -bios，默认等价于 -bios default，会自动加载 QEMU release 自带的默认 OpenSBI firmware。见 QEMU RISC-V firmware 文档：
https://www.qemu.org/docs/master/system/target-riscv.html#risc-v-cpu-firmware

- QEMU virt 机器文档也说明，virt 可以用默认 OpenSBI firmware 作为 -bios 来启动 Linux / S-mode U-Boot，并且 virt 是一个不对应真实硬件的通用虚拟平台：
https://www.qemu.org/docs/master/system/riscv/virt.html

- OpenSBI 官方文档里也有对应平台说明：QEMU RISC-V Virt Machine 是用于 RISC-V 软件开发和测试的虚拟平台，OpenSBI 使用 PLATFORM=generic 构建，并给出了 qemu-system-riscv64 -M virt ... -bios build/platform/generic/firmware/... 的启动方式：
https://github.com/riscv-software-src/opensbi/blob/master/docs/platform/qemu_virt.md

## 当前实现

`RISCVVCpuSbi` 持有 per-vCPU `VirtualPmu`，并通过 `#[rustsbi(pmu)]` 注册为 RustSBI PMU extension。`vcpu.rs` 对 `pmu::EID_PMU` 单独分发，避免进入默认 forward warning 路径。

`VirtualPmu` 当前分成两层：

- guest-visible vPMU：维护 SBI PMU ABI、counter 生命周期、虚拟值、event 映射和 firmware counter。
- backend：提供底层 PMU/counter 来源，不向 guest 直通硬件状态。

当前默认 backend 是 `QemuPmuBackend`。它读取本地 `cycle` 和 `instret` CSR 作为 fixed counter 的 delta 来源，不暴露任何 HPM counter；guest 可见状态仍完全由 `VirtualPmu` 维护。真实开发板只需实现 `PmuBackend` trait 并替换默认 backend，即可接入板卡特定的 PMU 资源，无需修改 SBI ABI 层。

职责边界如下：

```text
Guest Linux perf / SBI PMU
        |
        v
VirtualPmu
  - SBI PMU ABI
  - guest-visible counter bank (Vec, 动态大小)
  - configure/start/stop/read lifecycle
  - fixed counter virtual offset/value
  - firmware counter accounting
  - HPM 虚拟槽管理（slot 分配/释放）
        |
        v
PmuBackend trait
  - read_cycle / read_instret  （fixed counter 来源）
  - num_hpm_counters           （bank 大小由此决定）
  - can_handle_event           （SKIP_MATCH 预检，无分配开销）
  - allocate_hpm / release_hpm （HPM slot 生命周期）
  - read_hpm                   （HPM 当前值）
  - on_bind / on_unbind        （vCPU 调度钩子）
        |
        v
QemuPmuBackend（默认） / BoardPmuBackend（板卡实现）
  - QEMU: 仅读本地 CSR，num_hpm_counters=0，其余为 no-op
  - 板卡: 硬件 counter 分配、保存恢复、multiplexing
```

`PmuBackend` 的完整接口：

```rust
trait PmuBackend {
    fn read_cycle(&self) -> u64;
    fn read_instret(&self) -> u64;
    fn num_hpm_counters(&self) -> usize;
    fn can_handle_event(&self, event_idx: usize) -> bool;
    fn allocate_hpm(&self, event_idx: usize, event_data: u64) -> Option<usize>;
    fn release_hpm(&self, hw_slot: usize);
    fn read_hpm(&self, hw_slot: usize) -> u64;
    fn on_bind(&self);
    fn on_unbind(&self);
}
```

counter bank 总长度在 `VirtualPmu::new()` 时由 `FIXED_COUNTERS(2) + FIRMWARE_COUNTERS(11) + backend.num_hpm_counters()` 决定，存储在 `Vec<VirtualPmuCounter>` 中，生命周期内不变。HPM 虚拟槽占用索引 13 及以上，每个槽持有一个来自 backend 的 `hw_slot` 标识符（`HW_SLOT_NONE` 表示未分配）。后续接真实开发板时，在 backend 背后引入 per-board/per-pCPU PMU manager，再由 manager 实现 `allocate_hpm` 等方法，不需要让 guest 直接操作硬件 PMU CSR。

`VirtualPmu` 当前支持：

- `NUM_COUNTERS`
- `COUNTER_GET_INFO`（fixed / firmware / HPM 均正确上报 CSR 或 firmware 类型）
- `COUNTER_CONFIG_MATCHING`（支持 `SKIP_MATCH`、`CLEAR_VALUE`、`AUTO_START`；HPM event 通过 backend 分配）
- `COUNTER_START`（支持 `START_SET_INIT_VALUE`）
- `COUNTER_STOP`（支持 `STOP_RESET`，reset 时释放 HPM slot）
- `COUNTER_FW_READ` / `COUNTER_FW_READ_HI`
- `cycle`、`instret` fixed PMU counter 的虚拟 offset/value 模型
- HPM 虚拟槽（索引 13+），数量由 backend 决定，QEMU 默认为 0
- `SET_TIMER`、`ILLEGAL_INSN`、`ACCESS_LOAD`、`ACCESS_STORE` 等 firmware counter
- RFENCE/HFENCE sent 类 firmware counter
- vCPU bind/unbind 时通过 `backend_bind()`/`backend_unbind()` 通知 backend 保存恢复硬件状态

Fixed PMU counter 采用 offset/baseline 模型：

1. guest 配置并启动 fixed PMU counter 时，记录当前 backend counter 值为 `hardware_base`。
2. counter 运行中，guest-visible value 为 `value + (hardware_now - hardware_base)`。
3. counter 停止且未带 `STOP_RESET` 时，将当前 delta 折叠回虚拟 `value`。
4. `CLEAR_VALUE` 和 `START_SET_INIT_VALUE` 只修改虚拟值，不清底层 counter。

`time` CSR 没有对应的标准 SBI PMU hardware event，因此不作为 PMU counter 暴露。它应通过 CSR/time source 虚拟化处理；若放入 PMU counter bank，会形成“可枚举但不可配置”的死槽。

## 后续 backend 演进

真实开发板通常会有各自的 PMU event 编码、counter 数量、overflow 行为和中断路由。`PmuBackend` trait 已提供完整的接入点，后续工作主要在 trait 的具体实现侧：

- `BoardPmuBackend`：实现 `PmuBackend` trait，封装具体芯片的 PMU 访问方式，不直接暴露给 guest。
- `PmuManager`：在 backend 背后管理 per-pCPU 或 per-board 的硬件 PMU 资源，负责多 vCPU 间的 counter 分配、delta 累计和 multiplexing；`on_bind`/`on_unbind` 调度钩子的实际 CSR 保存恢复逻辑在此实现。
- `EventKind`：把 SBI event 分类为 fixed、firmware、hardware、raw、platform、unsupported，避免把所有 event 直接硬编码到 counter index。
- CSR trap/emulation：把 guest 直接读 `cycle/instret/time/hpmcounter*` 的路径接到虚拟值或虚拟时间源。

推荐的长期路径：

```text
VirtualPmu per vCPU
        |
        v
PmuBackend trait
        |
        v
Board/QEMU PMU manager
        |
        v
physical or emulated PMU resources
```

这个结构允许多个客户机共享同一块真实 PMU 硬件，同时保持 guest-visible PMU 状态隔离。

## 错误码策略

`VirtualPmu::counter_stop()` 对“从未配置过”的 counter 返回 `SBI_ERR_INVALID_PARAM`，而不是 `SBI_ERR_ALREADY_STOPPED`。

SBI PMU 规范中 `sbi_pmu_counter_stop()` 的 `SBI_ERR_INVALID_PARAM` 主要描述 counter index 越界；未配置 counter 在状态机上也可以被理解为 stopped，因此返回 `ALREADY_STOPPED` 也可兼容。当前实现选择更严格的 `INVALID_PARAM`，用于尽早暴露 stop-before-configure 这类生命周期误用。

兼容性风险：若某个 guest PMU driver 预期未配置 counter 的 stop 返回 `ALREADY_STOPPED`，可能把当前返回值视为错误。

## 未完成项

CSR/计数器虚拟化：

- guest 直接读 `cycle`、`time`、`instret` CSR 时的 trap/emulation
- `hpmcounter3..31` 和 `mhpmevent3..31` 的完整虚拟状态
- `time` 的独立虚拟时间源

硬件 PMU backend：

- cache/raw/platform hardware events（`allocate_hpm` 接口已就绪，具体 `BoardPmuBackend` 实现待补）
- host PMU counter 调度、复用和隔离（需 `PmuManager`）
- vCPU schedule in/out 时的实际 CSR 保存恢复（`on_bind`/`on_unbind` 钩子已接入 `vcpu.rs`，`BoardPmuBackend` 中的具体实现待补）
- overflow pending 状态和 overflow interrupt 注入

SBI/firmware 能力：

- SBI 3.0 新增 PMU function
- SBI PMU snapshot shared memory
- `VUINH`、`VSINH`、`UINH`、`SINH`、`MINH` 等 privilege-mode filter
- received RFENCE/HFENCE、IPI、platform-specific firmware counters

CSR 访问虚拟化是优先级最高的后续工作。当前 `VirtualPmu` 已经提供 `cycle/instret` 的虚拟 fixed PMU counter value/offset 模型，但 guest 直接读 CSR 时仍可能看到硬件视图；`time` 则需要接入单独的虚拟时间源。

## 参考文档

- [RISC-V Supervisor Binary Interface Specification v2.0](https://docs.riscv.org/reference/platform-software/sbi/v2.0/_attachments/riscv-sbi.pdf)
- [RISC-V Unprivileged ISA: Zicntr and Zihpm Counters](https://docs.riscv.org/reference/isa/unpriv/counters.html)
- [RISC-V Privileged ISA: Machine-Level ISA](https://docs.riscv.org/reference/isa/priv/machine.html)
- [RISC-V Privileged ISA: Sscofpmf Count Overflow and Mode-Based Filtering](https://docs.riscv.org/reference/isa/priv/sscofpmf.html)
- [sbi-spec crate PMU module](https://docs.rs/sbi-spec/latest/sbi_spec/pmu/index.html)
- [RustSBI PMU trait implementation interface](https://docs.rs/rustsbi/latest/src/rustsbi/pmu.rs.html)
