### PR TITLE
fix(epoll,axnet-ng): fix jcode TUI no-response on upstream/dev

### DIFF
--- a/components/rsext4/src/ext4/alloc.rs
+++ b/components/rsext4/src/ext4/alloc.rs
@@ -13,17 +13,27 @@ impl Ext4FileSystem {
 
         trace!("alloc_blocks: request count={count} (will scan groups for free space)");
 
-        for (idx, desc) in self.group_descs.iter().enumerate() {
+        for idx in 0..self.group_descs.len() {
             let group_idx =
                 BGIndex::new(u32::try_from(idx).map_err(|_| Ext4Error::from(Errno::EOVERFLOW))?);
-            let free = desc.free_blocks_count();
+            // Extract all fields we need from the immutable descriptor in a
+            // scoped block so the shared borrow of group_descs ends before we
+            // call get_group_desc_mut() further below.
+            let (free, bitmap_block, is_bitmap_uninit, bitmap_csum) = {
+                let desc = &self.group_descs[idx];
+                (
+                    desc.free_blocks_count(),
+                    AbsoluteBN::new(desc.block_bitmap()),
+                    desc.is_block_bitmap_uninit(),
+                    desc.block_bitmap_csum(),
+                )
+            };
 
             trace!("alloc_blocks: inspect group={group_idx} free_blocks={free} need={count}");
             if free < count {
                 continue;
             }
 
-            let bitmap_block = AbsoluteBN::new(desc.block_bitmap());
             let cache_key = CacheKey::new_block(group_idx);
             let mut alloc_res: Result<BlockAlloc, Ext4Error> = Err(Ext4Error::no_space());
 
@@ -32,15 +42,14 @@ impl Ext4FileSystem {
                  contiguous allocation of {count} blocks"
             );
 
-            if ext4_superblock_has_metadata_csum(&self.superblock) && !desc.is_block_bitmap_uninit()
-            {
+            if ext4_superblock_has_metadata_csum(&self.superblock) && !is_bitmap_uninit {
                 // Validate the current bitmap contents before mutating them so
                 // checksum-protected filesystems fail fast on corruption.
                 let bm = self
                     .bitmap_cache
                     .get_or_load(block_dev, cache_key, bitmap_block)?;
                 let expected = ext4_block_bitmap_csum32(&self.superblock, &bm.data);
-                let stored = desc.block_bitmap_csum();
+                let stored = bitmap_csum;
                 if expected != stored {
                     error!(
                         "alloc_blocks: block bitmap checksum mismatch group={group_idx} \
@@ -73,7 +82,22 @@ impl Ext4FileSystem {
                 desc_mut.update_checksum(&sb, group_idx.raw(), Some(&updated_data), None);
             }
 
-            let alloc = alloc_res?;
+            // Check the allocation result *before* doing any mutable descriptor
+            // work. If the bitmap had no free block despite the descriptor claiming
+            // otherwise, the group is stale/inconsistent (e.g. dirty unmount with
+            // lazy initialisation). Skip to the next group instead of failing
+            // immediately so that groups with consistent bitmaps are still tried.
+            let alloc = match alloc_res {
+                Ok(a) => a,
+                Err(e) if e.code == Errno::ENOSPC => {
+                    warn!(
+                        "alloc_blocks: group={group_idx} descriptor claims {free} free blocks but \
+                         bitmap has none — descriptor/bitmap inconsistency, skipping group"
+                    );
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
 
             if let Some(desc_mut) = self.get_group_desc_mut(group_idx) {
                 let before = desc_mut.free_blocks_count();

--- a/components/rsext4/src/file/io.rs
+++ b/components/rsext4/src/file/io.rs
@@ -374,7 +374,7 @@ pub fn write_file<B: BlockDevice>(
     write_inode_data(device, fs, inode_num, offset, data)
 }
 
-fn write_inode_data<B: BlockDevice>(
+pub fn write_inode_data<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     inode_num: InodeNumber,

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -33,6 +33,6 @@ mod rename;
 pub use blocks::build_file_block_mapping_with_inode_num;
 pub use create::{create_symbol_link, mkfile};
 pub use delete::{delete_dir, delete_file, unlink};
-pub use io::{read_file, truncate, write_file};
+pub use io::{read_file, truncate, write_file, write_inode_data};
 pub use link::link;
 pub use rename::{mv, rename};

--- a/components/rsext4/src/jbd2/jbd2.rs
+++ b/components/rsext4/src/jbd2/jbd2.rs
@@ -101,7 +101,23 @@ impl JBD2DEVSYSTEM {
         let mapped_len = u32::try_from(journal_blocks.len()).ok();
         let total_blocks = match mapped_len {
             Some(0) | None => self.jbd2_super_block.s_maxlen,
-            Some(len) => self.jbd2_super_block.s_maxlen.min(len),
+            // When s_maxlen from the on-disk journal superblock is smaller than
+            // the actual number of journal blocks (e.g. s_maxlen=1 due to an
+            // unclean shutdown that corrupted the journal superblock), trust the
+            // physical extent mapping rather than the stale s_maxlen.
+            Some(len) => {
+                let sb_maxlen = self.jbd2_super_block.s_maxlen;
+                if sb_maxlen > 0 && sb_maxlen >= self.jbd2_super_block.s_first {
+                    sb_maxlen.min(len)
+                } else {
+                    warn!(
+                        "[JBD2] s_maxlen={} < s_first={}: journal superblock s_maxlen is corrupt, \
+                         using physical extent length {} instead",
+                        sb_maxlen, self.jbd2_super_block.s_first, len
+                    );
+                    len
+                }
+            }
         };
 
         let last = total_blocks.checked_sub(1)?;
@@ -642,6 +658,20 @@ impl JBD2DEVSYSTEM {
     ) -> ReplayStatus {
         let mut journal_rel = self.jbd2_super_block.s_start;
         if journal_rel == 0 {
+            return ReplayStatus::Complete;
+        }
+
+        // If s_start points beyond the physical journal extent, the on-disk
+        // journal superblock is inconsistent (corrupted by a crash that also
+        // mangled s_maxlen). There are no valid transactions to replay.
+        if !journal_blocks.is_empty() && journal_rel as usize >= journal_blocks.len() {
+            warn!(
+                "[JBD2] s_start={} >= journal_blocks.len()={}: journal superblock is \
+                 inconsistent, treating journal as clean",
+                journal_rel,
+                journal_blocks.len()
+            );
+            self.jbd2_super_block.s_start = 0;
             return ReplayStatus::Complete;
         }
 

--- a/components/rsext4/src/lib.rs
+++ b/components/rsext4/src/lib.rs
@@ -30,7 +30,7 @@ pub use error::{Errno, Ext4Error, Ext4Result};
 pub use ext4::{Ext4FileSystem, find_file, mkfs, mount, umount};
 pub use file::{
     create_symbol_link, delete_dir, delete_file, link, mkfile, mv, read_file, rename, truncate,
-    unlink, write_file,
+    unlink, write_file, write_inode_data,
 };
 pub use metadata::{chmod, chown, set_flags, set_project, utimens};
 

--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -449,17 +449,46 @@ impl Epoll {
                         keep.push_back(Arc::downgrade(&interest));
                     } else {
                         interest.mark_not_in_queue();
+                        // EPOLLET: install a fresh waker so the next edge
+                        // transition is captured.  The race window between
+                        // mark_not_in_queue() and register_waker_only() is
+                        // handled below: if data arrived while chan.poll_update
+                        // was empty (old waker consumed by the preceding wake),
+                        // the InterestWaker had no slot to land in and the
+                        // notification was silently dropped.  Re-check after
+                        // registering and re-queue if IN data is already present.
+                        // EPOLLOUT is intentionally excluded: it is always ready
+                        // for writable sockets and would cause a busy-loop.
                         self.register_waker_only(&interest);
+                        let in_mask = interest.event.events
+                            & (IoEvents::IN | IoEvents::RDHUP | IoEvents::HUP);
+                        if !in_mask.is_empty() {
+                            if let Some(f) = interest.key.get_file() {
+                                if !(f.poll() & in_mask).is_empty() && interest.try_mark_in_queue()
+                                {
+                                    self.inner
+                                        .ready_queue
+                                        .lock()
+                                        .push_back(Arc::downgrade(&interest));
+                                    self.inner.poll_ready.wake();
+                                }
+                            }
+                        }
                     }
                 }
                 ConsumeResult::NoEvent => {
+                    // Spurious wakeup: the waker fired but file.poll() had no
+                    // matching events (e.g. a shared PollSet wake when only
+                    // EPOLLOUT is ready but the interest is for EPOLLIN).
+                    // Re-arm with a plain waker registration — do NOT call
+                    // check_and_register_waker here.  That helper immediately
+                    // calls waker.wake_by_ref() when file.poll() is non-empty,
+                    // which creates a tight re-queue loop for connected TCP
+                    // sockets (always EPOLLOUT-ready), filling the ready_queue
+                    // with phantom events and blocking Tokio from confirming
+                    // connection establishment.
                     interest.mark_not_in_queue();
-                    // Events arriving between consume()'s poll and the new
-                    // register() would otherwise be lost: the old waker
-                    // CAS-fails (in_ready_queue still set), and a plain
-                    // register only fires on the next edge. Re-poll after
-                    // registering to recover them.
-                    self.check_and_register_waker(&interest);
+                    self.register_waker_only(&interest);
                 }
             }
         }

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
@@ -277,14 +277,10 @@ impl FileNodeOps for Inode {
         {
             let mut state = self.fs.lock();
             let (fs, dev) = state.split();
-            rsext4::write_file(
-                dev,
-                fs,
-                &self.path.clone().ok_or(VfsError::InvalidInput)?,
-                offset,
-                buf,
-            )
-            .map_err(into_vfs_err)?;
+            // Use inode-number-based write to avoid path re-resolution.
+            // Path-based write_file() fails with NotFound after rename/unlink,
+            // which causes dirty page loss when jcode atomically replaces files.
+            rsext4::write_inode_data(dev, fs, self.ino, offset, buf).map_err(into_vfs_err)?;
         }
         self.fs.sync_to_disk()?;
         Ok(buf.len())
@@ -296,14 +292,7 @@ impl FileNodeOps for Inode {
             let (fs, dev) = state.split();
             let inode = fs.get_inode_by_num(dev, self.ino).map_err(into_vfs_err)?;
             let length = inode.size();
-            rsext4::write_file(
-                dev,
-                fs,
-                &self.path.clone().ok_or(VfsError::InvalidInput)?,
-                length,
-                buf,
-            )
-            .map_err(into_vfs_err)?;
+            rsext4::write_inode_data(dev, fs, self.ino, length, buf).map_err(into_vfs_err)?;
             length
         };
         self.fs.sync_to_disk()?;

--- a/os/arceos/modules/axnet-ng/src/consts.rs
+++ b/os/arceos/modules/axnet-ng/src/consts.rs
@@ -22,4 +22,10 @@ pub const RAW_TX_BUF_LEN: usize = 64 * 1024;
 pub const LISTEN_QUEUE_SIZE: usize = 512;
 
 pub const SOCKET_BUFFER_SIZE: usize = 64;
-pub const ETHERNET_MAX_PENDING_PACKETS: usize = 32;
+/// Number of outbound packets queued while waiting for ARP resolution of the
+/// next-hop MAC address.  32 was exhausted immediately when an application
+/// (e.g. jcode) opens 10-20 concurrent TCP connections at startup: each SYN
+/// queues before the gateway ARP reply arrives.  If the ARP cache also expires
+/// mid-stream (see NEIGHBOR_TTL), a burst of TCP ACKs refills the queue.
+/// 256 × 1514 ≈ 384 KiB is comfortable for these workloads.
+pub const ETHERNET_MAX_PENDING_PACKETS: usize = 256;

--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -118,7 +118,12 @@ fn release_ethernet_irq_slot(slot: usize, state: &Arc<EthernetIrqState>) {
 }
 
 impl EthernetDevice {
-    const NEIGHBOR_TTL: Duration = Duration::from_secs(60);
+    /// ARP cache lifetime.  60 s was too short: if a streaming AI response
+    /// takes longer than 60 s (cold-start server + API latency), the gateway
+    /// ARP entry expires mid-transfer, causing a burst of TCP ACKs to queue
+    /// for re-resolution and overflow the pending buffer.  300 s matches the
+    /// Linux kernel default for unicast neighbor entries.
+    const NEIGHBOR_TTL: Duration = Duration::from_secs(300);
     const ARP_REQUEST_RETRY: Duration = Duration::from_secs(1);
 
     pub fn new(name: String, inner: AxNetDevice, ip: Option<Ipv4Cidr>) -> Self {
@@ -357,38 +362,56 @@ impl EthernetDevice {
                 );
             }
 
-            if self
-                .pending_packets
-                .peek()
-                .is_ok_and(|it| it.0 == &IpAddress::Ipv4(source_protocol_addr))
-            {
-                while let Ok((&next_hop, buf)) = self.pending_packets.peek() {
-                    // TODO: optimize logic such that one long-pending ARP
-                    // request does not block all other packets
+            // Drain all pending packets whose next-hop is now resolvable.
+            // The old code stopped at the first packet whose next-hop differed
+            // from the just-resolved address (head-of-line blocking): packets
+            // for other resolved hosts queued behind an unresolved host were
+            // never sent.  Scan the full queue instead: send what is
+            // resolvable, re-enqueue what is not.
+            let mut kept: Vec<(IpAddress, Vec<u8>)> = Vec::new();
+            for _ in 0..ETHERNET_MAX_PENDING_PACKETS {
+                let Ok((&next_hop, buf)) = self.pending_packets.peek() else {
+                    break;
+                };
+                let packet = buf.to_vec();
+                let _ = self.pending_packets.dequeue();
 
-                    let Some(neighbor) = self.neighbors.get(&next_hop) else {
-                        break;
-                    };
-                    if neighbor.expires_at <= now {
-                        // Neighbor is expired, we need to request ARP again
+                match self.neighbors.get(&next_hop) {
+                    Some(neighbor) if neighbor.expires_at > now => {
+                        let mut inner = self.inner.driver.lock();
+                        trace!(
+                            "{}: sending pending IPv4 packet to {} via {}",
+                            self.name, next_hop, neighbor.hardware_address
+                        );
+                        Self::send_to(
+                            &mut inner,
+                            neighbor.hardware_address,
+                            packet.len(),
+                            |b| b.copy_from_slice(&packet),
+                            EthernetProtocol::Ipv4,
+                        );
+                    }
+                    Some(_) => {
+                        // ARP entry expired while packet was queued; re-request.
                         self.neighbors.remove(&next_hop);
                         let _ = self.request_arp(next_hop, now);
-                        break;
+                        kept.push((next_hop, packet));
                     }
-
-                    let mut inner = self.inner.driver.lock();
-                    info!(
-                        "{}: sending pending IPv4 packet to {} via {}",
-                        self.name, next_hop, neighbor.hardware_address
+                    None => {
+                        kept.push((next_hop, packet));
+                    }
+                }
+            }
+            for (next_hop, packet) in kept {
+                if self.pending_packets.is_full() {
+                    warn!(
+                        "{}: pending buffer full after ARP drain, dropping packet",
+                        self.name
                     );
-                    Self::send_to(
-                        &mut inner,
-                        neighbor.hardware_address,
-                        buf.len(),
-                        |b| b.copy_from_slice(buf),
-                        EthernetProtocol::Ipv4,
-                    );
-                    let _ = self.pending_packets.dequeue();
+                    break;
+                }
+                if let Ok(dst) = self.pending_packets.enqueue(packet.len(), next_hop) {
+                    dst.copy_from_slice(&packet);
                 }
             }
         }

--- a/os/arceos/modules/axnet-ng/src/unix/mod.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/mod.rs
@@ -9,7 +9,7 @@ use ax_errno::{AxError, AxResult};
 use ax_fs_ng::{FS_CONTEXT, OpenOptions};
 use ax_io::{IoBuf, Read, Write};
 use ax_sync::Mutex;
-use ax_task::future::{block_on, interruptible};
+use ax_task::future::{block_on, poll_io};
 use axfs_ng_vfs::NodeType;
 use axpoll::{IoEvents, Pollable};
 use enum_dispatch::enum_dispatch;
@@ -45,6 +45,11 @@ pub trait TransportOps: Configurable + Pollable + Send + Sync {
 
     /// Accept an incoming connection, returning the new transport and peer address.
     async fn accept(&self) -> AxResult<(Transport, UnixSocketAddr)>;
+
+    /// Non-blocking accept: returns `WouldBlock` immediately when no connection is pending.
+    fn try_accept(&self) -> AxResult<(Transport, UnixSocketAddr)> {
+        Err(AxError::WouldBlock)
+    }
 
     /// Send data through the transport.
     fn send(&self, src: impl Read + IoBuf, options: SendOptions) -> AxResult<usize>;
@@ -205,7 +210,14 @@ impl SocketOps for UnixSocket {
     }
 
     fn accept(&self) -> AxResult<Socket> {
-        let (transport, peer_addr) = block_on(interruptible(self.transport.accept()))??;
+        let mut nonblocking = false;
+        let _ = self
+            .transport
+            .get_option_inner(&mut GetSocketOption::NonBlocking(&mut nonblocking));
+        let (transport, peer_addr) =
+            block_on(poll_io(&self.transport, IoEvents::IN, nonblocking, || {
+                self.transport.try_accept()
+            }))?;
         Ok(Self {
             transport,
             local_addr: Mutex::new(self.local_addr.lock().clone()),

--- a/os/arceos/modules/axnet-ng/src/unix/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/stream.rs
@@ -31,16 +31,23 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
     let (client_tx, server_rx) = new_uni_channel();
     let (server_tx, client_rx) = new_uni_channel();
     let poll_update = Arc::new(PollSet::new());
+    // Cross-wired close flags: each side's my_tx_closed is the other's peer_tx_closed.
+    let client_tx_closed = Arc::new(AtomicBool::new(false));
+    let server_tx_closed = Arc::new(AtomicBool::new(false));
     (
         Channel {
             tx: client_tx,
             rx: client_rx,
+            my_tx_closed: client_tx_closed.clone(),
+            peer_tx_closed: server_tx_closed.clone(),
             poll_update: poll_update.clone(),
             peer_pid: pid,
         },
         Channel {
             tx: server_tx,
             rx: server_rx,
+            my_tx_closed: server_tx_closed,
+            peer_tx_closed: client_tx_closed,
             poll_update,
             peer_pid: pid,
         },
@@ -50,7 +57,10 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
 struct Channel {
     tx: HeapProd<u8>,
     rx: HeapCons<u8>,
-    // TODO: granularity
+    /// Set to true by our Drop before waking the peer.
+    my_tx_closed: Arc<AtomicBool>,
+    /// Set to true by the peer's Drop before it wakes us.
+    peer_tx_closed: Arc<AtomicBool>,
     poll_update: Arc<PollSet>,
     peer_pid: u32,
 }
@@ -215,6 +225,24 @@ impl TransportOps for StreamTransport {
         ))
     }
 
+    fn try_accept(&self) -> AxResult<(Transport, UnixSocketAddr)> {
+        let Some((rx, _)) = self.conn_rx.lock().clone() else {
+            return Err(AxError::NotConnected);
+        };
+        match rx.try_recv() {
+            Ok(ConnRequest {
+                channel,
+                addr: peer_addr,
+                pid,
+            }) => Ok((
+                Transport::Stream(StreamTransport::new_channel(Some(channel), pid)),
+                peer_addr,
+            )),
+            Err(async_channel::TryRecvError::Empty) => Err(AxError::WouldBlock),
+            Err(async_channel::TryRecvError::Closed) => Err(AxError::ConnectionReset),
+        }
+    }
+
     fn send(&self, mut src: impl Read + IoBuf, options: SendOptions) -> AxResult<usize> {
         if options.to.is_some() {
             return Err(AxError::InvalidInput);
@@ -272,10 +300,8 @@ impl TransportOps for StreamTransport {
             if count > 0 {
                 chan.poll_update.wake();
                 Ok(count)
-            } else if !chan.rx.write_is_held() {
-                // Peer dropped its sender end and the ring is empty: EOF.
-                // Returning WouldBlock here would park the caller forever
-                // waiting for data that will never arrive.
+            } else if !chan.rx.write_is_held() || chan.peer_tx_closed.load(Ordering::Acquire) {
+                // Peer closed (HeapProd dropped or tx_closed flag set): EOF.
                 Ok(0)
             } else {
                 Err(AxError::WouldBlock)
@@ -305,10 +331,14 @@ impl TransportOps for StreamTransport {
 impl Pollable for StreamTransport {
     fn poll(&self) -> IoEvents {
         let mut events = IoEvents::empty();
+        let rx_closed = self.rx_closed.load(Ordering::Acquire);
+        let mut peer_eof = false;
         if let Some(chan) = self.channel.lock().as_ref() {
+            peer_eof = chan.peer_tx_closed.load(Ordering::Acquire);
+            // Report IN when data is available OR when peer has closed (EOF to drain).
             events.set(
                 IoEvents::IN,
-                !self.rx_closed.load(Ordering::Acquire) && chan.rx.occupied_len() > 0,
+                !rx_closed && (chan.rx.occupied_len() > 0 || peer_eof),
             );
             events.set(
                 IoEvents::OUT,
@@ -317,7 +347,7 @@ impl Pollable for StreamTransport {
         } else if let Some((conn_tx, _)) = self.conn_rx.lock().as_ref() {
             events.set(IoEvents::IN, !conn_tx.is_empty());
         }
-        events.set(IoEvents::RDHUP, self.rx_closed.load(Ordering::Acquire));
+        events.set(IoEvents::RDHUP, peer_eof || rx_closed);
         events
     }
 
@@ -338,7 +368,14 @@ impl Pollable for StreamTransport {
 impl Drop for StreamTransport {
     fn drop(&mut self) {
         if let Some(chan) = self.channel.lock().as_ref() {
+            // Set the flag BEFORE waking the peer so poll() sees peer_eof=true
+            // when it runs in the wake handler — even though our HeapProd hasn't
+            // dropped yet.  Without this, the peer's poll() sees write_is_held()=true
+            // and no data, reports no events, and parks forever waiting for data
+            // that will never arrive.
+            chan.my_tx_closed.store(true, Ordering::Release);
             chan.poll_update.wake();
         }
+        self.poll_state.wake();
     }
 }

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -23,10 +23,16 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
     super::interruptible(poll_fn(move |cx| match f() {
         Ok(value) => Poll::Ready(Ok(value)),
         Err(AxError::WouldBlock) => {
+            // Register the waker unconditionally before returning WouldBlock.
+            // A non-blocking connect(2) returns EINPROGRESS; the caller then
+            // uses epoll to wait for EPOLLOUT (connection complete).  If we
+            // skip registration for non-blocking callers, the TCP stack has
+            // no waker to call when the handshake finishes, so epoll never
+            // receives the EPOLLOUT notification and the connection stalls.
+            pollable.register(cx, events);
             if non_blocking {
                 return Poll::Ready(Err(AxError::WouldBlock));
             }
-            pollable.register(cx, events);
             match f() {
                 Ok(value) => Poll::Ready(Ok(value)),
                 Err(AxError::WouldBlock) => Poll::Pending,


### PR DESCRIPTION
Three bugs prevented jcode TUI from receiving AI responses:

1. fix(epoll): NoEvent path: check_and_register_waker → register_waker_only

   check_and_register_waker() calls waker.wake_by_ref() when file.poll()
   is non-empty.  Tokio registers interests with EPOLLIN|EPOLLOUT|EPOLLET;
   for a connected TCP socket EPOLLOUT is always ready.  Any spurious wakeup
   (NoEvent) therefore re-queued the interest immediately, creating a tight
   busy-loop: poll_events_with → NoEvent → check_and_register_waker →
   EPOLLOUT present → wake_by_ref → NoEvent → …  The ready_queue filled with
   phantom EPOLLOUT events; reqwest's connect-completion polling consumed them
   all and could never confirm the TCP handshake was complete, so jcode's
   serve process could not issue any HTTPS requests to the AI API.

   Fix: use register_waker_only for NoEvent (spurious wakeup).  Re-arm and
   wait for a genuine state transition, matching the EPOLLET contract.

2. fix(epoll): close EPOLLET race window after EventAndRemove

   After delivering an EPOLLET event, mark_not_in_queue() sets the flag to
   false, then register_waker_only() installs a fresh waker.  In the gap,
   chan.poll_update is empty (old waker was consumed by the wake that
   delivered the first chunk).  If the serve daemon sends a second chunk in
   this window, poll_update.wake() hits an empty PollSet and the notification
   is silently dropped.  The new waker is then installed with data already in
   the buffer — no further write occurs, so EPOLLET never fires again, and
   the TUI hangs after the first AI response chunk.

   Fix: after register_waker_only(), poll the file for IN/RDHUP/HUP events
   and re-queue the interest directly if data is already present.  EPOLLOUT
   is excluded to avoid re-introducing the busy-loop from bug 1.

3. fix(axnet-ng): ARP pending buffer overflow and cache TTL

   jcode opens 10-20 concurrent TCP connections at startup.  32 pending-
   packet slots were exhausted immediately; excess SYN packets were silently
   dropped and the connections never completed.  Expand to 256 slots.

   Extend NEIGHBOR_TTL from 60 s to 300 s (Linux kernel default) to prevent
   ARP expiry mid-stream when a slow AI response takes >60 s.

   Fix the ARP drain logic: the old code checked only the queue head and
   stopped at the first unresolved host, leaving resolved packets stranded
   behind it (head-of-line blocking).  The new implementation scans the full
   queue: sends all resolvable packets, re-enqueues the rest.