### PR TITLE
feat: nsproxy integration, unshare, clone, user credentials, and PID …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ members = [
     "drivers/usb/usb-if",
     "drivers/usb/utils/*",
 
+    "os/StarryOS/axnsproxy",
     "os/StarryOS/kernel",
     "os/StarryOS/starryos",
     "os/arceos/api/*",
@@ -345,6 +346,7 @@ sdhci-host = { version = "0.1.1", path = "drivers/blk/sdhci-host", default-featu
 sdmmc-protocol = { version = "0.1.1", path = "drivers/blk/sdmmc-protocol", default-features = false }
 smoltcp = { version = "0.13.1", default-features = false }
 smp-kernel = { version = "0.3.1", path = "components/axplat_crates/examples/smp-kernel" }
+axnsproxy = { version = "0.1.0", path = "os/StarryOS/axnsproxy" }
 starry-kernel = { version = "0.5.12", path = "os/StarryOS/kernel" }
 starry-process = { version = "0.4.7", path = "components/starry-process" }
 starry-signal = { version = "0.7.0", path = "components/starry-signal" }

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -79,6 +79,7 @@ rdrive = { workspace = true, optional = true }
 
 axbacktrace = { workspace = true }
 ax-errno = { workspace = true }
+axnsproxy = { workspace = true }
 axfs-ng-vfs = { workspace = true }
 ax-io = { workspace = true }
 axpoll = { workspace = true }

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -547,6 +547,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::fork => sys_fork(uctx),
         #[cfg(target_arch = "x86_64")]
         Sysno::vfork => sys_vfork(uctx),
+        Sysno::unshare => sys_unshare(uctx.arg0() as _),
         Sysno::exit => sys_exit(uctx.arg0() as _),
         Sysno::exit_group => sys_exit_group(uctx.arg0() as _),
         Sysno::wait4 => sys_waitpid(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
@@ -629,6 +630,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::setgroups => sys_setgroups(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::setfsuid => sys_setfsuid(uctx.arg0() as _),
         Sysno::setfsgid => sys_setfsgid(uctx.arg0() as _),
+        Sysno::sethostname => sys_sethostname(uctx.arg0() as _, uctx.arg1() as _),
+        Sysno::setdomainname => sys_setdomainname(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::uname => sys_uname(uctx.arg0() as _),
         Sysno::sysinfo => sys_sysinfo(uctx.arg0() as _),
         Sysno::syslog => sys_syslog(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),

--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -1,7 +1,6 @@
 use alloc::{sync::Arc, vec, vec::Vec};
 use core::{ffi::c_char, mem::MaybeUninit};
 
-use ax_config::ARCH;
 use ax_errno::{AxError, AxResult};
 use ax_fs::FS_CONTEXT;
 use ax_sync::Mutex;
@@ -119,27 +118,63 @@ fn dumpable_should_reset(old: &crate::task::Cred, new: &crate::task::Cred) -> bo
     old.euid != new.euid || old.egid != new.egid || old.fsuid != new.fsuid || old.fsgid != new.fsgid
 }
 
+fn user_ns_is_root() -> bool {
+    let curr = current();
+    let nsproxy = curr.as_thread().proc_data.nsproxy.lock();
+    nsproxy.user_ns.lock().is_root
+}
+
+fn user_ns_overflow_uid() -> u32 {
+    if user_ns_is_root() {
+        return 0;
+    }
+    65534
+}
+
 pub fn sys_getuid() -> AxResult<isize> {
+    let overflow = user_ns_overflow_uid();
+    if overflow != 0 {
+        return Ok(overflow as isize);
+    }
     let cred = current().as_thread().cred();
     Ok(cred.uid as isize)
 }
 
 pub fn sys_geteuid() -> AxResult<isize> {
+    let overflow = user_ns_overflow_uid();
+    if overflow != 0 {
+        return Ok(overflow as isize);
+    }
     let cred = current().as_thread().cred();
     Ok(cred.euid as isize)
 }
 
 pub fn sys_getgid() -> AxResult<isize> {
+    let overflow = user_ns_overflow_uid();
+    if overflow != 0 {
+        return Ok(overflow as isize);
+    }
     let cred = current().as_thread().cred();
     Ok(cred.gid as isize)
 }
 
 pub fn sys_getegid() -> AxResult<isize> {
+    let overflow = user_ns_overflow_uid();
+    if overflow != 0 {
+        return Ok(overflow as isize);
+    }
     let cred = current().as_thread().cred();
     Ok(cred.egid as isize)
 }
 
 pub fn sys_getresuid(ruid: *mut u32, euid: *mut u32, suid: *mut u32) -> AxResult<isize> {
+    let overflow = user_ns_overflow_uid();
+    if overflow != 0 {
+        ruid.vm_write(overflow)?;
+        euid.vm_write(overflow)?;
+        suid.vm_write(overflow)?;
+        return Ok(0);
+    }
     let cred = current().as_thread().cred();
     ruid.vm_write(cred.uid)?;
     euid.vm_write(cred.euid)?;
@@ -148,6 +183,13 @@ pub fn sys_getresuid(ruid: *mut u32, euid: *mut u32, suid: *mut u32) -> AxResult
 }
 
 pub fn sys_getresgid(rgid: *mut u32, egid: *mut u32, sgid: *mut u32) -> AxResult<isize> {
+    let overflow = user_ns_overflow_uid();
+    if overflow != 0 {
+        rgid.vm_write(overflow)?;
+        egid.vm_write(overflow)?;
+        sgid.vm_write(overflow)?;
+        return Ok(0);
+    }
     let cred = current().as_thread().cred();
     rgid.vm_write(cred.gid)?;
     egid.vm_write(cred.egid)?;
@@ -539,27 +581,62 @@ pub fn sys_setgroups(size: usize, list: *const u32) -> AxResult<isize> {
     Ok(0)
 }
 
-const fn pad_str(info: &str) -> [c_char; 65] {
-    let mut data: [c_char; 65] = [0; 65];
-    // this needs #![feature(const_copy_from_slice)]
-    // data[..info.len()].copy_from_slice(info.as_bytes());
-    unsafe {
-        core::ptr::copy_nonoverlapping(info.as_ptr().cast(), data.as_mut_ptr(), info.len());
-    }
-    data
+pub fn sys_uname(name: *mut new_utsname) -> AxResult<isize> {
+    let curr = current();
+    // Build the utsname inside a block so the SpinNoIrq guard is dropped
+    // before we touch user memory via vm_write (access_user_memory requires
+    // IRQs enabled, but SpinNoIrq disables them).
+    let uts = {
+        let nsproxy = curr.as_thread().proc_data.nsproxy.lock();
+        let ns = nsproxy.uts_ns.lock();
+        axnsproxy::build_utsname(&ns)
+    };
+    name.vm_write(uts)?;
+    Ok(0)
 }
 
-const UTSNAME: new_utsname = new_utsname {
-    sysname: pad_str("Linux"),
-    nodename: pad_str("starry"),
-    release: pad_str("10.0.0"),
-    version: pad_str("10.0.0"),
-    machine: pad_str(ARCH),
-    domainname: pad_str("https://github.com/Starry-OS/StarryOS"),
-};
+pub fn sys_sethostname(name: *const c_char, len: usize) -> AxResult<isize> {
+    if len > 64 {
+        return Err(AxError::InvalidInput);
+    }
+    let curr = current();
+    if curr.as_thread().cred().euid != 0 {
+        return Err(AxError::OperationNotPermitted);
+    }
+    let mut buf: Vec<MaybeUninit<u8>> = vec![MaybeUninit::uninit(); len];
+    vm_read_slice(name.cast::<u8>(), &mut buf)?;
+    let bytes: Vec<u8> = unsafe { buf.into_iter().map(|v| v.assume_init()).collect() };
+    let mut nodename: [c_char; 65] = [0; 65];
+    unsafe {
+        core::ptr::copy_nonoverlapping(bytes.as_ptr().cast::<c_char>(), nodename.as_mut_ptr(), len);
+    }
+    let proc_data = &curr.as_thread().proc_data;
+    proc_data.nsproxy.lock().uts_ns.lock().nodename = nodename;
+    Ok(0)
+}
 
-pub fn sys_uname(name: *mut new_utsname) -> AxResult<isize> {
-    name.vm_write(UTSNAME)?;
+pub fn sys_setdomainname(name: *const c_char, len: usize) -> AxResult<isize> {
+    if len > 64 {
+        return Err(AxError::InvalidInput);
+    }
+    let curr = current();
+    if curr.as_thread().cred().euid != 0 {
+        return Err(AxError::OperationNotPermitted);
+    }
+    let mut buf: Vec<MaybeUninit<u8>> = vec![MaybeUninit::uninit(); len];
+    vm_read_slice(name.cast::<u8>(), &mut buf)?;
+    // SAFETY: vm_read_slice filled buf with valid data from user space.
+    let bytes: Vec<u8> = unsafe { buf.into_iter().map(|v| v.assume_init()).collect() };
+    let mut domainname: [c_char; 65] = [0; 65];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            bytes.as_ptr().cast::<c_char>(),
+            domainname.as_mut_ptr(),
+            len,
+        );
+    }
+    let proc_data = &curr.as_thread().proc_data;
+    proc_data.nsproxy.lock().uts_ns.lock().domainname = domainname;
     Ok(0)
 }
 

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -116,16 +116,10 @@ impl CloneArgs {
             return Err(AxError::InvalidInput);
         }
 
-        let namespace_flags = CloneFlags::NEWNS
-            | CloneFlags::NEWIPC
-            | CloneFlags::NEWNET
-            | CloneFlags::NEWPID
-            | CloneFlags::NEWUSER
-            | CloneFlags::NEWUTS
-            | CloneFlags::NEWCGROUP;
-
-        if flags.intersects(namespace_flags) {
-            warn!("sys_clone/sys_clone3: namespace flags detected, stub support only");
+        // CLONE_NEWCGROUP is not yet implemented.
+        if flags.contains(CloneFlags::NEWCGROUP) {
+            error!("sys_clone/sys_clone3: unsupported namespace flag CLONE_NEWCGROUP");
+            return Err(AxError::InvalidInput);
         }
 
         Ok(())
@@ -241,6 +235,42 @@ impl CloneArgs {
             // supposed to enforce. Verified via Linux host: parent sets 0,
             // fork child PR_GET_DUMPABLE returns 0.
             proc_data.set_dumpable(old_proc_data.dumpable());
+
+            // Inherit the parent's namespace proxy, then unshare
+            // each namespace for which a CLONE_NEW* flag is set.
+            let mut new_nsproxy = old_proc_data.nsproxy.lock().clone_all();
+            if flags.contains(CloneFlags::NEWUTS) {
+                new_nsproxy.unshare_uts();
+            }
+            if flags.contains(CloneFlags::NEWIPC) {
+                new_nsproxy.unshare_ipc();
+            }
+            if flags.contains(CloneFlags::NEWNS) {
+                new_nsproxy.unshare_mnt();
+            }
+            if flags.contains(CloneFlags::NEWPID) {
+                new_nsproxy.unshare_pid();
+                new_nsproxy.pid_ns.lock().alloc_local_pid(tid as u64);
+            }
+            if flags.contains(CloneFlags::NEWNET) {
+                new_nsproxy.unshare_net();
+            }
+            if flags.contains(CloneFlags::NEWUSER) {
+                new_nsproxy.unshare_user();
+            }
+
+            // Consume a pending child PID namespace prepared by
+            // unshare(CLONE_NEWPID) in the parent (Linux: the parent is
+            // not moved; the child becomes PID 1 in the new namespace).
+            if !flags.contains(CloneFlags::NEWPID) {
+                let mut parent_ns = old_proc_data.nsproxy.lock();
+                if let Some(child_pid_ns) = parent_ns.child_pid_ns.take() {
+                    new_nsproxy.pid_ns = child_pid_ns;
+                    new_nsproxy.pid_ns.lock().alloc_local_pid(tid as u64);
+                }
+            }
+
+            *proc_data.nsproxy.lock() = new_nsproxy;
 
             {
                 let mut scope = proc_data.scope.write();

--- a/os/StarryOS/kernel/src/syscall/task/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/task/mod.rs
@@ -4,10 +4,12 @@ mod ctl;
 mod execve;
 mod exit;
 mod job;
+mod namespace;
 mod schedule;
 mod thread;
 mod wait;
 
 pub use self::{
-    clone::*, clone3::*, ctl::*, execve::*, exit::*, job::*, schedule::*, thread::*, wait::*,
+    clone::*, clone3::*, ctl::*, execve::*, exit::*, job::*, namespace::*, schedule::*, thread::*,
+    wait::*,
 };

--- a/os/StarryOS/kernel/src/syscall/task/namespace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/namespace.rs
@@ -1,0 +1,43 @@
+use ax_errno::{AxError, AxResult};
+use ax_task::current;
+use linux_raw_sys::general::{
+    CLONE_NEWIPC, CLONE_NEWNET, CLONE_NEWNS, CLONE_NEWPID, CLONE_NEWUSER, CLONE_NEWUTS,
+};
+
+use crate::task::AsThread;
+
+const SUPPORTED_NS_FLAGS: u32 =
+    CLONE_NEWUTS | CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWNET | CLONE_NEWIPC | CLONE_NEWUSER;
+
+/// unshare(2) — disassociate parts of the process execution context.
+pub fn sys_unshare(flags: u32) -> AxResult<isize> {
+    if flags & !SUPPORTED_NS_FLAGS != 0 {
+        warn!("sys_unshare: unsupported flags {:#x}", flags);
+        return Err(AxError::InvalidInput);
+    }
+
+    let curr = current();
+    let proc_data = &curr.as_thread().proc_data;
+    let mut nsproxy = proc_data.nsproxy.lock();
+
+    if flags & CLONE_NEWUTS != 0 {
+        nsproxy.unshare_uts();
+    }
+    if flags & CLONE_NEWPID != 0 {
+        nsproxy.prepare_child_pid_ns();
+    }
+    if flags & CLONE_NEWNS != 0 {
+        nsproxy.unshare_mnt();
+    }
+    if flags & CLONE_NEWNET != 0 {
+        nsproxy.unshare_net();
+    }
+    if flags & CLONE_NEWIPC != 0 {
+        nsproxy.unshare_ipc();
+    }
+    if flags & CLONE_NEWUSER != 0 {
+        nsproxy.unshare_user();
+    }
+
+    Ok(0)
+}

--- a/os/StarryOS/kernel/src/syscall/task/thread.rs
+++ b/os/StarryOS/kernel/src/syscall/task/thread.rs
@@ -4,7 +4,17 @@ use ax_task::current;
 use crate::task::AsThread;
 
 pub fn sys_getpid() -> AxResult<isize> {
-    Ok(current().as_thread().proc_data.proc.pid() as _)
+    let curr = current();
+    let thr = curr.as_thread();
+    let global_pid = thr.proc_data.proc.pid() as u64;
+    let nsproxy = thr.proc_data.nsproxy.lock();
+    let local = nsproxy.pid_ns.lock().local_pid(global_pid);
+    drop(nsproxy);
+    if let Some(local) = local {
+        Ok(local as isize)
+    } else {
+        Ok(global_pid as isize)
+    }
 }
 
 pub fn sys_getppid() -> AxResult<isize> {

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -511,6 +511,8 @@ pub struct ProcessData {
     aspace: SpinNoIrq<Arc<Mutex<AddrSpace>>>,
     /// The resource scope
     pub scope: RwLock<Scope>,
+    /// The namespace proxy — aggregates all namespace types for this process.
+    pub nsproxy: SpinNoIrq<axnsproxy::NsProxy>,
     /// The user heap top
     heap_top: AtomicUsize,
 
@@ -620,6 +622,8 @@ impl ProcessData {
             )),
 
             futex_table: Arc::new(FutexTable::new()),
+
+            nsproxy: SpinNoIrq::new(axnsproxy::NsProxy::new_root()),
 
             vfork_done: SpinNoIrq::new(None),
 


### PR DESCRIPTION
…namespace

- Replace uts_ns with nsproxy in ProcessData
- Implement sys_unshare for all 6 namespace flags
- Implement clone namespace inheritance for all 6 types
- Add user namespace credential filtering (getuid/getgid etc.)
- Add PID namespace translation for getpid
- Register new syscalls in syscall dispatch table
（可以合并）