### PR TITLE
chore(axbuild): remove unused feature toggles

### DIFF
--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -15,7 +15,7 @@ ax-config-gen = { workspace = true }
 axvmconfig = { workspace = true, features = ["std"] }
 cargo_metadata = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4.6", features = ["derive"], optional = true }
+clap = { version = "4.6", features = ["derive"] }
 colored = { version = "3" }
 env_logger = { workspace = true }
 futures-util = "0.3"
@@ -34,7 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1" }
 sha2 = { version = "0.10" }
 tar = { version = "0.4" }
-tokio = { version = "1.0", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"], optional = true }
+tokio = { version = "1.0", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"] }
 toml.workspace = true
 tracing = "0.1"
 tracing-log = "0.2"
@@ -55,12 +55,6 @@ windows-sys = { version = "0.59", features = [
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-[features]
-clap = ["dep:clap", "dep:tokio"]
-cli = ["dep:clap", "tokio"]
-default = ["cli"]
-tokio = ["dep:tokio", "dep:clap"]
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## 问题

`axbuild` 当前源码没有基于 `clap` 或 `tokio` feature 做条件编译，但 `Cargo.toml` 里仍把这两个依赖声明为 optional，并通过 `default`/`cli`/`clap`/`tokio` features 再启用。这会让 manifest 表达的可选能力和实际代码需求不一致，也增加维护成本。

## 修改

- 将 `clap` 和 `tokio` 改为普通依赖。
- 移除未被源码使用的 `axbuild` feature 定义。

## 方案说明

`axbuild` 当前直接使用 CLI 解析和 async runtime 相关能力，因此这两个依赖属于构建工具的基础依赖，而不是可选能力。移除 feature 层后，manifest 与实际行为保持一致，同时避免继续维护没有实际分支效果的 feature 组合。

## 验证

- `cargo fmt --check`
- `python3 -c 'import toml; toml.load("scripts/axbuild/Cargo.toml"); print("toml ok")'`
- `cargo xtask clippy --package axbuild`