### PR TITLE
chore: bump ax-page-table-entry to 0.8.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "ax-page-table-entry"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "ax-memory-addr",

--- a/components/page_table_multiarch/page_table_entry/Cargo.toml
+++ b/components/page_table_multiarch/page_table_entry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ax-page-table-entry"
 description = "Page table entry definition for various hardware architectures"
-version = "0.8.8"
+version = "0.8.9"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]


### PR DESCRIPTION
## Summary
- Bump `ax-page-table-entry` crate version from 0.8.8 to 0.8.9

## Test plan
- [ ] Verify `cargo build` succeeds
- [ ] Verify `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)