### PR TITLE
fix(ax-fs-ng): complete direct device transfers

### DIFF
--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -922,11 +922,29 @@ impl FileBackend {
     pub fn read_at(&self, mut dst: impl Write + IoBufMut, mut offset: u64) -> VfsResult<usize> {
         match self {
             Self::Cached(cached) => cached.read_at(dst, offset),
-            Self::Direct(loc) => dst.read_from(&mut ax_io::read_fn(|buf| {
-                loc.entry().as_file()?.read_at(buf, offset).inspect(|read| {
-                    offset += *read as u64;
-                })
-            })),
+            Self::Direct(loc) => {
+                let mut total = 0;
+                while dst.remaining_mut() > 0 {
+                    let chunk = dst.remaining_mut().min(ax_io::DEFAULT_BUF_SIZE);
+                    let read = match dst.read_from(&mut ax_io::read_fn(|buf| {
+                        loc.entry().as_file()?.read_at(buf, offset).inspect(|read| {
+                            offset += *read as u64;
+                        })
+                    })) {
+                        Ok(read) => read,
+                        Err(VfsError::WouldBlock) if total > 0 => break,
+                        Err(err) => return Err(err),
+                    };
+                    if read == 0 {
+                        break;
+                    }
+                    total += read;
+                    if read < chunk {
+                        break;
+                    }
+                }
+                Ok(total)
+            }
         }
     }
 
@@ -934,14 +952,32 @@ impl FileBackend {
     pub fn write_at(&self, mut src: impl Read + IoBuf, mut offset: u64) -> VfsResult<usize> {
         match self {
             Self::Cached(cached) => cached.write_at(src, offset),
-            Self::Direct(loc) => src.write_to(&mut ax_io::write_fn(|buf| {
-                loc.entry()
-                    .as_file()?
-                    .write_at(buf, offset)
-                    .inspect(|written| {
-                        offset += *written as u64;
-                    })
-            })),
+            Self::Direct(loc) => {
+                let mut total = 0;
+                while src.remaining() > 0 {
+                    let chunk = src.remaining().min(ax_io::DEFAULT_BUF_SIZE);
+                    let written = match src.write_to(&mut ax_io::write_fn(|buf| {
+                        loc.entry()
+                            .as_file()?
+                            .write_at(buf, offset)
+                            .inspect(|written| {
+                                offset += *written as u64;
+                            })
+                    })) {
+                        Ok(written) => written,
+                        Err(VfsError::WouldBlock) if total > 0 => break,
+                        Err(err) => return Err(err),
+                    };
+                    if written == 0 {
+                        break;
+                    }
+                    total += written;
+                    if written < chunk {
+                        break;
+                    }
+                }
+                Ok(total)
+            }
         }
     }
 
@@ -950,14 +986,29 @@ impl FileBackend {
         match self {
             Self::Cached(cached) => cached.append(src),
             Self::Direct(loc) => {
-                let mut end = 0;
-                src.write_to(&mut ax_io::write_fn(|buf| {
-                    loc.entry().as_file()?.append(buf).map(|(n, offset)| {
-                        end = offset;
-                        n
-                    })
-                }))
-                .map(|n| (n, end))
+                let mut total = 0;
+                let mut end = loc.entry().as_file()?.len()?;
+                while src.remaining() > 0 {
+                    let chunk = src.remaining().min(ax_io::DEFAULT_BUF_SIZE);
+                    let written = match src.write_to(&mut ax_io::write_fn(|buf| {
+                        loc.entry().as_file()?.append(buf).map(|(n, offset)| {
+                            end = offset;
+                            n
+                        })
+                    })) {
+                        Ok(written) => written,
+                        Err(VfsError::WouldBlock) if total > 0 => break,
+                        Err(err) => return Err(err),
+                    };
+                    if written == 0 {
+                        break;
+                    }
+                    total += written;
+                    if written < chunk {
+                        break;
+                    }
+                }
+                Ok((total, end))
             }
         }
     }

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -35,6 +35,7 @@ test_commands = [
     "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
+    "/usr/bin/test-dev-zero-full-transfer",
     "/usr/bin/clone3-badsize",
     "/usr/bin/bug-unaligned-cow-split",
     "/usr/bin/bug-proc-maps-lseek-refresh",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -36,6 +36,7 @@ test_commands = [
     "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
+    "/usr/bin/test-dev-zero-full-transfer",
     "/usr/bin/clone3-badsize",
     "/usr/bin/bug-unaligned-cow-split",
     "/usr/bin/bug-proc-maps-lseek-refresh",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -41,6 +41,7 @@ test_commands = [
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-wait4-invalid-options",
     "/usr/bin/bug-writev-dir-ebadf",
+    "/usr/bin/test-dev-zero-full-transfer",
     "/usr/bin/clone3-badsize",
     "/usr/bin/bug-unaligned-cow-split",
     "/usr/bin/bug-proc-maps-lseek-refresh",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -40,6 +40,7 @@ test_commands = [
     "/usr/bin/bug-tty-sigint",
     "/usr/bin/bug-unlinkat-einval",
     "/usr/bin/bug-writev-dir-ebadf",
+    "/usr/bin/test-dev-zero-full-transfer",
     "/usr/bin/bug-zombie-process-queries",
     "/usr/bin/clone3-badsize",
     "/usr/bin/bug-unaligned-cow-split",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/test-dev-zero-full-transfer/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/test-dev-zero-full-transfer/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(test_dev_zero_full_transfer C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-dev-zero-full-transfer src/main.c)
+target_compile_options(test-dev-zero-full-transfer PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-dev-zero-full-transfer RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/test-dev-zero-full-transfer/c/prebuild.sh
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/test-dev-zero-full-transfer/c/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+apk add binutils gcc musl-dev

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/test-dev-zero-full-transfer/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/test-dev-zero-full-transfer/c/src/main.c
@@ -1,0 +1,51 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+enum {
+    BUF_SIZE = 65536,
+};
+
+static unsigned char buffer[BUF_SIZE];
+
+int main(void)
+{
+    int zero_fd = open("/dev/zero", O_RDONLY);
+    if (zero_fd < 0) {
+        printf("TEST FAILED: open /dev/zero: %s\n", strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    ssize_t nread = read(zero_fd, buffer, sizeof(buffer));
+    close(zero_fd);
+    if (nread != (ssize_t)sizeof(buffer)) {
+        printf("TEST FAILED: /dev/zero short read got %zd expected %zu\n", nread, sizeof(buffer));
+        return EXIT_FAILURE;
+    }
+
+    for (size_t i = 0; i < sizeof(buffer); i++) {
+        if (buffer[i] != 0) {
+            printf("TEST FAILED: /dev/zero byte %zu is %u\n", i, buffer[i]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    int null_fd = open("/dev/null", O_WRONLY);
+    if (null_fd < 0) {
+        printf("TEST FAILED: open /dev/null: %s\n", strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    ssize_t nwritten = write(null_fd, buffer, sizeof(buffer));
+    close(null_fd);
+    if (nwritten != (ssize_t)sizeof(buffer)) {
+        printf("TEST FAILED: /dev/null short write got %zd expected %zu\n", nwritten, sizeof(buffer));
+        return EXIT_FAILURE;
+    }
+
+    puts("TEST PASSED");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

修复 `ax-fs-ng` direct backend 对 `/dev/zero`、`/dev/null` 这类非缓存设备文件的大块 I/O 短传输问题。

- direct `read_at` 不再只执行一次内部 2048-byte buffer transfer，而是在目标 buffer 尚有空间且设备持续返回完整 chunk 时继续读取。
- direct `write_at` 同样循环写入，避免大块 `/dev/null` write 只报告 2048 bytes。
- 新增 StarryOS 回归测例 `test-dev-zero-full-transfer`，覆盖 `/dev/zero` 64 KiB full read 和 `/dev/null` 64 KiB full write。

## Root Cause

`FileBackend::Direct` 原先直接调用 `IoBufMut::read_from` / `IoBuf::write_to` 一次。`ax-io` 的内部 transfer buffer 默认大小是 2048 bytes，因此即使底层设备本身可以继续提供或接收更多数据，direct backend 也会在一次 chunk 后返回。

这会让用户态看到不符合预期的短读/短写。例如并发 guest workload 中使用 `dd if=/dev/zero of=/dev/null bs=... count=...` 时，单次大块 I/O 会被提前截断，进而污染后续多进程/SMP 问题定位。

## Fix

direct backend 现在按 chunk 循环推进 offset，并累计 total bytes：

- 返回 `0` 时停止，保持 EOF 语义。
- 返回短 chunk 时停止，把它视为底层设备的真实短传输。
- `WouldBlock` 且已经有部分进展时返回已完成字节数，保留非阻塞 I/O 的部分成功语义。
- 其它错误仍直接返回。

## Changed Areas

- `os/arceos/modules/axfs-ng/src/highlevel/file.rs`
  - 这是 direct/cached backend 分流所在位置，也是原始短传输的发生点。
  - 修复放在这里可以保持具体设备实现不变，让所有 direct file backend 获得一致的大块 I/O 语义。
- `test-suit/starryos/normal/test-dev-zero-full-transfer`
  - 用 StarryOS 用户态测例复现真实 syscall 行为，而不是只测 Rust crate 内部函数。
  - 选择 `/dev/zero` 和 `/dev/null` 是因为它们不依赖磁盘内容，适合稳定覆盖 full read/full write。

## Test Plan

已本地验证：

```text
cargo fmt --check
git diff --check
cc -std=c11 -Wall -Wextra -Werror -fsyntax-only test-suit/starryos/normal/test-dev-zero-full-transfer/c/src/main.c
docker run ... cargo check -p ax-fs-ng --target riscv64gc-unknown-none-elf --release
```

结果：

```text
cargo fmt --check: PASS
git diff --check: PASS
C syntax check: PASS
ax-fs-ng riscv64 target check: PASS, Finished release profile in 32.77s
```

功能验证：

```text
test-dev-zero-full-transfer under StarryOS SMP=4, QEMU TCG thread=single: PASS
direct dd background case after this fix: PASS, wait statuses 0 0
```

## Remaining Risk

这个 PR 只修复 direct device I/O 的大块传输语义。并发 Bash subshell / fork+exec wait 的 SMP 问题已被进一步缩小，但属于独立的进程调度/等待路径问题，应拆到后续 PR 处理。
