### PR TITLE
fix(starry-test): set orangepi-5-plus max_cpu_num to 1

### DIFF
--- a/test-suit/starryos/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -16,5 +16,5 @@ features = [
   "rknpu",
 ]
 log = "Info"
-max_cpu_num = 8
+max_cpu_num = 1
 plat_dyn = true


### PR DESCRIPTION
## Summary
- 将 StarryOS Orange Pi 5 Plus 测试配置中的 `max_cpu_num` 从 8 改为 1，以匹配单核测试环境

## Test plan
- [ ] 确认 `test-suit/starryos/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml` 中 `max_cpu_num = 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)