### PR TITLE
feat(axvisor): add PhytiumPi and ROC-RK3568 board tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,18 +334,7 @@ jobs:
           - name: Test axvisor loongarch64 qemu
             use_container: true
             runs_on: '["ubuntu-latest"]'
-            command: |
-              set -eux
-              cargo xtask arceos build --arch loongarch64 -p ax-helloworld --smp 1
-              vmconfig=tmp/ci-arceos-loongarch64-qemu-smp1.toml
-              cp os/axvisor/configs/vms/arceos-loongarch64-qemu-smp1.toml "${vmconfig}"
-              sed -i 's|^image_location = "fs"|image_location = "memory"|' "${vmconfig}"
-              sed -i 's|^kernel_path = .*|kernel_path = "'"${GITHUB_WORKSPACE}"'/target/loongarch64-unknown-none-softfloat/release/ax-helloworld.bin"|' "${vmconfig}"
-              cargo xtask axvisor qemu \
-                --arch loongarch64 \
-                --config os/axvisor/configs/board/qemu-loongarch64.toml \
-                --vmconfigs "${vmconfig}" \
-                --qemu-config os/axvisor/configs/qemu/qemu-loongarch64.toml
+            command: cargo xtask axvisor test qemu --arch loongarch64
             cache_key: test-axvisor-loongarch64
             container_image: axvisor-lvz
             limit_to_owner: ""
@@ -494,6 +483,22 @@ jobs:
             use_container: false
             runs_on: '["self-hosted","linux","board"]'
             command: cargo xtask axvisor test board --board orangepi-5-plus-linux
+            cache_key: ""
+            container_image: ""
+            limit_to_owner: rcore-os
+            main_pr_only: false
+          - name: Test axvisor self-hosted board roc-rk3568-pc-linux
+            use_container: false
+            runs_on: '["self-hosted","linux","board"]'
+            command: cargo xtask axvisor test board --board roc-rk3568-pc-linux
+            cache_key: ""
+            container_image: ""
+            limit_to_owner: rcore-os
+            main_pr_only: false
+          - name: Test axvisor self-hosted board phytiumpi-linux
+            use_container: false
+            runs_on: '["self-hosted","linux","board"]'
+            command: cargo xtask axvisor test board --board phytiumpi-linux
             cache_key: ""
             container_image: ""
             limit_to_owner: rcore-os

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "ax-plat-aarch64-peripherals",
  "axklib",
  "log",
+ "mmio-api",
 ]
 
 [[package]]
@@ -1407,6 +1408,7 @@ dependencies = [
  "chrono",
  "log",
  "loongArch64",
+ "mmio-api",
  "uart_16550 0.5.0",
 ]
 
@@ -1433,6 +1435,7 @@ dependencies = [
  "ax-riscv-plic",
  "axklib",
  "log",
+ "mmio-api",
  "riscv 0.16.0",
  "riscv_goldfish",
  "sbi-rt 0.0.3",

--- a/components/axvm/src/config.rs
+++ b/components/axvm/src/config.rs
@@ -368,6 +368,11 @@ impl PhysCpuList {
     pub fn set_guest_cpu_sets(&mut self, phys_cpu_sets: Vec<usize>) {
         self.phys_cpu_sets = Some(phys_cpu_sets);
     }
+
+    /// Sets the CPU IDs exposed to the guest.
+    pub fn set_guest_phys_cpu_ids(&mut self, phys_cpu_ids: Vec<usize>) {
+        self.phys_cpu_ids = Some(phys_cpu_ids);
+    }
 }
 
 #[cfg(test)]

--- a/os/axvisor/configs/board/phytiumpi.toml
+++ b/os/axvisor/configs/board/phytiumpi.toml
@@ -1,7 +1,7 @@
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = [
     "fs",
-    "sdmmc",
+    "phytium-mci",
 ]
 log = "Info"
 plat_dyn = true

--- a/os/axvisor/src/vmm/fdt/create.rs
+++ b/os/axvisor/src/vmm/fdt/create.rs
@@ -241,43 +241,35 @@ fn is_ancestor_of_passthrough_device(node_path: &str, passthrough_device_names: 
 }
 
 /// Determine if CPU node is needed
+fn cpu_node_id(node_path: &str) -> Option<usize> {
+    node_path
+        .strip_prefix("/cpus/cpu@")
+        .and_then(|rest| rest.split('/').next())
+        .and_then(|id| usize::from_str_radix(id, 16).ok())
+}
+
+fn cpu_reg_address(node: &Node) -> Option<usize> {
+    node.reg()
+        .and_then(|mut reg| reg.next())
+        .map(|reg_entry| reg_entry.address as usize)
+}
+
 fn need_cpu_node(phys_cpu_ids: &[usize], node: &Node, node_path: &str) -> bool {
     if !node_path.starts_with("/cpus/cpu@") {
         return true;
     }
 
-    if let Some(cpu_id) = node_path
-        .strip_prefix("/cpus/cpu@")
-        .and_then(|rest| rest.split('/').next())
-        .and_then(|id| usize::from_str_radix(id, 16).ok())
-        && phys_cpu_ids.contains(&cpu_id)
-    {
-        return true;
+    if let Some(cpu_id) = cpu_node_id(node_path) {
+        return phys_cpu_ids.contains(&cpu_id);
     }
 
-    if let Some(mut cpu_reg) = node.reg()
-        && let Some(reg_entry) = cpu_reg.next()
-    {
-        let cpu_address = reg_entry.address as usize;
+    if let Some(cpu_address) = cpu_reg_address(node) {
         debug!(
             "Checking CPU node {} with address 0x{:x}",
             node.name(),
             cpu_address
         );
-        if phys_cpu_ids.contains(&cpu_address) {
-            debug!(
-                "CPU node {} with address 0x{:x} is in phys_cpu_ids, including in guest FDT",
-                node.name(),
-                cpu_address
-            );
-            return true;
-        }
-
-        debug!(
-            "CPU node {} with address 0x{:x} is NOT in phys_cpu_ids, skipping",
-            node.name(),
-            cpu_address
-        );
+        return phys_cpu_ids.contains(&cpu_address);
     }
 
     false
@@ -521,12 +513,15 @@ pub fn update_fdt(
     let fdt = Fdt::from_bytes(fdt_bytes)
         .map_err(|e| format!("Failed to parse cached guest FDT: {e:#?}"))
         .expect("Failed to parse cached guest FDT");
-    // Keep boot metadata such as /chosen from the host FDT.
-    let host_fdt = Fdt::from_bytes(super::get_host_fdt())
-        .map_err(|e| format!("Failed to parse host FDT while updating guest FDT: {e:#?}"))
-        .expect("Failed to parse host FDT while updating guest FDT");
+    // Keep boot metadata such as /chosen from the host FDT when it is available.
+    let host_fdt_bytes = super::try_get_host_fdt();
+    let host_fdt = host_fdt_bytes.map(|bytes| {
+        Fdt::from_bytes(bytes)
+            .map_err(|e| format!("Failed to parse host FDT while updating guest FDT: {e:#?}"))
+            .expect("Failed to parse host FDT while updating guest FDT")
+    });
     let new_fdt_bytes =
-        patch_guest_fdt_for_runtime(&fdt, &vm.memory_regions(), crate_config, &host_fdt);
+        patch_guest_fdt_for_runtime(&fdt, &vm.memory_regions(), crate_config, host_fdt.as_ref());
     // Recompute the DTB load address from the runtime memory layout.
     let dest_addr = calculate_dtb_load_addr(vm.clone(), new_fdt_bytes.len());
 
@@ -535,9 +530,52 @@ pub fn update_fdt(
 
 #[cfg(test)]
 mod tests {
-    use super::{initrd_range_from_image_config, sanitize_bootargs};
+    use super::{cpu_node_id, initrd_range_from_image_config, need_cpu_node, sanitize_bootargs};
     use axaddrspace::GuestPhysAddr;
     use axvm::config::RamdiskInfo;
+    use fdt_parser::Fdt;
+
+    fn test_fdt(dts: &str) -> Fdt<'static> {
+        let mut writer = super::FdtWriter::new().unwrap();
+        let root = writer.begin_node("").unwrap();
+        let cpus = writer.begin_node("cpus").unwrap();
+        writer.property_u32("#address-cells", 2).unwrap();
+        writer.property_u32("#size-cells", 0).unwrap();
+
+        for line in dts.lines().map(str::trim).filter(|line| !line.is_empty()) {
+            let (name, reg) = line.split_once('=').unwrap();
+            let node = writer.begin_node(name).unwrap();
+            writer.property_u32("device_type", 0).unwrap();
+            let reg = usize::from_str_radix(reg, 16).unwrap();
+            writer.property_array_u32("reg", &[0, reg as u32]).unwrap();
+            writer.end_node(node).unwrap();
+        }
+
+        writer.end_node(cpus).unwrap();
+        writer.end_node(root).unwrap();
+        let bytes = writer.finish().unwrap().leak();
+        Fdt::from_bytes(bytes).unwrap()
+    }
+
+    #[test]
+    fn cpu_node_selection_uses_node_id_when_reg_differs() {
+        let fdt = test_fdt("cpu@0=200\ncpu@100=0\ncpu@101=100");
+        let nodes: Vec<_> = fdt.all_nodes().collect();
+        let paths = crate::vmm::fdt::build_all_node_paths(&nodes);
+        let selected: Vec<_> = nodes
+            .iter()
+            .zip(paths.iter())
+            .filter(|(_, path)| path.starts_with("/cpus/cpu@"))
+            .filter_map(|(node, path)| need_cpu_node(&[0x100], node, path).then(|| path.clone()))
+            .collect();
+
+        assert_eq!(selected, ["/cpus/cpu@100"]);
+    }
+
+    #[test]
+    fn cpu_node_id_parses_hex_unit_address() {
+        assert_eq!(cpu_node_id("/cpus/cpu@100"), Some(0x100));
+    }
 
     #[test]
     fn initrd_range_requires_both_address_and_size() {
@@ -616,7 +654,7 @@ pub(crate) fn patch_guest_fdt_for_runtime(
     fdt: &Fdt,
     memory_regions: &[VMMemoryRegion],
     crate_config: &AxVMCrateConfig,
-    host_fdt: &Fdt,
+    host_fdt: Option<&Fdt>,
 ) -> Vec<u8> {
     let mut new_fdt = FdtWriter::new().unwrap();
     let mut previous_node_level = 0usize;
@@ -660,7 +698,10 @@ pub(crate) fn patch_guest_fdt_for_runtime(
     assert_eq!(node_stack.len(), 1);
 
     // Restore /chosen from the host FDT when it is missing.
-    if !has_chosen && let Some(chosen_node) = host_fdt.find_nodes("/chosen").next() {
+    if !has_chosen
+        && let Some(host_fdt) = host_fdt
+        && let Some(chosen_node) = host_fdt.find_nodes("/chosen").next()
+    {
         let chosen = new_fdt.begin_node("chosen").unwrap();
         for prop in chosen_node.propertys() {
             new_fdt.property(prop.name, prop.raw_value()).unwrap();

--- a/os/axvisor/src/vmm/fdt/parser.rs
+++ b/os/axvisor/src/vmm/fdt/parser.rs
@@ -17,9 +17,9 @@
 use alloc::{string::ToString, vec::Vec};
 use ax_hal::{dtb, mem};
 use axaddrspace::MappingFlags;
-#[cfg(target_arch = "aarch64")]
-use axvm::config::PassThroughDeviceConfig;
-use axvm::config::{AxVMConfig, AxVMCrateConfig, VmMemConfig, VmMemMappingType};
+use axvm::config::{
+    AxVMConfig, AxVMCrateConfig, PassThroughDeviceConfig, VmMemConfig, VmMemMappingType,
+};
 use fdt_parser::{Fdt, FdtHeader, PciRange, PciSpace};
 
 use crate::vmm::fdt::crate_guest_fdt_with_cache;
@@ -27,10 +27,6 @@ use crate::vmm::fdt::crate_guest_fdt_with_cache;
 use crate::vmm::fdt::create::update_cpu_node;
 
 const PAGE_SIZE_4K: usize = 0x1000;
-
-pub fn get_host_fdt() -> &'static [u8] {
-    try_get_host_fdt().expect("Failed to get host FDT from boot context")
-}
 
 pub fn try_get_host_fdt() -> Option<&'static [u8]> {
     const FDT_VALID_MAGIC: u32 = 0xd00d_feed;
@@ -382,66 +378,43 @@ pub fn set_phys_cpu_sets(vm_cfg: &mut AxVMConfig, fdt: &Fdt, crate_config: &AxVM
         .as_ref()
         .expect("ERROR: phys_cpu_ids not found in config.toml");
 
-    // Collect all CPU node information into Vec to avoid using iterators multiple times
     let cpu_nodes_info: Vec<_> = host_cpus
         .iter()
         .filter_map(|cpu_node| {
-            if let Some(mut cpu_reg) = cpu_node.reg() {
-                if let Some(r) = cpu_reg.next() {
-                    info!(
-                        "CPU node: {}, phys_cpu_id: 0x{:x}",
-                        cpu_node.name(),
-                        r.address
-                    );
-                    Some((cpu_node.name().to_string(), r.address as usize))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
+            let node_id = cpu_node
+                .name()
+                .strip_prefix("cpu@")
+                .and_then(|id| usize::from_str_radix(id, 16).ok())?;
+            let cpu_reg = cpu_node.reg().and_then(|mut reg| reg.next())?;
+            let guest_cpu_id = cpu_reg.address as usize;
+            info!(
+                "CPU node: {}, node_id: 0x{:x}, guest_cpu_id: 0x{:x}",
+                cpu_node.name(),
+                node_id,
+                guest_cpu_id
+            );
+            Some((node_id, guest_cpu_id))
         })
         .collect();
-    // Create mapping from phys_cpu_id to physical CPU index
-    // Collect all unique CPU addresses, maintaining the order of appearance in the device tree
-    let mut unique_cpu_addresses = Vec::new();
-    for (_, cpu_address) in &cpu_nodes_info {
-        if !unique_cpu_addresses.contains(cpu_address) {
-            unique_cpu_addresses.push(*cpu_address);
-        } else {
-            panic!("Duplicate CPU address found");
-        }
-    }
 
-    // Assign index to each CPU address in the device tree and print detailed information
-    for (index, &cpu_address) in unique_cpu_addresses.iter().enumerate() {
-        // Find all CPU nodes using this address
-        for (cpu_name, node_address) in &cpu_nodes_info {
-            if *node_address == cpu_address {
-                debug!(
-                    "  CPU node: {cpu_name}, address: 0x{cpu_address:x}, assigned index: {index}"
-                );
-                break; // Print each address only once
-            }
-        }
-    }
-
-    // Calculate phys_cpu_sets based on phys_cpu_ids in vcpu_mappings
     let mut new_phys_cpu_sets = Vec::new();
+    let mut guest_phys_cpu_ids = Vec::new();
     for phys_cpu_id in phys_cpu_ids {
-        // Find the index corresponding to phys_cpu_id in unique_cpu_addresses
-        if let Some(cpu_index) = unique_cpu_addresses
+        if let Some((cpu_index, (_, guest_cpu_id))) = cpu_nodes_info
             .iter()
-            .position(|&addr| addr == *phys_cpu_id)
+            .enumerate()
+            .find(|(_, (node_id, _))| node_id == phys_cpu_id)
         {
-            let cpu_mask = 1usize << cpu_index; // Convert index to mask bit
+            let cpu_mask = 1usize << cpu_index;
             new_phys_cpu_sets.push(cpu_mask);
+            guest_phys_cpu_ids.push(*guest_cpu_id);
             debug!(
-                "vCPU {} with phys_cpu_id 0x{:x} mapped to CPU index {} (mask: 0x{:x})",
+                "vCPU {} with phys_cpu_id 0x{:x} mapped to CPU index {} (mask: 0x{:x}), guest CPU ID 0x{:x}",
                 vm_cfg.id(),
                 phys_cpu_id,
                 cpu_index,
-                cpu_mask
+                cpu_mask,
+                guest_cpu_id
             );
         } else {
             error!(
@@ -452,12 +425,12 @@ pub fn set_phys_cpu_sets(vm_cfg: &mut AxVMConfig, fdt: &Fdt, crate_config: &AxVM
         }
     }
 
-    // Update phys_cpu_sets in VM configuration (if VM configuration supports setting)
     info!("Calculated phys_cpu_sets: {new_phys_cpu_sets:?}");
+    info!("Calculated guest phys_cpu_ids: {guest_phys_cpu_ids:?}");
 
-    vm_cfg
-        .phys_cpu_ls_mut()
-        .set_guest_cpu_sets(new_phys_cpu_sets);
+    let phys_cpu_ls = vm_cfg.phys_cpu_ls_mut();
+    phys_cpu_ls.set_guest_cpu_sets(new_phys_cpu_sets);
+    phys_cpu_ls.set_guest_phys_cpu_ids(guest_phys_cpu_ids);
 
     debug!(
         "vcpu_mappings: {:?}",
@@ -515,7 +488,7 @@ fn add_device_address_config(
     };
 
     // Add new device configuration
-    let pt_dev = axvm::config::PassThroughDeviceConfig {
+    let pt_dev = PassThroughDeviceConfig {
         name: device_name,
         base_gpa: base_address,
         base_hpa: base_address,
@@ -550,7 +523,7 @@ fn add_pci_ranges_config(vm_cfg: &mut AxVMConfig, node_name: &str, range: &PciRa
     };
 
     // Add new device configuration
-    let pt_dev = axvm::config::PassThroughDeviceConfig {
+    let pt_dev = PassThroughDeviceConfig {
         name: device_name,
         base_gpa: base_address,
         base_hpa: base_address,

--- a/test-suit/axvisor/normal/board-phytiumpi/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-phytiumpi/build-aarch64-unknown-none-softfloat.toml
@@ -1,9 +1,9 @@
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = [
     "fs",
-    "rockchip-sdhci",
+    "phytium-mci",
 ]
 log = "Info"
 plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
-vm_configs = []
+vm_configs = ["os/axvisor/configs/vms/linux-aarch64-e2000-smp1.toml"]

--- a/test-suit/axvisor/normal/board-phytiumpi/smoke/board-phytiumpi-linux.toml
+++ b/test-suit/axvisor/normal/board-phytiumpi/smoke/board-phytiumpi-linux.toml
@@ -1,0 +1,11 @@
+board_type = "PhytiumPi"
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+  "(?i)login incorrect",
+  "(?i)permission denied",
+]
+success_regex = [
+  "(?m)^phytiumpi login:",
+]
+timeout = 300

--- a/test-suit/axvisor/normal/board-roc-rk3568-pc/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-roc-rk3568-pc/build-aarch64-unknown-none-softfloat.toml
@@ -1,9 +1,10 @@
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = [
-    "fs",
-    "rockchip-sdhci",
+  "rockchip-sdhci",
+  "rockchip-soc",
+  "fs",
 ]
 log = "Info"
 plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
-vm_configs = []
+vm_configs = ["os/axvisor/configs/vms/linux-aarch64-rk3568-smp1.toml"]

--- a/test-suit/axvisor/normal/board-roc-rk3568-pc/smoke/board-roc-rk3568-pc-linux.toml
+++ b/test-suit/axvisor/normal/board-roc-rk3568-pc/smoke/board-roc-rk3568-pc-linux.toml
@@ -1,0 +1,11 @@
+board_type = "ROC-RK3568-PC"
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+  "(?i)login incorrect",
+  "(?i)permission denied",
+]
+success_regex = [
+  "(?m)login:",
+]
+timeout = 300


### PR DESCRIPTION
## Problem

Axvisor board-test coverage did not include PhytiumPi or ROC-RK3568-PC, so their Linux guest boot paths were not covered by the unified `cargo xtask axvisor test board` flow or self-hosted board CI.

These boards also need more precise FDT CPU handling. The previous logic could mix host CPU node unit addresses with guest-visible CPU IDs, which breaks CPU node filtering and vCPU mapping on boards where those values differ.

## Changes

- Add Axvisor board test-suit cases:
  - `phytiumpi-linux`
  - `roc-rk3568-pc-linux`
- Add build and smoke configs for both boards.
- Update board driver features:
  - PhytiumPi uses `phytium-mci`
  - ROC-RK3568-PC uses `rockchip-sdhci`
- Add both board tests to self-hosted board CI.
- Switch Axvisor loongarch64 QEMU CI to the unified test command:
  - `cargo xtask axvisor test qemu --arch loongarch64`
- Refine Axvisor FDT CPU mapping:
  - Select CPU nodes by `/cpus/cpu@...` unit address when available.
  - Preserve the guest-visible CPU IDs from each CPU node `reg`.
  - Add an `axvm` setter for guest physical CPU IDs.
- Make riscv64 runtime FDT patching use `try_get_host_fdt()`:
  - Restore `/chosen` from the host FDT when available.
  - Continue patching runtime memory layout even when no host FDT is available.

## Implementation Notes

The new board tests follow the existing `test-suit/axvisor/normal` discovery layout, so they can be run through the same board-test path as the existing Axvisor board cases.

CPU handling now separates host CPU node selection from guest CPU ID exposure. The host FDT unit address decides which CPU nodes are kept, while the node `reg` value is written back as the guest-visible CPU ID. This keeps vCPU placement and guest FDT generation consistent on boards where those values differ.

For the riscv64 runtime FDT patch path, host FDT access is now optional. When a host FDT is available, missing `/chosen` metadata can still be restored from it; otherwise the patcher keeps the existing cached guest FDT content and still rebuilds the runtime memory node.