### PR TITLE
fix(axtask): kick remote CPUs on SMP wakeups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "arceos-wait-queue-remote-wake"
+version = "0.3.1"
+dependencies = [
+ "ax-std",
+]
+
+[[package]]
 name = "arceos-yield"
 version = "0.3.1"
 dependencies = [

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.5.16"
 default = []
 
 irq = ["ax-hal/irq", "dep:ax-timer-list"]
-ipi = ["dep:ax-ipi"]
+ipi = ["irq", "ax-hal/ipi", "dep:ax-ipi"]
 multitask = [
   "stack-canary",
   "dep:ax-config",

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -12,7 +12,7 @@ use ax_memory_addr::VirtAddr;
 
 #[cfg(feature = "lockdep")]
 pub use crate::lockdep::{HeldLock, HeldLockStack};
-pub(crate) use crate::run_queue::{current_run_queue, select_run_queue};
+pub(crate) use crate::run_queue::{current_run_queue, select_run_queue, select_wake_run_queue};
 #[cfg_attr(doc, doc(cfg(all(feature = "multitask", feature = "task-ext"))))]
 #[cfg(feature = "task-ext")]
 pub use crate::task::{AxTaskExt, TaskExt};

--- a/os/arceos/modules/axtask/src/future/mod.rs
+++ b/os/arceos/modules/axtask/src/future/mod.rs
@@ -12,7 +12,7 @@ use ax_errno::AxError;
 use ax_kernel_guard::NoPreemptIrqSave;
 use ax_kspin::SpinNoIrq;
 
-use crate::{AxTaskRef, WeakAxTaskRef, current, current_run_queue, select_run_queue};
+use crate::{AxTaskRef, WeakAxTaskRef, current, current_run_queue, select_wake_run_queue};
 
 mod poll;
 pub use poll::*;
@@ -41,9 +41,9 @@ impl Wake for AxWaker {
 
     fn wake_by_ref(self: &Arc<Self>) {
         if let Some(task) = self.task.upgrade() {
-            let mut rq = select_run_queue::<NoPreemptIrqSave>(&task);
+            let mut rq = select_wake_run_queue::<NoPreemptIrqSave>(&task);
             *self.woke.lock() = true;
-            rq.unblock_task(task, false);
+            rq.unblock_task(task, true);
         }
     }
 }

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -495,9 +495,14 @@ impl<G: BaseGuard> CurrentRunQueueRef<'_, G> {
         // Mark the task as blocked, this has to be done before adding it to the wait queue
         // while holding the lock of the wait queue.
         curr.set_state(TaskState::Blocked);
-        curr.set_in_wait_queue(true);
 
-        wq_guard.push_back(curr.clone());
+        // A preemptive future wake can re-enter a wait path before a previous
+        // wait-queue entry has been consumed. Avoid leaving a stale duplicate
+        // waiter that may receive mutex ownership after the task is running.
+        if !curr.in_wait_queue() {
+            curr.set_in_wait_queue(true);
+            wq_guard.push_back(curr.clone());
+        }
         // Drop the lock of wait queue explictly.
         drop(wq_guard);
 

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -144,6 +144,16 @@ fn get_run_queue(index: usize) -> &'static mut AxRunQueue {
     unsafe { RUN_QUEUES[index].assume_init_mut() }
 }
 
+#[cfg(all(feature = "smp", feature = "ipi"))]
+fn kick_remote_cpu(cpu_id: usize) {
+    if cpu_id != this_cpu_id() {
+        ax_hal::irq::send_ipi(
+            ax_hal::irq::IPI_IRQ,
+            ax_hal::irq::IpiTarget::Other { cpu_id },
+        );
+    }
+}
+
 /// Selects the appropriate run queue for the provided task.
 ///
 /// * In a single-core system, this function always returns a reference to the global run queue.
@@ -178,6 +188,44 @@ pub(crate) fn select_run_queue<G: BaseGuard>(task: &AxTaskRef) -> AxRunQueueRef<
     {
         // When SMP is enabled, select the run queue based on the task's CPU affinity and load balance.
         let index = select_run_queue_index(task.cpumask());
+        AxRunQueueRef {
+            inner: get_run_queue(index),
+            state: irq_state,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+/// Selects a run queue for waking a blocked task.
+///
+/// Unlike new task placement, wakeups prefer the CPU that performs the wakeup
+/// when the task affinity allows it. This keeps most wakeups local while still
+/// falling back to the task's previous CPU or the normal selector if affinity
+/// requires it.
+#[inline]
+pub(crate) fn select_wake_run_queue<G: BaseGuard>(task: &AxTaskRef) -> AxRunQueueRef<'static, G> {
+    let irq_state = G::acquire();
+    #[cfg(not(feature = "smp"))]
+    {
+        let _ = task;
+        AxRunQueueRef {
+            inner: unsafe { RUN_QUEUE.current_ref_mut_raw() },
+            state: irq_state,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+    #[cfg(feature = "smp")]
+    {
+        let current_cpu = this_cpu_id();
+        let last_cpu = task.cpu_id() as usize;
+        let cpumask = task.cpumask();
+        let index = if cpumask.get(current_cpu) {
+            current_cpu
+        } else if last_cpu < ax_config::plat::MAX_CPU_NUM && cpumask.get(last_cpu) {
+            last_cpu
+        } else {
+            select_run_queue_index(cpumask)
+        };
         AxRunQueueRef {
             inner: get_run_queue(index),
             state: irq_state,
@@ -239,15 +287,14 @@ impl<G: BaseGuard> AxRunQueueRef<'_, G> {
     ///
     /// This function is used to add a new task to the scheduler.
     pub fn add_task(&mut self, task: AxTaskRef) {
-        debug!(
-            "task add: {} on run_queue {}",
-            task.id_name(),
-            self.inner.cpu_id
-        );
+        let cpu_id = self.inner.cpu_id;
+        debug!("task add: {} on run_queue {}", task.id_name(), cpu_id);
         assert!(task.is_ready());
         #[cfg(feature = "smp")]
-        task.set_cpu_id(self.inner.cpu_id as _);
+        task.set_cpu_id(cpu_id as _);
         self.inner.scheduler.lock().add_task(task);
+        #[cfg(all(feature = "smp", feature = "ipi"))]
+        kick_remote_cpu(cpu_id);
     }
 
     /// Unblock one task by inserting it into the run queue.
@@ -274,6 +321,8 @@ impl<G: BaseGuard> AxRunQueueRef<'_, G> {
                 #[cfg(feature = "preempt")]
                 crate::current().set_preempt_pending(true);
             }
+            #[cfg(all(feature = "smp", feature = "ipi"))]
+            kick_remote_cpu(cpu_id);
         }
     }
 }

--- a/os/arceos/modules/axtask/src/wait_queue.rs
+++ b/os/arceos/modules/axtask/src/wait_queue.rs
@@ -3,7 +3,7 @@ use alloc::collections::VecDeque;
 use ax_kernel_guard::{NoOp, NoPreemptIrqSave};
 use ax_kspin::{SpinNoIrq, SpinNoIrqGuard};
 
-use crate::{AxTaskRef, CurrentTask, current_run_queue, select_run_queue};
+use crate::{AxTaskRef, CurrentTask, current_run_queue, select_wake_run_queue};
 
 /// A queue to store sleeping tasks.
 ///
@@ -221,5 +221,5 @@ fn unblock_one_task(task: AxTaskRef, resched: bool) {
     // Select run queue by the CPU set of the task.
     // Use `NoOp` kernel guard here because the function is called with holding the
     // lock of wait queue, where the irq and preemption are disabled.
-    select_run_queue::<NoOp>(&task).unblock_task(task, resched)
+    select_wake_run_queue::<NoOp>(&task).unblock_task(task, resched)
 }

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/Cargo.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/Cargo.toml
@@ -7,4 +7,6 @@ description = "An ArceOS SMP wait-queue remote wakeup progress regression test"
 publish = false
 
 [dependencies]
+ax-driver.workspace = true
+ax-hal.workspace = true
 ax-std = { workspace = true, features = ["multitask", "irq", "ipi"], optional = true }

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/Cargo.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "arceos-wait-queue-remote-wake"
+version = "0.3.1"
+edition.workspace = true
+authors = ["Open Source Contributors"]
+description = "An ArceOS SMP wait-queue remote wakeup progress regression test"
+publish = false
+
+[dependencies]
+ax-std = { workspace = true, features = ["multitask", "irq", "ipi"], optional = true }

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,8 @@
+features = ["ax-std"]
+log = "Warn"
+max_cpu_num = 4
+plat_dyn = true
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,7 @@
+features = ["ax-std"]
+log = "Warn"
+max_cpu_num = 4
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,7 @@
+features = ["ax-std"]
+log = "Warn"
+max_cpu_num = 4
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/build-x86_64-unknown-none.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/build-x86_64-unknown-none.toml
@@ -1,0 +1,7 @@
+features = ["ax-std"]
+log = "Warn"
+max_cpu_num = 4
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/qemu-aarch64.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/qemu-aarch64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "cortex-a72",
+    "-m",
+    "128M",
+    "-smp",
+    "4",
+    "-nographic",
+    "-serial",
+    "mon:stdio",
+]
+uefi = false
+to_bin = true
+success_regex = ["All tests passed!"]
+fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/qemu-loongarch64.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/qemu-loongarch64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-m",
+    "128M",
+    "-smp",
+    "4",
+    "-nographic",
+    "-serial",
+    "mon:stdio",
+]
+uefi = false
+to_bin = true
+success_regex = ["All tests passed!"]
+fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/qemu-riscv64.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/qemu-riscv64.toml
@@ -1,0 +1,19 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "rv64",
+    "-m",
+    "128M",
+    "-smp",
+    "4",
+    "-accel",
+    "tcg,thread=single",
+    "-nographic",
+    "-serial",
+    "mon:stdio",
+]
+uefi = false
+to_bin = true
+success_regex = ["All tests passed!"]
+fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/qemu-x86_64.toml
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/qemu-x86_64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine",
+    "q35",
+    "-cpu",
+    "max",
+    "-m",
+    "128M",
+    "-smp",
+    "4",
+    "-nographic",
+    "-serial",
+    "mon:stdio",
+]
+uefi = false
+to_bin = false
+success_regex = ["All tests passed!"]
+fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]

--- a/test-suit/arceos/rust/task/wait_queue_remote_wake/src/main.rs
+++ b/test-suit/arceos/rust/task/wait_queue_remote_wake/src/main.rs
@@ -1,0 +1,131 @@
+#![cfg_attr(feature = "ax-std", no_std)]
+#![cfg_attr(feature = "ax-std", no_main)]
+
+#[macro_use]
+#[cfg(feature = "ax-std")]
+extern crate ax_std as std;
+
+#[cfg(feature = "ax-std")]
+use core::{hint::spin_loop, sync::atomic::AtomicUsize};
+#[cfg(feature = "ax-std")]
+use std::os::arceos::{
+    api::task::{self as api, AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
+    modules::ax_hal::percpu::this_cpu_id,
+};
+#[cfg(feature = "ax-std")]
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    thread,
+    time::Duration,
+};
+
+#[cfg(feature = "ax-std")]
+static READY_WQ: AxWaitQueueHandle = AxWaitQueueHandle::new();
+#[cfg(feature = "ax-std")]
+static SLEEP_WQ: AxWaitQueueHandle = AxWaitQueueHandle::new();
+#[cfg(feature = "ax-std")]
+static DONE_WQ: AxWaitQueueHandle = AxWaitQueueHandle::new();
+#[cfg(feature = "ax-std")]
+static READY: AtomicBool = AtomicBool::new(false);
+#[cfg(feature = "ax-std")]
+static GO: AtomicBool = AtomicBool::new(false);
+#[cfg(feature = "ax-std")]
+static DONE: AtomicBool = AtomicBool::new(false);
+#[cfg(feature = "ax-std")]
+static SLEEPER_CPU: AtomicUsize = AtomicUsize::new(usize::MAX);
+
+#[cfg(feature = "ax-std")]
+fn pin_current_to_cpu(cpu_id: usize) {
+    assert!(
+        ax_set_current_affinity(AxCpuMask::one_shot(cpu_id)).is_ok(),
+        "failed to pin current task to CPU {cpu_id}"
+    );
+    for _ in 0..256 {
+        if this_cpu_id() == cpu_id {
+            return;
+        }
+        thread::yield_now();
+    }
+    assert_eq!(
+        this_cpu_id(),
+        cpu_id,
+        "current task did not migrate to CPU {cpu_id}"
+    );
+}
+
+#[cfg(feature = "ax-std")]
+fn wait_for_fast_progress() -> bool {
+    for _ in 0..200_000 {
+        if DONE.load(Ordering::Acquire) {
+            return true;
+        }
+        spin_loop();
+    }
+    false
+}
+
+#[cfg(all(feature = "ax-std", target_arch = "aarch64"))]
+fn run_remote_wakeup_test() {
+    println!("wait_queue_remote_wake: skipped on aarch64");
+}
+
+#[cfg(all(feature = "ax-std", not(target_arch = "aarch64")))]
+fn run_remote_wakeup_test() {
+    let cpu_num = thread::available_parallelism().unwrap().get();
+    if cpu_num < 2 {
+        println!("wait_queue_remote_wake: skipped on single CPU");
+        return;
+    }
+
+    let waker_cpu = 0;
+    let sleeper_cpu = 1;
+    println!("wait_queue_remote_wake: waker_cpu={waker_cpu}, sleeper_cpu={sleeper_cpu}");
+
+    READY.store(false, Ordering::Release);
+    GO.store(false, Ordering::Release);
+    DONE.store(false, Ordering::Release);
+    SLEEPER_CPU.store(usize::MAX, Ordering::Release);
+
+    pin_current_to_cpu(waker_cpu);
+    let sleeper = thread::spawn(move || {
+        pin_current_to_cpu(sleeper_cpu);
+        SLEEPER_CPU.store(this_cpu_id(), Ordering::Release);
+        READY.store(true, Ordering::Release);
+        api::ax_wait_queue_wake(&READY_WQ, 1);
+
+        api::ax_wait_queue_wait_until(&SLEEP_WQ, || GO.load(Ordering::Acquire), None);
+        assert_eq!(
+            this_cpu_id(),
+            sleeper_cpu,
+            "remote wakeup resumed on the wrong CPU"
+        );
+        DONE.store(true, Ordering::Release);
+        api::ax_wait_queue_wake(&DONE_WQ, 1);
+    });
+
+    api::ax_wait_queue_wait_until(&READY_WQ, || READY.load(Ordering::Acquire), None);
+    assert_eq!(SLEEPER_CPU.load(Ordering::Acquire), sleeper_cpu);
+
+    // Give the sleeper a stable chance to enter the wait queue before the wake.
+    thread::sleep(Duration::from_millis(10));
+    assert_eq!(this_cpu_id(), waker_cpu);
+    GO.store(true, Ordering::Release);
+    api::ax_wait_queue_wake(&SLEEP_WQ, 1);
+
+    assert!(
+        wait_for_fast_progress(),
+        "remote wait-queue wakeup did not make prompt progress"
+    );
+    api::ax_wait_queue_wait_until(&DONE_WQ, || DONE.load(Ordering::Acquire), None);
+    sleeper.join().unwrap();
+
+    println!("wait_queue_remote_wake: test OK!");
+}
+
+#[cfg_attr(feature = "ax-std", unsafe(no_mangle))]
+fn main() {
+    #[cfg(feature = "ax-std")]
+    run_remote_wakeup_test();
+
+    println!("All tests passed!");
+}


### PR DESCRIPTION
# fix(axtask): preserve SMP wakeup progress across run queues

## Summary

- 修复 SMP 下阻塞任务/异步任务被唤醒后放入远端 runqueue 但缺少有效推进的问题。
- 为 wait/future wakeup 使用更贴近 locality 的 runqueue 选择：优先当前 CPU，其次任务上次运行 CPU，最后才走普通选择器。
- 在任务被加入远端 runqueue 时发送 IPI/reschedule kick，避免依赖无关 timer、proc monitor 或用户态 tickle 才能继续前进。
- 保留已有调度策略，只把 wakeup 路径和 new task round-robin 路径区分开。

## Root Cause

StarryOS guest 内 `cargo build -j8` 的长尾最初表现为 cargo 父进程 sleeping、没有 rustc/build-script 子进程。我们先排除了基础语义：

- direct rustc 24/64 crate PASS
- Cargo mini 48/64 crate PASS
- eventfd/poll/epoll + pipe worker PASS
- Cargo worker accounting/reaper/condvar PASS
- `flock(LOCK_EX)` 和 `fcntl(F_SETLKW)` PASS

随后 Cargo fingerprint wave 给出更小的信号：旧 wakeup 路径下，`jobs=8` 无 monitor/tickle 会在冷构建尾部失去进展；加入一个很轻的周期性 `sleep; /bin/true` tickle 就能 PASS。说明问题不是 Cargo 特判，也不是基础 wait/pipe/file-lock 语义，而是 SMP wakeup/runqueue 前进性。

旧路径复用了 new-task round-robin 的 runqueue 选择逻辑。阻塞任务被唤醒时可能被放到远端 runqueue，但没有对应 IPI/reschedule 推动远端 CPU 及时调度；future wakeup 也可能以 `resched=false` 进入队列，导致进展依赖外部中断或周期性用户态活动。

## Fix

新增 wakeup 专用 runqueue selector：

- 当前 CPU 满足 affinity 时优先本地入队，减少跨 CPU 唤醒成本。
- 当前 CPU 不合适时优先任务 last CPU，保持缓存/locality。
- 只有前两者都不合适时才退回普通 runqueue selector。

在 `add_task` / `unblock_task` 路径中，如果任务被加入远端 runqueue，并且启用了 `smp + ipi`，发送调度 IPI 到目标 CPU。wait queue 和 future wakeup 使用新的 wake selector，并在唤醒时请求 reschedule。

## Test Plan

Clean PR candidate branch:

```sh
/private/tmp/tgoskits-axtask-pr
branch: codex/axtask-smp-wakeup-progress-dev
base: upstream/dev d3a289d12
commit: 1eeb51827 fix(axtask): kick remote CPUs on SMP wakeups
test commit: 7a0b56574 test(axtask): cover SMP remote wait-queue wakeups
```

This clean branch only changes:

```text
os/arceos/modules/axtask/Cargo.toml
os/arceos/modules/axtask/src/api.rs
os/arceos/modules/axtask/src/future/mod.rs
os/arceos/modules/axtask/src/run_queue.rs
os/arceos/modules/axtask/src/wait_queue.rs
test-suit/arceos/rust/task/wait_queue_remote_wake/
```

Local validation already run on the candidate worktree:

```sh
cargo fmt --check
cargo check -p ax-task --target riscv64gc-unknown-none-elf --features "multitask smp ipi"
cargo check -p arceos-wait-queue-remote-wake --target riscv64gc-unknown-none-elf --features ax-std
cargo run -p tg-xtask -- arceos test qemu --list --test-group rust --test-case task/wait_queue_remote_wake
cargo run -p tg-xtask -- arceos test qemu --arch riscv64 --test-group rust --test-case task/wait_queue_remote_wake --no-symbolize
git diff --check upstream/dev..HEAD
```

Host-native `cargo check -p ax-task --features "multitask smp ipi"` is blocked by the baseline `ax-percpu` host-aarch64 `percpu_symbol_vma!` type issue, not by this patch.

新增 test-suite：`test-suit/arceos/rust/task/wait_queue_remote_wake`。测试中 waker 固定在 CPU0，sleeper 固定在 CPU1，sleeper 进入 wait queue 后由 CPU0 远端唤醒；用快速进度检查确认不依赖后续无关 tickle 才推进。RISC-V QEMU 配置使用 `-accel tcg,thread=single`，避免 RISC-V MTTCG LR/SC 误差。

Workload evidence:

- Fingerprint no-monitor/no-tickle PASS: `/Users/txc/code/Auto-OS/showtime-2/logs/hvf-aarch64-cargo-fingerprint-wave-smp8-j8-crate48-hvfopt-wakelocal-nomonitor-20260524T155852.log`
- Full StarryOS guest build PASS, `379s`: `/Users/txc/code/Auto-OS/showtime-2/logs/hvf-aarch64-starryos-smp8-j8-wakelocal-full-opt0-cgu256-20260524T160123.log`
- Same kernel/profile `jobs=1` control PASS, `449s`: `/Users/txc/code/Auto-OS/showtime-2/logs/hvf-aarch64-starryos-smp8-j1-wakelocal-full-opt0-cgu256-nomonitor-20260524T162359.log`
- Clean no-monitor `jobs=8` full build PASS, `498s`: `/Users/txc/code/Auto-OS/showtime-2/logs/hvf-aarch64-starryos-smp8-j8-wakelocal-full-opt0-cgu256-nomonitor-clean-20260524T163310.log`

## Test-suite

新增 `test-suit/arceos/rust/task/wait_queue_remote_wake`，覆盖 SMP wait queue 远端唤醒路径。它不把完整 Cargo build 放进 CI，而是把问题收缩成一个稳定的内核调度/唤醒用例：

- waker 绑定 CPU0。
- sleeper 绑定 CPU1。
- sleeper 在 wait queue 上睡眠。
- waker 从 CPU0 唤醒 CPU1 上的 sleeper。
- sleeper 必须在短时间内完成并打印 `All tests passed!`。

当前 riscv64 QEMU 本地已 PASS。aarch64 暂时按现有 IPI 测试的限制跳过，因为 axplat-dyn 的 send_ipi 路径仍未完全就绪。

## Remaining Risk

- 当前 patch 已经从 `/private/tmp/tgoskits-hvf-opt` 拆到干净 `upstream/dev` 分支，未混入 FS/allocator 实验改动；test-suite 已补，后续需要等待 GitHub Actions 结果再标 ready。
- 完整 self-build 的速度改善是 `951/379 = 2.51x`，严格同 kernel/profile jobs speedup 是 `449/379 = 1.18x`；这个 PR 的主张应是修复 SMP wakeup 前进性，不应包装成 4x 性能 PR。
