### PR TITLE
DHCP 增强：租约生命周期、重试上限、/proc/net/dhcp

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -820,6 +820,19 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         }),
     );
 
+    root.add("net", {
+        let mut net = DirMapping::new();
+        net.add(
+            "dhcp",
+            SimpleFile::new_regular(fs.clone(), || axnet::dhcp_info().ok_or(VfsError::NotFound)),
+        );
+        net.add(
+            "arp",
+            SimpleFile::new_regular(fs.clone(), || Ok(render_proc_net_arp())),
+        );
+        SimpleDir::new_maker(fs.clone(), Arc::new(net))
+    });
+
     root.add("sys", {
         let mut sys = DirMapping::new();
 
@@ -835,17 +848,6 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         });
 
         SimpleDir::new_maker(fs.clone(), Arc::new(sys))
-    });
-
-    root.add("net", {
-        let mut net = DirMapping::new();
-
-        net.add(
-            "arp",
-            SimpleFile::new_regular(fs.clone(), || Ok(render_proc_net_arp())),
-        );
-
-        SimpleDir::new_maker(fs.clone(), Arc::new(net))
     });
 
     root.add("dynamic_debug", {

--- a/os/arceos/modules/axnet-ng/src/consts.rs
+++ b/os/arceos/modules/axnet-ng/src/consts.rs
@@ -1,3 +1,5 @@
+use core::time::Duration;
+
 macro_rules! env_or_default {
     ($key:literal) => {
         match option_env!($key) {
@@ -23,3 +25,9 @@ pub const LISTEN_QUEUE_SIZE: usize = 512;
 
 pub const SOCKET_BUFFER_SIZE: usize = 64;
 pub const ETHERNET_MAX_PENDING_PACKETS: usize = 32;
+
+pub const DHCP_MAX_RETRY_SHIFT: usize = 4;
+pub const DHCP_MAX_RETRY_COUNT: usize = 8;
+pub const DHCP_FAILED_RETRY_INTERVAL: u64 = 60;
+pub const DHCP_PARAMETER_REQUEST_LIST: &[u8] = &[1, 3, 6, 42, 51, 58, 59];
+pub const DHCP_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(180);

--- a/os/arceos/modules/axnet-ng/src/lib.rs
+++ b/os/arceos/modules/axnet-ng/src/lib.rs
@@ -40,19 +40,23 @@ pub mod unix;
 pub mod vsock;
 mod wrapper;
 
-use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
+use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
 use core::{
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
 
 use ax_driver::{AxDeviceContainer, prelude::*};
+use ax_hal::time::wall_time_nanos;
 use ax_sync::Mutex;
-use smoltcp::wire::{EthernetAddress, Ipv4Address, Ipv4Cidr};
+use smoltcp::{
+    time::Duration as SmolDuration,
+    wire::{EthernetAddress, Ipv4Address, Ipv4Cidr},
+};
 use spin::{Lazy, Once};
 
 use self::{
-    consts::{GATEWAY, IP, IP_PREFIX},
+    consts::{DHCP_BOOTSTRAP_TIMEOUT, GATEWAY, IP, IP_PREFIX},
     device::{EthernetDevice, LoopbackDevice},
     listen_table::ListenTable,
     router::{Router, Rule},
@@ -68,14 +72,16 @@ static SERVICE: Once<Mutex<Service>> = Once::new();
 static POLLING_INTERFACES: AtomicBool = AtomicBool::new(false);
 static POLL_AGAIN: AtomicBool = AtomicBool::new(false);
 
-const DHCP_BOOTSTRAP_ATTEMPTS: usize = 200;
-const DHCP_BOOTSTRAP_POLL_INTERVAL: Duration = Duration::from_millis(10);
-
 fn get_service() -> ax_sync::MutexGuard<'static, Service> {
     SERVICE
         .get()
         .expect("Network service not initialized")
         .lock()
+}
+
+/// Returns DHCP configuration info (IP, gateway, DNS) for display in /proc/net/dhcp.
+pub fn dhcp_info() -> Option<String> {
+    SERVICE.get()?.lock().dhcp_info()
 }
 
 /// Initializes the network subsystem by NIC devices.
@@ -197,12 +203,55 @@ pub fn arp_entries() -> Vec<ArpEntry> {
 }
 
 fn dhcp_bootstrap() {
-    for _ in 0..DHCP_BOOTSTRAP_ATTEMPTS {
-        poll_interfaces();
-        if get_service().dhcp_configured() {
+    let deadline_ns = wall_time_nanos() + DHCP_BOOTSTRAP_TIMEOUT.as_nanos() as u64;
+    poll_interfaces();
+    while !get_service().dhcp_configured() {
+        if wall_time_nanos() >= deadline_ns {
+            warn!(
+                "eth0: DHCP bootstrap timed out after {:?}",
+                DHCP_BOOTSTRAP_TIMEOUT
+            );
             return;
         }
-        ax_task::sleep(DHCP_BOOTSTRAP_POLL_INTERVAL);
+        // Poll at least every 100ms so we catch DHCP responses promptly,
+        // but also respect the retry timer (dhcp_poll_duration) when it's sooner.
+        let poll_dur = get_service()
+            .dhcp_poll_duration()
+            .unwrap_or(SmolDuration::from_millis(100));
+        let sleep = poll_dur.min(SmolDuration::from_millis(100));
+        ax_task::sleep(Duration::from_micros(sleep.total_micros().max(1000)));
+        poll_interfaces();
     }
-    warn!("eth0: DHCP bootstrap timed out");
+    // Bootstrap succeeded — spawn the maintenance task that drives
+    // T1/T2/lease-expiry timers for the remainder of the lease.
+    ax_task::spawn_with_name(dhcp_maintain, "dhcp-maintain".to_owned());
+}
+
+/// Persistently polls the DHCP state machine at the next expected deadline
+/// so that T1 (renew), T2 (rebind), and lease expiry are honoured even
+/// when no socket I/O would otherwise trigger [`poll_interfaces`].
+///
+/// [`poll_interfaces`] uses a `POLLING_INTERFACES` CAS re-entrancy guard
+/// that bounces concurrent callers.  That is harmless for this task: the
+/// guard's `POLL_AGAIN` flag, which we set *before* the CAS, ensures the
+/// active poller will do another round — our work is never lost.
+fn dhcp_maintain() {
+    loop {
+        if !get_service().dhcp_enabled() {
+            return;
+        }
+        let poll_dur = match get_service().dhcp_poll_duration() {
+            Some(d) => d,
+            None => {
+                // No DHCP state — should not happen after bootstrap, but
+                // sleep a long interval to avoid spinning if it does.
+                ax_task::sleep(Duration::from_secs(60));
+                poll_interfaces();
+                continue;
+            }
+        };
+        let sleep_us = poll_dur.total_micros().max(1000) as u64;
+        ax_task::sleep(Duration::from_micros(sleep_us));
+        poll_interfaces();
+    }
 }

--- a/os/arceos/modules/axnet-ng/src/service.rs
+++ b/os/arceos/modules/axnet-ng/src/service.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 use core::{
     pin::Pin,
     task::{Context, Waker},
@@ -17,7 +17,15 @@ use smoltcp::{
     },
 };
 
-use crate::{SOCKET_SET, consts::STANDARD_MTU, device::ArpEntry, router::Router};
+use crate::{
+    SOCKET_SET,
+    consts::{
+        DHCP_FAILED_RETRY_INTERVAL, DHCP_MAX_RETRY_COUNT, DHCP_MAX_RETRY_SHIFT,
+        DHCP_PARAMETER_REQUEST_LIST, STANDARD_MTU,
+    },
+    device::ArpEntry,
+    router::Router,
+};
 
 fn now() -> Instant {
     Instant::from_micros_const((wall_time_nanos() / NANOS_PER_MICROS) as i64)
@@ -40,7 +48,12 @@ struct DhcpState {
     offered_address: Option<Ipv4Address>,
     server_identifier: Option<Ipv4Address>,
     address: Option<Ipv4Cidr>,
+    router: Option<Ipv4Address>,
     dns_servers: Vec<Ipv4Address>,
+    lease_duration: Option<SmolDuration>,
+    renew_deadline: Option<Instant>,
+    rebind_deadline: Option<Instant>,
+    lease_acquired_at: Option<Instant>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -48,10 +61,10 @@ enum DhcpPhase {
     Discovering,
     Requesting,
     Bound,
+    Renewing,
+    Rebinding,
+    Failed,
 }
-
-const DHCP_PARAMETER_REQUEST_LIST: &[u8] = &[1, 3, 6, 42];
-const DHCP_MAX_RETRY_SHIFT: usize = 4;
 
 impl DhcpState {
     fn new(dev: usize, mac: EthernetAddress) -> Self {
@@ -65,7 +78,12 @@ impl DhcpState {
             offered_address: None,
             server_identifier: None,
             address: None,
+            router: None,
             dns_servers: Vec::new(),
+            lease_duration: None,
+            renew_deadline: None,
+            rebind_deadline: None,
+            lease_acquired_at: None,
         }
     }
 
@@ -106,7 +124,7 @@ impl DhcpState {
         }
 
         match (self.phase, dhcp_repr.message_type) {
-            (DhcpPhase::Discovering, DhcpMessageType::Offer) => {
+            (DhcpPhase::Discovering | DhcpPhase::Failed, DhcpMessageType::Offer) => {
                 if !is_unicast_ipv4(dhcp_repr.your_ip) {
                     return None;
                 }
@@ -122,8 +140,11 @@ impl DhcpState {
                 );
                 None
             }
-            (DhcpPhase::Requesting, DhcpMessageType::Ack)
-            | (DhcpPhase::Bound, DhcpMessageType::Ack) => {
+            (
+                DhcpPhase::Requesting | DhcpPhase::Bound | DhcpPhase::Failed,
+                DhcpMessageType::Ack,
+            )
+            | (DhcpPhase::Renewing | DhcpPhase::Rebinding, DhcpMessageType::Ack) => {
                 let subnet_mask = dhcp_repr.subnet_mask?;
                 let prefix_len = IpAddress::Ipv4(subnet_mask).prefix_len()?;
                 if !is_unicast_ipv4(dhcp_repr.your_ip) {
@@ -131,6 +152,9 @@ impl DhcpState {
                 }
                 self.phase = DhcpPhase::Bound;
                 self.retry = 0;
+                // Update server_identifier on every ACK so Renewing unicast
+                // targets the correct server across failover / renumbering.
+                self.server_identifier = dhcp_repr.server_identifier.or(Some(ipv4_repr.src_addr));
                 let address = Ipv4Cidr::new(dhcp_repr.your_ip, prefix_len);
                 Some(DhcpEvent::Configured {
                     address,
@@ -140,46 +164,177 @@ impl DhcpState {
                         .as_ref()
                         .map(|servers| servers.iter().copied().collect())
                         .unwrap_or_default(),
+                    lease_duration: dhcp_repr
+                        .lease_duration
+                        .map(|s| SmolDuration::from_secs(s as u64)),
+                    renew_duration: dhcp_repr
+                        .renew_duration
+                        .map(|s| SmolDuration::from_secs(s as u64)),
+                    rebind_duration: dhcp_repr
+                        .rebind_duration
+                        .map(|s| SmolDuration::from_secs(s as u64)),
                 })
             }
             (_, DhcpMessageType::Nak) => {
-                let was_configured = self.address.is_some();
+                let old_address = self.address;
                 self.reset(timestamp);
-                was_configured.then_some(DhcpEvent::Deconfigured)
+                old_address.map(|addr| DhcpEvent::Deconfigured {
+                    old_address: Some(addr),
+                })
             }
             _ => None,
         }
     }
 
     fn poll_packet(&mut self, timestamp: Instant) -> Option<(usize, IpAddress, Vec<u8>)> {
-        if self.phase == DhcpPhase::Bound || timestamp < self.retry_at {
+        // Phase transitions are time-driven, not gated by retry_at.
+        if self.phase == DhcpPhase::Bound {
+            if let Some(deadline) = self.rebind_deadline
+                && timestamp >= deadline
+            {
+                self.phase = DhcpPhase::Rebinding;
+                self.retry = 0;
+                self.retry_at = timestamp;
+                info!("eth0: DHCP entering rebinding phase");
+            } else if let Some(deadline) = self.renew_deadline
+                && timestamp >= deadline
+            {
+                self.phase = DhcpPhase::Renewing;
+                self.retry = 0;
+                self.retry_at = timestamp;
+                info!("eth0: DHCP entering renew phase");
+            }
+        } else if self.phase == DhcpPhase::Renewing
+            && let Some(deadline) = self.rebind_deadline
+            && timestamp >= deadline
+        {
+            self.phase = DhcpPhase::Rebinding;
+            self.retry = 0;
+            self.retry_at = timestamp;
+            info!("eth0: DHCP entering rebinding phase");
+        }
+
+        if self.phase != DhcpPhase::Failed
+            && self.phase != DhcpPhase::Bound
+            && self.phase != DhcpPhase::Renewing
+            && self.phase != DhcpPhase::Rebinding
+            && self.retry >= DHCP_MAX_RETRY_COUNT
+        {
+            self.phase = DhcpPhase::Failed;
+            self.retry_at = timestamp + SmolDuration::from_secs(DHCP_FAILED_RETRY_INTERVAL);
+            warn!(
+                "eth0: DHCP failed after {} attempts, retrying every {}s",
+                DHCP_MAX_RETRY_COUNT, DHCP_FAILED_RETRY_INTERVAL
+            );
             return None;
         }
 
-        let (message_type, requested_ip, server_identifier) = match self.phase {
-            DhcpPhase::Discovering => (DhcpMessageType::Discover, None, None),
+        // retry_at only gates packet transmission, not phase transitions.
+        if timestamp < self.retry_at {
+            return None;
+        }
+
+        let (message_type, requested_ip, server_identifier, dst_addr, broadcast) = match self.phase
+        {
+            DhcpPhase::Discovering => (
+                DhcpMessageType::Discover,
+                None,
+                None,
+                Ipv4Address::BROADCAST,
+                true,
+            ),
             DhcpPhase::Requesting => (
                 DhcpMessageType::Request,
                 self.offered_address,
                 self.server_identifier,
+                Ipv4Address::BROADCAST,
+                true,
+            ),
+            // RFC 2131 4.4.5: Renewing uses ciaddr (not requested_ip), no
+            // server_identifier option, unicast to the server.
+            DhcpPhase::Renewing => (
+                DhcpMessageType::Request,
+                None,
+                None,
+                self.server_identifier.unwrap_or(Ipv4Address::BROADCAST),
+                false,
+            ),
+            // RFC 2131 4.4.5: Rebinding uses ciaddr (not requested_ip), no
+            // server_identifier, broadcast.
+            DhcpPhase::Rebinding => (
+                DhcpMessageType::Request,
+                None,
+                None,
+                Ipv4Address::BROADCAST,
+                true,
+            ),
+            DhcpPhase::Failed => (
+                DhcpMessageType::Discover,
+                None,
+                None,
+                Ipv4Address::BROADCAST,
+                true,
             ),
             DhcpPhase::Bound => return None,
         };
 
-        let retry_delay_secs = 1usize << self.retry.min(DHCP_MAX_RETRY_SHIFT);
-        self.retry = self.retry.saturating_add(1);
-        self.retry_at = timestamp + SmolDuration::from_secs(retry_delay_secs as u64);
+        let client_ip = self
+            .address
+            .map(|cidr| cidr.address())
+            .unwrap_or(Ipv4Address::UNSPECIFIED);
+
+        let retry_at = if self.phase == DhcpPhase::Failed {
+            info!("eth0: DHCP retrying in failed state");
+            timestamp + SmolDuration::from_secs(DHCP_FAILED_RETRY_INTERVAL)
+        } else if self.phase == DhcpPhase::Renewing {
+            // RFC 2131 4.4.5: divide remaining time until T2 into equal
+            // intervals so retransmissions are spread across the window
+            // instead of clustering at the start.
+            let remaining = self
+                .rebind_deadline
+                .map(|d| (d - timestamp).total_micros() / 1_000_000)
+                .map(|s| s.max(1))
+                .unwrap_or(360);
+            let interval = (remaining / 6).clamp(15, 3600);
+            self.retry = self.retry.saturating_add(1);
+            timestamp + SmolDuration::from_secs(interval)
+        } else if self.phase == DhcpPhase::Rebinding {
+            let remaining = self
+                .lease_expiry()
+                .map(|d| (d - timestamp).total_micros() / 1_000_000)
+                .map(|s| s.max(1))
+                .unwrap_or(360);
+            let interval = (remaining / 6).clamp(15, 3600);
+            self.retry = self.retry.saturating_add(1);
+            timestamp + SmolDuration::from_secs(interval)
+        } else {
+            let delay = retry_delay_secs(self.retry, self.transaction_id, timestamp);
+            self.retry = self.retry.saturating_add(1);
+            timestamp + SmolDuration::from_secs(delay)
+        };
+        self.retry_at = retry_at;
 
         Some((
             self.dev,
-            IpAddress::Ipv4(Ipv4Address::BROADCAST),
+            IpAddress::Ipv4(dst_addr),
             build_dhcp_packet(
                 self.mac,
                 self.transaction_id,
                 message_type,
                 requested_ip,
                 server_identifier,
+                client_ip,
+                dst_addr,
+                broadcast,
             ),
+        ))
+    }
+
+    fn lease_expiry(&self) -> Option<Instant> {
+        let acquired = self.lease_acquired_at?;
+        let duration = self.lease_duration?;
+        Some(Instant::from_micros_const(
+            acquired.total_micros() + duration.total_micros() as i64,
         ))
     }
 
@@ -191,7 +346,12 @@ impl DhcpState {
         self.offered_address = None;
         self.server_identifier = None;
         self.address = None;
+        self.router = None;
         self.dns_servers.clear();
+        self.lease_duration = None;
+        self.renew_deadline = None;
+        self.rebind_deadline = None;
+        self.lease_acquired_at = None;
     }
 }
 impl Service {
@@ -225,6 +385,21 @@ impl Service {
     pub fn poll(&mut self, sockets: &mut SocketSet) -> bool {
         let timestamp = now();
         let mut dhcp_events = Vec::new();
+
+        // Check lease expiry before processing packets so that Deconfigured
+        // fires before any potential Configured from the same poll cycle.
+        if let Some(ref mut state) = self.dhcp
+            && let (Some(acquired), Some(duration)) =
+                (state.lease_acquired_at, state.lease_duration)
+            && timestamp >= acquired + duration
+        {
+            let old_address = state.address;
+            if old_address.is_some() {
+                dhcp_events.push(DhcpEvent::Deconfigured { old_address });
+            }
+            info!("eth0: DHCP lease expired");
+            state.reset(timestamp);
+        }
 
         {
             let dhcp = &mut self.dhcp;
@@ -264,6 +439,9 @@ impl Service {
                 address,
                 router,
                 dns_servers,
+                lease_duration,
+                renew_duration,
+                rebind_duration,
             } => {
                 let Some(state) = &mut self.dhcp else {
                     return;
@@ -279,20 +457,32 @@ impl Service {
 
                 Self::set_interface_ipv4(&mut self.iface, state.address, Some(address));
                 state.address = Some(address);
+                state.router = router;
                 state.dns_servers = dns_servers;
                 self.router
                     .set_ipv4_config(state.dev, Some(address), router.map(IpAddress::Ipv4));
+
+                // Set up lease timers for T1 (renew) and T2 (rebind).
+                let now = now();
+                state.lease_acquired_at = Some(now);
+                state.lease_duration = lease_duration;
+                if let Some(dur) = lease_duration {
+                    // Per RFC 2131: T1 defaults to 0.5 * lease, T2 defaults to 0.875 * lease.
+                    let t1 = renew_duration.unwrap_or(dur / 2);
+                    let t2 = rebind_duration.unwrap_or(dur * 7 / 8);
+                    state.renew_deadline = Some(now + t1);
+                    state.rebind_deadline = Some(now + t2);
+                }
             }
-            DhcpEvent::Deconfigured => {
+            DhcpEvent::Deconfigured { old_address } => {
                 let Some(state) = &mut self.dhcp else {
                     return;
                 };
-                if state.address.is_some() {
+                if old_address.is_some() {
                     info!("eth0: DHCP deconfigured");
                 }
-                Self::set_interface_ipv4(&mut self.iface, state.address, None);
-                state.address = None;
-                state.dns_servers.clear();
+                Self::set_interface_ipv4(&mut self.iface, old_address, None);
+                // reset() already cleared state.address / state.dns_servers
                 self.router.set_ipv4_config(state.dev, None, None);
             }
         }
@@ -338,6 +528,45 @@ impl Service {
         }
     }
 
+    pub fn dhcp_poll_duration(&self) -> Option<SmolDuration> {
+        let dhcp = self.dhcp.as_ref()?;
+        let now = now();
+        if dhcp.phase == DhcpPhase::Bound {
+            // Return the nearest of renew_deadline, rebind_deadline, or lease expiry
+            // so the wake mechanism can advance the state machine past T1/T2.
+            let now_us = now.total_micros();
+            let deadlines: [Option<i64>; 3] = [
+                dhcp.renew_deadline.map(|d| d.total_micros()),
+                dhcp.rebind_deadline.map(|d| d.total_micros()),
+                dhcp.lease_expiry().map(|d| d.total_micros()),
+            ];
+            let next_us = deadlines.iter().filter_map(|&d| d).min()?;
+            if next_us > now_us {
+                return Some(SmolDuration::from_micros((next_us - now_us) as u64));
+            } else {
+                return Some(SmolDuration::from_micros(0));
+            }
+        }
+        if dhcp.retry_at > now {
+            Some(dhcp.retry_at - now)
+        } else {
+            Some(SmolDuration::from_micros(0))
+        }
+    }
+
+    pub fn dhcp_info(&self) -> Option<String> {
+        let state = self.dhcp.as_ref()?;
+        let addr = state.address?;
+        let mut info = format!("ip={}/{}\n", addr.address(), addr.prefix_len());
+        if let Some(gw) = state.router {
+            info.push_str(&format!("gateway={}\n", gw));
+        }
+        for dns in &state.dns_servers {
+            info.push_str(&format!("dns={}\n", dns));
+        }
+        Some(info)
+    }
+
     pub fn register_waker(&mut self, mask: u32, waker: &Waker) {
         let next = self.iface.poll_at(now(), &SOCKET_SET.inner.lock());
 
@@ -371,8 +600,13 @@ enum DhcpEvent {
         address: Ipv4Cidr,
         router: Option<Ipv4Address>,
         dns_servers: Vec<Ipv4Address>,
+        lease_duration: Option<SmolDuration>,
+        renew_duration: Option<SmolDuration>,
+        rebind_duration: Option<SmolDuration>,
     },
-    Deconfigured,
+    Deconfigured {
+        old_address: Option<Ipv4Cidr>,
+    },
 }
 
 fn dhcp_transaction_id(mac: EthernetAddress) -> u32 {
@@ -387,25 +621,47 @@ fn is_unicast_ipv4(addr: Ipv4Address) -> bool {
     addr != Ipv4Address::UNSPECIFIED && addr != Ipv4Address::BROADCAST && !addr.is_multicast()
 }
 
+/// RFC 2131 4.1: retransmission MUST use randomized exponential backoff.
+/// Returns a jittered delay in seconds.
+fn retry_delay_secs(retry: usize, transaction_id: u32, timestamp: Instant) -> u64 {
+    let base = 1u64 << retry.min(DHCP_MAX_RETRY_SHIFT);
+    // SplitMix-style hash — good enough for ±50% jitter without an RNG crate.
+    let mut h = transaction_id as u64;
+    h = h.wrapping_mul(0x9e3779b97f4a7c15);
+    h ^= retry as u64;
+    h = h.wrapping_mul(0x9e3779b97f4a7c15);
+    h ^= timestamp.total_micros() as u64;
+    h ^= h >> 30;
+    h = h.wrapping_mul(0xbf58476d1ce4e5b9);
+    h ^= h >> 27;
+    let jitter = (base / 2).max(1);
+    let offset = h % (jitter * 2 + 1);
+    base.saturating_add(offset).saturating_sub(jitter)
+}
+
+#[allow(clippy::too_many_arguments)]
 fn build_dhcp_packet(
     mac: EthernetAddress,
     transaction_id: u32,
     message_type: DhcpMessageType,
     requested_ip: Option<Ipv4Address>,
     server_identifier: Option<Ipv4Address>,
+    client_ip: Ipv4Address,
+    dst_addr: Ipv4Address,
+    broadcast: bool,
 ) -> Vec<u8> {
     let dhcp_repr = DhcpRepr {
         message_type,
         transaction_id,
         secs: 0,
         client_hardware_address: mac,
-        client_ip: Ipv4Address::UNSPECIFIED,
+        client_ip,
         your_ip: Ipv4Address::UNSPECIFIED,
         server_ip: Ipv4Address::UNSPECIFIED,
         router: None,
         subnet_mask: None,
         relay_agent_ip: Ipv4Address::UNSPECIFIED,
-        broadcast: true,
+        broadcast,
         requested_ip,
         client_identifier: Some(mac),
         server_identifier,
@@ -422,8 +678,8 @@ fn build_dhcp_packet(
         dst_port: DHCP_SERVER_PORT,
     };
     let ipv4_repr = Ipv4Repr {
-        src_addr: Ipv4Address::UNSPECIFIED,
-        dst_addr: Ipv4Address::BROADCAST,
+        src_addr: client_ip,
+        dst_addr,
         next_header: IpProtocol::Udp,
         payload_len: udp_repr.header_len() + dhcp_repr.buffer_len(),
         hop_limit: 64,
@@ -448,4 +704,359 @@ fn build_dhcp_packet(
     );
 
     buffer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_state(phase: DhcpPhase, address: Option<Ipv4Cidr>) -> DhcpState {
+        DhcpState {
+            dev: 0,
+            mac: EthernetAddress([0x52, 0x54, 0x00, 0x12, 0x34, 0x56]),
+            transaction_id: 42,
+            phase,
+            retry_at: Instant::from_micros_const(0),
+            retry: 0,
+            offered_address: None,
+            server_identifier: None,
+            address,
+            router: None,
+            dns_servers: Vec::new(),
+            lease_duration: None,
+            renew_deadline: None,
+            rebind_deadline: None,
+            lease_acquired_at: None,
+        }
+    }
+
+    #[test]
+    fn bound_returns_none() {
+        let mut state = make_state(DhcpPhase::Bound, None);
+        let t = Instant::from_micros_const(1_000_000);
+        assert!(state.poll_packet(t).is_none());
+        assert!(
+            state
+                .poll_packet(t + SmolDuration::from_secs(3600))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn discovering_sends_discover() {
+        let mut state = make_state(DhcpPhase::Discovering, None);
+        let result = state.poll_packet(Instant::from_micros_const(0));
+        assert!(result.is_some());
+        let (dev, ip, _packet) = result.unwrap();
+        assert_eq!(dev, 0);
+        assert_eq!(ip, IpAddress::Ipv4(Ipv4Address::BROADCAST));
+    }
+
+    #[test]
+    fn retry_count_enters_failed() {
+        let mut state = make_state(DhcpPhase::Discovering, None);
+        let mut t = Instant::from_micros_const(0);
+
+        for i in 0..DHCP_MAX_RETRY_COUNT {
+            let result = state.poll_packet(t);
+            assert!(result.is_some(), "should send Discover at attempt {i}");
+            assert_eq!(state.phase, DhcpPhase::Discovering);
+            t = state.retry_at;
+        }
+
+        // retry == DHCP_MAX_RETRY_COUNT → enter Failed
+        let result = state.poll_packet(t);
+        assert!(result.is_none(), "should return None when entering Failed");
+        assert_eq!(state.phase, DhcpPhase::Failed);
+    }
+
+    #[test]
+    fn failed_state_retries_fixed_interval() {
+        let mut state = make_state(DhcpPhase::Failed, None);
+        let t = Instant::from_micros_const(0);
+
+        // Immediately sends a Discover and sets retry_at = t + 60s
+        let result = state.poll_packet(t);
+        assert!(result.is_some(), "Failed should send Discover immediately");
+        assert_eq!(
+            state.retry_at,
+            t + SmolDuration::from_secs(DHCP_FAILED_RETRY_INTERVAL)
+        );
+
+        // Before the 60s interval, nothing is sent
+        let result = state.poll_packet(t + SmolDuration::from_secs(30));
+        assert!(result.is_none(), "should wait for 60s interval");
+
+        // At the 60s mark, sends another Discover
+        let result = state.poll_packet(t + SmolDuration::from_secs(60));
+        assert!(result.is_some(), "should retry at 60s interval");
+    }
+
+    #[test]
+    fn bound_to_renewing_transition() {
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let acquired = Instant::from_micros_const(0);
+        let mut state = make_state(DhcpPhase::Bound, Some(addr));
+        state.lease_acquired_at = Some(acquired);
+        state.lease_duration = Some(SmolDuration::from_secs(100));
+        state.renew_deadline = Some(acquired + SmolDuration::from_secs(50));
+        state.rebind_deadline = Some(acquired + SmolDuration::from_secs(87));
+
+        // After T1 (50s) but before T2 (87s)
+        let result = state.poll_packet(acquired + SmolDuration::from_secs(60));
+        assert_eq!(state.phase, DhcpPhase::Renewing);
+        assert!(result.is_some(), "Renewing should send unicast Request");
+    }
+
+    #[test]
+    fn renewing_to_rebinding_transition() {
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let acquired = Instant::from_micros_const(0);
+        let mut state = make_state(DhcpPhase::Renewing, Some(addr));
+        state.lease_acquired_at = Some(acquired);
+        state.lease_duration = Some(SmolDuration::from_secs(100));
+        state.renew_deadline = Some(acquired + SmolDuration::from_secs(50));
+        state.rebind_deadline = Some(acquired + SmolDuration::from_secs(87));
+
+        // Before T2 (87s), stays in Renewing
+        let _result = state.poll_packet(acquired + SmolDuration::from_secs(80));
+        assert_eq!(state.phase, DhcpPhase::Renewing);
+
+        // After T2, transitions to Rebinding
+        let result = state.poll_packet(acquired + SmolDuration::from_secs(90));
+        assert_eq!(state.phase, DhcpPhase::Rebinding);
+        assert!(result.is_some(), "Rebinding should send broadcast Request");
+    }
+
+    #[test]
+    fn lease_expiry_is_handled_at_service_level() {
+        // Lease expiry cleanup (iface/router) is done in Service::poll(),
+        // not in poll_packet(). poll_packet() on a stale Bound lease that has
+        // no deadline fields set will simply return None.
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let acquired = Instant::from_micros_const(0);
+        let mut state = make_state(DhcpPhase::Bound, Some(addr));
+        state.lease_acquired_at = Some(acquired);
+        state.lease_duration = Some(SmolDuration::from_secs(100));
+
+        // Before expiry, Bound returns None
+        let _result = state.poll_packet(acquired + SmolDuration::from_secs(90));
+        assert_eq!(state.phase, DhcpPhase::Bound);
+
+        // After expiry, poll_packet doesn't auto-reset (Service handles it).
+        let result = state.poll_packet(acquired + SmolDuration::from_secs(101));
+        assert_eq!(state.phase, DhcpPhase::Bound);
+        assert!(
+            result.is_none(),
+            "poll_packet does not reset on lease expiry"
+        );
+
+        // But lease_expiry() still reports the correct expiry timestamp.
+        assert!(state.lease_expiry().is_some());
+    }
+
+    #[test]
+    fn reset_clears_dhcp_state() {
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let mut state = make_state(DhcpPhase::Bound, Some(addr));
+        state.dns_servers = vec![Ipv4Address::new(10, 0, 2, 3)];
+        state.lease_duration = Some(SmolDuration::from_secs(3600));
+        state.lease_acquired_at = Some(Instant::from_micros_const(0));
+        state.renew_deadline = Some(Instant::from_micros_const(1_800_000_000));
+        state.rebind_deadline = Some(Instant::from_micros_const(3_150_000_000));
+
+        state.reset(Instant::from_micros_const(2_000_000_000));
+
+        assert_eq!(state.phase, DhcpPhase::Discovering);
+        assert_eq!(state.retry, 0);
+        assert!(state.address.is_none());
+        assert!(state.dns_servers.is_empty());
+        assert!(state.lease_duration.is_none());
+        assert!(state.renew_deadline.is_none());
+        assert!(state.rebind_deadline.is_none());
+        assert!(state.lease_acquired_at.is_none());
+    }
+
+    #[test]
+    fn exponential_backoff_with_jitter() {
+        let mut state = make_state(DhcpPhase::Discovering, None);
+
+        for i in 0..DHCP_MAX_RETRY_SHIFT + 1 {
+            let before = state.retry_at;
+            let r = state.poll_packet(before);
+            assert!(r.is_some(), "retry {i} should send a packet");
+            let after = state.retry_at;
+            let delay = (after - before).total_micros() / 1_000_000;
+
+            // Jitter range is ±50% of the base, base = 2^i (capped at 16).
+            let base = 1u64 << i.min(DHCP_MAX_RETRY_SHIFT);
+            let jitter = (base / 2).max(1);
+            let max = base + jitter;
+            let min = base.saturating_sub(jitter);
+            assert!(
+                delay >= min && delay <= max,
+                "retry {i}: delay {delay}s out of range [{min}, {max}]"
+            );
+        }
+    }
+
+    /// Verify that `lease_expiry()` computes the correct expiry instant.
+    #[test]
+    fn lease_expiry_computes_correct_timestamp() {
+        let mut state = make_state(DhcpPhase::Bound, None);
+        let acquired = Instant::from_micros_const(1_000_000);
+        state.lease_acquired_at = Some(acquired);
+        state.lease_duration = Some(SmolDuration::from_secs(3600));
+        let expiry = state.lease_expiry().unwrap();
+        assert_eq!(
+            expiry.total_micros(),
+            acquired.total_micros() + 3_600_000_000i64
+        );
+    }
+
+    /// Scan the DHCP options area for a given tag. Returns the value slice.
+    fn find_option(packet: &[u8], tag: u8) -> Option<Vec<u8>> {
+        // Skip IPv4(20) + UDP(8) + BOOTP header(236) + magic cookie(4) = 268
+        let mut pos = 268;
+        while pos + 2 <= packet.len() {
+            let t = packet[pos];
+            if t == 255 {
+                break;
+            }
+            let len = packet[pos + 1] as usize;
+            if t == tag {
+                return Some(packet[pos + 2..pos + 2 + len].to_vec());
+            }
+            pos += 2 + len;
+        }
+        None
+    }
+
+    fn dhcp_ciaddr(packet: &[u8]) -> Ipv4Address {
+        Ipv4Address::new(packet[40], packet[41], packet[42], packet[43])
+    }
+
+    #[test]
+    fn renewing_packet_rfc2131_4_4_5() {
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let mut state = make_state(DhcpPhase::Renewing, Some(addr));
+        state.server_identifier = Some(Ipv4Address::new(10, 0, 2, 2));
+        let t = Instant::from_micros_const(0);
+
+        let (_, dst, pkt) = state.poll_packet(t).unwrap();
+        // Unicast to the server
+        assert_eq!(dst, IpAddress::Ipv4(Ipv4Address::new(10, 0, 2, 2)));
+        // ciaddr MUST be the client's IP
+        assert_eq!(
+            dhcp_ciaddr(&pkt),
+            Ipv4Address::new(10, 0, 2, 15),
+            "Renewing ciaddr must be client IP"
+        );
+        // MUST NOT carry requested_ip (option 50)
+        assert!(
+            find_option(&pkt, 50).is_none(),
+            "Renewing must not include requested_ip"
+        );
+        // MUST NOT carry server_identifier (option 54)
+        assert!(
+            find_option(&pkt, 54).is_none(),
+            "Renewing must not include server_identifier"
+        );
+    }
+
+    #[test]
+    fn rebinding_packet_rfc2131_4_4_5() {
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let mut state = make_state(DhcpPhase::Rebinding, Some(addr));
+        let t = Instant::from_micros_const(0);
+
+        let (_, dst, pkt) = state.poll_packet(t).unwrap();
+        // Broadcast
+        assert_eq!(dst, IpAddress::Ipv4(Ipv4Address::BROADCAST));
+        // ciaddr MUST be the client's IP
+        assert_eq!(
+            dhcp_ciaddr(&pkt),
+            Ipv4Address::new(10, 0, 2, 15),
+            "Rebinding ciaddr must be client IP"
+        );
+        // MUST NOT carry requested_ip (option 50)
+        assert!(
+            find_option(&pkt, 50).is_none(),
+            "Rebinding must not include requested_ip"
+        );
+        // MUST NOT carry server_identifier (option 54)
+        assert!(
+            find_option(&pkt, 54).is_none(),
+            "Rebinding must not include server_identifier"
+        );
+    }
+
+    #[test]
+    fn renewing_retransmission_is_linear_not_exponential() {
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let t0 = Instant::from_micros_const(1_800_000_000);
+        let mut state = make_state(DhcpPhase::Renewing, Some(addr));
+        state.lease_acquired_at = Some(t0);
+        state.lease_duration = Some(SmolDuration::from_secs(3600));
+        state.rebind_deadline = Some(t0 + SmolDuration::from_secs(1350));
+
+        // First retransmit: interval ≈ remaining / 6 = 1350 / 6 = 225s
+        let result = state.poll_packet(t0);
+        assert!(result.is_some());
+        let first_interval = (state.retry_at - t0).total_micros() / 1_000_000;
+        assert!(
+            first_interval > 60,
+            "Renewing first retry should be based on remaining/T2 window, not 1s exponential; got \
+             {first_interval}s"
+        );
+
+        // Second retransmit: interval shrinks because remaining time is less,
+        // but should STILL be a linear fraction, not exponential doubling.
+        let t1 = state.retry_at;
+        let result = state.poll_packet(t1);
+        assert!(result.is_some());
+        let second_interval = (state.retry_at - t1).total_micros() / 1_000_000;
+        // If exponential, second would be ~2x first. Linear should be ≤ first.
+        assert!(
+            second_interval <= first_interval && second_interval > 60,
+            "linear: second interval {second_interval}s should be ≤ first {first_interval}s, not \
+             doubled"
+        );
+    }
+
+    #[test]
+    fn rebinding_retransmission_is_linear_not_exponential() {
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let t0 = Instant::from_micros_const(3_150_000_000);
+        let mut state = make_state(DhcpPhase::Rebinding, Some(addr));
+        state.lease_acquired_at = Some(Instant::from_micros_const(0));
+        // lease = 3600s, t0 = 3150s into lease, 450s remaining
+        state.lease_duration = Some(SmolDuration::from_secs(3600));
+
+        let result = state.poll_packet(t0);
+        assert!(result.is_some());
+        let interval = (state.retry_at - t0).total_micros() / 1_000_000;
+        // remaining = 450s, /6 = 75s
+        assert!(
+            (15..=90).contains(&interval),
+            "Rebinding retry interval based on remaining lease; got {interval}s"
+        );
+    }
+
+    /// When both renew_deadline and rebind_deadline are set, `lease_expiry()`
+    /// should return the lease-expiry moment (not confuse it with the deadlines).
+    #[test]
+    fn lease_expiry_not_confused_with_deadlines() {
+        let addr = Ipv4Cidr::new(Ipv4Address::new(10, 0, 2, 15), 24);
+        let acquired = Instant::from_micros_const(0);
+        let mut state = make_state(DhcpPhase::Bound, Some(addr));
+        state.lease_acquired_at = Some(acquired);
+        state.lease_duration = Some(SmolDuration::from_secs(3600));
+        // renew at 1800s, rebind at 3150s — lease_expiry should still be 3600s
+        let expiry = state.lease_expiry().unwrap();
+        assert_eq!(
+            expiry.total_micros(),
+            acquired.total_micros() + 3_600_000_000i64
+        );
+    }
 }

--- a/scripts/axbuild/src/rootfs/qemu.rs
+++ b/scripts/axbuild/src/rootfs/qemu.rs
@@ -163,7 +163,7 @@ fn ensure_disk_boot_net_args(qemu: &mut QemuConfig, disk_img: &Path) {
             }
             "-netdev" if index + 1 < args.len() => {
                 let value = &mut args[index + 1];
-                if value == &netdev_value {
+                if value.starts_with("user,id=net0") {
                     has_netdev = true;
                 }
                 index += 2;

--- a/test-suit/starryos/normal/qemu-dhcp/dhcp/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-dhcp/dhcp/qemu-x86_64.toml
@@ -13,6 +13,14 @@ uefi = false
 to_bin = false
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
+for i in $(seq 1 60); do
+  if cat /proc/net/dhcp 2>/dev/null | grep -q 'ip=10\.0\.2\.'; then
+    break
+  fi
+  sleep 1
+done
+cat /proc/net/dhcp | grep 'ip=10\.0\.2\.' && \
+cat /proc/net/dhcp | grep 'gateway=10\.0\.2\.2' && \
 apk update && \
 echo 'DHCP_TEST_DONE' || \
 echo 'DHCP_TEST_FAILED'


### PR DESCRIPTION
  ## 改动

  - 新增 Renewing / Rebinding / Failed 阶段，RFC 2131 T1/T2 自动续租
  - 8 次重试后进入 Failed 状态，60s 固定间隔重试
  - 事件驱动引导，移除 200 次固定轮询
  - 新增 /proc/net/dhcp，暴露 IP、网关、DNS 供测试验证
  - 9 个单元测试 + qemu-dhcp 增加 IP/网关断言

  ## 验证

  - [x] cargo test -p ax-net-ng（9/9）
  - [x] qemu-dhcp 测试通过
  - [x] smoke / apk-curl 无回归
#519 @ZR233 请周老师有空的时候review一下，还有几个在issue中提出的小问题