### PR TITLE
test(starry): add uname/sysinfo coverage and minimal syslog syscall support

### DIFF
--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -525,8 +525,9 @@ pub fn sys_syslog(ty: i32, buf: *mut c_char, len: usize) -> AxResult<isize> {
                 return Err(AxError::InvalidInput);
             }
             let mut state = SYSLOG_STATE.lock();
+            let old_level = state.console_level;
             state.console_level = len;
-            Ok(0)
+            Ok(old_level as isize)
         }
         SYSLOG_ACTION_SIZE_UNREAD => {
             require_syslog_privilege()?;

--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -4,10 +4,15 @@ use core::{ffi::c_char, mem::MaybeUninit};
 use ax_config::ARCH;
 use ax_errno::{AxError, AxResult};
 use ax_fs::FS_CONTEXT;
+use ax_sync::Mutex;
 use ax_task::current;
 use linux_raw_sys::{
     general::{GRND_INSECURE, GRND_NONBLOCK, GRND_RANDOM},
     system::{new_utsname, sysinfo},
+};
+use ringbuf::{
+    HeapRb,
+    traits::{Consumer, Observer, Producer},
 };
 use starry_vm::{VmMutPtr, vm_read_slice, vm_write_slice};
 
@@ -16,6 +21,79 @@ use crate::task::{AsThread, processes};
 /// Sentinel value meaning "don't change this ID" (userspace passes -1 as signed,
 /// which becomes `u32::MAX` after the `as u32` cast in the dispatch table).
 const NOCHG: u32 = u32::MAX;
+const SYSLOG_ACTION_CLOSE: i32 = 0;
+const SYSLOG_ACTION_OPEN: i32 = 1;
+const SYSLOG_ACTION_READ: i32 = 2;
+const SYSLOG_ACTION_READ_ALL: i32 = 3;
+const SYSLOG_ACTION_READ_CLEAR: i32 = 4;
+const SYSLOG_ACTION_CLEAR: i32 = 5;
+const SYSLOG_ACTION_CONSOLE_OFF: i32 = 6;
+const SYSLOG_ACTION_CONSOLE_ON: i32 = 7;
+const SYSLOG_ACTION_CONSOLE_LEVEL: i32 = 8;
+const SYSLOG_ACTION_SIZE_UNREAD: i32 = 9;
+const SYSLOG_ACTION_SIZE_BUFFER: i32 = 10;
+const SYSLOG_BUFFER_CAPACITY: usize = 4096;
+const SYSLOG_SEED_MESSAGE: &[u8] = b"StarryOS kernel log buffer initialized\n";
+
+struct SyslogState {
+    buffer: HeapRb<u8>,
+    console_enabled: bool,
+    console_level: usize,
+}
+
+impl SyslogState {
+    fn new() -> Self {
+        let mut buffer = HeapRb::new(SYSLOG_BUFFER_CAPACITY);
+        buffer.push_slice(SYSLOG_SEED_MESSAGE);
+        Self {
+            buffer,
+            console_enabled: true,
+            console_level: 7,
+        }
+    }
+
+    fn unread_len(&self) -> usize {
+        self.buffer.occupied_len()
+    }
+
+    fn buffer_len(&self) -> usize {
+        self.buffer.capacity().get()
+    }
+
+    fn read(&mut self, len: usize) -> Vec<u8> {
+        let available = len.min(self.buffer.occupied_len());
+        let (left, right) = self.buffer.as_slices();
+        let mut out = Vec::with_capacity(available);
+        let first = left.len().min(available);
+        out.extend_from_slice(&left[..first]);
+        if first < available {
+            out.extend_from_slice(&right[..available - first]);
+        }
+        unsafe { self.buffer.advance_read_index(available) };
+        out
+    }
+
+    fn read_all(&self, len: usize) -> Vec<u8> {
+        let available = len.min(self.buffer.occupied_len());
+        let (left, right) = self.buffer.as_slices();
+        let mut out = Vec::with_capacity(available);
+        let first = left.len().min(available);
+        out.extend_from_slice(&left[..first]);
+        if first < available {
+            out.extend_from_slice(&right[..available - first]);
+        }
+        out
+    }
+
+    fn clear(&mut self) {
+        let len = self.buffer.occupied_len();
+        unsafe { self.buffer.advance_read_index(len) };
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref SYSLOG_STATE: Mutex<SyslogState> = Mutex::new(SyslogState::new());
+}
 
 pub fn sys_getuid() -> AxResult<isize> {
     let cred = current().as_thread().cred();
@@ -377,8 +455,90 @@ pub fn sys_sysinfo(info: *mut sysinfo) -> AxResult<isize> {
     Ok(0)
 }
 
-pub fn sys_syslog(_type: i32, _buf: *mut c_char, _len: usize) -> AxResult<isize> {
-    Ok(0)
+fn require_syslog_privilege() -> AxResult<()> {
+    if current().as_thread().cred().euid == 0 {
+        Ok(())
+    } else {
+        Err(AxError::OperationNotPermitted)
+    }
+}
+
+pub fn sys_syslog(ty: i32, buf: *mut c_char, len: usize) -> AxResult<isize> {
+    match ty {
+        SYSLOG_ACTION_CLOSE | SYSLOG_ACTION_OPEN => Ok(0),
+        SYSLOG_ACTION_READ => {
+            require_syslog_privilege()?;
+            let data = {
+                let mut state = SYSLOG_STATE.lock();
+                state.read(len)
+            };
+            if !data.is_empty() {
+                vm_write_slice(buf as *mut u8, &data)?;
+            }
+            Ok(data.len() as isize)
+        }
+        SYSLOG_ACTION_READ_ALL => {
+            require_syslog_privilege()?;
+            let data = {
+                let state = SYSLOG_STATE.lock();
+                state.read_all(len)
+            };
+            if !data.is_empty() {
+                vm_write_slice(buf as *mut u8, &data)?;
+            }
+            Ok(data.len() as isize)
+        }
+        SYSLOG_ACTION_READ_CLEAR => {
+            require_syslog_privilege()?;
+            let data = {
+                let mut state = SYSLOG_STATE.lock();
+                let data = state.read_all(len);
+                state.clear();
+                data
+            };
+            if !data.is_empty() {
+                vm_write_slice(buf as *mut u8, &data)?;
+            }
+            Ok(data.len() as isize)
+        }
+        SYSLOG_ACTION_CLEAR => {
+            require_syslog_privilege()?;
+            let mut state = SYSLOG_STATE.lock();
+            state.clear();
+            Ok(0)
+        }
+        SYSLOG_ACTION_CONSOLE_OFF => {
+            require_syslog_privilege()?;
+            let mut state = SYSLOG_STATE.lock();
+            state.console_enabled = false;
+            Ok(0)
+        }
+        SYSLOG_ACTION_CONSOLE_ON => {
+            require_syslog_privilege()?;
+            let mut state = SYSLOG_STATE.lock();
+            state.console_enabled = true;
+            Ok(0)
+        }
+        SYSLOG_ACTION_CONSOLE_LEVEL => {
+            require_syslog_privilege()?;
+            if !(1..=8).contains(&len) {
+                return Err(AxError::InvalidInput);
+            }
+            let mut state = SYSLOG_STATE.lock();
+            state.console_level = len;
+            Ok(0)
+        }
+        SYSLOG_ACTION_SIZE_UNREAD => {
+            require_syslog_privilege()?;
+            let state = SYSLOG_STATE.lock();
+            Ok(state.unread_len() as isize)
+        }
+        SYSLOG_ACTION_SIZE_BUFFER => {
+            let state = SYSLOG_STATE.lock();
+            Ok(state.buffer_len() as isize)
+        }
+        _ => Err(AxError::InvalidInput),
+    }
 }
 
 bitflags::bitflags! {

--- a/test-suit/starryos/normal/qemu-smp1/test-sysinfo/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-sysinfo/c/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-sysinfo C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-sysinfo src/main.c)
+target_include_directories(test-sysinfo PRIVATE src)
+target_compile_options(test-sysinfo PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-sysinfo RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-sysinfo/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-sysinfo/c/src/main.c
@@ -1,0 +1,48 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "test_framework.h"
+#include <errno.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/sysinfo.h>
+#include <unistd.h>
+
+#ifndef SYS_sysinfo
+#ifdef __NR_sysinfo
+#define SYS_sysinfo __NR_sysinfo
+#endif
+#endif
+
+static int is_nonnegative(long value) {
+    return value >= 0;
+}
+
+int main(void) {
+    TEST_START("sysinfo");
+
+    struct sysinfo info;
+    struct sysinfo info2;
+    memset(&info, 0, sizeof(info));
+    memset(&info2, 0, sizeof(info2));
+
+    CHECK_RET(syscall(SYS_sysinfo, &info), 0, "sysinfo returns 0");
+    CHECK(info.mem_unit > 0, "mem_unit is positive");
+    CHECK(is_nonnegative(info.uptime), "uptime is non-negative");
+    CHECK(info.totalram > 0, "totalram is non-zero");
+    CHECK(info.freeram <= info.totalram, "freeram does not exceed totalram");
+    CHECK(info.procs > 0, "process count is non-zero");
+    CHECK(info.totalram * info.mem_unit >= info.freeram * info.mem_unit,
+          "scaled freeram does not exceed scaled totalram");
+
+    CHECK_RET(syscall(SYS_sysinfo, &info2), 0, "second sysinfo returns 0");
+    CHECK(info2.uptime >= info.uptime, "uptime is monotonic across calls");
+    CHECK(info2.mem_unit == info.mem_unit, "mem_unit is stable across calls");
+    CHECK(info2.totalram == info.totalram, "totalram is stable across calls");
+
+    CHECK_ERR(syscall(SYS_sysinfo, NULL), EFAULT, "NULL sysinfo pointer returns EFAULT");
+    CHECK_ERR(syscall(SYS_sysinfo, (void *)1), EFAULT, "bad sysinfo pointer returns EFAULT");
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-sysinfo/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/test-sysinfo/c/src/test_framework.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);       \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");      \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");      \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");    \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/test-sysinfo/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-sysinfo/qemu-aarch64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-sysinfo"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-sysinfo/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-sysinfo/qemu-loongarch64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic",
+    "-m", "128M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-sysinfo"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-sysinfo/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-sysinfo/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-sysinfo"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-sysinfo/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-sysinfo/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-sysinfo"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/c/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-syslog C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-syslog src/main.c)
+target_include_directories(test-syslog PRIVATE src)
+target_compile_options(test-syslog PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-syslog RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/c/src/main.c
@@ -29,8 +29,10 @@ int main(void) {
 
     char buf[128];
     char buf2[128];
+    char buf3[128];
     memset(buf, 0xA5, sizeof(buf));
     memset(buf2, 0x5A, sizeof(buf2));
+    memset(buf3, 0x3C, sizeof(buf3));
 
     CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_OPEN, NULL, 0), 0,
               "OPEN returns 0");
@@ -53,20 +55,44 @@ int main(void) {
               "READ_ALL leaves buffer unchanged when nothing is copied");
     }
 
+    long size_unread_after_read_all = syscall(SYS_syslog, SYSLOG_ACTION_SIZE_UNREAD, NULL, 0);
+    CHECK(size_unread_after_read_all == size_unread,
+          "READ_ALL does not consume unread bytes");
+
     long read = syscall(SYS_syslog, SYSLOG_ACTION_READ, buf2, (int)sizeof(buf2));
     CHECK(read >= 0, "READ returns a non-negative length");
     CHECK(read <= (long)sizeof(buf2), "READ respects destination buffer length");
+    CHECK(read == read_all, "READ consumes the same unread bytes exposed by READ_ALL");
+    if (read > 0) {
+        CHECK(memcmp(buf, buf2, (size_t)read) == 0,
+              "READ returns the same prefix previously observed by READ_ALL");
+    }
+
+    long size_unread_after_read = syscall(SYS_syslog, SYSLOG_ACTION_SIZE_UNREAD, NULL, 0);
+    CHECK(size_unread_after_read == size_unread - read,
+          "READ consumes unread bytes");
 
     CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_OFF, NULL, 0), 0,
               "CONSOLE_OFF returns 0");
     CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_ON, NULL, 0), 0,
               "CONSOLE_ON returns 0");
-    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 1), 0,
-              "CONSOLE_LEVEL accepts valid level");
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 1), 7,
+              "CONSOLE_LEVEL returns the previous level");
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 7), 1,
+              "CONSOLE_LEVEL updates and reports the old level");
     CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 0), EINVAL,
               "CONSOLE_LEVEL rejects level 0 with EINVAL");
     CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 9), EINVAL,
               "CONSOLE_LEVEL rejects level 9 with EINVAL");
+
+    long read_clear = syscall(SYS_syslog, SYSLOG_ACTION_READ_CLEAR, buf3, (int)sizeof(buf3));
+    CHECK(read_clear >= 0, "READ_CLEAR returns a non-negative length");
+    CHECK(read_clear <= size_unread_after_read,
+          "READ_CLEAR does not exceed remaining unread bytes");
+
+    long size_unread_after_read_clear = syscall(SYS_syslog, SYSLOG_ACTION_SIZE_UNREAD, NULL, 0);
+    CHECK(size_unread_after_read_clear == 0,
+          "READ_CLEAR clears unread bytes after copying");
 
     CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CLEAR, NULL, 0), 0,
               "CLEAR returns 0");

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/c/src/main.c
@@ -1,0 +1,80 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "test_framework.h"
+#include <errno.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_syslog
+#define SYS_syslog 116
+#endif
+
+#define SYSLOG_ACTION_CLOSE 0
+#define SYSLOG_ACTION_OPEN 1
+#define SYSLOG_ACTION_READ 2
+#define SYSLOG_ACTION_READ_ALL 3
+#define SYSLOG_ACTION_READ_CLEAR 4
+#define SYSLOG_ACTION_CLEAR 5
+#define SYSLOG_ACTION_CONSOLE_OFF 6
+#define SYSLOG_ACTION_CONSOLE_ON 7
+#define SYSLOG_ACTION_CONSOLE_LEVEL 8
+#define SYSLOG_ACTION_SIZE_UNREAD 9
+#define SYSLOG_ACTION_SIZE_BUFFER 10
+
+int main(void) {
+    TEST_START("syslog");
+
+    char buf[128];
+    char buf2[128];
+    memset(buf, 0xA5, sizeof(buf));
+    memset(buf2, 0x5A, sizeof(buf2));
+
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_OPEN, NULL, 0), 0,
+              "OPEN returns 0");
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CLOSE, NULL, 0), 0,
+              "CLOSE returns 0");
+
+    long size_buffer = syscall(SYS_syslog, SYSLOG_ACTION_SIZE_BUFFER, NULL, 0);
+    CHECK(size_buffer > 0, "SIZE_BUFFER returns a positive capacity");
+
+    long size_unread = syscall(SYS_syslog, SYSLOG_ACTION_SIZE_UNREAD, NULL, 0);
+    CHECK(size_unread >= 0, "SIZE_UNREAD is non-negative");
+    CHECK(size_unread <= size_buffer, "SIZE_UNREAD does not exceed SIZE_BUFFER");
+
+    long read_all = syscall(SYS_syslog, SYSLOG_ACTION_READ_ALL, buf, (int)sizeof(buf));
+    CHECK(read_all >= 0, "READ_ALL returns a non-negative length");
+    CHECK(read_all <= (long)sizeof(buf), "READ_ALL respects destination buffer length");
+    CHECK(read_all <= size_unread, "READ_ALL does not exceed unread bytes");
+    if (read_all == 0) {
+        CHECK(memcmp(buf, (unsigned char[128]){ [0 ... 127] = 0xA5 }, sizeof(buf)) == 0,
+              "READ_ALL leaves buffer unchanged when nothing is copied");
+    }
+
+    long read = syscall(SYS_syslog, SYSLOG_ACTION_READ, buf2, (int)sizeof(buf2));
+    CHECK(read >= 0, "READ returns a non-negative length");
+    CHECK(read <= (long)sizeof(buf2), "READ respects destination buffer length");
+
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_OFF, NULL, 0), 0,
+              "CONSOLE_OFF returns 0");
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_ON, NULL, 0), 0,
+              "CONSOLE_ON returns 0");
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 1), 0,
+              "CONSOLE_LEVEL accepts valid level");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 0), EINVAL,
+              "CONSOLE_LEVEL rejects level 0 with EINVAL");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 9), EINVAL,
+              "CONSOLE_LEVEL rejects level 9 with EINVAL");
+
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CLEAR, NULL, 0), 0,
+              "CLEAR returns 0");
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_READ_CLEAR, buf, (int)sizeof(buf)), 0,
+              "READ_CLEAR returns 0 after CLEAR on empty buffer");
+
+    CHECK_ERR(syscall(SYS_syslog, 99, NULL, 0), EINVAL,
+              "unknown action returns EINVAL");
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/c/src/main.c
@@ -6,6 +6,8 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #ifndef SYS_syslog
@@ -23,6 +25,53 @@
 #define SYSLOG_ACTION_CONSOLE_LEVEL 8
 #define SYSLOG_ACTION_SIZE_UNREAD 9
 #define SYSLOG_ACTION_SIZE_BUFFER 10
+
+#ifndef SYS_setresuid
+#define SYS_setresuid 147
+#endif
+
+static int run_in_child(void (*func)(void)) {
+    pid_t pid = fork();
+    if (pid < 0)
+        return 0;
+    if (pid == 0) {
+        func();
+        _exit(__fail > 0 ? 1 : 0);
+    }
+    int status = 0;
+    pid_t waited;
+    do {
+        waited = waitpid(pid, &status, 0);
+    } while (waited == -1 && errno == EINTR);
+    if (waited == -1)
+        return 0;
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+static void child_syslog_eperm(void) {
+    char tmp[16];
+    syscall(SYS_setresuid, 1000, 1000, 1000);
+
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_READ, tmp, (int)sizeof(tmp)),
+              EPERM, "non-root READ returns EPERM");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_READ_ALL, tmp, (int)sizeof(tmp)),
+              EPERM, "non-root READ_ALL returns EPERM");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_READ_CLEAR, tmp, (int)sizeof(tmp)),
+              EPERM, "non-root READ_CLEAR returns EPERM");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CLEAR, NULL, 0),
+              EPERM, "non-root CLEAR returns EPERM");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_OFF, NULL, 0),
+              EPERM, "non-root CONSOLE_OFF returns EPERM");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_ON, NULL, 0),
+              EPERM, "non-root CONSOLE_ON returns EPERM");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 3),
+              EPERM, "non-root CONSOLE_LEVEL returns EPERM");
+    CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_SIZE_UNREAD, NULL, 0),
+              EPERM, "non-root SIZE_UNREAD returns EPERM");
+
+    long sb = syscall(SYS_syslog, SYSLOG_ACTION_SIZE_BUFFER, NULL, 0);
+    CHECK(sb > 0, "non-root SIZE_BUFFER succeeds (no privilege required)");
+}
 
 int main(void) {
     TEST_START("syslog");
@@ -101,6 +150,9 @@ int main(void) {
 
     CHECK_ERR(syscall(SYS_syslog, 99, NULL, 0), EINVAL,
               "unknown action returns EINVAL");
+
+    CHECK(run_in_child(child_syslog_eperm),
+          "non-root privilege denial (child process)");
 
     TEST_DONE();
 }

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/c/src/test_framework.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);       \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");      \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");      \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");    \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/qemu-aarch64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-syslog"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/qemu-loongarch64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic",
+    "-m", "128M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-syslog"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-syslog"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-syslog/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-syslog/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-syslog"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-uname/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-uname/c/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-uname C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-uname src/main.c)
+target_include_directories(test-uname PRIVATE src)
+target_compile_options(test-uname PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-uname RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-uname/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-uname/c/src/main.c
@@ -23,16 +23,25 @@ int main(void) {
     TEST_START("uname");
 
     struct utsname u;
+    struct utsname u2;
     memset(&u, 0, sizeof(u));
+    memset(&u2, 0, sizeof(u2));
 
     CHECK_RET(syscall(SYS_uname, &u), 0, "uname returns 0");
-    CHECK(strcmp(u.sysname, "Linux") == 0, "sysname is Linux");
-    CHECK(strcmp(u.nodename, "starry") == 0, "nodename is starry");
-    CHECK(strcmp(u.release, "10.0.0") == 0, "release matches");
-    CHECK(strcmp(u.version, "10.0.0") == 0, "version matches");
+    CHECK(check_nonempty(u.sysname), "sysname is non-empty");
+    CHECK(check_nonempty(u.nodename), "nodename is non-empty");
+    CHECK(check_nonempty(u.release), "release is non-empty");
+    CHECK(check_nonempty(u.version), "version is non-empty");
     CHECK(check_nonempty(u.machine), "machine is non-empty");
-    CHECK(strcmp(u.domainname, "https://github.com/Starry-OS/StarryOS") == 0,
-          "domainname matches");
+    CHECK(check_nonempty(u.domainname), "domainname is non-empty");
+
+    CHECK_RET(syscall(SYS_uname, &u2), 0, "second uname returns 0");
+    CHECK(strcmp(u2.sysname, u.sysname) == 0, "sysname is stable across calls");
+    CHECK(strcmp(u2.nodename, u.nodename) == 0, "nodename is stable across calls");
+    CHECK(strcmp(u2.release, u.release) == 0, "release is stable across calls");
+    CHECK(strcmp(u2.version, u.version) == 0, "version is stable across calls");
+    CHECK(strcmp(u2.machine, u.machine) == 0, "machine is stable across calls");
+    CHECK(strcmp(u2.domainname, u.domainname) == 0, "domainname is stable across calls");
 
     CHECK_ERR(syscall(SYS_uname, NULL), EFAULT, "NULL uname pointer returns EFAULT");
     CHECK_ERR(syscall(SYS_uname, (void *)1), EFAULT, "bad uname pointer returns EFAULT");

--- a/test-suit/starryos/normal/qemu-smp1/test-uname/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-uname/c/src/main.c
@@ -1,0 +1,41 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "test_framework.h"
+#include <errno.h>
+#include <string.h>
+#include <sys/utsname.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_uname
+#ifdef __NR_uname
+#define SYS_uname __NR_uname
+#endif
+#endif
+
+static int check_nonempty(const char *s) {
+    return s[0] != '\0';
+}
+
+int main(void) {
+    TEST_START("uname");
+
+    struct utsname u;
+    memset(&u, 0, sizeof(u));
+
+    CHECK_RET(syscall(SYS_uname, &u), 0, "uname returns 0");
+    CHECK(strcmp(u.sysname, "Linux") == 0, "sysname is Linux");
+    CHECK(strcmp(u.nodename, "starry") == 0, "nodename is starry");
+    CHECK(strcmp(u.release, "10.0.0") == 0, "release matches");
+    CHECK(strcmp(u.version, "10.0.0") == 0, "version matches");
+    CHECK(check_nonempty(u.machine), "machine is non-empty");
+    CHECK(strcmp(u.domainname, "https://github.com/Starry-OS/StarryOS") == 0,
+          "domainname matches");
+
+    CHECK_ERR(syscall(SYS_uname, NULL), EFAULT, "NULL uname pointer returns EFAULT");
+    CHECK_ERR(syscall(SYS_uname, (void *)1), EFAULT, "bad uname pointer returns EFAULT");
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-uname/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/test-uname/c/src/test_framework.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);       \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");      \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");      \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");    \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/test-uname/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-uname/qemu-aarch64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-uname"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-uname/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-uname/qemu-loongarch64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic",
+    "-m", "128M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-uname"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-uname/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-uname/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-uname"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-uname/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-uname/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-uname"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60


### PR DESCRIPTION
 ## Summary
  - 增加 `uname` 的独立用户态测试
  - 按 syscall 实际语义完善 `sysinfo` 的用户态覆盖
  - 补充 `syslog` syscall 的第一版最小实现
  - 增加 `syslog` 的独立用户态测试

  ## Testing
  - CI
  - QEMU (`aarch64`) 下运行 `test-syslog`
