### PR TITLE
docs(review-single-pr): require validation for untested changes

### DIFF
--- a/.claude/skills/review-single-pr/SKILL.md
+++ b/.claude/skills/review-single-pr/SKILL.md
@@ -23,7 +23,7 @@ Prefer the GitHub MCP/connector for structured PR data. Use local `git` for fetc
 
 ## Intake
 
-1. Follow `github:github` to resolve repository identity, current user, PR number or URL, title, author, base/head refs, `headRefOid`, draft state, merge state, changed files, patch context, existing reviews/comments, and available checks.
+1. Follow `github:github` to resolve repository identity, current user, PR number or URL, title, body, author, base/head refs, `headRefOid`, draft state, merge state, changed files, patch context, commit messages, existing reviews/comments, and available checks.
 2. If the PR is authored by the current GitHub user, say so and ask before submitting a formal review.
 3. Include draft PRs unless the user explicitly says to skip drafts.
 4. Keep connector state and local checkout state aligned before creating the worktree.
@@ -33,7 +33,7 @@ Fallback only when the GitHub MCP/connector cannot provide the needed data:
    ```bash
    gh auth status
    gh repo view --json nameWithOwner,defaultBranchRef,url
-   gh pr view <pr> --json number,title,author,baseRefName,headRefName,headRefOid,headRepositoryOwner,isDraft,mergeStateStatus,maintainerCanModify,reviewDecision,url
+   gh pr view <pr> --json number,title,body,author,baseRefName,headRefName,headRefOid,headRepositoryOwner,isDraft,mergeStateStatus,maintainerCanModify,reviewDecision,url,commits
    gh pr diff <pr> --patch --color=never
    gh pr checks <pr> --watch=false
    gh api "repos/<owner>/<repo>/pulls/<pr>/reviews?per_page=100"
@@ -167,6 +167,14 @@ For StarryOS grouped QEMU cases, verify that new `test_commands` are actually di
 
 For bugfix tests in grouped cases, inspect the new test's assertions as well as running the case. A grouped case passing is not sufficient when the new test accepts both the fixed behavior and the broken behavior.
 
+When the PR does not add or modify a test case, inspect the PR body and commit messages for any claimed non-board validation method, such as QEMU, host unit tests, `cargo xtask`, `cargo test`, `cargo clippy`, shell scripts, emulators, or reproducible manual commands that do not require physical hardware:
+
+- If such validation is claimed, run it or an equivalent local command before approval. Compare the actual command, target, output, and pass/fail condition with the PR's claim.
+- If the claimed validation fails, is not reproducible as written, exercises a different target than claimed, silently skips the changed behavior, or cannot be run for an avoidable reason, submit `REQUEST_CHANGES`. Explain the mismatch and the expected fix direction: either make the validation true and reproducible, add an appropriate test, or correct the PR description.
+- If the claimed validation cannot be run because the environment is genuinely unavailable, record the exact limitation and do not treat the claim as proof. Require another reproducible non-board validation method or a test unless the user explicitly accepts the limitation.
+- If the PR has no test changes and neither the PR body nor commit messages describe a reproducible non-board validation method, do not approve. Request changes asking the author to add a test or document and provide a runnable validation command that covers the changed behavior.
+- Physical board-only validation may be useful evidence, but it does not satisfy this no-test fallback rule by itself unless the user explicitly scopes the review to board-only behavior.
+
 Use GitHub check status as required evidence, but not as the only review input:
 
 ```bash
@@ -182,6 +190,8 @@ Treat these as blocking unless clearly non-blocking:
 - behavior differs from POSIX/Linux/RFC/VirtIO semantics;
 - targeted tests, formatting, clippy, or PR-related CI fail;
 - new tests are not discovered by the project test runner or do not exercise the fixed ABI surface;
+- a PR has no test changes and lacks a reproducible non-board validation method in the PR body or commit messages;
+- a claimed non-board validation method is not actually reproducible or does not match the claimed coverage/result;
 - `success_regex` or `fail_regex` cannot reliably classify the intended StarryOS case result;
 - bug fixes lack meaningful reproduction coverage;
 - the implementation is a test-only or fake fix that does not implement the intended behavior;
@@ -233,6 +243,7 @@ Review body must explain in Chinese:
 - what the PR changed;
 - the implementation logic and why this approach is correct for the project semantics;
 - validation commands and results, including exact failure mode for failing tests;
+- when no tests are added, the PR body/commit-message validation claim that was checked, the command actually run, and whether it matched the claim;
 - CI status, including any unrelated failing checks, the evidence for unrelatedness, and the linked tracking issue;
 - for PR-related CI failures, the failing check, failure mode, and expected fix direction;
 - reproduction coverage status for bug fixes;


### PR DESCRIPTION
## Summary

- require single-PR reviews to collect PR body and commit-message validation claims
- require reviewers to run claimed non-board validation when no tests are added or changed
- request changes when claimed validation is missing, unreproducible, mismatched, or skipped
- require a test or runnable non-board validation command when an untested PR provides neither

## Validation

- `git diff --check -- .claude/skills/review-single-pr/SKILL.md`

This is a documentation/skill update only.