### PR TITLE
fix(starry-kernel): repair serial console input on dynamic platforms

### DIFF
--- a/components/someboot/src/fdt/earlycon.rs
+++ b/components/someboot/src/fdt/earlycon.rs
@@ -30,24 +30,44 @@ fn set_by_stdout() -> Option<()> {
     let fdt = crate::fdt::fdt_base()?;
 
     let chosen = fdt.chosen()?;
-    let stdout = chosen.stdout_path()?;
+    let stdout = split_stdout_options(chosen.stdout_path()?);
     let node = fdt.find_by_path(stdout)?;
     let reg = node.reg()?.next()?;
     let address = fdt.translate_address(stdout, reg.address);
 
     let addr = NonNull::new(_fixmap_io(address as usize))?;
-    // let clock = stdout.clock_frequency().unwrap_or(0);
+    let clock = node
+        .find_property("clock-frequency")
+        .and_then(|prop| prop.as_u32())
+        .unwrap_or(0);
+    let reg_width = node
+        .find_property("reg-io-width")
+        .and_then(|prop| prop.as_u32())
+        .unwrap_or(1) as usize;
 
+    let mut installed = false;
     for com in node.compatibles() {
         match com {
             "arm,pl011" | "arm,primecell" => {
-                let mut serial = pl011::Pl011::new(addr, 0);
+                let mut serial = pl011::Pl011::new(addr, clock);
                 serial.open();
                 let tx = serial.take_tx()?;
                 let rx = serial.take_rx()?;
 
                 crate::console::set_earlycon_sender(tx);
                 crate::console::set_earlycon_reciever(rx);
+                installed = true;
+                break;
+            }
+            "snps,dw-apb-uart" => {
+                let mut serial = ns16550::Ns16550::new_mmio(addr, clock, reg_width);
+                serial.open();
+                let tx = serial.take_tx()?;
+                let rx = serial.take_rx()?;
+
+                crate::console::set_earlycon_sender(tx);
+                crate::console::set_earlycon_reciever(rx);
+                installed = true;
                 break;
             }
             _ => {
@@ -55,9 +75,16 @@ fn set_by_stdout() -> Option<()> {
             }
         }
     }
+    if !installed {
+        return None;
+    }
     unsafe {
         DEBUG_BASE = address as usize;
         DEBUG_IS_MMIO = true;
     }
     Some(())
+}
+
+fn split_stdout_options(path: &str) -> &str {
+    path.split_once(':').map_or(path, |(path, _)| path)
 }

--- a/platform/axplat-dyn/src/console.rs
+++ b/platform/axplat-dyn/src/console.rs
@@ -1,4 +1,6 @@
 use ax_plat::console::ConsoleIf;
+#[cfg(feature = "irq")]
+use ax_plat::console::ConsoleIrqEvent;
 
 struct ConsoleIfImpl;
 
@@ -45,7 +47,7 @@ impl ConsoleIf for ConsoleIfImpl {
     fn set_input_irq_enabled(_enabled: bool) {}
 
     #[cfg(feature = "irq")]
-    fn handle_irq() -> ax_plat::console::ConsoleIrqEvent {
-        ax_plat::console::ConsoleIrqEvent::empty()
+    fn handle_irq() -> ConsoleIrqEvent {
+        ConsoleIrqEvent::empty()
     }
 }

--- a/platform/axplat-dyn/src/drivers/serial/mod.rs
+++ b/platform/axplat-dyn/src/drivers/serial/mod.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::boxed::Box;
-
 use rdrive::{PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo};
 use some_serial::{BSerial, ns16550, pl011};
 
@@ -35,8 +33,9 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
     info!("Probing serial device: {}", info.node.name());
     let base_reg = info
         .node
-        .reg()
-        .and_then(|mut regs| regs.next())
+        .regs()
+        .into_iter()
+        .next()
         .ok_or(OnProbeError::other(alloc::format!(
             "[{}] has no reg",
             info.node.name()
@@ -45,24 +44,32 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
     let mmio_size = base_reg.size.unwrap_or(0x1000);
     let mmio_base = iomap((base_reg.address as usize).into(), mmio_size as usize)?;
 
-    let clock_freq = info.node.clock_frequency().unwrap_or(24_000_000);
-
+    let node = info.node.as_node();
+    let clock_freq = prop_u32(node, "clock-frequency").unwrap_or(24_000_000);
+    let reg_width = prop_u32(node, "reg-io-width").unwrap_or(1) as usize;
     let mut serial: Option<BSerial> = None;
-    for c in info.node.compatibles() {
+    for c in node.compatibles() {
         if c == "arm,pl011" {
-            serial = Some(Box::new(pl011::Pl011::new(mmio_base, clock_freq)));
+            serial = Some(pl011::Pl011::new_boxed(mmio_base, clock_freq));
             break;
         }
 
         if c == "snps,dw-apb-uart" {
-            serial = Some(Box::new(ns16550::Ns16550::new_mmio(mmio_base, clock_freq)));
+            serial = Some(ns16550::Ns16550::new_mmio_boxed(
+                mmio_base, clock_freq, reg_width,
+            ));
             break;
         }
     }
     if let Some(s) = serial {
-        info!("Serial@{:#x} registered successfully", s.base());
+        let base = s.base_addr();
+        info!("Serial@{base:#x} registered successfully");
         plat_dev.register(s);
     }
 
     Ok(())
+}
+
+fn prop_u32(node: &fdt_edit::Node, name: &str) -> Option<u32> {
+    node.get_property(name).and_then(|prop| prop.get_u32())
 }

--- a/scripts/test/clippy_crates.csv
+++ b/scripts/test/clippy_crates.csv
@@ -118,6 +118,7 @@ rsext4
 scope-local
 simple-sdmmc
 some-serial
+someboot
 starry-kernel
 starryos
 starry-process


### PR DESCRIPTION
## Summary

This is a prerequisite fix for #493's board CI path.

- Teach `someboot` FDT earlycon to resolve `/chosen/stdout-path` with options stripped, and to install `snps,dw-apb-uart` via `some-serial` using `clock-frequency` / `reg-io-width`.
- Keep `axplat-dyn` as a generic console forwarder and align its regular serial probe with the workspace `some-serial` API, without duplicating live FDT stdout parsing.
- Enable `axplat-dyn/serial` for Starry `plat-dyn`, use scheduler-yield polling on no-RX-IRQ platforms, and flush pending ldisc input state fully.

## Why

#493's OrangePi board test failure is not architecture-specific. The board console input path was using the wrong stdout UART setup and then polling too slowly for the high-baud serial input stream. That could truncate injected shell commands before the Starry test reached `STARRY_LSUSB_HUB_OK`.

This PR moves the stdout UART fix to the common `someboot` earlycon path, so `somehal::console` naturally uses the real stdout serial backend.

## Relation

- Related to #493.
- #493 should be rebased/updated after this PR is merged; its CI is expected to keep failing on the OrangePi board path without this prerequisite.

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package someboot`
- `cargo xtask clippy --package axplat-dyn`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask sync-lint`
- `cargo xtask starry test board --board orangepi-5-plus -c lsusb`

The board test passed locally and matched `STARRY_LSUSB_HUB_OK`.
