### PR TITLE
add busybox_ttysize test case

### DIFF
--- a/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
@@ -207,6 +207,10 @@ if echo "$_t" | grep -qF "hello"; then echo "PASS: busybox_grep"; PASS=$((PASS+1
 _t=$({ timeout 10 sh -c "busybox groups 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "root"; then echo "PASS: busybox_groups"; PASS=$((PASS+1)); else echo "FAIL: busybox_groups"; FAIL=$((FAIL+1)); fi
 
+# busybox_ttysize — query terminal size (outputs "rows cols")
+_t=$({ timeout 10 sh -c 'busybox ttysize 2>&1'; } 2>&1)
+if echo "$_t" | grep -qE '^[0-9]+ [0-9]+$'; then echo "PASS: busybox_ttysize"; PASS=$((PASS+1)); else echo "FAIL: busybox_ttysize"; echo "$_t"; FAIL=$((FAIL+1)); fi
+
 _t=$({ timeout 10 sh -c "busybox echo -n hello | busybox gzip -c | busybox gunzip -c 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "hello"; then echo "PASS: busybox_gunzip"; PASS=$((PASS+1)); else echo "FAIL: busybox_gunzip"; FAIL=$((FAIL+1)); fi
 


### PR DESCRIPTION
## Summary
- Add busybox_ttysize test case to the busybox sh test suite
- The ttysize applet uses TIOCGWINSZ ioctl to query terminal dimensions
- Verified working on StarryOS — returns actual console window size (e.g., "80 24")

## Test Results
```
PASS: busybox_ttysize
```
Full test suite: **269 PASS, 0 FAIL**

## Changes
- `test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh`: Added ttysize test (4 lines)