### PR TITLE
fix(starry-kernel): close EPOLLET race window and NoEvent busy-loop

### DIFF
--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -457,17 +457,52 @@ impl Epoll {
                         keep.push_back(Arc::downgrade(&interest));
                     } else {
                         interest.mark_not_in_queue();
+                        // EPOLLET: install a fresh waker so the next edge
+                        // transition fires.  There is a race window between
+                        // mark_not_in_queue() above and register_waker_only()
+                        // below: the previous InterestWaker may have already
+                        // been consumed by the wake that delivered the event
+                        // we are returning here, leaving the underlying
+                        // PollSet empty.  If new data arrives in that gap,
+                        // poll_update.wake() hits the empty PollSet and the
+                        // notification is silently dropped — EPOLLET would
+                        // then never fire again because the new waker is
+                        // installed only after the data already arrived.
+                        // Close the window by re-checking the file's poll
+                        // state after registering and re-queueing the
+                        // interest directly if IN-side data is already
+                        // present.  EPOLLOUT is intentionally excluded: it
+                        // is normally always ready on writable sockets and
+                        // would cause a busy-loop.
                         self.register_waker_only(&interest);
+                        let in_mask = interest.event.events
+                            & (IoEvents::IN | IoEvents::RDHUP | IoEvents::HUP);
+                        if !in_mask.is_empty()
+                            && let Some(f) = interest.key.get_file()
+                            && !(f.poll() & in_mask).is_empty()
+                            && interest.try_mark_in_queue()
+                        {
+                            self.inner
+                                .ready_queue
+                                .lock()
+                                .push_back(Arc::downgrade(&interest));
+                            self.inner.poll_ready.wake();
+                        }
                     }
                 }
                 ConsumeResult::NoEvent => {
+                    // Spurious wakeup: the waker fired but file.poll() did
+                    // not match the interest mask (e.g. a shared PollSet
+                    // wake on a socket that has only EPOLLOUT ready when
+                    // the interest is for EPOLLIN).  Re-arm with a plain
+                    // waker registration — using check_and_register_waker
+                    // here would immediately re-queue the interest via
+                    // waker.wake_by_ref() whenever file.poll() is non-empty,
+                    // which a connected TCP socket (always EPOLLOUT-ready)
+                    // satisfies on every iteration, producing a tight loop
+                    // that fills the ready_queue with phantom events.
                     interest.mark_not_in_queue();
-                    // Events arriving between consume()'s poll and the new
-                    // register() would otherwise be lost: the old waker
-                    // CAS-fails (in_ready_queue still set), and a plain
-                    // register only fires on the next edge. Re-poll after
-                    // registering to recover them.
-                    self.check_and_register_waker(&interest);
+                    self.register_waker_only(&interest);
                 }
             }
         }

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-epollet-second-chunk/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-epollet-second-chunk/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-epollet-second-chunk C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+add_executable(bug-epollet-second-chunk src/main.c)
+target_compile_options(bug-epollet-second-chunk PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-epollet-second-chunk RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/bug-epollet-second-chunk/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/bug-epollet-second-chunk/c/src/main.c
@@ -1,0 +1,188 @@
+/*
+ * bug-epollet-second-chunk: an EPOLLET registration must report a second
+ * chunk that arrives after the first chunk was fully drained.
+ *
+ * Two related bugs in the EPOLLET delivery path used to break this:
+ *
+ *   1. NoEvent path called check_and_register_waker(), which on a connected
+ *      TCP socket immediately observed EPOLLOUT-ready in file.poll() and
+ *      re-fired the waker.  That created a tight busy-loop that filled the
+ *      ready_queue with phantom events and starved real wakeups.
+ *
+ *   2. EventAndRemove cleared the in-queue flag and then registered a new
+ *      waker.  The previous InterestWaker had already been consumed by the
+ *      wake that delivered the first chunk, so writes that arrived between
+ *      mark_not_in_queue() and register_waker_only() hit an empty PollSet
+ *      and the second chunk's wake was silently dropped.
+ *
+ * This test exercises the second-chunk path repeatedly to maximise the
+ * chance of hitting the race window, and also verifies the basic NoEvent
+ * path by polling with a 0 ms timeout on a connected socket without any
+ * outstanding data.
+ */
+
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define ROUNDS 32
+
+static int make_loopback_pair(int *cli, int *srv)
+{
+    int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd < 0)
+        return -1;
+    int opt = 1;
+    setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+        .sin_port = 0,
+    };
+    if (bind(listen_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0
+        || listen(listen_fd, 1) < 0) {
+        close(listen_fd);
+        return -1;
+    }
+    socklen_t len = sizeof(addr);
+    if (getsockname(listen_fd, (struct sockaddr *)&addr, &len) < 0) {
+        close(listen_fd);
+        return -1;
+    }
+
+    int c = socket(AF_INET, SOCK_STREAM, 0);
+    if (c < 0) {
+        close(listen_fd);
+        return -1;
+    }
+    if (connect(c, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        close(c);
+        close(listen_fd);
+        return -1;
+    }
+    int s = accept(listen_fd, NULL, NULL);
+    close(listen_fd);
+    if (s < 0) {
+        close(c);
+        return -1;
+    }
+    *cli = c;
+    *srv = s;
+    return 0;
+}
+
+static int drain(int fd)
+{
+    char buf[64];
+    int total = 0;
+    for (;;) {
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n > 0) {
+            total += (int)n;
+            continue;
+        }
+        if (n < 0 && errno == EAGAIN)
+            return total;
+        return -1;
+    }
+}
+
+int main(void)
+{
+    int cli, srv;
+    if (make_loopback_pair(&cli, &srv) < 0) {
+        fprintf(stderr, "loopback pair setup failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    int flags = fcntl(cli, F_GETFL, 0);
+    fcntl(cli, F_SETFL, flags | O_NONBLOCK);
+
+    int epfd = epoll_create1(EPOLL_CLOEXEC);
+    if (epfd < 0) {
+        fprintf(stderr, "epoll_create1: %s\n", strerror(errno));
+        return 1;
+    }
+    struct epoll_event ev = {
+        .events = EPOLLIN | EPOLLET,
+        .data.fd = cli,
+    };
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, cli, &ev) < 0) {
+        fprintf(stderr, "epoll_ctl: %s\n", strerror(errno));
+        return 1;
+    }
+
+    /*
+     * Bug 1: a connected TCP socket has EPOLLOUT always ready.  With the
+     * NoEvent path's old check_and_register_waker, any spurious wake would
+     * find OUT in file.poll() and re-queue the interest, returning phantom
+     * events here.  After the fix, epoll_wait must time out cleanly.
+     */
+    struct epoll_event evs[8];
+    int n = epoll_wait(epfd, evs, 8, 50);
+    if (n != 0) {
+        fprintf(stderr, "STARRY_GROUPED_TEST_FAILED: bug-epollet-second-chunk "
+                        "(phantom events from idle socket: n=%d)\n", n);
+        return 1;
+    }
+
+    /*
+     * Bug 2: send a chunk, drain it, send another chunk back-to-back.
+     * Repeat to maximise the chance of writing in the race window between
+     * mark_not_in_queue() and the fresh register_waker_only() install.
+     */
+    for (int i = 0; i < ROUNDS; i++) {
+        char msg[16];
+        int len = snprintf(msg, sizeof(msg), "round-%d-A", i);
+        if (write(srv, msg, (size_t)len) != len) {
+            fprintf(stderr, "write A failed: %s\n", strerror(errno));
+            return 1;
+        }
+        n = epoll_wait(epfd, evs, 8, 1000);
+        if (n != 1) {
+            fprintf(stderr,
+                    "STARRY_GROUPED_TEST_FAILED: bug-epollet-second-chunk "
+                    "(round=%d chunk A: epoll_wait returned %d, expected 1)\n",
+                    i, n);
+            return 1;
+        }
+        if (drain(cli) <= 0) {
+            fprintf(stderr, "drain A failed: %s\n", strerror(errno));
+            return 1;
+        }
+
+        len = snprintf(msg, sizeof(msg), "round-%d-B", i);
+        if (write(srv, msg, (size_t)len) != len) {
+            fprintf(stderr, "write B failed: %s\n", strerror(errno));
+            return 1;
+        }
+        n = epoll_wait(epfd, evs, 8, 1000);
+        if (n != 1) {
+            fprintf(stderr,
+                    "STARRY_GROUPED_TEST_FAILED: bug-epollet-second-chunk "
+                    "(round=%d chunk B: epoll_wait returned %d, expected 1)\n",
+                    i, n);
+            return 1;
+        }
+        if (drain(cli) <= 0) {
+            fprintf(stderr, "drain B failed: %s\n", strerror(errno));
+            return 1;
+        }
+    }
+
+    close(epfd);
+    close(cli);
+    close(srv);
+
+    printf("STARRY_GROUPED_TEST_PASSED: bug-epollet-second-chunk\n");
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-aarch64.toml
@@ -58,6 +58,7 @@ test_commands = [
     "/usr/bin/bug-af-inet6-v4mapped",
     "/usr/bin/bug-tcp-udp-bind-same-port",
     "/usr/bin/bug-tcp-send-no-epoll-notify",
+    "/usr/bin/bug-epollet-second-chunk",
     "/usr/bin/bug-tcp-concurrent-connect",
     "/usr/bin/bug-tcp-nonblocking-connect-so-error",
     "/usr/bin/bug-kill-zombie-esrch",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-loongarch64.toml
@@ -59,6 +59,7 @@ test_commands = [
     "/usr/bin/bug-af-inet6-v4mapped",
     "/usr/bin/bug-tcp-udp-bind-same-port",
     "/usr/bin/bug-tcp-send-no-epoll-notify",
+    "/usr/bin/bug-epollet-second-chunk",
     "/usr/bin/bug-tcp-concurrent-connect",
     "/usr/bin/bug-tcp-nonblocking-connect-so-error",
     "/usr/bin/bug-kill-zombie-esrch",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-riscv64.toml
@@ -66,6 +66,7 @@ test_commands = [
     "/usr/bin/bug-af-inet6-v4mapped",
     "/usr/bin/bug-tcp-udp-bind-same-port",
     "/usr/bin/bug-tcp-send-no-epoll-notify",
+    "/usr/bin/bug-epollet-second-chunk",
     "/usr/bin/bug-tcp-concurrent-connect",
     "/usr/bin/bug-tcp-nonblocking-connect-so-error",
     "/usr/bin/bug-kill-zombie-esrch",

--- a/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bugfix/qemu-x86_64.toml
@@ -64,6 +64,7 @@ test_commands = [
     "/usr/bin/bug-af-inet6-v4mapped",
     "/usr/bin/bug-tcp-udp-bind-same-port",
     "/usr/bin/bug-tcp-send-no-epoll-notify",
+    "/usr/bin/bug-epollet-second-chunk",
     "/usr/bin/bug-tcp-concurrent-connect",
     "/usr/bin/bug-tcp-nonblocking-connect-so-error",
     "/usr/bin/bug-kill-zombie-esrch",


### PR DESCRIPTION
Two related bugs in the EPOLLET delivery path broke event-driven runtimes on Tokio-style applications (jcode TUI, reqwest, etc.).

1. NoEvent path busy-loop on connected TCP sockets

   When InterestWaker fires but consume() reports no matching events (a spurious wake, e.g. a shared PollSet wake on an interest registered only for EPOLLIN while the underlying socket has EPOLLOUT-ready), the old code called check_and_register_waker().  That helper polls the file and immediately calls waker.wake_by_ref() if file.poll() is non-empty.  Connected TCP sockets always advertise EPOLLOUT, so every spurious NoEvent reissued the waker and re-queued the interest: NoEvent -> check_and_register_waker -> EPOLLOUT present -> wake_by_ref -> re-queued -> NoEvent -> ... The ready_queue filled with phantom entries and epoll_wait returned maxevents (up to 1024) of duplicate notifications, which kept tokio spinning without ever confirming the TCP handshake.

   Fix: use register_waker_only on the NoEvent path so the interest is re-armed and only fires on a genuine state transition, matching the EPOLLET contract.

2. EventAndRemove race window between mark_not_in_queue() and re-arm

   After delivering an EPOLLET event, mark_not_in_queue() clears the in-queue flag and then register_waker_only() installs a new InterestWaker.  The previous InterestWaker had already been consumed by the wake that delivered the first chunk, leaving the underlying PollSet empty in the gap between the two calls.  If the peer writes a second chunk inside that window, poll_update.wake() hits the empty PollSet and the notification is silently dropped.  The fresh waker is then installed only after the data has already arrived; no further write occurs and EPOLLET never fires again.  The visible symptom was jcode TUI hanging after the first AI response chunk.

   Fix: after register_waker_only(), re-check the file for IN/RDHUP/HUP events.  If data is already present, CAS the in-queue flag back to true and re-push the interest onto the ready queue directly (without going through waker.wake_by_ref(), which would reintroduce the bug-1 busy-loop).  EPOLLOUT is intentionally excluded: writable sockets are normally always OUT-ready and a check there would spin.

Add bug-epollet-second-chunk regression test covering both paths: an idle EPOLLET interest must not return phantom events from an always-OUT socket, and 32 back-to-back chunk-A/chunk-B rounds must each be reported by their own epoll_wait() call.