### PR TITLE
feat(starry): add PicoClaw phase 1 and 2 support

### DIFF
--- a/examples/starry/README.md
+++ b/examples/starry/README.md
@@ -33,6 +33,23 @@ Example:
 cargo starry example board -t orangepi-5-plus-uvc
 ```
 
+## PicoClaw CLI
+
+The `picoclaw-cli` case is an opt-in StarryOS x86_64 QEMU workflow for checking
+PicoClaw compatibility in two initial stages: offline CLI smoke and online agent
+request. It prepares local-only release assets and rootfs images under
+`target/picoclaw/` and `tmp/axbuild/rootfs/`.
+
+```bash
+examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh
+cargo xtask starry qemu \
+  --arch x86_64 \
+  --qemu-config examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-offline.toml \
+  --rootfs tmp/axbuild/rootfs/rootfs-x86_64-picoclaw.img
+```
+
+See `picoclaw-cli/README.md` for the online agent flow.
+
 ## Orange Pi 5 Plus UVC
 
 The `orangepi-5-plus-uvc` case needs `/usr/bin/uvc-fps` to be installed in the

--- a/examples/starry/picoclaw-cli/PHASE1_OFFLINE_SMOKE.md
+++ b/examples/starry/picoclaw-cli/PHASE1_OFFLINE_SMOKE.md
@@ -1,0 +1,100 @@
+# Phase 1: Offline Smoke Record
+
+This is a short factual record for later expansion.
+
+## Result
+
+Phase 1 offline smoke passed on StarryOS x86_64 QEMU.
+
+Command:
+
+```bash
+cargo xtask starry qemu \
+  --arch x86_64 \
+  --qemu-config examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-offline.toml \
+  --rootfs tmp/axbuild/rootfs/rootfs-x86_64-picoclaw.img
+```
+
+Guest commands covered:
+
+- `picoclaw version`
+- `picoclaw --help`
+- `picoclaw onboard`
+- `picoclaw status`
+- checked `/root/.picoclaw/config.json`
+- checked `/root/.picoclaw/workspace`
+
+Success marker:
+
+```text
+STARRY_PICOCLAW_OFFLINE_PASSED
+```
+
+## Problems Found
+
+1. QEMU config schema mismatch.
+
+   `success_regex` and `fail_regex` must be arrays in this repository's ostool
+   QEMU config format. A single string failed TOML parsing before QEMU started.
+
+2. Rootfs injection wrote the debugfs command file into the guest image.
+
+   The temporary `debugfs.cmds` file was originally placed inside the overlay
+   directory, so the generic overlay walk injected it as `/debugfs.cmds`. It was
+   moved outside the overlay temp directory.
+
+3. PicoClaw binary was injected as a FIFO.
+
+   The debugfs mode command used `010%s`, which produced `010755` for executable
+   files. In ext inode mode this became a FIFO with mode `0755`, so the guest
+   returned `Permission denied` when running `/usr/local/bin/picoclaw`.
+
+   Fix: use `0100%s`, producing `0100755`, which is a regular executable file.
+
+4. Non-blocking StarryOS warnings appeared while running PicoClaw.
+
+   Observed warnings:
+
+   - `sys_prctl: unsupported option 1398164801`
+   - `Unsupported ioctl command: 21505 for fd: 1`
+
+   These did not block `version`, `--help`, `onboard`, or `status`. Keep them as
+   watch points for the online agent and gateway phases.
+
+## Files Completed
+
+- `examples/starry/picoclaw-cli/prepare_picoclaw_assets.sh`
+  - Downloads or reuses the PicoClaw Linux x86_64 release asset.
+  - Verifies SHA-256.
+  - Installs `picoclaw` and `picoclaw-launcher` under `target/picoclaw/assets/`.
+
+- `examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh`
+  - Builds or reuses the StarryOS x86_64 Alpine rootfs.
+  - Injects PicoClaw binaries into `/usr/local/bin/`.
+  - Supports optional online config, `.security.yml`, proxy env file, and CA bundle injection.
+
+- `examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-offline.toml`
+  - Runs the offline smoke commands.
+  - Checks local PicoClaw config/workspace state.
+  - Emits `STARRY_PICOCLAW_OFFLINE_PASSED`.
+
+- `examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml`
+  - Prepared for Phase 2 online agent validation.
+  - Requires online rootfs with config and `.security.yml`.
+
+- `examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-gateway.toml`
+  - Prepared for Phase 3 gateway validation.
+  - Starts gateway and checks `/health`.
+
+- `examples/starry/picoclaw-cli/README.md`
+  - Documents offline, online agent, and gateway usage.
+
+- `examples/starry/README.md`
+  - Adds a short entry pointing to the PicoClaw CLI example.
+
+## Not Done Yet
+
+- Online agent request validation.
+- Gateway health validation.
+- StarryOS kernel changes. No kernel change was needed for Phase 1.
+- Regression tests for syscall or ABI gaps. No blocking gap was confirmed in Phase 1.

--- a/examples/starry/picoclaw-cli/PHASE2_AGENT_SMOKE.md
+++ b/examples/starry/picoclaw-cli/PHASE2_AGENT_SMOKE.md
@@ -1,0 +1,113 @@
+# Phase 2: Online Agent Record
+
+This is a short factual record for later expansion.
+
+## Result
+
+Phase 2 online agent smoke passed on StarryOS x86_64 QEMU.
+
+Command:
+
+```bash
+cargo xtask starry qemu \
+  --arch x86_64 \
+  --qemu-config examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml \
+  --rootfs tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-online.img
+```
+
+Guest command:
+
+```bash
+picoclaw agent -m 'Reply with exactly: STARRY_PICOCLAW_AGENT_OK'
+```
+
+Success markers:
+
+```text
+STARRY_PICOCLAW_AGENT_OK
+STARRY_PICOCLAW_AGENT_PASSED
+```
+
+The passing run used an OpenAI-compatible endpoint:
+
+- provider: `openai`
+- model: `mimo-v2.5`
+- api_base: `https://token-plan-cn.xiaomimimo.com/v1`
+
+No API key or generated rootfs image is tracked.
+
+## Problems Found
+
+1. QEMU success and failure markers were unsafe because the guest shell echoes
+   commands before executing them.
+
+   `echo STARRY_PICOCLAW_AGENT_PASSED` appeared in the echoed script and could
+   satisfy `success_regex` before the agent request completed. The marker is now
+   printed as `printf 'STARRY_%s\n' PICOCLAW_AGENT_PASSED`, so the echoed command
+   does not contain the full success token.
+
+2. `tee` masked the `picoclaw agent` exit status.
+
+   The agent command originally piped through `tee`, so the pipeline could
+   return success even when `picoclaw agent` failed. The QEMU script now writes
+   agent output to a file, checks the command directly, then prints the file.
+
+3. Go DNS failed on UDP `setsockopt`.
+
+   First real online run failed with:
+
+   ```text
+   dial udp 10.0.2.3:53: setsockopt: protocol not available
+   ```
+
+   Root cause: Go enables `SO_BROADCAST` on UDP sockets during DNS setup.
+   StarryOS returned `ENOPROTOOPT`. The StarryOS syscall layer now accepts
+   `SOL_SOCKET/SO_BROADCAST` as a validated no-op.
+
+4. The provided Anthropic-style endpoint was not suitable for the first config.
+
+   With `provider = "anthropic"`, PicoClaw used the OpenAI-compatible
+   `/chat/completions` path and received 404 from the `/anthropic` base.
+
+   With `provider = "anthropic-messages"`, the request reached the service but
+   the default Claude model was not supported.
+
+   Host-side probing showed the usable path for this key is the
+   OpenAI-compatible root `/v1` with model `mimo-v2.5`.
+
+## Files Changed
+
+- `os/StarryOS/kernel/src/syscall/net/opt.rs`
+  - Accepts `SO_BROADCAST` in `setsockopt` as a no-op after validating the int
+    option value.
+
+- `examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh`
+  - Accepts `OPENAI_API_KEY` and `ANTHROPIC_AUTH_TOKEN` as fallback key sources.
+  - Supports Anthropic Messages defaults when `ANTHROPIC_AUTH_TOKEN` is used.
+
+- `examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml`
+  - Avoids success marker false positives from shell echo.
+  - Preserves the agent command exit status.
+
+- `examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-offline.toml`
+  - Uses the safer split success marker.
+
+- `examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-gateway.toml`
+  - Uses the safer split success marker.
+
+- `examples/starry/picoclaw-cli/README.md`
+  - Documents explicit OpenAI-compatible online rootfs preparation.
+
+## Verification
+
+- `cargo fmt`
+- `cargo xtask clippy --package starry-kernel`
+  - 10 checks passed.
+- Phase 2 QEMU agent smoke passed and printed
+  `STARRY_PICOCLAW_AGENT_PASSED`.
+
+## Remaining Watch Points
+
+- `sys_prctl: unsupported option 1398164801` still appears as a non-blocking warning.
+- `Unsupported ioctl command: 21505` still appears as a non-blocking terminal ioctl warning.
+- Gateway validation is not done yet.

--- a/examples/starry/picoclaw-cli/README.md
+++ b/examples/starry/picoclaw-cli/README.md
@@ -1,0 +1,121 @@
+# StarryOS PicoClaw CLI example
+
+这个目录提供一个 opt-in 的 PicoClaw 验证样例，用来确认 StarryOS x86_64 QEMU 对 PicoClaw 前两阶段的支持情况。它不会进入默认 CI，也不会提交 PicoClaw 二进制、rootfs 镜像、在线配置或任何密钥。
+
+## 目标层级
+
+1. 离线 Smoke：验证静态 Linux x86_64 PicoClaw 二进制能启动、写入配置并执行本地 CLI。
+2. 在线 Agent：注入 API key、代理和 CA 后，验证 `picoclaw agent -m ...` 能完成一次模型请求。
+
+## 准备离线 rootfs
+
+```bash
+examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh
+```
+
+脚本会复用或下载 `sipeed/picoclaw` 的 `v0.2.8` Linux x86_64 release tarball，校验 SHA-256，并把 `picoclaw` 与 `picoclaw-launcher` 注入到 Alpine rootfs 的 `/usr/local/bin/`。
+
+运行离线 smoke：
+
+```bash
+cargo xtask starry qemu \
+  --arch x86_64 \
+  --qemu-config examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-offline.toml \
+  --rootfs tmp/axbuild/rootfs/rootfs-x86_64-picoclaw.img
+```
+
+成功标记：
+
+```text
+STARRY_PICOCLAW_OFFLINE_PASSED
+```
+
+## 准备在线 rootfs
+
+可以让脚本生成最小在线配置和 `.security.yml`：
+
+```bash
+PICOCLAW_API_KEY=sk-... \
+examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh \
+  --output-rootfs tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-online.img \
+  --proxy http://10.0.2.2:7890
+```
+
+如果没有设置 `PICOCLAW_API_KEY`，脚本会回退读取 `OPENAI_API_KEY`，再回退读取
+`ANTHROPIC_AUTH_TOKEN`。当使用 `ANTHROPIC_AUTH_TOKEN` 时，脚本默认生成
+Anthropic Messages 配置，并读取 `ANTHROPIC_BASE_URL` 作为 `api_base`。也可以用
+`--api-key`、`--provider`、`--model` 和 `--api-base` 显式传入。
+
+对于 OpenAI-compatible 的中转服务，显式指定 provider、model 和 api_base：
+
+```bash
+examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh \
+  --output-rootfs tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-online.img \
+  --api-key "$PICOCLAW_API_KEY" \
+  --provider openai \
+  --model-name mimo-v2.5 \
+  --model mimo-v2.5 \
+  --api-base https://token-plan-cn.xiaomimimo.com/v1
+```
+
+也可以手动提供配置文件：
+
+```bash
+examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh \
+  --output-rootfs tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-online.img \
+  --config-json /path/to/config.json \
+  --security-yml /path/to/.security.yml \
+  --env-file /path/to/online-env
+```
+
+`online-env` 是普通 shell 文件，可包含 `http_proxy`、`https_proxy`、`all_proxy` 等导出语句。默认会注入 host 上的 `SSL_CERT_FILE`，如果该环境变量不存在，则尝试使用 `/etc/ssl/certs/ca-certificates.crt`。
+
+运行在线 Agent smoke：
+
+```bash
+cargo xtask starry qemu \
+  --arch x86_64 \
+  --qemu-config examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml \
+  --rootfs tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-online.img
+```
+
+成功标记：
+
+```text
+STARRY_PICOCLAW_AGENT_PASSED
+```
+
+## 当面演示脚本
+
+如果要从 Docker 环境开始，一步一步演示 StarryOS 中的 PicoClaw 在线对话，可以运行：
+
+```bash
+PICOCLAW_API_KEY=... examples/starry/picoclaw-cli/demo_picoclaw_agent.sh
+```
+
+脚本会逐步暂停，依次展示 Docker 检查、rootfs 准备、StarryOS QEMU 启动，以及一次
+可验收请求加多次 `picoclaw agent` 闲聊。没有提前设置 `PICOCLAW_API_KEY` 时，脚本会在本地隐藏输入。
+
+默认演示配置为：
+
+```text
+provider = openai
+model = mimo-v2.5
+api_base = https://token-plan-cn.xiaomimimo.com/v1
+```
+
+成功时会看到：
+
+```text
+STARRY_PICOCLAW_AGENT_OK
+STARRY_PICOCLAW_AGENT_PASSED
+```
+
+中间还会看到多段 `PicoClaw chat`，用于现场展示 StarryOS guest 内连续模型对话。
+
+## 边界
+
+- 第一目标只覆盖 StarryOS x86_64 QEMU。
+- 资产放在 `target/picoclaw/assets/`，rootfs 放在 `tmp/axbuild/rootfs/`。
+- Gateway 服务和交互式长期使用入口后续单独推进。
+- 如果 smoke 暴露 syscall 或 ABI 缺口，再按最小复现补 StarryOS 内核和对应回归测试。

--- a/examples/starry/picoclaw-cli/demo_picoclaw_agent.sh
+++ b/examples/starry/picoclaw-cli/demo_picoclaw_agent.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+image="${STARRYOS_DOCKER_IMAGE:-starryos-dev:ubuntu-qemu10.2.1}"
+rootfs="${PICOCLAW_DEMO_ROOTFS:-tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-online.img}"
+qemu_config="${PICOCLAW_DEMO_QEMU_CONFIG:-examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml}"
+provider="${PICOCLAW_PROVIDER:-openai}"
+model_name="${PICOCLAW_MODEL_NAME:-mimo-v2.5}"
+model="${PICOCLAW_MODEL:-mimo-v2.5}"
+api_base="${PICOCLAW_API_BASE:-https://token-plan-cn.xiaomimimo.com/v1}"
+pause_enabled=1
+
+usage() {
+    cat <<EOF
+Usage: $0 [--no-pause]
+
+Run a teacher-facing Phase 2 demo:
+  1. check Docker and the StarryOS development image;
+  2. prepare a PicoClaw online rootfs inside Docker;
+  3. boot StarryOS x86_64 QEMU inside Docker;
+  4. run one verifiable PicoClaw request and several short chats.
+
+Required secret:
+  PICOCLAW_API_KEY      API key for the configured endpoint. If it is unset,
+                        this script asks for it without echoing.
+
+Optional environment:
+  STARRYOS_DOCKER_IMAGE default: ${image}
+  PICOCLAW_PROVIDER     default: ${provider}
+  PICOCLAW_MODEL_NAME   default: ${model_name}
+  PICOCLAW_MODEL        default: ${model}
+  PICOCLAW_API_BASE     default: ${api_base}
+  PICOCLAW_DEMO_ROOTFS  default: ${rootfs}
+
+The API key is not written to tracked files. The generated rootfs contains the
+key and must stay local.
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+        --no-pause)
+            pause_enabled=0
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+say() {
+    printf '\n\033[1;36m==> %s\033[0m\n' "$1"
+}
+
+pause() {
+    if [[ "$pause_enabled" -eq 1 ]]; then
+        printf '\n按 Enter 继续...'
+        read -r _
+    fi
+}
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+image_exists() {
+    docker image inspect "$image" >/dev/null 2>&1 && return 0
+    docker image ls --format '{{.Repository}}:{{.Tag}}' | grep -Fx "$image" >/dev/null
+}
+
+run_docker() {
+    docker run --rm \
+        -v "$workspace:/mnt" \
+        -w /mnt \
+        -e PICOCLAW_API_KEY \
+        -e PICOCLAW_PROVIDER="$provider" \
+        -e PICOCLAW_MODEL_NAME="$model_name" \
+        -e PICOCLAW_MODEL="$model" \
+        -e PICOCLAW_API_BASE="$api_base" \
+        "$image" \
+        bash -lc "$1"
+}
+
+need_cmd docker
+
+if [[ -z "${PICOCLAW_API_KEY:-}" ]]; then
+    printf '请输入 PicoClaw/API endpoint key，输入时不会回显: '
+    read -r -s PICOCLAW_API_KEY
+    printf '\n'
+    export PICOCLAW_API_KEY
+fi
+
+if [[ -z "$PICOCLAW_API_KEY" ]]; then
+    echo "PICOCLAW_API_KEY is empty" >&2
+    exit 1
+fi
+
+say "Step 1: 检查 Docker 可用性"
+docker info >/dev/null
+if ! image_exists; then
+    echo "Docker image not found: $image" >&2
+    echo "Available StarryOS-like images:" >&2
+    docker image ls --format '  {{.Repository}}:{{.Tag}}  {{.ID}}' | grep -E 'starry|rcore|qemu' >&2 || true
+    echo "Set STARRYOS_DOCKER_IMAGE to an available image name if needed." >&2
+    exit 1
+fi
+echo "Docker OK"
+echo "Using image: $image"
+pause
+
+say "Step 2: 展示本次在线对话配置"
+echo "provider:  $provider"
+echo "model:     $model"
+echo "api_base:  $api_base"
+echo "rootfs:    $rootfs"
+echo "qemu conf: $qemu_config"
+echo "API key:   <hidden>"
+pause
+
+say "Step 3: 在 Docker 中确认 StarryOS/PicoClaw 所需工具"
+run_docker 'command -v debugfs; command -v qemu-system-x86_64; command -v cargo; rustup toolchain list | sed -n "1,3p"'
+pause
+
+say "Step 4: 生成带 PicoClaw 和在线配置的 StarryOS rootfs"
+run_docker "export PATH=/opt/qemu-10.2.1/bin:\$PATH; examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh --output-rootfs '$rootfs'"
+pause
+
+say "Step 5: 启动 StarryOS x86_64 QEMU，并让 PicoClaw 完成多次真实对话"
+echo "成功时请向老师指出这两行："
+echo "  STARRY_PICOCLAW_AGENT_OK"
+echo "  STARRY_PICOCLAW_AGENT_PASSED"
+echo "中间还会出现多段 PicoClaw chat，展示它在 StarryOS guest 里连续闲聊。"
+pause
+run_docker "export PATH=/opt/qemu-10.2.1/bin:/opt/x86_64-linux-musl-cross/bin:\$PATH; cargo xtask starry qemu --arch x86_64 --qemu-config '$qemu_config' --rootfs '$rootfs'"
+
+say "演示完成"
+echo "StarryOS 已在 QEMU 中运行 PicoClaw，并完成多次真实 API 对话。"
+echo "注意：$rootfs 是本地生成物，里面包含在线配置和 secret，不要提交。"

--- a/examples/starry/picoclaw-cli/prepare_picoclaw_assets.sh
+++ b/examples/starry/picoclaw-cli/prepare_picoclaw_assets.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+version="${PICOCLAW_VERSION:-v0.2.8}"
+asset_name="${PICOCLAW_ASSET_NAME:-picoclaw_Linux_x86_64.tar.gz}"
+asset_sha256="${PICOCLAW_ASSET_SHA256:-e35aea853711db829e0d1969d875f2efcca9cfeec92a43dedb84b46a56b890be}"
+asset_url="${PICOCLAW_ASSET_URL:-https://github.com/sipeed/picoclaw/releases/download/${version}/${asset_name}}"
+asset_dir="${PICOCLAW_ASSET_DIR:-${workspace}/target/picoclaw/assets}"
+
+usage() {
+    cat <<EOF
+Usage: $0 [--asset-dir DIR] [--url URL] [--sha256 HEX]
+
+Download or reuse the PicoClaw Linux x86_64 release asset and place the
+static binaries under target/picoclaw/assets/.
+
+Environment overrides:
+  PICOCLAW_VERSION      Release tag, default: ${version}
+  PICOCLAW_ASSET_URL    Full release asset URL
+  PICOCLAW_ASSET_SHA256 Expected SHA-256 of the tarball
+  PICOCLAW_ASSET_DIR    Output directory
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+        --asset-dir)
+            asset_dir="$2"
+            shift 2
+            ;;
+        --url)
+            asset_url="$2"
+            shift 2
+            ;;
+        --sha256)
+            asset_sha256="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        echo "missing required command: sha256sum or shasum" >&2
+        exit 1
+    fi
+}
+
+need_cmd curl
+need_cmd tar
+need_cmd install
+need_cmd mktemp
+
+mkdir -p "$asset_dir"
+
+if [[ -x "${asset_dir}/picoclaw" && -x "${asset_dir}/picoclaw-launcher" ]]; then
+    echo "PicoClaw assets already exist in ${asset_dir}"
+    exit 0
+fi
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/picoclaw-assets.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+tarball="${tmpdir}/${asset_name}"
+echo "Downloading ${asset_url}"
+curl -L --fail --retry 3 --output "$tarball" "$asset_url"
+
+actual_sha256="$(sha256_of "$tarball")"
+if [[ "$actual_sha256" != "$asset_sha256" ]]; then
+    echo "SHA-256 mismatch for ${asset_name}" >&2
+    echo "expected: ${asset_sha256}" >&2
+    echo "actual:   ${actual_sha256}" >&2
+    exit 1
+fi
+
+tar -xzf "$tarball" -C "$tmpdir"
+
+if [[ ! -f "${tmpdir}/picoclaw" || ! -f "${tmpdir}/picoclaw-launcher" ]]; then
+    echo "release asset does not contain expected PicoClaw binaries" >&2
+    exit 1
+fi
+
+install -m 0755 "${tmpdir}/picoclaw" "${asset_dir}/picoclaw"
+install -m 0755 "${tmpdir}/picoclaw-launcher" "${asset_dir}/picoclaw-launcher"
+
+echo "PicoClaw assets ready in ${asset_dir}"

--- a/examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh
+++ b/examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+example_dir="${workspace}/examples/starry/picoclaw-cli"
+
+base_rootfs="${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img"
+output_rootfs="${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-picoclaw.img"
+asset_dir="${workspace}/target/picoclaw/assets"
+config_json=""
+security_yml=""
+env_file=""
+api_key="${PICOCLAW_API_KEY:-${OPENAI_API_KEY:-${ANTHROPIC_AUTH_TOKEN:-}}}"
+proxy_url="${PICOCLAW_ONLINE_PROXY:-}"
+ca_cert="${SSL_CERT_FILE:-/etc/ssl/certs/ca-certificates.crt}"
+
+model_name="${PICOCLAW_MODEL_NAME:-starry-smoke}"
+provider="${PICOCLAW_PROVIDER:-openai}"
+model="${PICOCLAW_MODEL:-gpt-5.4}"
+api_base="${PICOCLAW_API_BASE:-https://api.openai.com/v1}"
+
+if [[ -z "${PICOCLAW_PROVIDER:-}" && -z "${PICOCLAW_API_KEY:-}" && -z "${OPENAI_API_KEY:-}" && -n "${ANTHROPIC_AUTH_TOKEN:-}" ]]; then
+    model_name="${PICOCLAW_MODEL_NAME:-claude-sonnet-4.6}"
+    provider="anthropic-messages"
+    model="${PICOCLAW_MODEL:-claude-sonnet-4.6}"
+    api_base="${PICOCLAW_API_BASE:-${ANTHROPIC_BASE_URL:-https://api.anthropic.com/v1}}"
+fi
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Build a StarryOS x86_64 rootfs with PicoClaw injected.
+
+Options:
+  --base-rootfs PATH      Source Alpine rootfs image
+  --output-rootfs PATH    Output rootfs image
+  --config-json PATH      Inject a prepared /root/.picoclaw/config.json
+  --security-yml PATH     Inject a prepared /root/.picoclaw/.security.yml
+  --api-key KEY           Generate online config and secret security file
+  --model-name NAME       Generated online config model name
+  --provider NAME         Generated online config provider
+  --model NAME            Generated online config model id
+  --api-base URL          Generated online config API base
+  --proxy URL             Inject http_proxy/https_proxy/all_proxy env file
+  --env-file PATH         Inject a shell env file as starry-online-env
+  --ca-cert PATH          Inject CA bundle as /etc/ssl/certs/ca-certificates.crt
+  -h, --help              Show this help
+
+Secrets and generated rootfs images stay under tmp/ or target/ and must not be
+committed.
+
+The generated online config uses PICOCLAW_API_KEY first, then OPENAI_API_KEY,
+then ANTHROPIC_AUTH_TOKEN, or the explicit --api-key value. If
+ANTHROPIC_AUTH_TOKEN is the selected source, the generated provider defaults to
+Anthropic Messages and ANTHROPIC_BASE_URL is used as the API base when present.
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+        --base-rootfs)
+            base_rootfs="$2"
+            shift 2
+            ;;
+        --output-rootfs)
+            output_rootfs="$2"
+            shift 2
+            ;;
+        --config-json)
+            config_json="$2"
+            shift 2
+            ;;
+        --security-yml)
+            security_yml="$2"
+            shift 2
+            ;;
+        --api-key)
+            api_key="$2"
+            shift 2
+            ;;
+        --model-name)
+            model_name="$2"
+            shift 2
+            ;;
+        --provider)
+            provider="$2"
+            shift 2
+            ;;
+        --model)
+            model="$2"
+            shift 2
+            ;;
+        --api-base)
+            api_base="$2"
+            shift 2
+            ;;
+        --proxy)
+            proxy_url="$2"
+            shift 2
+            ;;
+        --env-file)
+            env_file="$2"
+            shift 2
+            ;;
+        --ca-cert)
+            ca_cert="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+shell_quote() {
+    local value="$1"
+    printf "'%s'" "${value//\'/\'\\\'\'}"
+}
+
+json_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    printf '%s' "$value"
+}
+
+yaml_double_quote() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    printf '"%s"' "$value"
+}
+
+stat_mode() {
+    stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+need_cmd cp
+need_cmd debugfs
+need_cmd install
+need_cmd mktemp
+
+"${example_dir}/prepare_picoclaw_assets.sh" --asset-dir "$asset_dir"
+
+if [[ ! -f "$base_rootfs" ]]; then
+    if [[ "$base_rootfs" == "${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img" ]]; then
+        echo "Base rootfs is missing; building ${base_rootfs}"
+        (cd "$workspace" && cargo xtask starry rootfs --arch x86_64)
+    else
+        echo "base rootfs does not exist: ${base_rootfs}" >&2
+        exit 1
+    fi
+fi
+
+mkdir -p "$(dirname "$output_rootfs")"
+cp "$base_rootfs" "$output_rootfs"
+
+overlay="$(mktemp -d "${TMPDIR:-/tmp}/picoclaw-rootfs.XXXXXX")"
+debug_cmds="$(mktemp "${TMPDIR:-/tmp}/picoclaw-debugfs.XXXXXX")"
+trap 'rm -rf "$overlay" "$debug_cmds"' EXIT
+
+install -d "${overlay}/usr/local/bin"
+install -m 0755 "${asset_dir}/picoclaw" "${overlay}/usr/local/bin/picoclaw"
+install -m 0755 "${asset_dir}/picoclaw-launcher" "${overlay}/usr/local/bin/picoclaw-launcher"
+
+install -d "${overlay}/root/.picoclaw/workspace"
+
+if [[ -n "$config_json" ]]; then
+    install -m 0644 "$config_json" "${overlay}/root/.picoclaw/config.json"
+elif [[ -n "$api_key" ]]; then
+    cat >"${overlay}/root/.picoclaw/config.json" <<EOF
+{
+  "version": 3,
+  "agents": {
+    "defaults": {
+      "model_name": "$(json_escape "$model_name")",
+      "workspace": "/root/.picoclaw/workspace",
+      "restrict_to_workspace": true,
+      "max_tool_iterations": 3
+    }
+  },
+  "model_list": [
+    {
+      "model_name": "$(json_escape "$model_name")",
+      "provider": "$(json_escape "$provider")",
+      "model": "$(json_escape "$model")",
+      "api_base": "$(json_escape "$api_base")",
+      "enabled": true
+    }
+  ],
+  "gateway": {
+    "host": "127.0.0.1",
+    "port": 18790,
+    "hot_reload": false,
+    "log_level": "warn"
+  }
+}
+EOF
+fi
+
+if [[ -n "$security_yml" ]]; then
+    install -m 0600 "$security_yml" "${overlay}/root/.picoclaw/.security.yml"
+elif [[ -n "$api_key" ]]; then
+    {
+        printf 'model_list:\n'
+        printf '  %s:\n' "$(yaml_double_quote "$model_name")"
+        printf '    api_keys:\n'
+        printf '      - %s\n' "$(yaml_double_quote "$api_key")"
+    } >"${overlay}/root/.picoclaw/.security.yml"
+    chmod 0600 "${overlay}/root/.picoclaw/.security.yml"
+fi
+
+if [[ -n "$env_file" ]]; then
+    install -m 0600 "$env_file" "${overlay}/root/.picoclaw/starry-online-env"
+elif [[ -n "$proxy_url" ]]; then
+    {
+        printf 'export http_proxy=%s\n' "$(shell_quote "$proxy_url")"
+        printf 'export https_proxy=%s\n' "$(shell_quote "$proxy_url")"
+        printf 'export all_proxy=%s\n' "$(shell_quote "$proxy_url")"
+        printf 'export HTTP_PROXY=%s\n' "$(shell_quote "$proxy_url")"
+        printf 'export HTTPS_PROXY=%s\n' "$(shell_quote "$proxy_url")"
+        printf 'export ALL_PROXY=%s\n' "$(shell_quote "$proxy_url")"
+    } >"${overlay}/root/.picoclaw/starry-online-env"
+    chmod 0600 "${overlay}/root/.picoclaw/starry-online-env"
+fi
+
+if [[ -n "$ca_cert" && -f "$ca_cert" ]]; then
+    install -d "${overlay}/etc/ssl/certs"
+    install -m 0644 "$ca_cert" "${overlay}/etc/ssl/certs/ca-certificates.crt"
+fi
+
+: >"$debug_cmds"
+while IFS= read -r -d '' dir; do
+    rel="${dir#${overlay}}"
+    [[ -z "$rel" ]] && continue
+    printf 'mkdir "%s"\n' "$rel" >>"$debug_cmds"
+done < <(find "$overlay" -type d -print0 | sort -z)
+
+while IFS= read -r -d '' file; do
+    rel="${file#${overlay}}"
+    mode="$(stat_mode "$file")"
+    printf 'rm "%s"\n' "$rel" >>"$debug_cmds"
+    printf 'write "%s" "%s"\n' "$file" "$rel" >>"$debug_cmds"
+    printf 'sif "%s" mode 0100%s\n' "$rel" "$mode" >>"$debug_cmds"
+done < <(find "$overlay" -type f -print0 | sort -z)
+
+debugfs -w -f "$debug_cmds" "$output_rootfs"
+
+echo "PicoClaw rootfs ready: ${output_rootfs}"
+echo
+echo "Offline smoke:"
+echo "  cargo xtask starry qemu --arch x86_64 --qemu-config examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-offline.toml --rootfs ${output_rootfs#${workspace}/}"
+if [[ -n "$api_key" || -n "$config_json" || -n "$security_yml" ]]; then
+    echo
+    echo "Online agent smoke:"
+    echo "  cargo xtask starry qemu --arch x86_64 --qemu-config examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml --rootfs ${output_rootfs#${workspace}/}"
+fi

--- a/examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml
+++ b/examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml
@@ -1,0 +1,81 @@
+timeout = 600
+shell_prefix = "root@starry:"
+uefi = false
+to_bin = false
+success_regex = ["(?m)^STARRY_PICOCLAW_AGENT_PASSED\\s*$"]
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)page fault",
+  "(?i)segmentation fault",
+  "exec format error",
+  "Permission denied",
+  "unsupported syscall",
+]
+
+args = [
+  "-machine", "q35",
+  "-nographic",
+  "-m", "2G",
+  "-device", "virtio-blk-pci,drive=disk0",
+  "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-online.img",
+  "-device", "virtio-net-pci,netdev=net0",
+  "-netdev", "user,id=net0",
+  "-snapshot",
+]
+
+shell_init_cmd = """
+export HOME=/root
+export USER=root
+export SHELL=/bin/sh
+export TERM=dumb
+export NO_COLOR=1
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export PICOCLAW_HOME=/root/.picoclaw
+export PICOCLAW_CONFIG=/root/.picoclaw/config.json
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+set -e
+mkdir -p "$PICOCLAW_HOME" "$PICOCLAW_HOME/workspace" /tmp/picoclaw-smoke
+if [ -f "$PICOCLAW_HOME/starry-online-env" ]; then
+    . "$PICOCLAW_HOME/starry-online-env"
+fi
+if [ ! -f "$PICOCLAW_CONFIG" ]; then
+    echo "missing online PicoClaw config at $PICOCLAW_CONFIG"
+    echo STARRY_PICOCLAW_AGENT_FAILED
+    exit 1
+fi
+if [ ! -f "$PICOCLAW_HOME/.security.yml" ]; then
+    echo "missing PicoClaw security file at $PICOCLAW_HOME/.security.yml"
+    echo STARRY_PICOCLAW_AGENT_FAILED
+    exit 1
+fi
+picoclaw status > /tmp/picoclaw-smoke/status.txt 2>&1
+cat /tmp/picoclaw-smoke/status.txt
+
+run_picoclaw_chat() {
+    label="$1"
+    prompt="$2"
+    output="/tmp/picoclaw-smoke/${label}.txt"
+    printf '\\n===== PicoClaw chat: %s =====\\n' "$label"
+    printf 'Prompt: %s\\n' "$prompt"
+    if ! picoclaw agent -m "$prompt" > "$output" 2>&1; then
+        cat "$output"
+        exit 1
+    fi
+    printf 'Reply:\\n'
+    cat "$output"
+    printf '\\n===== End chat: %s =====\\n' "$label"
+}
+
+run_picoclaw_chat agent-token 'Reply with exactly: STARRY_PICOCLAW_AGENT_OK'
+grep -F "STARRY_PICOCLAW_AGENT_OK" /tmp/picoclaw-smoke/agent-token.txt
+
+run_picoclaw_chat chat-hello '你现在运行在 StarryOS 的 x86_64 QEMU guest 里。请用一句中文向老师打招呼。'
+run_picoclaw_chat chat-capability '请用两句话说明：这次演示证明 PicoClaw 已经能在 StarryOS 里发起真实模型请求。'
+run_picoclaw_chat chat-wrapup '请用一句中文总结本次 PicoClaw 演示已经完成，不要超过二十个字。'
+
+if [ ! -s /tmp/picoclaw-smoke/chat-wrapup.txt ]; then
+    echo "missing PicoClaw chat output"
+    exit 1
+fi
+printf 'STARRY_%s\n' PICOCLAW_AGENT_PASSED
+"""

--- a/examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-offline.toml
+++ b/examples/starry/picoclaw-cli/qemu-x86_64-picoclaw-offline.toml
@@ -1,0 +1,49 @@
+timeout = 420
+shell_prefix = "root@starry:"
+uefi = false
+to_bin = false
+success_regex = ["(?m)^STARRY_PICOCLAW_OFFLINE_PASSED\\s*$"]
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)page fault",
+  "(?i)segmentation fault",
+  "exec format error",
+  "Permission denied",
+  "unsupported syscall",
+]
+
+args = [
+  "-machine", "q35",
+  "-nographic",
+  "-m", "2G",
+  "-device", "virtio-blk-pci,drive=disk0",
+  "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-picoclaw.img",
+  "-device", "virtio-net-pci,netdev=net0",
+  "-netdev", "user,id=net0",
+  "-snapshot",
+]
+
+shell_init_cmd = """
+export HOME=/root
+export USER=root
+export SHELL=/bin/sh
+export TERM=dumb
+export NO_COLOR=1
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export PICOCLAW_HOME=/root/.picoclaw
+export PICOCLAW_CONFIG=/root/.picoclaw/config.json
+set -e
+rm -rf "$PICOCLAW_HOME" /tmp/picoclaw-smoke
+mkdir -p "$PICOCLAW_HOME" /tmp/picoclaw-smoke
+picoclaw version | tee /tmp/picoclaw-smoke/version.txt
+picoclaw --help > /tmp/picoclaw-smoke/help.txt
+picoclaw onboard | tee /tmp/picoclaw-smoke/onboard.txt
+test -f "$PICOCLAW_CONFIG"
+test -d "$PICOCLAW_HOME/workspace"
+picoclaw status | tee /tmp/picoclaw-smoke/status.txt
+grep -F "picoclaw" /tmp/picoclaw-smoke/version.txt
+grep -F "PicoClaw" /tmp/picoclaw-smoke/help.txt
+grep -F "config.json" /tmp/picoclaw-smoke/onboard.txt
+grep -F '"version"' "$PICOCLAW_CONFIG"
+printf 'STARRY_%s\n' PICOCLAW_OFFLINE_PASSED
+"""

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -204,6 +204,15 @@ pub fn sys_setsockopt(
         }
     }
 
+    {
+        use linux_raw_sys::net::{SO_BROADCAST, SOL_SOCKET};
+
+        if (level, optname) == (SOL_SOCKET, SO_BROADCAST) {
+            let _ = read_int_sockopt(optval, optlen)?;
+            return Ok(0);
+        }
+    }
+
     fn get<'a, T: 'static>(val: UserConstPtr<u8>, len: socklen_t) -> AxResult<&'a T> {
         if len as usize != size_of::<T>() {
             return Err(AxError::InvalidInput);


### PR DESCRIPTION
## Summary

- add an opt-in StarryOS x86_64 QEMU PicoClaw example for Phase 1 offline CLI smoke and Phase 2 online agent smoke
- add asset/rootfs preparation scripts that keep release binaries, rootfs images, and secrets outside tracked files
- tolerate `setsockopt(SOL_SOCKET, SO_BROADCAST)` in StarryOS, which is needed by the Go DNS path used by PicoClaw online requests

## Validation

- `cargo fmt`
- `bash -n examples/starry/picoclaw-cli/prepare_picoclaw_assets.sh`
- `bash -n examples/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh`
- `bash -n examples/starry/picoclaw-cli/demo_picoclaw_agent.sh`
- Docker default toolchain: `cargo xtask clippy --package starry-kernel` passed 10/10 checks
- Phase 1 offline QEMU smoke reached `STARRY_PICOCLAW_OFFLINE_PASSED`
- Phase 2 online QEMU smoke reached `STARRY_PICOCLAW_AGENT_PASSED`

## Notes

PicoClaw release assets, generated rootfs images, API keys, and online config outputs are intentionally local-only and are not committed.