### PR TITLE
fix(file): validate fchmodat2 flags

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -448,6 +448,11 @@ pub fn sys_fchmod(fd: i32, mode: u32) -> AxResult<isize> {
 }
 
 pub fn sys_fchmodat(dirfd: i32, path: *const c_char, mode: u32, flags: u32) -> AxResult<isize> {
+    const FCHMODAT_VALID_FLAGS: u32 = AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW;
+    if flags & !FCHMODAT_VALID_FLAGS != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
     let path = path.nullable().map(vm_load_string).transpose()?;
     let loc = resolve_at(dirfd, path.as_deref(), flags)?
         .into_file()

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -97,7 +97,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         #[cfg(target_arch = "x86_64")]
         Sysno::chmod => sys_chmod(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::fchmod => sys_fchmod(uctx.arg0() as _, uctx.arg1() as _),
-        Sysno::fchmodat | Sysno::fchmodat2 => sys_fchmodat(
+        Sysno::fchmodat => sys_fchmodat(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _, 0),
+        Sysno::fchmodat2 => sys_fchmodat(
             uctx.arg0() as _,
             uctx.arg1() as _,
             uctx.arg2() as _,

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-fchmodat2-flags/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-fchmodat2-flags/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-fchmodat2-flags C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-fchmodat2-flags src/main.c)
+target_compile_options(bug-fchmodat2-flags PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-fchmodat2-flags RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-fchmodat2-flags/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-fchmodat2-flags/c/src/main.c
@@ -1,0 +1,139 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef __NR_fchmodat2
+#define __NR_fchmodat2 452
+#endif
+
+#ifndef __NR_fchmodat
+#error "__NR_fchmodat is required for this test"
+#endif
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define TEST_START(name) \
+    do { \
+        printf("[TEST] %s\n", (name)); \
+        test_passed = 0; \
+        test_failed = 0; \
+    } while (0)
+
+#define CHECK(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            printf("  [FAIL] %s (errno=%d %s)\n", (msg), errno, strerror(errno)); \
+            test_failed++; \
+        } else { \
+            printf("  [OK] %s\n", (msg)); \
+            test_passed++; \
+        } \
+    } while (0)
+
+#define TEST_DONE() \
+    do { \
+        printf("\n=== result: %d passed, %d failed ===\n", test_passed, test_failed); \
+        if (test_failed == 0) { \
+            printf("TEST PASSED\n"); \
+        } \
+        return (test_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE; \
+    } while (0)
+
+static int raw_fchmodat2(int dirfd, const char *path, mode_t mode, int flags)
+{
+    return (int)syscall(__NR_fchmodat2, dirfd, path, mode, flags);
+}
+
+static int raw_fchmodat_with_extra_arg(int dirfd, const char *path, mode_t mode, unsigned long extra)
+{
+    return (int)syscall(__NR_fchmodat, dirfd, path, mode, extra);
+}
+
+static int create_file_with_mode(const char *path, mode_t mode)
+{
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        return -1;
+    }
+    if (fchmod(fd, mode) != 0) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return -1;
+    }
+    return close(fd);
+}
+
+static int path_mode(const char *path, mode_t *mode)
+{
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        return -1;
+    }
+    *mode = st.st_mode & 07777;
+    return 0;
+}
+
+static int check_mode(const char *path, mode_t expected)
+{
+    mode_t actual = 0;
+    errno = 0;
+    if (path_mode(path, &actual) != 0) {
+        return 0;
+    }
+    if (actual != expected) {
+        errno = 0;
+        printf("    mode mismatch: expected %04o actual %04o\n", expected, actual);
+        return 0;
+    }
+    return 1;
+}
+
+int main(void)
+{
+    const char *path = "/tmp/bug_fchmodat2_flags_file";
+    int fd;
+
+    TEST_START("fchmodat2: reject invalid flags and keep legacy fchmodat flagless");
+
+    unlink(path);
+
+    CHECK(create_file_with_mode(path, 0600) == 0, "create regular file mode 0600");
+
+    errno = 0;
+    CHECK(raw_fchmodat2(AT_FDCWD, path, 0644, 0) == 0,
+          "fchmodat2(flags=0) succeeds");
+    CHECK(check_mode(path, 0644), "fchmodat2(flags=0) changes mode to 0644");
+
+    errno = 0;
+    CHECK(raw_fchmodat2(AT_FDCWD, path, 0600, AT_REMOVEDIR) == -1 && errno == EINVAL,
+          "fchmodat2 rejects AT_REMOVEDIR with EINVAL");
+    CHECK(check_mode(path, 0644), "invalid fchmodat2 flags do not change mode");
+
+    fd = open(path, O_RDONLY);
+    CHECK(fd >= 0, "open file for AT_EMPTY_PATH smoke");
+    if (fd >= 0) {
+        errno = 0;
+        CHECK(raw_fchmodat2(fd, "", 0600, AT_EMPTY_PATH) == 0,
+              "fchmodat2(AT_EMPTY_PATH) changes fd target");
+        close(fd);
+        CHECK(check_mode(path, 0600), "AT_EMPTY_PATH result mode is 0600");
+    }
+
+    errno = 0;
+    CHECK(raw_fchmodat_with_extra_arg(AT_FDCWD, path, 0666, AT_REMOVEDIR) == 0,
+          "legacy fchmodat ignores a fourth raw syscall argument");
+    CHECK(check_mode(path, 0666), "legacy fchmodat changes mode to 0666");
+
+    unlink(path);
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -18,6 +18,7 @@ to_bin = true
 shell_prefix = "root@starry:"
 test_commands = [
     "/usr/bin/bug-futex-wait-wake",
+    "/usr/bin/bug-fchmodat2-flags",
     "/usr/bin/bug-lseek-negative-einval",
     "/usr/bin/bug-mkdir-empty-path",
     "/usr/bin/bug-mmap-fd-zero-anon",


### PR DESCRIPTION
## Summary

- Reject unsupported `fchmodat2` flag bits before path resolution and chmod side effects.
- Keep legacy `fchmodat` dispatch flagless by forcing its fourth argument to `0`.
- Add a StarryOS QEMU regression case covering invalid flags, `AT_EMPTY_PATH`, and legacy `fchmodat` dispatch.

## Root Cause

`sys_fchmodat` did not validate flags, so unsupported bits could be ignored by `resolve_at` and the chmod operation could still modify the target. The syscall dispatcher also grouped `fchmodat` with `fchmodat2`, causing the legacy syscall to incorrectly consume the fourth raw argument as flags.

## Test plan

- `gcc -Wall -Wextra -Werror test-suit/starryos/normal/qemu-smp1/bugfix/bug-fchmodat2-flags/c/src/main.c -o /tmp/bug-fchmodat2-flags-linux && /tmp/bug-fchmodat2-flags-linux`
- `git diff --check`
- `cargo fmt --check`
- `PKG_CONFIG_PATH=/tmp/libudev-pkgconfig cargo xtask clippy --package starry-kernel`
- `PKG_CONFIG_PATH=/tmp/libudev-pkgconfig cargo xtask starry test qemu --arch riscv64 --test-group normal --test-case bugfix`
