### PR TITLE
feat(starryos): add Lua/LuaRocks runtime coverage and fix rmdir ENOTEMPTY

### DIFF
--- a/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
@@ -295,6 +295,10 @@ impl FsContext {
     /// Removes a directory from the filesystem.
     pub fn remove_dir(&self, path: impl AsRef<Path>) -> VfsResult<()> {
         let entry = self.resolve_no_follow(path.as_ref())?;
+        let dir = entry.entry().as_dir()?;
+        if dir.has_children()? {
+            return Err(VfsError::DirectoryNotEmpty);
+        }
         entry
             .parent()
             .ok_or(VfsError::ResourceBusy)?

--- a/test-suit/starryos/normal/qemu-smp1/c-regression/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/c-regression/qemu-aarch64.toml
@@ -18,6 +18,7 @@ test_commands = [
     "/usr/bin/test-netlink-genl",
     "/usr/bin/test-netlink-rtnetlink",
     "/usr/bin/test-netlink-uevent",
+    "/usr/bin/test-rmdir-nonempty",
     "/usr/bin/test-sysfs-class",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]

--- a/test-suit/starryos/normal/qemu-smp1/c-regression/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/c-regression/qemu-loongarch64.toml
@@ -21,6 +21,7 @@ test_commands = [
     "/usr/bin/test-netlink-genl",
     "/usr/bin/test-netlink-rtnetlink",
     "/usr/bin/test-netlink-uevent",
+    "/usr/bin/test-rmdir-nonempty",
     "/usr/bin/test-sysfs-class",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]

--- a/test-suit/starryos/normal/qemu-smp1/c-regression/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/c-regression/qemu-riscv64.toml
@@ -18,6 +18,7 @@ test_commands = [
     "/usr/bin/test-netlink-genl",
     "/usr/bin/test-netlink-rtnetlink",
     "/usr/bin/test-netlink-uevent",
+    "/usr/bin/test-rmdir-nonempty",
     "/usr/bin/test-sysfs-class",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]

--- a/test-suit/starryos/normal/qemu-smp1/c-regression/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/c-regression/qemu-x86_64.toml
@@ -18,6 +18,7 @@ test_commands = [
     "/usr/bin/test-netlink-genl",
     "/usr/bin/test-netlink-rtnetlink",
     "/usr/bin/test-netlink-uevent",
+    "/usr/bin/test-rmdir-nonempty",
     "/usr/bin/test-sysfs-class",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]

--- a/test-suit/starryos/normal/qemu-smp1/c-regression/test-rmdir-nonempty/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/c-regression/test-rmdir-nonempty/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-rmdir-nonempty C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+add_executable(test-rmdir-nonempty src/main.c)
+target_compile_options(test-rmdir-nonempty PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-rmdir-nonempty RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/c-regression/test-rmdir-nonempty/c/prebuild.sh
+++ b/test-suit/starryos/normal/qemu-smp1/c-regression/test-rmdir-nonempty/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add gcc musl-dev

--- a/test-suit/starryos/normal/qemu-smp1/c-regression/test-rmdir-nonempty/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/c-regression/test-rmdir-nonempty/c/src/main.c
@@ -1,0 +1,61 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define TEST_DIR "/root/starry-rmdir-nonempty"
+#define TEST_FILE TEST_DIR "/child"
+
+static int fail(const char *msg)
+{
+    printf("FAIL: %s: errno=%d (%s)\n", msg, errno, strerror(errno));
+    return 1;
+}
+
+int main(void)
+{
+    unlink(TEST_FILE);
+    rmdir(TEST_DIR);
+
+    if (mkdir(TEST_DIR, 0755) != 0) {
+        return fail("mkdir test directory");
+    }
+
+    int fd = open(TEST_FILE, O_WRONLY | O_CREAT | O_EXCL, 0644);
+    if (fd < 0) {
+        rmdir(TEST_DIR);
+        return fail("create child file");
+    }
+    if (write(fd, "x", 1) != 1) {
+        close(fd);
+        unlink(TEST_FILE);
+        rmdir(TEST_DIR);
+        return fail("write child file");
+    }
+    close(fd);
+
+    errno = 0;
+    if (rmdir(TEST_DIR) == 0) {
+        printf("FAIL: rmdir unexpectedly removed a non-empty directory\n");
+        return 1;
+    }
+    if (errno != ENOTEMPTY) {
+        return fail("rmdir non-empty directory should fail with ENOTEMPTY");
+    }
+
+    if (access(TEST_FILE, F_OK) != 0) {
+        return fail("child file should remain after failed rmdir");
+    }
+
+    if (unlink(TEST_FILE) != 0) {
+        return fail("cleanup child file");
+    }
+    if (rmdir(TEST_DIR) != 0) {
+        return fail("cleanup test directory");
+    }
+
+    printf("RMDIR_NONEMPTY_TEST_PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/lua-luarocks/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/lua-luarocks/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/lua-luarocks-tests.sh"
+success_regex = ["(?m)^LUA_LUAROCKS_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^LUA_LUAROCKS_TEST_FAILED\\s*$"]
+timeout = 600

--- a/test-suit/starryos/normal/qemu-smp1/lua-luarocks/sh/lua-luarocks-main.lua
+++ b/test-suit/starryos/normal/qemu-smp1/lua-luarocks/sh/lua-luarocks-main.lua
@@ -1,0 +1,7 @@
+local inspect = require("inspect")
+
+local rendered = inspect({ runtime = "starry", values = { 1, 2, 3 } })
+assert(rendered:match('runtime = "starry"'), rendered)
+assert(rendered:match("values"), rendered)
+
+print("LUA_LUAROCKS_TEST_PASSED")

--- a/test-suit/starryos/normal/qemu-smp1/lua-luarocks/sh/lua-luarocks-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/lua-luarocks/sh/lua-luarocks-tests.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+apk update
+apk add lua5.4 luarocks5.4
+
+luarocks-5.4 install inspect
+test -f /usr/local/share/lua/5.4/inspect.lua
+
+lua5.4 /usr/bin/lua-luarocks-main.lua || {
+    echo "LUA_LUAROCKS_TEST_FAILED"
+    exit 1
+}

--- a/test-suit/starryos/normal/qemu-smp1/lua/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/lua/qemu-aarch64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/lua-app-tests.sh"
+success_regex = ["(?m)^LUA_APP_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^LUA_APP_TEST_FAILED\\s*$"]
+timeout = 600

--- a/test-suit/starryos/normal/qemu-smp1/lua/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/lua/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/lua-app-tests.sh"
+success_regex = ["(?m)^LUA_APP_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^LUA_APP_TEST_FAILED\\s*$"]
+timeout = 600

--- a/test-suit/starryos/normal/qemu-smp1/lua/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/lua/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/lua-app-tests.sh"
+success_regex = ["(?m)^LUA_APP_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^LUA_APP_TEST_FAILED\\s*$"]
+timeout = 600

--- a/test-suit/starryos/normal/qemu-smp1/lua/sh/lua-app-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/lua/sh/lua-app-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+apk update
+apk add lua5.4 lua5.4-cjson
+
+lua5.4 /usr/bin/lua-main.lua alpha beta || {
+    echo "LUA_APP_TEST_FAILED"
+    exit 1
+}

--- a/test-suit/starryos/normal/qemu-smp1/lua/sh/lua-main.lua
+++ b/test-suit/starryos/normal/qemu-smp1/lua/sh/lua-main.lua
@@ -1,0 +1,26 @@
+package.path = "/usr/bin/?.lua;" .. package.path
+
+local helper = require("starry_lua_helper")
+local cjson = require("cjson")
+
+assert(_VERSION == "Lua 5.4", _VERSION)
+assert(arg[1] == "alpha", "missing first script argument")
+assert(arg[2] == "beta", "missing second script argument")
+
+local joined = helper.join({ "starry", "lua", tostring(helper.answer()) }, "-")
+assert(joined == "starry-lua-42", joined)
+
+local encoded = cjson.encode({ runtime = "starry", values = { 1, 2, 3 } })
+local decoded = cjson.decode(encoded)
+assert(decoded.runtime == "starry", encoded)
+assert(decoded.values[1] == 1 and decoded.values[2] == 2 and decoded.values[3] == 3, encoded)
+
+local path = "/tmp/starry-lua-script-data.txt"
+helper.write_lines(path, { "script", "module", joined })
+local data = helper.read_all(path)
+assert(data == "script\nmodule\nstarry-lua-42\n", data)
+
+local dofile_value = dofile("/usr/bin/lua-secondary.lua")
+assert(dofile_value == "secondary-ok", tostring(dofile_value))
+
+print("LUA_APP_TEST_PASSED")

--- a/test-suit/starryos/normal/qemu-smp1/lua/sh/lua-secondary.lua
+++ b/test-suit/starryos/normal/qemu-smp1/lua/sh/lua-secondary.lua
@@ -1,0 +1,1 @@
+return "secondary-ok"

--- a/test-suit/starryos/normal/qemu-smp1/lua/sh/starry_lua_helper.lua
+++ b/test-suit/starryos/normal/qemu-smp1/lua/sh/starry_lua_helper.lua
@@ -1,0 +1,26 @@
+local M = {}
+
+function M.answer()
+    return 21 * 2
+end
+
+function M.join(values, separator)
+    return table.concat(values, separator)
+end
+
+function M.write_lines(path, lines)
+    local file = assert(io.open(path, "w"))
+    for _, line in ipairs(lines) do
+        assert(file:write(line, "\n"))
+    end
+    assert(file:close())
+end
+
+function M.read_all(path)
+    local file = assert(io.open(path, "r"))
+    local data = assert(file:read("*a"))
+    assert(file:close())
+    return data
+end
+
+return M


### PR DESCRIPTION
## 问题
本 PR 为 StarryOS 补齐 Lua 应用运行时的测试覆盖，并修复一个阻碍 Lua 应用稳定运行的文件系统缺陷：
1. StarryOS 尚无 Lua 5.4 运行时及 LuaRocks 包管理的自动化测试
2. `rmdir` 对非空目录未返回 `ENOTEMPTY`，不符合 POSIX 语义，Lua 应用可能误删非空目录
## 改动
### 1. Lua 5.4 运行时测试 
在 `test-suit/starryos/normal/qemu-smp1/lua/` 下新增三架构 (aarch64/riscv64/x86_64) QEMU 测试：
- `lua-app-tests.sh`：通过 apk 安装 lua5.4 + cjson 后执行测试
- 覆盖点：运行时版本、命令行参数传递、自定义模块 require、cjson 编解码、文件 I/O、dofile 加载
### 2. LuaRocks 包管理测试
在 `test-suit/starryos/normal/qemu-smp1/lua-luarocks/` 下新增 riscv64 QEMU 测试：
- `luarocks-5.4 install inspect` → 验证安装路径 → require("inspect") 可用
### 3. rmdir ENOTEMPTY 修复 + 回归测试
- `axfs-ng/src/highlevel/fs.rs`：`remove_dir()` 增加 `has_children()` 检查，非空目录拒绝删除
- 新增 c-regression `test-rmdir-nonempty`：覆盖 rmdir 非空目录应返回 ENOTEMPTY，子文件应保留，清理后正常删除
## 验证
```bash
# Lua 运行时测试
cargo xtask test starry --test-case lua
# LuaRocks 测试
cargo xtask test starry --test-case lua-luarocks
# rmdir 回归测试
cargo xtask test starry --test-case c-regression