### PR TITLE
fix(riscv-vcpu): handle HLVX fetch faults

### DIFF
--- a/components/riscv_vcpu/src/guest_mem.rs
+++ b/components/riscv_vcpu/src/guest_mem.rs
@@ -14,9 +14,10 @@
 
 use core::arch::riscv64::hfence_vvma_all;
 
-use ax_errno::{AxResult, ax_err_type};
 use axaddrspace::{GuestPhysAddr, GuestVirtAddr};
 use riscv_h::register::vsatp::Vsatp;
+
+use crate::trap::Exception;
 
 // Notes about this file:
 //
@@ -36,7 +37,86 @@ unsafe extern "C" {
     /// Copy data from host address to guest virtual address.
     fn _copy_to_guest(dst_gva: usize, src: *const u8, len: usize) -> usize;
     /// Fetch the guest instruction at the given guest virtual address.
-    fn _fetch_guest_instruction(gva: usize, raw_inst: *mut u32) -> isize;
+    ///
+    /// Returns zero on success. On fault, returns non-zero and writes the trap
+    /// CSRs captured at the HLVX fault site into `fault`.
+    fn _fetch_guest_instruction(
+        gva: usize,
+        raw_inst: *mut u32,
+        fault: *mut GuestInstructionFetchFaultRaw,
+    ) -> usize;
+}
+
+#[derive(Debug, Default)]
+#[repr(C)]
+/// Raw trap CSR snapshot returned by the HLVX fetch helper on fault.
+struct GuestInstructionFetchFaultRaw {
+    scause: usize,
+    stval: usize,
+    htval: usize,
+}
+
+/// Fault categories produced while fetching a guest instruction with HLVX.
+///
+/// HLVX checks execute permission, but architecturally reports load-class
+/// exceptions. These variants carry the guest-facing fetch semantics that the
+/// vCPU code should inject or forward.
+#[derive(Debug)]
+pub(crate) enum GuestInstructionFetchFault {
+    /// Guest VS-stage translation denied or missed the instruction address.
+    PageFault { addr: GuestVirtAddr },
+    /// Guest instruction access fault after translation.
+    AccessFault { addr: GuestVirtAddr },
+    /// Guest instruction address was misaligned.
+    Misaligned { addr: GuestVirtAddr },
+    /// G-stage translation fault while resolving the instruction access.
+    GuestPageFault { addr: GuestPhysAddr },
+    /// A trap cause that is not expected from HLVX instruction fetching.
+    Unhandled {
+        scause: usize,
+        stval: usize,
+        htval: usize,
+    },
+}
+
+impl GuestInstructionFetchFaultRaw {
+    fn into_fetch_fault(self, gva: GuestVirtAddr) -> GuestInstructionFetchFault {
+        let exception = self.scause & !(1usize << (usize::BITS - 1));
+        let fault_gva = GuestVirtAddr::from_usize(self.stval);
+
+        match exception {
+            // HLVX reports these as load faults even though the guest-visible
+            // operation is an instruction fetch.
+            x if x == Exception::InstructionPageFault as usize
+                || x == Exception::LoadPageFault as usize =>
+            {
+                GuestInstructionFetchFault::PageFault { addr: fault_gva }
+            }
+            x if x == Exception::InstructionFault as usize
+                || x == Exception::LoadFault as usize =>
+            {
+                GuestInstructionFetchFault::AccessFault { addr: fault_gva }
+            }
+            x if x == Exception::InstructionMisaligned as usize
+                || x == Exception::LoadMisaligned as usize =>
+            {
+                GuestInstructionFetchFault::Misaligned { addr: gva }
+            }
+            x if x == Exception::InstructionGuestPageFault as usize
+                || x == Exception::LoadGuestPageFault as usize =>
+            {
+                // For guest-page faults, htval holds GPA[XLEN-1:2] and stval
+                // supplies the low two bits of the faulting guest physical address.
+                let fault_gpa = GuestPhysAddr::from((self.htval << 2) | (self.stval & 0b11));
+                GuestInstructionFetchFault::GuestPageFault { addr: fault_gpa }
+            }
+            _ => GuestInstructionFetchFault::Unhandled {
+                scause: self.scause,
+                stval: self.stval,
+                htval: self.htval,
+            },
+        }
+    }
 }
 
 /// Copies data from guest virtual address to host memory.
@@ -86,16 +166,26 @@ pub(crate) fn copy_to_guest(src: &[u8], gpa: GuestPhysAddr) -> usize {
 }
 
 /// Fetches the guest instruction at the given guest virtual address.
+///
+/// The assembly helper uses HLVX so execute permission is checked as a guest
+/// instruction fetch, while this wrapper converts the load-class trap CSRs back
+/// into guest instruction-fetch categories.
 #[inline(always)]
-pub(crate) fn fetch_guest_instruction(gva: GuestVirtAddr) -> AxResult<u32> {
+pub(crate) fn fetch_guest_instruction(
+    gva: GuestVirtAddr,
+) -> Result<u32, GuestInstructionFetchFault> {
     let mut inst = 0u32;
-    let ret = unsafe { _fetch_guest_instruction(gva.as_usize(), &mut inst as *mut u32) };
+    let mut fault = GuestInstructionFetchFaultRaw::default();
+    let ret = unsafe {
+        _fetch_guest_instruction(
+            gva.as_usize(),
+            &mut inst as *mut u32,
+            &mut fault as *mut GuestInstructionFetchFaultRaw,
+        )
+    };
     if ret == 0 {
         Ok(inst)
     } else {
-        Err(ax_err_type!(
-            BadAddress,
-            alloc::format!("failed to fetch guest instruction at {gva:#x}")
-        ))
+        Err(fault.into_fetch_fault(gva))
     }
 }

--- a/components/riscv_vcpu/src/mem_extable.S
+++ b/components/riscv_vcpu/src/mem_extable.S
@@ -60,12 +60,14 @@ _copy_from_guest:
 //   A0: Guest address of the instruction to fetch, using the translation modes/tables currently
 //       programmed in HGATP and VSATP.
 //   A1: Pointer to a u32 where the instruction will be written.
+//   A2: Pointer to fault info written if the access faults.
 //
-// Returns -1 on error.
+// Returns 1 on error and writes scause, stval, and htval to A2. HLVX checks execute
+// permission but reports load-class exceptions, so the Rust side needs the raw
+// trap CSRs to recover the guest-visible fetch semantics.
 .global _fetch_guest_instruction
 _fetch_guest_instruction:
-    // handle_trap assumes t0 holds the address of where we want to jump to when we encounter
-    // a fault and will stick SCAUSE in t1.
+    // The exception table fixup redirects a faulting HLVX here.
     la    t0, 4f
 1:
     hlvx.hu t2, (a0)
@@ -86,8 +88,14 @@ _fetch_guest_instruction:
     mv    a0, zero
     ret
 4:
-    // Took a fault, return -1.
-    not   a0, zero
+    // Took a fault, record trap CSRs and return 1.
+    csrr  t2, scause
+    sd    t2, 0(a2)
+    csrr  t2, stval
+    sd    t2, 8(a2)
+    csrr  t2, htval
+    sd    t2, 16(a2)
+    li    a0, 1
     ret
 
 // memcpy() to a user address.

--- a/components/riscv_vcpu/src/vcpu.rs
+++ b/components/riscv_vcpu/src/vcpu.rs
@@ -38,7 +38,7 @@ use sbi_spec::{hsm, legacy, pmu, rfnc, srst};
 
 use crate::{
     EID_HVC, RISCVVCpuCreateConfig, consts::traps::irq::S_EXT, guest_mem, regs::*, sbi_console::*,
-    vpmu::VirtualPmu,
+    trap::Exception, vpmu::VirtualPmu,
 };
 
 unsafe extern "C" {
@@ -72,6 +72,19 @@ struct RISCVVCpuSbi {
     pmu: VirtualPmu,
     #[rustsbi(console, fence, reset, info, hsm, timer)]
     forward: Forward,
+}
+
+#[cfg(feature = "sstc")]
+/// Result of reading an instruction for virtual-instruction emulation.
+enum VirtualInstructionRead {
+    Instruction(u32),
+    Handled(AxVCpuExitReason),
+}
+
+/// Result of decoding the trapped guest load/store instruction.
+enum InstructionDecode {
+    Decoded(Instruction, usize),
+    Handled(AxVCpuExitReason),
 }
 
 impl Default for RISCVVCpuSbi {
@@ -335,13 +348,81 @@ impl RISCVVCpu {
 }
 
 impl RISCVVCpu {
+    /// Inject a synchronous VS exception so the guest handles a fault that happened during
+    /// hypervisor-side instruction emulation.
+    fn inject_guest_exception(&mut self, exception: Exception, fault_addr: GuestVirtAddr) {
+        let mut vsstatus = vsstatus::read();
+        let hstatus = hstatus::Hstatus::from_bits(self.regs.guest_regs.hstatus);
+        let vstvec = vstvec::read().bits();
+        let trap_pc = vstvec & !0b11;
+
+        vsstatus.set_spie(vsstatus.sie());
+        vsstatus.set_sie(false);
+        vsstatus.set_spp(hstatus.spvp());
+
+        self.regs.vs_csrs.vstvec = vstvec;
+        self.regs.vs_csrs.vsepc = self.regs.guest_regs.sepc;
+        self.regs.vs_csrs.vscause = exception as usize;
+        self.regs.vs_csrs.vstval = fault_addr.as_usize();
+        self.regs.vs_csrs.vsstatus = vsstatus.bits();
+        self.regs.guest_regs.sepc = trap_pc;
+
+        // `run_vcpu()` may re-enter the same bound vCPU without reloading the
+        // cached VS CSR block, so keep the live CSRs in sync with the cache.
+        unsafe {
+            vsstatus.write();
+            vscause::Vscause::from_bits(self.regs.vs_csrs.vscause).write();
+            vstval::write(self.regs.vs_csrs.vstval);
+            vsepc::write(self.regs.vs_csrs.vsepc);
+        }
+    }
+
+    fn handle_guest_instruction_fetch_fault(
+        &mut self,
+        fault: guest_mem::GuestInstructionFetchFault,
+    ) -> AxResult<AxVCpuExitReason> {
+        match fault {
+            // HLVX reports load-class faults, but the emulated operation is a
+            // guest instruction fetch. Convert them before injecting to VS mode.
+            guest_mem::GuestInstructionFetchFault::PageFault { addr } => {
+                self.inject_guest_exception(Exception::InstructionPageFault, addr);
+                Ok(AxVCpuExitReason::Nothing)
+            }
+            guest_mem::GuestInstructionFetchFault::AccessFault { addr } => {
+                self.inject_guest_exception(Exception::InstructionFault, addr);
+                Ok(AxVCpuExitReason::Nothing)
+            }
+            guest_mem::GuestInstructionFetchFault::Misaligned { addr } => {
+                self.inject_guest_exception(Exception::InstructionMisaligned, addr);
+                Ok(AxVCpuExitReason::Nothing)
+            }
+            guest_mem::GuestInstructionFetchFault::GuestPageFault { addr } => {
+                // G-stage faults must stay visible to AxVM so it can populate or
+                // reject the nested mapping.
+                Ok(AxVCpuExitReason::NestedPageFault {
+                    addr,
+                    access_flags: MappingFlags::EXECUTE,
+                })
+            }
+            guest_mem::GuestInstructionFetchFault::Unhandled {
+                scause,
+                stval,
+                htval,
+            } => Err(ax_errno::ax_err_type!(
+                Unsupported,
+                alloc::format!(
+                    "unhandled riscv HLVX fault while fetching guest instruction: \
+                     scause={scause:#x}, stval={stval:#x}, htval={htval:#x}"
+                )
+            )),
+        }
+    }
+
     fn vmexit_handler(&mut self) -> AxResult<AxVCpuExitReason> {
         self.regs.trap_csrs.load_from_hw();
 
         let scause = scause::read();
         use riscv::interrupt::{Interrupt, Trap};
-
-        use super::trap::Exception;
 
         trace!(
             "vmexit_handler: {:?}, sepc: {:#x}, stval: {:#x}",
@@ -633,7 +714,10 @@ impl RISCVVCpu {
 
     #[cfg(feature = "sstc")]
     fn handle_virtual_instruction(&mut self) -> AxResult<AxVCpuExitReason> {
-        let instr = self.read_virtual_instruction()?;
+        let instr = match self.read_virtual_instruction()? {
+            VirtualInstructionRead::Instruction(instr) => instr,
+            VirtualInstructionRead::Handled(exit_reason) => return Ok(exit_reason),
+        };
         let csr = ((instr >> 20) & 0xfff) as u16;
 
         if csr != CSR_STIMECMP {
@@ -735,14 +819,19 @@ impl RISCVVCpu {
     }
 
     #[cfg(feature = "sstc")]
-    fn read_virtual_instruction(&self) -> AxResult<u32> {
+    fn read_virtual_instruction(&mut self) -> AxResult<VirtualInstructionRead> {
         let instr = self.regs.trap_csrs.stval as u32;
         if instr & 0x7f == SYSTEM_OPCODE {
-            return Ok(instr);
+            return Ok(VirtualInstructionRead::Instruction(instr));
         }
 
         let guest_pc = GuestVirtAddr::from(self.regs.guest_regs.sepc);
-        guest_mem::fetch_guest_instruction(guest_pc)
+        match guest_mem::fetch_guest_instruction(guest_pc) {
+            Ok(instr) => Ok(VirtualInstructionRead::Instruction(instr)),
+            Err(fault) => self
+                .handle_guest_instruction_fetch_fault(fault)
+                .map(VirtualInstructionRead::Handled),
+        }
     }
 
     #[cfg(feature = "sstc")]
@@ -760,15 +849,22 @@ impl RISCVVCpu {
     }
 
     /// Decode the instruction at the given virtual address. Return the decoded instruction and its
-    /// length in bytes.
-    fn decode_instr_at(&self, vaddr: GuestVirtAddr) -> AxResult<(Instruction, usize)> {
+    /// length in bytes, or an exit reason already produced while fetching it.
+    fn decode_instr_at(&mut self, vaddr: GuestVirtAddr) -> AxResult<InstructionDecode> {
         // The htinst CSR contains "transformed instruction" that caused the page fault. We
         // can use it but we use the sepc to fetch the original instruction instead for now.
         let mut instr = riscv_h::register::htinst::read();
         let instr_len;
         if instr == 0 {
             // Read the instruction from guest memory.
-            instr = guest_mem::fetch_guest_instruction(vaddr)? as _;
+            instr = match guest_mem::fetch_guest_instruction(vaddr) {
+                Ok(instr) => instr as _,
+                Err(fault) => {
+                    return self
+                        .handle_guest_instruction_fetch_fault(fault)
+                        .map(InstructionDecode::Handled);
+                }
+            };
             instr_len = riscv_decode::instruction_length(instr as u16);
             instr = match instr_len {
                 2 => instr & 0xffff,
@@ -801,7 +897,7 @@ impl RISCVVCpu {
                     "risc-v vcpu guest pf handler decoding instruction failed"
                 )
             })
-            .map(|instr| (instr, instr_len))
+            .map(|instr| InstructionDecode::Decoded(instr, instr_len))
     }
 
     /// Handle a guest page fault. Return an exit reason.
@@ -825,7 +921,10 @@ impl RISCVVCpu {
 
         use DecodedOp::*;
 
-        let (decoded_instr, instr_len) = self.decode_instr_at(sepc_vaddr)?;
+        let (decoded_instr, instr_len) = match self.decode_instr_at(sepc_vaddr)? {
+            InstructionDecode::Decoded(instr, instr_len) => (instr, instr_len),
+            InstructionDecode::Handled(exit_reason) => return Ok(exit_reason),
+        };
         let op = match decoded_instr {
             Instruction::Lb(i) => Read {
                 i,


### PR DESCRIPTION
## 问题

RISC-V Axvisor 在 guest Linux 进入 shell 后，低概率会在 `HLVX` 取 guest 指令时触发 guest 地址访问异常。#788 已经避免了该异常导致 host panic，但后续仍会把 `_fetch_guest_instruction` 的失败统一上抛为 `BadAddress`，导致 `run_vcpu()` 直接关闭 VM。

## 修改

- 扩展 `_fetch_guest_instruction` 的 fault 返回信息，发生 HLVX fault 时记录 `scause/stval/htval`。
- 将 HLVX 返回的 load 类异常转换为 guest instruction-fetch 语义：
  - page fault 注入 guest `InstructionPageFault`
  - access fault 注入 guest `InstructionFault`
  - misaligned 注入 guest `InstructionMisaligned`
  - guest-page fault 转为 `NestedPageFault` 交由 AxVM 处理 stage-2 映射
- 在虚拟指令读取和 guest page fault 解码路径中保留已处理的 exit reason，避免忽略 nested fault。

## 思路

本修复先保留硬件给出的 trap CSR，再根据异常类型恢复 guest 可见语义：VS-stage 取指失败注入 guest 异常，G-stage fault 则继续交给 AxVM 的 nested page fault 路径处理。