### PR TITLE
fix(loop,pivot_root): replace UnsafeCell with SpinNoPreempt for cache…

### DIFF
--- a/components/axfs-ng-vfs/src/mount.rs
+++ b/components/axfs-ng-vfs/src/mount.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    borrow::Cow,
     string::String,
     sync::{Arc, Weak},
     vec,
@@ -23,8 +24,8 @@ use crate::{
 pub struct Mountpoint {
     /// Root dir entry in the mountpoint.
     root: DirEntry,
-    /// Location in the parent mountpoint.
-    location: Option<Location>,
+    /// Location in the parent mountpoint. `None` for the global root mount.
+    location: Mutex<Option<Location>>,
     /// Children of the mountpoint.
     children: Mutex<HashMap<ReferenceKey, Weak<Self>>>,
     /// Device ID
@@ -38,7 +39,7 @@ impl Mountpoint {
         let root = fs.root_dir();
         Arc::new(Self {
             root,
-            location: location_in_parent,
+            location: Mutex::new(location_in_parent),
             children: Mutex::default(),
             device: DEVICE_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
@@ -54,11 +55,55 @@ impl Mountpoint {
 
     /// Returns the location in the parent mountpoint.
     pub fn location(&self) -> Option<Location> {
-        self.location.clone()
+        self.location.lock().clone()
     }
 
     pub fn is_root(&self) -> bool {
-        self.location.is_none()
+        self.location.lock().is_none()
+    }
+
+    /// Pivot the mount tree: the old root (`self`) is detached and re-attached
+    /// at `put_old` under `new_root_mp`, which becomes the global root.
+    ///
+    /// This implements the mount-tree portion of Linux `pivot_root(2)`.
+    pub fn pivot_mount(
+        self: &Arc<Self>,        // old root mountpoint
+        new_root_mp: &Arc<Self>, // new root mountpoint
+        put_old: &Location,      // directory under new_root_mp where old root goes
+    ) -> VfsResult<()> {
+        // put_old must belong to the new root's mountpoint tree.
+        if !Arc::ptr_eq(put_old.mountpoint(), new_root_mp) {
+            return Err(VfsError::InvalidInput);
+        }
+        // put_old must be a directory and not already a mountpoint.
+        put_old.check_is_dir()?;
+        if put_old.is_mountpoint() {
+            return Err(VfsError::ResourceBusy);
+        }
+
+        // 1. Detach new_root from old root's children and clear the old mount
+        //    slot (where new_root was attached in the old root).
+        {
+            let mut new_root_loc = new_root_mp.location.lock();
+            if let Some(ref old_loc) = *new_root_loc {
+                self.children.lock().remove(&old_loc.entry.key());
+                *old_loc.entry.as_dir()?.mountpoint.lock() = None;
+            }
+            // new_root becomes the global root.
+            *new_root_loc = None;
+        }
+
+        // 2. Attach old root at put_old under new_root.
+        {
+            *put_old.entry.as_dir()?.mountpoint.lock() = Some(self.clone());
+            new_root_mp
+                .children
+                .lock()
+                .insert(put_old.entry.key(), Arc::downgrade(self));
+            *self.location.lock() = Some(put_old.clone());
+        }
+
+        Ok(())
     }
 
     /// Returns the effective mountpoint.
@@ -133,11 +178,21 @@ impl Location {
         &self.entry
     }
 
-    pub fn name(&self) -> &str {
+    /// Returns the entry name.
+    ///
+    /// For mount roots the name is derived from the parent location (where this
+    /// mount was attached). Because `location` lives behind a `Mutex`, the
+    /// mount-root case returns an owned `Cow::Owned`; the common non-root case
+    /// returns a borrowed `Cow::Borrowed`.
+    pub fn name(&self) -> Cow<'_, str> {
         if self.is_root_of_mount() {
-            self.mountpoint.location.as_ref().map_or("", Location::name)
+            self.mountpoint
+                .location
+                .lock()
+                .as_ref()
+                .map_or(Cow::Borrowed(""), |loc| Cow::Owned(loc.name().into_owned()))
         } else {
-            self.entry.name()
+            Cow::Borrowed(self.entry.name())
         }
     }
 
@@ -281,8 +336,16 @@ impl Location {
             return Err(VfsError::ResourceBusy);
         }
         assert!(self.entry.ptr_eq(&self.mountpoint.root));
+
+        // Flush filesystem metadata (superblock, bitmaps, etc.) to the
+        // backing block device before tearing down the mount.  For ext4
+        // this writes a clean superblock so the next mount does not see
+        // s_state = ERROR_FS.  For tmpfs/ramfs the default flush is a
+        // no-op.
+        self.filesystem().flush()?;
+
         self.entry.as_dir()?.forget();
-        if let Some(parent_loc) = &self.mountpoint.location {
+        if let Some(parent_loc) = self.mountpoint.location.lock().as_ref() {
             *parent_loc.entry.as_dir()?.mountpoint.lock() = None;
         }
         Ok(())

--- a/components/rsext4/src/ext4/mount.rs
+++ b/components/rsext4/src/ext4/mount.rs
@@ -236,6 +236,13 @@ impl Ext4FileSystem {
                 // on-disk state.
                 fs.reload_after_journal_replay(block_dev)?;
             }
+            // If the filesystem was created without a journal (e.g. small images
+            // where mkfs.ext4 omits it), disable journal_use so that metadata
+            // writes bypass the journal path instead of hitting the
+            // "system uninitialized" guard on every write.
+            if !fs.superblock.has_journal() {
+                block_dev.set_journal_use(false);
+            }
         }
 
         // Emit a one-shot bitmap usage summary and verify bitmap checksums on

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -15,6 +15,7 @@ license.workspace = true
 
 [features]
 dev-log = []
+ext4 = ["ax-fs/ext4"]
 input = ["dep:ax-input", "ax-feat/input"]
 memtrack = ["ax-feat/dwarf", "ax-alloc/tracking", "dep:gimli"]
 rknpu = ["dep:axplat-dyn", "axplat-dyn/rknpu"]

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -28,7 +28,7 @@ pub fn init(args: &[String], envs: &[String]) {
     let path = loc
         .absolute_path()
         .expect("Failed to get executable absolute path");
-    let name = loc.name();
+    let name = loc.name().into_owned();
 
     let mut uspace = new_user_aspace_empty()
         .and_then(|mut it| {
@@ -41,7 +41,7 @@ pub fn init(args: &[String], envs: &[String]) {
         .unwrap_or_else(|e| panic!("Failed to load user app: {}", e));
 
     let uctx = UserContext::new(entry_vaddr.into(), ustack_top, 0);
-    let mut task = new_user_task(name, uctx, 0);
+    let mut task = new_user_task(&name, uctx, 0);
     task.ctx_mut().set_page_table_root(uspace.page_table_root());
 
     let pid = task.id().as_u64() as Pid;

--- a/os/StarryOS/kernel/src/pseudofs/dev/loop.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/loop.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ext4")]
+use alloc::{boxed::Box, sync::Arc};
 use core::{
     any::Any,
     sync::atomic::{AtomicBool, AtomicU32, Ordering},
@@ -5,11 +7,19 @@ use core::{
 
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_fs::FileBackend;
+#[cfg(feature = "ext4")]
+use ax_kspin::SpinNoPreempt;
 use ax_sync::Mutex;
 use axfs_ng_vfs::{DeviceId, NodeFlags, VfsResult};
 use linux_raw_sys::{
-    ioctl::{BLKGETSIZE, BLKGETSIZE64, BLKRAGET, BLKRASET, BLKROGET, BLKROSET},
-    loop_device::{LOOP_CLR_FD, LOOP_GET_STATUS, LOOP_SET_FD, LOOP_SET_STATUS, loop_info},
+    ioctl::{
+        BLKFLSBUF, BLKGETSIZE, BLKGETSIZE64, BLKIOMIN, BLKIOOPT, BLKPG, BLKRAGET, BLKRASET,
+        BLKROGET, BLKROSET, BLKRRPART, BLKSSZGET,
+    },
+    loop_device::{
+        LOOP_CLR_FD, LOOP_CONFIGURE, LOOP_GET_STATUS, LOOP_GET_STATUS64, LOOP_SET_FD,
+        LOOP_SET_STATUS, LOOP_SET_STATUS64, loop_config, loop_info, loop_info64,
+    },
 };
 use starry_vm::{VmMutPtr, VmPtr};
 
@@ -17,6 +27,168 @@ use crate::{
     file::get_file_like,
     pseudofs::{DeviceMmap, DeviceOps},
 };
+
+/// HDIO_GETGEO ioctl command (get drive geometry).
+/// Not defined in linux-raw-sys, so we use the standard value directly.
+const HDIO_GETGEO: u32 = 0x0301;
+
+#[cfg(feature = "ext4")]
+/// Write `data` back to `file` starting at offset 0, then sync.
+///
+/// Returns `true` if the entire buffer was written and synced successfully.
+/// On failure the caller should **not** clear the dirty flag so that
+/// subsequent flush attempts (detach, re-mount, BLKFLSBUF) can retry.
+fn writeback_data(file: &FileBackend, data: &[u8]) -> bool {
+    let mut offset: u64 = 0;
+    while offset < data.len() as u64 {
+        match file.write_at(&data[offset as usize..], offset) {
+            Ok(0) => {
+                warn!("LoopDevice: writeback stalled at {offset}");
+                return false;
+            }
+            Ok(n) => offset += n as u64,
+            Err(e) => {
+                warn!("LoopDevice: writeback err at {offset}: {e:?}");
+                return false;
+            }
+        }
+    }
+    if let Err(e) = file.sync(true) {
+        warn!("LoopDevice: writeback sync failed: {e:?}");
+        return false;
+    }
+    true
+}
+
+/// Shared cache data backing a `LoopBlockDevice`.
+///
+/// Owning an `Arc<CacheData>` keeps the buffer alive even if the
+/// `LoopDevice` replaces its cache slot (e.g. on re-mount).
+///
+/// The buffer is protected by a `SpinNoPreempt` lock.  Both block-device
+/// I/O (`read_block`/`write_block`, already under ext4's SpinNoPreempt)
+/// and write-back paths (normal syscall context) acquire this lock,
+/// so no concurrent access is possible regardless of mount state.
+#[cfg(feature = "ext4")]
+struct CacheData {
+    buffer: SpinNoPreempt<alloc::vec::Vec<u8>>,
+    dirty: AtomicBool,
+    /// `true` while a `LoopBlockDevice` referencing this cache is alive.
+    mounted: AtomicBool,
+}
+
+#[cfg(feature = "ext4")]
+impl CacheData {
+    fn new(data: alloc::vec::Vec<u8>) -> Self {
+        Self {
+            buffer: SpinNoPreempt::new(data),
+            dirty: AtomicBool::new(false),
+            mounted: AtomicBool::new(false),
+        }
+    }
+}
+
+/// Adapter that wraps a LoopDevice's file backend as a block device.
+///
+/// This allows ext4 (or other filesystem drivers) to use a loop device as
+/// backing storage by converting offset-based I/O to block-based I/O.
+///
+/// The adapter holds an `Arc<CacheData>` so the buffer remains valid even if
+/// the `LoopDevice`'s cache slot is later replaced (e.g. on re-mount while
+/// old filesystem references still exist).  The old adapter keeps its buffer
+/// alive through the Arc — no use-after-free.
+///
+/// Write-back happens in three places:
+///   - `LOOP_CLR_FD` (losetup -d): writes back and clears the cache
+///   - `as_dyn_block_device()` (re-mount): writes back before re-reading
+///   - `BLKFLSBUF` ioctl: explicit flush
+///
+/// All three run in normal syscall context where VFS I/O is safe.
+/// The `flush()` callback is intentionally a no-op because ext4 invokes it
+/// inside `SpinNoPreempt`.
+#[cfg(feature = "ext4")]
+pub struct LoopBlockDevice {
+    cache: Arc<CacheData>,
+    block_size: usize,
+}
+
+#[cfg(feature = "ext4")]
+impl LoopBlockDevice {
+    /// Create a new block device adapter backed by the given `CacheData`.
+    fn new(cache: Arc<CacheData>) -> VfsResult<Self> {
+        cache.mounted.store(true, Ordering::Release);
+        Ok(Self {
+            cache,
+            block_size: 512,
+        })
+    }
+}
+
+#[cfg(feature = "ext4")]
+impl Drop for LoopBlockDevice {
+    fn drop(&mut self) {
+        self.cache.mounted.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(feature = "ext4")]
+impl ax_driver::prelude::BaseDriverOps for LoopBlockDevice {
+    fn device_name(&self) -> &str {
+        "loop"
+    }
+
+    fn device_type(&self) -> ax_driver::prelude::DeviceType {
+        ax_driver::prelude::DeviceType::Block
+    }
+}
+
+#[cfg(feature = "ext4")]
+impl ax_driver::prelude::BlockDriverOps for LoopBlockDevice {
+    fn num_blocks(&self) -> u64 {
+        self.cache.buffer.lock().len() as u64 / self.block_size as u64
+    }
+
+    fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> ax_driver::prelude::DevResult {
+        let data = self.cache.buffer.lock();
+        let offset = block_id as usize * self.block_size;
+        let end = offset + buf.len();
+        if end > data.len() {
+            return Err(ax_driver::prelude::DevError::Io);
+        }
+        buf.copy_from_slice(&data[offset..end]);
+        Ok(())
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> ax_driver::prelude::DevResult {
+        let mut data = self.cache.buffer.lock();
+        let offset = block_id as usize * self.block_size;
+        let end = offset + buf.len();
+        if end > data.len() {
+            return Err(ax_driver::prelude::DevError::Io);
+        }
+        data[offset..end].copy_from_slice(buf);
+        self.cache.dirty.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> ax_driver::prelude::DevResult {
+        // Intentionally a no-op.  ext4 calls this from inside SpinNoPreempt
+        // where sleeping VFS I/O would panic.  Dirty data is written back in
+        // LOOP_CLR_FD (losetup -d), BLKFLSBUF, or after umount — all in
+        // normal syscall context.
+        Ok(())
+    }
+}
+
+/// Block-device data cache owned by the LoopDevice.
+#[cfg(feature = "ext4")]
+struct BlockCache {
+    data: Option<Arc<CacheData>>,
+}
 
 /// /dev/loopX devices
 pub struct LoopDevice {
@@ -28,6 +200,12 @@ pub struct LoopDevice {
     pub ro: AtomicBool,
     /// Read-ahead size for the loop device, in bytes.
     pub ra: AtomicU32,
+    /// Backing file name for the loop device.
+    file_name: Mutex<[u8; 64]>,
+    /// Block-device data cache.  Populated by `as_dyn_block_device()`,
+    /// written back and cleared by `LOOP_CLR_FD`.
+    #[cfg(feature = "ext4")]
+    block_cache: Mutex<BlockCache>,
 }
 
 impl LoopDevice {
@@ -38,6 +216,9 @@ impl LoopDevice {
             file: Mutex::new(None),
             ro: AtomicBool::new(false),
             ra: AtomicU32::new(512),
+            file_name: Mutex::new([0u8; 64]),
+            #[cfg(feature = "ext4")]
+            block_cache: Mutex::new(BlockCache { data: None }),
         }
     }
 
@@ -49,6 +230,15 @@ impl LoopDevice {
         let mut res: loop_info = unsafe { core::mem::zeroed() };
         res.lo_number = self.number as _;
         res.lo_rdevice = self.dev_id.0 as _;
+        let name = self.file_name.lock();
+        for (i, &c) in name.iter().enumerate() {
+            if i < 64 {
+                res.lo_name[i] = c as _;
+            }
+            if c == 0 {
+                break;
+            }
+        }
         Ok(res)
     }
 
@@ -57,10 +247,101 @@ impl LoopDevice {
         Ok(())
     }
 
+    /// Get information about the loop device (64-bit variant).
+    pub fn get_info64(&self) -> AxResult<loop_info64> {
+        if self.file.lock().is_none() {
+            return Err(AxError::from(LinuxError::ENXIO));
+        }
+        let mut res: loop_info64 = unsafe { core::mem::zeroed() };
+        res.lo_number = self.number as _;
+        res.lo_rdevice = self.dev_id.0 as _;
+        res.lo_file_name = *self.file_name.lock();
+        Ok(res)
+    }
+
     /// Clone the underlying file of the loop device.
     pub fn clone_file(&self) -> VfsResult<FileBackend> {
         let file = self.file.lock().clone();
         file.ok_or(AxError::from(LinuxError::ENXIO))
+    }
+
+    /// Create a boxed block device adapter from this loop device.
+    ///
+    /// Returns `Err` if no file is attached to the loop device.
+    ///
+    /// If a previous `CacheData` still has outstanding `Arc` references from
+    /// an old (unmounted) filesystem, those references keep the old buffer
+    /// alive — no use-after-free.  The new adapter gets a fresh `CacheData`
+    /// re-read from the backing file.
+    #[cfg(feature = "ext4")]
+    pub fn as_dyn_block_device(&self) -> VfsResult<Box<dyn ax_driver::prelude::BlockDriverOps>> {
+        let file = self.file.lock().clone();
+        let file = file.ok_or(AxError::from(LinuxError::ENXIO))?;
+
+        // Write back any dirty cache before re-reading the backing file.
+        // This covers the scenario: mount -> write -> umount -> mount again
+        // (without losetup -d), where the in-memory writes must be persisted
+        // to the backing file before we reload from it.
+        {
+            let cache = self.block_cache.lock();
+            #[allow(clippy::collapsible_if)]
+            if let Some(ref cd) = cache.data
+                && cd.dirty.load(Ordering::Acquire)
+            {
+                let data = cd.buffer.lock().clone();
+                if writeback_data(&file, &data) {
+                    cd.dirty.store(false, Ordering::Release);
+                }
+            }
+        }
+
+        // Read the entire backing file into the block cache.
+        let len = file.location().len().unwrap_or(0) as usize;
+        let mut data = alloc::vec![0u8; len];
+        if len > 0 {
+            let n = file.read_at(&mut data[..], 0)?;
+            if n != len {
+                warn!("LoopDevice: short read {n}/{len} bytes from backing file");
+                return Err(AxError::Io);
+            }
+        }
+
+        // Store in block_cache.  Any outstanding Arc<CacheData> held by an
+        // old (unmounted) filesystem keeps the old buffer alive independently;
+        // the new adapter owns the fresh Arc and the two never alias.
+        let mut cache = self.block_cache.lock();
+        let cd = Arc::new(CacheData::new(data));
+        cache.data = Some(cd.clone());
+        drop(cache);
+
+        Ok(Box::new(LoopBlockDevice::new(cd)?))
+    }
+
+    /// Write back dirty block-cache data to the backing file.
+    ///
+    /// Called after `unmount` in normal syscall context where VFS I/O is
+    /// safe, so that data is persisted without requiring an explicit
+    /// `losetup -d` or `BLKFLSBUF`.
+    #[cfg(feature = "ext4")]
+    pub fn flush_cache_to_file(&self) {
+        let file = self.file.lock().clone();
+        let cache = self.block_cache.lock();
+        if let Some(ref cd) = cache.data {
+            // Mark as no longer actively mounted — called after unmount so
+            // no further write_block calls are possible.  This allows
+            // LOOP_CLR_FD to proceed with detach.
+            cd.mounted.store(false, Ordering::Release);
+
+            #[allow(clippy::collapsible_if)]
+            if cd.dirty.load(Ordering::Acquire)
+                && let Some(ref file) = file
+            {
+                let data = cd.buffer.lock().clone();
+                if writeback_data(file, &data) {
+                    cd.dirty.store(false, Ordering::Release);
+                }
+            }
+        }
     }
 }
 
@@ -103,7 +384,44 @@ impl DeviceOps for LoopDevice {
                 if guard.is_none() {
                     return Err(AxError::from(LinuxError::ENXIO));
                 }
+
+                // Write back dirty data from the block cache before clearing.
+                // This runs in normal syscall context so CachedFile VFS I/O
+                // (page cache updates) is safe.  The SpinNoPreempt lock
+                // ensures no concurrent write_block() can race.
+                #[cfg(feature = "ext4")]
+                {
+                    let cache = self.block_cache.lock();
+                    // If a LoopBlockDevice is still alive (mounted), refuse to
+                    // detach — the old Arc<CacheData> would keep receiving
+                    // write_block calls but the backing file would be gone,
+                    // causing silent data loss on umount.
+                    if let Some(ref cd) = cache.data
+                        && cd.mounted.load(Ordering::Acquire)
+                    {
+                        return Err(AxError::from(LinuxError::EBUSY));
+                    }
+
+                    if let Some(ref cd) = cache.data
+                        && cd.dirty.load(Ordering::Acquire)
+                    {
+                        if let Some(ref file) = *guard {
+                            let data = cd.buffer.lock().clone();
+                            if !writeback_data(file, &data) {
+                                warn!(
+                                    "LoopDevice: writeback failed on LOOP_CLR_FD, data may be lost"
+                                );
+                                return Err(AxError::Io);
+                            }
+                        }
+                        cd.dirty.store(false, Ordering::Release);
+                    }
+                    drop(cache);
+                    self.block_cache.lock().data = None;
+                }
+
                 *guard = None;
+                *self.file_name.lock() = [0u8; 64];
             }
             LOOP_GET_STATUS => {
                 (arg as *mut loop_info).vm_write(self.get_info()?)?;
@@ -112,6 +430,42 @@ impl DeviceOps for LoopDevice {
                 // FIXME: AnyBitPattern
                 let info = unsafe { (arg as *const loop_info).vm_read_uninit()?.assume_init() };
                 self.set_info(info)?;
+                let mut name = self.file_name.lock();
+                for (i, &c) in info.lo_name.iter().enumerate() {
+                    if i < 64 {
+                        name[i] = c as u8;
+                    }
+                    if c == 0 {
+                        break;
+                    }
+                }
+            }
+            LOOP_GET_STATUS64 => {
+                (arg as *mut loop_info64).vm_write(self.get_info64()?)?;
+            }
+            LOOP_SET_STATUS64 => {
+                // FIXME: AnyBitPattern
+                let info = unsafe { (arg as *const loop_info64).vm_read_uninit()?.assume_init() };
+                *self.file_name.lock() = info.lo_file_name;
+            }
+            LOOP_CONFIGURE => {
+                // FIXME: AnyBitPattern
+                let cfg = unsafe { (arg as *const loop_config).vm_read_uninit()?.assume_init() };
+                let fd = cfg.fd as i32;
+                if fd < 0 {
+                    return Err(AxError::BadFileDescriptor);
+                }
+                let f = get_file_like(fd)?;
+                let Some(file) = f.downcast_ref::<crate::file::File>() else {
+                    return Err(AxError::InvalidInput);
+                };
+                let mut guard = self.file.lock();
+                if guard.is_some() {
+                    return Err(AxError::ResourceBusy);
+                }
+                *guard = Some(file.inner().backend()?.clone());
+                drop(guard);
+                *self.file_name.lock() = cfg.info.lo_file_name;
             }
             // TODO: the following should apply to any block devices
             BLKGETSIZE | BLKGETSIZE64 => {
@@ -139,6 +493,73 @@ impl DeviceOps for LoopDevice {
             BLKRASET => {
                 self.ra
                     .store((arg as *const u32).vm_read()? as _, Ordering::Relaxed);
+            }
+            BLKRRPART => {
+                // loop device has no physical partition table; no-op
+            }
+            BLKPG => {
+                // partition manipulation not supported on loop devices
+                return Err(AxError::from(LinuxError::ENOTTY));
+            }
+            BLKFLSBUF => {
+                // Flush dirty block cache back to the backing file.
+                #[cfg(feature = "ext4")]
+                {
+                    let file = self.file.lock().clone();
+                    let cache = self.block_cache.lock();
+                    #[allow(clippy::collapsible_if)]
+                    if let Some(ref cd) = cache.data
+                        && cd.dirty.load(Ordering::Acquire)
+                        && let Some(ref file) = file
+                    {
+                        let data = cd.buffer.lock().clone();
+                        if writeback_data(file, &data) {
+                            cd.dirty.store(false, Ordering::Release);
+                        }
+                    }
+                }
+            }
+            BLKSSZGET => {
+                // get logical block size
+                (arg as *mut u32).vm_write(512)?;
+            }
+            BLKIOMIN => {
+                // minimum I/O size
+                (arg as *mut u32).vm_write(512)?;
+            }
+            BLKIOOPT => {
+                // optimal I/O size
+                (arg as *mut u32).vm_write(512)?;
+            }
+            // HDIO_GETGEO: virtual CHS geometry for fdisk
+            HDIO_GETGEO => {
+                let size = match self.file.lock().clone() {
+                    Some(f) => f.location().len().unwrap_or(0),
+                    None => 0,
+                };
+                // hd_geometry: { u8 heads, u8 sectors, u16 cylinders, unsigned long start }
+                // On 64-bit targets unsigned long is 8 bytes.
+                let heads: u8 = 64;
+                let sectors: u8 = 32;
+                let cyl = if size > 0 {
+                    (size / (heads as u64 * sectors as u64 * 512)) as u16
+                } else {
+                    0
+                };
+                #[repr(C)]
+                struct HdGeometry {
+                    heads: u8,
+                    sectors: u8,
+                    cylinders: u16,
+                    start: u64,
+                }
+                let geo = HdGeometry {
+                    heads,
+                    sectors,
+                    cylinders: cyl,
+                    start: 0,
+                };
+                (arg as *mut HdGeometry).vm_write(geo)?;
             }
             _ => {
                 warn!("unknown ioctl for loop device: {cmd}");

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -14,6 +14,8 @@ mod fb;
 #[cfg(feature = "dev-log")]
 mod log;
 mod r#loop;
+#[cfg(feature = "ext4")]
+pub use r#loop::LoopDevice;
 #[cfg(feature = "memtrack")]
 mod memtrack;
 mod rtc;
@@ -324,9 +326,9 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         root.add("dri", SimpleDir::new_maker(fs.clone(), Arc::new(dri_dir)));
     }
 
-    // Loop devices
+    // Loop devices (major 7, minor = device index)
     for i in 0..16 {
-        let dev_id = DeviceId::new(7, 0);
+        let dev_id = DeviceId::new(7, i);
         root.add(
             format!("loop{i}"),
             Device::new(

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -17,22 +17,171 @@ pub fn sys_mount(
     let fs_type = vm_load_string(fs_type)?;
     debug!("sys_mount <= source: {source:?}, target: {target:?}, fs_type: {fs_type:?}");
 
-    if fs_type != "tmpfs" {
-        return Err(AxError::NoSuchDevice);
+    match fs_type.as_str() {
+        "tmpfs" => {
+            let fs = MemoryFs::new();
+            let target = FS_CONTEXT.lock().resolve(target)?;
+            target.mount(&fs)?;
+        }
+        #[cfg(feature = "ext4")]
+        "ext4" => {
+            mount_ext4(&source, &target)?;
+        }
+        _ => return Err(AxError::NoSuchDevice),
     }
-
-    let fs = MemoryFs::new();
-
-    let target = FS_CONTEXT.lock().resolve(target)?;
-    target.mount(&fs)?;
 
     Ok(0)
 }
 
+#[cfg(feature = "ext4")]
+fn mount_ext4(source: &str, target: &str) -> AxResult<()> {
+    use alloc::{boxed::Box, sync::Arc};
+
+    use ax_driver::prelude::BlockDriverOps;
+
+    let ctx = FS_CONTEXT.lock();
+
+    // Resolve source device path (e.g., "/dev/loop0") to a block device
+    let source_loc = ctx.resolve(source)?;
+    let device = source_loc
+        .entry()
+        .downcast::<crate::pseudofs::Device>()
+        .map_err(|_| {
+            warn!("mount_ext4: {:?} is not a device", source);
+            AxError::NoSuchDevice
+        })?;
+    let loop_dev = device
+        .inner()
+        .as_any()
+        .downcast_ref::<crate::pseudofs::dev::LoopDevice>()
+        .ok_or_else(|| {
+            warn!("mount_ext4: {:?} is not a loop device", source);
+            AxError::NoSuchDevice
+        })?;
+    let block_dev = loop_dev.as_dyn_block_device().map_err(|e| {
+        warn!("mount_ext4: loop device has no backing file: {:?}", e);
+        AxError::Io
+    })?;
+
+    let num_blocks = block_dev.num_blocks();
+    let region = ax_driver::PartitionRegion::from_num_blocks(num_blocks);
+
+    // Create ext4 filesystem from the dynamic block device
+    let fs = ax_fs::new_filesystem_from_dyn(block_dev, region).map_err(|e| {
+        warn!("mount_ext4: failed to create ext4 filesystem: {:?}", e);
+        AxError::Io
+    })?;
+
+    // Mount at the target location
+    let target_loc = ctx.resolve(target)?;
+    target_loc.mount(&fs).map_err(|e| {
+        warn!("mount_ext4: failed to mount at {:?}: {:?}", target, e);
+        AxError::Io
+    })?;
+
+    // Store a writeback callback in the mount root's user_data so that
+    // sys_umount2 can flush the loop device's block cache to the backing
+    // file after the filesystem is unmounted.
+    let ops: Arc<dyn crate::pseudofs::DeviceOps> = device.inner().clone();
+    {
+        let mount_root = ctx.resolve(target)?;
+        mount_root.user_data().insert(Box::new(move || {
+            if let Some(ld) = ops
+                .as_any()
+                .downcast_ref::<crate::pseudofs::dev::LoopDevice>()
+            {
+                ld.flush_cache_to_file();
+            }
+        }) as Box<dyn Fn() + Send + Sync>);
+    }
+
+    Ok(())
+}
+
 pub fn sys_umount2(target: *const c_char, _flags: i32) -> AxResult<isize> {
+    use alloc::boxed::Box;
+
     let target = vm_load_string(target)?;
     debug!("sys_umount2 <= target: {target:?}");
     let target = FS_CONTEXT.lock().resolve(target)?;
+
+    // Retrieve the writeback callback (if any) before unmount tears down
+    // the mount.  For ext4-on-loop mounts this flushes the block device
+    // cache to the backing file after the filesystem is unmounted; for
+    // other filesystem types (tmpfs) the callback is absent.
+    let writeback = {
+        let ud = target.user_data();
+        ud.get::<Box<dyn Fn() + Send + Sync>>()
+    }; // user_data lock released
+
     target.unmount()?;
+
+    // After unmount the SpinNoPreempt lock inside ext4 is released; safe
+    // to do VFS I/O here.
+    if let Some(cb) = writeback {
+        cb();
+    }
+
+    Ok(0)
+}
+
+pub fn sys_pivot_root(new_root: *const c_char, put_old: *const c_char) -> AxResult<isize> {
+    let new_root = vm_load_string(new_root)?;
+    let put_old = vm_load_string(put_old)?;
+    debug!(
+        "sys_pivot_root <= new_root: {:?}, put_old: {:?}",
+        new_root, put_old
+    );
+
+    // Validate: put_old must be under new_root
+    if !put_old.starts_with(&new_root) {
+        return Err(AxError::InvalidInput);
+    }
+    // new_root cannot be "/"
+    if new_root == "/" {
+        return Err(AxError::InvalidInput);
+    }
+
+    let mut ctx = FS_CONTEXT.lock();
+
+    // Resolve paths
+    let new_root_loc = ctx.resolve(&new_root)?;
+
+    // Both must be directories
+    new_root_loc.check_is_dir()?;
+    let put_old_loc = ctx.resolve(&put_old)?;
+    put_old_loc.check_is_dir()?;
+
+    // new_root must be the root of a non-root mount (i.e. the root of a
+    // filesystem mounted somewhere, not the global root).  Because path
+    // resolution crosses mount boundaries transparently, the resolved
+    // Location is the *root entry* of the mounted filesystem, so we check
+    // is_root_of_mount + the mountpoint is not the global root.
+    if !(new_root_loc.is_root_of_mount() && !new_root_loc.mountpoint().is_root()) {
+        warn!(
+            "sys_pivot_root: new_root {:?} is not the root of a mounted filesystem",
+            new_root
+        );
+        return Err(AxError::InvalidInput);
+    }
+
+    // Capture the old root Location BEFORE the pivot, so that we can
+    // propagate the change to every other task afterwards (Linux
+    // chroot_fs_refs semantics).  We save the full Location (mountpoint +
+    // dentry) rather than just the mountpoint, so that tasks chroot'd
+    // into a subdirectory of the old root are not incorrectly updated.
+    let old_root = ctx.root_dir().clone();
+
+    // Perform pivot: swap the root mount (updates this task's FsContext).
+    ctx.pivot_root(new_root_loc, put_old_loc)?;
+
+    let new_root_loc = ctx.root_dir().clone();
+    drop(ctx); // Release this task's lock before touching others.
+
+    // Propagate root / cwd to all other tasks whose root_dir or current_dir
+    // exactly matches the old root Location — mirroring Linux
+    // chroot_fs_refs() in fs/namespace.c.
+    ax_fs::FsContext::propagate_pivot_root(&old_root, &new_root_loc);
+
     Ok(0)
 }

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -292,6 +292,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg4() as _,
         ) as _,
         Sysno::umount2 => sys_umount2(uctx.arg0() as _, uctx.arg1() as _) as _,
+        Sysno::pivot_root => sys_pivot_root(uctx.arg0() as _, uctx.arg1() as _) as _,
 
         // pipe
         Sysno::pipe2 => sys_pipe2(uctx.arg0() as _, uctx.arg1() as _),

--- a/os/StarryOS/kernel/src/syscall/task/execve.rs
+++ b/os/StarryOS/kernel/src/syscall/task/execve.rs
@@ -59,7 +59,7 @@ pub fn sys_execve(
     drop(aspace);
 
     let loc = FS_CONTEXT.lock().resolve(&path)?;
-    curr.set_name(loc.name());
+    curr.set_name(&loc.name());
 
     *proc_data.exe_path.write() = loc.absolute_path()?.to_string();
     *proc_data.cmdline.write() = Arc::new(args);

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -42,7 +42,7 @@ path = "xtask/main.rs"
 [dependencies]
 ax-feat = { workspace = true, features = ["fs-ng-times", "irq"] }
 axplat-dyn = { workspace = true, optional = true }
-starry-kernel = { workspace = true, features = ["dev-log"] }
+starry-kernel = { workspace = true, features = ["dev-log", "ext4"] }
 
 [target.'cfg(any(windows,unix))'.dependencies]
 anyhow = "1.0"

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/fs.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/fs.rs
@@ -1,12 +1,12 @@
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc};
 use core::cell::OnceCell;
 
-use ax_driver::{AxBlockDevice, PartitionRegion};
+use ax_driver::{AxBlockDevice, PartitionRegion, prelude::BlockDriverOps};
 use ax_kspin::{SpinNoPreempt as Mutex, SpinNoPreemptGuard as MutexGuard};
 use axfs_ng_vfs::{
     DirEntry, DirNode, Filesystem, FilesystemOps, Reference, StatFs, VfsResult, path::MAX_NAME_LEN,
 };
-use rsext4::{Jbd2Dev, bmalloc::InodeNumber};
+use rsext4::{Jbd2Dev, bmalloc::InodeNumber, superblock::Ext4Superblock};
 
 use super::{Ext4Disk, Inode, util::into_vfs_err};
 
@@ -31,7 +31,16 @@ pub struct Ext4Filesystem {
 }
 
 impl Ext4Filesystem {
+    /// Create from a compile-time block device (e.g. VirtIO root device).
     pub fn new(dev: AxBlockDevice, region: PartitionRegion) -> VfsResult<Filesystem> {
+        Self::new_from_boxed(Box::new(dev) as Box<dyn BlockDriverOps>, region)
+    }
+
+    /// Create from a dynamic (boxed) block device (e.g. loop device).
+    pub fn new_from_boxed(
+        dev: Box<dyn BlockDriverOps>,
+        region: PartitionRegion,
+    ) -> VfsResult<Filesystem> {
         let mut dev = Jbd2Dev::initial_jbd2dev(0, Ext4Disk::new(dev, region), true);
         let fs = rsext4::mount(&mut dev).map_err(into_vfs_err)?;
 
@@ -63,6 +72,9 @@ impl Ext4Filesystem {
         fs.datablock_cache.flush_all(dev).map_err(into_vfs_err)?;
         fs.bitmap_cache.flush_all(dev).map_err(into_vfs_err)?;
         fs.inodetable_cahce.flush_all(dev).map_err(into_vfs_err)?;
+        // Mark the filesystem clean before writing the superblock so the
+        // on-disk state reflects a clean sync / unmount.
+        fs.superblock.s_state = Ext4Superblock::EXT4_VALID_FS;
         fs.sync_superblock(dev).map_err(into_vfs_err)?;
         fs.sync_group_descriptors(dev).map_err(into_vfs_err)?;
         if dev.is_use_journal() {

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/mod.rs
@@ -2,7 +2,9 @@ mod fs;
 mod inode;
 mod util;
 
-use ax_driver::{AxBlockDevice, PartitionBlockDevice, PartitionRegion, prelude::BlockDriverOps};
+use alloc::boxed::Box;
+
+use ax_driver::{PartitionBlockDevice, PartitionRegion, prelude::BlockDriverOps};
 pub use fs::*;
 pub use inode::*;
 use rsext4::{
@@ -13,10 +15,10 @@ use rsext4::{
     error::{Ext4Error, Ext4Result},
 };
 
-pub(crate) struct Ext4Disk(PartitionBlockDevice<AxBlockDevice>);
+pub(crate) struct Ext4Disk(PartitionBlockDevice<Box<dyn BlockDriverOps>>);
 
 impl Ext4Disk {
-    pub(crate) const fn new(dev: AxBlockDevice, region: PartitionRegion) -> Self {
+    pub fn new(dev: Box<dyn BlockDriverOps>, region: PartitionRegion) -> Self {
         Self(PartitionBlockDevice::new(dev, region))
     }
 }

--- a/os/arceos/modules/axfs-ng/src/fs/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "ext4")]
+use alloc::boxed::Box;
+
+#[cfg(feature = "ext4")]
+use ax_driver::prelude::BlockDriverOps;
 use ax_driver::{AxBlockDevice, PartitionRegion};
 use axfs_ng_vfs::{Filesystem, VfsResult};
 
@@ -18,6 +23,19 @@ cfg_if::cfg_if! {
     }
 }
 
+/// Create a filesystem instance from a block device.
 pub fn new_default(dev: AxBlockDevice, region: PartitionRegion) -> VfsResult<Filesystem> {
     DefaultFilesystem::new(dev, region)
+}
+
+/// Create a filesystem instance from a dynamic (boxed) block device.
+///
+/// Use this for loop devices and other block backends that don't match
+/// the compile-time `AxBlockDevice` type alias.
+#[cfg(feature = "ext4")]
+pub fn new_from_dyn(
+    dev: Box<dyn BlockDriverOps>,
+    region: PartitionRegion,
+) -> VfsResult<Filesystem> {
+    ext4::Ext4Filesystem::new_from_boxed(dev, region)
 }

--- a/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
@@ -2,7 +2,7 @@ use alloc::{
     borrow::{Cow, ToOwned},
     collections::vec_deque::VecDeque,
     string::String,
-    sync::Arc,
+    sync::{Arc, Weak},
     vec::Vec,
 };
 
@@ -22,15 +22,32 @@ pub const SYMLINKS_MAX: usize = 40;
 /// Global root filesystem context, initialized once during [`init_filesystems`](crate::init_filesystems).
 pub static ROOT_FS_CONTEXT: Once<FsContext> = Once::new();
 
+/// Registry of all live `FsContext` instances (weak references).
+///
+/// Each time a task-local [`FS_CONTEXT`] is created, it registers its
+/// `Arc<Mutex<FsContext>>` here via [`register_fs_context`].  This allows
+/// [`FsContext::propagate_pivot_root`] to iterate over every task's
+/// filesystem context and apply the same root / cwd fixup that Linux
+/// performs in `chroot_fs_refs()` after `pivot_root(2)`.
+static FS_REGISTRY: spin::Mutex<Vec<Weak<Mutex<FsContext>>>> = spin::Mutex::new(Vec::new());
+
+/// Register an `FsContext` in the global [`FS_REGISTRY`].
+fn register_fs_context(ctx: &Arc<Mutex<FsContext>>) {
+    FS_REGISTRY.lock().push(Arc::downgrade(ctx));
+}
+
 scope_local::scope_local! {
     /// Task-local filesystem context, defaulting to a clone of [`ROOT_FS_CONTEXT`].
-    pub static FS_CONTEXT: Arc<Mutex<FsContext>> =
-        Arc::new(Mutex::new(
+    pub static FS_CONTEXT: Arc<Mutex<FsContext>> = {
+        let ctx = Arc::new(Mutex::new(
             ROOT_FS_CONTEXT
                 .get()
                 .expect("Root FS context not initialized")
                 .clone(),
         ));
+        register_fs_context(&ctx);
+        ctx
+    };
 }
 
 /// A single entry returned by [`FsContext::read_dir`].
@@ -182,7 +199,7 @@ impl FsContext {
         if let Some(name) = name {
             Ok((dir, Cow::Borrowed(name)))
         } else if let Some(parent) = dir.parent() {
-            Ok((parent, Cow::Owned(dir.name().to_owned())))
+            Ok((parent, dir.name().into_owned().into()))
         } else {
             Err(VfsError::InvalidInput)
         }
@@ -249,7 +266,7 @@ impl FsContext {
         entry
             .parent()
             .ok_or(VfsError::IsADirectory)?
-            .unlink(entry.name(), false)
+            .unlink(&entry.name(), false)
     }
 
     /// Removes a directory from the filesystem.
@@ -258,7 +275,7 @@ impl FsContext {
         entry
             .parent()
             .ok_or(VfsError::ResourceBusy)?
-            .unlink(entry.name(), true)
+            .unlink(&entry.name(), true)
     }
 
     /// Renames a file or directory to a new name, replacing the original file
@@ -324,6 +341,84 @@ impl FsContext {
     /// Returns the canonical, absolute form of a path.
     pub fn canonicalize(&self, path: impl AsRef<Path>) -> VfsResult<PathBuf> {
         self.resolve(path.as_ref())?.absolute_path()
+    }
+
+    /// Pivot the root filesystem to `new_root`, moving the old root to
+    /// `put_old` (which must be a directory under `new_root`).
+    ///
+    /// This follows Linux `pivot_root(2)` semantics: after the call the old
+    /// root filesystem is accessible at `put_old`, and can be unmounted from
+    /// there.
+    ///
+    /// Note: this method only updates **this** `FsContext`.  The caller must
+    /// invoke [`FsContext::propagate_pivot_root`] afterwards to update every
+    /// other task whose root / cwd still points at the old root, mirroring
+    /// Linux's `chroot_fs_refs()`.
+    pub fn pivot_root(&mut self, new_root: Location, put_old: Location) -> VfsResult<()> {
+        let old_root = self.root_dir.clone();
+        let old_root_mp = self.root_dir.mountpoint().clone();
+        let new_root_mp = new_root.mountpoint().clone();
+        old_root_mp.pivot_mount(&new_root_mp, &put_old)?;
+        let new_root_loc = new_root_mp.root_location();
+        self.root_dir = new_root_loc.clone();
+        // Only replace cwd if it was pointing at the old root — mirrors
+        // Linux's chroot_fs_refs / replace_path semantics.
+        if old_root.ptr_eq(&self.current_dir) {
+            self.current_dir = new_root_loc;
+        }
+        Ok(())
+    }
+
+    /// After a successful [`pivot_root`](Self::pivot_root), propagate the
+    /// root / cwd change to **all** other tasks in the same mount namespace.
+    ///
+    /// This mirrors `chroot_fs_refs()` in Linux's `fs/namespace.c`:
+    /// after `pivot_root(2)` reorganises the mount tree the kernel walks
+    /// every thread's `fs_struct` and switches any `root` / `pwd` that
+    /// pointed at the old root over to the new root.
+    ///
+    /// * `old_root` – the `Location` of the old root **before** the pivot
+    ///   (obtained from `ctx.root_dir().clone()` before calling
+    ///   [`pivot_root`](Self::pivot_root)).
+    /// * `new_root` – the `Location` of the new root **after** the pivot
+    ///   (obtained from `ctx.root_dir()` after calling
+    ///   [`pivot_root`](Self::pivot_root)).
+    ///
+    /// # Linux semantics
+    ///
+    /// For each registered `FsContext`, [`Location::ptr_eq`] is used to
+    /// compare both mountpoint **and** dentry, mirroring the kernel's
+    /// `replace_path()` check `fs->root.mnt == old_root->mnt &&
+    /// fs->root.dentry == old_root->dentry`:
+    /// - If `root_dir` is exactly `old_root` → set to `new_root`.
+    /// - If `current_dir` is exactly `old_root` → set to `new_root`.
+    ///
+    /// This avoids incorrectly updating tasks that have chroot'd into a
+    /// subdirectory of the old root (same mountpoint, different dentry).
+    pub fn propagate_pivot_root(old_root: &Location, new_root: &Location) {
+        // 1. Collect strong references while holding the registry lock, then
+        //    release it so we never nest two Mutex guards.
+        let refs: Vec<Arc<Mutex<FsContext>>> = {
+            let mut registry = FS_REGISTRY.lock();
+            registry.retain(|weak| weak.upgrade().is_some());
+            registry.iter().filter_map(|weak| weak.upgrade()).collect()
+        };
+
+        // 2. Walk every live FsContext and apply the same logic as
+        //    Linux chroot_fs_refs().
+        for ctx_arc in refs {
+            let mut ctx = ctx_arc.lock();
+
+            let update_root = old_root.ptr_eq(&ctx.root_dir);
+            let update_cwd = old_root.ptr_eq(&ctx.current_dir);
+
+            if update_root {
+                ctx.root_dir = new_root.clone();
+            }
+            if update_cwd {
+                ctx.current_dir = new_root.clone();
+            }
+        }
     }
 }
 

--- a/os/arceos/modules/axfs-ng/src/lib.rs
+++ b/os/arceos/modules/axfs-ng/src/lib.rs
@@ -27,6 +27,10 @@ use ax_driver::{
 mod fs;
 
 mod highlevel;
+
+/// Create a filesystem from a dynamic (boxed) block device.
+#[cfg(feature = "ext4")]
+pub use fs::new_from_dyn as new_filesystem_from_dyn;
 pub use highlevel::*;
 
 #[derive(Debug, Default)]

--- a/test-suit/starryos/normal/qemu-smp1/coreutils/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/coreutils/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(coreutils-test C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(coreutils-test src/main.c)
+target_compile_options(coreutils-test PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS coreutils-test RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/coreutils/c/prebuild.sh
+++ b/test-suit/starryos/normal/qemu-smp1/coreutils/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add coreutils

--- a/test-suit/starryos/normal/qemu-smp1/coreutils/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/coreutils/c/src/main.c
@@ -1,0 +1,724 @@
+/*
+ * coreutils-test.c -- GNU coreutils 9.x validation for StarryOS
+ *
+ * Key dependencies: stat, readlink, chmod, chown, mkfifo, mknod
+ * Acceptance criteria: ls -la /usr, cp -r, mv, rm -rf work correctly
+ *
+ * Note: BusyBox ash intercepts command names as built-in applets,
+ * bypassing coreutils symlinks.  For commands that need strict
+ * coreutils verification (e.g. stat -c), we use fork+exec+pipe
+ * to bypass the shell entirely.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdarg.h>
+
+static int pass = 0, fail = 0, skip = 0;
+
+/* Run a shell command via system(), return exit status (0-255) */
+static int run(const char *cmd)
+{
+    int ret = system(cmd);
+    if (WIFEXITED(ret))
+        return WEXITSTATUS(ret);
+    return -1;
+}
+
+/*
+ * Capture first line of a command's stdout into buf via popen().
+ * Returns length of captured line (>=0) or -1 on error.
+ */
+static int capture_first_line(const char *cmd, char *buf, int bufsz)
+{
+    FILE *p = popen(cmd, "r");
+    if (!p) return -1;
+    buf[0] = '\0';
+    if (!fgets(buf, bufsz, p)) { pclose(p); return -1; }
+    pclose(p);
+    int len = (int)strlen(buf);
+    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+        buf[--len] = '\0';
+    return len;
+}
+
+/*
+ * Execute a binary directly via fork+exec+pipe (bypasses BusyBox ash).
+ * Captures the first line of stdout into buf.
+ * Returns exit status (0-255) or -1 on error. Sets *outlen to captured length.
+ */
+static int exec_capture(const char *binary, char *buf, int bufsz, int *outlen, ...)
+{
+    va_list ap;
+    va_start(ap, outlen);
+
+    int pipefd[2];
+    if (pipe(pipefd) < 0) { va_end(ap); return -1; }
+
+    pid_t pid = fork();
+    if (pid < 0) { close(pipefd[0]); close(pipefd[1]); va_end(ap); return -1; }
+
+    if (pid == 0) {
+        close(pipefd[0]);
+        dup2(pipefd[1], STDOUT_FILENO);
+        dup2(pipefd[1], STDERR_FILENO);
+        close(pipefd[1]);
+
+        /* Build argv: binary, variadic args, NULL */
+        char *argv[16];
+        int i = 0;
+        argv[i++] = (char *)binary;
+        char *arg;
+        while ((arg = va_arg(ap, char *)) != NULL) {
+            if (i < 15) argv[i++] = arg;
+        }
+        argv[i] = NULL;
+        va_end(ap);
+
+        execv(binary, argv);
+        _exit(127);
+    }
+    va_end(ap);
+
+    close(pipefd[1]);
+    size_t total = 0;
+    ssize_t n;
+    while ((n = read(pipefd[0], buf + total, bufsz - 1 - total)) > 0) {
+        total += (size_t)n;
+        if (total >= (size_t)(bufsz - 1)) break;
+    }
+    close(pipefd[0]);
+    buf[total] = '\0';
+
+    /* Strip trailing newlines */
+    while (total > 0 && (buf[total - 1] == '\n' || buf[total - 1] == '\r'))
+        buf[--total] = '\0';
+
+    int status;
+    waitpid(pid, &status, 0);
+    if (outlen) *outlen = (int)total;
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    return -1;
+}
+
+/* Write data to a file, return 0 on success */
+static int write_file(const char *path, const char *data)
+{
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0) return -1;
+    size_t len = strlen(data);
+    ssize_t w = write(fd, data, len);
+    close(fd);
+    return (w == (ssize_t)len) ? 0 : -1;
+}
+
+/* Get file permission bits via C stat() */
+static int get_mode(const char *path, mode_t *mode)
+{
+    struct stat st;
+    if (stat(path, &st) < 0) return -1;
+    *mode = st.st_mode & 07777;
+    return 0;
+}
+
+/* Get file type string via C stat() */
+static int get_file_type(const char *path, char *buf, int bufsz)
+{
+    struct stat st;
+    if (stat(path, &st) < 0) return -1;
+    const char *type;
+    if (S_ISREG(st.st_mode))       type = "regular file";
+    else if (S_ISDIR(st.st_mode))  type = "directory";
+    else if (S_ISCHR(st.st_mode))  type = "character special file";
+    else if (S_ISBLK(st.st_mode))  type = "block special file";
+    else if (S_ISFIFO(st.st_mode)) type = "fifo";
+    else if (S_ISLNK(st.st_mode))  type = "symbolic link";
+    else type = "unknown";
+    strncpy(buf, type, bufsz - 1);
+    buf[bufsz - 1] = '\0';
+    return 0;
+}
+
+/* Check owner uid/gid via C stat() */
+static int get_owner(const char *path, uid_t *uid, gid_t *gid)
+{
+    struct stat st;
+    if (stat(path, &st) < 0) return -1;
+    *uid = st.st_uid;
+    *gid = st.st_gid;
+    return 0;
+}
+
+#define PASS(name) do { printf("  PASS | %s\n", name); pass++; } while(0)
+#define FAIL(name, ...) do { printf("  FAIL | %s ", name); printf(__VA_ARGS__); printf("\n"); fail++; } while(0)
+#define SKIP(name, ...) do { printf("  SKIP | %s ", name); printf(__VA_ARGS__); printf("\n"); skip++; } while(0)
+
+/* ==================================================================
+ *  Group 1: stat — /bin/stat is GNU coreutils (symlink → coreutils)
+ *  Use fork+exec to bypass BusyBox ash applet interception.
+ * ================================================================== */
+static void test_stat(void)
+{
+    printf("[stat]\n");
+    char buf[256];
+    int len;
+    int rc;
+
+    /* 1. stat default format: output contains "File:" and "Size:" */
+    rc = exec_capture("/bin/stat", buf, sizeof(buf), &len, "/etc/passwd", NULL);
+    if (rc == 0 && len > 0 && strstr(buf, "File:") != NULL) {
+        PASS("stat default format");
+    } else {
+        FAIL("stat default format", "(rc=%d len=%d output='%s')", rc, len, buf);
+    }
+
+    /* 2. stat -c '%s' returns file size (positive integer) */
+    rc = exec_capture("/bin/stat", buf, sizeof(buf), &len, "-c", "%s", "/etc/passwd", NULL);
+    if (rc == 0 && len > 0 && atoi(buf) > 0) {
+        PASS("stat -c %%s size");
+    } else {
+        FAIL("stat -c %%s size", "(rc=%d len=%d output='%s')", rc, len, buf);
+    }
+
+    /* 3. stat -c '%F' returns "regular file" */
+    rc = exec_capture("/bin/stat", buf, sizeof(buf), &len, "-c", "%F", "/etc/passwd", NULL);
+    if (rc == 0 && len > 0 && strcmp(buf, "regular file") == 0) {
+        PASS("stat -c %%F type");
+    } else {
+        FAIL("stat -c %%F type", "(rc=%d len=%d output='%s')", rc, len, buf);
+    }
+
+    /* 4. stat -c '%a' returns octal permissions */
+    rc = exec_capture("/bin/stat", buf, sizeof(buf), &len, "-c", "%a", "/etc/passwd", NULL);
+    if (rc == 0 && len > 0) {
+        char *end;
+        long val = strtol(buf, &end, 8);
+        if (*end == '\0' && val > 0 && val <= 07777) {
+            PASS("stat -c %%a perms");
+        } else {
+            FAIL("stat -c %%a perms", "(output='%s' not valid octal)", buf);
+        }
+    } else {
+        FAIL("stat -c %%a perms", "(rc=%d len=%d output='%s')", rc, len, buf);
+    }
+
+    /* 5. stat on directory: -c '%F' returns "directory" */
+    rc = exec_capture("/bin/stat", buf, sizeof(buf), &len, "-c", "%F", "/etc", NULL);
+    if (rc == 0 && len > 0 && strcmp(buf, "directory") == 0) {
+        PASS("stat -c %%F directory");
+    } else {
+        FAIL("stat -c %%F directory", "(rc=%d output='%s')", rc, buf);
+    }
+}
+
+/* ==================================================================
+ *  Group 2: readlink
+ * ================================================================== */
+static void test_readlink(void)
+{
+    printf("[readlink]\n");
+    char buf[256];
+
+    /* 1. Basic symlink read */
+    {
+        write_file("/tmp/cu_rlk_target", "hello");
+        unlink("/tmp/cu_rlk_link");
+        symlink("/tmp/cu_rlk_target", "/tmp/cu_rlk_link");
+
+        int rc = capture_first_line("readlink /tmp/cu_rlk_link", buf, sizeof(buf));
+        if (rc > 0 && strcmp(buf, "/tmp/cu_rlk_target") == 0) {
+            PASS("readlink basic");
+        } else {
+            FAIL("readlink basic", "(rc=%d output='%s')", rc, buf);
+        }
+        unlink("/tmp/cu_rlk_link");
+        unlink("/tmp/cu_rlk_target");
+    }
+
+    /* 2. readlink -f canonical path */
+    {
+        int rc = capture_first_line("readlink -f /etc/passwd", buf, sizeof(buf));
+        if (rc > 0 && strcmp(buf, "/etc/passwd") == 0) {
+            PASS("readlink -f canonical");
+        } else {
+            FAIL("readlink -f canonical", "(rc=%d output='%s')", rc, buf);
+        }
+    }
+
+    /* 3. readlink on broken symlink: should return target even if target missing */
+    {
+        unlink("/tmp/cu_rlk_broken_link");
+        unlink("/tmp/cu_rlk_no_such_target");
+        symlink("/tmp/cu_rlk_no_such_target", "/tmp/cu_rlk_broken_link");
+
+        int rc = capture_first_line("readlink /tmp/cu_rlk_broken_link", buf, sizeof(buf));
+        if (rc > 0 && strcmp(buf, "/tmp/cu_rlk_no_such_target") == 0) {
+            PASS("readlink broken symlink");
+        } else {
+            FAIL("readlink broken symlink", "(rc=%d output='%s')", rc, buf);
+        }
+        unlink("/tmp/cu_rlk_broken_link");
+    }
+}
+
+/* ==================================================================
+ *  Group 3: chmod
+ * ================================================================== */
+static void test_chmod(void)
+{
+    printf("[chmod]\n");
+    mode_t mode;
+
+    /* 1. chmod 0755 */
+    {
+        write_file("/tmp/cu_chmod_test", "x");
+        run("chmod 0755 /tmp/cu_chmod_test");
+        if (get_mode("/tmp/cu_chmod_test", &mode) == 0 && mode == 0755) {
+            PASS("chmod 0755");
+        } else {
+            FAIL("chmod 0755", "(mode=%o)", mode);
+        }
+        unlink("/tmp/cu_chmod_test");
+    }
+
+    /* 2. chmod 0600 */
+    {
+        write_file("/tmp/cu_chmod_test", "x");
+        run("chmod 0600 /tmp/cu_chmod_test");
+        if (get_mode("/tmp/cu_chmod_test", &mode) == 0 && mode == 0600) {
+            PASS("chmod 0600");
+        } else {
+            FAIL("chmod 0600", "(mode=%o)", mode);
+        }
+        unlink("/tmp/cu_chmod_test");
+    }
+
+    /* 3. chmod u+x (symbolic) */
+    {
+        write_file("/tmp/cu_chmod_test", "x");
+        run("chmod 0644 /tmp/cu_chmod_test");
+        run("chmod u+x /tmp/cu_chmod_test");
+        if (get_mode("/tmp/cu_chmod_test", &mode) == 0 && mode == 0744) {
+            PASS("chmod u+x symbolic");
+        } else {
+            FAIL("chmod u+x symbolic", "(mode=%o)", mode);
+        }
+        unlink("/tmp/cu_chmod_test");
+    }
+
+    /* 4. chmod go-rwx (symbolic) */
+    {
+        write_file("/tmp/cu_chmod_test", "x");
+        run("chmod 0755 /tmp/cu_chmod_test");
+        run("chmod go-rwx /tmp/cu_chmod_test");
+        if (get_mode("/tmp/cu_chmod_test", &mode) == 0 && mode == 0700) {
+            PASS("chmod go-rwx symbolic");
+        } else {
+            FAIL("chmod go-rwx symbolic", "(mode=%o)", mode);
+        }
+        unlink("/tmp/cu_chmod_test");
+    }
+
+    /* 5. chmod on directory */
+    {
+        run("rm -rf /tmp/cu_chmod_dir");
+        run("mkdir /tmp/cu_chmod_dir");
+        run("chmod 0755 /tmp/cu_chmod_dir");
+        if (get_mode("/tmp/cu_chmod_dir", &mode) == 0 && mode == 0755) {
+            PASS("chmod directory");
+        } else {
+            FAIL("chmod directory", "(mode=%o)", mode);
+        }
+        run("rm -rf /tmp/cu_chmod_dir");
+    }
+}
+
+/* ==================================================================
+ *  Group 4: chown
+ * ================================================================== */
+static void test_chown(void)
+{
+    printf("[chown]\n");
+    uid_t uid;
+    gid_t gid;
+
+    /* 1. chown root:root (named) */
+    {
+        write_file("/tmp/cu_chown_test", "x");
+        int rc = run("chown root:root /tmp/cu_chown_test");
+        if (rc == 0) {
+            if (get_owner("/tmp/cu_chown_test", &uid, &gid) == 0 &&
+                uid == 0 && gid == 0) {
+                PASS("chown root:root named");
+            } else {
+                FAIL("chown root:root named", "(uid=%d gid=%d)", uid, gid);
+            }
+        } else {
+            FAIL("chown root:root named", "(rc=%d)", rc);
+        }
+        unlink("/tmp/cu_chown_test");
+    }
+
+    /* 2. chown 0:0 (numeric) */
+    {
+        write_file("/tmp/cu_chown_test", "x");
+        int rc = run("chown 0:0 /tmp/cu_chown_test");
+        if (rc == 0) {
+            if (get_owner("/tmp/cu_chown_test", &uid, &gid) == 0 &&
+                uid == 0 && gid == 0) {
+                PASS("chown 0:0 numeric");
+            } else {
+                FAIL("chown 0:0 numeric", "(uid=%d gid=%d)", uid, gid);
+            }
+        } else {
+            FAIL("chown 0:0 numeric", "(rc=%d)", rc);
+        }
+        unlink("/tmp/cu_chown_test");
+    }
+
+    /* 3. chown :root (group only) */
+    {
+        write_file("/tmp/cu_chown_test", "x");
+        int rc = run("chown :root /tmp/cu_chown_test");
+        if (rc == 0) {
+            if (get_owner("/tmp/cu_chown_test", &uid, &gid) == 0 && gid == 0) {
+                PASS("chown :root group-only");
+            } else {
+                FAIL("chown :root group-only", "(uid=%d gid=%d)", uid, gid);
+            }
+        } else {
+            FAIL("chown :root group-only", "(rc=%d)", rc);
+        }
+        unlink("/tmp/cu_chown_test");
+    }
+}
+
+/* ==================================================================
+ *  Group 5: mkfifo
+ * ================================================================== */
+static void test_mkfifo(void)
+{
+    printf("[mkfifo]\n");
+    char type[64];
+    mode_t mode;
+
+    /* 1. mkfifo creates a fifo */
+    {
+        unlink("/tmp/cu_fifo");
+        int rc = run("mkfifo /tmp/cu_fifo");
+        if (rc == 0) {
+            if (get_file_type("/tmp/cu_fifo", type, sizeof(type)) == 0 &&
+                strcmp(type, "fifo") == 0) {
+                PASS("mkfifo basic");
+            } else {
+                FAIL("mkfifo basic", "(type='%s')", type);
+            }
+        } else {
+            SKIP("mkfifo basic", "(rc=%d)", rc);
+        }
+        unlink("/tmp/cu_fifo");
+    }
+
+    /* 2. mkfifo with mode */
+    {
+        unlink("/tmp/cu_fifo");
+        int rc = run("mkfifo -m 0620 /tmp/cu_fifo");
+        if (rc == 0) {
+            if (get_mode("/tmp/cu_fifo", &mode) == 0 && mode == 0620) {
+                PASS("mkfifo -m 0620");
+            } else {
+                FAIL("mkfifo -m 0620", "(mode=%o)", mode);
+            }
+        } else {
+            SKIP("mkfifo -m 0620", "(rc=%d)", rc);
+        }
+        unlink("/tmp/cu_fifo");
+    }
+}
+
+/* ==================================================================
+ *  Group 6: mknod
+ * ================================================================== */
+static void test_mknod(void)
+{
+    printf("[mknod]\n");
+    char type[64];
+
+    /* 1. mknod char device c 1 3 */
+    {
+        unlink("/tmp/cu_char");
+        int rc = run("mknod /tmp/cu_char c 1 3 2>/dev/null");
+        if (rc == 0) {
+            if (get_file_type("/tmp/cu_char", type, sizeof(type)) == 0 &&
+                strcmp(type, "character special file") == 0) {
+                PASS("mknod char c 1 3");
+            } else {
+                FAIL("mknod char c 1 3", "(type='%s')", type);
+            }
+            unlink("/tmp/cu_char");
+        } else {
+            SKIP("mknod char c 1 3", "(rc=%d)", rc);
+        }
+    }
+
+    /* 2. mknod block device b 7 0 */
+    {
+        unlink("/tmp/cu_blk");
+        int rc = run("mknod /tmp/cu_blk b 7 0 2>/dev/null");
+        if (rc == 0) {
+            if (get_file_type("/tmp/cu_blk", type, sizeof(type)) == 0 &&
+                strcmp(type, "block special file") == 0) {
+                PASS("mknod block b 7 0");
+            } else {
+                FAIL("mknod block b 7 0", "(type='%s')", type);
+            }
+            unlink("/tmp/cu_blk");
+        } else {
+            SKIP("mknod block b 7 0", "(rc=%d)", rc);
+        }
+    }
+}
+
+/* ==================================================================
+ *  Group 7: ls -la /usr
+ * ================================================================== */
+static void test_ls(void)
+{
+    printf("[ls]\n");
+    char buf[4096];
+
+    /* 1. ls -la /usr output contains "total" */
+    {
+        int len = capture_first_line("ls -la /usr", buf, sizeof(buf));
+        if (len > 0 && strstr(buf, "total") != NULL) {
+            PASS("ls -la /usr header");
+        } else {
+            FAIL("ls -la /usr header", "(output='%s')", buf);
+        }
+    }
+
+    /* 2. ls /usr contains known directory entries */
+    {
+        int rc = run("ls /usr | grep -q -E '^(bin|lib|share|sbin)$'");
+        if (rc == 0) {
+            PASS("ls /usr entries");
+        } else {
+            FAIL("ls /usr entries", "(rc=%d)", rc);
+        }
+    }
+
+    /* 3. ls -la permission format (drwxr-xr-x or similar) */
+    {
+        int rc = run("ls -la /usr | grep -q '^d'");
+        if (rc == 0) {
+            PASS("ls -la permission format");
+        } else {
+            FAIL("ls -la permission format", "(rc=%d)", rc);
+        }
+    }
+
+    /* 4. ls -la shows owner and group columns ("root" appears) */
+    {
+        int rc = run("ls -la /usr | grep -q 'root'");
+        if (rc == 0) {
+            PASS("ls -la owner/group columns");
+        } else {
+            FAIL("ls -la owner/group columns", "(rc=%d)", rc);
+        }
+    }
+}
+
+/* ==================================================================
+ *  Group 8: cp
+ * ================================================================== */
+static void test_cp(void)
+{
+    printf("[cp]\n");
+
+    /* 1. cp single file */
+    {
+        write_file("/tmp/cu_cp_single_src", "single");
+        unlink("/tmp/cu_cp_single_dst");
+        int rc = run("cp /tmp/cu_cp_single_src /tmp/cu_cp_single_dst");
+        if (rc == 0) {
+            char buf[64];
+            capture_first_line("cat /tmp/cu_cp_single_dst", buf, sizeof(buf));
+            if (strcmp(buf, "single") == 0) {
+                PASS("cp single file");
+            } else {
+                FAIL("cp single file", "(content='%s')", buf);
+            }
+        } else {
+            FAIL("cp single file", "(rc=%d)", rc);
+        }
+        unlink("/tmp/cu_cp_single_src");
+        unlink("/tmp/cu_cp_single_dst");
+    }
+
+    /* 2. cp -r directory tree */
+    {
+        run("rm -rf /tmp/cu_cp_src /tmp/cu_cp_dst");
+        run("mkdir -p /tmp/cu_cp_src/sub");
+        write_file("/tmp/cu_cp_src/a.txt", "aaa\n");
+        write_file("/tmp/cu_cp_src/sub/b.txt", "bbb\n");
+
+        int rc = run("cp -r /tmp/cu_cp_src /tmp/cu_cp_dst");
+        if (rc == 0) {
+            if (access("/tmp/cu_cp_dst/a.txt", F_OK) == 0 &&
+                access("/tmp/cu_cp_dst/sub/b.txt", F_OK) == 0) {
+                PASS("cp -r directory tree");
+            } else {
+                FAIL("cp -r directory tree", "(files missing)");
+            }
+        } else {
+            FAIL("cp -r directory tree", "(rc=%d)", rc);
+        }
+
+        /* 3. cp -r preserves file content */
+        {
+            char buf[64];
+            int len = capture_first_line("cat /tmp/cu_cp_dst/a.txt", buf, sizeof(buf));
+            if (len > 0 && strcmp(buf, "aaa") == 0) {
+                PASS("cp -r content preserved");
+            } else {
+                FAIL("cp -r content preserved", "(output='%s')", buf);
+            }
+        }
+
+        run("rm -rf /tmp/cu_cp_src /tmp/cu_cp_dst");
+    }
+}
+
+/* ==================================================================
+ *  Group 9: mv
+ * ================================================================== */
+static void test_mv(void)
+{
+    printf("[mv]\n");
+
+    /* 1. mv file */
+    {
+        write_file("/tmp/cu_mv_src", "move_me");
+        unlink("/tmp/cu_mv_dst");
+        int rc = run("mv /tmp/cu_mv_src /tmp/cu_mv_dst");
+        if (rc == 0) {
+            if (access("/tmp/cu_mv_src", F_OK) != 0 &&
+                access("/tmp/cu_mv_dst", F_OK) == 0) {
+                char buf[64];
+                capture_first_line("cat /tmp/cu_mv_dst", buf, sizeof(buf));
+                if (strcmp(buf, "move_me") == 0) {
+                    PASS("mv file");
+                } else {
+                    FAIL("mv file", "(content='%s')", buf);
+                }
+            } else {
+                FAIL("mv file", "(src exists=%d dst exists=%d)",
+                     access("/tmp/cu_mv_src", F_OK) == 0,
+                     access("/tmp/cu_mv_dst", F_OK) == 0);
+            }
+        } else {
+            FAIL("mv file", "(rc=%d)", rc);
+        }
+        unlink("/tmp/cu_mv_src");
+        unlink("/tmp/cu_mv_dst");
+    }
+
+    /* 2. mv directory */
+    {
+        run("rm -rf /tmp/cu_mv_dir_src /tmp/cu_mv_dir_dst");
+        run("mkdir -p /tmp/cu_mv_dir_src");
+        write_file("/tmp/cu_mv_dir_src/f.txt", "dir_move");
+        int rc = run("mv /tmp/cu_mv_dir_src /tmp/cu_mv_dir_dst");
+        if (rc == 0) {
+            if (access("/tmp/cu_mv_dir_src", F_OK) != 0 &&
+                access("/tmp/cu_mv_dir_dst/f.txt", F_OK) == 0) {
+                PASS("mv directory");
+            } else {
+                FAIL("mv directory", "(src exists=%d dst_file exists=%d)",
+                     access("/tmp/cu_mv_dir_src", F_OK) == 0,
+                     access("/tmp/cu_mv_dir_dst/f.txt", F_OK) == 0);
+            }
+        } else {
+            FAIL("mv directory", "(rc=%d)", rc);
+        }
+        run("rm -rf /tmp/cu_mv_dir_src /tmp/cu_mv_dir_dst");
+    }
+}
+
+/* ==================================================================
+ *  Group 10: rm -rf
+ * ================================================================== */
+static void test_rm(void)
+{
+    printf("[rm]\n");
+
+    /* 1. rm -rf directory tree */
+    {
+        run("mkdir -p /tmp/cu_rm_dir/sub1/sub2");
+        write_file("/tmp/cu_rm_dir/a.txt", "x");
+        write_file("/tmp/cu_rm_dir/sub1/b.txt", "y");
+        int rc = run("rm -rf /tmp/cu_rm_dir");
+        if (rc == 0 && access("/tmp/cu_rm_dir", F_OK) != 0) {
+            PASS("rm -rf directory tree");
+        } else {
+            FAIL("rm -rf directory tree", "(rc=%d exists=%d)",
+                 rc, access("/tmp/cu_rm_dir", F_OK) == 0);
+        }
+    }
+
+    /* 2. rm -f single file */
+    {
+        write_file("/tmp/cu_rm_file", "x");
+        int rc = run("rm -f /tmp/cu_rm_file");
+        if (rc == 0 && access("/tmp/cu_rm_file", F_OK) != 0) {
+            PASS("rm -f single file");
+        } else {
+            FAIL("rm -f single file", "(rc=%d exists=%d)",
+                 rc, access("/tmp/cu_rm_file", F_OK) == 0);
+        }
+    }
+
+    /* 3. rm -f on non-existent file (should succeed silently) */
+    {
+        unlink("/tmp/cu_rm_noexist");
+        int rc = run("rm -f /tmp/cu_rm_noexist");
+        if (rc == 0) {
+            PASS("rm -f non-existent");
+        } else {
+            FAIL("rm -f non-existent", "(rc=%d)", rc);
+        }
+    }
+}
+
+/* ==================================================================
+ *  Main
+ * ================================================================== */
+int main(void)
+{
+    printf("=== GNU coreutils 9.x test ===\n");
+
+    test_stat();
+    test_readlink();
+    test_chmod();
+    test_chown();
+    test_mkfifo();
+    test_mknod();
+    test_ls();
+    test_cp();
+    test_mv();
+    test_rm();
+
+    printf("=== total: %d passed, %d failed, %d skipped ===\n", pass, fail, skip);
+
+    if (fail > 0) return 1;
+    printf("COREUTILS TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/coreutils/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/coreutils/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/coreutils-test"
+success_regex = ["(?m)^COREUTILS TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/coreutils/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/coreutils/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/coreutils-test"
+success_regex = ["(?m)^COREUTILS TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/coreutils/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/coreutils/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/coreutils-test"
+success_regex = ["(?m)^COREUTILS TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/coreutils/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/coreutils/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/coreutils-test"
+success_regex = ["(?m)^COREUTILS TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/c/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(util-linux-test C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(util-linux-test src/main.c)
+target_compile_options(util-linux-test PRIVATE -Wall -Wextra -Werror)
+
+# Create a 4MB ext4 test image at build time using host mkfs.ext4.
+# This image is used at runtime for mount -t ext4 testing since
+# mkfs.ext4 does not work reliably on the StarryOS guest.
+# 4MB is sufficient for ext4 and avoids excessive memory use when the
+# kernel buffers the entire image in RAM.
+set(EXT4_TEST_IMG "${CMAKE_CURRENT_BINARY_DIR}/test-ext4.img")
+add_custom_command(
+    OUTPUT "${EXT4_TEST_IMG}"
+    COMMAND dd if=/dev/zero of="${EXT4_TEST_IMG}" bs=1M count=4 2>/dev/null
+    COMMAND mkfs.ext4 -F "${EXT4_TEST_IMG}" >/dev/null 2>&1
+    COMMENT "Creating ext4 test image"
+)
+add_custom_target(ext4-img ALL DEPENDS "${EXT4_TEST_IMG}")
+
+install(TARGETS util-linux-test RUNTIME DESTINATION usr/bin)
+install(FILES "${EXT4_TEST_IMG}" DESTINATION usr/share/util-linux-test RENAME test-ext4.img)

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/c/prebuild.sh
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add util-linux e2fsprogs binutils gcc musl-dev

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/c/src/main.c
@@ -1,0 +1,695 @@
+/*
+ * util-linux-test.c -- util-linux 2.38+ combined verification
+ *
+ * Key dependencies: mount, pivot_root, blkid, fdisk, losetup
+ * Acceptance criteria:
+ *   - mount -t ext4 works (ext4 filesystem mount/unmount)
+ *   - fdisk -l works (partition table listing)
+ *   - losetup full chain (attach/detach loop device)
+ *   - blkid block device identification
+ *   - pivot_root command available
+ *
+ * The ext4 mount test uses a pre-formatted image created during
+ * CMake build via host mkfs.ext4 (available in the CI Docker image).
+ */
+
+#define _GNU_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <fcntl.h>
+#include <sys/mount.h>
+
+static int pass = 0, fail = 0;
+
+static int run(const char *cmd)
+{
+    int ret = system(cmd);
+    if (WIFEXITED(ret))
+        return WEXITSTATUS(ret);
+    return -1;
+}
+
+/* Capture first line of command output into buf, return exit code */
+static int capture(const char *cmd, char *buf, int bufsz)
+{
+    FILE *p = popen(cmd, "r");
+    if (!p) return -1;
+    buf[0] = '\0';
+    if (fgets(buf, bufsz, p)) {
+        int len = (int)strlen(buf);
+        while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+            buf[--len] = '\0';
+    }
+    int status = pclose(p);
+    if (WIFEXITED(status))
+        return WEXITSTATUS(status);
+    return -1;
+}
+
+/* Write string to file, return 0 on success */
+static int write_file(const char *path, const char *data)
+{
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0) return -1;
+    size_t len = strlen(data);
+    ssize_t w = write(fd, data, len);
+    close(fd);
+    return (w == (ssize_t)len) ? 0 : -1;
+}
+
+/* Read first line of file into buf, return line length or -1 */
+static int read_first_line(const char *path, char *buf, int bufsz)
+{
+    FILE *f = fopen(path, "r");
+    if (!f) return -1;
+    if (!fgets(buf, bufsz, f)) { fclose(f); return -1; }
+    int len = (int)strlen(buf);
+    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+        buf[--len] = '\0';
+    fclose(f);
+    return len;
+}
+
+static void check(int ok, const char *name)
+{
+    if (ok) { printf("  PASS | %s\n", name); pass++; }
+    else    { printf("  FAIL | %s\n", name); fail++; }
+}
+
+/* Path to the pre-formatted ext4 test image (created at CMake build time) */
+#define PREBUILT_IMG "/usr/share/util-linux-test/test-ext4.img"
+
+/* Expected image size: 4 MiB = 4194304 bytes = 8192 sectors */
+#define IMG_BYTES  4194304
+#define IMG_SECTORS 8192
+
+int main(void)
+{
+    char buf[1024];
+    char loopdev[64] = "";
+    int rc;
+
+    printf("=== util-linux 2.38+ test ===\n");
+
+    /* ================================================================
+     *  Tier 1: Tool availability
+     * ================================================================ */
+
+    /* 1. mount present */
+    {
+        rc = run("which mount >/dev/null 2>&1");
+        check(rc == 0, "mount command available");
+    }
+
+    /* 2. losetup present */
+    {
+        rc = run("which losetup >/dev/null 2>&1");
+        check(rc == 0, "losetup command available");
+    }
+
+    /* 3. blkid present */
+    {
+        rc = run("which blkid >/dev/null 2>&1");
+        check(rc == 0, "blkid command available");
+    }
+
+    /* 4. fdisk present */
+    {
+        rc = run("which fdisk >/dev/null 2>&1");
+        check(rc == 0, "fdisk command available");
+    }
+
+    /* ================================================================
+     *  Tier 2: losetup full chain
+     * ================================================================ */
+
+    /* 5. Create 4MB test image */
+    {
+        rc = run("dd if=/dev/zero of=/tmp/ul-test.img bs=1M count=4 2>/dev/null");
+        check(rc == 0, "dd create 4MB image");
+    }
+
+    /* 6. Find free loop device */
+    {
+        rc = capture("losetup -f 2>&1", buf, sizeof(buf));
+        int found = (rc == 0 && strncmp(buf, "/dev/loop", 9) == 0);
+        if (found)
+            snprintf(loopdev, sizeof(loopdev), "%s", buf);
+        check(found, "losetup -f find free device");
+    }
+
+    /* 7. Attach loop device */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s /tmp/ul-test.img 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach");
+    } else {
+        check(0, "losetup attach");
+    }
+
+    /* 8. List attached loop devices */
+    {
+        rc = run("losetup -a 2>&1 | grep -q 'ul-test.img'");
+        check(rc == 0, "losetup -a list attached");
+    }
+
+    /* ================================================================
+     *  Tier 3: fdisk -l (acceptance criterion)
+     * ================================================================ */
+
+    /* 9-10. fdisk -l output: capture and verify disk header + size */
+    {
+        char cmd[256];
+        char fdisk_out[2048];
+        int fdisk_ok = 0;
+
+        /* Capture full fdisk -l output */
+        if (loopdev[0]) {
+            snprintf(cmd, sizeof(cmd), "fdisk -l %s 2>&1", loopdev);
+            /* Read all output lines into fdisk_out */
+            FILE *p = popen(cmd, "r");
+            if (p) {
+                size_t pos = 0;
+                while (pos < sizeof(fdisk_out) - 1 &&
+                       fgets(fdisk_out + pos, sizeof(fdisk_out) - pos, p)) {
+                    pos += strlen(fdisk_out + pos);
+                }
+                fdisk_out[pos] = '\0';
+                int st = pclose(p);
+                fdisk_ok = WIFEXITED(st) && WEXITSTATUS(st) == 0;
+            } else {
+                fdisk_out[0] = '\0';
+            }
+        }
+
+        /* Test 9: disk header present */
+        check(fdisk_ok && strstr(fdisk_out, loopdev) != NULL,
+              "fdisk -l shows disk header");
+
+        /* Test 10: verify size appears in output.
+         * BusyBox fdisk formats vary by version:
+         *   - "4194304 bytes" (direct byte count)
+         *   - "8192 sectors" (sector count)
+         *   - "heads, 32 sectors/track" (geometry-derived)
+         * We check that at least one of these size indicators is present
+         * and consistent with the 4 MiB image (4194304 bytes / 8192 sectors).
+         */
+        {
+            int found_bytes = (strstr(fdisk_out, "4194304") != NULL);
+            int found_sectors = (strstr(fdisk_out, "8192") != NULL);
+            check(found_bytes || found_sectors,
+                  "fdisk -l shows 4 MiB / 8192 sectors");
+        }
+    }
+
+    /* ================================================================
+     *  Tier 4: mount -t ext4 full chain (acceptance criterion)
+     * ================================================================ */
+
+    /* 11. Pre-built ext4 image exists */
+    {
+        struct stat st;
+        rc = (stat(PREBUILT_IMG, &st) == 0 && st.st_size == IMG_BYTES) ? 0 : -1;
+        check(rc == 0, "pre-built ext4 image exists (4 MiB)");
+    }
+
+    /* 12. Detach raw image, attach ext4 image */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        run(cmd);
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach ext4 image");
+    } else {
+        check(0, "losetup attach ext4 image");
+    }
+
+    /* 13. blkid identifies ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "blkid %s 2>&1 | grep -qi 'ext4'", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "blkid identifies ext4 filesystem");
+    } else {
+        check(0, "blkid identifies ext4 filesystem");
+    }
+
+    /* 14. Create mount point */
+    {
+        rc = run("mkdir /tmp/ul-mnt");
+        check(rc == 0, "mkdir mount point");
+    }
+
+    /* 15. mount -t ext4 (acceptance criterion) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount -t ext4 (acceptance)");
+    } else {
+        check(0, "mount -t ext4 (acceptance)");
+    }
+
+    /* 16. Write file on ext4 mount */
+    {
+        rc = write_file("/tmp/ul-mnt/test.txt", "util-linux mount test\n");
+        check(rc == 0, "write file on ext4 mount");
+    }
+
+    /* 17. Read file from ext4 mount */
+    {
+        char content[256] = {0};
+        int len = read_first_line("/tmp/ul-mnt/test.txt", content, sizeof(content));
+        check(len > 0 && strcmp(content, "util-linux mount test") == 0,
+              "read file from ext4 mount");
+    }
+
+    /* 18. umount ext4 */
+    {
+        rc = run("umount /tmp/ul-mnt 2>&1");
+        check(rc == 0, "umount ext4");
+    }
+
+    /* 19. Detach loop device */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup detach");
+    } else {
+        check(0, "losetup detach");
+    }
+
+    /* ================================================================
+     *  Tier 4b: Loop device write persistence
+     *
+     *  Verify that data written through the loop block device survives
+     *  umount + losetup -d.  Re-attach and re-mount the same image,
+     *  then read the file back — it must match what was written above.
+     * ================================================================ */
+
+    /* 20. Re-attach ext4 image */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup re-attach ext4 image");
+    } else {
+        check(0, "losetup re-attach ext4 image");
+    }
+
+    /* 21. Re-mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "re-mount ext4 after detach");
+    } else {
+        check(0, "re-mount ext4 after detach");
+    }
+
+    /* 22. Read file back — must survive umount + detach */
+    {
+        char content[256] = {0};
+        int len = read_first_line("/tmp/ul-mnt/test.txt", content, sizeof(content));
+        check(len > 0 && strcmp(content, "util-linux mount test") == 0,
+              "data persists after umount+detach+remount");
+    }
+
+    /* 23. Cleanup: umount + detach after persistence test */
+    {
+        run("umount /tmp/ul-mnt 2>&1");
+        if (loopdev[0]) {
+            char cmd[256];
+            snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+            run(cmd);
+        }
+    }
+
+    /* ================================================================
+     *  Tier 4c: Loop device write-back without detach
+     *
+     *  Verify that data written through the loop block device survives
+     *  umount followed by a re-mount *without* losetup -d in between.
+     *  This exercises the write-back path in as_dyn_block_device()
+     *  where dirty cache is flushed to the backing file before the
+     *  cache is re-initialised from a fresh read of the file.
+     * ================================================================ */
+
+    /* 24. Attach ext4 image (fresh) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for no-detach test");
+    } else {
+        check(0, "losetup attach for no-detach test");
+    }
+
+    /* 25. Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for no-detach test");
+    } else {
+        check(0, "mount for no-detach test");
+    }
+
+    /* 26. Write distinct file */
+    {
+        rc = write_file("/tmp/ul-mnt/writeback.txt", "writeback ok\n");
+        check(rc == 0, "write writeback.txt on ext4");
+    }
+
+    /* 27. Read back to confirm write */
+    {
+        char content[256] = {0};
+        int len = read_first_line("/tmp/ul-mnt/writeback.txt", content, sizeof(content));
+        check(len > 0 && strcmp(content, "writeback ok") == 0,
+              "read writeback.txt before umount");
+    }
+
+    /* 28. Umount (do NOT detach loop device) */
+    {
+        rc = run("umount /tmp/ul-mnt 2>&1");
+        check(rc == 0, "umount without detach");
+    }
+
+    /* 29. Re-mount same loop device (no detach in between) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "re-mount without detach");
+    } else {
+        check(0, "re-mount without detach");
+    }
+
+    /* 30. Read writeback.txt back — must survive umount-only cycle */
+    {
+        char content[256] = {0};
+        int len = read_first_line("/tmp/ul-mnt/writeback.txt", content, sizeof(content));
+        check(len > 0 && strcmp(content, "writeback ok") == 0,
+              "data persists after umount+remount (no detach)");
+    }
+
+    /* 31. Cleanup: umount + detach */
+    {
+        run("umount /tmp/ul-mnt 2>&1");
+        if (loopdev[0]) {
+            char cmd[256];
+            snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+            run(cmd);
+        }
+    }
+
+    /* ================================================================
+     *  Tier 4d: Loop device write-back — verify via direct image read
+     *
+     *  Verify that data written through the loop block device is
+     *  persisted to the backing file immediately after umount, WITHOUT
+     *  requiring losetup -d or a subsequent mount as a write-back
+     *  trigger.  We write a unique marker string, umount, then grep
+     *  the raw backing image for that string.
+     * ================================================================ */
+
+    /* Attach ext4 image (fresh) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for direct-read test");
+    } else {
+        check(0, "losetup attach for direct-read test");
+    }
+
+    /* Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for direct-read test");
+    } else {
+        check(0, "mount for direct-read test");
+    }
+
+    /* Write unique marker file */
+    {
+        rc = write_file("/tmp/ul-mnt/wb-verify.txt", "WB-VERIFY-a7c3-9f2e\n");
+        check(rc == 0, "write wb-verify.txt on ext4");
+    }
+
+    /* Umount (do NOT detach) */
+    {
+        rc = run("umount /tmp/ul-mnt 2>&1");
+        check(rc == 0, "umount for direct-read test");
+    }
+
+    /* Grep the raw backing image for the unique string.
+     * If the umount write-back hook worked correctly, the string
+     * must be present in the image — no detach or re-mount needed. */
+    {
+        rc = run("grep -c 'WB-VERIFY-a7c3-9f2e' " PREBUILT_IMG " >/dev/null 2>&1");
+        check(rc == 0, "data in backing image after umount (no detach)");
+    }
+
+    /* Cleanup: detach */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        run(cmd);
+    }
+
+    /* ================================================================
+     *  Tier 5: pivot_root command availability & semantics
+     * ================================================================ */
+
+    /* 32. pivot_root command exists */
+    {
+        int exists = (run("which pivot_root >/dev/null 2>&1") == 0);
+        check(exists, "pivot_root command exists");
+    }
+
+    /* 33. pivot_root semantics: old root appears at put_old.
+     *
+     *  pivot_root(2) reorganises the global mount tree and, matching
+     *  Linux chroot_fs_refs(), updates root/cwd for every task whose
+     *  root or cwd pointed at the old root.  We fork a child so that
+     *  the child's _exit() does not terminate the test runner; the
+     *  mount tree change is global and propagates to the parent.
+     *
+     *  Inside the child we:
+     *    1. pivot_root /tmp/pivot-newroot /tmp/pivot-newroot/oldroot
+     *    2. stat /oldroot — must succeed (old root moved here)
+     *    3. stat /oldroot/tmp — must succeed (original root content)
+     *
+     *  After the child exits, the parent also verifies that its own
+     *  root was switched to the new root (chroot_fs_refs semantic)
+     *  and can still reach the old filesystem through /oldroot.
+     *
+     *  Additionally we verify that a task chroot'd into a subdirectory
+     *  of the old root is NOT affected by pivot_root — only tasks
+     *  whose root *exactly equals* old_root should be updated.
+     */
+    {
+        /* Set up sentinel for the chroot-subdirectory regression child */
+        run("mkdir -p /tmp/chroot-sub");
+        run("touch /tmp/chroot-sub/sentinel");
+
+        run("mkdir -p /tmp/pivot-newroot 2>&1");
+        int mnt_ok = (run("mount -t tmpfs tmpfs /tmp/pivot-newroot 2>&1") == 0);
+        if (mnt_ok) {
+            run("mkdir /tmp/pivot-newroot/oldroot 2>&1");
+
+            /* ---- chroot-subdirectory regression child ----
+             * Fork before pivot_root, chroot into /tmp/chroot-sub (a
+             * subdirectory of the old root), then verify after pivot_root
+             * that this child's root was NOT replaced with new_root. */
+            int ch_p2c[2], ch_c2p[2];
+            int ch_pipes_ok = (pipe(ch_p2c) == 0 && pipe(ch_c2p) == 0);
+            pid_t chroot_child = -1;
+            if (ch_pipes_ok) {
+                chroot_child = fork();
+                if (chroot_child == 0) {
+                    close(ch_p2c[1]);
+                    close(ch_c2p[0]);
+
+                    /* chroot into /tmp/chroot-sub */
+                    chdir("/tmp/chroot-sub");
+                    chroot("/tmp/chroot-sub");
+
+                    struct stat st;
+                    ino_t root_ino = (stat("/", &st) == 0) ? st.st_ino : 0;
+
+                    /* signal parent: chroot done */
+                    char c = 1;
+                    write(ch_c2p[1], &c, 1);
+
+                    /* wait for pivot_root */
+                    read(ch_p2c[0], &c, 1);
+
+                    /* verify root unchanged */
+                    ino_t new_ino = (stat("/", &st) == 0) ? st.st_ino : 0;
+                    int root_ok = (root_ino != 0 && root_ino == new_ino);
+                    int sentinel_ok = (stat("/sentinel", &st) == 0);
+
+                    char result = (root_ok && sentinel_ok) ? 1 : 0;
+                    write(ch_c2p[1], &result, 1);
+
+                    close(ch_p2c[0]);
+                    close(ch_c2p[1]);
+                    _exit(0);
+                }
+                /* parent: close child-side fds */
+                if (chroot_child > 0) {
+                    close(ch_p2c[0]);
+                    close(ch_c2p[1]);
+                    /* wait for child to finish chroot */
+                    char c;
+                    read(ch_c2p[0], &c, 1);
+                }
+            }
+
+            pid_t pid = fork();
+            if (pid == 0) {
+                /* child — perform pivot_root */
+                int ret = syscall(__NR_pivot_root,
+                                  "/tmp/pivot-newroot",
+                                  "/tmp/pivot-newroot/oldroot");
+                if (ret == 0) {
+                    struct stat st;
+                    int ok = (stat("/oldroot", &st) == 0 &&
+                              S_ISDIR(st.st_mode) &&
+                              stat("/oldroot/tmp", &st) == 0);
+                    _exit(ok ? 0 : 1);
+                }
+                _exit(2); /* pivot_root itself failed */
+            } else if (pid > 0) {
+                int status;
+                waitpid(pid, &status, 0);
+                if (WIFEXITED(status)) {
+                    int ec = WEXITSTATUS(status);
+                    check(ec == 0, "pivot_root: child sees old root at put_old");
+                } else {
+                    check(0, "pivot_root: child sees old root at put_old");
+                }
+
+                /* After pivot_root + chroot_fs_refs propagation the
+                 * parent's root has also been switched to the new root
+                 * (tmpfs).  Verify with a direct stat syscall — shell
+                 * commands are unavailable because /bin/sh is now under
+                 * /oldroot. */
+                {
+                    struct stat st;
+                    int parent_ok = (stat("/oldroot", &st) == 0 &&
+                                     S_ISDIR(st.st_mode));
+                    check(parent_ok,
+                          "pivot_root: parent root updated (chroot_fs_refs)");
+                }
+
+                /* Signal chroot child to re-check and collect result */
+                if (chroot_child > 0) {
+                    char c = 1;
+                    write(ch_p2c[1], &c, 1);
+                    char result = 0;
+                    read(ch_c2p[0], &result, 1);
+                    check(result == 1,
+                          "chroot subdirectory: root not replaced after pivot_root");
+                    close(ch_p2c[1]);
+                    close(ch_c2p[0]);
+                    waitpid(chroot_child, &status, 0);
+                }
+            } else {
+                check(0, "pivot_root: fork failed");
+            }
+
+            /* No umount cleanup: after pivot_root the mount tree is
+             * permanently rearranged.  The old mountpoint slot was
+             * cleared by pivot_mount, and the parent's root is now the
+             * tmpfs.  The QEMU VM is discarded after the test. */
+        } else {
+            check(0, "pivot_root: mount tmpfs for new root");
+        }
+    }
+
+    /* ================================================================
+     *  Tier 5a: second pivot_root — verify mount tree hierarchy
+     *
+     *  After the first pivot_root (test 33) the current root is a
+     *  tmpfs with the original root at /oldroot.  We mount a second
+     *  tmpfs and pivot_root again, then verify the entire mount tree
+     *  hierarchy is preserved:
+     *
+     *    new root (second tmpfs)
+     *      /putold → first tmpfs (old root from second pivot)
+     *        /oldroot → original root (old root from first pivot)
+     *
+     *  This exercises propagate_pivot_root a second time and confirms
+     *  the mount tree restructuring is correct across stacked pivots.
+     *
+     *  All operations use direct syscalls because after the first
+     *  pivot_root /bin/sh is no longer at its original path.
+     *
+     *  Note: the original chroot regression test (verifying that
+     *  propagate_pivot_root skips tasks chroot'd into subdirectories)
+     *  cannot be exercised here because fork'd children initialise
+     *  their FS_CONTEXT from ROOT_FS_CONTEXT, which is never updated
+     *  by pivot_root and becomes stale after the first pivot — the
+     *  child cannot resolve any paths.  The Location::ptr_eq fix is
+     *  verified indirectly: test 33's propagate_pivot_root correctly
+     *  updates only tasks whose root_dir exactly matches old_root
+     *  (mountpoint + dentry), using Location::ptr_eq.
+     * ================================================================ */
+    {
+        int setup_ok = (mkdir("/pivot2-nr", 0755) == 0);
+        setup_ok = setup_ok && (mount("tmpfs", "/pivot2-nr", "tmpfs", 0, NULL) == 0);
+        setup_ok = setup_ok && (mkdir("/pivot2-nr/putold", 0755) == 0);
+
+        if (setup_ok) {
+            int piv_ok = (syscall(__NR_pivot_root,
+                                  "/pivot2-nr", "/pivot2-nr/putold") == 0);
+
+            if (piv_ok) {
+                struct stat st;
+                /* putold should contain the first tmpfs */
+                int ok = (stat("/putold", &st) == 0 && S_ISDIR(st.st_mode));
+                check(ok, "pivot_root 2: /putold accessible (first tmpfs)");
+
+                /* The original root should still be reachable through
+                 * the first tmpfs's /oldroot mountpoint */
+                ok = (stat("/putold/oldroot", &st) == 0 && S_ISDIR(st.st_mode));
+                check(ok, "pivot_root 2: /putold/oldroot (original root)");
+
+                /* Original content should still be visible */
+                ok = (stat("/putold/oldroot/tmp", &st) == 0);
+                check(ok, "pivot_root 2: original root content reachable");
+            } else {
+                check(0, "pivot_root 2: syscall failed");
+            }
+        } else {
+            check(0, "pivot_root 2: setup failed");
+        }
+    }
+
+    /* Cleanup: after a successful pivot_root the old filesystem is at
+     * /oldroot; if pivot_root was not reached the original paths apply.
+     * One of these two calls will succeed, the other silently fails. */
+    unlink("/tmp/ul-test.img");
+    unlink("/oldroot/tmp/ul-test.img");
+
+    printf("=== total: %d passed, %d failed ===\n", pass, fail);
+
+    if (fail > 0) return 1;
+    printf("UTIL LINUX TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/util-linux-test"
+success_regex = ["(?m)^UTIL LINUX TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/util-linux-test"
+success_regex = ["(?m)^UTIL LINUX TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/util-linux-test"
+success_regex = ["(?m)^UTIL LINUX TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/util-linux-test"
+success_regex = ["(?m)^UTIL LINUX TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 60


### PR DESCRIPTION
… sync, add chroot regression test

- pivot_root: only replace cwd when it exactly equals old_root (ptr_eq), matching Linux chroot_fs_refs semantics
- loop block cache: replace UnsafeCell<Vec> with SpinNoPreempt<Vec> so that write-back paths (flush_cache_to_file, BLKFLSBUF, LOOP_CLR_FD, as_dyn_block_device) cannot race with ext4 write_block; all accesses go through the lock, write-back clones under lock then writes outside
- LOOP_CLR_FD: only clear dirty flag after successful writeback, return error on failure to preserve retry opportunity
- util-linux test: add chroot subdirectory regression case that verifies a task chroot'd into old-root subdir is NOT affected by pivot_root