### PR TITLE
feat: add axnsproxy crate with all namespace types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ members = [
     "drivers/usb/usb-if",
     "drivers/usb/utils/*",
 
+    "os/StarryOS/axnsproxy",
     "os/StarryOS/kernel",
     "os/StarryOS/starryos",
     "os/arceos/api/*",
@@ -345,6 +346,7 @@ sdhci-host = { version = "0.1.1", path = "drivers/blk/sdhci-host", default-featu
 sdmmc-protocol = { version = "0.1.1", path = "drivers/blk/sdmmc-protocol", default-features = false }
 smoltcp = { version = "0.13.1", default-features = false }
 smp-kernel = { version = "0.3.1", path = "components/axplat_crates/examples/smp-kernel" }
+axnsproxy = { version = "0.1.0", path = "os/StarryOS/axnsproxy" }
 starry-kernel = { version = "0.5.12", path = "os/StarryOS/kernel" }
 starry-process = { version = "0.4.7", path = "components/starry-process" }
 starry-signal = { version = "0.7.0", path = "components/starry-signal" }

--- a/os/StarryOS/axnsproxy/Cargo.toml
+++ b/os/StarryOS/axnsproxy/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "axnsproxy"
+version = "0.1.0"
+edition.workspace = true
+description = "Namespace proxy for Starry OS"
+keywords = ["starry-os"]
+repository = "https://github.com/Starry-OS/StarryOS"
+license = "Apache-2.0"
+
+[dependencies]
+ax-config = { workspace = true }
+ax-errno = { workspace = true }
+ax-kspin = { workspace = true }
+linux-raw-sys = { version = "0.12", default-features = false, features = [
+    "general",
+    "no_std",
+    "system",
+] }
+log = "0.4"
+spin = { workspace = true }

--- a/os/StarryOS/axnsproxy/src/ipc.rs
+++ b/os/StarryOS/axnsproxy/src/ipc.rs
@@ -1,0 +1,34 @@
+use alloc::sync::Arc;
+use core::sync::atomic::AtomicU64;
+
+use ax_kspin::SpinNoIrq;
+
+static NEXT_IPC_NS_ID: AtomicU64 = AtomicU64::new(0);
+
+/// The initial root IPC namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWIPC)` or `clone(CLONE_NEWIPC)`.
+pub static ROOT_IPC_NS: spin::Lazy<Arc<SpinNoIrq<IpcNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(IpcNamespace::new_root())));
+
+/// Per-process IPC namespace.
+///
+/// Isolates System V IPC objects (shared memory, semaphores, message
+/// queues) and POSIX message queues so that processes in different
+/// IPC namespaces cannot access each other's IPC resources.
+pub struct IpcNamespace {
+    pub ns_id: u64,
+}
+
+impl IpcNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            ns_id: NEXT_IPC_NS_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed),
+        }
+    }
+
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            ns_id: NEXT_IPC_NS_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed),
+        }
+    }
+}

--- a/os/StarryOS/axnsproxy/src/lib.rs
+++ b/os/StarryOS/axnsproxy/src/lib.rs
@@ -1,0 +1,118 @@
+#![no_std]
+
+extern crate alloc;
+
+mod ipc;
+mod mnt;
+mod net;
+mod pid;
+mod user;
+mod uts;
+
+use alloc::sync::Arc;
+
+use ax_kspin::SpinNoIrq;
+pub use ipc::{IpcNamespace, ROOT_IPC_NS};
+pub use mnt::{MntNamespace, ROOT_MNT_NS};
+pub use net::{NetNamespace, ROOT_NET_NS};
+pub use pid::{PidNamespace, ROOT_PID_NS};
+pub use user::{ROOT_USER_NS, UserNamespace};
+pub use uts::{ROOT_UTS_NS, UtNamespace, build_utsname};
+
+/// Aggregates all namespace types for a process.
+///
+/// `ProcessData` holds a single `SpinNoIrq<NsProxy>` field.  Clone and unshare
+/// operations work through `NsProxy` methods so that syscall handlers do not
+/// manipulate namespace internals directly.
+pub struct NsProxy {
+    /// The UTS namespace (hostname, domainname).
+    pub uts_ns: Arc<SpinNoIrq<UtNamespace>>,
+    /// The IPC namespace (System V IPC objects).
+    pub ipc_ns: Arc<SpinNoIrq<IpcNamespace>>,
+    /// The mount namespace (filesystem mount points).
+    pub mnt_ns: Arc<SpinNoIrq<MntNamespace>>,
+    /// The PID namespace (process ID numbering).
+    pub pid_ns: Arc<SpinNoIrq<PidNamespace>>,
+    /// Pending PID namespace for the next child created via
+    /// `unshare(CLONE_NEWPID)`.  Linux does not move the calling
+    /// process into a new PID namespace; instead the next fork/clone
+    /// child becomes the first process (PID 1) in the new namespace.
+    pub child_pid_ns: Option<Arc<SpinNoIrq<PidNamespace>>>,
+    /// The network namespace (interfaces, routing, sockets).
+    pub net_ns: Arc<SpinNoIrq<NetNamespace>>,
+    /// The user namespace (UID/GID mappings).
+    pub user_ns: Arc<SpinNoIrq<UserNamespace>>,
+}
+
+impl NsProxy {
+    /// Create a new [`NsProxy`] pointing to the root namespaces.
+    pub fn new_root() -> Self {
+        Self {
+            uts_ns: ROOT_UTS_NS.clone(),
+            ipc_ns: ROOT_IPC_NS.clone(),
+            mnt_ns: ROOT_MNT_NS.clone(),
+            pid_ns: ROOT_PID_NS.clone(),
+            child_pid_ns: None,
+            net_ns: ROOT_NET_NS.clone(),
+            user_ns: ROOT_USER_NS.clone(),
+        }
+    }
+
+    /// Clone all namespace references (shallow `Arc` clone).
+    ///
+    /// Used by `fork` / `clone` (without `CLONE_NEW*` flags) so the child
+    /// shares the same namespaces as the parent.  `child_pid_ns` is never
+    /// inherited — it is consumed by the first child that uses it.
+    pub fn clone_all(&self) -> Self {
+        Self {
+            uts_ns: self.uts_ns.clone(),
+            ipc_ns: self.ipc_ns.clone(),
+            mnt_ns: self.mnt_ns.clone(),
+            pid_ns: self.pid_ns.clone(),
+            child_pid_ns: None,
+            net_ns: self.net_ns.clone(),
+            user_ns: self.user_ns.clone(),
+        }
+    }
+
+    pub fn unshare_uts(&mut self) {
+        let new_inner = self.uts_ns.lock().clone_ns();
+        self.uts_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    pub fn unshare_ipc(&mut self) {
+        let new_inner = self.ipc_ns.lock().clone_ns();
+        self.ipc_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    pub fn unshare_mnt(&mut self) {
+        let new_inner = self.mnt_ns.lock().clone_ns();
+        self.mnt_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    /// Directly replace the PID namespace — used in `clone(CLONE_NEWPID)`.
+    pub fn unshare_pid(&mut self) {
+        let new_inner = self.pid_ns.lock().clone_ns();
+        self.pid_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    /// Prepare a new PID namespace for the next child of this process.
+    ///
+    /// Called by `unshare(CLONE_NEWPID)`.  The calling process stays in
+    /// its current PID namespace; the new namespace is consumed by the
+    /// next `fork` / `clone` child, which becomes PID 1 in that namespace.
+    pub fn prepare_child_pid_ns(&mut self) {
+        let new_inner = self.pid_ns.lock().clone_ns();
+        self.child_pid_ns = Some(Arc::new(SpinNoIrq::new(new_inner)));
+    }
+
+    pub fn unshare_net(&mut self) {
+        let new_inner = self.net_ns.lock().clone_ns();
+        self.net_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    pub fn unshare_user(&mut self) {
+        let new_inner = self.user_ns.lock().clone_ns();
+        self.user_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+}

--- a/os/StarryOS/axnsproxy/src/mnt.rs
+++ b/os/StarryOS/axnsproxy/src/mnt.rs
@@ -1,0 +1,37 @@
+use alloc::sync::Arc;
+use core::ffi::c_char;
+
+use ax_kspin::SpinNoIrq;
+
+/// The initial root mount namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWNS)` or `clone(CLONE_NEWNS)`.
+pub static ROOT_MNT_NS: spin::Lazy<Arc<SpinNoIrq<MntNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(MntNamespace::new_root())));
+
+const fn pad_mnt_root(root: &str) -> [c_char; 256] {
+    let mut data: [c_char; 256] = [0; 256];
+    unsafe {
+        core::ptr::copy_nonoverlapping(root.as_ptr().cast(), data.as_mut_ptr(), root.len());
+    }
+    data
+}
+
+/// Per-process mount namespace.
+///
+/// Isolates the set of filesystem mount points seen by a process.
+/// In the root namespace `root` starts as `"/"`.
+pub struct MntNamespace {
+    pub root: [c_char; 256],
+}
+
+impl MntNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            root: pad_mnt_root("/"),
+        }
+    }
+
+    pub fn clone_ns(&self) -> Self {
+        Self { root: self.root }
+    }
+}

--- a/os/StarryOS/axnsproxy/src/net.rs
+++ b/os/StarryOS/axnsproxy/src/net.rs
@@ -1,0 +1,34 @@
+use alloc::sync::Arc;
+use core::sync::atomic::AtomicU64;
+
+use ax_kspin::SpinNoIrq;
+
+static NEXT_NET_NS_ID: AtomicU64 = AtomicU64::new(0);
+
+/// The initial root network namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWNET)` or `clone(CLONE_NEWNET)`.
+pub static ROOT_NET_NS: spin::Lazy<Arc<SpinNoIrq<NetNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(NetNamespace::new_root())));
+
+/// Per-process network namespace.
+///
+/// Isolates network interfaces, routing tables, firewall rules, and
+/// sockets so that processes in different network namespaces see
+/// independent network stacks.
+pub struct NetNamespace {
+    pub ns_id: u64,
+}
+
+impl NetNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            ns_id: NEXT_NET_NS_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed),
+        }
+    }
+
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            ns_id: NEXT_NET_NS_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed),
+        }
+    }
+}

--- a/os/StarryOS/axnsproxy/src/pid.rs
+++ b/os/StarryOS/axnsproxy/src/pid.rs
@@ -1,0 +1,56 @@
+use alloc::{collections::BTreeMap, sync::Arc};
+
+use ax_kspin::SpinNoIrq;
+
+/// The initial root PID namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWPID)` or `clone(CLONE_NEWPID)`.
+pub static ROOT_PID_NS: spin::Lazy<Arc<SpinNoIrq<PidNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(PidNamespace::new_root())));
+
+/// Per-process PID namespace.
+///
+/// Each PID namespace has a nesting `level` (0 for the root namespace,
+/// incremented for each nested PID namespace) and isolates PID numbering
+/// so that processes in different PID namespaces may have the same PID
+/// value as seen from within their respective namespace.
+pub struct PidNamespace {
+    /// PID namespace nesting level.  Root is 0, first child is 1, etc.
+    pub level: u32,
+    /// Next local PID to allocate in this namespace (starts at 1).
+    next_pid: u32,
+    /// Map from global TID to namespace-local PID.
+    pid_map: BTreeMap<u64, u32>,
+}
+
+impl PidNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            level: 0,
+            next_pid: 1,
+            pid_map: BTreeMap::new(),
+        }
+    }
+
+    /// Create a fresh child PID namespace (level + 1, empty pid map,
+    /// next_pid starts at 1).
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            level: self.level + 1,
+            next_pid: 1,
+            pid_map: BTreeMap::new(),
+        }
+    }
+
+    /// Allocate a namespace-local PID for the given global TID.
+    pub fn alloc_local_pid(&mut self, global_tid: u64) -> u32 {
+        let local = self.next_pid;
+        self.next_pid += 1;
+        self.pid_map.insert(global_tid, local);
+        local
+    }
+
+    /// Resolve a global TID to its namespace-local PID.
+    pub fn local_pid(&self, global_tid: u64) -> Option<u32> {
+        self.pid_map.get(&global_tid).copied()
+    }
+}

--- a/os/StarryOS/axnsproxy/src/user.rs
+++ b/os/StarryOS/axnsproxy/src/user.rs
@@ -1,0 +1,43 @@
+use alloc::sync::Arc;
+
+use ax_kspin::SpinNoIrq;
+
+/// The initial root user namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWUSER)` or `clone(CLONE_NEWUSER)`.
+pub static ROOT_USER_NS: spin::Lazy<Arc<SpinNoIrq<UserNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(UserNamespace::new_root())));
+
+/// Per-process user namespace.
+///
+/// Isolates UID/GID mappings so that a process may have uid 0 inside
+/// its namespace while mapping to an unprivileged UID in the parent.
+/// `owner_uid` is the effective UID of the process that created the
+/// namespace (0 for the root namespace).
+///
+/// When `is_root` is false (child namespace without configured mappings),
+/// all UIDs/GIDs are reported as `nobody` (65534), matching Linux default
+/// behaviour for unconfigured user namespaces.
+pub struct UserNamespace {
+    /// Effective UID of the namespace creator (0 for root namespace).
+    pub owner_uid: u32,
+    /// Whether this is the initial root user namespace.  false for
+    /// namespaces created via unshare / clone(CLONE_NEWUSER) that
+    /// have not yet had uid_map / gid_map configured.
+    pub is_root: bool,
+}
+
+impl UserNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            owner_uid: 0,
+            is_root: true,
+        }
+    }
+
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            owner_uid: self.owner_uid,
+            is_root: false,
+        }
+    }
+}

--- a/os/StarryOS/axnsproxy/src/uts.rs
+++ b/os/StarryOS/axnsproxy/src/uts.rs
@@ -1,0 +1,61 @@
+use alloc::sync::Arc;
+use core::ffi::c_char;
+
+use ax_config::ARCH;
+use ax_kspin::SpinNoIrq;
+
+/// The initial root UTS namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWUTS)`.
+pub static ROOT_UTS_NS: spin::Lazy<Arc<SpinNoIrq<UtNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(UtNamespace::new_root())));
+
+const fn pad_str(info: &str) -> [c_char; 65] {
+    let mut data: [c_char; 65] = [0; 65];
+    unsafe {
+        core::ptr::copy_nonoverlapping(info.as_ptr().cast(), data.as_mut_ptr(), info.len());
+    }
+    data
+}
+
+/// Per-process UTS namespace, containing the hostname and domain name
+/// visible to `uname(2)`.  When a process calls `unshare(CLONE_NEWUTS)` or
+/// `clone(CLONE_NEWUTS)`, it receives a fresh copy of the parent namespace
+/// so that subsequent `sethostname(2)` / `setdomainname(2)` do not affect
+/// the original namespace.
+pub struct UtNamespace {
+    pub nodename: [c_char; 65],
+    pub domainname: [c_char; 65],
+}
+
+impl UtNamespace {
+    /// Create the initial root UTS namespace with default values.
+    pub fn new_root() -> Self {
+        Self {
+            nodename: pad_str("starry"),
+            domainname: pad_str("https://github.com/Starry-OS/StarryOS"),
+        }
+    }
+
+    /// Clone the namespace (shallow copy of nodename/domainname).
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            nodename: self.nodename,
+            domainname: self.domainname,
+        }
+    }
+}
+
+/// Build a `new_utsname` from a UTS namespace.
+/// The `sysname`, `release`, `version`, and `machine` fields are
+/// system-wide constants; only `nodename` and `domainname` are
+/// per-namespace.
+pub fn build_utsname(ns: &UtNamespace) -> linux_raw_sys::system::new_utsname {
+    linux_raw_sys::system::new_utsname {
+        sysname: pad_str("Linux"),
+        nodename: ns.nodename,
+        release: pad_str("10.0.0"),
+        version: pad_str("10.0.0"),
+        machine: pad_str(ARCH),
+        domainname: ns.domainname,
+    }
+}

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -79,6 +79,7 @@ rdrive = { workspace = true, optional = true }
 
 axbacktrace = { workspace = true }
 ax-errno = { workspace = true }
+axnsproxy = { workspace = true }
 axfs-ng-vfs = { workspace = true }
 ax-io = { workspace = true }
 axpoll = { workspace = true }

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -24,6 +24,9 @@ qemu = [
   "ax-feat/display",
   "starry-kernel/input",
   "starry-kernel/vsock", # auxilary features
+  "ax-driver/pci",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
 ]
 smp = ["ax-feat/smp", "axplat-dyn?/smp", "axplat-riscv64-visionfive2?/smp"]
 


### PR DESCRIPTION
- Create axnsproxy crate with NsProxy aggregator
- Add UtNamespace, IpcNamespace, NetNamespace, PidNamespace, UserNamespace, MntNamespace stubs
- Each type follows the same pattern: new_root() + clone_ns() + ROOT_XXX_NS
- Connect axnsproxy to kernel and starryos via Cargo.toml dependencies
（好合并）