### PR TITLE
fix(starry-task): suspend on SIGSTOP instead of killing (job control)

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -15,7 +15,8 @@ use starry_signal::SignalInfo;
 use starry_vm::{VmMutPtr, VmPtr};
 
 use crate::task::{
-    AsThread, decode_wait_status, get_task, get_zombie_cred, remove_process, unregister_zombie,
+    AsThread, JobStatus, decode_wait_status, get_process_data, get_task, get_zombie_cred,
+    remove_process, unregister_zombie,
 };
 
 bitflags! {
@@ -115,8 +116,38 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
             child.free();
             remove_process(child.pid());
             unregister_zombie(child.pid());
-            Ok(Some(child.pid() as _))
-        } else if options.contains(WaitPidOptions::WNOHANG) {
+            return Ok(Some(child.pid() as _));
+        }
+
+        // Job-control status: a stopped (WUNTRACED) or continued (WCONTINUED)
+        // child reports its status without being reaped, unlike a zombie.
+        let want_stopped = options.contains(WaitPidOptions::WUNTRACED);
+        let want_continued = options.contains(WaitPidOptions::WCONTINUED);
+        if want_stopped || want_continued {
+            for child in &children {
+                let Ok(cdata) = get_process_data(child.pid()) else {
+                    continue;
+                };
+                if let Some(status) = cdata.peek_job_status_if(want_stopped, want_continued) {
+                    // Linux wait status encoding: stopped = (signo << 8) | 0x7f
+                    // (W_STOPCODE), continued = 0xffff (__W_CONTINUED).
+                    let raw = match status {
+                        JobStatus::Stopped(signo) => ((signo as i32) << 8) | 0x7f,
+                        JobStatus::Continued => 0xffff,
+                    };
+                    // Publish to userspace before consuming, so a faulting
+                    // `exit_code` pointer leaves the report intact to retry
+                    // (mirrors the zombie-reap ordering above).
+                    if let Some(exit_code) = exit_code.nullable() {
+                        exit_code.vm_write(raw)?;
+                    }
+                    cdata.take_job_status_if(want_stopped, want_continued);
+                    return Ok(Some(child.pid() as _));
+                }
+            }
+        }
+
+        if options.contains(WaitPidOptions::WNOHANG) {
             Ok(Some(0))
         } else {
             Ok(None)

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -436,6 +436,46 @@ impl VforkDone {
     }
 }
 
+/// A pending job-control status change awaiting report to the parent's
+/// `waitpid(WUNTRACED | WCONTINUED)`.
+#[derive(Clone, Copy)]
+pub enum JobStatus {
+    /// The process stopped after receiving the given job-control signal
+    /// (`SIGSTOP`/`SIGTSTP`/`SIGTTIN`/`SIGTTOU`).
+    Stopped(Signo),
+    /// The process continued after receiving `SIGCONT`.
+    Continued,
+}
+
+/// Job-control state for a process, kept under a single lock so the stop flag
+/// and the pending parent report are updated atomically (a concurrent
+/// stop/continue on another CPU must not split the two).
+///
+/// `stopped` and `status` are **intentionally independent** and may legitimately
+/// diverge — do not collapse them into one field. `stopped` is the live parked
+/// state (cleared only by continue/kill); `status` is a one-shot report the
+/// parent's `waitpid` consumes (so `stopped == Some` with `status == None` is
+/// valid once the report has been reaped).
+#[derive(Default)]
+struct JobControl {
+    /// `None` = running, `Some(signo)` = stopped by the given job-control
+    /// signal. A stopped process parks its threads in the kernel until
+    /// `SIGCONT` (or `SIGKILL`) is delivered.
+    stopped: Option<Signo>,
+    /// Pending status change for the parent's `waitpid`, consumed once
+    /// reported. Single-slot: a new stop/continue before the parent reaps the
+    /// previous one overwrites it (unlike Linux, which queues each SIGCHLD).
+    /// Adequate for the single-threaded job-control this targets.
+    status: Option<JobStatus>,
+    /// Bumped on every continue. A thread about to park (`set_job_stopped`)
+    /// snapshots this; if it changed by the time the thread checks before
+    /// parking, a `SIGCONT` raced in after the stop was recorded and the park
+    /// is skipped. This closes the STOP-immediately-followed-by-CONT race
+    /// (e.g. busybox `killall5 -STOP` then `-CONT`) without having to scrub the
+    /// pending-signal queue.
+    continue_generation: u64,
+}
+
 /// [`Process`]-shared data.
 pub struct ProcessData {
     /// The process.
@@ -513,6 +553,13 @@ pub struct ProcessData {
     /// Set after [`Self::release_aspace_slot_if_needed`] runs so `Drop` does not
     /// double-decrement [`AddrSpace::process_slots`].
     aspace_slot_released: AtomicBool,
+
+    /// Job-control state (stop flag + pending parent report) under one lock.
+    job_control: SpinNoIrq<JobControl>,
+
+    /// Woken to release threads parked in a job-control stop. Fired by
+    /// `SIGCONT` (continue) and `SIGKILL` (force-resume so the kill proceeds).
+    cont_event: Arc<PollSet>,
 }
 
 impl ProcessData {
@@ -561,6 +608,9 @@ impl ProcessData {
 
             vm_aspace_shared: AtomicBool::new(vm_aspace_shared),
             aspace_slot_released: AtomicBool::new(false),
+
+            job_control: SpinNoIrq::new(JobControl::default()),
+            cont_event: Arc::default(),
         });
         // Clone the Arc in a separate statement: a temporary `SpinNoIrq` guard
         // from `lock()` lives until the end of the statement, so calling
@@ -650,6 +700,105 @@ impl ProcessData {
     /// (SUID_DUMP_USER). Callers must validate before storing.
     pub fn set_dumpable(&self, dumpable: i32) {
         self.dumpable.store(dumpable, Ordering::SeqCst);
+    }
+
+    /// Returns true if the process is currently job-control stopped.
+    pub fn is_job_stopped(&self) -> bool {
+        self.job_control.lock().stopped.is_some()
+    }
+
+    /// Mark the process stopped by `signo` and queue a `Stopped` report for the
+    /// parent's `waitpid(WUNTRACED)`. Returns `true` if the caller should park.
+    ///
+    /// Returns `false` (and records nothing) when a `SIGCONT` arrived after the
+    /// stop signal was dequeued but before this call — see
+    /// [`Self::set_job_continued`] / `continue_generation`. Closing this race at
+    /// the stop site lets us avoid scrubbing the pending-signal queue (which
+    /// would require modifying `starry-signal`).
+    pub fn set_job_stopped(&self, signo: Signo, continue_gen_snapshot: u64) -> bool {
+        let mut jc = self.job_control.lock();
+        if jc.continue_generation != continue_gen_snapshot {
+            // A continue raced in after we observed `continue_gen_snapshot`;
+            // honor it and do not stop.
+            return false;
+        }
+        jc.stopped = Some(signo);
+        jc.status = Some(JobStatus::Stopped(signo));
+        true
+    }
+
+    /// Snapshot the continue generation. Taken right after a stop signal is
+    /// dequeued and passed to [`Self::set_job_stopped`]; any intervening
+    /// `SIGCONT` advances the generation and cancels the stop.
+    pub fn continue_generation(&self) -> u64 {
+        self.job_control.lock().continue_generation
+    }
+
+    /// Continue a stopped process: clear the stop, queue a `Continued` report,
+    /// and wake parked threads. Returns true if it had been stopped.
+    ///
+    /// Always advances `continue_generation` so a concurrent stop in progress
+    /// (signal already dequeued, not yet parked) observes the continue and
+    /// skips parking.
+    pub fn set_job_continued(&self) -> bool {
+        let mut jc = self.job_control.lock();
+        jc.continue_generation = jc.continue_generation.wrapping_add(1);
+        let was_stopped = jc.stopped.take().is_some();
+        if was_stopped {
+            jc.status = Some(JobStatus::Continued);
+            drop(jc);
+            // Wake only when a thread was actually parked; avoids spurious
+            // wakeups on SIGCONT to an already-running process.
+            self.cont_event.wake();
+        }
+        was_stopped
+    }
+
+    /// Force-clear the stop (for `SIGKILL`) so a parked thread re-checks and
+    /// proceeds to terminate. Does not queue a `Continued` report.
+    pub fn clear_job_stop_for_kill(&self) {
+        let was_stopped = self.job_control.lock().stopped.take().is_some();
+        if was_stopped {
+            self.cont_event.wake();
+        }
+    }
+
+    /// The wait queue woken when the process is continued or killed.
+    pub fn cont_event(&self) -> Arc<PollSet> {
+        self.cont_event.clone()
+    }
+
+    /// Peek the pending job-control status report (without consuming it) if it
+    /// matches a kind the caller's `waitpid` flags allow (`WUNTRACED` for
+    /// stopped, `WCONTINUED` for continued).
+    pub fn peek_job_status_if(
+        &self,
+        want_stopped: bool,
+        want_continued: bool,
+    ) -> Option<JobStatus> {
+        let jc = self.job_control.lock();
+        match jc.status {
+            Some(s @ JobStatus::Stopped(_)) if want_stopped => Some(s),
+            Some(s @ JobStatus::Continued) if want_continued => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Consume the pending job-control status report if it matches a kind the
+    /// caller's `waitpid` flags allow. Mirrors [`Self::peek_job_status_if`] but
+    /// clears the slot; call it only after the status has been published to
+    /// userspace so a faulting copy leaves the report intact to retry.
+    pub fn take_job_status_if(
+        &self,
+        want_stopped: bool,
+        want_continued: bool,
+    ) -> Option<JobStatus> {
+        let mut jc = self.job_control.lock();
+        match jc.status {
+            Some(JobStatus::Stopped(_)) if want_stopped => jc.status.take(),
+            Some(JobStatus::Continued) if want_continued => jc.status.take(),
+            _ => None,
+        }
     }
 
     /// Get the accumulated CPU time of waited children.

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -1,12 +1,15 @@
+use core::{future::poll_fn, task::Poll};
+
 use ax_errno::{AxError, AxResult};
 use ax_hal::uspace::UserContext;
-use ax_task::{TaskInner, current};
+use ax_task::{TaskInner, current, future::block_on};
+use linux_raw_sys::general::{CLD_CONTINUED, CLD_STOPPED};
 use starry_process::Pid;
-use starry_signal::{SignalInfo, SignalOSAction, SignalSet};
+use starry_signal::{SignalInfo, SignalOSAction, SignalSet, Signo};
 
 use super::{
-    AsThread, SYSCALL_INSN_LEN, Thread, do_exit, get_process_data, get_process_group, get_task,
-    is_zombie_pid,
+    AsThread, ProcessData, SYSCALL_INSN_LEN, Thread, do_exit, get_process_data, get_process_group,
+    get_task, is_zombie_pid,
 };
 
 /// Information needed to restart a syscall if SA_RESTART applies.
@@ -150,11 +153,78 @@ pub fn check_signals(
             }
             do_exit(128 + signo as i32, true);
         }
-        SignalOSAction::Stop => do_exit(1, true),
+        SignalOSAction::Stop => do_job_stop(thr, signo),
         SignalOSAction::Continue => {}
         SignalOSAction::NoFurtherAction => {}
     }
     true
+}
+
+/// Notify a process's parent of a job-control state change by sending it
+/// `SIGCHLD` (with `CLD_STOPPED`/`CLD_CONTINUED`) and waking its `waitpid`.
+fn notify_parent_job_change(proc_data: &ProcessData, code: i32, status: i32) {
+    let proc = &proc_data.proc;
+    let Some(parent) = proc.parent() else {
+        return;
+    };
+    // si_uid carries the child's real UID; read it from any live thread.
+    let child_uid = proc
+        .threads()
+        .into_iter()
+        .next()
+        .and_then(|tid| get_task(tid).ok())
+        .map_or(0, |task| task.as_thread().cred().uid);
+    let sig = SignalInfo::new_sigchld(proc.pid(), child_uid, code, status);
+    let _ = send_signal_to_process(parent.pid(), Some(sig));
+    if let Ok(data) = get_process_data(parent.pid()) {
+        data.child_exit_event.wake();
+    }
+}
+
+/// Enter a job-control stop: record the stop, notify the parent, then park the
+/// current thread until `SIGCONT` clears the stop (or `SIGKILL` force-resumes it
+/// so the kill can proceed).
+///
+/// Uses a plain block — not [`interruptible`](ax_task::future::interruptible) —
+/// because an ordinary signal must **not** wake a stopped process; only
+/// continue/kill clear `is_job_stopped`.
+///
+/// The STOP-immediately-followed-by-CONT race (e.g. busybox `killall5 -STOP`
+/// then `-CONT`) is closed by snapshotting `continue_generation` *before*
+/// recording the stop: if a `SIGCONT` bumped the generation in between,
+/// [`ProcessData::set_job_stopped`] returns `false` and we never park. This
+/// replaces the pending-signal scrubbing the reference design used (which would
+/// require modifying `starry-signal`).
+///
+/// Known limitations (acceptable for the single-threaded shells/tools this
+/// targets):
+/// - Only the thread that dequeues the stop signal parks; sibling threads of a
+///   multi-threaded process keep running until they next hit a stop signal.
+///   Linux stops every thread in the group.
+fn do_job_stop(thr: &Thread, signo: Signo) {
+    let proc_data = &thr.proc_data;
+    // Snapshot before recording the stop so a racing SIGCONT (which advances the
+    // generation) cancels this stop.
+    let continue_gen = proc_data.continue_generation();
+    if !proc_data.set_job_stopped(signo, continue_gen) {
+        return;
+    }
+    notify_parent_job_change(proc_data, CLD_STOPPED as i32, signo as i32);
+
+    let cont_event = proc_data.cont_event();
+    block_on(poll_fn(|cx| {
+        if !proc_data.is_job_stopped() {
+            return Poll::Ready(());
+        }
+        cont_event.register(cx.waker());
+        // Re-check after registering to avoid a lost wakeup if the continue
+        // landed between the check above and registration.
+        if proc_data.is_job_stopped() {
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }));
 }
 
 pub fn block_next_signal() {
@@ -216,6 +286,26 @@ pub fn send_signal_to_process(pid: Pid, sig: Option<SignalInfo>) -> AxResult<()>
             return Err(AxError::NoSuchProcess);
         }
     };
+
+    // Job-control side effects must run at send time: a stopped process is
+    // parked in the kernel and cannot dequeue SIGCONT itself.
+    if let Some(sig) = &sig {
+        match sig.signo() {
+            // POSIX: SIGCONT resumes a stopped process and reports CLD_CONTINUED.
+            // `set_job_continued` (evaluated in the guard) always advances the
+            // process's continue generation as a side effect — so a stop signal
+            // already dequeued but not yet parked (e.g. killall5's
+            // kill(-1,SIGSTOP) immediately followed by kill(-1,SIGCONT)) observes
+            // the continue and skips parking, closing the STOP-then-CONT race
+            // without scrubbing the pending queue — and returns whether the
+            // process had actually been stopped; only then do we notify the parent.
+            Signo::SIGCONT if proc_data.set_job_continued() => {
+                notify_parent_job_change(&proc_data, CLD_CONTINUED as i32, Signo::SIGCONT as i32);
+            }
+            Signo::SIGKILL => proc_data.clear_job_stop_for_kill(),
+            _ => {}
+        }
+    }
 
     if let Some(sig) = sig {
         let signo = sig.signo();

--- a/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/c/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-job-control-stop C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+find_package(Threads REQUIRED)
+
+add_executable(test-job-control-stop src/main.c)
+target_include_directories(test-job-control-stop PRIVATE src)
+target_compile_options(test-job-control-stop PRIVATE -Wall -Wextra -Werror)
+target_link_libraries(test-job-control-stop PRIVATE Threads::Threads)
+
+install(TARGETS test-job-control-stop RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/c/src/main.c
@@ -1,0 +1,81 @@
+/*
+ * test-job-control-stop
+ *
+ * Regression test for POSIX job control. A `SIGSTOP` (or SIGTSTP/SIGTTIN/
+ * SIGTTOU) must *suspend* the target process, not kill it; the parent's
+ * waitpid(WUNTRACED) must observe WIFSTOPPED. A subsequent `SIGCONT` must
+ * resume the process and waitpid(WCONTINUED) must observe WIFCONTINUED.
+ * Finally SIGKILL must terminate even a stopped process.
+ *
+ * Before this fix StarryOS turned SignalOSAction::Stop into do_exit(1):
+ * the child was *killed* by SIGSTOP, so the WUNTRACED check below would
+ * have seen WIFEXITED/WIFSIGNALED instead of WIFSTOPPED and FAILed. That
+ * broke shell job control and busybox `killall5 -STOP/-CONT`.
+ */
+
+#include "test_framework.h"
+#include <sched.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(void)
+{
+    TEST_START("job control: SIGSTOP suspends, SIGCONT resumes");
+
+    pid_t child = fork();
+    CHECK(child >= 0, "fork");
+    if (child < 0) {
+        TEST_DONE();
+    }
+
+    if (child == 0) {
+        /* Child: spin forever. It must keep "running" (be schedulable)
+         * until stopped, and must be re-schedulable after SIGCONT. We rely
+         * on the parent's kill+waitpid to drive the state transitions. */
+        for (;;) {
+            /* busy-yield so the parent gets CPU time on smp=1 */
+            sched_yield();
+        }
+        _exit(0); /* unreachable */
+    }
+
+    int st;
+
+    /* --- SIGSTOP must STOP, not kill --- */
+    CHECK_RET(kill(child, SIGSTOP), 0, "kill(child, SIGSTOP)");
+
+    /* waitpid(WUNTRACED) blocks until the child is stopped, then reports it.
+     * If the old (buggy) behavior were present, the child would have exited
+     * and we'd get WIFEXITED/WIFSIGNALED here instead. */
+    pid_t w = waitpid(child, &st, WUNTRACED);
+    CHECK_RET(w, child, "waitpid(WUNTRACED) returns child pid");
+    CHECK(WIFSTOPPED(st), "child is STOPPED (WIFSTOPPED)");
+    CHECK(!WIFEXITED(st), "child did NOT exit on SIGSTOP");
+    CHECK(!WIFSIGNALED(st), "child was NOT killed by SIGSTOP");
+    if (WIFSTOPPED(st)) {
+        CHECK(WSTOPSIG(st) == SIGSTOP, "WSTOPSIG == SIGSTOP");
+    }
+
+    /* The child must still exist (a stopped process is not reaped). A
+     * second kill(child, 0) probing existence should succeed. */
+    CHECK_RET(kill(child, 0), 0, "stopped child still exists (kill 0)");
+
+    /* --- SIGCONT must CONTINUE --- */
+    CHECK_RET(kill(child, SIGCONT), 0, "kill(child, SIGCONT)");
+
+    w = waitpid(child, &st, WCONTINUED);
+    CHECK_RET(w, child, "waitpid(WCONTINUED) returns child pid");
+    CHECK(WIFCONTINUED(st), "child reported CONTINUED (WIFCONTINUED)");
+
+    /* --- SIGKILL must terminate even after a stop/continue cycle --- */
+    CHECK_RET(kill(child, SIGKILL), 0, "kill(child, SIGKILL)");
+    w = waitpid(child, &st, 0);
+    CHECK_RET(w, child, "waitpid reaps killed child");
+    CHECK(WIFSIGNALED(st), "child terminated by signal");
+    if (WIFSIGNALED(st)) {
+        CHECK(WTERMSIG(st) == SIGKILL, "WTERMSIG == SIGKILL");
+    }
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/c/src/test_framework.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);       \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");      \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");      \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");    \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/qemu-aarch64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-job-control-stop"
+success_regex = ["(?s)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/qemu-loongarch64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic",
+    "-m", "128M",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-job-control-stop"
+success_regex = ["(?s)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-job-control-stop"
+success_regex = ["(?s)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-job-control-stop/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/target/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-job-control-stop"
+success_regex = ["(?s)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60


### PR DESCRIPTION
## 问题

在 dev 上,`os/StarryOS/kernel/src/task/signal.rs` 的 `check_signals` 把 `SignalOSAction::Stop` 处理成 `do_exit(1, true)`:进程收到 SIGSTOP/SIGTSTP/SIGTTIN/SIGTTOU 时不是被挂起,而是被直接退出(杀死);`SignalOSAction::Continue` 为空实现。父进程的 `waitpid(WUNTRACED/WCONTINUED)` 也无从得知子进程的停止/继续。这破坏了 shell 作业控制、`killall5 -STOP/-CONT` 以及 busybox 等依赖作业控制的工具。

## 根因

缺少真正的作业控制状态机:没有"已停止"标志,没有让停止线程在内核里挂起、等待 SIGCONT(或 SIGKILL)唤醒的机制,也没有把停止/继续状态报告给父进程 `waitpid` 的通道。

## 修复

仅改动三个内核文件,加性叠加到 dev 现有结构上:

- `task/mod.rs`:新增 `enum JobStatus {Stopped(Signo), Continued}` 与受单锁保护的 `struct JobControl {stopped, status, continue_generation}` 作为 `ProcessData` 的字段,并新增 `cont_event: Arc<PollSet>`;配套方法 `is_job_stopped` / `set_job_stopped` / `continue_generation` / `set_job_continued`(唤醒 cont_event)/ `clear_job_stop_for_kill` / `cont_event` / `peek_job_status_if` / `take_job_status_if`。
- `task/signal.rs`:`SignalOSAction::Stop` 改为 `do_job_stop(thr, signo)` —— 记录停止、向父进程发 SIGCHLD(CLD_STOPPED)、再 `block_on(poll_fn(...))` 在 cont_event 上挂起(刻意不走 interruptible:普通信号不得唤醒已停止进程,只有 continue/kill 清除停止标志)。`send_signal_to_process` 在发送时处理 SIGCONT(置 continued、报告 CLD_CONTINUED)与 SIGKILL(强制清除停止以便被杀死)。
- `syscall/task/wait.rs`:`sys_waitpid` 在僵尸回收之外,按 `WUNTRACED`/`WCONTINUED` 经 `peek/take_job_status_if` 报告停止/继续状态,编码为 `(signo<<8)|0x7f`(W_STOPCODE)与 `0xffff`。

为不修改 `starry-signal`,用 `continue_generation` 计数关闭 "STOP 后紧接 CONT" 竞态:停止前快照该计数,若期间有 SIGCONT 递增了它,`set_job_stopped` 返回 false 从而不挂起,等价于参考实现里在发送端 `discard_pending` 的效果。

## 对照 Linux(验证)

- SIGSTOP/SIGTSTP/SIGTTIN/SIGTTOU 挂起进程而非退出;SIGCONT 恢复;SIGKILL 即使对已停止进程也能终止。
- `waitpid(WUNTRACED)` 报告 `WIFSTOPPED` 且 `WSTOPSIG == 停止信号`;`waitpid(WCONTINUED)` 报告 `WIFCONTINUED`;状态字编码与 Linux 一致。
- 父进程在子进程停止/继续时收到 SIGCHLD(CLD_STOPPED / CLD_CONTINUED)。

## 测试

新增 `test-suit/starryos/normal/qemu-smp1/test-job-control-stop`(四架构 toml + C 测例):fork 一个忙等子进程,父进程 `kill(SIGSTOP)` → `waitpid(WUNTRACED)` 期望 `WIFSTOPPED`,并确认子进程未退出、仍存在;`kill(SIGCONT)` → `waitpid(WCONTINUED)` 期望 `WIFCONTINUED`;`kill(SIGKILL)` 回收,期望 `WIFSIGNALED && WTERMSIG==SIGKILL`。在 starry x86_64(smp=1)实跑:15/15 断言通过。`cargo xtask starry build --arch x86_64` 与 `cargo fmt --all -- --check` 均通过。
