### PR TITLE
fix(rsext4): skip inconsistent block groups in alloc_blocks

### DIFF
--- a/components/rsext4/src/ext4/alloc.rs
+++ b/components/rsext4/src/ext4/alloc.rs
@@ -59,6 +59,23 @@ impl Ext4FileSystem {
                         .alloc_contiguous_blocks(data, group_idx, count);
                 })?;
 
+            // Check the allocation result *before* doing any mutable descriptor
+            // work. If the bitmap had no free block despite the descriptor claiming
+            // otherwise, the group is stale/inconsistent (e.g. dirty unmount with
+            // lazy initialisation). Skip to the next group instead of failing
+            // immediately so that groups with consistent bitmaps are still tried.
+            let alloc = match alloc_res {
+                Ok(a) => a,
+                Err(e) if e.code == Errno::ENOSPC => {
+                    warn!(
+                        "alloc_blocks: group={group_idx} descriptor claims {free} free blocks but \
+                         bitmap has none — descriptor/bitmap inconsistency, skipping group"
+                    );
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+
             if ext4_superblock_has_metadata_csum(&self.superblock) {
                 let sb = self.superblock;
                 let updated_data = self
@@ -72,8 +89,6 @@ impl Ext4FileSystem {
                     .ok_or(Ext4Error::corrupted())?;
                 desc_mut.update_checksum(&sb, group_idx.raw(), Some(&updated_data), None);
             }
-
-            let alloc = alloc_res?;
 
             if let Some(desc_mut) = self.get_group_desc_mut(group_idx) {
                 let before = desc_mut.free_blocks_count();

--- a/components/rsext4/src/file/io.rs
+++ b/components/rsext4/src/file/io.rs
@@ -374,7 +374,7 @@ pub fn write_file<B: BlockDevice>(
     write_inode_data(device, fs, inode_num, offset, data)
 }
 
-fn write_inode_data<B: BlockDevice>(
+pub fn write_inode_data<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     inode_num: InodeNumber,

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -33,6 +33,6 @@ mod rename;
 pub use blocks::build_file_block_mapping_with_inode_num;
 pub use create::{create_symbol_link, mkfile};
 pub use delete::{delete_dir, delete_file, unlink};
-pub use io::{read_file, truncate, write_file};
+pub use io::{read_file, truncate, write_file, write_inode_data};
 pub use link::link;
 pub use rename::{mv, rename};

--- a/components/rsext4/src/jbd2/jbd2.rs
+++ b/components/rsext4/src/jbd2/jbd2.rs
@@ -101,7 +101,25 @@ impl JBD2DEVSYSTEM {
         let mapped_len = u32::try_from(journal_blocks.len()).ok();
         let total_blocks = match mapped_len {
             Some(0) | None => self.jbd2_super_block.s_maxlen,
-            Some(len) => self.jbd2_super_block.s_maxlen.min(len),
+            // When s_maxlen from the on-disk journal superblock is smaller than
+            // the actual number of journal blocks (e.g. s_maxlen=1 due to an
+            // unclean shutdown that corrupted the journal superblock), trust the
+            // physical extent mapping rather than the stale s_maxlen.
+            Some(len) => {
+                let sb_maxlen = self.jbd2_super_block.s_maxlen;
+                if sb_maxlen > 0 && sb_maxlen >= self.jbd2_super_block.s_first {
+                    sb_maxlen.min(len)
+                } else {
+                    // s_maxlen is 0 or smaller than s_first — it is corrupted.
+                    // Fall back to the physical extent length.
+                    warn!(
+                        "[JBD2] s_maxlen={} < s_first={}: journal superblock s_maxlen is corrupt, \
+                         using physical extent length {} instead",
+                        sb_maxlen, self.jbd2_super_block.s_first, len
+                    );
+                    len
+                }
+            }
         };
 
         let last = total_blocks.checked_sub(1)?;
@@ -642,6 +660,20 @@ impl JBD2DEVSYSTEM {
     ) -> ReplayStatus {
         let mut journal_rel = self.jbd2_super_block.s_start;
         if journal_rel == 0 {
+            return ReplayStatus::Complete;
+        }
+
+        // If s_start points beyond the physical journal extent the on-disk
+        // journal superblock is inconsistent (e.g. corrupted by a crash that
+        // also mangled s_maxlen). There are no valid transactions to replay.
+        if !journal_blocks.is_empty() && journal_rel as usize >= journal_blocks.len() {
+            warn!(
+                "[JBD2] s_start={} >= journal_blocks.len()={}: journal superblock is \
+                 inconsistent, treating journal as clean",
+                journal_rel,
+                journal_blocks.len()
+            );
+            self.jbd2_super_block.s_start = 0;
             return ReplayStatus::Complete;
         }
 

--- a/components/rsext4/src/lib.rs
+++ b/components/rsext4/src/lib.rs
@@ -30,7 +30,7 @@ pub use error::{Errno, Ext4Error, Ext4Result};
 pub use ext4::{Ext4FileSystem, find_file, mkfs, mount, umount};
 pub use file::{
     create_symbol_link, delete_dir, delete_file, link, mkfile, mv, read_file, rename, truncate,
-    unlink, write_file,
+    unlink, write_file, write_inode_data,
 };
 pub use metadata::{chmod, chown, set_flags, set_project, utimens};
 

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
@@ -277,14 +277,10 @@ impl FileNodeOps for Inode {
         {
             let mut state = self.fs.lock();
             let (fs, dev) = state.split();
-            rsext4::write_file(
-                dev,
-                fs,
-                &self.path.clone().ok_or(VfsError::InvalidInput)?,
-                offset,
-                buf,
-            )
-            .map_err(into_vfs_err)?;
+            // Use inode-number-based write to avoid path re-resolution.
+            // Path-based write_file() fails with NotFound after rename/unlink,
+            // which causes dirty page loss when jcode atomically replaces files.
+            rsext4::write_inode_data(dev, fs, self.ino, offset, buf).map_err(into_vfs_err)?;
         }
         self.fs.sync_to_disk()?;
         Ok(buf.len())
@@ -296,14 +292,7 @@ impl FileNodeOps for Inode {
             let (fs, dev) = state.split();
             let inode = fs.get_inode_by_num(dev, self.ino).map_err(into_vfs_err)?;
             let length = inode.size();
-            rsext4::write_file(
-                dev,
-                fs,
-                &self.path.clone().ok_or(VfsError::InvalidInput)?,
-                length,
-                buf,
-            )
-            .map_err(into_vfs_err)?;
+            rsext4::write_inode_data(dev, fs, self.ino, length, buf).map_err(into_vfs_err)?;
             length
         };
         self.fs.sync_to_disk()?;


### PR DESCRIPTION
When the block group descriptor claims free blocks but the on-disk bitmap shows none (bitmap/descriptor inconsistency), the previous code immediately propagated ENOSPC without trying subsequent groups.

This caused spurious ENOSPC errors on Alpine rootfs images that were saved without a clean unmount: groups 1 and 2 had descriptor/bitmap mismatches while groups 3-7 contained 13 000–32 000 free blocks.

Fix: check alloc_res *before* the mutable descriptor update. On Errno::ENOSPC, emit a warning and `continue` to the next group so groups with consistent bitmaps are still tried. Non-ENOSPC errors are still propagated immediately.

The checksum update is also moved after the successful-allocation check, which is more correct: we only recompute the bitmap checksum when the bitmap was actually modified.

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

fix(rsext4,axfs-ng): use inode-based write in write_at/append

rsext4 Inode::write_at and append used the path-based write_file() helper, which re-resolves the path from the directory tree on every write. When an application atomically replaces a file via write-temp→rename (a common pattern in config/session writers like jcode), the DirEntry held by CachedFile keeps the old path. The subsequent sync on drop called evict_cache → file.write_at → write_file with the now-invalid path, causing ENOENT ("Failed to sync file on drop: AxErrorKind::NotFound") and dirty-page loss.

In jcode's TUI mode this write failure blocked the session-persist path and caused the TUI to hang indefinitely at the "loading..." spinner after the AI response arrived, because jcode waited on the internal session-file write before updating the UI. The CLI mode (jcode run) is a one-shot command that exits without maintaining a persistent session file, so the same error was tolerable there.

Fix: expose write_inode_data as a pub function and use it directly in Inode::write_at and Inode::append. The inode number (self.ino) is stable across renames, so the write succeeds even after the file has been moved.

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

fix(rsext4): handle corrupted journal superblock (s_maxlen/s_start)

The Alpine rootfs image has a journal superblock where s_maxlen=1 and s_start=8192, both inconsistent with the actual 8192-block journal (physical extent via journal inode). This is caused by an unclean shutdown that corrupted the journal superblock fields.

Two bugs prevented correct handling:

1. last_logical_block() used s_maxlen.min(len), so s_maxlen=1 clamped the total to 1 block. With s_first=4096, last(0) < s_first → None, causing ReplayRing::new to return None, and replay_with_mapping to return Incomplete. mount() then returned Ext4Error::corrupted().

   Fix: when s_maxlen < s_first (clearly corrupt), trust the physical extent length (journal_blocks.len()) instead.

2. replay_with_mapping() started replay at s_start=8192, but the valid index range for journal_blocks is 0..8191. ring.phys(8192) returned Err → ReplayScan::Incomplete on the very first block, causing the mount to fail even after fix 1 above.

   Fix: if s_start >= journal_blocks.len(), the journal superblock is inconsistent. Treat the journal as clean (s_start=0, Complete) so mount proceeds normally without attempting a broken replay.

After both fixes: mount succeeds, the Group 1/2 bitmap vs. descriptor mismatches are worked around by the earlier alloc_blocks fix (skip inconsistent groups), and the repeated "descriptor claims N free blocks but bitmap has none" warnings cease because Group 2 (bitmap=455) is now picked for allocation instead of Group 1 (bitmap=0).

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

fix(rsext4): cargo fmt