### PR TITLE
fix(file): reject zero-size readlinkat buffers

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -355,6 +355,10 @@ pub fn sys_readlinkat(
     buf: *mut u8,
     size: usize,
 ) -> AxResult<isize> {
+    if size == 0 {
+        return Err(AxError::InvalidInput);
+    }
+
     let path = vm_load_string(path)?;
 
     debug!("sys_readlinkat <= dirfd: {dirfd}, path: {path:?}");

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-readlinkat-zero-size/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-readlinkat-zero-size/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-readlinkat-zero-size C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-readlinkat-zero-size src/main.c)
+target_compile_options(bug-readlinkat-zero-size PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-readlinkat-zero-size RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-readlinkat-zero-size/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-readlinkat-zero-size/c/src/main.c
@@ -1,0 +1,85 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void check(int condition, const char *message)
+{
+    if (condition) {
+        ++passed;
+        printf("PASS: %s\n", message);
+    } else {
+        ++failed;
+        printf("FAIL: %s\n", message);
+    }
+}
+
+static ssize_t raw_readlinkat(int dirfd, const char *path, char *buf, size_t bufsiz)
+{
+    errno = 0;
+    return syscall(SYS_readlinkat, dirfd, path, buf, bufsiz);
+}
+
+int main(void)
+{
+    const char *link_path = "/tmp/bug_readlinkat_zero_size_link";
+    const char *file_path = "/tmp/bug_readlinkat_zero_size_file";
+    const char *target = "readlinkat-zero-target";
+    char buf[64];
+
+    unlink(link_path);
+    unlink(file_path);
+
+    int fd = open(file_path, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+    check(fd >= 0, "create regular file fixture");
+    if (fd >= 0) {
+        check(write(fd, "x", 1) == 1, "write regular file fixture");
+        check(close(fd) == 0, "close regular file fixture");
+    }
+
+    check(symlink(target, link_path) == 0, "create symlink fixture");
+
+    memset(buf, 0x5a, sizeof(buf));
+    ssize_t ret = raw_readlinkat(AT_FDCWD, link_path, buf, 0);
+    check(ret == -1 && errno == EINVAL, "readlinkat symlink with size 0 fails EINVAL");
+    check(buf[0] == 0x5a, "size 0 readlinkat leaves destination buffer unchanged");
+
+    ret = raw_readlinkat(AT_FDCWD, link_path, NULL, 0);
+    check(ret == -1 && errno == EINVAL, "readlinkat NULL buffer with size 0 fails EINVAL");
+
+    memset(buf, 0, sizeof(buf));
+    ret = raw_readlinkat(AT_FDCWD, link_path, buf, 4);
+    check(ret == 4, "readlinkat truncates to caller buffer size");
+    check(memcmp(buf, target, 4) == 0, "truncated readlinkat bytes match target prefix");
+
+    memset(buf, 0, sizeof(buf));
+    ret = raw_readlinkat(AT_FDCWD, link_path, buf, sizeof(buf));
+    check(ret == (ssize_t)strlen(target), "readlinkat full-size return is target length");
+    if (ret > 0 && ret < (ssize_t)sizeof(buf)) {
+        buf[ret] = '\0';
+        check(strcmp(buf, target) == 0, "readlinkat full-size bytes match target");
+    } else {
+        check(0, "readlinkat full-size bytes match target");
+    }
+
+    ret = raw_readlinkat(AT_FDCWD, file_path, buf, sizeof(buf));
+    check(ret == -1 && errno == EINVAL, "readlinkat regular file fails EINVAL");
+
+    unlink(link_path);
+    unlink(file_path);
+
+    printf("RESULT: %d passed / %d failed\n", passed, failed);
+    if (failed == 0) {
+        printf("TEST PASSED\n");
+        return 0;
+    }
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -32,6 +32,7 @@ test_commands = [
     "/usr/bin/clone3-badsize",
     "/usr/bin/bug-unaligned-cow-split",
     "/usr/bin/bug-proc-maps-lseek-refresh",
+    "/usr/bin/bug-readlinkat-zero-size",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']


### PR DESCRIPTION
## Summary

- Return `EINVAL` for `readlinkat(..., size = 0)` before path resolution.
- Preserve existing short-buffer, full-buffer, and non-symlink behavior.
- Add a StarryOS QEMU regression case covering zero-size buffers, truncation, successful symlink reads, and regular-file `EINVAL`.

## Root Cause

`sys_readlinkat` computed `min(size, link.len())` and wrote that many bytes. With `size == 0`, this produced a zero-byte write and returned success, while Linux rejects zero-size `readlinkat` buffers with `EINVAL`.

## Test plan

- `gcc -Wall -Wextra -Werror test-suit/starryos/normal/qemu-smp1/bugfix/bug-readlinkat-zero-size/c/src/main.c -o /tmp/bug-readlinkat-zero-size-linux && /tmp/bug-readlinkat-zero-size-linux`
- `git diff --check`
- `cargo fmt --check`
- `PKG_CONFIG_PATH=/tmp/libudev-pkgconfig cargo xtask clippy --package starry-kernel`
- `PKG_CONFIG_PATH=/tmp/libudev-pkgconfig cargo xtask starry test qemu --arch riscv64 --test-group normal --test-case bugfix`
