### PR TITLE
refactor(axbuild): centralize build-info loading

### DIFF
--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1" }
 sha2 = { version = "0.10" }
 tar = { version = "0.4" }
-tokio = { version = "1.0", features = ["fs", "io-util", "macros", "process", "rt-multi-thread"], optional = true }
+tokio = { version = "1.0", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"], optional = true }
 toml.workspace = true
 tracing = "0.1"
 tracing-log = "0.2"

--- a/scripts/axbuild/src/arceos/build.rs
+++ b/scripts/axbuild/src/arceos/build.rs
@@ -61,9 +61,10 @@ fn load_build_info_with_makefile_features_and_metadata(
     makefile_features: &[String],
     metadata: Option<&Metadata>,
 ) -> anyhow::Result<ArceosBuildInfo> {
-    let mut build_info = build::load_or_create_build_info(&request.build_info_path, || {
+    build::ensure_build_info(&request.build_info_path, || {
         ArceosBuildInfo::default_for_target(&request.target)
     })?;
+    let mut build_info: ArceosBuildInfo = build::load_build_info(&request.build_info_path)?;
 
     if build_info.normalize_legacy_feature_aliases() {
         warn!(
@@ -102,19 +103,20 @@ fn load_build_info_with_makefile_features_and_metadata(
 }
 
 pub(crate) fn load_cargo_config(request: &ResolvedBuildRequest) -> anyhow::Result<Cargo> {
-    let metadata = build::workspace_metadata().context("failed to load workspace metadata")?;
+    let metadata =
+        build::cached_workspace_metadata().context("failed to load workspace metadata")?;
     let makefile_features = build::makefile_features_from_env();
     let build_info = load_build_info_with_makefile_features_and_metadata(
         request,
         &makefile_features,
-        Some(&metadata),
+        Some(metadata),
     )?;
 
     build_info.into_prepared_base_cargo_config_with_metadata(
         &request.package,
         &request.target,
         request.plat_dyn,
-        &metadata,
+        metadata,
     )
 }
 

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -194,9 +194,12 @@ impl ArceOS {
         uboot_config: Option<PathBuf>,
         persistence: SnapshotPersistence,
     ) -> anyhow::Result<ResolvedBuildRequest> {
-        let (request, snapshot) =
-            self.app
-                .prepare_arceos_request(args, qemu_config, uboot_config)?;
+        let (request, snapshot) = self.app.prepare_arceos_request(
+            args,
+            qemu_config,
+            uboot_config,
+            build::resolve_build_info_path,
+        )?;
         if persistence.should_store() {
             self.app.store_arceos_snapshot(&snapshot)?;
         }

--- a/scripts/axbuild/src/axvisor/build.rs
+++ b/scripts/axbuild/src/axvisor/build.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use ostool::build::config::Cargo;
 use serde::{Deserialize, Serialize};
 
@@ -112,23 +112,29 @@ pub(crate) fn default_build_info_path(axvisor_dir: &Path, target: &str) -> PathB
 }
 
 pub(crate) fn load_cargo_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<Cargo> {
-    to_cargo_config(load_build_config(request)?, request)
+    let metadata =
+        crate::build::cached_workspace_metadata().context("failed to load workspace metadata")?;
+    to_cargo_config(load_build_config(request)?, request, metadata)
 }
 
 fn to_cargo_config(
     mut config: LoadedAxvisorBuildConfig,
     request: &ResolvedAxvisorRequest,
+    metadata: &cargo_metadata::Metadata,
 ) -> anyhow::Result<Cargo> {
     config.target = request.target.clone();
     let plat_dyn = config
         .build_info
         .effective_plat_dyn(&config.target, request.plat_dyn);
     normalize_axvisor_platform_features(&mut config.build_info.features, plat_dyn);
-    let mut cargo = config.build_info.into_prepared_base_cargo_config(
-        &request.package,
-        &config.target,
-        request.plat_dyn,
-    )?;
+    let mut cargo = config
+        .build_info
+        .into_prepared_base_cargo_config_with_metadata(
+            &request.package,
+            &config.target,
+            request.plat_dyn,
+            metadata,
+        )?;
     patch_axvisor_cargo_config(&mut cargo, request, &config.vm_configs)?;
     Ok(cargo)
 }

--- a/scripts/axbuild/src/axvisor/context.rs
+++ b/scripts/axbuild/src/axvisor/context.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use crate::{
     axvisor::image::{config::IMAGE_CONFIG_FILENAME, storage::REGISTRY_FILENAME},
-    context::{workspace_member_dir, workspace_root_path},
+    context::{resolve_workspace_member_dir, workspace_root_path},
 };
 
 pub struct AxvisorContext {
@@ -13,7 +13,7 @@ pub struct AxvisorContext {
 impl AxvisorContext {
     pub fn new() -> anyhow::Result<Self> {
         let workspace_root = workspace_root_path()?;
-        let axvisor_dir = workspace_member_dir(crate::axvisor::build::AXVISOR_PACKAGE)?;
+        let axvisor_dir = resolve_workspace_member_dir(crate::axvisor::build::AXVISOR_PACKAGE)?;
         Ok(Self {
             workspace_root,
             axvisor_dir,

--- a/scripts/axbuild/src/axvisor/image/storage.rs
+++ b/scripts/axbuild/src/axvisor/image/storage.rs
@@ -16,7 +16,7 @@ use super::{
     registry::{ImageEntry, ImageRegistry},
     spec::ImageSpecRef,
 };
-use crate::support::download::{download_file, http_client};
+use crate::support::download::{acquire_path_lock, download_file, http_client};
 
 pub const REGISTRY_FILENAME: &str = "images.toml";
 const LAST_SYNC_FILENAME: &str = ".last_sync";
@@ -166,6 +166,7 @@ impl Storage {
     }
 
     async fn ensure_archive(&self, image: &ImageEntry, archive_path: &Path) -> anyhow::Result<()> {
+        let _lock = acquire_path_lock(archive_path).await?;
         if archive_path.exists() {
             match image_verify_sha256(archive_path, &image.sha256) {
                 Ok(true) => {

--- a/scripts/axbuild/src/axvisor/mod.rs
+++ b/scripts/axbuild/src/axvisor/mod.rs
@@ -8,7 +8,10 @@ use ostool::{
 
 use crate::{
     axvisor::context::AxvisorContext,
-    context::{AppContext, AxvisorCliArgs, ResolvedAxvisorRequest, SnapshotPersistence},
+    context::{
+        AppContext, AxvisorCliArgs, AxvisorRequestPaths, ResolvedAxvisorRequest,
+        SnapshotPersistence,
+    },
 };
 
 pub mod board;
@@ -305,7 +308,10 @@ impl Axvisor {
 
     fn defconfig(&mut self, args: ArgsDefconfig) -> anyhow::Result<()> {
         let workspace_root = self.app.workspace_root().to_path_buf();
-        let axvisor_dir = self.app.axvisor_dir()?.to_path_buf();
+        let axvisor_dir = self
+            .app
+            .workspace_member_dir(build::AXVISOR_PACKAGE)?
+            .to_path_buf();
         let path = config::write_defconfig(&workspace_root, &axvisor_dir, &args.board)?;
         println!("Generated {} for board {}", path.display(), args.board);
         Ok(())
@@ -314,7 +320,9 @@ impl Axvisor {
     fn config(&mut self, args: ArgsConfig) -> anyhow::Result<()> {
         match args.command {
             ConfigCommand::Ls => {
-                for board in config::available_board_names(self.app.axvisor_dir()?)? {
+                for board in config::available_board_names(
+                    self.app.workspace_member_dir(build::AXVISOR_PACKAGE)?,
+                )? {
                     println!("{board}");
                 }
             }
@@ -337,9 +345,21 @@ impl Axvisor {
         uboot_config: Option<PathBuf>,
         persistence: SnapshotPersistence,
     ) -> anyhow::Result<ResolvedAxvisorRequest> {
-        let (request, snapshot) =
-            self.app
-                .prepare_axvisor_request(args, qemu_config, uboot_config)?;
+        let axvisor_dir = self
+            .app
+            .workspace_member_dir(build::AXVISOR_PACKAGE)?
+            .to_path_buf();
+        let (request, snapshot) = self.app.prepare_axvisor_request(
+            args,
+            AxvisorRequestPaths {
+                package: build::AXVISOR_PACKAGE.to_string(),
+                axvisor_dir,
+                load_config_target: build::load_target_from_build_config,
+                resolve_build_info_path: build::resolve_build_info_path,
+            },
+            qemu_config,
+            uboot_config,
+        )?;
         if persistence.should_store() {
             self.app.store_axvisor_snapshot(&snapshot)?;
         }
@@ -407,7 +427,7 @@ mod tests {
     use clap::Parser;
 
     use super::*;
-    use crate::context::{workspace_member_dir, workspace_root_path};
+    use crate::context::{resolve_workspace_member_dir, workspace_root_path};
 
     #[test]
     fn context_resolves_workspace_root() {
@@ -418,7 +438,7 @@ mod tests {
         );
         assert_eq!(
             ctx.axvisor_dir(),
-            workspace_member_dir(crate::axvisor::build::AXVISOR_PACKAGE)
+            resolve_workspace_member_dir(crate::axvisor::build::AXVISOR_PACKAGE)
                 .unwrap()
                 .as_path()
         );

--- a/scripts/axbuild/src/build.rs
+++ b/scripts/axbuild/src/build.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
 use anyhow::{Context, anyhow, bail};
@@ -114,21 +115,6 @@ impl BuildInfo {
         self.prepare_max_cpu_num_env()
             .expect("max_cpu_num validation should run before cargo config generation");
         self.into_base_cargo_config(package, target, args)
-    }
-
-    pub(crate) fn into_prepared_base_cargo_config(
-        self,
-        package: &str,
-        target: &str,
-        plat_dyn_override: Option<bool>,
-    ) -> anyhow::Result<Cargo> {
-        let metadata = workspace_metadata().context("failed to load workspace metadata")?;
-        self.into_prepared_base_cargo_config_with_metadata(
-            package,
-            target,
-            plat_dyn_override,
-            &metadata,
-        )
     }
 
     pub(crate) fn into_prepared_base_cargo_config_with_metadata(
@@ -333,29 +319,33 @@ impl Default for BuildInfo {
     }
 }
 
-pub(crate) fn load_or_create_build_info<T>(
-    path: &Path,
-    default: impl FnOnce() -> T,
-) -> anyhow::Result<T>
+pub(crate) fn ensure_build_info<T>(path: &Path, default: impl FnOnce() -> T) -> anyhow::Result<()>
 where
-    T: Serialize + DeserializeOwned,
+    T: Serialize,
 {
     println!("Using build config: {}", path.display());
 
     if path.exists() {
         info!("Found build config at {}", path.display());
-    } else {
-        info!(
-            "Build config not found at {}, writing default config",
-            path.display()
-        );
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let default = default();
-        std::fs::write(path, toml::to_string_pretty(&default)?)?;
+        return Ok(());
     }
 
+    info!(
+        "Build config not found at {}, writing default config",
+        path.display()
+    );
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let default = default();
+    std::fs::write(path, toml::to_string_pretty(&default)?)?;
+    Ok(())
+}
+
+pub(crate) fn load_build_info<T>(path: &Path) -> anyhow::Result<T>
+where
+    T: DeserializeOwned,
+{
     toml::from_str::<T>(&std::fs::read_to_string(path)?)
         .with_context(|| format!("failed to parse build info {}", path.display()))
 }
@@ -516,9 +506,31 @@ pub(crate) fn workspace_metadata() -> anyhow::Result<Metadata> {
     workspace_metadata_root_manifest(&manifest_path)
 }
 
+pub(crate) fn cached_workspace_metadata() -> anyhow::Result<&'static Metadata> {
+    static METADATA: OnceLock<anyhow::Result<Metadata, String>> = OnceLock::new();
+
+    cached_metadata_result(
+        METADATA.get_or_init(|| workspace_metadata().map_err(|err| format!("{err:#}"))),
+    )
+}
+
 fn workspace_metadata_with_deps() -> anyhow::Result<Metadata> {
     let manifest_path = workspace_manifest_path()?;
     crate::context::workspace_metadata_root_manifest_with_deps(&manifest_path)
+}
+
+pub(crate) fn cached_workspace_metadata_with_deps() -> anyhow::Result<&'static Metadata> {
+    static METADATA: OnceLock<anyhow::Result<Metadata, String>> = OnceLock::new();
+
+    cached_metadata_result(
+        METADATA.get_or_init(|| workspace_metadata_with_deps().map_err(|err| format!("{err:#}"))),
+    )
+}
+
+fn cached_metadata_result(
+    result: &'static anyhow::Result<Metadata, String>,
+) -> anyhow::Result<&'static Metadata> {
+    result.as_ref().map_err(|err| anyhow::anyhow!("{err}"))
 }
 
 fn workspace_package<'a>(metadata: &'a Metadata, package: &str) -> anyhow::Result<&'a Package> {
@@ -694,9 +706,9 @@ pub(crate) fn resolve_platform_config_by_package(
     platform_package: &str,
     metadata: &Metadata,
 ) -> anyhow::Result<ResolvedPlatformConfig> {
-    let deps_metadata = workspace_metadata_with_deps()
+    let deps_metadata = cached_workspace_metadata_with_deps()
         .context("failed to load dependency metadata for platform config resolution")?;
-    resolve_platform_config_by_package_with_metadata(platform_package, metadata, &deps_metadata)
+    resolve_platform_config_by_package_with_metadata(platform_package, metadata, deps_metadata)
 }
 
 pub(crate) fn resolve_platform_config_by_package_with_metadata(

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     env,
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
@@ -31,7 +32,7 @@ pub(crate) use arch::{
     starry_default_platform_for_arch_checked, starry_target_for_arch_checked, supported_arches,
     supported_targets, validate_supported_target,
 };
-pub(crate) use resolve::snapshot_path_value;
+pub(crate) use resolve::{AxvisorRequestPaths, snapshot_path_value};
 pub use types::{
     ARCEOS_SNAPSHOT_FILE, AXVISOR_SNAPSHOT_FILE, ArceosCommandSnapshot, ArceosQemuSnapshot,
     ArceosUbootSnapshot, AxvisorCliArgs, AxvisorCommandSnapshot, AxvisorQemuSnapshot,
@@ -42,9 +43,9 @@ pub use types::{
     StarryUbootSnapshot,
 };
 pub(crate) use workspace::{
-    axbuild_tmp_dir, find_workspace_root, workspace_manifest_path, workspace_member_dir,
-    workspace_metadata_root_manifest, workspace_metadata_root_manifest_with_deps,
-    workspace_root_path,
+    axbuild_tmp_dir, find_workspace_root, workspace_manifest_path,
+    workspace_member_dir as resolve_workspace_member_dir, workspace_metadata_root_manifest,
+    workspace_metadata_root_manifest_with_deps, workspace_root_path,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,7 +72,7 @@ pub struct AppContext {
     tool: Tool,
     build_config_path: Option<PathBuf>,
     root: PathBuf,
-    axvisor_dir: Option<PathBuf>,
+    member_dirs: HashMap<String, PathBuf>,
     original_path: OsString,
     debug: bool,
 }
@@ -88,7 +89,7 @@ impl AppContext {
             tool,
             build_config_path: None,
             root: workspace_root,
-            axvisor_dir: None,
+            member_dirs: HashMap::new(),
             original_path: env::var_os("PATH").unwrap_or_default(),
             debug: false,
         })
@@ -102,16 +103,20 @@ impl AppContext {
         &mut self.tool
     }
 
-    pub(crate) fn axvisor_dir(&mut self) -> anyhow::Result<&Path> {
-        if self.axvisor_dir.is_none() {
-            let axvisor_dir = workspace_member_dir(crate::axvisor::build::AXVISOR_PACKAGE)?;
-            info!("Axvisor dir: {}", axvisor_dir.display());
-            self.axvisor_dir = Some(axvisor_dir);
+    pub(crate) fn workspace_member_dir(&mut self, package: &str) -> anyhow::Result<&Path> {
+        if !self.member_dirs.contains_key(package) {
+            let member_dir = resolve_workspace_member_dir(package)?;
+            info!(
+                "Workspace member dir for {package}: {}",
+                member_dir.display()
+            );
+            self.member_dirs.insert(package.to_string(), member_dir);
         }
 
-        self.axvisor_dir
-            .as_deref()
-            .context("axvisor_dir should be initialized")
+        self.member_dirs
+            .get(package)
+            .map(PathBuf::as_path)
+            .context("workspace member dir should be initialized")
     }
 
     pub(crate) async fn build(
@@ -243,7 +248,7 @@ impl Drop for PathRestoreGuard {
 }
 
 fn should_use_loongarch_lvz_for(package: &str, target: &str) -> bool {
-    package == crate::axvisor::build::AXVISOR_PACKAGE && target.contains("loongarch64")
+    package == "axvisor" && target.contains("loongarch64")
 }
 
 fn configure_loongarch_qemu_path(workspace_root: &Path) -> anyhow::Result<()> {

--- a/scripts/axbuild/src/context/resolve.rs
+++ b/scripts/axbuild/src/context/resolve.rs
@@ -17,12 +17,20 @@ struct ResolvedCommandPaths {
     uboot_config: Option<PathBuf>,
 }
 
+pub(crate) struct AxvisorRequestPaths<L, R> {
+    pub(crate) package: String,
+    pub(crate) axvisor_dir: PathBuf,
+    pub(crate) load_config_target: L,
+    pub(crate) resolve_build_info_path: R,
+}
+
 impl AppContext {
-    pub fn prepare_arceos_request(
+    pub(crate) fn prepare_arceos_request(
         &self,
         cli: BuildCliArgs,
         qemu_config: Option<PathBuf>,
         uboot_config: Option<PathBuf>,
+        resolve_build_info_path: impl FnOnce(&str, &str, Option<PathBuf>) -> anyhow::Result<PathBuf>,
     ) -> anyhow::Result<(ResolvedBuildRequest, ArceosCommandSnapshot)> {
         let snapshot = ArceosCommandSnapshot::load(&self.root)?;
 
@@ -69,8 +77,7 @@ impl AppContext {
                 None
             },
         );
-        let build_info_path =
-            crate::arceos::build::resolve_build_info_path(&package, &target, cli.config.clone())?;
+        let build_info_path = resolve_build_info_path(&package, &target, cli.config.clone())?;
 
         let request = ResolvedBuildRequest {
             package: package.clone(),
@@ -107,18 +114,19 @@ impl AppContext {
         Ok((request, snapshot))
     }
 
-    pub fn store_arceos_snapshot(
+    pub(crate) fn store_arceos_snapshot(
         &self,
         snapshot: &ArceosCommandSnapshot,
     ) -> anyhow::Result<PathBuf> {
         snapshot.store(&self.root)
     }
 
-    pub fn prepare_starry_request(
+    pub(crate) fn prepare_starry_request(
         &self,
         cli: StarryCliArgs,
         qemu_config: Option<PathBuf>,
         uboot_config: Option<PathBuf>,
+        resolve_build_info_path: impl FnOnce(&Path, &str, Option<PathBuf>) -> anyhow::Result<PathBuf>,
     ) -> anyhow::Result<(ResolvedStarryRequest, StarryCommandSnapshot)> {
         let snapshot = StarryCommandSnapshot::load(&self.root)?;
         let inherit_snapshot_config =
@@ -160,8 +168,7 @@ impl AppContext {
                 None
             },
         );
-        let build_info_path =
-            crate::starry::build::resolve_build_info_path(&self.root, &target, resolved_config)?;
+        let build_info_path = resolve_build_info_path(&self.root, &target, resolved_config)?;
 
         let request = ResolvedStarryRequest {
             package: STARRY_PACKAGE.to_string(),
@@ -198,20 +205,29 @@ impl AppContext {
         Ok((request, snapshot))
     }
 
-    pub fn store_starry_snapshot(
+    pub(crate) fn store_starry_snapshot(
         &self,
         snapshot: &StarryCommandSnapshot,
     ) -> anyhow::Result<PathBuf> {
         snapshot.store(&self.root)
     }
 
-    pub fn prepare_axvisor_request(
-        &mut self,
+    pub(crate) fn prepare_axvisor_request(
+        &self,
         cli: AxvisorCliArgs,
+        paths: AxvisorRequestPaths<
+            impl FnOnce(&Path) -> anyhow::Result<Option<String>>,
+            impl FnOnce(&Path, &str, Option<PathBuf>) -> anyhow::Result<PathBuf>,
+        >,
         qemu_config: Option<PathBuf>,
         uboot_config: Option<PathBuf>,
     ) -> anyhow::Result<(ResolvedAxvisorRequest, AxvisorCommandSnapshot)> {
-        let axvisor_dir = self.axvisor_dir()?.to_path_buf();
+        let AxvisorRequestPaths {
+            package,
+            axvisor_dir,
+            load_config_target,
+            resolve_build_info_path,
+        } = paths;
         let snapshot = AxvisorCommandSnapshot::load(&self.root)?;
         let inherit_snapshot_config =
             cli.config.is_none() && cli.arch.is_none() && cli.target.is_none();
@@ -224,7 +240,7 @@ impl AppContext {
         let config_target = resolved_config
             .as_ref()
             .filter(|path| path.exists())
-            .map(|path| crate::axvisor::build::load_target_from_build_config(path))
+            .map(|path| load_config_target(path))
             .transpose()?
             .flatten();
         let explicit_config = if cli.config.is_some() {
@@ -232,7 +248,6 @@ impl AppContext {
         } else {
             resolved_config.filter(|path| path.exists())
         };
-
         let effective_arch = cli.arch.clone().or_else(|| {
             if cli.target.is_some() || config_target.is_some() {
                 None
@@ -250,8 +265,7 @@ impl AppContext {
         let (arch, target) = resolve_axvisor_arch_and_target(effective_arch, effective_target)?;
         let plat_dyn = cli.plat_dyn.or(snapshot.plat_dyn);
         let smp = cli.smp.or(snapshot.smp);
-        let build_info_path =
-            crate::axvisor::build::resolve_build_info_path(&axvisor_dir, &target, explicit_config)?;
+        let build_info_path = resolve_build_info_path(&axvisor_dir, &target, explicit_config)?;
         let inherit_snapshot_runtime = cli.arch.is_none()
             && cli.target.is_none()
             && cli.config.is_none()
@@ -277,7 +291,7 @@ impl AppContext {
         };
 
         let request = ResolvedAxvisorRequest {
-            package: crate::axvisor::build::AXVISOR_PACKAGE.to_string(),
+            package,
             axvisor_dir,
             arch: arch.clone(),
             target: target.clone(),
@@ -317,7 +331,7 @@ impl AppContext {
         Ok((request, snapshot))
     }
 
-    pub fn store_axvisor_snapshot(
+    pub(crate) fn store_axvisor_snapshot(
         &self,
         snapshot: &AxvisorCommandSnapshot,
     ) -> anyhow::Result<PathBuf> {

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     env,
     ffi::{OsStr, OsString},
     fs,
@@ -16,10 +17,73 @@ fn test_app_context(root: &Path) -> AppContext {
         tool: Tool::new(ToolConfig::default()).unwrap(),
         build_config_path: None,
         root: root.to_path_buf(),
-        axvisor_dir: Some(root.join("os/axvisor")),
+        member_dirs: HashMap::from([("axvisor".to_string(), root.join("os/axvisor"))]),
         original_path: env::var_os("PATH").unwrap_or_default(),
         debug: false,
     }
+}
+
+fn resolve_arceos_build_info_path(
+    package: &str,
+    target: &str,
+    explicit_path: Option<PathBuf>,
+) -> anyhow::Result<PathBuf> {
+    crate::arceos::build::resolve_build_info_path(package, target, explicit_path)
+}
+
+fn prepare_arceos_request(
+    app: &AppContext,
+    cli: BuildCliArgs,
+    qemu_config: Option<PathBuf>,
+    uboot_config: Option<PathBuf>,
+) -> anyhow::Result<(ResolvedBuildRequest, ArceosCommandSnapshot)> {
+    app.prepare_arceos_request(
+        cli,
+        qemu_config,
+        uboot_config,
+        resolve_arceos_build_info_path,
+    )
+}
+
+fn resolve_starry_build_info_path(
+    workspace_root: &Path,
+    target: &str,
+    explicit_path: Option<PathBuf>,
+) -> anyhow::Result<PathBuf> {
+    crate::starry::build::resolve_build_info_path(workspace_root, target, explicit_path)
+}
+
+fn prepare_starry_request(
+    app: &AppContext,
+    cli: StarryCliArgs,
+    qemu_config: Option<PathBuf>,
+    uboot_config: Option<PathBuf>,
+) -> anyhow::Result<(ResolvedStarryRequest, StarryCommandSnapshot)> {
+    app.prepare_starry_request(
+        cli,
+        qemu_config,
+        uboot_config,
+        resolve_starry_build_info_path,
+    )
+}
+
+fn prepare_axvisor_request(
+    app: &AppContext,
+    cli: AxvisorCliArgs,
+    qemu_config: Option<PathBuf>,
+    uboot_config: Option<PathBuf>,
+) -> anyhow::Result<(ResolvedAxvisorRequest, AxvisorCommandSnapshot)> {
+    app.prepare_axvisor_request(
+        cli,
+        AxvisorRequestPaths {
+            package: crate::axvisor::build::AXVISOR_PACKAGE.to_string(),
+            axvisor_dir: app.root.join("os/axvisor"),
+            load_config_target: crate::axvisor::build::load_target_from_build_config,
+            resolve_build_info_path: crate::axvisor::build::resolve_build_info_path,
+        },
+        qemu_config,
+        uboot_config,
+    )
 }
 
 static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -198,21 +262,21 @@ uboot_config = "configs/snapshot-uboot.toml"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_arceos_request(
-            BuildCliArgs {
-                config: Some(PathBuf::from("/tmp/custom-build.toml")),
-                package: Some("from-cli".into()),
-                arch: Some("aarch64".into()),
-                target: Some(DEFAULT_ARCEOS_TARGET.into()),
-                plat_dyn: Some(true),
-                smp: Some(4),
-                debug: true,
-            },
-            Some(PathBuf::from("/tmp/qemu.toml")),
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_arceos_request(
+        &app,
+        BuildCliArgs {
+            config: Some(PathBuf::from("/tmp/custom-build.toml")),
+            package: Some("from-cli".into()),
+            arch: Some("aarch64".into()),
+            target: Some(DEFAULT_ARCEOS_TARGET.into()),
+            plat_dyn: Some(true),
+            smp: Some(4),
+            debug: true,
+        },
+        Some(PathBuf::from("/tmp/qemu.toml")),
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.package, "from-cli");
     assert_eq!(request.target, DEFAULT_ARCEOS_TARGET);
@@ -254,9 +318,8 @@ qemu_config = "configs/qemu.toml"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_arceos_request(BuildCliArgs::default(), None, None)
-        .unwrap();
+    let (request, snapshot) =
+        prepare_arceos_request(&app, BuildCliArgs::default(), None, None).unwrap();
 
     assert_eq!(request.package, "ax-helloworld");
     assert_eq!(request.arch, DEFAULT_ARCEOS_ARCH);
@@ -275,9 +338,7 @@ fn prepare_request_requires_package() {
     let root = tempdir().unwrap();
     let app = test_app_context(root.path());
 
-    let err = app
-        .prepare_arceos_request(BuildCliArgs::default(), None, None)
-        .unwrap_err();
+    let err = prepare_arceos_request(&app, BuildCliArgs::default(), None, None).unwrap_err();
 
     assert!(err.to_string().contains("missing ArceOS package"));
 }
@@ -287,21 +348,21 @@ fn prepare_request_resolves_arceos_target_from_arch() {
     let root = tempdir().unwrap();
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_arceos_request(
-            BuildCliArgs {
-                config: None,
-                package: Some("ax-helloworld".into()),
-                arch: Some("x86_64".into()),
-                target: None,
-                plat_dyn: None,
-                smp: None,
-                debug: false,
-            },
-            None,
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_arceos_request(
+        &app,
+        BuildCliArgs {
+            config: None,
+            package: Some("ax-helloworld".into()),
+            arch: Some("x86_64".into()),
+            target: None,
+            plat_dyn: None,
+            smp: None,
+            debug: false,
+        },
+        None,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.arch, "x86_64");
     assert_eq!(request.target, "x86_64-unknown-none");
@@ -394,21 +455,21 @@ uboot_config = "configs/uboot-aarch64.toml"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_arceos_request(
-            BuildCliArgs {
-                config: None,
-                package: None,
-                arch: None,
-                target: Some("riscv64gc-unknown-none-elf".into()),
-                plat_dyn: None,
-                smp: None,
-                debug: false,
-            },
-            None,
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_arceos_request(
+        &app,
+        BuildCliArgs {
+            config: None,
+            package: None,
+            arch: None,
+            target: Some("riscv64gc-unknown-none-elf".into()),
+            plat_dyn: None,
+            smp: None,
+            debug: false,
+        },
+        None,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.arch, "riscv64");
     assert_eq!(request.target, "riscv64gc-unknown-none-elf");
@@ -440,26 +501,26 @@ uboot_config = "configs/snapshot-uboot.toml"
     )
     .unwrap();
 
-    let mut app = test_app_context(root.path());
+    let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_axvisor_request(
-            AxvisorCliArgs {
-                config: Some(PathBuf::from("/tmp/custom-build.toml")),
-                arch: Some("aarch64".into()),
-                target: Some(DEFAULT_AXVISOR_TARGET.into()),
-                plat_dyn: Some(true),
-                smp: Some(6),
-                debug: true,
-                vmconfigs: vec![
-                    PathBuf::from("/tmp/vm1.toml"),
-                    PathBuf::from("/tmp/vm2.toml"),
-                ],
-            },
-            Some(PathBuf::from("/tmp/qemu.toml")),
-            Some(PathBuf::from("/tmp/uboot.toml")),
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_axvisor_request(
+        &app,
+        AxvisorCliArgs {
+            config: Some(PathBuf::from("/tmp/custom-build.toml")),
+            arch: Some("aarch64".into()),
+            target: Some(DEFAULT_AXVISOR_TARGET.into()),
+            plat_dyn: Some(true),
+            smp: Some(6),
+            debug: true,
+            vmconfigs: vec![
+                PathBuf::from("/tmp/vm1.toml"),
+                PathBuf::from("/tmp/vm2.toml"),
+            ],
+        },
+        Some(PathBuf::from("/tmp/qemu.toml")),
+        Some(PathBuf::from("/tmp/uboot.toml")),
+    )
+    .unwrap();
 
     assert_eq!(request.package, crate::axvisor::build::AXVISOR_PACKAGE);
     assert_eq!(request.arch, DEFAULT_AXVISOR_ARCH);
@@ -526,11 +587,10 @@ uboot_config = "configs/uboot.toml"
     )
     .unwrap();
 
-    let mut app = test_app_context(root.path());
+    let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_axvisor_request(AxvisorCliArgs::default(), None, None)
-        .unwrap();
+    let (request, snapshot) =
+        prepare_axvisor_request(&app, AxvisorCliArgs::default(), None, None).unwrap();
 
     assert_eq!(request.arch, DEFAULT_AXVISOR_ARCH);
     assert_eq!(request.target, DEFAULT_AXVISOR_TARGET);
@@ -576,23 +636,23 @@ uboot_config = "configs/uboot.toml"
 #[test]
 fn prepare_axvisor_request_resolves_target_from_arch() {
     let root = tempdir().unwrap();
-    let mut app = test_app_context(root.path());
+    let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_axvisor_request(
-            AxvisorCliArgs {
-                config: None,
-                arch: Some("x86_64".into()),
-                target: None,
-                plat_dyn: None,
-                smp: None,
-                debug: false,
-                vmconfigs: vec![],
-            },
-            None,
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_axvisor_request(
+        &app,
+        AxvisorCliArgs {
+            config: None,
+            arch: Some("x86_64".into()),
+            target: None,
+            plat_dyn: None,
+            smp: None,
+            debug: false,
+            vmconfigs: vec![],
+        },
+        None,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.arch, "x86_64");
     assert_eq!(request.target, "x86_64-unknown-none");
@@ -626,23 +686,23 @@ uboot_config = "configs/uboot-aarch64.toml"
     )
     .unwrap();
 
-    let mut app = test_app_context(root.path());
+    let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_axvisor_request(
-            AxvisorCliArgs {
-                config: None,
-                arch: Some("x86_64".into()),
-                target: None,
-                plat_dyn: None,
-                smp: None,
-                debug: false,
-                vmconfigs: vec![],
-            },
-            None,
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_axvisor_request(
+        &app,
+        AxvisorCliArgs {
+            config: None,
+            arch: Some("x86_64".into()),
+            target: None,
+            plat_dyn: None,
+            smp: None,
+            debug: false,
+            vmconfigs: vec![],
+        },
+        None,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.arch, "x86_64");
     assert_eq!(request.target, "x86_64-unknown-none");
@@ -675,23 +735,23 @@ target = "loongarch64-unknown-none-softfloat"
     )
     .unwrap();
 
-    let mut app = test_app_context(root.path());
+    let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_axvisor_request(
-            AxvisorCliArgs {
-                config: None,
-                arch: Some("x86_64".into()),
-                target: None,
-                plat_dyn: None,
-                smp: None,
-                debug: false,
-                vmconfigs: vec![],
-            },
-            None,
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_axvisor_request(
+        &app,
+        AxvisorCliArgs {
+            config: None,
+            arch: Some("x86_64".into()),
+            target: None,
+            plat_dyn: None,
+            smp: None,
+            debug: false,
+            vmconfigs: vec![],
+        },
+        None,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.arch, "x86_64");
     assert_eq!(request.target, "x86_64-unknown-none");
@@ -724,11 +784,10 @@ target = "aarch64-unknown-none-softfloat"
     )
     .unwrap();
 
-    let mut app = test_app_context(root.path());
+    let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_axvisor_request(AxvisorCliArgs::default(), None, None)
-        .unwrap();
+    let (request, snapshot) =
+        prepare_axvisor_request(&app, AxvisorCliArgs::default(), None, None).unwrap();
 
     assert_eq!(
         request.build_info_path,
@@ -797,19 +856,19 @@ uboot_config = "configs/snapshot-uboot.toml"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_starry_request(
-            StarryCliArgs {
-                config: Some(PathBuf::from("/tmp/starry-build.toml")),
-                arch: Some("aarch64".into()),
-                target: Some("aarch64-unknown-none-softfloat".into()),
-                smp: Some(4),
-                debug: true,
-            },
-            Some(PathBuf::from("/tmp/qemu.toml")),
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_starry_request(
+        &app,
+        StarryCliArgs {
+            config: Some(PathBuf::from("/tmp/starry-build.toml")),
+            arch: Some("aarch64".into()),
+            target: Some("aarch64-unknown-none-softfloat".into()),
+            smp: Some(4),
+            debug: true,
+        },
+        Some(PathBuf::from("/tmp/qemu.toml")),
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.package, STARRY_PACKAGE);
     assert_eq!(request.arch, "aarch64");
@@ -856,9 +915,8 @@ qemu_config = "configs/qemu.toml"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_starry_request(StarryCliArgs::default(), None, None)
-        .unwrap();
+    let (request, snapshot) =
+        prepare_starry_request(&app, StarryCliArgs::default(), None, None).unwrap();
 
     assert_eq!(request.package, STARRY_PACKAGE);
     assert_eq!(request.arch, DEFAULT_STARRY_ARCH);
@@ -900,9 +958,8 @@ config = "configs/custom-starry.toml"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_starry_request(StarryCliArgs::default(), None, None)
-        .unwrap();
+    let (request, snapshot) =
+        prepare_starry_request(&app, StarryCliArgs::default(), None, None).unwrap();
 
     assert_eq!(request.arch, "aarch64");
     assert_eq!(request.target, "aarch64-unknown-none-softfloat");
@@ -922,19 +979,19 @@ fn prepare_starry_request_rejects_mismatched_arch_and_target() {
     prepare_starry_workspace(root.path());
     let app = test_app_context(root.path());
 
-    let err = app
-        .prepare_starry_request(
-            StarryCliArgs {
-                config: None,
-                arch: Some("aarch64".into()),
-                target: Some("x86_64-unknown-none".into()),
-                smp: None,
-                debug: false,
-            },
-            None,
-            None,
-        )
-        .unwrap_err();
+    let err = prepare_starry_request(
+        &app,
+        StarryCliArgs {
+            config: None,
+            arch: Some("aarch64".into()),
+            target: Some("x86_64-unknown-none".into()),
+            smp: None,
+            debug: false,
+        },
+        None,
+        None,
+    )
+    .unwrap_err();
 
     assert!(err.to_string().contains("maps to target"));
 }
@@ -955,19 +1012,19 @@ target = "aarch64-unknown-none-softfloat"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_starry_request(
-            StarryCliArgs {
-                config: None,
-                arch: Some("riscv64".into()),
-                target: None,
-                smp: None,
-                debug: false,
-            },
-            None,
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_starry_request(
+        &app,
+        StarryCliArgs {
+            config: None,
+            arch: Some("riscv64".into()),
+            target: None,
+            smp: None,
+            debug: false,
+        },
+        None,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.arch, "riscv64");
     assert_eq!(request.target, "riscv64gc-unknown-none-elf");
@@ -994,19 +1051,19 @@ target = "aarch64-unknown-none-softfloat"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_starry_request(
-            StarryCliArgs {
-                config: None,
-                arch: None,
-                target: Some("x86_64-unknown-none".into()),
-                smp: None,
-                debug: false,
-            },
-            None,
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_starry_request(
+        &app,
+        StarryCliArgs {
+            config: None,
+            arch: None,
+            target: Some("x86_64-unknown-none".into()),
+            smp: None,
+            debug: false,
+        },
+        None,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.arch, "x86_64");
     assert_eq!(request.target, "x86_64-unknown-none");
@@ -1036,19 +1093,19 @@ uboot_config = "configs/uboot-aarch64.toml"
 
     let app = test_app_context(root.path());
 
-    let (request, snapshot) = app
-        .prepare_starry_request(
-            StarryCliArgs {
-                config: None,
-                arch: Some("riscv64".into()),
-                target: None,
-                smp: None,
-                debug: false,
-            },
-            None,
-            None,
-        )
-        .unwrap();
+    let (request, snapshot) = prepare_starry_request(
+        &app,
+        StarryCliArgs {
+            config: None,
+            arch: Some("riscv64".into()),
+            target: None,
+            smp: None,
+            debug: false,
+        },
+        None,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(request.arch, "riscv64");
     assert_eq!(request.target, "riscv64gc-unknown-none-elf");

--- a/scripts/axbuild/src/rootfs/store.rs
+++ b/scripts/axbuild/src/rootfs/store.rs
@@ -154,28 +154,19 @@ async fn ensure_rootfs_image(workspace_root: &Path, image_name: &str) -> anyhow:
     let rootfs_dir = rootfs_dir(workspace_root);
     let image_path = rootfs_dir.join(image_name);
 
-    if let Ok(metadata) = tokio_fs::metadata(&image_path).await {
-        if metadata.len() >= MIN_ROOTFS_IMAGE_SIZE {
-            return Ok(image_path);
-        }
-        // File exists but is too small — likely a truncated or empty file from
-        // a previously interrupted download/extraction.  Remove it so that the
-        // download+extraction path below runs cleanly.
-        eprintln!(
-            "managed rootfs image `{}` is too small ({} bytes, expected >= {} bytes), removing \
-             and re-downloading",
-            image_path.display(),
-            metadata.len(),
-            MIN_ROOTFS_IMAGE_SIZE
-        );
-        tokio_fs::remove_file(&image_path)
-            .await
-            .with_context(|| format!("failed to remove corrupt image {}", image_path.display()))?;
+    if rootfs_image_is_ready(&image_path).await? {
+        return Ok(image_path);
     }
 
     tokio_fs::create_dir_all(&rootfs_dir)
         .await
         .with_context(|| format!("failed to create {}", rootfs_dir.display()))?;
+
+    let _lock = crate::support::download::acquire_path_lock(&image_path).await?;
+    if rootfs_image_is_ready(&image_path).await? {
+        return Ok(image_path);
+    }
+    remove_incomplete_rootfs_image(&image_path).await?;
 
     let archive_path = archive_path(workspace_root, image_name);
     let client = crate::support::download::http_client()?;
@@ -198,6 +189,37 @@ async fn ensure_rootfs_image(workspace_root: &Path, image_name: &str) -> anyhow:
     }
 
     Ok(image_path)
+}
+
+async fn rootfs_image_is_ready(image_path: &Path) -> anyhow::Result<bool> {
+    match tokio_fs::metadata(image_path).await {
+        Ok(metadata) if metadata.len() >= MIN_ROOTFS_IMAGE_SIZE => Ok(true),
+        Ok(_) => Ok(false),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err)
+            .with_context(|| format!("failed to read metadata for {}", image_path.display())),
+    }
+}
+
+async fn remove_incomplete_rootfs_image(image_path: &Path) -> anyhow::Result<()> {
+    let metadata = match tokio_fs::metadata(image_path).await {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to read metadata for {}", image_path.display()));
+        }
+    };
+    eprintln!(
+        "managed rootfs image `{}` is too small ({} bytes, expected >= {} bytes), removing and \
+         re-downloading",
+        image_path.display(),
+        metadata.len(),
+        MIN_ROOTFS_IMAGE_SIZE
+    );
+    tokio_fs::remove_file(image_path)
+        .await
+        .with_context(|| format!("failed to remove corrupt image {}", image_path.display()))
 }
 
 /// Downloads the archive for a managed rootfs image if it is not cached yet.
@@ -254,11 +276,21 @@ fn unpack_image(archive_path: &Path, image_name: &str, out_dir: &Path) -> anyhow
             continue;
         }
         let dest = out_dir.join(name);
-        if !dest.exists() {
-            entry
-                .unpack(&dest)
-                .with_context(|| format!("failed to extract `{name}` to {}", dest.display()))?;
+        let temp_dest = temporary_rootfs_image_path(&dest);
+        if temp_dest.exists() {
+            fs::remove_file(&temp_dest)
+                .with_context(|| format!("failed to remove {}", temp_dest.display()))?;
         }
+        entry
+            .unpack(&temp_dest)
+            .with_context(|| format!("failed to extract `{name}` to {}", temp_dest.display()))?;
+        fs::rename(&temp_dest, &dest).with_context(|| {
+            format!(
+                "failed to move extracted image {} to {}",
+                temp_dest.display(),
+                dest.display()
+            )
+        })?;
         return Ok(());
     }
 
@@ -266,6 +298,15 @@ fn unpack_image(archive_path: &Path, image_name: &str, out_dir: &Path) -> anyhow
         "archive {} did not contain expected rootfs image `{image_name}`",
         archive_path.display()
     ))
+}
+
+fn temporary_rootfs_image_path(path: &Path) -> PathBuf {
+    let mut file_name = path
+        .file_name()
+        .expect("rootfs image path must have a file name")
+        .to_os_string();
+    file_name.push(".tmp");
+    path.with_file_name(file_name)
 }
 
 #[cfg(test)]

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -38,9 +38,10 @@ pub(crate) fn load_build_info(request: &ResolvedStarryRequest) -> anyhow::Result
     let mut build_info = if let Some(build_info) = &request.build_info_override {
         build_info.clone()
     } else {
-        crate::build::load_or_create_build_info(&request.build_info_path, || {
+        crate::build::ensure_build_info(&request.build_info_path, || {
             default_starry_build_info_for_target(&request.target)
-        })?
+        })?;
+        crate::build::load_build_info(&request.build_info_path)?
     };
 
     crate::build::apply_makefile_features(&mut build_info, &request.package, &makefile_features);
@@ -54,20 +55,21 @@ pub(crate) fn load_build_info(request: &ResolvedStarryRequest) -> anyhow::Result
 
 pub(crate) fn load_cargo_config(request: &ResolvedStarryRequest) -> anyhow::Result<Cargo> {
     let metadata =
-        crate::build::workspace_metadata().context("failed to load workspace metadata")?;
+        crate::build::cached_workspace_metadata().context("failed to load workspace metadata")?;
     let makefile_features = crate::build::makefile_features_from_env();
     let mut build_info = if let Some(build_info) = &request.build_info_override {
         build_info.clone()
     } else {
-        crate::build::load_or_create_build_info(&request.build_info_path, || {
+        crate::build::ensure_build_info(&request.build_info_path, || {
             default_starry_build_info_for_target(&request.target)
-        })?
+        })?;
+        crate::build::load_build_info(&request.build_info_path)?
     };
     crate::build::apply_makefile_features_with_metadata(
         &mut build_info,
         &request.package,
         &makefile_features,
-        &metadata,
+        metadata,
     );
     if let Some(smp) = request.smp {
         build_info.max_cpu_num = Some(smp);
@@ -76,9 +78,9 @@ pub(crate) fn load_cargo_config(request: &ResolvedStarryRequest) -> anyhow::Resu
         &request.package,
         &request.target,
         request.plat_dyn,
-        &metadata,
+        metadata,
     )?;
-    patch_starry_cargo_config(&mut cargo, request, &metadata)?;
+    patch_starry_cargo_config(&mut cargo, request, metadata)?;
     Ok(cargo)
 }
 

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -325,9 +325,12 @@ impl Starry {
         uboot_config: Option<PathBuf>,
         persistence: SnapshotPersistence,
     ) -> anyhow::Result<ResolvedStarryRequest> {
-        let (request, snapshot) =
-            self.app
-                .prepare_starry_request(args, qemu_config, uboot_config)?;
+        let (request, snapshot) = self.app.prepare_starry_request(
+            args,
+            qemu_config,
+            uboot_config,
+            build::resolve_build_info_path,
+        )?;
         if persistence.should_store() {
             self.app.store_starry_snapshot(&snapshot)?;
         }

--- a/scripts/axbuild/src/support/download.rs
+++ b/scripts/axbuild/src/support/download.rs
@@ -12,6 +12,7 @@ use reqwest::{StatusCode, header};
 use tokio::{fs as tokio_fs, io::AsyncWriteExt};
 
 const DOWNLOAD_LOCK_STALE_AFTER: Duration = Duration::from_secs(60 * 60 * 2);
+const DOWNLOAD_LOCK_WAIT: Duration = Duration::from_millis(100);
 
 pub(crate) fn http_client() -> anyhow::Result<reqwest::Client> {
     reqwest::Client::builder()
@@ -239,7 +240,7 @@ pub(crate) async fn acquire_path_lock(path: &Path) -> anyhow::Result<PathLock> {
                     let _ = tokio_fs::remove_file(&lock_path).await;
                     continue;
                 }
-                tokio::task::yield_now().await;
+                tokio::time::sleep(DOWNLOAD_LOCK_WAIT).await;
             }
             Err(err) => {
                 return Err(err)


### PR DESCRIPTION
- Use ensure_build_info and cached_workspace_metadata across Arceos, Starry, and Axvisor build flows
- Thread workspace metadata into cargo config via into_prepared_base_cargo_config_with_metadata
- Introduce resolve_build_info_path usage and AxvisorRequestPaths to centralize path resolution
- Acquire per-archive path locks before archive operations and add a small wait using DOWNLOAD_LOCK_WAIT
- Add ready-checks for rootfs images and safe removal of incomplete images
- Enable Tokio time feature for time-based waits in axbuild