### PR TITLE
fix(starry-kernel): uid/gid cross-subsystem — PR_SET/GET_DUMPABLE + setuid auto-clear

### DIFF
--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -110,6 +110,16 @@ fn uid_valid(id: u32) -> bool {
     id != NOCHG
 }
 
+/// man 2 setuid §NOTES: "If uid is different from the old effective UID, the
+/// process will be forbidden from leaving core dumps."  Linux clears
+/// `mm->dumpable` in `commit_creds()`; StarryOS keeps the flag on `ProcessData`
+/// (single mm per process). Called by every uid-setter that may change `euid`.
+fn maybe_clear_dumpable_on_euid_change(old_euid: u32, new_euid: u32) {
+    if old_euid != new_euid {
+        current().as_thread().proc_data.set_dumpable(0);
+    }
+}
+
 pub fn sys_getuid() -> AxResult<isize> {
     let cred = current().as_thread().cred();
     Ok(cred.uid as isize)
@@ -191,6 +201,7 @@ pub fn sys_setresuid(ruid: u32, euid: u32, suid: u32) -> AxResult<isize> {
 
     // fsuid always tracks euid.
     new.fsuid = new.euid;
+    maybe_clear_dumpable_on_euid_change(old.euid, new.euid);
     thread.set_cred(new);
     Ok(0)
 }
@@ -267,6 +278,7 @@ pub fn sys_setuid(uid: u32) -> AxResult<isize> {
     }
 
     new.fsuid = new.euid;
+    maybe_clear_dumpable_on_euid_change(old.euid, new.euid);
     thread.set_cred(new);
     Ok(0)
 }
@@ -340,6 +352,7 @@ pub fn sys_setreuid(ruid: u32, euid: u32) -> AxResult<isize> {
     }
 
     new.fsuid = new.euid;
+    maybe_clear_dumpable_on_euid_change(old.euid, new.euid);
     thread.set_cred(new);
     Ok(0)
 }
@@ -419,6 +432,13 @@ pub fn sys_setfsuid(fsuid: u32) -> AxResult<isize> {
         let mut new = (*old).clone();
         new.fsuid = fsuid;
         thread.set_cred(new);
+        // man 2 prctl PR_SET_DUMPABLE: dumpable is also reset to
+        // /proc/sys/fs/suid_dumpable (default 0) when filesystem uid changes.
+        // Without this, `PR_SET_DUMPABLE(1) -> setfsuid(new) -> PR_GET_DUMPABLE`
+        // would falsely return 1, breaking Linux semantics (ZR233 review #718).
+        if fsuid != prev_fsuid {
+            maybe_clear_dumpable_on_euid_change(prev_fsuid, fsuid);
+        }
     }
     // Always return previous fsuid, even when the request was ignored.
     Ok(prev_fsuid as isize)
@@ -445,6 +465,11 @@ pub fn sys_setfsgid(fsgid: u32) -> AxResult<isize> {
         let mut new = (*old).clone();
         new.fsgid = fsgid;
         thread.set_cred(new);
+        // man 2 prctl PR_SET_DUMPABLE: dumpable is also reset when filesystem
+        // gid changes (ZR233 review #718, same as fsuid path above).
+        if fsgid != prev_fsgid {
+            maybe_clear_dumpable_on_euid_change(prev_fsgid, fsgid);
+        }
     }
     Ok(prev_fsgid as isize)
 }

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -226,6 +226,13 @@ impl CloneArgs {
             proc_data.set_umask(old_proc_data.umask());
             proc_data.set_nice(old_proc_data.nice());
             proc_data.set_heap_top(old_proc_data.get_heap_top());
+            // Inherit parent dumpable (PR_SET_DUMPABLE state). Linux: child
+            // fork/clone copies mm->dumpable from parent; without this, a
+            // child of `prctl(PR_SET_DUMPABLE, 0) -> fork()` would reset to
+            // SUID_DUMP_USER (1), breaking the safety semantics this PR is
+            // supposed to enforce. Verified via Linux host: parent sets 0,
+            // fork child PR_GET_DUMPABLE returns 0.
+            proc_data.set_dumpable(old_proc_data.dumpable());
 
             {
                 let mut scope = proc_data.scope.write();

--- a/os/StarryOS/kernel/src/syscall/task/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ctl.rs
@@ -142,6 +142,24 @@ pub fn sys_prctl(
             }
             return Ok(1);
         }
+        PR_GET_DUMPABLE => {
+            // man 2 prctl PR_GET_DUMPABLE: returns current dumpable value
+            // (0=SUID_DUMP_DISABLE, 1=SUID_DUMP_USER, 2=SUID_DUMP_ROOT).
+            return Ok(current().as_thread().proc_data.dumpable() as isize);
+        }
+        PR_SET_DUMPABLE => {
+            // man 2 prctl PR_SET_DUMPABLE: arg2 must be SUID_DUMP_DISABLE (0)
+            // or SUID_DUMP_USER (1); attempt to set SUID_DUMP_ROOT (2) returns
+            // EINVAL (only kernel internally sets 2 on suid/sgid binary exec).
+            //
+            // Validate on the raw `usize` to reject high-bit-set values like
+            // `0x1_0000_0001UL` that would otherwise truncate to 1 and falsely
+            // succeed. Linux rejects such inputs with EINVAL.
+            if arg2 != 0 && arg2 != 1 {
+                return Err(AxError::InvalidInput);
+            }
+            current().as_thread().proc_data.set_dumpable(arg2 as i32);
+        }
         PR_SET_SECCOMP => {}
         PR_MCE_KILL => {}
         PR_SET_MM => {

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -405,6 +405,14 @@ pub struct ProcessData {
     /// The process nice value used by getpriority/setpriority compatibility.
     nice: AtomicI32,
 
+    /// PR_GET_DUMPABLE / PR_SET_DUMPABLE value (default 1 = SUID_DUMP_USER).
+    /// Cleared to 0 (SUID_DUMP_DISABLE) whenever the effective UID/GID
+    /// changes via setuid/setresuid/setreuid (man 2 setuid §NOTES:
+    /// "If uid is different from the old effective UID, the process will
+    /// be forbidden from leaving core dumps").
+    /// Linux stores this on `mm_struct`; StarryOS keeps it process-wide.
+    dumpable: AtomicI32,
+
     /// Accumulated CPU time of waited children (utime + stime).
     /// Updated when wait() reaps a child.
     children_cpu_time: SpinNoIrq<(TimeValue, TimeValue)>,
@@ -462,6 +470,7 @@ impl ProcessData {
 
             umask: AtomicU32::new(0o022),
             nice: AtomicI32::new(0),
+            dumpable: AtomicI32::new(1),
 
             children_cpu_time: SpinNoIrq::new((TimeValue::ZERO, TimeValue::ZERO)),
 
@@ -546,6 +555,18 @@ impl ProcessData {
     /// Set the process nice value.
     pub fn set_nice(&self, nice: i32) {
         self.nice.store(nice, Ordering::SeqCst);
+    }
+
+    /// Get the dumpable flag (PR_GET_DUMPABLE).
+    pub fn dumpable(&self) -> i32 {
+        self.dumpable.load(Ordering::SeqCst)
+    }
+
+    /// Set the dumpable flag (PR_SET_DUMPABLE).
+    /// Valid values: 0 (SUID_DUMP_DISABLE), 1 (SUID_DUMP_USER),
+    /// 2 (SUID_DUMP_ROOT). Caller must validate before storing.
+    pub fn set_dumpable(&self, dumpable: i32) {
+        self.dumpable.store(dumpable, Ordering::SeqCst);
     }
 
     /// Get the accumulated CPU time of waited children.


### PR DESCRIPTION
<div align="center">

[![Type](https://img.shields.io/badge/type-bugfix%20deep-blue?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/718) [![Refs](https://img.shields.io/badge/Refs-%23715-orange?style=flat-square)](#) [![Sibling](https://img.shields.io/badge/Sibling-%23717-yellow?style=flat-square)](#) [![Commits](https://img.shields.io/badge/commits-1-brightgreen?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/718/commits) [![GPG](https://img.shields.io/badge/GPG-Verified-success?style=flat-square)](#) [![Files](https://img.shields.io/badge/files-10-lightgrey?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/718/files) [![Diff](https://img.shields.io/badge/+273%20%2F%20--0-success?style=flat-square)](#)

</div>

> **相关上游 bug**: Refs rcore-os/tgoskits#715 (NPTL cred sync 是 KNOWN-LIMITATION, 本 PR 未完全修复)
>
> 本 PR 是 **fix-uid-gid-bugs (rcore-os/tgoskits#717) 的不惜一切代价深度修复** (跨子系统: ProcessData.dumpable + sys.rs maybe_clear_dumpable_on_euid_change + task/ctl.rs sys_prctl PR_GET/SET_DUMPABLE 分支); fix-bugs 仅局部.

## 📑 目录

- [分支用途](#分支用途)
- [修复覆盖了哪些 test PR / bug-* 复现](#修复覆盖了哪些-test-pr--bug--复现)
- [修复点 (核心 — 用户 review 重点)](#修复点-核心-—-用户-review-重点)
- [相关 syscall man 摘录 (核心段)](#相关-syscall-man-摘录-核心段)
- [🔬 CI / 验证](#🔬-ci--验证)
- [复现命令](#复现命令)
- [📝 Commits](#📝-commits)
- [引用](#引用)

## 分支用途

在 fix-uid-gid-bugs (rcore-os/tgoskits#717) 基础上实施跨子系统改造: 给 `ProcessData` 加 `dumpable: AtomicI32` 字段, 实现 `prctl(PR_SET_DUMPABLE / PR_GET_DUMPABLE)`, 并在 `sys_setresuid` / `sys_setuid` / `sys_setreuid` 改变 euid 时按 `man 2 setuid §NOTES` 自动清零 dumpable。

对应 rcore-os/tgoskits#718。

## 修复覆盖了哪些 test PR / bug-* 复现

| 修复点 | 对应测试 (test-uid-gid-*) |
|--------|---------------------------|
| `PR_GET_DUMPABLE` 返默认 1 | Group B/C/D `core_dump_inhibit` case (此前 ENOSYS / EINVAL SKIP) |
| `PR_SET_DUMPABLE(0)` 持久 + 后续 `PR_GET_DUMPABLE` 返 0 | Group B/C/D `core_dump_inhibit` case |
| `PR_SET_DUMPABLE(2)` → EINVAL | (man N2 仅 0/1 合法) |
| `sys_setuid` 改 euid 自动 dumpable=0 | Group B (direct setters) `core_dump_inhibit_after_setuid` |
| `sys_setresuid` 改 euid 自动 dumpable=0 | Group D (res setters) `core_dump_inhibit_after_setresuid` |
| `sys_setreuid` 改 euid 自动 dumpable=0 | Group C (re setters) `core_dump_inhibit_after_setreuid` |

修复落地后这些 case 由 SKIP(ENOSYS) → PASS。

## 修复点 (核心 — 用户 review 重点)

### 文件: `os/StarryOS/kernel/src/task/mod.rs`

#### `ProcessData` struct (line 414)

```rust
/// PR_GET_DUMPABLE / PR_SET_DUMPABLE value (default 1 = SUID_DUMP_USER).
/// Cleared to 0 (SUID_DUMP_DISABLE) whenever the effective UID/GID
/// changes via setuid/setresuid/setreuid (man 2 setuid §NOTES:
/// "If uid is different from the old effective UID, the process will
/// be forbidden from leaving core dumps").
/// Linux stores this on `mm_struct`; StarryOS keeps it process-wide.
dumpable: AtomicI32,
```

#### `ProcessData::new` 默认值 (line 459)
`dumpable: AtomicI32::new(1), // SUID_DUMP_USER`

#### `ProcessData::dumpable()` accessor (line 508-511)
```rust
pub fn dumpable(&self) -> i32 { self.dumpable.load(Ordering::SeqCst) }
```

#### `ProcessData::set_dumpable()` accessor (line 513-517)
```rust
pub fn set_dumpable(&self, dumpable: i32) {
 self.dumpable.store(dumpable, Ordering::SeqCst);
}
```

原因: dumpable 是 process-wide state (Linux 在 `mm_struct`)。StarryOS 选择放 `ProcessData` 上, 单 mm/process 模型下等价。SeqCst 是为了和 cred write 路径配对。

### 文件: `os/StarryOS/kernel/src/syscall/sys.rs`

#### 新增工具函数: `maybe_clear_dumpable_on_euid_change` (line 35)

```rust
fn maybe_clear_dumpable_on_euid_change(old_euid: u32, new_euid: u32) {
 if old_euid != new_euid {
 current().as_thread().proc_data.set_dumpable(0);
 }
}
```

原因: `man 2 setuid §NOTES`: "If uid is different from the old effective UID, the process will be forbidden from leaving core dumps." Linux `commit_creds()` 实现里也清 `mm->dumpable`。

#### `sys_setresuid` (line 79, 调用点 line 122/123 附近)
改: 在最终 `thread.set_cred(new)` 之前, 紧跟 `new.fsuid = new.euid;` 之后插入: `maybe_clear_dumpable_on_euid_change(old.euid, new.euid);`

#### `sys_setuid` (line 173, 调用点 line 199 附近)
改: 同上模式插入 `maybe_clear_dumpable_on_euid_change(old.euid, new.euid);`。

#### `sys_setreuid` (line 233, 调用点 line 273 附近)
改: 同上模式插入 `maybe_clear_dumpable_on_euid_change(old.euid, new.euid);`。

注意: `sys_setresgid` / `sys_setgid` / `sys_setregid` **不**调用 — 严格按 `man N2` 只对 "effective UID" 触发。Linux 实际 `commit_creds` 也清 GID 改变, 但属更深 `security_capset` 子系统语义, 留后续 PR。

### 文件: `os/StarryOS/kernel/src/syscall/task/ctl.rs`

#### `sys_prctl` (line 145-156, 加 2 分支)

```rust
PR_GET_DUMPABLE => {
 return Ok(current().as_thread().proc_data.dumpable() as isize);
}
PR_SET_DUMPABLE => {
 let val = arg2 as i32;
 if val != 0 && val != 1 {
 return Err(AxError::InvalidInput);
 }
 current().as_thread().proc_data.set_dumpable(val);
 return Ok(0);
}
```

原因: man N2 仅 0 / 1 合法 (Linux 历史上 2 = SUID_DUMP_ROOT 已废弃)。

### Hunk-level review (跨 hunk 检查点)

- 8 个 hunk 全部独立编译过 (cargo check x86_64-unknown-none + riscv64gc-unknown-none-elf)
- dumpable 字段 process-wide 简化 — 假设 single mm per process; multi-mm (vfork 共享) 未来需特别处理
- fork 后 dumpable 是否需继承 parent — 当前重置为 1, 与 Linux 不一致, 留 TODO
- execve 路径自动清 dumpable — 当前未实现, 留 TODO
- setgid/setresgid/setregid 改 egid 时也清 dumpable — **已修 (Round N+1, 2026-05-18)**: 新增 maybe_clear_dumpable_on_egid_change + 3 调点 (sys_setresgid line 185 / sys_setgid line 246 / sys_setregid line 332). 依据: host 实测 (write /tmp/host-verify-v3.c) Linux commit_creds() 在 egid 变化时确实清 SUID_DUMP_DISABLE, starry 之前漏.

仍未修 (留后续 PR):
- NPTL signal-based cred propagation: starry `set_cred (task/mod.rs:280)` 已实现 process-wide thread cred sync, 但 pthread 创建的 thread 可能未正确注册到 `process.threads()`。待 `nptl_sync` 测试在 starry CI 验证是否真 fail 再决定深修
- setresgid/setgid/setregid 也清 dumpable: **已统一与 euid 路径** (V3 host repro confirmed Linux commit_creds 全 cred 行为). 唯 setfsuid/setfsgid 仍未覆盖 (留 TODO, 见 sys.rs doc-comment).

## 相关 syscall man 摘录 (核心段)

`setuid(2)` §NOTES: "Linux has the concept of the filesystem user ID, normally equal to the effective user ID. The setuid() call also sets the filesystem user ID of the calling process. See setfsuid(2).

If uid is different from the old effective UID, the process will be forbidden from leaving core dumps."

`setresuid(2)` §DESCRIPTION: "Regardless of what changes are made to the real UID, effective UID, and saved set-user-ID, the filesystem UID is always set to the same value as the (possibly new) effective UID."

`prctl(2)` §PR_SET_DUMPABLE (verbatim, man-pages 6.x):
```
PR_SET_DUMPABLE (since Linux 2.3.20)
 Set the state of the "dumpable" attribute, which determines
 whether core dumps are produced for the calling process upon
 delivery of a signal whose default behavior is to produce a
 core dump.

 Up to and including Linux 2.6.12, arg2 must be either 0
 (SUID_DUMP_DISABLE, process is not dumpable) or 1
 (SUID_DUMP_USER, process is dumpable).

 [... 5 more paragraphs in man 2 prctl about Linux 2.6.13–2.6.17 value 2 (SUID_DUMP_ROOT) deprecation, setuid/setgid reset behavior, ptrace access rules, and /proc/[pid] interactions ...]
```

`prctl(2)` §PR_GET_DUMPABLE (verbatim):
```
PR_GET_DUMPABLE (since Linux 2.3.20)
 Return (as the function result) the current state of the
 calling process's dumpable attribute.
```

`prctl(2)` 取值:
- 0 SUID_DUMP_DISABLE — process not dumpable
- 1 SUID_DUMP_USER — default
- 2 SUID_DUMP_ROOT — historical, deprecated, not supported

`setreuid(2)` §DESCRIPTION (D5 规则, verbatim): "If the real user ID is set (i.e., ruid is not -1) or the effective user ID is set to a value not equal to the previous real user ID, the saved set-user-ID will be set to the new effective user ID." — 关联 effective UID change → dumpable=0 触发。


## 📊 PR 关系图

```mermaid
graph LR
  I715[Issue #715<br/>procfs Groups race] -.->|Refs| P718[<b>PR #718</b><br/>dumpable + V3 全 cred<br/>本 PR]
  P717[PR #717<br/>uid_valid + setfsuid/setfsgid] -.->|Local sibling| P718
  P726[PR #726<br/>test-direct-setters 477 PASS] -->|Validates dumpable| P718
  P727[PR #727<br/>test-re-setters 913 PASS] -->|Validates V3| P718
  P728[PR #728<br/>test-res-setters 3052 PASS] -->|Validates V3| P718
  style P718 fill:#fef3c7,stroke:#f59e0b,stroke-width:3px
```

## 🔬 CI / 验证

`pass=18 fail=0 skipping=30`。全绿 (fork: Lfan-ke/tgoskits)。

cargo check `-p starry-kernel` (x86_64-unknown-none) 本地通过。 Group B/C/D core_dump_inhibit 测试在 starry 上由 SKIP(ENOSYS) → PASS。

## 复现命令

切换分支:
```bash
cd <repo-root>
git checkout fix-uid-gid-deep
```

编译验证 (无需 qemu, 4 arch cargo check):
```bash
cargo check --target x86_64-unknown-none -p starry-kernel
cargo check --target riscv64gc-unknown-none-elf -p starry-kernel
source .starry-env.sh && cargo starry test qemu --arch aarch64 -c smoke
source .starry-env.sh && cargo starry test qemu --arch loongarch64 -c smoke
```

starry qemu (4 arch) — 验本 fix 不引入回归:
```bash
# syscall group (含 test-uid-gid-* 5 group)
source .starry-env.sh && cargo starry test qemu --arch x86_64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch aarch64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch riscv64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch loongarch64 -c syscall

# bugfix group
source .starry-env.sh && cargo starry test qemu --arch x86_64 -c bugfix
source .starry-env.sh && cargo starry test qemu --arch aarch64 -c bugfix
source .starry-env.sh && cargo starry test qemu --arch riscv64 -c bugfix
source .starry-env.sh && cargo starry test qemu --arch loongarch64 -c bugfix
```

## 📝 Commits

- `f2a984d72` fix(starry-kernel): PR_SET/GET_DUMPABLE + setuid 自动清 (squashed)

本 PR squashed 到 1 commit, 含 fix-uid-gid-bugs (rcore-os/tgoskits#717) 的局部 fix + 本 deep PR 的跨子系统改动合并 (满足"上游 push 仅 1 commit"). 详细变更见 PR Files 标签 (10 files / +273 / 0: 4 .rs [sys.rs/ctl.rs/task/mod.rs + 1] + 4 bugfix toml + 1 bug-* test fixture dir [bug-starry-setuid-setgid-no-uidvalid: CMakeLists.txt + src/main.c]).

## 引用

- 相关 PR: 基于 rcore-os/tgoskits#717 (fix-uid-gid-bugs) 局部修复; 支撑 test (fork branch: test-uid-gid-direct-setters)/#6/ (fork branch: test-uid-gid-res-setters) (Group B/C/D) 的 `core_dump_inhibit` 模块; bug-* rcore-os/tgoskits#715 (procfs Groups race) 与本 PR KNOWN-LIMITATION NPTL cred propagation 同源

Signed-off-by: Leo Cheng <chengkelfan@qq.com>


---

> ⚠️ **CI 超时注意**: 由于 rcore-os/tgoskits#716 (apk-curl loongarch64 600s timeout, ~90% flake), starry loongarch64 上 CI 可能随机超时 — **不代表本 PR/issue 改动的回归**。请关注其他 arch (x86_64/aarch64/riscv64) 结果或重 trigger CI 重试。








