### PR TITLE
fix(starry-mm): mprotect returns ENOMEM on unmapped holes within the range

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -450,8 +450,16 @@ pub fn sys_mprotect(addr: usize, length: usize, prot: u32) -> AxResult<isize> {
     let mut aspace = aspace_arc.lock();
     let length = align_up_4k(length);
     let start_addr = VirtAddr::from(addr);
-    // man 2 mprotect: addresses without a mapping → ENOMEM.
-    if aspace.find_area(start_addr).is_none() {
+    // man 2 mprotect: if any page in [addr, addr+len) lacks a mapping → ENOMEM.
+    // Linux validates the whole range, not just the first page: an unmapped hole
+    // in the middle of `[mapped][hole][mapped]` must fail instead of silently
+    // protecting only the mapped fragments. `can_access_range` with an empty
+    // access mask is a pure contiguous-coverage check (every area's flags
+    // trivially contain the empty set), so it returns false on the first gap.
+    // We pre-check and leave the mapping untouched on failure, i.e. report
+    // ENOMEM atomically without any half-applied protection — the errno real
+    // programs test for.
+    if !aspace.can_access_range(start_addr, length, MappingFlags::empty()) {
         return Err(AxError::NoMemory);
     }
     if permission_flags.contains(MmapProt::WRITE) {

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mmap-family/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mmap-family/c/src/main.c
@@ -15,6 +15,8 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
+#include <signal.h>
+#include <setjmp.h>
 
 #ifndef PROT_GROWSDOWN
 #define PROT_GROWSDOWN 0x01000000
@@ -41,6 +43,28 @@
         if (_r != MAP_FAILED) { munmap(_r, 4096); }                    \
     }                                                                   \
 } while(0)
+
+/* 写一字节到 *p, 返回是否触发 SIGSEGV (用于验证某页是否仍可写)。 */
+static sigjmp_buf g_jb;
+static volatile int g_faulted;
+static void on_segv(int sig)
+{
+    (void)sig;
+    g_faulted = 1;
+    siglongjmp(g_jb, 1);
+}
+static int write_faults(volatile char *p)
+{
+    struct sigaction sa = {0}, old;
+    sa.sa_handler = on_segv;
+    sigaction(SIGSEGV, &sa, &old);
+    g_faulted = 0;
+    if (sigsetjmp(g_jb, 1) == 0) {
+        *p = 0x55;
+    }
+    sigaction(SIGSEGV, &old, NULL);
+    return g_faulted;
+}
 
 int main(void)
 {
@@ -127,6 +151,34 @@ int main(void)
     CHECK_RET(munmap(gone, ps), 0, "munmap gone 页");
     CHECK_ERR(mprotect(gone, ps, PROT_READ),
               ENOMEM, "mprotect 未映射区间 → ENOMEM");
+
+    /* mprotect 跨 [mapped][hole][mapped] → ENOMEM (回归: 起始页有映射但区间
+     * 中段是空洞)。man 2 mprotect: 区间内任一页未映射即 ENOMEM。旧 starry 仅
+     * 检查起始页所在 VMA (find_area(start) 命中) 便放行, 静默成功跳过空洞;
+     * 修复后用 can_access_range 做整段连续覆盖校验。*/
+    {
+        char *hole = mmap(NULL, 3 * ps, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        CHECK(hole != MAP_FAILED, "mmap 3 页用于 hole-mprotect 测试");
+        if (hole != MAP_FAILED) {
+            /* 在中间页打一个洞, 留下 [mapped][hole][mapped] */
+            CHECK_RET(munmap(hole + ps, ps), 0, "munmap 中间页造洞");
+            CHECK_ERR(mprotect(hole, 3 * ps, PROT_READ),
+                      ENOMEM, "mprotect 跨中段空洞 → ENOMEM");
+            /* 原子性: StarryOS 用 can_access_range 在改任何权限前先校验整段,
+             * 命中空洞即原子拒绝、一页都不改, 故左右两页保持原 RW。
+             * 注: 真 Linux 在此并非原子 —— 它把保护位应用到空洞前的前缀页(左页
+             * 会变成 PROT_READ)再返回 ENOMEM; StarryOS 选择更安全的原子语义。
+             * 本断言锁住该原子行为: 若日后把 pre-check 挪到逐页 protect 之后,
+             * 左页会被半改成只读, 这里立刻抓住。*/
+            CHECK(write_faults(hole) == 0,
+                  "失败 mprotect 后左页仍可写 (StarryOS 原子拒绝, 未半改)");
+            CHECK(write_faults(hole + 2 * ps) == 0,
+                  "失败 mprotect 后右页仍可写 (空洞之后, 任何实现都不应改)");
+            munmap(hole, ps);
+            munmap(hole + 2 * ps, ps);
+        }
+    }
 
     /* ===================== munmap ===================== */
 


### PR DESCRIPTION
## 这个改动做了什么

`sys_mprotect` 之前只对范围首页做存在性检查(`find_area(start_addr)`),范围中间或末尾的未映射空洞会被静默跳过——形如 `[已映射][空洞][已映射]` 的 `mprotect(addr, len)` 在 StarryOS 上会"成功"返回 0。

## 为什么要改

`man 2 mprotect` 规定:范围内任何缺失映射的页都使调用失败并返回 `ENOMEM`(保护位应用到空洞之前的前缀)。静默成功会让自己探测映射、依赖该 `errno` 的程序(GC、sanitizer、做 W^X 的 JIT 等)读到错误结果。

## 怎么改的

对整段 `[addr, addr+len)` 做连续覆盖检查:复用已有的 `can_access_range`,传入空访问掩码即得到纯覆盖判定(每个区域的 flags 都包含空集),遇到第一个空洞即返回 false。检查在修改任何映射之前完成,失败时不改动映射,原子地报 `ENOMEM`,不留半应用的保护位。

## 验证

- x86_64 内核编译通过。
- x86_64 完整 syscall 回归套件 `STARRY_GROUPED_TESTS_PASSED`,本改动未引入新失败。
