### PR TITLE
fix: add procfs stats required by busybox iostat

### DIFF
--- a/os/StarryOS/docs/bug-fixes.md
+++ b/os/StarryOS/docs/bug-fixes.md
@@ -75,3 +75,108 @@ cargo test -p starry-kernel per_thread_signal_check_block_is_isolated -- --nocap
   `kernel/src/mm/io.rs`
   `kernel/src/task/ops.rs`
   `kernel/src/syscall/signal.rs`
+
+## Bug 4：`/proc/stat` 缺失导致 `busybox iostat` 无法工作
+
+- 类型：语义、正确性、兼容性
+- 关联用户态程序：
+  `busybox iostat`
+- 修复前相关代码：
+  `kernel/src/pseudofs/proc.rs`
+- 修复后相关代码：
+  `kernel/src/pseudofs/proc.rs`
+  `test-suit/starryos/normal/qemu-smp1/busybox-iostat`
+
+### 问题现象
+
+在 StarryOS 中执行 `busybox iostat 1 1` 时，程序不会输出 CPU/磁盘统计信息，而是直接报错退出：
+
+`iostat: can't open '/proc/stat': No such file or directory`
+
+这说明用户态工具已经正常启动，但在读取 Linux 兼容接口时立刻失败。进一步检查还可以发现，StarryOS 的 `/proc` 根目录虽然已经实现了 `meminfo`、`mounts`、`interrupts` 等节点，但仍然缺少 `iostat` 依赖的几个基础统计文件：
+
+- `/proc/stat`
+- `/proc/diskstats`
+- `/proc/uptime`
+
+由于这些节点不存在，`busybox iostat` 在最开始读取 CPU 统计信息时就直接退出，后续逻辑完全没有机会继续执行。
+
+### 为什么这是 bug
+
+- `busybox iostat` 是典型的 Linux 用户态系统观测工具，它不是依赖某个私有驱动接口，而是依赖标准 procfs 统计节点。
+- StarryOS 已经提供了 `/proc` 文件系统，并且目标就是模拟 Linux 兼容环境；在这种前提下，缺失 `iostat` 所依赖的核心节点会导致兼容性断裂。
+- 这不是“功能还没做”的抽象缺口，而是一个可以被稳定复现的用户态失败：命令启动后立刻因为缺文件报错。
+- 即使当前系统里没有完整的磁盘吞吐统计数据，也至少应该提供最基本、可读取、格式正确的 procfs 节点，让标准工具能够运行并输出合理的结果，而不是直接失败。
+
+### 修复方式
+
+本次修复没有去扩展复杂的块设备统计逻辑，而是采用“最小兼容补全”的方式，先把 `busybox iostat` 真正依赖的 procfs 接口补上：
+
+- 在 `kernel/src/pseudofs/proc.rs` 中新增 `/proc/stat`：
+  - 提供总 CPU 行 `cpu ...`
+  - 提供每个逻辑 CPU 的 `cpuN ...` 行
+  - 补充 `intr`、`ctxt`、`btime`、`processes`、`procs_running`、`procs_blocked`、`softirq` 等基础字段
+- 新增 `/proc/uptime`：
+  - 基于系统单调时钟 `monotonic_time_nanos()` 动态生成运行时间
+  - 以 Linux 常见的“秒.百分秒”格式输出
+- 新增 `/proc/diskstats`：
+  - 当前先提供一个可打开、可读取的空统计文件
+  - 这样 `iostat` 不会因为节点缺失而中止，后续即使没有设备统计，也可以先完成 CPU 部分输出
+- 新增若干单元测试，验证：
+  - `/proc/stat` 的 CPU 行格式正确
+  - `/proc/uptime` 的时间格式正确
+  - `/proc/diskstats` 至少稳定存在
+  - CPU 空闲 tick 计算遵循 Linux 常见的 `USER_HZ=100`
+
+这个修复策略的核心不是伪造复杂数据，而是先补齐 Linux 用户态真正依赖的接口边界，让标准工具从“直接失败”变成“能够正常工作并输出可解析结果”。
+
+### Docker 验证
+
+验证使用 `starryos-dev:ubuntu-qemu10.2.1` 镜像完成。
+
+#### 1. 修复前，bug 确实存在
+
+在修复前的临时 probe case 中，QEMU 内执行 `busybox iostat 1 1` 的实际输出为：
+
+`iostat: can't open '/proc/stat': No such file or directory`
+
+这一步用来证明：问题不是测例写错，也不是 `busybox` 自身不可用，而是 StarryOS 的 procfs 缺少必要节点，导致 `iostat` 无法运行。
+
+#### 2. 修复后，专用回归测例通过
+
+新增测例：
+
+- `test-suit/starryos/normal/qemu-smp1/busybox-iostat/qemu-x86_64.toml`
+- `test-suit/starryos/normal/qemu-smp1/busybox-iostat/sh/busybox-iostat.sh`
+
+验证命令：
+
+```bash
+docker run --rm -v "$PWD":/workspace -w /workspace \
+  starryos-dev:ubuntu-qemu10.2.1 \
+  bash -lc '
+    set -e
+    export RUSTUP_TOOLCHAIN=nightly-2026-04-27
+    cargo xtask starry test qemu --target x86_64-unknown-none -c busybox-iostat
+  '
+```
+
+修复后的 QEMU 关键输出：
+
+```text
+Linux 10.0.0 (starry)  05/09/26  _x86_64_  (1 CPU)
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           0.00    0.00    0.00    0.00    0.00  100.00
+
+Device:            tps   Blk_read/s   Blk_wrtn/s   Blk_read   Blk_wrtn
+TEST PASSED
+```
+
+这说明修复后 `busybox iostat` 已经可以正常读取 procfs 并完成输出，不再因为缺少 `/proc/stat` 而直接失败。
+
+### 附加检查
+
+- 已运行 `cargo fmt --manifest-path Cargo.toml --all`
+- 已在 docker 中运行 `cargo check -p starry-kernel --all-targets`，通过
+- 已在 docker 中运行 `cargo xtask clippy --package starry-kernel`，7 个检查全部通过

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -14,7 +14,7 @@ use core::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use ax_hal::paging::MappingFlags;
+use ax_hal::{paging::MappingFlags, time::monotonic_time_nanos};
 use ax_task::{AxCpuMask, AxTaskRef, WeakAxTaskRef, current};
 use axfs_ng_vfs::{DeviceId, Filesystem, NodeType, VfsError, VfsResult};
 use indoc::indoc;
@@ -89,6 +89,8 @@ const DUMMY_MEMINFO: &str = indoc! {"
     DirectMap2M:    31492096 kB
     DirectMap1G:     1048576 kB
 "};
+
+const USER_HZ: u64 = 100;
 
 pub fn new_procfs() -> Filesystem {
     SimpleFs::new_with("proc".into(), 0x9fa0, builder)
@@ -247,6 +249,49 @@ where
     }
 
     cpu_presence
+}
+
+fn nanos_to_clock_ticks(nanos: u64) -> u64 {
+    nanos.saturating_mul(USER_HZ) / 1_000_000_000
+}
+
+fn render_proc_stat() -> String {
+    render_proc_stat_with_uptime(monotonic_time_nanos() as u64, ax_hal::cpu_num())
+}
+
+fn render_proc_stat_with_uptime(uptime_nanos: u64, cpu_num: usize) -> String {
+    let idle_ticks = nanos_to_clock_ticks(uptime_nanos);
+    let mut output = format!("cpu  0 0 0 {idle_ticks} 0 0 0 0 0 0\n");
+
+    for cpu in 0..cpu_num {
+        let _ = writeln!(output, "cpu{cpu} 0 0 0 {idle_ticks} 0 0 0 0 0 0");
+    }
+
+    output.push_str("intr 0\n");
+    output.push_str("ctxt 0\n");
+    output.push_str("btime 0\n");
+    output.push_str("processes 0\n");
+    output.push_str("procs_running 1\n");
+    output.push_str("procs_blocked 0\n");
+    output.push_str("softirq 0 0 0 0 0 0 0 0 0 0 0\n");
+    output
+}
+
+fn render_proc_diskstats() -> &'static str {
+    ""
+}
+
+fn render_proc_uptime() -> String {
+    render_proc_uptime_from_nanos(monotonic_time_nanos() as u64, ax_hal::cpu_num())
+}
+
+fn render_proc_uptime_from_nanos(uptime_nanos: u64, cpu_num: usize) -> String {
+    let secs = uptime_nanos / 1_000_000_000;
+    let centis = (uptime_nanos % 1_000_000_000) / 10_000_000;
+    let idle_nanos = uptime_nanos.saturating_mul(cpu_num as u64);
+    let idle_secs = idle_nanos / 1_000_000_000;
+    let idle_centis = (idle_nanos % 1_000_000_000) / 10_000_000;
+    format!("{secs}.{centis:02} {idle_secs}.{idle_centis:02}\n")
 }
 
 /// The /proc/[pid]/fd directory
@@ -543,6 +588,18 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         }),
     );
     root.add(
+        "stat",
+        SimpleFile::new_regular(fs.clone(), || Ok(render_proc_stat())),
+    );
+    root.add(
+        "diskstats",
+        SimpleFile::new_regular(fs.clone(), || Ok(render_proc_diskstats())),
+    );
+    root.add(
+        "uptime",
+        SimpleFile::new_regular(fs.clone(), || Ok(render_proc_uptime())),
+    );
+    root.add(
         "instret",
         SimpleFile::new_regular(fs.clone(), || {
             #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
@@ -645,7 +702,8 @@ mod tests {
 
     use super::{
         collect_cpu_presence, format_cpu_presence_hex, format_cpu_presence_list,
-        render_task_status_fields,
+        nanos_to_clock_ticks, render_proc_diskstats, render_proc_stat_with_uptime,
+        render_proc_uptime_from_nanos, render_task_status_fields,
     };
     use crate::task::Cred;
 
@@ -704,5 +762,35 @@ mod tests {
         assert!(status.contains("Pid:\t84\n"));
         assert!(status.contains("Cpus_allowed:\t0000000a\n"));
         assert!(status.contains("Cpus_allowed_list:\t1,3\n"));
+    }
+
+    #[test]
+    fn proc_stat_reports_cpu_totals_and_core_lines() {
+        let stat = render_proc_stat_with_uptime(2_500_000_000, 2);
+
+        assert!(stat.starts_with("cpu  0 0 0 250 0 0 0 0 0 0\n"));
+        assert!(stat.contains("cpu0 0 0 0 250 0 0 0 0 0 0\n"));
+        assert!(stat.contains("cpu1 0 0 0 250 0 0 0 0 0 0\n"));
+        assert!(stat.contains("procs_running 1\n"));
+        assert!(stat.contains("softirq 0 0 0 0 0 0 0 0 0 0 0\n"));
+    }
+
+    #[test]
+    fn proc_uptime_formats_seconds_and_idle_centiseconds() {
+        let uptime = render_proc_uptime_from_nanos(12_340_000_000, 2);
+
+        assert_eq!(uptime, "12.34 24.68\n");
+    }
+
+    #[test]
+    fn proc_diskstats_exists_even_when_no_device_stats_are_available() {
+        assert_eq!(render_proc_diskstats(), "");
+    }
+
+    #[test]
+    fn proc_stat_idle_ticks_follow_linux_user_hz() {
+        assert_eq!(nanos_to_clock_ticks(0), 0);
+        assert_eq!(nanos_to_clock_ticks(1_000_000_000), 100);
+        assert_eq!(nanos_to_clock_ticks(2_500_000_000), 250);
     }
 }

--- a/test-suit/starryos/normal/qemu-smp1/busybox-iostat/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/busybox-iostat/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0"
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/busybox-iostat.sh"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\\bpanic(?:ked)?\\b', "(?m)^TEST FAILED"]
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/busybox-iostat/sh/busybox-iostat.sh
+++ b/test-suit/starryos/normal/qemu-smp1/busybox-iostat/sh/busybox-iostat.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+OUT="$(busybox iostat 1 1 2>&1 || true)"
+printf '%s\n' "$OUT"
+
+if printf '%s\n' "$OUT" | busybox grep -qF "avg-cpu"; then
+    echo "TEST PASSED"
+else
+    echo "TEST FAILED"
+    exit 1
+fi


### PR DESCRIPTION
## 变更说明

修复 StarryOS 中 `/proc` 兼容性不完整导致 `busybox iostat` 无法工作的 bug。

修复前，在 StarryOS 中执行：

`busybox iostat 1 1`

会直接失败并报错：

`iostat: can't open '/proc/stat': No such file or directory`

根因是 StarryOS 的 procfs 缺少 `busybox iostat` 依赖的基础统计节点。本次修改在 `os/StarryOS/kernel/src/pseudofs/proc.rs` 中补充了最小兼容实现：

- `/proc/stat`
- `/proc/diskstats`
- `/proc/uptime`

其中：

- `/proc/stat` 提供 CPU 总统计和每核统计行
- `/proc/uptime` 基于系统单调时钟动态生成
- `/proc/diskstats` 当前提供可读取的空统计文件，保证 `iostat` 不会因节点缺失而直接失败

同时新增了专用 BusyBox 回归测例：

`test-suit/starryos/normal/qemu-smp1/busybox-iostat`

以及中文 bug 记录：

`os/StarryOS/docs/bug-fixes.md`

## 测试计划

已完成以下验证：

- `cargo check -p starry-kernel --all-targets`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --target x86_64-unknown-none -c busybox-iostat`

修复后的 QEMU 输出为：

- `avg-cpu:`
- `TEST PASSED`

这说明 `busybox iostat` 已经可以在 StarryOS 上正常运行，不再因缺失 `/proc/stat` 而失败。
