### PR TITLE
chore: bump crate versions and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "ax-runtime"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "ax-alloc",
  "ax-config",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "ax-task"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "ax-config",
  "ax-cpumask",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "axklib"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "ax-errno",
  "ax-memory-addr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,8 +6535,8 @@ dependencies = [
  "riscv-decode",
  "riscv-h",
  "rustsbi",
- "sbi-rt 0.0.3",
- "sbi-spec 0.0.7",
+ "sbi-rt 0.0.4",
+ "sbi-spec 0.0.9",
  "tock-registers 0.10.1",
 ]
 

--- a/components/axklib/Cargo.toml
+++ b/components/axklib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axklib"
-version = "0.5.6"
+version = "0.5.7"
 edition.workspace = true
 authors = ["周睿 <zrufo747@outlook.com>"]
 description = "Small kernel-helper abstractions used across the microkernel"

--- a/components/riscv_vcpu/Cargo.toml
+++ b/components/riscv_vcpu/Cargo.toml
@@ -32,8 +32,8 @@ riscv = { version = "0.14.0", features = ["s-mode"] }
 riscv-h = { workspace = true }
 riscv-decode = "0.2.3"
 rustsbi = { version = "0.4.0", features = ["forward"] }
-sbi-rt = { version = "0.0.3", features = ["integer-impls"] }
-sbi-spec = { version = "0.0.7", features = ["legacy"] }
+sbi-rt = { version = "0.0.4", features = ["integer-impls"] }
+sbi-spec = { version = "0.0.9", features = ["legacy"] }
 tock-registers = "0.10"
 memoffset = { version = ">=0.6.5", features = ["unstable_const"] }
 

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-runtime"
-version = "0.5.12"
+version = "0.5.13"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 name = "ax-task"
 repository = "https://github.com/rcore-os/tgoskits"
-version = "0.5.12"
+version = "0.5.13"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- Bump `ax-runtime` and `ax-task` from 0.5.12 to 0.5.13
- Bump `axklib` from 0.5.6 to 0.5.7
- Update `sbi-rt` to 0.0.4 and `sbi-spec` to 0.0.9 in `riscv_vcpu`

## Test plan
- [ ] Verify `cargo check` passes with updated dependencies
- [ ] Confirm `sbi-rt` 0.0.4 and `sbi-spec` 0.0.9 API compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)