### PR TITLE
feat(starry): add DeepSeek TUI example app with Docker-based build

### DIFF
--- a/apps/starry/deepseek-tui/Dockerfile.build
+++ b/apps/starry/deepseek-tui/Dockerfile.build
@@ -1,0 +1,38 @@
+FROM alpine:latest AS builder
+
+RUN apk add --no-cache \
+    dbus-dev \
+    pkgconfig \
+    gcc \
+    musl-dev \
+    git \
+    rustup
+
+ENV RUSTUP_HOME=/root/.rustup \
+    CARGO_HOME=/root/.cargo
+
+RUN rustup-init -y --default-toolchain nightly-2026-04-27
+ENV PATH=/root/.cargo/bin:$PATH
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+ARG TAG=v0.8.18
+RUN git clone --depth 1 --branch "$TAG" https://github.com/Hmbown/DeepSeek-TUI.git /src
+
+WORKDIR /src
+
+# Dynamic linking so we can link against Alpine's libdbus-1.so
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+RUN cargo build --release --locked --target x86_64-unknown-linux-musl --bin deepseek
+RUN cargo build --release --locked --target x86_64-unknown-linux-musl --bin deepseek-tui
+
+RUN strip /src/target/x86_64-unknown-linux-musl/release/deepseek \
+    /src/target/x86_64-unknown-linux-musl/release/deepseek-tui
+
+FROM alpine:latest AS export
+RUN apk add --no-cache tar
+COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/deepseek /
+COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/deepseek-tui /
+COPY --from=builder /usr/lib/libdbus-1.so.3 /usr/lib/
+COPY --from=builder /usr/lib/libdbus-1.so.3.38.3 /usr/lib/
+COPY --from=builder /usr/lib/libgcc_s.so.1 /usr/lib/

--- a/apps/starry/deepseek-tui/Dockerfile.build
+++ b/apps/starry/deepseek-tui/Dockerfile.build
@@ -33,6 +33,5 @@ FROM alpine:latest AS export
 RUN apk add --no-cache tar
 COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/deepseek /
 COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/deepseek-tui /
-COPY --from=builder /usr/lib/libdbus-1.so.3 /usr/lib/
-COPY --from=builder /usr/lib/libdbus-1.so.3.38.3 /usr/lib/
+COPY --from=builder /usr/lib/libdbus-1.so.3* /usr/lib/
 COPY --from=builder /usr/lib/libgcc_s.so.1 /usr/lib/

--- a/apps/starry/deepseek-tui/README.md
+++ b/apps/starry/deepseek-tui/README.md
@@ -1,0 +1,118 @@
+# StarryOS DeepSeek TUI 示例
+
+本目录提供在 StarryOS x86_64 QEMU 虚拟机中运行 [DeepSeek TUI](https://github.com/Hmbown/DeepSeek-TUI) 的手动示例。不参与 CI 测试套件。
+
+## 前置依赖
+
+- **Docker** — 用于在 Alpine 容器中编译 musl 动态链接的 deepseek 二进制（`libdbus-1.so.3` 在 musl 目标下需容器环境构建）
+- **Rust 工具链** — 用于编译 StarryOS 内核（`cargo xtask starry qemu`）
+- **e2fsprogs** — 提供 `debugfs`，用于向 rootfs ext4 镜像注入文件
+
+## 文件清单
+
+| 文件 | 功能 |
+|---|---|
+| `run_me.sh` | 总控脚本，支持 `--build`、`--smoke`、`--test`、`--shell`、`--api-key`、`--proxy` |
+| `prepare_deepseek_assets.sh` | 编译 deepseek + deepseek-tui 二进制，提取至 `target/deepseek/assets/`"
+| `prepare_deepseek_rootfs.sh` | 构建 Alpine rootfs，注入二进制、共享库、API Key、CA 证书 |
+| `Dockerfile.build` | Alpine Docker 构建环境，用于编译 musl 动态链接的 deepseek 二进制 |
+| `build-x86_64-unknown-none.toml` | StarryOS 内核构建配置 |
+| `qemu-x86_64.toml` | 离线 smoke 测试 QEMU 配置（无网络需求） |
+| `qemu-x86_64-deepseek-prime-test.toml` | 在线 C 素数测试 QEMU 配置（需要 API Key + 网络） |
+
+## 构建流程说明
+
+1. `prepare_deepseek_assets.sh` 优先使用 Docker（检测到 docker 命令时），在 Alpine 容器中用 musl 工具链从源码编译 deepseek + deepseek-tui，并进行动态链接（依赖 `libdbus-1.so.3` 和 `libgcc_s.so.1`）。构建产物存放在 `target/deepseek/assets/`。
+2. `prepare_deepseek_rootfs.sh` 将上述二进制和共享库注入 Alpine rootfs ext4 镜像中。额外注入 CA 证书和 `DEEPSEEK_API_KEY` 环境变量（在线测试时）。
+3. `cargo xtask starry qemu` 编译 StarryOS 内核（`x86_64-unknown-none`），挂载 rootfs，启动 QEMU 虚拟机。
+
+## 使用方法
+
+### 构建二进制
+
+```bash
+bash apps/starry/deepseek-tui/run_me.sh --build
+```
+
+或直接运行：
+
+```bash
+bash apps/starry/deepseek-tui/prepare_deepseek_assets.sh
+```
+
+### 离线 smoke 测试
+
+验证 `deepseek --version`、`deepseek-tui --version`、`deepseek model list` 等基本命令，无需 API Key。
+
+```bash
+bash apps/starry/deepseek-tui/run_me.sh --smoke
+```
+
+预期输出包含：
+
+```
+STARRY_DEEPSEEK_STAGE_G_PASSED
+```
+
+### 在线 C 素数测试
+
+向 DeepSeek 发送提示词，要求其编写 C 程序找出大于 998244352 的最小素数，编译并运行，验证输出是否为 998244353。
+
+```bash
+bash apps/starry/deepseek-tui/run_me.sh --test --api-key sk-your-key-here
+```
+
+如需代理：
+
+```bash
+bash apps/starry/deepseek-tui/run_me.sh --test --api-key sk-your-key-here --proxy http://10.0.2.2:7890
+```
+
+预期输出包含：
+
+```
+STARRY_DEEPSEEK_PRIME_TEST_DONE
+STARRY_DEEPSEEK_PRIME_TEST_PASSED
+```
+
+### 交互式 shell
+
+```bash
+bash apps/starry/deepseek-tui/run_me.sh --shell
+```
+
+或带 API Key：
+
+```bash
+bash apps/starry/deepseek-tui/run_me.sh --shell --api-key sk-your-key-here
+```
+
+### 仅构建 rootfs（不启动 QEMU）
+
+离线版：
+
+```bash
+bash apps/starry/deepseek-tui/run_me.sh --rootfs
+```
+
+在线版：
+
+```bash
+bash apps/starry/deepseek-tui/run_me.sh --rootfs --api-key sk-your-key-here
+```
+
+## 本地产物
+
+- `target/deepseek/assets/` — deepseek + deepseek-tui 二进制及运行时共享库
+- `target/deepseek/build/` — DeepSeek-TUI 源码克隆
+- `tmp/axbuild/rootfs/rootfs-x86_64-deepseek*.img` — 构建好的 rootfs 镜像
+
+以上均为不受版本控制的本地构建产物。
+
+## 注意事项
+
+- 仅支持 x86_64 QEMU，不支持其他架构
+- 不覆盖 DeepSeek TUI 交互模式、默认 Linux Sandbox、CI 在线请求等场景
+- 在线测试需要 `--api-key` 参数
+- 二进制通过动态链接 `libdbus-1.so.3` 和 `libgcc_s.so.1`，rootfs 注入脚本会自动处理这些依赖
+- **构建依赖 Docker**：`prepare_deepseek_assets.sh` 需要 Docker 运行时，在 Alpine 容器中编译 musl 动态链接的 deepseek 二进制。当前脚本在检测到 docker 命令时自动使用容器方式；若宿主机没有 Docker，会回退到本地构建（但可能因 dbus 交叉编译问题失败）

--- a/apps/starry/deepseek-tui/build-x86_64-unknown-none.toml
+++ b/apps/starry/deepseek-tui/build-x86_64-unknown-none.toml
@@ -1,0 +1,5 @@
+target = "x86_64-unknown-none"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = ["qemu"]
+plat_dyn = false

--- a/apps/starry/deepseek-tui/prepare_deepseek_assets.sh
+++ b/apps/starry/deepseek-tui/prepare_deepseek_assets.sh
@@ -4,14 +4,8 @@ set -euo pipefail
 workspace="${STARRY_WORKSPACE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
 asset_dir="$workspace/target/deepseek/assets"
 src_dir="$workspace/target/deepseek/build/deepseek-tui"
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/starry-deepseek-assets.XXXXXX")"
 repo="https://github.com/Hmbown/DeepSeek-TUI.git"
 tag="v0.8.18"
-
-cleanup() {
-    rm -rf "$tmp_dir"
-}
-trap cleanup EXIT
 
 need_cmd() {
     if ! command -v "$1" >/dev/null 2>&1; then
@@ -43,7 +37,7 @@ docker_build() {
     echo "Extracting binaries and shared libraries..."
     docker run --rm deepseek-tui-builder tar -cO /deepseek /deepseek-tui | tar -xv -C "$asset_dir"
     mkdir -p "$asset_dir/lib"
-    docker run --rm deepseek-tui-builder tar -cO /usr/lib/libdbus-1.so.3 /usr/lib/libdbus-1.so.3.38.3 /usr/lib/libgcc_s.so.1 | tar -xv --strip-components=2 -C "$asset_dir/lib/" 2>/dev/null || true
+    docker run --rm deepseek-tui-builder tar -cO /usr/lib/ | tar -xv --strip-components=2 -C "$asset_dir/lib/" 2>/dev/null || true
     echo ""
     file "$asset_dir/deepseek" 2>/dev/null || true
     docker run --rm deepseek-tui-builder /deepseek --version 2>/dev/null || echo "(version check skipped — musl binary needs musl host)"

--- a/apps/starry/deepseek-tui/prepare_deepseek_assets.sh
+++ b/apps/starry/deepseek-tui/prepare_deepseek_assets.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="${STARRY_WORKSPACE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+asset_dir="$workspace/target/deepseek/assets"
+src_dir="$workspace/target/deepseek/build/deepseek-tui"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/starry-deepseek-assets.XXXXXX")"
+repo="https://github.com/Hmbown/DeepSeek-TUI.git"
+tag="v0.8.18"
+
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: required command not found: $1" >&2
+        exit 1
+    fi
+}
+
+need_cmd install
+
+if [ -x "$asset_dir/deepseek" ] && [ -x "$asset_dir/deepseek-tui" ]; then
+    echo "DeepSeek TUI assets already staged in $asset_dir"
+    file "$asset_dir/deepseek" 2>/dev/null | head -1
+    ls -lh "$asset_dir/deepseek"
+    exit 0
+fi
+
+mkdir -p "$asset_dir" "$src_dir"
+
+docker_build() {
+    local script_dir
+    script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+    echo "Building deepseek $tag in Docker (Alpine + musl)..."
+    docker build --network host \
+        -f "$script_dir/Dockerfile.build" \
+        -t deepseek-tui-builder \
+        "$workspace" 2>&1
+    echo ""
+    echo "Extracting binaries and shared libraries..."
+    docker run --rm deepseek-tui-builder tar -cO /deepseek /deepseek-tui | tar -xv -C "$asset_dir"
+    mkdir -p "$asset_dir/lib"
+    docker run --rm deepseek-tui-builder tar -cO /usr/lib/libdbus-1.so.3 /usr/lib/libdbus-1.so.3.38.3 /usr/lib/libgcc_s.so.1 | tar -xv --strip-components=2 -C "$asset_dir/lib/" 2>/dev/null || true
+    echo ""
+    file "$asset_dir/deepseek" 2>/dev/null || true
+    docker run --rm deepseek-tui-builder /deepseek --version 2>/dev/null || echo "(version check skipped — musl binary needs musl host)"
+    echo ""
+    echo "DeepSeek TUI assets ready in $asset_dir"
+    ls -lh "$asset_dir/"
+    exit 0
+}
+
+direct_build() {
+    need_cmd git
+    need_cmd cargo
+    need_cmd strip
+
+    echo "Cloning DeepSeek TUI $tag..."
+    if [ -d "$src_dir/.git" ]; then
+        echo "  Updating existing clone..."
+        cd "$src_dir" && git fetch --tags --depth 1 origin "$tag" && git checkout -f "$tag"
+    else
+        git clone --depth 1 --branch "$tag" "$repo" "$src_dir"
+    fi
+
+    echo ""
+    echo "Building deepseek ($tag)..."
+    cd "$src_dir"
+
+    echo "  Building deepseek (crates/cli) with musl target..."
+    cargo build --release --locked --target x86_64-unknown-linux-musl --bin deepseek
+
+    echo "  Building deepseek-tui (crates/tui) with musl target..."
+    cargo build --release --locked --target x86_64-unknown-linux-musl --bin deepseek-tui
+
+    echo ""
+    echo "Stripping and staging binaries..."
+    install -m 0755 "$src_dir/target/x86_64-unknown-linux-musl/release/deepseek" "$asset_dir/deepseek"
+    install -m 0755 "$src_dir/target/x86_64-unknown-linux-musl/release/deepseek-tui" "$asset_dir/deepseek-tui"
+    strip "$asset_dir/deepseek" "$asset_dir/deepseek-tui"
+
+    echo ""
+    file "$asset_dir/deepseek"
+    "$asset_dir/deepseek" --version
+    "$asset_dir/deepseek-tui" --version
+
+    echo ""
+    echo "DeepSeek TUI assets ready in $asset_dir"
+    ls -lh "$asset_dir/"
+}
+
+if command -v docker >/dev/null 2>&1; then
+    docker_build
+else
+    direct_build
+fi

--- a/apps/starry/deepseek-tui/prepare_deepseek_rootfs.sh
+++ b/apps/starry/deepseek-tui/prepare_deepseek_rootfs.sh
@@ -153,15 +153,18 @@ fi
 install -m 0755 "$deepseek_bin" "$overlay/usr/local/bin/deepseek"
 install -m 0755 "$deepseek_tui_bin" "$overlay/usr/local/bin/deepseek-tui"
 
-# Write env file with DEEPSEEK_API_KEY and optional proxy settings
-{
-    if [[ -n "$api_key" ]]; then
-        quoted_key="$(shell_quote "$api_key")"
-        echo "export DEEPSEEK_API_KEY=$quoted_key"
-    fi
-    if [[ -n "$proxy_url" ]]; then
-        quoted_proxy="$(shell_quote "$proxy_url")"
-        cat <<ENVEOF
+# Write env file with DEEPSEEK_API_KEY, optional proxy settings, or injected env file
+if [[ -n "$env_file" ]]; then
+    install -m 0644 "$env_file" "$overlay/root/.deepseek/starry-online-env"
+else
+    {
+        if [[ -n "$api_key" ]]; then
+            quoted_key="$(shell_quote "$api_key")"
+            echo "export DEEPSEEK_API_KEY=$quoted_key"
+        fi
+        if [[ -n "$proxy_url" ]]; then
+            quoted_proxy="$(shell_quote "$proxy_url")"
+            cat <<ENVEOF
 export HTTP_PROXY=$quoted_proxy
 export HTTPS_PROXY=$quoted_proxy
 export ALL_PROXY=$quoted_proxy
@@ -171,8 +174,9 @@ export all_proxy=$quoted_proxy
 export NO_PROXY='localhost,127.0.0.1,::1'
 export no_proxy='localhost,127.0.0.1,::1'
 ENVEOF
-    fi
-} > "$overlay/root/.deepseek/starry-online-env"
+        fi
+    } > "$overlay/root/.deepseek/starry-online-env"
+fi
 
 if [[ -f "$ca_cert" ]]; then
     mkdir -p "$overlay/etc/ssl/certs"

--- a/apps/starry/deepseek-tui/prepare_deepseek_rootfs.sh
+++ b/apps/starry/deepseek-tui/prepare_deepseek_rootfs.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace="$(cd "$script_dir/../../.." && pwd)"
+base_rootfs="$workspace/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img"
+output_rootfs="$workspace/tmp/axbuild/rootfs/rootfs-x86_64-deepseek.img"
+api_key=""
+proxy_url="${DEEPSEEK_ONLINE_PROXY:-}"
+env_file=""
+ca_cert="${SSL_CERT_FILE:-/etc/ssl/certs/ca-certificates.crt}"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Prepare a local rootfs for the StarryOS DeepSeek TUI example.
+
+Options:
+  --api-key KEY          DeepSeek API key to inject (sets DEEPSEEK_API_KEY env in guest)
+  --proxy URL            Write /root/.deepseek/starry-online-env with HTTP(S)/ALL proxy exports
+                         (default: DEEPSEEK_ONLINE_PROXY when set)
+  --env-file PATH        Inject an existing shell env file as /root/.deepseek/starry-online-env
+  --base-rootfs PATH     Base rootfs image to copy before injection
+                         (default: tmp/axbuild/rootfs/rootfs-x86_64-alpine.img)
+  --output-rootfs PATH   Output rootfs image for the example
+                         (default: tmp/axbuild/rootfs/rootfs-x86_64-deepseek.img)
+  --ca-cert PATH         CA bundle to inject as /etc/ssl/certs/ca-certificates.crt
+                         (default: SSL_CERT_FILE or /etc/ssl/certs/ca-certificates.crt)
+  -h, --help             Show this help
+
+Example (offline smoke test):
+  apps/starry/deepseek-tui/prepare_deepseek_rootfs.sh
+
+Example (online prime test):
+  apps/starry/deepseek-tui/prepare_deepseek_rootfs.sh \\
+    --output-rootfs tmp/axbuild/rootfs/rootfs-x86_64-deepseek-online.img \\
+    --api-key sk-your-key-here \\
+    --proxy http://10.0.2.2:7890
+EOF
+}
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: required command not found: $1" >&2
+        exit 1
+    fi
+}
+
+shell_quote() {
+    local value="$1"
+    printf "'%s'" "${value//\'/\'\\\'\'}"
+}
+
+workspace_path() {
+    local path="$1"
+    if [[ "$path" = /* ]]; then
+        printf '%s\n' "$path"
+    else
+        printf '%s/%s\n' "$workspace" "$path"
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --api-key)
+            api_key="$2"
+            shift 2
+            ;;
+        --proxy)
+            proxy_url="$2"
+            shift 2
+            ;;
+        --env-file)
+            env_file="$2"
+            shift 2
+            ;;
+        --base-rootfs)
+            base_rootfs="$2"
+            shift 2
+            ;;
+        --output-rootfs)
+            output_rootfs="$2"
+            shift 2
+            ;;
+        --ca-cert)
+            ca_cert="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+base_rootfs="$(workspace_path "$base_rootfs")"
+output_rootfs="$(workspace_path "$output_rootfs")"
+ca_cert="$(workspace_path "$ca_cert")"
+if [[ -n "$env_file" ]]; then
+    env_file="$(workspace_path "$env_file")"
+fi
+
+need_cmd cp
+need_cmd debugfs
+need_cmd install
+need_cmd mktemp
+need_cmd stat
+
+if [[ ! -f "$base_rootfs" ]]; then
+    if [[ "$base_rootfs" == "$workspace/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img" ]]; then
+        echo "Base rootfs not found; preparing the default x86_64 Alpine rootfs..."
+        (cd "$workspace" && cargo xtask starry rootfs --arch x86_64)
+    fi
+fi
+
+if [[ ! -f "$base_rootfs" ]]; then
+    echo "error: base rootfs not found: $base_rootfs" >&2
+    exit 1
+fi
+
+"$script_dir/prepare_deepseek_assets.sh"
+
+deepseek_bin="$workspace/target/deepseek/assets/deepseek"
+deepseek_tui_bin="$workspace/target/deepseek/assets/deepseek-tui"
+if [[ ! -x "$deepseek_bin" || ! -x "$deepseek_tui_bin" ]]; then
+    echo "error: DeepSeek TUI assets are missing after prepare_deepseek_assets.sh" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$output_rootfs")"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/starry-deepseek-rootfs.XXXXXX")"
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+overlay="$tmp_dir/overlay"
+mkdir -p "$overlay/usr/local/bin" "$overlay/usr/lib" "$overlay/root/.deepseek"
+
+# Inject shared libraries needed by the dynamically-linked binaries
+lib_dir="$workspace/target/deepseek/assets/lib"
+if [ -d "$lib_dir" ]; then
+    for lib in "$lib_dir"/*.so*; do
+        [ -f "$lib" ] && install -m 0644 "$lib" "$overlay/usr/lib/"
+    done
+fi
+install -m 0755 "$deepseek_bin" "$overlay/usr/local/bin/deepseek"
+install -m 0755 "$deepseek_tui_bin" "$overlay/usr/local/bin/deepseek-tui"
+
+# Write env file with DEEPSEEK_API_KEY and optional proxy settings
+{
+    if [[ -n "$api_key" ]]; then
+        quoted_key="$(shell_quote "$api_key")"
+        echo "export DEEPSEEK_API_KEY=$quoted_key"
+    fi
+    if [[ -n "$proxy_url" ]]; then
+        quoted_proxy="$(shell_quote "$proxy_url")"
+        cat <<ENVEOF
+export HTTP_PROXY=$quoted_proxy
+export HTTPS_PROXY=$quoted_proxy
+export ALL_PROXY=$quoted_proxy
+export http_proxy=$quoted_proxy
+export https_proxy=$quoted_proxy
+export all_proxy=$quoted_proxy
+export NO_PROXY='localhost,127.0.0.1,::1'
+export no_proxy='localhost,127.0.0.1,::1'
+ENVEOF
+    fi
+} > "$overlay/root/.deepseek/starry-online-env"
+
+if [[ -f "$ca_cert" ]]; then
+    mkdir -p "$overlay/etc/ssl/certs"
+    install -m 0644 "$ca_cert" "$overlay/etc/ssl/certs/ca-certificates.crt"
+else
+    echo "warning: CA bundle not found at $ca_cert; relying on the base rootfs CA bundle" >&2
+fi
+
+tmp_rootfs="$tmp_dir/rootfs.img"
+cp --reflink=auto "$base_rootfs" "$tmp_rootfs" 2>/dev/null || cp "$base_rootfs" "$tmp_rootfs"
+
+debugfs_script="$tmp_dir/inject.debugfs"
+{
+    find "$overlay" -type d | sort | while IFS= read -r dir; do
+        rel="${dir#"$overlay"}"
+        [[ -z "$rel" ]] && continue
+        printf 'mkdir %s\n' "$rel"
+    done
+    find "$overlay" -type f | sort | while IFS= read -r file; do
+        rel="${file#"$overlay"}"
+        mode="$(stat -c '%a' "$file")"
+        printf 'rm %s\n' "$rel"
+        printf 'write %s %s\n' "$file" "$rel"
+        printf 'sif %s mode 0100%s\n' "$rel" "$mode"
+    done
+    printf 'quit\n'
+} > "$debugfs_script"
+
+debugfs_log="$tmp_dir/debugfs.log"
+if ! debugfs -w -f "$debugfs_script" "$tmp_rootfs" >"$debugfs_log" 2>&1; then
+    cat "$debugfs_log" >&2
+    exit 1
+fi
+mv "$tmp_rootfs" "$output_rootfs"
+
+display_rootfs="$output_rootfs"
+case "$display_rootfs" in
+    "$workspace"/*)
+        display_rootfs="${display_rootfs#"$workspace"/}"
+        ;;
+esac
+
+echo "DeepSeek TUI example rootfs ready:"
+echo "  $output_rootfs"
+echo
+echo "Run the offline smoke test with:"
+echo "  cargo xtask starry qemu --arch x86_64 \\"
+echo "    --qemu-config apps/starry/deepseek-tui/qemu-x86_64.toml \\"
+echo "    --rootfs $display_rootfs"
+if [[ -n "$api_key" ]]; then
+    echo
+    echo "Run the online prime demo with:"
+    echo "  cargo xtask starry qemu --arch x86_64 \\"
+    echo "    --qemu-config apps/starry/deepseek-tui/qemu-x86_64-deepseek-prime-test.toml \\"
+    echo "    --rootfs $display_rootfs"
+fi

--- a/apps/starry/deepseek-tui/qemu-x86_64-deepseek-prime-test.toml
+++ b/apps/starry/deepseek-tui/qemu-x86_64-deepseek-prime-test.toml
@@ -1,0 +1,124 @@
+# Example only: this online flow is opt-in and is not part of test-suit or CI.
+# Prepare tmp/axbuild/rootfs/rootfs-x86_64-deepseek-online.img with
+# prepare_deepseek_rootfs.sh --api-key ... before running it.
+args = [
+    "-machine",
+    "q35",
+    "-nographic",
+    "-m",
+    "2G",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-deepseek-online.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-snapshot",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+export HOME=/root
+export USER=root
+export SHELL=/bin/sh
+export TERM=xterm-256color
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+if [ -f "$HOME/.deepseek/starry-online-env" ]; then
+    . "$HOME/.deepseek/starry-online-env"
+fi
+set -e
+
+echo "STARRY_DEEPSEEK_PRIME_TEST_ENV_READY"
+
+command -v deepseek
+command -v deepseek-tui
+command -v gcc
+
+deepseek --version
+
+if [ -z "${DEEPSEEK_API_KEY:-}" ]; then
+    echo "STARRY_DEEPSEEK_PRIME_TEST_MISSING_API_KEY"
+    echo "Run prepare_deepseek_rootfs.sh with --api-key first."
+    exit 1
+fi
+
+echo "DEEPSEEK_API_KEY is set" | head -c 30
+echo ""
+
+mkdir -p /tmp/deepseek-prime-test
+cd /tmp/deepseek-prime-test
+
+cat > /tmp/deepseek-prime-prompt.txt <<'PROMPT_EOF'
+Write a C program to /tmp/deepseek-prime-test/a.c using your write_file tool, then compile and run it.
+
+Requirements for a.c:
+1. Define a function is_prime(int n) that checks if n is prime.
+2. Find the smallest prime number strictly greater than 998244352.
+3. Print only the result number (nothing else).
+
+Steps:
+1. Use write_file to create /tmp/deepseek-prime-test/a.c with the program.
+2. Use exec_shell to compile: gcc -O2 -o /tmp/deepseek-prime-test/a /tmp/deepseek-prime-test/a.c
+3. Use exec_shell to run it: /tmp/deepseek-prime-test/a
+
+Do not output the code in your reply — just create, compile, and run.
+PROMPT_EOF
+
+deepseek \
+  --approval-policy never \
+  --sandbox-mode workspace-write \
+  --model deepseek-v4-flash \
+  exec \
+  --auto \
+  "$(cat /tmp/deepseek-prime-prompt.txt)" 2>&1 | tee /tmp/deepseek-exec-output.txt || true
+
+echo "===== CHECKING OUTPUT FILES ====="
+ls -la /tmp/deepseek-prime-test/ 2>/dev/null || echo "No files in test directory"
+
+if [ -f /tmp/deepseek-prime-test/a ]; then
+    echo "===== RUNNING COMPILED BINARY ====="
+    result=$(/tmp/deepseek-prime-test/a 2>&1)
+    echo "Result: $result"
+
+    if [ "$result" = "998244353" ]; then
+        echo "STARRY_DEEPSEEK_PRIME_TEST_DONE"
+        echo "STARRY_DEEPSEEK_PRIME_TEST_PASSED"
+    else
+        echo "STARRY_DEEPSEEK_PRIME_TEST_WRONG_OUTPUT"
+        echo "Expected: 998244353, Got: $result"
+    fi
+elif [ -f /tmp/deepseek-prime-test/a.c ]; then
+    echo "===== COMPILING AND RUNNING A.C ====="
+    cat /tmp/deepseek-prime-test/a.c
+    gcc -O2 -o /tmp/deepseek-prime-test/a /tmp/deepseek-prime-test/a.c && \
+      result=$(/tmp/deepseek-prime-test/a) && \
+      echo "Result: $result"
+    if [ "$result" = "998244353" ]; then
+        echo "STARRY_DEEPSEEK_PRIME_TEST_DONE"
+        echo "STARRY_DEEPSEEK_PRIME_TEST_PASSED"
+    else
+        echo "STARRY_DEEPSEEK_PRIME_TEST_WRONG_OUTPUT"
+        echo "Expected: 998244353, Got: $result"
+    fi
+else
+    echo "STARRY_DEEPSEEK_PRIME_TEST_NO_FILE"
+    echo "deepseek exec output file:"
+    cat /tmp/deepseek-exec-output.txt 2>/dev/null || true
+fi
+'''
+success_regex = ["(?m)^STARRY_DEEPSEEK_PRIME_TEST_PASSED\\s*$"]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)page fault",
+    "(?i)segmentation fault",
+    "No such process \\(os error 3\\)",
+    "sys_prctl: unsupported option 23",
+    "(?m)^STARRY_DEEPSEEK_PRIME_TEST_MISSING_API_KEY\\s*$",
+    "(?m)^STARRY_DEEPSEEK_PRIME_TEST_WRONG_OUTPUT\\s*$",
+    "(?m)^STARRY_DEEPSEEK_PRIME_TEST_NO_FILE\\s*$",
+]
+timeout = 2400

--- a/apps/starry/deepseek-tui/qemu-x86_64.toml
+++ b/apps/starry/deepseek-tui/qemu-x86_64.toml
@@ -43,7 +43,7 @@ fail_regex = [
     "(?i)\\bpanic(?:ked)?\\b",
     "(?i)page fault",
     "(?i)segmentation fault",
-    "No such process",
+    "No such process \\(os error 3\\)",
     "sys_prctl: unsupported option 23",
 ]
 timeout = 120

--- a/apps/starry/deepseek-tui/qemu-x86_64.toml
+++ b/apps/starry/deepseek-tui/qemu-x86_64.toml
@@ -1,0 +1,49 @@
+# Example only: this is not part of the StarryOS test-suit or CI.
+args = [
+    "-machine",
+    "q35",
+    "-nographic",
+    "-m",
+    "2G",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-deepseek.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-snapshot",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+export HOME=/root
+export USER=root
+export SHELL=/bin/sh
+export TERM=xterm-256color
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+set -e
+
+deepseek --version
+deepseek-tui --version
+
+deepseek --help > /tmp/deepseek-help.txt 2>&1
+grep -F "Usage:" /tmp/deepseek-help.txt
+
+deepseek model list > /tmp/deepseek-model-list.txt 2>&1
+head -3 /tmp/deepseek-model-list.txt
+grep -q "deepseek" /tmp/deepseek-model-list.txt
+
+echo "STARRY_DEEPSEEK_STAGE_G_PASSED"
+'''
+success_regex = ["(?m)^STARRY_DEEPSEEK_STAGE_G_PASSED\\s*$"]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)page fault",
+    "(?i)segmentation fault",
+    "No such process",
+    "sys_prctl: unsupported option 23",
+]
+timeout = 120

--- a/apps/starry/deepseek-tui/run_me.sh
+++ b/apps/starry/deepseek-tui/run_me.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace="$(cd "$script_dir/../../.." && pwd)"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Orchestrate building, running, and testing DeepSeek TUI on StarryOS.
+
+Options:
+  --build               Build deepseek assets only
+  --rootfs              Prepare offline rootfs (builds assets if needed)
+  --smoke               Run offline smoke test (build + rootfs + qemu)
+  --test                Run online C prime test (build + rootfs + qemu)
+  --shell               Boot interactive QEMU shell
+  --api-key KEY         DeepSeek API key (for online rootfs/test)
+  --proxy URL           Proxy URL (for online rootfs/test)
+  -h, --help            Show this help
+
+Examples:
+  $(basename "$0") --build
+  $(basename "$0") --smoke
+  $(basename "$0") --test --api-key sk-xxx --proxy http://10.0.2.2:7890
+  $(basename "$0") --shell
+EOF
+}
+
+build() {
+    echo "=== Build deepseek assets ==="
+    bash "$script_dir/prepare_deepseek_assets.sh"
+}
+
+rootfs_offline() {
+    echo "=== Prepare offline rootfs ==="
+    bash "$script_dir/prepare_deepseek_rootfs.sh"
+}
+
+rootfs_online() {
+    echo "=== Prepare online rootfs ==="
+    local args=()
+    args+=(--output-rootfs "tmp/axbuild/rootfs/rootfs-x86_64-deepseek-online.img")
+    if [[ -n "$api_key" ]]; then
+        args+=(--api-key "$api_key")
+    fi
+    if [[ -n "$proxy" ]]; then
+        args+=(--proxy "$proxy")
+    fi
+    bash "$script_dir/prepare_deepseek_rootfs.sh" "${args[@]}"
+}
+
+smoke() {
+    build
+    rootfs_offline
+    echo "=== Run offline smoke test ==="
+    cd "$workspace" && cargo xtask starry qemu \
+        --arch x86_64 \
+        --qemu-config apps/starry/deepseek-tui/qemu-x86_64.toml \
+        --rootfs tmp/axbuild/rootfs/rootfs-x86_64-deepseek.img
+}
+
+test_online() {
+    if [[ -z "$api_key" ]]; then
+        echo "Error: --api-key is required for --test" >&2
+        exit 1
+    fi
+    build
+    rootfs_online
+    echo "=== Run online C prime test ==="
+    cd "$workspace" && cargo xtask starry qemu \
+        --arch x86_64 \
+        --qemu-config apps/starry/deepseek-tui/qemu-x86_64-deepseek-prime-test.toml \
+        --rootfs tmp/axbuild/rootfs/rootfs-x86_64-deepseek-online.img
+}
+
+shell() {
+    build
+    if [[ -n "$api_key" ]]; then
+        rootfs_online
+        local rootfs="tmp/axbuild/rootfs/rootfs-x86_64-deepseek-online.img"
+    else
+        rootfs_offline
+        local rootfs="tmp/axbuild/rootfs/rootfs-x86_64-deepseek.img"
+    fi
+    echo "=== Interactive QEMU shell ==="
+    cd "$workspace" && cargo xtask starry qemu \
+        --arch x86_64 \
+        --rootfs "$rootfs"
+}
+
+api_key=""
+proxy=""
+mode=""
+
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 0
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build)       mode="build" ;;
+        --rootfs)      mode="rootfs" ;;
+        --smoke)       mode="smoke" ;;
+        --test)        mode="test" ;;
+        --shell)       mode="shell" ;;
+        --api-key)     api_key="$2"; shift ;;
+        --proxy)       proxy="$2"; shift ;;
+        -h|--help)     usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+done
+
+case "$mode" in
+    build)   build ;;
+    rootfs)
+        if [[ -n "$api_key" ]]; then
+            rootfs_online
+        else
+            rootfs_offline
+        fi
+        ;;
+    smoke)   smoke ;;
+    test)    test_online ;;
+    shell)   shell ;;
+    *)       usage; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

Add DeepSeek TUI example app on StarryOS supporting offline smoke test and online C prime test in x86_64 QEMU.

## Files

- **prepare_deepseek_assets.sh** - Build musl-linked deepseek/deepseek-tui binaries in Alpine Docker container
- **prepare_deepseek_rootfs.sh** - Prepare Alpine rootfs ext4 image with binaries, libs, CA certs, env
- **Dockerfile.build** - Alpine + Rust nightly build environment
- **run_me.sh** - Orchestrator with --build/--smoke/--test/--shell modes
- **qemu-x86_64.toml** - Offline smoke test config
- **qemu-x86_64-deepseek-prime-test.toml** - Online prime test config
- **README.md** - Documentation (Chinese)

## Test

- [x] Offline smoke test: deepseek --version, deepseek-tui --version, deepseek model list passed
- [ ] Online prime test: requires --api-key