### PR TITLE
fix(repo): normalize allocator and RISC-V dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
  "cfg-if",
  "log",
  "loongArch64",
- "riscv 0.16.0",
+ "riscv",
  "tock-registers 0.10.1",
  "x86",
  "x86_64",
@@ -1177,7 +1177,7 @@ name = "ax-lockdep"
 version = "0.1.1"
 dependencies = [
  "ax-crate-interface",
- "sbi-rt 0.0.3",
+ "sbi-rt",
 ]
 
 [[package]]
@@ -1286,7 +1286,7 @@ dependencies = [
  "bitmaps",
  "log",
  "rand 0.10.1",
- "riscv 0.16.0",
+ "riscv",
  "x86",
 ]
 
@@ -1443,9 +1443,9 @@ dependencies = [
  "axklib",
  "log",
  "mmio-api",
- "riscv 0.16.0",
+ "riscv",
  "riscv_goldfish",
- "sbi-rt 0.0.3",
+ "sbi-rt",
  "some-serial",
 ]
 
@@ -1463,8 +1463,8 @@ dependencies = [
  "axklib",
  "log",
  "rdif-block",
- "riscv 0.16.0",
- "sbi-rt 0.0.3",
+ "riscv",
+ "sbi-rt",
  "sg200x-bsp",
  "some-serial",
  "spin 0.12.0",
@@ -1483,9 +1483,9 @@ dependencies = [
  "axklib",
  "log",
  "rdrive",
- "riscv 0.14.0",
+ "riscv",
  "riscv_goldfish",
- "sbi-rt 0.0.3",
+ "sbi-rt",
  "uart_16550 0.4.0",
 ]
 
@@ -5894,6 +5894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pci_types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6904,40 +6910,13 @@ dependencies = [
 
 [[package]]
 name = "riscv"
-version = "0.14.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1671c79a01a149fe000af2429ce9ccc8e58cdecda72672355d50e5536b363c"
+checksum = "e42cdafa0aa3f0f956b7993cace26de5dafff7bb4f2c5b1dcb2c3723f4267a4f"
 dependencies = [
  "critical-section",
  "embedded-hal",
- "paste",
- "riscv-macros 0.2.0",
- "riscv-pac",
-]
-
-[[package]]
-name = "riscv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05cfa3f7b30c84536a9025150d44d26b8e1cc20ddf436448d74cd9591eefb25"
-dependencies = [
- "critical-section",
- "embedded-hal",
- "paste",
- "riscv-macros 0.3.0",
- "riscv-pac",
-]
-
-[[package]]
-name = "riscv"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9251433e48c39d2133cbaff3ae7809ce6a1ecbc8225ca7da33d96d10cf360582"
-dependencies = [
- "critical-section",
- "embedded-hal",
- "paste",
- "riscv-macros 0.4.0",
+ "pastey",
  "riscv-types",
 ]
 
@@ -6955,47 +6934,8 @@ dependencies = [
  "bit_field",
  "bitflags 2.11.1",
  "log",
- "riscv 0.14.0",
+ "riscv",
 ]
-
-[[package]]
-name = "riscv-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c4aa1ea1af6dcc83a61be12e8189f9b293c3ba5a487778a4cd89fb060fdbbc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "riscv-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "riscv-macros"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47d1fb716349455b8e5e3ebbf1eff95344dbdf9f782a4e1359d2f16f51e3dce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "riscv-pac"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
 name = "riscv-types"
@@ -7025,12 +6965,12 @@ dependencies = [
  "cfg-if",
  "log",
  "memoffset",
- "riscv 0.14.0",
+ "riscv",
  "riscv-decode",
  "riscv-h",
  "rustsbi",
- "sbi-rt 0.0.4",
- "sbi-spec 0.0.9",
+ "sbi-rt",
+ "sbi-spec",
  "tock-registers 0.10.1",
 ]
 
@@ -7310,8 +7250,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da89e7936845ca69a9c12307862828180f10e55cc3b313ace4a0efee5f20622"
 dependencies = [
  "rustsbi-macros",
- "sbi-rt 0.0.4",
- "sbi-spec 0.0.9",
+ "sbi-rt",
+ "sbi-spec",
 ]
 
 [[package]]
@@ -7366,27 +7306,12 @@ dependencies = [
 
 [[package]]
 name = "sbi-rt"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbaa69be1eedc61c426e6d489b2260482e928b465360576900d52d496a58bd0"
-dependencies = [
- "sbi-spec 0.0.7",
-]
-
-[[package]]
-name = "sbi-rt"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f7bf85822c8b453d7e3fca7de39684032f5c06c1ed338ad8d47f4a79c1d49a"
 dependencies = [
- "sbi-spec 0.0.9",
+ "sbi-spec",
 ]
-
-[[package]]
-name = "sbi-spec"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
 name = "sbi-spec"
@@ -7903,7 +7828,7 @@ dependencies = [
  "quote",
  "ranges-ext",
  "rgb",
- "sbi-rt 0.0.3",
+ "sbi-rt",
  "smccc",
  "some-serial",
  "somehal-macros",
@@ -7930,8 +7855,8 @@ dependencies = [
  "page-table-generic",
  "rdif-intc",
  "rdrive",
- "riscv 0.15.0",
- "sbi-rt 0.0.3",
+ "riscv",
+ "sbi-rt",
  "someboot",
  "somehal-macros",
  "spin 0.12.0",
@@ -8059,7 +7984,7 @@ dependencies = [
  "rand 0.10.1",
  "rdrive",
  "ringbuf",
- "riscv 0.16.0",
+ "riscv",
  "scope-local",
  "sg2002-tpu",
  "sg200x-bsp",
@@ -9087,9 +9012,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.36.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe9058b73ee2b6559524af9e33199c13b2485ddbf3ad1181b68051cdc50c17"
+checksum = "66ab9569afdd1e33a31d8002343aa1df594f055347b1a66136bf9dd6cbc3ec37"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -9114,9 +9039,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f64fe59e11af447d12fd60a403c74106eb104309f34b4c6dbce6e927d97da9d"
+checksum = "f3775e5934877acaef4b00f254f252df1e2266903c31e51455c117f4f2824eda"
 dependencies = [
  "bitflags 2.11.1",
  "uguid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,7 +348,9 @@ lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = "0.12"
 ostool = { version = "0.21" }
-uefi = "0.36"
+riscv = { version = "0.16.1", default-features = false }
+sbi-rt = { version = "0.0.4", default-features = false }
+uefi = "0.37.0"
 fdt-edit = "0.2.3"
 fdt-raw = "0.3"
 thiserror = { version = "2", default-features = false }

--- a/components/axcpu/Cargo.toml
+++ b/components/axcpu/Cargo.toml
@@ -48,7 +48,7 @@ aarch64-cpu = "11.0"
 tock-registers = "0.10"
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
-riscv = "0.16"
+riscv.workspace = true
 
 [target.'cfg(target_arch = "loongarch64")'.dependencies]
 loongArch64 = "0.2"

--- a/components/lockdep/Cargo.toml
+++ b/components/lockdep/Cargo.toml
@@ -14,4 +14,4 @@ task-context = []
 ax-crate-interface = { workspace = true }
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
-sbi-rt = { version = "0.0.3", features = ["legacy"] }
+sbi-rt = { workspace = true, features = ["legacy"] }

--- a/components/someboot/Cargo.toml
+++ b/components/someboot/Cargo.toml
@@ -61,7 +61,7 @@ uefi.workspace = true
 x86 = "0.52"
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
-sbi-rt = { version = "0.0.3", features = ["legacy"] }
+sbi-rt = { workspace = true, features = ["legacy"] }
 
 [build-dependencies]
 prettyplease = "0.2"

--- a/memory/page_table_multiarch/Cargo.toml
+++ b/memory/page_table_multiarch/Cargo.toml
@@ -26,7 +26,7 @@ ax-page-table-entry.workspace = true
 x86 = "0.52"
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64", doc, docsrs))'.dependencies]
-riscv = { version = "0.16", default-features = false }
+riscv.workspace = true
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -144,7 +144,7 @@ ksym = "0.6"
 x86 = "0.52"
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
-riscv = "0.16"
+riscv.workspace = true
 
 [target.'cfg(not(any(target_arch = "aarch64", target_arch = "loongarch64")))'.dependencies]
 ax-page-table-multiarch = { workspace = true, features = ["copy-from"] }

--- a/os/arceos/modules/axalloc/build.rs
+++ b/os/arceos/modules/axalloc/build.rs
@@ -4,13 +4,9 @@ fn main() {
 
     let tlsf = std::env::var("CARGO_FEATURE_TLSF").is_ok();
     let buddy_slab = std::env::var("CARGO_FEATURE_BUDDY_SLAB").is_ok();
-    if tlsf && buddy_slab {
-        panic!("Features \"tlsf\" and \"buddy-slab\" are mutually exclusive");
-    }
     if tlsf {
         println!("cargo:rustc-cfg=tlsf");
-    }
-    if buddy_slab {
+    } else if buddy_slab {
         println!("cargo:rustc-cfg=buddy_slab");
     }
 }

--- a/platforms/ax-plat-riscv64-qemu-virt/Cargo.toml
+++ b/platforms/ax-plat-riscv64-qemu-virt/Cargo.toml
@@ -21,10 +21,10 @@ smp = ["ax-plat/smp"]
 ax-kspin = { workspace = true }
 ax-lazyinit = { workspace = true }
 log = "0.4"
-riscv = "0.16"
+riscv.workspace = true
 riscv_goldfish = { version = "0.1", optional = true }
 ax-riscv-plic = { workspace = true, optional = true }
-sbi-rt = { version = "0.0.3", features = ["legacy"] }
+sbi-rt = { workspace = true, features = ["legacy"] }
 some-serial.workspace = true
 
 ax-config-macros = { workspace = true }

--- a/platforms/ax-plat-riscv64-sg2002/Cargo.toml
+++ b/platforms/ax-plat-riscv64-sg2002/Cargo.toml
@@ -36,8 +36,8 @@ spin.workspace = true
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 ax-riscv-plic = { workspace = true, optional = true }
-riscv = "0.16"
-sbi-rt = { version = "0.0.3", features = ["legacy"] }
+riscv.workspace = true
+sbi-rt = { workspace = true, features = ["legacy"] }
 
 [package.metadata.axplat]
 platform = "riscv64-sg2002"

--- a/platforms/ax-plat-riscv64-visionfive2/Cargo.toml
+++ b/platforms/ax-plat-riscv64-visionfive2/Cargo.toml
@@ -25,9 +25,9 @@ axklib = { workspace = true, features = ["tlsf"] }
 rdrive.workspace = true
 ax-riscv-plic = { workspace = true, optional = true }
 log = "0.4"
-riscv = "0.14"
+riscv.workspace = true
 riscv_goldfish = { version = "0.1", optional = true }
-sbi-rt = { version = "0.0.3", features = ["legacy"] }
+sbi-rt = { workspace = true, features = ["legacy"] }
 uart_16550 = "0.4.0"
 
 [package.metadata.axplat]

--- a/platforms/somehal/Cargo.toml
+++ b/platforms/somehal/Cargo.toml
@@ -38,5 +38,5 @@ arm-gic-driver = {workspace = true, features = ["rdif"]}
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 ax-riscv-plic = { workspace = true }
-riscv = "0.15"
-sbi-rt = { version = "0.0.3", features = ["legacy"] }
+riscv.workspace = true
+sbi-rt = { workspace = true, features = ["legacy"] }

--- a/virtualization/riscv-h/Cargo.toml
+++ b/virtualization/riscv-h/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["riscv", "hypervisor"]
 license = "Apache-2.0"
 
 [dependencies]
-riscv = { version = "0.14.0"}
+riscv.workspace = true
 bare-metal = "1.0"
 bitflags = "2.9.0"
 bit_field = "0.10.0"

--- a/virtualization/riscv_vcpu/Cargo.toml
+++ b/virtualization/riscv_vcpu/Cargo.toml
@@ -28,11 +28,11 @@ cfg-if = "1.0"
 bitflags = "2.2"
 bit_field = "0.10"
 ax-crate-interface = { workspace = true }
-riscv = { version = "0.14.0", features = ["s-mode"] }
+riscv = { workspace = true, features = ["s-mode"] }
 riscv-h = { workspace = true }
 riscv-decode = "0.2.3"
 rustsbi = { version = "0.4.0", features = ["forward"] }
-sbi-rt = { version = "0.0.4", features = ["integer-impls"] }
+sbi-rt = { workspace = true, features = ["integer-impls"] }
 sbi-spec = { version = "0.0.9", features = ["legacy"] }
 tock-registers = "0.10"
 memoffset = { version = ">=0.6.5", features = ["unstable_const"] }


### PR DESCRIPTION
## 问题

当前分支处理两个相关的构建/依赖问题：

- `rust-analyzer` 在 workspace feature union 场景下可能同时启用 `ax-alloc` 的 `tlsf` 和 `buddy-slab`，导致 build script 因互斥检查 panic，进而无法获取 build data。
- RISC-V、SBI、UEFI 相关外部依赖散落在多个本地 `Cargo.toml` 中，版本不一致，不利于统一升级和 feature 语义维护。

## 变更

- 调整 `ax-alloc` build script：当 `tlsf` 和 `buddy-slab` 同时启用时不再 panic，而是优先选择 `tlsf`；只启用 `buddy-slab` 时仍选择 `buddy_slab`，两者都不启用时继续走现有 stub 路径。
- 在根 `Cargo.toml` 的 `[workspace.dependencies]` 中统一声明：
  - `riscv = { version = "0.16.1", default-features = false }`
  - `sbi-rt = { version = "0.0.4", default-features = false }`
  - `uefi = "0.37.0"`
- 将本地 crate 中直接写版本的 `riscv` / `sbi-rt` 依赖改为 workspace 依赖。
- 保留原有 feature 语义：
  - `sbi-rt` 的 `legacy`
  - `riscv_vcpu` 的 `riscv` `s-mode`
  - `riscv_vcpu` 的 `sbi-rt` `integer-impls`
- 更新 `Cargo.lock`，确保 `riscv`、`sbi-rt`、`uefi` 解析到统一版本。

## 方案逻辑

`ax-alloc` 的实现选择本来依赖 build script 输出的 cfg，因此只需要在 build script 中把互斥 panic 改为稳定优先级选择即可，不需要改 `src/lib.rs` 的模块选择逻辑。这样可以兼容 rust-analyzer 的 workspace feature union，同时不改变单平台实际构建时的 allocator 后端选择。

依赖部分集中到 workspace 后，各 crate 继续通过本地 features 表达调用点需求，避免在升级版本的同时丢失 `legacy` SBI console、`integer-impls` 和 `s-mode` 等语义。

## 验证

已执行：

- `cargo check -p ax-alloc --features tlsf,buddy-slab --message-format=short`
- `cargo check -p ax-alloc --features buddy-slab --message-format=short`
- `cargo check -p ax-alloc --features tlsf --message-format=short`
- `cargo tree -i sbi-rt --target riscv64gc-unknown-none-elf -e features`
- `cargo tree -i riscv --target riscv64gc-unknown-none-elf -e features`
- `cargo tree -i uefi -e features`
- `cargo check -p ax-plat-riscv64-qemu-virt --target riscv64gc-unknown-none-elf --message-format=short`
- `cargo check -p ax-plat-riscv64-sg2002 --target riscv64gc-unknown-none-elf --message-format=short`
- `cargo check -p ax-plat-riscv64-visionfive2 --target riscv64gc-unknown-none-elf --message-format=short`
- `cargo check -p somehal --target riscv64gc-unknown-none-elf --message-format=short`
- `cargo check -p someboot --target riscv64gc-unknown-none-elf --message-format=short`
- `cargo check -p riscv_vcpu --target riscv64gc-unknown-none-elf --message-format=short`
- `cargo fmt --all --check`
- `cargo xtask clippy --package ax-plat-riscv64-qemu-virt --package ax-plat-riscv64-sg2002 --package ax-plat-riscv64-visionfive2 --package somehal --package someboot --package riscv_vcpu`
- `git diff --check`

补充说明：`cargo check -p someboot --target x86_64-unknown-uefi --features efi --message-format=short` 在本机因未安装 `x86_64-unknown-uefi` target 停在 `can't find crate for core`，当前环境只安装了 `riscv64gc-unknown-none-elf`。