### PR TITLE
fix(ax-task): preempt on async wake, guard wait queue against double-enqueue

### DIFF
--- a/os/arceos/modules/axtask/src/future/mod.rs
+++ b/os/arceos/modules/axtask/src/future/mod.rs
@@ -43,7 +43,14 @@ impl Wake for AxWaker {
         if let Some(task) = self.task.upgrade() {
             let mut rq = select_run_queue::<NoPreemptIrqSave>(&task);
             *self.woke.lock() = true;
-            rq.unblock_task(task, false);
+            // Pass resched=true so set_preempt_pending() is called when the
+            // task is moved back to ready.  Without this an async I/O wake
+            // sits behind one full timer tick of the currently running task
+            // before it can run, which manifests as latency spikes on the
+            // user→tty→TUI hop (any extra keystroke-to-redraw step adds
+            // ~10 ms).  Making the wake preemptive collapses that hop to
+            // the scheduler's next safe preemption point (microseconds).
+            rq.unblock_task(task, true);
         }
     }
 }

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -446,9 +446,19 @@ impl<G: BaseGuard> CurrentRunQueueRef<'_, G> {
         // Mark the task as blocked, this has to be done before adding it to the wait queue
         // while holding the lock of the wait queue.
         curr.set_state(TaskState::Blocked);
-        curr.set_in_wait_queue(true);
 
-        wq_guard.push_back(curr.clone());
+        // The task may already be in this wait queue when an async waker
+        // (e.g. AxWaker::wake_by_ref with resched=true) preempts the task
+        // while it is inside WaitQueue::wait_until and re-runs the same
+        // wait_until call before the previous push_back has been
+        // consumed.  Pushing twice would leave a phantom entry that
+        // notify_one_with can later hand mutex ownership to while the
+        // task is running user code, causing a spurious "tried to
+        // acquire mutex it already owns" panic on the next aspace().lock().
+        if !curr.in_wait_queue() {
+            curr.set_in_wait_queue(true);
+            wq_guard.push_back(curr.clone());
+        }
         // Drop the lock of wait queue explictly.
         drop(wq_guard);
 

--- a/os/arceos/modules/axtask/src/tests.rs
+++ b/os/arceos/modules/axtask/src/tests.rs
@@ -5,7 +5,9 @@ use std::{
     thread,
 };
 
-use crate::{WaitQueue, api as ax_task, current};
+use ax_kernel_guard::NoPreemptIrqSave;
+
+use crate::{WaitQueue, api as ax_task, current, run_queue::select_run_queue, task::TaskState};
 
 type TestResult = Result<(), Box<dyn core::any::Any + Send>>;
 type TestJob = (Box<dyn FnOnce() + Send + 'static>, mpsc::Sender<TestResult>);
@@ -158,5 +160,68 @@ fn test_task_join() {
         for (i, task) in tasks.into_iter().enumerate() {
             assert_eq!(task.join(), i as _);
         }
+    });
+}
+
+// Regression test for the double-enqueue bug fixed in blocked_resched.
+//
+// Scenario: a task is blocked in WaitQueue::wait_until (in_wait_queue = true,
+// one entry in the queue).  An AxWaker fires unblock_task directly — the same
+// path taken by AxWaker::wake_by_ref with resched=true — which transitions the
+// task to Ready without clearing its in_wait_queue flag.  The stale queue
+// entry is still present.  When the task re-runs and re-enters blocked_resched
+// (condition still false), the guard `if !curr.in_wait_queue()` must prevent a
+// second push_back.  Without the guard the queue would accumulate a phantom
+// entry; notify_one_with could later hand ownership to the already-running
+// task and produce a spurious "tried to acquire mutex it already owns" panic.
+#[test]
+fn test_blocked_resched_no_double_enqueue() {
+    run_in_test_scheduler(|| {
+        static WQ: WaitQueue = WaitQueue::new();
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        COUNTER.store(0, Ordering::Release);
+
+        // T1 waits until COUNTER reaches 2.
+        let task1 = ax_task::spawn_raw(
+            || {
+                WQ.wait_until(|| COUNTER.load(Ordering::Acquire) >= 2);
+            },
+            "waiter".into(),
+            RAW_TASK_STACK_SIZE,
+        );
+
+        // Let T1 run and block; it now has one entry in WQ with in_wait_queue=true.
+        ax_task::yield_now();
+
+        assert_eq!(task1.state(), TaskState::Blocked, "T1 should be blocked");
+        assert!(task1.in_wait_queue(), "T1 should have in_wait_queue=true");
+
+        // Simulate AxWaker::wake_by_ref (resched=true path): unblock T1 directly
+        // without going through notify_one, so in_wait_queue is NOT cleared and
+        // the stale queue entry remains.
+        select_run_queue::<NoPreemptIrqSave>(&task1).unblock_task(task1.clone(), false);
+        assert!(
+            task1.in_wait_queue(),
+            "in_wait_queue must stay true after direct unblock (stale entry)"
+        );
+
+        // Let T1 run: COUNTER is still 0 so condition is false; T1 re-enters
+        // blocked_resched.  The in_wait_queue guard must prevent a second push.
+        ax_task::yield_now();
+
+        // Signal the condition and do exactly one notify.
+        COUNTER.store(2, Ordering::Release);
+        assert!(WQ.notify_one(true), "notify_one must find the stale entry");
+
+        // Wait for T1 to finish.
+        task1.join();
+
+        // After T1 exits the queue must be empty.  A phantom entry here would
+        // mean the double-enqueue occurred and the fix is not working.
+        assert!(
+            !WQ.notify_one(false),
+            "wait queue has a phantom entry — blocked_resched double-enqueue not fixed"
+        );
     });
 }

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -47,19 +47,33 @@ fn workspace_package_names(metadata: &Metadata) -> HashSet<String> {
         .collect()
 }
 
+/// A package entry from the std-crates CSV, with optional feature flags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TestPackage {
+    name: String,
+    /// Feature names to pass via `--features`. Empty means no `--features` flag.
+    features: Vec<String>,
+}
+
 fn load_std_crates(
     csv_path: &Path,
     known_packages: &HashSet<String>,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<Vec<TestPackage>> {
     let contents = fs::read_to_string(csv_path)
         .with_context(|| format!("failed to read {}", csv_path.display()))?;
     parse_std_crates_csv(&contents, known_packages)
 }
 
+/// Parse the std-crates CSV.
+///
+/// Each data line may be either `package` or `package,feat1,feat2,...`.  The
+/// first field must be a known workspace package name; any remaining
+/// comma-separated fields are treated as Cargo feature names passed via
+/// `--features` when the test is run.
 fn parse_std_crates_csv(
     contents: &str,
     known_packages: &HashSet<String>,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<Vec<TestPackage>> {
     let mut lines = contents.lines().enumerate().filter_map(|(idx, raw)| {
         let line = raw.trim();
         (!line.is_empty()).then_some((idx + 1, line))
@@ -79,7 +93,18 @@ fn parse_std_crates_csv(
 
     let mut packages = Vec::new();
     let mut seen = HashSet::new();
-    for (line_no, package) in lines {
+    for (line_no, line) in lines {
+        let mut fields = line.splitn(2, ',');
+        let package = fields.next().unwrap_or("").trim();
+        let features: Vec<String> = fields
+            .next()
+            .unwrap_or("")
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
+
         if !known_packages.contains(package) {
             bail!(
                 "unknown workspace package `{}` at line {}",
@@ -90,35 +115,43 @@ fn parse_std_crates_csv(
         if !seen.insert(package.to_owned()) {
             bail!("duplicate package `{}` at line {}", package, line_no);
         }
-        packages.push(package.to_owned());
+        packages.push(TestPackage {
+            name: package.to_owned(),
+            features,
+        });
     }
 
     Ok(packages)
 }
 
-fn cargo_test_args(package: &str) -> Vec<String> {
-    vec!["test".into(), "-p".into(), package.into()]
+fn cargo_test_args(pkg: &TestPackage) -> Vec<String> {
+    let mut args = vec!["test".into(), "-p".into(), pkg.name.clone()];
+    if !pkg.features.is_empty() {
+        args.push("--features".into());
+        args.push(pkg.features.join(","));
+    }
+    args
 }
 
 fn run_std_tests<R: CargoRunner>(
     runner: &mut R,
     workspace_root: &Path,
-    packages: &[String],
+    packages: &[TestPackage],
 ) -> anyhow::Result<Vec<String>> {
     let mut failed = Vec::new();
 
-    for (index, package) in packages.iter().enumerate() {
+    for (index, pkg) in packages.iter().enumerate() {
         println!(
             "[{}/{}] cargo {}",
             index + 1,
             packages.len(),
-            cargo_test_args(package).join(" ")
+            cargo_test_args(pkg).join(" ")
         );
-        if runner.run_test(workspace_root, package)? {
-            println!("ok: {}", package);
+        if runner.run_test(workspace_root, pkg)? {
+            println!("ok: {}", pkg.name);
         } else {
-            eprintln!("failed: {}", package);
-            failed.push(package.clone());
+            eprintln!("failed: {}", pkg.name);
+            failed.push(pkg.name.clone());
         }
     }
 
@@ -126,14 +159,14 @@ fn run_std_tests<R: CargoRunner>(
 }
 
 trait CargoRunner {
-    fn run_test(&mut self, workspace_root: &Path, package: &str) -> anyhow::Result<bool>;
+    fn run_test(&mut self, workspace_root: &Path, pkg: &TestPackage) -> anyhow::Result<bool>;
 }
 
 struct ProcessCargoRunner;
 
 impl CargoRunner for ProcessCargoRunner {
-    fn run_test(&mut self, workspace_root: &Path, package: &str) -> anyhow::Result<bool> {
-        let args = cargo_test_args(package);
+    fn run_test(&mut self, workspace_root: &Path, pkg: &TestPackage) -> anyhow::Result<bool> {
+        let args = cargo_test_args(pkg);
         run_cargo_status(workspace_root, &args)
     }
 }
@@ -170,10 +203,24 @@ mod tests {
     }
 
     impl CargoRunner for FakeCargoRunner {
-        fn run_test(&mut self, workspace_root: &Path, package: &str) -> anyhow::Result<bool> {
+        fn run_test(&mut self, workspace_root: &Path, pkg: &TestPackage) -> anyhow::Result<bool> {
             self.invocations
-                .push((workspace_root.to_path_buf(), package.to_string()));
-            Ok(*self.results.get(package).unwrap_or(&true))
+                .push((workspace_root.to_path_buf(), pkg.name.clone()));
+            Ok(*self.results.get(&pkg.name).unwrap_or(&true))
+        }
+    }
+
+    fn pkg(name: &str) -> TestPackage {
+        TestPackage {
+            name: name.to_string(),
+            features: vec![],
+        }
+    }
+
+    fn pkg_with_features(name: &str, features: &[&str]) -> TestPackage {
+        TestPackage {
+            name: name.to_string(),
+            features: features.iter().map(|s| s.to_string()).collect(),
         }
     }
 
@@ -182,7 +229,7 @@ mod tests {
         let packages =
             parse_std_crates_csv("package\nax-feat\nax-hal\n", &known_packages()).unwrap();
 
-        assert_eq!(packages, vec!["ax-feat".to_string(), "ax-hal".to_string()]);
+        assert_eq!(packages, vec![pkg("ax-feat"), pkg("ax-hal")]);
     }
 
     #[test]
@@ -190,7 +237,24 @@ mod tests {
         let packages =
             parse_std_crates_csv("\npackage\n\nax-feat\n\nax-hal\n", &known_packages()).unwrap();
 
-        assert_eq!(packages, vec!["ax-feat".to_string(), "ax-hal".to_string()]);
+        assert_eq!(packages, vec![pkg("ax-feat"), pkg("ax-hal")]);
+    }
+
+    #[test]
+    fn parses_std_csv_with_features() {
+        let packages = parse_std_crates_csv(
+            "package\nax-feat,feat-a,feat-b\nax-hal\n",
+            &known_packages(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            packages,
+            vec![
+                pkg_with_features("ax-feat", &["feat-a", "feat-b"]),
+                pkg("ax-hal")
+            ]
+        );
     }
 
     #[test]
@@ -240,11 +304,7 @@ mod tests {
     #[test]
     fn std_test_runner_collects_all_failures() {
         let root = PathBuf::from("/tmp/workspace");
-        let packages = vec![
-            "ax-feat".to_string(),
-            "ax-hal".to_string(),
-            "starry-process".to_string(),
-        ];
+        let packages = vec![pkg("ax-feat"), pkg("ax-hal"), pkg("starry-process")];
         let mut runner = FakeCargoRunner::new(&[
             ("ax-feat", true),
             ("ax-hal", false),
@@ -270,11 +330,32 @@ mod tests {
     #[test]
     fn std_test_runner_returns_empty_failures_when_all_pass() {
         let root = PathBuf::from("/tmp/workspace");
-        let packages = vec!["ax-feat".to_string(), "ax-hal".to_string()];
+        let packages = vec![pkg("ax-feat"), pkg("ax-hal")];
         let mut runner = FakeCargoRunner::new(&[("ax-feat", true), ("ax-hal", true)]);
 
         let failed = run_std_tests(&mut runner, &root, &packages).unwrap();
 
         assert!(failed.is_empty());
+    }
+
+    #[test]
+    fn cargo_test_args_without_features() {
+        let p = pkg("ax-hal");
+        assert_eq!(cargo_test_args(&p), vec!["test", "-p", "ax-hal"]);
+    }
+
+    #[test]
+    fn cargo_test_args_with_features() {
+        let p = pkg_with_features("ax-task", &["multitask", "sched-fifo", "test"]);
+        assert_eq!(
+            cargo_test_args(&p),
+            vec![
+                "test",
+                "-p",
+                "ax-task",
+                "--features",
+                "multitask,sched-fifo,test"
+            ]
+        );
     }
 }

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -43,7 +43,7 @@ ax-display
 ax-driver
 ax-hal
 ax-sync
-ax-task
+ax-task,multitask,sched-fifo,test
 ax-input
 ax-ipi
 ax-log


### PR DESCRIPTION


Two small but related scheduler fixes that together remove a latency spike and a panic seen on async I/O paths.

1. AxWaker::wake_by_ref calls unblock_task with resched=true

   The previous resched=false meant any future woken by an interrupt or another task only became runnable after the currently running task reached its next voluntary yield point.  With the default 10 ms timer tick, the visible latency on a two-hop wake (interrupt -> tty reader -> TUI consumer) was up to 20 ms before the consumer started running. Passing resched=true triggers set_preempt_pending() inside unblock_task so the woken task can take over at the next safe preemption point, collapsing the latency to a few microseconds.

2. blocked_resched skips push_back when the task is already queued

   Enabling preemptive wakes exposes a race in WaitQueue::wait_until. wait_until acquires the queue lock, sets the task state to Blocked and calls blocked_resched.  blocked_resched used to unconditionally set in_wait_queue and push the task into the queue.  If an AxWaker firing on an unrelated future preempts the task between the previous push_back and the resched call (which is now possible because the AxWaker arms set_preempt_pending), the task can re-enter wait_until and reach blocked_resched a second time while the previous entry is still in the queue.  notify_one_with later pops the stale entry and transfers mutex ownership to it; the task subsequently observes the mutex as already owned and panics with "Thread(N) tried to acquire mutex it already owns" on the next aspace().lock().

   Guard the push_back with `if !curr.in_wait_queue()`.  The flag is still cleared by notify_one_with after a successful pop, so the skip only ever fires when the previous wait is still pending and the task is genuinely already queued.