### PR TITLE
fix(starry-kernel): handle prctl PR_SET_VMA as silent no-op

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ctl.rs
@@ -166,6 +166,12 @@ pub fn sys_prctl(
             // not implemented; but avoid annoying warnings
             return Err(AxError::InvalidInput);
         }
+        PR_SET_VMA => {
+            if arg2 == PR_SET_VMA_ANON_NAME as usize {
+                return Ok(0);
+            }
+            return Err(AxError::InvalidInput);
+        }
         _ => {
             warn!("sys_prctl: unsupported option {option}");
             return Err(AxError::InvalidInput);

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-prctl-set-vma-anon-name/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-prctl-set-vma-anon-name/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-prctl-set-vma-anon-name C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-prctl-set-vma-anon-name src/main.c)
+target_compile_options(bug-prctl-set-vma-anon-name PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-prctl-set-vma-anon-name RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-prctl-set-vma-anon-name/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-prctl-set-vma-anon-name/c/src/main.c
@@ -1,0 +1,105 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+#ifndef PR_SET_VMA_ANON_NAME
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static long prctl_raw(int option, unsigned long arg2, unsigned long arg3,
+                      unsigned long arg4, unsigned long arg5)
+{
+    return syscall(SYS_prctl, option, arg2, arg3, arg4, arg5);
+}
+
+static void test_vma_anon_name_ok(void)
+{
+    size_t len = 4096;
+    void *addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (addr == MAP_FAILED) {
+        note_fail("PR_SET_VMA ANON_NAME", "mmap failed");
+        return;
+    }
+
+    errno = 0;
+    long ret = prctl_raw(PR_SET_VMA, PR_SET_VMA_ANON_NAME,
+                         (unsigned long)addr, len, (unsigned long)"picoclaw-test");
+    if (ret == 0) {
+        note_pass("PR_SET_VMA ANON_NAME returns 0");
+    } else {
+        char detail[160];
+        snprintf(detail, sizeof(detail),
+                 "ret=%ld errno=%d (%s), expected 0",
+                 ret, errno, strerror(errno));
+        note_fail("PR_SET_VMA ANON_NAME", detail);
+    }
+
+    munmap(addr, len);
+}
+
+static void test_vma_unknown_subop_einval(void)
+{
+    size_t len = 4096;
+    void *addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (addr == MAP_FAILED) {
+        note_fail("PR_SET_VMA unknown subop", "mmap failed");
+        return;
+    }
+
+    errno = 0;
+    long ret = prctl_raw(PR_SET_VMA, 9999,
+                         (unsigned long)addr, len, (unsigned long)"bad");
+    int saved = errno;
+    if (ret == -1 && saved == EINVAL) {
+        note_pass("PR_SET_VMA unknown subop returns EINVAL");
+    } else {
+        char detail[160];
+        snprintf(detail, sizeof(detail),
+                 "ret=%ld errno=%d (%s), expected -1/EINVAL",
+                 ret, saved, strerror(saved));
+        note_fail("PR_SET_VMA unknown subop", detail);
+    }
+
+    munmap(addr, len);
+}
+
+int main(void)
+{
+    printf("=== bug-prctl-set-vma-anon-name ===\n");
+
+    test_vma_anon_name_ok();
+    test_vma_unknown_subop_einval();
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+    printf("SOME TESTS FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -85,6 +85,7 @@ test_commands = [
     "/usr/bin/bug-open-creat-dangling-no-create",
     "/usr/bin/bug-open-unix-socket-no-enxio",
     "/usr/bin/bug-open-fifo-wronly-no-reader-no-enxio",
+    "/usr/bin/bug-prctl-set-vma-anon-name",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -86,6 +86,7 @@ test_commands = [
     "/usr/bin/bug-open-creat-dangling-no-create",
     "/usr/bin/bug-open-unix-socket-no-enxio",
     "/usr/bin/bug-open-fifo-wronly-no-reader-no-enxio",
+    "/usr/bin/bug-prctl-set-vma-anon-name",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -93,6 +93,7 @@ test_commands = [
     "/usr/bin/bug-open-creat-dangling-no-create",
     "/usr/bin/bug-open-unix-socket-no-enxio",
     "/usr/bin/bug-open-fifo-wronly-no-reader-no-enxio",
+    "/usr/bin/bug-prctl-set-vma-anon-name",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -90,6 +90,7 @@ test_commands = [
     "/usr/bin/bug-open-creat-dangling-no-create",
     "/usr/bin/bug-open-unix-socket-no-enxio",
     "/usr/bin/bug-open-fifo-wronly-no-reader-no-enxio",
+    "/usr/bin/bug-prctl-set-vma-anon-name",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']


### PR DESCRIPTION
## 背景

PicoClaw (Go 静态链接 AI 助手) 在 StarryOS 上运行时，Go runtime 调用 `prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, ...)` 为匿名 VMA 命名。StarryOS 不识别此 option，每次打印 warning 并返回 EINVAL。

## 修复内容

在 `sys_prctl()` 中新增 `PR_SET_VMA` 分支，作为 **兼容性 silent no-op**：

- `PR_SET_VMA_ANON_NAME`：返回 `Ok(0)`，不存储 VMA name，不验证用户指针
- 其他子操作：返回 `EINVAL`
- 不打印 warning

使用 `linux_raw_sys::prctl::{PR_SET_VMA, PR_SET_VMA_ANON_NAME}` 常量。

**不是完整 Linux `PR_SET_VMA` 语义**：不验证 addr/len/name 指针，不保存 VMA name。对 PicoClaw 等 Go runtime 调用者足够（Go 对返回值不做功能性依赖）。

## 测试

新增 `bug-prctl-set-vma-anon-name` C 回归测试：
- `PR_SET_VMA + PR_SET_VMA_ANON_NAME`：期望返回 0
- `PR_SET_VMA + 未知子操作`：期望返回 -1/EINVAL

测试已添加到 x86_64、aarch64、riscv64、loongarch64 四个架构的 bugfix TOML。

## 验证

- `cargo fmt --all -- --check` 通过
- CI x86_64 bugfix 通过（其他架构为仓库已有超时/flaky，非本 PR 引入）