### PR TITLE
fix(rockchip-soc): add RK3588 PCIe clock gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
               - "Cargo.lock"
               - "rust-toolchain.toml"
               - "components/**"
+              - "drivers/**"
               - "examples/**"
               - "os/**"
               - "platform/**"

--- a/drivers/soc/rockchip/rockchip-soc/src/variants/rk3588/cru/clock/mod.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/variants/rk3588/cru/clock/mod.rs
@@ -262,16 +262,70 @@ clk_id_group!(
 );
 
 // =============================================================================
+// PCIe/PHP 时钟 ID
+// =============================================================================
+
+clk_id_group!(
+    ACLK_PHP_GIC_ITS = 326,
+    ACLK_MMU_PCIE = 327,
+    ACLK_MMU_PHP = 328,
+    ACLK_PCIE_4L_DBI = 329,
+    ACLK_PCIE_2L_DBI = 330,
+    ACLK_PCIE_1L0_DBI = 331,
+    ACLK_PCIE_1L1_DBI = 332,
+    ACLK_PCIE_1L2_DBI = 333,
+    ACLK_PCIE_4L_MSTR = 334,
+    ACLK_PCIE_2L_MSTR = 335,
+    ACLK_PCIE_1L0_MSTR = 336,
+    ACLK_PCIE_1L1_MSTR = 337,
+    ACLK_PCIE_1L2_MSTR = 338,
+    ACLK_PCIE_4L_SLV = 339,
+    ACLK_PCIE_2L_SLV = 340,
+    ACLK_PCIE_1L0_SLV = 341,
+    ACLK_PCIE_1L1_SLV = 342,
+    ACLK_PCIE_1L2_SLV = 343,
+    PCLK_PCIE_4L = 344,
+    PCLK_PCIE_2L = 345,
+    PCLK_PCIE_1L0 = 347,
+    PCLK_PCIE_1L1 = 348,
+    PCLK_PCIE_1L2 = 349,
+    CLK_PCIE_AUX0 = 350,
+    CLK_PCIE_AUX1 = 351,
+    CLK_PCIE_AUX2 = 352,
+    CLK_PCIE_AUX3 = 353,
+    CLK_PCIE_AUX4 = 354,
+    CLK_PIPEPHY0_REF = 355,
+    CLK_PIPEPHY1_REF = 356,
+    CLK_PIPEPHY2_REF = 357,
+    PCLK_PHP_ROOT = 358,
+    ACLK_PCIE_ROOT = 361,
+    ACLK_PHP_ROOT = 362,
+    ACLK_PCIE_BRIDGE = 363,
+);
+
+// =============================================================================
 // USB 时钟 ID
 // =============================================================================
 
 clk_id_group!(
-    PCLK_PHP_USBHOST3_0 = 358,
     ACLK_USB3OTG2 = 375,
     SUSPEND_CLK_USB3OTG2 = 376,
     REF_CLK_USB3OTG2 = 377,
     CLK_UTMI_OTG2 = 378,
-    CLK_PIPE_USBHOST3_0 = 385,
+    CLK_PIPEPHY0_PIPE_G = 379,
+    CLK_PIPEPHY1_PIPE_G = 380,
+    CLK_PIPEPHY2_PIPE_G = 381,
+    CLK_PIPEPHY0_PIPE_ASIC_G = 382,
+    CLK_PIPEPHY1_PIPE_ASIC_G = 383,
+    CLK_PIPEPHY2_PIPE_ASIC_G = 384,
+    CLK_PIPEPHY2_PIPE_U3_G = 385,
+    CLK_PCIE1L2_PIPE = 386,
+    CLK_PCIE4L_PIPE = 387,
+    CLK_PCIE2L_PIPE = 388,
+    PCLK_PCIE_COMBO_PIPE_PHY0 = 389,
+    PCLK_PCIE_COMBO_PIPE_PHY1 = 390,
+    PCLK_PCIE_COMBO_PIPE_PHY2 = 391,
+    PCLK_PCIE_COMBO_PIPE_PHY = 392,
 );
 
 clk_id_group!(
@@ -302,7 +356,10 @@ clk_id_group!(
 
 clk_id_group!(CLK_USBPHY_480M = 693,);
 clk_id_group!(USBDPPHY_MIPIDCPPHY_REF = 694,);
+clk_id_group!(CLK_PCIE1L0_PIPE = 708, CLK_PCIE1L1_PIPE = 709,);
 
+pub const PCLK_PHP_USBHOST3_0: ClkId = PCLK_PHP_ROOT;
+pub const CLK_PIPE_USBHOST3_0: ClkId = CLK_PIPEPHY2_PIPE_U3_G;
 pub const CLK_REF_USB3OTG0: ClkId = REF_CLK_USB3OTG0;
 pub const CLK_SUSPEND_USB3OTG0: ClkId = SUSPEND_CLK_USB3OTG0;
 pub const CLK_REF_USB3OTG1: ClkId = REF_CLK_USB3OTG1;

--- a/drivers/soc/rockchip/rockchip-soc/src/variants/rk3588/cru/gate.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/variants/rk3588/cru/gate.rs
@@ -19,13 +19,21 @@ pub enum ClkType {
     Composite,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateBank {
+    Main,
+    Pmu,
+    Php,
+}
+
 /// 时钟门控配置
 #[derive(Debug, Clone, Copy)]
 pub struct ClkGate {
     /// 时钟 ID
     pub clk_id: ClkId,
     pub kind: ClkType,
-    /// 寄存器索引 (0-31 用于 clkgate_con, 32+ 用于 pmu_clkgate_con)
+    pub bank: GateBank,
+    /// 寄存器索引，在 `bank` 指定的 CRU gate 寄存器组内编号。
     pub reg_idx: u32,
     /// 位偏移 (0-15)
     pub bit: u32,
@@ -52,6 +60,7 @@ macro_rules! clk_gate_table {
                 ClkGate {
                     clk_id: $clk_id,
                     kind: ClkType::Gate,
+                    bank: GateBank::Main,
                     reg_idx: $reg_idx,
                     bit: $bit,
                 }
@@ -68,6 +77,41 @@ macro_rules! clk_composite_table {
                 ClkGate {
                     clk_id: $clk_id,
                     kind: ClkType::Composite,
+                    bank: GateBank::Main,
+                    reg_idx: $reg_idx,
+                    bit: $bit,
+                }
+                ),*
+        ];
+    };
+}
+
+macro_rules! clk_pmu_gate_table {
+    ($($clk_id:expr => ($reg_idx:expr, $bit:expr)),* $(,)?) => {
+        #[allow(non_upper_case_globals)]
+        const CLK_PMU_GATE_TABLE: &[ClkGate] = &[
+            $(
+                ClkGate {
+                    clk_id: $clk_id,
+                    kind: ClkType::Gate,
+                    bank: GateBank::Pmu,
+                    reg_idx: $reg_idx,
+                    bit: $bit,
+                }
+                ),*
+        ];
+    };
+}
+
+macro_rules! clk_php_gate_table {
+    ($($clk_id:expr => ($reg_idx:expr, $bit:expr)),* $(,)?) => {
+        #[allow(non_upper_case_globals)]
+        const CLK_PHP_GATE_TABLE: &[ClkGate] = &[
+            $(
+                ClkGate {
+                    clk_id: $clk_id,
+                    kind: ClkType::Gate,
+                    bank: GateBank::Php,
                     reg_idx: $reg_idx,
                     bit: $bit,
                 }
@@ -100,9 +144,6 @@ clk_gate_table!(
     CLK_I2C7 => (11, 6),
     PCLK_I2C8 => (10, 15),
     CLK_I2C8 => (11, 7),
-    // I2C0 (PMU)
-    PCLK_I2C0 => (0x32 + 2, 1),
-    CLK_I2C0 => (0x32 + 2, 2),
     // ========================================================================
     // SPI 时钟门控
     // ========================================================================
@@ -137,9 +178,6 @@ clk_gate_table!(
     SCLK_UART8 => (14, 2),
     PCLK_UART9 => (12, 10),
     SCLK_UART9 => (14, 5),
-    // UART0 (PMU)
-    PCLK_UART0 => (0x32 + 2, 6),
-    SCLK_UART0 => (0x32 + 2, 5),
     // ========================================================================
     // PWM 时钟门控
     // ========================================================================
@@ -152,10 +190,6 @@ clk_gate_table!(
     PCLK_PWM3 => (15, 1),
     CLK_PWM3 => (15, 4),
     CLK_PWM3_CAPTURE => (15, 9),
-    // PMU PWM
-    PCLK_PMU1PWM => (0x32 + 2, 8),
-    CLK_PMU1PWM => (0x32 + 2, 11),
-    CLK_PMU1PWM_CAPTURE => (0x32 + 2, 12),
     // ========================================================================
     // ADC 时钟门控
     // ========================================================================
@@ -189,14 +223,62 @@ clk_gate_table!(
     ACLK_NPU0 => (30, 6),
     HCLK_NPU0 => (30, 8),
     // ========================================================================
+    // PCIe/PHP 时钟门控
+    // ========================================================================
+    ACLK_PCIE_ROOT => (32, 6),
+    ACLK_PHP_ROOT => (32, 7),
+    ACLK_PCIE_BRIDGE => (32, 8),
+    ACLK_PHP_GIC_ITS => (34, 6),
+    ACLK_MMU_PCIE => (34, 7),
+    ACLK_MMU_PHP => (34, 8),
+    ACLK_PCIE_4L_DBI => (32, 13),
+    ACLK_PCIE_2L_DBI => (32, 14),
+    ACLK_PCIE_1L0_DBI => (32, 15),
+    ACLK_PCIE_1L1_DBI => (33, 0),
+    ACLK_PCIE_1L2_DBI => (33, 1),
+    ACLK_PCIE_4L_MSTR => (33, 2),
+    ACLK_PCIE_2L_MSTR => (33, 3),
+    ACLK_PCIE_1L0_MSTR => (33, 4),
+    ACLK_PCIE_1L1_MSTR => (33, 5),
+    ACLK_PCIE_1L2_MSTR => (33, 6),
+    ACLK_PCIE_4L_SLV => (33, 7),
+    ACLK_PCIE_2L_SLV => (33, 8),
+    ACLK_PCIE_1L0_SLV => (33, 9),
+    ACLK_PCIE_1L1_SLV => (33, 10),
+    ACLK_PCIE_1L2_SLV => (33, 11),
+    PCLK_PCIE_4L => (33, 12),
+    PCLK_PCIE_2L => (33, 13),
+    PCLK_PCIE_1L0 => (33, 14),
+    PCLK_PCIE_1L1 => (33, 15),
+    PCLK_PCIE_1L2 => (34, 0),
+    CLK_PCIE_AUX0 => (34, 1),
+    CLK_PCIE_AUX1 => (34, 2),
+    CLK_PCIE_AUX2 => (34, 3),
+    CLK_PCIE_AUX3 => (34, 4),
+    CLK_PCIE_AUX4 => (34, 5),
+    CLK_PIPEPHY0_REF => (37, 0),
+    CLK_PIPEPHY1_REF => (37, 1),
+    CLK_PIPEPHY2_REF => (37, 2),
+    PCLK_PHP_ROOT => (32, 0),
+    CLK_PCIE4L_PIPE => (39, 0),
+    CLK_PCIE2L_PIPE => (39, 1),
+    CLK_PIPEPHY0_PIPE_G => (38, 3),
+    CLK_PIPEPHY1_PIPE_G => (38, 4),
+    CLK_PIPEPHY2_PIPE_G => (38, 5),
+    CLK_PIPEPHY0_PIPE_ASIC_G => (38, 6),
+    CLK_PIPEPHY1_PIPE_ASIC_G => (38, 7),
+    CLK_PIPEPHY2_PIPE_ASIC_G => (38, 8),
+    CLK_PIPEPHY2_PIPE_U3_G => (38, 9),
+    CLK_PCIE1L2_PIPE => (38, 13),
+    CLK_PCIE1L0_PIPE => (38, 14),
+    CLK_PCIE1L1_PIPE => (38, 15),
+    // ========================================================================
     // USB 时钟门控
     // ========================================================================
     // USB3 OTG2
     ACLK_USB3OTG2 => (35, 7),
     SUSPEND_CLK_USB3OTG2 => (35, 8),
     REF_CLK_USB3OTG2 => (35, 9),
-    CLK_PIPE_USBHOST3_0 => (38, 9),
-    PCLK_PHP_USBHOST3_0 => (32, 0),
     // USB 根时钟
     ACLK_USB_ROOT => (42, 0),
     HCLK_USB_ROOT => (42, 1),
@@ -223,6 +305,26 @@ clk_gate_table!(
 
 );
 
+clk_pmu_gate_table!(
+    // I2C0 (PMU)
+    PCLK_I2C0 => (2, 1),
+    CLK_I2C0 => (2, 2),
+    // UART0 (PMU)
+    PCLK_UART0 => (2, 6),
+    SCLK_UART0 => (2, 5),
+    // PMU PWM
+    PCLK_PMU1PWM => (2, 8),
+    CLK_PMU1PWM => (2, 11),
+    CLK_PMU1PWM_CAPTURE => (2, 12),
+);
+
+clk_php_gate_table!(
+    PCLK_PCIE_COMBO_PIPE_PHY0 => (0, 5),
+    PCLK_PCIE_COMBO_PIPE_PHY1 => (0, 6),
+    PCLK_PCIE_COMBO_PIPE_PHY2 => (0, 7),
+    PCLK_PCIE_COMBO_PIPE_PHY => (0, 8),
+);
+
 clk_composite_table!(
     USBDPPHY_MIPIDCPPHY_REF => (4, 3),
 );
@@ -234,29 +336,21 @@ clk_composite_table!(
 impl Cru {
     /// 查找时钟门控配置
     pub fn find_clk_gate(&self, id: ClkId) -> Option<ClkGate> {
-        if let Some(res) = CLK_GATE_TABLE
+        CLK_GATE_TABLE
             .iter()
-            .find(|gate| gate.clk_id == id)
-            .copied()
-        {
-            return Some(res);
-        }
-
-        CLK_COMPOSITE_TABLE
-            .iter()
+            .chain(CLK_PMU_GATE_TABLE)
+            .chain(CLK_PHP_GATE_TABLE)
+            .chain(CLK_COMPOSITE_TABLE)
             .find(|gate| gate.clk_id == id)
             .copied()
     }
 
     /// 获取时钟门控寄存器地址
     pub fn get_gate_reg_offset(&self, gate: ClkGate) -> u32 {
-        if gate.reg_idx >= 0x32 {
-            // PMU CRU: pmu_clkgate_con
-            let idx = gate.reg_idx - 0x32;
-            pmu_clkgate_con(idx)
-        } else {
-            // 主 CRU: clkgate_con
-            clkgate_con(gate.reg_idx)
+        match gate.bank {
+            GateBank::Main => clkgate_con(gate.reg_idx),
+            GateBank::Pmu => pmu_clkgate_con(gate.reg_idx),
+            GateBank::Php => php_clkgate_con(gate.reg_idx),
         }
     }
 }
@@ -268,6 +362,16 @@ impl Cru {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn find_gate(clk_id: ClkId) -> ClkGate {
+        CLK_GATE_TABLE
+            .iter()
+            .chain(CLK_PMU_GATE_TABLE)
+            .chain(CLK_PHP_GATE_TABLE)
+            .find(|gate| gate.clk_id == clk_id)
+            .copied()
+            .expect("gate not found")
+    }
 
     #[test]
     fn test_clk_gate_table_size() {
@@ -284,9 +388,13 @@ mod tests {
         // PWM: 12 (PWM1-3: 9, PMU1PWM: 3)
         // ADC: 4
         // NPU: 22
-        // USB: 23
-        // 总计: 109
-        assert_eq!(CLK_GATE_TABLE.len(), 109);
+        // PCIe/PHP: 51
+        // USB: 21
+        // 总计: 158
+        assert_eq!(
+            CLK_GATE_TABLE.len() + CLK_PMU_GATE_TABLE.len() + CLK_PHP_GATE_TABLE.len(),
+            158
+        );
     }
 
     #[test]
@@ -294,6 +402,8 @@ mod tests {
         // 检查是否有重复的 clkid
         let mut clk_ids = CLK_GATE_TABLE
             .iter()
+            .chain(CLK_PMU_GATE_TABLE)
+            .chain(CLK_PHP_GATE_TABLE)
             .map(|gate| gate.clk_id.value())
             .collect::<Vec<_>>();
 
@@ -302,7 +412,7 @@ mod tests {
 
         assert_eq!(
             clk_ids.len(),
-            CLK_GATE_TABLE.len(),
+            CLK_GATE_TABLE.len() + CLK_PMU_GATE_TABLE.len() + CLK_PHP_GATE_TABLE.len(),
             "CLK_GATE_TABLE should not have duplicate clkid entries"
         );
     }
@@ -310,43 +420,30 @@ mod tests {
     #[test]
     fn test_i2c_gates() {
         // 验证 I2C gate 配置
-        let pclk_i2c1 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == PCLK_I2C1)
-            .expect("PCLK_I2C1 not found");
+        let pclk_i2c1 = find_gate(PCLK_I2C1);
+        assert_eq!(pclk_i2c1.bank, GateBank::Main);
         assert_eq!(pclk_i2c1.reg_idx, 10);
         assert_eq!(pclk_i2c1.bit, 8);
 
-        let clk_i2c1 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == CLK_I2C1)
-            .expect("CLK_I2C1 not found");
+        let clk_i2c1 = find_gate(CLK_I2C1);
         assert_eq!(clk_i2c1.reg_idx, 11);
         assert_eq!(clk_i2c1.bit, 0);
 
         // PMU I2C0
-        let pclk_i2c0 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == PCLK_I2C0)
-            .expect("PCLK_I2C0 not found");
-        assert_eq!(pclk_i2c0.reg_idx, 0x32 + 2);
+        let pclk_i2c0 = find_gate(PCLK_I2C0);
+        assert_eq!(pclk_i2c0.bank, GateBank::Pmu);
+        assert_eq!(pclk_i2c0.reg_idx, 2);
         assert_eq!(pclk_i2c0.bit, 1);
     }
 
     #[test]
     fn test_spi_gates() {
         // 验证 SPI gate 配置
-        let pclk_spi0 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == PCLK_SPI0)
-            .expect("PCLK_SPI0 not found");
+        let pclk_spi0 = find_gate(PCLK_SPI0);
         assert_eq!(pclk_spi0.reg_idx, 14);
         assert_eq!(pclk_spi0.bit, 6);
 
-        let clk_spi0 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == CLK_SPI0)
-            .expect("CLK_SPI0 not found");
+        let clk_spi0 = find_gate(CLK_SPI0);
         assert_eq!(clk_spi0.reg_idx, 14);
         assert_eq!(clk_spi0.bit, 11);
     }
@@ -354,43 +451,29 @@ mod tests {
     #[test]
     fn test_uart_gates() {
         // 验证 UART gate 配置
-        let pclk_uart1 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == PCLK_UART1)
-            .expect("PCLK_UART1 not found");
+        let pclk_uart1 = find_gate(PCLK_UART1);
         assert_eq!(pclk_uart1.reg_idx, 12);
         assert_eq!(pclk_uart1.bit, 2);
 
-        let sclk_uart1 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == SCLK_UART1)
-            .expect("SCLK_UART1 not found");
+        let sclk_uart1 = find_gate(SCLK_UART1);
         assert_eq!(sclk_uart1.reg_idx, 12);
         assert_eq!(sclk_uart1.bit, 13);
 
         // PMU UART0
-        let pclk_uart0 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == PCLK_UART0)
-            .expect("PCLK_UART0 not found");
-        assert_eq!(pclk_uart0.reg_idx, 0x32 + 2);
+        let pclk_uart0 = find_gate(PCLK_UART0);
+        assert_eq!(pclk_uart0.bank, GateBank::Pmu);
+        assert_eq!(pclk_uart0.reg_idx, 2);
         assert_eq!(pclk_uart0.bit, 6);
     }
 
     #[test]
     fn test_pwm_gates() {
         // 验证 PWM gate 配置
-        let pclk_pwm1 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == PCLK_PWM1)
-            .expect("PCLK_PWM1 not found");
+        let pclk_pwm1 = find_gate(PCLK_PWM1);
         assert_eq!(pclk_pwm1.reg_idx, 15);
         assert_eq!(pclk_pwm1.bit, 0);
 
-        let clk_pwm1 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == CLK_PWM1)
-            .expect("CLK_PWM1 not found");
+        let clk_pwm1 = find_gate(CLK_PWM1);
         assert_eq!(clk_pwm1.reg_idx, 15);
         assert_eq!(clk_pwm1.bit, 3);
     }
@@ -398,17 +481,11 @@ mod tests {
     #[test]
     fn test_adc_gates() {
         // 验证 ADC gate 配置
-        let pclk_saradc = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == PCLK_SARADC)
-            .expect("PCLK_SARADC not found");
+        let pclk_saradc = find_gate(PCLK_SARADC);
         assert_eq!(pclk_saradc.reg_idx, 15);
         assert_eq!(pclk_saradc.bit, 11);
 
-        let clk_saradc = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == CLK_SARADC)
-            .expect("CLK_SARADC not found");
+        let clk_saradc = find_gate(CLK_SARADC);
         assert_eq!(clk_saradc.reg_idx, 15);
         assert_eq!(clk_saradc.bit, 12);
     }
@@ -416,18 +493,56 @@ mod tests {
     #[test]
     fn test_usb_gates() {
         // 验证 USB gate 配置
-        let aclk_usb_root = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == ACLK_USB_ROOT)
-            .expect("ACLK_USB_ROOT not found");
+        let aclk_usb_root = find_gate(ACLK_USB_ROOT);
         assert_eq!(aclk_usb_root.reg_idx, 42);
         assert_eq!(aclk_usb_root.bit, 0);
 
-        let aclk_usb3otg0 = CLK_GATE_TABLE
-            .iter()
-            .find(|gate| gate.clk_id == ACLK_USB3OTG0)
-            .expect("ACLK_USB3OTG0 not found");
+        let aclk_usb3otg0 = find_gate(ACLK_USB3OTG0);
         assert_eq!(aclk_usb3otg0.reg_idx, 42);
         assert_eq!(aclk_usb3otg0.bit, 4);
+    }
+
+    #[test]
+    fn test_pcie_gates_match_orangepi_6_1() {
+        let aclk_mst_1l1 = find_gate(ACLK_PCIE_1L1_MSTR);
+        assert_eq!(aclk_mst_1l1.bank, GateBank::Main);
+        assert_eq!(aclk_mst_1l1.reg_idx, 33);
+        assert_eq!(aclk_mst_1l1.bit, 5);
+
+        let aclk_slv_1l1 = find_gate(ACLK_PCIE_1L1_SLV);
+        assert_eq!(aclk_slv_1l1.reg_idx, 33);
+        assert_eq!(aclk_slv_1l1.bit, 10);
+
+        let aclk_dbi_1l1 = find_gate(ACLK_PCIE_1L1_DBI);
+        assert_eq!(aclk_dbi_1l1.reg_idx, 33);
+        assert_eq!(aclk_dbi_1l1.bit, 0);
+
+        let pclk_1l1 = find_gate(PCLK_PCIE_1L1);
+        assert_eq!(pclk_1l1.reg_idx, 33);
+        assert_eq!(pclk_1l1.bit, 15);
+
+        let aux_1l1 = find_gate(CLK_PCIE_AUX3);
+        assert_eq!(aux_1l1.reg_idx, 34);
+        assert_eq!(aux_1l1.bit, 4);
+
+        let pipe_1l1 = find_gate(CLK_PCIE1L1_PIPE);
+        assert_eq!(pipe_1l1.reg_idx, 38);
+        assert_eq!(pipe_1l1.bit, 15);
+
+        let aclk_mst_1l2 = find_gate(ACLK_PCIE_1L2_MSTR);
+        assert_eq!(aclk_mst_1l2.reg_idx, 33);
+        assert_eq!(aclk_mst_1l2.bit, 6);
+
+        let pipe_1l2 = find_gate(CLK_PCIE1L2_PIPE);
+        assert_eq!(pipe_1l2.reg_idx, 38);
+        assert_eq!(pipe_1l2.bit, 13);
+    }
+
+    #[test]
+    fn test_php_gates() {
+        let combo_phy0 = find_gate(PCLK_PCIE_COMBO_PIPE_PHY0);
+        assert_eq!(combo_phy0.bank, GateBank::Php);
+        assert_eq!(combo_phy0.reg_idx, 0);
+        assert_eq!(combo_phy0.bit, 5);
     }
 }


### PR DESCRIPTION
## Summary

- add RK3588 PCIe/PHP/PIPE clock IDs according to the OrangePi 6.1 RK35xx kernel bindings
- add main/PMU/PHP CRU gate-bank handling and PCIe/PHP gate mappings
- cover the OrangePi 5 Plus PCIe clock mappings used by the board DTB with unit tests
- include `drivers/**` in the CI path filter so driver-only PRs run the normal checks

## Root Cause

OrangePi 5 Plus uses the clock IDs from the OrangePi 6.1 RK35xx kernel tree. The RK3588 CRU table only covered part of the required clock IDs/gates, so enabling PCIe clocks such as aclk_mst failed during board boot. That prevented PCIe enumeration from reaching the RTL8125 endpoint, which left StarryOS without eth0 in board network tests.

The CI workflow also missed repository-root `drivers/**` in its path filter, so a driver-only PR incorrectly skipped fmt and follow-up CI checks.

## Validation

- cargo fmt
- cargo test -p rockchip-soc --lib
- cargo xtask clippy --package rockchip-soc
- cargo xtask clippy --package axplat-dyn
- cargo xtask starry test board --board orangepi-5-plus --test-case pcie-enumerate
- cargo xtask starry test board --board orangepi-5-plus --test-case net-smoke
- cargo xtask starry example board -t orangepi-5-plus-uvc
- git diff --check

Note: cargo test -p rockchip-soc still fails in existing integration-test setup because bare_test and num_align are unavailable; the crate lib tests pass.
