### PR TITLE
fix(loop/mount): chunked block cache, full lo_flags, fd-based EBUSY

### DIFF
--- a/components/axfs-ng-vfs/src/mount.rs
+++ b/components/axfs-ng-vfs/src/mount.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    borrow::Cow,
     string::String,
     sync::{Arc, Weak},
     vec,
@@ -23,8 +24,8 @@ use crate::{
 pub struct Mountpoint {
     /// Root dir entry in the mountpoint.
     root: DirEntry,
-    /// Location in the parent mountpoint.
-    location: Option<Location>,
+    /// Location in the parent mountpoint. `None` for the global root mount.
+    location: Mutex<Option<Location>>,
     /// Children of the mountpoint.
     children: Mutex<HashMap<ReferenceKey, Weak<Self>>>,
     /// Device ID
@@ -38,7 +39,7 @@ impl Mountpoint {
         let root = fs.root_dir();
         Arc::new(Self {
             root,
-            location: location_in_parent,
+            location: Mutex::new(location_in_parent),
             children: Mutex::default(),
             device: DEVICE_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
@@ -54,11 +55,55 @@ impl Mountpoint {
 
     /// Returns the location in the parent mountpoint.
     pub fn location(&self) -> Option<Location> {
-        self.location.clone()
+        self.location.lock().clone()
     }
 
     pub fn is_root(&self) -> bool {
-        self.location.is_none()
+        self.location.lock().is_none()
+    }
+
+    /// Pivot the mount tree: the old root (`self`) is detached and re-attached
+    /// at `put_old` under `new_root_mp`, which becomes the global root.
+    ///
+    /// This implements the mount-tree portion of Linux `pivot_root(2)`.
+    pub fn pivot_mount(
+        self: &Arc<Self>,        // old root mountpoint
+        new_root_mp: &Arc<Self>, // new root mountpoint
+        put_old: &Location,      // directory under new_root_mp where old root goes
+    ) -> VfsResult<()> {
+        // put_old must belong to the new root's mountpoint tree.
+        if !Arc::ptr_eq(put_old.mountpoint(), new_root_mp) {
+            return Err(VfsError::InvalidInput);
+        }
+        // put_old must be a directory and not already a mountpoint.
+        put_old.check_is_dir()?;
+        if put_old.is_mountpoint() {
+            return Err(VfsError::ResourceBusy);
+        }
+
+        // 1. Detach new_root from old root's children and clear the old mount
+        //    slot (where new_root was attached in the old root).
+        {
+            let mut new_root_loc = new_root_mp.location.lock();
+            if let Some(ref old_loc) = *new_root_loc {
+                self.children.lock().remove(&old_loc.entry.key());
+                *old_loc.entry.as_dir()?.mountpoint.lock() = None;
+            }
+            // new_root becomes the global root.
+            *new_root_loc = None;
+        }
+
+        // 2. Attach old root at put_old under new_root.
+        {
+            *put_old.entry.as_dir()?.mountpoint.lock() = Some(self.clone());
+            new_root_mp
+                .children
+                .lock()
+                .insert(put_old.entry.key(), Arc::downgrade(self));
+            *self.location.lock() = Some(put_old.clone());
+        }
+
+        Ok(())
     }
 
     /// Returns the effective mountpoint.
@@ -133,11 +178,21 @@ impl Location {
         &self.entry
     }
 
-    pub fn name(&self) -> &str {
+    /// Returns the entry name.
+    ///
+    /// For mount roots the name is derived from the parent location (where this
+    /// mount was attached). Because `location` lives behind a `Mutex`, the
+    /// mount-root case returns an owned `Cow::Owned`; the common non-root case
+    /// returns a borrowed `Cow::Borrowed`.
+    pub fn name(&self) -> Cow<'_, str> {
         if self.is_root_of_mount() {
-            self.mountpoint.location.as_ref().map_or("", Location::name)
+            self.mountpoint
+                .location
+                .lock()
+                .as_ref()
+                .map_or(Cow::Borrowed(""), |loc| Cow::Owned(loc.name().into_owned()))
         } else {
-            self.entry.name()
+            Cow::Borrowed(self.entry.name())
         }
     }
 
@@ -281,8 +336,16 @@ impl Location {
             return Err(VfsError::ResourceBusy);
         }
         assert!(self.entry.ptr_eq(&self.mountpoint.root));
+
+        // Flush filesystem metadata (superblock, bitmaps, etc.) to the
+        // backing block device before tearing down the mount.  For ext4
+        // this writes a clean superblock so the next mount does not see
+        // s_state = ERROR_FS.  For tmpfs/ramfs the default flush is a
+        // no-op.
+        self.filesystem().flush()?;
+
         self.entry.as_dir()?.forget();
-        if let Some(parent_loc) = &self.mountpoint.location {
+        if let Some(parent_loc) = self.mountpoint.location.lock().as_ref() {
             *parent_loc.entry.as_dir()?.mountpoint.lock() = None;
         }
         Ok(())

--- a/components/rsext4/src/ext4/mount.rs
+++ b/components/rsext4/src/ext4/mount.rs
@@ -226,6 +226,13 @@ impl Ext4FileSystem {
                     fs.clear_recovery_state();
                 }
             }
+            // If the filesystem was created without a journal (e.g. small images
+            // where mkfs.ext4 omits it), disable journal_use so that metadata
+            // writes bypass the journal path instead of hitting the
+            // "system uninitialized" guard on every write.
+            if !fs.superblock.has_journal() {
+                block_dev.set_journal_use(false);
+            }
         }
 
         // rootinode check !

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -16,6 +16,7 @@ license.workspace = true
 [features]
 default = ["dynamic_debug"]
 dev-log = []
+ext4 = ["ax-fs/ext4"]
 input = ["dep:ax-input", "ax-feat/input"]
 memtrack = ["ax-feat/dwarf", "ax-alloc/tracking", "dep:gimli"]
 rknpu = ["dep:axplat-dyn", "axplat-dyn/rknpu"]

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -29,7 +29,7 @@ pub fn init(args: &[String], envs: &[String]) {
     let path = loc
         .absolute_path()
         .expect("Failed to get executable absolute path");
-    let name = loc.name();
+    let name = loc.name().into_owned();
 
     let mut uspace = new_user_aspace_empty()
         .and_then(|mut it| {
@@ -42,7 +42,7 @@ pub fn init(args: &[String], envs: &[String]) {
         .unwrap_or_else(|e| panic!("Failed to load user app: {}", e));
 
     let uctx = UserContext::new(entry_vaddr.into(), ustack_top, 0);
-    let mut task = new_user_task(name, uctx, 0);
+    let mut task = new_user_task(&name, uctx, 0);
     task.ctx_mut().set_page_table_root(uspace.page_table_root());
 
     let pid = task.id().as_u64() as Pid;

--- a/os/StarryOS/kernel/src/pseudofs/dev/loop.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/loop.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ext4")]
+use alloc::{boxed::Box, sync::Arc};
 use core::{
     any::Any,
     sync::atomic::{AtomicBool, AtomicU32, Ordering},
@@ -5,21 +7,239 @@ use core::{
 
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_fs::FileBackend;
+#[cfg(feature = "ext4")]
+use ax_kspin::SpinNoPreempt;
 use ax_sync::Mutex;
 use axfs_ng_vfs::{DeviceId, NodeFlags, VfsResult};
 use linux_raw_sys::{
+    general::{O_ACCMODE, O_RDONLY},
     ioctl::{
-        BLKDISCARD, BLKGETSIZE, BLKGETSIZE64, BLKPBSZGET, BLKRAGET, BLKRASET, BLKROGET, BLKROSET,
-        BLKSSZGET,
+        BLKFLSBUF, BLKGETSIZE, BLKGETSIZE64, BLKIOMIN, BLKIOOPT, BLKPG, BLKRAGET, BLKRASET,
+        BLKROGET, BLKROSET, BLKRRPART, BLKSSZGET,
     },
-    loop_device::{LOOP_CLR_FD, LOOP_GET_STATUS, LOOP_SET_FD, LOOP_SET_STATUS, loop_info},
+    loop_device::{
+        LO_FLAGS_READ_ONLY, LOOP_CLR_FD, LOOP_CONFIGURE, LOOP_GET_STATUS, LOOP_GET_STATUS64,
+        LOOP_SET_FD, LOOP_SET_STATUS, LOOP_SET_STATUS64, loop_config, loop_info, loop_info64,
+    },
 };
 use starry_vm::{VmMutPtr, VmPtr};
 
 use crate::{
-    file::get_file_like,
+    file::{FileLike, get_file_like},
     pseudofs::{DeviceMmap, DeviceOps},
 };
+
+/// HDIO_GETGEO ioctl command (get drive geometry).
+/// Not defined in linux-raw-sys, so we use the standard value directly.
+const HDIO_GETGEO: u32 = 0x0301;
+
+#[cfg(feature = "ext4")]
+const CACHE_BLK: usize = 4096;
+
+#[cfg(feature = "ext4")]
+fn writeback_buffer(file: &FileBackend, cd: &CacheData) -> bool {
+    let total = cd.total_len;
+    let nchunks = cd.blocks.lock().len();
+    let mut offset: usize = 0;
+    for i in 0..nchunks {
+        let mut buf = [0u8; CACHE_BLK];
+        let to_write = {
+            let guard = cd.blocks.lock();
+            let Some(chunk) = guard.get(i) else { break };
+            let n = chunk.len().min(total.saturating_sub(offset));
+            buf[..n].copy_from_slice(&chunk[..n]);
+            n
+        };
+        if to_write == 0 {
+            break;
+        }
+        let mut written = 0usize;
+        while written < to_write {
+            match file.write_at(&buf[written..to_write], (offset + written) as u64) {
+                Ok(0) => {
+                    warn!("LoopDevice: writeback stalled at {}", offset + written);
+                    return false;
+                }
+                Ok(w) => written += w,
+                Err(e) => {
+                    warn!("LoopDevice: writeback err at {}: {e:?}", offset + written);
+                    return false;
+                }
+            }
+        }
+        offset += to_write;
+    }
+    if let Err(e) = file.sync(true) {
+        warn!("LoopDevice: writeback sync failed: {e:?}");
+        return false;
+    }
+    true
+}
+
+/// Shared cache data backing a `LoopBlockDevice`.
+///
+/// Owning an `Arc<CacheData>` keeps the buffer alive even if the
+/// `LoopDevice` replaces its cache slot (e.g. on re-mount).
+///
+/// The buffer is protected by a `SpinNoPreempt` lock.  Both block-device
+/// I/O (`read_block`/`write_block`, already under ext4's SpinNoPreempt)
+/// and write-back paths (normal syscall context) acquire this lock,
+/// so no concurrent access is possible regardless of mount state.
+#[cfg(feature = "ext4")]
+struct CacheData {
+    blocks: SpinNoPreempt<alloc::vec::Vec<alloc::vec::Vec<u8>>>,
+    total_len: usize,
+    dirty: AtomicBool,
+    /// `true` while a `LoopBlockDevice` referencing this cache is alive.
+    mounted: AtomicBool,
+}
+
+#[cfg(feature = "ext4")]
+impl CacheData {
+    fn new(blocks: alloc::vec::Vec<alloc::vec::Vec<u8>>, total_len: usize) -> Self {
+        Self {
+            blocks: SpinNoPreempt::new(blocks),
+            total_len,
+            dirty: AtomicBool::new(false),
+            mounted: AtomicBool::new(false),
+        }
+    }
+}
+
+/// Adapter that wraps a LoopDevice's file backend as a block device.
+///
+/// This allows ext4 (or other filesystem drivers) to use a loop device as
+/// backing storage by converting offset-based I/O to block-based I/O.
+///
+/// The adapter holds an `Arc<CacheData>` so the buffer remains valid even if
+/// the `LoopDevice`'s cache slot is later replaced (e.g. on re-mount while
+/// old filesystem references still exist).  The old adapter keeps its buffer
+/// alive through the Arc — no use-after-free.
+///
+/// Write-back happens in three places:
+///   - `LOOP_CLR_FD` (losetup -d): writes back and clears the cache
+///   - `as_dyn_block_device()` (re-mount): writes back before re-reading
+///   - `BLKFLSBUF` ioctl: explicit flush
+///
+/// All three run in normal syscall context where VFS I/O is safe.
+/// The `flush()` callback is intentionally a no-op because ext4 invokes it
+/// inside `SpinNoPreempt`.
+#[cfg(feature = "ext4")]
+pub struct LoopBlockDevice {
+    cache: Arc<CacheData>,
+    block_size: usize,
+    ro: bool,
+}
+
+#[cfg(feature = "ext4")]
+impl LoopBlockDevice {
+    /// Create a new block device adapter backed by the given `CacheData`.
+    fn new(cache: Arc<CacheData>, ro: bool) -> VfsResult<Self> {
+        cache.mounted.store(true, Ordering::Release);
+        Ok(Self {
+            cache,
+            block_size: 512,
+            ro,
+        })
+    }
+}
+
+#[cfg(feature = "ext4")]
+impl Drop for LoopBlockDevice {
+    fn drop(&mut self) {
+        self.cache.mounted.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(feature = "ext4")]
+impl ax_driver::prelude::BaseDriverOps for LoopBlockDevice {
+    fn device_name(&self) -> &str {
+        "loop"
+    }
+
+    fn device_type(&self) -> ax_driver::prelude::DeviceType {
+        ax_driver::prelude::DeviceType::Block
+    }
+}
+
+#[cfg(feature = "ext4")]
+impl ax_driver::prelude::BlockDriverOps for LoopBlockDevice {
+    fn num_blocks(&self) -> u64 {
+        self.cache.total_len as u64 / self.block_size as u64
+    }
+
+    fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> ax_driver::prelude::DevResult {
+        let byte_off = block_id as usize * self.block_size;
+        if byte_off
+            .checked_add(buf.len())
+            .is_none_or(|end| end > self.cache.total_len)
+        {
+            return Err(ax_driver::prelude::DevError::Io);
+        }
+        let blocks = self.cache.blocks.lock();
+        let mut pos = 0;
+        let mut cur = byte_off;
+        while pos < buf.len() {
+            let idx = cur / CACHE_BLK;
+            let off = cur % CACHE_BLK;
+            let Some(chunk) = blocks.get(idx) else {
+                return Err(ax_driver::prelude::DevError::Io);
+            };
+            let to_copy = (buf.len() - pos).min(CACHE_BLK - off);
+            buf[pos..pos + to_copy].copy_from_slice(&chunk[off..off + to_copy]);
+            pos += to_copy;
+            cur += to_copy;
+        }
+        Ok(())
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> ax_driver::prelude::DevResult {
+        if self.ro {
+            return Err(ax_driver::prelude::DevError::Io);
+        }
+        let byte_off = block_id as usize * self.block_size;
+        if byte_off
+            .checked_add(buf.len())
+            .is_none_or(|end| end > self.cache.total_len)
+        {
+            return Err(ax_driver::prelude::DevError::Io);
+        }
+        let mut blocks = self.cache.blocks.lock();
+        let mut pos = 0;
+        let mut cur = byte_off;
+        while pos < buf.len() {
+            let idx = cur / CACHE_BLK;
+            let off = cur % CACHE_BLK;
+            let Some(chunk) = blocks.get_mut(idx) else {
+                return Err(ax_driver::prelude::DevError::Io);
+            };
+            let to_copy = (buf.len() - pos).min(CACHE_BLK - off);
+            chunk[off..off + to_copy].copy_from_slice(&buf[pos..pos + to_copy]);
+            pos += to_copy;
+            cur += to_copy;
+        }
+        self.cache.dirty.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> ax_driver::prelude::DevResult {
+        // Intentionally a no-op.  ext4 calls this from inside SpinNoPreempt
+        // where sleeping VFS I/O would panic.  Dirty data is written back in
+        // LOOP_CLR_FD (losetup -d), BLKFLSBUF, or after umount — all in
+        // normal syscall context.
+        Ok(())
+    }
+}
+
+/// Block-device data cache owned by the LoopDevice.
+#[cfg(feature = "ext4")]
+struct BlockCache {
+    data: Option<Arc<CacheData>>,
+}
 
 /// /dev/loopX devices
 pub struct LoopDevice {
@@ -31,9 +251,16 @@ pub struct LoopDevice {
     pub ro: AtomicBool,
     /// Read-ahead size for the loop device, in bytes.
     pub ra: AtomicU32,
-    /// True while an O_EXCL opener holds the device. Non-exclusive opens
-    /// and further exclusive opens are rejected with EBUSY while set.
+    /// Backing file name for the loop device.
+    file_name: Mutex<[u8; 64]>,
+    /// Bit mask of `LO_FLAGS_*` (READ_ONLY, AUTOCLEAR, PARTSCAN, DIRECT_IO).
+    flags: AtomicU32,
+    /// Whether the device is opened exclusively (O_EXCL).
     exclusive: AtomicBool,
+    /// Block-device data cache.  Populated by `as_dyn_block_device()`,
+    /// written back and cleared by `LOOP_CLR_FD`.
+    #[cfg(feature = "ext4")]
+    block_cache: Mutex<BlockCache>,
 }
 
 impl LoopDevice {
@@ -44,12 +271,19 @@ impl LoopDevice {
             file: Mutex::new(None),
             ro: AtomicBool::new(false),
             ra: AtomicU32::new(512),
+            file_name: Mutex::new([0u8; 64]),
+            flags: AtomicU32::new(0),
             exclusive: AtomicBool::new(false),
+            #[cfg(feature = "ext4")]
+            block_cache: Mutex::new(BlockCache { data: None }),
         }
     }
 
-    fn is_bound(&self) -> bool {
-        self.file.lock().is_some()
+    /// Apply `lo_flags` from userspace, keeping `ro` and `flags` in sync.
+    fn set_lo_flags(&self, lo_flags: u32) {
+        self.flags.store(lo_flags, Ordering::Relaxed);
+        self.ro
+            .store(lo_flags & LO_FLAGS_READ_ONLY as u32 != 0, Ordering::Relaxed);
     }
 
     /// Get information about the loop device.
@@ -60,6 +294,16 @@ impl LoopDevice {
         let mut res: loop_info = unsafe { core::mem::zeroed() };
         res.lo_number = self.number as _;
         res.lo_rdevice = self.dev_id.0 as _;
+        res.lo_flags = self.flags.load(Ordering::Relaxed) as _;
+        let name = self.file_name.lock();
+        for (i, &c) in name.iter().enumerate() {
+            if i < 64 {
+                res.lo_name[i] = c as _;
+            }
+            if c == 0 {
+                break;
+            }
+        }
         Ok(res)
     }
 
@@ -68,10 +312,124 @@ impl LoopDevice {
         Ok(())
     }
 
+    /// Get information about the loop device (64-bit variant).
+    pub fn get_info64(&self) -> AxResult<loop_info64> {
+        if self.file.lock().is_none() {
+            return Err(AxError::from(LinuxError::ENXIO));
+        }
+        let mut res: loop_info64 = unsafe { core::mem::zeroed() };
+        res.lo_number = self.number as _;
+        res.lo_rdevice = self.dev_id.0 as _;
+        res.lo_file_name = *self.file_name.lock();
+        res.lo_flags = self.flags.load(Ordering::Relaxed);
+        Ok(res)
+    }
+
     /// Clone the underlying file of the loop device.
     pub fn clone_file(&self) -> VfsResult<FileBackend> {
         let file = self.file.lock().clone();
         file.ok_or(AxError::from(LinuxError::ENXIO))
+    }
+
+    /// Create a boxed block device adapter from this loop device.
+    ///
+    /// Returns `Err` if no file is attached to the loop device.
+    ///
+    /// If a previous `CacheData` still has outstanding `Arc` references from
+    /// an old (unmounted) filesystem, those references keep the old buffer
+    /// alive — no use-after-free.  The new adapter gets a fresh `CacheData`
+    /// re-read from the backing file.
+    #[cfg(feature = "ext4")]
+    pub fn as_dyn_block_device(&self) -> VfsResult<Box<dyn ax_driver::prelude::BlockDriverOps>> {
+        let file = self.file.lock().clone();
+        let file = file.ok_or(AxError::from(LinuxError::ENXIO))?;
+        let len = file.location().len().unwrap_or(0) as usize;
+
+        // Reject re-mount if an existing CacheData is still actively mounted.
+        {
+            let mut cache = self.block_cache.lock();
+            if let Some(ref cd) = cache.data {
+                if cd.mounted.load(Ordering::Acquire) {
+                    return Err(AxError::from(LinuxError::EBUSY));
+                }
+                if cd.dirty.swap(false, Ordering::AcqRel) {
+                    if self.ro.load(Ordering::Relaxed) {
+                        cd.dirty.store(true, Ordering::Release);
+                        return Err(AxError::Io);
+                    }
+                    if !writeback_buffer(&file, cd) {
+                        cd.dirty.store(true, Ordering::Release);
+                        return Err(AxError::Io);
+                    }
+                }
+            }
+            cache.data = None;
+        }
+
+        // Read the backing file in CACHE_BLK-sized chunks.  Each individual
+        // allocation is only 4 KiB, small enough to satisfy even when physical
+        // memory is fragmented after many mount/umount cycles.
+        let num_chunks = if len == 0 {
+            0
+        } else {
+            (len - 1) / CACHE_BLK + 1
+        };
+        let mut chunks = alloc::vec::Vec::with_capacity(num_chunks);
+        let mut offset: usize = 0;
+        for _ in 0..num_chunks {
+            let to_read = CACHE_BLK.min(len - offset);
+            let mut chunk = alloc::vec![0u8; CACHE_BLK];
+            let n = file.read_at(&mut chunk[..to_read], offset as u64)?;
+            if n != to_read {
+                warn!("LoopDevice: short read {n}/{to_read} at offset {offset}");
+                return Err(AxError::Io);
+            }
+            chunks.push(chunk);
+            offset += to_read;
+        }
+
+        let mut cache = self.block_cache.lock();
+        let cd = Arc::new(CacheData::new(chunks, len));
+        cache.data = Some(cd.clone());
+        drop(cache);
+
+        Ok(Box::new(LoopBlockDevice::new(
+            cd,
+            self.ro.load(Ordering::Relaxed),
+        )?))
+    }
+
+    /// Write back dirty block-cache data to the backing file.
+    ///
+    /// Called after `unmount` in normal syscall context where VFS I/O is
+    /// safe, so that data is persisted without requiring an explicit
+    /// `losetup -d` or `BLKFLSBUF`.
+    ///
+    /// Returns `Err(AxError::Io)` if writeback fails, so that callers
+    /// (`sys_umount2`) can propagate the error to userspace.  On failure
+    /// the dirty flag is preserved so that subsequent flush attempts
+    /// (BLKFLSBUF, LOOP_CLR_FD) can retry.
+    #[cfg(feature = "ext4")]
+    pub fn flush_cache_to_file(&self) -> AxResult<()> {
+        let file = self.file.lock().clone();
+        let cache = self.block_cache.lock();
+        if let Some(ref cd) = cache.data {
+            let mut wb_err = false;
+            if cd.dirty.swap(false, Ordering::AcqRel)
+                && let Some(ref file) = file
+            {
+                let writeback_ok = !self.ro.load(Ordering::Relaxed) && writeback_buffer(file, cd);
+                if !writeback_ok {
+                    cd.dirty.store(true, Ordering::Release);
+                    wb_err = true;
+                }
+            }
+            cd.mounted.store(false, Ordering::Release);
+            if wb_err {
+                return Err(AxError::Io);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -124,6 +482,13 @@ impl DeviceOps for LoopDevice {
                     return Err(AxError::ResourceBusy);
                 }
 
+                // Match Linux: if backing file opened O_RDONLY, device is read-only.
+                let ro = (file.open_flags() & O_ACCMODE) == O_RDONLY;
+                if ro {
+                    self.set_lo_flags(LO_FLAGS_READ_ONLY as u32);
+                } else {
+                    self.set_lo_flags(0);
+                }
                 *guard = Some(file.inner().backend()?.clone());
             }
             LOOP_CLR_FD => {
@@ -131,7 +496,45 @@ impl DeviceOps for LoopDevice {
                 if guard.is_none() {
                     return Err(AxError::from(LinuxError::ENXIO));
                 }
+
+                // Write back dirty data from the block cache before clearing.
+                // This runs in normal syscall context so CachedFile VFS I/O
+                // (page cache updates) is safe.  The SpinNoPreempt lock
+                // ensures no concurrent write_block() can race.
+                #[cfg(feature = "ext4")]
+                {
+                    let cache = self.block_cache.lock();
+                    // If a LoopBlockDevice is still alive (mounted), refuse to
+                    // detach — the old Arc<CacheData> would keep receiving
+                    // write_block calls but the backing file would be gone,
+                    // causing silent data loss on umount.
+                    if let Some(ref cd) = cache.data
+                        && cd.mounted.load(Ordering::Acquire)
+                    {
+                        return Err(AxError::from(LinuxError::EBUSY));
+                    }
+
+                    if let Some(ref cd) = cache.data
+                        && cd.dirty.load(Ordering::Acquire)
+                    {
+                        if self.ro.load(Ordering::Relaxed) {
+                            return Err(AxError::Io);
+                        }
+                        if let Some(ref file) = *guard
+                            && !writeback_buffer(file, cd)
+                        {
+                            warn!("LoopDevice: writeback failed on LOOP_CLR_FD, data may be lost");
+                            return Err(AxError::Io);
+                        }
+                        cd.dirty.store(false, Ordering::Release);
+                    }
+                    drop(cache);
+                    self.block_cache.lock().data = None;
+                }
+
                 *guard = None;
+                *self.file_name.lock() = [0u8; 64];
+                self.flags.store(0, Ordering::Relaxed);
             }
             LOOP_GET_STATUS => {
                 (arg as *mut loop_info).vm_write(self.get_info()?)?;
@@ -140,27 +543,51 @@ impl DeviceOps for LoopDevice {
                 // FIXME: AnyBitPattern
                 let info = unsafe { (arg as *const loop_info).vm_read_uninit()?.assume_init() };
                 self.set_info(info)?;
+                let mut name = self.file_name.lock();
+                for (i, &c) in info.lo_name.iter().enumerate() {
+                    if i < 64 {
+                        name[i] = c as u8;
+                    }
+                    if c == 0 {
+                        break;
+                    }
+                }
+                self.set_lo_flags(info.lo_flags as u32);
             }
-            BLKDISCARD => {
-                if !self.is_bound() {
-                    return Err(AxError::from(LinuxError::ENXIO));
-                }
-                if self.ro.load(Ordering::Relaxed) {
-                    return Err(AxError::ReadOnlyFilesystem);
-                }
-                let ptr = arg as *const u64;
-                let start = ptr.vm_read()?;
-                let len = unsafe { ptr.add(1) }.vm_read()?;
-                if len == 0 {
-                    return Err(AxError::InvalidInput);
-                }
-                let dev_size = self.clone_file()?.location().len()?;
-                if start.saturating_add(len) > dev_size {
-                    return Err(AxError::InvalidInput);
-                }
-                // Real discard (punch-hole on backing file) not yet implemented.
-                return Err(AxError::OperationNotSupported);
+            LOOP_GET_STATUS64 => {
+                (arg as *mut loop_info64).vm_write(self.get_info64()?)?;
             }
+            LOOP_SET_STATUS64 => {
+                // FIXME: AnyBitPattern
+                let info = unsafe { (arg as *const loop_info64).vm_read_uninit()?.assume_init() };
+                *self.file_name.lock() = info.lo_file_name;
+                self.set_lo_flags(info.lo_flags);
+            }
+            LOOP_CONFIGURE => {
+                // FIXME: AnyBitPattern
+                let cfg = unsafe { (arg as *const loop_config).vm_read_uninit()?.assume_init() };
+                let fd = cfg.fd as i32;
+                if fd < 0 {
+                    return Err(AxError::BadFileDescriptor);
+                }
+                let f = get_file_like(fd)?;
+                let Some(file) = f.downcast_ref::<crate::file::File>() else {
+                    return Err(AxError::InvalidInput);
+                };
+                let mut guard = self.file.lock();
+                if guard.is_some() {
+                    return Err(AxError::ResourceBusy);
+                }
+                *guard = Some(file.inner().backend()?.clone());
+                drop(guard);
+                *self.file_name.lock() = cfg.info.lo_file_name;
+                let mut flags = cfg.info.lo_flags;
+                if (file.open_flags() & O_ACCMODE) == O_RDONLY {
+                    flags |= LO_FLAGS_READ_ONLY as u32;
+                }
+                self.set_lo_flags(flags);
+            }
+            // TODO: the following should apply to any block devices
             BLKGETSIZE | BLKGETSIZE64 => {
                 let sectors = if let Ok(f) = self.clone_file() {
                     f.location().len()? / 512
@@ -173,7 +600,15 @@ impl DeviceOps for LoopDevice {
                     (arg as *mut u64).vm_write(sectors * 512)?;
                 }
             }
-            BLKSSZGET | BLKPBSZGET => {
+            BLKSSZGET => {
+                (arg as *mut u32).vm_write(512)?;
+            }
+            #[cfg(any(
+                target_arch = "riscv64",
+                target_arch = "aarch64",
+                target_arch = "loongarch64"
+            ))]
+            linux_raw_sys::ioctl::BLKPBSZGET => {
                 (arg as *mut u32).vm_write(512)?;
             }
             BLKROGET => {
@@ -184,7 +619,13 @@ impl DeviceOps for LoopDevice {
                 if ro != 0 && ro != 1 {
                     return Err(AxError::InvalidInput);
                 }
-                self.ro.store(ro != 0, Ordering::Relaxed);
+                let mut flags = self.flags.load(Ordering::Relaxed);
+                if ro != 0 {
+                    flags |= LO_FLAGS_READ_ONLY as u32;
+                } else {
+                    flags &= !(LO_FLAGS_READ_ONLY as u32);
+                }
+                self.set_lo_flags(flags);
             }
             BLKRAGET => {
                 (arg as *mut u32).vm_write(self.ra.load(Ordering::Relaxed))?;
@@ -192,6 +633,75 @@ impl DeviceOps for LoopDevice {
             BLKRASET => {
                 self.ra
                     .store((arg as *const u32).vm_read()? as _, Ordering::Relaxed);
+            }
+            BLKRRPART => {
+                // loop device has no physical partition table; no-op
+            }
+            BLKPG => {
+                // partition manipulation not supported on loop devices
+                return Err(AxError::from(LinuxError::ENOTTY));
+            }
+            BLKFLSBUF => {
+                // Atomically claim the dirty flag so that a concurrent
+                // write_block() will re-set dirty=true after our snapshot,
+                // guaranteeing its data is flushed on the next attempt.
+                #[cfg(feature = "ext4")]
+                {
+                    let file = self.file.lock().clone();
+                    let cache = self.block_cache.lock();
+                    if let Some(ref cd) = cache.data
+                        && let Some(ref file) = file
+                    {
+                        if self.ro.load(Ordering::Relaxed) {
+                            return Err(AxError::Io);
+                        }
+                        if !cd.dirty.swap(false, Ordering::AcqRel) {
+                            return Ok(0);
+                        }
+                        if !writeback_buffer(file, cd) {
+                            cd.dirty.store(true, Ordering::Release);
+                            return Err(AxError::Io);
+                        }
+                    }
+                }
+            }
+            BLKIOMIN => {
+                // minimum I/O size
+                (arg as *mut u32).vm_write(512)?;
+            }
+            BLKIOOPT => {
+                // optimal I/O size
+                (arg as *mut u32).vm_write(512)?;
+            }
+            // HDIO_GETGEO: virtual CHS geometry for fdisk
+            HDIO_GETGEO => {
+                let size = match self.file.lock().clone() {
+                    Some(f) => f.location().len().unwrap_or(0),
+                    None => 0,
+                };
+                // hd_geometry: { u8 heads, u8 sectors, u16 cylinders, unsigned long start }
+                // On 64-bit targets unsigned long is 8 bytes.
+                let heads: u8 = 64;
+                let sectors: u8 = 32;
+                let cyl = if size > 0 {
+                    (size / (heads as u64 * sectors as u64 * 512)) as u16
+                } else {
+                    0
+                };
+                #[repr(C)]
+                struct HdGeometry {
+                    heads: u8,
+                    sectors: u8,
+                    cylinders: u16,
+                    start: u64,
+                }
+                let geo = HdGeometry {
+                    heads,
+                    sectors,
+                    cylinders: cyl,
+                    start: 0,
+                };
+                (arg as *mut HdGeometry).vm_write(geo)?;
             }
             _ => {
                 warn!("unknown ioctl for loop device: {cmd}");

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -14,6 +14,8 @@ mod fb;
 #[cfg(feature = "dev-log")]
 mod log;
 mod r#loop;
+#[cfg(feature = "ext4")]
+pub use r#loop::LoopDevice;
 #[cfg(feature = "memtrack")]
 mod memtrack;
 pub mod tty;
@@ -322,9 +324,9 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         root.add("dri", SimpleDir::new_maker(fs.clone(), Arc::new(dri_dir)));
     }
 
-    // Loop devices
+    // Loop devices (major 7, minor = device index)
     for i in 0..16 {
-        let dev_id = DeviceId::new(7, 0);
+        let dev_id = DeviceId::new(7, i);
         root.add(
             format!("loop{i}"),
             Device::new(

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -1,9 +1,46 @@
+use alloc::sync::Arc;
 use core::ffi::{c_char, c_void};
 
-use ax_errno::{AxError, AxResult};
-use ax_fs::FS_CONTEXT;
+use ax_errno::{AxError, AxResult, LinuxError};
+use ax_fs::{FS_CONTEXT, is_mount_busy as fs_is_mount_busy};
 
-use crate::{mm::vm_load_string, pseudofs::MemoryFs};
+use crate::{
+    file::{Directory, FD_TABLE, File, FileLike},
+    mm::vm_load_string,
+    pseudofs::MemoryFs,
+    task::{AsThread, tasks},
+};
+
+fn fd_points_to_mount(fd: &dyn FileLike, mp: &Arc<axfs_ng_vfs::Mountpoint>) -> bool {
+    fd.downcast_ref::<File>()
+        .is_some_and(|f| Arc::ptr_eq(f.inner().location().mountpoint(), mp))
+        || fd
+            .downcast_ref::<Directory>()
+            .is_some_and(|d| Arc::ptr_eq(d.inner().mountpoint(), mp))
+}
+
+fn is_mount_busy(mp: &Arc<axfs_ng_vfs::Mountpoint>) -> bool {
+    if fs_is_mount_busy(mp) {
+        return true;
+    }
+    for task in tasks() {
+        let Some(thread) = task.try_as_thread() else {
+            continue;
+        };
+        let scope = thread.proc_data.scope.read();
+        let fd_table = FD_TABLE.scope(&scope).clone();
+        drop(scope);
+        let table = fd_table.read();
+        if table.ids().any(|id| {
+            table
+                .get(id)
+                .is_some_and(|fd| fd_points_to_mount(&*fd.inner, mp))
+        }) {
+            return true;
+        }
+    }
+    false
+}
 
 pub fn sys_mount(
     source: *const c_char,
@@ -17,22 +54,196 @@ pub fn sys_mount(
     let fs_type = vm_load_string(fs_type)?;
     debug!("sys_mount <= source: {source:?}, target: {target:?}, fs_type: {fs_type:?}");
 
-    if fs_type != "tmpfs" {
-        return Err(AxError::NoSuchDevice);
+    match fs_type.as_str() {
+        "tmpfs" => {
+            let fs = MemoryFs::new();
+            let target = FS_CONTEXT.lock().resolve(target)?;
+            target.mount(&fs)?;
+        }
+        #[cfg(feature = "ext4")]
+        "ext4" => {
+            mount_ext4(&source, &target)?;
+        }
+        _ => return Err(AxError::NoSuchDevice),
     }
-
-    let fs = MemoryFs::new();
-
-    let target = FS_CONTEXT.lock().resolve(target)?;
-    target.mount(&fs)?;
 
     Ok(0)
 }
 
+#[cfg(feature = "ext4")]
+fn mount_ext4(source: &str, target: &str) -> AxResult<()> {
+    use alloc::{boxed::Box, sync::Arc};
+
+    use ax_driver::prelude::BlockDriverOps;
+
+    let ctx = FS_CONTEXT.lock();
+
+    // Resolve source device path (e.g., "/dev/loop0") to a block device
+    let source_loc = ctx.resolve(source)?;
+    let device = source_loc
+        .entry()
+        .downcast::<crate::pseudofs::Device>()
+        .map_err(|_| {
+            warn!("mount_ext4: {:?} is not a device", source);
+            AxError::NoSuchDevice
+        })?;
+    let loop_dev = device
+        .inner()
+        .as_any()
+        .downcast_ref::<crate::pseudofs::dev::LoopDevice>()
+        .ok_or_else(|| {
+            warn!("mount_ext4: {:?} is not a loop device", source);
+            AxError::NoSuchDevice
+        })?;
+    let block_dev = loop_dev.as_dyn_block_device().inspect_err(|e| {
+        warn!(
+            "mount_ext4: loop device as_dyn_block_device failed: {:?}",
+            e
+        );
+    })?;
+
+    let num_blocks = block_dev.num_blocks();
+    let region = ax_driver::PartitionRegion::from_num_blocks(num_blocks);
+
+    // Create ext4 filesystem from the dynamic block device
+    let fs = ax_fs::new_filesystem_from_dyn(block_dev, region).map_err(|e| {
+        warn!("mount_ext4: failed to create ext4 filesystem: {:?}", e);
+        AxError::Io
+    })?;
+
+    // Mount at the target location
+    let target_loc = ctx.resolve(target)?;
+    target_loc.mount(&fs).map_err(|e| {
+        warn!("mount_ext4: failed to mount at {:?}: {:?}", target, e);
+        AxError::Io
+    })?;
+
+    // Store a writeback callback in the mount root's user_data so that
+    // sys_umount2 can flush the loop device's block cache to the backing
+    // file after the filesystem is unmounted.
+    let ops: Arc<dyn crate::pseudofs::DeviceOps> = device.inner().clone();
+    {
+        let mount_root = ctx.resolve(target)?;
+        mount_root.user_data().insert(Box::new(move || {
+            if let Some(ld) = ops
+                .as_any()
+                .downcast_ref::<crate::pseudofs::dev::LoopDevice>()
+            {
+                ld.flush_cache_to_file()
+            } else {
+                Ok(())
+            }
+        }) as Box<dyn Fn() -> AxResult<()> + Send + Sync>);
+    }
+
+    Ok(())
+}
+
 pub fn sys_umount2(target: *const c_char, _flags: i32) -> AxResult<isize> {
+    use alloc::boxed::Box;
+
     let target = vm_load_string(target)?;
     debug!("sys_umount2 <= target: {target:?}");
     let target = FS_CONTEXT.lock().resolve(target)?;
+
+    // Linux umount2 returns EINVAL for paths that are not mount points.
+    if !target.is_root_of_mount() {
+        return Err(AxError::InvalidInput);
+    }
+
+    // Linux umount2 returns EBUSY if any task has cwd/root or open fd
+    // inside the mount.
+    if is_mount_busy(target.mountpoint()) {
+        return Err(AxError::from(LinuxError::EBUSY));
+    }
+
+    // Retrieve the writeback callback (if any) before unmount tears down
+    // the mount.  For ext4-on-loop mounts this flushes the block device
+    // cache to the backing file after the filesystem is unmounted; for
+    // other filesystem types (tmpfs) the callback is absent.
+    let writeback = {
+        let ud = target.user_data();
+        ud.get::<Box<dyn Fn() -> AxResult<()> + Send + Sync>>()
+    }; // user_data lock released
+
     target.unmount()?;
+
+    // After unmount the SpinNoPreempt lock inside ext4 is released; safe
+    // to do VFS I/O here.  Propagate writeback errors so userspace sees
+    // EIO when dirty data could not be persisted to the backing file.
+    if let Some(cb) = writeback {
+        cb()?;
+    }
+
+    Ok(0)
+}
+
+pub fn sys_pivot_root(new_root: *const c_char, put_old: *const c_char) -> AxResult<isize> {
+    let new_root = vm_load_string(new_root)?;
+    let put_old = vm_load_string(put_old)?;
+    debug!(
+        "sys_pivot_root <= new_root: {:?}, put_old: {:?}",
+        new_root, put_old
+    );
+
+    // Validate: put_old must be at or under new_root (path-separator-aware
+    // so that "/new" does not falsely match "/newroot/old").
+    let nr = new_root.trim_end_matches('/');
+    let nr_slash = alloc::format!("{}/", nr);
+    if !(put_old == nr || put_old.starts_with(&nr_slash)) {
+        return Err(AxError::InvalidInput);
+    }
+    // new_root cannot be "/"
+    if new_root == "/" {
+        return Err(AxError::InvalidInput);
+    }
+
+    let mut ctx = FS_CONTEXT.lock();
+
+    // The caller's current root must itself be a mount point (Linux
+    // EINVAL if e.g. the process chroot'd into a subdirectory).
+    if !ctx.root_dir().is_root_of_mount() {
+        return Err(AxError::InvalidInput);
+    }
+
+    // Resolve paths
+    let new_root_loc = ctx.resolve(&new_root)?;
+
+    // Both must be directories
+    new_root_loc.check_is_dir()?;
+    let put_old_loc = ctx.resolve(&put_old)?;
+    put_old_loc.check_is_dir()?;
+
+    // new_root must be the root of a non-root mount (i.e. the root of a
+    // filesystem mounted somewhere, not the global root).  Because path
+    // resolution crosses mount boundaries transparently, the resolved
+    // Location is the *root entry* of the mounted filesystem, so we check
+    // is_root_of_mount + the mountpoint is not the global root.
+    if !(new_root_loc.is_root_of_mount() && !new_root_loc.mountpoint().is_root()) {
+        warn!(
+            "sys_pivot_root: new_root {:?} is not the root of a mounted filesystem",
+            new_root
+        );
+        return Err(AxError::InvalidInput);
+    }
+
+    // Capture the old root Location BEFORE the pivot, so that we can
+    // propagate the change to every other task afterwards (Linux
+    // chroot_fs_refs semantics).  We save the full Location (mountpoint +
+    // dentry) rather than just the mountpoint, so that tasks chroot'd
+    // into a subdirectory of the old root are not incorrectly updated.
+    let old_root = ctx.root_dir().clone();
+
+    // Perform pivot: swap the root mount (updates this task's FsContext).
+    ctx.pivot_root(new_root_loc, put_old_loc)?;
+
+    let new_root_loc = ctx.root_dir().clone();
+    drop(ctx); // Release this task's lock before touching others.
+
+    // Propagate root / cwd to all other tasks whose root_dir or current_dir
+    // exactly matches the old root Location — mirroring Linux
+    // chroot_fs_refs() in fs/namespace.c.
+    ax_fs::FsContext::propagate_pivot_root(&old_root, &new_root_loc);
+
     Ok(0)
 }

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -297,6 +297,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg4() as _,
         ) as _,
         Sysno::umount2 => sys_umount2(uctx.arg0() as _, uctx.arg1() as _) as _,
+        Sysno::pivot_root => sys_pivot_root(uctx.arg0() as _, uctx.arg1() as _) as _,
 
         // pipe
         Sysno::pipe2 => sys_pipe2(uctx.arg0() as _, uctx.arg1() as _),

--- a/os/StarryOS/kernel/src/syscall/task/execve.rs
+++ b/os/StarryOS/kernel/src/syscall/task/execve.rs
@@ -97,7 +97,7 @@ pub fn sys_execve(
     // Switch the hardware page table now that the new aspace is installed.
     curr.switch_page_table(new_pt_root);
 
-    curr.set_name(new_name);
+    curr.set_name(&new_name);
     *proc_data.exe_path.write() = new_exe_path;
     *proc_data.cmdline.write() = Arc::new(args);
 

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -43,7 +43,7 @@ path = "xtask/main.rs"
 [dependencies]
 ax-feat = { workspace = true, features = ["fs-ng-times", "irq"] }
 axplat-dyn = { workspace = true, optional = true }
-starry-kernel = { workspace = true, features = ["dev-log"] }
+starry-kernel = { workspace = true, features = ["dev-log", "ext4"] }
 
 [target.'cfg(any(windows,unix))'.dependencies]
 anyhow = "1.0"

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/fs.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/fs.rs
@@ -1,12 +1,12 @@
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc};
 use core::cell::OnceCell;
 
-use ax_driver::{AxBlockDevice, PartitionRegion};
+use ax_driver::{AxBlockDevice, PartitionRegion, prelude::BlockDriverOps};
 use ax_kspin::{SpinNoPreempt as Mutex, SpinNoPreemptGuard as MutexGuard};
 use axfs_ng_vfs::{
     DirEntry, DirNode, Filesystem, FilesystemOps, Reference, StatFs, VfsResult, path::MAX_NAME_LEN,
 };
-use rsext4::{Jbd2Dev, bmalloc::InodeNumber};
+use rsext4::{Jbd2Dev, bmalloc::InodeNumber, superblock::Ext4Superblock};
 
 use super::{Ext4Disk, Inode, util::into_vfs_err};
 
@@ -31,7 +31,16 @@ pub struct Ext4Filesystem {
 }
 
 impl Ext4Filesystem {
+    /// Create from a compile-time block device (e.g. VirtIO root device).
     pub fn new(dev: AxBlockDevice, region: PartitionRegion) -> VfsResult<Filesystem> {
+        Self::new_from_boxed(Box::new(dev) as Box<dyn BlockDriverOps>, region)
+    }
+
+    /// Create from a dynamic (boxed) block device (e.g. loop device).
+    pub fn new_from_boxed(
+        dev: Box<dyn BlockDriverOps>,
+        region: PartitionRegion,
+    ) -> VfsResult<Filesystem> {
         let mut dev = Jbd2Dev::initial_jbd2dev(0, Ext4Disk::new(dev, region), true);
         let fs = rsext4::mount(&mut dev).map_err(into_vfs_err)?;
 
@@ -63,6 +72,9 @@ impl Ext4Filesystem {
         fs.datablock_cache.flush_all(dev).map_err(into_vfs_err)?;
         fs.bitmap_cache.flush_all(dev).map_err(into_vfs_err)?;
         fs.inodetable_cahce.flush_all(dev).map_err(into_vfs_err)?;
+        // Mark the filesystem clean before writing the superblock so the
+        // on-disk state reflects a clean sync / unmount.
+        fs.superblock.s_state = Ext4Superblock::EXT4_VALID_FS;
         fs.sync_superblock(dev).map_err(into_vfs_err)?;
         fs.sync_group_descriptors(dev).map_err(into_vfs_err)?;
         if dev.is_use_journal() {

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/mod.rs
@@ -2,7 +2,9 @@ mod fs;
 mod inode;
 mod util;
 
-use ax_driver::{AxBlockDevice, PartitionBlockDevice, PartitionRegion, prelude::BlockDriverOps};
+use alloc::boxed::Box;
+
+use ax_driver::{PartitionBlockDevice, PartitionRegion, prelude::BlockDriverOps};
 pub use fs::*;
 pub use inode::*;
 use rsext4::{
@@ -13,10 +15,10 @@ use rsext4::{
     error::{Ext4Error, Ext4Result},
 };
 
-pub(crate) struct Ext4Disk(PartitionBlockDevice<AxBlockDevice>);
+pub(crate) struct Ext4Disk(PartitionBlockDevice<Box<dyn BlockDriverOps>>);
 
 impl Ext4Disk {
-    pub(crate) const fn new(dev: AxBlockDevice, region: PartitionRegion) -> Self {
+    pub fn new(dev: Box<dyn BlockDriverOps>, region: PartitionRegion) -> Self {
         Self(PartitionBlockDevice::new(dev, region))
     }
 }

--- a/os/arceos/modules/axfs-ng/src/fs/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "ext4")]
+use alloc::boxed::Box;
+
+#[cfg(feature = "ext4")]
+use ax_driver::prelude::BlockDriverOps;
 use ax_driver::{AxBlockDevice, PartitionRegion};
 use axfs_ng_vfs::{Filesystem, VfsResult};
 
@@ -18,6 +23,19 @@ cfg_if::cfg_if! {
     }
 }
 
+/// Create a filesystem instance from a block device.
 pub fn new_default(dev: AxBlockDevice, region: PartitionRegion) -> VfsResult<Filesystem> {
     DefaultFilesystem::new(dev, region)
+}
+
+/// Create a filesystem instance from a dynamic (boxed) block device.
+///
+/// Use this for loop devices and other block backends that don't match
+/// the compile-time `AxBlockDevice` type alias.
+#[cfg(feature = "ext4")]
+pub fn new_from_dyn(
+    dev: Box<dyn BlockDriverOps>,
+    region: PartitionRegion,
+) -> VfsResult<Filesystem> {
+    ext4::Ext4Filesystem::new_from_boxed(dev, region)
 }

--- a/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
@@ -2,14 +2,14 @@ use alloc::{
     borrow::{Cow, ToOwned},
     collections::vec_deque::VecDeque,
     string::String,
-    sync::Arc,
+    sync::{Arc, Weak},
     vec::Vec,
 };
 
 use ax_io::{Read, Write};
 use ax_sync::Mutex;
 use axfs_ng_vfs::{
-    Location, Metadata, NodePermission, NodeType, VfsError, VfsResult,
+    Location, Metadata, Mountpoint, NodePermission, NodeType, VfsError, VfsResult,
     path::{Component, Components, Path, PathBuf},
 };
 use spin::Once;
@@ -22,15 +22,55 @@ pub const SYMLINKS_MAX: usize = 40;
 /// Global root filesystem context, initialized once during [`init_filesystems`](crate::init_filesystems).
 pub static ROOT_FS_CONTEXT: Once<FsContext> = Once::new();
 
+/// Registry of all live `FsContext` instances (weak references).
+///
+/// Each time a task-local [`FS_CONTEXT`] is created, it registers its
+/// `Arc<Mutex<FsContext>>` here via [`register_fs_context`].  This allows
+/// [`FsContext::propagate_pivot_root`] to iterate over every task's
+/// filesystem context and apply the same root / cwd fixup that Linux
+/// performs in `chroot_fs_refs()` after `pivot_root(2)`.
+static FS_REGISTRY: spin::Mutex<Vec<Weak<Mutex<FsContext>>>> = spin::Mutex::new(Vec::new());
+
+/// Register an `FsContext` in the global [`FS_REGISTRY`].
+fn register_fs_context(ctx: &Arc<Mutex<FsContext>>) {
+    let mut registry = FS_REGISTRY.lock();
+    // Prune dead weak references so the registry does not grow unboundedly
+    // in long-running scenarios where pivot_root is never invoked.
+    registry.retain(|weak| weak.upgrade().is_some());
+    registry.push(Arc::downgrade(ctx));
+}
+
+/// Returns `true` if any live `FsContext` has its `root_dir` or `current_dir`
+/// inside the given `mountpoint`.
+pub fn is_mount_busy(mp: &Arc<Mountpoint>) -> bool {
+    let refs: Vec<Arc<Mutex<FsContext>>> = {
+        let mut registry = FS_REGISTRY.lock();
+        registry.retain(|weak| weak.upgrade().is_some());
+        registry.iter().filter_map(|weak| weak.upgrade()).collect()
+    };
+    for ctx_arc in refs {
+        let ctx = ctx_arc.lock();
+        if Arc::ptr_eq(ctx.root_dir().mountpoint(), mp)
+            || Arc::ptr_eq(ctx.current_dir().mountpoint(), mp)
+        {
+            return true;
+        }
+    }
+    false
+}
+
 scope_local::scope_local! {
     /// Task-local filesystem context, defaulting to a clone of [`ROOT_FS_CONTEXT`].
-    pub static FS_CONTEXT: Arc<Mutex<FsContext>> =
-        Arc::new(Mutex::new(
+    pub static FS_CONTEXT: Arc<Mutex<FsContext>> = {
+        let ctx = Arc::new(Mutex::new(
             ROOT_FS_CONTEXT
                 .get()
                 .expect("Root FS context not initialized")
                 .clone(),
         ));
+        register_fs_context(&ctx);
+        ctx
+    };
 }
 
 /// A single entry returned by [`FsContext::read_dir`].
@@ -182,7 +222,7 @@ impl FsContext {
         if let Some(name) = name {
             Ok((dir, Cow::Borrowed(name)))
         } else if let Some(parent) = dir.parent() {
-            Ok((parent, Cow::Owned(dir.name().to_owned())))
+            Ok((parent, dir.name().into_owned().into()))
         } else {
             Err(VfsError::InvalidInput)
         }
@@ -249,7 +289,7 @@ impl FsContext {
         entry
             .parent()
             .ok_or(VfsError::IsADirectory)?
-            .unlink(entry.name(), false)
+            .unlink(&entry.name(), false)
     }
 
     /// Removes a directory from the filesystem.
@@ -258,7 +298,7 @@ impl FsContext {
         entry
             .parent()
             .ok_or(VfsError::ResourceBusy)?
-            .unlink(entry.name(), true)
+            .unlink(&entry.name(), true)
     }
 
     /// Renames a file or directory to a new name, replacing the original file
@@ -324,6 +364,84 @@ impl FsContext {
     /// Returns the canonical, absolute form of a path.
     pub fn canonicalize(&self, path: impl AsRef<Path>) -> VfsResult<PathBuf> {
         self.resolve(path.as_ref())?.absolute_path()
+    }
+
+    /// Pivot the root filesystem to `new_root`, moving the old root to
+    /// `put_old` (which must be a directory under `new_root`).
+    ///
+    /// This follows Linux `pivot_root(2)` semantics: after the call the old
+    /// root filesystem is accessible at `put_old`, and can be unmounted from
+    /// there.
+    ///
+    /// Note: this method only updates **this** `FsContext`.  The caller must
+    /// invoke [`FsContext::propagate_pivot_root`] afterwards to update every
+    /// other task whose root / cwd still points at the old root, mirroring
+    /// Linux's `chroot_fs_refs()`.
+    pub fn pivot_root(&mut self, new_root: Location, put_old: Location) -> VfsResult<()> {
+        let old_root = self.root_dir.clone();
+        let old_root_mp = self.root_dir.mountpoint().clone();
+        let new_root_mp = new_root.mountpoint().clone();
+        old_root_mp.pivot_mount(&new_root_mp, &put_old)?;
+        let new_root_loc = new_root_mp.root_location();
+        self.root_dir = new_root_loc.clone();
+        // Only replace cwd if it was pointing at the old root — mirrors
+        // Linux's chroot_fs_refs / replace_path semantics.
+        if old_root.ptr_eq(&self.current_dir) {
+            self.current_dir = new_root_loc;
+        }
+        Ok(())
+    }
+
+    /// After a successful [`pivot_root`](Self::pivot_root), propagate the
+    /// root / cwd change to **all** other tasks in the same mount namespace.
+    ///
+    /// This mirrors `chroot_fs_refs()` in Linux's `fs/namespace.c`:
+    /// after `pivot_root(2)` reorganises the mount tree the kernel walks
+    /// every thread's `fs_struct` and switches any `root` / `pwd` that
+    /// pointed at the old root over to the new root.
+    ///
+    /// * `old_root` – the `Location` of the old root **before** the pivot
+    ///   (obtained from `ctx.root_dir().clone()` before calling
+    ///   [`pivot_root`](Self::pivot_root)).
+    /// * `new_root` – the `Location` of the new root **after** the pivot
+    ///   (obtained from `ctx.root_dir()` after calling
+    ///   [`pivot_root`](Self::pivot_root)).
+    ///
+    /// # Linux semantics
+    ///
+    /// For each registered `FsContext`, [`Location::ptr_eq`] is used to
+    /// compare both mountpoint **and** dentry, mirroring the kernel's
+    /// `replace_path()` check `fs->root.mnt == old_root->mnt &&
+    /// fs->root.dentry == old_root->dentry`:
+    /// - If `root_dir` is exactly `old_root` → set to `new_root`.
+    /// - If `current_dir` is exactly `old_root` → set to `new_root`.
+    ///
+    /// This avoids incorrectly updating tasks that have chroot'd into a
+    /// subdirectory of the old root (same mountpoint, different dentry).
+    pub fn propagate_pivot_root(old_root: &Location, new_root: &Location) {
+        // 1. Collect strong references while holding the registry lock, then
+        //    release it so we never nest two Mutex guards.
+        let refs: Vec<Arc<Mutex<FsContext>>> = {
+            let mut registry = FS_REGISTRY.lock();
+            registry.retain(|weak| weak.upgrade().is_some());
+            registry.iter().filter_map(|weak| weak.upgrade()).collect()
+        };
+
+        // 2. Walk every live FsContext and apply the same logic as
+        //    Linux chroot_fs_refs().
+        for ctx_arc in refs {
+            let mut ctx = ctx_arc.lock();
+
+            let update_root = old_root.ptr_eq(&ctx.root_dir);
+            let update_cwd = old_root.ptr_eq(&ctx.current_dir);
+
+            if update_root {
+                ctx.root_dir = new_root.clone();
+            }
+            if update_cwd {
+                ctx.current_dir = new_root.clone();
+            }
+        }
     }
 }
 

--- a/os/arceos/modules/axfs-ng/src/lib.rs
+++ b/os/arceos/modules/axfs-ng/src/lib.rs
@@ -27,6 +27,10 @@ use ax_driver::{
 mod fs;
 
 mod highlevel;
+
+/// Create a filesystem from a dynamic (boxed) block device.
+#[cfg(feature = "ext4")]
+pub use fs::new_from_dyn as new_filesystem_from_dyn;
 pub use highlevel::*;
 
 #[derive(Debug, Default)]

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/c/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(util-linux-test C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(util-linux-test src/main.c)
+target_compile_options(util-linux-test PRIVATE -Wall -Wextra -Werror)
+
+# Create a 4MB ext4 test image at build time using host mkfs.ext4.
+# This image is used at runtime for mount -t ext4 testing since
+# mkfs.ext4 does not work reliably on the StarryOS guest.
+# 4MB is sufficient for ext4 and avoids excessive memory use when the
+# kernel buffers the entire image in RAM.
+set(EXT4_TEST_IMG "${CMAKE_CURRENT_BINARY_DIR}/test-ext4.img")
+add_custom_command(
+    OUTPUT "${EXT4_TEST_IMG}"
+    COMMAND dd if=/dev/zero of="${EXT4_TEST_IMG}" bs=1M count=4 2>/dev/null
+    COMMAND mkfs.ext4 -F "${EXT4_TEST_IMG}" >/dev/null 2>&1
+    COMMENT "Creating ext4 test image"
+)
+add_custom_target(ext4-img ALL DEPENDS "${EXT4_TEST_IMG}")
+
+install(TARGETS util-linux-test RUNTIME DESTINATION usr/bin)
+install(FILES "${EXT4_TEST_IMG}" DESTINATION usr/share/util-linux-test RENAME test-ext4.img)

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/c/prebuild.sh
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add util-linux e2fsprogs binutils gcc musl-dev

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/c/src/main.c
@@ -1,0 +1,1288 @@
+/*
+ * util-linux-test.c -- util-linux 2.38+ combined verification
+ *
+ * Key dependencies: mount, pivot_root, blkid, fdisk, losetup
+ * Acceptance criteria:
+ *   - mount -t ext4 works (ext4 filesystem mount/unmount)
+ *   - fdisk -l works (partition table listing)
+ *   - losetup full chain (attach/detach loop device)
+ *   - blkid block device identification
+ *   - pivot_root command available
+ *
+ * The ext4 mount test uses a pre-formatted image created during
+ * CMake build via host mkfs.ext4 (available in the CI Docker image).
+ */
+
+#define _GNU_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <fcntl.h>
+#include <sys/mount.h>
+
+static int pass = 0, fail = 0;
+
+static int run(const char *cmd)
+{
+    int ret = system(cmd);
+    if (WIFEXITED(ret))
+        return WEXITSTATUS(ret);
+    return -1;
+}
+
+/* Capture first line of command output into buf, return exit code */
+static int capture(const char *cmd, char *buf, int bufsz)
+{
+    FILE *p = popen(cmd, "r");
+    if (!p) return -1;
+    buf[0] = '\0';
+    if (fgets(buf, bufsz, p)) {
+        int len = (int)strlen(buf);
+        while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+            buf[--len] = '\0';
+    }
+    int status = pclose(p);
+    if (WIFEXITED(status))
+        return WEXITSTATUS(status);
+    return -1;
+}
+
+/* Search for needle in a binary file, return 1 if found, 0 if not */
+static int file_contains(const char *path, const char *needle)
+{
+    size_t nlen = strlen(needle);
+    FILE *f = fopen(path, "rb");
+    if (!f) return 0;
+    char buf[4096];
+    size_t keep = 0;
+    int found = 0;
+    while (!found) {
+        size_t r = fread(buf + keep, 1, sizeof(buf) - keep, f);
+        if (r == 0) break;
+        size_t total = keep + r;
+        size_t scan = (total >= nlen) ? total - nlen + 1 : 0;
+        if (scan > 0 && memmem(buf, total, needle, nlen))
+            found = 1;
+        if (total >= nlen) {
+            keep = nlen - 1;
+            memmove(buf, buf + total - keep, keep);
+        } else {
+            keep = total;
+        }
+    }
+    fclose(f);
+    return found;
+}
+
+/* Write string to file, return 0 on success */
+static int write_file(const char *path, const char *data)
+{
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0) return -1;
+    size_t len = strlen(data);
+    ssize_t w = write(fd, data, len);
+    close(fd);
+    return (w == (ssize_t)len) ? 0 : -1;
+}
+
+/* Read first line of file into buf, return line length or -1 */
+static int read_first_line(const char *path, char *buf, int bufsz)
+{
+    FILE *f = fopen(path, "r");
+    if (!f) return -1;
+    if (!fgets(buf, bufsz, f)) { fclose(f); return -1; }
+    int len = (int)strlen(buf);
+    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+        buf[--len] = '\0';
+    fclose(f);
+    return len;
+}
+
+static void check(int ok, const char *name)
+{
+    if (ok) { printf("  PASS | %s\n", name); pass++; }
+    else    { printf("  FAIL | %s\n", name); fail++; }
+}
+
+/* Path to the pre-formatted ext4 test image (created at CMake build time) */
+#define PREBUILT_IMG "/usr/share/util-linux-test/test-ext4.img"
+
+/* Expected image size: 4 MiB = 4194304 bytes = 8192 sectors */
+#define IMG_BYTES  4194304
+#define IMG_SECTORS 8192
+
+int main(void)
+{
+    char buf[1024];
+    char loopdev[64] = "";
+    int rc;
+
+    printf("=== util-linux 2.38+ test ===\n");
+
+    /* ================================================================
+     *  Tier 1: Tool availability
+     * ================================================================ */
+
+    /* 1. mount present */
+    {
+        rc = run("which mount >/dev/null 2>&1");
+        check(rc == 0, "mount command available");
+    }
+
+    /* 2. losetup present */
+    {
+        rc = run("which losetup >/dev/null 2>&1");
+        check(rc == 0, "losetup command available");
+    }
+
+    /* 3. blkid present */
+    {
+        rc = run("which blkid >/dev/null 2>&1");
+        check(rc == 0, "blkid command available");
+    }
+
+    /* 4. fdisk present */
+    {
+        rc = run("which fdisk >/dev/null 2>&1");
+        check(rc == 0, "fdisk command available");
+    }
+
+    /* ================================================================
+     *  Tier 2: losetup full chain
+     * ================================================================ */
+
+    /* 5. Create 4MB test image */
+    {
+        rc = run("dd if=/dev/zero of=/tmp/ul-test.img bs=1M count=4 2>/dev/null");
+        check(rc == 0, "dd create 4MB image");
+    }
+
+    /* 6. Find free loop device */
+    {
+        rc = capture("losetup -f 2>&1", buf, sizeof(buf));
+        int found = (rc == 0 && strncmp(buf, "/dev/loop", 9) == 0);
+        if (found)
+            snprintf(loopdev, sizeof(loopdev), "%s", buf);
+        check(found, "losetup -f find free device");
+    }
+
+    /* 7. Attach loop device */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s /tmp/ul-test.img 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach");
+    } else {
+        check(0, "losetup attach");
+    }
+
+    /* 8. List attached loop devices */
+    {
+        rc = run("losetup -a 2>&1 | grep -q 'ul-test.img'");
+        check(rc == 0, "losetup -a list attached");
+    }
+
+    /* ================================================================
+     *  Tier 3: fdisk -l (acceptance criterion)
+     * ================================================================ */
+
+    /* 9-10. fdisk -l output: capture and verify disk header + size */
+    {
+        char cmd[256];
+        char fdisk_out[2048];
+        int fdisk_ok = 0;
+
+        /* Capture full fdisk -l output */
+        if (loopdev[0]) {
+            snprintf(cmd, sizeof(cmd), "fdisk -l %s 2>&1", loopdev);
+            /* Read all output lines into fdisk_out */
+            FILE *p = popen(cmd, "r");
+            if (p) {
+                size_t pos = 0;
+                while (pos < sizeof(fdisk_out) - 1 &&
+                       fgets(fdisk_out + pos, sizeof(fdisk_out) - pos, p)) {
+                    pos += strlen(fdisk_out + pos);
+                }
+                fdisk_out[pos] = '\0';
+                int st = pclose(p);
+                fdisk_ok = WIFEXITED(st) && WEXITSTATUS(st) == 0;
+            } else {
+                fdisk_out[0] = '\0';
+            }
+        }
+
+        /* Test 9: disk header present */
+        check(fdisk_ok && strstr(fdisk_out, loopdev) != NULL,
+              "fdisk -l shows disk header");
+
+        /* Test 10: verify size appears in output.
+         * BusyBox fdisk formats vary by version:
+         *   - "4194304 bytes" (direct byte count)
+         *   - "8192 sectors" (sector count)
+         *   - "heads, 32 sectors/track" (geometry-derived)
+         * We check that at least one of these size indicators is present
+         * and consistent with the 4 MiB image (4194304 bytes / 8192 sectors).
+         */
+        {
+            int found_bytes = (strstr(fdisk_out, "4194304") != NULL);
+            int found_sectors = (strstr(fdisk_out, "8192") != NULL);
+            check(found_bytes || found_sectors,
+                  "fdisk -l shows 4 MiB / 8192 sectors");
+        }
+    }
+
+    /* ================================================================
+     *  Tier 4: mount -t ext4 full chain (acceptance criterion)
+     * ================================================================ */
+
+    /* 11. Pre-built ext4 image exists */
+    {
+        struct stat st;
+        rc = (stat(PREBUILT_IMG, &st) == 0 && st.st_size == IMG_BYTES) ? 0 : -1;
+        check(rc == 0, "pre-built ext4 image exists (4 MiB)");
+    }
+
+    /* 12. Detach raw image, attach ext4 image */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        run(cmd);
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach ext4 image");
+    } else {
+        check(0, "losetup attach ext4 image");
+    }
+
+    /* 13. blkid identifies ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "blkid %s 2>&1 | grep -qi 'ext4'", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "blkid identifies ext4 filesystem");
+    } else {
+        check(0, "blkid identifies ext4 filesystem");
+    }
+
+    /* 14. Create mount point */
+    {
+        rc = run("mkdir /tmp/ul-mnt");
+        check(rc == 0, "mkdir mount point");
+    }
+
+    /* 15. mount -t ext4 (acceptance criterion) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount -t ext4 (acceptance)");
+    } else {
+        check(0, "mount -t ext4 (acceptance)");
+    }
+
+    /* 16. Write file on ext4 mount */
+    {
+        rc = write_file("/tmp/ul-mnt/test.txt", "util-linux mount test\n");
+        check(rc == 0, "write file on ext4 mount");
+    }
+
+    /* 17. Read file from ext4 mount */
+    {
+        char content[256] = {0};
+        int len = read_first_line("/tmp/ul-mnt/test.txt", content, sizeof(content));
+        check(len > 0 && strcmp(content, "util-linux mount test") == 0,
+              "read file from ext4 mount");
+    }
+
+    /* 18. umount ext4 */
+    {
+        rc = run("umount /tmp/ul-mnt 2>&1");
+        check(rc == 0, "umount ext4");
+    }
+
+    /* 19. Detach loop device */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup detach");
+    } else {
+        check(0, "losetup detach");
+    }
+
+    /* ================================================================
+     *  Tier 4b: Loop device write persistence
+     *
+     *  Verify that data written through the loop block device survives
+     *  umount + losetup -d.  Re-attach and re-mount the same image,
+     *  then read the file back — it must match what was written above.
+     * ================================================================ */
+
+    /* 20. Re-attach ext4 image */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup re-attach ext4 image");
+    } else {
+        check(0, "losetup re-attach ext4 image");
+    }
+
+    /* 21. Re-mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "re-mount ext4 after detach");
+    } else {
+        check(0, "re-mount ext4 after detach");
+    }
+
+    /* 22. Read file back — must survive umount + detach */
+    {
+        char content[256] = {0};
+        int len = read_first_line("/tmp/ul-mnt/test.txt", content, sizeof(content));
+        check(len > 0 && strcmp(content, "util-linux mount test") == 0,
+              "data persists after umount+detach+remount");
+    }
+
+    /* 23. Cleanup: umount + detach after persistence test */
+    {
+        run("umount /tmp/ul-mnt 2>&1");
+        if (loopdev[0]) {
+            char cmd[256];
+            snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+            run(cmd);
+        }
+    }
+
+    /* ================================================================
+     *  Tier 4c: Loop device write-back without detach
+     *
+     *  Verify that data written through the loop block device survives
+     *  umount followed by a re-mount *without* losetup -d in between.
+     *  This exercises the write-back path in as_dyn_block_device()
+     *  where dirty cache is flushed to the backing file before the
+     *  cache is re-initialised from a fresh read of the file.
+     * ================================================================ */
+
+    /* 24. Attach ext4 image (fresh) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for no-detach test");
+    } else {
+        check(0, "losetup attach for no-detach test");
+    }
+
+    /* 25. Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for no-detach test");
+    } else {
+        check(0, "mount for no-detach test");
+    }
+
+    /* 26. Write distinct file */
+    {
+        rc = write_file("/tmp/ul-mnt/writeback.txt", "writeback ok\n");
+        check(rc == 0, "write writeback.txt on ext4");
+    }
+
+    /* 27. Read back to confirm write */
+    {
+        char content[256] = {0};
+        int len = read_first_line("/tmp/ul-mnt/writeback.txt", content, sizeof(content));
+        check(len > 0 && strcmp(content, "writeback ok") == 0,
+              "read writeback.txt before umount");
+    }
+
+    /* 28. Umount (do NOT detach loop device) */
+    {
+        rc = run("umount /tmp/ul-mnt 2>&1");
+        check(rc == 0, "umount without detach");
+    }
+
+    /* 29. Re-mount same loop device (no detach in between) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "re-mount without detach");
+    } else {
+        check(0, "re-mount without detach");
+    }
+
+    /* 30. Read writeback.txt back — must survive umount-only cycle */
+    {
+        char content[256] = {0};
+        int len = read_first_line("/tmp/ul-mnt/writeback.txt", content, sizeof(content));
+        check(len > 0 && strcmp(content, "writeback ok") == 0,
+              "data persists after umount+remount (no detach)");
+    }
+
+    /* 31. Cleanup: umount + detach */
+    {
+        run("umount /tmp/ul-mnt 2>&1");
+        if (loopdev[0]) {
+            char cmd[256];
+            snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+            run(cmd);
+        }
+    }
+
+    /* ================================================================
+     *  Tier 4d: Loop device write-back — verify via direct image read
+     *
+     *  Verify that data written through the loop block device is
+     *  persisted to the backing file immediately after umount, WITHOUT
+     *  requiring losetup -d or a subsequent mount as a write-back
+     *  trigger.  We write a unique marker string, umount, then grep
+     *  the raw backing image for that string.
+     * ================================================================ */
+
+    /* Attach ext4 image (fresh) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for direct-read test");
+    } else {
+        check(0, "losetup attach for direct-read test");
+    }
+
+    /* Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for direct-read test");
+    } else {
+        check(0, "mount for direct-read test");
+    }
+
+    /* Write unique marker file */
+    {
+        rc = write_file("/tmp/ul-mnt/wb-verify.txt", "WB-VERIFY-a7c3-9f2e\n");
+        check(rc == 0, "write wb-verify.txt on ext4");
+    }
+
+    /* Umount (do NOT detach) */
+    {
+        rc = run("umount /tmp/ul-mnt 2>&1");
+        check(rc == 0, "umount for direct-read test");
+    }
+
+    /* Search the raw backing image for the unique string.
+     * If the umount write-back hook worked correctly, the string
+     * must be present in the image — no detach or re-mount needed. */
+    {
+        rc = file_contains(PREBUILT_IMG, "WB-VERIFY-a7c3-9f2e");
+        check(rc, "data in backing image after umount (no detach)");
+    }
+
+    /* Cleanup: detach */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        run(cmd);
+    }
+
+    /* ================================================================
+     *  Tier 4e: Double mount EBUSY regression
+     *
+     *  Mounting the same loop device to a second mount point while the
+     *  first mount is still active must fail with EBUSY.  Without this
+     *  guard, as_dyn_block_device() would silently replace the cache,
+     *  causing the first mount's ext4 writes to be lost on umount and
+     *  allowing LOOP_CLR_FD to clear the mounted flag while the old
+     *  adapter is still active.
+     * ================================================================ */
+
+    /* Attach ext4 image (fresh) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for double-mount test");
+    } else {
+        check(0, "losetup attach for double-mount test");
+    }
+
+    /* First mount — should succeed */
+    {
+        run("mkdir -p /tmp/ul-mnt2 2>/dev/null");
+        char cmd[256];
+        if (loopdev[0]) {
+            snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+            rc = run(cmd);
+            check(rc == 0, "first mount succeeds (double-mount test)");
+        } else {
+            check(0, "first mount succeeds (double-mount test)");
+        }
+    }
+
+    /* Second mount of same loop device — must fail with EBUSY */
+    {
+        if (loopdev[0]) {
+            errno = 0;
+            rc = mount(loopdev, "/tmp/ul-mnt2", "ext4", 0, NULL);
+            check(rc != 0 && errno == EBUSY,
+                  "second mount of same loop device rejected (EBUSY)");
+        } else {
+            check(0, "second mount of same loop device rejected (EBUSY)");
+        }
+    }
+
+    /* Umount first mount */
+    {
+        rc = run("umount /tmp/ul-mnt 2>&1");
+        check(rc == 0, "umount first mount (double-mount test)");
+    }
+
+    /* After umount, mount at second point should now succeed */
+    {
+        char cmd[256];
+        if (loopdev[0]) {
+            snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt2 2>&1", loopdev);
+            rc = run(cmd);
+            check(rc == 0, "mount at second point succeeds after first umount");
+        } else {
+            check(0, "mount at second point succeeds after first umount");
+        }
+    }
+
+    /* Cleanup: umount + detach */
+    {
+        run("umount /tmp/ul-mnt2 2>&1");
+        if (loopdev[0]) {
+            char cmd[256];
+            snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+            run(cmd);
+        }
+    }
+
+    /* ================================================================
+     *  Tier 4f: Writeback failure propagation via BLKROSET
+     *
+     *  Verify that writeback errors propagate to callers when the
+     *  loop device is set read-only via BLKROSET.  A read-only
+     *  device must not write dirty cache back to the backing file;
+     *  both BLKFLSBUF and umount(2) should return EIO.
+     *
+     *  This is a regression test for the writeback error propagation
+     *  fix: without it, flush_cache_to_file and BLKFLSBUF swallowed
+     *  errors and always returned success, hiding data-loss risk
+     *  from userspace.
+     * ================================================================ */
+
+    /* --- BLKFLSBUF error propagation --- */
+
+    /* Attach ext4 image (fresh) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for writeback-fail test");
+    } else {
+        check(0, "losetup attach for writeback-fail test");
+    }
+
+    /* Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for writeback-fail test");
+    } else {
+        check(0, "mount for writeback-fail test");
+    }
+
+    /* Write data to dirty the block cache */
+    {
+        rc = write_file("/tmp/ul-mnt/wb-fail.txt", "writeback-fail-test\n");
+        check(rc == 0, "write wb-fail.txt for writeback-fail test");
+    }
+
+    /* Open loop device for ioctl */
+    {
+        if (loopdev[0]) {
+            int fd = open(loopdev, O_RDWR);
+            if (fd >= 0) {
+                uint32_t ro;
+
+                /* Set read-only — writeback must now fail */
+                ro = 1;
+                rc = ioctl(fd, 0x125D /* BLKROSET */, &ro);
+                check(rc == 0, "BLKROSET set read-only (BLKFLSBUF test)");
+
+                /* BLKFLSBUF should fail with EIO on read-only device */
+                errno = 0;
+                rc = ioctl(fd, 0x1261 /* BLKFLSBUF */);
+                check(rc == -1 && errno == EIO,
+                      "BLKFLSBUF returns EIO on read-only device (dirty cache)");
+
+                /* Clear read-only — writeback should succeed */
+                ro = 0;
+                rc = ioctl(fd, 0x125D /* BLKROSET */, &ro);
+                check(rc == 0, "BLKROSET clear read-only (BLKFLSBUF test)");
+
+                /* BLKFLSBUF should now succeed */
+                rc = ioctl(fd, 0x1261 /* BLKFLSBUF */);
+                check(rc == 0, "BLKFLSBUF succeeds after clearing read-only");
+
+                close(fd);
+            } else {
+                check(0, "open loop device for writeback-fail test");
+            }
+        } else {
+            check(0, "BLKROSET set read-only (BLKFLSBUF test)");
+            check(0, "BLKFLSBUF returns EIO on read-only device (dirty cache)");
+            check(0, "BLKROSET clear read-only (BLKFLSBUF test)");
+            check(0, "BLKFLSBUF succeeds after clearing read-only");
+        }
+    }
+
+    /* Cleanup: umount + detach */
+    {
+        run("umount /tmp/ul-mnt 2>&1");
+        if (loopdev[0]) {
+            char cmd[256];
+            snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+            run(cmd);
+        }
+    }
+
+    /* --- umount error propagation --- */
+
+    /* Attach ext4 image (fresh) */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for umount-fail test");
+    } else {
+        check(0, "losetup attach for umount-fail test");
+    }
+
+    /* Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for umount-fail test");
+    } else {
+        check(0, "mount for umount-fail test");
+    }
+
+    /* Write data to dirty the block cache */
+    {
+        rc = write_file("/tmp/ul-mnt/umount-fail.txt", "umount-fail-test\n");
+        check(rc == 0, "write umount-fail.txt");
+    }
+
+    /* Set read-only, then umount should fail with EIO */
+    {
+        if (loopdev[0]) {
+            /* Set read-only via ioctl */
+            int fd = open(loopdev, O_RDWR);
+            if (fd >= 0) {
+                uint32_t ro = 1;
+                ioctl(fd, 0x125D /* BLKROSET */, &ro);
+                close(fd);
+            }
+
+            /* umount via syscall to check errno */
+            errno = 0;
+            rc = umount("/tmp/ul-mnt");
+            check(rc != 0 && errno == EIO,
+                  "umount returns EIO when writeback fails (read-only device)");
+
+            /* Filesystem is unmounted despite the error; clear ro
+             * and flush the dirty cache left behind. */
+            fd = open(loopdev, O_RDWR);
+            if (fd >= 0) {
+                uint32_t ro = 0;
+                ioctl(fd, 0x125D /* BLKROSET */, &ro);
+                ioctl(fd, 0x1261 /* BLKFLSBUF */);
+                close(fd);
+            }
+        } else {
+            check(0, "umount returns EIO when writeback fails (read-only device)");
+        }
+    }
+
+    /* Detach */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        run(cmd);
+    }
+
+    /* ================================================================
+     *  Tier 4g: umount EBUSY when cwd is inside the mount
+     *
+     *  Linux umount2 must return EBUSY if any task has its current
+     *  directory inside the target mount.  Without the busy-reference
+     *  check in sys_umount2, the umount would succeed, leaving the
+     *  child's cwd pointing at a detached ext4 instance and preventing
+     *  the loop device from ever detaching (mounted flag stays true).
+     * ================================================================ */
+
+    /* Attach ext4 image */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for umount-busy test");
+    } else {
+        check(0, "losetup attach for umount-busy test");
+    }
+
+    /* Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for umount-busy test");
+    } else {
+        check(0, "mount for umount-busy test");
+    }
+
+    /* Fork child that chdirs into the mount and holds cwd there */
+    {
+        int p2c[2], c2p[2];
+        int pipes_ok = (pipe(p2c) == 0 && pipe(c2p) == 0);
+        pid_t busy_child = -1;
+
+        if (pipes_ok) {
+            busy_child = fork();
+            if (busy_child == 0) {
+                /* child: chdir into mount, signal parent, wait */
+                close(p2c[1]);
+                close(c2p[0]);
+                chdir("/tmp/ul-mnt");
+                char c = 1;
+                write(c2p[1], &c, 1);   /* signal: cwd set */
+                read(p2c[0], &c, 1);    /* wait for parent */
+                chdir("/");             /* leave mount before exiting */
+                close(p2c[0]);
+                close(c2p[1]);
+                _exit(0);
+            }
+            if (busy_child > 0) {
+                close(p2c[0]);
+                close(c2p[1]);
+                /* wait for child to chdir */
+                char c;
+                read(c2p[0], &c, 1);
+
+                /* umount must fail with EBUSY while child holds cwd */
+                errno = 0;
+                rc = umount("/tmp/ul-mnt");
+                check(rc != 0 && errno == EBUSY,
+                      "umount EBUSY when child cwd inside mount");
+
+                /* signal child to exit */
+                c = 1;
+                write(p2c[1], &c, 1);
+                int status;
+                waitpid(busy_child, &status, 0);
+                close(p2c[1]);
+                close(c2p[0]);
+
+                /* After child exits, umount should succeed */
+                errno = 0;
+                rc = umount("/tmp/ul-mnt");
+                check(rc == 0, "umount succeeds after child exits");
+            }
+        }
+        if (!pipes_ok || busy_child < 0) {
+            check(0, "umount EBUSY when child cwd inside mount");
+            check(0, "umount succeeds after child exits");
+        }
+    }
+
+    /* Cleanup: detach */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        run(cmd);
+    }
+
+    /* ================================================================
+     *  Tier 4h: pivot_root EINVAL when caller is chroot'd into a
+     *           subdirectory (not a mount point)
+     *
+     *  Linux pivot_root(2) requires the caller's current root to be a
+     *  mount point.  A process that chroot'd into a regular
+     *  subdirectory must get EINVAL, not succeed and corrupt the
+     *  mount tree.
+     * ================================================================ */
+    {
+        run("mkdir -p /tmp/pivot-chroot/sub/nr 2>/dev/null");
+        int setup_ok = (run("mount -t tmpfs tmpfs /tmp/pivot-chroot 2>&1") == 0);
+        /* Mount tmpfs inside the chroot directory so the child can
+         * resolve /nr after chroot.  The key point is that the child's
+         * root (/tmp/pivot-chroot/sub) is a plain directory, NOT the
+         * root of any mount. */
+        setup_ok = setup_ok && (run("mkdir -p /tmp/pivot-chroot/sub/nr 2>&1") == 0);
+        setup_ok = setup_ok && (run("mount -t tmpfs tmpfs /tmp/pivot-chroot/sub/nr 2>&1") == 0);
+        setup_ok = setup_ok && (run("mkdir /tmp/pivot-chroot/sub/nr/putold 2>&1") == 0);
+
+        if (setup_ok) {
+            pid_t p = fork();
+            if (p == 0) {
+                /* chroot into /tmp/pivot-chroot/sub — a plain directory,
+                 * NOT the root of any mount. */
+                chdir("/tmp/pivot-chroot/sub");
+                chroot("/tmp/pivot-chroot/sub");
+
+                /* pivot_root must fail with EINVAL because the caller's
+                 * root is not a mount point. */
+                errno = 0;
+                int ret = syscall(__NR_pivot_root, "/nr", "/nr/putold");
+                int got_einval = (ret != 0 && errno == EINVAL);
+                _exit(got_einval ? 0 : 1);
+            } else if (p > 0) {
+                int status;
+                waitpid(p, &status, 0);
+                int ok = WIFEXITED(status) && WEXITSTATUS(status) == 0;
+                check(ok, "pivot_root EINVAL after chroot to subdirectory");
+            } else {
+                check(0, "pivot_root EINVAL after chroot to subdirectory");
+            }
+
+            /* cleanup tmpfs mounts */
+            run("umount /tmp/pivot-chroot/sub/nr 2>&1");
+            run("umount /tmp/pivot-chroot 2>&1");
+        } else {
+            check(0, "pivot_root EINVAL after chroot to subdirectory");
+        }
+    }
+
+    /* ================================================================
+     *  Tier 4i: umount EBUSY when open fd is inside the mount
+     *
+     *  Linux umount2 must return EBUSY if any task has an open file
+     *  descriptor pointing into the target mount.  This complements
+     *  the cwd/root busy check (Tier 4g) by covering the open-fd path.
+     * ================================================================ */
+
+    /* Attach ext4 image */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for umount-fd-busy test");
+    } else {
+        check(0, "losetup attach for umount-fd-busy test");
+    }
+
+    /* Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for umount-fd-busy test");
+    } else {
+        check(0, "mount for umount-fd-busy test");
+    }
+
+    /* Open a file inside the mount, then verify umount fails with EBUSY */
+    {
+        int mnt_fd = open("/tmp/ul-mnt/test.txt", O_RDONLY);
+        if (mnt_fd >= 0) {
+            errno = 0;
+            rc = umount("/tmp/ul-mnt");
+            check(rc != 0 && errno == EBUSY,
+                  "umount EBUSY when open fd inside mount");
+
+            /* Close the fd, umount should now succeed */
+            close(mnt_fd);
+            errno = 0;
+            rc = umount("/tmp/ul-mnt");
+            check(rc == 0, "umount succeeds after closing fd");
+        } else {
+            /* fd open failed — skip but still try umount */
+            check(0, "umount EBUSY when open fd inside mount");
+            run("umount /tmp/ul-mnt 2>&1");
+        }
+    }
+
+    /* Cleanup: detach */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        run(cmd);
+    }
+
+    /* ================================================================
+     *  Tier 4j: LO_FLAGS_READ_ONLY via losetup -r
+     *
+     *  Verify that attaching a loop device in read-only mode (-r flag)
+     *  correctly sets the read-only flag via LOOP_CONFIGURE.  Mounting
+     *  ext4 on a read-only loop device must prevent writes.
+     * ================================================================ */
+
+    /* Attach ext4 image as read-only */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -r %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup -r attach read-only");
+    } else {
+        check(0, "losetup -r attach read-only");
+    }
+
+    /* Verify BLKROGET reports read-only */
+    {
+        if (loopdev[0]) {
+            int fd = open(loopdev, O_RDONLY);
+            if (fd >= 0) {
+                uint32_t ro = 0;
+                rc = ioctl(fd, 0x125E /* BLKROGET */, &ro);
+                check(rc == 0 && ro == 1,
+                      "BLKROGET reports read-only after losetup -r");
+                close(fd);
+            } else {
+                check(0, "BLKROGET reports read-only after losetup -r");
+            }
+        } else {
+            check(0, "BLKROGET reports read-only after losetup -r");
+        }
+    }
+
+    /* Mount ext4 (read-only) and verify write fails */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        if (rc == 0) {
+            /* Writing to a file on a read-only mounted ext4 should fail */
+            int wr = write_file("/tmp/ul-mnt/ro-test.txt", "must fail\n");
+            check(wr != 0, "write fails on read-only loop mount");
+            run("umount /tmp/ul-mnt 2>&1");
+        } else {
+            /* Mount itself may fail if ext4 rejects read-only loop;
+             * either outcome is acceptable for this test. */
+            check(1, "write fails on read-only loop mount");
+        }
+    } else {
+        check(0, "write fails on read-only loop mount");
+    }
+
+    /* Cleanup: detach */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+        run(cmd);
+    }
+
+    /* ================================================================
+     *  Tier 4k: umount EINVAL for non-mount-point directory
+     *
+     *  Linux umount2 returns EINVAL when the target is not a mount
+     *  point.  Without the is_root_of_mount() guard, the busy check
+     *  would falsely return EBUSY because the target's mountpoint
+     *  (rootfs) matches every task's cwd/root.
+     * ================================================================ */
+    {
+        errno = 0;
+        rc = umount("/tmp/ul-mnt");
+        check(rc != 0 && errno == EINVAL,
+              "umount EINVAL for non-mount-point directory");
+    }
+
+    /* ================================================================
+     *  Tier 4l: LOOP_CLR_FD EBUSY when mount has open fds
+     *
+     *  Verify that LOOP_CLR_FD (losetup -d) returns EBUSY while the
+     *  loop device still has an active mount with open files.  This
+     *  ensures that the mounted flag is not prematurely cleared,
+     *  which would allow detach while the block device is still in use.
+     * ================================================================ */
+
+    /* Attach ext4 image */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for detach-busy test");
+    } else {
+        check(0, "losetup attach for detach-busy test");
+    }
+
+    /* Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for detach-busy test");
+    } else {
+        check(0, "mount for detach-busy test");
+    }
+
+    /* Open a file, then try losetup -d — must fail with EBUSY */
+    {
+        int mnt_fd = open("/tmp/ul-mnt/test.txt", O_RDONLY);
+        if (mnt_fd >= 0) {
+            /* losetup -d while fd is open: should fail */
+            if (loopdev[0]) {
+                char cmd[256];
+                snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+                rc = run(cmd);
+                /* busybox losetup -d returns non-zero on EBUSY */
+                check(rc != 0, "losetup -d EBUSY while mount has open fd");
+            } else {
+                check(0, "losetup -d EBUSY while mount has open fd");
+            }
+
+            close(mnt_fd);
+        } else {
+            check(0, "losetup -d EBUSY while mount has open fd");
+        }
+    }
+
+    /* Cleanup: umount then detach */
+    {
+        run("umount /tmp/ul-mnt 2>&1");
+        if (loopdev[0]) {
+            char cmd[256];
+            snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+            run(cmd);
+        }
+    }
+
+    /* ================================================================
+     *  Tier 5: pivot_root command availability & semantics
+     * ================================================================ */
+
+    /* 32. pivot_root command exists */
+    {
+        int exists = (run("which pivot_root >/dev/null 2>&1") == 0);
+        check(exists, "pivot_root command exists");
+    }
+
+    /* 33. pivot_root semantics: old root appears at put_old.
+     *
+     *  pivot_root(2) reorganises the global mount tree and, matching
+     *  Linux chroot_fs_refs(), updates root/cwd for every task whose
+     *  root or cwd pointed at the old root.  We fork a child so that
+     *  the child's _exit() does not terminate the test runner; the
+     *  mount tree change is global and propagates to the parent.
+     *
+     *  Inside the child we:
+     *    1. pivot_root /tmp/pivot-newroot /tmp/pivot-newroot/oldroot
+     *    2. stat /oldroot — must succeed (old root moved here)
+     *    3. stat /oldroot/tmp — must succeed (original root content)
+     *
+     *  After the child exits, the parent also verifies that its own
+     *  root was switched to the new root (chroot_fs_refs semantic)
+     *  and can still reach the old filesystem through /oldroot.
+     *
+     *  Additionally we verify that a task chroot'd into a subdirectory
+     *  of the old root is NOT affected by pivot_root — only tasks
+     *  whose root *exactly equals* old_root should be updated.
+     */
+    {
+        /* Set up sentinel for the chroot-subdirectory regression child */
+        run("mkdir -p /tmp/chroot-sub");
+        run("touch /tmp/chroot-sub/sentinel");
+
+        run("mkdir -p /tmp/pivot-newroot 2>&1");
+        int mnt_ok = (run("mount -t tmpfs tmpfs /tmp/pivot-newroot 2>&1") == 0);
+        if (mnt_ok) {
+            run("mkdir /tmp/pivot-newroot/oldroot 2>&1");
+
+            /* ---- chroot-subdirectory regression child ----
+             * Fork before pivot_root, chroot into /tmp/chroot-sub (a
+             * subdirectory of the old root), then verify after pivot_root
+             * that this child's root was NOT replaced with new_root. */
+            int ch_p2c[2], ch_c2p[2];
+            int ch_pipes_ok = (pipe(ch_p2c) == 0 && pipe(ch_c2p) == 0);
+            pid_t chroot_child = -1;
+            if (ch_pipes_ok) {
+                chroot_child = fork();
+                if (chroot_child == 0) {
+                    close(ch_p2c[1]);
+                    close(ch_c2p[0]);
+
+                    /* chroot into /tmp/chroot-sub */
+                    chdir("/tmp/chroot-sub");
+                    chroot("/tmp/chroot-sub");
+
+                    struct stat st;
+                    ino_t root_ino = (stat("/", &st) == 0) ? st.st_ino : 0;
+
+                    /* signal parent: chroot done */
+                    char c = 1;
+                    write(ch_c2p[1], &c, 1);
+
+                    /* wait for pivot_root */
+                    read(ch_p2c[0], &c, 1);
+
+                    /* verify root unchanged */
+                    ino_t new_ino = (stat("/", &st) == 0) ? st.st_ino : 0;
+                    int root_ok = (root_ino != 0 && root_ino == new_ino);
+                    int sentinel_ok = (stat("/sentinel", &st) == 0);
+
+                    char result = (root_ok && sentinel_ok) ? 1 : 0;
+                    write(ch_c2p[1], &result, 1);
+
+                    close(ch_p2c[0]);
+                    close(ch_c2p[1]);
+                    _exit(0);
+                }
+                /* parent: close child-side fds */
+                if (chroot_child > 0) {
+                    close(ch_p2c[0]);
+                    close(ch_c2p[1]);
+                    /* wait for child to finish chroot */
+                    char c;
+                    read(ch_c2p[0], &c, 1);
+                }
+            }
+
+            pid_t pid = fork();
+            if (pid == 0) {
+                /* child — perform pivot_root */
+                int ret = syscall(__NR_pivot_root,
+                                  "/tmp/pivot-newroot",
+                                  "/tmp/pivot-newroot/oldroot");
+                if (ret == 0) {
+                    struct stat st;
+                    int ok = (stat("/oldroot", &st) == 0 &&
+                              S_ISDIR(st.st_mode) &&
+                              stat("/oldroot/tmp", &st) == 0);
+                    _exit(ok ? 0 : 1);
+                }
+                _exit(2); /* pivot_root itself failed */
+            } else if (pid > 0) {
+                int status;
+                waitpid(pid, &status, 0);
+                if (WIFEXITED(status)) {
+                    int ec = WEXITSTATUS(status);
+                    check(ec == 0, "pivot_root: child sees old root at put_old");
+                } else {
+                    check(0, "pivot_root: child sees old root at put_old");
+                }
+
+                /* After pivot_root + chroot_fs_refs propagation the
+                 * parent's root has also been switched to the new root
+                 * (tmpfs).  Verify with a direct stat syscall — shell
+                 * commands are unavailable because /bin/sh is now under
+                 * /oldroot. */
+                {
+                    struct stat st;
+                    int parent_ok = (stat("/oldroot", &st) == 0 &&
+                                     S_ISDIR(st.st_mode));
+                    check(parent_ok,
+                          "pivot_root: parent root updated (chroot_fs_refs)");
+                }
+
+                /* Signal chroot child to re-check and collect result */
+                if (chroot_child > 0) {
+                    char c = 1;
+                    write(ch_p2c[1], &c, 1);
+                    char result = 0;
+                    read(ch_c2p[0], &result, 1);
+                    check(result == 1,
+                          "chroot subdirectory: root not replaced after pivot_root");
+                    close(ch_p2c[1]);
+                    close(ch_c2p[0]);
+                    waitpid(chroot_child, &status, 0);
+                }
+            } else {
+                check(0, "pivot_root: fork failed");
+            }
+
+            /* No umount cleanup: after pivot_root the mount tree is
+             * permanently rearranged.  The old mountpoint slot was
+             * cleared by pivot_mount, and the parent's root is now the
+             * tmpfs.  The QEMU VM is discarded after the test. */
+        } else {
+            check(0, "pivot_root: mount tmpfs for new root");
+        }
+    }
+
+    /* ================================================================
+     *  Tier 5a: second pivot_root — verify mount tree hierarchy
+     *
+     *  After the first pivot_root (test 33) the current root is a
+     *  tmpfs with the original root at /oldroot.  We mount a second
+     *  tmpfs and pivot_root again, then verify the entire mount tree
+     *  hierarchy is preserved:
+     *
+     *    new root (second tmpfs)
+     *      /putold → first tmpfs (old root from second pivot)
+     *        /oldroot → original root (old root from first pivot)
+     *
+     *  This exercises propagate_pivot_root a second time and confirms
+     *  the mount tree restructuring is correct across stacked pivots.
+     *
+     *  All operations use direct syscalls because after the first
+     *  pivot_root /bin/sh is no longer at its original path.
+     *
+     *  Note: the original chroot regression test (verifying that
+     *  propagate_pivot_root skips tasks chroot'd into subdirectories)
+     *  cannot be exercised here because fork'd children initialise
+     *  their FS_CONTEXT from ROOT_FS_CONTEXT, which is never updated
+     *  by pivot_root and becomes stale after the first pivot — the
+     *  child cannot resolve any paths.  The Location::ptr_eq fix is
+     *  verified indirectly: test 33's propagate_pivot_root correctly
+     *  updates only tasks whose root_dir exactly matches old_root
+     *  (mountpoint + dentry), using Location::ptr_eq.
+     * ================================================================ */
+    {
+        int setup_ok = (mkdir("/pivot2-nr", 0755) == 0);
+        setup_ok = setup_ok && (mount("tmpfs", "/pivot2-nr", "tmpfs", 0, NULL) == 0);
+        setup_ok = setup_ok && (mkdir("/pivot2-nr/putold", 0755) == 0);
+
+        if (setup_ok) {
+            int piv_ok = (syscall(__NR_pivot_root,
+                                  "/pivot2-nr", "/pivot2-nr/putold") == 0);
+
+            if (piv_ok) {
+                struct stat st;
+                /* putold should contain the first tmpfs */
+                int ok = (stat("/putold", &st) == 0 && S_ISDIR(st.st_mode));
+                check(ok, "pivot_root 2: /putold accessible (first tmpfs)");
+
+                /* The original root should still be reachable through
+                 * the first tmpfs's /oldroot mountpoint */
+                ok = (stat("/putold/oldroot", &st) == 0 && S_ISDIR(st.st_mode));
+                check(ok, "pivot_root 2: /putold/oldroot (original root)");
+
+                /* Original content should still be visible */
+                ok = (stat("/putold/oldroot/tmp", &st) == 0);
+                check(ok, "pivot_root 2: original root content reachable");
+            } else {
+                check(0, "pivot_root 2: syscall failed");
+            }
+        } else {
+            check(0, "pivot_root 2: setup failed");
+        }
+    }
+
+    /* Cleanup: after a successful pivot_root the old filesystem is at
+     * /oldroot; if pivot_root was not reached the original paths apply.
+     * One of these two calls will succeed, the other silently fails. */
+    unlink("/tmp/ul-test.img");
+    unlink("/oldroot/tmp/ul-test.img");
+
+    printf("=== total: %d passed, %d failed ===\n", pass, fail);
+
+    if (fail > 0) return 1;
+    printf("UTIL LINUX TEST PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/aarch64-unknown-none-softfloat/rootfs-aarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/util-linux-test"
+success_regex = ["(?m)^UTIL LINUX TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^\s*FAIL \|']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/loongarch64-unknown-none-softfloat/rootfs-loongarch64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/util-linux-test"
+success_regex = ["(?m)^UTIL LINUX TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^\s*FAIL \|']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/riscv64gc-unknown-none-elf/rootfs-riscv64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/util-linux-test"
+success_regex = ["(?m)^UTIL LINUX TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^\s*FAIL \|']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-nographic",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/x86_64-unknown-none/rootfs-x86_64.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/util-linux-test"
+success_regex = ["(?m)^UTIL LINUX TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^\s*FAIL \|']
+timeout = 60


### PR DESCRIPTION
Address four code-review issues and a StoreFault regression in the loop device / mount subsystem:

- Replace the flat 4 MiB CacheData buffer with 4 KiB chunked storage (Vec<Vec<u8>>).  Individual 4 KiB heap allocations succeed even when physical memory is fragmented after many mount/umount cycles, whereas a single contiguous 4 MiB allocation caused StoreFault on 128 MiB QEMU targets (riscv64, aarch64, loongarch64).

- Store the full LO_FLAGS bitmask (READ_ONLY, AUTOCLEAR, PARTSCAN, DIRECT_IO) in LoopDevice.flags via set_lo_flags(), syncing the ro boolean from the READ_ONLY bit.  LOOP_CONFIGURE now preserves all user-provided flags; BLKROSET toggles only READ_ONLY while keeping the rest intact.

- Extend is_mount_busy() in sys_umount2 to scan every task's fd table for open File/Directory descriptors pointing into the target mount, in addition to the existing cwd/root check.  Match Linux semantics where umount must fail with EBUSY if any fd references the mount.

- Check is_root_of_mount() before is_mount_busy() so that umount("/non-mount-dir") correctly returns EINVAL instead of a spurious EBUSY (the directory's mountpoint is rootfs, matching every task's cwd/root).

- Ensure flush_cache_to_file() clears the mounted flag unconditionally before propagating writeback errors, so a subsequent re-mount is not blocked by a stale mounted=true after a failed umount.

- Use chunked writeback_buffer() in all writeback paths (LOOP_CLR_FD, BLKFLSBUF, flush_cache_to_file) to avoid both cloning the full cache under SpinNoPreempt and holding the lock across VFS I/O.

Add test coverage: umount EBUSY with open fd, LO_FLAGS_READ_ONLY via losetup -r, umount EINVAL for non-mount-point, LOOP_CLR_FD EBUSY with active mount.  All 73 tests pass on riscv64.