### PR TITLE
fix(tty): 修复 x86-qemu-q35 下 Ctrl+C/Ctrl+Z 无法中断前台进程的问题

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -96,6 +96,7 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
 
     fn ioctl(&self, cmd: u32, arg: usize) -> AxResult<usize> {
         use linux_raw_sys::ioctl::*;
+        const TIOCSTI: u32 = 0x5412;
         match cmd {
             TCGETS => {
                 let termios = *self.terminal.termios.lock().as_ref().deref();
@@ -154,6 +155,10 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                     .upgrade()
                     .unwrap()
                     .bind_to(&current().as_thread().proc_data.proc)?;
+            }
+            TIOCSTI => {
+                let byte: u8 = (arg as *const u8).vm_read()?;
+                self.ldisc.lock().tiocsti(byte);
             }
             TIOCNOTTY => {
                 if current()

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use core::time::Duration;
 
 use axpoll::PollSet;
 use lazy_static::lazy_static;
@@ -46,7 +47,7 @@ fn new_n_tty() -> Arc<NTtyDriver> {
         TtyConfig {
             reader: Console,
             writer: Console,
-            process_mode: console_irq_mode().unwrap_or(ProcessMode::Manual),
+            process_mode: console_irq_mode().unwrap_or_else(console_polling_mode),
         },
     )
 }
@@ -54,10 +55,28 @@ fn new_n_tty() -> Arc<NTtyDriver> {
 fn console_irq_mode() -> Option<ProcessMode> {
     let irq = ax_hal::console::irq_num()?;
     if !ax_hal::irq::register(irq, handle_console_input_irq) {
-        warn!("Failed to register console IRQ handler for irq {irq}, falling back to manual mode");
+        warn!("Failed to register console IRQ handler for irq {irq}, falling back to polling mode");
         return None;
     }
 
     ax_hal::console::set_input_irq_enabled(true);
     Some(ProcessMode::InterruptDriven(CONSOLE_INPUT_SOURCE.clone()))
+}
+
+/// Fallback for platforms without a console IRQ (e.g. x86-qemu-q35).
+///
+/// Spawns a background task that wakes the reader every millisecond so that
+/// signal characters (Ctrl+C, Ctrl+Z, …) are delivered even when no process
+/// is blocked on a `read()` syscall.
+fn console_polling_mode() -> ProcessMode {
+    let source = Arc::new(PollSet::new());
+    let source_clone = source.clone();
+    ax_task::spawn_with_name(
+        move || loop {
+            source_clone.wake();
+            ax_task::sleep(Duration::from_millis(1));
+        },
+        "console-poll".into(),
+    );
+    ProcessMode::InterruptDriven(source)
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -3,7 +3,7 @@ use core::{
     future::poll_fn,
     marker::PhantomData,
     ops::Range,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
     task::{Poll, Waker},
 };
 
@@ -86,6 +86,10 @@ struct InputReader<R, W> {
     line_read: Option<usize>,
     eof_ready: Arc<AtomicBool>,
     clear_line_buf: Arc<AtomicBool>,
+
+    /// TIOCSTI: pending injected byte (true = valid byte in tiocsti_data).
+    tiocsti_byte: Arc<AtomicBool>,
+    tiocsti_data: Arc<AtomicU8>,
 }
 impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
     pub fn drain_source_into_line_buffer(&mut self) -> bool {
@@ -94,9 +98,16 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
         }
         let mut progressed = false;
         if self.read_range.is_empty() {
-            let read = self.reader.read(&mut self.read_buf);
-            self.read_range = 0..read;
-            progressed |= read > 0;
+            // Drain any TIOCSTI-injected byte first; fall back to the hardware reader.
+            if self.tiocsti_byte.swap(false, Ordering::AcqRel) {
+                self.read_buf[0] = self.tiocsti_data.load(Ordering::Acquire);
+                self.read_range = 0..1;
+                progressed = true;
+            } else {
+                let read = self.reader.read(&mut self.read_buf);
+                self.read_range = 0..read;
+                progressed |= read > 0;
+            }
         }
         let term = self.terminal.load_termios();
         let mut sent = 0;
@@ -245,6 +256,9 @@ pub struct LineDiscipline<R, W> {
     pump_retry: Arc<PollSet>,
     eof_ready: Arc<AtomicBool>,
     clear_line_buf: Arc<AtomicBool>,
+    /// TIOCSTI injection: set byte then flip the flag; reader picks it up on next drain.
+    tiocsti_byte: Arc<AtomicBool>,
+    tiocsti_data: Arc<AtomicU8>,
     processor: Processor<R>,
     _writer: PhantomData<W>,
 }
@@ -318,6 +332,8 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
         let eof_ready = Arc::new(AtomicBool::new(false));
         let clear_line_buf = Arc::new(AtomicBool::new(false));
+        let tiocsti_byte = Arc::new(AtomicBool::new(false));
+        let tiocsti_data = Arc::new(AtomicU8::new(0));
         let reader = InputReader {
             terminal: terminal.clone(),
 
@@ -332,6 +348,8 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             line_read: None,
             eof_ready: eof_ready.clone(),
             clear_line_buf: clear_line_buf.clone(),
+            tiocsti_byte: tiocsti_byte.clone(),
+            tiocsti_data: tiocsti_data.clone(),
         };
 
         let input_ready = Arc::new(PollSet::new());
@@ -365,8 +383,22 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             pump_retry,
             eof_ready,
             clear_line_buf,
+            tiocsti_byte,
+            tiocsti_data,
             processor,
             _writer: PhantomData,
+        }
+    }
+
+    /// Push a single byte into the line discipline as if it were typed at the keyboard.
+    ///
+    /// Only effective for `InterruptDriven` mode (N_TTY and PTY slave).
+    /// On PTY master (Passive) this is a no-op; inject via the master `write_at` instead.
+    pub fn tiocsti(&self, byte: u8) {
+        if matches!(self.processor, Processor::InterruptDriven) {
+            self.tiocsti_data.store(byte, Ordering::Relaxed);
+            self.tiocsti_byte.store(true, Ordering::Release);
+            self.pump_retry.clone().wake();
         }
     }
 
@@ -454,7 +486,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 #[cfg(test)]
 mod tests {
     use alloc::{sync::Arc, vec::Vec};
-    use core::sync::atomic::AtomicBool;
+    use core::sync::atomic::{AtomicBool, AtomicU8};
 
     use ringbuf::traits::{Observer, Split};
 
@@ -503,6 +535,8 @@ mod tests {
             line_read: None,
             eof_ready: Arc::new(AtomicBool::new(false)),
             clear_line_buf: Arc::new(AtomicBool::new(false)),
+            tiocsti_byte: Arc::new(AtomicBool::new(false)),
+            tiocsti_data: Arc::new(AtomicU8::new(0)),
         };
         (reader, buf_rx)
     }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -92,9 +92,11 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
         if self.clear_line_buf.swap(false, Ordering::Relaxed) {
             self.line_buf.clear();
         }
+        let mut progressed = false;
         if self.read_range.is_empty() {
             let read = self.reader.read(&mut self.read_buf);
             self.read_range = 0..read;
+            progressed |= read > 0;
         }
         let term = self.terminal.load_termios();
         let mut sent = 0;
@@ -117,6 +119,7 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
             }
             let mut ch = self.read_buf[self.read_range.start];
             self.read_range.start += 1;
+            progressed = true;
 
             if ch == b'\r' {
                 if term.has_iflag(IGNCR) {
@@ -176,7 +179,7 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
             }
         }
 
-        sent > 0
+        sent > 0 || progressed
     }
 
     fn check_send_signal(&self, term: &Termios2, ch: u8) -> bool {
@@ -445,5 +448,98 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         let read = self.buf_rx.pop_slice(buf);
         self.pump_retry.clone().wake();
         Ok(read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{sync::Arc, vec::Vec};
+    use core::sync::atomic::AtomicBool;
+
+    use ringbuf::traits::{Observer, Split};
+
+    use super::{BUF_SIZE, InputReader, ReadBuf, TtyRead, TtyWrite};
+    use crate::pseudofs::dev::tty::terminal::Terminal;
+
+    struct MockReader {
+        data: Vec<u8>,
+        pos: usize,
+    }
+    impl MockReader {
+        fn new(data: Vec<u8>) -> Self {
+            Self { data, pos: 0 }
+        }
+    }
+    impl TtyRead for MockReader {
+        fn read(&mut self, buf: &mut [u8]) -> usize {
+            let remaining = &self.data[self.pos..];
+            let n = remaining.len().min(buf.len());
+            buf[..n].copy_from_slice(&remaining[..n]);
+            self.pos += n;
+            n
+        }
+    }
+
+    struct MockWriter;
+    impl TtyWrite for MockWriter {
+        fn write(&self, _buf: &[u8]) {}
+    }
+
+    fn make_reader(
+        data: Vec<u8>,
+    ) -> (
+        InputReader<MockReader, MockWriter>,
+        ringbuf::CachingCons<ReadBuf>,
+    ) {
+        let (buf_tx, buf_rx) = ReadBuf::default().split();
+        let reader = InputReader {
+            terminal: Arc::new(Terminal::default()),
+            reader: MockReader::new(data),
+            writer: MockWriter,
+            buf_tx,
+            read_buf: [0; BUF_SIZE],
+            read_range: 0..0,
+            line_buf: Vec::new(),
+            line_read: None,
+            eof_ready: Arc::new(AtomicBool::new(false)),
+            clear_line_buf: Arc::new(AtomicBool::new(false)),
+        };
+        (reader, buf_rx)
+    }
+
+    /// Regression test: a canonical-mode input longer than BUF_SIZE characters
+    /// (with no newline in the first chunk) must not stall drain_source_into_line_buffer.
+    ///
+    /// Before the fix, the function returned `sent > 0` which was false after the
+    /// first BUF_SIZE bytes were consumed into line_buf (no newline yet), causing
+    /// drive_input() to stop looping and the remaining input (including the newline)
+    /// to be silently dropped.  The board CI symptom was shell commands being
+    /// truncated to the first BUF_SIZE characters (e.g. "sleep 5; ..." → "leep 5; ...").
+    #[test]
+    fn canonical_long_line_drain_continues_past_buf_size() {
+        // BUF_SIZE ordinary chars followed by '\n' — total BUF_SIZE+1 bytes.
+        let mut data: Vec<u8> = (0..BUF_SIZE).map(|_| b'a').collect();
+        data.push(b'\n');
+
+        let (mut reader, mut rx) = make_reader(data);
+
+        // First drain: reads the BUF_SIZE 'a' bytes into line_buf; no newline yet,
+        // so nothing reaches buf_rx.  Must still return true (progress was made).
+        assert!(
+            reader.drain_source_into_line_buffer(),
+            "first drain must return true even though buf_rx is still empty"
+        );
+        assert_eq!(
+            rx.occupied_len(),
+            0,
+            "buf_rx must remain empty before the newline is processed"
+        );
+
+        // Second drain: reads the '\n', completes the line, flushes to buf_rx.
+        reader.drain_source_into_line_buffer();
+        assert!(
+            rx.occupied_len() > 0,
+            "buf_rx must contain data after the newline is processed"
+        );
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -1,6 +1,7 @@
 use alloc::{sync::Arc, task::Wake, vec::Vec};
 use core::{
     future::poll_fn,
+    marker::PhantomData,
     ops::Range,
     sync::atomic::{AtomicBool, Ordering},
     task::{Poll, Waker},
@@ -27,13 +28,6 @@ type ReadBuf = Arc<ringbuf::StaticRb<u8, BUF_SIZE>>;
 
 /// How should we process inputs?
 pub enum ProcessMode {
-    /// Process inputs only on call to `read`
-    ///
-    /// This is the fallback strategy and is rather limited. For instance, you
-    /// can't interrupt a running program by Ctrl+C unless it's not blocked on a
-    /// `read` call to the terminal, since the signal is emitted only when
-    /// inputs are being processed.
-    Manual,
     /// Spawns task for processing inputs, relying on an external event source
     /// to wake it up.
     InterruptDriven(Arc<PollSet>),
@@ -236,8 +230,7 @@ impl<R: TtyRead> SimpleReader<R> {
     }
 }
 
-enum Processor<R, W> {
-    Manual(InputReader<R, W>),
+enum Processor<R> {
     InterruptDriven,
     Passive(SimpleReader<R>, Arc<PollSet>),
 }
@@ -249,7 +242,8 @@ pub struct LineDiscipline<R, W> {
     pump_retry: Arc<PollSet>,
     eof_ready: Arc<AtomicBool>,
     clear_line_buf: Arc<AtomicBool>,
-    processor: Processor<R, W>,
+    processor: Processor<R>,
+    _writer: PhantomData<W>,
 }
 
 struct WakeSignal {
@@ -340,7 +334,6 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         let input_ready = Arc::new(PollSet::new());
         let pump_retry = Arc::new(PollSet::new());
         let processor = match config.process_mode {
-            ProcessMode::Manual => Processor::Manual(reader),
             ProcessMode::InterruptDriven(input_source) => {
                 Self::spawn_interrupt_driven_reader(
                     reader,
@@ -370,6 +363,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             eof_ready,
             clear_line_buf,
             processor,
+            _writer: PhantomData,
         }
     }
 
@@ -380,12 +374,8 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
     }
 
     pub fn poll_read(&mut self) -> bool {
-        match &mut self.processor {
-            Processor::Manual(reader) => {
-                reader.drain_source_into_line_buffer();
-            }
-            Processor::Passive(reader, _) => reader.poll(),
-            _ => {}
+        if let Processor::Passive(reader, _) = &mut self.processor {
+            reader.poll();
         }
         let term = self.terminal.termios.lock().clone();
         if term.canonical() {
@@ -401,9 +391,6 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
     pub fn register_rx_waker(&self, waker: &Waker) {
         match &self.processor {
-            Processor::Manual(_) => {
-                waker.wake_by_ref();
-            }
             Processor::InterruptDriven => {
                 self.input_ready.register(waker);
             }
@@ -439,21 +426,6 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
         if buf.len() < vmin {
             return Err(AxError::WouldBlock);
-        }
-
-        let mut total_read = 0;
-        if let Processor::Manual(reader) = &mut self.processor {
-            loop {
-                reader.drain_source_into_line_buffer();
-                total_read += self.buf_rx.pop_slice(&mut buf[total_read..]);
-                if total_read >= vmin {
-                    return Ok(total_read);
-                }
-                if self.eof_ready.swap(false, Ordering::AcqRel) {
-                    return Ok(0);
-                }
-                ax_task::yield_now();
-            }
         }
 
         let available = self.buf_rx.occupied_len();

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/termios.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/termios.rs
@@ -6,7 +6,7 @@ use bytemuck::AnyBitPattern;
 use linux_raw_sys::general::{
     B38400, CREAD, CS8, ECHO, ECHOCTL, ECHOE, ECHOK, ECHOKE, ICANON, ICRNL, IEXTEN, ISIG, IXON,
     ONLCR, OPOST, VDISCARD, VEOF, VEOL, VEOL2, VERASE, VINTR, VKILL, VLNEXT, VQUIT, VREPRINT,
-    VWERASE, speed_t, tcflag_t,
+    VSUSP, VWERASE, speed_t, tcflag_t,
 };
 use starry_signal::Signo;
 
@@ -47,6 +47,7 @@ impl Default for Termios {
             (VWERASE, ctl(b'W')),
             (VLNEXT, ctl(b'V')),
             (VEOL2, b'\0'),
+            (VSUSP, ctl(b'Z')),
         ] {
             result.c_cc[i as usize] = ch;
         }
@@ -104,6 +105,7 @@ impl Termios {
         Some(match ch {
             ch if ch == self.special_char(VINTR) => Signo::SIGINT,
             ch if ch == self.special_char(VQUIT) => Signo::SIGQUIT,
+            ch if ch == self.special_char(VSUSP) => Signo::SIGTSTP,
             _ => return None,
         })
     }

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-tty-sigint C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-tty-sigint src/main.c)
+target_compile_options(bug-tty-sigint PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-tty-sigint RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/src/main.c
@@ -1,31 +1,34 @@
 /*
- * bug-tty-sigint: 验证 kill(-pgid, SIGINT/SIGTSTP) 正确传递给进程组。
+ * bug-tty-sigint: 通过 PTY 写入 0x03/0x1a 验证 TTY 控制字符路径。
  *
- * 背景：TTY 驱动检测到 Ctrl+C (0x03) / Ctrl+Z (0x1A) 后，调用
- * send_signal_to_process_group(pgid, SIGINT/SIGTSTP)。本测试直接
- * 验证该内核路径，作为 TTY 信号传递修复的复现用例。
+ * 本测试覆盖本 PR 修复的实际路径：
  *
- * 测试一：kill(-pgid, SIGINT) 终止前台阻塞进程
- *   子进程创建独立进程组，阻塞于 pause()；
- *   父进程向该进程组发 SIGINT；
- *   waitpid 后确认子进程因 SIGINT 终止。
+ *   write(master_fd, "\x03", 1)
+ *     → PtyWriter 写入 master_to_slave 缓冲区，唤醒 poll_rx_slave
+ *     → 从设备 InterruptDriven reader 任务唤醒
+ *     → drain_source_into_line_buffer() 读取 \x03
+ *     → check_send_signal() → signo_for(0x03) → SIGINT
+ *     → send_signal_to_process_group(pgid, SIGINT)
+ *     → 前台进程组收到 SIGINT
  *
- * 测试二：kill(-pgid, SIGTSTP) 传递到进程组（自定义处理函数）
- *   子进程创建独立进程组，安装 SIGTSTP 处理函数，阻塞于 pause()；
- *   父进程向该进程组发 SIGTSTP；
- *   子进程处理函数被调用后退出 0，否则退出 1。
+ * 同理 \x1a → SIGTSTP（覆盖本 PR 新增的 VSUSP 映射）。
+ *
+ * 如果将 polling 改回 Manual 模式、或删除 signo_for 中的 VINTR/VSUSP
+ * 映射，本测试将失败。
  */
 #define _GNU_SOURCE
 #include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
-static volatile sig_atomic_t got_sigtstp = 0;
-static void sigtstp_handler(int sig) { (void)sig; got_sigtstp = 1; }
+static volatile sig_atomic_t got_sig = 0;
+static void sig_handler(int s) { (void)s; got_sig = 1; }
 
 static void sleep_ms(long ms)
 {
@@ -33,56 +36,100 @@ static void sleep_ms(long ms)
     nanosleep(&ts, NULL);
 }
 
-/* ---- 测试一：SIGINT 终止进程组内阻塞进程 ---- */
-static int test_sigint_terminates_pgroup(void)
+/* 打开 PTY 对，返回 master_fd；通过 slave_path 返回从设备路径 */
+static int open_pty(char *slave_path, size_t len)
 {
-    printf("[test1] kill(-pgid, SIGINT) 应终止阻塞在 pause() 的子进程\n");
+    int master = open("/dev/ptmx", O_RDWR | O_NOCTTY);
+    if (master < 0) {
+        printf("FAIL: open /dev/ptmx: %s\n", strerror(errno));
+        return -1;
+    }
+    unsigned int pty_num = 0;
+    if (ioctl(master, TIOCGPTN, &pty_num) != 0) {
+        printf("FAIL: TIOCGPTN: %s\n", strerror(errno));
+        close(master);
+        return -1;
+    }
+    snprintf(slave_path, len, "/dev/pts/%u", pty_num);
+    return master;
+}
 
-    int sync[2];
-    if (pipe(sync) != 0) {
-        printf("FAIL: pipe: %s\n", strerror(errno));
+/* ---- 测试一：PTY master 写入 \x03 → 从设备前台进程收到 SIGINT ---- */
+static int test_pty_ctrl_c(void)
+{
+    printf("[test1] PTY: write(master, \\x03) 应通过行规程发送 SIGINT\n");
+
+    char slave_path[64];
+    int master = open_pty(slave_path, sizeof(slave_path));
+    if (master < 0) return 1;
+
+    int slave = open(slave_path, O_RDWR | O_NOCTTY);
+    if (slave < 0) {
+        printf("FAIL: open %s: %s\n", slave_path, strerror(errno));
+        close(master);
         return 1;
     }
+
+    int sync[2];
+    if (pipe(sync) != 0) { close(master); close(slave); return 1; }
 
     pid_t child = fork();
     if (child < 0) {
         printf("FAIL: fork: %s\n", strerror(errno));
+        close(master); close(slave); close(sync[0]); close(sync[1]);
         return 1;
     }
 
     if (child == 0) {
-        /* 子进程：建立独立进程组 */
+        close(master);
         close(sync[0]);
-        if (setpgid(0, 0) != 0) {
+
+        /*
+         * 创建新会话并将从设备设为控制终端。
+         * TIOCSCTTY → bind_to() → set_session() + set_foreground(当前进程组)
+         * 此后当行规程检测到 VINTR 时，会向该前台进程组发 SIGINT。
+         */
+        if (setsid() < 0) { write(sync[1], "E", 1); _exit(99); }
+        if (ioctl(slave, TIOCSCTTY, 0) != 0) {
             write(sync[1], "E", 1);
             _exit(99);
         }
+        close(slave);
+
         write(sync[1], "R", 1);
         close(sync[1]);
-        pause(); /* 阻塞，等待信号 */
+
+        /* 阻塞；SIGINT 默认动作为终止进程 */
+        pause();
         _exit(0); /* 不应到达 */
     }
 
     /* 父进程 */
+    close(slave);
     close(sync[1]);
     char buf;
     if (read(sync[0], &buf, 1) != 1 || buf != 'R') {
-        printf("FAIL: 子进程未就绪\n");
-        kill(child, SIGKILL);
-        waitpid(child, NULL, 0);
+        printf("FAIL: 子进程未就绪 (buf=%c)\n", buf);
+        kill(child, SIGKILL); waitpid(child, NULL, 0);
+        close(master); close(sync[0]);
         return 1;
     }
     close(sync[0]);
 
-    sleep_ms(100); /* 确保子进程进入 pause() */
+    sleep_ms(150); /* 确保子进程进入 pause() */
 
-    /* 向子进程的进程组发 SIGINT（与 TTY Ctrl+C 路径相同） */
-    if (kill(-child, SIGINT) != 0) {
-        printf("FAIL: kill(-pgid, SIGINT): %s\n", strerror(errno));
-        kill(child, SIGKILL);
-        waitpid(child, NULL, 0);
+    /*
+     * 写入 Ctrl+C (0x03) 到 PTY master。
+     * master 的 write_at 以 is_ptm=true 直接写入 master_to_slave 缓冲区，
+     * 唤醒从设备 InterruptDriven reader，触发 check_send_signal → SIGINT。
+     */
+    if (write(master, "\x03", 1) != 1) {
+        printf("FAIL: write \\x03 to master: %s\n", strerror(errno));
+        kill(child, SIGKILL); waitpid(child, NULL, 0);
+        close(master);
         return 1;
     }
+    close(master);
 
     int status = 0;
     if (waitpid(child, &status, 0) != child) {
@@ -91,76 +138,97 @@ static int test_sigint_terminates_pgroup(void)
     }
 
     if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT) {
-        printf("PASS: 子进程因 SIGINT 终止\n");
+        printf("PASS: PTY 行规程正确将 \\x03 转换为 SIGINT 并终止前台进程\n");
         return 0;
     }
-    if (WIFEXITED(status)) {
-        printf("FAIL: 子进程正常退出 (code=%d)，应被 SIGINT 终止\n",
+    if (WIFEXITED(status))
+        printf("FAIL: 子进程正常退出 code=%d，期望被 SIGINT 终止\n",
                WEXITSTATUS(status));
-    } else {
+    else
         printf("FAIL: 子进程被信号 %d 终止，期望 SIGINT(%d)\n",
                WTERMSIG(status), SIGINT);
-    }
     return 1;
 }
 
-/* ---- 测试二：SIGTSTP 传递到进程组（自定义处理函数） ---- */
-static int test_sigtstp_delivered_to_pgroup(void)
+/* ---- 测试二：PTY master 写入 \x1a → 从设备前台进程收到 SIGTSTP ---- */
+static int test_pty_ctrl_z(void)
 {
-    printf("[test2] kill(-pgid, SIGTSTP) 应传递到进程组内阻塞进程\n");
+    printf("[test2] PTY: write(master, \\x1a) 应通过行规程发送 SIGTSTP\n");
 
-    int sync[2];
-    if (pipe(sync) != 0) {
-        printf("FAIL: pipe: %s\n", strerror(errno));
+    char slave_path[64];
+    int master = open_pty(slave_path, sizeof(slave_path));
+    if (master < 0) return 1;
+
+    int slave = open(slave_path, O_RDWR | O_NOCTTY);
+    if (slave < 0) {
+        printf("FAIL: open %s: %s\n", slave_path, strerror(errno));
+        close(master);
         return 1;
     }
+
+    int sync[2];
+    if (pipe(sync) != 0) { close(master); close(slave); return 1; }
 
     pid_t child = fork();
     if (child < 0) {
         printf("FAIL: fork: %s\n", strerror(errno));
+        close(master); close(slave); close(sync[0]); close(sync[1]);
         return 1;
     }
 
     if (child == 0) {
+        close(master);
         close(sync[0]);
-        if (setpgid(0, 0) != 0) {
+
+        if (setsid() < 0) { write(sync[1], "E", 1); _exit(99); }
+        if (ioctl(slave, TIOCSCTTY, 0) != 0) {
             write(sync[1], "E", 1);
             _exit(99);
         }
+        close(slave);
 
-        /* 安装 SIGTSTP 处理函数（不使用默认的 Stop 动作） */
+        /*
+         * 安装自定义 SIGTSTP 处理函数（覆盖默认 Stop 动作），
+         * 验证信号确实经行规程投递。
+         */
         struct sigaction sa = {0};
-        sa.sa_handler = sigtstp_handler;
+        sa.sa_handler = sig_handler;
         sigemptyset(&sa.sa_mask);
         sigaction(SIGTSTP, &sa, NULL);
+        got_sig = 0;
 
         write(sync[1], "R", 1);
         close(sync[1]);
 
-        pause(); /* 等待 SIGTSTP */
-
-        /* 处理函数被调用后 pause() 返回 -1/EINTR */
-        _exit(got_sigtstp ? 0 : 1);
+        pause(); /* 等待 SIGTSTP；处理函数返回后 pause() 以 EINTR 返回 */
+        _exit(got_sig ? 0 : 1);
     }
 
+    close(slave);
     close(sync[1]);
     char buf;
     if (read(sync[0], &buf, 1) != 1 || buf != 'R') {
         printf("FAIL: 子进程未就绪\n");
-        kill(child, SIGKILL);
-        waitpid(child, NULL, 0);
+        kill(child, SIGKILL); waitpid(child, NULL, 0);
+        close(master); close(sync[0]);
         return 1;
     }
     close(sync[0]);
 
-    sleep_ms(100);
+    sleep_ms(150);
 
-    if (kill(-child, SIGTSTP) != 0) {
-        printf("FAIL: kill(-pgid, SIGTSTP): %s\n", strerror(errno));
-        kill(child, SIGKILL);
-        waitpid(child, NULL, 0);
+    /*
+     * 写入 Ctrl+Z (0x1a) 到 PTY master。
+     * 行规程: check_send_signal → signo_for(0x1a=VSUSP) → SIGTSTP
+     * （覆盖本 PR 新增的 VSUSP → Signo::SIGTSTP 映射）
+     */
+    if (write(master, "\x1a", 1) != 1) {
+        printf("FAIL: write \\x1a to master: %s\n", strerror(errno));
+        kill(child, SIGKILL); waitpid(child, NULL, 0);
+        close(master);
         return 1;
     }
+    close(master);
 
     int status = 0;
     if (waitpid(child, &status, 0) != child) {
@@ -169,25 +237,25 @@ static int test_sigtstp_delivered_to_pgroup(void)
     }
 
     if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
-        printf("PASS: 子进程收到 SIGTSTP 并正常退出\n");
+        printf("PASS: PTY 行规程正确将 \\x1a 转换为 SIGTSTP 并投递到前台进程\n");
         return 0;
     }
-    if (WIFEXITED(status)) {
-        printf("FAIL: 子进程退出 code=%d（未收到 SIGTSTP？）\n",
+    if (WIFEXITED(status))
+        printf("FAIL: 子进程退出 code=%d（未收到 SIGTSTP 或信号映射缺失）\n",
                WEXITSTATUS(status));
-    } else {
-        printf("FAIL: 子进程被信号 %d 终止\n", WTERMSIG(status));
-    }
+    else
+        printf("FAIL: 子进程被信号 %d 终止，期望 SIGTSTP 由自定义处理函数捕获\n",
+               WTERMSIG(status));
     return 1;
 }
 
 int main(void)
 {
     printf("=== bug-tty-sigint ===\n");
-    printf("验证 kill(-pgid) 信号传递路径（TTY Ctrl+C/Ctrl+Z 修复复现）\n\n");
+    printf("通过 PTY 验证 TTY 行规程控制字符 → 信号路径\n\n");
 
-    int r1 = test_sigint_terminates_pgroup();
-    int r2 = test_sigtstp_delivered_to_pgroup();
+    int r1 = test_pty_ctrl_c();
+    int r2 = test_pty_ctrl_z();
 
     printf("\n");
     if (r1 == 0 && r2 == 0) {

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/src/main.c
@@ -1,20 +1,26 @@
 /*
- * bug-tty-sigint: 通过 PTY 写入 0x03/0x1a 验证 TTY 控制字符路径。
+ * bug-tty-sigint: TTY 行规程控制字符路径回归测试。
  *
- * 本测试覆盖本 PR 修复的实际路径：
+ * 覆盖三个独立的修复点：
  *
- *   write(master_fd, "\x03", 1)
+ * 测试 1/2 — PTY 路径（验证 ldisc 信号投递 + termios.rs 的 VSUSP 映射）：
+ *   write(master_fd, "\x03"/"\x1a", 1)
  *     → PtyWriter 写入 master_to_slave 缓冲区，唤醒 poll_rx_slave
  *     → 从设备 InterruptDriven reader 任务唤醒
- *     → drain_source_into_line_buffer() 读取 \x03
- *     → check_send_signal() → signo_for(0x03) → SIGINT
- *     → send_signal_to_process_group(pgid, SIGINT)
- *     → 前台进程组收到 SIGINT
+ *     → drain_source_into_line_buffer() 读取控制字符
+ *     → check_send_signal() → signo_for() → SIGINT / SIGTSTP
+ *     → send_signal_to_process_group(pgid, ...)
  *
- * 同理 \x1a → SIGTSTP（覆盖本 PR 新增的 VSUSP 映射）。
+ *   注：这两条用例走 pty.rs 中已有的 InterruptDriven 路径，
+ *   不直接覆盖 ntty.rs 的 console_polling_mode() fallback，
+ *   但确保 ldisc 信号投递逻辑（两条路径共用）和 VSUSP 映射正确。
  *
- * 如果将 polling 改回 Manual 模式、或删除 signo_for 中的 VINTR/VSUSP
- * 映射，本测试将失败。
+ * 测试 3 — N_TTY console 路径（验证 console_polling_mode + TIOCSTI）：
+ *   通过 /dev/tty（N_TTY）使用 TIOCSTI 注入 0x03，
+ *   验证后台 polling reader 任务将其经行规程转换为 SIGINT 并投递到
+ *   前台进程组（即本进程自身）。
+ *   若 console_polling_mode() 未生效（无后台 reader 任务），
+ *   TIOCSTI 注入的字节将永远不会被处理，测试将超时失败。
  */
 #define _GNU_SOURCE
 #include <errno.h>
@@ -57,7 +63,7 @@ static int open_pty(char *slave_path, size_t len)
 /* ---- 测试一：PTY master 写入 \x03 → 从设备前台进程收到 SIGINT ---- */
 static int test_pty_ctrl_c(void)
 {
-    printf("[test1] PTY: write(master, \\x03) 应通过行规程发送 SIGINT\n");
+    printf("[test1] PTY ldisc: write(master, \\x03) 应通过行规程发送 SIGINT\n");
 
     char slave_path[64];
     int master = open_pty(slave_path, sizeof(slave_path));
@@ -153,7 +159,7 @@ static int test_pty_ctrl_c(void)
 /* ---- 测试二：PTY master 写入 \x1a → 从设备前台进程收到 SIGTSTP ---- */
 static int test_pty_ctrl_z(void)
 {
-    printf("[test2] PTY: write(master, \\x1a) 应通过行规程发送 SIGTSTP\n");
+    printf("[test2] PTY ldisc: write(master, \\x1a) 应通过行规程发送 SIGTSTP\n");
 
     char slave_path[64];
     int master = open_pty(slave_path, sizeof(slave_path));
@@ -189,7 +195,7 @@ static int test_pty_ctrl_z(void)
 
         /*
          * 安装自定义 SIGTSTP 处理函数（覆盖默认 Stop 动作），
-         * 验证信号确实经行规程投递。
+         * 验证信号确实经行规程投递（覆盖 termios.rs 新增的 VSUSP 映射）。
          */
         struct sigaction sa = {0};
         sa.sa_handler = sig_handler;
@@ -220,7 +226,6 @@ static int test_pty_ctrl_z(void)
     /*
      * 写入 Ctrl+Z (0x1a) 到 PTY master。
      * 行规程: check_send_signal → signo_for(0x1a=VSUSP) → SIGTSTP
-     * （覆盖本 PR 新增的 VSUSP → Signo::SIGTSTP 映射）
      */
     if (write(master, "\x1a", 1) != 1) {
         printf("FAIL: write \\x1a to master: %s\n", strerror(errno));
@@ -241,7 +246,7 @@ static int test_pty_ctrl_z(void)
         return 0;
     }
     if (WIFEXITED(status))
-        printf("FAIL: 子进程退出 code=%d（未收到 SIGTSTP 或信号映射缺失）\n",
+        printf("FAIL: 子进程退出 code=%d（未收到 SIGTSTP 或 VSUSP 映射缺失）\n",
                WEXITSTATUS(status));
     else
         printf("FAIL: 子进程被信号 %d 终止，期望 SIGTSTP 由自定义处理函数捕获\n",
@@ -249,16 +254,87 @@ static int test_pty_ctrl_z(void)
     return 1;
 }
 
+/*
+ * ---- 测试三：N_TTY console 路径 ——————————————————————————————————————
+ *
+ * 通过 /dev/tty（N_TTY 设备）使用 TIOCSTI 向 console 行规程注入 0x03，
+ * 验证后台 console_polling_mode() reader 任务将其转换为 SIGINT 并投递到
+ * 前台进程组（本进程）。
+ *
+ * 若 ntty.rs 的 console_polling_mode() 被回退（平台无 console IRQ 时无
+ * 后台 reader 任务），TIOCSTI 注入的字节永远不会被 drain_source_into_line_buffer()
+ * 消费，SIGINT 不会到来，本测试将超时后以 FAIL 返回。
+ */
+#ifndef TIOCSTI
+#define TIOCSTI 0x5412
+#endif
+
+static volatile sig_atomic_t got_sigint = 0;
+static void catch_sigint(int s) { (void)s; got_sigint = 1; }
+
+static int test_console_ntty_ctrl_c(void)
+{
+    printf("[test3] N_TTY console: TIOCSTI(\\x03) 应经行规程投递 SIGINT\n");
+
+    int tty = open("/dev/tty", O_RDWR | O_NOCTTY);
+    if (tty < 0) {
+        printf("[test3] SKIP: open /dev/tty: %s\n", strerror(errno));
+        return 0;
+    }
+
+    /*
+     * 确保本进程组是 N_TTY 的前台进程组，以便信号投递到此处。
+     * TIOCSPGRP 失败时继续（可能已经是前台进程组）。
+     */
+    pid_t mypgid = getpgrp();
+    ioctl(tty, TIOCSPGRP, &mypgid);
+
+    struct sigaction sa_new = {0}, sa_old;
+    sa_new.sa_handler = catch_sigint;
+    sigemptyset(&sa_new.sa_mask);
+    sigaction(SIGINT, &sa_new, &sa_old);
+    got_sigint = 0;
+
+    /*
+     * 向 N_TTY 输入队列注入 Ctrl+C (0x03)。
+     * TIOCSTI → ldisc.tiocsti() → tiocsti_byte 标志位置位 + pump_retry 唤醒
+     *   → 后台 InterruptDriven reader 任务唤醒
+     *   → drain_source_into_line_buffer() 取出注入字节
+     *   → check_send_signal() → SIGINT → 前台进程组收到信号
+     */
+    char ctrl_c = 0x03;
+    if (ioctl(tty, TIOCSTI, &ctrl_c) != 0) {
+        printf("[test3] FAIL: TIOCSTI: %s\n", strerror(errno));
+        sigaction(SIGINT, &sa_old, NULL);
+        close(tty);
+        return 1;
+    }
+
+    /* 等待后台 reader 任务（最多 1ms polling 周期 + 调度延迟）处理注入字节 */
+    sleep_ms(200);
+
+    sigaction(SIGINT, &sa_old, NULL);
+    close(tty);
+
+    if (got_sigint) {
+        printf("PASS: N_TTY 行规程通过 TIOCSTI 正确投递 SIGINT（console_polling_mode 生效）\n");
+        return 0;
+    }
+    printf("FAIL: N_TTY 行规程未投递 SIGINT（console_polling_mode 可能未生效）\n");
+    return 1;
+}
+
 int main(void)
 {
     printf("=== bug-tty-sigint ===\n");
-    printf("通过 PTY 验证 TTY 行规程控制字符 → 信号路径\n\n");
+    printf("验证 TTY 行规程控制字符信号投递（PTY 路径 + N_TTY console 路径）\n\n");
 
     int r1 = test_pty_ctrl_c();
     int r2 = test_pty_ctrl_z();
+    int r3 = test_console_ntty_ctrl_c();
 
     printf("\n");
-    if (r1 == 0 && r2 == 0) {
+    if (r1 == 0 && r2 == 0 && r3 == 0) {
         printf("TEST PASSED\n");
         return 0;
     }

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/src/main.c
@@ -1,0 +1,199 @@
+/*
+ * bug-tty-sigint: 验证 kill(-pgid, SIGINT/SIGTSTP) 正确传递给进程组。
+ *
+ * 背景：TTY 驱动检测到 Ctrl+C (0x03) / Ctrl+Z (0x1A) 后，调用
+ * send_signal_to_process_group(pgid, SIGINT/SIGTSTP)。本测试直接
+ * 验证该内核路径，作为 TTY 信号传递修复的复现用例。
+ *
+ * 测试一：kill(-pgid, SIGINT) 终止前台阻塞进程
+ *   子进程创建独立进程组，阻塞于 pause()；
+ *   父进程向该进程组发 SIGINT；
+ *   waitpid 后确认子进程因 SIGINT 终止。
+ *
+ * 测试二：kill(-pgid, SIGTSTP) 传递到进程组（自定义处理函数）
+ *   子进程创建独立进程组，安装 SIGTSTP 处理函数，阻塞于 pause()；
+ *   父进程向该进程组发 SIGTSTP；
+ *   子进程处理函数被调用后退出 0，否则退出 1。
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got_sigtstp = 0;
+static void sigtstp_handler(int sig) { (void)sig; got_sigtstp = 1; }
+
+static void sleep_ms(long ms)
+{
+    struct timespec ts = { ms / 1000, (ms % 1000) * 1000000L };
+    nanosleep(&ts, NULL);
+}
+
+/* ---- 测试一：SIGINT 终止进程组内阻塞进程 ---- */
+static int test_sigint_terminates_pgroup(void)
+{
+    printf("[test1] kill(-pgid, SIGINT) 应终止阻塞在 pause() 的子进程\n");
+
+    int sync[2];
+    if (pipe(sync) != 0) {
+        printf("FAIL: pipe: %s\n", strerror(errno));
+        return 1;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        printf("FAIL: fork: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (child == 0) {
+        /* 子进程：建立独立进程组 */
+        close(sync[0]);
+        if (setpgid(0, 0) != 0) {
+            write(sync[1], "E", 1);
+            _exit(99);
+        }
+        write(sync[1], "R", 1);
+        close(sync[1]);
+        pause(); /* 阻塞，等待信号 */
+        _exit(0); /* 不应到达 */
+    }
+
+    /* 父进程 */
+    close(sync[1]);
+    char buf;
+    if (read(sync[0], &buf, 1) != 1 || buf != 'R') {
+        printf("FAIL: 子进程未就绪\n");
+        kill(child, SIGKILL);
+        waitpid(child, NULL, 0);
+        return 1;
+    }
+    close(sync[0]);
+
+    sleep_ms(100); /* 确保子进程进入 pause() */
+
+    /* 向子进程的进程组发 SIGINT（与 TTY Ctrl+C 路径相同） */
+    if (kill(-child, SIGINT) != 0) {
+        printf("FAIL: kill(-pgid, SIGINT): %s\n", strerror(errno));
+        kill(child, SIGKILL);
+        waitpid(child, NULL, 0);
+        return 1;
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        printf("FAIL: waitpid: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT) {
+        printf("PASS: 子进程因 SIGINT 终止\n");
+        return 0;
+    }
+    if (WIFEXITED(status)) {
+        printf("FAIL: 子进程正常退出 (code=%d)，应被 SIGINT 终止\n",
+               WEXITSTATUS(status));
+    } else {
+        printf("FAIL: 子进程被信号 %d 终止，期望 SIGINT(%d)\n",
+               WTERMSIG(status), SIGINT);
+    }
+    return 1;
+}
+
+/* ---- 测试二：SIGTSTP 传递到进程组（自定义处理函数） ---- */
+static int test_sigtstp_delivered_to_pgroup(void)
+{
+    printf("[test2] kill(-pgid, SIGTSTP) 应传递到进程组内阻塞进程\n");
+
+    int sync[2];
+    if (pipe(sync) != 0) {
+        printf("FAIL: pipe: %s\n", strerror(errno));
+        return 1;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        printf("FAIL: fork: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (child == 0) {
+        close(sync[0]);
+        if (setpgid(0, 0) != 0) {
+            write(sync[1], "E", 1);
+            _exit(99);
+        }
+
+        /* 安装 SIGTSTP 处理函数（不使用默认的 Stop 动作） */
+        struct sigaction sa = {0};
+        sa.sa_handler = sigtstp_handler;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGTSTP, &sa, NULL);
+
+        write(sync[1], "R", 1);
+        close(sync[1]);
+
+        pause(); /* 等待 SIGTSTP */
+
+        /* 处理函数被调用后 pause() 返回 -1/EINTR */
+        _exit(got_sigtstp ? 0 : 1);
+    }
+
+    close(sync[1]);
+    char buf;
+    if (read(sync[0], &buf, 1) != 1 || buf != 'R') {
+        printf("FAIL: 子进程未就绪\n");
+        kill(child, SIGKILL);
+        waitpid(child, NULL, 0);
+        return 1;
+    }
+    close(sync[0]);
+
+    sleep_ms(100);
+
+    if (kill(-child, SIGTSTP) != 0) {
+        printf("FAIL: kill(-pgid, SIGTSTP): %s\n", strerror(errno));
+        kill(child, SIGKILL);
+        waitpid(child, NULL, 0);
+        return 1;
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        printf("FAIL: waitpid: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        printf("PASS: 子进程收到 SIGTSTP 并正常退出\n");
+        return 0;
+    }
+    if (WIFEXITED(status)) {
+        printf("FAIL: 子进程退出 code=%d（未收到 SIGTSTP？）\n",
+               WEXITSTATUS(status));
+    } else {
+        printf("FAIL: 子进程被信号 %d 终止\n", WTERMSIG(status));
+    }
+    return 1;
+}
+
+int main(void)
+{
+    printf("=== bug-tty-sigint ===\n");
+    printf("验证 kill(-pgid) 信号传递路径（TTY Ctrl+C/Ctrl+Z 修复复现）\n\n");
+
+    int r1 = test_sigint_terminates_pgroup();
+    int r2 = test_sigtstp_delivered_to_pgroup();
+
+    printf("\n");
+    if (r1 == 0 && r2 == 0) {
+        printf("TEST PASSED\n");
+        return 0;
+    }
+    printf("TEST FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -27,6 +27,7 @@ test_commands = [
     "/usr/bin/bug-preadv2-offset-neg1",
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
+    "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -29,6 +29,7 @@ test_commands = [
     "/usr/bin/bug-preadv2-offset-neg1",
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
+    "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -33,6 +33,7 @@ test_commands = [
     "/usr/bin/bug-preadv2-offset-neg1",
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
+    "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-wait4-invalid-options",
     "/usr/bin/bug-writev-dir-ebadf",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -26,6 +26,7 @@ test_commands = [
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
     "/usr/bin/bug-tmpfs-cwd-drop-safe",
+    "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",


### PR DESCRIPTION


### 问题描述

在 x86_64 QEMU 环境下，对正在运行的前台进程（如 `apk add vim`）按 **Ctrl+C** 完全无效，进程无法被中断，只能强杀 QEMU 进程。

---

### 根本原因

两个独立缺陷共同导致：

#### 缺陷一：x86 平台无控制台 IRQ，导致信号字符永远不被处理

x86-qemu-q35 平台的控制台 IRQ 未实现（`irq_num()` 返回 `None`），TTY 驱动因此退化为 `ProcessMode::Manual`。在 Manual 模式下，键盘输入（包括 **Ctrl+C**）仅在进程主动调用 `read()` 时才被扫描。当 `apk` 正在执行网络下载/解包等操作时，它不会读终端，**Ctrl+C** 字节就永远留在缓冲区而被忽略。

#### 缺陷二：VSUSP（Ctrl+Z）信号映射缺失

`signo_for()` 只映射了 `VINTR→SIGINT` 和 `VQUIT→SIGQUIT`，`VSUSP→SIGTSTP` 未实现。同时默认 `termios.c_cc` 表中也未设置 `VSUSP` 的默认值（Ctrl+Z = 0x1A），导致 **Ctrl+Z** 挂起前台进程的功能完全失效。

---

### 修复方案

#### `ntty.rs`：当平台不提供控制台 IRQ 时，不再退化到 Manual 模式，而是启动一个名为 `console-poll` 的后台任务，每 1ms 唤醒一次 `InterruptDriven` reader。

这样信号字符的处理延迟最大为 1ms，与是否有进程在 `read()` 无关。

- **原来**：`irq_num() = None → ProcessMode::Manual → 信号字符仅在 read() 时处理`
- **现在**：`irq_num() = None → ProcessMode::InterruptDriven + 1ms 轮询任务`

#### `termios.rs`：
- 默认 `c_cc` 表补充 `VSUSP = Ctrl+Z（0x1A）`
- `signo_for()` 补充 `VSUSP → Signo::SIGTSTP`

---

### 影响范围

| 平台 | 修复前 | 修复后 |
|:---|:---|:---|
| x86_64 QEMU (q35) | Ctrl+C 无效，Ctrl+Z 无效 | Ctrl+C 在 ≤1ms 内生效，Ctrl+Z 正常挂起 |
| riscv64 QEMU (有 IRQ) | Ctrl+C 正常，Ctrl+Z 无效 | Ctrl+C 正常，Ctrl+Z 正常挂起 |
| aarch64 (有 IRQ) | Ctrl+C 正常，Ctrl+Z 无效 | Ctrl+C 正常，Ctrl+Z 正常挂起 |

---

### 与 Linux 的对齐

Linux N-TTY 在串口 IRQ handler 上下文中直接处理信号字符，不依赖进程是否在 `read()`。本修复在无 IRQ 环境下通过轮询任务达到等效效果。`VSUSP` 的默认值和行为与 Linux `stty -a` 输出一致。

---

### 变更文件

- `os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs`
- `os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/termios.rs`