### PR TITLE
test(busybox): cover busybox_acpid via usage banner

### DIFF
--- a/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
@@ -985,6 +985,21 @@ if [ "$_printf" = "61 0a 62" ]; then echo "PASS: busybox_printf_escape"; PASS=$(
 _t=$({ timeout 10 sh -c "busybox sh -c 'export BB_SEM_ENV=ok; cd /tmp && [ \"\$BB_SEM_ENV:\$PWD\" = \"ok:/tmp\" ] && command -v busybox >/dev/null && busybox echo sh_env_cd_ok' 2>&1"; } 2>&1)
 if echo "$_t" | grep -qxF "sh_env_cd_ok"; then echo "PASS: busybox_sh_env_cd"; PASS=$((PASS+1)); else echo "FAIL: busybox_sh_env_cd"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
+# busybox_acpid — applet wiring sanity check.
+# Without -f, acpid would daemonize and close stdio (Issue #13's `[ -n "$_t" ]`
+# only succeeds if something is printed before fork). We pass an unknown flag
+# `-h` so getopt32 reaches bb_show_usage, which writes the applet banner to
+# stderr — confirming the applet table contains acpid and busybox can run it.
+_t=$({ timeout 10 sh -c "busybox acpid -h 2>&1"; echo "EXIT:$?"; } 2>&1)
+_rc=$(printf '%s\n' "$_t" | sed -n 's/^EXIT://p')
+_t=$(printf '%s\n' "$_t" | sed '/^EXIT:/d')
+if echo "$_t" | grep -qF "Usage:" && echo "$_t" | grep -qF "acpid"; then
+    echo "PASS: busybox_acpid"; PASS=$((PASS+1))
+else
+    echo "FAIL: busybox_acpid (rc=$_rc)"; echo "$_t"
+    FAIL=$((FAIL+1))
+fi
+
 echo "=== BusyBox Test Summary ==="
 echo "PASS: $PASS  FAIL: $FAIL  TOTAL: $((PASS+FAIL))"
 _m1="Test"; _m2="run"; _m3="completed"; echo "$_m1 $_m2 $_m3"


### PR DESCRIPTION
## 问题
Issue [rcore-os/linux-compatible-testsuit#13](https://github.com/rcore-os/linux-compatible-testsuit/issues/13)
列出的 48 个 busybox 用例里，`busybox_acpid` 之前一直没人补：

- issue 原文断言是 `busybox acpid 2>&1` 再 `[ -n "$_t" ]`；
- 但 busybox `acpid` 缺省调用 `bb_daemonize_or_rexec`，**fork 之前**就把 stdout/stderr 关掉，
  父进程返回 0、什么都不输出，shell 端永远拿不到非空 `$_t`，照搬反而过不了；
- 同时 StarryOS 现在并不暴露 `/dev/input/event*` 或 `/proc/acpi/event`，没法让 acpid 真正进入事件循环。

## 改动
`test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh` 末尾新增一条 `busybox_acpid`：
传入未知选项 `-h`，让 busybox `getopt32` 直接走 `bb_show_usage`，把 "Usage: acpid ..."
写到 stderr 后立刻退出。验证条件加强为同时匹配 `Usage:` 与 `acpid`，
比 issue 原文的 `[ -n "$_t" ]` 更具语义、但仍是其超集，
确保 applet 确实连进了 busybox 的 applet 表，没被剥掉。

未触及内核（rootfs busybox 本身就编译了 acpid applet）。

## 逻辑
- busybox `acpid_main` 启动流程：`INIT_G` → `getopt32(optstring="c:de:fl:a:M:..." )` → 默认 `bb_daemonize_or_rexec` → 主循环。
- `-h` 不在 optstring 中，触发 `bb_show_usage`，stderr 收到形如 `Usage: acpid [-df] [-c CONFDIR] ...`。
- 这条路径只依赖 `write(2)` 到 stderr、`exit(2)`，StarryOS 早已支持，无需新增 ACPI 伪文件 / netlink uevent。
- 同样的 `<applet> -h` 配 `grep -qF "Usage: <applet>"` 模式在脚本里已经被 `whois`/`xzcat`/`zcip` 使用，风格保持一致。

## 验证
- `cargo fmt --check` ✓
- `cargo starry test qemu --arch riscv64 -c busybox` ：
  - `PASS: busybox_acpid`
  - `=== BusyBox Test Summary === PASS: 283  FAIL: 0`（相比 dev 基线 282，+1，无回归）
  - `PASS busybox (173.53s)`

> 注：与 PR #668 / #517 不冲突 —— 仅追加 acpid 一项，没碰 #668 触及的脚本区间或 #517 的 `mm/loader.rs`。