### PR TITLE
chore(review-single-pr): document duplicate checks and reviewer assignment

### DIFF
--- a/.claude/skills/review-single-pr/SKILL.md
+++ b/.claude/skills/review-single-pr/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: review-single-pr
-description: Review one specified GitHub pull request in this tgoskits repository. Use when the user names a PR number or URL and asks to review, re-review, compare with Linux/POSIX/RFC/VirtIO semantics, run focused validation, leave Chinese inline review comments, approve, or request changes.
+description: Review one specified GitHub pull request in this tgoskits repository. Use when the user names a PR number or URL and asks to review, re-review, compare with Linux/POSIX/RFC/VirtIO semantics, check duplicate functionality or related open PRs, run focused validation, leave Chinese inline review comments, approve, request changes, or assign reviewers after review.
 ---
 
 # Review Single PR
 
 ## Goal
 
-Perform a focused review of exactly one PR, using an isolated worktree and local validation before submitting a GitHub review. The normal outcome is either `APPROVE` when no blocking issue remains, or `REQUEST_CHANGES` with Chinese inline comments when the PR has correctness, standards, test, or CI coverage problems.
+Perform a focused review of exactly one PR, using an isolated worktree and local validation before submitting a GitHub review. The review must also decide whether the PR duplicates existing base-branch functionality or overlaps with other open PRs. After the review decision is submitted, assign suitable human reviewers from the project reviewer direction table when the PR still needs domain follow-up. The normal outcome is either `APPROVE` when no blocking issue remains, or `REQUEST_CHANGES` with Chinese inline comments when the PR has correctness, standards, duplication, test, or CI coverage problems.
 
-This skill is the authoritative single-PR workflow used by `review-open-prs`: do not scan all open PRs unless needed to check duplicate or superseded fixes.
+This skill is the authoritative single-PR workflow used by `review-open-prs`: do not fully review all open PRs, but always inspect enough related open PR context to classify duplicate, overlapping, superseded, or conflicting work.
 
 ## System Skill Priority
 
@@ -132,18 +132,44 @@ Do not approve changes that are only shaped to satisfy the added tests, such as 
 
 Do not accept "success path" tests that silently skip on unexpected failure, such as returning early when `brk`, `sbrk`, I/O, or socket setup returns `ENOMEM`/`EAGAIN`, unless the test prints an explicit skip marker and the review explains why the environment legitimately cannot require success. Bugfix reproduction tests should fail loudly when the fixed behavior is absent.
 
-Before approving a bugfix PR, check whether the same bug is already fixed on base or in another open PR:
+## Duplicate And Overlap Analysis
+
+This analysis is required for every PR, not only bug fixes. Its purpose is to avoid approving duplicate implementations, stale rework, superseded fixes, or PRs that unknowingly conflict with another open PR.
+
+Build an intent fingerprint before searching:
+
+- PR title, body, linked issue numbers, commit subjects, and author-stated validation.
+- Changed crates, modules, test cases, configs, CI files, and generated assets.
+- Public APIs, syscall names, errno behavior, protocol terms, device types, runner commands, test binary names, and feature flags touched by the patch.
+- The semantic claim being made: new feature, bug fix, test coverage, refactor, config update, CI repair, or dependency/metadata change.
+
+Check current base branch first. Search for equivalent behavior, tests, config entries, public APIs, or previous fixes already present on `origin/<base>`:
 
 ```bash
 git grep -n -E '<relevant symbols|paths|commands>' origin/<base> -- <likely paths>
+git log --oneline --decorate -- <likely paths>
 ```
 
-Use the GitHub MCP/connector to search or list related open PRs first. Fallback only when the connector cannot search the needed PR set:
+If base already has the same behavior or a newer version of it, treat the PR as stale or duplicate unless it clearly adds distinct value. Verify that distinction by reading the relevant base code, not just matching names.
+
+Then check related open PRs. Use the GitHub MCP/connector to search or list candidate PRs before falling back to `gh`. Search with multiple terms derived from the intent fingerprint; do not rely only on the PR title. Useful terms include crate/module names, changed path fragments, syscall or API names, test case names, issue numbers, errno values, protocol/device names, CI job names, and config names.
 
 ```bash
-gh pr list --state open --limit 100 --search '<bug keyword or command>'
+gh pr list --state open --limit 200 --search '<symbol OR path OR issue keyword>'
+gh pr view <related-pr> --json number,title,body,author,baseRefName,headRefName,isDraft,updatedAt,files,commits
 gh pr diff <related-pr> --patch --color=never
+git diff --name-only origin/<base>...origin/pr/<related-pr>
 ```
+
+Inspect each plausible related PR enough to classify it:
+
+- `duplicate`: solves the same problem or adds the same test/API/config behavior with no meaningful distinction.
+- `partial-overlap`: touches the same surface but the changes are complementary, ordered, or separable.
+- `conflict-risk`: likely merge or semantic conflict because both PRs modify the same contract, runner behavior, generated asset, or ABI expectation.
+- `superseded`: another PR or current base implements the same intent more completely or in a better-aligned way.
+- `unrelated-after-inspection`: matched search terms but does not overlap after reading files/diff/intent.
+
+For `partial-overlap` or `conflict-risk`, compare the implementation direction with project semantics and note the expected merge order or follow-up needed. If correctness depends on another PR landing first, do not approve until that dependency is explicit in the PR body or review outcome. For `duplicate` or `superseded`, submit `REQUEST_CHANGES` or leave a neutral project-focused comment explaining which base code or open PR should be preferred and why.
 
 Use `git diff origin/<base>...origin/pr/<pr>` for the PR patch. Use `origin/<base>..origin/pr/<pr>` only when intentionally checking stale-branch effects.
 
@@ -197,7 +223,8 @@ Treat these as blocking unless clearly non-blocking:
 - the implementation is a test-only or fake fix that does not implement the intended behavior;
 - submitted buffers, DMA memory, queue tokens, or IRQ ownership can leak, be freed too early, or cross the wrong abstraction layer;
 - a change silently makes CI hang, time out, or skip the new coverage;
-- the PR duplicates, weakens, or is superseded by a newer base-branch or open-PR fix.
+- the PR duplicates existing base-branch behavior, weakens an existing implementation, conflicts with a related open PR, or is superseded by a newer base-branch or open-PR fix;
+- the review cannot explain how this PR differs from a plausible related open PR after duplicate and overlap analysis.
 
 All GitHub review text, including inline comments, review body, and replies, must be in Chinese, neutral, and project-focused. Each blocking comment should include the concrete problem, the relevant standard/project rule/observed failure, and a suggested fix.
 
@@ -245,6 +272,7 @@ Review body must explain in Chinese:
 - validation commands and results, including exact failure mode for failing tests;
 - when no tests are added, the PR body/commit-message validation claim that was checked, the command actually run, and whether it matched the claim;
 - CI status, including any unrelated failing checks, the evidence for unrelatedness, and the linked tracking issue;
+- duplicate and overlap analysis: base-branch evidence checked, related open PRs inspected, and why the PR is distinct, complementary, duplicate, conflicting, or superseded;
 - for PR-related CI failures, the failing check, failure mode, and expected fix direction;
 - reproduction coverage status for bug fixes;
 - unresolved review conversations that were resolved, and conversations intentionally left open and why;
@@ -258,6 +286,50 @@ Verify final state:
 ```bash
 gh pr view <pr> --json number,reviewDecision,latestReviews
 ```
+
+## Post-Review Reviewer Assignment
+
+After review submission, decide whether the PR still needs human reviewer requests. Do this after the technical review so reviewer choice is based on the actual changed surface, duplicate/overlap findings, validation risk, and remaining follow-up.
+
+Use discussion 594 as the reviewer source of truth. Read the current table directly before assigning because personnel directions may change:
+
+```bash
+gh api graphql \
+  -f query='query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner,name:$repo){ discussion(number:$number){ title body url comments(first:100){nodes{author{login} body createdAt}} } } }' \
+  -F owner=rcore-os -F repo=tgoskits -F number=594
+```
+
+Map PR content to reviewer directions from the "人员方向整理" table:
+
+- StarryOS tests, `test-suit/starryos`, QEMU cases, rootfs/app tests, `apk`, distro behavior, or `axbuild` test flow: prefer reviewers covering `测试`, `发行版/rootfs`, `axbuild`, and the relevant `starry` area.
+- Syscall, filesystem, network, driver, platform, architecture, CI, documentation, and display changes should be mapped to the matching table columns, then cross-checked against changed files and PR body claims.
+- If a PR matches several domains, request one primary reviewer for the highest-risk domain and one secondary reviewer for integration or test coverage. Avoid over-requesting reviewers.
+- Drop the PR author from targets. Preserve existing bot review requests and unrelated existing human reviewer requests unless the user explicitly asks to rebalance them.
+
+For StarryOS normal QEMU app tests like PR 795 (`test-suit/starryos/normal/qemu-smp1/git`, `apk add`, app/rootfs behavior), a good mapping is `测试` + `发行版/rootfs` + `starry`: `@ZCShou` for test/rootfs/axbuild ownership and `@luodeb` for Starry/rootfs experience. Use this as a pattern, not as a hard-coded rule; still inspect the current discussion table and PR contents.
+
+Before writing reviewer requests, check current requested reviewers and permissions:
+
+```bash
+gh api repos/rcore-os/tgoskits/pulls/<pr>/requested_reviewers
+gh api repos/rcore-os/tgoskits/collaborators/<login>/permission
+```
+
+Use the REST requested-reviewers API instead of `gh pr edit`, because `gh pr edit` can fail in this repository while querying deprecated Projects classic fields:
+
+```bash
+printf '%s\n' '{"reviewers":["<login1>","<login2>"]}' |
+  gh api -X POST repos/rcore-os/tgoskits/pulls/<pr>/requested_reviewers --input -
+```
+
+After assigning, re-query `requested_reviewers` and confirm the intended reviewers are present. If GitHub rejects a reviewer, record the exact login and API or permission error; do not silently substitute someone not supported by discussion 594.
+
+In the final user summary, state:
+
+- which reviewer direction columns matched the PR;
+- which reviewers were requested, already present, skipped, or rejected;
+- any permission/API limitation;
+- that only GitHub reviewer metadata was changed, when no code files were edited by the assignment step.
 
 ## Cleanup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - `review-open-prs`: project-local skill at `.claude/skills/review-open-prs/SKILL.md`
 - Use `review-open-prs` when the user wants to audit all open GitHub PRs, review non-self PRs, re-review PRs updated after their last review, use subagents/worktrees for PR review, compare changes with POSIX/Linux/RFC/VirtIO semantics, run local validation, and submit approve or request-changes reviews.
 - `review-single-pr`: project-local skill at `.claude/skills/review-single-pr/SKILL.md`
-- Use `review-single-pr` when the user names one PR number or URL and wants a focused review, re-review, Linux/POSIX/RFC/VirtIO comparison, local validation, Chinese inline review comments, approval, or request-changes submission.
+- Use `review-single-pr` when the user names one PR number or URL and wants a focused review, re-review, duplicate or overlapping open-PR analysis, Linux/POSIX/RFC/VirtIO comparison, local validation, Chinese inline review comments, approval, request-changes submission, or post-review reviewer assignment.
 - `reassign-pr-reviewers`: project-local skill at `.claude/skills/reassign-pr-reviewers/SKILL.md`
 - Use `reassign-pr-reviewers` when the user wants to assign or rebalance GitHub PR reviewers for `rcore-os/tgoskits` from a discussion, ownership matrix, open PR scope, or existing review-request state, including preserving bot requests and handling collaborator permission limits.
 - `board-uboot-fsck-repair`: project-local skill at `.claude/skills/board-uboot-fsck-repair/SKILL.md`


### PR DESCRIPTION
## 问题

`review-single-pr` 的流程缺少两个固定环节：

1. 审查单个 PR 时，需要系统性判断 PR 是否和 base 已有功能重复，或者和其他 open PR 存在重复、部分重叠、冲突或被替代关系。
2. 审查完成后，需要根据 discussion #594 的人员方向表，把仍需领域跟进的 PR 分配给合适 reviewer，并记录权限检查和实际请求状态。

## 修改

- 在 `review-single-pr` 中新增 duplicate/overlap analysis 流程，要求先从 PR 标题、正文、提交、变更文件和语义目标构造 intent fingerprint，再分别检查 base 分支和相关 open PR。
- 明确重复、部分重叠、冲突风险、被替代、检查后无关等分类，以及这些结论对 review 结论的影响。
- 在 review body 要求中加入重复/重叠分析摘要，避免只说明测试结果而没有说明和已有实现或其他 PR 的关系。
- 新增 post-review reviewer assignment 流程：审查提交后读取 discussion #594 最新人员方向表，按 PR 内容匹配 reviewer，排除 PR 作者，保留 bot 请求，检查权限，使用 requested reviewers REST API 请求，并二次确认结果。
- 同步更新 `AGENTS.md` 中 `review-single-pr` 的触发说明。

## 方案逻辑

重复/重叠检查放在技术审查阶段，是因为 reviewer 必须先判断 PR 的实际语义目标和变更范围，才能确定它是否已经被 base 或其他 PR 覆盖。reviewer 分配放在 review submission 之后，是为了让分配基于完整审查结论、风险点和剩余跟进方向，而不是只依赖标题或路径。

PR #795 已按该流程试运行：它属于 StarryOS normal QEMU app/rootfs 测试，匹配 discussion #594 中 `测试`、`发行版/rootfs`、`axbuild`、`starry` 方向，因此请求了 `ZCShou` 和 `luodeb` 作为 reviewer，并确认 GitHub requested reviewers 状态已更新。

## 验证

- `git diff --check origin/dev...HEAD`
- `python3 /home/zhourui/.codex/skills/.system/skill-creator/scripts/quick_validate.py /home/zhourui/opensource/tgoskits-all/.claude/skills/review-single-pr`

未运行 `cargo fmt` 或 `cargo clippy`，因为本次只修改 Markdown 文档和项目 skill 说明，没有改动 Rust crate 代码。