### PR TITLE
feat(starry-kernel): support cgroup2 hierarchy mkdir and rmdir

### DIFF
--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -59,6 +59,20 @@ pub trait DirNodeOps: NodeOps {
         true
     }
 
+    /// Returns whether this directory has child entries relevant to rmdir.
+    fn has_children(&self) -> VfsResult<bool> {
+        let mut has_children = false;
+        self.read_dir(0, &mut |name: &str, _, _, _| {
+            if name != DOT && name != DOTDOT {
+                has_children = true;
+                false
+            } else {
+                true
+            }
+        })?;
+        Ok(has_children)
+    }
+
     /// Creates a directory entry.
     fn create(
         &self,
@@ -164,6 +178,10 @@ impl DirNode {
     }
 
     fn lookup_locked(&self, name: &str, children: &mut DirChildren) -> VfsResult<DirEntry> {
+        if !self.ops.is_cacheable() {
+            return self.ops.lookup(name);
+        }
+
         use hashbrown::hash_map::Entry;
         match children.entry(name.to_owned()) {
             Entry::Occupied(e) => Ok(e.get().clone()),
@@ -223,7 +241,9 @@ impl DirNode {
             // file content.
             let user_data = node.user_data().clone();
             *entry.user_data() = user_data;
-            self.cache.lock().insert(name.to_owned(), entry.clone());
+            if self.ops.is_cacheable() {
+                self.cache.lock().insert(name.to_owned(), entry.clone());
+            }
         })
     }
 
@@ -249,16 +269,7 @@ impl DirNode {
 
     /// Returns whether the directory contains children.
     pub fn has_children(&self) -> VfsResult<bool> {
-        let mut has_children = false;
-        self.read_dir(0, &mut |name: &str, _, _, _| {
-            if name != DOT && name != DOTDOT {
-                has_children = true;
-                false
-            } else {
-                true
-            }
-        })?;
-        Ok(has_children)
+        self.ops.has_children()
     }
 
     fn create_locked(
@@ -269,7 +280,9 @@ impl DirNode {
         children: &mut DirChildren,
     ) -> VfsResult<DirEntry> {
         let entry = self.ops.create(name, node_type, permission)?;
-        children.insert(name.to_owned(), entry.clone());
+        if self.ops.is_cacheable() {
+            children.insert(name.to_owned(), entry.clone());
+        }
         Ok(entry)
     }
 

--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -107,7 +107,7 @@ pub fn create_child(parent: CgroupId, name: &str) -> AxResult<CgroupId> {
     }
 
     let id = tree.next_id;
-    tree.next_id += 1;
+    tree.next_id = id.checked_add(1).ok_or(AxError::NoMemory)?;
     tree.nodes.insert(id, CgroupNode::child(id, parent, name));
     tree.nodes
         .get_mut(&parent)
@@ -179,14 +179,8 @@ pub fn path(id: CgroupId) -> AxResult<String> {
 }
 
 pub fn procs_text(id: CgroupId) -> AxResult<String> {
-    let is_root = {
-        let tree = CGROUP_TREE.lock();
-        let node = tree.nodes.get(&id).ok_or(AxError::NotFound)?;
-        debug_assert_eq!(node.id, id);
-        id == ROOT_ID
-    };
-
-    if !is_root {
+    ensure_node_exists(id)?;
+    if id != ROOT_ID {
         return Ok(String::new());
     }
 
@@ -223,7 +217,7 @@ pub fn write_subtree_control(id: CgroupId, _data: &[u8]) -> AxResult<()> {
     Err(AxError::from(LinuxError::EINVAL))
 }
 
-fn ensure_node_exists(id: CgroupId) -> AxResult<()> {
+pub fn ensure_node_exists(id: CgroupId) -> AxResult<()> {
     let tree = CGROUP_TREE.lock();
     let node = tree.nodes.get(&id).ok_or(AxError::NotFound)?;
     debug_assert_eq!(node.id, id);

--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -1,10 +1,195 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::fmt::Write;
 
 use ax_errno::{AxError, AxResult, LinuxError};
+use ax_kspin::SpinNoIrq;
+use spin::LazyLock;
 
-/// Returns the process list for the root cgroup.
-pub fn root_procs_text() -> String {
+pub type CgroupId = u64;
+
+const ROOT_ID: CgroupId = 1;
+const INTERFACE_FILES: [&str; 3] = [
+    "cgroup.procs",
+    "cgroup.controllers",
+    "cgroup.subtree_control",
+];
+
+struct CgroupNode {
+    id: CgroupId,
+    name: String,
+    parent: Option<CgroupId>,
+    children: BTreeMap<String, CgroupId>,
+    live_processes: usize,
+}
+
+impl CgroupNode {
+    fn root() -> Self {
+        Self {
+            id: ROOT_ID,
+            name: String::new(),
+            parent: None,
+            children: BTreeMap::new(),
+            live_processes: 0,
+        }
+    }
+
+    fn child(id: CgroupId, parent: CgroupId, name: &str) -> Self {
+        Self {
+            id,
+            name: name.to_string(),
+            parent: Some(parent),
+            children: BTreeMap::new(),
+            live_processes: 0,
+        }
+    }
+}
+
+struct CgroupTree {
+    nodes: BTreeMap<CgroupId, CgroupNode>,
+    next_id: CgroupId,
+}
+
+impl CgroupTree {
+    fn new() -> Self {
+        let mut nodes = BTreeMap::new();
+        nodes.insert(ROOT_ID, CgroupNode::root());
+        Self {
+            nodes,
+            next_id: ROOT_ID + 1,
+        }
+    }
+}
+
+static CGROUP_TREE: LazyLock<SpinNoIrq<CgroupTree>> =
+    LazyLock::new(|| SpinNoIrq::new(CgroupTree::new()));
+
+pub fn root_id() -> CgroupId {
+    ROOT_ID
+}
+
+pub fn is_interface_file_name(name: &str) -> bool {
+    INTERFACE_FILES.contains(&name)
+}
+
+pub fn child_names(parent: CgroupId) -> AxResult<Vec<String>> {
+    let tree = CGROUP_TREE.lock();
+    let node = tree.nodes.get(&parent).ok_or(AxError::NotFound)?;
+    debug_assert_eq!(node.id, parent);
+    Ok(node.children.keys().cloned().collect())
+}
+
+pub fn lookup_child(parent: CgroupId, name: &str) -> AxResult<CgroupId> {
+    let tree = CGROUP_TREE.lock();
+    let node = tree.nodes.get(&parent).ok_or(AxError::NotFound)?;
+    debug_assert_eq!(node.id, parent);
+    node.children.get(name).copied().ok_or(AxError::NotFound)
+}
+
+pub fn create_child(parent: CgroupId, name: &str) -> AxResult<CgroupId> {
+    if name.is_empty() {
+        return Err(AxError::InvalidInput);
+    }
+    if is_interface_file_name(name) {
+        return Err(AxError::AlreadyExists);
+    }
+
+    let mut tree = CGROUP_TREE.lock();
+    {
+        let parent_node = tree.nodes.get(&parent).ok_or(AxError::NotFound)?;
+        debug_assert_eq!(parent_node.id, parent);
+        if parent_node.children.contains_key(name) {
+            return Err(AxError::AlreadyExists);
+        }
+    }
+
+    let id = tree.next_id;
+    tree.next_id += 1;
+    tree.nodes.insert(id, CgroupNode::child(id, parent, name));
+    tree.nodes
+        .get_mut(&parent)
+        .expect("parent was checked above")
+        .children
+        .insert(name.to_string(), id);
+    Ok(id)
+}
+
+pub fn remove_child(parent: CgroupId, name: &str) -> AxResult<()> {
+    if name.is_empty() {
+        return Err(AxError::InvalidInput);
+    }
+
+    let mut tree = CGROUP_TREE.lock();
+    let child_id = {
+        let parent_node = tree.nodes.get(&parent).ok_or(AxError::NotFound)?;
+        debug_assert_eq!(parent_node.id, parent);
+        parent_node
+            .children
+            .get(name)
+            .copied()
+            .ok_or(AxError::NotFound)?
+    };
+    let child = tree.nodes.get(&child_id).ok_or(AxError::NotFound)?;
+    debug_assert_eq!(child.id, child_id);
+    if !child.children.is_empty() {
+        return Err(AxError::DirectoryNotEmpty);
+    }
+    if child.live_processes != 0 {
+        return Err(AxError::ResourceBusy);
+    }
+
+    tree.nodes
+        .get_mut(&parent)
+        .expect("parent was checked above")
+        .children
+        .remove(name);
+    tree.nodes.remove(&child_id);
+    Ok(())
+}
+
+pub fn path(id: CgroupId) -> AxResult<String> {
+    let tree = CGROUP_TREE.lock();
+    let mut current = id;
+    let mut names = Vec::new();
+    loop {
+        let node = tree.nodes.get(&current).ok_or(AxError::NotFound)?;
+        debug_assert_eq!(node.id, current);
+        if let Some(parent) = node.parent {
+            names.push(node.name.clone());
+            current = parent;
+        } else {
+            break;
+        }
+    }
+
+    if names.is_empty() {
+        return Ok("/".to_string());
+    }
+
+    names.reverse();
+    let mut path = String::new();
+    for name in names {
+        path.push('/');
+        path.push_str(&name);
+    }
+    Ok(path)
+}
+
+pub fn procs_text(id: CgroupId) -> AxResult<String> {
+    let is_root = {
+        let tree = CGROUP_TREE.lock();
+        let node = tree.nodes.get(&id).ok_or(AxError::NotFound)?;
+        debug_assert_eq!(node.id, id);
+        id == ROOT_ID
+    };
+
+    if !is_root {
+        return Ok(String::new());
+    }
+
     let mut pids: Vec<_> = crate::task::processes()
         .into_iter()
         .map(|proc_data| proc_data.proc.pid())
@@ -15,25 +200,32 @@ pub fn root_procs_text() -> String {
     for pid in pids {
         let _ = writeln!(text, "{pid}");
     }
-    text
+    Ok(text)
 }
 
-/// Returns the controllers visible at the root cgroup.
-pub fn root_controllers_text() -> &'static str {
-    ""
+pub fn controllers_text(id: CgroupId) -> AxResult<&'static str> {
+    ensure_node_exists(id)?;
+    Ok("")
 }
 
-/// Returns enabled subtree controllers at the root cgroup.
-pub fn root_subtree_control_text() -> &'static str {
-    ""
+pub fn subtree_control_text(id: CgroupId) -> AxResult<&'static str> {
+    ensure_node_exists(id)?;
+    Ok("")
 }
 
-/// Writes to cgroup.procs are not implemented in this slice.
-pub fn write_root_procs(_data: &[u8]) -> AxResult<()> {
+pub fn write_procs(id: CgroupId, _data: &[u8]) -> AxResult<()> {
+    ensure_node_exists(id)?;
     Err(AxError::from(LinuxError::EOPNOTSUPP))
 }
 
-/// Writes to cgroup.subtree_control cannot enable unavailable controllers.
-pub fn write_root_subtree_control(_data: &[u8]) -> AxResult<()> {
+pub fn write_subtree_control(id: CgroupId, _data: &[u8]) -> AxResult<()> {
+    ensure_node_exists(id)?;
     Err(AxError::from(LinuxError::EINVAL))
+}
+
+fn ensure_node_exists(id: CgroupId) -> AxResult<()> {
+    let tree = CGROUP_TREE.lock();
+    let node = tree.nodes.get(&id).ok_or(AxError::NotFound)?;
+    debug_assert_eq!(node.id, id);
+    Ok(())
 }

--- a/os/StarryOS/kernel/src/pseudofs/cgroup.rs
+++ b/os/StarryOS/kernel/src/pseudofs/cgroup.rs
@@ -1,33 +1,82 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{string::ToString, sync::Arc, vec::Vec};
+use core::any::Any;
 
 use ax_errno::LinuxError;
-use axfs_ng_vfs::{Filesystem, NodePermission, VfsError, VfsResult};
+use axfs_ng_vfs::{
+    DirEntry, DirEntrySink, DirNode, DirNodeOps, FileNode, Filesystem, FilesystemOps, Metadata,
+    MetadataUpdate, NodeOps, NodePermission, NodeType, Reference, VfsError, VfsResult,
+    WeakDirEntry,
+    path::{DOT, DOTDOT},
+};
+use inherit_methods_macro::inherit_methods;
 
-use super::{DirMaker, DirMapping, DirectRwFsFileOps, SimpleDir, SimpleFs, SpecialFsFile};
+use super::{DirMaker, DirectRwFsFileOps, SimpleFs, SimpleFsNode, SpecialFsFile};
+use crate::cgroup::{CgroupId, root_id};
 
 const CGROUP2_SUPER_MAGIC: u32 = 0x6367_7270;
 
-enum RootFile {
-    Procs,
+#[derive(Clone, Copy)]
+enum CgroupFileKind {
     Controllers,
+    Procs,
     SubtreeControl,
 }
 
-impl RootFile {
-    fn read_content(&self) -> Vec<u8> {
-        match self {
-            Self::Procs => crate::cgroup::root_procs_text().into_bytes(),
-            Self::Controllers => crate::cgroup::root_controllers_text().as_bytes().to_vec(),
-            Self::SubtreeControl => crate::cgroup::root_subtree_control_text()
-                .as_bytes()
-                .to_vec(),
+impl CgroupFileKind {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "cgroup.controllers" => Some(Self::Controllers),
+            "cgroup.procs" => Some(Self::Procs),
+            "cgroup.subtree_control" => Some(Self::SubtreeControl),
+            _ => None,
         }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Controllers => "cgroup.controllers",
+            Self::Procs => "cgroup.procs",
+            Self::SubtreeControl => "cgroup.subtree_control",
+        }
+    }
+
+    fn permission(self) -> NodePermission {
+        let mode = match self {
+            Self::Controllers => 0o444,
+            Self::Procs | Self::SubtreeControl => 0o644,
+        };
+        NodePermission::from_bits_truncate(mode)
     }
 }
 
-impl DirectRwFsFileOps for RootFile {
+const CGROUP_FILES: [CgroupFileKind; 3] = [
+    CgroupFileKind::Controllers,
+    CgroupFileKind::Procs,
+    CgroupFileKind::SubtreeControl,
+];
+
+struct CgroupFile {
+    id: CgroupId,
+    kind: CgroupFileKind,
+}
+
+impl CgroupFile {
+    fn read_content(&self) -> VfsResult<Vec<u8>> {
+        Ok(match self.kind {
+            CgroupFileKind::Controllers => crate::cgroup::controllers_text(self.id)?
+                .as_bytes()
+                .to_vec(),
+            CgroupFileKind::Procs => crate::cgroup::procs_text(self.id)?.into_bytes(),
+            CgroupFileKind::SubtreeControl => crate::cgroup::subtree_control_text(self.id)?
+                .as_bytes()
+                .to_vec(),
+        })
+    }
+}
+
+impl DirectRwFsFileOps for CgroupFile {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> VfsResult<usize> {
-        let content = self.read_content();
+        let content = self.read_content()?;
         let offset = offset as usize;
         if offset >= content.len() {
             return Ok(0);
@@ -40,45 +89,170 @@ impl DirectRwFsFileOps for RootFile {
     }
 
     fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {
-        match self {
-            Self::Procs => crate::cgroup::write_root_procs(buf)?,
-            Self::Controllers => return Err(VfsError::from(LinuxError::EACCES)),
-            Self::SubtreeControl => crate::cgroup::write_root_subtree_control(buf)?,
+        match self.kind {
+            CgroupFileKind::Controllers => {
+                crate::cgroup::controllers_text(self.id)?;
+                return Err(VfsError::from(LinuxError::EACCES));
+            }
+            CgroupFileKind::Procs => crate::cgroup::write_procs(self.id, buf)?,
+            CgroupFileKind::SubtreeControl => crate::cgroup::write_subtree_control(self.id, buf)?,
         }
         Ok(buf.len())
     }
 }
 
-/// Creates a minimal cgroup v2 pseudo filesystem.
+struct CgroupDir {
+    node: SimpleFsNode,
+    this: WeakDirEntry,
+    fs: Arc<SimpleFs>,
+    id: CgroupId,
+}
+
+impl CgroupDir {
+    fn new(fs: Arc<SimpleFs>, id: CgroupId, this: WeakDirEntry) -> Arc<Self> {
+        debug_assert!(crate::cgroup::path(id).is_ok());
+        Arc::new(Self {
+            node: SimpleFsNode::new(
+                fs.clone(),
+                NodeType::Directory,
+                NodePermission::from_bits_truncate(0o755),
+            ),
+            this,
+            fs,
+            id,
+        })
+    }
+
+    fn new_maker(fs: Arc<SimpleFs>, id: CgroupId) -> DirMaker {
+        Arc::new(move |this| Self::new(fs.clone(), id, this))
+    }
+
+    fn this_entry(&self) -> VfsResult<DirEntry> {
+        self.this.upgrade().ok_or(VfsError::NotFound)
+    }
+
+    fn file_entry(&self, kind: CgroupFileKind) -> VfsResult<DirEntry> {
+        let file = SpecialFsFile::new_regular_with_perm(
+            self.fs.clone(),
+            CgroupFile { id: self.id, kind },
+            kind.permission(),
+        );
+        let reference = Reference::new(self.this.upgrade(), kind.name().to_string());
+        Ok(DirEntry::new_file(
+            FileNode::new(file),
+            NodeType::RegularFile,
+            reference,
+        ))
+    }
+
+    fn child_dir_entry(&self, name: &str, id: CgroupId) -> DirEntry {
+        let maker = Self::new_maker(self.fs.clone(), id);
+        let reference = Reference::new(self.this.upgrade(), name.to_string());
+        DirEntry::new_dir(|this| DirNode::new(maker(this)), reference)
+    }
+}
+
+#[inherit_methods(from = "self.node")]
+impl NodeOps for CgroupDir {
+    fn inode(&self) -> u64;
+
+    fn metadata(&self) -> VfsResult<Metadata>;
+
+    fn update_metadata(&self, update: MetadataUpdate) -> VfsResult<()>;
+
+    fn filesystem(&self) -> &dyn FilesystemOps;
+
+    fn sync(&self, data_only: bool) -> VfsResult<()>;
+
+    fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
+    }
+}
+
+impl DirNodeOps for CgroupDir {
+    fn read_dir(&self, offset: u64, sink: &mut dyn DirEntrySink) -> VfsResult<usize> {
+        let mut names = Vec::new();
+        names.push(DOT.to_string());
+        names.push(DOTDOT.to_string());
+        for kind in CGROUP_FILES {
+            names.push(kind.name().to_string());
+        }
+        names.extend(crate::cgroup::child_names(self.id)?);
+
+        let this_entry = self.this_entry()?;
+        let this_dir = this_entry.as_dir()?;
+        let mut count = 0;
+        for (i, name) in names.iter().enumerate().skip(offset as usize) {
+            let metadata = match name.as_str() {
+                DOT => this_entry.metadata(),
+                DOTDOT => this_entry
+                    .parent()
+                    .map_or_else(|| this_entry.metadata(), |parent| parent.metadata()),
+                other => this_dir.lookup(other)?.metadata(),
+            }?;
+            if !sink.accept(name, metadata.inode, metadata.node_type, i as u64 + 1) {
+                break;
+            }
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    fn lookup(&self, name: &str) -> VfsResult<DirEntry> {
+        if let Some(kind) = CgroupFileKind::from_name(name) {
+            return self.file_entry(kind);
+        }
+
+        let child_id = crate::cgroup::lookup_child(self.id, name)?;
+        Ok(self.child_dir_entry(name, child_id))
+    }
+
+    fn is_cacheable(&self) -> bool {
+        false
+    }
+
+    fn has_children(&self) -> VfsResult<bool> {
+        Ok(!crate::cgroup::child_names(self.id)?.is_empty())
+    }
+
+    fn create(
+        &self,
+        name: &str,
+        node_type: NodeType,
+        _permission: NodePermission,
+    ) -> VfsResult<DirEntry> {
+        if crate::cgroup::is_interface_file_name(name) {
+            return Err(VfsError::AlreadyExists);
+        }
+        if node_type != NodeType::Directory {
+            return Err(VfsError::OperationNotPermitted);
+        }
+
+        let child_id = crate::cgroup::create_child(self.id, name)?;
+        Ok(self.child_dir_entry(name, child_id))
+    }
+
+    fn link(&self, _name: &str, _node: &DirEntry) -> VfsResult<DirEntry> {
+        Err(VfsError::OperationNotPermitted)
+    }
+
+    fn unlink(&self, name: &str) -> VfsResult<()> {
+        if crate::cgroup::is_interface_file_name(name) {
+            return Err(VfsError::OperationNotPermitted);
+        }
+        crate::cgroup::remove_child(self.id, name)
+    }
+
+    fn rename(&self, _src_name: &str, _dst_dir: &DirNode, _dst_name: &str) -> VfsResult<()> {
+        Err(VfsError::OperationNotPermitted)
+    }
+}
+
+/// Creates a cgroup v2 pseudo filesystem backed by the global cgroup hierarchy.
 pub(crate) fn new_cgroup2fs() -> Filesystem {
     SimpleFs::new_with("cgroup2".into(), CGROUP2_SUPER_MAGIC, cgroup2fs_builder)
 }
 
 fn cgroup2fs_builder(fs: Arc<SimpleFs>) -> DirMaker {
-    let mut root = DirMapping::new();
-    root.add(
-        "cgroup.procs",
-        SpecialFsFile::new_regular_with_perm(
-            fs.clone(),
-            RootFile::Procs,
-            NodePermission::from_bits_truncate(0o644),
-        ),
-    );
-    root.add(
-        "cgroup.controllers",
-        SpecialFsFile::new_regular_with_perm(
-            fs.clone(),
-            RootFile::Controllers,
-            NodePermission::from_bits_truncate(0o444),
-        ),
-    );
-    root.add(
-        "cgroup.subtree_control",
-        SpecialFsFile::new_regular_with_perm(
-            fs.clone(),
-            RootFile::SubtreeControl,
-            NodePermission::from_bits_truncate(0o644),
-        ),
-    );
-    SimpleDir::new_maker(fs, Arc::new(root))
+    CgroupDir::new_maker(fs, root_id())
 }

--- a/os/StarryOS/kernel/src/pseudofs/cgroup.rs
+++ b/os/StarryOS/kernel/src/pseudofs/cgroup.rs
@@ -91,7 +91,7 @@ impl DirectRwFsFileOps for CgroupFile {
     fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {
         match self.kind {
             CgroupFileKind::Controllers => {
-                crate::cgroup::controllers_text(self.id)?;
+                crate::cgroup::ensure_node_exists(self.id)?;
                 return Err(VfsError::from(LinuxError::EACCES));
             }
             CgroupFileKind::Procs => crate::cgroup::write_procs(self.id, buf)?,

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c
@@ -46,7 +46,6 @@ static void check_mkdir(const char *path, const char *msg)
     errno = 0;
     int ret = mkdir(path, 0755);
     int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == 0 || saved_errno == EEXIST, msg);
 }
 
@@ -54,8 +53,6 @@ static void expect_mkdir_ok(const char *path, const char *msg)
 {
     errno = 0;
     int ret = mkdir(path, 0755);
-    int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == 0, msg);
 }
 
@@ -64,7 +61,6 @@ static void expect_mkdir_errno(const char *path, int expected_errno, const char 
     errno = 0;
     int ret = mkdir(path, 0755);
     int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == -1 && saved_errno == expected_errno, msg);
 }
 
@@ -72,8 +68,6 @@ static void expect_rmdir_ok(const char *path, const char *msg)
 {
     errno = 0;
     int ret = rmdir(path);
-    int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == 0, msg);
 }
 
@@ -82,7 +76,6 @@ static void expect_rmdir_errno(const char *path, int expected_errno, const char 
     errno = 0;
     int ret = rmdir(path);
     int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == -1 && saved_errno == expected_errno, msg);
 }
 
@@ -115,8 +108,6 @@ static void expect_path_exists(const char *path, const char *msg)
     struct stat st;
     errno = 0;
     int ret = stat(path, &st);
-    int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == 0, msg);
 }
 
@@ -126,7 +117,6 @@ static void expect_path_missing(const char *path, const char *msg)
     errno = 0;
     int ret = stat(path, &st);
     int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == -1 && saved_errno == ENOENT, msg);
 }
 
@@ -158,7 +148,7 @@ static void expect_empty_file(const char *path, const char *msg)
 {
     char buf[16];
     ssize_t nread = read_text_file(path, buf, sizeof(buf));
-    CHECK(nread >= 0 && nread == 0, msg);
+    CHECK(nread == 0, msg);
 }
 
 static int buffer_contains_pid(const char *buf, pid_t pid)
@@ -207,7 +197,6 @@ static void expect_link_errno(const char *old_path, const char *new_path,
     errno = 0;
     int ret = link(old_path, new_path);
     int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == -1 && saved_errno == expected_errno, msg);
 }
 
@@ -217,7 +206,6 @@ static void expect_symlink_errno(const char *target, const char *link_path,
     errno = 0;
     int ret = symlink(target, link_path);
     int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == -1 && saved_errno == expected_errno, msg);
 }
 
@@ -227,7 +215,6 @@ static void expect_rename_errno(const char *old_path, const char *new_path,
     errno = 0;
     int ret = rename(old_path, new_path);
     int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == -1 && saved_errno == expected_errno, msg);
 }
 
@@ -235,8 +222,6 @@ static void expect_chdir_ok(const char *path, const char *msg)
 {
     errno = 0;
     int ret = chdir(path);
-    int saved_errno = errno;
-    errno = saved_errno;
     CHECK(ret == 0, msg);
 }
 

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c
@@ -50,6 +50,86 @@ static void check_mkdir(const char *path, const char *msg)
     CHECK(ret == 0 || saved_errno == EEXIST, msg);
 }
 
+static void expect_mkdir_ok(const char *path, const char *msg)
+{
+    errno = 0;
+    int ret = mkdir(path, 0755);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == 0, msg);
+}
+
+static void expect_mkdir_errno(const char *path, int expected_errno, const char *msg)
+{
+    errno = 0;
+    int ret = mkdir(path, 0755);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == -1 && saved_errno == expected_errno, msg);
+}
+
+static void expect_rmdir_ok(const char *path, const char *msg)
+{
+    errno = 0;
+    int ret = rmdir(path);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == 0, msg);
+}
+
+static void expect_rmdir_errno(const char *path, int expected_errno, const char *msg)
+{
+    errno = 0;
+    int ret = rmdir(path);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == -1 && saved_errno == expected_errno, msg);
+}
+
+static void expect_open_create_errno(const char *path, int expected_errno, const char *msg)
+{
+    errno = 0;
+    int fd = open(path, O_CREAT | O_WRONLY, 0644);
+    int saved_errno = errno;
+    if (fd >= 0) {
+        close(fd);
+    }
+    errno = saved_errno;
+    CHECK(fd == -1 && saved_errno == expected_errno, msg);
+}
+
+static void expect_open_dir_errno(const char *path, int expected_errno, const char *msg)
+{
+    errno = 0;
+    int fd = open(path, O_RDONLY | O_DIRECTORY);
+    int saved_errno = errno;
+    if (fd >= 0) {
+        close(fd);
+    }
+    errno = saved_errno;
+    CHECK(fd == -1 && saved_errno == expected_errno, msg);
+}
+
+static void expect_path_exists(const char *path, const char *msg)
+{
+    struct stat st;
+    errno = 0;
+    int ret = stat(path, &st);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == 0, msg);
+}
+
+static void expect_path_missing(const char *path, const char *msg)
+{
+    struct stat st;
+    errno = 0;
+    int ret = stat(path, &st);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == -1 && saved_errno == ENOENT, msg);
+}
+
 static ssize_t read_text_file(const char *path, char *buf, size_t cap)
 {
     if (cap == 0) {
@@ -72,6 +152,13 @@ static ssize_t read_text_file(const char *path, char *buf, size_t cap)
     close(fd);
     errno = saved_errno;
     return nread;
+}
+
+static void expect_empty_file(const char *path, const char *msg)
+{
+    char buf[16];
+    ssize_t nread = read_text_file(path, buf, sizeof(buf));
+    CHECK(nread >= 0 && nread == 0, msg);
 }
 
 static int buffer_contains_pid(const char *buf, pid_t pid)
@@ -114,6 +201,45 @@ static void expect_write_errno(const char *path, const char *data,
     CHECK(written == -1 && saved_errno == expected_errno, msg);
 }
 
+static void expect_link_errno(const char *old_path, const char *new_path,
+                              int expected_errno, const char *msg)
+{
+    errno = 0;
+    int ret = link(old_path, new_path);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == -1 && saved_errno == expected_errno, msg);
+}
+
+static void expect_symlink_errno(const char *target, const char *link_path,
+                                 int expected_errno, const char *msg)
+{
+    errno = 0;
+    int ret = symlink(target, link_path);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == -1 && saved_errno == expected_errno, msg);
+}
+
+static void expect_rename_errno(const char *old_path, const char *new_path,
+                                int expected_errno, const char *msg)
+{
+    errno = 0;
+    int ret = rename(old_path, new_path);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == -1 && saved_errno == expected_errno, msg);
+}
+
+static void expect_chdir_ok(const char *path, const char *msg)
+{
+    errno = 0;
+    int ret = chdir(path);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(ret == 0, msg);
+}
+
 int main(void)
 {
     TEST_START("cgroup-basic");
@@ -153,6 +279,56 @@ int main(void)
 
     expect_write_errno(CGROUP2_PATH "/cgroup.subtree_control", "+pids",
                        EINVAL, "writing +pids to subtree_control fails with EINVAL");
+
+    expect_mkdir_ok(CGROUP2_PATH "/a", "mkdir child cgroup a succeeds");
+    expect_path_exists(CGROUP2_PATH "/a", "child cgroup a exists");
+    expect_empty_file(CGROUP2_PATH "/a/cgroup.procs",
+                      "child cgroup.procs is empty before migration exists");
+    expect_empty_file(CGROUP2_PATH "/a/cgroup.controllers",
+                      "child cgroup.controllers is empty before controllers exist");
+    expect_empty_file(CGROUP2_PATH "/a/cgroup.subtree_control",
+                      "child cgroup.subtree_control is initially empty");
+    expect_mkdir_errno(CGROUP2_PATH "/a", EEXIST,
+                       "duplicate mkdir child cgroup fails with EEXIST");
+
+    expect_mkdir_ok(CGROUP2_PATH "/a/b", "mkdir nested child cgroup succeeds");
+    expect_rmdir_errno(CGROUP2_PATH "/a", ENOTEMPTY,
+                       "rmdir cgroup with child fails with ENOTEMPTY");
+    expect_path_exists(CGROUP2_PATH "/a", "parent cgroup remains after failed rmdir");
+    expect_path_exists(CGROUP2_PATH "/a/b", "child cgroup remains after failed parent rmdir");
+    expect_rmdir_ok(CGROUP2_PATH "/a/b", "rmdir empty nested cgroup succeeds");
+    expect_path_missing(CGROUP2_PATH "/a/b", "removed nested cgroup is missing");
+    expect_rmdir_ok(CGROUP2_PATH "/a", "rmdir empty child cgroup succeeds");
+    expect_path_missing(CGROUP2_PATH "/a", "removed child cgroup is missing");
+
+    expect_mkdir_ok(CGROUP2_PATH "/cwd-cache", "mkdir cgroup for cwd cache regression");
+    expect_chdir_ok(CGROUP2_PATH "/cwd-cache", "chdir into cgroup for cwd cache regression");
+    expect_mkdir_ok("b", "relative mkdir child cgroup from cwd succeeds");
+    expect_rmdir_ok(CGROUP2_PATH "/cwd-cache/b",
+                    "absolute rmdir removes child created from cwd");
+    expect_open_dir_errno("b", ENOENT,
+                          "relative open after absolute rmdir does not return stale cgroup");
+    expect_chdir_ok("/", "restore cwd after cwd cache regression");
+    expect_rmdir_ok(CGROUP2_PATH "/cwd-cache", "cleanup cwd cache regression cgroup");
+
+    expect_open_create_errno(CGROUP2_PATH "/user.file", EPERM,
+                             "open O_CREAT regular file in cgroupfs fails with EPERM");
+    expect_path_missing(CGROUP2_PATH "/user.file",
+                        "failed open O_CREAT leaves no regular file");
+    expect_link_errno(CGROUP2_PATH "/cgroup.procs", CGROUP2_PATH "/procs.link",
+                      EPERM, "hard link in cgroupfs fails with EPERM");
+    expect_path_missing(CGROUP2_PATH "/procs.link",
+                        "failed hard link leaves no new path");
+    expect_symlink_errno("x", CGROUP2_PATH "/sym", EPERM,
+                         "symlink in cgroupfs fails with EPERM");
+    expect_path_missing(CGROUP2_PATH "/sym", "failed symlink leaves no new path");
+
+    expect_mkdir_ok(CGROUP2_PATH "/ren", "mkdir cgroup for rename negative test succeeds");
+    expect_rename_errno(CGROUP2_PATH "/ren", CGROUP2_PATH "/renamed", EPERM,
+                        "rename cgroup directory fails with EPERM");
+    expect_path_exists(CGROUP2_PATH "/ren", "rename failure keeps original cgroup");
+    expect_path_missing(CGROUP2_PATH "/renamed", "rename failure leaves destination missing");
+    expect_rmdir_ok(CGROUP2_PATH "/ren", "cleanup rename negative test cgroup");
 
     check_mkdir(CGROUP_V1_PATH, "mkdir cgroup v1 mountpoint");
 


### PR DESCRIPTION

## 背景

本PR继续前置PR #989 做cgroup支持工作，工作进度持续更新在 #582 中。

当前 cgroup2 支持停留在 root 基础接口文件阶段，缺少 child cgroup 的创建、查找和删除能力，用户态无法通过 `mkdir` / `rmdir` 维护 cgroup v2 层级。本轮实现 Slice 2 的 hierarchy 基础能力，为后续 `cgroup.procs` 迁移、membership、`/proc/[pid]/cgroup` 等工作铺路。

## 变更内容

- `os/StarryOS/kernel/src/cgroup/mod.rs`
  - 新增全局 cgroup tree，维护 cgroup id、父子关系、child 名称映射和后续 membership 删除保护预留字段。
  - 新增 root id、child names、child lookup、create child、remove child、path 等 hierarchy API。
  - `create_child()` 支持创建 child cgroup，重复创建返回 `EEXIST`，interface file 名称冲突返回 `EEXIST`。
  - `remove_child()` 支持删除空 child cgroup，目录含 child 时返回 `ENOTEMPTY`，预留 populated cgroup 的 `EBUSY` 检查。
  - `cgroup.procs` root 读取当前进程表，排序后按每行一个 PID 输出；非 root 暂返回空内容。
  - `cgroup.controllers` 和 `cgroup.subtree_control` 当前返回空内容。
  - `cgroup.procs` 写入暂返回 `EOPNOTSUPP`，`cgroup.subtree_control` 写入暂返回 `EINVAL`。

- `os/StarryOS/kernel/src/pseudofs/cgroup.rs`
  - 将 cgroup2fs 从静态 `SimpleDir + DirMapping` 改为动态 `CgroupDir`。
  - 每个 cgroup 目录动态注册 `cgroup.procs`、`cgroup.controllers`、`cgroup.subtree_control`。
  - 目录 `lookup`、`mkdir`、`rmdir` 统一通过全局 cgroup tree 处理，支持 child/nested cgroup hierarchy。
  - `read_dir()` 返回 `.`、`..`、三个 interface files 和当前 cgroup 的 child cgroup 列表。
  - `CgroupDir::is_cacheable()` 返回 `false`，避免动态目录使用 per-instance dentry cache。
  - `has_children()` 只统计真实 child cgroup，避免 interface files 阻塞空目录 `rmdir`。
  - 普通文件创建、hard link、symlink、rename 和 interface file 删除返回 `EPERM`。

- `components/axfs-ng-vfs/src/node/dir.rs`
  - 在 `DirNodeOps` 新增默认 `has_children()` hook，保留普通文件系统原有目录非空判断。
  - `DirNode::has_children()` 改为调用后端 hook，允许 cgroup2fs 自定义 rmdir 空目录语义。
  - `lookup_locked()` 对 non-cacheable 目录直接调用后端 `lookup()`，不读取旧 cache。
  - `create()` 和 `link()` 只在 cacheable 目录填充 per-instance cache，避免跨句柄删除后的 stale child dentry。

- `test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c`
  - 扩展 `cgroup-basic`，覆盖 cgroup2 hierarchy 的创建、查找、删除、错误码和失败无副作用。
  - 新增 cwd stale dentry 回归场景，覆盖相对 `mkdir`、绝对 `rmdir`、相对 `open("b", O_DIRECTORY)` 返回 `ENOENT`。

## 测试用例

`cgroup-basic` 本轮新增和扩展的覆盖点：

- child cgroup 创建成功，`stat` 可见，child 目录下三个基础 interface files 可读取。
- nested child cgroup 创建成功。
- 重复 `mkdir` 同名 cgroup 返回 `EEXIST`。
- parent 存在 child 时 `rmdir parent` 返回 `ENOTEMPTY`，parent 和 child 均保留。
- empty nested/child cgroup `rmdir` 成功，删除后 lookup/stat 返回 `ENOENT`。
- cwd 持有 cgroup 目录句柄时，相对 `mkdir b` 后经绝对路径删除，再相对 `open("b", O_DIRECTORY)` 返回 `ENOENT`，防止 stale dentry。
- cgroupfs 内 `open(O_CREAT)` 创建普通文件返回 `EPERM`，失败后目标路径不存在。
- hard link 和 symlink 返回 `EPERM`，失败后目标路径不存在。
- cgroup 目录 rename 返回 `EPERM`，失败后原路径保留、目标路径不存在。
- cgroup v1 mount 仍返回 `ENODEV`，确认本轮只接入 cgroup2。

## 实现逻辑

cgroup core 只维护内存中的 hierarchy 元数据，cgroup2fs 负责把 VFS 操作映射到 core API。这样后续 Slice 3 可以在 core 层扩展 membership，而不需要把进程归属状态散落在 pseudo fs 节点里。

`CgroupDir::is_cacheable()` 继续返回 `false`。同时 VFS 层修正为真正绕过 per-instance cache：`lookup_locked()` 对 non-cacheable 目录直接进入后端，`create()` 和 `link()` 也不会把结果写入 cache。这样不同路径、不同 mount 或 cwd 持有的目录句柄都以全局 cgroup tree 为准。

`has_children()` 默认实现仍保持普通文件系统原语义；cgroup2fs 覆盖该 hook，只检查 child cgroup 列表，因此 root/child 目录中的 `cgroup.procs`、`cgroup.controllers`、`cgroup.subtree_control` 不会阻塞 `rmdir`。

## 验证

以下命令均在 Docker 容器内执行：

```text
cargo fmt
cargo xtask clippy --package axfs-ng-vfs
cargo xtask clippy --package starry-kernel
cargo xtask starry test qemu --arch x86_64 -g normal -c cgroup-basic
cargo xtask starry test qemu --arch aarch64 -g normal -c cgroup-basic
cargo xtask starry test qemu --arch riscv64 -g normal -c cgroup-basic
cargo xtask starry test qemu --arch loongarch64 -g normal -c cgroup-basic
```

结果：

```text
x86_64:      DONE: 43 pass, 0 fail, result: 1/1 case(s) passed
aarch64:     DONE: 43 pass, 0 fail, result: 1/1 case(s) passed
riscv64:     DONE: 43 pass, 0 fail, result: 1/1 case(s) passed
loongarch64: DONE: 43 pass, 0 fail, result: 1/1 case(s) passed
```

## 说明
- loongarch64 普通 build 仍会打印既有 `kprobe` selftest dead-code warnings，与本次 cgroup 改动无关。
- 在容器内进行构建后，会修改cargo.lock文件，更新spin crate的版本，本PR将其视作噪声没有加入提交。

## 未覆盖和后续

- 尚未实现 per-process cgroup membership，非 root `cgroup.procs` 暂为空。
- 尚未实现 `cgroup.procs` 迁移、fork/exit membership 继承和清理。
- 尚未实现 `/proc/[pid]/cgroup`。
- 尚未实现 controller 注册和 controller interface files。
- populated non-root cgroup 的 `rmdir -> EBUSY` 预留在 core 字段中，用户态覆盖放到后续 slice。
