### PR TITLE
feat(starry-kernel): implement waitid syscall

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -489,6 +489,12 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::exit => sys_exit(uctx.arg0() as _),
         Sysno::exit_group => sys_exit_group(uctx.arg0() as _),
         Sysno::wait4 => sys_waitpid(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
+        Sysno::waitid => sys_waitid(
+            uctx.arg0() as _,
+            uctx.arg1() as _,
+            uctx.arg2() as _,
+            uctx.arg3() as _,
+        ),
         Sysno::getsid => sys_getsid(uctx.arg0() as _),
         Sysno::setsid => sys_setsid(),
         Sysno::getpgid => sys_getpgid(uctx.arg0() as _),

--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -14,7 +14,9 @@ use starry_process::{Pid, Process};
 use starry_signal::SignalInfo;
 use starry_vm::{VmMutPtr, VmPtr};
 
-use crate::task::{AsThread, get_task, get_zombie_cred, remove_process, unregister_zombie};
+use crate::task::{
+    AsThread, decode_wait_status, get_task, get_zombie_cred, remove_process, unregister_zombie,
+};
 
 bitflags! {
     /// Options accepted by wait4 / waitpid.
@@ -138,24 +140,6 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
     })))?
 }
 
-/// Decode the Linux wait-status encoding into (si_code, si_status) for siginfo.
-///
-/// - Normal exit (`_exit`/`exit_group`): `(CLD_EXITED, exit_value)`
-/// - Killed by signal: `(CLD_KILLED, signum)` or `(CLD_DUMPED, signum)`
-fn decode_wait_status(raw: i32) -> (i32, i32) {
-    use linux_raw_sys::general::{CLD_DUMPED, CLD_EXITED, CLD_KILLED};
-    if raw & 0x7f == 0 {
-        (CLD_EXITED as i32, (raw >> 8) & 0xff)
-    } else {
-        let signum = raw & 0x7f;
-        if (raw & 0x80) != 0 {
-            (CLD_DUMPED as i32, signum)
-        } else {
-            (CLD_KILLED as i32, signum)
-        }
-    }
-}
-
 pub fn sys_waitid(
     idtype: u32,
     id: i32,
@@ -207,12 +191,13 @@ pub fn sys_waitid(
     let check_children = || {
         if let Some(child) = children.iter().find(|child| child.is_zombie()) {
             let child_pid = child.pid();
-            let raw_status = child.exit_code();
-            let (code, status) = decode_wait_status(raw_status);
+            let (code, status) = decode_wait_status(child.exit_code());
             let child_uid = get_zombie_cred(child_pid).map(|c| c.uid).unwrap_or(0);
 
-            let siginfo = SignalInfo::new_sigchld(child_pid, child_uid, code, status);
-            infop.vm_write(siginfo.0)?;
+            if let Some(infop) = infop.nullable() {
+                let siginfo = SignalInfo::new_sigchld(child_pid, child_uid, code, status);
+                infop.vm_write(siginfo.0)?;
+            }
 
             if !options.contains(WaitIdOptions::WNOWAIT) {
                 // Accumulate child's CPU time before freeing.
@@ -230,9 +215,12 @@ pub fn sys_waitid(
             // waitid(2): on success returns 0 (not the child PID).
             Ok(Some(0))
         } else if options.contains(WaitIdOptions::WNOHANG) {
-            // WNOHANG with no ready child: return 0, zero out siginfo.
-            let zeroed: linux_raw_sys::general::siginfo = unsafe { core::mem::zeroed() };
-            infop.vm_write(zeroed)?;
+            // WNOHANG with no ready child: return 0. Zero out siginfo if
+            // infop is non-NULL so callers don't read stale data.
+            if let Some(infop) = infop.nullable() {
+                let zeroed: linux_raw_sys::general::siginfo = unsafe { core::mem::zeroed() };
+                infop.vm_write(zeroed)?;
+            }
             Ok(Some(0))
         } else {
             Ok(None)

--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -7,35 +7,45 @@ use ax_task::{
     future::{block_on, interruptible},
 };
 use bitflags::bitflags;
-use linux_raw_sys::general::{__WALL, __WCLONE, __WNOTHREAD, WCONTINUED, WNOHANG, WUNTRACED};
+use linux_raw_sys::general::{
+    __WALL, __WCLONE, __WNOTHREAD, P_ALL, P_PID, WCONTINUED, WEXITED, WNOHANG, WNOWAIT, WUNTRACED,
+};
 use starry_process::{Pid, Process};
+use starry_signal::SignalInfo;
 use starry_vm::{VmMutPtr, VmPtr};
 
-use crate::task::{AsThread, get_task, remove_process, unregister_zombie};
+use crate::task::{AsThread, get_task, get_zombie_cred, remove_process, unregister_zombie};
 
 bitflags! {
+    /// Options accepted by wait4 / waitpid.
     #[derive(Debug)]
-    struct WaitOptions: u32 {
-        /// Do not block when there are no processes wishing to report status.
+    struct WaitPidOptions: u32 {
         const WNOHANG = WNOHANG;
-        /// Report the status of selected processes which are stopped due to a
-        /// `SIGTTIN`, `SIGTTOU`, `SIGTSTP`, or `SIGSTOP` signal.
         const WUNTRACED = WUNTRACED;
-        /// Report the status of selected processes that have continued from a
-        /// job control stop by receiving a `SIGCONT` signal.
         const WCONTINUED = WCONTINUED;
-
-        /// Don't wait on children of other threads in this group
         const WNOTHREAD = __WNOTHREAD;
-        /// Wait on all children, regardless of type
         const WALL = __WALL;
-        /// Wait for "clone" children only.
+        const WCLONE = __WCLONE;
+    }
+}
+
+bitflags! {
+    /// Options accepted by waitid.
+    #[derive(Debug)]
+    struct WaitIdOptions: u32 {
+        const WNOHANG = WNOHANG;
+        const WUNTRACED = WUNTRACED;
+        const WEXITED = WEXITED;
+        const WCONTINUED = WCONTINUED;
+        const WNOWAIT = WNOWAIT;
+        const WNOTHREAD = __WNOTHREAD;
+        const WALL = __WALL;
         const WCLONE = __WCLONE;
     }
 }
 
 #[derive(Debug, Clone, Copy)]
-enum WaitPid {
+enum WaitTarget {
     /// Wait for any child process
     Any,
     /// Wait for the child whose process ID is equal to the value.
@@ -44,31 +54,31 @@ enum WaitPid {
     Pgid(Pid),
 }
 
-impl WaitPid {
-    fn apply(&self, child: &Process) -> bool {
+impl WaitTarget {
+    fn matches(&self, child: &Process) -> bool {
         match self {
-            WaitPid::Any => true,
-            WaitPid::Pid(pid) => child.pid() == *pid,
-            WaitPid::Pgid(pgid) => child.group().pgid() == *pgid,
+            WaitTarget::Any => true,
+            WaitTarget::Pid(pid) => child.pid() == *pid,
+            WaitTarget::Pgid(pgid) => child.group().pgid() == *pgid,
         }
     }
 }
 
 pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isize> {
-    let options = WaitOptions::from_bits(options).ok_or(AxError::InvalidInput)?;
+    let options = WaitPidOptions::from_bits(options).ok_or(AxError::InvalidInput)?;
     info!("sys_waitpid <= pid: {pid:?}, options: {options:?}");
 
     let curr = current();
     let proc = &curr.as_thread().proc_data.proc;
 
-    let pid = if pid == -1 {
-        WaitPid::Any
+    let target = if pid == -1 {
+        WaitTarget::Any
     } else if pid == 0 {
-        WaitPid::Pgid(proc.group().pgid())
+        WaitTarget::Pgid(proc.group().pgid())
     } else if pid > 0 {
-        WaitPid::Pid(pid as _)
+        WaitTarget::Pid(pid as _)
     } else {
-        WaitPid::Pgid(-pid as _)
+        WaitTarget::Pgid(-pid as _)
     };
 
     // FIXME: add back support for WALL & WCLONE, since ProcessData may drop before
@@ -76,7 +86,7 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
     let children = proc
         .children()
         .into_iter()
-        .filter(|child| pid.apply(child))
+        .filter(|child| target.matches(child))
         .collect::<Vec<_>>();
     if children.is_empty() {
         return Err(AxError::from(LinuxError::ECHILD));
@@ -104,7 +114,7 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
             remove_process(child.pid());
             unregister_zombie(child.pid());
             Ok(Some(child.pid() as _))
-        } else if options.contains(WaitOptions::WNOHANG) {
+        } else if options.contains(WaitPidOptions::WNOHANG) {
             Ok(Some(0))
         } else {
             Ok(None)
@@ -119,6 +129,121 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
                 // A child may exit between the check above and waker
                 // registration. Recheck after registering so that wakeup is
                 // not lost in that race window.
+                match check_children().transpose() {
+                    Some(res) => Poll::Ready(res),
+                    None => Poll::Pending,
+                }
+            }
+        }
+    })))?
+}
+
+/// Decode the Linux wait-status encoding into (si_code, si_status) for siginfo.
+///
+/// - Normal exit (`_exit`/`exit_group`): `(CLD_EXITED, exit_value)`
+/// - Killed by signal: `(CLD_KILLED, signum)` or `(CLD_DUMPED, signum)`
+fn decode_wait_status(raw: i32) -> (i32, i32) {
+    use linux_raw_sys::general::{CLD_DUMPED, CLD_EXITED, CLD_KILLED};
+    if raw & 0x7f == 0 {
+        (CLD_EXITED as i32, (raw >> 8) & 0xff)
+    } else {
+        let signum = raw & 0x7f;
+        if (raw & 0x80) != 0 {
+            (CLD_DUMPED as i32, signum)
+        } else {
+            (CLD_KILLED as i32, signum)
+        }
+    }
+}
+
+pub fn sys_waitid(
+    idtype: u32,
+    id: i32,
+    infop: *mut linux_raw_sys::general::siginfo,
+    options: u32,
+) -> AxResult<isize> {
+    use linux_raw_sys::general::P_PGID;
+
+    // Validate idtype
+    let target = match idtype {
+        P_ALL => WaitTarget::Any,
+        P_PID => {
+            if id <= 0 {
+                return Err(AxError::InvalidInput);
+            }
+            WaitTarget::Pid(id as Pid)
+        }
+        P_PGID => {
+            // Not yet supported; P_PIDFD also unsupported.
+            return Err(AxError::InvalidInput);
+        }
+        _ => return Err(AxError::InvalidInput),
+    };
+
+    // Validate options — WEXITED must be present (we don't support WSTOPPED/WCONTINUED yet).
+    let options = WaitIdOptions::from_bits(options).ok_or(AxError::InvalidInput)?;
+    if !options.contains(WaitIdOptions::WEXITED) {
+        return Err(AxError::InvalidInput);
+    }
+    if options.contains(WaitIdOptions::WUNTRACED) || options.contains(WaitIdOptions::WCONTINUED) {
+        return Err(AxError::InvalidInput);
+    }
+
+    info!("sys_waitid <= idtype: {idtype}, id: {id}, options: {options:?}");
+
+    let curr = current();
+    let proc = &curr.as_thread().proc_data.proc;
+
+    let children: Vec<_> = proc
+        .children()
+        .into_iter()
+        .filter(|child| target.matches(child))
+        .collect();
+    if children.is_empty() {
+        return Err(AxError::from(LinuxError::ECHILD));
+    }
+
+    let proc_data = curr.as_thread().proc_data.clone();
+    let check_children = || {
+        if let Some(child) = children.iter().find(|child| child.is_zombie()) {
+            let child_pid = child.pid();
+            let raw_status = child.exit_code();
+            let (code, status) = decode_wait_status(raw_status);
+            let child_uid = get_zombie_cred(child_pid).map(|c| c.uid).unwrap_or(0);
+
+            let siginfo = SignalInfo::new_sigchld(child_pid, child_uid, code, status);
+            infop.vm_write(siginfo.0)?;
+
+            if !options.contains(WaitIdOptions::WNOWAIT) {
+                // Accumulate child's CPU time before freeing.
+                for tid in child.threads() {
+                    if let Ok(task) = get_task(tid) {
+                        let thr = task.as_thread();
+                        let (utime, stime) = thr.time.borrow().output();
+                        proc_data.add_child_cpu_time(utime, stime);
+                    }
+                }
+                child.free();
+                remove_process(child_pid);
+                unregister_zombie(child_pid);
+            }
+            // waitid(2): on success returns 0 (not the child PID).
+            Ok(Some(0))
+        } else if options.contains(WaitIdOptions::WNOHANG) {
+            // WNOHANG with no ready child: return 0, zero out siginfo.
+            let zeroed: linux_raw_sys::general::siginfo = unsafe { core::mem::zeroed() };
+            infop.vm_write(zeroed)?;
+            Ok(Some(0))
+        } else {
+            Ok(None)
+        }
+    };
+
+    block_on(interruptible(poll_fn(|cx| {
+        match check_children().transpose() {
+            Some(res) => Poll::Ready(res),
+            None => {
+                proc_data.child_exit_event.register(cx.waker());
                 match check_children().transpose() {
                     Some(res) => Poll::Ready(res),
                     None => Poll::Pending,

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -25,6 +25,24 @@ const FUTEX_OWNER_DIED: u32 = 0x40000000;
 const FUTEX_TID_MASK: u32 = 0x3fffffff;
 const FUTEX_WAITERS: u32 = 0x80000000;
 
+/// Decode the Linux wait-status encoding into (si_code, si_status).
+///
+/// - Normal exit (`_exit`/`exit_group`): `(CLD_EXITED, exit_value)`
+/// - Killed by signal: `(CLD_KILLED, signum)` or `(CLD_DUMPED, signum)`
+pub fn decode_wait_status(raw: i32) -> (i32, i32) {
+    use linux_raw_sys::general::{CLD_DUMPED, CLD_EXITED, CLD_KILLED};
+    if raw & 0x7f == 0 {
+        (CLD_EXITED as i32, (raw >> 8) & 0xff)
+    } else {
+        let signum = raw & 0x7f;
+        if (raw & 0x80) != 0 {
+            (CLD_DUMPED as i32, signum)
+        } else {
+            (CLD_KILLED as i32, signum)
+        }
+    }
+}
+
 static TASK_TABLE: RwLock<WeakMap<Pid, WeakAxTaskRef>> = RwLock::new(WeakMap::new());
 
 static PROCESS_TABLE: RwLock<WeakMap<Pid, Weak<ProcessData>>> = RwLock::new(WeakMap::new());
@@ -486,32 +504,10 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
         process.exit();
         if let Some(parent) = process.parent() {
             if let Some(signo) = thr.proc_data.exit_signal {
-                use linux_raw_sys::general::{CLD_DUMPED, CLD_EXITED, CLD_KILLED};
                 use starry_signal::Signo;
 
                 let child_uid = thr.cred().uid;
-                // Decode si_code/si_status from the Linux wait-status encoding
-                // stored in exit_code, NOT from the `group_exit` flag.
-                //
-                // `group_exit` is true for both sys_exit_group() (normal exit)
-                // and signal-induced group termination, so it cannot distinguish
-                // the two cases.  The wait-status bits are the correct source:
-                //   bits 6:0 == 0  -> normal exit  (exit_code >> 8 is the value)
-                //   bits 6:0 != 0  -> killed by signal (bits 6:0 = signum,
-                //                     bit 7 = core dumped)
-                let raw = process.exit_code();
-                let (code, status) = if raw & 0x7f == 0 {
-                    // Normal exit via _exit() / exit_group().
-                    (CLD_EXITED as i32, (raw >> 8) & 0xff)
-                } else {
-                    let signum = raw & 0x7f;
-                    let core_dumped = (raw & 0x80) != 0;
-                    if core_dumped {
-                        (CLD_DUMPED as i32, signum)
-                    } else {
-                        (CLD_KILLED as i32, signum)
-                    }
-                };
+                let (code, status) = decode_wait_status(process.exit_code());
 
                 let sig = if signo == Signo::SIGCHLD {
                     SignalInfo::new_sigchld(process.pid(), child_uid, code, status)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-waitid-basic/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-waitid-basic/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-waitid-basic C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-waitid-basic src/main.c)
+target_compile_options(bug-waitid-basic PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-waitid-basic RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-waitid-basic/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-waitid-basic/c/src/main.c
@@ -276,6 +276,40 @@ static void test_einval_no_wexited(void)
     waitpid(pid, NULL, 0);
 }
 
+/* 8. infop == NULL: waitid should succeed and still reap the child */
+static void test_null_infop(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail("NULL infop", "fork failed");
+        return;
+    }
+    if (pid == 0)
+        _exit(13);
+
+    errno = 0;
+    int ret = waitid_raw(P_PID, pid, NULL, WEXITED);
+    if (ret != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "ret=%d errno=%d (%s)", ret, errno, strerror(errno));
+        note_fail("NULL infop ret", buf);
+        return;
+    }
+
+    /* Verify reaped: waitpid should fail with ECHILD */
+    int status;
+    errno = 0;
+    pid_t wret = waitpid(pid, &status, WNOHANG);
+    if (wret == -1 && errno == ECHILD) {
+        note_pass("NULL infop reaps child");
+    } else {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "waitpid ret=%ld errno=%d, expected -1/ECHILD",
+                 (long)wret, errno);
+        note_fail("NULL infop reap", buf);
+    }
+}
+
 int main(void)
 {
     printf("=== bug-waitid-basic ===\n");
@@ -287,6 +321,7 @@ int main(void)
     test_echild();
     test_einval_idtype();
     test_einval_no_wexited();
+    test_null_infop();
 
     printf("=== Results: %d passed, %d failed ===\n", passed, failed);
     if (failed == 0) {

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-waitid-basic/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-waitid-basic/c/src/main.c
@@ -1,0 +1,298 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef P_ALL
+#define P_ALL 0
+#endif
+#ifndef P_PID
+#define P_PID 1
+#endif
+#ifndef P_PGID
+#define P_PGID 2
+#endif
+#ifndef WEXITED
+#define WEXITED 0x00000004
+#endif
+#ifndef WNOWAIT
+#define WNOWAIT 0x01000000
+#endif
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static int waitid_raw(int idtype, pid_t id, siginfo_t *si, int options)
+{
+    return (int)syscall(SYS_waitid, idtype, id, si, options, NULL);
+}
+
+/* 1. P_PID + WEXITED: fork child that _exit(7), waitid and check siginfo */
+static void test_ppid_wexited(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail("P_PID WEXITED", "fork failed");
+        return;
+    }
+    if (pid == 0)
+        _exit(7);
+
+    siginfo_t si;
+    memset(&si, 0xa5, sizeof(si));
+    errno = 0;
+    int ret = waitid_raw(P_PID, pid, &si, WEXITED);
+    if (ret != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "ret=%d errno=%d (%s)", ret, errno, strerror(errno));
+        note_fail("P_PID WEXITED", buf);
+        return;
+    }
+    if (si.si_signo != SIGCHLD || si.si_code != CLD_EXITED || si.si_pid != pid ||
+        si.si_status != 7) {
+        char buf[256];
+        snprintf(buf, sizeof(buf),
+                 "signo=%d code=%d pid=%d status=%d, expected SIGCHLD/CLD_EXITED/%d/7",
+                 si.si_signo, si.si_code, si.si_pid, si.si_status, pid);
+        note_fail("P_PID WEXITED siginfo", buf);
+        return;
+    }
+
+    /* Verify reaped: waitpid should fail with ECHILD */
+    int status;
+    errno = 0;
+    pid_t wret = waitpid(pid, &status, WNOHANG);
+    if (wret == -1 && errno == ECHILD) {
+        note_pass("P_PID WEXITED reaps child");
+    } else {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "waitpid ret=%ld errno=%d, expected -1/ECHILD",
+                 (long)wret, errno);
+        note_fail("P_PID WEXITED reap", buf);
+    }
+}
+
+/* 2. P_ALL + WEXITED */
+static void test_pall_wexited(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail("P_ALL WEXITED", "fork failed");
+        return;
+    }
+    if (pid == 0)
+        _exit(3);
+
+    siginfo_t si;
+    memset(&si, 0, sizeof(si));
+    errno = 0;
+    int ret = waitid_raw(P_ALL, 0, &si, WEXITED);
+    if (ret != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "ret=%d errno=%d (%s)", ret, errno, strerror(errno));
+        note_fail("P_ALL WEXITED", buf);
+        return;
+    }
+    if (si.si_signo != SIGCHLD || si.si_code != CLD_EXITED || si.si_pid != pid ||
+        si.si_status != 3) {
+        char buf[256];
+        snprintf(buf, sizeof(buf),
+                 "signo=%d code=%d pid=%d status=%d, expected SIGCHLD/CLD_EXITED/%d/3",
+                 si.si_signo, si.si_code, si.si_pid, si.si_status, pid);
+        note_fail("P_ALL WEXITED siginfo", buf);
+        return;
+    }
+    note_pass("P_ALL WEXITED");
+}
+
+/* 3. WNOHANG: child still running -> return 0, si_pid==0 */
+static void test_wnohang(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail("WNOHANG", "fork failed");
+        return;
+    }
+    if (pid == 0) {
+        usleep(200000);
+        _exit(0);
+    }
+
+    siginfo_t si;
+    memset(&si, 0xff, sizeof(si));
+    errno = 0;
+    int ret = waitid_raw(P_PID, pid, &si, WEXITED | WNOHANG);
+    int saved_errno = errno;
+    if (ret != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "ret=%d errno=%d (%s)", ret, saved_errno, strerror(saved_errno));
+        note_fail("WNOHANG ret", buf);
+        /* reap child */
+        waitpid(pid, NULL, 0);
+        return;
+    }
+    if (si.si_pid != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "si_pid=%d, expected 0", si.si_pid);
+        note_fail("WNOHANG si_pid", buf);
+    } else {
+        note_pass("WNOHANG returns 0 with si_pid==0");
+    }
+
+    /* Reap the child */
+    waitpid(pid, NULL, 0);
+}
+
+/* 4. WNOWAIT: query siginfo without reaping, then reap with waitpid */
+static void test_wnowait(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail("WNOWAIT", "fork failed");
+        return;
+    }
+    if (pid == 0)
+        _exit(42);
+
+    /* Wait for child to exit */
+    usleep(50000);
+
+    /* First call: WNOWAIT — should get siginfo but NOT reap */
+    siginfo_t si;
+    memset(&si, 0, sizeof(si));
+    errno = 0;
+    int ret = waitid_raw(P_PID, pid, &si, WEXITED | WNOWAIT);
+    if (ret != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "WNOWAIT ret=%d errno=%d (%s)", ret, errno, strerror(errno));
+        note_fail("WNOWAIT waitid", buf);
+        waitpid(pid, NULL, 0);
+        return;
+    }
+    if (si.si_signo != SIGCHLD || si.si_code != CLD_EXITED || si.si_pid != pid ||
+        si.si_status != 42) {
+        char buf[256];
+        snprintf(buf, sizeof(buf),
+                 "signo=%d code=%d pid=%d status=%d, expected SIGCHLD/CLD_EXITED/%d/42",
+                 si.si_signo, si.si_code, si.si_pid, si.si_status, pid);
+        note_fail("WNOWAIT siginfo", buf);
+        waitpid(pid, NULL, 0);
+        return;
+    }
+
+    /* Child should still be reapable via waitpid */
+    int status = 0;
+    errno = 0;
+    pid_t wret = waitpid(pid, &status, 0);
+    if (wret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 42) {
+        note_pass("WNOWAIT does not reap, waitpid succeeds after");
+    } else {
+        char buf[256];
+        snprintf(buf, sizeof(buf),
+                 "waitpid ret=%ld errno=%d status=0x%x, expected pid=%d exit=42",
+                 (long)wret, errno, status, pid);
+        note_fail("WNOWAIT reap", buf);
+    }
+}
+
+/* 5. Error: ECHILD for non-child pid */
+static void test_echild(void)
+{
+    siginfo_t si;
+    memset(&si, 0, sizeof(si));
+    errno = 0;
+    /* pid 1 is init, not our child */
+    int ret = waitid_raw(P_PID, 1, &si, WEXITED);
+    if (ret == -1 && errno == ECHILD) {
+        note_pass("P_PID non-child returns ECHILD");
+    } else {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "ret=%d errno=%d (%s), expected -1/ECHILD",
+                 ret, errno, strerror(errno));
+        note_fail("P_PID non-child ECHILD", buf);
+    }
+}
+
+/* 6. Error: EINVAL for bad idtype */
+static void test_einval_idtype(void)
+{
+    siginfo_t si;
+    memset(&si, 0, sizeof(si));
+    errno = 0;
+    int ret = waitid_raw(99, 0, &si, WEXITED);
+    if (ret == -1 && errno == EINVAL) {
+        note_pass("bad idtype returns EINVAL");
+    } else {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "ret=%d errno=%d (%s), expected -1/EINVAL",
+                 ret, errno, strerror(errno));
+        note_fail("bad idtype EINVAL", buf);
+    }
+}
+
+/* 7. Error: EINVAL for missing WEXITED */
+static void test_einval_no_wexited(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail("no WEXITED", "fork failed");
+        return;
+    }
+    if (pid == 0)
+        _exit(0);
+
+    siginfo_t si;
+    memset(&si, 0, sizeof(si));
+    errno = 0;
+    int ret = waitid_raw(P_PID, pid, &si, WNOHANG);
+    int saved_errno = errno;
+    if (ret == -1 && saved_errno == EINVAL) {
+        note_pass("missing WEXITED returns EINVAL");
+    } else {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "ret=%d errno=%d (%s), expected -1/EINVAL",
+                 ret, saved_errno, strerror(saved_errno));
+        note_fail("missing WEXITED EINVAL", buf);
+    }
+
+    /* Reap child */
+    waitpid(pid, NULL, 0);
+}
+
+int main(void)
+{
+    printf("=== bug-waitid-basic ===\n");
+
+    test_ppid_wexited();
+    test_pall_wexited();
+    test_wnohang();
+    test_wnowait();
+    test_echild();
+    test_einval_idtype();
+    test_einval_no_wexited();
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+    printf("SOME TESTS FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -89,6 +89,7 @@ test_commands = [
     "/usr/bin/bug-open-unix-socket-no-enxio",
     "/usr/bin/bug-open-fifo-wronly-no-reader-no-enxio",
     "/usr/bin/bug-prctl-set-vma-anon-name",
+    "/usr/bin/bug-waitid-basic",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -90,6 +90,7 @@ test_commands = [
     "/usr/bin/bug-open-unix-socket-no-enxio",
     "/usr/bin/bug-open-fifo-wronly-no-reader-no-enxio",
     "/usr/bin/bug-prctl-set-vma-anon-name",
+    "/usr/bin/bug-waitid-basic",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -97,6 +97,7 @@ test_commands = [
     "/usr/bin/bug-open-unix-socket-no-enxio",
     "/usr/bin/bug-open-fifo-wronly-no-reader-no-enxio",
     "/usr/bin/bug-prctl-set-vma-anon-name",
+    "/usr/bin/bug-waitid-basic",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -95,6 +95,7 @@ test_commands = [
     "/usr/bin/bug-open-unix-socket-no-enxio",
     "/usr/bin/bug-open-fifo-wronly-no-reader-no-enxio",
     "/usr/bin/bug-prctl-set-vma-anon-name",
+    "/usr/bin/bug-waitid-basic",
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']


### PR DESCRIPTION
## 背景

PicoClaw gateway/tool 执行路径调用 `waitid()` 系统调用，StarryOS 打印 `Unimplemented syscall: waitid` 并返回 ENOSYS。这影响子进程清理和工具执行路径。

## 实现内容

新增 `sys_waitid()` 系统调用，基于已有的 `sys_waitpid` 框架：

### 支持的语义
- **idtype**: `P_ALL`（等待任意子进程）、`P_PID`（等待指定 PID）
- **options**: `WEXITED`、`WNOHANG`、`WNOWAIT`
- 写入 `siginfo_t`：`si_signo=SIGCHLD`，`si_code=CLD_EXITED`/`CLD_KILLED`/`CLD_DUMPED`，`si_pid`，`si_uid`，`si_status`
- `WNOHANG` 无就绪子进程时返回 0，siginfo 清零
- 无匹配子进程返回 `ECHILD`
- 默认行为 reap zombie 子进程；`WNOWAIT` 只查询不回收

### 暂不支持
- `P_PGID`、`P_PIDFD`：返回 EINVAL
- `WSTOPPED`、`WCONTINUED`：返回 EINVAL
- resource usage (rusage)

### 实现细节
- 复用 `WaitPid` 枚举和 `WaitOptions` bitflags（新增 `WEXITED`、`WNOWAIT`）
- `decode_wait_status()` 将 Linux wait-status 编码解码为 CLD_* codes
- 通过 `get_zombie_cred()` 获取子进程 UID（zombie 的 task 可能已被 GC）
- 异步等待逻辑与 `sys_waitpid` 一致（`child_exit_event` + waker recheck）

## 测试

新增 `bug-waitid-basic` C 回归测试，覆盖：
1. `P_PID + WEXITED`：fork child exit(7)，验证 siginfo 字段 + reap
2. `P_ALL + WEXITED`：fork child exit(3)，验证 siginfo
3. `WNOHANG`：child 仍在运行时返回 0，si_pid==0
4. `ECHILD`：对非子进程 PID 调用
5. `EINVAL`：非法 idtype
6. `EINVAL`：缺少 WEXITED

测试已添加到 x86_64、aarch64、riscv64、loongarch64 四个架构的 bugfix TOML。

## 验证

- `cargo fmt --all -- --check` 通过
- 完整 QEMU 回归测试需在 CI 中执行