### PR TITLE
fix(starry-kernel): MAP_FIXED failure preserves prior mapping

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -172,22 +172,21 @@ pub fn sys_mmap(
 
     // File-backed `MAP_FIXED`: validate fd mode before any destructive unmap
     // (Linux `do_mmap` ordering; avoids tearing down the old mapping on `EACCES`).
-    if let Some(dm) = device_mmap_top.as_ref() {
-        let needs_file_mmap_checks = match dm {
-            Ok(DeviceMmap::Physical(_)) | Ok(DeviceMmap::Cache(_)) => false,
-            Ok(DeviceMmap::None) | Err(_) => true,
-        };
-        if needs_file_mmap_checks && let Some(ref fl) = file {
-            let (_backend, flags) = fl.file_mmap()?;
-            if !flags.contains(FileFlags::READ) {
-                return Err(AxError::PermissionDenied);
-            }
-            if map_type == MmapFlags::SHARED
-                && permission_flags.contains(MmapProt::WRITE)
-                && !flags.contains(FileFlags::WRITE)
-            {
-                return Err(AxError::PermissionDenied);
-            }
+    // Covers both regular files and PRIVATE mappings that bypass device_mmap in the
+    // backend match (device_mmap may return Physical/Cache while PRIVATE still uses
+    // file_mmap). `file_mmap()` here is intentionally idempotent with the main path.
+    if map_flags.intersects(MmapFlags::FIXED | MmapFlags::FIXED_NOREPLACE)
+        && let Some(ref fl) = file
+    {
+        let (_backend, flags) = fl.file_mmap()?;
+        if !flags.contains(FileFlags::READ) {
+            return Err(AxError::PermissionDenied);
+        }
+        if matches!(map_type, MmapFlags::SHARED | MmapFlags::SHARED_VALIDATE)
+            && permission_flags.contains(MmapProt::WRITE)
+            && !flags.contains(FileFlags::WRITE)
+        {
+            return Err(AxError::PermissionDenied);
         }
     }
 

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -148,33 +148,9 @@ pub fn sys_mmap(
         PageSize::Size4K
     };
 
-    let start = addr.align_down(page_size);
+    let aligned = addr.align_down(page_size);
     let end = (addr + length).align_up(page_size);
-    let mut length = end - start;
-
-    let start = if map_flags.intersects(MmapFlags::FIXED | MmapFlags::FIXED_NOREPLACE) {
-        let dst_addr = VirtAddr::from(start);
-        if !map_flags.contains(MmapFlags::FIXED_NOREPLACE) {
-            aspace.unmap(dst_addr, length)?;
-        }
-        dst_addr
-    } else {
-        let align = page_size as usize;
-        aspace
-            .find_free_area(
-                VirtAddr::from(start),
-                length,
-                VirtAddrRange::new(aspace.base(), aspace.end()),
-                align,
-            )
-            .or(aspace.find_free_area(
-                aspace.base(),
-                length,
-                VirtAddrRange::new(aspace.base(), aspace.end()),
-                align,
-            ))
-            .ok_or(AxError::NoMemory)?
-    };
+    let mut length = end - aligned;
 
     let file = if anonymous {
         None
@@ -191,6 +167,52 @@ pub fn sys_mmap(
             return Err(AxError::OperationNotPermitted);
         }
         Some(get_file_like(fd)?)
+    };
+    let mut device_mmap_top = file.as_ref().map(|fl| fl.device_mmap(offset as u64));
+
+    // File-backed `MAP_FIXED`: validate fd mode before any destructive unmap
+    // (Linux `do_mmap` ordering; avoids tearing down the old mapping on `EACCES`).
+    if let Some(dm) = device_mmap_top.as_ref() {
+        let needs_file_mmap_checks = match dm {
+            Ok(DeviceMmap::Physical(_)) | Ok(DeviceMmap::Cache(_)) => false,
+            Ok(DeviceMmap::None) | Err(_) => true,
+        };
+        if needs_file_mmap_checks && let Some(ref fl) = file {
+            let (_backend, flags) = fl.file_mmap()?;
+            if !flags.contains(FileFlags::READ) {
+                return Err(AxError::PermissionDenied);
+            }
+            if map_type == MmapFlags::SHARED
+                && permission_flags.contains(MmapProt::WRITE)
+                && !flags.contains(FileFlags::WRITE)
+            {
+                return Err(AxError::PermissionDenied);
+            }
+        }
+    }
+
+    let start = if map_flags.intersects(MmapFlags::FIXED | MmapFlags::FIXED_NOREPLACE) {
+        let dst_addr = VirtAddr::from(aligned);
+        if !map_flags.contains(MmapFlags::FIXED_NOREPLACE) {
+            aspace.unmap(dst_addr, length)?;
+        }
+        dst_addr
+    } else {
+        let align = page_size as usize;
+        aspace
+            .find_free_area(
+                VirtAddr::from(aligned),
+                length,
+                VirtAddrRange::new(aspace.base(), aspace.end()),
+                align,
+            )
+            .or(aspace.find_free_area(
+                aspace.base(),
+                length,
+                VirtAddrRange::new(aspace.base(), aspace.end()),
+                align,
+            ))
+            .ok_or(AxError::NoMemory)?
     };
 
     // IonBufferFile 特殊处理：直接线性映射物理地址，跳过通用 file_mmap/device_mmap 路径。
@@ -246,7 +268,10 @@ pub fn sys_mmap(
     let backend = match map_type {
         MmapFlags::SHARED | MmapFlags::SHARED_VALIDATE => {
             if let Some(ref file) = file {
-                match file.device_mmap(offset as u64) {
+                match device_mmap_top
+                    .take()
+                    .expect("file-backed mmap has cached device_mmap")
+                {
                     Ok(DeviceMmap::Physical(mut range)) => {
                         mapping_flags |= MappingFlags::UNCACHED;
                         range.start += offset;

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mmap-family/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mmap-family/c/src/main.c
@@ -350,6 +350,66 @@ int main(void)
         }
     }
 
+    /* MAP_FIXED + EACCES: 失败时不得拆掉目标地址上的旧映射 */
+    {
+        const unsigned char magic = 0x5a;
+        void *base = mmap(NULL, ps, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        CHECK(base != MAP_FAILED, "mmap anon base for MAP_FIXED EACCES preserve");
+        if (base != MAP_FAILED) {
+            *(volatile unsigned char *)base = magic;
+
+            const char *path = "/tmp/mmap_family_fixed_eacces";
+            int wfd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+            CHECK(wfd >= 0, "open /tmp/mmap_family_fixed_eacces O_WRONLY (create)");
+            if (wfd >= 0) {
+                (void)write(wfd, "abcd", 4);
+                close(wfd);
+
+                int ro = open(path, O_RDONLY);
+                CHECK(ro >= 0, "reopen /tmp/mmap_family_fixed_eacces O_RDONLY");
+                if (ro >= 0) {
+                    CHECK_MMAP_ERR(mmap(base, ps, PROT_READ | PROT_WRITE,
+                                        MAP_SHARED | MAP_FIXED, ro, 0),
+                                   EACCES,
+                                   "MAP_FIXED SHARED|RW on O_RDONLY fd → EACCES");
+                    CHECK(*(volatile unsigned char *)base == magic,
+                          "MAP_FIXED EACCES 后旧匿名映射内容保留");
+                    close(ro);
+                }
+                unlink(path);
+            }
+            munmap(base, ps);
+        }
+    }
+
+    /* MAP_FIXED + MAP_PRIVATE: O_WRONLY fd 无读权限 → EACCES，旧映射保留 */
+    {
+        const unsigned char magic = 0xa5;
+        void *base = mmap(NULL, ps, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        CHECK(base != MAP_FAILED, "mmap anon base for MAP_FIXED PRIVATE EACCES");
+        if (base != MAP_FAILED) {
+            *(volatile unsigned char *)base = magic;
+
+            const char *path = "/tmp/mmap_family_fixed_private_eacces";
+            int wfd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+            CHECK(wfd >= 0, "open /tmp/mmap_family_fixed_private_eacces O_WRONLY");
+            if (wfd >= 0) {
+                (void)write(wfd, "abcd", 4);
+                CHECK_MMAP_ERR(mmap(base, ps, PROT_READ,
+                                    MAP_PRIVATE | MAP_FIXED, wfd, 0),
+                               EACCES,
+                               "MAP_FIXED PRIVATE|R on O_WRONLY fd → EACCES");
+                CHECK(*(volatile unsigned char *)base == magic,
+                      "MAP_FIXED PRIVATE EACCES 后旧匿名映射内容保留");
+                close(wfd);
+                unlink(path);
+            }
+            munmap(base, ps);
+        }
+    }
+
     /* ENODEV: 目录 mmap → ENODEV (不支持 memory mapping) */
     {
         const char *dir = "/tmp/mmap_family_dir";


### PR DESCRIPTION
## 问题

`MAP_FIXED` 在权限预检失败时若已执行 `unmap`，会撤销目标地址上的旧映射，与 Linux `do_mmap` 顺序不一致。

## 改动

- 在破坏性 `unmap` 之前执行 file-backed 权限预检；
- 将 `device_mmap Ok(None)` 视为需走 `file_mmap` 预检路径，避免 memfd/常规文件误报 `ENODEV`。

## 测试

本地 `cargo fmt --check`、`cargo xtask clippy --package starry-kernel` 通过。

Made with [Cursor](https://cursor.com)