### PR TITLE
fix(axalloc): use page-alloc-64g only for StarryOS, not as global default

### DIFF
--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -44,7 +44,7 @@ ax-feat = { workspace = true, features = [
     "irq",
     "uspace",
 
-    "page-alloc-4g",
+    "page-alloc-64g",
     "alloc-slab",
 
     "multitask",


### PR DESCRIPTION
## Summary

Moves `page-alloc-64g` enablement from `axalloc`'s global default feature to StarryOS kernel's `ax-feat` feature passthrough.

## Problem

Changing `axalloc`'s default feature from `page-alloc-4g` to `page-alloc-64g` affects ALL downstream consumers (ArceOS minimal targets, Axvisor, etc.), not just StarryOS. Small-memory ArceOS targets that need only 4G addressing end up with the large 64G bitmap allocator unnecessarily.

## Fix

- `axalloc` default stays at `page-alloc-4g` (already correct on upstream/dev)
- `os/StarryOS/kernel/Cargo.toml`: change `ax-feat` feature from `"page-alloc-4g"` to `"page-alloc-64g"` (line 47)

This uses the existing `ax-feat` passthrough mechanism: `ax-feat` exposes both `page-alloc-64g` and `page-alloc-4g` features that map to `ax-alloc/page-alloc-*`. StarryOS selects the one it needs without modifying the library default.

## Test plan
- [x] `cargo check -p starry-kernel` passes with the change
- [ ] Verify existing small-memory ArceOS targets still build

🤖 Generated with [Claude Code](https://claude.com/claude-code)