### PR TITLE
fix(starry): repair SG2002 CI build

### DIFF
--- a/os/StarryOS/kernel/src/file/inotify.rs
+++ b/os/StarryOS/kernel/src/file/inotify.rs
@@ -15,7 +15,6 @@ use ax_errno::{AxError, AxResult};
 use ax_sync::Mutex;
 use ax_task::future::{block_on, poll_io};
 use axpoll::{IoEvents, PollSet, Pollable};
-use lazy_static::lazy_static;
 use linux_raw_sys::{
     general::{
         IN_ALL_EVENTS, IN_CLOSE_WRITE, IN_CREATE, IN_DELETE, IN_DELETE_SELF, IN_IGNORED, IN_ISDIR,
@@ -23,6 +22,7 @@ use linux_raw_sys::{
     },
     ioctl::FIONREAD,
 };
+use spin::Lazy;
 use starry_vm::VmMutPtr;
 
 use crate::file::{FileLike, IoDst, IoSrc};
@@ -49,9 +49,7 @@ pub struct Inotify {
     poll_rx: PollSet,
 }
 
-lazy_static! {
-    static ref INOTIFY_INSTANCES: Mutex<Vec<Weak<Inotify>>> = Mutex::new(Vec::new());
-}
+static INOTIFY_INSTANCES: Lazy<Mutex<Vec<Weak<Inotify>>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
 impl Inotify {
     pub fn new() -> Arc<Self> {

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -632,7 +632,6 @@ impl SimpleDirOps for ThreadDir {
                 "stat",
                 "statm",
                 "status",
-                "statm",
                 "oom_score_adj",
                 "task",
                 "maps",
@@ -684,18 +683,6 @@ impl SimpleDirOps for ThreadDir {
                     } else {
                         Ok(task_status(&task))
                     }
-                })
-                .into()
-            }
-            "statm" => {
-                SimpleFile::new_regular(fs, move || {
-                    let aspace = task.as_thread().proc_data.aspace();
-                    let aspace_lock = aspace.lock();
-                    // Page size is 4096 on all supported architectures.
-                    let total_pages = aspace_lock.size() / 4096;
-                    let resident = total_pages;
-                    // Format: size resident shared text lib data dt
-                    Ok(format!("{total_pages} {resident} 0 0 0 0 0\n"))
                 })
                 .into()
             }

--- a/scripts/axbuild/src/context/resolve.rs
+++ b/scripts/axbuild/src/context/resolve.rs
@@ -137,14 +137,20 @@ impl AppContext {
                 .then_some(snapshot.config.as_ref())
                 .flatten(),
         );
+        let config_target = resolved_config
+            .as_deref()
+            .filter(|_| cli.config.is_some() && cli.target.is_none())
+            .map(crate::starry::build::load_target_from_build_config)
+            .transpose()?
+            .flatten();
         let effective_arch = cli.arch.clone().or_else(|| {
-            if cli.target.is_some() {
+            if cli.target.is_some() || config_target.is_some() {
                 None
             } else {
                 snapshot.arch.clone()
             }
         });
-        let effective_target = cli.target.clone().or_else(|| {
+        let effective_target = cli.target.clone().or(config_target).or_else(|| {
             if cli.arch.is_some() {
                 None
             } else {

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -974,6 +974,58 @@ config = "configs/custom-starry.toml"
 }
 
 #[test]
+fn prepare_starry_request_explicit_config_target_overrides_snapshot_target() {
+    let root = tempdir().unwrap();
+    prepare_starry_workspace(root.path());
+    let config = root.path().join("configs/sg2002.toml");
+    fs::create_dir_all(config.parent().unwrap()).unwrap();
+    fs::write(
+        &config,
+        r#"
+target = "riscv64gc-unknown-none-elf"
+env = {}
+features = ["sg2002"]
+log = "Info"
+"#,
+    )
+    .unwrap();
+    write_snapshot_text(
+        root.path(),
+        STARRY_SNAPSHOT_FILE,
+        r#"
+arch = "aarch64"
+target = "aarch64-unknown-none-softfloat"
+"#,
+    )
+    .unwrap();
+
+    let app = test_app_context(root.path());
+
+    let (request, snapshot) = prepare_starry_request(
+        &app,
+        StarryCliArgs {
+            config: Some(config.clone()),
+            arch: None,
+            target: None,
+            smp: None,
+            debug: false,
+        },
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(request.arch, "riscv64");
+    assert_eq!(request.target, "riscv64gc-unknown-none-elf");
+    assert_eq!(request.build_info_path, config);
+    assert_eq!(snapshot.arch.as_deref(), Some("riscv64"));
+    assert_eq!(
+        snapshot.target.as_deref(),
+        Some("riscv64gc-unknown-none-elf")
+    );
+}
+
+#[test]
 fn prepare_starry_request_rejects_mismatched_arch_and_target() {
     let root = tempdir().unwrap();
     prepare_starry_workspace(root.path());

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -1,9 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::Context as _;
+use anyhow::{Context as _, anyhow};
 use cargo_metadata::Metadata;
 use ostool::build::config::Cargo;
 
+use super::board;
 pub type StarryBuildInfo = crate::build::BuildInfo;
 pub use crate::build::LogLevel;
 use crate::context::{ResolvedStarryRequest, STARRY_PACKAGE, starry_arch_for_target_checked};
@@ -30,6 +31,20 @@ pub(crate) fn resolve_build_info_path(
         STARRY_PACKAGE,
         target,
     ))
+}
+
+pub(crate) fn load_target_from_build_config(path: &Path) -> anyhow::Result<Option<String>> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| anyhow!("failed to read Starry build config {}: {e}", path.display()))?;
+
+    if let Ok(board_file) = toml::from_str::<board::StarryBoardFile>(&content) {
+        return Ok(Some(board_file.target));
+    }
+    if toml::from_str::<StarryBuildInfo>(&content).is_ok() {
+        return Ok(None);
+    }
+
+    Err(anyhow!("invalid Starry build config {}", path.display()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 问题

`dev` 上最新 CI 在 `Test starry self-hosted board licheerv-nano-sg2002 / run_host` 失败。对应失败 run 挂在 `Refactor journal recovery and partition scanning logic (#927)` 的 merge commit 上，但本地复现后发现直接编译错误来自更早的 Starry inotify 改动：`lazy_static` 被使用但 `starry-kernel` 没有对应依赖。

复现过程中还发现 Starry 显式传入 `--config` 时，`axbuild` 仍可能沿用旧 snapshot/default target，导致 SG2002 配置被错误解析成 aarch64 构建。

## 修改

- 将 `starry-kernel` 的 inotify 全局实例表从 `lazy_static` 改为已有的 `spin::Lazy`，避免新增缺失依赖。
- 删除 `/proc/[pid]/task/[tid]` 下重复的 `statm` 分支，保留统一的 `render_thread_statm` 实现。
- 在 Starry 构建请求解析中，当用户显式传入 `--config` 且没有传 `--target` 时，从配置文件读取 target，避免被旧 snapshot target 覆盖。
- 增加回归测试，覆盖显式 Starry config target 覆盖 stale snapshot target 的场景。

## 验证

- `cargo fmt`
- `cargo test -p axbuild`
- `cargo xtask clippy --package axbuild`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry build --config test-suit/starryos/normal/board-licheerv-nano-sg2002/build-riscv64gc-unknown-none-elf.toml`

最后一项验证确认 SG2002 构建使用 `AX_ARCH=riscv64` 和 `AX_TARGET=riscv64gc-unknown-none-elf`，并成功生成 `starryos.bin`。