### PR TITLE
fix(starryos): restore login shell startup

### DIFF
--- a/components/starry-signal/tests/common/mod.rs
+++ b/components/starry-signal/tests/common/mod.rs
@@ -1,6 +1,9 @@
 use std::{
     mem::MaybeUninit,
-    sync::{Arc, LazyLock, Mutex, MutexGuard},
+    sync::{
+        Arc, LazyLock, Mutex, MutexGuard,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 use ax_kspin::SpinNoIrq;
@@ -13,9 +16,17 @@ static POOL: LazyLock<Mutex<Box<[u8]>>> = LazyLock::new(|| {
     Mutex::new(vec![0; size].into_boxed_slice())
 });
 
+const TEST_STACK_SIZE: usize = 0x1_0000;
+static NEXT_STACK_OFFSET: AtomicUsize = AtomicUsize::new(0);
+
 pub fn initial_sp() -> usize {
     let pool = POOL.lock().unwrap();
-    pool.as_ptr() as usize + pool.len()
+    let offset = NEXT_STACK_OFFSET.fetch_add(TEST_STACK_SIZE, Ordering::Relaxed);
+    assert!(
+        offset + TEST_STACK_SIZE <= pool.len(),
+        "starry-signal test VM stack pool exhausted"
+    );
+    pool.as_ptr() as usize + offset + TEST_STACK_SIZE
 }
 
 struct Vm(MutexGuard<'static, Box<[u8]>>);

--- a/os/StarryOS/starryos/src/init.sh
+++ b/os/StarryOS/starryos/src/init.sh
@@ -19,4 +19,4 @@ cat > /tmp/starry-shrc <<'EOF'
 export PS1='${USER}@${HOSTNAME}:${PWD} # '
 EOF
 export ENV=/tmp/starry-shrc
-exec /bin/sh --login -i
+exec /bin/sh -l -i

--- a/os/StarryOS/starryos/src/init.sh
+++ b/os/StarryOS/starryos/src/init.sh
@@ -15,5 +15,8 @@ echo
 # Do your initialization here!
 
 cd "$HOME" || cd /
+cat > /tmp/starry-shrc <<'EOF'
 export PS1='${USER}@${HOSTNAME}:${PWD} # '
-exec /bin/sh -i
+EOF
+export ENV=/tmp/starry-shrc
+exec /bin/sh --login -i

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -92,6 +92,7 @@ rsext4
 scope-local
 simple-sdmmc
 starry-kernel
+starryos
 starry-process
 starry-vm
 tg-xtask

--- a/test-suit/starryos/normal/qemu-smp1/apt/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apt/qemu-aarch64.toml
@@ -18,13 +18,19 @@ to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
 rm -f /etc/apt/sources.list.d/*.sources && \
-printf 'deb http://mirrors.tuna.tsinghua.edu.cn/debian trixie main\n' > /etc/apt/sources.list && \
-apt update && \
-DEBIAN_FRONTEND=noninteractive apt install -y hello && \
-hello && \
-echo 'APT_HELLO_TEST_PASSED' || \
-echo 'APT_HELLO_TEST_FAILED'
+apt_hello_test() { \
+    printf 'deb %s trixie main\n' "$1" > /etc/apt/sources.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends hello && \
+    hello; \
+}; \
+if apt_hello_test http://mirrors.tuna.tsinghua.edu.cn/debian || \
+   apt_hello_test http://deb.debian.org/debian; then \
+    echo 'APT_HELLO_TEST_PASSED'; \
+else \
+    echo 'APT_HELLO_TEST_FAILED'; \
+fi
 '''
 success_regex = ["(?m)^Hello, world!\\s*$", "(?m)^APT_HELLO_TEST_PASSED\\s*$"]
-fail_regex = ['(?m)^panicked at(?:\s|$)', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
+fail_regex = ['(?m)^(?:\x1b\[[0-9;]*[A-Za-z])*panicked at(?:\s|$)', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
 timeout = 600

--- a/test-suit/starryos/normal/qemu-smp1/apt/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apt/qemu-aarch64.toml
@@ -26,5 +26,5 @@ echo 'APT_HELLO_TEST_PASSED' || \
 echo 'APT_HELLO_TEST_FAILED'
 '''
 success_regex = ["(?m)^Hello, world!\\s*$", "(?m)^APT_HELLO_TEST_PASSED\\s*$"]
-fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
+fail_regex = ['(?m)^panicked at(?:\s|$)', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
 timeout = 600

--- a/test-suit/starryos/normal/qemu-smp1/apt/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apt/qemu-riscv64.toml
@@ -18,13 +18,19 @@ to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
 rm -f /etc/apt/sources.list.d/*.sources && \
-printf 'deb http://mirrors.tuna.tsinghua.edu.cn/debian trixie main\n' > /etc/apt/sources.list && \
-apt update && \
-DEBIAN_FRONTEND=noninteractive apt install -y hello && \
-hello && \
-echo 'APT_HELLO_TEST_PASSED' || \
-echo 'APT_HELLO_TEST_FAILED'
+apt_hello_test() { \
+    printf 'deb %s trixie main\n' "$1" > /etc/apt/sources.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends hello && \
+    hello; \
+}; \
+if apt_hello_test http://mirrors.tuna.tsinghua.edu.cn/debian || \
+   apt_hello_test http://deb.debian.org/debian; then \
+    echo 'APT_HELLO_TEST_PASSED'; \
+else \
+    echo 'APT_HELLO_TEST_FAILED'; \
+fi
 '''
 success_regex = ["(?m)^Hello, world!\\s*$", "(?m)^APT_HELLO_TEST_PASSED\\s*$"]
-fail_regex = ['(?m)^panicked at(?:\s|$)', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
+fail_regex = ['(?m)^(?:\x1b\[[0-9;]*[A-Za-z])*panicked at(?:\s|$)', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
 timeout = 600

--- a/test-suit/starryos/normal/qemu-smp1/apt/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apt/qemu-riscv64.toml
@@ -26,5 +26,5 @@ echo 'APT_HELLO_TEST_PASSED' || \
 echo 'APT_HELLO_TEST_FAILED'
 '''
 success_regex = ["(?m)^Hello, world!\\s*$", "(?m)^APT_HELLO_TEST_PASSED\\s*$"]
-fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
+fail_regex = ['(?m)^panicked at(?:\s|$)', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
 timeout = 600


### PR DESCRIPTION
## Summary
- restore StarryOS init to start `/bin/sh` as a login shell so `/etc/profile` and `$HOME/.profile` are loaded
- use the short `-l -i` shell flags so both BusyBox ash and Debian dash accept the startup path
- keep the stable `root@starry:` prompt through ash `ENV` so existing Starry qemu tests can still auto-send commands
- narrow the apt test panic fail regex to the kernel panic banner (`panicked at`) instead of matching any user-space `panic` text
- make the Debian apt qemu test fall back from the TUNA mirror to `deb.debian.org` when CI runners receive mirror-side failures
- add `starryos` to the clippy whitelist now that the targeted checks pass

## Root Cause
PR #183 replaced the original login shell startup with `exec /bin/sh -i`. BusyBox ash only reads `/etc/profile` and `$HOME/.profile` for login shells, so the current init path skipped system and user profile initialization. The first fix used the long `--login` option, but Debian dash rejects it in the apt rootfs; the updated startup uses the portable `-l` form.

The follow-up CI failure was in the Starry Debian apt case: the `riscv64` GitHub runner received `403 Forbidden` from `mirrors.tuna.tsinghua.edu.cn`, so `apt update` failed before `hello` could be installed. The case now preserves the fast mirror path and retries with `deb.debian.org` before reporting failure.

Fixes #354

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask clippy --package starryos`
- `cargo xtask starry test qemu --arch riscv64 -c smoke`
- `cargo xtask starry test qemu --arch aarch64 -c apt`
- `cargo xtask starry test qemu --arch riscv64 -c apt`
