### PR TITLE
fix(epoll)

### DIFF
--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -272,7 +272,8 @@ impl Epoll {
         Self::default()
     }
 
-    // only register waker, not add to ready queue
+    // Register waker only — no immediate poll check.
+    // Used for NoEvent (spurious wakeup): re-arm and wait for a real state change.
     fn register_waker_only(&self, interest: &Arc<EpollInterest>) {
         let Some(file) = interest.key.get_file() else {
             return;
@@ -397,6 +398,7 @@ impl Epoll {
         // into the loop and filling out[] with duplicates of one ready fd.
         let mut txlist = core::mem::take(&mut *self.inner.ready_queue.lock());
         let mut count = 0;
+        let mut no_event_count = 0usize;
         let mut keep: VecDeque<Weak<EpollInterest>> = VecDeque::new();
 
         while let Some(weak_interest) = txlist.pop_front() {
@@ -416,9 +418,10 @@ impl Epoll {
                 continue;
             };
 
+            let current_poll = file.poll();
             trace!(
-                "Epoll: consuming ready interest for fd={}, events={:?}",
-                interest.key.fd, interest.event.events
+                "Epoll: consuming ready interest for fd={}, interest_events={:?}, file.poll()={:?}",
+                interest.key.fd, interest.event.events, current_poll
             );
 
             match interest.consume(file.as_ref()) {
@@ -449,17 +452,24 @@ impl Epoll {
                         keep.push_back(Arc::downgrade(&interest));
                     } else {
                         interest.mark_not_in_queue();
+                        // EPOLLET: re-arm by registering a fresh waker.
+                        // Any new data that arrived between mark_not_in_queue() and
+                        // register() will be caught by the still-live old InterestWaker
+                        // (held by the underlying PollSet), which calls try_mark_in_queue()
+                        // and re-queues the interest atomically.  We must NOT poll the
+                        // file here: existing unread data must not re-trigger ET — only a
+                        // state transition (new data arriving) should.
                         self.register_waker_only(&interest);
                     }
                 }
                 ConsumeResult::NoEvent => {
+                    no_event_count += 1;
+                    debug!(
+                        "Epoll: NoEvent fd={} interest={:?} file.poll()={:?} (spurious #{})",
+                        interest.key.fd, interest.event.events, current_poll, no_event_count
+                    );
                     interest.mark_not_in_queue();
-                    // Events arriving between consume()'s poll and the new
-                    // register() would otherwise be lost: the old waker
-                    // CAS-fails (in_ready_queue still set), and a plain
-                    // register only fires on the next edge. Re-poll after
-                    // registering to recover them.
-                    self.check_and_register_waker(&interest);
+                    self.register_waker_only(&interest);
                 }
             }
         }
@@ -476,6 +486,9 @@ impl Epoll {
         if count == 0 {
             Err(AxError::WouldBlock)
         } else {
+            if no_event_count > 0 {
+                debug!("Epoll: poll_events count={count} no_event_spurious={no_event_count}");
+            }
             Ok(count)
         }
     }

--- a/os/StarryOS/kernel/src/syscall/io_mpx/select.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/select.rs
@@ -123,15 +123,15 @@ fn do_select(
                     let selected_except =
                         selected.contains(IoEvents::ERR) && except_set.0.get(index);
 
-                    if selected_read && let Some(set) = readfds.as_deref_mut() {
+                    if selected_read && let Some(ref mut set) = k_readfds {
                         res += 1;
                         unsafe { FD_SET(index as _, set) };
                     }
-                    if selected_write && let Some(set) = writefds.as_deref_mut() {
+                    if selected_write && let Some(ref mut set) = k_writefds {
                         res += 1;
                         unsafe { FD_SET(index as _, set) };
                     }
-                    if selected_except && let Some(set) = exceptfds.as_deref_mut() {
+                    if selected_except && let Some(ref mut set) = k_exceptfds {
                         res += 1;
                         unsafe { FD_SET(index as _, set) };
                     }

--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -512,8 +512,14 @@ impl Device for EthernetDevice {
     }
 
     fn register_waker(&self, waker: &Waker) {
-        if self.inner.irq_num.is_some() {
+        if let Some(irq) = self.inner.irq_num {
+            warn!("EthernetDevice: register_waker on IRQ={irq}");
             self.inner.poll_ready.register(waker);
+        } else {
+            warn!(
+                "EthernetDevice: register_waker called but irq_num=None — waker NOT registered, \
+                 TCP wake will never fire!"
+            );
         }
     }
 }

--- a/os/arceos/modules/axnet-ng/src/lib.rs
+++ b/os/arceos/modules/axnet-ng/src/lib.rs
@@ -69,6 +69,7 @@ static SOCKET_SET: Lazy<SocketSetWrapper> = Lazy::new(SocketSetWrapper::new);
 static SERVICE: Once<Mutex<Service>> = Once::new();
 static POLLING_INTERFACES: AtomicBool = AtomicBool::new(false);
 static POLL_AGAIN: AtomicBool = AtomicBool::new(false);
+static POLL_INTERFACES_COUNT: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
 const DHCP_BOOTSTRAP_ATTEMPTS: usize = 200;
 const DHCP_BOOTSTRAP_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -175,6 +176,10 @@ pub fn init_vsock(mut vsock_devs: AxDeviceContainer<AxVsockDevice>) {
 
 /// Poll all network interfaces for new events.
 pub fn poll_interfaces() {
+    let count = POLL_INTERFACES_COUNT.fetch_add(1, Ordering::Relaxed);
+    if count.is_multiple_of(200) {
+        debug!("poll_interfaces called {} times total", count);
+    }
     POLL_AGAIN.store(true, Ordering::Release);
     loop {
         if POLLING_INTERFACES

--- a/os/arceos/modules/axnet-ng/src/service.rs
+++ b/os/arceos/modules/axnet-ng/src/service.rs
@@ -343,6 +343,7 @@ impl Service {
 
         if let Some(t) = next {
             let next = TimeValue::from_micros(t.total_micros() as _);
+            warn!("Service::register_waker: next poll_at = {:?}", next);
 
             // drop old timeout future
             self.timeout = None;
@@ -351,15 +352,19 @@ impl Service {
             let mut cx = Context::from_waker(waker);
 
             if fut.as_mut().poll(&mut cx).is_ready() {
+                warn!("Service::register_waker: timeout already ready, waking immediately");
                 waker.wake_by_ref();
                 return;
             } else {
                 self.timeout = Some(fut);
             }
+        } else {
+            warn!("Service::register_waker: no next poll_at (no pending timers), mask={mask:#x}");
         }
 
         for (i, device) in self.router.devices.iter().enumerate() {
             if mask & (1 << i) != 0 {
+                warn!("Service::register_waker: registering on device[{i}]");
                 device.register_waker(waker);
             }
         }

--- a/os/arceos/modules/axnet-ng/src/service.rs
+++ b/os/arceos/modules/axnet-ng/src/service.rs
@@ -343,7 +343,7 @@ impl Service {
 
         if let Some(t) = next {
             let next = TimeValue::from_micros(t.total_micros() as _);
-            warn!("Service::register_waker: next poll_at = {:?}", next);
+            debug!("Service::register_waker: next poll_at = {:?}", next);
 
             // drop old timeout future
             self.timeout = None;

--- a/os/arceos/modules/axnet-ng/src/tcp.rs
+++ b/os/arceos/modules/axnet-ng/src/tcp.rs
@@ -163,13 +163,16 @@ impl TcpSocket {
         let mut events = IoEvents::empty();
         self.with_smol_socket(|socket| match socket.state() {
             smol::State::SynSent | smol::State::SynReceived => {
-                // wait for connection
+                debug!(
+                    "TCP {}: poll_connect — still SynSent/SynReceived (waiting)",
+                    self.handle
+                );
             }
             smol::State::Established => {
                 self.clear_pending_error();
-                self.state.set(State::Connected); // connected
-                debug!(
-                    "TCP socket {}: connected to {}",
+                self.state.set(State::Connected);
+                warn!(
+                    "TCP {}: poll_connect — Established, connected to {}",
                     self.handle,
                     socket.remote_endpoint().unwrap(),
                 );
@@ -177,9 +180,9 @@ impl TcpSocket {
             }
             state => {
                 self.store_pending_error(LinuxError::ECONNREFUSED);
-                self.state.set(State::Closed); // connection failed
-                debug!(
-                    "TCP socket {}: connect failed in state {:?}",
+                self.state.set(State::Closed);
+                warn!(
+                    "TCP {}: poll_connect — connect failed in state {:?}",
                     self.handle, state
                 );
                 events.set(IoEvents::OUT, true);
@@ -361,15 +364,23 @@ impl SocketOps for TcpSocket {
         ax_task::yield_now();
 
         // Here our state must be `CONNECTING`, and only one thread can run here.
+        warn!(
+            "TCP {}: entering connect poll loop (nonblocking={})",
+            self.handle,
+            self.general.nonblocking()
+        );
         self.general.send_poller(self, || {
             poll_interfaces();
             let events = self.poll_connect();
             if !events.contains(IoEvents::OUT) {
                 Err(AxError::WouldBlock)
             } else if self.state() == State::Connected {
+                warn!("TCP {}: connect succeeded", self.handle);
                 Ok(())
             } else {
-                Err(self.connect_error())
+                let err = self.connect_error();
+                warn!("TCP {}: connect error {:?}", self.handle, err);
+                Err(err)
             }
         })
     }
@@ -431,16 +442,19 @@ impl SocketOps for TcpSocket {
     }
 
     fn send(&self, mut src: impl Read, _options: SendOptions) -> AxResult<usize> {
-        // SAFETY: `self.handle` should be initialized in a connected socket.
         let result = self.general.send_poller(self, || {
             poll_interfaces();
             self.with_smol_socket(|socket| {
                 if !socket.is_active() {
+                    warn!(
+                        "TCP {}: send — not active (state={:?})",
+                        self.handle,
+                        socket.state()
+                    );
                     Err(AxError::NotConnected)
                 } else if !socket.can_send() {
                     Err(AxError::WouldBlock)
                 } else {
-                    // connected, and the tx buffer is not full
                     let len = socket
                         .send(|buffer| {
                             let result = src.read(buffer);
@@ -448,13 +462,11 @@ impl SocketOps for TcpSocket {
                             (len, result)
                         })
                         .map_err(|_| ax_err_type!(NotConnected, "not connected?"))??;
+                    debug!("TCP {}: sent {} bytes", self.handle, len);
                     Ok(len)
                 }
             })
         });
-        // Poll again after writing so the data is transmitted through the
-        // network stack immediately. For loopback, this causes loopback.send()
-        // to run, which wakes any epoll wakers registered on the peer socket.
         if result.is_ok() {
             poll_interfaces();
         }
@@ -463,14 +475,24 @@ impl SocketOps for TcpSocket {
 
     fn recv(&self, mut dst: impl Write + IoBufMut, options: RecvOptions<'_>) -> AxResult<usize> {
         if self.rx_closed.load(Ordering::Acquire) {
+            warn!(
+                "TCP {}: recv — rx_closed, returning NotConnected",
+                self.handle
+            );
             return Err(AxError::NotConnected);
         }
         self.general.recv_poller(self, || {
             poll_interfaces();
             self.with_smol_socket(|socket| {
                 if !socket.is_active() {
+                    warn!(
+                        "TCP {}: recv — not active (state={:?})",
+                        self.handle,
+                        socket.state()
+                    );
                     Err(AxError::NotConnected)
                 } else if !socket.may_recv() {
+                    warn!("TCP {}: recv — may_recv=false, returning EOF", self.handle);
                     Ok(0)
                 } else if socket.recv_queue() == 0 {
                     Err(AxError::WouldBlock)
@@ -481,13 +503,15 @@ impl SocketOps for TcpSocket {
                             .map_err(|_| ax_err_type!(NotConnected, "not connected?"))?,
                     )
                 } else {
-                    socket
+                    let n = socket
                         .recv(|buf| {
                             let result = dst.write(buf);
                             let len = result.unwrap_or(0);
                             (len, result)
                         })
-                        .map_err(|_| ax_err_type!(NotConnected, "not connected?"))?
+                        .map_err(|_| ax_err_type!(NotConnected, "not connected?"))??;
+                    debug!("TCP {}: recv got {} bytes", self.handle, n);
+                    Ok(n)
                 }
             })
         })

--- a/os/arceos/modules/axnet-ng/src/unix/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/stream.rs
@@ -242,6 +242,7 @@ impl TransportOps for StreamTransport {
             };
             total += count;
             if count > 0 {
+                debug!("UnixStream: sent {} bytes, waking peer", count);
                 chan.poll_update.wake();
             }
 
@@ -270,6 +271,7 @@ impl TransportOps for StreamTransport {
                 count
             };
             if count > 0 {
+                debug!("UnixStream: recv got {} bytes", count);
                 chan.poll_update.wake();
                 Ok(count)
             } else if !chan.rx.write_is_held() {

--- a/os/arceos/modules/axnet-ng/src/unix/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/stream.rs
@@ -31,16 +31,23 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
     let (client_tx, server_rx) = new_uni_channel();
     let (server_tx, client_rx) = new_uni_channel();
     let poll_update = Arc::new(PollSet::new());
+    // Cross-wired close flags: each side's my_tx_closed is the other's peer_tx_closed.
+    let client_tx_closed = Arc::new(AtomicBool::new(false));
+    let server_tx_closed = Arc::new(AtomicBool::new(false));
     (
         Channel {
             tx: client_tx,
             rx: client_rx,
+            my_tx_closed: client_tx_closed.clone(),
+            peer_tx_closed: server_tx_closed.clone(),
             poll_update: poll_update.clone(),
             peer_pid: pid,
         },
         Channel {
             tx: server_tx,
             rx: server_rx,
+            my_tx_closed: server_tx_closed,
+            peer_tx_closed: client_tx_closed,
             poll_update,
             peer_pid: pid,
         },
@@ -50,7 +57,10 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
 struct Channel {
     tx: HeapProd<u8>,
     rx: HeapCons<u8>,
-    // TODO: granularity
+    /// Set to true by Drop (our side) before waking the peer.
+    my_tx_closed: Arc<AtomicBool>,
+    /// Set to true by the peer's Drop before it wakes us.
+    peer_tx_closed: Arc<AtomicBool>,
     poll_update: Arc<PollSet>,
     peer_pid: u32,
 }
@@ -274,10 +284,8 @@ impl TransportOps for StreamTransport {
                 debug!("UnixStream: recv got {} bytes", count);
                 chan.poll_update.wake();
                 Ok(count)
-            } else if !chan.rx.write_is_held() {
-                // Peer dropped its sender end and the ring is empty: EOF.
-                // Returning WouldBlock here would park the caller forever
-                // waiting for data that will never arrive.
+            } else if !chan.rx.write_is_held() || chan.peer_tx_closed.load(Ordering::Acquire) {
+                // Peer closed (either HeapProd dropped or tx_closed flag set): EOF.
                 Ok(0)
             } else {
                 Err(AxError::WouldBlock)
@@ -307,10 +315,13 @@ impl TransportOps for StreamTransport {
 impl Pollable for StreamTransport {
     fn poll(&self) -> IoEvents {
         let mut events = IoEvents::empty();
+        let rx_closed = self.rx_closed.load(Ordering::Acquire);
+        let mut peer_eof = false;
         if let Some(chan) = self.channel.lock().as_ref() {
+            peer_eof = chan.peer_tx_closed.load(Ordering::Acquire);
             events.set(
                 IoEvents::IN,
-                !self.rx_closed.load(Ordering::Acquire) && chan.rx.occupied_len() > 0,
+                !rx_closed && (chan.rx.occupied_len() > 0 || peer_eof),
             );
             events.set(
                 IoEvents::OUT,
@@ -319,7 +330,7 @@ impl Pollable for StreamTransport {
         } else if let Some((conn_tx, _)) = self.conn_rx.lock().as_ref() {
             events.set(IoEvents::IN, !conn_tx.is_empty());
         }
-        events.set(IoEvents::RDHUP, self.rx_closed.load(Ordering::Acquire));
+        events.set(IoEvents::RDHUP, peer_eof || rx_closed);
         events
     }
 
@@ -340,7 +351,11 @@ impl Pollable for StreamTransport {
 impl Drop for StreamTransport {
     fn drop(&mut self) {
         if let Some(chan) = self.channel.lock().as_ref() {
+            // Set the flag BEFORE waking the peer so poll() sees peer_eof=true
+            // when it runs, even though our HeapProd hasn't dropped yet.
+            chan.my_tx_closed.store(true, Ordering::Release);
             chan.poll_update.wake();
         }
+        self.poll_state.wake();
     }
 }

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -23,10 +23,15 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
     super::interruptible(poll_fn(move |cx| match f() {
         Ok(value) => Poll::Ready(Ok(value)),
         Err(AxError::WouldBlock) => {
+            // Always register the waker before returning WouldBlock, even for
+            // non-blocking sockets.  A non-blocking connect(2) returns EINPROGRESS
+            // and the caller uses epoll to wait for EPOLLOUT (connection complete).
+            // If we skip registration here, the TCP stack never delivers the
+            // SYN-ACK notification to the epoll instance — the connection stalls.
+            pollable.register(cx, events);
             if non_blocking {
                 return Poll::Ready(Err(AxError::WouldBlock));
             }
-            pollable.register(cx, events);
             match f() {
                 Ok(value) => Poll::Ready(Ok(value)),
                 Err(AxError::WouldBlock) => Poll::Pending,


### PR DESCRIPTION
9c4906f14 StarryOS Fix: fix(unix-stream): signal peer EOF before wake to prevent epoll hang
c1ef1557f StarryOS Fix: fix(poll_io): register waker before returning WouldBlock for non-blocking sockets
2e1df97c1 StarryOS Fix: fix(epoll): close EPOLLET waker re-registration race window