### PR TITLE
fix(rsext4): bound data block cache growth

### DIFF
--- a/components/rsext4/src/cache/data_block.rs
+++ b/components/rsext4/src/cache/data_block.rs
@@ -142,10 +142,17 @@ impl DataBlockCache {
     }
 
     /// Creates a brand-new cached block and marks it dirty.
-    pub fn create_new(&mut self, block_num: AbsoluteBN) -> &mut CachedBlock {
+    pub fn create_new<B: BlockDevice>(
+        &mut self,
+        block_dev: &mut Jbd2Dev<B>,
+        block_num: AbsoluteBN,
+    ) -> Ext4Result<&mut CachedBlock> {
+        if self.cache.contains_key(&block_num) {
+            self.evict(block_dev, block_num)?;
+        }
+
         if self.cache.len() >= self.max_entries {
-            // Eviction for newly created entries is left to the caller because
-            // no block-device handle is available here.
+            self.evict_lru(block_dev)?;
         }
 
         let data = alloc::vec![0u8; self.block_size];
@@ -156,7 +163,7 @@ impl DataBlockCache {
         cached.last_access = self.access_counter;
 
         self.cache.insert(block_num, cached);
-        self.cache.get_mut(&block_num).unwrap()
+        self.cache.get_mut(&block_num).ok_or(Ext4Error::corrupted())
     }
 
     /// Marks a cached data block dirty.
@@ -199,7 +206,7 @@ impl DataBlockCache {
         B: BlockDevice,
         F: FnOnce(&mut [u8]),
     {
-        let cached = self.create_new(block_num);
+        let cached = self.create_new(block_dev, block_num)?;
         f(&mut cached.data);
         cached.mark_dirty();
 
@@ -363,6 +370,55 @@ pub struct DataBlockCacheStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::disknode::Ext4Timestamp;
+
+    struct TestBlockDevice {
+        data: Vec<u8>,
+    }
+
+    impl TestBlockDevice {
+        fn new(blocks: usize) -> Self {
+            Self {
+                data: alloc::vec![0; blocks * BLOCK_SIZE],
+            }
+        }
+    }
+
+    impl BlockDevice for TestBlockDevice {
+        fn read(&mut self, buffer: &mut [u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+            let start = block_id.as_usize()? * BLOCK_SIZE;
+            let end = start + buffer.len();
+            buffer.copy_from_slice(&self.data[start..end]);
+            Ok(())
+        }
+
+        fn write(&mut self, buffer: &[u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+            let start = block_id.as_usize()? * BLOCK_SIZE;
+            let end = start + buffer.len();
+            self.data[start..end].copy_from_slice(buffer);
+            Ok(())
+        }
+
+        fn open(&mut self) -> Ext4Result<()> {
+            Ok(())
+        }
+
+        fn close(&mut self) -> Ext4Result<()> {
+            Ok(())
+        }
+
+        fn total_blocks(&self) -> u64 {
+            (self.data.len() / BLOCK_SIZE) as u64
+        }
+
+        fn block_size(&self) -> u32 {
+            BLOCK_SIZE as u32
+        }
+
+        fn current_time(&self) -> Ext4Result<Ext4Timestamp> {
+            Ok(Ext4Timestamp::new(0, 0))
+        }
+    }
 
     #[test]
     fn test_datablock_cache_basic() {
@@ -378,7 +434,12 @@ mod tests {
     fn test_create_new_block() {
         let mut cache = DataBlockCache::new(8, BLOCK_SIZE);
 
-        let block = cache.create_new(AbsoluteBN::new(100));
+        let device = TestBlockDevice::new(1024);
+        let mut jbd2_dev = Jbd2Dev::initial_jbd2dev(0, device, false);
+
+        let block = cache
+            .create_new(&mut jbd2_dev, AbsoluteBN::new(100))
+            .expect("create new block");
         assert_eq!(block.block_num, AbsoluteBN::new(100));
         assert_eq!(block.data.len(), BLOCK_SIZE);
         assert!(block.dirty); // New cache entries should start dirty.
@@ -392,10 +453,32 @@ mod tests {
     fn test_invalidate() {
         let mut cache = DataBlockCache::new(8, BLOCK_SIZE);
 
-        cache.create_new(AbsoluteBN::new(100));
+        let device = TestBlockDevice::new(1024);
+        let mut jbd2_dev = Jbd2Dev::initial_jbd2dev(0, device, false);
+
+        cache
+            .create_new(&mut jbd2_dev, AbsoluteBN::new(100))
+            .expect("create new block");
         assert_eq!(cache.cache.len(), 1);
 
         cache.invalidate(AbsoluteBN::new(100));
         assert_eq!(cache.cache.len(), 0);
+    }
+
+    #[test]
+    fn create_new_respects_lru_limit() {
+        let mut cache = DataBlockCache::new(2, BLOCK_SIZE);
+        let device = TestBlockDevice::new(1024);
+        let mut jbd2_dev = Jbd2Dev::initial_jbd2dev(0, device, false);
+
+        for block in 10..14 {
+            cache
+                .create_new(&mut jbd2_dev, AbsoluteBN::new(block))
+                .expect("create new block");
+        }
+
+        let stats = cache.stats();
+        assert_eq!(stats.total_entries, 2);
+        assert_eq!(stats.max_entries, 2);
     }
 }

--- a/components/rsext4/src/dir/bootstrap.rs
+++ b/components/rsext4/src/dir/bootstrap.rs
@@ -85,7 +85,13 @@ pub fn create_root_directory_entry<B: BlockDevice>(
     inode.i_size_high = 0;
     inode.i_blocks_lo = (BLOCK_SIZE / 512) as u32;
     inode.l_i_blocks_high = 0;
-    build_file_block_mapping(fs, &mut inode, &[data_block], block_dev);
+    build_file_block_mapping_with_inode_num(
+        fs,
+        &mut inode,
+        fs.root_inode,
+        &[data_block],
+        block_dev,
+    );
     fs.finalize_inode_update(
         block_dev,
         fs.root_inode,
@@ -192,7 +198,13 @@ pub fn create_lost_found_directory<B: BlockDevice>(
     lost_inode.l_i_blocks_high = 0;
     lost_inode.i_flags =
         Ext4Inode::mask_flags_for_mode(dir_mode, root_inode.i_flags & Ext4Inode::EXT4_FL_INHERITED);
-    build_file_block_mapping(fs, &mut lost_inode, &[data_block], block_dev);
+    build_file_block_mapping_with_inode_num(
+        fs,
+        &mut lost_inode,
+        lost_ino,
+        &[data_block],
+        block_dev,
+    );
     debug!(
         "When create lost+found inode iblock,:{:?} ,data_block:{:?}",
         lost_inode.i_block, data_block

--- a/components/rsext4/src/dir/bootstrap.rs
+++ b/components/rsext4/src/dir/bootstrap.rs
@@ -27,7 +27,7 @@ pub fn create_root_directory_entry<B: BlockDevice>(
 
     {
         // Format the initial root directory block before the inode is finalized.
-        let cached = fs.datablock_cache.create_new(data_block);
+        let cached = fs.datablock_cache.create_new(block_dev, data_block)?;
         let data = &mut cached.data;
 
         let dot_name = b".";
@@ -138,7 +138,7 @@ pub fn create_lost_found_directory<B: BlockDevice>(
 
     {
         // Format the first block of the new directory, including the checksum tail.
-        let cached = fs.datablock_cache.create_new(data_block);
+        let cached = fs.datablock_cache.create_new(block_dev, data_block)?;
         let data = &mut cached.data;
 
         let dot_name = b".";

--- a/components/rsext4/src/dir/insert.rs
+++ b/components/rsext4/src/dir/insert.rs
@@ -164,7 +164,7 @@ pub fn insert_dir_entry<B: BlockDevice>(
 
     if fs.superblock.has_extents() && parent_inode.have_extend_header_and_use_extend() {
         let new_ext = Ext4Extent::new(new_lbn, new_block.raw(), 1);
-        let mut tree = ExtentTree::new(parent_inode);
+        let mut tree = ExtentTree::with_checksum(parent_inode, &fs.superblock, parent_ino_num);
         tree.insert_extent(fs, new_ext, device)?;
     } else {
         if old_blocks >= 12 {

--- a/components/rsext4/src/dir/mkdir.rs
+++ b/components/rsext4/src/dir/mkdir.rs
@@ -100,7 +100,7 @@ fn mkdir_internal<B: BlockDevice>(
 
     {
         // Initialize `.` and `..`, leaving room for the checksum tail when enabled.
-        let cached = fs.datablock_cache.create_new(data_block);
+        let cached = fs.datablock_cache.create_new(device, data_block)?;
         let data = &mut cached.data;
 
         let dot_name = b".";

--- a/components/rsext4/src/dir/mkdir.rs
+++ b/components/rsext4/src/dir/mkdir.rs
@@ -159,7 +159,7 @@ fn mkdir_internal<B: BlockDevice>(
         dir_mode,
         parent_inode.i_flags & Ext4Inode::EXT4_FL_INHERITED,
     );
-    build_file_block_mapping(fs, &mut new_inode, &[data_block], device);
+    build_file_block_mapping_with_inode_num(fs, &mut new_inode, new_dir_ino, &[data_block], device);
     let mut create_update = Ext4InodeMetadataUpdate::create(dir_mode);
     if fs
         .superblock

--- a/components/rsext4/src/disknode/extent.rs
+++ b/components/rsext4/src/disknode/extent.rs
@@ -62,7 +62,8 @@ impl Default for Ext4Extent {
 
 impl Ext4Extent {
     pub const EXT_INIT_MAX_LEN: u16 = 32768;
-    pub const EXT_UNINIT_MAX_LEN: u16 = 32768;
+    pub const EXT_UNINIT_MAX_LEN: u16 = 32767;
+    pub const EXT_UNWRITTEN_FLAG: u16 = 0x8000;
 
     pub fn new(logic_start: u32, start_phy_block: u64, len: u16) -> Self {
         let high = (start_phy_block >> 32) as u16;
@@ -79,7 +80,54 @@ impl Ext4Extent {
         (self.ee_start_hi as u64) << 32 | self.ee_start_lo as u64
     }
 
+    /// Returns the logical length encoded by ext4's initialized/unwritten extent format.
+    pub fn len(&self) -> u32 {
+        Self::decode_len(self.ee_len)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn is_unwritten(&self) -> bool {
+        self.ee_len > Self::EXT_UNWRITTEN_FLAG
+    }
+
     pub fn is_initialized(&self) -> bool {
-        self.ee_len <= Self::EXT_INIT_MAX_LEN
+        !self.is_unwritten()
+    }
+
+    pub fn encode_len(len: u32, unwritten: bool) -> Option<u16> {
+        if len == 0 {
+            return None;
+        }
+
+        if unwritten {
+            if len > Self::EXT_UNINIT_MAX_LEN as u32 {
+                return None;
+            }
+            Some((len as u16) | Self::EXT_UNWRITTEN_FLAG)
+        } else {
+            if len > Self::EXT_INIT_MAX_LEN as u32 {
+                return None;
+            }
+            Some(if len == Self::EXT_INIT_MAX_LEN as u32 {
+                Self::EXT_INIT_MAX_LEN
+            } else {
+                len as u16
+            })
+        }
+    }
+
+    pub fn decode_len(raw_len: u16) -> u32 {
+        if raw_len == Self::EXT_INIT_MAX_LEN {
+            Self::EXT_INIT_MAX_LEN as u32
+        } else {
+            (raw_len & !Self::EXT_UNWRITTEN_FLAG) as u32
+        }
+    }
+
+    pub fn build_len_like(&self, len: u32) -> Option<u16> {
+        Self::encode_len(len, self.is_unwritten())
     }
 }

--- a/components/rsext4/src/ext4/mkfs.rs
+++ b/components/rsext4/src/ext4/mkfs.rs
@@ -2,6 +2,8 @@ use super::*;
 
 /// Derived filesystem geometry used only during mkfs planning.
 pub struct FsLayoutInfo {
+    /// Total filesystem blocks.
+    total_blocks: u64,
     /// Logical block size in bytes.
     block_size: u32,
     /// Blocks per group.
@@ -112,6 +114,7 @@ pub fn compute_fs_layout(inode_size: u16, total_blocks: u64) -> FsLayoutInfo {
     let reserved_blocks: u64 = total_blocks / 20;
 
     FsLayoutInfo {
+        total_blocks,
         block_size,
         blocks_per_group,
         inodes_per_group,
@@ -129,6 +132,35 @@ pub fn compute_fs_layout(inode_size: u16, total_blocks: u64) -> FsLayoutInfo {
         group0_metadata_blocks,
         reserved_blocks,
     }
+}
+
+fn group_blocks_count(layout: &FsLayoutInfo, group_id: u32) -> u32 {
+    let group_start = u64::from(group_id) * u64::from(layout.blocks_per_group);
+    if group_start >= layout.total_blocks {
+        return 0;
+    }
+
+    let remaining = layout.total_blocks - group_start;
+    remaining.min(u64::from(layout.blocks_per_group)) as u32
+}
+
+fn group_free_blocks(layout: &FsLayoutInfo, group_id: u32, metadata_blocks: u32) -> u32 {
+    group_blocks_count(layout, group_id).saturating_sub(metadata_blocks)
+}
+
+fn mark_bitmap_range_allocated(bitmap: &mut [u8], start: u32, end: u32) {
+    let bits = (bitmap.len() * 8) as u32;
+    let end = end.min(bits);
+    for bit in start.min(bits)..end {
+        let byte_idx = (bit / 8) as usize;
+        let bit_idx = bit % 8;
+        bitmap[byte_idx] |= 1 << bit_idx;
+    }
+}
+
+fn mark_block_bitmap_padding(bitmap: &mut [u8], layout: &FsLayoutInfo, group_id: u32) {
+    let valid_blocks = group_blocks_count(layout, group_id);
+    mark_bitmap_range_allocated(bitmap, valid_blocks, layout.blocks_per_group);
 }
 
 pub fn mkfs<B: BlockDevice>(block_dev: &mut Jbd2Dev<B>) -> Ext4Result<()> {
@@ -317,9 +349,10 @@ fn build_uninit_group_desc(
     desc.bg_inode_bitmap_lo = gl.group_inode_bitmap_startblocks as u32;
     desc.bg_inode_table_lo = gl.group_inode_table_startblocks as u32;
 
-    // Free-block count is the group's total capacity minus its metadata area.
-    let used_meta = gl.metadata_blocks_in_group;
-    let free_blocks = layout.blocks_per_group.saturating_sub(used_meta);
+    // Free-block count is based on the group's real capacity. The last block
+    // group is often partial, so blocks past s_blocks_count must never be
+    // reported as free.
+    let free_blocks = group_free_blocks(layout, group_id, gl.metadata_blocks_in_group);
 
     if group_id == 0 {
         // Group 0 consumes the reserved inode range immediately.
@@ -544,13 +577,10 @@ fn initialize_group_0<B: BlockDevice>(
     {
         let buffer = block_dev.buffer_mut();
         buffer.fill(0);
-        // Mark all group-0 metadata blocks allocated in the block bitmap.
-        let used_metadata_blocks = layout.group0_metadata_blocks as usize;
-        for i in 0..used_metadata_blocks {
-            let byte_idx = i / 8;
-            let bit_idx = i % 8;
-            buffer[byte_idx] |= 1 << bit_idx;
-        }
+        // Mark all group-0 metadata blocks and out-of-filesystem padding bits
+        // allocated in the block bitmap.
+        mark_bitmap_range_allocated(buffer, 0, layout.group0_metadata_blocks);
+        mark_block_bitmap_padding(buffer, layout, 0);
     }
     block_dev.write_block(block_bitmap_blk.into(), true)?;
 
@@ -586,9 +616,7 @@ fn initialize_group_0<B: BlockDevice>(
     // Persist the now-initialized descriptor for group 0.
     let mut desc = Ext4GroupDesc {
         bg_flags: Ext4GroupDesc::EXT4_BG_INODE_ZEROED,
-        bg_free_blocks_count_lo: layout
-            .blocks_per_group
-            .saturating_sub(layout.group0_metadata_blocks) as u16,
+        bg_free_blocks_count_lo: group_free_blocks(layout, 0, layout.group0_metadata_blocks) as u16,
         bg_free_inodes_count_lo: layout.inodes_per_group.saturating_sub(RESERVED_INODES) as u16,
         bg_itable_unused_lo: layout.inodes_per_group.saturating_sub(RESERVED_INODES) as u16,
         bg_block_bitmap_lo: block_bitmap_blk,
@@ -631,12 +659,8 @@ fn initialize_other_groups_bitmaps<B: BlockDevice>(
         {
             let buffer = block_dev.buffer_mut();
             buffer.fill(0);
-            let used_blocks = gl.metadata_blocks_in_group as usize;
-            for i in 0..used_blocks {
-                let byte_idx = i / 8;
-                let bit_idx = i % 8;
-                buffer[byte_idx] |= 1 << bit_idx;
-            }
+            mark_bitmap_range_allocated(buffer, 0, gl.metadata_blocks_in_group);
+            mark_block_bitmap_padding(buffer, layout, group_id);
         }
         block_dev.write_block(block_bitmap_blk.into(), true)?;
 

--- a/components/rsext4/src/ext4/mount.rs
+++ b/components/rsext4/src/ext4/mount.rs
@@ -9,7 +9,7 @@ impl Ext4FileSystem {
     }
 
     fn dirty_for_mount(superblock: &mut Ext4Superblock) {
-        superblock.s_state = Ext4Superblock::EXT4_ERROR_FS;
+        superblock.s_state &= !Ext4Superblock::EXT4_VALID_FS;
         superblock.s_mnt_count = superblock.s_mnt_count.saturating_add(1);
     }
 
@@ -88,7 +88,7 @@ impl Ext4FileSystem {
 
         // Continue mounting even for an error-state filesystem so higher layers
         // can inspect or attempt repair.
-        if superblock.s_state == Ext4Superblock::EXT4_ERROR_FS {
+        if superblock.s_state & Ext4Superblock::EXT4_ERROR_FS != 0 {
             warn!("Filesystem is in error state");
         }
 
@@ -344,9 +344,8 @@ impl Ext4FileSystem {
             .flush_all(block_dev)
             .expect("flush failed!");
 
-        // Write the superblock with s_state = EXT4_ERROR_FS to disk so that if
-        // the system crashes before a clean umount, Linux will detect the dirty
-        // state and perform journal recovery / fsck.
+        // Write the superblock with EXT4_VALID_FS cleared so that a later mount
+        // can distinguish an unclean shutdown from a real EXT4_ERROR_FS state.
         fs.sync_superblock(block_dev)?;
 
         Ok(fs)

--- a/components/rsext4/src/ext4/sync.rs
+++ b/components/rsext4/src/ext4/sync.rs
@@ -1,6 +1,10 @@
 use super::{mkfs::write_superblock, *};
 
 impl Ext4FileSystem {
+    fn clean_state(superblock: &Ext4Superblock) -> u16 {
+        (superblock.s_state & Ext4Superblock::EXT4_ERROR_FS) | Ext4Superblock::EXT4_VALID_FS
+    }
+
     /// Flushes all filesystem metadata and caches to the backing device.
     pub fn sync_filesystem<B: BlockDevice>(
         &mut self,
@@ -26,7 +30,7 @@ impl Ext4FileSystem {
 
         // Mark clean in memory first so that sync_filesystem writes the
         // superblock with s_state = EXT4_VALID_FS through the journal.
-        self.superblock.s_state = Ext4Superblock::EXT4_VALID_FS;
+        self.superblock.s_state = Self::clean_state(&self.superblock);
 
         self.sync_filesystem(block_dev)?;
 
@@ -128,7 +132,7 @@ impl Ext4FileSystem {
     /// Call this during a clean unmount so that Linux sees `s_state =
     /// EXT4_VALID_FS` and skips fsck on the next boot.
     pub fn mark_clean<B: BlockDevice>(&mut self, block_dev: &mut Jbd2Dev<B>) -> Ext4Result<()> {
-        self.superblock.s_state = Ext4Superblock::EXT4_VALID_FS;
+        self.superblock.s_state = Self::clean_state(&self.superblock);
         self.sync_superblock(block_dev)
     }
 }

--- a/components/rsext4/src/extents_tree/insert.rs
+++ b/components/rsext4/src/extents_tree/insert.rs
@@ -11,7 +11,7 @@ impl<'a> ExtentTree<'a> {
         debug!(
             "ExtentTree::insert_extent: new_ext lbn={} len={} phys_start={}",
             new_ext.ee_block,
-            new_ext.ee_len & 0x7FFF,
+            new_ext.len(),
             new_ext.start_block()
         );
 
@@ -31,7 +31,7 @@ impl<'a> ExtentTree<'a> {
                     entries
                         .iter()
                         .take(4)
-                        .map(|e| (e.ee_block, e.ee_len & 0x7FFF, e.start_block()))
+                        .map(|e| (e.ee_block, e.len(), e.start_block()))
                         .collect::<Vec<_>>()
                 );
             }
@@ -77,10 +77,8 @@ impl<'a> ExtentTree<'a> {
                     new_left_block, split_info.start_block, split_info.phy_block
                 );
 
-                let block_eh_max = Self::calc_block_eh_max();
-
                 // Persist the old root contents into the new left child block.
-                Self::write_node_to_block(block_dev, new_left_block, &root, block_eh_max)?;
+                self.write_node_to_block(block_dev, new_left_block, &root)?;
 
                 // Rebuild the inline root as a two-entry index node.
                 let inline_bytes = self.inode.i_block.len() * 4;
@@ -140,7 +138,7 @@ impl<'a> ExtentTree<'a> {
                     header.eh_entries,
                     header.eh_max,
                     new_ext.ee_block,
-                    new_ext.ee_len & 0x7FFF,
+                    new_ext.len(),
                     new_ext.start_block(),
                     phy_block
                 );
@@ -148,17 +146,18 @@ impl<'a> ExtentTree<'a> {
                     .binary_search_by_key(&new_ext.ee_block, |e| e.ee_block)
                     .unwrap_or_else(|i| i);
 
-                const MAX_LEN: u32 = 32768;
-
                 if pos > 0 {
                     let prev = &mut entries[pos - 1];
 
                     let prev_logical = prev.ee_block;
-                    let prev_len = prev.ee_len as u32 & 0x7FFF;
+                    let prev_len = prev.len();
                     let new_logical = new_ext.ee_block;
-                    let new_len = new_ext.ee_len as u32 & 0x7FFF;
+                    let new_len = new_ext.len();
 
-                    if prev_len != 0 && new_len != 0 {
+                    if prev_len != 0
+                        && new_len != 0
+                        && prev.is_unwritten() == new_ext.is_unwritten()
+                    {
                         let prev_end = prev_logical.saturating_add(prev_len);
 
                         if new_logical == prev_end {
@@ -169,10 +168,15 @@ impl<'a> ExtentTree<'a> {
 
                             if new_phys_start == prev_phys_start + prev_len as u64 {
                                 let total = prev_len + new_len;
-                                let hi_flag = prev.ee_len & 0x8000;
+                                let max_len = if prev.is_unwritten() {
+                                    Ext4Extent::EXT_UNINIT_MAX_LEN as u32
+                                } else {
+                                    Ext4Extent::EXT_INIT_MAX_LEN as u32
+                                };
 
-                                if total <= MAX_LEN {
-                                    prev.ee_len = (total as u16 & 0x7FFF) | hi_flag;
+                                if total <= max_len {
+                                    prev.ee_len =
+                                        prev.build_len_like(total).ok_or(Ext4Error::corrupted())?;
                                     debug!(
                                         "insert_recursive: merged with previous extent -> \
                                          new_len={total} (no split yet)"
@@ -186,27 +190,27 @@ impl<'a> ExtentTree<'a> {
                                                 header: *header,
                                                 entries: entries.clone(),
                                             };
-                                            Self::write_node_to_block(
-                                                block_dev,
-                                                block_id,
-                                                &disk_node,
-                                                header.eh_max,
+                                            self.write_node_to_block(
+                                                block_dev, block_id, &disk_node,
                                             )?;
                                         }
                                         return Ok(None);
                                     }
                                 } else {
-                                    prev.ee_len = (MAX_LEN as u16 & 0x7FFF) | hi_flag;
+                                    prev.ee_len = prev
+                                        .build_len_like(max_len)
+                                        .ok_or(Ext4Error::corrupted())?;
 
-                                    let remain = total - MAX_LEN;
+                                    let remain = total - max_len;
                                     if remain > 0 {
-                                        let tail_logical = prev_logical + MAX_LEN;
-                                        let tail_phys = prev_phys_start + MAX_LEN as u64;
+                                        let tail_logical = prev_logical + max_len;
+                                        let tail_phys = prev_phys_start + max_len as u64;
 
                                         let tail = Ext4Extent {
                                             ee_block: tail_logical,
-                                            ee_len: (remain as u16 & 0x7FFF)
-                                                | (new_ext.ee_len & 0x8000),
+                                            ee_len: new_ext
+                                                .build_len_like(remain)
+                                                .ok_or(Ext4Error::corrupted())?,
                                             ee_start_hi: (tail_phys >> 32) as u16,
                                             ee_start_lo: (tail_phys & 0xFFFF_FFFF) as u32,
                                         };
@@ -219,7 +223,7 @@ impl<'a> ExtentTree<'a> {
                                              inserted tail extent (lbn={}, len={}, phys_start={}) \
                                              now entries_len={}",
                                             tail.ee_block,
-                                            tail.ee_len & 0x7FFF,
+                                            tail.len(),
                                             tail.start_block(),
                                             header.eh_entries
                                         );
@@ -230,11 +234,8 @@ impl<'a> ExtentTree<'a> {
                                                     header: *header,
                                                     entries: entries.clone(),
                                                 };
-                                                Self::write_node_to_block(
-                                                    block_dev,
-                                                    block_id,
-                                                    &disk_node,
-                                                    header.eh_max,
+                                                self.write_node_to_block(
+                                                    block_dev, block_id, &disk_node,
                                                 )?;
                                             }
                                             return Ok(None);
@@ -256,7 +257,7 @@ impl<'a> ExtentTree<'a> {
                     entries
                         .iter()
                         .take(4)
-                        .map(|e| (e.ee_block, e.ee_len & 0x7FFF, e.start_block()))
+                        .map(|e| (e.ee_block, e.len(), e.start_block()))
                         .collect::<Vec<_>>()
                 );
 
@@ -267,7 +268,7 @@ impl<'a> ExtentTree<'a> {
                             header: *header,
                             entries: entries.clone(),
                         };
-                        Self::write_node_to_block(block_dev, block_id, &disk_node, header.eh_max)?;
+                        self.write_node_to_block(block_dev, block_id, &disk_node)?;
                     }
                     return Ok(None);
                 }
@@ -302,12 +303,7 @@ impl<'a> ExtentTree<'a> {
                 };
 
                 // Persist the new right node first.
-                Self::write_node_to_block(
-                    block_dev,
-                    new_phy_block,
-                    &right_node,
-                    right_header.eh_max,
-                )?;
+                self.write_node_to_block(block_dev, new_phy_block, &right_node)?;
                 // Then persist the updated left node when it already lives in a
                 // real metadata block.
                 if let Some(block_id) = phy_block {
@@ -315,7 +311,7 @@ impl<'a> ExtentTree<'a> {
                         header: *header,
                         entries: entries.clone(),
                     };
-                    Self::write_node_to_block(block_dev, block_id, &disk_node, header.eh_max)?;
+                    self.write_node_to_block(block_dev, block_id, &disk_node)?;
                 }
 
                 // Bubble the right node's first logical block and physical block
@@ -339,7 +335,7 @@ impl<'a> ExtentTree<'a> {
                     header.eh_entries,
                     header.eh_max,
                     new_ext.ee_block,
-                    new_ext.ee_len & 0x7FFF,
+                    new_ext.len(),
                     new_ext.start_block(),
                     phy_block
                 );
@@ -400,12 +396,7 @@ impl<'a> ExtentTree<'a> {
                                 header: *header,
                                 entries: entries.clone(),
                             };
-                            Self::write_node_to_block(
-                                block_dev,
-                                block_id,
-                                &disk_node,
-                                header.eh_max,
-                            )?;
+                            self.write_node_to_block(block_dev, block_id, &disk_node)?;
                         }
                         return Ok(None);
                     }
@@ -444,18 +435,13 @@ impl<'a> ExtentTree<'a> {
                         entries: right_entries,
                     };
 
-                    Self::write_node_to_block(
-                        block_dev,
-                        new_phy_block,
-                        &right_node,
-                        right_header.eh_max,
-                    )?;
+                    self.write_node_to_block(block_dev, new_phy_block, &right_node)?;
                     if let Some(block_id) = phy_block {
                         let disk_node = ExtentNode::Index {
                             header: *header,
                             entries: entries.clone(),
                         };
-                        Self::write_node_to_block(block_dev, block_id, &disk_node, header.eh_max)?;
+                        self.write_node_to_block(block_dev, block_id, &disk_node)?;
                     }
 
                     // Bubble the new right child up to the parent.

--- a/components/rsext4/src/extents_tree/parse.rs
+++ b/components/rsext4/src/extents_tree/parse.rs
@@ -108,7 +108,7 @@ impl<'a> ExtentTree<'a> {
             ExtentNode::Leaf { entries, .. } => {
                 for et in entries {
                     let start = et.ee_block;
-                    let len = et.ee_len as u32;
+                    let len = et.len();
                     let end = start.saturating_add(len); // half-open range [start, end)
                     if lblock >= start && lblock < end {
                         return Ok(Some(*et));

--- a/components/rsext4/src/extents_tree/remove.rs
+++ b/components/rsext4/src/extents_tree/remove.rs
@@ -14,7 +14,7 @@ impl<'a> ExtentTree<'a> {
         block_dev: &mut Jbd2Dev<B>,
     ) -> Ext4Result<()> {
         let del_start = deleted_ext.ee_block;
-        let del_len = (deleted_ext.ee_len as u32) & 0x7FFF;
+        let del_len = deleted_ext.len();
         if del_len == 0 {
             return Ok(());
         }
@@ -36,15 +36,11 @@ impl<'a> ExtentTree<'a> {
                 next_lbn: u32,
             }
 
-            fn extent_len15(e: &Ext4Extent) -> u32 {
-                (e.ee_len as u32) & 0x7FFF
-            }
-
             // A leaf either contributes a deletable segment or points the walker at the next hole boundary.
             fn pre_leaf_step(entries: &[Ext4Extent], cur_lbn: u32) -> PreRes {
                 let mut best: Option<&Ext4Extent> = None;
                 for e in entries {
-                    let len = extent_len15(e);
+                    let len = e.len();
                     if len == 0 {
                         continue;
                     }
@@ -68,8 +64,8 @@ impl<'a> ExtentTree<'a> {
                     };
                 };
 
-                let len15 = extent_len15(e);
-                if len15 == 0 {
+                let len = e.len();
+                if len == 0 {
                     return PreRes {
                         kind: PreKind::NoMore,
                         can_take: 0,
@@ -77,7 +73,7 @@ impl<'a> ExtentTree<'a> {
                     };
                 }
                 let e_start = e.ee_block;
-                let e_end = e_start.saturating_add(len15);
+                let e_end = e_start.saturating_add(len);
 
                 if cur_lbn < e_start {
                     return PreRes {
@@ -88,7 +84,7 @@ impl<'a> ExtentTree<'a> {
                 }
 
                 let within_off = cur_lbn.saturating_sub(e_start);
-                let can_take = len15.saturating_sub(within_off);
+                let can_take = len.saturating_sub(within_off);
                 if can_take == 0 {
                     return PreRes {
                         kind: PreKind::HoleSkip,
@@ -201,19 +197,12 @@ impl<'a> ExtentTree<'a> {
             (inline_bytes.saturating_sub(hdr_size) / entry_size) as u16
         }
 
-        fn extent_len15(e: &Ext4Extent) -> u32 {
-            (e.ee_len as u32) & 0x7FFF
-        }
-
         fn extent_start_phys(e: &Ext4Extent) -> u64 {
             ((e.ee_start_hi as u64) << 32) | (e.ee_start_lo as u64)
         }
 
-        fn build_extent_len(orig_ee_len: u16, new_len15: u32) -> Ext4Result<u16> {
-            if new_len15 > 0x7FFF {
-                return Err(Ext4Error::corrupted());
-            }
-            Ok((orig_ee_len & 0x8000) | (new_len15 as u16))
+        fn build_extent_len(orig: &Ext4Extent, new_len: u32) -> Ext4Result<u16> {
+            orig.build_len_like(new_len).ok_or(Ext4Error::corrupted())
         }
 
         #[derive(Clone, Copy)]
@@ -266,7 +255,7 @@ impl<'a> ExtentTree<'a> {
 
             let mut best: Option<usize> = None;
             for (i, e) in entries.iter().enumerate() {
-                let len = extent_len15(e);
+                let len = e.len();
                 if len == 0 {
                     continue;
                 }
@@ -293,8 +282,8 @@ impl<'a> ExtentTree<'a> {
             };
 
             let e = entries[i];
-            let len15 = extent_len15(&e);
-            if len15 == 0 {
+            let len = e.len();
+            if len == 0 {
                 return Ok(StepRes {
                     kind: StepKind::NoMoreExtent,
                     deleted: 0,
@@ -304,7 +293,7 @@ impl<'a> ExtentTree<'a> {
                 });
             }
             let e_start = e.ee_block;
-            let e_end = e_start.saturating_add(len15);
+            let e_end = e_start.saturating_add(len);
 
             if cur_lbn < e_start {
                 return Ok(StepRes {
@@ -318,7 +307,7 @@ impl<'a> ExtentTree<'a> {
 
             let seg_start = cur_lbn;
             let within_off = seg_start.saturating_sub(e_start);
-            let can_take = len15.saturating_sub(within_off);
+            let can_take = len.saturating_sub(within_off);
             if can_take == 0 {
                 return Ok(StepRes {
                     kind: StepKind::HoleSkip,
@@ -346,31 +335,31 @@ impl<'a> ExtentTree<'a> {
                 entries.remove(i);
             } else if seg_start == e_start {
                 let delta = seg_end.saturating_sub(e_start);
-                let new_len15 = len15.saturating_sub(delta);
+                let new_len = len.saturating_sub(delta);
                 let new_start_phys = extent_start_phys(&e) + delta as u64;
                 let mut new_e = e;
                 new_e.ee_block = seg_end;
-                new_e.ee_len = build_extent_len(e.ee_len, new_len15)?;
+                new_e.ee_len = build_extent_len(&e, new_len)?;
                 new_e.ee_start_lo = (new_start_phys & 0xFFFF_FFFF) as u32;
                 new_e.ee_start_hi = (new_start_phys >> 32) as u16;
                 entries[i] = new_e;
             } else if seg_end == e_end {
-                let new_len15 = seg_start.saturating_sub(e_start);
+                let new_len = seg_start.saturating_sub(e_start);
                 let mut new_e = e;
-                new_e.ee_len = build_extent_len(e.ee_len, new_len15)?;
+                new_e.ee_len = build_extent_len(&e, new_len)?;
                 entries[i] = new_e;
             } else {
-                let left_len15 = seg_start.saturating_sub(e_start);
-                let right_len15 = e_end.saturating_sub(seg_end);
+                let left_len = seg_start.saturating_sub(e_start);
+                let right_len = e_end.saturating_sub(seg_end);
 
                 let mut left_e = e;
-                left_e.ee_len = build_extent_len(e.ee_len, left_len15)?;
+                left_e.ee_len = build_extent_len(&e, left_len)?;
 
                 let right_start_phys =
                     extent_start_phys(&e) + seg_end.saturating_sub(e_start) as u64;
                 let mut right_e = e;
                 right_e.ee_block = seg_end;
-                right_e.ee_len = build_extent_len(e.ee_len, right_len15)?;
+                right_e.ee_len = build_extent_len(&e, right_len)?;
                 right_e.ee_start_lo = (right_start_phys & 0xFFFF_FFFF) as u32;
                 right_e.ee_start_hi = (right_start_phys >> 32) as u16;
 
@@ -386,7 +375,7 @@ impl<'a> ExtentTree<'a> {
                     header: *header,
                     entries: entries.clone(),
                 };
-                ExtentTree::write_node_to_block(dev, block_id, &disk_node, header.eh_max)?;
+                tree.write_node_to_block(dev, block_id, &disk_node)?;
             }
 
             Ok(StepRes {
@@ -468,12 +457,7 @@ impl<'a> ExtentTree<'a> {
                                         header: *header,
                                         entries: entries.clone(),
                                     };
-                                    ExtentTree::write_node_to_block(
-                                        dev,
-                                        block_id,
-                                        &disk_node,
-                                        header.eh_max,
-                                    )?;
+                                    tree.write_node_to_block(dev, block_id, &disk_node)?;
                                 }
 
                                 return Ok(StepRes {
@@ -980,13 +964,13 @@ mod tests {
         let exts = collect_extents_from_inode(&mut inode, &mut dev);
         assert_eq!(exts.len(), 2);
         assert_eq!(exts[0].ee_block, 0);
-        assert_eq!((exts[0].ee_len as u32) & 0x7FFF, 1);
+        assert_eq!(exts[0].len(), 1);
         assert_eq!(
             ((exts[0].ee_start_hi as u64) << 32) | (exts[0].ee_start_lo as u64),
             base.raw()
         );
         assert_eq!(exts[1].ee_block, 3);
-        assert_eq!((exts[1].ee_len as u32) & 0x7FFF, 1);
+        assert_eq!(exts[1].len(), 1);
         assert_eq!(
             ((exts[1].ee_start_hi as u64) << 32) | (exts[1].ee_start_lo as u64),
             base.checked_add(3).unwrap().raw()
@@ -1062,7 +1046,7 @@ mod tests {
         let exts = collect_extents_from_inode(&mut inode, &mut dev);
         assert_eq!(exts.len(), 1);
         assert_eq!(exts[0].ee_block, 0);
-        assert_eq!((exts[0].ee_len as u32) & 0x7FFF, 1);
+        assert_eq!(exts[0].len(), 1);
         assert_eq!(
             ((exts[0].ee_start_hi as u64) << 32) | (exts[0].ee_start_lo as u64),
             base1.raw()

--- a/components/rsext4/src/extents_tree/root.rs
+++ b/components/rsext4/src/extents_tree/root.rs
@@ -1,14 +1,44 @@
 use super::*;
+use crate::{
+    bmalloc::InodeNumber,
+    crc32c::{ext4_crc32c_seed_from_superblock, ext4_superblock_has_metadata_csum},
+    superblock::Ext4Superblock,
+};
 
 /// Extent-tree view bound to a single inode.
 pub struct ExtentTree<'a> {
     pub inode: &'a mut Ext4Inode,
+    inode_num: Option<InodeNumber>,
+    generation: u32,
+    checksum_seed: Option<u32>,
 }
 
 impl<'a> ExtentTree<'a> {
     /// Creates an extent-tree handle backed by the given inode.
     pub fn new(inode: &'a mut Ext4Inode) -> Self {
-        Self { inode }
+        let generation = inode.i_generation;
+        Self {
+            inode,
+            inode_num: None,
+            generation,
+            checksum_seed: None,
+        }
+    }
+
+    /// Creates an extent-tree handle with enough metadata to checksum external nodes.
+    pub fn with_checksum(
+        inode: &'a mut Ext4Inode,
+        superblock: &Ext4Superblock,
+        inode_num: InodeNumber,
+    ) -> Self {
+        let generation = inode.i_generation;
+        Self {
+            inode,
+            inode_num: Some(inode_num),
+            generation,
+            checksum_seed: ext4_superblock_has_metadata_csum(superblock)
+                .then(|| ext4_crc32c_seed_from_superblock(superblock)),
+        }
     }
 
     pub(super) fn add_inode_sectors_for_block(&mut self) {
@@ -25,6 +55,45 @@ impl<'a> ExtentTree<'a> {
         let newv = cur.saturating_sub(sub_sectors);
         self.inode.i_blocks_lo = (newv & 0xFFFF_FFFF) as u32;
         self.inode.l_i_blocks_high = ((newv >> 32) & 0xFFFF) as u16;
+    }
+
+    /// Walks all extent-tree blocks that live outside the inode's inline root.
+    pub fn external_node_blocks<B: BlockDevice>(
+        &self,
+        dev: &mut Jbd2Dev<B>,
+    ) -> Ext4Result<Vec<AbsoluteBN>> {
+        let Some(root) = self.load_root_from_inode() else {
+            return Ok(Vec::new());
+        };
+
+        fn walk<B: BlockDevice>(
+            dev: &mut Jbd2Dev<B>,
+            node: &ExtentNode,
+            out: &mut Vec<AbsoluteBN>,
+        ) -> Ext4Result<()> {
+            match node {
+                ExtentNode::Leaf { .. } => Ok(()),
+                ExtentNode::Index { entries, .. } => {
+                    for idx in entries {
+                        let child = AbsoluteBN::new(
+                            ((idx.ei_leaf_hi as u64) << 32) | idx.ei_leaf_lo as u64,
+                        );
+                        out.push(child);
+                        dev.read_block(child)?;
+                        let child_node =
+                            ExtentTree::parse_node(dev.buffer()).ok_or(Ext4Error::corrupted())?;
+                        walk(dev, &child_node, out)?;
+                    }
+                    Ok(())
+                }
+            }
+        }
+
+        let mut blocks = Vec::new();
+        walk(dev, &root, &mut blocks)?;
+        blocks.sort_unstable();
+        blocks.dedup();
+        Ok(blocks)
     }
 
     /// Parses the inline extent root from `inode.i_block`.
@@ -98,11 +167,28 @@ impl<'a> ExtentTree<'a> {
     }
 
     /// Writes an extent node to an absolute physical block.
+    fn update_extent_block_checksum(&self, buf: &mut [u8]) {
+        let (Some(seed), Some(inode_num)) = (self.checksum_seed, self.inode_num) else {
+            return;
+        };
+        if buf.len() < 4 {
+            return;
+        }
+
+        let tail = buf.len() - 4;
+        buf[tail..].fill(0);
+        let inode_le = inode_num.raw().to_le_bytes();
+        let generation_le = self.generation.to_le_bytes();
+        let checksum =
+            crate::checksum::ext4_metadata_csum32(seed, &[&inode_le, &generation_le, &buf[..tail]]);
+        buf[tail..].copy_from_slice(&checksum.to_le_bytes());
+    }
+
     pub(super) fn write_node_to_block<B: BlockDevice>(
+        &self,
         dev: &mut Jbd2Dev<B>,
         block_id: AbsoluteBN,
         node: &ExtentNode,
-        _eh_max: u16,
     ) -> Ext4Result<()> {
         let hdr_size = Ext4ExtentHeader::disk_size();
         let block_eh_max = Self::calc_block_eh_max();
@@ -140,6 +226,7 @@ impl<'a> ExtentTree<'a> {
                 }
             }
         }
+        self.update_extent_block_checksum(buf);
         // Mark the metadata block dirty and write it back.
         dev.write_block(block_id, true)?;
         Ok(())

--- a/components/rsext4/src/file/blocks.rs
+++ b/components/rsext4/src/file/blocks.rs
@@ -1,9 +1,10 @@
 use super::*;
 
-/// Builds block mappings for a file inode from absolute data block numbers.
-pub fn build_file_block_mapping<B: BlockDevice>(
+/// Builds block mappings and enables checksums for external extent nodes.
+pub(crate) fn build_file_block_mapping_with_inode_num<B: BlockDevice>(
     fs: &mut Ext4FileSystem,
     inode: &mut Ext4Inode,
+    inode_num: InodeNumber,
     data_blocks: &[AbsoluteBN],
     block_dev: &mut Jbd2Dev<B>,
 ) {
@@ -57,7 +58,7 @@ pub fn build_file_block_mapping<B: BlockDevice>(
 
         // Insert the computed extents through `ExtentTree` so the inode root
         // receives the same serialized structure as runtime writes.
-        let mut tree = ExtentTree::new(inode);
+        let mut tree = ExtentTree::with_checksum(inode, &fs.superblock, inode_num);
         for extend in exts_vec {
             tree.insert_extent(fs, extend, block_dev)
                 .expect("Extend insert Failed!");

--- a/components/rsext4/src/file/blocks.rs
+++ b/components/rsext4/src/file/blocks.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Builds block mappings and enables checksums for external extent nodes.
-pub(crate) fn build_file_block_mapping_with_inode_num<B: BlockDevice>(
+pub fn build_file_block_mapping_with_inode_num<B: BlockDevice>(
     fs: &mut Ext4FileSystem,
     inode: &mut Ext4Inode,
     inode_num: InodeNumber,

--- a/components/rsext4/src/file/create.rs
+++ b/components/rsext4/src/file/create.rs
@@ -1,5 +1,30 @@
 use super::*;
 
+fn discard_unpublished_inode_blocks<B: BlockDevice>(
+    fs: &mut Ext4FileSystem,
+    device: &mut Jbd2Dev<B>,
+    data_blocks: &[AbsoluteBN],
+) {
+    for &blk in data_blocks {
+        fs.datablock_cache.invalidate(blk);
+        if let Err(e) = fs.free_block(device, blk) {
+            warn!("discard unpublished file block failed block={blk} err={e:?} ({e})");
+        }
+    }
+}
+
+fn discard_unpublished_inode<B: BlockDevice>(
+    fs: &mut Ext4FileSystem,
+    device: &mut Jbd2Dev<B>,
+    inode_num: InodeNumber,
+    data_blocks: &[AbsoluteBN],
+) {
+    discard_unpublished_inode_blocks(fs, device, data_blocks);
+    if let Err(e) = fs.free_inode(device, inode_num) {
+        warn!("discard unpublished inode failed ino={inode_num} err={e:?} ({e})");
+    }
+}
+
 pub fn create_symbol_link<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
@@ -79,18 +104,29 @@ pub fn create_symbol_link<B: BlockDevice>(
 
         while remaining > 0 {
             if !fs.superblock.has_extents() && data_blocks.len() >= 12 {
+                discard_unpublished_inode(fs, device, new_ino, &data_blocks);
                 return Err(Ext4Error::unsupported());
             }
 
             let blk = fs.alloc_block(device)?;
             let write_len = core::cmp::min(remaining, BLOCK_SIZE);
-            fs.datablock_cache.modify_new(device, blk, |data| {
+            if let Err(e) = fs.datablock_cache.modify_new(device, blk, |data| {
                 for b in data.iter_mut() {
                     *b = 0;
                 }
                 let end = src_off + write_len;
                 data[..write_len].copy_from_slice(&target_bytes[src_off..end]);
-            })?;
+            }) {
+                fs.datablock_cache.invalidate(blk);
+                if let Err(free_err) = fs.free_block(device, blk) {
+                    warn!(
+                        "discard failed symlink block failed block={blk} err={free_err:?} \
+                         ({free_err})"
+                    );
+                }
+                discard_unpublished_inode(fs, device, new_ino, &data_blocks);
+                return Err(e);
+            }
 
             data_blocks.push(blk);
             remaining -= write_len;
@@ -187,27 +223,39 @@ pub fn mkfile<B: BlockDevice>(
         while remaining > 0 {
             // Non-extent files only support the 12 direct pointers here.
             if !fs.superblock.has_extents() && data_blocks.len() >= 12 {
-                break;
+                discard_unpublished_inode(fs, device, new_file_ino, &data_blocks);
+                return Err(Ext4Error::unsupported());
             }
 
             let blk = match fs.alloc_block(device) {
                 Ok(b) => b,
                 Err(e) => {
                     error!("mkfile alloc_block failed path={path} err={e:?} ({e})");
-                    break;
+                    discard_unpublished_inode(fs, device, new_file_ino, &data_blocks);
+                    return Err(e);
                 }
             };
 
             let write_len = core::cmp::min(remaining, BLOCK_SIZE);
 
             // Zero-fill each new block and copy the live payload prefix into it.
-            fs.datablock_cache.modify_new(device, blk, |data| {
+            if let Err(e) = fs.datablock_cache.modify_new(device, blk, |data| {
                 for b in data.iter_mut() {
                     *b = 0;
                 }
                 let end = src_off + write_len;
                 data[..write_len].copy_from_slice(&buf[src_off..end]);
-            })?;
+            }) {
+                fs.datablock_cache.invalidate(blk);
+                if let Err(free_err) = fs.free_block(device, blk) {
+                    warn!(
+                        "discard failed file block failed path={path} block={blk} \
+                         err={free_err:?} ({free_err})"
+                    );
+                }
+                discard_unpublished_inode(fs, device, new_file_ino, &data_blocks);
+                return Err(e);
+            }
 
             data_blocks.push(blk);
             total_written += write_len;

--- a/components/rsext4/src/file/create.rs
+++ b/components/rsext4/src/file/create.rs
@@ -1,4 +1,4 @@
-use super::{blocks::build_file_block_mapping, *};
+use super::*;
 
 pub fn create_symbol_link<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
@@ -102,7 +102,7 @@ pub fn create_symbol_link<B: BlockDevice>(
         new_inode.i_blocks_lo = iblocks_used;
         new_inode.l_i_blocks_high = 0; // iblocks_used is u32, so high part is 0
 
-        build_file_block_mapping(fs, &mut new_inode, &data_blocks, device);
+        build_file_block_mapping_with_inode_num(fs, &mut new_inode, new_ino, &data_blocks, device);
     }
 
     let mut create_update = Ext4InodeMetadataUpdate::create(symlink_mode);
@@ -257,7 +257,13 @@ pub fn mkfile<B: BlockDevice>(
         new_inode.i_blocks_lo = used_blocks_lo;
         new_inode.l_i_blocks_high = (iblocks_used >> 32) as u16;
 
-        build_file_block_mapping(fs, &mut new_inode, &data_blocks, device);
+        build_file_block_mapping_with_inode_num(
+            fs,
+            &mut new_inode,
+            new_file_ino,
+            &data_blocks,
+            device,
+        );
     } else {
         // Empty file starts with no data blocks.
         new_inode.i_size_lo = 0;

--- a/components/rsext4/src/file/delete.rs
+++ b/components/rsext4/src/file/delete.rs
@@ -453,9 +453,8 @@ pub fn delete_file<B: BlockDevice>(
         debug!("Will free inode:{ino_num} path:{path}");
         free_inode_with_dtime(fs, block_dev, ino_num, &mut target_inode)?;
     } else {
-        error!(
-            "Inode num:{} links:{} >0 ,only remove entry!",
-            ino_num, new_links
+        debug!(
+            "inode {ino_num} still has {new_links} link(s); removing directory entry only"
         );
     }
 

--- a/components/rsext4/src/file/delete.rs
+++ b/components/rsext4/src/file/delete.rs
@@ -9,13 +9,33 @@ fn free_inode_with_dtime<B: BlockDevice>(
     let mut used_blocks: Vec<AbsoluteBN> = resolve_inode_block_allextend(fs, block_dev, inode)?
         .into_values()
         .collect();
+    if inode.have_extend_header_and_use_extend() {
+        used_blocks.extend(
+            ExtentTree::with_checksum(inode, &fs.superblock, inode_num)
+                .external_node_blocks(block_dev)?,
+        );
+    }
     used_blocks.sort_unstable();
+    used_blocks.dedup();
 
-    let _ = fs.apply_inode_dtime(block_dev, inode_num, Ext4DtimeUpdate::SetNow)?;
+    let updated_inode = fs.apply_inode_dtime(block_dev, inode_num, Ext4DtimeUpdate::SetNow)?;
 
     for blk in used_blocks {
         fs.free_block(block_dev, blk)?;
     }
+
+    *inode = updated_inode;
+    inode.i_block = [0; 15];
+    inode.i_blocks_lo = 0;
+    inode.l_i_blocks_high = 0;
+    inode.i_size_lo = 0;
+    inode.i_size_high = 0;
+    fs.finalize_inode_update(
+        block_dev,
+        inode_num,
+        inode,
+        Ext4InodeMetadataUpdate::link_count_change(),
+    )?;
 
     fs.free_inode(block_dev, inode_num)
 }

--- a/components/rsext4/src/file/io.rs
+++ b/components/rsext4/src/file/io.rs
@@ -79,9 +79,9 @@ fn truncate_inode<B: BlockDevice>(
                     del_start_lbn
                 };
 
-                let chunk = core::cmp::min(del_len, 0x7FFF);
+                let chunk = core::cmp::min(del_len, Ext4Extent::EXT_INIT_MAX_LEN as u32);
                 {
-                    let mut tree = ExtentTree::new(&mut inode);
+                    let mut tree = ExtentTree::with_checksum(&mut inode, &fs.superblock, inode_num);
                     tree.remove_extend(fs, Ext4Extent::new(start_lbn, 0, chunk as u16), device)?;
                 }
             }
@@ -99,7 +99,7 @@ fn truncate_inode<B: BlockDevice>(
                 new_blocks_map.push((lbn, phys));
             }
 
-            let mut tree = ExtentTree::new(&mut inode);
+            let mut tree = ExtentTree::with_checksum(&mut inode, &fs.superblock, inode_num);
             if !new_blocks_map.is_empty() {
                 let mut idx = 0usize;
                 while idx < new_blocks_map.len() {
@@ -131,7 +131,11 @@ fn truncate_inode<B: BlockDevice>(
         inode.i_size_high = (truncate_size >> 32) as u32;
         // i_blocks reflects number of allocated blocks, not logical length. Recompute after edits.
         let alloc_blocks = resolve_inode_block_allextend(fs, device, &mut inode)?.len() as u64;
-        let iblocks_used = alloc_blocks.saturating_mul(BLOCK_SIZE as u64 / 512);
+        let extent_tree_blocks = ExtentTree::with_checksum(&mut inode, &fs.superblock, inode_num)
+            .external_node_blocks(device)?
+            .len() as u64;
+        let iblocks_used =
+            alloc_blocks.saturating_add(extent_tree_blocks) * (BLOCK_SIZE as u64 / 512);
         inode.i_blocks_lo = (iblocks_used & 0xffff_ffff) as u32;
         inode.l_i_blocks_high = ((iblocks_used >> 32) & 0xffff) as u16;
 
@@ -416,7 +420,8 @@ fn write_inode_data<B: BlockDevice>(
                         }
                     })?;
                     {
-                        let mut tree = ExtentTree::new(&mut inode);
+                        let mut tree =
+                            ExtentTree::with_checksum(&mut inode, &fs.superblock, inode_num);
                         let ext = Ext4Extent::new(lbn as u32, new_phys.raw(), 1);
                         tree.insert_extent(fs, ext, device)?;
                     }

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -30,7 +30,7 @@ mod io;
 mod link;
 mod rename;
 
-pub(crate) use blocks::build_file_block_mapping_with_inode_num;
+pub use blocks::build_file_block_mapping_with_inode_num;
 pub use create::{create_symbol_link, mkfile};
 pub use delete::{delete_dir, delete_file, unlink};
 pub use io::{read_file, truncate, write_file};

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -30,7 +30,7 @@ mod io;
 mod link;
 mod rename;
 
-pub use blocks::build_file_block_mapping;
+pub(crate) use blocks::build_file_block_mapping_with_inode_num;
 pub use create::{create_symbol_link, mkfile};
 pub use delete::{delete_dir, delete_file, unlink};
 pub use io::{read_file, truncate, write_file};

--- a/components/rsext4/src/jbd2/jbd2.rs
+++ b/components/rsext4/src/jbd2/jbd2.rs
@@ -761,7 +761,13 @@ pub fn create_journal_entry<B: BlockDevice>(
     jour_inode.i_blocks_lo = (inode_size / 512) as u32;
     jour_inode.l_i_blocks_high = 0;
     jour_inode.write_extend_header();
-    build_file_block_mapping(fs, &mut jour_inode, &free_block, block_dev);
+    build_file_block_mapping_with_inode_num(
+        fs,
+        &mut jour_inode,
+        InodeNumber::new(journal_inode_num as u32)?,
+        &free_block,
+        block_dev,
+    );
     debug!(
         "When creating journal inode: iblock={:?}",
         jour_inode.i_block

--- a/components/rsext4/src/loopfile.rs
+++ b/components/rsext4/src/loopfile.rs
@@ -26,12 +26,7 @@ pub fn resolve_inode_block<B: BlockDevice>(
     if inode.have_extend_header_and_use_extend() {
         let mut tree = ExtentTree::new(inode);
         if let Some(ext) = tree.find_extent(block_dev, logical_block)? {
-            let raw_len = ext.ee_len as u32;
-            let is_unwritten = raw_len > 0x8000;
-            let mut len = raw_len;
-            if (len & 0x8000) != 0 {
-                len &= 0x7FFF;
-            }
+            let len = ext.len();
             if len == 0 {
                 return Ok(None);
             }
@@ -41,7 +36,7 @@ pub fn resolve_inode_block<B: BlockDevice>(
                 return Ok(None);
             }
 
-            if is_unwritten {
+            if ext.is_unwritten() {
                 return Ok(None);
             }
 
@@ -70,11 +65,10 @@ pub fn resolve_inode_block_allextend<B: BlockDevice>(
     }
 
     fn push_extent_blocks(out: &mut Vec<(u32, AbsoluteBN)>, ext: &Ext4Extent) {
-        let raw_len = ext.ee_len as u32;
-        if (raw_len & 0x8000) != 0 {
+        if ext.is_unwritten() {
             return;
         }
-        let len = raw_len;
+        let len = ext.len();
         if len == 0 {
             return;
         }

--- a/components/rsext4/tests/crc_integrity.rs
+++ b/components/rsext4/tests/crc_integrity.rs
@@ -190,6 +190,57 @@ fn checksums_are_persisted_and_clean_remount_preserves_the_written_file() {
 }
 
 #[test]
+fn unclean_shutdown_mount_state_does_not_set_error_fs() {
+    // Test idea: a crash after mount should leave the filesystem unclean, but
+    // it must not be reported as EXT4_ERROR_FS on the next boot.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    {
+        let mut fs = mount(&mut jbd2_dev).expect("mount failed");
+        fs.sync_superblock(&mut jbd2_dev)
+            .expect("persist dirty mount state");
+    }
+
+    let dirty_sb = read_superblock(&device);
+    assert_eq!(dirty_sb.s_state & Ext4Superblock::EXT4_VALID_FS, 0);
+    assert_eq!(dirty_sb.s_state & Ext4Superblock::EXT4_ERROR_FS, 0);
+
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut remount_dev).expect("mount after unclean shutdown failed");
+    assert_eq!(fs.superblock.s_state & Ext4Superblock::EXT4_ERROR_FS, 0);
+    umount(fs, &mut remount_dev).expect("umount failed");
+
+    let clean_sb = read_superblock(&device);
+    assert_eq!(clean_sb.s_state, Ext4Superblock::EXT4_VALID_FS);
+}
+
+#[test]
+fn clean_unmount_preserves_real_error_fs_state() {
+    // Test idea: EXT4_ERROR_FS is an independent state bit. A clean unmount may
+    // mark the filesystem clean, but must not erase a recorded error.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut sb = read_superblock(&device);
+    sb.s_state = Ext4Superblock::EXT4_VALID_FS | Ext4Superblock::EXT4_ERROR_FS;
+    sb.s_error_count = 1;
+    sb.update_checksum();
+    write_superblock(&device, &sb);
+
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut remount_dev).expect("mount with error state failed");
+    assert_ne!(fs.superblock.s_state & Ext4Superblock::EXT4_ERROR_FS, 0);
+    umount(fs, &mut remount_dev).expect("umount failed");
+
+    let clean_sb = read_superblock(&device);
+    assert_ne!(clean_sb.s_state & Ext4Superblock::EXT4_VALID_FS, 0);
+    assert_ne!(clean_sb.s_state & Ext4Superblock::EXT4_ERROR_FS, 0);
+}
+
+#[test]
 fn corrupted_superblock_checksum_is_reported_as_euclean_on_mount() {
     // Test idea: corrupt only the stored superblock CRC field and ensure mount
     // rejects the image with the checksum-specific EUCLEAN errno.

--- a/components/rsext4/tests/error_handling.rs
+++ b/components/rsext4/tests/error_handling.rs
@@ -6,7 +6,7 @@
 use std::cell::Cell;
 
 use rsext4::{
-    bmalloc::AbsoluteBN,
+    bmalloc::{AbsoluteBN, BGIndex},
     error::{Ext4Error, Ext4Result},
     *,
 };
@@ -329,6 +329,38 @@ mod error_handling_tests {
         assert_eq!(data, large_data);
 
         // Unmount may fail after exhaustion; the test only cares about data survival.
+        let _ = umount(fs, &mut jbd2_dev);
+    }
+
+    /// A device whose size does not end on a full block-group boundary must
+    /// not expose padding bits past `s_blocks_count` as allocatable blocks.
+    #[test]
+    fn test_partial_last_group_padding_is_not_allocated() {
+        let blocks_per_group = 8 * rsext4::BLOCK_SIZE as u64;
+        let total_blocks = blocks_per_group + 128;
+        let device = ErrorMockDevice::new(total_blocks as usize * rsext4::BLOCK_SIZE);
+        let mut jbd2_dev = Jbd2Dev::initial_jbd2dev(0, device, true);
+
+        mkfs(&mut jbd2_dev).expect("mkfs failed");
+        let fs = mount(&mut jbd2_dev).expect("mount failed");
+
+        let last_group = BGIndex::new(fs.group_count - 1);
+        let last_desc = fs
+            .get_group_desc(last_group)
+            .expect("last group descriptor should exist");
+        assert!(last_desc.free_blocks_count() < 128);
+
+        jbd2_dev
+            .read_block(AbsoluteBN::new(last_desc.block_bitmap()))
+            .expect("read last block bitmap");
+        let bitmap = jbd2_dev.buffer();
+        for bit in 128..fs.superblock.s_blocks_per_group as usize {
+            assert!(
+                bitmap[bit / 8] & (1 << (bit % 8)) != 0,
+                "partial-group padding bit {bit} should be marked allocated"
+            );
+        }
+
         let _ = umount(fs, &mut jbd2_dev);
     }
 

--- a/components/rsext4/tests/linux_image_repro.rs
+++ b/components/rsext4/tests/linux_image_repro.rs
@@ -179,6 +179,34 @@ fn e2fsck_readonly_clean(image: &Path, context: &str) {
     );
 }
 
+fn create_ext4_test_image(prefix: &str, size: &str) -> (PathBuf, PathBuf) {
+    let temp_dir = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+    if temp_dir.exists() {
+        fs::remove_dir_all(&temp_dir).expect("remove stale temp dir");
+    }
+    fs::create_dir(&temp_dir).expect("create temp dir");
+    let image = temp_dir.join("fs.img");
+
+    run_command(
+        {
+            let mut command = Command::new("truncate");
+            command.args(["-s", size]).arg(&image);
+            command
+        },
+        "truncate test image",
+    );
+    run_command(
+        {
+            let mut command = Command::new("mkfs.ext4");
+            command.args(["-F", "-q", "-b", "4096"]).arg(&image);
+            command
+        },
+        "mkfs.ext4 test image",
+    );
+
+    (temp_dir, image)
+}
+
 fn assert_debugfs_path_exists(image: &Path, path: &str) {
     let output = debugfs_query(image, &format!("stat {path}"));
     assert!(
@@ -342,6 +370,110 @@ fn replay_csum_v3_multi_block_journal_from_debugfs() {
     assert_debugfs_path_exists(&image, "/replay-repro/a");
     assert_debugfs_path_exists(&image, "/replay-repro/b");
     e2fsck_readonly_clean(&image, "rsext4 csum-v3 journal replay");
+    fs::remove_dir_all(temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn e2fsck_clean_after_sparse_extent_truncate_keeps_tree_blocks_counted() {
+    for tool in ["mkfs.ext4", "e2fsck", "truncate"] {
+        require_tool(tool);
+    }
+
+    let (temp_dir, image) = create_ext4_test_image("rsext4-sparse-truncate-repro", "64M");
+
+    {
+        let dev = FileBlockDevice::open(image.clone());
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, dev, true);
+        let mut fs = mount(&mut dev).expect("mount image");
+
+        let path = "/extent-truncate.bin";
+        mkfile(&mut dev, &mut fs, path, None, None).expect("create sparse file");
+        for lbn in [0u64, 2, 4, 6, 8] {
+            write_file(
+                &mut dev,
+                &mut fs,
+                path,
+                lbn * BLOCK_SIZE as u64,
+                &[lbn as u8],
+            )
+            .expect("sparse write");
+        }
+
+        truncate(&mut dev, &mut fs, path, 9 * BLOCK_SIZE as u64).expect("truncate sparse file");
+        umount(fs, &mut dev).expect("umount image");
+    }
+
+    e2fsck_readonly_clean(&image, "sparse extent truncate");
+    fs::remove_dir_all(temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn e2fsck_clean_after_deleting_split_extent_file_frees_tree_blocks() {
+    for tool in ["mkfs.ext4", "e2fsck", "truncate"] {
+        require_tool(tool);
+    }
+
+    let (temp_dir, image) = create_ext4_test_image("rsext4-split-extent-delete-repro", "64M");
+
+    {
+        let dev = FileBlockDevice::open(image.clone());
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, dev, true);
+        let mut fs = mount(&mut dev).expect("mount image");
+
+        let path = "/extent-delete.bin";
+        mkfile(&mut dev, &mut fs, path, None, None).expect("create sparse file");
+        for lbn in [0u64, 2, 4, 6, 8] {
+            write_file(
+                &mut dev,
+                &mut fs,
+                path,
+                lbn * BLOCK_SIZE as u64,
+                &[0x80 | lbn as u8],
+            )
+            .expect("sparse write");
+        }
+
+        delete_file(&mut fs, &mut dev, path).expect("delete sparse file");
+        umount(fs, &mut dev).expect("umount image");
+    }
+
+    e2fsck_readonly_clean(&image, "split extent delete");
+    fs::remove_dir_all(temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn e2fsck_clean_after_exact_32768_block_extent() {
+    for tool in ["mkfs.ext4", "e2fsck", "truncate"] {
+        require_tool(tool);
+    }
+
+    let (temp_dir, image) = create_ext4_test_image("rsext4-32768-extent-repro", "192M");
+
+    {
+        let dev = FileBlockDevice::open(image.clone());
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, dev, true);
+        let mut fs = mount(&mut dev).expect("mount image");
+
+        let path = "/extent-32768.bin";
+        mkfile(&mut dev, &mut fs, path, None, None).expect("create file");
+        let block = vec![0x5a; BLOCK_SIZE];
+        for lbn in 0..32768u64 {
+            write_file(&mut dev, &mut fs, path, lbn * BLOCK_SIZE as u64, &block)
+                .expect("write contiguous extent block");
+        }
+
+        let content = read_file(&mut dev, &mut fs, path).expect("read exact 32768-block file");
+        assert_eq!(content.len(), 32768 * BLOCK_SIZE);
+        assert_eq!(&content[..16], &[0x5a; 16]);
+        assert_eq!(
+            &content[32767 * BLOCK_SIZE..32767 * BLOCK_SIZE + 16],
+            &[0x5a; 16]
+        );
+
+        umount(fs, &mut dev).expect("umount image");
+    }
+
+    e2fsck_readonly_clean(&image, "exact 32768-block extent");
     fs::remove_dir_all(temp_dir).expect("remove temp dir");
 }
 

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
@@ -383,7 +383,13 @@ impl FileNodeOps for Inode {
                 let iblocks_used = used_datablocks.saturating_mul(BLOCK_SIZE as u64 / 512) as u32;
                 inode.i_blocks_lo = iblocks_used;
                 inode.l_i_blocks_high = 0;
-                rsext4::file::build_file_block_mapping(fs, &mut inode, &data_blocks, dev);
+                rsext4::file::build_file_block_mapping_with_inode_num(
+                    fs,
+                    &mut inode,
+                    self.ino,
+                    &data_blocks,
+                    dev,
+                );
             }
 
             fs.modify_inode(dev, self.ino, |on_disk| {


### PR DESCRIPTION
## 背景

`apk add gcc` 会在 Starry/QEMU 中触发大量新文件和数据块写入，之前 rsext4 在这个场景下会出现内存不足，并且还暴露出小镜像资源耗尽时的文件系统边界问题。

## 改动

- 修复 data block cache 新建块路径没有执行 LRU 淘汰的问题，避免 dirty cache 在连续写新块时无界增长。
- 修复 mkfs 对最后一个不完整 block group 的处理，确保超过 `s_blocks_count` 的 padding bits 按 ext4 规范标记为已分配。
- 修复 `mkfile` 初始数据写入失败时仍发布截断/空文件的问题，失败时回收已分配 inode 和 data blocks。
- 保留 clean/unclean mount state 修复，避免非干净关机被错误标记为 `EXT4_ERROR_FS`。
- 补充回归测试覆盖 cache LRU、partial group padding、资源耗尽后的数据完整性，以及 unclean mount state。

## 验证

- `cargo fmt --all --check`
- `cargo test -p rsext4`
- `cargo xtask clippy --package rsext4`
- `cargo starry qemu` 后执行 `apk add gcc` 成功，输出 `OK: 174.7 MiB in 32 packages`
- QEMU 后离线 `e2fsck -fn target/rootfs/rootfs-aarch64-alpine.img` 通过
