### PR TITLE
test(syscall): test-uid-gid-getters 6 getter 495 PASS

### DIFF
--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-uid-gid-getters C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+# 6 个 getter syscall 地毯式覆盖：
+#   getuid / geteuid / getgid / getegid / getresuid / getresgid
+# 每模块自计 __pass/__fail，main 汇总；每 case 头部 man 原文引用。
+add_executable(test-uid-gid-getters
+    src/main.c
+    src/getuid.c
+    src/geteuid.c
+    src/getgid.c
+    src/getegid.c
+    src/getresuid.c
+    src/getresgid.c
+    src/cross_consistency.c
+    src/boundary.c
+    src/matrix.c
+    src/procfs_visibility.c
+    src/uid32_no_trunc.c)
+
+target_include_directories(test-uid-gid-getters PRIVATE src)
+target_compile_options(test-uid-gid-getters PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-uid-gid-getters RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/boundary.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/boundary.c
@@ -1,0 +1,74 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* boundary — getter syscall 边界 / 错误注入测试.
+ *
+ * man 2 getresuid §"ERRORS":
+ *   "EFAULT — One of the arguments specified an address outside the calling
+ *    process's address space."
+ *
+ * 仅 getresuid/getresgid 接受指针参数 → 才有 EFAULT 路径.
+ * 0-arg getter (getuid/geteuid/getgid/getegid) 不接受任何参数, 无 EFAULT.
+ *
+ * 维度: 指针 invalid 位置 × 指针类型 (kernel-addr / NULL / 部分 OK)
+ *   (a) kernel-space address — ruid 槽 / egid 槽
+ *   (b) 部分 NULL (3 槽中 1 个) + 全 NULL
+ */
+
+static void getresuid_kernel_address_efault(void)
+{
+    /* 测什么: man §ERRORS — 任一 out-arg "address outside calling process's
+     *         address space" 应 -1 EFAULT. kernel-space 地址典型不可写.
+     * 怎么测: 用 raw syscall 传 kernel-canonical 地址 (0xdeadbeef.. / 0xffff..)
+     *         至 ruid 槽 (slot 1) / egid 槽 (slot 2). 测两个不同 syscall (uid/gid 镜像).
+     * 期望:   rc=-1, errno=EFAULT.
+     * 为什么: starry vm_write 实现必须 check user-vs-kernel 段, 不能 OOB 写 (会
+     *         crash kernel) 或 silently ignore (会让 user 误以为成功).
+     *         注: 用 raw syscall 直达 — libc 可能在 wrapper 内做地址校验拦截. */
+    uid_t valid;
+    long rc;
+
+    errno = 0;
+    rc = syscall(SYS_getresuid, (void *)0xdeadbeefdeadbeefULL, &valid, &valid);
+    CHECK(rc == -1 && errno == EFAULT,                             "boundary (a1): kernel addr as ruid slot -> -1 EFAULT");
+
+    errno = 0;
+    rc = syscall(SYS_getresgid, &valid, (void *)0xffffffffff000000ULL, &valid);
+    CHECK(rc == -1 && errno == EFAULT,                             "boundary (a2): kernel addr as egid slot -> -1 EFAULT");
+}
+
+static void getresuid_partial_efault(void)
+{
+    /* 测什么: man §ERRORS 隐含 — "ONE OF the arguments" 意味着任一槽无效
+     *         即应失败. 测部分 NULL (1 槽) 与全 NULL.
+     * 怎么测: 用 raw syscall, slot 1 设 NULL 其他正常 → 验 EFAULT.
+     *         再测三槽全 NULL.
+     * 期望:   两种情况都 -1 EFAULT.
+     * 为什么: 验证 starry 的 NULL 检查是 fail-fast (任一槽错就停),
+     *         不能因 "valid 槽都给了" 而 silently 成功. */
+    uid_t valid;
+    long rc;
+
+    errno = 0;
+    rc = syscall(SYS_getresuid, NULL, &valid, &valid);
+    CHECK(rc == -1 && errno == EFAULT,                             "boundary (b1): partial NULL (1 of 3) -> -1 EFAULT");
+
+    errno = 0;
+    rc = syscall(SYS_getresgid, NULL, NULL, NULL);
+    CHECK(rc == -1 && errno == EFAULT,                             "boundary (b2): all-NULL getresgid -> -1 EFAULT");
+}
+
+int boundary_run(void)
+{
+    printf("\n----- boundary -----\n");
+    getresuid_kernel_address_efault();
+    getresuid_partial_efault();
+    printf("  ----- boundary: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/cross_consistency.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/cross_consistency.c
@@ -1,0 +1,128 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* cross_consistency — 6 个 getter syscall 内部一致性矩阵.
+ *
+ * man 2 getuid §"DESCRIPTION":
+ *   "getuid() returns the real user ID of the calling process."
+ * man 2 getresuid §"DESCRIPTION":
+ *   "getresuid() returns the real UID, the effective UID, and the saved
+ *    set-user-ID of the calling process, in the arguments ruid, euid, and
+ *    suid, respectively."
+ *
+ * 隐含规范 — 同一 cred 子系统的多个 reader 应返回一致数据:
+ *   getuid()       == getresuid().ruid
+ *   geteuid()      == getresuid().euid
+ *   getgid()       == getresgid().rgid
+ *   getegid()      == getresgid().egid
+ *
+ * 任何不一致 = starry cred 子系统内部状态不同步 (locking bug / cache bug).
+ *
+ * 5 维度覆盖:
+ *   (a) uid pair (getuid vs getresuid).
+ *   (b) gid pair (getgid vs getresgid).
+ *   (c) 100x interleaved getuid/geteuid 稳定 (race detection).
+ *   (d) 100x interleaved getgid/getegid 稳定 (gid 镜像).
+ *   (e) 100x getresuid 全字段稳定 (multi-field cred read race).
+ */
+
+static void uid_pair_consistency(void)
+{
+    /* 测什么: 隐含规范 — getuid() == getresuid().ruid + geteuid() == ...euid.
+     * 怎么测: 同一进程内, 调 getuid + geteuid 后再调 getresuid 比对.
+     * 期望:   r2 == u, e2 == e.
+     * 为什么: 验证 starry sys_getuid + sys_getresuid 都读同一 cred.uid/euid 字段;
+     *         不同 syscall 路径不应有内部 cache 不同步. */
+    uid_t u = getuid();
+    uid_t e = geteuid();
+    uid_t r2, e2, s2;
+    if (getresuid(&r2, &e2, &s2) != 0) { CHECK(0, "skip"); return; }
+    CHECK(u == r2,                                                 "cross (a1): getuid() == getresuid().ruid");
+    CHECK(e == e2,                                                 "cross (a2): geteuid() == getresuid().euid");
+}
+
+static void gid_pair_consistency(void)
+{
+    /* 测什么: 同 uid_pair 但对 gid 维度.
+     * 怎么测: getgid + getegid → getresgid 比对.
+     * 期望:   gr2 == g, ge2 == eg.
+     * 为什么: 验证 starry sys_getgid + sys_getresgid 同源 cred.gid/egid. */
+    gid_t g = getgid();
+    gid_t e = getegid();
+    gid_t r2, e2, s2;
+    if (getresgid(&r2, &e2, &s2) != 0) { CHECK(0, "skip"); return; }
+    CHECK(g == r2,                                                 "cross (b1): getgid() == getresgid().rgid");
+    CHECK(e == e2,                                                 "cross (b2): getegid() == getresgid().egid");
+}
+
+static void interleaved_stability(void)
+{
+    /* 测什么: 同一进程多次 getuid/geteuid 之间无 race / cred 不被无故变.
+     * 怎么测: 100 轮内 getuid → geteuid → getuid → geteuid, 每轮验
+     *         前后 getuid 一致 + 前后 geteuid 一致. 累计 n_inconsistent.
+     * 期望:   n_inconsistent == 0.
+     * 为什么: 防 starry cred read path 有 race (并发 setuid 影响读) /
+     *         有 stale cache. 单线程纯读应永远稳定. */
+    int n_inconsistent = 0;
+    for (int i = 0; i < 100; i++) {
+        uid_t u1 = getuid();
+        uid_t e1 = geteuid();
+        uid_t u2 = getuid();
+        uid_t e2 = geteuid();
+        if (u1 != u2 || e1 != e2) n_inconsistent++;
+    }
+    CHECK(n_inconsistent == 0,                                     "cross (c): 100x interleaved getuid/geteuid stable");
+}
+
+static void interleaved_stability_gid(void)
+{
+    /* 测什么: gid 镜像 (c) — 100x getgid/getegid 稳定.
+     * 怎么测: 同 (c) 模式.
+     * 期望:   n_inconsistent == 0.
+     * 为什么: 覆盖 starry cred.gid/egid 读路径单线程稳定性
+     *         (uid 通过 (c) 已测; 单测一边不够, 镜像必要). */
+    int n_inconsistent = 0;
+    for (int i = 0; i < 100; i++) {
+        gid_t g1 = getgid();
+        gid_t e1 = getegid();
+        gid_t g2 = getgid();
+        gid_t e2 = getegid();
+        if (g1 != g2 || e1 != e2) n_inconsistent++;
+    }
+    CHECK(n_inconsistent == 0,                                     "cross (d): 100x interleaved getgid/getegid stable");
+}
+
+static void interleaved_stability_getres(void)
+{
+    /* 测什么: getresuid 多字段读 (r/e/s 3 个) 100x 稳定.
+     * 怎么测: baseline 一次 → 100x getresuid → 比对每次 r/e/s vs baseline.
+     * 期望:   全部一致.
+     * 为什么: getresuid 多字段读涉及 starry vm_write 3 次写 user pointer,
+     *         若有 partial-write / race 会读出 mixed cred 状态. 此测验证
+     *         三字段写之间 cred 不变. */
+    uid_t r0, e0, s0;
+    if (getresuid(&r0, &e0, &s0) != 0) { CHECK(0, "skip"); return; }
+    int n_inconsistent = 0;
+    for (int i = 0; i < 100; i++) {
+        uid_t r, e, s;
+        if (getresuid(&r, &e, &s) != 0) { n_inconsistent++; continue; }
+        if (r != r0 || e != e0 || s != s0) n_inconsistent++;
+    }
+    CHECK(n_inconsistent == 0,                                     "cross (e): 100x getresuid 全字段稳定");
+}
+
+int cross_consistency_run(void)
+{
+    printf("\n----- cross_consistency -----\n");
+    uid_pair_consistency();
+    gid_pair_consistency();
+    interleaved_stability();
+    interleaved_stability_gid();
+    interleaved_stability_getres();
+    printf("  ----- cross_consistency: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getegid.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getegid.c
@@ -1,0 +1,103 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* getegid(2) — returns the effective group ID of the calling process.
+ *
+ * man 2 getgid §"DESCRIPTION":
+ *   "getegid() returns the effective group ID of the calling process."
+ *
+ * man 2 getgid §"ERRORS":
+ *   "These functions are always successful and never modify errno."
+ *
+ * man 2 getgid §"HISTORY":
+ *   "The original Linux getuid() and geteuid() system calls supported only
+ *    16-bit user IDs. Subsequently, Linux 2.4 added getuid32() and geteuid32(),
+ *    supporting 32-bit IDs. The glibc getuid() and geteuid() wrapper functions
+ *    transparently deal with the variations across kernel versions."
+ *
+ * 5 维度覆盖 (a-e):
+ *   (a) basic 返回值                       man §DESCRIPTION
+ *   (b) idempotent 纯查询无副作用           man §DESCRIPTION (隐含)
+ *   (c) errno 不动                          man §ERRORS
+ *   (d) raw syscall vs libc wrapper 一致    man §HISTORY (libc 透明处理)
+ *   (e) 默认 egid == gid                    man §DESCRIPTION (无 setgid binary 时)
+ */
+
+static void getegid_basic_returns_egid(void)
+{
+    /* 测什么: man §DESCRIPTION — getegid() returns effective group ID.
+     * 怎么测: 直接调 getegid(), 打印.
+     * 期望:   返回当前进程的 effective gid (root 启动时为 0).
+     * 为什么: 验证 syscall 不 panic / 不返错误指示符 (gid_t 是 unsigned, 无 -1
+     *         失败语义, 所以 "always succeeds" 体现为 "调用返回任意值都合法"). */
+    gid_t e = getegid();
+    CHECK(e == e, "getegid (a) basic: returned value (always succeeds)");
+    printf("  current effective gid = %u\n", (unsigned)e);
+}
+
+static void getegid_idempotent(void)
+{
+    /* 测什么: man §DESCRIPTION 隐含语义 — 纯查询无 side effect.
+     * 怎么测: 连续 3 次调 getegid().
+     * 期望:   3 次返回值相同.
+     * 为什么: 防御 starry 实现是否有状态副作用 (如 cache invalidation bug). */
+    gid_t e1 = getegid();
+    gid_t e2 = getegid();
+    gid_t e3 = getegid();
+    CHECK(e1 == e2 && e2 == e3, "getegid (b) idempotent: 3 calls return same value");
+}
+
+static void getegid_does_not_modify_errno(void)
+{
+    /* 测什么: man §ERRORS — "never modify errno".
+     * 怎么测: 预设 errno = 11111 (任意值), 调 getegid(), 验 errno 未变.
+     * 期望:   errno 仍是 11111.
+     * 为什么: starry 实现必须仅读 cred.egid, 不能踩 errno. */
+    errno = 11111;
+    (void)getegid();
+    CHECK(errno == 11111, "getegid (c) does not modify errno");
+    errno = 0;
+}
+
+static void getegid_raw_syscall_matches_libc(void)
+{
+    /* 测什么: man §HISTORY — libc 透明处理 16-bit/32-bit 差异, 直接转发 syscall.
+     * 怎么测: 比较 syscall(SYS_getegid) 与 libc getegid() 返回值.
+     * 期望:   两者相等.
+     * 为什么: 验证 libc wrapper 无值转换 / 无内部 cache; raw 路径 ABI 一致. */
+    gid_t libc_v = getegid();
+    long raw_v = syscall(SYS_getegid);
+    CHECK(raw_v >= 0 && (gid_t)raw_v == libc_v,
+          "getegid (d) raw syscall matches libc wrapper");
+}
+
+static void getegid_default_equals_gid(void)
+{
+    /* 测什么: man §DESCRIPTION 隐含 — 普通进程 (非 setgid binary)
+     *         egid == gid (启动时未做权限提升).
+     * 怎么测: 比较 getegid() 与 getgid().
+     * 期望:   两者相等 (CI runner 不是 setgid program).
+     * 为什么: 验证 starry 启动时不误设 egid != gid; 也为后续 setresgid
+     *         矩阵提供 known-state 基线. */
+    gid_t g = getgid();
+    gid_t e = getegid();
+    CHECK(g == e, "getegid (e) default: egid == gid (no setgid binary)");
+}
+
+int getegid_run(void)
+{
+    printf("\n----- getegid -----\n");
+    getegid_basic_returns_egid();
+    getegid_idempotent();
+    getegid_does_not_modify_errno();
+    getegid_raw_syscall_matches_libc();
+    getegid_default_equals_gid();
+    printf("  ----- getegid: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/geteuid.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/geteuid.c
@@ -1,0 +1,104 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* geteuid(2) — returns the effective user ID of the calling process.
+ *
+ * man 2 getuid §"DESCRIPTION":
+ *   "geteuid() returns the effective user ID of the calling process."
+ *
+ * man 2 getuid §"ERRORS":
+ *   "These functions are always successful and never modify errno."
+ *
+ * man 2 getuid §"HISTORY":
+ *   "Linux 2.4 added getuid32() and geteuid32(), supporting 32-bit IDs.
+ *    The glibc getuid() and geteuid() wrapper functions transparently
+ *    deal with the variations across kernel versions."
+ *
+ * 5 维度覆盖 (a-e):
+ *   (a) basic 返回值                       man §DESCRIPTION
+ *   (b) idempotent 纯查询无副作用           man §DESCRIPTION (隐含)
+ *   (c) errno 不动                          man §ERRORS
+ *   (d) raw syscall vs libc wrapper 一致    man §HISTORY (libc 透明处理)
+ *   (e) 默认 euid == uid                    man fork+exec 继承 (无 setuid binary 时)
+ */
+
+static void geteuid_basic_returns_euid(void)
+{
+    /* 测什么: man §DESCRIPTION — geteuid() returns effective user ID.
+     * 怎么测: 直接调 geteuid(), 打印.
+     * 期望:   返回当前进程的 effective uid (root 启动时为 0).
+     * 为什么: 验证 syscall 不 panic / 不返错误指示符. uid_t 是 unsigned,
+     *         无 -1 失败语义, "always succeeds" 体现为"调用返回任意值都合法". */
+    uid_t e = geteuid();
+    CHECK(e == e, "geteuid (a) basic: returned value (always succeeds)");
+    printf("  current effective uid = %u\n", (unsigned)e);
+}
+
+static void geteuid_idempotent(void)
+{
+    /* 测什么: man §DESCRIPTION 隐含 — 纯查询无 side effect.
+     * 怎么测: 连续 3 次调 geteuid().
+     * 期望:   3 次返回值相同.
+     * 为什么: 防御 starry 实现是否有状态副作用 (如 cache invalidation bug). */
+    uid_t e1 = geteuid();
+    uid_t e2 = geteuid();
+    uid_t e3 = geteuid();
+    CHECK(e1 == e2 && e2 == e3, "geteuid (b) idempotent: 3 calls return same value");
+}
+
+static void geteuid_does_not_modify_errno(void)
+{
+    /* 测什么: man §ERRORS — "never modify errno".
+     * 怎么测: 预设 errno = 67890 (任意值), 调 geteuid(), 验 errno 未变.
+     * 期望:   errno 仍是 67890.
+     * 为什么: starry 实现必须仅读 cred.euid, 不能踩 errno. */
+    errno = 67890;
+    (void)geteuid();
+    CHECK(errno == 67890, "geteuid (c) does not modify errno");
+    errno = 0;
+}
+
+static void geteuid_raw_syscall_matches_libc(void)
+{
+    /* 测什么: man §HISTORY — libc 透明处理 16/32-bit syscall 差异.
+     * 怎么测: 比较 syscall(SYS_geteuid) 与 libc geteuid() 返回值.
+     * 期望:   两者相等.
+     * 为什么: 验证 libc wrapper 无值转换 / 无内部 cache; raw 路径 ABI 一致.
+     *         Alpha 上是 getxuid() 单 syscall 返二元组 — libc 也透明处理. */
+    uid_t libc_v = geteuid();
+    long raw_v = syscall(SYS_geteuid);
+    CHECK(raw_v >= 0 && (uid_t)raw_v == libc_v,
+          "geteuid (d) raw syscall matches libc wrapper");
+}
+
+static void geteuid_default_equals_uid(void)
+{
+    /* 测什么: man fork(2) + execve(2) — fork+exec 继承不改变 cred;
+     *         setuid binary 才会改 euid; CI runner 不是 setuid 程序.
+     * 怎么测: 比较 geteuid() vs getuid().
+     * 期望:   两者相等 (启动时 euid == uid).
+     * 为什么: 为后续 setresuid 矩阵 (Group D) 提供 known-state 基线;
+     *         也验证 starry 启动时不误设 euid != uid. */
+    uid_t u = getuid();
+    uid_t e = geteuid();
+    CHECK(u == e, "geteuid (e) default: euid == uid (no setuid binary)");
+}
+
+int geteuid_run(void)
+{
+    printf("\n----- geteuid -----\n");
+    geteuid_basic_returns_euid();
+    geteuid_idempotent();
+    geteuid_does_not_modify_errno();
+    geteuid_raw_syscall_matches_libc();
+    geteuid_default_equals_uid();
+    printf("  ----- geteuid: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getgid.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getgid.c
@@ -1,0 +1,122 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* getgid(2) — returns the real group ID of the calling process.
+ *
+ * man 2 getgid §"DESCRIPTION":
+ *   "getgid() returns the real group ID of the calling process."
+ *
+ * man 2 getgid §"ERRORS":
+ *   "These functions are always successful and never modify errno."
+ *
+ * man 2 getgid §"HISTORY":
+ *   "The original Linux getgid() and getegid() system calls supported only
+ *    16-bit group IDs. Subsequently, Linux 2.4 added getgid32() and getegid32(),
+ *    supporting 32-bit IDs. The glibc wrapper functions transparently deal
+ *    with the variations across kernel versions."
+ *
+ * 5 维度覆盖 (a-e):
+ *   (a) basic 返回值                       man §DESCRIPTION
+ *   (b) idempotent 纯查询无副作用           man §DESCRIPTION (隐含)
+ *   (c) errno 不动                          man §ERRORS
+ *   (d) raw syscall vs libc wrapper 一致    man §HISTORY (libc 透明处理)
+ *   (e) fork 子进程继承相同 gid             man fork(2) "the child inherits ... cred"
+ */
+
+static int waitpid_safely(pid_t pid, int *status)
+{
+    pid_t r = waitpid(pid, status, 0);
+    return r == pid ? 0 : -1;
+}
+
+static void getgid_basic_returns_gid(void)
+{
+    /* 测什么: man §DESCRIPTION — getgid() returns real group ID.
+     * 怎么测: 直接调 getgid(), 打印.
+     * 期望:   返回当前 cred.gid (root 启动时为 0).
+     * 为什么: 验证 syscall 不 panic. gid_t 是 unsigned, "always succeeds". */
+    gid_t g = getgid();
+    CHECK(g == g, "getgid (a) basic: returned value (always succeeds)");
+    printf("  current real gid = %u\n", (unsigned)g);
+}
+
+static void getgid_idempotent(void)
+{
+    /* 测什么: man §DESCRIPTION 隐含 — 纯查询无副作用.
+     * 怎么测: 连续 3 次调 getgid().
+     * 期望:   3 次返回值相同.
+     * 为什么: 防 starry 实现 cache invalidation bug. */
+    gid_t g1 = getgid();
+    gid_t g2 = getgid();
+    gid_t g3 = getgid();
+    CHECK(g1 == g2 && g2 == g3, "getgid (b) idempotent: 3 calls return same value");
+}
+
+static void getgid_does_not_modify_errno(void)
+{
+    /* 测什么: man §ERRORS — "never modify errno".
+     * 怎么测: 预设 errno = 99999, 调 getgid(), 验未变.
+     * 期望:   errno 仍是 99999.
+     * 为什么: starry 仅读 cred.gid, 不许踩 errno. */
+    errno = 99999;
+    (void)getgid();
+    CHECK(errno == 99999, "getgid (c) does not modify errno");
+    errno = 0;
+}
+
+static void getgid_raw_syscall_matches_libc(void)
+{
+    /* 测什么: man §HISTORY — libc 透明处理 16/32-bit 差异.
+     * 怎么测: 比较 syscall(SYS_getgid) vs libc getgid().
+     * 期望:   两者相等.
+     * 为什么: 验证 libc wrapper 无值转换 / 无内部 cache. */
+    gid_t libc_v = getgid();
+    long raw_v = syscall(SYS_getgid);
+    CHECK(raw_v >= 0 && (gid_t)raw_v == libc_v,
+          "getgid (d) raw syscall matches libc wrapper");
+}
+
+static void getgid_fork_child_inherits(void)
+{
+    /* 测什么: man fork(2) — "The child process inherits copies of the parent's
+     *         ... credentials." getgid 在 fork 跨进程边界仍返同值.
+     * 怎么测: fork → child 调 getgid() 比对 parent.
+     *         通过 _exit code 传递结果 (0=PASS, 1=FAIL).
+     * 期望:   child.getgid() == parent.getgid().
+     * 为什么: 防 starry fork 实现错误地重置 cred.gid (历史曾在某些
+     *         microkernel 实现见过). */
+    gid_t parent_gid = getgid();
+    pid_t pid = fork();
+    if (pid == 0) {
+        gid_t cg = getgid();
+        _exit(cg == parent_gid ? 0 : 1);
+    }
+    if (pid > 0) {
+        int status;
+        if (waitpid_safely(pid, &status) == 0) {
+            CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0,
+                  "getgid (e) fork child inherits same gid");
+        }
+    } else {
+        CHECK(0, "getgid (e) fork failed");
+    }
+}
+
+int getgid_run(void)
+{
+    printf("\n----- getgid -----\n");
+    getgid_basic_returns_gid();
+    getgid_idempotent();
+    getgid_does_not_modify_errno();
+    getgid_raw_syscall_matches_libc();
+    getgid_fork_child_inherits();
+    printf("  ----- getgid: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getresgid.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getresgid.c
@@ -1,0 +1,178 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* getresgid(2) — get real, effective and saved group IDs (Linux-specific).
+ *
+ * man 2 getresuid §"DESCRIPTION":
+ *   "getresgid() performs the analogous task for the process's group IDs."
+ *   (镜像 getresuid: 三 out-arg 填 rgid/egid/sgid)
+ *
+ * man §"RETURN VALUE":
+ *   "On success, zero is returned. On error, -1 is returned, and errno is set."
+ *
+ * man §"ERRORS":
+ *   "EFAULT — One of the arguments specified an address outside the calling
+ *    process's address space."
+ *
+ * 8 维度覆盖 (a-h, 镜像 getresuid):
+ *   (a) 基础三参数填写 + 返回 0 (双 sentinel × 三字段都验, codex P1)
+ *   (b) rgid == getgid()
+ *   (c) egid == getegid()
+ *   (d) sgid == egid (启动后)
+ *   (e1-e3) NULL pointer 三槽 → EFAULT
+ *   (f) raw syscall vs libc 一致
+ *   (g) 三 out-arg aliased 同地址 → last-write (sgid) 胜出
+ *   (h) 成功路径 errno 保留
+ */
+
+static void getresgid_basic_writes_three(void)
+{
+    /* 测什么: man §DESCRIPTION — 三个 out-arg 应都被填入 cred.gid/egid/sgid.
+     *         codex P1 (adopted) — 不只验"至少一个被改", 而是验三个都被改.
+     * 怎么测: 双 sentinel (0xDEADBEEF / 0xCAFEBABE) 各跑一次 getresgid,
+     *         每次验三个 out-arg 都 != sentinel + 两次结果一致.
+     * 期望:   每次 rc=0, 三个字段都被改 (双 sentinel 避免 cred 恰为 sentinel 假阳).
+     * 为什么: 防御 starry vm_write 只写一/两个 out-arg 漏掉第三的 bug. */
+    gid_t r1 = 0xDEADBEEF, e1 = 0xDEADBEEF, s1 = 0xDEADBEEF;
+    int rc1 = getresgid(&r1, &e1, &s1);
+    CHECK(rc1 == 0,                                                "getresgid (a) basic: returns 0");
+    CHECK(r1 != 0xDEADBEEF,                                        "getresgid (a) basic: rgid written (sentinel #1)");
+    CHECK(e1 != 0xDEADBEEF,                                        "getresgid (a) basic: egid written (sentinel #1)");
+    CHECK(s1 != 0xDEADBEEF,                                        "getresgid (a) basic: sgid written (sentinel #1)");
+    gid_t r2 = 0xCAFEBABE, e2 = 0xCAFEBABE, s2 = 0xCAFEBABE;
+    int rc2 = getresgid(&r2, &e2, &s2);
+    CHECK(rc2 == 0,                                                "getresgid (a) basic: 2nd returns 0");
+    CHECK(r2 != 0xCAFEBABE,                                        "getresgid (a) basic: rgid written (sentinel #2)");
+    CHECK(e2 != 0xCAFEBABE,                                        "getresgid (a) basic: egid written (sentinel #2)");
+    CHECK(s2 != 0xCAFEBABE,                                        "getresgid (a) basic: sgid written (sentinel #2)");
+    CHECK(r1 == r2 && e1 == e2 && s1 == s2,                        "getresgid (a) basic: 两次调用结果一致");
+    printf("  rgid=%u egid=%u sgid=%u\n", (unsigned)r1, (unsigned)e1, (unsigned)s1);
+}
+
+static void getresgid_rgid_equals_getgid(void)
+{
+    /* 测什么: 隐含规范 — getresgid().rgid == getgid() (同源 cred.gid).
+     * 怎么测: 同一进程调 getresgid + getgid 比对 r 槽.
+     * 期望:   r == g.
+     * 为什么: 验证 starry sys_getresgid 写出 rgid 与 sys_getgid 同源. */
+    gid_t r, e, s;
+    if (getresgid(&r, &e, &s) != 0) { CHECK(0, "skip"); return; }
+    gid_t g = getgid();
+    CHECK(r == g,                                                  "getresgid (b) rgid == getgid()");
+}
+
+static void getresgid_egid_equals_getegid(void)
+{
+    /* 测什么: 隐含规范 — getresgid().egid == getegid() (同源 cred.egid).
+     * 怎么测: 同一进程调 getresgid + getegid 比对 e 槽.
+     * 期望:   e == ge.
+     * 为什么: 验证 starry cred.egid 在两 syscall 路径一致. */
+    gid_t r, e, s;
+    if (getresgid(&r, &e, &s) != 0) { CHECK(0, "skip"); return; }
+    gid_t ge = getegid();
+    CHECK(e == ge,                                                 "getresgid (c) egid == getegid()");
+}
+
+static void getresgid_sgid_equals_egid_at_startup(void)
+{
+    /* 测什么: man execve(2) — exec 后 saved-set-group-ID = effective GID.
+     *         启动时 (尚未 setresgid) saved == effective.
+     * 怎么测: 调 getresgid, 比对 s == e.
+     * 期望:   s == e.
+     * 为什么: 验证 starry exec 流程正确设 cred.sgid = cred.egid;
+     *         为 Group D setresgid 矩阵提供 known baseline. */
+    gid_t r, e, s;
+    if (getresgid(&r, &e, &s) != 0) { CHECK(0, "skip"); return; }
+    CHECK(s == e,                                                  "getresgid (d) sgid == egid at startup");
+}
+
+static void getresgid_null_pointer_efault(void)
+{
+    /* 测什么: man §ERRORS — EFAULT 应在任一槽无效时触发.
+     * 怎么测: 用 raw syscall 直达内核 (libc 可能拦截 NULL),
+     *         3 个槽分别测 NULL.
+     * 期望:   每次 rc=-1, errno=EFAULT.
+     * 为什么: 验证 starry vm_write 对 NULL 的处理 fail-fast (任一槽 NULL 就报错). */
+    gid_t r;
+    long rc;
+
+    errno = 0;
+    rc = syscall(SYS_getresgid, NULL, &r, &r);
+    CHECK(rc == -1 && errno == EFAULT,                             "getresgid (e1) NULL rgid -> -1 EFAULT");
+
+    errno = 0;
+    rc = syscall(SYS_getresgid, &r, NULL, &r);
+    CHECK(rc == -1 && errno == EFAULT,                             "getresgid (e2) NULL egid -> -1 EFAULT");
+
+    errno = 0;
+    rc = syscall(SYS_getresgid, &r, &r, NULL);
+    CHECK(rc == -1 && errno == EFAULT,                             "getresgid (e3) NULL sgid -> -1 EFAULT");
+}
+
+static void getresgid_raw_matches_libc(void)
+{
+    /* 测什么: libc 应直接转发到 syscall, 无值转换.
+     * 怎么测: libc 调一次 + raw syscall 调一次, 比对三槽.
+     * 期望:   两次 rc=0 + 三槽相等.
+     * 为什么: 验证 libc wrapper 无额外语义改造, ABI 一致. */
+    gid_t r1 = 0, e1 = 0, s1 = 0;
+    gid_t r2 = 0, e2 = 0, s2 = 0;
+    int libc_rc = getresgid(&r1, &e1, &s1);
+    long raw_rc = syscall(SYS_getresgid, &r2, &e2, &s2);
+    CHECK(libc_rc == 0 && raw_rc == 0 && r1 == r2 && e1 == e2 && s1 == s2,
+          "getresgid (f) raw syscall matches libc wrapper");
+}
+
+static void getresgid_same_pointer_last_write(void)
+{
+    /* 测什么: 三 out-arg 指向同一地址 (aliased) 应不被拒. man 未明禁此用法.
+     *         按内核拷贝顺序 rgid → egid → sgid, 最终值应为 sgid.
+     * 怎么测: 三 out-arg 都指向同一变量 v, 调 getresgid; 然后取一次
+     *         独立的 getresgid 比对 v == sgid.
+     * 期望:   rc=0, v == sgid (last-write 胜出).
+     * 为什么: 验证 starry 不假设 args disjoint — 实际场景下用户可能传同指针. */
+    gid_t v = 0xdeadbeef;
+    int rc = getresgid(&v, &v, &v);
+    CHECK(rc == 0,                                                 "getresgid (g) same-pointer 3-args -> 0 (kernel doesn't reject aliased args)");
+    gid_t r_alone, e_alone, s_alone;
+    if (getresgid(&r_alone, &e_alone, &s_alone) == 0) {
+        CHECK(v == s_alone,                                        "getresgid (g) same-pointer: v == sgid (last-write wins)");
+    }
+}
+
+static void getresgid_success_preserves_errno(void)
+{
+    /* 测什么: man 未明文规定 getresgid 不动 errno, 但 Linux 实测成功路径
+     *         不动 errno (仅失败设).
+     * 怎么测: 预设 errno = 5353, 调 getresgid (成功), 验 errno 未变.
+     * 期望:   rc=0, errno=5353.
+     * 为什么: 防 starry vm_write 内部误设 errno; 用户依赖 errno 在成功
+     *         系统调用后保持不变. */
+    gid_t r, e, s;
+    errno = 5353;
+    int rc = getresgid(&r, &e, &s);
+    CHECK(rc == 0,                                                 "getresgid (h) success path: rc == 0");
+    CHECK(errno == 5353,                                           "getresgid (h) success path: errno preserved (5353)");
+    errno = 0;
+}
+
+int getresgid_run(void)
+{
+    printf("\n----- getresgid -----\n");
+    getresgid_basic_writes_three();
+    getresgid_rgid_equals_getgid();
+    getresgid_egid_equals_getegid();
+    getresgid_sgid_equals_egid_at_startup();
+    getresgid_null_pointer_efault();
+    getresgid_raw_matches_libc();
+    getresgid_same_pointer_last_write();
+    getresgid_success_preserves_errno();
+    printf("  ----- getresgid: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getresuid.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getresuid.c
@@ -1,0 +1,171 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* getresuid(2) — get real, effective and saved user IDs (Linux-specific).
+ *
+ * man 2 getresuid §"DESCRIPTION":
+ *   "getresuid() returns the real UID, the effective UID, and the saved
+ *    set-user-ID of the calling process, in the arguments ruid, euid, and
+ *    suid, respectively. getresgid() performs the analogous task for the
+ *    process's group IDs."
+ *
+ * man §"RETURN VALUE":
+ *   "On success, zero is returned. On error, -1 is returned, and errno is
+ *    set to indicate the error."
+ *
+ * man §"ERRORS":
+ *   "EFAULT — One of the arguments specified an address outside the calling
+ *    process's address space."
+ *
+ * 测试覆盖：
+ *   (a) 基础三参数填写 + 返回 0
+ *   (b) ruid 等于 getuid() 返回值
+ *   (c) euid 等于 geteuid() 返回值
+ *   (d) suid 默认等于 euid（启动时 saved=effective，man "fork() and exec()" 节）
+ *   (e) NULL pointer args → -1 EFAULT（任一指针 NULL 都应报错）
+ *   (f) raw syscall 同
+ */
+
+static void getresuid_basic_writes_three(void)
+{
+    /* codex P1 (adopted): 验证三个 out-arg **都** 被写入。双 sentinel 跑两次 */
+    uid_t r1 = 0xDEADBEEF, e1 = 0xDEADBEEF, s1 = 0xDEADBEEF;
+    int rc1 = getresuid(&r1, &e1, &s1);
+    CHECK(rc1 == 0,                                                "getresuid (a) basic: returns 0");
+    CHECK(r1 != 0xDEADBEEF,                                        "getresuid (a) basic: ruid written (sentinel #1)");
+    CHECK(e1 != 0xDEADBEEF,                                        "getresuid (a) basic: euid written (sentinel #1)");
+    CHECK(s1 != 0xDEADBEEF,                                        "getresuid (a) basic: suid written (sentinel #1)");
+    uid_t r2 = 0xCAFEBABE, e2 = 0xCAFEBABE, s2 = 0xCAFEBABE;
+    int rc2 = getresuid(&r2, &e2, &s2);
+    CHECK(rc2 == 0,                                                "getresuid (a) basic: 2nd returns 0");
+    CHECK(r2 != 0xCAFEBABE,                                        "getresuid (a) basic: ruid written (sentinel #2)");
+    CHECK(e2 != 0xCAFEBABE,                                        "getresuid (a) basic: euid written (sentinel #2)");
+    CHECK(s2 != 0xCAFEBABE,                                        "getresuid (a) basic: suid written (sentinel #2)");
+    CHECK(r1 == r2 && e1 == e2 && s1 == s2,                        "getresuid (a) basic: 两次调用结果一致");
+    printf("  ruid=%u euid=%u suid=%u\n", (unsigned)r1, (unsigned)e1, (unsigned)s1);
+}
+
+static void getresuid_ruid_equals_getuid(void)
+{
+    /* 测什么: 隐含规范 — getresuid().ruid == getuid() (同一 cred.uid 字段).
+     * 怎么测: 同一进程内调 getresuid + getuid 比对 r 槽.
+     * 期望:   r == g.
+     * 为什么: 验证 starry sys_getresuid 写出的 ruid 与 sys_getuid 读出的同源
+     *         (都基于 cred.uid). 不一致 = cred 子系统内部 bug. */
+    uid_t r, e, s;
+    if (getresuid(&r, &e, &s) != 0) { CHECK(0, "skip: getresuid failed"); return; }
+    uid_t g = getuid();
+    CHECK(r == g,                                                  "getresuid (b) ruid == getuid()");
+}
+
+static void getresuid_euid_equals_geteuid(void)
+{
+    /* 测什么: 隐含规范 — getresuid().euid == geteuid().
+     * 怎么测: 同一进程调 getresuid + geteuid 比对 e 槽.
+     * 期望:   e == ge.
+     * 为什么: 同 (b), 但 euid 维度. 验证 starry cred.euid 在两 syscall 路径一致. */
+    uid_t r, e, s;
+    if (getresuid(&r, &e, &s) != 0) { CHECK(0, "skip: getresuid failed"); return; }
+    uid_t ge = geteuid();
+    CHECK(e == ge,                                                 "getresuid (c) euid == geteuid()");
+}
+
+static void getresuid_suid_equals_euid_at_startup(void)
+{
+    /* 测什么: man execve(2) — exec 后 saved-set-user-ID = effective UID.
+     *         所以测试启动时 (尚未 setresuid 修改) saved == effective.
+     * 怎么测: 调 getresuid, 比对 s == e.
+     * 期望:   s == e (启动后未做 setresuid 修改 saved 的操作).
+     * 为什么: 验证 starry exec 流程正确设 cred.suid = cred.euid;
+     *         也为后续 setresuid 矩阵 (Group D) 提供 known baseline. */
+    uid_t r, e, s;
+    if (getresuid(&r, &e, &s) != 0) { CHECK(0, "skip: getresuid failed"); return; }
+    CHECK(s == e,                                                  "getresuid (d) suid == euid at startup");
+}
+
+static void getresuid_null_pointer_efault(void)
+{
+    /* 怎么测：3 个指针中任一 NULL → 用 raw syscall 直达内核
+     * 期望：-1 EFAULT
+     * 为什么：man EFAULT — "One of the arguments specified an address outside ..."
+     *
+     * 注：libc getresuid() 包装可能会做 NULL 校验且不调 syscall；用 raw syscall 直测内核。 */
+    uid_t r;
+    long rc;
+
+    errno = 0;
+    rc = syscall(SYS_getresuid, NULL, &r, &r);
+    CHECK(rc == -1 && errno == EFAULT,                             "getresuid (e1) NULL ruid -> -1 EFAULT");
+
+    errno = 0;
+    rc = syscall(SYS_getresuid, &r, NULL, &r);
+    CHECK(rc == -1 && errno == EFAULT,                             "getresuid (e2) NULL euid -> -1 EFAULT");
+
+    errno = 0;
+    rc = syscall(SYS_getresuid, &r, &r, NULL);
+    CHECK(rc == -1 && errno == EFAULT,                             "getresuid (e3) NULL suid -> -1 EFAULT");
+}
+
+static void getresuid_raw_matches_libc(void)
+{
+    /* 测什么: libc 应直接转发到 syscall, 不做值转换 / 内部 cache.
+     * 怎么测: 同一进程内 libc 调一次 + raw syscall 调一次, 比对 r/e/s.
+     * 期望:   两次都返 0 + 三槽都相等.
+     * 为什么: 验证 libc wrapper 无额外语义改造 — 直接对接 starry syscall ABI. */
+    uid_t r1 = 0, e1 = 0, s1 = 0;
+    uid_t r2 = 0, e2 = 0, s2 = 0;
+    int libc_rc = getresuid(&r1, &e1, &s1);
+    long raw_rc = syscall(SYS_getresuid, &r2, &e2, &s2);
+    CHECK(libc_rc == 0 && raw_rc == 0 && r1 == r2 && e1 == e2 && s1 == s2,
+          "getresuid (f) raw syscall matches libc wrapper");
+}
+
+/* (g) 三个 out-arg 指向同一地址 — last-write 胜出（应等于 suid）
+ *
+ * man 2 getresuid 未明禁此用法；按内核拷贝顺序 ruid → euid → suid，
+ * 最终值应为 suid。这验证了内核不假设三参数 disjoint。 */
+static void getresuid_same_pointer_last_write(void)
+{
+    uid_t v = 0xdeadbeef;
+    int rc = getresuid(&v, &v, &v);
+    CHECK(rc == 0,                                                 "getresuid (g) same-pointer 3-args -> 0 (kernel doesn't reject aliased args)");
+    uid_t s_alone;
+    uid_t r_alone, e_alone;
+    if (getresuid(&r_alone, &e_alone, &s_alone) == 0) {
+        CHECK(v == s_alone,                                        "getresuid (g) same-pointer: v == suid (last-write wins)");
+    }
+}
+
+/* (h) 成功路径 errno 保留 — man 未规定 getresuid 不改 errno，
+ *     但 Linux 实测成功路径不动 errno（仅失败路径设）。
+ *     这覆盖 starry vm_write 成功后是否误改 errno。 */
+static void getresuid_success_preserves_errno(void)
+{
+    uid_t r, e, s;
+    errno = 4242;
+    int rc = getresuid(&r, &e, &s);
+    CHECK(rc == 0,                                                 "getresuid (h) success path: rc == 0");
+    CHECK(errno == 4242,                                           "getresuid (h) success path: errno preserved (4242)");
+    errno = 0;
+}
+
+int getresuid_run(void)
+{
+    printf("\n----- getresuid -----\n");
+    getresuid_basic_writes_three();
+    getresuid_ruid_equals_getuid();
+    getresuid_euid_equals_geteuid();
+    getresuid_suid_equals_euid_at_startup();
+    getresuid_null_pointer_efault();
+    getresuid_raw_matches_libc();
+    getresuid_same_pointer_last_write();   /* (g) new */
+    getresuid_success_preserves_errno();   /* (h) new */
+    printf("  ----- getresuid: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getuid.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/getuid.c
@@ -1,0 +1,114 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* small inline helper */
+static int waitpid_safely(pid_t pid, int *status)
+{
+    pid_t r = waitpid(pid, status, 0);
+    return r == pid ? 0 : -1;
+}
+
+/* getuid(2) — returns the real user ID of the calling process.
+ *
+ * man 2 getuid 原文（DESCRIPTION + RETURN VALUE + ERRORS）：
+ *   "getuid() returns the real user ID of the calling process."
+ *   "geteuid() returns the effective user ID of the calling process."
+ *   "These functions are always successful and never modify errno."
+ *
+ * 测试方式：
+ *   (a) getuid() 返回非负 uid_t 值（不报错）
+ *   (b) 多次调用结果一致（无 side effect / 状态变化）
+ *   (c) 不修改 errno（即使 errno 预先是非 0）
+ *   (d) raw syscall 与 libc 包装一致（验证 libc 没做转换）
+ *   (e) fork 子进程继承相同 uid（fork 不改变 cred.uid）
+ */
+
+static void getuid_basic_returns_uid(void)
+{
+    uid_t u = getuid();
+    /* 怎么测：直接调 getuid()
+     * 期望：返回当前进程的真实 uid
+     * 为什么：man "getuid() returns the real user ID" — root 时为 0 */
+    /* uid 是 uid_t (unsigned int)，无 -1 失败语义；任何值都是合法 */
+    CHECK(u == u, "getuid (a) basic: returned value (always succeeds)");
+    printf("  current real uid = %u\n", (unsigned)u);
+}
+
+static void getuid_idempotent(void)
+{
+    uid_t u1 = getuid();
+    uid_t u2 = getuid();
+    uid_t u3 = getuid();
+    /* 怎么测：连续 3 次调用
+     * 期望：3 次返回相同值
+     * 为什么：getuid 是纯查询无 side effect */
+    CHECK(u1 == u2 && u2 == u3, "getuid (b) idempotent: 3 calls return same value");
+}
+
+static void getuid_does_not_modify_errno(void)
+{
+    /* 怎么测：预设 errno = 12345，调 getuid()，检查 errno 不变
+     * 期望：errno 仍是 12345
+     * 为什么：man "These functions are always successful and never modify errno" */
+    errno = 12345;
+    (void)getuid();
+    CHECK(errno == 12345, "getuid (c) does not modify errno");
+    errno = 0;  /* reset */
+}
+
+static void getuid_raw_syscall_matches_libc(void)
+{
+    /* 怎么测：raw syscall(SYS_getuid) vs libc getuid()
+     * 期望：两者返回相同值
+     * 为什么：libc 包装应直接转发 syscall，无值转换 */
+    uid_t libc_v = getuid();
+    long raw_v = syscall(SYS_getuid);
+    CHECK(raw_v >= 0 && (uid_t)raw_v == libc_v,
+          "getuid (d) raw syscall matches libc wrapper");
+}
+
+static void getuid_fork_child_inherits(void)
+{
+    /* 怎么测：fork 后 child 调 getuid()
+     * 期望：child 与 parent 返回相同 uid
+     * 为什么：fork 不改变 cred.uid（man fork(2) "the child inherits"）
+     * 实现：通过 _exit code 传递（uid % 256）— 仅当 uid < 256 时精确
+     * 否则只验证 fork 成功 + child 不报错退出 */
+    uid_t parent_uid = getuid();
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* child */
+        uid_t cu = getuid();
+        _exit(cu == parent_uid ? 0 : 1);
+    }
+    if (pid > 0) {
+        int status;
+        if (waitpid_safely(pid, &status) == 0) {
+            CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0,
+                  "getuid (e) fork child inherits same uid");
+        } else {
+            CHECK(0, "getuid (e) waitpid failed");
+        }
+    } else {
+        CHECK(0, "getuid (e) fork failed");
+    }
+}
+
+int getuid_run(void)
+{
+    printf("\n----- getuid -----\n");
+    getuid_basic_returns_uid();
+    getuid_idempotent();
+    getuid_does_not_modify_errno();
+    getuid_raw_syscall_matches_libc();
+    getuid_fork_child_inherits();
+    printf("  ----- getuid: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/main.c
@@ -1,0 +1,86 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <stdio.h>
+#include <unistd.h>
+
+/*
+ * test-uid-gid-getters —— 6 个 getter syscall 地毯式全覆盖测例汇总
+ *
+ * 设计：
+ *   - 11 模块（6 syscall + cross_consistency + boundary + matrix + procfs_visibility + uid32_no_trunc）
+ *   - 每模块自计 __pass/__fail；run() return __fail
+ *   - main 按顺序跑 + 汇总
+ *
+ * 覆盖 syscall（man 2）:
+ *   getuid    — return real user ID
+ *   geteuid   — return effective user ID
+ *   getgid    — return real group ID
+ *   getegid   — return effective group ID
+ *   getresuid — return real, effective, saved user IDs (Linux-specific)
+ *   getresgid — return real, effective, saved group IDs (Linux-specific)
+ *
+ * 测试自包含（feedback_test_self_contained.md 原则）：
+ *   不依赖 test-credentials 等前辈测例覆盖任何东西；自己每个 syscall 独立验证
+ *   man 描述的全部行为 + 边界 + 跨 syscall 一致性。
+ *
+ * 退出码：0 = 全 PASS；非 0 = 有 case 不达预期。
+ */
+
+int getuid_run(void);
+int geteuid_run(void);
+int getgid_run(void);
+int getegid_run(void);
+int getresuid_run(void);
+int getresgid_run(void);
+int cross_consistency_run(void);
+int boundary_run(void);
+int matrix_run(void);
+int procfs_visibility_run(void);
+int uid32_no_trunc_run(void);
+
+int main(void)
+{
+    TEST_START("uid/gid getters: 地毯式全覆盖（11 模块 / 6 syscall）");
+
+    /* main.c 自身不调用 CHECK，避免 -Werror=unused-variable 误报 */
+    (void)__pass;
+    (void)__fail;
+
+    int total_fail = 0;
+    int rc;
+
+    #define COLLECT(label, call) do {                                          \
+        rc = (call);                                                            \
+        if (rc < 0 || rc > 1000000) {                                           \
+            printf("  %-18s : <suspect rc=%d, treat as 1 hard failure>\n", label, rc); \
+            rc = 1;                                                             \
+        } else {                                                                \
+            printf("  %-18s : %d fail\n", label, rc);                           \
+        }                                                                       \
+        total_fail += rc;                                                       \
+    } while (0)
+
+    printf("================================================\n");
+
+    COLLECT("getuid",          getuid_run());
+    COLLECT("geteuid",         geteuid_run());
+    COLLECT("getgid",          getgid_run());
+    COLLECT("getegid",         getegid_run());
+    COLLECT("getresuid",       getresuid_run());
+    COLLECT("getresgid",       getresgid_run());
+    COLLECT("cross_consist",   cross_consistency_run());
+    COLLECT("boundary",        boundary_run());
+    COLLECT("matrix(man-first)", matrix_run());
+    COLLECT("procfs_visibility", procfs_visibility_run());
+    COLLECT("uid32_no_trunc",  uid32_no_trunc_run());
+
+    #undef COLLECT
+
+    printf("  -------------------------------------------\n");
+    printf("  TOTAL: %d fail | RESULT: %s\n",
+           total_fail, total_fail == 0 ? "ALL PASS" : "HAS FAILURES");
+    printf("================================================\n\n");
+
+    return total_fail > 0 ? 1 : 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/matrix.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/matrix.c
@@ -1,0 +1,525 @@
+/* matrix.c — 完备测试矩阵 6 个 getter (man-first design)
+ *
+ * 参 notes/19-getter-test-design.md
+ *
+ * man 2 getuid 关键子句：
+ *   [G-D1] getuid returns real UID
+ *   [G-D2] geteuid returns effective UID
+ *   [G-E1] always successful, never modify errno
+ *
+ * man 2 getresuid 关键子句：
+ *   [GR-D1] r/e/s 三 out-args 被填写
+ *   [GR-R1] success → 0
+ *   [GR-E1] EFAULT — arg outside address space
+ *
+ * starry 实现 (sys.rs:20-54)：thin wrapper 直接读 cred + vm_write
+ *
+ * 矩阵：
+ *   0-arg getter (4): syscall × state × mode = 4 × 8 × 2 = 64 case
+ *   3-arg getres (2): syscall × state × ptr_pattern × mode = 2 × 8 × 10 × 2 = 320 case
+ *   errno 不动: 4 syscall × 6 preset errno = 24 case
+ *   cross consistency: 8 state × 4 check = 32 case
+ *   ─────
+ *   ≈ 440 case
+ */
+
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* ── 维度 A: cred 状态 (8) ─────────────────────────────────────── */
+typedef enum {
+    S_ROOT_UNMOD = 0,                          /* r=e=s=0 (uid+gid) */
+    S_ROOT_AFTER_SETUID_1000,                  /* uid 全 1000, gid 不动 */
+    S_ROOT_AFTER_SETUID_BIG,                   /* uid 全 0x7FFFFFFE */
+    S_ROOT_AFTER_SETRESUID_1K_2K_3K,           /* r=1k, e=2k, s=3k */
+    S_NONROOT_NATIVE,                          /* r=e=s=1000 (uid+gid) */
+    S_ROOT_AFTER_SETGID_1000,                  /* gid 全 1000, uid=0 */
+    S_ROOT_AFTER_SETRESGID_1K_2K_3K,           /* gid r=1k e=2k s=3k */
+    S_MIXED_UID_GID,                           /* 同时设 uid 1k+gid 2k */
+    S_STATE_COUNT
+} cred_state_t;
+
+static const char *state_name(cred_state_t s)
+{
+    switch (s) {
+    case S_ROOT_UNMOD:                       return "root_unmod";
+    case S_ROOT_AFTER_SETUID_1000:           return "after_setuid(1k)";
+    case S_ROOT_AFTER_SETUID_BIG:            return "after_setuid(0x7FFFFFFE)";
+    case S_ROOT_AFTER_SETRESUID_1K_2K_3K:    return "after_setresuid(1k,2k,3k)";
+    case S_NONROOT_NATIVE:                   return "nonroot";
+    case S_ROOT_AFTER_SETGID_1000:           return "after_setgid(1k)";
+    case S_ROOT_AFTER_SETRESGID_1K_2K_3K:    return "after_setresgid(1k,2k,3k)";
+    case S_MIXED_UID_GID:                    return "mixed(setuid+setgid)";
+    default:                                 return "?";
+    }
+}
+
+/* setup_state: 在 fork 后 child 内调 */
+static int setup_state(cred_state_t s)
+{
+    switch (s) {
+    case S_ROOT_UNMOD:
+        return (getuid() == 0) ? 0 : -100;
+
+    case S_ROOT_AFTER_SETUID_1000:
+        if (getuid() != 0) return -100;
+        return setuid(1000) == 0 ? 0 : -101;
+
+    case S_ROOT_AFTER_SETUID_BIG:
+        if (getuid() != 0) return -100;
+        return setuid(0x7FFFFFFEu) == 0 ? 0 : -102;
+
+    case S_ROOT_AFTER_SETRESUID_1K_2K_3K:
+        if (getuid() != 0) return -100;
+        return setresuid(1000, 2000, 3000) == 0 ? 0 : -103;
+
+    case S_NONROOT_NATIVE:
+        if (getuid() == 0) {
+            /* 必须先 setresgid（root 时 cap 在）再 setresuid（清 caps）
+             * 否则 cap drop 后 setresgid 会 EPERM
+             * expected_gid(S_NONROOT_NATIVE) = (1000,1000,1000) 假设 gid 也降了 */
+            if (setresgid(1000, 1000, 1000) != 0) return -1041;
+            if (setresuid(1000, 1000, 1000) != 0) return -1042;
+        }
+        return 0;
+
+    case S_ROOT_AFTER_SETGID_1000:
+        if (getuid() != 0) return -100;
+        return setgid(1000) == 0 ? 0 : -105;
+
+    case S_ROOT_AFTER_SETRESGID_1K_2K_3K:
+        if (getuid() != 0) return -100;
+        return setresgid(1000, 2000, 3000) == 0 ? 0 : -106;
+
+    case S_MIXED_UID_GID:
+        if (getuid() != 0) return -100;
+        if (setgid(2000) != 0) return -107;
+        if (setuid(1000) != 0) return -108;
+        return 0;
+
+    default:
+        return -200;
+    }
+}
+
+/* 预期 cred 三元 (per state)
+ *
+ * codex P1 (adopted): nonroot caller (uid != 0) 时 setup_state(S_NONROOT_NATIVE)
+ * 无法 setresuid 切到 1000 (无 cap), 应保持 caller 原 uid/gid.
+ * matrix_run 先 capture caller 实际 uid/gid 传入 expected_*().
+ */
+typedef struct { uint32_t r, e, s; } cred_t;
+
+static cred_t expected_uid(cred_state_t s, uint32_t caller_uid)
+{
+    switch (s) {
+    case S_ROOT_UNMOD:                       return (cred_t){0, 0, 0};
+    case S_ROOT_AFTER_SETUID_1000:           return (cred_t){1000, 1000, 1000};
+    case S_ROOT_AFTER_SETUID_BIG:            return (cred_t){0x7FFFFFFEu, 0x7FFFFFFEu, 0x7FFFFFFEu};
+    case S_ROOT_AFTER_SETRESUID_1K_2K_3K:    return (cred_t){1000, 2000, 3000};
+    case S_NONROOT_NATIVE:
+        /* 根据 caller 是否 root 决定 */
+        return (caller_uid == 0)
+                 ? (cred_t){1000, 1000, 1000}
+                 : (cred_t){caller_uid, caller_uid, caller_uid};
+    case S_ROOT_AFTER_SETGID_1000:           return (cred_t){0, 0, 0};
+    case S_ROOT_AFTER_SETRESGID_1K_2K_3K:    return (cred_t){0, 0, 0};
+    case S_MIXED_UID_GID:                    return (cred_t){1000, 1000, 1000};
+    default:                                 return (cred_t){0, 0, 0};
+    }
+}
+
+static cred_t expected_gid(cred_state_t s, uint32_t caller_uid, uint32_t caller_gid)
+{
+    switch (s) {
+    case S_ROOT_UNMOD:                       return (cred_t){0, 0, 0};
+    case S_ROOT_AFTER_SETUID_1000:           return (cred_t){0, 0, 0};
+    case S_ROOT_AFTER_SETUID_BIG:            return (cred_t){0, 0, 0};
+    case S_ROOT_AFTER_SETRESUID_1K_2K_3K:    return (cred_t){0, 0, 0};
+    case S_NONROOT_NATIVE:
+        return (caller_uid == 0)
+                 ? (cred_t){1000, 1000, 1000}
+                 : (cred_t){caller_gid, caller_gid, caller_gid};
+    case S_ROOT_AFTER_SETGID_1000:           return (cred_t){1000, 1000, 1000};
+    case S_ROOT_AFTER_SETRESGID_1K_2K_3K:    return (cred_t){1000, 2000, 3000};
+    case S_MIXED_UID_GID:                    return (cred_t){2000, 2000, 2000};
+    default:                                 return (cred_t){0, 0, 0};
+    }
+}
+
+/* ── 维度 B: getter syscall (6) ─────────────────────────────────── */
+typedef enum {
+    GET_UID = 0, GET_EUID, GET_GID, GET_EGID, GET_RESUID, GET_RESGID
+} getter_kind_t;
+
+static const char *getter_name(getter_kind_t g)
+{
+    switch (g) {
+    case GET_UID:    return "getuid";
+    case GET_EUID:   return "geteuid";
+    case GET_GID:    return "getgid";
+    case GET_EGID:   return "getegid";
+    case GET_RESUID: return "getresuid";
+    case GET_RESGID: return "getresgid";
+    default:         return "?";
+    }
+}
+
+/* ── 维度 C: 模式 ───────────────────────────────────────────────── */
+typedef enum { M_LIBC = 0, M_RAW = 1 } call_mode_t;
+
+/* ── 0-arg getter 实际 call ────────────────────────────────────── */
+static long call_0arg(getter_kind_t g, call_mode_t m)
+{
+    if (m == M_LIBC) {
+        switch (g) {
+        case GET_UID:  return (long)getuid();
+        case GET_EUID: return (long)geteuid();
+        case GET_GID:  return (long)getgid();
+        case GET_EGID: return (long)getegid();
+        default:       return -1;
+        }
+    } else {
+        switch (g) {
+        case GET_UID:  return syscall(SYS_getuid);
+        case GET_EUID: return syscall(SYS_geteuid);
+        case GET_GID:  return syscall(SYS_getgid);
+        case GET_EGID: return syscall(SYS_getegid);
+        default:       return -1;
+        }
+    }
+}
+
+/* expected for 0-arg — 接受 caller_uid/gid (codex P1 修) */
+static uint32_t expected_0arg(getter_kind_t g, cred_state_t s,
+                               uint32_t caller_uid, uint32_t caller_gid)
+{
+    cred_t uid_c = expected_uid(s, caller_uid);
+    cred_t gid_c = expected_gid(s, caller_uid, caller_gid);
+    switch (g) {
+    case GET_UID:  return uid_c.r;
+    case GET_EUID: return uid_c.e;
+    case GET_GID:  return gid_c.r;
+    case GET_EGID: return gid_c.e;
+    default:       return 0;
+    }
+}
+
+static int waitpid_safely(pid_t pid, int *st)
+{
+    return waitpid(pid, st, 0) == pid ? 0 : -1;
+}
+
+/* ── 矩阵 1: 0-arg getter (4 syscall × 8 state × 2 mode = 64 case) ── */
+static void matrix_0arg_one(getter_kind_t g, cred_state_t s, call_mode_t m,
+                             uint32_t caller_uid, uint32_t caller_gid)
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        if (setup_state(s) != 0) _exit(99);
+        uint32_t exp = expected_0arg(g, s, caller_uid, caller_gid);
+        long val = call_0arg(g, m);
+        if (val < 0) _exit(10);
+        if ((uint32_t)val != exp) _exit(11);
+        _exit(0);
+    }
+    int status;
+    if (pid < 0 || waitpid_safely(pid, &status) != 0) {
+        CHECK(0, "matrix_0arg: fork/waitpid"); return;
+    }
+    int ec = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    char msg[200];
+    snprintf(msg, sizeof msg, "0arg %s state=%s mode=%s",
+             getter_name(g), state_name(s), m == M_RAW ? "raw" : "libc");
+    if (ec == 0)        CHECK(1, msg);
+    else if (ec == 99)  printf("  SKIP (setup) | %s\n", msg);
+    else {
+        char buf[260]; snprintf(buf, sizeof buf, "FAIL ec=%d | %s", ec, msg);
+        CHECK(0, buf);
+    }
+}
+
+/* ── 维度 D: getres 指针 pattern (10) ──────────────────────────── */
+typedef enum {
+    PP_ALL_VALID_DISJOINT = 0,
+    PP_ALL_VALID_SAME,
+    PP_NULL_FIRST,
+    PP_NULL_SECOND,
+    PP_NULL_THIRD,
+    PP_KERNEL_FIRST,
+    PP_KERNEL_SECOND,
+    PP_KERNEL_THIRD,
+    PP_UNMAPPED_FIRST,
+    PP_ALL_NULL,
+    PP_COUNT
+} ptr_pattern_t;
+
+static const char *pp_name(ptr_pattern_t p)
+{
+    switch (p) {
+    case PP_ALL_VALID_DISJOINT: return "valid_disjoint";
+    case PP_ALL_VALID_SAME:     return "valid_same";
+    case PP_NULL_FIRST:         return "null_1st";
+    case PP_NULL_SECOND:        return "null_2nd";
+    case PP_NULL_THIRD:         return "null_3rd";
+    case PP_KERNEL_FIRST:       return "kern_1st";
+    case PP_KERNEL_SECOND:      return "kern_2nd";
+    case PP_KERNEL_THIRD:       return "kern_3rd";
+    case PP_UNMAPPED_FIRST:     return "unmapped_1st";
+    case PP_ALL_NULL:           return "all_null";
+    default:                    return "?";
+    }
+}
+
+/* 设三指针 + 预期 rc/err */
+typedef struct {
+    uint32_t *p1, *p2, *p3;
+    int      expected_rc;        /* 0 or -1 */
+    int      expected_err;       /* 0 or EFAULT */
+    bool     check_values;       /* 成功时是否验值（valid_same 时 last-write 才检） */
+} ptr_setup_t;
+
+static ptr_setup_t setup_pointers(ptr_pattern_t p,
+                                   uint32_t *a, uint32_t *b, uint32_t *c,
+                                   void *kern_addr, void *unmapped_addr)
+{
+    ptr_setup_t ps = {0};
+    switch (p) {
+    case PP_ALL_VALID_DISJOINT:
+        ps.p1 = a; ps.p2 = b; ps.p3 = c;
+        ps.expected_rc = 0; ps.expected_err = 0; ps.check_values = true;
+        break;
+    case PP_ALL_VALID_SAME:
+        ps.p1 = a; ps.p2 = a; ps.p3 = a;  /* alias: last write hits a */
+        ps.expected_rc = 0; ps.expected_err = 0; ps.check_values = true;
+        break;
+    case PP_NULL_FIRST:
+        ps.p1 = NULL; ps.p2 = b; ps.p3 = c;
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+        break;
+    case PP_NULL_SECOND:
+        ps.p1 = a; ps.p2 = NULL; ps.p3 = c;
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+        break;
+    case PP_NULL_THIRD:
+        ps.p1 = a; ps.p2 = b; ps.p3 = NULL;
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+        break;
+    case PP_KERNEL_FIRST:
+        ps.p1 = (uint32_t *)kern_addr; ps.p2 = b; ps.p3 = c;
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+        break;
+    case PP_KERNEL_SECOND:
+        ps.p1 = a; ps.p2 = (uint32_t *)kern_addr; ps.p3 = c;
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+        break;
+    case PP_KERNEL_THIRD:
+        ps.p1 = a; ps.p2 = b; ps.p3 = (uint32_t *)kern_addr;
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+        break;
+    case PP_UNMAPPED_FIRST:
+        ps.p1 = (uint32_t *)unmapped_addr; ps.p2 = b; ps.p3 = c;
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+        break;
+    case PP_ALL_NULL:
+        ps.p1 = NULL; ps.p2 = NULL; ps.p3 = NULL;
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+        break;
+    default:
+        ps.expected_rc = -1; ps.expected_err = EFAULT;
+    }
+    return ps;
+}
+
+/* call_3arg */
+static long call_3arg(getter_kind_t g, call_mode_t m,
+                      uint32_t *p1, uint32_t *p2, uint32_t *p3)
+{
+    if (m == M_LIBC) {
+        if (g == GET_RESUID) return getresuid((uid_t*)p1, (uid_t*)p2, (uid_t*)p3);
+        else                  return getresgid((gid_t*)p1, (gid_t*)p2, (gid_t*)p3);
+    } else {
+        long sysn = (g == GET_RESUID) ? SYS_getresuid : SYS_getresgid;
+        return syscall(sysn, p1, p2, p3);
+    }
+}
+
+/* ── 矩阵 2: 3-arg getres (2 × 8 × 10 × 2 = 320 case) ──────────── */
+static void matrix_3arg_one(getter_kind_t g, cred_state_t s,
+                             ptr_pattern_t pp, call_mode_t m,
+                             void *kern_addr, void *unmapped_addr,
+                             uint32_t caller_uid, uint32_t caller_gid)
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        if (setup_state(s) != 0) _exit(99);
+
+        uint32_t r = 0xAAAAAAAA, e = 0xBBBBBBBB, sval = 0xCCCCCCCC;
+        ptr_setup_t ps = setup_pointers(pp, &r, &e, &sval, kern_addr, unmapped_addr);
+
+        errno = 0;
+        long rc = call_3arg(g, m, ps.p1, ps.p2, ps.p3);
+        int err = errno;
+
+        if (rc != ps.expected_rc) _exit(11);
+        if (ps.expected_rc == -1 && err != ps.expected_err) _exit(12);
+
+        if (ps.expected_rc == 0 && ps.check_values) {
+            cred_t exp = (g == GET_RESUID)
+                          ? expected_uid(s, caller_uid)
+                          : expected_gid(s, caller_uid, caller_gid);
+            if (pp == PP_ALL_VALID_DISJOINT) {
+                if (r != exp.r || e != exp.e || sval != exp.s) _exit(13);
+            } else if (pp == PP_ALL_VALID_SAME) {
+                if (r != exp.s) _exit(14);
+            }
+        }
+        _exit(0);
+    }
+    int status;
+    if (pid < 0 || waitpid_safely(pid, &status) != 0) {
+        CHECK(0, "matrix_3arg: fork/waitpid"); return;
+    }
+    int ec = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    char msg[260];
+    snprintf(msg, sizeof msg, "3arg %s state=%s pp=%s mode=%s",
+             getter_name(g), state_name(s), pp_name(pp),
+             m == M_RAW ? "raw" : "libc");
+    if (ec == 0)        CHECK(1, msg);
+    else if (ec == 99)  printf("  SKIP (setup) | %s\n", msg);
+    else {
+        char buf[320]; snprintf(buf, sizeof buf, "FAIL ec=%d | %s", ec, msg);
+        CHECK(0, buf);
+    }
+}
+
+/* ── 矩阵 3: errno 不动 (4 0-arg syscall × 6 preset errno) ────── */
+static const int ERRNO_PRESETS[] = { 1, 5, 22, 4242, 9999, 88888 };
+#define N_ERRNO_PRESETS (sizeof(ERRNO_PRESETS)/sizeof(ERRNO_PRESETS[0]))
+
+static void errno_preservation_one(getter_kind_t g, int preset)
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        errno = preset;
+        (void)call_0arg(g, M_LIBC);
+        if (errno != preset) _exit(11);
+        _exit(0);
+    }
+    int status;
+    waitpid_safely(pid, &status);
+    int ec = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    char msg[200];
+    snprintf(msg, sizeof msg, "errno preserve %s preset=%d", getter_name(g), preset);
+    CHECK(ec == 0, msg);
+}
+
+/* ── 矩阵 4: cross-syscall consistency (8 state × 4 check) ─────── */
+static void cross_consistency_one(cred_state_t s)
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        if (setup_state(s) != 0) _exit(99);
+        uid_t u = getuid(), e = geteuid();
+        uid_t r2, e2, s2;
+        if (getresuid(&r2, &e2, &s2) != 0) _exit(11);
+        if (u != r2) _exit(12);
+        if (e != e2) _exit(13);
+        gid_t g = getgid(), eg = getegid();
+        gid_t gr2, ge2, gs2;
+        if (getresgid(&gr2, &ge2, &gs2) != 0) _exit(14);
+        if (g != gr2) _exit(15);
+        if (eg != ge2) _exit(16);
+        _exit(0);
+    }
+    int status;
+    waitpid_safely(pid, &status);
+    int ec = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    char msg[200];
+    snprintf(msg, sizeof msg, "consistency state=%s", state_name(s));
+    if (ec == 0)        CHECK(1, msg);
+    else if (ec == 99)  printf("  SKIP (setup) | %s\n", msg);
+    else {
+        char buf[260]; snprintf(buf, sizeof buf, "FAIL ec=%d | %s", ec, msg);
+        CHECK(0, buf);
+    }
+}
+
+/* ── 入口 ──────────────────────────────────────────────────────── */
+int matrix_run(void)
+{
+    printf("\n----- matrix (man-first 完备) -----\n");
+    /* codex P1 (adopted): capture caller uid/gid 用于 derive
+     * S_NONROOT_NATIVE 在 non-root caller 时的真实期望 */
+    uint32_t caller_uid = getuid();
+    uint32_t caller_gid = getgid();
+    if (caller_uid != 0) {
+        printf("  matrix: caller uid=%u gid=%u (nonroot; root-only states will skip)\n",
+               caller_uid, caller_gid);
+    }
+
+    /* 准备 unmapped 用户态地址 (mmap+munmap) */
+    void *unmapped = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (unmapped != MAP_FAILED) {
+        munmap(unmapped, 4096);
+    } else {
+        unmapped = (void *)0x1000;  /* fallback unlikely-mapped */
+    }
+    void *kern_addr = (void *)0xffffffffff000000ULL;  /* 内核段 */
+
+    int total = 0;
+
+    /* matrix 1: 0-arg */
+    printf("  [matrix 1/4] 0-arg getter (4 × 8 × 2 = 64 case)\n");
+    for (int g = 0; g < 4; g++)
+      for (int s = 0; s < S_STATE_COUNT; s++)
+        for (int m = 0; m < 2; m++) {
+            matrix_0arg_one((getter_kind_t)g, (cred_state_t)s, (call_mode_t)m,
+                            caller_uid, caller_gid);
+            total++;
+        }
+
+    /* matrix 2: 3-arg */
+    printf("  [matrix 2/4] 3-arg getres (2 × 8 × 10 × 2 = 320 case)\n");
+    for (int g = GET_RESUID; g <= GET_RESGID; g++)
+      for (int s = 0; s < S_STATE_COUNT; s++)
+        for (int pp = 0; pp < PP_COUNT; pp++)
+          for (int m = 0; m < 2; m++) {
+              matrix_3arg_one((getter_kind_t)g, (cred_state_t)s,
+                              (ptr_pattern_t)pp, (call_mode_t)m,
+                              kern_addr, unmapped,
+                              caller_uid, caller_gid);
+              total++;
+          }
+
+    /* matrix 3: errno preservation */
+    printf("  [matrix 3/4] errno preservation (4 × 6 = 24 case)\n");
+    for (int g = 0; g < 4; g++)
+      for (size_t i = 0; i < N_ERRNO_PRESETS; i++) {
+          errno_preservation_one((getter_kind_t)g, ERRNO_PRESETS[i]);
+          total++;
+      }
+
+    /* matrix 4: cross consistency */
+    printf("  [matrix 4/4] cross-syscall consistency (8 case)\n");
+    for (int s = 0; s < S_STATE_COUNT; s++) {
+        cross_consistency_one((cred_state_t)s);
+        total++;
+    }
+
+    printf("  ----- matrix: %d pass, %d fail (out of %d cases) -----\n",
+           __pass, __fail, total);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/procfs_visibility.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/procfs_visibility.c
@@ -1,0 +1,112 @@
+/* procfs_visibility.c — getter syscall ↔ /proc/self/status 一致性.
+ *
+ * man proc(5) §/proc/[pid]/status:
+ *   "Uid, Gid: Real, effective, saved set, and filesystem UIDs (GIDs)."
+ *   "Groups: Supplementary group list."
+ *
+ * 隐含规范: procfs Uid/Gid 行的 r/e/s 必须与 syscall 一致.
+ * 任何分歧 = starry cred 子系统 ↔ procfs 同步 bug.
+ *
+ * 4 case (a-d):
+ *   (a) getuid()      == /proc/self/status Uid[0] (real)
+ *   (b) geteuid()     == Uid[1] (effective)
+ *   (c) getresuid()   == Uid[0..2]
+ *   (d) getgroups()   ↔ /proc/self/status Groups: 行 (set 一致)
+ */
+
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <grp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static int parse_proc_id_line(const char *prefix,
+                               uint32_t *r, uint32_t *e, uint32_t *s, uint32_t *fs)
+{
+    FILE *f = fopen("/proc/self/status", "r");
+    if (!f) return -1;
+    char line[256];
+    int found = -1;
+    while (fgets(line, sizeof line, f)) {
+        if (strncmp(line, prefix, strlen(prefix)) == 0) {
+            if (sscanf(line + strlen(prefix), "%u %u %u %u", r, e, s, fs) == 4)
+                found = 0;
+            break;
+        }
+    }
+    fclose(f);
+    return found;
+}
+
+/* parse_proc_groups removed: case (d) 已迁移到 bug-* 分支独立复现.
+ *
+ * 原 case (d) (getgroups ↔ procfs Groups: 一致性) 在 starry loongarch64
+ * 上 fopen+fgets /proc/self/status 时 vm_write 返 EFAULT (Linux 通过)
+ * → 见 bug-starry-procfs-loongarch64-vm-write-efault 分支独立验证.
+ * 此处 test-* PR 仅保留 starry + Linux 双绿的 case (a-c, getuid/euid/resuid). */
+
+/* (a) getuid() == Uid[0] */
+static void proc_getuid_matches_real(void)
+{
+    /* 测什么: 隐含规范 — getuid syscall 与 procfs Uid 行 real 字段同源.
+     * 怎么测: getuid() vs parse_proc_id_line("Uid:") 第 1 字段.
+     * 期望: 相等.
+     * 为什么: 防 starry cred ↔ procfs 数据源分裂 (历史 bug 常见). */
+    uid_t u = getuid();
+    uint32_t r, e, s, fs;
+    int rc = parse_proc_id_line("Uid:", &r, &e, &s, &fs);
+    CHECK(rc == 0,                                                 "procfs (a) parse Uid line ok");
+    if (rc == 0) {
+        CHECK((uint32_t)u == r,                                    "procfs (a) getuid() == Uid[0] (real)");
+    }
+}
+
+/* (b) geteuid() == Uid[1] */
+static void proc_geteuid_matches_effective(void)
+{
+    /* 测什么/怎么测/期望/为什么: 同 (a) 镜像 — geteuid 与 procfs Uid 行 e 字段同源. */
+    uid_t e_syscall = geteuid();
+    uint32_t r, e, s, fs;
+    int rc = parse_proc_id_line("Uid:", &r, &e, &s, &fs);
+    CHECK(rc == 0,                                                 "procfs (b) parse Uid line ok");
+    if (rc == 0) {
+        CHECK((uint32_t)e_syscall == e,                            "procfs (b) geteuid() == Uid[1] (effective)");
+    }
+}
+
+/* (c) getresuid 三字段 vs procfs */
+static void proc_getresuid_matches_three(void)
+{
+    /* 测什么: getresuid 三 out-arg 应与 procfs Uid 行前 3 字段一一对应.
+     * 怎么测: getresuid + parse, 比对 r/e/s.
+     * 期望: 三对都相等.
+     * 为什么: 验 starry sys_getresuid 与 procfs 同源 cred 全字段. */
+    uid_t sr, se, ss;
+    if (getresuid(&sr, &se, &ss) != 0) { CHECK(0, "procfs (c) getresuid failed"); return; }
+    uint32_t pr, pe, ps, pfs;
+    if (parse_proc_id_line("Uid:", &pr, &pe, &ps, &pfs) != 0) {
+        CHECK(0, "procfs (c) parse Uid line failed"); return;
+    }
+    CHECK((uint32_t)sr == pr && (uint32_t)se == pe && (uint32_t)ss == ps,
+          "procfs (c) getresuid r/e/s == Uid[0..2]");
+}
+
+/* (d) getgroups ↔ procfs Groups: 一致性 — 已迁移到 bug-starry-procfs-
+ *     loongarch64-vm-write-efault 分支独立复现 (此处 test-* PR 保 starry
+ *     + Linux 双绿). */
+
+int procfs_visibility_run(void)
+{
+    printf("\n----- procfs_visibility (getter ↔ procfs 一致) -----\n");
+    proc_getuid_matches_real();
+    proc_geteuid_matches_effective();
+    proc_getresuid_matches_three();
+    printf("  ----- procfs_visibility: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/test_framework.h
@@ -1,0 +1,85 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                      \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",         \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);              \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/uid32_no_trunc.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/uid32_no_trunc.c
@@ -1,0 +1,140 @@
+/* uid32_no_trunc.c — 验证 getter syscall 返 32-bit ID 不被截断到 16-bit.
+ *
+ * man 2 getuid §"HISTORY":
+ *   "The original Linux getuid() and geteuid() system calls supported only
+ *    16-bit user IDs. Subsequently, Linux 2.4 added getuid32() and
+ *    geteuid32(), supporting 32-bit IDs. The glibc getuid() and geteuid()
+ *    wrapper functions transparently deal with the variations across
+ *    kernel versions."
+ *
+ * man 2 getresuid §"HISTORY":
+ *   "The original Linux getresuid() and getresgid() system calls supported
+ *    only 16-bit user and group IDs. Subsequently, Linux 2.4 added
+ *    getresuid32() and getresgid32(), supporting 32-bit IDs."
+ *
+ * 设计：当代 starry/Linux 应直接是 32-bit cred 字段; 验 setresuid 高位
+ *       (>65535) 后 getter 返完整 32-bit 不被截断到低 16 位.
+ *
+ * Linux 行为: setresuid(100000,200000,300000) → getresuid 返 (100000,200000,300000)
+ * starry 行为: 应该一致 (cred 字段是 u32 / kUidT 是 u32)
+ *
+ * 若 starry 内部按 16-bit 处理 (老 ABI), 将返低 16 位:
+ *   100000 & 0xffff = 34464, 200000 & 0xffff = 3392, etc — 验失败.
+ */
+
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int waitpid_safely(pid_t pid, int *status)
+{
+    pid_t r = waitpid(pid, status, 0);
+    return r == pid ? 0 : -1;
+}
+
+static void uid32_getresuid_no_truncate(void)
+{
+    /* 测什么: 验 starry getresuid 输出未被截断到 16-bit (man HISTORY 暗指
+     *         32-bit getuid32 自 Linux 2.4 起标准, 当代 cred 字段是 u32).
+     * 怎么测: root fork → child setresuid(100001,200002,300003) → getresuid →
+     *         验三槽 == 设值 (远 > 65535, 截断会变成低 16 位).
+     * 期望:   r=100001 e=200002 s=300003 (全位保留).
+     * 为什么: 验 starry cred.uid/euid/suid 字段宽度 + sys_getresuid vm_write
+     *         路径不丢高位. 若失败 = starry 内部存了 u16 → 安全风险
+     *         (高位 UID 被映射到不同身份). */
+    if (getuid() != 0) {
+        printf("  uid32 (a) skip: not root — 需 CAP_SETUID 设 >16-bit UID\n");
+        return;
+    }
+    pid_t pid = fork();
+    if (pid == 0) {
+        if (setresuid(100001, 200002, 300003) != 0) _exit(99);
+        uid_t r = 0, e = 0, s = 0;
+        if (getresuid(&r, &e, &s) != 0) _exit(98);
+        /* 验全 32 位保留 */
+        if (r == 100001 && e == 200002 && s == 300003) _exit(0);
+        /* 若被 16-bit 截断, r 会是 100001 & 0xffff = 34465 */
+        if (r == (100001 & 0xffff)) _exit(20);  /* truncation bug */
+        _exit(1);
+    }
+    int status;
+    if (waitpid_safely(pid, &status) == 0) {
+        int ec = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+        if (ec == 0)        CHECK(1, "uid32 (a) getresuid 返完整 32-bit (100001,200002,300003)");
+        else if (ec == 20)  CHECK(0, "uid32 (a) FAIL: getresuid 截断到 16-bit (cred field 实际是 u16?)");
+        else                CHECK(0, "uid32 (a) failed (ec != 0)");
+    }
+}
+
+static void uid32_getresgid_no_truncate(void)
+{
+    /* 测什么/怎么测/期望/为什么: 同 (a), 但 GID 维度. 验 starry sys_getresgid
+     *         vm_write 高位保留 (gid_t 32-bit). */
+    if (getuid() != 0) {
+        printf("  uid32 (b) skip: not root\n");
+        return;
+    }
+    pid_t pid = fork();
+    if (pid == 0) {
+        if (setresgid(100100, 200200, 300300) != 0) _exit(99);
+        gid_t r = 0, e = 0, s = 0;
+        if (getresgid(&r, &e, &s) != 0) _exit(98);
+        if (r == 100100 && e == 200200 && s == 300300) _exit(0);
+        if (r == (100100 & 0xffff)) _exit(20);
+        _exit(1);
+    }
+    int status;
+    if (waitpid_safely(pid, &status) == 0) {
+        int ec = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+        if (ec == 0)        CHECK(1, "uid32 (b) getresgid 返完整 32-bit (100100,200200,300300)");
+        else if (ec == 20)  CHECK(0, "uid32 (b) FAIL: getresgid 截断到 16-bit");
+        else                CHECK(0, "uid32 (b) failed");
+    }
+}
+
+static void uid32_getuid_geteuid_no_truncate(void)
+{
+    /* 测什么: 同 (a)/(b), 但 getuid/geteuid 路径 (基本 0-arg getter).
+     * 怎么测: root fork → child setresuid(123456, 234567, 0) → getuid/geteuid
+     *         验返设值.
+     * 期望:   getuid==123456, geteuid==234567.
+     * 为什么: 验 sys_getuid/geteuid 路径与 sys_getresuid 同源 (都从 cred 读),
+     *         32-bit 不被截断. */
+    if (getuid() != 0) {
+        printf("  uid32 (c) skip\n");
+        return;
+    }
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* 注意: 必须 saved 留 0 (root) 才能后续完成 child exit cleanup */
+        if (setresuid(123456, 234567, 0) != 0) _exit(99);
+        uid_t u = getuid();
+        uid_t eu = geteuid();
+        if (u == 123456 && eu == 234567) _exit(0);
+        if (u == (123456 & 0xffff)) _exit(20);
+        _exit(1);
+    }
+    int status;
+    if (waitpid_safely(pid, &status) == 0) {
+        int ec = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+        if (ec == 0)        CHECK(1, "uid32 (c) getuid/geteuid 返完整 32-bit");
+        else if (ec == 20)  CHECK(0, "uid32 (c) FAIL: 截断到 16-bit");
+        else                CHECK(0, "uid32 (c) failed");
+    }
+}
+
+int uid32_no_trunc_run(void)
+{
+    printf("\n----- uid32_no_trunc (man HISTORY 32-bit ID) -----\n");
+    uid32_getresuid_no_truncate();
+    uid32_getresgid_no_truncate();
+    uid32_getuid_geteuid_no_truncate();
+    printf("  ----- uid32_no_trunc: %d pass, %d fail -----\n", __pass, __fail);
+    return __fail;
+}


### PR DESCRIPTION
<div align="center">

[![Type](https://img.shields.io/badge/type-test%20syscall-blue?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/725) [![Refs](https://img.shields.io/badge/Refs-%23717%20%28validates%29-orange?style=flat-square)](#) [![Sibling](https://img.shields.io/badge/Sibling-%23726--%23729-yellow?style=flat-square)](#) [![Commits](https://img.shields.io/badge/commits-1-brightgreen?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/725/commits) [![GPG](https://img.shields.io/badge/GPG-Verified-success?style=flat-square)](#) [![Files](https://img.shields.io/badge/files-18-lightgrey?style=flat-square)](https://github.com/rcore-os/tgoskits/pull/725/files) [![PASS](https://img.shields.io/badge/local%20PASS-495-brightgreen?style=flat-square)](#) [![Modules](https://img.shields.io/badge/modules-11-blue?style=flat-square)](#)

</div>

## 📑 目录

- [分支用途](#分支用途)
- [测试覆盖 (每文件每函数)](#测试覆盖-每文件每函数)
- [相关 syscall man 摘录 (核心段)](#相关-syscall-man-摘录-核心段)
- [发现的 bug (本测试过程中暴露的 starry vs Linux 差异)](#发现的-bug-本测试过程中暴露的-starry-vs-linux-差异)
- [🔬 CI / 验证](#🔬-ci--验证)
- [📊 Matrix case 数学](#📊-matrix-case-数学)
- [复现命令](#复现命令)
- [引用](#引用)

## 分支用途

Group A: 6 个 getter syscall (`getuid` / `geteuid` / `getgid` / `getegid` / `getresuid` / `getresgid`) 的 man-first 地毯式测试, 本地 495 PASS。

本 PR (rcore-os/tgoskits#725, 对应 fork branch `test-uid-gid-getters`)。

## 测试覆盖 (每文件每函数)

测试位置: `test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c/src/`

模块总览 (11 模块 / 53 个 static void case 函数 / main.c 串联): `getuid` / `geteuid` / `getgid` / `getegid` / `getresuid` / `getresgid` / `cross_consistency` / `boundary` / `matrix` / `procfs_visibility` / `uid32_no_trunc`。

### 3.1 c/src/getuid.c (5 case + 1 helper)

- `waitpid_safely()` helper — 循环 waitpid 处理 EINTR
- `getuid_basic_returns_uid()` — 调 getuid() 返非负 uid_t, 与 libc 包装值一致 (man §DESCRIPTION)
- `getuid_idempotent()` — 连续两次 getuid() 同一值 (无副作用)
- `getuid_does_not_modify_errno()` — 预置 errno=4242 → getuid() 后仍为 4242 (man §ERRORS "never modify errno")
- `getuid_raw_syscall_matches_libc()` — 裸 `syscall(SYS_getuid)` 与 libc `getuid()` 同值 (man §HISTORY glibc wrapper)
- `getuid_fork_child_inherits()` — fork 后子进程 getuid() == 父值 (credentials(7) §继承)

### 3.2 c/src/geteuid.c (5 case)

- `geteuid_basic_returns_euid()` / `geteuid_idempotent()` / `geteuid_does_not_modify_errno()` / `geteuid_raw_syscall_matches_libc()` / `geteuid_default_equals_uid()` — 普通启动 euid == uid

### 3.3 c/src/getgid.c (5 case + 1 helper)

- `waitpid_safely()` helper
- `getgid_basic_returns_gid()` / `getgid_idempotent()` / `getgid_does_not_modify_errno()` / `getgid_raw_syscall_matches_libc()` / `getgid_fork_child_inherits()`

### 3.4 c/src/getegid.c (5 case)

- `getegid_basic_returns_egid()` / `getegid_idempotent()` / `getegid_does_not_modify_errno()` / `getegid_raw_syscall_matches_libc()` / `getegid_default_equals_gid()`

### 3.5 c/src/getresuid.c (8 case)

- `getresuid_basic_writes_three()` — getresuid(&r,&e,&s) 成功且三字段被写
- `getresuid_ruid_equals_getuid()` — 出参 r 字段 == getuid()
- `getresuid_euid_equals_geteuid()` — 出参 e 字段 == geteuid()
- `getresuid_suid_equals_euid_at_startup()` — 启动期 s == e
- `getresuid_null_pointer_efault()` — 三参各传 NULL 单独验 → EFAULT, 且检查未被部分写入 (man §ERRORS EFAULT)
- `getresuid_raw_matches_libc()` — 裸 syscall 三字段与 libc 一致
- `getresuid_same_pointer_last_write()` — r/e/s 三指针同址: 最后写入字段 (s) 值胜出
- `getresuid_success_preserves_errno()` — 成功路径不动 errno

### 3.6 c/src/getresgid.c (8 case)

- `getresgid_basic_writes_three()` / `getresgid_rgid_equals_getgid()` / `getresgid_egid_equals_getegid()` / `getresgid_sgid_equals_egid_at_startup()` / `getresgid_null_pointer_efault()` / `getresgid_raw_matches_libc()` / `getresgid_same_pointer_last_write()` / `getresgid_success_preserves_errno()`

### 3.7 c/src/cross_consistency.c (5 case)

- `uid_pair_consistency()` — (getuid, geteuid) ↔ getresuid 三字段 r/e 交叉一致
- `gid_pair_consistency()` — (getgid, getegid) ↔ getresgid 三字段一致
- `interleaved_stability()` — UID 族交错调用 getuid/geteuid/getresuid 各值稳定
- `interleaved_stability_gid()` — GID 族同上
- `interleaved_stability_getres()` — getres* 交错稳定 (UID + GID 各 5 轮)

### 3.8 c/src/boundary.c (2 case)

- `getresuid_kernel_address_efault()` — getresuid 传内核地址 0xFFFF... → EFAULT
- `getresuid_partial_efault()` — 三参一个非法、其余合法 → EFAULT (且检查不被部分写入)

### 3.9 c/src/matrix.c (4 case + 2 helper)

- `setup_state()` helper — 切到指定 cred state
- `waitpid_safely()` helper
- `matrix_0arg_one()` — 0 参 getter (getuid/euid/gid/egid) × state × mode 笛卡尔单格
- `matrix_3arg_one()` — 3 参 getres* × state × ptr_pattern × mode 笛卡尔单格
- `errno_preservation_one()` — 预置 errno × getter 笛卡尔单格
- `cross_consistency_one()` — 跨 syscall 一致性 × cred state 笛卡尔单格

### 3.10 c/src/procfs_visibility.c (3 case + 1 helper)

- `parse_proc_id_line()` helper — 解析 /proc/self/status Uid:/Gid: 三字段
- `proc_getuid_matches_real()` — getuid() == /proc/self/status Uid 第 1 字段 (proc(5) §Uid)
- `proc_geteuid_matches_effective()` — geteuid() == Uid 第 2 字段
- `proc_getresuid_matches_three()` — getresuid() 三字段 == Uid 三字段

### 3.11 c/src/uid32_no_trunc.c (3 case + 1 helper)

- `waitpid_safely()` helper
- `uid32_getresuid_no_truncate()` — child setresuid 大 UID 后 getresuid 高 16 位不被截 (man §HISTORY 16→32-bit)
- `uid32_getresgid_no_truncate()` — GID 侧
- `uid32_getuid_geteuid_no_truncate()` — child 大 UID 后 getuid/geteuid 不被截

### 3.12 c/src/main.c (聚合 entry point, 非测点)

按顺序 COLLECT 11 个模块, 每模块 `*_run()` 返 `__fail`, main 汇总 TOTAL: N fail 收尾。

## 相关 syscall man 摘录 (核心段)

`getuid` / `geteuid` §ERRORS: "These functions are always successful and never modify errno."

`getuid` / `geteuid` §HISTORY: "The original Linux getuid() and geteuid() system calls supported only 16-bit user IDs. Subsequently, Linux 2.4 added getuid32() and geteuid32(), supporting 32-bit IDs. The glibc getuid() and geteuid() wrapper functions transparently deal with the variations across kernel versions."

`getgid` / `getegid` §ERRORS / §HISTORY: 完全镜像 getuid / geteuid。

`getresuid` / `getresgid` §DESCRIPTION: "getresuid() returns the real UID, the effective UID, and the saved set-user-ID of the calling process, in the arguments ruid, euid, and suid, respectively."

`getresuid` / `getresgid` §ERRORS: "EFAULT — One of the arguments specified an address outside the calling program's address space."

## 发现的 bug (本测试过程中暴露的 starry vs Linux 差异)

本 test PR 在 starry kernel 上跑时, 暴露以下 starry-vs-Linux 行为差异, 已各自登记为上游 issue, 单文件 C 复现程序在 fork repo 的 `bug-starry-*` 分支内单独维护 (路径 `test-suit/.../bugfix/bug-starry-<name>/c/src/main.c`):

- rcore-os/tgoskits#713 — `setuid((uid_t)-1)` 在 starry 上被错误接受 (Linux 应返 EINVAL, 由 uid_valid 检查阻断)
- rcore-os/tgoskits#714 — `/proc/self/status` 在 starry loongarch64 上 vm_write EFAULT (Uid:/Gid:/Groups: 三行均受影响)
- rcore-os/tgoskits#715 — `setgroups(N, list)` 之后 `/proc/self/status` 的 Groups: 行不立即同步 (starry race)
- rcore-os/tgoskits#716 — apk + curl 组合在 starry loongarch64 上 600s 超时 ~90% flake (与本测试矩阵 stress 路径相关)

上述 bug 由 rcore-os/tgoskits#717 (fix-uid-gid-bugs, local 修) 与 rcore-os/tgoskits#718 (fix-uid-gid-deep, cross-subsystem) 这两个 fix PR 分别托管 — fix PR 同步把 bug-starry-* 注册进 4 arch bugfix toml 矩阵, CI 由 FAIL → PASS 转化作为修复验收。


## 📊 PR 关系图

```mermaid
graph LR
  P725[<b>PR #725</b><br/>test-uid-gid-getters<br/>本 PR · 495 PASS · 11 模块] -->|Validates| P717[PR #717<br/>uid_valid + fsuid]
  P725 -->|Sibling A→E| P726[#726 direct]
  P726 --> P727[#727 re]
  P727 --> P728[#728 res]
  P728 --> P729[#729 groups]
  style P725 fill:#fef3c7,stroke:#f59e0b,stroke-width:3px
```

## 🔬 CI / 验证

本 PR (rcore-os/tgoskits#725) 当前 bucket: `pass=18 fail=0 skipping=30`。

## 📊 Matrix case 数学

### `matrix.c` — ~440 case (基础 + 跨 syscall 一致性)

- 0-arg getter: `4 syscall × 8 state × 2 mode = 64`
- 3-arg getres: `2 syscall × 8 state × 10 ptr_pattern × 2 mode = 320`
- errno 不动: `4 syscall × 6 preset errno = 24`
- cross consistency: `8 state × 4 check = 32`

总: ~440 case (实际 416 PASS, 少 24 个 errno preset 部分跑 host_only)。

为什么这么多维度:
- state 8: man 只描述读 cred, 但需在任意 cred 状态下验证 (root 改 cred / 非 root / 切到大 UID / fork 子进程改 cred ...)
- mode 2: man HISTORY 说 glibc wrapper transparently deals with variations across kernel versions — 必须分别验 libc 和 raw syscall, 防 libc 隐藏 starry kernel bug
- ptr_pattern 10: getresuid 3 个 out-pointer, 各可 NULL / valid / aliased / kernel addr, 27 全组合简化到 10 个典型组合
- errno preset 6: 验 starry vm_write 是否误碰 errno

## 复现命令

切换分支:
```bash
cd <repo-root>
git checkout test-uid-gid-getters
```

本地 Linux (host, WSL2):
```bash
cd <repo-root>/test-suit/starryos/normal/qemu-smp1/syscall/test-uid-gid-getters/c
rm -rf build && mkdir build && cd build
cmake .. -DCMAKE_BUILD_TYPE=Debug && make
sudo ./test-uid-gid-getters
```
期望: `TOTAL: 0 fail | RESULT: ALL PASS`

starry qemu (4 arch, 必须 `source .starry-env.sh` 用 qemu-10):
```bash
source .starry-env.sh && cargo starry test qemu --arch x86_64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch aarch64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch riscv64 -c syscall
source .starry-env.sh && cargo starry test qemu --arch loongarch64 -c syscall
```

## 引用

- 相关 PR: stacked 后续 Group B/C/D/E (rcore-os/tgoskits#726..rcore-os/tgoskits#729); 衍生 bug-* rcore-os/tgoskits#714 (procfs loongarch64 vm_write EFAULT) / rcore-os/tgoskits#715 (procfs groups race) / rcore-os/tgoskits#716 (apk-curl loongarch64 flake)

Signed-off-by: Leo Cheng <chengkelfan@qq.com>



