### PR TITLE
fix(starry): avoid teardown usercopy from kernel tasks

### DIFF
--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -47,7 +47,16 @@ fn check_region(start: VirtAddr, layout: Layout, access_flags: MappingFlags) -> 
     }
 
     let curr = current();
-    let aspace_arc = curr.as_thread().proc_data.aspace();
+    let Some(thr) = curr.try_as_thread() else {
+        warn!(
+            "reject user region check outside thread context: task={}, start={:#x}, len={}",
+            curr.id_name(),
+            start.as_usize(),
+            layout.size()
+        );
+        return Err(AxError::BadAddress);
+    };
+    let aspace_arc = thr.proc_data.aspace();
     if unsafe { aspace_arc.raw() }.is_owned_by_current() {
         return Err(AxError::BadAddress);
     }
@@ -94,7 +103,16 @@ fn check_null_terminated<T: PartialEq + Default>(
                 // querying the page table since the page might has not been
                 // allocated yet.
                 let curr = current();
-                let aspace_arc = curr.as_thread().proc_data.aspace();
+                let Some(thr) = curr.try_as_thread() else {
+                    warn!(
+                        "reject nul-terminated user check outside thread context: task={}, \
+                         start={:#x}",
+                        curr.id_name(),
+                        start as usize
+                    );
+                    return Err(AxError::BadAddress);
+                };
+                let aspace_arc = thr.proc_data.aspace();
                 if unsafe { aspace_arc.raw() }.is_owned_by_current() {
                     return Err(AxError::BadAddress);
                 }
@@ -280,10 +298,15 @@ fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
     }
 
     might_sleep();
-    thr.proc_data
-        .aspace()
-        .lock()
-        .handle_page_fault(vaddr, access_flags)
+    let aspace_arc = thr.proc_data.aspace();
+    if unsafe { aspace_arc.raw() }.is_owned_by_current() {
+        warn!(
+            "user page fault while current thread already owns its address-space lock: \
+             vaddr={vaddr:#x}, access_flags={access_flags:#x?}"
+        );
+        return false;
+    }
+    aspace_arc.lock().handle_page_fault(vaddr, access_flags)
 }
 
 pub fn vm_load_string(ptr: *const c_char) -> AxResult<String> {
@@ -305,6 +328,19 @@ pub fn check_access(start: usize, len: usize) -> VmResult {
     }
 }
 
+fn ensure_thread_context(op: &str, start: usize, len: usize) -> VmResult {
+    let curr = current();
+    if curr.try_as_thread().is_some() {
+        Ok(())
+    } else {
+        warn!(
+            "reject user memory {op} outside thread context: task={}, start={start:#x}, len={len}",
+            curr.id_name()
+        );
+        Err(VmError::AccessDenied)
+    }
+}
+
 #[extern_trait]
 unsafe impl VmIo for Vm {
     fn new() -> Self {
@@ -312,7 +348,11 @@ unsafe impl VmIo for Vm {
     }
 
     fn read(&mut self, start: usize, buf: &mut [MaybeUninit<u8>]) -> VmResult {
+        if buf.is_empty() {
+            return Ok(());
+        }
         check_access(start, buf.len())?;
+        ensure_thread_context("read", start, buf.len())?;
         let failed_at = access_user_memory(|| unsafe {
             user_copy(buf.as_mut_ptr() as *mut _, start as _, buf.len())
         });
@@ -324,7 +364,11 @@ unsafe impl VmIo for Vm {
     }
 
     fn write(&mut self, start: usize, buf: &[u8]) -> VmResult {
+        if buf.is_empty() {
+            return Ok(());
+        }
         check_access(start, buf.len())?;
+        ensure_thread_context("write", start, buf.len())?;
         let failed_at = access_user_memory(|| unsafe {
             user_copy(start as _, buf.as_ptr() as *const _, buf.len())
         });

--- a/os/StarryOS/kernel/src/task/futex.rs
+++ b/os/StarryOS/kernel/src/task/futex.rs
@@ -26,7 +26,7 @@ use hashbrown::HashMap;
 
 use crate::{
     mm::{AddrSpace, Backend, SharedPages},
-    task::AsThread,
+    task::{AsThread, ProcessData},
 };
 
 /// Wait queue used by futex.
@@ -416,11 +416,10 @@ impl FutexKey {
         Self::new(&aspace, address, mode)
     }
 
-    /// Best-effort variant for teardown paths that may be reached after a
-    /// faultable user-memory access.
-    pub fn new_current_teardown(address: usize) -> Self {
-        let curr = current();
-        let aspace_arc = curr.as_thread().proc_data.aspace();
+    /// Teardown variant that is anchored to the exiting process instead of
+    /// whatever scheduler task is currently running on this CPU.
+    pub fn new_for_process_teardown(proc_data: &ProcessData, address: usize) -> Self {
+        let aspace_arc = proc_data.aspace();
         let Some(aspace) = aspace_arc.try_lock() else {
             return Self::Private { address };
         };
@@ -575,8 +574,14 @@ static SHARED_FUTEX_TABLES: Mutex<FutexTables> = Mutex::new(FutexTables::new());
 
 /// Returns the futex table for the given key.
 pub fn futex_table_for(key: &FutexKey) -> Arc<FutexTable> {
+    let curr = current();
+    futex_table_for_process(curr.as_thread().proc_data.as_ref(), key)
+}
+
+/// Returns the futex table for a key in a known process context.
+pub fn futex_table_for_process(proc_data: &ProcessData, key: &FutexKey) -> Arc<FutexTable> {
     match key {
-        FutexKey::Private { .. } => current().as_thread().proc_data.futex_table.clone(),
+        FutexKey::Private { .. } => proc_data.futex_table.clone(),
         FutexKey::Shared { region, .. } => {
             let ptr = match region {
                 Ok(pages) => Weak::as_ptr(pages) as usize,

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -388,6 +388,7 @@ pub trait AsThread {
     fn try_as_thread(&self) -> Option<&Thread>;
 
     /// Get the thread from the task, panicking if it is a kernel task.
+    #[track_caller]
     fn as_thread(&self) -> &Thread {
         self.try_as_thread().expect("kernel task")
     }

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -17,8 +17,8 @@ use starry_vm::{VmMutPtr, VmPtr};
 use weak_map::WeakMap;
 
 use super::{
-    AsThread, Cred, FutexKey, ProcessData, TimerState, futex_table_for, send_signal_thread_inner,
-    send_signal_to_process, send_signal_to_thread,
+    AsThread, Cred, FutexKey, ProcessData, Thread, TimerState, futex_table_for_process,
+    send_signal_thread_inner, send_signal_to_process, send_signal_to_thread,
 };
 
 const FUTEX_OWNER_DIED: u32 = 0x40000000;
@@ -351,10 +351,10 @@ fn robust_futex_address(entry: *mut RobustList, offset: i64) -> AxResult<usize> 
     Ok(address)
 }
 
-fn wake_robust_futex(address: usize) {
-    let key = FutexKey::new_current_teardown(address);
+fn wake_robust_futex(proc_data: &ProcessData, address: usize) {
+    let key = FutexKey::new_for_process_teardown(proc_data, address);
 
-    let futex_table = futex_table_for(&key);
+    let futex_table = futex_table_for_process(proc_data, &key);
 
     let Some(futex) = futex_table.get(&key) else {
         return;
@@ -362,19 +362,24 @@ fn wake_robust_futex(address: usize) {
     futex.wq.wake(1, u32::MAX);
 }
 
-fn handle_futex_death(entry: *mut RobustList, offset: i64, pending: bool) -> AxResult<()> {
+fn handle_futex_death(
+    thr: &Thread,
+    entry: *mut RobustList,
+    offset: i64,
+    pending: bool,
+) -> AxResult<()> {
     let address = robust_futex_address(entry, offset)?;
     let futex_word = address as *mut u32;
     // Linux compares the robust-futex owner field against task_pid_vnr(curr),
     // i.e. the user-visible TID written by userspace through gettid().
     // After non-leader execve, that value is Thread::tid(), not the scheduler
     // task id.
-    let owner_tid = (current().as_thread().tid() as u32) & FUTEX_TID_MASK;
+    let owner_tid = thr.tid() & FUTEX_TID_MASK;
     let value = futex_word.vm_read()?;
     let owner = value & FUTEX_TID_MASK;
 
     if pending && owner == 0 {
-        wake_robust_futex(address);
+        wake_robust_futex(&thr.proc_data, address);
         return Ok(());
     }
 
@@ -384,12 +389,12 @@ fn handle_futex_death(entry: *mut RobustList, offset: i64, pending: bool) -> AxR
     futex_word.vm_write((value & FUTEX_WAITERS) | FUTEX_OWNER_DIED)?;
 
     if value & FUTEX_WAITERS != 0 {
-        wake_robust_futex(address);
+        wake_robust_futex(&thr.proc_data, address);
     }
     Ok(())
 }
 
-pub fn exit_robust_list(head: *const RobustListHead) -> AxResult<()> {
+pub fn exit_robust_list(thr: &Thread, head: *const RobustListHead) -> AxResult<()> {
     // Reference: https://elixir.bootlin.com/linux/v6.13.6/source/kernel/futex/core.c#L777
 
     let mut limit = ROBUST_LIST_LIMIT;
@@ -412,7 +417,7 @@ pub fn exit_robust_list(head: *const RobustListHead) -> AxResult<()> {
         };
         let next_entry = node.next;
         if entry != pending {
-            handle_futex_death(entry, offset, false).unwrap_or_else(|err| {
+            handle_futex_death(thr, entry, offset, false).unwrap_or_else(|err| {
                 debug!("robust list: failed to clean entry {entry:?}: {err:?}");
             });
         }
@@ -428,7 +433,7 @@ pub fn exit_robust_list(head: *const RobustListHead) -> AxResult<()> {
 
     // Process the pending entry that was skipped in the loop
     if !pending.is_null() && !core::ptr::eq(pending, end_ptr) {
-        handle_futex_death(pending, offset, true).unwrap_or_else(|err| {
+        handle_futex_death(thr, pending, offset, true).unwrap_or_else(|err| {
             debug!("robust list: failed to clean pending entry {pending:?}: {err:?}");
         });
     }
@@ -447,15 +452,15 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
     // OWNER_DIED handoff has been written.
     let head = thr.robust_list_head() as *const RobustListHead;
     if !head.is_null()
-        && let Err(err) = exit_robust_list(head)
+        && let Err(err) = exit_robust_list(thr, head)
     {
         warn!("exit robust list failed: {err:?}");
     }
 
     let clear_child_tid = thr.clear_child_tid() as *mut u32;
     if clear_child_tid.vm_write(0).is_ok() {
-        let key = FutexKey::new_current_teardown(clear_child_tid as usize);
-        let table = futex_table_for(&key);
+        let key = FutexKey::new_for_process_teardown(&thr.proc_data, clear_child_tid as usize);
+        let table = futex_table_for_process(&thr.proc_data, &key);
         let guard = table.get(&key);
         if let Some(futex) = guard {
             futex.wq.wake(1, u32::MAX);


### PR DESCRIPTION
# fix(starry): avoid teardown usercopy from kernel tasks

## 问题 / Root Cause

StarryOS 的退出清理路径会处理 robust futex list 和 `clear_child_tid`。旧实现里，teardown 路径通过 `current().as_thread()` 推导当前线程、地址空间和 futex table；一旦清理发生在非用户线程上下文，或者用户内存访问递归撞到当前地址空间锁，就会把“用户态上下文假设”带进内核任务路径，可能触发 `kernel task` panic、错误的 futex table 查找，或 page-fault/usercopy 重入。

这在 M6 guest cargo 并发编译中容易出现：大量 rustc 进程退出、wait、futex cleanup 和用户缓冲区访问交叠，错误会晚于启动阶段暴露，反馈链路很长。

## Fix Summary

- 用户内存 region/string 检查先确认当前任务确实是用户线程；非线程上下文返回 `EFAULT`/`AccessDenied`，不再 panic。
- page fault 处理前检查当前地址空间锁是否已被持有，避免递归锁路径进入 `might_sleep()` panic。
- robust futex teardown 改为显式传入正在退出的 `Thread`，owner TID、`ProcessData`、private futex table 都从退出线程取得。
- `clear_child_tid` 唤醒同样绑定退出线程的 `ProcessData`，避免使用当前 CPU 上的临时任务上下文。
- `AsThread::as_thread()` 增加 `#[track_caller]`，后续若还有错误上下文会直接指向调用点。

## 为什么改这些地方

- `mm/access.rs` 是 StarryOS 用户指针读写和 page fault 的统一入口，适合统一拒绝非线程上下文的 usercopy。
- `task/futex.rs` 是 futex key/table 选择处，需要提供“已知进程上下文”的 teardown 版本。
- `task/ops.rs` 是 `do_exit` / robust-list / clear-child-tid 的拥有者，修复必须围绕退出线程本身。
- `task/mod.rs` 的 `track_caller` 只用于后续诊断，不改变行为。

## Test Plan

- `git diff --check upstream/dev...HEAD`
- `cargo fmt --check`
- 现有 test-suite 覆盖：
  - `test-suit/starryos/normal/qemu-smp1/syscall/test-futex-robust-list`
  - `test-suit/starryos/normal/qemu-smp1/test-mt-execve`
- M6 证据：
  - 后续 8 核/8 job guest cargo self-build 使用该类修复作为并发退出/futex/usercopy 路径验证。

## Remaining Risk

本地 macOS host 上 `cargo xtask clippy --package starry-kernel` 触发既有 Mach-O/percpu section baseline 问题，未能作为本 PR 的有效信号；CI Linux 环境需要补跑完整 StarryOS qemu tests。
