### PR TITLE
chore(arceos): bump crate versions and update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "ax-api"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "ax-alloc",
  "ax-config",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "ax-feat"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "ax-alloc",
  "ax-config",
@@ -1070,7 +1070,7 @@ version = "0.4.7"
 
 [[package]]
 name = "ax-libc"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "ax-errno",
  "ax-feat",
@@ -1088,7 +1088,7 @@ name = "ax-lockdep"
 version = "0.1.0"
 dependencies = [
  "ax-crate-interface",
- "sbi-rt",
+ "sbi-rt 0.0.3",
 ]
 
 [[package]]
@@ -1343,7 +1343,7 @@ dependencies = [
  "log",
  "riscv 0.16.0",
  "riscv_goldfish",
- "sbi-rt",
+ "sbi-rt 0.0.3",
  "some-serial",
 ]
 
@@ -1360,7 +1360,7 @@ dependencies = [
  "dw_uart_rs",
  "log",
  "riscv 0.16.0",
- "sbi-rt",
+ "sbi-rt 0.0.3",
 ]
 
 [[package]]
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "ax-std"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "ax-api",
  "ax-errno",
@@ -1747,7 +1747,7 @@ dependencies = [
  "log",
  "riscv 0.14.0",
  "riscv_goldfish",
- "sbi-rt",
+ "sbi-rt 0.0.3",
  "some-serial",
 ]
 
@@ -1764,7 +1764,7 @@ dependencies = [
  "log",
  "riscv 0.14.0",
  "riscv_goldfish",
- "sbi-rt",
+ "sbi-rt 0.0.3",
  "uart_16550 0.4.0",
 ]
 
@@ -6535,8 +6535,8 @@ dependencies = [
  "riscv-decode",
  "riscv-h",
  "rustsbi",
- "sbi-rt",
- "sbi-spec",
+ "sbi-rt 0.0.3",
+ "sbi-spec 0.0.7",
  "tock-registers 0.10.1",
 ]
 
@@ -6816,13 +6816,13 @@ dependencies = [
 
 [[package]]
 name = "rustsbi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c13763120794ed11d64bac885fb31d384ae385c3287b0697711b97affbf8ab"
+checksum = "0da89e7936845ca69a9c12307862828180f10e55cc3b313ace4a0efee5f20622"
 dependencies = [
  "rustsbi-macros",
- "sbi-rt",
- "sbi-spec",
+ "sbi-rt 0.0.4",
+ "sbi-spec 0.0.9",
 ]
 
 [[package]]
@@ -6881,7 +6881,16 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbaa69be1eedc61c426e6d489b2260482e928b465360576900d52d496a58bd0"
 dependencies = [
- "sbi-spec",
+ "sbi-spec 0.0.7",
+]
+
+[[package]]
+name = "sbi-rt"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f7bf85822c8b453d7e3fca7de39684032f5c06c1ed338ad8d47f4a79c1d49a"
+dependencies = [
+ "sbi-spec 0.0.9",
 ]
 
 [[package]]
@@ -6889,6 +6898,15 @@ name = "sbi-spec"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
+
+[[package]]
+name = "sbi-spec"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "785b91fcc41c7426fc07510be49ed1db44f002b45d45c175ec7f155c3cd447a9"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "schannel"
@@ -7391,7 +7409,7 @@ dependencies = [
  "quote",
  "ranges-ext",
  "rgb",
- "sbi-rt",
+ "sbi-rt 0.0.3",
  "smccc",
  "some-serial",
  "somehal-macros",
@@ -8156,7 +8174,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8204,7 +8222,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8213,7 +8231,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -9331,9 +9349,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/os/arceos/api/arceos_api/Cargo.toml
+++ b/os/arceos/api/arceos_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-api"
-version = "0.5.12"
+version = "0.5.13"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]

--- a/os/arceos/api/axfeat/Cargo.toml
+++ b/os/arceos/api/axfeat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-feat"
-version = "0.5.12"
+version = "0.5.13"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]

--- a/os/arceos/ulib/axlibc/Cargo.toml
+++ b/os/arceos/ulib/axlibc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-libc"
-version = "0.5.11"
+version = "0.5.12"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = [

--- a/os/arceos/ulib/axstd/Cargo.toml
+++ b/os/arceos/ulib/axstd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-std"
-version = "0.5.11"
+version = "0.5.12"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = [


### PR DESCRIPTION
## Summary
- Bump `ax-api`/`ax-feat` from 0.5.12 to 0.5.13
- Bump `ax-libc`/`ax-std` from 0.5.11 to 0.5.12
- Update `rustsbi` 0.4.0 → 0.4.1, `winnow` 1.0.2 → 1.0.3 via Cargo.lock

## Test plan
- [ ] Verify `cargo check` passes for arceos targets
- [ ] Verify existing CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)