### PR TITLE
fix(starry-kernel): reap waitpid child only after status vm_write

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -93,12 +93,16 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
                     proc_data.add_child_cpu_time(utime, stime);
                 }
             }
-            child.free();
-            remove_process(child.pid());
-            unregister_zombie(child.pid());
+            // Copy status to userspace before `free` / `unregister_zombie`. If
+            // `vm_write` fails we must leave the zombie intact so the parent can
+            // retry; freeing first would strand the process and corrupt wait
+            // accounting (Linux also publishes the status byte before full reap).
             if let Some(exit_code) = exit_code.nullable() {
                 exit_code.vm_write(child.exit_code())?;
             }
+            child.free();
+            remove_process(child.pid());
+            unregister_zombie(child.pid());
             Ok(Some(child.pid() as _))
         } else if options.contains(WaitOptions::WNOHANG) {
             Ok(Some(0))


### PR DESCRIPTION
## 问题

`sys_waitpid` 在把退出码写入用户指针 **之前** 就执行了 `child.free()` / `remove_process()` / `unregister_zombie()`。当 `exit_code.vm_write(...)` 因用户指针无效或不可写而失败时：
- 子进程已经从 wait 相关结构里彻底回收；
- 但用户态没有拿到退出码；
- 父进程再次 `waitpid` 也找不到这个子进程，等于半截 reap，wait 账目错乱。

## 改动

调整顺序为：
1. 先把退出码写到用户态（`exit_code.vm_write(...)`）；
2. 写成功后再 `child.free()` / `remove_process()` / `unregister_zombie()`；
3. 写失败时僵尸保留，父进程可重新 `waitpid`。

与 Linux `do_wait` 在完全 reap 前先发布 status byte 的语义一致。

## 测试

本地 `cargo fmt --check`、`cargo xtask clippy --package starry-kernel` 通过。

Made with [Cursor](https://cursor.com)