### PR TITLE
remove unnecessary file

### DIFF
--- a/test-suit/starryos/normal/qemu-smp4/test-futex-clone-thread/path.md
+++ b/test-suit/starryos/normal/qemu-smp4/test-futex-clone-thread/path.md
@@ -1,1 +1,0 @@
-test-suit/starryos/normal/qemu-smp4/test-futex-clone-thread/


### PR DESCRIPTION
test-futex-clone-thread/path.md 仅包含测试目录路径字符串，系统不读取此文件，因此移除该冗余文件