### PR TITLE
chore(axplat-riscv64-visionfive2): bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "axplat-riscv64-visionfive2"
-version = "0.1.0-pre.3"
+version = "0.1.1"
 dependencies = [
  "ax-config-macros",
  "ax-cpu",

--- a/platform/riscv64-visionfive2/Cargo.toml
+++ b/platform/riscv64-visionfive2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axplat-riscv64-visionfive2"
-version = "0.1.0-pre.3"
+version = "0.1.1"
 edition.workspace = true
 authors = ["朝倉水希 <asakuramizu111@gmail.com>"]
 description = "Implementation of axplat hardware abstraction layer for RISC-V VisionFive2 board"


### PR DESCRIPTION
## 问题

 当前版本为 （预发布版本），需要正式发布为稳定版本。

## 变更

- 将  版本从  升级到 
- 同步更新  中对应的版本记录

## 说明

从预发布版本升级为正式版本 ，标识该 crate 已具备稳定的 API 接口。