### PR TITLE
feat(drivers): add SD/MMC platform driver support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "dwmmc-host"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitfield-struct",
  "dma-api",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "phytium-mci-host"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitfield-struct",
  "dma-api",
@@ -7146,7 +7146,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdhci-host"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dma-api",
  "embedded-hal",
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "sdmmc-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitflags 2.11.1",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,6 +1759,7 @@ dependencies = [
  "log",
  "mmio-api",
  "pcie",
+ "phytium-mci-host",
  "rd-block",
  "rd-net",
  "rdif-clk",
@@ -5801,6 +5802,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "phytium-mci-host"
+version = "0.1.0"
+dependencies = [
+ "bitfield-struct",
+ "dma-api",
+ "log",
+ "mmio-api",
+ "sdmmc-protocol",
+ "volatile 0.6.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ members = [
     "drivers/blk/ramdisk",
     "drivers/blk/rd-block",
     "drivers/blk/dwmmc-host",
+    "drivers/blk/phytium-mci-host",
     "drivers/blk/sdhci-host",
     "drivers/blk/sdmmc-protocol",
     "drivers/examples/enumerate",
@@ -418,6 +419,7 @@ crab-uvc = { version = "0.1.1", path = "drivers/usb/usb-device/uvc" }
 ktest-helper = { version = "0.1.1", path = "drivers/usb/utils/ktest-helper" }
 usb-if = { version = "0.7.1", path = "drivers/usb/usb-if" }
 dwmmc-host = { version = "0.1.0", path = "drivers/blk/dwmmc-host", default-features = false }
+phytium-mci-host = { version = "0.1.0", path = "drivers/blk/phytium-mci-host", default-features = false }
 sdhci-host = { version = "0.1.0", path = "drivers/blk/sdhci-host", default-features = false }
 sdmmc-protocol = { version = "0.1.0", path = "drivers/blk/sdmmc-protocol", default-features = false }
 smoltcp = { version = "0.13.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -418,10 +418,10 @@ crab-usb = { version = "0.9.3", path = "drivers/usb/usb-host" }
 crab-uvc = { version = "0.1.1", path = "drivers/usb/usb-device/uvc" }
 ktest-helper = { version = "0.1.1", path = "drivers/usb/utils/ktest-helper" }
 usb-if = { version = "0.7.1", path = "drivers/usb/usb-if" }
-dwmmc-host = { version = "0.1.0", path = "drivers/blk/dwmmc-host", default-features = false }
-phytium-mci-host = { version = "0.1.0", path = "drivers/blk/phytium-mci-host", default-features = false }
-sdhci-host = { version = "0.1.0", path = "drivers/blk/sdhci-host", default-features = false }
-sdmmc-protocol = { version = "0.1.0", path = "drivers/blk/sdmmc-protocol", default-features = false }
+dwmmc-host = { version = "0.1.1", path = "drivers/blk/dwmmc-host", default-features = false }
+phytium-mci-host = { version = "0.1.1", path = "drivers/blk/phytium-mci-host", default-features = false }
+sdhci-host = { version = "0.1.1", path = "drivers/blk/sdhci-host", default-features = false }
+sdmmc-protocol = { version = "0.1.1", path = "drivers/blk/sdmmc-protocol", default-features = false }
 smoltcp = { version = "0.13.1", default-features = false }
 smp-kernel = { version = "0.3.1", path = "components/axplat_crates/examples/smp-kernel" }
 starry-kernel = { version = "0.5.11", path = "os/StarryOS/kernel" }

--- a/drivers/blk/dwmmc-host/Cargo.toml
+++ b/drivers/blk/dwmmc-host/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dwmmc-host"
-version = "0.1.0"
+version = "0.1.1"
+repository.workspace = true
 edition = "2024"
 license = "Apache-2.0"
 description = "Synopsys DesignWare Mobile Storage Host Controller backend for sdmmc-protocol (no_std, FIFO/IDMAC)"

--- a/drivers/blk/dwmmc-host/src/dma.rs
+++ b/drivers/blk/dwmmc-host/src/dma.rs
@@ -230,6 +230,8 @@ impl DwMmc {
                 self.build_dma_read_request(start_block, buffer, size, dma, id)
             }
             BlockTransferMode::Fifo => self.build_fifo_read_request(start_block, buffer, size, id),
+            // Future BlockTransferMode variants are not supported by this controller.
+            _ => Err(Error::UnsupportedCommand),
         };
         match result {
             Ok(request) => Ok(request),
@@ -259,6 +261,8 @@ impl DwMmc {
                 self.build_dma_write_request(start_block, buffer, size, dma, id)
             }
             BlockTransferMode::Fifo => self.build_fifo_write_request(start_block, buffer, size, id),
+            // Future BlockTransferMode variants are not supported by this controller.
+            _ => Err(Error::UnsupportedCommand),
         };
         match result {
             Ok(request) => Ok(request),
@@ -279,6 +283,8 @@ impl DwMmc {
         match self.poll_block_request_response(request, id, slot)? {
             DataCommandPoll::Pending => Ok(BlockPoll::Pending),
             DataCommandPoll::Complete(_) => Ok(BlockPoll::Complete),
+            // Future DataCommandPoll variants are treated as completion.
+            _ => Ok(BlockPoll::Complete),
         }
     }
 
@@ -346,6 +352,8 @@ impl DwMmc {
                     }
                     return Ok(DataCommandPoll::Pending);
                 }
+                // Future CommandPoll variants: best-effort, treat as still pending.
+                Ok(_) => return Ok(DataCommandPoll::Pending),
                 Err(err) => {
                     self.abort_block_request(request, id, slot, phase);
                     return Err(err);
@@ -360,6 +368,8 @@ impl DwMmc {
         match self.poll_dma_complete(cmd_index, phase) {
             Ok(BlockPoll::Pending) => Ok(DataCommandPoll::Pending),
             Ok(BlockPoll::Complete) => self.finish_dma_data(request, id, slot),
+            // Future BlockPoll variants: best-effort, treat as still pending.
+            Ok(_) => Ok(DataCommandPoll::Pending),
             Err(err) => {
                 self.abort_block_request(request, id, slot, phase);
                 Err(err)
@@ -519,6 +529,8 @@ impl DwMmc {
             DataDirection::Read => BlockTransferDirection::Read,
             DataDirection::Write => BlockTransferDirection::Write,
             DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
         };
         let id = slot.start(BlockTransferMode::Fifo, transfer_direction)?;
         match self.build_fifo_data_request(
@@ -563,6 +575,8 @@ impl DwMmc {
             DataDirection::Read => Phase::DataRead,
             DataDirection::Write => Phase::DataWrite,
             DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
         };
         self.pending_data = Some(PendingData {
             direction,
@@ -597,6 +611,8 @@ impl DwMmc {
                 response: None,
             },
             DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
         };
         Ok(BlockRequest { inner })
     }
@@ -616,6 +632,8 @@ impl DwMmc {
             DataDirection::Read => Phase::DataRead,
             DataDirection::Write => Phase::DataWrite,
             DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
         };
         let byte_count = block_count
             .checked_mul(BLOCK_SIZE as u32)
@@ -779,6 +797,8 @@ impl DwMmc {
                 slot.complete(id)?;
                 Ok(DataCommandPoll::Complete(response))
             }
+            // Future CommandPoll variants: best-effort, treat as still pending.
+            Ok(_) => Ok(DataCommandPoll::Pending),
             Err(err) => {
                 self.abort_block_request(request, id, slot, phase);
                 Err(err)
@@ -829,6 +849,8 @@ impl DwMmc {
                     set_fifo_stage(request, BlockRequestStage::Data)?;
                     return Ok(DataCommandPoll::Pending);
                 }
+                // Future CommandPoll variants: best-effort, treat as still pending.
+                Ok(_) => return Ok(DataCommandPoll::Pending),
                 Err(err) => {
                     self.abort_block_request(request, id, slot, phase);
                     return Err(err);
@@ -848,6 +870,8 @@ impl DwMmc {
         match self.poll_fifo_data_step(request, cmd_index, phase) {
             Ok(BlockPoll::Pending) => Ok(DataCommandPoll::Pending),
             Ok(BlockPoll::Complete) => self.finish_fifo_data(request, id, slot),
+            // Future BlockPoll variants: best-effort, treat as still pending.
+            Ok(_) => Ok(DataCommandPoll::Pending),
             Err(err) => {
                 self.abort_block_request(request, id, slot, phase);
                 Err(err)

--- a/drivers/blk/dwmmc-host/src/host.rs
+++ b/drivers/blk/dwmmc-host/src/host.rs
@@ -339,6 +339,8 @@ impl DwMmc {
             BusWidth::Bit1 => CType::new(),
             BusWidth::Bit4 => CType::new().with_width4(1),
             BusWidth::Bit8 => CType::new().with_width8(1),
+            // Future BusWidth variants: fall back to 1-bit (no width bits set).
+            _ => CType::new(),
         };
         self.regs.ctype().write(ct);
     }

--- a/drivers/blk/dwmmc-host/src/lib.rs
+++ b/drivers/blk/dwmmc-host/src/lib.rs
@@ -395,6 +395,8 @@ impl DwMmc {
             BlockTransferMode::Dma => {
                 BlockBufferConfig::new(NonZeroUsize::new(512).unwrap(), 512, Some(self.dma_mask))
             }
+            // Future BlockTransferMode variants fall back to the conservative Fifo config.
+            _ => BlockBufferConfig::new(NonZeroUsize::new(512).unwrap(), 1, None),
         }
     }
 
@@ -420,6 +422,8 @@ fn clock_hz_for_speed(speed: ClockSpeed) -> u32 {
         ClockSpeed::Sdr50 | ClockSpeed::Ddr50 => 50_000_000,
         ClockSpeed::Sdr104 => 104_000_000,
         ClockSpeed::Hs200 => 200_000_000,
+        // Future ClockSpeed variants: unknown frequency, signal 0.
+        _ => 0,
     }
 }
 
@@ -435,6 +439,8 @@ pub(crate) fn volt_mask_for_signal(voltage: SignalVoltage) -> Result<u16, Error>
         SignalVoltage::V330 => Ok(0),
         SignalVoltage::V180 => Ok(1),
         SignalVoltage::V120 => Err(Error::UnsupportedCommand),
+        // Future SignalVoltage variants are not supported by this controller.
+        _ => Err(Error::UnsupportedCommand),
     }
 }
 

--- a/drivers/blk/phytium-mci-host/Cargo.toml
+++ b/drivers/blk/phytium-mci-host/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "phytium-mci-host"
-version = "0.1.0"
+version = "0.1.1"
+repository.workspace = true
 edition = "2024"
 license = "Apache-2.0"
-description = "Phytium MCI/FSDIF host controller backend for sdmmc-protocol (no_std, FIFO)"
+description = "Phytium MCI/FSDIF host controller backend for sdmmc-protocol (no_std, FIFO/IDMAC)"
 readme = "README.md"
 keywords = ["sd", "mmc", "phytium", "embedded", "no_std"]
 categories = ["embedded", "no-std", "hardware-support"]

--- a/drivers/blk/phytium-mci-host/Cargo.toml
+++ b/drivers/blk/phytium-mci-host/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "phytium-mci-host"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "Phytium MCI/FSDIF host controller backend for sdmmc-protocol (no_std, FIFO)"
+readme = "README.md"
+keywords = ["sd", "mmc", "phytium", "embedded", "no_std"]
+categories = ["embedded", "no-std", "hardware-support"]
+
+[dependencies]
+sdmmc-protocol = { workspace = true, default-features = false, features = ["sdio"] }
+bitfield-struct = "0.11"
+volatile = { version = "0.6", features = ["derive"] }
+log.workspace = true
+dma-api.workspace = true
+mmio-api.workspace = true
+
+[features]
+default = []

--- a/drivers/blk/phytium-mci-host/README.md
+++ b/drivers/blk/phytium-mci-host/README.md
@@ -3,12 +3,7 @@
 Portable `no_std` Phytium MCI/FSDIF host-controller backend for
 `sdmmc-protocol`.
 
-The crate owns register programming, command/response handling, FIFO data
-transfer, clock timing selection, and IRQ event extraction. Platform code still
+The crate owns register programming, command/response handling, FIFO and IDMAC
+block transfers, clock timing selection, and IRQ event extraction. Platform code still
 owns FDT/ACPI probe, MMIO mapping lifetime, IRQ registration, pad-controller
 setup, and block-device registration.
-
-DMA/IDMAC support is intentionally left out of the first portable cut. The
-public block request API accepts `BlockTransferMode::Dma` so callers can fall
-back to FIFO consistently, but DMA submissions currently return
-`Error::UnsupportedCommand`.

--- a/drivers/blk/phytium-mci-host/README.md
+++ b/drivers/blk/phytium-mci-host/README.md
@@ -1,0 +1,14 @@
+# phytium-mci-host
+
+Portable `no_std` Phytium MCI/FSDIF host-controller backend for
+`sdmmc-protocol`.
+
+The crate owns register programming, command/response handling, FIFO data
+transfer, clock timing selection, and IRQ event extraction. Platform code still
+owns FDT/ACPI probe, MMIO mapping lifetime, IRQ registration, pad-controller
+setup, and block-device registration.
+
+DMA/IDMAC support is intentionally left out of the first portable cut. The
+public block request API accepts `BlockTransferMode::Dma` so callers can fall
+back to FIFO consistently, but DMA submissions currently return
+`Error::UnsupportedCommand`.

--- a/drivers/blk/phytium-mci-host/src/command.rs
+++ b/drivers/blk/phytium-mci-host/src/command.rs
@@ -1,9 +1,3 @@
-//! Command issue and response decoding.
-//!
-//! Encodes [`sdmmc_protocol::cmd::Command`] into a DW_mshc CMD register
-//! value, fires it, polls RINTSTS for completion, and decodes the four
-//! 32-bit response slots back into [`Response`].
-
 use sdmmc_protocol::{
     CommandPoll, CommandResponsePoll,
     cmd::{Command as ProtoCmd, DataDirection},
@@ -15,8 +9,8 @@ use sdmmc_protocol::{
 };
 
 use crate::{
-    host::DwMmc,
-    regs::{Cmd, RegisterBlockVolatileFieldAccess},
+    host::PhytiumMci,
+    regs::{Cmd, RIntSts, RegisterBlockVolatileFieldAccess},
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -40,7 +34,7 @@ pub(crate) enum CommandState {
     },
 }
 
-impl DwMmc {
+impl PhytiumMci {
     pub fn poll_command_response(&mut self) -> Result<CommandResponsePoll, Error> {
         match self.poll_command() {
             Ok(CommandPoll::Pending) => Ok(CommandResponsePoll::Pending),
@@ -96,7 +90,7 @@ impl DwMmc {
             unreachable!();
         };
         let raw_status = self.take_command_irq_status();
-        let status = crate::regs::RIntSts::from_bits(raw_status);
+        let status = RIntSts::from_bits(raw_status);
         if status.error() {
             let err = self.translate_int_error(status, Phase::ResponseWait, cmd.cmd);
             self.command_state = CommandState::Failed { error: err };
@@ -106,10 +100,10 @@ impl DwMmc {
             let response = match decode_response(self, cmd.resp_type) {
                 Ok(r) => r,
                 Err(err) => {
-                    // Park the FSM in Failed before propagating: bare `?` would
-                    // leave it in Issued while the IRQ status bits are already
-                    // cleared, so the next poll would idle until the caller's
-                    // own timeout fires.
+                    // Park the FSM in Failed before propagating so the next
+                    // `take_command_response` sees the diagnostic instead of
+                    // re-entering Issued and re-reading already-cleared IRQ
+                    // status.
                     self.command_state = CommandState::Failed { error: err };
                     return Err(err);
                 }
@@ -148,49 +142,43 @@ impl DwMmc {
             self.data_cmd_index = cmd.cmd;
         }
         self.clear_command_int_status();
+        let mut use_idmac = false;
         let data_dir = data.map(|d| {
             self.program_data_phase(d.block_size, d.block_count);
+            use_idmac = d.use_idmac;
             d.direction
         });
         self.regs.cmdarg().write(cmd.arg);
-        self.regs.cmd().write(encode_command(cmd, data_dir));
+        let mut encoded = encode_command(cmd, data_dir).with_use_hold_reg(self.use_hold_reg);
+        if use_idmac {
+            encoded = encoded.with_transfer_mode(true);
+        }
+        self.regs.cmd().write(encoded);
         self.command_state = CommandState::WaitingStart { cmd: *cmd };
     }
 
     fn take_command_irq_status(&mut self) -> u32 {
         let raw_status = self.regs.rintsts().read().into_bits();
-        let consume = raw_status & (crate::DWMMC_INT_COMMAND_DONE | crate::DWMMC_INT_ERROR_MASK);
+        let consume = raw_status & (crate::MCI_INT_COMMAND_DONE | crate::MCI_INT_ERROR_MASK);
         if consume != 0 {
-            self.regs
-                .rintsts()
-                .write(crate::regs::RIntSts::from_bits(consume));
+            self.regs.rintsts().write(RIntSts::from_bits(consume));
         }
         let status = self.irq_pending_status | raw_status;
-        self.irq_pending_status &= !(crate::DWMMC_INT_COMMAND_DONE | crate::DWMMC_INT_ERROR_MASK);
+        self.irq_pending_status &= !(crate::MCI_INT_COMMAND_DONE | crate::MCI_INT_ERROR_MASK);
         status
     }
 
     fn clear_command_int_status(&mut self) {
         let raw_status = self.regs.rintsts().read().into_bits()
-            & (crate::DWMMC_INT_COMMAND_DONE | crate::DWMMC_INT_ERROR_MASK);
+            & (crate::MCI_INT_COMMAND_DONE | crate::MCI_INT_ERROR_MASK);
         if raw_status != 0 {
-            self.regs
-                .rintsts()
-                .write(crate::regs::RIntSts::from_bits(raw_status));
+            self.regs.rintsts().write(RIntSts::from_bits(raw_status));
         }
-        self.irq_pending_status &= !(crate::DWMMC_INT_COMMAND_DONE | crate::DWMMC_INT_ERROR_MASK);
+        self.irq_pending_status &= !(crate::MCI_INT_COMMAND_DONE | crate::MCI_INT_ERROR_MASK);
     }
 }
 
-/// Build the CMD register value for a single command.
-///
-/// `data_dir` is `Some` when the command carries a data phase (the
-/// protocol layer signals this by populating
-/// [`crate::host::PendingData`]). The direction selects `read_write`;
-/// passing `None` issues a non-data command.
-fn encode_command(cmd: &ProtoCmd, data_dir: Option<DataDirection>) -> Cmd {
-    // Defaults: start_cmd=1, wait_prvdata_complete=1, use_hold_reg=1.
-    // CMD0 needs send_initialization=1; everything else leaves it 0.
+pub(crate) fn encode_command(cmd: &ProtoCmd, data_dir: Option<DataDirection>) -> Cmd {
     let mut c = Cmd::new()
         .with_start_cmd(true)
         .with_use_hold_reg(true)
@@ -198,31 +186,20 @@ fn encode_command(cmd: &ProtoCmd, data_dir: Option<DataDirection>) -> Cmd {
         .with_cmd_index(cmd.cmd & 0x3F);
 
     match cmd.resp_type {
-        ResponseType::None => {
-            // No response_expect; no CRC check.
-        }
+        ResponseType::None => {}
         ResponseType::R1 | ResponseType::R5 | ResponseType::R6 | ResponseType::R7 => {
             c = c.with_response_expect(true).with_check_response_crc(true);
         }
         ResponseType::R1b => {
-            // R1b is short response with busy. The DW_mshc treats the
-            // busy hold-off through the same CMD bits as R1 plus the
-            // controller's own data-busy gating; no separate
-            // "response_length_busy" flag exists.
             c = c.with_response_expect(true).with_check_response_crc(true);
         }
         ResponseType::R2 => {
-            // R2 = long (136-bit) response. CRC of the on-bus frame is
-            // checked against the spec's R2 polynomial.
             c = c
                 .with_response_expect(true)
                 .with_response_length(true)
                 .with_check_response_crc(true);
         }
         ResponseType::R3 | ResponseType::R4 => {
-            // OCR responses don't include a valid CRC; check_response_crc
-            // must be 0 or the controller will flag every R3/R4 as a
-            // CRC error.
             c = c.with_response_expect(true);
         }
         // Future ResponseType variants land here as bare command; controller default is no response_expect.
@@ -230,26 +207,22 @@ fn encode_command(cmd: &ProtoCmd, data_dir: Option<DataDirection>) -> Cmd {
     }
 
     if cmd.cmd == 0 {
-        // Power-up cards need 80 init clocks before CMD0.
         c = c.with_send_initialization(true);
+    }
+    if cmd.cmd == 12 {
+        c = c.with_stop_abort_cmd(true);
     }
 
     if let Some(dir) = data_dir {
         c = c.with_data_expected(true);
-        // The data-command submit path carries direction explicitly because
-        // some indices are overloaded (CMD6 = ACMD6 SET_BUS_WIDTH no-data /
-        // SWITCH_FUNC read; CMD8 = SEND_IF_COND no-data on SD /
-        // SEND_EXT_CSD read on MMC). We trust that signal here rather than
-        // inferring from `cmd.cmd`.
         if matches!(dir, DataDirection::Write) {
             c = c.with_read_write(true);
         }
     }
-
     c
 }
 
-fn decode_response(host: &DwMmc, resp_type: ResponseType) -> Result<Response, Error> {
+fn decode_response(host: &PhytiumMci, resp_type: ResponseType) -> Result<Response, Error> {
     let resp = host.regs.resp().read();
     Ok(match resp_type {
         ResponseType::None => Response::Empty,
@@ -261,20 +234,12 @@ fn decode_response(host: &DwMmc, resp_type: ResponseType) -> Result<Response, Er
         ResponseType::R5 => Response::R5(SdioRwResponse::from_raw(resp[0])),
         ResponseType::R6 => Response::R6(RcaResponse::from_raw(resp[0])),
         ResponseType::R7 => Response::R7(IfCondResponse::from_raw(resp[0])),
-        // Future ResponseType variants are not decoded by this controller.
+        // Future ResponseType variants are not decoded by this controller;
+        // surface as UnsupportedCommand instead of returning silent zeros.
         _ => return Err(Error::UnsupportedCommand),
     })
 }
 
-/// Reorder the four 32-bit response slots into the 16-byte buffer the
-/// protocol layer's CID/CSD parsers expect.
-///
-/// On DW_mshc, RESP[3..0] holds the on-bus 128-bit R2 frame with the
-/// MSB of card_resp at the top of RESP3 (header / start bits are
-/// stripped by the CIU before storage). The protocol layer's
-/// `CidResponse::from_raw` / `CsdResponse::from_raw` expect byte 0 =
-/// card_resp[127:120] (i.e. MID for CID), so we serialize each u32
-/// big-endian and place RESP3 at offset 0.
 fn read_r2(resp: [u32; 4]) -> [u8; 16] {
     let mut bytes = [0u8; 16];
     bytes[0..4].copy_from_slice(&resp[3].to_be_bytes());

--- a/drivers/blk/phytium-mci-host/src/dma.rs
+++ b/drivers/blk/phytium-mci-host/src/dma.rs
@@ -1,0 +1,1447 @@
+use core::{num::NonZeroUsize, ptr::NonNull};
+
+use dma_api::{DArray, DeviceDma, DmaDirection, SArrayPtr};
+use log::warn;
+use sdmmc_protocol::{
+    block::{
+        BlockPoll, BlockRequestId, BlockTransferDirection, BlockTransferMode, BlockTransferState,
+        CommandPoll, DataCommandPoll,
+    },
+    cmd::{CMD12, Command, DataDirection, cmd17, cmd18, cmd24, cmd25},
+    error::{Error, Phase},
+    response::Response,
+};
+
+use crate::{
+    host::{PendingData, PhytiumMci},
+    regs::{RIntSts, RegisterBlockVolatileFieldAccess},
+};
+
+const BLOCK_SIZE: usize = 512;
+const IDMAC_DESC_ALIGN: usize = 32;
+const IDMAC_MAX_BUF_SIZE: usize = 0x1000;
+const IDMAC_DESC_LAST: u32 = 1 << 2;
+const IDMAC_DESC_FIRST: u32 = 1 << 3;
+const IDMAC_DESC_CHAIN: u32 = 1 << 4;
+const IDMAC_DESC_END_RING: u32 = 1 << 5;
+const IDMAC_DESC_OWN: u32 = 1 << 31;
+const BMOD_FIXED_BURST: u32 = 1 << 1;
+const BMOD_IDMAC_ENABLE: u32 = 1 << 7;
+const IDSTS_TRANSMIT: u32 = crate::MCI_IDSTS_TRANSMIT;
+const IDSTS_RECEIVE: u32 = crate::MCI_IDSTS_RECEIVE;
+const IDSTS_NORMAL_SUMMARY: u32 = 1 << 8;
+const IDSTS_ABNORMAL_SUMMARY: u32 = 1 << 9;
+const IDSTS_ERROR_MASK: u32 = crate::MCI_IDSTS_ERROR_MASK | IDSTS_ABNORMAL_SUMMARY;
+const IDSTS_INT_ENABLE_MASK: u32 =
+    crate::MCI_IDSTS_ERROR_MASK | IDSTS_NORMAL_SUMMARY | IDSTS_ABNORMAL_SUMMARY;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct IdmacDesc {
+    attribute: u32,
+    reserved0: u32,
+    len: u32,
+    reserved1: u32,
+    addr_lo: u32,
+    addr_hi: u32,
+    desc_lo: u32,
+    desc_hi: u32,
+}
+
+struct DmaProgress {
+    descriptors: DArray<IdmacDesc>,
+    buffer: SArrayPtr<u8>,
+    desc_count: usize,
+    complete: bool,
+    idmac_done: bool,
+    data_done: bool,
+}
+
+impl DmaProgress {
+    fn keep_alive(&self) {
+        let _ = self.descriptors.dma_addr();
+        let _ = self.desc_count;
+    }
+}
+
+pub type RequestId = BlockRequestId;
+
+#[derive(Default)]
+pub struct BlockRequestSlot {
+    next: usize,
+    state: BlockTransferState,
+}
+
+impl BlockRequestSlot {
+    pub fn start(
+        &mut self,
+        mode: BlockTransferMode,
+        direction: BlockTransferDirection,
+    ) -> Result<RequestId, Error> {
+        if !matches!(self.state, BlockTransferState::Idle) {
+            return Err(Error::UnsupportedCommand);
+        }
+        let id = RequestId::new(self.next);
+        self.next = self.next.wrapping_add(1);
+        self.state = BlockTransferState::Submitted {
+            id,
+            mode,
+            direction,
+        };
+        Ok(id)
+    }
+
+    pub fn complete(&mut self, id: RequestId) -> Result<(), Error> {
+        if self.state.id() != Some(id) {
+            return Err(Error::InvalidArgument);
+        }
+        self.state = BlockTransferState::Idle;
+        Ok(())
+    }
+
+    pub fn state(&self) -> BlockTransferState {
+        self.state
+    }
+}
+
+pub struct BlockRequest {
+    inner: BlockRequestKind,
+}
+
+unsafe impl Send for BlockRequest {}
+
+enum BlockRequestKind {
+    FifoRead {
+        id: RequestId,
+        buffer: NonNull<u8>,
+        len: usize,
+        block_size: usize,
+        progress: FifoProgress,
+        cmd_index: u8,
+        phase: Phase,
+        stage: BlockRequestStage,
+        stop_after_complete: bool,
+        response: Option<Response>,
+    },
+    DmaRead {
+        id: RequestId,
+        progress: DmaProgress,
+        cmd_index: u8,
+        phase: Phase,
+        stage: BlockRequestStage,
+        stop_after_complete: bool,
+        response: Option<Response>,
+    },
+    FifoWrite {
+        id: RequestId,
+        buffer: NonNull<u8>,
+        len: usize,
+        block_size: usize,
+        progress: FifoProgress,
+        cmd_index: u8,
+        phase: Phase,
+        stage: BlockRequestStage,
+        stop_after_complete: bool,
+        response: Option<Response>,
+    },
+    DmaWrite {
+        id: RequestId,
+        progress: DmaProgress,
+        cmd_index: u8,
+        phase: Phase,
+        stage: BlockRequestStage,
+        stop_after_complete: bool,
+        response: Option<Response>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct FifoProgress {
+    offset: usize,
+    transfer_done: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BlockRequestStage {
+    Command,
+    Data,
+    Stop,
+}
+
+impl BlockRequest {
+    pub fn id(&self) -> RequestId {
+        match &self.inner {
+            BlockRequestKind::FifoRead { id, .. }
+            | BlockRequestKind::FifoWrite { id, .. }
+            | BlockRequestKind::DmaRead { id, .. }
+            | BlockRequestKind::DmaWrite { id, .. } => *id,
+        }
+    }
+
+    pub fn state(&self) -> BlockTransferState {
+        match &self.inner {
+            BlockRequestKind::FifoRead { id, .. } => BlockTransferState::Submitted {
+                id: *id,
+                mode: BlockTransferMode::Fifo,
+                direction: BlockTransferDirection::Read,
+            },
+            BlockRequestKind::DmaRead { id, .. } => BlockTransferState::Submitted {
+                id: *id,
+                mode: BlockTransferMode::Dma,
+                direction: BlockTransferDirection::Read,
+            },
+            BlockRequestKind::FifoWrite { id, .. } => BlockTransferState::Submitted {
+                id: *id,
+                mode: BlockTransferMode::Fifo,
+                direction: BlockTransferDirection::Write,
+            },
+            BlockRequestKind::DmaWrite { id, .. } => BlockTransferState::Submitted {
+                id: *id,
+                mode: BlockTransferMode::Dma,
+                direction: BlockTransferDirection::Write,
+            },
+        }
+    }
+
+    fn response(&self) -> Option<Response> {
+        match &self.inner {
+            BlockRequestKind::FifoRead { response, .. }
+            | BlockRequestKind::FifoWrite { response, .. }
+            | BlockRequestKind::DmaRead { response, .. }
+            | BlockRequestKind::DmaWrite { response, .. } => *response,
+        }
+    }
+}
+
+impl PhytiumMci {
+    pub fn submit_read_blocks(
+        &mut self,
+        start_block: u32,
+        buffer: NonNull<u8>,
+        size: NonZeroUsize,
+        dma: Option<&DeviceDma>,
+        mode: BlockTransferMode,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<BlockRequest, Error> {
+        let id = slot.start(mode, BlockTransferDirection::Read)?;
+        let result = match mode {
+            BlockTransferMode::Dma => self.build_dma_read_request(
+                start_block,
+                buffer,
+                size,
+                dma.ok_or(Error::InvalidArgument)?,
+                id,
+            ),
+            BlockTransferMode::Fifo => self.build_fifo_read_request(start_block, buffer, size, id),
+            // Future BlockTransferMode variants are not supported by this controller.
+            _ => Err(Error::UnsupportedCommand),
+        };
+        match result {
+            Ok(request) => Ok(request),
+            Err(err) => {
+                let _ = slot.complete(id);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn submit_write_blocks(
+        &mut self,
+        start_block: u32,
+        buffer: NonNull<u8>,
+        size: NonZeroUsize,
+        dma: Option<&DeviceDma>,
+        mode: BlockTransferMode,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<BlockRequest, Error> {
+        let id = slot.start(mode, BlockTransferDirection::Write)?;
+        let result = match mode {
+            BlockTransferMode::Dma => self.build_dma_write_request(
+                start_block,
+                buffer,
+                size,
+                dma.ok_or(Error::InvalidArgument)?,
+                id,
+            ),
+            BlockTransferMode::Fifo => self.build_fifo_write_request(start_block, buffer, size, id),
+            // Future BlockTransferMode variants are not supported by this controller.
+            _ => Err(Error::UnsupportedCommand),
+        };
+        match result {
+            Ok(request) => Ok(request),
+            Err(err) => {
+                let _ = slot.complete(id);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn poll_block_request(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<BlockPoll, Error> {
+        match self.poll_block_request_response(request, id, slot)? {
+            DataCommandPoll::Pending => Ok(BlockPoll::Pending),
+            DataCommandPoll::Complete(_) => Ok(BlockPoll::Complete),
+            // Future DataCommandPoll variants are treated as completion.
+            _ => Ok(BlockPoll::Complete),
+        }
+    }
+
+    pub fn poll_block_request_response(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<DataCommandPoll, Error> {
+        let Some(active) = request.as_ref() else {
+            return Err(Error::InvalidArgument);
+        };
+        if active.id() != id {
+            return Err(Error::InvalidArgument);
+        }
+        self.poll_data_request_inner(request, id, slot)
+    }
+
+    fn build_fifo_read_request(
+        &mut self,
+        start_block: u32,
+        buffer: NonNull<u8>,
+        size: NonZeroUsize,
+        id: RequestId,
+    ) -> Result<BlockRequest, Error> {
+        let block_count = block_count(size)?;
+        let cmd = if block_count == 1 {
+            cmd17(start_block)
+        } else {
+            cmd18(start_block)
+        };
+        self.build_fifo_data_request(
+            &cmd,
+            buffer,
+            size.get(),
+            BLOCK_SIZE as u32,
+            block_count,
+            id,
+            DataDirection::Read,
+            block_count > 1,
+        )
+    }
+
+    fn build_fifo_write_request(
+        &mut self,
+        start_block: u32,
+        buffer: NonNull<u8>,
+        size: NonZeroUsize,
+        id: RequestId,
+    ) -> Result<BlockRequest, Error> {
+        let block_count = block_count(size)?;
+        let cmd = if block_count == 1 {
+            cmd24(start_block)
+        } else {
+            cmd25(start_block)
+        };
+        self.build_fifo_data_request(
+            &cmd,
+            buffer,
+            size.get(),
+            BLOCK_SIZE as u32,
+            block_count,
+            id,
+            DataDirection::Write,
+            block_count > 1,
+        )
+    }
+
+    fn build_dma_read_request(
+        &mut self,
+        start_block: u32,
+        buffer: NonNull<u8>,
+        size: NonZeroUsize,
+        dma: &DeviceDma,
+        id: RequestId,
+    ) -> Result<BlockRequest, Error> {
+        let block_count = block_count(size)?;
+        let cmd = if block_count == 1 {
+            cmd17(start_block)
+        } else {
+            cmd18(start_block)
+        };
+        self.build_dma_data_request(
+            &cmd,
+            buffer,
+            size.get(),
+            BLOCK_SIZE as u32,
+            block_count,
+            dma,
+            id,
+            DataDirection::Read,
+            block_count > 1,
+        )
+    }
+
+    fn build_dma_write_request(
+        &mut self,
+        start_block: u32,
+        buffer: NonNull<u8>,
+        size: NonZeroUsize,
+        dma: &DeviceDma,
+        id: RequestId,
+    ) -> Result<BlockRequest, Error> {
+        let block_count = block_count(size)?;
+        let cmd = if block_count == 1 {
+            cmd24(start_block)
+        } else {
+            cmd25(start_block)
+        };
+        self.build_dma_data_request(
+            &cmd,
+            buffer,
+            size.get(),
+            BLOCK_SIZE as u32,
+            block_count,
+            dma,
+            id,
+            DataDirection::Write,
+            block_count > 1,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_dma_data_request(
+        &mut self,
+        cmd: &Command,
+        buffer: NonNull<u8>,
+        len: usize,
+        block_size: u32,
+        block_count: u32,
+        dma: &DeviceDma,
+        id: RequestId,
+        direction: DataDirection,
+        stop_after_complete: bool,
+    ) -> Result<BlockRequest, Error> {
+        let block_size_usize = usize::try_from(block_size).map_err(|_| Error::InvalidArgument)?;
+        if block_size_usize == 0 || len != block_size_usize.saturating_mul(block_count as usize) {
+            return Err(Error::InvalidArgument);
+        }
+        let phase = match direction {
+            DataDirection::Read => Phase::DataRead,
+            DataDirection::Write => Phase::DataWrite,
+            DataDirection::None => return Err(Error::InvalidArgument),
+            _ => return Err(Error::InvalidArgument),
+        };
+        let dma_direction = match direction {
+            DataDirection::Read => DmaDirection::FromDevice,
+            DataDirection::Write => DmaDirection::ToDevice,
+            DataDirection::None => return Err(Error::InvalidArgument),
+            _ => return Err(Error::InvalidArgument),
+        };
+        let slice = unsafe { core::slice::from_raw_parts(buffer.as_ptr(), len) };
+        let mapped = dma
+            .map_single_array(slice, BLOCK_SIZE, dma_direction)
+            .map_err(|_| Error::Misaligned)?;
+        if matches!(direction, DataDirection::Write) {
+            mapped.confirm_write_all();
+        }
+        let desc_count = len.div_ceil(IDMAC_MAX_BUF_SIZE);
+        let mut descriptors = dma
+            .array_zero_with_align::<IdmacDesc>(
+                desc_count,
+                IDMAC_DESC_ALIGN,
+                DmaDirection::ToDevice,
+            )
+            .map_err(|_| Error::Misaligned)?;
+        let desc_dma = descriptors.dma_addr().as_u64();
+        let desc_values = build_idmac_descriptors(
+            mapped.dma_addr().as_u64(),
+            desc_dma,
+            len,
+            IDMAC_MAX_BUF_SIZE,
+        )?;
+        descriptors.write_with(desc_values.len(), |dst| dst.copy_from_slice(&desc_values));
+        self.start_idmac_transfer(cmd, block_size, block_count, desc_dma)?;
+
+        let progress = DmaProgress {
+            descriptors,
+            buffer: mapped,
+            desc_count,
+            complete: false,
+            idmac_done: false,
+            data_done: false,
+        };
+        let inner = match direction {
+            DataDirection::Read => BlockRequestKind::DmaRead {
+                id,
+                progress,
+                cmd_index: cmd.cmd,
+                phase,
+                stage: BlockRequestStage::Command,
+                stop_after_complete,
+                response: None,
+            },
+            DataDirection::Write => BlockRequestKind::DmaWrite {
+                id,
+                progress,
+                cmd_index: cmd.cmd,
+                phase,
+                stage: BlockRequestStage::Command,
+                stop_after_complete,
+                response: None,
+            },
+            DataDirection::None => return Err(Error::InvalidArgument),
+            _ => return Err(Error::InvalidArgument),
+        };
+        Ok(BlockRequest { inner })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn submit_fifo_data_request(
+        &mut self,
+        cmd: &Command,
+        buffer: NonNull<u8>,
+        len: usize,
+        block_size: u32,
+        block_count: u32,
+        direction: DataDirection,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<BlockRequest, Error> {
+        let transfer_direction = match direction {
+            DataDirection::Read => BlockTransferDirection::Read,
+            DataDirection::Write => BlockTransferDirection::Write,
+            DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
+        };
+        let id = slot.start(BlockTransferMode::Fifo, transfer_direction)?;
+        match self.build_fifo_data_request(
+            cmd,
+            buffer,
+            len,
+            block_size,
+            block_count,
+            id,
+            direction,
+            false,
+        ) {
+            Ok(request) => Ok(request),
+            Err(err) => {
+                let _ = slot.complete(id);
+                Err(err)
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_fifo_data_request(
+        &mut self,
+        cmd: &Command,
+        buffer: NonNull<u8>,
+        len: usize,
+        block_size: u32,
+        block_count: u32,
+        id: RequestId,
+        direction: DataDirection,
+        stop_after_complete: bool,
+    ) -> Result<BlockRequest, Error> {
+        let block_size_usize = usize::try_from(block_size).map_err(|_| Error::InvalidArgument)?;
+        let block_count_usize = usize::try_from(block_count).map_err(|_| Error::InvalidArgument)?;
+        if block_size_usize == 0
+            || block_count_usize == 0
+            || len != block_size_usize.saturating_mul(block_count_usize)
+        {
+            return Err(Error::InvalidArgument);
+        }
+        let phase = match direction {
+            DataDirection::Read => Phase::DataRead,
+            DataDirection::Write => Phase::DataWrite,
+            DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
+        };
+        self.pending_data = Some(PendingData {
+            direction,
+            block_size,
+            block_count,
+            use_idmac: false,
+        });
+        self.data_blocks_remaining = block_count;
+        self.submit_command(cmd)?;
+        let inner = match direction {
+            DataDirection::Read => BlockRequestKind::FifoRead {
+                id,
+                buffer,
+                len,
+                block_size: block_size_usize,
+                progress: FifoProgress::default(),
+                cmd_index: cmd.cmd,
+                phase,
+                stage: BlockRequestStage::Command,
+                stop_after_complete,
+                response: None,
+            },
+            DataDirection::Write => BlockRequestKind::FifoWrite {
+                id,
+                buffer,
+                len,
+                block_size: block_size_usize,
+                progress: FifoProgress::default(),
+                cmd_index: cmd.cmd,
+                phase,
+                stage: BlockRequestStage::Command,
+                stop_after_complete,
+                response: None,
+            },
+            DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
+        };
+        Ok(BlockRequest { inner })
+    }
+
+    fn poll_data_request_inner(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<DataCommandPoll, Error> {
+        match request.as_ref().map(|request| &request.inner) {
+            Some(BlockRequestKind::FifoRead { .. }) | Some(BlockRequestKind::FifoWrite { .. }) => {
+                self.poll_fifo_request(request, id, slot)
+            }
+            Some(BlockRequestKind::DmaRead { .. }) | Some(BlockRequestKind::DmaWrite { .. }) => {
+                self.poll_dma_request(request, id, slot)
+            }
+            None => Err(Error::InvalidArgument),
+        }
+    }
+
+    fn poll_fifo_request(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<DataCommandPoll, Error> {
+        let (cmd_index, phase, stage) = match request.as_ref().map(|request| &request.inner) {
+            Some(BlockRequestKind::FifoRead {
+                cmd_index,
+                phase,
+                stage,
+                ..
+            })
+            | Some(BlockRequestKind::FifoWrite {
+                cmd_index,
+                phase,
+                stage,
+                ..
+            }) => (*cmd_index, *phase, *stage),
+            _ => return Err(Error::InvalidArgument),
+        };
+
+        if stage == BlockRequestStage::Command {
+            match self.poll_command() {
+                Ok(CommandPoll::Pending) => return Ok(DataCommandPoll::Pending),
+                Ok(CommandPoll::Complete) => {
+                    let response = self.take_command_response()?;
+                    store_response(request, response)?;
+                    set_stage(request, BlockRequestStage::Data)?;
+                    return Ok(DataCommandPoll::Pending);
+                }
+                // Future CommandPoll variants: best-effort, treat as still pending.
+                Ok(_) => return Ok(DataCommandPoll::Pending),
+                Err(err) => {
+                    self.abort_block_request(request, id, slot, phase);
+                    return Err(err);
+                }
+            }
+        }
+
+        let stage = current_stage(request)?;
+        if stage == BlockRequestStage::Stop {
+            return self.poll_block_stop(request, id, slot, phase);
+        }
+
+        match self.poll_fifo_data_step(request, cmd_index, phase) {
+            Ok(BlockPoll::Pending) => Ok(DataCommandPoll::Pending),
+            Ok(BlockPoll::Complete) => self.finish_fifo_data(request, id, slot),
+            // Future BlockPoll variants: best-effort, treat as still pending.
+            Ok(_) => Ok(DataCommandPoll::Pending),
+            Err(err) => {
+                self.abort_block_request(request, id, slot, phase);
+                Err(err)
+            }
+        }
+    }
+
+    fn poll_dma_request(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<DataCommandPoll, Error> {
+        let (cmd_index, phase, stage) = match request.as_ref().map(|request| &request.inner) {
+            Some(BlockRequestKind::DmaRead {
+                cmd_index,
+                phase,
+                stage,
+                ..
+            })
+            | Some(BlockRequestKind::DmaWrite {
+                cmd_index,
+                phase,
+                stage,
+                ..
+            }) => (*cmd_index, *phase, *stage),
+            _ => return Err(Error::InvalidArgument),
+        };
+
+        if stage == BlockRequestStage::Command {
+            match self.poll_command() {
+                Ok(CommandPoll::Pending) => return Ok(DataCommandPoll::Pending),
+                Ok(CommandPoll::Complete) => {
+                    let response = self.take_command_response()?;
+                    store_response(request, response)?;
+                    set_stage(request, BlockRequestStage::Data)?;
+                    return Ok(DataCommandPoll::Pending);
+                }
+                Ok(_) => return Ok(DataCommandPoll::Pending),
+                Err(err) => {
+                    self.abort_block_request(request, id, slot, phase);
+                    return Err(err);
+                }
+            }
+        }
+
+        let stage = current_stage(request)?;
+        if stage == BlockRequestStage::Stop {
+            return self.poll_block_stop(request, id, slot, phase);
+        }
+
+        match self.poll_dma_data_step(request, cmd_index, phase) {
+            Ok(BlockPoll::Pending) => Ok(DataCommandPoll::Pending),
+            Ok(BlockPoll::Complete) => self.finish_dma_data(request, id, slot),
+            Ok(_) => Ok(DataCommandPoll::Pending),
+            Err(err) => {
+                self.abort_block_request(request, id, slot, phase);
+                Err(err)
+            }
+        }
+    }
+
+    fn poll_dma_data_step(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        cmd_index: u8,
+        phase: Phase,
+    ) -> Result<BlockPoll, Error> {
+        let raw_idsts = self.take_idmac_status();
+        let ints = self.take_data_irq_status(cmd_index, phase)?;
+        let Some(active) = request.as_mut() else {
+            return Err(Error::InvalidArgument);
+        };
+        let (progress, is_read) = match &mut active.inner {
+            BlockRequestKind::DmaRead { progress, .. } => (progress, true),
+            BlockRequestKind::DmaWrite { progress, .. } => (progress, false),
+            _ => return Err(Error::InvalidArgument),
+        };
+
+        if raw_idsts & IDSTS_ERROR_MASK != 0 {
+            warn!(
+                "phytium-mci IDMAC error cmd={} idsts={:#010x} rintsts={:#010x} status={:#010x} \
+                 cur_desc={:#010x}_{:08x} cur_buf={:#010x}_{:08x}",
+                cmd_index,
+                raw_idsts,
+                self.regs.rintsts().read().into_bits(),
+                self.regs.status().read().into_bits(),
+                self.regs.dscaddrh().read(),
+                self.regs.dscaddrl().read(),
+                self.regs.bufaddrh().read(),
+                self.regs.bufaddrl().read(),
+            );
+            return Err(Error::BusError(sdmmc_protocol::ErrorContext::for_cmd(
+                phase, cmd_index,
+            )));
+        }
+        progress.idmac_done |= raw_idsts & (IDSTS_RECEIVE | IDSTS_TRANSMIT) != 0;
+        progress.data_done |= ints.data_transfer_over();
+        if !progress.data_done {
+            return Ok(BlockPoll::Pending);
+        }
+
+        if is_read {
+            progress.buffer.prepare_read_all();
+        }
+        progress.complete = true;
+        Ok(BlockPoll::Complete)
+    }
+
+    fn finish_dma_data(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<DataCommandPoll, Error> {
+        self.disable_idmac();
+        let stop_after_complete = match request.as_mut().map(|r| &mut r.inner) {
+            Some(BlockRequestKind::DmaRead {
+                stage,
+                stop_after_complete,
+                ..
+            })
+            | Some(BlockRequestKind::DmaWrite {
+                stage,
+                stop_after_complete,
+                ..
+            }) => {
+                *stage = BlockRequestStage::Stop;
+                *stop_after_complete
+            }
+            _ => return Err(Error::InvalidArgument),
+        };
+        if stop_after_complete {
+            self.submit_command(&CMD12)?;
+            return Ok(DataCommandPoll::Pending);
+        }
+
+        let active = request.take().ok_or(Error::InvalidArgument)?;
+        let response = active.response().ok_or(Error::InvalidArgument)?;
+        self.finish_block_request(active);
+        slot.complete(id)?;
+        Ok(DataCommandPoll::Complete(response))
+    }
+
+    fn poll_fifo_data_step(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        cmd_index: u8,
+        phase: Phase,
+    ) -> Result<BlockPoll, Error> {
+        let Some(active) = request.as_mut() else {
+            return Err(Error::InvalidArgument);
+        };
+        match &mut active.inner {
+            BlockRequestKind::FifoRead {
+                buffer,
+                len,
+                block_size,
+                progress,
+                ..
+            } => poll_fifo_read_step(self, *buffer, *len, *block_size, progress, cmd_index, phase),
+            BlockRequestKind::FifoWrite {
+                buffer,
+                len,
+                block_size,
+                progress,
+                ..
+            } => poll_fifo_write_step(self, *buffer, *len, *block_size, progress, cmd_index, phase),
+            _ => Err(Error::InvalidArgument),
+        }
+    }
+
+    fn finish_fifo_data(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+    ) -> Result<DataCommandPoll, Error> {
+        let stop_after_complete = match request.as_mut().map(|r| &mut r.inner) {
+            Some(BlockRequestKind::FifoRead {
+                stage,
+                stop_after_complete,
+                ..
+            })
+            | Some(BlockRequestKind::FifoWrite {
+                stage,
+                stop_after_complete,
+                ..
+            }) => {
+                *stage = BlockRequestStage::Stop;
+                *stop_after_complete
+            }
+            _ => return Err(Error::InvalidArgument),
+        };
+        if stop_after_complete {
+            self.submit_command(&CMD12)?;
+            return Ok(DataCommandPoll::Pending);
+        }
+
+        let active = request.take().ok_or(Error::InvalidArgument)?;
+        let response = active.response().ok_or(Error::InvalidArgument)?;
+        self.finish_block_request(active);
+        slot.complete(id)?;
+        Ok(DataCommandPoll::Complete(response))
+    }
+
+    fn poll_block_stop(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+        phase: Phase,
+    ) -> Result<DataCommandPoll, Error> {
+        match self.poll_command() {
+            Ok(CommandPoll::Pending) => Ok(DataCommandPoll::Pending),
+            Ok(CommandPoll::Complete) => {
+                let _ = self.take_command_response()?;
+                let active = request.take().ok_or(Error::InvalidArgument)?;
+                let response = active.response().ok_or(Error::InvalidArgument)?;
+                self.finish_block_request(active);
+                slot.complete(id)?;
+                Ok(DataCommandPoll::Complete(response))
+            }
+            // Future CommandPoll variants: best-effort, treat as still pending.
+            Ok(_) => Ok(DataCommandPoll::Pending),
+            Err(err) => {
+                self.abort_block_request(request, id, slot, phase);
+                Err(err)
+            }
+        }
+    }
+
+    fn finish_block_request(&mut self, request: BlockRequest) {
+        match &request.inner {
+            BlockRequestKind::DmaRead { progress, .. }
+            | BlockRequestKind::DmaWrite { progress, .. } => progress.keep_alive(),
+            _ => {}
+        }
+        self.pending_data = None;
+        self.data_blocks_remaining = 0;
+        self.data_cmd_index = 0;
+    }
+
+    fn abort_block_request(
+        &mut self,
+        request: &mut Option<BlockRequest>,
+        id: RequestId,
+        slot: &mut BlockRequestSlot,
+        phase: Phase,
+    ) {
+        if let Some(active) = request.take() {
+            self.finish_block_request(active);
+        }
+        self.disable_idmac();
+        let _ = self.reset_fifo(phase);
+        let _ = slot.complete(id);
+    }
+
+    fn start_idmac_transfer(
+        &mut self,
+        cmd: &Command,
+        block_size: u32,
+        block_count: u32,
+        desc_dma: u64,
+    ) -> Result<(), Error> {
+        self.clear_all_int_status();
+        self.regs.idsts().write(u32::MAX);
+        self.regs.idinten().write(IDSTS_INT_ENABLE_MASK);
+        self.reset_fifo(Phase::Init)?;
+        self.reset_dma(Phase::Init)?;
+        self.program_data_phase(block_size, block_count);
+        self.program_idmac_registers(desc_dma);
+        self.pending_data = Some(PendingData {
+            direction: if matches!(cmd.cmd, 24 | 25) {
+                DataDirection::Write
+            } else {
+                DataDirection::Read
+            },
+            block_size,
+            block_count,
+            use_idmac: true,
+        });
+        self.data_blocks_remaining = block_count;
+        self.submit_command(cmd)
+    }
+
+    fn program_idmac_registers(&self, desc_dma: u64) {
+        self.regs
+            .ctrl()
+            .update(|r| r.with_use_internal_dmac(true).with_int_enable(true));
+        self.regs
+            .bmod()
+            .write(self.regs.bmod().read() | BMOD_FIXED_BURST | BMOD_IDMAC_ENABLE);
+        self.regs.dbaddrl().write(desc_dma as u32);
+        self.regs.dbaddrh().write((desc_dma >> 32) as u32);
+    }
+
+    fn disable_idmac(&mut self) {
+        self.regs.idinten().write(0);
+        self.regs.bmod().write(0);
+        self.regs
+            .ctrl()
+            .update(|r| r.with_dma_enable(false).with_use_internal_dmac(false));
+    }
+
+    fn take_idmac_status(&mut self) -> u32 {
+        let raw = self.regs.idsts().read();
+        if raw != 0 {
+            self.regs.idsts().write(raw);
+        }
+        let status = self.idmac_pending_status | raw;
+        self.idmac_pending_status &= !(IDSTS_RECEIVE | IDSTS_TRANSMIT | IDSTS_ERROR_MASK);
+        status
+    }
+
+    fn take_data_irq_status(&mut self, cmd_index: u8, phase: Phase) -> Result<RIntSts, Error> {
+        let raw_status = self.regs.rintsts().read().into_bits();
+        let consume = raw_status
+            & (crate::MCI_INT_DATA_TRANSFER_OVER
+                | crate::MCI_INT_RXDR
+                | crate::MCI_INT_TXDR
+                | crate::MCI_INT_ERROR_MASK);
+        if consume != 0 {
+            self.regs.rintsts().write(RIntSts::from_bits(consume));
+        }
+        let status = self.irq_pending_status | raw_status;
+        self.irq_pending_status &= !(crate::MCI_INT_DATA_TRANSFER_OVER
+            | crate::MCI_INT_RXDR
+            | crate::MCI_INT_TXDR
+            | crate::MCI_INT_ERROR_MASK);
+        let ints = RIntSts::from_bits(status);
+        if ints.error() {
+            return Err(self.translate_int_error(ints, phase, cmd_index));
+        }
+        Ok(ints)
+    }
+}
+
+fn poll_fifo_read_step(
+    host: &mut PhytiumMci,
+    buffer: NonNull<u8>,
+    len: usize,
+    block_size: usize,
+    progress: &mut FifoProgress,
+    cmd_index: u8,
+    phase: Phase,
+) -> Result<BlockPoll, Error> {
+    let ints = host.take_data_irq_status(cmd_index, phase)?;
+    progress.transfer_done |= ints.data_transfer_over();
+    let mut available_words = host.regs.status().read().fifo_count() as usize;
+    let fifo = host.fifo_ptr();
+    while progress.offset < len && available_words > 0 {
+        let word = unsafe { fifo.read_volatile() };
+        let bytes = word.to_le_bytes();
+        let copy = (len - progress.offset).min(bytes.len());
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                buffer.as_ptr().add(progress.offset),
+                copy,
+            );
+        }
+        progress.offset += copy;
+        available_words -= 1;
+    }
+    if progress.offset >= len && progress.transfer_done {
+        return Ok(BlockPoll::Complete);
+    }
+    if block_size > 0 && (progress.offset / block_size) as u32 >= host.data_blocks_remaining {
+        return Ok(BlockPoll::Pending);
+    }
+    Ok(BlockPoll::Pending)
+}
+
+fn poll_fifo_write_step(
+    host: &mut PhytiumMci,
+    buffer: NonNull<u8>,
+    len: usize,
+    _block_size: usize,
+    progress: &mut FifoProgress,
+    cmd_index: u8,
+    phase: Phase,
+) -> Result<BlockPoll, Error> {
+    let ints = host.take_data_irq_status(cmd_index, phase)?;
+    progress.transfer_done |= ints.data_transfer_over();
+    let status = host.regs.status().read();
+    let depth = host.fifo_word_depth() as usize;
+    let used = status.fifo_count() as usize;
+    let mut free_words = depth.saturating_sub(used);
+    let fifo = host.fifo_ptr();
+    while progress.offset < len && free_words > 0 {
+        let mut bytes = [0u8; 4];
+        let copy = (len - progress.offset).min(bytes.len());
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                buffer.as_ptr().add(progress.offset),
+                bytes.as_mut_ptr(),
+                copy,
+            );
+        }
+        unsafe { fifo.write_volatile(u32::from_le_bytes(bytes)) };
+        progress.offset += copy;
+        free_words -= 1;
+    }
+    if progress.offset >= len && progress.transfer_done {
+        return Ok(BlockPoll::Complete);
+    }
+    Ok(BlockPoll::Pending)
+}
+
+fn store_response(request: &mut Option<BlockRequest>, response: Response) -> Result<(), Error> {
+    match request.as_mut().map(|r| &mut r.inner) {
+        Some(BlockRequestKind::FifoRead {
+            response: stored, ..
+        })
+        | Some(BlockRequestKind::FifoWrite {
+            response: stored, ..
+        })
+        | Some(BlockRequestKind::DmaRead {
+            response: stored, ..
+        })
+        | Some(BlockRequestKind::DmaWrite {
+            response: stored, ..
+        }) => {
+            *stored = Some(response);
+            Ok(())
+        }
+        None => Err(Error::InvalidArgument),
+    }
+}
+
+fn set_stage(request: &mut Option<BlockRequest>, next: BlockRequestStage) -> Result<(), Error> {
+    match request.as_mut().map(|r| &mut r.inner) {
+        Some(BlockRequestKind::FifoRead { stage, .. })
+        | Some(BlockRequestKind::FifoWrite { stage, .. })
+        | Some(BlockRequestKind::DmaRead { stage, .. })
+        | Some(BlockRequestKind::DmaWrite { stage, .. }) => {
+            *stage = next;
+            Ok(())
+        }
+        None => Err(Error::InvalidArgument),
+    }
+}
+
+fn current_stage(request: &Option<BlockRequest>) -> Result<BlockRequestStage, Error> {
+    match request.as_ref().map(|r| &r.inner) {
+        Some(BlockRequestKind::FifoRead { stage, .. })
+        | Some(BlockRequestKind::FifoWrite { stage, .. })
+        | Some(BlockRequestKind::DmaRead { stage, .. })
+        | Some(BlockRequestKind::DmaWrite { stage, .. }) => Ok(*stage),
+        None => Err(Error::InvalidArgument),
+    }
+}
+
+fn block_count(size: NonZeroUsize) -> Result<u32, Error> {
+    if !size.get().is_multiple_of(BLOCK_SIZE) {
+        return Err(Error::InvalidArgument);
+    }
+    u32::try_from(size.get() / BLOCK_SIZE).map_err(|_| Error::InvalidArgument)
+}
+
+fn build_idmac_descriptors(
+    buffer_dma: u64,
+    desc_dma: u64,
+    len: usize,
+    max_segment: usize,
+) -> Result<alloc::vec::Vec<IdmacDesc>, Error> {
+    if len == 0 || max_segment == 0 {
+        return Err(Error::InvalidArgument);
+    }
+    if !buffer_dma.is_multiple_of(BLOCK_SIZE as u64) {
+        return Err(Error::Misaligned);
+    }
+    let desc_count = len.div_ceil(max_segment);
+    let mut descriptors = alloc::vec::Vec::with_capacity(desc_count);
+    for index in 0..desc_count {
+        let offset = index * max_segment;
+        let chunk_len = (len - offset).min(max_segment);
+        let is_first = index == 0;
+        let is_last = index + 1 == desc_count;
+        let buffer_addr = buffer_dma + offset as u64;
+        let next_desc = if is_last {
+            0
+        } else {
+            desc_dma + ((index + 1) * core::mem::size_of::<IdmacDesc>()) as u64
+        };
+        if next_desc != 0 && !next_desc.is_multiple_of(core::mem::size_of::<IdmacDesc>() as u64) {
+            return Err(Error::Misaligned);
+        }
+        let mut attribute = IDMAC_DESC_OWN | IDMAC_DESC_CHAIN;
+        if is_first {
+            attribute |= IDMAC_DESC_FIRST;
+        }
+        if is_last {
+            attribute |= IDMAC_DESC_LAST | IDMAC_DESC_END_RING;
+        }
+        descriptors.push(IdmacDesc {
+            attribute,
+            reserved0: 0,
+            len: u32::try_from(chunk_len).map_err(|_| Error::InvalidArgument)?,
+            reserved1: 0,
+            addr_lo: buffer_addr as u32,
+            addr_hi: (buffer_addr >> 32) as u32,
+            desc_lo: next_desc as u32,
+            desc_hi: (next_desc >> 32) as u32,
+        });
+    }
+    Ok(descriptors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idmac_descriptor_builder_marks_single_descriptor_chain() {
+        let descriptors = build_idmac_descriptors(0x1_2345_6000, 0x8000_0000, 4096, 4096).unwrap();
+
+        assert_eq!(descriptors.len(), 1);
+        assert_eq!(
+            descriptors[0].attribute,
+            IDMAC_DESC_OWN
+                | IDMAC_DESC_CHAIN
+                | IDMAC_DESC_FIRST
+                | IDMAC_DESC_LAST
+                | IDMAC_DESC_END_RING
+        );
+        assert_eq!(descriptors[0].len, 4096);
+        assert_eq!(descriptors[0].addr_lo, 0x2345_6000);
+        assert_eq!(descriptors[0].addr_hi, 0x0000_0001);
+        assert_eq!(descriptors[0].desc_lo, 0);
+        assert_eq!(descriptors[0].desc_hi, 0);
+    }
+
+    #[test]
+    fn idmac_descriptor_builder_chains_multiple_descriptors() {
+        let descriptors =
+            build_idmac_descriptors(0x4000_0000, 0x8000_0000, 0x3000, 0x1000).unwrap();
+
+        assert_eq!(descriptors.len(), 3);
+        assert_eq!(
+            descriptors[0].attribute,
+            IDMAC_DESC_OWN | IDMAC_DESC_CHAIN | IDMAC_DESC_FIRST
+        );
+        assert_eq!(
+            descriptors[0].desc_lo,
+            0x8000_0000 + core::mem::size_of::<IdmacDesc>() as u32
+        );
+        assert_eq!(descriptors[1].attribute, IDMAC_DESC_OWN | IDMAC_DESC_CHAIN);
+        assert_eq!(
+            descriptors[2].attribute,
+            IDMAC_DESC_OWN | IDMAC_DESC_CHAIN | IDMAC_DESC_LAST | IDMAC_DESC_END_RING
+        );
+        assert_eq!(descriptors[2].desc_lo, 0);
+    }
+
+    use core::ptr::NonNull;
+
+    use ::alloc::{alloc, boxed::Box};
+    use sdmmc_protocol::block::BlockPoll;
+
+    use crate::regs::{RIntSts, Status};
+
+    #[repr(align(512))]
+    struct AlignedBlock([u8; BLOCK_SIZE]);
+
+    struct NoopDmaBuffer;
+
+    impl NoopDmaBuffer {
+        fn progress() -> DmaProgress {
+            let dma = DeviceDma::new(u64::MAX, &TEST_DMA);
+            let descriptors = dma
+                .array_zero_with_align::<IdmacDesc>(1, IDMAC_DESC_ALIGN, DmaDirection::ToDevice)
+                .unwrap();
+            let backing = Box::leak(Box::new(AlignedBlock([0u8; BLOCK_SIZE])));
+            let buffer = dma
+                .map_single_array(&backing.0, BLOCK_SIZE, DmaDirection::FromDevice)
+                .unwrap();
+            DmaProgress {
+                descriptors,
+                buffer,
+                desc_count: 1,
+                complete: false,
+                idmac_done: false,
+                data_done: false,
+            }
+        }
+    }
+
+    struct TestDma;
+    static TEST_DMA: TestDma = TestDma;
+
+    impl dma_api::DmaOp for TestDma {
+        unsafe fn alloc_coherent(
+            &self,
+            _dma_mask: u64,
+            layout: core::alloc::Layout,
+        ) -> Option<dma_api::DmaHandle> {
+            let ptr = unsafe { alloc::alloc_zeroed(layout) };
+            let ptr = NonNull::new(ptr)?;
+            Some(unsafe { dma_api::DmaHandle::new(ptr, (ptr.as_ptr() as u64).into(), layout) })
+        }
+
+        unsafe fn dealloc_coherent(&self, handle: dma_api::DmaHandle) {
+            unsafe { alloc::dealloc(handle.as_ptr().as_ptr(), handle.layout()) };
+        }
+
+        unsafe fn map_single(
+            &self,
+            _dma_mask: u64,
+            addr: NonNull<u8>,
+            size: NonZeroUsize,
+            align: usize,
+            _direction: DmaDirection,
+        ) -> Result<dma_api::DmaMapHandle, dma_api::DmaError> {
+            let layout = core::alloc::Layout::from_size_align(size.get(), align).unwrap();
+            Ok(unsafe {
+                dma_api::DmaMapHandle::new(addr, (addr.as_ptr() as u64).into(), layout, None)
+            })
+        }
+
+        unsafe fn unmap_single(&self, _handle: dma_api::DmaMapHandle) {}
+
+        fn flush(&self, _addr: NonNull<u8>, _size: usize) {}
+        fn invalidate(&self, _addr: NonNull<u8>, _size: usize) {}
+        fn flush_invalidate(&self, _addr: NonNull<u8>, _size: usize) {}
+        fn page_size(&self) -> usize {
+            4096
+        }
+    }
+
+    const RINTSTS_WORD: usize = 17;
+    const STATUS_WORD: usize = 18;
+    const BMOD_WORD: usize = 32;
+    const PLDMND_WORD: usize = 33;
+    const DBADDRL_WORD: usize = 34;
+    const IDSTS_WORD: usize = 36;
+    const FIFO_WORD: usize = crate::host::DEFAULT_FIFO_OFFSET / core::mem::size_of::<u32>();
+
+    fn host_from_words(words: &mut [u32; 256]) -> PhytiumMci {
+        let base = NonNull::new(words.as_mut_ptr().cast()).unwrap();
+        unsafe { PhytiumMci::new(base) }
+    }
+
+    #[test]
+    fn idmac_start_preserves_bus_mode_and_enables_fixed_burst() {
+        let mut mmio = [0u32; 256];
+        mmio[BMOD_WORD] = 0x200;
+        let host = host_from_words(&mut mmio);
+
+        host.program_idmac_registers(0x1_8000_0000);
+
+        assert_eq!(
+            mmio[BMOD_WORD],
+            0x200 | BMOD_FIXED_BURST | BMOD_IDMAC_ENABLE
+        );
+        assert_eq!(mmio[PLDMND_WORD], 0);
+        assert_eq!(mmio[DBADDRL_WORD], 0x8000_0000);
+        assert_eq!(mmio[DBADDRL_WORD + 1], 1);
+    }
+
+    #[test]
+    fn idmac_read_completes_when_data_done_arrives_without_idmac_done() {
+        let mut mmio = [0u32; 256];
+        let mut host = host_from_words(&mut mmio);
+        let mut request = Some(BlockRequest {
+            inner: BlockRequestKind::DmaRead {
+                id: RequestId::new(3),
+                progress: NoopDmaBuffer::progress(),
+                cmd_index: 17,
+                phase: Phase::DataRead,
+                stage: BlockRequestStage::Data,
+                stop_after_complete: false,
+                response: Some(Response::Empty),
+            },
+        });
+
+        unsafe {
+            mmio.as_mut_ptr()
+                .add(RINTSTS_WORD)
+                .write_volatile(RIntSts::new().with_data_transfer_over(true).into_bits())
+        };
+
+        assert_eq!(
+            host.poll_dma_data_step(&mut request, 17, Phase::DataRead)
+                .unwrap(),
+            BlockPoll::Complete
+        );
+    }
+
+    #[test]
+    fn idmac_read_completes_when_idmac_and_data_done_arrive_separately() {
+        let mut mmio = [0u32; 256];
+        let mut host = host_from_words(&mut mmio);
+        let mut request = Some(BlockRequest {
+            inner: BlockRequestKind::DmaRead {
+                id: RequestId::new(2),
+                progress: NoopDmaBuffer::progress(),
+                cmd_index: 17,
+                phase: Phase::DataRead,
+                stage: BlockRequestStage::Data,
+                stop_after_complete: false,
+                response: Some(Response::Empty),
+            },
+        });
+
+        unsafe {
+            mmio.as_mut_ptr()
+                .add(IDSTS_WORD)
+                .write_volatile(IDSTS_RECEIVE)
+        };
+        assert_eq!(
+            host.poll_dma_data_step(&mut request, 17, Phase::DataRead)
+                .unwrap(),
+            BlockPoll::Pending
+        );
+
+        unsafe {
+            mmio.as_mut_ptr()
+                .add(RINTSTS_WORD)
+                .write_volatile(RIntSts::new().with_data_transfer_over(true).into_bits())
+        };
+        assert_eq!(
+            host.poll_dma_data_step(&mut request, 17, Phase::DataRead)
+                .unwrap(),
+            BlockPoll::Complete
+        );
+    }
+
+    #[test]
+    fn fifo_read_completes_when_dto_arrives_before_fifo_is_drained() {
+        let mut mmio = [0u32; 256];
+        let mut host = host_from_words(&mut mmio);
+        let mut buffer = [0u8; 512];
+        let mut request = Some(BlockRequest {
+            inner: BlockRequestKind::FifoRead {
+                id: RequestId::new(1),
+                buffer: NonNull::new(buffer.as_mut_ptr()).unwrap(),
+                len: buffer.len(),
+                block_size: BLOCK_SIZE,
+                progress: FifoProgress::default(),
+                cmd_index: 17,
+                phase: Phase::DataRead,
+                stage: BlockRequestStage::Data,
+                stop_after_complete: false,
+                response: None,
+            },
+        });
+
+        for index in 0..128 {
+            mmio[FIFO_WORD + index] = index as u32;
+        }
+
+        unsafe {
+            mmio.as_mut_ptr()
+                .add(RINTSTS_WORD)
+                .write_volatile(RIntSts::new().with_data_transfer_over(true).into_bits());
+            mmio.as_mut_ptr()
+                .add(STATUS_WORD)
+                .write_volatile(Status::new().with_fifo_count(64).into_bits());
+        }
+        assert_eq!(
+            host.poll_fifo_data_step(&mut request, 17, Phase::DataRead),
+            Ok(BlockPoll::Pending)
+        );
+
+        unsafe {
+            mmio.as_mut_ptr().add(RINTSTS_WORD).write_volatile(0);
+            mmio.as_mut_ptr()
+                .add(STATUS_WORD)
+                .write_volatile(Status::new().with_fifo_count(64).into_bits());
+        }
+        assert_eq!(
+            host.poll_fifo_data_step(&mut request, 17, Phase::DataRead),
+            Ok(BlockPoll::Complete)
+        );
+    }
+}

--- a/drivers/blk/phytium-mci-host/src/host.rs
+++ b/drivers/blk/phytium-mci-host/src/host.rs
@@ -1,0 +1,393 @@
+use core::{ptr::NonNull, sync::atomic};
+
+use mmio_api::MmioRaw;
+use sdmmc_protocol::{
+    error::{Error, ErrorContext, Phase},
+    sdio::{BusWidth, SignalVoltage},
+};
+use volatile::VolatilePtr;
+
+use crate::{
+    Event,
+    command::CommandState,
+    regs::{
+        CARD_THRCTL_OFFSET, CLK_SRC_OFFSET, CType, ClkEna, ClockSource, Cmd, RIntSts,
+        RegisterBlock, RegisterBlockVolatileFieldAccess, Uhs,
+    },
+    timing::TimingTable,
+};
+
+pub const DEFAULT_FIFO_OFFSET: usize = 0x200;
+const DEFAULT_FIFO_WORD_DEPTH: u32 = 128;
+const FIFO_THRESHOLD: u32 = (2 << 28) | (7 << 16) | 0x100;
+const CARD_READ_THRESHOLD_ENABLE: u32 = 1;
+const CARD_READ_THRESHOLD_DEPTH8: u32 = 1 << 23;
+const BMOD_SOFTWARE_RESET: u32 = 1;
+const RESET_POLL_LIMIT: usize = 1_000_000;
+const CLOCK_POLL_LIMIT: usize = 1_000_000;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PendingData {
+    pub direction: sdmmc_protocol::DataDirection,
+    pub block_size: u32,
+    pub block_count: u32,
+    pub use_idmac: bool,
+}
+
+pub struct PhytiumMci {
+    pub(crate) regs: VolatilePtr<'static, RegisterBlock>,
+    pub(crate) base_addr: usize,
+    pub(crate) fifo_offset: usize,
+    pub(crate) command_state: CommandState,
+    pub(crate) pending_data: Option<PendingData>,
+    pub(crate) data_cmd_index: u8,
+    pub(crate) data_blocks_remaining: u32,
+    pub(crate) use_hold_reg: bool,
+    pub(crate) irq_pending_status: u32,
+    pub(crate) idmac_pending_status: u32,
+    completion_irq_enabled: bool,
+}
+
+impl PhytiumMci {
+    pub unsafe fn new(base: NonNull<u8>) -> Self {
+        unsafe { Self::new_with_fifo_offset(base, DEFAULT_FIFO_OFFSET) }
+    }
+
+    pub unsafe fn new_with_fifo_offset(base: NonNull<u8>, fifo_offset: usize) -> Self {
+        let regs = unsafe { VolatilePtr::new(base.cast()) };
+        Self {
+            regs,
+            base_addr: base.as_ptr() as usize,
+            fifo_offset,
+            command_state: CommandState::Idle,
+            pending_data: None,
+            data_cmd_index: 0,
+            data_blocks_remaining: 0,
+            use_hold_reg: true,
+            irq_pending_status: 0,
+            idmac_pending_status: 0,
+            completion_irq_enabled: false,
+        }
+    }
+
+    pub unsafe fn new_from_mmio_raw(mmio: &MmioRaw) -> Self {
+        unsafe { Self::new(mmio.as_nonnull_ptr()) }
+    }
+
+    pub unsafe fn new_from_addr(base_addr: usize) -> Self {
+        let base = NonNull::new(base_addr as *mut u8).expect("MMIO base address must be non-null");
+        unsafe { Self::new(base) }
+    }
+
+    pub fn reset_and_init(&mut self) -> Result<(), Error> {
+        self.regs.clkena().write(ClkEna::new());
+        self.regs.ctrl().update(|r| {
+            r.with_use_internal_dmac(false)
+                .with_dma_enable(false)
+                .with_int_enable(false)
+        });
+        self.regs.ctrl().update(|r| {
+            r.with_controller_reset(true)
+                .with_fifo_reset(true)
+                .with_dma_reset(true)
+        });
+        self.wait_reset_clear(Phase::Init)?;
+
+        self.regs.intmask().write(0);
+        self.regs.idinten().write(0);
+        self.clear_all_int_status();
+        self.regs.idsts().write(u32::MAX);
+        self.irq_pending_status = 0;
+        self.idmac_pending_status = 0;
+        self.completion_irq_enabled = false;
+
+        self.regs.ctype().write(CType::new());
+        self.regs.uhs().write(Uhs::new());
+        self.regs.tmout().write(0xffff_ffff);
+        self.regs.pwren().write(1);
+        self.regs.fifoth().write(FIFO_THRESHOLD);
+        self.write_ext_reg(
+            CARD_THRCTL_OFFSET,
+            CARD_READ_THRESHOLD_ENABLE | CARD_READ_THRESHOLD_DEPTH8,
+        );
+
+        self.program_timing(TimingTable::sd_for_speed(
+            sdmmc_protocol::sdio::ClockSpeed::Identification,
+        )?)?;
+        Ok(())
+    }
+
+    pub fn program_timing(&mut self, timing: TimingTable) -> Result<(), Error> {
+        self.use_hold_reg = timing.use_hold;
+        self.update_external_clock(timing.clk_src)?;
+        self.set_card_clock(false)?;
+        self.send_update_clock(false)?;
+        self.regs.clkdiv().write(timing.clk_div);
+        self.set_card_clock(true)?;
+        self.send_update_clock(false)?;
+        Ok(())
+    }
+
+    fn update_external_clock(&self, raw: u32) -> Result<(), Error> {
+        self.write_ext_reg(CLK_SRC_OFFSET, 0);
+        self.write_ext_reg(CLK_SRC_OFFSET, raw);
+        for _ in 0..CLOCK_POLL_LIMIT {
+            if self.regs.cksts().read().ready() {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(Error::Timeout(ErrorContext::new(Phase::Init)))
+    }
+
+    fn set_card_clock(&self, enable: bool) -> Result<(), Error> {
+        let value = if enable {
+            ClkEna::new().with_cclk_enable(1)
+        } else {
+            ClkEna::new()
+        };
+        self.regs.clkena().write(value);
+        Ok(())
+    }
+
+    pub(crate) fn send_update_clock(&self, voltage_switch: bool) -> Result<(), Error> {
+        self.regs.cmd().write(
+            Cmd::new()
+                .with_start_cmd(true)
+                .with_wait_prvdata_complete(true)
+                .with_update_clock_registers_only(true)
+                .with_volt_switch(voltage_switch),
+        );
+        for _ in 0..CLOCK_POLL_LIMIT {
+            if !self.regs.cmd().read().start_cmd() {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(Error::Timeout(ErrorContext::new(Phase::Init)))
+    }
+
+    fn wait_reset_clear(&self, phase: Phase) -> Result<(), Error> {
+        for _ in 0..RESET_POLL_LIMIT {
+            let c = self.regs.ctrl().read();
+            if !c.controller_reset() && !c.fifo_reset() && !c.dma_reset() {
+                self.send_update_clock(false)?;
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(Error::Timeout(ErrorContext::new(phase)))
+    }
+
+    pub(crate) fn clear_all_int_status(&self) {
+        let cur = self.regs.rintsts().read();
+        self.regs.rintsts().write(cur);
+    }
+
+    pub fn enable_completion_irq(&mut self) {
+        self.completion_irq_enabled = true;
+        self.regs.intmask().write(
+            crate::MCI_INT_COMMAND_DONE
+                | crate::MCI_INT_DATA_TRANSFER_OVER
+                | crate::MCI_INT_RXDR
+                | crate::MCI_INT_TXDR
+                | crate::MCI_INT_ERROR_MASK,
+        );
+        self.regs.ctrl().update(|r| r.with_int_enable(true));
+    }
+
+    pub fn disable_completion_irq(&mut self) {
+        self.completion_irq_enabled = false;
+        self.regs.intmask().write(0);
+        self.regs.ctrl().update(|r| r.with_int_enable(false));
+    }
+
+    pub fn completion_irq_enabled(&self) -> bool {
+        self.completion_irq_enabled
+    }
+
+    pub fn handle_irq(&mut self) -> Event {
+        let raw = self.regs.rintsts().read().into_bits();
+        let idsts = self.regs.idsts().read();
+        if raw != 0 {
+            self.regs.rintsts().write(RIntSts::from_bits(raw));
+            self.irq_pending_status |= raw;
+        }
+        if idsts != 0 {
+            self.regs.idsts().write(idsts);
+            self.idmac_pending_status |= idsts;
+        }
+
+        if raw & crate::MCI_INT_ERROR_MASK != 0 {
+            Event::Error { raw_status: raw }
+        } else if idsts & crate::MCI_IDSTS_ERROR_MASK != 0 {
+            Event::Error { raw_status: idsts }
+        } else if raw & crate::MCI_INT_DATA_TRANSFER_OVER != 0
+            || idsts & (crate::MCI_IDSTS_RECEIVE | crate::MCI_IDSTS_TRANSMIT) != 0
+        {
+            Event::TransferComplete
+        } else if raw & crate::MCI_INT_COMMAND_DONE != 0 {
+            Event::CommandComplete
+        } else if raw & crate::MCI_INT_RXDR != 0 {
+            Event::ReceiveReady
+        } else if raw & crate::MCI_INT_TXDR != 0 {
+            Event::TransmitReady
+        } else if raw != 0 || idsts != 0 {
+            Event::Other {
+                raw_status: raw | idsts,
+            }
+        } else {
+            Event::None
+        }
+    }
+
+    pub(crate) fn set_bus_width(&mut self, width: BusWidth) {
+        let ctype = match width {
+            BusWidth::Bit1 => CType::new(),
+            BusWidth::Bit4 => CType::new().with_width4(1),
+            BusWidth::Bit8 => CType::new().with_width8(1),
+            // Future BusWidth variants: fall back to 1-bit (no width bits set).
+            _ => CType::new(),
+        };
+        self.regs.ctype().write(ctype);
+    }
+
+    pub(crate) fn set_signal_voltage(&mut self, voltage: SignalVoltage) -> Result<(), Error> {
+        let cur = self.regs.uhs().read();
+        let next = uhs_bits_after_voltage(cur, voltage)?;
+        self.regs.uhs().write(next);
+        self.send_update_clock(matches!(voltage, SignalVoltage::V180))?;
+        Ok(())
+    }
+
+    pub(crate) fn program_data_phase(&self, block_size: u32, block_count: u32) {
+        self.regs.blksiz().write(block_size);
+        self.regs.bytcnt().write(block_size * block_count);
+    }
+
+    pub(crate) fn reset_fifo(&self, phase: Phase) -> Result<(), Error> {
+        self.regs.ctrl().update(|r| r.with_fifo_reset(true));
+        for _ in 0..RESET_POLL_LIMIT {
+            if !self.regs.ctrl().read().fifo_reset() {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(Error::Timeout(ErrorContext::new(phase)))
+    }
+
+    pub(crate) fn reset_dma(&self, phase: Phase) -> Result<(), Error> {
+        self.regs.ctrl().update(|r| r.with_dma_reset(true));
+        for _ in 0..RESET_POLL_LIMIT {
+            if !self.regs.ctrl().read().dma_reset() {
+                self.regs.bmod().write(BMOD_SOFTWARE_RESET);
+                for _ in 0..RESET_POLL_LIMIT {
+                    if self.regs.bmod().read() & BMOD_SOFTWARE_RESET == 0 {
+                        return Ok(());
+                    }
+                    core::hint::spin_loop();
+                }
+                break;
+            }
+            core::hint::spin_loop();
+        }
+        Err(Error::Timeout(ErrorContext::new(phase)))
+    }
+
+    pub(crate) fn translate_int_error(&self, ints: RIntSts, phase: Phase, cmd_index: u8) -> Error {
+        let ctx = ErrorContext::for_cmd(phase, cmd_index);
+        if ints.response_timeout() || ints.data_read_timeout() || ints.host_timeout() {
+            Error::Timeout(ctx)
+        } else if ints.response_crc_error() || ints.data_crc_error() {
+            Error::Crc(ctx)
+        } else if ints.response_error() {
+            Error::BadResponse(ctx)
+        } else if matches!(phase, Phase::DataRead) {
+            Error::ReadError(ctx)
+        } else if matches!(phase, Phase::DataWrite) {
+            Error::WriteError(ctx)
+        } else {
+            Error::BusError(ctx)
+        }
+    }
+
+    pub(crate) fn fifo_word_depth(&self) -> u32 {
+        DEFAULT_FIFO_WORD_DEPTH
+    }
+
+    pub(crate) fn fifo_ptr(&self) -> *mut u32 {
+        (self.base_addr + self.fifo_offset) as *mut u32
+    }
+
+    fn write_ext_reg(&self, offset: usize, value: u32) {
+        let ptr = (self.base_addr + offset) as *mut u32;
+        unsafe {
+            ptr.write_volatile(value);
+        }
+        atomic::fence(atomic::Ordering::SeqCst);
+    }
+
+    pub(crate) fn read_clock_source_raw(&self) -> u32 {
+        let ptr = (self.base_addr + CLK_SRC_OFFSET) as *const u32;
+        unsafe { ptr.read_volatile() }
+    }
+
+    #[allow(dead_code)]
+    fn read_clock_source(&self) -> ClockSource {
+        ClockSource::from_bits(self.read_clock_source_raw())
+    }
+}
+
+pub(crate) fn uhs_bits_after_voltage(bits: Uhs, voltage: SignalVoltage) -> Result<Uhs, Error> {
+    match voltage {
+        SignalVoltage::V330 => Ok(bits.with_volt(0)),
+        SignalVoltage::V180 => Ok(bits.with_volt(1)),
+        SignalVoltage::V120 => Err(Error::UnsupportedCommand),
+        // Future SignalVoltage variants are not supported by this controller.
+        _ => Err(Error::UnsupportedCommand),
+    }
+}
+
+unsafe impl Send for PhytiumMci {}
+unsafe impl Sync for PhytiumMci {}
+
+#[cfg(test)]
+mod tests {
+    use core::ptr::NonNull;
+
+    use super::*;
+
+    #[test]
+    fn constructs_from_mapped_mmio_pointer() {
+        let base = NonNull::new(0x2800_0000 as *mut u8).unwrap();
+        let host = unsafe { PhytiumMci::new(base) };
+
+        assert_eq!(host.base_addr, 0x2800_0000);
+        assert_eq!(host.fifo_offset, DEFAULT_FIFO_OFFSET);
+    }
+
+    #[test]
+    fn explicit_fifo_offset_is_kept() {
+        let base = NonNull::new(0x2800_0000 as *mut u8).unwrap();
+        let host = unsafe { PhytiumMci::new_with_fifo_offset(base, 0x400) };
+
+        assert_eq!(host.fifo_offset, 0x400);
+    }
+
+    #[test]
+    fn handle_irq_wakes_on_idmac_receive_done() {
+        let mut mmio = [0u32; 256];
+        let base = NonNull::new(mmio.as_mut_ptr().cast()).unwrap();
+        let mut host = unsafe { PhytiumMci::new(base) };
+        const IDSTS_WORD: usize = 36;
+        const IDSTS_RECEIVE: u32 = 1 << 1;
+
+        unsafe {
+            mmio.as_mut_ptr()
+                .add(IDSTS_WORD)
+                .write_volatile(IDSTS_RECEIVE)
+        };
+
+        assert_eq!(host.handle_irq(), crate::Event::TransferComplete);
+    }
+}

--- a/drivers/blk/phytium-mci-host/src/lib.rs
+++ b/drivers/blk/phytium-mci-host/src/lib.rs
@@ -1,0 +1,328 @@
+//! Phytium MCI/FSDIF host controller backend for `sdmmc-protocol`.
+//!
+//! The register layout is the Phytium Memory Card Interface found on E2000
+//! class SoCs. It is close to the DesignWare MSHC programming model, with
+//! Phytium-specific clock-source and timing registers.
+//!
+//! # Scope
+//!
+//! - **Implemented**: controller/FIFO reset, power and clock setup, Phytium
+//!   timing tables, 1-bit / 4-bit / 8-bit bus selection, command response
+//!   decoding, FIFO block transfers, and stable IRQ event extraction.
+//! - **Out of scope for this crate**: FDT/ACPI probe, MMIO remapping, IRQ
+//!   registration, pad-controller programming, OS sleeps/wakeups, and rd-block
+//!   registration.
+//! - **Implemented for block I/O**: IDMAC descriptor setup, DMA buffer mapping,
+//!   DMA block read/write polling, and FIFO fallback at the platform adapter.
+
+#![no_std]
+#![allow(clippy::missing_safety_doc)]
+
+extern crate alloc;
+
+use core::{marker::PhantomData, ptr::NonNull};
+
+mod command;
+mod dma;
+mod host;
+mod regs;
+mod timing;
+
+pub use dma::{BlockRequest, BlockRequestSlot, RequestId};
+pub use host::{DEFAULT_FIFO_OFFSET, PhytiumMci};
+pub use sdmmc_protocol::block::{
+    BlockBufferConfig, BlockPoll, BlockRequestId, BlockTransferDirection, BlockTransferMode,
+    BlockTransferState,
+};
+use sdmmc_protocol::{
+    DataCommandPoll,
+    cmd::{Command, DataDirection},
+    error::Error,
+    sdio::{
+        BusWidth, ClockSpeed, HostEvent, HostEventKind, HostEventSource, SdioHost, SignalVoltage,
+    },
+};
+
+/// Stable controller event extracted from Phytium MCI raw interrupt status.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Event {
+    /// No status bit requiring runtime action is currently pending.
+    #[default]
+    None,
+    /// A command response has completed.
+    CommandComplete,
+    /// A data transfer has completed.
+    TransferComplete,
+    /// Receive FIFO can be drained.
+    ReceiveReady,
+    /// Transmit FIFO can accept more data.
+    TransmitReady,
+    /// One or more controller error bits are pending.
+    Error { raw_status: u32 },
+    /// Status bits are pending but do not map to a high-level event yet.
+    Other { raw_status: u32 },
+}
+
+impl HostEvent for Event {
+    fn kind(&self) -> HostEventKind {
+        match self {
+            Event::None => HostEventKind::None,
+            Event::CommandComplete => HostEventKind::CommandComplete,
+            Event::TransferComplete => HostEventKind::TransferComplete,
+            Event::ReceiveReady => HostEventKind::ReceiveReady,
+            Event::TransmitReady => HostEventKind::TransmitReady,
+            Event::Error { .. } => HostEventKind::Error,
+            Event::Other { .. } => HostEventKind::Other,
+        }
+    }
+
+    fn source(&self) -> HostEventSource {
+        match self {
+            Event::CommandComplete => HostEventSource::Command,
+            Event::TransferComplete | Event::ReceiveReady | Event::TransmitReady => {
+                HostEventSource::Data
+            }
+            Event::None | Event::Error { .. } | Event::Other { .. } => HostEventSource::Controller,
+        }
+    }
+}
+
+pub(crate) const MCI_INT_RESPONSE_ERROR: u32 = 1 << 1;
+pub(crate) const MCI_INT_COMMAND_DONE: u32 = 1 << 2;
+pub(crate) const MCI_INT_DATA_TRANSFER_OVER: u32 = 1 << 3;
+pub(crate) const MCI_INT_TXDR: u32 = 1 << 4;
+pub(crate) const MCI_INT_RXDR: u32 = 1 << 5;
+pub(crate) const MCI_INT_RESPONSE_CRC_ERROR: u32 = 1 << 6;
+pub(crate) const MCI_INT_DATA_CRC_ERROR: u32 = 1 << 7;
+pub(crate) const MCI_INT_RESPONSE_TIMEOUT: u32 = 1 << 8;
+pub(crate) const MCI_INT_DATA_READ_TIMEOUT: u32 = 1 << 9;
+pub(crate) const MCI_INT_HOST_TIMEOUT: u32 = 1 << 10;
+pub(crate) const MCI_INT_FIFO_UNDER_OVER_RUN: u32 = 1 << 11;
+pub(crate) const MCI_INT_HARDWARE_LOCKED_WRITE: u32 = 1 << 12;
+pub(crate) const MCI_INT_START_BIT_ERROR: u32 = 1 << 13;
+pub(crate) const MCI_INT_END_BIT_ERROR: u32 = 1 << 15;
+pub(crate) const MCI_INT_ERROR_MASK: u32 = MCI_INT_RESPONSE_ERROR
+    | MCI_INT_RESPONSE_CRC_ERROR
+    | MCI_INT_DATA_CRC_ERROR
+    | MCI_INT_RESPONSE_TIMEOUT
+    | MCI_INT_DATA_READ_TIMEOUT
+    | MCI_INT_HOST_TIMEOUT
+    | MCI_INT_FIFO_UNDER_OVER_RUN
+    | MCI_INT_HARDWARE_LOCKED_WRITE
+    | MCI_INT_START_BIT_ERROR
+    | MCI_INT_END_BIT_ERROR;
+
+pub(crate) const MCI_IDSTS_TRANSMIT: u32 = 1 << 0;
+pub(crate) const MCI_IDSTS_RECEIVE: u32 = 1 << 1;
+pub(crate) const MCI_IDSTS_FATAL_BUS_ERROR: u32 = 1 << 2;
+pub(crate) const MCI_IDSTS_DESCRIPTOR_UNAVAILABLE: u32 = (1 << 3) | (1 << 4);
+pub(crate) const MCI_IDSTS_CARD_ERROR_SUMMARY: u32 = 1 << 5;
+pub(crate) const MCI_IDSTS_ERROR_MASK: u32 =
+    MCI_IDSTS_FATAL_BUS_ERROR | MCI_IDSTS_DESCRIPTOR_UNAVAILABLE | MCI_IDSTS_CARD_ERROR_SUMMARY;
+
+pub struct DataRequest<'a> {
+    id: RequestId,
+    request: Option<BlockRequest>,
+    slot: BlockRequestSlot,
+    _buffer: PhantomData<&'a [u8]>,
+}
+
+impl SdioHost for PhytiumMci {
+    type Event = Event;
+    type DataRequest<'a> = DataRequest<'a>;
+
+    fn submit_command(&mut self, cmd: &Command) -> Result<(), Error> {
+        PhytiumMci::submit_command(self, cmd)
+    }
+
+    fn poll_command_response(&mut self) -> Result<sdmmc_protocol::CommandResponsePoll, Error> {
+        PhytiumMci::poll_command_response(self)
+    }
+
+    fn submit_read_data<'a>(
+        &mut self,
+        cmd: &Command,
+        buf: &'a mut [u8],
+        block_size: u32,
+        block_count: u32,
+    ) -> Result<Self::DataRequest<'a>, Error> {
+        let buffer = NonNull::new(buf.as_mut_ptr()).ok_or(Error::InvalidArgument)?;
+        let mut slot = BlockRequestSlot::default();
+        let request = self.submit_fifo_data_request(
+            cmd,
+            buffer,
+            buf.len(),
+            block_size,
+            block_count,
+            DataDirection::Read,
+            &mut slot,
+        )?;
+        let id = request.id();
+        Ok(DataRequest {
+            id,
+            request: Some(request),
+            slot,
+            _buffer: PhantomData,
+        })
+    }
+
+    fn submit_write_data<'a>(
+        &mut self,
+        cmd: &Command,
+        buf: &'a [u8],
+        block_size: u32,
+        block_count: u32,
+    ) -> Result<Self::DataRequest<'a>, Error> {
+        let buffer = NonNull::new(buf.as_ptr() as *mut u8).ok_or(Error::InvalidArgument)?;
+        let mut slot = BlockRequestSlot::default();
+        let request = self.submit_fifo_data_request(
+            cmd,
+            buffer,
+            buf.len(),
+            block_size,
+            block_count,
+            DataDirection::Write,
+            &mut slot,
+        )?;
+        let id = request.id();
+        Ok(DataRequest {
+            id,
+            request: Some(request),
+            slot,
+            _buffer: PhantomData,
+        })
+    }
+
+    fn poll_data_request<'a>(
+        &mut self,
+        request: &mut Self::DataRequest<'a>,
+    ) -> Result<DataCommandPoll, Error> {
+        self.poll_block_request_response(&mut request.request, request.id, &mut request.slot)
+    }
+
+    fn set_bus_width(&mut self, width: BusWidth) -> Result<(), Error> {
+        self.set_bus_width(width);
+        Ok(())
+    }
+
+    fn set_clock(&mut self, speed: ClockSpeed) -> Result<(), Error> {
+        self.program_timing(timing::TimingTable::sd_for_speed(speed)?)
+    }
+
+    fn switch_voltage(&mut self, voltage: SignalVoltage) -> Result<(), Error> {
+        self.set_signal_voltage(voltage)
+    }
+
+    fn enable_completion_irq(&mut self) -> Result<(), Error> {
+        PhytiumMci::enable_completion_irq(self);
+        Ok(())
+    }
+
+    fn disable_completion_irq(&mut self) -> Result<(), Error> {
+        PhytiumMci::disable_completion_irq(self);
+        Ok(())
+    }
+
+    fn handle_irq(&mut self) -> Self::Event {
+        PhytiumMci::handle_irq(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sdmmc_protocol::{
+        cmd::CMD0,
+        response::ResponseType,
+        sdio::{ClockSpeed, SignalVoltage},
+    };
+
+    use crate::{
+        command::encode_command,
+        regs::{Ctrl, Uhs},
+        timing::{MediaKind, TimingTable},
+    };
+
+    #[test]
+    fn sd_timing_table_matches_phytium_sd_values() {
+        let init = TimingTable::for_speed(ClockSpeed::Identification, MediaKind::Sd).unwrap();
+        assert_eq!(init.clk_div, 0x7e7dfa);
+        assert_eq!(init.clk_src, 0x000502);
+        assert!(init.use_hold);
+
+        let hs = TimingTable::for_speed(ClockSpeed::HighSpeed, MediaKind::Sd).unwrap();
+        assert_eq!(hs.clk_div, 0x030204);
+        assert_eq!(hs.clk_src, 0x000502);
+        assert!(hs.use_hold);
+    }
+
+    #[test]
+    fn mmc_timing_table_uses_mmc_specific_rates() {
+        let default = TimingTable::for_speed(ClockSpeed::Default, MediaKind::Mmc).unwrap();
+        assert_eq!(default.target_hz, 26_000_000);
+
+        let high = TimingTable::for_speed(ClockSpeed::HighSpeed, MediaKind::Mmc).unwrap();
+        assert_eq!(high.target_hz, 52_000_000);
+    }
+
+    #[test]
+    fn unsupported_sd_clock_modes_are_rejected() {
+        assert!(TimingTable::sd_for_speed(ClockSpeed::Sdr104).is_err());
+    }
+
+    #[test]
+    fn ctrl_register_bits_match_phytium_mci_layout() {
+        let reg = Ctrl::new()
+            .with_int_enable(true)
+            .with_dma_enable(true)
+            .with_read_wait(true)
+            .with_use_internal_dmac(true);
+
+        assert_eq!(reg.into_bits(), (1 << 4) | (1 << 5) | (1 << 6) | (1 << 25));
+    }
+
+    #[test]
+    fn r3_command_encoding_does_not_enable_crc_check() {
+        let cmd = sdmmc_protocol::cmd::Command {
+            cmd: 1,
+            arg: 0,
+            resp_type: ResponseType::R3,
+        };
+        let reg = encode_command(&cmd, None);
+        assert!(reg.response_expect());
+        assert!(!reg.check_response_crc());
+    }
+
+    #[test]
+    fn cmd0_encoding_sends_initialization_clocks() {
+        let reg = encode_command(&CMD0, None);
+        assert!(reg.send_initialization());
+        assert!(!reg.response_expect());
+    }
+
+    #[test]
+    fn cmd12_encoding_marks_stop_abort() {
+        let reg = encode_command(&sdmmc_protocol::cmd::CMD12, None);
+        assert!(reg.stop_abort_cmd());
+    }
+
+    #[test]
+    fn uhs_voltage_bit_tracks_signal_voltage() {
+        let v180 = crate::host::uhs_bits_after_voltage(Uhs::new(), SignalVoltage::V180).unwrap();
+        assert_eq!(v180.volt(), 1);
+
+        let v330 = crate::host::uhs_bits_after_voltage(v180, SignalVoltage::V330).unwrap();
+        assert_eq!(v330.volt(), 0);
+    }
+
+    #[test]
+    fn command_register_keeps_hold_register_optional() {
+        let cmd = sdmmc_protocol::cmd::Command {
+            cmd: 17,
+            arg: 0,
+            resp_type: ResponseType::R1,
+        };
+        let without_hold = encode_command(&cmd, None).with_use_hold_reg(false);
+        assert!(!without_hold.use_hold_reg());
+        assert_eq!(without_hold.cmd_index(), 17);
+    }
+}

--- a/drivers/blk/phytium-mci-host/src/regs.rs
+++ b/drivers/blk/phytium-mci-host/src/regs.rs
@@ -1,0 +1,220 @@
+//! Phytium MCI/FSDIF register definitions.
+
+use bitfield_struct::bitfield;
+use volatile::{VolatileFieldAccess, access::ReadOnly};
+
+#[repr(C)]
+#[derive(VolatileFieldAccess)]
+pub struct RegisterBlock {
+    pub ctrl: Ctrl,
+    pub pwren: u32,
+    pub clkdiv: u32,
+    _reserved0: u32,
+    pub clkena: ClkEna,
+    pub tmout: u32,
+    pub ctype: CType,
+    pub blksiz: u32,
+    pub bytcnt: u32,
+    pub intmask: u32,
+    pub cmdarg: u32,
+    pub cmd: Cmd,
+    #[access(ReadOnly)]
+    pub resp: [u32; 4],
+    #[access(ReadOnly)]
+    pub mintsts: u32,
+    pub rintsts: RIntSts,
+    #[access(ReadOnly)]
+    pub status: Status,
+    pub fifoth: u32,
+    #[access(ReadOnly)]
+    pub cdetect: u32,
+    #[access(ReadOnly)]
+    pub wrtprt: u32,
+    #[access(ReadOnly)]
+    pub cksts: ClockStatus,
+    #[access(ReadOnly)]
+    pub tcbcnt: u32,
+    #[access(ReadOnly)]
+    pub tbbcnt: u32,
+    pub debnce: u32,
+    #[access(ReadOnly)]
+    pub usrid: u32,
+    #[access(ReadOnly)]
+    pub verid: u32,
+    #[access(ReadOnly)]
+    pub hcon: u32,
+    pub uhs: Uhs,
+    pub rst: u32,
+    _reserved1: u32,
+    pub bmod: u32,
+    pub pldmnd: u32,
+    pub dbaddrl: u32,
+    pub dbaddrh: u32,
+    pub idsts: u32,
+    pub idinten: u32,
+    #[access(ReadOnly)]
+    pub dscaddrl: u32,
+    #[access(ReadOnly)]
+    pub dscaddrh: u32,
+    #[access(ReadOnly)]
+    pub bufaddrl: u32,
+    #[access(ReadOnly)]
+    pub bufaddrh: u32,
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct Ctrl {
+    #[bits(6)]
+    __: u8,
+    pub use_internal_dmac: bool,
+    pub enable_od_pullup: bool,
+    #[bits(4)]
+    pub card_voltage_b: u8,
+    #[bits(4)]
+    pub card_voltage_a: u8,
+    #[bits(4)]
+    __: u8,
+    pub ceata_device_interrupt: bool,
+    pub send_auto_stop_ccsd: bool,
+    pub send_ccsd: bool,
+    pub abort_read_data: bool,
+    pub send_irq_response: bool,
+    pub read_wait: bool,
+    pub dma_enable: bool,
+    pub int_enable: bool,
+    __: bool,
+    pub dma_reset: bool,
+    pub fifo_reset: bool,
+    pub controller_reset: bool,
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct ClkEna {
+    pub cclk_low_power: u16,
+    pub cclk_enable: u16,
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct CType {
+    pub width8: u16,
+    pub width4: u16,
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct Cmd {
+    #[bits(default = true)]
+    pub start_cmd: bool,
+    __: bool,
+    pub use_hold_reg: bool,
+    pub volt_switch: bool,
+    pub boot_mode: bool,
+    pub disable_boot: bool,
+    pub expect_boot_ack: bool,
+    pub enable_boot: bool,
+    pub ccs_expected: bool,
+    pub read_ceata_device: bool,
+    pub update_clock_registers_only: bool,
+    #[bits(5)]
+    pub card_number: u16,
+    pub send_initialization: bool,
+    pub stop_abort_cmd: bool,
+    #[bits(default = true)]
+    pub wait_prvdata_complete: bool,
+    pub send_auto_stop: bool,
+    pub transfer_mode: bool,
+    pub read_write: bool,
+    pub data_expected: bool,
+    pub check_response_crc: bool,
+    pub response_length: bool,
+    pub response_expect: bool,
+    #[bits(6)]
+    pub cmd_index: u8,
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct RIntSts {
+    pub sdio: u16,
+    pub end_bit_error: bool,
+    pub auto_command_done: bool,
+    pub start_bit_error: bool,
+    pub hardware_locked_write: bool,
+    pub fifo_under_over_run: bool,
+    pub host_timeout: bool,
+    pub data_read_timeout: bool,
+    pub response_timeout: bool,
+    pub data_crc_error: bool,
+    pub response_crc_error: bool,
+    pub receive_fifo_data_request: bool,
+    pub transmit_fifo_data_request: bool,
+    pub data_transfer_over: bool,
+    pub command_done: bool,
+    pub response_error: bool,
+    pub card_detect: bool,
+}
+
+impl RIntSts {
+    pub fn error(&self) -> bool {
+        self.response_error()
+            || self.response_crc_error()
+            || self.data_crc_error()
+            || self.response_timeout()
+            || self.data_read_timeout()
+            || self.host_timeout()
+            || self.fifo_under_over_run()
+            || self.hardware_locked_write()
+            || self.start_bit_error()
+            || self.end_bit_error()
+    }
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct Status {
+    pub dma_req: bool,
+    pub dma_ack: bool,
+    #[bits(13)]
+    pub fifo_count: u16,
+    #[bits(6)]
+    pub response_index: u8,
+    pub data_state_mc_busy: bool,
+    pub data_busy: bool,
+    pub data_3_status: bool,
+    #[bits(4)]
+    pub command_fsm_states: u8,
+    pub fifo_full: bool,
+    pub fifo_empty: bool,
+    pub fifo_tx_watermark: bool,
+    pub fifo_rx_watermark: bool,
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct ClockStatus {
+    #[bits(31)]
+    __: u32,
+    pub ready: bool,
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct Uhs {
+    pub ddr: u16,
+    pub volt: u16,
+}
+
+#[bitfield(u32, order = Msb)]
+pub struct ClockSource {
+    pub ext_clock_mux: bool,
+    #[bits(7)]
+    pub drive_phase: u8,
+    __: bool,
+    #[bits(7)]
+    pub sample_phase: u8,
+    __: bool,
+    #[bits(7)]
+    pub clock_div: u8,
+    #[bits(6)]
+    __: u8,
+    pub ext_clock_enable: bool,
+    pub ext_mmc_volt: bool,
+}
+
+pub const CARD_THRCTL_OFFSET: usize = 0x100;
+pub const CLK_SRC_OFFSET: usize = 0x108;

--- a/drivers/blk/phytium-mci-host/src/timing.rs
+++ b/drivers/blk/phytium-mci-host/src/timing.rs
@@ -1,0 +1,95 @@
+use sdmmc_protocol::{error::Error, sdio::ClockSpeed};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MediaKind {
+    Sd,
+    Mmc,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TimingTable {
+    pub target_hz: u32,
+    pub use_hold: bool,
+    pub clk_div: u32,
+    pub clk_src: u32,
+    pub shift: u32,
+}
+
+impl TimingTable {
+    pub fn sd_for_speed(speed: ClockSpeed) -> Result<Self, Error> {
+        Self::for_speed(speed, MediaKind::Sd)
+    }
+
+    pub fn for_speed(speed: ClockSpeed, media: MediaKind) -> Result<Self, Error> {
+        match (speed, media) {
+            (ClockSpeed::Identification, _) => Ok(MMC_SD_400KHZ),
+            (ClockSpeed::Default | ClockSpeed::Sdr12, MediaKind::Sd) => Ok(SD_25MHZ),
+            (ClockSpeed::HighSpeed | ClockSpeed::Sdr25, MediaKind::Sd) => Ok(SD_50MHZ),
+            (ClockSpeed::Sdr50 | ClockSpeed::Ddr50, MediaKind::Sd) => Ok(SD_100MHZ),
+            (ClockSpeed::Default | ClockSpeed::Sdr12, MediaKind::Mmc) => Ok(MMC_26MHZ),
+            (ClockSpeed::HighSpeed | ClockSpeed::Sdr25, MediaKind::Mmc) => Ok(MMC_52MHZ),
+            (ClockSpeed::Sdr50 | ClockSpeed::Ddr50, MediaKind::Mmc) => Ok(MMC_100MHZ),
+            (ClockSpeed::Hs200, MediaKind::Mmc) => Ok(MMC_100MHZ),
+            (ClockSpeed::Sdr104 | ClockSpeed::Hs200, MediaKind::Sd)
+            | (ClockSpeed::Sdr104, MediaKind::Mmc) => Err(Error::UnsupportedCommand),
+            // Future ClockSpeed variants are not represented in this timing table.
+            (..) => Err(Error::UnsupportedCommand),
+        }
+    }
+}
+
+pub const MMC_SD_400KHZ: TimingTable = TimingTable {
+    target_hz: 400_000,
+    use_hold: true,
+    clk_div: 0x7e7dfa,
+    clk_src: 0x000502,
+    shift: 0,
+};
+
+pub const SD_25MHZ: TimingTable = TimingTable {
+    target_hz: 25_000_000,
+    use_hold: true,
+    clk_div: 0x030204,
+    clk_src: 0x000302,
+    shift: 0,
+};
+
+pub const SD_50MHZ: TimingTable = TimingTable {
+    target_hz: 50_000_000,
+    use_hold: true,
+    clk_div: 0x030204,
+    clk_src: 0x000502,
+    shift: 0,
+};
+
+pub const SD_100MHZ: TimingTable = TimingTable {
+    target_hz: 100_000_000,
+    use_hold: false,
+    clk_div: 0x010002,
+    clk_src: 0x000202,
+    shift: 0,
+};
+
+pub const MMC_26MHZ: TimingTable = TimingTable {
+    target_hz: 26_000_000,
+    use_hold: true,
+    clk_div: 0x030204,
+    clk_src: 0x000302,
+    shift: 0,
+};
+
+pub const MMC_52MHZ: TimingTable = TimingTable {
+    target_hz: 52_000_000,
+    use_hold: false,
+    clk_div: 0x030204,
+    clk_src: 0x000202,
+    shift: 0,
+};
+
+pub const MMC_100MHZ: TimingTable = TimingTable {
+    target_hz: 100_000_000,
+    use_hold: false,
+    clk_div: 0x010002,
+    clk_src: 0x000202,
+    shift: 0,
+};

--- a/drivers/blk/sdhci-host/Cargo.toml
+++ b/drivers/blk/sdhci-host/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "sdhci-host"
-version = "0.1.0"
+version = "0.1.1"
+repository.workspace = true
 edition = "2024"
 license = "Apache-2.0"
 description = "SDHCI host controller backend for sdmmc-protocol (no_std, FIFO/ADMA2)"

--- a/drivers/blk/sdhci-host/src/command.rs
+++ b/drivers/blk/sdhci-host/src/command.rs
@@ -43,6 +43,10 @@ impl Sdhci {
             Ok(CommandPoll::Complete) => self
                 .take_command_response()
                 .map(CommandResponsePoll::Complete),
+            // Future CommandPoll variants: treat as best-effort harvest, same as Err path.
+            Ok(_) => self
+                .take_command_response()
+                .map(CommandResponsePoll::Complete),
             Err(_) => self
                 .take_command_response()
                 .map(CommandResponsePoll::Complete),
@@ -92,7 +96,17 @@ impl Sdhci {
 
         let (normal, error) = self.take_command_irq_status();
         if normal & NORMAL_INT_CMD_COMPLETE != 0 {
-            let response = decode_response(self, cmd.resp_type)?;
+            let response = match decode_response(self, cmd.resp_type) {
+                Ok(r) => r,
+                Err(err) => {
+                    // Park the FSM in Failed before propagating: bare `?` would
+                    // leave it in Issued while the IRQ status bits are already
+                    // cleared, so the next poll would idle until the caller's
+                    // own timeout fires.
+                    self.command_state = CommandState::Failed { error: err };
+                    return Err(err);
+                }
+            };
             log::debug!("sdhci: CMD{} response {:?}", cmd.cmd, response);
             self.command_state = CommandState::Complete { response };
             Ok(CommandPoll::Complete)
@@ -362,6 +376,8 @@ fn encode_command(cmd: &Command, has_data: bool) -> Result<u16, Error> {
         ResponseType::R1b => CMD_RESP_LEN48_BUSY | CMD_CRC_CHECK | CMD_INDEX_CHECK,
         ResponseType::R2 => CMD_RESP_LEN136 | CMD_CRC_CHECK,
         ResponseType::R3 | ResponseType::R4 => CMD_RESP_LEN48,
+        // Future ResponseType variants are unsupported by this encoder.
+        _ => return Err(Error::UnsupportedCommand),
     };
 
     let data_bit = if has_data { CMD_DATA_PRESENT } else { 0 };
@@ -371,7 +387,7 @@ fn encode_command(cmd: &Command, has_data: bool) -> Result<u16, Error> {
 
 fn decode_response(host: &Sdhci, resp_type: ResponseType) -> Result<Response, Error> {
     Ok(match resp_type {
-        ResponseType::None => Response::None,
+        ResponseType::None => Response::Empty,
         ResponseType::R1 | ResponseType::R1b => Response::R1(R1Response {
             raw: host.response32(0),
         }),
@@ -384,6 +400,8 @@ fn decode_response(host: &Sdhci, resp_type: ResponseType) -> Result<Response, Er
         }
         ResponseType::R6 => Response::R6(RcaResponse::from_raw(host.response32(0))),
         ResponseType::R7 => Response::R7(IfCondResponse::from_raw(host.response32(0))),
+        // Future ResponseType variants are not decoded by this controller.
+        _ => return Err(Error::UnsupportedCommand),
     })
 }
 

--- a/drivers/blk/sdhci-host/src/dma.rs
+++ b/drivers/blk/sdhci-host/src/dma.rs
@@ -297,6 +297,8 @@ impl Sdhci {
                 self.build_dma_read_request(start_block, buffer, size, dma, id)
             }
             BlockTransferMode::Fifo => self.build_fifo_read_request(start_block, buffer, size, id),
+            // Future BlockTransferMode variants are not supported by this controller.
+            _ => Err(Error::UnsupportedCommand),
         };
         match result {
             Ok(request) => Ok(request),
@@ -326,6 +328,8 @@ impl Sdhci {
                 self.build_dma_write_request(start_block, buffer, size, dma, id)
             }
             BlockTransferMode::Fifo => self.build_fifo_write_request(start_block, buffer, size, id),
+            // Future BlockTransferMode variants are not supported by this controller.
+            _ => Err(Error::UnsupportedCommand),
         };
         match result {
             Ok(request) => Ok(request),
@@ -346,6 +350,8 @@ impl Sdhci {
         match self.poll_block_request_response(request, id, slot)? {
             DataCommandPoll::Pending => Ok(BlockPoll::Pending),
             DataCommandPoll::Complete(_) => Ok(BlockPoll::Complete),
+            // Future DataCommandPoll variants are treated as completion.
+            _ => Ok(BlockPoll::Complete),
         }
     }
 
@@ -413,6 +419,8 @@ impl Sdhci {
                     }
                     return Ok(DataCommandPoll::Pending);
                 }
+                // Future CommandPoll variants: best-effort, treat as still pending.
+                Ok(_) => return Ok(DataCommandPoll::Pending),
                 Err(err) => {
                     self.abort_block_request(request, id, slot);
                     return Err(err);
@@ -427,6 +435,8 @@ impl Sdhci {
         match self.poll_data_complete_with_adma(cmd_index, phase) {
             Ok(BlockPoll::Pending) => Ok(DataCommandPoll::Pending),
             Ok(BlockPoll::Complete) => self.finish_dma_data(request, id, slot),
+            // Future BlockPoll variants: best-effort, treat as still pending.
+            Ok(_) => Ok(DataCommandPoll::Pending),
             Err(err) => {
                 self.abort_block_request(request, id, slot);
                 Err(err)
@@ -606,6 +616,8 @@ impl Sdhci {
             DataDirection::Read => BlockTransferDirection::Read,
             DataDirection::Write => BlockTransferDirection::Write,
             DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
         };
         let id = slot.start(BlockTransferMode::Fifo, transfer_direction)?;
         match self.build_fifo_data_request(
@@ -650,6 +662,8 @@ impl Sdhci {
             DataDirection::Read => Phase::DataRead,
             DataDirection::Write => Phase::DataWrite,
             DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
         };
         self.pending_data = Some(PendingData {
             direction,
@@ -684,6 +698,8 @@ impl Sdhci {
                 response: None,
             },
             DataDirection::None => return Err(Error::InvalidArgument),
+            // Future DataDirection variants are not supported by this engine.
+            _ => return Err(Error::InvalidArgument),
         };
         Ok(BlockRequest { inner })
     }
@@ -807,6 +823,8 @@ impl Sdhci {
                 slot.complete(id)?;
                 Ok(DataCommandPoll::Complete(response))
             }
+            // Future CommandPoll variants: best-effort, treat as still pending.
+            Ok(_) => Ok(DataCommandPoll::Pending),
             Err(err) => {
                 self.abort_block_request(request, id, slot);
                 Err(err)
@@ -857,6 +875,8 @@ impl Sdhci {
                     set_fifo_stage(request, BlockRequestStage::Data)?;
                     return Ok(DataCommandPoll::Pending);
                 }
+                // Future CommandPoll variants: best-effort, treat as still pending.
+                Ok(_) => return Ok(DataCommandPoll::Pending),
                 Err(err) => {
                     self.abort_block_request(request, id, slot);
                     return Err(err);
@@ -877,6 +897,8 @@ impl Sdhci {
         match self.poll_fifo_data_step(request, cmd_index, phase) {
             Ok(BlockPoll::Pending) => Ok(DataCommandPoll::Pending),
             Ok(BlockPoll::Complete) => self.finish_fifo_data(request, id, slot),
+            // Future BlockPoll variants: best-effort, treat as still pending.
+            Ok(_) => Ok(DataCommandPoll::Pending),
             Err(err) => {
                 self.abort_block_request(request, id, slot);
                 Err(err)

--- a/drivers/blk/sdhci-host/src/host.rs
+++ b/drivers/blk/sdhci-host/src/host.rs
@@ -42,6 +42,13 @@ pub struct Sdhci {
     /// for 1:1 passthrough) instead of using the internal 10-bit divider.
     /// Used on controllers whose internal divider is unusable.
     pub(crate) ext_clock: Option<&'static dyn HostClock>,
+    /// Whether the platform has wired up the IO-domain regulator needed to
+    /// actually run the bus at 1.8 V. Default `false` — toggling
+    /// `HOST_CONTROL2.1V8_SIGNALING_ENABLE` alone changes the controller
+    /// sampling behaviour without changing the IO rail, which corrupts
+    /// subsequent transfers; refusing the switch lets the protocol layer
+    /// fall back to a 3.3 V-compatible mode.
+    pub(crate) support_1v8: bool,
     /// Command index for the data phase currently being drained by the
     /// submit/poll data-command state machine.
     pub(crate) active_data_cmd: u8,
@@ -65,6 +72,7 @@ impl Sdhci {
             pending_data: None,
             use_dma: false,
             ext_clock: None,
+            support_1v8: false,
             active_data_cmd: 0,
             dma: None,
             dma_mask: u32::MAX as u64,
@@ -114,6 +122,18 @@ impl Sdhci {
         C: HostClock + 'static,
     {
         self.ext_clock = Some(clock);
+    }
+
+    /// Declare that the platform can switch the SD/eMMC IO rail to 1.8 V.
+    ///
+    /// Until this is called, [`SdioHost::switch_voltage`] refuses
+    /// [`SignalVoltage::V180`], which steers the protocol layer away from
+    /// UHS-I / HS200 / HS400. Platforms that wire up the regulator (PMIC
+    /// or per-domain LDO) should call this after construction so that
+    /// `switch_voltage(V180)` is allowed to drive
+    /// `HOST_CONTROL2.1V8_SIGNALING_ENABLE`.
+    pub fn enable_1v8_signaling(&mut self) {
+        self.support_1v8 = true;
     }
 
     /// Install a DMA capability used by the high-level data-transfer hooks.

--- a/drivers/blk/sdhci-host/src/lib.rs
+++ b/drivers/blk/sdhci-host/src/lib.rs
@@ -10,8 +10,11 @@
 //!   4-bit bus, default-speed and high-speed clocking, 32-bit response
 //!   slots, 136-bit R2 reconstruction, software reset / clock setup.
 //! - **Out of scope (for now)**: 64-bit ADMA2, 8-bit eMMC bus, HS200 /
-//!   SDR50 / SDR104 clocking, voltage / signaling switch (CMD11), tuning
-//!   (CMD19 / CMD21), eMMC-specific commands.
+//!   SDR50 / SDR104 clocking, tuning (CMD19 / CMD21), eMMC-specific
+//!   commands. 1.8 V signaling is wired up at the register level but is
+//!   gated behind [`Sdhci::enable_1v8_signaling`] — platforms that haven't
+//!   plumbed the IO-rail regulator MUST leave it off so the protocol
+//!   layer falls back instead of corrupting transfers.
 //!
 //! # Usage
 //!
@@ -199,6 +202,8 @@ impl SdioHost for Sdhci {
             // refuse cleanly instead of silently writing the bit and
             // misconfiguring the bus.
             BusWidth::Bit8 => return Err(Error::UnsupportedCommand),
+            // Future BusWidth variants are not supported by this controller.
+            _ => return Err(Error::UnsupportedCommand),
         }
         self.write_u8(REG_HOST_CONTROL1, ctrl);
         Ok(())
@@ -212,6 +217,8 @@ impl SdioHost for Sdhci {
             ClockSpeed::Sdr50 | ClockSpeed::Ddr50 => 50_000_000,
             ClockSpeed::Sdr104 => 104_000_000,
             ClockSpeed::Hs200 => 200_000_000,
+            // Future ClockSpeed variants are not supported by this controller.
+            _ => return Err(Error::UnsupportedCommand),
         };
 
         // Toggle the High-Speed Enable bit in HOST_CONTROL1 alongside the
@@ -250,6 +257,18 @@ impl SdioHost for Sdhci {
         //    immediately, so the wait is a soft requirement enforced by
         //    the platform delay (we don't have one here — bring-up code
         //    on the caller side should add one if needed).
+        // V180 requires the platform to actually swing the IO rail —
+        // flipping the controller bit in isolation makes the host
+        // sample at the wrong reference, breaking every subsequent
+        // data transfer (observed on rk3568-dwcmshc, where HS200
+        // tuning fails and the leaked bit then corrupts HS@52 reads).
+        // Refuse here unless the platform has opted in via
+        // `Sdhci::enable_1v8_signaling`. Returning `UnsupportedCommand`
+        // makes the protocol layer fall back cleanly.
+        if matches!(voltage, SignalVoltage::V180) && !self.support_1v8 {
+            return Err(Error::UnsupportedCommand);
+        }
+
         self.disable_sd_clock();
 
         // 2. Flip the voltage selector. 1.2 V isn't part of the SDHCI
@@ -266,6 +285,8 @@ impl SdioHost for Sdhci {
                 self.set_power(POWER_180);
             }
             SignalVoltage::V120 => return Err(Error::UnsupportedCommand),
+            // Future SignalVoltage variants are not supported by this controller.
+            _ => return Err(Error::UnsupportedCommand),
         }
         self.write_u16(REG_HOST_CONTROL2, ctrl2);
 
@@ -517,6 +538,8 @@ impl Sdhci {
             BlockTransferMode::Dma => {
                 BlockBufferConfig::new(NonZeroUsize::new(512).unwrap(), 512, Some(self.dma_mask))
             }
+            // Future BlockTransferMode variants fall back to the conservative Fifo config.
+            _ => BlockBufferConfig::new(NonZeroUsize::new(512).unwrap(), 1, None),
         }
     }
 

--- a/drivers/blk/sdmmc-protocol/Cargo.toml
+++ b/drivers/blk/sdmmc-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdmmc-protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "no_std SD/MMC protocol building blocks for embedded systems"

--- a/drivers/blk/sdmmc-protocol/README.md
+++ b/drivers/blk/sdmmc-protocol/README.md
@@ -17,10 +17,10 @@ It provides:
 - A SDIO/native-mode host-controller abstraction and driver skeleton
 - One shared `Error` type with command/phase context for protocol and host errors
 
-The crate is currently early-stage. The SPI path has protocol-level unit tests
-and basic block read/write support. The SDIO path is the integration boundary
-used by host crates such as `sdhci-host` and `dwmmc-host`, and needs
-platform-specific validation before use on hardware.
+The SPI path has protocol-level unit tests and basic block read/write support.
+The SDIO path is the integration boundary used by the host crates in this
+workspace and has been validated end-to-end on the controller / SoC
+combinations listed under [Validated host backends](#validated-host-backends).
 
 ## Features
 
@@ -205,6 +205,16 @@ callers can poll from a blocking loop, an IRQ wakeup path, a worker, or an async
 runtime wrapper. `SdioSdmmc` does not choose the waiting policy; the caller owns
 whether pending work spins, yields, sleeps, waits for an IRQ, or uses a timer.
 
+### Optional wall-clock timeouts
+
+ACMD41 / CMD1 power-up and MMC `CMD6 SWITCH` busy-waits default to a poll
+counter that assumes the caller paces `poll_*` at ~10 ms. Hosts that can
+expose a monotonic clock should override `SdioHost::now_ms() -> Option<u64>`:
+the protocol layer then enforces wall-clock deadlines (1 s for power-up,
+250 ms for CMD6) in addition to the poll budget, so timeouts stay accurate
+no matter how fast or slow the caller polls. Hosts that return `None` (the
+default) keep the pure poll-counter behavior.
+
 ## Command Helpers
 
 The `cmd` module contains helpers for common commands:
@@ -262,6 +272,24 @@ cargo xtask clippy --package sdmmc-protocol
   mode switching is still incomplete.
 - UHS-I and HS200 entry depends on host support for voltage switching and
   tuning. Unsupported host operations return `Error::UnsupportedCommand`.
+
+## Validated host backends
+
+The protocol layer has been exercised on the controller / SoC combinations
+below through dedicated host crates in this workspace. Modes not listed are
+either unimplemented in the host backend or have not yet been signed off on
+real hardware.
+
+| Host crate         | SoC / controller       | Mode                  | Notes                                       |
+|--------------------|------------------------|-----------------------|---------------------------------------------|
+| `sdhci-host`       | RK3568 (dwcmshc)       | eMMC HS@52, FIFO/DMA  | HS200 path exists; not yet signed off       |
+| `sdhci-host`       | RK3588 (dwcmshc)       | eMMC HS@52, FIFO/DMA  | HS200 path exists; not yet signed off       |
+| `dwmmc-host`       | RK3568 SD (dw_mshc)    | SD HS, DMA            |                                             |
+| `phytium-mci-host` | Phytium MCI            | SD HS, DMA            |                                             |
+
+See `drivers/blk/sdmmc-protocol/docs/REVIEW.md` for the remaining 1.0 roadmap
+(non_exhaustive enums, `Display` impls, time-base contract, fuzz coverage,
+SDIO IO-card support, etc.).
 
 ## License
 

--- a/drivers/blk/sdmmc-protocol/src/block.rs
+++ b/drivers/blk/sdmmc-protocol/src/block.rs
@@ -24,7 +24,11 @@ impl From<BlockRequestId> for usize {
 }
 
 /// Data engine used by an in-flight block request.
+///
+/// Marked `#[non_exhaustive]`: new engines (e.g. SDMA, ADMA3) may be added
+/// before 1.0.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BlockTransferMode {
     /// Controller FIFO/data-port engine.
     Fifo,
@@ -54,14 +58,23 @@ impl BlockBufferConfig {
 }
 
 /// Direction of a block request.
+///
+/// Marked `#[non_exhaustive]` for forward compatibility (future variants like
+/// `Erase` may join the queue contract).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BlockTransferDirection {
     Read,
     Write,
 }
 
 /// Observable state of one host block-transfer state machine.
+///
+/// Marked `#[non_exhaustive]`: queue-level intermediate states (e.g. tuning,
+/// drain) may be added before 1.0; downstream match sites must keep a
+/// `_ => ...` arm.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BlockTransferState {
     #[default]
     Idle,
@@ -112,21 +125,31 @@ impl BlockTransferState {
 }
 
 /// Result of advancing a submitted transfer without blocking.
+///
+/// Marked `#[non_exhaustive]`: intermediate states such as `Aborted` or
+/// per-block progress may be added before 1.0.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BlockPoll {
     Pending,
     Complete,
 }
 
 /// Direction of a generic SD/MMC data command.
+///
+/// Marked `#[non_exhaustive]` for forward compatibility.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DataCommandDirection {
     Read,
     Write,
 }
 
 /// Observable state of one protocol data command.
+///
+/// Marked `#[non_exhaustive]` for forward compatibility.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DataCommandState {
     #[default]
     Idle,
@@ -139,14 +162,20 @@ pub enum DataCommandState {
 }
 
 /// Result of advancing a generic data command without blocking.
+///
+/// Marked `#[non_exhaustive]` for forward compatibility.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum DataCommandPoll {
     Pending,
     Complete(crate::response::Response),
 }
 
 /// Result of advancing a submitted command without blocking.
+///
+/// Marked `#[non_exhaustive]` for forward compatibility.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CommandPoll {
     Pending,
     Complete,
@@ -154,14 +183,20 @@ pub enum CommandPoll {
 
 /// Result of advancing a submitted command and harvesting its response when
 /// available.
+///
+/// Marked `#[non_exhaustive]` for forward compatibility.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum CommandResponsePoll {
     Pending,
     Complete(crate::response::Response),
 }
 
 /// Generic result of advancing an operation without blocking.
+///
+/// Marked `#[non_exhaustive]` for forward compatibility.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum OperationPoll<T> {
     Pending,
     Complete(T),

--- a/drivers/blk/sdmmc-protocol/src/cmd.rs
+++ b/drivers/blk/sdmmc-protocol/src/cmd.rs
@@ -1,7 +1,11 @@
 use crate::response::ResponseType;
 
 /// Direction of the data phase that follows a command, if any.
+///
+/// Marked `#[non_exhaustive]`: bidirectional / control-stream variants may be
+/// added before 1.0.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DataDirection {
     /// No data phase follows this command.
     None,

--- a/drivers/blk/sdmmc-protocol/src/error.rs
+++ b/drivers/blk/sdmmc-protocol/src/error.rs
@@ -2,13 +2,26 @@
 //!
 //! See [`Phase`] and [`ErrorContext`] for the operational metadata that
 //! recoverable [`Error`] variants carry.
+//!
+//! All public error types implement [`core::fmt::Display`] for human-readable
+//! logging, and [`Error`] additionally implements [`core::error::Error`]
+//! (stabilized in `no_std` since Rust 1.81) so it composes with
+//! `?`-propagation chains and downstream error-handling utilities. The
+//! `Debug` impls are still derived for `{:?}` use inside the driver.
+
+use core::fmt;
 
 /// Where in the driver pipeline a fault was observed.
 ///
 /// Attached to recoverable [`Error`] variants via [`ErrorContext`] so callers
 /// can distinguish e.g. a CMD0 send timeout from a `BusyWait` programming
 /// timeout without parsing log strings.
+///
+/// Marked `#[non_exhaustive]`: more phases (e.g. tuning, voltage switch) are
+/// expected to land before 1.0, and downstream `match` sites must keep a
+/// `_ => ...` arm to absorb them without recompiling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum Phase {
     /// Phase was not recorded.
     ///
@@ -70,7 +83,12 @@ impl ErrorContext {
 /// the phase and (when known) command index that raised them. Caller-facing
 /// programming errors (`Misaligned`, `InvalidArgument`) and card-state
 /// reports (`NoCard`, `CardError`, `CardLocked`) do not.
+///
+/// Marked `#[non_exhaustive]`: more variants (e.g. `NoCardDetected`,
+/// `VoltageSwitchFailed`, retry-exhausted) are expected before 1.0. Match
+/// sites in downstream crates must keep a `_ => ...` arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error {
     /// No response from card within the deadline for the wrapped phase.
     Timeout(ErrorContext),
@@ -99,20 +117,184 @@ pub enum Error {
 }
 
 /// Per-bit error status decoded out of an R1 response.
+///
+/// SD Physical Layer spec section 4.10.1 reserves bits 19..=31 of the 32-bit
+/// native R1 response for card-state error flags. SPI R1 reuses bits 1..=6 of
+/// the single response byte for a subset of those. Variants below cover both,
+/// with [`CardError::Unknown`] preserving the raw native bit pattern when no
+/// known flag matches (e.g. reserved-for-application bits).
+///
+/// Marked `#[non_exhaustive]`: new card-status bits may be classified out of
+/// `Unknown(_)` over time, and downstream match sites must keep a `_ => ...`
+/// arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CardError {
-    /// A command was issued out of sequence.
-    IllegalCommand,
-    /// CRC check of the last command failed.
-    CommandCrcFailed,
-    /// Erase sequence error.
-    EraseSequence,
-    /// Address alignment error.
+    /// `OUT_OF_RANGE` (bit 31): the command's argument was out of the allowed
+    /// range for this card (e.g. LBA beyond capacity).
+    OutOfRange,
+    /// `ADDRESS_ERROR` (bit 30) / SPI `ADDRESS_ERROR` (bit 5): misaligned
+    /// address for the current block length, or out-of-range address.
     AddressError,
-    /// Card internal ECC error.
+    /// `BLOCK_LEN_ERROR` (bit 29) / SPI `PARAMETER_ERROR` (bit 6): transferred
+    /// block length is not allowed for this card or the parameter argument
+    /// was out of range.
+    BlockLenError,
+    /// `ERASE_SEQ_ERROR` (bit 28) / SPI `ERASE_SEQ_ERROR` (bit 4): erase
+    /// command sequence error, or `ERASE_RESET` (SPI bit 1).
+    EraseSequence,
+    /// `ERASE_PARAM` (bit 27): an invalid selection of write blocks for erase.
+    EraseParam,
+    /// `WP_VIOLATION` (bit 26): attempted write to a write-protected block.
+    WriteProtect,
+    /// `CARD_IS_LOCKED` (bit 25): card is locked by host, normal data
+    /// transfers are inhibited.
+    CardIsLocked,
+    /// `LOCK_UNLOCK_FAILED` (bit 24): a sequence or password error in the
+    /// lock/unlock command.
+    LockUnlockFailed,
+    /// `COM_CRC_ERROR` (bit 23) / SPI `COM_CRC_ERROR` (bit 3): CRC check of
+    /// the previous command failed.
+    CommandCrcFailed,
+    /// `ILLEGAL_COMMAND` (bit 22) / SPI `ILLEGAL_COMMAND` (bit 2): command not
+    /// legal for the current card state.
+    IllegalCommand,
+    /// `CARD_ECC_FAILED` (bit 21): card internal ECC was applied but failed
+    /// to correct the data.
     CardEccFailed,
-    /// Generic controller error.
+    /// `CC_ERROR` (bit 20): generic card controller error.
     ControllerError,
-    /// Unknown error bit set.
-    Unknown(u8),
+    /// `ERROR` (bit 19): a catch-all reported by the card when a non-classified
+    /// internal error occurred during the command execution.
+    GenericError,
+    /// Unknown / reserved error bit set. Carries the native 13-bit error
+    /// nibble (`raw >> 19`) so the caller can log the exact pattern.
+    Unknown(u32),
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Unspecified => "unspecified phase",
+            Self::Init => "init",
+            Self::CommandSend => "command send",
+            Self::ResponseWait => "response wait",
+            Self::DataWrite => "data write",
+            Self::DataRead => "data read",
+            Self::BusyWait => "busy wait",
+            Self::Switch => "switch",
+            Self::Erase => "erase",
+        };
+        f.write_str(s)
+    }
+}
+
+impl fmt::Display for ErrorContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.cmd {
+            Some(cmd) => write!(f, "{} (CMD{cmd})", self.phase),
+            None => fmt::Display::fmt(&self.phase, f),
+        }
+    }
+}
+
+impl fmt::Display for CardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::OutOfRange => "out-of-range argument",
+            Self::AddressError => "misaligned address",
+            Self::BlockLenError => "invalid block length",
+            Self::EraseSequence => "erase sequence error",
+            Self::EraseParam => "invalid erase selection",
+            Self::WriteProtect => "write-protect violation",
+            Self::CardIsLocked => "card is locked",
+            Self::LockUnlockFailed => "lock/unlock command failed",
+            Self::CommandCrcFailed => "command CRC failed",
+            Self::IllegalCommand => "illegal command for current card state",
+            Self::CardEccFailed => "card internal ECC failed",
+            Self::ControllerError => "card controller error",
+            Self::GenericError => "generic card error",
+            Self::Unknown(bits) => return write!(f, "unknown card error bits {bits:#x}"),
+        };
+        f.write_str(s)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout(ctx) => write!(f, "timeout during {ctx}"),
+            Self::Crc(ctx) => write!(f, "CRC mismatch during {ctx}"),
+            Self::NoCard => f.write_str("no card present"),
+            Self::UnsupportedCommand => f.write_str("command not supported by transport"),
+            Self::BadResponse(ctx) => write!(f, "bad response during {ctx}"),
+            Self::CardError(err) => write!(f, "card reported {err}"),
+            Self::WriteError(ctx) => write!(f, "write failed during {ctx}"),
+            Self::ReadError(ctx) => write!(f, "read failed during {ctx}"),
+            Self::Misaligned => f.write_str("misaligned address or length"),
+            Self::InvalidArgument => f.write_str("invalid argument"),
+            Self::CardLocked => f.write_str("card is locked; unlock before further I/O"),
+            Self::BusError(ctx) => write!(f, "bus error during {ctx}"),
+        }
+    }
+}
+
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::CardError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl core::error::Error for CardError {}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use std::format;
+
+    use super::*;
+
+    #[test]
+    fn display_error_includes_phase_and_cmd() {
+        let err = Error::Timeout(ErrorContext::for_cmd(Phase::DataRead, 17));
+        assert_eq!(format!("{err}"), "timeout during data read (CMD17)");
+    }
+
+    #[test]
+    fn display_error_without_cmd_drops_parenthesis() {
+        let err = Error::BadResponse(ErrorContext::new(Phase::ResponseWait));
+        assert_eq!(format!("{err}"), "bad response during response wait");
+    }
+
+    #[test]
+    fn display_card_error_known_variant() {
+        let err = Error::CardError(CardError::OutOfRange);
+        assert_eq!(format!("{err}"), "card reported out-of-range argument");
+    }
+
+    #[test]
+    fn display_card_error_unknown_preserves_bits() {
+        let err = Error::CardError(CardError::Unknown(0x1234));
+        assert_eq!(
+            format!("{err}"),
+            "card reported unknown card error bits 0x1234"
+        );
+    }
+
+    #[test]
+    fn error_trait_source_threads_card_error_through() {
+        let err = Error::CardError(CardError::WriteProtect);
+        let src = core::error::Error::source(&err).expect("source should be CardError");
+        assert_eq!(format!("{src}"), "write-protect violation");
+    }
+
+    #[test]
+    fn error_trait_source_is_none_for_bus_errors() {
+        let err = Error::Crc(ErrorContext::for_cmd(Phase::DataRead, 18));
+        assert!(core::error::Error::source(&err).is_none());
+    }
 }

--- a/drivers/blk/sdmmc-protocol/src/ext_csd.rs
+++ b/drivers/blk/sdmmc-protocol/src/ext_csd.rs
@@ -26,7 +26,11 @@ pub struct DeviceType {
 }
 
 /// Currently selected MMC bus width, decoded from `BUS_WIDTH` (EXT_CSD[183]).
+///
+/// Marked `#[non_exhaustive]`: HS400 / strobe encodings may be classified out
+/// of `Unknown(_)` over time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MmcBusWidth {
     /// 1-bit SDR.
     Sdr1,
@@ -43,7 +47,11 @@ pub enum MmcBusWidth {
 }
 
 /// Currently selected MMC timing mode, decoded from `HS_TIMING` (EXT_CSD[185]).
+///
+/// Marked `#[non_exhaustive]`: HS400_ES and future timing modes may be
+/// classified out of `Unknown(_)` over time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MmcTiming {
     /// Backwards-compatible (≤ 26 MHz).
     Compat,

--- a/drivers/blk/sdmmc-protocol/src/lib.rs
+++ b/drivers/blk/sdmmc-protocol/src/lib.rs
@@ -60,8 +60,20 @@
 //! # Maturity
 //!
 //! The SPI path has protocol-level unit tests and basic block read/write
-//! support. The SDIO path is a host abstraction skeleton and needs
-//! platform-specific validation before use on real hardware.
+//! support. The SDIO path has been validated end-to-end against several host
+//! controller / SoC combinations through the dedicated host backends in this
+//! workspace:
+//!
+//! | Host crate         | SoC / controller        | Mode                  | Status |
+//! |--------------------|-------------------------|-----------------------|--------|
+//! | `sdhci-host`       | RK3568 (dwcmshc)        | eMMC HS@52, FIFO/DMA  | OK     |
+//! | `sdhci-host`       | RK3588 (dwcmshc)        | eMMC HS@52, FIFO/DMA  | OK     |
+//! | `dwmmc-host`       | RK3568 SD (dw_mshc)     | SD HS, DMA            | OK     |
+//! | `phytium-mci-host` | Phytium MCI             | SD HS, DMA            | OK     |
+//!
+//! UHS-I / HS200 / HS400 paths exist in the state machine but have not yet
+//! been signed off on a real card + IO regulator combination. See
+//! `drivers/blk/sdmmc-protocol/docs/REVIEW.md` for the remaining roadmap.
 //!
 //! # MSRV
 //!

--- a/drivers/blk/sdmmc-protocol/src/response.rs
+++ b/drivers/blk/sdmmc-protocol/src/response.rs
@@ -1,7 +1,11 @@
 use crate::error::{CardError, Error, ErrorContext, Phase};
 
 /// SD/MMC response types
+///
+/// Marked `#[non_exhaustive]`: new transport-level response shapes
+/// (e.g. SDIO IO_RW extension, UHS-II) may be added before 1.0.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ResponseType {
     /// No response
     None,
@@ -24,9 +28,17 @@ pub enum ResponseType {
 }
 
 /// Parsed response from the card
+///
+/// Marked `#[non_exhaustive]`: new response shapes (e.g. SDIO IO_RW
+/// extensions) may be added before 1.0.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum Response {
-    None,
+    /// No response phase — emitted when the command's [`ResponseType`] is
+    /// [`ResponseType::None`] (e.g. CMD0). Renamed from `Response::None` to
+    /// avoid lexical confusion with [`ResponseType::None`]; the two now read
+    /// at a glance as "no response type configured" vs "no response decoded".
+    Empty,
     R1(R1Response),
     R1b(R1Response),
     R2([u8; 16]),
@@ -46,11 +58,37 @@ pub struct R1Response {
 impl R1Response {
     /// Parse a native (SDIO/SDHCI) 32-bit R1 response.
     ///
-    /// Card error bits live in bits 19..=24. If any error bit is set this
-    /// returns `Err(Error::CardError(..))`. Otherwise the raw value is
-    /// preserved.
+    /// SD Physical Layer spec section 4.10.1 (Table 4-42) places the card
+    /// status error flags at bits 19..=31:
+    ///
+    /// | Bit | Name                |
+    /// |-----|---------------------|
+    /// | 31  | `OUT_OF_RANGE`      |
+    /// | 30  | `ADDRESS_ERROR`     |
+    /// | 29  | `BLOCK_LEN_ERROR`   |
+    /// | 28  | `ERASE_SEQ_ERROR`   |
+    /// | 27  | `ERASE_PARAM`       |
+    /// | 26  | `WP_VIOLATION`      |
+    /// | 25  | `CARD_IS_LOCKED`    |
+    /// | 24  | `LOCK_UNLOCK_FAILED`|
+    /// | 23  | `COM_CRC_ERROR`     |
+    /// | 22  | `ILLEGAL_COMMAND`   |
+    /// | 21  | `CARD_ECC_FAILED`   |
+    /// | 20  | `CC_ERROR`          |
+    /// | 19  | `ERROR`             |
+    ///
+    /// If **any** of those 13 bits is set this returns
+    /// `Err(Error::CardError(..))`. Otherwise the raw value is preserved so
+    /// callers can inspect informational state bits (`current_state`,
+    /// `ready_for_data`, ...).
+    ///
+    /// Note: earlier versions only looked at bits 19..=24 and silently
+    /// dropped `OUT_OF_RANGE`, `ADDRESS_ERROR`, `BLOCK_LEN_ERROR`,
+    /// `ERASE_PARAM`, `WP_VIOLATION`, `CARD_IS_LOCKED`, and `COM_CRC_ERROR`.
+    /// Callers that used to see `Ok` for one of those now correctly see
+    /// `Err(CardError::..)`.
     pub fn from_native_raw(raw: u32) -> Result<Self, Error> {
-        let err_bits = ((raw >> 19) & 0x3F) as u8;
+        let err_bits = raw & R1_NATIVE_ERROR_MASK;
         if err_bits != 0 {
             return Err(Error::CardError(decode_native_card_error(err_bits)));
         }
@@ -88,21 +126,6 @@ impl R1Response {
             None
         } else {
             Some(decode_spi_card_error(bits))
-        }
-    }
-
-    /// Backwards-compatible parser. Prefer [`R1Response::from_native_raw`] for
-    /// SDIO/native transports and [`R1Response::from_spi_byte`] for SPI mode.
-    ///
-    /// This is retained because external code may still call it. The behavior
-    /// matches `from_native_raw` for values larger than `0xFF` and treats
-    /// smaller values as raw SPI bytes (decoding their error bits as such).
-    #[deprecated(note = "use from_native_raw or from_spi_byte instead")]
-    pub fn from_raw(raw: u32) -> Result<Self, Error> {
-        if raw > 0xFF {
-            Self::from_native_raw(raw)
-        } else {
-            Self::from_spi_byte(raw as u8)
         }
     }
 
@@ -169,7 +192,11 @@ impl R1Response {
 }
 
 /// Card state machine states
+///
+/// Marked `#[non_exhaustive]`: SD/MMC specs may carve new state values out of
+/// the reserved range, and downstream match sites must keep a `_ => ...` arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CardState {
     Idle,
     Ready,
@@ -508,6 +535,26 @@ impl SdioRwResponse {
     }
 }
 
+/// Bitmask covering every native R1 error flag (bits 19..=31 of the 32-bit
+/// response, per SD spec section 4.10.1). `from_native_raw` ANDs the raw
+/// response against this and routes any non-zero result through
+/// `decode_native_card_error`.
+const R1_NATIVE_ERROR_MASK: u32 = 0xFFF8_0000;
+
+const R1_BIT_OUT_OF_RANGE: u32 = 1 << 31;
+const R1_BIT_ADDRESS_ERROR: u32 = 1 << 30;
+const R1_BIT_BLOCK_LEN_ERROR: u32 = 1 << 29;
+const R1_BIT_ERASE_SEQ_ERROR: u32 = 1 << 28;
+const R1_BIT_ERASE_PARAM: u32 = 1 << 27;
+const R1_BIT_WP_VIOLATION: u32 = 1 << 26;
+const R1_BIT_CARD_IS_LOCKED: u32 = 1 << 25;
+const R1_BIT_LOCK_UNLOCK_FAILED: u32 = 1 << 24;
+const R1_BIT_COM_CRC_ERROR: u32 = 1 << 23;
+const R1_BIT_ILLEGAL_COMMAND: u32 = 1 << 22;
+const R1_BIT_CARD_ECC_FAILED: u32 = 1 << 21;
+const R1_BIT_CC_ERROR: u32 = 1 << 20;
+const R1_BIT_ERROR: u32 = 1 << 19;
+
 /// Decode SPI R1 byte error bits (bits 1..=6 of the byte).
 ///
 /// SPI R1 layout (SD spec, simplified):
@@ -529,43 +576,52 @@ fn decode_spi_card_error(bits: u8) -> CardError {
     } else if bits & 0b0010_0000 != 0 {
         CardError::AddressError
     } else if bits & 0b0100_0000 != 0 {
-        // PARAMETER_ERROR — closest existing variant
-        CardError::AddressError
+        // SPI PARAMETER_ERROR maps to native BLOCK_LEN_ERROR/parameter family.
+        CardError::BlockLenError
     } else if bits & (0b0001_0000 | 0b0000_0010) != 0 {
         // ERASE_SEQ_ERROR or ERASE_RESET — both fall under EraseSequence.
         CardError::EraseSequence
     } else {
-        CardError::Unknown(bits)
+        CardError::Unknown(bits as u32)
     }
 }
 
-/// Decode native R1 error nibble (bits 19..=24 of the 32-bit response,
-/// passed in pre-shifted into the low 6 bits).
+/// Decode the native R1 error bits (bits 19..=31 of the 32-bit response).
 ///
-/// Native R1 layout:
-///   bit 19 = AKE_SEQ_ERROR (0x01 in nibble)
-///   bit 20 = CC_ERROR / controller (0x02)
-///   bit 21 = CARD_ECC_FAILED (0x04)
-///   bit 22 = ILLEGAL_COMMAND (0x08)
-///   bit 23 = COM_CRC_ERROR (0x10)
-///   bit 24 = LOCK_UNLOCK_FAILED (0x20)
-fn decode_native_card_error(bits: u8) -> CardError {
-    if bits & 0b0001_0000 != 0 {
+/// Caller passes `raw & R1_NATIVE_ERROR_MASK` (non-zero). When multiple bits
+/// are set we surface the most-severe-first variant per SD spec convention:
+/// argument/addressing errors first (so a write to an invalid LBA is reported
+/// as `OutOfRange` even if the card also raises lower-priority companions),
+/// then bus-integrity errors, then card-state errors, then catch-all
+/// erase/generic. Unknown patterns preserve the raw 13-bit error nibble
+/// (shifted to bit 0) so callers can log the exact bits.
+fn decode_native_card_error(err_bits: u32) -> CardError {
+    if err_bits & R1_BIT_OUT_OF_RANGE != 0 {
+        CardError::OutOfRange
+    } else if err_bits & R1_BIT_ADDRESS_ERROR != 0 {
+        CardError::AddressError
+    } else if err_bits & R1_BIT_BLOCK_LEN_ERROR != 0 {
+        CardError::BlockLenError
+    } else if err_bits & R1_BIT_WP_VIOLATION != 0 {
+        CardError::WriteProtect
+    } else if err_bits & R1_BIT_COM_CRC_ERROR != 0 {
         CardError::CommandCrcFailed
-    } else if bits & 0b0000_1000 != 0 {
+    } else if err_bits & R1_BIT_ILLEGAL_COMMAND != 0 {
         CardError::IllegalCommand
-    } else if bits & 0b0000_0100 != 0 {
+    } else if err_bits & R1_BIT_CARD_ECC_FAILED != 0 {
         CardError::CardEccFailed
-    } else if bits & 0b0000_0010 != 0 {
+    } else if err_bits & R1_BIT_CC_ERROR != 0 {
         CardError::ControllerError
-    } else if bits & 0b0010_0000 != 0 {
-        // LOCK_UNLOCK_FAILED — closest existing variant
-        CardError::ControllerError
-    } else if bits & 0b0000_0001 != 0 {
-        // AKE_SEQ_ERROR — closest existing variant
+    } else if err_bits & R1_BIT_LOCK_UNLOCK_FAILED != 0 {
+        CardError::LockUnlockFailed
+    } else if err_bits & R1_BIT_CARD_IS_LOCKED != 0 {
+        CardError::CardIsLocked
+    } else if err_bits & (R1_BIT_ERASE_SEQ_ERROR | R1_BIT_ERASE_PARAM) != 0 {
         CardError::EraseSequence
+    } else if err_bits & R1_BIT_ERROR != 0 {
+        CardError::GenericError
     } else {
-        CardError::Unknown(bits)
+        CardError::Unknown(err_bits >> 19)
     }
 }
 
@@ -620,6 +676,59 @@ mod tests {
         // illegal command = bit 22 in native R1
         let err = R1Response::from_native_raw(1 << 22).unwrap_err();
         assert_eq!(err, Error::CardError(CardError::IllegalCommand));
+    }
+
+    /// Regression: bits 25..=31 used to be silently dropped because
+    /// `from_native_raw` only masked bits 19..=24. A write to an LBA past
+    /// the end of the card raises `OUT_OF_RANGE` (bit 31) and used to be
+    /// reported as `Ok`. After the mask widening it must surface as an
+    /// `Err(CardError::OutOfRange)`.
+    #[test]
+    fn native_r1_out_of_range_was_previously_dropped() {
+        let err = R1Response::from_native_raw(1 << 31).unwrap_err();
+        assert_eq!(err, Error::CardError(CardError::OutOfRange));
+    }
+
+    #[test]
+    fn native_r1_decodes_each_priority_class() {
+        let cases = [
+            (1u32 << 31, CardError::OutOfRange),
+            (1 << 30, CardError::AddressError),
+            (1 << 29, CardError::BlockLenError),
+            (1 << 26, CardError::WriteProtect),
+            (1 << 25, CardError::CardIsLocked),
+            (1 << 24, CardError::LockUnlockFailed),
+            (1 << 23, CardError::CommandCrcFailed),
+            (1 << 22, CardError::IllegalCommand),
+            (1 << 21, CardError::CardEccFailed),
+            (1 << 20, CardError::ControllerError),
+            (1 << 19, CardError::GenericError),
+            (1 << 28, CardError::EraseSequence),
+            (1 << 27, CardError::EraseSequence),
+        ];
+        for (raw, expected) in cases {
+            let err = R1Response::from_native_raw(raw).unwrap_err();
+            assert_eq!(err, Error::CardError(expected), "raw={raw:#010x}");
+        }
+    }
+
+    /// OUT_OF_RANGE outranks WP_VIOLATION when the card sets both — exercises
+    /// the priority ordering in `decode_native_card_error`.
+    #[test]
+    fn native_r1_priority_picks_argument_errors_first() {
+        let err = R1Response::from_native_raw((1 << 31) | (1 << 26)).unwrap_err();
+        assert_eq!(err, Error::CardError(CardError::OutOfRange));
+    }
+
+    /// Informational status bits (bit 8 READY_FOR_DATA, current_state nibble)
+    /// must not be treated as errors. Regression guard against accidentally
+    /// extending the mask too far.
+    #[test]
+    fn native_r1_status_only_response_is_ok() {
+        let raw = (1u32 << 8) | (4u32 << 9); // READY_FOR_DATA + Transfer state
+        let r1 = R1Response::from_native_raw(raw).unwrap();
+        assert!(r1.ready_for_data());
+        assert_eq!(r1.current_state(), CardState::Transfer);
     }
 
     #[test]

--- a/drivers/blk/sdmmc-protocol/src/sdio.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio.rs
@@ -20,7 +20,12 @@ use crate::{
 };
 
 /// Host IRQ event category returned by portable controller cores.
+///
+/// Marked `#[non_exhaustive]`: new event categories (e.g. card-detect,
+/// re-tuning required) may be added before 1.0; downstream match sites must
+/// keep a `_ => ...` arm.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum HostEventKind {
     /// No runtime action is required.
     #[default]
@@ -40,7 +45,10 @@ pub enum HostEventKind {
 }
 
 /// Hardware engine affected by a host IRQ event.
+///
+/// Marked `#[non_exhaustive]` for forward compatibility.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum HostEventSource {
     /// Whole controller or unknown source.
     #[default]
@@ -71,7 +79,11 @@ impl HostEvent for () {
 }
 
 /// SDIO bus width
+///
+/// Marked `#[non_exhaustive]`: UHS-II / SD Express widths may be added before
+/// 1.0; downstream match sites must keep a `_ => ...` arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BusWidth {
     /// 1-bit bus
     Bit1,
@@ -83,7 +95,12 @@ pub enum BusWidth {
 }
 
 /// SDIO clock speed
+///
+/// Marked `#[non_exhaustive]`: HS400 / HS400_ES / SD Express modes are
+/// expected to land before 1.0; downstream match sites must keep a
+/// `_ => ...` arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ClockSpeed {
     /// Identification clock used during card reset / OCR negotiation.
     Identification,
@@ -109,7 +126,11 @@ pub enum ClockSpeed {
 
 /// Bus signaling voltage. Default-speed and HS modes use 3.3 V; UHS-I
 /// and HS200/HS400 require switching to 1.8 V via CMD11.
+///
+/// Marked `#[non_exhaustive]`: SD Express may introduce additional voltage
+/// domains; downstream match sites must keep a `_ => ...` arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SignalVoltage {
     /// 3.3 V (or 3.0 V — they share an IO domain on most controllers).
     /// The bus comes up here at power-on.
@@ -224,20 +245,121 @@ pub trait SdioHost {
     /// Register the task that should be woken when command or data progress is
     /// possible. Polling-only hosts may keep the default no-op implementation.
     fn register_waker(&mut self, _waker: &Waker) {}
+
+    /// Optional monotonic wall-clock source, in milliseconds.
+    ///
+    /// `None` (the default) means the host has no clock; the protocol layer
+    /// falls back to the poll-counter timeouts documented in
+    /// [`SdioInitTiming`] / [`MmcSwitchTiming`]. `Some(t)` switches the
+    /// ACMD41 / CMD1 power-up and MMC `CMD6 SWITCH` busy-wait budgets to
+    /// wall-clock deadlines, making timeouts independent of caller poll
+    /// cadence.
+    ///
+    /// The protocol layer keeps both checks active whenever a clock is
+    /// available — whichever fires first surfaces as `Error::Timeout`. So a
+    /// host that opts in via this method gets accurate timeouts even when
+    /// glue polls very slowly, and is still protected by the poll budget if
+    /// the clock unexpectedly stalls.
+    ///
+    /// Implementations must be monotonic across calls within a single host
+    /// instance. Resolution finer than 1 ms is fine but not required —
+    /// jiffies at 100 Hz works. Wraparound at `u64` milliseconds
+    /// (~584 million years) is safe to ignore.
+    fn now_ms(&self) -> Option<u64> {
+        None
+    }
 }
 
+/// Poll-cadence contract for [`SdioSdmmc::poll_init_request`] and the
+/// [`MmcSwitchRequest`] busy-wait sub-state.
+///
+/// The protocol layer does not own a wall clock. Every internal "elapsed
+/// time" counter (ACMD41 / CMD1 power-up budget, MMC `CMD6 SWITCH` busy-wait
+/// budget) increments by exactly one tick per `poll_*` invocation and is
+/// compared against [`SdioInitTiming::MAX_POLLS`] / [`MmcSwitchTiming::MAX_POLLS`].
+/// That means timeouts are expressed in **poll iterations**, not seconds.
+///
+/// Caller glue (executor yield, OS sleep, IRQ wakeup) **MUST pace `poll_*`
+/// invocations at roughly [`SdioInitTiming::POLL_TICK_MS_HINT`]** — failing
+/// to do so does not produce undefined behavior, but the observed timeout
+/// will diverge from the documented budget:
+///
+/// - Tight `loop { poll() }` → ACMD41 1 s budget collapses to microseconds.
+/// - Executor that wakes only on hardware IRQ with no fallback timer →
+///   budget extends to seconds because the tick counter advances slowly.
+///
+/// The 10 ms cadence matches the SD spec's recommended ACMD41 retry rate
+/// (sect. 4.2.3) and gives ~100 retries before the protocol layer surfaces
+/// `Error::Timeout`.
+///
+/// # Wall-clock escape hatch
+///
+/// Hosts that implement [`SdioHost::now_ms`] get an additional wall-clock
+/// deadline check layered on top of the poll counter:
+/// [`SdioInitTiming::TIMEOUT_MS`] / [`MmcSwitchTiming::TIMEOUT_MS`] are
+/// enforced against `now_ms() - submit_time_ms`, so the budgets stay
+/// accurate no matter how slow or fast the caller polls. The poll counter
+/// is still consulted as a fallback that fires if the clock unexpectedly
+/// stalls; whichever check trips first surfaces as `Error::Timeout`.
 struct SdioInitTiming;
 
 impl SdioInitTiming {
-    const TIMEOUT_MS: u32 = 1_000;
-    const POLL_MS: u32 = 10;
+    /// Wall-time the protocol layer **assumes** elapses between two
+    /// successive `poll_init_request` invocations. Document-only — the
+    /// protocol code itself never multiplies anything by this constant.
+    /// Caller glue should pace polls at approximately this cadence.
+    const POLL_TICK_MS_HINT: u32 = 10;
+
+    /// Maximum number of `poll_init_request` iterations the protocol layer
+    /// will tolerate while waiting for ACMD41 (SD) or CMD1 (MMC) to report
+    /// `card_powered_up`. At the [`Self::POLL_TICK_MS_HINT`] cadence this is
+    /// equivalent to ~1 second.
+    const MAX_POLLS: u32 = 100;
+
+    /// Wall-clock budget for ACMD41 / CMD1 power-up retries, enforced when
+    /// the host implements [`SdioHost::now_ms`]. Matches the SD spec's
+    /// recommended 1 s ACMD41 retry window (sect. 4.2.3).
+    const TIMEOUT_MS: u64 = 1_000;
 }
 
 struct MmcSwitchTiming;
 
 impl MmcSwitchTiming {
-    const TIMEOUT_MS: u32 = 250;
-    const POLL_MS: u32 = SdioInitTiming::POLL_MS;
+    /// Maximum number of poll iterations spent waiting for an MMC
+    /// `CMD6 SWITCH` to leave the Programming state. At the
+    /// [`SdioInitTiming::POLL_TICK_MS_HINT`] cadence this is equivalent to
+    /// ~250 ms — long enough to absorb worst-case `GENERIC_CMD6_TIME` while
+    /// short enough that a hung card surfaces as `Error::Timeout` rather
+    /// than blocking init forever.
+    const MAX_POLLS: u32 = 25;
+
+    /// Wall-clock budget for the MMC `CMD6 SWITCH` busy-wait, enforced when
+    /// the host implements [`SdioHost::now_ms`]. Sized to match `MAX_POLLS`
+    /// at the recommended poll cadence so clock-aware and poll-only hosts
+    /// see the same effective budget.
+    const TIMEOUT_MS: u64 = 250;
+}
+
+/// Return whether the wall-clock budget for ACMD41 / CMD1 power-up has
+/// elapsed. `started_ms` is the time the busy-wait phase began (captured
+/// from [`SdioHost::now_ms`] on the first not-ready response). The check is
+/// a no-op when either the host has no clock or the budget has not been
+/// armed yet.
+fn power_up_deadline_passed<H: SdioHost>(host: &H, started_ms: Option<u64>) -> bool {
+    match (started_ms, host.now_ms()) {
+        (Some(started), Some(now)) => now.saturating_sub(started) >= SdioInitTiming::TIMEOUT_MS,
+        _ => false,
+    }
+}
+
+/// Return whether the wall-clock budget for MMC `CMD6 SWITCH` has elapsed.
+/// See [`power_up_deadline_passed`] for the contract.
+fn mmc_switch_deadline_passed<H: SdioHost>(host: &H, request: &MmcSwitchRequest) -> bool {
+    let elapsed_exceeded = match (request.started_ms, host.now_ms()) {
+        (Some(started), Some(now)) => now.saturating_sub(started) >= MmcSwitchTiming::TIMEOUT_MS,
+        _ => false,
+    };
+    elapsed_exceeded || request.polls >= MmcSwitchTiming::MAX_POLLS
 }
 
 /// SDIO mode SD/MMC driver
@@ -248,6 +370,7 @@ pub struct SdioSdmmc<H: SdioHost> {
     bus_width: BusWidth,
     kind: CardKind,
     sd_speed_selection_enabled: bool,
+    sd_uhs_selection_enabled: bool,
 }
 
 pub struct SdioDataRequest<'a, H: SdioHost + 'a> {
@@ -277,7 +400,12 @@ pub struct MmcSwitchRequest {
     rca: u16,
     index: u8,
     value: u8,
-    elapsed_ms: u32,
+    polls: u32,
+    /// Wall-clock submit time captured from [`SdioHost::now_ms`], used as
+    /// the start of the [`MmcSwitchTiming::TIMEOUT_MS`] window. `None`
+    /// means the host has no clock and only [`MmcSwitchTiming::MAX_POLLS`]
+    /// gates the busy-wait.
+    started_ms: Option<u64>,
     state: MmcSwitchRequestState,
 }
 
@@ -288,7 +416,11 @@ enum MmcSwitchRequestState {
 }
 
 /// Card initialization probe order.
+///
+/// Marked `#[non_exhaustive]`: SDIO-only / no-SD-fallback modes may be added
+/// before 1.0; downstream match sites must keep a `_ => ...` arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CardInitPreference {
     /// Probe SD first, then fall back to MMC.
     SdFirst,
@@ -297,6 +429,10 @@ pub enum CardInitPreference {
 }
 
 /// Caller-owned scratch buffers for SD/MMC initialization data commands.
+///
+/// Keeping the buffers on the caller's side keeps the `SdioInitRequest`
+/// transferable across `Send` boundaries without pinning, and lets bring-up
+/// code reuse the same backing storage across retries.
 pub struct SdioInitScratch {
     ext_csd: [u8; 512],
     switch_status: [u8; 64],
@@ -317,6 +453,84 @@ impl Default for SdioInitScratch {
     }
 }
 
+/// Pointer to a fixed-size scratch buffer with runtime borrow tracking.
+///
+/// The init state machine is *self-referential*: an in-flight data request
+/// (`ExtCsdRequest`, `SwitchFunctionRequest`) lends the buffer to the host
+/// for the duration of a transfer, and the host's `DataRequest<'a>` type
+/// ties that lifetime back to the scratch. Rust's borrow checker can't
+/// express "host has the buffer until the next `poll_*` reports Complete"
+/// inside `SdioInitRequest`, so the code uses a raw pointer.
+///
+/// `ScratchSlot` keeps that pointer but adds a debug-time `lent` flag, so
+/// any future state-machine path that tries to peek into the buffer while
+/// it's still on loan to the host (which would be a use-after-free /
+/// aliasing UB on real hardware) trips an assertion in development builds.
+/// In release builds the flag is still tracked but the assertions compile
+/// down to nothing, preserving the zero-overhead intent.
+///
+/// # Safety
+///
+/// Constructing a `ScratchSlot` is safe: the constructor takes a `&'a mut`
+/// reference and the surrounding [`SdioInitRequest`] carries `'a` so the
+/// underlying storage cannot be dropped while the slot is reachable. The
+/// pointer-based accessors (`lend`, `peek`) are `unsafe` to call when the
+/// borrow state lies (i.e. you returned the buffer to the host without
+/// calling `release`); the `_ = lend(); release()` discipline below makes
+/// that hard to get wrong.
+struct ScratchSlot<const N: usize> {
+    ptr: core::ptr::NonNull<[u8; N]>,
+    lent: bool,
+}
+
+impl<const N: usize> ScratchSlot<N> {
+    fn new(buf: &mut [u8; N]) -> Self {
+        Self {
+            ptr: core::ptr::NonNull::from(buf),
+            lent: false,
+        }
+    }
+
+    /// Hand the buffer to a data-engine call site. Records that the buffer
+    /// is on loan; pair with [`Self::release`] once the request completes.
+    ///
+    /// # Safety
+    ///
+    /// The returned `&mut [u8; N]` is aliased with the raw pointer held by
+    /// this slot. Caller must ensure no other path reads through the slot
+    /// (via `peek` / `lend`) until [`Self::release`] is called. The init
+    /// state machine satisfies this by gating all access on
+    /// `request.{ext_csd,switch_function}_request.is_some()`.
+    unsafe fn lend<'b>(&mut self) -> &'b mut [u8; N] {
+        debug_assert!(
+            !self.lent,
+            "scratch slot lent twice without release; this is a state-machine bug"
+        );
+        self.lent = true;
+        unsafe { &mut *self.ptr.as_ptr() }
+    }
+
+    /// Mark the buffer as no longer owned by the host so `peek` is safe.
+    /// Idempotent.
+    fn release(&mut self) {
+        self.lent = false;
+    }
+
+    /// Read-only view, valid after the host has released the buffer.
+    ///
+    /// # Safety
+    ///
+    /// Caller must call this only when the buffer is not on loan to a host
+    /// data engine. The `debug_assert!` traps the bug in dev builds.
+    unsafe fn peek<'b>(&self) -> &'b [u8; N] {
+        debug_assert!(
+            !self.lent,
+            "scratch slot peeked while still lent to host; this is a state-machine bug"
+        );
+        unsafe { &*self.ptr.as_ptr() }
+    }
+}
+
 /// Submitted SDIO initialization transaction.
 pub struct SdioInitRequest<'a, H: SdioHost + 'a> {
     state: SdioInitState,
@@ -327,12 +541,20 @@ pub struct SdioInitRequest<'a, H: SdioHost + 'a> {
     cid: Option<CidResponse>,
     capacity_blocks: Option<u64>,
     parsed_ext_csd: Option<crate::ext_csd::ExtCsd>,
-    acmd41_elapsed_ms: u32,
-    mmc_elapsed_ms: u32,
+    acmd41_polls: u32,
+    mmc_polls: u32,
+    /// Wall-clock time captured the first time ACMD41 reported the SD card
+    /// was not yet powered up. Used together with
+    /// [`SdioInitTiming::TIMEOUT_MS`] to surface an accurate timeout when
+    /// the host implements [`SdioHost::now_ms`].
+    acmd41_started_ms: Option<u64>,
+    /// MMC counterpart to `acmd41_started_ms`, captured on the first CMD1
+    /// not-ready response.
+    mmc_started_ms: Option<u64>,
     mmc_ocr_arg: u32,
     needs_pace: bool,
-    ext_csd_buf: core::ptr::NonNull<[u8; 512]>,
-    switch_status_buf: core::ptr::NonNull<[u8; 64]>,
+    ext_csd_buf: ScratchSlot<512>,
+    switch_status_buf: ScratchSlot<64>,
     ext_csd_request: Option<ExtCsdRequest<'a, H>>,
     switch_function_request: Option<SwitchFunctionRequest<'a, H>>,
     mmc_switch_request: Option<MmcSwitchRequest>,
@@ -356,12 +578,14 @@ impl<'a, H: SdioHost + 'a> SdioInitRequest<'a, H> {
             cid: None,
             capacity_blocks: None,
             parsed_ext_csd: None,
-            acmd41_elapsed_ms: 0,
-            mmc_elapsed_ms: 0,
+            acmd41_polls: 0,
+            mmc_polls: 0,
+            acmd41_started_ms: None,
+            mmc_started_ms: None,
             mmc_ocr_arg: 0,
             needs_pace: false,
-            ext_csd_buf: core::ptr::NonNull::from(&mut scratch.ext_csd),
-            switch_status_buf: core::ptr::NonNull::from(&mut scratch.switch_status),
+            ext_csd_buf: ScratchSlot::new(&mut scratch.ext_csd),
+            switch_status_buf: ScratchSlot::new(&mut scratch.switch_status),
             ext_csd_request: None,
             switch_function_request: None,
             mmc_switch_request: None,
@@ -463,6 +687,7 @@ impl<H: SdioHost> SdioSdmmc<H> {
             bus_width: BusWidth::Bit1,
             kind: CardKind::Sd,
             sd_speed_selection_enabled: true,
+            sd_uhs_selection_enabled: true,
         }
     }
 
@@ -483,6 +708,16 @@ impl<H: SdioHost> SdioSdmmc<H> {
     /// UHS-I timing.
     pub fn set_sd_speed_selection_enabled(&mut self, enabled: bool) {
         self.sd_speed_selection_enabled = enabled;
+    }
+
+    /// Enable or disable UHS-I SD access-mode selection.
+    ///
+    /// When disabled while SD speed selection remains enabled, initialization
+    /// still uses CMD6 to select legacy HighSpeed when the card supports it,
+    /// but it does not try CMD11 voltage switching, SDR50, SDR104, DDR50, or
+    /// tuning.
+    pub fn set_sd_uhs_selection_enabled(&mut self, enabled: bool) {
+        self.sd_uhs_selection_enabled = enabled;
     }
 
     /// Which card family the driver detected. Meaningful only after a
@@ -651,12 +886,14 @@ impl<H: SdioHost> SdioSdmmc<H> {
         value: u8,
     ) -> Result<MmcSwitchRequest, Error> {
         let cmd = crate::cmd::cmd6_mmc_switch(access, index, value);
+        let started_ms = self.host.now_ms();
         self.host.submit_command(&cmd)?;
         Ok(MmcSwitchRequest {
             rca: self.rca,
             index,
             value,
-            elapsed_ms: 0,
+            polls: 0,
+            started_ms,
             state: MmcSwitchRequestState::PollSwitch,
         })
     }
@@ -688,21 +925,19 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     if r1.ready_for_data() && matches!(r1.current_state(), CardState::Transfer) {
                         return Ok(OperationPoll::Complete(()));
                     }
-                    if request.elapsed_ms >= MmcSwitchTiming::TIMEOUT_MS {
+                    if mmc_switch_deadline_passed(&self.host, request) {
                         return Err(Error::Timeout(ErrorContext::for_cmd(Phase::Init, 6)));
                     }
-                    request.elapsed_ms =
-                        request.elapsed_ms.saturating_add(MmcSwitchTiming::POLL_MS);
+                    request.polls = request.polls.saturating_add(1);
                     let cmd = crate::cmd::cmd13(request.rca);
                     self.host.submit_command(&cmd)?;
                     Ok(OperationPoll::Pending)
                 }
                 CommandResponsePoll::Complete(_) => {
-                    if request.elapsed_ms >= MmcSwitchTiming::TIMEOUT_MS {
+                    if mmc_switch_deadline_passed(&self.host, request) {
                         return Err(Error::Timeout(ErrorContext::for_cmd(Phase::Init, 6)));
                     }
-                    request.elapsed_ms =
-                        request.elapsed_ms.saturating_add(MmcSwitchTiming::POLL_MS);
+                    request.polls = request.polls.saturating_add(1);
                     let cmd = crate::cmd::cmd13(request.rca);
                     self.host.submit_command(&cmd)?;
                     Ok(OperationPoll::Pending)
@@ -714,6 +949,21 @@ impl<H: SdioHost> SdioSdmmc<H> {
 
 impl<H: SdioHost> SdioSdmmc<H> {
     /// Submit SD/MMC card initialization without waiting for completion.
+    ///
+    /// # Poll-cadence contract
+    ///
+    /// The returned [`SdioInitRequest`] expects the caller to drive it via
+    /// repeated [`Self::poll_init_request`] calls. The protocol layer does
+    /// not own a clock — its ACMD41 / CMD1 timeouts and MMC `CMD6 SWITCH`
+    /// busy-waits count poll iterations, not wall-time. Caller glue
+    /// (executor yield, OS sleep, IRQ wakeup) **must space `poll_*`
+    /// invocations by approximately
+    /// [`SdioInitTiming::POLL_TICK_MS_HINT`] (10 ms)**. See
+    /// [`SdioInitTiming`] / [`MmcSwitchTiming`] for the full contract.
+    /// `take_needs_pace` on the returned request reports when the protocol
+    /// layer specifically wants the caller to wait before re-polling
+    /// (used during ACMD41 power-up); ordinary pending states do not set
+    /// it but still benefit from the same cadence.
     pub fn submit_init<'a>(
         &mut self,
         scratch: &'a mut SdioInitScratch,
@@ -733,17 +983,44 @@ impl<H: SdioHost> SdioSdmmc<H> {
     where
         H: 'a,
     {
-        info!("sdio: init starting");
+        debug!("sdio: init starting");
+        // Best-effort cleanup of any state a previous, aborted init may have
+        // left on the host (e.g. UHS_MODE bits, 4-bit bus, 50 MHz clock).
+        // We can't propagate failures here without poisoning the caller's
+        // retry path — `set_*` calls below run with `?` so the actual
+        // identification-mode requirements are enforced.
+        self.abort_init();
+
         self.host.set_bus_width(BusWidth::Bit1)?;
         self.host.set_clock(ClockSpeed::Identification)?;
 
-        info!("sdio: CMD0 reset");
+        debug!("sdio: CMD0 reset");
         self.host.submit_command(&crate::cmd::CMD0)?;
         Ok(SdioInitRequest::new(preference, scratch))
     }
 
     /// Advance a submitted initialization request without blocking.
+    ///
+    /// On any terminal `Err` the controller is reset back toward an
+    /// identification-mode-compatible state (1-bit bus, 400 kHz clock, 3.3 V
+    /// signaling) so a retry from a fresh [`submit_init`](Self::submit_init)
+    /// starts from a known baseline. `Ok(OperationPoll::Pending)` does not
+    /// trigger the reset; only terminal failures do.
     pub fn poll_init_request<'a>(
+        &mut self,
+        request: &mut SdioInitRequest<'a, H>,
+    ) -> Result<OperationPoll<CardInfo>, Error> {
+        match self.poll_init_inner(request) {
+            Ok(progress) => Ok(progress),
+            Err(err) => {
+                warn!("sdio: init aborted ({:?}), resetting host", err);
+                self.abort_init();
+                Err(err)
+            }
+        }
+    }
+
+    fn poll_init_inner<'a>(
         &mut self,
         request: &mut SdioInitRequest<'a, H>,
     ) -> Result<OperationPoll<CardInfo>, Error> {
@@ -762,7 +1039,7 @@ impl<H: SdioHost> SdioSdmmc<H> {
                             request.state = SdioInitState::PollCmd8;
                         }
                         CardInitPreference::MmcFirst => {
-                            info!("sdio: MMC-first init, trying CMD1");
+                            debug!("sdio: MMC-first init, trying CMD1");
                             self.host.submit_command(&crate::cmd::cmd1(0))?;
                             request.state = SdioInitState::PollMmcInitial;
                         }
@@ -774,7 +1051,7 @@ impl<H: SdioHost> SdioSdmmc<H> {
                 Ok(CommandResponsePoll::Pending) => Ok(OperationPoll::Pending),
                 Ok(CommandResponsePoll::Complete(Response::R7(resp))) => {
                     request.sd_v2 = resp.verify(0x01, 0xAA);
-                    info!("sdio: CMD8 sd_v2={}", request.sd_v2);
+                    debug!("sdio: CMD8 sd_v2={}", request.sd_v2);
                     let cmd55 = crate::cmd::cmd55(0);
                     self.host.submit_command(&cmd55)?;
                     request.state = SdioInitState::PollAcmd41Cmd55;
@@ -785,7 +1062,7 @@ impl<H: SdioHost> SdioSdmmc<H> {
                 | Err(Error::BadResponse(_))
                 | Err(Error::Crc(_)) => {
                     request.sd_v2 = false;
-                    info!("sdio: CMD8 sd_v2=false");
+                    debug!("sdio: CMD8 sd_v2=false");
                     let cmd55 = crate::cmd::cmd55(0);
                     self.host.submit_command(&cmd55)?;
                     request.state = SdioInitState::PollAcmd41Cmd55;
@@ -802,7 +1079,7 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     Ok(OperationPoll::Pending)
                 }
                 Err(_sd_err) => {
-                    info!(
+                    debug!(
                         "sdio: ACMD41 prologue failed ({:?}), trying MMC CMD1",
                         _sd_err
                     );
@@ -822,18 +1099,23 @@ impl<H: SdioHost> SdioSdmmc<H> {
                         self.host.submit_command(&crate::cmd::CMD2)?;
                         request.state = SdioInitState::PollCmd2;
                     } else {
-                        if request.acmd41_elapsed_ms >= SdioInitTiming::TIMEOUT_MS {
+                        let elapsed_exceeded =
+                            power_up_deadline_passed(&self.host, request.acmd41_started_ms);
+                        if request.acmd41_polls >= SdioInitTiming::MAX_POLLS || elapsed_exceeded {
                             warn!(
-                                "sdio: ACMD41 timed out after {}ms, trying MMC CMD1",
-                                request.acmd41_elapsed_ms
+                                "sdio: ACMD41 timed out after {} polls (~{} ms at the recommended \
+                                 cadence), trying MMC CMD1",
+                                request.acmd41_polls,
+                                request.acmd41_polls * SdioInitTiming::POLL_TICK_MS_HINT,
                             );
                             self.host.submit_command(&crate::cmd::cmd1(0))?;
                             request.state = SdioInitState::PollMmcInitial;
                             return Ok(OperationPoll::Pending);
                         }
-                        request.acmd41_elapsed_ms = request
-                            .acmd41_elapsed_ms
-                            .saturating_add(SdioInitTiming::POLL_MS);
+                        if request.acmd41_started_ms.is_none() {
+                            request.acmd41_started_ms = self.host.now_ms();
+                        }
+                        request.acmd41_polls = request.acmd41_polls.saturating_add(1);
                         let cmd55 = crate::cmd::cmd55(0);
                         self.host.submit_command(&cmd55)?;
                         request.state = SdioInitState::PollAcmd41Cmd55;
@@ -842,13 +1124,13 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     Ok(OperationPoll::Pending)
                 }
                 Ok(CommandResponsePoll::Complete(_)) => {
-                    info!("sdio: ACMD41 returned bad response, trying MMC CMD1");
+                    debug!("sdio: ACMD41 returned bad response, trying MMC CMD1");
                     self.host.submit_command(&crate::cmd::cmd1(0))?;
                     request.state = SdioInitState::PollMmcInitial;
                     Ok(OperationPoll::Pending)
                 }
                 Err(_sd_err) => {
-                    info!("sdio: ACMD41 failed ({:?}), trying MMC CMD1", _sd_err);
+                    debug!("sdio: ACMD41 failed ({:?}), trying MMC CMD1", _sd_err);
                     self.host.submit_command(&crate::cmd::cmd1(0))?;
                     request.state = SdioInitState::PollMmcInitial;
                     Ok(OperationPoll::Pending)
@@ -893,13 +1175,21 @@ impl<H: SdioHost> SdioSdmmc<H> {
                         self.host.submit_command(&crate::cmd::CMD2)?;
                         request.state = SdioInitState::PollCmd2;
                     } else {
-                        if request.mmc_elapsed_ms >= SdioInitTiming::TIMEOUT_MS {
-                            warn!("sdio: CMD1 timed out after {}ms", request.mmc_elapsed_ms);
+                        let elapsed_exceeded =
+                            power_up_deadline_passed(&self.host, request.mmc_started_ms);
+                        if request.mmc_polls >= SdioInitTiming::MAX_POLLS || elapsed_exceeded {
+                            warn!(
+                                "sdio: CMD1 timed out after {} polls (~{} ms at the recommended \
+                                 cadence)",
+                                request.mmc_polls,
+                                request.mmc_polls * SdioInitTiming::POLL_TICK_MS_HINT,
+                            );
                             return Err(Error::Timeout(ErrorContext::for_cmd(Phase::Init, 1)));
                         }
-                        request.mmc_elapsed_ms = request
-                            .mmc_elapsed_ms
-                            .saturating_add(SdioInitTiming::POLL_MS);
+                        if request.mmc_started_ms.is_none() {
+                            request.mmc_started_ms = self.host.now_ms();
+                        }
+                        request.mmc_polls = request.mmc_polls.saturating_add(1);
                         let cmd = crate::cmd::cmd1(request.mmc_ocr_arg);
                         self.host.submit_command(&cmd)?;
                         request.needs_pace = true;
@@ -936,7 +1226,7 @@ impl<H: SdioHost> SdioSdmmc<H> {
                             return Err(Error::BadResponse(ErrorContext::for_cmd(Phase::Init, 3)));
                         }
                     };
-                    info!("sdio: CMD3 rca={:#x}", self.rca);
+                    debug!("sdio: CMD3 rca={:#x}", self.rca);
                     let cmd9 = crate::cmd::cmd9(self.rca);
                     self.host.submit_command(&cmd9)?;
                     request.state = SdioInitState::PollCmd9;
@@ -998,18 +1288,22 @@ impl<H: SdioHost> SdioSdmmc<H> {
                 let kind = request.kind.ok_or(Error::InvalidArgument)?;
                 match kind {
                     CardKind::Sd => {
+                        self.host.set_clock(ClockSpeed::Default)?;
                         if self.sd_speed_selection_enabled {
                             request.state = SdioInitState::PrepareSdSpeed;
                         } else {
-                            self.host.set_clock(ClockSpeed::Default)?;
-                            info!("sdio: SD speed selection disabled; staying at default speed");
+                            debug!("sdio: SD speed selection disabled; staying at default speed");
                             request.state = SdioInitState::Complete;
                         }
                         Ok(OperationPoll::Pending)
                     }
                     CardKind::Mmc => {
-                        info!("sdio: read MMC EXT_CSD");
-                        let ext_csd = unsafe { request.ext_csd_buf.as_mut() };
+                        debug!("sdio: read MMC EXT_CSD");
+                        // SAFETY: the slot's debug_assert traps re-lending; the
+                        // returned reference's lifetime is bound to the host's
+                        // DataRequest via SwitchFunctionRequest/ExtCsdRequest,
+                        // and we release on the Complete arm below.
+                        let ext_csd = unsafe { request.ext_csd_buf.lend() };
                         request.ext_csd_request = Some(self.submit_read_ext_csd(ext_csd)?);
                         request.state = SdioInitState::PollMmcExtCsd;
                         Ok(OperationPoll::Pending)
@@ -1025,8 +1319,13 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     OperationPoll::Pending => Ok(OperationPoll::Pending),
                     OperationPoll::Complete(()) => {
                         request.ext_csd_request = None;
+                        request.ext_csd_buf.release();
+                        // SAFETY: we just released the slot above; the host
+                        // has finished writing the buffer (DataCommandPoll::
+                        // Complete is the host's promise) and nothing else
+                        // holds a reference.
                         let csd = crate::ext_csd::ExtCsd::from_bytes(unsafe {
-                            *request.ext_csd_buf.as_ref()
+                            *request.ext_csd_buf.peek()
                         });
                         if let Some(sectors) = csd.sector_count() {
                             request.capacity_blocks = Some(sectors as u64);
@@ -1053,11 +1352,11 @@ impl<H: SdioHost> SdioSdmmc<H> {
                                 Ok(OperationPoll::Pending)
                             }
                             Err(err) if matches!(request.current_bus_width, BusWidth::Bit8) => {
-                                info!("sdio: 8-bit refused ({:?}), trying 4-bit", err);
+                                debug!("sdio: 8-bit refused ({:?}), trying 4-bit", err);
                                 submit_mmc_bus_width_or_continue(self, request, BusWidth::Bit4)
                             }
                             Err(err) if matches!(request.current_bus_width, BusWidth::Bit4) => {
-                                info!("sdio: 4-bit refused ({:?}), staying at 1-bit", err);
+                                debug!("sdio: 4-bit refused ({:?}), staying at 1-bit", err);
                                 request.state = SdioInitState::PrepareMmcSpeed;
                                 Ok(OperationPoll::Pending)
                             }
@@ -1066,12 +1365,12 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     }
                     Err(err) if matches!(request.current_bus_width, BusWidth::Bit8) => {
                         request.mmc_switch_request = None;
-                        info!("sdio: 8-bit refused ({:?}), trying 4-bit", err);
+                        debug!("sdio: 8-bit refused ({:?}), trying 4-bit", err);
                         submit_mmc_bus_width_or_continue(self, request, BusWidth::Bit4)
                     }
                     Err(err) if matches!(request.current_bus_width, BusWidth::Bit4) => {
                         request.mmc_switch_request = None;
-                        info!("sdio: 4-bit refused ({:?}), staying at 1-bit", err);
+                        debug!("sdio: 4-bit refused ({:?}), staying at 1-bit", err);
                         request.state = SdioInitState::PrepareMmcSpeed;
                         Ok(OperationPoll::Pending)
                     }
@@ -1089,7 +1388,7 @@ impl<H: SdioHost> SdioSdmmc<H> {
                 {
                     request.mmc_hs200_attempted = true;
                     match self.host.switch_voltage(SignalVoltage::V180) {
-                        Ok(()) | Err(Error::UnsupportedCommand) => {
+                        Ok(()) => {
                             let switch_request = self.submit_mmc_switch(
                                 0b11,
                                 crate::cmd::ext_csd::HS_TIMING as u8,
@@ -1099,6 +1398,13 @@ impl<H: SdioHost> SdioSdmmc<H> {
                             request.state = SdioInitState::PollMmcHs200Switch;
                             return Ok(OperationPoll::Pending);
                         }
+                        // The host has no way to actually drive the IO rail
+                        // at 1.8 V (controllers like the rk3568 SDHCI MVP
+                        // refuse here on purpose); HS200 requires 1.8 V, so
+                        // skip the attempt entirely instead of leaving the
+                        // controller's 1.8 V Signaling Enable bit set while
+                        // running the bus at 3.3 V.
+                        Err(Error::UnsupportedCommand) => {}
                         Err(err) => debug!("sdio: switch_voltage(V180) failed ({:?})", err),
                     }
                     self.rollback_to_hs_compat();
@@ -1174,21 +1480,23 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     Ok(OperationPoll::Complete(())) => {
                         request.mmc_switch_request = None;
                         if let Err(_e) = self.host.set_clock(ClockSpeed::HighSpeed) {
-                            info!("sdio: host refused HighSpeed clock ({:?})", _e);
+                            debug!("sdio: host refused HighSpeed clock ({:?})", _e);
                         }
                         request.state = SdioInitState::Complete;
                         Ok(OperationPoll::Pending)
                     }
                     Err(_e) => {
                         request.mmc_switch_request = None;
-                        info!("sdio: MMC HS_TIMING switch refused ({:?})", _e);
+                        debug!("sdio: MMC HS_TIMING switch refused ({:?})", _e);
                         request.state = SdioInitState::Complete;
                         Ok(OperationPoll::Pending)
                     }
                 }
             }
             SdioInitState::PrepareSdSpeed => {
-                let buf = unsafe { request.switch_status_buf.as_mut() };
+                // SAFETY: see ext_csd lend above; release happens on the
+                // PollSdSwitchFunctionCheck Complete arm below.
+                let buf = unsafe { request.switch_status_buf.lend() };
                 let switch_request =
                     self.submit_switch_function(&crate::cmd::cmd6_sd_access_mode(false, 0), buf)?;
                 request.switch_function_request = Some(switch_request);
@@ -1204,9 +1512,12 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     Ok(OperationPoll::Pending) => Ok(OperationPoll::Pending),
                     Ok(OperationPoll::Complete(())) => {
                         request.switch_function_request = None;
+                        request.switch_status_buf.release();
+                        // SAFETY: just released above; host promised the data
+                        // phase is done via DataCommandPoll::Complete.
                         let status =
-                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.as_ref() });
-                        info!(
+                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.peek() });
+                        debug!(
                             "sdio: SD access mode support hs={} sdr50={} sdr104={} ddr50={} \
                              s18a={}",
                             status.access_mode_supported(SdAccessMode::HighSpeed.function()),
@@ -1220,6 +1531,7 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     }
                     Err(err) => {
                         request.switch_function_request = None;
+                        request.switch_status_buf.release();
                         warn!("sdio: SD speed selection skipped ({:?})", err);
                         request.state = SdioInitState::Complete;
                         Ok(OperationPoll::Pending)
@@ -1240,8 +1552,11 @@ impl<H: SdioHost> SdioSdmmc<H> {
                             Ok(()) => submit_sd_access_mode_switch(self, request, mode),
                             Err(err) => {
                                 warn!("sdio: SD {} failed ({:?})", mode.name(), err);
+                                // SAFETY: no switch_function_request is in
+                                // flight on this branch (CMD11 path uses the
+                                // command channel), so the slot is not lent.
                                 let status = SwitchStatus::from_raw(unsafe {
-                                    *request.switch_status_buf.as_ref()
+                                    *request.switch_status_buf.peek()
                                 });
                                 submit_next_sd_access_mode(self, request, status)
                             }
@@ -1250,8 +1565,9 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     Err(err) => {
                         request.command_request = None;
                         warn!("sdio: SD {} failed ({:?})", mode.name(), err);
+                        // SAFETY: same as above — no in-flight data request.
                         let status =
-                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.as_ref() });
+                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.peek() });
                         submit_next_sd_access_mode(self, request, status)
                     }
                 }
@@ -1266,8 +1582,10 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     Ok(OperationPoll::Pending) => Ok(OperationPoll::Pending),
                     Ok(OperationPoll::Complete(())) => {
                         request.switch_function_request = None;
+                        request.switch_status_buf.release();
+                        // SAFETY: just released above.
                         let status =
-                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.as_ref() });
+                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.peek() });
                         if status.selected_function(1) != mode.function() {
                             warn!("sdio: SD {} failed (function mismatch)", mode.name());
                             submit_next_sd_access_mode(self, request, status)
@@ -1284,9 +1602,11 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     }
                     Err(err) => {
                         request.switch_function_request = None;
+                        request.switch_status_buf.release();
                         warn!("sdio: SD {} failed ({:?})", mode.name(), err);
+                        // SAFETY: just released above.
                         let status =
-                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.as_ref() });
+                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.peek() });
                         submit_next_sd_access_mode(self, request, status)
                     }
                 }
@@ -1308,8 +1628,11 @@ impl<H: SdioHost> SdioSdmmc<H> {
                     OperationPoll::Complete(_) => {
                         request.status_request = None;
                         warn!("sdio: SD {} failed (bad status)", mode.name());
+                        // SAFETY: PollSdStatus is reached after the switch
+                        // request released the slot in PollSdSetAccessMode;
+                        // no data request is in flight.
                         let status =
-                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.as_ref() });
+                            SwitchStatus::from_raw(unsafe { *request.switch_status_buf.peek() });
                         submit_next_sd_access_mode(self, request, status)
                     }
                 }
@@ -1335,6 +1658,36 @@ impl<H: SdioHost> SdioSdmmc<H> {
         }
     }
 
+    /// Best-effort host + driver reset after a failed or abandoned init.
+    ///
+    /// Init can leave the controller in any number of partially-programmed
+    /// states: 4-bit/8-bit bus already negotiated, clock raised to HS@52,
+    /// HOST_CONTROL2 UHS bits set from a HS200 attempt, 1.8 V signaling
+    /// armed. None of those are safe defaults for a subsequent retry that
+    /// expects to start by replaying CMD0 in identification mode.
+    ///
+    /// This helper:
+    ///
+    /// - Asks the host to drop back to identification clock, 1-bit bus, and
+    ///   3.3 V signaling. Errors from each call are swallowed — we're
+    ///   already on the error path and want maximum cleanup, not a second
+    ///   failure mid-recovery.
+    /// - Clears the driver's cached card state (RCA, kind, bus width,
+    ///   high-capacity flag) so subsequent calls don't act on stale data
+    ///   from the aborted card.
+    ///
+    /// Idempotent: calling it twice or on a fresh driver is a no-op
+    /// modulo the (already-defaulted) field stores.
+    fn abort_init(&mut self) {
+        let _ = self.host.switch_voltage(SignalVoltage::V330);
+        let _ = self.host.set_clock(ClockSpeed::Identification);
+        let _ = self.host.set_bus_width(BusWidth::Bit1);
+        self.rca = 0;
+        self.high_capacity = false;
+        self.bus_width = BusWidth::Bit1;
+        self.kind = CardKind::Sd;
+    }
+
     /// Best-effort rollback after a failed HS200 attempt. Drops the
     /// controller clock back to default speed; the outer `init` will
     /// then re-program HS_TIMING=1 + HighSpeed in its fallback branch.
@@ -1342,6 +1695,11 @@ impl<H: SdioHost> SdioSdmmc<H> {
     /// path and want to give the rest of `init` the best shot at
     /// recovering.
     fn rollback_to_hs_compat(&mut self) {
+        // Drop any 1.8 V signaling the HS200 attempt may have armed on the
+        // controller. Without this, the IO sampling stays at the 1.8 V
+        // reference while we drive the bus back at 3.3 V, so the very next
+        // data transfer (e.g. the FS layer's CMD17 at LBA 0) times out.
+        let _ = self.host.switch_voltage(SignalVoltage::V330);
         let _ = self.host.set_clock(ClockSpeed::Default);
     }
 }
@@ -1369,7 +1727,7 @@ fn submit_next_sd_access_mode<'a, H: SdioHost + 'a>(
     status: SwitchStatus,
 ) -> Result<OperationPoll<CardInfo>, Error> {
     let ocr = request.ocr.ok_or(Error::InvalidArgument)?;
-    let candidates = if ocr.s18a() {
+    let candidates = if driver.sd_uhs_selection_enabled && ocr.s18a() {
         &[
             SdAccessMode::Sdr104,
             SdAccessMode::Sdr50,
@@ -1387,14 +1745,14 @@ fn submit_next_sd_access_mode<'a, H: SdioHost + 'a>(
             continue;
         }
         if matches!(mode, SdAccessMode::HighSpeed) {
-            info!("sdio: trying SD HighSpeed");
+            debug!("sdio: trying SD HighSpeed");
         } else {
-            info!("sdio: trying SD {}", mode.name());
+            debug!("sdio: trying SD {}", mode.name());
         }
         return submit_sd_access_mode(driver, request, mode);
     }
 
-    info!("sdio: SD card stayed at default speed");
+    debug!("sdio: SD card stayed at default speed");
     request.state = SdioInitState::Complete;
     Ok(OperationPoll::Pending)
 }
@@ -1421,7 +1779,12 @@ fn submit_sd_access_mode_switch<'a, H: SdioHost + 'a>(
     request: &mut SdioInitRequest<'a, H>,
     mode: SdAccessMode,
 ) -> Result<OperationPoll<CardInfo>, Error> {
-    let buf = unsafe { request.switch_status_buf.as_mut() };
+    // SAFETY: the prior switch_function_request was either consumed and
+    // released in PollSdSwitchFunctionCheck Complete, or never lent (CMD11
+    // voltage-switch failure path); release defensively so a re-entered
+    // path doesn't keep the slot flagged.
+    request.switch_status_buf.release();
+    let buf = unsafe { request.switch_status_buf.lend() };
     request.switch_function_request = Some(
         driver
             .submit_switch_function(&crate::cmd::cmd6_sd_access_mode(true, mode.function()), buf)?,
@@ -1479,6 +1842,7 @@ pub struct CardInfo {
 /// - CMD8 has no response and ACMD41 also fails, but CMD1 reports
 ///   power-up → eMMC / MMC
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CardKind {
     /// SD memory card (SDSC / SDHC / SDXC).
     Sd,
@@ -1499,6 +1863,7 @@ mod tests {
     enum MockEvent {
         Command(Command),
         Clock(ClockSpeed),
+        Voltage(SignalVoltage),
     }
 
     /// Mock host that replays canned responses in order. Used to verify the
@@ -1533,6 +1898,11 @@ mod tests {
         /// `execute_tuning` call.
         last_tuning_cmd: Option<u8>,
         pending_polls: usize,
+        /// Optional monotonic clock value returned from
+        /// [`SdioHost::now_ms`]. Tests advance this directly to verify the
+        /// wall-clock timeout path; `None` keeps the legacy poll-counter
+        /// behavior used by every pre-existing test.
+        now_ms: Option<u64>,
     }
 
     struct MockDataRequest<'a> {
@@ -1558,6 +1928,7 @@ mod tests {
                 tuning_result: None,
                 last_tuning_cmd: None,
                 pending_polls: 0,
+                now_ms: None,
             }
         }
 
@@ -1580,6 +1951,7 @@ mod tests {
                 tuning_result: None,
                 last_tuning_cmd: None,
                 pending_polls: 0,
+                now_ms: None,
             }
         }
     }
@@ -1682,6 +2054,7 @@ mod tests {
 
         fn switch_voltage(&mut self, v: SignalVoltage) -> Result<(), Error> {
             self.last_voltage = Some(v);
+            self.events.push(MockEvent::Voltage(v));
             if let Some(e) = self.voltage_switch_result {
                 return Err(e);
             }
@@ -1694,6 +2067,10 @@ mod tests {
                 return Err(e);
             }
             Ok(())
+        }
+
+        fn now_ms(&self) -> Option<u64> {
+            self.now_ms
         }
     }
 
@@ -1801,6 +2178,52 @@ mod tests {
                 OperationPoll::Complete(info) => return Ok(info),
             }
         }
+    }
+
+    /// When init fails mid-flight after the driver has already negotiated
+    /// past identification mode (e.g. host switched to 4-bit, raised clock
+    /// to Default), the driver must reset the host back to a clean baseline
+    /// (1-bit, identification clock, 3.3 V signaling) so a caller retry from
+    /// `submit_init` starts on solid ground. Without this, a later CMD0
+    /// would be issued over a bus configured for a card that just failed.
+    #[test]
+    fn poll_init_request_resets_host_when_card_init_fails() {
+        // SD init runs through CMD0 → CMD8 → ACMD41 → CMD2 → CMD3 → CMD9 →
+        // CMD7 → CMD55 → ACMD6 (host now at 4-bit + Default clock), then
+        // PrepareSdSpeed issues a 64-byte CMD6 SWITCH_FUNC. We feed it a
+        // valid switch-status payload so the read completes, then poison
+        // the *next* reply with OUT_OF_RANGE so the protocol layer raises
+        // Err on PollSdSetAccessMode's R1 — long after the host left
+        // identification mode.
+        let mut replies = sd_init_replies_with_ocr(ocr_ready_sdhc());
+        // After ACMD6: CMD6 SWITCH_FUNC query (R1 + 64B data) succeeds.
+        replies.push(Ok(ok_r1()));
+        // Then the access-mode switch CMD6 returns a poisoned R1 with
+        // OUT_OF_RANGE; protocol surfaces Err(CardError::OutOfRange).
+        replies.push(Ok(Response::R1(R1Response { raw: 1 << 31 })));
+        let mut host = MockHost::with_results(replies);
+        // SwitchStatus payload advertising HighSpeed (function 1, bit 1
+        // supported in group 1). Used for both CMD6 reads.
+        host.read_payloads = std::vec![
+            switch_status_payload(0, 1 << 1),
+            switch_status_payload(1, 1 << 1),
+        ];
+        let mut driver = SdioSdmmc::new(host);
+
+        let err = poll_init_to_completion(&mut driver)
+            .expect_err("init must propagate the injected failure");
+        // Exact error type isn't load-bearing; what matters is that the
+        // abort_init path ran on the failure.
+        let _ = err;
+
+        // After the abort path runs, the host must be back at 1-bit /
+        // identification clock / 3.3 V signaling. The driver also clears its
+        // cached card state so a retry from submit_init is well-defined.
+        assert_eq!(driver.host.bus_width, Some(BusWidth::Bit1));
+        assert_eq!(driver.host.last_clock, Some(ClockSpeed::Identification));
+        assert_eq!(driver.host.last_voltage, Some(SignalVoltage::V330));
+        assert_eq!(driver.rca(), 0);
+        assert!(!driver.is_high_capacity());
     }
 
     #[test]
@@ -1911,7 +2334,7 @@ mod tests {
         let mut request = SdioInitRequest::new(CardInitPreference::SdFirst, &mut scratch);
         request.state = SdioInitState::PollAcmd41;
         request.sd_v2 = false;
-        request.acmd41_elapsed_ms = SdioInitTiming::TIMEOUT_MS;
+        request.acmd41_polls = SdioInitTiming::MAX_POLLS;
 
         assert!(matches!(
             driver.poll_init_request(&mut request).unwrap(),
@@ -1990,6 +2413,60 @@ mod tests {
             driver.poll_mmc_switch_request(&mut request).unwrap(),
             OperationPoll::Complete(())
         ));
+    }
+
+    #[test]
+    fn mmc_switch_surfaces_wall_clock_timeout_when_host_has_clock() {
+        // Programming-state R1: READY_FOR_DATA (bit 8) + state nibble 7
+        // (bits 9..=12). The mmc_switch loop will keep retrying until either
+        // MAX_POLLS or TIMEOUT_MS trips.
+        let programming = || -> Response {
+            Response::R1(R1Response::from_native_raw((1u32 << 8) | (7u32 << 9)).unwrap())
+        };
+
+        let mut driver = SdioSdmmc::new(MockHost::with_results(std::vec![
+            Ok(ok_r1()),       // CMD6 ack
+            Ok(programming()), // CMD13 #1
+            Ok(programming()), // CMD13 #2
+        ]));
+        driver.rca = 1;
+        // Arm the clock at t=0 so submit_mmc_switch records started_ms=0.
+        driver.host.now_ms = Some(0);
+
+        let mut request = driver
+            .submit_mmc_switch(0b11, crate::cmd::ext_csd::HS_TIMING as u8, 1)
+            .unwrap();
+        // 1st poll: CMD6 ack, schedule CMD13.
+        assert!(matches!(
+            driver.poll_mmc_switch_request(&mut request).unwrap(),
+            OperationPoll::Pending
+        ));
+        // 2nd poll: CMD13 says still programming; well within the wall-clock
+        // budget, so the loop reissues CMD13.
+        assert!(matches!(
+            driver.poll_mmc_switch_request(&mut request).unwrap(),
+            OperationPoll::Pending
+        ));
+        let polls_before_jump = request.polls;
+        assert!(polls_before_jump < MmcSwitchTiming::MAX_POLLS);
+
+        // Jump the wall clock past the 250 ms CMD6 SWITCH budget.
+        driver.host.now_ms = Some(MmcSwitchTiming::TIMEOUT_MS + 1);
+
+        // 3rd poll: CMD13 still reports programming, but the wall-clock
+        // deadline fires before the poll counter would have.
+        let err = driver.poll_mmc_switch_request(&mut request).unwrap_err();
+        assert!(
+            matches!(err, Error::Timeout(ctx) if ctx.cmd == Some(6)),
+            "expected CMD6 timeout, got {:?}",
+            err
+        );
+        assert!(
+            request.polls < MmcSwitchTiming::MAX_POLLS,
+            "wall-clock check should fire before the poll budget ({} < {})",
+            request.polls,
+            MmcSwitchTiming::MAX_POLLS
+        );
     }
 
     #[test]
@@ -2168,6 +2645,57 @@ mod tests {
     }
 
     #[test]
+    fn sd_init_can_limit_speed_selection_to_legacy_high_speed() {
+        let mut replies = sd_init_replies_with_ocr(ocr_ready_sdhc_s18a());
+        replies.extend([
+            Ok(ok_r1()),         // CMD6 query access modes
+            Ok(ok_r1()),         // CMD6 switch HighSpeed
+            Ok(r1_tran_ready()), // CMD13 verify
+        ]);
+        let mut host = MockHost::with_results(replies);
+        host.read_payloads = std::vec![
+            switch_status_payload(0, (1 << 3) | (1 << 1)),
+            switch_status_payload(1, (1 << 3) | (1 << 1)),
+        ];
+
+        let mut driver = SdioSdmmc::new(host);
+        driver.set_sd_uhs_selection_enabled(false);
+        poll_init_to_completion(&mut driver)
+            .expect("SD init selects legacy HighSpeed without trying UHS");
+
+        assert!(
+            !driver
+                .host
+                .events
+                .iter()
+                .any(|e| matches!(e, MockEvent::Voltage(SignalVoltage::V180))),
+            "legacy-HighSpeed init must never ask the host for 1.8 V"
+        );
+        assert_eq!(driver.host.last_clock, Some(ClockSpeed::HighSpeed));
+        assert_eq!(driver.host.last_tuning_cmd, None);
+        assert!(
+            !driver.host.commands.iter().any(|c| c.cmd == 11),
+            "CMD11 voltage switch must not be issued in legacy HighSpeed-only mode"
+        );
+        assert!(
+            driver
+                .host
+                .commands
+                .iter()
+                .any(|c| c.cmd == 6 && c.arg == 0x80FF_FFF1),
+            "CMD6 switched group 1 to HighSpeed"
+        );
+        assert!(
+            !driver
+                .host
+                .commands
+                .iter()
+                .any(|c| c.cmd == 6 && c.arg == 0x80FF_FFF3),
+            "SDR104 must not be selected in legacy HighSpeed-only mode"
+        );
+    }
+
+    #[test]
     fn sd_init_falls_back_to_high_speed_when_uhs_voltage_switch_fails() {
         let mut replies = sd_init_replies_with_ocr(ocr_ready_sdhc_s18a());
         replies.extend([
@@ -2221,7 +2749,14 @@ mod tests {
                 .all(|c| c.arg == 2),
             "only ACMD6 bus-width switch is issued; no CMD6 SWITCH_FUNC"
         );
-        assert_eq!(driver.host.last_voltage, None);
+        assert!(
+            !driver
+                .host
+                .events
+                .iter()
+                .any(|e| matches!(e, MockEvent::Voltage(SignalVoltage::V180))),
+            "speed-selection-disabled init must never ask the host for 1.8 V"
+        );
         assert_eq!(driver.host.last_tuning_cmd, None);
     }
 
@@ -2506,8 +3041,30 @@ mod tests {
         let _info = poll_init_to_completion(&mut driver)
             .expect("init succeeds even when HS200 tuning fails");
 
-        // We *did* attempt HS200 — voltage switched, tuning called.
-        assert_eq!(driver.host.last_voltage, Some(SignalVoltage::V180));
+        // We *did* attempt HS200 — voltage switched to 1.8 V, tuning called,
+        // then the rollback reverted voltage to 3.3 V so the controller's
+        // 1.8 V sampling reference doesn't bleed into the HS@52 retry.
+        let voltage_switches: Vec<SignalVoltage> = driver
+            .host
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                MockEvent::Voltage(v) => Some(*v),
+                _ => None,
+            })
+            .collect();
+        // Voltage events look like: [V330 (init defensive reset), V180
+        // (HS200 attempt), V330 (HS200 rollback)]. The leading V330 is the
+        // abort_init cleanup that `submit_init` runs upfront to guarantee a
+        // known controller state.
+        assert_eq!(
+            voltage_switches,
+            std::vec![
+                SignalVoltage::V330,
+                SignalVoltage::V180,
+                SignalVoltage::V330
+            ]
+        );
         assert_eq!(driver.host.last_tuning_cmd, Some(21));
         // But ended up at HighSpeed, not Hs200.
         assert_eq!(driver.host.last_clock, Some(ClockSpeed::HighSpeed));
@@ -2522,6 +3079,57 @@ mod tests {
             .map(|c| ((c.arg >> 8) & 0xFF) as u8)
             .collect();
         assert_eq!(hs_timing_writes, std::vec![0x02, 0x01]);
+    }
+
+    #[test]
+    fn mmc_init_skips_hs200_when_host_refuses_voltage_switch() {
+        // Card advertises HS200 @ 1.8 V, but the host has no way to drive
+        // the IO rail at 1.8 V and refuses `switch_voltage(V180)` with
+        // `UnsupportedCommand` (the rk3568 SDHCI default until a regulator
+        // hook is wired up). The driver must NOT issue the HS_TIMING=2
+        // SWITCH or call `execute_tuning`; leaving the controller's 1.8 V
+        // signaling bit set while the bus is still on the 3.3 V rail
+        // corrupts subsequent transfers. The driver should fall straight
+        // through to HS @ 52 MHz.
+        let replies = std::vec![
+            Ok(ok_r1()),                // CMD0
+            cmd8_timeout(),             // CMD8
+            Ok(ok_r1()),                // CMD55
+            acmd41_timeout(),           // ACMD41
+            Ok(ocr_ready_mmc_sector()), // CMD1
+            Ok(cid_response()),         // CMD2
+            Ok(ok_r1()),                // CMD3
+            Ok(csd_v2_response()),      // CMD9
+            Ok(ok_r1()),                // CMD7
+            Ok(ok_r1()),                // CMD8 MMC R1
+            Ok(ok_r1()),                // CMD6 BUS_WIDTH=8
+            Ok(r1_tran_ready()),        // CMD13
+            // HS200 skipped — only HS_TIMING=1 + CMD13:
+            Ok(ok_r1()),         // CMD6 HS_TIMING=1
+            Ok(r1_tran_ready()), // CMD13
+        ];
+        let mut host = MockHost::with_results(replies);
+        host.next_read_payload = Some(ext_csd_blob_hs200());
+        host.voltage_switch_result = Some(Error::UnsupportedCommand);
+
+        let mut driver = SdioSdmmc::new(host);
+        let _info = poll_init_to_completion(&mut driver)
+            .expect("init succeeds when host refuses V180 voltage switch");
+
+        // V180 was asked for once (and refused); no V330 rollback is needed
+        // because no HS200 commands were issued, but the protocol may emit
+        // it defensively. Verify HS200 was NOT entered: no HS_TIMING=2,
+        // no tuning, final clock is HighSpeed.
+        assert_eq!(driver.host.last_tuning_cmd, None);
+        assert_eq!(driver.host.last_clock, Some(ClockSpeed::HighSpeed));
+        let hs_timing_writes: Vec<u8> = driver
+            .host
+            .commands
+            .iter()
+            .filter(|c| c.cmd == 6 && ((c.arg >> 16) & 0xFF) as u8 == 185)
+            .map(|c| ((c.arg >> 8) & 0xFF) as u8)
+            .collect();
+        assert_eq!(hs_timing_writes, std::vec![0x01]);
     }
 
     #[test]

--- a/drivers/soc/rockchip/rockchip-soc/src/clock/mod.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/clock/mod.rs
@@ -94,6 +94,7 @@ pub trait CruOp {
 
 #[enum_dispatch::enum_dispatch(CruOp)]
 pub enum Cru {
+    Rk3568(crate::variants::rk3568::cru::Cru),
     Rk3588(crate::variants::rk3588::cru::Cru),
 }
 
@@ -102,6 +103,7 @@ impl Cru {
     /// `sys_grf`: "rockchip,grf"
     pub fn new(ty: SocType, base: Mmio, sys_grf: Mmio) -> Self {
         match ty {
+            SocType::Rk3568 => Cru::Rk3568(crate::variants::rk3568::cru::Cru::new(base, sys_grf)),
             SocType::Rk3588 => Cru::Rk3588(crate::variants::rk3588::cru::Cru::new(base, sys_grf)),
         }
     }

--- a/drivers/soc/rockchip/rockchip-soc/src/lib.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/lib.rs
@@ -33,5 +33,6 @@ pub type Mmio = NonNull<u8>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SocType {
+    Rk3568,
     Rk3588,
 }

--- a/drivers/soc/rockchip/rockchip-soc/src/pinctrl/mod.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/pinctrl/mod.rs
@@ -81,6 +81,7 @@ impl PinCtrl {
     pub fn new(ty: SocType, ioc: Mmio, gpio: &[Mmio]) -> Self {
         match ty {
             SocType::Rk3588 => PinCtrl::Rk3588(crate::variants::rk3588::PinCtrl::new(ioc, gpio)),
+            SocType::Rk3568 => panic!("RK3568 pinctrl is not implemented"),
         }
     }
 }

--- a/drivers/soc/rockchip/rockchip-soc/src/variants/mod.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/variants/mod.rs
@@ -1,3 +1,4 @@
+pub mod rk3568;
 pub mod rk3588;
 
 pub(crate) const MHZ: u64 = 1_000_000;

--- a/drivers/soc/rockchip/rockchip-soc/src/variants/rk3568/cru/mod.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/variants/rk3568/cru/mod.rs
@@ -1,0 +1,327 @@
+use crate::{
+    ClockError, ClockResult, Mmio, ResetRockchip, RstId,
+    clock::{ClkId, CruOp},
+    variants::MHZ,
+};
+
+const OSC_HZ: u64 = 24 * MHZ;
+
+const CLKSEL_CON_OFFSET: u32 = 0x0100;
+const CLKGATE_CON_OFFSET: u32 = 0x0300;
+const SOFTRST_CON_OFFSET: u32 = 0x0400;
+const EMMC_CON_OFFSET: u32 = 0x0598;
+
+const CCLK_EMMC: ClkId = ClkId::new(0x7c);
+const BCLK_EMMC: ClkId = ClkId::new(0x7b);
+const ACLK_EMMC: ClkId = ClkId::new(0x79);
+const HCLK_EMMC: ClkId = ClkId::new(0x7a);
+const TCLK_EMMC: ClkId = ClkId::new(0x7d);
+const EMMC_RESETS: [RstId; 5] = [
+    RstId::new(0x78),
+    RstId::new(0x76),
+    RstId::new(0x75),
+    RstId::new(0x77),
+    RstId::new(0x79),
+];
+
+const CLKGATE_CON09: u32 = 9;
+const GATE_ACLK_EMMC: u32 = bit(5);
+const GATE_HCLK_EMMC: u32 = bit(6);
+const GATE_BCLK_EMMC: u32 = bit(7);
+const GATE_CCLK_EMMC: u32 = bit(8);
+const GATE_TCLK_EMMC: u32 = bit(9);
+
+const CLKSEL_CON28: u32 = 28;
+const CCLK_EMMC_SEL_SHIFT: u32 = 12;
+const CCLK_EMMC_SEL_MASK: u32 = 0x7 << CCLK_EMMC_SEL_SHIFT;
+const CCLK_EMMC_XIN_SOC0: u32 = 0x0 << CCLK_EMMC_SEL_SHIFT;
+const CCLK_EMMC_GPLL_200M: u32 = 0x1 << CCLK_EMMC_SEL_SHIFT;
+const CCLK_EMMC_GPLL_150M: u32 = 0x2 << CCLK_EMMC_SEL_SHIFT;
+const CCLK_EMMC_CPLL_100M: u32 = 0x3 << CCLK_EMMC_SEL_SHIFT;
+const CCLK_EMMC_CPLL_50M: u32 = 0x4 << CCLK_EMMC_SEL_SHIFT;
+const CCLK_EMMC_XIN_375K: u32 = 0x5 << CCLK_EMMC_SEL_SHIFT;
+
+const BCLK_EMMC_SEL_SHIFT: u32 = 8;
+const BCLK_EMMC_SEL_MASK: u32 = 0x3 << BCLK_EMMC_SEL_SHIFT;
+const BCLK_EMMC_GPLL_200M: u32 = 0x0 << BCLK_EMMC_SEL_SHIFT;
+
+const EMMC_DELAYNUM: u32 = 0x20;
+const EMMC_CON0_DRV_ENABLE: u32 = bit(11);
+const EMMC_CON0_DRV_DELAYNUM_SHIFT: u32 = 3;
+const EMMC_CON0_DRV_DELAYNUM_MASK: u32 = 0xff << EMMC_CON0_DRV_DELAYNUM_SHIFT;
+const EMMC_CON0_DRV_DEGREE_SHIFT: u32 = 1;
+const EMMC_CON0_DRV_DEGREE_MASK: u32 = 0x3 << EMMC_CON0_DRV_DEGREE_SHIFT;
+const EMMC_CON1_SAMPLE_ENABLE: u32 = bit(10);
+const EMMC_CON1_SAMPLE_DELAYNUM_SHIFT: u32 = 2;
+const EMMC_CON1_SAMPLE_DELAYNUM_MASK: u32 = 0xff << EMMC_CON1_SAMPLE_DELAYNUM_SHIFT;
+const EMMC_CON1_SAMPLE_DEGREE_SHIFT: u32 = 0;
+const EMMC_CON1_SAMPLE_DEGREE_MASK: u32 = 0x3 << EMMC_CON1_SAMPLE_DEGREE_SHIFT;
+
+const fn bit(bit: u32) -> u32 {
+    1 << bit
+}
+
+const fn clksel_con(index: u32) -> u32 {
+    CLKSEL_CON_OFFSET + index * 4
+}
+
+const fn clkgate_con(index: u32) -> u32 {
+    CLKGATE_CON_OFFSET + index * 4
+}
+
+const fn emmc_con(index: u32) -> u32 {
+    EMMC_CON_OFFSET + index * 4
+}
+
+const fn rate_selector(rate_hz: u64) -> Option<(u32, u64)> {
+    match rate_hz {
+        375_000..=400_000 => Some((CCLK_EMMC_XIN_375K, 375_000)),
+        400_001..=24_000_000 => Some((CCLK_EMMC_XIN_SOC0, OSC_HZ)),
+        24_000_001..=50_000_000 => Some((CCLK_EMMC_CPLL_50M, 50 * MHZ)),
+        50_000_001..=150_000_000 => Some((CCLK_EMMC_CPLL_100M, 100 * MHZ)),
+        150_000_001..=200_000_000 => Some((CCLK_EMMC_GPLL_200M, 200 * MHZ)),
+        _ => None,
+    }
+}
+
+#[derive(Clone)]
+pub struct Cru {
+    base: usize,
+    reset: ResetRockchip,
+}
+
+impl Cru {
+    pub fn new(base: Mmio, _sys_grf: Mmio) -> Self {
+        let base = base.as_ptr() as usize;
+        Self {
+            base,
+            reset: ResetRockchip::new(base + SOFTRST_CON_OFFSET as usize, 512),
+        }
+    }
+
+    pub fn init_emmc(&mut self) {
+        self.enable_emmc_gates();
+        self.deassert_emmc_resets();
+        self.write_clksel(CCLK_EMMC_SEL_MASK, CCLK_EMMC_GPLL_200M);
+        self.write_clksel(BCLK_EMMC_SEL_MASK, BCLK_EMMC_GPLL_200M);
+        self.configure_emmc_delay();
+    }
+
+    pub fn clk_enable(&mut self, id: ClkId) -> ClockResult<()> {
+        let Some(mask) = emmc_gate_mask(id) else {
+            return Err(ClockError::unsupported(id));
+        };
+        self.clrreg(clkgate_con(CLKGATE_CON09), mask);
+        Ok(())
+    }
+
+    pub fn clk_disable(&mut self, id: ClkId) -> ClockResult<()> {
+        let Some(mask) = emmc_gate_mask(id) else {
+            return Err(ClockError::unsupported(id));
+        };
+        self.setreg(clkgate_con(CLKGATE_CON09), mask);
+        Ok(())
+    }
+
+    pub fn clk_is_enabled(&self, id: ClkId) -> ClockResult<bool> {
+        let Some(mask) = emmc_gate_mask(id) else {
+            return Err(ClockError::unsupported(id));
+        };
+        Ok(self.read(clkgate_con(CLKGATE_CON09)) & mask == 0)
+    }
+
+    pub fn clk_get_rate(&self, id: ClkId) -> ClockResult<u64> {
+        match id {
+            CCLK_EMMC => self.cclk_emmc_rate(),
+            BCLK_EMMC => Ok(200 * MHZ),
+            ACLK_EMMC | HCLK_EMMC => Ok(200 * MHZ),
+            TCLK_EMMC => Ok(OSC_HZ),
+            _ => Err(ClockError::unsupported(id)),
+        }
+    }
+
+    pub fn clk_set_rate(&mut self, id: ClkId, rate_hz: u64) -> ClockResult<u64> {
+        if id != CCLK_EMMC {
+            return Err(ClockError::unsupported(id));
+        }
+        let Some((selector, actual_hz)) = rate_selector(rate_hz) else {
+            return Err(ClockError::invalid_rate(id, rate_hz));
+        };
+        self.write_clksel(CCLK_EMMC_SEL_MASK, selector);
+        Ok(actual_hz)
+    }
+
+    fn enable_emmc_gates(&mut self) {
+        self.clrreg(
+            clkgate_con(CLKGATE_CON09),
+            GATE_ACLK_EMMC | GATE_HCLK_EMMC | GATE_BCLK_EMMC | GATE_CCLK_EMMC | GATE_TCLK_EMMC,
+        );
+    }
+
+    fn deassert_emmc_resets(&mut self) {
+        for reset in EMMC_RESETS {
+            self.reset_deassert(reset);
+        }
+    }
+
+    fn configure_emmc_delay(&mut self) {
+        self.clrsetreg(
+            emmc_con(0),
+            EMMC_CON0_DRV_ENABLE | EMMC_CON0_DRV_DELAYNUM_MASK | EMMC_CON0_DRV_DEGREE_MASK,
+            EMMC_CON0_DRV_ENABLE | (EMMC_DELAYNUM << EMMC_CON0_DRV_DELAYNUM_SHIFT),
+        );
+        self.clrsetreg(
+            emmc_con(1),
+            EMMC_CON1_SAMPLE_ENABLE | EMMC_CON1_SAMPLE_DELAYNUM_MASK | EMMC_CON1_SAMPLE_DEGREE_MASK,
+            EMMC_CON1_SAMPLE_ENABLE | (EMMC_DELAYNUM << EMMC_CON1_SAMPLE_DELAYNUM_SHIFT),
+        );
+    }
+
+    fn cclk_emmc_rate(&self) -> ClockResult<u64> {
+        let selector = self.read(clksel_con(CLKSEL_CON28)) & CCLK_EMMC_SEL_MASK;
+        match selector {
+            CCLK_EMMC_XIN_SOC0 => Ok(OSC_HZ),
+            CCLK_EMMC_GPLL_200M => Ok(200 * MHZ),
+            CCLK_EMMC_GPLL_150M => Ok(150 * MHZ),
+            CCLK_EMMC_CPLL_100M => Ok(100 * MHZ),
+            CCLK_EMMC_CPLL_50M => Ok(50 * MHZ),
+            CCLK_EMMC_XIN_375K => Ok(375_000),
+            _ => Err(ClockError::rate_read_failed(
+                CCLK_EMMC,
+                "invalid RK3568 eMMC selector",
+            )),
+        }
+    }
+
+    fn write_clksel(&mut self, mask: u32, value: u32) {
+        self.update_bits(clksel_con(CLKSEL_CON28), mask, value);
+    }
+
+    fn reg(&self, offset: u32) -> *mut u32 {
+        (self.base + offset as usize) as *mut u32
+    }
+
+    fn read(&self, offset: u32) -> u32 {
+        unsafe { core::ptr::read_volatile(self.reg(offset)) }
+    }
+
+    fn write(&mut self, offset: u32, value: u32) {
+        unsafe { core::ptr::write_volatile(self.reg(offset), value) }
+    }
+
+    fn update_bits(&mut self, offset: u32, mask: u32, value: u32) {
+        let current = self.read(offset);
+        self.write(offset, (current & !mask) | (mask << 16) | value);
+    }
+
+    fn clrsetreg(&mut self, offset: u32, clr: u32, set: u32) {
+        self.update_bits(offset, clr, set);
+    }
+
+    fn clrreg(&mut self, offset: u32, clr: u32) {
+        self.update_bits(offset, clr, 0);
+    }
+
+    fn setreg(&mut self, offset: u32, set: u32) {
+        self.update_bits(offset, set, set);
+    }
+}
+
+impl CruOp for Cru {
+    fn reset_assert(&mut self, id: RstId) {
+        self.reset.reset_assert(id);
+    }
+
+    fn reset_deassert(&mut self, id: RstId) {
+        self.reset.reset_deassert(id);
+    }
+
+    fn clk_enable(&mut self, id: ClkId) -> ClockResult<()> {
+        self.clk_enable(id)
+    }
+
+    fn clk_disable(&mut self, id: ClkId) -> ClockResult<()> {
+        self.clk_disable(id)
+    }
+
+    fn clk_is_enabled(&self, id: ClkId) -> ClockResult<bool> {
+        self.clk_is_enabled(id)
+    }
+
+    fn clk_get_rate(&self, id: ClkId) -> ClockResult<u64> {
+        self.clk_get_rate(id)
+    }
+
+    fn clk_set_rate(&mut self, id: ClkId, rate_hz: u64) -> ClockResult<u64> {
+        self.clk_set_rate(id, rate_hz)
+    }
+}
+
+fn emmc_gate_mask(id: ClkId) -> Option<u32> {
+    match id {
+        CCLK_EMMC => Some(GATE_CCLK_EMMC),
+        BCLK_EMMC => Some(GATE_BCLK_EMMC),
+        ACLK_EMMC => Some(GATE_ACLK_EMMC),
+        HCLK_EMMC => Some(GATE_HCLK_EMMC),
+        TCLK_EMMC => Some(GATE_TCLK_EMMC),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rk3568_cru_offsets_match_u_boot_layout() {
+        assert_eq!(clksel_con(28), 0x0170);
+        assert_eq!(clkgate_con(9), 0x0324);
+        assert_eq!(SOFTRST_CON_OFFSET, 0x0400);
+        assert_eq!(emmc_con(0), 0x0598);
+        assert_eq!(emmc_con(1), 0x059c);
+    }
+
+    #[test]
+    fn emmc_delay_programs_drive_and_sample_delaynum() {
+        let con0_mask =
+            EMMC_CON0_DRV_ENABLE | EMMC_CON0_DRV_DELAYNUM_MASK | EMMC_CON0_DRV_DEGREE_MASK;
+        let con0_value = EMMC_CON0_DRV_ENABLE | (EMMC_DELAYNUM << EMMC_CON0_DRV_DELAYNUM_SHIFT);
+        let con1_mask =
+            EMMC_CON1_SAMPLE_ENABLE | EMMC_CON1_SAMPLE_DELAYNUM_MASK | EMMC_CON1_SAMPLE_DEGREE_MASK;
+        let con1_value =
+            EMMC_CON1_SAMPLE_ENABLE | (EMMC_DELAYNUM << EMMC_CON1_SAMPLE_DELAYNUM_SHIFT);
+
+        assert_eq!((con0_mask << 16) | con0_value, 0x0ffe_0900);
+        assert_eq!((con1_mask << 16) | con1_value, 0x07ff_0480);
+    }
+
+    #[test]
+    fn emmc_reset_ids_match_rk3568_dts() {
+        let ids = EMMC_RESETS.map(|reset| reset.value());
+
+        assert_eq!(ids, [0x78, 0x76, 0x75, 0x77, 0x79]);
+    }
+
+    #[test]
+    fn emmc_rate_selector_uses_supported_rk3568_steps() {
+        assert_eq!(rate_selector(400_000), Some((CCLK_EMMC_XIN_375K, 375_000)));
+        assert_eq!(
+            rate_selector(25 * MHZ),
+            Some((CCLK_EMMC_CPLL_50M, 50 * MHZ))
+        );
+        assert_eq!(
+            rate_selector(50 * MHZ),
+            Some((CCLK_EMMC_CPLL_50M, 50 * MHZ))
+        );
+        assert_eq!(
+            rate_selector(104 * MHZ),
+            Some((CCLK_EMMC_CPLL_100M, 100 * MHZ))
+        );
+        assert_eq!(
+            rate_selector(200 * MHZ),
+            Some((CCLK_EMMC_GPLL_200M, 200 * MHZ))
+        );
+        assert_eq!(rate_selector(374_999), None);
+        assert_eq!(rate_selector(201 * MHZ), None);
+    }
+}

--- a/drivers/soc/rockchip/rockchip-soc/src/variants/rk3568/mod.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/variants/rk3568/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod cru;

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -41,7 +41,12 @@ svm = ["axvm/svm"]
 sstc = ["riscv_vcpu/sstc"]
 dyn-plat = ["ax-std/plat-dyn", "dep:axplat-dyn"]
 rockchip-soc = ["dep:axplat-dyn", "axplat-dyn/rockchip-soc"]
-sdmmc = ["dep:axplat-dyn", "axplat-dyn/rockchip-sdhci"]
+sdmmc = [
+    "dep:axplat-dyn",
+    "axplat-dyn/rockchip-sdhci",
+    "axplat-dyn/rockchip-soc",
+    "axplat-dyn/phytium-mci",
+]
 rockchip-pm = ["dep:axplat-dyn", "axplat-dyn/rockchip-pm"]
 serial = ["dep:axplat-dyn", "axplat-dyn/serial"]
 

--- a/platform/axplat-dyn/Cargo.toml
+++ b/platform/axplat-dyn/Cargo.toml
@@ -28,6 +28,11 @@ rockchip-dwmmc = [
     "dep:sdmmc-protocol",
     "sdmmc-protocol/sdio",
 ]
+phytium-mci = [
+    "dep:phytium-mci-host",
+    "dep:sdmmc-protocol",
+    "sdmmc-protocol/sdio",
+]
 rockchip-pm = ["dep:rockchip-pm"]
 usb = ["dep:crab-usb"]
 rockchip-dwc-xhci = ["usb", "rockchip-soc", "rockchip-pm"]
@@ -77,6 +82,7 @@ rockchip-soc = { workspace = true, optional = true }
 rockchip-npu = { workspace = true, optional = true }
 rockchip-pm = { workspace = true, optional = true }
 dwmmc-host = { workspace = true, optional = true }
+phytium-mci-host = { workspace = true, optional = true }
 sdhci-host = { workspace = true, optional = true }
 sdmmc-protocol = { workspace = true, default-features = false, optional = true }
 somehal.workspace = true

--- a/platform/axplat-dyn/src/drivers/blk/mod.rs
+++ b/platform/axplat-dyn/src/drivers/blk/mod.rs
@@ -27,10 +27,10 @@ use spin::Mutex;
 
 use super::DmaImpl;
 
-#[cfg(feature = "rockchip-sdhci")]
-mod rockchip_mmc;
-#[cfg(feature = "rockchip-dwmmc")]
-mod rockchip_sd;
+#[cfg(feature = "phytium-mci")]
+mod phytium_mci;
+#[cfg(any(feature = "rockchip-sdhci", feature = "rockchip-dwmmc"))]
+mod rockchip;
 mod virtio;
 mod virtio_pci;
 
@@ -300,13 +300,21 @@ impl PlatformDeviceBlock for rdrive::PlatformDevice {
     }
 }
 
-#[cfg(any(feature = "rockchip-sdhci", feature = "rockchip-dwmmc"))]
+#[cfg(any(
+    feature = "rockchip-sdhci",
+    feature = "rockchip-dwmmc",
+    feature = "phytium-mci"
+))]
 pub(super) fn decode_fdt_irq(interrupts: &[rdrive::probe::fdt::InterruptRef]) -> Option<usize> {
     let interrupt = interrupts.first()?;
     decode_irq_cells(&interrupt.specifier)
 }
 
-#[cfg(any(feature = "rockchip-sdhci", feature = "rockchip-dwmmc"))]
+#[cfg(any(
+    feature = "rockchip-sdhci",
+    feature = "rockchip-dwmmc",
+    feature = "phytium-mci"
+))]
 fn decode_irq_cells(specifier: &[u32]) -> Option<usize> {
     match specifier {
         [irq] => Some(*irq as usize),

--- a/platform/axplat-dyn/src/drivers/blk/phytium_mci.rs
+++ b/platform/axplat-dyn/src/drivers/blk/phytium_mci.rs
@@ -1,0 +1,511 @@
+use alloc::{format, sync::Arc, vec::Vec};
+use core::{num::NonZeroUsize, ptr::NonNull, time::Duration};
+
+use ax_kspin::SpinNoIrq;
+use dma_api::DeviceDma;
+use phytium_mci_host::{BlockRequest, BlockRequestSlot, PhytiumMci, RequestId};
+use rdrive::{
+    DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
+};
+use sdmmc_protocol::{
+    BlockPoll, BlockTransferMode, Error, OperationPoll,
+    error::Phase,
+    sdio::{CardInfo, CardInitPreference, SdioHost, SdioInitScratch, SdioSdmmc},
+};
+
+use crate::drivers::{
+    DmaImpl,
+    blk::{PlatformDeviceBlock, decode_fdt_irq},
+    iomap,
+};
+
+const BLOCK_SIZE: usize = 512;
+
+type PhytiumSdMmc = SdioSdmmc<PhytiumMci>;
+
+module_driver!(
+    name: "Phytium MCI",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["phytium,mci"],
+            on_probe: probe
+        }
+    ],
+);
+
+fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let base_reg = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or(OnProbeError::other(alloc::format!(
+            "[{}] has no reg",
+            info.node.name()
+        )))?;
+
+    let mmio_size = base_reg.size.unwrap_or(0x1000);
+    info!(
+        "phytium-mci probe: node={}, addr={:#x}, size={:#x}",
+        info.node.name(),
+        base_reg.address as usize,
+        mmio_size
+    );
+    let mmio_base = iomap((base_reg.address as usize).into(), mmio_size as usize)?;
+
+    let mut host = unsafe { PhytiumMci::new(mmio_base) };
+    info!("phytium-mci: reset controller");
+    host.reset_and_init()
+        .map_err(|e| init_error(base_reg.address, mmio_size, e))?;
+
+    info!("phytium-mci: initialize card");
+    let mut card = SdioSdmmc::new(host);
+    card.set_sd_uhs_selection_enabled(false);
+    let preference = card_init_preference(&info);
+    let card_info = poll_card_init(&mut card, preference).map_err(|e| {
+        warn!("phytium-mci: card init failed: {:?}", e);
+        card_init_error(base_reg.address, mmio_size, e)
+    })?;
+    info!(
+        "phytium-mci card: kind={:?} high_capacity={} rca={} ocr={:#010x} capacity_blocks={:?} \
+         cid={} ext_csd={}",
+        card_info.kind,
+        card_info.high_capacity,
+        card_info.rca,
+        card_info.ocr,
+        card_info.capacity_blocks,
+        card_info.cid.is_some(),
+        card_info.ext_csd.is_some()
+    );
+
+    let irq_num = decode_fdt_irq(&info.interrupts());
+    let raw = Arc::new(SpinNoIrq::new(card));
+    let dev = MciBlockDevice {
+        raw: Some(raw),
+        capacity_blocks: card_info.capacity_blocks.unwrap_or(0),
+        irq_enabled: false,
+        queue_created: false,
+    };
+    plat_dev.register_block_with_irq(dev, irq_num);
+    info!("phytium-mci block device registered irq={:?}", irq_num);
+    Ok(())
+}
+
+fn poll_card_init(
+    card: &mut PhytiumSdMmc,
+    preference: CardInitPreference,
+) -> Result<CardInfo, Error> {
+    let mut scratch = SdioInitScratch::new();
+    let mut request = card.submit_init_with_preference(preference, &mut scratch)?;
+    loop {
+        match card.poll_init_request(&mut request)? {
+            OperationPoll::Pending => {
+                if request.take_needs_pace() {
+                    axklib::time::busy_wait(Duration::from_millis(10));
+                } else {
+                    core::hint::spin_loop();
+                }
+            }
+            OperationPoll::Complete(info) => return Ok(info),
+            _ => return Err(Error::UnsupportedCommand),
+        }
+    }
+}
+
+fn card_init_preference(info: &FdtInfo<'_>) -> CardInitPreference {
+    let node = info.node.as_node();
+    if node.get_property("no-sd").is_some() || node.get_property("non-removable").is_some() {
+        CardInitPreference::MmcFirst
+    } else {
+        CardInitPreference::SdFirst
+    }
+}
+
+fn init_error(address: u64, size: u64, err: Error) -> OnProbeError {
+    OnProbeError::other(format!(
+        "failed to initialize Phytium MCI device at [PA:{:?}, SZ:0x{:x}): {err:?}",
+        address, size
+    ))
+}
+
+fn card_init_error(address: u64, size: u64, err: Error) -> OnProbeError {
+    if is_absent_card_init_error(err) {
+        warn!(
+            "phytium-mci: no responsive card at [PA:{:?}, SZ:0x{:x}); skipping controller: {err:?}",
+            address, size
+        );
+        return OnProbeError::NotMatch;
+    }
+
+    init_error(address, size, err)
+}
+
+fn is_absent_card_init_error(err: Error) -> bool {
+    match err {
+        Error::NoCard => true,
+        Error::Timeout(ctx) | Error::Crc(ctx) | Error::BadResponse(ctx) => {
+            ctx.cmd.is_some()
+                && matches!(
+                    ctx.phase,
+                    Phase::CommandSend | Phase::ResponseWait | Phase::Init
+                )
+        }
+        _ => false,
+    }
+}
+
+struct MciBlockDevice {
+    raw: Option<Arc<SpinNoIrq<PhytiumSdMmc>>>,
+    capacity_blocks: u64,
+    irq_enabled: bool,
+    queue_created: bool,
+}
+
+struct MciBlockQueue {
+    raw: Arc<SpinNoIrq<PhytiumSdMmc>>,
+    capacity_blocks: u64,
+    id: usize,
+    dma: DeviceDma,
+    slot: BlockRequestSlot,
+    pending: Option<BlockRequest>,
+    completed: Vec<rd_block::RequestId>,
+}
+
+impl DriverGeneric for MciBlockDevice {
+    fn name(&self) -> &str {
+        "phytium-mci"
+    }
+}
+
+impl rd_block::Interface for MciBlockDevice {
+    fn create_queue(&mut self) -> Option<alloc::boxed::Box<dyn rd_block::IQueue>> {
+        if self.queue_created {
+            return None;
+        }
+        self.raw.as_ref().map(|dev| {
+            self.queue_created = true;
+            alloc::boxed::Box::new(MciBlockQueue {
+                raw: dev.clone(),
+                capacity_blocks: self.capacity_blocks,
+                id: 0,
+                dma: DeviceDma::new(u32::MAX as u64, &DmaImpl),
+                slot: BlockRequestSlot::default(),
+                pending: None,
+                completed: Vec::new(),
+            }) as _
+        })
+    }
+
+    fn enable_irq(&mut self) {
+        if let Some(raw) = &self.raw {
+            let mut raw = raw.lock();
+            if let Err(err) = SdioHost::enable_completion_irq(raw.host_mut()) {
+                warn!("phytium-mci: enable completion IRQ failed: {:?}", err);
+                return;
+            }
+            self.irq_enabled = true;
+        }
+    }
+
+    fn disable_irq(&mut self) {
+        if let Some(raw) = &self.raw {
+            let mut raw = raw.lock();
+            if let Err(err) = SdioHost::disable_completion_irq(raw.host_mut()) {
+                warn!("phytium-mci: disable completion IRQ failed: {:?}", err);
+            }
+        }
+        self.irq_enabled = false;
+    }
+
+    fn is_irq_enabled(&self) -> bool {
+        self.irq_enabled
+    }
+
+    fn handle_irq(&mut self) -> rd_block::Event {
+        let Some(raw) = &self.raw else {
+            return rd_block::Event::none();
+        };
+        let irq_event = raw.lock().host_mut().handle_irq();
+        block_event_from_mci_irq(irq_event)
+    }
+}
+
+fn block_event_from_mci_irq(irq_event: phytium_mci_host::Event) -> rd_block::Event {
+    match irq_event {
+        phytium_mci_host::Event::None => rd_block::Event::none(),
+        phytium_mci_host::Event::CommandComplete
+        | phytium_mci_host::Event::TransferComplete
+        | phytium_mci_host::Event::ReceiveReady
+        | phytium_mci_host::Event::TransmitReady
+        | phytium_mci_host::Event::Error { .. }
+        | phytium_mci_host::Event::Other { .. } => {
+            let mut event = rd_block::Event::none();
+            event.queue.insert(0);
+            event
+        }
+    }
+}
+
+impl rd_block::IQueue for MciBlockQueue {
+    fn num_blocks(&self) -> usize {
+        self.capacity_blocks as usize
+    }
+
+    fn block_size(&self) -> usize {
+        BLOCK_SIZE
+    }
+
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn buff_config(&self) -> rd_block::BuffConfig {
+        rd_block::BuffConfig {
+            dma_mask: self.dma.dma_mask(),
+            align: BLOCK_SIZE,
+            size: BLOCK_SIZE,
+        }
+    }
+
+    fn submit_request(
+        &mut self,
+        request: rd_block::Request<'_>,
+    ) -> Result<rd_block::RequestId, rd_block::BlkError> {
+        self.reap_pending_request()?;
+        let mut raw = self.raw.lock();
+        let start_block = block_addr_for_card(request.block_id, raw.is_high_capacity())?;
+        match request.kind {
+            rd_block::RequestKind::Read(buffer) => {
+                if !buffer.len().is_multiple_of(BLOCK_SIZE) {
+                    return Err(rd_block::BlkError::Other(
+                        "read buffer is not block aligned".into(),
+                    ));
+                }
+                let ptr = NonNull::new(buffer.virt).ok_or_else(|| {
+                    rd_block::BlkError::Other("read buffer pointer is null".into())
+                })?;
+                let size = NonZeroUsize::new(buffer.len())
+                    .ok_or_else(|| rd_block::BlkError::Other("read buffer is empty".into()))?;
+                let id = submit_read_request(
+                    raw.host_mut(),
+                    start_block,
+                    ptr,
+                    size,
+                    &self.dma,
+                    &mut self.slot,
+                    &mut self.pending,
+                )?;
+                Ok(rd_block::RequestId::new(usize::from(id)))
+            }
+            rd_block::RequestKind::Write(items) => {
+                if !items.len().is_multiple_of(BLOCK_SIZE) {
+                    return Err(rd_block::BlkError::Other(
+                        "write buffer is not block aligned".into(),
+                    ));
+                }
+                let ptr = NonNull::new(items.as_ptr() as *mut u8).ok_or_else(|| {
+                    rd_block::BlkError::Other("write buffer pointer is null".into())
+                })?;
+                let size = NonZeroUsize::new(items.len())
+                    .ok_or_else(|| rd_block::BlkError::Other("write buffer is empty".into()))?;
+                let id = submit_write_request(
+                    raw.host_mut(),
+                    start_block,
+                    ptr,
+                    size,
+                    &self.dma,
+                    &mut self.slot,
+                    &mut self.pending,
+                )?;
+                Ok(rd_block::RequestId::new(usize::from(id)))
+            }
+        }
+    }
+
+    fn poll_request(&mut self, request: rd_block::RequestId) -> Result<(), rd_block::BlkError> {
+        if let Some(index) = self.completed.iter().position(|id| *id == request) {
+            self.completed.swap_remove(index);
+            return Ok(());
+        }
+        self.poll_active_request(request)
+    }
+}
+
+impl MciBlockQueue {
+    fn poll_active_request(
+        &mut self,
+        request: rd_block::RequestId,
+    ) -> Result<(), rd_block::BlkError> {
+        match self.raw.lock().host_mut().poll_block_request(
+            &mut self.pending,
+            RequestId::new(usize::from(request)),
+            &mut self.slot,
+        ) {
+            Ok(BlockPoll::Complete) => Ok(()),
+            Ok(BlockPoll::Pending) => Err(rd_block::BlkError::Retry),
+            Ok(_) => Err(rd_block::BlkError::Other(
+                "Phytium MCI returned an unknown poll state".into(),
+            )),
+            Err(err) => Err(map_dev_err_to_blk_err(err)),
+        }
+    }
+
+    fn pending_id(&self) -> Option<RequestId> {
+        self.pending.as_ref().map(BlockRequest::id)
+    }
+
+    fn reap_pending_request(&mut self) -> Result<(), rd_block::BlkError> {
+        let Some(active) = self.pending_id() else {
+            return Ok(());
+        };
+        let id = rd_block::RequestId::new(usize::from(active));
+        match self.poll_active_request(id) {
+            Ok(()) => {
+                self.completed.push(id);
+                Ok(())
+            }
+            Err(rd_block::BlkError::Retry) => Err(rd_block::BlkError::Retry),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+fn submit_read_request(
+    host: &mut PhytiumMci,
+    start_block: u32,
+    buffer: NonNull<u8>,
+    size: NonZeroUsize,
+    dma: &DeviceDma,
+    slot: &mut BlockRequestSlot,
+    pending: &mut Option<BlockRequest>,
+) -> Result<RequestId, rd_block::BlkError> {
+    if pending.is_some() {
+        return Err(rd_block::BlkError::Retry);
+    }
+    let request = match host.submit_read_blocks(
+        start_block,
+        buffer,
+        size,
+        Some(dma),
+        BlockTransferMode::Dma,
+        slot,
+    ) {
+        Ok(request) => request,
+        Err(err) if can_fallback_to_fifo(err) => {
+            warn!(
+                "phytium-mci: DMA read unavailable ({:?}); falling back to FIFO",
+                err
+            );
+            host.submit_read_blocks(
+                start_block,
+                buffer,
+                size,
+                None,
+                BlockTransferMode::Fifo,
+                slot,
+            )
+            .map_err(map_dev_err_to_blk_err)?
+        }
+        Err(err) => return Err(map_dev_err_to_blk_err(err)),
+    };
+    let id = request.id();
+    *pending = Some(request);
+    Ok(id)
+}
+
+fn submit_write_request(
+    host: &mut PhytiumMci,
+    start_block: u32,
+    buffer: NonNull<u8>,
+    size: NonZeroUsize,
+    dma: &DeviceDma,
+    slot: &mut BlockRequestSlot,
+    pending: &mut Option<BlockRequest>,
+) -> Result<RequestId, rd_block::BlkError> {
+    if pending.is_some() {
+        return Err(rd_block::BlkError::Retry);
+    }
+    let request = match host.submit_write_blocks(
+        start_block,
+        buffer,
+        size,
+        Some(dma),
+        BlockTransferMode::Dma,
+        slot,
+    ) {
+        Ok(request) => request,
+        Err(err) if can_fallback_to_fifo(err) => {
+            warn!(
+                "phytium-mci: DMA write unavailable ({:?}); falling back to FIFO",
+                err
+            );
+            host.submit_write_blocks(
+                start_block,
+                buffer,
+                size,
+                None,
+                BlockTransferMode::Fifo,
+                slot,
+            )
+            .map_err(map_dev_err_to_blk_err)?
+        }
+        Err(err) => return Err(map_dev_err_to_blk_err(err)),
+    };
+    let id = request.id();
+    *pending = Some(request);
+    Ok(id)
+}
+
+fn can_fallback_to_fifo(err: Error) -> bool {
+    matches!(
+        err,
+        Error::UnsupportedCommand | Error::InvalidArgument | Error::Misaligned
+    )
+}
+
+fn block_addr_for_card(block_id: usize, high_capacity: bool) -> Result<u32, rd_block::BlkError> {
+    let block_id =
+        u32::try_from(block_id).map_err(|_| rd_block::BlkError::InvalidBlockIndex(block_id))?;
+    if high_capacity {
+        Ok(block_id)
+    } else {
+        block_id
+            .checked_mul(BLOCK_SIZE as u32)
+            .ok_or(rd_block::BlkError::InvalidBlockIndex(block_id as usize))
+    }
+}
+
+fn map_dev_err_to_blk_err(err: Error) -> rd_block::BlkError {
+    match err {
+        Error::NoCard | Error::UnsupportedCommand | Error::CardLocked => {
+            rd_block::BlkError::NotSupported
+        }
+        Error::Misaligned | Error::InvalidArgument => {
+            rd_block::BlkError::Other("Phytium MCI request is not block aligned".into())
+        }
+        _ => rd_block::BlkError::Other("Phytium MCI I/O error".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sdmmc_protocol::error::ErrorContext;
+
+    use super::*;
+
+    #[test]
+    fn command_timeout_during_card_init_is_absent_card() {
+        let err = Error::Timeout(ErrorContext::for_cmd(Phase::ResponseWait, 1));
+
+        assert!(is_absent_card_init_error(err));
+    }
+
+    #[test]
+    fn data_timeout_after_card_init_is_not_absent_card() {
+        let err = Error::Timeout(ErrorContext::for_cmd(Phase::DataRead, 17));
+
+        assert!(!is_absent_card_init_error(err));
+    }
+}

--- a/platform/axplat-dyn/src/drivers/blk/rockchip/dwmmc.rs
+++ b/platform/axplat-dyn/src/drivers/blk/rockchip/dwmmc.rs
@@ -12,50 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{format, string::ToString, sync::Arc, vec::Vec};
+use alloc::{format, sync::Arc, vec::Vec};
 use core::{num::NonZeroUsize, ptr::NonNull, time::Duration};
 
 use ax_kspin::SpinNoIrq;
 use dma_api::DeviceDma;
+use dwmmc_host::{BlockRequest, BlockRequestSlot, DwMmc, RequestId};
 use rdif_clk::ClockId;
 use rdrive::{
-    Device, DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
+    DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
 };
-use sdhci_host::{BlockRequest, BlockRequestSlot, HostClock, RequestId, Sdhci};
 use sdmmc_protocol::{
-    BlockPoll, BlockTransferMode, Error, OperationPoll,
-    error::{ErrorContext, Phase},
-    sdio::{CardInfo, CardInitPreference, SdioHost, SdioInitScratch, SdioSdmmc},
+    BlockPoll, BlockTransferMode, DataCommandPoll, Error, OperationPoll,
+    error::Phase,
+    sdio::{CardInfo, SdioHost, SdioInitScratch, SdioSdmmc},
 };
-use spin::Once;
 
 use crate::drivers::{
     DmaImpl,
     blk::{PlatformDeviceBlock, decode_fdt_irq},
     iomap,
+    soc::scmi,
 };
 
 const BLOCK_SIZE: usize = 512;
-const SDHCI_POWER_330: u8 = 0x0e;
-static SDHCI_CLOCK: RockchipSdhciClock = RockchipSdhciClock;
+const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
+const ENABLE_SD_SPEED_SELECTION: bool = true;
+const RK3588_CRU_BASE: usize = 0xfd7c_0000;
+const RK3588_CRU_SIZE: usize = 0x5c000;
+const RK3588_SDMMC_CON0: usize = 0x0c30;
+const RK3588_SDMMC_CON1: usize = 0x0c34;
+const RK3588_SDMMC_PHASE_SHIFT: u32 = 1;
+const RK3588_SDMMC_DRV_PHASE_DEG: u32 = 90;
+const RK3588_SDMMC_SAMPLE_PHASE_DEG: u32 = 0;
+const RK3588_SDMMC_SAMPLE_PHASE_CANDIDATES: [u32; 8] = [0, 45, 90, 135, 180, 225, 270, 315];
 
-type RockchipSdhci = SdioSdmmc<Sdhci>;
-
-struct RockchipSdhciClock;
-
-impl HostClock for RockchipSdhciClock {
-    fn set_clock(&self, target_hz: u32) -> Result<(), Error> {
-        set_sdhci_clock(target_hz)
-    }
-}
+type RockchipDwMmc = SdioSdmmc<DwMmc>;
 
 module_driver!(
-    name: "Rockchip sdhci",
+    name: "Rockchip SD",
     level: ProbeLevel::PostKernel,
     priority: ProbePriority::DEFAULT,
     probe_kinds: &[
         ProbeKind::Fdt {
-            compatibles: &["rockchip,rk3588-dwcmshc", "rockchip,dwcmshc-sdhci"],
+            compatibles: &["rockchip,rk3588-dw-mshc", "rockchip,rk3288-dw-mshc"],
             on_probe: probe
         }
     ],
@@ -74,36 +74,45 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
 
     let mmio_size = base_reg.size.unwrap_or(0x1000);
     info!(
-        "rockchip-sdhci probe: node={}, addr={:#x}, size={:#x}",
+        "rockchip-dwmmc probe: node={}, addr={:#x}, size={:#x}",
         info.node.name(),
         base_reg.address as usize,
         mmio_size
     );
     let mmio_base = iomap((base_reg.address as usize).into(), mmio_size as usize)?;
 
-    init_core_clock(&info)?;
-
-    let mut host = unsafe { Sdhci::new(mmio_base) };
-    if CLK_DEV.is_completed() {
-        info!("rockchip-sdhci: using external CRU clock");
-        host.set_external_clock(&SDHCI_CLOCK);
+    let mut host = unsafe { DwMmc::new(mmio_base) };
+    let reference_clock = dwmmc_reference_clock(&info);
+    if let Some(reference_clock) = reference_clock {
+        info!(
+            "rockchip-dwmmc: using ciu reference clock {} Hz",
+            reference_clock
+        );
+        host.set_reference_clock(reference_clock);
+        if is_rk3588_dwmmc(&info) {
+            init_rk3588_sdmmc_phase(&info, reference_clock)?;
+        }
     } else {
-        warn!("rockchip-sdhci: no core clock found; using SDHCI internal clock divider");
+        warn!(
+            "rockchip-dwmmc: ciu clock not found; leaving DWMMC divider bypassed and relying on \
+             CRU rate"
+        );
     }
-    info!("rockchip-sdhci: reset controller");
-    host.reset_all()
+    info!("rockchip-dwmmc: reset controller");
+    host.reset_and_init()
         .map_err(|e| init_error(base_reg.address, mmio_size, e))?;
-    host.set_power(SDHCI_POWER_330);
-    host.enable_interrupts();
     host.set_dma(DeviceDma::new(u32::MAX as u64, &DmaImpl));
 
-    info!("rockchip-sdhci: initialize card");
-    let mut card = SdioSdmmc::new(host);
-    let card_info = poll_card_init_mmc(&mut card)
-        .map_err(|e| card_init_error(base_reg.address, mmio_size, e))?;
+    info!("rockchip-dwmmc: initialize card");
+    let mut sd = SdioSdmmc::new(host);
+    sd.set_sd_speed_selection_enabled(ENABLE_SD_SPEED_SELECTION);
+    let card_info = poll_card_init(&mut sd).map_err(|e| {
+        warn!("rockchip-dwmmc: card init failed: {:?}", e);
+        card_init_error(base_reg.address, mmio_size, e)
+    })?;
     info!(
-        "SDHCI card: kind={:?} high_capacity={} rca={} ocr={:#010x} capacity_blocks={:?} cid={} \
-         ext_csd={}",
+        "rockchip-dwmmc card: kind={:?} high_capacity={} rca={} ocr={:#010x} capacity_blocks={:?} \
+         cid={} ext_csd={}",
         card_info.kind,
         card_info.high_capacity,
         card_info.rca,
@@ -113,25 +122,30 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
         card_info.ext_csd.is_some()
     );
 
+    if let Some(reference_clock) = reference_clock
+        && is_rk3588_dwmmc(&info)
+    {
+        tune_rk3588_sdmmc_sample_phase(&mut sd, reference_clock);
+    }
+
     let irq_num = decode_fdt_irq(&info.interrupts());
-    let raw = Arc::new(SpinNoIrq::new(card));
-    let dev = BlockDevice {
+    let raw = Arc::new(SpinNoIrq::new(sd));
+    let dev = SdBlockDevice {
         raw: Some(raw.clone()),
         capacity_blocks: card_info.capacity_blocks.unwrap_or(0),
         irq_enabled: false,
         queue_created: false,
     };
     plat_dev.register_block_with_irq(dev, irq_num);
-    info!("rockchip-sdhci block device registered irq={:?}", irq_num);
+    info!("rockchip-sd block device registered irq={:?}", irq_num);
     Ok(())
 }
 
-fn poll_card_init_mmc(card: &mut RockchipSdhci) -> Result<CardInfo, Error> {
+fn poll_card_init(sd: &mut RockchipDwMmc) -> Result<CardInfo, Error> {
     let mut scratch = SdioInitScratch::new();
-    let mut request =
-        card.submit_init_with_preference(CardInitPreference::MmcFirst, &mut scratch)?;
+    let mut request = sd.submit_init(&mut scratch)?;
     loop {
-        match card.poll_init_request(&mut request)? {
+        match sd.poll_init_request(&mut request)? {
             OperationPoll::Pending => {
                 if request.take_needs_pace() {
                     axklib::time::busy_wait(Duration::from_millis(10));
@@ -140,13 +154,14 @@ fn poll_card_init_mmc(card: &mut RockchipSdhci) -> Result<CardInfo, Error> {
                 }
             }
             OperationPoll::Complete(info) => return Ok(info),
+            _ => return Err(Error::UnsupportedCommand),
         }
     }
 }
 
 fn init_error(address: u64, size: u64, err: Error) -> OnProbeError {
     OnProbeError::other(format!(
-        "failed to initialize SDHCI device at [PA:{:?}, SZ:0x{:x}): {err:?}",
+        "failed to initialize DWMMC device at [PA:{:?}, SZ:0x{:x}): {err:?}",
         address, size
     ))
 }
@@ -154,7 +169,7 @@ fn init_error(address: u64, size: u64, err: Error) -> OnProbeError {
 fn card_init_error(address: u64, size: u64, err: Error) -> OnProbeError {
     if is_absent_card_init_error(err) {
         warn!(
-            "rockchip-sdhci: no responsive card at [PA:{:?}, SZ:0x{:x}); skipping controller: \
+            "rockchip-dwmmc: no responsive card at [PA:{:?}, SZ:0x{:x}); skipping controller: \
              {err:?}",
             address, size
         );
@@ -178,61 +193,238 @@ fn is_absent_card_init_error(err: Error) -> bool {
     }
 }
 
-fn init_core_clock(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
-    for clk in info.node.clocks() {
-        info!(
-            "rockchip-sdhci clock: phandle <{}>, name: {:?}, cells: {}",
-            clk.phandle, clk.name, clk.cells
+fn dwmmc_reference_clock(info: &FdtInfo<'_>) -> Option<u32> {
+    let Some(clk) = info.find_clk_by_name("ciu") else {
+        return None;
+    };
+    let Some(device_id) = info.phandle_to_device_id(clk.phandle) else {
+        warn!(
+            "[{}] ciu clock phandle {} has no device id",
+            info.node.name(),
+            clk.phandle
         );
-        if clk.name == Some("core".to_string()) {
-            let device_id = info.phandle_to_device_id(clk.phandle).ok_or_else(|| {
-                OnProbeError::other(format!(
-                    "[{}] core clock phandle {} has no device id",
-                    info.node.name(),
-                    clk.phandle
-                ))
-            })?;
-            let clk_dev = rdrive::get::<rdif_clk::Clk>(device_id).map_err(|_| {
-                OnProbeError::other(format!(
-                    "[{}] core clock device {:?} is not registered",
-                    info.node.name(),
-                    device_id
-                ))
-            })?;
-            CLK_DEV.call_once(|| ClkDev {
-                inner: clk_dev,
-                id: (clk.select().unwrap_or(0) as usize).into(),
-            });
-            return Ok(());
+        return None;
+    };
+    let clk_dev = match rdrive::get::<rdif_clk::Clk>(device_id) {
+        Ok(clk_dev) => clk_dev,
+        Err(_) => {
+            let clock_id = clk.select().unwrap_or(0);
+            if scmi::set_clock_rate(clk.phandle, clock_id, DWMMC_STABLE_REFERENCE_CLOCK as u64)
+                .is_some()
+            {
+                return Some(DWMMC_STABLE_REFERENCE_CLOCK);
+            }
+            if let Some(rate) = scmi::clock_rate(clk.phandle, clock_id) {
+                return validate_reference_clock(info, rate);
+            }
+            warn!(
+                "[{}] ciu clock device {:?} is not registered",
+                info.node.name(),
+                device_id
+            );
+            return None;
+        }
+    };
+    let mut clk_guard = match clk_dev.lock() {
+        Ok(clk_guard) => clk_guard,
+        Err(_) => {
+            warn!(
+                "[{}] ciu clock device {:?} is locked",
+                info.node.name(),
+                device_id
+            );
+            return None;
+        }
+    };
+    let clock_id = ClockId::from(clk.select().unwrap_or(0) as usize);
+    if let Err(err) = clk_guard.set_rate(clock_id, DWMMC_STABLE_REFERENCE_CLOCK as u64) {
+        warn!(
+            "[{}] failed to set ciu clock {:?} to {} Hz: {:?}",
+            info.node.name(),
+            clock_id,
+            DWMMC_STABLE_REFERENCE_CLOCK,
+            err
+        );
+    }
+    let rate = match clk_guard.get_rate(clock_id) {
+        Ok(rate) => rate,
+        Err(err) => {
+            warn!(
+                "[{}] failed to read ciu clock {:?}: {:?}",
+                info.node.name(),
+                clock_id,
+                err
+            );
+            return None;
+        }
+    };
+    validate_reference_clock(info, rate)
+}
+
+fn is_rk3588_dwmmc(info: &FdtInfo<'_>) -> bool {
+    info.node
+        .as_node()
+        .compatibles()
+        .any(|compatible| compatible == "rockchip,rk3588-dw-mshc")
+}
+
+fn init_rk3588_sdmmc_phase(info: &FdtInfo<'_>, parent_rate: u32) -> Result<(), OnProbeError> {
+    let has_drive_clk = info.find_clk_by_name("ciu-drive").is_some();
+    let has_sample_clk = info.find_clk_by_name("ciu-sample").is_some();
+    if !has_drive_clk || !has_sample_clk {
+        warn!(
+            "[{}] RK3588 SDMMC phase clocks missing: ciu-drive={} ciu-sample={}",
+            info.node.name(),
+            has_drive_clk,
+            has_sample_clk
+        );
+        return Ok(());
+    }
+
+    let cru = iomap(RK3588_CRU_BASE.into(), RK3588_CRU_SIZE)?;
+    set_rk3588_mmc_phase(
+        cru,
+        RK3588_SDMMC_CON0,
+        parent_rate,
+        RK3588_SDMMC_DRV_PHASE_DEG,
+    );
+    set_rk3588_mmc_phase(
+        cru,
+        RK3588_SDMMC_CON1,
+        parent_rate,
+        RK3588_SDMMC_SAMPLE_PHASE_DEG,
+    );
+    info!(
+        "rockchip-dwmmc: RK3588 SDMMC phase configured: drive={}deg sample={}deg parent={}Hz",
+        RK3588_SDMMC_DRV_PHASE_DEG, RK3588_SDMMC_SAMPLE_PHASE_DEG, parent_rate
+    );
+    Ok(())
+}
+
+fn tune_rk3588_sdmmc_sample_phase(sd: &mut RockchipDwMmc, parent_rate: u32) {
+    let Ok(cru) = iomap(RK3588_CRU_BASE.into(), RK3588_CRU_SIZE) else {
+        warn!("rockchip-dwmmc: failed to map RK3588 CRU for sample phase scan");
+        return;
+    };
+
+    for sample_phase in RK3588_SDMMC_SAMPLE_PHASE_CANDIDATES {
+        set_rk3588_mmc_phase(cru, RK3588_SDMMC_CON1, parent_rate, sample_phase);
+
+        let mut block0 = [0; BLOCK_SIZE];
+        let block0_result = read_block_sync(sd, 0, &mut block0);
+        let block0_valid = block0_result.is_ok() && has_mbr_signature(&block0);
+
+        let mut block1 = [0; BLOCK_SIZE];
+        let block1_result = read_block_sync(sd, 1, &mut block1);
+        let block1_valid = block1_result.is_ok() && has_gpt_header(&block1);
+
+        info!(
+            "rockchip-dwmmc: sample phase probe {}deg: block0_ok={} mbr_sig={:02x}{:02x} \
+             block0_head={:02x?} block1_ok={} gpt_head={:02x?}",
+            sample_phase,
+            block0_result.is_ok(),
+            block0[511],
+            block0[510],
+            &block0[..16],
+            block1_result.is_ok(),
+            &block1[..8]
+        );
+
+        if block0_valid || block1_valid {
+            set_rk3588_mmc_phase(cru, RK3588_SDMMC_CON1, parent_rate, sample_phase);
+            info!(
+                "rockchip-dwmmc: selected RK3588 SDMMC sample phase {}deg",
+                sample_phase
+            );
+            return;
         }
     }
-    Ok(())
+
+    set_rk3588_mmc_phase(
+        cru,
+        RK3588_SDMMC_CON1,
+        parent_rate,
+        RK3588_SDMMC_SAMPLE_PHASE_DEG,
+    );
+    warn!(
+        "rockchip-dwmmc: no valid RK3588 SDMMC sample phase found; restored {}deg",
+        RK3588_SDMMC_SAMPLE_PHASE_DEG
+    );
 }
 
-fn set_sdhci_clock(target_hz: u32) -> Result<(), Error> {
-    let clk = CLK_DEV.wait();
-    let mut clk_dev = clk.inner.lock().map_err(|_| clock_error())?;
-    clk_dev
-        .set_rate(clk.id, target_hz as u64)
-        .map_err(|_| clock_error())?;
-    let rate = clk_dev.get_rate(clk.id).map_err(|_| clock_error())?;
-    info!("rockchip-sdhci: core clock set to {} Hz", rate);
-    Ok(())
+fn read_block_sync(
+    sd: &mut RockchipDwMmc,
+    addr: u32,
+    buf: &mut [u8; BLOCK_SIZE],
+) -> Result<(), Error> {
+    let mut request = sd.submit_read_blocks_into(addr, buf)?;
+    loop {
+        match sd.poll_data_request(&mut request)? {
+            DataCommandPoll::Pending => core::hint::spin_loop(),
+            DataCommandPoll::Complete(_) => return Ok(()),
+        }
+    }
 }
 
-fn clock_error() -> Error {
-    Error::BusError(ErrorContext::new(Phase::Init))
+fn set_rk3588_mmc_phase(cru: NonNull<u8>, offset: usize, parent_rate: u32, degrees: u32) {
+    let delay_num = rk3588_mmc_delay_num(parent_rate, degrees);
+    let raw_value = if delay_num != 0 { 1 << 10 } else { 0 }
+        | ((delay_num & 0xff) << 2)
+        | ((degrees / 90) & 0x03);
+    let reg_value =
+        ((0x07ff_u32 << RK3588_SDMMC_PHASE_SHIFT) << 16) | (raw_value << RK3588_SDMMC_PHASE_SHIFT);
+    unsafe {
+        (cru.as_ptr().add(offset) as *mut u32).write_volatile(reg_value);
+    }
 }
 
-struct BlockDevice {
-    raw: Option<Arc<SpinNoIrq<RockchipSdhci>>>,
+fn rk3588_mmc_delay_num(parent_rate: u32, degrees: u32) -> u32 {
+    let degree = degrees % 360;
+    let remainder = degree % 90;
+    if parent_rate == 0 {
+        0
+    } else {
+        div_round_closest(
+            10_000_000_u64 * remainder as u64,
+            (parent_rate as u64 / 1_000) * 36 * 6,
+        )
+        .min(255) as u32
+    }
+}
+
+fn div_round_closest(numerator: u64, denominator: u64) -> u64 {
+    if denominator == 0 {
+        0
+    } else {
+        (numerator + denominator / 2) / denominator
+    }
+}
+
+fn has_mbr_signature(block: &[u8; BLOCK_SIZE]) -> bool {
+    block[510] == 0x55 && block[511] == 0xaa
+}
+
+fn has_gpt_header(block: &[u8; BLOCK_SIZE]) -> bool {
+    &block[..8] == b"EFI PART"
+}
+
+fn validate_reference_clock(info: &FdtInfo<'_>, rate: u64) -> Option<u32> {
+    if rate == 0 || rate > u32::MAX as u64 {
+        warn!("[{}] invalid ciu clock rate {} Hz", info.node.name(), rate);
+        return None;
+    }
+    Some(rate as u32)
+}
+
+struct SdBlockDevice {
+    raw: Option<Arc<SpinNoIrq<RockchipDwMmc>>>,
     capacity_blocks: u64,
     irq_enabled: bool,
     queue_created: bool,
 }
 
-struct BlockQueue {
-    raw: Arc<SpinNoIrq<RockchipSdhci>>,
+struct SdBlockQueue {
+    raw: Arc<SpinNoIrq<RockchipDwMmc>>,
     capacity_blocks: u64,
     id: usize,
     dma: DeviceDma,
@@ -241,20 +433,20 @@ struct BlockQueue {
     completed: Vec<rd_block::RequestId>,
 }
 
-impl DriverGeneric for BlockDevice {
+impl DriverGeneric for SdBlockDevice {
     fn name(&self) -> &str {
-        "rockchip-sdhci"
+        "rockchip-sd"
     }
 }
 
-impl rd_block::Interface for BlockDevice {
+impl rd_block::Interface for SdBlockDevice {
     fn create_queue(&mut self) -> Option<alloc::boxed::Box<dyn rd_block::IQueue>> {
         if self.queue_created {
             return None;
         }
         self.raw.as_ref().map(|dev| {
             self.queue_created = true;
-            alloc::boxed::Box::new(BlockQueue {
+            alloc::boxed::Box::new(SdBlockQueue {
                 raw: dev.clone(),
                 capacity_blocks: self.capacity_blocks,
                 id: 0,
@@ -270,7 +462,7 @@ impl rd_block::Interface for BlockDevice {
         if let Some(raw) = &self.raw {
             let mut raw = raw.lock();
             if let Err(err) = SdioHost::enable_completion_irq(raw.host_mut()) {
-                warn!("rockchip-sdhci: enable completion IRQ failed: {:?}", err);
+                warn!("rockchip-dwmmc: enable completion IRQ failed: {:?}", err);
                 return;
             }
             self.irq_enabled = true;
@@ -281,7 +473,7 @@ impl rd_block::Interface for BlockDevice {
         if let Some(raw) = &self.raw {
             let mut raw = raw.lock();
             if let Err(err) = SdioHost::disable_completion_irq(raw.host_mut()) {
-                warn!("rockchip-sdhci: disable completion IRQ failed: {:?}", err);
+                warn!("rockchip-dwmmc: disable completion IRQ failed: {:?}", err);
             }
         }
         self.irq_enabled = false;
@@ -296,17 +488,19 @@ impl rd_block::Interface for BlockDevice {
             return rd_block::Event::none();
         };
         let irq_event = raw.lock().host_mut().handle_irq();
-        block_event_from_sdhci_irq(irq_event)
+        block_event_from_dwmmc_irq(irq_event)
     }
 }
 
-fn block_event_from_sdhci_irq(irq_event: sdhci_host::Event) -> rd_block::Event {
+fn block_event_from_dwmmc_irq(irq_event: dwmmc_host::Event) -> rd_block::Event {
     match irq_event {
-        sdhci_host::Event::None => rd_block::Event::none(),
-        sdhci_host::Event::CommandComplete
-        | sdhci_host::Event::TransferComplete
-        | sdhci_host::Event::Error { .. }
-        | sdhci_host::Event::Other { .. } => {
+        dwmmc_host::Event::None => rd_block::Event::none(),
+        dwmmc_host::Event::CommandComplete
+        | dwmmc_host::Event::TransferComplete
+        | dwmmc_host::Event::ReceiveReady
+        | dwmmc_host::Event::TransmitReady
+        | dwmmc_host::Event::Error { .. }
+        | dwmmc_host::Event::Other { .. } => {
             let mut event = rd_block::Event::none();
             event.queue.insert(0);
             event
@@ -314,7 +508,7 @@ fn block_event_from_sdhci_irq(irq_event: sdhci_host::Event) -> rd_block::Event {
     }
 }
 
-impl rd_block::IQueue for BlockQueue {
+impl rd_block::IQueue for SdBlockQueue {
     fn num_blocks(&self) -> usize {
         self.capacity_blocks as usize
     }
@@ -402,7 +596,7 @@ impl rd_block::IQueue for BlockQueue {
     }
 }
 
-impl BlockQueue {
+impl SdBlockQueue {
     fn poll_active_request(
         &mut self,
         request: rd_block::RequestId,
@@ -414,6 +608,9 @@ impl BlockQueue {
         ) {
             Ok(BlockPoll::Complete) => Ok(()),
             Ok(BlockPoll::Pending) => Err(rd_block::BlkError::Retry),
+            Ok(_) => Err(rd_block::BlkError::Other(
+                "DWMMC returned an unknown poll state".into(),
+            )),
             Err(err) => Err(map_dev_err_to_blk_err(err)),
         }
     }
@@ -439,7 +636,7 @@ impl BlockQueue {
 }
 
 fn submit_read_request(
-    host: &mut Sdhci,
+    host: &mut DwMmc,
     start_block: u32,
     buffer: NonNull<u8>,
     size: NonZeroUsize,
@@ -477,7 +674,7 @@ fn submit_read_request(
 }
 
 fn submit_write_request(
-    host: &mut Sdhci,
+    host: &mut DwMmc,
     start_block: u32,
     buffer: NonNull<u8>,
     size: NonZeroUsize,
@@ -541,13 +738,27 @@ fn map_dev_err_to_blk_err(err: Error) -> rd_block::BlkError {
         Error::Misaligned | Error::InvalidArgument => {
             rd_block::BlkError::Other("SD/MMC request is not block aligned".into())
         }
-        _ => rd_block::BlkError::Other("SDHCI I/O error".into()),
+        _ => rd_block::BlkError::Other("DWMMC I/O error".into()),
     }
 }
 
-static CLK_DEV: Once<ClkDev> = Once::new();
+#[cfg(test)]
+mod tests {
+    use sdmmc_protocol::error::ErrorContext;
 
-struct ClkDev {
-    inner: Device<rdif_clk::Clk>,
-    id: ClockId,
+    use super::*;
+
+    #[test]
+    fn command_timeout_during_card_init_is_absent_card() {
+        let err = Error::Timeout(ErrorContext::for_cmd(Phase::ResponseWait, 1));
+
+        assert!(is_absent_card_init_error(err));
+    }
+
+    #[test]
+    fn data_timeout_after_card_init_is_not_absent_card() {
+        let err = Error::Timeout(ErrorContext::for_cmd(Phase::DataRead, 17));
+
+        assert!(!is_absent_card_init_error(err));
+    }
 }

--- a/platform/axplat-dyn/src/drivers/blk/rockchip/dwmmc.rs
+++ b/platform/axplat-dyn/src/drivers/blk/rockchip/dwmmc.rs
@@ -362,6 +362,7 @@ fn read_block_sync(
         match sd.poll_data_request(&mut request)? {
             DataCommandPoll::Pending => core::hint::spin_loop(),
             DataCommandPoll::Complete(_) => return Ok(()),
+            _ => core::hint::spin_loop(),
         }
     }
 }

--- a/platform/axplat-dyn/src/drivers/blk/rockchip/mod.rs
+++ b/platform/axplat-dyn/src/drivers/blk/rockchip/mod.rs
@@ -1,0 +1,6 @@
+#[cfg(feature = "rockchip-dwmmc")]
+mod dwmmc;
+#[cfg(feature = "rockchip-sdhci")]
+mod sdhci_rk3568;
+#[cfg(feature = "rockchip-sdhci")]
+mod sdhci_rk3588;

--- a/platform/axplat-dyn/src/drivers/blk/rockchip/sdhci_rk3568.rs
+++ b/platform/axplat-dyn/src/drivers/blk/rockchip/sdhci_rk3568.rs
@@ -12,50 +12,97 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{format, sync::Arc, vec::Vec};
+use alloc::{format, string::ToString, sync::Arc, vec::Vec};
 use core::{num::NonZeroUsize, ptr::NonNull, time::Duration};
 
 use ax_kspin::SpinNoIrq;
 use dma_api::DeviceDma;
-use dwmmc_host::{BlockRequest, BlockRequestSlot, DwMmc, RequestId};
 use rdif_clk::ClockId;
 use rdrive::{
-    DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
+    Device, DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
 };
+use sdhci_host::{BlockRequest, BlockRequestSlot, HostClock, RequestId, Sdhci};
 use sdmmc_protocol::{
-    BlockPoll, BlockTransferMode, DataCommandPoll, Error, OperationPoll,
-    error::Phase,
-    sdio::{CardInfo, SdioHost, SdioInitScratch, SdioSdmmc},
+    BlockPoll, BlockTransferMode, Error, OperationPoll,
+    error::{ErrorContext, Phase},
+    sdio::{CardInfo, CardInitPreference, SdioHost, SdioInitScratch, SdioSdmmc},
 };
+use spin::Once;
 
 use crate::drivers::{
     DmaImpl,
     blk::{PlatformDeviceBlock, decode_fdt_irq},
     iomap,
-    soc::scmi,
 };
 
 const BLOCK_SIZE: usize = 512;
-const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
-const ENABLE_SD_SPEED_SELECTION: bool = true;
-const RK3588_CRU_BASE: usize = 0xfd7c_0000;
-const RK3588_CRU_SIZE: usize = 0x5c000;
-const RK3588_SDMMC_CON0: usize = 0x0c30;
-const RK3588_SDMMC_CON1: usize = 0x0c34;
-const RK3588_SDMMC_PHASE_SHIFT: u32 = 1;
-const RK3588_SDMMC_DRV_PHASE_DEG: u32 = 90;
-const RK3588_SDMMC_SAMPLE_PHASE_DEG: u32 = 0;
-const RK3588_SDMMC_SAMPLE_PHASE_CANDIDATES: [u32; 8] = [0, 45, 90, 135, 180, 225, 270, 315];
+const SDHCI_POWER_330: u8 = 0x0e;
 
-type RockchipDwMmc = SdioSdmmc<DwMmc>;
+const DWCMSHC_P_VENDOR_AREA1: usize = 0xe8;
+const DWCMSHC_AREA1_MASK: u16 = 0x0fff;
+const DWCMSHC_HOST_CTRL3: usize = 0x08;
+const DWCMSHC_EMMC_CONTROL: usize = 0x2c;
+const DWCMSHC_CARD_IS_EMMC: u16 = 1 << 0;
+const DWCMSHC_EMMC_DLL_CTRL: usize = 0x800;
+const DWCMSHC_EMMC_DLL_RXCLK: usize = 0x804;
+const DWCMSHC_EMMC_DLL_TXCLK: usize = 0x808;
+const DWCMSHC_EMMC_DLL_STRBIN: usize = 0x80c;
+const DWCMSHC_EMMC_DLL_CMDOUT: usize = 0x810;
+const DWCMSHC_EMMC_MISC_CON: usize = 0x81c;
+const DWCMSHC_EMMC_DLL_BYPASS: u32 = 1 << 24;
+const DWCMSHC_EMMC_DLL_START: u32 = 1 << 0;
+const DWCMSHC_EMMC_DLL_DLYENA: u32 = 1 << 27;
+const DLL_RXCLK_ORI_GATE: u32 = 1 << 31;
+const DLL_STRBIN_DELAY_NUM_SEL: u32 = 1 << 26;
+const DLL_STRBIN_DELAY_NUM_DEFAULT: u32 = 0x16;
+const DLL_STRBIN_DELAY_NUM_OFFSET: u32 = 16;
+const MISC_INTCLK_EN: u32 = 1 << 1;
+
+const DWC_MSHC_PTR_PHY_R: usize = 0x300;
+const PHY_CNFG_R: usize = DWC_MSHC_PTR_PHY_R;
+const PHY_CMDPAD_CNFG_R: usize = DWC_MSHC_PTR_PHY_R + 0x04;
+const PHY_DATAPAD_CNFG_R: usize = DWC_MSHC_PTR_PHY_R + 0x06;
+const PHY_CLKPAD_CNFG_R: usize = DWC_MSHC_PTR_PHY_R + 0x08;
+const PHY_STBPAD_CNFG_R: usize = DWC_MSHC_PTR_PHY_R + 0x0a;
+const PHY_RSTNPAD_CNFG_R: usize = DWC_MSHC_PTR_PHY_R + 0x0c;
+const PHY_SDCLKDL_CNFG_R: usize = DWC_MSHC_PTR_PHY_R + 0x1d;
+const PHY_SDCLKDL_DC_R: usize = DWC_MSHC_PTR_PHY_R + 0x1e;
+const PHY_SMPLDL_CNFG_R: usize = DWC_MSHC_PTR_PHY_R + 0x20;
+const PHY_DLL_CTRL_R: usize = DWC_MSHC_PTR_PHY_R + 0x24;
+const PHY_DLL_CNFG2_R: usize = DWC_MSHC_PTR_PHY_R + 0x26;
+const PHY_CNFG_RSTN_DEASSERT: u32 = 1 << 0;
+const PHY_CNFG_PAD_SP: u32 = 0x0c;
+const PHY_CNFG_PAD_SN: u32 = 0x0c;
+const PHY_PAD_RXSEL_3V3: u16 = 0x2;
+const PHY_PAD_WEAKPULL_PULLUP: u16 = 0x1;
+const PHY_PAD_WEAKPULL_PULLDOWN: u16 = 0x2;
+const PHY_PAD_TXSLEW_CTRL_P: u16 = 0x3;
+const PHY_PAD_TXSLEW_CTRL_N: u16 = 0x3;
+const PHY_SDCLKDL_CNFG_UPDATE: u8 = 1 << 4;
+const PHY_SDCLKDL_DC_DEFAULT: u8 = 0x32;
+const PHY_SMPLDL_CNFG_BYPASS_EN: u8 = 1 << 1;
+const PHY_DLL_CTRL_ENABLE: u8 = 0x1;
+const PHY_DLL_CNFG2_JUMPSTEP: u8 = 0x0a;
+
+static SDHCI_CLOCK: RockchipSdhciClock = RockchipSdhciClock;
+
+type RockchipSdhci = SdioSdmmc<Sdhci>;
+
+struct RockchipSdhciClock;
+
+impl HostClock for RockchipSdhciClock {
+    fn set_clock(&self, target_hz: u32) -> Result<(), Error> {
+        set_sdhci_clock(target_hz)
+    }
+}
 
 module_driver!(
-    name: "Rockchip SD",
+    name: "Rockchip RK3568 sdhci",
     level: ProbeLevel::PostKernel,
     priority: ProbePriority::DEFAULT,
     probe_kinds: &[
         ProbeKind::Fdt {
-            compatibles: &["rockchip,rk3588-dw-mshc", "rockchip,rk3288-dw-mshc"],
+            compatibles: &["rockchip,rk3568-dwcmshc"],
             on_probe: probe
         }
     ],
@@ -74,45 +121,37 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
 
     let mmio_size = base_reg.size.unwrap_or(0x1000);
     info!(
-        "rockchip-dwmmc probe: node={}, addr={:#x}, size={:#x}",
+        "rockchip-rk3568-sdhci probe: node={}, addr={:#x}, size={:#x}",
         info.node.name(),
         base_reg.address as usize,
         mmio_size
     );
     let mmio_base = iomap((base_reg.address as usize).into(), mmio_size as usize)?;
 
-    let mut host = unsafe { DwMmc::new(mmio_base) };
-    let reference_clock = dwmmc_reference_clock(&info);
-    if let Some(reference_clock) = reference_clock {
-        info!(
-            "rockchip-dwmmc: using ciu reference clock {} Hz",
-            reference_clock
-        );
-        host.set_reference_clock(reference_clock);
-        if is_rk3588_dwmmc(&info) {
-            init_rk3588_sdmmc_phase(&info, reference_clock)?;
-        }
+    init_core_clock(&info)?;
+
+    let mut host = unsafe { Sdhci::new(mmio_base) };
+    if CLK_DEV.is_completed() {
+        info!("rockchip-rk3568-sdhci: using external CRU clock");
+        host.set_external_clock(&SDHCI_CLOCK);
     } else {
-        warn!(
-            "rockchip-dwmmc: ciu clock not found; leaving DWMMC divider bypassed and relying on \
-             CRU rate"
-        );
+        warn!("rockchip-rk3568-sdhci: no core clock found; using SDHCI internal clock divider");
     }
-    info!("rockchip-dwmmc: reset controller");
-    host.reset_and_init()
+    info!("rockchip-rk3568-sdhci: reset controller");
+    host.reset_all()
         .map_err(|e| init_error(base_reg.address, mmio_size, e))?;
+    init_dwcmshc_after_reset(mmio_base);
+    host.set_power(SDHCI_POWER_330);
+    host.enable_interrupts();
     host.set_dma(DeviceDma::new(u32::MAX as u64, &DmaImpl));
 
-    info!("rockchip-dwmmc: initialize card");
-    let mut sd = SdioSdmmc::new(host);
-    sd.set_sd_speed_selection_enabled(ENABLE_SD_SPEED_SELECTION);
-    let card_info = poll_card_init(&mut sd).map_err(|e| {
-        warn!("rockchip-dwmmc: card init failed: {:?}", e);
-        card_init_error(base_reg.address, mmio_size, e)
-    })?;
+    info!("rockchip-rk3568-sdhci: initialize card");
+    let mut card = SdioSdmmc::new(host);
+    let card_info = poll_card_init_mmc(&mut card)
+        .map_err(|e| card_init_error(base_reg.address, mmio_size, e))?;
     info!(
-        "rockchip-dwmmc card: kind={:?} high_capacity={} rca={} ocr={:#010x} capacity_blocks={:?} \
-         cid={} ext_csd={}",
+        "SDHCI card: kind={:?} high_capacity={} rca={} ocr={:#010x} capacity_blocks={:?} cid={} \
+         ext_csd={}",
         card_info.kind,
         card_info.high_capacity,
         card_info.rca,
@@ -122,30 +161,28 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
         card_info.ext_csd.is_some()
     );
 
-    if let Some(reference_clock) = reference_clock
-        && is_rk3588_dwmmc(&info)
-    {
-        tune_rk3588_sdmmc_sample_phase(&mut sd, reference_clock);
-    }
-
     let irq_num = decode_fdt_irq(&info.interrupts());
-    let raw = Arc::new(SpinNoIrq::new(sd));
-    let dev = SdBlockDevice {
+    let raw = Arc::new(SpinNoIrq::new(card));
+    let dev = BlockDevice {
         raw: Some(raw.clone()),
         capacity_blocks: card_info.capacity_blocks.unwrap_or(0),
         irq_enabled: false,
         queue_created: false,
     };
     plat_dev.register_block_with_irq(dev, irq_num);
-    info!("rockchip-sd block device registered irq={:?}", irq_num);
+    info!(
+        "rockchip-rk3568-sdhci block device registered irq={:?}",
+        irq_num
+    );
     Ok(())
 }
 
-fn poll_card_init(sd: &mut RockchipDwMmc) -> Result<CardInfo, Error> {
+fn poll_card_init_mmc(card: &mut RockchipSdhci) -> Result<CardInfo, Error> {
     let mut scratch = SdioInitScratch::new();
-    let mut request = sd.submit_init(&mut scratch)?;
+    let mut request =
+        card.submit_init_with_preference(CardInitPreference::MmcFirst, &mut scratch)?;
     loop {
-        match sd.poll_init_request(&mut request)? {
+        match card.poll_init_request(&mut request)? {
             OperationPoll::Pending => {
                 if request.take_needs_pace() {
                     axklib::time::busy_wait(Duration::from_millis(10));
@@ -154,13 +191,105 @@ fn poll_card_init(sd: &mut RockchipDwMmc) -> Result<CardInfo, Error> {
                 }
             }
             OperationPoll::Complete(info) => return Ok(info),
+            _ => return Err(Error::UnsupportedCommand),
         }
     }
 }
 
+fn init_dwcmshc_after_reset(base: NonNull<u8>) {
+    let area1 = vendor_area1(base);
+
+    // Match Linux rk35xx reset/set_clock setup for identification speed:
+    // keep the internal clock ungated, disable command-conflict checking,
+    // and put Rockchip's DLL path in bypass while the bus runs below 52 MHz.
+    write_u32(
+        base,
+        DWCMSHC_EMMC_MISC_CON,
+        read_u32(base, DWCMSHC_EMMC_MISC_CON) | MISC_INTCLK_EN,
+    );
+    write_u32(base, area1 + DWCMSHC_HOST_CTRL3, 0);
+    write_u16(
+        base,
+        area1 + DWCMSHC_EMMC_CONTROL,
+        read_u16(base, area1 + DWCMSHC_EMMC_CONTROL) | DWCMSHC_CARD_IS_EMMC,
+    );
+    write_u32(
+        base,
+        DWCMSHC_EMMC_DLL_CTRL,
+        DWCMSHC_EMMC_DLL_BYPASS | DWCMSHC_EMMC_DLL_START,
+    );
+    write_u32(base, DWCMSHC_EMMC_DLL_RXCLK, DLL_RXCLK_ORI_GATE);
+    write_u32(base, DWCMSHC_EMMC_DLL_TXCLK, 0);
+    write_u32(base, DWCMSHC_EMMC_DLL_CMDOUT, 0);
+    write_u32(
+        base,
+        DWCMSHC_EMMC_DLL_STRBIN,
+        DWCMSHC_EMMC_DLL_DLYENA
+            | DLL_STRBIN_DELAY_NUM_SEL
+            | (DLL_STRBIN_DELAY_NUM_DEFAULT << DLL_STRBIN_DELAY_NUM_OFFSET),
+    );
+    init_dwcmshc_phy_3v3(base);
+    info!(
+        "rockchip-rk3568-sdhci: dwcmshc vendor init area1={:#x}",
+        area1
+    );
+}
+
+fn init_dwcmshc_phy_3v3(base: NonNull<u8>) {
+    let phy_cfg = PHY_CNFG_RSTN_DEASSERT | (PHY_CNFG_PAD_SP << 16) | (PHY_CNFG_PAD_SN << 20);
+    write_u32(base, PHY_CNFG_R, phy_cfg);
+    write_u8(base, PHY_SDCLKDL_CNFG_R, PHY_SDCLKDL_CNFG_UPDATE);
+    write_u8(base, PHY_SDCLKDL_DC_R, PHY_SDCLKDL_DC_DEFAULT);
+    write_u8(base, PHY_DLL_CNFG2_R, PHY_DLL_CNFG2_JUMPSTEP);
+    write_u8(base, PHY_SDCLKDL_CNFG_R, 0);
+
+    let pad_pullup = PHY_PAD_RXSEL_3V3
+        | (PHY_PAD_WEAKPULL_PULLUP << 3)
+        | (PHY_PAD_TXSLEW_CTRL_P << 5)
+        | (PHY_PAD_TXSLEW_CTRL_N << 9);
+    write_u16(base, PHY_CMDPAD_CNFG_R, pad_pullup);
+    write_u16(base, PHY_DATAPAD_CNFG_R, pad_pullup);
+    write_u16(base, PHY_RSTNPAD_CNFG_R, pad_pullup);
+
+    let clk_pad = (PHY_PAD_TXSLEW_CTRL_P << 5) | (PHY_PAD_TXSLEW_CTRL_N << 9);
+    write_u16(base, PHY_CLKPAD_CNFG_R, clk_pad);
+
+    let strobe_pad = PHY_PAD_RXSEL_3V3
+        | (PHY_PAD_WEAKPULL_PULLDOWN << 3)
+        | (PHY_PAD_TXSLEW_CTRL_P << 5)
+        | (PHY_PAD_TXSLEW_CTRL_N << 9);
+    write_u16(base, PHY_STBPAD_CNFG_R, strobe_pad);
+    write_u8(base, PHY_SMPLDL_CNFG_R, PHY_SMPLDL_CNFG_BYPASS_EN);
+    write_u8(base, PHY_DLL_CTRL_R, PHY_DLL_CTRL_ENABLE);
+}
+
+fn vendor_area1(base: NonNull<u8>) -> usize {
+    (read_u16(base, DWCMSHC_P_VENDOR_AREA1) & DWCMSHC_AREA1_MASK) as usize
+}
+
+fn read_u32(base: NonNull<u8>, off: usize) -> u32 {
+    unsafe { core::ptr::read_volatile(base.as_ptr().add(off) as *const u32) }
+}
+
+fn write_u32(base: NonNull<u8>, off: usize, val: u32) {
+    unsafe { core::ptr::write_volatile(base.as_ptr().add(off) as *mut u32, val) }
+}
+
+fn read_u16(base: NonNull<u8>, off: usize) -> u16 {
+    unsafe { core::ptr::read_volatile(base.as_ptr().add(off) as *const u16) }
+}
+
+fn write_u16(base: NonNull<u8>, off: usize, val: u16) {
+    unsafe { core::ptr::write_volatile(base.as_ptr().add(off) as *mut u16, val) }
+}
+
+fn write_u8(base: NonNull<u8>, off: usize, val: u8) {
+    unsafe { core::ptr::write_volatile(base.as_ptr().add(off), val) }
+}
+
 fn init_error(address: u64, size: u64, err: Error) -> OnProbeError {
     OnProbeError::other(format!(
-        "failed to initialize DWMMC device at [PA:{:?}, SZ:0x{:x}): {err:?}",
+        "failed to initialize SDHCI device at [PA:{:?}, SZ:0x{:x}): {err:?}",
         address, size
     ))
 }
@@ -168,8 +297,8 @@ fn init_error(address: u64, size: u64, err: Error) -> OnProbeError {
 fn card_init_error(address: u64, size: u64, err: Error) -> OnProbeError {
     if is_absent_card_init_error(err) {
         warn!(
-            "rockchip-dwmmc: no responsive card at [PA:{:?}, SZ:0x{:x}); skipping controller: \
-             {err:?}",
+            "rockchip-rk3568-sdhci: no responsive card at [PA:{:?}, SZ:0x{:x}); skipping \
+             controller: {err:?}",
             address, size
         );
         return OnProbeError::NotMatch;
@@ -192,238 +321,61 @@ fn is_absent_card_init_error(err: Error) -> bool {
     }
 }
 
-fn dwmmc_reference_clock(info: &FdtInfo<'_>) -> Option<u32> {
-    let Some(clk) = info.find_clk_by_name("ciu") else {
-        return None;
-    };
-    let Some(device_id) = info.phandle_to_device_id(clk.phandle) else {
-        warn!(
-            "[{}] ciu clock phandle {} has no device id",
-            info.node.name(),
-            clk.phandle
+fn init_core_clock(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
+    for clk in info.node.clocks() {
+        info!(
+            "rockchip-sdhci clock: phandle <{}>, name: {:?}, cells: {}",
+            clk.phandle, clk.name, clk.cells
         );
-        return None;
-    };
-    let clk_dev = match rdrive::get::<rdif_clk::Clk>(device_id) {
-        Ok(clk_dev) => clk_dev,
-        Err(_) => {
-            let clock_id = clk.select().unwrap_or(0);
-            if scmi::set_clock_rate(clk.phandle, clock_id, DWMMC_STABLE_REFERENCE_CLOCK as u64)
-                .is_some()
-            {
-                return Some(DWMMC_STABLE_REFERENCE_CLOCK);
-            }
-            if let Some(rate) = scmi::clock_rate(clk.phandle, clock_id) {
-                return validate_reference_clock(info, rate);
-            }
-            warn!(
-                "[{}] ciu clock device {:?} is not registered",
-                info.node.name(),
-                device_id
-            );
-            return None;
+        if clk.name == Some("core".to_string()) {
+            let device_id = info.phandle_to_device_id(clk.phandle).ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] core clock phandle {} has no device id",
+                    info.node.name(),
+                    clk.phandle
+                ))
+            })?;
+            let clk_dev = rdrive::get::<rdif_clk::Clk>(device_id).map_err(|_| {
+                OnProbeError::other(format!(
+                    "[{}] core clock device {:?} is not registered",
+                    info.node.name(),
+                    device_id
+                ))
+            })?;
+            CLK_DEV.call_once(|| ClkDev {
+                inner: clk_dev,
+                id: (clk.select().unwrap_or(0) as usize).into(),
+            });
+            return Ok(());
         }
-    };
-    let mut clk_guard = match clk_dev.lock() {
-        Ok(clk_guard) => clk_guard,
-        Err(_) => {
-            warn!(
-                "[{}] ciu clock device {:?} is locked",
-                info.node.name(),
-                device_id
-            );
-            return None;
-        }
-    };
-    let clock_id = ClockId::from(clk.select().unwrap_or(0) as usize);
-    if let Err(err) = clk_guard.set_rate(clock_id, DWMMC_STABLE_REFERENCE_CLOCK as u64) {
-        warn!(
-            "[{}] failed to set ciu clock {:?} to {} Hz: {:?}",
-            info.node.name(),
-            clock_id,
-            DWMMC_STABLE_REFERENCE_CLOCK,
-            err
-        );
     }
-    let rate = match clk_guard.get_rate(clock_id) {
-        Ok(rate) => rate,
-        Err(err) => {
-            warn!(
-                "[{}] failed to read ciu clock {:?}: {:?}",
-                info.node.name(),
-                clock_id,
-                err
-            );
-            return None;
-        }
-    };
-    validate_reference_clock(info, rate)
-}
-
-fn is_rk3588_dwmmc(info: &FdtInfo<'_>) -> bool {
-    info.node
-        .as_node()
-        .compatibles()
-        .any(|compatible| compatible == "rockchip,rk3588-dw-mshc")
-}
-
-fn init_rk3588_sdmmc_phase(info: &FdtInfo<'_>, parent_rate: u32) -> Result<(), OnProbeError> {
-    let has_drive_clk = info.find_clk_by_name("ciu-drive").is_some();
-    let has_sample_clk = info.find_clk_by_name("ciu-sample").is_some();
-    if !has_drive_clk || !has_sample_clk {
-        warn!(
-            "[{}] RK3588 SDMMC phase clocks missing: ciu-drive={} ciu-sample={}",
-            info.node.name(),
-            has_drive_clk,
-            has_sample_clk
-        );
-        return Ok(());
-    }
-
-    let cru = iomap(RK3588_CRU_BASE.into(), RK3588_CRU_SIZE)?;
-    set_rk3588_mmc_phase(
-        cru,
-        RK3588_SDMMC_CON0,
-        parent_rate,
-        RK3588_SDMMC_DRV_PHASE_DEG,
-    );
-    set_rk3588_mmc_phase(
-        cru,
-        RK3588_SDMMC_CON1,
-        parent_rate,
-        RK3588_SDMMC_SAMPLE_PHASE_DEG,
-    );
-    info!(
-        "rockchip-dwmmc: RK3588 SDMMC phase configured: drive={}deg sample={}deg parent={}Hz",
-        RK3588_SDMMC_DRV_PHASE_DEG, RK3588_SDMMC_SAMPLE_PHASE_DEG, parent_rate
-    );
     Ok(())
 }
 
-fn tune_rk3588_sdmmc_sample_phase(sd: &mut RockchipDwMmc, parent_rate: u32) {
-    let Ok(cru) = iomap(RK3588_CRU_BASE.into(), RK3588_CRU_SIZE) else {
-        warn!("rockchip-dwmmc: failed to map RK3588 CRU for sample phase scan");
-        return;
-    };
-
-    for sample_phase in RK3588_SDMMC_SAMPLE_PHASE_CANDIDATES {
-        set_rk3588_mmc_phase(cru, RK3588_SDMMC_CON1, parent_rate, sample_phase);
-
-        let mut block0 = [0; BLOCK_SIZE];
-        let block0_result = read_block_sync(sd, 0, &mut block0);
-        let block0_valid = block0_result.is_ok() && has_mbr_signature(&block0);
-
-        let mut block1 = [0; BLOCK_SIZE];
-        let block1_result = read_block_sync(sd, 1, &mut block1);
-        let block1_valid = block1_result.is_ok() && has_gpt_header(&block1);
-
-        info!(
-            "rockchip-dwmmc: sample phase probe {}deg: block0_ok={} mbr_sig={:02x}{:02x} \
-             block0_head={:02x?} block1_ok={} gpt_head={:02x?}",
-            sample_phase,
-            block0_result.is_ok(),
-            block0[511],
-            block0[510],
-            &block0[..16],
-            block1_result.is_ok(),
-            &block1[..8]
-        );
-
-        if block0_valid || block1_valid {
-            set_rk3588_mmc_phase(cru, RK3588_SDMMC_CON1, parent_rate, sample_phase);
-            info!(
-                "rockchip-dwmmc: selected RK3588 SDMMC sample phase {}deg",
-                sample_phase
-            );
-            return;
-        }
-    }
-
-    set_rk3588_mmc_phase(
-        cru,
-        RK3588_SDMMC_CON1,
-        parent_rate,
-        RK3588_SDMMC_SAMPLE_PHASE_DEG,
-    );
-    warn!(
-        "rockchip-dwmmc: no valid RK3588 SDMMC sample phase found; restored {}deg",
-        RK3588_SDMMC_SAMPLE_PHASE_DEG
-    );
+fn set_sdhci_clock(target_hz: u32) -> Result<(), Error> {
+    let clk = CLK_DEV.wait();
+    let mut clk_dev = clk.inner.lock().map_err(|_| clock_error())?;
+    clk_dev
+        .set_rate(clk.id, target_hz as u64)
+        .map_err(|_| clock_error())?;
+    let rate = clk_dev.get_rate(clk.id).map_err(|_| clock_error())?;
+    info!("rockchip-rk3568-sdhci: core clock set to {} Hz", rate);
+    Ok(())
 }
 
-fn read_block_sync(
-    sd: &mut RockchipDwMmc,
-    addr: u32,
-    buf: &mut [u8; BLOCK_SIZE],
-) -> Result<(), Error> {
-    let mut request = sd.submit_read_blocks_into(addr, buf)?;
-    loop {
-        match sd.poll_data_request(&mut request)? {
-            DataCommandPoll::Pending => core::hint::spin_loop(),
-            DataCommandPoll::Complete(_) => return Ok(()),
-        }
-    }
+fn clock_error() -> Error {
+    Error::BusError(ErrorContext::new(Phase::Init))
 }
 
-fn set_rk3588_mmc_phase(cru: NonNull<u8>, offset: usize, parent_rate: u32, degrees: u32) {
-    let delay_num = rk3588_mmc_delay_num(parent_rate, degrees);
-    let raw_value = if delay_num != 0 { 1 << 10 } else { 0 }
-        | ((delay_num & 0xff) << 2)
-        | ((degrees / 90) & 0x03);
-    let reg_value =
-        ((0x07ff_u32 << RK3588_SDMMC_PHASE_SHIFT) << 16) | (raw_value << RK3588_SDMMC_PHASE_SHIFT);
-    unsafe {
-        (cru.as_ptr().add(offset) as *mut u32).write_volatile(reg_value);
-    }
-}
-
-fn rk3588_mmc_delay_num(parent_rate: u32, degrees: u32) -> u32 {
-    let degree = degrees % 360;
-    let remainder = degree % 90;
-    if parent_rate == 0 {
-        0
-    } else {
-        div_round_closest(
-            10_000_000_u64 * remainder as u64,
-            (parent_rate as u64 / 1_000) * 36 * 6,
-        )
-        .min(255) as u32
-    }
-}
-
-fn div_round_closest(numerator: u64, denominator: u64) -> u64 {
-    if denominator == 0 {
-        0
-    } else {
-        (numerator + denominator / 2) / denominator
-    }
-}
-
-fn has_mbr_signature(block: &[u8; BLOCK_SIZE]) -> bool {
-    block[510] == 0x55 && block[511] == 0xaa
-}
-
-fn has_gpt_header(block: &[u8; BLOCK_SIZE]) -> bool {
-    &block[..8] == b"EFI PART"
-}
-
-fn validate_reference_clock(info: &FdtInfo<'_>, rate: u64) -> Option<u32> {
-    if rate == 0 || rate > u32::MAX as u64 {
-        warn!("[{}] invalid ciu clock rate {} Hz", info.node.name(), rate);
-        return None;
-    }
-    Some(rate as u32)
-}
-
-struct SdBlockDevice {
-    raw: Option<Arc<SpinNoIrq<RockchipDwMmc>>>,
+struct BlockDevice {
+    raw: Option<Arc<SpinNoIrq<RockchipSdhci>>>,
     capacity_blocks: u64,
     irq_enabled: bool,
     queue_created: bool,
 }
 
-struct SdBlockQueue {
-    raw: Arc<SpinNoIrq<RockchipDwMmc>>,
+struct BlockQueue {
+    raw: Arc<SpinNoIrq<RockchipSdhci>>,
     capacity_blocks: u64,
     id: usize,
     dma: DeviceDma,
@@ -432,20 +384,20 @@ struct SdBlockQueue {
     completed: Vec<rd_block::RequestId>,
 }
 
-impl DriverGeneric for SdBlockDevice {
+impl DriverGeneric for BlockDevice {
     fn name(&self) -> &str {
-        "rockchip-sd"
+        "rockchip-rk3568-sdhci"
     }
 }
 
-impl rd_block::Interface for SdBlockDevice {
+impl rd_block::Interface for BlockDevice {
     fn create_queue(&mut self) -> Option<alloc::boxed::Box<dyn rd_block::IQueue>> {
         if self.queue_created {
             return None;
         }
         self.raw.as_ref().map(|dev| {
             self.queue_created = true;
-            alloc::boxed::Box::new(SdBlockQueue {
+            alloc::boxed::Box::new(BlockQueue {
                 raw: dev.clone(),
                 capacity_blocks: self.capacity_blocks,
                 id: 0,
@@ -461,7 +413,10 @@ impl rd_block::Interface for SdBlockDevice {
         if let Some(raw) = &self.raw {
             let mut raw = raw.lock();
             if let Err(err) = SdioHost::enable_completion_irq(raw.host_mut()) {
-                warn!("rockchip-dwmmc: enable completion IRQ failed: {:?}", err);
+                warn!(
+                    "rockchip-rk3568-sdhci: enable completion IRQ failed: {:?}",
+                    err
+                );
                 return;
             }
             self.irq_enabled = true;
@@ -472,7 +427,10 @@ impl rd_block::Interface for SdBlockDevice {
         if let Some(raw) = &self.raw {
             let mut raw = raw.lock();
             if let Err(err) = SdioHost::disable_completion_irq(raw.host_mut()) {
-                warn!("rockchip-dwmmc: disable completion IRQ failed: {:?}", err);
+                warn!(
+                    "rockchip-rk3568-sdhci: disable completion IRQ failed: {:?}",
+                    err
+                );
             }
         }
         self.irq_enabled = false;
@@ -487,19 +445,17 @@ impl rd_block::Interface for SdBlockDevice {
             return rd_block::Event::none();
         };
         let irq_event = raw.lock().host_mut().handle_irq();
-        block_event_from_dwmmc_irq(irq_event)
+        block_event_from_sdhci_irq(irq_event)
     }
 }
 
-fn block_event_from_dwmmc_irq(irq_event: dwmmc_host::Event) -> rd_block::Event {
+fn block_event_from_sdhci_irq(irq_event: sdhci_host::Event) -> rd_block::Event {
     match irq_event {
-        dwmmc_host::Event::None => rd_block::Event::none(),
-        dwmmc_host::Event::CommandComplete
-        | dwmmc_host::Event::TransferComplete
-        | dwmmc_host::Event::ReceiveReady
-        | dwmmc_host::Event::TransmitReady
-        | dwmmc_host::Event::Error { .. }
-        | dwmmc_host::Event::Other { .. } => {
+        sdhci_host::Event::None => rd_block::Event::none(),
+        sdhci_host::Event::CommandComplete
+        | sdhci_host::Event::TransferComplete
+        | sdhci_host::Event::Error { .. }
+        | sdhci_host::Event::Other { .. } => {
             let mut event = rd_block::Event::none();
             event.queue.insert(0);
             event
@@ -507,7 +463,7 @@ fn block_event_from_dwmmc_irq(irq_event: dwmmc_host::Event) -> rd_block::Event {
     }
 }
 
-impl rd_block::IQueue for SdBlockQueue {
+impl rd_block::IQueue for BlockQueue {
     fn num_blocks(&self) -> usize {
         self.capacity_blocks as usize
     }
@@ -595,7 +551,7 @@ impl rd_block::IQueue for SdBlockQueue {
     }
 }
 
-impl SdBlockQueue {
+impl BlockQueue {
     fn poll_active_request(
         &mut self,
         request: rd_block::RequestId,
@@ -607,6 +563,9 @@ impl SdBlockQueue {
         ) {
             Ok(BlockPoll::Complete) => Ok(()),
             Ok(BlockPoll::Pending) => Err(rd_block::BlkError::Retry),
+            Ok(_) => Err(rd_block::BlkError::Other(
+                "SDHCI returned an unknown poll state".into(),
+            )),
             Err(err) => Err(map_dev_err_to_blk_err(err)),
         }
     }
@@ -631,8 +590,12 @@ impl SdBlockQueue {
     }
 }
 
+fn rk3568_block_transfer_mode() -> BlockTransferMode {
+    BlockTransferMode::Fifo
+}
+
 fn submit_read_request(
-    host: &mut DwMmc,
+    host: &mut Sdhci,
     start_block: u32,
     buffer: NonNull<u8>,
     size: NonZeroUsize,
@@ -647,8 +610,8 @@ fn submit_read_request(
         start_block,
         buffer,
         size,
-        Some(dma),
-        BlockTransferMode::Dma,
+        transfer_dma(rk3568_block_transfer_mode(), dma),
+        rk3568_block_transfer_mode(),
         slot,
     ) {
         Ok(request) => request,
@@ -670,7 +633,7 @@ fn submit_read_request(
 }
 
 fn submit_write_request(
-    host: &mut DwMmc,
+    host: &mut Sdhci,
     start_block: u32,
     buffer: NonNull<u8>,
     size: NonZeroUsize,
@@ -685,8 +648,8 @@ fn submit_write_request(
         start_block,
         buffer,
         size,
-        Some(dma),
-        BlockTransferMode::Dma,
+        transfer_dma(rk3568_block_transfer_mode(), dma),
+        rk3568_block_transfer_mode(),
         slot,
     ) {
         Ok(request) => request,
@@ -705,6 +668,14 @@ fn submit_write_request(
     let id = request.id();
     *pending = Some(request);
     Ok(id)
+}
+
+fn transfer_dma<'a>(mode: BlockTransferMode, dma: &'a DeviceDma) -> Option<&'a DeviceDma> {
+    match mode {
+        BlockTransferMode::Dma => Some(dma),
+        BlockTransferMode::Fifo => None,
+        _ => None,
+    }
 }
 
 fn can_fallback_to_fifo(err: Error) -> bool {
@@ -734,27 +705,23 @@ fn map_dev_err_to_blk_err(err: Error) -> rd_block::BlkError {
         Error::Misaligned | Error::InvalidArgument => {
             rd_block::BlkError::Other("SD/MMC request is not block aligned".into())
         }
-        _ => rd_block::BlkError::Other("DWMMC I/O error".into()),
+        _ => rd_block::BlkError::Other("SDHCI I/O error".into()),
     }
+}
+
+static CLK_DEV: Once<ClkDev> = Once::new();
+
+struct ClkDev {
+    inner: Device<rdif_clk::Clk>,
+    id: ClockId,
 }
 
 #[cfg(test)]
 mod tests {
-    use sdmmc_protocol::error::ErrorContext;
-
     use super::*;
 
     #[test]
-    fn command_timeout_during_card_init_is_absent_card() {
-        let err = Error::Timeout(ErrorContext::for_cmd(Phase::ResponseWait, 1));
-
-        assert!(is_absent_card_init_error(err));
-    }
-
-    #[test]
-    fn data_timeout_after_card_init_is_not_absent_card() {
-        let err = Error::Timeout(ErrorContext::for_cmd(Phase::DataRead, 17));
-
-        assert!(!is_absent_card_init_error(err));
+    fn rk3568_block_io_uses_fifo_transfer_mode() {
+        assert_eq!(rk3568_block_transfer_mode(), BlockTransferMode::Fifo);
     }
 }

--- a/platform/axplat-dyn/src/drivers/blk/rockchip/sdhci_rk3588.rs
+++ b/platform/axplat-dyn/src/drivers/blk/rockchip/sdhci_rk3588.rs
@@ -1,0 +1,557 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloc::{format, string::ToString, sync::Arc, vec::Vec};
+use core::{num::NonZeroUsize, ptr::NonNull, time::Duration};
+
+use ax_kspin::SpinNoIrq;
+use dma_api::DeviceDma;
+use rdif_clk::ClockId;
+use rdrive::{
+    Device, DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
+};
+use sdhci_host::{BlockRequest, BlockRequestSlot, HostClock, RequestId, Sdhci};
+use sdmmc_protocol::{
+    BlockPoll, BlockTransferMode, Error, OperationPoll,
+    error::{ErrorContext, Phase},
+    sdio::{CardInfo, CardInitPreference, SdioHost, SdioInitScratch, SdioSdmmc},
+};
+use spin::Once;
+
+use crate::drivers::{
+    DmaImpl,
+    blk::{PlatformDeviceBlock, decode_fdt_irq},
+    iomap,
+};
+
+const BLOCK_SIZE: usize = 512;
+const SDHCI_POWER_330: u8 = 0x0e;
+static SDHCI_CLOCK: RockchipSdhciClock = RockchipSdhciClock;
+
+type RockchipSdhci = SdioSdmmc<Sdhci>;
+
+struct RockchipSdhciClock;
+
+impl HostClock for RockchipSdhciClock {
+    fn set_clock(&self, target_hz: u32) -> Result<(), Error> {
+        set_sdhci_clock(target_hz)
+    }
+}
+
+module_driver!(
+    name: "Rockchip sdhci",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["rockchip,rk3588-dwcmshc"],
+            on_probe: probe
+        }
+    ],
+);
+
+fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let base_reg = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or(OnProbeError::other(alloc::format!(
+            "[{}] has no reg",
+            info.node.name()
+        )))?;
+
+    let mmio_size = base_reg.size.unwrap_or(0x1000);
+    info!(
+        "rockchip-sdhci probe: node={}, addr={:#x}, size={:#x}",
+        info.node.name(),
+        base_reg.address as usize,
+        mmio_size
+    );
+    let mmio_base = iomap((base_reg.address as usize).into(), mmio_size as usize)?;
+
+    init_core_clock(&info)?;
+
+    let mut host = unsafe { Sdhci::new(mmio_base) };
+    if CLK_DEV.is_completed() {
+        info!("rockchip-sdhci: using external CRU clock");
+        host.set_external_clock(&SDHCI_CLOCK);
+    } else {
+        warn!("rockchip-sdhci: no core clock found; using SDHCI internal clock divider");
+    }
+    info!("rockchip-sdhci: reset controller");
+    host.reset_all()
+        .map_err(|e| init_error(base_reg.address, mmio_size, e))?;
+    host.set_power(SDHCI_POWER_330);
+    host.enable_interrupts();
+    host.set_dma(DeviceDma::new(u32::MAX as u64, &DmaImpl));
+
+    info!("rockchip-sdhci: initialize card");
+    let mut card = SdioSdmmc::new(host);
+    let card_info = poll_card_init_mmc(&mut card)
+        .map_err(|e| card_init_error(base_reg.address, mmio_size, e))?;
+    info!(
+        "SDHCI card: kind={:?} high_capacity={} rca={} ocr={:#010x} capacity_blocks={:?} cid={} \
+         ext_csd={}",
+        card_info.kind,
+        card_info.high_capacity,
+        card_info.rca,
+        card_info.ocr,
+        card_info.capacity_blocks,
+        card_info.cid.is_some(),
+        card_info.ext_csd.is_some()
+    );
+
+    let irq_num = decode_fdt_irq(&info.interrupts());
+    let raw = Arc::new(SpinNoIrq::new(card));
+    let dev = BlockDevice {
+        raw: Some(raw.clone()),
+        capacity_blocks: card_info.capacity_blocks.unwrap_or(0),
+        irq_enabled: false,
+        queue_created: false,
+    };
+    plat_dev.register_block_with_irq(dev, irq_num);
+    info!("rockchip-sdhci block device registered irq={:?}", irq_num);
+    Ok(())
+}
+
+fn poll_card_init_mmc(card: &mut RockchipSdhci) -> Result<CardInfo, Error> {
+    let mut scratch = SdioInitScratch::new();
+    let mut request =
+        card.submit_init_with_preference(CardInitPreference::MmcFirst, &mut scratch)?;
+    loop {
+        match card.poll_init_request(&mut request)? {
+            OperationPoll::Pending => {
+                if request.take_needs_pace() {
+                    axklib::time::busy_wait(Duration::from_millis(10));
+                } else {
+                    core::hint::spin_loop();
+                }
+            }
+            OperationPoll::Complete(info) => return Ok(info),
+            _ => return Err(Error::UnsupportedCommand),
+        }
+    }
+}
+
+fn init_error(address: u64, size: u64, err: Error) -> OnProbeError {
+    OnProbeError::other(format!(
+        "failed to initialize SDHCI device at [PA:{:?}, SZ:0x{:x}): {err:?}",
+        address, size
+    ))
+}
+
+fn card_init_error(address: u64, size: u64, err: Error) -> OnProbeError {
+    if is_absent_card_init_error(err) {
+        warn!(
+            "rockchip-sdhci: no responsive card at [PA:{:?}, SZ:0x{:x}); skipping controller: \
+             {err:?}",
+            address, size
+        );
+        return OnProbeError::NotMatch;
+    }
+
+    init_error(address, size, err)
+}
+
+fn is_absent_card_init_error(err: Error) -> bool {
+    match err {
+        Error::NoCard => true,
+        Error::Timeout(ctx) | Error::Crc(ctx) | Error::BadResponse(ctx) => {
+            ctx.cmd.is_some()
+                && matches!(
+                    ctx.phase,
+                    Phase::CommandSend | Phase::ResponseWait | Phase::Init
+                )
+        }
+        _ => false,
+    }
+}
+
+fn init_core_clock(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
+    for clk in info.node.clocks() {
+        info!(
+            "rockchip-sdhci clock: phandle <{}>, name: {:?}, cells: {}",
+            clk.phandle, clk.name, clk.cells
+        );
+        if clk.name == Some("core".to_string()) {
+            let device_id = info.phandle_to_device_id(clk.phandle).ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] core clock phandle {} has no device id",
+                    info.node.name(),
+                    clk.phandle
+                ))
+            })?;
+            let clk_dev = rdrive::get::<rdif_clk::Clk>(device_id).map_err(|_| {
+                OnProbeError::other(format!(
+                    "[{}] core clock device {:?} is not registered",
+                    info.node.name(),
+                    device_id
+                ))
+            })?;
+            CLK_DEV.call_once(|| ClkDev {
+                inner: clk_dev,
+                id: (clk.select().unwrap_or(0) as usize).into(),
+            });
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+fn set_sdhci_clock(target_hz: u32) -> Result<(), Error> {
+    let clk = CLK_DEV.wait();
+    let mut clk_dev = clk.inner.lock().map_err(|_| clock_error())?;
+    clk_dev
+        .set_rate(clk.id, target_hz as u64)
+        .map_err(|_| clock_error())?;
+    let rate = clk_dev.get_rate(clk.id).map_err(|_| clock_error())?;
+    info!("rockchip-sdhci: core clock set to {} Hz", rate);
+    Ok(())
+}
+
+fn clock_error() -> Error {
+    Error::BusError(ErrorContext::new(Phase::Init))
+}
+
+struct BlockDevice {
+    raw: Option<Arc<SpinNoIrq<RockchipSdhci>>>,
+    capacity_blocks: u64,
+    irq_enabled: bool,
+    queue_created: bool,
+}
+
+struct BlockQueue {
+    raw: Arc<SpinNoIrq<RockchipSdhci>>,
+    capacity_blocks: u64,
+    id: usize,
+    dma: DeviceDma,
+    slot: BlockRequestSlot,
+    pending: Option<BlockRequest>,
+    completed: Vec<rd_block::RequestId>,
+}
+
+impl DriverGeneric for BlockDevice {
+    fn name(&self) -> &str {
+        "rockchip-sdhci"
+    }
+}
+
+impl rd_block::Interface for BlockDevice {
+    fn create_queue(&mut self) -> Option<alloc::boxed::Box<dyn rd_block::IQueue>> {
+        if self.queue_created {
+            return None;
+        }
+        self.raw.as_ref().map(|dev| {
+            self.queue_created = true;
+            alloc::boxed::Box::new(BlockQueue {
+                raw: dev.clone(),
+                capacity_blocks: self.capacity_blocks,
+                id: 0,
+                dma: DeviceDma::new(u32::MAX as u64, &DmaImpl),
+                slot: BlockRequestSlot::default(),
+                pending: None,
+                completed: Vec::new(),
+            }) as _
+        })
+    }
+
+    fn enable_irq(&mut self) {
+        if let Some(raw) = &self.raw {
+            let mut raw = raw.lock();
+            if let Err(err) = SdioHost::enable_completion_irq(raw.host_mut()) {
+                warn!("rockchip-sdhci: enable completion IRQ failed: {:?}", err);
+                return;
+            }
+            self.irq_enabled = true;
+        }
+    }
+
+    fn disable_irq(&mut self) {
+        if let Some(raw) = &self.raw {
+            let mut raw = raw.lock();
+            if let Err(err) = SdioHost::disable_completion_irq(raw.host_mut()) {
+                warn!("rockchip-sdhci: disable completion IRQ failed: {:?}", err);
+            }
+        }
+        self.irq_enabled = false;
+    }
+
+    fn is_irq_enabled(&self) -> bool {
+        self.irq_enabled
+    }
+
+    fn handle_irq(&mut self) -> rd_block::Event {
+        let Some(raw) = &self.raw else {
+            return rd_block::Event::none();
+        };
+        let irq_event = raw.lock().host_mut().handle_irq();
+        block_event_from_sdhci_irq(irq_event)
+    }
+}
+
+fn block_event_from_sdhci_irq(irq_event: sdhci_host::Event) -> rd_block::Event {
+    match irq_event {
+        sdhci_host::Event::None => rd_block::Event::none(),
+        sdhci_host::Event::CommandComplete
+        | sdhci_host::Event::TransferComplete
+        | sdhci_host::Event::Error { .. }
+        | sdhci_host::Event::Other { .. } => {
+            let mut event = rd_block::Event::none();
+            event.queue.insert(0);
+            event
+        }
+    }
+}
+
+impl rd_block::IQueue for BlockQueue {
+    fn num_blocks(&self) -> usize {
+        self.capacity_blocks as usize
+    }
+
+    fn block_size(&self) -> usize {
+        BLOCK_SIZE
+    }
+
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn buff_config(&self) -> rd_block::BuffConfig {
+        rd_block::BuffConfig {
+            dma_mask: self.dma.dma_mask(),
+            align: BLOCK_SIZE,
+            size: BLOCK_SIZE,
+        }
+    }
+
+    fn submit_request(
+        &mut self,
+        request: rd_block::Request<'_>,
+    ) -> Result<rd_block::RequestId, rd_block::BlkError> {
+        self.reap_pending_request()?;
+        let mut raw = self.raw.lock();
+        let start_block = block_addr_for_card(request.block_id, raw.is_high_capacity())?;
+        // Block I/O uses the host crate's submit/poll request API so
+        // completions can be driven by IRQ wakeups. Protocol data commands
+        // use the same submit/poll contract through SdioHost.
+        match request.kind {
+            rd_block::RequestKind::Read(buffer) => {
+                if !buffer.len().is_multiple_of(BLOCK_SIZE) {
+                    return Err(rd_block::BlkError::Other(
+                        "read buffer is not block aligned".into(),
+                    ));
+                }
+                let ptr = NonNull::new(buffer.virt).ok_or_else(|| {
+                    rd_block::BlkError::Other("read buffer pointer is null".into())
+                })?;
+                let size = NonZeroUsize::new(buffer.len())
+                    .ok_or_else(|| rd_block::BlkError::Other("read buffer is empty".into()))?;
+                let id = submit_read_request(
+                    raw.host_mut(),
+                    start_block,
+                    ptr,
+                    size,
+                    &self.dma,
+                    &mut self.slot,
+                    &mut self.pending,
+                )?;
+                Ok(rd_block::RequestId::new(usize::from(id)))
+            }
+            rd_block::RequestKind::Write(items) => {
+                if !items.len().is_multiple_of(BLOCK_SIZE) {
+                    return Err(rd_block::BlkError::Other(
+                        "write buffer is not block aligned".into(),
+                    ));
+                }
+                let ptr = NonNull::new(items.as_ptr() as *mut u8).ok_or_else(|| {
+                    rd_block::BlkError::Other("write buffer pointer is null".into())
+                })?;
+                let size = NonZeroUsize::new(items.len())
+                    .ok_or_else(|| rd_block::BlkError::Other("write buffer is empty".into()))?;
+                let id = submit_write_request(
+                    raw.host_mut(),
+                    start_block,
+                    ptr,
+                    size,
+                    &self.dma,
+                    &mut self.slot,
+                    &mut self.pending,
+                )?;
+                Ok(rd_block::RequestId::new(usize::from(id)))
+            }
+        }
+    }
+
+    fn poll_request(&mut self, request: rd_block::RequestId) -> Result<(), rd_block::BlkError> {
+        if let Some(index) = self.completed.iter().position(|id| *id == request) {
+            self.completed.swap_remove(index);
+            return Ok(());
+        }
+        self.poll_active_request(request)
+    }
+}
+
+impl BlockQueue {
+    fn poll_active_request(
+        &mut self,
+        request: rd_block::RequestId,
+    ) -> Result<(), rd_block::BlkError> {
+        match self.raw.lock().host_mut().poll_block_request(
+            &mut self.pending,
+            RequestId::new(usize::from(request)),
+            &mut self.slot,
+        ) {
+            Ok(BlockPoll::Complete) => Ok(()),
+            Ok(BlockPoll::Pending) => Err(rd_block::BlkError::Retry),
+            Ok(_) => Err(rd_block::BlkError::Other(
+                "SDHCI returned an unknown poll state".into(),
+            )),
+            Err(err) => Err(map_dev_err_to_blk_err(err)),
+        }
+    }
+
+    fn pending_id(&self) -> Option<RequestId> {
+        self.pending.as_ref().map(BlockRequest::id)
+    }
+
+    fn reap_pending_request(&mut self) -> Result<(), rd_block::BlkError> {
+        let Some(active) = self.pending_id() else {
+            return Ok(());
+        };
+        let id = rd_block::RequestId::new(usize::from(active));
+        match self.poll_active_request(id) {
+            Ok(()) => {
+                self.completed.push(id);
+                Ok(())
+            }
+            Err(rd_block::BlkError::Retry) => Err(rd_block::BlkError::Retry),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+fn submit_read_request(
+    host: &mut Sdhci,
+    start_block: u32,
+    buffer: NonNull<u8>,
+    size: NonZeroUsize,
+    dma: &DeviceDma,
+    slot: &mut BlockRequestSlot,
+    pending: &mut Option<BlockRequest>,
+) -> Result<RequestId, rd_block::BlkError> {
+    if pending.is_some() {
+        return Err(rd_block::BlkError::Retry);
+    }
+    let request = match host.submit_read_blocks(
+        start_block,
+        buffer,
+        size,
+        Some(dma),
+        BlockTransferMode::Dma,
+        slot,
+    ) {
+        Ok(request) => request,
+        Err(err) if can_fallback_to_fifo(err) => host
+            .submit_read_blocks(
+                start_block,
+                buffer,
+                size,
+                None,
+                BlockTransferMode::Fifo,
+                slot,
+            )
+            .map_err(map_dev_err_to_blk_err)?,
+        Err(err) => return Err(map_dev_err_to_blk_err(err)),
+    };
+    let id = request.id();
+    *pending = Some(request);
+    Ok(id)
+}
+
+fn submit_write_request(
+    host: &mut Sdhci,
+    start_block: u32,
+    buffer: NonNull<u8>,
+    size: NonZeroUsize,
+    dma: &DeviceDma,
+    slot: &mut BlockRequestSlot,
+    pending: &mut Option<BlockRequest>,
+) -> Result<RequestId, rd_block::BlkError> {
+    if pending.is_some() {
+        return Err(rd_block::BlkError::Retry);
+    }
+    let request = match host.submit_write_blocks(
+        start_block,
+        buffer,
+        size,
+        Some(dma),
+        BlockTransferMode::Dma,
+        slot,
+    ) {
+        Ok(request) => request,
+        Err(err) if can_fallback_to_fifo(err) => host
+            .submit_write_blocks(
+                start_block,
+                buffer,
+                size,
+                None,
+                BlockTransferMode::Fifo,
+                slot,
+            )
+            .map_err(map_dev_err_to_blk_err)?,
+        Err(err) => return Err(map_dev_err_to_blk_err(err)),
+    };
+    let id = request.id();
+    *pending = Some(request);
+    Ok(id)
+}
+
+fn can_fallback_to_fifo(err: Error) -> bool {
+    matches!(
+        err,
+        Error::UnsupportedCommand | Error::InvalidArgument | Error::Misaligned
+    )
+}
+
+fn block_addr_for_card(block_id: usize, high_capacity: bool) -> Result<u32, rd_block::BlkError> {
+    let block_id =
+        u32::try_from(block_id).map_err(|_| rd_block::BlkError::InvalidBlockIndex(block_id))?;
+    if high_capacity {
+        Ok(block_id)
+    } else {
+        block_id
+            .checked_mul(BLOCK_SIZE as u32)
+            .ok_or(rd_block::BlkError::InvalidBlockIndex(block_id as usize))
+    }
+}
+
+fn map_dev_err_to_blk_err(err: Error) -> rd_block::BlkError {
+    match err {
+        Error::NoCard | Error::UnsupportedCommand | Error::CardLocked => {
+            rd_block::BlkError::NotSupported
+        }
+        Error::Misaligned | Error::InvalidArgument => {
+            rd_block::BlkError::Other("SD/MMC request is not block aligned".into())
+        }
+        _ => rd_block::BlkError::Other("SDHCI I/O error".into()),
+    }
+}
+
+static CLK_DEV: Once<ClkDev> = Once::new();
+
+struct ClkDev {
+    inner: Device<rdif_clk::Clk>,
+    id: ClockId,
+}

--- a/platform/axplat-dyn/src/drivers/soc/rockchip/clk/mod.rs
+++ b/platform/axplat-dyn/src/drivers/soc/rockchip/clk/mod.rs
@@ -1,0 +1,113 @@
+use rdrive::{DriverGeneric, KError, probe::OnProbeError};
+use rockchip_soc::{ClkId, Cru, CruOp};
+
+mod rk3568;
+mod rk3588;
+
+pub struct ClkDrv {
+    name: &'static str,
+    inner: Cru,
+}
+
+impl ClkDrv {
+    pub const fn new(name: &'static str, cru: Cru) -> Self {
+        Self { name, inner: cru }
+    }
+
+    fn enable_clock(&mut self, id: u32) -> Result<(), OnProbeError> {
+        let id = ClkId::from(id);
+        if self.inner.clk_is_enabled(id).unwrap_or(false) {
+            return Ok(());
+        }
+
+        self.inner.clk_enable(id).map_err(|err| {
+            OnProbeError::other(alloc::format!("failed to enable clock {id}: {err}"))
+        })
+    }
+
+    fn set_clock_rate(&mut self, id: u32, rate: u64) -> Result<(), OnProbeError> {
+        self.inner
+            .clk_set_rate(ClkId::from(id), rate)
+            .map_err(|err| {
+                OnProbeError::other(alloc::format!("failed to set clock {id}: {err}"))
+            })?;
+        Ok(())
+    }
+
+    fn reset_assert(&mut self, id: u64) {
+        self.inner.reset_assert(id.into());
+    }
+
+    fn reset_deassert(&mut self, id: u64) {
+        self.inner.reset_deassert(id.into());
+    }
+}
+
+unsafe impl Send for ClkDrv {}
+
+impl DriverGeneric for ClkDrv {
+    fn name(&self) -> &str {
+        self.name
+    }
+}
+
+impl rdif_clk::Interface for ClkDrv {
+    fn perper_enable(&mut self) {}
+
+    fn get_rate(&self, id: rdif_clk::ClockId) -> Result<u64, KError> {
+        self.inner
+            .clk_get_rate(clock_id(id))
+            .map_err(|_| KError::InvalidArg { name: "clock_id" })
+    }
+
+    fn set_rate(&mut self, id: rdif_clk::ClockId, rate: u64) -> Result<(), KError> {
+        self.inner
+            .clk_set_rate(clock_id(id), rate)
+            .map_err(|_| KError::InvalidArg { name: "clock_id" })?;
+        Ok(())
+    }
+}
+
+fn clock_id(id: rdif_clk::ClockId) -> ClkId {
+    let id: usize = id.into();
+    ClkId::from(id)
+}
+
+fn with_clk_drv<T>(
+    f: impl FnOnce(&mut ClkDrv) -> Result<T, OnProbeError>,
+) -> Result<T, OnProbeError> {
+    let clk = rdrive::get_one::<rdif_clk::Clk>()
+        .ok_or_else(|| OnProbeError::other("Rockchip CRU clock device not registered"))?;
+    let mut clk = clk.lock().map_err(|err| {
+        OnProbeError::other(alloc::format!(
+            "failed to lock Rockchip CRU clock device: {err}"
+        ))
+    })?;
+    let drv = clk
+        .typed_mut::<ClkDrv>()
+        .ok_or_else(|| OnProbeError::other("Rockchip CRU clock device type mismatch"))?;
+
+    f(drv)
+}
+
+pub(crate) fn rk3588_enable_clock(id: u32) -> Result<(), OnProbeError> {
+    with_clk_drv(|drv| drv.enable_clock(id))
+}
+
+pub(crate) fn rk3588_set_clock_rate(id: u32, rate: u64) -> Result<(), OnProbeError> {
+    with_clk_drv(|drv| drv.set_clock_rate(id, rate))
+}
+
+pub(crate) fn rk3588_reset_assert(id: u64) -> Result<(), OnProbeError> {
+    with_clk_drv(|drv| {
+        drv.reset_assert(id);
+        Ok(())
+    })
+}
+
+pub(crate) fn rk3588_reset_deassert(id: u64) -> Result<(), OnProbeError> {
+    with_clk_drv(|drv| {
+        drv.reset_deassert(id);
+        Ok(())
+    })
+}

--- a/platform/axplat-dyn/src/drivers/soc/rockchip/clk/rk3568.rs
+++ b/platform/axplat-dyn/src/drivers/soc/rockchip/clk/rk3568.rs
@@ -4,16 +4,16 @@ use rockchip_soc::{Cru, SocType};
 use super::ClkDrv;
 use crate::drivers::iomap;
 
-const RK3588_CRU_GRF_BASE: usize = 0xfd5b_0000;
-const RK3588_CRU_GRF_SIZE: usize = 0x1000;
+const RK3568_CRU_GRF_BASE: usize = 0xfdc6_0000;
+const RK3568_CRU_GRF_SIZE: usize = 0x10000;
 
 module_driver!(
-    name: "Rockchip RK3588 CRU",
+    name: "Rockchip RK3568 CRU",
     level: ProbeLevel::PostKernel,
     priority: ProbePriority::CLK,
     probe_kinds: &[
         ProbeKind::Fdt {
-            compatibles: &["rockchip,rk3588-cru"],
+            compatibles: &["rockchip,rk3568-cru"],
             on_probe: probe
         }
     ],
@@ -41,7 +41,7 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
         )))?;
 
     info!(
-        "RK3588 CRU reg: addr={:#x}, size={:#x}, rockchip,grf=<{:#x}>",
+        "RK3568 CRU reg: addr={:#x}, size={:#x}, rockchip,grf=<{:#x}>",
         base_reg.address as usize,
         base_reg.size.unwrap_or(0),
         grf_phandle
@@ -49,12 +49,15 @@ fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError
 
     let mmio_base = iomap(
         (base_reg.address as usize).into(),
-        base_reg.size.unwrap_or(0x5c000) as usize,
+        base_reg.size.unwrap_or(0x1000) as usize,
     )?;
-    let grf_base = iomap(RK3588_CRU_GRF_BASE.into(), RK3588_CRU_GRF_SIZE)?;
+    let grf_base = iomap(RK3568_CRU_GRF_BASE.into(), RK3568_CRU_GRF_SIZE)?;
 
-    let cru = Cru::new(SocType::Rk3588, mmio_base, grf_base);
-    plat_dev.register(rdif_clk::Clk::new(ClkDrv::new("rk3588-cru", cru)));
-    info!("RK3588 CRU clock registered successfully");
+    let mut cru = Cru::new(SocType::Rk3568, mmio_base, grf_base);
+    if let Cru::Rk3568(ref mut rk3568) = cru {
+        rk3568.init_emmc();
+    }
+    plat_dev.register(rdif_clk::Clk::new(ClkDrv::new("rk3568-cru", cru)));
+    info!("RK3568 CRU clock registered successfully");
     Ok(())
 }

--- a/platform/axplat-dyn/src/drivers/soc/rockchip/mod.rs
+++ b/platform/axplat-dyn/src/drivers/soc/rockchip/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #[cfg(feature = "rockchip-soc")]
-#[path = "clk/rk3588.rs"]
 mod clk;
 
 #[cfg(feature = "rockchip-pm")]


### PR DESCRIPTION
## Background

The current SD/MMC support lacks a Phytium MCI/FSDIF host driver and the related platform integration for PhytiumPi. The Rockchip SDHCI/DWMMC platform glue is also reorganized to make SoC-specific support easier to extend.

## Changes

- Add the `phytium-mci-host` driver crate
  - Implements Phytium MCI/FSDIF registers, command/response handling, timing setup, bus width setup, FIFO transfers, and IDMAC block transfers
  - Fixes the `CTRL` register bit layout so `INT_ENABLE`, `DMA_ENABLE`, and `USE_INTERNAL_DMAC` are programmed correctly
  - Adds IDMAC descriptor setup, DMA buffer mapping, read/write polling, and error handling

- Add Phytium MCI integration in `axplat-dyn`
  - Adds FDT probe, MMIO mapping, IRQ decoding, SD initialization, and rd-block queue registration
  - Uses DMA for block I/O while keeping FIFO fallback support
  - Removes temporary debug logs from the normal path

- Extend `sdmmc-protocol`
  - Improves SD/MMC initialization, response parsing, error context, and block request abstractions
  - Adds support needed for SD HighSpeed selection and data command polling

- Update existing DWMMC/SDHCI hosts
  - Adapts them to the updated `DataCommandPoll` and block request interfaces
  - Handles non-exhaustive data command poll states in platform glue

- Reorganize Rockchip block platform drivers
  - Moves Rockchip DWMMC/SDHCI glue under `platform/axplat-dyn/src/drivers/blk/rockchip/`
  - Adds RK3568 SDHCI support and RK3568 clock/SoC variant scaffolding
  - Keeps RK3588 SDHCI/DWMMC support in the reorganized layout