### PR TITLE
feat(starry-kernel): add kprobe support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4988,6 +4988,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kprobe"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf6b7b70ff393b62d067f6f2e35bd64c9278ac77fd6fa2de883b2c0be8fa5ff"
+dependencies = [
+ "cfg-if",
+ "lock_api",
+ "log",
+ "yaxpeax-arch",
+ "yaxpeax-x86",
+]
+
+[[package]]
 name = "ktest-helper"
 version = "0.1.1"
 dependencies = [
@@ -7964,6 +7977,7 @@ dependencies = [
  "indoc",
  "inherit-methods-macro",
  "kernel-elf-parser",
+ "kprobe",
  "ktracepoint",
  "linux-raw-sys 0.12.1",
  "lock_api",
@@ -10192,6 +10206,26 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yaxpeax-arch"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36274fcc5403da2a7636ffda4d02eca12a1b2b8267b9d2e04447bd2ccfc72082"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "yaxpeax-x86"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9a30b7dd533c7b1a73eaf7c4ea162a7a632a2bb29b9fff47d8f2cc8513a883"
+dependencies = [
+ "cfg-if",
+ "num-traits",
+ "yaxpeax-arch",
+]
 
 [[package]]
 name = "yoke"

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -18,7 +18,6 @@ default = ["dynamic_debug"]
 dev-log = []
 ext4 = ["ax-fs/ext4"]
 input = ["dep:ax-input", "ax-feat/input"]
-kcov = ["ax-hal/starry-kcov"]
 memtrack = ["ax-feat/dwarf", "ax-alloc/tracking", "dep:gimli"]
 rknpu = ["dep:ax-driver", "ax-driver/rknpu"]
 plat-dyn = [

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -14,12 +14,11 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-default = ["dynamic_debug", "kprobe"]
+default = ["dynamic_debug"]
 dev-log = []
 ext4 = ["ax-fs/ext4"]
 input = ["dep:ax-input", "ax-feat/input"]
 kcov = ["ax-hal/starry-kcov"]
-kprobe = ["dep:kprobe"]
 memtrack = ["ax-feat/dwarf", "ax-alloc/tracking", "dep:gimli"]
 rknpu = ["dep:ax-driver", "ax-driver/rknpu"]
 plat-dyn = [
@@ -133,7 +132,7 @@ zerocopy = { version = "0.8", features = ["derive"] }
 ax-ipi = { workspace = true }
 static-keys = "0.8"
 ddebug = "0.5"
-kprobe = { version = "0.5", optional = true }
+kprobe = { version = "0.5" }
 dw_apb_uart = { workspace = true, features = ["sg2002"], optional = true }
 sg200x-bsp = { workspace = true, optional = true }
 # 0.9 to match sg200x-bsp's internal tock-registers; cannot use workspace (0.10)

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -29,6 +29,7 @@ plat-dyn = [
 ]
 vsock = ["ax-feat/vsock"]
 dynamic_debug = ["ax-feat/ipi"]
+kprobe = ["dep:kprobe"]
 sg2002 = [
     "dep:ax-dma",
     "dep:sg2002-tpu",
@@ -132,7 +133,7 @@ zerocopy = { version = "0.8", features = ["derive"] }
 ax-ipi = { workspace = true }
 static-keys = "0.8"
 ddebug = "0.5"
-kprobe = { version = "0.5" }
+kprobe = { version = "0.5", optional = true }
 dw_apb_uart = { workspace = true, features = ["sg2002"], optional = true }
 sg200x-bsp = { workspace = true, optional = true }
 # 0.9 to match sg200x-bsp's internal tock-registers; cannot use workspace (0.10)

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -14,10 +14,12 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-default = ["dynamic_debug"]
+default = ["dynamic_debug", "kprobe"]
 dev-log = []
 ext4 = ["ax-fs/ext4"]
 input = ["dep:ax-input", "ax-feat/input"]
+kcov = ["ax-hal/starry-kcov"]
+kprobe = ["dep:kprobe"]
 memtrack = ["ax-feat/dwarf", "ax-alloc/tracking", "dep:gimli"]
 rknpu = ["dep:ax-driver", "ax-driver/rknpu"]
 plat-dyn = [
@@ -131,6 +133,7 @@ zerocopy = { version = "0.8", features = ["derive"] }
 ax-ipi = { workspace = true }
 static-keys = "0.8"
 ddebug = "0.5"
+kprobe = { version = "0.5", optional = true }
 dw_apb_uart = { workspace = true, features = ["sg2002"], optional = true }
 sg200x-bsp = { workspace = true, optional = true }
 # 0.9 to match sg200x-bsp's internal tock-registers; cannot use workspace (0.10)

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -29,7 +29,6 @@ plat-dyn = [
 ]
 vsock = ["ax-feat/vsock"]
 dynamic_debug = ["ax-feat/ipi"]
-kprobe = ["dep:kprobe"]
 sg2002 = [
     "dep:ax-dma",
     "dep:sg2002-tpu",
@@ -133,7 +132,7 @@ zerocopy = { version = "0.8", features = ["derive"] }
 ax-ipi = { workspace = true }
 static-keys = "0.8"
 ddebug = "0.5"
-kprobe = { version = "0.5", optional = true }
+kprobe = "0.5"
 dw_apb_uart = { workspace = true, features = ["sg2002"], optional = true }
 sg200x-bsp = { workspace = true, optional = true }
 # 0.9 to match sg200x-bsp's internal tock-registers; cannot use workspace (0.10)

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -22,10 +22,7 @@ pub fn init(args: &[String], envs: &[String]) {
     static_keys::global_init();
     tracepoint_init().expect("Failed to initialize tracepoints");
 
-    #[cfg(feature = "kprobe")]
-    {
-        crate::kprobe::run_selftest();
-    }
+    crate::kprobe::run_selftest();
 
     pseudofs::mount_all().expect("Failed to mount pseudofs");
     spawn_alarm_task();

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -22,6 +22,11 @@ pub fn init(args: &[String], envs: &[String]) {
     static_keys::global_init();
     tracepoint_init().expect("Failed to initialize tracepoints");
 
+    #[cfg(feature = "kprobe")]
+    {
+        crate::kprobe::run_selftest();
+    }
+
     pseudofs::mount_all().expect("Failed to mount pseudofs");
     spawn_alarm_task();
 

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -22,6 +22,9 @@ pub fn init(args: &[String], envs: &[String]) {
     static_keys::global_init();
     tracepoint_init().expect("Failed to initialize tracepoints");
 
+    // FIXME: loongarch64 selftest hangs on QEMU; the kprobe crate's loongarch64
+    // breakpoint handling needs upstream fixes before selftest can be enabled.
+    #[cfg(not(target_arch = "loongarch64"))]
     crate::kprobe::run_selftest();
 
     pseudofs::mount_all().expect("Failed to mount pseudofs");

--- a/os/StarryOS/kernel/src/kprobe.rs
+++ b/os/StarryOS/kernel/src/kprobe.rs
@@ -399,14 +399,21 @@ fn kprobe_selftest_target() -> i32 {
 }
 
 static SELFTEST_HIT: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+static SELFTEST_RET_HIT: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
 
 fn selftest_pre_handler(_data: &dyn kprobe::ProbeData, _pt: &mut kprobe::PtRegs) {
     SELFTEST_HIT.store(true, core::sync::atomic::Ordering::SeqCst);
 }
 
+fn selftest_ret_handler(_data: &dyn kprobe::ProbeData, _pt: &mut kprobe::PtRegs) {
+    SELFTEST_RET_HIT.store(true, core::sync::atomic::Ordering::SeqCst);
+}
+
 pub fn run_selftest() -> bool {
     let target_addr = kprobe_selftest_target as *const () as usize;
-    let mut hit = false;
+    let mut kprobe_ok = false;
+    let mut kretprobe_ok = false;
 
     with_manager(|manager| {
         let mut probe_list = kprobe::ProbePointList::new();
@@ -417,18 +424,41 @@ pub fn run_selftest() -> bool {
 
         let kp = kprobe::register_kprobe(manager, &mut probe_list, builder);
         let val = kprobe_selftest_target();
-        hit = SELFTEST_HIT.load(core::sync::atomic::Ordering::SeqCst);
+        kprobe_ok = SELFTEST_HIT.load(core::sync::atomic::Ordering::SeqCst);
 
         kprobe::unregister_kprobe(manager, &mut probe_list, kp);
 
-        if hit && val == 42 {
+        if kprobe_ok && val == 42 {
             info!("kprobe selftest passed");
         } else {
-            warn!("kprobe selftest failed: hit={}, val={}", hit, val);
+            warn!("kprobe selftest failed: hit={}, val={}", kprobe_ok, val);
         }
     });
 
-    hit
+    with_manager(|manager| {
+        let mut probe_list = kprobe::ProbePointList::new();
+        let builder = kprobe::KretprobeBuilder::<spin::Mutex<()>>::new(4)
+            .with_symbol_addr(target_addr)
+            .with_ret_handler(selftest_ret_handler)
+            .with_enable(true);
+
+        let kr = kprobe::register_kretprobe(manager, &mut probe_list, builder);
+        let val = kprobe_selftest_target();
+        kretprobe_ok = SELFTEST_RET_HIT.load(core::sync::atomic::Ordering::SeqCst);
+
+        kprobe::unregister_kretprobe(manager, &mut probe_list, kr);
+
+        if kretprobe_ok && val == 42 {
+            info!("kretprobe selftest passed");
+        } else {
+            warn!(
+                "kretprobe selftest failed: hit={}, val={}",
+                kretprobe_ok, val
+            );
+        }
+    });
+
+    kprobe_ok && kretprobe_ok
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/os/StarryOS/kernel/src/kprobe.rs
+++ b/os/StarryOS/kernel/src/kprobe.rs
@@ -89,7 +89,7 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
         let mut guard = ax_mm::kernel_aspace().lock();
         let range = VirtAddrRange::new(guard.base(), guard.end());
         let vaddr = guard
-            .find_free_area(VirtAddr::from(0), PAGE_SIZE_4K, range)
+            .find_free_area(guard.base(), PAGE_SIZE_4K, range)
             .expect("kprobe: no free virtual address for exec memory");
         guard
             .map_alloc(
@@ -137,7 +137,8 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
 
 type KprobeManager = kprobe::ProbeManager<spin::Mutex<()>, KernelKprobeOps>;
 
-static KPROBE_MANAGER: ax_sync::Mutex<Option<KprobeManager>> = ax_sync::Mutex::new(None);
+static KPROBE_MANAGER: ax_sync::spin::SpinNoIrq<Option<KprobeManager>> =
+    ax_sync::spin::SpinNoIrq::new(None);
 
 fn with_manager<F, R>(f: F) -> R
 where
@@ -222,7 +223,7 @@ fn trapframe_to_ptregs(tf: &ax_hal::context::TrapFrame) -> kprobe::PtRegs {
     {
         kprobe::PtRegs {
             regs: tf.x,
-            sp: 0,
+            sp: 0, // aarch64 SP is not saved in TrapFrame
             pc: tf.elr,
             pstate: tf.spsr,
             orig_x0: tf.x[0],

--- a/os/StarryOS/kernel/src/kprobe.rs
+++ b/os/StarryOS/kernel/src/kprobe.rs
@@ -11,69 +11,17 @@
 //! conversion to bridge the kernel's trap frame format with the kprobe
 //! crate's portable `PtRegs` type.
 //!
-//! # Feature Gate
-//!
-//! The kprobe module is gated behind the `kprobe` feature (enabled by default).
-//! When disabled, breakpoint and debug exception handlers fall back to stubs
-//! that return `false`.
-//!
 //! # Key Components
 //!
-//! - [`KernelRawMutex`]: CAS-based spinlock implementing `lock_api::RawMutex`
 //! - [`KernelKprobeOps`]: Platform-specific auxiliary operations for the kprobe crate
 //! - [`handle_breakpoint`]: Entry point for breakpoint exceptions (INT3/EBREAK/BRK)
 //! - [`handle_debug`]: Entry point for debug exceptions (x86_64 single-step only)
 
-use alloc::alloc::{Layout, alloc, dealloc};
-use core::sync::atomic::{AtomicBool, Ordering};
-
-use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
+use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr, VirtAddrRange};
 use kprobe::KprobeAuxiliaryOps;
-use lock_api::RawMutex;
 
 use crate::task::AsThread;
 
-/// A CAS-based spinlock implementing [`RawMutex`] for use with [`kprobe::ProbeManager`].
-///
-/// Uses `compare_exchange_weak` in a busy-wait loop, suitable for interrupt
-/// context where sleeping is not allowed.
-pub struct KernelRawMutex {
-    locked: AtomicBool,
-}
-
-unsafe impl RawMutex for KernelRawMutex {
-    const INIT: Self = KernelRawMutex {
-        locked: AtomicBool::new(false),
-    };
-
-    type GuardMarker = lock_api::GuardNoSend;
-
-    fn lock(&self) {
-        while self
-            .locked
-            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            core::hint::spin_loop();
-        }
-    }
-
-    fn try_lock(&self) -> bool {
-        self.locked
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
-    }
-
-    unsafe fn unlock(&self) {
-        self.locked.store(false, Ordering::Release);
-    }
-}
-
-/// StarryOS-specific implementation of [`KprobeAuxiliaryOps`].
-///
-/// Provides the platform glue that the `kprobe` crate needs: memory copy,
-/// page table manipulation for breakpoint insertion, executable memory
-/// allocation, and per-task kretprobe instance management.
 #[derive(Debug)]
 pub struct KernelKprobeOps;
 
@@ -122,7 +70,7 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
                         original_flags | ax_hal::paging::MappingFlags::WRITE,
                     )
                     .expect("kprobe: set_writeable: protect failed");
-                flush_tlb_range(aligned_addr, aligned_length);
+                crate::mm::flush_tlb_range(aligned_addr, aligned_length);
                 action(addr.as_mut_ptr());
                 #[cfg(target_arch = "aarch64")]
                 ax_hal::asm::clean_dcache_range_to_pou(addr, len);
@@ -131,24 +79,37 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
                     .expect("kprobe: set_writeable: restore failed");
             },
             move || {
-                flush_tlb_range(aligned_addr, aligned_length);
+                crate::mm::flush_tlb_range(aligned_addr, aligned_length);
                 ax_hal::asm::flush_icache_all();
             },
         );
     }
 
     fn alloc_kernel_exec_memory() -> *mut u8 {
-        let layout = Layout::from_size_align(PAGE_SIZE_4K, PAGE_SIZE_4K).unwrap();
-        let ptr = unsafe { alloc(layout) };
-        if ptr.is_null() {
-            panic!("kprobe: alloc_kernel_exec_memory failed: OOM");
-        }
-        ptr
+        let mut guard = ax_mm::kernel_aspace().lock();
+        let range = VirtAddrRange::new(guard.base(), guard.end());
+        let vaddr = guard
+            .find_free_area(VirtAddr::from(0), PAGE_SIZE_4K, range)
+            .expect("kprobe: no free virtual address for exec memory");
+        guard
+            .map_alloc(
+                vaddr,
+                PAGE_SIZE_4K,
+                ax_hal::paging::MappingFlags::READ
+                    | ax_hal::paging::MappingFlags::WRITE
+                    | ax_hal::paging::MappingFlags::EXECUTE,
+                true,
+            )
+            .expect("kprobe: map_alloc for exec memory failed");
+        vaddr.as_mut_ptr()
     }
 
     fn free_kernel_exec_memory(ptr: *mut u8) {
-        let layout = Layout::from_size_align(PAGE_SIZE_4K, PAGE_SIZE_4K).unwrap();
-        unsafe { dealloc(ptr, layout) }
+        let vaddr = VirtAddr::from(ptr as usize);
+        let mut guard = ax_mm::kernel_aspace().lock();
+        guard
+            .unmap(vaddr, PAGE_SIZE_4K)
+            .expect("kprobe: unmap exec memory failed");
     }
 
     fn alloc_user_exec_memory<F: FnOnce(*mut u8)>(_pid: Option<i32>, _action: F) -> *mut u8 {
@@ -174,10 +135,9 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
     }
 }
 
-type KprobeManager = kprobe::ProbeManager<KernelRawMutex, KernelKprobeOps>;
+type KprobeManager = kprobe::ProbeManager<spin::Mutex<()>, KernelKprobeOps>;
 
-static KPROBE_MANAGER: ax_sync::spin::SpinNoIrq<Option<KprobeManager>> =
-    ax_sync::spin::SpinNoIrq::new(None);
+static KPROBE_MANAGER: ax_sync::Mutex<Option<KprobeManager>> = ax_sync::Mutex::new(None);
 
 fn with_manager<F, R>(f: F) -> R
 where
@@ -190,12 +150,6 @@ where
     f(guard.as_mut().expect("kprobe: manager not initialized"))
 }
 
-/// Convert the kernel's [`TrapFrame`](ax_hal::context::TrapFrame) to kprobe's
-/// portable [`PtRegs`](kprobe::PtRegs) format.
-///
-/// Each architecture maps its trap frame registers to the corresponding
-/// `PtRegs` fields. CSRs or status registers that are not available in
-/// `TrapFrame` are set to zero.
 fn trapframe_to_ptregs(tf: &ax_hal::context::TrapFrame) -> kprobe::PtRegs {
     #[cfg(target_arch = "x86_64")]
     {
@@ -268,7 +222,6 @@ fn trapframe_to_ptregs(tf: &ax_hal::context::TrapFrame) -> kprobe::PtRegs {
     {
         kprobe::PtRegs {
             regs: tf.x,
-            // NOTE: aarch64 TrapFrame does not store SP; kprobe handlers relying on SP will get 0.
             sp: 0,
             pc: tf.elr,
             pstate: tf.spsr,
@@ -326,12 +279,6 @@ fn trapframe_to_ptregs(tf: &ax_hal::context::TrapFrame) -> kprobe::PtRegs {
     }
 }
 
-/// Write back modified [`PtRegs`](kprobe::PtRegs) values to the kernel's
-/// [`TrapFrame`](ax_hal::context::TrapFrame).
-///
-/// This is called after a kprobe handler returns `Some(())` to apply any
-/// register modifications the handler made (e.g., altering return values
-/// or redirecting control flow).
 fn ptregs_write_back(pt: &kprobe::PtRegs, tf: &mut ax_hal::context::TrapFrame) {
     #[cfg(target_arch = "x86_64")]
     {
@@ -436,12 +383,6 @@ fn ptregs_write_back(pt: &kprobe::PtRegs, tf: &mut ax_hal::context::TrapFrame) {
     }
 }
 
-/// Handle a breakpoint exception (INT3/EBREAK/BRK) by dispatching to the
-/// kprobe subsystem.
-///
-/// Converts the trap frame to `PtRegs`, runs the kprobe handler, and writes
-/// back any register modifications. Returns `true` if a kprobe was hit and
-/// handled, `false` otherwise.
 pub fn handle_breakpoint(tf: &mut ax_hal::context::TrapFrame) -> bool {
     let mut pt_regs = trapframe_to_ptregs(tf);
     let handled = with_manager(|manager| kprobe::kprobe_handler_from_break(manager, &mut pt_regs));
@@ -452,10 +393,6 @@ pub fn handle_breakpoint(tf: &mut ax_hal::context::TrapFrame) -> bool {
     false
 }
 
-/// Handle a debug exception (single-step) by dispatching to the kprobe subsystem.
-///
-/// Currently only available on x86_64, which is the only architecture that
-/// uses hardware single-step for kprobe execution.
 #[cfg(target_arch = "x86_64")]
 pub fn handle_debug(tf: &mut ax_hal::context::TrapFrame) -> bool {
     let mut pt_regs = trapframe_to_ptregs(tf);
@@ -465,11 +402,4 @@ pub fn handle_debug(tf: &mut ax_hal::context::TrapFrame) -> bool {
         return true;
     }
     false
-}
-
-#[allow(dead_code)]
-fn flush_tlb_range(start: VirtAddr, size: usize) {
-    for offset in (0..size).step_by(PAGE_SIZE_4K) {
-        ax_hal::asm::flush_tlb(Some(start + offset));
-    }
 }

--- a/os/StarryOS/kernel/src/kprobe.rs
+++ b/os/StarryOS/kernel/src/kprobe.rs
@@ -393,6 +393,44 @@ pub fn handle_breakpoint(tf: &mut ax_hal::context::TrapFrame) -> bool {
     false
 }
 
+#[allow(dead_code)]
+fn kprobe_selftest_target() -> i32 {
+    42
+}
+
+static SELFTEST_HIT: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+fn selftest_pre_handler(_data: &dyn kprobe::ProbeData, _pt: &mut kprobe::PtRegs) {
+    SELFTEST_HIT.store(true, core::sync::atomic::Ordering::SeqCst);
+}
+
+pub fn run_selftest() -> bool {
+    let target_addr = kprobe_selftest_target as *const () as usize;
+    let mut hit = false;
+
+    with_manager(|manager| {
+        let mut probe_list = kprobe::ProbePointList::new();
+        let builder = kprobe::ProbeBuilder::<KernelKprobeOps>::new()
+            .with_symbol_addr(target_addr)
+            .with_pre_handler(selftest_pre_handler)
+            .with_enable(true);
+
+        let kp = kprobe::register_kprobe(manager, &mut probe_list, builder);
+        let val = kprobe_selftest_target();
+        hit = SELFTEST_HIT.load(core::sync::atomic::Ordering::SeqCst);
+
+        kprobe::unregister_kprobe(manager, &mut probe_list, kp);
+
+        if hit && val == 42 {
+            info!("kprobe selftest passed");
+        } else {
+            warn!("kprobe selftest failed: hit={}, val={}", hit, val);
+        }
+    });
+
+    hit
+}
+
 #[cfg(target_arch = "x86_64")]
 pub fn handle_debug(tf: &mut ax_hal::context::TrapFrame) -> bool {
     let mut pt_regs = trapframe_to_ptregs(tf);

--- a/os/StarryOS/kernel/src/kprobe.rs
+++ b/os/StarryOS/kernel/src/kprobe.rs
@@ -67,20 +67,20 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
                     .protect(
                         aligned_addr,
                         aligned_length,
-                        original_flags | ax_hal::paging::MappingFlags::WRITE,
+                        original_flags | ax_runtime::hal::paging::MappingFlags::WRITE,
                     )
                     .expect("kprobe: set_writeable: protect failed");
                 crate::mm::flush_tlb_range(aligned_addr, aligned_length);
                 action(addr.as_mut_ptr());
                 #[cfg(target_arch = "aarch64")]
-                ax_hal::asm::clean_dcache_range_to_pou(addr, len);
+                ax_runtime::hal::cpu::asm::clean_dcache_range_to_pou(addr, len);
                 guard
                     .protect(aligned_addr, aligned_length, original_flags)
                     .expect("kprobe: set_writeable: restore failed");
             },
             move || {
                 crate::mm::flush_tlb_range(aligned_addr, aligned_length);
-                ax_hal::asm::flush_icache_all();
+                ax_runtime::hal::cpu::asm::flush_icache_all();
             },
         );
     }
@@ -95,9 +95,9 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
             .map_alloc(
                 vaddr,
                 PAGE_SIZE_4K,
-                ax_hal::paging::MappingFlags::READ
-                    | ax_hal::paging::MappingFlags::WRITE
-                    | ax_hal::paging::MappingFlags::EXECUTE,
+                ax_runtime::hal::paging::MappingFlags::READ
+                    | ax_runtime::hal::paging::MappingFlags::WRITE
+                    | ax_runtime::hal::paging::MappingFlags::EXECUTE,
                 true,
             )
             .expect("kprobe: map_alloc for exec memory failed");
@@ -151,7 +151,7 @@ where
     f(guard.as_mut().expect("kprobe: manager not initialized"))
 }
 
-fn trapframe_to_ptregs(tf: &ax_hal::context::TrapFrame) -> kprobe::PtRegs {
+fn trapframe_to_ptregs(tf: &ax_runtime::hal::cpu::TrapFrame) -> kprobe::PtRegs {
     #[cfg(target_arch = "x86_64")]
     {
         kprobe::PtRegs {
@@ -280,7 +280,7 @@ fn trapframe_to_ptregs(tf: &ax_hal::context::TrapFrame) -> kprobe::PtRegs {
     }
 }
 
-fn ptregs_write_back(pt: &kprobe::PtRegs, tf: &mut ax_hal::context::TrapFrame) {
+fn ptregs_write_back(pt: &kprobe::PtRegs, tf: &mut ax_runtime::hal::cpu::TrapFrame) {
     #[cfg(target_arch = "x86_64")]
     {
         tf.r15 = pt.r15 as u64;
@@ -384,7 +384,7 @@ fn ptregs_write_back(pt: &kprobe::PtRegs, tf: &mut ax_hal::context::TrapFrame) {
     }
 }
 
-pub fn handle_breakpoint(tf: &mut ax_hal::context::TrapFrame) -> bool {
+pub fn handle_breakpoint(tf: &mut ax_runtime::hal::cpu::TrapFrame) -> bool {
     let mut pt_regs = trapframe_to_ptregs(tf);
     let handled = with_manager(|manager| kprobe::kprobe_handler_from_break(manager, &mut pt_regs));
     if handled.is_some() {
@@ -463,7 +463,7 @@ pub fn run_selftest() -> bool {
 }
 
 #[cfg(target_arch = "x86_64")]
-pub fn handle_debug(tf: &mut ax_hal::context::TrapFrame) -> bool {
+pub fn handle_debug(tf: &mut ax_runtime::hal::cpu::TrapFrame) -> bool {
     let mut pt_regs = trapframe_to_ptregs(tf);
     let handled = with_manager(|manager| kprobe::kprobe_handler_from_debug(manager, &mut pt_regs));
     if handled.is_some() {

--- a/os/StarryOS/kernel/src/kprobe.rs
+++ b/os/StarryOS/kernel/src/kprobe.rs
@@ -1,0 +1,474 @@
+//! Kernel probe (kprobe) subsystem for StarryOS.
+//!
+//! This module provides dynamic tracing support by allowing breakpoint
+//! insertion at kernel function entry/return points. It integrates the
+//! [`kprobe`] crate with StarryOS kernel infrastructure.
+//!
+//! # Architecture Support
+//!
+//! All four supported architectures are enabled: x86_64, riscv64, aarch64,
+//! and loongarch64. Each architecture provides TrapFrame↔PtRegs register
+//! conversion to bridge the kernel's trap frame format with the kprobe
+//! crate's portable `PtRegs` type.
+//!
+//! # Feature Gate
+//!
+//! The kprobe module is gated behind the `kprobe` feature (enabled by default).
+//! When disabled, breakpoint and debug exception handlers fall back to stubs
+//! that return `false`.
+//!
+//! # Key Components
+//!
+//! - [`KernelRawMutex`]: CAS-based spinlock implementing `lock_api::RawMutex`
+//! - [`KernelKprobeOps`]: Platform-specific auxiliary operations for the kprobe crate
+//! - [`handle_breakpoint`]: Entry point for breakpoint exceptions (INT3/EBREAK/BRK)
+//! - [`handle_debug`]: Entry point for debug exceptions (x86_64 single-step only)
+
+use alloc::alloc::{Layout, alloc, dealloc};
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
+use kprobe::KprobeAuxiliaryOps;
+use lock_api::RawMutex;
+
+use crate::task::AsThread;
+
+/// A CAS-based spinlock implementing [`RawMutex`] for use with [`kprobe::ProbeManager`].
+///
+/// Uses `compare_exchange_weak` in a busy-wait loop, suitable for interrupt
+/// context where sleeping is not allowed.
+pub struct KernelRawMutex {
+    locked: AtomicBool,
+}
+
+unsafe impl RawMutex for KernelRawMutex {
+    const INIT: Self = KernelRawMutex {
+        locked: AtomicBool::new(false),
+    };
+
+    type GuardMarker = lock_api::GuardNoSend;
+
+    fn lock(&self) {
+        while self
+            .locked
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+    }
+
+    fn try_lock(&self) -> bool {
+        self.locked
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+    }
+
+    unsafe fn unlock(&self) {
+        self.locked.store(false, Ordering::Release);
+    }
+}
+
+/// StarryOS-specific implementation of [`KprobeAuxiliaryOps`].
+///
+/// Provides the platform glue that the `kprobe` crate needs: memory copy,
+/// page table manipulation for breakpoint insertion, executable memory
+/// allocation, and per-task kretprobe instance management.
+#[derive(Debug)]
+pub struct KernelKprobeOps;
+
+impl KprobeAuxiliaryOps for KernelKprobeOps {
+    fn copy_memory(src: *const u8, dst: *mut u8, len: usize, user_pid: Option<i32>) {
+        if let Some(_pid) = user_pid {
+            unsafe {
+                let buf =
+                    core::slice::from_raw_parts_mut(dst as *mut core::mem::MaybeUninit<u8>, len);
+                if let Err(e) = starry_vm::vm_read_slice(src, buf) {
+                    warn!("kprobe copy_memory: vm_read_slice failed: {:?}", e);
+                }
+            }
+        } else {
+            unsafe {
+                core::ptr::copy_nonoverlapping(src, dst, len);
+            }
+        }
+    }
+
+    fn set_writeable_for_address<F: FnOnce(*mut u8)>(
+        address: usize,
+        len: usize,
+        user_pid: Option<i32>,
+        action: F,
+    ) {
+        if user_pid.is_some() {
+            unimplemented!("user space breakpoint insertion not yet supported")
+        }
+        let addr = VirtAddr::from(address);
+        let aligned_addr = addr.align_down_4k();
+        let aligned_end = (addr + len).align_up_4k();
+        let aligned_length: usize = aligned_end - aligned_addr;
+
+        crate::stop_machine::stop_machine(
+            move || {
+                let mut guard = ax_mm::kernel_aspace().lock();
+                let (_, original_flags, _) = guard
+                    .page_table()
+                    .query(aligned_addr)
+                    .expect("kprobe: set_writeable: address not mapped");
+                guard
+                    .protect(
+                        aligned_addr,
+                        aligned_length,
+                        original_flags | ax_hal::paging::MappingFlags::WRITE,
+                    )
+                    .expect("kprobe: set_writeable: protect failed");
+                flush_tlb_range(aligned_addr, aligned_length);
+                action(addr.as_mut_ptr());
+                #[cfg(target_arch = "aarch64")]
+                ax_hal::asm::clean_dcache_range_to_pou(addr, len);
+                guard
+                    .protect(aligned_addr, aligned_length, original_flags)
+                    .expect("kprobe: set_writeable: restore failed");
+            },
+            move || {
+                flush_tlb_range(aligned_addr, aligned_length);
+                ax_hal::asm::flush_icache_all();
+            },
+        );
+    }
+
+    fn alloc_kernel_exec_memory() -> *mut u8 {
+        let layout = Layout::from_size_align(PAGE_SIZE_4K, PAGE_SIZE_4K).unwrap();
+        let ptr = unsafe { alloc(layout) };
+        if ptr.is_null() {
+            panic!("kprobe: alloc_kernel_exec_memory failed: OOM");
+        }
+        ptr
+    }
+
+    fn free_kernel_exec_memory(ptr: *mut u8) {
+        let layout = Layout::from_size_align(PAGE_SIZE_4K, PAGE_SIZE_4K).unwrap();
+        unsafe { dealloc(ptr, layout) }
+    }
+
+    fn alloc_user_exec_memory<F: FnOnce(*mut u8)>(_pid: Option<i32>, _action: F) -> *mut u8 {
+        unimplemented!("user exec memory allocation for uprobes not yet supported")
+    }
+
+    fn free_user_exec_memory(_pid: Option<i32>, _ptr: *mut u8) {
+        unimplemented!("user exec memory deallocation for uprobes not yet supported")
+    }
+
+    fn insert_kretprobe_instance_to_task(instance: kprobe::retprobe::RetprobeInstance) {
+        let curr = ax_task::current();
+        curr.as_thread().kretprobe_stack.lock().push(instance);
+    }
+
+    fn pop_kretprobe_instance_from_task() -> kprobe::retprobe::RetprobeInstance {
+        let curr = ax_task::current();
+        curr.as_thread()
+            .kretprobe_stack
+            .lock()
+            .pop()
+            .expect("kretprobe instance stack underflow")
+    }
+}
+
+type KprobeManager = kprobe::ProbeManager<KernelRawMutex, KernelKprobeOps>;
+
+static KPROBE_MANAGER: ax_sync::spin::SpinNoIrq<Option<KprobeManager>> =
+    ax_sync::spin::SpinNoIrq::new(None);
+
+fn with_manager<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut KprobeManager) -> R,
+{
+    let mut guard = KPROBE_MANAGER.lock();
+    if guard.is_none() {
+        *guard = Some(KprobeManager::default());
+    }
+    f(guard.as_mut().expect("kprobe: manager not initialized"))
+}
+
+/// Convert the kernel's [`TrapFrame`](ax_hal::context::TrapFrame) to kprobe's
+/// portable [`PtRegs`](kprobe::PtRegs) format.
+///
+/// Each architecture maps its trap frame registers to the corresponding
+/// `PtRegs` fields. CSRs or status registers that are not available in
+/// `TrapFrame` are set to zero.
+fn trapframe_to_ptregs(tf: &ax_hal::context::TrapFrame) -> kprobe::PtRegs {
+    #[cfg(target_arch = "x86_64")]
+    {
+        kprobe::PtRegs {
+            r15: tf.r15 as usize,
+            r14: tf.r14 as usize,
+            r13: tf.r13 as usize,
+            r12: tf.r12 as usize,
+            rbp: tf.rbp as usize,
+            rbx: tf.rbx as usize,
+            r11: tf.r11 as usize,
+            r10: tf.r10 as usize,
+            r9: tf.r9 as usize,
+            r8: tf.r8 as usize,
+            rax: tf.rax as usize,
+            rcx: tf.rcx as usize,
+            rdx: tf.rdx as usize,
+            rsi: tf.rsi as usize,
+            rdi: tf.rdi as usize,
+            orig_rax: 0,
+            rip: tf.rip as usize,
+            cs: tf.cs as usize,
+            rflags: tf.rflags as usize,
+            rsp: tf.rsp as usize,
+            ss: tf.ss as usize,
+        }
+    }
+    #[cfg(target_arch = "riscv64")]
+    {
+        kprobe::PtRegs {
+            epc: tf.sepc,
+            ra: tf.regs.ra,
+            sp: tf.regs.sp,
+            gp: tf.regs.gp,
+            tp: tf.regs.tp,
+            t0: tf.regs.t0,
+            t1: tf.regs.t1,
+            t2: tf.regs.t2,
+            s0: tf.regs.s0,
+            s1: tf.regs.s1,
+            a0: tf.regs.a0,
+            a1: tf.regs.a1,
+            a2: tf.regs.a2,
+            a3: tf.regs.a3,
+            a4: tf.regs.a4,
+            a5: tf.regs.a5,
+            a6: tf.regs.a6,
+            a7: tf.regs.a7,
+            s2: tf.regs.s2,
+            s3: tf.regs.s3,
+            s4: tf.regs.s4,
+            s5: tf.regs.s5,
+            s6: tf.regs.s6,
+            s7: tf.regs.s7,
+            s8: tf.regs.s8,
+            s9: tf.regs.s9,
+            s10: tf.regs.s10,
+            s11: tf.regs.s11,
+            t3: tf.regs.t3,
+            t4: tf.regs.t4,
+            t5: tf.regs.t5,
+            t6: tf.regs.t6,
+            status: tf.sstatus.bits(),
+            badaddr: 0,
+            cause: 0,
+            orig_a0: tf.regs.a0,
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        kprobe::PtRegs {
+            regs: tf.x,
+            sp: 0,
+            pc: tf.elr,
+            pstate: tf.spsr,
+            orig_x0: tf.x[0],
+            syscallno: -1,
+            unused2: 0,
+        }
+    }
+    #[cfg(target_arch = "loongarch64")]
+    {
+        kprobe::PtRegs {
+            regs: [
+                tf.regs.zero,
+                tf.regs.ra,
+                tf.regs.tp,
+                tf.regs.sp,
+                tf.regs.a0,
+                tf.regs.a1,
+                tf.regs.a2,
+                tf.regs.a3,
+                tf.regs.a4,
+                tf.regs.a5,
+                tf.regs.a6,
+                tf.regs.a7,
+                tf.regs.t0,
+                tf.regs.t1,
+                tf.regs.t2,
+                tf.regs.t3,
+                tf.regs.t4,
+                tf.regs.t5,
+                tf.regs.t6,
+                tf.regs.t7,
+                tf.regs.t8,
+                tf.regs.u0,
+                tf.regs.fp,
+                tf.regs.s0,
+                tf.regs.s1,
+                tf.regs.s2,
+                tf.regs.s3,
+                tf.regs.s4,
+                tf.regs.s5,
+                tf.regs.s6,
+                tf.regs.s7,
+                tf.regs.s8,
+            ],
+            orig_a0: tf.regs.a0,
+            csr_era: tf.era,
+            csr_badvaddr: 0,
+            csr_crmd: 0,
+            csr_prmd: tf.prmd,
+            csr_euen: 0,
+            csr_ecfg: 0,
+            csr_estat: 0,
+        }
+    }
+}
+
+/// Write back modified [`PtRegs`](kprobe::PtRegs) values to the kernel's
+/// [`TrapFrame`](ax_hal::context::TrapFrame).
+///
+/// This is called after a kprobe handler returns `Some(())` to apply any
+/// register modifications the handler made (e.g., altering return values
+/// or redirecting control flow).
+fn ptregs_write_back(pt: &kprobe::PtRegs, tf: &mut ax_hal::context::TrapFrame) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        tf.r15 = pt.r15 as u64;
+        tf.r14 = pt.r14 as u64;
+        tf.r13 = pt.r13 as u64;
+        tf.r12 = pt.r12 as u64;
+        tf.rbp = pt.rbp as u64;
+        tf.rbx = pt.rbx as u64;
+        tf.r11 = pt.r11 as u64;
+        tf.r10 = pt.r10 as u64;
+        tf.r9 = pt.r9 as u64;
+        tf.r8 = pt.r8 as u64;
+        tf.rax = pt.rax as u64;
+        tf.rcx = pt.rcx as u64;
+        tf.rdx = pt.rdx as u64;
+        tf.rsi = pt.rsi as u64;
+        tf.rdi = pt.rdi as u64;
+        tf.rip = pt.rip as u64;
+        tf.cs = pt.cs as u64;
+        tf.rflags = pt.rflags as u64;
+        tf.rsp = pt.rsp as u64;
+        tf.ss = pt.ss as u64;
+    }
+    #[cfg(target_arch = "riscv64")]
+    {
+        tf.sepc = pt.epc;
+        tf.regs.ra = pt.ra;
+        tf.regs.sp = pt.sp;
+        tf.regs.gp = pt.gp;
+        tf.regs.tp = pt.tp;
+        tf.regs.t0 = pt.t0;
+        tf.regs.t1 = pt.t1;
+        tf.regs.t2 = pt.t2;
+        tf.regs.s0 = pt.s0;
+        tf.regs.s1 = pt.s1;
+        tf.regs.a0 = pt.a0;
+        tf.regs.a1 = pt.a1;
+        tf.regs.a2 = pt.a2;
+        tf.regs.a3 = pt.a3;
+        tf.regs.a4 = pt.a4;
+        tf.regs.a5 = pt.a5;
+        tf.regs.a6 = pt.a6;
+        tf.regs.a7 = pt.a7;
+        tf.regs.s2 = pt.s2;
+        tf.regs.s3 = pt.s3;
+        tf.regs.s4 = pt.s4;
+        tf.regs.s5 = pt.s5;
+        tf.regs.s6 = pt.s6;
+        tf.regs.s7 = pt.s7;
+        tf.regs.s8 = pt.s8;
+        tf.regs.s9 = pt.s9;
+        tf.regs.s10 = pt.s10;
+        tf.regs.s11 = pt.s11;
+        tf.regs.t3 = pt.t3;
+        tf.regs.t4 = pt.t4;
+        tf.regs.t5 = pt.t5;
+        tf.regs.t6 = pt.t6;
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        tf.x = pt.regs;
+        tf.elr = pt.pc;
+        tf.spsr = pt.pstate;
+    }
+    #[cfg(target_arch = "loongarch64")]
+    {
+        tf.regs.zero = pt.regs[0];
+        tf.regs.ra = pt.regs[1];
+        tf.regs.tp = pt.regs[2];
+        tf.regs.sp = pt.regs[3];
+        tf.regs.a0 = pt.regs[4];
+        tf.regs.a1 = pt.regs[5];
+        tf.regs.a2 = pt.regs[6];
+        tf.regs.a3 = pt.regs[7];
+        tf.regs.a4 = pt.regs[8];
+        tf.regs.a5 = pt.regs[9];
+        tf.regs.a6 = pt.regs[10];
+        tf.regs.a7 = pt.regs[11];
+        tf.regs.t0 = pt.regs[12];
+        tf.regs.t1 = pt.regs[13];
+        tf.regs.t2 = pt.regs[14];
+        tf.regs.t3 = pt.regs[15];
+        tf.regs.t4 = pt.regs[16];
+        tf.regs.t5 = pt.regs[17];
+        tf.regs.t6 = pt.regs[18];
+        tf.regs.t7 = pt.regs[19];
+        tf.regs.t8 = pt.regs[20];
+        tf.regs.u0 = pt.regs[21];
+        tf.regs.fp = pt.regs[22];
+        tf.regs.s0 = pt.regs[23];
+        tf.regs.s1 = pt.regs[24];
+        tf.regs.s2 = pt.regs[25];
+        tf.regs.s3 = pt.regs[26];
+        tf.regs.s4 = pt.regs[27];
+        tf.regs.s5 = pt.regs[28];
+        tf.regs.s6 = pt.regs[29];
+        tf.regs.s7 = pt.regs[30];
+        tf.regs.s8 = pt.regs[31];
+        tf.era = pt.csr_era;
+        tf.prmd = pt.csr_prmd;
+    }
+}
+
+/// Handle a breakpoint exception (INT3/EBREAK/BRK) by dispatching to the
+/// kprobe subsystem.
+///
+/// Converts the trap frame to `PtRegs`, runs the kprobe handler, and writes
+/// back any register modifications. Returns `true` if a kprobe was hit and
+/// handled, `false` otherwise.
+pub fn handle_breakpoint(tf: &mut ax_hal::context::TrapFrame) -> bool {
+    let mut pt_regs = trapframe_to_ptregs(tf);
+    let handled = with_manager(|manager| kprobe::kprobe_handler_from_break(manager, &mut pt_regs));
+    if handled.is_some() {
+        ptregs_write_back(&pt_regs, tf);
+        return true;
+    }
+    false
+}
+
+/// Handle a debug exception (single-step) by dispatching to the kprobe subsystem.
+///
+/// Currently only available on x86_64, which is the only architecture that
+/// uses hardware single-step for kprobe execution.
+#[cfg(target_arch = "x86_64")]
+pub fn handle_debug(tf: &mut ax_hal::context::TrapFrame) -> bool {
+    let mut pt_regs = trapframe_to_ptregs(tf);
+    let handled = with_manager(|manager| kprobe::kprobe_handler_from_debug(manager, &mut pt_regs));
+    if handled.is_some() {
+        ptregs_write_back(&pt_regs, tf);
+        return true;
+    }
+    false
+}
+
+#[allow(dead_code)]
+fn flush_tlb_range(start: VirtAddr, size: usize) {
+    for offset in (0..size).step_by(PAGE_SIZE_4K) {
+        ax_hal::asm::flush_tlb(Some(start + offset));
+    }
+}

--- a/os/StarryOS/kernel/src/kprobe.rs
+++ b/os/StarryOS/kernel/src/kprobe.rs
@@ -268,6 +268,7 @@ fn trapframe_to_ptregs(tf: &ax_hal::context::TrapFrame) -> kprobe::PtRegs {
     {
         kprobe::PtRegs {
             regs: tf.x,
+            // NOTE: aarch64 TrapFrame does not store SP; kprobe handlers relying on SP will get 0.
             sp: 0,
             pc: tf.elr,
             pstate: tf.spsr,

--- a/os/StarryOS/kernel/src/lib.rs
+++ b/os/StarryOS/kernel/src/lib.rs
@@ -19,6 +19,10 @@ pub mod entry;
 
 mod config;
 mod file;
+#[cfg(feature = "kcov")]
+mod kcov;
+#[cfg(feature = "kprobe")]
+mod kprobe;
 mod mm;
 mod pseudofs;
 mod stop_machine;

--- a/os/StarryOS/kernel/src/lib.rs
+++ b/os/StarryOS/kernel/src/lib.rs
@@ -21,7 +21,6 @@ mod config;
 mod file;
 #[cfg(feature = "kcov")]
 mod kcov;
-#[cfg(feature = "kprobe")]
 mod kprobe;
 mod mm;
 mod pseudofs;

--- a/os/StarryOS/kernel/src/lib.rs
+++ b/os/StarryOS/kernel/src/lib.rs
@@ -19,8 +19,6 @@ pub mod entry;
 
 mod config;
 mod file;
-#[cfg(feature = "kcov")]
-mod kcov;
 mod kprobe;
 mod mm;
 mod pseudofs;

--- a/os/StarryOS/kernel/src/lib.rs
+++ b/os/StarryOS/kernel/src/lib.rs
@@ -21,6 +21,7 @@ mod config;
 mod file;
 #[cfg(feature = "kcov")]
 mod kcov;
+#[cfg(feature = "kprobe")]
 mod kprobe;
 mod mm;
 mod pseudofs;

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -520,7 +520,7 @@ pub fn write_kernel_text(addr: VirtAddr, data: &[u8]) -> AxResult<()> {
     )
 }
 
-fn flush_tlb_range(start: VirtAddr, size: usize) {
+pub fn flush_tlb_range(start: VirtAddr, size: usize) {
     for offset in (0..size).step_by(PAGE_SIZE_4K) {
         ax_runtime::hal::cpu::asm::flush_tlb(Some(start + offset));
     }

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -160,6 +160,7 @@ pub struct Thread {
     /// the real fault terminated silently.
     pub fault_dump_signo: AtomicU8,
 
+    #[cfg(feature = "kprobe")]
     pub kretprobe_stack: SpinNoIrq<alloc::vec::Vec<kprobe::retprobe::RetprobeInstance>>,
 }
 
@@ -190,6 +191,7 @@ impl Thread {
             cred: SpinNoIrq::new(cred),
 
             fault_dump_signo: AtomicU8::new(0),
+            #[cfg(feature = "kprobe")]
             kretprobe_stack: SpinNoIrq::new(alloc::vec::Vec::new()),
         })
     }

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -160,7 +160,6 @@ pub struct Thread {
     /// the real fault terminated silently.
     pub fault_dump_signo: AtomicU8,
 
-    #[cfg(feature = "kprobe")]
     pub kretprobe_stack: SpinNoIrq<alloc::vec::Vec<kprobe::retprobe::RetprobeInstance>>,
 }
 
@@ -191,7 +190,6 @@ impl Thread {
             cred: SpinNoIrq::new(cred),
 
             fault_dump_signo: AtomicU8::new(0),
-            #[cfg(feature = "kprobe")]
             kretprobe_stack: SpinNoIrq::new(alloc::vec::Vec::new()),
         })
     }

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -159,6 +159,9 @@ pub struct Thread {
     /// wrong context or, if it had a user handler, swallow the dump so
     /// the real fault terminated silently.
     pub fault_dump_signo: AtomicU8,
+
+    #[cfg(feature = "kprobe")]
+    pub kretprobe_stack: SpinNoIrq<alloc::vec::Vec<kprobe::retprobe::RetprobeInstance>>,
 }
 
 impl Thread {
@@ -188,6 +191,8 @@ impl Thread {
             cred: SpinNoIrq::new(cred),
 
             fault_dump_signo: AtomicU8::new(0),
+            #[cfg(feature = "kprobe")]
+            kretprobe_stack: SpinNoIrq::new(alloc::vec::Vec::new()),
         })
     }
 

--- a/os/StarryOS/kernel/src/trap.rs
+++ b/os/StarryOS/kernel/src/trap.rs
@@ -1,10 +1,10 @@
 #[ax_runtime::hal::cpu::trap::breakpoint_handler]
-fn default_breakpoint_handler(_tf: &mut ax_runtime::hal::cpu::TrapFrame) -> bool {
-    false
+fn default_breakpoint_handler(tf: &mut ax_runtime::hal::cpu::TrapFrame) -> bool {
+    crate::kprobe::handle_breakpoint(tf)
 }
 
 #[cfg(target_arch = "x86_64")]
 #[ax_runtime::hal::cpu::trap::debug_handler]
-fn default_debug_handler(_tf: &mut ax_runtime::hal::cpu::TrapFrame) -> bool {
-    false
+fn default_debug_handler(tf: &mut ax_runtime::hal::cpu::TrapFrame) -> bool {
+    crate::kprobe::handle_debug(tf)
 }


### PR DESCRIPTION
## 概述

为 StarryOS 内核添加 kprobe（内核探针）子系统支持，允许在内核函数入口/返回处设置断点进行动态跟踪。基于 `kprobe` crate（v0.5）实现，提供完整的 kprobe 和 kretprobe 能力。

## 背景

kprobe 是 Linux 内核的经典动态跟踪机制，广泛用于性能分析、故障诊断和安全监控。本实现遵循 Linux 的 kprobe 语义，使用 `stop_machine` 确保 SMP 安全性，per-thread kretprobe_stack 与 Linux per-task 语义一致。

## 变更内容

### 新增文件

- **`kprobe.rs`**（~474 行）：kprobe 子系统核心实现
  - `KernelRawMutex`：基于 `SpinNoIrq` 实现 `lock_api::RawMutex`
  - `KernelKprobeOps`：实现 `KprobeAuxiliaryOps` trait，提供 TrapFrame↔PtRegs 转换
  - 四架构（x86_64 / riscv64 / aarch64 / loongarch64）TrapFrame↔PtRegs 寄存器转换
  - `handle_breakpoint` / `handle_debug`：breakpoint 和 debug 异常入口
  - 全局 `KPROBE_MANAGER`：基于 `LazyInit` 延迟初始化
  - `copy_memory` / `alloc_kernel_exec_memory`：安全内存操作
  - kprobe + kretprobe selftest

### 修改文件

- **`trap.rs`**：路由 breakpoint（INT3/EBREAK/BRK）和 debug 异常到 kprobe handler（使用 `ax_runtime::hal::cpu::trap` 属性宏）
- **`task/mod.rs`**：`Thread` 结构体新增 `kretprobe_stack` 字段（per-thread）
- **`lib.rs`**：注册 `kprobe` 模块
- **`Cargo.toml`**：添加 `kprobe = "0.5"` 依赖
- **`mm/access.rs`**：`flush_tlb_range` 改为 `pub`，供 kprobe 模块调用
- **`entry.rs`**：内核启动时调用 kprobe selftest（loongarch64 跳过）

## 关键设计

- **SMP 安全**：使用 `stop_machine` 机制确保断点插入的原子性
- **Per-thread kretprobe_stack**：与 Linux per-task 语义一致
- **条件编译**：`feature = "kprobe"` 默认启用，可通过 `--no-default-features` 禁用
- **四架构统一**：x86_64（16 GPR + RIP/RFLAGS/RSP/CS/SS）、riscv64（32 整数 + SEPC/SSTATUS）、aarch64（X0-X30 + ELR/SPSR）、loongarch64（32 GPR + ERA/PRMD）

## 验证

- `cargo xtask clippy --package starry-kernel`：全部 feature 配置通过
- `cargo xtask starry build --arch x86_64 / riscv64 / aarch64 / loongarch64`：编译通过
- kprobe + kretprobe selftest 验证

## 关联

- 下游依赖：#848（eBPF）、#849（LKM）、#886、#891（eBPF JIT）