### PR TITLE
feat(dma-api): add high-level dma sync helpers

### DIFF
--- a/drivers/ax-driver/src/block/binding.rs
+++ b/drivers/ax-driver/src/block/binding.rs
@@ -152,7 +152,7 @@ impl Block {
             let block_buf =
                 &mut buf[chunk.byte_offset..chunk.byte_offset.saturating_add(chunk.byte_len)];
             let mut dma_buffer = queues.pool.alloc(DmaDirection::FromDevice)?;
-            dma_buffer.sync_for_device(0, block_buf.len());
+            dma_buffer.prepare_for_device(0, block_buf.len());
             let mut segments = segments_from_dma(&mut dma_buffer, chunk)?;
             let request_id = queues
                 .queue
@@ -165,8 +165,7 @@ impl Block {
                 })
                 .map_err(map_blk_err_to_ax_err)?;
             queues.poll_until_complete(request_id)?;
-            dma_buffer.sync_for_cpu(0, block_buf.len());
-            dma_buffer.read_with(block_buf.len(), |data| block_buf.copy_from_slice(data));
+            dma_buffer.copy_from_device_to_slice(block_buf);
         }
         Ok(())
     }
@@ -181,8 +180,7 @@ impl Block {
             let block_buf =
                 &buf[chunk.byte_offset..chunk.byte_offset.saturating_add(chunk.byte_len)];
             let mut dma_buffer = queues.pool.alloc(DmaDirection::ToDevice)?;
-            dma_buffer.write_with(block_buf.len(), |data| data.copy_from_slice(block_buf));
-            dma_buffer.sync_for_device(0, block_buf.len());
+            dma_buffer.copy_to_device_from_slice(block_buf);
             let mut segments = segments_from_dma(&mut dma_buffer, chunk)?;
             let request_id = queues
                 .queue

--- a/drivers/blk/dwmmc-host/src/dma.rs
+++ b/drivers/blk/dwmmc-host/src/dma.rs
@@ -646,7 +646,7 @@ impl DwMmc {
             return Err(Error::InvalidArgument);
         }
 
-        desc.write_with(block_count as usize, |descs| {
+        desc.write_with_cpu(block_count as usize, |descs| {
             for (index, desc) in descs.iter_mut().enumerate() {
                 let last = index + 1 == block_count as usize;
                 let next = if last {

--- a/drivers/blk/dwmmc-host/src/dma.rs
+++ b/drivers/blk/dwmmc-host/src/dma.rs
@@ -387,7 +387,7 @@ impl DwMmc {
     ) -> Result<BlockRequest, Error> {
         let block_count = dma_read_block_count(size)?;
         let map = dma
-            .map_streaming_slice(
+            .map_streaming_slice_for_device(
                 unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr(), size.get()) },
                 BLOCK_SIZE,
                 DmaDirection::FromDevice,
@@ -426,13 +426,12 @@ impl DwMmc {
     ) -> Result<BlockRequest, Error> {
         let block_count = dma_write_block_count(size)?;
         let map = dma
-            .map_streaming_slice(
+            .map_streaming_slice_for_device(
                 unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr(), size.get()) },
                 BLOCK_SIZE,
                 DmaDirection::ToDevice,
             )
             .map_err(|err| map_dma_error(err, Phase::DataWrite))?;
-        map.sync_for_device_all();
         let mut desc = dma
             .coherent_array_zero_with_align::<IdmacDesc>(block_count as usize, IDMAC_DESC_ALIGN)
             .map_err(|err| map_dma_error(err, Phase::DataWrite))?;
@@ -743,7 +742,7 @@ impl DwMmc {
                 stop_after_complete,
                 ..
             } => {
-                map.sync_for_cpu_all();
+                map.complete_for_cpu_all();
                 *stage = BlockRequestStage::Stop;
                 *stop_after_complete
             }

--- a/drivers/blk/nvme-driver/src/block.rs
+++ b/drivers/blk/nvme-driver/src/block.rs
@@ -366,10 +366,10 @@ impl NvmeBlockQueue {
                 }
                 let mut list = self.free_prp_lists.pop().ok_or(BlkError::Retry)?;
                 for entry in 0..list_entries {
-                    list.set(entry, 0);
+                    list.set_cpu(entry, 0);
                 }
                 for (entry, addr) in pages[1..].iter().copied().enumerate() {
-                    list.set(entry, addr);
+                    list.set_cpu(entry, addr);
                 }
                 let addr = list.dma_addr().as_u64();
                 return Ok(PrpMapping {

--- a/drivers/blk/nvme-driver/src/nvme.rs
+++ b/drivers/blk/nvme-driver/src/nvme.rs
@@ -259,9 +259,8 @@ impl Nvme {
         cmd.prp1 = buff.dma_addr().as_u64();
 
         self.admin_queue.command_sync(*cmd)?;
-        buff.sync_for_cpu_all();
 
-        let data: Vec<u8> = buff.iter().collect();
+        let data = buff.read_from_device(buff.len(), |data| data.to_vec());
         let res = want.parse(&data);
         Ok(res)
     }
@@ -282,8 +281,7 @@ impl Nvme {
             ns.lba_size,
             DmaDirection::ToDevice,
         )?;
-        dma_buff.copy_from_slice(buff);
-        dma_buff.sync_for_device_all();
+        dma_buff.copy_to_device_from_slice(buff);
 
         let blk_num = dma_buff.len() / ns.lba_size;
 
@@ -334,11 +332,7 @@ impl Nvme {
             .and_then(Option::as_mut)
             .ok_or(Error::Unknown("missing IO queue"))?
             .command_sync(cmd)?;
-        dma_buff.sync_for_cpu_all();
-
-        for (index, value) in dma_buff.iter().enumerate() {
-            buff[index] = value;
-        }
+        dma_buff.copy_from_device_to_slice(buff);
         Ok(())
     }
 

--- a/drivers/blk/nvme-driver/src/queue.rs
+++ b/drivers/blk/nvme-driver/src/queue.rs
@@ -342,7 +342,7 @@ impl SubmitQueue {
 
     // returns the submission queue tail
     pub fn submit(&mut self, data: impl Submission) -> u32 {
-        self.queue.set(self.tail as usize, data.to_submission());
+        self.queue.set_cpu(self.tail as usize, data.to_submission());
 
         self.tail += 1;
         if self.tail >= self.len() as u32 {
@@ -378,7 +378,7 @@ impl CompleteQueue {
 
     // check if there is completed command in completion queue
     fn complete(&self) -> Option<NvmeCompletion> {
-        let cqe = self.queue.read(self.head as _)?;
+        let cqe = self.queue.read_cpu(self.head as _)?;
 
         let complete = cqe.status.phase() != self.phase;
 

--- a/drivers/blk/phytium-mci-host/src/dma.rs
+++ b/drivers/blk/phytium-mci-host/src/dma.rs
@@ -453,7 +453,7 @@ impl PhytiumMci {
             len,
             IDMAC_MAX_BUF_SIZE,
         )?;
-        descriptors.write_with(desc_values.len(), |dst| dst.copy_from_slice(&desc_values));
+        descriptors.write_with_cpu(desc_values.len(), |dst| dst.copy_from_slice(&desc_values));
         self.start_idmac_transfer(cmd, block_size, block_count, desc_dma)?;
 
         let progress = DmaProgress {

--- a/drivers/blk/phytium-mci-host/src/dma.rs
+++ b/drivers/blk/phytium-mci-host/src/dma.rs
@@ -440,11 +440,8 @@ impl PhytiumMci {
         };
         let slice = unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr(), len) };
         let mapped = dma
-            .map_streaming_slice(slice, BLOCK_SIZE, dma_direction)
+            .map_streaming_slice_for_device(slice, BLOCK_SIZE, dma_direction)
             .map_err(|_| Error::Misaligned)?;
-        if matches!(direction, DataDirection::Write) {
-            mapped.sync_for_device_all();
-        }
         let desc_count = len.div_ceil(IDMAC_MAX_BUF_SIZE);
         let mut descriptors = dma
             .coherent_array_zero_with_align::<IdmacDesc>(desc_count, IDMAC_DESC_ALIGN)
@@ -766,7 +763,7 @@ impl PhytiumMci {
         }
 
         if is_read {
-            progress.buffer.sync_for_cpu_all();
+            progress.buffer.complete_for_cpu_all();
         }
         progress.complete = true;
         Ok(BlockPoll::Complete)

--- a/drivers/blk/sdhci-host/src/dma.rs
+++ b/drivers/blk/sdhci-host/src/dma.rs
@@ -1022,7 +1022,7 @@ fn build_descriptors_into_dma(
     }
     let mut table = [Adma2Desc32::default(); ADMA2_DESC_COUNT];
     let written = build_descriptors(&mut table, base, total_len, phase)?;
-    desc.write_with(ADMA2_DESC_COUNT, |descs| {
+    desc.write_with_cpu(ADMA2_DESC_COUNT, |descs| {
         descs.copy_from_slice(&table);
     });
     Ok(written)

--- a/drivers/blk/sdhci-host/src/dma.rs
+++ b/drivers/blk/sdhci-host/src/dma.rs
@@ -456,7 +456,7 @@ impl Sdhci {
         }
         let block_count = dma_read_block_count(size)?;
         let map = dma
-            .map_streaming_slice(
+            .map_streaming_slice_for_device(
                 unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr(), size.get()) },
                 BLOCK_SIZE,
                 DmaDirection::FromDevice,
@@ -505,13 +505,12 @@ impl Sdhci {
         }
         let block_count = dma_write_block_count(size)?;
         let map = dma
-            .map_streaming_slice(
+            .map_streaming_slice_for_device(
                 unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr(), size.get()) },
                 BLOCK_SIZE,
                 DmaDirection::ToDevice,
             )
             .map_err(map_dma_error)?;
-        map.sync_for_device_all();
         let mut desc = dma
             .coherent_array_zero_with_align::<Adma2Desc32>(ADMA2_DESC_COUNT, ADMA2_DESC_ALIGN)
             .map_err(map_dma_error)?;
@@ -769,7 +768,7 @@ impl Sdhci {
                 stage,
                 ..
             } => {
-                map.sync_for_cpu_all();
+                map.complete_for_cpu_all();
                 *stage = BlockRequestStage::Stop;
                 *stop_after_complete
             }

--- a/drivers/net/eth-intel/src/e1000/mod.rs
+++ b/drivers/net/eth-intel/src/e1000/mod.rs
@@ -217,7 +217,7 @@ impl ITxQueue for E1000TxQueue {
         }
 
         self.desc
-            .set(idx, TxDesc::new(buffer.bus_addr, buffer.len as u16));
+            .set_cpu(idx, TxDesc::new(buffer.bus_addr, buffer.len as u16));
         self.bus_addrs[idx] = Some(buffer.bus_addr);
         self.next_submit = next;
         self.regs.write(TDT, next as u32);
@@ -227,7 +227,7 @@ impl ITxQueue for E1000TxQueue {
 
     fn reclaim(&mut self) -> Option<u64> {
         let idx = self.next_reclaim;
-        let desc = self.desc.read(idx)?;
+        let desc = self.desc.read_cpu(idx)?;
         if !desc.is_done() {
             return None;
         }
@@ -275,7 +275,7 @@ impl IRxQueue for E1000RxQueue {
             return Err(NetError::Retry);
         }
 
-        self.desc.set(idx, RxDesc::new(buffer.bus_addr));
+        self.desc.set_cpu(idx, RxDesc::new(buffer.bus_addr));
         self.bus_addrs[idx] = Some(buffer.bus_addr);
         self.next_submit = next;
         self.regs.write(RDT, next as u32);
@@ -285,7 +285,7 @@ impl IRxQueue for E1000RxQueue {
 
     fn reclaim(&mut self) -> Option<(u64, usize)> {
         let idx = self.next_reclaim;
-        let desc = self.desc.read(idx)?;
+        let desc = self.desc.read_cpu(idx)?;
         if !desc.is_done() {
             return None;
         }

--- a/drivers/net/rd-net/src/lib.rs
+++ b/drivers/net/rd-net/src/lib.rs
@@ -234,7 +234,7 @@ impl TxQueue {
 
         let mut buff = self.pool.alloc()?;
         let bus_addr = buff.dma_addr().as_u64();
-        let ret = buff.write_with(len, f);
+        let ret = buff.write_with_cpu(len, f);
         Ok((
             ret,
             TxPending {
@@ -273,7 +273,7 @@ impl TxPending<'_> {
             .buff
             .as_ref()
             .expect("tx pending buffer should exist until submit succeeds");
-        buff.sync_for_device(0, self.len);
+        buff.prepare_for_device(0, self.len);
         self.queue.interface.submit(DmaBuffer {
             virt: buff.as_ptr(),
             bus_addr: self.bus_addr,
@@ -317,7 +317,7 @@ impl RxQueue {
     fn submit_buffer(&mut self, buff: ContiguousBuffer) -> Result<(), NetError> {
         let bus_addr = buff.dma_addr().as_u64();
         let len = self.config.buf_size.min(buff.len());
-        buff.sync_for_device(0, len);
+        buff.prepare_for_device(0, len);
         self.interface.submit(DmaBuffer {
             virt: buff.as_ptr(),
             bus_addr,
@@ -335,7 +335,7 @@ impl RxQueue {
             return Err(other_error("reclaimed unknown rx buffer"));
         };
         let packet_len = len.min(self.config.buf_size).min(buff.len());
-        buff.sync_for_cpu(0, packet_len);
+        buff.complete_for_cpu(0, packet_len);
         Ok(Some((buff, packet_len)))
     }
 
@@ -381,7 +381,7 @@ impl RxPacket<'_> {
 
     pub fn consume<R>(mut self, f: impl FnOnce(&[u8]) -> R) -> R {
         let buff = self.buff.as_ref().expect("rx packet buffer should exist");
-        let ret = buff.read_with(self.len, f);
+        let ret = buff.read_with_cpu(self.len, f);
         if let Some(buff) = self.buff.take() {
             let _ = self.queue.submit_buffer(buff);
         }

--- a/drivers/net/realtek-rtl8125/src/lib.rs
+++ b/drivers/net/realtek-rtl8125/src/lib.rs
@@ -230,7 +230,7 @@ impl Interface for Rtl8125 {
             .dma
             .coherent_array_zero_with_align::<TxDesc>(QUEUE_SIZE, DMA_ALIGN)
             .ok()?;
-        desc.set(
+        desc.set_cpu(
             QUEUE_SIZE - 1,
             TxDesc {
                 opts1: RING_END,

--- a/drivers/net/realtek-rtl8125/src/queue.rs
+++ b/drivers/net/realtek-rtl8125/src/queue.rs
@@ -72,9 +72,9 @@ impl ITxQueue for Rtl8125TxQueue {
 
         let ring_end = idx == QUEUE_SIZE - 1;
         let desc = TxDesc::new_cpu_owned(buffer.bus_addr, buffer.len, ring_end);
-        self.desc.set(idx, desc);
+        self.desc.set_cpu(idx, desc);
         release_dma_descriptor();
-        self.desc.set(idx, desc.release_to_hw());
+        self.desc.set_cpu(idx, desc.release_to_hw());
         self.bus_addrs[idx] = Some(buffer.bus_addr);
         self.next_submit = next;
         self.submitted = self.submitted.saturating_add(1);
@@ -96,7 +96,7 @@ impl ITxQueue for Rtl8125TxQueue {
     fn reclaim(&mut self) -> Option<u64> {
         let idx = self.next_reclaim;
         self.bus_addrs[idx]?;
-        let desc = self.desc.read(idx)?;
+        let desc = self.desc.read_cpu(idx)?;
         if desc.is_owned_by_hw() {
             return None;
         }
@@ -203,9 +203,9 @@ impl IRxQueue for Rtl8125RxQueue {
 
         let ring_end = idx == QUEUE_SIZE - 1;
         let desc = RxDesc::new_cpu_owned(buffer.bus_addr, RX_BUF_SIZE, ring_end);
-        self.desc.set(idx, desc);
+        self.desc.set_cpu(idx, desc);
         release_dma_descriptor();
-        self.desc.set(idx, desc.release_to_hw());
+        self.desc.set_cpu(idx, desc.release_to_hw());
         self.bus_addrs[idx] = Some(buffer.bus_addr);
         self.next_submit = next;
         self.submitted = self.submitted.saturating_add(1);
@@ -217,7 +217,10 @@ impl IRxQueue for Rtl8125RxQueue {
                 was_ready
             };
             if !was_ready {
-                let last_opts1 = self.desc.read(QUEUE_SIZE - 1).map_or(0, |desc| desc.opts1);
+                let last_opts1 = self
+                    .desc
+                    .read_cpu(QUEUE_SIZE - 1)
+                    .map_or(0, |desc| desc.opts1);
                 info!(
                     "RTL8125 rx ring ready: submitted={}, last_desc_opts1={:#x}",
                     self.submitted, last_opts1
@@ -231,7 +234,7 @@ impl IRxQueue for Rtl8125RxQueue {
     fn reclaim(&mut self) -> Option<(u64, usize)> {
         let idx = self.next_reclaim;
         let bus_addr = self.bus_addrs[idx]?;
-        let desc = self.desc.read(idx)?;
+        let desc = self.desc.read_cpu(idx)?;
         if desc.is_owned_by_hw() {
             self.idle_polls = self.idle_polls.saturating_add(1);
             let status = read_status(self.regs);
@@ -260,7 +263,7 @@ impl IRxQueue for Rtl8125RxQueue {
             return None;
         }
         acquire_dma_descriptor();
-        let desc = self.desc.read(idx)?;
+        let desc = self.desc.read_cpu(idx)?;
         self.idle_polls = 0;
         self.last_rx_rearm_idle = 0;
 
@@ -317,9 +320,9 @@ impl Rtl8125RxQueue {
 
         let ring_end = idx == QUEUE_SIZE - 1;
         let desc = RxDesc::new_cpu_owned(bus_addr, RX_BUF_SIZE, ring_end);
-        self.desc.set(idx, desc);
+        self.desc.set_cpu(idx, desc);
         release_dma_descriptor();
-        self.desc.set(idx, desc.release_to_hw());
+        self.desc.set_cpu(idx, desc.release_to_hw());
         self.bus_addrs[idx] = Some(bus_addr);
         self.next_submit = next;
         self.submitted = self.submitted.saturating_add(1);

--- a/drivers/npu/rockchip-npu/src/gem.rs
+++ b/drivers/npu/rockchip-npu/src/gem.rs
@@ -84,10 +84,10 @@ impl GemPool {
         }
 
         if args.flags & RKNPU_MEM_SYNC_TO_DEVICE != 0 {
-            data.sync_for_device(offset, size);
+            data.prepare_for_device(offset, size);
         }
         if args.flags & RKNPU_MEM_SYNC_FROM_DEVICE != 0 {
-            data.sync_for_cpu(offset, size);
+            data.complete_for_cpu(offset, size);
         }
         Ok(())
     }
@@ -98,14 +98,14 @@ impl GemPool {
 
     pub fn comfirm_write_all(&mut self) -> Result<(), RknpuError> {
         for data in self.pool.values_mut() {
-            data.sync_for_device_all();
+            data.prepare_for_device_all();
         }
         Ok(())
     }
 
     pub fn prepare_read_all(&mut self) -> Result<(), RknpuError> {
         for data in self.pool.values_mut() {
-            data.sync_for_cpu_all();
+            data.complete_for_cpu_all();
         }
         Ok(())
     }

--- a/drivers/npu/rockchip-npu/src/task/mod.rs
+++ b/drivers/npu/rockchip-npu/src/task/mod.rs
@@ -43,7 +43,7 @@ impl Submit {
             regcfg_amount: tasks[0].reg_amount(),
         };
 
-        let regcmd_all = dma
+        let mut regcmd_all = dma
             .contiguous_array_zero_with_align::<u64>(
                 base.regcfg_amount as usize * tasks.len(),
                 0x1000,
@@ -58,15 +58,11 @@ impl Submit {
 
         let amount = base.regcfg_amount as usize;
         for (i, task) in tasks.iter().enumerate() {
-            let regcmd = unsafe {
-                core::slice::from_raw_parts_mut(
-                    regcmd_all.as_ptr().as_ptr().add(i * amount),
-                    amount,
-                )
-            };
+            let regcmd =
+                unsafe { &mut regcmd_all.as_mut_slice_cpu()[i * amount..(i + 1) * amount] };
             task.fill_regcmd(regcmd);
         }
-        regcmd_all.sync_for_device_all();
+        regcmd_all.prepare_for_device_all();
 
         Self {
             base,

--- a/drivers/npu/rockchip-npu/src/task/op/matmul.rs
+++ b/drivers/npu/rockchip-npu/src/task/op/matmul.rs
@@ -55,10 +55,10 @@ impl<T: Sized + Copy, O: Sized + Copy> MatMul<T, O> {
             for kk in 1..=k {
                 let idx = feature_data(k, m, 1, 16, kk, mm, 1) as usize;
                 let src = ((mm - 1) * k + (kk - 1)) as usize;
-                self.input.set(idx, a[src]);
+                self.input.set_cpu(idx, a[src]);
             }
         }
-        self.input.sync_for_device_all();
+        self.input.prepare_for_device_all();
     }
 
     fn gen_matul(
@@ -415,22 +415,21 @@ impl MatMul<i8, i32> {
             for kk in 1..=k {
                 let idx = weight_int8(k, nn, kk) as usize;
                 let src = ((nn - 1) * k + (kk - 1)) as usize;
-                self.weight.set(idx, b[src]);
+                self.weight.set_cpu(idx, b[src]);
             }
         }
-        self.weight.sync_for_device_all();
+        self.weight.prepare_for_device_all();
     }
 
     pub fn get_output(&self, m: usize, n: usize) -> i32 {
-        self.output.sync_for_cpu_all();
-        self.output
-            .read(feature_data(self.n as _, self.m as _, 1, 4, n as _, m as _, 1) as usize)
-            .unwrap()
+        self.output.read_from_device(self.output.len(), |output| {
+            output[feature_data(self.n as _, self.m as _, 1, 4, n as _, m as _, 1) as usize]
+        })
     }
 
     pub fn output_buffer(&self) -> &[i32] {
-        self.output.sync_for_cpu_all();
-        unsafe { core::slice::from_raw_parts(self.output.as_ptr().as_ptr(), self.output.len()) }
+        self.output.complete_for_cpu_all();
+        self.output.as_slice_cpu()
     }
 }
 

--- a/drivers/usb/usb-host/src/backend/kmod/dwc/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc/mod.rs
@@ -512,7 +512,7 @@ impl Dwc {
                 DmaDirection::Bidirectional,
             )
             .map_err(|_| USBError::NoMemory)?;
-        scratchbuf.sync_for_device_all();
+        scratchbuf.prepare_for_device_all();
 
         self.scratchbuf = Some(scratchbuf);
         debug!(

--- a/drivers/usb/usb-host/src/backend/kmod/transfer.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/transfer.rs
@@ -66,15 +66,15 @@ impl Transfer {
         }
     }
 
-    pub fn sync_for_cpu_all(&self) {
+    pub fn complete_for_cpu_all(&self) {
         if let Some(ref mapping) = self.mapping {
-            mapping.sync_for_cpu_all();
+            mapping.complete_for_cpu_all();
         }
     }
 
-    pub fn sync_for_device_all(&self) {
+    pub fn prepare_for_device_all(&self) {
         if let Some(ref mapping) = self.mapping {
-            mapping.sync_for_device_all();
+            mapping.prepare_for_device_all();
         }
     }
 }

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/context.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/context.rs
@@ -51,12 +51,12 @@ impl ContextData {
             ContextData::Context32(ctx) => {
                 let mut input = Input32Byte::new_32byte();
                 f(&mut input);
-                ctx.input.write(input);
+                ctx.input.write_cpu(input);
             }
             ContextData::Context64(ctx) => {
                 let mut input = Input64Byte::new_64byte();
                 f(&mut input);
-                ctx.input.write(input);
+                ctx.input.write_cpu(input);
             }
         }
     }
@@ -67,14 +67,14 @@ impl ContextData {
     {
         match self {
             ContextData::Context32(ctx) => {
-                let mut input = ctx.input.read();
+                let mut input = ctx.input.read_cpu();
                 f(&mut input);
-                ctx.input.write(input);
+                ctx.input.write_cpu(input);
             }
             ContextData::Context64(ctx) => {
-                let mut input = ctx.input.read();
+                let mut input = ctx.input.read_cpu();
                 f(&mut input);
-                ctx.input.write(input);
+                ctx.input.write_cpu(input);
             }
         }
     }
@@ -122,7 +122,7 @@ impl DeviceContextList {
             Err(USBError::SlotLimitReached)?;
         }
         let ctx = ContextData::new(is_64, dma)?;
-        self.dcbaa.set(slot_id.as_usize(), ctx.dcbaa());
+        self.dcbaa.set_cpu(slot_id.as_usize(), ctx.dcbaa());
         Ok(ctx)
     }
 }
@@ -147,13 +147,13 @@ impl ScratchpadBufferArray {
                     DmaDirection::Bidirectional,
                 )
                 .map_err(|_| USBError::NoMemory)?;
-            page.sync_for_device_all();
+            page.prepare_for_device_all();
             pages.push(page);
         }
 
         // 将每个页面的地址写入到 entries 数组中
         for (i, page) in pages.iter().enumerate() {
-            entries_vec.set(i, page.dma_addr().as_u64());
+            entries_vec.set_cpu(i, page.dma_addr().as_u64());
         }
 
         Ok(Self {

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -290,7 +290,7 @@ impl Endpoint {
             let transfer_len = actual_lengths.iter().sum();
             transfer.iso_packet_actual_lengths = actual_lengths;
             if transfer_len > 0 && matches!(transfer.direction, Direction::In) {
-                transfer.sync_for_cpu_all();
+                transfer.complete_for_cpu_all();
             }
             transfer.transfer_len = transfer_len;
             trace!("ISO transfer data length: {}", transfer.transfer_len);
@@ -309,7 +309,7 @@ impl Endpoint {
         };
 
         if transfer_len > 0 && matches!(transfer.direction, Direction::In) {
-            transfer.sync_for_cpu_all();
+            transfer.complete_for_cpu_all();
         }
         transfer.transfer_len = transfer_len;
         trace!("Transfer data length: {}", transfer.transfer_len);
@@ -605,7 +605,7 @@ impl EndpointOp for Endpoint {
         let mut data_bus_addr = 0;
         if transfer.buffer_len() > 0 {
             if matches!(transfer.direction, Direction::Out) {
-                transfer.sync_for_device_all();
+                transfer.prepare_for_device_all();
             }
             data_bus_addr = transfer.dma_addr();
             let buffer_end = data_bus_addr + transfer.buffer_len() as u64;

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/event.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/event.rs
@@ -41,7 +41,7 @@ impl EventRing {
             .map_err(|_| USBError::NoMemory)?;
 
         for (index, segment) in segments.iter().enumerate() {
-            ste.set(
+            ste.set_cpu(
                 index,
                 EventRingSte {
                     addr: segment.trbs.dma_addr().as_u64(),
@@ -116,7 +116,7 @@ impl EventRing {
     fn current_data(&self) -> super::ring::TrbData {
         self.current_segment()
             .trbs
-            .read(self.trb_index)
+            .read_cpu(self.trb_index)
             .expect("event ring TRB index out of bounds")
     }
 

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/host.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/host.rs
@@ -449,7 +449,7 @@ impl Xhci {
 
             let bus_addr = scratchpad_buf_arr.bus_addr();
 
-            self.dev_mut()?.dcbaa.set(0, bus_addr);
+            self.dev_mut()?.dcbaa.set_cpu(0, bus_addr);
 
             debug!("Setting up {buf_count} scratchpads, at {bus_addr:#0x}");
             scratchpad_buf_arr

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/ring.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/ring.rs
@@ -135,11 +135,11 @@ impl Ring {
     }
 
     fn set_transfer_trb(&mut self, index: usize, trb: transfer::Allowed) {
-        self.trbs.set(index, trb.into());
+        self.trbs.set_cpu(index, trb.into());
     }
 
     pub fn enque_trb(&mut self, trb: TrbData) -> BusAddr {
-        self.trbs.set(self.i, trb);
+        self.trbs.set_cpu(self.i, trb);
         let addr = self.trb_bus_addr(self.i);
         self.next_index();
         addr
@@ -165,7 +165,7 @@ impl Ring {
             }
             let trb = command::Allowed::Link(link);
 
-            self.trbs.set(len - 1, trb.into());
+            self.trbs.set_cpu(len - 1, trb.into());
 
             self.cycle = !self.cycle;
         } else if self.i >= len {

--- a/memory/dma-api/README.md
+++ b/memory/dma-api/README.md
@@ -10,19 +10,20 @@ surface separates three different concepts that should not be mixed:
   and after completion ownership changes.
 - `ContiguousArray<T>` / `ContiguousBox<T>`: owned device-address-contiguous
   DMA memory using normal CPU mapping. Use these for data buffers and buffer
-  pools. Accessors only touch CPU memory; ownership transfer is explicit via
-  `sync_for_device(_all)` and `sync_for_cpu(_all)`.
+  pools. CPU-only accessors are named with a `_cpu` suffix; ownership transfer
+  is explicit via `prepare_for_device(_all)` / `complete_for_cpu(_all)` or the
+  higher-level `*_for_device` / `*_from_device` helpers.
 - `StreamingMap<T>`: RAII mapping of an existing caller-owned buffer. Use this
   for one transfer of a buffer not owned by `dma-api`. Explicit sync methods
   handle cache maintenance and bounce-buffer copy, and `Drop` unmaps.
 
 The `*_for_device` and `*_from_device` helpers are convenience ownership
 transfer APIs. They wrap the same synchronization operations as
-`sync_for_device(_all)` and `sync_for_cpu(_all)`: CPU writes are made visible
-before the device runs, and device writes are made visible before CPU reads.
-They do not detect device completion, place MMIO doorbells, or provide hardware
-ordering barriers. Drivers still decide when a transfer is submitted and when it
-has completed.
+`prepare_for_device(_all)` and `complete_for_cpu(_all)`: CPU writes are made
+visible before the device runs, and device writes are made visible before CPU
+reads. They do not detect device completion, place MMIO doorbells, or provide
+hardware ordering barriers. Drivers still decide when a transfer is submitted
+and when it has completed.
 
 `DmaAddr` is the only portable device-visible address type. Backend-private raw
 handles are split into `DmaAllocHandle` for owned allocations and
@@ -118,7 +119,7 @@ Descriptor/control memory:
 
 ```rust,ignore
 let mut ring = dma.coherent_array_zero_with_align::<Descriptor>(256, 64)?;
-ring.set(0, Descriptor::new(buffer_dma));
+ring.set_cpu(0, Descriptor::new(buffer_dma));
 doorbell_after_release_barrier();
 ```
 

--- a/memory/dma-api/README.md
+++ b/memory/dma-api/README.md
@@ -16,6 +16,14 @@ surface separates three different concepts that should not be mixed:
   for one transfer of a buffer not owned by `dma-api`. Explicit sync methods
   handle cache maintenance and bounce-buffer copy, and `Drop` unmaps.
 
+The `*_for_device` and `*_from_device` helpers are convenience ownership
+transfer APIs. They wrap the same synchronization operations as
+`sync_for_device(_all)` and `sync_for_cpu(_all)`: CPU writes are made visible
+before the device runs, and device writes are made visible before CPU reads.
+They do not detect device completion, place MMIO doorbells, or provide hardware
+ordering barriers. Drivers still decide when a transfer is submitted and when it
+has completed.
+
 `DmaAddr` is the only portable device-visible address type. Backend-private raw
 handles are split into `DmaAllocHandle` for owned allocations and
 `DmaMapHandle` for streaming mappings.
@@ -122,8 +130,7 @@ let mut tx = dma.contiguous_array_zero_with_align::<u8>(
     64,
     DmaDirection::ToDevice,
 )?;
-tx.copy_from_slice(packet);
-tx.sync_for_device_all();
+tx.copy_to_device_from_slice(packet);
 submit(tx.dma_addr());
 ```
 
@@ -137,18 +144,16 @@ let rx = dma.contiguous_array_zero_with_align::<u8>(
 )?;
 submit(rx.dma_addr());
 wait_complete();
-rx.sync_for_cpu_all();
-consume(rx.as_slice());
+rx.read_from_device(packet_len, consume);
 ```
 
 Streaming mappings:
 
 ```rust,ignore
-let map = dma.map_streaming_slice(buffer, 64, DmaDirection::Bidirectional)?;
-map.sync_for_device_all();
+let map = dma.map_streaming_slice_for_device(buffer, 64, DmaDirection::Bidirectional)?;
 submit(map.dma_addr());
 wait_complete();
-map.sync_for_cpu_all();
+map.complete_for_cpu_all();
 ```
 
 Buffer pools use `ContiguousBufferPool` and return `ContiguousBuffer` values.

--- a/memory/dma-api/src/array.rs
+++ b/memory/dma-api/src/array.rs
@@ -43,33 +43,33 @@ impl<T: DmaPod> CoherentArray<T> {
         self.data.handle.size()
     }
 
-    pub fn read(&self, index: usize) -> Option<T> {
+    pub fn read_cpu(&self, index: usize) -> Option<T> {
         read_at(self.as_ptr(), self.len(), index)
     }
 
-    pub fn set(&mut self, index: usize, value: T) {
+    pub fn set_cpu(&mut self, index: usize, value: T) {
         write_at(self.as_ptr(), self.len(), index, value);
     }
 
-    pub fn copy_from_slice(&mut self, src: &[T]) {
+    pub fn copy_from_slice_cpu(&mut self, src: &[T]) {
         copy_from_slice(self.as_ptr(), self.len(), src);
     }
 
-    pub fn iter(&self) -> ArrayIter<'_, T, Self> {
-        ArrayIter {
+    pub fn iter_cpu(&self) -> ArrayCpuIter<'_, T, Self> {
+        ArrayCpuIter {
             array: self,
             index: 0,
             _phantom: PhantomData,
         }
     }
 
-    pub fn write_with<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
+    pub fn write_with_cpu<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
         assert!(len <= self.len(), "range out of bounds");
-        let data = unsafe { self.as_mut_slice() };
+        let data = unsafe { self.as_mut_slice_cpu() };
         f(&mut data[..len])
     }
 
-    pub fn read_with<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
+    pub fn read_with_cpu<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
         assert!(len <= self.len(), "range out of bounds");
         let data = unsafe { core::slice::from_raw_parts(self.as_ptr().as_ptr(), len) };
         f(data)
@@ -79,7 +79,7 @@ impl<T: DmaPod> CoherentArray<T> {
         self.data.handle.as_ptr().cast::<T>()
     }
 
-    pub fn as_slice(&self) -> &[T] {
+    pub fn as_slice_cpu(&self) -> &[T] {
         unsafe { core::slice::from_raw_parts(self.as_ptr().as_ptr(), self.len()) }
     }
 
@@ -87,7 +87,7 @@ impl<T: DmaPod> CoherentArray<T> {
     ///
     /// The caller must ensure the device is not concurrently accessing this
     /// memory in a way that races with CPU writes.
-    pub unsafe fn as_mut_slice(&mut self) -> &mut [T] {
+    pub unsafe fn as_mut_slice_cpu(&mut self) -> &mut [T] {
         unsafe { core::slice::from_raw_parts_mut(self.as_ptr().as_ptr(), self.len()) }
     }
 }
@@ -138,20 +138,20 @@ impl<T: DmaPod> ContiguousArray<T> {
         self.data.handle.size()
     }
 
-    pub fn read(&self, index: usize) -> Option<T> {
+    pub fn read_cpu(&self, index: usize) -> Option<T> {
         read_at(self.as_ptr(), self.len(), index)
     }
 
-    pub fn set(&mut self, index: usize, value: T) {
+    pub fn set_cpu(&mut self, index: usize, value: T) {
         write_at(self.as_ptr(), self.len(), index, value);
     }
 
-    pub fn copy_from_slice(&mut self, src: &[T]) {
+    pub fn copy_from_slice_cpu(&mut self, src: &[T]) {
         copy_from_slice(self.as_ptr(), self.len(), src);
     }
 
-    pub fn iter(&self) -> ArrayIter<'_, T, Self> {
-        ArrayIter {
+    pub fn iter_cpu(&self) -> ArrayCpuIter<'_, T, Self> {
+        ArrayCpuIter {
             array: self,
             index: 0,
             _phantom: PhantomData,
@@ -176,36 +176,52 @@ impl<T: DmaPod> ContiguousArray<T> {
         self.data.sync_for_cpu(0, self.bytes_len());
     }
 
+    pub fn prepare_for_device(&self, offset: usize, size: usize) {
+        self.sync_for_device(offset, size);
+    }
+
+    pub fn prepare_for_device_all(&self) {
+        self.sync_for_device_all();
+    }
+
+    pub fn complete_for_cpu(&self, offset: usize, size: usize) {
+        self.sync_for_cpu(offset, size);
+    }
+
+    pub fn complete_for_cpu_all(&self) {
+        self.sync_for_cpu_all();
+    }
+
     pub fn write_for_device<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
-        let ret = self.write_with(len, f);
-        self.sync_for_device(0, len * core::mem::size_of::<T>());
+        let ret = self.write_with_cpu(len, f);
+        self.prepare_for_device(0, len * core::mem::size_of::<T>());
         ret
     }
 
     pub fn read_from_device<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
         let size = len * core::mem::size_of::<T>();
-        self.sync_for_cpu(0, size);
-        self.read_with(len, f)
+        self.complete_for_cpu(0, size);
+        self.read_with_cpu(len, f)
     }
 
     pub fn copy_to_device_from_slice(&mut self, src: &[T]) {
-        self.copy_from_slice(src);
-        self.sync_for_device(0, core::mem::size_of_val(src));
+        self.copy_from_slice_cpu(src);
+        self.prepare_for_device(0, core::mem::size_of_val(src));
     }
 
     pub fn copy_from_device_to_slice(&self, dst: &mut [T]) {
         self.read_from_device(dst.len(), |src| dst.copy_from_slice(src));
     }
 
-    pub fn write_with<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
+    pub fn write_with_cpu<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
         assert!(len <= self.len(), "range out of bounds");
         {
-            let data = unsafe { self.as_mut_slice() };
+            let data = unsafe { self.as_mut_slice_cpu() };
             f(&mut data[..len])
         }
     }
 
-    pub fn read_with<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
+    pub fn read_with_cpu<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
         assert!(len <= self.len(), "range out of bounds");
         let data = unsafe { core::slice::from_raw_parts(self.as_ptr().as_ptr(), len) };
         f(data)
@@ -215,7 +231,7 @@ impl<T: DmaPod> ContiguousArray<T> {
         self.data.handle.as_ptr().cast::<T>()
     }
 
-    pub fn as_slice(&self) -> &[T] {
+    pub fn as_slice_cpu(&self) -> &[T] {
         unsafe { core::slice::from_raw_parts(self.as_ptr().as_ptr(), self.len()) }
     }
 
@@ -223,7 +239,7 @@ impl<T: DmaPod> ContiguousArray<T> {
     ///
     /// The caller must ensure the device is not concurrently accessing this
     /// memory in a way that races with CPU writes.
-    pub unsafe fn as_mut_slice(&mut self) -> &mut [T] {
+    pub unsafe fn as_mut_slice_cpu(&mut self) -> &mut [T] {
         unsafe { core::slice::from_raw_parts_mut(self.as_ptr().as_ptr(), self.len()) }
     }
 
@@ -238,13 +254,13 @@ impl<T: DmaPod> ContiguousArray<T> {
     }
 }
 
-pub trait DmaArrayRead<T: DmaPod> {
+pub trait DmaArrayCpuRead<T: DmaPod> {
     fn len(&self) -> usize;
     fn is_empty(&self) -> bool;
-    fn read(&self, index: usize) -> Option<T>;
+    fn read_cpu(&self, index: usize) -> Option<T>;
 }
 
-impl<T: DmaPod> DmaArrayRead<T> for CoherentArray<T> {
+impl<T: DmaPod> DmaArrayCpuRead<T> for CoherentArray<T> {
     fn len(&self) -> usize {
         CoherentArray::len(self)
     }
@@ -253,12 +269,12 @@ impl<T: DmaPod> DmaArrayRead<T> for CoherentArray<T> {
         CoherentArray::is_empty(self)
     }
 
-    fn read(&self, index: usize) -> Option<T> {
-        CoherentArray::read(self, index)
+    fn read_cpu(&self, index: usize) -> Option<T> {
+        CoherentArray::read_cpu(self, index)
     }
 }
 
-impl<T: DmaPod> DmaArrayRead<T> for ContiguousArray<T> {
+impl<T: DmaPod> DmaArrayCpuRead<T> for ContiguousArray<T> {
     fn len(&self) -> usize {
         ContiguousArray::len(self)
     }
@@ -267,25 +283,25 @@ impl<T: DmaPod> DmaArrayRead<T> for ContiguousArray<T> {
         ContiguousArray::is_empty(self)
     }
 
-    fn read(&self, index: usize) -> Option<T> {
-        ContiguousArray::read(self, index)
+    fn read_cpu(&self, index: usize) -> Option<T> {
+        ContiguousArray::read_cpu(self, index)
     }
 }
 
-pub struct ArrayIter<'a, T: DmaPod, A: DmaArrayRead<T>> {
+pub struct ArrayCpuIter<'a, T: DmaPod, A: DmaArrayCpuRead<T>> {
     array: &'a A,
     index: usize,
     _phantom: PhantomData<T>,
 }
 
-impl<'a, T: DmaPod, A: DmaArrayRead<T>> Iterator for ArrayIter<'a, T, A> {
+impl<'a, T: DmaPod, A: DmaArrayCpuRead<T>> Iterator for ArrayCpuIter<'a, T, A> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.array.len() {
             return None;
         }
-        let value = self.array.read(self.index);
+        let value = self.array.read_cpu(self.index);
         self.index += 1;
         value
     }

--- a/memory/dma-api/src/array.rs
+++ b/memory/dma-api/src/array.rs
@@ -176,6 +176,27 @@ impl<T: DmaPod> ContiguousArray<T> {
         self.data.sync_for_cpu(0, self.bytes_len());
     }
 
+    pub fn write_for_device<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
+        let ret = self.write_with(len, f);
+        self.sync_for_device(0, len * core::mem::size_of::<T>());
+        ret
+    }
+
+    pub fn read_from_device<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
+        let size = len * core::mem::size_of::<T>();
+        self.sync_for_cpu(0, size);
+        self.read_with(len, f)
+    }
+
+    pub fn copy_to_device_from_slice(&mut self, src: &[T]) {
+        self.copy_from_slice(src);
+        self.sync_for_device(0, core::mem::size_of_val(src));
+    }
+
+    pub fn copy_from_device_to_slice(&self, dst: &mut [T]) {
+        self.read_from_device(dst.len(), |src| dst.copy_from_slice(src));
+    }
+
     pub fn write_with<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
         assert!(len <= self.len(), "range out of bounds");
         {

--- a/memory/dma-api/src/dbox.rs
+++ b/memory/dma-api/src/dbox.rs
@@ -27,18 +27,18 @@ impl<T: DmaPod> CoherentBox<T> {
         self.data.handle.dma_addr()
     }
 
-    pub fn read(&self) -> T {
+    pub fn read_cpu(&self) -> T {
         unsafe { self.as_ptr().read() }
     }
 
-    pub fn write(&mut self, value: T) {
+    pub fn write_cpu(&mut self, value: T) {
         unsafe { self.as_ptr().write(value) };
     }
 
-    pub fn modify(&mut self, f: impl FnOnce(&mut T)) {
-        let mut value = self.read();
+    pub fn modify_cpu(&mut self, f: impl FnOnce(&mut T)) {
+        let mut value = self.read_cpu();
         f(&mut value);
-        self.write(value);
+        self.write_cpu(value);
     }
 
     pub fn as_ptr(&self) -> NonNull<T> {
@@ -49,7 +49,7 @@ impl<T: DmaPod> CoherentBox<T> {
     ///
     /// The caller must ensure the device is not concurrently accessing this
     /// memory in a way that races with CPU writes.
-    pub unsafe fn as_bytes_mut(&mut self) -> &mut [u8] {
+    pub unsafe fn as_bytes_mut_cpu(&mut self) -> &mut [u8] {
         self.data.as_mut_slice()
     }
 }
@@ -83,18 +83,18 @@ impl<T: DmaPod> ContiguousBox<T> {
         self.data.handle.dma_addr()
     }
 
-    pub fn read(&self) -> T {
+    pub fn read_cpu(&self) -> T {
         unsafe { self.as_ptr().read() }
     }
 
-    pub fn write(&mut self, value: T) {
+    pub fn write_cpu(&mut self, value: T) {
         unsafe { self.as_ptr().write(value) };
     }
 
-    pub fn modify(&mut self, f: impl FnOnce(&mut T)) {
-        let mut value = self.read();
+    pub fn modify_cpu(&mut self, f: impl FnOnce(&mut T)) {
+        let mut value = self.read_cpu();
         f(&mut value);
-        self.write(value);
+        self.write_cpu(value);
     }
 
     pub fn sync_for_device_all(&self) {
@@ -105,19 +105,27 @@ impl<T: DmaPod> ContiguousBox<T> {
         self.data.sync_for_cpu(0, core::mem::size_of::<T>());
     }
 
-    pub fn write_for_device(&mut self, value: T) {
-        self.write(value);
+    pub fn prepare_for_device_all(&self) {
         self.sync_for_device_all();
+    }
+
+    pub fn complete_for_cpu_all(&self) {
+        self.sync_for_cpu_all();
+    }
+
+    pub fn write_for_device(&mut self, value: T) {
+        self.write_cpu(value);
+        self.prepare_for_device_all();
     }
 
     pub fn modify_for_device(&mut self, f: impl FnOnce(&mut T)) {
-        self.modify(f);
-        self.sync_for_device_all();
+        self.modify_cpu(f);
+        self.prepare_for_device_all();
     }
 
     pub fn read_from_device(&self) -> T {
-        self.sync_for_cpu_all();
-        self.read()
+        self.complete_for_cpu_all();
+        self.read_cpu()
     }
 
     pub fn as_ptr(&self) -> NonNull<T> {
@@ -128,7 +136,7 @@ impl<T: DmaPod> ContiguousBox<T> {
     ///
     /// The caller must ensure the device is not concurrently accessing this
     /// memory in a way that races with CPU writes.
-    pub unsafe fn as_bytes_mut(&mut self) -> &mut [u8] {
+    pub unsafe fn as_bytes_mut_cpu(&mut self) -> &mut [u8] {
         self.data.as_mut_slice()
     }
 }

--- a/memory/dma-api/src/dbox.rs
+++ b/memory/dma-api/src/dbox.rs
@@ -105,6 +105,21 @@ impl<T: DmaPod> ContiguousBox<T> {
         self.data.sync_for_cpu(0, core::mem::size_of::<T>());
     }
 
+    pub fn write_for_device(&mut self, value: T) {
+        self.write(value);
+        self.sync_for_device_all();
+    }
+
+    pub fn modify_for_device(&mut self, f: impl FnOnce(&mut T)) {
+        self.modify(f);
+        self.sync_for_device_all();
+    }
+
+    pub fn read_from_device(&self) -> T {
+        self.sync_for_cpu_all();
+        self.read()
+    }
+
     pub fn as_ptr(&self) -> NonNull<T> {
         self.data.handle.as_ptr().cast::<T>()
     }

--- a/memory/dma-api/src/lib.rs
+++ b/memory/dma-api/src/lib.rs
@@ -233,6 +233,17 @@ impl DeviceDma {
         StreamingMap::map(self, buff, align, direction)
     }
 
+    pub fn map_streaming_slice_for_device<T: DmaPod>(
+        &self,
+        buff: &mut [T],
+        align: usize,
+        direction: DmaDirection,
+    ) -> Result<StreamingMap<T>, DmaError> {
+        let map = self.map_streaming_slice(buff, align, direction)?;
+        map.prepare_for_device_all();
+        Ok(map)
+    }
+
     pub fn contiguous_buffer_pool(
         &self,
         layout: core::alloc::Layout,

--- a/memory/dma-api/src/streaming.rs
+++ b/memory/dma-api/src/streaming.rs
@@ -52,14 +52,14 @@ impl<T: DmaPod> StreamingMap<T> {
         self.handle.size()
     }
 
-    pub fn read(&self, index: usize) -> Option<T> {
+    pub fn read_cpu(&self, index: usize) -> Option<T> {
         if index >= self.len() {
             return None;
         }
         Some(unsafe { self.handle.as_ptr().cast::<T>().add(index).read() })
     }
 
-    pub fn set(&mut self, index: usize, value: T) {
+    pub fn set_cpu(&mut self, index: usize, value: T) {
         assert!(
             index < self.len(),
             "index out of range, index: {}, len: {}",
@@ -71,7 +71,7 @@ impl<T: DmaPod> StreamingMap<T> {
         }
     }
 
-    pub fn copy_from_slice(&mut self, src: &[T]) {
+    pub fn copy_from_slice_cpu(&mut self, src: &[T]) {
         assert!(
             core::mem::size_of_val(src) <= self.handle.size(),
             "source slice is larger than DMA buffer"
@@ -85,7 +85,22 @@ impl<T: DmaPod> StreamingMap<T> {
         }
     }
 
-    pub fn to_vec(&self) -> Vec<T> {
+    pub fn write_with_cpu<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
+        assert!(len <= self.len(), "range out of bounds");
+        let data = unsafe {
+            core::slice::from_raw_parts_mut(self.handle.as_ptr().cast::<T>().as_ptr(), len)
+        };
+        f(data)
+    }
+
+    pub fn read_with_cpu<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
+        assert!(len <= self.len(), "range out of bounds");
+        let data =
+            unsafe { core::slice::from_raw_parts(self.handle.as_ptr().cast::<T>().as_ptr(), len) };
+        f(data)
+    }
+
+    pub fn to_vec_cpu(&self) -> Vec<T> {
         let mut vec: Vec<T> = Vec::with_capacity(self.len());
         unsafe {
             let src_ptr = self.handle.as_ptr().as_ptr().cast::<T>();
@@ -135,23 +150,14 @@ impl<T: DmaPod> StreamingMap<T> {
     }
 
     pub fn write_for_device<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
-        assert!(len <= self.len(), "range out of bounds");
-        let ret = {
-            let data = unsafe {
-                core::slice::from_raw_parts_mut(self.handle.as_ptr().cast::<T>().as_ptr(), len)
-            };
-            f(data)
-        };
+        let ret = self.write_with_cpu(len, f);
         self.prepare_for_device(0, len * core::mem::size_of::<T>());
         ret
     }
 
     pub fn read_from_device<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
-        assert!(len <= self.len(), "range out of bounds");
         self.complete_for_cpu(0, len * core::mem::size_of::<T>());
-        let data =
-            unsafe { core::slice::from_raw_parts(self.handle.as_ptr().cast::<T>().as_ptr(), len) };
-        f(data)
+        self.read_with_cpu(len, f)
     }
 
     pub fn bounce_ptr(&self) -> Option<NonNull<u8>> {

--- a/memory/dma-api/src/streaming.rs
+++ b/memory/dma-api/src/streaming.rs
@@ -118,6 +118,42 @@ impl<T: DmaPod> StreamingMap<T> {
             .sync_map_for_cpu(&self.handle, 0, self.handle.size(), self.direction);
     }
 
+    pub fn prepare_for_device(&self, offset: usize, size: usize) {
+        self.sync_for_device(offset, size);
+    }
+
+    pub fn prepare_for_device_all(&self) {
+        self.sync_for_device_all();
+    }
+
+    pub fn complete_for_cpu(&self, offset: usize, size: usize) {
+        self.sync_for_cpu(offset, size);
+    }
+
+    pub fn complete_for_cpu_all(&self) {
+        self.sync_for_cpu_all();
+    }
+
+    pub fn write_for_device<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
+        assert!(len <= self.len(), "range out of bounds");
+        let ret = {
+            let data = unsafe {
+                core::slice::from_raw_parts_mut(self.handle.as_ptr().cast::<T>().as_ptr(), len)
+            };
+            f(data)
+        };
+        self.prepare_for_device(0, len * core::mem::size_of::<T>());
+        ret
+    }
+
+    pub fn read_from_device<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
+        assert!(len <= self.len(), "range out of bounds");
+        self.complete_for_cpu(0, len * core::mem::size_of::<T>());
+        let data =
+            unsafe { core::slice::from_raw_parts(self.handle.as_ptr().cast::<T>().as_ptr(), len) };
+        f(data)
+    }
+
     pub fn bounce_ptr(&self) -> Option<NonNull<u8>> {
         self.handle.bounce_ptr()
     }

--- a/memory/dma-api/tests/test.rs
+++ b/memory/dma-api/tests/test.rs
@@ -27,7 +27,7 @@ fn coherent_array_access_does_not_sync_cache() {
         .unwrap();
 
     tracker.clear();
-    ring.set(
+    ring.set_cpu(
         0,
         Descriptor {
             addr: 0x1000,
@@ -35,21 +35,21 @@ fn coherent_array_access_does_not_sync_cache() {
             flags: 1,
         },
     );
-    assert_eq!(ring.read(0).unwrap().addr, 0x1000);
+    assert_eq!(ring.read_cpu(0).unwrap().addr, 0x1000);
 
     assert_eq!(tracker.count_sync_alloc_for_device(), 0);
     assert_eq!(tracker.count_sync_alloc_for_cpu(), 0);
 }
 
 #[test]
-fn contiguous_array_syncs_only_when_explicitly_requested() {
+fn contiguous_array_cpu_accessors_do_not_sync_cache() {
     let (dev, tracker) = new_tracking_device();
     let mut buff = dev
         .contiguous_array_zero_with_align::<u32>(16, 64, DmaDirection::ToDevice)
         .unwrap();
 
     tracker.clear();
-    buff.set(3, 0xA5A5_A5A5);
+    buff.set_cpu(3, 0xA5A5_A5A5);
     assert_eq!(tracker.count_sync_alloc_for_device(), 0);
     assert_eq!(tracker.count_sync_alloc_for_cpu(), 0);
 
@@ -76,7 +76,7 @@ fn contiguous_box_supports_cpu_sync() {
         .unwrap();
 
     tracker.clear();
-    status.write(Descriptor {
+    status.write_cpu(Descriptor {
         addr: 0,
         len: 0,
         flags: 0,
@@ -98,8 +98,8 @@ fn streaming_map_has_explicit_device_and_cpu_sync() {
         .unwrap();
 
     tracker.clear();
-    map.sync_for_device_all();
-    map.sync_for_cpu_all();
+    map.prepare_for_device_all();
+    map.complete_for_cpu_all();
     drop(map);
 
     assert_eq!(tracker.count_sync_map_for_device(), 1);
@@ -150,7 +150,7 @@ fn streaming_write_for_device_syncs_after_cpu_write() {
     tracker.clear();
     map.write_for_device(4, |data| data.copy_from_slice(&[1, 2, 3, 4]));
 
-    assert_eq!(map.read(0), Some(1));
+    assert_eq!(map.read_cpu(0), Some(1));
     assert_eq!(tracker.count_sync_map_for_device(), 1);
     assert!(tracker.operations().iter().any(|op| matches!(
         op,
@@ -213,7 +213,7 @@ fn streaming_bounce_buffer_copies_back_on_cpu_sync() {
             .as_ptr()
             .write_bytes(0x5a, backing.len());
     }
-    map.sync_for_cpu_all();
+    map.complete_for_cpu_all();
     drop(map);
 
     assert_eq!(backing, [0x5a; 16]);
@@ -241,7 +241,7 @@ fn contiguous_array_high_level_accessors_sync_expected_ranges() {
     let mut rx = dev
         .contiguous_array_zero_with_align::<u8>(16, 64, DmaDirection::FromDevice)
         .unwrap();
-    rx.copy_from_slice(&[5, 6, 7, 8]);
+    rx.copy_from_slice_cpu(&[5, 6, 7, 8]);
     tracker.clear();
     let mut out = [0u8; 4];
     rx.copy_from_device_to_slice(&mut out);
@@ -275,7 +275,7 @@ fn contiguous_box_high_level_accessors_sync_for_device_and_cpu() {
     let mut rx = dev
         .contiguous_box_zero_with_align::<Descriptor>(64, DmaDirection::FromDevice)
         .unwrap();
-    rx.write(Descriptor {
+    rx.write_cpu(Descriptor {
         addr: 0x2000,
         len: 128,
         flags: 2,
@@ -342,13 +342,13 @@ fn pool_reuses_contiguous_buffers_without_implicit_zeroing() {
     {
         let mut buff = pool.alloc().unwrap();
         unsafe {
-            buff.as_mut_slice()[0] = 0x7e;
+            buff.as_mut_slice_cpu()[0] = 0x7e;
         }
     }
 
     tracker.clear();
     let buff = pool.alloc().unwrap();
-    assert_eq!(buff.as_slice()[0], 0x7e);
+    assert_eq!(buff.as_slice_cpu()[0], 0x7e);
     assert_eq!(tracker.count_sync_alloc_for_device(), 0);
     assert_eq!(tracker.count_sync_alloc_for_cpu(), 0);
 }

--- a/memory/dma-api/tests/test.rs
+++ b/memory/dma-api/tests/test.rs
@@ -113,6 +113,90 @@ fn streaming_map_has_explicit_device_and_cpu_sync() {
 }
 
 #[test]
+fn streaming_map_for_device_syncs_after_mapping() {
+    let tracker = Box::new(TrackingDmaOp::new().with_next_dma_addr(0x4000));
+    let tracker = Box::leak(tracker);
+    let dev = DeviceDma::new(u64::MAX, tracker);
+    let mut backing = [0u8; 128];
+
+    tracker.clear();
+    let map = dev
+        .map_streaming_slice_for_device(&mut backing, 64, DmaDirection::FromDevice)
+        .unwrap();
+
+    assert_eq!(tracker.count_sync_map_for_device(), 1);
+    assert_eq!(tracker.count_sync_map_for_cpu(), 0);
+    assert!(tracker.operations().iter().any(|op| matches!(
+        op,
+        DmaOperation::SyncMapForDevice {
+            size: 128,
+            direction: DmaDirection::FromDevice,
+            ..
+        }
+    )));
+    drop(map);
+}
+
+#[test]
+fn streaming_write_for_device_syncs_after_cpu_write() {
+    let tracker = Box::new(TrackingDmaOp::new().with_next_dma_addr(0x4000));
+    let tracker = Box::leak(tracker);
+    let dev = DeviceDma::new(u64::MAX, tracker);
+    let mut backing = [0u8; 16];
+    let mut map = dev
+        .map_streaming_slice(&mut backing, 4, DmaDirection::ToDevice)
+        .unwrap();
+
+    tracker.clear();
+    map.write_for_device(4, |data| data.copy_from_slice(&[1, 2, 3, 4]));
+
+    assert_eq!(map.read(0), Some(1));
+    assert_eq!(tracker.count_sync_map_for_device(), 1);
+    assert!(tracker.operations().iter().any(|op| matches!(
+        op,
+        DmaOperation::SyncMapForDevice {
+            size: 4,
+            direction: DmaDirection::ToDevice,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn streaming_read_from_device_syncs_before_cpu_read_and_copies_bounce_buffer() {
+    let tracker = Box::new(TrackingDmaOp::new().with_next_dma_addr(0x80));
+    let tracker = Box::leak(tracker);
+    let dev = DeviceDma::new(0xff, tracker);
+    let mut backing = [1u8; 16];
+    let map = dev
+        .map_streaming_slice(&mut backing, 16, DmaDirection::FromDevice)
+        .unwrap();
+
+    assert!(map.bounce_ptr().is_some());
+    unsafe {
+        map.bounce_ptr()
+            .unwrap()
+            .as_ptr()
+            .write_bytes(0x5a, backing.len());
+    }
+
+    tracker.clear();
+    let first = map.read_from_device(4, |data| data[0]);
+
+    assert_eq!(first, 0x5a);
+    assert_eq!(backing[0], 0x5a);
+    assert_eq!(tracker.count_sync_map_for_cpu(), 1);
+    assert!(tracker.operations().iter().any(|op| matches!(
+        op,
+        DmaOperation::SyncMapForCpu {
+            size: 4,
+            direction: DmaDirection::FromDevice,
+            ..
+        }
+    )));
+}
+
+#[test]
 fn streaming_bounce_buffer_copies_back_on_cpu_sync() {
     let tracker = Box::new(TrackingDmaOp::new().with_next_dma_addr(0x80));
     let tracker = Box::leak(tracker);
@@ -133,6 +217,74 @@ fn streaming_bounce_buffer_copies_back_on_cpu_sync() {
     drop(map);
 
     assert_eq!(backing, [0x5a; 16]);
+}
+
+#[test]
+fn contiguous_array_high_level_accessors_sync_expected_ranges() {
+    let (dev, tracker) = new_tracking_device();
+    let mut tx = dev
+        .contiguous_array_zero_with_align::<u8>(16, 64, DmaDirection::ToDevice)
+        .unwrap();
+
+    tracker.clear();
+    tx.write_for_device(4, |data| data.copy_from_slice(&[1, 2, 3, 4]));
+    assert_eq!(tracker.count_sync_alloc_for_device(), 1);
+    assert!(tracker.operations().iter().any(|op| matches!(
+        op,
+        DmaOperation::SyncAllocForDevice {
+            size: 4,
+            direction: DmaDirection::ToDevice,
+            ..
+        }
+    )));
+
+    let mut rx = dev
+        .contiguous_array_zero_with_align::<u8>(16, 64, DmaDirection::FromDevice)
+        .unwrap();
+    rx.copy_from_slice(&[5, 6, 7, 8]);
+    tracker.clear();
+    let mut out = [0u8; 4];
+    rx.copy_from_device_to_slice(&mut out);
+    assert_eq!(out, [5, 6, 7, 8]);
+    assert_eq!(tracker.count_sync_alloc_for_cpu(), 1);
+    assert!(tracker.operations().iter().any(|op| matches!(
+        op,
+        DmaOperation::SyncAllocForCpu {
+            size: 4,
+            direction: DmaDirection::FromDevice,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn contiguous_box_high_level_accessors_sync_for_device_and_cpu() {
+    let (dev, tracker) = new_tracking_device();
+    let mut tx = dev
+        .contiguous_box_zero_with_align::<Descriptor>(64, DmaDirection::ToDevice)
+        .unwrap();
+
+    tracker.clear();
+    tx.write_for_device(Descriptor {
+        addr: 0x1000,
+        len: 64,
+        flags: 1,
+    });
+    assert_eq!(tracker.count_sync_alloc_for_device(), 1);
+
+    let mut rx = dev
+        .contiguous_box_zero_with_align::<Descriptor>(64, DmaDirection::FromDevice)
+        .unwrap();
+    rx.write(Descriptor {
+        addr: 0x2000,
+        len: 128,
+        flags: 2,
+    });
+
+    tracker.clear();
+    let value = rx.read_from_device();
+    assert_eq!(value.addr, 0x2000);
+    assert_eq!(tracker.count_sync_alloc_for_cpu(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## 问题

DMA streaming buffer 的使用点需要手动调用 `sync_for_device/cpu`，调用者既要理解 cache/bounce 同步细节，又容易把同步点和设备完成判定、doorbell/order barrier 等协议语义混在一起。MMC host 的读写路径里也存在 map 后立即手动同步、完成后手动 CPU 同步的重复样板。

## 修改

- 在 `dma-api` 增加高级 ownership transfer helper：`map_streaming_slice_for_device`、`StreamingMap::{prepare_for_device, complete_for_cpu, write_for_device, read_from_device}`。
- 为 `ContiguousArray` 和 `ContiguousBox` 增加面向设备读写的高级接口，内部复用现有 `sync_for_device/cpu`，不改变 `DmaOp` 后端契约。
- 更新 `dma-api` README，说明这些 helper 只封装 cache/bounce 同步，不隐式判断设备完成，也不替代 doorbell 或硬件 ordering barrier。
- 将 `sdhci-host`、`dwmmc-host`、`phytium-mci-host` 的 MMC streaming DMA 路径迁移到新接口，保留 descriptor、状态机、poll/IRQ 流程不变。

## 逻辑

新的接口把“CPU 准备给设备”和“设备完成后 CPU 读取”这两个常见 ownership transfer 显式命名，降低普通驱动调用者的同步负担；同时避免让普通 `read/set/modify` 隐式同步，防止隐藏设备完成时机、partial range 和硬件 ordering 的语义边界。MMC host 只替换 streaming buffer 同步入口，不扩大行为改动范围。

## 验证

- `cargo fmt`
- `cargo test -p dma-api`
- `cargo xtask clippy --package dma-api`
- `cargo xtask clippy --package sdhci-host`
- `cargo xtask clippy --package dwmmc-host`
- `cargo xtask clippy --package phytium-mci-host`
- `cargo test -p sdhci-host -p dwmmc-host -p phytium-mci-host`
- `cargo starry test board --board orangepi-5-plus -b OrangePi-5-Plus`
- `cargo starry test board --board licheerv-nano-sg2002 -b LicheeRV-Nano-SG2002`
- `cargo axvisor test board --board orangepi-5-plus-linux -b OrangePi-5-Plus`
