### PR TITLE
feat: implement sys_unshare and clone namespace inheritance

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -116,16 +116,10 @@ impl CloneArgs {
             return Err(AxError::InvalidInput);
         }
 
-        let namespace_flags = CloneFlags::NEWNS
-            | CloneFlags::NEWIPC
-            | CloneFlags::NEWNET
-            | CloneFlags::NEWPID
-            | CloneFlags::NEWUSER
-            | CloneFlags::NEWUTS
-            | CloneFlags::NEWCGROUP;
-
-        if flags.intersects(namespace_flags) {
-            warn!("sys_clone/sys_clone3: namespace flags detected, stub support only");
+        // CLONE_NEWCGROUP is not yet implemented.
+        if flags.contains(CloneFlags::NEWCGROUP) {
+            error!("sys_clone/sys_clone3: unsupported namespace flag CLONE_NEWCGROUP");
+            return Err(AxError::InvalidInput);
         }
 
         Ok(())
@@ -241,6 +235,42 @@ impl CloneArgs {
             // supposed to enforce. Verified via Linux host: parent sets 0,
             // fork child PR_GET_DUMPABLE returns 0.
             proc_data.set_dumpable(old_proc_data.dumpable());
+
+            // Inherit the parent's namespace proxy, then unshare
+            // each namespace for which a CLONE_NEW* flag is set.
+            let mut new_nsproxy = old_proc_data.nsproxy.lock().clone_all();
+            if flags.contains(CloneFlags::NEWUTS) {
+                new_nsproxy.unshare_uts();
+            }
+            if flags.contains(CloneFlags::NEWIPC) {
+                new_nsproxy.unshare_ipc();
+            }
+            if flags.contains(CloneFlags::NEWNS) {
+                new_nsproxy.unshare_mnt();
+            }
+            if flags.contains(CloneFlags::NEWPID) {
+                new_nsproxy.unshare_pid();
+                new_nsproxy.pid_ns.lock().alloc_local_pid(tid as u64);
+            }
+            if flags.contains(CloneFlags::NEWNET) {
+                new_nsproxy.unshare_net();
+            }
+            if flags.contains(CloneFlags::NEWUSER) {
+                new_nsproxy.unshare_user();
+            }
+
+            // Consume a pending child PID namespace prepared by
+            // unshare(CLONE_NEWPID) in the parent (Linux: the parent is
+            // not moved; the child becomes PID 1 in the new namespace).
+            if !flags.contains(CloneFlags::NEWPID) {
+                let mut parent_ns = old_proc_data.nsproxy.lock();
+                if let Some(child_pid_ns) = parent_ns.child_pid_ns.take() {
+                    new_nsproxy.pid_ns = child_pid_ns;
+                    new_nsproxy.pid_ns.lock().alloc_local_pid(tid as u64);
+                }
+            }
+
+            *proc_data.nsproxy.lock() = new_nsproxy;
 
             {
                 let mut scope = proc_data.scope.write();

--- a/os/StarryOS/kernel/src/syscall/task/namespace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/namespace.rs
@@ -1,0 +1,43 @@
+use ax_errno::{AxError, AxResult};
+use ax_task::current;
+use linux_raw_sys::general::{
+    CLONE_NEWIPC, CLONE_NEWNET, CLONE_NEWNS, CLONE_NEWPID, CLONE_NEWUSER, CLONE_NEWUTS,
+};
+
+use crate::task::AsThread;
+
+const SUPPORTED_NS_FLAGS: u32 =
+    CLONE_NEWUTS | CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWNET | CLONE_NEWIPC | CLONE_NEWUSER;
+
+/// unshare(2) — disassociate parts of the process execution context.
+pub fn sys_unshare(flags: u32) -> AxResult<isize> {
+    if flags & !SUPPORTED_NS_FLAGS != 0 {
+        warn!("sys_unshare: unsupported flags {:#x}", flags);
+        return Err(AxError::InvalidInput);
+    }
+
+    let curr = current();
+    let proc_data = &curr.as_thread().proc_data;
+    let mut nsproxy = proc_data.nsproxy.lock();
+
+    if flags & CLONE_NEWUTS != 0 {
+        nsproxy.unshare_uts();
+    }
+    if flags & CLONE_NEWPID != 0 {
+        nsproxy.prepare_child_pid_ns();
+    }
+    if flags & CLONE_NEWNS != 0 {
+        nsproxy.unshare_mnt();
+    }
+    if flags & CLONE_NEWNET != 0 {
+        nsproxy.unshare_net();
+    }
+    if flags & CLONE_NEWIPC != 0 {
+        nsproxy.unshare_ipc();
+    }
+    if flags & CLONE_NEWUSER != 0 {
+        nsproxy.unshare_user();
+    }
+
+    Ok(0)
+}


### PR DESCRIPTION
- sys_unshare handles all 6 namespace flags (UTS/IPC/MNT/PID/NET/USER)
- do_clone supports CLONE_NEW* inheritance for all 6 types
- CLONE_NEWPID allocates local PID in child's pid_ns
（好合并）