### PR TITLE
Fix RK3588 PCIe and eMMC stability on Orange Pi 5 Plus

### DIFF
--- a/components/rsext4/src/checksum/dirblock.rs
+++ b/components/rsext4/src/checksum/dirblock.rs
@@ -4,7 +4,8 @@ use super::core::ext4_metadata_csum32;
 use crate::{
     BLOCK_SIZE,
     crc32c::{ext4_crc32c_seed_from_superblock, ext4_superblock_has_metadata_csum},
-    entries::Ext4DirEntryTail,
+    endian::read_u16_le,
+    entries::{Ext4DirEntryTail, Ext4DxEntry, Ext4DxRootInfo},
     superblock::Ext4Superblock,
 };
 
@@ -87,4 +88,91 @@ pub fn ext4_update_dirblock_tail_checksum(
     block_bytes[tail_offset + 8..tail_offset + 12].fill(0);
     let checksum = ext4_dirblock_csum32(sb, ino, generation, &block_bytes[..tail_offset]);
     block_bytes[tail_offset + 8..tail_offset + 12].copy_from_slice(&checksum.to_le_bytes());
+}
+
+/// Verifies the checksum stored in an HTree dx_tail block.
+pub fn verify_ext4_dx_checksum(
+    sb: &Ext4Superblock,
+    ino: u32,
+    generation: u32,
+    block_bytes: &[u8],
+) -> Option<bool> {
+    if !ext4_superblock_has_metadata_csum(sb) {
+        return Some(true);
+    }
+    if block_bytes.len() < BLOCK_SIZE {
+        return Some(false);
+    }
+
+    let count_offset = dx_countlimit_offset(block_bytes)?;
+    if count_offset + 4 > BLOCK_SIZE {
+        return Some(false);
+    }
+
+    let limit = read_u16_le(&block_bytes[count_offset..count_offset + 2]) as usize;
+    let count = read_u16_le(&block_bytes[count_offset + 2..count_offset + 4]) as usize;
+    let entry_size = core::mem::size_of::<Ext4DxEntry>();
+    let tail_len = core::mem::size_of::<u64>();
+
+    if count > limit || count_offset + limit.saturating_mul(entry_size) > BLOCK_SIZE - tail_len {
+        return Some(false);
+    }
+
+    let tail_offset = count_offset + limit * entry_size;
+    if tail_offset + tail_len > BLOCK_SIZE {
+        return Some(false);
+    }
+
+    let data_len = count_offset + count * entry_size;
+    if data_len > tail_offset {
+        return Some(false);
+    }
+
+    let stored = u32::from_le_bytes([
+        block_bytes[tail_offset + 4],
+        block_bytes[tail_offset + 5],
+        block_bytes[tail_offset + 6],
+        block_bytes[tail_offset + 7],
+    ]);
+    let zero_checksum = [0u8; 4];
+    let seed = ext4_crc32c_seed_from_superblock(sb);
+    let ino_le = ino.to_le_bytes();
+    let generation_le = generation.to_le_bytes();
+    let computed = ext4_metadata_csum32(
+        seed,
+        &[
+            &ino_le,
+            &generation_le,
+            &block_bytes[..data_len],
+            &block_bytes[tail_offset..tail_offset + 4],
+            &zero_checksum,
+        ],
+    );
+
+    Some(computed == stored)
+}
+
+fn dx_countlimit_offset(block_bytes: &[u8]) -> Option<usize> {
+    let rec_len = read_u16_le(&block_bytes[4..6]) as usize;
+    if rec_len == BLOCK_SIZE {
+        return Some(8);
+    }
+
+    if rec_len != 12 || BLOCK_SIZE < 32 {
+        return None;
+    }
+
+    let root_info_offset = 24;
+    let reserved_zero = u32::from_le_bytes([
+        block_bytes[root_info_offset],
+        block_bytes[root_info_offset + 1],
+        block_bytes[root_info_offset + 2],
+        block_bytes[root_info_offset + 3],
+    ]);
+    let info_length = block_bytes[root_info_offset + 5];
+    if reserved_zero != 0 || info_length != Ext4DxRootInfo::INFO_LENGTH {
+        return None;
+    }
+
+    Some(32)
 }

--- a/components/rsext4/src/checksum/mod.rs
+++ b/components/rsext4/src/checksum/mod.rs
@@ -12,7 +12,7 @@ pub use core::ext4_metadata_csum32;
 pub use bitmap::{ext4_block_bitmap_csum32, ext4_inode_bitmap_csum32};
 pub use dirblock::{
     ext4_dirblock_csum32, ext4_metadata_block_csum32, ext4_update_dirblock_tail_checksum,
-    update_ext4_dirblock_csum32, verify_ext4_dirblock_checksum,
+    update_ext4_dirblock_csum32, verify_ext4_dirblock_checksum, verify_ext4_dx_checksum,
 };
 pub use inode::{ext4_inode_csum32, ext4_update_inode_checksum};
 pub use journal::{jbd2_superblock_csum32, jbd2_update_superblock_checksum};

--- a/components/rsext4/src/checksum/tests.rs
+++ b/components/rsext4/src/checksum/tests.rs
@@ -1,7 +1,14 @@
 use super::*;
 use crate::{
-    BLOCK_SIZE, bmalloc::InodeNumber, disknode::Ext4Inode, endian::DiskFormat,
-    entries::Ext4DirEntryTail, error::Errno, jbd2::jbdstruct::*, superblock::Ext4Superblock,
+    BLOCK_SIZE,
+    bmalloc::InodeNumber,
+    crc32c::ext4_crc32c_seed_from_superblock,
+    disknode::Ext4Inode,
+    endian::DiskFormat,
+    entries::{Ext4DirEntryTail, Ext4DxEntry},
+    error::Errno,
+    jbd2::jbdstruct::*,
+    superblock::Ext4Superblock,
 };
 
 fn metadata_csum_superblock() -> Ext4Superblock {
@@ -127,6 +134,62 @@ fn dirblock_checksum_is_stored_and_detects_corruption() {
 
     block[0] ^= 0x80;
     assert!(!verify_ext4_dirblock_checksum(&sb, ino, generation, &block));
+}
+
+#[test]
+fn dx_checksum_uses_counted_entries_and_tail() {
+    // Test idea: HTree index blocks store a dx_tail checksum after the full entry limit,
+    // while the checksum covers only the counted dx entries plus the tail's reserved word.
+    let sb = metadata_csum_superblock();
+    let ino = 704258u32;
+    let generation = 7817325u32;
+    let mut block = [0u8; BLOCK_SIZE];
+    let count_offset = 32;
+    let entry_size = ::core::mem::size_of::<Ext4DxEntry>();
+    let limit = ((BLOCK_SIZE - count_offset - 8) / entry_size) as u16;
+    let count = 3u16;
+    let tail_offset = count_offset + limit as usize * entry_size;
+
+    block[0..4].copy_from_slice(&ino.to_le_bytes());
+    block[4..6].copy_from_slice(&12u16.to_le_bytes());
+    block[6] = 1;
+    block[7] = 2;
+    block[12..16].copy_from_slice(&2u32.to_le_bytes());
+    block[16..18].copy_from_slice(&((BLOCK_SIZE - 12) as u16).to_le_bytes());
+    block[18] = 2;
+    block[19] = 2;
+    block[24..28].fill(0);
+    block[29] = 8;
+    block[30] = 0;
+    block[count_offset..count_offset + 2].copy_from_slice(&limit.to_le_bytes());
+    block[count_offset + 2..count_offset + 4].copy_from_slice(&count.to_le_bytes());
+    block[count_offset + 4..count_offset + 8].copy_from_slice(&0x1234_5678u32.to_le_bytes());
+    block[count_offset + 8..count_offset + 12].copy_from_slice(&1u32.to_le_bytes());
+    block[count_offset + 12..count_offset + 16].copy_from_slice(&0x9ABC_DEF0u32.to_le_bytes());
+    block[count_offset + 16..count_offset + 20].copy_from_slice(&5u32.to_le_bytes());
+    block[tail_offset..tail_offset + 4].copy_from_slice(&0u32.to_le_bytes());
+
+    let expected = ext4_metadata_csum32(
+        ext4_crc32c_seed_from_superblock(&sb),
+        &[
+            &ino.to_le_bytes(),
+            &generation.to_le_bytes(),
+            &block[..count_offset + count as usize * entry_size],
+            &block[tail_offset..tail_offset + 4],
+            &[0, 0, 0, 0],
+        ],
+    );
+    block[tail_offset + 4..tail_offset + 8].copy_from_slice(&expected.to_le_bytes());
+
+    assert_eq!(
+        verify_ext4_dx_checksum(&sb, ino, generation, &block),
+        Some(true)
+    );
+    block[count_offset + 8] ^= 0x20;
+    assert_eq!(
+        verify_ext4_dx_checksum(&sb, ino, generation, &block),
+        Some(false)
+    );
 }
 
 #[test]

--- a/components/rsext4/src/loopfile.rs
+++ b/components/rsext4/src/loopfile.rs
@@ -7,7 +7,7 @@ use log::{debug, error};
 use crate::{
     blockdev::*,
     bmalloc::{AbsoluteBN, InodeNumber},
-    checksum::verify_ext4_dirblock_checksum,
+    checksum::{verify_ext4_dirblock_checksum, verify_ext4_dx_checksum},
     config::*,
     disknode::*,
     entries::*,
@@ -189,12 +189,31 @@ pub fn get_file_inode<B: BlockDevice>(
                     let cached_block = fs.datablock_cache.get_or_load(block_dev, *phys.1)?;
                     let block_data = &cached_block.data[..block_bytes];
 
-                    if !verify_ext4_dirblock_checksum(
-                        &fs.superblock,
-                        current_ino_num.raw(),
-                        current_inode.i_generation,
-                        block_data,
-                    ) {
+                    let checksum_ok = if current_inode.is_htree_indexed() {
+                        verify_ext4_dx_checksum(
+                            &fs.superblock,
+                            current_ino_num.raw(),
+                            current_inode.i_generation,
+                            block_data,
+                        )
+                        .unwrap_or_else(|| {
+                            verify_ext4_dirblock_checksum(
+                                &fs.superblock,
+                                current_ino_num.raw(),
+                                current_inode.i_generation,
+                                block_data,
+                            )
+                        })
+                    } else {
+                        verify_ext4_dirblock_checksum(
+                            &fs.superblock,
+                            current_ino_num.raw(),
+                            current_inode.i_generation,
+                            block_data,
+                        )
+                    };
+
+                    if !checksum_ok {
                         error!(
                             "dir block checksum mismatch: ino={} blk_idx={} phys={}",
                             current_ino_num, idx, phys.1

--- a/os/StarryOS/starryos/src/init.sh
+++ b/os/StarryOS/starryos/src/init.sh
@@ -19,4 +19,4 @@ cat > /tmp/starry-shrc <<'EOF'
 export PS1='${USER}@${HOSTNAME}:${PWD} # '
 EOF
 export ENV=/tmp/starry-shrc
-exec /bin/sh -i
+exec /bin/sh -l -i

--- a/os/StarryOS/starryos/src/init.sh
+++ b/os/StarryOS/starryos/src/init.sh
@@ -19,4 +19,4 @@ cat > /tmp/starry-shrc <<'EOF'
 export PS1='${USER}@${HOSTNAME}:${PWD} # '
 EOF
 export ENV=/tmp/starry-shrc
-exec /bin/sh -l -i
+exec /bin/sh -i

--- a/platform/axplat-dyn/src/drivers/blk/rockchip_mmc.rs
+++ b/platform/axplat-dyn/src/drivers/blk/rockchip_mmc.rs
@@ -111,6 +111,8 @@ struct BlockQueue {
     raw: EMmcHost,
 }
 
+const MMC_IO_RETRIES: usize = 3;
+
 impl DriverGeneric for BlockDivce {
     fn name(&self) -> &str {
         "rockchip-emmc"
@@ -170,16 +172,64 @@ impl rd_block::IQueue for BlockQueue {
         match request.kind {
             rd_block::RequestKind::Read(mut buffer) => {
                 let blocks = buffer.len() / self.block_size();
-                self.raw
-                    .read_blocks(id as _, blocks as _, &mut buffer)
-                    .map_err(maping_dev_err_to_blk_err)?;
+                let mut attempt = 0;
+                loop {
+                    match self.raw.read_blocks(id as _, blocks as _, &mut buffer) {
+                        Ok(()) => break,
+                        Err(err) if is_retryable_dev_err(&err) && attempt < MMC_IO_RETRIES => {
+                            attempt += 1;
+                            warn!(
+                                "Rockchip eMMC read timeout, retrying: lba={} blocks={} bytes={} \
+                                 attempt={}/{} err={err:?}",
+                                id,
+                                blocks,
+                                buffer.len(),
+                                attempt,
+                                MMC_IO_RETRIES
+                            );
+                        }
+                        Err(err) => {
+                            warn!(
+                                "Rockchip eMMC read failed: lba={} blocks={} bytes={} err={err:?}",
+                                id,
+                                blocks,
+                                buffer.len()
+                            );
+                            return Err(maping_dev_err_to_blk_err(err));
+                        }
+                    }
+                }
                 Ok(rd_block::RequestId::new(0))
             }
             rd_block::RequestKind::Write(items) => {
                 let blocks = items.len() / self.block_size();
-                self.raw
-                    .write_blocks(id as _, blocks as _, items)
-                    .map_err(maping_dev_err_to_blk_err)?;
+                let mut attempt = 0;
+                loop {
+                    match self.raw.write_blocks(id as _, blocks as _, items) {
+                        Ok(()) => break,
+                        Err(err) if is_retryable_dev_err(&err) && attempt < MMC_IO_RETRIES => {
+                            attempt += 1;
+                            warn!(
+                                "Rockchip eMMC write timeout, retrying: lba={} blocks={} bytes={} \
+                                 attempt={}/{} err={err:?}",
+                                id,
+                                blocks,
+                                items.len(),
+                                attempt,
+                                MMC_IO_RETRIES
+                            );
+                        }
+                        Err(err) => {
+                            warn!(
+                                "Rockchip eMMC write failed: lba={} blocks={} bytes={} err={err:?}",
+                                id,
+                                blocks,
+                                items.len()
+                            );
+                            return Err(maping_dev_err_to_blk_err(err));
+                        }
+                    }
+                }
                 Ok(rd_block::RequestId::new(0))
             }
         }
@@ -190,11 +240,17 @@ impl rd_block::IQueue for BlockQueue {
     }
 }
 
+fn is_retryable_dev_err(err: &sdmmc::err::SdError) -> bool {
+    matches!(
+        err,
+        sdmmc::err::SdError::Timeout | sdmmc::err::SdError::DataTimeout
+    )
+}
+
 fn maping_dev_err_to_blk_err(err: sdmmc::err::SdError) -> rd_block::BlkError {
     match err {
         sdmmc::err::SdError::Timeout | sdmmc::err::SdError::DataTimeout => {
-            // transient timeout, ask caller to retry
-            rd_block::BlkError::Retry
+            rd_block::BlkError::Other("SD/MMC timeout".into())
         }
         sdmmc::err::SdError::Crc
         | sdmmc::err::SdError::DataCrc

--- a/platform/axplat-dyn/src/drivers/pci/rk3588.rs
+++ b/platform/axplat-dyn/src/drivers/pci/rk3588.rs
@@ -1,9 +1,9 @@
 extern crate alloc;
 
-use alloc::format;
+use alloc::{format, vec::Vec};
 use core::time::Duration;
 
-use fdt_edit::{PciRange, PciSpace, RegFixed};
+use fdt_edit::{Node, PciRange, PciSpace, RegFixed};
 use mmio_api::{MmioAddr, MmioOp, MmioRaw};
 use rdif_pcie::{PciMem64, PcieController};
 use rdrive::{
@@ -14,6 +14,9 @@ use rdrive::{
 use rk3588_pci::{
     Delay, HostConfig, MEM_ATU_FIRST_REGION, OutboundWindow, ResetControl, Rk3588PcieHost,
 };
+use rockchip_pm::{PowerDomain, RockchipPM};
+
+use crate::drivers::soc::{rk3588_enable_clock, rk3588_reset_deassert};
 
 const RK3588_GPIO_BASES: [u64; 5] = [
     0xfd8a_0000,
@@ -119,6 +122,7 @@ fn probe_rk3588(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnPro
     let (cfg_phys, cfg_size) = config_window(&regs, &ranges)?;
     let (bus_base, logical_bus_end) = bus_range_info(node.bus_range());
     let mut reset = pcie_reset_gpio(&info, apb_reg.address);
+    prepare_controller_resources(info.node)?;
 
     let apb_size = apb_reg.size.unwrap_or(0x10000) as usize;
     let dbi_size = dbi_reg.size.unwrap_or(0x400000) as usize;
@@ -188,6 +192,92 @@ fn map_mmio(phys: u64, size: usize) -> Result<MmioRaw, OnProbeError> {
 
 fn map_rk3588_error(err: rk3588_pci::Error) -> OnProbeError {
     OnProbeError::other(format!("{err:?}"))
+}
+
+fn prepare_controller_resources(node: NodeType<'_>) -> Result<(), OnProbeError> {
+    enable_power_domains(&parse_power_domains(node.as_node())?)?;
+    enable_clocks(node.clocks())?;
+    deassert_resets(parse_resets(node)?)?;
+    axklib::time::busy_wait(Duration::from_millis(1));
+    Ok(())
+}
+
+fn parse_power_domains(node: &Node) -> Result<Vec<usize>, OnProbeError> {
+    let Some(prop) = node.get_property("power-domains") else {
+        return Ok(Vec::new());
+    };
+    let cells = prop.get_u32_iter().collect::<Vec<_>>();
+    if cells.len() % 2 != 0 {
+        return Err(OnProbeError::other(format!(
+            "[{}] has malformed power-domains",
+            node.name()
+        )));
+    }
+    Ok(cells.chunks(2).map(|chunk| chunk[1] as usize).collect())
+}
+
+fn enable_power_domains(domains: &[usize]) -> Result<(), OnProbeError> {
+    if domains.is_empty() {
+        return Ok(());
+    }
+
+    let pm = rdrive::get_one::<RockchipPM>()
+        .ok_or_else(|| OnProbeError::other("RockchipPM not found for RK3588 PCIe"))?;
+    let mut pm = pm
+        .lock()
+        .map_err(|err| OnProbeError::other(format!("failed to lock RockchipPM: {err}")))?;
+
+    for &domain in domains {
+        pm.power_domain_on(PowerDomain(domain)).map_err(|err| {
+            OnProbeError::other(format!(
+                "failed to enable RK3588 PCIe power domain {domain}: {err:?}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn enable_clocks(clocks: Vec<fdt_edit::ClockRef>) -> Result<(), OnProbeError> {
+    for clock in clocks {
+        let Some(&id) = clock.specifier.first() else {
+            continue;
+        };
+        if id == 0 {
+            continue;
+        }
+        rk3588_enable_clock(id).map_err(|err| {
+            OnProbeError::other(format!(
+                "failed to enable RK3588 PCIe clock {:?} ({id:#x}): {err}",
+                clock.name
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn parse_resets(node: NodeType<'_>) -> Result<Vec<u64>, OnProbeError> {
+    let Some(prop) = node.as_node().get_property("resets") else {
+        return Ok(Vec::new());
+    };
+    let cells = prop.get_u32_iter().collect::<Vec<_>>();
+    if cells.len() % 2 != 0 {
+        return Err(OnProbeError::other(format!(
+            "[{}] has malformed resets",
+            node.name()
+        )));
+    }
+    Ok(cells.chunks(2).map(|chunk| u64::from(chunk[1])).collect())
+}
+
+fn deassert_resets(resets: Vec<u64>) -> Result<(), OnProbeError> {
+    for reset in resets {
+        rk3588_reset_deassert(reset).map_err(|err| {
+            OnProbeError::other(format!(
+                "failed to deassert RK3588 PCIe reset {reset:#x}: {err}"
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 fn pcie_reset_gpio(info: &FdtInfo<'_>, apb_base: u64) -> Option<Rk3588GpioReset> {

--- a/platform/axplat-dyn/src/drivers/pci/rk3588.rs
+++ b/platform/axplat-dyn/src/drivers/pci/rk3588.rs
@@ -14,9 +14,8 @@ use rdrive::{
 use rk3588_pci::{
     Delay, HostConfig, MEM_ATU_FIRST_REGION, OutboundWindow, ResetControl, Rk3588PcieHost,
 };
-use rockchip_pm::{PowerDomain, RockchipPM};
 
-use crate::drivers::soc::{rk3588_enable_clock, rk3588_reset_deassert};
+use crate::drivers::soc::{rk3588_enable_clock, rk3588_enable_power_domain, rk3588_reset_deassert};
 
 const RK3588_GPIO_BASES: [u64; 5] = [
     0xfd8a_0000,
@@ -221,16 +220,10 @@ fn enable_power_domains(domains: &[usize]) -> Result<(), OnProbeError> {
         return Ok(());
     }
 
-    let pm = rdrive::get_one::<RockchipPM>()
-        .ok_or_else(|| OnProbeError::other("RockchipPM not found for RK3588 PCIe"))?;
-    let mut pm = pm
-        .lock()
-        .map_err(|err| OnProbeError::other(format!("failed to lock RockchipPM: {err}")))?;
-
     for &domain in domains {
-        pm.power_domain_on(PowerDomain(domain)).map_err(|err| {
+        rk3588_enable_power_domain(domain).map_err(|err| {
             OnProbeError::other(format!(
-                "failed to enable RK3588 PCIe power domain {domain}: {err:?}"
+                "failed to enable RK3588 PCIe power domain {domain}: {err}"
             ))
         })?;
     }

--- a/platform/axplat-dyn/src/drivers/soc/mod.rs
+++ b/platform/axplat-dyn/src/drivers/soc/mod.rs
@@ -19,3 +19,24 @@ pub(crate) use rockchip::{
     RockchipPinCtrl, rk3588_enable_clock, rk3588_enable_power_domain, rk3588_reset_assert,
     rk3588_reset_deassert,
 };
+
+#[cfg(not(all(feature = "rockchip-soc", not(feature = "rk3568-clk"))))]
+pub(crate) fn rk3588_enable_clock(id: u32) -> Result<(), rdrive::probe::OnProbeError> {
+    Err(rdrive::probe::OnProbeError::other(alloc::format!(
+        "RK3588 clock support is not enabled for clock {id:#x}"
+    )))
+}
+
+#[cfg(not(all(feature = "rockchip-soc", not(feature = "rk3568-clk"))))]
+pub(crate) fn rk3588_enable_power_domain(domain: usize) -> Result<(), alloc::string::String> {
+    Err(alloc::format!(
+        "RK3588 power-domain support is not enabled for power domain {domain}"
+    ))
+}
+
+#[cfg(not(all(feature = "rockchip-soc", not(feature = "rk3568-clk"))))]
+pub(crate) fn rk3588_reset_deassert(id: u64) -> Result<(), rdrive::probe::OnProbeError> {
+    Err(rdrive::probe::OnProbeError::other(alloc::format!(
+        "RK3588 reset support is not enabled for reset {id:#x}"
+    )))
+}

--- a/platform/axplat-dyn/src/drivers/soc/mod.rs
+++ b/platform/axplat-dyn/src/drivers/soc/mod.rs
@@ -16,5 +16,6 @@ mod rockchip;
 
 #[cfg(all(feature = "rockchip-soc", not(feature = "rk3568-clk")))]
 pub(crate) use rockchip::{
-    RockchipPinCtrl, rk3588_enable_clock, rk3588_reset_assert, rk3588_reset_deassert,
+    RockchipPinCtrl, rk3588_enable_clock, rk3588_enable_power_domain, rk3588_reset_assert,
+    rk3588_reset_deassert,
 };

--- a/platform/axplat-dyn/src/drivers/soc/rockchip/mod.rs
+++ b/platform/axplat-dyn/src/drivers/soc/rockchip/mod.rs
@@ -30,3 +30,20 @@ mod pinctrl;
 pub(crate) use clk::{rk3588_enable_clock, rk3588_reset_assert, rk3588_reset_deassert};
 #[cfg(all(feature = "rockchip-soc", not(feature = "rk3568-clk")))]
 pub(crate) use pinctrl::RockchipPinCtrl;
+#[cfg(all(
+    feature = "rockchip-soc",
+    feature = "rockchip-pm",
+    not(feature = "rk3568-clk")
+))]
+pub(crate) use pm::rk3588_enable_power_domain;
+
+#[cfg(all(
+    feature = "rockchip-soc",
+    not(feature = "rockchip-pm"),
+    not(feature = "rk3568-clk")
+))]
+pub(crate) fn rk3588_enable_power_domain(domain: usize) -> Result<(), alloc::string::String> {
+    Err(alloc::format!(
+        "rockchip-pm feature is not enabled for power domain {domain}"
+    ))
+}

--- a/platform/axplat-dyn/src/drivers/soc/rockchip/pm.rs
+++ b/platform/axplat-dyn/src/drivers/soc/rockchip/pm.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use rdrive::{PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo};
-use rockchip_pm::{RkBoard, RockchipPM};
+use rockchip_pm::{PowerDomain, RkBoard, RockchipPM};
 
 use crate::drivers::iomap;
 
@@ -49,4 +49,15 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
     plat_dev.register(pm);
     info!("Rockchip power manager registered successfully");
     Ok(())
+}
+
+pub(crate) fn rk3588_enable_power_domain(domain: usize) -> Result<(), alloc::string::String> {
+    let pm = rdrive::get_one::<RockchipPM>()
+        .ok_or_else(|| alloc::format!("RockchipPM not found for power domain {domain}"))?;
+    let mut pm = pm
+        .lock()
+        .map_err(|err| alloc::format!("failed to lock RockchipPM: {err}"))?;
+
+    pm.power_domain_on(PowerDomain(domain))
+        .map_err(|err| alloc::format!("{err:?}"))
 }

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -616,8 +616,8 @@ impl Starry {
         &mut self,
         args: quick_start::QuickOrangeConfigArgs,
     ) -> anyhow::Result<()> {
-        quick_start::refresh_orangepi_configs(self.app.workspace_root())?;
         quick_start::prepare_orangepi_uboot_config(self.app.workspace_root(), &args)?;
+        quick_start::ensure_orangepi_configs(self.app.workspace_root())?;
         let request = self.prepare_request(
             Self::quick_start_build_args(
                 "aarch64",
@@ -634,6 +634,8 @@ impl Starry {
         &mut self,
         args: quick_start::QuickOrangeRunArgs,
     ) -> anyhow::Result<()> {
+        let uboot_config =
+            quick_start::prepare_orangepi_uboot_config(self.app.workspace_root(), &args)?;
         quick_start::ensure_orangepi_configs(self.app.workspace_root())?;
         let request = self.prepare_request(
             Self::quick_start_build_args(
@@ -641,10 +643,7 @@ impl Starry {
                 quick_start::tmp_orangepi_build_config_path(self.app.workspace_root()),
             ),
             None,
-            Some(quick_start::prepare_orangepi_uboot_config(
-                self.app.workspace_root(),
-                &args,
-            )?),
+            Some(uboot_config),
             SnapshotPersistence::Store,
         )?;
         self.run_uboot_request(request).await

--- a/scripts/axbuild/src/starry/quick_start.rs
+++ b/scripts/axbuild/src/starry/quick_start.rs
@@ -71,6 +71,12 @@ pub struct QuickOrangeConfigArgs {
 
 pub type QuickOrangeRunArgs = QuickOrangeConfigArgs;
 
+impl QuickOrangeConfigArgs {
+    fn has_overrides(&self) -> bool {
+        self.serial.is_some() || self.baud.is_some() || self.dtb.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum QuickQemuPlatform {
     Aarch64,
@@ -269,11 +275,14 @@ pub fn prepare_orangepi_uboot_config(
     args: &QuickOrangeConfigArgs,
 ) -> anyhow::Result<PathBuf> {
     let tmp_path = tmp_orangepi_uboot_config_path(workspace_root);
-    if tmp_path.exists() {
+    let tmp_exists = tmp_path.exists();
+    if tmp_exists && !args.has_overrides() {
         return Ok(tmp_path);
     }
 
-    copy_template(&orangepi_uboot_config_path(workspace_root), &tmp_path)?;
+    if !tmp_exists {
+        copy_template(&orangepi_uboot_config_path(workspace_root), &tmp_path)?;
+    }
 
     let mut value: toml::Value = toml::from_str(
         &fs::read_to_string(&tmp_path)
@@ -291,19 +300,91 @@ pub fn prepare_orangepi_uboot_config(
         table.insert("baud_rate".into(), toml::Value::String(baud.clone()));
     }
 
-    let dtb_path = args
+    if let Some(dtb_path) = args
         .dtb
         .clone()
-        .unwrap_or_else(|| default_orangepi_dtb_path(workspace_root));
-    if !dtb_path.exists() {
-        bail!("DTB path does not exist: {}", dtb_path.display());
+        .or_else(|| (!tmp_exists).then(|| default_orangepi_dtb_path(workspace_root)))
+    {
+        if !dtb_path.exists() {
+            bail!("DTB path does not exist: {}", dtb_path.display());
+        }
+        table.insert(
+            "dtb_file".into(),
+            toml::Value::String(dtb_path.display().to_string()),
+        );
     }
-    table.insert(
-        "dtb_file".into(),
-        toml::Value::String(dtb_path.display().to_string()),
-    );
 
     fs::write(&tmp_path, toml::to_string_pretty(&value)?)
         .with_context(|| format!("failed to write {}", tmp_path.display()))?;
     Ok(tmp_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn write_orangepi_uboot_template(root: &Path) {
+        let path = orangepi_uboot_config_path(root);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            path,
+            "serial = \"/dev/template\"\nbaud_rate = \"1500000\"\ndtb_file = \"template.dtb\"\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn prepare_orangepi_uboot_config_keeps_existing_tmp_without_overrides() {
+        let root = tempdir().unwrap();
+        write_orangepi_uboot_template(root.path());
+        let tmp_path = tmp_orangepi_uboot_config_path(root.path());
+        fs::create_dir_all(tmp_path.parent().unwrap()).unwrap();
+        fs::write(
+            &tmp_path,
+            "serial = \"/dev/existing\"\nbaud_rate = \"9600\"\ndtb_file = \"existing.dtb\"\n",
+        )
+        .unwrap();
+
+        prepare_orangepi_uboot_config(root.path(), &QuickOrangeConfigArgs::default()).unwrap();
+
+        let value: toml::Value = toml::from_str(&fs::read_to_string(tmp_path).unwrap()).unwrap();
+        assert_eq!(value["serial"].as_str(), Some("/dev/existing"));
+        assert_eq!(value["baud_rate"].as_str(), Some("9600"));
+        assert_eq!(value["dtb_file"].as_str(), Some("existing.dtb"));
+    }
+
+    #[test]
+    fn prepare_orangepi_uboot_config_updates_existing_tmp_overrides() {
+        let root = tempdir().unwrap();
+        write_orangepi_uboot_template(root.path());
+        let tmp_path = tmp_orangepi_uboot_config_path(root.path());
+        fs::create_dir_all(tmp_path.parent().unwrap()).unwrap();
+        fs::write(
+            &tmp_path,
+            "serial = \"/dev/existing\"\nbaud_rate = \"9600\"\ndtb_file = \"existing.dtb\"\n",
+        )
+        .unwrap();
+        let dtb_path = root.path().join("custom.dtb");
+        fs::write(&dtb_path, "").unwrap();
+
+        prepare_orangepi_uboot_config(
+            root.path(),
+            &QuickOrangeConfigArgs {
+                serial: Some("/dev/ttyUSB1".to_string()),
+                baud: Some("115200".to_string()),
+                dtb: Some(dtb_path.clone()),
+            },
+        )
+        .unwrap();
+
+        let value: toml::Value = toml::from_str(&fs::read_to_string(tmp_path).unwrap()).unwrap();
+        assert_eq!(value["serial"].as_str(), Some("/dev/ttyUSB1"));
+        assert_eq!(value["baud_rate"].as_str(), Some("115200"));
+        let expected_dtb = dtb_path.display().to_string();
+        assert_eq!(value["dtb_file"].as_str(), Some(expected_dtb.as_str()));
+    }
 }

--- a/scripts/axbuild/src/starry/quick_start.rs
+++ b/scripts/axbuild/src/starry/quick_start.rs
@@ -255,8 +255,11 @@ pub fn refresh_orangepi_configs(workspace_root: &Path) -> anyhow::Result<()> {
 pub fn ensure_orangepi_configs(workspace_root: &Path) -> anyhow::Result<()> {
     let build_cfg = tmp_orangepi_build_config_path(workspace_root);
     let run_cfg = tmp_orangepi_uboot_config_path(workspace_root);
-    if !build_cfg.exists() || !run_cfg.exists() {
-        refresh_orangepi_configs(workspace_root)?;
+    if !build_cfg.exists() {
+        copy_template(&orangepi_build_config_path(workspace_root), &build_cfg)?;
+    }
+    if !run_cfg.exists() {
+        copy_template(&orangepi_uboot_config_path(workspace_root), &run_cfg)?;
     }
     Ok(())
 }
@@ -266,6 +269,11 @@ pub fn prepare_orangepi_uboot_config(
     args: &QuickOrangeConfigArgs,
 ) -> anyhow::Result<PathBuf> {
     let tmp_path = tmp_orangepi_uboot_config_path(workspace_root);
+    if tmp_path.exists() {
+        return Ok(tmp_path);
+    }
+
+    copy_template(&orangepi_uboot_config_path(workspace_root), &tmp_path)?;
 
     let mut value: toml::Value = toml::from_str(
         &fs::read_to_string(&tmp_path)

--- a/scripts/axbuild/src/test/board.rs
+++ b/scripts/axbuild/src/test/board.rs
@@ -31,6 +31,9 @@ pub(crate) fn filter_board_test_groups<T: BoardTestGroupInfo>(
     });
 
     if let Some(case_name) = selected_case {
+        if groups.is_empty() {
+            bail!("{}", empty_message());
+        }
         let available = available_values(groups.iter().map(BoardTestGroupInfo::name));
         groups.retain(|group| group.name() == case_name);
         if groups.is_empty() {
@@ -42,6 +45,9 @@ pub(crate) fn filter_board_test_groups<T: BoardTestGroupInfo>(
     }
 
     if let Some(board_name) = selected_board {
+        if groups.is_empty() {
+            bail!("{}", empty_message());
+        }
         let available = available_values(groups.iter().map(BoardTestGroupInfo::board_name));
         groups.retain(|group| group.board_name() == board_name);
         if groups.is_empty() {
@@ -158,5 +164,36 @@ mod tests {
         );
         assert_eq!(configs[0].case_dir, case_dir);
         assert_eq!(configs[1].case_dir, nested_case_dir);
+    }
+
+    #[test]
+    fn filter_selected_board_on_empty_group_reports_empty_group() {
+        let err = filter_board_test_groups(
+            Vec::<TestBoardGroup>::new(),
+            None,
+            Some("orangepi-5-plus"),
+            "Starry",
+            || "no Starry board test groups found under /tmp/stress".to_string(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert_eq!(err, "no Starry board test groups found under /tmp/stress");
+    }
+
+    #[derive(Debug)]
+    struct TestBoardGroup {
+        name: String,
+        board_name: String,
+    }
+
+    impl BoardTestGroupInfo for TestBoardGroup {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn board_name(&self) -> &str {
+            &self.board_name
+        }
     }
 }

--- a/test-suit/starryos/normal/board-orangepi-5-plus/lsusb/board-orangepi-5-plus.toml
+++ b/test-suit/starryos/normal/board-orangepi-5-plus/lsusb/board-orangepi-5-plus.toml
@@ -1,6 +1,6 @@
 board_type = "OrangePi-5-Plus"
 shell_prefix = "root@starry:/root #"
-shell_init_cmd = "sleep 5; echo STARRY_LSUSB_BEGIN; lsusb | tee /tmp/starry-lsusb.out; if ! grep -Eq 'ID 1d6b:000[23]' /tmp/starry-lsusb.out; then echo STARRY_LSUSB_ROOT_HUB_MISSING; elif ! grep -Eq 'ID 05e3:06(10|20)' /tmp/starry-lsusb.out; then echo STARRY_LSUSB_GENESYS_HUB_MISSING; else echo STARRY_LSUSB_HUB_OK; fi"
+shell_init_cmd = "sleep 5; echo STARRY_LSUSB_BEGIN; lsusb > /tmp/starry-lsusb.out; cat /tmp/starry-lsusb.out; if ! grep -Eq 'ID 1d6b:000[23]' /tmp/starry-lsusb.out; then echo STARRY_LSUSB_ROOT_HUB_MISSING; elif ! grep -Eq 'ID 05e3:06(10|20)' /tmp/starry-lsusb.out; then echo STARRY_LSUSB_GENESYS_HUB_MISSING; else echo STARRY_LSUSB_HUB_OK; fi"
 success_regex = ["(?m)^STARRY_LSUSB_HUB_OK\\s*$"]
 fail_regex = [
   '(?i)\bpanic(?:ked)?\b',


### PR DESCRIPTION
本 PR 修复 StarryOS 在 Orange Pi 5 Plus 开发板上的启动和存储稳定性问题：

- 修复 RK3588 PCIe 初始化顺序，在创建 PCIe host 前先打开 power domain、clock 并释放 reset。
- 修改 Starry quick-start 逻辑，避免每次运行都覆盖临时 Orange Pi 配置。
- 增强 Rockchip eMMC I/O 稳定性，在驱动队列内部重试临时 SD/MMC timeout。
- 修复 rsext4 对 ext4 HTree 目录 checksum 的识别，避免 Linux rootfs 上的误报。
- 调整 Starry board shell 启动和 `lsusb` 测试命令，修复 CI 中 login shell 和 pipeline 导致的卡住问题。