### PR TITLE
chore: bump ax-plat-riscv64-sg2002 to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "ax-plat-riscv64-sg2002"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ax-config-macros",
  "ax-cpu",

--- a/components/axplat_crates/platforms/axplat-riscv64-sg2002/Cargo.toml
+++ b/components/axplat_crates/platforms/axplat-riscv64-sg2002/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-plat-riscv64-sg2002"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
     "Luoyuan Xiao <xiaoluoyuan@163.com>",
     "Zechen Peng <927068267@qq.com>",


### PR DESCRIPTION
## Summary
- Update `ax-plat-riscv64-sg2002` version from 0.3.1 to 0.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)