### PR TITLE
feat(starry-kernel): add inotifywait support

### DIFF
--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -204,13 +204,20 @@ impl FileLike for File {
         if self.append() {
             inner.seek(SeekFrom::End(0))?;
         }
-        if likely(self.is_blocking()) {
+        let result = if likely(self.is_blocking()) {
             inner.write(src)
         } else {
             block_on(poll_io(self, IoEvents::OUT, self.nonblocking(), || {
                 inner.write(&mut *src)
             }))
+        };
+        if let Ok(bytes) = result
+            && bytes > 0
+        {
+            let path = path_for(inner.location()).into_owned();
+            crate::file::inotify::notify_modify_path(&path);
         }
+        result
     }
 
     fn stat(&self) -> AxResult<Kstat> {

--- a/os/StarryOS/kernel/src/file/inotify.rs
+++ b/os/StarryOS/kernel/src/file/inotify.rs
@@ -6,6 +6,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{
+    mem::size_of,
     sync::atomic::{AtomicBool, Ordering},
     task::Context,
 };
@@ -16,7 +17,10 @@ use ax_task::future::{block_on, poll_io};
 use axpoll::{IoEvents, PollSet, Pollable};
 use lazy_static::lazy_static;
 use linux_raw_sys::{
-    general::{IN_IGNORED, IN_MODIFY},
+    general::{
+        IN_ALL_EVENTS, IN_CLOSE_WRITE, IN_CREATE, IN_DELETE, IN_DELETE_SELF, IN_IGNORED, IN_ISDIR,
+        IN_MODIFY,
+    },
     ioctl::FIONREAD,
 };
 use starry_vm::VmMutPtr;
@@ -89,44 +93,91 @@ impl Inotify {
         if state.watches.remove(&wd).is_none() {
             return Err(AxError::InvalidInput);
         }
-        Self::push_event(&mut state.queue, wd, IN_IGNORED);
+        Self::push_event(&mut state.queue, wd, IN_IGNORED, None);
         self.poll_rx.wake();
         Ok(())
     }
 
-    fn notify_modify(&self, path: &str) {
+    fn notify_path(&self, path: &str, exact_mask: u32, parent_mask: u32) {
         let mut state = self.state.lock();
-        let matched_wds = state
+        let parent = parent_and_name(path);
+        let events = state
             .watches
             .iter()
-            .filter_map(|(wd, watch)| {
-                if watch.path == path && watch.mask & IN_MODIFY != 0 {
-                    Some(*wd)
-                } else {
-                    None
+            .filter_map(|(wd, watch)| match parent {
+                _ if exact_mask != 0
+                    && watch.path == path
+                    && watch.mask & (exact_mask & IN_ALL_EVENTS) != 0 =>
+                {
+                    Some((*wd, exact_mask, None))
                 }
+                Some((parent, name))
+                    if parent_mask != 0
+                        && watch.path == parent
+                        && watch.mask & (parent_mask & IN_ALL_EVENTS) != 0 =>
+                {
+                    Some((*wd, parent_mask, Some(String::from(name))))
+                }
+                _ => None,
             })
             .collect::<Vec<_>>();
 
-        if matched_wds.is_empty() {
+        if events.is_empty() {
             return;
         }
-        for wd in matched_wds {
-            Self::push_event(&mut state.queue, wd, IN_MODIFY);
+        for (wd, mask, name) in events {
+            Self::push_event(&mut state.queue, wd, mask, name.as_deref());
         }
         self.poll_rx.wake();
     }
 
-    fn push_event(queue: &mut VecDeque<Vec<u8>>, wd: i32, mask: u32) {
+    fn notify_delete(&self, path: &str, is_dir: bool) {
+        let dir_mask = if is_dir { IN_ISDIR } else { 0 };
+        let mut state = self.state.lock();
+        let parent = parent_and_name(path);
+        let events = state
+            .watches
+            .iter()
+            .filter_map(|(wd, watch)| match parent {
+                _ if watch.path == path && watch.mask & IN_DELETE_SELF != 0 => {
+                    Some((*wd, IN_DELETE_SELF | dir_mask, None))
+                }
+                Some((parent, name)) if watch.path == parent && watch.mask & IN_DELETE != 0 => {
+                    Some((*wd, IN_DELETE | dir_mask, Some(String::from(name))))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        if events.is_empty() {
+            return;
+        }
+        for (wd, mask, name) in events {
+            Self::push_event(&mut state.queue, wd, mask, name.as_deref());
+        }
+        state.watches.retain(|_, watch| watch.path != path);
+        self.poll_rx.wake();
+    }
+
+    fn push_event(queue: &mut VecDeque<Vec<u8>>, wd: i32, mask: u32, name: Option<&str>) {
         if queue.len() >= MAX_QUEUED_EVENTS {
             queue.pop_front();
         }
 
-        let mut event = Vec::with_capacity(INOTIFY_EVENT_SIZE);
+        let name = name.map(str::as_bytes);
+        let name_len = name
+            .map(|name| align_event_name_len(name.len() + 1))
+            .unwrap_or_default();
+
+        let mut event = Vec::with_capacity(INOTIFY_EVENT_SIZE + name_len);
         event.extend_from_slice(&wd.to_ne_bytes());
         event.extend_from_slice(&mask.to_ne_bytes());
         event.extend_from_slice(&0u32.to_ne_bytes());
-        event.extend_from_slice(&0u32.to_ne_bytes());
+        event.extend_from_slice(&(name_len as u32).to_ne_bytes());
+        if let Some(name) = name {
+            event.extend_from_slice(name);
+            event.resize(INOTIFY_EVENT_SIZE + name_len, 0);
+        }
         queue.push_back(event);
     }
 }
@@ -205,7 +256,23 @@ impl Pollable for Inotify {
     }
 }
 
-pub fn notify_modify_path(path: &str) {
+fn parent_and_name(path: &str) -> Option<(&str, &str)> {
+    let (parent, name) = path.rsplit_once('/')?;
+    if name.is_empty() {
+        None
+    } else if parent.is_empty() {
+        Some(("/", name))
+    } else {
+        Some((parent, name))
+    }
+}
+
+fn align_event_name_len(len: usize) -> usize {
+    let align = size_of::<usize>();
+    (len + align - 1) & !(align - 1)
+}
+
+fn notify_instances(path: &str, notify: impl Fn(&Inotify, &str)) {
     if path == "<error>" {
         return;
     }
@@ -213,10 +280,35 @@ pub fn notify_modify_path(path: &str) {
     let mut instances = INOTIFY_INSTANCES.lock();
     instances.retain(|watcher| {
         if let Some(inotify) = watcher.upgrade() {
-            inotify.notify_modify(path);
+            notify(&inotify, path);
             true
         } else {
             false
         }
+    });
+}
+
+pub fn notify_modify_path(path: &str) {
+    notify_instances(path, |inotify, path| {
+        inotify.notify_path(path, IN_MODIFY, IN_MODIFY);
+    });
+}
+
+pub fn notify_close_write_path(path: &str) {
+    notify_instances(path, |inotify, path| {
+        inotify.notify_path(path, IN_CLOSE_WRITE, IN_CLOSE_WRITE);
+    });
+}
+
+pub fn notify_create_path(path: &str, is_dir: bool) {
+    let mask = IN_CREATE | if is_dir { IN_ISDIR } else { 0 };
+    notify_instances(path, |inotify, path| {
+        inotify.notify_path(path, 0, mask);
+    });
+}
+
+pub fn notify_delete_path(path: &str, is_dir: bool) {
+    notify_instances(path, |inotify, path| {
+        inotify.notify_delete(path, is_dir);
     });
 }

--- a/os/StarryOS/kernel/src/file/inotify.rs
+++ b/os/StarryOS/kernel/src/file/inotify.rs
@@ -1,0 +1,222 @@
+use alloc::{
+    borrow::Cow,
+    collections::{BTreeMap, VecDeque},
+    string::String,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    task::Context,
+};
+
+use ax_errno::{AxError, AxResult};
+use ax_sync::Mutex;
+use ax_task::future::{block_on, poll_io};
+use axpoll::{IoEvents, PollSet, Pollable};
+use lazy_static::lazy_static;
+use linux_raw_sys::{
+    general::{IN_IGNORED, IN_MODIFY},
+    ioctl::FIONREAD,
+};
+use starry_vm::VmMutPtr;
+
+use crate::file::{FileLike, IoDst, IoSrc};
+
+const INOTIFY_EVENT_SIZE: usize = 16;
+const MAX_QUEUED_EVENTS: usize = 1024;
+
+#[derive(Clone)]
+struct Watch {
+    path: String,
+    mask: u32,
+}
+
+#[derive(Default)]
+struct InotifyState {
+    next_wd: i32,
+    watches: BTreeMap<i32, Watch>,
+    queue: VecDeque<Vec<u8>>,
+}
+
+pub struct Inotify {
+    non_blocking: AtomicBool,
+    state: Mutex<InotifyState>,
+    poll_rx: PollSet,
+}
+
+lazy_static! {
+    static ref INOTIFY_INSTANCES: Mutex<Vec<Weak<Inotify>>> = Mutex::new(Vec::new());
+}
+
+impl Inotify {
+    pub fn new() -> Arc<Self> {
+        let inotify = Arc::new(Self {
+            non_blocking: AtomicBool::new(false),
+            state: Mutex::new(InotifyState {
+                next_wd: 1,
+                ..InotifyState::default()
+            }),
+            poll_rx: PollSet::new(),
+        });
+        INOTIFY_INSTANCES.lock().push(Arc::downgrade(&inotify));
+        inotify
+    }
+
+    pub fn add_watch(&self, path: String, mask: u32) -> AxResult<i32> {
+        if mask == 0 {
+            return Err(AxError::InvalidInput);
+        }
+
+        let mut state = self.state.lock();
+        if let Some((wd, watch)) = state
+            .watches
+            .iter_mut()
+            .find(|(_, watch)| watch.path == path)
+        {
+            watch.mask = mask;
+            return Ok(*wd);
+        }
+
+        let wd = state.next_wd;
+        state.next_wd = state.next_wd.checked_add(1).ok_or(AxError::NoMemory)?;
+        state.watches.insert(wd, Watch { path, mask });
+        Ok(wd)
+    }
+
+    pub fn rm_watch(&self, wd: i32) -> AxResult {
+        let mut state = self.state.lock();
+        if state.watches.remove(&wd).is_none() {
+            return Err(AxError::InvalidInput);
+        }
+        Self::push_event(&mut state.queue, wd, IN_IGNORED);
+        self.poll_rx.wake();
+        Ok(())
+    }
+
+    fn notify_modify(&self, path: &str) {
+        let mut state = self.state.lock();
+        let matched_wds = state
+            .watches
+            .iter()
+            .filter_map(|(wd, watch)| {
+                if watch.path == path && watch.mask & IN_MODIFY != 0 {
+                    Some(*wd)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if matched_wds.is_empty() {
+            return;
+        }
+        for wd in matched_wds {
+            Self::push_event(&mut state.queue, wd, IN_MODIFY);
+        }
+        self.poll_rx.wake();
+    }
+
+    fn push_event(queue: &mut VecDeque<Vec<u8>>, wd: i32, mask: u32) {
+        if queue.len() >= MAX_QUEUED_EVENTS {
+            queue.pop_front();
+        }
+
+        let mut event = Vec::with_capacity(INOTIFY_EVENT_SIZE);
+        event.extend_from_slice(&wd.to_ne_bytes());
+        event.extend_from_slice(&mask.to_ne_bytes());
+        event.extend_from_slice(&0u32.to_ne_bytes());
+        event.extend_from_slice(&0u32.to_ne_bytes());
+        queue.push_back(event);
+    }
+}
+
+impl FileLike for Inotify {
+    fn read(&self, dst: &mut IoDst) -> AxResult<usize> {
+        if dst.remaining_mut() < INOTIFY_EVENT_SIZE {
+            return Err(AxError::InvalidInput);
+        }
+
+        block_on(poll_io(self, IoEvents::IN, self.nonblocking(), || {
+            let mut state = self.state.lock();
+            let mut written = 0;
+            while let Some(event) = state.queue.front() {
+                if dst.remaining_mut() < event.len() {
+                    break;
+                }
+                written += dst.write(event)?;
+                state.queue.pop_front();
+            }
+            if written == 0 {
+                Err(AxError::WouldBlock)
+            } else {
+                Ok(written)
+            }
+        }))
+    }
+
+    fn write(&self, _src: &mut IoSrc) -> AxResult<usize> {
+        Err(AxError::BadFileDescriptor)
+    }
+
+    fn nonblocking(&self) -> bool {
+        self.non_blocking.load(Ordering::Acquire)
+    }
+
+    fn set_nonblocking(&self, non_blocking: bool) -> AxResult {
+        self.non_blocking.store(non_blocking, Ordering::Release);
+        Ok(())
+    }
+
+    fn path(&self) -> Cow<'_, str> {
+        "anon_inode:[inotify]".into()
+    }
+
+    fn ioctl(&self, cmd: u32, arg: usize) -> AxResult<usize> {
+        match cmd {
+            FIONREAD => {
+                let pending = self
+                    .state
+                    .lock()
+                    .queue
+                    .iter()
+                    .map(Vec::len)
+                    .sum::<usize>()
+                    .min(u32::MAX as usize) as u32;
+                (arg as *mut u32).vm_write(pending)?;
+                Ok(0)
+            }
+            _ => Err(AxError::NotATty),
+        }
+    }
+}
+
+impl Pollable for Inotify {
+    fn poll(&self) -> IoEvents {
+        let mut events = IoEvents::empty();
+        events.set(IoEvents::IN, !self.state.lock().queue.is_empty());
+        events
+    }
+
+    fn register(&self, context: &mut Context<'_>, events: IoEvents) {
+        if events.contains(IoEvents::IN) {
+            self.poll_rx.register(context.waker());
+        }
+    }
+}
+
+pub fn notify_modify_path(path: &str) {
+    if path == "<error>" {
+        return;
+    }
+
+    let mut instances = INOTIFY_INSTANCES.lock();
+    instances.retain(|watcher| {
+        if let Some(inotify) = watcher.upgrade() {
+            inotify.notify_modify(path);
+            true
+        } else {
+            false
+        }
+    });
+}

--- a/os/StarryOS/kernel/src/file/mod.rs
+++ b/os/StarryOS/kernel/src/file/mod.rs
@@ -1,6 +1,7 @@
 pub mod epoll;
 pub mod event;
 mod fs;
+pub mod inotify;
 #[cfg(feature = "sg2002")]
 pub mod ion;
 pub mod memfd;

--- a/os/StarryOS/kernel/src/file/mod.rs
+++ b/os/StarryOS/kernel/src/file/mod.rs
@@ -25,7 +25,8 @@ use axpoll::Pollable;
 use downcast_rs::{DowncastSync, impl_downcast};
 use flatten_objects::FlattenObjects;
 use linux_raw_sys::general::{
-    O_PATH, O_RDONLY, O_WRONLY, RLIMIT_NOFILE, STATX_BASIC_STATS, stat, statx, statx_timestamp,
+    O_ACCMODE, O_PATH, O_RDONLY, O_RDWR, O_WRONLY, RLIMIT_NOFILE, STATX_BASIC_STATS, stat, statx,
+    statx_timestamp,
 };
 use spin::RwLock;
 
@@ -304,6 +305,14 @@ pub fn close_file_like(fd: c_int) -> AxResult {
     Ok(())
 }
 
+fn notify_close_write(fd: &FileDescriptor) {
+    let access = fd.inner.open_flags() & O_ACCMODE;
+    if (access == O_WRONLY || access == O_RDWR) && fd.inner.is::<File>() {
+        let path = fd.inner.path();
+        inotify::notify_close_write_path(path.as_ref());
+    }
+}
+
 /// Close-time advisory-lock cleanup (the kernel side of POSIX
 /// "close-eats-locks", plus OFD release-on-last-close):
 ///
@@ -321,6 +330,7 @@ pub fn close_file_like(fd: c_int) -> AxResult {
 /// `Weak` still alive, and sleep forever.
 pub fn release_locks_on_close(fd: FileDescriptor) {
     let key = fd.inner.inode_key();
+    notify_close_write(&fd);
     if let Some(k) = key {
         let pid = current().as_thread().proc_data.proc.pid();
         crate::syscall::release_inode_posix_locks(pid, k);
@@ -375,6 +385,9 @@ pub fn close_all_fds() {
         .iter()
         .filter_map(|fd| fd.inner.inode_key())
         .collect();
+    for fd in &removed {
+        notify_close_write(fd);
+    }
     // Drop removed descriptors after releasing FD_TABLE lock to avoid
     // lock re-entry or side effects from destructor paths.
     drop(removed);

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -1,4 +1,9 @@
-use alloc::{ffi::CString, vec, vec::Vec};
+use alloc::{
+    ffi::CString,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use core::{
     ffi::{c_char, c_int},
     mem::offset_of,
@@ -22,6 +27,14 @@ use crate::{
     task::AsThread,
     time::TimeValueLike,
 };
+
+fn path_info_at(dirfd: i32, path: &str) -> AxResult<(String, bool)> {
+    with_fs(dirfd, |fs| {
+        let loc = fs.resolve_no_follow(path)?;
+        let is_dir = loc.metadata()?.node_type == NodeType::Directory;
+        Ok((loc.absolute_path()?.to_string(), is_dir))
+    })
+}
 
 /// The ioctl() system call manipulates the underlying device parameters
 /// of special files.
@@ -137,7 +150,7 @@ pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize
     // call tp:trace_sys_mkdirat
     trace_sys_mkdirat(&path, mode.bits());
 
-    with_fs(dirfd, |fs| match fs.create_dir(&path, mode) {
+    let result = with_fs(dirfd, |fs| match fs.create_dir(&path, mode) {
         Ok(_) => Ok(0),
         // mkdir on an existing path should report EEXIST.
         // Use no-follow lookup so dangling symlinks are treated as existing
@@ -146,7 +159,13 @@ pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize
             Err(AxError::AlreadyExists)
         }
         Err(err) => Err(err),
-    })
+    });
+    if result.is_ok()
+        && let Ok((path, _)) = path_info_at(dirfd, &path)
+    {
+        crate::file::inotify::notify_create_path(&path, true);
+    }
+    result
 }
 
 pub fn sys_mknodat(dirfd: i32, path: *const c_char, mode: u32, dev: u64) -> Result<isize, AxError> {
@@ -339,14 +358,21 @@ pub fn sys_unlinkat(dirfd: i32, path: *const c_char, flags: usize) -> AxResult<i
         return Err(AxError::InvalidInput);
     }
 
-    with_fs(dirfd, |fs| {
+    let deleted = path_info_at(dirfd, &path).ok();
+    let result = with_fs(dirfd, |fs| {
         if flags & AT_REMOVEDIR as usize != 0 {
-            fs.remove_dir(path)?;
+            fs.remove_dir(&path)?;
         } else {
-            fs.remove_file(path)?;
+            fs.remove_file(&path)?;
         }
         Ok(0)
-    })
+    });
+    if result.is_ok()
+        && let Some((path, is_dir)) = deleted
+    {
+        crate::file::inotify::notify_delete_path(&path, is_dir);
+    }
+    result
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -270,9 +270,21 @@ pub fn sys_openat(
 
     let cred = current().as_thread().cred();
     let options = flags_to_options(flags, mode, (cred.fsuid, cred.fsgid));
-    with_fs(dirfd, |fs| options.open(fs, path))
-        .and_then(|it| add_to_fd(it, flags as _))
-        .map(|fd| fd as isize)
+    let should_notify_create = uflags & O_CREAT != 0
+        && uflags & O_PATH == 0
+        && with_fs(dirfd, |fs| match fs.resolve_no_follow(&path) {
+            Ok(_) => Ok(false),
+            Err(AxError::NotFound) => Ok(true),
+            Err(err) => Err(err),
+        })?;
+
+    let fd =
+        with_fs(dirfd, |fs| options.open(fs, path)).and_then(|it| add_to_fd(it, flags as _))?;
+    if should_notify_create {
+        let file = get_file_like(fd)?;
+        crate::file::inotify::notify_create_path(file.path().as_ref(), false);
+    }
+    Ok(fd as isize)
 }
 
 /// Open a file by `filename` and insert it into the file descriptor table.

--- a/os/StarryOS/kernel/src/syscall/fs/inotify.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/inotify.rs
@@ -1,0 +1,47 @@
+use alloc::string::ToString;
+use core::ffi::{c_char, c_int};
+
+use ax_errno::{AxError, AxResult};
+use linux_raw_sys::general::{AT_FDCWD, IN_CLOEXEC, IN_NONBLOCK};
+
+use crate::{
+    file::{FileLike, add_file_like, get_file_like, inotify::Inotify, resolve_at},
+    mm::vm_load_string,
+};
+
+pub fn sys_inotify_init1(flags: u32) -> AxResult<isize> {
+    debug!("sys_inotify_init1 <= flags: {flags}");
+
+    let valid_flags = IN_CLOEXEC | IN_NONBLOCK;
+    if flags & !valid_flags != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
+    let inotify = Inotify::new();
+    inotify.set_nonblocking(flags & IN_NONBLOCK != 0)?;
+    add_file_like(inotify as _, flags & IN_CLOEXEC != 0).map(|fd| fd as _)
+}
+
+pub fn sys_inotify_add_watch(fd: c_int, path: *const c_char, mask: u32) -> AxResult<isize> {
+    let path = vm_load_string(path)?;
+    debug!("sys_inotify_add_watch <= fd: {fd}, path: {path}, mask: {mask}");
+
+    let resolved_path = resolve_at(AT_FDCWD, Some(&path), 0)?
+        .into_file()
+        .and_then(|loc| loc.absolute_path().ok().map(|path| path.to_string()))
+        .ok_or(AxError::InvalidInput)?;
+
+    let inotify = get_file_like(fd)?
+        .downcast_arc::<Inotify>()
+        .map_err(|_| AxError::InvalidInput)?;
+    inotify.add_watch(resolved_path, mask).map(|wd| wd as isize)
+}
+
+pub fn sys_inotify_rm_watch(fd: c_int, wd: c_int) -> AxResult<isize> {
+    debug!("sys_inotify_rm_watch <= fd: {fd}, wd: {wd}");
+
+    let inotify = get_file_like(fd)?
+        .downcast_arc::<Inotify>()
+        .map_err(|_| AxError::InvalidInput)?;
+    inotify.rm_watch(wd).map(|()| 0)
+}

--- a/os/StarryOS/kernel/src/syscall/fs/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mod.rs
@@ -1,6 +1,7 @@
 mod ctl;
 mod event;
 mod fd_ops;
+mod inotify;
 mod io;
 mod lock;
 mod memfd;
@@ -15,6 +16,7 @@ pub use self::{
     ctl::*,
     event::*,
     fd_ops::*,
+    inotify::*,
     io::*,
     lock::{release_inode_posix_locks, release_pid_locks, wake_flock_waiters, wake_lock_waiters},
     memfd::*,

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -318,6 +318,13 @@ pub fn handle_syscall(uctx: &mut UserContext) {
 
         // event
         Sysno::eventfd2 => sys_eventfd2(uctx.arg0() as _, uctx.arg1() as _),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::inotify_init => sys_inotify_init1(0),
+        Sysno::inotify_init1 => sys_inotify_init1(uctx.arg0() as _),
+        Sysno::inotify_add_watch => {
+            sys_inotify_add_watch(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _)
+        }
+        Sysno::inotify_rm_watch => sys_inotify_rm_watch(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::timerfd_create => sys_timerfd_create(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::timerfd_settime => sys_timerfd_settime(
             uctx.arg0() as _,
@@ -713,7 +720,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         | Sysno::open_tree
         | Sysno::memfd_secret => sys_dummy_fd(sysno),
 
-        Sysno::fanotify_init | Sysno::inotify_init1 => Err(AxError::Unsupported),
+        Sysno::fanotify_init => Err(AxError::Unsupported),
 
         Sysno::timer_create => {
             sys_timer_create(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _)

--- a/test-suit/starryos/normal/qemu-smp1/inotifywait/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/inotifywait/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/inotifywait-tests.sh"
+success_regex = ["(?m)^INOTIFYWAIT_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^INOTIFYWAIT_TEST_FAILED:"]
+timeout = 600

--- a/test-suit/starryos/normal/qemu-smp1/inotifywait/sh/inotifywait-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/inotifywait/sh/inotifywait-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+fail() {
+    echo "INOTIFYWAIT_TEST_FAILED: $*"
+    exit 1
+}
+
+apk update || fail "apk update"
+apk add inotify-tools || fail "apk add inotify-tools"
+
+command -v inotifywait >/dev/null || fail "inotifywait missing"
+
+workdir=/tmp/starry-inotifywait
+watched="$workdir/watched.txt"
+out="$workdir/out"
+err="$workdir/err"
+
+rm -rf "$workdir"
+mkdir -p "$workdir"
+: > "$watched"
+
+(
+    sleep 1
+    echo changed >> "$watched"
+) &
+writer=$!
+
+if ! inotifywait -q -e modify --format "%w %e" -t 5 "$watched" > "$out" 2> "$err"; then
+    wait "$writer" || true
+    cat "$err"
+    fail "inotifywait did not observe modify"
+fi
+
+wait "$writer" || true
+grep -q "MODIFY" "$out" || fail "missing MODIFY event"
+
+echo "INOTIFYWAIT_TEST_PASSED"

--- a/test-suit/starryos/normal/qemu-smp1/inotifywait/sh/inotifywait-tests.sh
+++ b/test-suit/starryos/normal/qemu-smp1/inotifywait/sh/inotifywait-tests.sh
@@ -13,11 +13,13 @@ command -v inotifywait >/dev/null || fail "inotifywait missing"
 
 workdir=/tmp/starry-inotifywait
 watched="$workdir/watched.txt"
+watchdir="$workdir/watchdir"
 out="$workdir/out"
 err="$workdir/err"
 
 rm -rf "$workdir"
 mkdir -p "$workdir"
+mkdir -p "$watchdir"
 : > "$watched"
 
 (
@@ -34,5 +36,51 @@ fi
 
 wait "$writer" || true
 grep -q "MODIFY" "$out" || fail "missing MODIFY event"
+
+(
+    sleep 1
+    : > "$watchdir/created.txt"
+) &
+creator=$!
+
+if ! inotifywait -q -e create --format "%f %e" -t 5 "$watchdir" > "$out" 2> "$err"; then
+    wait "$creator" || true
+    cat "$err"
+    fail "inotifywait did not observe create"
+fi
+
+wait "$creator" || true
+grep -q "created.txt .*CREATE" "$out" || fail "missing CREATE event"
+
+(
+    sleep 1
+    echo closed > "$watchdir/closed.txt"
+) &
+closer=$!
+
+if ! inotifywait -q -e close_write --format "%f %e" -t 5 "$watchdir" > "$out" 2> "$err"; then
+    wait "$closer" || true
+    cat "$err"
+    fail "inotifywait did not observe close_write"
+fi
+
+wait "$closer" || true
+grep -q "closed.txt .*CLOSE_WRITE" "$out" || fail "missing CLOSE_WRITE event"
+
+: > "$watchdir/deleted.txt"
+(
+    sleep 1
+    rm "$watchdir/deleted.txt"
+) &
+deleter=$!
+
+if ! inotifywait -q -e delete --format "%f %e" -t 5 "$watchdir" > "$out" 2> "$err"; then
+    wait "$deleter" || true
+    cat "$err"
+    fail "inotifywait did not observe delete"
+fi
+
+wait "$deleter" || true
+grep -q "deleted.txt .*DELETE" "$out" || fail "missing DELETE event"
 
 echo "INOTIFYWAIT_TEST_PASSED"


### PR DESCRIPTION
## 问题

`inotifywait` 依赖 Linux inotify 系统调用来创建监听 fd、添加 watch，并通过 poll/read 获取文件事件。StarryOS 之前对 `inotify_init1` 直接返回 `Unsupported`，因此 `inotify-tools` 中的 `inotifywait` 无法运行。

## 修改

1. 新增 `Inotify` file-like 对象，支持：
   - `inotify_init1` 创建匿名 fd
   - `inotify_add_watch` / `inotify_rm_watch`
   - poll/read 读取 `inotify_event`
   - `IN_NONBLOCK` / `IN_CLOEXEC`
   - `ioctl(FIONREAD)` 查询当前事件队列可读字节数
   - 目录 watch 事件携带 `name` 字段
2. 接入文件系统事件：
   - 普通文件 `write` 成功后投递 `IN_MODIFY`
   - `open(O_CREAT)` 新建文件后向父目录投递 `IN_CREATE`
   - 可写文件描述符关闭时投递 `IN_CLOSE_WRITE`
   - `unlinkat` / `rmdir` 成功后投递 `IN_DELETE`，直接 watch 被删除路径时投递 `IN_DELETE_SELF`
3. 扩展 `test-suit/starryos/normal/qemu-smp1/inotifywait` 用例，在 guest 中安装 `inotify-tools`，验证 `MODIFY`、`CREATE`、`CLOSE_WRITE`、`DELETE` 都能被 `inotifywait` 观察到。

## 实现逻辑

当前实现覆盖 `inotifywait` 的常用核心路径。watch 以解析后的绝对路径为 key，普通文件事件同时匹配直接 watch 和父目录 watch；父目录事件会把文件名写入 `inotify_event.name`，以满足 `inotifywait --format %f` 等目录监听场景。删除路径时会清理对应 watch，避免后续继续对已删除路径投递事件。

## 验证

- `cargo fmt`
- Docker: `cargo xtask starry test qemu --arch x86_64 -c inotifywait`
- Docker: `cargo xtask clippy --package starry-kernel`