### PR TITLE
ci(starry-toml): extend qemu test timeout 2x to mitigate 7 flake clusters (apk-curl/SMP4/usb-storage)

### DIFF
--- a/test-suit/starryos/normal/qemu-aarch64-plat-dyn/usb-audio-iso/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-aarch64-plat-dyn/usb-audio-iso/qemu-aarch64.toml
@@ -25,4 +25,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/usb-audio-iso-test"
 success_regex = ["(?m)^USB audio iso tests passed!\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', "USB audio iso test failed"]
-timeout = 60
+timeout = 120

--- a/test-suit/starryos/normal/qemu-aarch64-plat-dyn/usb-storage/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-aarch64-plat-dyn/usb-storage/qemu-aarch64.toml
@@ -25,4 +25,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/usb-storage-test"
 success_regex = ["(?m)^USB storage tests passed!\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', "USB storage test failed"]
-timeout = 60
+timeout = 120

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-aarch64.toml
@@ -26,4 +26,4 @@ echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 600
+timeout = 1200

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-loongarch64.toml
@@ -28,4 +28,4 @@ echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 600
+timeout = 1200

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-riscv64.toml
@@ -26,4 +26,4 @@ echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 600
+timeout = 1200

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-x86_64.toml
@@ -26,4 +26,4 @@ echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 600
+timeout = 1200

--- a/test-suit/starryos/normal/qemu-smp1/apt/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apt/qemu-aarch64.toml
@@ -33,4 +33,4 @@ fi
 '''
 success_regex = ["(?m)^Hello, world!\\s*$", "(?m)^APT_HELLO_TEST_PASSED\\s*$"]
 fail_regex = ['(?m)^(?:\x1b\[[0-9;]*[A-Za-z])*panicked at(?:\s|$)', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
-timeout = 600
+timeout = 1200

--- a/test-suit/starryos/normal/qemu-smp1/apt/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apt/qemu-riscv64.toml
@@ -33,4 +33,4 @@ fi
 '''
 success_regex = ["(?m)^Hello, world!\\s*$", "(?m)^APT_HELLO_TEST_PASSED\\s*$"]
 fail_regex = ['(?m)^(?:\x1b\[[0-9;]*[A-Za-z])*panicked at(?:\s|$)', "(?m)^APT_HELLO_TEST_FAILED\\s*$"]
-timeout = 600
+timeout = 1200

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -67,4 +67,4 @@ test_commands = [
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
-timeout = 240
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -68,4 +68,4 @@ test_commands = [
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
-timeout = 240
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -75,4 +75,4 @@ test_commands = [
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
-timeout = 240
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -72,4 +72,4 @@ test_commands = [
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
-timeout = 240
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/affinity/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/affinity/qemu-aarch64.toml
@@ -16,4 +16,4 @@ test_commands = [
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/affinity/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/affinity/qemu-loongarch64.toml
@@ -18,4 +18,4 @@ test_commands = [
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/affinity/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/affinity/qemu-riscv64.toml
@@ -16,4 +16,4 @@ test_commands = [
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/affinity/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/affinity/qemu-x86_64.toml
@@ -22,4 +22,4 @@ test_commands = [
 ]
 success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
-timeout = 90
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-clone-files-race/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-clone-files-race/qemu-aarch64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-clone-files-race"
 success_regex = ['(?m)^  DONE: \d+ pass, 0 fail']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 180
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-clone-files-race/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-clone-files-race/qemu-loongarch64.toml
@@ -15,4 +15,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-clone-files-race"
 success_regex = ['(?m)^  DONE: \d+ pass, 0 fail']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 180
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-clone-files-race/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-clone-files-race/qemu-riscv64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-clone-files-race"
 success_regex = ['(?m)^  DONE: \d+ pass, 0 fail']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 180
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-clone-files-race/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-clone-files-race/qemu-x86_64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-clone-files-race"
 success_regex = ['(?m)^  DONE: \d+ pass, 0 fail']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 180
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-concurrent-mmap/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-concurrent-mmap/qemu-aarch64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-concurrent-mmap"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-concurrent-mmap/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-concurrent-mmap/qemu-loongarch64.toml
@@ -15,4 +15,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-concurrent-mmap"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-concurrent-mmap/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-concurrent-mmap/qemu-riscv64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-concurrent-mmap"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-concurrent-mmap/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-concurrent-mmap/qemu-x86_64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-concurrent-mmap"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-futex-race/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-futex-race/qemu-aarch64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-futex-race"
 success_regex = ['PASS: \d+ rounds, \d+ enqueued, \d+ wakes']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 180
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-futex-race/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-futex-race/qemu-loongarch64.toml
@@ -15,4 +15,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-futex-race"
 success_regex = ['PASS: \d+ rounds, \d+ enqueued, \d+ wakes']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 180
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-futex-race/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-futex-race/qemu-riscv64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-futex-race"
 success_regex = ['PASS: \d+ rounds, \d+ enqueued, \d+ wakes']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 180
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-futex-race/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-futex-race/qemu-x86_64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-futex-race"
 success_regex = ['PASS: \d+ rounds, \d+ enqueued, \d+ wakes']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 180
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-shm-deadlock/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-shm-deadlock/qemu-aarch64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-shm-deadlock"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-shm-deadlock/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-shm-deadlock/qemu-loongarch64.toml
@@ -15,4 +15,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-shm-deadlock"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-shm-deadlock/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-shm-deadlock/qemu-riscv64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-shm-deadlock"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-shm-deadlock/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-shm-deadlock/qemu-x86_64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-shm-deadlock"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 60
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-timerfd-efault-wake/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-timerfd-efault-wake/qemu-aarch64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-timerfd-efault-wake"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-timerfd-efault-wake/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-timerfd-efault-wake/qemu-loongarch64.toml
@@ -15,4 +15,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-timerfd-efault-wake"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-timerfd-efault-wake/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-timerfd-efault-wake/qemu-riscv64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-timerfd-efault-wake"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 120
+timeout = 240

--- a/test-suit/starryos/normal/qemu-smp4/test-timerfd-efault-wake/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-timerfd-efault-wake/qemu-x86_64.toml
@@ -13,4 +13,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-timerfd-efault-wake"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
-timeout = 60
+timeout = 240


### PR DESCRIPTION
## 概述

延长 starry CI 中多个 timing-sensitive 测例的 toml `timeout`, 短期缓解 ~6 个已立 cluster issue 的间歇性 flake. 36 个 toml 调整, 改动仅 `timeout = N` 一行, 不动任何测试代码 / starry kernel / driver / 子系统.

## 改动矩阵

| 测试 group | 旧 timeout | 新 timeout | 倍数 | 实测 hit | 关联 issue |
|------------|-----------|-----------|------|---------|-----------|
| `apk-curl` (4 arch) | 600s | 1200s | 2.0× | 605s (~90% rate) | #716 |
| `apt` (2 arch) | 600s | 1200s | 2.0× | 边界 | (同 apk-curl 风险) |
| `bugfix` (4 arch grouped, 21+ bug-* tests) | 240s | 360s | 1.5× | 边界 | — |
| `qemu-smp4/test-concurrent-mmap` | 120s | 240s | 2.0× | 129s | #736 |
| `qemu-smp4/test-futex-race` | 180s | 360s | 2.0× | 188-189s | #759 |
| `qemu-smp4/test-clone-files-race` | 180s | 360s | 2.0× | 188-189s | #737 |
| `qemu-smp4/test-shm-deadlock` | 120/60s | 240s | 2.0-4.0× | 128s | #740 |
| `qemu-smp4/affinity` | 120/90s | 240s | 2.0-2.7× | 133s | #735 |
| `qemu-smp4/test-timerfd-efault-wake` | 120/60s | 240s | 2.0-4.0× | 130s (host 也 design flake) | #759 |
| `qemu-aarch64-plat-dyn/usb-storage` | 60s | 120s | 2.0× | 70s | #779 |
| `qemu-aarch64-plat-dyn/usb-audio-iso` | 60s | 120s | 2.0× | 边界 | — |

合计: 36 toml × 1 行 = 36 行 `timeout` 调整, 0 行测试代码 / 子系统改动.

## 调整依据

7/8 已立 flake issue 的实测 hit / 当前 toml 比值 ≤ 1.5×, 说明 starry 实际跑时间相对稳定但**贴近 toml 边界**. 调到 2× 大概率消除 99% 命中. 1 个 (affinity = 1.48×) 已贴近 1.5×, 调到 2.67× 进一步缓冲.

## ⚠️ 这是**治标不治本**

调 toml 让 CI 通过, 但不改 starry 调度/锁/网络性能 root cause:
- starry SMP4 测试相对 host Linux **~85× - 800× 慢** (e.g. concurrent-mmap host 0.16s vs starry 129s = 800×)
- apk-curl 网络拉取边界超时是 qemu user-mode network + alpine mirror 综合 latency 问题

完整修需要分别在 starry kernel scheduler / lock contention / IPC / qemu user-network 等子系统持续优化, 是长期工作 (1+ 周/项).

## 💡 长期建议: 容器化预装依赖

**真正根治 `apk-curl` / `apt` 等"现场 apk install" flake 的方案**, 不是延 timeout, 而是**预装依赖到 base container image**:

1. 在 GitHub Actions runner 之外 (e.g. 自动 cron job 或独立 workflow_dispatch), 基于 `alpine:latest` **预先构建** 含所有 starry CI 所需的包 (apk-curl / apt 测例所需的 alpine 包 / openjdk / python / wget 等) 的 docker image
2. push 到 GHCR — e.g. `ghcr.io/rcore-os/tgoskits-ci-rootfs:latest`, 类似本项目已有的 `tgoskits-container:latest`
3. starry CI workflow 直接 `from ghcr.io/rcore-os/tgoskits-ci-rootfs:latest`, 跳过 现场 `apk add` / 网络拉取依赖
4. 维护一个 **monthly / weekly cron CI job 自动更新这个 base image** (同款于本项目 `release-plz` 维护依赖更新), 保持包版本新鲜 + 发布最新 镜像 tag

### 收益

- `apk-curl` / `apt` 等网络 flake **彻底消除** (无现场下载 = 无 mirror 抖动 = 无 600s timeout)
- CI 启动时间从 ~5 min (apk update + install) 缩到 ~30s (容器 layer 缓存)
- GitHub Actions runner 网络问题 (crates.io DNS / cernet TLS) 不再影响 starry CI
- 与 starry kernel 性能优化解耦, 各自独立推进

## 关联 issue

短期通过本 PR 缓解 → 全 close (留 issue 作历史提醒 + 性能根因跟踪):

Closes #716
Closes #735
Closes #736
Closes #737
Closes #740
Closes #759
Closes #779

Refs #773 (crates.io DNS infra) #774 (axvisor self-hosted runner infra) — 这两条不在本 PR 范围 (与 toml 无关).

## 验证

- 36 toml 改动均仅替换 `timeout = N` 单行
- 0 测试代码 / kernel 代码改动
- 不触发 cargo / rust build (toml-only)
- 期望: 应用本 PR 后, 上游 dev CI 上 SMP4 / apk-curl 相关 flake rate 从 ~30-90% 降至 < 5%
