### PR TITLE
fix(tty): drain console input without RX IRQ

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
@@ -54,7 +54,7 @@ fn new_n_tty() -> Arc<NTtyDriver> {
 fn console_irq_mode() -> Option<ProcessMode> {
     let irq = ax_hal::console::irq_num()?;
     if !ax_hal::irq::register(irq, handle_console_input_irq) {
-        warn!("Failed to register console IRQ handler for irq {irq}, falling back to manual mode");
+        warn!("Failed to register console IRQ handler for irq {irq}, falling back to polling mode");
         return None;
     }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -1,6 +1,7 @@
 use alloc::{sync::Arc, task::Wake, vec::Vec};
 use core::{
     future::poll_fn,
+    marker::PhantomData,
     ops::Range,
     sync::atomic::{AtomicBool, Ordering},
     task::{Poll, Waker},
@@ -27,12 +28,12 @@ type ReadBuf = Arc<ringbuf::StaticRb<u8, BUF_SIZE>>;
 
 /// How should we process inputs?
 pub enum ProcessMode {
-    /// Process inputs only on call to `read`
+    /// Process inputs without an external event source.
     ///
-    /// This is the fallback strategy and is rather limited. For instance, you
-    /// can't interrupt a running program by Ctrl+C unless it's not blocked on a
-    /// `read` call to the terminal, since the signal is emitted only when
-    /// inputs are being processed.
+    /// This is used as the fallback for consoles without an RX interrupt. A
+    /// background task drains input directly and yields when idle, so signals
+    /// and serial auto-init commands still work while no user task is blocked
+    /// in `read()`.
     Manual,
     /// Spawns task for processing inputs, relying on an external event source
     /// to wake it up.
@@ -98,9 +99,11 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
         if self.clear_line_buf.swap(false, Ordering::Relaxed) {
             self.line_buf.clear();
         }
+        let mut progressed = false;
         if self.read_range.is_empty() {
             let read = self.reader.read(&mut self.read_buf);
             self.read_range = 0..read;
+            progressed |= read > 0;
         }
         let term = self.terminal.load_termios();
         let mut sent = 0;
@@ -123,6 +126,7 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
             }
             let mut ch = self.read_buf[self.read_range.start];
             self.read_range.start += 1;
+            progressed = true;
 
             if ch == b'\r' {
                 if term.has_iflag(IGNCR) {
@@ -182,7 +186,7 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
             }
         }
 
-        sent > 0
+        sent > 0 || progressed
     }
 
     fn check_send_signal(&self, term: &Termios2, ch: u8) -> bool {
@@ -236,8 +240,7 @@ impl<R: TtyRead> SimpleReader<R> {
     }
 }
 
-enum Processor<R, W> {
-    Manual(InputReader<R, W>),
+enum Processor<R> {
     InterruptDriven,
     Passive(SimpleReader<R>, Arc<PollSet>),
 }
@@ -249,7 +252,8 @@ pub struct LineDiscipline<R, W> {
     pump_retry: Arc<PollSet>,
     eof_ready: Arc<AtomicBool>,
     clear_line_buf: Arc<AtomicBool>,
-    processor: Processor<R, W>,
+    processor: Processor<R>,
+    _writer: PhantomData<W>,
 }
 
 struct WakeSignal {
@@ -316,6 +320,17 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         );
     }
 
+    fn spawn_polling_reader(mut reader: InputReader<R, W>, input_ready: Arc<PollSet>) {
+        ax_task::spawn_with_name(
+            move || loop {
+                if !Self::drive_input(&mut reader, input_ready.as_ref()) {
+                    ax_task::yield_now();
+                }
+            },
+            "tty-poll-reader".into(),
+        );
+    }
+
     pub fn new(terminal: Arc<Terminal>, config: TtyConfig<R, W>) -> Self {
         let (buf_tx, buf_rx) = ReadBuf::default().split();
 
@@ -340,7 +355,6 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         let input_ready = Arc::new(PollSet::new());
         let pump_retry = Arc::new(PollSet::new());
         let processor = match config.process_mode {
-            ProcessMode::Manual => Processor::Manual(reader),
             ProcessMode::InterruptDriven(input_source) => {
                 Self::spawn_interrupt_driven_reader(
                     reader,
@@ -348,6 +362,10 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
                     input_ready.clone(),
                     pump_retry.clone(),
                 );
+                Processor::InterruptDriven
+            }
+            ProcessMode::Manual => {
+                Self::spawn_polling_reader(reader, input_ready.clone());
                 Processor::InterruptDriven
             }
             ProcessMode::Passive(poll_rx) => {
@@ -370,6 +388,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             eof_ready,
             clear_line_buf,
             processor,
+            _writer: PhantomData,
         }
     }
 
@@ -380,12 +399,8 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
     }
 
     pub fn poll_read(&mut self) -> bool {
-        match &mut self.processor {
-            Processor::Manual(reader) => {
-                reader.drain_source_into_line_buffer();
-            }
-            Processor::Passive(reader, _) => reader.poll(),
-            _ => {}
+        if let Processor::Passive(reader, _) = &mut self.processor {
+            reader.poll();
         }
         let term = self.terminal.termios.lock().clone();
         if term.canonical() {
@@ -401,9 +416,6 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
     pub fn register_rx_waker(&self, waker: &Waker) {
         match &self.processor {
-            Processor::Manual(_) => {
-                waker.wake_by_ref();
-            }
             Processor::InterruptDriven => {
                 self.input_ready.register(waker);
             }
@@ -441,21 +453,6 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             return Err(AxError::WouldBlock);
         }
 
-        let mut total_read = 0;
-        if let Processor::Manual(reader) = &mut self.processor {
-            loop {
-                reader.drain_source_into_line_buffer();
-                total_read += self.buf_rx.pop_slice(&mut buf[total_read..]);
-                if total_read >= vmin {
-                    return Ok(total_read);
-                }
-                if self.eof_ready.swap(false, Ordering::AcqRel) {
-                    return Ok(0);
-                }
-                ax_task::yield_now();
-            }
-        }
-
         let available = self.buf_rx.occupied_len();
         if available == 0 {
             if term.canonical() && self.eof_ready.swap(false, Ordering::AcqRel) {
@@ -473,5 +470,98 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         let read = self.buf_rx.pop_slice(buf);
         self.pump_retry.clone().wake();
         Ok(read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{sync::Arc, vec::Vec};
+    use core::sync::atomic::AtomicBool;
+
+    use ringbuf::traits::{Observer, Split};
+
+    use super::{BUF_SIZE, InputReader, ReadBuf, TtyRead, TtyWrite};
+    use crate::pseudofs::dev::tty::terminal::Terminal;
+
+    struct MockReader {
+        data: Vec<u8>,
+        pos: usize,
+    }
+    impl MockReader {
+        fn new(data: Vec<u8>) -> Self {
+            Self { data, pos: 0 }
+        }
+    }
+    impl TtyRead for MockReader {
+        fn read(&mut self, buf: &mut [u8]) -> usize {
+            let remaining = &self.data[self.pos..];
+            let n = remaining.len().min(buf.len());
+            buf[..n].copy_from_slice(&remaining[..n]);
+            self.pos += n;
+            n
+        }
+    }
+
+    struct MockWriter;
+    impl TtyWrite for MockWriter {
+        fn write(&self, _buf: &[u8]) {}
+    }
+
+    fn make_reader(
+        data: Vec<u8>,
+    ) -> (
+        InputReader<MockReader, MockWriter>,
+        ringbuf::CachingCons<ReadBuf>,
+    ) {
+        let (buf_tx, buf_rx) = ReadBuf::default().split();
+        let reader = InputReader {
+            terminal: Arc::new(Terminal::default()),
+            reader: MockReader::new(data),
+            writer: MockWriter,
+            buf_tx,
+            read_buf: [0; BUF_SIZE],
+            read_range: 0..0,
+            line_buf: Vec::new(),
+            line_read: None,
+            eof_ready: Arc::new(AtomicBool::new(false)),
+            clear_line_buf: Arc::new(AtomicBool::new(false)),
+        };
+        (reader, buf_rx)
+    }
+
+    /// Regression test: a canonical-mode input longer than BUF_SIZE characters
+    /// (with no newline in the first chunk) must not stall drain_source_into_line_buffer.
+    ///
+    /// Before the fix, the function returned `sent > 0` which was false after the
+    /// first BUF_SIZE bytes were consumed into line_buf (no newline yet), causing
+    /// drive_input() to stop looping and the remaining input (including the newline)
+    /// to be silently dropped.  The board CI symptom was shell commands being
+    /// truncated to the first BUF_SIZE characters (e.g. "sleep 5; ..." → "leep 5; ...").
+    #[test]
+    fn canonical_long_line_drain_continues_past_buf_size() {
+        // BUF_SIZE ordinary chars followed by '\n' — total BUF_SIZE+1 bytes.
+        let mut data: Vec<u8> = (0..BUF_SIZE).map(|_| b'a').collect();
+        data.push(b'\n');
+
+        let (mut reader, mut rx) = make_reader(data);
+
+        // First drain: reads the BUF_SIZE 'a' bytes into line_buf; no newline yet,
+        // so nothing reaches buf_rx.  Must still return true (progress was made).
+        assert!(
+            reader.drain_source_into_line_buffer(),
+            "first drain must return true even though buf_rx is still empty"
+        );
+        assert_eq!(
+            rx.occupied_len(),
+            0,
+            "buf_rx must remain empty before the newline is processed"
+        );
+
+        // Second drain: reads the '\n', completes the line, flushes to buf_rx.
+        reader.drain_source_into_line_buffer();
+        assert!(
+            rx.occupied_len() > 0,
+            "buf_rx must contain data after the newline is processed"
+        );
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/termios.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/termios.rs
@@ -6,7 +6,7 @@ use bytemuck::AnyBitPattern;
 use linux_raw_sys::general::{
     B38400, CREAD, CS8, ECHO, ECHOCTL, ECHOE, ECHOK, ECHOKE, ICANON, ICRNL, IEXTEN, ISIG, IXON,
     ONLCR, OPOST, VDISCARD, VEOF, VEOL, VEOL2, VERASE, VINTR, VKILL, VLNEXT, VQUIT, VREPRINT,
-    VWERASE, speed_t, tcflag_t,
+    VSUSP, VWERASE, speed_t, tcflag_t,
 };
 use starry_signal::Signo;
 
@@ -47,6 +47,7 @@ impl Default for Termios {
             (VWERASE, ctl(b'W')),
             (VLNEXT, ctl(b'V')),
             (VEOL2, b'\0'),
+            (VSUSP, ctl(b'Z')),
         ] {
             result.c_cc[i as usize] = ch;
         }
@@ -104,6 +105,7 @@ impl Termios {
         Some(match ch {
             ch if ch == self.special_char(VINTR) => Signo::SIGINT,
             ch if ch == self.special_char(VQUIT) => Signo::SIGQUIT,
+            ch if ch == self.special_char(VSUSP) => Signo::SIGTSTP,
             _ => return None,
         })
     }

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-tty-sigint C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-tty-sigint src/main.c)
+target_compile_options(bug-tty-sigint PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-tty-sigint RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-tty-sigint/c/src/main.c
@@ -1,0 +1,267 @@
+/*
+ * bug-tty-sigint: 通过 PTY 写入 0x03/0x1a 验证 TTY 控制字符路径。
+ *
+ * 本测试覆盖本 PR 修复的实际路径：
+ *
+ *   write(master_fd, "\x03", 1)
+ *     → PtyWriter 写入 master_to_slave 缓冲区，唤醒 poll_rx_slave
+ *     → 从设备 InterruptDriven reader 任务唤醒
+ *     → drain_source_into_line_buffer() 读取 \x03
+ *     → check_send_signal() → signo_for(0x03) → SIGINT
+ *     → send_signal_to_process_group(pgid, SIGINT)
+ *     → 前台进程组收到 SIGINT
+ *
+ * 同理 \x1a → SIGTSTP（覆盖本 PR 新增的 VSUSP 映射）。
+ *
+ * 如果将 polling 改回 Manual 模式、或删除 signo_for 中的 VINTR/VSUSP
+ * 映射，本测试将失败。
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got_sig = 0;
+static void sig_handler(int s) { (void)s; got_sig = 1; }
+
+static void sleep_ms(long ms)
+{
+    struct timespec ts = { ms / 1000, (ms % 1000) * 1000000L };
+    nanosleep(&ts, NULL);
+}
+
+/* 打开 PTY 对，返回 master_fd；通过 slave_path 返回从设备路径 */
+static int open_pty(char *slave_path, size_t len)
+{
+    int master = open("/dev/ptmx", O_RDWR | O_NOCTTY);
+    if (master < 0) {
+        printf("FAIL: open /dev/ptmx: %s\n", strerror(errno));
+        return -1;
+    }
+    unsigned int pty_num = 0;
+    if (ioctl(master, TIOCGPTN, &pty_num) != 0) {
+        printf("FAIL: TIOCGPTN: %s\n", strerror(errno));
+        close(master);
+        return -1;
+    }
+    snprintf(slave_path, len, "/dev/pts/%u", pty_num);
+    return master;
+}
+
+/* ---- 测试一：PTY master 写入 \x03 → 从设备前台进程收到 SIGINT ---- */
+static int test_pty_ctrl_c(void)
+{
+    printf("[test1] PTY: write(master, \\x03) 应通过行规程发送 SIGINT\n");
+
+    char slave_path[64];
+    int master = open_pty(slave_path, sizeof(slave_path));
+    if (master < 0) return 1;
+
+    int slave = open(slave_path, O_RDWR | O_NOCTTY);
+    if (slave < 0) {
+        printf("FAIL: open %s: %s\n", slave_path, strerror(errno));
+        close(master);
+        return 1;
+    }
+
+    int sync[2];
+    if (pipe(sync) != 0) { close(master); close(slave); return 1; }
+
+    pid_t child = fork();
+    if (child < 0) {
+        printf("FAIL: fork: %s\n", strerror(errno));
+        close(master); close(slave); close(sync[0]); close(sync[1]);
+        return 1;
+    }
+
+    if (child == 0) {
+        close(master);
+        close(sync[0]);
+
+        /*
+         * 创建新会话并将从设备设为控制终端。
+         * TIOCSCTTY → bind_to() → set_session() + set_foreground(当前进程组)
+         * 此后当行规程检测到 VINTR 时，会向该前台进程组发 SIGINT。
+         */
+        if (setsid() < 0) { write(sync[1], "E", 1); _exit(99); }
+        if (ioctl(slave, TIOCSCTTY, 0) != 0) {
+            write(sync[1], "E", 1);
+            _exit(99);
+        }
+        close(slave);
+
+        write(sync[1], "R", 1);
+        close(sync[1]);
+
+        /* 阻塞；SIGINT 默认动作为终止进程 */
+        pause();
+        _exit(0); /* 不应到达 */
+    }
+
+    /* 父进程 */
+    close(slave);
+    close(sync[1]);
+    char buf;
+    if (read(sync[0], &buf, 1) != 1 || buf != 'R') {
+        printf("FAIL: 子进程未就绪 (buf=%c)\n", buf);
+        kill(child, SIGKILL); waitpid(child, NULL, 0);
+        close(master); close(sync[0]);
+        return 1;
+    }
+    close(sync[0]);
+
+    sleep_ms(150); /* 确保子进程进入 pause() */
+
+    /*
+     * 写入 Ctrl+C (0x03) 到 PTY master。
+     * master 的 write_at 以 is_ptm=true 直接写入 master_to_slave 缓冲区，
+     * 唤醒从设备 InterruptDriven reader，触发 check_send_signal → SIGINT。
+     */
+    if (write(master, "\x03", 1) != 1) {
+        printf("FAIL: write \\x03 to master: %s\n", strerror(errno));
+        kill(child, SIGKILL); waitpid(child, NULL, 0);
+        close(master);
+        return 1;
+    }
+    close(master);
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        printf("FAIL: waitpid: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT) {
+        printf("PASS: PTY 行规程正确将 \\x03 转换为 SIGINT 并终止前台进程\n");
+        return 0;
+    }
+    if (WIFEXITED(status))
+        printf("FAIL: 子进程正常退出 code=%d，期望被 SIGINT 终止\n",
+               WEXITSTATUS(status));
+    else
+        printf("FAIL: 子进程被信号 %d 终止，期望 SIGINT(%d)\n",
+               WTERMSIG(status), SIGINT);
+    return 1;
+}
+
+/* ---- 测试二：PTY master 写入 \x1a → 从设备前台进程收到 SIGTSTP ---- */
+static int test_pty_ctrl_z(void)
+{
+    printf("[test2] PTY: write(master, \\x1a) 应通过行规程发送 SIGTSTP\n");
+
+    char slave_path[64];
+    int master = open_pty(slave_path, sizeof(slave_path));
+    if (master < 0) return 1;
+
+    int slave = open(slave_path, O_RDWR | O_NOCTTY);
+    if (slave < 0) {
+        printf("FAIL: open %s: %s\n", slave_path, strerror(errno));
+        close(master);
+        return 1;
+    }
+
+    int sync[2];
+    if (pipe(sync) != 0) { close(master); close(slave); return 1; }
+
+    pid_t child = fork();
+    if (child < 0) {
+        printf("FAIL: fork: %s\n", strerror(errno));
+        close(master); close(slave); close(sync[0]); close(sync[1]);
+        return 1;
+    }
+
+    if (child == 0) {
+        close(master);
+        close(sync[0]);
+
+        if (setsid() < 0) { write(sync[1], "E", 1); _exit(99); }
+        if (ioctl(slave, TIOCSCTTY, 0) != 0) {
+            write(sync[1], "E", 1);
+            _exit(99);
+        }
+        close(slave);
+
+        /*
+         * 安装自定义 SIGTSTP 处理函数（覆盖默认 Stop 动作），
+         * 验证信号确实经行规程投递。
+         */
+        struct sigaction sa = {0};
+        sa.sa_handler = sig_handler;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGTSTP, &sa, NULL);
+        got_sig = 0;
+
+        write(sync[1], "R", 1);
+        close(sync[1]);
+
+        pause(); /* 等待 SIGTSTP；处理函数返回后 pause() 以 EINTR 返回 */
+        _exit(got_sig ? 0 : 1);
+    }
+
+    close(slave);
+    close(sync[1]);
+    char buf;
+    if (read(sync[0], &buf, 1) != 1 || buf != 'R') {
+        printf("FAIL: 子进程未就绪\n");
+        kill(child, SIGKILL); waitpid(child, NULL, 0);
+        close(master); close(sync[0]);
+        return 1;
+    }
+    close(sync[0]);
+
+    sleep_ms(150);
+
+    /*
+     * 写入 Ctrl+Z (0x1a) 到 PTY master。
+     * 行规程: check_send_signal → signo_for(0x1a=VSUSP) → SIGTSTP
+     * （覆盖本 PR 新增的 VSUSP → Signo::SIGTSTP 映射）
+     */
+    if (write(master, "\x1a", 1) != 1) {
+        printf("FAIL: write \\x1a to master: %s\n", strerror(errno));
+        kill(child, SIGKILL); waitpid(child, NULL, 0);
+        close(master);
+        return 1;
+    }
+    close(master);
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        printf("FAIL: waitpid: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        printf("PASS: PTY 行规程正确将 \\x1a 转换为 SIGTSTP 并投递到前台进程\n");
+        return 0;
+    }
+    if (WIFEXITED(status))
+        printf("FAIL: 子进程退出 code=%d（未收到 SIGTSTP 或信号映射缺失）\n",
+               WEXITSTATUS(status));
+    else
+        printf("FAIL: 子进程被信号 %d 终止，期望 SIGTSTP 由自定义处理函数捕获\n",
+               WTERMSIG(status));
+    return 1;
+}
+
+int main(void)
+{
+    printf("=== bug-tty-sigint ===\n");
+    printf("通过 PTY 验证 TTY 行规程控制字符 → 信号路径\n\n");
+
+    int r1 = test_pty_ctrl_c();
+    int r2 = test_pty_ctrl_z();
+
+    printf("\n");
+    if (r1 == 0 && r2 == 0) {
+        printf("TEST PASSED\n");
+        return 0;
+    }
+    printf("TEST FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -28,6 +28,7 @@ test_commands = [
     "/usr/bin/bug-preadv2-offset-neg1",
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
+    "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -30,6 +30,7 @@ test_commands = [
     "/usr/bin/bug-preadv2-offset-neg1",
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
+    "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -34,6 +34,7 @@ test_commands = [
     "/usr/bin/bug-preadv2-offset-neg1",
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
+    "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-wait4-invalid-options",
     "/usr/bin/bug-writev-dir-ebadf",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -27,6 +27,7 @@ test_commands = [
     "/usr/bin/bug-pwritev2-read-at",
     "/usr/bin/bug-signal-to-child",
     "/usr/bin/bug-tmpfs-cwd-drop-safe",
+    "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
     "/usr/bin/clone3-badsize",


### PR DESCRIPTION
## Summary

- Keep console input processing active when the platform has no console RX IRQ, so Ctrl+C/Ctrl+Z are delivered even while the foreground task is not blocked in `read()`.
- Preserve the `Manual` process-mode naming from `dev`, while changing its fallback behavior to drain input in a background reader task.
- Add/keep the `bug-tty-sigint` Starry grouped test coverage for VINTR/VSUSP signal delivery through the TTY line discipline.
- Also fixes the Starry board auto-init truncation seen in #493 CI, where long shell commands could lose bytes on no-IRQ serial input.

Replaces #493 with the same functional intent plus the local CI/board-test fix.

## Validation

- `cargo fmt`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --arch x86_64 -c bugfix`
- `cargo xtask starry test board --board orangepi-5-plus -c lsusb`
- `cargo xtask starry test board --board orangepi-5-plus -c boot`

Notes: a full local OrangePi board run also passed `lsusb`, `net-smoke`, and `pcie-enumerate`; `npu-yolov8` did not run to success on this board because `/guest/npu_demo` is missing from the local rootfs.
