### PR TITLE
chore(arceos-rust-interface): add publish metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "ax-posix-api"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "ax-alloc",
  "ax-config",

--- a/os/arceos/api/arceos_posix_api/Cargo.toml
+++ b/os/arceos/api/arceos_posix_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-posix-api"
-version = "0.5.12"
+version = "0.5.13"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = [

--- a/os/arceos/ulib/arceos-rust/lib/Cargo.toml
+++ b/os/arceos/ulib/arceos-rust/lib/Cargo.toml
@@ -1,22 +1,25 @@
 [package]
-name = "arceos-rust-interface"
-version = "1.0.0"
-edition = "2024"
 authors = [
-    "eternalcomet <mydragonos@outlook.com>"
+  "eternalcomet <mydragonos@outlook.com>",
 ]
+categories.workspace = true
 description = "Arceos ABI definitions"
+edition = "2024"
+keywords.workspace = true
 license.workspace = true
+name = "arceos-rust-interface"
+repository.workspace = true
+version = "1.0.0"
 
 [lib]
 crate-type = ["staticlib"]
 
 [features]
 default = [
-    "fp-simd",
-    "tls",
-    "defplat",
-    "fd",
+  "fp-simd",
+  "tls",
+  "defplat",
+  "fd",
 ]
 
 # Multicore
@@ -26,37 +29,37 @@ smp = ["ax-feat/smp", "ax-kspin/smp"]
 fp-simd = ["ax-feat/fp-simd"]
 
 # Interrupts
-irq = ["ax-api/irq", "ax-feat/irq"]
 ipi = ["ax-api/ipi", "ax-feat/ipi"]
+irq = ["ax-api/irq", "ax-feat/irq"]
 
 # Custom or default platforms
-myplat = ["ax-feat/myplat"]
 defplat = ["ax-feat/defplat"]
+myplat = ["ax-feat/myplat"]
 
 # Memory
 alloc = ["ax-api/alloc", "ax-feat/alloc", "ax-io/alloc"]
-alloc-tlsf = ["ax-feat/alloc-tlsf"]
-alloc-slab = ["ax-feat/alloc-slab"]
 alloc-buddy = ["ax-feat/alloc-buddy"]
-page-alloc-64g = ["ax-feat/page-alloc-64g"] # Support up to 64G memory capacity
-page-alloc-4g = ["ax-feat/page-alloc-4g"] # Support up to 4G memory capacity
-paging = ["ax-feat/paging"]
+alloc-slab = ["ax-feat/alloc-slab"]
+alloc-tlsf = ["ax-feat/alloc-tlsf"]
 dma = ["ax-api/dma", "ax-feat/dma"]
+page-alloc-4g = ["ax-feat/page-alloc-4g"] # Support up to 4G memory capacity
+page-alloc-64g = ["ax-feat/page-alloc-64g"] # Support up to 64G memory capacity
+paging = ["ax-feat/paging"]
 tls = ["ax-feat/tls"]
 
 # Multi-threading and scheduler
 multitask = ["ax-api/multitask", "ax-feat/multitask", "irq"]
+sched-cfs = ["ax-feat/sched-cfs"]
 sched-fifo = ["ax-feat/sched-fifo"]
 sched-rr = ["ax-feat/sched-rr"]
-sched-cfs = ["ax-feat/sched-cfs"]
 
 # File system
 fd = ["ax-posix-api/fd"]
 fs = ["ax-api/fs", "ax-posix-api/fs", "ax-feat/fs"]
 
 # Networking
-net = ["ax-api/net", "ax-posix-api/net", "ax-posix-api/poll", "ax-feat/net"]
 dns = []
+net = ["ax-api/net", "ax-posix-api/net", "ax-posix-api/poll", "ax-feat/net"]
 
 # Display
 display = ["ax-api/display", "ax-feat/display"]
@@ -67,26 +70,26 @@ rtc = ["ax-feat/rtc"]
 # Device drivers
 bus-mmio = ["ax-feat/bus-mmio"]
 bus-pci = ["ax-feat/bus-pci"]
-driver-ramdisk = ["ax-feat/driver-ramdisk"]
-driver-ixgbe = ["ax-feat/driver-ixgbe"]
-driver-fxmac = ["ax-feat/driver-fxmac"]
 driver-bcm2835-sdhci = ["ax-feat/driver-bcm2835-sdhci"]
+driver-fxmac = ["ax-feat/driver-fxmac"]
+driver-ixgbe = ["ax-feat/driver-ixgbe"]
+driver-ramdisk = ["ax-feat/driver-ramdisk"]
 
 # Logging
-log-level-off = []
-log-level-error = []
-log-level-warn = []
-log-level-info = []
 log-level-debug = []
+log-level-error = []
+log-level-info = []
+log-level-off = []
 log-level-trace = []
+log-level-warn = []
 
 [dependencies]
-ax-feat = { workspace = true }
-ax-posix-api = { workspace = true, features = ["use-hermit-types"] }
-ax-api = { workspace = true, features = ["alloc"] }
-ax-runtime = { workspace = true }
-ax-errno = { workspace = true }
-ax-io = { workspace = true }
-ax-kspin = { workspace = true }
-rand = { version = "0.9.2", default-features = false, features = ["small_rng"] }
-log = { workspace = true }
+ax-api = {workspace = true, features = ["alloc"]}
+ax-errno = {workspace = true}
+ax-feat = {workspace = true}
+ax-io = {workspace = true}
+ax-kspin = {workspace = true}
+ax-posix-api = {workspace = true, features = ["use-hermit-types"]}
+ax-runtime = {workspace = true}
+log = {workspace = true}
+rand = {version = "0.9.2", default-features = false, features = ["small_rng"]}


### PR DESCRIPTION
`arceos-rust-interface` 缺少 `repository`、`keywords`、`categories` 三个 publish 必需的 metadata 字段，导致无法发布到 crates.io。

本次修改从 workspace 继承这些字段：
- `repository.workspace = true` → `https://github.com/rcore-os/tgoskits`
- `keywords.workspace = true` → `["arceos", "kernel"]`
- `categories.workspace = true` → `["os", "no-std"]`

与项目中其他 crate 保持一致。