### PR TITLE
fix(axbuild): use target spec stem as rustflags config key

### DIFF
--- a/scripts/axbuild/src/build.rs
+++ b/scripts/axbuild/src/build.rs
@@ -426,6 +426,14 @@ impl BuildInfo {
         ];
 
         if !extra_rustflags.is_empty() {
+            // Cargo resolves `target.<name>.rustflags` for a JSON target spec by the
+            // spec file *stem* (e.g. `x86_64-unknown-none`), not the path passed to
+            // `--target`. Using the full path as the key makes cargo silently drop the
+            // entry, so flags like `-Cforce-frame-pointers=yes` never reach rustc.
+            let target_key = Path::new(target)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or(target);
             args.push("--config".to_string());
             let rustflags_toml = toml::Value::Array(
                 extra_rustflags
@@ -435,7 +443,7 @@ impl BuildInfo {
                     .collect(),
             )
             .to_string();
-            args.push(format!("target.'{target}'.rustflags={rustflags_toml}"));
+            args.push(format!("target.{target_key}.rustflags={rustflags_toml}"));
         }
         args
     }
@@ -1458,20 +1466,25 @@ mod tests {
     }
 
     #[test]
-    fn build_cargo_args_quotes_json_target_rustflags_key() {
+    fn build_cargo_args_uses_target_stem_as_rustflags_key() {
         let args = BuildInfo::build_cargo_args(
             "scripts/targets/no-pie/aarch64-unknown-none-softfloat.json",
-            &["-Cdebuginfo=2".to_string()],
+            &["-Cforce-frame-pointers=yes".to_string()],
         );
 
+        // Cargo matches the JSON target by file stem, so the config key must be the
+        // stem (`aarch64-unknown-none-softfloat`) and not the full spec path.
         assert!(args.windows(2).any(|pair| {
             pair[0] == "--config"
-                && pair[1].starts_with(
-                    "target.'scripts/targets/no-pie/aarch64-unknown-none-softfloat.json'.\
-                     rustflags=",
-                )
-                && pair[1].contains("\"-Cdebuginfo=2\"")
+                && pair[1].starts_with("target.aarch64-unknown-none-softfloat.rustflags=")
+                && pair[1].contains("\"-Cforce-frame-pointers=yes\"")
         }));
+        assert!(
+            !args
+                .iter()
+                .any(|arg| arg.contains("scripts/targets/no-pie")),
+            "config key must not use the spec path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #146

### Summary（做了什么 / 为什么）

#839 把 ArceOS/StarryOS 内核构建从 Rust 内置 target triple 改为自定义 JSON
target spec（`scripts/targets/{no-pie,pie}/*.json`）之后，per-target 的
`--config target.<key>.rustflags=[...]` 注入**静默失效**：`-Cforce-frame-pointers=yes`
（`BACKTRACE=y` / `DWARF=y` 时注入）再也没有到达 rustc，基于帧指针的 backtrace
退化为只能展开一帧。

根因：对 JSON target spec，cargo 解析 `target.<name>.rustflags` 时，`<name>`
取的是 **spec 文件的 stem**（如 `x86_64-unknown-none`），不是传给 `--target`
的路径。#839 把 `--config` 的 key 写成了 spec **路径串**
（`target.'scripts/targets/no-pie/x86_64-unknown-none.json'.rustflags`），永远
匹配不上 cargo 实际查找的 stem，于是该条目被 cargo 直接丢弃且不报警。

修复：在 `BuildInfo::build_cargo_args` 中从 spec 文件 stem 派生 config key
（恰好等于原 triple），与 cargo 的实际解析一致。修复保持**条件性**——只有
`[env]` 含 `BACKTRACE=y` 或 `DWARF=y` 的构建配置才会产生非空 rustflags，普通
用例（fs/shell、net 等）不受影响，也不会平白占用帧指针寄存器。

本 PR 仅改 rustflags 的 **key 派生方式**：不修改任何 JSON spec，不无条件开启
任何 flag。

### 关键改动

`scripts/axbuild/src/build.rs` — `build_cargo_args`：从 `Path::new(target).file_stem()`
得到 key，再拼 `target.<stem>.rustflags=[...]`（原先用的是完整 spec 路径）。
单测更新为 `build_cargo_args_uses_target_stem_as_rustflags_key`，断言 key 为
stem 且不含 spec 路径。

### Test plan（本地可复制命令 + 期望输出）

```bash
# 容器
docker start tgoskits-dev
docker exec -it -w /workspace tgoskits-dev bash

# 单测
cargo test -p axbuild build_cargo_args
# 期望：build_cargo_args_uses_target_stem_as_rustflags_key 等用例 PASS

# E2E（x86_64）
cargo xtask arceos test qemu --arch x86_64 --test-group rust --test-case backtrace-raw-normal
```

E2E 期望输出（修复前 vs 修复后）：

- 修复前：`BACKTRACE_BEGIN` 内只有 `BT 0 ip=0x4 fp=0xffffffffffffffff`（单帧、垃圾值）。
- 修复后：`BT 0..7` 多帧，`ip` 非 0、`fp` 链单调，末帧 `ip=0x0 fp=0x0` 收尾；
  随后出现 `=== host backtrace symbolize ===`，函数名为
  `arceos_backtrace_raw_normal::b/a` → `main` → `ax_runtime::ax_app_entry`
  → `__axplat_main` → `ax_plat::call_main` → `ax_plat_x86_pc::rust_entry`
  （`DWARF=y` 用例还带 `main.rs:34/41/48` 文件行号）。

建议另跑 aarch64 / riscv64 / loongarch64 各一遍 `backtrace-raw-normal` 确认跨架构一致。

### Risk / rollback

- 风险低：只改 config key 的字符串派生，行为对齐 cargo 既有解析；非 backtrace
  用例 `extra_rustflags` 为空，完全不加 `--config`，构建产物不变。
- 回滚：还原 `build.rs` 一处 `format!` 即可。

### 备注

- 与本改动无关的预存 clippy 失败：`scripts/axbuild/src/arceos/cbuild.rs:409`
  (`items-after-test-module`)，不在本 PR diff 内，建议单独清理。
- 后续可考虑把「保留 debuginfo 给 host symbolize」与 `DWARF`（内核内 gimli）
  解耦，便于 raw 用例在不开 target dwarf 的情况下也拿到 host 侧文件行号。
