### PR TITLE
fix(axsync): release raw mutex before waking waiter

### DIFF
--- a/os/arceos/modules/axsync/src/mutex.rs
+++ b/os/arceos/modules/axsync/src/mutex.rs
@@ -7,9 +7,9 @@ use ax_task::{WaitQueue, current, might_sleep};
 /// A [`lock_api::RawMutex`] implementation.
 ///
 /// When the mutex is locked, the current task will block and be put into the
-/// wait queue. When the mutex is unlocked, ownership is handed off to at most
-/// one task waiting on the queue; if no tasks are waiting, the mutex simply
-/// becomes unlocked.
+/// wait queue. When the mutex is unlocked, ownership is released before waking
+/// at most one waiting task; the woken task then acquires the mutex with the
+/// normal compare-exchange path.
 pub struct RawMutex {
     wq: WaitQueue,
     owner_id: AtomicU64,
@@ -80,7 +80,7 @@ impl Default for RawMutex {
 }
 
 unsafe impl lock_api::RawMutex for RawMutex {
-    type GuardMarker = lock_api::GuardSend;
+    type GuardMarker = lock_api::GuardNoSend;
 
     /// Initial value for an unlocked mutex.
     ///
@@ -129,10 +129,8 @@ unsafe impl lock_api::RawMutex for RawMutex {
         );
         #[cfg(feature = "lockdep")]
         crate::lockdep::release(self);
-        // wake up one waiting thread.
-        self.wq.notify_one_with(true, |id: u64| {
-            self.owner_id.swap(id, Ordering::Release);
-        });
+        self.owner_id.store(0, Ordering::Release);
+        self.wq.notify_one(true);
     }
 
     #[inline(always)]
@@ -168,7 +166,10 @@ impl RawMutex {
                         owner_id, current_id,
                         "Thread({current_id}) tried to acquire mutex it already owns.",
                     );
-                    // Wait until someone hands off lock to me or lock is released
+                    // Wait until the lock is released. The woken waiter
+                    // competes through the normal CAS path, avoiding a state
+                    // where the owner id names a task that has not returned a
+                    // guard yet.
                     self.wq
                         .wait_until(|| self.is_owner(current_id) || !self.is_locked_inner());
                     // This check is necessary: some newcomers may race with a wakened one.

--- a/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/c/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-rawmutex-handoff C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+find_package(Threads REQUIRED)
+
+add_executable(test-rawmutex-handoff src/main.c)
+target_include_directories(test-rawmutex-handoff PRIVATE src)
+target_compile_options(test-rawmutex-handoff PRIVATE -Wall -Wextra -Werror)
+target_link_libraries(test-rawmutex-handoff PRIVATE Threads::Threads)
+
+install(TARGETS test-rawmutex-handoff RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/c/src/main.c
@@ -1,0 +1,210 @@
+/*
+ * Stress StarryOS SMP mutex wait/wake handoff through the process address
+ * space lock.
+ *
+ * The M6 guest self-build exposed a kernel panic where RawMutex handed
+ * ownership directly to a sleeping waiter before the waiter returned a guard.
+ * Under SMP load this left a transient owner id naming a task that could reach
+ * another page-fault/aspace-lock path and panic as "tried to acquire mutex it
+ * already owns".
+ *
+ * This test keeps several threads in one process contending on the same
+ * address-space mutex by repeatedly creating, faulting, protecting, and
+ * unmapping anonymous VMAs. A buggy handoff path can surface as a kernel panic;
+ * success is surviving the stress with every worker completing.
+ */
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#include <sched.h>
+#include <sys/syscall.h>
+#endif
+
+#define N_WORKERS 4
+#define ROUNDS 160
+#define PAGES_PER_MAP 8
+#define PAGE_SIZE 4096
+#define MAP_SIZE ((size_t)PAGES_PER_MAP * PAGE_SIZE)
+
+struct worker_arg {
+    int cpu;
+    int id;
+    struct start_barrier *barrier;
+    int ok;
+};
+
+struct start_barrier {
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    int count;
+    int trip;
+};
+
+static int start_barrier_init(struct start_barrier *barrier, int trip)
+{
+    memset(barrier, 0, sizeof(*barrier));
+    barrier->trip = trip;
+    if (pthread_mutex_init(&barrier->lock, NULL) != 0) {
+        return -1;
+    }
+    if (pthread_cond_init(&barrier->cond, NULL) != 0) {
+        pthread_mutex_destroy(&barrier->lock);
+        return -1;
+    }
+    return 0;
+}
+
+static void start_barrier_wait(struct start_barrier *barrier)
+{
+    pthread_mutex_lock(&barrier->lock);
+    barrier->count++;
+    if (barrier->count == barrier->trip) {
+        pthread_cond_broadcast(&barrier->cond);
+    } else {
+        while (barrier->count < barrier->trip) {
+            pthread_cond_wait(&barrier->cond, &barrier->lock);
+        }
+    }
+    pthread_mutex_unlock(&barrier->lock);
+}
+
+static void start_barrier_destroy(struct start_barrier *barrier)
+{
+    pthread_cond_destroy(&barrier->cond);
+    pthread_mutex_destroy(&barrier->lock);
+}
+
+static pid_t my_tid(void)
+{
+#ifdef __linux__
+    return (pid_t)syscall(SYS_gettid);
+#else
+    return getpid();
+#endif
+}
+
+static void pin_to_cpu(int cpu)
+{
+#ifdef __linux__
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(cpu, &cpuset);
+    (void)sched_setaffinity(0, sizeof(cpuset), &cpuset);
+#else
+    (void)cpu;
+#endif
+}
+
+static void touch_pages(unsigned char *p, int id, int round)
+{
+    for (int page = 0; page < PAGES_PER_MAP; page++) {
+        size_t off = (size_t)page * PAGE_SIZE;
+        p[off] = (unsigned char)(id * 17 + round + page);
+    }
+}
+
+static void *worker(void *arg)
+{
+    struct worker_arg *wa = (struct worker_arg *)arg;
+    wa->ok = 0;
+
+    pin_to_cpu(wa->cpu);
+
+    start_barrier_wait(wa->barrier);
+
+    for (int round = 0; round < ROUNDS; round++) {
+        unsigned char *p = mmap(NULL, MAP_SIZE, PROT_READ | PROT_WRITE,
+                                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (p == MAP_FAILED) {
+            printf("worker %d tid %d mmap failed at round %d\n",
+                   wa->id, my_tid(), round);
+            return NULL;
+        }
+
+        touch_pages(p, wa->id, round);
+
+        if (mprotect(p, MAP_SIZE, PROT_READ) != 0) {
+            printf("worker %d tid %d mprotect R failed at round %d\n",
+                   wa->id, my_tid(), round);
+            munmap(p, MAP_SIZE);
+            return NULL;
+        }
+
+        volatile unsigned int sum = 0;
+        for (int page = 0; page < PAGES_PER_MAP; page++) {
+            sum += p[(size_t)page * PAGE_SIZE];
+        }
+        (void)sum;
+
+        if (mprotect(p, MAP_SIZE, PROT_READ | PROT_WRITE) != 0) {
+            printf("worker %d tid %d mprotect RW failed at round %d\n",
+                   wa->id, my_tid(), round);
+            munmap(p, MAP_SIZE);
+            return NULL;
+        }
+
+        touch_pages(p, wa->id, round + 1);
+
+        if (munmap(p, MAP_SIZE) != 0) {
+            printf("worker %d tid %d munmap failed at round %d\n",
+                   wa->id, my_tid(), round);
+            return NULL;
+        }
+
+        if ((round & 7) == 0) {
+            sched_yield();
+        }
+    }
+
+    wa->ok = 1;
+    return NULL;
+}
+
+int main(void)
+{
+    setvbuf(stdout, NULL, _IONBF, 0);
+    TEST_START("rawmutex handoff under SMP aspace contention");
+
+    struct start_barrier barrier;
+    CHECK(start_barrier_init(&barrier, N_WORKERS) == 0,
+          "create start barrier");
+
+    pthread_t threads[N_WORKERS];
+    struct worker_arg args[N_WORKERS];
+    int created = 0;
+    for (int i = 0; i < N_WORKERS; i++) {
+        args[i] = (struct worker_arg) {
+            .cpu = i,
+            .id = i,
+            .barrier = &barrier,
+            .ok = 0,
+        };
+        if (pthread_create(&threads[i], NULL, worker, &args[i]) != 0) {
+            break;
+        }
+        created++;
+    }
+    CHECK(created == N_WORKERS, "spawn all mmap stress workers");
+
+    for (int i = 0; i < created; i++) {
+        CHECK(pthread_join(threads[i], NULL) == 0, "join worker");
+    }
+
+    int all_ok = 1;
+    for (int i = 0; i < created; i++) {
+        all_ok &= args[i].ok;
+    }
+    CHECK(all_ok, "all workers completed mmap/protect/unmap stress");
+
+    start_barrier_destroy(&barrier);
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/c/src/test_framework.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);       \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");      \
+    printf("  TEST: %s\n", name);                                      \
+    printf("  FILE: %s\n", __FILE__);                                  \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");      \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");    \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic", "-cpu", "cortex-a53",
+    "-m", "512M",
+    "-smp", "4",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-rawmutex-handoff"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/qemu-loongarch64.toml
@@ -1,0 +1,18 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic",
+    "-m", "512M",
+    "-smp", "4",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-rawmutex-handoff"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/qemu-riscv64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-m", "512M",
+    "-smp", "4",
+    "-accel", "tcg,thread=single",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-rawmutex-handoff"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 360

--- a/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff/qemu-x86_64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-smp", "4",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-rawmutex-handoff"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 360


### PR DESCRIPTION
# fix(axsync): release raw mutex before waking waiter

## 问题 / Root Cause

SMP 下 `RawMutex::unlock` 旧逻辑用 `notify_one_with` 把 `owner_id` 直接切到等待者。这个“直接 handoff”在竞争环境里不安全：被唤醒任务真正拿到 guard 前，owner 状态已经指向它；如果该任务重新进入同一把锁，会被判定为“已经拥有 mutex”，触发自拥有 panic。

M6 guest cargo 并发编译会高频触发地址空间锁、page cache、进程退出和 futex wait/wake，这类锁 handoff 竞态会把编译推进卡在很晚的位置。

## Fix Summary

- `RawMutex::unlock` 先用 `Release` 把 `owner_id` 清零，再唤醒一个等待者。
- 等待者醒来后仍走 CAS acquire 路径，真正成功拿锁后才成为 owner。
- guard marker 改成 `GuardNoSend`，避免 mutex guard 被跨任务/线程转移后破坏 owner 语义。
- 增加 `qemu-smp4/test-rawmutex-handoff` 回归：4 个 worker 并发执行 `mmap`、fault、`mprotect`、`munmap`，持续压测地址空间锁竞争。

## 为什么改这些地方

- `os/arceos/modules/axsync/src/mutex.rs` 是 sleepable mutex 的核心实现，问题是锁语义而不是某个 syscall 脚本。
- `test-suit/starryos/normal/qemu-smp4/test-rawmutex-handoff` 专门覆盖 SMP 竞争场景，比单核 syscall case 更贴近 M6 暴露的失败形态。
- RISC-V qemu 配置保留 `-accel tcg,thread=single`，因为 QEMU RISC-V MTTCG 的 LR/SC 模拟不能作为正确性证明；速度实验另行记录。

## Test Plan

- `git diff --check upstream/dev...HEAD`
- `cargo fmt --check`
- test-suite 新增：
  - `cargo xtask starry test qemu --arch riscv64 -g normal -c test-rawmutex-handoff`
  - 同目录提供 aarch64 / loongarch64 / x86_64 配置，CI 可按架构发现。

## Remaining Risk

本地 macOS host 上 `cargo xtask clippy --package ax-sync` 触发既有 Mach-O/percpu section baseline 问题，未能作为本 PR 的有效信号；需要以 Linux CI 和 qemu-smp4 testsuite 结果为准。
