### PR TITLE
feat(lockdep): support nested lock subclasses

### DIFF
--- a/components/kspin/src/base.rs
+++ b/components/kspin/src/base.rs
@@ -63,8 +63,6 @@ pub struct BaseSpinLockGuard<'a, G: BaseGuard, T: ?Sized + 'a> {
     _phantom: &'a PhantomData<G>,
     irq_state: G::State,
     #[cfg(feature = "lockdep")]
-    lock_id: Option<u32>,
-    #[cfg(feature = "lockdep")]
     lock_addr: usize,
     data: *mut T,
     #[cfg(feature = "smp")]
@@ -198,8 +196,6 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
             _phantom: &PhantomData,
             irq_state,
             #[cfg(feature = "lockdep")]
-            lock_id: lockdep.lock_id(),
-            #[cfg(feature = "lockdep")]
             lock_addr: lockdep.lock_addr(),
             data: unsafe { &mut *self.data.get() },
             #[cfg(feature = "smp")]
@@ -241,8 +237,6 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
                 _phantom: &PhantomData,
                 irq_state,
                 #[cfg(feature = "lockdep")]
-                lock_id: lockdep.lock_id(),
-                #[cfg(feature = "lockdep")]
                 lock_addr: lockdep.lock_addr(),
                 data: unsafe { &mut *self.data.get() },
                 #[cfg(feature = "smp")]
@@ -268,7 +262,7 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
         #[cfg(feature = "lockdep")]
         {
             let addr = self as *const _ as *const () as usize;
-            crate::lockdep::force_release::<G>(&self.lockdep, addr);
+            crate::lockdep::force_release::<G>(addr);
         }
         #[cfg(feature = "smp")]
         self.lock.store(false, Ordering::Release);
@@ -338,7 +332,7 @@ impl<G: BaseGuard, T: ?Sized> Drop for BaseSpinLockGuard<'_, G, T> {
             let _lockdep_irq_guard = IrqSave::new();
 
             #[cfg(feature = "lockdep")]
-            crate::lockdep::release::<G>(self.lock_id, self.lock_addr);
+            crate::lockdep::release::<G>(self.lock_addr);
             #[cfg(feature = "smp")]
             self.lock.store(false, Ordering::Release);
         }

--- a/components/kspin/src/lockdep.rs
+++ b/components/kspin/src/lockdep.rs
@@ -13,7 +13,6 @@ use crate::base::BaseSpinLock;
 #[derive(Clone, Copy)]
 pub(crate) struct Lockdep {
     addr: usize,
-    lock_id: Option<u32>,
     inner: ax_lockdep::Lockdep,
     prepared: Option<ax_lockdep::PreparedAcquire>,
 }
@@ -39,7 +38,6 @@ impl Lockdep {
         };
         Self {
             addr,
-            lock_id: prepared.map(ax_lockdep::PreparedAcquire::lock_id),
             inner: ax_lockdep::Lockdep::prepare(
                 "spin",
                 addr,
@@ -62,25 +60,20 @@ impl Lockdep {
     pub(crate) fn lock_addr(&self) -> usize {
         self.addr
     }
-
-    #[inline(always)]
-    pub(crate) fn lock_id(&self) -> Option<u32> {
-        self.lock_id
-    }
 }
 
 #[inline(always)]
-pub(crate) fn release<G: BaseGuard>(lock_id: Option<u32>, addr: usize) {
+pub(crate) fn release<G: BaseGuard>(addr: usize) {
     if tracks_task_locks::<G>() {
-        ax_lockdep::release_task(lock_id);
+        ax_lockdep::release_task(addr);
     }
     ax_lockdep::Lockdep::release("spin", addr, Some(core::any::type_name::<G>()));
 }
 
 #[inline(always)]
-pub(crate) fn force_release<G: BaseGuard>(map: &LockdepMap, addr: usize) {
+pub(crate) fn force_release<G: BaseGuard>(addr: usize) {
     if tracks_task_locks::<G>() {
-        ax_lockdep::force_release_task(map);
+        ax_lockdep::force_release_task(addr);
     }
     ax_lockdep::Lockdep::release("spin", addr, Some(core::any::type_name::<G>()));
 }

--- a/components/kspin/src/lockdep.rs
+++ b/components/kspin/src/lockdep.rs
@@ -2,9 +2,10 @@ use core::{any::type_name, panic::Location};
 
 use ax_kernel_guard::BaseGuard;
 pub use ax_lockdep::{
-    HeldLock, HeldLockSnapshot, HeldLockStack, KspinLockdepIf, LockdepMap, PreparedAcquire,
-    current_task_held_lock_snapshot, finish_acquire_task, finish_acquire_with_stack,
-    force_release_task, prepare_acquire_with_snapshot, release_from_stack, release_task,
+    HeldLock, HeldLockSnapshot, HeldLockStack, KspinLockdepIf, LockSubclass, LockdepMap,
+    PreparedAcquire, current_task_held_lock_snapshot, finish_acquire_task,
+    finish_acquire_with_stack, force_release_task, prepare_acquire_with_snapshot,
+    prepare_acquire_with_snapshot_nested, release_from_stack, release_task,
 };
 
 use crate::base::BaseSpinLock;

--- a/components/lockdep/src/lib.rs
+++ b/components/lockdep/src/lib.rs
@@ -8,10 +8,12 @@ mod trace;
 
 pub use self::{
     state::{
-        HeldLock, HeldLockSnapshot, HeldLockStack, KspinLockdepIf, LockdepCheckError, LockdepMap,
-        PreparedAcquire, current_task_held_lock_snapshot, finish_acquire_task,
-        finish_acquire_with_stack, force_release_task, prepare_acquire_with_snapshot,
-        prepare_acquire_with_snapshot_checked, release_from_stack, release_task,
+        DEFAULT_LOCK_SUBCLASS, HeldLock, HeldLockSnapshot, HeldLockStack, KspinLockdepIf,
+        LockSubclass, LockdepCheckError, LockdepMap, PreparedAcquire,
+        current_task_held_lock_snapshot, finish_acquire_task, finish_acquire_with_stack,
+        force_release_task, prepare_acquire_with_snapshot, prepare_acquire_with_snapshot_checked,
+        prepare_acquire_with_snapshot_checked_nested, prepare_acquire_with_snapshot_nested,
+        release_from_stack, release_task,
     },
     trace::{dump_trace_buffer, set_trace_enabled},
 };

--- a/components/lockdep/src/state.rs
+++ b/components/lockdep/src/state.rs
@@ -88,32 +88,35 @@ impl HeldLockStack {
     }
 
     pub fn push(&mut self, held: HeldLock) {
-        assert!(
-            !self.contains_addr(held.addr),
-            "lockdep: duplicate held lock push while acquiring {:?}; stack {:?}",
-            held,
-            self
-        );
-        assert!(
-            self.depth < MAX_HELD_LOCKS,
-            "lockdep: held lock stack overflow while acquiring {:?}",
-            held
-        );
+        if self.contains_addr(held.addr) {
+            lockdep_fatal(format_args!(
+                "lockdep: duplicate held lock push while acquiring {:?}; stack {:?}",
+                held, self
+            ));
+        }
+        if self.depth >= MAX_HELD_LOCKS {
+            lockdep_fatal(format_args!(
+                "lockdep: held lock stack overflow while acquiring {:?}",
+                held
+            ));
+        }
         self.entries[self.depth] = held;
         self.depth += 1;
     }
 
     pub fn pop_checked(&mut self, addr: usize) {
-        assert!(
-            self.depth != 0,
-            "lockdep: releasing lock {addr:#x} with empty held lock stack"
-        );
+        if self.depth == 0 {
+            lockdep_fatal(format_args!(
+                "lockdep: releasing lock {addr:#x} with empty held lock stack"
+            ));
+        }
         let top = self.entries[self.depth - 1];
-        assert_eq!(
-            top.addr, addr,
-            "lockdep: unlock order violation, releasing addr={:#x} while top of stack is {:?}",
-            addr, top
-        );
+        if top.addr != addr {
+            lockdep_fatal(format_args!(
+                "lockdep: unlock order violation, releasing addr={:#x} while top of stack is {:?}",
+                addr, top
+            ));
+        }
         self.depth -= 1;
     }
 }
@@ -169,11 +172,12 @@ impl HeldLockSnapshot {
             return;
         }
 
-        assert!(
-            self.depth < MAX_HELD_LOCK_SNAPSHOT,
-            "lockdep: combined held lock snapshot overflow while acquiring {:?}",
-            held
-        );
+        if self.depth >= MAX_HELD_LOCK_SNAPSHOT {
+            lockdep_fatal(format_args!(
+                "lockdep: combined held lock snapshot overflow while acquiring {:?}",
+                held
+            ));
+        }
         self.entries[self.depth] = held;
         self.depth += 1;
     }
@@ -271,6 +275,7 @@ pub trait KspinLockdepIf {
     fn push_current_task_held_lock(held: HeldLock);
     fn pop_current_task_held_lock(lock_addr: usize);
     fn console_write_str(s: &str);
+    fn fatal() -> !;
 }
 
 pub struct LockdepMap {
@@ -356,10 +361,11 @@ impl ClassRegistry {
         }
 
         let new_id = NEXT_CLASS_ID.fetch_add(1, Ordering::AcqRel);
-        assert!(
-            (new_id as usize) < MAX_LOCK_CLASSES,
-            "lockdep: exceeded maximum tracked lock classes ({MAX_LOCK_CLASSES})"
-        );
+        if (new_id as usize) >= MAX_LOCK_CLASSES {
+            lockdep_fatal(format_args!(
+                "lockdep: exceeded maximum tracked lock classes ({MAX_LOCK_CLASSES})"
+            ));
+        }
 
         self.keys[new_id as usize] = key;
         new_id
@@ -397,6 +403,12 @@ impl LockGraph {
     }
 
     fn add_order(&mut self, before: u32, after: u32, max_id: u32) {
+        if before as usize >= MAX_LOCK_CLASSES || after as usize >= MAX_LOCK_CLASSES {
+            lockdep_fatal(format_args!(
+                "lockdep: invalid class edge {} -> {} exceeds maximum tracked lock classes ({})",
+                before, after, MAX_LOCK_CLASSES
+            ));
+        }
         let mut closure = self.reachability[after as usize];
         let word = (after as usize) / 64;
         let bit = (after as usize) % 64;
@@ -554,16 +566,17 @@ fn ensure_class(
 fn pack_class_key(class_key: *const Location<'static>, subclass: LockSubclass) -> usize {
     let key = class_key as usize;
     let subclass = subclass as usize;
-    assert!(
-        subclass <= LOCK_SUBCLASS_MASK,
-        "lockdep: subclass {subclass} exceeds maximum {}",
-        LOCK_SUBCLASS_MASK
-    );
-    assert_eq!(
-        key & LOCK_SUBCLASS_MASK,
-        0,
-        "lockdep: class key {key:#x} is not aligned enough to encode subclasses"
-    );
+    if subclass > LOCK_SUBCLASS_MASK {
+        lockdep_fatal(format_args!(
+            "lockdep: subclass {subclass} exceeds maximum {}",
+            LOCK_SUBCLASS_MASK
+        ));
+    }
+    if key & LOCK_SUBCLASS_MASK != 0 {
+        lockdep_fatal(format_args!(
+            "lockdep: class key {key:#x} is not aligned enough to encode subclasses"
+        ));
+    }
     key | subclass
 }
 
@@ -654,6 +667,56 @@ fn pop_current_task_held_lock(lock_addr: usize) {
     with_current_task_held_locks_mut(|stack| stack.pop_checked(lock_addr));
 }
 
+#[cfg(all(feature = "task-context", not(any(test, doctest))))]
+fn lockdep_fatal(message: fmt::Arguments<'_>) -> ! {
+    struct ConsoleWriter;
+
+    impl fmt::Write for ConsoleWriter {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            emergency_write_str(s);
+            Ok(())
+        }
+    }
+
+    let mut writer = ConsoleWriter;
+    let _ = fmt::Write::write_fmt(&mut writer, message);
+    let _ = fmt::Write::write_str(&mut writer, "\n");
+    emergency_write_str("lockdep fatal violation\n");
+    call_interface!(KspinLockdepIf::fatal)
+}
+
+#[cfg(all(
+    feature = "task-context",
+    not(any(test, doctest)),
+    target_arch = "riscv64"
+))]
+fn emergency_write_str(s: &str) {
+    for &byte in s.as_bytes() {
+        #[allow(deprecated)]
+        {
+            sbi_rt::legacy::console_putchar(byte as usize);
+        }
+    }
+}
+
+#[cfg(all(
+    feature = "task-context",
+    not(any(test, doctest)),
+    not(target_arch = "riscv64")
+))]
+fn emergency_write_str(s: &str) {
+    call_interface!(KspinLockdepIf::console_write_str, s);
+}
+
+#[cfg(any(
+    test,
+    doctest,
+    all(not(target_os = "none"), not(feature = "task-context"))
+))]
+fn lockdep_fatal(message: fmt::Arguments<'_>) -> ! {
+    panic!("{message}")
+}
+
 pub fn current_task_held_lock_snapshot() -> HeldLockSnapshot {
     let mut snapshot = HeldLockSnapshot::new();
     collect_current_task_held_locks(&mut snapshot);
@@ -686,7 +749,7 @@ pub fn prepare_acquire_with_snapshot_nested(
     subclass: LockSubclass,
 ) -> PreparedAcquire {
     prepare_acquire_with_snapshot_result(map, addr, caller, held_before, subclass).unwrap_or_else(
-        |(err, state)| panic_on_lockdep_error(err, lock_kind, state, addr, &held_before),
+        |(err, state)| fatal_on_lockdep_error(err, lock_kind, state, addr, &held_before),
     )
 }
 
@@ -733,7 +796,7 @@ fn prepare_acquire_with_snapshot_result(
     Ok(PreparedAcquire { state, held_before })
 }
 
-fn panic_on_lockdep_error(
+fn fatal_on_lockdep_error(
     err: LockdepCheckError,
     lock_kind: &str,
     state: LockdepState,
@@ -745,13 +808,12 @@ fn panic_on_lockdep_error(
     let held_subclasses = held_lock_subclass_snapshot(held_before);
     match err {
         LockdepCheckError::Recursive => {
-            let (held_index, held) = held_before
-                .iter()
-                .enumerate()
-                .find(|(_, held)| held.addr == addr)
-                .or_else(|| held_before.iter().enumerate().next())
-                .expect("held lock snapshot unexpectedly empty");
-            panic!(
+            let (held_index, held) = conflicting_held_lock(
+                held_before,
+                |held| held.addr == addr,
+                "lockdep: recursive acquire without held lock snapshot",
+            );
+            lockdep_fatal(format_args!(
                 "lockdep: recursive {lock_kind} acquisition detected\nrequested:\n  class={} \
                  subclass={} addr={:#x} acquire_at={}\nalready held:\n  {}\nheld stack:\n{}",
                 requested_class,
@@ -766,17 +828,15 @@ fn panic_on_lockdep_error(
                     snapshot: held_before,
                     subclasses: &held_subclasses,
                 }
-            )
+            ))
         }
         LockdepCheckError::OrderInversion => {
-            emit_lockdep_marker("lockdep: lock order inversion detected\n");
-            let (held_index, held) = held_before
-                .iter()
-                .enumerate()
-                .find(|(_, held)| with_graph(|graph| graph.reaches(requested_class, held.class_id)))
-                .or_else(|| held_before.iter().enumerate().next())
-                .expect("held lock snapshot unexpectedly empty");
-            panic!(
+            let (held_index, held) = conflicting_held_lock(
+                held_before,
+                |held| with_graph(|graph| graph.reaches(requested_class, held.class_id)),
+                "lockdep: order inversion without held lock snapshot",
+            );
+            lockdep_fatal(format_args!(
                 "lockdep: lock order inversion detected\nrequested:\n  kind={} class={} \
                  subclass={} addr={:#x} acquire_at={}\nconflicting held lock:\n  {}\nheld \
                  stack:\n{}",
@@ -793,23 +853,27 @@ fn panic_on_lockdep_error(
                     snapshot: held_before,
                     subclasses: &held_subclasses,
                 }
-            );
+            ));
         }
     }
 }
 
-#[cfg(all(feature = "task-context", not(any(test, doctest))))]
-fn emit_lockdep_marker(s: &str) {
-    call_interface!(KspinLockdepIf::console_write_str, s);
-}
+fn conflicting_held_lock(
+    held_before: &HeldLockSnapshot,
+    matches: impl Fn(HeldLock) -> bool,
+    empty_message: &'static str,
+) -> (usize, HeldLock) {
+    for (index, held) in held_before.iter().enumerate() {
+        if matches(held) {
+            return (index, held);
+        }
+    }
 
-#[cfg(any(
-    test,
-    doctest,
-    all(not(target_os = "none"), not(feature = "task-context"))
-))]
-fn emit_lockdep_marker(s: &str) {
-    std::eprint!("{s}");
+    if let Some((index, held)) = held_before.iter().enumerate().next() {
+        return (index, held);
+    }
+
+    lockdep_fatal(format_args!("{empty_message}"))
 }
 
 pub fn finish_acquire_with_stack(

--- a/components/lockdep/src/state.rs
+++ b/components/lockdep/src/state.rs
@@ -15,10 +15,10 @@ use std::cell::RefCell;
 #[cfg(feature = "task-context")]
 use ax_crate_interface::call_interface;
 
-const MAX_LOCKS: usize = 1024;
+const MAX_LOCK_CLASSES: usize = 1024;
 const MAX_HELD_LOCKS: usize = 32;
 const MAX_HELD_LOCK_SNAPSHOT: usize = MAX_HELD_LOCKS;
-const WORDS_PER_ROW: usize = MAX_LOCKS.div_ceil(64);
+const WORDS_PER_ROW: usize = MAX_LOCK_CLASSES.div_ceil(64);
 const LOCK_SUBCLASS_BITS: usize = 3;
 const LOCK_SUBCLASS_MASK: usize = (1 << LOCK_SUBCLASS_BITS) - 1;
 
@@ -27,7 +27,6 @@ pub const DEFAULT_LOCK_SUBCLASS: LockSubclass = 0;
 
 #[derive(Clone, Copy)]
 pub struct HeldLock {
-    pub id: u32,
     pub class_id: u32,
     pub addr: usize,
     pub caller: &'static Location<'static>,
@@ -37,7 +36,6 @@ impl HeldLock {
     #[track_caller]
     const fn placeholder() -> Self {
         Self {
-            id: 0,
             class_id: 0,
             addr: 0,
             caller: Location::caller(),
@@ -48,7 +46,6 @@ impl HeldLock {
 impl fmt::Debug for HeldLock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HeldLock")
-            .field("id", &self.id)
             .field("class_id", &self.class_id)
             .field("addr", &format_args!("{:#x}", self.addr))
             .field("caller", &self.caller)
@@ -60,8 +57,8 @@ impl fmt::Display for HeldLock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "id={} class={} addr={:#x} acquired_at={}",
-            self.id, self.class_id, self.addr, self.caller
+            "class={} addr={:#x} acquired_at={}",
+            self.class_id, self.addr, self.caller
         )
     }
 }
@@ -86,13 +83,13 @@ impl HeldLockStack {
 
     // The live held-lock stack must preserve exact acquisition state; callers
     // use this for checks, but push/pop must not silently deduplicate entries.
-    pub fn contains(&self, id: u32) -> bool {
-        self.iter().any(|held| held.id == id)
+    pub fn contains_addr(&self, addr: usize) -> bool {
+        self.iter().any(|held| held.addr == addr)
     }
 
     pub fn push(&mut self, held: HeldLock) {
         assert!(
-            !self.contains(held.id),
+            !self.contains_addr(held.addr),
             "lockdep: duplicate held lock push while acquiring {:?}; stack {:?}",
             held,
             self
@@ -106,16 +103,16 @@ impl HeldLockStack {
         self.depth += 1;
     }
 
-    pub fn pop_checked(&mut self, id: u32) {
+    pub fn pop_checked(&mut self, addr: usize) {
         assert!(
             self.depth != 0,
-            "lockdep: releasing lock {id} with empty held lock stack"
+            "lockdep: releasing lock {addr:#x} with empty held lock stack"
         );
         let top = self.entries[self.depth - 1];
         assert_eq!(
-            top.id, id,
-            "lockdep: unlock order violation, releasing id={} while top of stack is {:?}",
-            id, top
+            top.addr, addr,
+            "lockdep: unlock order violation, releasing addr={:#x} while top of stack is {:?}",
+            addr, top
         );
         self.depth -= 1;
     }
@@ -156,9 +153,9 @@ impl HeldLockSnapshot {
     }
 
     // A snapshot is a temporary set-like view used for acquire checks, so
-    // duplicate lock ids are filtered out when extending/pushing into it.
-    pub fn contains(&self, id: u32) -> bool {
-        self.iter().any(|held| held.id == id)
+    // duplicate lock addresses are filtered out when extending/pushing into it.
+    pub fn contains_addr(&self, addr: usize) -> bool {
+        self.iter().any(|held| held.addr == addr)
     }
 
     pub fn extend(&mut self, stack: &HeldLockStack) {
@@ -168,7 +165,7 @@ impl HeldLockSnapshot {
     }
 
     pub fn push(&mut self, held: HeldLock) {
-        if self.contains(held.id) {
+        if self.contains_addr(held.addr) {
             return;
         }
 
@@ -221,8 +218,8 @@ impl fmt::Display for HeldLockDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "id={} class={} subclass={} addr={:#x} acquired_at={}",
-            self.held.id, self.held.class_id, self.subclass, self.held.addr, self.held.caller
+            "class={} subclass={} addr={:#x} acquired_at={}",
+            self.held.class_id, self.subclass, self.held.addr, self.held.caller
         )
     }
 }
@@ -272,12 +269,11 @@ std::thread_local! {
 pub trait KspinLockdepIf {
     fn collect_current_task_held_locks(snapshot: &mut HeldLockSnapshot);
     fn push_current_task_held_lock(held: HeldLock);
-    fn pop_current_task_held_lock(lock_id: u32);
+    fn pop_current_task_held_lock(lock_addr: usize);
     fn console_write_str(s: &str);
 }
 
 pub struct LockdepMap {
-    instance_id: AtomicU32,
     class_id: AtomicU32,
     class_key: AtomicPtr<Location<'static>>,
 }
@@ -294,16 +290,8 @@ impl LockdepMap {
 
     const fn new_with_class_key(class_key: *const Location<'static>) -> Self {
         Self {
-            instance_id: AtomicU32::new(0),
             class_id: AtomicU32::new(0),
             class_key: AtomicPtr::new(class_key as *mut Location<'static>),
-        }
-    }
-
-    pub fn lock_id(&self) -> Option<u32> {
-        match self.instance_id.load(Ordering::Acquire) {
-            0 => None,
-            id => Some(id),
         }
     }
 
@@ -328,10 +316,6 @@ pub struct PreparedAcquire {
 }
 
 impl PreparedAcquire {
-    pub fn lock_id(self) -> u32 {
-        self.state.instance_id
-    }
-
     pub fn class_id(self) -> u32 {
         self.state.class_id
     }
@@ -339,7 +323,6 @@ impl PreparedAcquire {
 
 #[derive(Clone, Copy)]
 struct LockdepState {
-    instance_id: u32,
     class_id: u32,
     caller: &'static Location<'static>,
 }
@@ -351,18 +334,20 @@ pub enum LockdepCheckError {
 }
 
 struct ClassRegistry {
-    keys: [usize; MAX_LOCKS],
+    keys: [usize; MAX_LOCK_CLASSES],
 }
 
 impl ClassRegistry {
     const fn new() -> Self {
         Self {
-            keys: [0; MAX_LOCKS],
+            keys: [0; MAX_LOCK_CLASSES],
         }
     }
 
     fn find_or_register(&mut self, key: usize) -> u32 {
-        let max_id = NEXT_CLASS_ID.load(Ordering::Acquire).min(MAX_LOCKS as u32);
+        let max_id = NEXT_CLASS_ID
+            .load(Ordering::Acquire)
+            .min(MAX_LOCK_CLASSES as u32);
 
         for class_id in 1..max_id {
             if self.keys[class_id as usize] == key {
@@ -372,8 +357,8 @@ impl ClassRegistry {
 
         let new_id = NEXT_CLASS_ID.fetch_add(1, Ordering::AcqRel);
         assert!(
-            (new_id as usize) < MAX_LOCKS,
-            "lockdep: exceeded maximum tracked lock classes ({MAX_LOCKS})"
+            (new_id as usize) < MAX_LOCK_CLASSES,
+            "lockdep: exceeded maximum tracked lock classes ({MAX_LOCK_CLASSES})"
         );
 
         self.keys[new_id as usize] = key;
@@ -391,13 +376,13 @@ impl ClassRegistry {
 }
 
 struct LockGraph {
-    reachability: [[u64; WORDS_PER_ROW]; MAX_LOCKS],
+    reachability: [[u64; WORDS_PER_ROW]; MAX_LOCK_CLASSES],
 }
 
 impl LockGraph {
     const fn new() -> Self {
         Self {
-            reachability: [[0; WORDS_PER_ROW]; MAX_LOCKS],
+            reachability: [[0; WORDS_PER_ROW]; MAX_LOCK_CLASSES],
         }
     }
 
@@ -429,10 +414,10 @@ impl LockGraph {
     fn check_can_acquire(
         &self,
         held_locks: &HeldLockSnapshot,
-        instance_id: u32,
+        addr: usize,
         class_id: u32,
     ) -> Result<(), LockdepCheckError> {
-        if held_locks.contains(instance_id) {
+        if held_locks.contains_addr(addr) {
             return Err(LockdepCheckError::Recursive);
         }
 
@@ -445,7 +430,9 @@ impl LockGraph {
     }
 
     fn record_edges(&mut self, held_before: &HeldLockSnapshot, class_id: u32) {
-        let max_id = NEXT_CLASS_ID.load(Ordering::Acquire).min(MAX_LOCKS as u32);
+        let max_id = NEXT_CLASS_ID
+            .load(Ordering::Acquire)
+            .min(MAX_LOCK_CLASSES as u32);
 
         for held in held_before.iter() {
             self.add_order(held.class_id, class_id, max_id);
@@ -461,7 +448,6 @@ impl LockGraph {
     ) {
         self.record_edges(held_before, state.class_id);
         held_locks.push(HeldLock {
-            id: state.instance_id,
             class_id: state.class_id,
             addr,
             caller: state.caller,
@@ -500,7 +486,6 @@ impl Drop for GraphGuard {
     }
 }
 
-static NEXT_INSTANCE_ID: AtomicU32 = AtomicU32::new(1);
 static NEXT_CLASS_ID: AtomicU32 = AtomicU32::new(1);
 
 static GRAPH_STATE: GraphState = GraphState {
@@ -517,35 +502,20 @@ fn with_graph<R>(f: impl FnOnce(&mut LockGraph) -> R) -> R {
     f(graph)
 }
 
-fn ensure_ids(
+fn ensure_class(
     map: &LockdepMap,
     class_key: *const Location<'static>,
     subclass: LockSubclass,
 ) -> LockdepState {
-    let existing_instance = map.instance_id.load(Ordering::Acquire);
     let existing_class = map.class_id.load(Ordering::Acquire);
-    if subclass == DEFAULT_LOCK_SUBCLASS && existing_instance != 0 && existing_class != 0 {
+    if subclass == DEFAULT_LOCK_SUBCLASS && existing_class != 0 {
         return LockdepState {
-            instance_id: existing_instance,
             class_id: existing_class,
             caller: class_key_to_location(class_key),
         };
     }
 
     let _guard = GraphGuard::acquire();
-
-    let instance_id = match map.instance_id.load(Ordering::Acquire) {
-        0 => {
-            let new_id = NEXT_INSTANCE_ID.fetch_add(1, Ordering::AcqRel);
-            assert!(
-                (new_id as usize) < MAX_LOCKS,
-                "lockdep: exceeded maximum tracked lock instances ({MAX_LOCKS})"
-            );
-            map.instance_id.store(new_id, Ordering::Release);
-            new_id
-        }
-        id => id,
-    };
 
     let key = match map.class_key.load(Ordering::Acquire) {
         ptr if ptr.is_null() => {
@@ -576,7 +546,6 @@ fn ensure_ids(
     };
 
     LockdepState {
-        instance_id,
         class_id,
         caller: class_key_to_location(class_key),
     }
@@ -672,8 +641,8 @@ fn push_current_task_held_lock(held: HeldLock) {
 }
 
 #[cfg(all(feature = "task-context", not(any(test, doctest))))]
-fn pop_current_task_held_lock(lock_id: u32) {
-    call_interface!(KspinLockdepIf::pop_current_task_held_lock, lock_id);
+fn pop_current_task_held_lock(lock_addr: usize) {
+    call_interface!(KspinLockdepIf::pop_current_task_held_lock, lock_addr);
 }
 
 #[cfg(any(
@@ -681,8 +650,8 @@ fn pop_current_task_held_lock(lock_id: u32) {
     doctest,
     all(not(target_os = "none"), not(feature = "task-context"))
 ))]
-fn pop_current_task_held_lock(lock_id: u32) {
-    with_current_task_held_locks_mut(|stack| stack.pop_checked(lock_id));
+fn pop_current_task_held_lock(lock_addr: usize) {
+    with_current_task_held_locks_mut(|stack| stack.pop_checked(lock_addr));
 }
 
 pub fn current_task_held_lock_snapshot() -> HeldLockSnapshot {
@@ -716,7 +685,7 @@ pub fn prepare_acquire_with_snapshot_nested(
     held_before: HeldLockSnapshot,
     subclass: LockSubclass,
 ) -> PreparedAcquire {
-    prepare_acquire_with_snapshot_result(map, caller, held_before, subclass).unwrap_or_else(
+    prepare_acquire_with_snapshot_result(map, addr, caller, held_before, subclass).unwrap_or_else(
         |(err, state)| panic_on_lockdep_error(err, lock_kind, state, addr, &held_before),
     )
 }
@@ -724,14 +693,14 @@ pub fn prepare_acquire_with_snapshot_nested(
 pub fn prepare_acquire_with_snapshot_checked(
     map: &LockdepMap,
     _lock_kind: &'static str,
-    _addr: usize,
+    addr: usize,
     caller: &'static Location<'static>,
     held_before: HeldLockSnapshot,
 ) -> Result<PreparedAcquire, LockdepCheckError> {
     prepare_acquire_with_snapshot_checked_nested(
         map,
         _lock_kind,
-        _addr,
+        addr,
         caller,
         held_before,
         DEFAULT_LOCK_SUBCLASS,
@@ -741,24 +710,25 @@ pub fn prepare_acquire_with_snapshot_checked(
 pub fn prepare_acquire_with_snapshot_checked_nested(
     map: &LockdepMap,
     _lock_kind: &'static str,
-    _addr: usize,
+    addr: usize,
     caller: &'static Location<'static>,
     held_before: HeldLockSnapshot,
     subclass: LockSubclass,
 ) -> Result<PreparedAcquire, LockdepCheckError> {
-    prepare_acquire_with_snapshot_result(map, caller, held_before, subclass)
+    prepare_acquire_with_snapshot_result(map, addr, caller, held_before, subclass)
         .map_err(|(err, _state)| err)
 }
 
 fn prepare_acquire_with_snapshot_result(
     map: &LockdepMap,
+    addr: usize,
     caller: &'static Location<'static>,
     held_before: HeldLockSnapshot,
     subclass: LockSubclass,
 ) -> Result<PreparedAcquire, (LockdepCheckError, LockdepState)> {
     let class_key = caller as *const Location<'static>;
-    let state = ensure_ids(map, class_key, subclass);
-    with_graph(|graph| graph.check_can_acquire(&held_before, state.instance_id, state.class_id))
+    let state = ensure_class(map, class_key, subclass);
+    with_graph(|graph| graph.check_can_acquire(&held_before, addr, state.class_id))
         .map_err(|err| (err, state))?;
     Ok(PreparedAcquire { state, held_before })
 }
@@ -770,7 +740,6 @@ fn panic_on_lockdep_error(
     addr: usize,
     held_before: &HeldLockSnapshot,
 ) -> ! {
-    let requested_id = state.instance_id;
     let requested_class = state.class_id;
     let requested_subclass = class_subclass(requested_class);
     let held_subclasses = held_lock_subclass_snapshot(held_before);
@@ -779,14 +748,12 @@ fn panic_on_lockdep_error(
             let (held_index, held) = held_before
                 .iter()
                 .enumerate()
-                .find(|(_, held)| held.id == requested_id)
+                .find(|(_, held)| held.addr == addr)
                 .or_else(|| held_before.iter().enumerate().next())
                 .expect("held lock snapshot unexpectedly empty");
             panic!(
-                "lockdep: recursive {lock_kind} acquisition detected\nrequested:\n  id={} \
-                 class={} subclass={} addr={:#x} acquire_at={}\nalready held:\n  {}\nheld \
-                 stack:\n{}",
-                requested_id,
+                "lockdep: recursive {lock_kind} acquisition detected\nrequested:\n  class={} \
+                 subclass={} addr={:#x} acquire_at={}\nalready held:\n  {}\nheld stack:\n{}",
                 requested_class,
                 requested_subclass,
                 addr,
@@ -810,11 +777,10 @@ fn panic_on_lockdep_error(
                 .or_else(|| held_before.iter().enumerate().next())
                 .expect("held lock snapshot unexpectedly empty");
             panic!(
-                "lockdep: lock order inversion detected\nrequested:\n  kind={} id={} class={} \
+                "lockdep: lock order inversion detected\nrequested:\n  kind={} class={} \
                  subclass={} addr={:#x} acquire_at={}\nconflicting held lock:\n  {}\nheld \
                  stack:\n{}",
                 lock_kind,
-                requested_id,
                 requested_class,
                 requested_subclass,
                 addr,
@@ -859,27 +825,22 @@ pub fn finish_acquire_with_stack(
 pub fn finish_acquire_task(prepared: PreparedAcquire, addr: usize) {
     with_graph(|graph| graph.record_edges(&prepared.held_before, prepared.state.class_id));
     push_current_task_held_lock(HeldLock {
-        id: prepared.state.instance_id,
         class_id: prepared.state.class_id,
         addr,
         caller: prepared.state.caller,
     });
 }
 
-pub fn release_from_stack(lock_id: Option<u32>, held_locks: &mut HeldLockStack) {
-    if let Some(lock_id) = lock_id {
-        held_locks.pop_checked(lock_id);
-    }
+pub fn release_from_stack(lock_addr: usize, held_locks: &mut HeldLockStack) {
+    held_locks.pop_checked(lock_addr);
 }
 
-pub fn release_task(lock_id: Option<u32>) {
-    if let Some(lock_id) = lock_id {
-        pop_current_task_held_lock(lock_id);
-    }
+pub fn release_task(lock_addr: usize) {
+    pop_current_task_held_lock(lock_addr);
 }
 
-pub fn force_release_task(map: &LockdepMap) {
-    release_task(map.lock_id());
+pub fn force_release_task(lock_addr: usize) {
+    release_task(lock_addr);
 }
 
 #[cfg(test)]
@@ -887,15 +848,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn held_lock_display_includes_id_class_addr_and_location() {
+    fn held_lock_display_includes_class_addr_and_location() {
         let held = HeldLock {
-            id: 7,
             class_id: 3,
             addr: 0x1234,
             caller: Location::caller(),
         };
         let rendered = held.to_string();
-        assert!(rendered.contains("id=7"));
         assert!(rendered.contains("class=3"));
         assert!(rendered.contains("addr=0x1234"));
         assert!(rendered.contains("acquired_at="));
@@ -915,13 +874,11 @@ mod tests {
         let caller = Location::caller();
         let mut snapshot = HeldLockSnapshot::new();
         snapshot.push(HeldLock {
-            id: 1,
             class_id: 2,
             addr: 0x10,
             caller,
         });
         snapshot.push(HeldLock {
-            id: 2,
             class_id: 3,
             addr: 0x20,
             caller,
@@ -934,8 +891,27 @@ mod tests {
             },
         }
         .to_string();
-        assert!(rendered.contains("[0] held: id=1"));
-        assert!(rendered.contains("[1] top: id=2"));
+        assert!(rendered.contains("[0] held: class=2"));
+        assert!(rendered.contains("[1] top: class=3"));
+    }
+
+    #[test]
+    fn dynamic_lock_instances_do_not_consume_class_slots() {
+        let locks: Vec<_> = (0..(MAX_LOCK_CLASSES + 128))
+            .map(|_| LockdepMap::new_dynamic())
+            .collect();
+
+        for lock in &locks {
+            let prepared = prepare_acquire_with_snapshot_checked(
+                lock,
+                "test lock",
+                lock as *const _ as usize,
+                Location::caller(),
+                HeldLockSnapshot::new(),
+            )
+            .unwrap();
+            assert_ne!(prepared.class_id(), 0);
+        }
     }
 
     #[test]
@@ -968,7 +944,6 @@ mod tests {
                 entries: {
                     let mut entries = [HeldLock::placeholder(); MAX_HELD_LOCK_SNAPSHOT];
                     entries[0] = HeldLock {
-                        id: parent_acquire.lock_id(),
                         class_id: parent_class,
                         addr: &parent as *const _ as usize,
                         caller: Location::caller(),
@@ -988,15 +963,14 @@ mod tests {
             &mut held_locks,
         );
         finish_acquire_with_stack(child_acquire, &child as *const _ as usize, &mut held_locks);
-        release_from_stack(child.lock_id(), &mut held_locks);
-        release_from_stack(parent.lock_id(), &mut held_locks);
+        release_from_stack(&child as *const _ as usize, &mut held_locks);
+        release_from_stack(&parent as *const _ as usize, &mut held_locks);
 
         let nested_held = HeldLockSnapshot {
             depth: 1,
             entries: {
                 let mut entries = [HeldLock::placeholder(); MAX_HELD_LOCK_SNAPSHOT];
                 entries[0] = HeldLock {
-                    id: child_acquire.lock_id(),
                     class_id: child_acquire.class_id(),
                     addr: &child as *const _ as usize,
                     caller: Location::caller(),

--- a/components/lockdep/src/state.rs
+++ b/components/lockdep/src/state.rs
@@ -19,6 +19,11 @@ const MAX_LOCKS: usize = 1024;
 const MAX_HELD_LOCKS: usize = 32;
 const MAX_HELD_LOCK_SNAPSHOT: usize = MAX_HELD_LOCKS;
 const WORDS_PER_ROW: usize = MAX_LOCKS.div_ceil(64);
+const LOCK_SUBCLASS_BITS: usize = 3;
+const LOCK_SUBCLASS_MASK: usize = (1 << LOCK_SUBCLASS_BITS) - 1;
+
+pub type LockSubclass = u32;
+pub const DEFAULT_LOCK_SUBCLASS: LockSubclass = 0;
 
 #[derive(Clone, Copy)]
 pub struct HeldLock {
@@ -193,21 +198,62 @@ impl fmt::Debug for HeldLockSnapshot {
     }
 }
 
-struct HeldLockStackDisplay<'a>(&'a HeldLockSnapshot);
+#[derive(Clone, Copy)]
+struct HeldLockSubclassSnapshot {
+    values: [LockSubclass; MAX_HELD_LOCK_SNAPSHOT],
+}
+
+impl HeldLockSubclassSnapshot {
+    fn get(&self, index: usize) -> LockSubclass {
+        self.values
+            .get(index)
+            .copied()
+            .unwrap_or(DEFAULT_LOCK_SUBCLASS)
+    }
+}
+
+struct HeldLockDisplay<'a> {
+    held: &'a HeldLock,
+    subclass: LockSubclass,
+}
+
+impl fmt::Display for HeldLockDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "id={} class={} subclass={} addr={:#x} acquired_at={}",
+            self.held.id, self.held.class_id, self.subclass, self.held.addr, self.held.caller
+        )
+    }
+}
+
+struct HeldLockStackDisplay<'a> {
+    snapshot: &'a HeldLockSnapshot,
+    subclasses: &'a HeldLockSubclassSnapshot,
+}
 
 impl fmt::Display for HeldLockStackDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.0.depth == 0 {
+        if self.snapshot.depth == 0 {
             return write!(f, "  (empty)");
         }
 
-        for (index, held) in self.0.iter().enumerate() {
-            let relation = if index + 1 == self.0.depth {
+        for (index, held) in self.snapshot.iter().enumerate() {
+            let relation = if index + 1 == self.snapshot.depth {
                 "top"
             } else {
                 "held"
             };
-            writeln!(f, "  [{}] {}: {}", index, relation, held)?;
+            writeln!(
+                f,
+                "  [{}] {}: {}",
+                index,
+                relation,
+                HeldLockDisplay {
+                    held: &held,
+                    subclass: self.subclasses.get(index),
+                }
+            )?;
         }
         Ok(())
     }
@@ -332,6 +378,15 @@ impl ClassRegistry {
 
         self.keys[new_id as usize] = key;
         new_id
+    }
+
+    fn subclass(&self, class_id: u32) -> LockSubclass {
+        self.keys
+            .get(class_id as usize)
+            .copied()
+            .filter(|key| *key != 0)
+            .map(class_key_subclass)
+            .unwrap_or(DEFAULT_LOCK_SUBCLASS)
     }
 }
 
@@ -462,11 +517,19 @@ fn with_graph<R>(f: impl FnOnce(&mut LockGraph) -> R) -> R {
     f(graph)
 }
 
-fn ensure_ids(map: &LockdepMap, class_key: *const Location<'static>) -> (u32, u32) {
+fn ensure_ids(
+    map: &LockdepMap,
+    class_key: *const Location<'static>,
+    subclass: LockSubclass,
+) -> LockdepState {
     let existing_instance = map.instance_id.load(Ordering::Acquire);
     let existing_class = map.class_id.load(Ordering::Acquire);
-    if existing_instance != 0 && existing_class != 0 {
-        return (existing_instance, existing_class);
+    if subclass == DEFAULT_LOCK_SUBCLASS && existing_instance != 0 && existing_class != 0 {
+        return LockdepState {
+            instance_id: existing_instance,
+            class_id: existing_class,
+            caller: class_key_to_location(class_key),
+        };
     }
 
     let _guard = GraphGuard::acquire();
@@ -484,26 +547,82 @@ fn ensure_ids(map: &LockdepMap, class_key: *const Location<'static>) -> (u32, u3
         id => id,
     };
 
-    let class_id = match map.class_id.load(Ordering::Acquire) {
+    let key = match map.class_key.load(Ordering::Acquire) {
+        ptr if ptr.is_null() => {
+            map.class_key
+                .store(class_key as *mut Location<'static>, Ordering::Release);
+            class_key
+        }
+        ptr => ptr as *const Location<'static>,
+    };
+
+    let default_class_id = match map.class_id.load(Ordering::Acquire) {
         0 => {
-            let key = match map.class_key.load(Ordering::Acquire) {
-                ptr if ptr.is_null() => {
-                    map.class_key
-                        .store(class_key as *mut Location<'static>, Ordering::Release);
-                    class_key
-                }
-                ptr => ptr as *const Location<'static>,
-            };
             // SAFETY: protected by the global graph spinlock above.
             let classes = unsafe { &mut *GRAPH_STATE.classes.get() };
-            let id = classes.find_or_register(key as usize);
+            let id = classes.find_or_register(pack_class_key(key, DEFAULT_LOCK_SUBCLASS));
             map.class_id.store(id, Ordering::Release);
             id
         }
         id => id,
     };
 
-    (instance_id, class_id)
+    let class_id = if subclass == DEFAULT_LOCK_SUBCLASS {
+        default_class_id
+    } else {
+        // SAFETY: protected by the global graph spinlock above.
+        let classes = unsafe { &mut *GRAPH_STATE.classes.get() };
+        classes.find_or_register(pack_class_key(key, subclass))
+    };
+
+    LockdepState {
+        instance_id,
+        class_id,
+        caller: class_key_to_location(class_key),
+    }
+}
+
+fn pack_class_key(class_key: *const Location<'static>, subclass: LockSubclass) -> usize {
+    let key = class_key as usize;
+    let subclass = subclass as usize;
+    assert!(
+        subclass <= LOCK_SUBCLASS_MASK,
+        "lockdep: subclass {subclass} exceeds maximum {}",
+        LOCK_SUBCLASS_MASK
+    );
+    assert_eq!(
+        key & LOCK_SUBCLASS_MASK,
+        0,
+        "lockdep: class key {key:#x} is not aligned enough to encode subclasses"
+    );
+    key | subclass
+}
+
+fn class_key_subclass(key: usize) -> LockSubclass {
+    (key & LOCK_SUBCLASS_MASK) as LockSubclass
+}
+
+fn class_subclass(class_id: u32) -> LockSubclass {
+    let _guard = GraphGuard::acquire();
+    // SAFETY: protected by the global graph spinlock above.
+    let classes = unsafe { &*GRAPH_STATE.classes.get() };
+    classes.subclass(class_id)
+}
+
+fn held_lock_subclass_snapshot(snapshot: &HeldLockSnapshot) -> HeldLockSubclassSnapshot {
+    let _guard = GraphGuard::acquire();
+    // SAFETY: protected by the global graph spinlock above.
+    let classes = unsafe { &*GRAPH_STATE.classes.get() };
+    let mut values = [DEFAULT_LOCK_SUBCLASS; MAX_HELD_LOCK_SNAPSHOT];
+    for (index, held) in snapshot.iter().enumerate() {
+        values[index] = classes.subclass(held.class_id);
+    }
+    HeldLockSubclassSnapshot { values }
+}
+
+fn class_key_to_location(class_key: *const Location<'static>) -> &'static Location<'static> {
+    // SAFETY: class keys are constructed from `Location::caller()` references.
+    unsafe { &*class_key }
 }
 
 #[cfg(any(
@@ -579,8 +698,26 @@ pub fn prepare_acquire_with_snapshot(
     caller: &'static Location<'static>,
     held_before: HeldLockSnapshot,
 ) -> PreparedAcquire {
-    prepare_acquire_with_snapshot_checked(map, lock_kind, addr, caller, held_before).unwrap_or_else(
-        |err| panic_on_lockdep_error(err, lock_kind, map, addr, caller, &held_before),
+    prepare_acquire_with_snapshot_nested(
+        map,
+        lock_kind,
+        addr,
+        caller,
+        held_before,
+        DEFAULT_LOCK_SUBCLASS,
+    )
+}
+
+pub fn prepare_acquire_with_snapshot_nested(
+    map: &LockdepMap,
+    lock_kind: &'static str,
+    addr: usize,
+    caller: &'static Location<'static>,
+    held_before: HeldLockSnapshot,
+    subclass: LockSubclass,
+) -> PreparedAcquire {
+    prepare_acquire_with_snapshot_result(map, caller, held_before, subclass).unwrap_or_else(
+        |(err, state)| panic_on_lockdep_error(err, lock_kind, state, addr, &held_before),
     )
 }
 
@@ -591,61 +728,105 @@ pub fn prepare_acquire_with_snapshot_checked(
     caller: &'static Location<'static>,
     held_before: HeldLockSnapshot,
 ) -> Result<PreparedAcquire, LockdepCheckError> {
-    let class_key = caller as *const Location<'static>;
-    let (instance_id, class_id) = ensure_ids(map, class_key);
-    with_graph(|graph| graph.check_can_acquire(&held_before, instance_id, class_id))?;
-    Ok(PreparedAcquire {
-        state: LockdepState {
-            instance_id,
-            class_id,
-            caller,
-        },
+    prepare_acquire_with_snapshot_checked_nested(
+        map,
+        _lock_kind,
+        _addr,
+        caller,
         held_before,
-    })
+        DEFAULT_LOCK_SUBCLASS,
+    )
+}
+
+pub fn prepare_acquire_with_snapshot_checked_nested(
+    map: &LockdepMap,
+    _lock_kind: &'static str,
+    _addr: usize,
+    caller: &'static Location<'static>,
+    held_before: HeldLockSnapshot,
+    subclass: LockSubclass,
+) -> Result<PreparedAcquire, LockdepCheckError> {
+    prepare_acquire_with_snapshot_result(map, caller, held_before, subclass)
+        .map_err(|(err, _state)| err)
+}
+
+fn prepare_acquire_with_snapshot_result(
+    map: &LockdepMap,
+    caller: &'static Location<'static>,
+    held_before: HeldLockSnapshot,
+    subclass: LockSubclass,
+) -> Result<PreparedAcquire, (LockdepCheckError, LockdepState)> {
+    let class_key = caller as *const Location<'static>;
+    let state = ensure_ids(map, class_key, subclass);
+    with_graph(|graph| graph.check_can_acquire(&held_before, state.instance_id, state.class_id))
+        .map_err(|err| (err, state))?;
+    Ok(PreparedAcquire { state, held_before })
 }
 
 fn panic_on_lockdep_error(
     err: LockdepCheckError,
     lock_kind: &str,
-    map: &LockdepMap,
+    state: LockdepState,
     addr: usize,
-    caller: &'static Location<'static>,
     held_before: &HeldLockSnapshot,
 ) -> ! {
-    let requested_id = map.lock_id().unwrap_or(0);
-    let requested_class = map.class_id().unwrap_or(0);
+    let requested_id = state.instance_id;
+    let requested_class = state.class_id;
+    let requested_subclass = class_subclass(requested_class);
+    let held_subclasses = held_lock_subclass_snapshot(held_before);
     match err {
-        LockdepCheckError::Recursive => panic!(
-            "lockdep: recursive {lock_kind} acquisition detected\nrequested:\n  id={} class={} \
-             addr={:#x} acquire_at={}\nalready held:\n  {}\nheld stack:\n{}",
-            requested_id,
-            requested_class,
-            addr,
-            caller,
-            held_before
+        LockdepCheckError::Recursive => {
+            let (held_index, held) = held_before
                 .iter()
-                .find(|held| held.id == requested_id)
-                .or_else(|| held_before.iter().next())
-                .expect("held lock snapshot unexpectedly empty"),
-            HeldLockStackDisplay(held_before)
-        ),
+                .enumerate()
+                .find(|(_, held)| held.id == requested_id)
+                .or_else(|| held_before.iter().enumerate().next())
+                .expect("held lock snapshot unexpectedly empty");
+            panic!(
+                "lockdep: recursive {lock_kind} acquisition detected\nrequested:\n  id={} \
+                 class={} subclass={} addr={:#x} acquire_at={}\nalready held:\n  {}\nheld \
+                 stack:\n{}",
+                requested_id,
+                requested_class,
+                requested_subclass,
+                addr,
+                state.caller,
+                HeldLockDisplay {
+                    held: &held,
+                    subclass: held_subclasses.get(held_index),
+                },
+                HeldLockStackDisplay {
+                    snapshot: held_before,
+                    subclasses: &held_subclasses,
+                }
+            )
+        }
         LockdepCheckError::OrderInversion => {
             emit_lockdep_marker("lockdep: lock order inversion detected\n");
-            let held = held_before
+            let (held_index, held) = held_before
                 .iter()
-                .find(|held| with_graph(|graph| graph.reaches(requested_class, held.class_id)))
-                .or_else(|| held_before.iter().next())
+                .enumerate()
+                .find(|(_, held)| with_graph(|graph| graph.reaches(requested_class, held.class_id)))
+                .or_else(|| held_before.iter().enumerate().next())
                 .expect("held lock snapshot unexpectedly empty");
             panic!(
                 "lockdep: lock order inversion detected\nrequested:\n  kind={} id={} class={} \
-                 addr={:#x} acquire_at={}\nconflicting held lock:\n  {}\nheld stack:\n{}",
+                 subclass={} addr={:#x} acquire_at={}\nconflicting held lock:\n  {}\nheld \
+                 stack:\n{}",
                 lock_kind,
                 requested_id,
                 requested_class,
+                requested_subclass,
                 addr,
-                caller,
-                held,
-                HeldLockStackDisplay(held_before)
+                state.caller,
+                HeldLockDisplay {
+                    held: &held,
+                    subclass: held_subclasses.get(held_index),
+                },
+                HeldLockStackDisplay {
+                    snapshot: held_before,
+                    subclasses: &held_subclasses,
+                }
             );
         }
     }
@@ -720,6 +901,15 @@ mod tests {
         assert!(rendered.contains("acquired_at="));
     }
 
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn subclass_support_does_not_increase_held_lock_state_size() {
+        assert_eq!(core::mem::size_of::<HeldLock>(), 24);
+        assert_eq!(core::mem::size_of::<HeldLockStack>(), 776);
+        assert_eq!(core::mem::size_of::<HeldLockSnapshot>(), 776);
+        assert_eq!(core::mem::size_of::<PreparedAcquire>(), 792);
+    }
+
     #[test]
     fn held_stack_display_marks_top_entry() {
         let caller = Location::caller();
@@ -737,8 +927,91 @@ mod tests {
             caller,
         });
 
-        let rendered = HeldLockStackDisplay(&snapshot).to_string();
+        let rendered = HeldLockStackDisplay {
+            snapshot: &snapshot,
+            subclasses: &HeldLockSubclassSnapshot {
+                values: [DEFAULT_LOCK_SUBCLASS; MAX_HELD_LOCK_SNAPSHOT],
+            },
+        }
+        .to_string();
         assert!(rendered.contains("[0] held: id=1"));
         assert!(rendered.contains("[1] top: id=2"));
+    }
+
+    #[test]
+    fn subclass_tracks_same_base_class_nesting() {
+        fn prepare_with_subclass(
+            map: &LockdepMap,
+            held_before: HeldLockSnapshot,
+            subclass: LockSubclass,
+        ) -> PreparedAcquire {
+            prepare_acquire_with_snapshot_checked_nested(
+                map,
+                "test lock",
+                map as *const _ as usize,
+                Location::caller(),
+                held_before,
+                subclass,
+            )
+            .unwrap()
+        }
+
+        let parent = LockdepMap::new_dynamic();
+        let child = LockdepMap::new_dynamic();
+        let parent_acquire =
+            prepare_with_subclass(&parent, HeldLockSnapshot::new(), DEFAULT_LOCK_SUBCLASS);
+        let parent_class = parent_acquire.class_id();
+        let child_acquire = prepare_with_subclass(
+            &child,
+            HeldLockSnapshot {
+                depth: 1,
+                entries: {
+                    let mut entries = [HeldLock::placeholder(); MAX_HELD_LOCK_SNAPSHOT];
+                    entries[0] = HeldLock {
+                        id: parent_acquire.lock_id(),
+                        class_id: parent_class,
+                        addr: &parent as *const _ as usize,
+                        caller: Location::caller(),
+                    };
+                    entries
+                },
+            },
+            1,
+        );
+        assert_eq!(class_subclass(parent_class), DEFAULT_LOCK_SUBCLASS);
+        assert_eq!(class_subclass(child_acquire.class_id()), 1);
+
+        let mut held_locks = HeldLockStack::new();
+        finish_acquire_with_stack(
+            parent_acquire,
+            &parent as *const _ as usize,
+            &mut held_locks,
+        );
+        finish_acquire_with_stack(child_acquire, &child as *const _ as usize, &mut held_locks);
+        release_from_stack(child.lock_id(), &mut held_locks);
+        release_from_stack(parent.lock_id(), &mut held_locks);
+
+        let nested_held = HeldLockSnapshot {
+            depth: 1,
+            entries: {
+                let mut entries = [HeldLock::placeholder(); MAX_HELD_LOCK_SNAPSHOT];
+                entries[0] = HeldLock {
+                    id: child_acquire.lock_id(),
+                    class_id: child_acquire.class_id(),
+                    addr: &child as *const _ as usize,
+                    caller: Location::caller(),
+                };
+                entries
+            },
+        };
+        let reverse = prepare_acquire_with_snapshot_checked_nested(
+            &parent,
+            "test lock",
+            &parent as *const _ as usize,
+            Location::caller(),
+            nested_held,
+            DEFAULT_LOCK_SUBCLASS,
+        );
+        assert!(matches!(reverse, Err(LockdepCheckError::OrderInversion)));
     }
 }

--- a/components/starry-process/src/process.rs
+++ b/components/starry-process/src/process.rs
@@ -202,22 +202,26 @@ impl Process {
     /// This method panics if the [`Process`] is the init process.
     pub fn exit(self: &Arc<Self>) {
         // TODO: child subreaper
-        let reaper = INIT_PROC.get().unwrap();
+        let reaper_proc = INIT_PROC.get().unwrap();
 
-        if Arc::ptr_eq(self, reaper) {
+        if Arc::ptr_eq(self, reaper_proc) {
             return;
         }
 
-        let mut children = self.children.lock(); // Acquire the lock first
-        self.is_zombie.store(true, Ordering::Release);
+        let reaper_parent = Arc::downgrade(reaper_proc);
+        let children = {
+            let mut children = self.children.lock();
+            core::mem::take(&mut *children)
+        };
 
-        let mut reaper_children = reaper.children.lock();
-        let reaper = Arc::downgrade(reaper);
-
-        for (pid, child) in core::mem::take(&mut *children) {
-            *child.parent.lock() = reaper.clone();
+        let mut reaper_children = reaper_proc.children.lock();
+        for (pid, child) in children {
+            *child.parent.lock() = reaper_parent.clone();
             reaper_children.insert(pid, child);
         }
+        drop(reaper_children);
+
+        self.is_zombie.store(true, Ordering::Release);
     }
 
     /// Frees a zombie [`Process`]. Removes it from the parent.

--- a/docs/docs/debug/check-mechanisms-summary.md
+++ b/docs/docs/debug/check-mechanisms-summary.md
@@ -93,6 +93,17 @@ task stack canary 用来发现任务栈溢出或栈底被破坏。
 - secondary CPU 的 boot/idle stack。
 - `plat-dyn` 场景下由平台提供的 secondary boot stack。
 
+平台栈边界需要按平台类型区分。静态平台可以使用 linker script 中的
+`boot_stack` / `boot_stack_top` 符号作为主 CPU boot stack 的边界；
+`plat-dyn` 下这两个符号只是兼容占位，并不表示真实栈空间。`plat-dyn`
+的主 CPU 和 secondary CPU boot stack 都应通过平台提供的
+`boot_stack_bounds(cpu_id)` 获取，否则 stack canary 写入可能落到内核镜像
+映射边界之外，在真实板卡上触发 page fault。
+
+当前 primary idle task 栈大小仍保留一个过渡策略：非 `lockdep` 构建保持
+原来的 16 KiB 栈，`lockdep` 构建使用 `TASK_STACK_SIZE`，以便为额外的
+检查路径保留栈空间。后续可以考虑统一 idle task 栈大小配置。
+
 主要入口：
 
 - `os/arceos/modules/axtask/src/task.rs`

--- a/os/StarryOS/kernel/src/pseudofs/lockdep-tmpfs-analysis.md
+++ b/os/StarryOS/kernel/src/pseudofs/lockdep-tmpfs-analysis.md
@@ -214,7 +214,8 @@ A first subclass prototype was implemented with the following shape:
 
 - `components/lockdep` accepts an acquire-time subclass and uses `(base class key, subclass)` as the effective dependency graph node.
 - `HeldLock`, `HeldLockStack`, `HeldLockSnapshot`, and `PreparedAcquire` do not store a separate subclass field; they continue to carry the effective dense `class_id`.
-- The class registry remains `[usize; MAX_LOCKS]`; subclass values are encoded in the low bits of the packed class key.
+- The class registry remains a fixed class table; subclass values are encoded
+  in the low bits of the packed class key.
 - Panic diagnostics recover subclass values from the class registry only for the requested lock and the held-lock snapshot being printed; the hot-path held-lock structures do not grow.
 - Existing lockdep acquire APIs remain default-subclass wrappers.
 - `ax-sync` exposes `LockdepMutexExt::lock_nested(subclass)`, which degrades to a normal lock when the `lockdep` feature is disabled.
@@ -283,3 +284,76 @@ stack=[0xffffffc080520000..0xffffffc080524000), expected magic=0x57acce1157acce1
 That is no longer a lockdep order report. It points at the 16 KiB primary idle
 task stack in `os/arceos/modules/axtask/src/run_queue.rs`. Further work should
 separate that stack-canary issue from the subclass implementation.
+
+## Instance identity cleanup
+
+The first lockdep implementation also assigned each `LockdepMap` a global
+monotonic `instance_id`. That was intended to model Linux lockdep's lock
+instance identity, but it is not equivalent to Linux's representation.
+
+Linux stores the actual `lockdep_map *` in each held lock and compares that
+pointer to match a concrete lock object. It does not allocate a finite global
+ID for every lock object. The previous Starry/ArceOS implementation therefore
+made dynamic lock objects consume the same `MAX_LOCKS` capacity used by lock
+classes and could panic after enough dynamic lock instances were observed.
+
+The revised implementation keeps instance identity but uses the lock object's
+address directly:
+
+- held-lock entries retain the concrete lock address;
+- recursive acquisition detection compares the requested lock address with
+  addresses already held by the task;
+- release tracking pops by lock address;
+- `LockdepMap` now stores only class-related state.
+
+This removes the artificial tracked-instance limit without increasing the
+held-lock stack or snapshot size. A regression test creates more dynamic lock
+objects than the class table size and verifies that they do not consume class
+slots merely by existing as distinct instances.
+
+## Follow-up: intermittent `test-shm-deadlock` timeout
+
+After the tmpfs and `starry-process` lockdep reports were fixed, another
+targeted QEMU run was observed to intermittently time out:
+
+```text
+TMPDIR=/tmp FEATURES=lockdep cargo xtask starry test qemu --arch riscv64 -g normal -c test-shm-deadlock
+```
+
+The reproduced failure pattern is:
+
+- the test prints the first seven PASS lines through `clone shmget_thread`;
+- it does not print the final `no deadlock detected` PASS line;
+- it does not print a lockdep report;
+- it does not print a panic or stack-canary diagnostic;
+- the QEMU harness eventually reports `QEMU timed out after 120s`.
+
+The relevant C test code is:
+
+```text
+usleep(SHM_RACE_USEC);
+g_running = 0;
+waitpid(tid1, &status, __WALL);
+waitpid(tid2, &status, __WALL);
+waitpid(tid3, &status, __WALL);
+CHECK(!g_deadlock_detected, "no deadlock detected");
+```
+
+This means the timeout happens before the final CHECK and most likely while the
+main test thread is waiting for one of the cloned workers to exit. The watchdog
+thread is not conclusive in this phase: once the main thread sets
+`g_running = 0`, the watchdog exits cleanly, so a worker stuck in the kernel can
+still lead to a harness timeout without printing the test's `FAIL` line.
+
+Two non-lockdep control runs of the same command without `FEATURES=lockdep`
+completed successfully. That is useful data, but not enough to prove that
+lockdep itself is the cause; enabling lockdep changes timing and can expose an
+existing SMP race or an exit/SHM cleanup issue.
+
+Current status:
+
+- this intermittent timeout is recorded as an unresolved follow-up;
+- it is not currently attributed to the lockdep subclass or instance-identity
+  changes;
+- the lockdep cleanup should proceed separately from this possible
+  `test-shm-deadlock` runtime race.

--- a/os/StarryOS/kernel/src/pseudofs/lockdep-tmpfs-analysis.md
+++ b/os/StarryOS/kernel/src/pseudofs/lockdep-tmpfs-analysis.md
@@ -1,0 +1,285 @@
+# StarryOS tmpfs lockdep analysis
+
+## Background
+
+Running:
+
+```text
+FEATURES=lockdep cargo xtask starry test qemu --arch riscv64
+```
+
+triggered:
+
+```text
+lockdep: lock order inversion detected
+requested:
+  kind=mutex id=98 class=23 addr=0xffffffc0807ce218 acquire_at=os/StarryOS/kernel/src/pseudofs/tmp.rs:174:43
+conflicting held lock:
+  id=94 class=23 addr=0xffffffc0807ce418 acquired_at=os/StarryOS/kernel/src/pseudofs/tmp.rs:388:39
+held stack:
+  [0] held: id=23 class=11 addr=0xffffffc080949e10 acquired_at=os/StarryOS/kernel/src/pseudofs/mod.rs:64:25
+  [1] top: id=94 class=23 addr=0xffffffc0807ce418 acquired_at=os/StarryOS/kernel/src/pseudofs/tmp.rs:388:39
+```
+
+The same lockdep report is also reproducible with a targeted Starry test case:
+
+```text
+TMPDIR=/tmp FEATURES=lockdep cargo xtask starry test qemu --arch riscv64 -g normal -c test-shm-deadlock
+```
+
+This note records the current analysis before changing `tmp.rs`.
+
+## Relevant code path
+
+The reported lock sites match the following flow in `os/StarryOS/kernel/src/pseudofs/tmp.rs`:
+
+1. `MemoryNode::create()` locks the parent directory entries at `tmp.rs:388`.
+2. While the parent `entries` mutex is still held, it calls `Inode::new()` at `tmp.rs:393`.
+3. If the new inode is a directory, `Inode::new()` locks the new directory's `entries` mutex at `tmp.rs:174` in order to insert `"."` and `".."`.
+
+So the immediate runtime nesting is:
+
+```text
+parent_dir.entries.lock() -> child_dir.entries.lock()
+```
+
+The extra held lock shown from `os/StarryOS/kernel/src/pseudofs/mod.rs:64` is `FS_CONTEXT.lock()` held by `mount_all()`. It is not the direct cause of the directory lock report.
+
+## Relation to `test-shm-deadlock`
+
+The targeted `test-shm-deadlock` reproduction does not change the reported lock sites:
+
+- requested lock: `os/StarryOS/kernel/src/pseudofs/tmp.rs:174`
+- conflicting held lock: `os/StarryOS/kernel/src/pseudofs/tmp.rs:388`
+- extra held lock: `os/StarryOS/kernel/src/pseudofs/mod.rs:64`
+
+So the reproduced failure still lands in pseudofs tmpfs initialization, not in the SysV shared-memory lock ordering that `test-shm-deadlock` is intended to exercise.
+
+That test case itself targets the `SHM_MANAGER -> ShmInner` ordering in `os/StarryOS/kernel/src/syscall/ipc/shm.rs`, but the observed panic happens earlier on the tmpfs path used during pseudofs setup, including mounts such as `/dev/shm`, `/tmp`, `/sys`, and the follow-up directory creation below `/sys/class/...`.
+
+Current implication:
+
+- the test command is a valid reproducer for the tmpfs lockdep report;
+- it is not, by itself, evidence of a new regression in the SHM lock ordering code path.
+
+## Why this is not a blanket same-class rule
+
+`lockdep` does not reject nested locks just because they have the same class. The order-inversion check in `components/lockdep/src/state.rs` only fails when the dependency graph already contains a reverse edge:
+
+```text
+requested_class -> held_class
+```
+
+Specifically:
+
+- `check_can_acquire()` reports `OrderInversion` only if `graph.reaches(class_id, held.class_id)` is true.
+- `record_edges()` adds edges from every currently held class to the newly acquired class.
+
+That means the report is not caused by a hardcoded "same class may never nest" rule.
+
+## Why this specific report is likely conservative
+
+The two directory-entry mutexes are different lock instances (`id=94` and `id=98`), but they ended up with the same `class=23`.
+
+That can happen because runtime-created `ax_sync::Mutex` values use `RawMutex::INIT`, which contains `LockdepMap::new_dynamic()` in `os/arceos/modules/axsync/src/mutex.rs`. For a dynamic lock map, the class key is filled lazily in `components/lockdep/src/state.rs:465-500` from the tracked caller of the first successful lock preparation.
+
+For `tmpfs` directory entry mutexes, many instances can therefore collapse into the same logical class when they are first observed at the same `entries.lock()` call site.
+
+Under that model, the reported stack is best read as:
+
+```text
+directory entries class -> directory entries class
+```
+
+rather than as proof that these two specific inode instances have already been seen in the reverse order.
+
+For the `create()` path alone, this makes the report look like a conservative false positive:
+
+- the code is taking a parent directory lock and then a freshly created child directory lock;
+- the two locks are different instances;
+- the class granularity is too coarse to express "same kind of lock, but different directory objects in a tree relationship".
+
+Another reason this looks conservative is that the requested lock at `tmp.rs:174` is taken only while initializing the brand-new child directory's `"."` and `".."` entries. In that local path:
+
+- the child inode has just been allocated;
+- the child directory is not yet published into the parent map until `tmp.rs:394`;
+- the nesting is structurally parent -> newly created child, not an arbitrary peer -> peer relation.
+
+That makes this specific stack a poor match for a real two-way deadlock cycle, even though the class-level graph cannot distinguish it from more general multi-directory nesting.
+
+## Why the report should still not be ignored
+
+Even if the current `create()` stack is likely conservative, `tmpfs` still needs an explicit multi-directory locking discipline.
+
+The current `MemoryNode::rename()` implementation no longer holds `src_dir.entries` while locking `dst_dir.entries`; it removes the source entry, drops the source directory lock, and then locks the destination directory. That avoids the immediate two-directory ABBA pattern, but it also leaves the operation non-atomic, as the local `TODO: atomicity` comment notes.
+
+If `rename()` is later made atomic by holding two directory-entry locks at once, it will need either:
+
+- a stable ordering rule, such as inode number or lock address order; or
+- explicit lockdep nesting/subclass annotations when the locking relation is structurally one-way.
+
+The current report is therefore useful as a design warning:
+
+- this exact `create()` stack is likely not a real ABBA instance;
+- the directory locking model still lacks a documented rule for nested directory-entry locks;
+- a future atomic `rename()` implementation can reintroduce a genuine two-directory inversion unless the order is explicit.
+
+## Current conclusion
+
+Current assessment:
+
+- The observed `tmp.rs:388 -> tmp.rs:174` report is more likely a conservative `lockdep` report than a true deadlock in that exact path.
+- It should not be dismissed as "pure lockdep noise", because the same directory-entry locking model already permits real two-directory inversion scenarios elsewhere.
+
+In short:
+
+```text
+This stack is likely a false positive for the specific create path,
+but it still exposes a real locking-design problem in tmpfs.
+```
+
+## Follow-up directions
+
+Reasonable next steps are:
+
+1. Remove avoidable nested directory-entry locking in `create()` if possible.
+2. Add a stable ordering rule for any path that may take two directory `entries` locks, especially `rename()`.
+3. Re-run the Starry `lockdep` configuration after the locking order is explicit.
+
+Possible implementation directions:
+
+- create the child inode without holding the parent `entries` lock across child directory initialization;
+- or introduce a stable order, such as ordering by inode number or lock address, before taking two directory-entry locks;
+- or extend lockdep expressiveness with nesting/subclass information if the filesystem intentionally relies on structured parent/child lock nesting.
+
+## Subclass experiment plan
+
+The next experiment should make lockdep able to distinguish an ordinary acquisition of a lock class from a structurally nested acquisition of the same base class.
+
+Proposed model:
+
+- keep the default lockdep behavior unchanged by treating all existing lock acquisitions as subclass `0`;
+- add an acquire-time subclass parameter, so a single lock instance can be acquired as `(base class, subclass)` depending on the current locking role;
+- use `(base class key, subclass)` as the effective dependency-graph node;
+- keep the held-lock stack and snapshots storing only the effective dense `class_id`;
+- encode the subclass in the class registry key rather than adding a field to `HeldLock`;
+- keep order checks real: if lockdep observes `subclass 0 -> subclass 1`, then a later `subclass 1 -> subclass 0` acquisition should still report an inversion.
+
+This is not a suppression mechanism. It is a way to express an intentional one-way nesting relation while preserving the ability to catch the reverse relation.
+
+The representation matters because `HeldLockStack`, `HeldLockSnapshot`, and
+`PreparedAcquire` are on hot paths and can affect task memory or function stack
+usage. The initial prototype stored `subclass: u32` directly in `HeldLock`,
+which increased each held-lock entry from 24 bytes to 32 bytes on 64-bit
+targets. With 32 fixed slots, that enlarged each per-task held-lock stack and
+each temporary held-lock snapshot by 256 bytes, and also enlarged
+`PreparedAcquire` by roughly the same amount.
+
+The revised model therefore treats `class_id` as the effective graph node for
+`(base class, subclass)`, but packs the subclass into the registry key:
+
+```text
+packed_class_key = (base Location pointer) | subclass
+```
+
+The dependency graph still uses dense class IDs, so `MAX_LOCKS` and the
+reachability matrix do not grow. The only extra capacity consumed is one class
+ID for each actually observed `(base class, subclass)` pair. A unit test locks
+the 64-bit sizes back to the previous layout:
+
+```text
+HeldLock          = 24 bytes
+HeldLockStack     = 776 bytes
+HeldLockSnapshot  = 776 bytes
+PreparedAcquire   = 792 bytes
+```
+
+For the first prototype:
+
+1. Extend `components/lockdep` with nested acquire helpers that accept a `subclass` argument.
+2. Keep existing `prepare_acquire_with_snapshot*()` APIs as wrappers using subclass `0`.
+3. Add an `ax-sync` helper for `Mutex` nested acquisition, because `lock_api::RawMutex::lock()` itself has no parameter slot for subclass.
+4. Use subclass `1` for tmpfs directory-entry locks that are taken while another directory-entry lock is already held, such as parent directory `entries` -> freshly created child directory `entries`.
+5. Add a regression test that verifies same-base-class `0 -> 1` is allowed, but `1 -> 0` is rejected after the forward edge has been recorded.
+
+Expected outcome:
+
+- the tmpfs `create()` path no longer trips lockdep solely because parent and child directory-entry mutexes share the same base class;
+- lockdep remains able to catch real reverse ordering of the same base class;
+- future atomic multi-directory operations, especially `rename()`, still need a stable lock ordering rule rather than relying on subclass annotations alone.
+
+## Experiment result
+
+A first subclass prototype was implemented with the following shape:
+
+- `components/lockdep` accepts an acquire-time subclass and uses `(base class key, subclass)` as the effective dependency graph node.
+- `HeldLock`, `HeldLockStack`, `HeldLockSnapshot`, and `PreparedAcquire` do not store a separate subclass field; they continue to carry the effective dense `class_id`.
+- The class registry remains `[usize; MAX_LOCKS]`; subclass values are encoded in the low bits of the packed class key.
+- Panic diagnostics recover subclass values from the class registry only for the requested lock and the held-lock snapshot being printed; the hot-path held-lock structures do not grow.
+- Existing lockdep acquire APIs remain default-subclass wrappers.
+- `ax-sync` exposes `LockdepMutexExt::lock_nested(subclass)`, which degrades to a normal lock when the `lockdep` feature is disabled.
+- `tmpfs` uses subclass `1` only for the child directory `entries` lock taken while `MemoryNode::create()` still holds the parent directory `entries` lock.
+  It also uses the same nested subclass for the child directory nonempty check in `unlink()`, where the parent directory `entries` lock is still held.
+
+The local verification for the revised packed-key implementation is:
+
+```text
+cargo test -p ax-lockdep
+cargo xtask clippy --package ax-lockdep
+cargo xtask clippy --package ax-sync
+cargo xtask clippy --package ax-kspin
+cargo xtask clippy --package starry-kernel
+```
+
+All of the above checks passed.
+
+The targeted reproducer was rerun:
+
+```text
+TMPDIR=/tmp FEATURES=lockdep cargo xtask starry test qemu --arch riscv64 -g normal -c test-shm-deadlock
+```
+
+The previous tmpfs report:
+
+```text
+os/StarryOS/kernel/src/pseudofs/tmp.rs:388 -> os/StarryOS/kernel/src/pseudofs/tmp.rs:174
+```
+
+did not recur after the subclass annotation.
+
+The run now stops later on a different lockdep report:
+
+```text
+lockdep: lock order inversion detected
+requested:
+  kind=spin lock ... acquire_at=components/starry-process/src/process.rs:214:51
+conflicting held lock:
+  ... acquired_at=components/starry-process/src/process.rs:211:42
+```
+
+That new report is in `Process::exit()`:
+
+```text
+self.children.lock() -> reaper.children.lock()
+```
+
+Both locks are `Process::children` locks from different `Process` instances and still use the default subclass `0`.
+
+Current experiment conclusion:
+
+- subclass support is sufficient to express the tmpfs parent -> freshly-created-child nesting and removes the original conservative report;
+- the broader lockdep run exposed another same-class multi-instance nesting in `starry-process`;
+- `Process::exit()` did not need a subclass annotation: it was restructured to move `self.children` into a local map, drop the `self.children` lock, then lock `reaper.children`;
+- after that restructuring, the `starry-process` lockdep report no longer appears in the targeted QEMU run.
+
+The current targeted QEMU run now reaches the shell and fails later on a
+different diagnostic:
+
+```text
+stack overflow/corruption detected for Task(1, "idle"):
+stack=[0xffffffc080520000..0xffffffc080524000), expected magic=0x57acce1157acce11
+```
+
+That is no longer a lockdep order report. It points at the 16 KiB primary idle
+task stack in `os/arceos/modules/axtask/src/run_queue.rs`. Further work should
+separate that stack-canary issue from the subclass implementation.

--- a/os/StarryOS/kernel/src/pseudofs/lockdep-tmpfs-analysis.md
+++ b/os/StarryOS/kernel/src/pseudofs/lockdep-tmpfs-analysis.md
@@ -357,3 +357,111 @@ Current status:
   changes;
 - the lockdep cleanup should proceed separately from this possible
   `test-shm-deadlock` runtime race.
+
+## Follow-up: FAT32/VFS lockdep visibility gap
+
+There is another possible filesystem lock-order issue that is not currently
+covered by lockdep.
+
+The relevant FAT32 implementation uses the project-local kernel spin lock:
+
+```text
+os/arceos/modules/axfs-ng/src/fs/fat/fs.rs:
+  use ax_kspin::{SpinNoPreempt as Mutex, SpinNoPreemptGuard as MutexGuard};
+```
+
+So the FAT filesystem lock is visible to lockdep when `ax-kspin/lockdep` is
+enabled.
+
+However, the VFS layer still imports the third-party `spin` crate directly:
+
+```text
+components/axfs-ng-vfs/src/lib.rs:
+  use spin::{Mutex, MutexGuard};
+```
+
+That dependency was already present when `axfs-ng-vfs` was imported as a
+subtree:
+
+```text
+components/axfs-ng-vfs/Cargo.toml:
+  spin = { version = "0.10", default-features = false, features = ["mutex"] }
+```
+
+`ax-kspin` is related but not identical to this external `spin` crate. Its
+`BaseSpinLock` is explicitly based on `spin::Mutex`, but it is a separate
+project-local implementation that adds kernel guard semantics and, with the
+current lockdep work, lockdep acquire/release hooks.
+
+This creates a lockdep blind spot:
+
+- `ax_kspin::SpinNoPreempt` locks are visible to lockdep;
+- `spin::Mutex` locks in `axfs-ng-vfs` are not visible to lockdep;
+- any dependency edge involving a VFS `spin::Mutex` therefore cannot be
+  recorded.
+
+The suspected FAT32/VFS ordering is:
+
+```text
+DirNode.cache lock -> FAT filesystem lock
+FAT filesystem lock -> DirNode.cache lock
+```
+
+The first direction can happen through the VFS cached lookup path:
+
+```text
+DirNode::lookup()
+  -> self.cache.lock()
+  -> lookup_locked()
+  -> self.ops.lookup(name)
+  -> FAT lookup takes the FAT filesystem lock
+```
+
+The second direction can happen through FAT directory iteration:
+
+```text
+FatDirNode::read_dir()
+  -> self.fs.lock()
+  -> dir_node.lookup_cache(name) / dir_node.insert_cache(name, entry)
+  -> DirNode.cache lock
+```
+
+This is a real ABBA-shaped ordering risk, not a subclass problem like the tmpfs
+parent/child entry lock report. The reason current lockdep may not report it is
+that one side of the pair, `DirNode.cache`, is outside the lockdep-visible lock
+set.
+
+Current implication:
+
+- a missing lockdep report does not prove the FAT32/VFS ordering is safe;
+- the current lockdep coverage is incomplete for `axfs-ng-vfs` internals;
+- FAT32-specific testing may also be absent from the normal Starry QEMU path,
+  so the code path might not be exercised even if all locks were visible.
+
+Future work should consider migrating suitable `axfs-ng-vfs` internal locks
+from third-party `spin::Mutex` to `ax_kspin`.
+
+That migration should not be treated as a mechanical rename. The lock type must
+match the context:
+
+- `SpinNoPreempt` is probably the first candidate for VFS cache locks if they
+  are only used in task context;
+- `SpinNoIrq` may be needed only for locks that can be taken from IRQ-enabled
+  contexts where interrupt-side reentry is possible;
+- `SpinRaw` should remain reserved for contexts that already guarantee the
+  necessary preemption/IRQ state externally.
+
+Before changing the VFS lock type, the code paths that access `DirNode.cache`
+and `DirEntry` user data should be checked for:
+
+- use from interrupt context;
+- use while holding block-device or filesystem implementation locks;
+- nested VFS operations through callbacks such as directory-entry sinks;
+- layout or dependency impact on `axfs-ng-vfs`, which is a component crate and
+  not only a StarryOS-local module.
+
+After such a migration, the FAT32/VFS ordering should be retested with a
+targeted FAT32 case. If lockdep then reports the suspected ABBA, the fix should
+be a real ordering change, not a subclass annotation: either avoid holding the
+VFS cache lock across filesystem backend callbacks, or establish a single
+stable order between VFS cache locks and filesystem implementation locks.

--- a/os/StarryOS/kernel/src/pseudofs/tmp.rs
+++ b/os/StarryOS/kernel/src/pseudofs/tmp.rs
@@ -2,7 +2,7 @@ use alloc::{borrow::ToOwned, string::String, sync::Arc};
 use core::{any::Any, borrow::Borrow, cmp::Ordering, task::Context, time::Duration};
 
 use ax_kspin::SpinNoIrq;
-use ax_sync::Mutex;
+use ax_sync::{LockdepMutexExt, Mutex};
 use axfs_ng_vfs::{
     DeviceId, DirEntry, DirEntrySink, DirNode, DirNodeOps, FileNode, FileNodeOps, Filesystem,
     FilesystemOps, Metadata, MetadataUpdate, NodeFlags, NodeOps, NodePermission, NodeType,
@@ -13,6 +13,8 @@ use hashbrown::HashMap;
 use slab::Slab;
 
 use crate::pseudofs::dummy_stat_fs;
+
+const TMPFS_DIR_ENTRIES_NESTED_SUBCLASS: ax_sync::LockSubclass = 1;
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 struct FileName(String);
@@ -45,6 +47,11 @@ where
     }
 }
 
+#[inline(always)]
+fn lock_tmpfs_nested<T: ?Sized>(mutex: &Mutex<T>) -> ax_sync::MutexGuard<'_, T> {
+    mutex.lock_nested(TMPFS_DIR_ENTRIES_NESTED_SUBCLASS)
+}
+
 impl Borrow<str> for FileName {
     fn borrow(&self) -> &str {
         &self.0
@@ -72,6 +79,7 @@ impl MemoryFs {
             None,
             NodeType::Directory,
             NodePermission::from_bits_truncate(0o755),
+            false,
         );
         *fs.root.lock() = Some(DirEntry::new_dir(
             |this| DirNode::new(MemoryNode::new(fs.clone(), root_ino, Some(this))),
@@ -140,6 +148,7 @@ impl Inode {
         parent: Option<u64>,
         node_type: NodeType,
         permission: NodePermission,
+        nested_dir_entries: bool,
     ) -> Arc<Inode> {
         let mut inodes = fs.inodes.lock();
         let entry = inodes.vacant_entry();
@@ -174,7 +183,11 @@ impl Inode {
         entry.insert(result.clone());
         drop(inodes);
         if let NodeContent::Dir(dir) = &result.content {
-            let mut entries = dir.entries.lock();
+            let mut entries = if nested_dir_entries {
+                lock_tmpfs_nested(&dir.entries)
+            } else {
+                dir.entries.lock()
+            };
             entries.insert(".".into(), InodeRef::new(fs.clone(), ino));
             entries.insert(
                 "..".into(),
@@ -405,7 +418,7 @@ impl DirNodeOps for MemoryNode {
         if entries.contains_key(name) {
             return Err(VfsError::AlreadyExists);
         }
-        let inode = Inode::new(&self.fs, Some(self.inode.ino), node_type, permission);
+        let inode = Inode::new(&self.fs, Some(self.inode.ino), node_type, permission, true);
         entries.insert(name.into(), InodeRef::new(self.fs.clone(), inode.ino));
         self.new_entry(name, node_type, inode)
     }
@@ -435,7 +448,7 @@ impl DirNodeOps for MemoryNode {
             };
             let inode = entry.get();
             if let NodeContent::Dir(DirContent { entries }) = &inode.content
-                && entries.lock().len() > 2
+                && lock_tmpfs_nested(entries).len() > 2
             {
                 return Err(VfsError::DirectoryNotEmpty);
             }

--- a/os/arceos/modules/axhal/src/mem.rs
+++ b/os/arceos/modules/axhal/src/mem.rs
@@ -110,9 +110,18 @@ pub fn memory_regions() -> impl Iterator<Item = PhysMemRegion> {
     ALL_MEM_REGIONS.iter().cloned()
 }
 
-#[cfg(plat_dyn)]
 pub fn boot_stack_bounds(cpu_id: usize) -> (VirtAddr, usize) {
-    axplat_dyn::boot_stack_bounds(cpu_id)
+    #[cfg(plat_dyn)]
+    {
+        axplat_dyn::boot_stack_bounds(cpu_id)
+    }
+    #[cfg(not(plat_dyn))]
+    {
+        let _ = cpu_id;
+        let bottom = addr_of_sym!(boot_stack);
+        let top = addr_of_sym!(boot_stack_top);
+        (VirtAddr::from(bottom), top - bottom)
+    }
 }
 
 /// Fills the `.bss` section with zeros.

--- a/os/arceos/modules/axruntime/src/lang_items.rs
+++ b/os/arceos/modules/axruntime/src/lang_items.rs
@@ -18,8 +18,11 @@ use core::panic::PanicInfo;
 fn panic(info: &PanicInfo) -> ! {
     match axpanic::enter_panic(current_cpu_id()) {
         axpanic::PanicDisposition::Primary => panic_primary(info),
+        // Once panic ownership is established, recursive and cross-CPU panic
+        // entries must avoid the full print/backtrace path and terminate the
+        // system instead of halting one CPU and risking test timeouts.
         axpanic::PanicDisposition::Recursive | axpanic::PanicDisposition::Concurrent => {
-            halt_current_cpu()
+            panic_shutdown()
         }
     }
 }
@@ -48,13 +51,6 @@ fn should_print_panic_backtrace() -> bool {
 
 fn panic_shutdown() -> ! {
     ax_hal::power::system_off()
-}
-
-fn halt_current_cpu() -> ! {
-    loop {
-        ax_hal::asm::halt();
-        core::hint::spin_loop();
-    }
 }
 
 fn current_cpu_id() -> usize {

--- a/os/arceos/modules/axsync/src/lib.rs
+++ b/os/arceos/modules/axsync/src/lib.rs
@@ -53,4 +53,4 @@ pub use ax_kspin::{SpinNoIrq as Mutex, SpinNoIrqGuard as MutexGuard};
 
 #[cfg(feature = "multitask")]
 #[cfg_attr(doc, doc(cfg(feature = "multitask")))]
-pub use self::mutex::{Mutex, MutexGuard, RawMutex};
+pub use self::mutex::{LockSubclass, LockdepMutexExt, Mutex, MutexGuard, RawMutex};

--- a/os/arceos/modules/axsync/src/lockdep.rs
+++ b/os/arceos/modules/axsync/src/lockdep.rs
@@ -1,7 +1,7 @@
 use core::panic::Location;
 
-pub(crate) use ax_kspin::lockdep::LockdepMap;
 use ax_kspin::lockdep::{self as common, HeldLockSnapshot, PreparedAcquire};
+pub(crate) use ax_kspin::lockdep::{LockSubclass, LockdepMap};
 
 use crate::mutex::RawMutex;
 
@@ -18,14 +18,15 @@ pub(crate) struct LockdepAcquire {
 impl LockdepAcquire {
     #[inline(always)]
     #[track_caller]
-    pub(crate) fn prepare(lock: &RawMutex, is_try: bool) -> Self {
+    pub(crate) fn prepare_nested(lock: &RawMutex, is_try: bool, subclass: LockSubclass) -> Self {
         let addr = lock as *const _ as *const () as usize;
-        let prepared = common::prepare_acquire_with_snapshot(
+        let prepared = common::prepare_acquire_with_snapshot_nested(
             &lock.lockdep,
             "mutex",
             addr,
             Location::caller(),
             current_held_locks(),
+            subclass,
         );
         let inner = ax_lockdep::Lockdep::prepare("mutex", addr, is_try, None);
         Self {

--- a/os/arceos/modules/axsync/src/lockdep.rs
+++ b/os/arceos/modules/axsync/src/lockdep.rs
@@ -47,7 +47,7 @@ impl LockdepAcquire {
 
 #[inline(always)]
 pub(crate) fn release(lock: &RawMutex) {
-    common::release_task(lock.lockdep.lock_id());
     let addr = lock as *const _ as *const () as usize;
+    common::release_task(addr);
     ax_lockdep::Lockdep::release("mutex", addr, None);
 }

--- a/os/arceos/modules/axsync/src/mutex.rs
+++ b/os/arceos/modules/axsync/src/mutex.rs
@@ -17,6 +17,37 @@ pub struct RawMutex {
     pub(crate) lockdep: crate::lockdep::LockdepMap,
 }
 
+#[cfg(not(feature = "lockdep"))]
+pub type LockSubclass = u32;
+#[cfg(feature = "lockdep")]
+pub type LockSubclass = crate::lockdep::LockSubclass;
+
+pub trait LockdepMutexExt<T: ?Sized> {
+    fn lock_nested(&self, subclass: LockSubclass) -> MutexGuard<'_, T>;
+}
+
+impl<T: ?Sized> LockdepMutexExt<T> for Mutex<T> {
+    #[inline(always)]
+    #[track_caller]
+    fn lock_nested(&self, subclass: LockSubclass) -> MutexGuard<'_, T> {
+        #[cfg(not(feature = "lockdep"))]
+        {
+            let _ = subclass;
+            self.lock()
+        }
+
+        #[cfg(feature = "lockdep")]
+        {
+            // SAFETY: `raw()` is used only to perform the matching raw lock; the
+            // returned guard owns the corresponding unlock.
+            let raw = unsafe { self.raw() };
+            raw.lock_nested(subclass);
+            // SAFETY: The raw mutex is locked, as required.
+            unsafe { self.make_guard_unchecked() }
+        }
+    }
+}
+
 impl RawMutex {
     /// Creates a [`RawMutex`].
     #[inline(always)]
@@ -67,57 +98,25 @@ unsafe impl lock_api::RawMutex for RawMutex {
     #[inline(always)]
     #[track_caller]
     fn lock(&self) {
-        might_sleep();
-        let current_id = current().id().as_u64();
         #[cfg(feature = "lockdep")]
-        let lockdep = crate::lockdep::LockdepAcquire::prepare(self, false);
+        self.lock_nested(ax_lockdep::DEFAULT_LOCK_SUBCLASS);
 
-        loop {
-            // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
-            // when called in a loop.
-            match self.owner_id.compare_exchange_weak(
-                0,
-                current_id,
-                Ordering::Acquire,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(owner_id) => {
-                    assert_ne!(
-                        owner_id, current_id,
-                        "Thread({current_id}) tried to acquire mutex it already owns.",
-                    );
-                    // Wait until someone hands off lock to me or lock is released
-                    self.wq
-                        .wait_until(|| self.is_owner(current_id) || !self.is_locked());
-                    // This check is necessary: some newcomers may race with a wakened one.
-                    if self.is_owner(current_id) {
-                        break;
-                    }
-                }
-            }
-        }
-
-        #[cfg(feature = "lockdep")]
-        lockdep.finish(true);
+        #[cfg(not(feature = "lockdep"))]
+        self.lock_plain();
     }
 
     #[inline(always)]
     #[track_caller]
     fn try_lock(&self) -> bool {
-        might_sleep();
-        let current_id = current().id().as_u64();
         #[cfg(feature = "lockdep")]
-        let lockdep = crate::lockdep::LockdepAcquire::prepare(self, true);
-        // The reason for using a strong compare_exchange is explained here:
-        // https://github.com/Amanieu/parking_lot/pull/207#issuecomment-575869107
-        let acquired = self
-            .owner_id
-            .compare_exchange(0, current_id, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok();
-        #[cfg(feature = "lockdep")]
-        lockdep.finish(acquired);
-        acquired
+        {
+            self.try_lock_nested(ax_lockdep::DEFAULT_LOCK_SUBCLASS)
+        }
+
+        #[cfg(not(feature = "lockdep"))]
+        {
+            self.try_lock_plain()
+        }
     }
 
     #[inline(always)]
@@ -138,7 +137,95 @@ unsafe impl lock_api::RawMutex for RawMutex {
 
     #[inline(always)]
     fn is_locked(&self) -> bool {
+        self.is_locked_inner()
+    }
+}
+
+impl RawMutex {
+    #[inline(always)]
+    #[track_caller]
+    #[cfg(not(feature = "lockdep"))]
+    fn lock_plain(&self) {
+        might_sleep();
+        let current_id = current().id().as_u64();
+        self.lock_after_prepare(current_id);
+    }
+
+    #[inline(always)]
+    fn lock_after_prepare(&self, current_id: u64) {
+        loop {
+            // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
+            // when called in a loop.
+            match self.owner_id.compare_exchange_weak(
+                0,
+                current_id,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(owner_id) => {
+                    assert_ne!(
+                        owner_id, current_id,
+                        "Thread({current_id}) tried to acquire mutex it already owns.",
+                    );
+                    // Wait until someone hands off lock to me or lock is released
+                    self.wq
+                        .wait_until(|| self.is_owner(current_id) || !self.is_locked_inner());
+                    // This check is necessary: some newcomers may race with a wakened one.
+                    if self.is_owner(current_id) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline(always)]
+    #[track_caller]
+    #[cfg(feature = "lockdep")]
+    fn lock_nested(&self, subclass: crate::lockdep::LockSubclass) {
+        might_sleep();
+        let current_id = current().id().as_u64();
+
+        let lockdep = crate::lockdep::LockdepAcquire::prepare_nested(self, false, subclass);
+        self.lock_after_prepare(current_id);
+        lockdep.finish(true);
+    }
+
+    #[inline(always)]
+    #[track_caller]
+    #[cfg(not(feature = "lockdep"))]
+    fn try_lock_plain(&self) -> bool {
+        might_sleep();
+        let current_id = current().id().as_u64();
+        self.try_lock_after_prepare(current_id)
+    }
+
+    #[inline(always)]
+    fn is_locked_inner(&self) -> bool {
         self.owner_id.load(Ordering::Acquire) != 0
+    }
+
+    #[inline(always)]
+    #[track_caller]
+    #[cfg(feature = "lockdep")]
+    fn try_lock_nested(&self, subclass: crate::lockdep::LockSubclass) -> bool {
+        might_sleep();
+        let current_id = current().id().as_u64();
+
+        let lockdep = crate::lockdep::LockdepAcquire::prepare_nested(self, true, subclass);
+        let acquired = self.try_lock_after_prepare(current_id);
+        lockdep.finish(acquired);
+        acquired
+    }
+
+    #[inline(always)]
+    fn try_lock_after_prepare(&self, current_id: u64) -> bool {
+        // The reason for using a strong compare_exchange is explained here:
+        // https://github.com/Amanieu/parking_lot/pull/207#issuecomment-575869107
+        self.owner_id
+            .compare_exchange(0, current_id, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
     }
 }
 

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -88,10 +88,10 @@ impl ax_kspin::lockdep::KspinLockdepIf for KspinLockdepIfImpl {
         }
     }
 
-    fn pop_current_task_held_lock(lock_id: u32) {
+    fn pop_current_task_held_lock(lock_addr: usize) {
         let _lockdep_irq_guard = IrqSave::new();
         if let Some(curr) = current_may_uninit() {
-            curr.with_held_locks(|stack| stack.pop_checked(lock_id));
+            curr.with_held_locks(|stack| stack.pop_checked(lock_addr));
         }
     }
 

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -98,6 +98,10 @@ impl ax_kspin::lockdep::KspinLockdepIf for KspinLockdepIfImpl {
     fn console_write_str(s: &str) {
         ax_hal::console::write_bytes(s.as_bytes());
     }
+
+    fn fatal() -> ! {
+        ax_hal::power::system_off()
+    }
 }
 
 /// Gets the current task, or returns [`None`] if the current task is not

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -55,16 +55,8 @@ const ARRAY_REPEAT_VALUE: MaybeUninit<&'static mut AxRunQueue> = MaybeUninit::un
 
 #[cfg(target_os = "none")]
 fn main_task_stack() -> TaskStack {
-    unsafe extern "C" {
-        fn boot_stack();
-        fn boot_stack_top();
-    }
-
-    TaskStack::borrowed(
-        VirtAddr::from(boot_stack as *const () as usize),
-        (boot_stack_top as *const () as usize) - (boot_stack as *const () as usize),
-        TASK_STACK_ALIGN,
-    )
+    let (stack_ptr, stack_size) = ax_hal::mem::boot_stack_bounds(this_cpu_id());
+    TaskStack::borrowed(stack_ptr, stack_size, TASK_STACK_ALIGN)
 }
 
 #[cfg(not(target_os = "none"))]

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -696,13 +696,12 @@ pub(crate) fn init() {
 
     // Create the `idle` task (not current task).
     // The idle task will run when there is no other runnable task.
-    // The idle task also runs trap/IRQ handling on architectures without a
-    // separate IRQ stack, so keep it aligned with regular task stack sizing.
-    let idle_task = TaskInner::new(
-        || crate::run_idle(),
-        "idle".into(),
-        ax_config::TASK_STACK_SIZE,
-    );
+    #[cfg(feature = "lockdep")]
+    const IDLE_TASK_STACK_SIZE: usize = ax_config::TASK_STACK_SIZE;
+    // TODO: Consider unifying the non-lockdep idle stack size with the task stack configuration.
+    #[cfg(not(feature = "lockdep"))]
+    const IDLE_TASK_STACK_SIZE: usize = 16384;
+    let idle_task = TaskInner::new(|| crate::run_idle(), "idle".into(), IDLE_TASK_STACK_SIZE);
     // idle task should be pinned to the current CPU.
     idle_task.set_cpumask(AxCpuMask::one_shot(cpu_id));
     IDLE_TASK.with_current(|i| {

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -696,10 +696,13 @@ pub(crate) fn init() {
 
     // Create the `idle` task (not current task).
     // The idle task will run when there is no other runnable task.
-    // Stack size of idle task should be large because traps/interrupts may happen in idle task,
-    // which need more stack space.
-    const IDLE_TASK_STACK_SIZE: usize = 16384;
-    let idle_task = TaskInner::new(|| crate::run_idle(), "idle".into(), IDLE_TASK_STACK_SIZE);
+    // The idle task also runs trap/IRQ handling on architectures without a
+    // separate IRQ stack, so keep it aligned with regular task stack sizing.
+    let idle_task = TaskInner::new(
+        || crate::run_idle(),
+        "idle".into(),
+        ax_config::TASK_STACK_SIZE,
+    );
     // idle task should be pinned to the current CPU.
     idle_task.set_cpumask(AxCpuMask::one_shot(cpu_id));
     IDLE_TASK.with_current(|i| {

--- a/test-suit/arceos/rust/task/lockdep/README.md
+++ b/test-suit/arceos/rust/task/lockdep/README.md
@@ -37,8 +37,8 @@ Dedicated baseline configs remain available for explicit manual runs:
 - Without `lockdep`, the app should end with:
   `All tests passed!`
 - In the `lockdep`-enabled path, the inversion banner is the success signal.
-  The app may panic immediately afterwards, which is expected for this
-  regression test and does not count as a failure.
+  Lockdep then emits its report through the fatal path and shuts the system down
+  without entering the panic handler.
 - If `lockdep` is enabled but no inversion is reported, the app panics with:
   `lockdep did not report an expected lock order inversion`
 
@@ -63,11 +63,13 @@ Typical output looks like:
 ```text
 lockdep: lock order inversion detected
 requested:
-  kind=spin lock id=23 class=9 addr=0xffffffc08029f9d0 acquire_at=test-suit/arceos/rust/task/lockdep/src/main.rs:127:16
+  kind=spin lock class=9 subclass=0 addr=0xffffffc08029f9d0 acquire_at=test-suit/arceos/rust/task/lockdep/src/main.rs:127:16
 conflicting held lock:
-  id=24 class=10 addr=0xffffffc08029f9f0 acquired_at=test-suit/arceos/rust/task/lockdep/src/main.rs:125:27
+  class=10 subclass=0 addr=0xffffffc08029f9f0 acquired_at=test-suit/arceos/rust/task/lockdep/src/main.rs:125:27
 held stack:
-  [0] top: id=24 class=10 addr=0xffffffc08029f9f0 acquired_at=test-suit/arceos/rust/task/lockdep/src/main.rs:125:27
+  [0] top: class=10 subclass=0 addr=0xffffffc08029f9f0 acquired_at=test-suit/arceos/rust/task/lockdep/src/main.rs:125:27
+
+lockdep fatal violation
 ```
 
 Enable `lockdep` on the ArceOS C-test batch to look for system-level lock order
@@ -84,15 +86,15 @@ Typical output from the current `httpclient` violation looks like:
 ```text
 Hello, ArceOS C HTTP client!
 lockdep: lock order inversion detected
-panicked at components/lockdep/src/state.rs:639:13:
-lockdep: lock order inversion detected
 requested:
-  kind=mutex id=16 class=12 addr=0xffffffc08030eef0 acquire_at=os/arceos/modules/axnet/src/smoltcp_impl/mod.rs:174:35
+  kind=mutex class=12 subclass=0 addr=0xffffffc08030eef0 acquire_at=os/arceos/modules/axnet/src/smoltcp_impl/mod.rs:174:35
 conflicting held lock:
-  id=12 class=9 addr=0xffffffc08030e300 acquired_at=os/arceos/modules/axnet/src/smoltcp_impl/mod.rs:173:36
+  class=9 subclass=0 addr=0xffffffc08030e300 acquired_at=os/arceos/modules/axnet/src/smoltcp_impl/mod.rs:173:36
 held stack:
-  [0] held: id=18 class=13 addr=0xffffffc08030d120 acquired_at=os/arceos/modules/axnet/src/smoltcp_impl/mod.rs:172:32
-  [1] top: id=12 class=9 addr=0xffffffc08030e300 acquired_at=os/arceos/modules/axnet/src/smoltcp_impl/mod.rs:173:36
+  [0] held: class=13 subclass=0 addr=0xffffffc08030d120 acquired_at=os/arceos/modules/axnet/src/smoltcp_impl/mod.rs:172:32
+  [1] top: class=9 subclass=0 addr=0xffffffc08030e300 acquired_at=os/arceos/modules/axnet/src/smoltcp_impl/mod.rs:173:36
+
+lockdep fatal violation
 ```
 
 ## Common commands


### PR DESCRIPTION
  ## Summary

  Add lockdep subclass support so intentional nested acquisitions of the same base lock class can be represented without
  growing the hot-path held-lock structures.

  This PR also fixes several issues found while validating StarryOS with lockdep enabled:

  - encode subclasses into the lock class key instead of adding fields to `HeldLock`
  - keep `HeldLock`, `HeldLockStack`, `HeldLockSnapshot`, and `PreparedAcquire` at their previous sizes
  - add nested mutex acquisition support through `ax-sync`
  - mark tmpfs parent-directory -> child-directory entry locking as a nested acquisition
  - restructure `starry-process` exit handling to avoid nested `children` locks
  - use lock object addresses as instance identity instead of allocating global instance IDs
  - make lockdep fatal reporting avoid panic recursion and shut down directly
  - size the primary idle stack consistently with `TASK_STACK_SIZE`
  - document tmpfs, starry-process, idle-stack, FAT32/VFS, and remaining lockdep follow-ups

  ## Notes

  The tmpfs report was a conservative same-class report for a parent directory lock followed by a freshly created child
  directory lock. Subclassing is used only for that structurally nested case.

  The `starry-process` report was handled differently: the code now avoids holding two `Process::children` locks at once
  instead of annotating it as nested.

  The FAT32/VFS lock-order risk is documented but not fixed here. Current lockdep cannot fully observe it because `axfs-ng-
  vfs` still uses third-party `spin::Mutex` for internal VFS locks.
