### PR TITLE
fix(starry-kernel,x86-qemu-q35): probe terminal size, deliver SIGWINCH, batch ONLCR writes

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -13,6 +13,7 @@ use ax_task::current;
 use axfs_ng_vfs::NodeFlags;
 use axpoll::{IoEvents, Pollable};
 use starry_process::Process;
+use starry_signal::{SignalInfo, Signo};
 use starry_vm::{VmMutPtr, VmPtr};
 
 use self::terminal::{
@@ -28,7 +29,7 @@ pub use self::{
 };
 use crate::{
     pseudofs::DeviceOps,
-    task::{AsThread, get_process_group},
+    task::{AsThread, get_process_group, send_signal_to_process_group},
 };
 
 const ANSI_CURSOR_POSITION_REQUEST: &[u8] = b"\x1b[6n";
@@ -153,7 +154,22 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
             }
             TIOCSWINSZ => {
                 let window_size = (arg as *const WindowSize).vm_read()?;
-                *self.terminal.window_size.lock() = window_size;
+                let old = {
+                    let mut guard = self.terminal.window_size.lock();
+                    let old = *guard;
+                    *guard = window_size;
+                    old
+                };
+                // Match Linux tty_do_resize(): notify the foreground process
+                // group via SIGWINCH so TUI applications (e.g. ratatui) can
+                // re-layout when the user resizes the host terminal.
+                let changed = old.ws_row != window_size.ws_row || old.ws_col != window_size.ws_col;
+                if changed && let Some(pg) = self.terminal.job_control.foreground() {
+                    let _ = send_signal_to_process_group(
+                        pg.pgid(),
+                        Some(SignalInfo::new_kernel(Signo::SIGWINCH)),
+                    );
+                }
             }
             TIOCSPTLCK => {}
             TIOCGPTN => {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
@@ -5,7 +5,10 @@ use spin::Lazy;
 
 use super::{
     Tty,
-    terminal::ldisc::{ProcessMode, TtyConfig, TtyRead, TtyWrite},
+    terminal::{
+        WindowSize,
+        ldisc::{ProcessMode, TtyConfig, TtyRead, TtyWrite},
+    },
 };
 
 pub type NTtyDriver = Tty<Console, Console>;
@@ -39,14 +42,92 @@ fn handle_console_input_irq(_irq_num: usize) {
 }
 
 fn new_n_tty() -> Arc<NTtyDriver> {
+    // Synchronously query the connected terminal's dimensions before the
+    // poll-reader task is spawned so TIOCGWINSZ reports the real host
+    // terminal size.  TUI applications (e.g. ratatui-based clients) use the
+    // size both to lay out panels and to map mouse-event coordinates;
+    // returning a stale fallback misplaces the UI and leaves clicks/scroll
+    // outside the rendered widgets.  Falls back silently to the default
+    // 24x80 if the host terminal does not support CPR.
+    let terminal = {
+        let t = super::terminal::Terminal::default();
+        if let Some((rows, cols)) = query_console_size() {
+            *t.window_size.lock() = WindowSize {
+                ws_row: rows,
+                ws_col: cols,
+                ws_xpixel: 0,
+                ws_ypixel: 0,
+            };
+        }
+        Arc::new(t)
+    };
+
     Tty::new(
-        Arc::default(),
+        terminal,
         TtyConfig {
             reader: Console,
             writer: Console,
             process_mode: console_irq_mode().unwrap_or(ProcessMode::Manual),
         },
     )
+}
+
+/// Probe the connected terminal for its current size using the
+/// standard cursor-position-report sequence.
+///
+/// Sequence: save cursor (DECSC) -> move to (9999, 9999) -> request
+/// cursor position (CPR) -> restore cursor (DECRC).  The terminal
+/// clamps the move to its actual bottom-right corner before reporting
+/// back, so the reply `\x1b[rows;colsR` reflects the real geometry.
+/// Spin-waits up to roughly 100 ms for the reply and returns `None`
+/// on timeout or parse failure.
+///
+/// Called once during NTTY initialisation, before the polling reader
+/// task is spawned, so there is no concurrent consumer racing on the
+/// UART receive FIFO.
+fn query_console_size() -> Option<(u16, u16)> {
+    ax_hal::console::write_bytes(b"\x1b7\x1b[9999;9999H\x1b[6n\x1b8");
+
+    let mut buf = [0u8; 32];
+    let mut len = 0usize;
+
+    // Spin up to ~100 ms (in wall time, polled via ax_hal::time::wall_time)
+    // for the `R` terminator.  Hosts that ignore CPR (jcode running under
+    // a non-interactive serial, automated CI runners) will time out and
+    // we fall back to the 24x80 default without blocking boot further.
+    let deadline = ax_hal::time::wall_time() + core::time::Duration::from_millis(100);
+    'collect: while ax_hal::time::wall_time() < deadline {
+        let mut tmp = [0u8; 1];
+        if ax_hal::console::read_bytes(&mut tmp) > 0 {
+            if len < buf.len() {
+                buf[len] = tmp[0];
+                len += 1;
+            } else {
+                // Buffer full without seeing 'R'; give up rather than
+                // spinning until the deadline on a misbehaving terminal.
+                break 'collect;
+            }
+            if tmp[0] == b'R' {
+                break 'collect;
+            }
+        }
+        core::hint::spin_loop();
+    }
+
+    if len == 0 {
+        return None;
+    }
+
+    let r_pos = buf[..len].iter().rposition(|&b| b == b'R')?;
+    let escape_pos = buf[..r_pos].windows(2).rposition(|w| w == b"\x1b[")?;
+    let inner = core::str::from_utf8(&buf[escape_pos + 2..r_pos]).ok()?;
+    let mut parts = inner.splitn(2, ';');
+    let rows: u16 = parts.next()?.parse().ok()?;
+    let cols: u16 = parts.next()?.parse().ok()?;
+    if rows == 0 || cols == 0 {
+        return None;
+    }
+    Some((rows, cols))
 }
 
 fn console_irq_mode() -> Option<ProcessMode> {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -64,19 +64,25 @@ pub fn write_output_bytes<W: TtyWrite + ?Sized>(writer: &W, term: &Termios2, buf
         return;
     }
 
-    let mut start = 0;
-    for (i, &byte) in buf.iter().enumerate() {
+    // Collect output with \n -> \r\n translation into a single buffer so the
+    // underlying writer sees exactly one call per write_output_bytes() instead
+    // of one call per newline.  A TUI frame typically contains many cursor-
+    // movement newlines; the per-newline approach forced the UART driver to
+    // acquire/release its lock dozens of times for a single frame and made
+    // terminal emulators render the frame line-by-line (visible flicker).
+    let extra = buf.iter().filter(|&&b| b == b'\n').count();
+    if extra == 0 {
+        writer.write(buf);
+        return;
+    }
+    let mut out = alloc::vec::Vec::with_capacity(buf.len() + extra);
+    for &byte in buf {
         if byte == b'\n' {
-            if start < i {
-                writer.write(&buf[start..i]);
-            }
-            writer.write(b"\r\n");
-            start = i + 1;
+            out.push(b'\r');
         }
+        out.push(byte);
     }
-    if start < buf.len() {
-        writer.write(&buf[start..]);
-    }
+    writer.write(&out);
 }
 
 struct InputReader<R, W> {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/mod.rs
@@ -30,8 +30,10 @@ impl Default for Terminal {
         Self {
             job_control: job::JobControl::new(),
             window_size: SpinNoIrq::new(WindowSize {
-                ws_row: 28,
-                ws_col: 110,
+                // 24x80 is the standard VT100 fallback that applications
+                // expect when TIOCGWINSZ reports a "default" terminal.
+                ws_row: 24,
+                ws_col: 80,
                 ws_xpixel: 0,
                 ws_ypixel: 0,
             }),

--- a/platform/x86-qemu-q35/src/console.rs
+++ b/platform/x86-qemu-q35/src/console.rs
@@ -20,11 +20,6 @@ use uart_16550::SerialPort;
 
 static COM1: SpinNoIrq<SerialPort> = unsafe { SpinNoIrq::new(SerialPort::new(0x3f8)) };
 
-/// Writes a byte to the console.
-pub fn putchar(c: u8) {
-    COM1.lock().send(c)
-}
-
 /// Reads a byte from the console, or returns [`None`] if no input is available.
 pub fn getchar() -> Option<u8> {
     COM1.lock().try_receive().ok()
@@ -40,8 +35,13 @@ struct ConsoleIfImpl;
 impl ConsoleIf for ConsoleIfImpl {
     /// Writes given bytes to the console.
     fn write_bytes(bytes: &[u8]) {
-        for c in bytes {
-            putchar(*c);
+        // Hold COM1 for the entire write so that one logical output
+        // (e.g. a full ANSI TUI frame) is never interleaved with output
+        // from another task.  This also avoids paying lock-acquire cost
+        // for every byte, which is visible on large frame dumps.
+        let mut com = COM1.lock();
+        for &c in bytes {
+            com.send(c);
         }
     }
 


### PR DESCRIPTION


Four serial-console / TTY improvements that together make TUI applications (ratatui-based clients, anything that reacts to SIGWINCH or that draws a full frame per render) usable on the QEMU serial console.

1. NTTY probes the connected terminal's real dimensions

   On NTTY initialisation (synchronously, before the input poll task is spawned) the kernel sends the standard cursor-position-report sequence (`\x1b7\x1b[9999;9999H\x1b[6n\x1b8`) and parses the `\x1b[rows;colsR` reply.  TIOCGWINSZ then reports the real host terminal size instead of a stale fallback, which is what TUI applications rely on to lay out panels and to translate mouse coordinates to widgets.  The wait is bounded to ~100 ms of wall time via `ax_hal::time::wall_time()` so a host that ignores CPR does not delay boot.

2. Default window size 28x110 -> 24x80

   24x80 is the standard VT100 fallback that applications expect when TIOCGWINSZ reports a "default" terminal.  The previous value was an arbitrary serial-friendly size that confused applications on first paint.

3. SIGWINCH on TIOCSWINSZ

   Match Linux tty_do_resize(): when an ioctl changes the recorded window size, send SIGWINCH to the foreground process group so TUI applications can re-layout immediately when the user resizes the host terminal.

4. Batched ONLCR output and atomic UART writes

   write_output_bytes() now collects the `\n -> \r\n` translation into a single Vec and issues exactly one writer.write() call. The previous per-newline issue path produced O(newlines) separate writes; a typical TUI frame contains many cursor-movement newlines, so the COM1 driver acquired/released its lock dozens of times for a single frame and terminal emulators rendered the frame line-by-line (visible flicker).

   On the x86-qemu-q35 platform the ConsoleIfImpl::write_bytes implementation also holds the COM1 lock for the whole call so that one logical write is never interleaved with output from another task and pays the lock-acquire cost once per write_bytes rather than once per byte.