### PR TITLE
fix(rsext4): improve journal recovery and MBR partition scanning

### DIFF
--- a/components/rsext4/src/blockdev/cached_device.rs
+++ b/components/rsext4/src/blockdev/cached_device.rs
@@ -127,6 +127,23 @@ impl<B: BlockDevice> BlockDev<B> {
         self.buffer.as_mut_slice()
     }
 
+    /// Replaces the cached block contents without writing to the device.
+    ///
+    /// The caller supplies the exact bytes that should now be considered the
+    /// authoritative content of `block_id` (e.g. a journal-side update or a
+    /// freshly written block). The buffer is overwritten with `data`, the
+    /// cache key is set to `block_id`, and the block is marked clean so that
+    /// no flush is triggered.
+    pub(crate) fn cache_clean_block(
+        &mut self,
+        block_id: AbsoluteBN,
+        data: &[u8; crate::config::BLOCK_SIZE],
+    ) {
+        self.buffer.as_mut_slice().copy_from_slice(data);
+        self.cached_block = Some(block_id);
+        self.is_dirty = false;
+    }
+
     /// Flushes a dirty cached block and the underlying device.
     pub fn flush(&mut self) -> Ext4Result<()> {
         if self.is_dirty

--- a/components/rsext4/src/blockdev/journal.rs
+++ b/components/rsext4/src/blockdev/journal.rs
@@ -190,6 +190,17 @@ impl<B: BlockDevice> Jbd2Dev<B> {
 
     /// Reads one block through the cached inner device.
     pub fn read_block(&mut self, block_id: AbsoluteBN) -> Ext4Result<()> {
+        if self.journal_use
+            && let Some(system) = self.system.as_ref()
+            && let Some(update) = system
+                .commit_queue
+                .iter()
+                .find(|queued| queued.0 == block_id)
+        {
+            self.inner.cache_clean_block(block_id, &update.1);
+            return Ok(());
+        }
+
         self.inner.read_block(block_id)
     }
 

--- a/components/rsext4/src/blockgroup_description/desc.rs
+++ b/components/rsext4/src/blockgroup_description/desc.rs
@@ -123,8 +123,8 @@ impl Ext4GroupDesc {
                 self.used_dirs_count(),
                 self.itable_unused(),
                 self.bg_flags,
-                self.block_bitmap_csum(),
-                self.inode_bitmap_csum()
+                self.block_bitmap_csum(superblock),
+                self.inode_bitmap_csum(superblock)
             );
             return Err(Ext4Error::checksum());
         }
@@ -172,13 +172,21 @@ impl Ext4GroupDesc {
     }
 
     /// Returns the 32-bit block bitmap checksum.
-    pub fn block_bitmap_csum(&self) -> u32 {
-        (self.bg_block_bitmap_csum_hi as u32) << 16 | self.bg_block_bitmap_csum_lo as u32
+    pub fn block_bitmap_csum(&self, superblock: &Ext4Superblock) -> u32 {
+        if superblock.get_desc_size() as usize >= Self::EXT4_DESC_SIZE_64BIT {
+            (self.bg_block_bitmap_csum_hi as u32) << 16 | self.bg_block_bitmap_csum_lo as u32
+        } else {
+            self.bg_block_bitmap_csum_lo as u32
+        }
     }
 
     /// Returns the 32-bit inode bitmap checksum.
-    pub fn inode_bitmap_csum(&self) -> u32 {
-        (self.bg_inode_bitmap_csum_hi as u32) << 16 | self.bg_inode_bitmap_csum_lo as u32
+    pub fn inode_bitmap_csum(&self, superblock: &Ext4Superblock) -> u32 {
+        if superblock.get_desc_size() as usize >= Self::EXT4_DESC_SIZE_64BIT {
+            (self.bg_inode_bitmap_csum_hi as u32) << 16 | self.bg_inode_bitmap_csum_lo as u32
+        } else {
+            self.bg_inode_bitmap_csum_lo as u32
+        }
     }
 
     /// Returns whether a computed bitmap checksum matches this descriptor.
@@ -187,12 +195,12 @@ impl Ext4GroupDesc {
     /// descriptors. The high checksum fields are present only in 64-byte
     /// descriptors.
     pub fn block_bitmap_csum_matches(&self, superblock: &Ext4Superblock, computed: u32) -> bool {
-        Self::bitmap_csum_matches(superblock, self.block_bitmap_csum(), computed)
+        Self::bitmap_csum_matches(superblock, self.block_bitmap_csum(superblock), computed)
     }
 
     /// Returns whether a computed inode bitmap checksum matches this descriptor.
     pub fn inode_bitmap_csum_matches(&self, superblock: &Ext4Superblock, computed: u32) -> bool {
-        Self::bitmap_csum_matches(superblock, self.inode_bitmap_csum(), computed)
+        Self::bitmap_csum_matches(superblock, self.inode_bitmap_csum(superblock), computed)
     }
 
     fn bitmap_csum_matches(superblock: &Ext4Superblock, stored: u32, computed: u32) -> bool {

--- a/components/rsext4/src/ext4/alloc.rs
+++ b/components/rsext4/src/ext4/alloc.rs
@@ -40,13 +40,13 @@ impl Ext4FileSystem {
                     .bitmap_cache
                     .get_or_load(block_dev, cache_key, bitmap_block)?;
                 let expected = ext4_block_bitmap_csum32(&self.superblock, &bm.data);
-                let stored = desc.block_bitmap_csum();
+                let stored = desc.block_bitmap_csum(&self.superblock);
                 if !desc.block_bitmap_csum_matches(&self.superblock, expected) {
                     error!(
                         "alloc_blocks: block bitmap checksum mismatch group={group_idx} \
                          expected={expected:#x} stored={stored:#x}"
                     );
-                    return Err(Ext4Error::checksum());
+                    return Err(Ext4Error::checksum().with_operation("alloc_blocks:block_bitmap"));
                 }
             }
 
@@ -182,7 +182,7 @@ impl Ext4FileSystem {
                     .get_or_load(block_dev, cache_key, bitmap_block)?;
                 let expected = ext4_inode_bitmap_csum32(&self.superblock, &bm.data);
                 if !desc.inode_bitmap_csum_matches(&self.superblock, expected) {
-                    return Err(Ext4Error::checksum());
+                    return Err(Ext4Error::checksum().with_operation("alloc_inode:inode_bitmap"));
                 }
             }
 

--- a/components/rsext4/src/ext4/mkfs.rs
+++ b/components/rsext4/src/ext4/mkfs.rs
@@ -165,10 +165,10 @@ fn mark_block_bitmap_padding(bitmap: &mut [u8], layout: &FsLayoutInfo, group_id:
 
 pub fn mkfs<B: BlockDevice>(block_dev: &mut Jbd2Dev<B>) -> Ext4Result<()> {
     debug!("Start initializing Ext4 filesystem...");
+    let old_journal_use = block_dev.is_use_journal();
     // Disable journaling while laying out the initial filesystem image. The
     // journal inode and journal superblock do not exist yet at this stage.
     block_dev.set_journal_use(false);
-    let old_jouranl_use = block_dev.is_use_journal();
 
     // Compute the full mkfs layout before any on-disk write happens.
     let total_blocks = block_dev.total_blocks();
@@ -235,7 +235,7 @@ pub fn mkfs<B: BlockDevice>(block_dev: &mut Jbd2Dev<B>) -> Ext4Result<()> {
     let verify_sb = read_superblock(block_dev)?;
 
     // Restore the previous journal setting for the caller.
-    block_dev.set_journal_use(old_jouranl_use);
+    block_dev.set_journal_use(old_journal_use);
 
     if verify_sb.s_magic == EXT4_SUPER_MAGIC {
         debug!(

--- a/components/rsext4/src/ext4/mount.rs
+++ b/components/rsext4/src/ext4/mount.rs
@@ -50,6 +50,23 @@ impl Ext4FileSystem {
         self.superblock.s_feature_incompat &= !Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
     }
 
+    fn set_recovery_state(&mut self) {
+        self.superblock.s_feature_incompat |= Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    }
+
+    fn valid_lost_found_hint<B: BlockDevice>(
+        &mut self,
+        block_dev: &mut Jbd2Dev<B>,
+    ) -> Ext4Result<bool> {
+        let ino = self.superblock.s_lpf_ino;
+        if ino == 0 {
+            return Ok(false);
+        }
+
+        let inode = self.get_inode_by_num(block_dev, InodeNumber::new(ino)?)?;
+        Ok(inode.i_mode != 0 && inode.is_dir())
+    }
+
     fn journal_blocks<B: BlockDevice>(
         &mut self,
         block_dev: &mut Jbd2Dev<B>,
@@ -224,6 +241,8 @@ impl Ext4FileSystem {
                     // mounting from the recovered on-disk state.
                     fs.reload_after_journal_replay(block_dev)?;
                     fs.clear_recovery_state();
+                } else if block_dev.is_use_journal() {
+                    fs.set_recovery_state();
                 }
             }
             // If the filesystem was created without a journal (e.g. small images
@@ -236,7 +255,6 @@ impl Ext4FileSystem {
         }
 
         // rootinode check !
-        debug!("Checking root directory...");
         {
             let root_inode = fs.get_root(block_dev).map_err(|e| {
                 error!("Failed to load root inode: {e}");
@@ -254,30 +272,36 @@ impl Ext4FileSystem {
         }
 
         // Verify the recovery directory after the root directory is known good.
-        debug!("Checking lost+found directory...");
         {
-            // Trust the superblock hint when present, but still validate via a
-            // path lookup so stale metadata does not silently pass.
-            if fs.superblock.s_lpf_ino != 0 {
+            if fs.valid_lost_found_hint(block_dev)? {
                 let ino = fs.superblock.s_lpf_ino;
-                debug!("Lost+found inode recorded in superblock: {ino}");
+                info!("/lost+found exists (superblock hint inode={ino})");
             } else {
-                debug!("s_lpf_ino is 0, lost+found inode hint missing in superblock");
-            }
+                if fs.superblock.s_lpf_ino != 0 {
+                    let ino = fs.superblock.s_lpf_ino;
+                    warn!("s_lpf_ino={ino} is not a valid directory, falling back to path scan");
+                }
 
-            match find_file(&mut fs, block_dev, "/lost+found") {
-                Ok(_inode) => {
-                    info!("/lost+found exists (path resolution)");
-                }
-                Err(err) if err.code == Errno::ENOENT => {
-                    info!("/lost+found not found by path scan;will create!");
-                    if create_lost_found_directory(&mut fs, block_dev).is_err() {
-                        warn!("/lost+found missing and create failed");
+                match get_file_inode(&mut fs, block_dev, "/lost+found") {
+                    Ok(Some((ino, inode))) if inode.is_dir() => {
+                        fs.superblock.s_lpf_ino = ino.raw();
+                        fs.sync_superblock(block_dev)?;
+                        info!("/lost+found exists (path resolution, repaired hint inode={ino})");
                     }
-                }
-                Err(err) => {
-                    error!("Failed to resolve /lost+found: {err}");
-                    return Err(err);
+                    Ok(Some((_ino, _inode))) => {
+                        error!("/lost+found exists but is not a directory");
+                        return Err(Ext4Error::corrupted());
+                    }
+                    Ok(None) => {
+                        info!("/lost+found not found by path scan;will create!");
+                        if create_lost_found_directory(&mut fs, block_dev).is_err() {
+                            warn!("/lost+found missing and create failed");
+                        }
+                    }
+                    Err(err) => {
+                        error!("Failed to resolve /lost+found: {err}");
+                        return Err(err);
+                    }
                 }
             }
         }
@@ -310,9 +334,10 @@ impl Ext4FileSystem {
 
             if ext4_superblock_has_metadata_csum(&fs.superblock) {
                 if !g0.is_inode_bitmap_uninit() {
-                    let expected_inode =
+                    let stored_inode = g0.inode_bitmap_csum(&fs.superblock);
+                    let computed_inode =
                         ext4_inode_bitmap_csum32(&fs.superblock, &inode_bitmap_data.data);
-                    let stored_inode = g0.inode_bitmap_csum();
+                    let expected_inode = computed_inode;
                     if !g0.inode_bitmap_csum_matches(&fs.superblock, expected_inode) {
                         error!(
                             "Inode bitmap checksum mismatch group=0 expected={expected_inode:#x} \
@@ -326,9 +351,10 @@ impl Ext4FileSystem {
                 }
 
                 if !g0.is_block_bitmap_uninit() {
-                    let expected_block =
+                    let stored_block = g0.block_bitmap_csum(&fs.superblock);
+                    let computed_block =
                         ext4_block_bitmap_csum32(&fs.superblock, &blockbitmap_data.data);
-                    let stored_block = g0.block_bitmap_csum();
+                    let expected_block = computed_block;
                     if !g0.block_bitmap_csum_matches(&fs.superblock, expected_block) {
                         error!(
                             "Block bitmap checksum mismatch group=0 expected={expected_block:#x} \
@@ -389,6 +415,7 @@ impl Ext4FileSystem {
         // The superblock is written with EXT4_VALID_FS cleared so a later mount
         // can distinguish an unclean shutdown from a real EXT4_ERROR_FS state.
         fs.sync_filesystem(block_dev)?;
+        block_dev.umount_commit();
 
         Ok(fs)
     }

--- a/components/rsext4/src/ext4/sync.rs
+++ b/components/rsext4/src/ext4/sync.rs
@@ -31,6 +31,7 @@ impl Ext4FileSystem {
         // Mark clean in memory first so that sync_filesystem writes the
         // superblock with s_state = EXT4_VALID_FS through the journal.
         self.superblock.s_state = Self::clean_state(&self.superblock);
+        self.superblock.s_feature_incompat &= !Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
 
         self.sync_filesystem(block_dev)?;
 

--- a/components/rsext4/src/jbd2/jbd2.rs
+++ b/components/rsext4/src/jbd2/jbd2.rs
@@ -26,6 +26,12 @@ struct ReplayTag {
     flags: u32,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ReplayPayload {
+    tag: ReplayTag,
+    journal_rel: u32,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ReplayStatus {
     Complete,
@@ -34,9 +40,22 @@ pub(crate) enum ReplayStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReplayScan {
-    CleanEnd,
-    Incomplete { restart_rel: u32 },
-    Applied { next_rel: u32, next_seq: u32 },
+    CleanEnd {
+        records: u32,
+    },
+    Incomplete {
+        restart_rel: u32,
+        records: u32,
+    },
+    Applied {
+        next_rel: u32,
+        next_seq: u32,
+        records: u32,
+        payloads: usize,
+        applied_payloads: usize,
+        journal_read_ops: usize,
+        home_write_ops: usize,
+    },
 }
 
 struct ReplayRing<'a> {
@@ -492,11 +511,6 @@ impl JBD2DEVSYSTEM {
         Ok(true)
     }
 
-    /// Replays as many complete committed transactions as possible.
-    pub fn replay<B: BlockDevice>(&mut self, block_dev: &mut B) {
-        let _ = self.replay_with_mapping(block_dev, &[]);
-    }
-
     fn replay_one_transaction<B: BlockDevice>(
         &self,
         block_dev: &mut B,
@@ -505,15 +519,19 @@ impl JBD2DEVSYSTEM {
         expect_seq: u32,
     ) -> ReplayScan {
         let mut record_rel = start_rel;
-        let mut meta_blocks: Vec<(ReplayTag, [u8; BLOCK_SIZE])> = Vec::new();
+        let mut payloads: Vec<ReplayPayload> = Vec::new();
         let mut revoked_blocks = BTreeSet::new();
+        let max_records = ring.last_rel - ring.first_rel + 1;
+        let mut records = 0u32;
 
-        loop {
+        for _ in 0..max_records {
+            records = records.saturating_add(1);
             let record_phys = match ring.phys(record_rel) {
                 Ok(block) => block,
                 Err(_) => {
                     return ReplayScan::Incomplete {
                         restart_rel: start_rel,
+                        records,
                     };
                 }
             };
@@ -525,6 +543,7 @@ impl JBD2DEVSYSTEM {
                 );
                 return ReplayScan::Incomplete {
                     restart_rel: start_rel,
+                    records,
                 };
             }
 
@@ -536,56 +555,40 @@ impl JBD2DEVSYSTEM {
             );
 
             if hdr.h_magic != JBD2_MAGIC || hdr.h_sequence != expect_seq {
-                return if record_rel == start_rel {
-                    ReplayScan::CleanEnd
-                } else {
-                    ReplayScan::Incomplete {
-                        restart_rel: start_rel,
-                    }
-                };
+                return ReplayScan::CleanEnd { records };
             }
 
             match hdr.h_blocktype {
                 JBD2_BLOCKTYPE_DESCRIPTOR => {
                     let tags = match self.parse_replay_tags(&record_buf, expect_seq) {
                         Some(tags) if !tags.is_empty() => tags,
-                        _ => {
+                        Some(tags) => tags,
+                        None => {
                             return ReplayScan::Incomplete {
                                 restart_rel: start_rel,
+                                records,
                             };
                         }
                     };
 
-                    for (idx, tag) in tags.iter().enumerate() {
+                    for tag in tags {
                         ring.advance(&mut record_rel);
-                        let meta_phys = match ring.phys(record_rel) {
-                            Ok(block) => block,
-                            Err(_) => {
-                                return ReplayScan::Incomplete {
-                                    restart_rel: start_rel,
-                                };
-                            }
-                        };
-                        let mut mbuf = [0u8; BLOCK_SIZE];
-                        if let Err(e) = block_dev.read(&mut mbuf, meta_phys, 1) {
-                            debug!(
-                                "[JBD2 replay] read meta block failed: idx={idx} \
-                                 rel_block={record_rel} phys_block={meta_phys} err={e:?}"
-                            );
+                        if ring.phys(record_rel).is_err() {
                             return ReplayScan::Incomplete {
                                 restart_rel: start_rel,
+                                records,
                             };
                         }
-                        debug!(
-                            "[JBD2 replay] tid={expect_seq} loaded meta_idx={idx} from \
-                             rel_block={record_rel} phys_block={meta_phys}"
-                        );
-                        meta_blocks.push((*tag, mbuf));
+                        payloads.push(ReplayPayload {
+                            tag,
+                            journal_rel: record_rel,
+                        });
                     }
                 }
                 JBD2_BLOCKTYPE_COMMIT => {
-                    for (idx, (tag, data)) in meta_blocks.iter_mut().enumerate() {
-                        let phys = tag.block;
+                    let mut committed: Vec<(usize, ReplayPayload, AbsoluteBN)> = Vec::new();
+                    for (idx, payload) in payloads.iter().copied().enumerate() {
+                        let phys = payload.tag.block;
                         if revoked_blocks.contains(&phys) {
                             debug!(
                                 "[JBD2 replay] tid={expect_seq} skip revoked meta_idx={idx} \
@@ -594,29 +597,102 @@ impl JBD2DEVSYSTEM {
                             continue;
                         }
 
-                        if (tag.flags & u32::from(JOURNAL_ESCAPE)) != 0 {
-                            data[0..4].copy_from_slice(&JBD2_MAGIC.to_be_bytes());
-                            debug!("[JBD2 replay] restored escaped journal magic for block {phys}");
-                        }
-                        debug!(
-                            "[JBD2 replay] tid={expect_seq} apply meta_idx={idx} phys_block={phys}"
-                        );
+                        let meta_phys = match ring.phys(payload.journal_rel) {
+                            Ok(block) => block,
+                            Err(_) => {
+                                return ReplayScan::Incomplete {
+                                    restart_rel: start_rel,
+                                    records,
+                                };
+                            }
+                        };
+                        committed.push((idx, payload, meta_phys));
+                    }
 
-                        if let Err(e) = block_dev.write(data, phys, 1) {
+                    let mut applied_payloads = 0usize;
+                    let mut journal_read_ops = 0usize;
+                    let mut home_write_ops = 0usize;
+                    let mut pos = 0usize;
+                    while pos < committed.len() {
+                        let run_start = pos;
+                        let mut run_end = pos + 1;
+                        while run_end < committed.len()
+                            && committed[run_end].2.raw()
+                                == committed[run_end - 1].2.raw().saturating_add(1)
+                        {
+                            run_end += 1;
+                        }
+
+                        let run_len = run_end - run_start;
+                        let first_journal = committed[run_start].2;
+                        let mut data = vec![0u8; run_len * BLOCK_SIZE];
+                        if let Err(e) = block_dev.read(&mut data, first_journal, run_len as u32) {
                             debug!(
-                                "[JBD2 replay] write meta block failed: idx={idx} \
-                                 phys_block={phys} err={e:?}"
+                                "[JBD2 replay] read committed meta run failed: start_idx={} \
+                                 phys_block={} count={} err={e:?}",
+                                committed[run_start].0, first_journal, run_len
                             );
                             return ReplayScan::Incomplete {
                                 restart_rel: start_rel,
+                                records,
                             };
                         }
-                    }
-                    if let Err(e) = block_dev.flush() {
-                        debug!("[JBD2 replay] flush after transaction failed: err={e:?}");
-                        return ReplayScan::Incomplete {
-                            restart_rel: start_rel,
-                        };
+                        journal_read_ops = journal_read_ops.saturating_add(1);
+
+                        let mut write_start = 0usize;
+                        while write_start < run_len {
+                            let first = run_start + write_start;
+                            let first_home = committed[first].1.tag.block;
+                            let mut write_end = write_start + 1;
+                            while write_end < run_len {
+                                let prev = run_start + write_end - 1;
+                                let next = run_start + write_end;
+                                let prev_home = committed[prev].1.tag.block.raw();
+                                let next_home = committed[next].1.tag.block.raw();
+                                if next_home != prev_home.saturating_add(1) {
+                                    break;
+                                }
+                                write_end += 1;
+                            }
+
+                            for rel_idx in write_start..write_end {
+                                let absolute_idx = run_start + rel_idx;
+                                let (idx, payload, _) = committed[absolute_idx];
+                                let off = rel_idx * BLOCK_SIZE;
+                                if (payload.tag.flags & u32::from(JOURNAL_ESCAPE)) != 0 {
+                                    data[off..off + 4].copy_from_slice(&JBD2_MAGIC.to_be_bytes());
+                                    debug!(
+                                        "[JBD2 replay] restored escaped journal magic for block {}",
+                                        payload.tag.block
+                                    );
+                                }
+                                debug!(
+                                    "[JBD2 replay] tid={expect_seq} apply meta_idx={idx} \
+                                     phys_block={}",
+                                    payload.tag.block
+                                );
+                            }
+
+                            let off = write_start * BLOCK_SIZE;
+                            let bytes = &data[off..write_end * BLOCK_SIZE];
+                            let write_count = write_end - write_start;
+                            if let Err(e) = block_dev.write(bytes, first_home, write_count as u32) {
+                                debug!(
+                                    "[JBD2 replay] write meta run failed: start_idx={} \
+                                     home_block={} count={} err={e:?}",
+                                    committed[first].0, first_home, write_count
+                                );
+                                return ReplayScan::Incomplete {
+                                    restart_rel: start_rel,
+                                    records,
+                                };
+                            }
+                            home_write_ops = home_write_ops.saturating_add(1);
+                            applied_payloads = applied_payloads.saturating_add(write_count);
+                            write_start = write_end;
+                        }
+
+                        pos = run_end;
                     }
 
                     let mut next_rel = record_rel;
@@ -624,6 +700,11 @@ impl JBD2DEVSYSTEM {
                     return ReplayScan::Applied {
                         next_rel,
                         next_seq: expect_seq.wrapping_add(1),
+                        records,
+                        payloads: payloads.len(),
+                        applied_payloads,
+                        journal_read_ops,
+                        home_write_ops,
                     };
                 }
                 JBD2_BLOCKTYPE_REVOKE => {
@@ -632,23 +713,23 @@ impl JBD2DEVSYSTEM {
                         None => {
                             return ReplayScan::Incomplete {
                                 restart_rel: start_rel,
+                                records,
                             };
                         }
                     };
                     revoked_blocks.extend(blocks);
                 }
                 _ => {
-                    return if record_rel == start_rel {
-                        ReplayScan::CleanEnd
-                    } else {
-                        ReplayScan::Incomplete {
-                            restart_rel: start_rel,
-                        }
-                    };
+                    return ReplayScan::CleanEnd { records };
                 }
             }
 
             ring.advance(&mut record_rel);
+        }
+
+        ReplayScan::Incomplete {
+            restart_rel: start_rel,
+            records,
         }
     }
 
@@ -692,9 +773,32 @@ impl JBD2DEVSYSTEM {
             self.start_block, ring.first_rel, ring.last_rel, journal_rel, maxlen, expect_seq,
         );
 
+        let mut total_transactions = 0usize;
+        let mut total_records = 0u64;
+        let mut total_payloads = 0usize;
+        let mut total_applied_payloads = 0usize;
+        let mut total_journal_read_ops = 0usize;
+        let mut total_home_write_ops = 0usize;
+
         let status = loop {
             match self.replay_one_transaction(block_dev, &ring, journal_rel, expect_seq) {
-                ReplayScan::Applied { next_rel, next_seq } => {
+                ReplayScan::Applied {
+                    next_rel,
+                    next_seq,
+                    records,
+                    payloads,
+                    applied_payloads,
+                    journal_read_ops,
+                    home_write_ops,
+                } => {
+                    total_transactions = total_transactions.saturating_add(1);
+                    total_records = total_records.saturating_add(u64::from(records));
+                    total_payloads = total_payloads.saturating_add(payloads);
+                    total_applied_payloads =
+                        total_applied_payloads.saturating_add(applied_payloads);
+                    total_journal_read_ops =
+                        total_journal_read_ops.saturating_add(journal_read_ops);
+                    total_home_write_ops = total_home_write_ops.saturating_add(home_write_ops);
                     journal_rel = next_rel;
                     expect_seq = next_seq;
                     self.jbd2_super_block.s_start = journal_rel;
@@ -705,11 +809,18 @@ impl JBD2DEVSYSTEM {
                         self.jbd2_super_block.s_sequence, self.jbd2_super_block.s_start
                     );
                 }
-                ReplayScan::CleanEnd => {
+                ReplayScan::CleanEnd { records } => {
+                    total_records = total_records.saturating_add(u64::from(records));
                     self.jbd2_super_block.s_start = 0;
+                    self.jbd2_super_block.s_sequence = expect_seq;
+                    self.sequence = expect_seq;
                     break ReplayStatus::Complete;
                 }
-                ReplayScan::Incomplete { restart_rel } => {
+                ReplayScan::Incomplete {
+                    restart_rel,
+                    records,
+                } => {
+                    total_records = total_records.saturating_add(u64::from(records));
                     self.jbd2_super_block.s_start = restart_rel;
                     self.jbd2_super_block.s_sequence = expect_seq;
                     self.sequence = expect_seq;
@@ -734,8 +845,17 @@ impl JBD2DEVSYSTEM {
             let _ = block_dev.flush();
         }
         debug!(
-            "[JBD2 replay] end: final_sequence={} final_s_start={} ",
-            self.jbd2_super_block.s_sequence, self.jbd2_super_block.s_start
+            "[JBD2 replay] end: status={status:?} transactions={} records={} payloads={} \
+             applied_payloads={} journal_read_ops={} home_write_ops={} final_sequence={} \
+             final_s_start={}",
+            total_transactions,
+            total_records,
+            total_payloads,
+            total_applied_payloads,
+            total_journal_read_ops,
+            total_home_write_ops,
+            self.jbd2_super_block.s_sequence,
+            self.jbd2_super_block.s_start
         );
 
         status

--- a/components/rsext4/tests/crc_integrity.rs
+++ b/components/rsext4/tests/crc_integrity.rs
@@ -20,7 +20,11 @@ use rsext4::{
     },
     endian::DiskFormat,
     error::{Errno, Ext4Error, Ext4Result},
-    jbd2::jbdstruct::{JBD2_BLOCKTYPE_DESCRIPTOR, JBD2_MAGIC, JournalHeaderS, JournalSuperBllockS},
+    jbd2::jbdstruct::{
+        JBD2_BLOCKTYPE_DESCRIPTOR, JBD2_BLOCKTYPE_REVOKE, JBD2_FLAG_LAST_TAG, JBD2_FLAG_SAME_UUID,
+        JBD2_MAGIC, JBD2_UUID_SIZE, JournalBlockTagS, JournalHeaderS, JournalSuperBllockS,
+    },
+    loopfile::resolve_inode_block,
     superblock::Ext4Superblock,
     *,
 };
@@ -32,6 +36,7 @@ struct SharedCrcDevice {
     data: Rc<RefCell<Vec<u8>>>,
     block_size: u32,
     now: Rc<Cell<i64>>,
+    blocked_read_block: Rc<Cell<Option<u64>>>,
 }
 
 impl SharedCrcDevice {
@@ -40,6 +45,7 @@ impl SharedCrcDevice {
             data: Rc::new(RefCell::new(vec![0; size])),
             block_size: BLOCK_SIZE as u32,
             now: Rc::new(Cell::new(1_700_000_000)),
+            blocked_read_block: Rc::new(Cell::new(None)),
         }
     }
 
@@ -62,6 +68,9 @@ impl SharedCrcDevice {
 
 impl BlockDevice for SharedCrcDevice {
     fn read(&mut self, buffer: &mut [u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+        if self.blocked_read_block.get() == Some(block_id.raw()) {
+            return Err(Ext4Error::io());
+        }
         let start = block_id.as_usize()? * self.block_size as usize;
         let end = start + buffer.len();
         if end > self.data.borrow().len() {
@@ -174,6 +183,121 @@ fn write_incomplete_journal_descriptor(device: &SharedCrcDevice, journal_block: 
     device.write_block_bytes(journal_block + 1, &descriptor);
 }
 
+fn write_uncommitted_journal_update(
+    device: &SharedCrcDevice,
+    journal_block: u64,
+    target_block: u64,
+    payload: &[u8],
+) {
+    let bytes = device.read_block_bytes(journal_block);
+    let journal_sb = JournalSuperBllockS::from_disk_bytes(&bytes);
+
+    let mut descriptor = vec![0u8; BLOCK_SIZE];
+    JournalHeaderS {
+        h_magic: JBD2_MAGIC,
+        h_blocktype: JBD2_BLOCKTYPE_DESCRIPTOR,
+        h_sequence: journal_sb.s_sequence,
+    }
+    .to_disk_bytes(&mut descriptor);
+    JournalBlockTagS {
+        t_blocknr: target_block as u32,
+        t_checksum: 0,
+        t_flags: JBD2_FLAG_LAST_TAG,
+    }
+    .to_disk_bytes(&mut descriptor[12..20]);
+    descriptor[20..20 + JBD2_UUID_SIZE].copy_from_slice(&journal_sb.s_uuid);
+    device.write_block_bytes(journal_block + 1, &descriptor);
+
+    let mut metadata = vec![0u8; BLOCK_SIZE];
+    metadata[..payload.len()].copy_from_slice(payload);
+    device.write_block_bytes(journal_block + 2, &metadata);
+}
+
+fn write_invalid_journal_revoke(device: &SharedCrcDevice, journal_block: u64) {
+    let bytes = device.read_block_bytes(journal_block);
+    let journal_sb = JournalSuperBllockS::from_disk_bytes(&bytes);
+
+    let mut revoke = vec![0u8; BLOCK_SIZE];
+    JournalHeaderS {
+        h_magic: JBD2_MAGIC,
+        h_blocktype: JBD2_BLOCKTYPE_REVOKE,
+        h_sequence: journal_sb.s_sequence,
+    }
+    .to_disk_bytes(&mut revoke);
+    revoke[12..16].copy_from_slice(&((BLOCK_SIZE as u32) + 1).to_be_bytes());
+    device.write_block_bytes(journal_block + 1, &revoke);
+}
+
+fn write_repeating_journal_descriptors(device: &SharedCrcDevice, journal_block: u64) {
+    let bytes = device.read_block_bytes(journal_block);
+    let journal_sb = JournalSuperBllockS::from_disk_bytes(&bytes);
+
+    let mut descriptor = vec![0u8; BLOCK_SIZE];
+    JournalHeaderS {
+        h_magic: JBD2_MAGIC,
+        h_blocktype: JBD2_BLOCKTYPE_DESCRIPTOR,
+        h_sequence: journal_sb.s_sequence,
+    }
+    .to_disk_bytes(&mut descriptor);
+    JournalBlockTagS {
+        t_blocknr: (journal_block - 1) as u32,
+        t_checksum: 0,
+        t_flags: JBD2_FLAG_LAST_TAG,
+    }
+    .to_disk_bytes(&mut descriptor[12..20]);
+    descriptor[20..20 + JBD2_UUID_SIZE].copy_from_slice(&journal_sb.s_uuid);
+
+    for rel in journal_sb.s_first..journal_sb.s_maxlen {
+        device.write_block_bytes(journal_block + u64::from(rel), &descriptor);
+    }
+}
+
+fn write_uncommitted_journal_updates(
+    device: &SharedCrcDevice,
+    journal_block: u64,
+    target_blocks: &[u64],
+) {
+    let bytes = device.read_block_bytes(journal_block);
+    let journal_sb = JournalSuperBllockS::from_disk_bytes(&bytes);
+
+    let mut descriptor = vec![0u8; BLOCK_SIZE];
+    JournalHeaderS {
+        h_magic: JBD2_MAGIC,
+        h_blocktype: JBD2_BLOCKTYPE_DESCRIPTOR,
+        h_sequence: journal_sb.s_sequence,
+    }
+    .to_disk_bytes(&mut descriptor);
+
+    let mut offset = 12usize;
+    for (idx, target) in target_blocks.iter().enumerate() {
+        let mut flags = 0;
+        if idx > 0 {
+            flags |= JBD2_FLAG_SAME_UUID;
+        }
+        if idx == target_blocks.len() - 1 {
+            flags |= JBD2_FLAG_LAST_TAG;
+        }
+        JournalBlockTagS {
+            t_blocknr: *target as u32,
+            t_checksum: 0,
+            t_flags: flags,
+        }
+        .to_disk_bytes(&mut descriptor[offset..offset + 8]);
+        offset += 8;
+        if idx == 0 {
+            descriptor[offset..offset + JBD2_UUID_SIZE].copy_from_slice(&journal_sb.s_uuid);
+            offset += JBD2_UUID_SIZE;
+        }
+    }
+    device.write_block_bytes(journal_block + 1, &descriptor);
+
+    for (idx, _) in target_blocks.iter().enumerate() {
+        let mut metadata = vec![0u8; BLOCK_SIZE];
+        metadata[..8].copy_from_slice(&(idx as u64).to_le_bytes());
+        device.write_block_bytes(journal_block + 2 + idx as u64, &metadata);
+    }
+}
+
 #[test]
 fn checksums_are_persisted_and_clean_remount_preserves_the_written_file() {
     // Test idea: write one real file, inspect the raw on-disk checksum fields,
@@ -197,11 +321,11 @@ fn checksums_are_persisted_and_clean_remount_preserves_the_written_file() {
     let block_bitmap = device.read_block_bytes(desc.block_bitmap());
     let inode_bitmap = device.read_block_bytes(desc.inode_bitmap());
     assert_eq!(
-        desc.block_bitmap_csum(),
+        desc.block_bitmap_csum(&sb),
         ext4_block_bitmap_csum32(&sb, &block_bitmap)
     );
     assert_eq!(
-        desc.inode_bitmap_csum(),
+        desc.inode_bitmap_csum(&sb),
         ext4_inode_bitmap_csum32(&sb, &inode_bitmap)
     );
 
@@ -238,11 +362,13 @@ fn old_32_byte_descriptors_match_low_16_bits_of_bitmap_checksums() {
 }
 
 #[test]
-fn clean_mount_does_not_replay_journal_without_recovery_feature() {
-    // Test idea: normal journaled operation may leave a non-zero journal
-    // superblock start value, but ext4 recovery is driven by the superblock
-    // needs_recovery bit. A clean mount should initialize journal state for
-    // future writes without treating the journal as mandatory recovery input.
+fn incomplete_journal_is_not_replayed_when_recovery_flag_is_clear() {
+    // Test idea: ext4 recovery is driven by the superblock needs_recovery bit,
+    // not by leftover journal state. If we clear that bit on disk and leave a
+    // deliberately broken journal descriptor behind, the next mount must
+    // ignore the journal contents instead of trying to replay them. The mount
+    // itself will still set needs_recovery for its own writable session, and a
+    // clean umount must clear it again before the test ends.
     let device = SharedCrcDevice::new(100 * 1024 * 1024);
     let mut jbd2_dev = new_jbd2_dev(device.clone());
     mkfs(&mut jbd2_dev).expect("mkfs failed");
@@ -262,14 +388,252 @@ fn clean_mount_does_not_replay_journal_without_recovery_feature() {
     write_journal_start(&device, journal_block, 1);
     write_incomplete_journal_descriptor(&device, journal_block);
 
+    let clean_mount_sb = read_superblock(&device);
+    assert_eq!(
+        clean_mount_sb.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
+        0
+    );
+
     let mut remount_dev = new_jbd2_dev(device.clone());
     let fs = mount(&mut remount_dev).expect("clean mount should not force journal replay");
-    assert_eq!(
+    assert_ne!(
         fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
         0
     );
     assert!(remount_dev.is_use_journal());
     umount(fs, &mut remount_dev).expect("umount failed");
+
+    let clean_unmount_sb = read_superblock(&device);
+    assert_eq!(
+        clean_unmount_sb.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
+        0
+    );
+    assert_ne!(clean_unmount_sb.s_lpf_ino, 0);
+}
+
+#[test]
+fn uncommitted_journal_tail_is_discarded_during_recovery() {
+    // Test idea: an unclean shutdown may leave a descriptor for a transaction
+    // that never reached its commit block. The transaction is not durable, so
+    // recovery must discard the tail instead of failing the whole mount.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_block = fs
+        .journal_sb_block_start
+        .expect("journal superblock should be mapped")
+        .raw();
+    umount(fs, &mut first_mount_dev).expect("umount failed");
+
+    let mut sb = read_superblock(&device);
+    sb.s_feature_incompat |= Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    sb.update_checksum();
+    write_superblock(&device, &sb);
+    let target_block = journal_block - 1;
+    let original_target = device.read_block_bytes(target_block);
+    write_journal_start(&device, journal_block, 1);
+    write_uncommitted_journal_update(
+        &device,
+        journal_block,
+        target_block,
+        b"uncommitted metadata payload",
+    );
+
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut remount_dev).expect("mount should discard uncommitted journal tail");
+    assert_eq!(
+        fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
+        0
+    );
+    umount(fs, &mut remount_dev).expect("umount failed");
+
+    assert_eq!(device.read_block_bytes(target_block), original_target);
+
+    let recovered_journal = device.read_block_bytes(journal_block);
+    let recovered_journal_sb = JournalSuperBllockS::from_disk_bytes(&recovered_journal);
+    assert_eq!(recovered_journal_sb.s_start, 0);
+}
+
+#[test]
+fn uncommitted_journal_tail_does_not_read_payload_blocks() {
+    // Test idea: Linux JBD2 first scans control records to find a commit block.
+    // Payload blocks from an uncommitted transaction must not be read during recovery.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_block = fs
+        .journal_sb_block_start
+        .expect("journal superblock should be mapped")
+        .raw();
+    umount(fs, &mut first_mount_dev).expect("umount failed");
+
+    let mut sb = read_superblock(&device);
+    sb.s_feature_incompat |= Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    sb.update_checksum();
+    write_superblock(&device, &sb);
+    write_journal_start(&device, journal_block, 1);
+    write_uncommitted_journal_updates(
+        &device,
+        journal_block,
+        &[journal_block - 1, journal_block - 2],
+    );
+    device.blocked_read_block.set(Some(journal_block + 2));
+
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut remount_dev).expect("uncommitted payload should not be read");
+    assert_eq!(
+        fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
+        0
+    );
+    umount(fs, &mut remount_dev).expect("umount failed");
+}
+
+#[test]
+fn invalid_revoke_record_fails_recovery() {
+    // Test idea: Linux JBD2 treats an expected-sequence revoke block with an
+    // invalid record count as journal corruption, not as an uncommitted tail.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_block = fs
+        .journal_sb_block_start
+        .expect("journal superblock should be mapped")
+        .raw();
+    umount(fs, &mut first_mount_dev).expect("umount failed");
+
+    let mut sb = read_superblock(&device);
+    sb.s_feature_incompat |= Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    sb.update_checksum();
+    write_superblock(&device, &sb);
+    write_journal_start(&device, journal_block, 1);
+    write_invalid_journal_revoke(&device, journal_block);
+
+    let mut remount_dev = new_jbd2_dev(device);
+    let err = match mount(&mut remount_dev) {
+        Ok(_) => panic!("invalid revoke block should fail recovery"),
+        Err(err) => err,
+    };
+    assert_eq!(err.code, Errno::EUCLEAN);
+}
+
+#[test]
+fn empty_descriptor_header_is_discarded_during_recovery() {
+    // Test idea: a crash can leave only the descriptor header without any tags.
+    // With no commit block, this is an uncommitted tail rather than durable work.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_block = fs
+        .journal_sb_block_start
+        .expect("journal superblock should be mapped")
+        .raw();
+    umount(fs, &mut first_mount_dev).expect("umount failed");
+
+    let mut sb = read_superblock(&device);
+    sb.s_feature_incompat |= Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    sb.update_checksum();
+    write_superblock(&device, &sb);
+    write_journal_start(&device, journal_block, 1);
+    write_incomplete_journal_descriptor(&device, journal_block);
+
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut remount_dev).expect("mount should discard empty descriptor tail");
+    assert_eq!(
+        fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
+        0
+    );
+    umount(fs, &mut remount_dev).expect("umount failed");
+}
+
+#[test]
+fn replay_scan_is_bounded_by_journal_ring_length() {
+    // Test idea: malformed journal contents that keep looking like the expected
+    // sequence must not make recovery loop forever around the journal ring.
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_block = fs
+        .journal_sb_block_start
+        .expect("journal superblock should be mapped")
+        .raw();
+    umount(fs, &mut first_mount_dev).expect("umount failed");
+
+    let mut sb = read_superblock(&device);
+    sb.s_feature_incompat |= Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    sb.update_checksum();
+    write_superblock(&device, &sb);
+    write_journal_start(&device, journal_block, 1);
+    write_repeating_journal_descriptors(&device, journal_block);
+
+    let mut remount_dev = new_jbd2_dev(device);
+    let err = match mount(&mut remount_dev) {
+        Ok(_) => panic!("cyclic journal scan should fail recovery"),
+        Err(err) => err,
+    };
+    assert_eq!(err.code, Errno::EUCLEAN);
+}
+
+#[test]
+fn path_resolved_lost_found_rebuilds_superblock_hint() {
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let clean_sb = read_superblock(&device);
+    assert_ne!(clean_sb.s_lpf_ino, 0);
+
+    let mut missing_hint = clean_sb;
+    missing_hint.s_lpf_ino = 0;
+    missing_hint.update_checksum();
+    write_superblock(&device, &missing_hint);
+
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut remount_dev).expect("mount should resolve existing lost+found");
+    assert_ne!(fs.superblock.s_lpf_ino, 0);
+    assert_eq!(fs.superblock.s_lpf_ino, clean_sb.s_lpf_ino);
+    umount(fs, &mut remount_dev).expect("umount failed");
+
+    let repaired_sb = read_superblock(&device);
+    assert_eq!(repaired_sb.s_lpf_ino, clean_sb.s_lpf_ino);
+}
+
+#[test]
+fn mount_uses_valid_lost_found_hint_without_root_path_scan() {
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut inspect_dev = new_jbd2_dev(device.clone());
+    let mut fs = mount(&mut inspect_dev).expect("mount failed");
+    let mut root = fs.get_root(&mut inspect_dev).expect("root inode");
+    let root_block = resolve_inode_block(&mut inspect_dev, &mut root, 0)
+        .expect("resolve root block")
+        .expect("root directory block")
+        .raw();
+    umount(fs, &mut inspect_dev).expect("umount failed");
+
+    let clean_sb = read_superblock(&device);
+    assert_ne!(clean_sb.s_lpf_ino, 0);
+
+    device.blocked_read_block.set(Some(root_block));
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut remount_dev).expect("mount should trust valid lost+found hint");
+    assert_eq!(fs.superblock.s_lpf_ino, clean_sb.s_lpf_ino);
 }
 
 #[test]

--- a/os/arceos/modules/axfs/src/partition.rs
+++ b/os/arceos/modules/axfs/src/partition.rs
@@ -114,7 +114,20 @@ pub fn scan_gpt_partitions(disk: &mut Disk) -> AxResult<Vec<PartitionInfo>> {
         }
     }
 
-    // If both GPT fail, treat the whole disk as a single partition
+    match parse_mbr_partitions(disk, disk_size) {
+        Ok(partitions) if !partitions.is_empty() => {
+            info!("Found {} MBR partitions", partitions.len());
+            return Ok(partitions);
+        }
+        Ok(_) => {
+            info!("No MBR partitions found");
+        }
+        Err(e) => {
+            warn!("Failed to parse MBR: {:?}", e);
+        }
+    }
+
+    // If both GPT and MBR fail, treat the whole disk as a single partition
     warn!("No partition table found, treating whole disk as single partition");
     let filesystem_type = detect_filesystem_type(disk, 0);
     let partition = PartitionInfo {
@@ -124,12 +137,216 @@ pub fn scan_gpt_partitions(disk: &mut Disk) -> AxResult<Vec<PartitionInfo>> {
         unique_partition_guid: [0; 16],
         filesystem_uuid: None,
         starting_lba: 0,
-        ending_lba: disk_size / 512,
+        ending_lba: disk_size.saturating_div(512).saturating_sub(1),
         size_bytes: disk_size,
         filesystem_type,
     };
 
     Ok(vec![partition])
+}
+
+fn parse_mbr_partitions(disk: &mut Disk, disk_size: u64) -> AxResult<Vec<PartitionInfo>> {
+    let mut sector = [0u8; 512];
+    disk.set_position(0);
+    read_exact(disk, &mut sector).map_err(|_| AxError::InvalidData)?;
+
+    let disk_blocks = disk_size.saturating_div(512);
+    let mut partitions =
+        parse_mbr_partition_entries_with_reader(&sector, disk_blocks, |lba, sector| {
+            disk.set_position(lba * 512);
+            read_exact(disk, sector).map_err(|_| AxError::InvalidData)
+        })?;
+    for partition in &mut partitions {
+        partition.filesystem_type = detect_filesystem_type(disk, partition.starting_lba);
+        partition.filesystem_uuid = partition
+            .filesystem_type
+            .as_ref()
+            .and_then(|fs| read_filesystem_uuid_simple(disk, partition.starting_lba, fs));
+        info!(
+            "Found MBR partition {}: '{}' ({} bytes) with filesystem: {:?}, UUID: {:?}",
+            partition.index,
+            partition.name,
+            partition.size_bytes,
+            partition.filesystem_type,
+            partition.filesystem_uuid,
+        );
+    }
+
+    Ok(partitions)
+}
+
+#[cfg(test)]
+fn parse_mbr_partition_entries(
+    sector: &[u8; 512],
+    disk_blocks: u64,
+) -> AxResult<Vec<PartitionInfo>> {
+    parse_mbr_partition_entries_with_reader(sector, disk_blocks, |_, _| Err(AxError::Unsupported))
+}
+
+fn parse_mbr_partition_entries_with_reader(
+    sector: &[u8; 512],
+    disk_blocks: u64,
+    mut read_sector: impl FnMut(u64, &mut [u8; 512]) -> AxResult,
+) -> AxResult<Vec<PartitionInfo>> {
+    if !has_mbr_signature(sector) {
+        return Err(AxError::InvalidData);
+    }
+
+    let mut partitions = Vec::new();
+    for index in 0..4 {
+        let entry = MbrPartitionEntry::parse(sector, index);
+        if entry.is_unused() || entry.is_protective() {
+            continue;
+        }
+        if entry.is_extended() {
+            parse_extended_mbr_partitions(
+                entry.starting_lba,
+                disk_blocks,
+                &mut read_sector,
+                &mut partitions,
+            )?;
+            continue;
+        }
+        push_mbr_partition(&mut partitions, index as u32, entry, disk_blocks);
+    }
+
+    Ok(partitions)
+}
+
+fn parse_extended_mbr_partitions(
+    extended_base_lba: u64,
+    disk_blocks: u64,
+    read_sector: &mut impl FnMut(u64, &mut [u8; 512]) -> AxResult,
+    partitions: &mut Vec<PartitionInfo>,
+) -> AxResult {
+    let mut ebr_lba = extended_base_lba;
+    let mut visited = 0;
+    while visited < 128 {
+        let mut sector = [0u8; 512];
+        read_sector(ebr_lba, &mut sector)?;
+        if !has_mbr_signature(&sector) {
+            warn!(
+                "Stopping extended MBR scan at LBA {}: invalid EBR signature",
+                ebr_lba
+            );
+            break;
+        }
+
+        let logical = MbrPartitionEntry::parse(&sector, 0);
+        if !logical.is_unused() && !logical.is_extended() && !logical.is_protective() {
+            let Some(starting_lba) = ebr_lba.checked_add(logical.starting_lba) else {
+                warn!("Skipping logical MBR partition with overflowing start LBA");
+                break;
+            };
+            let entry = MbrPartitionEntry {
+                starting_lba,
+                ..logical
+            };
+            push_mbr_partition(partitions, partitions.len() as u32 + 4, entry, disk_blocks);
+        }
+
+        let next = MbrPartitionEntry::parse(&sector, 1);
+        if !next.is_extended() || next.starting_lba == 0 || next.sector_count == 0 {
+            break;
+        }
+        let Some(next_ebr_lba) = extended_base_lba.checked_add(next.starting_lba) else {
+            warn!("Stopping extended MBR scan after overflowing next EBR LBA");
+            break;
+        };
+        if next_ebr_lba == ebr_lba {
+            warn!(
+                "Stopping extended MBR scan at self-referential EBR LBA {}",
+                ebr_lba
+            );
+            break;
+        }
+        ebr_lba = next_ebr_lba;
+        visited += 1;
+    }
+
+    if visited == 128 {
+        warn!("Stopping extended MBR scan after reaching EBR chain limit");
+    }
+
+    Ok(())
+}
+
+fn push_mbr_partition(
+    partitions: &mut Vec<PartitionInfo>,
+    index: u32,
+    entry: MbrPartitionEntry,
+    disk_blocks: u64,
+) {
+    let Some(ending_lba) = entry.starting_lba.checked_add(entry.sector_count - 1) else {
+        warn!(
+            "Skipping MBR partition {} with overflowing LBA range",
+            index
+        );
+        return;
+    };
+    if disk_blocks != 0 && ending_lba >= disk_blocks {
+        warn!(
+            "Skipping MBR partition {} outside disk: start={}, sectors={}, disk_blocks={}",
+            index, entry.starting_lba, entry.sector_count, disk_blocks
+        );
+        return;
+    }
+
+    partitions.push(PartitionInfo {
+        index,
+        name: format!("partition_{}", index),
+        partition_type_guid: [0; 16],
+        unique_partition_guid: [0; 16],
+        filesystem_uuid: None,
+        starting_lba: entry.starting_lba,
+        ending_lba,
+        size_bytes: entry.sector_count * 512,
+        filesystem_type: None,
+    });
+}
+
+fn has_mbr_signature(sector: &[u8; 512]) -> bool {
+    sector[510] == 0x55 && sector[511] == 0xaa
+}
+
+#[derive(Clone, Copy)]
+struct MbrPartitionEntry {
+    partition_type: u8,
+    starting_lba: u64,
+    sector_count: u64,
+}
+
+impl MbrPartitionEntry {
+    fn parse(sector: &[u8; 512], index: usize) -> Self {
+        let offset = 446 + index * 16;
+        Self {
+            partition_type: sector[offset + 4],
+            starting_lba: u32::from_le_bytes([
+                sector[offset + 8],
+                sector[offset + 9],
+                sector[offset + 10],
+                sector[offset + 11],
+            ]) as u64,
+            sector_count: u32::from_le_bytes([
+                sector[offset + 12],
+                sector[offset + 13],
+                sector[offset + 14],
+                sector[offset + 15],
+            ]) as u64,
+        }
+    }
+
+    fn is_unused(&self) -> bool {
+        self.partition_type == 0 || self.starting_lba == 0 || self.sector_count == 0
+    }
+
+    fn is_extended(&self) -> bool {
+        matches!(self.partition_type, 0x05 | 0x0f | 0x85)
+    }
+
+    fn is_protective(&self) -> bool {
+        self.partition_type == 0xee
+    }
 }
 
 /// Parse GPT partition table


### PR DESCRIPTION
## Problem

rsext4 journal recovery did not handle several crash-recovery edge cases precisely enough. Uncommitted journal tails could be treated as hard recovery failures, replay scanning was not explicitly bounded by the journal ring length, and payload blocks could be read before a transaction was known to be committed.

axfs partition scanning also fell back to treating the whole disk as one partition when GPT was unavailable, even if a valid MBR partition table existed.

## Changes

- Refactor rsext4 JBD2 replay to scan control records first and read/write payload blocks only after a matching commit block is found.
- Discard uncommitted journal tails during recovery while still rejecting corrupted journal records such as invalid revoke blocks.
- Bound replay scanning by journal ring length to avoid looping on malformed journal contents.
- Batch consecutive journal reads and home-block writes during replay.
- Update mount/recovery state handling for `needs_recovery`, journal superblock `s_start`/`s_sequence`, clean unmount, and `lost+found` hint repair.
- Fix bitmap checksum handling for different block group descriptor sizes.
- Add MBR partition scanning in axfs after GPT probing fails, including primary and extended/logical partitions.
- Add rsext4 integrity tests for uncommitted tails, empty descriptors, invalid revoke records, bounded replay scans, payload read timing, and `lost+found` hint behavior.

## Implementation Notes

JBD2 replay is split into two phases. The first phase scans descriptor, revoke, and commit records and records where payload blocks live in the journal. The second phase only reads those payload blocks and writes them back after the transaction commit block is confirmed. This keeps uncommitted tails discardable while preserving strict failure behavior for malformed committed recovery data.

The partition scanner still prefers GPT. If both GPT probes fail, it now tries MBR before falling back to a whole-disk partition. MBR parsing validates signatures, skips invalid or protective entries, follows bounded EBR chains for logical partitions, and rejects out-of-range partition extents.