### PR TITLE
fix: UDP loopback dispatch and recv EAGAIN semantics

### DIFF
--- a/os/arceos/modules/axnet-ng/src/udp.rs
+++ b/os/arceos/modules/axnet-ng/src/udp.rs
@@ -185,7 +185,7 @@ impl SocketOps for UdpSocket {
                 0,
             )))?;
         }
-        self.general.send_poller(self, || {
+        let result = self.general.send_poller(self, || {
             poll_interfaces();
             self.with_smol_socket(|socket| {
                 if !socket.is_open() {
@@ -214,7 +214,11 @@ impl SocketOps for UdpSocket {
                     Ok(read)
                 }
             })
-        })
+        });
+        // Dispatch the packet through the network stack (needed for loopback
+        // delivery to wake epoll waiters on the receiving socket).
+        poll_interfaces();
+        result
     }
 
     fn recv(&self, mut dst: impl Write, options: RecvOptions) -> AxResult<usize> {
@@ -224,11 +228,15 @@ impl SocketOps for UdpSocket {
 
         enum ExpectedRemote<'a> {
             Any(&'a mut SocketAddrEx),
+            AnyDiscard,
             Expecting(IpEndpoint),
         }
         let mut expected_remote = match options.from {
             Some(addr) => ExpectedRemote::Any(addr),
-            None => ExpectedRemote::Expecting(self.remote_endpoint()?.0),
+            None => match self.remote_endpoint() {
+                Ok((endpoint, _)) => ExpectedRemote::Expecting(endpoint),
+                Err(_) => ExpectedRemote::AnyDiscard,
+            },
         };
 
         self.general.recv_poller(self, || {
@@ -250,6 +258,9 @@ impl SocketOps for UdpSocket {
                             match &mut expected_remote {
                                 ExpectedRemote::Any(remote_addr) => {
                                     **remote_addr = SocketAddrEx::Ip(meta.endpoint.into());
+                                }
+                                ExpectedRemote::AnyDiscard => {
+                                    // recv() with no addr buffer and no peer — accept from any
                                 }
                                 ExpectedRemote::Expecting(expected) => {
                                     if (!expected.addr.is_unspecified()

--- a/test-suit/starryos/normal/qemu-smp1/test-epoll-network/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-epoll-network/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(test-epoll-network C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-epoll-network src/main.c)
+target_compile_options(test-epoll-network PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-epoll-network RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-epoll-network/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-epoll-network/c/src/main.c
@@ -1,0 +1,201 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <sys/wait.h>
+
+/* usleep replacement using pure POSIX nanosleep */
+static void msleep(long ms) {
+    struct timespec ts = { .tv_sec = ms / 1000, .tv_nsec = (ms % 1000) * 1000000L };
+    nanosleep(&ts, NULL);
+}
+
+#define PORT 12345
+
+int total_failures = 0;
+int total_tests = 5;
+
+void set_nonblocking(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+void fail(const char* msg) {
+    printf("[FAIL] %s\n", msg);
+    total_failures++;
+}
+
+void pass(const char* msg) {
+    printf("[PASS] %s\n", msg);
+}
+
+/* Drain the socket buffer between tests so failures don't cascade */
+void drain_socket(int fd) {
+    char temp[128];
+    while (recv(fd, temp, sizeof(temp), 0) > 0)
+        ;
+}
+
+int main(void) {
+    printf("=== Starting Comprehensive Network/Epoll Tokio-Compat Suite ===\n\n");
+
+    int epfd = epoll_create1(0);
+    if (epfd < 0) {
+        printf("[FATAL] epoll_create1 failed\n");
+        return 1;
+    }
+
+    int rx_sock = socket(AF_INET, SOCK_DGRAM, 0);
+    int tx_sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (rx_sock < 0 || tx_sock < 0) {
+        printf("[FATAL] Failed to create sockets\n");
+        return 1;
+    }
+
+    set_nonblocking(rx_sock);
+
+    struct sockaddr_in addr = {
+        .sin_family = AF_INET,
+        .sin_port   = htons(PORT),
+    };
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+    if (bind(rx_sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        printf("[FATAL] Failed to bind rx_sock. Does your OS support loopback networking?\n");
+        return 1;
+    }
+
+    struct epoll_event ev = { .events = EPOLLIN, .data.fd = rx_sock };
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, rx_sock, &ev) < 0) {
+        printf("[FATAL] epoll_ctl ADD failed\n");
+        return 1;
+    }
+
+    struct epoll_event events[2];
+    int n;
+    char buf[128];
+
+    /* -----------------------------------------------------------------------
+     * TEST 1: Network Stack Waker (smoltcp -> epoll)
+     * --------------------------------------------------------------------- */
+    printf("[TEST 1] Testing basic network packet wakeup...\n");
+    drain_socket(rx_sock);
+
+    pid_t pid1 = fork();
+    if (pid1 == 0) {
+        sleep(1);
+        sendto(tx_sock, "A", 1, 0, (struct sockaddr*)&addr, sizeof(addr));
+        exit(0);
+    }
+
+    n = epoll_wait(epfd, events, 1, 2000);
+    if (n == 1 && events[0].data.fd == rx_sock) {
+        pass("Network packet correctly woke epoll_wait.");
+    } else {
+        fail("epoll_wait timed out. Your network stack is not waking the PollSet!");
+    }
+    waitpid(pid1, NULL, 0);
+
+    /* -----------------------------------------------------------------------
+     * TEST 2: The EWOULDBLOCK / EAGAIN Contract
+     * --------------------------------------------------------------------- */
+    printf("\n[TEST 2] Testing non-blocking EAGAIN semantics...\n");
+    drain_socket(rx_sock);
+
+    int bytes = recv(rx_sock, buf, sizeof(buf), 0);
+    if (bytes == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        pass("Empty non-blocking socket returned EAGAIN correctly.");
+    } else if (bytes == 0) {
+        fail("Empty socket returned 0! Tokio will think the connection closed (EOF).");
+    } else {
+        fail("Empty socket did not return EAGAIN.");
+    }
+
+    /* -----------------------------------------------------------------------
+     * TEST 3: EPOLL_CTL_MOD State Preservation
+     * --------------------------------------------------------------------- */
+    printf("\n[TEST 3] Testing EPOLL_CTL_MOD...\n");
+    ev.events = EPOLLOUT;
+    if (epoll_ctl(epfd, EPOLL_CTL_MOD, rx_sock, &ev) < 0) {
+        fail("EPOLL_CTL_MOD failed to execute.");
+    } else {
+        n = epoll_wait(epfd, events, 1, 100);
+        if (n == 1 && (events[0].events & EPOLLOUT)) {
+            pass("EPOLL_CTL_MOD correctly updated interest to EPOLLOUT.");
+        } else {
+            fail("EPOLL_CTL_MOD broke the wait queue or failed to wake on EPOLLOUT.");
+        }
+    }
+
+    /* Restore to EPOLLIN for remaining tests */
+    ev.events = EPOLLIN;
+    epoll_ctl(epfd, EPOLL_CTL_MOD, rx_sock, &ev);
+
+    /* -----------------------------------------------------------------------
+     * TEST 4: Partial Drain (Level-Triggered Re-arm)
+     * --------------------------------------------------------------------- */
+    printf("\n[TEST 4] Testing Level-Triggered partial drain...\n");
+    drain_socket(rx_sock);
+    /* Send two separate datagrams so the second remains after reading the first */
+    sendto(tx_sock, "B", 1, 0, (struct sockaddr*)&addr, sizeof(addr));
+    sendto(tx_sock, "C", 1, 0, (struct sockaddr*)&addr, sizeof(addr));
+    msleep(100); /* Give network stack time to process */
+
+    n = epoll_wait(epfd, events, 1, 500);
+    if (n > 0) {
+        recv(rx_sock, buf, sizeof(buf), 0); /* Read datagram "B"; "C" remains */
+        n = epoll_wait(epfd, events, 1, 500); /* Should wake immediately */
+        if (n == 1) {
+            pass("Level-triggered epoll correctly woke up again for unread bytes.");
+        } else {
+            fail("Level-triggered epoll failed to re-arm when buffer still had data.");
+        }
+    } else {
+        fail("Initial epoll_wait failed, skipping partial drain check.");
+    }
+
+    /* -----------------------------------------------------------------------
+     * TEST 5: Edge-Triggered (EPOLLET) Isolation
+     * --------------------------------------------------------------------- */
+    printf("\n[TEST 5] Testing Edge-Triggered (EPOLLET) semantics...\n");
+    drain_socket(rx_sock);
+    ev.events = EPOLLIN | EPOLLET;
+    epoll_ctl(epfd, EPOLL_CTL_MOD, rx_sock, &ev);
+
+    sendto(tx_sock, "D", 1, 0, (struct sockaddr*)&addr, sizeof(addr));
+    msleep(100);
+
+    n = epoll_wait(epfd, events, 1, 500); /* 1st wait: edge fires */
+    if (n != 1) {
+        fail("EPOLLET failed to wake on new data.");
+    } else {
+        /* Do NOT read the data — second wait must NOT fire */
+        n = epoll_wait(epfd, events, 1, 500);
+        if (n == 0) {
+            pass("EPOLLET correctly ignored existing data (did not multi-fire).");
+        } else {
+            fail("EPOLLET behaved like Level-Triggered! It woke up without new data arriving.");
+        }
+    }
+
+    /* -----------------------------------------------------------------------
+     * SUMMARY
+     * --------------------------------------------------------------------- */
+    printf("\n=== Test Suite Complete ===\n");
+    printf("Passed: %d / %d\n", total_tests - total_failures, total_tests);
+    if (total_failures > 0) {
+        printf("Result: FAILED\n");
+        return 1;
+    } else {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-epoll-network/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-epoll-network/qemu-aarch64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-epoll-network"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', 'Result: FAILED']
+timeout = 30

--- a/test-suit/starryos/normal/qemu-smp1/test-epoll-network/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-epoll-network/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "128M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-epoll-network"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', 'Result: FAILED']
+timeout = 30

--- a/test-suit/starryos/normal/qemu-smp1/test-epoll-network/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-epoll-network/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-epoll-network"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', 'Result: FAILED']
+timeout = 30

--- a/test-suit/starryos/normal/qemu-smp1/test-epoll-network/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-epoll-network/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-epoll-network"
+success_regex = ['(?m)^ALL TESTS PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', 'Result: FAILED']
+timeout = 30


### PR DESCRIPTION
## Summary

Fixes two bugs in `axnet-ng` UDP socket that break epoll-based async networking (Tokio compatibility).

## Changes

### 1. `recv()` on unconnected UDP socket returns `ENOTCONN` instead of `EAGAIN`

When a non-blocking UDP socket calls `recv()` (NULL src_addr), the code unconditionally calls `remote_endpoint()` to determine which peer to expect data from. On an unconnected socket this returns `NotConnected` → maps to `ENOTCONN` in userspace.

POSIX requires `EAGAIN`/`EWOULDBLOCK` when the receive buffer is empty, regardless of connection state. Linux allows `recv()` on unconnected UDP sockets — it simply reads the next available datagram.

**Fix:** Added `AnyDiscard` variant — when no peer is set and no addr buffer is provided, accept datagrams from any source.

### 2. `sendto()` on loopback doesn't dispatch packet before returning

`UdpSocket::send()` calls `poll_interfaces()` before `socket.send()`, but the actual packet enters smoltcp's tx buffer *after* that call. The packet isn't dispatched to the loopback device until the next `poll_interfaces()` cycle. If no subsequent poll happens (e.g. sender is a child process that exits immediately), the packet is stuck and the receiver's epoll waker is never fired.

**Fix:** Added `poll_interfaces()` after `send_poller` completes, ensuring the packet is fully dispatched through the loopback device before `sendto` returns.

## Test

Added `test-epoll-network` covering 5 scenarios:
1. Network packet wakes `epoll_wait` (fork + sendto over loopback)
2. Non-blocking `recv` returns `EAGAIN` on empty socket
3. `EPOLL_CTL_MOD` correctly updates interest set
4. Level-triggered epoll re-arms when buffer still has data
5. Edge-triggered (`EPOLLET`) does not multi-fire

All 5 pass on x86_64. Previously tests 1 and 2 failed.

## Dependencies

Based on https://github.com/rcore-os/tgoskits/pull/500 (needed for correct `fork`/`waitpid` behavior in the test).