### PR TITLE
fix(ci): avoid full clippy on first feature push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,22 @@ jobs:
                 git_cmd fetch --no-tags --depth=1 origin "${ref}" || true
                 git_cmd cat-file -e "${ref}^{commit}" 2>/dev/null
               }
+              dev_merge_base() {
+                git_cmd fetch --no-tags origin +refs/heads/dev:refs/remotes/origin/dev || true
+                git_cmd cat-file -e "refs/remotes/origin/dev^{commit}" 2>/dev/null || return 1
+                git_cmd merge-base HEAD refs/remotes/origin/dev
+              }
+              clippy_since_dev_merge_base() {
+                case "${GITHUB_REF_NAME}" in
+                  main|dev)
+                    return 1
+                    ;;
+                esac
+
+                since="$(dev_merge_base)" || return 1
+                echo "::notice::first feature-branch push detected; running incremental clippy since origin/dev merge-base ${since}"
+                cargo xtask clippy --since "${since}"
+              }
               ensure_host_clippy_deps
 
               if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
@@ -221,12 +237,18 @@ jobs:
               elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
                 before="${{ github.event.before }}"
                 if [ "${before}" = "0000000000000000000000000000000000000000" ]; then
-                  cargo xtask clippy
+                  if ! clippy_since_dev_merge_base; then
+                    echo "::notice::no dev merge-base available for first push; running full clippy"
+                    cargo xtask clippy
+                  fi
                 elif ensure_since_ref "${before}"; then
                   cargo xtask clippy --since "${before}"
                 else
-                  echo "::notice::before commit ${before} is unavailable; running full clippy"
-                  cargo xtask clippy
+                  echo "::notice::before commit ${before} is unavailable"
+                  if ! clippy_since_dev_merge_base; then
+                    echo "::notice::no dev merge-base available; running full clippy"
+                    cargo xtask clippy
+                  fi
                 fi
               else
                 cargo xtask clippy


### PR DESCRIPTION
## 问题
- feature 分支首次 push 时，`github.event.before` 为全 0，现有 CI 会直接执行 `cargo xtask clippy`，导致全 workspace clippy。
- 对于已经或即将进入 PR 的 feature 分支，这会和 PR 事件里的增量 clippy 重复，浪费 runner 时间，并且旧 push run 的状态还可能污染 PR 的 status rollup。

## 修改
- 保留 `main` / `dev` push 的全量 clippy 保障。
- feature 分支首次 push 遇到全 0 `before` 时，拉取 `origin/dev`，计算 `HEAD` 与 `origin/dev` 的 merge-base，并执行 `cargo xtask clippy --since <merge-base>`。
- 当普通 push 的 `before` commit 不可用时，也优先尝试同样的 `origin/dev` merge-base 增量路径。
- 只有在无法取得 `origin/dev` merge-base 时，才回退到全量 clippy。

## 验证
- `git diff --check`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml') ... PY`
- `bash -n` 验证 clippy command 片段语法
- 本地 stub `cargo` 模拟 feature 分支首次 push：确认执行 `cargo xtask clippy --since <origin/dev merge-base>`
- 本地 stub `cargo` 模拟 `dev` 首次 push：确认仍回退执行全量 `cargo xtask clippy`
