### PR TITLE
fix(axruntime): initialize the page allocator from the largest free RAM region

### DIFF
--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -319,21 +319,28 @@ fn init_allocator() {
     info!("Initialize global memory allocator...");
     info!("  use {} allocator.", ax_alloc::global_allocator().name());
 
+    // The page allocator (which backs user-space page population via
+    // `alloc_pages`) is initialized from a single contiguous region by
+    // `global_init`; every other free region is handed to the byte/heap
+    // allocator by `global_add_memory` (the bitmap page allocator does not
+    // support `add_memory`). So the region chosen for `global_init` *is* the
+    // entire pool available for user memory.
+    //
+    // Pick the LARGEST free region for the page allocator. Platforms with a
+    // single contiguous RAM region (x86/aarch64/riscv64 qemu-virt) are
+    // unaffected (largest == the only region). Platforms with disjoint regions
+    // (loongarch64 qemu-virt: a small ~248 MB low region below the MMIO hole
+    // plus the multi-GB high region at 0x8000_0000) previously picked the small
+    // low region — the "first free region after .bss" heuristic — which capped
+    // all user allocations at ~248 MB regardless of total RAM, OOM'ing large
+    // workloads (e.g. the gradle build JVM) even with gigabytes free.
     let mut max_region_size = 0;
     let mut max_region_paddr = 0.into();
-    let mut use_next_free = false;
 
     for r in memory_regions() {
-        if r.name == ".bss" {
-            use_next_free = true;
-        } else if r.flags.contains(MemRegionFlags::FREE) {
-            if use_next_free {
-                max_region_paddr = r.paddr;
-                break;
-            } else if r.size > max_region_size {
-                max_region_size = r.size;
-                max_region_paddr = r.paddr;
-            }
+        if r.flags.contains(MemRegionFlags::FREE) && r.size > max_region_size {
+            max_region_size = r.size;
+            max_region_paddr = r.paddr;
         }
     }
 


### PR DESCRIPTION
## 问题
loongarch64 上大内存负载(如 gradle 构建的 JVM)即使系统有数 GB 空闲内存仍 OOM,用户态分配被莫名钳制在 ~248 MB。

## 根因
撑起用户态页填充(`alloc_pages`)的页分配器由 `global_init` 从**单个连续空闲区**初始化;其余空闲区交给 byte/heap 分配器(bitmap 页分配器不支持 `global_add_memory`)。因此 `global_init` 选中的那个区**就是**用户内存的全部来源。原启发式取"`.bss` 之后的第一个空闲区";而 loongarch64 qemu-virt 的物理内存**不连续**——MMIO 洞下方一个 ~248 MB 的低区,外加 `0x8000_0000` 起的多 GB 高区——第一个空闲区恰是小的低区,于是无论总 RAM 多大,用户态分配都被钳在 ~248 MB。

## 修复
改为选**最大**的空闲区初始化页分配器。单连续 RAM 区的平台(x86/aarch64/riscv64 qemu-virt)不受影响(最大区==唯一区)。

## 对照 Linux(验证)
Linux 经 memblock 使用全部物理 RAM(跨不连续区);本修使 StarryOS 至少把最大区完整供给用户态,消除 loongarch 上"有内存却 OOM"。

## 测试
`cargo xtask starry build --arch x86_64` 通过;loongarch64 上大内存 JVM 负载不再因 ~248 MB 上限 OOM。
