### PR TITLE
chore(arceos): bump ax-driver version to 0.5.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "ax-driver"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "ax-alloc",
  "ax-config",

--- a/os/arceos/modules/axdriver/Cargo.toml
+++ b/os/arceos/modules/axdriver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-driver"
-version = "0.5.12"
+version = "0.5.13"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = [


### PR DESCRIPTION
## Summary
- Bump `ax-driver` crate version from `0.5.12` to `0.5.13`

## Test plan
- [ ] Verify crate version consistency in `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)