### PR TITLE
fix(ci): add CARGO_REGISTRY_TOKEN to release-plz release job

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,6 +38,7 @@ jobs:
           config: release-plz.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
## Summary
- Add `CARGO_REGISTRY_TOKEN` secret to the `release-plz release` job so it can publish crates to crates.io

## Test plan
- [ ] Verify the secret `CARGO_REGISTRY_TOKEN` is configured in repo settings
- [ ] Next release-plz run should succeed in publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)