### PR TITLE
fix(starry-kernel): avoid tmpfs cwd cleanup panic

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/tmp.rs
+++ b/os/StarryOS/kernel/src/pseudofs/tmp.rs
@@ -1,6 +1,7 @@
 use alloc::{borrow::ToOwned, string::String, sync::Arc};
 use core::{any::Any, borrow::Borrow, cmp::Ordering, task::Context, time::Duration};
 
+use ax_kspin::SpinNoIrq;
 use ax_sync::Mutex;
 use axfs_ng_vfs::{
     DeviceId, DirEntry, DirEntrySink, DirNode, DirNodeOps, FileNode, FileNodeOps, Filesystem,
@@ -52,7 +53,9 @@ impl Borrow<str> for FileName {
 
 /// A simple in-memory filesystem that supports basic file operations.
 pub struct MemoryFs {
-    inodes: Mutex<Slab<Arc<Inode>>>,
+    // Inodes may be released from atomic cleanup paths, so the slab and
+    // metadata locks must not sleep.
+    inodes: SpinNoIrq<Slab<Arc<Inode>>>,
     root: Mutex<Option<DirEntry>>,
 }
 
@@ -61,7 +64,7 @@ impl MemoryFs {
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Filesystem {
         let fs = Arc::new(Self {
-            inodes: Mutex::new(Slab::new()),
+            inodes: SpinNoIrq::new(Slab::new()),
             root: Mutex::default(),
         });
         let root_ino = Inode::new(
@@ -127,7 +130,7 @@ enum NodeContent {
 
 struct Inode {
     ino: u64,
-    metadata: Mutex<Metadata>,
+    metadata: SpinNoIrq<Metadata>,
     content: NodeContent,
 }
 
@@ -165,7 +168,7 @@ impl Inode {
         };
         let result = Arc::new(Self {
             ino,
-            metadata: Mutex::new(metadata),
+            metadata: SpinNoIrq::new(metadata),
             content,
         });
         entry.insert(result.clone());
@@ -247,6 +250,15 @@ impl MemoryNode {
                 reference,
             )
         })
+    }
+
+    fn clear_dir_entries(inode: &Inode) {
+        // Do this from unlink/rename paths while still in normal syscall
+        // context. MemoryNode::drop may run during task cleanup, where a
+        // blocking directory-entry mutex would panic in might_sleep().
+        if let NodeContent::Dir(dir) = &inode.content {
+            dir.entries.lock().clear();
+        }
     }
 }
 
@@ -412,17 +424,24 @@ impl DirNodeOps for MemoryNode {
 
     fn unlink(&self, name: &str) -> VfsResult<()> {
         let dir = self.inode.as_dir()?;
-        let mut entries = dir.entries.lock();
 
-        let Some(entry) = entries.get(name) else {
-            return Err(VfsError::NotFound);
+        let (entry, inode) = {
+            let mut entries = dir.entries.lock();
+            let Some(entry) = entries.get(name) else {
+                return Err(VfsError::NotFound);
+            };
+            let inode = entry.get();
+            if let NodeContent::Dir(DirContent { entries }) = &inode.content
+                && entries.lock().len() > 2
+            {
+                return Err(VfsError::DirectoryNotEmpty);
+            }
+            let entry = entries.remove(name).ok_or(VfsError::NotFound)?;
+            (entry, inode)
         };
-        if let NodeContent::Dir(DirContent { entries }) = &entry.get().content
-            && entries.lock().len() > 2
-        {
-            return Err(VfsError::DirectoryNotEmpty);
-        }
-        entries.remove(name);
+
+        Self::clear_dir_entries(&inode);
+        drop(entry);
 
         Ok(())
     }
@@ -437,28 +456,24 @@ impl DirNodeOps for MemoryNode {
             }
         }
 
-        let src_entry = self
-            .inode
-            .as_dir()?
-            .entries
-            .lock()
-            .remove(src_name)
-            .ok_or(VfsError::NotFound)?;
-        dst_node
-            .inode
-            .as_dir()?
-            .entries
-            .lock()
-            .insert(dst_name.into(), src_entry);
+        let src_entry = {
+            let mut entries = self.inode.as_dir()?.entries.lock();
+            entries.remove(src_name).ok_or(VfsError::NotFound)?
+        };
+        let overwritten = {
+            let mut entries = dst_node.inode.as_dir()?.entries.lock();
+            entries.insert(dst_name.into(), src_entry)
+        };
+        if let Some(entry) = overwritten {
+            Self::clear_dir_entries(&entry.get());
+            drop(entry);
+        }
         Ok(())
     }
 }
 
 impl Drop for MemoryNode {
     fn drop(&mut self) {
-        if let NodeContent::Dir(dir) = &self.inode.content {
-            dir.entries.lock().clear();
-        }
         release_inode(&self.fs, &self.inode, 0);
     }
 }

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tmpfs-cwd-drop-safe/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tmpfs-cwd-drop-safe/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-tmpfs-cwd-drop-safe C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-tmpfs-cwd-drop-safe src/main.c)
+target_compile_options(bug-tmpfs-cwd-drop-safe PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-tmpfs-cwd-drop-safe RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tmpfs-cwd-drop-safe/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tmpfs-cwd-drop-safe/c/src/main.c
@@ -1,0 +1,145 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static void remove_dir_if_exists(const char *path)
+{
+    if (rmdir(path) != 0 && errno != ENOENT) {
+        printf("WARN: cleanup rmdir(%s): %s\n", path, strerror(errno));
+    }
+}
+
+static void expect_child_cwd_drop_is_safe(void)
+{
+    const char *dir = "/tmp/bug-tmpfs-cwd-drop-safe";
+    int ready_pipe[2] = {-1, -1};
+    int release_pipe[2] = {-1, -1};
+
+    remove_dir_if_exists(dir);
+    if (mkdir(dir, 0700) != 0) {
+        note_fail("mkdir tmpfs cwd dir", strerror(errno));
+        return;
+    }
+
+    if (pipe(ready_pipe) != 0 || pipe(release_pipe) != 0) {
+        note_fail("pipe", strerror(errno));
+        if (ready_pipe[0] >= 0) {
+            close(ready_pipe[0]);
+        }
+        if (ready_pipe[1] >= 0) {
+            close(ready_pipe[1]);
+        }
+        if (release_pipe[0] >= 0) {
+            close(release_pipe[0]);
+        }
+        if (release_pipe[1] >= 0) {
+            close(release_pipe[1]);
+        }
+        remove_dir_if_exists(dir);
+        return;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        note_fail("fork", strerror(errno));
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
+        close(release_pipe[0]);
+        close(release_pipe[1]);
+        remove_dir_if_exists(dir);
+        return;
+    }
+
+    if (child == 0) {
+        char token;
+
+        close(ready_pipe[0]);
+        close(release_pipe[1]);
+        if (chdir(dir) != 0) {
+            _exit(10);
+        }
+        if (write(ready_pipe[1], "R", 1) != 1) {
+            _exit(11);
+        }
+        close(ready_pipe[1]);
+        if (read(release_pipe[0], &token, 1) != 1) {
+            _exit(12);
+        }
+        close(release_pipe[0]);
+        _exit(0);
+    }
+
+    close(ready_pipe[1]);
+    close(release_pipe[0]);
+
+    char token;
+    int child_ready = read(ready_pipe[0], &token, 1) == 1;
+    if (child_ready) {
+        note_pass("child entered tmpfs cwd");
+    } else {
+        note_fail("wait child cwd ready", strerror(errno));
+    }
+    close(ready_pipe[0]);
+
+    if (child_ready) {
+        if (rmdir(dir) == 0) {
+            note_pass("rmdir tmpfs dir while child uses cwd");
+        } else {
+            note_fail("rmdir tmpfs active cwd dir", strerror(errno));
+        }
+
+        if (write(release_pipe[1], "X", 1) != 1) {
+            note_fail("release child", strerror(errno));
+        }
+    }
+    close(release_pipe[1]);
+
+    int status = 0;
+    pid_t waited = waitpid(child, &status, 0);
+    if (waited == child && WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        note_pass("child can exit after tmpfs cwd unlink");
+    } else {
+        char detail[160];
+        snprintf(detail, sizeof(detail), "waited=%d errno=%d status=0x%x",
+                 waited, errno, status);
+        note_fail("child tmpfs unlinked cwd exit", detail);
+    }
+
+    remove_dir_if_exists(dir);
+}
+
+int main(void)
+{
+    printf("=== bug-tmpfs-cwd-drop-safe ===\n");
+
+    for (int i = 0; i < 8; i++) {
+        expect_child_cwd_drop_is_safe();
+    }
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+    printf("SOME TESTS FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -24,6 +24,7 @@ test_commands = [
     "/usr/bin/bug-preadv2-offset-neg1",
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
+    "/usr/bin/bug-tmpfs-cwd-drop-safe",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",


### PR DESCRIPTION
## Summary

* Stop tmpfs `MemoryNode::drop` from cleaning directory entries during object destruction.
* Move tmpfs inode slab/metadata locking to non-sleeping `SpinNoIrq` locks for this cleanup path.
* Clean removed tmpfs directory entries from normal syscall context in `unlink` and `rename` instead.
* Add a StarryOS regression case where a child exits while its cwd points at a tmpfs directory already removed by the parent.

## Root Cause

A child can keep its current working directory pinned after the parent removes that tmpfs directory. When the child exits, the cwd reference is dropped from a path that may be in atomic context. The old tmpfs drop cleanup tried to take locks that can sleep while removing directory entries, which could panic during process teardown.

## Fix

Directory-entry cleanup is now done while handling the mutating syscalls, where sleeping filesystem work is expected. Dropping a tmpfs node no longer performs that cleanup, and the remaining tmpfs metadata paths use IRQ-safe spin locking where needed.

## Test plan

* `git diff --check upstream/dev..fix/tmpfs-cwd-cleanup-panic`
* `cargo fmt`
* `cargo xtask clippy --package starry-kernel`
* `cargo xtask starry test qemu --arch x86_64 -c bugfix`
* Added grouped StarryOS case: `/usr/bin/bug-tmpfs-cwd-drop-safe`.
