### PR TITLE
feat: add IPC namespace isolation for shared memory and message queues

### DIFF
--- a/os/StarryOS/kernel/src/syscall/ipc/msg.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/msg.rs
@@ -15,6 +15,20 @@ use super::{
 };
 use crate::task::{AsThread, WaitQueue as MsgWaitQueue};
 
+fn current_ipc_ns_id() -> u64 {
+    let curr = current();
+    let thr = curr.as_thread();
+    thr.proc_data.nsproxy.lock().ipc_ns.lock().ns_id
+}
+
+fn msg_ns_check(queue: &MessageQueue) -> AxResult<()> {
+    let ns_id = current_ipc_ns_id();
+    if queue.ns_id != ns_id {
+        return Err(AxError::from(LinuxError::EINVAL));
+    }
+    Ok(())
+}
+
 /// Data structure describing a message queue.
 #[repr(C)]
 #[derive(Clone, Copy, AnyBitPattern)]
@@ -93,11 +107,13 @@ pub struct MessageQueue {
     pub recv_wait_queue: Arc<MsgWaitQueue>,
     /// Marked for removal
     pub mark_removed: bool,
+    /// IPC namespace id that owns this queue.
+    pub ns_id: u64,
 }
 
 impl MessageQueue {
     /// Creates a new [`MessageQueue`].
-    pub fn new(key: i32, mode: __kernel_mode_t, pid: Pid, uid: u32, gid: u32) -> Self {
+    pub fn new(key: i32, mode: __kernel_mode_t, pid: Pid, uid: u32, gid: u32, ns_id: u64) -> Self {
         MessageQueue {
             msqid_ds: msqid_ds::new(key, mode, pid as __kernel_pid_t, uid, gid),
             messages: BTreeMap::new(),
@@ -106,6 +122,7 @@ impl MessageQueue {
             send_wait_queue: Arc::new(MsgWaitQueue::new()),
             recv_wait_queue: Arc::new(MsgWaitQueue::new()),
             mark_removed: false,
+            ns_id,
         }
     }
 
@@ -335,16 +352,6 @@ impl MsgManager {
         self.key_msqid.retain(|_, &mut v| v != msqid);
         self.msqid_queues.remove(&msqid);
     }
-
-    /// get total bytes in all queues
-    pub fn total_bytes(&self) -> usize {
-        self.iter_active_queues()
-            .map(|(_, queue)| {
-                let guard = queue.lock();
-                guard.total_bytes
-            })
-            .sum()
-    }
 }
 
 /// System limits
@@ -408,12 +415,14 @@ pub fn sys_msgget(key: i32, msgflg: i32) -> AxResult<isize> {
     // Handle IPC_PRIVATE (always create new queue)
     if key == IPC_PRIVATE {
         let msqid = next_ipc_id();
+        let ns_id = proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
         let msg_queue = Arc::new(Mutex::new(MessageQueue::new(
             key,
             (msgflg & 0o777) as _,
             current_pid,
             current_uid,
             current_gid,
+            ns_id,
         )));
 
         msg_manager.insert_msqid_queues(msqid, msg_queue);
@@ -457,12 +466,14 @@ pub fn sys_msgget(key: i32, msgflg: i32) -> AxResult<isize> {
     }
 
     let msqid = next_ipc_id();
+    let ns_id = proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
     let msg_queue = Arc::new(Mutex::new(MessageQueue::new(
         key,
         (msgflg & 0o777) as _,
         current_pid,
         current_uid,
         current_gid,
+        ns_id,
     )));
 
     msg_manager.insert_key_msqid(key, msqid);
@@ -773,7 +784,17 @@ pub fn sys_msgctl(msqid: i32, cmd: i32, buf: usize) -> AxResult<isize> {
     // MSG_INFO (put before looking up the queue!)
     if cmd == MSG_INFO {
         let msg_manager = MSG_MANAGER.lock();
-        // Manually create IpcPerm
+        let ns_id = current_ipc_ns_id();
+        let (count, bytes) = msg_manager
+            .iter_active_queues()
+            .filter(|(_, q)| {
+                let guard = q.lock();
+                guard.ns_id == ns_id && !guard.mark_removed
+            })
+            .fold((0u64, 0u64), |(c, b), (_, q)| {
+                let guard = q.lock();
+                (c + 1, b + guard.total_bytes as u64)
+            });
         let msg_perm = IpcPerm {
             key: 0,
             uid: current_uid,
@@ -787,34 +808,33 @@ pub fn sys_msgctl(msqid: i32, cmd: i32, buf: usize) -> AxResult<isize> {
             unused1: 0,
         };
 
-        // Create a temporary msqid_ds to return information
         let info_ds = msqid_ds {
             msg_perm,
             msg_stime: 0,
             msg_rtime: 0,
             msg_ctime: 0,
-            msg_cbytes: msg_manager.total_bytes() as u64,
-            // Use msg_qnum to return the number of allocated queues
-            msg_qnum: msg_manager.queue_count() as u64,
-            // Use msg_qbytes to return system limits or usage
+            msg_cbytes: bytes,
+            msg_qnum: count,
             msg_qbytes: MSGMNB as u64,
             msg_lspid: Pid::from(0u32) as _,
             msg_lrpid: Pid::from(0u32) as _,
         };
 
-        // Copy to user space
         let ptr = buf as *mut msqid_ds;
         ptr.vm_write(info_ds)?;
-
-        // Return the current number of allocated queues
-        return Ok(msg_manager.queue_count() as isize);
+        return Ok(count as isize);
     }
     // MSG_STAT handling
     if cmd == MSG_STAT {
+        let ns_id = current_ipc_ns_id();
         let msg_manager = MSG_MANAGER.lock();
 
         let result = msg_manager
             .iter_active_queues()
+            .filter(|(_, q)| {
+                let guard = q.lock();
+                guard.ns_id == ns_id
+            })
             .nth(msqid as usize)
             .ok_or(AxError::from(LinuxError::EINVAL))
             .and_then(|(actual_msqid, queue)| {
@@ -847,6 +867,7 @@ pub fn sys_msgctl(msqid: i32, cmd: i32, buf: usize) -> AxResult<isize> {
 
     // Lock the internal structure of the queue
     let mut msg_queue = msg_queue.lock();
+    msg_ns_check(&msg_queue)?;
     // Check if the queue is marked as removed
     if msg_queue.mark_removed {
         return Err(AxError::from(LinuxError::EIDRM)); // EIDRM - Queue has been removed

--- a/os/StarryOS/kernel/src/syscall/ipc/shm.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/shm.rs
@@ -8,10 +8,17 @@ use ax_hal::{
 use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr, VirtAddrRange};
 use ax_sync::Mutex;
 use ax_task::current;
-use linux_raw_sys::{ctypes::c_ushort, general::*};
+use bytemuck::AnyBitPattern;
+use linux_raw_sys::{
+    ctypes::{c_ulong, c_ushort},
+    general::*,
+};
 use starry_process::Pid;
+use starry_vm::VmMutPtr;
 
-use super::{IPC_CREAT, IPC_EXCL, IPC_PRIVATE, IPC_RMID, IPC_SET, IPC_STAT, IpcPerm, next_ipc_id};
+use super::{
+    IPC_CREAT, IPC_EXCL, IPC_INFO, IPC_PRIVATE, IPC_RMID, IPC_SET, IPC_STAT, IpcPerm, next_ipc_id,
+};
 use crate::{
     mm::{AddrSpace, Backend, SharedPages, UserPtr, nullable},
     task::AsThread,
@@ -85,6 +92,27 @@ impl ShmidDs {
     }
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, AnyBitPattern)]
+struct ShmInfo64 {
+    shmmax: c_ulong,
+    shmmin: c_ulong,
+    shmmni: c_ulong,
+    shmseg: c_ulong,
+    shmall: c_ulong,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, AnyBitPattern)]
+struct ShmInfo {
+    used_ids: i32,
+    shm_tot: c_ulong,
+    shm_rss: c_ulong,
+    shm_swp: c_ulong,
+    swap_attempts: c_ulong,
+    swap_successes: c_ulong,
+}
+
 /// This struct is used to maintain the shmem in kernel.
 pub struct ShmInner {
     /// Shared memory segment identifier.
@@ -100,6 +128,8 @@ pub struct ShmInner {
     pub mapping_flags: MappingFlags,
     /// c type struct, used in shm_ctl
     pub shmid_ds: ShmidDs,
+    /// IPC namespace id that owns this segment.
+    pub ns_id: u64,
 }
 
 impl ShmInner {
@@ -112,6 +142,7 @@ impl ShmInner {
         pid: Pid,
         uid: u32,
         gid: u32,
+        ns_id: u64,
     ) -> Self {
         ShmInner {
             shmid,
@@ -128,6 +159,7 @@ impl ShmInner {
                 uid,
                 gid,
             ),
+            ns_id,
         }
     }
 
@@ -263,7 +295,7 @@ pub struct ShmManager {
     /// key <-> shm_id
     key_shmid: BiBTreeMap<i32, i32>,
     /// shm_id -> shm_inner
-    shmid_inner: BTreeMap<i32, Arc<Mutex<ShmInner>>>,
+    pub(crate) shmid_inner: BTreeMap<i32, Arc<Mutex<ShmInner>>>,
     /// pid -> shm_id <-> vaddr
     pid_shmid_vaddr: BTreeMap<Pid, BiBTreeMap<i32, VirtAddr>>,
 }
@@ -445,19 +477,31 @@ pub fn sys_shmget(key: i32, size: usize, shmflg: usize) -> AxResult<isize> {
     let cred = thread.cred();
     let mut shm_manager = SHM_MANAGER.lock();
 
+    let ns_id = thread.proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
+
     if key != IPC_PRIVATE {
         // A segment already exists for this key.
         if let Some(shmid) = shm_manager.get_shmid_by_key(key) {
-            // IPC_CREAT | IPC_EXCL requires the creation to fail when the
-            // segment is already present. See Linux ipcget_public().
-            if shmflg & IPC_CREAT as usize != 0 && shmflg & IPC_EXCL as usize != 0 {
-                return Err(AxError::AlreadyExists);
-            }
             let shm_inner = shm_manager
                 .get_inner_by_shmid(shmid)
                 .ok_or(AxError::NotFound)?;
-            let mut shm_inner = shm_inner.lock();
-            return shm_inner.try_update(size, cur_pid);
+            let shm_inner = shm_inner.lock();
+            // Only match if the segment lives in our IPC namespace.
+            if shm_inner.ns_id == ns_id {
+                // IPC_CREAT | IPC_EXCL requires the creation to fail when the
+                // segment is already present. See Linux ipcget_public().
+                if shmflg & IPC_CREAT as usize != 0 && shmflg & IPC_EXCL as usize != 0 {
+                    return Err(AxError::AlreadyExists);
+                }
+                drop(shm_inner);
+                let shm_inner = shm_manager
+                    .get_inner_by_shmid(shmid)
+                    .ok_or(AxError::NotFound)?;
+                let mut shm_inner = shm_inner.lock();
+                return shm_inner.try_update(size, cur_pid);
+            }
+            // Key exists in a different namespace — fall through and
+            // create a new segment in the current namespace.
         }
 
         // No segment exists for this key: create one only when IPC_CREAT
@@ -483,6 +527,7 @@ pub fn sys_shmget(key: i32, size: usize, shmflg: usize) -> AxResult<isize> {
         cur_pid,
         cred.euid,
         cred.egid,
+        ns_id,
     )));
     shm_manager.insert_key_shmid(key, shmid);
     shm_manager.insert_shmid_inner(shmid, shm_inner);
@@ -569,35 +614,82 @@ pub fn sys_shmat(shmid: i32, addr: usize, shmflg: u32) -> AxResult<isize> {
     Ok(start_addr.as_usize() as isize)
 }
 
+fn current_ipc_ns_id() -> u64 {
+    let curr = current();
+    let thr = curr.as_thread();
+    thr.proc_data.nsproxy.lock().ipc_ns.lock().ns_id
+}
+
+fn shm_ns_check(shm_inner: &ShmInner) -> AxResult<()> {
+    let ns_id = current_ipc_ns_id();
+    if shm_inner.ns_id != ns_id {
+        return Err(AxError::InvalidInput);
+    }
+    Ok(())
+}
+
 pub fn sys_shmctl(shmid: i32, cmd: u32, buf: UserPtr<ShmidDs>) -> AxResult<isize> {
     let cmd = cmd as i32;
+    let ns_id = current_ipc_ns_id();
+
+    // IPC_INFO and SHM_INFO don't use shmid.
+    if cmd == IPC_INFO {
+        let _shm_manager = SHM_MANAGER.lock();
+        let info = ShmInfo64 {
+            shmmax: 0x2000000,
+            shmmin: 1,
+            shmmni: 4096,
+            shmseg: 4096,
+            shmall: 0x2000000,
+        };
+        (buf.as_ptr() as *mut ShmInfo64).vm_write(info)?;
+        return Ok(0);
+    }
+
+    if cmd == 14 {
+        // SHM_INFO = 14 (Linux)
+        let shm_manager = SHM_MANAGER.lock();
+        let mut used_ids = 0i32;
+        let mut shm_tot = 0u64;
+        for inner_arc in shm_manager.shmid_inner.values() {
+            let inner = inner_arc.lock();
+            if inner.ns_id == ns_id {
+                used_ids += 1;
+                shm_tot += inner.page_num as u64;
+            }
+        }
+        let shm_info = ShmInfo {
+            used_ids,
+            shm_tot,
+            shm_rss: shm_tot,
+            shm_swp: 0,
+            swap_attempts: 0,
+            swap_successes: 0,
+        };
+        (buf.as_ptr() as *mut ShmInfo).vm_write(shm_info)?;
+        return Ok(0);
+    }
 
     if cmd == IPC_RMID {
-        // If no processes are attached, destroy the segment immediately.
-        // Otherwise mark it for deferred destruction and remove the key
-        // mapping so future shmget() calls won't find it. See Linux
-        // do_shm_rmid() in ipc/shm.c.
         let mut shm_manager = SHM_MANAGER.lock();
         let shm_inner_arc = shm_manager
             .get_inner_by_shmid(shmid)
             .ok_or(AxError::InvalidInput)?;
         let mut shm_inner = shm_inner_arc.lock();
+        shm_ns_check(&shm_inner)?;
 
         shm_inner.rmid = true;
         shm_inner.shmid_ds.shm_ctime = monotonic_time_nanos() as __kernel_time_t;
-
-        // Make private so no new shmget() finds it by key.
         shm_manager.make_private(shmid);
 
         if shm_inner.attach_count() == 0 {
             drop(shm_inner);
             shm_manager.remove_shmid(shmid);
         }
-
         return Ok(0);
     }
 
-    // IPC_SET and IPC_STAT only need shm_inner.
+    // IPC_SET and IPC_STAT
     let shm_inner_arc = {
         let shm_manager = SHM_MANAGER.lock();
         shm_manager
@@ -605,6 +697,7 @@ pub fn sys_shmctl(shmid: i32, cmd: u32, buf: UserPtr<ShmidDs>) -> AxResult<isize
             .ok_or(AxError::InvalidInput)?
     };
     let mut shm_inner = shm_inner_arc.lock();
+    shm_ns_check(&shm_inner)?;
 
     if cmd == IPC_SET {
         shm_inner.shmid_ds = *buf.get_as_mut()?;


### PR DESCRIPTION
- ShmInner.ns_id + filter by current process's ipc_ns on create/lookup/control
- MessageQueue.ns_id + filter by current process's ipc_ns on create/lookup/control
- IPC_INFO/SHM_INFO/MSG_INFO/MSG_STAT filtered to current namespace
（部分实现）