### PR TITLE
chore(release): update metadata and manual workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,7 +15,7 @@ env:
 jobs:
   release-plz-release:
     name: Release-plz release
-    if: ${{ github.repository == 'rcore-os/tgoskits' }}
+    if: ${{ github.repository == 'rcore-os/tgoskits' && (github.event_name == 'workflow_dispatch' || github.ref_name == 'dev') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -42,7 +43,7 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
-    if: ${{ github.repository == 'rcore-os/tgoskits' }}
+    if: ${{ github.repository == 'rcore-os/tgoskits' && (github.event_name == 'workflow_dispatch' || github.ref_name == 'dev') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "arm-scmi-rs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aarch64-cpu-ext",
  "bitflags 2.11.1",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "arm_vcpu"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "ax-errno",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arm_vgic"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "aarch64_sysreg",
@@ -1099,7 +1099,7 @@ version = "0.5.5"
 
 [[package]]
 name = "ax-lockdep"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ax-crate-interface",
  "sbi-rt 0.0.3",
@@ -1259,7 +1259,7 @@ dependencies = [
  "ax-page-table-entry",
  "ax-plat",
  "ax-plat-aarch64-peripherals",
- "dw_apb_uart 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dw_apb_uart 0.1.0",
  "log",
 ]
 
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "axaddrspace"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "assert_matches",
  "ax-errno",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "axdevice_base"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "ax-errno",
  "axaddrspace",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "axvcpu"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "ax-errno",
  "ax-memory-addr",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "axvisor_api"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "ax-cpumask",
  "ax-crate-interface",
@@ -3329,17 +3329,17 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "dw_apb_uart"
 version = "0.1.0"
-dependencies = [
- "tock-registers 0.10.1",
-]
-
-[[package]]
-name = "dw_apb_uart"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93d496c8faa9dc676ebfa225432e1e3b57645c9268ead889286546f6d39356d"
 dependencies = [
  "tock-registers 0.8.1",
+]
+
+[[package]]
+name = "dw_apb_uart"
+version = "0.1.1"
+dependencies = [
+ "tock-registers 0.10.1",
 ]
 
 [[package]]
@@ -7702,7 +7702,7 @@ dependencies = [
  "crab-usb",
  "ddebug",
  "downcast-rs",
- "dw_apb_uart 0.1.0",
+ "dw_apb_uart 0.1.1",
  "enum_dispatch",
  "event-listener",
  "extern-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ members = [
 [workspace.dependencies]
 # Local workspace crates
 aarch64_sysreg = { version = "0.3.7", path = "components/aarch64_sysreg" }
-arm-scmi-rs = { version = "0.1.1", path = "components/arm-scmi-rs" }
+arm-scmi-rs = { version = "0.1.2", path = "components/arm-scmi-rs" }
 arceos-affinity = { version = "0.3.1", path = "test-suit/arceos/rust/task/affinity" }
 arceos-backtrace = { version = "0.3.1", path = "test-suit/arceos/rust/backtrace" }
 arceos-display = { version = "0.3.1", path = "test-suit/arceos/rust/display" }
@@ -259,8 +259,8 @@ arceos-sleep = { version = "0.3.1", path = "test-suit/arceos/rust/task/sleep" }
 arceos-tls = { version = "0.3.1", path = "test-suit/arceos/rust/task/tls" }
 arceos-wait-queue = { version = "0.3.1", path = "test-suit/arceos/rust/task/wait_queue" }
 arceos-yield = { version = "0.3.1", path = "test-suit/arceos/rust/task/yield" }
-arm_vcpu = { version = "0.5.6", path = "components/arm_vcpu" }
-arm_vgic = { version = "0.4.7", path = "components/arm_vgic" }
+arm_vcpu = { version = "0.5.7", path = "components/arm_vcpu" }
+arm_vgic = { version = "0.4.8", path = "components/arm_vgic" }
 ax-alloc = { version = "0.7.0", path = "os/arceos/modules/axalloc" }
 ax-allocator = { version = "0.5.0", path = "components/axallocator" }
 ax-api = { version = "0.5.14", path = "os/arceos/api/arceos_api" }
@@ -305,7 +305,7 @@ ax-int-ratio = { version = "0.3.7", path = "components/int_ratio" }
 ax-io = { version = "0.5.5", path = "components/axio" }
 ax-ipi = { version = "0.5.12", path = "os/arceos/modules/axipi" }
 ax-kernel-guard = { version = "0.3.10", path = "components/kernel_guard" }
-ax-lockdep = { version = "0.1.0", path = "components/lockdep" }
+ax-lockdep = { version = "0.1.1", path = "components/lockdep" }
 ax-kspin = { version = "0.3.8", path = "components/kspin" }
 ax-lazyinit = { version = "0.4.7", path = "components/ax-lazyinit" }
 ax-libc = { version = "0.5.13", path = "os/arceos/ulib/axlibc" }
@@ -341,11 +341,11 @@ ax-std = { version = "0.5.13", path = "os/arceos/ulib/axstd" }
 ax-sync = { version = "0.5.13", path = "os/arceos/modules/axsync" }
 ax-task = { version = "0.5.14", path = "os/arceos/modules/axtask" }
 ax-timer-list = { version = "0.3.5", path = "components/timer_list" }
-axaddrspace = { version = "0.5.8", path = "components/axaddrspace" }
+axaddrspace = { version = "0.5.9", path = "components/axaddrspace" }
 axbacktrace = { version = "0.3.9", path = "components/axbacktrace" }
 axbuild = { version = "0.4.6", path = "scripts/axbuild" }
 axdevice = { version = "0.4.8", path = "components/axdevice" }
-axdevice_base = { version = "0.4.8", path = "components/axdevice_base" }
+axdevice_base = { version = "0.4.9", path = "components/axdevice_base" }
 axfs-ng-vfs = { version = "0.4.0", path = "components/axfs-ng-vfs" }
 axhvc = { version = "0.4.6", path = "components/axhvc" }
 axklib = { version = "0.5.7", path = "components/axklib" }
@@ -354,9 +354,9 @@ axplat-riscv64-visionfive2 = { version = "0.1.2", path = "platform/riscv64-visio
 axplat-riscv64-qemu-virt-hv = { version = "0.5.6", path = "platform/riscv64-qemu-virt" }
 axplat-x86-qemu-q35 = { version = "0.4.6", path = "platform/x86-qemu-q35" }
 axpoll = { version = "0.3.9", path = "components/axpoll" }
-axvcpu = { version = "0.5.6", path = "components/axvcpu" }
+axvcpu = { version = "0.5.7", path = "components/axvcpu" }
 axvisor = { version = "0.5.6", path = "os/axvisor" }
-axvisor_api = { version = "0.5.8", path = "components/axvisor_api" }
+axvisor_api = { version = "0.5.9", path = "components/axvisor_api" }
 axvisor_api_proc = { version = "0.5.7", path = "components/axvisor_api/axvisor_api_proc" }
 axvm = { version = "0.5.7", path = "components/axvm", default-features = false }
 axvmconfig = { version = "0.5.0", path = "components/axvmconfig", default-features = false }
@@ -406,7 +406,7 @@ rdrive = { version = "0.20.1", path = "drivers/rdrive" }
 rdrive-macros = { version = "0.4.2", path = "drivers/rdrive-macros" }
 rsext4 = { version = "0.4.0", path = "components/rsext4" }
 scope-local = { version = "0.3.7", path = "components/scope-local" }
-crab-usb = { version = "0.9.2", path = "drivers/usb/usb-host" }
+crab-usb = { version = "0.9.3", path = "drivers/usb/usb-host" }
 crab-uvc = { version = "0.1.1", path = "drivers/usb/usb-device/uvc" }
 ktest-helper = { version = "0.1.1", path = "drivers/usb/utils/ktest-helper" }
 usb-if = { version = "0.7.1", path = "drivers/usb/usb-if" }

--- a/components/arm-scmi-rs/CHANGELOG.md
+++ b/components/arm-scmi-rs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/rcore-os/tgoskits/compare/arm-scmi-rs-v0.1.1...arm-scmi-rs-v0.1.2) - 2026-05-18
+
+### Added
+
+- *(dma-api)* vendor dma and mmio api crates ([#742](https://github.com/rcore-os/tgoskits/pull/742))
+
 ## [0.1.1](https://github.com/rcore-os/tgoskits/releases/tag/arm-scmi-rs-v0.1.1) - 2026-05-16
 
 ### Added

--- a/components/arm-scmi-rs/Cargo.toml
+++ b/components/arm-scmi-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arm-scmi-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 autotests = false
 description = "ARM SCMI (System Control and Management Interface) protocol implementation for no_std embedded environments"

--- a/components/arm_vcpu/CHANGELOG.md
+++ b/components/arm_vcpu/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7](https://github.com/rcore-os/tgoskits/compare/arm_vcpu-v0.5.6...arm_vcpu-v0.5.7) - 2026-05-18
+
+### Other
+
+- updated the following local packages: axaddrspace, axdevice_base, axvisor_api, axvcpu
+
 ## [0.5.6](https://github.com/rcore-os/tgoskits/compare/arm_vcpu-v0.5.5...arm_vcpu-v0.5.6) - 2026-05-15
 
 ### Other

--- a/components/arm_vcpu/Cargo.toml
+++ b/components/arm_vcpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition.workspace = true
 name = "arm_vcpu"
-version = "0.5.6"
+version = "0.5.7"
 authors = [
   "KeYang Hu <keyang.hu@qq.com>",
   "Mingxian Su <aarkegz@gmail.com>",

--- a/components/arm_vgic/CHANGELOG.md
+++ b/components/arm_vgic/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8](https://github.com/rcore-os/tgoskits/compare/arm_vgic-v0.4.7...arm_vgic-v0.4.8) - 2026-05-18
+
+### Other
+
+- updated the following local packages: axaddrspace, axdevice_base, axvisor_api
+
 ## [0.4.7](https://github.com/rcore-os/tgoskits/compare/arm_vgic-v0.4.6...arm_vgic-v0.4.7) - 2026-05-15
 
 ### Other

--- a/components/arm_vgic/Cargo.toml
+++ b/components/arm_vgic/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.4.7"
+version = "0.4.8"
 authors = [
   "Mingxian Su <aarkegz@gmail.com>",
   "DeBin Luo <luodeb@outlook.com>",

--- a/components/axaddrspace/CHANGELOG.md
+++ b/components/axaddrspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/rcore-os/tgoskits/compare/axaddrspace-v0.5.8...axaddrspace-v0.5.9) - 2026-05-18
+
+### Fixed
+
+- *(ci)* address usb release and axaddrspace std failures ([#743](https://github.com/rcore-os/tgoskits/pull/743))
+
 ## [0.5.8](https://github.com/rcore-os/tgoskits/compare/axaddrspace-v0.5.7...axaddrspace-v0.5.8) - 2026-05-15
 
 ### Added

--- a/components/axaddrspace/Cargo.toml
+++ b/components/axaddrspace/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 keywords = ["hypervisor", "address-space"]
 name = "axaddrspace"
 repository = "https://github.com/arceos-hypervisor/axaddrspace"
-version = "0.5.8"
+version = "0.5.9"
 license = "Apache-2.0"
 
 [features]

--- a/components/axdevice_base/CHANGELOG.md
+++ b/components/axdevice_base/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9](https://github.com/rcore-os/tgoskits/compare/axdevice_base-v0.4.8...axdevice_base-v0.4.9) - 2026-05-18
+
+### Other
+
+- updated the following local packages: axaddrspace
+
 ## [0.4.8](https://github.com/rcore-os/tgoskits/compare/axdevice_base-v0.4.7...axdevice_base-v0.4.8) - 2026-05-15
 
 ### Other

--- a/components/axdevice_base/Cargo.toml
+++ b/components/axdevice_base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axdevice_base"
-version = "0.4.8"
+version = "0.4.9"
 edition.workspace = true
 authors = ["Hui Xiao <1127751018@qq.com>"]
 description = "Basic traits and structures for emulated devices in ArceOS hypervisor."

--- a/components/axvcpu/CHANGELOG.md
+++ b/components/axvcpu/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7](https://github.com/rcore-os/tgoskits/compare/axvcpu-v0.5.6...axvcpu-v0.5.7) - 2026-05-18
+
+### Other
+
+- updated the following local packages: axaddrspace, axvisor_api
+
 ## [0.5.6](https://github.com/rcore-os/tgoskits/compare/axvcpu-v0.5.5...axvcpu-v0.5.6) - 2026-05-15
 
 ### Other

--- a/components/axvcpu/Cargo.toml
+++ b/components/axvcpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axvcpu"
 authors = ["aarkegz <aarkegz@gmail.com>"]
-version = "0.5.6"
+version = "0.5.7"
 edition.workspace = true
 categories = ["virtualization", "no-std"]
 description = "Virtual CPU abstraction for ArceOS hypervisor"

--- a/components/axvisor_api/CHANGELOG.md
+++ b/components/axvisor_api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/rcore-os/tgoskits/compare/axvisor_api-v0.5.8...axvisor_api-v0.5.9) - 2026-05-18
+
+### Other
+
+- updated the following local packages: axaddrspace
+
 ## [0.5.8](https://github.com/rcore-os/tgoskits/compare/axvisor_api-v0.5.7...axvisor_api-v0.5.8) - 2026-05-15
 
 ### Other

--- a/components/axvisor_api/Cargo.toml
+++ b/components/axvisor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axvisor_api"
-version = "0.5.8"
+version = "0.5.9"
 description = "Basic API for components of the Hypervisor on ArceOS"
 documentation = "https://docs.rs/axvisor_api"
 readme = "README.md"

--- a/components/dma-api/CHANGELOG.md
+++ b/components/dma-api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/rcore-os/tgoskits/compare/dma-api-v0.7.2...dma-api-v0.7.3) - 2026-05-18
+
+### Added
+
+- *(dma-api)* vendor dma and mmio api crates ([#742](https://github.com/rcore-os/tgoskits/pull/742))
+
 ## [0.7.2](https://github.com/drivercraft/sparreal-os/compare/dma-api-v0.7.1...dma-api-v0.7.2) - 2026-04-10
 
 ### Other

--- a/components/dw_apb_uart/CHANGELOG.md
+++ b/components/dw_apb_uart/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/rcore-os/tgoskits/compare/dw_apb_uart-v0.1.0...dw_apb_uart-v0.1.1) - 2026-05-18
+
+### Added
+
+- *(starry-kernel)* SG2002 extra drivers — ttyS{1,2}, cvi-camera0, /dev/devmem, pwm sysfs, cvi-tpu ([#649](https://github.com/rcore-os/tgoskits/pull/649))

--- a/components/dw_apb_uart/Cargo.toml
+++ b/components/dw_apb_uart/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dw_apb_uart"
 authors = ["Luoyuan Xiao <xiaoluoyuan@163.com>"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Uart snps,dw-apb-uart driver in Rust for BST A1000b FADA board."
 license = "GPL-3.0-or-later OR Apache-2.0 OR MulanPSL-2.0"

--- a/components/lockdep/CHANGELOG.md
+++ b/components/lockdep/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/rcore-os/tgoskits/compare/ax-lockdep-v0.1.0...ax-lockdep-v0.1.1) - 2026-05-18
+
+### Added
+
+- *(lockdep)* support nested lock subclasses ([#616](https://github.com/rcore-os/tgoskits/pull/616))

--- a/components/lockdep/Cargo.toml
+++ b/components/lockdep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-lockdep"
-version = "0.1.0"
+version = "0.1.1"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Shi Lei <shi_lei@massclouds.com>"]

--- a/components/mmio-api/CHANGELOG.md
+++ b/components/mmio-api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/rcore-os/tgoskits/compare/mmio-api-v0.2.1...mmio-api-v0.2.2) - 2026-05-18
+
+### Added
+
+- *(dma-api)* vendor dma and mmio api crates ([#742](https://github.com/rcore-os/tgoskits/pull/742))
+
 ## [0.2.1](https://github.com/drivercraft/sparreal-os/compare/mmio-api-v0.2.0...mmio-api-v0.2.1) - 2026-03-11
 
 ### Other

--- a/drivers/usb/usb-host/CHANGELOG.md
+++ b/drivers/usb/usb-host/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/rcore-os/tgoskits/compare/crab-usb-v0.9.1...crab-usb-v0.9.3) - 2026-05-18
+
+### Added
+
+- *(dma-api)* vendor dma and mmio api crates ([#742](https://github.com/rcore-os/tgoskits/pull/742))
+
+### Fixed
+
+- *(ci)* address usb release and axaddrspace std failures ([#743](https://github.com/rcore-os/tgoskits/pull/743))
+
+### Other
+
+- bump up usb version
+- Refactor USB driver configuration and tests
+- *(drivers)* integrate usb crates into workspace
+
 ## [0.9.1](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.9.0...crab-usb-v0.9.1) - 2026-05-09
 
 ### Other

--- a/drivers/usb/usb-if/CHANGELOG.md
+++ b/drivers/usb/usb-if/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/rcore-os/tgoskits/compare/usb-if-v0.7.0...usb-if-v0.7.1) - 2026-05-18
+
+### Other
+
+- bump up usb version
+- *(drivers)* integrate usb crates into workspace
+
 ## [0.7.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.6.0...usb-if-v0.7.0) - 2026-04-30
 
 ### Other


### PR DESCRIPTION
## 问题

release-plz 工作流目前只在 `dev` 分支 push 后自动运行，无法通过 GitHub Actions 手动触发；同时本次 release metadata 需要随分支一起提交，保持 workspace 版本、锁文件和 changelog 一致。

## 变更

- 为 `.github/workflows/release-plz.yml` 增加 `workflow_dispatch` 手动触发入口。
- 调整 `release-plz-release` 和 `release-plz-pr` 的 job 条件：自动触发仍限制在 `dev`，手动触发时不依赖是否由 release-plz PR 相关流程触发。
- 更新相关 crate 的版本号、workspace dependency、`Cargo.lock` 和 changelog。
- 为 `dw_apb_uart` 与 `ax-lockdep` 补充 changelog 文件。

## 实现逻辑

- 手动触发由 `github.event_name == 'workflow_dispatch'` 显式放行，避免被分支来源判断拦截。
- 自动触发继续通过 `github.ref_name == 'dev'` 保持原有默认分支发布语义。
- 保留 `github.repository == 'rcore-os/tgoskits'` 约束，避免 fork 或非目标仓库执行发布相关 job。

## 本地验证

- 已执行 `python3` + PyYAML 解析 `.github/workflows/release-plz.yml`。
- 已执行 `git diff --check origin/dev...HEAD`。
- 已执行 `cargo fmt --all --check`。
- 按要求未继续运行 clippy 或其他测试。