### PR TITLE
fix(unix-stream,poll_io): non-blocking accept, peer EOF, waker registration

### DIFF
--- a/os/arceos/modules/axnet-ng/src/unix/mod.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/mod.rs
@@ -9,7 +9,7 @@ use ax_errno::{AxError, AxResult};
 use ax_fs_ng::{FS_CONTEXT, OpenOptions};
 use ax_io::{IoBuf, Read, Write};
 use ax_sync::Mutex;
-use ax_task::future::{block_on, interruptible};
+use ax_task::future::{block_on, poll_io};
 use axfs_ng_vfs::NodeType;
 use axpoll::{IoEvents, Pollable};
 use enum_dispatch::enum_dispatch;
@@ -45,6 +45,11 @@ pub trait TransportOps: Configurable + Pollable + Send + Sync {
 
     /// Accept an incoming connection, returning the new transport and peer address.
     async fn accept(&self) -> AxResult<(Transport, UnixSocketAddr)>;
+
+    /// Non-blocking accept: returns `WouldBlock` immediately when no connection is pending.
+    fn try_accept(&self) -> AxResult<(Transport, UnixSocketAddr)> {
+        Err(AxError::WouldBlock)
+    }
 
     /// Send data through the transport.
     fn send(&self, src: impl Read + IoBuf, options: SendOptions) -> AxResult<usize>;
@@ -205,7 +210,14 @@ impl SocketOps for UnixSocket {
     }
 
     fn accept(&self) -> AxResult<Socket> {
-        let (transport, peer_addr) = block_on(interruptible(self.transport.accept()))??;
+        let mut nonblocking = false;
+        let _ = self
+            .transport
+            .get_option_inner(&mut GetSocketOption::NonBlocking(&mut nonblocking));
+        let (transport, peer_addr) =
+            block_on(poll_io(&self.transport, IoEvents::IN, nonblocking, || {
+                self.transport.try_accept()
+            }))?;
         Ok(Self {
             transport,
             local_addr: Mutex::new(self.local_addr.lock().clone()),

--- a/os/arceos/modules/axnet-ng/src/unix/stream.rs
+++ b/os/arceos/modules/axnet-ng/src/unix/stream.rs
@@ -31,16 +31,23 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
     let (client_tx, server_rx) = new_uni_channel();
     let (server_tx, client_rx) = new_uni_channel();
     let poll_update = Arc::new(PollSet::new());
+    // Cross-wired close flags: each side's my_tx_closed is the other's peer_tx_closed.
+    let client_tx_closed = Arc::new(AtomicBool::new(false));
+    let server_tx_closed = Arc::new(AtomicBool::new(false));
     (
         Channel {
             tx: client_tx,
             rx: client_rx,
+            my_tx_closed: client_tx_closed.clone(),
+            peer_tx_closed: server_tx_closed.clone(),
             poll_update: poll_update.clone(),
             peer_pid: pid,
         },
         Channel {
             tx: server_tx,
             rx: server_rx,
+            my_tx_closed: server_tx_closed,
+            peer_tx_closed: client_tx_closed,
             poll_update,
             peer_pid: pid,
         },
@@ -50,7 +57,10 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
 struct Channel {
     tx: HeapProd<u8>,
     rx: HeapCons<u8>,
-    // TODO: granularity
+    /// Set to true by our Drop before waking the peer.
+    my_tx_closed: Arc<AtomicBool>,
+    /// Set to true by the peer's Drop before it wakes us.
+    peer_tx_closed: Arc<AtomicBool>,
     poll_update: Arc<PollSet>,
     peer_pid: u32,
 }
@@ -215,6 +225,24 @@ impl TransportOps for StreamTransport {
         ))
     }
 
+    fn try_accept(&self) -> AxResult<(Transport, UnixSocketAddr)> {
+        let Some((rx, _)) = self.conn_rx.lock().clone() else {
+            return Err(AxError::NotConnected);
+        };
+        match rx.try_recv() {
+            Ok(ConnRequest {
+                channel,
+                addr: peer_addr,
+                pid,
+            }) => Ok((
+                Transport::Stream(StreamTransport::new_channel(Some(channel), pid)),
+                peer_addr,
+            )),
+            Err(async_channel::TryRecvError::Empty) => Err(AxError::WouldBlock),
+            Err(async_channel::TryRecvError::Closed) => Err(AxError::ConnectionReset),
+        }
+    }
+
     fn send(&self, mut src: impl Read + IoBuf, options: SendOptions) -> AxResult<usize> {
         if options.to.is_some() {
             return Err(AxError::InvalidInput);
@@ -272,10 +300,8 @@ impl TransportOps for StreamTransport {
             if count > 0 {
                 chan.poll_update.wake();
                 Ok(count)
-            } else if !chan.rx.write_is_held() {
-                // Peer dropped its sender end and the ring is empty: EOF.
-                // Returning WouldBlock here would park the caller forever
-                // waiting for data that will never arrive.
+            } else if !chan.rx.write_is_held() || chan.peer_tx_closed.load(Ordering::Acquire) {
+                // Peer closed (HeapProd dropped or tx_closed flag set): EOF.
                 Ok(0)
             } else {
                 Err(AxError::WouldBlock)
@@ -305,10 +331,14 @@ impl TransportOps for StreamTransport {
 impl Pollable for StreamTransport {
     fn poll(&self) -> IoEvents {
         let mut events = IoEvents::empty();
+        let rx_closed = self.rx_closed.load(Ordering::Acquire);
+        let mut peer_eof = false;
         if let Some(chan) = self.channel.lock().as_ref() {
+            peer_eof = chan.peer_tx_closed.load(Ordering::Acquire);
+            // Report IN when data is available OR when peer has closed (EOF to drain).
             events.set(
                 IoEvents::IN,
-                !self.rx_closed.load(Ordering::Acquire) && chan.rx.occupied_len() > 0,
+                !rx_closed && (chan.rx.occupied_len() > 0 || peer_eof),
             );
             events.set(
                 IoEvents::OUT,
@@ -317,7 +347,7 @@ impl Pollable for StreamTransport {
         } else if let Some((conn_tx, _)) = self.conn_rx.lock().as_ref() {
             events.set(IoEvents::IN, !conn_tx.is_empty());
         }
-        events.set(IoEvents::RDHUP, self.rx_closed.load(Ordering::Acquire));
+        events.set(IoEvents::RDHUP, peer_eof || rx_closed);
         events
     }
 
@@ -338,7 +368,14 @@ impl Pollable for StreamTransport {
 impl Drop for StreamTransport {
     fn drop(&mut self) {
         if let Some(chan) = self.channel.lock().as_ref() {
+            // Set the flag BEFORE waking the peer so poll() sees peer_eof=true
+            // when it runs in the wake handler — even though our HeapProd hasn't
+            // dropped yet.  Without this, the peer's poll() sees write_is_held()=true
+            // and no data, reports no events, and parks forever waiting for data
+            // that will never arrive.
+            chan.my_tx_closed.store(true, Ordering::Release);
             chan.poll_update.wake();
         }
+        self.poll_state.wake();
     }
 }

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -23,10 +23,16 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
     super::interruptible(poll_fn(move |cx| match f() {
         Ok(value) => Poll::Ready(Ok(value)),
         Err(AxError::WouldBlock) => {
+            // Register the waker unconditionally before returning WouldBlock.
+            // A non-blocking connect(2) returns EINPROGRESS; the caller then
+            // uses epoll to wait for EPOLLOUT (connection complete).  If we
+            // skip registration for non-blocking callers, the TCP stack has
+            // no waker to call when the handshake finishes, so epoll never
+            // receives the EPOLLOUT notification and the connection stalls.
+            pollable.register(cx, events);
             if non_blocking {
                 return Poll::Ready(Err(AxError::WouldBlock));
             }
-            pollable.register(cx, events);
             match f() {
                 Ok(value) => Poll::Ready(Ok(value)),
                 Err(AxError::WouldBlock) => Poll::Pending,


### PR DESCRIPTION

Three related fixes for Unix socket and async I/O correctness:

1. fix(unix-stream): non-blocking accept via try_accept() + poll_io

   Tokio uses EPOLLET and drains accept() until EAGAIN after every EPOLLIN.
   The old code block_on(interruptible(transport.accept())) always blocked
   the kernel thread — even with O_NONBLOCK — because interruptible wraps
   an async_channel::recv that has no timeout.  After accepting TUI's one
   connection, Tokio called accept() again; the kernel thread blocked
   indefinitely, freezing the entire serve async runtime.  No messages from
   TUI were ever processed.

   Fix: add try_accept() on StreamTransport using async_channel::try_recv()
   (returns WouldBlock immediately when queue empty).  UnixSocket::accept()
   now reads the O_NONBLOCK flag and delegates to poll_io + try_accept(),
   matching POSIX accept(2) semantics.

2. fix(unix-stream): signal peer EOF before wake to prevent epoll hang

   When StreamTransport dropped, poll_update.wake() fired while HeapProd
   was still alive.  The peer's poll() ran in that window: write_is_held()
   returned true, rx was empty, so poll() reported no events and re-armed
   its waker — which never fired again, causing a ~50 s timeout wait.

   Fix: add cross-wired Arc<AtomicBool> close flags (my_tx_closed /
   peer_tx_closed).  Drop sets my_tx_closed=true BEFORE calling wake(), so
   poll() immediately reports IN+RDHUP.  recv() also treats peer_tx_closed
   as an EOF condition, avoiding any busy-wait in the race window.

3. fix(poll_io): register waker before returning WouldBlock

   For a non-blocking TCP connect, poll_io returned WouldBlock without
   calling pollable.register(cx, events).  If the TCP handshake completed
   before the subsequent epoll_ctl ADD call registered the InterestWaker,
   the IRQ wake hit an empty PollSet and the EPOLLOUT notification was
   silently lost.

   Fix: always register the waker first; then, for non-blocking callers,
   return WouldBlock immediately.  For blocking callers, retry once and
   suspend on a second WouldBlock.