### PR TITLE
fix(starry-kernel): uid/gid local fixes — uid_valid + setfsuid/setfsgid

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -556,6 +556,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::getresgid => sys_getresgid(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         Sysno::getgroups => sys_getgroups(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::setgroups => sys_setgroups(uctx.arg0() as _, uctx.arg1() as _),
+        Sysno::setfsuid => sys_setfsuid(uctx.arg0() as _),
+        Sysno::setfsgid => sys_setfsgid(uctx.arg0() as _),
         Sysno::uname => sys_uname(uctx.arg0() as _),
         Sysno::sysinfo => sys_sysinfo(uctx.arg0() as _),
         Sysno::syslog => sys_syslog(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),

--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -15,7 +15,22 @@ use crate::task::{AsThread, processes};
 
 /// Sentinel value meaning "don't change this ID" (userspace passes -1 as signed,
 /// which becomes `u32::MAX` after the `as u32` cast in the dispatch table).
+///
+/// Note: paired with `uid_valid()` below — multi-arg `set*res*uid/gid` and
+/// `setre*uid/gid` use this sentinel for NOCHG semantics, while single-arg
+/// `setuid/setgid` reject it as EINVAL (no NOCHG slot exists there).
 const NOCHG: u32 = u32::MAX;
+
+/// Mirror of Linux kernel `uid_valid()` / `make_kuid()` rejection: any caller-
+/// supplied UID/GID of `(uid_t)-1` (`u32::MAX`) is invalid outside the NOCHG
+/// sentinel slots of multi-arg setters. Single-arg `setuid`/`setgid` have no
+/// NOCHG semantic, so they must always reject `u32::MAX` with `EINVAL` before
+/// touching `cred` — otherwise a malicious caller writes the sentinel into
+/// real / effective / saved IDs and the next `setresuid` NOCHG path silently
+/// no-ops on already-poisoned credentials.
+fn uid_valid(id: u32) -> bool {
+    id != NOCHG
+}
 
 pub fn sys_getuid() -> AxResult<isize> {
     let cred = current().as_thread().cred();
@@ -150,6 +165,11 @@ pub fn sys_setresgid(rgid: u32, egid: u32, sgid: u32) -> AxResult<isize> {
 
 pub fn sys_setuid(uid: u32) -> AxResult<isize> {
     debug!("sys_setuid <= uid: {uid}");
+    // Linux setuid(2) §ERRORS: "EINVAL — uid is not valid in this user namespace."
+    // Single-arg setuid has no NOCHG sentinel; (uid_t)-1 must be rejected.
+    if !uid_valid(uid) {
+        return Err(AxError::InvalidInput);
+    }
     let thread = current();
     let thread = thread.as_thread();
     let old = thread.cred();
@@ -175,6 +195,10 @@ pub fn sys_setuid(uid: u32) -> AxResult<isize> {
 
 pub fn sys_setgid(gid: u32) -> AxResult<isize> {
     debug!("sys_setgid <= gid: {gid}");
+    // Linux setgid(2) §ERRORS: "EINVAL — gid is not valid in this user namespace."
+    if !uid_valid(gid) {
+        return Err(AxError::InvalidInput);
+    }
     let thread = current();
     let thread = thread.as_thread();
     let old = thread.cred();
@@ -278,6 +302,73 @@ pub fn sys_setregid(rgid: u32, egid: u32) -> AxResult<isize> {
     new.fsgid = new.egid;
     thread.set_cred(new);
     Ok(0)
+}
+
+// ── setfsuid / setfsgid ─────────────────────────────────────────────
+//
+// man 2 setfsuid:
+//   "setfsuid() sets the user ID that the Linux kernel uses to check for all
+//    accesses to the filesystem. ... On both success and failure, this call
+//    returns the previous filesystem user ID of the caller."
+//   "When the effective user ID is changed (via setuid(), setresuid(), etc.),
+//    the kernel also changes the filesystem user ID to the new value of the
+//    effective user ID."
+//   Query trick: passing `(uid_t)-1` leaves the fsuid unchanged but still
+//   returns the previous value — used by libc to read the current fsuid.
+
+pub fn sys_setfsuid(fsuid: u32) -> AxResult<isize> {
+    debug!("sys_setfsuid <= fsuid: {fsuid}");
+    let thread = current();
+    let thread = thread.as_thread();
+    let old = thread.cred();
+    let prev_fsuid = old.fsuid;
+
+    // (uid_t)-1 = query-only: don't change, just return prev.
+    if fsuid == NOCHG {
+        return Ok(prev_fsuid as isize);
+    }
+
+    // Linux: setfsuid silently ignores an invalid fsuid but always returns the
+    // previous fsuid (never reports error). Unprivileged callers may only set
+    // fsuid to one of {uid, euid, suid, fsuid}; CAP_SETUID allows arbitrary.
+    let allowed = old.has_cap_setuid()
+        || fsuid == old.uid
+        || fsuid == old.euid
+        || fsuid == old.suid
+        || fsuid == old.fsuid;
+
+    if allowed {
+        let mut new = (*old).clone();
+        new.fsuid = fsuid;
+        thread.set_cred(new);
+    }
+    // Always return previous fsuid, even when the request was ignored.
+    Ok(prev_fsuid as isize)
+}
+
+pub fn sys_setfsgid(fsgid: u32) -> AxResult<isize> {
+    debug!("sys_setfsgid <= fsgid: {fsgid}");
+    let thread = current();
+    let thread = thread.as_thread();
+    let old = thread.cred();
+    let prev_fsgid = old.fsgid;
+
+    if fsgid == NOCHG {
+        return Ok(prev_fsgid as isize);
+    }
+
+    let allowed = old.has_cap_setgid()
+        || fsgid == old.gid
+        || fsgid == old.egid
+        || fsgid == old.sgid
+        || fsgid == old.fsgid;
+
+    if allowed {
+        let mut new = (*old).clone();
+        new.fsgid = fsgid;
+        thread.set_cred(new);
+    }
+    Ok(prev_fsgid as isize)
 }
 
 pub fn sys_getgroups(size: usize, list: *mut u32) -> AxResult<isize> {

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-starry-setuid-setgid-no-uidvalid/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-starry-setuid-setgid-no-uidvalid/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-starry-setuid-setgid-no-uidvalid C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-starry-setuid-setgid-no-uidvalid src/main.c)
+target_compile_options(bug-starry-setuid-setgid-no-uidvalid PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-starry-setuid-setgid-no-uidvalid RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-starry-setuid-setgid-no-uidvalid/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-starry-setuid-setgid-no-uidvalid/c/src/main.c
@@ -1,0 +1,119 @@
+/*
+ * bug-starry-setuid-setgid-no-uidvalid
+ *
+ * 现象: starry kernel 在 setuid((uid_t)-1) / setgid((gid_t)-1) 时
+ *       直接接受并设置 r/e/s = 0xFFFFFFFF；Linux 应返 -1 EINVAL。
+ *
+ * Linux man 2 setuid §"ERRORS":
+ *   "EINVAL — The user ID specified in uid is not valid in this user namespace."
+ *
+ * Linux kernel/cred.c sys_setuid:
+ *   kuid = make_kuid(ns, uid);
+ *   if (!uid_valid(kuid))
+ *       return -EINVAL;
+ *
+ * uid_valid 拒绝 __kuid_val(uid) == (uid_t)-1。
+ *
+ * starry: os/StarryOS/kernel/src/syscall/sys.rs::sys_setuid 无 uid_valid 检查；
+ *         若 has_cap_setuid → 直接 new.uid = new.euid = new.suid = uid (含 -1)。
+ *         这违反 Linux/POSIX 约定，且使 (uid_t)-1 在后续 setresuid 中无法作
+ *         NOCHG sentinel 区分（NOCHG 也是 -1）。
+ *
+ * 影响: 与 setresuid/setresgid 的 -1 NOCHG 语义冲突；用户态可能因 -1 被
+ *       cred 化而出现安全错配（rare 但严重）。
+ *
+ * 触发条件: starry kernel 任何版本；以 root 调用 setuid(0xFFFFFFFF)
+ *           或 setgid(0xFFFFFFFF)。
+ *
+ * 期望修复方向: 在 sys_setuid/setgid/setresuid/setresgid 入口校验
+ *               (uid_t)-1 → 返 EINVAL（除 setres* 的 NOCHG 路径）。
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int run_setuid_minus_one(void)
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        errno = 0;
+        int rc = setuid((uid_t)-1);
+        int err = errno;
+        printf("  setuid((uid_t)-1) returned rc=%d errno=%d (%s)\n",
+               rc, err, strerror(err));
+        printf("  expected: rc=-1, errno=EINVAL (%d)\n", EINVAL);
+        if (rc == -1 && err == EINVAL) {
+            printf("  → behavior matches Linux: PASS\n");
+            _exit(0);
+        }
+        if (rc == 0) {
+            uid_t r, e, s;
+            getresuid(&r, &e, &s);
+            printf("  → starry accepted -1, now r=%u e=%u s=%u (cred poisoned)\n",
+                   r, e, s);
+            _exit(1);
+        }
+        printf("  → unexpected rc/errno combo\n");
+        _exit(2);
+    }
+    int status;
+    waitpid(pid, &status, 0);
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+}
+
+static int run_setgid_minus_one(void)
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        errno = 0;
+        int rc = setgid((gid_t)-1);
+        int err = errno;
+        printf("  setgid((gid_t)-1) returned rc=%d errno=%d (%s)\n",
+               rc, err, strerror(err));
+        printf("  expected: rc=-1, errno=EINVAL (%d)\n", EINVAL);
+        if (rc == -1 && err == EINVAL) {
+            printf("  → behavior matches Linux: PASS\n");
+            _exit(0);
+        }
+        if (rc == 0) {
+            gid_t r, e, s;
+            getresgid(&r, &e, &s);
+            printf("  → starry accepted -1, now r=%u e=%u s=%u (cred poisoned)\n",
+                   r, e, s);
+            _exit(1);
+        }
+        printf("  → unexpected rc/errno combo\n");
+        _exit(2);
+    }
+    int status;
+    waitpid(pid, &status, 0);
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+}
+
+int main(void)
+{
+    printf("=== bug-starry-setuid-setgid-no-uidvalid ===\n");
+    printf("Linux 拒绝 setuid/setgid 接受 (uid_t)-1 = 0xFFFFFFFF, 应返 EINVAL\n");
+    printf("starry 缺 uid_valid 检查 → 直接接受 (cred 被污染)\n\n");
+
+    if (getuid() != 0) {
+        printf("SKIP: needs root\n");
+        return 0;
+    }
+
+    int u = run_setuid_minus_one();
+    int g = run_setgid_minus_one();
+
+    if (u == 0 && g == 0) {
+        printf("\nTEST PASSED (bug fixed)\n");
+        return 0;
+    }
+    printf("\nTEST FAILED — starry behavior diverges from Linux on uid_valid check\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -53,6 +53,7 @@ test_commands = [
     "/usr/bin/bug-proc-init-pid",
     "/usr/bin/bug-tcp-udp-bind-same-port",
     "/usr/bin/bug-tcp-send-no-epoll-notify",
+    "/usr/bin/bug-starry-setuid-setgid-no-uidvalid",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -55,6 +55,7 @@ test_commands = [
     "/usr/bin/bug-proc-init-pid",
     "/usr/bin/bug-tcp-udp-bind-same-port",
     "/usr/bin/bug-tcp-send-no-epoll-notify",
+    "/usr/bin/bug-starry-setuid-setgid-no-uidvalid",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -62,6 +62,7 @@ test_commands = [
     "/usr/bin/bug-proc-init-pid",
     "/usr/bin/bug-tcp-udp-bind-same-port",
     "/usr/bin/bug-tcp-send-no-epoll-notify",
+    "/usr/bin/bug-starry-setuid-setgid-no-uidvalid",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -58,6 +58,7 @@ test_commands = [
     "/usr/bin/bug-proc-init-pid",
     "/usr/bin/bug-tcp-udp-bind-same-port",
     "/usr/bin/bug-tcp-send-no-epoll-notify",
+    "/usr/bin/bug-starry-setuid-setgid-no-uidvalid",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']


### PR DESCRIPTION
<div align="center">

[![Type](https://img.shields.io/badge/type-bugfix%20local-blue?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/717) [![Fixes](https://img.shields.io/badge/Fixes-%23713-red?style=flat-square)](https://github.com/rcore-os/tgoskits/issues/713) [![Sibling](https://img.shields.io/badge/Sibling%20deep-%23718-orange?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/718) [![Commits](https://img.shields.io/badge/commits-1-brightgreen?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/717/commits) [![GPG](https://img.shields.io/badge/GPG-Verified-success?style=flat-square)](#) [![Files](https://img.shields.io/badge/files-8-lightgrey?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/717/files) [![Diff](https://img.shields.io/badge/+224%20%2F%20--0-success?style=flat-square)](#)

</div>

> **修复上游 bug**: Fixes rcore-os/tgoskits#713
>
> 本 PR 是 **改动范围小的局部 fix** (uid_valid + setfsuid/setfsgid, 仅 2 文件 sys.rs + mod.rs); 衍生跨子系统改造 (PR_SET_DUMPABLE + ProcessData.dumpable) 在 deep PR rcore-os/tgoskits#718.

## 📑 目录

- [🎯 分支用途](#-分支用途)
- [🧪 修复覆盖了哪些 test PR / bug-* 复现](#-修复覆盖了哪些-test-pr--bug--复现)
- [🔧 修复点 (核心 — 用户 review 重点)](#-修复点-核心--用户-review-重点)
- [📊 PR 关系图](#-pr-关系图)
- [🔬 验收 / 复现命令](#-验收--复现命令)
- [📝 Commits](#-commits)
- [🔗 引用](#-引用)

## 🎯 分支用途

修复 starry-kernel `sys.rs` 中 uid/gid setter 与 Linux 不一致的两类局部 bug:
1. `sys_setuid` / `sys_setgid` 缺少 `uid_valid()` 检查
2. `setfsuid` / `setfsgid` syscall 完全缺失

对应 rcore-os/tgoskits#717。跨子系统改造 (NPTL cred 同步 / `PR_SET_DUMPABLE` 自动清) 拆到 fix-uid-gid-deep (rcore-os/tgoskits#718)。

## 🧪 修复覆盖了哪些 test PR / bug-* 复现

| 修复点 | 对应 bug 分支 | 对应 test 分支 |
|--------|---------------|----------------|
| `sys_setuid`/`sys_setgid` 接受 `(uid_t)-1` | `bug-starry-setuid-setgid-no-uidvalid` (rcore-os/tgoskits#713) | `test-uid-gid-direct-setters` ((fork branch: test-uid-gid-direct-setters)) |
| `setfsuid`/`setfsgid` ENOSYS | (无独立 bug-repro) | `test-uid-gid-direct-setters` 的 fs 字段断言, `test-uid-gid-getters` ((fork branch: test-uid-gid-getters)) procfs `Uid:` 第 4 字段 |

修复落地后:
- `bug-starry-setuid-setgid-no-uidvalid` C 程序由 FAIL (starry 接受 -1) → PASS (返 -1, errno=EINVAL)
- 4 个 arch toml (`bugfix/qemu-{aarch64,loongarch64,riscv64,x86_64}.toml`) 末尾追加 `/usr/bin/bug-starry-setuid-setgid-no-uidvalid`, 由 CI 自动验

## 🔧 修复点 (核心 — 用户 review 重点)

### 文件: `os/StarryOS/kernel/src/syscall/sys.rs`

#### 新增工具函数: `uid_valid` (line 31)

```rust
fn uid_valid(id: u32) -> bool {
    id != NOCHG  // NOCHG = u32::MAX
}
```

改动: 新增 4 行私有工具函数, 外加注释说明它与现有 `NOCHG` const 的语义配对。
原因: 镜像 Linux kernel `kernel/cred.c` 中 `make_kuid()` + `uid_valid()` 的判定: `(uid_t)-1` 在单参 setter 里不是合法 UID, 必须 EINVAL; 只在 multi-arg setter (`setresuid` / `setreuid`) 的 NOCHG 槽位才是合法 sentinel。

#### `sys_setuid` (line 166) — 入口加 `uid_valid` 检查

```rust
if !uid_valid(uid) {
    return Err(AxError::InvalidInput);
}
```

原因: `man 2 setuid §ERRORS`: "EINVAL — The user ID specified in uid is not valid in this user namespace." Linux `kernel/cred.c sys_setuid` 通过 `make_kuid + uid_valid` 拒绝 `(uid_t)-1`。修复前 starry 在 root 上调 `setuid((uid_t)-1)` 时执行 `new.uid = new.euid = new.suid = 0xFFFFFFFF`, cred 被污染; 并且与 setresuid 的 NOCHG sentinel 冲突。

#### `sys_setgid` (line 196) — 同 `uid_valid` 入口检查

原因: `man 2 setgid §ERRORS`: "EINVAL — The group ID specified in gid is not valid in this user namespace."

<details>
<summary>📄 新增 <code>sys_setfsuid</code> 完整实现 (~30 行) — 点开看代码</summary>

#### 新增 `sys_setfsuid` (line 319)

```rust
pub fn sys_setfsuid(fsuid: u32) -> AxResult<isize> {
    let prev_fsuid = old.fsuid;
    if fsuid == NOCHG { return Ok(prev_fsuid as isize); } // query trick
    let allowed = old.has_cap_setuid()
        || fsuid == old.uid || fsuid == old.euid
        || fsuid == old.suid || fsuid == old.fsuid;
    if allowed {
        let mut new = (*old).clone();
        new.fsuid = fsuid;
        thread.set_cred(new);
    }
    Ok(prev_fsuid as isize) // always return prev, even when silently ignored
}
```

原因: `man 2 setfsuid`:
- §RETURN VALUE: "On both success and failure, this call returns the previous filesystem user ID of the caller." — 必须永远返 prev
- §DESCRIPTION: "setfsuid() will succeed only if the caller is the superuser or if fsuid matches either the caller's real user ID, effective user ID, saved set-user-ID, or current filesystem user ID." — 否则静默忽略
- §BUGS: "the caller must resort to looking at the return value from a further call such as setfsuid(-1) (which will always fail), in order to determine if a preceding call to setfsuid() changed the filesystem user ID." — `(uid_t)-1` 是用户态查询 fsuid 的唯一渠道

</details>

#### 新增 `sys_setfsgid` (line 349)
改动: 与 `sys_setfsuid` 同结构, 使用 `has_cap_setgid()` 和 `gid/egid/sgid/fsgid` 比较。

### 文件: `os/StarryOS/kernel/src/syscall/mod.rs`

#### `handle_syscall` 分发表 (line 559-560)

```rust
Sysno::setfsuid => sys_setfsuid(uctx.arg0() as _),
Sysno::setfsgid => sys_setfsgid(uctx.arg0() as _),
```

原因: 修复前对应 `Sysno` 走 fall-through → ENOSYS。

### 文件: `test-suit/starryos/normal/qemu-smp1/bugfix/qemu-{aarch64,loongarch64,riscv64,x86_64}.toml`

每 arch 末尾追加 1 行 `/usr/bin/bug-starry-setuid-setgid-no-uidvalid`, 由 CI 自动跑 fixture, 验证修复前 FAIL → 修复后 PASS。

### 文件: `test-suit/starryos/normal/qemu-smp1/bugfix/bug-starry-setuid-setgid-no-uidvalid/c/{CMakeLists.txt,src/main.c}`

新增最小 repro fixture (单文件 C, 2 文件 dir). 与 bug issue #713 body 内置 repro 命令一致。

## 📊 PR 关系图

```mermaid
graph LR
  I713[Issue #713<br/>setuid -1 EINVAL] -->|Fixes| P717[<b>PR #717</b><br/>uid_valid + setfsuid/setfsgid<br/>本 PR]
  P717 -.->|Sibling deep| P718[PR #718<br/>dumpable + V3 全 cred]
  P726[PR #726<br/>test-direct-setters 477 PASS] -->|Validates| P717
  P725[PR #725<br/>test-getters 495 PASS] -.->|Validates fsuid| P717
  style P717 fill:#fef3c7,stroke:#f59e0b,stroke-width:3px
```

## 🔬 验收 / 复现命令

```bash
# 切换到本 fix 分支
cd <repo-root>
git checkout fix-uid-gid-bugs

# syscall group (含 test-uid-gid-direct-setters / -getters 等)
source .starry-env.sh && cargo starry test qemu --arch x86_64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch aarch64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch riscv64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch loongarch64 -c syscall

# bugfix group (含 bug-starry-setuid-setgid-no-uidvalid + 其他 bug-*)
source .starry-env.sh && cargo starry test qemu --arch x86_64 -c bugfix
source .starry-env.sh && cargo starry test qemu --arch aarch64 -c bugfix
source .starry-env.sh && cargo starry test qemu --arch riscv64 -c bugfix
source .starry-env.sh && cargo starry test qemu --arch loongarch64 -c bugfix
```

期望: 4 arch 全 PASS; `bug-starry-setuid-setgid-no-uidvalid` 应由 fix 前的 FAIL → PASS。

## 📝 Commits

- `b23945a31` (orig) → **`7413659e7`** (Round N+1 re-amend, email gmail→qq, body 去 hard-wrap, blockquote recovery)

本 PR squashed 到 1 commit (满足 "上游 push 仅 1 commit"; 含开发期主功能 fix + NOCHG doc 注释 / CI re-run 合并). 详细变更见 PR Files 标签 (8 files / +224 / 0: 2 .rs [sys.rs/mod.rs] + 4 bugfix toml + 1 bug-* test fixture dir [bug-starry-setuid-setgid-no-uidvalid: CMakeLists.txt + src/main.c]).

## 🔗 引用

- **相关 PR**: 修复 bug-* rcore-os/tgoskits#713 (setuid/setgid no uid_valid); 支撑 test PR (fork branch: test-uid-gid-direct-setters) / (fork branch: test-uid-gid-getters) procfs Uid 行 fs 字段断言; 衍生 deep rcore-os/tgoskits#718 (fix-uid-gid-deep) 补 PR_SET_DUMPABLE 跨子系统改造

Signed-off-by: Leo Cheng <chengkelfan@qq.com>

---

> <kbd>⚠️ CI 超时注意</kbd>: 由于 rcore-os/tgoskits#716 (apk-curl loongarch64 600s timeout, ~90% flake), starry loongarch64 上 CI 可能随机超时 — **不代表本 PR/issue 改动的回归**。请关注其他 arch (x86_64/aarch64/riscv64) 结果或重 trigger CI 重试。
