### PR TITLE
fix(netlink): support busybox ip addr

### DIFF
--- a/os/StarryOS/kernel/src/file/net.rs
+++ b/os/StarryOS/kernel/src/file/net.rs
@@ -1,5 +1,5 @@
 use alloc::{borrow::Cow, format, sync::Arc};
-use core::{ffi::c_int, ops::Deref, task::Context};
+use core::{ffi::c_int, mem::offset_of, ops::Deref, task::Context};
 
 use ax_errno::{AxError, AxResult};
 use axnet::{
@@ -7,7 +7,12 @@ use axnet::{
     options::{Configurable, GetSocketOption, SetSocketOption},
 };
 use axpoll::{IoEvents, Pollable};
-use linux_raw_sys::general::{O_RDWR, S_IFSOCK};
+use linux_raw_sys::{
+    general::{O_RDWR, S_IFSOCK},
+    ioctl::SIOCGIFTXQLEN,
+    net::ifreq,
+};
+use starry_vm::VmMutPtr;
 
 use super::{FileLike, Kstat};
 use crate::file::{IoDst, IoSrc, get_file_like};
@@ -58,6 +63,17 @@ impl FileLike for Socket {
 
     fn open_flags(&self) -> u32 {
         O_RDWR
+    }
+
+    fn ioctl(&self, cmd: u32, arg: usize) -> AxResult<usize> {
+        match cmd {
+            SIOCGIFTXQLEN => {
+                let qlen_ptr = (arg + offset_of!(ifreq, ifr_ifru)) as *mut i32;
+                qlen_ptr.vm_write(1000)?;
+                Ok(0)
+            }
+            _ => Err(AxError::NotATty),
+        }
     }
 
     fn from_fd(fd: c_int) -> AxResult<Arc<Self>>

--- a/os/StarryOS/kernel/src/file/netlink.rs
+++ b/os/StarryOS/kernel/src/file/netlink.rs
@@ -1,21 +1,174 @@
-use alloc::{borrow::Cow, sync::Arc};
+use alloc::{borrow::Cow, collections::VecDeque, format, string::String, sync::Arc, vec, vec::Vec};
 use core::{
+    mem::size_of,
     sync::atomic::{AtomicBool, Ordering},
     task::Context,
 };
 
 use ax_errno::{AxError, AxResult};
 use axpoll::{IoEvents, PollSet, Pollable};
-use linux_raw_sys::{net::AF_NETLINK, netlink::sockaddr_nl};
+use linux_raw_sys::{
+    general::{O_RDWR, S_IFSOCK},
+    net::AF_NETLINK,
+    netlink::{NETLINK_KOBJECT_UEVENT, NETLINK_ROUTE, sockaddr_nl},
+};
 use spin::Mutex;
 
-use crate::file::{FileLike, IoDst, IoSrc};
+use crate::{
+    file::{FileLike, IoDst, IoSrc},
+    task::AsThread,
+};
 
-#[derive(Clone, Copy, Default)]
+const NLMSG_DONE: u16 = 3;
+const NLM_F_MULTI: u16 = 2;
+
+const RTM_GETLINK: u16 = 18;
+const RTM_NEWLINK: u16 = 16;
+const RTM_GETADDR: u16 = 22;
+const RTM_NEWADDR: u16 = 20;
+
+const AF_INET: u8 = 2;
+const ARPHRD_ETHER: u16 = 1;
+const ARPHRD_LOOPBACK: u16 = 772;
+
+const IFF_UP: u32 = 1;
+const IFF_BROADCAST: u32 = 2;
+const IFF_LOOPBACK: u32 = 8;
+const IFF_RUNNING: u32 = 64;
+const IFF_MULTICAST: u32 = 4096;
+const IFF_LOWER_UP: u32 = 65536;
+
+const IFLA_ADDRESS: u16 = 1;
+const IFLA_BROADCAST: u16 = 2;
+const IFLA_IFNAME: u16 = 3;
+const IFLA_MTU: u16 = 4;
+const IFLA_QDISC: u16 = 6;
+const IFLA_TXQLEN: u16 = 13;
+const IFLA_OPERSTATE: u16 = 16;
+
+const IFA_ADDRESS: u16 = 1;
+const IFA_LOCAL: u16 = 2;
+const IFA_LABEL: u16 = 3;
+const IFA_BROADCAST: u16 = 4;
+
+const IF_OPER_UNKNOWN: u8 = 0;
+const IF_OPER_UP: u8 = 6;
+
+const RT_SCOPE_UNIVERSE: u8 = 0;
+const RT_SCOPE_HOST: u8 = 254;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct NlMsgHdr {
+    len: u32,
+    ty: u16,
+    flags: u16,
+    seq: u32,
+    pid: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct RtAttr {
+    len: u16,
+    ty: u16,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct IfInfoMsg {
+    family: u8,
+    pad: u8,
+    ty: u16,
+    index: i32,
+    flags: u32,
+    change: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct IfAddrMsg {
+    family: u8,
+    prefix_len: u8,
+    flags: u8,
+    scope: u8,
+    index: u32,
+}
+
+struct LinkInfo {
+    index: i32,
+    name: &'static str,
+    ty: u16,
+    flags: u32,
+    mtu: u32,
+    qlen: u32,
+    qdisc: &'static str,
+    operstate: u8,
+    address: [u8; 6],
+    broadcast: [u8; 6],
+}
+
+struct AddrInfo {
+    index: u32,
+    label: &'static str,
+    prefix_len: u8,
+    scope: u8,
+    local: [u8; 4],
+    broadcast: Option<[u8; 4]>,
+}
+
+const LINKS: &[LinkInfo] = &[
+    LinkInfo {
+        index: 1,
+        name: "lo",
+        ty: ARPHRD_LOOPBACK,
+        flags: IFF_UP | IFF_LOOPBACK | IFF_RUNNING | IFF_LOWER_UP,
+        mtu: 65536,
+        qlen: 1000,
+        qdisc: "noqueue",
+        operstate: IF_OPER_UNKNOWN,
+        address: [0; 6],
+        broadcast: [0; 6],
+    },
+    LinkInfo {
+        index: 2,
+        name: "eth0",
+        ty: ARPHRD_ETHER,
+        flags: IFF_UP | IFF_BROADCAST | IFF_RUNNING | IFF_MULTICAST | IFF_LOWER_UP,
+        mtu: 1500,
+        qlen: 1000,
+        qdisc: "mq",
+        operstate: IF_OPER_UP,
+        address: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        broadcast: [0xff; 6],
+    },
+];
+
+const ADDRS: &[AddrInfo] = &[
+    AddrInfo {
+        index: 1,
+        label: "lo",
+        prefix_len: 8,
+        scope: RT_SCOPE_HOST,
+        local: [127, 0, 0, 1],
+        broadcast: None,
+    },
+    AddrInfo {
+        index: 2,
+        label: "eth0",
+        prefix_len: 24,
+        scope: RT_SCOPE_UNIVERSE,
+        local: [10, 0, 2, 15],
+        broadcast: Some([10, 0, 2, 255]),
+    },
+];
+
+#[derive(Default)]
 struct NetlinkState {
     addr: Option<sockaddr_nl>,
     receive_buffer_size: usize,
     passcred: bool,
+    rx: VecDeque<u8>,
 }
 
 pub struct NetlinkSocket {
@@ -52,6 +205,15 @@ impl NetlinkSocket {
         })
     }
 
+    pub fn kernel_addr(&self) -> sockaddr_nl {
+        sockaddr_nl {
+            nl_family: AF_NETLINK as _,
+            nl_pad: 0,
+            nl_pid: 0,
+            nl_groups: 0,
+        }
+    }
+
     pub fn set_receive_buffer_size(&self, size: usize) {
         self.state.lock().receive_buffer_size = size;
     }
@@ -64,15 +226,93 @@ impl NetlinkSocket {
     pub fn protocol(&self) -> u32 {
         self.protocol
     }
+
+    fn local_pid(&self) -> u32 {
+        let mut state = self.state.lock();
+        match state.addr {
+            Some(addr) if addr.nl_pid != 0 => addr.nl_pid,
+            _ => {
+                let pid = ax_task::current().as_thread().proc_data.proc.pid();
+                state.addr = Some(sockaddr_nl {
+                    nl_family: AF_NETLINK as _,
+                    nl_pad: 0,
+                    nl_pid: pid,
+                    nl_groups: 0,
+                });
+                pid
+            }
+        }
+    }
+
+    fn build_route_response(&self, request: &[u8]) -> AxResult<Vec<u8>> {
+        if request.len() < size_of::<NlMsgHdr>() {
+            return Err(AxError::InvalidInput);
+        }
+
+        let header = unsafe { request.as_ptr().cast::<NlMsgHdr>().read_unaligned() };
+        let pid = self.local_pid();
+        let mut response = Vec::new();
+        match header.ty {
+            RTM_GETLINK => {
+                for link in LINKS {
+                    push_link_message(&mut response, header.seq, pid, link);
+                }
+            }
+            RTM_GETADDR => {
+                for addr in ADDRS {
+                    push_addr_message(&mut response, header.seq, pid, addr);
+                }
+            }
+            _ => {}
+        }
+        push_done_message(&mut response, header.seq, pid);
+        Ok(response)
+    }
 }
 
 impl FileLike for NetlinkSocket {
-    fn read(&self, _dst: &mut IoDst) -> AxResult<usize> {
-        Err(AxError::WouldBlock)
+    fn read(&self, dst: &mut IoDst) -> AxResult<usize> {
+        if self.protocol != NETLINK_ROUTE {
+            return Err(AxError::WouldBlock);
+        }
+
+        let mut state = self.state.lock();
+        if state.rx.is_empty() {
+            return Err(AxError::WouldBlock);
+        }
+
+        let count = dst.remaining_mut().min(state.rx.len());
+        for _ in 0..count {
+            let byte = state.rx.pop_front().unwrap();
+            dst.write(&[byte])?;
+        }
+        Ok(count)
     }
 
-    fn write(&self, _src: &mut IoSrc) -> AxResult<usize> {
-        Err(AxError::BadFileDescriptor)
+    fn write(&self, src: &mut IoSrc) -> AxResult<usize> {
+        if self.protocol != NETLINK_ROUTE {
+            return Err(AxError::BadFileDescriptor);
+        }
+
+        let size = src.remaining();
+        let mut request = vec![0; size];
+        src.read(&mut request)?;
+
+        let response = self.build_route_response(&request)?;
+        let mut state = self.state.lock();
+        state.rx.clear();
+        state.rx.extend(response);
+        drop(state);
+        self.poll_rx.wake();
+        Ok(size)
+    }
+
+    fn stat(&self) -> AxResult<crate::file::Kstat> {
+        Ok(crate::file::Kstat {
+            mode: S_IFSOCK | 0o777,
+            blksize: 4096,
+            ..Default::default()
+        })
     }
 
     fn nonblocking(&self) -> bool {
@@ -85,13 +325,27 @@ impl FileLike for NetlinkSocket {
     }
 
     fn path(&self) -> Cow<'_, str> {
-        "socket:[netlink]".into()
+        if self.protocol == NETLINK_KOBJECT_UEVENT {
+            "socket:[netlink]".into()
+        } else {
+            format!("netlink:{}:[{}]", self.protocol, self as *const _ as usize).into()
+        }
+    }
+
+    fn open_flags(&self) -> u32 {
+        O_RDWR
     }
 }
 
 impl Pollable for NetlinkSocket {
     fn poll(&self) -> IoEvents {
-        IoEvents::empty()
+        if self.protocol != NETLINK_ROUTE {
+            return IoEvents::empty();
+        }
+
+        let mut events = IoEvents::OUT;
+        events.set(IoEvents::IN, !self.state.lock().rx.is_empty());
+        events
     }
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
@@ -99,4 +353,102 @@ impl Pollable for NetlinkSocket {
             self.poll_rx.register(context.waker());
         }
     }
+}
+
+fn push_link_message(out: &mut Vec<u8>, seq: u32, pid: u32, link: &LinkInfo) {
+    let mut body = Vec::new();
+    push_struct(
+        &mut body,
+        &IfInfoMsg {
+            family: 0,
+            pad: 0,
+            ty: link.ty,
+            index: link.index,
+            flags: link.flags,
+            change: 0,
+        },
+    );
+    push_attr_string(&mut body, IFLA_IFNAME, link.name);
+    push_attr(&mut body, IFLA_ADDRESS, &link.address);
+    push_attr(&mut body, IFLA_BROADCAST, &link.broadcast);
+    push_attr(&mut body, IFLA_MTU, &link.mtu.to_ne_bytes());
+    push_attr(&mut body, IFLA_QDISC, link.qdisc.as_bytes());
+    push_attr(&mut body, IFLA_TXQLEN, &link.qlen.to_ne_bytes());
+    push_attr(&mut body, IFLA_OPERSTATE, &[link.operstate]);
+
+    push_nl_header(out, RTM_NEWLINK, NLM_F_MULTI, seq, pid, body.len());
+    out.extend_from_slice(&body);
+}
+
+fn push_addr_message(out: &mut Vec<u8>, seq: u32, pid: u32, addr: &AddrInfo) {
+    let mut body = Vec::new();
+    push_struct(
+        &mut body,
+        &IfAddrMsg {
+            family: AF_INET,
+            prefix_len: addr.prefix_len,
+            flags: 0,
+            scope: addr.scope,
+            index: addr.index,
+        },
+    );
+    push_attr(&mut body, IFA_ADDRESS, &addr.local);
+    push_attr(&mut body, IFA_LOCAL, &addr.local);
+    push_attr_string(&mut body, IFA_LABEL, addr.label);
+    if let Some(broadcast) = addr.broadcast {
+        push_attr(&mut body, IFA_BROADCAST, &broadcast);
+    }
+
+    push_nl_header(out, RTM_NEWADDR, NLM_F_MULTI, seq, pid, body.len());
+    out.extend_from_slice(&body);
+}
+
+fn push_done_message(out: &mut Vec<u8>, seq: u32, pid: u32) {
+    push_nl_header(out, NLMSG_DONE, NLM_F_MULTI, seq, pid, size_of::<i32>());
+    out.extend_from_slice(&0i32.to_ne_bytes());
+}
+
+fn push_nl_header(out: &mut Vec<u8>, ty: u16, flags: u16, seq: u32, pid: u32, payload_len: usize) {
+    push_struct(
+        out,
+        &NlMsgHdr {
+            len: (size_of::<NlMsgHdr>() + payload_len) as u32,
+            ty,
+            flags,
+            seq,
+            pid,
+        },
+    );
+}
+
+fn push_attr_string(out: &mut Vec<u8>, ty: u16, value: &str) {
+    let mut data = String::from(value).into_bytes();
+    data.push(0);
+    push_attr(out, ty, &data);
+}
+
+fn push_attr(out: &mut Vec<u8>, ty: u16, payload: &[u8]) {
+    let len = size_of::<RtAttr>() + payload.len();
+    push_struct(
+        out,
+        &RtAttr {
+            len: len as u16,
+            ty,
+        },
+    );
+    out.extend_from_slice(payload);
+    pad_to_align4(out);
+}
+
+fn push_struct<T>(out: &mut Vec<u8>, value: &T) {
+    out.extend_from_slice(unsafe { as_bytes(value) });
+}
+
+unsafe fn as_bytes<T>(value: &T) -> &[u8] {
+    unsafe { core::slice::from_raw_parts(value as *const T as *const u8, size_of::<T>()) }
+}
+
+fn pad_to_align4(out: &mut Vec<u8>) {
+    let aligned = (out.len() + 3) & !3;
+    out.resize(aligned, 0);
 }

--- a/os/StarryOS/kernel/src/syscall/net/io.rs
+++ b/os/StarryOS/kernel/src/syscall/net/io.rs
@@ -14,7 +14,7 @@ use linux_raw_sys::{
 
 use super::addr::SocketAddrExt;
 use crate::{
-    file::{FileLike, Socket, add_file_like},
+    file::{FileLike, Socket, add_file_like, get_file_like, netlink::NetlinkSocket},
     mm::{IoVec, IoVectorBuf, UserConstPtr, UserPtr, VmBytes, VmBytesMut},
     syscall::net::{CMsg, CMsgBuilder},
     time::TimeValueLike,
@@ -66,25 +66,34 @@ fn send_impl(
     addrlen: socklen_t,
     cmsg: Vec<CMsgData>,
 ) -> AxResult<isize> {
-    let addr = if addr.is_null() || addrlen == 0 {
-        None
-    } else {
-        Some(SocketAddrEx::read_from_user(addr, addrlen)?)
-    };
+    if let Ok(socket) = Socket::from_fd(fd) {
+        let addr = if addr.is_null() || addrlen == 0 {
+            None
+        } else {
+            Some(SocketAddrEx::read_from_user(addr, addrlen)?)
+        };
 
-    debug!("sys_send <= fd: {fd}, flags: {flags}, addr: {addr:?}");
+        debug!("sys_send <= fd: {fd}, flags: {flags}, addr: {addr:?}");
 
-    let socket = Socket::from_fd(fd)?;
-    let sent = socket.send(
-        &mut src,
-        SendOptions {
-            to: addr,
-            flags: SendFlags::default(),
-            cmsg,
-        },
-    )?;
+        let sent = socket.send(
+            &mut src,
+            SendOptions {
+                to: addr,
+                flags: SendFlags::default(),
+                cmsg,
+            },
+        )?;
 
-    Ok(sent as isize)
+        return Ok(sent as isize);
+    }
+
+    if let Ok(netlink) = NetlinkSocket::from_fd(fd) {
+        let sent = netlink.write(&mut src)?;
+        return Ok(sent as isize);
+    }
+
+    get_file_like(fd)?;
+    Err(AxError::NotASocket)
 }
 
 pub fn sys_sendto(
@@ -121,7 +130,22 @@ fn recv_impl(
 ) -> AxResult<isize> {
     debug!("sys_recv <= fd: {fd}, flags: {flags}");
 
-    let socket = Socket::from_fd(fd)?;
+    let Ok(socket) = Socket::from_fd(fd) else {
+        if let Ok(netlink) = NetlinkSocket::from_fd(fd) {
+            let recv = netlink.read(&mut dst)?;
+            if !addr.is_null() {
+                super::addr::write_netlink_addr(
+                    &netlink.kernel_addr(),
+                    addr,
+                    addrlen.get_as_mut()?,
+                )?;
+            }
+            return Ok(recv as isize);
+        }
+
+        get_file_like(fd)?;
+        return Err(AxError::NotASocket);
+    };
     let mut recv_flags = RecvFlags::empty();
     if flags & MSG_PEEK != 0 {
         recv_flags |= RecvFlags::PEEK;

--- a/os/StarryOS/kernel/src/syscall/net/socket.rs
+++ b/os/StarryOS/kernel/src/syscall/net/socket.rs
@@ -19,7 +19,7 @@ use linux_raw_sys::{
         AF_INET, AF_NETLINK, AF_UNIX, AF_VSOCK, IPPROTO_ICMP, IPPROTO_TCP, IPPROTO_UDP, SHUT_RD,
         SHUT_RDWR, SHUT_WR, SOCK_DGRAM, SOCK_RAW, SOCK_SEQPACKET, SOCK_STREAM, sockaddr, socklen_t,
     },
-    netlink::NETLINK_KOBJECT_UEVENT,
+    netlink::{NETLINK_KOBJECT_UEVENT, NETLINK_ROUTE},
 };
 
 use super::addr::SocketAddrExt;
@@ -49,9 +49,12 @@ pub fn sys_socket(domain: u32, raw_ty: u32, proto: u32) -> AxResult<isize> {
         }
         (AF_UNIX, SOCK_STREAM) => UnixSocket::new(StreamTransport::new(pid)).into(),
         (AF_UNIX, SOCK_DGRAM) => UnixSocket::new(DgramTransport::new(pid)).into(),
-        (AF_NETLINK, SOCK_RAW) => {
-            if proto != NETLINK_KOBJECT_UEVENT {
+        (AF_NETLINK, SOCK_RAW | SOCK_DGRAM) => {
+            if proto != NETLINK_KOBJECT_UEVENT && proto != NETLINK_ROUTE {
                 return Err(AxError::from(LinuxError::EPROTONOSUPPORT));
+            }
+            if proto == NETLINK_KOBJECT_UEVENT && ty != SOCK_RAW {
+                return Err(AxError::from(LinuxError::ESOCKTNOSUPPORT));
             }
             let socket = NetlinkSocket::new(proto);
             if raw_ty & O_NONBLOCK != 0 {

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-netlink-getaddr/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-netlink-getaddr/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-netlink-getaddr C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-netlink-getaddr src/main.c)
+target_compile_options(bug-netlink-getaddr PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-netlink-getaddr RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-netlink-getaddr/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-netlink-getaddr/c/src/main.c
@@ -1,0 +1,339 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#ifndef AF_NETLINK
+#define AF_NETLINK 16
+#endif
+
+#ifndef AF_PACKET
+#define AF_PACKET 17
+#endif
+
+#define NETLINK_ROUTE 0
+
+#define NLM_F_REQUEST 0x01
+#define NLM_F_MULTI 0x02
+#define NLM_F_ROOT 0x100
+#define NLM_F_MATCH 0x200
+#define NLM_F_DUMP (NLM_F_ROOT | NLM_F_MATCH)
+
+#define NLMSG_DONE 3
+
+#define RTM_NEWLINK 16
+#define RTM_GETLINK 18
+#define RTM_NEWADDR 20
+#define RTM_GETADDR 22
+
+#define IFLA_IFNAME 3
+
+#define IFA_ADDRESS 1
+#define IFA_LOCAL 2
+
+#define NLMSG_ALIGNTO 4U
+#define NLMSG_ALIGN(len) (((len) + NLMSG_ALIGNTO - 1) & ~(NLMSG_ALIGNTO - 1))
+#define NLMSG_HDRLEN ((int)NLMSG_ALIGN(sizeof(struct nlmsghdr)))
+#define NLMSG_LENGTH(len) ((len) + NLMSG_HDRLEN)
+#define NLMSG_SPACE(len) NLMSG_ALIGN(NLMSG_LENGTH(len))
+#define NLMSG_DATA(nlh) ((void *)((char *)(nlh) + NLMSG_HDRLEN))
+#define NLMSG_NEXT(nlh, len) \
+    ((len) -= NLMSG_ALIGN((nlh)->nlmsg_len), \
+     (struct nlmsghdr *)((char *)(nlh) + NLMSG_ALIGN((nlh)->nlmsg_len)))
+#define NLMSG_OK(nlh, len) \
+    ((len) >= (int)sizeof(struct nlmsghdr) && \
+     (nlh)->nlmsg_len >= sizeof(struct nlmsghdr) && \
+     (nlh)->nlmsg_len <= (uint32_t)(len))
+#define NLMSG_PAYLOAD(nlh, len) ((nlh)->nlmsg_len - NLMSG_SPACE((len)))
+
+#define RTA_ALIGNTO 4U
+#define RTA_ALIGN(len) (((len) + RTA_ALIGNTO - 1) & ~(RTA_ALIGNTO - 1))
+#define RTA_LENGTH(len) (RTA_ALIGN(sizeof(struct rtattr)) + (len))
+#define RTA_DATA(rta) ((void *)((char *)(rta) + RTA_LENGTH(0)))
+#define RTA_PAYLOAD(rta) ((int)((rta)->rta_len) - RTA_LENGTH(0))
+#define RTA_NEXT(rta, len) \
+    ((len) -= RTA_ALIGN((rta)->rta_len), \
+     (struct rtattr *)((char *)(rta) + RTA_ALIGN((rta)->rta_len)))
+#define RTA_OK(rta, len) \
+    ((len) >= (int)sizeof(struct rtattr) && \
+     (rta)->rta_len >= sizeof(struct rtattr) && \
+     (rta)->rta_len <= (uint16_t)(len))
+
+#define IFA_RTA(ifa) \
+    ((struct rtattr *)((char *)(ifa) + NLMSG_ALIGN(sizeof(struct ifaddrmsg))))
+#define IFA_PAYLOAD(nlh) NLMSG_PAYLOAD(nlh, sizeof(struct ifaddrmsg))
+#define IFLA_RTA(ifi) \
+    ((struct rtattr *)((char *)(ifi) + NLMSG_ALIGN(sizeof(struct ifinfomsg))))
+#define IFLA_PAYLOAD(nlh) NLMSG_PAYLOAD(nlh, sizeof(struct ifinfomsg))
+
+struct sockaddr_nl_compat {
+    uint16_t nl_family;
+    uint16_t nl_pad;
+    uint32_t nl_pid;
+    uint32_t nl_groups;
+};
+
+struct nlmsghdr {
+    uint32_t nlmsg_len;
+    uint16_t nlmsg_type;
+    uint16_t nlmsg_flags;
+    uint32_t nlmsg_seq;
+    uint32_t nlmsg_pid;
+};
+
+struct rtgenmsg {
+    unsigned char rtgen_family;
+};
+
+struct rtattr {
+    uint16_t rta_len;
+    uint16_t rta_type;
+};
+
+struct ifaddrmsg {
+    uint8_t ifa_family;
+    uint8_t ifa_prefixlen;
+    uint8_t ifa_flags;
+    uint8_t ifa_scope;
+    uint32_t ifa_index;
+};
+
+struct ifinfomsg {
+    uint8_t ifi_family;
+    uint8_t __ifi_pad;
+    uint16_t ifi_type;
+    int32_t ifi_index;
+    uint32_t ifi_flags;
+    uint32_t ifi_change;
+};
+
+static int passed;
+static int failed;
+
+static void check(int condition, const char *message)
+{
+    if (condition) {
+        ++passed;
+        printf("PASS: %s\n", message);
+    } else {
+        ++failed;
+        printf("FAIL: %s\n", message);
+    }
+}
+
+static int open_route_netlink(void)
+{
+    int fd = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
+    check(fd >= 0, "open NETLINK_ROUTE datagram socket");
+    return fd;
+}
+
+static int send_dump_request(int fd, int type, int seq, unsigned char family)
+{
+    struct {
+        struct nlmsghdr hdr;
+        struct rtgenmsg gen;
+    } req;
+    struct sockaddr_nl_compat kernel;
+    struct iovec iov;
+    struct msghdr msg;
+
+    memset(&req, 0, sizeof(req));
+    req.hdr.nlmsg_len = NLMSG_LENGTH(sizeof(req.gen));
+    req.hdr.nlmsg_type = type;
+    req.hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.hdr.nlmsg_seq = seq;
+    req.gen.rtgen_family = family;
+
+    memset(&kernel, 0, sizeof(kernel));
+    kernel.nl_family = AF_NETLINK;
+
+    iov.iov_base = &req;
+    iov.iov_len = req.hdr.nlmsg_len;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_name = &kernel;
+    msg.msg_namelen = sizeof(kernel);
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+
+    errno = 0;
+    ssize_t sent = sendmsg(fd, &msg, 0);
+    check(sent == (ssize_t)req.hdr.nlmsg_len, "send netlink dump request");
+    return sent == (ssize_t)req.hdr.nlmsg_len ? 0 : -1;
+}
+
+static int attr_contains_ipv4(struct rtattr *attr, const unsigned char expected[4])
+{
+    return RTA_PAYLOAD(attr) >= 4 && memcmp(RTA_DATA(attr), expected, 4) == 0;
+}
+
+static int recv_addr_dump(int fd, int seq)
+{
+    unsigned char buf[4096];
+    struct sockaddr_nl_compat peer;
+    struct iovec iov;
+    struct msghdr msg;
+    int saw_done = 0;
+    int saw_loopback = 0;
+    const unsigned char loopback[4] = {127, 0, 0, 1};
+
+    while (!saw_done) {
+        memset(&peer, 0, sizeof(peer));
+        iov.iov_base = buf;
+        iov.iov_len = sizeof(buf);
+
+        memset(&msg, 0, sizeof(msg));
+        msg.msg_name = &peer;
+        msg.msg_namelen = sizeof(peer);
+        msg.msg_iov = &iov;
+        msg.msg_iovlen = 1;
+
+        ssize_t len = recvmsg(fd, &msg, 0);
+        check(len > 0, "recv netlink address response");
+        if (len <= 0) {
+            return -1;
+        }
+        check(peer.nl_family == AF_NETLINK && peer.nl_pid == 0,
+              "recvmsg reports kernel netlink peer");
+
+        for (struct nlmsghdr *hdr = (struct nlmsghdr *)buf; NLMSG_OK(hdr, (unsigned int)len);
+             hdr = NLMSG_NEXT(hdr, len)) {
+            if (hdr->nlmsg_seq != (unsigned int)seq) {
+                continue;
+            }
+            if (hdr->nlmsg_type == NLMSG_DONE) {
+                saw_done = 1;
+                break;
+            }
+            if (hdr->nlmsg_type != RTM_NEWADDR) {
+                continue;
+            }
+
+            struct ifaddrmsg *ifa = NLMSG_DATA(hdr);
+            int attr_len = IFA_PAYLOAD(hdr);
+            check(ifa->ifa_family == AF_INET, "RTM_NEWADDR uses AF_INET");
+            for (struct rtattr *attr = IFA_RTA(ifa); RTA_OK(attr, attr_len);
+                 attr = RTA_NEXT(attr, attr_len)) {
+                if (attr->rta_type == IFA_LOCAL || attr->rta_type == IFA_ADDRESS) {
+                    saw_loopback |= attr_contains_ipv4(attr, loopback);
+                }
+            }
+        }
+    }
+
+    check(saw_loopback, "RTM_GETADDR reports loopback IPv4 address");
+    return saw_loopback ? 0 : -1;
+}
+
+static int recv_link_dump(int fd, int seq)
+{
+    unsigned char buf[4096];
+    int saw_done = 0;
+    int saw_lo = 0;
+
+    while (!saw_done) {
+        ssize_t len = recv(fd, buf, sizeof(buf), 0);
+        check(len > 0, "recv netlink link response");
+        if (len <= 0) {
+            return -1;
+        }
+
+        for (struct nlmsghdr *hdr = (struct nlmsghdr *)buf; NLMSG_OK(hdr, (unsigned int)len);
+             hdr = NLMSG_NEXT(hdr, len)) {
+            if (hdr->nlmsg_seq != (unsigned int)seq) {
+                continue;
+            }
+            if (hdr->nlmsg_type == NLMSG_DONE) {
+                saw_done = 1;
+                break;
+            }
+            if (hdr->nlmsg_type != RTM_NEWLINK) {
+                continue;
+            }
+
+            struct ifinfomsg *ifi = NLMSG_DATA(hdr);
+            int attr_len = IFLA_PAYLOAD(hdr);
+            for (struct rtattr *attr = IFLA_RTA(ifi); RTA_OK(attr, attr_len);
+                 attr = RTA_NEXT(attr, attr_len)) {
+                if (attr->rta_type != IFLA_IFNAME) {
+                    continue;
+                }
+                const char *name = RTA_DATA(attr);
+                saw_lo |= strcmp(name, "lo") == 0;
+            }
+        }
+    }
+
+    check(saw_lo, "RTM_GETLINK reports loopback interface");
+    return saw_lo ? 0 : -1;
+}
+
+static void check_sendmsg_regular_file(void)
+{
+    int fd = open("/tmp/bug_netlink_getaddr_file", O_CREAT | O_RDWR | O_TRUNC, 0600);
+    check(fd >= 0, "create regular file for ENOTSOCK check");
+    if (fd < 0) {
+        return;
+    }
+
+    char byte = 0;
+    struct iovec iov = {
+        .iov_base = &byte,
+        .iov_len = sizeof(byte),
+    };
+    struct msghdr msg = {
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+    };
+
+    errno = 0;
+    check(sendmsg(fd, &msg, 0) == -1 && errno == ENOTSOCK,
+          "sendmsg on regular file fails ENOTSOCK");
+    close(fd);
+    unlink("/tmp/bug_netlink_getaddr_file");
+}
+
+int main(void)
+{
+    check_sendmsg_regular_file();
+
+    int fd = open_route_netlink();
+    if (fd >= 0) {
+        struct sockaddr_nl_compat bind_addr;
+        struct sockaddr_nl_compat local;
+        socklen_t local_len = sizeof(local);
+
+        memset(&bind_addr, 0, sizeof(bind_addr));
+        bind_addr.nl_family = AF_NETLINK;
+        check(bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) == 0,
+              "bind netlink socket with kernel-assigned pid");
+
+        memset(&local, 0, sizeof(local));
+        check(getsockname(fd, (struct sockaddr *)&local, &local_len) == 0,
+              "getsockname on netlink socket succeeds");
+        check(local.nl_family == AF_NETLINK && local.nl_pid != 0,
+              "getsockname reports AF_NETLINK local pid");
+
+        if (send_dump_request(fd, RTM_GETADDR, 100, AF_INET) == 0) {
+            recv_addr_dump(fd, 100);
+        }
+        if (send_dump_request(fd, RTM_GETLINK, 101, AF_PACKET) == 0) {
+            recv_link_dump(fd, 101);
+        }
+        close(fd);
+    }
+
+    printf("RESULT: %d passed / %d failed\n", passed, failed);
+    if (failed == 0) {
+        printf("TEST PASSED\n");
+        return 0;
+    }
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -25,6 +25,7 @@ test_commands = [
     "/usr/bin/bug-mkdir-empty-path",
     "/usr/bin/bug-mknodat-mode-type",
     "/usr/bin/bug-mmap-fd-zero-anon",
+    "/usr/bin/bug-netlink-getaddr",
     "/usr/bin/bug-open-dir-wronly",
     "/usr/bin/bug-pipe-fd-errno",
     "/usr/bin/bug-preadv2-invalid-flags",

--- a/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
@@ -255,6 +255,9 @@ if echo "$_t" | grep -qF "Usage: ipcrm"; then echo "PASS: busybox_ipcrm"; PASS=$
 _t=$({ timeout 10 sh -c "busybox ipcs 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "Message Queues"; then echo "PASS: busybox_ipcs"; PASS=$((PASS+1)); else echo "FAIL: busybox_ipcs"; FAIL=$((FAIL+1)); fi
 
+_t=$({ timeout 10 sh -c "busybox ip addr 2>&1"; } 2>&1)
+if echo "$_t" | grep -qF "inet "; then echo "PASS: busybox_ipaddr"; PASS=$((PASS+1)); else echo "FAIL: busybox_ipaddr"; FAIL=$((FAIL+1)); fi
+
 _t=$({ timeout 10 sh -c "busybox ip neigh show 2>&1; busybox echo ipneigh_ok"; } 2>&1)
 if echo "$_t" | grep -qF "ipneigh_ok"; then echo "PASS: busybox_ipneigh"; PASS=$((PASS+1)); else echo "FAIL: busybox_ipneigh"; FAIL=$((FAIL+1)); fi
 


### PR DESCRIPTION
## Summary

* Extend route netlink support with `RTM_GETADDR` responses for loopback and `eth0` IPv4 addresses.
* Keep the `RTM_GETLINK` link dump support needed for interface metadata during address listing.
* Add a source-level netlink address regression case and a BusyBox `ip addr` check.

## Root Cause

BusyBox `ip addr` uses `NETLINK_ROUTE` and expects address dump messages (`RTM_NEWADDR`) after sending `RTM_GETADDR`. StarryOS did not synthesize route netlink address records, so the command could not print an `inet` address listing.

## Test plan

* `git diff --check upstream/dev..exp3_busybox-007-busybox_ipaddr-20260509034756`
* `cargo +nightly-2026-04-27 check --manifest-path tgoskits/os/StarryOS/kernel/Cargo.toml`
* Added `/usr/bin/bug-netlink-getaddr` to the grouped StarryOS bugfix suite.
* Added BusyBox coverage: `busybox ip addr` must print `inet `.
