### PR TITLE
fix(ax-net-ng): route connected socket wakeups by peer

### DIFF
--- a/os/arceos/modules/axnet-ng/src/lib.rs
+++ b/os/arceos/modules/axnet-ng/src/lib.rs
@@ -16,6 +16,8 @@
 #[macro_use]
 extern crate log;
 extern crate alloc;
+#[cfg(test)]
+extern crate std;
 
 mod consts;
 mod device;
@@ -205,4 +207,58 @@ fn dhcp_bootstrap() {
         ax_task::sleep(DHCP_BOOTSTRAP_POLL_INTERVAL);
     }
     warn!("eth0: DHCP bootstrap timed out");
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use alloc::boxed::Box;
+    use std::sync::Once;
+
+    use ax_sync::Mutex;
+    use smoltcp::wire::{IpAddress, Ipv4Address, Ipv4Cidr};
+
+    use crate::{
+        SERVICE,
+        device::LoopbackDevice,
+        router::{Router, Rule},
+        service::Service,
+    };
+
+    pub(crate) const LOCAL_MASK: u32 = 1 << 0;
+    pub(crate) const PEER_MASK: u32 = 1 << 1;
+    pub(crate) const LOCAL_ADDR: Ipv4Address = Ipv4Address::new(192, 0, 2, 10);
+    pub(crate) const PEER_ADDR: Ipv4Address = Ipv4Address::new(198, 51, 100, 20);
+
+    pub(crate) fn init_split_route_network() {
+        static INIT: Once = Once::new();
+
+        INIT.call_once(|| {
+            let mut router = Router::new();
+            let local_dev = router.add_device(Box::new(LoopbackDevice::new()));
+            let peer_dev = router.add_device(Box::new(LoopbackDevice::new()));
+            let local_cidr = Ipv4Cidr::new(LOCAL_ADDR, 24);
+            let peer_cidr = Ipv4Cidr::new(PEER_ADDR, 24);
+
+            router.add_rule(Rule::new(
+                local_cidr.into(),
+                None,
+                local_dev,
+                IpAddress::Ipv4(LOCAL_ADDR),
+            ));
+            router.add_rule(Rule::new(
+                peer_cidr.into(),
+                None,
+                peer_dev,
+                IpAddress::Ipv4(PEER_ADDR),
+            ));
+
+            let mut service = Service::new(router);
+            service.iface.update_ip_addrs(|ip_addrs| {
+                ip_addrs.push(local_cidr.into()).unwrap();
+                ip_addrs.push(peer_cidr.into()).unwrap();
+            });
+
+            SERVICE.call_once(|| Mutex::new(service));
+        });
+    }
 }

--- a/os/arceos/modules/axnet-ng/src/tcp.rs
+++ b/os/arceos/modules/axnet-ng/src/tcp.rs
@@ -414,11 +414,9 @@ impl SocketOps for TcpSocket {
                 if register_bound {
                     self.bound_registered.store(true, Ordering::Release);
                 }
-                self.general
-                    .set_device_mask(get_service().device_mask_for(&IpListenEndpoint {
-                        addr: Some(remote_endpoint.addr),
-                        port: remote_endpoint.port,
-                    }));
+                self.general.set_device_mask(
+                    get_service().device_mask_for(&endpoint_from_ip_endpoint(remote_endpoint)),
+                );
                 Ok(())
             })?;
 
@@ -761,4 +759,34 @@ fn get_ephemeral_port() -> AxResult<u16> {
         tries += 1;
     }
     ax_bail!(AddrInUse, "no available ports");
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::{IpAddr, SocketAddr};
+
+    use super::*;
+    use crate::{
+        options::{Configurable, SetSocketOption},
+        test_support::{LOCAL_ADDR, LOCAL_MASK, PEER_ADDR, PEER_MASK, init_split_route_network},
+    };
+
+    #[test]
+    fn connect_uses_peer_route_for_device_mask() {
+        init_split_route_network();
+
+        let socket = TcpSocket::new();
+        let nonblocking = true;
+        socket
+            .set_option(SetSocketOption::NonBlocking(&nonblocking))
+            .unwrap();
+        socket
+            .bind(SocketAddrEx::Ip(SocketAddr::new(IpAddr::V4(LOCAL_ADDR), 0)))
+            .unwrap();
+        assert_eq!(socket.general.device_mask(), LOCAL_MASK);
+
+        let _ = socket.connect(SocketAddrEx::Ip(SocketAddr::new(IpAddr::V4(PEER_ADDR), 80)));
+
+        assert_eq!(socket.general.device_mask(), PEER_MASK);
+    }
 }

--- a/os/arceos/modules/axnet-ng/src/tcp.rs
+++ b/os/arceos/modules/axnet-ng/src/tcp.rs
@@ -415,7 +415,10 @@ impl SocketOps for TcpSocket {
                     self.bound_registered.store(true, Ordering::Release);
                 }
                 self.general
-                    .set_device_mask(get_service().device_mask_for(&bound_endpoint));
+                    .set_device_mask(get_service().device_mask_for(&IpListenEndpoint {
+                        addr: Some(remote_endpoint.addr),
+                        port: remote_endpoint.port,
+                    }));
                 Ok(())
             })?;
 

--- a/os/arceos/modules/axnet-ng/src/tcp.rs
+++ b/os/arceos/modules/axnet-ng/src/tcp.rs
@@ -355,70 +355,7 @@ impl SocketOps for TcpSocket {
 
     fn connect(&self, remote_addr: SocketAddrEx) -> AxResult {
         let remote_addr = remote_addr.into_ip()?;
-        self.state
-            .lock(State::Idle)
-            .map_err(|state| {
-                if state == State::Connecting {
-                    AxError::InProgress
-                } else {
-                    // TODO(mivik): error code
-                    ax_err_type!(AlreadyConnected)
-                }
-            })?
-            .transit(State::Connecting, || {
-                self.clear_pending_error();
-                // TODO: check remote addr unreachable
-                // let (bound_endpoint, remote_endpoint) = self.get_endpoint_pair(remote_addr)?;
-                let remote_endpoint = IpEndpoint::from(remote_addr);
-                let mut bound_endpoint = *self.bound_endpoint.lock();
-                if bound_endpoint.addr.is_none() {
-                    bound_endpoint.addr =
-                        Some(get_service().get_source_address(&remote_endpoint.addr));
-                }
-                if bound_endpoint.port == 0 {
-                    bound_endpoint.port = get_ephemeral_port()?;
-                }
-                info!(
-                    "TCP connection from {} to {}",
-                    bound_endpoint, remote_endpoint
-                );
-                let register_bound = !self.bound_registered.load(Ordering::Acquire);
-                if register_bound {
-                    register_tcp_bound(bound_endpoint)?;
-                }
-
-                let result = {
-                    let mut service = get_service();
-                    let context = service.iface.context();
-                    self.with_smol_socket(|socket| {
-                        socket
-                            .connect(context, remote_endpoint, bound_endpoint)
-                            .map_err(|e| match e {
-                                smol::ConnectError::InvalidState => {
-                                    ax_err_type!(AlreadyConnected)
-                                }
-                                smol::ConnectError::Unaddressable => {
-                                    ax_err_type!(ConnectionRefused, "unaddressable")
-                                }
-                            })?;
-                        Ok::<(), AxError>(())
-                    })
-                };
-                if let Err(err) = result {
-                    if register_bound {
-                        unregister_tcp_bound(bound_endpoint);
-                    }
-                    return Err(err);
-                }
-                *self.bound_endpoint.lock() = bound_endpoint;
-                if register_bound {
-                    self.bound_registered.store(true, Ordering::Release);
-                }
-                self.general.set_device_mask(
-                    get_service().device_mask_for(&endpoint_from_ip_endpoint(remote_endpoint)),
-                );
-                Ok(())
-            })?;
+        self.start_connect(remote_addr)?;
 
         // Hack: let the server listen
         ax_task::yield_now();
@@ -678,6 +615,73 @@ fn socket_bound_endpoint(socket: &smol::Socket<'_>) -> IpListenEndpoint {
 }
 
 impl TcpSocket {
+    fn start_connect(&self, remote_addr: SocketAddr) -> AxResult {
+        self.state
+            .lock(State::Idle)
+            .map_err(|state| {
+                if state == State::Connecting {
+                    AxError::InProgress
+                } else {
+                    // TODO(mivik): error code
+                    ax_err_type!(AlreadyConnected)
+                }
+            })?
+            .transit(State::Connecting, || {
+                self.clear_pending_error();
+                // TODO: check remote addr unreachable
+                // let (bound_endpoint, remote_endpoint) = self.get_endpoint_pair(remote_addr)?;
+                let remote_endpoint = IpEndpoint::from(remote_addr);
+                let mut bound_endpoint = *self.bound_endpoint.lock();
+                if bound_endpoint.addr.is_none() {
+                    bound_endpoint.addr =
+                        Some(get_service().get_source_address(&remote_endpoint.addr));
+                }
+                if bound_endpoint.port == 0 {
+                    bound_endpoint.port = get_ephemeral_port()?;
+                }
+                info!(
+                    "TCP connection from {} to {}",
+                    bound_endpoint, remote_endpoint
+                );
+                let register_bound = !self.bound_registered.load(Ordering::Acquire);
+                if register_bound {
+                    register_tcp_bound(bound_endpoint)?;
+                }
+
+                let result = {
+                    let mut service = get_service();
+                    let context = service.iface.context();
+                    self.with_smol_socket(|socket| {
+                        socket
+                            .connect(context, remote_endpoint, bound_endpoint)
+                            .map_err(|e| match e {
+                                smol::ConnectError::InvalidState => {
+                                    ax_err_type!(AlreadyConnected)
+                                }
+                                smol::ConnectError::Unaddressable => {
+                                    ax_err_type!(ConnectionRefused, "unaddressable")
+                                }
+                            })?;
+                        Ok::<(), AxError>(())
+                    })
+                };
+                if let Err(err) = result {
+                    if register_bound {
+                        unregister_tcp_bound(bound_endpoint);
+                    }
+                    return Err(err);
+                }
+                *self.bound_endpoint.lock() = bound_endpoint;
+                if register_bound {
+                    self.bound_registered.store(true, Ordering::Release);
+                }
+                self.general.set_device_mask(
+                    get_service().device_mask_for(&endpoint_from_ip_endpoint(remote_endpoint)),
+                );
+                Ok(())
+            })
+    }
+
     fn register_bound_endpoint(&self, endpoint: IpListenEndpoint) -> AxResult {
         if !self.bound_registered.load(Ordering::Acquire) {
             register_tcp_bound(endpoint)?;
@@ -785,7 +789,9 @@ mod tests {
             .unwrap();
         assert_eq!(socket.general.device_mask(), LOCAL_MASK);
 
-        let _ = socket.connect(SocketAddrEx::Ip(SocketAddr::new(IpAddr::V4(PEER_ADDR), 80)));
+        socket
+            .start_connect(SocketAddr::new(IpAddr::V4(PEER_ADDR), 80))
+            .unwrap();
 
         assert_eq!(socket.general.device_mask(), PEER_MASK);
     }

--- a/os/arceos/modules/axnet-ng/src/udp.rs
+++ b/os/arceos/modules/axnet-ng/src/udp.rs
@@ -162,11 +162,9 @@ impl SocketOps for UdpSocket {
         let remote_addr = IpEndpoint::from(remote_addr);
         let src = get_service().get_source_address(&remote_addr.addr);
         *guard = Some((remote_addr, src));
-        self.general
-            .set_device_mask(get_service().device_mask_for(&IpListenEndpoint {
-                addr: Some(remote_addr.addr),
-                port: remote_addr.port,
-            }));
+        self.general.set_device_mask(
+            get_service().device_mask_for(&endpoint_from_ip_endpoint(remote_addr)),
+        );
         debug!("UDP socket {}: connected to {}", self.handle, remote_addr);
         Ok(())
     }
@@ -356,6 +354,13 @@ impl Drop for UdpSocket {
     }
 }
 
+fn endpoint_from_ip_endpoint(endpoint: IpEndpoint) -> IpListenEndpoint {
+    IpListenEndpoint {
+        addr: Some(endpoint.addr),
+        port: endpoint.port,
+    }
+}
+
 fn get_ephemeral_port() -> AxResult<u16> {
     const PORT_START: u16 = 0xc000;
     const PORT_END: u16 = 0xffff;
@@ -369,4 +374,31 @@ fn get_ephemeral_port() -> AxResult<u16> {
         *curr += 1;
     }
     Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::{IpAddr, SocketAddr};
+
+    use super::*;
+    use crate::test_support::{
+        LOCAL_ADDR, LOCAL_MASK, PEER_ADDR, PEER_MASK, init_split_route_network,
+    };
+
+    #[test]
+    fn connect_uses_peer_route_for_device_mask() {
+        init_split_route_network();
+
+        let socket = UdpSocket::new();
+        socket
+            .bind(SocketAddrEx::Ip(SocketAddr::new(IpAddr::V4(LOCAL_ADDR), 0)))
+            .unwrap();
+        assert_eq!(socket.general.device_mask(), LOCAL_MASK);
+
+        socket
+            .connect(SocketAddrEx::Ip(SocketAddr::new(IpAddr::V4(PEER_ADDR), 53)))
+            .unwrap();
+
+        assert_eq!(socket.general.device_mask(), PEER_MASK);
+    }
 }

--- a/os/arceos/modules/axnet-ng/src/udp.rs
+++ b/os/arceos/modules/axnet-ng/src/udp.rs
@@ -162,6 +162,11 @@ impl SocketOps for UdpSocket {
         let remote_addr = IpEndpoint::from(remote_addr);
         let src = get_service().get_source_address(&remote_addr.addr);
         *guard = Some((remote_addr, src));
+        self.general
+            .set_device_mask(get_service().device_mask_for(&IpListenEndpoint {
+                addr: Some(remote_addr.addr),
+                port: remote_addr.port,
+            }));
         debug!("UDP socket {}: connected to {}", self.handle, remote_addr);
         Ok(())
     }

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -48,6 +48,7 @@ ax-input
 ax-ipi
 ax-log
 ax-net
+ax-net-ng
 ax-runtime
 ax-feat
 ax-api


### PR DESCRIPTION
## Summary

Update connected TCP and UDP sockets to derive their receive wakeup device mask from the peer endpoint instead of the local bound endpoint.

## Motivation

The device mask controls which network devices register RX wakers for a socket. For connected sockets, incoming packets are associated with the route to the peer address. Using the local bound endpoint can select the wrong device, especially in multi-interface routing setups, which can leave the socket without the correct RX wakeup and cause readiness stalls.

## Changes

- Use the remote endpoint when setting the TCP socket device mask after `connect`.
- Set the UDP socket device mask after `connect` using the peer endpoint.
- Reuse the existing `device_mask_for` helper without changing the service API.