### PR TITLE
fix(starry): expose SMP CPU topology in sysfs

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/sysfs.rs
+++ b/os/StarryOS/kernel/src/pseudofs/sysfs.rs
@@ -329,7 +329,11 @@ struct DevicesDir {
 
 impl SimpleDirOps for DevicesDir {
     fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
-        Box::new(["platform", "system", "virtual"].into_iter().map(Cow::Borrowed))
+        Box::new(
+            ["platform", "system", "virtual"]
+                .into_iter()
+                .map(Cow::Borrowed),
+        )
     }
 
     fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
@@ -357,7 +361,9 @@ impl SimpleDirOps for SystemDir {
         match name {
             "cpu" => Ok(NodeOpsMux::Dir(SimpleDir::new_maker(
                 self.fs.clone(),
-                Arc::new(SystemCpuDir { fs: self.fs.clone() }),
+                Arc::new(SystemCpuDir {
+                    fs: self.fs.clone(),
+                }),
             ))),
             _ => Err(VfsError::NotFound),
         }
@@ -416,7 +422,11 @@ impl SimpleDirOps for SystemCpuEntryDir {
     fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
         match name {
             "online" => {
-                let online = if self.cpu < ax_hal::cpu_num() { "1\n" } else { "0\n" };
+                let online = if self.cpu < ax_hal::cpu_num() {
+                    "1\n"
+                } else {
+                    "0\n"
+                };
                 Ok(SimpleFile::new_regular(self.fs.clone(), move || Ok(online.to_owned())).into())
             }
             _ => Err(VfsError::NotFound),

--- a/os/StarryOS/kernel/src/pseudofs/sysfs.rs
+++ b/os/StarryOS/kernel/src/pseudofs/sysfs.rs
@@ -329,16 +329,107 @@ struct DevicesDir {
 
 impl SimpleDirOps for DevicesDir {
     fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
-        Box::new(["platform", "virtual"].into_iter().map(Cow::Borrowed))
+        Box::new(["platform", "system", "virtual"].into_iter().map(Cow::Borrowed))
     }
 
     fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
         let fs = self.fs.clone();
         Ok(NodeOpsMux::Dir(match name {
             "platform" => SimpleDir::new_maker(fs.clone(), Arc::new(PlatformBusDir { fs })),
+            "system" => SimpleDir::new_maker(fs.clone(), Arc::new(SystemDir { fs })),
             "virtual" => SimpleDir::new_maker(fs.clone(), Arc::new(VirtualDir { fs })),
             _ => return Err(VfsError::NotFound),
         }))
+    }
+}
+
+/// `/sys/devices/system/` — kernel topology subsystems.
+struct SystemDir {
+    fs: Arc<SimpleFs>,
+}
+
+impl SimpleDirOps for SystemDir {
+    fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
+        Box::new(["cpu"].into_iter().map(Cow::Borrowed))
+    }
+
+    fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
+        match name {
+            "cpu" => Ok(NodeOpsMux::Dir(SimpleDir::new_maker(
+                self.fs.clone(),
+                Arc::new(SystemCpuDir { fs: self.fs.clone() }),
+            ))),
+            _ => Err(VfsError::NotFound),
+        }
+    }
+}
+
+/// `/sys/devices/system/cpu/` — enough CPU topology for userspace to size pools.
+struct SystemCpuDir {
+    fs: Arc<SimpleFs>,
+}
+
+impl SimpleDirOps for SystemCpuDir {
+    fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
+        let mut names: Vec<Cow<'a, str>> = alloc::vec![
+            Cow::Borrowed("online"),
+            Cow::Borrowed("possible"),
+            Cow::Borrowed("present"),
+        ];
+        names.extend((0..ax_hal::cpu_num()).map(|cpu| Cow::Owned(format!("cpu{cpu}"))));
+        Box::new(names.into_iter())
+    }
+
+    fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
+        let fs = self.fs.clone();
+        Ok(match name {
+            "online" | "possible" | "present" => {
+                SimpleFile::new_regular(fs, || Ok(format!("{}\n", cpu_range_string()))).into()
+            }
+            _ => {
+                let cpu = name
+                    .strip_prefix("cpu")
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .ok_or(VfsError::NotFound)?;
+                if cpu >= ax_hal::cpu_num() {
+                    return Err(VfsError::NotFound);
+                }
+                NodeOpsMux::Dir(SimpleDir::new_maker(
+                    fs.clone(),
+                    Arc::new(SystemCpuEntryDir { fs, cpu }),
+                ))
+            }
+        })
+    }
+}
+
+struct SystemCpuEntryDir {
+    fs: Arc<SimpleFs>,
+    cpu: usize,
+}
+
+impl SimpleDirOps for SystemCpuEntryDir {
+    fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
+        Box::new(["online"].into_iter().map(Cow::Borrowed))
+    }
+
+    fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
+        match name {
+            "online" => {
+                let online = if self.cpu < ax_hal::cpu_num() { "1\n" } else { "0\n" };
+                Ok(SimpleFile::new_regular(self.fs.clone(), move || Ok(online.to_owned())).into())
+            }
+            _ => Err(VfsError::NotFound),
+        }
+    }
+}
+
+fn cpu_range_string() -> String {
+    let cpu_num = ax_hal::cpu_num();
+    if cpu_num <= 1 {
+        "0".to_owned()
+    } else {
+        format!("0-{}", cpu_num - 1)
     }
 }
 

--- a/test-suit/starryos/normal/qemu-smp4/affinity/bug-proc-status-affinity/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp4/affinity/bug-proc-status-affinity/c/src/main.c
@@ -47,9 +47,67 @@ static void read_affinity_lines(char *allowed, size_t allowed_size, char *allowe
     expect(found_allowed_list, "missing Cpus_allowed_list in /proc/self/status");
 }
 
+static void read_first_line(const char *path, char *buf, size_t size) {
+    FILE *fp = fopen(path, "r");
+    expect(fp != NULL, path);
+    expect(fgets(buf, size, fp) != NULL, path);
+    fclose(fp);
+    trim_newline(buf);
+}
+
+static int cpu_range_count(const char *range) {
+    int start = -1;
+    int end = -1;
+    if (sscanf(range, "%d-%d", &start, &end) == 2) {
+        return end >= start ? end - start + 1 : 0;
+    }
+    if (sscanf(range, "%d", &start) == 1) {
+        return 1;
+    }
+    return 0;
+}
+
+static int cpuinfo_processor_count(void) {
+    FILE *fp = fopen("/proc/cpuinfo", "r");
+    expect(fp != NULL, "failed to open /proc/cpuinfo");
+
+    char line[256];
+    int count = 0;
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        if (strncmp(line, "processor", 9) == 0) {
+            count++;
+        }
+    }
+
+    fclose(fp);
+    return count;
+}
+
 int main(void) {
     long cpu_num = sysconf(_SC_NPROCESSORS_ONLN);
-    expect(cpu_num >= 2, "expected at least 2 online CPUs");
+    expect(cpu_num >= 4, "expected at least 4 online CPUs");
+
+    cpu_set_t default_mask;
+    CPU_ZERO(&default_mask);
+    expect(sched_getaffinity(0, sizeof(default_mask), &default_mask) == 0,
+           "default sched_getaffinity failed");
+    expect(CPU_COUNT(&default_mask) >= 4, "default affinity exposes fewer than 4 CPUs");
+
+    char allowed[64];
+    char allowed_list[64];
+    read_affinity_lines(allowed, sizeof(allowed), allowed_list, sizeof(allowed_list));
+    expect(strcmp(allowed, "0000000f") == 0, "initial Cpus_allowed should expose CPUs 0-3");
+    expect(strcmp(allowed_list, "0-3") == 0, "initial Cpus_allowed_list should expose CPUs 0-3");
+
+    expect(cpuinfo_processor_count() >= 4, "/proc/cpuinfo exposes fewer than 4 CPUs");
+
+    char sysfs_range[64];
+    read_first_line("/sys/devices/system/cpu/online", sysfs_range, sizeof(sysfs_range));
+    expect(cpu_range_count(sysfs_range) >= 4, "sysfs online exposes fewer than 4 CPUs");
+    read_first_line("/sys/devices/system/cpu/possible", sysfs_range, sizeof(sysfs_range));
+    expect(cpu_range_count(sysfs_range) >= 4, "sysfs possible exposes fewer than 4 CPUs");
+    read_first_line("/sys/devices/system/cpu/present", sysfs_range, sizeof(sysfs_range));
+    expect(cpu_range_count(sysfs_range) >= 4, "sysfs present exposes fewer than 4 CPUs");
 
     cpu_set_t mask;
     CPU_ZERO(&mask);
@@ -63,8 +121,6 @@ int main(void) {
     expect(CPU_ISSET(1, &current_mask), "CPU1 not present in current affinity");
     expect(CPU_COUNT(&current_mask) == 1, "current affinity should contain exactly one CPU");
 
-    char allowed[64];
-    char allowed_list[64];
     read_affinity_lines(allowed, sizeof(allowed), allowed_list, sizeof(allowed_list));
 
     expect(strcmp(allowed, "00000002") == 0, "unexpected Cpus_allowed");


### PR DESCRIPTION
# fix(starry): expose SMP CPU topology in sysfs

## 问题

StarryOS SMP kernel 已能以 4/8 HART 启动，但用户态 CPU 拓扑暴露不完整。工具链和脚本会看到不一致的 CPU 数，例如 kernel banner 是 `smp = 8`，但 guest `nproc` 报告较小值。

这会误导 cargo/rayon 默认并行度，也会让验收时难以证明“内核看到的 CPU”和“用户态看到的 CPU”是一致的。

## 根因

`/proc/cpuinfo` 和 affinity/status 路径在最新 `upstream/dev` 已有基础修复，但 `/sys/devices/system/cpu/` 仍缺少 Linux 常见的 `online/possible/present` 拓扑文件。部分用户态会通过 sysfs 读取 CPU topology。

## 修复

- 在 sysfs 中新增 `/sys/devices/system/cpu/online`、`possible`、`present`。
- 暴露 `cpuN/online`，内容基于 `ax_hal::cpu_num()`。
- 扩展 qemu-smp4 affinity regression，检查默认 affinity、`/proc/self/status`、`/proc/cpuinfo` 和 sysfs CPU topology 至少覆盖 4 个 CPU。

## 使用原因

- sysfs 是用户态发现 CPU topology 的标准入口之一，和 procfs/affinity 互补。
- test 放在 qemu-smp4，因为该行为必须在多核配置下才能证明。

## Test plan

- `git diff --check`
- `cargo fmt --check --manifest-path os/StarryOS/starryos/Cargo.toml`
- CMake configure for `qemu-smp4/affinity/bug-proc-status-affinity`

待补：

- `cargo xtask starry test qemu --arch riscv64 --test-group normal --test-case qemu-smp4/affinity/bug-proc-status-affinity`

## 风险

当前实现把所有已启动 CPU 都作为 online/possible/present 暴露；暂不支持 CPU hotplug。对当前 QEMU SMP 平台这是正确的，未来热插拔需要另行扩展。
