### PR TITLE
fix(ci): unblock release-plz and starry checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,7 +334,7 @@ axvisor = { version = "0.5.6", path = "os/axvisor" }
 axvisor_api = { version = "0.5.8", path = "components/axvisor_api" }
 axvisor_api_proc = { version = "0.5.7", path = "components/axvisor_api/axvisor_api_proc" }
 axvm = { version = "0.5.7", path = "components/axvm", default-features = false }
-axvmconfig = { version = "0.5.0", path = "components/axvmconfig" }
+axvmconfig = { version = "0.5.0", path = "components/axvmconfig", default-features = false }
 bitmap-allocator = { version = "0.4.5", path = "components/bitmap-allocator" }
 bwbench-client = { version = "0.3.1", path = "os/arceos/tools/bwbench_client" }
 define-simple-traits = { version = "0.3.4", path = "components/crate_interface/test_crates/define-simple-traits" }

--- a/components/axdevice/Cargo.toml
+++ b/components/axdevice/Cargo.toml
@@ -22,7 +22,7 @@ spin = "0.10"
 # System independent crates provided by ArceOS.
 ax-errno = { workspace = true }
 ax-memory-addr = { workspace = true }
-axvmconfig = { path = "../axvmconfig", default-features = false }
+axvmconfig = { workspace = true, default-features = false }
 axaddrspace = { workspace = true }
 axdevice_base = { workspace = true }
 range-alloc-arceos = { workspace = true }

--- a/components/axdevice_base/Cargo.toml
+++ b/components/axdevice_base/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 # ArceOS and AxVisor crates.
 axaddrspace = { workspace = true }
 ax-errno = { workspace = true }
-axvmconfig = { path = "../axvmconfig", default-features = false }
+axvmconfig = { workspace = true, default-features = false }
 [dev-dependencies]
 
 [package.metadata.docs.rs]

--- a/components/axvm/Cargo.toml
+++ b/components/axvm/Cargo.toml
@@ -34,7 +34,7 @@ axaddrspace = { workspace = true }
 axvisor_api = { workspace = true }
 axdevice = { workspace = true }
 axdevice_base = { workspace = true }
-axvmconfig = { path = "../axvmconfig", default-features = false }
+axvmconfig = { workspace = true, default-features = false }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_vcpu = { workspace = true }
 [target.'cfg(target_arch = "riscv64")'.dependencies]

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -406,7 +406,7 @@ impl DeviceOps for Card0 {
         }
     }
 
-    fn mmap(&self, _offset: u64) -> DeviceMmap {
+    fn mmap(&self, _offset: u64, _length: u64) -> DeviceMmap {
         // Map the whole axdisplay scanout region. All dumb buffers
         // share this backing in the F+G+H+I scope.
         if !ax_display::has_display() {


### PR DESCRIPTION
## 问题

`release-plz release` 在发布 `axdevice_base` 时会因为 `axvmconfig` 依赖只有本地 `path`、没有版本号而失败。`axdevice` 和 `axvm` 中也存在同样写法，后续发布到这些 crate 时会遇到相同问题。

PR CI 还暴露了 `Test starry riscv64 qemu / run_container` 的构建期失败：`DeviceOps::mmap` trait 已经带有 `length` 参数，但 `card0` 的实现仍然是旧签名，导致 `starry-kernel` 编译时报 `E0050`。

## 修改

- 在 workspace 依赖中为 `axvmconfig` 保留 `version = "0.5.0"`，并统一关闭默认特性。
- 将 `axdevice_base`、`axdevice`、`axvm` 中的 `axvmconfig` 改为继承 workspace 依赖。
- 将 `Card0` 的 `mmap` 实现签名同步为 `fn mmap(&self, _offset: u64, _length: u64) -> DeviceMmap`，与 `DeviceOps` trait 以及其它设备实现保持一致。

## 逻辑

Cargo 在打包发布时会从 workspace 继承 `axvmconfig` 的版本号，同时保留这些 no-std/虚拟化相关 crate 原本关闭默认特性的行为，避免 release-plz 因 path-only dependency 中断。

`card0` 当前 mmap 逻辑映射整块 display scanout 区域，和 `fb` 等设备一样暂不使用调用方传入的长度；因此只需要补齐 `_length` 参数即可恢复 trait 实现匹配，不改变现有映射行为。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry build --arch riscv64`

另外尝试运行过 `cargo xtask starry test qemu --arch riscv64`：Starry riscv64 release 构建已通过并进入 qemu 用例，原 CI 的 `E0050` 编译错误未再出现；完整 qemu 套件因会继续进入网络/rootfs 相关长用例，本地未等待全量结束。