### PR TITLE
fix(epoll): fix EPOLLET NoEvent busy-loop and race window

### DIFF
--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -449,17 +449,45 @@ impl Epoll {
                         keep.push_back(Arc::downgrade(&interest));
                     } else {
                         interest.mark_not_in_queue();
+                        // EPOLLET: install a fresh waker so the next edge
+                        // transition is captured.  The race window between
+                        // mark_not_in_queue() and register_waker_only() is
+                        // handled below: if data arrived while chan.poll_update
+                        // was empty (old waker consumed by the preceding wake),
+                        // the InterestWaker had no slot to land in and the
+                        // notification was silently dropped.  Re-check after
+                        // registering and re-queue if IN data is already present.
+                        // EPOLLOUT is intentionally excluded: it is always ready
+                        // for writable sockets and would cause a busy-loop.
                         self.register_waker_only(&interest);
+                        let in_mask = interest.event.events
+                            & (IoEvents::IN | IoEvents::RDHUP | IoEvents::HUP);
+                        if !in_mask.is_empty()
+                            && let Some(f) = interest.key.get_file()
+                            && !(f.poll() & in_mask).is_empty()
+                            && interest.try_mark_in_queue()
+                        {
+                            self.inner
+                                .ready_queue
+                                .lock()
+                                .push_back(Arc::downgrade(&interest));
+                            self.inner.poll_ready.wake();
+                        }
                     }
                 }
                 ConsumeResult::NoEvent => {
+                    // Spurious wakeup: the waker fired but file.poll() had no
+                    // matching events (e.g. a shared PollSet wake when only
+                    // EPOLLOUT is ready but the interest is for EPOLLIN).
+                    // Re-arm with a plain waker registration — do NOT call
+                    // check_and_register_waker here.  That helper immediately
+                    // calls waker.wake_by_ref() when file.poll() is non-empty,
+                    // which creates a tight re-queue loop for connected TCP
+                    // sockets (always EPOLLOUT-ready), filling the ready_queue
+                    // with phantom events and blocking Tokio from confirming
+                    // connection establishment.
                     interest.mark_not_in_queue();
-                    // Events arriving between consume()'s poll and the new
-                    // register() would otherwise be lost: the old waker
-                    // CAS-fails (in_ready_queue still set), and a plain
-                    // register only fires on the next edge. Re-poll after
-                    // registering to recover them.
-                    self.check_and_register_waker(&interest);
+                    self.register_waker_only(&interest);
                 }
             }
         }


### PR DESCRIPTION
Two bugs caused jcode serve's Tokio runtime to malfunction:

1. NoEvent path: check_and_register_waker → register_waker_only

   check_and_register_waker() calls waker.wake_by_ref() when file.poll()
   is non-empty.  Tokio registers interests with EPOLLIN|EPOLLOUT|EPOLLET;
   for a connected TCP socket EPOLLOUT is always ready.  Any spurious wake
   (NoEvent) therefore re-queued the interest immediately: poll_events_with
   → NoEvent → check_and_register_waker → EPOLLOUT present → wake_by_ref
   → NoEvent → …  The ready_queue filled with phantom events; reqwest's
   connect-completion polling received 1024 spurious events per call and
   could never confirm the TCP handshake, so all HTTPS requests silently
   failed.

   Fix: use register_waker_only for NoEvent (spurious wakeup).  Re-arm and
   wait for a genuine state transition, matching the EPOLLET contract.

2. EPOLLET race window after EventAndRemove

   After delivering an EPOLLET event, mark_not_in_queue() sets the flag to false then register_waker_only() installs a new waker.  In that gap chan.poll_update is empty (old waker consumed by the preceding wake). If serve sends a second chunk in this window, poll_update.wake() hits an empty PollSet and the notification is silently dropped.  The new waker is then installed with data already in the buffer; no further write occurs so EPOLLET never fires again — TUI hangs after first chunk.

   Fix: after register_waker_only(), poll the file for IN/RDHUP/HUP events and re-queue the interest directly if data is already present.  EPOLLOUT is excluded to avoid re-introducing bug 1.