### PR TITLE
fix(mm): accept fd 0 for file mmap and ignore fd for anonymous mappings

### DIFF
--- a/os/StarryOS/kernel/CHANGELOG.md
+++ b/os/StarryOS/kernel/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(mmap)* accept fd 0 for file mappings and ignore fd for anonymous mappings
+
 ## [0.5.9](https://github.com/rcore-os/tgoskits/compare/starry-kernel-v0.5.8...starry-kernel-v0.5.9) - 2026-04-27
 
 ### Added

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -126,15 +126,13 @@ pub fn sys_mmap(
     if type_bits != MAP_PRIVATE && type_bits != MAP_SHARED {
         return Err(AxError::InvalidInput);
     }
-    if map_flags.contains(MmapFlags::ANONYMOUS) != (fd <= 0) {
-        return Err(AxError::InvalidInput);
-    }
-    if fd <= 0 && offset != 0 {
-        return Err(AxError::InvalidInput);
-    }
     let offset: usize = offset.try_into().map_err(|_| AxError::InvalidInput)?;
     if !PageSize::Size4K.is_aligned(offset) {
         return Err(AxError::InvalidInput);
+    }
+    let anonymous = map_flags.contains(MmapFlags::ANONYMOUS);
+    if !anonymous && fd < 0 {
+        return Err(AxError::BadFileDescriptor);
     }
 
     debug!(
@@ -178,10 +176,10 @@ pub fn sys_mmap(
             .ok_or(AxError::NoMemory)?
     };
 
-    let file = if fd > 0 {
-        Some(get_file_like(fd)?)
-    } else {
+    let file = if anonymous {
         None
+    } else {
+        Some(get_file_like(fd)?)
     };
 
     let backend = match map_type {

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-mmap-fd-zero-anon/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-mmap-fd-zero-anon/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-mmap-fd-zero-anon C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-mmap-fd-zero-anon src/main.c)
+target_compile_options(bug-mmap-fd-zero-anon PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-mmap-fd-zero-anon RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-mmap-fd-zero-anon/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-mmap-fd-zero-anon/c/src/main.c
@@ -1,0 +1,118 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+#define CHECK(cond, msg) \
+    do { \
+        if (cond) { \
+            printf("  [OK] %s\n", (msg)); \
+            passed++; \
+        } else { \
+            printf("  [FAIL] %s (errno=%d %s)\n", (msg), errno, strerror(errno)); \
+            failed++; \
+        } \
+    } while (0)
+
+static int write_all(int fd, const char *data)
+{
+    size_t len = strlen(data);
+    ssize_t written = write(fd, data, len);
+    return written == (ssize_t)len ? 0 : -1;
+}
+
+static int create_test_file(const char *path)
+{
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        return -1;
+    }
+    if (write_all(fd, "mmap-fd-zero") != 0) {
+        int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    if (lseek(fd, 0, SEEK_SET) != 0) {
+        int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+int main(void)
+{
+    const char *path = "/tmp/bug_mmap_fd_zero_anon_file";
+    const size_t len = 4096;
+
+    printf("=== bug-mmap-fd-zero-anon ===\n");
+    unlink(path);
+
+    int fd = create_test_file(path);
+    CHECK(fd >= 0, "create mmap source file");
+    if (fd < 0) {
+        return EXIT_FAILURE;
+    }
+
+    int saved_stdin = dup(STDIN_FILENO);
+    CHECK(saved_stdin >= 0, "save original stdin fd");
+    CHECK(dup2(fd, STDIN_FILENO) == STDIN_FILENO, "move source file onto fd 0");
+
+    errno = 0;
+    void *p = mmap(NULL, len, PROT_READ, MAP_PRIVATE, STDIN_FILENO, 0);
+    CHECK(p != MAP_FAILED, "file-backed mmap accepts fd 0");
+    if (p != MAP_FAILED) {
+        CHECK(memcmp(p, "mmap-fd-zero", strlen("mmap-fd-zero")) == 0,
+              "fd 0 mapping exposes file contents");
+        CHECK(munmap(p, len) == 0, "munmap fd 0 file mapping");
+    }
+
+    if (saved_stdin >= 0) {
+        CHECK(dup2(saved_stdin, STDIN_FILENO) == STDIN_FILENO, "restore stdin fd");
+        close(saved_stdin);
+    }
+
+    errno = 0;
+    p = mmap(NULL, len, PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS, fd, 4096);
+    CHECK(p != MAP_FAILED, "anonymous mmap ignores positive fd and accepts page-aligned offset");
+    if (p != MAP_FAILED) {
+        char *bytes = (char *)p;
+        bytes[0] = 'x';
+        CHECK(bytes[0] == 'x', "anonymous mapping is writable");
+        CHECK(munmap(p, len) == 0, "munmap anonymous mapping");
+    }
+
+    errno = 0;
+    p = mmap(NULL, len, PROT_READ, MAP_PRIVATE, -1, 0);
+    CHECK(p == MAP_FAILED && errno == EBADF,
+          "file-backed mmap with fd -1 fails with EBADF");
+
+    errno = 0;
+    p = mmap(NULL, len, PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 1);
+    CHECK(p == MAP_FAILED && errno == EINVAL,
+          "anonymous mmap still rejects unaligned offset");
+
+    close(fd);
+    unlink(path);
+
+    printf("\n=== result: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("TEST PASSED\n");
+    } else {
+        printf("TEST FAILED\n");
+    }
+    return failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -20,6 +20,7 @@ test_commands = [
     "/usr/bin/bug-futex-wait-wake",
     "/usr/bin/bug-lseek-negative-einval",
     "/usr/bin/bug-mkdir-empty-path",
+    "/usr/bin/bug-mmap-fd-zero-anon",
     "/usr/bin/bug-open-dir-wronly",
     "/usr/bin/bug-pipe-fd-errno",
     "/usr/bin/bug-preadv2-invalid-flags",


### PR DESCRIPTION
## Summary

- Accept fd `0` for file-backed `mmap`.
- Ignore fd for `MAP_ANONYMOUS` mappings while still enforcing page-aligned offsets.
- Return `EBADF` for non-anonymous mappings with a negative fd.
- Add a StarryOS QEMU regression case covering fd 0, anonymous fd handling, and error paths.

## Root Cause

`sys_mmap` previously tied `MAP_ANONYMOUS` to `fd <= 0` and only looked up a backing file for `fd > 0`. That rejected valid file-backed mappings on fd 0 and rejected anonymous mappings that passed a positive fd, both of which differ from Linux behavior.

## Test plan

- `cc -Wall -Wextra -Werror test-suit/starryos/normal/qemu-smp1/bugfix/bug-mmap-fd-zero-anon/c/src/main.c -o /tmp/bug-mmap-fd-zero-anon && /tmp/bug-mmap-fd-zero-anon`
- `git diff --check`
- `cargo fmt --all -- --check`
- `PKG_CONFIG_PATH=target/local-pkgconfig cargo xtask clippy --package starry-kernel`
- `PKG_CONFIG_PATH=target/local-pkgconfig cargo xtask sync-lint`
- `PKG_CONFIG_PATH=target/local-pkgconfig cargo xtask starry test qemu --arch riscv64 --test-group normal --test-case bugfix`
