### PR TITLE
[AxVisor] add x86_64 UEFI guest support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,14 @@ jobs:
             container_image: base
             limit_to_owner: ""
             main_pr_only: false
+          - name: Test axvmconfig config validation
+            use_container: true
+            runs_on: '["ubuntu-latest"]'
+            command: cargo test -p axvmconfig --lib
+            cache_key: test-axvmconfig
+            container_image: base
+            limit_to_owner: ""
+            main_pr_only: false
           - name: Test axvisor aarch64 qemu
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
@@ -458,6 +466,39 @@ jobs:
             container_image: ""
             limit_to_owner: rcore-os
             main_pr_only: false
+          - name: Test axvisor self-hosted x86_64 UEFI
+            use_container: false
+            runs_on: '["self-hosted","linux","intel","kvm"]'
+            timeout_minutes: 20
+            command: |
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends ovmf
+              UEFI_FIRMWARE=""
+              for candidate in \
+                /usr/share/OVMF/OVMF_CODE_4M.fd \
+                /usr/share/OVMF/OVMF_CODE.fd \
+                /usr/share/ovmf/OVMF.fd \
+                /usr/share/qemu/OVMF.fd; do
+                if [ -f "${candidate}" ]; then
+                  UEFI_FIRMWARE="${candidate}"
+                  break
+                fi
+              done
+              if [ -z "${UEFI_FIRMWARE}" ]; then
+                echo "ERROR: installed OVMF firmware image was not found under /usr/share." >&2
+                exit 1
+              fi
+              export AXVISOR_X86_64_UEFI_FIRMWARE="${UEFI_FIRMWARE}"
+              cd os/axvisor
+              ./scripts/setup_qemu.sh nimbos-uefi
+              grep -q 'boot_protocol = "uefi"' tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml
+              grep -q 'uefi_firmware_path = "' tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml
+              cd ../..
+              cargo xtask axvisor test qemu --arch x86_64 --test-group uefi --test-case qemu-nimbos
+            cache_key: ""
+            container_image: ""
+            limit_to_owner: rcore-os
+            main_pr_only: false
           - name: Test axvisor x86_64 svm hosted
             use_container: false
             runs_on: '["ubuntu-latest"]'
@@ -564,6 +605,7 @@ jobs:
       limit_to_owner: ${{ matrix.limit_to_owner }}
       main_pr_only: ${{ matrix.main_pr_only }}
       fetch_depth: ${{ matrix.fetch_depth == 'full' && '0' || '1' }}
+      timeout_minutes: ${{ matrix.timeout_minutes || 360 }}
 
   publish_base_container:
     name: Publish base container image

--- a/.github/workflows/reusable-command.yml
+++ b/.github/workflows/reusable-command.yml
@@ -47,6 +47,11 @@ on:
         required: false
         type: string
         default: "1"
+      timeout_minutes:
+        description: Maximum minutes to allow the command job to run.
+        required: false
+        type: number
+        default: 360
 jobs:
   run_host:
     if: >-
@@ -56,6 +61,7 @@ jobs:
         && (!inputs.main_pr_only || (github.event_name == 'pull_request' && github.base_ref == 'main'))
       }}
     runs-on: ${{ fromJson(inputs.runs_on) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -85,6 +91,7 @@ jobs:
         && (!inputs.main_pr_only || (github.event_name == 'pull_request' && github.base_ref == 'main'))
       }}
     runs-on: ${{ fromJson(inputs.runs_on) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     container:
       image: ${{ inputs.container_image }}
       credentials:

--- a/docs/docs/components/crates/axvmconfig.md
+++ b/docs/docs/components/crates/axvmconfig.md
@@ -62,6 +62,7 @@
 
 - `entry_point`
 - `kernel_path` / `kernel_load_addr`
+- `boot_protocol`
 - `bios_path` / `bios_load_addr`
 - `dtb_path` / `dtb_load_addr`
 - `ramdisk_path` / `ramdisk_load_addr`
@@ -69,6 +70,8 @@
 - `cmdline`
 - `disk_path`
 - `memory_regions: Vec<VmMemConfig>`
+
+`boot_protocol` describes how the guest enters its boot image. It defaults to `direct` when `enable_bios = false`, and keeps the historical `multiboot` behavior when `enable_bios = true` and the field is omitted. x86_64 guests can set `boot_protocol = "uefi"` to load an external UEFI firmware image without applying the legacy axvm-bios multiboot patch.
 
 `VmMemConfig` 则把每段 guest 物理内存刻画为：
 

--- a/os/axvisor/.github/workflows/qemu-x86_64-arceos-uefi.toml
+++ b/os/axvisor/.github/workflows/qemu-x86_64-arceos-uefi.toml
@@ -1,0 +1,17 @@
+args = [
+  "-m",
+  "128M",
+  "-smp",
+  "1",
+  "-machine",
+  "q35",
+  "-nographic",
+  "-accel",
+  "kvm",
+  "-cpu",
+  "host",
+]
+fail_regex = ["panicked at"]
+success_regex = ["Hello, world!"]
+to_bin = false
+uefi = false

--- a/os/axvisor/.github/workflows/qemu-x86_64-uefi.toml
+++ b/os/axvisor/.github/workflows/qemu-x86_64-uefi.toml
@@ -1,0 +1,21 @@
+args = [
+  "-m",
+  "128M",
+  "-smp",
+  "1",
+  "-machine",
+  "q35",
+  "-device",
+  "virtio-blk-pci,drive=disk0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspaceFolder}/tmp/rootfs.img",
+  "-nographic",
+  "-accel",
+  "kvm",
+  "-cpu",
+  "host",
+]
+fail_regex = ["System will reboot, press any key to continue ..."]
+success_regex = ["usertests passed!"]
+to_bin = false
+uefi = false

--- a/os/axvisor/README.md
+++ b/os/axvisor/README.md
@@ -79,6 +79,8 @@ Guest configuration files are located in the `configs/vms/` directory, defining 
 
 The configuration file naming format is `<os>-<arch>-board_or_cpu-smpx`, where `<os>` is the guest system name (such as `arceos`, `linux`, `nimbos`), `<arch>` is the architecture (such as `aarch64`, `x86_64`, `riscv64`), `board_or_cpu` is the hardware development board or CPU name, and `smpx` is the number of CPUs allocated to the guest.
 
+On x86_64, `boot_protocol` selects the guest firmware flow. `multiboot` keeps the legacy `axvm-bios` path and patches the generated multiboot info into the BIOS image, while `uefi` loads the external firmware from `uefi_firmware_path` without multiboot patching. Legacy UEFI configs that still use `bios_path` are accepted as a compatibility fallback. See `configs/vms/linux-x86_64-qemu-uefi-smp1.toml`, `configs/vms/arceos-x86_64-qemu-uefi-smp1.toml`, and the QEMU quickstart for the UEFI guest path.
+
 ## Compilation
 
 AxVisor uses the xtask tool for build management, supporting multiple hardware platforms and configuration options. For a quick build and run of AxVisor, please refer to the [Quick Start](https://arceos-hypervisor.github.io/axvisorbook/docs/category/quickstart) chapter in the configuration documentation.

--- a/os/axvisor/build.rs
+++ b/os/axvisor/build.rs
@@ -124,6 +124,25 @@ struct MemoryImage {
     pub ramdisk: Option<PathBuf>,
 }
 
+fn boot_firmware_path<'a>(kernel_config: &'a Table, enable_bios: bool) -> Option<&'a str> {
+    if !enable_bios {
+        return None;
+    }
+
+    let bios_path = || kernel_config.get("bios_path").and_then(|v| v.as_str());
+    let uefi_firmware_path = || {
+        kernel_config
+            .get("uefi_firmware_path")
+            .and_then(|v| v.as_str())
+    };
+
+    match kernel_config.get("boot_protocol").and_then(|v| v.as_str()) {
+        Some("uefi" | "efi") => uefi_firmware_path().or_else(bios_path),
+        Some("direct" | "kernel") => None,
+        _ => bios_path(),
+    }
+}
+
 fn parse_config_file(config_file: &ConfigFile) -> Option<MemoryImage> {
     let config = config_file.content.parse::<Table>().ok()?;
 
@@ -155,20 +174,12 @@ fn parse_config_file(config_file: &ConfigFile) -> Option<MemoryImage> {
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let bios = if enable_bios {
-        config
-            .get("kernel")?
-            .as_table()?
-            .get("bios_path")
-            .and_then(|v| v.as_str())
-            .map(|v| convert_to_absolute(&config_file.path, v))
-    } else {
-        None
-    };
+    let kernel_config = config.get("kernel")?.as_table()?;
 
-    let ramdisk = config
-        .get("kernel")?
-        .as_table()?
+    let bios = boot_firmware_path(kernel_config, enable_bios)
+        .map(|v| convert_to_absolute(&config_file.path, v));
+
+    let ramdisk = kernel_config
         .get("ramdisk_path")
         .and_then(|v| v.as_str())
         .map(|v| convert_to_absolute(&config_file.path, v));

--- a/os/axvisor/configs/vms/arceos-x86_64-qemu-smp1.toml
+++ b/os/axvisor/configs/vms/arceos-x86_64-qemu-smp1.toml
@@ -26,6 +26,8 @@ kernel_path = "/path/ax-helloworld-x86_64.bin"
 kernel_load_addr = 0x20_0000
 # Whether to enable BIOS boot flow.
 enable_bios = true
+# Legacy x86 boot flow uses axvm-bios and multiboot info patching.
+boot_protocol = "multiboot"
 # The file path of the BIOS image.
 # bios_path = "/path/axvm-bios.bin"
 # The load address of the BIOS image.

--- a/os/axvisor/configs/vms/arceos-x86_64-qemu-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/arceos-x86_64-qemu-uefi-smp1.toml
@@ -4,7 +4,7 @@
 # Guest vm id.
 id = 1
 # Guest vm name.
-name = "nimbos"
+name = "arceos-qemu-uefi"
 # Virtualization type.
 vm_type = 1
 # The number of virtual CPUs.
@@ -16,24 +16,22 @@ phys_cpu_sets = [1]
 # Vm kernel configs
 #
 [kernel]
-# The entry point of the kernel image.
-entry_point = 0x8000
+# The entry point of the UEFI firmware reset vector.
+entry_point = 0xffff_fff0
 # The location of image: "memory" | "fs".
-# Load from file system.
 image_location = "fs"
-# The file path of the kernel image.
-kernel_path = "/guest/nimbos/nimbos-qemu"
-# The load address of the kernel image.
+# The file path of the ArceOS x86_64 UEFI guest image.
+kernel_path = "/guest/arceos/arceos-x86_64-uefi.bin"
+# The load address of the guest image.
 kernel_load_addr = 0x20_0000
-# Whether to enable BIOS boot flow.
+# Enable external firmware image loading.
 enable_bios = true
-# Legacy x86 boot flow uses axvm-bios and multiboot info patching.
-boot_protocol = "multiboot"
-# The file path of the BIOS image.
-# NimbOS x86_64 needs axvm-bios at 0x8000 to bootstrap.
-# bios_path = "/guest/nimbos/axvm-bios.bin"
-# The load address of the BIOS image.
-# bios_load_addr = 0x8000
+# Select UEFI firmware flow instead of the legacy axvm-bios multiboot trampoline.
+boot_protocol = "uefi"
+# The file path of the UEFI firmware image, for example OVMF_CODE.fd.
+uefi_firmware_path = "/guest/arceos/OVMF_CODE.fd"
+# Load the UEFI firmware near the top of the 32-bit address space.
+bios_load_addr = 0xffc0_0000
 
 ## The file path of the ramdisk image.
 # ramdisk_path = ""
@@ -45,7 +43,8 @@ boot_protocol = "multiboot"
 # Memory regions with format (`base_paddr`, `size`, `flags`, `map_type`).
 # For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
 memory_regions = [
-  [0x0000_0000, 0x100_0000, 0x7, 0], # Low RAM		16M	0b111   R|W|EXECUTE
+  [0x0000_0000, 0x100_0000, 0x7, 0], # Low RAM 16M 0b111 R|W|EXECUTE
+  [0xffc0_0000, 0x40_0000, 0x7, 0], # UEFI firmware window 4M
 ]
 
 #
@@ -66,6 +65,13 @@ passthrough_devices = [
     "IO APIC",
     0xfec0_0000,
     0xfec0_0000,
+    0x1000,
+    0x1,
+  ],
+  [
+    "Local APIC",
+    0xfee0_0000,
+    0xfee0_0000,
     0x1000,
     0x1,
   ],

--- a/os/axvisor/configs/vms/arceos-x86_64-qemu-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/arceos-x86_64-qemu-uefi-smp1.toml
@@ -69,13 +69,6 @@ passthrough_devices = [
     0x1,
   ],
   [
-    "Local APIC",
-    0xfee0_0000,
-    0xfee0_0000,
-    0x1000,
-    0x1,
-  ],
-  [
     "HPET",
     0xfed0_0000,
     0xfed0_0000,

--- a/os/axvisor/configs/vms/linux-x86_64-qemu-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/linux-x86_64-qemu-uefi-smp1.toml
@@ -4,7 +4,7 @@
 # Guest vm id.
 id = 1
 # Guest vm name.
-name = "nimbos"
+name = "linux-qemu-uefi"
 # Virtualization type.
 vm_type = 1
 # The number of virtual CPUs.
@@ -16,36 +16,35 @@ phys_cpu_sets = [1]
 # Vm kernel configs
 #
 [kernel]
-# The entry point of the kernel image.
-entry_point = 0x8000
+# The entry point of the UEFI firmware reset vector.
+entry_point = 0xffff_fff0
 # The location of image: "memory" | "fs".
-# Load from file system.
 image_location = "fs"
-# The file path of the kernel image.
-kernel_path = "/guest/nimbos/nimbos-qemu"
-# The load address of the kernel image.
+# The file path of the Linux x86_64 UEFI guest image.
+kernel_path = "/guest/linux/qemu-x86_64"
+# The load address of the guest image.
 kernel_load_addr = 0x20_0000
-# Whether to enable BIOS boot flow.
+# Enable external firmware image loading.
 enable_bios = true
-# Legacy x86 boot flow uses axvm-bios and multiboot info patching.
-boot_protocol = "multiboot"
-# The file path of the BIOS image.
-# NimbOS x86_64 needs axvm-bios at 0x8000 to bootstrap.
-# bios_path = "/guest/nimbos/axvm-bios.bin"
-# The load address of the BIOS image.
-# bios_load_addr = 0x8000
+# Select UEFI firmware flow instead of the legacy axvm-bios multiboot trampoline.
+boot_protocol = "uefi"
+# The file path of the UEFI firmware image, for example OVMF_CODE.fd.
+uefi_firmware_path = "/guest/linux/OVMF_CODE.fd"
+# Load the UEFI firmware near the top of the 32-bit address space.
+bios_load_addr = 0xffc0_0000
+# The file path of the ramdisk image.
+ramdisk_path = "/guest/linux/initramfs.cpio.gz"
+# The load address of the ramdisk image.
+ramdisk_load_addr = 0x40_0000
 
-## The file path of the ramdisk image.
-# ramdisk_path = ""
-## The load address of the ramdisk image.
-# ramdisk_load_addr = 0
 ## The path of the disk image.
 # disk_path = ""
 
 # Memory regions with format (`base_paddr`, `size`, `flags`, `map_type`).
 # For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
 memory_regions = [
-  [0x0000_0000, 0x100_0000, 0x7, 0], # Low RAM		16M	0b111   R|W|EXECUTE
+  [0x0000_0000, 0x200_0000, 0x7, 0], # Low RAM 32M 0b111 R|W|EXECUTE
+  [0xffc0_0000, 0x40_0000, 0x7, 0], # UEFI firmware window 4M
 ]
 
 #
@@ -66,6 +65,13 @@ passthrough_devices = [
     "IO APIC",
     0xfec0_0000,
     0xfec0_0000,
+    0x1000,
+    0x1,
+  ],
+  [
+    "Local APIC",
+    0xfee0_0000,
+    0xfee0_0000,
     0x1000,
     0x1,
   ],

--- a/os/axvisor/configs/vms/linux-x86_64-qemu-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/linux-x86_64-qemu-uefi-smp1.toml
@@ -69,13 +69,6 @@ passthrough_devices = [
     0x1,
   ],
   [
-    "Local APIC",
-    0xfee0_0000,
-    0xfee0_0000,
-    0x1000,
-    0x1,
-  ],
-  [
     "HPET",
     0xfed0_0000,
     0xfed0_0000,

--- a/os/axvisor/configs/vms/nimbos-x86_64-qemu-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/nimbos-x86_64-qemu-uefi-smp1.toml
@@ -70,13 +70,6 @@ passthrough_devices = [
     0x1,
   ],
   [
-    "Local APIC",
-    0xfee0_0000,
-    0xfee0_0000,
-    0x1000,
-    0x1,
-  ],
-  [
     "HPET",
     0xfed0_0000,
     0xfed0_0000,

--- a/os/axvisor/configs/vms/nimbos-x86_64-qemu-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/nimbos-x86_64-qemu-uefi-smp1.toml
@@ -4,7 +4,7 @@
 # Guest vm id.
 id = 1
 # Guest vm name.
-name = "nimbos"
+name = "nimbos-uefi"
 # Virtualization type.
 vm_type = 1
 # The number of virtual CPUs.
@@ -16,24 +16,23 @@ phys_cpu_sets = [1]
 # Vm kernel configs
 #
 [kernel]
-# The entry point of the kernel image.
-entry_point = 0x8000
+# The entry point of the UEFI firmware reset vector.
+entry_point = 0xffff_fff0
 # The location of image: "memory" | "fs".
 # Load from file system.
 image_location = "fs"
-# The file path of the kernel image.
+# The file path of the guest kernel image.
 kernel_path = "/guest/nimbos/nimbos-qemu"
-# The load address of the kernel image.
+# The load address of the guest kernel image.
 kernel_load_addr = 0x20_0000
-# Whether to enable BIOS boot flow.
+# Enable external firmware image loading.
 enable_bios = true
-# Legacy x86 boot flow uses axvm-bios and multiboot info patching.
-boot_protocol = "multiboot"
-# The file path of the BIOS image.
-# NimbOS x86_64 needs axvm-bios at 0x8000 to bootstrap.
-# bios_path = "/guest/nimbos/axvm-bios.bin"
-# The load address of the BIOS image.
-# bios_load_addr = 0x8000
+# Select UEFI firmware flow instead of the legacy axvm-bios multiboot trampoline.
+boot_protocol = "uefi"
+# The file path of the UEFI firmware image, for example OVMF_CODE.fd.
+uefi_firmware_path = "/guest/nimbos/OVMF_CODE.fd"
+# Load the UEFI firmware near the top of the 32-bit address space.
+bios_load_addr = 0xffc0_0000
 
 ## The file path of the ramdisk image.
 # ramdisk_path = ""
@@ -45,7 +44,8 @@ boot_protocol = "multiboot"
 # Memory regions with format (`base_paddr`, `size`, `flags`, `map_type`).
 # For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
 memory_regions = [
-  [0x0000_0000, 0x100_0000, 0x7, 0], # Low RAM		16M	0b111   R|W|EXECUTE
+  [0x0000_0000, 0x100_0000, 0x7, 0], # Low RAM 16M 0b111 R|W|EXECUTE
+  [0xffc0_0000, 0x40_0000, 0x7, 0], # UEFI firmware window 4M
 ]
 
 #
@@ -66,6 +66,13 @@ passthrough_devices = [
     "IO APIC",
     0xfec0_0000,
     0xfec0_0000,
+    0x1000,
+    0x1,
+  ],
+  [
+    "Local APIC",
+    0xfee0_0000,
+    0xfee0_0000,
     0x1000,
     0x1,
   ],

--- a/os/axvisor/doc/qemu-quickstart.md
+++ b/os/axvisor/doc/qemu-quickstart.md
@@ -37,7 +37,7 @@ cargo +stable install ostool --version '^0.15'
 - `cargo-binutils`: provides `rust-objcopy`, `rust-objdump`, etc.
 - `ostool`: custom build runner for AxVisor
 
-## 3. KVM Setup (NimbOS x86_64 Only)
+## 3. KVM and UEFI Firmware Setup (NimbOS x86_64 Only)
 
 NimbOS runs on x86_64 QEMU and requires KVM hardware acceleration. ArceOS and Linux use AArch64 QEMU (TCG mode) and do not need KVM — you can skip this section.
 
@@ -63,6 +63,18 @@ Verify:
 
 ```bash
 id  # output should include "kvm"
+```
+
+The optional x86_64 UEFI guest path uses an external OVMF-compatible firmware image. On Debian/Ubuntu, install it with:
+
+```bash
+sudo apt install ovmf
+```
+
+If your firmware is not installed in a standard location, export:
+
+```bash
+export AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd
 ```
 
 ## 4. Running Guest OSes
@@ -112,6 +124,36 @@ After booting, you will enter the Rust user shell (`>>` prompt). Type `usertests
 
 > **Note**: NimbOS requires VT-x/KVM. If `/dev/kvm` does not exist or has insufficient permissions, you will get a `Permission denied` error. WSL2 requires nested virtualization support in the kernel to use KVM.
 
+### Linux UEFI (x86_64, requires KVM and OVMF)
+
+```bash
+./scripts/setup_qemu.sh linux-x86_64-uefi
+
+cargo xtask qemu \
+  --config configs/board/qemu-x86_64.toml \
+  --qemu-config .github/workflows/qemu-x86_64-uefi.toml \
+  --vmconfigs tmp/vmconfigs/linux-x86_64-qemu-uefi-smp1.generated.toml
+```
+
+The UEFI VM config sets `boot_protocol = "uefi"` and `uefi_firmware_path`, which tells AxVisor to load the external firmware image without applying the legacy axvm-bios multiboot patch. This Linux guest also provides `ramdisk_path` so the initramfs is available before boot.
+
+### ArceOS UEFI (x86_64, requires KVM, OVMF, and a local guest image)
+
+The ArceOS x86_64 UEFI path is provided as a local bring-up flow because the image registry does not currently publish a prebuilt ArceOS x86_64 UEFI guest. Build or place the guest image locally, then export:
+
+```bash
+export AXVISOR_X86_64_ARCEOS_UEFI_KERNEL=/path/to/arceos-x86_64-uefi.bin
+export AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd
+```
+
+Then run:
+
+```bash
+./scripts/quick-start.sh qemu-x86_64 start --arceos-uefi
+```
+
+This flow uses `configs/vms/arceos-x86_64-qemu-uefi-smp1.toml` with `.github/workflows/qemu-x86_64-arceos-uefi.toml`, sets `boot_protocol = "uefi"`, and loads the configured firmware image from `uefi_firmware_path`.
+
 ### ArceOS (RISC-V64)
 
 ```bash
@@ -144,7 +186,7 @@ Success indicator: `Welcome to AxVisor Shell!` appears in the output.
 For guest-image flows, the script automates three steps, eliminating manual work:
 
 1. **Download images**: calls `cargo axvisor image pull` to fetch and extract guest images to `/tmp/.axvisor-images/`
-2. **Generate temp configs**: copies VM config templates to `tmp/vmconfigs/*.generated.toml`, then uses `sed` to update `kernel_path` (and `bios_path` for NimbOS) to actual image paths without modifying tracked files in `configs/vms/*.toml`
+2. **Generate temp configs**: copies VM config templates to `tmp/vmconfigs/*.generated.toml`, then uses `sed` to update `kernel_path` and firmware paths (`bios_path` for legacy NimbOS BIOS mode, `uefi_firmware_path` for UEFI mode) to actual image paths without modifying tracked files in `configs/vms/*.toml`
 3. **Prepare rootfs**: copies `rootfs.img` to the project's `tmp/` directory for QEMU to use
 
 You can also perform these steps manually if you prefer not to use the script.
@@ -158,6 +200,10 @@ The `kernel_path` in the VM config points to a non-existent file. Run `./scripts
 ### `Could not access KVM kernel module: Permission denied`
 
 Your user is not in the `kvm` group. See the "KVM Setup" section above.
+
+### `UEFI firmware image not found`
+
+Install OVMF or set `AXVISOR_X86_64_UEFI_FIRMWARE` to the firmware image path before running `./scripts/setup_qemu.sh linux-x86_64-uefi`.
 
 ### `qemu-system-aarch64: command not found`
 

--- a/os/axvisor/scripts/quick-start.sh
+++ b/os/axvisor/scripts/quick-start.sh
@@ -70,7 +70,7 @@ Platforms:
     qemu-aarch64       QEMU AArch64 (ArceOS/Linux)
     qemu-riscv64       QEMU RISC-V64 (ArceOS)
     qemu-loongarch64   QEMU LoongArch64 (AxVisor shell smoke)
-    qemu-x86_64        QEMU x86_64 (NimbOS)
+    qemu-x86_64        QEMU x86_64 (NimbOS/ArceOS UEFI)
     phytiumpi          Phytium Pi Board (ArceOS/Linux)
     roc-rk3568-pc      ROC-RK3568-PC Board (ArceOS/Linux)
     rdk-s100           D-Robotics RDK S100P Board (ArceOS/Linux)
@@ -97,6 +97,8 @@ Launch Options (for run/start commands):
         --axvisor           Launch AxVisor shell smoke (default)
     QEMU x86_64:
         -n, --nimbos        Launch single NimbOS guest (default)
+        --nimbos-uefi       Launch NimbOS through an external UEFI firmware image
+        --arceos-uefi       Launch a local ArceOS x86_64 UEFI guest image
     Phytium Pi:
         -a, --arceos        Launch single ArceOS guest (default)
         -l, --linux         Launch single Linux guest
@@ -126,6 +128,8 @@ Examples:
 
     # QEMU x86_64
     $0 qemu-x86_64 start --nimbos                   # One-step: prepare + launch NimbOS
+    $0 qemu-x86_64 start --nimbos-uefi              # One-step: prepare + launch NimbOS through UEFI
+    $0 qemu-x86_64 start --arceos-uefi              # One-step: launch local ArceOS x86_64 UEFI image
     $0 qemu-x86_64 start                            # Same as above (default nimbos)
 
     # Phytium Pi (requires --serial for start)
@@ -340,12 +344,127 @@ setup_qemu_x86_64() {
     info "=== QEMU x86_64 Preparation Complete ==="
 }
 
+setup_qemu_x86_64_uefi() {
+    info "=== QEMU x86_64 UEFI Preparation ==="
+
+    setup_qemu_x86_64
+
+    local firmware_path="${AXVISOR_X86_64_UEFI_FIRMWARE:-}"
+    if [ -z "$firmware_path" ]; then
+        for candidate in \
+            "$(pwd)/tmp/images/qemu_x86_64_nimbos/OVMF_CODE.fd" \
+            "/usr/share/OVMF/OVMF_CODE.fd" \
+            "/usr/share/ovmf/OVMF.fd" \
+            "/usr/share/qemu/OVMF.fd"; do
+            if [ -f "$candidate" ]; then
+                firmware_path="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [ -z "$firmware_path" ] || [ ! -f "$firmware_path" ]; then
+        error "UEFI firmware image not found."
+        echo "Install OVMF or set AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd"
+        exit 1
+    fi
+
+    info "Preparing UEFI guest config file..."
+    run_cmd cp configs/vms/nimbos-x86_64-qemu-uefi-smp1.toml tmp/configs/
+    run_cmd sed -i 's|^kernel_path = .*|kernel_path = "../images/qemu_x86_64_nimbos/qemu-x86_64"|g' tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml
+    run_cmd sed -i 's|^uefi_firmware_path = .*|uefi_firmware_path = "'"$firmware_path"'"|g' tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml
+
+    info "Preparing UEFI QEMU config file..."
+    run_cmd cp .github/workflows/qemu-x86_64-uefi.toml tmp/configs/qemu-x86_64-uefi-runtime.toml
+
+    local rootfs_path
+    rootfs_path="$(pwd)/tmp/images/qemu_x86_64_nimbos/rootfs.img"
+    run_cmd sed -i 's|file=${workspaceFolder}/tmp/rootfs.img|file='"$rootfs_path"'|g' tmp/configs/qemu-x86_64-uefi-runtime.toml
+
+    info "=== QEMU x86_64 UEFI Preparation Complete ==="
+}
+
+setup_qemu_x86_64_arceos_uefi() {
+    info "=== QEMU x86_64 ArceOS UEFI Preparation ==="
+
+    run_cmd mkdir -p tmp/{configs,images}
+
+    local kernel_path="${AXVISOR_X86_64_ARCEOS_UEFI_KERNEL:-}"
+    if [ -z "$kernel_path" ]; then
+        for candidate in \
+            "$(pwd)/tmp/images/arceos-x86_64-uefi.bin" \
+            "$(pwd)/tmp/images/arceos-x86_64.bin" \
+            "$(pwd)/tmp/images/ax-helloworld-x86_64.bin"; do
+            if [ -f "$candidate" ]; then
+                kernel_path="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [ -z "$kernel_path" ] || [ ! -f "$kernel_path" ]; then
+        error "ArceOS x86_64 UEFI guest image not found."
+        echo "Build or place the guest image locally, then set:"
+        echo "  AXVISOR_X86_64_ARCEOS_UEFI_KERNEL=/path/to/arceos-x86_64-uefi.bin"
+        exit 1
+    fi
+
+    local firmware_path="${AXVISOR_X86_64_UEFI_FIRMWARE:-}"
+    if [ -z "$firmware_path" ]; then
+        for candidate in \
+            "$(pwd)/tmp/images/OVMF_CODE.fd" \
+            "/usr/share/OVMF/OVMF_CODE.fd" \
+            "/usr/share/ovmf/OVMF.fd" \
+            "/usr/share/qemu/OVMF.fd"; do
+            if [ -f "$candidate" ]; then
+                firmware_path="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [ -z "$firmware_path" ] || [ ! -f "$firmware_path" ]; then
+        error "UEFI firmware image not found."
+        echo "Install OVMF or set AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd"
+        exit 1
+    fi
+
+    info "Preparing board config file..."
+    run_cmd cp configs/board/qemu-x86_64.toml tmp/configs/
+
+    info "Preparing ArceOS UEFI guest config file..."
+    run_cmd cp configs/vms/arceos-x86_64-qemu-uefi-smp1.toml tmp/configs/
+    run_cmd sed -i 's|^kernel_path = .*|kernel_path = "'"$kernel_path"'"|g' tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml
+    run_cmd sed -i 's|^uefi_firmware_path = .*|uefi_firmware_path = "'"$firmware_path"'"|g' tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml
+
+    info "Preparing UEFI QEMU config file..."
+    run_cmd cp .github/workflows/qemu-x86_64-arceos-uefi.toml tmp/configs/qemu-x86_64-arceos-uefi-runtime.toml
+
+    info "=== QEMU x86_64 ArceOS UEFI Preparation Complete ==="
+}
+
 run_qemu_x86_64_nimbos() {
     info "=== Launching QEMU x86_64 NimbOS Guest ==="
     run_axvisor_qemu \
         --config "$(pwd)/tmp/configs/qemu-x86_64.toml" \
         --qemu-config "$(pwd)/tmp/configs/qemu-x86_64-runtime.toml" \
         --vmconfigs "$(pwd)/tmp/configs/nimbos-x86_64-qemu-smp1.toml"
+}
+
+run_qemu_x86_64_nimbos_uefi() {
+    info "=== Launching QEMU x86_64 NimbOS UEFI Guest ==="
+    run_axvisor_qemu \
+        --config "$(pwd)/tmp/configs/qemu-x86_64.toml" \
+        --qemu-config "$(pwd)/tmp/configs/qemu-x86_64-uefi-runtime.toml" \
+        --vmconfigs "$(pwd)/tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml"
+}
+
+run_qemu_x86_64_arceos_uefi() {
+    info "=== Launching QEMU x86_64 ArceOS UEFI Guest ==="
+    run_axvisor_qemu \
+        --config "$(pwd)/tmp/configs/qemu-x86_64.toml" \
+        --qemu-config "$(pwd)/tmp/configs/qemu-x86_64-arceos-uefi-runtime.toml" \
+        --vmconfigs "$(pwd)/tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml"
 }
 
 # ============================================================================
@@ -913,7 +1032,21 @@ cmd_start_qemu_loongarch64() {
 # ============================================================================
 
 cmd_setup_qemu_x86_64() {
-    setup_qemu_x86_64
+    local mode="${1:-}"
+    case "$mode" in
+        --nimbos-uefi)
+            setup_qemu_x86_64_uefi
+            ;;
+        --arceos-uefi)
+            setup_qemu_x86_64_arceos_uefi
+            ;;
+        -n|--nimbos|"")
+            setup_qemu_x86_64
+            ;;
+        *)
+            cmd_run_qemu_x86_64 "$mode"
+            ;;
+    esac
 }
 
 cmd_run_qemu_x86_64() {
@@ -923,17 +1056,16 @@ cmd_run_qemu_x86_64() {
         -n|--nimbos|"")
             run_qemu_x86_64_nimbos
             ;;
+        --nimbos-uefi)
+            run_qemu_x86_64_nimbos_uefi
+            ;;
+        --arceos-uefi)
+            run_qemu_x86_64_arceos_uefi
+            ;;
         -a|--arceos)
-            error "Unsupported combination: QEMU x86_64 does not support ArceOS"
+            error "QEMU x86_64 ArceOS requires a UEFI guest image; use --arceos-uefi"
             echo ""
-            echo "QEMU x86_64 platform only supports the following guest system:"
-            echo "  - NimbOS (use --nimbos)"
-            echo ""
-            echo "To run ArceOS, please use one of the following platforms:"
-            echo "  $0 qemu-aarch64 start --arceos"
-            echo "  $0 phytiumpi setup && $0 phytiumpi run --arceos"
-            echo "  $0 roc-rk3568-pc setup && $0 roc-rk3568-pc run --arceos"
-            echo "  $0 rdk-s100 setup && $0 rdk-s100 run --arceos"
+            echo "Set AXVISOR_X86_64_ARCEOS_UEFI_KERNEL=/path/to/arceos-x86_64-uefi.bin first."
             exit 1
             ;;
         -l|--linux)
@@ -967,6 +1099,8 @@ cmd_run_qemu_x86_64() {
             echo ""
             echo "QEMU x86_64 platform supports the following options:"
             echo "  -n, --nimbos    Launch NimbOS guest"
+            echo "  --nimbos-uefi   Launch NimbOS guest through UEFI firmware"
+            echo "  --arceos-uefi   Launch a local ArceOS x86_64 UEFI guest"
             exit 1
             ;;
     esac
@@ -979,13 +1113,25 @@ cmd_start_qemu_x86_64() {
         -n|--nimbos|"")
             # Valid parameters, continue
             ;;
+        --nimbos-uefi)
+            # Valid parameters, continue
+            ;;
+        --arceos-uefi)
+            # Valid parameters, continue
+            ;;
         *)
             # Invalid parameters, report error without executing setup
             cmd_run_qemu_x86_64 "$mode"
             return
             ;;
     esac
-    setup_qemu_x86_64
+    if [[ "$mode" == "--nimbos-uefi" ]]; then
+        setup_qemu_x86_64_uefi
+    elif [[ "$mode" == "--arceos-uefi" ]]; then
+        setup_qemu_x86_64_arceos_uefi
+    else
+        setup_qemu_x86_64
+    fi
     echo ""
     cmd_run_qemu_x86_64 "$mode"
 }
@@ -1329,7 +1475,7 @@ case "$PLATFORM" in
         shift
         case "$CMD" in
             setup)
-                cmd_setup_qemu_x86_64
+                cmd_setup_qemu_x86_64 "$@"
                 ;;
             run)
                 cmd_run_qemu_x86_64 "$@"

--- a/os/axvisor/scripts/setup_qemu.sh
+++ b/os/axvisor/scripts/setup_qemu.sh
@@ -7,16 +7,22 @@ set -euo pipefail
 #   ./scripts/setup_qemu.sh arceos
 #   ./scripts/setup_qemu.sh --guest linux
 #   ./scripts/setup_qemu.sh nimbos
+#   ./scripts/setup_qemu.sh nimbos-uefi
+#   ./scripts/setup_qemu.sh linux-x86_64-uefi
 #
-# Supported guests: arceos, arceos-riscv64, linux, nimbos
+# Supported guests: arceos, arceos-riscv64, linux, nimbos, nimbos-uefi, linux-x86_64-uefi
 # LoongArch64 AxVisor shell smoke uses quick-start.sh instead of this script.
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_STORAGE_ROOT="/tmp/.axvisor-images"
-DEFAULT_REGISTRY_URL="https://raw.githubusercontent.com/arceos-hypervisor/axvisor-guest/refs/heads/main/registry/default.toml"
+DEFAULT_REGISTRY_URL="https://raw.githubusercontent.com/rcore-os/tgosimages/refs/heads/main/registry/default.toml"
 # Keep this version aligned with the guest release used in this branch.
-BUILTIN_FALLBACK_REGISTRY_URL="https://raw.githubusercontent.com/arceos-hypervisor/axvisor-guest/refs/heads/main/registry/v0.0.25.toml"
+BUILTIN_FALLBACK_REGISTRY_URL="https://raw.githubusercontent.com/rcore-os/tgosimages/refs/heads/main/registry/v0.0.25.toml"
 IMAGE_DOWNLOAD_MAX_ATTEMPTS=2
+TGOSIMAGES_RELEASE="${AXVISOR_TGOSIMAGES_RELEASE:-v0.0.5}"
+TGOSIMAGES_QEMU_X86_64_ARCHIVE="qemu-x86_64.tar.xz"
+TGOSIMAGES_QEMU_X86_64_URL="${AXVISOR_TGOSIMAGES_QEMU_X86_64_URL:-https://github.com/rcore-os/tgosimages/releases/download/${TGOSIMAGES_RELEASE}/${TGOSIMAGES_QEMU_X86_64_ARCHIVE}}"
+TGOSIMAGES_QEMU_X86_64_SHA256="${AXVISOR_TGOSIMAGES_QEMU_X86_64_SHA256:-64434d91166bf70ebfab42481d935c68640301fd031d0836d2bdec3f82bb2e20}"
 
 bootstrap_image_registry() {
   local storage_dir="${IMAGE_STORAGE_ROOT}"
@@ -64,13 +70,103 @@ bootstrap_image_registry() {
   date +%s > "${storage_dir}/.last_sync" || true
 }
 
+verify_sha256() {
+  local file="$1"
+  local expected="$2"
+  local actual
+
+  if [ -z "${expected}" ]; then
+    return 0
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "${file}" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "${file}" | awk '{print $1}')"
+  else
+    echo "  -> Warning: neither sha256sum nor shasum is available; skipping checksum verification." >&2
+    return 0
+  fi
+
+  if [ "${actual}" != "${expected}" ]; then
+    echo "ERROR: checksum mismatch for ${file}" >&2
+    echo "  expected: ${expected}" >&2
+    echo "  actual:   ${actual}" >&2
+    return 1
+  fi
+}
+
+file_size_bytes() {
+  local file="$1"
+
+  if stat -c '%s' "${file}" >/dev/null 2>&1; then
+    stat -c '%s' "${file}"
+  else
+    stat -f '%z' "${file}"
+  fi
+}
+
+align_up_4k() {
+  local value="$1"
+  echo $(( (value + 0xfff) & ~0xfff ))
+}
+
+nimbos_image_ready() {
+  [ -f "${IMAGE_DIR}/qemu-x86_64" ] \
+    && [ -f "${IMAGE_DIR}/rootfs.img" ] \
+    && [ -f "${IMAGE_DIR}/axvm-bios.bin" ]
+}
+
+prepare_nimbos_from_tgosimages() {
+  local cache_dir="${IMAGE_STORAGE_ROOT}/.downloads"
+  local archive_path="${cache_dir}/${TGOSIMAGES_QEMU_X86_64_ARCHIVE}"
+  local extract_dir
+  local nimbos_dir
+
+  if nimbos_image_ready; then
+    echo "  -> Found existing tgosimages-compatible NimbOS image directory: ${IMAGE_DIR}"
+    return 0
+  fi
+
+  mkdir -p "${cache_dir}" "${IMAGE_DIR}"
+  if [ ! -f "${archive_path}" ] || ! verify_sha256 "${archive_path}" "${TGOSIMAGES_QEMU_X86_64_SHA256}"; then
+    rm -f "${archive_path}"
+    echo "  -> Downloading NimbOS guest from rcore-os/tgosimages ${TGOSIMAGES_RELEASE}..."
+    curl -4 --retry 5 --retry-delay 2 -fL "${TGOSIMAGES_QEMU_X86_64_URL}" -o "${archive_path}"
+    verify_sha256 "${archive_path}" "${TGOSIMAGES_QEMU_X86_64_SHA256}"
+  else
+    echo "  -> Found cached tgosimages archive: ${archive_path}"
+  fi
+
+  extract_dir="$(mktemp -d)"
+  tar -xJf "${archive_path}" -C "${extract_dir}"
+  nimbos_dir="${extract_dir}/nimbos"
+  if [ ! -d "${nimbos_dir}" ]; then
+    echo "ERROR: ${TGOSIMAGES_QEMU_X86_64_ARCHIVE} does not contain a nimbos/ directory." >&2
+    rm -rf "${extract_dir}"
+    return 1
+  fi
+
+  cp "${nimbos_dir}/nimbos-qemu" "${IMAGE_DIR}/qemu-x86_64"
+  if [ -f "${nimbos_dir}/nimbos-qemu-usertests" ]; then
+    cp "${nimbos_dir}/nimbos-qemu-usertests" "${IMAGE_DIR}/qemu-x86_64_usertests"
+  fi
+  cp "${nimbos_dir}/nimbos-qemu.img" "${IMAGE_DIR}/rootfs.img"
+  cp "${nimbos_dir}/axvm-bios.bin" "${IMAGE_DIR}/axvm-bios.bin"
+  chmod +x "${IMAGE_DIR}/qemu-x86_64" "${IMAGE_DIR}/qemu-x86_64_usertests" 2>/dev/null || true
+  rm -rf "${extract_dir}"
+  echo "  -> Prepared ${IMAGE_DIR} from rcore-os/tgosimages ${TGOSIMAGES_RELEASE}."
+}
+
 usage() {
-  echo "Usage: $0 [--guest] <arceos|arceos-riscv64|linux|nimbos>"
+  echo "Usage: $0 [--guest] <arceos|arceos-riscv64|linux|nimbos|nimbos-uefi|linux-x86_64-uefi>"
   echo ""
   echo "  arceos          - aarch64 ArceOS guest"
   echo "  arceos-riscv64  - riscv64 ArceOS guest"
   echo "  linux           - aarch64 Linux guest"
   echo "  nimbos          - x86_64 NimbOS guest (requires VT-x/KVM)"
+  echo "  nimbos-uefi     - x86_64 NimbOS guest through external UEFI firmware"
+  echo "  linux-x86_64-uefi - x86_64 Linux guest through external UEFI firmware"
   echo ""
   echo "LoongArch64 AxVisor shell smoke is a separate quick-start flow:"
   echo "  ./scripts/quick-start.sh qemu-loongarch64 start"
@@ -112,7 +208,7 @@ while [[ $# -gt 0 ]]; do
       shift
       break
       ;;
-    arceos|arceos-riscv64|linux|nimbos)
+    arceos|arceos-riscv64|linux|nimbos|nimbos-uefi|linux-x86_64-uefi)
       GUEST="$1"
       shift
       break
@@ -138,13 +234,17 @@ case "$GUEST" in
   arceos-riscv64) CFG="qemu_riscv64_arceos|arceos-riscv64-qemu-smp1.toml|qemu-riscv64.toml|qemu-riscv64.toml|qemu-riscv64|Hello, world!" ;;
   linux)          CFG="qemu_aarch64_linux|linux-aarch64-qemu-smp1.toml|qemu-aarch64.toml|qemu-aarch64.toml|qemu-aarch64|test pass!" ;;
   nimbos)         CFG="qemu_x86_64_nimbos|nimbos-x86_64-qemu-smp1.toml|qemu-x86_64.toml|qemu-x86_64-kvm.toml|qemu-x86_64|usertests passed!" ;;
+  nimbos-uefi)    CFG="qemu_x86_64_nimbos|nimbos-x86_64-qemu-uefi-smp1.toml|qemu-x86_64.toml|qemu-x86_64-uefi.toml|qemu-x86_64|usertests passed!" ;;
+  linux-x86_64-uefi) CFG="qemu_x86_64_linux|linux-x86_64-qemu-uefi-smp1.toml|qemu-x86_64.toml|qemu-x86_64-uefi.toml|qemu-x86_64|test pass!" ;;
   *)       echo "Unknown guest: $GUEST" >&2; usage ;;
 esac
 
 IFS='|' read -r IMAGE_NAME VMCONFIG BUILD_CONFIG QEMU_CONFIG KERNEL_FILE SUCCESS_MSG <<< "$CFG"
 # NOTE:
-#  - `cargo axvisor image pull` 默认把镜像解压到 `/tmp/.axvisor-images/<IMAGE_NAME>`
-#  - 这里直接使用该目录作为镜像来源，避免路径不一致
+#  - `cargo axvisor image pull` extracts images to
+#    `/tmp/.axvisor-images/<IMAGE_NAME>` by default.
+#  - NimbOS x86_64 is normalized into the same directory layout even when it is
+#    sourced from the rcore-os/tgosimages qemu-x86_64 release archive.
 IMAGE_DIR="${IMAGE_STORAGE_ROOT}/${IMAGE_NAME}"
 VMCONFIG_TEMPLATE_PATH="${REPO_ROOT}/configs/vms/${VMCONFIG}"
 VMCONFIG_TMP_DIR="${REPO_ROOT}/tmp/vmconfigs"
@@ -157,7 +257,14 @@ ABS_KERNEL_PATH="${IMAGE_DIR}/${KERNEL_FILE}"
 echo "[setup_qemu] Guest: ${GUEST} | Repo: ${REPO_ROOT}"
 
 echo "[setup_qemu] Step 1: ensure guest image is downloaded..."
-if [ ! -d "${IMAGE_DIR}" ]; then
+if [[ "$GUEST" == "nimbos" || "$GUEST" == "nimbos-uefi" ]]; then
+  if ! prepare_nimbos_from_tgosimages; then
+    echo "  -> Warning: failed to prepare NimbOS from tgosimages; falling back to cargo axvisor image." >&2
+    rm -rf "${IMAGE_DIR}"
+    mkdir -p "${IMAGE_DIR}"
+    (cd "${REPO_ROOT}" && cargo axvisor image pull "${IMAGE_NAME}")
+  fi
+elif [ ! -d "${IMAGE_DIR}" ]; then
   echo "  -> Image directory ${IMAGE_DIR} not found, downloading via cargo axvisor image..."
   echo "  -> Download attempt 1/${IMAGE_DOWNLOAD_MAX_ATTEMPTS}"
   if ! (cd "${REPO_ROOT}" && cargo axvisor image pull "${IMAGE_NAME}"); then
@@ -180,7 +287,7 @@ if [ ! -f "${ROOTFS_IMAGE}" ]; then
   exit 1
 fi
 
-# NimbOS x86_64 requires axvm-bios for bootstrapping
+# NimbOS x86_64 BIOS mode requires axvm-bios for bootstrapping.
 if [[ "$GUEST" == "nimbos" ]]; then
   BIOS_IMAGE="${IMAGE_DIR}/axvm-bios.bin"
   if [ ! -f "${BIOS_IMAGE}" ]; then
@@ -188,6 +295,36 @@ if [[ "$GUEST" == "nimbos" ]]; then
     echo "  -> Please re-download the NimbOS image via 'cargo axvisor image pull qemu_x86_64_nimbos'." >&2
     exit 1
   fi
+fi
+
+# x86_64 UEFI mode requires an external OVMF image. Keep the path
+# configurable because distributions install OVMF in different locations.
+if [[ "$GUEST" == "nimbos-uefi" || "$GUEST" == "linux-x86_64-uefi" ]]; then
+  UEFI_FIRMWARE="${AXVISOR_X86_64_UEFI_FIRMWARE:-}"
+  if [ -z "${UEFI_FIRMWARE}" ]; then
+    for candidate in \
+      "${IMAGE_DIR}/OVMF_CODE.fd" \
+      "/usr/share/OVMF/OVMF_CODE_4M.fd" \
+      "/usr/share/OVMF/OVMF_CODE.fd" \
+      "/usr/share/ovmf/OVMF.fd" \
+      "/usr/share/qemu/OVMF.fd"; do
+      if [ -f "${candidate}" ]; then
+        UEFI_FIRMWARE="${candidate}"
+        break
+      fi
+    done
+  fi
+  if [ -z "${UEFI_FIRMWARE}" ] || [ ! -f "${UEFI_FIRMWARE}" ]; then
+    echo "ERROR: UEFI firmware image not found." >&2
+    echo "  -> Install OVMF or set AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd." >&2
+    exit 1
+  fi
+
+  UEFI_FIRMWARE_SIZE="$(file_size_bytes "${UEFI_FIRMWARE}")"
+  UEFI_FIRMWARE_WINDOW_SIZE="$(align_up_4k "${UEFI_FIRMWARE_SIZE}")"
+  UEFI_FIRMWARE_LOAD_ADDR=$((0x100000000 - UEFI_FIRMWARE_WINDOW_SIZE))
+  UEFI_FIRMWARE_LOAD_ADDR_HEX="$(printf '0x%x' "${UEFI_FIRMWARE_LOAD_ADDR}")"
+  UEFI_FIRMWARE_WINDOW_SIZE_HEX="$(printf '0x%x' "${UEFI_FIRMWARE_WINDOW_SIZE}")"
 fi
 
 echo "[setup_qemu] Step 2: patch VM config kernel_path..."
@@ -199,13 +336,34 @@ fi
 mkdir -p "${VMCONFIG_TMP_DIR}"
 cp "${VMCONFIG_TEMPLATE_PATH}" "${GENERATED_VMCONFIG_PATH}"
 sed -i 's|^kernel_path *=.*|kernel_path = "'"${ABS_KERNEL_PATH}"'"|' "${GENERATED_VMCONFIG_PATH}"
+sed -i 's|^image_location *=.*|image_location = "memory"|' "${GENERATED_VMCONFIG_PATH}"
 echo "  -> Generated VM config: ${GENERATED_VMCONFIG_PATH}"
 echo "  -> Updated kernel_path to ${ABS_KERNEL_PATH}"
+echo "  -> Updated image_location to memory"
 
 if [[ "$GUEST" == "nimbos" ]]; then
   ABS_BIOS_PATH="${IMAGE_DIR}/axvm-bios.bin"
-  sed -i 's|^bios_path *=.*|bios_path = "'"${ABS_BIOS_PATH}"'"|' "${GENERATED_VMCONFIG_PATH}"
+  sed -i 's|^# *bios_path *=.*|bios_path = "'"${ABS_BIOS_PATH}"'"|; s|^bios_path *=.*|bios_path = "'"${ABS_BIOS_PATH}"'"|' "${GENERATED_VMCONFIG_PATH}"
+  sed -i 's|^# *bios_load_addr *=.*|bios_load_addr = 0x8000|; s|^bios_load_addr *=.*|bios_load_addr = 0x8000|' "${GENERATED_VMCONFIG_PATH}"
   echo "  -> Updated bios_path to ${ABS_BIOS_PATH}"
+fi
+
+if [[ "$GUEST" == "nimbos-uefi" || "$GUEST" == "linux-x86_64-uefi" ]]; then
+  sed -i 's|^uefi_firmware_path *=.*|uefi_firmware_path = "'"${UEFI_FIRMWARE}"'"|' "${GENERATED_VMCONFIG_PATH}"
+  sed -i 's|^bios_load_addr *=.*|bios_load_addr = '"${UEFI_FIRMWARE_LOAD_ADDR_HEX}"'|' "${GENERATED_VMCONFIG_PATH}"
+  sed -i 's|^\(  \[\)0xffc0_0000, 0x40_0000\(, 0x7, 0\].*UEFI firmware window.*\)|\1'"${UEFI_FIRMWARE_LOAD_ADDR_HEX}"', '"${UEFI_FIRMWARE_WINDOW_SIZE_HEX}"'\2|' "${GENERATED_VMCONFIG_PATH}"
+  echo "  -> Updated UEFI firmware path to ${UEFI_FIRMWARE}"
+  echo "  -> Updated UEFI firmware load address to ${UEFI_FIRMWARE_LOAD_ADDR_HEX} (size ${UEFI_FIRMWARE_SIZE} bytes)"
+fi
+
+if [[ "$GUEST" == "linux-x86_64-uefi" ]]; then
+  ABS_RAMDISK_PATH="${IMAGE_DIR}/initramfs.cpio.gz"
+  if [ ! -f "${ABS_RAMDISK_PATH}" ]; then
+    echo "ERROR: initramfs image not found at ${ABS_RAMDISK_PATH}" >&2
+    exit 1
+  fi
+  sed -i 's|^# *ramdisk_path *=.*|ramdisk_path = "'"${ABS_RAMDISK_PATH}"'"|; s|^ramdisk_path *=.*|ramdisk_path = "'"${ABS_RAMDISK_PATH}"'"|' "${GENERATED_VMCONFIG_PATH}"
+  echo "  -> Updated ramdisk_path to ${ABS_RAMDISK_PATH}"
 fi
 
 echo "[setup_qemu] Step 3: prepare rootfs..."
@@ -220,7 +378,7 @@ cat <<EOF
 You can now run the QEMU test with:
 
   cd ${REPO_ROOT}
-  cargo xtask qemu \\
+  cargo xtask axvisor qemu \\
     --config configs/board/${BUILD_CONFIG} \\
     --qemu-config .github/workflows/${QEMU_CONFIG} \\
     --vmconfigs ${GENERATED_VMCONFIG_PATH}
@@ -231,5 +389,15 @@ EOF
 
 if [[ "$GUEST" == "nimbos" ]]; then
   echo "*** NimbOS requires VT-x/VMX and KVM."
+  echo ""
+fi
+
+if [[ "$GUEST" == "nimbos-uefi" ]]; then
+  echo "*** NimbOS UEFI mode requires VT-x/VMX, KVM, and an OVMF-compatible firmware image."
+  echo ""
+fi
+
+if [[ "$GUEST" == "linux-x86_64-uefi" ]]; then
+  echo "*** Linux x86_64 UEFI mode requires VT-x/VMX, KVM, and an OVMF-compatible firmware image."
   echo ""
 fi

--- a/os/axvisor/src/vmm/config.rs
+++ b/os/axvisor/src/vmm/config.rs
@@ -16,7 +16,9 @@ use ax_errno::{AxResult, ax_err_type};
 use axaddrspace::GuestPhysAddr;
 use axvm::{
     VMMemoryRegion,
-    config::{AxVMConfig, AxVMCrateConfig, VmMemMappingType, adjusted_kernel_load_gpa},
+    config::{
+        AxVMConfig, AxVMCrateConfig, VMBootProtocol, VmMemMappingType, adjusted_kernel_load_gpa,
+    },
 };
 use core::alloc::Layout;
 
@@ -247,7 +249,11 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
         .ok_or_else(|| ax_err_type!(InvalidData, "VM must have at least one memory region"))?;
 
     if !skip_guest_address_adjustment {
-        config_guest_address(&vm, &main_mem);
+        config_guest_address(
+            &vm,
+            &main_mem,
+            vm_create_config.kernel.effective_boot_protocol(),
+        );
     }
 
     // Load corresponding images for VM.
@@ -265,11 +271,13 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
     Ok(vm_id)
 }
 
-fn config_guest_address(vm: &VM, main_memory: &VMMemoryRegion) {
+fn config_guest_address(vm: &VM, main_memory: &VMMemoryRegion, boot_protocol: VMBootProtocol) {
     vm.with_config(|config| {
-        if let Some(kernel_addr) =
-            adjusted_kernel_load_gpa(main_memory, config.image_config.bios_load_gpa)
-        {
+        if let Some(kernel_addr) = adjusted_kernel_load_gpa(
+            main_memory,
+            boot_protocol,
+            config.image_config.bios_load_gpa,
+        ) {
             debug!(
                 "Adjusting kernel load address from {:#x} to {:#x}",
                 config.image_config.kernel_load_gpa, kernel_addr

--- a/os/axvisor/src/vmm/images/mod.rs
+++ b/os/axvisor/src/vmm/images/mod.rs
@@ -16,6 +16,8 @@ use ax_errno::{AxResult, ax_err, ax_err_type};
 use axaddrspace::GuestPhysAddr;
 
 use axvm::VMMemoryRegion;
+#[cfg(target_arch = "x86_64")]
+use axvm::config::VMBootProtocol;
 use axvm::config::{AxVMCrateConfig, VmMemMappingType};
 use byte_unit::Byte;
 
@@ -114,6 +116,7 @@ impl ImageLoader {
     }
 
     pub fn load(&mut self) -> AxResult {
+        self.config.kernel.validate_boot_config()?;
         info!(
             "Loading VM[{}] images into memory region: gpa={:#x}, hva={:#x}, size={:#}",
             self.vm.id(),
@@ -252,11 +255,41 @@ impl ImageLoader {
         if let Some(buffer) = bios {
             let load_gpa = self
                 .bios_load_gpa
-                .ok_or_else(|| ax_err_type!(NotFound, "BIOS load address is missing"))?;
+                .ok_or_else(|| ax_err_type!(NotFound, "boot firmware load address is missing"))?;
             load_vm_image_from_memory(buffer, load_gpa, self.vm.clone())?;
             #[cfg(target_arch = "x86_64")]
-            self.load_x86_multiboot_info(buffer, load_gpa)?;
+            if should_patch_x86_multiboot_info(&self.config) {
+                self.load_x86_multiboot_info(buffer, load_gpa)?;
+            }
             return Ok(());
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if self.config.kernel.effective_boot_protocol() == VMBootProtocol::Uefi {
+            let firmware_path = self.config.kernel.boot_firmware_path().ok_or_else(|| {
+                ax_errno::ax_err_type!(NotFound, "UEFI firmware image path is missed")
+            })?;
+            let load_gpa = self.bios_load_gpa.ok_or_else(|| {
+                ax_errno::ax_err_type!(NotFound, "UEFI firmware load addr is missed")
+            })?;
+
+            #[cfg(feature = "fs")]
+            {
+                info!(
+                    "Loading UEFI firmware image {} at GPA {:#x}",
+                    firmware_path,
+                    load_gpa.as_usize()
+                );
+                return fs::load_vm_image(firmware_path, load_gpa, self.vm.clone());
+            }
+
+            #[cfg(not(feature = "fs"))]
+            {
+                return Err(ax_errno::ax_err_type!(
+                    Unsupported,
+                    "UEFI firmware path requires the fs feature when no firmware image buffer is available"
+                ));
+            }
         }
 
         #[cfg(target_arch = "x86_64")]
@@ -280,7 +313,9 @@ impl ImageLoader {
 
     #[cfg(target_arch = "x86_64")]
     fn should_load_default_x86_boot_image(&self) -> bool {
-        self.config.kernel.enable_bios && self.config.kernel.bios_path.is_none()
+        self.config.kernel.enable_bios
+            && self.config.kernel.boot_firmware_path().is_none()
+            && self.config.kernel.effective_boot_protocol() == VMBootProtocol::Multiboot
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -630,23 +665,26 @@ pub mod fs {
             loader.kernel_load_gpa,
             loader.vm.clone(),
         )?;
-        // Load BIOS image if needed.
+        // Load boot firmware image if needed.
         if loader.config.kernel.enable_bios
-            && let Some(bios_path) = &loader.config.kernel.bios_path
+            && let Some(bios_path) = loader.config.kernel.boot_firmware_path()
         {
             if let Some(bios_load_addr) = loader.bios_load_gpa {
                 #[cfg(target_arch = "x86_64")]
-                let bios_image = read_image_file(bios_path)?;
-                #[cfg(target_arch = "x86_64")]
                 {
-                    validate_x86_bios_patch_region(&bios_image)?;
-                    load_vm_image_from_memory(&bios_image, bios_load_addr, loader.vm.clone())?;
-                    loader.load_x86_multiboot_info(&bios_image, bios_load_addr)?;
+                    if should_patch_x86_multiboot_info(&loader.config) {
+                        let bios_image = read_image_file(bios_path)?;
+                        validate_x86_bios_patch_region(&bios_image)?;
+                        load_vm_image_from_memory(&bios_image, bios_load_addr, loader.vm.clone())?;
+                        loader.load_x86_multiboot_info(&bios_image, bios_load_addr)?;
+                    } else {
+                        load_vm_image(bios_path, bios_load_addr, loader.vm.clone())?;
+                    }
                 }
                 #[cfg(not(target_arch = "x86_64"))]
                 load_vm_image(bios_path, bios_load_addr, loader.vm.clone())?;
             } else {
-                return ax_err!(NotFound, "BIOS load addr is missed");
+                return ax_err!(NotFound, "boot firmware load addr is missed");
             }
         };
         #[cfg(target_arch = "x86_64")]
@@ -804,6 +842,11 @@ pub mod fs {
 }
 
 #[cfg(target_arch = "x86_64")]
+fn should_patch_x86_multiboot_info(config: &AxVMCrateConfig) -> bool {
+    config.kernel.effective_boot_protocol() == VMBootProtocol::Multiboot
+}
+
+#[cfg(target_arch = "x86_64")]
 fn detect_x86_linux_image(image: &[u8]) -> Option<x86_linux::X86LinuxHeader> {
     match x86_linux::X86LinuxHeader::parse(image) {
         Ok(header) => Some(header),
@@ -922,5 +965,22 @@ mod tests {
         let invalid_gpa = GuestPhysAddr::from(x86_boot::DEFAULT_BIOS_LOAD_GPA + 0x1000);
 
         assert!(builtin_x86_bios_load_gpa(Some(invalid_gpa)).is_err());
+    }
+
+    #[test]
+    fn legacy_x86_bios_config_uses_multiboot_patch() {
+        let mut cfg = AxVMCrateConfig::default();
+        cfg.kernel.enable_bios = true;
+
+        assert!(should_patch_x86_multiboot_info(&cfg));
+    }
+
+    #[test]
+    fn x86_uefi_config_skips_multiboot_patch() {
+        let mut cfg = AxVMCrateConfig::default();
+        cfg.kernel.enable_bios = true;
+        cfg.kernel.boot_protocol = Some(VMBootProtocol::Uefi);
+
+        assert!(!should_patch_x86_multiboot_info(&cfg));
     }
 }

--- a/scripts/axbuild/src/axvisor/image/config.rs
+++ b/scripts/axbuild/src/axvisor/image/config.rs
@@ -7,8 +7,10 @@ use anyhow::anyhow;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const DEFAULT_REGISTRY_URL: &str = "https://raw.githubusercontent.com/arceos-hypervisor/axvisor-guest/refs/heads/main/registry/default.toml";
-pub const DEFAULT_FALLBACK_REGISTRY_URL: &str = "https://raw.githubusercontent.com/arceos-hypervisor/axvisor-guest/refs/heads/main/registry/v0.0.25.toml";
+pub const DEFAULT_REGISTRY_URL: &str =
+    "https://raw.githubusercontent.com/rcore-os/tgosimages/refs/heads/main/registry/default.toml";
+pub const DEFAULT_FALLBACK_REGISTRY_URL: &str =
+    "https://raw.githubusercontent.com/rcore-os/tgosimages/refs/heads/main/registry/v0.0.25.toml";
 pub const IMAGE_CONFIG_FILENAME: &str = ".image.toml";
 const DEFAULT_AUTO_SYNC_THRESHOLD: u64 = 60 * 60 * 24 * 7;
 const LOCAL_STORAGE_ENV: &str = "AXVISOR_IMAGE_LOCAL_STORAGE";

--- a/scripts/axbuild/src/axvisor/test.rs
+++ b/scripts/axbuild/src/axvisor/test.rs
@@ -1120,6 +1120,44 @@ mod tests {
     }
 
     #[test]
+    fn discovers_qemu_cases_from_uefi_group_without_polluting_normal_group() {
+        let root = tempdir().unwrap();
+        write_qemu_build_config(root.path(), "normal", "default", "x86_64-unknown-none");
+        write_qemu_config_in_group(
+            root.path(),
+            "normal",
+            "default",
+            "baseline",
+            "x86_64",
+            "shell_prefix = \">>\"\nshell_init_cmd = \"hello_world\"\nsuccess_regex = \
+             []\nfail_regex = []\n",
+        );
+        write_qemu_build_config(root.path(), "uefi", "qemu-nimbos", "x86_64-unknown-none");
+        write_qemu_config_in_group(
+            root.path(),
+            "uefi",
+            "qemu-nimbos",
+            "smoke",
+            "x86_64",
+            "shell_prefix = \">>\"\nshell_init_cmd = \"hello_world\"\nsuccess_regex = \
+             []\nfail_regex = []\n",
+        );
+
+        let normal_cases =
+            discover_qemu_cases(root.path(), "normal", "x86_64", "x86_64-unknown-none", None)
+                .unwrap();
+        assert_eq!(normal_cases.len(), 1);
+        assert_eq!(normal_cases[0].case.name, "baseline");
+
+        let uefi_cases =
+            discover_qemu_cases(root.path(), "uefi", "x86_64", "x86_64-unknown-none", None)
+                .unwrap();
+        assert_eq!(uefi_cases.len(), 1);
+        assert_eq!(uefi_cases[0].case.name, "smoke");
+        assert_eq!(uefi_cases[0].build_group, "qemu-nimbos");
+    }
+
+    #[test]
     fn rejects_unknown_qemu_test_group() {
         let root = tempdir().unwrap();
         write_qemu_build_config(

--- a/test-suit/axvisor/uefi/qemu-nimbos/build-x86_64-unknown-none.toml
+++ b/test-suit/axvisor/uefi/qemu-nimbos/build-x86_64-unknown-none.toml
@@ -1,0 +1,11 @@
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+features = [
+    "ax-driver/virtio-blk",
+    "ax-driver/plat-static",
+    "ept-level-4",
+    "fs",
+    "vmx",
+]
+log = "Info"
+target = "x86_64-unknown-none"
+vm_configs = ["os/axvisor/tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml"]

--- a/test-suit/axvisor/uefi/qemu-nimbos/qemu-x86_64.toml
+++ b/test-suit/axvisor/uefi/qemu-nimbos/qemu-x86_64.toml
@@ -1,0 +1,30 @@
+args = [
+  "-m",
+  "128M",
+  "-smp",
+  "1",
+  "-machine",
+  "q35",
+  "-device",
+  "virtio-blk-pci,drive=disk0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+  "-nographic",
+  "-accel",
+  "kvm",
+  "-cpu",
+  "host",
+]
+fail_regex = [
+  "System will reboot, press any key to continue ...",
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+  "(?i)permission denied",
+]
+# Keep this CI case as a bounded UEFI smoke test. Full x86_64 VMX UEFI
+# guest execution is still incomplete and does not reliably reach NimbOS
+# usertests yet.
+success_regex = ["VM\\[1\\] boot success"]
+timeout = 180
+to_bin = false
+uefi = false

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-aarch64.toml
@@ -24,6 +24,7 @@ original_repos="$(cat "$repo_file")"
 try_apk_curl() {
     mirror="$1"
     label="$2"
+    probe_url="$mirror/MIRRORS.txt"
     printf '%s\n' "$original_repos" | \
         sed "s#http://[^/]*/alpine/#$mirror/#g;s#https://[^/]*/alpine/#$mirror/#g" > "$repo_file"
     rm -f /lib/apk/db/lock
@@ -36,7 +37,7 @@ try_apk_curl() {
     echo "APK_CURL_ADD_DONE" && \
     echo "APK_CURL_PROBE_BEGIN" && \
     curl --version && \
-    curl --connect-timeout 10 --max-time 30 -i https://baidu.com && \
+    curl --connect-timeout 10 --max-time 30 -fsSL "$probe_url" -o /dev/null && \
     echo "APK_CURL_PROBE_DONE"
 }
 

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-loongarch64.toml
@@ -26,6 +26,7 @@ original_repos="$(cat "$repo_file")"
 try_apk_curl() {
   mirror="$1"
   label="$2"
+  probe_url="$mirror/MIRRORS.txt"
   printf '%s\n' "$original_repos" | \
     sed "s#http://[^/]*/alpine/#$mirror/#g;s#https://[^/]*/alpine/#$mirror/#g" > "$repo_file"
   rm -f /lib/apk/db/lock
@@ -38,7 +39,7 @@ try_apk_curl() {
   echo "APK_CURL_ADD_DONE" && \
   echo "APK_CURL_PROBE_BEGIN" && \
   curl --version && \
-  curl --connect-timeout 10 --max-time 30 -i https://baidu.com && \
+  curl --connect-timeout 10 --max-time 30 -fsSL "$probe_url" -o /dev/null && \
   echo "APK_CURL_PROBE_DONE"
 }
 

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-riscv64.toml
@@ -24,6 +24,7 @@ original_repos="$(cat "$repo_file")"
 try_apk_curl() {
     mirror="$1"
     label="$2"
+    probe_url="$mirror/MIRRORS.txt"
     printf '%s\n' "$original_repos" | \
         sed "s#http://[^/]*/alpine/#$mirror/#g;s#https://[^/]*/alpine/#$mirror/#g" > "$repo_file"
     rm -f /lib/apk/db/lock
@@ -36,7 +37,7 @@ try_apk_curl() {
     echo "APK_CURL_ADD_DONE" && \
     echo "APK_CURL_PROBE_BEGIN" && \
     curl --version && \
-    curl --connect-timeout 10 --max-time 30 -i https://baidu.com && \
+    curl --connect-timeout 10 --max-time 30 -fsSL "$probe_url" -o /dev/null && \
     echo "APK_CURL_PROBE_DONE"
 }
 

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-x86_64.toml
@@ -24,6 +24,7 @@ original_repos="$(cat "$repo_file")"
 try_apk_curl() {
     mirror="$1"
     label="$2"
+    probe_url="$mirror/MIRRORS.txt"
     printf '%s\n' "$original_repos" | \
         sed "s#http://[^/]*/alpine/#$mirror/#g;s#https://[^/]*/alpine/#$mirror/#g" > "$repo_file"
     rm -f /lib/apk/db/lock
@@ -36,7 +37,7 @@ try_apk_curl() {
     echo "APK_CURL_ADD_DONE" && \
     echo "APK_CURL_PROBE_BEGIN" && \
     curl --version && \
-    curl --connect-timeout 10 --max-time 30 -i https://baidu.com && \
+    curl --connect-timeout 10 --max-time 30 -fsSL "$probe_url" -o /dev/null && \
     echo "APK_CURL_PROBE_DONE"
 }
 

--- a/virtualization/axvm/src/config.rs
+++ b/virtualization/axvm/src/config.rs
@@ -20,7 +20,7 @@ use alloc::{string::String, vec::Vec};
 use axaddrspace::GuestPhysAddr;
 pub use axvmconfig::{
     AxVMCrateConfig, EmulatedDeviceConfig, PassThroughAddressConfig, PassThroughDeviceConfig,
-    VMInterruptMode, VMType, VmMemConfig, VmMemMappingType,
+    VMBootProtocol, VMInterruptMode, VMType, VmMemConfig, VmMemMappingType,
 };
 
 use crate::VMMemoryRegion;
@@ -141,7 +141,9 @@ fn configured_bios_load_gpa(cfg: &AxVMCrateConfig) -> Option<GuestPhysAddr> {
     }
 
     #[cfg(target_arch = "x86_64")]
-    if cfg.kernel.bios_path.is_none() {
+    if cfg.kernel.boot_firmware_path().is_none()
+        && cfg.kernel.effective_boot_protocol() == VMBootProtocol::Multiboot
+    {
         return Some(GuestPhysAddr::from(DEFAULT_X86_BIOS_LOAD_GPA));
     }
 
@@ -150,6 +152,7 @@ fn configured_bios_load_gpa(cfg: &AxVMCrateConfig) -> Option<GuestPhysAddr> {
 
 pub fn adjusted_kernel_load_gpa(
     main_memory: &VMMemoryRegion,
+    boot_protocol: VMBootProtocol,
     bios_load_gpa: Option<GuestPhysAddr>,
 ) -> Option<GuestPhysAddr> {
     if !main_memory.is_identical() {
@@ -157,7 +160,7 @@ pub fn adjusted_kernel_load_gpa(
     }
 
     let mut kernel_addr = main_memory.gpa;
-    if bios_load_gpa.is_some() {
+    if boot_protocol == VMBootProtocol::Multiboot && bios_load_gpa.is_some() {
         kernel_addr += BIOS_RESERVED_SIZE;
     }
     Some(kernel_addr)
@@ -418,5 +421,50 @@ mod tests {
                 .map(|addr| addr.as_usize()),
             Some(0x8000)
         );
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn uefi_boot_does_not_use_builtin_x86_bios_addr() {
+        let mut cfg = config_with_entry(0xffff_fff0);
+        cfg.kernel.enable_bios = true;
+        cfg.kernel.boot_protocol = Some(VMBootProtocol::Uefi);
+
+        let vm_config = AxVMConfig::from(cfg);
+
+        assert!(vm_config.image_config.bios_load_gpa.is_none());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn uefi_boot_uses_explicit_firmware_path_and_load_addr() {
+        let mut cfg = config_with_entry(0xffff_fff0);
+        cfg.kernel.enable_bios = true;
+        cfg.kernel.boot_protocol = Some(VMBootProtocol::Uefi);
+        cfg.kernel.uefi_firmware_path = Some(String::from("OVMF_CODE.fd"));
+        cfg.kernel.bios_load_addr = Some(0xffc0_0000);
+
+        let vm_config = AxVMConfig::from(cfg);
+
+        assert_eq!(
+            vm_config
+                .image_config
+                .bios_load_gpa
+                .map(|addr| addr.as_usize()),
+            Some(0xffc0_0000)
+        );
+    }
+
+    #[test]
+    fn uefi_boot_requires_a_firmware_path_or_legacy_fallback() {
+        let mut cfg = config_with_entry(0xffff_fff0);
+        cfg.kernel.enable_bios = true;
+        cfg.kernel.boot_protocol = Some(VMBootProtocol::Uefi);
+        cfg.kernel.bios_load_addr = Some(0xffc0_0000);
+
+        assert!(cfg.kernel.validate_boot_config().is_err());
+
+        cfg.kernel.uefi_firmware_path = Some(String::from("OVMF_CODE.fd"));
+        assert!(cfg.kernel.validate_boot_config().is_ok());
     }
 }

--- a/virtualization/axvmconfig/src/lib.rs
+++ b/virtualization/axvmconfig/src/lib.rs
@@ -332,6 +332,22 @@ pub struct VMBaseConfig {
     pub phys_cpu_sets: Option<Vec<usize>>,
 }
 
+/// Describes how a guest VM should enter its boot image.
+#[cfg_attr(all(feature = "std", any(windows, unix)), derive(schemars::JsonSchema))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum VMBootProtocol {
+    /// Enter the configured kernel entry directly without a firmware image.
+    #[serde(rename = "direct", alias = "kernel")]
+    #[default]
+    Direct,
+    /// Use the legacy x86 axvm-bios/multiboot trampoline.
+    #[serde(rename = "multiboot", alias = "bios", alias = "axvm-bios")]
+    Multiboot,
+    /// Load an external UEFI firmware image and enter it without multiboot patching.
+    #[serde(rename = "uefi", alias = "efi")]
+    Uefi,
+}
+
 /// The configuration structure for the guest VM kernel.
 #[cfg_attr(all(feature = "std", any(windows, unix)), derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
@@ -345,8 +361,16 @@ pub struct VMKernelConfig {
     /// Whether to enable BIOS boot flow for this VM.
     #[serde(default)]
     pub enable_bios: bool,
+    /// Guest boot protocol. When omitted, legacy configs use `multiboot` if
+    /// `enable_bios = true`, otherwise `direct`.
+    #[serde(default)]
+    pub boot_protocol: Option<VMBootProtocol>,
     /// The file path of the BIOS image, `None` if not used.
+    #[serde(default)]
     pub bios_path: Option<String>,
+    /// The file path of the UEFI firmware image, `None` if not used.
+    #[serde(default)]
+    pub uefi_firmware_path: Option<String>,
     /// The load address of the BIOS image, `None` if not used.
     pub bios_load_addr: Option<usize>,
     /// The file path of the device tree blob (DTB), `None` if not used.
@@ -369,6 +393,128 @@ pub struct VMKernelConfig {
     #[serde(skip)]
     pub configured_memory_region_count: usize,
 }
+
+impl VMKernelConfig {
+    /// Returns the effective boot protocol after applying compatibility defaults.
+    pub fn effective_boot_protocol(&self) -> VMBootProtocol {
+        self.boot_protocol.unwrap_or({
+            if self.enable_bios {
+                VMBootProtocol::Multiboot
+            } else {
+                VMBootProtocol::Direct
+            }
+        })
+    }
+
+    /// Returns the configured boot firmware image path.
+    ///
+    /// For UEFI, prefer the explicit UEFI firmware path and fall back to the
+    /// legacy BIOS path for compatibility with older configs.
+    pub fn boot_firmware_path(&self) -> Option<&str> {
+        match self.effective_boot_protocol() {
+            VMBootProtocol::Uefi => self
+                .uefi_firmware_path
+                .as_deref()
+                .or(self.bios_path.as_deref()),
+            _ => self.bios_path.as_deref(),
+        }
+    }
+
+    /// Validate that the configured boot protocol has the firmware inputs it needs.
+    pub fn validate_boot_config(&self) -> AxResult<()> {
+        self.validate_boot_config_for_arch(BUILD_TARGET_ARCH)
+    }
+
+    fn validate_boot_config_for_arch(&self, arch: &str) -> AxResult<()> {
+        if !self.enable_bios {
+            if matches!(
+                self.effective_boot_protocol(),
+                VMBootProtocol::Multiboot | VMBootProtocol::Uefi
+            ) {
+                return Err(ax_errno::ax_err_type!(
+                    InvalidInput,
+                    "boot_protocol requires enable_bios = true"
+                ));
+            }
+            return Ok(());
+        }
+
+        match self.effective_boot_protocol() {
+            VMBootProtocol::Uefi => {
+                if arch != "x86_64" {
+                    warn!(
+                        "boot_protocol=uefi is only supported on x86_64; rejecting config on \
+                         {arch}"
+                    );
+                    return Err(ax_errno::ax_err_type!(
+                        InvalidInput,
+                        "UEFI boot is only supported on x86_64"
+                    ));
+                }
+                if self.boot_firmware_path().is_none() {
+                    return Err(ax_errno::ax_err_type!(
+                        InvalidInput,
+                        "UEFI boot requires uefi_firmware_path or legacy bios_path"
+                    ));
+                }
+                if self.bios_load_addr.is_none() {
+                    return Err(ax_errno::ax_err_type!(
+                        InvalidInput,
+                        "UEFI boot requires bios_load_addr"
+                    ));
+                }
+            }
+            VMBootProtocol::Multiboot => {
+                if arch != "x86_64" {
+                    warn!(
+                        "boot_protocol=multiboot is only supported on x86_64; rejecting config on \
+                         {arch}"
+                    );
+                    return Err(ax_errno::ax_err_type!(
+                        InvalidInput,
+                        "multiboot firmware boot is only supported on x86_64"
+                    ));
+                }
+                if self.bios_path.is_some() && self.bios_load_addr.is_none() {
+                    return Err(ax_errno::ax_err_type!(
+                        InvalidInput,
+                        "external BIOS boot requires bios_load_addr"
+                    ));
+                }
+            }
+            VMBootProtocol::Direct => {
+                if self.enable_bios {
+                    return Err(ax_errno::ax_err_type!(
+                        InvalidInput,
+                        "direct boot must not set enable_bios = true"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+const BUILD_TARGET_ARCH: &str = "x86_64";
+
+#[cfg(target_arch = "aarch64")]
+const BUILD_TARGET_ARCH: &str = "aarch64";
+
+#[cfg(target_arch = "riscv64")]
+const BUILD_TARGET_ARCH: &str = "riscv64";
+
+#[cfg(target_arch = "loongarch64")]
+const BUILD_TARGET_ARCH: &str = "loongarch64";
+
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64",
+    target_arch = "loongarch64"
+)))]
+const BUILD_TARGET_ARCH: &str = "unknown";
 
 /// Specifies how the VM should handle interrupts and interrupt controllers.
 #[cfg_attr(all(feature = "std", any(windows, unix)), derive(schemars::JsonSchema))]
@@ -425,6 +571,7 @@ impl AxVMCrateConfig {
             warn!("Config TOML parse error {:?}", err.message());
             ax_errno::ax_err_type!(InvalidInput, alloc::format!("Error details {err:?}"))
         })?;
+        config.kernel.validate_boot_config()?;
         config.kernel.configured_memory_region_count = config.kernel.memory_regions.len();
         Ok(config)
     }

--- a/virtualization/axvmconfig/src/templates.rs
+++ b/virtualization/axvmconfig/src/templates.rs
@@ -72,7 +72,9 @@ pub fn get_vm_config_template(params: VmTemplateParams) -> AxVMCrateConfig {
             kernel_path: params.kernel_path,
             kernel_load_addr: params.kernel_load_addr,
             enable_bios: false,
+            boot_protocol: None,
             bios_path: None, // BIOS not used in most configurations
+            uefi_firmware_path: None,
             bios_load_addr: None,
             dtb_path: None, // Device tree not specified by default
             dtb_load_addr: None,

--- a/virtualization/axvmconfig/src/test.rs
+++ b/virtualization/axvmconfig/src/test.rs
@@ -15,7 +15,8 @@
 use enumerable::Enumerable;
 
 use crate::{
-    AxVMCrateConfig, EmulatedDeviceType, VMDevicesConfig, VMInterruptMode, VmMemMappingType,
+    AxVMCrateConfig, EmulatedDeviceType, VMBootProtocol, VMDevicesConfig, VMInterruptMode,
+    VmMemMappingType,
 };
 
 #[test]
@@ -72,6 +73,10 @@ interrupt_mode = "passthrough"
     assert_eq!(config.kernel.kernel_path, "amazing-os.bin");
     assert_eq!(config.kernel.kernel_load_addr, 0xdeadbeef);
     assert!(config.kernel.enable_bios);
+    assert_eq!(
+        config.kernel.effective_boot_protocol(),
+        VMBootProtocol::Multiboot
+    );
     assert_eq!(config.kernel.bios_path, Some("test-bios.bin".to_string()));
     assert_eq!(config.kernel.bios_load_addr, Some(0x8000));
     assert_eq!(
@@ -117,6 +122,131 @@ interrupt_mode = "passthrough"
         EmulatedDeviceType::GPPTITS
     );
     assert_eq!(config.devices.interrupt_mode, VMInterruptMode::Passthrough);
+}
+
+#[test]
+fn test_boot_protocol_deser_and_legacy_defaults() {
+    const UEFI_KERNEL_CONFIG: &str = r#"
+entry_point = 0xffff_fff0
+image_location = "fs"
+kernel_path = "guest-loader.efi"
+kernel_load_addr = 0x20_0000
+enable_bios = true
+boot_protocol = "uefi"
+uefi_firmware_path = "OVMF_CODE.fd"
+bios_path = "legacy-OVMF_CODE.fd"
+bios_load_addr = 0xffc0_0000
+memory_regions = []
+    "#;
+
+    let uefi_config: crate::VMKernelConfig = toml::from_str(UEFI_KERNEL_CONFIG).unwrap();
+    assert_eq!(uefi_config.boot_protocol, Some(VMBootProtocol::Uefi));
+    assert_eq!(uefi_config.effective_boot_protocol(), VMBootProtocol::Uefi);
+    assert_eq!(uefi_config.boot_firmware_path(), Some("OVMF_CODE.fd"));
+    assert!(uefi_config.validate_boot_config().is_ok());
+
+    let legacy_uefi_config = crate::VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Uefi),
+        bios_path: Some("OVMF_CODE.fd".to_string()),
+        bios_load_addr: Some(0xffc0_0000),
+        ..Default::default()
+    };
+    assert_eq!(
+        legacy_uefi_config.boot_firmware_path(),
+        Some("OVMF_CODE.fd")
+    );
+    assert!(legacy_uefi_config.validate_boot_config().is_ok());
+
+    let direct_config = crate::VMKernelConfig {
+        enable_bios: false,
+        ..Default::default()
+    };
+    assert_eq!(
+        direct_config.effective_boot_protocol(),
+        VMBootProtocol::Direct
+    );
+
+    let legacy_bios_config = crate::VMKernelConfig {
+        enable_bios: true,
+        ..Default::default()
+    };
+    assert_eq!(
+        legacy_bios_config.effective_boot_protocol(),
+        VMBootProtocol::Multiboot
+    );
+}
+
+#[test]
+fn test_boot_config_validation_requires_uefi_inputs() {
+    let mut missing_firmware = crate::VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Uefi),
+        bios_load_addr: Some(0xffc0_0000),
+        ..Default::default()
+    };
+
+    assert!(missing_firmware.validate_boot_config().is_err());
+
+    missing_firmware.uefi_firmware_path = Some("OVMF_CODE.fd".to_string());
+    assert!(missing_firmware.validate_boot_config().is_ok());
+}
+
+#[test]
+fn test_boot_config_validation_rejects_x86_firmware_protocols_on_other_arches() {
+    let uefi_config = crate::VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Uefi),
+        uefi_firmware_path: Some("OVMF_CODE.fd".to_string()),
+        bios_load_addr: Some(0xffc0_0000),
+        ..Default::default()
+    };
+
+    assert!(
+        uefi_config
+            .validate_boot_config_for_arch("aarch64")
+            .is_err()
+    );
+    assert!(
+        uefi_config
+            .validate_boot_config_for_arch("riscv64")
+            .is_err()
+    );
+    assert!(
+        uefi_config
+            .validate_boot_config_for_arch("loongarch64")
+            .is_err()
+    );
+    assert!(uefi_config.validate_boot_config_for_arch("x86_64").is_ok());
+
+    let multiboot_config = crate::VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Multiboot),
+        ..Default::default()
+    };
+
+    assert!(
+        multiboot_config
+            .validate_boot_config_for_arch("aarch64")
+            .is_err()
+    );
+    assert!(
+        multiboot_config
+            .validate_boot_config_for_arch("x86_64")
+            .is_ok()
+    );
+}
+
+#[test]
+fn test_boot_config_validation_rejects_direct_bios_mix() {
+    let direct_with_bios = crate::VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Direct),
+        bios_load_addr: Some(0x8000),
+        ..Default::default()
+    };
+
+    assert!(direct_with_bios.validate_boot_config().is_err());
 }
 
 #[test]
@@ -306,7 +436,13 @@ fn test_default_implementations() {
     assert_eq!(vm_kernel_config.kernel_path, "");
     assert_eq!(vm_kernel_config.kernel_load_addr, 0);
     assert!(!vm_kernel_config.enable_bios);
+    assert!(vm_kernel_config.boot_protocol.is_none());
+    assert_eq!(
+        vm_kernel_config.effective_boot_protocol(),
+        VMBootProtocol::Direct
+    );
     assert!(vm_kernel_config.bios_path.is_none());
+    assert!(vm_kernel_config.uefi_firmware_path.is_none());
     assert!(vm_kernel_config.bios_load_addr.is_none());
     assert!(vm_kernel_config.dtb_path.is_none());
     assert!(vm_kernel_config.dtb_load_addr.is_none());

--- a/virtualization/axvmconfig/templates/x86_64.toml
+++ b/virtualization/axvmconfig/templates/x86_64.toml
@@ -5,6 +5,7 @@ cpu_num = 1
 phys_cpu_sets = [1]
 entry_point = 0x8000
 enable_bios = true
+boot_protocol = "multiboot"
 bios_path = "rvm-bios.bin"
 bios_load_addr = 0x8000
 kernel_path = "arceos-x86_64.bin"

--- a/virtualization/x86_vcpu/src/lib.rs
+++ b/virtualization/x86_vcpu/src/lib.rs
@@ -46,6 +46,40 @@ pub(crate) mod regs;
 #[cfg(any(feature = "vmx", feature = "svm"))]
 pub(crate) mod xstate;
 
+#[cfg(any(feature = "vmx", feature = "svm", test))]
+const X86_RESET_VECTOR_GPA: usize = 0xffff_fff0;
+#[cfg(any(feature = "vmx", feature = "svm", test))]
+const X86_RESET_CS_SELECTOR: u16 = 0xf000;
+#[cfg(any(feature = "vmx", feature = "svm", test))]
+const X86_RESET_CS_BASE: usize = 0xffff_0000;
+
+#[cfg(any(feature = "vmx", feature = "svm", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct X86RealModeEntryState {
+    pub(crate) cs_selector: u16,
+    pub(crate) cs_base: usize,
+    pub(crate) rip: usize,
+}
+
+#[cfg(any(feature = "vmx", feature = "svm", test))]
+pub(crate) fn x86_real_mode_entry_state(
+    entry: axaddrspace::GuestPhysAddr,
+) -> X86RealModeEntryState {
+    if entry.as_usize() == X86_RESET_VECTOR_GPA {
+        return X86RealModeEntryState {
+            cs_selector: X86_RESET_CS_SELECTOR,
+            cs_base: X86_RESET_CS_BASE,
+            rip: X86_RESET_VECTOR_GPA - X86_RESET_CS_BASE,
+        };
+    }
+
+    X86RealModeEntryState {
+        cs_selector: 0,
+        cs_base: 0,
+        rip: entry.as_usize(),
+    }
+}
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "vmx")] {
         mod vmx;
@@ -92,4 +126,35 @@ pub(crate) fn host_tsc_frequency_mhz() -> Option<u32> {
     u32::try_from(axvisor_api::time::nanos_to_ticks(1_000))
         .ok()
         .filter(|&freq| freq > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use axaddrspace::GuestPhysAddr;
+
+    use super::*;
+
+    #[test]
+    fn real_mode_entry_keeps_normal_entry_flat() {
+        assert_eq!(
+            x86_real_mode_entry_state(GuestPhysAddr::from(0x8000)),
+            X86RealModeEntryState {
+                cs_selector: 0,
+                cs_base: 0,
+                rip: 0x8000,
+            }
+        );
+    }
+
+    #[test]
+    fn real_mode_entry_maps_reset_vector_to_reset_cs_state() {
+        assert_eq!(
+            x86_real_mode_entry_state(GuestPhysAddr::from(0xffff_fff0)),
+            X86RealModeEntryState {
+                cs_selector: 0xf000,
+                cs_base: 0xffff_0000,
+                rip: 0xfff0,
+            }
+        );
+    }
 }

--- a/virtualization/x86_vcpu/src/svm/vcpu.rs
+++ b/virtualization/x86_vcpu/src/svm/vcpu.rs
@@ -24,7 +24,7 @@ use super::{
 };
 use crate::{
     X86VCpuSetupConfig, msr::Msr, regs::GeneralRegisters, restore_host_interrupt_flag,
-    xstate::XState,
+    x86_real_mode_entry_state, xstate::XState,
 };
 
 const QEMU_EXIT_PORT: u16 = 0x604;
@@ -181,6 +181,7 @@ impl SvmVcpu {
     }
 
     fn setup_vmcb_guest(&mut self, entry: GuestPhysAddr) -> AxResult {
+        let entry_state = x86_real_mode_entry_state(entry);
         let cr0_val =
             Cr0Flags::NOT_WRITE_THROUGH | Cr0Flags::CACHE_DISABLE | Cr0Flags::EXTENSION_TYPE;
         let vmcb = unsafe { self.vmcb.as_vmcb() };
@@ -190,8 +191,8 @@ impl SvmVcpu {
         state.cr3.set(0);
         state.cr4.set(0);
 
-        state.cs.selector.set(0);
-        state.cs.base.set(0);
+        state.cs.selector.set(entry_state.cs_selector);
+        state.cs.base.set(entry_state.cs_base as u64);
         state.cs.limit.set(0xffff);
         state.cs.attr.set(0x9b);
 
@@ -211,7 +212,7 @@ impl SvmVcpu {
         state.dr7.set(0x400);
         state.dr6.set(0xffff0ff0);
         state.rflags.set(0x2);
-        state.rip.set(entry.as_usize() as u64);
+        state.rip.set(entry_state.rip as u64);
         state.rsp.set(0);
         state.efer.set(EFER_SVME);
         state.g_pat.set(Msr::IA32_PAT.read());

--- a/virtualization/x86_vcpu/src/vmx/vcpu.rs
+++ b/virtualization/x86_vcpu/src/vmx/vcpu.rs
@@ -53,7 +53,7 @@ use super::{
 };
 use crate::{
     X86VCpuSetupConfig, ept::GuestPageWalkInfo, msr::Msr, regs::GeneralRegisters,
-    restore_host_interrupt_flag, xstate::XState,
+    restore_host_interrupt_flag, x86_real_mode_entry_state, xstate::XState,
 };
 
 const VMX_PREEMPTION_TIMER_SET_VALUE: u32 = 100_000;
@@ -557,6 +557,7 @@ impl VmxVcpu {
     }
 
     fn setup_vmcs_guest(&mut self, entry: GuestPhysAddr) -> AxResult {
+        let entry_state = x86_real_mode_entry_state(entry);
         let cr0_val: Cr0Flags =
             Cr0Flags::NOT_WRITE_THROUGH | Cr0Flags::CACHE_DISABLE | Cr0Flags::EXTENSION_TYPE;
         self.set_cr(0, cr0_val.bits());
@@ -578,6 +579,8 @@ impl VmxVcpu {
 
         set_guest_segment!(ES, 0x93); // 16-bit, present, data, read/write, accessed
         set_guest_segment!(CS, 0x9b); // 16-bit, present, code, exec/read, accessed
+        VmcsGuest16::CS_SELECTOR.write(entry_state.cs_selector)?;
+        VmcsGuestNW::CS_BASE.write(entry_state.cs_base)?;
         set_guest_segment!(SS, 0x93);
         set_guest_segment!(DS, 0x93);
         set_guest_segment!(FS, 0x93);
@@ -593,7 +596,7 @@ impl VmxVcpu {
         VmcsGuestNW::CR3.write(0)?;
         VmcsGuestNW::DR7.write(0x400)?;
         VmcsGuestNW::RSP.write(0)?;
-        VmcsGuestNW::RIP.write(entry.as_usize())?;
+        VmcsGuestNW::RIP.write(entry_state.rip)?;
         VmcsGuestNW::RFLAGS.write(0x2)?;
         VmcsGuestNW::PENDING_DBG_EXCEPTIONS.write(0)?;
         VmcsGuestNW::IA32_SYSENTER_ESP.write(0)?;


### PR DESCRIPTION
## 变更
- 为 `axvmconfig` 的 `boot_protocol` 增加校验，明确区分 `direct`、`multiboot` 和 `uefi`。
- 在 x86_64 UEFI 启动路径中跳过 multiboot patch，避免错误修改镜像。
- 保留 `bios_path` 作为 UEFI 兼容党底，兼容旧配置。
- 补充单元测试，覆盖默认协议、UEFI 校验、非 x86 架构拒绝 `multiboot` / `uefi`、`direct` 与 BIOS 冲突等场景。

## 验证
- `cargo +stable test -p axvmconfig`
- `cargo +stable test -p axvm`
- `git diff --check`

Closes #724