### PR TITLE
fix(loongarch64): make userspace LSX usable (preserve FP/LSX state + fix uc_mcontext offset + advertise AT_HWCAP)

### DIFF
--- a/components/axcpu/src/loongarch64/context.rs
+++ b/components/axcpu/src/loongarch64/context.rs
@@ -43,12 +43,29 @@ pub struct GeneralRegisters {
     pub s8: usize,
 }
 
-/// Floating-point registers of LoongArch64
+/// Floating-point / LSX vector registers of LoongArch64.
+///
+/// The platform enables the LSX 128-bit vector extension at boot (see
+/// `axplat-loongarch64-qemu-virt` `enable_lsx`), so user code (e.g. the JVM)
+/// uses the full 128-bit vector registers `vr0`-`vr31`. The scalar FP registers
+/// `f0`-`f31` alias the low 64 bits of `vr0`-`vr31`. To correctly save/restore
+/// the live FP/vector state across a context switch or a signal delivery we must
+/// preserve all 128 bits of each register, not just the low 64.
+///
+/// `fp` holds the low 64 bits (`vr[63:0]`, i.e. the scalar `fN` view) and
+/// `fp_high` holds the high 64 bits (`vr[127:64]`). Keeping `fp` first and with
+/// its original layout means any consumer that treated `fp[i]` as the scalar
+/// double `fN` still observes the same value; `fp_high` is purely additive.
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FpuState {
-    /// Floating-point registers (f0-f31)
+    /// Low 64 bits of the vector registers `vr0`-`vr31` (the scalar `f0`-`f31`).
     pub fp: [u64; 32],
+    /// High 64 bits of the vector registers `vr0`-`vr31` (`vr[127:64]`).
+    ///
+    /// Saved/restored via LSX so an async signal (or preemptive switch)
+    /// interrupting a thread mid-LSX-op does not clobber these on resume.
+    pub fp_high: [u64; 32],
     /// Floating-point Condition Code register
     pub fcc: [u8; 8],
     /// Floating-point Control and Status register
@@ -291,11 +308,14 @@ unsafe extern "C" fn save_fp_registers(fpu: &mut FpuState) {
         include_fp_asm_macros!(),
         "
         SAVE_FP $a0
+        addi.d $t8, $a0, {fp_high_offset}
+        SAVE_FP_HIGH $t8
         addi.d $t8, $a0, {fcc_offset}
         SAVE_FCC $t8
         addi.d $t8, $a0, {fcsr_offset}
         SAVE_FCSR $t8
         ret",
+        fp_high_offset = const offset_of!(FpuState, fp_high),
         fcc_offset = const offset_of!(FpuState, fcc),
         fcsr_offset = const offset_of!(FpuState, fcsr),
     )
@@ -308,11 +328,14 @@ unsafe extern "C" fn restore_fp_registers(fpu: &FpuState) {
         include_fp_asm_macros!(),
         "
         RESTORE_FP $a0
+        addi.d $t8, $a0, {fp_high_offset}
+        RESTORE_FP_HIGH $t8
         addi.d $t8, $a0, {fcc_offset}
         RESTORE_FCC $t8
         addi.d $t8, $a0, {fcsr_offset}
         RESTORE_FCSR $t8
         ret",
+        fp_high_offset = const offset_of!(FpuState, fp_high),
         fcc_offset = const offset_of!(FpuState, fcc),
         fcsr_offset = const offset_of!(FpuState, fcsr),
     )

--- a/components/axcpu/src/loongarch64/macros.rs
+++ b/components/axcpu/src/loongarch64/macros.rs
@@ -88,6 +88,12 @@ macro_rules! include_asm_macros {
 macro_rules! include_fp_asm_macros {
     () => {
         r#"
+        // NOTE: The LSX (128-bit vector) instructions used by
+        // SAVE_FP_HIGH/RESTORE_FP_HIGH below (vstelm.d / vld+vinsgr2vr.d) are
+        // accepted by the LLVM integrated assembler for this target without an
+        // explicit `.option arch, +lsx` (that GNU-as directive is rejected by
+        // LLVM). LSX is enabled in EUEN.SXE at boot, so these execute correctly.
+
         .ifndef FP_MACROS_FLAG
         .equ FP_MACROS_FLAG, 1
 
@@ -183,6 +189,94 @@ macro_rules! include_fp_asm_macros {
 
         .macro RESTORE_FP, base_reg
             PUSH_POP_FLOAT_REGS fld.d, \base_reg
+        .endm
+
+        // LSX 128-bit vector registers vr0-vr31 alias the scalar FP registers
+        // f0-f31 in their low 64 bits. The macros below save/restore the HIGH
+        // 64 bits (vr[127:64], element index 1 of the doubleword view) that the
+        // scalar fst.d/fld.d above do not touch. LSX must be enabled in EUEN.SXE
+        // (done at boot) for these to execute.
+        //
+        // `vstelm.d vd, rj, si8, idx` stores doubleword element `idx` of `vd`.
+        // `vld`/`vinsgr2vr.d` are used on restore: vinsgr2vr.d inserts a GPR into
+        // a vector element, leaving the other (low) element untouched, so it must
+        // run AFTER the scalar fld.d that loads the low half.
+        .macro SAVE_VR_HIGH vd, base_reg, off
+            vstelm.d \vd, \base_reg, \off, 1
+        .endm
+        .macro RESTORE_VR_HIGH vd, base_reg, off
+            ld.d        $t0, \base_reg, \off
+            vinsgr2vr.d \vd, $t0, 1
+        .endm
+
+        .macro SAVE_FP_HIGH, base_reg
+            SAVE_VR_HIGH $vr0,  \base_reg, 0*8
+            SAVE_VR_HIGH $vr1,  \base_reg, 1*8
+            SAVE_VR_HIGH $vr2,  \base_reg, 2*8
+            SAVE_VR_HIGH $vr3,  \base_reg, 3*8
+            SAVE_VR_HIGH $vr4,  \base_reg, 4*8
+            SAVE_VR_HIGH $vr5,  \base_reg, 5*8
+            SAVE_VR_HIGH $vr6,  \base_reg, 6*8
+            SAVE_VR_HIGH $vr7,  \base_reg, 7*8
+            SAVE_VR_HIGH $vr8,  \base_reg, 8*8
+            SAVE_VR_HIGH $vr9,  \base_reg, 9*8
+            SAVE_VR_HIGH $vr10, \base_reg, 10*8
+            SAVE_VR_HIGH $vr11, \base_reg, 11*8
+            SAVE_VR_HIGH $vr12, \base_reg, 12*8
+            SAVE_VR_HIGH $vr13, \base_reg, 13*8
+            SAVE_VR_HIGH $vr14, \base_reg, 14*8
+            SAVE_VR_HIGH $vr15, \base_reg, 15*8
+            SAVE_VR_HIGH $vr16, \base_reg, 16*8
+            SAVE_VR_HIGH $vr17, \base_reg, 17*8
+            SAVE_VR_HIGH $vr18, \base_reg, 18*8
+            SAVE_VR_HIGH $vr19, \base_reg, 19*8
+            SAVE_VR_HIGH $vr20, \base_reg, 20*8
+            SAVE_VR_HIGH $vr21, \base_reg, 21*8
+            SAVE_VR_HIGH $vr22, \base_reg, 22*8
+            SAVE_VR_HIGH $vr23, \base_reg, 23*8
+            SAVE_VR_HIGH $vr24, \base_reg, 24*8
+            SAVE_VR_HIGH $vr25, \base_reg, 25*8
+            SAVE_VR_HIGH $vr26, \base_reg, 26*8
+            SAVE_VR_HIGH $vr27, \base_reg, 27*8
+            SAVE_VR_HIGH $vr28, \base_reg, 28*8
+            SAVE_VR_HIGH $vr29, \base_reg, 29*8
+            SAVE_VR_HIGH $vr30, \base_reg, 30*8
+            SAVE_VR_HIGH $vr31, \base_reg, 31*8
+        .endm
+
+        .macro RESTORE_FP_HIGH, base_reg
+            RESTORE_VR_HIGH $vr0,  \base_reg, 0*8
+            RESTORE_VR_HIGH $vr1,  \base_reg, 1*8
+            RESTORE_VR_HIGH $vr2,  \base_reg, 2*8
+            RESTORE_VR_HIGH $vr3,  \base_reg, 3*8
+            RESTORE_VR_HIGH $vr4,  \base_reg, 4*8
+            RESTORE_VR_HIGH $vr5,  \base_reg, 5*8
+            RESTORE_VR_HIGH $vr6,  \base_reg, 6*8
+            RESTORE_VR_HIGH $vr7,  \base_reg, 7*8
+            RESTORE_VR_HIGH $vr8,  \base_reg, 8*8
+            RESTORE_VR_HIGH $vr9,  \base_reg, 9*8
+            RESTORE_VR_HIGH $vr10, \base_reg, 10*8
+            RESTORE_VR_HIGH $vr11, \base_reg, 11*8
+            RESTORE_VR_HIGH $vr12, \base_reg, 12*8
+            RESTORE_VR_HIGH $vr13, \base_reg, 13*8
+            RESTORE_VR_HIGH $vr14, \base_reg, 14*8
+            RESTORE_VR_HIGH $vr15, \base_reg, 15*8
+            RESTORE_VR_HIGH $vr16, \base_reg, 16*8
+            RESTORE_VR_HIGH $vr17, \base_reg, 17*8
+            RESTORE_VR_HIGH $vr18, \base_reg, 18*8
+            RESTORE_VR_HIGH $vr19, \base_reg, 19*8
+            RESTORE_VR_HIGH $vr20, \base_reg, 20*8
+            RESTORE_VR_HIGH $vr21, \base_reg, 21*8
+            RESTORE_VR_HIGH $vr22, \base_reg, 22*8
+            RESTORE_VR_HIGH $vr23, \base_reg, 23*8
+            RESTORE_VR_HIGH $vr24, \base_reg, 24*8
+            RESTORE_VR_HIGH $vr25, \base_reg, 25*8
+            RESTORE_VR_HIGH $vr26, \base_reg, 26*8
+            RESTORE_VR_HIGH $vr27, \base_reg, 27*8
+            RESTORE_VR_HIGH $vr28, \base_reg, 28*8
+            RESTORE_VR_HIGH $vr29, \base_reg, 29*8
+            RESTORE_VR_HIGH $vr30, \base_reg, 30*8
+            RESTORE_VR_HIGH $vr31, \base_reg, 31*8
         .endm
 
         .endif"#

--- a/components/starry-signal/src/arch/loongarch64.rs
+++ b/components/starry-signal/src/arch/loongarch64.rs
@@ -1,4 +1,4 @@
-use ax_cpu::{GeneralRegisters, uspace::UserContext};
+use ax_cpu::{FpuState, GeneralRegisters, uspace::UserContext};
 
 use crate::{SignalSet, SignalStack};
 
@@ -21,20 +21,36 @@ pub struct MContext {
     sc_pc: u64,
     sc_regs: GeneralRegisters,
     sc_flags: u32,
+    // Kernel-saved FP/FCC/FCSR of the interrupted thread. The musl-visible
+    // mcontext fields a handler reads are sc_pc/sc_regs/sc_flags above; this FP
+    // block lives where musl places `__extcontext` and is managed only by the
+    // kernel. Traps (incl. the signal-delivery path) do not save FP, so without
+    // this an async signal — e.g. a HotSpot safepoint-poll SIGSEGV interrupting
+    // FP-using user code — would resume with the handler's clobbered FP and
+    // corrupt state (gradle/kotlin compiler SIGSEGV on loongarch, #237).
+    fpu: FpuState,
 }
 
 impl MContext {
     pub fn new(uctx: &UserContext) -> Self {
+        // Capture the interrupted thread's live FP before the handler runs. The
+        // kernel is softfloat and does not touch FP between the trap and here,
+        // so the FP registers still hold the interrupted user state.
+        let mut fpu = FpuState::default();
+        fpu.save();
         Self {
             sc_pc: uctx.era as _,
             sc_regs: uctx.regs,
             sc_flags: 0,
+            fpu,
         }
     }
 
     pub fn restore(&self, uctx: &mut UserContext) {
         uctx.era = self.sc_pc as _;
         uctx.regs = self.sc_regs;
+        // Restore FP the handler may have clobbered, before resuming user code.
+        self.fpu.restore();
     }
 }
 
@@ -46,6 +62,11 @@ pub struct UContext {
     pub stack: SignalStack,
     pub sigmask: SignalSet,
     __unused: [u8; 1024 / 8 - size_of::<SignalSet>()],
+    // musl loongarch64 `ucontext_t` has `long __uc_pad` between `uc_sigmask` and
+    // `uc_mcontext`; without it `mcontext` lands 8 bytes early and a userspace
+    // SIGSEGV handler reading/writing `uc_mcontext` (e.g. HotSpot advancing the
+    // saved PC / inspecting GPRs) corrupts the resumed register state.
+    __uc_pad: u64,
     pub mcontext: MContext,
 }
 
@@ -57,6 +78,7 @@ impl UContext {
             stack: SignalStack::default(),
             sigmask,
             __unused: [0; 1024 / 8 - size_of::<SignalSet>()],
+            __uc_pad: 0,
             mcontext: MContext::new(uctx),
         }
     }

--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -12,7 +12,9 @@ use ax_hal::{
 use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
 use ax_sync::Mutex;
 use axfs_ng_vfs::Location;
-use kernel_elf_parser::{AuxEntry, ELFHeaders, ELFHeadersBuilder, ELFParser, app_stack_region};
+use kernel_elf_parser::{
+    AuxEntry, AuxType, ELFHeaders, ELFHeadersBuilder, ELFParser, app_stack_region,
+};
 use ouroboros::self_referencing;
 use uluru::LRUCache;
 
@@ -170,6 +172,45 @@ impl ElfCacheEntry {
     }
 }
 
+/// The value reported in the `AT_HWCAP` auxiliary vector entry.
+///
+/// `AT_HWCAP` (auxv type 16) advertises architecture-dependent CPU capability
+/// bits to userspace. `getauxval(AT_HWCAP)` reads it, and feature-dispatching
+/// runtimes gate optional instruction sets on it.
+///
+/// Per-arch policy:
+/// - **loongarch64**: report the baseline the kernel actually provides. The
+///   platform enables LSX (128-bit vectors) at boot via `enable_lsx()`
+///   (`EUEN.SXE`), so we set `CPUCFG | LAM | UAL | FPU | LSX`. This is required:
+///   numpy on Alpine loongarch is built with an LSX baseline and refuses to
+///   import unless `HWCAP_LOONGARCH_LSX` (bit 4) is set. LASX (256-bit, bit 5)
+///   is intentionally *not* set because the kernel does not enable `EUEN.ASXE`;
+///   claiming it could trap when userspace executes 256-bit ops.
+/// - **x86_64 / aarch64 / riscv64**: 0. glibc/musl on these arches do not gate
+///   numpy on `AT_HWCAP` (x86 uses CPUID; aarch64 ASIMD/NEON is mandatory), and
+///   numpy already imports successfully there today with `AT_HWCAP` absent.
+///   Reporting 0 preserves the current (passing) behavior.
+const fn hwcap_value() -> usize {
+    #[cfg(target_arch = "loongarch64")]
+    {
+        // Linux loongarch HWCAP bits (uapi/asm/hwcap.h):
+        const HWCAP_LOONGARCH_CPUCFG: usize = 1 << 0;
+        const HWCAP_LOONGARCH_LAM: usize = 1 << 1;
+        const HWCAP_LOONGARCH_UAL: usize = 1 << 2;
+        const HWCAP_LOONGARCH_FPU: usize = 1 << 3;
+        const HWCAP_LOONGARCH_LSX: usize = 1 << 4;
+        HWCAP_LOONGARCH_CPUCFG
+            | HWCAP_LOONGARCH_LAM
+            | HWCAP_LOONGARCH_UAL
+            | HWCAP_LOONGARCH_FPU
+            | HWCAP_LOONGARCH_LSX
+    }
+    #[cfg(not(target_arch = "loongarch64"))]
+    {
+        0
+    }
+}
+
 struct ElfLoader(LRUCache<ElfCacheEntry, 32>);
 
 type LoadResult = Result<(VirtAddr, Vec<AuxEntry>), Vec<u8>>;
@@ -251,9 +292,14 @@ impl ElfLoader {
             ldso.as_ref()
                 .map_or_else(|| elf.entry(), |ldso| ldso.entry()),
         );
-        let auxv = elf
+        let mut auxv = elf
             .aux_vector(PAGE_SIZE_4K, ldso.map(|elf| elf.base()))
             .collect::<Vec<_>>();
+        // `aux_vector()` only emits PHDR/PHENT/PHNUM/PAGESZ/ENTRY (+BASE). Add
+        // AT_HWCAP so `getauxval(AT_HWCAP)` returns the CPU capability bits the
+        // kernel actually provides (notably LSX on loongarch64, which numpy
+        // requires to import). See `hwcap_value()` for the per-arch policy.
+        auxv.push(AuxEntry::new(AuxType::HWCAP, hwcap_value()));
 
         Ok(Ok((entry, auxv)))
     }


### PR DESCRIPTION
loongarch64 上 FP/向量密集的用户程序在信号/抢占下崩溃或挂起:gradle/kotlin 编译器(HotSpot)SIGSEGV(#237);numpy(Alpine,LSX baseline)拒绝 import。这需要三处协同修复——它们**必须同时落地**:只通告 LSX 而不保全它,会让 userspace 的 LSX 运算被信号/上下文切换破坏(比完全不通告更糟)。

## 根因与修复

### 1. LSX 高 64 位跨切换/信号丢失(`axcpu/loongarch64/{context.rs,macros.rs}`)
平台启动即开启 LSX 128 位向量(`enable_lsx`,`EUEN.SXE`),用户态(JVM/numpy)用完整 `vr0`-`vr31`,但 `FpuState` 只存低 64 位(标量 `f0`-`f31`)。上下文切换/信号打断 LSX 运算后 `vr[127:64]` 被破坏。
- `FpuState` 增 `fp_high: [u64; 32]`(`vr[127:64]`),`save_fp_registers`/`restore_fp_registers` 经新增 `SAVE_FP_HIGH`/`RESTORE_FP_HIGH` 宏(LSX `vst`/`vld`)存全 128 位。`fp` 保持首位原布局,把 `fp[i]` 当标量 `fN` 的消费者仍见相同值,`fp_high` 纯增量。

### 2. 信号投递不保存 FP + `uc_mcontext` 偏移错位(`starry-signal/arch/loongarch64.rs`)
trap(含信号投递)只存 GPR;异步信号(HotSpot safepoint SIGSEGV)打断 FP 代码后,sigreturn 用 handler 残留 FP 恢复 → 损坏。且 musl loongarch `ucontext_t` 在 `uc_sigmask` 与 `uc_mcontext` 间有 `long __uc_pad`,缺它则 `mcontext` 落早 8 字节,用户 handler 读写 `uc_mcontext` 损坏恢复态。
- `MContext` 增 `fpu: FpuState`(`new()` 前 `fpu.save()` 抓活 FP,`restore()` 恢复 handler 可能破坏的 FP);该 FP 块位于 musl 放 `__extcontext` 处,仅内核管理。
- `UContext` 在 `sigmask` 与 `mcontext` 间增 `__uc_pad: u64`,令 `uc_mcontext` 落回 musl ABI 偏移。

### 3. `AT_HWCAP` 未通告 LSX(`kernel/src/mm/loader.rs`)
ELF 加载器 `aux_vector()` 从不发 `AT_HWCAP`,`getauxval(AT_HWCAP)` 返回 0;numpy 据 `HWCAP_LOONGARCH_LSX`(bit 4)门控 import,缺失即拒绝。
- 新增 `hwcap_value()`:loongarch 报 `CPUCFG|LAM|UAL|FPU|LSX`(匹配 `enable_lsx`;不报 LASX,因未启 `EUEN.ASXE`);其它 arch 报 0(x86 用 CPUID、aarch64 NEON 强制,当前 AT_HWCAP 缺失下已正常,报 0 保持现状)。`aux_vector()` 后 `push(AuxEntry::new(AuxType::HWCAP, hwcap_value()))`。

## 对照 Linux/musl(验证)
Linux loongarch 保存完整 128 位向量(`__extcontext` 含 LSX)、ucontext 有 `__uc_pad`、`ARCH_DLINFO` 发 `AT_HWCAP`;host loongarch 上 JVM/numpy 据此正常。StarryOS 此前三处偏离,本修对齐。

## 测试
`cargo xtask starry build --arch loongarch64`(及 x86_64,验全 arch auxv 路径)通过;openjdk17(FP/信号密集)loongarch64 实测 1/1 通过;numpy(需 LSX 检测+跨信号保全)在三处齐备下 import 成功。
