### PR TITLE
fix(rsext4): preserve directory inode generation

### DIFF
--- a/components/rsext4/src/dir/bootstrap.rs
+++ b/components/rsext4/src/dir/bootstrap.rs
@@ -80,6 +80,7 @@ pub fn create_root_directory_entry<B: BlockDevice>(
     // Persist a clean directory inode that points at the newly initialized block.
     let dir_mode = Ext4Inode::S_IFDIR | 0o755;
     let mut inode = Ext4Inode::empty_for_reuse(fs.default_inode_extra_isize());
+    inode.i_generation = root_gen;
     inode.i_links_count = 2;
     inode.i_size_lo = BLOCK_SIZE as u32;
     inode.i_size_high = 0;
@@ -191,6 +192,7 @@ pub fn create_lost_found_directory<B: BlockDevice>(
     let (lf_group, _idx) = fs.inode_allocator.global_to_group(lost_ino)?;
     let dir_mode = Ext4Inode::S_IFDIR | 0o755;
     let mut lost_inode = Ext4Inode::empty_for_reuse(fs.default_inode_extra_isize());
+    lost_inode.i_generation = lost_gen;
     lost_inode.i_links_count = 2;
     lost_inode.i_size_lo = BLOCK_SIZE as u32;
     lost_inode.i_size_high = 0;

--- a/components/rsext4/src/dir/mkdir.rs
+++ b/components/rsext4/src/dir/mkdir.rs
@@ -150,6 +150,7 @@ fn mkdir_internal<B: BlockDevice>(
     let (group_idx, _idx) = fs.inode_allocator.global_to_group(new_dir_ino)?;
     let dir_mode = Ext4Inode::S_IFDIR | 0o755;
     let mut new_inode = Ext4Inode::empty_for_reuse(fs.default_inode_extra_isize());
+    new_inode.i_generation = new_dir_gen;
     new_inode.i_links_count = 2;
     new_inode.i_size_lo = BLOCK_SIZE as u32;
     new_inode.i_size_high = 0;

--- a/components/rsext4/tests/directory_operations.rs
+++ b/components/rsext4/tests/directory_operations.rs
@@ -7,8 +7,11 @@ use std::cell::Cell;
 
 use rsext4::{
     bmalloc::AbsoluteBN,
+    checksum::verify_ext4_dirblock_checksum,
+    dir::get_inode_with_num,
     disknode::Ext4Inode,
     error::{Ext4Error, Ext4Result},
+    loopfile::resolve_inode_block,
     *,
 };
 
@@ -114,6 +117,43 @@ mod directory_functional_tests {
         test_mkdir(&mut jbd2_dev, &mut fs, "/siblings/sibling1").expect("mkdir failed");
         test_mkdir(&mut jbd2_dev, &mut fs, "/siblings/sibling2").expect("mkdir failed");
         test_mkdir(&mut jbd2_dev, &mut fs, "/siblings/sibling3").expect("mkdir failed");
+
+        umount(fs, &mut jbd2_dev).expect("umount failed");
+    }
+
+    #[test]
+    fn created_directory_block_checksum_matches_persisted_inode_generation() {
+        let device = MockBlockDevice::new(100 * 1024 * 1024);
+        let mut jbd2_dev = Jbd2Dev::initial_jbd2dev(0, device, true);
+
+        mkfs(&mut jbd2_dev).expect("mkfs failed");
+        let mut fs = mount(&mut jbd2_dev).expect("mount failed");
+
+        let (dir_ino, mut dir_inode) = get_inode_with_num(&mut fs, &mut jbd2_dev, "/checksum-dir")
+            .expect("lookup should succeed")
+            .unwrap_or_else(|| {
+                mkdir(&mut jbd2_dev, &mut fs, "/checksum-dir").expect("mkdir failed");
+                get_inode_with_num(&mut fs, &mut jbd2_dev, "/checksum-dir")
+                    .expect("lookup after mkdir should succeed")
+                    .expect("created directory should exist")
+            });
+        let dir_block = resolve_inode_block(&mut jbd2_dev, &mut dir_inode, 0)
+            .expect("resolve directory block failed")
+            .expect("directory should have a first block");
+        let cached = fs
+            .datablock_cache
+            .get_or_load(&mut jbd2_dev, dir_block)
+            .expect("load directory block failed");
+
+        assert!(
+            verify_ext4_dirblock_checksum(
+                &fs.superblock,
+                dir_ino.raw(),
+                dir_inode.i_generation,
+                &cached.data
+            ),
+            "new directory checksum must use the inode generation persisted on disk"
+        );
 
         umount(fs, &mut jbd2_dev).expect("umount failed");
     }


### PR DESCRIPTION
## 问题

StarryOS 的 apt 场景会触发 rsext4 日志 `dir block checksum mismatch`。清理旧 rootfs 后仍可复现，说明不是本地镜像污染。

根因是创建目录时，目录块 checksum 使用了分配 inode 后的 `i_generation`，但随后构造新的 inode 元数据写回时没有保留该 generation，导致落盘 inode generation 与目录块 checksum 计算时使用的 generation 不一致。

## 修改

- 在普通目录创建路径中保留新分配 inode 的 `i_generation`。
- 在 root 和 `lost+found` 引导目录创建路径中同样保留 generation。
- 新增回归测试，验证新目录块 checksum 使用的是最终持久化的 inode generation。

## 验证

- `cargo fmt --all`
- `cargo test -p rsext4 created_directory_block_checksum_matches_persisted_inode_generation --test directory_operations -- --nocapture`
- `cargo test -p rsext4 --test directory_operations`
- `cargo xtask clippy --package rsext4`

额外在原工作区用干净 rootfs 复测过：

- `cargo xtask starry test qemu --arch riscv64 -c apt`
- `cargo xtask starry test qemu --arch riscv64 -c util-linux`

两者均通过，日志中不再出现 `dir block checksum mismatch`。
