### PR TITLE
fix(axbuild): use versioned qemu config template instead of ostool auto-generated file

### DIFF
--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -431,14 +431,23 @@ impl Starry {
         cargo: &Cargo,
         apply_default_args: bool,
     ) -> anyhow::Result<ostool::run::qemu::QemuConfig> {
-        let mut qemu = match request.qemu_config.as_deref() {
+        // Resolve the QEMU config path: explicit flag > versioned template in
+        // configs/qemu/ > ostool auto-create fallback (unknown arch only).
+        let config_path: Option<PathBuf> = request
+            .qemu_config
+            .clone()
+            .or_else(|| starry_qemu_config_template(self.app.workspace_root(), &request.arch));
+
+        let mut qemu = match config_path {
             Some(path) => {
                 self.app
                     .tool_mut()
-                    .read_qemu_config_from_path_for_cargo(cargo, path)
+                    .read_qemu_config_from_path_for_cargo(cargo, &path)
                     .await?
             }
             None => {
+                // Unknown arch — no template exists; let ostool create a
+                // minimal default as a last resort.
                 self.app
                     .tool_mut()
                     .ensure_qemu_config_for_cargo(cargo)
@@ -601,6 +610,15 @@ impl Starry {
         )?;
         self.run_uboot_request(request).await
     }
+}
+
+/// Returns the path to the versioned QEMU run-config template for `arch` under
+/// `os/StarryOS/configs/qemu/qemu-{arch}.toml`, or `None` if no such file exists.
+fn starry_qemu_config_template(workspace_root: &Path, arch: &str) -> Option<PathBuf> {
+    let path = workspace_root
+        .join("os/StarryOS/configs/qemu")
+        .join(format!("qemu-{arch}.toml"));
+    path.exists().then_some(path)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
  ## Summary

  - `cargo starry qemu --arch riscv64` 原本调用 `ensure_qemu_config_for_cargo`，在 `os/StarryOS/starryos/` 下自动创建 gitignored 的
  `.qemu-{arch}.toml`，内容为 ostool 最简默认值（无 `-m`、无 virtio 设备等），导致 QEMU 仅以 128 MB 启动而内核期望 512 MB，运行 `du -sh /`
  等内存用量稍大的命令时触发 StoreFault panic。
  - `os/StarryOS/configs/qemu/qemu-{arch}.toml` 已有正确的版本控制配置（quick-start 流程使用它），但直接走 `cargo starry qemu` 路径时从未被读取。
  - 修复：`load_qemu_config` 优先级改为 **显式 `--qemu-config`** > **`configs/qemu/qemu-{arch}.toml` 版本控制模板** > **ostool 兜底（仅未知
  arch）**，消除了 gitignored 中间文件，并统一了 quick-start 与直接调用两条路径的配置来源。

  ## Test plan

  - [ ] `cargo starry qemu --arch riscv64` 启动后在 StarryOS 内执行 `du -sh /` 不再 panic
  - [ ] `cargo starry quick-start qemu-riscv64 run` 行为不变
  - [ ] `cargo starry qemu --arch riscv64 --qemu-config <custom>` 仍优先使用显式路径