### PR TITLE
fix(starry-kernel): handle COW write faults from kernel-mode user-memory writes

### DIFF
--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -281,7 +281,26 @@ fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
     };
 
     if unlikely(!thr.is_accessing_user_memory()) {
-        return false;
+        // Still try to handle kernel-mode faults on user-space addresses.
+        // Several syscall sites (e.g. event.rs, net/io.rs, fs/lock.rs) obtain
+        // a direct `&mut` reference into user memory via get_as_mut /
+        // get_as_mut_slice and write through it outside of
+        // access_user_memory().  If a concurrent fork has re-marked the page
+        // read-only between check_region() and the write, the kernel write
+        // hits a COW #PF with no fixup-table entry and panics.  Handling the
+        // fault here lets the standard COW path copy the page just as it
+        // would for a user-mode write.
+        let user_range = USER_SPACE_BASE..USER_SPACE_BASE + USER_SPACE_SIZE;
+        if !user_range.contains(&vaddr.as_usize()) {
+            return false;
+        }
+        // Avoid recursion / deadlock: if this thread already holds the
+        // aspace lock (e.g. fault inside aspace.lock().handle_page_fault())
+        // we have to bail out instead of trying to lock it again.
+        let aspace_arc = thr.proc_data.aspace();
+        if unsafe { aspace_arc.raw() }.is_owned_by_current() {
+            return false;
+        }
     }
 
     might_sleep();


### PR DESCRIPTION

Several syscall sites still obtain a direct `&mut` reference into user memory through get_as_mut / get_as_mut_slice and write through it outside of access_user_memory().  Examples that remain on the current upstream/dev tree include sys_select (io_mpx/select.rs), the network sendmsg / recvmsg path (net/io.rs), event-device ioctls (pseudofs/dev/event.rs) and the file-lock ioctls (fs/lock.rs).

When a concurrent fork(clone_map) re-marks the underlying COW pages read-only between check_region() and the kernel-mode write, the write triggers a #PF (present + WRITE bit set) whose RIP is in kernel text and has no fixup-table entry.  The previous handler returned early on !is_accessing_user_memory(), turning this into an unrecoverable panic.

Extend handle_page_fault so a kernel-mode fault on a user-space address goes through the regular aspace.handle_page_fault() path (which invokes the COW backend) just like a user-mode write would.  Two guards keep the extension safe:

  1. Reject fault addresses outside USER_SPACE_BASE..USER_SPACE_END so genuine kernel-text / kernel-stack faults still bubble up unchanged.
  2. Bail out if the current thread already holds the aspace lock, which prevents a recursive lock acquisition / deadlock when a fault occurs inside aspace.lock().handle_page_fault() itself.