### PR TITLE
fix(starry): reject invalid umount2 flags

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -16,6 +16,14 @@ const MNT_DETACH: i32 = 2;
 const MNT_EXPIRE: i32 = 4;
 const UMOUNT_NOFOLLOW: i32 = 8;
 
+const MS_REC: i32 = 1 << 14;
+const MS_SILENT: i32 = 1 << 15;
+const MS_UNBINDABLE: i32 = 1 << 17;
+const MS_PRIVATE: i32 = 1 << 18;
+const MS_SLAVE: i32 = 1 << 19;
+const MS_SHARED: i32 = 1 << 20;
+
+const PROPAGATION_FLAGS: i32 = MS_SHARED | MS_PRIVATE | MS_SLAVE | MS_UNBINDABLE;
 const VALID_UMOUNT_FLAGS: i32 = MNT_FORCE | MNT_DETACH | MNT_EXPIRE | UMOUNT_NOFOLLOW;
 
 fn fd_points_to_mount(fd: &dyn FileLike, mp: &Arc<axfs_ng_vfs::Mountpoint>) -> bool {
@@ -53,13 +61,26 @@ pub fn sys_mount(
     source: *const c_char,
     target: *const c_char,
     fs_type: *const c_char,
-    _flags: i32,
+    flags: i32,
     _data: *const c_void,
 ) -> AxResult<isize> {
     let source = vm_load_string(source)?;
     let target = vm_load_string(target)?;
     let fs_type = vm_load_string(fs_type)?;
     debug!("sys_mount <= source: {source:?}, target: {target:?}, fs_type: {fs_type:?}");
+
+    let propagation = flags & PROPAGATION_FLAGS;
+
+    if propagation.count_ones() > 1 {
+        return Err(AxError::InvalidInput);
+    }
+
+    if propagation != 0 {
+        let allowed = propagation | MS_REC | MS_SILENT;
+        if flags & !allowed != 0 {
+            return Err(AxError::InvalidInput);
+        }
+    }
 
     match fs_type.as_str() {
         "tmpfs" => {

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -11,6 +11,13 @@ use crate::{
     task::{AsThread, tasks},
 };
 
+const MNT_FORCE: i32 = 1;
+const MNT_DETACH: i32 = 2;
+const MNT_EXPIRE: i32 = 4;
+const UMOUNT_NOFOLLOW: i32 = 8;
+
+const VALID_UMOUNT_FLAGS: i32 = MNT_FORCE | MNT_DETACH | MNT_EXPIRE | UMOUNT_NOFOLLOW;
+
 fn fd_points_to_mount(fd: &dyn FileLike, mp: &Arc<axfs_ng_vfs::Mountpoint>) -> bool {
     fd.downcast_ref::<File>()
         .is_some_and(|f| Arc::ptr_eq(f.inner().location().mountpoint(), mp))
@@ -139,11 +146,20 @@ fn mount_ext4(source: &str, target: &str) -> AxResult<()> {
     Ok(())
 }
 
-pub fn sys_umount2(target: *const c_char, _flags: i32) -> AxResult<isize> {
+pub fn sys_umount2(target: *const c_char, flags: i32) -> AxResult<isize> {
     use alloc::boxed::Box;
 
     let target = vm_load_string(target)?;
-    debug!("sys_umount2 <= target: {target:?}");
+    debug!("sys_umount2 <= target: {target:?}, flags: {flags:#x}");
+
+    if (flags & !VALID_UMOUNT_FLAGS) != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
+    if (flags & MNT_EXPIRE) != 0 && (flags & (MNT_FORCE | MNT_DETACH)) != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
     let target = FS_CONTEXT.lock().resolve(target)?;
 
     // Linux umount2 returns EINVAL for paths that are not mount points.

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/c/src/main.c
@@ -1004,6 +1004,38 @@ int main(void)
     }
 
     /* ================================================================
+     *  Tier 4k0: mount EINVAL for invalid propagation flag combos
+     *
+     *  Linux mount(2) rejects multiple propagation type flags in one
+     *  call. The failed mount must not create a mount side effect.
+     * ================================================================ */
+    {
+        const char *invalid_mount_point = "/tmp/ul-mnt-invalid-mountflags";
+        int saved_errno;
+
+        rc = run("mkdir -p /tmp/ul-mnt-invalid-mountflags");
+        check(rc == 0, "mkdir invalid-mountflags mount point");
+
+        errno = 0;
+        rc = mount(
+            "none",
+            invalid_mount_point,
+            "tmpfs",
+            MS_SHARED | MS_PRIVATE,
+            NULL
+        );
+        saved_errno = errno;
+        check(rc == -1 && saved_errno == EINVAL,
+              "mount EINVAL for conflicting propagation flags");
+
+        errno = 0;
+        rc = umount(invalid_mount_point);
+        saved_errno = errno;
+        check(rc == -1 && saved_errno == EINVAL,
+              "mount invalid propagation flags has no mount side effect");
+    }
+
+    /* ================================================================
      *  Tier 4k1: umount2 EINVAL for invalid flags
      *
      *  Linux umount2 must reject unsupported flag bits with EINVAL.

--- a/test-suit/starryos/normal/qemu-smp1/util-linux/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/util-linux/c/src/main.c
@@ -1004,6 +1004,55 @@ int main(void)
     }
 
     /* ================================================================
+     *  Tier 4k1: umount2 EINVAL for invalid flags
+     *
+     *  Linux umount2 must reject unsupported flag bits with EINVAL.
+     *  Verify that the kernel does not silently ignore invalid flags.
+     * ================================================================ */
+
+    /* Attach ext4 image */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "losetup %s " PREBUILT_IMG " 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "losetup attach for umount2-invalid-flags test");
+    } else {
+        check(0, "losetup attach for umount2-invalid-flags test");
+    }
+
+    /* Mount ext4 */
+    if (loopdev[0]) {
+        char cmd[256];
+        snprintf(cmd, sizeof(cmd), "mount -t ext4 %s /tmp/ul-mnt 2>&1", loopdev);
+        rc = run(cmd);
+        check(rc == 0, "mount for umount2-invalid-flags test");
+    } else {
+        check(0, "mount for umount2-invalid-flags test");
+    }
+
+    /* umount2 with invalid flags must fail with EINVAL */
+    {
+        const unsigned int invalid_flags = 0xdeadbeefu;
+        int saved_errno;
+        errno = 0;
+        rc = (int)syscall(SYS_umount2, "/tmp/ul-mnt", invalid_flags);
+        saved_errno = errno;
+        check(rc == -1 && saved_errno == EINVAL,
+              "umount2 EINVAL for invalid flags");
+    }
+
+    /* Cleanup: normal umount then detach */
+    {
+        rc = umount("/tmp/ul-mnt");
+        check(rc == 0, "umount cleanup after umount2-invalid-flags test");
+        if (loopdev[0]) {
+            char cmd[256];
+            snprintf(cmd, sizeof(cmd), "losetup -d %s 2>&1", loopdev);
+            run(cmd);
+        }
+    }
+
+    /* ================================================================
      *  Tier 4l: LOOP_CLR_FD EBUSY when mount has open fds
      *
      *  Verify that LOOP_CLR_FD (losetup -d) returns EBUSY while the


### PR DESCRIPTION
## Summary

- Add a util-linux userspace test for invalid `umount2` flags.
- Validate `umount2` flags in StarryOS.
- Return `EINVAL` for unsupported flag bits without unmounting the target.

## Motivation

`sys_umount2` previously ignored the `flags` argument. As a result, calls with invalid flags could proceed as a normal unmount operation instead of failing with `EINVAL`.

## Changes

- Add a test case for `umount2(..., invalid_flags)`.
- Check that invalid flags return `EINVAL`.
- Check that the failed `umount2` call does not unmount the target.
- Add flag validation in `sys_umount2`.

## Tests

```bash
cargo xtask starry test qemu --target aarch64-unknown-none-softfloat -c util-linux