### PR TITLE
fix(rsext4): avoid replaying clean journals on mount

### DIFF
--- a/components/rsext4/src/blockgroup_description/desc.rs
+++ b/components/rsext4/src/blockgroup_description/desc.rs
@@ -107,8 +107,24 @@ impl Ext4GroupDesc {
         let expected = ext4_group_desc_csum16(superblock, group_id, &raw_desc_bytes[..desc_size]);
         if expected != self.bg_checksum {
             error!(
-                "Group descriptor checksum mismatch for group {}: expected {:04x}, got {:04x}",
-                group_id, self.bg_checksum, expected
+                "Group descriptor checksum mismatch: group={} stored={:#06x} expected={:#06x} \
+                 desc_size={} block_bitmap={} inode_bitmap={} inode_table={} free_blocks={} \
+                 free_inodes={} used_dirs={} itable_unused={} flags={:#x} block_bitmap_csum={:#x} \
+                 inode_bitmap_csum={:#x}",
+                group_id,
+                self.bg_checksum,
+                expected,
+                desc_size,
+                self.block_bitmap(),
+                self.inode_bitmap(),
+                self.inode_table(),
+                self.free_blocks_count(),
+                self.free_inodes_count(),
+                self.used_dirs_count(),
+                self.itable_unused(),
+                self.bg_flags,
+                self.block_bitmap_csum(),
+                self.inode_bitmap_csum()
             );
             return Err(Ext4Error::checksum());
         }

--- a/components/rsext4/src/ext4/mount.rs
+++ b/components/rsext4/src/ext4/mount.rs
@@ -147,7 +147,12 @@ impl Ext4FileSystem {
 
             if fs.superblock.has_journal() {
                 let journal_inode_num = InodeNumber::new(JOURNAL_FILE_INODE as u32)?;
-                let journal_exists = fs.get_inode_by_num(block_dev, journal_inode_num)?.i_mode != 0;
+                let journal_inode = fs
+                    .get_inode_by_num(block_dev, journal_inode_num)
+                    .inspect_err(|e| {
+                        error!("Failed to load journal inode {journal_inode_num}: {e}");
+                    })?;
+                let journal_exists = journal_inode.i_mode != 0;
 
                 if fs
                     .superblock
@@ -173,11 +178,15 @@ impl Ext4FileSystem {
                     .get_inode_by_num(block_dev, InodeNumber::new(JOURNAL_FILE_INODE as u32)?)
                     .expect("load journal inode failed");
 
-                let journal_blocks = fs.journal_blocks(block_dev, &mut j_inode)?;
-                let journal_first_block = journal_blocks
-                    .first()
-                    .copied()
-                    .ok_or_else(Ext4Error::corrupted)?;
+                let journal_blocks =
+                    fs.journal_blocks(block_dev, &mut j_inode)
+                        .inspect_err(|e| {
+                            error!("Failed to resolve journal blocks: {e}");
+                        })?;
+                let journal_first_block = journal_blocks.first().copied().ok_or_else(|| {
+                    error!("Journal has no mapped blocks");
+                    Ext4Error::corrupted()
+                })?;
 
                 fs.journal_sb_block_start = Some(journal_first_block);
                 let journal_data = fs
@@ -191,32 +200,41 @@ impl Ext4FileSystem {
 
                 block_dev.set_journal_superblock_with_mapping(j_sb, journal_blocks)?;
 
-                // Replay before touching ordinary filesystem metadata. Until
-                // this completes, home blocks may be stale.
-                let original_journal_use = block_dev.is_use_journal();
-                if needs_recovery && !original_journal_use {
-                    info!("Filesystem needs journal recovery; enabling replay for mount");
-                    block_dev.set_journal_use(true);
-                }
-                let replay_status = block_dev.journal_replay_checked();
-                block_dev.set_journal_use(original_journal_use);
-                if replay_status != ReplayStatus::Complete {
-                    return Err(Ext4Error::corrupted());
-                }
+                if needs_recovery {
+                    // Replay before touching ordinary filesystem metadata.
+                    // Until this completes, home blocks may be stale. A clean
+                    // filesystem with journaling enabled still needs JBD2
+                    // state initialized for future metadata writes, but it
+                    // must not force replay without the ext4 recovery bit.
+                    let original_journal_use = block_dev.is_use_journal();
+                    if !original_journal_use {
+                        info!("Filesystem needs journal recovery; enabling replay for mount");
+                        block_dev.set_journal_use(true);
+                    }
+                    let replay_status = block_dev.journal_replay_checked();
+                    block_dev.set_journal_use(original_journal_use);
+                    if replay_status != ReplayStatus::Complete {
+                        error!("Journal replay did not complete: status={replay_status:?}");
+                        return Err(Ext4Error::corrupted());
+                    }
 
-                // Journal replay can update the superblock, group descriptors,
-                // bitmaps, inode table, and directory blocks. Drop all metadata
-                // read before replay and continue mounting from the recovered
-                // on-disk state.
-                fs.reload_after_journal_replay(block_dev)?;
-                fs.clear_recovery_state();
+                    // Journal replay can update the superblock, group
+                    // descriptors, bitmaps, inode table, and directory blocks.
+                    // Drop all metadata read before replay and continue
+                    // mounting from the recovered on-disk state.
+                    fs.reload_after_journal_replay(block_dev)?;
+                    fs.clear_recovery_state();
+                }
             }
         }
 
         // rootinode check !
         debug!("Checking root directory...");
         {
-            let root_inode = fs.get_root(block_dev).map_err(|_| Ext4Error::io())?;
+            let root_inode = fs.get_root(block_dev).map_err(|e| {
+                error!("Failed to load root inode: {e}");
+                Ext4Error::io()
+            })?;
             if root_inode.i_mode == 0 || !root_inode.is_dir() {
                 warn!(
                     "Root inode is uninitialized or not a directory, creating root and \
@@ -250,7 +268,10 @@ impl Ext4FileSystem {
                         warn!("/lost+found missing and create failed");
                     }
                 }
-                Err(err) => return Err(err),
+                Err(err) => {
+                    error!("Failed to resolve /lost+found: {err}");
+                    return Err(err);
+                }
             }
         }
 
@@ -288,7 +309,10 @@ impl Ext4FileSystem {
                     if expected_inode != stored_inode {
                         error!(
                             "Inode bitmap checksum mismatch group=0 expected={expected_inode:#x} \
-                             stored={stored_inode:#x}"
+                             stored={stored_inode:#x} inode_bitmap_block={inode_bitmap_blk} \
+                             inode_table_block={} flags={:#x}",
+                            g0.inode_table(),
+                            g0.bg_flags
                         );
                         return Err(Ext4Error::checksum());
                     }
@@ -301,7 +325,10 @@ impl Ext4FileSystem {
                     if expected_block != stored_block {
                         error!(
                             "Block bitmap checksum mismatch group=0 expected={expected_block:#x} \
-                             stored={stored_block:#x}"
+                             stored={stored_block:#x} block_bitmap_block={data_bitmap_blk} \
+                             inode_table_block={} flags={:#x}",
+                            g0.inode_table(),
+                            g0.bg_flags
                         );
                         return Err(Ext4Error::checksum());
                     }

--- a/components/rsext4/src/superblock/geometry.rs
+++ b/components/rsext4/src/superblock/geometry.rs
@@ -96,10 +96,16 @@ impl Ext4Superblock {
 
     /// Verifies the superblock checksum when `metadata_csum` is enabled.
     pub fn verify_superblock(&self) -> Ext4Result<Self> {
-        if ext4_superblock_has_metadata_csum(self)
-            && self.s_checksum != ext4_superblock_csum32(self)
-        {
-            return Err(Ext4Error::checksum());
+        if ext4_superblock_has_metadata_csum(self) {
+            let expected = ext4_superblock_csum32(self);
+            if self.s_checksum != expected {
+                log::error!(
+                    "Superblock checksum mismatch: stored={:#x} expected={:#x}",
+                    self.s_checksum,
+                    expected
+                );
+                return Err(Ext4Error::checksum());
+            }
         }
         Ok(*self)
     }

--- a/components/rsext4/tests/crc_integrity.rs
+++ b/components/rsext4/tests/crc_integrity.rs
@@ -20,6 +20,7 @@ use rsext4::{
     },
     endian::DiskFormat,
     error::{Errno, Ext4Error, Ext4Result},
+    jbd2::jbdstruct::{JBD2_BLOCKTYPE_DESCRIPTOR, JBD2_MAGIC, JournalHeaderS, JournalSuperBllockS},
     superblock::Ext4Superblock,
     *,
 };
@@ -151,6 +152,28 @@ fn write_group_desc0(device: &SharedCrcDevice, sb: &Ext4Superblock, desc: &Ext4G
     device.write_bytes(BLOCK_SIZE, &bytes[..desc_size]);
 }
 
+fn write_journal_start(device: &SharedCrcDevice, journal_block: u64, start: u32) {
+    let mut bytes = device.read_block_bytes(journal_block);
+    let mut journal_sb = JournalSuperBllockS::from_disk_bytes(&bytes);
+    journal_sb.s_start = start;
+    journal_sb.to_disk_bytes(&mut bytes);
+    device.write_block_bytes(journal_block, &bytes);
+}
+
+fn write_incomplete_journal_descriptor(device: &SharedCrcDevice, journal_block: u64) {
+    let bytes = device.read_block_bytes(journal_block);
+    let journal_sb = JournalSuperBllockS::from_disk_bytes(&bytes);
+
+    let mut descriptor = vec![0u8; BLOCK_SIZE];
+    JournalHeaderS {
+        h_magic: JBD2_MAGIC,
+        h_blocktype: JBD2_BLOCKTYPE_DESCRIPTOR,
+        h_sequence: journal_sb.s_sequence,
+    }
+    .to_disk_bytes(&mut descriptor);
+    device.write_block_bytes(journal_block + 1, &descriptor);
+}
+
 #[test]
 fn checksums_are_persisted_and_clean_remount_preserves_the_written_file() {
     // Test idea: write one real file, inspect the raw on-disk checksum fields,
@@ -186,6 +209,41 @@ fn checksums_are_persisted_and_clean_remount_preserves_the_written_file() {
     let mut fs = mount(&mut remount_dev).expect("mount after intact checksum data failed");
     let read_back = read_file(&mut remount_dev, &mut fs, "/crc.txt").expect("read_file failed");
     assert_eq!(read_back, payload);
+    umount(fs, &mut remount_dev).expect("umount failed");
+}
+
+#[test]
+fn clean_mount_does_not_replay_journal_without_recovery_feature() {
+    // Test idea: normal journaled operation may leave a non-zero journal
+    // superblock start value, but ext4 recovery is driven by the superblock
+    // needs_recovery bit. A clean mount should initialize journal state for
+    // future writes without treating the journal as mandatory recovery input.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_block = fs
+        .journal_sb_block_start
+        .expect("journal superblock should be mapped")
+        .raw();
+    umount(fs, &mut first_mount_dev).expect("umount failed");
+
+    let mut sb = read_superblock(&device);
+    sb.s_feature_incompat &= !Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    sb.update_checksum();
+    write_superblock(&device, &sb);
+    write_journal_start(&device, journal_block, 1);
+    write_incomplete_journal_descriptor(&device, journal_block);
+
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut remount_dev).expect("clean mount should not force journal replay");
+    assert_eq!(
+        fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
+        0
+    );
+    assert!(remount_dev.is_use_journal());
     umount(fs, &mut remount_dev).expect("umount failed");
 }
 


### PR DESCRIPTION
## Summary

- Fix rsext4 mount behavior so clean journaled filesystems do not force journal replay.
- Initialize JBD2 state for later metadata writes when journaling is enabled.
- Replay the journal only when the ext4 superblock has EXT4_FEATURE_INCOMPAT_RECOVER set.
- Add a regression test for clean mounts with a non-zero journal s_start.

## Motivation

use_journal=true means metadata writes should use the journal after mount. It should not mean the filesystem must replay the journal during mount.

Previously, clean filesystems with journaling enabled could still enter replay and fail with EUCLEAN if the journal looked incomplete, even when needs_recovery=false.