### PR TITLE
test(busybox): exercise busybox add-shell real /etc/shells rewrite path

### DIFF
--- a/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
@@ -944,6 +944,39 @@ _rc=$?; if [ "$_rc" -eq 0 ] && echo "$_t" | grep -q "[0-9]"; then echo "PASS: bl
 _t=$({ timeout 10 sh -c "busybox hwclock -r 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "hwclock"; then echo "PASS: busybox_hwclock"; PASS=$((PASS+1)); else echo "FAIL: busybox_hwclock"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
+# busybox_add_shell — exercise the real /etc/shells rewrite path (NOT --help).
+# add-shell opens /etc/shells O_RDONLY, opens /etc/shells.tmp
+# O_WRONLY|O_CREAT|O_TRUNC, writes the merged list, then rename(2)s
+# /etc/shells.tmp over /etc/shells.  Probe a unique path each run, verify
+# it lands in /etc/shells, verify the .tmp file did NOT leak, and restore
+# the original file so re-runs stay idempotent.
+_addshell_probe="/tmp/bb_addshell_probe_$$"
+_t=$(timeout 15 sh -c '
+    busybox cp /etc/shells /tmp/bb_addshell_backup
+    _probe='"$_addshell_probe"'
+    busybox add-shell "$_probe" 2>&1
+    _arc=$?
+    if [ "$_arc" = 0 ] \
+        && busybox grep -qxF "$_probe" /etc/shells \
+        && [ ! -e /etc/shells.tmp ]; then
+        busybox echo add_shell_ok
+    else
+        busybox echo "add_shell_failed arc=$_arc"
+        busybox echo "--- /etc/shells ---"
+        busybox cat /etc/shells 2>&1
+        busybox echo "--- /etc/shells.tmp (should not exist) ---"
+        busybox ls -la /etc/shells.tmp 2>&1
+    fi
+    busybox cp /tmp/bb_addshell_backup /etc/shells 2>&1 || true
+    busybox rm -f /tmp/bb_addshell_backup
+' 2>&1)
+if echo "$_t" | grep -qF "add_shell_ok"; then
+    echo "PASS: busybox_add_shell"; PASS=$((PASS+1))
+else
+    echo "FAIL: busybox_add_shell"; echo "$_t"
+    FAIL=$((FAIL+1))
+fi
+
 # Additional stable BusyBox semantics for shell-script compatibility.
 _t=$({ timeout 10 sh -c "busybox sh -c 'busybox rm -f /tmp/bb_sem_touch_missing && busybox touch -c /tmp/bb_sem_touch_missing && busybox test ! -e /tmp/bb_sem_touch_missing && busybox echo touch_no_create_ok' 2>&1"; } 2>&1)
 if echo "$_t" | grep -qxF "touch_no_create_ok"; then echo "PASS: busybox_touch_no_create"; PASS=$((PASS+1)); else echo "FAIL: busybox_touch_no_create"; echo "$_t"; FAIL=$((FAIL+1)); fi


### PR DESCRIPTION
> Supersedes #723。#723 走 `busybox add-shell --help` 触发顶层 dispatch 的 usage banner，并未触及 `add_remove_shell_main` 真正会跑的 `/etc/shells` 读 + `/etc/shells.tmp` 写 + `rename(2)` 路径。本 PR 改用真实硬路径，并按 `busybox-fix-workflow.md` §5 重做了核验。

## 问题

issue [rcore-os/linux-compatible-testsuit#13](https://github.com/rcore-os/linux-compatible-testsuit/issues/13) 中 `busybox_add_shell` 原文验证只是 `[ -n "$_t" ]`，门槛极低。#723 利用这个弱验证用 `--help` banner 过线，未证伪以下三件事：
1. busybox 能在 StarryOS 上以 `O_WRONLY|O_CREAT|O_TRUNC` 打开 `/etc/shells.tmp`；
2. `rename("/etc/shells.tmp", "/etc/shells")` 在同一目录 `/etc` 内可用；
3. `/etc/shells` 在 rootfs 中存在且 root 可写。

## Claim（§5.3）

`busybox add-shell <new-path>` 在 StarryOS riscv64 上**已可用**，无内核 bug。具体调用链（依据 `loginutils/add-remove-shell.c`）：

- `fopen_for_read("/etc/shells")` — 走 `open(O_RDONLY)`，rootfs `/etc/shells` 由镜像内置 `"# valid login shells\n/bin/sh\n/bin/ash\n"`；
- `open("/etc/shells.tmp", O_WRONLY|O_CREAT|O_TRUNC, 0644)` — 仅 `O_TRUNC`（**不**带 `O_APPEND`），`axfs-ng/src/highlevel/file.rs` 的 `is_valid` 早已接受；
- 写合并行 → `fclose(stdout)` flush；
- `rename("/etc/shells.tmp", "/etc/shells")` 由 `os/StarryOS/kernel/src/syscall/fs/ctl.rs:620-655` 的 `sys_renameat2` 处理，对同目录 rename 无特殊限制；
- rc=0 返回。

PR #723 当时观察到 `busybox add-shell /bin/sh` 静默 rc=0，**误判**为"路径被吞掉"。实际上 `/bin/sh` 已在 `/etc/shells` 内，busybox 按源码走 `dont_add` 分支静默成功是正确行为。换成唯一新路径即可强制走完 write + rename。

## 改动

1. `test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh`：在 `busybox_hwclock` 之后插入 `busybox_add_shell` 真实 round-trip 探针；用 `$$` 形成唯一 probe 路径以绕开 `dont_add`，并在结束时把 `/etc/shells` 恢复，保证重复运行幂等。

PR #723 是 banner 弱版本，本 PR 取代之后建议关闭 #723。

## 逻辑

- 探针的 PASS 条件是三条 AND：(a) busybox `add-shell` rc=0；(b) `grep -qxF "$probe" /etc/shells` 命中；(c) `/etc/shells.tmp` **不**存在（已被 `rename(2)` 替换走）。任何一条不成立就 FAIL 并 dump `/etc/shells` + `/etc/shells.tmp` 现场。
- 因此本测试反向证伪如下回归：内核 `is_valid` 拒掉 `O_TRUNC` / `sys_renameat2` 在同目录 rename 返非 0 / rootfs 缺失 `/etc/shells` / busybox 写完未 rename（`.tmp` 残留）等。
- 与 `busybox_crontab`（PR #750）思路一致：硬约束 = "marker 出现 ∧ 状态符合预期 ∧ 中间文件不残留"。

## 反向自检（§5.6）

1. **是否绕开真实代码路径？** 否。命令是 `busybox add-shell <unique-path>`，`add_remove_shell_main` 必定走 read+write+rename；唯一路径绕开了 `dont_add` 早退分支。
2. **busybox 是否偷偷 fallback？** 否。源码 `loginutils/add-remove-shell.c` 仅有 `dont_add` 早退（被本测试唯一路径排除）和 `rename` 失败时的 `unlink(.tmp)` 回退（被本测试 `.tmp 不存在 + grep 命中`双断言反向 detect）。
3. **Linux/POSIX 语义对齐？** 是。stdout 静默、rc=0、`/etc/shells` 末行新增、`/etc/shells.tmp` 不残留——与 alpine/Debian busybox 一致。本探针使用的 marker `add_shell_ok` 是 shell 侧自造，但断言条件就是源码语义。
4. **是否引入未测试的旁路？** 否，本 PR 只动测试脚本，无内核新代码。

## 验证

- `cargo fmt --check`：clean（无 Rust 改动，按 AGENTS.md 仍跑过一遍）。
- Clippy：N/A（无 Rust 改动）。
- `cargo xtask starry test qemu --arch riscv64 -c busybox` → `PASS: 315 FAIL: 0 TOTAL: 315`。
  - 基线 commit：rcore/dev `15421a8f8`（基线 PASS=314，本 PR 新增 `busybox_add_shell` 1 项，对齐 +1）。
  - 无 panic、无新 FAIL、无回归。