### PR TITLE
test(starry): remove non-semantic BusyBox checks

### DIFF
--- a/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/busybox/sh/busybox-tests.sh
@@ -783,8 +783,8 @@ c
 ' | busybox wc -l 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "3"; then echo "PASS: busybox_wc"; PASS=$((PASS+1)); else echo "FAIL: busybox_wc"; FAIL=$((FAIL+1)); fi
 
-_t=$({ timeout 10 sh -c "busybox wget -h 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "Usage: wget"; then echo "PASS: busybox_wget"; PASS=$((PASS+1)); else echo "FAIL: busybox_wget"; FAIL=$((FAIL+1)); fi
+_t=$({ timeout 30 sh -c "busybox rm -f /tmp/bb_wget.html && busybox wget -O /tmp/bb_wget.html http://example.com/ 2>&1 && busybox test -s /tmp/bb_wget.html && busybox grep -qi example /tmp/bb_wget.html && busybox echo wget_download_ok"; } 2>&1)
+if echo "$_t" | grep -qF "wget_download_ok"; then echo "PASS: busybox_wget"; PASS=$((PASS+1)); else echo "FAIL: busybox_wget"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
 _t=$({ timeout 10 sh -c "busybox which busybox 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "busybox"; then echo "PASS: busybox_which"; PASS=$((PASS+1)); else echo "FAIL: busybox_which"; FAIL=$((FAIL+1)); fi
@@ -852,44 +852,20 @@ if echo "$_t" | grep -qF "test"; then echo "PASS: busybox_lzcat"; PASS=$((PASS+1
 _t=$({ timeout 10 sh -c "busybox sh -c 'busybox printf %s XQAAgAD//////////wA2Hondf+Fbcap///6gWAA= | busybox base64 -d > /tmp/bb_lzma.lzma && busybox lzma -dc /tmp/bb_lzma.lzma' 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "lzma_t"; then echo "PASS: busybox_lzma"; PASS=$((PASS+1)); else echo "FAIL: busybox_lzma"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
-_t=$({ timeout 10 sh -c "busybox fdflush -h 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "fdflush:"; then echo "PASS: busybox_fdflush"; PASS=$((PASS+1)); else echo "FAIL: busybox_fdflush"; echo "$_t"; FAIL=$((FAIL+1)); fi
-
 _t=$({ timeout 10 sh -c "busybox ifconfig 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "eth0"; then echo "PASS: busybox_ifconfig"; PASS=$((PASS+1)); else echo "FAIL: busybox_ifconfig"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
 _t=$({ timeout 10 sh -c "busybox ifenslave 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "eth0" && echo "$_t" | grep -qF "lo"; then echo "PASS: busybox_ifenslave"; PASS=$((PASS+1)); else echo "FAIL: busybox_ifenslave"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
-_t=$({ timeout 10 sh -c "busybox insmod 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "Usage: insmod"; then echo "PASS: busybox_insmod"; PASS=$((PASS+1)); else echo "FAIL: busybox_insmod"; echo "$_t"; FAIL=$((FAIL+1)); fi
-
-_t=$({ timeout 10 sh -c "busybox killall5 --help 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "Usage: killall5"; then echo "PASS: busybox_killall5"; PASS=$((PASS+1)); else echo "FAIL: busybox_killall5"; echo "$_t"; FAIL=$((FAIL+1)); fi
-
 _t=$({ timeout 10 sh -c "busybox ping -c 1 127.0.0.1 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "1 packets transmitted"; then echo "PASS: busybox_ping"; PASS=$((PASS+1)); else echo "FAIL: busybox_ping"; echo "$_t"; FAIL=$((FAIL+1)); fi
+if echo "$_t" | grep -qF "1 packets transmitted" && echo "$_t" | grep -qE "1 packets? received|1 received" && echo "$_t" | grep -qF "0% packet loss"; then echo "PASS: busybox_ping"; PASS=$((PASS+1)); else echo "FAIL: busybox_ping"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
 _t=$({ timeout 10 sh -c "busybox printf abc | busybox pipe_progress 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "abc"; then echo "PASS: busybox_pipe_progress"; PASS=$((PASS+1)); else echo "FAIL: busybox_pipe_progress"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
-_t=$({ timeout 10 sh -c "busybox raidautorun --help 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "Usage: raidautorun"; then echo "PASS: busybox_raidautorun"; PASS=$((PASS+1)); else echo "FAIL: busybox_raidautorun"; echo "$_t"; FAIL=$((FAIL+1)); fi
-
-_t=$({ timeout 10 sh -c "busybox rdev --help 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "Usage: rdev"; then echo "PASS: busybox_rdev"; PASS=$((PASS+1)); else echo "FAIL: busybox_rdev"; echo "$_t"; FAIL=$((FAIL+1)); fi
-
 _t=$({ timeout 10 sh -c "busybox iostat 1 1 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "avg-cpu"; then echo "PASS: busybox_iostat"; PASS=$((PASS+1)); else echo "FAIL: busybox_iostat"; echo "$_t"; FAIL=$((FAIL+1)); fi
-
-_t=$({ timeout 10 sh -c "busybox remove-shell --help 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "Usage: remove-shell"; then echo "PASS: busybox_remove_shell"; PASS=$((PASS+1)); else echo "FAIL: busybox_remove_shell"; echo "$_t"; FAIL=$((FAIL+1)); fi
-
-_t=$({ timeout 10 sh -c "busybox resize --help 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "Usage: resize"; then echo "PASS: busybox_resize"; PASS=$((PASS+1)); else echo "FAIL: busybox_resize"; echo "$_t"; FAIL=$((FAIL+1)); fi
-
-_t=$({ timeout 10 sh -c "busybox setlogcons --help 2>&1"; } 2>&1)
-if echo "$_t" | grep -qF "Usage: setlogcons"; then echo "PASS: busybox_setlogcons"; PASS=$((PASS+1)); else echo "FAIL: busybox_setlogcons"; echo "$_t"; FAIL=$((FAIL+1)); fi
 
 _t=$({ timeout 10 sh -c "busybox sh -c 'busybox rm -rf /tmp/bb_spl && busybox mkdir -p /tmp/bb_spl && busybox printf abcdef > /tmp/bb_spl/in && busybox split -b2 /tmp/bb_spl/in /tmp/bb_spl/o && busybox cat /tmp/bb_spl/oaa' 2>&1"; } 2>&1)
 if echo "$_t" | grep -qF "ab"; then echo "PASS: busybox_split"; PASS=$((PASS+1)); else echo "FAIL: busybox_split"; echo "$_t"; FAIL=$((FAIL+1)); fi


### PR DESCRIPTION
## 问题

#668 为 BusyBox 补充了一批 applet 测例，但其中部分新增项只检查 `--help`、`-h` 或无参数 usage 输出，并没有验证对应 Linux applet 的真实功能语义。这会让 BusyBox 总 PASS 数看起来覆盖更完整，但实际只能证明 applet 被编译进 BusyBox，不能证明 StarryOS 支持相关内核能力。

## 改动

1. 移除以下非语义验证测例：
   - `fdflush`
   - `insmod`
   - `killall5`
   - `raidautorun`
   - `rdev`
   - `remove-shell`
   - `resize`
   - `setlogcons`

2. 保留有实际行为验证的 BusyBox applet 测例，例如 `ifconfig`、`ifenslave`、`ping`、`pipe_progress`、`iostat`、`getopt`、`lzcat/lzma`、`split`、`nohup`、`run-parts` 等。

3. 加强已有网络相关测例：
   - `wget` 从帮助输出检查改为真实 HTTP 下载并校验文件内容
   - `ping` 从只检查 transmitted 改为同时检查 received 和 `0% packet loss`

## 验证

```text
docker run --rm --platform linux/amd64 -v "$(pwd)":/workspace -w /workspace ghcr.io/rcore-os/tgoskits-container:latest cargo xtask starry test qemu --arch riscv64 -c busybox
```
PASS: 306  FAIL: 0  TOTAL: 306
result: 1/1 case(s) passed
all starry normal qemu tests passed