### PR TITLE
fix(starry-kernel): release AddrSpace on last process slot, not on Arc strong-count

### DIFF
--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -1,5 +1,9 @@
 use alloc::sync::Arc;
-use core::{fmt, ops::DerefMut};
+use core::{
+    fmt,
+    ops::DerefMut,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use ax_errno::{AxError, AxResult, ax_bail};
 use ax_hal::{
@@ -35,6 +39,14 @@ pub struct AddrSpace {
     va_range: VirtAddrRange,
     areas: MemorySet<Backend>,
     pt: PageTable,
+    /// Number of live [`crate::task::ProcessData`] instances that reference this
+    /// address space (each `fork`/`clone` / `execve` slot that holds the
+    /// `Arc<Mutex<AddrSpace>>`).
+    ///
+    /// This must **not** be confused with `Arc::strong_count`, which also counts
+    /// transient clones from `ProcessData::aspace()` and is not reliable for
+    /// SMP teardown decisions.
+    pub(crate) process_slots: AtomicUsize,
 }
 
 impl AddrSpace {
@@ -79,6 +91,7 @@ impl AddrSpace {
             va_range: VirtAddrRange::from_start_size(base, size),
             areas: MemorySet::new(),
             pt: PageTable::try_new().map_err(|_| AxError::NoMemory)?,
+            process_slots: AtomicUsize::new(0),
         })
     }
 
@@ -500,12 +513,31 @@ impl AddrSpace {
     }
 }
 
+/// Increment how many [`crate::task::ProcessData`] slots refer to `aspace`.
+pub(crate) fn attach_process_slot(aspace: &Arc<Mutex<AddrSpace>>) {
+    aspace.lock().process_slots.fetch_add(1, Ordering::AcqRel);
+}
+
+/// One [`crate::task::ProcessData`] releases its logical slot. When the last slot
+/// is dropped while holding [`Mutex`]`<`[`AddrSpace`]`>`, run [`AddrSpace::clear`]
+/// so inode-scoped accounting (memfd, etc.) is torn down before the page table
+/// is reclaimed.
+pub(crate) fn release_process_slot(aspace: &Arc<Mutex<AddrSpace>>) {
+    let mut guard = aspace.lock();
+    let prev = guard.process_slots.fetch_sub(1, Ordering::AcqRel);
+    debug_assert!(prev >= 1, "AddrSpace::process_slots underflow");
+    if prev == 1 {
+        guard.clear();
+    }
+}
+
 impl fmt::Debug for AddrSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("AddrSpace")
             .field("va_range", &self.va_range)
             .field("page_table_root", &self.pt.root_paddr())
             .field("areas", &self.areas)
+            .field("process_slots", &self.process_slots.load(Ordering::Relaxed))
             .finish()
     }
 }

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -382,6 +382,10 @@ pub struct ProcessData {
 
     /// POSIX per-process interval timers (timer_create/timer_settime/etc.)
     pub posix_timers: Arc<PosixTimerTable>,
+
+    /// Set after [`Self::release_aspace_slot_if_needed`] runs so `Drop` does not
+    /// double-decrement [`AddrSpace::process_slots`].
+    aspace_slot_released: AtomicBool,
 }
 
 impl ProcessData {
@@ -394,7 +398,7 @@ impl ProcessData {
         signal_actions: Arc<SpinNoIrq<SignalActions>>,
         exit_signal: Option<Signo>,
     ) -> Arc<Self> {
-        Arc::new(Self {
+        let this = Arc::new(Self {
             proc,
             exe_path: RwLock::new(exe_path),
             cmdline: RwLock::new(cmdline),
@@ -423,7 +427,30 @@ impl ProcessData {
             children_cpu_time: SpinNoIrq::new((TimeValue::ZERO, TimeValue::ZERO)),
 
             posix_timers: Arc::new(PosixTimerTable::default()),
-        })
+
+            aspace_slot_released: AtomicBool::new(false),
+        });
+        // Clone the Arc in a separate statement: a temporary `SpinNoIrq` guard
+        // from `lock()` lives until the end of the statement, so calling
+        // `attach_process_slot` (which locks `Mutex<AddrSpace>`) in the same
+        // expression would nest a sleepable lock inside atomic context.
+        let aspace_arc = this.aspace.lock().clone();
+        crate::mm::attach_process_slot(&aspace_arc);
+        this
+    }
+
+    /// Release this process's [`AddrSpace::process_slots`] entry.
+    ///
+    /// Invoked from the last-thread exit path so VMA-backed inode accounting is
+    /// torn down before `waitpid` returns, and again from `Drop` if not already
+    /// run. Only the last slot holder triggers [`AddrSpace::clear`], so
+    /// `CLONE_VM` co-owners are unaffected.
+    pub fn release_aspace_slot_if_needed(&self) {
+        if self.aspace_slot_released.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let aspace = self.aspace.lock().clone();
+        crate::mm::release_process_slot(&aspace);
     }
 
     /// Get the top address of the user heap.
@@ -506,11 +533,13 @@ impl ProcessData {
     /// `mem::replace` moves the old Arc out of the guard so it is dropped
     /// **after** the `SpinNoIrq` guard, in normal preemptible context.
     pub fn replace_aspace(&self, new_aspace: Arc<Mutex<AddrSpace>>) {
-        let _old = {
+        let old = {
             let mut guard = self.aspace.lock();
             core::mem::replace(&mut *guard, new_aspace)
         };
-        // `_old` drops here — SpinNoIrq already released, IRQs re-enabled.
+        crate::mm::release_process_slot(&old);
+        let aspace_arc = self.aspace.lock().clone();
+        crate::mm::attach_process_slot(&aspace_arc);
     }
 
     /// Set the vfork completion (called on the child after a vfork,
@@ -556,6 +585,12 @@ impl ProcessData {
             // guard dropped here
         };
         wq.notify_one(true);
+    }
+}
+
+impl Drop for ProcessData {
+    fn drop(&mut self) {
+        self.release_aspace_slot_if_needed();
     }
 }
 

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -440,6 +440,10 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
         thr.proc_data.notify_vfork_done();
 
         crate::syscall::clear_proc_shm(process.pid(), &thr.proc_data.aspace());
+
+        // Tear down this process's address-space slot before waitpid returns on
+        // SMP; only the last slot holder runs AddrSpace::clear.
+        thr.proc_data.release_aspace_slot_if_needed();
     }
     thr.exit_event.wake();
 


### PR DESCRIPTION
waitpid can return on SMP before ProcessData::drop runs on the exiting
thread. Relying on transient Arc::strong_count probes to decide when to
call AddrSpace::clear races with other holders of the same Arc.

Switch to an explicit per-aspace process_slots refcount:
- attach_process_slot on ProcessData::new;
- release_process_slot on last-thread do_exit and Drop (guarded against
  double release);
- replace_aspace swaps slots when execve installs a new address space;
- only the last slot release runs AddrSpace::clear, so CLONE_VM peers
  sharing one Arc<Mutex<AddrSpace>> remain safe.

Made with [Cursor](https://cursor.com)