### PR TITLE
chore(review): simplify PR review skills

### DIFF
--- a/.claude/skills/review-open-prs/SKILL.md
+++ b/.claude/skills/review-open-prs/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: review-open-prs
-description: Review eligible open GitHub pull requests in this tgoskits repository. Use when the user asks to audit all PRs, review non-self PRs, re-review PRs updated after their last review, use subagents/worktrees for PR review, compare syscall/network/filesystem behavior with POSIX or Linux semantics, run local verification before approving, or submit GitHub approve/request-changes reviews with Chinese inline comments.
+description: Audit open GitHub pull requests in this tgoskits repository, identify non-self PRs that need the current user's review, then dispatch each eligible PR through review-single-pr. Use when the user asks to review all open PRs, review non-self PRs, re-review PRs updated after their last review, or coordinate per-PR review worktrees/subagents.
 ---
 
 # Review Open PRs
 
-## Overview
+## Goal
 
-Review only open PRs that actually need the current user attention, using isolated worktrees and local validation before submitting GitHub reviews. By default this is not a full re-review of every open PR: review PRs the current user has never reviewed, or PRs whose latest commit is newer than the current user's last submitted review. The default outcome is a submitted `APPROVE` review when no blocking issue remains, or a submitted `REQUEST_CHANGES` review with Chinese inline comments when correctness, standards compliance, tests, or CI coverage are insufficient.
+Find open PRs that actually need the current user's attention, then review each eligible PR with `review-single-pr`. This skill is only the multi-PR discovery and dispatch layer; single-PR review standards, validation, inline comments, approval, request-changes, conflict repair, and final submission rules live in `review-single-pr`.
 
-When the user asks to handle conflicts too, treat merge-conflict repair as a separate maintenance pass: fix and push only PRs that allow maintainer edits, and request changes for conflicted PRs that do not allow maintainer edits.
+By default, do not re-review every open PR. Review PRs the current user has never reviewed, or PRs whose latest commit is newer than the current user's last submitted review. Include draft PRs unless the user explicitly says to skip drafts.
 
-Respect the global subagent policy: spawn subagents only when the user explicitly asks for subagents, delegation, or parallel agent work. If subagents are allowed, use them for bounded per-PR review work and keep final GitHub submission in the main agent.
+Respect the global subagent policy: spawn subagents only when the user explicitly asks for subagents, delegation, or parallel agent work. Even when workers are used, the main agent owns the final GitHub review submission unless the user explicitly assigns that authority elsewhere.
 
-## Eligibility
+## Eligibility Pass
 
 1. Resolve repository and user identity:
    ```bash
@@ -22,238 +22,56 @@ Respect the global subagent policy: spawn subagents only when the user explicitl
    gh pr list --state open --limit 100 --json number,title,author,headRefName,headRepositoryOwner,baseRefName,updatedAt,isDraft,url,reviewDecision,mergeStateStatus,maintainerCanModify
    ```
 2. Exclude PRs authored by the current GitHub user.
-3. For each remaining PR, fetch latest commit and the current user's last review:
+3. For each remaining PR, fetch latest commits, reviews, and changed files:
    ```bash
    gh api "repos/<owner>/<repo>/pulls/<pr>/commits?per_page=100"
    gh api "repos/<owner>/<repo>/pulls/<pr>/reviews?per_page=100"
    gh api "repos/<owner>/<repo>/pulls/<pr>/files?per_page=100"
    ```
-4. Mark a PR eligible when the user has never reviewed it, or the PR latest commit time is newer than the user's last review time. Compare the PR latest commit date against the current user's last submitted review timestamp, not `updatedAt`, because comments, CI, or thread resolution can update the PR without new code.
-5. Include drafts unless the user explicitly says to skip drafts; note draft status in the summary.
-6. For PRs already reviewed by the current user at the latest commit, do not submit another review unless the user explicitly asks for a fresh pass of those PRs. A general request like "review open PRs" still means review only eligible/unreviewed-or-updated PRs, not every open PR. If the user asks to audit already-approved PRs too, treat that as an explicit expanded scope for that turn only.
-7. List excluded PRs and the reason: self-authored, already reviewed at latest commit, closed, or skipped by user scope.
+4. Mark a PR eligible when the current user has never reviewed it, or when the PR latest commit timestamp is newer than the current user's last submitted review timestamp. Compare against the latest commit date, not `updatedAt`, because comments, CI, or thread resolution can update a PR without code changes.
+5. Treat PRs already reviewed by the current user at the latest commit as excluded unless the user explicitly asks for a fresh pass of already-reviewed PRs.
+6. Keep a summary of excluded PRs and the reason: self-authored, already reviewed at latest commit, closed, skipped by user scope, or blocked by a stated constraint.
 
-## Merge Conflicts
+## Dispatch
 
-When the user explicitly asks to handle conflicted PRs, inspect `mergeStateStatus` and `maintainerCanModify`:
+For each eligible PR, invoke `review-single-pr` with a prompt that carries the multi-PR context but leaves review decisions to the single-PR skill:
 
-- If `mergeStateStatus` is `DIRTY` and `maintainerCanModify=false`, do not attempt to repair the branch. Submit `REQUEST_CHANGES` explaining that the branch conflicts with the base and maintainers cannot push a fix; ask the author to merge/rebase the latest base branch and suggest enabling "Allow edits by maintainers".
-- If `mergeStateStatus` is `DIRTY` and `maintainerCanModify=true`, create a separate conflict worktree such as `/home/zhourui/opensource/tgoskits-conflict-pr<pr>`, checkout `origin/pr/<pr>` detached, merge `origin/<base>`, resolve conflicts according to the PR intent and current base behavior, validate, then commit the merge locally.
-- Keep conflict workers scoped to one worktree and one PR. Workers may resolve and commit locally, but the main agent must perform the final head-SHA check and push.
-- Before pushing a repaired conflict branch, fetch or query the PR again and confirm the local merge commit's first parent equals the current remote `headRefOid`. If the remote head changed, stop and rebase/re-review instead of pushing.
-- Push repaired fork branches with a normal non-force push to the PR head owner and branch, for example `git push https://github.com/<head-owner>/<repo>.git HEAD:<headRefName>`. Never force-push a contributor branch.
-- After pushing conflict repairs, refresh PR status. A PR may remain `BLOCKED` or `UNSTABLE` because of CI or reviews even after the merge conflict is gone; do not treat that as a failed conflict repair by itself.
+```text
+Use $review-single-pr to review PR #<pr> in <owner>/<repo>.
 
-## Duplicate or Superseded Fixes
+Context from $review-open-prs:
+- This PR is eligible because <never reviewed by current user | latest commit <sha/time> is newer than current user's last review <time>>.
+- Draft status: <draft|ready>.
+- Merge state: <mergeStateStatus>; maintainer edits: <maintainerCanModify>.
+- Scope requested by user: <scope summary>.
 
-Before approving a PR that fixes a user-visible bug, check whether the same bug is already fixed on the latest base branch or in another open PR:
-
-```bash
-git fetch origin <base> '+refs/pull/*/head:refs/remotes/origin/pr/*'
-gh pr list --state open --limit 100 --search '<bug keyword or command>'
-git grep -n -E '<relevant symbols|paths|commands>' origin/<base> -- <likely paths>
-gh pr diff <related-pr> --patch --color=never
+Review exactly this PR. Follow $review-single-pr for worktree setup, duplicate/superseded fix checks, conflict handling policy, local validation, Chinese inline comments, head-SHA freshness checks, and final APPROVE or REQUEST_CHANGES submission.
 ```
 
-Use `gh pr diff` or `git diff origin/<base>...origin/pr/<pr>` to understand the PR's own patch. Use `git diff origin/<base>..origin/pr/<pr>` only when intentionally checking how stale the branch is against current base; stale branches can show large unrelated reversions.
+If workers or subagents are explicitly allowed, give each worker exactly one PR and one worktree. Worker prompts must say:
 
-Treat a PR as not mergeable when it is superseded by a more complete PR or would regress newer base-branch work. In that case, leave a neutral project-focused comment explaining why the newer PR or base implementation should be preferred. If asked to close such a PR, prefer:
-
-```bash
-gh pr comment <pr> --body-file comment.md
-gh pr close <pr>
-```
-
-Some `gh` versions do not support `gh pr close --comment-file`; avoid shell backticks in inline `--comment` strings because they can be executed by the shell.
-
-## Worktrees
-
-Fetch PR heads and create one isolated worktree per eligible PR:
-
-```bash
-git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*' '+refs/heads/*:refs/remotes/origin/*'
-git worktree add --detach /home/zhourui/opensource/tgoskits-review-pr<pr> origin/pr/<pr>
-```
-
-Never review multiple StarryOS QEMU cases in the same checkout at the same time. Use separate worktrees for parallel PR review, and do not modify or revert the user's main worktree.
-
-If a review worktree already exists, verify it is clean and at the expected PR head before reusing it:
-
-```bash
-git -C /home/zhourui/opensource/tgoskits-review-pr<pr> status --short
-git -C /home/zhourui/opensource/tgoskits-review-pr<pr> rev-parse HEAD
-git rev-parse refs/remotes/origin/pr/<pr>
-```
-
-If the existing worktree is stale and clean, update it to the fetched PR head with a non-destructive detached checkout. If it has local changes, do not overwrite them; create a fresh worktree path or ask how to proceed.
-
-When spawning workers, give each worker exactly one PR and one worktree. Tell workers to:
-
+- use `review-single-pr` for the actual review procedure;
 - perform read-only review plus local validation only;
-- not submit GitHub reviews;
-- not push contributor branches unless explicitly assigned a conflict-repair task, and even then prefer local commit only with final push by the main agent;
+- do not submit GitHub reviews;
+- do not push contributor branches unless explicitly assigned conflict-repair work, and then prefer local commit only with final push by the main agent;
 - return `APPROVE` or `REQUEST_CHANGES`;
 - provide `path`, `line`, `side=RIGHT`, and Chinese inline comment body for each blocking issue;
 - include commands run and exact failures;
 - identify missing reproduction tests for bug fixes.
+- clean temporary worktrees/files before returning, or report the path and reason when cleanup is unsafe.
 
-## Review Threads
+Before submitting any worker-derived review, the main agent must refresh the PR head, verify each finding still applies to a current right-side diff line, and follow `review-single-pr` submission rules.
 
-Use thread-aware review data whenever the task includes resolving old comments or deciding whether previous requested changes are fixed. Flat review comments are not enough because they omit `isResolved`, `isOutdated`, and thread IDs.
+## Conflict Handling
 
-Fetch review threads with GraphQL:
+For each conflicted eligible PR, dispatch through `review-single-pr`; it owns the conflict policy, including repairing conflicts after an otherwise-approvable review when maintainer edits are allowed. If the user explicitly asks for conflict handling, say that in the dispatch prompt. The main agent must keep conflict repair separate from ordinary review, and must not force-push contributor branches.
 
-```bash
-gh api graphql -F query=@query.graphql -F owner=<owner> -F repo=<repo> -F number=<pr>
-```
+## Final Summary
 
-The query must include `reviewThreads { nodes { id isResolved isOutdated path line diffSide comments(first: 100) { nodes { author { login } body createdAt } } } }`. Detached worktrees cannot rely on `gh pr view` branch inference, so pass `<owner>`, `<repo>`, and `<pr>` explicitly when using helper scripts.
+End with a concise summary of:
 
-When resolving threads:
-
-- resolve only threads whose concrete issue is fixed in the current PR head;
-- keep threads open when the fix is partial, the test is not wired into the runner, or the comment is still behaviorally valid;
-- resolving an old thread does not imply approval if new blocking issues remain;
-- after resolving, fetch threads again and confirm `isResolved=true`.
-
-Resolve with:
-
-```bash
-gh api graphql \
-  -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}}' \
-  -f threadId=<thread-id>
-```
-
-## Review Standards
-
-Review code against the PR's stated intent, existing project patterns, and relevant external semantics:
-
-- POSIX/Linux semantics for syscalls, filesystem errors, process/session/signal behavior, sockets, IPv4/IPv6, `IPV6_V6ONLY`, and `/proc`.
-- RFCs or Linux behavior for networking details such as IPv6 NDP, IPv4-mapped IPv6, dual-stack listeners, route/listen conflicts, and errno behavior.
-- VirtIO, PCI, DMA, MMIO, IRQ, and driver ownership rules for driver changes.
-- Axvisor VM config semantics for `entry_point`, `kernel_load_addr`, `memory_regions`, `map_type`, and guest image layout.
-- StarryOS test-suit layout rules from `starry-test-suit` when test cases or `qemu-*.toml` files change.
-- `cross-kernel-driver` architecture rules when portable driver crates or driver glue change.
-
-For bug fixes, require a reproduction test that fails before the fix and passes after it, unless the environment makes that impossible. If a reproduction cannot be run locally, explain the blocker and what evidence was checked instead.
-
-For syscall semantics bugs, ensure tests exercise the same ABI surface being fixed. A libc wrapper may translate raw syscall return values or errno behavior, so raw syscall bugs often need direct `syscall(SYS_...)` coverage in addition to libc wrapper coverage.
-
-Do not accept "success path" tests that silently skip on unexpected failure, such as returning early when `brk`, `sbrk`, I/O, or socket setup returns `ENOMEM`/`EAGAIN`, unless the test prints an explicit skip marker and the review explains why the environment legitimately cannot require success. Bugfix reproduction tests should fail loudly when the fixed behavior is absent.
-
-## Validation
-
-Always run local verification that matches the changed surface. Prefer project `xtask` commands:
-
-- Baseline formatting:
-  ```bash
-  cargo fmt --check
-  ```
-- Changed Rust crate:
-  ```bash
-  cargo xtask clippy --package <crate>
-  ```
-- Crates outside the workspace or special manifests:
-  ```bash
-  cargo clippy --manifest-path <path>/Cargo.toml --all-features -- -D warnings
-  ```
-- StarryOS cases:
-  ```bash
-  cargo xtask starry test qemu --arch <arch> -c <case>
-  ```
-- Axvisor configs:
-  ```bash
-  cargo xtask axvisor build ... --vmconfigs <config>
-  ```
-
-If `cargo xtask` cannot satisfy a special configuration, inspect the relevant `xtask` help or source first, then fall back to a native Cargo command with matched arguments. Record exact command output for failures such as unknown package names, QEMU timeout, missing guest image, or clippy diagnostics.
-
-For StarryOS grouped QEMU cases, verify that newly listed commands are actually installed into the guest overlay. A `qemu-*.toml` `test_commands` entry such as `/usr/bin/<test>` must correspond to a case/subcase asset path that the runner discovers and builds. Running the containing grouped case is the preferred check, for example:
-
-```bash
-cargo xtask starry test qemu --arch x86_64 -c syscall
-```
-
-Treat `/usr/bin/<test>: not found`, `status=127`, skipped discovery, or an unbuilt asset directory as blocking even when the Rust code and clippy pass.
-
-For bugfix tests in grouped cases, inspect the new test's assertions as well as running the case. A grouped case passing is not sufficient when the new test accepts both the fixed behavior and the broken behavior.
-
-Use GitHub check status as required evidence, but not as the only review input:
-
-```bash
-gh pr checks <pr> --watch=false
-```
-
-Do not approve solely because remote CI passes; local review and targeted validation still matter. Conversely, if required checks are failing, cancelled, or missing for a branch that needs CI coverage, treat that as blocking unless there is a clear project-approved reason. A branch with "no checks reported" is not equivalent to passing; require targeted local validation before approving, and request changes when the changed surface is too large or risky to validate locally.
-
-## Findings
-
-Treat these as blocking unless clearly non-blocking:
-
-- behavior differs from POSIX/Linux/RFC/VirtIO semantics;
-- local targeted tests or clippy fail;
-- new tests are not discovered by the project test runner;
-- `success_regex` or `fail_regex` cannot reliably classify the intended StarryOS case result;
-- bug fix lacks a meaningful reproduction test;
-- submitted buffers, DMA memory, queue tokens, or IRQ ownership can be leaked, freed too early, or handled in the wrong layer;
-- a change silently makes CI hang, time out, or skip the new coverage.
-- an older PR duplicates or weakens a fix already present on the base branch or in a more complete open PR.
-
-Inline comments must be in Chinese, neutral, and project-focused. Each comment should include:
-
-1. the concrete problem;
-2. the relevant standard, project rule, or observed test failure;
-3. a suggested fix.
-
-Prefer commenting on changed lines in the PR diff. If GitHub cannot resolve a comment line, move the comment to the nearest changed line that demonstrates the problem or put the finding in the review body. Before submitting inline comments from a worker, verify each `line` is present on the right side of the current PR diff; context or unchanged lines may be rejected by the review API.
-
-## Submit Reviews
-
-Before submission, confirm the PR head SHA has not changed:
-
-```bash
-gh pr view <pr> --json number,headRefOid,reviewDecision
-```
-
-If the PR head changed after a worker reported, after local validation, or after a previous review was submitted, do not submit stale findings against the old head. Fetch the new head, update the worktree, re-check whether each finding still applies on changed right-side lines, and rerun at least the targeted validation that supported the decision.
-
-Submit with the GitHub review API so inline comments and final event land together:
-
-```bash
-gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input review.json
-```
-
-Use `REQUEST_CHANGES` when there is any blocking issue. Use `APPROVE` when there are no blocking issues; non-blocking suggestions may be included as comments or in the review body.
-
-Inline review payloads must include the current `headRefOid` as `commit_id`, and each inline comment should use a changed-line anchor on `side=RIGHT`:
-
-```json
-{
-  "commit_id": "<headRefOid>",
-  "event": "REQUEST_CHANGES",
-  "body": "...",
-  "comments": [
-    {"path": "path/to/file.rs", "line": 123, "side": "RIGHT", "body": "..."}
-  ]
-}
-```
-
-If a worker returns a finding on a line that is not present on the current PR diff, move the comment to the nearest changed line that demonstrates the problem or put the finding in the review body.
-
-After the API call returns, re-query the PR. If a new commit landed during review submission, immediately refresh and submit a follow-up review only if the blocking issue still applies to the new head.
-
-Review body should summarize:
-
-- decision;
-- local validation commands and results;
-- for failing tests, the exact failure mode;
-- for bug fixes, reproduction coverage status;
-- any known environment limitation.
-
-After submission, verify final state:
-
-```bash
-gh pr view <pr> --json number,reviewDecision,latestReviews
-```
-
-End with a concise user summary listing each reviewed PR, decision, key reason, and review link.
+- reviewed PRs, decision, and key reason;
+- PRs excluded from review and why;
+- validation commands that failed or could not be run;
+- any PRs left for the author because of conflicts, missing maintainer edit permission, stale heads, or insufficient local/CI evidence;
+- temporary worktrees/files that could not be cleaned and why.

--- a/.claude/skills/review-open-prs/agents/openai.yaml
+++ b/.claude/skills/review-open-prs/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review Open PRs"
-  short_description: "Audit and review eligible open PRs"
-  default_prompt: "Use $review-open-prs to review eligible open PRs in this project."
+  short_description: "Find eligible open PRs and dispatch single-PR reviews"
+  default_prompt: "Use $review-open-prs to find eligible open PRs, then call $review-single-pr for each PR that needs review."

--- a/.claude/skills/review-single-pr/SKILL.md
+++ b/.claude/skills/review-single-pr/SKILL.md
@@ -9,7 +9,7 @@ description: Review one specified GitHub pull request in this tgoskits repositor
 
 Perform a focused review of exactly one PR, using an isolated worktree and local validation before submitting a GitHub review. The normal outcome is either `APPROVE` when no blocking issue remains, or `REQUEST_CHANGES` with Chinese inline comments when the PR has correctness, standards, test, or CI coverage problems.
 
-This skill is the single-PR subset of `review-open-prs`: do not scan all open PRs unless needed to check duplicate or superseded fixes.
+This skill is the authoritative single-PR workflow used by `review-open-prs`: do not scan all open PRs unless needed to check duplicate or superseded fixes.
 
 ## System Skill Priority
 
@@ -42,7 +42,19 @@ Fallback only when the GitHub MCP/connector cannot provide the needed data:
 
 ## Review Threads And CI
 
-For prior requested changes, unresolved review threads, inline review locations, or resolution state, follow `github:gh-address-comments`: use the GitHub app/MCP for PR metadata and patch context, and use its GraphQL-based `gh` fallback only when thread-level fields such as `isResolved`, `isOutdated`, `diffSide`, or exact line anchors are required. Do not treat flat connector comments as a complete representation of review-thread state.
+For prior requested changes, unresolved review conversations, inline review locations, or resolution state, follow `github:gh-address-comments`: use the GitHub app/MCP for PR metadata and patch context, and use its GraphQL-based `gh` fallback only when thread-level fields such as `isResolved`, `isOutdated`, `diffSide`, or exact line anchors are required. Do not treat flat connector comments as a complete representation of review-thread state.
+
+When using GraphQL directly, request `reviewThreads { nodes { id isResolved isOutdated path line diffSide comments(first: 100) { nodes { author { login } body createdAt } } } }`. Detached worktrees cannot rely on current-branch PR inference, so pass `<owner>`, `<repo>`, and `<pr>` explicitly to helpers.
+
+Always inspect unresolved review conversations from previous reviews. If the concrete issue is fixed in the current PR head, resolve the conversation before finishing the review. Keep threads open when the fix is partial, the test is not wired into the runner, or the comment is still behaviorally valid. Resolving old threads does not imply approval if new blocking issues remain.
+
+Resolve fixed conversations with the review-thread API, then fetch threads again and confirm every resolved thread reports `isResolved=true`:
+
+```bash
+gh api graphql \
+  -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}}' \
+  -f threadId=<thread-id>
+```
 
 For failing or suspicious GitHub Actions checks, follow `github:gh-fix-ci`: use the GitHub app/MCP for PR context and use `gh` for Actions check/log inspection because the connector does not expose that workflow end to end. Remote CI is evidence, not a substitute for local review and targeted validation.
 
@@ -68,9 +80,22 @@ git rev-parse refs/remotes/origin/pr/<pr>
 
 If it is stale and clean, update it non-destructively to the fetched PR head. If it has local changes, create a fresh worktree path or ask how to proceed. Do not modify or revert the user's main worktree while reviewing.
 
+Never review multiple StarryOS QEMU cases in the same checkout at the same time. Use separate worktrees for parallel PR review.
+
+## Merge Conflicts
+
+Handle merge conflicts in either of these cases: the user explicitly asks for conflict handling, or the review has no blocking findings and would otherwise be `APPROVE` while `mergeStateStatus=DIRTY` and `maintainerCanModify=true`. Do not submit approval before the conflict repair is pushed and re-validated against the new head.
+
+- If `mergeStateStatus` is `DIRTY` and `maintainerCanModify=false`, do not repair the branch. When conflict handling was explicitly requested, submit `REQUEST_CHANGES` explaining that the branch conflicts with base and maintainers cannot push a fix; ask the author to merge/rebase latest base and suggest enabling "Allow edits by maintainers". Otherwise, include the conflict limitation in the review body or user summary.
+- If `mergeStateStatus` is `DIRTY` and `maintainerCanModify=true`, create a separate conflict worktree, check out `origin/pr/<pr>` detached, merge `origin/<base>`, resolve conflicts according to PR intent and current base behavior, validate, then commit the merge locally.
+- Before pushing a repaired conflict branch, refresh the PR and confirm the local merge commit's first parent equals the current remote `headRefOid`. If the remote head changed, stop and rebase/re-review instead of pushing.
+- Push repaired fork branches with a normal non-force push to the PR head owner and branch, for example `git push https://github.com/<head-owner>/<repo>.git HEAD:<headRefName>`. Never force-push a contributor branch.
+- After pushing conflict repairs, refresh PR status, update the review worktree to the new head, and rerun the targeted validation that supports approval. Submit `APPROVE` only if the repaired head still has no blocking findings; otherwise submit `REQUEST_CHANGES` with the remaining conflict or validation problem.
+- `BLOCKED` or `UNSTABLE` may remain because of CI or reviews even after conflicts are gone; do not treat that alone as failed conflict repair.
+
 ## Review Focus
 
-Review the PR against its stated intent, the current base branch, existing project patterns, and relevant external semantics:
+Review the PR against its stated intent, the current base branch, existing project patterns, and relevant external semantics. Understand the implementation logic, not just whether tests pass:
 
 - POSIX/Linux behavior for syscalls, process/session/signal semantics, filesystem errors, sockets, IPv4/IPv6, and `/proc`.
 - RFC or Linux behavior for networking details such as IPv6 NDP, IPv4-mapped IPv6, dual-stack listeners, route/listen conflicts, and errno behavior.
@@ -80,6 +105,10 @@ Review the PR against its stated intent, the current base branch, existing proje
 - `cross-kernel-driver` architecture rules when portable driver crates or driver glue change.
 
 For bug fixes, require a reproduction test that fails before the fix and passes after it unless the environment makes that impossible. For raw syscall fixes, prefer direct `syscall(SYS_...)` coverage when libc wrappers could mask return values or errno.
+
+Do not approve changes that are only shaped to satisfy the added tests, such as hard-coded special cases, skipped behavior, fake state updates, no-op compatibility shims, or logic that does not implement the intended subsystem semantics. Treat this as blocking even when local tests and CI pass.
+
+Do not accept "success path" tests that silently skip on unexpected failure, such as returning early when `brk`, `sbrk`, I/O, or socket setup returns `ENOMEM`/`EAGAIN`, unless the test prints an explicit skip marker and the review explains why the environment legitimately cannot require success. Bugfix reproduction tests should fail loudly when the fixed behavior is absent.
 
 Before approving a bugfix PR, check whether the same bug is already fixed on base or in another open PR:
 
@@ -91,9 +120,12 @@ Use the GitHub MCP/connector to search or list related open PRs first. Fallback 
 
 ```bash
 gh pr list --state open --limit 100 --search '<bug keyword or command>'
+gh pr diff <related-pr> --patch --color=never
 ```
 
 Use `git diff origin/<base>...origin/pr/<pr>` for the PR patch. Use `origin/<base>..origin/pr/<pr>` only when intentionally checking stale-branch effects.
+
+Treat a PR as not mergeable when it is superseded by a more complete PR or would regress newer base-branch work. Leave a neutral project-focused comment explaining why the newer PR or base implementation should be preferred. If asked to close such a PR, prefer `gh pr comment <pr> --body-file comment.md` followed by `gh pr close <pr>`; avoid shell backticks in inline `--comment` strings.
 
 ## Validation
 
@@ -102,15 +134,24 @@ Run focused validation matching the changed surface. Prefer project `xtask` comm
 ```bash
 cargo fmt --check
 cargo xtask clippy --package <crate>
+cargo clippy --manifest-path <path>/Cargo.toml --all-features -- -D warnings
 cargo xtask starry test qemu --arch <arch> -c <case>
 cargo xtask axvisor build ... --vmconfigs <config>
 ```
 
 If `cargo xtask` does not cover a special configuration, inspect the relevant `xtask` help or source before falling back to native Cargo with matched arguments. Record exact commands and failures.
 
-For StarryOS grouped QEMU cases, verify that new `test_commands` are actually discovered and installed into the guest overlay. Treat `/usr/bin/<test>: not found`, `status=127`, skipped discovery, unbuilt asset directories, unreliable `success_regex`/`fail_regex`, or tests that accept both broken and fixed behavior as blocking.
+For StarryOS grouped QEMU cases, verify that new `test_commands` are actually discovered and installed into the guest overlay. A `qemu-*.toml` command such as `/usr/bin/<test>` must correspond to a case/subcase asset path that the runner discovers and builds. Running the containing grouped case is the preferred check, for example `cargo xtask starry test qemu --arch x86_64 -c syscall`. Treat `/usr/bin/<test>: not found`, `status=127`, skipped discovery, unbuilt asset directories, unreliable `success_regex`/`fail_regex`, or tests that accept both broken and fixed behavior as blocking.
 
-Remote CI is useful evidence but not a substitute for local review. A branch with no reported checks is not equivalent to passing.
+For bugfix tests in grouped cases, inspect the new test's assertions as well as running the case. A grouped case passing is not sufficient when the new test accepts both the fixed behavior and the broken behavior.
+
+Use GitHub check status as required evidence, but not as the only review input:
+
+```bash
+gh pr checks <pr> --watch=false
+```
+
+Do not approve solely because remote CI passes. Conversely, if required checks are failing, cancelled, or missing for a branch that needs CI coverage, treat that as blocking unless there is a clear project-approved reason. A branch with no reported checks is not equivalent to passing; require targeted local validation before approving, and request changes when the changed surface is too large or risky to validate locally.
 
 ## Blocking Findings
 
@@ -118,14 +159,17 @@ Treat these as blocking unless clearly non-blocking:
 
 - behavior differs from POSIX/Linux/RFC/VirtIO semantics;
 - targeted tests, formatting, clippy, or CI fail;
-- new tests are not discovered or do not exercise the fixed ABI surface;
+- new tests are not discovered by the project test runner or do not exercise the fixed ABI surface;
+- `success_regex` or `fail_regex` cannot reliably classify the intended StarryOS case result;
 - bug fixes lack meaningful reproduction coverage;
+- the implementation is a test-only or fake fix that does not implement the intended behavior;
 - submitted buffers, DMA memory, queue tokens, or IRQ ownership can leak, be freed too early, or cross the wrong abstraction layer;
+- a change silently makes CI hang, time out, or skip the new coverage;
 - the PR duplicates, weakens, or is superseded by a newer base-branch or open-PR fix.
 
-Inline comments must be Chinese, neutral, and project-focused. Each comment should include the concrete problem, the relevant standard/project rule/observed failure, and a suggested fix.
+All GitHub review text, including inline comments, review body, and replies, must be in Chinese, neutral, and project-focused. Each blocking comment should include the concrete problem, the relevant standard/project rule/observed failure, and a suggested fix.
 
-Prefer changed lines on the PR diff. Before submitting, verify every inline `line` exists on the current right side of the diff; if GitHub cannot resolve a line, move to the nearest changed line that demonstrates the issue or put the finding in the review body.
+Prefer changed lines on the PR diff. Before submitting, verify every inline `line` exists on the current right side of the diff; if GitHub cannot resolve a line, move to the nearest changed line that demonstrates the issue or put the finding in the review body. Context or unchanged lines may be rejected by the review API.
 
 ## Submit Review
 
@@ -157,3 +201,34 @@ Use the current `headRefOid` as `commit_id`, `side=RIGHT` for inline comments, `
 ```
 
 Do not submit stale findings against an old head.
+
+If a worker returns a finding on a line that is not present on the current PR diff, move the comment to the nearest changed line that demonstrates the problem or put the finding in the review body.
+
+After submission, re-query the PR. If a new commit landed during review submission, refresh the worktree and submit a follow-up review only if the blocking issue still applies to the new head.
+
+Review body must explain in Chinese:
+
+- what the PR changed;
+- the implementation logic and why this approach is correct for the project semantics;
+- validation commands and results, including exact failure mode for failing tests;
+- reproduction coverage status for bug fixes;
+- unresolved review conversations that were resolved, and conversations intentionally left open and why;
+- any behavior that remains unimplemented, partial, or should be completed in future work;
+- any known environment limitation.
+
+Do not approve when the review cannot explain the implementation logic beyond "tests pass".
+
+Verify final state:
+
+```bash
+gh pr view <pr> --json number,reviewDecision,latestReviews
+```
+
+## Cleanup
+
+After review submission or an explicit no-submit stop, clean temporary resources before ending:
+
+- Remove clean review and conflict worktrees with `git worktree remove <path>`, then run `git worktree prune` from the main repository.
+- Delete temporary files created for review payloads, GraphQL queries, comments, logs, or conflict notes unless the user asked to keep them.
+- Do not remove a worktree that has uncommitted conflict-repair work, diagnostics needed for a reported failure, or user-created changes; report the path and reason instead.
+- Confirm the main worktree status was not changed by the review workflow.


### PR DESCRIPTION
## Summary

- make `review-open-prs` a lightweight eligibility and dispatch skill
- centralize single-PR review rules in `review-single-pr`
- add conflict-repair and cleanup requirements to the PR review workflow

## Validation

- `git diff --check -- .claude/skills/review-open-prs .claude/skills/review-single-pr`

No Rust code changed, so `cargo fmt` / `cargo clippy` were not run.