### PR TITLE
fix(starry-kernel): reject unsupported fcntl cmds with EINVAL

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -308,7 +308,7 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> AxResult<isize> {
         }
         _ => {
             warn!("unsupported fcntl parameters: cmd: {cmd}");
-            Ok(0)
+            Err(AxError::InvalidInput)
         }
     }
 }


### PR DESCRIPTION
## 问题

`sys_fcntl` 对未识别的 cmd 直接返回 `Ok(0)` 假装成功，导致用户态无法区分"成功"与"未实现"。Linux 对未知 cmd 返回 `EINVAL`。

## 改动

把默认分支改为 `Err(AxError::InvalidInput)`，与 Linux 行为一致，方便上层 probe。

## 测试

本地 `cargo fmt --check` 与 `cargo xtask clippy --package starry-kernel` 通过；无新增行为测试。

Made with [Cursor](https://cursor.com)