### PR TITLE
fix(ci): skip hosted axvisor svm test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,18 +381,6 @@ jobs:
             container_image: ""
             required_repository_owner: rcore-os
             main_pr_only: false
-          - name: Test axvisor x86_64 svm hosted
-            use_container: false
-            runs_on: '["ubuntu-latest"]'
-            command: |
-              sudo apt-get update
-              sudo apt-get install -y libudev-dev pkg-config qemu-system-x86
-              sudo usermod -aG kvm $USER
-              newgrp kvm <<< "cargo xtask axvisor test qemu --arch x86_64 --test-group svm --test-case smoke"
-            cache_key: ""
-            container_image: ""
-            required_repository_owner: ""
-            main_pr_only: false
           - name: Test axvisor self-hosted board orangepi-5-plus-linux
             use_container: false
             runs_on: '["self-hosted","linux","board"]'


### PR DESCRIPTION
## Summary
- remove the hosted `ubuntu-latest` Axvisor SVM CI matrix job
- keep the SVM test suite files available for manual or future SVM-capable runners

## Root Cause
The hosted SVM job runs `cargo xtask axvisor test qemu --arch x86_64 --test-group svm --test-case smoke` on `ubuntu-latest`. The runner does not guarantee AMD SVM exposure to the guest, and the failing CI run showed Axvisor reporting `Hardware support: false` before panicking with `Hardware does not support virtualization`.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
