### PR TITLE
fix(starry): 测试失败即停止，不再继续运行后续用例

### DIFF
--- a/scripts/axbuild/src/starry/test.rs
+++ b/scripts/axbuild/src/starry/test.rs
@@ -595,6 +595,12 @@ impl Starry {
                             outcome: StarryQemuCaseOutcome::Failed,
                             duration: case_started.elapsed(),
                         });
+                        finalize_qemu_case_run(&StarryQemuRunReport {
+                            group: test_group,
+                            cases: reports,
+                            total_duration: suite_started.elapsed(),
+                        })?;
+                        bail!("starry qemu test aborted: case `{case_name}` failed");
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Starry QEMU 测试失败后立即停止运行，输出当前摘要并报错退出，不再继续执行后续测试用例

## Test plan
- [ ] 运行 `cargo xtask starry test qemu --arch aarch64`，确认失败 case 后立即停止
- [ ] 确认所有 case 通过时行为与之前一致