### PR TITLE
fix(axruntime): park secondary harts beyond MAX_CPU_NUM instead of panicking

### DIFF
--- a/os/arceos/modules/axruntime/src/mp.rs
+++ b/os/arceos/modules/axruntime/src/mp.rs
@@ -124,6 +124,18 @@ pub fn start_secondary_cpus(primary_cpu_id: usize) {
 /// It is called from the bootstrapping code in the specific platform crate.
 #[ax_plat::secondary_main]
 pub fn rust_main_secondary(cpu_id: usize) -> ! {
+    // Park harts whose logical index is beyond the compile-time CPU count: QEMU
+    // may start more harts (`-smp M`) than the kernel was built for
+    // (`MAX_CPU_NUM == N`). Mirror Linux — run on the first N CPUs and park the
+    // excess, rather than panicking in `percpu::init_secondary(cpu_id)` /
+    // `AxCpuMask::one_shot(cpu_id)` / `RUN_QUEUES[cpu_id]`, which all assert
+    // `index < MAX_CPU_NUM`. Must precede `init_secondary`, which would otherwise
+    // mis-index the per-CPU area first.
+    if cpu_id >= MAX_CPU_NUM {
+        loop {
+            ax_hal::asm::wait_for_irqs();
+        }
+    }
     ax_hal::percpu::init_secondary(cpu_id);
     #[cfg(all(feature = "alloc", feature = "buddy-slab"))]
     ax_alloc::init_percpu_slab(cpu_id);


### PR DESCRIPTION
## 问题
当 QEMU 以 `-smp M` 启动、而内核按 `MAX_CPU_NUM == N`(`N < M`)编译时,第 N..M 个 hart 进入 `rust_main_secondary` 后内核 panic(`percpu::init_secondary(cpu_id)` / `AxCpuMask::one_shot(cpu_id)` / `RUN_QUEUES[cpu_id]` 均断言 `index < MAX_CPU_NUM`),启动失败。

## 根因
`rust_main_secondary(cpu_id)` 未对 `cpu_id` 设上界即去索引按 `MAX_CPU_NUM` 定容的 per-CPU 结构。超额 hart 的 `cpu_id >= MAX_CPU_NUM` 越界。

## 修复
对齐 Linux 的做法(用前 N 个 CPU、park 多余的):在 `init_secondary` 之前,若 `cpu_id >= MAX_CPU_NUM` 则该 hart 进入 `wait_for_irqs()` 永久 park,绝不触碰按 `MAX_CPU_NUM` 定容的结构。`cpu_id < MAX_CPU_NUM` 的 hart 行为不变。

## 测试
`cargo xtask starry build --arch x86_64` 通过;`-smp` 与 `MAX_CPU_NUM` 匹配时行为不变(park 分支不触发),`-smp` 超额时多余 hart 安全 park 而非 panic。
