### PR TITLE
fix(rsext4): rmdir returns ENOTEMPTY on non-empty dirs, rename rejects cross-type overwrites

### DIFF
--- a/components/rsext4/src/error/mod.rs
+++ b/components/rsext4/src/error/mod.rs
@@ -66,6 +66,10 @@ impl Ext4Error {
         Self::new(Errno::EBUSY)
     }
 
+    pub const fn not_empty() -> Self {
+        Self::new(Errno::ENOTEMPTY)
+    }
+
     pub const fn no_space() -> Self {
         Self::new(Errno::ENOSPC)
     }

--- a/components/rsext4/src/file/delete.rs
+++ b/components/rsext4/src/file/delete.rs
@@ -554,6 +554,28 @@ pub fn delete_dir<B: BlockDevice>(
     Ok(())
 }
 
+/// Check whether a directory inode is empty (contains only `.` and `..`).
+///
+/// Returns `Ok(true)` if the directory has no real children, `Ok(false)` otherwise.
+pub fn is_dir_empty<B: BlockDevice>(
+    fs: &mut Ext4FileSystem,
+    block_dev: &mut Jbd2Dev<B>,
+    inode: &mut Ext4Inode,
+) -> Ext4Result<bool> {
+    let dir_blocks = resolve_inode_block_allextend(fs, block_dev, inode)?;
+    for &phys in dir_blocks.values() {
+        let cached = fs.datablock_cache.get_or_load(block_dev, phys)?;
+        let data = &cached.data[..BLOCK_SIZE];
+        let iter = DirEntryIterator::new(data);
+        for (entry, _) in iter {
+            if !entry.is_dot() && !entry.is_dotdot() {
+                return Ok(false);
+            }
+        }
+    }
+    Ok(true)
+}
+
 /// Remove a non-directory inode from its parent directory.
 pub fn delete_file<B: BlockDevice>(
     fs: &mut Ext4FileSystem,

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -32,7 +32,7 @@ mod rename;
 
 pub use blocks::build_file_block_mapping_with_inode_num;
 pub use create::{create_symbol_link, mkfile};
-pub use delete::{delete_dir, delete_file, unlink};
+pub use delete::{delete_dir, delete_file, is_dir_empty, unlink};
 pub use io::{read_file, truncate, write_file, write_inode_data};
 pub use link::link;
 pub use rename::{mv, rename};

--- a/components/rsext4/src/file/rename.rs
+++ b/components/rsext4/src/file/rename.rs
@@ -1,11 +1,21 @@
 use super::{
     delete::{
-        delete_dir, delete_file, find_named_entry_in_parent, remove_inodeentry_from_parentdir,
+        delete_dir, delete_file, find_named_entry_in_parent, is_dir_empty,
+        remove_inodeentry_from_parentdir,
     },
     *,
 };
 
+// TODO: RENAME_EXCHANGE — atomic swap of src and dst
+// TODO: RENAME_NOREPLACE — EEXIST if dst exists
+
 /// Renames or replaces a file-system entry.
+///
+/// When the destination already exists, POSIX requires type cross-checks:
+/// - rename(file, dir)  → ENOTDIR
+/// - rename(dir, file)  → EISDIR
+/// - rename(dir, dir)   → ENOTEMPTY if dst is non-empty
+/// - rename(file, file) → overwrite
 pub fn rename<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
@@ -15,11 +25,28 @@ pub fn rename<B: BlockDevice>(
     let old_norm = split_paren_child_and_tranlatevalid(old_path);
     let new_norm = split_paren_child_and_tranlatevalid(new_path);
 
+    // Resolve source type for cross-type checks.
+    let src_is_dir = get_inode_with_num(fs, device, &old_norm)?.is_some_and(|(_, i)| i.is_dir());
+
     // Replace existing destination entries before moving the source entry.
-    if let Some((_ino, inod)) = get_inode_with_num(fs, device, &new_norm).ok().flatten() {
-        if inod.is_dir() {
+    if let Some((_ino, dst_inode)) = get_inode_with_num(fs, device, &new_norm)? {
+        if dst_inode.is_dir() {
+            if !src_is_dir {
+                // rename file → dir: not allowed
+                return Err(Ext4Error::not_dir());
+            }
+            // rename dir → dir: destination must be empty
+            let mut dir_inode = dst_inode; // Ext4Inode is Copy
+            if !is_dir_empty(fs, device, &mut dir_inode)? {
+                return Err(Ext4Error::not_empty());
+            }
             delete_dir(fs, device, new_path)?;
         } else {
+            // dst is a file
+            if src_is_dir {
+                // rename dir → file: not allowed
+                return Err(Ext4Error::is_dir());
+            }
             delete_file(fs, device, new_path)?;
         }
     }

--- a/components/rsext4/src/lib.rs
+++ b/components/rsext4/src/lib.rs
@@ -29,8 +29,8 @@ pub use disknode::{Ext4TimeSpec, Ext4Timestamp};
 pub use error::{Errno, Ext4Error, Ext4Result};
 pub use ext4::{Ext4FileSystem, find_file, mkfs, mount, umount};
 pub use file::{
-    create_symbol_link, delete_dir, delete_file, link, mkfile, mv, read_file, rename, truncate,
-    unlink, write_file, write_inode_data,
+    create_symbol_link, delete_dir, delete_file, is_dir_empty, link, mkfile, mv, read_file, rename,
+    truncate, unlink, write_file, write_inode_data,
 };
 pub use metadata::{chmod, chown, set_flags, set_project, utimens};
 

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
@@ -573,8 +573,12 @@ impl DirNodeOps for Inode {
             if inode_info.is_none() {
                 return Err(VfsError::NotFound);
             }
-            let (_, inode) = inode_info.unwrap();
+            let (_ino, inode) = inode_info.unwrap();
             if inode.is_dir() {
+                let mut dir_inode = inode; // Ext4Inode is Copy
+                if !rsext4::is_dir_empty(fs, dev, &mut dir_inode).map_err(into_vfs_err)? {
+                    return Err(VfsError::DirectoryNotEmpty);
+                }
                 rsext4::delete_dir(fs, dev, &path).map_err(into_vfs_err)?;
             } else {
                 rsext4::unlink(fs, dev, &path).map_err(into_vfs_err)?;

--- a/os/arceos/modules/axfs/src/fs/ext4fs.rs
+++ b/os/arceos/modules/axfs/src/fs/ext4fs.rs
@@ -29,7 +29,7 @@ use rsext4::{
     api::{OpenFile, fs_mount, lseek, open, read_at},
     dir::{get_inode_with_num, mkdir},
     entries::classic_dir::list_entries,
-    file::{delete_dir, mkfile, mv, truncate, unlink, write_file},
+    file::{delete_dir, is_dir_empty, mkfile, mv, truncate, unlink, write_file},
     loopfile::resolve_inode_block_allextend,
 };
 use spin::Mutex;
@@ -268,17 +268,29 @@ impl VfsNodeOps for FileWrapper {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
                 if inode.is_dir() {
-                    let _ = delete_dir(&mut fs, &mut inner, &fpath);
+                    let mut dir_inode = inode;
+                    if !is_dir_empty(&mut fs, &mut inner, &mut dir_inode)
+                        .map_err(|_| VfsError::Io)?
+                    {
+                        return Err(VfsError::DirectoryNotEmpty);
+                    }
+                    delete_dir(&mut fs, &mut inner, &fpath).map_err(|_| VfsError::Io)?;
                 } else {
-                    let _ = unlink(&mut fs, &mut inner, &fpath);
+                    unlink(&mut fs, &mut inner, &fpath).map_err(|_| VfsError::Io)?;
                 }
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
                 if inode.is_dir() {
-                    let _ = delete_dir(&mut fs, &mut inner, &fpath);
+                    let mut dir_inode = inode;
+                    if !is_dir_empty(&mut fs, &mut inner, &mut dir_inode)
+                        .map_err(|_| VfsError::Io)?
+                    {
+                        return Err(VfsError::DirectoryNotEmpty);
+                    }
+                    delete_dir(&mut fs, &mut inner, &fpath).map_err(|_| VfsError::Io)?;
                 } else {
-                    let _ = unlink(&mut fs, &mut inner, &fpath);
+                    unlink(&mut fs, &mut inner, &fpath).map_err(|_| VfsError::Io)?;
                 }
             }
         }

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-ext4-dir-ops C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+add_executable(bug-ext4-dir-ops src/main.c)
+target_compile_options(bug-ext4-dir-ops PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-ext4-dir-ops RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/c/src/main.c
@@ -1,4 +1,4 @@
-/*
+/*！
  * bug-ext4-dir-ops.c
  *
  * Verifies POSIX rmdir() and rename() semantics on ext4 (rsext4):

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/c/src/main.c
@@ -1,0 +1,626 @@
+/*
+ * bug-ext4-dir-ops.c
+ *
+ * Verifies POSIX rmdir() and rename() semantics on ext4 (rsext4):
+ *
+ *   rmdir:
+ *     1. rmdir(non_empty_dir) == ENOTEMPTY  -- must not recursively delete
+ *     2. rmdir(empty_dir)     == 0          -- must succeed
+ *
+ *   rename (target already exists):
+ *     3. rename(dir, non_empty_dir) == ENOTEMPTY  -- no recursive delete
+ *     4. rename(dir, empty_dir)     == 0          -- replace empty dir
+ *     5. rename(file, dir)          == ENOTDIR    -- no cross-type overwrite
+ *     6. rename(dir, file)          == EISDIR     -- no cross-type overwrite
+ *     7. rename(file, file)         == 0          -- overwrite file
+ *
+ * Previous rmdir bug: DirNodeOps::unlink called rsext4::delete_dir()
+ * (recursive rm -rf semantics) instead of checking emptiness first.
+ *
+ * Previous rename bug: rename() called delete_dir() on non-empty directory
+ * targets (same recursive-delete issue), and lacked type cross-checks so
+ * file-over-dir and dir-over-file overwrites silently destroyed data.
+ *
+ * Test path must be on ext4 root filesystem (/root), not /tmp (tmpfs),
+ * because tmpfs correctly returns ENOTEMPTY and would mask the rsext4 bug.
+ */
+
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+static int bug_count;
+
+#define CHECK(cond, msg)                                                \
+    do {                                                                \
+        if (cond) {                                                     \
+            printf("  [OK]   %s\n", (msg));                            \
+            passed++;                                                   \
+        } else {                                                        \
+            printf("  [FAIL] %s (errno=%d %s)\n",                      \
+                   (msg), errno, strerror(errno));                      \
+            failed++;                                                   \
+        }                                                               \
+    } while (0)
+
+/*
+ * Manual recursive removal — returns 0 on success, -1 on any failure.
+ * Unlike system("rm -rf"), this propagates errors so we can detect
+ * if the bug corrupts the filesystem during cleanup.
+ */
+static int manual_rmdir_recursive(const char *path)
+{
+    DIR *d = opendir(path);
+    if (!d)
+        return -1;
+
+    struct dirent *ent;
+    char child[512];
+    int ret = 0;
+
+    while ((ent = readdir(d)) != NULL) {
+        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+            continue;
+        snprintf(child, sizeof(child), "%s/%s", path, ent->d_name);
+        if (ent->d_type == DT_DIR) {
+            if (manual_rmdir_recursive(child) != 0)
+                ret = -1;
+        } else {
+            if (unlink(child) != 0)
+                ret = -1;
+        }
+    }
+    closedir(d);
+
+    if (rmdir(path) != 0)
+        ret = -1;
+    return ret;
+}
+
+/*
+ * Remove a file or directory tree at path, ignoring errors.
+ * Used for cleanup between test scenarios where the filesystem
+ * state may be corrupted by a bug.
+ */
+static void force_remove(const char *path)
+{
+    struct stat st;
+    if (stat(path, &st) != 0)
+        return;
+    if (S_ISDIR(st.st_mode))
+        manual_rmdir_recursive(path);
+    else
+        unlink(path);
+}
+
+/*
+ * Try rmdir on a non-empty directory and verify ENOTEMPTY + no cascade.
+ * Returns 1 if bug detected, 0 if correct behavior.
+ */
+static int test_rmdir_nonempty(const char *label, const char *dir_path,
+                               const char *parent_dir, const char *sibling_path)
+{
+    printf("\n--- rmdir(non-empty): %s ---\n", label);
+    printf("  target:   %s\n", dir_path);
+    printf("  parent:   %s\n", parent_dir);
+    printf("  sibling:  %s\n", sibling_path);
+
+    /* Verify pre-conditions */
+    CHECK(access(dir_path, F_OK) == 0, "target exists before rmdir");
+    CHECK(access(sibling_path, F_OK) == 0, "sibling exists before rmdir");
+
+    errno = 0;
+    int rc = rmdir(dir_path);
+
+    if (rc == 0) {
+        printf("  [BUG]   rmdir succeeded on non-empty dir — recursive delete!\n");
+        bug_count++;
+        failed++;
+
+        /* Check cascade damage */
+        if (access(dir_path, F_OK) != 0)
+            printf("  [BUG]   target/ was deleted\n");
+        if (access(sibling_path, F_OK) != 0) {
+            printf("  [BUG]   sibling was destroyed (cascading)\n");
+            bug_count++;
+        }
+        if (access(parent_dir, F_OK) != 0) {
+            printf("  [BUG]   parent/ was destroyed (cascading)\n");
+            bug_count++;
+        }
+        return 1; /* bug detected */
+    }
+
+    if (errno == ENOTEMPTY || errno == EEXIST) {
+        printf("  [OK]   returned ENOTEMPTY (rc=%d, errno=%d)\n", rc, errno);
+        passed++;
+    } else {
+        printf("  [FAIL] unexpected errno=%d (%s)\n", errno, strerror(errno));
+        failed++;
+    }
+
+    /* Verify no cascade damage */
+    CHECK(access(dir_path, F_OK) == 0, "target still exists");
+    CHECK(access(sibling_path, F_OK) == 0, "sibling survived");
+    CHECK(access(parent_dir, F_OK) == 0, "parent survived");
+    return 0;
+}
+
+/* ================================================================
+ * RENAME TESTS
+ *
+ * POSIX rename() semantics when destination already exists:
+ *   - rename(dir,  non_empty_dir) → ENOTEMPTY  (no recursive delete)
+ *   - rename(dir,  empty_dir)     → 0          (replace empty dir)
+ *   - rename(file, dir)           → ENOTDIR    (type mismatch)
+ *   - rename(dir,  file)          → EISDIR     (type mismatch)
+ *   - rename(file, file)          → 0          (overwrite)
+ * ================================================================ */
+
+/*
+ * Test: rename dir → non-empty dir.
+ * Expect: ENOTEMPTY, both directory trees intact.
+ * Bug: rsext4 delete_dir() recursively destroys the target tree.
+ */
+static void test_rename_dir_to_nonempty_dir(const char *base)
+{
+    printf("\n--- rename(dir → non-empty dir) ---\n");
+
+    char src_dir[256], src_file[256];
+    char dst_dir[256], dst_file[256];
+
+    snprintf(src_dir, sizeof(src_dir), "%s/rn_src_dir", base);
+    snprintf(src_file, sizeof(src_file), "%s/rn_src_dir/data.txt", base);
+    snprintf(dst_dir, sizeof(dst_dir), "%s/rn_dst_dir", base);
+    snprintf(dst_file, sizeof(dst_file), "%s/rn_dst_dir/keep.txt", base);
+
+    CHECK(mkdir(src_dir, 0755) == 0, "mkdir src_dir");
+    CHECK(mkdir(dst_dir, 0755) == 0, "mkdir dst_dir");
+
+    FILE *f = fopen(src_file, "w");
+    CHECK(f != NULL, "create src_dir/data.txt");
+    if (f) { fprintf(f, "source\n"); fclose(f); }
+
+    f = fopen(dst_file, "w");
+    CHECK(f != NULL, "create dst_dir/keep.txt");
+    if (f) { fprintf(f, "target\n"); fclose(f); }
+
+    errno = 0;
+    int rc = rename(src_dir, dst_dir);
+
+    if (rc == 0) {
+        printf("  [BUG]   rename succeeded — recursive delete of non-empty dir!\n");
+        bug_count++;
+        failed++;
+        if (access(dst_file, F_OK) != 0)
+            printf("  [BUG]   dst_dir/keep.txt was destroyed\n");
+        if (access(src_dir, F_OK) != 0)
+            printf("  [BUG]   src_dir was removed\n");
+    } else if (errno == ENOTEMPTY || errno == EEXIST) {
+        printf("  [OK]   returned ENOTEMPTY (rc=%d, errno=%d)\n", rc, errno);
+        passed++;
+        CHECK(access(src_dir, F_OK) == 0, "src_dir still exists");
+        CHECK(access(src_file, F_OK) == 0, "src_dir/data.txt intact");
+        CHECK(access(dst_dir, F_OK) == 0, "dst_dir still exists");
+        CHECK(access(dst_file, F_OK) == 0, "dst_dir/keep.txt intact");
+    } else {
+        printf("  [FAIL] unexpected errno=%d (%s)\n", errno, strerror(errno));
+        failed++;
+    }
+
+    force_remove(src_dir);
+    force_remove(dst_dir);
+}
+
+/*
+ * Test: rename dir → empty dir.
+ * Expect: success, old empty dir replaced by source dir.
+ */
+static void test_rename_dir_to_empty_dir(const char *base)
+{
+    printf("\n--- rename(dir → empty dir) ---\n");
+
+    char src_dir[256], src_file[256];
+    char dst_dir[256];
+    char moved_file[256];
+
+    snprintf(src_dir, sizeof(src_dir), "%s/rn_src2", base);
+    snprintf(src_file, sizeof(src_file), "%s/rn_src2/moved.txt", base);
+    snprintf(dst_dir, sizeof(dst_dir), "%s/rn_dst2", base);
+    snprintf(moved_file, sizeof(moved_file), "%s/rn_dst2/moved.txt", base);
+
+    CHECK(mkdir(src_dir, 0755) == 0, "mkdir src_dir");
+    CHECK(mkdir(dst_dir, 0755) == 0, "mkdir dst_dir (empty)");
+
+    FILE *f = fopen(src_file, "w");
+    CHECK(f != NULL, "create src_dir/moved.txt");
+    if (f) { fprintf(f, "payload\n"); fclose(f); }
+
+    errno = 0;
+    int rc = rename(src_dir, dst_dir);
+
+    CHECK(rc == 0, "rename(dir, empty_dir) succeeded");
+    if (rc == 0) {
+        CHECK(access(src_dir, F_OK) != 0, "src_dir removed");
+        CHECK(access(moved_file, F_OK) == 0, "moved.txt accessible at new path");
+    }
+
+    force_remove(dst_dir);
+    force_remove(src_dir);
+}
+
+/*
+ * Test: rename file → directory.
+ * Expect: ENOTDIR, both source file and target dir intact.
+ * Bug: rsext4 rename() deletes the target dir and moves file into its place.
+ */
+static void test_rename_file_to_dir(const char *base)
+{
+    printf("\n--- rename(file → dir) ---\n");
+
+    char src_file[256], dst_dir[256], dst_child[256];
+
+    snprintf(src_file, sizeof(src_file), "%s/rn_file.txt", base);
+    snprintf(dst_dir, sizeof(dst_dir), "%s/rn_dir_target", base);
+    snprintf(dst_child, sizeof(dst_child), "%s/rn_dir_target/child.txt", base);
+
+    FILE *f = fopen(src_file, "w");
+    CHECK(f != NULL, "create source file");
+    if (f) { fprintf(f, "file\n"); fclose(f); }
+
+    CHECK(mkdir(dst_dir, 0755) == 0, "mkdir target dir");
+    f = fopen(dst_child, "w");
+    CHECK(f != NULL, "create target dir/child.txt");
+    if (f) { fprintf(f, "child\n"); fclose(f); }
+
+    errno = 0;
+    int rc = rename(src_file, dst_dir);
+
+    if (rc == 0) {
+        printf("  [BUG]   rename(file, dir) succeeded — dir destroyed!\n");
+        bug_count++;
+        failed++;
+        if (access(dst_child, F_OK) != 0)
+            printf("  [BUG]   target dir contents destroyed\n");
+    } else if (errno == ENOTDIR || errno == EISDIR) {
+        printf("  [OK]   returned ENOTDIR/EISDIR (rc=%d, errno=%d)\n", rc, errno);
+        passed++;
+        CHECK(access(src_file, F_OK) == 0, "source file still exists");
+        CHECK(access(dst_dir, F_OK) == 0, "target dir still exists");
+        CHECK(access(dst_child, F_OK) == 0, "target dir contents intact");
+    } else {
+        printf("  [FAIL] unexpected errno=%d (%s)\n", errno, strerror(errno));
+        failed++;
+    }
+
+    force_remove(dst_dir);
+    force_remove(src_file);
+}
+
+/*
+ * Test: rename directory → file.
+ * Expect: EISDIR, both source dir and target file intact.
+ * Bug: rsext4 rename() deletes the target file and moves dir into its place.
+ */
+static void test_rename_dir_to_file(const char *base)
+{
+    printf("\n--- rename(dir → file) ---\n");
+
+    char src_dir[256], src_child[256], dst_file[256];
+
+    snprintf(src_dir, sizeof(src_dir), "%s/rn_dir_src", base);
+    snprintf(src_child, sizeof(src_child), "%s/rn_dir_src/inside.txt", base);
+    snprintf(dst_file, sizeof(dst_file), "%s/rn_file_target.txt", base);
+
+    CHECK(mkdir(src_dir, 0755) == 0, "mkdir source dir");
+
+    FILE *f = fopen(src_child, "w");
+    CHECK(f != NULL, "create source dir/inside.txt");
+    if (f) { fprintf(f, "inside\n"); fclose(f); }
+
+    f = fopen(dst_file, "w");
+    CHECK(f != NULL, "create target file");
+    if (f) { fprintf(f, "target\n"); fclose(f); }
+
+    errno = 0;
+    int rc = rename(src_dir, dst_file);
+
+    if (rc == 0) {
+        printf("  [BUG]   rename(dir, file) succeeded — dir overwrote file!\n");
+        bug_count++;
+        failed++;
+    } else if (errno == EISDIR || errno == ENOTDIR) {
+        printf("  [OK]   returned EISDIR (rc=%d, errno=%d)\n", rc, errno);
+        passed++;
+        CHECK(access(src_dir, F_OK) == 0, "source dir still exists");
+        CHECK(access(src_child, F_OK) == 0, "source dir contents intact");
+        CHECK(access(dst_file, F_OK) == 0, "target file still exists");
+    } else {
+        printf("  [FAIL] unexpected errno=%d (%s)\n", errno, strerror(errno));
+        failed++;
+    }
+
+    force_remove(src_dir);
+    force_remove(dst_file);
+}
+
+/*
+ * Test: rename file → file (overwrite).
+ * Expect: success, old file replaced by source file.
+ */
+static void test_rename_file_to_file(const char *base)
+{
+    printf("\n--- rename(file → file) ---\n");
+
+    char src[256], dst[256];
+
+    snprintf(src, sizeof(src), "%s/rn_f2f_src.txt", base);
+    snprintf(dst, sizeof(dst), "%s/rn_f2f_dst.txt", base);
+
+    FILE *f = fopen(src, "w");
+    CHECK(f != NULL, "create source file");
+    if (f) { fprintf(f, "new-content\n"); fclose(f); }
+
+    f = fopen(dst, "w");
+    CHECK(f != NULL, "create destination file");
+    if (f) { fprintf(f, "old-content\n"); fclose(f); }
+
+    errno = 0;
+    int rc = rename(src, dst);
+
+    CHECK(rc == 0, "rename(file, file) succeeded");
+    if (rc == 0) {
+        CHECK(access(src, F_OK) != 0, "source removed");
+        CHECK(access(dst, F_OK) == 0, "destination exists");
+
+        /* Verify content was overwritten */
+        f = fopen(dst, "r");
+        if (f) {
+            char buf[64] = {0};
+            fread(buf, 1, sizeof(buf) - 1, f);
+            fclose(f);
+            CHECK(strstr(buf, "new-content") != NULL, "content is from source file");
+        }
+    }
+
+    force_remove(src);
+    force_remove(dst);
+}
+
+/* ================================================================
+ * MAIN
+ * ================================================================ */
+
+int main(void)
+{
+    const char *base = "/root/bug-ext4-dir-ops-test";
+    char parent[256], sibling[256], empty_dir[256];
+
+    printf("=== bug-ext4-dir-ops ===\n");
+
+    /* Cleanup from previous runs */
+    manual_rmdir_recursive(base);
+
+    /* Create base structure */
+    snprintf(parent, sizeof(parent), "%s/parent", base);
+    snprintf(sibling, sizeof(sibling), "%s/parent/sibling.txt", base);
+    snprintf(empty_dir, sizeof(empty_dir), "%s/parent/empty", base);
+
+    CHECK(mkdir(base, 0755) == 0, "mkdir base");
+    CHECK(mkdir(parent, 0755) == 0, "mkdir parent");
+
+    FILE *f = fopen(sibling, "w");
+    CHECK(f != NULL, "create sibling.txt");
+    if (f) { fprintf(f, "sibling\n"); fclose(f); }
+
+    CHECK(mkdir(empty_dir, 0755) == 0, "mkdir empty (control group)");
+
+    /* ==============================================================
+     * RMDR TESTS
+     * ============================================================== */
+
+    /*
+     * === Test 1: dir with files + subdirectory (mixed) ===
+     *
+     *   parent/
+     *     target_mixed/
+     *       file1.txt
+     *       file2.txt
+     *       sub/
+     *         deep.txt
+     *     sibling.txt
+     */
+    {
+        char tdir[256], sub[256], f1[256], f2[256], deep[256];
+        snprintf(tdir, sizeof(tdir), "%s/parent/target_mixed", base);
+        snprintf(sub, sizeof(sub), "%s/parent/target_mixed/sub", base);
+        snprintf(f1, sizeof(f1), "%s/parent/target_mixed/file1.txt", base);
+        snprintf(f2, sizeof(f2), "%s/parent/target_mixed/file2.txt", base);
+        snprintf(deep, sizeof(deep), "%s/parent/target_mixed/sub/deep.txt", base);
+
+        CHECK(mkdir(tdir, 0755) == 0, "mkdir target_mixed");
+        CHECK(mkdir(sub, 0755) == 0, "mkdir target_mixed/sub");
+
+        f = fopen(f1, "w");
+        CHECK(f != NULL, "create file1.txt");
+        if (f) { fprintf(f, "hello\n"); fclose(f); }
+        f = fopen(f2, "w");
+        CHECK(f != NULL, "create file2.txt");
+        if (f) { fprintf(f, "world\n"); fclose(f); }
+        f = fopen(deep, "w");
+        CHECK(f != NULL, "create sub/deep.txt");
+        if (f) { fprintf(f, "deep\n"); fclose(f); }
+
+        test_rmdir_nonempty("mixed (files+subdir)", tdir, parent, sibling);
+
+        /* Verify deep content survived */
+        CHECK(access(deep, F_OK) == 0, "sub/deep.txt intact");
+
+        /* Cleanup for next test */
+        manual_rmdir_recursive(tdir);
+    }
+
+    /*
+     * === Test 2: dir with files only (no subdirectories) ===
+     *
+     *   parent/
+     *     target_files/
+     *       a.txt
+     *       b.txt
+     *       c.txt
+     *     sibling.txt
+     */
+    {
+        char tdir[256], fa[256], fb[256], fc[256];
+        snprintf(tdir, sizeof(tdir), "%s/parent/target_files", base);
+        snprintf(fa, sizeof(fa), "%s/parent/target_files/a.txt", base);
+        snprintf(fb, sizeof(fb), "%s/parent/target_files/b.txt", base);
+        snprintf(fc, sizeof(fc), "%s/parent/target_files/c.txt", base);
+
+        CHECK(mkdir(tdir, 0755) == 0, "mkdir target_files");
+
+        f = fopen(fa, "w");
+        CHECK(f != NULL, "create a.txt");
+        if (f) { fprintf(f, "a\n"); fclose(f); }
+        f = fopen(fb, "w");
+        CHECK(f != NULL, "create b.txt");
+        if (f) { fprintf(f, "b\n"); fclose(f); }
+        f = fopen(fc, "w");
+        CHECK(f != NULL, "create c.txt");
+        if (f) { fprintf(f, "c\n"); fclose(f); }
+
+        test_rmdir_nonempty("files only", tdir, parent, sibling);
+        CHECK(access(fa, F_OK) == 0, "a.txt intact");
+        CHECK(access(fb, F_OK) == 0, "b.txt intact");
+        CHECK(access(fc, F_OK) == 0, "c.txt intact");
+
+        manual_rmdir_recursive(tdir);
+    }
+
+    /*
+     * === Test 3: dir with subdirectories only (no files) ===
+     *
+     *   parent/
+     *     target_subdirs/
+     *       child1/
+     *         dummy.txt
+     *       child2/
+     *         dummy.txt
+     *     sibling.txt
+     */
+    {
+        char tdir[256], c1[256], c2[256], d1[256], d2[256];
+        snprintf(tdir, sizeof(tdir), "%s/parent/target_subdirs", base);
+        snprintf(c1, sizeof(c1), "%s/parent/target_subdirs/child1", base);
+        snprintf(c2, sizeof(c2), "%s/parent/target_subdirs/child2", base);
+        snprintf(d1, sizeof(d1), "%s/parent/target_subdirs/child1/dummy.txt", base);
+        snprintf(d2, sizeof(d2), "%s/parent/target_subdirs/child2/dummy.txt", base);
+
+        CHECK(mkdir(tdir, 0755) == 0, "mkdir target_subdirs");
+        CHECK(mkdir(c1, 0755) == 0, "mkdir child1");
+        CHECK(mkdir(c2, 0755) == 0, "mkdir child2");
+
+        f = fopen(d1, "w");
+        CHECK(f != NULL, "create child1/dummy.txt");
+        if (f) { fprintf(f, "d1\n"); fclose(f); }
+        f = fopen(d2, "w");
+        CHECK(f != NULL, "create child2/dummy.txt");
+        if (f) { fprintf(f, "d2\n"); fclose(f); }
+
+        test_rmdir_nonempty("subdirs only", tdir, parent, sibling);
+        CHECK(access(d1, F_OK) == 0, "child1/dummy.txt intact");
+        CHECK(access(d2, F_OK) == 0, "child2/dummy.txt intact");
+
+        manual_rmdir_recursive(tdir);
+    }
+
+    /*
+     * === Test 4: rmdir on parent (which contains sibling.txt) ===
+     *
+     * This tests cascade upward: if delete_dir is truly recursive,
+     * attempting to rmdir parent/ should destroy base/ as well.
+     */
+    {
+        printf("\n--- rmdir(non-empty): parent dir ---\n");
+        CHECK(access(parent, F_OK) == 0, "parent exists");
+        CHECK(access(sibling, F_OK) == 0, "sibling exists");
+
+        errno = 0;
+        int rc = rmdir(parent);
+
+        if (rc == 0) {
+            printf("  [BUG]   rmdir(parent) succeeded — cascade to parent!\n");
+            bug_count++;
+            failed++;
+            if (access(base, F_OK) != 0) {
+                printf("  [BUG]   base/ was also destroyed (cascade upward)\n");
+                bug_count++;
+            }
+        } else if (errno == ENOTEMPTY || errno == EEXIST) {
+            printf("  [OK]   rmdir(parent) correctly returned ENOTEMPTY\n");
+            passed++;
+        } else {
+            printf("  [FAIL] unexpected errno=%d (%s)\n", errno, strerror(errno));
+            failed++;
+        }
+
+        CHECK(access(parent, F_OK) == 0, "parent still exists");
+        CHECK(access(sibling, F_OK) == 0, "sibling still exists");
+        CHECK(access(base, F_OK) == 0, "base still exists");
+    }
+
+    /*
+     * === Test 5: rmdir on empty directory (control group) ===
+     */
+    printf("\n--- rmdir(empty dir) ---\n");
+    {
+        int rc = rmdir(empty_dir);
+        CHECK(rc == 0, "rmdir(empty) succeeded");
+        CHECK(access(empty_dir, F_OK) != 0, "empty dir removed");
+    }
+
+    /*
+     * === Test 6: repeated rmdir on same path ===
+     *
+     * After successful rmdir, calling again should return ENOENT.
+     * If the bug corrupts internal state, this might crash or return
+     * unexpected errors.
+     */
+    printf("\n--- repeated rmdir on removed dir ---\n");
+    {
+        errno = 0;
+        int rc = rmdir(empty_dir);
+        CHECK(rc != 0, "second rmdir(empty) fails");
+        CHECK(errno == ENOENT, "second rmdir returns ENOENT");
+    }
+
+    /* ==============================================================
+     * RENAME TESTS
+     * ============================================================== */
+
+    test_rename_dir_to_nonempty_dir(base);
+    test_rename_dir_to_empty_dir(base);
+    test_rename_file_to_dir(base);
+    test_rename_dir_to_file(base);
+    test_rename_file_to_file(base);
+
+    /* Final cleanup */
+    manual_rmdir_recursive(base);
+
+    /* === Summary === */
+    printf("\n=== result: %d passed, %d failed, %d bugs ===\n",
+           passed, failed, bug_count);
+    if (failed == 0)
+        printf("TEST PASSED\n");
+    else
+        printf("TEST FAILED\n");
+
+    return failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-aarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "cortex-a72",
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-ext4-dir-ops"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+to_bin = true
+uefi = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-ext4-dir-ops"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-ext4-dir-ops"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-x86_64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-machine",
+    "q35",
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/bug-ext4-dir-ops"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b']
+timeout = 60


### PR DESCRIPTION
我在移植和测试pip应用时，发现严重错误。

pip uninstall时，竟然直接把我的/root文件夹删掉了。

追踪后发现，他有一个rmdir操作，如果文件夹是空，就删除，否则不删除。

但是在starryos里，rmdir会直接递归删除所有的文件。根源是系统会调用delete_dir函数，这个函数是递归删除文件树。（等价rm -rf）这是linux绝不允许的。（limux的标准应该是内核不能有递归删除功能，所有递归删除应该在用户态。因为直接删除所有文件还没提醒非常不安全）然后我也发现rename里也有同样的问题，也会直接递归删除整个文件夹。所以一并进行修复。并且增加一组测试样例。

考虑到维护性，可能有些软件甚至还依赖这个特性，所以我选择不重构delete_dir代码。而是在调用曾增加一个守卫来保证文件安全。然后rename一并增加了几个交叉检查。

一并检查了rename的完整性，但是注意到有两个flag没有支持。但是工作量较大，我这里加上两个todo标签，分别是RENAME_EXCHANGE，RENAME_NOREPLACE，对应”原子交换“，和”不覆盖“特殊操作。（RENAME_WHITEOUT 是 overlayfs 内部专用，暂不考虑）。

## 问题

`rmdir()` 删除非空 ext4 目录时，会递归删除整个目录树，而不是返回 `ENOTEMPTY`。`rename()` 在目标已存在时，会静默覆盖文件/目录，不做类型交叉检查。

**根因：** `rsext4::delete_dir` 是递归树删除器（`rm -rf` 语义）。POSIX 要求 `rmdir()` 只能删除空目录，但 `DirNodeOps::unlink` 无条件调用 `delete_dir`，没有检查目录是否为空。同理，`rename()` 在删除目标前也没有检查源/目标的类型兼容性。

**影响：** `pip uninstall` → `shutil.rmtree()` → `os.rmdir()` 对非空目录调用时，会递归销毁整个目录树，导致 venv 和 pip 操作全部失败。

## 修复

### rmdir — 添加 `is_dir_empty` 守卫

新增 `is_dir_empty()` 函数，通过 `DirEntryIterator` 扫描目录数据块，跳过 `.` 和 `..`。在新 VFS（`axfs-ng`）和旧 VFS（`axfs/ext4fs`）两条路径中，调用 `delete_dir` 前先检查目录是否为空。非空目录现在正确返回 `ENOTEMPTY`。

同时修复旧 VFS 中的错误静默吞掉问题：`delete_dir` 和 `unlink` 的返回值之前被 `let _ =` 忽略，现在通过 `.map_err()` 正确传播。

### rename — 类型交叉检查

在删除目标之前解析源 inode 类型，强制执行 POSIX 语义：
- `rename(file, dir)` → `ENOTDIR`
- `rename(dir, file)` → `EISDIR`
- `rename(dir, 非空dir)` → `ENOTEMPTY`
- `rename(file, file)` → 覆盖（不变）

同时修复错误传播：`get_inode_with_num` 的错误之前通过 `.ok().flatten()` 被静默吞掉，现在通过 `?` 正确传播。

## 修改文件

| 文件 | 改动 |
|------|------|
| `components/rsext4/src/error/mod.rs` | 添加 `Ext4Error::not_empty()` |
| `components/rsext4/src/file/delete.rs` | 新增 `is_dir_empty()` |
| `components/rsext4/src/file/mod.rs` | 导出 `is_dir_empty` |
| `components/rsext4/src/lib.rs` | 导出 `is_dir_empty` |
| `components/rsext4/src/file/rename.rs` | 类型交叉检查 + `is_dir_empty` 守卫 |
| `os/arceos/modules/axfs-ng/.../inode.rs` | 新 VFS：守卫 + ENOTEMPTY |
| `os/arceos/modules/axfs/src/fs/ext4fs.rs` | 旧 VFS：守卫 + 错误传播 |
| `test-suit/.../bug-ext4-dir-ops/` | C 测试，87 个断言，4 个架构 |

## POSIX 合规性（修复前 → 修复后）

| 系统调用 | 修复前 | 修复后 | Linux |
|---------|--------|--------|-------|
| `rmdir(空目录)` | 成功 | 成功 | 成功 |
| `rmdir(非空目录)` | 递归删除 | ENOTEMPTY | ENOTEMPTY |
| `rename(file, dir)` | 覆盖目录 | ENOTDIR | ENOTDIR |
| `rename(dir, file)` | 覆盖文件 | EISDIR | EISDIR |
| `rename(dir, 非空dir)` | 递归删除 | ENOTEMPTY | ENOTEMPTY |
| `rename(file, file)` | 成功 | 成功 | 成功 |

## 测试

`bug-ext4-dir-ops` — 6 个 rmdir 场景 + 5 个 rename 场景，每个场景验证 errno、目录树完整性和内容。在 x86_64、aarch64、riscv64、loongarch64 四个平台测试通过：87 passed，0 failed。