### PR TITLE
feat(starry-kernel): add runtime dynamic debug control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clear-cache"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a99cd4270644c07e6102f3080aa70a0328c1a5703890f710536b302cdec524"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +3359,17 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "ddebug"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3fb9d25e18b52da413e073e435a48078241cd5287b9f762cf1808a9618ee48"
+dependencies = [
+ "function_name",
+ "lock_api",
+ "static-keys",
+]
 
 [[package]]
 name = "define-simple-traits"
@@ -4032,6 +4053,21 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "function_name"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ab577a896d09940b5fe12ec5ae71f9d8211fff62c919c03a3750a9901e98a7"
+dependencies = [
+ "function_name-proc-macro",
+]
+
+[[package]]
+name = "function_name-proc-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673464e1e314dd67a0fd9544abc99e8eb28d0c7e3b69b033bcff9b2d00b87333"
 
 [[package]]
 name = "funty"
@@ -4829,7 +4865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
  "core-foundation-sys",
- "mach2",
+ "mach2 0.4.3",
 ]
 
 [[package]]
@@ -5384,6 +5420,15 @@ name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -7965,7 +8010,7 @@ dependencies = [
  "core-foundation-sys",
  "io-kit-sys",
  "libudev",
- "mach2",
+ "mach2 0.4.3",
  "nix 0.26.4",
  "scopeguard",
  "unescaper",
@@ -8547,6 +8592,7 @@ dependencies = [
  "ax-hal",
  "ax-input",
  "ax-io",
+ "ax-ipi",
  "ax-kernel-guard",
  "ax-kspin",
  "ax-lazyinit",
@@ -8570,6 +8616,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "crab-usb",
+ "ddebug",
  "downcast-rs",
  "enum_dispatch",
  "event-listener",
@@ -8595,6 +8642,7 @@ dependencies = [
  "starry-process",
  "starry-signal",
  "starry-vm",
+ "static-keys",
  "strum 0.28.0",
  "syscalls",
  "uluru",
@@ -8653,6 +8701,18 @@ dependencies = [
  "clap",
  "starry-kernel",
  "tokio",
+]
+
+[[package]]
+name = "static-keys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a55c94bb459faf8c09d58013c631fa01e320f191cbc0bd27515ef4402ef57b"
+dependencies = [
+ "clear-cache",
+ "libc",
+ "mach2 0.5.0",
+ "windows",
 ]
 
 [[package]]
@@ -10124,6 +10184,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10134,6 +10215,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -10163,6 +10255,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -10284,6 +10386,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/components/axcpu/src/aarch64/asm.rs
+++ b/components/axcpu/src/aarch64/asm.rs
@@ -155,7 +155,62 @@ pub fn flush_icache_all() {
     unsafe { asm!("ic iallu; dsb sy; isb") };
 }
 
-/// Flushes the data cache line (64 bytes) at the given virtual address
+#[inline]
+fn read_ctr_el0() -> u64 {
+    let value;
+    unsafe {
+        asm!("mrs {}, ctr_el0", out(reg) value);
+    }
+    value
+}
+
+/// Reads the data cache line size from `CTR_EL0` and returns it in bytes.
+#[inline]
+pub fn dcache_line_size_from_ctr() -> usize {
+    let ctr = read_ctr_el0();
+
+    // CTR_EL0.DminLine: bits [19:16]
+    // bytes = 4 << DminLine
+    let dminline = ((ctr >> 16) & 0xf) as usize;
+
+    4usize << dminline
+}
+
+/// Reads the instruction cache line size from `CTR_EL0` and returns it in bytes.
+#[inline]
+pub fn icache_line_size_from_ctr() -> usize {
+    let ctr = read_ctr_el0();
+
+    // CTR_EL0.IminLine: bits [3:0]
+    // bytes = 4 << IminLine
+    let iminline = (ctr & 0xf) as usize;
+
+    4usize << iminline
+}
+
+/// Cleans a data cache range to the point of unification.
+#[inline]
+pub fn clean_dcache_range_to_pou(vaddr: VirtAddr, size: usize) {
+    if size == 0 {
+        return;
+    }
+
+    let line_size = dcache_line_size_from_ctr();
+    let start = vaddr.as_usize() & !(line_size - 1);
+    let end = (vaddr.as_usize() + size + line_size - 1) & !(line_size - 1);
+
+    for line in (start..end).step_by(line_size) {
+        unsafe { asm!("dc cvau, {0:x}", in(reg) line) };
+    }
+
+    unsafe { asm!("dsb sy") };
+}
+
+/// Cleans and invalidates the data cache line that covers the given address.
+///
+/// This is useful for publishing small pieces of data to other agents that may
+/// observe memory outside the local D-cache, such as spin tables used to start
+/// secondary CPUs.
 #[inline]
 pub fn flush_dcache_line(vaddr: VirtAddr) {
     unsafe { asm!("dc ivac, {0:x}; dsb sy; isb", in(reg) vaddr.as_usize()) };

--- a/components/axcpu/src/loongarch64/asm.rs
+++ b/components/axcpu/src/loongarch64/asm.rs
@@ -78,6 +78,13 @@ pub unsafe fn write_kernel_page_table(root_paddr: PhysAddr) {
     pgdh::set_base(root_paddr.as_usize());
 }
 
+/// Flushes the entire instruction cache.
+/// See <https://elixir.bootlin.com/linux/v6.6/source/arch/loongarch/mm/cache.c#L38>
+#[inline]
+pub fn flush_icache_all() {
+    unsafe { asm!("ibar 0") };
+}
+
 /// Flushes the TLB.
 ///
 /// If `vaddr` is [`None`], flushes the entire TLB. Otherwise, flushes the TLB

--- a/components/axcpu/src/riscv/asm.rs
+++ b/components/axcpu/src/riscv/asm.rs
@@ -93,6 +93,12 @@ pub unsafe fn write_kernel_page_table(root_paddr: PhysAddr) {
     unsafe { write_user_page_table(root_paddr) };
 }
 
+/// Flushes the entire instruction cache.
+#[inline]
+pub fn flush_icache_all() {
+    riscv::asm::fence_i();
+}
+
 /// Flushes the TLB.
 ///
 /// If `vaddr` is [`None`], flushes the entire TLB. Otherwise, flushes the TLB

--- a/components/axcpu/src/x86_64/asm.rs
+++ b/components/axcpu/src/x86_64/asm.rs
@@ -107,6 +107,10 @@ pub unsafe fn write_kernel_page_table(root_paddr: PhysAddr) {
     unsafe { write_user_page_table(root_paddr) }
 }
 
+/// Flushes the entire instruction cache.
+#[inline]
+pub fn flush_icache_all() {}
+
 /// Flushes the TLB.
 ///
 /// If `vaddr` is [`None`], flushes the entire TLB. Otherwise, flushes the TLB

--- a/components/axfs-ng-vfs/src/node/file.rs
+++ b/components/axfs-ng-vfs/src/node/file.rs
@@ -29,12 +29,6 @@ pub trait FileNodeOps: NodeOps + Pollable {
     fn ioctl(&self, _cmd: u32, _arg: usize) -> VfsResult<usize> {
         Err(VfsError::NotATty)
     }
-
-    /// A hint to the backend that the file position has changed.
-    /// This is used for operations like resetting file content in proc/sys.
-    fn seek_to(&self, _pos: u64) -> VfsResult<()> {
-        Ok(())
-    }
 }
 
 #[repr(transparent)]

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -21,7 +21,7 @@ memtrack = ["ax-feat/dwarf", "ax-alloc/tracking", "dep:gimli"]
 rknpu = ["dep:axplat-dyn", "axplat-dyn/rknpu"]
 plat-dyn = ["dep:axplat-dyn", "axplat-dyn/usb", "dep:crab-usb", "dep:rdrive"]
 vsock = ["ax-feat/vsock"]
-dynamic_debug = []
+dynamic_debug = ["ax-feat/ipi"]
 
 [dependencies]
 ax-feat = { workspace = true, features = [

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -111,6 +111,9 @@ uluru = "3.1.0"
 weak-map = "0.1.1"
 xmas-elf = "0.9"
 zerocopy = { version = "0.8", features = ["derive"] }
+ax-ipi = { workspace = true }
+static-keys = "0.8"
+ddebug = "0.5"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86 = "0.52"

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -14,12 +14,14 @@ repository.workspace = true
 license.workspace = true
 
 [features]
+default = ["dynamic_debug"]
 dev-log = []
 input = ["dep:ax-input", "ax-feat/input"]
 memtrack = ["ax-feat/dwarf", "ax-alloc/tracking", "dep:gimli"]
 rknpu = ["dep:axplat-dyn", "axplat-dyn/rknpu"]
 plat-dyn = ["dep:axplat-dyn", "axplat-dyn/usb", "dep:crab-usb", "dep:rdrive"]
 vsock = ["ax-feat/vsock"]
+dynamic_debug = []
 
 [dependencies]
 ax-feat = { workspace = true, features = [

--- a/os/StarryOS/kernel/src/dyn_debug.rs
+++ b/os/StarryOS/kernel/src/dyn_debug.rs
@@ -1,0 +1,51 @@
+use ax_memory_addr::VirtAddr;
+use ax_task::current;
+use ddebug::{ControlFile, DebugOps};
+pub struct DynamicDebugOps;
+
+impl DebugOps for DynamicDebugOps {
+    fn write_kernel_text(addr: *mut u8, data: &[u8]) {
+        crate::mm::write_kernel_text(VirtAddr::from_mut_ptr_of(addr), data)
+            .expect("Failed to write kernel text");
+    }
+
+    fn emit(line: &str) {
+        ax_print!("{}", line);
+    }
+
+    fn thread_id() -> u64 {
+        current().id().as_u64()
+    }
+}
+
+/// See [ax_debug_fn] for usage.
+///
+/// # Note
+/// This macro don't depend on the derive macro `#[ddebug::named]`, so the 'f' flag can't be used to print the function name.
+#[macro_export]
+macro_rules! ax_debug {
+    ($fmt:literal $(, $arg:expr)* $(,)?) => {{
+        ddebug::pr_debug!($crate::dyn_debug::DynamicDebugOps, $fmt $(, $arg)*);
+    }};
+}
+
+/// A debug print macro that also prints the function name. This is useful for debugging dynamic debug sites, as it can help identify which site is being hit.
+///
+/// # Note
+/// This macro depends on the derive macro `#[ddebug::named]` to work, which will set the function name for the debug site.
+#[macro_export]
+macro_rules! ax_debug_fn {
+    ($fmt:literal $(, $arg:expr)* $(,)?) => {{
+        ddebug::pr_debug_fn!($crate::dyn_debug::DynamicDebugOps, $fmt $(, $arg)*);
+    }};
+}
+
+/// Initialize dynamic debug subsystem.
+/// This should be called after static keys are initialized, and before any dynamic debug site is hit.
+pub fn dynamic_debug_init() -> ControlFile<DynamicDebugOps> {
+    info!("debug_init: initializing dynamic debug sites");
+    let ctl = ddebug::dynamic_debug_init::<DynamicDebugOps>();
+    let site_count = ctl.site_count();
+    info!("debug_init: found {site_count} dynamic debug sites");
+    ctl
+}

--- a/os/StarryOS/kernel/src/dyn_debug.rs
+++ b/os/StarryOS/kernel/src/dyn_debug.rs
@@ -18,25 +18,40 @@ impl DebugOps for DynamicDebugOps {
     }
 }
 
-/// See [ax_debug_fn] for usage.
+/// Dynamic debug macro. When `dynamic_debug` feature is enabled,
+/// uses per-callsite static key for runtime control via `/proc/dynamic_debug/control`.
+/// Otherwise falls back to `log::debug!`.
 ///
 /// # Note
 /// This macro doesn't depend on the derive macro `#[ddebug::named]`, so the 'f' flag can't be used to print the function name.
+#[cfg(feature = "dynamic_debug")]
 #[macro_export]
-macro_rules! ax_debug {
+macro_rules! debug {
     ($fmt:literal $(, $arg:expr)* $(,)?) => {{
         ddebug::pr_debug!($crate::dyn_debug::DynamicDebugOps, $fmt $(, $arg)*);
     }};
 }
 
-/// A debug print macro that also prints the function name. This is useful for debugging dynamic debug sites, as it can help identify which site is being hit.
+/// Dynamic debug macro. When `dynamic_debug` feature is enabled,
+/// uses per-callsite static key for runtime control via `/proc/dynamic_debug/control`, and also prints the function name of the callsite.
+/// Otherwise falls back to `log::debug!`.
 ///
 /// # Note
 /// This macro depends on the derive macro `#[ddebug::named]` to work, which will set the function name for the debug site.
+#[cfg(feature = "dynamic_debug")]
 #[macro_export]
-macro_rules! ax_debug_fn {
+macro_rules! debug_fn {
     ($fmt:literal $(, $arg:expr)* $(,)?) => {{
         ddebug::pr_debug_fn!($crate::dyn_debug::DynamicDebugOps, $fmt $(, $arg)*);
+    }};
+}
+
+/// When `dynamic_debug` feature is disabled, `debug!` and `debug_fn!` both fall back to `log::debug!`.
+#[cfg(not(feature = "dynamic_debug"))]
+#[macro_export]
+macro_rules! debug_fn {
+    ($fmt:literal $(, $arg:expr)* $(,)?) => {{
+        ax_log::debug!($fmt $(, $arg)*);
     }};
 }
 

--- a/os/StarryOS/kernel/src/dyn_debug.rs
+++ b/os/StarryOS/kernel/src/dyn_debug.rs
@@ -21,7 +21,7 @@ impl DebugOps for DynamicDebugOps {
 /// See [ax_debug_fn] for usage.
 ///
 /// # Note
-/// This macro don't depend on the derive macro `#[ddebug::named]`, so the 'f' flag can't be used to print the function name.
+/// This macro doesn't depend on the derive macro `#[ddebug::named]`, so the 'f' flag can't be used to print the function name.
 #[macro_export]
 macro_rules! ax_debug {
     ($fmt:literal $(, $arg:expr)* $(,)?) => {{

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -18,6 +18,7 @@ use crate::{
 
 /// Initialize and run initproc.
 pub fn init(args: &[String], envs: &[String]) {
+    static_keys::global_init();
     pseudofs::mount_all().expect("Failed to mount pseudofs");
     spawn_alarm_task();
 

--- a/os/StarryOS/kernel/src/lib.rs
+++ b/os/StarryOS/kernel/src/lib.rs
@@ -12,6 +12,9 @@ extern crate ax_runtime;
 #[macro_use]
 extern crate ax_log;
 
+#[macro_use]
+pub mod dyn_debug; // Re-export debug macros for use in other modules. It will override the `debug` macro from `log` crate when `dynamic_debug` feature is enabled.
+
 pub mod entry;
 
 mod config;
@@ -23,5 +26,3 @@ mod syscall;
 mod task;
 mod time;
 mod trap;
-#[macro_use]
-mod dyn_debug;

--- a/os/StarryOS/kernel/src/lib.rs
+++ b/os/StarryOS/kernel/src/lib.rs
@@ -18,7 +18,10 @@ mod config;
 mod file;
 mod mm;
 mod pseudofs;
+mod stop_machine;
 mod syscall;
 mod task;
 mod time;
 mod trap;
+#[macro_use]
+mod dyn_debug;

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -408,3 +408,48 @@ impl IoBufMut for VmBytesMut {
         self.len
     }
 }
+
+/// Writes data to kernel text, ensuring the page permissions are properly handled.
+pub fn write_kernel_text(addr: VirtAddr, data: &[u8]) -> AxResult<()> {
+    if data.is_empty() {
+        return Ok(());
+    }
+
+    let aligned_addr = addr.align_down_4k();
+    let aligned_length = (addr + data.len()).align_up_4k() - aligned_addr;
+
+    crate::stop_machine::stop_machine(
+        || -> AxResult<()> {
+            let kspace = ax_mm::kernel_aspace();
+            let mut guard = kspace.lock();
+            let (_, original_flags, _) = guard.page_table().query(aligned_addr)?;
+
+            guard.protect(
+                aligned_addr,
+                aligned_length,
+                original_flags | MappingFlags::WRITE,
+            )?;
+            flush_tlb_range(aligned_addr, aligned_length);
+
+            unsafe {
+                core::ptr::copy_nonoverlapping(data.as_ptr(), addr.as_mut_ptr(), data.len());
+            }
+
+            guard.protect(aligned_addr, aligned_length, original_flags)?;
+            Ok(())
+        },
+        move || sync_modified_kernel_text(aligned_addr, aligned_length),
+    )
+}
+
+fn flush_tlb_range(start: VirtAddr, size: usize) {
+    for offset in (0..size).step_by(PAGE_SIZE_4K) {
+        ax_hal::asm::flush_tlb(Some(start + offset));
+    }
+}
+
+fn sync_modified_kernel_text(start: VirtAddr, size: usize) {
+    flush_tlb_range(start, size);
+
+    ax_hal::asm::flush_icache_all();
+}

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -418,27 +418,30 @@ pub fn write_kernel_text(addr: VirtAddr, data: &[u8]) -> AxResult<()> {
     let aligned_addr = addr.align_down_4k();
     let aligned_length = (addr + data.len()).align_up_4k() - aligned_addr;
 
-    crate::stop_machine::stop_machine(
-        || -> AxResult<()> {
-            let kspace = ax_mm::kernel_aspace();
-            let mut guard = kspace.lock();
-            let (_, original_flags, _) = guard.page_table().query(aligned_addr)?;
+    let mut guard = ax_mm::kernel_aspace().lock();
+    let (_, original_flags, _) = guard.page_table().query(aligned_addr)?;
 
+    crate::stop_machine::stop_machine(
+        move || -> AxResult<()> {
             guard.protect(
                 aligned_addr,
                 aligned_length,
                 original_flags | MappingFlags::WRITE,
             )?;
+
             flush_tlb_range(aligned_addr, aligned_length);
 
             unsafe {
                 core::ptr::copy_nonoverlapping(data.as_ptr(), addr.as_mut_ptr(), data.len());
             }
 
+            #[cfg(target_arch = "aarch64")]
+            ax_hal::asm::clean_dcache_range_to_pou(addr, data.len());
+
             guard.protect(aligned_addr, aligned_length, original_flags)?;
             Ok(())
         },
-        move || sync_modified_kernel_text(aligned_addr, aligned_length, addr),
+        move || sync_modified_kernel_text(aligned_addr, aligned_length),
     )
 }
 
@@ -448,11 +451,8 @@ fn flush_tlb_range(start: VirtAddr, size: usize) {
     }
 }
 
-fn sync_modified_kernel_text(start: VirtAddr, size: usize, _addr: VirtAddr) {
+fn sync_modified_kernel_text(start: VirtAddr, size: usize) {
     flush_tlb_range(start, size);
-
-    #[cfg(target_arch = "aarch64")]
-    ax_hal::asm::flush_dcache_line(_addr);
 
     ax_hal::asm::flush_icache_all();
 }

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -438,7 +438,7 @@ pub fn write_kernel_text(addr: VirtAddr, data: &[u8]) -> AxResult<()> {
             guard.protect(aligned_addr, aligned_length, original_flags)?;
             Ok(())
         },
-        move || sync_modified_kernel_text(aligned_addr, aligned_length),
+        move || sync_modified_kernel_text(aligned_addr, aligned_length, addr),
     )
 }
 
@@ -448,8 +448,11 @@ fn flush_tlb_range(start: VirtAddr, size: usize) {
     }
 }
 
-fn sync_modified_kernel_text(start: VirtAddr, size: usize) {
+fn sync_modified_kernel_text(start: VirtAddr, size: usize, _addr: VirtAddr) {
     flush_tlb_range(start, size);
+
+    #[cfg(target_arch = "aarch64")]
+    ax_hal::asm::flush_dcache_line(_addr);
 
     ax_hal::asm::flush_icache_all();
 }

--- a/os/StarryOS/kernel/src/pseudofs/dyn_debug.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dyn_debug.rs
@@ -22,7 +22,11 @@ pub struct DynDebugControlFile {
 impl DynDebugControlFile {
     fn new(fs: Arc<SimpleFs>, control: ControlFile<DynamicDebugOps>) -> Arc<Self> {
         Arc::new(Self {
-            node: SimpleFsNode::new(fs, NodeType::RegularFile, NodePermission::default()),
+            node: SimpleFsNode::new(
+                fs,
+                NodeType::RegularFile,
+                NodePermission::from_bits_truncate(0o644),
+            ),
             control: Mutex::new(control),
             snapshot: Mutex::new(None),
         })

--- a/os/StarryOS/kernel/src/pseudofs/dyn_debug.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dyn_debug.rs
@@ -1,0 +1,128 @@
+use alloc::{string::String, sync::Arc, vec::Vec};
+use core::{any::Any, task::Context};
+
+use ax_sync::Mutex;
+use axfs_ng_vfs::{
+    FileNodeOps, FilesystemOps, Metadata, MetadataUpdate, NodeFlags, NodeOps, NodePermission,
+    NodeType, VfsError, VfsResult,
+};
+use axpoll::{IoEvents, Pollable};
+use ddebug::ControlFile;
+use inherit_methods_macro::inherit_methods;
+
+use super::{SimpleFs, SimpleFsNode};
+use crate::dyn_debug::{DynamicDebugOps, dynamic_debug_init};
+
+pub struct DynDebugControlFile {
+    node: SimpleFsNode,
+    control: Mutex<ControlFile<DynamicDebugOps>>,
+    snapshot: Mutex<Option<Vec<u8>>>,
+}
+
+impl DynDebugControlFile {
+    fn new(fs: Arc<SimpleFs>, control: ControlFile<DynamicDebugOps>) -> Arc<Self> {
+        Arc::new(Self {
+            node: SimpleFsNode::new(fs, NodeType::RegularFile, NodePermission::default()),
+            control: Mutex::new(control),
+            snapshot: Mutex::new(None),
+        })
+    }
+
+    fn apply_command(&self, data: &[u8]) -> VfsResult<()> {
+        let content = core::str::from_utf8(data).map_err(|_| VfsError::InvalidInput)?;
+        self.control
+            .lock()
+            .write(content)
+            .map_err(|_| VfsError::InvalidInput)?;
+        Ok(())
+    }
+}
+
+#[inherit_methods(from = "self.node")]
+impl NodeOps for DynDebugControlFile {
+    fn inode(&self) -> u64;
+
+    fn metadata(&self) -> VfsResult<Metadata>;
+
+    fn update_metadata(&self, update: MetadataUpdate) -> VfsResult<()>;
+
+    fn filesystem(&self) -> &dyn FilesystemOps;
+
+    fn sync(&self, data_only: bool) -> VfsResult<()>;
+
+    fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
+    }
+
+    fn len(&self) -> VfsResult<u64> {
+        let mut snapshot = self.snapshot.lock();
+        if snapshot.is_none() {
+            let data = self.control.lock().read().unwrap_or_else(|_| String::new());
+            *snapshot = Some(data.into_bytes().to_vec());
+        }
+        Ok(snapshot.as_ref().unwrap().len() as u64)
+    }
+
+    fn flags(&self) -> NodeFlags {
+        NodeFlags::NON_CACHEABLE
+    }
+}
+
+impl FileNodeOps for DynDebugControlFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> VfsResult<usize> {
+        let mut snapshot = self.snapshot.lock();
+        if snapshot.is_none() || offset == 0 {
+            let data = self.control.lock().read().unwrap_or_else(|_| String::new());
+            *snapshot = Some(data.into_bytes().to_vec());
+        }
+        let data = snapshot.as_ref().unwrap();
+        if offset >= data.len() as u64 {
+            return Ok(0);
+        }
+
+        let data = &data[offset as usize..];
+        let read = data.len().min(buf.len());
+        buf[..read].copy_from_slice(&data[..read]);
+        Ok(read)
+    }
+
+    fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        self.apply_command(buf)?;
+        Ok(buf.len())
+    }
+
+    fn append(&self, buf: &[u8]) -> VfsResult<(usize, u64)> {
+        let written = self.write_at(buf, 0)?;
+        Ok((written, 0))
+    }
+
+    fn set_len(&self, len: u64) -> VfsResult<()> {
+        if len == 0 {
+            // Shell redirection usually opens proc control files with O_TRUNC.
+            return Ok(());
+        }
+        Err(VfsError::OperationNotPermitted)
+    }
+
+    fn set_symlink(&self, _target: &str) -> VfsResult<()> {
+        Err(VfsError::OperationNotPermitted)
+    }
+}
+
+impl Pollable for DynDebugControlFile {
+    fn poll(&self) -> IoEvents {
+        IoEvents::IN | IoEvents::OUT
+    }
+
+    fn register(&self, _context: &mut Context<'_>, _events: IoEvents) {}
+}
+
+/// Creates a control file for dynamic debug. This file can be used to enable/disable dynamic debug sites at runtime.
+pub fn create_dyn_debug_control_file(fs: Arc<SimpleFs>) -> Arc<DynDebugControlFile> {
+    let control = dynamic_debug_init();
+    DynDebugControlFile::new(fs, control)
+}

--- a/os/StarryOS/kernel/src/pseudofs/file.rs
+++ b/os/StarryOS/kernel/src/pseudofs/file.rs
@@ -178,6 +178,7 @@ impl Pollable for SimpleFile {
     fn register(&self, _context: &mut Context<'_>, _events: IoEvents) {}
 }
 
+// TODO: create a linux like seq file that supports iterating content in chunks instead of reading all content at once, to avoid large memory usage for large files.
 /// A Sequential file, which only supports reading all content. It is used for procfs and sysfs.
 pub struct SeqFile {
     node: SimpleFsNode,
@@ -202,7 +203,6 @@ impl SeqFile {
     }
 }
 
-// TODO: create a linux like seq file that supports iterating content in chunks instead of reading all content at once, to avoid large memory usage for large files.
 /// Operations for a sequential file.
 pub trait SeqFileOps: Send + Sync + 'static {
     /// Reads all content in the file.
@@ -256,7 +256,7 @@ impl NodeOps for SeqFile {
 impl FileNodeOps for SeqFile {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> VfsResult<usize> {
         let mut cache = self.content_cache.lock();
-        if cache.is_none() {
+        if cache.is_none() || offset == 0 {
             let content = self.ops.read_all()?;
             *cache = Some(content.into_owned());
         }
@@ -271,18 +271,10 @@ impl FileNodeOps for SeqFile {
         Ok(read)
     }
 
-    fn seek_to(&self, pos: u64) -> VfsResult<()> {
-        if pos == 0 {
-            // Clear the cache to reset the file content.
-            let mut cache = self.content_cache.lock();
-            *cache = None;
-        }
-        Ok(())
-    }
-
     fn write_at(&self, _buf: &[u8], _offset: u64) -> VfsResult<usize> {
         Err(VfsError::OperationNotPermitted)
     }
+
     fn append(&self, _buf: &[u8]) -> VfsResult<(usize, u64)> {
         Err(VfsError::OperationNotPermitted)
     }

--- a/os/StarryOS/kernel/src/pseudofs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/mod.rs
@@ -3,6 +3,7 @@
 pub mod dev;
 mod device;
 mod dir;
+mod dyn_debug;
 mod file;
 mod fs;
 mod proc;

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -743,6 +743,17 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         SimpleDir::new_maker(fs.clone(), Arc::new(sys))
     });
 
+    root.add("dynamic_debug", {
+        let mut dynamic_debug = DirMapping::new();
+
+        dynamic_debug.add(
+            "control",
+            super::dyn_debug::create_dyn_debug_control_file(fs.clone()),
+        );
+
+        SimpleDir::new_maker(fs.clone(), Arc::new(dynamic_debug))
+    });
+
     let proc_dir = ProcFsHandler(fs.clone());
     SimpleDir::new_maker(fs, Arc::new(proc_dir.chain(root)))
 }

--- a/os/StarryOS/kernel/src/stop_machine.rs
+++ b/os/StarryOS/kernel/src/stop_machine.rs
@@ -4,7 +4,7 @@ use core::{
     sync::atomic::{AtomicU8, AtomicUsize, Ordering},
 };
 
-use ax_hal::{cpu_num, percpu::this_cpu_id};
+use ax_hal::{cpu_num, percpu::this_cpu_id, time::monotonic_time_nanos};
 use ax_ipi::run_on_cpu;
 use ax_kernel_guard::NoPreemptIrqSave;
 use ax_kspin::SpinNoIrq;
@@ -78,8 +78,13 @@ where
         run_on_cpu(cpu_id, move || park_remote_cpu(state));
     }
 
+    const MAX_WAIT_NS: u64 = 5_000_000_000; // 5 seconds
+    let now = monotonic_time_nanos();
     while state.parked.load(Ordering::SeqCst) != remote_cpu_count {
         spin_loop();
+        if monotonic_time_nanos() - now > MAX_WAIT_NS {
+            panic!("stop_machine: timeout waiting for remote CPUs to park");
+        }
     }
 
     // Now all remote CPUs are parked. We can safely execute the critical section.

--- a/os/StarryOS/kernel/src/stop_machine.rs
+++ b/os/StarryOS/kernel/src/stop_machine.rs
@@ -1,0 +1,95 @@
+use alloc::{boxed::Box, sync::Arc};
+use core::{
+    hint::spin_loop,
+    sync::atomic::{AtomicU8, AtomicUsize, Ordering},
+};
+
+use ax_hal::{cpu_num, percpu::this_cpu_id};
+use ax_ipi::run_on_cpu;
+use ax_kernel_guard::NoPreemptIrqSave;
+use ax_kspin::SpinNoIrq;
+
+static STOP_MACHINE_LOCK: SpinNoIrq<()> = SpinNoIrq::new(());
+
+const STAGE_PARKED: u8 = 0;
+const STAGE_SYNC: u8 = 1;
+
+struct StopMachineState {
+    stage: AtomicU8,
+    parked: AtomicUsize,
+    finished: AtomicUsize,
+    per_cpu_sync: Box<dyn Fn() + Send + Sync>,
+}
+
+impl StopMachineState {
+    fn new<F>(per_cpu_sync: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        Self {
+            stage: AtomicU8::new(STAGE_PARKED),
+            parked: AtomicUsize::new(0),
+            finished: AtomicUsize::new(0),
+            per_cpu_sync: Box::new(per_cpu_sync),
+        }
+    }
+}
+
+fn park_remote_cpu(state: Arc<StopMachineState>) {
+    let _guard = NoPreemptIrqSave::new();
+
+    state.parked.fetch_add(1, Ordering::SeqCst);
+    while state.stage.load(Ordering::SeqCst) == STAGE_PARKED {
+        spin_loop();
+    }
+
+    (state.per_cpu_sync.as_ref())();
+    state.finished.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Run a short non-blocking critical section while all other CPUs are parked.
+///
+/// Both `action` and `per_cpu_sync` must not sleep or fault, and may only take
+/// IRQ-safe locks.
+pub(crate) fn stop_machine<R, A, S>(action: A, per_cpu_sync: S) -> R
+where
+    A: FnOnce() -> R,
+    S: Fn() + Send + Sync + 'static,
+{
+    let _lock = STOP_MACHINE_LOCK.lock();
+    let total_cpus = cpu_num();
+
+    if total_cpus <= 1 {
+        let result = action();
+        per_cpu_sync();
+        return result;
+    }
+
+    let current_cpu = this_cpu_id();
+    let remote_cpu_count = total_cpus - 1;
+    let state = Arc::new(StopMachineState::new(per_cpu_sync));
+
+    for cpu_id in 0..total_cpus {
+        if cpu_id == current_cpu {
+            continue;
+        }
+
+        let state = state.clone();
+        run_on_cpu(cpu_id, move || park_remote_cpu(state));
+    }
+
+    while state.parked.load(Ordering::SeqCst) != remote_cpu_count {
+        spin_loop();
+    }
+
+    // Now all remote CPUs are parked. We can safely execute the critical section.
+    let result = action();
+    (state.per_cpu_sync.as_ref())();
+    state.stage.store(STAGE_SYNC, Ordering::SeqCst);
+
+    while state.finished.load(Ordering::SeqCst) != remote_cpu_count {
+        spin_loop();
+    }
+
+    result
+}

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -17,6 +17,7 @@ use linux_raw_sys::{
 use starry_vm::{VmPtr, vm_write_slice};
 
 use crate::{
+    ax_debug, ax_debug_fn,
     file::{Directory, FileLike, get_file_like, resolve_at, with_fs},
     mm::vm_load_string,
     pseudofs::Device,
@@ -48,9 +49,10 @@ pub fn sys_ioctl(fd: i32, cmd: u32, arg: usize) -> AxResult<isize> {
         })
 }
 
+#[ddebug::named]
 pub fn sys_chdir(path: *const c_char) -> AxResult<isize> {
     let path = vm_load_string(path)?;
-    debug!("sys_chdir <= path: {path}");
+    ax_debug_fn!("sys_chdir <= path: {path}");
 
     let mut fs = FS_CONTEXT.lock();
     let entry = fs.resolve(path)?;
@@ -59,7 +61,7 @@ pub fn sys_chdir(path: *const c_char) -> AxResult<isize> {
 }
 
 pub fn sys_fchdir(dirfd: i32) -> AxResult<isize> {
-    debug!("sys_fchdir <= dirfd: {dirfd}");
+    ax_debug!("sys_fchdir <= dirfd: {dirfd}");
 
     let entry = with_fs(dirfd, |fs| Ok(fs.current_dir().clone()))?;
     FS_CONTEXT.lock().set_current_dir(entry)?;
@@ -73,7 +75,7 @@ pub fn sys_mkdir(path: *const c_char, mode: u32) -> AxResult<isize> {
 
 pub fn sys_chroot(path: *const c_char) -> AxResult<isize> {
     let path = vm_load_string(path)?;
-    debug!("sys_chroot <= path: {path}");
+    ax_debug!("sys_chroot <= path: {path}");
 
     let mut fs = FS_CONTEXT.lock();
     let loc = fs.resolve(path)?;
@@ -86,7 +88,7 @@ pub fn sys_chroot(path: *const c_char) -> AxResult<isize> {
 
 pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize> {
     let path = vm_load_string(path)?;
-    debug!("sys_mkdirat <= dirfd: {dirfd}, path: {path}, mode: {mode}");
+    ax_debug!("sys_mkdirat <= dirfd: {dirfd}, path: {path}, mode: {mode}");
 
     let mode = mode & !current().as_thread().proc_data.umask();
     let mode = NodePermission::from_bits_truncate(mode as u16);
@@ -105,9 +107,12 @@ pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize
 
 pub fn sys_mknodat(dirfd: i32, path: *const c_char, mode: u32, dev: u64) -> Result<isize, AxError> {
     let path = vm_load_string(path)?;
-    debug!(
+    ax_debug!(
         "sys_mknodat <= dirfd: {}, path: {:?}, mode: {}, dev: {}",
-        dirfd, path, mode, dev
+        dirfd,
+        path,
+        mode,
+        dev
     );
 
     // Split type and permission bits

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -17,7 +17,6 @@ use linux_raw_sys::{
 use starry_vm::{VmPtr, vm_write_slice};
 
 use crate::{
-    ax_debug, ax_debug_fn,
     file::{Directory, FileLike, get_file_like, resolve_at, with_fs},
     mm::vm_load_string,
     pseudofs::Device,
@@ -52,7 +51,7 @@ pub fn sys_ioctl(fd: i32, cmd: u32, arg: usize) -> AxResult<isize> {
 #[ddebug::named]
 pub fn sys_chdir(path: *const c_char) -> AxResult<isize> {
     let path = vm_load_string(path)?;
-    ax_debug_fn!("sys_chdir <= path: {path}");
+    debug_fn!("sys_chdir <= path: {path}");
 
     let mut fs = FS_CONTEXT.lock();
     let entry = fs.resolve(path)?;
@@ -61,7 +60,7 @@ pub fn sys_chdir(path: *const c_char) -> AxResult<isize> {
 }
 
 pub fn sys_fchdir(dirfd: i32) -> AxResult<isize> {
-    ax_debug!("sys_fchdir <= dirfd: {dirfd}");
+    debug!("sys_fchdir <= dirfd: {dirfd}");
 
     let entry = with_fs(dirfd, |fs| Ok(fs.current_dir().clone()))?;
     FS_CONTEXT.lock().set_current_dir(entry)?;
@@ -75,7 +74,7 @@ pub fn sys_mkdir(path: *const c_char, mode: u32) -> AxResult<isize> {
 
 pub fn sys_chroot(path: *const c_char) -> AxResult<isize> {
     let path = vm_load_string(path)?;
-    ax_debug!("sys_chroot <= path: {path}");
+    debug!("sys_chroot <= path: {path}");
 
     let mut fs = FS_CONTEXT.lock();
     let loc = fs.resolve(path)?;
@@ -88,7 +87,7 @@ pub fn sys_chroot(path: *const c_char) -> AxResult<isize> {
 
 pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize> {
     let path = vm_load_string(path)?;
-    ax_debug!("sys_mkdirat <= dirfd: {dirfd}, path: {path}, mode: {mode}");
+    debug!("sys_mkdirat <= dirfd: {dirfd}, path: {path}, mode: {mode}");
 
     let mode = mode & !current().as_thread().proc_data.umask();
     let mode = NodePermission::from_bits_truncate(mode as u16);
@@ -107,12 +106,9 @@ pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize
 
 pub fn sys_mknodat(dirfd: i32, path: *const c_char, mode: u32, dev: u64) -> Result<isize, AxError> {
     let path = vm_load_string(path)?;
-    ax_debug!(
+    debug!(
         "sys_mknodat <= dirfd: {}, path: {:?}, mode: {}, dev: {}",
-        dirfd,
-        path,
-        mode,
-        dev
+        dirfd, path, mode, dev
     );
 
     // Split type and permission bits

--- a/os/StarryOS/starryos/build.rs
+++ b/os/StarryOS/starryos/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rerun-if-changed=ext_linker.ld");
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let ext_linker = format!("{out_dir}/ext_linker.ld");
+
+    std::fs::write(&ext_linker, include_str!("ext_linker.ld")).unwrap();
+    println!("cargo:rustc-link-arg-bin=starryos=-T{ext_linker}");
+}

--- a/os/StarryOS/starryos/ext_linker.ld
+++ b/os/StarryOS/starryos/ext_linker.ld
@@ -1,5 +1,5 @@
 SECTIONS {
-    __static_keys : {
+    .static_keys : {
         __start___static_keys = .;
         KEEP(*(__static_keys))
         __stop___static_keys = .;

--- a/os/StarryOS/starryos/ext_linker.ld
+++ b/os/StarryOS/starryos/ext_linker.ld
@@ -1,0 +1,15 @@
+SECTIONS {
+    __static_keys : {
+        __start___static_keys = .;
+        KEEP(*(__static_keys))
+        __stop___static_keys = .;
+    }
+
+    .dyndbg : {
+        __start___dyndbg = .;
+        KEEP(*(__dyndbg))
+        __stop___dyndbg = .;
+    }
+}
+
+INSERT AFTER .data;

--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -466,12 +466,6 @@ impl CachedFile {
         self.in_memory
     }
 
-    /// A hint to the backend that the file position has changed.
-    /// This is used for operations like resetting file content in proc/sys.
-    pub fn seek_to(&self, pos: u64) -> VfsResult<()> {
-        self.inner.entry().as_file()?.seek_to(pos)
-    }
-
     /// Registers a listener that is called when a page is evicted from cache.
     ///
     /// Returns a handle that can later be passed to
@@ -736,15 +730,6 @@ impl FileBackend {
         Self::Cached(CachedFile::get_or_create(location))
     }
 
-    /// A hint to the backend that the file position has changed.
-    /// This is used for operations like resetting file content in proc/sys.
-    pub fn seek_to(&self, pos: u64) -> VfsResult<()> {
-        match self {
-            Self::Cached(cached) => cached.seek_to(pos),
-            Self::Direct(loc) => loc.entry().as_file()?.seek_to(pos),
-        }
-    }
-
     /// Reads data from the file at `offset` into `dst`.
     pub fn read_at(&self, mut dst: impl Write + IoBufMut, mut offset: u64) -> VfsResult<usize> {
         match self {
@@ -991,10 +976,6 @@ impl Seek for &File {
                     .ok_or(VfsError::InvalidInput)?,
             };
             *guard = new_pos;
-            // Seeking doesn't actually require any action on the backend since we
-            // track the position in the `File` struct, but we can hint to the backend
-            // about it for potential operations like resetting file content(proc/sys).
-            self.inner.seek_to(new_pos)?;
             Ok(new_pos)
         } else {
             Ok(0)


### PR DESCRIPTION
## 背景

当前 StarryOS 的调试日志主要依赖编译期控制，运行时无法按 callsite 精细启停。这个 PR 为 `starry-kernel` 接入基于 `static-keys` 的 dynamic debug，并提供 `/proc/dynamic_debug/control` 作为运行时控制入口。

关于dynamic debug，可以直接查看 Linux 的[官方文档](https://docs.kernel.org/admin-guide/dynamic-debug-howto.html)。 

## 主要变更

- 为 `starry-kernel` 引入 `static-keys` 与 `ddebug`
- 新增 `debug!` / `debug_fn!` 宏，用于声明可运行时控制的调试点
- 在启动阶段初始化 static keys，并补充 dynamic debug 所需的 linker section
- 新增内核私有 `stop_machine` 实现，用于在运行时安全地 patch kernel text
- 在 text patch 完成后执行每 CPU 的 TLB / icache 同步，覆盖多架构场景
- 在 `/proc/dynamic_debug/control` 暴露动态调试控制文件
- 在部分文件系统 syscall 路径上接入 dynamic debug，作为首批使用点

## 使用方法

### 1. 查看当前所有 dynamic debug callsite

```sh
cat /proc/dynamic_debug/control
```
输出格式类似：
```
# filename:lineno [module]function flags format
```
### 2. 按格式串启用某条日志
```sh
echo 'format "sys_chdir <=" +p' > /proc/dynamic_debug/control
```
### 3. 按函数名启用并附加前缀信息
```sh
echo 'func sys_chdir =ptmfsl' > /proc/dynamic_debug/control
```
说明：
- `func` 选择器只对使用 `ax_debug_fn!` 且带 `#[ddebug::named]` 的 callsite 生效
- `=ptmfsl` 表示直接设置 flags
### 4. 关闭某条日志
```sh
echo 'format "sys_chdir <=" -p' > /proc/dynamic_debug/control
```
### 5. 清空某条日志的 flags
```sh
echo 'func sys_chdir =_' > /proc/dynamic_debug/control
```
### 6. 常用选择器
- `file <pattern>`
- `func <pattern>`
- `module <pattern>`
- `line <start-end>`
- `format <pattern>`
支持 `*` 和 `?` 通配符，也支持用 `;` 一次写多条规则。

示例：
```sh
echo 'file *ctl.rs format "sys_mkdirat <=" +p; func sys_chdir =ptmfsl' > /proc/dynamic_debug/control
```

### 7. flags 含义
- p：启用打印
- t：输出线程 ID
- m：输出模块名
- f：输出函数名
- s：输出源文件名
- l：输出行号