### PR TITLE
chore(ci): update QEMU-LVZ to include lddir/ldpte address fix

### DIFF
--- a/container/Dockerfile.axvisor-lvz
+++ b/container/Dockerfile.axvisor-lvz
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/rcore-os/tgoskits-container:latest
 FROM ${BASE_IMAGE}
 
 # Pin the external source revision so container rebuilds stay reproducible.
-ARG QEMU_LVZ_REPO=https://github.com/numpy1314/QEMU-LVZ
+ARG QEMU_LVZ_REPO=https://github.com/Hengyu-Yu/QEMU-LVZ
 ARG QEMU_LVZ_REF=1d24ba8819fb5eb073dcaf2484e4634bb7b0d78f
 ARG QEMU_TARGET_LIST=loongarch64-softmmu
 

--- a/container/Dockerfile.axvisor-lvz
+++ b/container/Dockerfile.axvisor-lvz
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 # Pin the external source revision so container rebuilds stay reproducible.
 ARG QEMU_LVZ_REPO=https://github.com/numpy1314/QEMU-LVZ
-ARG QEMU_LVZ_REF=f82f6aee0da1cd1ee86e455a799f07057f477dee
+ARG QEMU_LVZ_REF=1d24ba8819fb5eb073dcaf2484e4634bb7b0d78f
 ARG QEMU_TARGET_LIST=loongarch64-softmmu
 
 ENV AXBUILD_QEMU_SYSTEM_LOONGARCH64=/opt/qemu-lvz/bin/qemu-system-loongarch64 \


### PR DESCRIPTION
Pin QEMU-LVZ to commit 1d24ba8 which fixes flag bits corrupting physical address calculation in the lddir/ldpte helpers. This is required for correct LoongArch stage-2 page table walking when table entries have the V (Valid) flag set.