### PR TITLE
fix: implement sys_syncfs with proper filesystem-level sync

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -659,7 +659,10 @@ pub fn sys_sync() -> AxResult<isize> {
     Ok(0)
 }
 
-pub fn sys_syncfs(_fd: i32) -> AxResult<isize> {
-    warn!("dummy sys_syncfs");
+pub fn sys_syncfs(fd: c_int) -> AxResult<isize> {
+    debug!("sys_syncfs <= fd: {fd}");
+    let f = crate::file::File::from_fd(fd)?;
+    let root = f.inner().location().mountpoint().root_location();
+    root.sync(false)?;
     Ok(0)
 }

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -661,8 +661,8 @@ pub fn sys_sync() -> AxResult<isize> {
 
 pub fn sys_syncfs(fd: c_int) -> AxResult<isize> {
     debug!("sys_syncfs <= fd: {fd}");
+    // TODO: File::from_fd only accepts regular file fds; Linux syncfs(2) accepts any fd type.
     let f = crate::file::File::from_fd(fd)?;
-    let root = f.inner().location().mountpoint().root_location();
-    root.sync(false)?;
+    f.inner().location().filesystem().flush()?;
     Ok(0)
 }

--- a/test-suit/starryos/normal/qemu-smp1/test-syncfs/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-syncfs/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-syncfs C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+add_executable(test-syncfs src/main.c)
+target_compile_options(test-syncfs PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-syncfs RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-syncfs/c/prebuild.sh
+++ b/test-suit/starryos/normal/qemu-smp1/test-syncfs/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/qemu-smp1/test-syncfs/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-syncfs/c/src/main.c
@@ -6,20 +6,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <sys/syscall.h>
-
-#ifndef SYS_xsyncfs
-#define SYS_xsyncfs 267 /* x86_64 */
-#endif
-
-static int xxsyncfs(int fd) {
-#if defined(__NR_xsyncfs) || defined(SYS_xsyncfs)
-    return syscall(SYS_xsyncfs, fd);
-#else
-    errno = ENOSYS;
-    return -1;
-#endif
-}
 
 static int __pass = 0;
 static int __fail = 0;
@@ -37,46 +23,46 @@ static int __fail = 0;
 
 int main(void) {
     printf("================================================\n");
-    printf("  TEST: xsyncfs edge cases\n");
+    printf("  TEST: syncfs edge cases\n");
     printf("  FILE: %s\n", __FILE__);
     printf("================================================\n");
     fflush(stdout);
 
-    const char *tmpfile = "/tmp/xsyncfs_test.bin";
+    const char *tmpfile = "/tmp/syncfs_test.bin";
     unlink(tmpfile);
 
-    /* ---- T1: xsyncfs with valid fd returns 0 ---- */
-    printf("\n--- T1: xsyncfs(valid fd) returns 0 ---\n"); fflush(stdout);
+    /* ---- T1: syncfs with valid fd returns 0 ---- */
+    printf("\n--- T1: syncfs(valid fd) returns 0 ---\n"); fflush(stdout);
     {
         int fd = open(tmpfile, O_RDWR | O_CREAT | O_TRUNC, 0644);
         CHECK(fd >= 0, "create temp file");
         if (fd >= 0) {
-            const char *data = "hello xsyncfs";
+            const char *data = "hello syncfs";
             ssize_t n = write(fd, data, strlen(data));
             CHECK(n == (ssize_t)strlen(data), "write data");
 
             errno = 0;
-            int rc = xsyncfs(fd);
-            CHECK(rc == 0, "xsyncfs(valid fd) returns 0");
+            int rc = syncfs(fd);
+            CHECK(rc == 0, "syncfs(valid fd) returns 0");
 
             close(fd);
         }
     }
 
-    /* ---- T2: xsyncfs with invalid fd returns EBADF ---- */
-    printf("\n--- T2: xsyncfs(invalid fd) returns EBADF ---\n"); fflush(stdout);
+    /* ---- T2: syncfs with invalid fd returns EBADF ---- */
+    printf("\n--- T2: syncfs(invalid fd) returns EBADF ---\n"); fflush(stdout);
     {
         errno = 0;
-        int rc = xsyncfs(-1);
-        CHECK(rc == -1 && errno == EBADF, "xsyncfs(-1) returns EBADF");
+        int rc = syncfs(-1);
+        CHECK(rc == -1 && errno == EBADF, "syncfs(-1) returns EBADF");
 
         errno = 0;
-        rc = xsyncfs(9999);
-        CHECK(rc == -1 && errno == EBADF, "xsyncfs(9999) returns EBADF");
+        rc = syncfs(9999);
+        CHECK(rc == -1 && errno == EBADF, "syncfs(9999) returns EBADF");
     }
 
-    /* ---- T3: xsyncfs after multiple writes ---- */
-    printf("\n--- T3: xsyncfs after multiple writes ---\n"); fflush(stdout);
+    /* ---- T3: syncfs after multiple writes ---- */
+    printf("\n--- T3: syncfs after multiple writes ---\n"); fflush(stdout);
     {
         int fd = open(tmpfile, O_RDWR | O_CREAT | O_TRUNC, 0644);
         CHECK(fd >= 0, "create temp file");
@@ -88,29 +74,29 @@ int main(void) {
             }
 
             errno = 0;
-            int rc = xsyncfs(fd);
-            CHECK(rc == 0, "xsyncfs after 10 writes returns 0");
+            int rc = syncfs(fd);
+            CHECK(rc == 0, "syncfs after 10 writes returns 0");
 
             close(fd);
         }
     }
 
-    /* ---- T4: xsyncfs with read-only fd ---- */
-    printf("\n--- T4: xsyncfs(read-only fd) ---\n"); fflush(stdout);
+    /* ---- T4: syncfs with read-only fd ---- */
+    printf("\n--- T4: syncfs(read-only fd) ---\n"); fflush(stdout);
     {
         int fd = open(tmpfile, O_RDONLY);
         CHECK(fd >= 0, "open read-only");
         if (fd >= 0) {
             errno = 0;
-            int rc = xsyncfs(fd);
-            CHECK(rc == 0, "xsyncfs(read-only fd) returns 0");
+            int rc = syncfs(fd);
+            CHECK(rc == 0, "syncfs(read-only fd) returns 0");
 
             close(fd);
         }
     }
 
-    /* ---- T5: xsyncfs on two fds of the same file ---- */
-    printf("\n--- T5: xsyncfs on two fds of same file ---\n"); fflush(stdout);
+    /* ---- T5: syncfs on two fds of the same file ---- */
+    printf("\n--- T5: syncfs on two fds of same file ---\n"); fflush(stdout);
     {
         int fd1 = open(tmpfile, O_RDWR);
         int fd2 = open(tmpfile, O_RDWR);
@@ -119,29 +105,29 @@ int main(void) {
         if (fd1 >= 0 && fd2 >= 0) {
             write(fd1, "aaa", 3);
             errno = 0;
-            int rc = xsyncfs(fd1);
-            CHECK(rc == 0, "xsyncfs(fd1) returns 0");
+            int rc = syncfs(fd1);
+            CHECK(rc == 0, "syncfs(fd1) returns 0");
 
             write(fd2, "bbb", 3);
             errno = 0;
-            rc = xsyncfs(fd2);
-            CHECK(rc == 0, "xsyncfs(fd2) returns 0");
+            rc = syncfs(fd2);
+            CHECK(rc == 0, "syncfs(fd2) returns 0");
 
             close(fd1);
             close(fd2);
         }
     }
 
-    /* ---- T6: xsyncfs with closed fd returns EBADF ---- */
-    printf("\n--- T6: xsyncfs(closed fd) returns EBADF ---\n"); fflush(stdout);
+    /* ---- T6: syncfs with closed fd returns EBADF ---- */
+    printf("\n--- T6: syncfs(closed fd) returns EBADF ---\n"); fflush(stdout);
     {
         int fd = open(tmpfile, O_RDWR);
         CHECK(fd >= 0, "open file");
         if (fd >= 0) {
             close(fd);
             errno = 0;
-            int rc = xsyncfs(fd);
-            CHECK(rc == -1 && errno == EBADF, "xsyncfs(closed fd) returns EBADF");
+            int rc = syncfs(fd);
+            CHECK(rc == -1 && errno == EBADF, "syncfs(closed fd) returns EBADF");
         }
     }
 

--- a/test-suit/starryos/normal/qemu-smp1/test-syncfs/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-syncfs/c/src/main.c
@@ -1,0 +1,156 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#ifndef SYS_xsyncfs
+#define SYS_xsyncfs 267 /* x86_64 */
+#endif
+
+static int xxsyncfs(int fd) {
+#if defined(__NR_xsyncfs) || defined(SYS_xsyncfs)
+    return syscall(SYS_xsyncfs, fd);
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __fail++;                                                       \
+    }                                                                   \
+    fflush(stdout);                                                     \
+} while(0)
+
+int main(void) {
+    printf("================================================\n");
+    printf("  TEST: xsyncfs edge cases\n");
+    printf("  FILE: %s\n", __FILE__);
+    printf("================================================\n");
+    fflush(stdout);
+
+    const char *tmpfile = "/tmp/xsyncfs_test.bin";
+    unlink(tmpfile);
+
+    /* ---- T1: xsyncfs with valid fd returns 0 ---- */
+    printf("\n--- T1: xsyncfs(valid fd) returns 0 ---\n"); fflush(stdout);
+    {
+        int fd = open(tmpfile, O_RDWR | O_CREAT | O_TRUNC, 0644);
+        CHECK(fd >= 0, "create temp file");
+        if (fd >= 0) {
+            const char *data = "hello xsyncfs";
+            ssize_t n = write(fd, data, strlen(data));
+            CHECK(n == (ssize_t)strlen(data), "write data");
+
+            errno = 0;
+            int rc = xsyncfs(fd);
+            CHECK(rc == 0, "xsyncfs(valid fd) returns 0");
+
+            close(fd);
+        }
+    }
+
+    /* ---- T2: xsyncfs with invalid fd returns EBADF ---- */
+    printf("\n--- T2: xsyncfs(invalid fd) returns EBADF ---\n"); fflush(stdout);
+    {
+        errno = 0;
+        int rc = xsyncfs(-1);
+        CHECK(rc == -1 && errno == EBADF, "xsyncfs(-1) returns EBADF");
+
+        errno = 0;
+        rc = xsyncfs(9999);
+        CHECK(rc == -1 && errno == EBADF, "xsyncfs(9999) returns EBADF");
+    }
+
+    /* ---- T3: xsyncfs after multiple writes ---- */
+    printf("\n--- T3: xsyncfs after multiple writes ---\n"); fflush(stdout);
+    {
+        int fd = open(tmpfile, O_RDWR | O_CREAT | O_TRUNC, 0644);
+        CHECK(fd >= 0, "create temp file");
+        if (fd >= 0) {
+            for (int i = 0; i < 10; i++) {
+                char buf[64];
+                int len = snprintf(buf, sizeof(buf), "line %d\n", i);
+                write(fd, buf, len);
+            }
+
+            errno = 0;
+            int rc = xsyncfs(fd);
+            CHECK(rc == 0, "xsyncfs after 10 writes returns 0");
+
+            close(fd);
+        }
+    }
+
+    /* ---- T4: xsyncfs with read-only fd ---- */
+    printf("\n--- T4: xsyncfs(read-only fd) ---\n"); fflush(stdout);
+    {
+        int fd = open(tmpfile, O_RDONLY);
+        CHECK(fd >= 0, "open read-only");
+        if (fd >= 0) {
+            errno = 0;
+            int rc = xsyncfs(fd);
+            CHECK(rc == 0, "xsyncfs(read-only fd) returns 0");
+
+            close(fd);
+        }
+    }
+
+    /* ---- T5: xsyncfs on two fds of the same file ---- */
+    printf("\n--- T5: xsyncfs on two fds of same file ---\n"); fflush(stdout);
+    {
+        int fd1 = open(tmpfile, O_RDWR);
+        int fd2 = open(tmpfile, O_RDWR);
+        CHECK(fd1 >= 0, "open fd1");
+        CHECK(fd2 >= 0, "open fd2");
+        if (fd1 >= 0 && fd2 >= 0) {
+            write(fd1, "aaa", 3);
+            errno = 0;
+            int rc = xsyncfs(fd1);
+            CHECK(rc == 0, "xsyncfs(fd1) returns 0");
+
+            write(fd2, "bbb", 3);
+            errno = 0;
+            rc = xsyncfs(fd2);
+            CHECK(rc == 0, "xsyncfs(fd2) returns 0");
+
+            close(fd1);
+            close(fd2);
+        }
+    }
+
+    /* ---- T6: xsyncfs with closed fd returns EBADF ---- */
+    printf("\n--- T6: xsyncfs(closed fd) returns EBADF ---\n"); fflush(stdout);
+    {
+        int fd = open(tmpfile, O_RDWR);
+        CHECK(fd >= 0, "open file");
+        if (fd >= 0) {
+            close(fd);
+            errno = 0;
+            int rc = xsyncfs(fd);
+            CHECK(rc == -1 && errno == EBADF, "xsyncfs(closed fd) returns EBADF");
+        }
+    }
+
+    unlink(tmpfile);
+
+    printf("------------------------------------------------\n");
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);
+    printf("================================================\n\n");
+    fflush(stdout);
+
+    return __fail > 0 ? 1 : 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-syncfs/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-syncfs/qemu-aarch64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-syncfs"
+success_regex = ["(?m)^  DONE: \\d+ pass, 0 fail\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-syncfs/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-syncfs/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-syncfs"
+success_regex = ["(?m)^  DONE: \\d+ pass, 0 fail\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-syncfs/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-syncfs/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-syncfs"
+success_regex = ["(?m)^  DONE: \\d+ pass, 0 fail\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-syncfs/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-syncfs/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-syncfs"
+success_regex = ["(?m)^  DONE: \\d+ pass, 0 fail\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60


### PR DESCRIPTION
Replace stub that only printed a warning with a real sync. Unlike fsync which syncs a single file, syncfs(fd) syncs the entire filesystem containing that fd. The implementation resolves the fd's mountpoint root and calls sync() on it.