### PR TITLE
fix(axvisor): enable buddy-slab allocator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,15 +357,6 @@ jobs:
             apk_region: us
             limit_to_owner: ""
             main_pr_only: false
-          - name: Test starry aarch64 buddy-slab qemu
-            use_container: true
-            runs_on: '["ubuntu-latest"]'
-            command: cargo xtask starry test qemu --arch aarch64 -c test-clone-files-race-buddy-slab
-            cache_key: test-starry-aarch64-buddy-slab
-            container_image: base
-            apk_region: us
-            limit_to_owner: ""
-            main_pr_only: false
           - name: Test starry loongarch64 qemu
             use_container: true
             runs_on: '["ubuntu-latest"]'

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -22,7 +22,7 @@ smp = ["alloc", "ax-hal/smp", "ax-task?/smp"]
 stack-guard-page = ["multitask", "paging", "ax-task/stack-guard-page"]
 tls = ["ax-hal/tls", "ax-task?/tls"]
 
-plat-dyn = ["ax-hal/plat-dyn", "paging", "ax-alloc/buddy-slab", "dep:ax-ipi", "irq", "rtc", "smp", "stack-guard-page", "tls"]
+plat-dyn = ["ax-hal/plat-dyn", "paging", "ax-alloc/buddy-slab", "ipi", "irq", "rtc", "smp", "stack-guard-page", "tls"]
 
 display = ["dep:ax-display", "ax-driver/display"]
 fs = [

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -22,7 +22,17 @@ smp = ["alloc", "ax-hal/smp", "ax-task?/smp"]
 stack-guard-page = ["multitask", "paging", "ax-task/stack-guard-page"]
 tls = ["ax-hal/tls", "ax-task?/tls"]
 
-plat-dyn = ["ax-hal/plat-dyn", "paging", "ax-alloc/buddy-slab", "irq", "rtc", "smp", "stack-guard-page", "tls"]
+plat-dyn = [
+  "ax-hal/plat-dyn",
+  "paging",
+  "buddy-slab",
+  "irq",
+  "rtc",
+  "smp",
+  "stack-guard-page",
+  "tls",
+  "alloc",
+]
 
 display = ["dep:ax-display", "ax-driver/display"]
 fs = [

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "ax-runtime"
-version = "0.5.16"
-repository = "https://github.com/rcore-os/tgoskits"
-edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]
 description = "Runtime library of ArceOS"
+edition.workspace = true
 license.workspace = true
+name = "ax-runtime"
+repository = "https://github.com/rcore-os/tgoskits"
+version = "0.5.16"
 
 [features]
 default = []
 
 alloc = ["dep:ax-alloc"]
-dma = ["paging"]
 buddy-slab = ["alloc", "ax-alloc/buddy-slab"]
+dma = ["paging"]
 ipi = ["dep:ax-ipi"]
 irq = ["ax-hal/irq", "ax-task?/irq", "dep:ax-percpu"]
 multitask = ["ax-task/multitask"]
@@ -22,24 +22,24 @@ smp = ["alloc", "ax-hal/smp", "ax-task?/smp"]
 stack-guard-page = ["multitask", "paging", "ax-task/stack-guard-page"]
 tls = ["ax-hal/tls", "ax-task?/tls"]
 
-plat-dyn = ["ax-hal/plat-dyn", "paging"]
+plat-dyn = ["ax-hal/plat-dyn", "paging", "ax-alloc/buddy-slab", "dep:ax-ipi", "irq", "rtc", "smp", "stack-guard-page", "tls"]
 
 display = ["dep:ax-display", "ax-driver/display"]
 fs = [
-    "dep:ax-errno",
-    "dep:ax-fs",
-    "dep:rd-block",
-    "dep:spin",
-    "dep:axklib",
-    "ax-driver/block",
+  "dep:ax-errno",
+  "dep:ax-fs",
+  "dep:rd-block",
+  "dep:spin",
+  "dep:axklib",
+  "ax-driver/block",
 ]
 fs-ng = [
-    "dep:ax-errno",
-    "dep:ax-fs-ng",
-    "dep:rd-block",
-    "dep:spin",
-    "dep:axklib",
-    "ax-driver/block",
+  "dep:ax-errno",
+  "dep:ax-fs-ng",
+  "dep:rd-block",
+  "dep:spin",
+  "dep:axklib",
+  "ax-driver/block",
 ]
 input = ["dep:ax-input", "ax-driver/input"]
 net = ["dep:ax-net", "ax-driver/net"]
@@ -47,34 +47,34 @@ net-ng = ["dep:ax-net-ng", "dep:rd-net", "dep:spin", "dep:axklib", "ax-driver/ne
 vsock = ["net-ng", "ax-net-ng/vsock", "ax-driver/vsock"]
 
 [dependencies]
-ax-alloc = { workspace = true, optional = true, features = ["default"] }
-axbacktrace = { workspace = true }
-ax-config = { workspace = true }
-ax-display = { workspace = true, optional = true }
-ax-driver = { workspace = true }
-ax-errno = { workspace = true, optional = true }
-ax-fs = { workspace = true, optional = true }
-ax-fs-ng = { workspace = true, optional = true }
-ax-hal = { workspace = true }
-ax-input = { workspace = true, optional = true }
-ax-ipi = { workspace = true, optional = true }
-axklib = { workspace = true, optional = true }
-ax-log = { workspace = true }
-ax-lazyinit = { workspace = true }
-ax-memory-addr = { workspace = true }
-ax-mm = { workspace = true, optional = true }
-ax-net = { workspace = true, optional = true }
-ax-net-ng = { workspace = true, optional = true }
-axpanic = { workspace = true }
-ax-plat = { workspace = true }
-ax-task = { workspace = true, optional = true }
-cfg-if = { workspace = true }
-chrono = { version = "0.4", default-features = false }
-ax-crate-interface = { workspace = true }
-ax-ctor-bare = { workspace = true }
+ax-alloc = {workspace = true, optional = true, features = ["default"]}
+ax-config = {workspace = true}
+ax-crate-interface = {workspace = true}
+ax-ctor-bare = {workspace = true}
+ax-display = {workspace = true, optional = true}
+ax-driver = {workspace = true}
+ax-errno = {workspace = true, optional = true}
+ax-fs = {workspace = true, optional = true}
+ax-fs-ng = {workspace = true, optional = true}
+ax-hal = {workspace = true}
+ax-input = {workspace = true, optional = true}
+ax-ipi = {workspace = true, optional = true}
+ax-lazyinit = {workspace = true}
+ax-log = {workspace = true}
+ax-memory-addr = {workspace = true}
+ax-mm = {workspace = true, optional = true}
+ax-net = {workspace = true, optional = true}
+ax-net-ng = {workspace = true, optional = true}
+ax-percpu = {workspace = true, optional = true}
+ax-plat = {workspace = true}
+ax-task = {workspace = true, optional = true}
+axbacktrace = {workspace = true}
+axklib = {workspace = true, optional = true}
+axpanic = {workspace = true}
+cfg-if = {workspace = true}
+chrono = {version = "0.4", default-features = false}
 indoc = "2"
-ax-percpu = { workspace = true, optional = true }
-rd-block = { workspace = true, optional = true }
-rd-net = { workspace = true, optional = true }
+rd-block = {workspace = true, optional = true}
+rd-net = {workspace = true, optional = true}
 rdrive.workspace = true
-spin = { workspace = true, optional = true }
+spin = {workspace = true, optional = true}

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -22,7 +22,7 @@ smp = ["alloc", "ax-hal/smp", "ax-task?/smp"]
 stack-guard-page = ["multitask", "paging", "ax-task/stack-guard-page"]
 tls = ["ax-hal/tls", "ax-task?/tls"]
 
-plat-dyn = ["ax-hal/plat-dyn", "paging", "ax-alloc/buddy-slab", "ipi", "irq", "rtc", "smp", "stack-guard-page", "tls"]
+plat-dyn = ["ax-hal/plat-dyn", "paging", "ax-alloc/buddy-slab", "irq", "rtc", "smp", "stack-guard-page", "tls"]
 
 display = ["dep:ax-display", "ax-driver/display"]
 fs = [

--- a/os/arceos/ulib/axstd/Cargo.toml
+++ b/os/arceos/ulib/axstd/Cargo.toml
@@ -43,6 +43,7 @@ alloc = ["ax-api/alloc", "ax-feat/alloc", "ax-io/alloc"]
 alloc-tlsf = ["ax-feat/alloc-tlsf"]
 alloc-slab = ["ax-feat/alloc-slab"]
 alloc-buddy = ["ax-feat/alloc-buddy"]
+buddy-slab = ["ax-feat/buddy-slab"]
 page-alloc-64g = ["ax-feat/page-alloc-64g"]                 # Support up to 64G memory capacity
 page-alloc-4g = ["ax-feat/page-alloc-4g"]                   # Support up to 4G memory capacity
 paging = ["ax-feat/paging", "alloc"]

--- a/os/arceos/ulib/axstd/src/lib.rs
+++ b/os/arceos/ulib/axstd/src/lib.rs
@@ -20,6 +20,7 @@
 //!     - `alloc-tlsf`: Use the TLSF allocator.
 //!     - `alloc-slab`: Use the slab allocator.
 //!     - `alloc-buddy`: Use the buddy system allocator.
+//!     - `buddy-slab`: Use the buddy-slab allocator.
 //!     - `paging`: Enable page table manipulation.
 //!     - `tls`: Enable thread-local storage.
 //! - Task management

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -67,7 +67,7 @@ ax-timer-list = { workspace = true }
 hashbrown = "0.14"
 
 # System dependent modules provided by ArceOS.
-ax-std = { workspace = true, features = ["paging", "irq", "multitask", "task-ext", "smp", "hv"] }
+ax-std = { workspace = true, features = ["paging", "irq", "multitask", "task-ext", "smp", "hv", "buddy-slab"] }
 ax-hal = { workspace = true, features = ["paging", "irq", "smp", "hv", "axvisor-linker"] }
 # System dependent modules provided by ArceOS-Hypervisor (bare-metal only)
 axaddrspace = { workspace = true }


### PR DESCRIPTION
## 问题

Axvisor aarch64 QEMU CI 在 8 GiB 内存配置下仍使用默认 TLSF/bitmap page allocator，启动阶段触发 `bitmap capacity exceeded` panic。Axvisor 应直接声明使用 buddy-slab allocator，而不是依赖构建脚本临时注入 feature。

同时，CI 中额外的 `Test starry aarch64 buddy-slab qemu` 与常规 Starry aarch64 覆盖重复，会让这个 Axvisor allocator 修复多跑一个不必要的 Starry 专项 job。

## 变更

- 为 `ax-std` 增加 `buddy-slab` feature，并转发到 `ax-feat/buddy-slab`。
- 在 `axvisor` 对 `ax-std` 的依赖上直接启用 `buddy-slab`。
- 同步 `ax-std` feature 文档。
- 从 CI 矩阵移除重复的 `Test starry aarch64 buddy-slab qemu` job。

## 方案逻辑

Axvisor 是 allocator 选择的使用方，应在自身依赖契约中固定启用 `ax-std/buddy-slab`。`ax-std` 暴露该 feature 后，下游可以通过标准 feature 转发链启用 `ax-runtime/buddy-slab` 和 `ax-alloc/buddy-slab`，避免 Axvisor 在 CI 的大内存 QEMU 配置下回落到 TLSF/bitmap allocator。

删除重复 Starry buddy-slab CI job 只影响 workflow 矩阵，不删除 `test-suit/starryos` 中的用例文件；需要时仍可通过 xtask 显式运行该 case。

## 验证

- `cargo xtask axvisor build --arch aarch64`
- `cargo xtask axvisor test qemu --arch aarch64`
- `cargo xtask clippy --package ax-std`
- 按 axvisor aarch64 xtask 生成的 target/features/env 手动执行 `cargo clippy -p axvisor`
- `cargo fmt --check`
- `git diff --check`
