### PR TITLE
chore: remove circular dev-deps, bump crate versions, configure release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,7 +38,6 @@ jobs:
           config: release-plz.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
     name: Release-plz PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,6 @@ dependencies = [
 name = "ax-allocator"
 version = "0.5.0"
 dependencies = [
- "ax-allocator",
  "ax-errno",
  "ax_slab_allocator",
  "bitmap-allocator",
@@ -1097,7 +1096,6 @@ version = "0.5.12"
 dependencies = [
  "ax-crate-interface",
  "ax-kspin",
- "ax-log",
  "axpanic",
  "cfg-if",
  "chrono",
@@ -1482,7 +1480,6 @@ version = "0.5.13"
 dependencies = [
  "ax-kspin",
  "ax-lockdep",
- "ax-sync",
  "ax-task",
  "fastrand",
  "lock_api",
@@ -1504,7 +1501,6 @@ dependencies = [
  "ax-memory-addr",
  "ax-percpu",
  "ax-sched",
- "ax-task",
  "ax-timer-list",
  "axpoll",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,7 @@ members = [
 
 [workspace.dependencies]
 # Local workspace crates
-aarch64_sysreg = { version = "0.3.6", path = "components/aarch64_sysreg" }
+aarch64_sysreg = { version = "0.3.7", path = "components/aarch64_sysreg" }
 arceos-affinity = { version = "0.3.1", path = "test-suit/arceos/rust/task/affinity" }
 arceos-display = { version = "0.3.1", path = "test-suit/arceos/rust/display" }
 arceos-exception = { version = "0.3.1", path = "test-suit/arceos/rust/exception" }
@@ -229,7 +229,7 @@ arceos-net-httpserver = { version = "0.3.1", path = "test-suit/arceos/rust/net/h
 arceos-net-udpserver = { version = "0.3.1", path = "test-suit/arceos/rust/net/udpserver" }
 arceos-parallel = { version = "0.3.1", path = "test-suit/arceos/rust/task/parallel" }
 arceos-priority = { version = "0.3.1", path = "test-suit/arceos/rust/task/priority" }
-arceos-rust = { version = "0.1", path = "os/arceos/ulib/arceos-rust", default-features = false }
+arceos-rust = { version = "0.1.1", path = "os/arceos/ulib/arceos-rust", default-features = false }
 arceos-sleep = { version = "0.3.1", path = "test-suit/arceos/rust/task/sleep" }
 arceos-tls = { version = "0.3.1", path = "test-suit/arceos/rust/task/tls" }
 arceos-wait-queue = { version = "0.3.1", path = "test-suit/arceos/rust/task/wait_queue" }
@@ -239,15 +239,15 @@ arm_vgic = { version = "0.4.7", path = "components/arm_vgic" }
 ax-alloc = { version = "0.7.0", path = "os/arceos/modules/axalloc" }
 ax-allocator = { version = "0.5.0", path = "components/axallocator" }
 ax-api = { version = "0.5.14", path = "os/arceos/api/arceos_api" }
-ax-arm-pl011 = { version = "0.3.6", path = "components/arm_pl011" }
-ax-arm-pl031 = { version = "0.4.5", path = "components/arm_pl031" }
+ax-arm-pl011 = { version = "0.3.7", path = "components/arm_pl011" }
+ax-arm-pl031 = { version = "0.4.6", path = "components/arm_pl031" }
 ax-cap-access = { version = "0.3.5", path = "components/cap_access" }
 ax-config = { version = "0.5.10", path = "os/arceos/modules/axconfig" }
 ax-config-gen = { version = "0.4.9", path = "components/axconfig-gen/axconfig-gen" }
 ax-config-macros = { version = "0.4.9", path = "components/axconfig-gen/axconfig-macros" }
 ax-cpu = { version = "0.6.2", path = "components/axcpu" }
 ax-cpumask = { version = "0.3.5", path = "components/cpumask" }
-ax-crate-interface = { version = "0.5.5", path = "components/crate_interface" }
+ax-crate-interface = { version = "0.5.7", path = "components/crate_interface" }
 ax-crate-interface-lite = { version = "0.3.5", path = "components/crate_interface/crate_interface_lite" }
 ax-ctor-bare = { version = "0.4.8", path = "components/ctor_bare/ctor_bare" }
 ax-ctor-bare-macros = { version = "0.4.8", path = "components/ctor_bare/ctor_bare_macros" }
@@ -255,14 +255,14 @@ ax-display = { version = "0.5.12", path = "os/arceos/modules/axdisplay" }
 ax-dma = { version = "0.5.13", path = "os/arceos/modules/axdma" }
 ax-driver = { version = "0.5.14", path = "os/arceos/modules/axdriver" }
 ax-driver-base = { version = "0.3.12", path = "components/axdriver_crates/axdriver_base" }
-ax-driver-block = { version = "0.3.11", path = "components/axdriver_crates/axdriver_block" }
+ax-driver-block = { version = "0.3.12", path = "components/axdriver_crates/axdriver_block" }
 ax-driver-display = { version = "0.3.12", path = "components/axdriver_crates/axdriver_display" }
 ax-driver-input = { version = "0.3.13", path = "components/axdriver_crates/axdriver_input" }
 ax-driver-net = { version = "0.3.12", path = "components/axdriver_crates/axdriver_net" }
 ax-driver-pci = { version = "0.3.12", path = "components/axdriver_crates/axdriver_pci" }
 ax-driver-virtio = { version = "0.3.12", path = "components/axdriver_crates/axdriver_virtio" }
 ax-driver-vsock = { version = "0.3.12", path = "components/axdriver_crates/axdriver_vsock" }
-ax-errno = { version = "0.4.7", path = "components/axerrno" }
+ax-errno = { version = "0.4.8", path = "components/axerrno" }
 ax-feat = { version = "0.5.14", path = "os/arceos/api/axfeat" }
 ax-fs = { version = "0.5.12", path = "os/arceos/modules/axfs" }
 ax-fs-devfs = { version = "0.3.9", path = "components/axfs_crates/axfs_devfs" }
@@ -282,20 +282,20 @@ ax-ipi = { version = "0.5.12", path = "os/arceos/modules/axipi" }
 ax-kernel-guard = { version = "0.3.10", path = "components/kernel_guard" }
 ax-lockdep = { version = "0.1.0", path = "components/lockdep" }
 ax-kspin = { version = "0.3.8", path = "components/kspin" }
-ax-lazyinit = { version = "0.4.6", path = "components/ax-lazyinit" }
+ax-lazyinit = { version = "0.4.7", path = "components/ax-lazyinit" }
 ax-libc = { version = "0.5.13", path = "os/arceos/ulib/axlibc" }
 ax-linked-list-r4l = { version = "0.5.5", path = "components/linked_list_r4l" }
 ax-log = { version = "0.5.12", path = "os/arceos/modules/axlog" }
-ax-memory-addr = { version = "0.6.7", path = "components/axmm_crates/memory_addr" }
+ax-memory-addr = { version = "0.6.8", path = "components/axmm_crates/memory_addr" }
 ax-memory-set = { version = "0.6.7", path = "components/axmm_crates/memory_set" }
 axpanic = { version = "0.1.0", path = "components/axpanic" }
 ax-mm = { version = "0.5.13", path = "os/arceos/modules/axmm" }
 ax-net = { version = "0.5.12", path = "os/arceos/modules/axnet" }
 ax-net-ng = { version = "0.5.13", path = "os/arceos/modules/axnet-ng" }
-ax-page-table-entry = { version = "0.8.8", path = "components/page_table_multiarch/page_table_entry" }
+ax-page-table-entry = { version = "0.8.9", path = "components/page_table_multiarch/page_table_entry" }
 ax-page-table-multiarch = { version = "0.8.8", path = "components/page_table_multiarch/page_table_multiarch" }
 ax-percpu = { version = "0.4.11", path = "components/percpu/percpu" }
-ax-percpu-macros = { version = "0.4.9", path = "components/percpu/percpu_macros" }
+ax-percpu-macros = { version = "0.4.10", path = "components/percpu/percpu_macros" }
 ax-plat = { version = "0.5.8", path = "components/axplat_crates/axplat" }
 ax-plat-aarch64-bsta1000b = { version = "0.5.8", path = "components/axplat_crates/platforms/axplat-aarch64-bsta1000b" }
 ax-plat-aarch64-peripherals = { version = "0.5.8", path = "components/axplat_crates/platforms/axplat-aarch64-peripherals" }
@@ -323,7 +323,7 @@ axdevice = { version = "0.4.8", path = "components/axdevice" }
 axdevice_base = { version = "0.4.8", path = "components/axdevice_base" }
 axfs-ng-vfs = { version = "0.4.0", path = "components/axfs-ng-vfs" }
 axhvc = { version = "0.4.6", path = "components/axhvc" }
-axklib = { version = "0.5.6", path = "components/axklib" }
+axklib = { version = "0.5.7", path = "components/axklib" }
 axplat-dyn = { version = "0.6.0", path = "platform/axplat-dyn", default-features = false }
 axplat-riscv64-visionfive2 = { version = "0.1.2", path = "platform/riscv64-visionfive2" }
 axplat-riscv64-qemu-virt-hv = { version = "0.5.6", path = "platform/riscv64-qemu-virt" }
@@ -355,35 +355,34 @@ range-alloc-arceos = { version = "0.3.9", path = "components/range-alloc-arceos"
 riscv-h = { version = "0.4.7", path = "components/riscv-h" }
 riscv_vcpu = { version = "0.5.7", path = "components/riscv_vcpu" }
 riscv_vplic = { version = "0.4.10", path = "components/riscv_vplic" }
-nvme-driver = { version = "0.4", path = "drivers/blk/nvme-driver" }
-pcie = { version = "0.6", path = "drivers/pci/pcie" }
-ramdisk = { version = "0.1", path = "drivers/blk/ramdisk" }
-rd-block = { version = "0.1", path = "drivers/blk/rd-block" }
-rd-net = { version = "0.1", path = "drivers/net/rd-net" }
-rdif-base = { version = "0.8", path = "drivers/interface/rdif-base" }
-rdif-block = { version = "0.7", path = "drivers/interface/rdif-block" }
-rdif-clk = { version = "0.5", path = "drivers/interface/rdif-clk" }
-rdif-def = { version = "0.2", path = "drivers/interface/rdif-def" }
-rdif-eth = { version = "0.2", path = "drivers/interface/rdif-eth" }
-rdif-intc = { version = "0.14", path = "drivers/interface/rdif-intc" }
-rdif-pcie = { version = "0.2", path = "drivers/interface/rdif-pcie" }
-rdif-power = { version = "0.7", path = "drivers/interface/rdif-power" }
-rdif-serial = { version = "0.7", path = "drivers/interface/rdif-serial" }
-rdif-systick = { version = "0.6", path = "drivers/interface/rdif-systick" }
-rdif-timer = { version = "0.6", path = "drivers/interface/rdif-timer" }
-rk3588-pci = { version = "0.2", path = "drivers/pci/rk3588-pci" }
-rockchip-npu = { version = "0.2", path = "drivers/npu/rockchip-npu" }
-realtek-rtl8125 = { version = "0.2", path = "drivers/net/realtek-rtl8125" }
-rockchip-pm = { version = "0.4", path = "drivers/soc/rockchip/rockchip-pm" }
-rockchip-soc = { version = "0.2", path = "drivers/soc/rockchip/rockchip-soc" }
-sg2002-tpu = { version = "0.1", path = "drivers/tpu/sg2002-tpu" }
-rdrive = { version = "0.20", path = "drivers/rdrive" }
-rdrive-macros = { version = "0.4", path = "drivers/rdrive-macros" }
+nvme-driver = { version = "0.4.2", path = "drivers/blk/nvme-driver" }
+pcie = { version = "0.6.1", path = "drivers/pci/pcie" }
+ramdisk = { version = "0.1.1", path = "drivers/blk/ramdisk" }
+rd-block = { version = "0.1.2", path = "drivers/blk/rd-block" }
+rd-net = { version = "0.1.1", path = "drivers/net/rd-net" }
+rdif-base = { version = "0.8.1", path = "drivers/interface/rdif-base" }
+rdif-block = { version = "0.7.1", path = "drivers/interface/rdif-block" }
+rdif-clk = { version = "0.5.1", path = "drivers/interface/rdif-clk" }
+rdif-def = { version = "0.2.3", path = "drivers/interface/rdif-def" }
+rdif-eth = { version = "0.2.1", path = "drivers/interface/rdif-eth" }
+rdif-intc = { version = "0.14.1", path = "drivers/interface/rdif-intc" }
+rdif-pcie = { version = "0.2.1", path = "drivers/interface/rdif-pcie" }
+rdif-power = { version = "0.7.1", path = "drivers/interface/rdif-power" }
+rdif-serial = { version = "0.7.1", path = "drivers/interface/rdif-serial" }
+rdif-systick = { version = "0.6.1", path = "drivers/interface/rdif-systick" }
+rdif-timer = { version = "0.6.1", path = "drivers/interface/rdif-timer" }
+rk3588-pci = { version = "0.2.0", path = "drivers/pci/rk3588-pci" }
+rockchip-npu = { version = "0.2.0", path = "drivers/npu/rockchip-npu" }
+realtek-rtl8125 = { version = "0.2.0", path = "drivers/net/realtek-rtl8125" }
+rockchip-pm = { version = "0.4.3", path = "drivers/soc/rockchip/rockchip-pm" }
+rockchip-soc = { version = "0.2.0", path = "drivers/soc/rockchip/rockchip-soc" }
+sg2002-tpu = { version = "0.1.0", path = "drivers/tpu/sg2002-tpu" }
+rdrive = { version = "0.20.1", path = "drivers/rdrive" }
+rdrive-macros = { version = "0.4.2", path = "drivers/rdrive-macros" }
 rsext4 = { version = "0.4.0", path = "components/rsext4" }
 scope-local = { version = "0.3.7", path = "components/scope-local" }
 simple-sdmmc = { version = "0.1.1", path = "drivers/blk/simple-sdmmc" }
 smoltcp = { version = "0.13.1", default-features = false }
-smoltcp-fuzz = { version = "0.2.2", path = "components/starry-smoltcp/fuzz" }
 smp-kernel = { version = "0.3.1", path = "components/axplat_crates/examples/smp-kernel" }
 starry-kernel = { version = "0.5.10", path = "os/StarryOS/kernel" }
 starry-process = { version = "0.4.6", path = "components/starry-process" }
@@ -396,14 +395,14 @@ test-weak-partial = { version = "0.3.4", path = "components/crate_interface/test
 tg-xtask = { version = "0.5.11", path = "xtask" }
 x86_vcpu = { version = "0.5.7", path = "components/x86_vcpu", default-features = false }
 x86_vlapic = { version = "0.4.8", path = "components/x86_vlapic" }
-page-table-generic = { version = "0.7", path = "components/page-table-generic" }
-someboot = { version = "0.1", path = "components/someboot" }
+page-table-generic = { version = "0.7.2", path = "components/page-table-generic" }
+someboot = { version = "0.1.15", path = "components/someboot" }
 some-serial = { version = "0.4.1", path = "drivers/serial/some-serial" }
-kernutil = { path = "components/kernutil", version = "0.2" }
-ranges-ext = { version = "0.6", path = "components/ranges-ext" }
-somehal-macros = { path = "components/somehal-macros", version = "0.1" }
-kasm-aarch64 = { path = "components/kasm-aarch64", version = "0.2" }
-somehal = { version = "0.6", path = "platform/somehal" }
+kernutil = { path = "components/kernutil", version = "0.2.2" }
+ranges-ext = { version = "0.6.4", path = "components/ranges-ext" }
+somehal-macros = { path = "components/somehal-macros", version = "0.1.3" }
+kasm-aarch64 = { path = "components/kasm-aarch64", version = "0.2.1" }
+somehal = { version = "0.6.7", path = "platform/somehal" }
 
 # External crates
 anyhow = { version = "1.0", default-features = false }

--- a/components/axallocator/Cargo.toml
+++ b/components/axallocator/Cargo.toml
@@ -38,10 +38,14 @@ buddy_system_allocator = { version = "0.10", default-features = false, optional 
 ax_slab_allocator = { version = "0.4", optional = true }
 bitmap-allocator = { workspace = true, optional = true }
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
-ax-allocator = { workspace = true, features = ["full"] }
 rand = { version = "0.8", features = ["small_rng"] }
 criterion = { version = "0.5", features = ["html_reports"] }
+
+[[test]]
+name = "allocator"
+required-features = ["full"]
 
 [[bench]]
 name = "collections"
 harness = false
+required-features = ["full"]

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -48,13 +48,13 @@ ax-alloc.workspace = true
 ax-config.workspace = true
 ax-display.workspace = true
 ax-driver.workspace = true
-ax-fs = { path = "../../arceos/modules/axfs-ng", package = "ax-fs-ng" }
+ax-fs = { version = "0.5.13", path = "../../arceos/modules/axfs-ng", package = "ax-fs-ng" }
 ax-hal.workspace = true
 ax-input = { workspace = true, optional = true }
 ax-lazyinit.workspace = true
 ax-log.workspace = true
 ax-mm.workspace = true
-axnet = { path = "../../arceos/modules/axnet-ng", package = "ax-net-ng" }
+axnet = { version = "0.5.13", path = "../../arceos/modules/axnet-ng", package = "ax-net-ng" }
 axplat-dyn = { workspace = true, optional = true }
 ax-runtime.workspace = true
 ax-sync.workspace = true

--- a/os/arceos/modules/axlog/Cargo.toml
+++ b/os/arceos/modules/axlog/Cargo.toml
@@ -18,7 +18,3 @@ chrono = { workspace = true, default-features = true, optional = true }
 ax-crate-interface.workspace = true
 ax-kspin.workspace = true
 log.workspace = true
-
-# [dev-dependencies]
-[target.'cfg(not(target_os="none"))'.dev-dependencies]
-ax-log = { workspace = true, features = ["std"] }

--- a/os/arceos/modules/axlog/src/lib.rs
+++ b/os/arceos/modules/axlog/src/lib.rs
@@ -22,6 +22,8 @@
 //! # Examples
 //!
 //! ```
+//! # #[cfg(feature = "std")]
+//! # {
 //! use ax_log::{debug, error, info, trace, warn};
 //!
 //! // Initialize the logger.
@@ -37,6 +39,7 @@
 //! // The following logs will not be printed.
 //! debug!("debug");
 //! trace!("trace");
+//! # }
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/os/arceos/modules/axsync/Cargo.toml
+++ b/os/arceos/modules/axsync/Cargo.toml
@@ -25,7 +25,6 @@ ax-kspin.workspace = true
 lock_api.workspace = true
 
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
-ax-sync = { workspace = true, features = ["multitask"] }
 ax-task = { workspace = true, features = ["test"] }
 # FIXME: `rand` crate can not be used since https://github.com/google/zerocopy/pull/2574
 fastrand = "2.3"

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -71,4 +71,3 @@ spin = {workspace = true, optional = true}
 
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
 ax-hal = { workspace = true, features = ["fp-simd"] }
-ax-task = { workspace = true, features = ["test", "multitask"] }

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -34,7 +34,7 @@
     test_runner(crate::bare_metal_test_runner)
 )]
 
-#[cfg(all(test, not(target_os = "none")))]
+#[cfg(all(test, not(target_os = "none"), feature = "multitask"))]
 mod tests;
 
 #[cfg(all(test, target_os = "none"))]

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -20,7 +20,6 @@ include = [
     "configs/**",
     "scripts/**",
     "xtask/src/**",
-    "rust-toolchain.toml",
     "README.md",
     "LICENSE*",
 ]
@@ -90,17 +89,17 @@ ax-page-table-multiarch = { workspace = true }
 ax-percpu = { workspace = true, features = ["arm-el2", "non-zero-vma"] }
 rdif-intc.workspace = true
 rdrive.workspace = true
-axplat-dyn = { path = "../../platform/axplat-dyn", optional = true, default-features = false }
+axplat-dyn = { workspace = true, optional = true, default-features = false }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-axplat-x86-qemu-q35 = { path = "../../platform/x86-qemu-q35", default-features = false, features = ["reboot-on-system-off", "irq", "smp"] }
+axplat-x86-qemu-q35 = { version = "0.4.6", path = "../../platform/x86-qemu-q35", default-features = false, features = ["reboot-on-system-off", "irq", "smp"] }
 ax-config = { workspace = true, features = ["plat-dyn"] }
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu-ext = "0.1"
 arm-gic-driver = { workspace = true, features = ["rdif"] }
 
 [target.'cfg(target_arch = "loongarch64")'.dependencies]
-ax-plat-loongarch64-qemu-virt = { path = "../../components/axplat_crates/platforms/axplat-loongarch64-qemu-virt", default-features = false, features = ["irq", "smp"] }
+ax-plat-loongarch64-qemu-virt = { version = "0.5.8", path = "../../components/axplat_crates/platforms/axplat-loongarch64-qemu-virt", default-features = false, features = ["irq", "smp"] }
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 axplat-riscv64-qemu-virt-hv = { workspace = true }
 riscv_vcpu = { workspace = true }

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -37,7 +37,7 @@ rknpu = ["dep:rockchip-npu", "rockchip-pm", "rockchip-soc"]
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-ax-alloc = { path = "../../os/arceos/modules/axalloc", default-features = false, features = ["buddy-slab"] }
+ax-alloc = { version = "0.7.0", path = "../../os/arceos/modules/axalloc", default-features = false, features = ["buddy-slab"] }
 ax-config-macros = { workspace = true }
 ax-cpu.workspace = true
 ax-driver-base.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,3 @@
 [workspace]
 publish_no_verify = true
+release_always = false


### PR DESCRIPTION
## Summary
- 移除循环 dev-dependency（ax-log、ax-sync、ax-task、ax-allocator 自引用自身）
- 为 axtask tests 添加 `multitask` feature gate，为 axlog doctest 添加 `std` feature gate
- 为纯 path 依赖补全 version 字段，确保 release 一致性
- Bump 多个 workspace crate 和 driver 版本号
- 配置 release-plz：`release_always = false`，移除 `CARGO_REGISTRY_TOKEN`

## Test plan
- [ ] `cargo check --workspace` 通过
- [ ] `cargo test -p ax-log --features std` 通过
- [ ] `cargo test -p ax-sync --features multitask` 通过
- [ ] release-plz CI 正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)