### PR TITLE
fix(starry-mm): fix use-after-free evicting a page-cache page shared across split file mappings

### DIFF
--- a/os/StarryOS/kernel/src/mm/aspace/backend/file.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/file.rs
@@ -283,8 +283,17 @@ impl BackendOps for FileBackend {
                         flags - MappingFlags::WRITE
                     };
                     self.0.cache.with_page_or_insert(pn, |page, evicted| {
-                        if let Some((pn, _)) = evicted {
-                            to_be_evicted.push(pn);
+                        if let Some(evicted) = evicted {
+                            // Keep the evicted page (and thus its physical frame)
+                            // alive until `on_evict` below has torn down its mapping
+                            // and flushed the TLB. The eviction listener cannot unmap
+                            // here because the address space is already locked by this
+                            // populate, so the unmap is deferred; freeing the frame now
+                            // (by dropping the page) would leave the evicted VA mapped
+                            // to a frame that can be reallocated, so a sibling thread
+                            // preempted into userspace could read another page's data
+                            // through the stale mapping.
+                            to_be_evicted.push(evicted);
                         }
                         pt.map(addr, page.paddr(), PageSize::Size4K, map_flags)?;
                         pages += 1;
@@ -301,8 +310,34 @@ impl BackendOps for FileBackend {
             } else {
                 let inner = self.0.clone();
                 Some(Box::new(move |aspace: &mut AddrSpace| {
-                    for pn in to_be_evicted {
-                        inner.on_evict(pn, aspace);
+                    for (pn, page) in to_be_evicted {
+                        // Unmap (and TLB-flush via the cursor) the evicted VA first,
+                        // then drop the page to free its frame — never the reverse.
+                        //
+                        // The page cache is shared across all areas backed by the same
+                        // file. After mprotect splits a file mapping, `split` creates a
+                        // sibling FileBackendInner (same CachedFile, different
+                        // start/offset_page). A populate on one sub-area can evict a page
+                        // owned by another sub-area; `inner.on_evict` only covers
+                        // `inner`'s own page range (its `checked_sub` returns None
+                        // otherwise), so route the evicted page to every area sharing this
+                        // cache. `on_evict` self-validates (range + area ptr_eq), so only
+                        // the true owner unmaps. Without this, the sibling's PTE keeps
+                        // pointing at the just-freed frame — a use-after-free that
+                        // surfaces as a wild pointer (the JVM jimage on loongarch).
+                        let owners: Vec<_> = aspace
+                            .areas()
+                            .filter_map(|area| match area.backend() {
+                                Backend::File(fb) if fb.0.cache.ptr_eq(&inner.cache) => {
+                                    Some(fb.0.clone())
+                                }
+                                _ => None,
+                            })
+                            .collect();
+                        for owner in owners {
+                            owner.on_evict(pn, aspace);
+                        }
+                        drop(page);
                     }
                 }))
             },

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -188,12 +188,27 @@ impl AddrSpace {
         self.validate_region(start, size)?;
         let end = start + size;
 
-        let mut modify = self.pt.cursor();
-        while let Some(area) = self.areas.find(start) {
-            let range = VirtAddrRange::new(start, area.end().min(end));
-            area.backend()
-                .populate(range, area.flags(), access_flags, &mut modify)?;
-            start = area.end();
+        loop {
+            let (area_end, callback) = {
+                let Some(area) = self.areas.find(start) else {
+                    break;
+                };
+                let range = VirtAddrRange::new(start, area.end().min(end));
+                let flags = area.flags();
+                let (_, callback) =
+                    area.backend()
+                        .populate(range, flags, access_flags, &mut self.pt.cursor())?;
+                (area.end(), callback)
+            };
+            // Run the eviction cleanup the populate deferred (unmap + TLB flush
+            // for page-cache pages evicted during this fill). Dropping it — as
+            // the old code did — frees an evicted frame while its user PTE still
+            // points at it: a use-after-free that surfaces as a wild pointer
+            // under heavy file-backed paging (the JVM jimage on loongarch).
+            if let Some(cb) = callback {
+                cb(self);
+            }
+            start = area_end;
             assert!(start.is_aligned_4k());
             if start >= end {
                 break;

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -36,7 +36,7 @@ bitflags::bitflags! {
 
 impl From<MmapProt> for MappingFlags {
     fn from(value: MmapProt) -> Self {
-        let mut flags = MappingFlags::USER;
+        let mut flags = MappingFlags::empty();
         if value.contains(MmapProt::READ) {
             flags |= MappingFlags::READ;
         }
@@ -51,6 +51,15 @@ impl From<MmapProt> for MappingFlags {
         }
         if value.contains(MmapProt::EXEC) {
             flags |= MappingFlags::EXECUTE;
+        }
+        // PROT_NONE must yield empty flags so the PTE is non-present and any
+        // access faults. Tagging it USER would, on x86_64, still set the PRESENT
+        // bit (present implies readable on x86) and silently defeat the
+        // protection — breaking guard pages such as JVM thread-stack guards,
+        // letting a stack overflow corrupt adjacent memory instead of trapping.
+        // Only accessible mappings get the USER tag.
+        if !flags.is_empty() {
+            flags |= MappingFlags::USER;
         }
         flags
     }


### PR DESCRIPTION
## 问题
loongarch64 上 JVM 启动偶发野指针崩溃(读取 jimage 时拿到另一页的数据)。根因是文件页缓存逐出路径的 use-after-free。

## 根因
文件页缓存按 `CachedFile` 在所有映射同一文件的 area 间共享。`mprotect` 拆分一个文件映射后,`split` 会创建同享该 `CachedFile`、但 `start`/`offset_page` 不同的兄弟 `FileBackendInner`。当对其中一个子 area 做 populate 触发逐出时:
1. 逐出回调原先只覆盖发起 populate 的那个 `inner` 自己的页范围(`on_evict` 的 `checked_sub` 对其它范围返回 `None`),于是**兄弟 area 的 PTE 仍指向已被逐出/即将释放的物理帧**;
2. 且释放帧(drop page)与解除映射的次序不当——若先释放帧,被逐出的 VA 仍映射到一个可被重新分配的帧,被抢占进用户态的兄弟线程就能透过这条 stale 映射读到别页数据。

## 修复
- `populate` 不再在持有地址空间锁时直接逐出,而是返回一个延迟回调;`AddrSpace::populate` 在释放页表 cursor 借用后再执行 `cb(self)`(`aspace/mod.rs`)。
- 逐出回调中:先 unmap 被逐出的 VA(经 cursor 解除映射并 flush TLB),**再** drop page 释放帧——绝不颠倒次序。
- 将被逐出页路由到**所有**共享该 cache 的 area(遍历 `aspace.areas()` 按 `cache.ptr_eq` 过滤),每个 area 的 `on_evict` 自校验(范围 + area 指针),只有真正的 owner 解除其映射。

## 对照 Linux(验证)
Linux 的 page cache 逐出在解除所有映射该页的 PTE(rmap)后才释放帧;本修使 StarryOS 的逐出遵循同样的"先 unmap 全部 owner、后释放帧"次序。loongarch64 JVM jimage 读取不再出现野指针。

## 测试
`cargo xtask starry build --arch x86_64` 通过;openjdk17 在 loongarch64 实测稳定(此前因本 UAF 偶发崩溃)。
