### PR TITLE
example(starryos): add Codex CLI demo flow

### DIFF
--- a/examples/starry/README.md
+++ b/examples/starry/README.md
@@ -1,11 +1,11 @@
 # Starry Examples
 
-`examples/starry/` contains runnable StarryOS scenarios. Each direct child
-directory is a case selected by `cargo starry example board -t <case>`.
+`examples/starry/` contains runnable StarryOS scenarios. Most direct child
+directories are board cases selected by `cargo starry example board -t <case>`;
+some x86_64 QEMU demos provide their own `cargo xtask starry qemu` commands.
 
 Cases are intentionally separate from `test-suit/starryos`: examples are
-operator-facing board workflows, while the test suit remains CI-oriented
-coverage.
+operator-facing workflows, while the test suit remains CI-oriented coverage.
 
 ## Case Layout
 

--- a/examples/starry/codex-cli/README.md
+++ b/examples/starry/codex-cli/README.md
@@ -1,0 +1,108 @@
+# StarryOS Codex CLI Example
+
+这个目录提供 StarryOS x86_64 QEMU 中运行 Codex CLI 的手动示例。它不是 `test-suit/starryos` 用例，也不会进入 CI；下载 Codex CLI、注入 rootfs、在线请求模型都只会在用户显式执行本目录脚本或 QEMU 配置时发生。
+
+## 准备 Codex Rootfs
+
+先在 host 侧准备本地 rootfs。脚本会按固定版本下载 `@openai/codex@0.115.0-linux-x64`，提取 `codex` 和 `rg` 到 `target/codex/assets/`，然后把它们注入到本地 rootfs 镜像中。
+
+离线 help 示例不需要认证：
+
+```bash
+examples/starry/codex-cli/prepare_codex_rootfs.sh
+```
+
+在线示例需要把 host 侧的 Codex 登录文件注入 guest。常见准备方式如下，代理地址请替换成当前 host 可被 QEMU guest 访问的地址；QEMU user network 下通常可以用 `10.0.2.2` 指向 host。
+
+```bash
+examples/starry/codex-cli/prepare_codex_rootfs.sh \
+  --output-rootfs tmp/axbuild/rootfs/rootfs-x86_64-codex-online.img \
+  --auth-json target/auth.json \
+  --proxy http://10.0.2.2:7890
+```
+
+`target/auth.json`、`target/codex/assets/`、`tmp/axbuild/rootfs/rootfs-x86_64-codex*.img` 都是本地资产，不提交到仓库。
+
+## 离线启动检查
+
+离线配置只验证 Codex CLI、`rg`、`git` 和本地 workspace 命令能在 StarryOS guest 中运行，不会请求模型。
+
+```bash
+cargo xtask starry qemu \
+  --arch x86_64 \
+  --qemu-config examples/starry/codex-cli/qemu-x86_64-codex-help.toml \
+  --rootfs tmp/axbuild/rootfs/rootfs-x86_64-codex.img
+```
+
+期望输出包含：
+
+```text
+STARRY_CODEX_STAGE_G_CODEX_HELP_PASSED
+```
+
+## 在线仓库 Demo
+
+在线配置会在 StarryOS guest 中直接 clone TGOSKits 仓库，然后让 Codex CLI 在真实仓库里寻找一个小的 syscall/内核语义差异，并尽量给出最小修复或验证计划。这个流程会访问 GitHub 和 OpenAI 服务，耗时和结果都依赖本地网络、认证、代理和模型状态。
+
+```bash
+cargo xtask starry qemu \
+  --arch x86_64 \
+  --qemu-config examples/starry/codex-cli/qemu-x86_64-codex-syscall-hunt.toml \
+  --rootfs tmp/axbuild/rootfs/rootfs-x86_64-codex-online.img
+```
+
+QEMU 内部会执行的核心动作包括：
+
+```sh
+git clone --depth 1 --branch dev https://github.com/rcore-os/tgoskits.git repo
+cd repo
+codex exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  --color never \
+  -C /tmp/tgoskits-syscall-hunt/repo \
+  --output-last-message /tmp/codex-tgoskits-syscall-hunt.txt \
+  "$(cat /tmp/tgoskits-syscall-hunt-prompt.txt)"
+```
+
+期望输出包含：
+
+```text
+STARRY_TGOSKITS_SYSCALL_HUNT_DONE
+STARRY_TGOSKITS_SYSCALL_HUNT_PASSED
+```
+
+## 手动交互
+
+如果希望自己逐步输入命令，可以只用准备好的 online rootfs 启动 QEMU：
+
+```bash
+cargo xtask starry qemu \
+  --arch x86_64 \
+  --rootfs tmp/axbuild/rootfs/rootfs-x86_64-codex-online.img
+```
+
+进入 `root@starry` 后：
+
+```sh
+export HOME=/root
+export USER=root
+export SHELL=/bin/sh
+export TERM=xterm-256color
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export CODEX_HOME=/root/.codex
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+[ -f "$CODEX_HOME/starry-online-env" ] && . "$CODEX_HOME/starry-online-env"
+
+mkdir -p /tmp/tgoskits-demo
+cd /tmp/tgoskits-demo
+git clone --depth 1 --branch dev https://github.com/rcore-os/tgoskits.git repo
+cd repo
+codex exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  -C /tmp/tgoskits-demo/repo \
+  'Please read this repository and briefly describe its StarryOS syscall test structure. Answer in Simplified Chinese.'
+```
+
+## 边界
+
+这个 example 只声明 x86_64 QEMU 下的手动演示流程。它不覆盖 Codex TUI、默认 Linux sandbox、CI 在线请求模型，或其他架构上的 Codex CLI。

--- a/examples/starry/codex-cli/prepare_codex_assets.sh
+++ b/examples/starry/codex-cli/prepare_codex_assets.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+asset_dir="$workspace/target/codex/assets"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/starry-codex-assets.XXXXXX")"
+package="@openai/codex@0.115.0-linux-x64"
+
+codex_sha256="440269f35afeb90d38115af844629d98705fb7266fdcd5fe7c040a78ebc75b85"
+rg_sha256="ebeaf56f8a25e102e9419933423738b3a2a613a444fd749d695e15eba53f71f2"
+
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: required command not found: $1" >&2
+        exit 1
+    fi
+}
+
+verify_sha256() {
+    local expected="$1"
+    local path="$2"
+    local actual
+
+    actual="$(sha256sum "$path" | awk '{print $1}')"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "error: SHA-256 mismatch for $path" >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+need_cmd npm
+need_cmd tar
+need_cmd sha256sum
+need_cmd install
+
+mkdir -p "$asset_dir"
+
+echo "Preparing Codex CLI assets from npm package $package"
+pack_output="$(npm pack "$package" --pack-destination "$tmp_dir" --silent)"
+tarball="$(printf '%s\n' "$pack_output" | tail -n 1)"
+tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
+
+codex_src="$tmp_dir/package/vendor/x86_64-unknown-linux-musl/codex/codex"
+rg_src="$tmp_dir/package/vendor/x86_64-unknown-linux-musl/path/rg"
+
+if [[ ! -f "$codex_src" || ! -f "$rg_src" ]]; then
+    echo "error: expected Codex or ripgrep binary missing from $package" >&2
+    exit 1
+fi
+
+install -m 0755 "$codex_src" "$asset_dir/codex"
+install -m 0755 "$rg_src" "$asset_dir/rg"
+
+verify_sha256 "$codex_sha256" "$asset_dir/codex"
+verify_sha256 "$rg_sha256" "$asset_dir/rg"
+
+"$asset_dir/codex" --version
+"$asset_dir/rg" --version | head -n 1
+
+echo "Codex CLI assets ready in $asset_dir"

--- a/examples/starry/codex-cli/prepare_codex_rootfs.sh
+++ b/examples/starry/codex-cli/prepare_codex_rootfs.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace="$(cd "$script_dir/../../.." && pwd)"
+base_rootfs="$workspace/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img"
+output_rootfs="$workspace/tmp/axbuild/rootfs/rootfs-x86_64-codex.img"
+auth_json="${CODEX_AUTH_JSON:-}"
+proxy_url="${CODEX_ONLINE_PROXY:-}"
+env_file=""
+ca_cert="${SSL_CERT_FILE:-/etc/ssl/certs/ca-certificates.crt}"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Prepare a local rootfs for the StarryOS Codex CLI example.
+
+Options:
+  --auth-json PATH     Host auth.json to inject as /root/.codex/auth.json
+                       (default: CODEX_AUTH_JSON when set; otherwise omitted)
+  --proxy URL          Write /root/.codex/starry-online-env with HTTP(S)/ALL proxy exports
+                       (default: CODEX_ONLINE_PROXY when set)
+  --env-file PATH      Inject an existing shell env file as /root/.codex/starry-online-env
+  --base-rootfs PATH   Base rootfs image to copy before injection
+                       (default: tmp/axbuild/rootfs/rootfs-x86_64-alpine.img)
+  --output-rootfs PATH Output rootfs image for the example
+                       (default: tmp/axbuild/rootfs/rootfs-x86_64-codex.img)
+  --ca-cert PATH       CA bundle to inject as /etc/ssl/certs/ca-certificates.crt
+                       (default: SSL_CERT_FILE or /etc/ssl/certs/ca-certificates.crt)
+  -h, --help           Show this help
+
+Example:
+  examples/starry/codex-cli/prepare_codex_rootfs.sh \\
+    --output-rootfs tmp/axbuild/rootfs/rootfs-x86_64-codex-online.img \\
+    --auth-json target/auth.json \\
+    --proxy http://10.0.2.2:7890
+EOF
+}
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: required command not found: $1" >&2
+        exit 1
+    fi
+}
+
+shell_quote() {
+    local value="$1"
+    printf "'%s'" "${value//\'/\'\\\'\'}"
+}
+
+workspace_path() {
+    local path="$1"
+    if [[ "$path" = /* ]]; then
+        printf '%s\n' "$path"
+    else
+        printf '%s/%s\n' "$workspace" "$path"
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --auth-json)
+            auth_json="$2"
+            shift 2
+            ;;
+        --proxy)
+            proxy_url="$2"
+            shift 2
+            ;;
+        --env-file)
+            env_file="$2"
+            shift 2
+            ;;
+        --base-rootfs)
+            base_rootfs="$2"
+            shift 2
+            ;;
+        --output-rootfs)
+            output_rootfs="$2"
+            shift 2
+            ;;
+        --ca-cert)
+            ca_cert="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -n "$auth_json" ]]; then
+    auth_json="$(workspace_path "$auth_json")"
+fi
+base_rootfs="$(workspace_path "$base_rootfs")"
+output_rootfs="$(workspace_path "$output_rootfs")"
+ca_cert="$(workspace_path "$ca_cert")"
+if [[ -n "$env_file" ]]; then
+    env_file="$(workspace_path "$env_file")"
+fi
+
+need_cmd cp
+need_cmd debugfs
+need_cmd install
+need_cmd mktemp
+need_cmd stat
+
+if [[ -n "$auth_json" && ! -f "$auth_json" ]]; then
+    echo "error: auth.json not found: $auth_json" >&2
+    echo "       pass --auth-json PATH, set CODEX_AUTH_JSON, or omit auth for offline examples" >&2
+    exit 1
+fi
+
+if [[ ! -f "$base_rootfs" ]]; then
+    if [[ "$base_rootfs" == "$workspace/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img" ]]; then
+        echo "Base rootfs not found; preparing the default x86_64 Alpine rootfs..."
+        (cd "$workspace" && cargo xtask starry rootfs --arch x86_64)
+    fi
+fi
+
+if [[ ! -f "$base_rootfs" ]]; then
+    echo "error: base rootfs not found: $base_rootfs" >&2
+    exit 1
+fi
+
+"$script_dir/prepare_codex_assets.sh"
+
+codex_bin="$workspace/target/codex/assets/codex"
+rg_bin="$workspace/target/codex/assets/rg"
+if [[ ! -x "$codex_bin" || ! -x "$rg_bin" ]]; then
+    echo "error: Codex assets are missing after prepare_codex_assets.sh" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$output_rootfs")"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/starry-codex-rootfs.XXXXXX")"
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+overlay="$tmp_dir/overlay"
+mkdir -p "$overlay/usr/local/bin" "$overlay/root/.codex"
+install -m 0755 "$codex_bin" "$overlay/usr/local/bin/codex"
+install -m 0755 "$rg_bin" "$overlay/usr/local/bin/rg"
+if [[ -n "$auth_json" ]]; then
+    install -m 0600 "$auth_json" "$overlay/root/.codex/auth.json"
+fi
+
+if [[ -n "$env_file" ]]; then
+    if [[ ! -f "$env_file" ]]; then
+        echo "error: env file not found: $env_file" >&2
+        exit 1
+    fi
+    install -m 0644 "$env_file" "$overlay/root/.codex/starry-online-env"
+elif [[ -n "$proxy_url" ]]; then
+    quoted_proxy="$(shell_quote "$proxy_url")"
+    cat > "$overlay/root/.codex/starry-online-env" <<EOF
+export HTTP_PROXY=$quoted_proxy
+export HTTPS_PROXY=$quoted_proxy
+export ALL_PROXY=$quoted_proxy
+export http_proxy=$quoted_proxy
+export https_proxy=$quoted_proxy
+export all_proxy=$quoted_proxy
+export NO_PROXY='localhost,127.0.0.1,::1'
+export no_proxy='localhost,127.0.0.1,::1'
+EOF
+    chmod 0644 "$overlay/root/.codex/starry-online-env"
+fi
+
+if [[ -f "$ca_cert" ]]; then
+    mkdir -p "$overlay/etc/ssl/certs"
+    install -m 0644 "$ca_cert" "$overlay/etc/ssl/certs/ca-certificates.crt"
+else
+    echo "warning: CA bundle not found at $ca_cert; relying on the base rootfs CA bundle" >&2
+fi
+
+tmp_rootfs="$tmp_dir/rootfs.img"
+cp --reflink=auto "$base_rootfs" "$tmp_rootfs" 2>/dev/null || cp "$base_rootfs" "$tmp_rootfs"
+
+debugfs_script="$tmp_dir/inject.debugfs"
+{
+    find "$overlay" -type d | sort | while IFS= read -r dir; do
+        rel="${dir#"$overlay"}"
+        [[ -z "$rel" ]] && continue
+        printf 'mkdir %s\n' "$rel"
+    done
+    find "$overlay" -type f | sort | while IFS= read -r file; do
+        rel="${file#"$overlay"}"
+        mode="$(stat -c '%a' "$file")"
+        printf 'rm %s\n' "$rel"
+        printf 'write %s %s\n' "$file" "$rel"
+        printf 'sif %s mode 0100%s\n' "$rel" "$mode"
+    done
+    printf 'quit\n'
+} > "$debugfs_script"
+
+debugfs_log="$tmp_dir/debugfs.log"
+if ! debugfs -w -f "$debugfs_script" "$tmp_rootfs" >"$debugfs_log" 2>&1; then
+    cat "$debugfs_log" >&2
+    exit 1
+fi
+mv "$tmp_rootfs" "$output_rootfs"
+
+display_rootfs="$output_rootfs"
+case "$display_rootfs" in
+    "$workspace"/*)
+        display_rootfs="${display_rootfs#"$workspace"/}"
+        ;;
+esac
+
+echo "Codex example rootfs ready:"
+echo "  $output_rootfs"
+echo
+echo "Run the offline help example with:"
+echo "  cargo xtask starry qemu --arch x86_64 \\"
+echo "    --qemu-config examples/starry/codex-cli/qemu-x86_64-codex-help.toml \\"
+echo "    --rootfs $display_rootfs"
+if [[ -n "$auth_json" ]]; then
+    echo
+    echo "Run the opt-in online syscall-hunt example with:"
+    echo "  cargo xtask starry qemu --arch x86_64 \\"
+    echo "    --qemu-config examples/starry/codex-cli/qemu-x86_64-codex-syscall-hunt.toml \\"
+    echo "    --rootfs $display_rootfs"
+fi

--- a/examples/starry/codex-cli/qemu-x86_64-codex-help.toml
+++ b/examples/starry/codex-cli/qemu-x86_64-codex-help.toml
@@ -1,0 +1,81 @@
+# Example only: this is not part of the StarryOS test-suit or CI.
+args = [
+    "-machine",
+    "q35",
+    "-nographic",
+    "-m",
+    "2G",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-codex.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-snapshot",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+export HOME=/root
+export USER=root
+export SHELL=/bin/sh
+export TERM=xterm-256color
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export CODEX_HOME=/root/codex-smoke-home
+rm -rf "$CODEX_HOME" /tmp/codex-smoke
+mkdir -p "$CODEX_HOME" /tmp/codex-smoke
+set -e
+
+codex --version | tee /tmp/codex-smoke/version.txt
+codex --help > /tmp/codex-smoke/help.txt
+codex exec --help > /tmp/codex-smoke/exec-help.txt
+rg --version > /tmp/codex-smoke/rg-version.txt
+
+grep -F "codex-cli 0.115.0" /tmp/codex-smoke/version.txt
+grep -F "Codex CLI" /tmp/codex-smoke/help.txt
+grep -F "Usage:" /tmp/codex-smoke/exec-help.txt
+grep -F "ripgrep 15.1.0" /tmp/codex-smoke/rg-version.txt
+echo "STARRY_CODEX_STAGE_G_HELP_OK"
+
+set +e
+codex login status -c 'cli_auth_credentials_store="file"' > /tmp/codex-smoke/login-status.txt 2>&1
+LOGIN_RC=$?
+set -e
+cat /tmp/codex-smoke/login-status.txt
+test "$LOGIN_RC" -ne 0
+grep -F "Not logged in" /tmp/codex-smoke/login-status.txt
+echo "STARRY_CODEX_STAGE_G_LOGIN_STATUS_OK"
+
+mkdir -p /tmp/codex-smoke/workspace
+cd /tmp/codex-smoke/workspace
+git init
+git config user.name 'StarryOS Codex Smoke'
+git config user.email 'codex-smoke@example.invalid'
+printf '# Codex Smoke Workspace\n' > README.md
+git add README.md
+git commit -m 'smoke baseline'
+printf 'STARRY_CODEX_SMOKE_WORKSPACE_TOKEN\n' >> README.md
+git status --short | tee /tmp/codex-smoke/git-status.txt
+git diff -- README.md | tee /tmp/codex-smoke/git-diff.txt
+rg -n --with-filename 'STARRY_CODEX_SMOKE_WORKSPACE_TOKEN' README.md | tee /tmp/codex-smoke/rg-workspace.txt
+grep -E '^ M README\.md$' /tmp/codex-smoke/git-status.txt
+grep -F '+STARRY_CODEX_SMOKE_WORKSPACE_TOKEN' /tmp/codex-smoke/git-diff.txt
+grep -F 'README.md:2:STARRY_CODEX_SMOKE_WORKSPACE_TOKEN' /tmp/codex-smoke/rg-workspace.txt
+echo "STARRY_CODEX_STAGE_G_LOCAL_WORKSPACE_OK"
+
+echo "STARRY_CODEX_STAGE_G_CODEX_HELP_PASSED"
+'''
+success_regex = ["(?m)^STARRY_CODEX_STAGE_G_CODEX_HELP_PASSED\\s*$"]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)page fault",
+    "(?i)segmentation fault",
+    "(?i)codex.*fatal",
+    "No such process",
+    "sys_prctl: unsupported option 23",
+    "(?m)^STARRY_CODEX_STAGE_G_CODEX_HELP_FAILED\\s*$",
+]
+timeout = 420

--- a/examples/starry/codex-cli/qemu-x86_64-codex-syscall-hunt.toml
+++ b/examples/starry/codex-cli/qemu-x86_64-codex-syscall-hunt.toml
@@ -1,0 +1,124 @@
+# Example only: this online flow is opt-in and is not part of test-suit or CI.
+# Prepare tmp/axbuild/rootfs/rootfs-x86_64-codex-online.img with
+# prepare_codex_rootfs.sh --auth-json ... before running it.
+args = [
+    "-machine",
+    "q35",
+    "-nographic",
+    "-m",
+    "2G",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-codex-online.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-snapshot",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+export HOME=/root
+export USER=root
+export SHELL=/bin/sh
+export TERM=xterm-256color
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export CODEX_HOME=/root/.codex
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+if [ -f "$CODEX_HOME/starry-online-env" ]; then
+    . "$CODEX_HOME/starry-online-env"
+fi
+set -e
+echo "STARRY_TGOSKITS_SYSCALL_HUNT_ENV_READY"
+
+if [ ! -s "$CODEX_HOME/auth.json" ]; then
+    echo "STARRY_TGOSKITS_SYSCALL_HUNT_MISSING_AUTH_JSON"
+    echo "Run examples/starry/codex-cli/prepare_codex_rootfs.sh with --auth-json first."
+    exit 1
+fi
+
+command -v git
+command -v rg
+command -v codex
+codex --version
+codex login status -c 'cli_auth_credentials_store="file"'
+
+if [ ! -d /tmp/tgoskits-syscall-hunt/repo/.git ]; then
+    rm -rf /tmp/tgoskits-syscall-hunt
+    mkdir -p /tmp/tgoskits-syscall-hunt
+    cd /tmp/tgoskits-syscall-hunt
+    clone_ok=0
+    for attempt in 1 2 3; do
+        echo "clone attempt ${attempt}/3"
+        rm -rf repo
+        if time git clone --quiet --depth 1 --branch dev https://github.com/rcore-os/tgoskits.git repo; then
+            clone_ok=1
+            break
+        fi
+        sleep 2
+    done
+    test "$clone_ok" = "1"
+fi
+
+cd /tmp/tgoskits-syscall-hunt/repo
+git config user.name 'StarryOS Codex Syscall Hunt'
+git config user.email 'codex-syscall-hunt@example.invalid'
+test -f AGENTS.md
+test -d os/StarryOS/kernel
+test -d test-suit/starryos
+git status --short
+echo "STARRY_TGOSKITS_SYSCALL_HUNT_REPO_READY"
+
+cat > /tmp/tgoskits-syscall-hunt-prompt.txt <<'EOF'
+You are running inside a StarryOS x86_64 QEMU guest. The working directory is a real clone of the TGOSKits repository.
+
+Task: find and, if practical, fix one small and well-scoped syscall or kernel semantic bug.
+
+Rules:
+- Treat Linux behavior as the reference.
+- Prefer one small target from filesystem/directory semantics, process wait/exit semantics, or memory mapping semantics.
+- Handle only one clear issue in this run. Do not do a broad refactor.
+- First read `AGENTS.md`, `test-suit/starryos/GUIDE.md`, and the relevant StarryOS kernel/test-suit code.
+- First explain the minimal Linux-vs-StarryOS differential idea, then decide whether to write a test.
+- If it is safe to edit, prefer adding or updating one minimal regression test and one minimal fix.
+- If time, tools, or environment limits prevent a safe fix, do not force a patch. Instead report the candidate bug, evidence, relevant files, and the next minimal validation command.
+- Do not read, print, or copy any auth.json.
+
+Use necessary read-only commands such as `rg`, `sed`, and `git status`. If you edit files, only edit files directly related to the selected issue.
+
+Your final answer must be in Simplified Chinese and must include:
+- `STARRY_TGOSKITS_SYSCALL_HUNT_DONE`
+- selected syscall/semantic target
+- bug hypothesis or confirmed issue
+- key files inspected
+- if files changed, changed files and validation commands; if no files changed, the next minimal validation plan
+EOF
+
+codex exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  --color never \
+  -C /tmp/tgoskits-syscall-hunt/repo \
+  --output-last-message /tmp/codex-tgoskits-syscall-hunt.txt \
+  "$(cat /tmp/tgoskits-syscall-hunt-prompt.txt)"
+
+cat /tmp/codex-tgoskits-syscall-hunt.txt
+grep -F 'STARRY_TGOSKITS_SYSCALL_HUNT_DONE' /tmp/codex-tgoskits-syscall-hunt.txt
+echo "===== GIT STATUS AFTER CODEX ====="
+git status --short
+echo "===== GIT DIFF STAT AFTER CODEX ====="
+git diff --stat || true
+echo "STARRY_TGOSKITS_SYSCALL_HUNT_PASSED"
+'''
+success_regex = ["(?m)^STARRY_TGOSKITS_SYSCALL_HUNT_PASSED\\s*$"]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)page fault",
+    "(?i)segmentation fault",
+    "No such process \\(os error 3\\)",
+    "sys_prctl: unsupported option 23",
+    "(?m)^STARRY_TGOSKITS_SYSCALL_HUNT_MISSING_AUTH_JSON\\s*$",
+]
+timeout = 2400


### PR DESCRIPTION
## 背景

前置 StarryOS 兼容性修复合入后，Codex CLI 已能在 x86_64 QEMU guest 中启动并完成基础本地命令，也可以在带 `auth.json` 和代理的本地环境中联网请求模型。上一版把 Codex CLI smoke 放进 `test-suit/starryos/manual`，但额外下载 Codex 会增加耗时并消耗自部署主机流量，因此本轮按 review 建议改为 `examples/starry` 下的 opt-in 示例，不再进入测试框架。

## 改动

- 新增 `examples/starry/codex-cli/README.md`，用中文说明 StarryOS Codex CLI 本地演示流程、online rootfs 准备、直接 clone TGOSKits 仓库后的在线 demo，以及不提交 auth/rootfs/log 的边界。
- 新增 `examples/starry/codex-cli/prepare_codex_assets.sh`，手动执行时才从固定 npm package `@openai/codex@0.115.0-linux-x64` 提取 `codex` 和 `rg` 到 `target/codex/assets/`，并校验 SHA-256。
- 新增 `examples/starry/codex-cli/prepare_codex_rootfs.sh`，手动生成本地 rootfs：默认只注入 `codex`/`rg`；传入 `--auth-json` 和 `--proxy` 后可生成 online demo rootfs。
- 新增 `qemu-x86_64-codex-help.toml`，作为离线启动检查示例：验证 `codex --version/help`、`codex exec --help`、空 `CODEX_HOME` 的登录状态、`rg` 和本地 `git diff`。
- 新增 `qemu-x86_64-codex-syscall-hunt.toml`，作为 opt-in 在线示例：guest 内直接 `git clone --depth 1 --branch dev https://github.com/rcore-os/tgoskits.git`，然后让 Codex CLI 在真实 TGOSKits 仓库中寻找一个小的 syscall/内核语义差异并给出修复或验证计划。
- 更新 `examples/starry/README.md`，说明 `examples/starry` 除 board case 外也可以包含显式 `cargo xtask starry qemu` 的 QEMU demo。

## 和上一版相比

- 不再修改 `scripts/axbuild/src/test/case.rs`。
- 不再新增 `prebuilt-assets` pipeline。
- 不再修改 `test-suit/starryos/GUIDE.md`，也不再新增 `test-suit/starryos/manual` 下的 Codex case。
- 不再修改 `docs/docs/build/test/*`。
- Codex 下载、rootfs 注入、在线请求模型都只发生在用户显式运行 `examples/starry/codex-cli` 下脚本或 QEMU 配置时。

## 验证

本轮只做不触发下载和在线请求的轻量验证，避免继续消耗自部署主机流量：

- `git merge-tree --write-tree upstream/dev HEAD`
- `git diff --check upstream/dev...HEAD`
- `bash -n examples/starry/codex-cli/prepare_codex_assets.sh examples/starry/codex-cli/prepare_codex_rootfs.sh`
- `examples/starry/codex-cli/prepare_codex_rootfs.sh --help`

未在本轮运行 Codex 下载、QEMU offline example 或 online example；这些流程现在都是明确的 opt-in example，不是 PR/CI 的必跑测试。
