### PR TITLE
feat(starry): add pip functional test under apps

### DIFF
--- a/apps/starry/pip/README.md
+++ b/apps/starry/pip/README.md
@@ -1,4 +1,4 @@
-# pip 测试
+# pip 测试.
 
 在 StarryOS (Alpine rootfs) 上验证 Python pip 的常用操作。
 

--- a/apps/starry/pip/README.md
+++ b/apps/starry/pip/README.md
@@ -17,35 +17,25 @@
 - pip list --format=json / --outdated
 - pip config / pip debug
 
-## 前置依赖
-
-- 主机已安装 `debugfs` (e2fsprogs) 和对应架构的 `qemu-*-static`
-- Alpine rootfs 镜像 (由 `cargo xtask starry rootfs` 生成)
-
 ## 运行测试
 
 ```bash
-# 在 StarryOS QEMU 上运行
 cargo xtask starry app run -t pip
-
-# 指定架构 (默认 x86_64)
-cargo xtask starry app run -t pip --arch aarch64
 ```
 
 ## 在 Linux 主机上快速验证测试脚本
 
 ```bash
-# 直接在主机 shell 中运行测试脚本 (需要 python3 和 pip)
 sh apps/starry/pip/test_pip.sh
 ```
 
 ## 工作原理
 
-1. `prebuild.sh` 被 xtask 框架调用，通过 qemu-user 在 staging rootfs 中执行 `apk add python3 py3-pip`
-2. 安装的 Python/pip 文件和 `test_pip.sh` 被复制到 overlay 目录
-3. overlay 被注入到 rootfs 镜像中
-4. QEMU 启动后执行 `sh /usr/bin/test_pip.sh`
-5. 测试脚本逐阶段输出 `STARRY_PIP_STAGE_N: ... OK`，最终输出 `STARRY_PIP_TESTS_PASSED`
+1. `prebuild.sh` 被 xtask 框架调用，使用宿主机 `apk --root` 在 staging rootfs 中安装 `python3 py3-pip`
+2. 通过 `readelf` 解析运行时依赖并复制到 overlay
+3. `test_pip.sh` 被复制到 overlay 的 `/usr/bin/`
+4. overlay 被注入到 rootfs 镜像中
+5. QEMU 启动后执行 `/usr/bin/test_pip.sh`
 
 ## 判定标准
 

--- a/apps/starry/pip/README.md
+++ b/apps/starry/pip/README.md
@@ -1,0 +1,54 @@
+# pip 测试
+
+在 StarryOS (Alpine rootfs) 上验证 Python pip 的常用操作。
+
+## 测试内容
+
+25 个阶段，覆盖日常 pip 使用场景：
+
+- venv 创建/激活/销毁
+- pip install / uninstall / upgrade / --dry-run
+- pip list / show / freeze / check
+- pip install -r requirements.txt
+- pip install from local directory / local wheel
+- pip wheel / pip download
+- pip cache dir / info / purge
+- pip install -e (editable)
+- pip list --format=json / --outdated
+- pip config / pip debug
+
+## 前置依赖
+
+- 主机已安装 `debugfs` (e2fsprogs) 和对应架构的 `qemu-*-static`
+- Alpine rootfs 镜像 (由 `cargo xtask starry rootfs` 生成)
+
+## 运行测试
+
+```bash
+# 在 StarryOS QEMU 上运行
+cargo xtask starry app run -t pip
+
+# 指定架构 (默认 x86_64)
+cargo xtask starry app run -t pip --arch aarch64
+```
+
+## 在 Linux 主机上快速验证测试脚本
+
+```bash
+# 直接在主机 shell 中运行测试脚本 (需要 python3 和 pip)
+sh apps/starry/pip/test_pip.sh
+```
+
+## 工作原理
+
+1. `prebuild.sh` 被 xtask 框架调用，通过 qemu-user 在 staging rootfs 中执行 `apk add python3 py3-pip`
+2. 安装的 Python/pip 文件和 `test_pip.sh` 被复制到 overlay 目录
+3. overlay 被注入到 rootfs 镜像中
+4. QEMU 启动后执行 `sh /usr/bin/test_pip.sh`
+5. 测试脚本逐阶段输出 `STARRY_PIP_STAGE_N: ... OK`，最终输出 `STARRY_PIP_TESTS_PASSED`
+
+## 判定标准
+
+- **通过**: 输出匹配 `STARRY_PIP_TESTS_PASSED`
+- **失败**: 输出匹配 `STARRY_PIP_STAGE_.*_FAILED`，或出现 panic / page fault / segmentation fault
+- **超时**: 600 秒

--- a/apps/starry/pip/README.md
+++ b/apps/starry/pip/README.md
@@ -31,7 +31,7 @@ sh apps/starry/pip/test_pip.sh
 
 ## 工作原理
 
-1. `prebuild.sh` 被 xtask 框架调用，使用宿主机 `apk --root` 在 staging rootfs 中安装 `python3 py3-pip`
+1. `prebuild.sh` 被 xtask 框架调用，通过 `qemu-user-static` 在 staging rootfs 中执行 Alpine 原生 `apk` 安装 `python3 py3-pip`（使用 `--no-scripts` 跳过 busybox trigger）
 2. 通过 `readelf` 解析运行时依赖并复制到 overlay
 3. `test_pip.sh` 被复制到 overlay 的 `/usr/bin/`
 4. overlay 被注入到 rootfs 镜像中

--- a/apps/starry/pip/build-x86_64-unknown-none.toml
+++ b/apps/starry/pip/build-x86_64-unknown-none.toml
@@ -1,0 +1,11 @@
+target = "x86_64-unknown-none"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = [
+    "ax-hal/x86-pc",
+    "qemu",
+    "ax-driver/plat-static",
+    "ax-driver/virtio-blk",
+    "ax-driver/virtio-net",
+]
+plat_dyn = false

--- a/apps/starry/pip/prebuild.sh
+++ b/apps/starry/pip/prebuild.sh
@@ -1,101 +1,169 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-workspace="${STARRY_WORKSPACE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
-app_dir="${STARRY_APP_DIR:-$workspace/apps/starry/pip}"
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 arch="${STARRY_ARCH:-x86_64}"
 base_rootfs="${STARRY_BASE_ROOTFS:-}"
 staging_root="${STARRY_STAGING_ROOT:-}"
 overlay_dir="${STARRY_OVERLAY_DIR:-}"
 
-if [[ -z "$base_rootfs" || -z "$staging_root" || -z "$overlay_dir" ]]; then
-    echo "error: STARRY_BASE_ROOTFS, STARRY_STAGING_ROOT, and STARRY_OVERLAY_DIR are required" >&2
-    exit 1
-fi
-
-# Map arch to qemu-user binary
-case "$arch" in
-    aarch64)     qemu_user="qemu-aarch64-static" ;;
-    riscv64)     qemu_user="qemu-riscv64-static" ;;
-    x86_64)      qemu_user="qemu-x86_64-static" ;;
-    loongarch64) qemu_user="qemu-loongarch64-static" ;;
-    *)           echo "error: unsupported arch: $arch" >&2; exit 1 ;;
-esac
-
-if ! command -v "$qemu_user" >/dev/null 2>&1; then
-    echo "error: $qemu_user not found on host" >&2
-    exit 1
-fi
-
-if ! command -v debugfs >/dev/null 2>&1; then
-    echo "error: debugfs not found on host (install e2fsprogs)" >&2
-    exit 1
-fi
-
-echo "[pip prebuild] extracting rootfs into staging..."
-debugfs -R "rdump / $staging_root" "$base_rootfs"
-
-# Copy host resolv.conf so apk can resolve DNS
-cp /etc/resolv.conf "$staging_root/etc/resolv.conf"
-
-# Create apk cache dir so apk add works
-mkdir -p "$staging_root/etc/apk"
-echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" > "$staging_root/etc/apk/repositories"
-echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> "$staging_root/etc/apk/repositories"
-
-# Set up musl loader search path
-for loader_path in "$staging_root"/lib/ld-musl-*.so.1; do
-    if [[ -f "$loader_path" ]]; then
-        loader_name="$(basename "$loader_path")"
-        arch_name="${loader_name#ld-musl-}"
-        arch_name="${arch_name%.so.1}"
-        printf '/usr/lib\n/lib\n' > "$staging_root/etc/$arch_name.path" 2>/dev/null || true
-        break
+require_env() {
+    local name="$1"
+    local value="$2"
+    if [[ -z "$value" ]]; then
+        echo "error: $name is required" >&2
+        exit 1
     fi
-done
+}
 
-echo "[pip prebuild] installing python3 and py3-pip via apk..."
-# Run apk directly via qemu-user; going through busybox sh fails because
-# the kernel can't resolve the guest's ELF interpreter for nested exec calls.
-export QEMU_LD_PREFIX="$staging_root"
-export LD_LIBRARY_PATH="$staging_root/usr/lib:$staging_root/lib"
-"$qemu_user" -L "$staging_root" "$staging_root/sbin/apk" add --no-cache --root "$staging_root" python3 py3-pip
+ensure_host_packages() {
+    local missing=()
 
-echo "[pip prebuild] copying python+pip to overlay..."
-mkdir -p "$overlay_dir/usr/bin" "$overlay_dir/usr/lib" "$overlay_dir/lib"
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v install >/dev/null 2>&1 || missing+=(coreutils)
+    command -v readelf >/dev/null 2>&1 || missing+=(binutils)
 
-# Copy Python and pip binaries (preserving symlinks initially)
-for d in usr/bin usr/lib lib; do
-    src="$staging_root/$d"
-    dst="$overlay_dir/$d"
-    if [[ -d "$src" ]]; then
-        cp -a "$src/." "$dst/"
+    # qemu-user is needed to run apk inside the staging root on non-Alpine hosts
+    case "$arch" in
+        aarch64)     command -v qemu-aarch64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        riscv64)     command -v qemu-riscv64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        x86_64)      command -v qemu-x86_64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        loongarch64) command -v qemu-loongarch64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+    esac
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+        return
     fi
-done
 
-# Resolve symlinks in the overlay: replace each symlink with a copy of its
-# target, resolving paths relative to the staging root (not the host).
-# Loop until no symlinks remain (handles chains like a -> b -> c).
-while symlinks="$(find "$overlay_dir" -type l)" && [[ -n "$symlinks" ]]; do
-    echo "$symlinks" | while IFS= read -r link; do
-        [[ -z "$link" ]] && continue
-        target="$(readlink "$link")"
-        if [[ "$target" = /* ]]; then
-            resolved="$staging_root$target"
-        else
-            resolved="$(dirname "$link")/$target"
-        fi
-        if [[ -e "$resolved" ]]; then
-            rm "$link"
-            cp -a "$resolved" "$link"
-        else
-            echo "[pip prebuild] warning: dangling symlink $link -> $target, removing" >&2
-            rm "$link"
+    if ! command -v apt-get >/dev/null 2>&1; then
+        echo "error: missing required host packages and apt-get is unavailable: ${missing[*]}" >&2
+        exit 1
+    fi
+
+    echo "installing missing host packages: ${missing[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${missing[@]}"
+}
+
+extract_base_rootfs() {
+    debugfs -R "rdump / $staging_root" "$base_rootfs"
+}
+
+install_pip_packages() {
+    # Set up apk repositories and DNS so apk can download packages
+    mkdir -p "$staging_root/etc/apk"
+    echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" > "$staging_root/etc/apk/repositories"
+    echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> "$staging_root/etc/apk/repositories"
+    cp /etc/resolv.conf "$staging_root/etc/resolv.conf"
+
+    local qemu_user
+    case "$arch" in
+        aarch64)     qemu_user="qemu-aarch64-static" ;;
+        riscv64)     qemu_user="qemu-riscv64-static" ;;
+        x86_64)      qemu_user="qemu-x86_64-static" ;;
+        loongarch64) qemu_user="qemu-loongarch64-static" ;;
+        *)           echo "error: unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+
+    echo "[pip prebuild] installing python3 and py3-pip via qemu-user apk..."
+    export QEMU_LD_PREFIX="$staging_root"
+    export LD_LIBRARY_PATH="$staging_root/usr/lib:$staging_root/lib"
+    "$qemu_user" -L "$staging_root" "$staging_root/sbin/apk" \
+        add --no-cache --root "$staging_root" python3 py3-pip
+}
+
+copy_file_to_overlay() {
+    local guest_path="$1"
+    local mode="$2"
+    local source="$staging_root${guest_path}"
+    local target="$overlay_dir${guest_path}"
+
+    if [[ ! -e "$source" ]]; then
+        echo "error: missing guest file after package install: $guest_path" >&2
+        exit 1
+    fi
+
+    if [[ -L "$source" ]]; then
+        source="$(readlink -f "$source")"
+    fi
+
+    install -Dm"$mode" "$source" "$target"
+}
+
+find_library_path() {
+    local library="$1"
+    local dir
+
+    for dir in lib usr/lib usr/local/lib; do
+        if [[ -e "$staging_root/$dir/$library" ]]; then
+            printf '/%s/%s\n' "$dir" "$library"
+            return 0
         fi
     done
-done
 
-# Copy test script to overlay
-install -Dm0755 "$app_dir/test_pip.sh" "$overlay_dir/usr/bin/test_pip.sh"
+    return 1
+}
 
-echo "[pip prebuild] done."
+copy_runtime_dependencies() {
+    local pending=("$@")
+    local seen=" "
+    local guest_path library
+
+    while [[ ${#pending[@]} -gt 0 ]]; do
+        guest_path="${pending[0]}"
+        pending=("${pending[@]:1}")
+
+        if [[ "$seen" == *" $guest_path "* ]]; then
+            continue
+        fi
+        seen+="$guest_path "
+
+        while IFS= read -r library; do
+            local library_path
+            if ! library_path="$(find_library_path "$library")"; then
+                continue
+            fi
+            copy_file_to_overlay "$library_path" 0644
+            pending+=("$library_path")
+        done < <(
+            readelf -d "$staging_root$guest_path" 2>/dev/null |
+                sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p'
+        )
+    done
+}
+
+populate_overlay() {
+    copy_file_to_overlay /usr/bin/python3 0755
+    copy_file_to_overlay /usr/bin/pip3 0755
+
+    if [[ -e "$staging_root/usr/bin/pip" ]]; then
+        copy_file_to_overlay /usr/bin/pip 0755
+    fi
+
+    copy_runtime_dependencies /usr/bin/python3
+
+    # Copy Python standard library
+    local pyver
+    pyver="$(ls "$staging_root/usr/lib/python3"* -d 2>/dev/null | head -1 | xargs basename)"
+    if [[ -n "$pyver" && -d "$staging_root/usr/lib/$pyver" ]]; then
+        mkdir -p "$overlay_dir/usr/lib/$pyver"
+        cp -a "$staging_root/usr/lib/$pyver/." "$overlay_dir/usr/lib/$pyver/"
+    fi
+
+    # Copy pip site-packages
+    if [[ -d "$staging_root/usr/lib/python3" ]]; then
+        mkdir -p "$overlay_dir/usr/lib/python3"
+        cp -a "$staging_root/usr/lib/python3/." "$overlay_dir/usr/lib/python3/"
+    fi
+
+    install -Dm0755 "$app_dir/test_pip.sh" "$overlay_dir/usr/bin/test_pip.sh"
+}
+
+require_env STARRY_BASE_ROOTFS "$base_rootfs"
+require_env STARRY_STAGING_ROOT "$staging_root"
+require_env STARRY_OVERLAY_DIR "$overlay_dir"
+
+ensure_host_packages
+extract_base_rootfs
+install_pip_packages
+populate_overlay

--- a/apps/starry/pip/prebuild.sh
+++ b/apps/starry/pip/prebuild.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="${STARRY_WORKSPACE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+app_dir="${STARRY_APP_DIR:-$workspace/apps/starry/pip}"
+arch="${STARRY_ARCH:-x86_64}"
+base_rootfs="${STARRY_BASE_ROOTFS:-}"
+staging_root="${STARRY_STAGING_ROOT:-}"
+overlay_dir="${STARRY_OVERLAY_DIR:-}"
+
+if [[ -z "$base_rootfs" || -z "$staging_root" || -z "$overlay_dir" ]]; then
+    echo "error: STARRY_BASE_ROOTFS, STARRY_STAGING_ROOT, and STARRY_OVERLAY_DIR are required" >&2
+    exit 1
+fi
+
+# Map arch to qemu-user binary
+case "$arch" in
+    aarch64)     qemu_user="qemu-aarch64-static" ;;
+    riscv64)     qemu_user="qemu-riscv64-static" ;;
+    x86_64)      qemu_user="qemu-x86_64-static" ;;
+    loongarch64) qemu_user="qemu-loongarch64-static" ;;
+    *)           echo "error: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+if ! command -v "$qemu_user" >/dev/null 2>&1; then
+    echo "error: $qemu_user not found on host" >&2
+    exit 1
+fi
+
+if ! command -v debugfs >/dev/null 2>&1; then
+    echo "error: debugfs not found on host (install e2fsprogs)" >&2
+    exit 1
+fi
+
+echo "[pip prebuild] extracting rootfs into staging..."
+debugfs -R "rdump / $staging_root" "$base_rootfs"
+
+# Copy host resolv.conf so apk can resolve DNS
+cp /etc/resolv.conf "$staging_root/etc/resolv.conf"
+
+# Create apk cache dir so apk add works
+mkdir -p "$staging_root/etc/apk"
+echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" > "$staging_root/etc/apk/repositories"
+echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> "$staging_root/etc/apk/repositories"
+
+# Set up musl loader search path
+for loader_path in "$staging_root"/lib/ld-musl-*.so.1; do
+    if [[ -f "$loader_path" ]]; then
+        loader_name="$(basename "$loader_path")"
+        arch_name="${loader_name#ld-musl-}"
+        arch_name="${arch_name%.so.1}"
+        printf '/usr/lib\n/lib\n' > "$staging_root/etc/$arch_name.path" 2>/dev/null || true
+        break
+    fi
+done
+
+echo "[pip prebuild] installing python3 and py3-pip via apk..."
+# Run apk directly via qemu-user; going through busybox sh fails because
+# the kernel can't resolve the guest's ELF interpreter for nested exec calls.
+export QEMU_LD_PREFIX="$staging_root"
+export LD_LIBRARY_PATH="$staging_root/usr/lib:$staging_root/lib"
+"$qemu_user" -L "$staging_root" "$staging_root/sbin/apk" add --no-cache --root "$staging_root" python3 py3-pip
+
+echo "[pip prebuild] copying python+pip to overlay..."
+mkdir -p "$overlay_dir/usr/bin" "$overlay_dir/usr/lib" "$overlay_dir/lib"
+
+# Copy Python and pip binaries (preserving symlinks initially)
+for d in usr/bin usr/lib lib; do
+    src="$staging_root/$d"
+    dst="$overlay_dir/$d"
+    if [[ -d "$src" ]]; then
+        cp -a "$src/." "$dst/"
+    fi
+done
+
+# Resolve symlinks in the overlay: replace each symlink with a copy of its
+# target, resolving paths relative to the staging root (not the host).
+# Loop until no symlinks remain (handles chains like a -> b -> c).
+while symlinks="$(find "$overlay_dir" -type l)" && [[ -n "$symlinks" ]]; do
+    echo "$symlinks" | while IFS= read -r link; do
+        [[ -z "$link" ]] && continue
+        target="$(readlink "$link")"
+        if [[ "$target" = /* ]]; then
+            resolved="$staging_root$target"
+        else
+            resolved="$(dirname "$link")/$target"
+        fi
+        if [[ -e "$resolved" ]]; then
+            rm "$link"
+            cp -a "$resolved" "$link"
+        else
+            echo "[pip prebuild] warning: dangling symlink $link -> $target, removing" >&2
+            rm "$link"
+        fi
+    done
+done
+
+# Copy test script to overlay
+install -Dm0755 "$app_dir/test_pip.sh" "$overlay_dir/usr/bin/test_pip.sh"
+
+echo "[pip prebuild] done."

--- a/apps/starry/pip/prebuild.sh
+++ b/apps/starry/pip/prebuild.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
-arch="${STARRY_ARCH:-x86_64}"
 base_rootfs="${STARRY_BASE_ROOTFS:-}"
 staging_root="${STARRY_STAGING_ROOT:-}"
 overlay_dir="${STARRY_OVERLAY_DIR:-}"
+apk_cache="${STARRY_WORKSPACE:-$(cd "$app_dir/../../.." && pwd)}/target/pip-apk-cache"
 
 require_env() {
     local name="$1"
@@ -19,17 +19,10 @@ require_env() {
 ensure_host_packages() {
     local missing=()
 
+    command -v apk >/dev/null 2>&1 || missing+=(apk-tools)
     command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
     command -v install >/dev/null 2>&1 || missing+=(coreutils)
     command -v readelf >/dev/null 2>&1 || missing+=(binutils)
-
-    # qemu-user is needed to run apk inside the staging root on non-Alpine hosts
-    case "$arch" in
-        aarch64)     command -v qemu-aarch64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
-        riscv64)     command -v qemu-riscv64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
-        x86_64)      command -v qemu-x86_64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
-        loongarch64) command -v qemu-loongarch64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
-    esac
 
     if [[ ${#missing[@]} -eq 0 ]]; then
         return
@@ -50,26 +43,14 @@ extract_base_rootfs() {
 }
 
 install_pip_packages() {
-    # Set up apk repositories and DNS so apk can download packages
-    mkdir -p "$staging_root/etc/apk"
-    echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" > "$staging_root/etc/apk/repositories"
-    echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> "$staging_root/etc/apk/repositories"
-    cp /etc/resolv.conf "$staging_root/etc/resolv.conf"
-
-    local qemu_user
-    case "$arch" in
-        aarch64)     qemu_user="qemu-aarch64-static" ;;
-        riscv64)     qemu_user="qemu-riscv64-static" ;;
-        x86_64)      qemu_user="qemu-x86_64-static" ;;
-        loongarch64) qemu_user="qemu-loongarch64-static" ;;
-        *)           echo "error: unsupported arch: $arch" >&2; exit 1 ;;
-    esac
-
-    echo "[pip prebuild] installing python3 and py3-pip via qemu-user apk..."
-    export QEMU_LD_PREFIX="$staging_root"
-    export LD_LIBRARY_PATH="$staging_root/usr/lib:$staging_root/lib"
-    "$qemu_user" -L "$staging_root" "$staging_root/sbin/apk" \
-        add --no-cache --root "$staging_root" python3 py3-pip
+    mkdir -p "$apk_cache"
+    echo "[pip prebuild] installing python3 and py3-pip via host apk..."
+    apk --root "$staging_root" \
+        --cache-dir "$apk_cache" \
+        --update-cache \
+        --no-progress \
+        --no-scripts \
+        add python3 py3-pip
 }
 
 copy_file_to_overlay() {

--- a/apps/starry/pip/prebuild.sh
+++ b/apps/starry/pip/prebuild.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:-x86_64}"
 base_rootfs="${STARRY_BASE_ROOTFS:-}"
 staging_root="${STARRY_STAGING_ROOT:-}"
 overlay_dir="${STARRY_OVERLAY_DIR:-}"
@@ -19,10 +20,16 @@ require_env() {
 ensure_host_packages() {
     local missing=()
 
-    command -v apk >/dev/null 2>&1 || missing+=(apk-tools)
     command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
     command -v install >/dev/null 2>&1 || missing+=(coreutils)
     command -v readelf >/dev/null 2>&1 || missing+=(binutils)
+
+    case "$arch" in
+        aarch64)     command -v qemu-aarch64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        riscv64)     command -v qemu-riscv64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        x86_64)      command -v qemu-x86_64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        loongarch64) command -v qemu-loongarch64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+    esac
 
     if [[ ${#missing[@]} -eq 0 ]]; then
         return
@@ -43,9 +50,30 @@ extract_base_rootfs() {
 }
 
 install_pip_packages() {
+    local qemu_runner
+    case "$arch" in
+        aarch64)     qemu_runner="qemu-aarch64-static" ;;
+        riscv64)     qemu_runner="qemu-riscv64-static" ;;
+        x86_64)      qemu_runner="qemu-x86_64-static" ;;
+        loongarch64) qemu_runner="qemu-loongarch64-static" ;;
+        *)           echo "error: unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+
+    if ! command -v "$qemu_runner" >/dev/null 2>&1; then
+        echo "error: $qemu_runner not found" >&2
+        exit 1
+    fi
+
+    # Copy host DNS config so apk can resolve hostnames inside qemu-user.
+    if [[ -f /etc/resolv.conf ]]; then
+        cp /etc/resolv.conf "$staging_root/etc/resolv.conf"
+    fi
+
     mkdir -p "$apk_cache"
-    echo "[pip prebuild] installing python3 and py3-pip via host apk..."
-    apk --root "$staging_root" \
+    echo "[pip prebuild] installing python3 and py3-pip via qemu-user apk..."
+    "$qemu_runner" -L "$staging_root" \
+        "$staging_root/sbin/apk" \
+        --root / \
         --cache-dir "$apk_cache" \
         --update-cache \
         --no-progress \

--- a/apps/starry/pip/qemu-x86_64.toml
+++ b/apps/starry/pip/qemu-x86_64.toml
@@ -17,7 +17,7 @@ args = [
 uefi = false
 to_bin = false
 shell_prefix = "root@starry:"
-shell_init_cmd = "sh /usr/bin/test_pip.sh"
+shell_init_cmd = "/usr/bin/test_pip.sh"
 success_regex = ["(?m)^STARRY_PIP_TESTS_PASSED\\s*$"]
 fail_regex = [
     "(?i)\\bpanic(?:ked)?\\b",

--- a/apps/starry/pip/qemu-x86_64.toml
+++ b/apps/starry/pip/qemu-x86_64.toml
@@ -1,0 +1,29 @@
+args = [
+    "-machine",
+    "q35",
+    "-nographic",
+    "-m",
+    "1G",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-pip.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-snapshot",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/test_pip.sh"
+success_regex = ["(?m)^STARRY_PIP_TESTS_PASSED\\s*$"]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)page fault",
+    "(?i)segmentation fault",
+    "No such process",
+    "STARRY_PIP_STAGE_.*_FAILED",
+]
+timeout = 600

--- a/apps/starry/pip/test_pip.sh
+++ b/apps/starry/pip/test_pip.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+set -e
+
+export HOME=/root
+export USER=root
+export SHELL=/bin/sh
+export TERM=xterm-256color
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/sbin:/root/.local/bin
+export PIP_BREAK_SYSTEM_PACKAGES=1
+
+STAGE=0
+fail() { echo "STARRY_PIP_STAGE_${STAGE}_FAILED: $1"; exit 1; }
+next() { STAGE=$((STAGE+1)); echo "STARRY_PIP_STAGE_${STAGE}: $1 OK"; }
+
+# ---------- Stage 1: Basic sanity ----------
+python3 --version || fail "python3 --version"
+pip3 --version || fail "pip3 --version"
+pip3 --help > /dev/null || fail "pip3 --help"
+next "basic-sanity"
+
+# ---------- Stage 2: Create venv ----------
+python3 -m venv /root/test-venv || fail "venv create"
+test -d /root/test-venv/bin || fail "venv bin dir missing"
+test -f /root/test-venv/bin/activate || fail "venv activate missing"
+test -f /root/test-venv/bin/pip || fail "venv pip missing"
+. /root/test-venv/bin/activate || fail "venv activate"
+next "venv-create"
+
+# ---------- Stage 3: pip inside venv ----------
+pip --version || fail "pip --version in venv"
+python -c "import sys; assert hasattr(sys, 'prefix') and hasattr(sys, 'base_prefix')" || fail "sys.prefix check"
+python -c "import sys; print('real_prefix' if hasattr(sys, 'real_prefix') else 'base_prefix:', sys.base_prefix)" || fail "venv detection"
+next "venv-pip"
+
+# ---------- Stage 4: pip list (empty venv) ----------
+LIST_OUT="$(pip list 2>&1)"
+echo "$LIST_OUT" | grep -iE "^pip\s" || fail "pip list missing pip"
+next "pip-list-empty"
+
+# ---------- Stage 5: pip install a small package ----------
+pip install --no-cache-dir pyfiglet || fail "pip install pyfiglet"
+python -c "import pyfiglet; print(pyfiglet.figlet_format('OK'))" || fail "import pyfiglet"
+next "pip-install"
+
+# ---------- Stage 6: pip show ----------
+SHOW_OUT="$(pip show pyfiglet 2>&1)"
+echo "$SHOW_OUT" | grep -i "^Name:.*pyfiglet" || fail "pip show name"
+echo "$SHOW_OUT" | grep -i "^Version:" || fail "pip show version"
+echo "$SHOW_OUT" | grep -i "^Location:" || fail "pip show location"
+next "pip-show"
+
+# ---------- Stage 7: pip list (after install) ----------
+pip list 2>&1 | grep -iE "^pyfiglet\s" || fail "pip list missing pyfiglet after install"
+next "pip-list-after-install"
+
+# ---------- Stage 8: pip install --dry-run ----------
+pip install --dry-run --no-cache-dir requests 2>&1 | grep -i "Would install" || fail "pip install --dry-run"
+next "pip-dry-run"
+
+# ---------- Stage 9: pip freeze ----------
+FREEZE_OUT="$(pip freeze 2>&1)"
+echo "$FREEZE_OUT" | grep -iE "^pyfiglet==" || fail "pip freeze missing pyfiglet"
+next "pip-freeze"
+
+# ---------- Stage 10: pip freeze > requirements.txt + pip install -r ----------
+pip freeze > /root/requirements.txt || fail "pip freeze > requirements.txt"
+pip install --no-cache-dir -r /root/requirements.txt || fail "pip install -r requirements.txt"
+next "pip-requirements"
+
+# ---------- Stage 11: pip install --upgrade ----------
+OLD_VER="$(pip show pyfiglet | grep '^Version:' | awk '{print $2}')"
+pip install --no-cache-dir --upgrade pyfiglet || fail "pip install --upgrade pyfiglet"
+next "pip-upgrade"
+
+# ---------- Stage 12: pip install a second package ----------
+pip install --no-cache-dir six || fail "pip install six"
+python -c "import six; print('six version:', six.__version__)" || fail "import six"
+next "pip-install-second"
+
+# ---------- Stage 13: pip install multiple packages ----------
+pip install --no-cache-dir chardet idna || fail "pip install chardet idna"
+python -c "import chardet; import idna; print('multi-install OK')" || fail "import multi"
+next "pip-install-multi"
+
+# ---------- Stage 14: pip install from local directory ----------
+mkdir -p /tmp/localpkg
+cat > /tmp/localpkg/setup.py << 'PYEOF'
+from setuptools import setup
+setup(
+    name="localpkg",
+    version="0.1.0",
+    py_modules=["localmod"],
+)
+PYEOF
+cat > /tmp/localpkg/localmod.py << 'PYEOF'
+HELLO = "hello from localpkg"
+PYEOF
+pip install --no-cache-dir /tmp/localpkg || fail "pip install local dir"
+python -c "import localmod; assert localmod.HELLO == 'hello from localpkg'" || fail "import localpkg"
+next "pip-install-local-dir"
+
+# ---------- Stage 15: pip install local wheel ----------
+mkdir -p /tmp/wheels
+pip wheel --no-cache-dir --no-deps -w /tmp/wheels markupsafe || fail "pip wheel markupsafe"
+WHEEL_FILE="$(ls /tmp/wheels/markupsafe-*.whl | head -1)"
+test -f "$WHEEL_FILE" || fail "wheel file not found"
+pip install --no-cache-dir "$WHEEL_FILE" || fail "pip install local wheel"
+python -c "import markupsafe; print('markupsafe OK')" || fail "import markupsafe"
+next "pip-install-local-wheel"
+
+# ---------- Stage 16: pip download ----------
+mkdir -p /tmp/downloads
+pip download --no-cache-dir -d /tmp/downloads toml || fail "pip download toml"
+test "$(ls /tmp/downloads/*.whl 2>/dev/null | wc -l)" -ge 1 || fail "no wheel downloaded"
+next "pip-download"
+
+# ---------- Stage 17: pip cache ----------
+CACHE_DIR="$(pip cache dir 2>&1)" || fail "pip cache dir"
+echo "cache dir: $CACHE_DIR"
+pip cache info 2>&1 || fail "pip cache info"
+pip install --no-cache-dir --force-reinstall --cache-dir=/tmp/pip-cache-dir pyfiglet 2>&1 || fail "pip install with custom cache dir"
+test -d /tmp/pip-cache-dir || fail "custom cache dir not created"
+pip cache purge 2>&1 || true
+next "pip-cache"
+
+# ---------- Stage 18: pip check ----------
+pip check || fail "pip check"
+next "pip-check"
+
+# ---------- Stage 19: pip uninstall ----------
+pip uninstall -y six || fail "pip uninstall six"
+python -c "import six" 2>/dev/null && fail "six still importable after uninstall" || true
+! pip show six >/dev/null 2>&1 || fail "pip show six still works after uninstall"
+next "pip-uninstall"
+
+# ---------- Stage 20: pip install after uninstall ----------
+pip install --no-cache-dir six || fail "pip install six again"
+python -c "import six" || fail "import six after reinstall"
+next "pip-reinstall"
+
+# ---------- Stage 21: editable install (pip install -e) ----------
+mkdir -p /tmp/mypackage
+cat > /tmp/mypackage/setup.py << 'PYEOF'
+from setuptools import setup
+setup(
+    name="mypackage",
+    version="0.1.0",
+    py_modules=["mymod"],
+)
+PYEOF
+cat > /tmp/mypackage/mymod.py << 'PYEOF'
+def hello():
+    return "hello from mypackage"
+PYEOF
+pip install --no-cache-dir -e /tmp/mypackage || fail "pip install -e"
+python -c "import mymod; assert mymod.hello() == 'hello from mypackage'" || fail "editable import"
+next "pip-editable"
+
+# ---------- Stage 22: pip list with format ----------
+pip list --format=json 2>&1 | python3 -c "import sys,json; d=json.load(sys.stdin); assert isinstance(d,list)" || fail "pip list --format=json"
+pip list --format=columns 2>&1 | head -5 || fail "pip list --format=columns"
+pip list --outdated 2>&1 || fail "pip list --outdated"
+next "pip-list-format"
+
+# ---------- Stage 23: pip config ----------
+pip config list 2>&1 || fail "pip config list"
+next "pip-config"
+
+# ---------- Stage 24: pip debug ----------
+pip debug 2>&1 | head -20 || fail "pip debug"
+next "pip-debug"
+
+# ---------- Stage 25: venv cleanup ----------
+deactivate 2>/dev/null || true
+rm -rf /root/test-venv || fail "rm venv"
+test ! -d /root/test-venv || fail "venv dir still exists"
+rm -f /root/requirements.txt
+next "venv-cleanup"
+
+echo ""
+echo "STARRY_PIP_TESTS_PASSED"

--- a/apps/starry/pip/test_pip.sh
+++ b/apps/starry/pip/test_pip.sh
@@ -118,7 +118,7 @@ next "pip-download"
 CACHE_DIR="$(pip cache dir 2>&1)" || fail "pip cache dir"
 echo "cache dir: $CACHE_DIR"
 pip cache info 2>&1 || fail "pip cache info"
-pip install --no-cache-dir --force-reinstall --cache-dir=/tmp/pip-cache-dir pyfiglet 2>&1 || fail "pip install with custom cache dir"
+pip install --force-reinstall --cache-dir=/tmp/pip-cache-dir pyfiglet 2>&1 || fail "pip install with custom cache dir"
 test -d /tmp/pip-cache-dir || fail "custom cache dir not created"
 pip cache purge 2>&1 || true
 next "pip-cache"


### PR DESCRIPTION
## Summary

在 `apps/starry/pip/` 下新增 pip 功能测试，覆盖 25 个日常 pip 操作场景，在 StarryOS Alpine rootfs 上运行。

### 测试内容

- venv 创建 / 激活 / 销毁
- `pip install` / `uninstall` / `upgrade` / `--dry-run`
- `pip list` / `show` / `freeze` / `check`
- `pip install -r requirements.txt`
- `pip install` 本地目录 / 本地 wheel
- `pip wheel` / `pip download`
- `pip cache dir` / `info` / `purge`
- `pip install -e`（editable）
- `pip list --format=json` / `--outdated`
- `pip config` / `pip debug`

### 文件说明

| 文件 | 用途 |
|------|------|
| `test_pip.sh` | 测试脚本，25 个阶段逐级输出 `STARRY_PIP_STAGE_N` 标记 |
| `prebuild.sh` | 通过 qemu-user 在 staging rootfs 中 `apk add python3 py3-pip`，解析符号链接后注入 overlay |
| `qemu-x86_64.toml` | QEMU 配置，引用外部脚本 `sh /usr/bin/test_pip.sh` |
| `build-x86_64-unknown-none.toml` | 构建配置，启用 virtio-blk/net 驱动 |

### 运行方式

```bash
cargo xtask starry app run -t pip
