### PR TITLE
chore(arceos): bump ax-driver-block version to 0.3.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ version = "0.3.12"
 
 [[package]]
 name = "ax-driver-block"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "ax-driver-base",
  "bcm2835-sdhci",

--- a/components/axdriver_crates/axdriver_block/Cargo.toml
+++ b/components/axdriver_crates/axdriver_block/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ax-driver-block"
 edition.workspace = true
-version = "0.3.11"
+version = "0.3.12"
 repository = "https://github.com/rcore-os/tgoskits"
 authors = ["Yuekai Jia <equation618@gmail.com>", "朝倉水希 <asakuramizu111@gmail.com>", "Yu Chen <yuchen@tsinghua.edu.cn>"]
 description = "Common traits and types for block storage drivers"


### PR DESCRIPTION
## Summary
- Bump `ax-driver-block` crate version from `0.3.11` to `0.3.12`

## Test plan
- [ ] Verify crate version consistency in `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)