### PR TITLE
fix(axplat-loongarch64-qemu-virt): send runtime IPIs non-blocking to fix SMP IPI-burst deadlock

### DIFF
--- a/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/irq.rs
+++ b/components/axplat_crates/platforms/axplat-loongarch64-qemu-virt/src/irq.rs
@@ -183,18 +183,26 @@ impl IrqIf for IrqIfImpl {
     }
 
     /// Sends an inter-processor interrupt (IPI) to the specified target CPU or all CPUs.
+    ///
+    /// Runtime IPIs are sent NON-blocking (`IOCSR_IPI_SEND_BLOCKING` unset). The
+    /// blocking variant stalls the issuing CPU until the target clears its
+    /// `IOCSR_IPI_STATUS`; under a high-rate IPI burst the sender can block while
+    /// the target is mid-handler (IRQs disabled) — or while the sender itself holds
+    /// an IRQ-disabling lock — which deadlocks (the arceos-ipi SMP test hung 6h on
+    /// loongarch). Linux/riscv/x86 likewise fire runtime IPIs non-blocking; the
+    /// blocking form is reserved for the secondary-CPU boot mailbox (see `mp.rs`).
     fn send_ipi(_irq_num: usize, target: IpiTarget) {
         match target {
             IpiTarget::Current { cpu_id } => {
-                iocsr_write_w(IOCSR_IPI_SEND, make_ipi_send_value(cpu_id, 0, true));
+                iocsr_write_w(IOCSR_IPI_SEND, make_ipi_send_value(cpu_id, 0, false));
             }
             IpiTarget::Other { cpu_id } => {
-                iocsr_write_w(IOCSR_IPI_SEND, make_ipi_send_value(cpu_id, 0, true));
+                iocsr_write_w(IOCSR_IPI_SEND, make_ipi_send_value(cpu_id, 0, false));
             }
             IpiTarget::AllExceptCurrent { cpu_id, cpu_num } => {
                 for i in 0..cpu_num {
                     if i != cpu_id {
-                        iocsr_write_w(IOCSR_IPI_SEND, make_ipi_send_value(i, 0, true));
+                        iocsr_write_w(IOCSR_IPI_SEND, make_ipi_send_value(i, 0, false));
                     }
                 }
             }


### PR DESCRIPTION
## 问题

arceos `task/ipi` 多核测试在 loongarch64(`qemu -smp 4 -cpu la464`)上单独挂起约 6 小时被 CI 超时取消,是近期多个 PR(如 #730)CI 中唯一的失败/取消项;其余架构(x86_64/riscv64)以及该测试在它们上均正常通过。

## 根因

`send_ipi`(`axplat-loongarch64-qemu-virt/src/irq.rs`)对运行时 IPI 使用了 `IOCSR_IPI_SEND_BLOCKING`(阻塞位)。`task/ipi` 在单轮发送约 393K 个 IPI 的高频突发下,发送方的 `iocsr` 写会阻塞直到目标 CPU 清除其 `IOCSR_IPI_STATUS` 对应位;而目标此刻往往正在 `handle_irq` 内(IRQ 已禁),或发送方自身持有 `SpinNoIrq`(IRQ 已禁),双方相互等待形成死锁。`make_ipi_send_value(.., blocking=true)` 对全部 `send_ipi` 调用无条件设置阻塞位,但运行时 IPI 不需要、也不应使用阻塞语义。

## 修复

将 `send_ipi` 的三处(`Current`/`Other`/`AllExceptCurrent`)改为非阻塞(`blocking=false`),与 riscv64(`sbi_rt::send_ipi`)、x86_64(APIC ICR)的运行时 IPI 一致(fire-and-forget)。目标 CPU 的 `IOCSR_IPI_STATUS` 位仍由硬件置位,在 IPI 中断使能(`set_enable`/ECFG LIE)后被取走;`ipi_handler` 以 `while`-drain 循环排空回调队列,因此即使多个发送方的 IPI 在同一中断边沿合并(coalesce),也不会丢失任何回调。阻塞位仅保留给二级 CPU 启动 mailbox 路径(`mp.rs` 的 `send_ipi_single`,走 `loongArch64` crate 的独立实现,不受本改影响)。

## 验证

本地实测:`cargo xtask arceos test qemu --arch loongarch64 --test-group rust --test-case task/ipi` 由挂起 6h → `All tests passed!` / `result: 1/1 case(s) passed`。

此修复使 arceos loongarch64 多核 CI 转绿,从而解除对 #730 等 PR 的阻塞(那些 PR 自身与 arceos 多核无关)。
