### PR TITLE
fix(epoll,sigmask-related): align sigsetsize checks with linux abi

### DIFF
--- a/os/StarryOS/kernel/src/syscall/io_mpx/poll.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/poll.rs
@@ -157,7 +157,9 @@ pub fn sys_ppoll(
     sigmask: UserConstPtr<SignalSet>,
     sigsetsize: usize,
 ) -> AxResult<isize> {
-    check_sigset_size(sigsetsize)?;
+    if !sigmask.is_null() {
+        check_sigset_size(sigsetsize)?;
+    }
     let nfds = nfds.try_into().map_err(|_| AxError::InvalidInput)?;
     let mut poll_fds = read_poll_fds(fds, nfds)?;
     let timeout = nullable!(timeout.get_as_ref())?

--- a/os/StarryOS/kernel/src/syscall/signal.rs
+++ b/os/StarryOS/kernel/src/syscall/signal.rs
@@ -23,11 +23,9 @@ use crate::{
 };
 
 pub(crate) fn check_sigset_size(size: usize) -> AxResult<()> {
-    // Accept the kernel sigset size and any larger libc/ABI sigset size,
-    // since the kernel only uses the low `size_of::<SignalSet>()` bytes
-    // (glibc uses 8, musl uses 16). Keep accepting 0 for callers that use
-    // it to mean "no mask".
-    if size != 0 && size < size_of::<SignalSet>() {
+    // Align with Linux raw syscall semantics (for ABI param 'sigmask'): when sigsetsize is checked,
+    // it must exactly match the kernel SignalSet size (8 bytes).
+    if size != size_of::<SignalSet>() {
         return Err(AxError::InvalidInput);
     }
     Ok(())

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-epoll-pwait-sigsetsize/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-epoll-pwait-sigsetsize/c/src/main.c
@@ -1,10 +1,9 @@
 /*
  * test_epoll_pwait_sigsetsize.c
  *
- * epoll_pwait 的 sigsetsize 参数在 musl libc 下为 16 字节 (musl _NSIG/8 = 128/8)，
- * glibc 为 8 字节，内核 sigset 为 8 字节。内核应接受任意 >= 内核 sigset 大小的值，
- * 只读取低 8 字节。本测试通过直接发起 syscall 绕过 libc wrapper，验证不同 sigsetsize
- * 的接受行为，并验证 sigmask 为 NULL 时 sigsetsize 不再参与校验（epoll_wait 语义）。
+ * 验证 raw epoll_pwait 的 sigsetsize 语义：
+ * - sigmask == NULL 时，sigsetsize 不参与校验；
+ * - sigmask != NULL 时，sigsetsize 必须严格等于 8。
  */
 
 #include "test_framework.h"
@@ -22,7 +21,7 @@ static long raw_epoll_pwait(int epfd, struct epoll_event *events, int maxevents,
 
 int main(void)
 {
-    TEST_START("epoll_pwait: sigsetsize 兼容 musl/glibc");
+    TEST_START("epoll_pwait: sigsetsize Linux semantics");
 
     int epfd = epoll_create1(0);
     CHECK(epfd >= 0, "epoll_create1 ok");
@@ -58,15 +57,23 @@ int main(void)
         CHECK(r == 0, "sigmask + size=8 (glibc) accepted");
     }
 
-    /* Test 4: real sigmask with musl-style sigsetsize = 16 */
+    /* Test 4: real sigmask with sigsetsize = 16 should fail */
     {
         sigset_t mask;
         sigemptyset(&mask);
         long r = raw_epoll_pwait(epfd, out, 4, 0, &mask, 16);
-        CHECK(r == 0, "sigmask + size=16 (musl) accepted");
+        CHECK(r == -1 && errno == EINVAL, "sigmask + size=16 rejected with EINVAL");
     }
 
-    /* Test 5: sigsetsize smaller than kernel sigset should fail */
+    /* Test 5: non-NULL sigmask with size=0 should fail */
+    {
+        sigset_t mask;
+        sigemptyset(&mask);
+        long r = raw_epoll_pwait(epfd, out, 4, 0, &mask, 0);
+        CHECK(r == -1 && errno == EINVAL, "sigmask + size=0 rejected with EINVAL");
+    }
+
+    /* Test 6: sigsetsize smaller than kernel sigset should fail */
     {
         sigset_t mask;
         sigemptyset(&mask);

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-epoll-pwait2/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-epoll-pwait2/c/src/main.c
@@ -14,6 +14,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#define KERNEL_SIGSET_SIZE 8
+
 static void on_sigusr1(int signo)
 {
     (void)signo;
@@ -32,7 +34,7 @@ static void test_invalid_args(void)
     struct epoll_event out[4];
 
     errno = 0;
-    CHECK(raw_epoll_pwait2(-1, out, 4, NULL, NULL, sizeof(sigset_t)) == -1 && errno == EBADF,
+    CHECK(raw_epoll_pwait2(-1, out, 4, NULL, NULL, KERNEL_SIGSET_SIZE) == -1 && errno == EBADF,
           "invalid epfd returns EBADF");
 
     int epfd = epoll_create1(0);
@@ -42,11 +44,11 @@ static void test_invalid_args(void)
     }
 
     errno = 0;
-    CHECK(raw_epoll_pwait2(epfd, out, 0, NULL, NULL, sizeof(sigset_t)) == -1 && errno == EINVAL,
+    CHECK(raw_epoll_pwait2(epfd, out, 0, NULL, NULL, KERNEL_SIGSET_SIZE) == -1 && errno == EINVAL,
           "maxevents == 0 returns EINVAL");
 
     errno = 0;
-    CHECK(raw_epoll_pwait2(epfd, out, -1, NULL, NULL, sizeof(sigset_t)) == -1 && errno == EINVAL,
+    CHECK(raw_epoll_pwait2(epfd, out, -1, NULL, NULL, KERNEL_SIGSET_SIZE) == -1 && errno == EINVAL,
           "maxevents < 0 returns EINVAL");
 
     close(epfd);
@@ -78,11 +80,11 @@ static void test_null_timeout_and_zero_timeout(void)
     struct epoll_event out[4];
     struct timespec ts0 = {.tv_sec = 0, .tv_nsec = 0};
 
-    CHECK_RET(raw_epoll_pwait2(epfd, out, 4, &ts0, NULL, sizeof(sigset_t)), 0,
+    CHECK_RET(raw_epoll_pwait2(epfd, out, 4, &ts0, NULL, KERNEL_SIGSET_SIZE), 0,
               "zero timeout returns 0 when no fd is ready");
 
     CHECK_RET(write(pipefd[1], "X", 1), 1, "write one byte to pipe");
-    long n = raw_epoll_pwait2(epfd, out, 4, NULL, NULL, sizeof(sigset_t));
+    long n = raw_epoll_pwait2(epfd, out, 4, NULL, NULL, KERNEL_SIGSET_SIZE);
     CHECK(n == 1 && (out[0].events & EPOLLIN) != 0 && out[0].data.fd == pipefd[0],
           "NULL timeout waits and returns ready event");
 
@@ -108,12 +110,17 @@ static void test_timeout_and_sigsetsize(void)
     CHECK_RET(raw_epoll_pwait2(epfd, out, 4, &ts, NULL, 0), 0,
               "NULL sigmask ignores sigsetsize and times out");
 
-    CHECK_RET(raw_epoll_pwait2(epfd, out, 4, &ts, &mask, sizeof(sigset_t)), 0,
-              "sigmask + sizeof(sigset_t) accepted");
+    CHECK_RET(raw_epoll_pwait2(epfd, out, 4, &ts, &mask, KERNEL_SIGSET_SIZE), 0,
+              "sigmask + size=8 accepted");
 
     errno = 0;
     CHECK(raw_epoll_pwait2(epfd, out, 4, &ts, &mask, 4) == -1 && errno == EINVAL,
           "sigmask with too small sigsetsize returns EINVAL");
+
+    errno = 0;
+    size_t bad_size = sizeof(sigset_t) == KERNEL_SIGSET_SIZE ? 16 : sizeof(sigset_t);
+    CHECK(raw_epoll_pwait2(epfd, out, 4, &ts, &mask, bad_size) == -1 && errno == EINVAL,
+          "sigmask with non-8 sigsetsize returns EINVAL");
 
     close(epfd);
 }
@@ -143,7 +150,7 @@ static void test_efault_events_ptr(void)
     CHECK_RET(write(pipefd[1], "Z", 1), 1, "write one byte to make event ready");
 
     errno = 0;
-    long n = raw_epoll_pwait2(epfd, (struct epoll_event *)(uintptr_t)1, 1, NULL, NULL, sizeof(sigset_t));
+    long n = raw_epoll_pwait2(epfd, (struct epoll_event *)(uintptr_t)1, 1, NULL, NULL, KERNEL_SIGSET_SIZE);
     CHECK(n == -1 && errno == EFAULT, "invalid events pointer returns EFAULT");
 
     close(pipefd[0]);
@@ -166,7 +173,7 @@ static void test_timeout_monotonic_duration(void)
     struct timespec end;
     CHECK(clock_gettime(CLOCK_MONOTONIC, &start) == 0, "clock_gettime start ok");
 
-    long n = raw_epoll_pwait2(epfd, out, 2, &ts, NULL, sizeof(sigset_t));
+    long n = raw_epoll_pwait2(epfd, out, 2, &ts, NULL, KERNEL_SIGSET_SIZE);
     CHECK(n == 0, "no event with 100ms timeout returns 0");
 
     CHECK(clock_gettime(CLOCK_MONOTONIC, &end) == 0, "clock_gettime end ok");
@@ -214,11 +221,11 @@ static void test_maxevents_boundary(void)
     CHECK_RET(write(p2[1], "B", 1), 1, "write pipe2");
 
     struct epoll_event one[1];
-    long n1 = raw_epoll_pwait2(epfd, one, 1, NULL, NULL, sizeof(sigset_t));
+    long n1 = raw_epoll_pwait2(epfd, one, 1, NULL, NULL, KERNEL_SIGSET_SIZE);
     CHECK(n1 == 1, "maxevents=1 returns exactly one ready event");
 
     struct epoll_event many[1024];
-    long n2 = raw_epoll_pwait2(epfd, many, 1024, NULL, NULL, sizeof(sigset_t));
+    long n2 = raw_epoll_pwait2(epfd, many, 1024, NULL, NULL, KERNEL_SIGSET_SIZE);
     CHECK(n2 >= 1, "large maxevents can fetch remaining ready events");
 
     close(p1[0]);
@@ -259,7 +266,7 @@ static void test_sigmask_effect_and_eintr(void)
     struct epoll_event out[1];
 
     errno = 0;
-    long r_masked = raw_epoll_pwait2(epfd, out, 1, &ts, &block_usr1, sizeof(sigset_t));
+    long r_masked = raw_epoll_pwait2(epfd, out, 1, &ts, &block_usr1, KERNEL_SIGSET_SIZE);
     CHECK(r_masked == 0, "masked SIGUSR1 does not interrupt epoll_pwait2 timeout");
     waitpid(pid, NULL, 0);
 
@@ -272,7 +279,7 @@ static void test_sigmask_effect_and_eintr(void)
     }
 
     errno = 0;
-    r_masked = raw_epoll_pwait2(epfd, out, 1, NULL, NULL, sizeof(sigset_t));
+    r_masked = raw_epoll_pwait2(epfd, out, 1, NULL, NULL, KERNEL_SIGSET_SIZE);
     CHECK(r_masked == -1 && errno == EINTR, "unmasked signal interrupts with EINTR");
     waitpid(pid, NULL, 0);
 

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-pselect-ppoll/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-pselect-ppoll/c/src/main.c
@@ -8,6 +8,8 @@
 #include <signal.h>
 #include <sys/syscall.h>
 
+#define KERNEL_SIGSET_SIZE 8
+
 // Helper to invoke raw pselect6 if available
 static int raw_pselect6(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timespec *timeout, const sigset_t *sigmask) {
 #ifdef SYS_pselect6
@@ -16,7 +18,7 @@ static int raw_pselect6(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exc
     struct {
         const sigset_t *ss;
         size_t ss_len;
-    } data = { sigmask, sizeof(sigset_t) };
+    } data = { sigmask, KERNEL_SIGSET_SIZE };
     return syscall(SYS_pselect6, nfds, readfds, writefds, exceptfds, timeout, &data);
 #else
     return pselect(nfds, readfds, writefds, exceptfds, timeout, sigmask);
@@ -26,7 +28,7 @@ static int raw_pselect6(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exc
 // Helper to invoke raw ppoll if available
 static int raw_ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const sigset_t *sigmask) {
 #ifdef SYS_ppoll
-    return syscall(SYS_ppoll, fds, nfds, tmo_p, sigmask, sizeof(sigset_t));
+    return syscall(SYS_ppoll, fds, nfds, tmo_p, sigmask, KERNEL_SIGSET_SIZE);
 #else
     return ppoll(fds, nfds, tmo_p, sigmask);
 #endif

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-signalfd4/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-signalfd4/c/src/main.c
@@ -3,7 +3,7 @@
  *
  * 覆盖场景：
  *   1. 基本创建：各种 flag 组合，非法 flags → EINVAL
- *   2. sigsetsize 校验：size < 8 → EINVAL
+ *   2. sigsetsize 校验：非空 mask 时 size 必须为 8
  *   3. 修改已有 signalfd 的 mask（fd != -1）
  *   4. 修改已有 fd 时传 SFD_CLOEXEC → EINVAL
  *   5. 非阻塞空读 → EAGAIN
@@ -130,9 +130,9 @@ static void test_sigsetsize(void) {
     CHECK(fd >= 0, "sigsetsize=8 succeeds");
     if (fd >= 0) close(fd);
 
-    /* sigsetsize=0 is explicitly allowed ("no mask" callers) */
+    /* non-NULL mask with sigsetsize=0 should fail */
     fd = (int)syscall(__NR_signalfd4, -1, &mask, 0, 0);
-    CHECK(fd >= 0, "sigsetsize=0 succeeds");
+    CHECK(fd == -1 && errno == EINVAL, "sigsetsize=0 -> EINVAL");
     if (fd >= 0) close(fd);
 }
 


### PR DESCRIPTION
在 Linux 运行 `epoll_pwait2` 测例未通过。继续追查后发现，StarryOS 在处理这类带 `sigmask` 参数的信号相关 syscall 时，和 Linux 的 `sigsetsize` 语义存在偏差。在 `test-suit/starryos/normal/qemu-smp1/syscall` 范围内，至少有 `test-epoll-pwait-sigsetsize`、`test-epoll-pwait2`、`test-pselect-ppoll`、`test-signalfd4` 四个在 starryos 跑通的测例，在 Linux 用户态运行都未通过。

## 说明

这类 raw syscall ABI 里，libc 需要额外补一个 `sigsetsize` 参数，用来表示 `sigmask` 的有效字节数，该有效字节数对应 `sigmask` 在内核中 u64 的 `SignalSet` 类型，因此应当传入 8。

在 Linux 上观察到的行为是：

- 当 `sigmask == NULL` 时，`sigsetsize` 不参与校验。
- 当 `sigmask != NULL` 时，`sigsetsize` 必须严格等于 8（也不接受 0）。

而 StarryOS 当前实现允许更宽松的取值范围。PR #250 之前，内核只允许 `0` 和 `8`（`size_of::<SignalSet>()`）；#250 之后放宽为允许 `0` 和任意大于等于 `8` 的值，均和 Linux 语义不符。

由于 #250 中提到 "16（musl `sigset_t` 大小）"，可能是误把用户态 128 位 `sigset_t` 对应的字节数 16 当作正确输入，因此推断 #250 的修改有误，在 `sigmask` 非空时，starryos 应该严格检查 `sigsetsize` 是否为 8。而 #250 提到的网络应用错误有可能是应用本身传递了错误的参数。在 Linux 环境下，上述的 `sigsetsize` 相关测例，包括一例 #250 新增测例，都因为这一原因未通过。

## musl 源码确认

#250 提到 musl 的 `epoll_pwait` 封装传入了 `sigsetsize=16`。musl 的 `epoll_pwait` 封装如下：

<https://git.musl-libc.org/cgit/musl/tree/src/linux/epoll.c>

```c
int epoll_pwait(int fd, struct epoll_event *ev, int cnt, int to, const sigset_t *sigs)
{
	int r = __syscall_cp(SYS_epoll_pwait, fd, ev, cnt, to, sigs, _NSIG/8);
#ifdef SYS_epoll_wait
	if (r==-ENOSYS && !sigs) r = __syscall_cp(SYS_epoll_wait, fd, ev, cnt, to);
#endif
	return __syscall_ret(r);
}
```

也就是说 musl 直接传 `_NSIG / 8`。

继续检查 musl 所有架构 `signal.h` 中的 `_NSIG` 定义：

<https://git.musl-libc.org/cgit/musl/tree/arch/*/bits/signal.h>

| `_NSIG` | 架构 |
| ------: | --- |
| 65 | aarch64, arm, generic, i386, loongarch64, m68k, microblaze, or1k, powerpc, powerpc64, riscv32, riscv64, s390x, sh, x32, x86_64 |
| 128 | mips, mips64, mipsn32 |

因此除了 `mips`、`mips64`、`mipsn32` 会传 `sigsetsize = 16`，其余大多数架构上传入的都是 `8`。而 StarryOS 里定义的 `SignalSet` 本身也是 `u64`，因此内核只接受 `8` 更符合 Linux 语义。

## Linux 用户态实验

为了排除测试封装的干扰，又额外写了一个 Linux 用户态 raw syscall 实验，直接调用 `epoll_pwait`，分别测试：`0`、`1`、`7`、`8`、`9`、`16`、`17`、`32`、`sizeof(sigset_t)`。

实验结果如下：

| `sigsetsize` | `sigmask != NULL` | `sigmask == NULL` |
| ---: | --- | --- |
| 0 | `ret=-1 errno=EINVAL` | `ret=0 errno=0` |
| 1 | `ret=-1 errno=EINVAL` | `ret=0 errno=0` |
| 7 | `ret=-1 errno=EINVAL` | `ret=0 errno=0` |
| 8 | `ret=0 errno=0` | `ret=0 errno=0` |
| 9 | `ret=-1 errno=EINVAL` | `ret=0 errno=0` |
| 16 | `ret=-1 errno=EINVAL` | `ret=0 errno=0` |
| 17 | `ret=-1 errno=EINVAL` | `ret=0 errno=0` |
| 32 | `ret=-1 errno=EINVAL` | `ret=0 errno=0` |
| `sizeof(sigset_t)` | `ret=-1 errno=EINVAL` | `ret=0 errno=0` |

分别测试了 gcc 和 musl 两套静态链接构建，结果一致。

因此认为，在 Linux 上，`epoll_pwait` 的 raw syscall 路径里，只要 `sigmask` 非空，`sigsetsize` 就只接受 `8`。

## Linux 下未通过的 sigsetsize 相关测例

| 测例 | GCC 静态 Linux 输出 | musl 静态 Linux 输出 | 预期 | 实际 | 原因 |
| --- | --- | --- | --- | --- | --- |
| `test-epoll-pwait-sigsetsize` | `FAIL ... errno=22 (Invalid argument)` | `FAIL ... errno=22 (Invalid argument)` | 测例认为非空 `sigmask` 搭配 `sigsetsize=16` 也应成功 | Linux 返回 `EINVAL` | 测例直接调用 `raw_epoll_pwait(..., &mask, 16)`，把 `16` 当作合法输入；但 Linux 对这条 raw syscall 路径只接受 `8`。 |
| `test-epoll-pwait2` | 两处都 `FAIL ... errno=22 (Invalid argument)` | 两处都 `FAIL ... errno=22 (Invalid argument)` | 测例认为 `sizeof(sigset_t)` 合法，且带 mask 的等待应超时返回 `0` | 首个带 mask 调用就先因 `EINVAL` 失败，后面的 masked wait 也直接失败 | 测例把用户态 `sizeof(sigset_t)` 直接传给 `raw_epoll_pwait2`。在当前 Linux/x86_64 用户态里这个值是 `128`，不是内核要求的 `8`。 |
| `test-pselect-ppoll` | 多个节点都 `FAIL ... errno=22 (Invalid argument)` | 多个节点都 `FAIL ... errno=22 (Invalid argument)` | 测例期望 timeout 场景返回 `0`，有数据时返回 `1` | 这些检查点都被前置的 `EINVAL` 打断 | 测例封装 `raw_pselect6` 和 `raw_ppoll` 时，都把 `sizeof(sigset_t)` 当作长度传入。只要 `sigmask` 非空，就会先撞上 Linux 的 `sigsetsize` 校验。 |
| `test-signalfd4` | 进程提前 `*** buffer overflow detected ***: terminated` | `FAIL ... sigsetsize=0 succeeds | errno=22 (Invalid argument)` | 测例认为 `sigsetsize=0` 应成功 | musl 下该节点返回 `EINVAL`；gcc 版本后续又被 FORTIFY 终止 | 测例在 `test_sigsetsize()` 中直接断言 `syscall(__NR_signalfd4, -1, &mask, 0, 0) >= 0`。但 Linux 实际并不接受这里的 `0`。另外 gcc 静态链接版本在后续 `read(fd, small, 127)` 处还会触发 glibc FORTIFY。 |


## 改动说明

| 项目 | 改动说明 |
| --- | --- |
| 内核 `check_sigset_size` | 改为仅接受 `sigsetsize == 8`。 |
| 内核 `sys_ppoll` | 改为仅在 `sigmask != NULL` 时校验 `sigsetsize`。 |
| `test-epoll-pwait-sigsetsize` | ABI 按 `sigsetsize == 8` 调整断言。 |
| `test-epoll-pwait2` | ABI 按 `sigsetsize == 8` 调整调用和断言。 |
| `test-pselect-ppoll` | ABI 按 `sigsetsize == 8` 调整 raw syscall 封装。 |
| `test-signalfd4` | ABI 按 `sigsetsize == 8` 调整失败预期。 |

已通过本地 syscall 测试和 riscv normal 测试。


## 结论

从对齐 Linux 语义来看，`sigmask != NULL` 时，`sigsetsize` 应当只允许 `8`。而用户态调用 `sigmask` 相关 ABI 时，常见将用户态的 `sizeof(sigset_t)` 传入 `sigsetsize` 的错误，包括未通过的 Linux 参考测例中的相同错误。使用 AI 封装或测试 ABI 时，尤其注意 AI 对此类错误并不敏感。

建议：
从 Linux 兼容性的角度看，内核把 `sigsetsize` 限制为 `8` 更合理；但考虑到 StarryOS 这部分行为已经存在一段时间，而且 PR #250 的动机也是为了解决实际问题，所以尚不清楚这一改动是否会造成影响。
