### PR TITLE
refactor(axbacktrace): replace BacktraceReport with Backtrace::kind()

### DIFF
--- a/components/axbacktrace/src/lib.rs
+++ b/components/axbacktrace/src/lib.rs
@@ -152,11 +152,7 @@ enum Inner {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct Backtrace {
     inner: Inner,
-}
-
-pub struct BacktraceReport<'a> {
-    backtrace: &'a Backtrace,
-    kind: &'static str,
+    kind: Option<&'static str>,
 }
 
 impl Backtrace {
@@ -165,6 +161,7 @@ impl Backtrace {
         #[cfg(not(feature = "alloc"))]
         return Self {
             inner: Inner::Disabled,
+            kind: None,
         };
 
         #[cfg(feature = "alloc")]
@@ -184,6 +181,7 @@ impl Backtrace {
                 } else {
                     return Self {
                         inner: Inner::Unsupported,
+                        kind: None,
                     };
                 }
             }
@@ -194,6 +192,7 @@ impl Backtrace {
 
             Self {
                 inner: Inner::Captured(frames),
+                kind: None,
             }
         }
     }
@@ -204,6 +203,7 @@ impl Backtrace {
         #[cfg(not(feature = "alloc"))]
         return Self {
             inner: Inner::Disabled,
+            kind: None,
         };
 
         #[cfg(feature = "alloc")]
@@ -226,8 +226,15 @@ impl Backtrace {
 
             Self {
                 inner: Inner::Captured(frames),
+                kind: None,
             }
         }
+    }
+
+    /// Sets the backtrace kind for machine-parseable raw output via [`Display`].
+    pub fn kind(mut self, kind: &'static str) -> Self {
+        self.kind = Some(kind);
+        self
     }
 
     /// Visit each stack frame in the captured backtrace in order.
@@ -241,29 +248,22 @@ impl Backtrace {
 
         Some(FrameIter::new(capture))
     }
-
-    pub fn report(&self, kind: &'static str) -> BacktraceReport<'_> {
-        BacktraceReport {
-            backtrace: self,
-            kind,
-        }
-    }
 }
 
-impl fmt::Display for BacktraceReport<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Backtrace {
+    fn fmt_raw_block(&self, f: &mut fmt::Formatter<'_>, kind: &'static str) -> fmt::Result {
         let arch = TARGET_ARCH;
 
         writeln!(
             f,
             "BACKTRACE_BEGIN kind={} arch={} alloc={} dwarf={}",
-            self.kind,
+            kind,
             arch,
             cfg!(feature = "alloc"),
             cfg!(feature = "dwarf")
         )?;
 
-        match &self.backtrace.inner {
+        match &self.inner {
             Inner::Unsupported => {
                 writeln!(f, "BT_ERROR unsupported")?;
             }
@@ -288,6 +288,10 @@ impl fmt::Display for BacktraceReport<'_> {
 
 impl fmt::Display for Backtrace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(kind) = self.kind {
+            return self.fmt_raw_block(f, kind);
+        }
+
         match &self.inner {
             Inner::Unsupported => {
                 writeln!(f, "<unwinding unsupported>")
@@ -358,6 +362,21 @@ mod tests {
         let (frames, start_fp) = boxed_frame_chain(&[0x1111, 0x2222, 0x3333]);
         let out = unwind_stack(start_fp);
         assert_eq!(out, frames.as_ref());
+    }
+
+    #[test]
+    fn kind_formats_raw_block_without_dwarf() {
+        init_for_tests();
+        let (_frames, start_fp) = boxed_frame_chain(&[0xdead, 0xbeef]);
+        let s = alloc::format!(
+            "{}",
+            Backtrace::capture_trap(start_fp, 0x1000, 0xbeef).kind("raw")
+        );
+        assert!(s.contains("BACKTRACE_BEGIN kind=raw"));
+        assert!(s.contains("BT 0 ip=0x1001 fp="));
+        assert!(s.contains("BT 1 ip=0xbeef fp="));
+        assert!(s.ends_with("BACKTRACE_END\n"));
+        assert!(!s.contains("Backtrace:"));
     }
 
     #[test]

--- a/components/axcpu/src/aarch64/trap.rs
+++ b/components/axcpu/src/aarch64/trap.rs
@@ -98,7 +98,7 @@ fn handle_page_fault(tf: &mut TrapFrame, access_flags: PageFaultFlags) {
         esr_value(),
         access_flags,
         tf,
-        bt.report("trap")
+        bt.kind("trap")
     );
 }
 
@@ -114,7 +114,7 @@ fn aarch64_trap_handler(tf: &mut TrapFrame, kind: TrapKind, source: TrapSource) 
             kind,
             source,
             tf,
-            bt.report("trap")
+            bt.kind("trap")
         );
     }
     match kind {
@@ -124,7 +124,7 @@ fn aarch64_trap_handler(tf: &mut TrapFrame, kind: TrapKind, source: TrapSource) 
                 "Unhandled exception {:?}:\n{:#x?}\n{}",
                 kind,
                 tf,
-                bt.report("trap")
+                bt.kind("trap")
             );
         }
         TrapKind::Irq => {
@@ -209,7 +209,7 @@ fn aarch64_trap_handler(tf: &mut TrapFrame, kind: TrapKind, source: TrapSource) 
                         ec_bits,
                         vaddr,
                         iss,
-                        bt.report("trap")
+                        bt.kind("trap")
                     );
                 }
             }

--- a/components/axcpu/src/loongarch64/trap.rs
+++ b/components/axcpu/src/loongarch64/trap.rs
@@ -40,7 +40,7 @@ fn handle_page_fault(tf: &mut TrapFrame, access_flags: PageFaultFlags) {
         vaddr,
         access_flags,
         tf,
-        bt.report("trap")
+        bt.kind("trap")
     );
 }
 
@@ -76,7 +76,7 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame) {
                 trap,
                 tf.era,
                 tf,
-                bt.report("trap")
+                bt.kind("trap")
             );
         }
     }

--- a/components/axcpu/src/riscv/trap.rs
+++ b/components/axcpu/src/riscv/trap.rs
@@ -42,7 +42,7 @@ fn handle_page_fault(tf: &mut TrapFrame, access_flags: PageFaultFlags) {
         vaddr,
         access_flags,
         tf,
-        bt.report("trap")
+        bt.kind("trap")
     );
 }
 
@@ -68,7 +68,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame) {
                     tf.sepc,
                     stval::read(),
                     tf,
-                    bt.report("trap")
+                    bt.kind("trap")
                 );
             }
         }
@@ -79,7 +79,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame) {
             scause.cause(),
             tf.sepc,
             tf,
-            bt.report("trap")
+            bt.kind("trap")
         );
     }
 

--- a/components/axcpu/src/x86_64/trap.rs
+++ b/components/axcpu/src/x86_64/trap.rs
@@ -39,7 +39,7 @@ fn handle_page_fault(tf: &mut TrapFrame) {
         tf.error_code,
         access_flags,
         tf,
-        bt.report("trap")
+        bt.kind("trap")
     );
 }
 
@@ -59,7 +59,7 @@ fn handle_debug(tf: &mut TrapFrame) {
         tf.rip,
         tf.error_code,
         tf,
-        bt.report("trap")
+        bt.kind("trap")
     );
 }
 
@@ -76,7 +76,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
                 tf.rip,
                 tf.error_code,
                 tf,
-                bt.report("trap")
+                bt.kind("trap")
             );
         }
         IRQ_VECTOR_START..=IRQ_VECTOR_END => {
@@ -91,7 +91,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
                 tf.error_code,
                 tf.rip,
                 tf,
-                bt.report("trap")
+                bt.kind("trap")
             );
         }
     }

--- a/docs/docs/components/crates/axbacktrace.md
+++ b/docs/docs/components/crates/axbacktrace.md
@@ -107,7 +107,7 @@ axbacktrace = { workspace = true, features = ["dwarf"] }
 
 ### Host 离线符号化（Issue #146）
 
-Target 可通过 `Backtrace::report(kind)` 输出机器可解析的 raw 块（`BACKTRACE_BEGIN` / `BT` / `BACKTRACE_END`），在 host 上用 `cargo xtask backtrace symbolize` 对日志与 ELF 做符号化。用法与后续「测试结束后自动 symbolize」计划见 [Backtrace Host 符号化](../../debug/backtrace-host-symbolize.md)（PR #635 / #646）。
+Target 可通过 `Backtrace::capture().kind(kind)` 输出机器可解析的 raw 块（`BACKTRACE_BEGIN` / `BT` / `BACKTRACE_END`），在 host 上用 `cargo xtask backtrace symbolize` 对日志与 ELF 做符号化。用法与后续「测试结束后自动 symbolize」计划见 [Backtrace Host 符号化](../../debug/backtrace-host-symbolize.md)（PR #635 / #646）。
 
 ### 注意事项
 1. 修改架构相关帧指针读取逻辑时，必须同步检查 `capture()` 和 `capture_trap()` 两条路径。

--- a/docs/docs/debug/backtrace-host-symbolize.md
+++ b/docs/docs/debug/backtrace-host-symbolize.md
@@ -28,7 +28,7 @@ sidebar_label: "Backtrace Host 符号化"
 
 1. **Host 工具**：`PATH` 中可执行 `llvm-addr2line` 或 `addr2line`。
 2. **ELF**：与产生日志的那次构建一致（例如 `target/x86_64-unknown-none/release/arceos-backtrace-raw-normal`），且含 debug 信息（测例通常通过 `[env] DWARF=y` 等打开帧指针与调试构建）。
-3. **日志**：串口或 QEMU 输出中已包含 target 打印的 raw 块（例如 `Backtrace::report("raw")`、panic 路径的 `report("panic")`、trap 的 `report("trap")`）。
+3. **日志**：串口或 QEMU 输出中已包含 target 打印的 raw 块（例如 `Backtrace::capture().kind("raw")`、panic 路径的 `.kind("panic")`、trap 的 `.kind("trap")`）。
 
 ## 命令
 
@@ -57,7 +57,7 @@ cargo xtask backtrace symbolize \
 
 ## Target 日志格式（输入）
 
-工具解析如下块（与 `axbacktrace` 的 `BacktraceReport` / `report(kind)` 输出一致）：
+工具解析如下块（与 `axbacktrace` 在设置 `kind` 后的 [`Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) 输出一致）：
 
 ```text
 BACKTRACE_BEGIN kind=raw arch=x86_64 alloc=true dwarf=true

--- a/os/arceos/modules/axruntime/src/lang_items.rs
+++ b/os/arceos/modules/axruntime/src/lang_items.rs
@@ -40,8 +40,7 @@ fn panic_message(info: &PanicInfo) {
 
 fn panic_backtrace() {
     if should_print_panic_backtrace() {
-        let bt = axbacktrace::Backtrace::capture();
-        ax_println!("{}", bt.report("panic"));
+        ax_println!("{}", axbacktrace::Backtrace::capture().kind("panic"));
     }
 }
 

--- a/test-suit/arceos/rust/backtrace-raw-badfp/src/main.rs
+++ b/test-suit/arceos/rust/backtrace-raw-badfp/src/main.rs
@@ -26,7 +26,7 @@ fn emit_invalid_fp_report() {
     let anchor = 0usize;
     let fp = (&anchor as *const usize as usize).wrapping_add(1);
     let bt = Backtrace::capture_trap(fp, 0, 0);
-    println!("{}", bt.report("raw"));
+    println!("{}", bt.kind("raw"));
 }
 
 #[cfg_attr(feature = "ax-std", unsafe(no_mangle))]

--- a/test-suit/arceos/rust/backtrace-raw-basic/src/main.rs
+++ b/test-suit/arceos/rust/backtrace-raw-basic/src/main.rs
@@ -31,7 +31,7 @@ fn panic_path() {
 #[inline(never)]
 fn c() {
     let bt = Backtrace::capture();
-    println!("{}", bt.report("raw"));
+    println!("{}", bt.kind("raw"));
     core::hint::black_box(());
 }
 

--- a/test-suit/arceos/rust/backtrace-raw-normal/src/main.rs
+++ b/test-suit/arceos/rust/backtrace-raw-normal/src/main.rs
@@ -24,7 +24,7 @@ use std::println;
 #[inline(never)]
 fn c() {
     let bt = Backtrace::capture();
-    println!("{}", bt.report("raw"));
+    println!("{}", bt.kind("raw"));
     core::hint::black_box(());
 }
 

--- a/test-suit/arceos/rust/backtrace/src/main.rs
+++ b/test-suit/arceos/rust/backtrace/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
 
     println!("Running backtrace tests...");
     let bt = axbacktrace::Backtrace::capture();
-    println!("{}", bt.report("test"));
+    println!("{}", bt.kind("test"));
     println!("test pass");
     ax_hal::power::system_off();
 }


### PR DESCRIPTION
Tracking issue: #146

## 背景

助教 review 建议：不要在 `Backtrace` 外再引入 `BacktraceReport` 类型，而是在 `Backtrace` 上增加 `kind` 字段，由 `capture()` 时留空，打印前通过链式调用设置，例如：

```rust
println!("{}", Backtrace::capture().kind("panic"));
```

本 PR 在 #619 / #635 / #646 已合入 `dev` 的基础上完成该 API 调整，**不改变** raw 日志协议（`BACKTRACE_BEGIN` / `BT` / `BACKTRACE_END`）及 host `cargo xtask backtrace symbolize` 的解析方式。

## 改动摘要

- 在 `Backtrace` 上增加 `kind: Option<&'static str>`；`capture()` / `capture_trap()` 默认 `kind = None`。
- 新增 `pub fn kind(mut self, kind: &'static str) -> Self`。
- 删除 `BacktraceReport` 与 `Backtrace::report()`。
- **`Display` 行为**：
  - 已设置 `kind`（如 `.kind("raw")`）→ 输出机器可解析的 raw 块（与原先 `report(kind)` 一致）。
  - 未设置 `kind` → 保持原有人类可读格式（`Backtrace:` + 帧列表；开启 `dwarf` 时仍可在线符号化），供 alloc tracking 等路径使用。

## 调用点更新

| 场景 | 原写法 | 新写法 |
|------|--------|--------|
| panic | `bt.report("panic")` | `Backtrace::capture().kind("panic")` |
| trap | `bt.report("trap")` | `bt.kind("trap")` |
| 测例 raw | `bt.report("raw")` | `bt.kind("raw")` |

涉及：`axruntime` panic、`axcpu` 各 arch trap、`backtrace` / `backtrace-raw-*` 测例。

## 文档

- 更新 `docs/docs/debug/backtrace-host-symbolize.md`
- 更新 `docs/docs/components/crates/axbacktrace.md`

将文中 `report(kind)` 改为 `kind()` 用法说明。

## 验证

```bash
cargo fmt -p axbacktrace
cargo test -p axbacktrace --features alloc
cargo clippy -p axbacktrace --all-features -- -D warnings
```

（本地均已通过。）

可选 QEMU 冒烟：

```bash
cargo xtask arceos test qemu --arch x86_64 --test-group rust --test-case backtrace-raw-normal
```

## 范围说明（本 PR 不做）

- host 跑完自动 symbolize（计划单独 follow-up PR）
- axalloc tracking / Starry memtrack 统一 raw 块（计划单独 follow-up PR）
- 函数实参打印

## 关联 PR

- #619 — raw 块与 unwind 基础
- #635 — host `backtrace symbolize`
- #646 — ArceOS raw backtrace E2E 测例

Made with [Cursor](https://cursor.com)