### PR TITLE
fix(process): reject invalid wait4 options

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -7,9 +7,7 @@ use ax_task::{
     future::{block_on, interruptible},
 };
 use bitflags::bitflags;
-use linux_raw_sys::general::{
-    __WALL, __WCLONE, __WNOTHREAD, WCONTINUED, WEXITED, WNOHANG, WNOWAIT, WUNTRACED,
-};
+use linux_raw_sys::general::{__WALL, __WCLONE, __WNOTHREAD, WCONTINUED, WNOHANG, WUNTRACED};
 use starry_process::{Pid, Process};
 use starry_vm::{VmMutPtr, VmPtr};
 
@@ -23,13 +21,9 @@ bitflags! {
         /// Report the status of selected processes which are stopped due to a
         /// `SIGTTIN`, `SIGTTOU`, `SIGTSTP`, or `SIGSTOP` signal.
         const WUNTRACED = WUNTRACED;
-        /// Report the status of selected processes which have terminated.
-        const WEXITED = WEXITED;
         /// Report the status of selected processes that have continued from a
         /// job control stop by receiving a `SIGCONT` signal.
         const WCONTINUED = WCONTINUED;
-        /// Don't reap, just poll status.
-        const WNOWAIT = WNOWAIT;
 
         /// Don't wait on children of other threads in this group
         const WNOTHREAD = __WNOTHREAD;
@@ -61,7 +55,7 @@ impl WaitPid {
 }
 
 pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isize> {
-    let options = WaitOptions::from_bits_truncate(options);
+    let options = WaitOptions::from_bits(options).ok_or(AxError::InvalidInput)?;
     info!("sys_waitpid <= pid: {pid:?}, options: {options:?}");
 
     let curr = current();
@@ -91,17 +85,15 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
     let proc_data = curr.as_thread().proc_data.clone();
     let check_children = || {
         if let Some(child) = children.iter().find(|child| child.is_zombie()) {
-            if !options.contains(WaitOptions::WNOWAIT) {
-                // Accumulate child's CPU time before freeing
-                for tid in child.threads() {
-                    if let Ok(task) = get_task(tid) {
-                        let thr = task.as_thread();
-                        let (utime, stime) = thr.time.borrow().output();
-                        proc_data.add_child_cpu_time(utime, stime);
-                    }
+            // Accumulate child's CPU time before freeing.
+            for tid in child.threads() {
+                if let Ok(task) = get_task(tid) {
+                    let thr = task.as_thread();
+                    let (utime, stime) = thr.time.borrow().output();
+                    proc_data.add_child_cpu_time(utime, stime);
                 }
-                child.free();
             }
+            child.free();
             if let Some(exit_code) = exit_code.nullable() {
                 exit_code.vm_write(child.exit_code())?;
             }

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-wait4-invalid-options/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-wait4-invalid-options/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-wait4-invalid-options C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-wait4-invalid-options src/main.c)
+target_compile_options(bug-wait4-invalid-options PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-wait4-invalid-options RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-wait4-invalid-options/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-wait4-invalid-options/c/src/main.c
@@ -1,0 +1,141 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef WEXITED
+#define WEXITED 0x00000004
+#endif
+#ifndef WNOWAIT
+#define WNOWAIT 0x01000000
+#endif
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static pid_t wait4_raw(pid_t pid, int *status, int options, struct rusage *usage)
+{
+    return (pid_t)syscall(SYS_wait4, pid, status, options, usage);
+}
+
+static int cleanup_child(pid_t pid, int expect_exit)
+{
+    int status = 0;
+    errno = 0;
+    pid_t ret = wait4_raw(pid, &status, 0, NULL);
+    if (ret != pid) {
+        printf("  cleanup wait4 ret=%ld errno=%d (%s), expected pid=%ld\n",
+               (long)ret, errno, strerror(errno), (long)pid);
+        return 0;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != expect_exit) {
+        printf("  cleanup status=0x%x, expected exit=%d\n", status, expect_exit);
+        return 0;
+    }
+    return 1;
+}
+
+static void expect_invalid_option(const char *name, int option)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail(name, "fork failed");
+        return;
+    }
+    if (pid == 0) {
+        _exit(7);
+    }
+
+    usleep(50000);
+
+    int status = 0x12345678;
+    struct rusage usage;
+    memset(&usage, 0x5a, sizeof(usage));
+    errno = 0;
+    pid_t ret = wait4_raw(pid, &status, option, &usage);
+    int saved_errno = errno;
+
+    if (ret == -1 && saved_errno == EINVAL) {
+        if (status == 0x12345678 && cleanup_child(pid, 7)) {
+            note_pass(name);
+        } else {
+            note_fail(name, "EINVAL returned but status changed or child was not waitable");
+        }
+        return;
+    }
+
+    char detail[192];
+    snprintf(detail, sizeof(detail),
+             "wait4(option=0x%x) ret=%ld errno=%d (%s), expected -1/EINVAL",
+             option, (long)ret, saved_errno, strerror(saved_errno));
+    note_fail(name, detail);
+
+    if (ret == 0 || ret == -1) {
+        (void)cleanup_child(pid, 7);
+    }
+}
+
+static void expect_valid_wait4(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail("valid wait4", "fork failed");
+        return;
+    }
+    if (pid == 0) {
+        _exit(9);
+    }
+
+    int status = 0;
+    struct rusage usage;
+    memset(&usage, 0, sizeof(usage));
+    errno = 0;
+    pid_t ret = wait4_raw(pid, &status, 0, &usage);
+    if (ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 9) {
+        note_pass("valid wait4 still reaps exited child");
+    } else {
+        char detail[192];
+        snprintf(detail, sizeof(detail),
+                 "ret=%ld errno=%d (%s) status=0x%x",
+                 (long)ret, errno, strerror(errno), status);
+        note_fail("valid wait4", detail);
+        if (ret != pid) {
+            (void)cleanup_child(pid, 9);
+        }
+    }
+}
+
+int main(void)
+{
+    printf("=== bug-wait4-invalid-options ===\n");
+
+    expect_invalid_option("wait4 rejects waitid-only WEXITED", WEXITED);
+    expect_invalid_option("wait4 rejects waitid-only WNOWAIT", WNOWAIT);
+    expect_invalid_option("wait4 rejects unknown option bit 0x10", 0x10);
+    expect_valid_wait4();
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+    printf("SOME TESTS FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -28,6 +28,7 @@ test_commands = [
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
     "/usr/bin/bug-unlinkat-einval",
+    "/usr/bin/bug-wait4-invalid-options",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",
     "/usr/bin/bug-unaligned-cow-split",


### PR DESCRIPTION
## Summary

- Reject waitid-only and unknown option bits in `wait4` before scanning or reaping children.
- Remove `WNOWAIT` handling from the `wait4` path so invalid options do not consume child status.
- Add a StarryOS QEMU regression case covering `WEXITED`, `WNOWAIT`, unknown bits, and normal child reaping.

## Root Cause

`sys_waitpid` used `WaitOptions::from_bits_truncate`, silently dropping unknown bits. It also accepted waitid-only flags such as `WEXITED` and `WNOWAIT`, which let invalid `wait4` calls succeed and in some cases reap a child instead of returning Linux-compatible `EINVAL`.

## Test plan

- `gcc -Wall -Wextra -Werror -O2 test-suit/starryos/normal/qemu-smp1/bugfix/bug-wait4-invalid-options/c/src/main.c -o /tmp/bug-wait4-invalid-options-linux && /tmp/bug-wait4-invalid-options-linux`
- `git diff --check`
- `cargo fmt --check`
- `PKG_CONFIG_PATH=/tmp/libudev-shim/pkgconfig cargo xtask clippy --package starry-kernel`
- `PKG_CONFIG_PATH=/tmp/libudev-shim/pkgconfig cargo xtask starry test qemu --arch riscv64 --test-group normal --test-case bugfix`
