### PR TITLE
fix(rsext4): replay journal before mount repairs

### DIFF
--- a/components/rsext4/src/ext4/mount.rs
+++ b/components/rsext4/src/ext4/mount.rs
@@ -46,6 +46,10 @@ impl Ext4FileSystem {
         self.reset_runtime_from_superblock(block_dev)
     }
 
+    fn clear_recovery_state(&mut self) {
+        self.superblock.s_feature_incompat &= !Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    }
+
     fn journal_blocks<B: BlockDevice>(
         &mut self,
         block_dev: &mut Jbd2Dev<B>,
@@ -71,9 +75,9 @@ impl Ext4FileSystem {
 
         // Mount flow:
         // 1. read and verify the superblock,
-        // 2. load group descriptors and allocator state,
-        // 3. repair bootstrap directories if they are missing,
-        // 4. initialize journal replay state when journaling is enabled.
+        // 2. load only enough metadata to locate/replay the journal,
+        // 3. reload metadata from the recovered home blocks,
+        // 4. repair bootstrap directories if they are missing.
         let mut superblock = read_superblock(block_dev).map_err(|_| Ext4Error::io())?;
 
         if superblock.s_magic != EXT4_SUPER_MAGIC {
@@ -134,6 +138,81 @@ impl Ext4FileSystem {
         // the logs.
         debug_super_and_desc(&fs.superblock, &fs);
 
+        // Journal bootstrap has two stages: ensure the journal inode exists,
+        // then load its superblock and enable replay on the device wrapper.
+        {
+            let needs_recovery = fs
+                .superblock
+                .has_feature_incompat(Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER);
+
+            if fs.superblock.has_journal() {
+                let journal_inode_num = InodeNumber::new(JOURNAL_FILE_INODE as u32)?;
+                let journal_exists = fs.get_inode_by_num(block_dev, journal_inode_num)?.i_mode != 0;
+
+                if fs
+                    .superblock
+                    .has_feature_compat(Ext4Superblock::EXT4_FEATURE_COMPAT_HAS_JOURNAL)
+                    && !journal_exists
+                {
+                    if needs_recovery {
+                        error!("Journal inode missing while filesystem needs recovery");
+                        return Err(Ext4Error::corrupted());
+                    }
+                    create_journal_entry(&mut fs, block_dev).expect("create journal entry failed");
+                }
+            }
+            if needs_recovery && !fs.superblock.has_journal() {
+                error!("Filesystem needs journal recovery, but no journal is present");
+                return Err(Ext4Error::corrupted());
+            }
+            if (block_dev.is_use_journal() || needs_recovery) && fs.superblock.has_journal() {
+                // By this point the journal inode must exist, so resolve its
+                // first data block and hand the loaded journal superblock to
+                // `Jbd2Dev`.
+                let mut j_inode = fs
+                    .get_inode_by_num(block_dev, InodeNumber::new(JOURNAL_FILE_INODE as u32)?)
+                    .expect("load journal inode failed");
+
+                let journal_blocks = fs.journal_blocks(block_dev, &mut j_inode)?;
+                let journal_first_block = journal_blocks
+                    .first()
+                    .copied()
+                    .ok_or_else(Ext4Error::corrupted)?;
+
+                fs.journal_sb_block_start = Some(journal_first_block);
+                let journal_data = fs
+                    .datablock_cache
+                    .get_or_load(block_dev, journal_first_block)
+                    .expect("load journal superblock block failed")
+                    .data
+                    .clone();
+
+                let j_sb = JournalSuperBllockS::from_disk_bytes(&journal_data);
+
+                block_dev.set_journal_superblock_with_mapping(j_sb, journal_blocks)?;
+
+                // Replay before touching ordinary filesystem metadata. Until
+                // this completes, home blocks may be stale.
+                let original_journal_use = block_dev.is_use_journal();
+                if needs_recovery && !original_journal_use {
+                    info!("Filesystem needs journal recovery; enabling replay for mount");
+                    block_dev.set_journal_use(true);
+                }
+                let replay_status = block_dev.journal_replay_checked();
+                block_dev.set_journal_use(original_journal_use);
+                if replay_status != ReplayStatus::Complete {
+                    return Err(Ext4Error::corrupted());
+                }
+
+                // Journal replay can update the superblock, group descriptors,
+                // bitmaps, inode table, and directory blocks. Drop all metadata
+                // read before replay and continue mounting from the recovered
+                // on-disk state.
+                fs.reload_after_journal_replay(block_dev)?;
+                fs.clear_recovery_state();
+            }
+        }
+
         // rootinode check !
         debug!("Checking root directory...");
         {
@@ -172,69 +251,6 @@ impl Ext4FileSystem {
                     }
                 }
                 Err(err) => return Err(err),
-            }
-        }
-
-        // Journal bootstrap has two stages: ensure the journal inode exists,
-        // then load its superblock and enable replay on the device wrapper.
-        {
-            if fs.superblock.has_journal() {
-                let mut journal_exists = true;
-                fs.modify_inode(
-                    block_dev,
-                    InodeNumber::new(JOURNAL_FILE_INODE as u32)?,
-                    |ji| {
-                        journal_exists = ji.i_mode != 0;
-                    },
-                )
-                .expect("file system error panic!");
-
-                if fs
-                    .superblock
-                    .has_feature_compat(Ext4Superblock::EXT4_FEATURE_COMPAT_HAS_JOURNAL)
-                    && !journal_exists
-                {
-                    create_journal_entry(&mut fs, block_dev).expect("create journal entry failed");
-                }
-            }
-            if block_dev.is_use_journal() && fs.superblock.has_journal() {
-                // By this point the journal inode must exist, so resolve its
-                // first data block and hand the loaded journal superblock to
-                // `Jbd2Dev`.
-                let mut j_inode = fs
-                    .get_inode_by_num(block_dev, InodeNumber::new(JOURNAL_FILE_INODE as u32)?)
-                    .expect("load journal inode failed");
-
-                let journal_blocks = fs.journal_blocks(block_dev, &mut j_inode)?;
-                let journal_first_block = journal_blocks
-                    .first()
-                    .copied()
-                    .ok_or_else(Ext4Error::corrupted)?;
-
-                fs.journal_sb_block_start = Some(journal_first_block);
-                let journal_data = fs
-                    .datablock_cache
-                    .get_or_load(block_dev, journal_first_block)
-                    .expect("load journal superblock block failed")
-                    .data
-                    .clone();
-
-                let j_sb = JournalSuperBllockS::from_disk_bytes(&journal_data);
-
-                block_dev.set_journal_superblock_with_mapping(j_sb, journal_blocks)?;
-
-                // Replay after reading the filesystem metadata. Superblock and
-                // descriptor writes are already forced to media to avoid stale
-                // reads during fast recovery.
-                if block_dev.journal_replay_checked() != ReplayStatus::Complete {
-                    return Err(Ext4Error::corrupted());
-                }
-
-                // Journal replay can update the superblock, group descriptors,
-                // bitmaps, inode table, and directory blocks. Drop all metadata
-                // read before replay and continue mounting from the recovered
-                // on-disk state.
-                fs.reload_after_journal_replay(block_dev)?;
             }
         }
 
@@ -334,19 +350,11 @@ impl Ext4FileSystem {
         info!("  - free blocks: {}", fs.superblock.free_blocks_count());
         info!("  - total inodes: {}", fs.superblock.s_inodes_count);
         info!("  - free inodes: {}", fs.superblock.s_free_inodes_count);
-        // Flush caches once at the end of mount so any bootstrap repairs are
-        // persisted before normal operation begins.
-        fs.datablock_cache
-            .flush_all(block_dev)
-            .expect("flush failed!");
-        fs.bitmap_cache.flush_all(block_dev).expect("flush failed!");
-        fs.inodetable_cahce
-            .flush_all(block_dev)
-            .expect("flush failed!");
-
-        // Write the superblock with EXT4_VALID_FS cleared so that a later mount
+        // Flush metadata once at the end of mount so any replay state changes
+        // or bootstrap repairs are persisted before normal operation begins.
+        // The superblock is written with EXT4_VALID_FS cleared so a later mount
         // can distinguish an unclean shutdown from a real EXT4_ERROR_FS state.
-        fs.sync_superblock(block_dev)?;
+        fs.sync_filesystem(block_dev)?;
 
         Ok(fs)
     }

--- a/components/rsext4/tests/crc_integrity.rs
+++ b/components/rsext4/tests/crc_integrity.rs
@@ -241,6 +241,35 @@ fn clean_unmount_preserves_real_error_fs_state() {
 }
 
 #[test]
+fn needs_recovery_enables_mount_replay_when_caller_disabled_journal() {
+    // Test idea: EXT4_FEATURE_INCOMPAT_RECOVER means home metadata may be
+    // stale. Mount should replay the journal before ordinary metadata access
+    // even if the caller disabled journaling for normal writes.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut sb = read_superblock(&device);
+    sb.s_feature_incompat |= Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    sb.update_checksum();
+    write_superblock(&device, &sb);
+
+    let mut remount_dev = Jbd2Dev::initial_jbd2dev(0, device.clone(), false);
+    let fs = mount(&mut remount_dev).expect("mount should replay needs_recovery journal");
+    assert!(!remount_dev.is_use_journal());
+    assert_eq!(
+        fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
+        0
+    );
+
+    let recovered_sb = read_superblock(&device);
+    assert_eq!(
+        recovered_sb.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
+        0
+    );
+}
+
+#[test]
 fn corrupted_superblock_checksum_is_reported_as_euclean_on_mount() {
     // Test idea: corrupt only the stored superblock CRC field and ensure mount
     // rejects the image with the checksum-specific EUCLEAN errno.

--- a/components/rsext4/tests/linux_image_repro.rs
+++ b/components/rsext4/tests/linux_image_repro.rs
@@ -266,6 +266,20 @@ fn inject_csum_v3_journal(image: &Path, target_blocks: &[u64], payload: &Path) {
     run_debugfs_script(image, &script, "inject csum-v3 journal");
 }
 
+fn dumpe2fs_header(image: &Path, context: &str) -> String {
+    let output = Command::new("dumpe2fs")
+        .arg("-h")
+        .arg(image)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to spawn dumpe2fs for {context}: {err}"));
+    assert!(
+        output.status.success(),
+        "dumpe2fs failed for {context}\n{}",
+        command_text(&output)
+    );
+    command_text(&output)
+}
+
 fn repair_baseline_image(path: &PathBuf) {
     let probe = Command::new("e2fsck")
         .args(["-fn"])
@@ -349,6 +363,11 @@ fn replay_csum_v3_multi_block_journal_from_debugfs() {
     );
     read_image_blocks(&mutated, &changed_blocks, &payload);
     inject_csum_v3_journal(&image, &changed_blocks, &payload);
+    let dirty_header = dumpe2fs_header(&image, "pending journal fixture");
+    assert!(
+        dirty_header.contains("needs_recovery"),
+        "debugfs journal fixture should require recovery\n{dirty_header}"
+    );
 
     fs::copy(&image, &baseline).expect("copy baseline image");
     run_debugfs_script(
@@ -369,6 +388,11 @@ fn replay_csum_v3_multi_block_journal_from_debugfs() {
 
     assert_debugfs_path_exists(&image, "/replay-repro/a");
     assert_debugfs_path_exists(&image, "/replay-repro/b");
+    let recovered_header = dumpe2fs_header(&image, "rsext4 journal replay");
+    assert!(
+        !recovered_header.contains("needs_recovery"),
+        "rsext4 should clear needs_recovery after successful replay\n{recovered_header}"
+    );
     e2fsck_readonly_clean(&image, "rsext4 csum-v3 journal replay");
     fs::remove_dir_all(temp_dir).expect("remove temp dir");
 }


### PR DESCRIPTION
## 摘要

- 在 rsext4 mount 流程中，发现 `needs_recovery` 时先完成 journal replay，再做 root 和 `/lost+found` 元数据检查和修复。
- 即使调用方为了普通写入传入 `Jbd2Dev::initial_jbd2dev(..., false)`，只要镜像带 journal 且需要恢复，mount 会临时启用一次 replay；replay 后恢复原来的 journal 开关。
- replay 成功后重新加载 superblock、block group、inode/block bitmap，并清除 `EXT4_FEATURE_INCOMPAT_RECOVER`。
- 补充 Linux 镜像和 crc regression 测试，覆盖 pending journal 与 disabled normal journaling 场景。

## 问题出现原因

CI 的 OrangePi-5-Plus rootfs 是真实板子反复启动和写入后的 ext4 镜像，可能留下 `needs_recovery` 标志和未回放的 journal。旧 rsext4 mount 顺序会先检查 root 和 `/lost+found` 等普通元数据，再进行 journal recovery；在这种状态下读取到的是 replay 前的 home blocks，checksum/path resolution 可能和 journal 里的真实更新不一致，于是出现：

```text
/lost+found exists (path resolution)
Mount failed: EUCLEAN: Structure needs cleaning
```

另外 Starry/Axvisor 使用 axfs 挂载 rootfs 时会用 `Jbd2Dev::initial_jbd2dev(..., false)` 关闭普通写入 journaling。旧代码把这个开关也当作禁止 recovery replay，导致带 `needs_recovery` 的镜像在 CI 上更容易直接失败。这不是单纯修一次 fs 能根除的问题，因为下次板子异常断电或测试中断后仍会再次留下 pending journal。

## 修复方式

- mount 初期只加载足够定位 journal 的元数据，优先处理 recovery。
- 如果 superblock 带 `needs_recovery` 且存在 journal，则解析 journal inode/block mapping，临时打开 replay，执行 `journal_replay_checked()`。
- replay 完成后恢复调用方原本的 `journal_use` 状态，避免改变普通写入策略。
- replay 后重新读取 superblock、group descriptors、bitmaps 等缓存，保证后续 root 和 `/lost+found` 检查看到的是恢复后的元数据。
- 成功 recovery 后清理 `needs_recovery`，并在 mount 末尾同步元数据。
- 如果 `needs_recovery` 但镜像没有 journal，则仍拒绝挂载，避免在不完整状态下继续访问。

## 验证

- `cargo test -p rsext4 --test crc_integrity needs_recovery_enables_mount_replay_when_caller_disabled_journal -- --nocapture`
- `cargo test -p rsext4 --test linux_image_repro replay_csum_v3_multi_block_journal_from_debugfs -- --nocapture`
- `cargo test -p rsext4 --test crc_integrity -- --nocapture`
- `cargo test -p rsext4`
- `cargo fmt`
- `cargo xtask clippy --package rsext4`

Fixes #448.
