### PR TITLE
feat(syscall): implement vfork syscall with parent blocking

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -453,6 +453,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         ),
         #[cfg(target_arch = "x86_64")]
         Sysno::fork => sys_fork(uctx),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::vfork => sys_vfork(uctx),
         Sysno::exit => sys_exit(uctx.arg0() as _),
         Sysno::exit_group => sys_exit_group(uctx.arg0() as _),
         Sysno::wait4 => sys_waitpid(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -1,10 +1,15 @@
 use alloc::sync::Arc;
+use core::{future::poll_fn, sync::atomic::Ordering, task::Poll};
 
 use ax_errno::{AxError, AxResult};
 use ax_fs::FS_CONTEXT;
 use ax_hal::uspace::UserContext;
 use ax_kspin::SpinNoIrq;
-use ax_task::{AxTaskExt, current, spawn_task};
+use ax_task::{
+    AxTaskExt, current,
+    future::{block_on, interruptible},
+    spawn_task,
+};
 use bitflags::bitflags;
 use linux_raw_sys::general::*;
 use starry_process::Pid;
@@ -144,8 +149,9 @@ impl CloneArgs {
             pidfd,
         } = self;
 
-        if flags.contains(CloneFlags::VFORK) {
-            debug!("do_clone: CLONE_VFORK slow path");
+        let is_vfork = flags.contains(CloneFlags::VFORK);
+        if is_vfork {
+            debug!("do_clone: CLONE_VFORK — parent will block until child execve/_exit");
             flags.remove(CloneFlags::VM);
         }
 
@@ -257,6 +263,16 @@ impl CloneArgs {
 
         let parent_cred = Some(curr.as_thread().cred());
         let thr = Thread::new(tid, new_proc_data.clone(), parent_cred);
+
+        let vfork_done = if is_vfork {
+            let done = Arc::new(core::sync::atomic::AtomicBool::new(false));
+            let event: Arc<axpoll::PollSet> = Arc::default();
+            thr.set_vfork_state(done.clone(), event.clone());
+            Some((done, event))
+        } else {
+            None
+        };
+
         if flags.contains(CloneFlags::CHILD_CLEARTID) {
             thr.set_clear_child_tid(child_tid);
         }
@@ -276,6 +292,21 @@ impl CloneArgs {
 
         let task = spawn_task(new_task);
         add_task_to_table(&task);
+
+        if let Some((vfork_done, vfork_event)) = vfork_done {
+            debug!("do_clone: parent blocking on vfork for child tid {tid}");
+            block_on(interruptible(poll_fn(|cx| {
+                if vfork_done.load(Ordering::Acquire) {
+                    return Poll::Ready(());
+                }
+                vfork_event.register(cx.waker());
+                if vfork_done.load(Ordering::Acquire) {
+                    return Poll::Ready(());
+                }
+                Poll::Pending
+            })))?;
+            debug!("do_clone: parent resumed after vfork, child tid {tid}");
+        }
 
         Ok(tid as _)
     }
@@ -319,4 +350,14 @@ pub fn sys_clone(
 #[cfg(target_arch = "x86_64")]
 pub fn sys_fork(uctx: &UserContext) -> AxResult<isize> {
     sys_clone(uctx, SIGCHLD, 0, 0, 0, 0)
+}
+
+#[cfg(target_arch = "x86_64")]
+pub fn sys_vfork(uctx: &UserContext) -> AxResult<isize> {
+    CloneArgs {
+        flags: CloneFlags::VFORK,
+        exit_signal: SIGCHLD as _,
+        ..Default::default()
+    }
+    .do_clone(uctx)
 }

--- a/os/StarryOS/kernel/src/syscall/task/execve.rs
+++ b/os/StarryOS/kernel/src/syscall/task/execve.rs
@@ -84,5 +84,8 @@ pub fn sys_execve(
 
     uctx.set_ip(entry_point.as_usize());
     uctx.set_sp(user_stack_base.as_usize());
+
+    current().as_thread().signal_vfork_done();
+
     Ok(0)
 }

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -101,6 +101,12 @@ pub struct Thread {
 
     /// Process credentials (uid, gid, etc.).
     cred: SpinNoIrq<Arc<Cred>>,
+
+    /// vfork completion flag — set by child on execve/_exit.
+    vfork_done: SpinNoIrq<Arc<AtomicBool>>,
+
+    /// vfork wake event — parent blocks on this until child signals.
+    vfork_event: SpinNoIrq<Option<Arc<PollSet>>>,
 }
 
 impl Thread {
@@ -123,6 +129,8 @@ impl Thread {
             rseq_area: AtomicUsize::new(0),
             pdeathsig: AtomicU32::new(0),
             cred: SpinNoIrq::new(cred),
+            vfork_done: SpinNoIrq::new(Arc::new(AtomicBool::new(false))),
+            vfork_event: SpinNoIrq::new(None),
         })
     }
 
@@ -235,6 +243,22 @@ impl Thread {
     /// Set the registered rseq area pointer.
     pub fn set_rseq_area(&self, addr: usize) {
         self.rseq_area.store(addr, Ordering::SeqCst);
+    }
+
+    /// Replace the vfork shared state with parent-provided Arcs.
+    /// Called by the parent after constructing the child Thread.
+    pub fn set_vfork_state(&self, done: Arc<AtomicBool>, event: Arc<PollSet>) {
+        *self.vfork_done.lock() = done;
+        *self.vfork_event.lock() = Some(event);
+    }
+
+    /// Signal vfork completion (called by child on execve or _exit).
+    /// Wakes the blocked parent.
+    pub fn signal_vfork_done(&self) {
+        self.vfork_done.lock().store(true, Ordering::Release);
+        if let Some(event) = self.vfork_event.lock().take() {
+            event.wake();
+        }
     }
 }
 

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -218,6 +218,8 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
     let curr = current();
     let thr = curr.as_thread();
 
+    thr.signal_vfork_done();
+
     info!("{} exit with code: {}", curr.id_name(), exit_code);
 
     let clear_child_tid = thr.clear_child_tid() as *mut u32;


### PR DESCRIPTION
## Summary
- Implement real vfork semantics (COW fork + parent blocking) replacing the previous CLONE_VFORK stub
- Parent blocks until child calls execve or _exit, using AtomicBool + PollSet race-free pattern
- Add sys_vfork dispatch for x86_64; riscv64/aarch64/loongarch64 use clone with CLONE_VFORK

## Root Cause
254/257 busybox tests fail because musl's `system()`/`popen()`/`posix_spawn()` all use vfork internally. The previous implementation just removed CLONE_VM without blocking the parent, which violates the vfork contract.

## Changes
| File | Change |
|------|--------|
| `task/mod.rs` | Add `vfork_done` + `vfork_event` fields to Thread, with `set_vfork_state`/`signal_vfork_done` methods |
| `task/ops.rs` | Call `signal_vfork_done()` at start of `do_exit` — unblocks parent on child _exit |
| `syscall/task/execve.rs` | Call `signal_vfork_done()` before `Ok(0)` — unblocks parent on child execve |
| `syscall/task/clone.rs` | Replace CLONE_VFORK stub with real parent blocking via `block_on(interruptible(poll_fn(...)))`; add `sys_vfork` for x86_64 |
| `syscall/mod.rs` | Add `Sysno::vfork` dispatch (x86_64 only) |

## Test plan
- [ ] Busybox test suite should show significant improvement (254 failures → fewer)
- [ ] x86_64 and riscv64 builds pass
- [ ] No regression on existing syscall tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)