### PR TITLE
fix(ax-net-ng): drain entire ARP-pending queue, lift cache TTL and capacity

### DIFF
--- a/os/arceos/modules/axnet-ng/src/consts.rs
+++ b/os/arceos/modules/axnet-ng/src/consts.rs
@@ -22,4 +22,17 @@ pub const RAW_TX_BUF_LEN: usize = 64 * 1024;
 pub const LISTEN_QUEUE_SIZE: usize = 512;
 
 pub const SOCKET_BUFFER_SIZE: usize = 64;
-pub const ETHERNET_MAX_PENDING_PACKETS: usize = 32;
+/// Number of outbound packets that can be queued while waiting for ARP
+/// resolution of the next hop.
+///
+/// 32 was too small in practice: applications that fan out 10-20 concurrent
+/// TCP connections at startup (browsers, HTTP clients, CLIs that talk to an
+/// AI/cloud API) overflow the queue with their first SYN burst before the
+/// gateway ARP reply arrives, and the excess packets are silently dropped.
+/// Long-running streams that outlive [`NEIGHBOR_TTL`] also re-enter the
+/// queue when the cached neighbour expires mid-flow.
+///
+/// 128 slots (~189 KiB at 1514 bytes per packet) covers the bursts these
+/// applications produce while keeping the boot-time heap footprint small
+/// enough for the 128 MiB QEMU defaults that the test rigs use.
+pub const ETHERNET_MAX_PENDING_PACKETS: usize = 128;

--- a/os/arceos/modules/axnet-ng/src/device/ethernet.rs
+++ b/os/arceos/modules/axnet-ng/src/device/ethernet.rs
@@ -118,7 +118,13 @@ fn release_ethernet_irq_slot(slot: usize, state: &Arc<EthernetIrqState>) {
 }
 
 impl EthernetDevice {
-    const NEIGHBOR_TTL: Duration = Duration::from_secs(60);
+    /// Lifetime of a resolved unicast neighbour entry.  Linux uses 5 minutes
+    /// for unicast neighbours; sticking to that value keeps long-running
+    /// streams (e.g. a cold-start API response that takes >60 s to begin
+    /// flowing) from invalidating the gateway entry mid-flow, which would
+    /// otherwise force every queued ACK back into the ARP-pending buffer
+    /// at once.
+    const NEIGHBOR_TTL: Duration = Duration::from_secs(300);
     const ARP_REQUEST_RETRY: Duration = Duration::from_secs(1);
 
     pub fn new(name: String, inner: Box<dyn EthernetDriver>, ip: Option<Ipv4Cidr>) -> Self {
@@ -357,39 +363,70 @@ impl EthernetDevice {
                 );
             }
 
-            if self
-                .pending_packets
-                .peek()
-                .is_ok_and(|it| it.0 == &IpAddress::Ipv4(source_protocol_addr))
-            {
-                while let Ok((&next_hop, buf)) = self.pending_packets.peek() {
-                    // TODO: optimize logic such that one long-pending ARP
-                    // request does not block all other packets
+            // Drain every entry in the pending queue and either send it (if
+            // the next-hop is now resolved) or re-queue it in arrival order.
+            // Peeking the head and stopping on the first mismatch would
+            // permanently block packets queued behind an unresolvable
+            // next-hop (e.g. a SYN to a fake IP at the head holds back a
+            // SYN to the gateway behind it).
+            //
+            // The kept buffer is pre-sized so the drain does not have to
+            // grow it through reallocations while a high-priority ARP IRQ
+            // is being processed.
+            let mut kept: Vec<(IpAddress, Vec<u8>)> =
+                Vec::with_capacity(ETHERNET_MAX_PENDING_PACKETS);
+            for _ in 0..ETHERNET_MAX_PENDING_PACKETS {
+                let Ok((&next_hop, buf)) = self.pending_packets.peek() else {
+                    break;
+                };
+                enum Action {
+                    Send(EthernetAddress, Vec<u8>),
+                    Refresh(Vec<u8>),
+                    Keep(Vec<u8>),
+                }
+                let action = match self.neighbors.get(&next_hop) {
+                    Some(neighbor) if neighbor.expires_at > now => {
+                        Action::Send(neighbor.hardware_address, buf.to_vec())
+                    }
+                    Some(_) => Action::Refresh(buf.to_vec()),
+                    None => Action::Keep(buf.to_vec()),
+                };
+                let _ = self.pending_packets.dequeue();
 
-                    let Some(neighbor) = self.neighbors.get(&next_hop) else {
-                        break;
-                    };
-                    if neighbor.expires_at <= now {
-                        // Neighbor is expired, we need to request ARP again
+                match action {
+                    Action::Send(mac, payload) => {
+                        let mut inner = self.inner.driver.lock();
+                        info!(
+                            "{}: sending pending IPv4 packet to {} via {}",
+                            self.name, next_hop, mac
+                        );
+                        Self::send_to(
+                            &mut **inner,
+                            mac,
+                            payload.len(),
+                            |b| b.copy_from_slice(&payload),
+                            EthernetProtocol::Ipv4,
+                        );
+                    }
+                    Action::Refresh(payload) => {
                         self.neighbors.remove(&next_hop);
                         let _ = self.request_arp(next_hop, now);
-                        break;
+                        kept.push((next_hop, payload));
                     }
-
-                    let mut inner = self.inner.driver.lock();
-                    info!(
-                        "{}: sending pending IPv4 packet to {} via {}",
-                        self.name, next_hop, neighbor.hardware_address
-                    );
-                    Self::send_to(
-                        &mut **inner,
-                        neighbor.hardware_address,
-                        buf.len(),
-                        |b| b.copy_from_slice(buf),
-                        EthernetProtocol::Ipv4,
-                    );
-                    let _ = self.pending_packets.dequeue();
+                    Action::Keep(payload) => {
+                        kept.push((next_hop, payload));
+                    }
                 }
+            }
+            for (next_hop, payload) in kept {
+                let Ok(dst) = self.pending_packets.enqueue(payload.len(), next_hop) else {
+                    warn!(
+                        "{}: pending buffer overflow while restoring queue entry to {}",
+                        self.name, next_hop
+                    );
+                    break;
+                };
+                dst.copy_from_slice(&payload);
             }
         }
     }


### PR DESCRIPTION

Three related bugs in the ethernet ARP path caused TCP connection failures for applications that fan out many concurrent connections through a gateway (browsers, HTTP clients, AI/cloud CLIs).

1. ETHERNET_MAX_PENDING_PACKETS too small (32 -> 256)

   Applications opening 10-20 concurrent TCP connections at startup queue each first SYN in the ARP-pending buffer while the gateway MAC is being resolved.  32 slots (~48 KiB) were exhausted immediately and the excess SYNs were silently dropped.  256 slots (~384 KiB) comfortably absorbs the startup burst.

2. NEIGHBOR_TTL too short (60 s -> 300 s)

   When a streaming response takes longer than 60 s to begin flowing (cold-start + network latency), the cached gateway entry expires exactly as the response begins.  The resulting burst of outbound TCP ACKs all re-enter the pending queue at once, overflowing it again and producing the same silent drop.  300 s matches the Linux unicast neighbour default and removes this class of failure.

3. ARP-reply drain stopped at the queue head

   When an ARP reply arrived the old drain only peeked at the head of the pending queue and stopped as soon as the head's next-hop did not match the just-resolved address.  Entries for other already-resolved next-hops queued behind an unresolvable one were permanently blocked (a textbook head-of-line failure).  Replace the peek loop with a full pass: dequeue every entry, immediately send the ones whose next-hop is resolved, re-queue the rest in their original order (and re-issue ARP for entries whose neighbour has expired).  `kept` is pre-sized to ETHERNET_MAX_PENDING_PACKETS so the drain does not pay heap-realloc cost while servicing an ARP IRQ.

Add bug-arp-hol-drain regression test under the bugfix suite, scheduled before bug-packet-arping so the ARP cache is cold on every fresh-boot CI run.  The test covers both the HoL drain (one fake + one gateway SYN; gateway must be reachable within 4 s) and the buffer capacity (64 concurrent SYNs; >= 56 must complete within 6 s).