### PR TITLE
fix(file): validate faccessat2 mode and flags

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/stat.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/stat.rs
@@ -5,8 +5,8 @@ use ax_fs::FS_CONTEXT;
 use ax_task::current;
 use axfs_ng_vfs::{Location, NodePermission};
 use linux_raw_sys::general::{
-    __kernel_fsid_t, AT_EMPTY_PATH, AT_NO_AUTOMOUNT, AT_STATX_SYNC_TYPE, AT_SYMLINK_NOFOLLOW, R_OK,
-    STATX__RESERVED, W_OK, X_OK, stat, statfs, statx,
+    __kernel_fsid_t, AT_EACCESS, AT_EMPTY_PATH, AT_NO_AUTOMOUNT, AT_STATX_SYNC_TYPE,
+    AT_SYMLINK_NOFOLLOW, R_OK, STATX__RESERVED, W_OK, X_OK, stat, statfs, statx,
 };
 use starry_vm::{VmMutPtr, VmPtr};
 
@@ -133,6 +133,15 @@ pub fn sys_access(path: *const c_char, mode: u32) -> AxResult<isize> {
 // because fsuid/fsgid track euid/egid by default in our credential model,
 // so the real-ID vs effective-ID distinction AT_EACCESS controls is a no-op.
 pub fn sys_faccessat2(dirfd: c_int, path: *const c_char, mode: u32, flags: u32) -> AxResult<isize> {
+    // man 2 access: mode is a mask of F_OK(0), R_OK, W_OK, and X_OK;
+    // faccessat2 flags are limited to AT_EACCESS, AT_EMPTY_PATH, and
+    // AT_SYMLINK_NOFOLLOW. Linux rejects invalid bits before path resolution.
+    const FACCESSAT2_VALID_FLAGS: u32 = AT_EACCESS | AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW;
+    const FACCESSAT2_VALID_MODE: u32 = R_OK | W_OK | X_OK;
+    if mode & !FACCESSAT2_VALID_MODE != 0 || flags & !FACCESSAT2_VALID_FLAGS != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
     let path = path.nullable().map(vm_load_string).transpose()?;
     debug!("sys_faccessat2 <= dirfd: {dirfd}, path: {path:?}, mode: {mode}, flags: {flags}");
 

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -343,7 +343,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         ),
         #[cfg(target_arch = "x86_64")]
         Sysno::access => sys_access(uctx.arg0() as _, uctx.arg1() as _),
-        Sysno::faccessat | Sysno::faccessat2 => sys_faccessat2(
+        Sysno::faccessat => sys_faccessat2(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _, 0),
+        Sysno::faccessat2 => sys_faccessat2(
             uctx.arg0() as _,
             uctx.arg1() as _,
             uctx.arg2() as _,

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-faccessat2-validation/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-faccessat2-validation/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-faccessat2-validation C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-faccessat2-validation src/main.c)
+target_compile_options(bug-faccessat2-validation PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-faccessat2-validation RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-faccessat2-validation/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-faccessat2-validation/c/src/main.c
@@ -1,0 +1,157 @@
+/*
+ * bug-faccessat2-validation.c -- faccessat2 mode/flag validation
+ *
+ * Linux rejects access mode bits outside R_OK/W_OK/X_OK and flag bits outside
+ * AT_EACCESS/AT_EMPTY_PATH/AT_SYMLINK_NOFOLLOW with EINVAL before treating the
+ * path as a successful existence check. This keeps callers from silently
+ * accepting misspelled access checks.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_faccessat2
+#define SYS_faccessat2 439
+#endif
+
+#ifndef AT_EMPTY_PATH
+#define AT_EMPTY_PATH 0x1000
+#endif
+
+#ifndef AT_EACCESS
+#define AT_EACCESS 0x200
+#endif
+
+#define INVALID_ACCESS_MODE 0x8
+#define INVALID_ACCESS_FLAG 0x80000000u
+
+static int test_passed;
+static int test_failed;
+
+#define TEST_START(name)                                                      \
+    do {                                                                      \
+        printf("[TEST] %s\n", (name));                                        \
+        test_passed = 0;                                                      \
+        test_failed = 0;                                                      \
+    } while (0)
+
+#define CHECK(cond, msg)                                                      \
+    do {                                                                      \
+        if (cond) {                                                           \
+            printf("  [OK] %s\n", (msg));                                    \
+            test_passed++;                                                    \
+        } else {                                                              \
+            printf("  [FAIL] %s (errno=%d %s)\n", (msg), errno,              \
+                   strerror(errno));                                          \
+            test_failed++;                                                    \
+        }                                                                     \
+    } while (0)
+
+#define TEST_DONE()                                                           \
+    do {                                                                      \
+        printf("\n=== result: %d passed, %d failed ===\n", test_passed,       \
+               test_failed);                                                  \
+        if (test_failed == 0) {                                                \
+            printf("TEST PASSED\n");                                         \
+        }                                                                     \
+        return test_failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;                \
+    } while (0)
+
+static long raw_faccessat2(int dirfd, const char *path, int mode,
+                           unsigned int flags)
+{
+    return syscall(SYS_faccessat2, dirfd, path, mode, flags);
+}
+
+static long raw_faccessat_legacy(int dirfd, const char *path, int mode,
+                                 unsigned int ignored_flags)
+{
+    return syscall(SYS_faccessat, dirfd, path, mode, ignored_flags);
+}
+
+static void expect_ok(const char *label, int dirfd, const char *path, int mode,
+                      unsigned int flags)
+{
+    errno = 0;
+    long rc = raw_faccessat2(dirfd, path, mode, flags);
+    CHECK(rc == 0, label);
+}
+
+static void expect_errno(const char *label, int dirfd, const char *path,
+                         int mode, unsigned int flags, int expected)
+{
+    errno = 0;
+    long rc = raw_faccessat2(dirfd, path, mode, flags);
+    CHECK(rc == -1 && errno == expected, label);
+}
+
+int main(void)
+{
+    TEST_START("faccessat2 validates mode and flags");
+
+    const char *file_path = "/tmp/bug_faccessat2_validation_file";
+    const char *link_path = "/tmp/bug_faccessat2_validation_link";
+    const char *dangling_path = "/tmp/bug_faccessat2_validation_dangling";
+
+    unlink(file_path);
+    unlink(link_path);
+    unlink(dangling_path);
+
+    int fd = open(file_path, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    CHECK(fd >= 0, "create regular file");
+    if (fd >= 0) {
+        CHECK(write(fd, "x", 1) == 1, "write regular file");
+        close(fd);
+    }
+
+    CHECK(symlink(file_path, link_path) == 0, "create symlink to file");
+    CHECK(symlink("/tmp/bug_faccessat2_validation_missing", dangling_path) == 0,
+          "create dangling symlink");
+
+    expect_ok("F_OK on existing file succeeds", AT_FDCWD, file_path, F_OK, 0);
+    expect_ok("R_OK|W_OK on existing file succeeds", AT_FDCWD, file_path,
+              R_OK | W_OK, 0);
+    expect_ok("AT_EACCESS accepted as a valid flag", AT_FDCWD, file_path, R_OK,
+              AT_EACCESS);
+
+    errno = 0;
+    CHECK(raw_faccessat_legacy(AT_FDCWD, file_path, F_OK, INVALID_ACCESS_FLAG) == 0,
+          "legacy faccessat ignores the fourth syscall register");
+
+    expect_errno("invalid access mode bit returns EINVAL", AT_FDCWD, file_path,
+                 INVALID_ACCESS_MODE, 0, EINVAL);
+    expect_errno("mixed valid and invalid access mode returns EINVAL", AT_FDCWD,
+                 file_path, R_OK | INVALID_ACCESS_MODE, 0, EINVAL);
+    expect_errno("invalid flag bit returns EINVAL", AT_FDCWD, file_path, F_OK,
+                 INVALID_ACCESS_FLAG, EINVAL);
+    expect_errno("AT_EMPTY_PATH plus invalid flag returns EINVAL", AT_FDCWD, "",
+                 F_OK, AT_EMPTY_PATH | INVALID_ACCESS_FLAG, EINVAL);
+
+    int fd2 = open(file_path, O_RDONLY);
+    CHECK(fd2 >= 0, "open regular file for AT_EMPTY_PATH");
+    if (fd2 >= 0) {
+        expect_ok("AT_EMPTY_PATH with empty path succeeds", fd2, "", F_OK,
+                  AT_EMPTY_PATH);
+        expect_errno("invalid mode with AT_EMPTY_PATH returns EINVAL", fd2, "",
+                     INVALID_ACCESS_MODE, AT_EMPTY_PATH, EINVAL);
+        close(fd2);
+    }
+
+    expect_errno("dangling symlink follows target and returns ENOENT", AT_FDCWD,
+                 dangling_path, F_OK, 0, ENOENT);
+    expect_ok("AT_SYMLINK_NOFOLLOW checks dangling symlink itself", AT_FDCWD,
+              dangling_path, F_OK, AT_SYMLINK_NOFOLLOW);
+
+    unlink(file_path);
+    unlink(link_path);
+    unlink(dangling_path);
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -18,6 +18,7 @@ to_bin = true
 shell_prefix = "root@starry:"
 test_commands = [
     "/usr/bin/bug-futex-wait-wake",
+    "/usr/bin/bug-faccessat2-validation",
     "/usr/bin/bug-lseek-negative-einval",
     "/usr/bin/bug-mkdir-empty-path",
     "/usr/bin/bug-mmap-fd-zero-anon",


### PR DESCRIPTION
## Summary

- Reject invalid `faccessat2` access mode bits and unsupported flag bits before path resolution.
- Keep legacy `faccessat` dispatch flagless by forcing its fourth argument to `0`.
- Add a StarryOS QEMU regression case covering invalid mode bits, invalid flags, `AT_EMPTY_PATH`, symlink handling, and legacy `faccessat` dispatch.

## Root Cause

`sys_faccessat2` accepted arbitrary mode and flag bits. Unsupported bits could be ignored by later path resolution or permission checks, which differs from Linux's `EINVAL` behavior and could perform path work before rejecting bad inputs. The syscall dispatcher also grouped `faccessat` with `faccessat2`, so the legacy syscall incorrectly consumed the fourth raw argument as flags.

## Test plan

- `cc -Wall -Wextra -Werror test-suit/starryos/normal/qemu-smp1/bugfix/bug-faccessat2-validation/c/src/main.c -o /tmp/bug-faccessat2-validation-linux && /tmp/bug-faccessat2-validation-linux`
- `git diff --check`
- `cargo fmt --check`
- `PKG_CONFIG_PATH=$PWD/target/host-libs/pkgconfig cargo xtask clippy --package starry-kernel`
- `PKG_CONFIG_PATH=$PWD/target/host-libs/pkgconfig cargo xtask starry test qemu --arch riscv64 --test-group normal --test-case bugfix`
