### PR TITLE
chore(repo): bump core crate package versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "ax-kernel-guard"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ax-crate-interface",
  "cfg-if",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "ax-lazyinit"
-version = "0.4.6"
+version = "0.4.7"
 
 [[package]]
 name = "ax-libc"
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "ax-memory-addr"
-version = "0.6.7"
+version = "0.6.8"
 
 [[package]]
 name = "ax-memory-set"
@@ -2406,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3702,13 +3702,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -4983,18 +4982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
-
-[[package]]
 name = "libudev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5710,7 +5697,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -5948,12 +5935,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -6699,15 +6680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7366,9 +7338,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
  "twox-hash",
 ]
@@ -8797,9 +8769,9 @@ checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/components/ax-lazyinit/Cargo.toml
+++ b/components/ax-lazyinit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-lazyinit"
-version = "0.4.6"
+version = "0.4.7"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]

--- a/components/axmm_crates/memory_addr/Cargo.toml
+++ b/components/axmm_crates/memory_addr/Cargo.toml
@@ -3,7 +3,7 @@ name = "ax-memory-addr"
 description = "Wrappers and helper functions for physical and virtual addresses"
 keywords = ["arceos", "address", "virtual-memory"]
 
-version = "0.6.7"
+version = "0.6.8"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>", "aarkegz <aarkegz@gmail.com>"]

--- a/components/kernel_guard/Cargo.toml
+++ b/components/kernel_guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-kernel-guard"
-version = "0.3.8"
+version = "0.3.9"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -51,6 +51,7 @@ ax-lockdep
 ax-kspin
 ax-kernel-guard
 ax-lazyinit
+ax-memory-addr
 ax-memory-set
 axpanic
 ax-plat


### PR DESCRIPTION
## Summary
- bump `ax-lazyinit` to 0.4.7
- bump `ax-memory-addr` to 0.6.8
- bump `ax-kernel-guard` to 0.3.9
- refresh `Cargo.lock` and add `ax-memory-addr` to the clippy package list after its targeted check passed

## Validation
- `cargo fmt --all -- --check`
- `cargo xtask clippy --package ax-lazyinit`
- `cargo xtask clippy --package ax-memory-addr`
- `cargo xtask clippy --package ax-kernel-guard`
