### PR TITLE
chore(ci): bump Rust toolchain to nightly-2026-05-28 and fix clippy

### DIFF
--- a/components/rsext4/src/loopfile.rs
+++ b/components/rsext4/src/loopfile.rs
@@ -180,12 +180,12 @@ pub fn get_file_inode<B: BlockDevice>(
                 let blocks = resolve_inode_block_allextend(fs, block_dev, &mut current_inode)?;
                 debug!(
                     "Directory inode size: {} bytes, blocks used: {}",
-                    &total_size,
-                    &blocks.len()
+                    total_size,
+                    blocks.len()
                 );
 
                 for (idx, phys) in blocks.iter().enumerate() {
-                    debug!("Scan dir block idx {} phys {}", &idx, phys.1);
+                    debug!("Scan dir block idx {} phys {}", idx, phys.1);
                     let cached_block = fs.datablock_cache.get_or_load(block_dev, *phys.1)?;
                     let block_data = &cached_block.data[..block_bytes];
 

--- a/components/rsext4/src/tool.rs
+++ b/components/rsext4/src/tool.rs
@@ -41,7 +41,7 @@ pub fn generate_uuid_8() -> [u8; 16] {
 }
 
 pub fn debug_super_and_desc(superblock: &Ext4Superblock, fs: &Ext4FileSystem) {
-    debug!("Superblock info: {:?}", &superblock);
+    debug!("Superblock info: {:?}", superblock);
     debug!("Block group descriptors:");
     let desc = &fs.group_descs;
     for gid in desc {

--- a/memory/memory_set/src/set.rs
+++ b/memory/memory_set/src/set.rs
@@ -309,7 +309,7 @@ impl<B: MappingBackend> MemorySet<B> {
 
     /// Remove all memory areas and the underlying mappings.
     pub fn clear(&mut self, page_table: &mut B::PageTable) -> MappingResult {
-        for (_, area) in self.areas.iter() {
+        for area in self.areas.values() {
             area.unmap_area(page_table)?;
         }
         self.areas.clear();

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -435,7 +435,7 @@ impl DeviceOps for Card0 {
             ));
         }
         let dumbs = self.dumbs.lock();
-        for (_, buf) in dumbs.iter() {
+        for buf in dumbs.values() {
             if offset == buf.offset
                 && let Some(paddr) = buf.paddr
             {

--- a/os/arceos/ulib/arceos-rust/build.rs
+++ b/os/arceos/ulib/arceos-rust/build.rs
@@ -71,7 +71,7 @@ fn generate_config(manifest_dir: &Path, out_dir: &Path) -> PathBuf {
         .arg(&template)
         .arg(platform_config_path)
         .arg("-w")
-        .arg(format!(r#"arch="{}""#, &arch))
+        .arg(format!(r#"arch="{}""#, arch))
         .arg("-w")
         .arg(format!(r#"platform="{}""#, get_platform()))
         .arg("-o")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2026-04-27"
+channel = "nightly-2026-05-28"
 components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
 targets = [
     "x86_64-unknown-none",

--- a/scripts/axbuild/src/clippy.rs
+++ b/scripts/axbuild/src/clippy.rs
@@ -586,8 +586,12 @@ fn run_clippy_checks<R: CargoRunner>(
             passed_checks += 1;
             println!("ok: {}", check.label());
         } else {
-            eprintln!("failed: {}", check.label());
             package_report.failed_checks.push(check.label());
+            bail!(
+                "clippy failed for {}: aborting (fail-fast, {} check(s) remaining)",
+                check.label(),
+                checks.len() - index - 1
+            );
         }
     }
 

--- a/scripts/axbuild/src/clippy.rs
+++ b/scripts/axbuild/src/clippy.rs
@@ -1457,7 +1457,7 @@ mod tests {
     }
 
     #[test]
-    fn package_failures_keep_the_package_out_of_the_pass_list() {
+    fn package_failures_abort_remaining_checks() {
         let root = PathBuf::from("/tmp/workspace");
         let checks = vec![
             ClippyCheck {
@@ -1488,25 +1488,17 @@ mod tests {
             (checks[2].clone(), true),
         ]);
 
-        let report = run_clippy_checks(&mut runner, &root, &checks).unwrap();
+        let err = run_clippy_checks(&mut runner, &root, &checks).unwrap_err();
 
-        assert_eq!(report.passed_packages(), vec!["beta"]);
-        assert_eq!(report.failed_packages(), vec!["alpha"]);
         assert_eq!(
-            report
-                .packages
-                .iter()
-                .find(|package| package.package == "alpha")
-                .unwrap()
-                .failed_checks,
-            vec!["alpha (feature: feat-a)".to_string()]
+            err.to_string(),
+            "clippy failed for alpha (feature: feat-a): aborting (fail-fast, 1 check(s) remaining)"
         );
         assert_eq!(
             runner.invocations,
             vec![
                 (root.clone(), checks[0].clone()),
                 (root.clone(), checks[1].clone()),
-                (root, checks[2].clone()),
             ]
         );
     }


### PR DESCRIPTION
## 变更内容

### 1. Rust 工具链升级
- `rust-toolchain.toml`: 从 `nightly-2026-04-27` 升级到 `nightly-2026-05-28`

### 2. `cargo xtask clippy` 优化
- **fail-fast 行为**: 遇到第一个 clippy 错误立即退出，不再跑完所有 check 再汇总报告，节省开发调试时间
- 同步更新 `axbuild` 中 clippy fail-fast 行为的单元测试预期，避免 CI 中 `cargo test -p axbuild` 继续按旧的“收集全部失败”语义断言

### 3. Clippy 警告修复
新版 nightly 引入了更严格的 clippy 规则，修复以下问题：

- `components/rsext4/src/loopfile.rs`: 移除 format/debug 中多余的 & 引用
- `components/rsext4/src/tool.rs`: 移除 debug 中多余的 &superblock
- `memory/memory_set/src/set.rs`: `for (_, area) in iter()` 改为 `for area in values()`
- `os/StarryOS/kernel/src/pseudofs/dev/card0.rs`: `for (_, buf) in iter()` 改为 `for buf in values()`
- `os/arceos/ulib/arceos-rust/build.rs`: 移除 format 中多余的 &arch

### 验证
- `cargo fmt --all`
- `cargo test -p axbuild clippy`
- `cargo test -p axbuild package_failures_abort_remaining_checks`
- `cargo test -p axbuild`
- `cargo xtask clippy --package axbuild`
- `git diff --check`
- 追加测试修复前，本地复现到 `clippy::tests::package_failures_keep_the_package_out_of_the_pass_list` 因 fail-fast 返回错误而失败；更新后上述检查通过
- 早前已验证：`cargo xtask clippy --all` 全部 749 个 check 通过