### PR TITLE
fix(ioctl): suppress block ioctl warnings + add blkid test

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -12,7 +12,7 @@ use ax_task::current;
 use axfs_ng_vfs::{DeviceId, MetadataUpdate, NodePermission, NodeType, path::Path};
 use linux_raw_sys::{
     general::*,
-    ioctl::{FIONBIO, TIOCGWINSZ},
+    ioctl::{BLKGETSIZE64, BLKRAGET, BLKSSZGET, FIONBIO, TIOCGWINSZ},
 };
 use starry_vm::{VmPtr, vm_write_slice};
 
@@ -38,9 +38,9 @@ pub fn sys_ioctl(fd: i32, cmd: u32, arg: usize) -> AxResult<isize> {
         .map(|result| result as isize)
         .inspect_err(|err| {
             if *err == AxError::NotATty {
-                // glibc likes to call TIOCGWINSZ on non-terminal files, just
-                // ignore it
-                if cmd == TIOCGWINSZ {
+                // Applications commonly probe non-terminal/blobk fds with
+                // these ioctls; suppress noise.
+                if matches!(cmd, TIOCGWINSZ | BLKGETSIZE64 | BLKRAGET | BLKSSZGET) {
                     return;
                 }
                 warn!("Unsupported ioctl command: {cmd} for fd: {fd}");

--- a/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
@@ -168,6 +168,11 @@ if echo "$_t" | grep -qF "Usage: fbsplash"; then echo "PASS: busybox_fbsplash"; 
 _t=$({ timeout 10 sh -c "busybox fdisk -h 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "Usage: fdisk"; then echo "PASS: busybox_fdisk"; PASS=$((PASS+1)); else echo "FAIL: busybox_fdisk"; FAIL=$((FAIL+1)); fi
 
+# busybox_blkid — list block device attributes
+# blkid should handle non-block-device files gracefully (exit 0, error msg to stderr)
+_t=$({ timeout 10 sh -c 'busybox blkid 2>&1; S=$(busybox blkid /dev/null 2>&1); R=$?; echo "$S"; echo EXIT:$R >&2'; } 2>&1)
+if echo "$_t" | grep -qF "EXIT:0"; then echo "PASS: busybox_blkid"; PASS=$((PASS+1)); else echo "FAIL: busybox_blkid"; echo "$_t"; FAIL=$((FAIL+1)); fi
+
 _t=$({ timeout 10 sh -c "busybox echo hello | busybox fgrep hell 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "hello"; then echo "PASS: busybox_fgrep"; PASS=$((PASS+1)); else echo "FAIL: busybox_fgrep"; FAIL=$((FAIL+1)); fi
 


### PR DESCRIPTION
## Summary
- Suppress kernel warnings for BLKGETSIZE64, BLKRAGET, BLKSSZGET on non-block fds (similar to TIOCGWINSZ on non-ttys)
- Add busybox_blkid test case that verifies blkid handles non-block devices gracefully

## Changes
- `os/StarryOS/kernel/src/syscall/fs/ctl.rs`: Extend ioctl warning suppression to common block device ioctls
- `test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh`: Add blkid test (5 lines)

## Test Results
All 269 tests PASS, 0 FAIL.