### PR TITLE
fix(ci): stabilize Starry LoongArch apk-curl test

### DIFF
--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -155,8 +155,8 @@ impl DirNode {
             .map_err(|_| VfsError::InvalidInput)
     }
 
-    fn forget_entry(children: &mut DirChildren, name: &str) {
-        if let Some(entry) = children.remove(name)
+    fn forget_removed_entry(entry: Option<DirEntry>) {
+        if let Some(entry) = entry
             && let Ok(dir) = entry.as_dir()
         {
             dir.forget();
@@ -221,11 +221,8 @@ impl DirNode {
             // source node.  Without this, in-memory filesystems like tmpfs
             // would create a new empty page cache for the link, losing the
             // file content.
-            {
-                let src = node.user_data();
-                let mut dst = entry.user_data();
-                *dst = src.clone();
-            }
+            let user_data = node.user_data().clone();
+            *entry.user_data() = user_data;
             self.cache.lock().insert(name.to_owned(), entry.clone());
         })
     }
@@ -234,17 +231,20 @@ impl DirNode {
     pub fn unlink(&self, name: &str, is_dir: bool) -> VfsResult<()> {
         verify_entry_name(name)?;
 
-        let mut children = self.cache.lock();
-        let entry = self.lookup_locked(name, &mut children)?;
-        match (entry.is_dir(), is_dir) {
-            (true, false) => return Err(VfsError::IsADirectory),
-            (false, true) => return Err(VfsError::NotADirectory),
-            _ => {}
-        }
+        let removed = {
+            let mut children = self.cache.lock();
+            let entry = self.lookup_locked(name, &mut children)?;
+            match (entry.is_dir(), is_dir) {
+                (true, false) => return Err(VfsError::IsADirectory),
+                (false, true) => return Err(VfsError::NotADirectory),
+                _ => {}
+            }
 
-        self.ops.unlink(name).inspect(|_| {
-            Self::forget_entry(&mut children, name);
-        })
+            self.ops.unlink(name)?;
+            children.remove(name)
+        };
+        Self::forget_removed_entry(removed);
+        Ok(())
     }
 
     /// Returns whether the directory contains children.
@@ -328,27 +328,37 @@ impl DirNode {
         drop(dst_children);
 
         self.ops.rename(src_name, dst_dir, dst_name).inspect(|_| {
-            let (mut src_children, mut dst_children) = self.lock_both_cache(dst_dir);
-            let src_entry = src_children.remove(src_name);
-            let dst_children_ref = dst_children
-                .as_mut()
-                .map_or_else(|| src_children.deref_mut(), DerefMut::deref_mut);
-            if let Some(prev) = dst_children_ref.remove(dst_name)
-                && let Ok(dir) = prev.as_dir()
-            {
-                dir.forget();
-            }
+            let (src_entry, prev_entry) = {
+                let (mut src_children, mut dst_children) = self.lock_both_cache(dst_dir);
+                let src_entry = src_children.remove(src_name);
+                let dst_children_ref = dst_children
+                    .as_mut()
+                    .map_or_else(|| src_children.deref_mut(), DerefMut::deref_mut);
+                let prev_entry = dst_children_ref.remove(dst_name);
+                (src_entry, prev_entry)
+            };
+
+            Self::forget_removed_entry(prev_entry);
+
             if let Some(entry) = src_entry
                 && dst_dir.ops.is_cacheable()
                 && let Ok(fresh_entry) = dst_dir.ops.lookup(dst_name)
             {
-                *fresh_entry.user_data().deref_mut() = mem::take(entry.user_data().deref_mut());
-                if let (Ok(src_dir), Ok(dst_dir)) = (entry.as_dir(), fresh_entry.as_dir()) {
-                    *dst_dir.cache.lock().deref_mut() = mem::take(src_dir.cache.lock().deref_mut());
-                    *dst_dir.mountpoint.lock().deref_mut() =
-                        mem::take(src_dir.mountpoint.lock().deref_mut());
+                let user_data = {
+                    let mut source = entry.user_data();
+                    mem::take(source.deref_mut())
+                };
+                *fresh_entry.user_data().deref_mut() = user_data;
+                if let (Ok(src_dir), Ok(fresh_dir)) = (entry.as_dir(), fresh_entry.as_dir()) {
+                    let cache = mem::take(src_dir.cache.lock().deref_mut());
+                    *fresh_dir.cache.lock().deref_mut() = cache;
+                    let mountpoint = mem::take(src_dir.mountpoint.lock().deref_mut());
+                    *fresh_dir.mountpoint.lock().deref_mut() = mountpoint;
                 }
-                dst_children_ref.insert(dst_name.to_owned(), fresh_entry);
+                dst_dir
+                    .cache
+                    .lock()
+                    .insert(dst_name.to_owned(), fresh_entry);
             }
         })
     }
@@ -390,7 +400,8 @@ impl DirNode {
     /// Clears the cache of directory entries & user data, allowing them to be
     /// released.
     pub(crate) fn forget(&self) {
-        for (_, child) in mem::take(self.cache.lock().deref_mut()) {
+        let children = mem::take(self.cache.lock().deref_mut());
+        for (_, child) in children {
             if let Ok(dir) = child.as_dir() {
                 dir.forget();
             }

--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -5,7 +5,6 @@ use alloc::{
 };
 use core::{
     num::NonZeroUsize,
-    ops::Range,
     sync::atomic::{AtomicU8, Ordering},
     task::Context,
 };
@@ -663,71 +662,74 @@ impl CachedFile {
         f(page, evicted)
     }
 
-    fn with_pages<T>(
-        &self,
-        range: Range<u64>,
-        page_initial: impl FnOnce(&FileNode) -> VfsResult<T>,
-        mut page_each: impl FnMut(T, &mut PageCache, Range<usize>) -> VfsResult<T>,
-    ) -> VfsResult<T> {
-        let file = self.inner.entry().as_file()?;
-        let mut initial = page_initial(file)?;
-        let start_page = (range.start / PAGE_SIZE as u64) as u32;
-        let end_page = range.end.div_ceil(PAGE_SIZE as u64) as u32;
-        let mut page_offset = (range.start % PAGE_SIZE as u64) as usize;
-        for pn in start_page..end_page {
-            let page_start = pn as u64 * PAGE_SIZE as u64;
-
-            let mut guard = self.shared.page_cache.lock();
-            let page = self.page_or_insert(file, &mut guard, pn)?.0;
-
-            initial = page_each(
-                initial,
-                page,
-                page_offset..(range.end - page_start).min(PAGE_SIZE as u64) as usize,
-            )?;
-            page_offset = 0;
-        }
-
-        Ok(initial)
-    }
-
     /// Reads data from the file at `offset` into `dst`.
     pub fn read_at(&self, mut dst: impl Write + IoBufMut, offset: u64) -> VfsResult<usize> {
         let len = self.inner.len()?;
-        let end = (offset + dst.remaining_mut() as u64).min(len);
+        let end = offset.saturating_add(dst.remaining_mut() as u64).min(len);
         if end <= offset {
             return Ok(0);
         }
-        self.with_pages(
-            offset..end,
-            |_| Ok(0),
-            |read, page, range| {
-                let len = range.end - range.start;
-                dst.write(&page.data()[range.start..range.end])?;
-                Ok(read + len)
-            },
-        )
+
+        let file = self.inner.entry().as_file()?;
+        let mut scratch = PageCache::new()?;
+        let mut read = 0;
+        let mut current = offset;
+        while current < end {
+            let pn = (current / PAGE_SIZE as u64) as u32;
+            let page_start = pn as u64 * PAGE_SIZE as u64;
+            let page_offset = (current - page_start) as usize;
+            let chunk_len = (end - page_start).min(PAGE_SIZE as u64) as usize - page_offset;
+
+            {
+                let mut guard = self.shared.page_cache.lock();
+                let page = self.page_or_insert(file, &mut guard, pn)?.0;
+                scratch.data()[..chunk_len]
+                    .copy_from_slice(&page.data()[page_offset..page_offset + chunk_len]);
+            }
+
+            dst.write_all(&scratch.data()[..chunk_len])?;
+            read += chunk_len;
+            current += chunk_len as u64;
+        }
+
+        Ok(read)
     }
 
     fn write_at_locked(&self, mut buf: impl Read + IoBuf, offset: u64) -> VfsResult<usize> {
-        let end = offset + buf.remaining() as u64;
-        self.with_pages(
-            offset..end,
-            |file| {
-                if end > file.len()? {
-                    file.set_len(end)?;
-                }
-                Ok(0)
-            },
-            |written, page, range| {
-                let len = range.end - range.start;
-                buf.read(&mut page.data()[range.start..range.end])?;
+        let file = self.inner.entry().as_file()?;
+        let end = offset.saturating_add(buf.remaining() as u64);
+        if end > file.len()? {
+            file.set_len(end)?;
+        }
+
+        let mut scratch = PageCache::new()?;
+        let mut written = 0;
+        let mut current = offset;
+        while current < end && buf.remaining() > 0 {
+            let pn = (current / PAGE_SIZE as u64) as u32;
+            let page_start = pn as u64 * PAGE_SIZE as u64;
+            let page_offset = (current - page_start) as usize;
+            let chunk_len =
+                ((PAGE_SIZE - page_offset).min(buf.remaining())).min((end - current) as usize);
+            let n = buf.read(&mut scratch.data()[..chunk_len])?;
+            if n == 0 {
+                break;
+            }
+
+            {
+                let mut guard = self.shared.page_cache.lock();
+                let page = self.page_or_insert(file, &mut guard, pn)?.0;
+                page.data()[page_offset..page_offset + n].copy_from_slice(&scratch.data()[..n]);
                 if !self.in_memory {
                     page.dirty = true;
                 }
-                Ok(written + len)
-            },
-        )
+            }
+
+            written += n;
+            current += n as u64;
+        }
+
+        Ok(written)
     }
 
     /// Writes `buf` to the file at `offset`.

--- a/scripts/axbuild/src/starry/test.rs
+++ b/scripts/axbuild/src/starry/test.rs
@@ -1240,6 +1240,122 @@ mod tests {
         .unwrap();
     }
 
+    #[test]
+    fn apk_curl_qemu_configs_bound_guest_network_commands() {
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let case_dir = workspace_root.join("test-suit/starryos/normal/qemu-smp1/apk-curl");
+
+        for arch in ["aarch64", "loongarch64", "riscv64", "x86_64"] {
+            let path = case_dir.join(format!("qemu-{arch}.toml"));
+            let content = fs::read_to_string(&path).unwrap();
+            let config: toml::Value = toml::from_str(&content).unwrap();
+            let shell_init_cmd = config
+                .get("shell_init_cmd")
+                .and_then(toml::Value::as_str)
+                .unwrap_or_default();
+
+            assert!(
+                shell_init_cmd.contains("fetch_timeout=60"),
+                "{} must keep apk/curl network waits short enough for CI retries",
+                path.display()
+            );
+            for mirror in [
+                "https://mirrors.cernet.edu.cn/alpine",
+                "https://dl-cdn.alpinelinux.org/alpine",
+            ] {
+                assert!(
+                    shell_init_cmd.contains(mirror),
+                    "{} must retry apk-curl through fallback mirror {mirror}",
+                    path.display()
+                );
+            }
+            assert!(
+                shell_init_cmd.contains("APK_CURL_REPO_"),
+                "{} must report which apk mirror is being tried",
+                path.display()
+            );
+            assert!(
+                shell_init_cmd
+                    .contains("timeout \"$fetch_timeout\" apk --timeout \"$fetch_timeout\" update"),
+                "{} must bound apk update so CI can retry mirror stalls",
+                path.display()
+            );
+            assert!(
+                shell_init_cmd.contains(
+                    "timeout \"$fetch_timeout\" apk --timeout \"$fetch_timeout\" add curl"
+                ),
+                "{} must bound apk add so CI can retry mirror stalls",
+                path.display()
+            );
+            assert!(
+                shell_init_cmd.contains("curl --connect-timeout 10 --max-time 30"),
+                "{} must bound the external curl probe",
+                path.display()
+            );
+            let timeout = config
+                .get("timeout")
+                .and_then(toml::Value::as_integer)
+                .unwrap_or_default();
+            assert!(
+                timeout <= 600,
+                "{} must not leave apk-curl with the old long QEMU timeout",
+                path.display()
+            );
+            for marker in [
+                "APK_CURL_UPDATE_BEGIN",
+                "APK_CURL_UPDATE_DONE",
+                "APK_CURL_ADD_BEGIN",
+                "APK_CURL_ADD_DONE",
+                "APK_CURL_PROBE_BEGIN",
+                "APK_CURL_PROBE_DONE",
+            ] {
+                assert!(
+                    shell_init_cmd.contains(marker),
+                    "{} must mark apk-curl progress with {marker}",
+                    path.display()
+                );
+            }
+
+            let fail_regex = config
+                .get("fail_regex")
+                .and_then(toml::Value::as_array)
+                .unwrap();
+            assert!(
+                fail_regex
+                    .iter()
+                    .filter_map(toml::Value::as_str)
+                    .any(|regex| regex.contains("lockdep fatal violation")),
+                "{} must fail when lockdep reports a fatal violation",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn bug_ext4_dir_ops_qemu_configs_fail_on_lockdep_fatal() {
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let case_dir = workspace_root.join("test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops");
+
+        for arch in ["aarch64", "loongarch64", "riscv64", "x86_64"] {
+            let path = case_dir.join(format!("qemu-{arch}.toml"));
+            let content = fs::read_to_string(&path).unwrap();
+            let config: toml::Value = toml::from_str(&content).unwrap();
+            let fail_regex = config
+                .get("fail_regex")
+                .and_then(toml::Value::as_array)
+                .unwrap();
+
+            assert!(
+                fail_regex
+                    .iter()
+                    .filter_map(toml::Value::as_str)
+                    .any(|regex| regex.contains("lockdep fatal violation")),
+                "{} must fail when lockdep reports a fatal violation",
+                path.display()
+            );
+        }
+    }
+
     fn prepared_qemu_case(name: &str, build_config_path: PathBuf) -> PreparedStarryQemuCase {
         PreparedStarryQemuCase {
             case: TestQemuCase {

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-aarch64.toml
@@ -17,19 +17,46 @@ uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
-i=0
-while [ $i -lt 3 ]; do
-    apk update && \
-    apk add curl && \
+fetch_timeout=60
+repo_file=/etc/apk/repositories
+original_repos="$(cat "$repo_file")"
+
+try_apk_curl() {
+    mirror="$1"
+    label="$2"
+    printf '%s\n' "$original_repos" | \
+        sed "s#http://[^/]*/alpine/#$mirror/#g;s#https://[^/]*/alpine/#$mirror/#g" > "$repo_file"
+    rm -f /lib/apk/db/lock
+    echo "APK_CURL_REPO_$label"
+    echo "APK_CURL_UPDATE_BEGIN"
+    timeout "$fetch_timeout" apk --timeout "$fetch_timeout" update && \
+    echo "APK_CURL_UPDATE_DONE" && \
+    echo "APK_CURL_ADD_BEGIN" && \
+    timeout "$fetch_timeout" apk --timeout "$fetch_timeout" add curl && \
+    echo "APK_CURL_ADD_DONE" && \
+    echo "APK_CURL_PROBE_BEGIN" && \
     curl --version && \
-    curl -i https://baidu.com && \
-    echo 'APK_CURL_TEST_PASSED' && \
-    exit 0
+    curl --connect-timeout 10 --max-time 30 -i https://baidu.com && \
+    echo "APK_CURL_PROBE_DONE"
+}
+
+i=0
+for repo in \
+    "https://mirrors.cernet.edu.cn/alpine cernet" \
+    "https://dl-cdn.alpinelinux.org/alpine upstream"
+do
     i=$((i + 1))
+    mirror=${repo% *}
+    label=${repo#* }
+    echo "APK_CURL_ATTEMPT_$i"
+    if try_apk_curl "$mirror" "$label"; then
+        echo 'APK_CURL_TEST_PASSED'
+        exit 0
+    fi
     sleep 2
 done
 echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
-fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 1200
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^lockdep fatal violation\\s*$", "(?m)^APK_CURL_TEST_FAILED\\s*$"]
+timeout = 420

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-loongarch64.toml
@@ -19,19 +19,46 @@ to_bin = true
 uefi = false
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
-i=0
-while [ $i -lt 3 ]; do
-  apk update && \
-  apk add curl && \
+fetch_timeout=60
+repo_file=/etc/apk/repositories
+original_repos="$(cat "$repo_file")"
+
+try_apk_curl() {
+  mirror="$1"
+  label="$2"
+  printf '%s\n' "$original_repos" | \
+    sed "s#http://[^/]*/alpine/#$mirror/#g;s#https://[^/]*/alpine/#$mirror/#g" > "$repo_file"
+  rm -f /lib/apk/db/lock
+  echo "APK_CURL_REPO_$label"
+  echo "APK_CURL_UPDATE_BEGIN"
+  timeout "$fetch_timeout" apk --timeout "$fetch_timeout" update && \
+  echo "APK_CURL_UPDATE_DONE" && \
+  echo "APK_CURL_ADD_BEGIN" && \
+  timeout "$fetch_timeout" apk --timeout "$fetch_timeout" add curl && \
+  echo "APK_CURL_ADD_DONE" && \
+  echo "APK_CURL_PROBE_BEGIN" && \
   curl --version && \
-  curl -i https://baidu.com && \
-  echo 'APK_CURL_TEST_PASSED' && \
-  exit 0
+  curl --connect-timeout 10 --max-time 30 -i https://baidu.com && \
+  echo "APK_CURL_PROBE_DONE"
+}
+
+i=0
+for repo in \
+  "https://mirrors.cernet.edu.cn/alpine cernet" \
+  "https://dl-cdn.alpinelinux.org/alpine upstream"
+do
   i=$((i + 1))
+  mirror=${repo% *}
+  label=${repo#* }
+  echo "APK_CURL_ATTEMPT_$i"
+  if try_apk_curl "$mirror" "$label"; then
+    echo 'APK_CURL_TEST_PASSED'
+    exit 0
+  fi
   sleep 2
 done
 echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
-fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 1200
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^lockdep fatal violation\\s*$", "(?m)^APK_CURL_TEST_FAILED\\s*$"]
+timeout = 420

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-riscv64.toml
@@ -17,19 +17,46 @@ uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
-i=0
-while [ $i -lt 3 ]; do
-    apk update && \
-    apk add curl && \
+fetch_timeout=60
+repo_file=/etc/apk/repositories
+original_repos="$(cat "$repo_file")"
+
+try_apk_curl() {
+    mirror="$1"
+    label="$2"
+    printf '%s\n' "$original_repos" | \
+        sed "s#http://[^/]*/alpine/#$mirror/#g;s#https://[^/]*/alpine/#$mirror/#g" > "$repo_file"
+    rm -f /lib/apk/db/lock
+    echo "APK_CURL_REPO_$label"
+    echo "APK_CURL_UPDATE_BEGIN"
+    timeout "$fetch_timeout" apk --timeout "$fetch_timeout" update && \
+    echo "APK_CURL_UPDATE_DONE" && \
+    echo "APK_CURL_ADD_BEGIN" && \
+    timeout "$fetch_timeout" apk --timeout "$fetch_timeout" add curl && \
+    echo "APK_CURL_ADD_DONE" && \
+    echo "APK_CURL_PROBE_BEGIN" && \
     curl --version && \
-    curl -i https://baidu.com && \
-    echo 'APK_CURL_TEST_PASSED' && \
-    exit 0
+    curl --connect-timeout 10 --max-time 30 -i https://baidu.com && \
+    echo "APK_CURL_PROBE_DONE"
+}
+
+i=0
+for repo in \
+    "https://mirrors.cernet.edu.cn/alpine cernet" \
+    "https://dl-cdn.alpinelinux.org/alpine upstream"
+do
     i=$((i + 1))
+    mirror=${repo% *}
+    label=${repo#* }
+    echo "APK_CURL_ATTEMPT_$i"
+    if try_apk_curl "$mirror" "$label"; then
+        echo 'APK_CURL_TEST_PASSED'
+        exit 0
+    fi
     sleep 2
 done
 echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
-fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 1200
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^lockdep fatal violation\\s*$", "(?m)^APK_CURL_TEST_FAILED\\s*$"]
+timeout = 420

--- a/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/apk-curl/qemu-x86_64.toml
@@ -17,19 +17,46 @@ uefi = false
 to_bin = false
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
-i=0
-while [ $i -lt 3 ]; do
-    apk update && \
-    apk add curl && \
+fetch_timeout=60
+repo_file=/etc/apk/repositories
+original_repos="$(cat "$repo_file")"
+
+try_apk_curl() {
+    mirror="$1"
+    label="$2"
+    printf '%s\n' "$original_repos" | \
+        sed "s#http://[^/]*/alpine/#$mirror/#g;s#https://[^/]*/alpine/#$mirror/#g" > "$repo_file"
+    rm -f /lib/apk/db/lock
+    echo "APK_CURL_REPO_$label"
+    echo "APK_CURL_UPDATE_BEGIN"
+    timeout "$fetch_timeout" apk --timeout "$fetch_timeout" update && \
+    echo "APK_CURL_UPDATE_DONE" && \
+    echo "APK_CURL_ADD_BEGIN" && \
+    timeout "$fetch_timeout" apk --timeout "$fetch_timeout" add curl && \
+    echo "APK_CURL_ADD_DONE" && \
+    echo "APK_CURL_PROBE_BEGIN" && \
     curl --version && \
-    curl -i https://baidu.com && \
-    echo 'APK_CURL_TEST_PASSED' && \
-    exit 0
+    curl --connect-timeout 10 --max-time 30 -i https://baidu.com && \
+    echo "APK_CURL_PROBE_DONE"
+}
+
+i=0
+for repo in \
+    "https://mirrors.cernet.edu.cn/alpine cernet" \
+    "https://dl-cdn.alpinelinux.org/alpine upstream"
+do
     i=$((i + 1))
+    mirror=${repo% *}
+    label=${repo#* }
+    echo "APK_CURL_ATTEMPT_$i"
+    if try_apk_curl "$mirror" "$label"; then
+        echo 'APK_CURL_TEST_PASSED'
+        exit 0
+    fi
     sleep 2
 done
 echo 'APK_CURL_TEST_FAILED'
 '''
 success_regex = ["(?m)^APK_CURL_TEST_PASSED\\s*$"]
-fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^APK_CURL_TEST_FAILED\\s*$"]
-timeout = 1200
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^lockdep fatal violation\\s*$", "(?m)^APK_CURL_TEST_FAILED\\s*$"]
+timeout = 420

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-aarch64.toml
@@ -20,5 +20,5 @@ to_bin = false
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/bug-ext4-dir-ops"
 success_regex = ['(?m)^TEST PASSED\s*$']
-fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b']
+fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b', "(?m)^lockdep fatal violation\\s*$"]
 timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-loongarch64.toml
@@ -20,5 +20,5 @@ uefi = false
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/bug-ext4-dir-ops"
 success_regex = ['(?m)^TEST PASSED\s*$']
-fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b']
+fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b', "(?m)^lockdep fatal violation\\s*$"]
 timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-riscv64.toml
@@ -18,5 +18,5 @@ to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/bug-ext4-dir-ops"
 success_regex = ['(?m)^TEST PASSED\s*$']
-fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b']
+fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b', "(?m)^lockdep fatal violation\\s*$"]
 timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/bug-ext4-dir-ops/qemu-x86_64.toml
@@ -18,5 +18,5 @@ to_bin = false
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/bug-ext4-dir-ops"
 success_regex = ['(?m)^TEST PASSED\s*$']
-fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b']
+fail_regex = ['(?m)^TEST FAILED\s*$', '(?i)\bpanic(?:ked)?\b', "(?m)^lockdep fatal violation\\s*$"]
 timeout = 60


### PR DESCRIPTION
## 问题

近期 Starry LoongArch CI 中 `apk-curl` 偶发长时间卡住。排查后确认 virtio-net PCI 中断号路由本身没有异常，主要卡点在 guest 内 `apk update`/`apk add curl` 的外部镜像 fetch 阶段；同时开启 lockdep 后暴露出 axfs-ng/VFS 路径中若干锁顺序问题，会增加随机卡死或误判风险。

## 修改

- 调整 `apk-curl` QEMU 用例：
  - 为 `apk update`、`apk add curl` 和 `curl` probe 增加独立超时。
  - 增加 CERNET 与 Alpine upstream 镜像 fallback。
  - 增加 `APK_CURL_*` 阶段 marker，方便 CI 日志定位卡在哪一步。
  - 将用例总 timeout 从 1200s 降到 420s，避免外部网络异常拖满 CI。
  - 将 lockdep fatal violation 加入 fail regex。
- 修复 axfs-ng `CachedFile` 读写路径：
  - 避免持有 `page_cache` 锁时访问外部/user buffer，从而避免 `page_cache -> aspace` 的 lockdep 反转。
- 修复 axfs-ng-vfs 目录项缓存路径：
  - 避免 `link`/`rename` 中嵌套持有同类 `user_data` 锁。
  - 避免 `unlink`/`forget` 在目录 cache 锁内递归释放子目录 cache。
- 增加 axbuild 回归测试，约束 `apk-curl` 的短超时、fallback、阶段 marker，以及 `bug-ext4-dir-ops` 的 lockdep fatal fail regex。

## 验证

- `cargo fmt --check && git diff --check`
- `cargo test -p axbuild starry::test::tests::`
- `cargo xtask clippy --package axfs-ng-vfs`
- `cargo xtask clippy --package ax-fs-ng`
- `cargo xtask starry test qemu --arch loongarch64 -c bug-ext4-dir-ops`
- `cargo xtask starry test qemu --arch loongarch64 -c apk-curl`