### PR TITLE
feat: IPC namespace isolation and network namespace filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "axnsproxy"
+version = "0.1.0"
+dependencies = [
+ "ax-config",
+ "ax-errno",
+ "ax-kspin",
+ "linux-raw-sys 0.12.1",
+ "log",
+ "spin",
+]
+
+[[package]]
 name = "axpanic"
 version = "0.1.0"
 
@@ -7875,6 +7887,7 @@ dependencies = [
  "ax-task",
  "axbacktrace",
  "axfs-ng-vfs",
+ "axnsproxy",
  "axplat-dyn",
  "axpoll",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ members = [
     "drivers/usb/usb-if",
     "drivers/usb/utils/*",
 
+    "os/StarryOS/axnsproxy",
     "os/StarryOS/kernel",
     "os/StarryOS/starryos",
     "os/arceos/api/*",
@@ -345,6 +346,7 @@ sdhci-host = { version = "0.1.1", path = "drivers/blk/sdhci-host", default-featu
 sdmmc-protocol = { version = "0.1.1", path = "drivers/blk/sdmmc-protocol", default-features = false }
 smoltcp = { version = "0.13.1", default-features = false }
 smp-kernel = { version = "0.3.1", path = "components/axplat_crates/examples/smp-kernel" }
+axnsproxy = { version = "0.1.0", path = "os/StarryOS/axnsproxy" }
 starry-kernel = { version = "0.5.12", path = "os/StarryOS/kernel" }
 starry-process = { version = "0.4.7", path = "components/starry-process" }
 starry-signal = { version = "0.7.0", path = "components/starry-signal" }

--- a/os/StarryOS/axnsproxy/Cargo.toml
+++ b/os/StarryOS/axnsproxy/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "axnsproxy"
+version = "0.1.0"
+edition.workspace = true
+description = "Namespace proxy for Starry OS"
+keywords = ["starry-os"]
+repository = "https://github.com/Starry-OS/StarryOS"
+license = "Apache-2.0"
+
+[dependencies]
+ax-config = { workspace = true }
+ax-errno = { workspace = true }
+ax-kspin = { workspace = true }
+linux-raw-sys = { version = "0.12", default-features = false, features = [
+    "general",
+    "no_std",
+    "system",
+] }
+log = "0.4"
+spin = { workspace = true }

--- a/os/StarryOS/axnsproxy/src/ipc.rs
+++ b/os/StarryOS/axnsproxy/src/ipc.rs
@@ -1,0 +1,34 @@
+use alloc::sync::Arc;
+use core::sync::atomic::AtomicU64;
+
+use ax_kspin::SpinNoIrq;
+
+static NEXT_IPC_NS_ID: AtomicU64 = AtomicU64::new(0);
+
+/// The initial root IPC namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWIPC)` or `clone(CLONE_NEWIPC)`.
+pub static ROOT_IPC_NS: spin::Lazy<Arc<SpinNoIrq<IpcNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(IpcNamespace::new_root())));
+
+/// Per-process IPC namespace.
+///
+/// Isolates System V IPC objects (shared memory, semaphores, message
+/// queues) and POSIX message queues so that processes in different
+/// IPC namespaces cannot access each other's IPC resources.
+pub struct IpcNamespace {
+    pub ns_id: u64,
+}
+
+impl IpcNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            ns_id: NEXT_IPC_NS_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed),
+        }
+    }
+
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            ns_id: NEXT_IPC_NS_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed),
+        }
+    }
+}

--- a/os/StarryOS/axnsproxy/src/lib.rs
+++ b/os/StarryOS/axnsproxy/src/lib.rs
@@ -1,0 +1,118 @@
+#![no_std]
+
+extern crate alloc;
+
+mod ipc;
+mod mnt;
+mod net;
+mod pid;
+mod user;
+mod uts;
+
+use alloc::sync::Arc;
+
+use ax_kspin::SpinNoIrq;
+pub use ipc::{IpcNamespace, ROOT_IPC_NS};
+pub use mnt::{MntNamespace, ROOT_MNT_NS};
+pub use net::{NetNamespace, ROOT_NET_NS};
+pub use pid::{PidNamespace, ROOT_PID_NS};
+pub use user::{ROOT_USER_NS, UserNamespace};
+pub use uts::{ROOT_UTS_NS, UtNamespace, build_utsname};
+
+/// Aggregates all namespace types for a process.
+///
+/// `ProcessData` holds a single `SpinNoIrq<NsProxy>` field.  Clone and unshare
+/// operations work through `NsProxy` methods so that syscall handlers do not
+/// manipulate namespace internals directly.
+pub struct NsProxy {
+    /// The UTS namespace (hostname, domainname).
+    pub uts_ns: Arc<SpinNoIrq<UtNamespace>>,
+    /// The IPC namespace (System V IPC objects).
+    pub ipc_ns: Arc<SpinNoIrq<IpcNamespace>>,
+    /// The mount namespace (filesystem mount points).
+    pub mnt_ns: Arc<SpinNoIrq<MntNamespace>>,
+    /// The PID namespace (process ID numbering).
+    pub pid_ns: Arc<SpinNoIrq<PidNamespace>>,
+    /// Pending PID namespace for the next child created via
+    /// `unshare(CLONE_NEWPID)`.  Linux does not move the calling
+    /// process into a new PID namespace; instead the next fork/clone
+    /// child becomes the first process (PID 1) in the new namespace.
+    pub child_pid_ns: Option<Arc<SpinNoIrq<PidNamespace>>>,
+    /// The network namespace (interfaces, routing, sockets).
+    pub net_ns: Arc<SpinNoIrq<NetNamespace>>,
+    /// The user namespace (UID/GID mappings).
+    pub user_ns: Arc<SpinNoIrq<UserNamespace>>,
+}
+
+impl NsProxy {
+    /// Create a new [`NsProxy`] pointing to the root namespaces.
+    pub fn new_root() -> Self {
+        Self {
+            uts_ns: ROOT_UTS_NS.clone(),
+            ipc_ns: ROOT_IPC_NS.clone(),
+            mnt_ns: ROOT_MNT_NS.clone(),
+            pid_ns: ROOT_PID_NS.clone(),
+            child_pid_ns: None,
+            net_ns: ROOT_NET_NS.clone(),
+            user_ns: ROOT_USER_NS.clone(),
+        }
+    }
+
+    /// Clone all namespace references (shallow `Arc` clone).
+    ///
+    /// Used by `fork` / `clone` (without `CLONE_NEW*` flags) so the child
+    /// shares the same namespaces as the parent.  `child_pid_ns` is never
+    /// inherited — it is consumed by the first child that uses it.
+    pub fn clone_all(&self) -> Self {
+        Self {
+            uts_ns: self.uts_ns.clone(),
+            ipc_ns: self.ipc_ns.clone(),
+            mnt_ns: self.mnt_ns.clone(),
+            pid_ns: self.pid_ns.clone(),
+            child_pid_ns: None,
+            net_ns: self.net_ns.clone(),
+            user_ns: self.user_ns.clone(),
+        }
+    }
+
+    pub fn unshare_uts(&mut self) {
+        let new_inner = self.uts_ns.lock().clone_ns();
+        self.uts_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    pub fn unshare_ipc(&mut self) {
+        let new_inner = self.ipc_ns.lock().clone_ns();
+        self.ipc_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    pub fn unshare_mnt(&mut self) {
+        let new_inner = self.mnt_ns.lock().clone_ns();
+        self.mnt_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    /// Directly replace the PID namespace — used in `clone(CLONE_NEWPID)`.
+    pub fn unshare_pid(&mut self) {
+        let new_inner = self.pid_ns.lock().clone_ns();
+        self.pid_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    /// Prepare a new PID namespace for the next child of this process.
+    ///
+    /// Called by `unshare(CLONE_NEWPID)`.  The calling process stays in
+    /// its current PID namespace; the new namespace is consumed by the
+    /// next `fork` / `clone` child, which becomes PID 1 in that namespace.
+    pub fn prepare_child_pid_ns(&mut self) {
+        let new_inner = self.pid_ns.lock().clone_ns();
+        self.child_pid_ns = Some(Arc::new(SpinNoIrq::new(new_inner)));
+    }
+
+    pub fn unshare_net(&mut self) {
+        let new_inner = self.net_ns.lock().clone_ns();
+        self.net_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+
+    pub fn unshare_user(&mut self) {
+        let new_inner = self.user_ns.lock().clone_ns();
+        self.user_ns = Arc::new(SpinNoIrq::new(new_inner));
+    }
+}

--- a/os/StarryOS/axnsproxy/src/mnt.rs
+++ b/os/StarryOS/axnsproxy/src/mnt.rs
@@ -1,0 +1,37 @@
+use alloc::sync::Arc;
+use core::ffi::c_char;
+
+use ax_kspin::SpinNoIrq;
+
+/// The initial root mount namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWNS)` or `clone(CLONE_NEWNS)`.
+pub static ROOT_MNT_NS: spin::Lazy<Arc<SpinNoIrq<MntNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(MntNamespace::new_root())));
+
+const fn pad_mnt_root(root: &str) -> [c_char; 256] {
+    let mut data: [c_char; 256] = [0; 256];
+    unsafe {
+        core::ptr::copy_nonoverlapping(root.as_ptr().cast(), data.as_mut_ptr(), root.len());
+    }
+    data
+}
+
+/// Per-process mount namespace.
+///
+/// Isolates the set of filesystem mount points seen by a process.
+/// In the root namespace `root` starts as `"/"`.
+pub struct MntNamespace {
+    pub root: [c_char; 256],
+}
+
+impl MntNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            root: pad_mnt_root("/"),
+        }
+    }
+
+    pub fn clone_ns(&self) -> Self {
+        Self { root: self.root }
+    }
+}

--- a/os/StarryOS/axnsproxy/src/net.rs
+++ b/os/StarryOS/axnsproxy/src/net.rs
@@ -1,0 +1,34 @@
+use alloc::sync::Arc;
+use core::sync::atomic::AtomicU64;
+
+use ax_kspin::SpinNoIrq;
+
+static NEXT_NET_NS_ID: AtomicU64 = AtomicU64::new(0);
+
+/// The initial root network namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWNET)` or `clone(CLONE_NEWNET)`.
+pub static ROOT_NET_NS: spin::Lazy<Arc<SpinNoIrq<NetNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(NetNamespace::new_root())));
+
+/// Per-process network namespace.
+///
+/// Isolates network interfaces, routing tables, firewall rules, and
+/// sockets so that processes in different network namespaces see
+/// independent network stacks.
+pub struct NetNamespace {
+    pub ns_id: u64,
+}
+
+impl NetNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            ns_id: NEXT_NET_NS_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed),
+        }
+    }
+
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            ns_id: NEXT_NET_NS_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed),
+        }
+    }
+}

--- a/os/StarryOS/axnsproxy/src/pid.rs
+++ b/os/StarryOS/axnsproxy/src/pid.rs
@@ -1,0 +1,56 @@
+use alloc::{collections::BTreeMap, sync::Arc};
+
+use ax_kspin::SpinNoIrq;
+
+/// The initial root PID namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWPID)` or `clone(CLONE_NEWPID)`.
+pub static ROOT_PID_NS: spin::Lazy<Arc<SpinNoIrq<PidNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(PidNamespace::new_root())));
+
+/// Per-process PID namespace.
+///
+/// Each PID namespace has a nesting `level` (0 for the root namespace,
+/// incremented for each nested PID namespace) and isolates PID numbering
+/// so that processes in different PID namespaces may have the same PID
+/// value as seen from within their respective namespace.
+pub struct PidNamespace {
+    /// PID namespace nesting level.  Root is 0, first child is 1, etc.
+    pub level: u32,
+    /// Next local PID to allocate in this namespace (starts at 1).
+    next_pid: u32,
+    /// Map from global TID to namespace-local PID.
+    pid_map: BTreeMap<u64, u32>,
+}
+
+impl PidNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            level: 0,
+            next_pid: 1,
+            pid_map: BTreeMap::new(),
+        }
+    }
+
+    /// Create a fresh child PID namespace (level + 1, empty pid map,
+    /// next_pid starts at 1).
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            level: self.level + 1,
+            next_pid: 1,
+            pid_map: BTreeMap::new(),
+        }
+    }
+
+    /// Allocate a namespace-local PID for the given global TID.
+    pub fn alloc_local_pid(&mut self, global_tid: u64) -> u32 {
+        let local = self.next_pid;
+        self.next_pid += 1;
+        self.pid_map.insert(global_tid, local);
+        local
+    }
+
+    /// Resolve a global TID to its namespace-local PID.
+    pub fn local_pid(&self, global_tid: u64) -> Option<u32> {
+        self.pid_map.get(&global_tid).copied()
+    }
+}

--- a/os/StarryOS/axnsproxy/src/user.rs
+++ b/os/StarryOS/axnsproxy/src/user.rs
@@ -1,0 +1,43 @@
+use alloc::sync::Arc;
+
+use ax_kspin::SpinNoIrq;
+
+/// The initial root user namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWUSER)` or `clone(CLONE_NEWUSER)`.
+pub static ROOT_USER_NS: spin::Lazy<Arc<SpinNoIrq<UserNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(UserNamespace::new_root())));
+
+/// Per-process user namespace.
+///
+/// Isolates UID/GID mappings so that a process may have uid 0 inside
+/// its namespace while mapping to an unprivileged UID in the parent.
+/// `owner_uid` is the effective UID of the process that created the
+/// namespace (0 for the root namespace).
+///
+/// When `is_root` is false (child namespace without configured mappings),
+/// all UIDs/GIDs are reported as `nobody` (65534), matching Linux default
+/// behaviour for unconfigured user namespaces.
+pub struct UserNamespace {
+    /// Effective UID of the namespace creator (0 for root namespace).
+    pub owner_uid: u32,
+    /// Whether this is the initial root user namespace.  false for
+    /// namespaces created via unshare / clone(CLONE_NEWUSER) that
+    /// have not yet had uid_map / gid_map configured.
+    pub is_root: bool,
+}
+
+impl UserNamespace {
+    pub fn new_root() -> Self {
+        Self {
+            owner_uid: 0,
+            is_root: true,
+        }
+    }
+
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            owner_uid: self.owner_uid,
+            is_root: false,
+        }
+    }
+}

--- a/os/StarryOS/axnsproxy/src/uts.rs
+++ b/os/StarryOS/axnsproxy/src/uts.rs
@@ -1,0 +1,61 @@
+use alloc::sync::Arc;
+use core::ffi::c_char;
+
+use ax_config::ARCH;
+use ax_kspin::SpinNoIrq;
+
+/// The initial root UTS namespace, shared by all processes until
+/// they call `unshare(CLONE_NEWUTS)`.
+pub static ROOT_UTS_NS: spin::Lazy<Arc<SpinNoIrq<UtNamespace>>> =
+    spin::Lazy::new(|| Arc::new(SpinNoIrq::new(UtNamespace::new_root())));
+
+const fn pad_str(info: &str) -> [c_char; 65] {
+    let mut data: [c_char; 65] = [0; 65];
+    unsafe {
+        core::ptr::copy_nonoverlapping(info.as_ptr().cast(), data.as_mut_ptr(), info.len());
+    }
+    data
+}
+
+/// Per-process UTS namespace, containing the hostname and domain name
+/// visible to `uname(2)`.  When a process calls `unshare(CLONE_NEWUTS)` or
+/// `clone(CLONE_NEWUTS)`, it receives a fresh copy of the parent namespace
+/// so that subsequent `sethostname(2)` / `setdomainname(2)` do not affect
+/// the original namespace.
+pub struct UtNamespace {
+    pub nodename: [c_char; 65],
+    pub domainname: [c_char; 65],
+}
+
+impl UtNamespace {
+    /// Create the initial root UTS namespace with default values.
+    pub fn new_root() -> Self {
+        Self {
+            nodename: pad_str("starry"),
+            domainname: pad_str("https://github.com/Starry-OS/StarryOS"),
+        }
+    }
+
+    /// Clone the namespace (shallow copy of nodename/domainname).
+    pub fn clone_ns(&self) -> Self {
+        Self {
+            nodename: self.nodename,
+            domainname: self.domainname,
+        }
+    }
+}
+
+/// Build a `new_utsname` from a UTS namespace.
+/// The `sysname`, `release`, `version`, and `machine` fields are
+/// system-wide constants; only `nodename` and `domainname` are
+/// per-namespace.
+pub fn build_utsname(ns: &UtNamespace) -> linux_raw_sys::system::new_utsname {
+    linux_raw_sys::system::new_utsname {
+        sysname: pad_str("Linux"),
+        nodename: ns.nodename,
+        release: pad_str("10.0.0"),
+        version: pad_str("10.0.0"),
+        machine: pad_str(ARCH),
+        domainname: ns.domainname,
+    }
+}

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -79,6 +79,7 @@ rdrive = { workspace = true, optional = true }
 
 axbacktrace = { workspace = true }
 ax-errno = { workspace = true }
+axnsproxy = { workspace = true }
 axfs-ng-vfs = { workspace = true }
 ax-io = { workspace = true }
 axpoll = { workspace = true }

--- a/os/StarryOS/kernel/src/file/net.rs
+++ b/os/StarryOS/kernel/src/file/net.rs
@@ -8,6 +8,7 @@ use core::{
 };
 
 use ax_errno::{AxError, AxResult};
+use ax_task::current;
 use axnet::{
     RecvOptions, SendOptions, Socket as SocketInner, SocketOps,
     options::{Configurable, GetSocketOption, SetSocketOption},
@@ -24,7 +25,10 @@ use linux_raw_sys::{
 use starry_vm::{VmMutPtr, vm_read_slice, vm_write_slice};
 
 use super::{FileLike, Kstat};
-use crate::file::{IoDst, IoSrc, get_file_like};
+use crate::{
+    file::{IoDst, IoSrc, get_file_like},
+    task::AsThread,
+};
 
 const ETH0_NAME: &[u8] = b"eth0";
 const ETH0_HWADDR: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
@@ -102,10 +106,21 @@ fn read_ifreq_interface(arg: usize) -> AxResult<NetInterface> {
     let name = read_user_bytes::<IFREQ_NAME_LEN>(arg as *const u8)?;
     let end = name.iter().position(|&b| b == 0).unwrap_or(name.len());
     match &name[..end] {
-        ETH0_NAME => Ok(NetInterface::Eth0),
+        ETH0_NAME => {
+            if !in_root_net_ns() {
+                return Err(AxError::NoSuchDevice);
+            }
+            Ok(NetInterface::Eth0)
+        }
         LO_NAME => Ok(NetInterface::Loopback),
         _ => Err(AxError::NoSuchDevice),
     }
+}
+
+fn in_root_net_ns() -> bool {
+    let curr = current();
+    let nsproxy = curr.as_thread().proc_data.nsproxy.lock();
+    nsproxy.net_ns.lock().ns_id == 0
 }
 
 fn write_ifreq_data(arg: usize, data: &[u8]) -> AxResult<()> {
@@ -146,7 +161,7 @@ fn write_eth0_ifconf(arg: usize) -> AxResult<()> {
 
     if buf != 0 {
         let mut written = 0;
-        if ifc_len >= IFREQ_COMPAT_LEN as i32 {
+        if in_root_net_ns() && ifc_len >= IFREQ_COMPAT_LEN as i32 {
             write_ifconf_entry(buf, written, ETH0_NAME, configured_eth0_ipv4())?;
             written += IFREQ_COMPAT_LEN;
         }

--- a/os/StarryOS/kernel/src/file/netlink.rs
+++ b/os/StarryOS/kernel/src/file/netlink.rs
@@ -33,7 +33,10 @@ use core::{
 
 use ax_errno::{AxError, AxResult};
 use ax_kspin::SpinNoIrq as Mutex;
-use ax_task::future::{block_on, poll_io};
+use ax_task::{
+    current,
+    future::{block_on, poll_io},
+};
 use axpoll::{IoEvents, PollSet, Pollable};
 use linux_raw_sys::{
     general::{O_RDWR, S_IFSOCK},
@@ -230,6 +233,12 @@ const ADDRS: &[AddrInfo] = &[
     },
 ];
 
+fn in_root_net_ns() -> bool {
+    let curr = current();
+    let nsproxy = curr.as_thread().proc_data.nsproxy.lock();
+    nsproxy.net_ns.lock().ns_id == 0
+}
+
 #[derive(Clone, Copy, Default)]
 struct NetlinkState {
     addr: Option<sockaddr_nl>,
@@ -394,15 +403,22 @@ impl NetlinkSocket {
 
         let header = unsafe { request.as_ptr().cast::<NlMsgHdr>().read_unaligned() };
         let pid = self.local_pid();
+        let in_root = in_root_net_ns();
         let mut response = Vec::new();
         match header.ty {
             RTM_GETLINK => {
                 for link in LINKS {
+                    if !in_root && link.index != 1 {
+                        continue;
+                    }
                     push_link_message(&mut response, header.seq, pid, link);
                 }
             }
             RTM_GETADDR => {
                 for addr in ADDRS {
+                    if !in_root && addr.index != 1 {
+                        continue;
+                    }
                     push_addr_message(&mut response, header.seq, pid, addr);
                 }
             }

--- a/os/StarryOS/kernel/src/file/packet.rs
+++ b/os/StarryOS/kernel/src/file/packet.rs
@@ -9,7 +9,10 @@ use core::{
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_io::prelude::*;
 use ax_sync::Mutex;
-use ax_task::future::{block_on, poll_io};
+use ax_task::{
+    current,
+    future::{block_on, poll_io},
+};
 use axpoll::{IoEvents, PollSet, Pollable};
 use linux_raw_sys::{
     general::{O_RDWR, S_IFSOCK},
@@ -19,7 +22,10 @@ use linux_raw_sys::{
 use starry_vm::{vm_read_slice, vm_write_slice};
 
 use super::{FileLike, Kstat};
-use crate::file::{IoDst, IoSrc, get_file_like};
+use crate::{
+    file::{IoDst, IoSrc, get_file_like},
+    task::AsThread,
+};
 
 pub(super) const ETH0_IFINDEX: i32 = 2;
 const ETH0_NAME: &[u8] = b"eth0";
@@ -256,6 +262,12 @@ fn write_ifreq_data(arg: usize, data: &[u8]) -> AxResult<()> {
     Ok(vm_write_slice((arg + IFREQ_DATA_OFFSET) as *mut u8, data)?)
 }
 
+fn in_root_net_ns() -> bool {
+    let curr = current();
+    let nsproxy = curr.as_thread().proc_data.nsproxy.lock();
+    nsproxy.net_ns.lock().ns_id == 0
+}
+
 impl FileLike for PacketSocket {
     fn stat(&self) -> AxResult<Kstat> {
         Ok(Kstat {
@@ -283,7 +295,7 @@ impl FileLike for PacketSocket {
     }
 
     fn ioctl(&self, cmd: u32, arg: usize) -> AxResult<usize> {
-        if !ifreq_name_is_eth0(arg)? {
+        if !in_root_net_ns() || !ifreq_name_is_eth0(arg)? {
             return Err(AxError::NoSuchDevice);
         }
 

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -131,7 +131,7 @@ pub fn sys_mount(
     }
 
     match fs_type.as_str() {
-        "tmpfs" => {
+        "proc" | "sysfs" | "devtmpfs" | "devpts" | "tmpfs" => {
             let fs = MemoryFs::new();
             let target = FS_CONTEXT.lock().resolve(target)?;
             let mp = target.mount(&fs)?;

--- a/os/StarryOS/kernel/src/syscall/ipc/msg.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/msg.rs
@@ -15,6 +15,20 @@ use super::{
 };
 use crate::task::{AsThread, WaitQueue as MsgWaitQueue};
 
+fn current_ipc_ns_id() -> u64 {
+    let curr = current();
+    let thr = curr.as_thread();
+    thr.proc_data.nsproxy.lock().ipc_ns.lock().ns_id
+}
+
+fn msg_ns_check(queue: &MessageQueue) -> AxResult<()> {
+    let ns_id = current_ipc_ns_id();
+    if queue.ns_id != ns_id {
+        return Err(AxError::from(LinuxError::EINVAL));
+    }
+    Ok(())
+}
+
 /// Data structure describing a message queue.
 #[repr(C)]
 #[derive(Clone, Copy, AnyBitPattern)]
@@ -93,11 +107,13 @@ pub struct MessageQueue {
     pub recv_wait_queue: Arc<MsgWaitQueue>,
     /// Marked for removal
     pub mark_removed: bool,
+    /// IPC namespace id that owns this queue.
+    pub ns_id: u64,
 }
 
 impl MessageQueue {
     /// Creates a new [`MessageQueue`].
-    pub fn new(key: i32, mode: __kernel_mode_t, pid: Pid, uid: u32, gid: u32) -> Self {
+    pub fn new(key: i32, mode: __kernel_mode_t, pid: Pid, uid: u32, gid: u32, ns_id: u64) -> Self {
         MessageQueue {
             msqid_ds: msqid_ds::new(key, mode, pid as __kernel_pid_t, uid, gid),
             messages: BTreeMap::new(),
@@ -106,6 +122,7 @@ impl MessageQueue {
             send_wait_queue: Arc::new(MsgWaitQueue::new()),
             recv_wait_queue: Arc::new(MsgWaitQueue::new()),
             mark_removed: false,
+            ns_id,
         }
     }
 
@@ -335,16 +352,6 @@ impl MsgManager {
         self.key_msqid.retain(|_, &mut v| v != msqid);
         self.msqid_queues.remove(&msqid);
     }
-
-    /// get total bytes in all queues
-    pub fn total_bytes(&self) -> usize {
-        self.iter_active_queues()
-            .map(|(_, queue)| {
-                let guard = queue.lock();
-                guard.total_bytes
-            })
-            .sum()
-    }
 }
 
 /// System limits
@@ -408,12 +415,14 @@ pub fn sys_msgget(key: i32, msgflg: i32) -> AxResult<isize> {
     // Handle IPC_PRIVATE (always create new queue)
     if key == IPC_PRIVATE {
         let msqid = next_ipc_id();
+        let ns_id = proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
         let msg_queue = Arc::new(Mutex::new(MessageQueue::new(
             key,
             (msgflg & 0o777) as _,
             current_pid,
             current_uid,
             current_gid,
+            ns_id,
         )));
 
         msg_manager.insert_msqid_queues(msqid, msg_queue);
@@ -457,12 +466,14 @@ pub fn sys_msgget(key: i32, msgflg: i32) -> AxResult<isize> {
     }
 
     let msqid = next_ipc_id();
+    let ns_id = proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
     let msg_queue = Arc::new(Mutex::new(MessageQueue::new(
         key,
         (msgflg & 0o777) as _,
         current_pid,
         current_uid,
         current_gid,
+        ns_id,
     )));
 
     msg_manager.insert_key_msqid(key, msqid);
@@ -773,7 +784,17 @@ pub fn sys_msgctl(msqid: i32, cmd: i32, buf: usize) -> AxResult<isize> {
     // MSG_INFO (put before looking up the queue!)
     if cmd == MSG_INFO {
         let msg_manager = MSG_MANAGER.lock();
-        // Manually create IpcPerm
+        let ns_id = current_ipc_ns_id();
+        let (count, bytes) = msg_manager
+            .iter_active_queues()
+            .filter(|(_, q)| {
+                let guard = q.lock();
+                guard.ns_id == ns_id && !guard.mark_removed
+            })
+            .fold((0u64, 0u64), |(c, b), (_, q)| {
+                let guard = q.lock();
+                (c + 1, b + guard.total_bytes as u64)
+            });
         let msg_perm = IpcPerm {
             key: 0,
             uid: current_uid,
@@ -787,34 +808,33 @@ pub fn sys_msgctl(msqid: i32, cmd: i32, buf: usize) -> AxResult<isize> {
             unused1: 0,
         };
 
-        // Create a temporary msqid_ds to return information
         let info_ds = msqid_ds {
             msg_perm,
             msg_stime: 0,
             msg_rtime: 0,
             msg_ctime: 0,
-            msg_cbytes: msg_manager.total_bytes() as u64,
-            // Use msg_qnum to return the number of allocated queues
-            msg_qnum: msg_manager.queue_count() as u64,
-            // Use msg_qbytes to return system limits or usage
+            msg_cbytes: bytes,
+            msg_qnum: count,
             msg_qbytes: MSGMNB as u64,
             msg_lspid: Pid::from(0u32) as _,
             msg_lrpid: Pid::from(0u32) as _,
         };
 
-        // Copy to user space
         let ptr = buf as *mut msqid_ds;
         ptr.vm_write(info_ds)?;
-
-        // Return the current number of allocated queues
-        return Ok(msg_manager.queue_count() as isize);
+        return Ok(count as isize);
     }
     // MSG_STAT handling
     if cmd == MSG_STAT {
+        let ns_id = current_ipc_ns_id();
         let msg_manager = MSG_MANAGER.lock();
 
         let result = msg_manager
             .iter_active_queues()
+            .filter(|(_, q)| {
+                let guard = q.lock();
+                guard.ns_id == ns_id
+            })
             .nth(msqid as usize)
             .ok_or(AxError::from(LinuxError::EINVAL))
             .and_then(|(actual_msqid, queue)| {
@@ -847,6 +867,7 @@ pub fn sys_msgctl(msqid: i32, cmd: i32, buf: usize) -> AxResult<isize> {
 
     // Lock the internal structure of the queue
     let mut msg_queue = msg_queue.lock();
+    msg_ns_check(&msg_queue)?;
     // Check if the queue is marked as removed
     if msg_queue.mark_removed {
         return Err(AxError::from(LinuxError::EIDRM)); // EIDRM - Queue has been removed

--- a/os/StarryOS/kernel/src/syscall/ipc/msg.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/msg.rs
@@ -295,8 +295,8 @@ fn find_matching_message<'a>(
 
 /// Message queue manager
 pub struct MsgManager {
-    /// key -> msqid mapping
-    key_msqid: BTreeMap<i32, i32>,
+    /// (key, ns_id) -> msqid mapping
+    key_msqid: BTreeMap<(i32, u64), i32>,
     /// msqid -> message queue structure
     msqid_queues: BTreeMap<i32, Arc<Mutex<MessageQueue>>>,
 }
@@ -323,8 +323,8 @@ impl MsgManager {
     }
 
     /// Returns the message queue ID associated with the given key.
-    pub fn get_msqid_by_key(&self, key: i32) -> Option<i32> {
-        self.key_msqid.get(&key).cloned()
+    pub fn get_msqid_by_key(&self, key: i32, ns_id: u64) -> Option<i32> {
+        self.key_msqid.get(&(key, ns_id)).cloned()
     }
 
     /// Returns the message queue associated with the given ID.
@@ -333,8 +333,8 @@ impl MsgManager {
     }
 
     /// Inserts a mapping from a key to a message queue ID.
-    pub fn insert_key_msqid(&mut self, key: i32, msqid: i32) {
-        self.key_msqid.insert(key, msqid);
+    pub fn insert_key_msqid(&mut self, key: i32, ns_id: u64, msqid: i32) {
+        self.key_msqid.insert((key, ns_id), msqid);
     }
 
     /// Inserts a mapping from a message queue ID to its queue.
@@ -404,6 +404,7 @@ pub fn sys_msgget(key: i32, msgflg: i32) -> AxResult<isize> {
     let current_uid = cred.euid;
     let current_gid = cred.egid;
     let current_pid = proc_data.proc.pid();
+    let ns_id = proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
 
     let mut msg_manager = MSG_MANAGER.lock();
 
@@ -430,7 +431,7 @@ pub fn sys_msgget(key: i32, msgflg: i32) -> AxResult<isize> {
     }
 
     // Look for existing message queue
-    if let Some(msqid) = msg_manager.get_msqid_by_key(key) {
+    if let Some(msqid) = msg_manager.get_msqid_by_key(key, ns_id) {
         let msg_queue = msg_manager
             .get_queue_by_msqid(msqid)
             .ok_or(AxError::from(LinuxError::ENOENT))?; // ENOENT
@@ -476,7 +477,7 @@ pub fn sys_msgget(key: i32, msgflg: i32) -> AxResult<isize> {
         ns_id,
     )));
 
-    msg_manager.insert_key_msqid(key, msqid);
+    msg_manager.insert_key_msqid(key, ns_id, msqid);
     msg_manager.insert_msqid_queues(msqid, msg_queue);
 
     Ok(msqid as isize)

--- a/os/StarryOS/kernel/src/syscall/ipc/shm.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/shm.rs
@@ -8,10 +8,17 @@ use ax_hal::{
 use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr, VirtAddrRange};
 use ax_sync::Mutex;
 use ax_task::current;
-use linux_raw_sys::{ctypes::c_ushort, general::*};
+use bytemuck::AnyBitPattern;
+use linux_raw_sys::{
+    ctypes::{c_ulong, c_ushort},
+    general::*,
+};
 use starry_process::Pid;
+use starry_vm::VmMutPtr;
 
-use super::{IPC_CREAT, IPC_EXCL, IPC_PRIVATE, IPC_RMID, IPC_SET, IPC_STAT, IpcPerm, next_ipc_id};
+use super::{
+    IPC_CREAT, IPC_EXCL, IPC_INFO, IPC_PRIVATE, IPC_RMID, IPC_SET, IPC_STAT, IpcPerm, next_ipc_id,
+};
 use crate::{
     mm::{AddrSpace, Backend, SharedPages, UserPtr, nullable},
     task::AsThread,
@@ -85,6 +92,27 @@ impl ShmidDs {
     }
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, AnyBitPattern)]
+struct ShmInfo64 {
+    shmmax: c_ulong,
+    shmmin: c_ulong,
+    shmmni: c_ulong,
+    shmseg: c_ulong,
+    shmall: c_ulong,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, AnyBitPattern)]
+struct ShmInfo {
+    used_ids: i32,
+    shm_tot: c_ulong,
+    shm_rss: c_ulong,
+    shm_swp: c_ulong,
+    swap_attempts: c_ulong,
+    swap_successes: c_ulong,
+}
+
 /// This struct is used to maintain the shmem in kernel.
 pub struct ShmInner {
     /// Shared memory segment identifier.
@@ -100,6 +128,8 @@ pub struct ShmInner {
     pub mapping_flags: MappingFlags,
     /// c type struct, used in shm_ctl
     pub shmid_ds: ShmidDs,
+    /// IPC namespace id that owns this segment.
+    pub ns_id: u64,
 }
 
 impl ShmInner {
@@ -112,6 +142,7 @@ impl ShmInner {
         pid: Pid,
         uid: u32,
         gid: u32,
+        ns_id: u64,
     ) -> Self {
         ShmInner {
             shmid,
@@ -128,6 +159,7 @@ impl ShmInner {
                 uid,
                 gid,
             ),
+            ns_id,
         }
     }
 
@@ -263,7 +295,7 @@ pub struct ShmManager {
     /// key <-> shm_id
     key_shmid: BiBTreeMap<i32, i32>,
     /// shm_id -> shm_inner
-    shmid_inner: BTreeMap<i32, Arc<Mutex<ShmInner>>>,
+    pub(crate) shmid_inner: BTreeMap<i32, Arc<Mutex<ShmInner>>>,
     /// pid -> shm_id <-> vaddr
     pid_shmid_vaddr: BTreeMap<Pid, BiBTreeMap<i32, VirtAddr>>,
 }
@@ -445,19 +477,31 @@ pub fn sys_shmget(key: i32, size: usize, shmflg: usize) -> AxResult<isize> {
     let cred = thread.cred();
     let mut shm_manager = SHM_MANAGER.lock();
 
+    let ns_id = thread.proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
+
     if key != IPC_PRIVATE {
         // A segment already exists for this key.
         if let Some(shmid) = shm_manager.get_shmid_by_key(key) {
-            // IPC_CREAT | IPC_EXCL requires the creation to fail when the
-            // segment is already present. See Linux ipcget_public().
-            if shmflg & IPC_CREAT as usize != 0 && shmflg & IPC_EXCL as usize != 0 {
-                return Err(AxError::AlreadyExists);
-            }
             let shm_inner = shm_manager
                 .get_inner_by_shmid(shmid)
                 .ok_or(AxError::NotFound)?;
-            let mut shm_inner = shm_inner.lock();
-            return shm_inner.try_update(size, cur_pid);
+            let shm_inner = shm_inner.lock();
+            // Only match if the segment lives in our IPC namespace.
+            if shm_inner.ns_id == ns_id {
+                // IPC_CREAT | IPC_EXCL requires the creation to fail when the
+                // segment is already present. See Linux ipcget_public().
+                if shmflg & IPC_CREAT as usize != 0 && shmflg & IPC_EXCL as usize != 0 {
+                    return Err(AxError::AlreadyExists);
+                }
+                drop(shm_inner);
+                let shm_inner = shm_manager
+                    .get_inner_by_shmid(shmid)
+                    .ok_or(AxError::NotFound)?;
+                let mut shm_inner = shm_inner.lock();
+                return shm_inner.try_update(size, cur_pid);
+            }
+            // Key exists in a different namespace — fall through and
+            // create a new segment in the current namespace.
         }
 
         // No segment exists for this key: create one only when IPC_CREAT
@@ -483,6 +527,7 @@ pub fn sys_shmget(key: i32, size: usize, shmflg: usize) -> AxResult<isize> {
         cur_pid,
         cred.euid,
         cred.egid,
+        ns_id,
     )));
     shm_manager.insert_key_shmid(key, shmid);
     shm_manager.insert_shmid_inner(shmid, shm_inner);
@@ -569,35 +614,82 @@ pub fn sys_shmat(shmid: i32, addr: usize, shmflg: u32) -> AxResult<isize> {
     Ok(start_addr.as_usize() as isize)
 }
 
+fn current_ipc_ns_id() -> u64 {
+    let curr = current();
+    let thr = curr.as_thread();
+    thr.proc_data.nsproxy.lock().ipc_ns.lock().ns_id
+}
+
+fn shm_ns_check(shm_inner: &ShmInner) -> AxResult<()> {
+    let ns_id = current_ipc_ns_id();
+    if shm_inner.ns_id != ns_id {
+        return Err(AxError::InvalidInput);
+    }
+    Ok(())
+}
+
 pub fn sys_shmctl(shmid: i32, cmd: u32, buf: UserPtr<ShmidDs>) -> AxResult<isize> {
     let cmd = cmd as i32;
+    let ns_id = current_ipc_ns_id();
+
+    // IPC_INFO and SHM_INFO don't use shmid.
+    if cmd == IPC_INFO {
+        let _shm_manager = SHM_MANAGER.lock();
+        let info = ShmInfo64 {
+            shmmax: 0x2000000,
+            shmmin: 1,
+            shmmni: 4096,
+            shmseg: 4096,
+            shmall: 0x2000000,
+        };
+        (buf.as_ptr() as *mut ShmInfo64).vm_write(info)?;
+        return Ok(0);
+    }
+
+    if cmd == 14 {
+        // SHM_INFO = 14 (Linux)
+        let shm_manager = SHM_MANAGER.lock();
+        let mut used_ids = 0i32;
+        let mut shm_tot = 0u64;
+        for inner_arc in shm_manager.shmid_inner.values() {
+            let inner = inner_arc.lock();
+            if inner.ns_id == ns_id {
+                used_ids += 1;
+                shm_tot += inner.page_num as u64;
+            }
+        }
+        let shm_info = ShmInfo {
+            used_ids,
+            shm_tot,
+            shm_rss: shm_tot,
+            shm_swp: 0,
+            swap_attempts: 0,
+            swap_successes: 0,
+        };
+        (buf.as_ptr() as *mut ShmInfo).vm_write(shm_info)?;
+        return Ok(0);
+    }
 
     if cmd == IPC_RMID {
-        // If no processes are attached, destroy the segment immediately.
-        // Otherwise mark it for deferred destruction and remove the key
-        // mapping so future shmget() calls won't find it. See Linux
-        // do_shm_rmid() in ipc/shm.c.
         let mut shm_manager = SHM_MANAGER.lock();
         let shm_inner_arc = shm_manager
             .get_inner_by_shmid(shmid)
             .ok_or(AxError::InvalidInput)?;
         let mut shm_inner = shm_inner_arc.lock();
+        shm_ns_check(&shm_inner)?;
 
         shm_inner.rmid = true;
         shm_inner.shmid_ds.shm_ctime = monotonic_time_nanos() as __kernel_time_t;
-
-        // Make private so no new shmget() finds it by key.
         shm_manager.make_private(shmid);
 
         if shm_inner.attach_count() == 0 {
             drop(shm_inner);
             shm_manager.remove_shmid(shmid);
         }
-
         return Ok(0);
     }
 
-    // IPC_SET and IPC_STAT only need shm_inner.
+    // IPC_SET and IPC_STAT
     let shm_inner_arc = {
         let shm_manager = SHM_MANAGER.lock();
         shm_manager
@@ -605,6 +697,7 @@ pub fn sys_shmctl(shmid: i32, cmd: u32, buf: UserPtr<ShmidDs>) -> AxResult<isize
             .ok_or(AxError::InvalidInput)?
     };
     let mut shm_inner = shm_inner_arc.lock();
+    shm_ns_check(&shm_inner)?;
 
     if cmd == IPC_SET {
         shm_inner.shmid_ds = *buf.get_as_mut()?;

--- a/os/StarryOS/kernel/src/syscall/ipc/shm.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/shm.rs
@@ -298,8 +298,8 @@ where
 /// processes. note: this struct do not modify the struct ShmInner, but only
 /// manage the mapping.
 pub struct ShmManager {
-    /// key <-> shm_id
-    key_shmid: BiBTreeMap<i32, i32>,
+    /// (key, ns_id) <-> shm_id
+    key_shmid: BiBTreeMap<(i32, u64), i32>,
     /// shm_id -> shm_inner
     pub(crate) shmid_inner: BTreeMap<i32, Arc<Mutex<ShmInner>>>,
     /// pid -> shm_id <-> vaddr
@@ -315,9 +315,10 @@ impl ShmManager {
         }
     }
 
-    /// Returns the shared memory ID associated with the given key.
-    pub fn get_shmid_by_key(&self, key: i32) -> Option<i32> {
-        self.key_shmid.get_by_key(&key).cloned()
+    /// Returns the shared memory ID associated with the given key and IPC
+    /// namespace.
+    pub fn get_shmid_by_key(&self, key: i32, ns_id: u64) -> Option<i32> {
+        self.key_shmid.get_by_key(&(key, ns_id)).cloned()
     }
 
     /// Returns the shared memory inner structure [`ShmInner`] associated with
@@ -353,9 +354,9 @@ impl ShmManager {
             .cloned()
     }
 
-    /// Inserts a mapping from a key to a shared memory ID.
-    pub fn insert_key_shmid(&mut self, key: i32, shmid: i32) {
-        self.key_shmid.insert(key, shmid);
+    /// Inserts a mapping from a (key, ns_id) pair to a shared memory ID.
+    pub fn insert_key_shmid(&mut self, key: i32, ns_id: u64, shmid: i32) {
+        self.key_shmid.insert((key, ns_id), shmid);
     }
 
     /// Inserts a mapping from a shared memory ID to its inner
@@ -481,33 +482,22 @@ pub fn sys_shmget(key: i32, size: usize, shmflg: usize) -> AxResult<isize> {
     let thread = curr.as_thread();
     let cur_pid = thread.proc_data.proc.pid();
     let cred = thread.cred();
+    let ns_id = thread.proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
     let mut shm_manager = SHM_MANAGER.lock();
 
-    let ns_id = thread.proc_data.nsproxy.lock().ipc_ns.lock().ns_id;
-
     if key != IPC_PRIVATE {
-        // A segment already exists for this key.
-        if let Some(shmid) = shm_manager.get_shmid_by_key(key) {
+        // A segment already exists for this (key, ns_id) pair.
+        if let Some(shmid) = shm_manager.get_shmid_by_key(key, ns_id) {
+            // IPC_CREAT | IPC_EXCL requires the creation to fail when the
+            // segment is already present. See Linux ipcget_public().
+            if shmflg & IPC_CREAT as usize != 0 && shmflg & IPC_EXCL as usize != 0 {
+                return Err(AxError::AlreadyExists);
+            }
             let shm_inner = shm_manager
                 .get_inner_by_shmid(shmid)
                 .ok_or(AxError::NotFound)?;
-            let shm_inner = shm_inner.lock();
-            // Only match if the segment lives in our IPC namespace.
-            if shm_inner.ns_id == ns_id {
-                // IPC_CREAT | IPC_EXCL requires the creation to fail when the
-                // segment is already present. See Linux ipcget_public().
-                if shmflg & IPC_CREAT as usize != 0 && shmflg & IPC_EXCL as usize != 0 {
-                    return Err(AxError::AlreadyExists);
-                }
-                drop(shm_inner);
-                let shm_inner = shm_manager
-                    .get_inner_by_shmid(shmid)
-                    .ok_or(AxError::NotFound)?;
-                let mut shm_inner = shm_inner.lock();
-                return shm_inner.try_update(size, cur_pid);
-            }
-            // Key exists in a different namespace — fall through and
-            // create a new segment in the current namespace.
+            let mut shm_inner = shm_inner.lock();
+            return shm_inner.try_update(size, cur_pid);
         }
 
         // No segment exists for this key: create one only when IPC_CREAT
@@ -537,7 +527,7 @@ pub fn sys_shmget(key: i32, size: usize, shmflg: usize) -> AxResult<isize> {
             ns_id,
         },
     )));
-    shm_manager.insert_key_shmid(key, shmid);
+    shm_manager.insert_key_shmid(key, ns_id, shmid);
     shm_manager.insert_shmid_inner(shmid, shm_inner);
 
     Ok(shmid as isize)

--- a/os/StarryOS/kernel/src/syscall/ipc/shm.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/shm.rs
@@ -132,6 +132,15 @@ pub struct ShmInner {
     pub ns_id: u64,
 }
 
+/// Parameters passed to [`ShmInner::new`] that identify the creating process
+/// and the namespace the segment belongs to.
+pub struct ShmCreateInfo {
+    pub pid: Pid,
+    pub uid: u32,
+    pub gid: u32,
+    pub ns_id: u64,
+}
+
 impl ShmInner {
     /// Creates a new [`ShmInner`].
     pub fn new(
@@ -139,10 +148,7 @@ impl ShmInner {
         shmid: i32,
         size: usize,
         mapping_flags: MappingFlags,
-        pid: Pid,
-        uid: u32,
-        gid: u32,
-        ns_id: u64,
+        info: ShmCreateInfo,
     ) -> Self {
         ShmInner {
             shmid,
@@ -155,11 +161,11 @@ impl ShmInner {
                 key,
                 size,
                 mapping_flags.bits() as __kernel_mode_t,
-                pid as __kernel_pid_t,
-                uid,
-                gid,
+                info.pid as __kernel_pid_t,
+                info.uid,
+                info.gid,
             ),
-            ns_id,
+            ns_id: info.ns_id,
         }
     }
 
@@ -524,10 +530,12 @@ pub fn sys_shmget(key: i32, size: usize, shmflg: usize) -> AxResult<isize> {
         shmid,
         size,
         mapping_flags,
-        cur_pid,
-        cred.euid,
-        cred.egid,
-        ns_id,
+        ShmCreateInfo {
+            pid: cur_pid,
+            uid: cred.euid,
+            gid: cred.egid,
+            ns_id,
+        },
     )));
     shm_manager.insert_key_shmid(key, shmid);
     shm_manager.insert_shmid_inner(shmid, shm_inner);

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -547,6 +547,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::fork => sys_fork(uctx),
         #[cfg(target_arch = "x86_64")]
         Sysno::vfork => sys_vfork(uctx),
+        Sysno::unshare => sys_unshare(uctx.arg0() as _),
         Sysno::exit => sys_exit(uctx.arg0() as _),
         Sysno::exit_group => sys_exit_group(uctx.arg0() as _),
         Sysno::wait4 => sys_waitpid(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),

--- a/os/StarryOS/kernel/src/syscall/task/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/task/mod.rs
@@ -4,10 +4,12 @@ mod ctl;
 mod execve;
 mod exit;
 mod job;
+mod namespace;
 mod schedule;
 mod thread;
 mod wait;
 
 pub use self::{
-    clone::*, clone3::*, ctl::*, execve::*, exit::*, job::*, schedule::*, thread::*, wait::*,
+    clone::*, clone3::*, ctl::*, execve::*, exit::*, job::*, namespace::*, schedule::*, thread::*,
+    wait::*,
 };

--- a/os/StarryOS/kernel/src/syscall/task/namespace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/namespace.rs
@@ -1,10 +1,10 @@
 use ax_errno::{AxError, AxResult};
 use ax_task::current;
-
-use crate::task::AsThread;
 use linux_raw_sys::general::{
     CLONE_NEWIPC, CLONE_NEWNET, CLONE_NEWNS, CLONE_NEWPID, CLONE_NEWUSER, CLONE_NEWUTS,
 };
+
+use crate::task::AsThread;
 
 const SUPPORTED_NS_FLAGS: u32 =
     CLONE_NEWUTS | CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWNET | CLONE_NEWIPC | CLONE_NEWUSER;

--- a/os/StarryOS/kernel/src/syscall/task/namespace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/namespace.rs
@@ -1,0 +1,43 @@
+use ax_errno::{AxError, AxResult};
+use ax_task::current;
+
+use crate::task::AsThread;
+use linux_raw_sys::general::{
+    CLONE_NEWIPC, CLONE_NEWNET, CLONE_NEWNS, CLONE_NEWPID, CLONE_NEWUSER, CLONE_NEWUTS,
+};
+
+const SUPPORTED_NS_FLAGS: u32 =
+    CLONE_NEWUTS | CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWNET | CLONE_NEWIPC | CLONE_NEWUSER;
+
+/// unshare(2) — disassociate parts of the process execution context.
+pub fn sys_unshare(flags: u32) -> AxResult<isize> {
+    if flags & !SUPPORTED_NS_FLAGS != 0 {
+        warn!("sys_unshare: unsupported flags {:#x}", flags);
+        return Err(AxError::InvalidInput);
+    }
+
+    let curr = current();
+    let proc_data = &curr.as_thread().proc_data;
+    let mut nsproxy = proc_data.nsproxy.lock();
+
+    if flags & CLONE_NEWUTS != 0 {
+        nsproxy.unshare_uts();
+    }
+    if flags & CLONE_NEWPID != 0 {
+        nsproxy.prepare_child_pid_ns();
+    }
+    if flags & CLONE_NEWNS != 0 {
+        nsproxy.unshare_mnt();
+    }
+    if flags & CLONE_NEWNET != 0 {
+        nsproxy.unshare_net();
+    }
+    if flags & CLONE_NEWIPC != 0 {
+        nsproxy.unshare_ipc();
+    }
+    if flags & CLONE_NEWUSER != 0 {
+        nsproxy.unshare_user();
+    }
+
+    Ok(0)
+}

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -511,6 +511,8 @@ pub struct ProcessData {
     aspace: SpinNoIrq<Arc<Mutex<AddrSpace>>>,
     /// The resource scope
     pub scope: RwLock<Scope>,
+    /// The namespace proxy — aggregates all namespace types for this process.
+    pub nsproxy: SpinNoIrq<axnsproxy::NsProxy>,
     /// The user heap top
     heap_top: AtomicUsize,
 
@@ -620,6 +622,8 @@ impl ProcessData {
             )),
 
             futex_table: Arc::new(FutexTable::new()),
+
+            nsproxy: SpinNoIrq::new(axnsproxy::NsProxy::new_root()),
 
             vfork_done: SpinNoIrq::new(None),
 

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-namespace/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-namespace/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-namespace C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-namespace src/main.c)
+target_include_directories(test-namespace PRIVATE src)
+target_compile_options(test-namespace PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-namespace RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-namespace/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-namespace/c/src/main.c
@@ -1,0 +1,194 @@
+/*
+ * test-namespace — verify UTS, PID and USER namespace semantics.
+ *
+ * Scenarios exercised:
+ *   1. unshare(CLONE_NEWUTS) + sethostname does not affect the parent.
+ *   2. clone(CLONE_NEWPID)  -> child getpid() returns the local PID.
+ *   3. unshare(CLONE_NEWUSER) -> getuid() returns 65534 (nobody).
+ */
+
+#include "test_framework.h"
+
+#include <errno.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+// ---- clone3 helpers (standardised across architectures) --------------------
+
+#ifndef __NR_clone3
+#if defined(__aarch64__)
+#define __NR_clone3 435
+#elif defined(__x86_64__)
+#define __NR_clone3 435
+#elif defined(__riscv)
+#define __NR_clone3 435
+#else
+#error "unknown architecture: define __NR_clone3"
+#endif
+#endif
+
+struct clone3_args
+{
+    unsigned long long flags;       /* CLONE_* flags */
+    unsigned long long pidfd;       /* PID fd for CLONE_PIDFD */
+    unsigned long long child_tid;   /* address to store child TID */
+    unsigned long long parent_tid;  /* address to store parent TID */
+    unsigned long long exit_signal; /* exit signal */
+    unsigned long long stack;       /* child stack (lowest address) */
+    unsigned long long stack_size;  /* stack size */
+    unsigned long long tls;         /* TLS descriptor */
+    unsigned long long set_tid;     /* pointer to set_tid array */
+    unsigned long long set_tid_size;/* number of elements in set_tid */
+    unsigned long long cgroup;      /* CLONE_INTO_CGROUP fd */
+};
+
+static pid_t clone3_child(unsigned long long flags)
+{
+    struct clone3_args args;
+    memset(&args, 0, sizeof(args));
+    args.flags = flags;
+    args.exit_signal = SIGCHLD;
+    return (pid_t)syscall(__NR_clone3, &args, sizeof(args));
+}
+
+// ---------------------------------------------------------------------------
+
+static void run_uts_namespace_test(void)
+{
+    int pipefd[2];
+    int rc = pipe(pipefd);
+    CHECK(rc == 0, "pipe");
+
+    pid_t child = fork();
+    CHECK(child >= 0, "fork for UTS test");
+
+    if (child == 0)
+    {
+        /* ---- child ---------------------------------------------------- */
+        close(pipefd[0]); /* close read end */
+
+        /* Save the parent hostname before we change anything. */
+        char parent_hostname[65];
+        rc = gethostname(parent_hostname, sizeof(parent_hostname));
+        CHECK(rc == 0, "child: gethostname before unshare");
+        ssize_t wr = write(pipefd[1], parent_hostname, strlen(parent_hostname) + 1);
+        (void)wr;
+
+        /* Enter a new UTS namespace. */
+        rc = unshare(CLONE_NEWUTS);
+        CHECK_RET(rc, 0, "unshare(CLONE_NEWUTS)");
+
+        /* Set a different hostname inside the new namespace. */
+        const char *new_name = "newns-host";
+        rc = sethostname(new_name, strlen(new_name));
+        CHECK_RET(rc, 0, "sethostname in new UTS ns");
+
+        /* Verify the hostname inside the child namespace. */
+        char hostname[65];
+        rc = gethostname(hostname, sizeof(hostname));
+        CHECK_RET(rc, 0, "child: gethostname after sethostname");
+        CHECK(strcmp(hostname, new_name) == 0, "child hostname == newname");
+
+        close(pipefd[1]);
+        _exit(0);
+    }
+
+    /* ---- parent -------------------------------------------------------- */
+    close(pipefd[1]); /* close write end */
+
+    /* Read the original hostname that the child captured. */
+    char orig_hostname[65];
+    ssize_t rd = read(pipefd[0], orig_hostname, sizeof(orig_hostname));
+    CHECK(rd > 0, "parent: read original hostname from pipe");
+    close(pipefd[0]);
+
+    /* Wait for the child. */
+    int status;
+    waitpid(child, &status, 0);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0, "UTS child exited 0");
+
+    /* The parent's hostname must be unchanged. */
+    char parent_now[65];
+    rc = gethostname(parent_now, sizeof(parent_now));
+    CHECK_RET(rc, 0, "parent: gethostname after child exit");
+    CHECK(strcmp(parent_now, orig_hostname) == 0,
+          "parent hostname unchanged after child unshare(CLONE_NEWUTS)");
+}
+
+static void run_pid_namespace_test(void)
+{
+    pid_t parent_pid = getpid();
+
+    pid_t child = clone3_child(CLONE_NEWPID);
+    CHECK(child >= 0, "clone3(CLONE_NEWPID)");
+
+    if (child == 0)
+    {
+        /* ---- child ---------------------------------------------------- */
+        pid_t my_pid = getpid();
+
+        /* The first process in a new PID namespace is PID 1. */
+        CHECK(my_pid == 1, "child in new PID namespace: getpid() == 1");
+
+        /* The parent PID seen from inside must be 0
+         * (the parent is in a different PID namespace). */
+        pid_t ppid = getppid();
+        CHECK(ppid == 0, "child getppid() == 0 (parent in different PID ns)");
+
+        /* Verify the pid reported by getpid() is NOT the parent's pid.
+         * This catches an implementation that fails to translate. */
+        CHECK(my_pid != parent_pid,
+              "child pid differs from parent pid (namespace isolation)");
+
+        _exit(0);
+    }
+
+    /* ---- parent -------------------------------------------------------- */
+    int status;
+    waitpid(child, &status, 0);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0, "PID child exited 0");
+
+    /* Parent pid must not change. */
+    pid_t now = getpid();
+    CHECK(now == parent_pid, "parent getpid() unchanged after child clone");
+}
+
+static void run_user_namespace_test(void)
+{
+    /* Save pre-unshare uid for later comparison. */
+    uid_t before = getuid();
+
+    int rc = unshare(CLONE_NEWUSER);
+    CHECK_RET(rc, 0, "unshare(CLONE_NEWUSER)");
+
+    uid_t after = getuid();
+
+    /* In a non-root user namespace, uid maps to the overflow uid (65534). */
+    CHECK(after == 65534,
+          "getuid() == 65534 after unshare(CLONE_NEWUSER)");
+
+    /* Should differ from the pre-unshare value. */
+    CHECK(after != before,
+          "getuid() changed after unshare(CLONE_NEWUSER)");
+
+    /* gid should also be 65534. */
+    gid_t gid = getgid();
+    CHECK(gid == 65534,
+          "getgid() == 65534 after unshare(CLONE_NEWUSER)");
+}
+
+int main(void)
+{
+    setvbuf(stdout, NULL, _IONBF, 0);
+    TEST_START("namespace (UTS / PID / USER isolation)");
+
+    run_uts_namespace_test();
+    run_pid_namespace_test();
+    run_user_namespace_test();
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-namespace/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-namespace/c/src/test_framework.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg)                                              \
+    do                                                                \
+    {                                                                 \
+        if (cond)                                                     \
+        {                                                             \
+            printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg); \
+            __pass++;                                                 \
+        }                                                             \
+        else                                                          \
+        {                                                             \
+            printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",           \
+                   __FILE__, __LINE__, msg, errno, strerror(errno));  \
+            __fail++;                                                 \
+        }                                                             \
+    } while (0)
+
+#define CHECK_RET(call, expected, msg)                                             \
+    do                                                                             \
+    {                                                                              \
+        errno = 0;                                                                 \
+        long _r = (long)(call);                                                    \
+        long _e = (long)(expected);                                                \
+        if (_r == _e)                                                              \
+        {                                                                          \
+            printf("  PASS | %s:%d | %s (ret=%ld)\n",                              \
+                   __FILE__, __LINE__, msg, _r);                                   \
+            __pass++;                                                              \
+        }                                                                          \
+        else                                                                       \
+        {                                                                          \
+            printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+                   __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));       \
+            __fail++;                                                              \
+        }                                                                          \
+    } while (0)
+
+#define CHECK_ERR(call, exp_errno, msg)                                                    \
+    do                                                                                     \
+    {                                                                                      \
+        errno = 0;                                                                         \
+        long _r = (long)(call);                                                            \
+        if (_r == -1 && errno == (exp_errno))                                              \
+        {                                                                                  \
+            printf("  PASS | %s:%d | %s (errno=%d as expected)\n",                         \
+                   __FILE__, __LINE__, msg, errno);                                        \
+            __pass++;                                                                      \
+        }                                                                                  \
+        else                                                                               \
+        {                                                                                  \
+            printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n",  \
+                   __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno)); \
+            __fail++;                                                                      \
+        }                                                                                  \
+    } while (0)
+
+#define TEST_START(name)                                          \
+    printf("================================================\n"); \
+    printf("  TEST: %s\n", name);                                 \
+    printf("  FILE: %s\n", __FILE__);                             \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                 \
+    printf("------------------------------------------------\n");   \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);           \
+    printf("================================================\n\n"); \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-shmctl-info/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-shmctl-info/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-shmctl-info C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-shmctl-info src/main.c)
+target_include_directories(test-shmctl-info PRIVATE src)
+target_compile_options(test-shmctl-info PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-shmctl-info RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-shmctl-info/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-shmctl-info/c/src/main.c
@@ -1,0 +1,175 @@
+/*
+ * test-shmctl-info — verify shmctl(2) IPC_INFO, SHM_INFO and SHM_STAT
+ *                    command paths.
+ *
+ * These commands are Linux-specific and bypass the per-segment lookup;
+ * they exist so that tools like `ipcs` can enumerate the shared memory
+ * table without knowing shmids in advance.
+ */
+
+#include "test_framework.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <unistd.h>
+
+/* Linux-specific shmctl commands (may be missing from libc headers). */
+#ifndef IPC_INFO
+#define IPC_INFO 3
+#endif
+
+#ifndef SHM_STAT
+#define SHM_STAT 13
+#endif
+
+#ifndef SHM_INFO
+#define SHM_INFO 14
+#endif
+
+/*
+ * struct shminfo64 — filled by shmctl(0, IPC_INFO, ...).
+ *
+ * Layout must match the kernel's 64-bit layout (each field is an unsigned
+ * long, i.e. 8 bytes on 64-bit platforms).
+ */
+struct shminfo64
+{
+    unsigned long shmmax;
+    unsigned long shmmin;
+    unsigned long shmmni;
+    unsigned long shmseg;
+    unsigned long shmall;
+};
+
+/*
+ * struct shm_info — filled by shmctl(0, SHM_INFO, ...).
+ */
+struct shm_info
+{
+    int used_ids;
+    int __pad;          /* pad to sizeof(unsigned long) */
+    unsigned long shm_tot;
+    unsigned long shm_rss;
+    unsigned long shm_swp;
+    unsigned long swap_attempts;
+    unsigned long swap_successes;
+};
+
+/* Build a process-unique key that is never IPC_PRIVATE. */
+static key_t make_key(unsigned int salt)
+{
+    key_t key = (key_t)(((unsigned int)getpid() << 8) ^ salt);
+    if (key == IPC_PRIVATE)
+    {
+        key ^= 0x1234;
+    }
+    return key;
+}
+
+static void run_ipc_info_test(void)
+{
+    struct shminfo64 info;
+    memset(&info, 0, sizeof(info));
+
+    /* IPC_INFO fills system-wide parameters. */
+    int maxid = shmctl(0, IPC_INFO, (struct shmid_ds *)&info);
+    CHECK(maxid >= 0, "shmctl(0, IPC_INFO, ...) succeeds");
+
+    /* The returned values must be sane. */
+    CHECK(info.shmmax > 0, "IPC_INFO: shmmax > 0");
+    CHECK(info.shmmin == 1, "IPC_INFO: shmmin == 1");
+    CHECK(info.shmmni > 0, "IPC_INFO: shmmni > 0");
+    CHECK(info.shmseg > 0, "IPC_INFO: shmseg > 0");
+    CHECK(info.shmall > 0, "IPC_INFO: shmall > 0");
+
+    printf("  INFO | shmmax=%lu shmmin=%lu shmmni=%lu shmseg=%lu shmall=%lu maxid=%d\n",
+           info.shmmax, info.shmmin, info.shmmni, info.shmseg, info.shmall, maxid);
+}
+
+static void run_shm_info_test(void)
+{
+    /* Create a segment so that used_ids > 0. */
+    key_t key = make_key('S');
+    int shmid = shmget(key, 4096, IPC_CREAT | 0600);
+    CHECK(shmid >= 0, "shmget for SHM_INFO test");
+
+    struct shm_info info;
+    memset(&info, 0, sizeof(info));
+
+    int maxid = shmctl(0, SHM_INFO, (struct shmid_ds *)&info);
+    CHECK(maxid >= 0, "shmctl(0, SHM_INFO, ...) succeeds");
+
+    CHECK(info.used_ids >= 1, "SHM_INFO: used_ids >= 1 (we created a segment)");
+    CHECK(info.shm_tot > 0, "SHM_INFO: shm_tot > 0");
+    /* Without swap, rss == tot. */
+    CHECK(info.shm_rss == info.shm_tot, "SHM_INFO: shm_rss == shm_tot");
+    CHECK(info.shm_swp == 0, "SHM_INFO: shm_swp == 0");
+
+    printf("  INFO | used_ids=%d shm_tot=%lu shm_rss=%lu maxid=%d\n",
+           info.used_ids, info.shm_tot, info.shm_rss, maxid);
+
+    /* Cleanup. */
+    int rc = shmctl(shmid, IPC_RMID, NULL);
+    CHECK_RET(rc, 0, "IPC_RMID cleanup after SHM_INFO test");
+}
+
+static void run_shm_stat_test(void)
+{
+    /* Create two segments so we can walk them via SHM_STAT. */
+    key_t key1 = make_key('A');
+    key_t key2 = make_key('B');
+
+    int id1 = shmget(key1, 4096, IPC_CREAT | 0600);
+    CHECK(id1 >= 0, "shmget seg1");
+    int id2 = shmget(key2, 8192, IPC_CREAT | 0600);
+    CHECK(id2 >= 0, "shmget seg2");
+
+    /* Get the max index via IPC_INFO. */
+    struct shminfo64 info;
+    memset(&info, 0, sizeof(info));
+    int maxid = shmctl(0, IPC_INFO, (struct shmid_ds *)&info);
+    CHECK(maxid >= 0, "IPC_INFO before SHM_STAT walk");
+
+    int found = 0;
+    for (int i = 0; i <= maxid; i++)
+    {
+        struct shmid_ds ds;
+        memset(&ds, 0, sizeof(ds));
+        errno = 0;
+        int cur = shmctl(i, SHM_STAT, &ds);
+        if (cur == -1)
+        {
+            /* EINVAL means no segment at this index — expected. */
+            CHECK(errno == EINVAL || errno == EACCES,
+                  "SHM_STAT: non-existent index gives EINVAL or EACCES");
+            continue;
+        }
+        /* The return value is the actual shmid. */
+        CHECK(cur == id1 || cur == id2,
+              "SHM_STAT returned a known shmid");
+        CHECK(ds.shm_segsz > 0, "SHM_STAT: shm_segsz > 0");
+        found++;
+    }
+
+    CHECK(found >= 2, "SHM_STAT: found at least 2 segments via iteration");
+
+    /* Cleanup. */
+    shmctl(id1, IPC_RMID, NULL);
+    shmctl(id2, IPC_RMID, NULL);
+}
+
+int main(void)
+{
+    setvbuf(stdout, NULL, _IONBF, 0);
+    TEST_START("shmctl IPC_INFO / SHM_INFO / SHM_STAT basic paths");
+
+    run_ipc_info_test();
+    run_shm_info_test();
+    run_shm_stat_test();
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-shmctl-info/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-shmctl-info/c/src/test_framework.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg)                                              \
+    do                                                                \
+    {                                                                 \
+        if (cond)                                                     \
+        {                                                             \
+            printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg); \
+            __pass++;                                                 \
+        }                                                             \
+        else                                                          \
+        {                                                             \
+            printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",           \
+                   __FILE__, __LINE__, msg, errno, strerror(errno));  \
+            __fail++;                                                 \
+        }                                                             \
+    } while (0)
+
+#define CHECK_RET(call, expected, msg)                                             \
+    do                                                                             \
+    {                                                                              \
+        errno = 0;                                                                 \
+        long _r = (long)(call);                                                    \
+        long _e = (long)(expected);                                                \
+        if (_r == _e)                                                              \
+        {                                                                          \
+            printf("  PASS | %s:%d | %s (ret=%ld)\n",                              \
+                   __FILE__, __LINE__, msg, _r);                                   \
+            __pass++;                                                              \
+        }                                                                          \
+        else                                                                       \
+        {                                                                          \
+            printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+                   __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));       \
+            __fail++;                                                              \
+        }                                                                          \
+    } while (0)
+
+#define CHECK_ERR(call, exp_errno, msg)                                                    \
+    do                                                                                     \
+    {                                                                                      \
+        errno = 0;                                                                         \
+        long _r = (long)(call);                                                            \
+        if (_r == -1 && errno == (exp_errno))                                              \
+        {                                                                                  \
+            printf("  PASS | %s:%d | %s (errno=%d as expected)\n",                         \
+                   __FILE__, __LINE__, msg, errno);                                        \
+            __pass++;                                                                      \
+        }                                                                                  \
+        else                                                                               \
+        {                                                                                  \
+            printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n",  \
+                   __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno)); \
+            __fail++;                                                                      \
+        }                                                                                  \
+    } while (0)
+
+#define TEST_START(name)                                          \
+    printf("================================================\n"); \
+    printf("  TEST: %s\n", name);                                 \
+    printf("  FILE: %s\n", __FILE__);                             \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                 \
+    printf("------------------------------------------------\n");   \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);           \
+    printf("================================================\n\n"); \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
- ShmInner.ns_id + filter by current process's ipc_ns
- MessageQueue.ns_id + filter by current process's ipc_ns
- Network: in_root_net_ns() helper filters eth0 in ioctl/netlink/packet paths
- Mount: extend sys_mount to support proc/sysfs/devtmpfs/devpts
（谨慎合并）