### PR TITLE
fix(starry-net): epoll_pwait user-buffer alignment + netlink MSG_PEEK/TRUNC/DONTWAIT (Go network servers)

### DIFF
--- a/components/starry-vm/src/lib.rs
+++ b/components/starry-vm/src/lib.rs
@@ -60,18 +60,26 @@ pub unsafe trait VmIo {
 }
 
 /// Reads a slice from the virtual memory.
+///
+/// The user pointer need NOT be aligned to `align_of::<T>()`. The underlying
+/// `user_copy` is byte-granular on every arch (x86 `rep movsb`;
+/// aarch64/riscv64/ loongarch64 byte-align the destination first, then
+/// bulk-copy) — exactly like Linux `copy_from_user`, which never requires
+/// user-buffer alignment. The old `is_aligned()` gate wrongly rejected valid
+/// unaligned user buffers.
 pub fn vm_read_slice<T>(ptr: *const T, buf: &mut [MaybeUninit<T>]) -> VmResult {
-    if !ptr.is_aligned() {
-        return Err(VmError::BadAddress);
-    }
     VmImpl::new().read(ptr.addr(), buf.as_bytes_mut())
 }
 
 /// Writes data to the virtual memory.
+///
+/// No pointer-alignment requirement (Linux-parity: `copy_to_user` is
+/// alignment-agnostic; see [`vm_read_slice`]). The old `is_aligned()` gate made
+/// `epoll_pwait` return EFAULT on riscv64/loongarch64: Go's `[]epollevent` is
+/// 4-byte-aligned (`data [8]byte`) while `struct epoll_event` is 8-aligned
+/// (`u64 data`) on non-x86, so the events buffer failed the check and crashed
+/// the Go netpoller (`netpoll failed`).
 pub fn vm_write_slice<T>(ptr: *mut T, buf: &[T]) -> VmResult {
-    if !ptr.is_aligned() {
-        return Err(VmError::BadAddress);
-    }
     // SAFETY: we don't care about validity, since these bytes are only used for
     // writing to the virtual memory.
     let bytes = unsafe { slice::from_raw_parts(buf.as_ptr().cast::<u8>(), size_of_val(buf)) };

--- a/os/StarryOS/kernel/src/file/netlink.rs
+++ b/os/StarryOS/kernel/src/file/netlink.rs
@@ -422,17 +422,35 @@ impl NetlinkSocket {
 
     /// Drain at most one queued message into `dst`.  Returns `WouldBlock`
     /// when the queue is empty.
-    fn read_one(&self, dst: &mut IoDst) -> AxResult<usize> {
+    ///
+    /// `peek` (MSG_PEEK): copy the front message into `dst` without removing it
+    /// from the queue, so a following non-peek recv reads the same message.
+    /// glibc/musl `getifaddrs()` and dnsmasq size their buffer with a
+    /// `MSG_PEEK|MSG_TRUNC` recv first, then read for real; popping on peek
+    /// loses the dump and the second recv blocks forever (startup stall).
+    ///
+    /// `truncate` (MSG_TRUNC): netlink datagrams are not coalesced, so a short
+    /// buffer drops the tail. Linux returns the *real* datagram length (not the
+    /// copied length) so the caller can resize and retry.
+    fn read_one(&self, dst: &mut IoDst, peek: bool, truncate: bool) -> AxResult<usize> {
         let msg = {
             let mut queue = self.queue.lock();
-            let Some(msg) = queue.pop_front() else {
-                return Err(AxError::WouldBlock);
-            };
-            msg
+            if peek {
+                let Some(msg) = queue.front() else {
+                    return Err(AxError::WouldBlock);
+                };
+                msg.clone()
+            } else {
+                let Some(msg) = queue.pop_front() else {
+                    return Err(AxError::WouldBlock);
+                };
+                msg
+            }
         };
         // Cap at the message length; netlink datagrams are not coalesced.
-        let n = dst.write(&msg)?;
-        Ok(n)
+        let full = msg.len();
+        let copied = dst.write(&msg)?;
+        Ok(if truncate { full } else { copied })
     }
 }
 
@@ -466,10 +484,28 @@ pub fn broadcast(protocol: u32, group_mask: u32, payload: &[u8]) {
     }
 }
 
+impl NetlinkSocket {
+    /// Flag-aware receive used by `recvmsg`/`recvfrom`. Honors MSG_PEEK (do not
+    /// consume), MSG_TRUNC (return full datagram length), and MSG_DONTWAIT
+    /// (per-call non-blocking).
+    pub fn recv(
+        &self,
+        dst: &mut IoDst,
+        peek: bool,
+        truncate: bool,
+        dontwait: bool,
+    ) -> AxResult<usize> {
+        let non_blocking = self.nonblocking() || dontwait;
+        block_on(poll_io(self, IoEvents::IN, non_blocking, || {
+            self.read_one(dst, peek, truncate)
+        }))
+    }
+}
+
 impl FileLike for NetlinkSocket {
     fn read(&self, dst: &mut IoDst) -> AxResult<usize> {
         block_on(poll_io(self, IoEvents::IN, self.nonblocking(), || {
-            self.read_one(dst)
+            self.read_one(dst, false, false)
         }))
     }
 

--- a/os/StarryOS/kernel/src/file/netlink.rs
+++ b/os/StarryOS/kernel/src/file/netlink.rs
@@ -432,7 +432,11 @@ impl NetlinkSocket {
     /// `truncate` (MSG_TRUNC): netlink datagrams are not coalesced, so a short
     /// buffer drops the tail. Linux returns the *real* datagram length (not the
     /// copied length) so the caller can resize and retry.
-    fn read_one(&self, dst: &mut IoDst, peek: bool, truncate: bool) -> AxResult<usize> {
+    /// Returns `(len, truncated)`: `len` is the full datagram length when
+    /// `truncate` (MSG_TRUNC) is set, else the number of bytes copied;
+    /// `truncated` is true when the datagram did not fit in `dst` (so the
+    /// caller can raise MSG_TRUNC in `msg_flags`).
+    fn read_one(&self, dst: &mut IoDst, peek: bool, truncate: bool) -> AxResult<(usize, bool)> {
         let msg = {
             let mut queue = self.queue.lock();
             if peek {
@@ -450,7 +454,8 @@ impl NetlinkSocket {
         // Cap at the message length; netlink datagrams are not coalesced.
         let full = msg.len();
         let copied = dst.write(&msg)?;
-        Ok(if truncate { full } else { copied })
+        let truncated = full > copied;
+        Ok((if truncate { full } else { copied }, truncated))
     }
 }
 
@@ -494,7 +499,7 @@ impl NetlinkSocket {
         peek: bool,
         truncate: bool,
         dontwait: bool,
-    ) -> AxResult<usize> {
+    ) -> AxResult<(usize, bool)> {
         let non_blocking = self.nonblocking() || dontwait;
         block_on(poll_io(self, IoEvents::IN, non_blocking, || {
             self.read_one(dst, peek, truncate)
@@ -507,6 +512,7 @@ impl FileLike for NetlinkSocket {
         block_on(poll_io(self, IoEvents::IN, self.nonblocking(), || {
             self.read_one(dst, false, false)
         }))
+        .map(|(len, _)| len)
     }
 
     fn write(&self, src: &mut IoSrc) -> AxResult<usize> {

--- a/os/StarryOS/kernel/src/syscall/net/io.rs
+++ b/os/StarryOS/kernel/src/syscall/net/io.rs
@@ -162,7 +162,17 @@ fn recv_impl(
 
     let Ok(socket) = Socket::from_fd(fd) else {
         if let Ok(netlink) = NetlinkSocket::from_fd(fd) {
-            let recv = netlink.read(&mut dst)?;
+            // Netlink is a FileLike, not an axnet Socket, so the flag-aware recv
+            // path below is unreachable for it. Honor the recv flags here:
+            // MSG_PEEK (do not consume the dump — getifaddrs/dnsmasq peek-then-
+            // read to size their buffer), MSG_TRUNC (full datagram length),
+            // MSG_DONTWAIT (non-blocking).
+            let recv = netlink.recv(
+                &mut dst,
+                flags & MSG_PEEK != 0,
+                flags & MSG_TRUNC != 0,
+                flags & MSG_DONTWAIT != 0,
+            )?;
             if !addr.is_null() {
                 super::addr::write_netlink_addr(
                     &netlink.kernel_addr(),

--- a/os/StarryOS/kernel/src/syscall/net/io.rs
+++ b/os/StarryOS/kernel/src/syscall/net/io.rs
@@ -167,12 +167,15 @@ fn recv_impl(
             // MSG_PEEK (do not consume the dump — getifaddrs/dnsmasq peek-then-
             // read to size their buffer), MSG_TRUNC (full datagram length),
             // MSG_DONTWAIT (non-blocking).
-            let recv = netlink.recv(
+            let (recv, truncated) = netlink.recv(
                 &mut dst,
                 flags & MSG_PEEK != 0,
                 flags & MSG_TRUNC != 0,
                 flags & MSG_DONTWAIT != 0,
             )?;
+            // Surface MSG_TRUNC in the returned `msg_flags` when the datagram
+            // did not fit (Linux sets it; getifaddrs sizes its buffer from it).
+            *truncated_out = truncated;
             if !addr.is_null() {
                 super::addr::write_netlink_addr(
                     &netlink.kernel_addr(),

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-epoll-pwait2/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-epoll-pwait2/c/src/main.c
@@ -8,6 +8,7 @@
 #include <signal.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 #include <sys/epoll.h>
 #include <sys/syscall.h>
 #include <time.h>
@@ -286,6 +287,54 @@ static void test_sigmask_effect_and_eintr(void)
     close(epfd);
 }
 
+/* 回归: epoll_pwait2 把就绪事件写出到一个"有效但未按 alignof(epoll_event)
+ * 对齐"的用户缓冲时不应返回 EFAULT。Go 的 []syscall.EpollEvent 仅按 4 字节
+ * 对齐, 而 starry 曾对用户指针强制 8 字节对齐 → epoll_pwait 在 riscv64/
+ * loongarch64/aarch64 上误返 EFAULT。Linux copy_to_user 是逐字节的, 任何
+ * 有效地址都能写。这里用一个 8 对齐缓冲 +4 偏移构造 4-对齐-非-8 的指针
+ * (与 Go 的内存布局同形), 经 memcpy 读回事件以隔离纯内核 copy-out 行为。*/
+static void test_misaligned_events_buffer(void)
+{
+    int epfd = epoll_create1(0);
+    CHECK(epfd >= 0, "epoll_create1 ok (misaligned events buffer)");
+    if (epfd < 0) {
+        return;
+    }
+
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        CHECK(0, "pipe created (misaligned events buffer)");
+        close(epfd);
+        return;
+    }
+
+    struct epoll_event ev = {
+        .events = EPOLLIN,
+        .data = {.fd = pipefd[0]},
+    };
+    CHECK_RET(epoll_ctl(epfd, EPOLL_CTL_ADD, pipefd[0], &ev), 0,
+              "epoll_ctl ADD (misaligned events buffer)");
+    CHECK_RET(write(pipefd[1], "X", 1), 1, "write one byte (misaligned events buffer)");
+
+    _Alignas(8) unsigned char raw[4 + sizeof(struct epoll_event) * 4];
+    struct epoll_event *out = (struct epoll_event *)(void *)(raw + 4);
+    CHECK(((uintptr_t)out & 7u) == 4u,
+          "events buffer is 4-byte-aligned but not 8 (Go []EpollEvent layout)");
+
+    long n = raw_epoll_pwait2(epfd, out, 4, NULL, NULL, KERNEL_SIGSET_SIZE);
+    CHECK(n == 1,
+          "epoll_pwait2 to 4-aligned (non-8) events buffer returns 1, not EFAULT");
+
+    struct epoll_event got;
+    memcpy(&got, raw + 4, sizeof(got));
+    CHECK((got.events & EPOLLIN) != 0 && got.data.fd == pipefd[0],
+          "event content from misaligned buffer is correct");
+
+    close(pipefd[0]);
+    close(pipefd[1]);
+    close(epfd);
+}
+
 int main(void)
 {
     TEST_START("epoll_pwait2 Linux semantics");
@@ -297,6 +346,7 @@ int main(void)
     test_timeout_monotonic_duration();
     test_maxevents_boundary();
     test_sigmask_effect_and_eintr();
+    test_misaligned_events_buffer();
 
     TEST_DONE();
 }

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-netlink-recvmsg/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-netlink-recvmsg/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-netlink-recvmsg C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-netlink-recvmsg src/main.c)
+target_compile_options(test-netlink-recvmsg PRIVATE -Wall -Wextra)
+target_link_options(test-netlink-recvmsg PRIVATE -static)
+
+install(TARGETS test-netlink-recvmsg RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-netlink-recvmsg/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-netlink-recvmsg/c/src/main.c
@@ -1,0 +1,127 @@
+/*
+ * test_netlink_recvmsg.c — recvmsg(2) MSG_PEEK / MSG_TRUNC / MSG_DONTWAIT on an
+ * AF_NETLINK (NETLINK_ROUTE) socket.
+ *
+ * Regression for the bug where NetlinkSocket (a FileLike, not an axnet Socket)
+ * ignored the recvmsg flags and always popped the front datagram:
+ *   - MSG_PEEK consumed the message instead of leaving it queued,
+ *   - MSG_TRUNC reported the copied length instead of the real datagram length,
+ *   - MSG_DONTWAIT blocked instead of returning EAGAIN on an empty queue.
+ * glibc/musl getifaddrs() does exactly "peek to size the buffer, then read for
+ * real", so a consuming peek made the follow-up read block forever.
+ *
+ * The netlink uAPI (linux/netlink.h, linux/rtnetlink.h) is NOT in the musl
+ * cross sysroot, so the few structs/constants we need are defined inline with
+ * their fixed kernel-ABI values; this keeps the test self-contained.
+ */
+
+#include "test_framework.h"
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/socket.h>
+
+#ifndef NETLINK_ROUTE
+#define NETLINK_ROUTE 0
+#endif
+#define RTM_GETADDR 22
+#define NLM_F_REQUEST 0x01
+#define NLM_F_ROOT 0x100
+#define NLM_F_MATCH 0x200
+#define NLM_F_DUMP (NLM_F_ROOT | NLM_F_MATCH)
+
+struct nlmsghdr {
+    uint32_t nlmsg_len;
+    uint16_t nlmsg_type;
+    uint16_t nlmsg_flags;
+    uint32_t nlmsg_seq;
+    uint32_t nlmsg_pid;
+};
+
+struct ifaddrmsg {
+    uint8_t ifa_family;
+    uint8_t ifa_prefixlen;
+    uint8_t ifa_flags;
+    uint8_t ifa_scope;
+    uint32_t ifa_index;
+};
+
+struct sockaddr_nl {
+    sa_family_t nl_family;
+    unsigned short nl_pad;
+    uint32_t nl_pid;
+    uint32_t nl_groups;
+};
+
+#define NLMSG_ALIGNTO 4u
+#define NLMSG_ALIGN(len) (((len) + NLMSG_ALIGNTO - 1) & ~(NLMSG_ALIGNTO - 1))
+#define NLMSG_HDRLEN ((int)NLMSG_ALIGN(sizeof(struct nlmsghdr)))
+#define NLMSG_LENGTH(len) ((int)(NLMSG_HDRLEN + (len)))
+
+int main(void)
+{
+    TEST_START("netlink recvmsg MSG_PEEK/MSG_TRUNC/MSG_DONTWAIT");
+
+    int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    CHECK(fd >= 0, "socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE)");
+    if (fd < 0) {
+        TEST_DONE();
+    }
+
+    /* ---- MSG_DONTWAIT on an empty queue → EAGAIN (no message sent yet) ---- */
+    {
+        char buf[64];
+        struct iovec iov = {.iov_base = buf, .iov_len = sizeof(buf)};
+        struct msghdr mh = {0};
+        mh.msg_iov = &iov;
+        mh.msg_iovlen = 1;
+        CHECK_ERR(recvmsg(fd, &mh, MSG_DONTWAIT), EAGAIN,
+                  "recvmsg(MSG_DONTWAIT) on empty queue → EAGAIN");
+    }
+
+    /* ---- send an RTM_GETADDR dump request ---- */
+    struct {
+        struct nlmsghdr nlh;
+        struct ifaddrmsg ifa;
+    } req;
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = (uint32_t)NLMSG_LENGTH(sizeof(struct ifaddrmsg));
+    req.nlh.nlmsg_type = RTM_GETADDR;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.nlh.nlmsg_seq = 1;
+    req.ifa.ifa_family = AF_UNSPEC;
+
+    struct sockaddr_nl kernel = {0};
+    kernel.nl_family = AF_NETLINK;
+    ssize_t sent = sendto(fd, &req, req.nlh.nlmsg_len, 0,
+                          (struct sockaddr *)&kernel, sizeof(kernel));
+    CHECK(sent == (ssize_t)req.nlh.nlmsg_len, "sendto RTM_GETADDR dump request");
+
+    /* ---- MSG_PEEK | MSG_TRUNC with a deliberately tiny buffer ----
+     * MSG_TRUNC must return the FULL datagram length (the real reply is a full
+     * nlmsghdr+payload, well over 16 bytes), proving truncation reporting; and
+     * MSG_PEEK must NOT consume it, so the follow-up real read still sees it. */
+    char tiny[16];
+    struct iovec piov = {.iov_base = tiny, .iov_len = sizeof(tiny)};
+    struct msghdr pmh = {0};
+    pmh.msg_iov = &piov;
+    pmh.msg_iovlen = 1;
+    ssize_t peeked = recvmsg(fd, &pmh, MSG_PEEK | MSG_TRUNC);
+    CHECK(peeked > (ssize_t)sizeof(tiny),
+          "recvmsg(MSG_PEEK|MSG_TRUNC) returns full datagram length (> tiny buf)");
+    CHECK((pmh.msg_flags & MSG_TRUNC) != 0,
+          "peeked msg_flags has MSG_TRUNC set (buffer was too small)");
+
+    /* ---- real read must still see the peeked datagram (peek didn't consume) ---- */
+    char full[8192];
+    struct iovec fiov = {.iov_base = full, .iov_len = sizeof(full)};
+    struct msghdr fmh = {0};
+    fmh.msg_iov = &fiov;
+    fmh.msg_iovlen = 1;
+    ssize_t got = recvmsg(fd, &fmh, 0);
+    CHECK(got > 0, "follow-up recvmsg() still returns the datagram (peek non-destructive)");
+    CHECK(peeked == got,
+          "peeked length == subsequently read length (same datagram)");
+
+    close(fd);
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-netlink-recvmsg/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-netlink-recvmsg/c/src/test_framework.h
@@ -1,0 +1,86 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno)); \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno,     \
+               strerror(errno));                                        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
两个面向真实网络服务（Go netpoll / glibc-musl `getifaddrs`）的 Linux-ABI 修复。

## 1. `vm_read_slice`/`vm_write_slice` 去除用户指针对齐检查

`components/starry-vm/src/lib.rs` 对用户指针强制 `align_of::<T>()` 对齐，未对齐即返回 `BadAddress`。这与 Linux 不一致：`copy_to_user`/`copy_from_user` 是逐字节的，从不要求用户缓冲区对齐；且各架构的 `user_copy`（x86 `rep movsb`；aarch64/riscv64/loongarch64 先逐字节对齐 dst 再批量拷贝）本就处理任意对齐。

该检查导致 `epoll_pwait` 在 **riscv64/loongarch64 返回 EFAULT**：Go 的 `[]epollevent` 是 4 字节对齐（`data` 字段为 `[8]byte`），而 `struct epoll_event` 在非 x86 架构是 8 字节对齐（`u64 data`），于是 events 缓冲区无法通过对齐检查，Go runtime 的 netpoller 在启动时直接 abort（`epollwait failed with 14` / `netpoll failed`），导致 riscv64/loongarch64 上每个 Go 网络服务（prometheus/consul/minio 等）都崩溃。x86_64 不受影响（packed `epoll_event`，对齐 1）。

去除检查是安全的：内核侧缓冲区本就对齐，仅用户指针可能非对齐，而 `user_copy` 已正确处理。

## 2. netlink recvmsg 支持 `MSG_PEEK`/`MSG_TRUNC`/`MSG_DONTWAIT`

`NetlinkSocket` 是 `FileLike` 而非 axnet `Socket`，`recvmsg(2)` 走无 flag 的 netlink 读路径，总是弹出队首消息。于是 `MSG_PEEK` 消费了消息而非窥视、`MSG_TRUNC` 不报完整 datagram 长度、`MSG_DONTWAIT` 被忽略。glibc/musl 的 `getifaddrs()` 先 `MSG_PEEK|MSG_TRUNC` 探测缓冲区大小再正式读，故第二次 recv 永久阻塞。

将 flag 接入 `read_one()` 与新增的 `NetlinkSocket::recv()`：peek 克隆队首而不弹出，truncate 返回完整 datagram 长度，dontwait 做单次非阻塞 poll；`read(2)` 保持原有消费、非 peek 行为。

## 验证

- 修复 1：qemu-10 单核四架构 StarryOS 跑 prometheus（启动 + loopback HTTP ready + PromQL query），riscv64/loongarch64 由 `netpoll failed` 崩溃转为 `PROM_OK=1` 通过；x86_64/aarch64 无回归。
- 修复 2：netlink peek-then-read（getifaddrs 路径）由永久阻塞转为正常返回。

## Changed files

| 文件 | 改动 |
|---|---|
| `components/starry-vm/src/lib.rs` | 去除 `vm_read_slice`/`vm_write_slice` 的对齐检查 |
| `os/StarryOS/kernel/src/file/netlink.rs` | `read_one(peek, truncate)` + 新增 `NetlinkSocket::recv()` |
| `os/StarryOS/kernel/src/syscall/net/io.rs` | netlink recv 路径接入 `MSG_PEEK`/`MSG_TRUNC`/`MSG_DONTWAIT` |
