### PR TITLE
fix(ci): run release publish after dev checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,21 +432,11 @@ jobs:
         && needs.detect_changes.outputs.ci_checks == 'true'
         && needs.fmt.result == 'success'
         && needs.post_fmt_checks.result == 'success'
-        && (
-          needs.publish_base_container.result == 'success'
-          || needs.publish_base_container.result == 'skipped'
-        )
-        && (
-          needs.publish_axvisor_lvz_container.result == 'success'
-          || needs.publish_axvisor_lvz_container.result == 'skipped'
-        )
       }}
     needs:
       - detect_changes
       - fmt
       - post_fmt_checks
-      - publish_base_container
-      - publish_axvisor_lvz_container
     runs-on: ubuntu-latest
     concurrency:
       group: release-plz-release-${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,3 +420,72 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+  release_publish:
+    name: Publish releases
+    if: >-
+      ${{
+        always()
+        && github.repository == 'rcore-os/tgoskits'
+        && github.event_name == 'push'
+        && github.ref_name == 'dev'
+        && needs.detect_changes.outputs.ci_checks == 'true'
+        && needs.fmt.result == 'success'
+        && needs.post_fmt_checks.result == 'success'
+        && (
+          needs.publish_base_container.result == 'success'
+          || needs.publish_base_container.result == 'skipped'
+        )
+        && (
+          needs.publish_axvisor_lvz_container.result == 'success'
+          || needs.publish_axvisor_lvz_container.result == 'skipped'
+        )
+      }}
+    needs:
+      - detect_changes
+      - fmt
+      - post_fmt_checks
+      - publish_base_container
+      - publish_axvisor_lvz_container
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-release-${{ github.ref_name }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Attach checkout to dev branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --prune origin +refs/heads/dev:refs/remotes/origin/dev
+          origin_dev="$(git rev-parse origin/dev)"
+          if [ "${origin_dev}" != "${GITHUB_SHA}" ]; then
+            echo "origin/dev (${origin_dev}) does not match this CI commit (${GITHUB_SHA}); skipping release publish." >&2
+            exit 1
+          fi
+
+          git switch -C dev "${GITHUB_SHA}"
+          git branch --set-upstream-to=origin/dev dev
+          git status --short --branch
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+          config: release-plz.toml
+          token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,13 +1,6 @@
 name: Release-plz
 
 on:
-  workflow_run:
-    workflows:
-      - CI
-    types:
-      - completed
-    branches:
-      - dev
   push:
     branches:
       - main
@@ -51,80 +44,3 @@ jobs:
           config: release-plz.toml
         env:
           GITHUB_TOKEN: ${{ github.token }}
-
-  release-ci-gate:
-    name: Confirm CI checks ran
-    if: >-
-      ${{
-        github.repository_owner == 'rcore-os'
-        && github.event_name == 'workflow_run'
-        && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.event == 'push'
-        && github.event.workflow_run.head_branch == 'dev'
-      }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-    outputs:
-      ready: ${{ steps.check.outputs.ready }}
-    steps:
-      - name: Check CI job results
-        id: check
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const run_id = context.payload.workflow_run.id;
-            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
-              owner,
-              repo,
-              run_id,
-              per_page: 100,
-            });
-
-            const fmtJobs = jobs.filter((job) =>
-              job.name === "Check formatting" || job.name.startsWith("Check formatting /")
-            );
-            const ready = fmtJobs.some((job) => job.conclusion === "success");
-
-            if (!ready) {
-              core.notice("CI finished successfully without running Check formatting; release publishing will be skipped.");
-            }
-
-            core.setOutput("ready", ready ? "true" : "false");
-
-  release-plz-release:
-    name: Publish releases
-    needs: release-ci-gate
-    if: >-
-      ${{
-        needs.release-ci-gate.outputs.ready == 'true'
-      }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: release-plz-release-${{ github.event.workflow_run.head_branch }}
-      cancel-in-progress: false
-    permissions:
-      contents: write
-      pull-requests: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Run release-plz release
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          config: release-plz.toml
-          token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- move `release-plz release` into the CI workflow as a final `dev` push job
- gate release publishing on formatting, follow-up CI checks, and container publish jobs succeeding or being skipped
- keep the separate Release-plz workflow only for `main` release PR creation

## Root Cause

The previous `workflow_run` release path checked out the CI-tested SHA directly, leaving the repository in detached `HEAD`. `release-plz release` then failed when trying to resolve the current branch/upstream.

## Validation

- `python3` YAML parse for `.github/workflows/ci.yml` and `.github/workflows/release-plz.yml`
- `git diff --check`
- structural checks for the release job gates and removed `workflow_run` trigger
