### PR TITLE
fix(ramdisk): enable crate publishing

### DIFF
--- a/drivers/blk/ramdisk/Cargo.toml
+++ b/drivers/blk/ramdisk/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 name = "ramdisk"
 repository.workspace = true
 version = "0.1.1"
-publish = false
 
 [dependencies]
 rdif-block = { workspace = true }


### PR DESCRIPTION
## 问题

`release-plz release` 在发布 `ax-driver` 时会执行 Cargo 的发布准备流程。`ax-driver` 暴露了可选依赖 `ramdisk`，但 `ramdisk` 当前设置了 `publish = false`，导致 Cargo 在 crates.io 索引中无法解析该依赖，从而阻塞发布。

## 改动

- 移除 `drivers/blk/ramdisk/Cargo.toml` 中的 `publish = false`，允许 `ramdisk` 作为 workspace 内可发布 crate 进入 release-plz 发布流程。

## 逻辑

- `ramdisk` 本身已经具备 crates.io 发布所需的基础元数据。
- 先让 `ramdisk` 可发布，release-plz 后续即可先发布 `ramdisk`，再让依赖它的 `ax-driver` 通过发布准备检查。
- 该改动不涉及运行时代码，只调整发布条件。

## 验证

- `cargo publish --dry-run -p ramdisk --allow-dirty`
- `cargo xtask clippy --package ramdisk`