### PR TITLE
feat(starry/net): add AF_INET6 socket support

### DIFF
--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -11,6 +11,8 @@ const PROTO_TCP: u32 = linux_raw_sys::net::IPPROTO_TCP as u32;
 
 const PROTO_IP: u32 = linux_raw_sys::net::IPPROTO_IP as u32;
 
+const PROTO_IPV6: u32 = linux_raw_sys::net::IPPROTO_IPV6 as u32;
+
 mod conv {
     use ax_errno::{AxError, AxResult};
     use axnet::options::UnixCredentials;
@@ -99,6 +101,8 @@ macro_rules! call_dispatch {
 
             (PROTO_IP, IP_TTL) => Ttl as Int<u8>,
             (PROTO_IP, IP_RECVERR) => RecvErr as IntBool,
+
+            (PROTO_IPV6, IPV6_V6ONLY) => V6Only as IntBool,
         }
     }};
     ($dispatch:ident, $in:expr, $($pat:pat => $which:ident $(as $conv:ty)?),* $(,)?) => {

--- a/os/StarryOS/kernel/src/syscall/net/socket.rs
+++ b/os/StarryOS/kernel/src/syscall/net/socket.rs
@@ -8,6 +8,7 @@ use axfs_ng_vfs::{MetadataUpdate, NodeType};
 use axnet::vsock::{VsockSocket, VsockStreamTransport};
 use axnet::{
     Shutdown, Socket as SocketInner, SocketAddrEx, SocketOps,
+    options::{Configurable, SetSocketOption},
     raw::{IpProtocol, IpVersion, RawSocket},
     tcp::TcpSocket,
     udp::UdpSocket,
@@ -16,8 +17,8 @@ use axnet::{
 use linux_raw_sys::{
     general::{O_CLOEXEC, O_NONBLOCK},
     net::{
-        AF_INET, AF_UNIX, AF_VSOCK, IPPROTO_ICMP, IPPROTO_TCP, IPPROTO_UDP, SHUT_RD, SHUT_RDWR,
-        SHUT_WR, SOCK_DGRAM, SOCK_RAW, SOCK_SEQPACKET, SOCK_STREAM, sockaddr, socklen_t,
+        AF_INET, AF_INET6, AF_UNIX, AF_VSOCK, IPPROTO_ICMP, IPPROTO_TCP, IPPROTO_UDP, SHUT_RD,
+        SHUT_RDWR, SHUT_WR, SOCK_DGRAM, SOCK_RAW, SOCK_SEQPACKET, SOCK_STREAM, sockaddr, socklen_t,
     },
 };
 
@@ -34,13 +35,13 @@ pub fn sys_socket(domain: u32, raw_ty: u32, proto: u32) -> AxResult<isize> {
 
     let pid = current().as_thread().proc_data.proc.pid();
     let socket = match (domain, ty) {
-        (AF_INET, SOCK_STREAM) => {
+        (AF_INET, SOCK_STREAM) | (AF_INET6, SOCK_STREAM) => {
             if proto != 0 && proto != IPPROTO_TCP as _ {
                 return Err(AxError::from(LinuxError::EPROTONOSUPPORT));
             }
             TcpSocket::new().into()
         }
-        (AF_INET, SOCK_DGRAM) => {
+        (AF_INET, SOCK_DGRAM) | (AF_INET6, SOCK_DGRAM) => {
             if proto != 0 && proto != IPPROTO_UDP as _ {
                 return Err(AxError::from(LinuxError::EPROTONOSUPPORT));
             }
@@ -59,7 +60,7 @@ pub fn sys_socket(domain: u32, raw_ty: u32, proto: u32) -> AxResult<isize> {
             }
             SocketInner::Raw(Box::new(RawSocket::new(IpVersion::Ipv4, IpProtocol::Icmp)))
         }
-        (AF_INET, _) | (AF_UNIX, _) | (AF_VSOCK, _) => {
+        (AF_INET, _) | (AF_INET6, _) | (AF_UNIX, _) | (AF_VSOCK, _) => {
             warn!("Unsupported socket type: domain: {domain}, ty: {ty}");
             return Err(AxError::from(LinuxError::ESOCKTNOSUPPORT));
         }
@@ -73,6 +74,10 @@ pub fn sys_socket(domain: u32, raw_ty: u32, proto: u32) -> AxResult<isize> {
         socket.set_nonblocking(true)?;
     }
     let cloexec = raw_ty & O_CLOEXEC != 0;
+
+    if domain == AF_INET6 {
+        socket.set_option(SetSocketOption::IsIpv6(&true))?;
+    }
 
     socket.add_to_fd_table(cloexec).map(|fd| fd as isize)
 }

--- a/os/arceos/modules/axnet-ng/Cargo.toml
+++ b/os/arceos/modules/axnet-ng/Cargo.toml
@@ -49,6 +49,7 @@ features = [
   "socket-tcp",
   "socket-dhcpv4",
   "socket-dns",
+  "iface-max-addr-count-5",
   # "fragmentation-buffer-size-65536", "proto-ipv4-fragmentation",
   # "reassembly-buffer-size-65536", "reassembly-buffer-count-32",
   # "assembler-max-segment-count-32",

--- a/os/arceos/modules/axnet-ng/src/general.rs
+++ b/os/arceos/modules/axnet-ng/src/general.rs
@@ -19,6 +19,10 @@ pub(crate) struct GeneralOptions {
     nonblock: AtomicBool,
     /// Whether the socket should reuse the address.
     reuse_address: AtomicBool,
+    /// IPV6_V6ONLY: if true, AF_INET6 socket only accepts IPv6 connections.
+    v6only: AtomicBool,
+    /// Whether this socket was created as AF_INET6.
+    is_ipv6: AtomicBool,
 
     send_timeout_nanos: AtomicU64,
     recv_timeout_nanos: AtomicU64,
@@ -35,6 +39,8 @@ impl GeneralOptions {
         Self {
             nonblock: AtomicBool::new(false),
             reuse_address: AtomicBool::new(false),
+            v6only: AtomicBool::new(false),
+            is_ipv6: AtomicBool::new(false),
 
             send_timeout_nanos: AtomicU64::new(0),
             recv_timeout_nanos: AtomicU64::new(0),
@@ -49,6 +55,18 @@ impl GeneralOptions {
 
     pub fn reuse_address(&self) -> bool {
         self.reuse_address.load(Ordering::Relaxed)
+    }
+
+    pub fn v6only(&self) -> bool {
+        self.v6only.load(Ordering::Relaxed)
+    }
+
+    pub fn is_ipv6(&self) -> bool {
+        self.is_ipv6.load(Ordering::Relaxed)
+    }
+
+    pub fn set_is_ipv6(&self, val: bool) {
+        self.is_ipv6.store(val, Ordering::Relaxed);
     }
 
     pub fn send_timeout(&self) -> Option<Duration> {
@@ -109,6 +127,15 @@ impl Configurable for GeneralOptions {
             O::ReuseAddress(reuse) => {
                 **reuse = self.reuse_address();
             }
+            O::V6Only(v6only) => {
+                if !self.is_ipv6() {
+                    return Ok(false);
+                }
+                **v6only = self.v6only.load(Ordering::Relaxed);
+            }
+            O::IsIpv6(is_ipv6) => {
+                **is_ipv6 = self.is_ipv6.load(Ordering::Relaxed);
+            }
             O::SendTimeout(timeout) => {
                 **timeout = Duration::from_nanos(self.send_timeout_nanos.load(Ordering::Relaxed));
             }
@@ -132,6 +159,15 @@ impl Configurable for GeneralOptions {
             }
             O::ReuseAddress(reuse) => {
                 self.reuse_address.store(*reuse, Ordering::Relaxed);
+            }
+            O::V6Only(v6only) => {
+                if !self.is_ipv6() {
+                    return Ok(false);
+                }
+                self.v6only.store(*v6only, Ordering::Relaxed);
+            }
+            O::IsIpv6(is_ipv6) => {
+                self.is_ipv6.store(*is_ipv6, Ordering::Relaxed);
             }
             O::SendTimeout(timeout) => {
                 self.send_timeout_nanos

--- a/os/arceos/modules/axnet-ng/src/lib.rs
+++ b/os/arceos/modules/axnet-ng/src/lib.rs
@@ -48,7 +48,7 @@ use core::{
 
 use ax_driver::{AxDeviceContainer, prelude::*};
 use ax_sync::Mutex;
-use smoltcp::wire::{EthernetAddress, Ipv4Address, Ipv4Cidr};
+use smoltcp::wire::{EthernetAddress, Ipv4Address, Ipv4Cidr, Ipv6Address, Ipv6Cidr};
 use spin::{Lazy, Once};
 
 pub use self::socket::*;
@@ -91,6 +91,14 @@ pub fn init_network(mut net_devs: AxDeviceContainer<AxNetDevice>) {
         None,
         lo_dev,
         lo_ip.address().into(),
+    ));
+
+    let lo_ip6 = Ipv6Cidr::new(Ipv6Address::new(0, 0, 0, 0, 0, 0, 0, 1), 128);
+    router.add_rule(Rule::new(
+        lo_ip6.into(),
+        None,
+        lo_dev,
+        lo_ip6.address().into(),
     ));
 
     let static_network = !IP.is_empty() && !GATEWAY.is_empty();
@@ -142,6 +150,7 @@ pub fn init_network(mut net_devs: AxDeviceContainer<AxNetDevice>) {
     let mut service = Service::new(router);
     service.iface.update_ip_addrs(|ip_addrs| {
         ip_addrs.push(lo_ip.into()).unwrap();
+        ip_addrs.push(lo_ip6.into()).unwrap();
         if let Some(eth0_ip) = eth0_ip {
             ip_addrs.push(eth0_ip.into()).unwrap();
         }

--- a/os/arceos/modules/axnet-ng/src/listen_table.rs
+++ b/os/arceos/modules/axnet-ng/src/listen_table.rs
@@ -6,7 +6,7 @@ use ax_sync::Mutex;
 use smoltcp::{
     iface::{SocketHandle, SocketSet},
     socket::tcp::{self, SocketBuffer, State},
-    wire::{IpEndpoint, IpListenEndpoint},
+    wire::{IpAddress, IpEndpoint, IpListenEndpoint},
 };
 
 use crate::{
@@ -20,20 +20,35 @@ struct ListenTableEntryInner {
     listen_endpoint: IpListenEndpoint,
     backlog: usize,
     syn_queue: VecDeque<SocketHandle>,
+    is_ipv6: bool,
+    v6only: bool,
 }
 
 impl ListenTableEntryInner {
-    pub fn new(listen_endpoint: IpListenEndpoint, backlog: usize) -> Self {
+    pub fn new(
+        listen_endpoint: IpListenEndpoint,
+        backlog: usize,
+        is_ipv6: bool,
+        v6only: bool,
+    ) -> Self {
         let backlog = backlog.clamp(1, LISTEN_QUEUE_SIZE);
         Self {
             listen_endpoint,
             backlog,
             syn_queue: VecDeque::with_capacity(backlog),
+            is_ipv6,
+            v6only,
         }
     }
 
     fn can_accept_endpoint(&self, dst: IpEndpoint) -> bool {
         if self.listen_endpoint.port != dst.port {
+            return false;
+        }
+        if !self.is_ipv6 && matches!(dst.addr, IpAddress::Ipv6(_)) {
+            return false;
+        }
+        if self.is_ipv6 && self.v6only && matches!(dst.addr, IpAddress::Ipv4(_)) {
             return false;
         }
         match self.listen_endpoint.addr {
@@ -69,7 +84,13 @@ impl ListenTable {
         self.tcp[port as usize].lock().is_none()
     }
 
-    pub fn listen(&self, listen_endpoint: IpListenEndpoint, backlog: usize) -> AxResult {
+    pub fn listen(
+        &self,
+        listen_endpoint: IpListenEndpoint,
+        backlog: usize,
+        is_ipv6: bool,
+        v6only: bool,
+    ) -> AxResult {
         let port = listen_endpoint.port;
         assert_ne!(port, 0);
         let mut entry = self.tcp[port as usize].lock();
@@ -77,6 +98,8 @@ impl ListenTable {
             *entry = Some(Box::new(ListenTableEntryInner::new(
                 listen_endpoint,
                 backlog,
+                is_ipv6,
+                v6only,
             )));
             Ok(())
         } else {
@@ -115,7 +138,7 @@ impl ListenTable {
         }
     }
 
-    pub fn accept(&self, port: u16, sockets: &SocketSet<'_>) -> AxResult<SocketHandle> {
+    pub fn accept(&self, port: u16, sockets: &SocketSet<'_>) -> AxResult<(SocketHandle, bool)> {
         let entry = self.listen_entry(port);
         let mut table = entry.lock();
         let Some(entry) = table.deref_mut() else {
@@ -123,6 +146,7 @@ impl ListenTable {
             return Err(AxError::InvalidInput);
         };
 
+        let is_ipv6 = entry.is_ipv6;
         let syn_queue: &mut VecDeque<SocketHandle> = &mut entry.syn_queue;
         let idx = syn_queue
             .iter()
@@ -143,7 +167,7 @@ impl ListenTable {
             warn!("accept failed: connection reset");
             Err(AxError::ConnectionReset)
         } else {
-            Ok(handle)
+            Ok((handle, is_ipv6))
         }
     }
 
@@ -168,7 +192,7 @@ impl ListenTable {
                 SocketBuffer::new(vec![0; TCP_TX_BUF_LEN]),
             );
             if let Err(err) = socket.listen(IpListenEndpoint {
-                addr: None,
+                addr: entry.listen_endpoint.addr,
                 port: dst.port,
             }) {
                 warn!("Failed to listen on {}: {:?}", entry.listen_endpoint, err);

--- a/os/arceos/modules/axnet-ng/src/options.rs
+++ b/os/arceos/modules/axnet-ng/src/options.rs
@@ -73,8 +73,12 @@ define_options! {
     Ttl(u8),
     RecvErr(bool),
 
+    // ---- IPv6 level options (IPV6_*) ----
+    V6Only(bool),
+
     // ---- Extra options ----
     NonBlocking(bool),
+    IsIpv6(bool),
 }
 
 /// Trait for configurable socket-like objects.

--- a/os/arceos/modules/axnet-ng/src/tcp.rs
+++ b/os/arceos/modules/axnet-ng/src/tcp.rs
@@ -1,6 +1,6 @@
 use alloc::{vec, vec::Vec};
 use core::{
-    net::{Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::atomic::{AtomicBool, AtomicI32, Ordering},
     task::Context,
 };
@@ -14,7 +14,7 @@ use smoltcp::{
     iface::SocketHandle,
     socket::tcp as smol,
     time::Duration,
-    wire::{IpEndpoint, IpListenEndpoint},
+    wire::{IpAddress, IpEndpoint, IpListenEndpoint},
 };
 use spin::Lazy;
 
@@ -68,7 +68,7 @@ impl TcpSocket {
     }
 
     /// Creates a new TCP socket that is already connected.
-    fn new_connected(handle: SocketHandle) -> Self {
+    fn new_connected(handle: SocketHandle, is_ipv6: bool) -> Self {
         let result = Self {
             state: StateLock::new(State::Connected),
             handle,
@@ -80,6 +80,7 @@ impl TcpSocket {
             rx_closed: AtomicBool::new(false),
             poll_rx_closed: PollSet::new(),
         };
+        result.general.set_is_ipv6(is_ipv6);
         let endpoint = result.with_smol_socket(|socket| socket_bound_endpoint(socket));
         *result.bound_endpoint.lock() = endpoint;
         result
@@ -135,13 +136,49 @@ impl TcpSocket {
             .map_or(AxError::ConnectionRefused, AxError::from)
     }
 
+    fn unspecified_addr(&self) -> IpAddr {
+        if self.general.is_ipv6() {
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+        } else {
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+        }
+    }
+
+    fn normalize_socket_addr(&self, addr: SocketAddr) -> AxResult<SocketAddr> {
+        match (self.general.is_ipv6(), addr) {
+            (false, SocketAddr::V4(_)) => Ok(addr),
+            (true, SocketAddr::V6(addr)) => {
+                if let Some(v4) = addr.ip().to_ipv4_mapped() {
+                    if self.general.v6only() {
+                        Err(AxError::from(LinuxError::EAFNOSUPPORT))
+                    } else {
+                        Ok(SocketAddr::new(IpAddr::V4(v4), addr.port()))
+                    }
+                } else {
+                    Ok(SocketAddr::V6(addr))
+                }
+            }
+            _ => Err(AxError::from(LinuxError::EAFNOSUPPORT)),
+        }
+    }
+
+    fn ip_addr_for_user(&self, addr: Option<IpAddress>) -> IpAddr {
+        match addr {
+            Some(IpAddress::Ipv4(v4)) if self.general.is_ipv6() => IpAddr::V6(v4.to_ipv6_mapped()),
+            Some(addr) => addr.into(),
+            None => self.unspecified_addr(),
+        }
+    }
+
     fn poll_connect(&self) -> IoEvents {
         let mut events = IoEvents::empty();
         self.with_smol_socket(|socket| match socket.state() {
             smol::State::SynSent | smol::State::SynReceived => {
                 // wait for connection
             }
-            smol::State::Established => {
+            smol::State::Established | smol::State::CloseWait => {
+                // CloseWait: server accepted then immediately sent FIN.
+                // connect() should still succeed because the 3-way handshake completed.
                 self.clear_pending_error();
                 self.state.set(State::Connected); // connected
                 debug!(
@@ -254,7 +291,7 @@ impl Configurable for TcpSocket {
 }
 impl SocketOps for TcpSocket {
     fn bind(&self, local_addr: SocketAddrEx) -> AxResult {
-        let mut local_addr = local_addr.into_ip()?;
+        let mut local_addr = self.normalize_socket_addr(local_addr.into_ip()?)?;
         self.state
             .lock(State::Idle)
             .map_err(|_| ax_err_type!(InvalidInput, "already bound"))?
@@ -291,7 +328,7 @@ impl SocketOps for TcpSocket {
     }
 
     fn connect(&self, remote_addr: SocketAddrEx) -> AxResult {
-        let remote_addr = remote_addr.into_ip()?;
+        let remote_addr = self.normalize_socket_addr(remote_addr.into_ip()?)?;
         self.state
             .lock(State::Idle)
             .map_err(|state| {
@@ -384,7 +421,12 @@ impl SocketOps for TcpSocket {
                 if register_bound {
                     register_tcp_bound(bound_endpoint)?;
                 }
-                if let Err(err) = LISTEN_TABLE.listen(bound_endpoint, backlog) {
+                if let Err(err) = LISTEN_TABLE.listen(
+                    bound_endpoint,
+                    backlog,
+                    self.general.is_ipv6(),
+                    self.general.v6only(),
+                ) {
                     if register_bound {
                         unregister_tcp_bound(bound_endpoint);
                     }
@@ -413,12 +455,12 @@ impl SocketOps for TcpSocket {
         let bound_port = self.bound_endpoint()?.port;
         self.general.recv_poller(self, || {
             poll_interfaces();
-            let handle = {
+            let (handle, is_ipv6) = {
                 let sockets = SOCKET_SET.inner.lock();
                 LISTEN_TABLE.accept(bound_port, &sockets)?
             };
             Ok({
-                let socket = TcpSocket::new_connected(handle);
+                let socket = TcpSocket::new_connected(handle, is_ipv6);
                 debug!(
                     "accepted connection from {}, {}",
                     handle,
@@ -493,21 +535,32 @@ impl SocketOps for TcpSocket {
                 .unwrap_or_else(|| *self.bound_endpoint.lock())
         });
         Ok(SocketAddrEx::Ip(SocketAddr::new(
-            endpoint
-                .addr
-                .map_or_else(|| Ipv4Addr::UNSPECIFIED.into(), Into::into),
+            self.ip_addr_for_user(endpoint.addr),
             endpoint.port,
         )))
     }
 
     fn peer_addr(&self) -> AxResult<SocketAddrEx> {
+        let is_ipv6 = self.general.is_ipv6();
         self.with_smol_socket(|socket| {
-            Ok(SocketAddrEx::Ip(
-                socket
-                    .remote_endpoint()
-                    .ok_or(AxError::NotConnected)?
+            let endpoint = socket.remote_endpoint().ok_or(AxError::NotConnected)?;
+            if is_ipv6 {
+                // For an IPv6 socket with an IPv4 peer, present the address as
+                // IPv4-mapped (::ffff:a.b.c.d) so that userspace sees AF_INET6.
+                let mapped_addr = match endpoint.addr {
+                    IpAddress::Ipv4(v4) => IpAddress::Ipv6(v4.to_ipv6_mapped()),
+                    other => other,
+                };
+                Ok(SocketAddrEx::Ip(
+                    IpEndpoint {
+                        addr: mapped_addr,
+                        port: endpoint.port,
+                    }
                     .into(),
-            ))
+                ))
+            } else {
+                Ok(SocketAddrEx::Ip(endpoint.into()))
+            }
         })
     }
 

--- a/os/arceos/modules/axnet-ng/src/udp.rs
+++ b/os/arceos/modules/axnet-ng/src/udp.rs
@@ -1,10 +1,10 @@
 use alloc::vec;
 use core::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     task::Context,
 };
 
-use ax_errno::{AxError, AxResult, ax_bail, ax_err_type};
+use ax_errno::{AxError, AxResult, LinuxError, ax_bail, ax_err_type};
 use ax_io::prelude::*;
 use ax_sync::Mutex;
 use axpoll::{IoEvents, Pollable};
@@ -69,6 +69,40 @@ impl UdpSocket {
             None => Err(AxError::NotConnected),
         }
     }
+
+    fn normalize_socket_addr(&self, addr: SocketAddr) -> AxResult<SocketAddr> {
+        match (self.general.is_ipv6(), addr) {
+            (false, SocketAddr::V4(_)) => Ok(addr),
+            (true, SocketAddr::V6(addr)) => {
+                if let Some(v4) = addr.ip().to_ipv4_mapped() {
+                    if self.general.v6only() {
+                        Err(AxError::from(LinuxError::EAFNOSUPPORT))
+                    } else {
+                        Ok(SocketAddr::new(IpAddr::V4(v4), addr.port()))
+                    }
+                } else {
+                    Ok(SocketAddr::V6(addr))
+                }
+            }
+            _ => Err(AxError::from(LinuxError::EAFNOSUPPORT)),
+        }
+    }
+
+    fn unspecified_addr(&self) -> IpAddr {
+        if self.general.is_ipv6() {
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+        } else {
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+        }
+    }
+
+    fn ip_endpoint_for_user(&self, endpoint: IpEndpoint) -> SocketAddr {
+        let addr = match endpoint.addr {
+            IpAddress::Ipv4(v4) if self.general.is_ipv6() => IpAddr::V6(v4.to_ipv6_mapped()),
+            addr => addr.into(),
+        };
+        SocketAddr::new(addr, endpoint.port)
+    }
 }
 
 impl Configurable for UdpSocket {
@@ -114,7 +148,7 @@ impl Configurable for UdpSocket {
 }
 impl SocketOps for UdpSocket {
     fn bind(&self, local_addr: SocketAddrEx) -> AxResult {
-        let mut local_addr = local_addr.into_ip()?;
+        let mut local_addr = self.normalize_socket_addr(local_addr.into_ip()?)?;
         let mut guard = self.local_addr.write();
 
         if local_addr.port() == 0 {
@@ -150,11 +184,11 @@ impl SocketOps for UdpSocket {
     }
 
     fn connect(&self, remote_addr: SocketAddrEx) -> AxResult {
-        let remote_addr = remote_addr.into_ip()?;
+        let remote_addr = self.normalize_socket_addr(remote_addr.into_ip()?)?;
         let mut guard = self.peer_addr.write();
         if self.local_addr.read().is_none() {
             self.bind(SocketAddrEx::Ip(SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                self.unspecified_addr(),
                 0,
             )))?;
         }
@@ -169,7 +203,7 @@ impl SocketOps for UdpSocket {
     fn send(&self, mut src: impl Read + IoBuf, options: SendOptions) -> AxResult<usize> {
         let (remote_addr, source_addr) = match options.to {
             Some(addr) => {
-                let addr = IpEndpoint::from(addr.into_ip()?);
+                let addr = IpEndpoint::from(self.normalize_socket_addr(addr.into_ip()?)?);
                 let src = get_service().get_source_address(&addr.addr);
                 (addr, src)
             }
@@ -181,7 +215,7 @@ impl SocketOps for UdpSocket {
 
         if self.local_addr.read().is_none() {
             self.bind(SocketAddrEx::Ip(SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                self.unspecified_addr(),
                 0,
             )))?;
         }
@@ -249,7 +283,8 @@ impl SocketOps for UdpSocket {
                         Ok((src, meta)) => {
                             match &mut expected_remote {
                                 ExpectedRemote::Any(remote_addr) => {
-                                    **remote_addr = SocketAddrEx::Ip(meta.endpoint.into());
+                                    **remote_addr =
+                                        SocketAddrEx::Ip(self.ip_endpoint_for_user(meta.endpoint));
                                 }
                                 ExpectedRemote::Expecting(expected) => {
                                     if (!expected.addr.is_unspecified()
@@ -286,7 +321,7 @@ impl SocketOps for UdpSocket {
     fn local_addr(&self) -> AxResult<SocketAddrEx> {
         match self.local_addr.try_read() {
             Some(addr) => addr
-                .map(Into::into)
+                .map(|addr| self.ip_endpoint_for_user(addr))
                 .map(SocketAddrEx::Ip)
                 .ok_or(AxError::NotConnected),
             None => Err(AxError::NotConnected),
@@ -295,7 +330,7 @@ impl SocketOps for UdpSocket {
 
     fn peer_addr(&self) -> AxResult<SocketAddrEx> {
         self.remote_endpoint()
-            .map(|it| it.0.into())
+            .map(|it| self.ip_endpoint_for_user(it.0))
             .map(SocketAddrEx::Ip)
     }
 

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-ipv6-dualstack C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-ipv6-dualstack src/main.c)
+target_include_directories(test-ipv6-dualstack PRIVATE src)
+target_compile_options(test-ipv6-dualstack PRIVATE -Wall -Wextra)
+
+install(TARGETS test-ipv6-dualstack RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/c/prebuild.sh
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/c/src/main.c
@@ -1,0 +1,321 @@
+/*
+ * test-ipv6-dualstack: 验证 AF_INET6 双栈模式（IPV6_V6ONLY=0）
+ *
+ * 背景：wget 在系统同时有 A 和 AAAA 记录时，会先创建 AF_INET6 socket，
+ * 并通过 IPV6_V6ONLY=0（双栈）让同一个 socket 也能连接 IPv4 目标。
+ * 这要求内核对 AF_INET6 socket 做 IPv4-mapped 地址转换：
+ *   - 客户端通过 127.0.0.1 连接服务端
+ *   - 服务端（AF_INET6 socket，IPV6_V6ONLY=0）accept 到的对端地址
+ *     应为 ::ffff:127.0.0.1（IN6_IS_ADDR_V4MAPPED 为真）
+ *
+ * 测试分两部分：
+ *   A. 纯 IPv6-only 模式（IPV6_V6ONLY=1）：AF_INET 客户端连接被拒绝
+ *   B. 双栈模式（IPV6_V6ONLY=0）：AF_INET 客户端可成功连接
+ *
+ * 全部使用本地回环，无需外部网络。
+ */
+
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+#define BASE_PORT 28090
+#define MSG       "dual"
+#define MSGLEN    (sizeof(MSG))
+
+/* 等待子进程并检查退出状态 */
+static void wait_child(pid_t pid, const char *label)
+{
+    int status = 0;
+    pid_t r;
+    do { r = waitpid(pid, &status, 0); } while (r == -1 && errno == EINTR);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0, label);
+}
+
+/* ── A. IPV6_V6ONLY = 1：AF_INET 客户端必须被拒绝 ──────────────── */
+static void test_v6only_rejects_v4(void)
+{
+    int server = socket(AF_INET6, SOCK_STREAM, 0);
+    if (server < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    /* 设置 IPV6_V6ONLY = 1：只接受纯 IPv6 连接 */
+    CHECK_RET(setsockopt(server, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one)),
+              0, "setsockopt(IPV6_V6ONLY=1)");
+
+    struct sockaddr_in6 saddr = {0};
+    saddr.sin6_family = AF_INET6;
+    saddr.sin6_port   = htons(BASE_PORT);
+    saddr.sin6_addr   = in6addr_any; /* :: */
+
+    if (bind(server, (struct sockaddr *)&saddr, sizeof(saddr)) != 0 ||
+        listen(server, 5) != 0) {
+        close(server);
+        __fail++;
+        return;
+    }
+
+    /* 子进程：AF_INET 客户端尝试连接 127.0.0.1 */
+    pid_t pid = fork();
+    if (pid == 0) {
+        close(server);
+        int c = socket(AF_INET, SOCK_STREAM, 0);
+        if (c < 0) _exit(2);
+        struct sockaddr_in v4 = {0};
+        v4.sin_family      = AF_INET;
+        v4.sin_port        = htons(BASE_PORT);
+        v4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        /* 连接应失败（IPV6_V6ONLY=1 → 服务端不接受 IPv4-mapped）*/
+        int r = connect(c, (struct sockaddr *)&v4, sizeof(v4));
+        close(c);
+        /* 退出码 0：connect 失败（预期）；退出码 1：connect 成功（非预期）*/
+        _exit(r != 0 ? 0 : 1);
+    }
+
+    /* 设置非阻塞，短暂等待后关闭（不期望 accept 成功）*/
+    struct timeval tv = { .tv_sec = 2, .tv_usec = 0 };
+    setsockopt(server, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    struct sockaddr_in6 peer = {0};
+    socklen_t plen = sizeof(peer);
+    int conn = accept(server, (struct sockaddr *)&peer, &plen);
+    CHECK(conn < 0, "IPV6_V6ONLY=1: AF_INET client should NOT be accepted");
+    if (conn >= 0) close(conn);
+
+    close(server);
+    wait_child(pid, "IPV6_V6ONLY=1: AF_INET client connect should fail");
+}
+
+/* ── B. IPV6_V6ONLY = 0：AF_INET 客户端必须成功连接 ────────────── */
+static void test_dualstack_accepts_v4(void)
+{
+    int server = socket(AF_INET6, SOCK_STREAM, 0);
+    if (server < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    /* 设置 IPV6_V6ONLY = 0：双栈模式，接受 IPv4-mapped 连接 */
+    int zero = 0;
+    CHECK_RET(setsockopt(server, IPPROTO_IPV6, IPV6_V6ONLY, &zero, sizeof(zero)),
+              0, "setsockopt(IPV6_V6ONLY=0)");
+
+    struct sockaddr_in6 saddr = {0};
+    saddr.sin6_family = AF_INET6;
+    saddr.sin6_port   = htons(BASE_PORT + 1);
+    saddr.sin6_addr   = in6addr_any; /* :: */
+
+    if (bind(server, (struct sockaddr *)&saddr, sizeof(saddr)) != 0 ||
+        listen(server, 5) != 0) {
+        close(server);
+        __fail++;
+        return;
+    }
+
+    /* 子进程：AF_INET 客户端连接 127.0.0.1 */
+    pid_t pid = fork();
+    if (pid == 0) {
+        close(server);
+        int c = socket(AF_INET, SOCK_STREAM, 0);
+        if (c < 0) _exit(1);
+        struct sockaddr_in v4 = {0};
+        v4.sin_family      = AF_INET;
+        v4.sin_port        = htons(BASE_PORT + 1);
+        v4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        if (connect(c, (struct sockaddr *)&v4, sizeof(v4)) != 0) {
+            close(c); _exit(1);
+        }
+        ssize_t n = send(c, MSG, MSGLEN, 0);
+        close(c);
+        _exit(n == (ssize_t)MSGLEN ? 0 : 1);
+    }
+
+    /* 服务端 accept */
+    struct sockaddr_in6 peer = {0};
+    socklen_t plen = sizeof(peer);
+    int conn = accept(server, (struct sockaddr *)&peer, &plen);
+    CHECK(conn >= 0, "IPV6_V6ONLY=0: accept() from AF_INET client succeeded");
+
+    if (conn >= 0) {
+        /* 对端地址必须是 AF_INET6 且为 IPv4-mapped（::ffff:127.0.0.1）*/
+        CHECK(peer.sin6_family == AF_INET6,
+              "peer.sin6_family == AF_INET6 (IPv4-mapped)");
+        CHECK(IN6_IS_ADDR_V4MAPPED(&peer.sin6_addr),
+              "peer address is IPv4-mapped (::ffff:127.0.0.1)");
+
+        /* 验证数据收发正常 */
+        char buf[32] = {0};
+        ssize_t n = recv(conn, buf, sizeof(buf), 0);
+        CHECK(n == (ssize_t)MSGLEN, "recv from IPv4-mapped client: correct length");
+        CHECK(memcmp(buf, MSG, MSGLEN) == 0, "recv from IPv4-mapped client: correct data");
+
+        /* getpeername 也应返回 IPv4-mapped 地址 */
+        struct sockaddr_in6 remote = {0};
+        socklen_t rlen = sizeof(remote);
+        CHECK_RET(getpeername(conn, (struct sockaddr *)&remote, &rlen),
+                  0, "getpeername on dual-stack conn");
+        CHECK(IN6_IS_ADDR_V4MAPPED(&remote.sin6_addr),
+              "getpeername: IPv4-mapped address");
+
+        close(conn);
+    }
+
+    close(server);
+    wait_child(pid, "dual-stack: AF_INET client connect + send succeeded");
+}
+
+/* ── C. AF_INET6 客户端使用 IPv4-mapped 地址连接 IPv4 服务端 ───── */
+static void test_v6_client_v4mapped_connect(void)
+{
+    int server = socket(AF_INET, SOCK_STREAM, 0);
+    if (server < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct sockaddr_in saddr = {0};
+    saddr.sin_family      = AF_INET;
+    saddr.sin_port        = htons(BASE_PORT + 2);
+    saddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    if (bind(server, (struct sockaddr *)&saddr, sizeof(saddr)) != 0 ||
+        listen(server, 5) != 0) {
+        close(server);
+        __fail++;
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        close(server);
+        int c = socket(AF_INET6, SOCK_STREAM, 0);
+        if (c < 0) _exit(1);
+
+        int zero = 0;
+        if (setsockopt(c, IPPROTO_IPV6, IPV6_V6ONLY, &zero, sizeof(zero)) != 0) {
+            close(c); _exit(1);
+        }
+
+        struct sockaddr_in6 mapped = {0};
+        mapped.sin6_family = AF_INET6;
+        mapped.sin6_port   = htons(BASE_PORT + 2);
+        inet_pton(AF_INET6, "::ffff:127.0.0.1", &mapped.sin6_addr);
+
+        if (connect(c, (struct sockaddr *)&mapped, sizeof(mapped)) != 0) {
+            close(c); _exit(1);
+        }
+
+        struct sockaddr_in6 local = {0};
+        socklen_t llen = sizeof(local);
+        if (getsockname(c, (struct sockaddr *)&local, &llen) != 0 ||
+            local.sin6_family != AF_INET6 ||
+            !IN6_IS_ADDR_V4MAPPED(&local.sin6_addr)) {
+            close(c); _exit(1);
+        }
+
+        struct sockaddr_in6 peer = {0};
+        socklen_t plen = sizeof(peer);
+        if (getpeername(c, (struct sockaddr *)&peer, &plen) != 0 ||
+            peer.sin6_family != AF_INET6 ||
+            !IN6_IS_ADDR_V4MAPPED(&peer.sin6_addr)) {
+            close(c); _exit(1);
+        }
+
+        ssize_t n = send(c, MSG, MSGLEN, 0);
+        close(c);
+        _exit(n == (ssize_t)MSGLEN ? 0 : 1);
+    }
+
+    struct sockaddr_in peer = {0};
+    socklen_t plen = sizeof(peer);
+    int conn = accept(server, (struct sockaddr *)&peer, &plen);
+    CHECK(conn >= 0, "IPv4 server accepts AF_INET6 IPv4-mapped client");
+    if (conn >= 0) {
+        CHECK(peer.sin_family == AF_INET,
+              "IPv4 server accept peer family remains AF_INET");
+        char buf[32] = {0};
+        ssize_t n = recv(conn, buf, sizeof(buf), 0);
+        CHECK(n == (ssize_t)MSGLEN, "IPv4-mapped connect: recv correct length");
+        CHECK(memcmp(buf, MSG, MSGLEN) == 0, "IPv4-mapped connect: recv correct data");
+        close(conn);
+    }
+
+    close(server);
+    wait_child(pid, "AF_INET6 IPv4-mapped client connect + send succeeded");
+}
+
+/* ── D. IPv6-only 客户端连接 IPv6-only 服务端 ───────────────────── */
+static void test_v6only_pure_ipv6(void)
+{
+    int server = socket(AF_INET6, SOCK_STREAM, 0);
+    if (server < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    setsockopt(server, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one));
+
+    struct sockaddr_in6 saddr = {0};
+    saddr.sin6_family = AF_INET6;
+    saddr.sin6_port   = htons(BASE_PORT + 3);
+    saddr.sin6_addr   = in6addr_loopback; /* ::1 */
+
+    if (bind(server, (struct sockaddr *)&saddr, sizeof(saddr)) != 0 ||
+        listen(server, 5) != 0) {
+        close(server);
+        __fail++;
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        close(server);
+        /* AF_INET6 客户端连接 ::1 */
+        int c = socket(AF_INET6, SOCK_STREAM, 0);
+        if (c < 0) _exit(1);
+        if (connect(c, (struct sockaddr *)&saddr, sizeof(saddr)) != 0) {
+            close(c); _exit(1);
+        }
+        ssize_t n = send(c, MSG, MSGLEN, 0);
+        close(c);
+        _exit(n == (ssize_t)MSGLEN ? 0 : 1);
+    }
+
+    struct sockaddr_in6 peer = {0};
+    socklen_t plen = sizeof(peer);
+    int conn = accept(server, (struct sockaddr *)&peer, &plen);
+    CHECK(conn >= 0, "IPV6_V6ONLY=1: pure IPv6 client accepted");
+
+    if (conn >= 0) {
+        CHECK(!IN6_IS_ADDR_V4MAPPED(&peer.sin6_addr),
+              "pure IPv6 peer is NOT IPv4-mapped");
+
+        char buf[32] = {0};
+        ssize_t n = recv(conn, buf, sizeof(buf), 0);
+        CHECK(n == (ssize_t)MSGLEN, "pure IPv6: recv correct length");
+        close(conn);
+    }
+
+    close(server);
+    wait_child(pid, "IPV6_V6ONLY=1: pure IPv6 connect + send succeeded");
+}
+
+int main(void)
+{
+    TEST_START("AF_INET6 dual-stack (IPV6_V6ONLY)");
+
+    test_v6only_rejects_v4();
+    test_dualstack_accepts_v4();
+    test_v6_client_v4mapped_connect();
+    test_v6only_pure_ipv6();
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/c/src/test_framework.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                      \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",         \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);              \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-ipv6-dualstack"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-dualstack/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-ipv6-dualstack"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-ipv6-socket C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-ipv6-socket src/main.c)
+target_include_directories(test-ipv6-socket PRIVATE src)
+target_compile_options(test-ipv6-socket PRIVATE -Wall -Wextra)
+
+install(TARGETS test-ipv6-socket RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/c/prebuild.sh
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/c/src/main.c
@@ -1,0 +1,382 @@
+/*
+ * test-ipv6-socket: 验证 AF_INET6 socket 完整 syscall 路径
+ *
+ * 测试覆盖 wget 发起 HTTP 连接所需的全部 syscall：
+ *   socket(AF_INET6, SOCK_STREAM, 0)
+ *   socket(AF_INET6, SOCK_DGRAM,  0)
+ *   setsockopt / getsockopt (IPV6_V6ONLY, SO_REUSEADDR)
+ *   bind(sockaddr_in6) / listen / accept / connect
+ *   send / recv
+ *   getsockname / getpeername（验证返回 AF_INET6 地址）
+ *   shutdown
+ *
+ * 全部使用本地回环地址 ::1，无需外部网络。
+ *
+ * 通过条件：DONE: N pass, 0 fail
+ */
+
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+/* 每个子测试使用独立端口，避免 TIME_WAIT 干扰 */
+#define BASE_PORT 28080
+#define MSG       "hello ipv6"
+#define MSGLEN    (sizeof(MSG))  /* 含末尾 '\0' */
+
+/* ── 1. socket() 创建与关闭 ─────────────────────────────────────── */
+static void test_socket_create(void)
+{
+    int fd;
+
+    fd = socket(AF_INET6, SOCK_STREAM, 0);
+    CHECK(fd >= 0, "socket(AF_INET6, SOCK_STREAM, 0)");
+    if (fd >= 0) close(fd);
+
+    fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    CHECK(fd >= 0, "socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP)");
+    if (fd >= 0) close(fd);
+
+    fd = socket(AF_INET6, SOCK_DGRAM, 0);
+    CHECK(fd >= 0, "socket(AF_INET6, SOCK_DGRAM, 0)");
+    if (fd >= 0) close(fd);
+
+    fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+    CHECK(fd >= 0, "socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)");
+    if (fd >= 0) close(fd);
+}
+
+/* ── 2. setsockopt / getsockopt (IPV6_V6ONLY) ───────────────────── */
+static void test_sockopt_ipv6only(void)
+{
+    int fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) { __fail++; return; }
+
+    /* setsockopt IPV6_V6ONLY = 1 */
+    int val = 1;
+    CHECK_RET(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val)),
+              0, "setsockopt(IPPROTO_IPV6, IPV6_V6ONLY, 1)");
+
+    /* getsockopt should reflect the set value */
+    int got = 0;
+    socklen_t len = sizeof(got);
+    CHECK_RET(getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &got, &len),
+              0, "getsockopt(IPPROTO_IPV6, IPV6_V6ONLY)");
+    CHECK(got == 1, "IPV6_V6ONLY reads back 1");
+
+    /* setsockopt IPV6_V6ONLY = 0 (dual-stack mode) */
+    val = 0;
+    CHECK_RET(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val)),
+              0, "setsockopt(IPPROTO_IPV6, IPV6_V6ONLY, 0)");
+
+    close(fd);
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) { __fail++; return; }
+
+    val = 1;
+    CHECK_ERR(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val)),
+              ENOPROTOOPT, "AF_INET setsockopt(IPV6_V6ONLY) -> ENOPROTOOPT");
+    got = 0;
+    len = sizeof(got);
+    CHECK_ERR(getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &got, &len),
+              ENOPROTOOPT, "AF_INET getsockopt(IPV6_V6ONLY) -> ENOPROTOOPT");
+
+    close(fd);
+}
+
+/* ── 3. SO_REUSEADDR on AF_INET6 socket ─────────────────────────── */
+static void test_sockopt_reuseaddr(void)
+{
+    int fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) { __fail++; return; }
+
+    int val = 1;
+    CHECK_RET(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)),
+              0, "setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)");
+
+    int got = 0;
+    socklen_t len = sizeof(got);
+    CHECK_RET(getsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &got, &len),
+              0, "getsockopt(SOL_SOCKET, SO_REUSEADDR)");
+    CHECK(got != 0, "SO_REUSEADDR reads back non-zero");
+
+    close(fd);
+}
+
+/* ── 4. bind(sockaddr_in6) 到 ::1 ───────────────────────────────── */
+static void test_bind_loopback(void)
+{
+    int fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct sockaddr_in6 addr = {0};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port   = htons(BASE_PORT);
+    addr.sin6_addr   = in6addr_loopback; /* ::1 */
+
+    CHECK_RET(bind(fd, (struct sockaddr *)&addr, sizeof(addr)),
+              0, "bind(AF_INET6, ::1, port)");
+
+    close(fd);
+}
+
+/* ── 5. TCP 回环：listen / accept / connect / send / recv ────────── */
+static void test_tcp_loopback(void)
+{
+    int server = socket(AF_INET6, SOCK_STREAM, 0);
+    if (server < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct sockaddr_in6 addr = {0};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port   = htons(BASE_PORT + 1);
+    addr.sin6_addr   = in6addr_loopback;
+
+    if (bind(server, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        printf("  FAIL | %s:%d | bind failed: errno=%d\n",
+               __FILE__, __LINE__, errno);
+        __fail++;
+        close(server);
+        return;
+    }
+    CHECK_RET(listen(server, 5), 0, "listen(AF_INET6 server)");
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* ── child: client ── */
+        close(server);
+        int c = socket(AF_INET6, SOCK_STREAM, 0);
+        if (c < 0) _exit(1);
+        if (connect(c, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+            close(c);
+            _exit(1);
+        }
+        ssize_t n = send(c, MSG, MSGLEN, 0);
+        close(c);
+        _exit(n == (ssize_t)MSGLEN ? 0 : 1);
+    }
+
+    /* ── parent: server ── */
+    struct sockaddr_in6 peer = {0};
+    socklen_t plen = sizeof(peer);
+    int conn = accept(server, (struct sockaddr *)&peer, &plen);
+    CHECK(conn >= 0, "accept() returns valid fd");
+
+    if (conn >= 0) {
+        /* peer 地址族必须是 AF_INET6 */
+        CHECK(peer.sin6_family == AF_INET6,
+              "accepted peer.sin6_family == AF_INET6");
+
+        /* recv 数据 */
+        char buf[64] = {0};
+        ssize_t n = recv(conn, buf, sizeof(buf), 0);
+        CHECK(n == (ssize_t)MSGLEN, "recv: correct length");
+        CHECK(memcmp(buf, MSG, MSGLEN) == 0, "recv: correct data");
+
+        /* getsockname：获取本端地址 */
+        struct sockaddr_in6 local = {0};
+        socklen_t llen = sizeof(local);
+        CHECK_RET(getsockname(conn, (struct sockaddr *)&local, &llen),
+                  0, "getsockname on accepted conn");
+        CHECK(local.sin6_family == AF_INET6,
+              "getsockname: local.sin6_family == AF_INET6");
+        CHECK(ntohs(local.sin6_port) == (BASE_PORT + 1),
+              "getsockname: local port matches bind port");
+
+        /* getpeername：获取对端地址 */
+        struct sockaddr_in6 remote = {0};
+        socklen_t rlen = sizeof(remote);
+        CHECK_RET(getpeername(conn, (struct sockaddr *)&remote, &rlen),
+                  0, "getpeername on accepted conn");
+        CHECK(remote.sin6_family == AF_INET6,
+              "getpeername: remote.sin6_family == AF_INET6");
+
+        close(conn);
+    }
+
+    close(server);
+
+    int status = 0;
+    pid_t waited;
+    do { waited = waitpid(pid, &status, 0); } while (waited == -1 && errno == EINTR);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0,
+          "client child: connect + send succeeded");
+}
+
+/* ── 6. getsockname 在 bind 之后（未 accept 前）─────────────────── */
+static void test_getsockname_bound(void)
+{
+    int fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct sockaddr_in6 addr = {0};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port   = htons(BASE_PORT + 2);
+    addr.sin6_addr   = in6addr_loopback;
+    bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+
+    struct sockaddr_in6 out = {0};
+    socklen_t olen = sizeof(out);
+    CHECK_RET(getsockname(fd, (struct sockaddr *)&out, &olen),
+              0, "getsockname after bind");
+    CHECK(out.sin6_family == AF_INET6,
+          "getsockname: family == AF_INET6");
+    CHECK(ntohs(out.sin6_port) == (BASE_PORT + 2),
+          "getsockname: port matches");
+
+    close(fd);
+}
+
+/* ── 7. shutdown on AF_INET6 listening socket ───────────────────── */
+static void test_shutdown(void)
+{
+    int fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct sockaddr_in6 addr = {0};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port   = htons(BASE_PORT + 3);
+    addr.sin6_addr   = in6addr_loopback;
+    bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+    listen(fd, 1);
+
+    CHECK_RET(shutdown(fd, SHUT_RD),   0, "shutdown(SHUT_RD)");
+    CHECK_RET(shutdown(fd, SHUT_WR),   0, "shutdown(SHUT_WR)");
+
+    close(fd);
+}
+
+/* ── 8. UDP over IPv6 loopback ──────────────────────────────────── */
+static void test_udp_loopback(void)
+{
+    int server = socket(AF_INET6, SOCK_DGRAM, 0);
+    if (server < 0) { __fail++; return; }
+
+    struct sockaddr_in6 addr = {0};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port   = htons(BASE_PORT + 4);
+    addr.sin6_addr   = in6addr_loopback;
+
+    CHECK_RET(bind(server, (struct sockaddr *)&addr, sizeof(addr)),
+              0, "UDP bind(AF_INET6, ::1)");
+
+    int client = socket(AF_INET6, SOCK_DGRAM, 0);
+    CHECK(client >= 0, "UDP client socket(AF_INET6, SOCK_DGRAM)");
+    if (client < 0) { close(server); return; }
+
+    /* sendto */
+    ssize_t n = sendto(client, MSG, MSGLEN, 0,
+                       (struct sockaddr *)&addr, sizeof(addr));
+    CHECK(n == (ssize_t)MSGLEN, "UDP sendto ::1");
+
+    /* recvfrom */
+    char buf[64] = {0};
+    struct sockaddr_in6 from = {0};
+    socklen_t fromlen = sizeof(from);
+    n = recvfrom(server, buf, sizeof(buf), 0,
+                 (struct sockaddr *)&from, &fromlen);
+    CHECK(n == (ssize_t)MSGLEN, "UDP recvfrom: correct length");
+    CHECK(memcmp(buf, MSG, MSGLEN) == 0, "UDP recvfrom: correct data");
+    CHECK(from.sin6_family == AF_INET6,
+          "UDP recvfrom: sender.sin6_family == AF_INET6");
+
+    close(client);
+    close(server);
+}
+
+/* ── 9. connect + getsockname（auto-bind 后本地端口非零）────────── */
+static void test_connect_autobind(void)
+{
+    /* 先建一个 TCP 服务端监听 ::1 */
+    int server = socket(AF_INET6, SOCK_STREAM, 0);
+    if (server < 0) { __fail++; return; }
+
+    int one = 1;
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct sockaddr_in6 saddr = {0};
+    saddr.sin6_family = AF_INET6;
+    saddr.sin6_port   = htons(BASE_PORT + 5);
+    saddr.sin6_addr   = in6addr_loopback;
+
+    if (bind(server, (struct sockaddr *)&saddr, sizeof(saddr)) != 0 ||
+        listen(server, 5) != 0) {
+        close(server);
+        __fail++;
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* child: just accept and close */
+        struct sockaddr_in6 peer;
+        socklen_t plen = sizeof(peer);
+        int conn = accept(server, (struct sockaddr *)&peer, &plen);
+        if (conn >= 0) close(conn);
+        close(server);
+        _exit(0);
+    }
+
+    close(server);
+
+    /* parent: connect, then getsockname to check auto-bound port */
+    int c = socket(AF_INET6, SOCK_STREAM, 0);
+    if (c < 0) { __fail++; goto wait; }
+
+    CHECK_RET(connect(c, (struct sockaddr *)&saddr, sizeof(saddr)),
+              0, "connect to ::1");
+
+    struct sockaddr_in6 local = {0};
+    socklen_t llen = sizeof(local);
+    CHECK_RET(getsockname(c, (struct sockaddr *)&local, &llen),
+              0, "getsockname after connect");
+    CHECK(local.sin6_family == AF_INET6,
+          "getsockname after connect: AF_INET6");
+    CHECK(ntohs(local.sin6_port) != 0,
+          "getsockname after connect: auto-bound port != 0");
+
+    close(c);
+
+wait:
+    {
+        int status = 0;
+        pid_t waited;
+        do { waited = waitpid(pid, &status, 0); } while (waited == -1 && errno == EINTR);
+    }
+}
+
+int main(void)
+{
+    TEST_START("AF_INET6 socket syscalls (wget path)");
+
+    test_socket_create();
+    test_sockopt_ipv6only();
+    test_sockopt_reuseaddr();
+    test_bind_loopback();
+    test_tcp_loopback();
+    test_getsockname_bound();
+    test_shutdown();
+    test_udp_loopback();
+    test_connect_autobind();
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/c/src/test_framework.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                      \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",         \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);              \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-ipv6-socket"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30

--- a/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-ipv6-socket/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-ipv6-socket"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 30


### PR DESCRIPTION
## Summary

This replaces #323 with the same AF_INET6 socket support rebased onto the latest `dev` branch.

Changes include:

- enable smoltcp IPv6 support for `ax-net-ng`
- add AF_INET6 TCP/UDP socket creation and `IPV6_V6ONLY` getsockopt/setsockopt handling in StarryOS
- add dual-stack TCP handling, including IPv4-mapped IPv6 addresses and `IPV6_V6ONLY` behavior
- preserve current `dev` TCP connect/SO_ERROR behavior while rebasing
- add Starry QEMU cases for IPv6 socket operations and dual-stack behavior

The original PR branch cannot be updated from this repository because #323 has `maintainerCanModify=false` and the head branch belongs to `os-biglab/tgoskits`.

Closes #323.

## Validation

- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `cargo xtask clippy --package ax-net-ng`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --arch x86_64 -c test-ipv6-socket`
- `cargo xtask starry test qemu --arch x86_64 -c test-ipv6-dualstack`
