### PR TITLE
fix(starry-signal): keep x86-64 uc_mcontext at Linux ABI offset 40

### DIFF
--- a/components/starry-signal/src/arch/x86_64.rs
+++ b/components/starry-signal/src/arch/x86_64.rs
@@ -16,7 +16,18 @@ signal_trampoline:
 "
 );
 
-#[repr(C, align(16))]
+// Linux x86-64 `mcontext_t` (`struct sigcontext`) has NATURAL 8-byte alignment,
+// NOT 16. In `ucontext_t`, `uc_mcontext` sits in the MIDDLE of the struct (offset
+// 40, after uc_flags/uc_link/uc_stack); forcing `align(16)` here inserts 8 bytes
+// of padding and pushes `uc_mcontext` to offset 48 — shifting every general
+// register (RSP@160, RIP@168), the fpregs pointer and `uc_sigmask` 8 bytes off
+// the Linux ABI. Runtimes that read the context by raw ABI offset — notably Go's
+// async preemption, which reads/writes `uc_mcontext.gregs[REG_RSP/REG_RIP]` and
+// expects `rt_sigreturn` to honor those writes — then corrupt RSP/RIP (observed:
+// `sp` loaded with adjacent non-pointer bytes -> `unsafe.Slice: len out of range`).
+// The 16-byte alignment the signal frame itself requires is provided by the outer
+// `UContext` (see below), not by over-aligning this inner struct.
+#[repr(C)]
 #[derive(Clone)]
 pub struct MContext {
     r8: usize,
@@ -108,7 +119,13 @@ impl MContext {
     }
 }
 
-#[repr(C)]
+// `align(16)` keeps the whole signal frame 16-byte aligned on the user stack (the
+// x86-64 signal ABI requires the handler to observe `RSP % 16 == 8` after its
+// return address is pushed). This frame alignment was previously (incorrectly)
+// supplied by over-aligning the inner `MContext`, which corrupted `uc_mcontext`'s
+// offset; aligning the outer `UContext` instead keeps `uc_mcontext` at the Linux
+// ABI offset 40 while still guaranteeing frame alignment.
+#[repr(C, align(16))]
 #[derive(Clone)]
 pub struct UContext {
     pub flags: usize,
@@ -129,3 +146,11 @@ impl UContext {
         }
     }
 }
+
+const _: () = {
+    // Lock the Linux/musl x86-64 `ucontext_t` ABI offsets (compile-time regression
+    // guard for the alignment trap documented on `MContext`): `uc_mcontext`@40,
+    // `uc_sigmask`@296.
+    assert!(core::mem::offset_of!(UContext, mcontext) == 40);
+    assert!(core::mem::offset_of!(UContext, sigmask) == 296);
+};


### PR DESCRIPTION
## 问题
x86-64 上,依赖 raw ABI 偏移读写信号上下文的运行时会损坏寄存器。最典型是 Go 的异步抢占(SIGURG):其 signal handler 读写 `uc_mcontext.gregs[REG_RSP/REG_RIP]` 并指望 `rt_sigreturn` 按这些写回恢复;在 StarryOS 上 `RSP` 被错位 8 字节、载入相邻的非指针字节 → `unsafe.Slice: len out of range` panic。

## 根因
`MContext`(对应 Linux `struct sigcontext` / `mcontext_t`)被标注 `#[repr(C, align(16))]`。但 Linux 的 `mcontext_t` 是**自然 8 字节对齐**,且在 `ucontext_t` 里 `uc_mcontext` 位于结构体**中部**(偏移 40,紧随 `uc_flags`/`uc_link`/`uc_stack`)。强制 16 对齐会在 `uc_stack`(@16..40)之后插入 8 字节填充,把 `uc_mcontext` 推到偏移 48 → 其内每个通用寄存器(RSP@160、RIP@168)、fpregs 指针、以及随后的 `uc_sigmask` 全部相对 Linux ABI 偏移 8 字节。Go 按裸偏移访问即错位。

## 修复
- `MContext`:`#[repr(C, align(16))]` → `#[repr(C)]`(恢复自然 8 对齐 → `uc_mcontext`@40)。
- `UContext`:`#[repr(C)]` → `#[repr(C, align(16))]`。信号帧本身要求落在用户栈 16 对齐处(handler 入口须 `RSP%16==8`);该对齐改由**外层** `UContext` 提供,既保帧对齐、又不再扰动 `uc_mcontext` 的偏移。
- 新增编译期 `const _` 断言锁定 `offset_of!(UContext, mcontext)==40 && offset_of!(UContext, sigmask)==296`,作为 ABI 回归守卫(偏移再被改错即编译失败)。
仅改 `components/starry-signal/src/arch/x86_64.rs`,不触其它 arch/调用方。

## 对照 Linux(验证)
Linux/musl x86-64 `ucontext_t`:`uc_flags`@0、`uc_link`@8、`uc_stack`@16、`uc_mcontext`@40、`uc_sigmask`@296(`struct sigcontext` 256 字节)。本修后 StarryOS 偏移与之逐一吻合(const-assert 编译期证实)。Go runtime 在 host Linux 正常异步抢占即依赖此布局。

## 测试
`cargo xtask starry build --arch x86_64` 通过(含上述 const-assert);openjdk17(信号密集:GC safepoint/SIGSEGV null-check)x86_64 实测无回归。
