### PR TITLE
feat(axtask): prefer current CPU in select_run_queue for cache affinity

### DIFF
--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -186,8 +186,14 @@ pub(crate) fn select_run_queue<G: BaseGuard>(task: &AxTaskRef) -> AxRunQueueRef<
     }
     #[cfg(feature = "smp")]
     {
-        // When SMP is enabled, select the run queue based on the task's CPU affinity and load balance.
-        let index = select_run_queue_index(task.cpumask());
+        // When SMP is enabled, prefer the current CPU to keep the task's
+        // cache warm. Fall back to round-robin only when affinity forbids it.
+        let current_cpu = this_cpu_id();
+        let index = if task.cpumask().get(current_cpu) {
+            current_cpu
+        } else {
+            select_run_queue_index(task.cpumask())
+        };
         AxRunQueueRef {
             inner: get_run_queue(index),
             state: irq_state,


### PR DESCRIPTION
## Summary

`select_run_queue` 在 SMP 场景下使用全局 round-robin 分配任务到各 CPU 队列，忽略了 cache 热度。`select_wake_run_queue`（#926）已经优先放置到当前 CPU，但 `select_run_queue`（新任务创建、定时器唤醒、任务迁移）仍在做盲轮询。

本 PR 让 `select_run_queue` 也优先选择当前 CPU，改动仅 1 处，3 行。

## Root Cause

SMP 启动后，`select_run_queue` 每次调用都走 `select_run_queue_index`，其中 `RUN_QUEUE_INDEX.fetch_add(1, SeqCst)` 是一个全局原子操作。在 4 核场景下，四个 CPU 同时争抢这条 cache line，本身就有开销。更糟的是，任务被随机分到别的 CPU 后：

- 每次切回来都要跨 CPU 操作 `Arc` 引用计数
- 原 CPU 上的指令/数据 cache 全部作废
- qperf 数据验证了这一点：SMP=4 时 `data_offset` 比单核劣化 55%

而 `select_wake_run_queue`（#926）已经在做正确的事——优先当前 CPU，其次上次运行的 CPU，最后才 round-robin。`select_run_queue` 缺的就是最前面这一步。

`select_run_queue` 三个调用点中，定时器唤醒（`timers.rs:48`）受影响最大——任务在当前 CPU 上睡眠，定时器在当前 CPU 上触发，结果任务被随机扔到了别的 CPU。

## Fix

在 `select_run_queue` 的 SMP 分支中，先检查当前 CPU 是否在任务的 cpumask 中，是则直接使用当前 CPU 的队列。仅当 affinity 不允许时才退回到 round-robin 选择。

与 `select_wake_run_queue` 的区别是不查 `last_cpu`——新建任务和迁移任务的 `cpu_id` 还未被赋予有意义的值，查了也是废的。

```rust
// Before
let index = select_run_queue_index(task.cpumask());

// After
let current_cpu = this_cpu_id();
let index = if task.cpumask().get(current_cpu) {
    current_cpu
} else {
    select_run_queue_index(task.cpumask())
};
```

## Test Plan

已验证：

```sh
cargo fmt --all -- --check                           # PASS
cargo clippy -p ax-task --all-features -- -D warnings  # PASS
```

待验证（需 QEMU SMP 环境）：

```sh
timeout 180s cargo xtask starry qemu --arch riscv64 --smp 4    # boot to shell
timeout 180s cargo xtask starry qemu --arch aarch64 --smp 4    # boot to shell
# qperf SMP=4 对比，预期 data_offset 显著优于当前 dev
```

## Remaining Risk

- 新建任务粘在当前 CPU 可能造成短期的负载不均衡。后续 #1016（工作窃取）专门解决这个问题
- `select_run_queue` 查 `last_cpu` 在新建任务场景下无意义（cpu_id 为初始值），不会产生错误行为，只是多一次无效判断。留到后续有更清晰的迁移需求时再加

🤖 Generated with [Claude Code](https://claude.com/claude-code)