### PR TITLE
feat(starry-kernel): add initial cgroup2 support

### DIFF
--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -1,0 +1,39 @@
+use alloc::{string::String, vec::Vec};
+use core::fmt::Write;
+
+use ax_errno::{AxError, AxResult, LinuxError};
+
+/// Returns the process list for the root cgroup.
+pub fn root_procs_text() -> String {
+    let mut pids: Vec<_> = crate::task::processes()
+        .into_iter()
+        .map(|proc_data| proc_data.proc.pid())
+        .collect();
+    pids.sort_unstable();
+
+    let mut text = String::new();
+    for pid in pids {
+        let _ = writeln!(text, "{pid}");
+    }
+    text
+}
+
+/// Returns the controllers visible at the root cgroup.
+pub fn root_controllers_text() -> &'static str {
+    ""
+}
+
+/// Returns enabled subtree controllers at the root cgroup.
+pub fn root_subtree_control_text() -> &'static str {
+    ""
+}
+
+/// Writes to cgroup.procs are not implemented in this slice.
+pub fn write_root_procs(_data: &[u8]) -> AxResult<()> {
+    Err(AxError::from(LinuxError::EOPNOTSUPP))
+}
+
+/// Writes to cgroup.subtree_control cannot enable unavailable controllers.
+pub fn write_root_subtree_control(_data: &[u8]) -> AxResult<()> {
+    Err(AxError::from(LinuxError::EINVAL))
+}

--- a/os/StarryOS/kernel/src/lib.rs
+++ b/os/StarryOS/kernel/src/lib.rs
@@ -17,6 +17,7 @@ pub mod dyn_debug; // Re-export debug macros for use in other modules. It will o
 
 pub mod entry;
 
+mod cgroup;
 mod config;
 #[cfg(feature = "ebpf")]
 mod ebpf;

--- a/os/StarryOS/kernel/src/pseudofs/cgroup.rs
+++ b/os/StarryOS/kernel/src/pseudofs/cgroup.rs
@@ -1,0 +1,84 @@
+use alloc::{sync::Arc, vec::Vec};
+
+use ax_errno::LinuxError;
+use axfs_ng_vfs::{Filesystem, NodePermission, VfsError, VfsResult};
+
+use super::{DirMaker, DirMapping, DirectRwFsFileOps, SimpleDir, SimpleFs, SpecialFsFile};
+
+const CGROUP2_SUPER_MAGIC: u32 = 0x6367_7270;
+
+enum RootFile {
+    Procs,
+    Controllers,
+    SubtreeControl,
+}
+
+impl RootFile {
+    fn read_content(&self) -> Vec<u8> {
+        match self {
+            Self::Procs => crate::cgroup::root_procs_text().into_bytes(),
+            Self::Controllers => crate::cgroup::root_controllers_text().as_bytes().to_vec(),
+            Self::SubtreeControl => crate::cgroup::root_subtree_control_text()
+                .as_bytes()
+                .to_vec(),
+        }
+    }
+}
+
+impl DirectRwFsFileOps for RootFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> VfsResult<usize> {
+        let content = self.read_content();
+        let offset = offset as usize;
+        if offset >= content.len() {
+            return Ok(0);
+        }
+
+        let content = &content[offset..];
+        let read = content.len().min(buf.len());
+        buf[..read].copy_from_slice(&content[..read]);
+        Ok(read)
+    }
+
+    fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {
+        match self {
+            Self::Procs => crate::cgroup::write_root_procs(buf)?,
+            Self::Controllers => return Err(VfsError::from(LinuxError::EACCES)),
+            Self::SubtreeControl => crate::cgroup::write_root_subtree_control(buf)?,
+        }
+        Ok(buf.len())
+    }
+}
+
+/// Creates a minimal cgroup v2 pseudo filesystem.
+pub(crate) fn new_cgroup2fs() -> Filesystem {
+    SimpleFs::new_with("cgroup2".into(), CGROUP2_SUPER_MAGIC, cgroup2fs_builder)
+}
+
+fn cgroup2fs_builder(fs: Arc<SimpleFs>) -> DirMaker {
+    let mut root = DirMapping::new();
+    root.add(
+        "cgroup.procs",
+        SpecialFsFile::new_regular_with_perm(
+            fs.clone(),
+            RootFile::Procs,
+            NodePermission::from_bits_truncate(0o644),
+        ),
+    );
+    root.add(
+        "cgroup.controllers",
+        SpecialFsFile::new_regular_with_perm(
+            fs.clone(),
+            RootFile::Controllers,
+            NodePermission::from_bits_truncate(0o444),
+        ),
+    );
+    root.add(
+        "cgroup.subtree_control",
+        SpecialFsFile::new_regular_with_perm(
+            fs.clone(),
+            RootFile::SubtreeControl,
+            NodePermission::from_bits_truncate(0o644),
+        ),
+    );
+    SimpleDir::new_maker(fs, Arc::new(root))
+}

--- a/os/StarryOS/kernel/src/pseudofs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/mod.rs
@@ -1,5 +1,6 @@
 //! Basic virtual filesystem support
 
+pub(crate) mod cgroup;
 pub mod debug;
 pub mod dev;
 mod device;

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -139,6 +139,14 @@ pub fn sys_mount(
                 mp.set_readonly(true);
             }
         }
+        "cgroup2" => {
+            let fs = crate::pseudofs::cgroup::new_cgroup2fs();
+            let target = FS_CONTEXT.lock().resolve(target)?;
+            let mp = target.mount(&fs)?;
+            if (flags & MS_RDONLY) != 0 {
+                mp.set_readonly(true);
+            }
+        }
         #[cfg(feature = "ext4")]
         "ext4" => {
             mount_ext4(&source, &target, (flags & MS_RDONLY) != 0)?;

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(cgroup-basic C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(cgroup-basic src/main.c)
+target_include_directories(cgroup-basic PRIVATE src)
+target_compile_options(cgroup-basic PRIVATE -Wall -Wextra -Werror)
+install(TARGETS cgroup-basic RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c
@@ -1,0 +1,166 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);       \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0
+
+#define CGROUP2_PATH "/tmp/cg"
+#define CGROUP_V1_PATH "/tmp/cg-v1"
+
+static void check_mkdir(const char *path, const char *msg)
+{
+    errno = 0;
+    int ret = mkdir(path, 0755);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == 0 || saved_errno == EEXIST, msg);
+}
+
+static ssize_t read_text_file(const char *path, char *buf, size_t cap)
+{
+    if (cap == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return -1;
+    }
+
+    errno = 0;
+    ssize_t nread = read(fd, buf, cap - 1);
+    int saved_errno = errno;
+    if (nread >= 0) {
+        buf[nread] = '\0';
+    }
+
+    close(fd);
+    errno = saved_errno;
+    return nread;
+}
+
+static int buffer_contains_pid(const char *buf, pid_t pid)
+{
+    const char *cursor = buf;
+
+    while (*cursor != '\0') {
+        char *end = NULL;
+        errno = 0;
+        long value = strtol(cursor, &end, 10);
+        if (cursor != end && errno == 0 && value == (long)pid) {
+            return 1;
+        }
+
+        while (*cursor != '\0' && *cursor != '\n') {
+            cursor++;
+        }
+        while (*cursor == '\n' || *cursor == '\r') {
+            cursor++;
+        }
+    }
+
+    return 0;
+}
+
+static void expect_write_errno(const char *path, const char *data,
+                               int expected_errno, const char *msg)
+{
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) {
+        CHECK(0, msg);
+        return;
+    }
+
+    errno = 0;
+    ssize_t written = write(fd, data, strlen(data));
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    CHECK(written == -1 && saved_errno == expected_errno, msg);
+}
+
+int main(void)
+{
+    TEST_START("cgroup-basic");
+
+    check_mkdir(CGROUP2_PATH, "mkdir cgroup2 mountpoint");
+
+    errno = 0;
+    int ret = mount("none", CGROUP2_PATH, "cgroup2", 0, NULL);
+    int mount_errno = errno;
+    errno = mount_errno;
+    CHECK(ret == 0, "mount cgroup2 succeeds");
+    if (ret != 0) {
+        printf("  OBSERVE | mount cgroup2 failed errno=%d (%s)\n",
+               mount_errno, strerror(mount_errno));
+        TEST_DONE();
+    }
+
+    char buf[4096];
+    ssize_t nread = read_text_file(CGROUP2_PATH "/cgroup.procs", buf, sizeof(buf));
+    CHECK(nread >= 0, "read root cgroup.procs");
+    if (nread >= 0) {
+        CHECK(buffer_contains_pid(buf, getpid()),
+              "root cgroup.procs contains current process");
+    }
+
+    nread = read_text_file(CGROUP2_PATH "/cgroup.controllers", buf, sizeof(buf));
+    CHECK(nread >= 0, "read root cgroup.controllers");
+    if (nread >= 0) {
+        CHECK(nread == 0, "root cgroup.controllers is empty before controllers exist");
+    }
+
+    nread = read_text_file(CGROUP2_PATH "/cgroup.subtree_control", buf, sizeof(buf));
+    CHECK(nread >= 0, "read root cgroup.subtree_control");
+    if (nread >= 0) {
+        CHECK(nread == 0, "root cgroup.subtree_control is initially empty");
+    }
+
+    expect_write_errno(CGROUP2_PATH "/cgroup.subtree_control", "+pids",
+                       EINVAL, "writing +pids to subtree_control fails with EINVAL");
+
+    check_mkdir(CGROUP_V1_PATH, "mkdir cgroup v1 mountpoint");
+
+    errno = 0;
+    ret = mount("none", CGROUP_V1_PATH, "cgroup", 0, NULL);
+    int v1_errno = errno;
+    errno = v1_errno;
+    CHECK(ret == -1 && v1_errno == ENODEV, "mount cgroup v1 fails with ENODEV");
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-aarch64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/cgroup-basic"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/cgroup-basic"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/cgroup-basic"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-x86_64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/cgroup-basic"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60


### PR DESCRIPTION

### 背景与范围

本 PR 是 StarryOS cgroup 支持的第一阶段提交，目标不是一次性实现 Docker/systemd 可用的完整 cgroup，而是在可验证的分层路线里先落地最小可运行语义。对于cgroup的相关工作进展，将持续更新在 #582 

本次提交覆盖两个最小 slice：

- Slice 0：新增 `cgroup-basic` 测试用例，先固化 StarryOS 当前行为和期望行为。
- Slice 1：让该测试从 Red 进入 Green，实现显式挂载 cgroup v2 后 root cgroup 的最小文件可见性和基础 errno 行为。

本 PR 的 scope 只包含：

- 支持 `mount("none", target, "cgroup2", 0, NULL)`。
- 暴露 root cgroup 下的 `cgroup.procs`、`cgroup.controllers`、`cgroup.subtree_control`。
- 让 `cgroup.procs` 能读到当前活跃进程 PID 列表。
- 在没有真实 controller 前保持 `cgroup.controllers` 和 `cgroup.subtree_control` 为空。
- 对未实现写操作返回明确错误，而不是静默成功。
- 保持 cgroup v1 `mount -t cgroup` 不支持，继续返回 `ENODEV`。

本 PR 不实现 cgroup 层级目录、controller 注册、进程迁移、`/proc/[pid]/cgroup`、pids/cpu/memory controller、cgroup namespace、`clone3.cgroup` 或 `CLONE_INTO_CGROUP`。

### 测试设计

新增 `test-suit/starryos/normal/qemu-smp1/cgroup-basic`，使用 C pipeline 构建 guest 内可执行文件 `/usr/bin/cgroup-basic`。

测试覆盖：

- 创建 cgroup2 mountpoint。
- `mount("none", "/tmp/cg", "cgroup2", 0, NULL)` 成功。
- root `cgroup.procs` 可读。
- root `cgroup.procs` 至少包含当前进程 `getpid()`。
- root `cgroup.controllers` 可读且当前为 0 字节。
- root `cgroup.subtree_control` 可读且初始为 0 字节。
- 写 `+pids` 到 root `cgroup.subtree_control` 失败，errno 为 `EINVAL`。
- 创建 cgroup v1 mountpoint。
- `mount("none", "/tmp/cg-v1", "cgroup", 0, NULL)` 失败，errno 为 `ENODEV`。

测试已补齐四个平台 QEMU 配置：

- `x86_64`
- `aarch64`
- `riscv64`
- `loongarch64`

未覆盖内容：

- `cgroup.procs` 写入迁移语义。
- `cgroup.controllers` 写入 errno。
- 多次 read、非 0 offset 或跨 chunk 读取行为。
- read-only mount 后写入路径。
- cgroup 子目录创建、删除和层级关系。
- controller enable/disable 规则。
- `/proc/[pid]/cgroup`。
- 多进程退出、fork 后 membership 生命周期。

### 测试发现的问题与最小修复

Red baseline 中，`mount("none", "/tmp/cg", "cgroup2", 0, NULL)` 返回 `ENODEV`。原因是 `sys_mount()` 只识别 `tmpfs` 和 `ext4`，`fs_type == "cgroup2"` 直接落入 `AxError::NoSuchDevice`。

对应最小修复：

- 新增 `starry-kernel` 内部 `cgroup` core 模块，集中提供 root cgroup 的最小状态入口。
- 新增 `pseudofs::cgroup`，只负责把 VFS read/write 翻译到 cgroup core。
- 在 `sys_mount()` 中新增 `cgroup2` 分支，创建并挂载最小 cgroup2 pseudofs。
- 不新增 `cgroup` 分支，确保 cgroup v1 仍然保持 `ENODEV`。

实现中特别保持了 controller 列表为空，避免在还没有实现 controller 时向用户态暴露虚假能力。`cgroup.subtree_control` 写 `+pids` 返回 `EINVAL`，避免未实现 controller 被静默启用。

### 文件改动

内核实现：

- `os/StarryOS/kernel/src/cgroup/mod.rs`
  - 新增 root cgroup 最小状态入口。
  - `cgroup.procs` 读取当前进程表，排序后按每行一个 PID 输出。
  - `cgroup.controllers` 和 `cgroup.subtree_control` 当前返回空内容。
  - 未实现写操作返回 `EOPNOTSUPP` 或 `EINVAL`。

- `os/StarryOS/kernel/src/pseudofs/cgroup.rs`
  - 新增最小 cgroup2 pseudofs。
  - root 目录只注册 `cgroup.procs`、`cgroup.controllers`、`cgroup.subtree_control`。
  - 使用动态文件读写处理，避免把业务状态放在 VFS 层。

- `os/StarryOS/kernel/src/syscall/fs/mount.rs`
  - 接入 `fs_type == "cgroup2"`。
  - 保持 `fs_type == "cgroup"` 未支持。

- `os/StarryOS/kernel/src/lib.rs`
  - 注册 `cgroup` 模块。

- `os/StarryOS/kernel/src/pseudofs/mod.rs`
  - 注册 `pseudofs::cgroup` 模块。

测试相关文件：

- `test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/CMakeLists.txt`
- `test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c`
- `test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-x86_64.toml`
- `test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-aarch64.toml`
- `test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-riscv64.toml`
- `test-suit/starryos/normal/qemu-smp1/cgroup-basic/qemu-loongarch64.toml`

### 本地验证

以下命令均在 Docker Compose `tgoskits` 容器内执行：

```text
cargo fmt
```

结果：通过。

```text
cargo xtask clippy --package starry-kernel
```

结果：14 个配置全部通过，0 failed。

```text
cargo xtask starry test qemu --arch x86_64 -g normal -c cgroup-basic
cargo xtask starry test qemu --arch aarch64 -g normal -c cgroup-basic
cargo xtask starry test qemu --arch riscv64 -g normal -c cgroup-basic
cargo xtask starry test qemu --arch loongarch64 -g normal -c cgroup-basic
```

结果：四个平台均通过，guest 均输出 `DONE: 11 pass, 0 fail`，runner 均输出 `result: 1/1 case(s) passed`。

### 其他说明

- 本次没有新增 cgroup tree lock；`cgroup.procs` 读取当前通过 `task::processes()` 获取进程快照，再格式化文本。
- 后续如果引入 cgroup tree lock，应避免在持有 cgroup lock 时调用进程表遍历逻辑，建议先取快照再格式化。
- 当前 `cgroup.procs` 表示所有活跃进程都属于 root cgroup，这是没有 hierarchy 和迁移语义时的最小真实模型，不是假 controller 状态。
- 当前仓库没有 `scripts/test/clippy_crates.csv`，因此本次未更新 clippy crate whitelist。
