### PR TITLE
fix(mm,syscall): fix kernel-mode COW write faults in poll/select/epoll

### DIFF
--- a/components/rsext4/src/ext4/alloc.rs
+++ b/components/rsext4/src/ext4/alloc.rs
@@ -59,6 +59,23 @@ impl Ext4FileSystem {
                         .alloc_contiguous_blocks(data, group_idx, count);
                 })?;
 
+            // Check the allocation result *before* doing any mutable descriptor
+            // work. If the bitmap had no free block despite the descriptor claiming
+            // otherwise, the group is stale/inconsistent (e.g. dirty unmount with
+            // lazy initialisation). Skip to the next group instead of failing
+            // immediately so that groups with consistent bitmaps are still tried.
+            let alloc = match alloc_res {
+                Ok(a) => a,
+                Err(e) if e.code == Errno::ENOSPC => {
+                    warn!(
+                        "alloc_blocks: group={group_idx} descriptor claims {free} free blocks but \
+                         bitmap has none — descriptor/bitmap inconsistency, skipping group"
+                    );
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+
             if ext4_superblock_has_metadata_csum(&self.superblock) {
                 let sb = self.superblock;
                 let updated_data = self
@@ -72,8 +89,6 @@ impl Ext4FileSystem {
                     .ok_or(Ext4Error::corrupted())?;
                 desc_mut.update_checksum(&sb, group_idx.raw(), Some(&updated_data), None);
             }
-
-            let alloc = alloc_res?;
 
             if let Some(desc_mut) = self.get_group_desc_mut(group_idx) {
                 let before = desc_mut.free_blocks_count();

--- a/components/rsext4/src/file/io.rs
+++ b/components/rsext4/src/file/io.rs
@@ -374,7 +374,7 @@ pub fn write_file<B: BlockDevice>(
     write_inode_data(device, fs, inode_num, offset, data)
 }
 
-fn write_inode_data<B: BlockDevice>(
+pub fn write_inode_data<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     inode_num: InodeNumber,

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -33,6 +33,6 @@ mod rename;
 pub use blocks::build_file_block_mapping_with_inode_num;
 pub use create::{create_symbol_link, mkfile};
 pub use delete::{delete_dir, delete_file, unlink};
-pub use io::{read_file, truncate, write_file};
+pub use io::{read_file, truncate, write_file, write_inode_data};
 pub use link::link;
 pub use rename::{mv, rename};

--- a/components/rsext4/src/jbd2/jbd2.rs
+++ b/components/rsext4/src/jbd2/jbd2.rs
@@ -101,7 +101,25 @@ impl JBD2DEVSYSTEM {
         let mapped_len = u32::try_from(journal_blocks.len()).ok();
         let total_blocks = match mapped_len {
             Some(0) | None => self.jbd2_super_block.s_maxlen,
-            Some(len) => self.jbd2_super_block.s_maxlen.min(len),
+            // When s_maxlen from the on-disk journal superblock is smaller than
+            // the actual number of journal blocks (e.g. s_maxlen=1 due to an
+            // unclean shutdown that corrupted the journal superblock), trust the
+            // physical extent mapping rather than the stale s_maxlen.
+            Some(len) => {
+                let sb_maxlen = self.jbd2_super_block.s_maxlen;
+                if sb_maxlen > 0 && sb_maxlen >= self.jbd2_super_block.s_first {
+                    sb_maxlen.min(len)
+                } else {
+                    // s_maxlen is 0 or smaller than s_first — it is corrupted.
+                    // Fall back to the physical extent length.
+                    warn!(
+                        "[JBD2] s_maxlen={} < s_first={}: journal superblock s_maxlen is corrupt, \
+                         using physical extent length {} instead",
+                        sb_maxlen, self.jbd2_super_block.s_first, len
+                    );
+                    len
+                }
+            }
         };
 
         let last = total_blocks.checked_sub(1)?;
@@ -642,6 +660,20 @@ impl JBD2DEVSYSTEM {
     ) -> ReplayStatus {
         let mut journal_rel = self.jbd2_super_block.s_start;
         if journal_rel == 0 {
+            return ReplayStatus::Complete;
+        }
+
+        // If s_start points beyond the physical journal extent the on-disk
+        // journal superblock is inconsistent (e.g. corrupted by a crash that
+        // also mangled s_maxlen). There are no valid transactions to replay.
+        if !journal_blocks.is_empty() && journal_rel as usize >= journal_blocks.len() {
+            warn!(
+                "[JBD2] s_start={} >= journal_blocks.len()={}: journal superblock is \
+                 inconsistent, treating journal as clean",
+                journal_rel,
+                journal_blocks.len()
+            );
+            self.jbd2_super_block.s_start = 0;
             return ReplayStatus::Complete;
         }
 

--- a/components/rsext4/src/lib.rs
+++ b/components/rsext4/src/lib.rs
@@ -30,7 +30,7 @@ pub use error::{Errno, Ext4Error, Ext4Result};
 pub use ext4::{Ext4FileSystem, find_file, mkfs, mount, umount};
 pub use file::{
     create_symbol_link, delete_dir, delete_file, link, mkfile, mv, read_file, rename, truncate,
-    unlink, write_file,
+    unlink, write_file, write_inode_data,
 };
 pub use metadata::{chmod, chown, set_flags, set_project, utimens};
 

--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -272,7 +272,8 @@ impl Epoll {
         Self::default()
     }
 
-    // only register waker, not add to ready queue
+    // Register waker only — no immediate poll check.
+    // Used for NoEvent (spurious wakeup): re-arm and wait for a real state change.
     fn register_waker_only(&self, interest: &Arc<EpollInterest>) {
         let Some(file) = interest.key.get_file() else {
             return;
@@ -397,6 +398,7 @@ impl Epoll {
         // into the loop and filling out[] with duplicates of one ready fd.
         let mut txlist = core::mem::take(&mut *self.inner.ready_queue.lock());
         let mut count = 0;
+        let mut no_event_count = 0usize;
         let mut keep: VecDeque<Weak<EpollInterest>> = VecDeque::new();
 
         while let Some(weak_interest) = txlist.pop_front() {
@@ -416,9 +418,10 @@ impl Epoll {
                 continue;
             };
 
+            let current_poll = file.poll();
             trace!(
-                "Epoll: consuming ready interest for fd={}, events={:?}",
-                interest.key.fd, interest.event.events
+                "Epoll: consuming ready interest for fd={}, interest_events={:?}, file.poll()={:?}",
+                interest.key.fd, interest.event.events, current_poll
             );
 
             match interest.consume(file.as_ref()) {
@@ -449,17 +452,24 @@ impl Epoll {
                         keep.push_back(Arc::downgrade(&interest));
                     } else {
                         interest.mark_not_in_queue();
+                        // EPOLLET: re-arm by registering a fresh waker.
+                        // Any new data that arrived between mark_not_in_queue() and
+                        // register() will be caught by the still-live old InterestWaker
+                        // (held by the underlying PollSet), which calls try_mark_in_queue()
+                        // and re-queues the interest atomically.  We must NOT poll the
+                        // file here: existing unread data must not re-trigger ET — only a
+                        // state transition (new data arriving) should.
                         self.register_waker_only(&interest);
                     }
                 }
                 ConsumeResult::NoEvent => {
+                    no_event_count += 1;
+                    debug!(
+                        "Epoll: NoEvent fd={} interest={:?} file.poll()={:?} (spurious #{})",
+                        interest.key.fd, interest.event.events, current_poll, no_event_count
+                    );
                     interest.mark_not_in_queue();
-                    // Events arriving between consume()'s poll and the new
-                    // register() would otherwise be lost: the old waker
-                    // CAS-fails (in_ready_queue still set), and a plain
-                    // register only fires on the next edge. Re-poll after
-                    // registering to recover them.
-                    self.check_and_register_waker(&interest);
+                    self.register_waker_only(&interest);
                 }
             }
         }
@@ -476,6 +486,9 @@ impl Epoll {
         if count == 0 {
             Err(AxError::WouldBlock)
         } else {
+            if no_event_count > 0 {
+                debug!("Epoll: poll_events count={count} no_event_spurious={no_event_count}");
+            }
             Ok(count)
         }
     }

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -149,6 +149,7 @@ impl<T> UserPtr<T> {
         VirtAddr::from_ptr_of(self.0)
     }
 
+    #[allow(dead_code)]
     pub fn as_ptr(&self) -> *mut T {
         self.0
     }

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -276,7 +276,20 @@ fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
     };
 
     if unlikely(!thr.is_accessing_user_memory()) {
-        return false;
+        // Still handle kernel-mode faults on user-space addresses.
+        // This covers COW write faults that arise when kernel code holds a direct
+        // `&mut` reference into user memory (via get_as_mut / get_as_mut_slice) and
+        // a concurrent fork has re-marked the page read-only between check_region
+        // and the actual write.
+        let user_range = USER_SPACE_BASE..USER_SPACE_BASE + USER_SPACE_SIZE;
+        if !user_range.contains(&vaddr.as_usize()) {
+            return false;
+        }
+        // Avoid deadlock: the aspace lock must not already be held by this thread.
+        let aspace_arc = thr.proc_data.aspace();
+        if unsafe { aspace_arc.raw() }.is_owned_by_current() {
+            return false;
+        }
     }
 
     might_sleep();

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -162,6 +162,43 @@ impl DeviceOps for CpuDmaLatency {
     }
 }
 
+/// QEMU debugcon device (I/O port 0xE9). Userspace writes land in the
+/// `-debugcon` output file, bypassing the TTY and jcode's log rotation.
+/// Only meaningful on x86_64 with QEMU `-debugcon` configured.
+#[cfg(target_arch = "x86_64")]
+struct DebugConDev;
+
+#[cfg(target_arch = "x86_64")]
+impl DeviceOps for DebugConDev {
+    fn read_at(&self, _buf: &mut [u8], _offset: u64) -> VfsResult<usize> {
+        Ok(0)
+    }
+
+    fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {
+        for &b in buf {
+            // SAFETY: writing to the QEMU debugcon port is a pure side-effect;
+            // no memory is read or written.
+            unsafe {
+                core::arch::asm!(
+                    "out dx, al",
+                    in("dx") 0xe9u16,
+                    in("al") b,
+                    options(nomem, nostack, preserves_flags)
+                );
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn flags(&self) -> NodeFlags {
+        NodeFlags::NON_CACHEABLE | NodeFlags::STREAM
+    }
+}
+
 fn builder(fs: Arc<SimpleFs>) -> DirMaker {
     let mut root = DirMapping::new();
     root.add(
@@ -277,6 +314,16 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
             NodeType::CharacterDevice,
             DeviceId::new(10, 1024),
             Arc::new(CpuDmaLatency),
+        ),
+    );
+    #[cfg(target_arch = "x86_64")]
+    root.add(
+        "debugcon",
+        Device::new(
+            fs.clone(),
+            NodeType::CharacterDevice,
+            DeviceId::new(1, 254),
+            Arc::new(DebugConDev),
         ),
     );
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -13,6 +13,7 @@ use ax_task::current;
 use axfs_ng_vfs::NodeFlags;
 use axpoll::{IoEvents, Pollable};
 use starry_process::Process;
+use starry_signal::{SignalInfo, Signo};
 use starry_vm::{VmMutPtr, VmPtr};
 
 use self::terminal::{
@@ -28,7 +29,7 @@ pub use self::{
 };
 use crate::{
     pseudofs::DeviceOps,
-    task::{AsThread, get_process_group},
+    task::{AsThread, get_process_group, send_signal_to_process_group},
 };
 
 /// Tty device
@@ -143,7 +144,22 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
             }
             TIOCSWINSZ => {
                 let window_size = (arg as *const WindowSize).vm_read()?;
-                *self.terminal.window_size.lock() = window_size;
+                let old = {
+                    let mut guard = self.terminal.window_size.lock();
+                    let old = *guard;
+                    *guard = window_size;
+                    old
+                };
+                // Send SIGWINCH to the foreground process group when the
+                // terminal dimensions change, matching Linux tty_do_resize().
+                if old.ws_row != window_size.ws_row || old.ws_col != window_size.ws_col {
+                    if let Some(pg) = self.terminal.job_control.foreground() {
+                        let _ = send_signal_to_process_group(
+                            pg.pgid(),
+                            Some(SignalInfo::new_kernel(Signo::SIGWINCH)),
+                        );
+                    }
+                }
             }
             TIOCSPTLCK => {}
             TIOCGPTN => {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
@@ -5,7 +5,10 @@ use lazy_static::lazy_static;
 
 use super::{
     Tty,
-    terminal::ldisc::{ProcessMode, TtyConfig, TtyRead, TtyWrite},
+    terminal::{
+        WindowSize,
+        ldisc::{ProcessMode, TtyConfig, TtyRead, TtyWrite},
+    },
 };
 
 pub type NTtyDriver = Tty<Console, Console>;
@@ -41,14 +44,81 @@ fn handle_console_input_irq(_irq_num: usize) {
 }
 
 fn new_n_tty() -> Arc<NTtyDriver> {
+    // Query the actual terminal dimensions before spawning the input reader,
+    // so that TIOCGWINSZ reports the real host terminal size.  Applications
+    // like jcode use the size to lay out panels and to map mouse coordinates
+    // to screen regions; a stale or wrong size breaks mouse scroll entirely.
+    let terminal = {
+        let t = super::terminal::Terminal::default();
+        if let Some((rows, cols)) = query_console_size() {
+            *t.window_size.lock() = WindowSize {
+                ws_row: rows,
+                ws_col: cols,
+                ws_xpixel: 0,
+                ws_ypixel: 0,
+            };
+        }
+        Arc::new(t)
+    };
+
     Tty::new(
-        Arc::default(),
+        terminal,
         TtyConfig {
             reader: Console,
             writer: Console,
             process_mode: console_irq_mode().unwrap_or(ProcessMode::Manual),
         },
     )
+}
+
+/// Query the connected terminal's dimensions using the standard cursor-position
+/// interrogation sequence (CPR / DECXCPR).
+///
+/// Sequence: save cursor → move to (9999,9999) → request CPR → restore cursor.
+/// The terminal replies with `\x1b[rows;colsR`.  We spin-wait up to ~100 ms
+/// for the reply and return `None` on timeout or parse failure.
+///
+/// This is called once, synchronously, before the poll-reader task is spawned,
+/// so there is no race on the UART receive FIFO.
+fn query_console_size() -> Option<(u16, u16)> {
+    // save cursor, jump to extreme bottom-right, request CPR, restore cursor
+    ax_hal::console::write_bytes(b"\x1b7\x1b[9999;9999H\x1b[6n\x1b8");
+
+    let mut buf = [0u8; 32];
+    let mut len = 0usize;
+
+    // Spin-wait up to ~100 ms for the `R` terminator.  On a 1 GHz CPU 60 M
+    // iterations ≈ 60 ms; on a 3 GHz host the round-trip is well under 1 ms.
+    'collect: for _ in 0..60_000_000usize {
+        let mut tmp = [0u8; 1];
+        if ax_hal::console::read_bytes(&mut tmp) > 0 {
+            if len < buf.len() {
+                buf[len] = tmp[0];
+                len += 1;
+            }
+            if tmp[0] == b'R' {
+                break 'collect;
+            }
+        }
+        core::hint::spin_loop();
+    }
+
+    if len == 0 {
+        return None;
+    }
+
+    // The response is `\x1b[rows;colsR`.  Search for the *last* `\x1b[`
+    // before the `R` to skip any garbage that may precede it.
+    let r_pos = buf[..len].iter().rposition(|&b| b == b'R')?;
+    let escape_pos = buf[..r_pos].windows(2).rposition(|w| w == b"\x1b[")?;
+    let inner = core::str::from_utf8(&buf[escape_pos + 2..r_pos]).ok()?;
+    let mut parts = inner.splitn(2, ';');
+    let rows: u16 = parts.next()?.parse().ok()?;
+    let cols: u16 = parts.next()?.parse().ok()?;
+    if rows == 0 || cols == 0 {
+        return None;
+    }
+    Some((rows, cols))
 }
 
 fn console_irq_mode() -> Option<ProcessMode> {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -22,7 +22,13 @@ use starry_signal::SignalInfo;
 use super::{Terminal, termios::Termios2};
 use crate::task::send_signal_to_process_group;
 
-const BUF_SIZE: usize = 80;
+// Keep input line-processing buffer small (one line is rarely > 80 chars), but
+// give the ring buffer itself 4096 bytes so that a PTY passive-read can drain
+// the full slave_to_master ring (also 4096) in a single poll_read() call.
+// Without this, a 500-byte shell output generates ⌈500/80⌉ = 7 epoll round-trips
+// with Tokio's EPOLLET reactor; with 4096 the same burst needs only one.
+const LINE_BUF_SIZE: usize = 128;
+const BUF_SIZE: usize = 4096;
 
 type ReadBuf = Arc<ringbuf::StaticRb<u8, BUF_SIZE>>;
 
@@ -64,19 +70,19 @@ pub fn write_output_bytes<W: TtyWrite + ?Sized>(writer: &W, term: &Termios2, buf
         return;
     }
 
-    let mut start = 0;
-    for (i, &byte) in buf.iter().enumerate() {
+    // Collect output with \n→\r\n translation into a single buffer so we
+    // make exactly one writer.write() call instead of one per newline.
+    // This prevents partial-frame writes to the UART that cause visible
+    // line-by-line flicker on serial-connected terminal emulators.
+    let extra = buf.iter().filter(|&&b| b == b'\n').count();
+    let mut out = alloc::vec::Vec::with_capacity(buf.len() + extra);
+    for &byte in buf {
         if byte == b'\n' {
-            if start < i {
-                writer.write(&buf[start..i]);
-            }
-            writer.write(b"\r\n");
-            start = i + 1;
+            out.push(b'\r');
         }
+        out.push(byte);
     }
-    if start < buf.len() {
-        writer.write(&buf[start..]);
-    }
+    writer.write(&out);
 }
 
 struct InputReader<R, W> {
@@ -86,7 +92,7 @@ struct InputReader<R, W> {
     writer: W,
 
     buf_tx: CachingProd<ReadBuf>,
-    read_buf: [u8; BUF_SIZE],
+    read_buf: [u8; LINE_BUF_SIZE],
     read_range: Range<usize>,
 
     line_buf: Vec<u8>,
@@ -230,13 +236,28 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
 
 struct SimpleReader<R> {
     reader: R,
-    read_buf: [u8; BUF_SIZE],
+    read_buf: [u8; LINE_BUF_SIZE],
     buf_tx: CachingProd<ReadBuf>,
 }
 impl<R: TtyRead> SimpleReader<R> {
     pub fn poll(&mut self) {
-        let read = self.reader.read(&mut self.read_buf);
-        let _ = self.buf_tx.push_slice(&self.read_buf[..read]);
+        // Drain all available data from the underlying source into buf_rx.
+        // Looping ensures that a burst larger than LINE_BUF_SIZE (the scratch
+        // chunk) still reaches the ring buffer in a single poll() call as long
+        // as there is room in buf_rx (BUF_SIZE = 4096).
+        loop {
+            if self.buf_tx.vacant_len() == 0 {
+                break;
+            }
+            let read = self.reader.read(&mut self.read_buf);
+            if read == 0 {
+                break;
+            }
+            let pushed = self.buf_tx.push_slice(&self.read_buf[..read]);
+            if pushed < read {
+                break; // buf_rx full
+            }
+        }
     }
 }
 
@@ -343,7 +364,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             writer: config.writer,
 
             buf_tx,
-            read_buf: [0; BUF_SIZE],
+            read_buf: [0; LINE_BUF_SIZE],
             read_range: 0..0,
 
             line_buf: Vec::new(),
@@ -373,7 +394,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
                 Processor::Passive(
                     SimpleReader {
                         reader,
-                        read_buf: [0; BUF_SIZE],
+                        read_buf: [0; LINE_BUF_SIZE],
                         buf_tx,
                     },
                     poll_rx,
@@ -480,7 +501,7 @@ mod tests {
 
     use ringbuf::traits::{Observer, Split};
 
-    use super::{BUF_SIZE, InputReader, ReadBuf, TtyRead, TtyWrite};
+    use super::{InputReader, LINE_BUF_SIZE, ReadBuf, TtyRead, TtyWrite};
     use crate::pseudofs::dev::tty::terminal::Terminal;
 
     struct MockReader {
@@ -519,7 +540,7 @@ mod tests {
             reader: MockReader::new(data),
             writer: MockWriter,
             buf_tx,
-            read_buf: [0; BUF_SIZE],
+            read_buf: [0; LINE_BUF_SIZE],
             read_range: 0..0,
             line_buf: Vec::new(),
             line_read: None,
@@ -529,23 +550,23 @@ mod tests {
         (reader, buf_rx)
     }
 
-    /// Regression test: a canonical-mode input longer than BUF_SIZE characters
+    /// Regression test: a canonical-mode input longer than LINE_BUF_SIZE characters
     /// (with no newline in the first chunk) must not stall drain_source_into_line_buffer.
     ///
     /// Before the fix, the function returned `sent > 0` which was false after the
-    /// first BUF_SIZE bytes were consumed into line_buf (no newline yet), causing
+    /// first LINE_BUF_SIZE bytes were consumed into line_buf (no newline yet), causing
     /// drive_input() to stop looping and the remaining input (including the newline)
     /// to be silently dropped.  The board CI symptom was shell commands being
-    /// truncated to the first BUF_SIZE characters (e.g. "sleep 5; ..." → "leep 5; ...").
+    /// truncated to the first LINE_BUF_SIZE characters.
     #[test]
     fn canonical_long_line_drain_continues_past_buf_size() {
-        // BUF_SIZE ordinary chars followed by '\n' — total BUF_SIZE+1 bytes.
-        let mut data: Vec<u8> = (0..BUF_SIZE).map(|_| b'a').collect();
+        // LINE_BUF_SIZE ordinary chars followed by '\n' — total LINE_BUF_SIZE+1 bytes.
+        let mut data: Vec<u8> = (0..LINE_BUF_SIZE).map(|_| b'a').collect();
         data.push(b'\n');
 
         let (mut reader, mut rx) = make_reader(data);
 
-        // First drain: reads the BUF_SIZE 'a' bytes into line_buf; no newline yet,
+        // First drain: reads the LINE_BUF_SIZE 'a' bytes into line_buf; no newline yet,
         // so nothing reaches buf_rx.  Must still return true (progress was made).
         assert!(
             reader.drain_source_into_line_buffer(),

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/mod.rs
@@ -30,8 +30,8 @@ impl Default for Terminal {
         Self {
             job_control: job::JobControl::new(),
             window_size: SpinNoPreempt::new(WindowSize {
-                ws_row: 28,
-                ws_col: 110,
+                ws_row: 24,
+                ws_col: 80,
                 ws_xpixel: 0,
                 ws_ypixel: 0,
             }),

--- a/os/StarryOS/kernel/src/syscall/io_mpx/epoll.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/epoll.rs
@@ -1,4 +1,5 @@
-use core::{mem::size_of, time::Duration};
+use alloc::vec;
+use core::time::Duration;
 
 use ax_errno::{AxError, AxResult};
 use ax_task::future::{self, block_on, poll_io};
@@ -15,23 +16,11 @@ use crate::{
         FileLike,
         epoll::{Epoll, EpollEvent, EpollFlags},
     },
-    mm::{UserConstPtr, UserPtr, check_access, nullable},
+    mm::{UserConstPtr, UserPtr, nullable},
     syscall::signal::check_sigset_size,
     task::with_blocked_signals,
     time::TimeValueLike,
 };
-
-const EP_MAX_EVENTS: usize = i32::MAX as usize / size_of::<epoll_event>();
-
-fn check_epoll_events_access(events: UserPtr<epoll_event>, maxevents: usize) -> AxResult<()> {
-    let len = maxevents
-        .checked_mul(size_of::<epoll_event>())
-        .ok_or(AxError::BadAddress)?;
-    let start = events.as_ptr() as usize;
-    start.checked_add(len).ok_or(AxError::BadAddress)?;
-    check_access(start, len)?;
-    Ok(())
-}
 
 bitflags! {
     /// Flags for the `epoll_create` syscall.
@@ -107,33 +96,35 @@ fn do_epoll_wait(
         return Err(AxError::InvalidInput);
     }
     let maxevents = maxevents as usize;
-    if maxevents > EP_MAX_EVENTS {
-        return Err(AxError::InvalidInput);
-    }
-    if events.is_null() {
-        return Err(AxError::BadAddress);
-    }
-    check_epoll_events_access(events, maxevents)?;
+
+    // Allocate a kernel-owned buffer for the events (Linux-compatible approach).
+    // We operate on kernel memory and write results back via vm_write_slice,
+    // avoiding direct references to user memory that can trigger unhandled
+    // COW write-faults from kernel mode.
+    // epoll_event derives Copy, so vec![zero; n] is safe and avoids unsafe.
+    let mut kevents = vec![epoll_event { events: 0, data: 0 }; maxevents];
 
     let count = with_blocked_signals(
         nullable!(sigmask.get_as_ref())?.copied(),
         || match block_on(future::timeout(
             timeout,
             poll_io(epoll.as_ref(), IoEvents::IN, false, || {
-                epoll.poll_events_with(maxevents, |index, event| {
-                    vm_write_slice(
-                        events.as_ptr().wrapping_add(index),
-                        core::slice::from_ref(&event),
-                    )?;
-                    Ok(())
-                })
+                epoll.poll_events(&mut kevents)
             }),
         )) {
-            Ok(r) => r.map(|n| n as _),
+            Ok(r) => r.map(|n| n as isize),
             Err(_) => Ok(0),
         },
     )?;
 
+    // Write only the filled events back to user space.
+    if count > 0 {
+        vm_write_slice(
+            events.address().as_usize() as *mut epoll_event,
+            &kevents[..count as usize],
+        )
+        .map_err(|_| AxError::BadAddress)?;
+    }
     Ok(count)
 }
 

--- a/os/StarryOS/kernel/src/syscall/io_mpx/epoll.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/epoll.rs
@@ -109,7 +109,10 @@ fn do_epoll_wait(
         || match block_on(future::timeout(
             timeout,
             poll_io(epoll.as_ref(), IoEvents::IN, false, || {
-                epoll.poll_events(&mut kevents)
+                epoll.poll_events_with(maxevents, |index, event| {
+                    kevents[index] = event;
+                    Ok(())
+                })
             }),
         )) {
             Ok(r) => r.map(|n| n as isize),

--- a/os/StarryOS/kernel/src/syscall/io_mpx/poll.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/poll.rs
@@ -1,14 +1,11 @@
 use alloc::vec::Vec;
-use core::mem::{MaybeUninit, offset_of};
+use core::mem::MaybeUninit;
 
 use ax_errno::{AxError, AxResult};
 use ax_hal::time::TimeValue;
-use ax_task::{
-    current,
-    future::{self, block_on, poll_io},
-};
+use ax_task::future::{self, block_on, poll_io};
 use axpoll::IoEvents;
-use linux_raw_sys::general::{POLLNVAL, RLIMIT_NOFILE, pollfd, timespec};
+use linux_raw_sys::general::{POLLNVAL, pollfd, timespec};
 use starry_signal::SignalSet;
 use starry_vm::{vm_read_slice, vm_write_slice};
 
@@ -17,45 +14,27 @@ use crate::{
     file::get_file_like,
     mm::{UserConstPtr, UserPtr, nullable},
     syscall::signal::check_sigset_size,
-    task::{AsThread, with_blocked_signals},
+    task::with_blocked_signals,
     time::TimeValueLike,
 };
 
-fn check_nfds_limit(nfds: usize) -> AxResult<()> {
-    let nofile = current().as_thread().proc_data.rlim.read()[RLIMIT_NOFILE].current;
-    if nfds as u64 > nofile {
-        Err(AxError::InvalidInput)
-    } else {
-        Ok(())
-    }
-}
-
-fn read_poll_fds(fds: UserPtr<pollfd>, nfds: usize) -> AxResult<Vec<pollfd>> {
-    check_nfds_limit(nfds)?;
+/// Copy a user-space pollfd array into a kernel-owned Vec.
+///
+/// This is the Linux-style approach: copy the struct array to kernel memory
+/// first, operate on the copy, then write results back via vm_write_slice.
+/// Direct references to user memory are avoided to prevent unhandled COW
+/// write-faults when the page is re-protected by a concurrent fork.
+fn read_poll_fds_from_user(ptr: UserPtr<pollfd>, nfds: usize) -> AxResult<Vec<pollfd>> {
     if nfds == 0 {
         return Ok(Vec::new());
     }
-
-    let mut buf = Vec::with_capacity(nfds);
-    buf.resize_with(nfds, MaybeUninit::uninit);
-    vm_read_slice(fds.as_ptr(), &mut buf)?;
-    Ok(buf
-        .into_iter()
-        .map(|fd| unsafe { fd.assume_init() })
-        .collect())
-}
-
-fn write_poll_revents(fds: UserPtr<pollfd>, poll_fds: &[pollfd]) -> AxResult<()> {
-    let revents_offset = offset_of!(pollfd, revents);
-
-    for (index, poll_fd) in poll_fds.iter().enumerate() {
-        let revents_ptr = (fds.as_ptr().wrapping_add(index) as *mut u8)
-            .wrapping_add(revents_offset)
-            .cast::<_>();
-        vm_write_slice(revents_ptr, core::slice::from_ref(&poll_fd.revents))?;
-    }
-
-    Ok(())
+    let mut buf = alloc::vec![MaybeUninit::<pollfd>::uninit(); nfds];
+    vm_read_slice(ptr.address().as_usize() as *const pollfd, &mut buf)
+        .map_err(|_| AxError::BadAddress)?;
+    // SAFETY: pollfd consists entirely of integer fields (i32, i16, i16);
+    // all bit patterns are valid, so assume_init is sound.
+    let mut md = core::mem::ManuallyDrop::new(buf);
+    Ok(unsafe { Vec::from_raw_parts(md.as_mut_ptr().cast::<pollfd>(), md.len(), md.capacity()) })
 }
 
 fn do_poll(
@@ -67,9 +46,8 @@ fn do_poll(
 
     let mut res = 0isize;
     let mut fds = Vec::with_capacity(poll_fds.len());
-    let mut revent_indices = Vec::with_capacity(poll_fds.len());
-    for (index, fd) in poll_fds.iter_mut().enumerate() {
-        fd.revents = 0;
+    let mut revents = Vec::with_capacity(poll_fds.len());
+    for fd in poll_fds.iter_mut() {
         if fd.fd == -1 {
             // Skip -1
             continue;
@@ -81,7 +59,7 @@ fn do_poll(
                     IoEvents::from_bits(fd.events as _).ok_or(AxError::InvalidInput)?
                         | IoEvents::ALWAYS_POLL,
                 ));
-                revent_indices.push(index);
+                revents.push(&mut fd.revents);
             }
             Err(_) => {
                 // If the fd is invalid, set revents to POLLNVAL
@@ -100,7 +78,7 @@ fn do_poll(
             timeout,
             poll_io(&fds, IoEvents::empty(), false, || {
                 let mut res = 0usize;
-                for ((fd, events), revent_index) in fds.0.iter().zip(revent_indices.iter()) {
+                for ((fd, events), revents) in fds.0.iter().zip(revents.iter_mut()) {
                     let mut result = fd.poll();
                     if result.contains(IoEvents::IN) {
                         result |= IoEvents::RDNORM;
@@ -115,9 +93,8 @@ fn do_poll(
                     result &= *events;
                     result |= always_report;
 
-                    let revents = &mut poll_fds[*revent_index].revents;
-                    *revents = result.bits() as _;
-                    if *revents != 0 {
+                    **revents = result.bits() as _;
+                    if **revents != 0 {
                         res += 1;
                     }
                 }
@@ -136,18 +113,22 @@ fn do_poll(
 
 #[cfg(target_arch = "x86_64")]
 pub fn sys_poll(fds: UserPtr<pollfd>, nfds: u32, timeout: i32) -> AxResult<isize> {
+    debug!("sys_poll <= nfds: {nfds}");
     let nfds = nfds as usize;
-    let mut poll_fds = read_poll_fds(fds, nfds)?;
+    // Copy user pollfd array into kernel buffer (Linux-compatible approach).
+    let mut kfds = read_poll_fds_from_user(fds, nfds)?;
     let timeout = if timeout < 0 {
         None
     } else {
         Some(TimeValue::from_millis(timeout as u64))
     };
-    let res = do_poll(&mut poll_fds, timeout, None)?;
+    let result = do_poll(&mut kfds, timeout, None)?;
+    // Write the updated pollfd array (including revents) back to user space.
     if nfds > 0 {
-        write_poll_revents(fds, &poll_fds)?;
+        vm_write_slice(fds.address().as_usize() as *mut pollfd, &kfds)
+            .map_err(|_| AxError::BadAddress)?;
     }
-    Ok(res)
+    Ok(result)
 }
 
 pub fn sys_ppoll(
@@ -159,18 +140,18 @@ pub fn sys_ppoll(
 ) -> AxResult<isize> {
     check_sigset_size(sigsetsize)?;
     let nfds = nfds.try_into().map_err(|_| AxError::InvalidInput)?;
-    let mut poll_fds = read_poll_fds(fds, nfds)?;
+    let mut kfds = read_poll_fds_from_user(fds, nfds)?;
     let timeout = nullable!(timeout.get_as_ref())?
         .map(|ts| ts.try_into_time_value())
         .transpose()?;
-    // TODO: handle signal
-    let res = do_poll(
-        &mut poll_fds,
+    let result = do_poll(
+        &mut kfds,
         timeout,
         nullable!(sigmask.get_as_ref())?.copied(),
     )?;
     if nfds > 0 {
-        write_poll_revents(fds, &poll_fds)?;
+        vm_write_slice(fds.address().as_usize() as *mut pollfd, &kfds)
+            .map_err(|_| AxError::BadAddress)?;
     }
-    Ok(res)
+    Ok(result)
 }

--- a/os/StarryOS/kernel/src/syscall/io_mpx/select.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/select.rs
@@ -123,15 +123,15 @@ fn do_select(
                     let selected_except =
                         selected.contains(IoEvents::ERR) && except_set.0.get(index);
 
-                    if selected_read && let Some(set) = readfds.as_deref_mut() {
+                    if selected_read && let Some(ref mut set) = k_readfds {
                         res += 1;
                         unsafe { FD_SET(index as _, set) };
                     }
-                    if selected_write && let Some(set) = writefds.as_deref_mut() {
+                    if selected_write && let Some(ref mut set) = k_writefds {
                         res += 1;
                         unsafe { FD_SET(index as _, set) };
                     }
-                    if selected_except && let Some(set) = exceptfds.as_deref_mut() {
+                    if selected_except && let Some(ref mut set) = k_exceptfds {
                         res += 1;
                         unsafe { FD_SET(index as _, set) };
                     }

--- a/os/StarryOS/kernel/src/syscall/io_mpx/select.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/select.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use core::{fmt, time::Duration};
+use core::{fmt, mem::MaybeUninit, time::Duration};
 
 use ax_errno::{AxError, AxResult};
 use ax_task::future::{self, block_on, poll_io};
@@ -7,9 +7,10 @@ use axpoll::IoEvents;
 use bitmaps::Bitmap;
 use linux_raw_sys::{
     general::*,
-    select_macros::{FD_ISSET, FD_SET, FD_ZERO},
+    select_macros::{FD_ISSET, FD_SET},
 };
 use starry_signal::SignalSet;
+use starry_vm::{vm_read_slice, vm_write_slice};
 
 use super::FdPollSet;
 use crate::{
@@ -42,6 +43,32 @@ impl fmt::Debug for FdSet {
     }
 }
 
+/// Copy a single `__kernel_fd_set` from user space into a kernel-local value.
+///
+/// Returns `None` if the pointer is null (fd_set argument was omitted).
+fn read_fd_set_from_user(ptr: UserPtr<__kernel_fd_set>) -> AxResult<Option<__kernel_fd_set>> {
+    if ptr.is_null() {
+        return Ok(None);
+    }
+    let mut buf = [MaybeUninit::<__kernel_fd_set>::uninit()];
+    vm_read_slice(ptr.address().as_usize() as *const __kernel_fd_set, &mut buf)
+        .map_err(|_| AxError::BadAddress)?;
+    // SAFETY: __kernel_fd_set is [c_ulong; 16]; all bit patterns are valid.
+    Ok(Some(unsafe { buf[0].assume_init() }))
+}
+
+/// Write a kernel-local `__kernel_fd_set` back to user space.
+fn write_fd_set_to_user(ptr: UserPtr<__kernel_fd_set>, set: &__kernel_fd_set) -> AxResult<()> {
+    if ptr.is_null() {
+        return Ok(());
+    }
+    vm_write_slice(
+        ptr.address().as_usize() as *mut __kernel_fd_set,
+        core::slice::from_ref(set),
+    )
+    .map_err(|_| AxError::BadAddress)
+}
+
 fn do_select(
     nfds: u32,
     readfds: UserPtr<__kernel_fd_set>,
@@ -61,13 +88,16 @@ fn do_select(
         None
     };
 
-    let mut readfds = nullable!(readfds.get_as_mut())?;
-    let mut writefds = nullable!(writefds.get_as_mut())?;
-    let mut exceptfds = nullable!(exceptfds.get_as_mut())?;
+    // Read the input fd_sets from user space into kernel-local copies.
+    // Reads are safe even on COW pages (read faults are never triggered by
+    // COW; only writes are).
+    let r_readfds = read_fd_set_from_user(readfds)?;
+    let r_writefds = read_fd_set_from_user(writefds)?;
+    let r_exceptfds = read_fd_set_from_user(exceptfds)?;
 
-    let read_set = FdSet::new(nfds as _, readfds.as_deref());
-    let write_set = FdSet::new(nfds as _, writefds.as_deref());
-    let except_set = FdSet::new(nfds as _, exceptfds.as_deref());
+    let read_set = FdSet::new(nfds as _, r_readfds.as_ref());
+    let write_set = FdSet::new(nfds as _, r_writefds.as_ref());
+    let except_set = FdSet::new(nfds as _, r_exceptfds.as_ref());
 
     debug!(
         "sys_select <= nfds: {nfds} sets: [read: {read_set:?}, write: {write_set:?}, except: \
@@ -98,16 +128,16 @@ fn do_select(
     drop(fd_table);
     let fds = FdPollSet(fds);
 
-    if let Some(readfds) = readfds.as_deref_mut() {
-        unsafe { FD_ZERO(readfds) };
-    }
-    if let Some(writefds) = writefds.as_deref_mut() {
-        unsafe { FD_ZERO(writefds) };
-    }
-    if let Some(exceptfds) = exceptfds.as_deref_mut() {
-        unsafe { FD_ZERO(exceptfds) };
-    }
-    with_blocked_signals(sigmask.copied(), || {
+    // Kernel-local output fd_sets, zero-initialised (equivalent to FD_ZERO).
+    // We build results here and write them back to user space after polling.
+    let mut k_readfds: Option<__kernel_fd_set> =
+        r_readfds.map(|_| unsafe { core::mem::zeroed::<__kernel_fd_set>() });
+    let mut k_writefds: Option<__kernel_fd_set> =
+        r_writefds.map(|_| unsafe { core::mem::zeroed::<__kernel_fd_set>() });
+    let mut k_exceptfds: Option<__kernel_fd_set> =
+        r_exceptfds.map(|_| unsafe { core::mem::zeroed::<__kernel_fd_set>() });
+
+    let result = with_blocked_signals(sigmask.copied(), || {
         match block_on(future::timeout(
             timeout,
             poll_io(&fds, IoEvents::empty(), false, || {
@@ -146,7 +176,22 @@ fn do_select(
             Ok(r) => r,
             Err(_) => Ok(0),
         }
-    })
+    })?;
+
+    // Write the kernel-local fd_sets back to user space via vm_write_slice.
+    // This goes through access_user_memory + user_copy, which correctly handles
+    // COW write-faults that may have been introduced by a concurrent fork.
+    if let Some(ref set) = k_readfds {
+        write_fd_set_to_user(readfds, set)?;
+    }
+    if let Some(ref set) = k_writefds {
+        write_fd_set_to_user(writefds, set)?;
+    }
+    if let Some(ref set) = k_exceptfds {
+        write_fd_set_to_user(exceptfds, set)?;
+    }
+
+    Ok(result)
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
@@ -277,14 +277,10 @@ impl FileNodeOps for Inode {
         {
             let mut state = self.fs.lock();
             let (fs, dev) = state.split();
-            rsext4::write_file(
-                dev,
-                fs,
-                &self.path.clone().ok_or(VfsError::InvalidInput)?,
-                offset,
-                buf,
-            )
-            .map_err(into_vfs_err)?;
+            // Use inode-number-based write to avoid path re-resolution.
+            // Path-based write_file() fails with NotFound after rename/unlink,
+            // which causes dirty page loss when jcode atomically replaces files.
+            rsext4::write_inode_data(dev, fs, self.ino, offset, buf).map_err(into_vfs_err)?;
         }
         self.fs.sync_to_disk()?;
         Ok(buf.len())
@@ -296,14 +292,7 @@ impl FileNodeOps for Inode {
             let (fs, dev) = state.split();
             let inode = fs.get_inode_by_num(dev, self.ino).map_err(into_vfs_err)?;
             let length = inode.size();
-            rsext4::write_file(
-                dev,
-                fs,
-                &self.path.clone().ok_or(VfsError::InvalidInput)?,
-                length,
-                buf,
-            )
-            .map_err(into_vfs_err)?;
+            rsext4::write_inode_data(dev, fs, self.ino, length, buf).map_err(into_vfs_err)?;
             length
         };
         self.fs.sync_to_disk()?;

--- a/os/arceos/modules/axnet-ng/src/consts.rs
+++ b/os/arceos/modules/axnet-ng/src/consts.rs
@@ -22,4 +22,11 @@ pub const RAW_TX_BUF_LEN: usize = 64 * 1024;
 pub const LISTEN_QUEUE_SIZE: usize = 512;
 
 pub const SOCKET_BUFFER_SIZE: usize = 64;
-pub const ETHERNET_MAX_PENDING_PACKETS: usize = 32;
+/// Number of outbound packets that can be queued while waiting for ARP
+/// resolution of the next-hop.  32 was too small: applications like jcode
+/// open 10-20 concurrent TCP connections at startup and generate a burst of
+/// SYN/HTTP-CONNECT packets before the gateway ARP reply arrives.  Also,
+/// if the ARP cache expires mid-stream (60 s TTL) while a large streaming
+/// response is in flight, all the TCP ACKs queue simultaneously.
+/// 256 × 1514 ≈ 384 KiB is comfortable for these workloads.
+pub const ETHERNET_MAX_PENDING_PACKETS: usize = 256;

--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -118,7 +118,12 @@ fn release_ethernet_irq_slot(slot: usize, state: &Arc<EthernetIrqState>) {
 }
 
 impl EthernetDevice {
-    const NEIGHBOR_TTL: Duration = Duration::from_secs(60);
+    /// ARP cache lifetime.  60 s was too short: if an AI streaming response
+    /// takes longer than 60 s to arrive (cold-start server + API latency), the
+    /// gateway ARP expires just as the response begins flowing, causing a burst
+    /// of outbound ACKs to queue for re-resolution and overflow the pending
+    /// buffer.  300 s matches the Linux kernel default for unicast entries.
+    const NEIGHBOR_TTL: Duration = Duration::from_secs(300);
     const ARP_REQUEST_RETRY: Duration = Duration::from_secs(1);
 
     pub fn new(name: String, inner: AxNetDevice, ip: Option<Ipv4Cidr>) -> Self {
@@ -357,38 +362,57 @@ impl EthernetDevice {
                 );
             }
 
-            if self
-                .pending_packets
-                .peek()
-                .is_ok_and(|it| it.0 == &IpAddress::Ipv4(source_protocol_addr))
-            {
-                while let Ok((&next_hop, buf)) = self.pending_packets.peek() {
-                    // TODO: optimize logic such that one long-pending ARP
-                    // request does not block all other packets
+            // Drain all pending packets whose next-hop is now resolved.
+            // The old code checked only the queue head; if packets for a
+            // different (still-unresolved) next-hop happened to be at the
+            // front, packets for the just-resolved address were never sent.
+            // Instead, dequeue everything, send what is resolvable, and
+            // re-enqueue the rest.
+            let mut kept: Vec<(IpAddress, Vec<u8>)> = Vec::new();
+            // Cap iterations to the buffer capacity to avoid an infinite loop
+            // if re-enqueued items are immediately visible on peek().
+            for _ in 0..ETHERNET_MAX_PENDING_PACKETS {
+                let Ok((&next_hop, buf)) = self.pending_packets.peek() else {
+                    break;
+                };
+                let packet = buf.to_vec();
+                let _ = self.pending_packets.dequeue();
 
-                    let Some(neighbor) = self.neighbors.get(&next_hop) else {
-                        break;
-                    };
-                    if neighbor.expires_at <= now {
-                        // Neighbor is expired, we need to request ARP again
+                match self.neighbors.get(&next_hop) {
+                    Some(neighbor) if neighbor.expires_at > now => {
+                        let mut inner = self.inner.driver.lock();
+                        trace!(
+                            "{}: sending pending IPv4 packet to {} via {}",
+                            self.name, next_hop, neighbor.hardware_address
+                        );
+                        Self::send_to(
+                            &mut inner,
+                            neighbor.hardware_address,
+                            packet.len(),
+                            |b| b.copy_from_slice(&packet),
+                            EthernetProtocol::Ipv4,
+                        );
+                    }
+                    Some(_) => {
+                        // ARP expired; re-request and keep the packet.
                         self.neighbors.remove(&next_hop);
                         let _ = self.request_arp(next_hop, now);
-                        break;
+                        kept.push((next_hop, packet));
                     }
-
-                    let mut inner = self.inner.driver.lock();
-                    info!(
-                        "{}: sending pending IPv4 packet to {} via {}",
-                        self.name, next_hop, neighbor.hardware_address
-                    );
-                    Self::send_to(
-                        &mut inner,
-                        neighbor.hardware_address,
-                        buf.len(),
-                        |b| b.copy_from_slice(buf),
-                        EthernetProtocol::Ipv4,
-                    );
-                    let _ = self.pending_packets.dequeue();
+                    None => {
+                        // Not yet resolved; keep waiting.
+                        kept.push((next_hop, packet));
+                    }
+                }
+            }
+            // Re-enqueue packets that could not be sent yet.
+            for (next_hop, packet) in kept {
+                if self.pending_packets.is_full() {
+                    warn!("Pending packets buffer is full after ARP drain, dropping packet");
+                    break;
+                }
+                if let Ok(dst) = self.pending_packets.enqueue(packet.len(), next_hop) {
+                    dst.copy_from_slice(&packet);
                 }
             }
         }

--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -512,8 +512,14 @@ impl Device for EthernetDevice {
     }
 
     fn register_waker(&self, waker: &Waker) {
-        if self.inner.irq_num.is_some() {
+        if let Some(irq) = self.inner.irq_num {
+            warn!("EthernetDevice: register_waker on IRQ={irq}");
             self.inner.poll_ready.register(waker);
+        } else {
+            warn!(
+                "EthernetDevice: register_waker called but irq_num=None — waker NOT registered, \
+                 TCP wake will never fire!"
+            );
         }
     }
 }

--- a/os/arceos/modules/axnet-ng/src/lib.rs
+++ b/os/arceos/modules/axnet-ng/src/lib.rs
@@ -69,6 +69,7 @@ static SOCKET_SET: Lazy<SocketSetWrapper> = Lazy::new(SocketSetWrapper::new);
 static SERVICE: Once<Mutex<Service>> = Once::new();
 static POLLING_INTERFACES: AtomicBool = AtomicBool::new(false);
 static POLL_AGAIN: AtomicBool = AtomicBool::new(false);
+static POLL_INTERFACES_COUNT: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
 const DHCP_BOOTSTRAP_ATTEMPTS: usize = 200;
 const DHCP_BOOTSTRAP_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -175,6 +176,10 @@ pub fn init_vsock(mut vsock_devs: AxDeviceContainer<AxVsockDevice>) {
 
 /// Poll all network interfaces for new events.
 pub fn poll_interfaces() {
+    let count = POLL_INTERFACES_COUNT.fetch_add(1, Ordering::Relaxed);
+    if count.is_multiple_of(200) {
+        debug!("poll_interfaces called {} times total", count);
+    }
     POLL_AGAIN.store(true, Ordering::Release);
     loop {
         if POLLING_INTERFACES

--- a/os/arceos/modules/axnet-ng/src/service.rs
+++ b/os/arceos/modules/axnet-ng/src/service.rs
@@ -343,6 +343,7 @@ impl Service {
 
         if let Some(t) = next {
             let next = TimeValue::from_micros(t.total_micros() as _);
+            warn!("Service::register_waker: next poll_at = {:?}", next);
 
             // drop old timeout future
             self.timeout = None;
@@ -351,15 +352,19 @@ impl Service {
             let mut cx = Context::from_waker(waker);
 
             if fut.as_mut().poll(&mut cx).is_ready() {
+                warn!("Service::register_waker: timeout already ready, waking immediately");
                 waker.wake_by_ref();
                 return;
             } else {
                 self.timeout = Some(fut);
             }
+        } else {
+            warn!("Service::register_waker: no next poll_at (no pending timers), mask={mask:#x}");
         }
 
         for (i, device) in self.router.devices.iter().enumerate() {
             if mask & (1 << i) != 0 {
+                warn!("Service::register_waker: registering on device[{i}]");
                 device.register_waker(waker);
             }
         }

--- a/os/arceos/modules/axnet-ng/src/service.rs
+++ b/os/arceos/modules/axnet-ng/src/service.rs
@@ -343,7 +343,7 @@ impl Service {
 
         if let Some(t) = next {
             let next = TimeValue::from_micros(t.total_micros() as _);
-            warn!("Service::register_waker: next poll_at = {:?}", next);
+            debug!("Service::register_waker: next poll_at = {:?}", next);
 
             // drop old timeout future
             self.timeout = None;

--- a/os/arceos/modules/axnet-ng/src/tcp.rs
+++ b/os/arceos/modules/axnet-ng/src/tcp.rs
@@ -163,13 +163,16 @@ impl TcpSocket {
         let mut events = IoEvents::empty();
         self.with_smol_socket(|socket| match socket.state() {
             smol::State::SynSent | smol::State::SynReceived => {
-                // wait for connection
+                debug!(
+                    "TCP {}: poll_connect — still SynSent/SynReceived (waiting)",
+                    self.handle
+                );
             }
             smol::State::Established => {
                 self.clear_pending_error();
-                self.state.set(State::Connected); // connected
-                debug!(
-                    "TCP socket {}: connected to {}",
+                self.state.set(State::Connected);
+                warn!(
+                    "TCP {}: poll_connect — Established, connected to {}",
                     self.handle,
                     socket.remote_endpoint().unwrap(),
                 );
@@ -177,9 +180,9 @@ impl TcpSocket {
             }
             state => {
                 self.store_pending_error(LinuxError::ECONNREFUSED);
-                self.state.set(State::Closed); // connection failed
-                debug!(
-                    "TCP socket {}: connect failed in state {:?}",
+                self.state.set(State::Closed);
+                warn!(
+                    "TCP {}: poll_connect — connect failed in state {:?}",
                     self.handle, state
                 );
                 events.set(IoEvents::OUT, true);
@@ -361,15 +364,23 @@ impl SocketOps for TcpSocket {
         ax_task::yield_now();
 
         // Here our state must be `CONNECTING`, and only one thread can run here.
+        warn!(
+            "TCP {}: entering connect poll loop (nonblocking={})",
+            self.handle,
+            self.general.nonblocking()
+        );
         self.general.send_poller(self, || {
             poll_interfaces();
             let events = self.poll_connect();
             if !events.contains(IoEvents::OUT) {
                 Err(AxError::WouldBlock)
             } else if self.state() == State::Connected {
+                warn!("TCP {}: connect succeeded", self.handle);
                 Ok(())
             } else {
-                Err(self.connect_error())
+                let err = self.connect_error();
+                warn!("TCP {}: connect error {:?}", self.handle, err);
+                Err(err)
             }
         })
     }
@@ -431,16 +442,19 @@ impl SocketOps for TcpSocket {
     }
 
     fn send(&self, mut src: impl Read, _options: SendOptions) -> AxResult<usize> {
-        // SAFETY: `self.handle` should be initialized in a connected socket.
         let result = self.general.send_poller(self, || {
             poll_interfaces();
             self.with_smol_socket(|socket| {
                 if !socket.is_active() {
+                    warn!(
+                        "TCP {}: send — not active (state={:?})",
+                        self.handle,
+                        socket.state()
+                    );
                     Err(AxError::NotConnected)
                 } else if !socket.can_send() {
                     Err(AxError::WouldBlock)
                 } else {
-                    // connected, and the tx buffer is not full
                     let len = socket
                         .send(|buffer| {
                             let result = src.read(buffer);
@@ -448,13 +462,11 @@ impl SocketOps for TcpSocket {
                             (len, result)
                         })
                         .map_err(|_| ax_err_type!(NotConnected, "not connected?"))??;
+                    debug!("TCP {}: sent {} bytes", self.handle, len);
                     Ok(len)
                 }
             })
         });
-        // Poll again after writing so the data is transmitted through the
-        // network stack immediately. For loopback, this causes loopback.send()
-        // to run, which wakes any epoll wakers registered on the peer socket.
         if result.is_ok() {
             poll_interfaces();
         }
@@ -463,14 +475,24 @@ impl SocketOps for TcpSocket {
 
     fn recv(&self, mut dst: impl Write + IoBufMut, options: RecvOptions<'_>) -> AxResult<usize> {
         if self.rx_closed.load(Ordering::Acquire) {
+            warn!(
+                "TCP {}: recv — rx_closed, returning NotConnected",
+                self.handle
+            );
             return Err(AxError::NotConnected);
         }
         self.general.recv_poller(self, || {
             poll_interfaces();
             self.with_smol_socket(|socket| {
                 if !socket.is_active() {
+                    warn!(
+                        "TCP {}: recv — not active (state={:?})",
+                        self.handle,
+                        socket.state()
+                    );
                     Err(AxError::NotConnected)
                 } else if !socket.may_recv() {
+                    warn!("TCP {}: recv — may_recv=false, returning EOF", self.handle);
                     Ok(0)
                 } else if socket.recv_queue() == 0 {
                     Err(AxError::WouldBlock)
@@ -481,13 +503,15 @@ impl SocketOps for TcpSocket {
                             .map_err(|_| ax_err_type!(NotConnected, "not connected?"))?,
                     )
                 } else {
-                    socket
+                    let n = socket
                         .recv(|buf| {
                             let result = dst.write(buf);
                             let len = result.unwrap_or(0);
                             (len, result)
                         })
-                        .map_err(|_| ax_err_type!(NotConnected, "not connected?"))?
+                        .map_err(|_| ax_err_type!(NotConnected, "not connected?"))??;
+                    debug!("TCP {}: recv got {} bytes", self.handle, n);
+                    Ok(n)
                 }
             })
         })

--- a/os/arceos/modules/axnet-ng/src/unix/mod.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/mod.rs
@@ -9,7 +9,7 @@ use ax_errno::{AxError, AxResult};
 use ax_fs_ng::{FS_CONTEXT, OpenOptions};
 use ax_io::{IoBuf, Read, Write};
 use ax_sync::Mutex;
-use ax_task::future::{block_on, interruptible};
+use ax_task::future::{block_on, poll_io};
 use axfs_ng_vfs::NodeType;
 use axpoll::{IoEvents, Pollable};
 use enum_dispatch::enum_dispatch;
@@ -45,6 +45,11 @@ pub trait TransportOps: Configurable + Pollable + Send + Sync {
 
     /// Accept an incoming connection, returning the new transport and peer address.
     async fn accept(&self) -> AxResult<(Transport, UnixSocketAddr)>;
+
+    /// Non-blocking accept: returns `WouldBlock` immediately when no connection is pending.
+    fn try_accept(&self) -> AxResult<(Transport, UnixSocketAddr)> {
+        Err(AxError::WouldBlock)
+    }
 
     /// Send data through the transport.
     fn send(&self, src: impl Read + IoBuf, options: SendOptions) -> AxResult<usize>;
@@ -205,7 +210,14 @@ impl SocketOps for UnixSocket {
     }
 
     fn accept(&self) -> AxResult<Socket> {
-        let (transport, peer_addr) = block_on(interruptible(self.transport.accept()))??;
+        let mut nonblocking = false;
+        let _ = self
+            .transport
+            .get_option_inner(&mut GetSocketOption::NonBlocking(&mut nonblocking));
+        let (transport, peer_addr) =
+            block_on(poll_io(&self.transport, IoEvents::IN, nonblocking, || {
+                self.transport.try_accept()
+            }))?;
         Ok(Self {
             transport,
             local_addr: Mutex::new(self.local_addr.lock().clone()),

--- a/os/arceos/modules/axnet-ng/src/unix/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/stream.rs
@@ -242,6 +242,7 @@ impl TransportOps for StreamTransport {
             };
             total += count;
             if count > 0 {
+                debug!("UnixStream: sent {} bytes, waking peer", count);
                 chan.poll_update.wake();
             }
 
@@ -270,6 +271,7 @@ impl TransportOps for StreamTransport {
                 count
             };
             if count > 0 {
+                debug!("UnixStream: recv got {} bytes", count);
                 chan.poll_update.wake();
                 Ok(count)
             } else if !chan.rx.write_is_held() {

--- a/os/arceos/modules/axnet-ng/src/unix/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/stream.rs
@@ -31,16 +31,23 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
     let (client_tx, server_rx) = new_uni_channel();
     let (server_tx, client_rx) = new_uni_channel();
     let poll_update = Arc::new(PollSet::new());
+    // Cross-wired close flags: each side's my_tx_closed is the other's peer_tx_closed.
+    let client_tx_closed = Arc::new(AtomicBool::new(false));
+    let server_tx_closed = Arc::new(AtomicBool::new(false));
     (
         Channel {
             tx: client_tx,
             rx: client_rx,
+            my_tx_closed: client_tx_closed.clone(),
+            peer_tx_closed: server_tx_closed.clone(),
             poll_update: poll_update.clone(),
             peer_pid: pid,
         },
         Channel {
             tx: server_tx,
             rx: server_rx,
+            my_tx_closed: server_tx_closed,
+            peer_tx_closed: client_tx_closed,
             poll_update,
             peer_pid: pid,
         },
@@ -50,7 +57,10 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
 struct Channel {
     tx: HeapProd<u8>,
     rx: HeapCons<u8>,
-    // TODO: granularity
+    /// Set to true by Drop (our side) before waking the peer.
+    my_tx_closed: Arc<AtomicBool>,
+    /// Set to true by the peer's Drop before it wakes us.
+    peer_tx_closed: Arc<AtomicBool>,
     poll_update: Arc<PollSet>,
     peer_pid: u32,
 }
@@ -274,10 +284,8 @@ impl TransportOps for StreamTransport {
                 debug!("UnixStream: recv got {} bytes", count);
                 chan.poll_update.wake();
                 Ok(count)
-            } else if !chan.rx.write_is_held() {
-                // Peer dropped its sender end and the ring is empty: EOF.
-                // Returning WouldBlock here would park the caller forever
-                // waiting for data that will never arrive.
+            } else if !chan.rx.write_is_held() || chan.peer_tx_closed.load(Ordering::Acquire) {
+                // Peer closed (either HeapProd dropped or tx_closed flag set): EOF.
                 Ok(0)
             } else {
                 Err(AxError::WouldBlock)
@@ -307,10 +315,13 @@ impl TransportOps for StreamTransport {
 impl Pollable for StreamTransport {
     fn poll(&self) -> IoEvents {
         let mut events = IoEvents::empty();
+        let rx_closed = self.rx_closed.load(Ordering::Acquire);
+        let mut peer_eof = false;
         if let Some(chan) = self.channel.lock().as_ref() {
+            peer_eof = chan.peer_tx_closed.load(Ordering::Acquire);
             events.set(
                 IoEvents::IN,
-                !self.rx_closed.load(Ordering::Acquire) && chan.rx.occupied_len() > 0,
+                !rx_closed && (chan.rx.occupied_len() > 0 || peer_eof),
             );
             events.set(
                 IoEvents::OUT,
@@ -319,7 +330,7 @@ impl Pollable for StreamTransport {
         } else if let Some((conn_tx, _)) = self.conn_rx.lock().as_ref() {
             events.set(IoEvents::IN, !conn_tx.is_empty());
         }
-        events.set(IoEvents::RDHUP, self.rx_closed.load(Ordering::Acquire));
+        events.set(IoEvents::RDHUP, peer_eof || rx_closed);
         events
     }
 
@@ -340,7 +351,11 @@ impl Pollable for StreamTransport {
 impl Drop for StreamTransport {
     fn drop(&mut self) {
         if let Some(chan) = self.channel.lock().as_ref() {
+            // Set the flag BEFORE waking the peer so poll() sees peer_eof=true
+            // when it runs, even though our HeapProd hasn't dropped yet.
+            chan.my_tx_closed.store(true, Ordering::Release);
             chan.poll_update.wake();
         }
+        self.poll_state.wake();
     }
 }

--- a/os/arceos/modules/axnet-ng/src/unix/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/stream.rs
@@ -225,6 +225,24 @@ impl TransportOps for StreamTransport {
         ))
     }
 
+    fn try_accept(&self) -> AxResult<(Transport, UnixSocketAddr)> {
+        let Some((rx, _)) = self.conn_rx.lock().clone() else {
+            return Err(AxError::NotConnected);
+        };
+        match rx.try_recv() {
+            Ok(ConnRequest {
+                channel,
+                addr: peer_addr,
+                pid,
+            }) => Ok((
+                Transport::Stream(StreamTransport::new_channel(Some(channel), pid)),
+                peer_addr,
+            )),
+            Err(async_channel::TryRecvError::Empty) => Err(AxError::WouldBlock),
+            Err(async_channel::TryRecvError::Closed) => Err(AxError::ConnectionReset),
+        }
+    }
+
     fn send(&self, mut src: impl Read + IoBuf, options: SendOptions) -> AxResult<usize> {
         if options.to.is_some() {
             return Err(AxError::InvalidInput);
@@ -252,7 +270,6 @@ impl TransportOps for StreamTransport {
             };
             total += count;
             if count > 0 {
-                debug!("UnixStream: sent {} bytes, waking peer", count);
                 chan.poll_update.wake();
             }
 
@@ -270,7 +287,6 @@ impl TransportOps for StreamTransport {
             let Some(chan) = guard.as_mut() else {
                 return Err(AxError::NotConnected);
             };
-
             let count = {
                 let (left, right) = chan.rx.as_slices();
                 let mut count = dst.write(left)?;
@@ -281,11 +297,9 @@ impl TransportOps for StreamTransport {
                 count
             };
             if count > 0 {
-                debug!("UnixStream: recv got {} bytes", count);
                 chan.poll_update.wake();
                 Ok(count)
             } else if !chan.rx.write_is_held() || chan.peer_tx_closed.load(Ordering::Acquire) {
-                // Peer closed (either HeapProd dropped or tx_closed flag set): EOF.
                 Ok(0)
             } else {
                 Err(AxError::WouldBlock)

--- a/os/arceos/modules/axtask/src/future/mod.rs
+++ b/os/arceos/modules/axtask/src/future/mod.rs
@@ -43,7 +43,7 @@ impl Wake for AxWaker {
         if let Some(task) = self.task.upgrade() {
             let mut rq = select_run_queue::<NoPreemptIrqSave>(&task);
             *self.woke.lock() = true;
-            rq.unblock_task(task, false);
+            rq.unblock_task(task, true);
         }
     }
 }

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -23,10 +23,15 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
     super::interruptible(poll_fn(move |cx| match f() {
         Ok(value) => Poll::Ready(Ok(value)),
         Err(AxError::WouldBlock) => {
+            // Always register the waker before returning WouldBlock, even for
+            // non-blocking sockets.  A non-blocking connect(2) returns EINPROGRESS
+            // and the caller uses epoll to wait for EPOLLOUT (connection complete).
+            // If we skip registration here, the TCP stack never delivers the
+            // SYN-ACK notification to the epoll instance — the connection stalls.
+            pollable.register(cx, events);
             if non_blocking {
                 return Poll::Ready(Err(AxError::WouldBlock));
             }
-            pollable.register(cx, events);
             match f() {
                 Ok(value) => Poll::Ready(Ok(value)),
                 Err(AxError::WouldBlock) => Poll::Pending,

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -421,9 +421,16 @@ impl<G: BaseGuard> CurrentRunQueueRef<'_, G> {
         // Mark the task as blocked, this has to be done before adding it to the wait queue
         // while holding the lock of the wait queue.
         curr.set_state(TaskState::Blocked);
-        curr.set_in_wait_queue(true);
-
-        wq_guard.push_back(curr.clone());
+        // Guard against double-add: if the task was spuriously woken by an AxWaker
+        // (e.g. a network wakeup arriving while waiting for a sleeping mutex), it
+        // re-enters blocked_resched with in_wait_queue still true. Pushing again
+        // creates a duplicate entry; a later notify_one_with during unlock would
+        // hand ownership to the stale entry while the task is not waiting,
+        // causing a re-entrant mutex panic.
+        if !curr.in_wait_queue() {
+            curr.set_in_wait_queue(true);
+            wq_guard.push_back(curr.clone());
+        }
         // Drop the lock of wait queue explictly.
         drop(wq_guard);
 

--- a/platform/x86-qemu-q35/src/console.rs
+++ b/platform/x86-qemu-q35/src/console.rs
@@ -40,8 +40,13 @@ struct ConsoleIfImpl;
 impl ConsoleIf for ConsoleIfImpl {
     /// Writes given bytes to the console.
     fn write_bytes(bytes: &[u8]) {
-        for c in bytes {
-            putchar(*c);
+        // Hold the lock for the entire write so that a single logical output
+        // (e.g. one full TUI frame) is never interleaved with output from
+        // another task.  This also cuts lock-acquire overhead from O(N) to
+        // O(1) per write() syscall, which matters for large ANSI frame dumps.
+        let mut com = COM1.lock();
+        for &c in bytes {
+            com.send(c);
         }
     }
 


### PR DESCRIPTION
**Root cause**: sys_poll, sys_ppoll, sys_epoll_wait, sys_select, and sys_pselect6 used get_as_mut_slice()/get_as_mut() to obtain &mut references directly into user-space memory, then wrote to them in kernel mode outside of access_user_memory() scope.

When a concurrent fork (clone_map) re-marked those COW pages read-only between check_region and the actual write, the kernel write triggered an unhandled #PF (error_code=0x3: present+write-protected, rip in kernel text, no fixup-table entry) → panic.

**Fix 1 – Linux-compatible copy approach (poll/select/epoll)**

Adopt the same copy_from_user / copy_to_user pattern that Linux uses:

- poll.rs: read_poll_fds_from_user() copies the pollfd array from user to a kernel Vec<pollfd> via vm_read_slice, do_poll operates on the kernel copy, vm_write_slice writes results back.
- epoll.rs: do_epoll_wait() allocates a kernel Vec<epoll_event>, passes it to poll_events(), then vm_write_slice writes only the filled events.
- select.rs: read_fd_set_from_user() / write_fd_set_to_user() helpers copy __kernel_fd_set via vm_read_slice / vm_write_slice; all FD_ZERO and FD_SET operations are performed on kernel-local copies.

All write-backs go through vm_write_slice → access_user_memory + user_copy, whose fixup-table entry handles any remaining COW faults.

**Fix 2 – Defence-in-depth (handle_page_fault)**

Extend the page-fault handler in mm/access.rs to also process kernel-mode faults on user-space addresses when not inside access_user_memory().  This covers the many other syscall sites (event.rs, net/name.rs, net/io.rs, shm.rs, …) that still use get_as_mut() + direct write.

The extended path:
1. Rejects kernel-space fault addresses (avoids masking kernel bugs).
2. Skips if the aspace lock is already held (avoids deadlock).
3. Proceeds to aspace.handle_page_fault() → CowBackend::populate() → handle_cow_fault() → upgrades or copies the COW page.



refactor(epoll): replace unsafe Vec init with safe vec! for epoll_event

epoll_event derives Copy, so use vec![zero_event; n] instead of the unsafe with_capacity + set_len + write_bytes pattern.