### PR TITLE
refactor(axruntime): 移除 alloc feature，使其成为无条件能力

### DIFF
--- a/os/arceos/api/axfeat/Cargo.toml
+++ b/os/arceos/api/axfeat/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 default = ["alloc"]
 
 # Multicore
-smp = ["alloc", "ax-hal/smp", "ax-runtime/smp", "ax-task?/smp", "ax-kspin/smp"]
+smp = ["ax-hal/smp", "ax-runtime/smp", "ax-task?/smp", "ax-kspin/smp"]
 
 # Floating point/SIMD
 fp-simd = ["ax-hal/fp-simd"]
@@ -21,7 +21,7 @@ uspace = ["ax-hal/uspace", "ax-task?/uspace"]
 hv = ["ax-hal/hv"]
 
 # Interrupts
-irq = ["alloc", "ax-hal/irq", "ax-runtime/irq", "ax-task?/irq", "ax-driver?/irq"]
+irq = ["ax-hal/irq", "ax-runtime/irq", "ax-task?/irq", "ax-driver?/irq"]
 ipi = ["irq", "dep:ax-ipi", "ax-hal/ipi", "ax-runtime/ipi", "ax-task?/ipi"]
 
 # Custom or default platforms
@@ -44,20 +44,19 @@ aarch64-gic-v3 = ["ax-hal/aarch64-gic-v3"]
 aarch64-cntv-timer = ["ax-hal/aarch64-cntv-timer"]
 
 # Memory
-alloc = ["ax-alloc", "ax-runtime/alloc"]
+alloc = ["ax-alloc"]
 alloc-tlsf = ["ax-alloc/tlsf"]
 alloc-slab = ["ax-alloc/slab"]
 alloc-buddy = ["ax-alloc/buddy"]
-buddy-slab = ["alloc", "ax-runtime/buddy-slab"]
+buddy-slab = ["ax-runtime/buddy-slab"]
 page-alloc-64g = ["ax-alloc/page-alloc-64g"]                  # up to 64G memory capacity
 page-alloc-4g = ["ax-alloc/page-alloc-4g"]                    # up to 4G memory capacity
-paging = ["alloc", "ax-hal/paging", "ax-runtime/paging"]
-tls = ["alloc", "ax-hal/tls", "ax-runtime/tls", "ax-task?/tls"]
-dma = ["alloc", "paging"]
+paging = ["ax-hal/paging", "ax-runtime/paging"]
+tls = ["ax-hal/tls", "ax-runtime/tls", "ax-task?/tls"]
+dma = ["paging"]
 
 # Multi-threading and scheduler
 multitask = [
-    "alloc",
     "ax-task/multitask",
     "ax-sync/multitask",
     "ax-runtime/multitask",
@@ -77,31 +76,28 @@ stack-guard-page = [
 
 # File system
 fs = [
-    "alloc",
     "paging",
     "dep:ax-fs",
     "ax-runtime/fs",
 ] # TODO: try to remove "paging"
-fs-ng = ["alloc", "paging", "dep:ax-fs-ng", "ax-runtime/fs-ng"]
+fs-ng = ["paging", "dep:ax-fs-ng", "ax-runtime/fs-ng"]
 fs-ng-ext4 = ["fs-ng", "ax-fs-ng/ext4"]
 fs-ng-fat = ["fs-ng", "ax-fs-ng/fat"]
 fs-ng-times = ["fs-ng", "ax-fs-ng/times"]
 
 # Networking
 net = [
-    "alloc",
     "paging",
     "irq",
     "multitask",
     "dep:ax-net",
     "ax-runtime/net",
 ]
-net-ng = ["alloc", "paging", "irq", "multitask", "dep:ax-net-ng", "ax-runtime/net-ng"]
+net-ng = ["paging", "irq", "multitask", "dep:ax-net-ng", "ax-runtime/net-ng"]
 vsock = ["ax-runtime/vsock"]
 
 # Display
 display = [
-    "alloc",
     "paging",
     "dep:ax-display",
     "ax-runtime/display",
@@ -109,7 +105,6 @@ display = [
 
 # Input
 input = [
-    "alloc",
     "paging",
     "dep:ax-input",
     "ax-runtime/input",
@@ -119,8 +114,8 @@ input = [
 rtc = ["ax-hal/rtc", "ax-runtime/rtc"]
 
 # Backtrace
-backtrace = ["alloc", "axbacktrace/alloc"]
-dwarf = ["alloc", "axbacktrace/dwarf"]
+backtrace = ["axbacktrace/alloc"]
+dwarf = ["axbacktrace/dwarf"]
 
 [dependencies]
 ax-alloc = { workspace = true, optional = true, features = ["default"] }

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -10,15 +10,14 @@ version = "0.5.16"
 [features]
 default = []
 
-alloc = ["dep:ax-alloc"]
-buddy-slab = ["alloc", "ax-alloc/buddy-slab"]
+buddy-slab = ["ax-alloc/buddy-slab"]
 dma = ["paging"]
 ipi = ["dep:ax-ipi"]
 irq = ["ax-hal/irq", "ax-task?/irq", "dep:ax-percpu"]
 multitask = ["ax-task/multitask"]
-paging = ["alloc", "ax-hal/paging", "dep:ax-mm", "dep:axklib"]
+paging = ["ax-hal/paging", "dep:ax-mm", "dep:axklib"]
 rtc = []
-smp = ["alloc", "ax-hal/smp", "ax-task?/smp"]
+smp = ["ax-hal/smp", "ax-task?/smp"]
 stack-guard-page = ["multitask", "paging", "ax-task/stack-guard-page"]
 tls = ["ax-hal/tls", "ax-task?/tls"]
 
@@ -31,7 +30,6 @@ plat-dyn = [
   "smp",
   "stack-guard-page",
   "tls",
-  "alloc",
 ]
 
 display = ["dep:ax-display", "ax-driver/display"]
@@ -57,7 +55,7 @@ net-ng = ["dep:ax-net-ng", "dep:rd-net", "dep:spin", "dep:axklib", "ax-driver/ne
 vsock = ["net-ng", "ax-net-ng/vsock", "ax-driver/vsock"]
 
 [dependencies]
-ax-alloc = {workspace = true, optional = true, features = ["default"]}
+ax-alloc = {workspace = true, features = ["default"]}
 ax-config = {workspace = true}
 ax-crate-interface = {workspace = true}
 ax-ctor-bare = {workspace = true}

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -19,7 +19,6 @@
 //!
 //! # Cargo Features
 //!
-//! - `alloc`: Enable global memory allocator.
 //! - `paging`: Enable page table manipulation support.
 //! - `irq`: Enable interrupt handling support.
 //! - `multitask`: Enable multi-threading support.
@@ -56,15 +55,6 @@ pub use ax_hal as hal;
 #[cfg(feature = "smp")]
 pub use self::mp::rust_main_secondary;
 
-#[cfg(any(
-    all(any(feature = "fs", feature = "fs-ng"), not(feature = "plat-dyn")),
-    all(any(feature = "fs", feature = "fs-ng"), feature = "plat-dyn"),
-    feature = "net",
-    feature = "net-ng",
-    feature = "display",
-    feature = "input",
-    feature = "vsock"
-))]
 extern crate alloc;
 
 const LOGO: &str = r#"
@@ -166,7 +156,7 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
         ax_hal::mem::clear_bss()
     };
     ax_hal::percpu::init_primary(cpu_id);
-    #[cfg(all(feature = "alloc", feature = "buddy-slab"))]
+    #[cfg(feature = "buddy-slab")]
     // After per-CPU init, before scheduler/IPI/IRQ paths can allocate.
     ax_alloc::init_percpu_slab(cpu_id);
     ax_hal::init_early(cpu_id, arg);
@@ -214,7 +204,6 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
         );
     }
 
-    #[cfg(feature = "alloc")]
     init_allocator();
 
     {
@@ -353,7 +342,6 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
     }
 }
 
-#[cfg(feature = "alloc")]
 fn init_allocator() {
     use ax_hal::mem::{MemRegionFlags, memory_regions, phys_to_virt};
 


### PR DESCRIPTION
## Summary
- 删除 axruntime 的 `alloc` feature，将 `ax-alloc` 从 optional 变为必需依赖
- 移除 axruntime lib.rs 中所有 `#[cfg(feature = "alloc")]` 门控，`extern crate alloc` 无条件启用
- 清理 axfeat 中 15 个 feature 对 alloc 的冗余传播（smp/irq/multitask/paging/tls/dma/fs/fs-ng/net/net-ng/display/input/backtrace/dwarf/buddy-slab）

## Test plan
- [x] `cargo check -p ax-runtime` 通过
- [x] `cargo check -p ax-feat` 通过
- [x] `cargo check -p ax-std` 通过
- [x] `cargo check -p starry-kernel` 通过
- [ ] CI 全架构构建验证