### PR TITLE
docs(repo): document PR submission guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,4 +28,8 @@
 - For PRs, issues, review replies, discussions, and similar project-facing submissions, keep the language neutral and project-focused.
 - For PR titles, follow `type(scope): content` in Conventional Commits style. Prefer the main affected crate name as `scope` when one crate clearly dominates the change; for cross-cutting or infrastructure work, broader scopes such as `ci`, `repo`, or `docs` are acceptable.
 - PR title examples: `feat(axbuild): add Starry remote board test flow`, `fix(starry-process): correct tty session cleanup`, `chore(ci): split Starry self-hosted board matrix`.
+- When submitting a PR, write the title in English and the body in Chinese.
+- PR descriptions must clearly cover: the problem being solved, what was changed to solve it, and the logic behind each step of the solution.
+- Before submitting a PR, locally validate the CI flow as much as practical, excluding only physical board tests and self-hosted test flows unless the user explicitly asks to run them. Changes unrelated to building or testing, such as documentation-only updates, do not require local CI validation.
+- After adding or changing commits on a PR branch, update the PR description so it stays synchronized with the committed changes.
 - Do not insert agent-related labels, signatures, branding, or other advertisement-style wording such as `codex`, `agent`, `AI`, or similar self-promotional tags unless the user explicitly requests it.


### PR DESCRIPTION
## 解决的问题

当前项目记忆中已有 PR 标题格式和项目沟通语气要求，但缺少更完整的 PR 提交流程约束，容易导致后续提交时出现描述语言不一致、PR 正文缺少问题背景和修改逻辑、本地验证范围不明确，以及追加 commit 后 PR 描述没有同步更新的问题。

## 修改内容

- 补充 PR 标题和正文语言要求：标题使用英文，正文使用中文。
- 补充 PR 描述内容要求：需要说明要解决的问题、为了解决问题做了哪些修改，以及每一步修改背后的逻辑。
- 补充提交前验证要求：在实际可行范围内本地验证 CI 流程，但真机测试和 self-hosted 测试流程默认不要求本地执行。
- 补充文档类例外：与编译、测试无关的变更，例如纯文档更新，不需要本地验证 CI。
- 补充 PR 分支更新后的同步要求：追加或修改 commit 后，需要同步更新 PR 描述。

## 修改逻辑

1. 将新的规则放在 `AGENTS.md` 中已有 PR 规范附近，使标题格式、正文语言、验证范围和描述同步要求集中维护。
2. 先规定 PR 标题和正文语言，保证项目提交入口的展示语言一致。
3. 再规定 PR 正文必须覆盖问题、修改和步骤逻辑，保证 review 时能快速理解变更目的和实现路径。
4. 对本地验证要求增加边界：代码和构建相关变更需要尽量验证 CI，真机和 self-hosted 流程除外；纯文档等无关编译测试的变更则无需执行不相关验证。
5. 最后补充 commit 变更后的 PR 描述同步要求，避免 PR 描述与实际提交内容脱节。

## 本地验证

- 已执行 `git diff --check -- AGENTS.md`。
- 本次为 `AGENTS.md` 文档/项目记忆更新，不涉及编译或测试逻辑；按新增规则，不需要本地验证编译类 CI。