### PR TITLE
feat(tools): add qperf profiling harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4669,6 +4669,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90807d610575744524d9bdc69f3885d96f0e6c3354565b0828354a7ff2a262b8"
+dependencies = [
+ "ahash 0.8.12",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inherit-methods-macro"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5621,6 +5637,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6291,6 +6317,19 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
+ "inferno",
+ "object 0.37.3",
+ "regex",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -8075,6 +8114,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strsim"

--- a/docs/harness-os-knowledge-graph.md
+++ b/docs/harness-os-knowledge-graph.md
@@ -1,0 +1,124 @@
+# Harness OS 知识图谱功能说明
+
+`tools/starry-syscall-harness` 的 GUI 新增了一个独立的 `Knowledge` 页，用于在处理 StarryOS / ArceOS OS 相关 coding 任务时，自动扫描当前仓库并生成结构化知识图谱。
+
+## 目标
+
+该功能解决两个问题：
+
+1. 新接手任务时，需要快速知道当前代码改动落在 OS 哪个子系统。
+2. 写代码或做性能分析时，需要把仓库实践和 OS 课本知识关联起来，便于讲解、复盘和教学报告。
+
+## 启动
+
+```bash
+python3 tools/starry-syscall-harness/harness.py ui --host 127.0.0.1 --port 8765
+```
+
+浏览器打开：
+
+```text
+http://127.0.0.1:8765/
+```
+
+进入左侧 `Knowledge` tab。
+
+## 页面能力
+
+`Knowledge` 页面包含：
+
+* 当前开发任务输入框。
+* 粗粒度 / 细粒度讲解切换。
+* OS 子系统知识图谱 SVG。
+* 当前任务焦点节点高亮。
+* 节点详情面板。
+
+点击图谱节点后，右侧会显示：
+
+* 子系统职责。
+* 相关目录。
+* 扫描到的代表文件。
+* 扫描到的 Rust 符号。
+* OS 课本知识。
+* 当前仓库实践关联。
+
+## API
+
+GUI 使用以下本地 API：
+
+```text
+GET /api/knowledge-graph?task=<当前任务>&granularity=coarse|fine&refresh=0|1
+```
+
+也可以让当前 GUI 扫描相邻的本地教学仓库：
+
+```text
+GET /api/knowledge-graph?repo_root=../tg-arceos-tutorial&task=分析教程实验&granularity=fine&refresh=1
+```
+
+`repo_root` 为空时扫描当前仓库；非空时必须位于当前仓库或当前仓库的父目录下，且只用于静态扫描，不会通过 artifact API 暴露外部文件。
+
+返回结构包含：
+
+* `graph.nodes`：OS 子系统节点。
+* `graph.edges`：子系统依赖边。
+* `task.focus_node_ids`：当前任务命中的焦点节点。
+* `focus.code_explanation`：代码讲解。
+* `focus.os_explanation`：OS 课本知识与实践关联。
+* `focus.coding_guidance`：编码建议。
+
+## 扫描方式
+
+当前实现是轻量本地静态扫描，不依赖外部服务：
+
+* 扫描 `os/`、`components/`、`drivers/`、`scripts/`、`tools/`、`test-suit/`、`docs/`。
+* 对教学仓库额外扫描 `app-*`、`exercise-*`、根 `README.md`、`report.md`、`Cargo.toml`。
+* 跳过 `.git`、`target`、`node_modules`、`__pycache__` 等目录。
+* 提取 `.rs`、`.toml`、`.py`、`.md`、`.c`、`.h`、`.json` 文件。
+* 根据预定义 OS 子系统目录、关键词、当前任务文本、未提交文件或最近提交文件进行匹配。
+
+当前预置的主要节点包括：
+
+* Linux syscall compatibility
+* Task / process lifecycle
+* Scheduler / wait / synchronization
+* Virtual memory / address space
+* Allocator / object lifetime
+* VFS / file I/O
+* rsext4 / block cache
+* Block layer / request queue
+* virtio-blk driver
+* Network stack / socket path
+* virtio-net driver
+* virtio-vsock / vhost-vsock
+* PCI / interrupt / transport
+* procfs / debug observability
+* qperf / harness / GUI
+* Build / rootfs / qemu tests
+
+## 粗/细粒度
+
+`coarse`：
+
+* 面向任务入门和 PPT 总结。
+* 每个焦点节点只给职责、关键目录和 OS 概念关联。
+
+`fine`：
+
+* 面向写代码和 code review。
+* 展示代表文件、符号、命中文件、实践风险和编码建议。
+
+## 局限
+
+* 当前是启发式静态扫描，不做完整 Rust 语义解析，也不构建精确调用图。
+* 任务焦点依赖目录、关键词、git diff 和最近提交文件，不能替代人工读代码。
+* 图谱节点是 OS 教学/工程视角下的子系统归类，不等价于 crate 依赖图。
+* 该功能不调用 LLM，因此讲解模板是确定性的；后续可接入更细的符号索引或 rustdoc JSON。
+
+## 后续扩展建议
+
+1. 读取 `Cargo.toml` workspace 和 crate dependency，补充 crate 依赖边。
+2. 用 `rustdoc --output-format json` 或 `cargo metadata` 生成更精确的符号图。
+3. 将 qperf report 的 hotspot category 自动映射到知识图谱节点。
+4. 在 GUI 的 qperf report 页点击 hotspot 时，跳转到对应知识图谱节点。
+5. 为每个节点补充课程章节、推荐阅读和典型 bug 模式。

--- a/docs/qperf-callchain-flamegraph-design.md
+++ b/docs/qperf-callchain-flamegraph-design.md
@@ -1,0 +1,129 @@
+# qperf 深调用栈火焰图设计说明
+
+## 1. 问题背景
+
+旧版 qperf 生成的 `qperf/stack.folded` 大多只有一层函数名，因此 `flamegraph.svg` 只能横向展示 leaf hotspot，几乎没有纵向调用链。典型检查命令如下：
+
+```bash
+awk -F';' '{print NF}' target/qperf-host-rerun/blk-harness/perf/riscv64/latest/qperf/stack.folded | sort -n | uniq -c
+```
+
+旧 blk 产物的结果为 `623 1`，说明 623 条 folded stack 全部只有一帧。结合 `resolve.stats.json` 中 `format_version=2`、`raw_records=1292`、`total_frames=1292`，可以判断当时 raw sample 本身只有 PC/TB leaf 地址，不是 analyzer 把多帧调用栈压扁了。
+
+## 2. 根因诊断
+
+本轮诊断结论如下：
+
+| 类别 | 结论 |
+| --- | --- |
+| raw sample 是否有 callchain | 旧格式没有，只有 elapsed timestamp 与 PC leaf。 |
+| analyzer 是否压扁多帧 | 未发现多帧被压扁的问题；问题主要在采样侧没有多帧数据。 |
+| QEMU plugin 是否读寄存器 | 旧执行回调使用 `QEMU_PLUGIN_CB_NO_REGS`，无法稳定读取 guest SP/FP。 |
+| RISC-V FP 寄存器别名 | QEMU 暴露 `sp`、`fp`，同时也可能有 `x2`、`s0`、`x8` 别名；旧实现没有完整候选别名。 |
+| 构建参数 | 旧 `--full-stack` 没有把 `-Cforce-frame-pointers=yes` 稳定传入实际 StarryOS kernel 构建。 |
+| debug info | 只保留 leaf symbol 时还能解析函数名，但深栈与 inline 展开需要 `debuginfo=2` 与不剥离符号。 |
+
+因此，火焰图浅的核心原因不是 SVG 展示参数、采样频率或 `--max-depth`，而是 qperf 采样链路没有拿到可 unwind 的 guest callchain。
+
+## 3. 实现方案
+
+本轮采用真实 frame-pointer callchain 方案，默认仍保留 leaf 模式：
+
+| 模式 | 说明 |
+| --- | --- |
+| `leaf` | 默认模式，只记录 PC leaf，开销低、兼容旧命令。 |
+| `fp` | 通过 QEMU TCG plugin 读取 guest `pc/sp/fp`，按 RISC-V frame pointer 链恢复调用栈。 |
+| `logical` | 预留 CLI 值，但当前不实现；如果后续真实 unwind 不够稳定，再做人工插桩逻辑栈。 |
+
+`cargo starry perf --full-stack` 等价于：
+
+* 启用 qperf `callchain=fp`。
+* 为 StarryOS kernel 构建加入 `-Cdebuginfo=2`、`-Cstrip=none`、`-Cforce-frame-pointers=yes`。
+* 启用 `DWARF=y`、`BACKTRACE=y`，方便符号和 debug 信息保留。
+
+## 4. raw sample v3
+
+qperf plugin 新增 v3 sample 格式：
+
+```text
+elapsed_ns
+pc
+sp
+fp
+cpu
+callchain
+trace[]
+```
+
+其中：
+
+* `pc` 是采样点 leaf PC。
+* `sp` 是 guest stack pointer。
+* `fp` 是 RISC-V `s0/fp`。
+* `trace[]` 是 plugin 通过 frame pointer unwind 得到的地址链。
+* `callchain=leaf|fp` 标记该样本来源。
+
+analyzer 继续兼容旧 v1/v2 raw 格式；旧数据会自动退化为 leaf-only 栈。
+
+## 5. RISC-V frame pointer unwind
+
+RISC-V ABI 下，开启 frame pointer 后通常可从当前 `fp` 附近读取上一个 frame pointer 与 return address。本轮实现按如下策略恢复：
+
+1. QEMU execute callback 使用 `QEMU_PLUGIN_CB_R_REGS`。
+2. 采样时读取 guest `sp` 与 `fp`，寄存器候选包括 `sp/x2` 与 `fp/s0/x8`。
+3. 只对 kernel text 或其物理映射别名范围内的 PC 做 unwind，避免在 OpenSBI 或用户态地址上误读。
+4. 按 `fp - 16` 读取 `{prev_fp, ra}`。
+5. 遇到非法地址、非单调 frame pointer、距离过大、循环 frame、不可读内存或非 kernel text return address 时停止。
+6. 单个样本 unwind 失败时回退到 leaf，不中断整个 profile。
+
+输出新增：
+
+* `qperf/stack-depth-summary.csv`
+* `report.json.callchain`
+* `report.json.resolve_stats.depth_histogram`
+* `qperf/summary.txt` 中的 sample format 与 callchain 字段
+
+## 6. analyzer 与 folded stack
+
+analyzer 的变化：
+
+* 保留 raw sample 中的多帧地址，不再只按 leaf 聚合。
+* folded stack 按 caller-to-leaf 顺序输出。
+* `stack.folded` 默认保留完整 demangled Rust 路径。
+* `hotspots.csv` 继续提供函数热点聚合，但函数百分比按函数帧总量计算，避免深栈下出现超过 100% 的函数占比。
+* `hotspot_categories.csv` 是 inclusive stack 分类，表示某类别在多少条样本调用栈中出现，不是互斥 CPU 时间分摊。
+
+## 7. cargo starry 集成
+
+新增或完善的参数：
+
+```text
+cargo starry perf --full-stack
+cargo starry perf --perf-callchain leaf|fp|logical
+cargo starry perf --perf-debuginfo
+cargo starry perf --perf-force-frame-pointers
+cargo starry perf --symbol-style full|module|short
+cargo starry perf --max-depth 128
+```
+
+推荐深栈用法：
+
+```bash
+cargo starry perf \
+  --case blk-full-stack \
+  --full-stack \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload 'echo QPERF_BEGIN:blk; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk'
+```
+
+默认 `cargo starry perf` 仍使用 `leaf`，避免对普通 profile 强制引入 frame pointer 与 debug info 的构建开销。
+
+## 8. 局限性
+
+* `fp` 模式依赖 kernel 编译时保留 frame pointer；没有 `--full-stack` 时不能期待深栈。
+* 目前只解析 kernel ELF，用户态符号和用户栈不是本轮目标。
+* trap/syscall/task 切换附近的栈可能截断，不能保证穿透所有上下文切换。
+* inline 展开会让 `stack.folded` 的符号层数大于 raw FP frame 数；原始地址深度以 `stack-depth-summary.csv` 为准。
+* QEMU 退出如果被 SIGKILL 截断，plugin shutdown summary 可能缺失；analyzer 仍可处理已落盘 raw sample。
+* `logical` 模式尚未实现，当前不会把人工 instrumentation 路径伪装成真实 CPU callchain。

--- a/docs/qperf-callchain-validation-report.md
+++ b/docs/qperf-callchain-validation-report.md
@@ -1,0 +1,346 @@
+# qperf 深调用栈火焰图优化验收报告
+
+## 1. 验收目标
+
+本轮验证要回答的问题：
+
+* qperf 火焰图浅是否确认为“只有 PC/TB leaf 采样”。
+* `--full-stack` / `--perf-callchain fp` 是否能生成真实纵向调用链。
+* folded stack 是否保留完整 Rust demangled 路径。
+* blk/net workload 是否能看到 syscall、fs/net、virtio、allocator、BTreeMap、memcpy/memmove 等路径。
+* 默认 leaf profile 是否保持兼容。
+
+## 2. 验收环境
+
+| 项目 | 值 |
+| --- | --- |
+| 仓库 commit | `34d0e92d5` |
+| host | WSL2 Linux `5.15.167.4-microsoft-standard-WSL2` |
+| CPU | Intel Core i7-14650HX，24 vCPU |
+| QEMU | `qemu-system-riscv64` 10.2.1 |
+| guest arch | `riscv64` |
+| 运行方式 | 直接在宿主 WSL 环境运行，不在 Docker 中运行。本轮按用户已安装宿主 QEMU 的环境继续验证。 |
+| host perf | 未启用 |
+| qperf metrics | net case 启用，blk full-stack case 未启用 |
+
+当前工作区还包含本轮代码改动与此前未跟踪的文档/图片文件，验收报告只引用确认存在的 `target/qperf-callchain-validation/` 产物。
+
+full-stack 构建后的 ELF 已做反汇编抽查，`VirtQueue::add_notify_wait_pop` prologue 中存在：
+
+```text
+sd      ra, 0x88(sp)
+sd      s0, 0x80(sp)
+addi    s0, sp, 0x90
+```
+
+证据文件：`target/qperf-callchain-validation/full-stack-frame-pointer-objdump.txt`。这说明 `-Cforce-frame-pointers=yes` 已经进入实际 kernel 构建，而不是只停留在 CLI 参数层面。
+
+## 3. 诊断结论
+
+旧 blk 产物：
+
+```bash
+awk -F';' '{print NF}' target/qperf-host-rerun/blk-harness/perf/riscv64/latest/qperf/stack.folded | sort -n | uniq -c
+```
+
+结果为：
+
+```text
+623 1
+```
+
+`resolve.stats.json` 显示旧 raw 格式为 v2，`raw_records=1292`、`total_frames=1292`，说明旧样本基本只有 leaf PC。根因是采样侧没有真实 callchain，而不是 flamegraph SVG 样式、采样频率或 analyzer 把多帧压扁。
+
+## 4. 实现与验证矩阵
+
+| 验收项 | 结果 | 证据路径 | 备注 |
+| --- | --- | --- | --- |
+| `cargo starry perf --help` 暴露 callchain 参数 | PASS | `target/qperf-callchain-validation/cargo-starry-perf-help.txt` | 包含 `--full-stack`、`--perf-callchain`、`--perf-debuginfo`、`--perf-force-frame-pointers`。 |
+| harness `perf-profile --help` 暴露 callchain 参数 | PASS | `target/qperf-callchain-validation/harness-perf-profile-help.txt` | 包含 `--callchain`、`--full-stack`。 |
+| leaf baseline 兼容 | PASS | `target/qperf-callchain-validation/blk-leaf/perf/riscv64/latest/report.json` | 默认 leaf 仍为一层栈。 |
+| blk full-stack 深栈 | PASS | `target/qperf-callchain-validation/blk-full-stack/perf/riscv64/latest/qperf/stack.folded` | 579 条 workload 样本中 578 条为多帧。 |
+| net full-stack 深栈 | PASS | `target/qperf-callchain-validation/net-full-stack/perf/riscv64/latest/qperf/stack.folded` | 661 条 workload 样本中 652 条为多帧。 |
+| `stack-depth-summary.csv` | PASS | `target/qperf-callchain-validation/*/perf/riscv64/latest/qperf/stack-depth-summary.csv` | 输出 raw FP trace depth 分布。 |
+| `hotspots.csv` 深栈百分比 | PASS | `target/qperf-callchain-validation/blk-full-stack/perf/riscv64/latest/hotspots.csv` | 函数热点百分比已按帧总量计算。 |
+| net qperf metrics 合入 report | PASS | `target/qperf-callchain-validation/net-full-stack/perf/riscv64/latest/report.json` | `workload_metrics.values` 包含 virtio/net counters。 |
+| logical stack fallback | N/A | 无 | 因真实 FP unwind 已可用，本轮未实现 logical stack；CLI 会明确拒绝该模式。 |
+
+## 5. leaf baseline
+
+命令：
+
+```bash
+cargo starry perf \
+  --case blk-leaf \
+  --output-dir target/qperf-callchain-validation/blk-leaf \
+  --host-time \
+  --timeout 120 \
+  --workload-timeout 75 \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --shell-init-cmd 'echo QPERF_BEGIN:blk; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk' \
+  --no-truncate
+```
+
+结果：
+
+| 指标 | 值 |
+| --- | ---: |
+| result | `ok` |
+| dd bytes | 53,601,104 |
+| dd elapsed | 5.764698 s |
+| dd throughput | 9,298,163 B/s |
+| marker window | 5.832138317 s |
+| boot samples excluded | 154 |
+| selected records | 577 |
+| selected multi-frame records | 0 |
+| raw max depth | 1 |
+
+depth 分布：
+
+```text
+depth,samples
+1,577
+```
+
+结论：默认 leaf 模式保持旧行为和低开销，但不会生成纵向火焰图。
+
+## 6. blk full-stack
+
+命令：
+
+```bash
+cargo starry perf \
+  --case blk-full-stack \
+  --output-dir target/qperf-callchain-validation/blk-full-stack \
+  --full-stack \
+  --host-time \
+  --timeout 180 \
+  --workload-timeout 120 \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --shell-init-cmd 'echo QPERF_BEGIN:blk; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk' \
+  --no-truncate
+```
+
+结果：
+
+| 指标 | 值 |
+| --- | ---: |
+| result | `incomplete` |
+| dd bytes | 53,601,104 |
+| dd elapsed | 5.779240 s |
+| dd throughput | 9,274,766 B/s |
+| marker window | 5.845178559 s |
+| boot samples excluded | 160 |
+| post-window samples excluded | 1222 |
+| selected records | 579 |
+| selected multi-frame records | 578 |
+| samples with FP | 578 |
+| unwind success | 578 |
+| report avg symbol depth | 43.887737478 |
+| raw max depth | 18 |
+
+`stack-depth-summary.csv`：
+
+```text
+depth,samples
+1,1
+4,2
+5,2
+6,39
+7,2
+8,6
+9,42
+10,52
+11,44
+12,77
+13,41
+14,72
+15,183
+16,8
+17,7
+18,1
+```
+
+`awk -F';' '{print NF}' .../stack.folded` 能看到 folded 符号层数最高到 72。层数大于 raw depth 的原因是 analyzer 通过 debug info 展开了 inline frame。
+
+blk 关键路径已经能在 `stack.folded` 中看到：
+
+```text
+starry_kernel::syscall::fs::io::sys_read
+  -> ax_fs_ng / rsext4
+  -> ax_driver::block::binding::Block::read_blocks_wait
+  -> rd_block::CmdQueue::read_blocks_blocking
+  -> ax_driver::virtio::block::BlockQueue::submit_request
+  -> virtio_drivers::device::blk::VirtIOBlk::read_blocks
+  -> virtio_drivers::queue::VirtQueue::add_notify_wait_pop
+```
+
+top categories：
+
+| category | samples | percent |
+| --- | ---: | ---: |
+| block_io_path | 434 | 74.9568% |
+| memcpy | 179 | 30.9154% |
+| virtio_notify_kick | 176 | 30.3972% |
+| virtqueue_add_notify_wait_pop | 173 | 29.8791% |
+| lock_mutex_wait | 82 | 14.1623% |
+
+`result=incomplete` 的原因是 QMP stop 后 QEMU 在等待退出阶段被超时清理，导致 plugin shutdown summary 不完整；marker window、raw sample、folded stack 与 report 已生成。本项是 stop/shutdown 可靠性问题，不影响“是否能生成深调用栈”的结论。
+
+## 7. net full-stack
+
+命令：
+
+```bash
+cargo starry perf \
+  --case net-full-stack \
+  --output-dir target/qperf-callchain-validation/net-full-stack \
+  --full-stack \
+  --qperf-metrics \
+  --host-time \
+  --timeout 300 \
+  --workload-timeout 240 \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --shell-init-cmd 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:net; wget -O /dev/null http://10.0.2.2:8000/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img.tar.xz; cat /proc/qperf_metrics; echo QPERF_END:net' \
+  --no-truncate
+```
+
+结果：
+
+| 指标 | 值 |
+| --- | ---: |
+| result | `ok` |
+| wget bytes | 63,543,705 |
+| wget elapsed | 6.688766343 s |
+| wget throughput | 9,500,063 B/s |
+| marker window | 6.688766343 s |
+| boot samples excluded | 159 |
+| selected records | 661 |
+| selected multi-frame records | 652 |
+| samples with FP | 658 |
+| unwind success | 652 |
+| report avg symbol depth | 50.69591528 |
+| raw max depth | 17 |
+
+`stack-depth-summary.csv`：
+
+```text
+depth,samples
+1,9
+3,3
+4,2
+5,1
+6,34
+7,7
+8,12
+9,8
+10,58
+11,136
+12,62
+13,93
+14,183
+15,45
+16,5
+17,3
+```
+
+net 关键路径已经能在 `stack.folded` 中看到：
+
+```text
+starry_kernel::syscall::fs::io::sys_readv
+  -> starry_kernel::file::net::Socket::read
+  -> ax_net_ng::SocketOps::recv
+  -> ax_net_ng::poll_interfaces
+  -> ax_net_ng::device::driver::RdNetDriver::prefetch_rx_packets
+  -> rd_net::RxQueue::receive / reclaim_packet
+  -> dma_api::array::ContiguousArray::read_with
+  -> compiler_builtins::mem::memcpy
+```
+
+net counters 已进入 `report.json.workload_metrics.values`：
+
+| counter | 值 |
+| --- | ---: |
+| virtqueue_add_count | 47,855 |
+| virtio_notify_kick_count | 47,855 |
+| virtqueue_pop_complete_count | 47,791 |
+| virtqueue_add_notify_wait_pop_count | 1,177 |
+| virtqueue_depth_max | 63 |
+| virtio_net_rx_packets | 44,139 |
+| virtio_net_rx_bytes | 65,935,922 |
+| virtio_net_rx_copy_within_count | 44,139 |
+| virtio_net_rx_copy_within_bytes | 65,935,922 |
+| virtio_net_tx_packets | 2,476 |
+| virtio_net_tx_staging_copy_bytes | 148,700 |
+| virtio_net_inflight_insert_count | 46,678 |
+| virtio_net_inflight_remove_count | 46,614 |
+| virtio_net_inflight_get_count | 46,614 |
+
+top categories：
+
+| category | samples | percent |
+| --- | ---: | ---: |
+| net_rx_tx_path | 441 | 66.7171% |
+| memcpy | 233 | 35.2496% |
+| lock_mutex_wait | 100 | 15.1286% |
+| memmove | 65 | 9.8336% |
+| net_inflight_btree | 63 | 9.5310% |
+
+## 8. 证据文件
+
+| 用途 | 路径 |
+| --- | --- |
+| blk leaf report | `target/qperf-callchain-validation/blk-leaf/perf/riscv64/latest/report.json` |
+| blk leaf depth | `target/qperf-callchain-validation/blk-leaf/perf/riscv64/latest/qperf/stack-depth-summary.csv` |
+| blk full-stack report | `target/qperf-callchain-validation/blk-full-stack/perf/riscv64/latest/report.json` |
+| blk full-stack flamegraph | `target/qperf-callchain-validation/blk-full-stack/perf/riscv64/latest/qperf/flamegraph.svg` |
+| blk full-stack workload flamegraph | `target/qperf-callchain-validation/blk-full-stack/perf/riscv64/latest/qperf/flamegraph.workload.svg` |
+| blk full-stack folded | `target/qperf-callchain-validation/blk-full-stack/perf/riscv64/latest/qperf/stack.folded` |
+| blk full-stack depth | `target/qperf-callchain-validation/blk-full-stack/perf/riscv64/latest/qperf/stack-depth-summary.csv` |
+| net full-stack report | `target/qperf-callchain-validation/net-full-stack/perf/riscv64/latest/report.json` |
+| net full-stack flamegraph | `target/qperf-callchain-validation/net-full-stack/perf/riscv64/latest/qperf/flamegraph.svg` |
+| net full-stack workload flamegraph | `target/qperf-callchain-validation/net-full-stack/perf/riscv64/latest/qperf/flamegraph.workload.svg` |
+| net full-stack folded | `target/qperf-callchain-validation/net-full-stack/perf/riscv64/latest/qperf/stack.folded` |
+| net full-stack depth | `target/qperf-callchain-validation/net-full-stack/perf/riscv64/latest/qperf/stack-depth-summary.csv` |
+| full-stack FP 反汇编抽查 | `target/qperf-callchain-validation/full-stack-frame-pointer-objdump.txt` |
+
+## 9. 验证命令
+
+已执行：
+
+```bash
+cargo fmt
+cargo clippy --manifest-path tools/qperf/Cargo.toml -- -D warnings
+cargo clippy --manifest-path tools/qperf/analyzer/Cargo.toml -- -D warnings
+cargo clippy -p axbuild -- -D warnings
+python3 -m py_compile tools/starry-syscall-harness/harness.py
+```
+
+其中 qperf clippy 初次发现两个手写 `% 8 == 0` 对齐判断，已改为 `is_multiple_of(8)` 后通过。
+
+## 10. 局限性
+
+* 默认模式仍是 leaf；只有 `--full-stack` 或 `--perf-callchain fp --perf-force-frame-pointers --perf-debuginfo` 才能期待深栈。
+* 当前 unwind 只覆盖 kernel symbol；用户态栈与用户 ELF symbol 尚未纳入。
+* trap、异常入口、任务切换、汇编 trampoline 仍可能截断调用链。
+* `report.json.callchain.avg_depth` 是 symbolized/inlined frame 平均层数；raw FP 地址深度以 `stack-depth-summary.csv` 为准。
+* `hotspot_categories.csv` 是 inclusive stack 归类，深栈下 allocator/scheduler 可能因为共同上层路径被频繁命中，不能按互斥 CPU 时间解读。
+* blk full-stack 本次 QEMU stop 结果为 `incomplete`，需要后续继续改善 QMP stop 与 plugin shutdown flush。
+* host perf/PMU 未启用，本报告不包含 host PMU 结论。
+* vsock 未在本轮补测；没有 `/dev/vhost-vsock` 的 host 不能做定量结论。
+
+## 11. 结论
+
+结论：PASS，针对“火焰图没有纵向延展”的 MVP 目标已经达成。
+
+证据是：
+
+* leaf baseline 仍全部为一帧，复现了原问题。
+* `--full-stack` blk case 中 578/579 条 workload 样本为多帧，raw max depth 为 18，folded symbol depth 最高到 72。
+* `--full-stack` net case 中 652/661 条 workload 样本为多帧，raw max depth 为 17，folded symbol depth 最高到 78。
+* folded stack 中已经出现 syscall -> fs/net -> driver -> virtqueue/memcpy 的完整工程路径。
+
+因此，现在 qperf 不再只能生成 leaf hotspot 火焰图；在 full-stack 模式下可以生成具备明显纵向展开的 RISC-V kernel flamegraph。默认 leaf 模式保留为低开销兼容路径。

--- a/docs/qperf-cargo-starry-integration-report.md
+++ b/docs/qperf-cargo-starry-integration-report.md
@@ -1,0 +1,179 @@
+# qperf 与 cargo starry 集成报告
+
+## 1. 背景与目标
+
+本轮目标是降低 qperf 使用门槛，并提升火焰图可读性：
+
+* 用户不再需要手写复杂 `tools/starry-syscall-harness/harness.py perf-profile ...`。
+* `cargo starry perf` 生成完整 qperf report、csv、folded stack、SVG flamegraph。
+* `cargo starry run --perf` 作为 `cargo starry qemu --perf` alias 路径，提供 run 语义入口。
+* 火焰图保留更完整的 Rust demangled symbol，支持 symbol style、focus、boot/workload/post/focused 视图。
+
+本轮不修改 virtio 数据路径，也不宣称修复 virtio 性能问题。
+
+## 2. 现有架构梳理
+
+`.cargo/config.toml` 中 `cargo starry` 是 alias：`cargo run -p tg-xtask -- starry`。实际 StarryOS CLI 在 `scripts/axbuild/src/starry/mod.rs`，qperf runner 在 `scripts/axbuild/src/starry/perf.rs`。
+
+本轮选择的集成点：
+
+* 保留并增强已有 `Command::Perf(ArgsPerf)`，即 `cargo starry perf`。
+* 给 `Command::Qemu(ArgsQemu)` 增加 `run` alias，并在 `ArgsQemu` 上增加 `--perf` 与 `--perf-*` 参数。
+* 继续复用 `perf::run()`，避免复制 qperf/QEMU/plugin/analyzer 逻辑。
+* 增加 harness `perf-postprocess`，让 cargo 入口也能生成与 harness 一致的 `report.json/report.md/hotspots.csv/hotspot_categories.csv`。
+* `cargo starry perf` 默认把 axbuild 临时目录隔离到输出目录下的 `axbuild-tmp/`；底层 `axbuild_tmp_dir()` 也支持 `AXBUILD_TMP_DIR`，避免已有 `tmp/axbuild/` 被 Docker/root-owned 文件污染时阻塞 profile。
+
+## 3. 新命令设计
+
+### `cargo starry perf`
+
+```bash
+cargo starry perf --case boot
+```
+
+默认值：
+
+| 参数 | 默认值 |
+| --- | --- |
+| arch | `riscv64` |
+| case | `boot` |
+| output | `target/qperf/<case>/perf/<arch>/latest/` |
+| freq | `99` |
+| max-depth | `128` |
+| mode | `tb` |
+| format | `all` |
+| top | `80` |
+| min-percent | `0.3` |
+| host-time | enabled unless `--no-host-time` |
+
+### `cargo starry run --perf`
+
+`cargo starry run` 是 `cargo starry qemu` 的 alias。带 `--perf` 时转换为 `ArgsPerf` 并调用同一套 `perf::run()`：
+
+```bash
+cargo starry run \
+  --perf \
+  --perf-case blk-read \
+  --perf-workload 'echo QPERF_BEGIN:blk; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk' \
+  --perf-start-marker QPERF_BEGIN \
+  --perf-stop-marker QPERF_END \
+  --perf-qperf-metrics
+```
+
+当前 `run --perf` 支持默认 qperf QEMU/rootfs flow，不支持和 `--qemu-config`、`--rootfs`、`--config`、`--target`、`--smp` 混用；这些组合会给出明确错误，避免静默忽略。
+
+## 4. 火焰图增强
+
+新增能力：
+
+* analyzer 支持 `--symbol-style full|short|module`。
+* analyzer fallback symtab 也会做 Rust demangle。
+* analyzer 支持 `--focus <regex>` 生成聚焦 folded/flamegraph。
+* analyzer 支持 `--min-percent` 控制 SVG frame 最小宽度。
+* `cargo starry perf` 输出默认、workload、boot、post、focus 多个火焰图路径。
+* `--full-stack` 会把 qperf plugin max depth 至少提升到 256。
+* `--no-truncate` 会把 flamegraph min width 降到 0。
+
+真实验证中，新 analyzer 已能把旧 `_R...` mangled symbol 转换为可读 Rust 路径，例如：
+
+```text
+<virtio_drivers::queue::VirtQueue<ax_driver::virtio::VirtIoHalImpl, 16usize>>::add_notify_wait_pop
+<ax_alloc::buddy_slab::GlobalAllocator>::alloc
+```
+
+但当前 qperf 仍不保证恢复截图级完整调用栈。根因是 stack unwind 仍依赖 frame pointer 链，QEMU plugin sample 只记录 IP trace，没有 DWARF unwind 状态、vCPU/thread 元数据或 guest backtrace。
+
+## 5. 使用示例
+
+boot：
+
+```bash
+cargo starry perf --case boot
+```
+
+blk-read：
+
+```bash
+cargo starry perf \
+  --case blk-read \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 45 \
+  --workload 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; cat /proc/qperf_metrics; echo QPERF_END:blk-read'
+```
+
+net-wget：
+
+```bash
+cargo starry perf \
+  --case net-wget \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:net-wget; wget -O /dev/null http://10.0.2.2:8000/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img.tar.xz; cat /proc/qperf_metrics; echo QPERF_END:net-wget'
+```
+
+在 Docker/WSL 下，net server 应与 QEMU 处在可达网络拓扑中；此前验证显示 WSL host 上直接启动 HTTP server 时 guest 访问 `10.0.2.2:8000` 会 connection refused。
+
+A/B compare：
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-compare \
+  --baseline target/qperf/blk-read/perf/riscv64/latest/report.json \
+  --candidate target/qperf/blk-read-patched/perf/riscv64/latest/report.json \
+  --name blk-read-ab \
+  --output-dir target/qperf/compare
+```
+
+## 6. 验收结果
+
+| 验收项 | 结果 | 证据路径 | 备注 |
+| --- | --- | --- | --- |
+| qperf-analyzer help | PASS | `target/qperf-integration-smoke/help/qperf-analyzer-help.txt` | `--symbol-style`、`--focus`、`--min-percent` 出现在 help |
+| harness perf-profile help | PASS | `target/qperf-integration-smoke/help/harness-perf-profile-help.txt` | 旧 harness 入口保留，并暴露新增 flamegraph 参数 |
+| harness perf-postprocess help | PASS | `target/qperf-integration-smoke/help/harness-perf-postprocess-help.txt` | cargo 入口复用此 postprocess 生成 report/csv |
+| cargo starry perf help | PASS | `target/qperf-integration-smoke/help/cargo-starry-perf-help.txt` | 使用临时 `CARGO_HOME` 与测试用 `PKG_CONFIG_PATH` 通过；当前 host 原生环境仍缺 `libudev.pc` |
+| cargo starry run help | PASS | `target/qperf-integration-smoke/help/cargo-starry-run-help.txt` | `run` alias 暴露 `--perf`、`--perf-case`、`--perf-workload`、`--perf-focus` 等参数 |
+| axbuild check/clippy | PASS | command output | `cargo check -p axbuild`、`cargo clippy -p axbuild -- -D warnings` 通过 |
+| cargo CLI parse tests | PASS | command output | `command_parses_perf_*` 与 `command_parses_run_perf_alias` 通过 |
+| qperf plugin check | PASS | command output | `cargo check --manifest-path tools/qperf/Cargo.toml` 通过 |
+| analyzer flamegraph resolve | PASS | `target/qperf-integration-smoke/analyzer/flamegraph.svg` | 复用已有 blk raw sample 生成 SVG |
+| analyzer focused flamegraph | PASS | `target/qperf-integration-smoke/analyzer/flamegraph.virtio.svg` | `--focus 'virtio|VirtQueue'` 输出 159 samples |
+| stack.folded symbol 粒度 | PARTIAL | `target/qperf-integration-smoke/analyzer/stack.full.folded` | symbol demangle 可读；调用链仍常短栈 |
+| harness perf-postprocess | PASS | `target/qperf-integration-smoke/postprocess/report.json` | 从既有 qperf artifacts 生成 report/csv，参数中包含 `symbol_style/focus/no_truncate` |
+| cargo starry perf boot | FAIL | `target/qperf-integration-smoke/logs/cargo-starry-perf-boot.log` | qperf tools、StarryOS build、rootfs 准备均已推进；宿主缺 `qemu-system-riscv64`，未产生 raw samples/report |
+| cargo starry perf blk | NOT RUN | N/A | 与 boot 相同的 QEMU host 依赖阻塞，未重复下载/运行 |
+| old full harness QEMU run | NOT RUN | N/A | 本轮未再触发 Docker profile，避免重新生成 root-owned `tmp/axbuild`；CLI/help 兼容已验证 |
+
+本轮真实 boot profile 阻塞原因：
+
+```text
+Error: qperf requires `qemu-system-riscv64` in PATH; install the matching QEMU system emulator or run the Docker-based harness perf-profile entrypoint
+```
+
+额外环境说明：
+
+* 当前 host 原生 `pkg-config` 找不到 `libudev.pc`。help/check 验证使用 `/tmp/fake-pkgconfig` 作为只用于编译帮助/测试的替代，不代表生产运行环境；正常环境应安装 `libudev-dev`。
+* 默认 Cargo registry cache 仍有 root-owned cache warning；验证使用 `CARGO_HOME=/tmp/tgoskits-cargo-home` 避免写入用户 cache。
+* 原仓库 `tmp/axbuild/` 存在 root-owned 文件；本轮已通过 `AXBUILD_TMP_DIR` 和 cargo perf 默认 `axbuild-tmp/` 隔离规避。
+* `rust-objcopy` 初始不在 PATH；验证时临时加入 Rust toolchain 的 llvm-tools 路径，随后现有 `starry-kallsyms.sh` 安装了 `cargo-binutils` 与 `gen_ksym` 到 `/tmp/tgoskits-cargo-home/bin`。
+
+## 7. 局限性
+
+* `cargo starry perf` 代码路径已实现并推进到 QEMU 启动前，但当前 host 缺 `qemu-system-riscv64`，所以 boot/blk profile 未能生成新的 raw samples 和最终 report。
+* qperf 仍是 QEMU TCG plugin 采样，不是 guest PMU。
+* marker window 仍是 timestamp 后处理过滤，不是 runtime pause/resume。
+* stack unwind 仍依赖 frame pointer，不能保证完整 Rust 调用链。
+* counters 仍是 driver-visible 近似值，不是 ring-level 精确统计。
+* host perf/PMU 是可选 host QEMU process 指标。
+* vsock 仍受 `/dev/vhost-vsock` 限制。
+
+## 8. 下一步建议
+
+1. 在安装 `qemu-system-riscv64`、`libudev-dev`，并保证 `rust-objcopy` 在 PATH 的 host 上重跑 `cargo starry perf --case boot`。
+2. 重跑 blk marker profile，确认 cargo 入口完整生成 `report.json/report.md/hotspots.csv/hotspot_categories.csv/qperf/flamegraph.svg`。
+3. cargo 入口闭环后开始 net RX 去 `copy_within()` A/B。
+4. 开始 net inflight `BTreeMap` 到 fixed array/slab 的 A/B。
+5. 开始 blk pending read / async queue 原型 A/B。
+6. 继续探索 ring-level virtqueue counters 和 runtime pause/resume sampling。

--- a/docs/qperf-cargo-starry-integration.md
+++ b/docs/qperf-cargo-starry-integration.md
@@ -1,0 +1,170 @@
+# qperf cargo starry 集成指南
+
+## 快速开始
+
+默认 boot profile：
+
+```bash
+cargo starry perf --case boot
+```
+
+blk marker profile：
+
+```bash
+cargo starry perf \
+  --case blk-read \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 45 \
+  --workload 'echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk-read'
+```
+
+`--qperf-metrics` 只负责把 guest stdout 中的 `QPERF_METRIC key=value`
+合入报告；内核或 driver 侧的 `/proc/qperf_metrics` 插桩需要由被测分支单独提供。
+
+`cargo starry run --perf` 是 `cargo starry qemu --perf` 的 alias 路径，适合用户按 run 语义启动默认 qperf：
+
+```bash
+cargo starry run --perf --perf-case boot
+```
+
+如果只是复盘已有结果或在没有 host QEMU 的机器上做报告分析，可以直接阅读已经生成的
+`report.json`、`hotspot_categories.csv` 和 `qperf/stack.folded`。当前仓库中的 blk
+瓶颈分析见 `docs/qperf-current-blk-bottleneck-analysis.md`。
+
+## 环境依赖
+
+`cargo starry perf` 在 host 上直接运行 QEMU，需要：
+
+* `qemu-system-riscv64` 或对应 arch 的 system QEMU 在 `PATH` 中。
+* Rust `llvm-tools`/`cargo-binutils` 提供 `rust-objcopy`、`rust-nm`。
+* axbuild 依赖的 host 库，例如 `libudev.pc`；Debian/Ubuntu 通常来自 `libudev-dev`。
+
+本入口会把 StarryOS build config、generated axconfig 和 managed rootfs 隔离到当前 qperf 输出目录下的 `axbuild-tmp/`。高级用户可以显式设置 `AXBUILD_TMP_DIR=<dir>` 复用或重定向这部分临时文件。
+
+## 默认值
+
+`cargo starry perf` 默认使用：
+
+| 参数 | 默认值 |
+| --- | --- |
+| arch | `riscv64` |
+| case | `boot` |
+| output | `target/qperf/<case>/perf/<arch>/latest/` |
+| qperf freq | `99` |
+| max depth | `128` |
+| mode | `tb` |
+| format | `all` |
+| top | `80` |
+| min percent | `0.3` |
+| host time | enabled |
+| qperf metrics | disabled unless guest prints `QPERF_METRIC` lines |
+
+生成完成后会打印：
+
+```text
+qperf report generated:
+  report: target/qperf/<case>/perf/riscv64/latest/report.md
+  flamegraph: target/qperf/<case>/perf/riscv64/latest/qperf/flamegraph.svg
+  folded stack: target/qperf/<case>/perf/riscv64/latest/qperf/stack.folded
+  json: target/qperf/<case>/perf/riscv64/latest/report.json
+```
+
+## 高级参数
+
+常用 qperf 参数：
+
+```bash
+cargo starry perf \
+  --case net-wget \
+  --freq 199 \
+  --max-depth 256 \
+  --mode insn \
+  --symbol-style full \
+  --focus 'virtio|net|memcpy|memmove' \
+  --no-truncate
+```
+
+`cargo starry run --perf` 使用 `--perf-*` 前缀：
+
+```bash
+cargo starry run \
+  --perf \
+  --perf-case blk-read \
+  --perf-workload 'echo QPERF_BEGIN:blk; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk' \
+  --perf-start-marker QPERF_BEGIN \
+  --perf-stop-marker QPERF_END \
+  --perf-qperf-metrics \
+  --perf-symbol-style full \
+  --perf-focus 'virtio|block'
+```
+
+当前 `run --perf` 只支持默认 qperf QEMU/rootfs flow，以及 `--arch`、`--debug` 这类轻量 build override。带 `--qemu-config`、`--rootfs`、`--config`、`--target`、`--smp` 的 perf run 仍应使用 plain `cargo starry qemu` 或后续扩展。
+
+## 输出文件
+
+| 文件 | 说明 |
+| --- | --- |
+| `report.json` | 机器可读报告 |
+| `report.md` | 可直接阅读/粘贴的 Markdown 报告 |
+| `hotspots.csv` | symbol hotspot |
+| `hotspot_categories.csv` | 工程归因类别 |
+| `qperf/stack.folded` | 完整 folded stack |
+| `qperf/flamegraph.svg` | 默认完整火焰图 |
+| `qperf/flamegraph.workload.svg` | marker workload window 火焰图 |
+| `qperf/flamegraph.boot.svg` | boot 阶段火焰图 |
+| `qperf/flamegraph.post.svg` | post-window 火焰图 |
+| `qperf/flamegraph.focus.svg` | `--focus` 过滤后的火焰图 |
+| `qperf/summary.txt` | qperf run 摘要 |
+
+## 用 qperf 做 blk 瓶颈初筛
+
+推荐先跑 marker + metrics workload：
+
+```bash
+cargo starry perf \
+  --case blk-read \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 45 \
+  --workload 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; cat /proc/qperf_metrics; echo QPERF_END:blk-read'
+```
+
+读报告时优先看三组字段：
+
+| 字段 | 用途 |
+| --- | --- |
+| `window` | 确认 boot/post-window 样本是否被排除 |
+| `hotspot_categories.csv` | 看 copy、virtqueue、allocator、scheduler 等工程类别占比 |
+| `workload_metrics.values` | 看 `virtqueue_add_notify_wait_pop_count`、notify/kick、blk read bytes/requests 等 driver-visible counters |
+
+当前已有 blk profile 显示，`virtqueue_add_notify_wait_pop` 和
+`virtio_notify_kick` 都在 workload window 内占到约 25% 级别，且
+`virtio_blk_read_bytes / virtio_blk_read_requests` 约为 4 KiB。这个结果指向
+“大量同步 4 KiB 级别 virtqueue 请求，queue depth 没有被持续利用”的 blk
+优化方向。完整证据和限制见 `docs/qperf-current-blk-bottleneck-analysis.md`。
+
+## A/B compare
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-compare \
+  --baseline target/qperf/blk-read/perf/riscv64/latest/report.json \
+  --candidate target/qperf/blk-read-patched/perf/riscv64/latest/report.json \
+  --name blk-read-ab \
+  --output-dir target/qperf/compare
+```
+
+## 网络与 vsock 注意事项
+
+在 Docker/WSL 下，guest 的 `10.0.2.2` 通常指向 QEMU slirp 所在网络命名空间，不一定能访问 WSL host 上启动的 HTTP server。net profile 建议在同一个 Docker 容器内启动 HTTP server，或明确使用 host 网络。
+
+vsock 需要 host 具备 `/dev/vhost-vsock`。如果不存在，不应输出伪造吞吐或 counter。
+
+## 当前局限
+
+* qperf 仍是 QEMU TCG plugin 采样，不是 guest PMU。
+* marker window 仍是 raw timestamp 后处理过滤，不是 runtime pause/resume。
+* stack unwind 依赖 frame pointer 和可解析 DWARF；inline、tail call、汇编 trampoline 可能断栈。
+* virtio counters 是 driver-visible 近似值，不是 ring-level 精确硬件事件。
+* user symbol 解析当前只在符号存在于 kernel ELF 时可见。

--- a/docs/qperf-flamegraph-guide.md
+++ b/docs/qperf-flamegraph-guide.md
@@ -1,0 +1,182 @@
+# qperf 火焰图指南
+
+## 快速生成
+
+默认 profile 使用 leaf 模式，开销低，但调用栈通常只有一层：
+
+```bash
+cargo starry perf --case boot --symbol-style full
+```
+
+需要纵向展开的深调用栈时，使用 `--full-stack`：
+
+```bash
+cargo starry perf \
+  --case blk-full-stack \
+  --full-stack \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload 'echo QPERF_BEGIN:blk; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk'
+```
+
+`--full-stack` 会启用 frame pointer callchain，并在 kernel 构建中加入：
+
+```text
+-Cdebuginfo=2
+-Cstrip=none
+-Cforce-frame-pointers=yes
+```
+
+因此它比默认 profile 慢，也会触发更多构建工作；只在需要深栈火焰图时开启。
+
+## callchain 模式
+
+| 模式 | 用法 | 说明 |
+| --- | --- | --- |
+| `leaf` | 默认 | 只记录采样 PC，适合粗略热点和旧命令兼容。 |
+| `fp` | `--perf-callchain fp` 或 `--full-stack` | 读取 RISC-V `sp/fp`，按 frame pointer 链恢复 kernel 调用栈。 |
+| `logical` | 当前不可用 | 预留人工插桩逻辑栈模式。本轮没有实现，不会伪装成真实 callchain。 |
+
+如果只传 `--perf-callchain fp`，还应配合：
+
+```bash
+--perf-debuginfo --perf-force-frame-pointers
+```
+
+实际使用中推荐直接传 `--full-stack`。
+
+## 读哪些文件
+
+| 文件 | 说明 |
+| --- | --- |
+| `qperf/flamegraph.svg` | 完整 profile 火焰图。 |
+| `qperf/flamegraph.workload.svg` | marker window 内样本火焰图。 |
+| `qperf/flamegraph.boot.svg` | start marker 前样本火焰图。 |
+| `qperf/flamegraph.post.svg` | stop marker 后样本火焰图，可能为空。 |
+| `qperf/flamegraph.focus.svg` | `--focus` regex 命中的 focused 火焰图。 |
+| `qperf/stack.folded` | folded stack 原始输入，默认保留完整 demangled Rust symbol。 |
+| `qperf/stack-depth-summary.csv` | raw callchain 地址深度分布。 |
+| `hotspots.csv` | 函数级热点聚合。 |
+| `hotspot_categories.csv` | 工程类别 inclusive stack 聚合。 |
+| `report.json` | 机器可读报告，包含 `callchain` 与 `resolve_stats`。 |
+
+检查火焰图是否真的有深栈：
+
+```bash
+awk -F';' '{print NF}' target/.../qperf/stack.folded | sort -n | uniq -c
+cat target/.../qperf/stack-depth-summary.csv
+```
+
+如果大部分 `NF=1`，说明当前 folded stack 仍是 leaf-only；应确认是否开启 `--full-stack`，以及 kernel 是否用 frame pointer 构建。
+
+## symbol style
+
+| style | 用途 |
+| --- | --- |
+| `full` | 保留完整 Rust demangled path，适合归因和搜索。 |
+| `module` | 保留 crate 与尾部模块/函数，适合 SVG 可读性。 |
+| `short` | 只看函数尾名，适合粗略热点。 |
+
+SVG 因空间限制可能截断长 frame；需要确认完整 symbol 时看 `stack.folded`。
+
+## marker/window
+
+推荐所有 workload profile 使用 marker，避免 boot 样本污染：
+
+```bash
+cargo starry perf \
+  --case blk-read \
+  --full-stack \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload 'echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk-read'
+```
+
+`report.json.window` 会记录：
+
+* `start_time`
+* `stop_time`
+* `duration_sec`
+* `boot_samples_excluded`
+* `post_window_samples_excluded`
+* `warnings`
+
+当前 window 过滤是 postprocess 级别过滤，不是 QEMU plugin runtime pause/resume。
+
+## 聚焦 virtio/block 路径
+
+```bash
+cargo starry perf \
+  --case blk-virtio \
+  --full-stack \
+  --qperf-metrics \
+  --focus 'virtio|VirtQueue|block|memcpy|memmove' \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:blk; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; cat /proc/qperf_metrics; echo QPERF_END:blk'
+```
+
+典型深栈应能看到类似路径：
+
+```text
+starry_kernel::syscall::fs::io::sys_read
+  -> ax_fs_ng / rsext4
+  -> ax_driver::block::binding::Block::read_blocks_wait
+  -> rd_block::CmdQueue::read_blocks_blocking
+  -> ax_driver::virtio::block::BlockQueue::submit_request
+  -> virtio_drivers::queue::VirtQueue::add_notify_wait_pop
+```
+
+## 聚焦 net 路径
+
+先启动 host HTTP server：
+
+```bash
+python3 -m http.server 8000 --bind 0.0.0.0
+```
+
+另一个终端运行：
+
+```bash
+cargo starry perf \
+  --case net-full-stack \
+  --full-stack \
+  --qperf-metrics \
+  --timeout 300 \
+  --workload-timeout 240 \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:net; wget -O /dev/null http://10.0.2.2:8000/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img.tar.xz; cat /proc/qperf_metrics; echo QPERF_END:net'
+```
+
+典型深栈应能看到：
+
+```text
+starry_kernel::syscall::fs::io::sys_readv
+  -> ax_net_ng::SocketOps::recv
+  -> ax_net_ng::poll_interfaces
+  -> RdNetDriver::prefetch_rx_packets
+  -> rd_net::RxQueue
+  -> compiler_builtins::mem::memcpy / memmove
+```
+
+## 当前验证数据
+
+本轮验证产物位于 `target/qperf-callchain-validation/`：
+
+| case | callchain | 多帧样本 | raw max depth | folded symbol depth |
+| --- | --- | ---: | ---: | ---: |
+| blk leaf | `leaf` | 0 / 577 | 1 | 1 |
+| blk full-stack | `fp` | 578 / 579 | 18 | 最高 72 |
+| net full-stack | `fp` | 652 / 661 | 17 | 最高 78 |
+
+详细报告见 `docs/qperf-callchain-validation-report.md`。
+
+## 技术边界
+
+* qperf 仍是 QEMU TCG plugin 采样，不是 guest PMU。
+* `fp` 模式依赖 frame pointer；没有 `-Cforce-frame-pointers=yes` 时无法保证深栈。
+* 当前只解析 kernel ELF，用户态符号尚未纳入。
+* trap、异常入口、任务切换、汇编 trampoline 可能截断调用链。
+* inline frame 会让 folded symbol 层数大于 raw FP 地址层数；两者都是真实信息，但含义不同。
+* `hotspot_categories.csv` 是 inclusive stack 分类，不是互斥 CPU 时间分解。

--- a/docs/qperf-marker-and-metrics-usage.md
+++ b/docs/qperf-marker-and-metrics-usage.md
@@ -1,0 +1,158 @@
+# qperf Marker And Metrics Usage
+
+`cargo starry perf` is now the preferred entrypoint for local qperf runs. The
+lower-level harness commands below remain supported for Docker-wrapped syscall
+harness workflows and compatibility.
+
+```bash
+cargo starry perf \
+  --case blk-read \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; cat /proc/qperf_metrics; echo QPERF_END:blk-read'
+```
+
+See also `docs/qperf-cargo-starry-integration.md` and
+`docs/qperf-flamegraph-guide.md`.
+
+## Basic Marker Run
+
+Use explicit guest stdout markers around the workload:
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --timeout 60 \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 30 \
+  --shell-init-cmd 'echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk-read'
+```
+
+The report window is written to `report.json.window` and `qperf/window.json`.
+
+Important fields:
+
+- `window.start_marker`
+- `window.stop_marker`
+- `window.start_time`
+- `window.stop_time`
+- `window.duration_sec`
+- `window.truncated_by_timeout`
+- `window.boot_samples_excluded`
+- `window.warnings`
+
+If the start marker is missing, the report includes a warning because boot samples may still be present. If the stop marker is missing, the window extends until QEMU exits or times out.
+
+## Virtio Counter Run
+
+The tools-side parser can merge any `QPERF_METRIC key=value` line printed by the
+guest into `report.json.workload_metrics.values`. If the profiled StarryOS
+branch provides `/proc/qperf_metrics`, enable parsing with `--qperf-metrics`,
+reset before the workload, and print `/proc/qperf_metrics` before the stop
+marker:
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --timeout 60 \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 30 \
+  --shell-init-cmd 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; cat /proc/qperf_metrics; echo QPERF_END:blk-read'
+```
+
+For net:
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --timeout 90 \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 45 \
+  --shell-init-cmd 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:net-wget; wget -O /dev/null http://10.0.2.2:8000/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img.tar.xz; cat /proc/qperf_metrics; echo QPERF_END:net-wget'
+```
+
+When this command is run through the default Docker wrapper, the HTTP server for
+`10.0.2.2:8000` must be inside the same container namespace as QEMU. One usable
+pattern is to start `python3 -m http.server 8000 --bind 0.0.0.0` in the wrapper
+before invoking `harness.py --no-docker`.
+
+The parser merges `QPERF_METRIC key=value` fields into `report.json.workload_metrics.values`.
+This tools-only integration does not create `/proc/qperf_metrics` by itself;
+that procfs export is a separate kernel/driver instrumentation concern.
+
+## Counter Interpretation
+
+When a profiled branch exports counters through `/proc/qperf_metrics`, those
+counters are driver-visible observations. They are useful for A/B validation,
+but they should not be described as exact virtqueue ring-level accounting.
+
+Important blk counters:
+
+- `virtqueue_add_notify_wait_pop_count`: synchronous virtqueue submit/notify/wait/pop path count.
+- `virtqueue_add_count`: driver-visible virtqueue add count.
+- `virtio_notify_kick_count`: driver-visible notify/kick count.
+- `virtqueue_pop_complete_count`: driver-visible completion pop count.
+- `virtqueue_depth_max` and `virtqueue_depth_hist_*`: approximate queue depth observation.
+- `virtio_blk_read_requests` and `virtio_blk_read_bytes`: blk read request count and bytes recorded by the driver.
+
+One existing marker-aware blk profile at
+`target/qperf-validation/blk/perf/riscv64/latest/report.json` reported:
+
+| metric | value |
+| --- | ---: |
+| `dd` bytes | 53,601,104 |
+| `dd` elapsed | 5.794463 s |
+| `virtqueue_add_notify_wait_pop_count` | 13,780 |
+| `virtio_notify_kick_count` | 13,847 |
+| `virtio_blk_read_requests` | 13,478 |
+| `virtio_blk_read_bytes` | 55,195,136 |
+| average blk read request size | 4,095.20 bytes |
+
+This is a useful bottleneck signal: even when the guest command uses
+`bs=64k`, the driver-visible blk request size is still about 4 KiB and the
+number of notify/kick events is close to the number of virtqueue adds. See
+`docs/qperf-current-blk-bottleneck-analysis.md` for the full analysis.
+
+## Host Perf
+
+Host perf is opt-in:
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --host-time \
+  --host-perf \
+  --host-perf-events task-clock,cycles,instructions,cache-references,cache-misses
+```
+
+These counters measure the host QEMU process. They are not guest PMU counters.
+
+## A/B Compare
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-compare \
+  --baseline target/starry-syscall-harness/perf/riscv64/baseline/report.json \
+  --candidate target/starry-syscall-harness/perf/riscv64/candidate/report.json \
+  --name blk-read-ab
+```
+
+The comparison output is under:
+
+```text
+target/starry-syscall-harness/perf-compare/blk-read-ab/
+```
+
+`compare.md` gives an automatic conclusion: `明显改善`, `基本无变化`, `退化`, or `数据不足`.
+
+## Limitations
+
+- Runtime qperf plugin enable/disable is not implemented; filtering is done by sample timestamps during analyzer postprocess.
+- Driver-visible queue depth and notify/kick counters are approximate. Exact ring-level accounting requires adding counters inside `virtio-drivers`.
+- Place `cat /proc/qperf_metrics` before the stop marker. The harness asks QEMU to quit once the stop marker is observed.
+- If `/dev/vhost-vsock` is missing on the host, vsock experiments should record the environment blocker and must not fabricate vsock throughput or counters.

--- a/docs/qperf-tooling-improvement-report.md
+++ b/docs/qperf-tooling-improvement-report.md
@@ -1,0 +1,331 @@
+# qperf Tooling Improvement Report
+
+## 当前问题复盘
+
+原 qperf 更接近“从 QEMU 启动到退出的栈采样器”。对 virtio-blk/net/vsock 做性能归因时有三个直接问题：
+
+- 采样窗口默认覆盖 boot，PCI probe、调度、allocator、rootfs 初始化会混入数据面结论。
+- 输出主要是 folded stack、火焰图和符号热点，不能直接回答 queue depth、notify/kick、copy bytes、inflight 操作次数等工程问题。
+- 优化前后需要人工翻多个报告，缺少字段级 delta、百分比变化和数据不足提示。
+
+## 改造目标
+
+本轮改造的目标是形成一个最小可闭环的实验工具：
+
+- 用 guest stdout marker 定义 workload 窗口，默认避免 boot 污染。
+- 保留原有 qperf 输出，同时增加类别归因、workload metrics、归一化指标。
+- 用 feature-gated 轻量 counter 记录 virtio-blk/net 的关键路径事件。
+- 增加 A/B compare，支撑优化验证。
+- 对 vsock 环境阻塞显式记录，不伪造吞吐或 counter。
+
+## 实现方案
+
+### marker/window
+
+`cargo xtask starry perf` 与 `harness.py perf-profile` 新增：
+
+- `--start-marker TEXT`
+- `--stop-marker TEXT`
+- `--workload-timeout SECONDS`
+- `--qperf-metrics`
+
+qperf plugin raw record 升级为带 `elapsed_ns` 的 v2 格式。`qperf-analyzer resolve` 新增 `--start-sec`、`--stop-sec`、`--stats`，按 marker 时间在 postprocess 阶段过滤 folded stack 和 flamegraph。旧 raw 格式仍可解析，但不能做时间窗口过滤。
+
+marker 模式下，harness 会在 shell prompt 出现后注入 workload，并先关闭串口回显，避免 shell 把整行命令回显出来导致 `QPERF_END` 被提前匹配。stop marker 出现后，harness 优先通过 QMP `quit` 停 QEMU，失败再退回 SIGINT。
+
+### 分类聚合
+
+报告新增 `hotspot_categories.csv`，并在 `report.json.hotspots.category_totals` 和 `report.md` 写入 inclusive category 聚合。当前类别包括：
+
+- `virtqueue_add_notify_wait_pop`
+- `virtqueue_add`
+- `virtqueue_pop_complete`
+- `virtio_notify_kick`
+- `memcpy`
+- `memmove`
+- `allocator`
+- `scheduler_wait_preempt`
+- `lock_mutex_wait`
+- `pci_probe_transport`
+- `net_inflight_btree`
+- `block_io_path`
+- `net_rx_tx_path`
+- `vsock_tx_rx_path`
+
+类别是工程归因视角，和符号热点并列展示；一个栈可以同时计入 subsystem 和 bottleneck 类别。
+
+### workload metrics
+
+harness 解析 guest stdout：
+
+- `dd`：bytes、seconds、reported MB/s、派生 B/s。
+- `wget`：saved 状态、BusyBox 进度条里的大小；若 wget 不输出耗时，则使用 marker window duration 作为 `elapsed_source=marker_window`。
+- `QPERF_METRIC key=value`：合入 `report.json.workload_metrics.values`。
+
+新增归一化字段：
+
+- `guest_instructions_per_MB`
+- `guest_blocks_per_MB`
+- `host_elapsed_sec_per_MB`
+- `samples_per_MB`
+- `category_samples_per_MB`
+
+本轮示例未启用 `--host-perf`，报告中明确记录 `未启用 host perf`。
+
+### virtio counters
+
+`ax-driver` 新增默认关闭的 `qperf-metrics` feature。启用后通过 `AtomicU64` 记录 driver-visible counter，并由 StarryOS `/proc/qperf_metrics` 导出 `QPERF_METRIC`：
+
+- virtqueue add/notify/pop/add_notify_wait_pop 近似计数。
+- driver 可见 inflight depth max 和 histogram。
+- blk read/write request count 和 bytes。
+- net RX/TX packet count 和 bytes。
+- net RX `copy_within` count 和 bytes。
+- net TX staging copy count 和 bytes。
+- net inflight map insert/remove/get count。
+
+这些 counter 是 driver glue 层视角的近似值。精确 descriptor-ring depth、精确 notify/kick 和 `VirtQueue::add_notify_wait_pop()` 内部事件仍需要在 `virtio-drivers` crate 内增加 instrumentation。
+
+### A/B compare
+
+新增：
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-compare \
+  --baseline <baseline-report-or-dir> \
+  --candidate <candidate-report-or-dir> \
+  --name <case-name>
+```
+
+输出：
+
+- `compare.json`
+- `compare.md`
+- `compare.csv`
+
+对比字段包括 workload throughput/elapsed、guest executed instructions/blocks、host elapsed/user/sys、hotspot categories、virtio counters、copy bytes、notify/kick count、queue depth max/histogram。缺失字段显示 `N/A`。
+
+已做 smoke test：
+
+```text
+target/qperf-tooling-experiments/blk/compare-self/perf-compare/blk-self-smoke/compare.md
+```
+
+结论为 `基本无变化`，这是同一份 blk report 自比较的预期结果。
+
+## 新增 JSON 字段说明
+
+`report.json.window`：
+
+- `start_marker` / `stop_marker`：marker 文本。
+- `start_time` / `stop_time`：相对 QEMU 启动的秒数。
+- `duration_sec`：workload 窗口时长。
+- `workload_timeout`：窗口超时配置。
+- `truncated_by_timeout`：是否由 workload timeout 截断。
+- `boot_samples_excluded`：过滤掉的 start marker 之前样本数。
+- `post_window_samples_excluded`：过滤掉的 stop marker 之后样本数。
+- `stop_method`：如 `qmp_quit`。
+- `warnings`：marker 缺失、旧 raw 格式等风险。
+
+`report.json.workload_metrics`：
+
+- `dd[]`
+- `wget[]`
+- `custom[]`
+- `values`
+- `raw_metric_lines`
+
+`report.json.normalized_metrics`：
+
+- `workload_bytes`
+- `workload_elapsed_seconds`
+- `samples_per_MB`
+- `host_elapsed_sec_per_MB`
+- `guest_instructions_per_MB`
+- `guest_blocks_per_MB`
+- `category_samples_per_MB`
+
+## 示例实验结果
+
+实验环境：
+
+- arch: `riscv64`
+- qperf freq: `99`
+- mode: `tb`
+- `--host-time` enabled
+- `--host-perf` disabled
+- `--qperf-metrics` enabled
+- net 用例在同一个 Docker 容器内启动临时 `python3 -m http.server 8000`，确保 guest 的 `10.0.2.2:8000` 可达。
+
+### blk focused workload
+
+命令：
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --timeout 90 \
+  --format folded \
+  --top 20 \
+  --host-time \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 45 \
+  --output-dir target/qperf-tooling-experiments/blk \
+  --shell-init-cmd 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; cat /proc/qperf_metrics; echo QPERF_END:blk-read'
+```
+
+产物：
+
+```text
+target/qperf-tooling-experiments/blk/perf/riscv64/latest/report.json
+```
+
+实际结果：
+
+- samples: `589`
+- window: `1.58549195 -> 7.539382377`, duration `5.953890427s`
+- boot samples excluded: `156`
+- post-window samples excluded: `496`
+- dd: `53601104 bytes`, `5.805581s`, `9232685.58 B/s`
+- host elapsed: `12.552265s`
+- samples_per_MB: `10.98858`
+- host_elapsed_sec_per_MB: `0.234179`
+
+主要类别：
+
+| Category | Samples | Percent |
+|---|---:|---:|
+| `memcpy` | 166 | 28.18% |
+| `virtio_notify_kick` | 145 | 24.62% |
+| `virtqueue_add_notify_wait_pop` | 144 | 24.45% |
+| `block_io_path` | 115 | 19.52% |
+| `allocator` | 89 | 15.11% |
+
+关键 counter：
+
+| Counter | Value |
+|---|---:|
+| `virtqueue_add_notify_wait_pop_count` | 13780 |
+| `virtqueue_add_count` | 13847 |
+| `virtio_notify_kick_count` | 13847 |
+| `virtqueue_pop_complete_count` | 13783 |
+| `virtqueue_depth_max` | 63 |
+| `virtio_blk_read_requests` | 13478 |
+| `virtio_blk_read_bytes` | 55195136 |
+| `virtio_blk_write_requests` | 302 |
+| `virtio_blk_write_bytes` | 1236992 |
+
+结论：blk 数据面窗口里 `add_notify_wait_pop` 和 notify/kick 占比明确可见，且 counter 显示 read request 数与同步等待次数基本同量级，支持继续验证异步化、批处理和更高 queue depth 的优化方向。
+
+### net focused workload
+
+命令核心：
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --timeout 120 \
+  --format folded \
+  --top 20 \
+  --host-time \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 60 \
+  --output-dir target/qperf-tooling-experiments/net \
+  --shell-init-cmd 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:net-wget; wget -O /dev/null http://10.0.2.2:8000/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img.tar.xz; cat /proc/qperf_metrics; echo QPERF_END:net-wget'
+```
+
+产物：
+
+```text
+target/qperf-tooling-experiments/net/perf/riscv64/latest/report.json
+```
+
+实际结果：
+
+- samples: `719`
+- window: `1.566331117 -> 8.825886896`, duration `7.259555779s`
+- boot samples excluded: `154`
+- post-window samples excluded: `494`
+- wget: BusyBox progress `60.6M`, parsed as `63543705 bytes`
+- wget elapsed source: `marker_window`
+- wget throughput: `8753112.03 B/s`
+- host elapsed: `13.836669s`
+- samples_per_MB: `11.315047`
+- host_elapsed_sec_per_MB: `0.21775`
+
+主要类别：
+
+| Category | Samples | Percent |
+|---|---:|---:|
+| `memcpy` | 231 | 32.13% |
+| `net_rx_tx_path` | 169 | 23.50% |
+| `allocator` | 117 | 16.27% |
+| `memmove` | 53 | 7.37% |
+| `scheduler_wait_preempt` | 24 | 3.34% |
+
+关键 counter：
+
+| Counter | Value |
+|---|---:|
+| `virtqueue_add_notify_wait_pop_count` | 605 |
+| `virtqueue_add_count` | 47289 |
+| `virtio_notify_kick_count` | 47289 |
+| `virtqueue_pop_complete_count` | 47225 |
+| `virtqueue_depth_max` | 63 |
+| `virtio_net_rx_packets` | 44141 |
+| `virtio_net_rx_bytes` | 65937102 |
+| `virtio_net_rx_copy_within_bytes` | 65937102 |
+| `virtio_net_tx_staging_copy_bytes` | 149442 |
+| `virtio_net_inflight_insert_count` | 46684 |
+| `virtio_net_inflight_remove_count` | 46620 |
+| `virtio_net_inflight_get_count` | 46620 |
+
+结论：net 数据面里的 copy 成本已被同时体现在符号热点、类别聚合和 counter 中。RX `copy_within` bytes 与 RX bytes 同量级，说明 RX 路径每包仍有完整搬移；TX staging copy 相对下载流量较小。inflight map 操作次数和包数同量级，后续应针对该结构做替换或减少访问频率的 A/B 验证。
+
+## 新旧报告对比
+
+旧报告只能回答“哪些 guest 函数/栈采样最多”，且默认混入 boot-to-exit 样本。新报告可以直接看到：
+
+- marker window 起止时间、时长、boot/post-window 排除样本数。
+- 符号热点与工程类别热点分离展示。
+- workload bytes、elapsed、throughput 和 per-MB 归一化指标。
+- virtio counter 与 copy bytes。
+- host perf 未启用时的显式说明。
+- A/B compare 的 delta、百分比变化和 `N/A` 缺失字段。
+
+本轮没有生成“旧工具同 workload”的历史 baseline，因此没有伪造旧版数字。已有 `blk-self-smoke` compare 只用于验证 compare 工具输出路径和缺失字段处理。
+
+## 局限性
+
+- qperf plugin 仍未支持运行时暂停/恢复；当前是 timestamped raw sample + analyzer postprocess 过滤。
+- driver-visible queue depth/notify/kick 是近似 counter，不等价于 virtio ring 内部精确事件。
+- `guest_instructions_per_MB` 和 `guest_blocks_per_MB` 当前为 `N/A`，需要 qperf summary 稳定导出 executed instruction/block 字段后才能归一化。
+- net wget 的 BusyBox 输出没有真实下载耗时，本轮用 marker window duration 派生 elapsed/throughput，并在 JSON 中记录 `elapsed_source=marker_window`。
+- host perf 本轮未启用；报告只合入 host wall/user/sys time。
+- 当前宿主机没有 `/dev/vhost-vsock`：`ls /dev/vhost-vsock` 返回 `No such file or directory`。因此本轮没有 vsock 吞吐数据，也没有编造 vsock counter。
+- `target/qperf-tooling-experiments` 曾由 Docker root 创建，直接写顶层 compare 目录会遇到权限问题；后续可统一在 wrapper 里 chown 输出根目录。
+
+## 后续优化建议
+
+virtio-blk：
+
+- 将同步 `add_notify_wait_pop` 路径改为可批处理或异步 completion，先用 `virtqueue_add_notify_wait_pop_count`、throughput 和 `block_io_path` category 做 A/B。
+- 对连续 read 请求做合并或更大块提交，观察 request count、notify/kick count 是否下降。
+- 在 `virtio-drivers` 内加入精确 ring depth 和 kick counter，校准 driver-visible 近似值。
+
+virtio-net：
+
+- 优先减少 RX `copy_within`，目标是让 `virtio_net_rx_copy_within_bytes / virtio_net_rx_bytes` 明显下降。
+- 减少 TX staging Vec copy，观察 `virtio_net_tx_staging_copy_bytes` 和 `memcpy` category。
+- 替换或减少 inflight `BTreeMap` 操作，使用 counter 和 `net_inflight_btree` category 做验证。
+- 将 RX/TX queue lock 拆分或缩短锁内 copy，观察 `net_rx_tx_path`、allocator、scheduler 类别变化。
+
+virtio-vsock：
+
+- 先补齐 `/dev/vhost-vsock` 环境和可重复 workload。
+- 环境不可用时，report 应保留 blocker 字段或 stdout marker 说明，不输出吞吐。
+- 可用后按 net 的方式增加 vsock TX/RX bytes、packet、copy、queue counter，并纳入 compare。

--- a/docs/qperf-tooling-redesign.md
+++ b/docs/qperf-tooling-redesign.md
@@ -1,0 +1,117 @@
+# qperf Tooling Redesign
+
+## Goals
+
+This redesign turns qperf from a boot-to-exit stack sampler into a workload-oriented experiment tool for virtio-blk, virtio-net, and virtio-vsock attribution.
+
+The main changes are:
+
+- workload windows driven by guest stdout markers;
+- timestamped qperf samples and analyzer-side time filtering;
+- hotspot category aggregation in addition to symbol hotspots;
+- workload stdout metric parsing for `dd`, `wget`, and `QPERF_METRIC`;
+- feature-gated virtio counters exported through `/proc/qperf_metrics`;
+- report-level A/B comparison for baseline and candidate runs.
+
+## Sampling Window
+
+`cargo xtask starry perf` and `harness.py perf-profile` accept:
+
+- `--start-marker TEXT`
+- `--stop-marker TEXT`
+- `--workload-timeout SECONDS`
+
+When a start marker is observed in guest stdout, the host records elapsed time since QEMU launch. When a stop marker is observed, qperf asks QEMU to quit through QMP, falling back to SIGINT if QMP is unavailable.
+
+For shell-injected workloads, the monitor disables shell echo before sending the command so marker matching is driven by workload output rather than by the echoed command line.
+
+The qperf plugin now writes raw records as format version 2:
+
+- `elapsed_ns`
+- stack IP trace
+
+`qperf-analyzer resolve` accepts `--start-sec`, `--stop-sec`, and `--stats`. The generated folded stack and flamegraph are filtered to the marker window when timestamps are available. Older raw files are still accepted, but elapsed-time filtering cannot be applied to format version 1 samples.
+
+## Attribution Categories
+
+The harness parses `qperf/stack.folded` and writes inclusive category totals to:
+
+- `hotspot_categories.csv`
+- `report.json.hotspots.category_totals`
+- `report.md`
+
+The current category set is:
+
+- `virtqueue_add_notify_wait_pop`
+- `virtqueue_add`
+- `virtqueue_pop_complete`
+- `virtio_notify_kick`
+- `memcpy`
+- `memmove`
+- `allocator`
+- `scheduler_wait_preempt`
+- `lock_mutex_wait`
+- `pci_probe_transport`
+- `net_inflight_btree`
+- `block_io_path`
+- `net_rx_tx_path`
+- `vsock_tx_rx_path`
+
+Categories are inclusive and non-exclusive: one stack can contribute to both a subsystem category, such as `net_rx_tx_path`, and a bottleneck category, such as `memmove`.
+
+## Workload Metrics
+
+The harness parses guest stdout for:
+
+- `dd` byte count, elapsed seconds, and throughput;
+- `wget` length/saved byte count and elapsed seconds when visible;
+- custom `QPERF_METRIC key=value` fields.
+
+Parsed values are stored in:
+
+- `report.json.workload_metrics`
+- `report.json.normalized_metrics`
+
+Normalized fields include:
+
+- `guest_instructions_per_MB`
+- `guest_blocks_per_MB`
+- `host_elapsed_sec_per_MB`
+- `samples_per_MB`
+- `category_samples_per_MB`
+
+Host perf stat output is included only when `--host-perf` is enabled. Otherwise the report explicitly records `未启用 host perf`.
+
+## Virtio Counters
+
+The `qperf-metrics` feature is off by default. When enabled, `ax-driver` records lightweight `AtomicU64` counters in the virtio glue layer:
+
+- blk read/write request count and bytes;
+- net RX/TX packet count and bytes;
+- net RX `copy_within` count and bytes;
+- net TX staging copy count and bytes;
+- inflight map insert/remove/get count;
+- approximate virtqueue add/notify/pop counts from driver submit/reclaim points;
+- approximate queue depth max and histogram from driver-visible inflight depth.
+
+The counters are exported by StarryOS at `/proc/qperf_metrics` as `QPERF_METRIC` lines. Writing `reset` clears the counters.
+
+These counters are intentionally described as driver-visible approximations. Exact descriptor-ring depth, exact notify/kick count, and `VirtQueue::add_notify_wait_pop()` internals require instrumentation inside the `virtio-drivers` crate.
+
+## A/B Compare
+
+Use:
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-compare \
+  --baseline target/starry-syscall-harness/perf/riscv64/baseline \
+  --candidate target/starry-syscall-harness/perf/riscv64/candidate
+```
+
+Inputs can be a `report.json`, a profile directory, a qperf directory, or a folded stack file. Outputs are:
+
+- `compare.json`
+- `compare.md`
+- `compare.csv`
+
+The comparison includes workload throughput/elapsed time, guest executed instructions/blocks, host time/perf metrics, hotspot categories, virtio counters, copy bytes, notify/kick count, and queue depth fields when present. Missing fields are rendered as `N/A` instead of failing.

--- a/docs/qperf-tooling-validation-report.md
+++ b/docs/qperf-tooling-validation-report.md
@@ -1,0 +1,262 @@
+# qperf 工具改造验收报告
+
+## 1. 验收目标
+
+本轮验收验证 qperf 工具改造是否已经从“启动即采样的火焰图工具”升级为可支撑 virtio-blk、virtio-net、virtio-vsock 性能归因和优化 A/B 验证的实验工具。重点回答：
+
+* 是否解决 boot 阶段样本污染 workload 数据面的问题。
+* 是否具备 marker 驱动的 workload window。
+* 是否具备工程分类热点，而不只是 symbol hotspot。
+* 是否具备 virtio-aware counters，并能进入最终 report。
+* 是否具备 A/B compare 输出。
+* 是否保持旧 perf-profile 命令兼容。
+* 是否足以支撑下一轮 virtio 优化验证。
+
+## 2. 验收环境
+
+| 项目 | 值 |
+| --- | --- |
+| 仓库 commit | `6e748d6b7a5b3a8e90e2cba3b030ea0ca9c3e617` |
+| 分支 | `fix/starry-syscall-harness` |
+| git status | 工作区非干净，包含本轮 qperf 改造文件和若干既有未跟踪文档；本报告未覆盖已有实验结果 |
+| Host kernel | `Linux LAPTOP-SAOPKIGH 5.15.167.4-microsoft-standard-WSL2 x86_64` |
+| CPU | Intel Core i7-14650HX, 24 vCPU, WSL2 |
+| Docker image | `ghcr.io/rcore-os/tgoskits-container:latest`, image id `sha256:b7c4600e825dcb474d1f6a6bc51b8e6616ada23a24d048fc45522a58f76eb162` |
+| Guest arch | `riscv64` |
+| QEMU | `qemu-system-riscv64`, `virt` machine, 512 MiB, virtio-blk-pci, virtio-net-pci user net, qperf plugin, QMP unix socket |
+| qperf 参数 | marker runs 使用 `--host-time --qperf-metrics --start-marker QPERF_BEGIN --stop-marker QPERF_END --workload-timeout 45` |
+| qperf-metrics | blk/net marker 用例启用；兼容性旧命令未启用 |
+| host perf | 未启用；报告中显示 `未启用 host perf` |
+
+构建检查：
+
+* `python3 -m py_compile tools/starry-syscall-harness/harness.py`：PASS。
+* `cargo clippy -p ax-driver --no-default-features --features 'plat-dyn,virtio-blk,virtio-net,virtio-socket,qperf-metrics' -- -D warnings`：PASS。
+* `cargo clippy -p ax-driver --no-default-features --features 'plat-dyn,virtio-blk,virtio-net,virtio-socket' -- -D warnings`：PASS。
+
+## 3. 验收矩阵
+
+| 模块 | 验收项 | 结果 | 证据文件 | 备注 |
+| --- | --- | --- | --- | --- |
+| harness/window | start/stop marker | PASS | `target/qperf-validation/blk/perf/riscv64/latest/report.json` | window start/stop/duration 已记录 |
+| harness/window | boot/post-window 样本排除 | PASS | `target/qperf-validation/blk/perf/riscv64/latest/report.json` | blk boot 排除 164，post-window 排除 492 |
+| harness/window | marker missing warning | PASS | `target/qperf-validation/missing-stop/perf/riscv64/latest/report.json` | 超时截断并记录 warning |
+| qperf/report | required report artifacts | PASS | `target/qperf-validation/blk/perf/riscv64/latest/` | report/json/md、csv、folded、flamegraph、stdout/stderr 存在 |
+| qperf/report | plugin summary / guest instr | PARTIAL | `target/qperf-validation/blk/perf/riscv64/latest/report.json` | blk 缺少 `qperf/qperf.summary.txt`，guest instr/blocks per MB 为 N/A |
+| qperf/report | hotspot_categories.csv | PASS | `target/qperf-validation/blk/perf/riscv64/latest/hotspot_categories.csv` | 分类非空，包含 memcpy、virtqueue、block path 等 |
+| qperf/report | dd parser | PASS | `target/qperf-validation/blk/perf/riscv64/latest/report.json` | 解析 53,601,104 bytes、5.794463s |
+| qperf/report | wget parser | PASS | `target/qperf-validation/net-container/perf/riscv64/latest/report.json` | container 内 HTTP server 用例解析成功 |
+| qperf/report | 用户给定 net 命令 | FAIL | `target/qperf-validation/net/perf/riscv64/latest/profile.stdout` | Docker/WSL 拓扑下 `10.0.2.2:8000` connection refused |
+| virtio counters | feature 默认关闭 | PASS | `drivers/ax-driver/Cargo.toml`，clippy 输出 | 默认 feature 未强制开启 instrumentation |
+| virtio counters | blk counters | PASS | `target/qperf-validation/blk/perf/riscv64/latest/report.json` | blk read bytes/request、virtqueue、notify/kick 计数进入 report |
+| virtio counters | net counters | PASS | `target/qperf-validation/net-container/perf/riscv64/latest/report.json` | RX/TX bytes、copy bytes、inflight 操作进入 report |
+| virtio counters | reset counters | PARTIAL | marker workload shell 命令与 `/proc/qperf_metrics` 代码 | 已执行 `echo reset`，但未做单独 before/after 定量隔离 |
+| compare | self compare | PASS | `target/qperf-validation/blk/compare-self/perf-compare/blk-self-smoke/compare.md` | 主要指标 delta 为 0，结论“基本无变化” |
+| compare | cross compare | PASS | `target/qperf-validation/blk/compare-cross/perf-compare/blk-vs-net-cross/compare.md` | 不 crash，缺失字段显示 N/A；跨 workload 结论不应用作优化判断 |
+| compatibility | old command | PASS | `target/qperf-validation/compat-old/perf/riscv64/latest/report.json` | 未传 marker/qperf-metrics 时仍可运行 |
+| vsock | vhost-vsock 环境 | BLOCKED | `/dev/vhost-vsock` 检查 | 当前 host 无该设备，未做定量结论 |
+
+本轮发现并做了一个最小修复：`report.json` 的 artifacts 列表原先缺少 `profile.stdout`、`profile.stderr`、raw sample、summary、QEMU config 等已生成文件。已在 `tools/starry-syscall-harness/harness.py` 中补充，并通过 py_compile 与旧命令兼容性 smoke test。
+
+## 4. blk 验证结果
+
+命令：
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --host-time \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 45 \
+  --shell-init-cmd 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; cat /proc/qperf_metrics; echo QPERF_END:blk-read' \
+  --output-dir target/qperf-validation/blk
+```
+
+证据：`target/qperf-validation/blk/perf/riscv64/latest/report.json`
+
+| 指标 | 值 |
+| --- | --- |
+| dd bytes | `53601104` |
+| dd elapsed | `5.794463` s |
+| dd throughput | `9250400.597950146` B/s，约 `8.8 MB/s` |
+| marker window duration | `5.951667225` s |
+| boot samples excluded | `164` |
+| post-window samples excluded | `492` |
+| total workload samples | `590` |
+| samples per MB | `11.007236` |
+| instructions per MB | N/A |
+| blocks per MB | N/A |
+| host elapsed per MB | `0.235666` s/MB |
+| host elapsed/user/sys | `12.631965` / `14.222615` / `0.750295` s |
+
+Top hotspot categories：
+
+| category | samples | percent |
+| --- | ---: | ---: |
+| `memcpy` | 173 | 29.3220% |
+| `virtio_notify_kick` | 154 | 26.1017% |
+| `virtqueue_add_notify_wait_pop` | 151 | 25.5932% |
+| `block_io_path` | 108 | 18.3051% |
+| `allocator` | 79 | 13.3898% |
+| `scheduler_wait_preempt` | 10 | 1.6949% |
+
+Virtio/block counters：
+
+| counter | value |
+| --- | ---: |
+| `virtqueue_add_notify_wait_pop_count` | 13,780 |
+| `virtqueue_add_count` | 13,847 |
+| `virtio_notify_kick_count` | 13,847 |
+| `virtqueue_pop_complete_count` | 13,783 |
+| `virtqueue_depth_max` | 63 |
+| `virtio_blk_read_requests` | 13,478 |
+| `virtio_blk_read_bytes` | 55,195,136 |
+| `virtio_blk_write_requests` | 302 |
+| `virtio_blk_write_bytes` | 1,236,992 |
+
+判断：blk 已能支撑后续“同步 `add_notify_wait_pop` 是否下降、queue depth 是否被利用、blk read bytes/request 是否匹配 workload”的 A/B 验证。但当前 blk 报告缺少 `qperf/qperf.summary.txt`，导致 guest instructions/blocks per MB 为 N/A；这会削弱严肃的指令级归一化判断，需要修复 plugin summary 落盘或 QEMU 退出流程。
+
+## 5. net 验证结果
+
+用户给定命令在当前 Docker/WSL 环境下失败：host HTTP server 启动在 WSL host，guest 访问 Docker 内 QEMU slirp 的 `10.0.2.2:8000`，结果为 connection refused。失败证据：`target/qperf-validation/net/perf/riscv64/latest/profile.stdout`。
+
+为验证工具本身，补跑了 container 内 HTTP server 版本，使 guest 的 `10.0.2.2:8000` 指向同一个 Docker 网络命名空间内的服务。证据：`target/qperf-validation/net-container/perf/riscv64/latest/report.json`。
+
+| 指标 | 值 |
+| --- | --- |
+| wget bytes | `63543705` |
+| wget elapsed | `7.299213151` s，来源为 marker window |
+| wget throughput | `8705555.473646423` B/s |
+| marker window duration | `7.299213151` s |
+| boot samples excluded | `155` |
+| post-window samples excluded | `0` |
+| total workload samples | `722` |
+| samples per MB | `11.362258` |
+| instructions per MB | `18821395.746439` |
+| blocks per MB | `2875126.497581` |
+| host elapsed per MB | `0.141124` s/MB |
+| host elapsed/user/sys | `8.967565` / `9.559295` / `0.818735` s |
+
+Top hotspot categories：
+
+| category | samples | percent |
+| --- | ---: | ---: |
+| `memcpy` | 220 | 30.4709% |
+| `net_rx_tx_path` | 158 | 21.8837% |
+| `allocator` | 114 | 15.7895% |
+| `memmove` | 81 | 11.2188% |
+| `scheduler_wait_preempt` | 21 | 2.9086% |
+| `block_io_path` | 2 | 0.2770% |
+
+Virtio/net counters：
+
+| counter | value |
+| --- | ---: |
+| `virtio_net_rx_packets` | 44,141 |
+| `virtio_net_rx_bytes` | 65,937,102 |
+| `virtio_net_rx_copy_within_count` | 44,141 |
+| `virtio_net_rx_copy_within_bytes` | 65,937,102 |
+| `virtio_net_tx_packets` | 2,478 |
+| `virtio_net_tx_bytes` | 149,322 |
+| `virtio_net_tx_staging_copy_count` | 2,478 |
+| `virtio_net_tx_staging_copy_bytes` | 149,322 |
+| `virtio_net_inflight_insert_count` | 46,682 |
+| `virtio_net_inflight_remove_count` | 46,618 |
+| `virtio_net_inflight_get_count` | 46,618 |
+| `virtqueue_depth_max` | 63 |
+
+判断：net 工具链已经能支撑 RX 去 `copy_within()`、TX staging copy 优化、inflight map 替换的 A/B 验证。需要注意，当前用户文档中的 host server 启动方式在 Docker/WSL 下不可复现，应改为 container 内 server、host 网络模式，或显式说明网络拓扑。
+
+## 6. compare 验证结果
+
+Self compare 命令：
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-compare \
+  --baseline target/qperf-validation/blk/perf/riscv64/latest/report.json \
+  --candidate target/qperf-validation/blk/perf/riscv64/latest/report.json \
+  --name blk-self-smoke \
+  --output-dir target/qperf-validation/blk/compare-self
+```
+
+输出：
+
+* `target/qperf-validation/blk/compare-self/perf-compare/blk-self-smoke/compare.json`
+* `target/qperf-validation/blk/compare-self/perf-compare/blk-self-smoke/compare.md`
+* `target/qperf-validation/blk/compare-self/perf-compare/blk-self-smoke/compare.csv`
+
+Self compare 结果为“基本无变化”，可比字段 delta 为 0。由于 blk 报告本身缺 guest instructions/blocks，相关字段显示 N/A。
+
+Cross compare 命令：
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-compare \
+  --baseline target/qperf-validation/blk/perf/riscv64/latest/report.json \
+  --candidate target/qperf-validation/net-container/perf/riscv64/latest/report.json \
+  --name blk-vs-net-cross \
+  --output-dir target/qperf-validation/blk/compare-cross
+```
+
+输出：
+
+* `target/qperf-validation/blk/compare-cross/perf-compare/blk-vs-net-cross/compare.json`
+* `target/qperf-validation/blk/compare-cross/perf-compare/blk-vs-net-cross/compare.md`
+* `target/qperf-validation/blk/compare-cross/perf-compare/blk-vs-net-cross/compare.csv`
+
+Cross compare 不 crash，Markdown 中缺失字段显示 N/A，说明 compare 对 schema 缺口有容错。但跨 workload 的自动结论显示“退化”，这不应解释为真实优化回归；compare 目前不校验 baseline/candidate 是否同一 workload、同一输入大小。
+
+初次将 compare 输出写到 `target/qperf-validation/compare-self` 时失败，原因是该目录由 Docker/root 创建，host 用户无写权限。改写到 `target/qperf-validation/blk/compare-self` 后通过。后续应避免 Docker 创建 root-owned 顶层验证目录，或在 harness 中修正 uid/gid。
+
+## 7. vsock 状态
+
+当前 host 缺少 `/dev/vhost-vsock`：
+
+```text
+ls: cannot access '/dev/vhost-vsock': No such file or directory
+```
+
+因此本轮未做 virtio-vsock 定量结论，也未伪造 vsock 指标。具备 vhost-vsock 的 Linux host 上应补测：
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --host-time \
+  --qperf-metrics \
+  --start-marker QPERF_BEGIN \
+  --stop-marker QPERF_END \
+  --workload-timeout 45 \
+  --shell-init-cmd 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:vsock; <vsock workload>; cat /proc/qperf_metrics; echo QPERF_END:vsock' \
+  --output-dir target/qperf-validation/vsock
+```
+
+补测时应在报告中记录 `/dev/vhost-vsock` 权限、QEMU vsock 参数、CID/port、workload bytes 与 elapsed。
+
+## 8. 未达标项与风险
+
+* runtime pause/resume 仍未验证为真实启停采样；当前能力主要依赖 timestamp 后处理过滤和 marker window 标注。结论应表述为“boot samples excluded by postprocess”，不能声称采样器运行时暂停。
+* blk 用例缺失 `qperf/qperf.summary.txt`，导致 guest instructions per MB 与 guest blocks per MB 为 N/A。这是归一化指标的关键缺口。
+* queue depth、notify/kick、pop/complete 计数是 driver-visible 近似统计，不是 virtqueue ring-level 精确硬件事件计数；当前使用 relaxed atomics，snapshot 不是强一致事务。
+* host perf 未启用，PMU 级 cycles/cache-miss 等 host 指标不存在。报告有明确 `未启用 host perf` 说明。
+* 用户给定 net 命令在当前 Docker/WSL 网络拓扑下失败。工具可用，但示例命令需要改成 container 内 HTTP server 或明确网络前提。
+* compare 对跨 workload 输入没有 guard，可能给出形式上的“退化/改善”结论；实际 A/B 应只比较同 workload、同输入、同 qperf 参数。
+* compare CSV 中缺失字段为空值，Markdown 显示 N/A；若后续自动消费 CSV，建议也输出显式 N/A。
+* `/proc/qperf_metrics reset` 已在 workload 中执行，但本轮未做独立 before/after 断言；建议补一个微型读写 reset 单测或 harness smoke。
+* 顶层 `target/qperf-validation` 可能被 Docker 创建为 root-owned，导致 host-side compare 输出 PermissionError。
+
+## 9. 总体结论
+
+结论：**PARTIAL**。
+
+本轮改造达到 qperf 工具 MVP 的主要方向：marker window 可用，boot/post-window 样本能从 workload 报告中排除；工程分类热点、dd/wget/QPERF_METRIC parser、virtio-blk/net counters、A/B compare 都有可复现实验文件支撑。blk 和 net 的关键候选瓶颈已经能在 report 中直接看到。
+
+但仍存在关键缺口：blk 运行缺 guest instruction/block summary，用户给定 net 命令在当前 Docker/WSL 拓扑下不可复现，采样窗口仍是后处理过滤而不是运行时 pause/resume，virtio counters 是 driver-visible 近似值。它可以支撑下一轮小规模 virtio 优化 A/B 验证，但报告必须保留这些限制，不能把当前数据解释为完整 PMU/virtqueue ring 级精确观测。
+
+## 10. 下一步建议
+
+1. net RX 去 `copy_within()` 的 A/B 优化验证：使用 `target/qperf-validation/net-container` 同样的 container 内 HTTP server 拓扑，比较 `virtio_net_rx_copy_within_bytes`、`memmove` category、throughput、samples per MB。
+2. net inflight `BTreeMap` 替换固定数组/slab 的 A/B 优化验证：比较 `virtio_net_inflight_insert/remove/get_count`、`net_inflight_btree` category、allocator category、host elapsed per MB。
+3. blk `read_blocks_nb()` / `complete_read_blocks()` 最小 pending-read 原型验证：比较 `virtqueue_add_notify_wait_pop_count`、`virtio_notify_kick_count`、`virtqueue_depth_max`、blk throughput、samples per MB。
+4. 修复 blk `qperf.summary.txt` 缺失问题后重跑 blk；要求 `guest_instructions_per_MB` 和 `guest_blocks_per_MB` 不再是 N/A。
+5. 在具备 `/dev/vhost-vsock` 的 Linux host 上补测 vsock，并把环境阻塞、CID/port、bytes、elapsed、vsock counters 明确写入 report。

--- a/scripts/axbuild/src/context/workspace.rs
+++ b/scripts/axbuild/src/context/workspace.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashSet,
+    env,
     path::{Path, PathBuf},
 };
 
@@ -38,7 +39,17 @@ pub(crate) fn workspace_manifest_path() -> anyhow::Result<PathBuf> {
 }
 
 pub(crate) fn axbuild_tmp_dir(workspace_root: &Path) -> PathBuf {
-    workspace_root.join("tmp").join("axbuild")
+    env::var_os("AXBUILD_TMP_DIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                workspace_root.join(path)
+            }
+        })
+        .unwrap_or_else(|| workspace_root.join("tmp").join("axbuild"))
 }
 
 pub(crate) fn workspace_manifest_path_in(workspace_root: &Path) -> PathBuf {

--- a/scripts/axbuild/src/lib.rs
+++ b/scripts/axbuild/src/lib.rs
@@ -81,7 +81,7 @@ enum Commands {
     /// StarryOS build commands
     Starry {
         #[command(subcommand)]
-        command: starry::Command,
+        command: Box<starry::Command>,
     },
 }
 
@@ -100,6 +100,6 @@ async fn run_root_cli(cli: Cli) -> anyhow::Result<()> {
         Commands::Backtrace { command } => backtrace::execute(command),
         Commands::Axvisor { command } => Axvisor::new()?.execute(command).await,
         Commands::Arceos { command } => ArceOS::new()?.execute(command).await,
-        Commands::Starry { command } => Starry::new()?.execute(command).await,
+        Commands::Starry { command } => Starry::new()?.execute(*command).await,
     }
 }

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use clap::{Args, Subcommand, ValueEnum};
 use ostool::{
@@ -25,6 +28,7 @@ pub enum Command {
     /// Build StarryOS application
     Build(ArgsBuild),
     /// Build and run StarryOS application
+    #[command(alias = "run")]
     Qemu(ArgsQemu),
     /// Generate a default StarryOS board config
     Defconfig(ArgsDefconfig),
@@ -74,24 +78,188 @@ pub struct ArgsQemu {
     /// Override the rootfs disk image path (skips auto-download).
     #[arg(long, value_name = "IMAGE")]
     pub rootfs: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub perf: ArgsQemuPerf,
+}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct ArgsQemuPerf {
+    /// Profile this run with qperf instead of launching a plain QEMU session.
+    #[arg(long)]
+    pub perf: bool,
+    #[arg(long = "perf-case", value_name = "NAME")]
+    pub case: Option<String>,
+    #[arg(long = "perf-workload", value_name = "CMD")]
+    pub workload: Option<String>,
+    #[arg(long = "perf-shell-prefix", value_name = "PREFIX")]
+    pub shell_prefix: Option<String>,
+    #[arg(long = "perf-output-dir", value_name = "DIR")]
+    pub output_dir: Option<PathBuf>,
+    #[arg(long = "perf-start-marker", value_name = "MARKER")]
+    pub start_marker: Option<String>,
+    #[arg(long = "perf-stop-marker", value_name = "MARKER")]
+    pub stop_marker: Option<String>,
+    #[arg(long = "perf-timeout", value_name = "SECONDS")]
+    pub timeout: Option<u64>,
+    #[arg(long = "perf-workload-timeout", value_name = "SECONDS")]
+    pub workload_timeout: Option<u64>,
+    #[arg(long = "perf-freq", value_name = "HZ")]
+    pub freq: Option<u32>,
+    #[arg(long = "perf-max-depth", value_name = "DEPTH")]
+    pub max_depth: Option<usize>,
+    #[arg(long = "perf-mode", value_enum)]
+    pub mode: Option<PerfMode>,
+    #[arg(long = "perf-format", value_enum)]
+    pub format: Option<PerfFormat>,
+    #[arg(long = "perf-top", value_name = "N")]
+    pub top: Option<usize>,
+    #[arg(long = "perf-min-percent", value_name = "PERCENT")]
+    pub min_percent: Option<f64>,
+    #[arg(long = "perf-host-time")]
+    pub host_time: bool,
+    #[arg(long = "perf-no-host-time")]
+    pub no_host_time: bool,
+    #[arg(long = "perf-host-perf")]
+    pub host_perf: bool,
+    #[arg(long = "perf-host-perf-events", value_name = "EVENTS")]
+    pub host_perf_events: Option<String>,
+    /// Parse QPERF_METRIC lines from guest stdout into the generated report.
+    ///
+    /// Kernel-side counter instrumentation must be enabled by the profiled
+    /// workload or by a separate StarryOS feature.
+    #[arg(long = "perf-qperf-metrics")]
+    pub qperf_metrics: bool,
+    #[arg(long = "perf-qemu-arg", value_name = "ARG", allow_hyphen_values = true)]
+    pub qemu_args: Vec<String>,
+    #[arg(long = "perf-flamegraph")]
+    pub flamegraph: bool,
+    #[arg(long = "perf-flamegraph-kind", value_enum)]
+    pub flamegraph_kind: Option<PerfFlamegraphKind>,
+    #[arg(long = "perf-full-stack")]
+    pub full_stack: bool,
+    #[arg(long = "perf-callchain", value_enum)]
+    pub callchain: Option<PerfCallchain>,
+    #[arg(long = "perf-debuginfo")]
+    pub debuginfo: bool,
+    #[arg(long = "perf-force-frame-pointers")]
+    pub force_frame_pointers: bool,
+    #[arg(long = "perf-demangle")]
+    pub demangle: bool,
+    #[arg(long = "perf-no-truncate")]
+    pub no_truncate: bool,
+    #[arg(long = "perf-symbol-style", value_enum)]
+    pub symbol_style: Option<PerfSymbolStyle>,
+    #[arg(long = "perf-focus", value_name = "REGEX")]
+    pub focus: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
 pub struct ArgsPerf {
+    /// Profile case name used in the default output path.
+    #[arg(long, default_value = "boot")]
+    pub case: String,
     #[arg(long)]
     pub arch: Option<String>,
     #[arg(long, default_value_t = 99)]
     pub freq: u32,
-    #[arg(long)]
+    #[arg(long = "out", hide = true)]
     pub out: Option<PathBuf>,
+    /// Output root. Final reports go under <DIR>/perf/<arch>/latest.
+    #[arg(long)]
+    pub output_dir: Option<PathBuf>,
     #[arg(long, value_enum, default_value_t = PerfFormat::All)]
     pub format: PerfFormat,
-    #[arg(long, default_value_t = 64)]
+    #[arg(long, default_value_t = 128)]
     pub max_depth: usize,
     #[arg(long, value_name = "SECONDS", default_value_t = 20)]
     pub timeout: u64,
-    #[arg(long, value_name = "CPUS")]
-    pub smp: Option<usize>,
+    #[arg(long, value_enum, default_value_t = PerfMode::Tb)]
+    pub mode: PerfMode,
+    #[arg(long, default_value_t = 80)]
+    pub top: usize,
+    #[arg(long, default_value_t = 0.3)]
+    pub min_percent: f64,
+    #[arg(long)]
+    pub debug: bool,
+    #[arg(long)]
+    pub kernel_filter: bool,
+    /// Collect host wall/user/system CPU time metrics for the QEMU process wrapper.
+    #[arg(long)]
+    pub host_time: bool,
+    /// Disable the cargo starry perf default host-time metrics.
+    #[arg(long)]
+    pub no_host_time: bool,
+    /// Run QEMU under host perf stat. These are host/QEMU process metrics, not guest PMU values.
+    #[arg(long)]
+    pub host_perf: bool,
+    /// Comma-separated host perf stat events used with --host-perf.
+    #[arg(
+        long,
+        default_value = "task-clock,cycles,instructions,cache-references,cache-misses,\
+                         context-switches,cpu-migrations,page-faults"
+    )]
+    pub host_perf_events: String,
+    /// Send this command to the guest shell after the qperf boot prompt appears.
+    #[arg(long, visible_alias = "workload")]
+    pub shell_init_cmd: Option<String>,
+    /// Prompt substring used before sending --shell-init-cmd.
+    #[arg(long)]
+    pub shell_prefix: Option<String>,
+    /// Append one raw QEMU argument. Repeat for options and values.
+    #[arg(long = "qemu-arg", value_name = "ARG", allow_hyphen_values = true)]
+    pub qemu_args: Vec<String>,
+    /// Guest stdout marker that starts the workload sampling window.
+    #[arg(long)]
+    pub start_marker: Option<String>,
+    /// Guest stdout marker that stops the workload sampling window.
+    #[arg(long)]
+    pub stop_marker: Option<String>,
+    /// Stop QEMU if the workload window stays open longer than this many seconds.
+    #[arg(long, value_name = "SECONDS")]
+    pub workload_timeout: Option<u64>,
+    /// Parse QPERF_METRIC lines from guest stdout into the generated report.
+    ///
+    /// Kernel-side counter instrumentation must be enabled by the profiled
+    /// workload or by a separate StarryOS feature.
+    #[arg(long)]
+    pub qperf_metrics: bool,
+    /// Request SVG flamegraph generation even when --format is folded.
+    #[arg(long)]
+    pub flamegraph: bool,
+    /// Flamegraph view format.
+    #[arg(long, value_enum, default_value_t = PerfFlamegraphKind::Svg)]
+    pub flamegraph_kind: PerfFlamegraphKind,
+    /// Preserve the deepest stack qperf can collect for this build.
+    #[arg(long)]
+    pub full_stack: bool,
+    /// qperf callchain collection mode. `leaf` is fastest; `fp` requires frame pointers.
+    #[arg(long = "perf-callchain", visible_alias = "callchain", value_enum)]
+    pub callchain: Option<PerfCallchain>,
+    /// Add DWARF debug info and keep symbols for qperf symbolization.
+    #[arg(long = "perf-debuginfo")]
+    pub debuginfo: bool,
+    /// Force frame pointers for qperf FP unwinding.
+    #[arg(long = "perf-force-frame-pointers")]
+    pub force_frame_pointers: bool,
+    /// Force Rust demangling in qperf-analyzer.
+    #[arg(long)]
+    pub demangle: bool,
+    /// Keep tiny frames in SVG output by setting flamegraph min width to zero.
+    #[arg(long)]
+    pub no_truncate: bool,
+    /// Include kernel symbols in symbolized stacks. This is the default for StarryOS kernels.
+    #[arg(long)]
+    pub include_kernel_symbols: bool,
+    /// Include user symbols when available. Current StarryOS qperf only resolves the kernel ELF.
+    #[arg(long)]
+    pub include_user_symbols: bool,
+    /// Folded-stack symbol style.
+    #[arg(long, value_enum, default_value_t = PerfSymbolStyle::Full)]
+    pub symbol_style: PerfSymbolStyle,
+    /// Generate an additional focused folded stack/flamegraph for matching frames.
+    #[arg(long, value_name = "REGEX")]
+    pub focus: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -100,6 +268,72 @@ pub enum PerfFormat {
     Svg,
     Pprof,
     All,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum PerfMode {
+    Tb,
+    Insn,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum PerfCallchain {
+    Leaf,
+    Fp,
+    Logical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum PerfFlamegraphKind {
+    Svg,
+    Html,
+    Folded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum PerfSymbolStyle {
+    Full,
+    Short,
+    Module,
+}
+
+impl fmt::Display for PerfMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Tb => "tb",
+            Self::Insn => "insn",
+        })
+    }
+}
+
+impl fmt::Display for PerfCallchain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Leaf => "leaf",
+            Self::Fp => "fp",
+            Self::Logical => "logical",
+        })
+    }
+}
+
+impl fmt::Display for PerfFlamegraphKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Svg => "svg",
+            Self::Html => "html",
+            Self::Folded => "folded",
+        })
+    }
+}
+
+impl fmt::Display for PerfSymbolStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Full => "full",
+            Self::Short => "short",
+            Self::Module => "module",
+        })
+    }
 }
 
 #[derive(Args)]
@@ -162,6 +396,100 @@ impl From<&ArgsBuild> for StarryCliArgs {
     }
 }
 
+impl ArgsQemuPerf {
+    fn has_overrides(&self) -> bool {
+        self.case.is_some()
+            || self.workload.is_some()
+            || self.shell_prefix.is_some()
+            || self.output_dir.is_some()
+            || self.start_marker.is_some()
+            || self.stop_marker.is_some()
+            || self.timeout.is_some()
+            || self.workload_timeout.is_some()
+            || self.freq.is_some()
+            || self.max_depth.is_some()
+            || self.mode.is_some()
+            || self.format.is_some()
+            || self.top.is_some()
+            || self.min_percent.is_some()
+            || self.host_time
+            || self.no_host_time
+            || self.host_perf
+            || self.host_perf_events.is_some()
+            || self.qperf_metrics
+            || !self.qemu_args.is_empty()
+            || self.flamegraph
+            || self.flamegraph_kind.is_some()
+            || self.full_stack
+            || self.callchain.is_some()
+            || self.debuginfo
+            || self.force_frame_pointers
+            || self.demangle
+            || self.no_truncate
+            || self.symbol_style.is_some()
+            || self.focus.is_some()
+    }
+}
+
+fn perf_args_from_qemu(args: ArgsQemu) -> anyhow::Result<ArgsPerf> {
+    if args.qemu_config.is_some() || args.rootfs.is_some() {
+        anyhow::bail!(
+            "cargo starry run --perf currently uses the default StarryOS qperf QEMU/rootfs flow; \
+             --qemu-config and --rootfs are not supported with --perf yet"
+        );
+    }
+    if args.build.config.is_some() || args.build.target.is_some() || args.build.smp.is_some() {
+        anyhow::bail!(
+            "cargo starry run --perf currently supports --arch and --debug build overrides; use \
+             cargo starry perf for the default qperf path or plain cargo starry qemu for custom \
+             --config/--target/--smp runs"
+        );
+    }
+    let perf = args.perf;
+    Ok(ArgsPerf {
+        case: perf.case.unwrap_or_else(|| "boot".to_string()),
+        arch: args.build.arch,
+        freq: perf.freq.unwrap_or(99),
+        out: None,
+        output_dir: perf.output_dir,
+        format: perf.format.unwrap_or(PerfFormat::All),
+        max_depth: perf.max_depth.unwrap_or(128),
+        timeout: perf.timeout.unwrap_or(20),
+        mode: perf.mode.unwrap_or(PerfMode::Tb),
+        top: perf.top.unwrap_or(80),
+        min_percent: perf.min_percent.unwrap_or(0.3),
+        debug: args.build.debug,
+        kernel_filter: false,
+        host_time: perf.host_time,
+        no_host_time: perf.no_host_time,
+        host_perf: perf.host_perf,
+        host_perf_events: perf.host_perf_events.unwrap_or_else(|| {
+            "task-clock,cycles,instructions,cache-references,cache-misses,context-switches,\
+             cpu-migrations,page-faults"
+                .to_string()
+        }),
+        shell_init_cmd: perf.workload,
+        shell_prefix: perf.shell_prefix,
+        qemu_args: perf.qemu_args,
+        start_marker: perf.start_marker,
+        stop_marker: perf.stop_marker,
+        workload_timeout: perf.workload_timeout,
+        qperf_metrics: perf.qperf_metrics,
+        flamegraph: perf.flamegraph,
+        flamegraph_kind: perf.flamegraph_kind.unwrap_or(PerfFlamegraphKind::Svg),
+        full_stack: perf.full_stack,
+        callchain: perf.callchain,
+        debuginfo: perf.debuginfo,
+        force_frame_pointers: perf.force_frame_pointers,
+        demangle: perf.demangle,
+        no_truncate: perf.no_truncate,
+        include_kernel_symbols: true,
+        include_user_symbols: false,
+        symbol_style: perf.symbol_style.unwrap_or(PerfSymbolStyle::Full),
+        focus: perf.focus,
+    })
+}
+
 impl Starry {
     pub fn new() -> anyhow::Result<Self> {
         let app = AppContext::new()?;
@@ -191,6 +519,12 @@ impl Starry {
     }
 
     async fn qemu(&mut self, args: ArgsQemu) -> anyhow::Result<()> {
+        if args.perf.perf {
+            return self.perf(perf_args_from_qemu(args)?).await;
+        }
+        if args.perf.has_overrides() {
+            anyhow::bail!("--perf-* options require --perf");
+        }
         let request = self.prepare_request(
             (&args.build).into(),
             args.qemu_config,
@@ -685,6 +1019,143 @@ mod tests {
                 ConfigCommand::Ls => {}
             },
             _ => panic!("expected config ls command"),
+        }
+    }
+
+    #[test]
+    fn command_parses_perf_workload_options() {
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: Command,
+        }
+
+        let cli = Cli::try_parse_from([
+            "starry",
+            "perf",
+            "--arch",
+            "riscv64",
+            "--shell-init-cmd",
+            "echo qperf",
+            "--shell-prefix",
+            "root@starry:",
+            "--host-time",
+            "--host-perf",
+            "--host-perf-events",
+            "task-clock,instructions",
+            "--qemu-arg=-device",
+            "--qemu-arg=vhost-vsock-pci,guest-cid=3",
+            "--start-marker",
+            "QPERF_BEGIN",
+            "--stop-marker",
+            "QPERF_END",
+            "--workload-timeout",
+            "5",
+            "--qperf-metrics",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Perf(args) => {
+                assert_eq!(args.arch.as_deref(), Some("riscv64"));
+                assert_eq!(args.shell_init_cmd.as_deref(), Some("echo qperf"));
+                assert_eq!(args.shell_prefix.as_deref(), Some("root@starry:"));
+                assert!(args.host_time);
+                assert!(args.host_perf);
+                assert_eq!(args.host_perf_events, "task-clock,instructions");
+                assert_eq!(
+                    args.qemu_args,
+                    vec!["-device", "vhost-vsock-pci,guest-cid=3"]
+                );
+                assert_eq!(args.start_marker.as_deref(), Some("QPERF_BEGIN"));
+                assert_eq!(args.stop_marker.as_deref(), Some("QPERF_END"));
+                assert_eq!(args.workload_timeout, Some(5));
+                assert!(args.qperf_metrics);
+            }
+            _ => panic!("expected perf command"),
+        }
+    }
+
+    #[test]
+    fn command_parses_perf_flamegraph_options() {
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: Command,
+        }
+
+        let cli = Cli::try_parse_from([
+            "starry",
+            "perf",
+            "--case",
+            "blk-read",
+            "--workload",
+            "echo qperf",
+            "--flamegraph-kind",
+            "html",
+            "--full-stack",
+            "--no-truncate",
+            "--symbol-style",
+            "module",
+            "--focus",
+            "virtio|VirtQueue",
+            "--min-percent",
+            "0",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Perf(args) => {
+                assert_eq!(args.case, "blk-read");
+                assert_eq!(args.shell_init_cmd.as_deref(), Some("echo qperf"));
+                assert_eq!(args.flamegraph_kind, PerfFlamegraphKind::Html);
+                assert!(args.full_stack);
+                assert!(args.no_truncate);
+                assert_eq!(args.symbol_style, PerfSymbolStyle::Module);
+                assert_eq!(args.focus.as_deref(), Some("virtio|VirtQueue"));
+                assert_eq!(args.min_percent, 0.0);
+            }
+            _ => panic!("expected perf command"),
+        }
+    }
+
+    #[test]
+    fn command_parses_run_perf_alias() {
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: Command,
+        }
+
+        let cli = Cli::try_parse_from([
+            "starry",
+            "run",
+            "--arch",
+            "riscv64",
+            "--perf",
+            "--perf-case",
+            "net-wget",
+            "--perf-workload",
+            "echo qperf",
+            "--perf-qperf-metrics",
+            "--perf-symbol-style",
+            "short",
+            "--perf-focus",
+            "memcpy|memmove",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Qemu(args) => {
+                assert_eq!(args.build.arch.as_deref(), Some("riscv64"));
+                assert!(args.perf.perf);
+                assert_eq!(args.perf.case.as_deref(), Some("net-wget"));
+                assert_eq!(args.perf.workload.as_deref(), Some("echo qperf"));
+                assert!(args.perf.qperf_metrics);
+                assert_eq!(args.perf.symbol_style, Some(PerfSymbolStyle::Short));
+                assert_eq!(args.perf.focus.as_deref(), Some("memcpy|memmove"));
+            }
+            _ => panic!("expected qemu command"),
         }
     }
 

--- a/scripts/axbuild/src/starry/perf.rs
+++ b/scripts/axbuild/src/starry/perf.rs
@@ -1,21 +1,31 @@
 use std::{
-    env, fs,
+    env,
+    ffi::OsString,
+    fs,
     fs::File,
-    io::{BufRead, BufReader, Write},
+    io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
     process::{Command, ExitStatus, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, bail};
+use object::{Object, ObjectSection};
+use ostool::build::config::Cargo;
 use serde::{Deserialize, Serialize};
 
-use super::{ArgsBuild, ArgsPerf, PerfFormat, Starry, build, rootfs};
+use super::{
+    ArgsBuild, ArgsPerf, PerfCallchain, PerfFlamegraphKind, PerfFormat, Starry, build, rootfs,
+};
 use crate::{
     context::{SnapshotPersistence, StarryCliArgs, starry_target_for_arch_checked},
     support::process::ProcessExt,
 };
 
 const QPERF_QUEUE_SIZE: usize = 4096;
+const DEFAULT_STARRY_SHELL_PREFIX: &str = "root@starry:";
 
 #[derive(Deserialize, Serialize)]
 struct PerfQemuConfig {
@@ -27,6 +37,9 @@ struct PerfQemuConfig {
     shell_prefix: Option<String>,
     shell_init_cmd: Option<String>,
     timeout: Option<u64>,
+    start_marker: Option<String>,
+    stop_marker: Option<String>,
+    workload_timeout: Option<u64>,
 }
 
 struct QperfTools {
@@ -35,12 +48,105 @@ struct QperfTools {
 }
 
 struct PerfOutputs {
+    work_dir: PathBuf,
     dir: PathBuf,
     raw: PathBuf,
     folded: PathBuf,
     flamegraph: PathBuf,
+    folded_boot: PathBuf,
+    flamegraph_boot: PathBuf,
+    folded_workload: PathBuf,
+    flamegraph_workload: PathBuf,
+    folded_post: PathBuf,
+    flamegraph_post: PathBuf,
+    folded_focus: PathBuf,
+    flamegraph_focus: PathBuf,
+    stack_depth_summary: PathBuf,
+    flamegraph_html: PathBuf,
     summary: PathBuf,
     qemu_config: PathBuf,
+    host_time: PathBuf,
+    host_perf: PathBuf,
+    resolve_stats: PathBuf,
+    window: PathBuf,
+    qmp_socket: PathBuf,
+    profile_stdout: PathBuf,
+    profile_stderr: PathBuf,
+    report_json: PathBuf,
+    report_md: PathBuf,
+    hotspots_csv: PathBuf,
+    hotspot_categories_csv: PathBuf,
+}
+
+#[derive(Default, Serialize)]
+struct PerfWindowReport {
+    enabled: bool,
+    start_marker: Option<String>,
+    stop_marker: Option<String>,
+    start_time: Option<f64>,
+    stop_time: Option<f64>,
+    duration_sec: Option<f64>,
+    workload_timeout: Option<u64>,
+    truncated_by_timeout: bool,
+    boot_samples_excluded: Option<u64>,
+    stop_requested: bool,
+    stop_method: Option<String>,
+    warnings: Vec<String>,
+    method: String,
+}
+
+struct QemuRun {
+    status: ExitStatus,
+    window: PerfWindowReport,
+}
+
+#[derive(Clone, Copy, Default)]
+struct ChildResourceUsage {
+    user_micros: i128,
+    system_micros: i128,
+    major_faults: i128,
+    minor_faults: i128,
+    voluntary_context_switches: i128,
+    involuntary_context_switches: i128,
+}
+
+impl ChildResourceUsage {
+    fn delta_since(self, before: Self) -> Self {
+        Self {
+            user_micros: nonnegative_delta(self.user_micros, before.user_micros),
+            system_micros: nonnegative_delta(self.system_micros, before.system_micros),
+            major_faults: nonnegative_delta(self.major_faults, before.major_faults),
+            minor_faults: nonnegative_delta(self.minor_faults, before.minor_faults),
+            voluntary_context_switches: nonnegative_delta(
+                self.voluntary_context_switches,
+                before.voluntary_context_switches,
+            ),
+            involuntary_context_switches: nonnegative_delta(
+                self.involuntary_context_switches,
+                before.involuntary_context_switches,
+            ),
+        }
+    }
+
+    fn user_seconds(self) -> f64 {
+        self.user_micros as f64 / 1_000_000.0
+    }
+
+    fn system_seconds(self) -> f64 {
+        self.system_micros as f64 / 1_000_000.0
+    }
+}
+
+#[derive(Clone, Copy)]
+struct AddressRange {
+    start: u64,
+    end: u64,
+}
+
+#[derive(Clone, Copy)]
+struct KernelTextRange {
+    virt: AddressRange,
+    phys: Option<AddressRange>,
 }
 
 pub(super) async fn run(starry: &mut Starry, args: ArgsPerf) -> anyhow::Result<()> {
@@ -50,16 +156,29 @@ pub(super) async fn run(starry: &mut Starry, args: ArgsPerf) -> anyhow::Result<(
         .clone()
         .unwrap_or_else(|| crate::context::DEFAULT_STARRY_ARCH.to_string());
     let target = starry_target_for_arch_checked(&arch)?.to_string();
-    let outputs = prepare_outputs(starry.app.workspace_root(), &arch, args.out.as_deref())?;
+    let outputs = prepare_outputs(
+        starry.app.workspace_root(),
+        &arch,
+        &args.case,
+        args.out.as_deref(),
+        args.output_dir.as_deref(),
+    )?;
+    let _axbuild_tmp_dir = set_env_if_missing(
+        "AXBUILD_TMP_DIR",
+        outputs.work_dir.join("axbuild-tmp").into_os_string(),
+    )?;
+    let generate_svg = args.flamegraph
+        || matches!(args.format, PerfFormat::Svg | PerfFormat::All)
+            && !matches!(args.flamegraph_kind, PerfFlamegraphKind::Folded);
 
-    let tools = build_qperf_tools(starry.app.workspace_root())?;
+    let tools = build_qperf_tools(starry.app.workspace_root(), generate_svg)?;
 
     let build_args = ArgsBuild {
         config: None,
         arch: Some(arch.clone()),
         target: None,
-        smp: args.smp,
-        debug: true,
+        smp: None,
+        debug: args.debug,
     };
     let request = starry.prepare_request(
         StarryCliArgs::from(&build_args),
@@ -68,46 +187,125 @@ pub(super) async fn run(starry: &mut Starry, args: ArgsPerf) -> anyhow::Result<(
         SnapshotPersistence::Store,
     )?;
 
-    let cargo = build::load_cargo_config(&request)?;
-    starry.app.set_debug_mode(true)?;
+    let mut cargo = build::load_cargo_config(&request)?;
+    apply_perf_cargo_features(&mut cargo, &args);
+    starry.app.set_debug_mode(args.debug)?;
     starry
         .app
         .build(cargo, request.build_info_path.clone())
         .await?;
     rootfs::ensure_qemu_rootfs_ready(&request, starry.app.workspace_root(), None).await?;
-    let cargo = build::load_cargo_config(&request)?;
+    let mut cargo = build::load_cargo_config(&request)?;
+    apply_perf_cargo_features(&mut cargo, &args);
     let qemu = rootfs::load_patched_qemu_config(starry, &request, &cargo, None, true).await?;
-    write_qemu_config(&outputs, &tools, &args, qemu.args)?;
+    let elf = kernel_elf_path(starry.app.workspace_root(), &target, args.debug);
+    let axconfig_path = cargo.env.get("AX_CONFIG_PATH").map(PathBuf::from);
+    let text_range = detect_kernel_text_range(&elf, axconfig_path.as_deref())?;
+    write_qemu_config(&outputs, &tools, &args, &arch, qemu.args, text_range)?;
 
-    let kernel_bin = kernel_bin_path(starry.app.workspace_root(), &target);
-    let qemu_status = run_qemu_direct(&outputs, &args, &arch, &kernel_bin)?;
-    if !qemu_status.success() {
+    let kernel_bin = kernel_bin_path(starry.app.workspace_root(), &target, args.debug);
+    let qemu_run = run_qemu_direct(&outputs, &args, &arch, &kernel_bin)?;
+    if !qemu_run.status.success() {
         if !file_nonempty(&outputs.raw) {
-            bail!("qperf QEMU run failed before producing samples: {qemu_status}");
+            bail!(
+                "qperf QEMU run failed before producing samples: {}",
+                qemu_run.status
+            );
         }
-        eprintln!("qperf: QEMU ended with {qemu_status} after producing samples");
+        eprintln!(
+            "qperf: QEMU ended with {} after producing samples",
+            qemu_run.status
+        );
     }
 
-    let elf = kernel_elf_path(starry.app.workspace_root(), &target);
-    run_analyzer(&tools.analyzer, &elf, &outputs.raw, &outputs.folded)?;
+    run_analyzer(AnalyzerRun {
+        analyzer: &tools.analyzer,
+        elf: &elf,
+        raw: &outputs.raw,
+        folded: &outputs.folded,
+        flamegraph: &outputs.flamegraph,
+        resolve_stats: &outputs.resolve_stats,
+        depth_summary: Some(&outputs.stack_depth_summary),
+        generate_svg,
+        top_n: args.top,
+        start_sec: qemu_run.window.start_time,
+        stop_sec: qemu_run.window.stop_time,
+        symbol_style: args.symbol_style.to_string(),
+        demangle: true,
+        focus: None,
+        min_percent: flamegraph_min_percent(&args),
+    })?;
 
-    let flamegraph_generated = if matches!(args.format, PerfFormat::Svg | PerfFormat::All) {
-        try_generate_flamegraph(&outputs.folded, &outputs.flamegraph)?
-    } else {
-        false
-    };
-
-    write_summary(
-        &outputs,
+    generate_phase_flamegraphs(
         &tools,
         &elf,
-        &arch,
-        &target,
+        &outputs,
         &args,
-        flamegraph_generated,
+        &qemu_run.window,
+        generate_svg,
     )?;
-    print_report(&outputs, flamegraph_generated);
+    generate_focus_flamegraph(&tools, &elf, &outputs, &args, generate_svg)?;
+
+    let flamegraph_generated = if generate_svg && !file_nonempty(&outputs.flamegraph) {
+        try_generate_flamegraph(&outputs.folded, &outputs.flamegraph)?
+    } else {
+        generate_svg && file_nonempty(&outputs.flamegraph)
+    };
+
+    write_summary(SummaryInputs {
+        outputs: &outputs,
+        tools: &tools,
+        elf: &elf,
+        arch: &arch,
+        target: &target,
+        args: &args,
+        flamegraph_generated,
+        window: &qemu_run.window,
+    })?;
+    write_flamegraph_html(&outputs, args.flamegraph_kind, flamegraph_generated)?;
+    run_report_postprocess(&outputs, &args, &arch, exit_status_code(&qemu_run.status))?;
+    print_report(&outputs, &args);
     Ok(())
+}
+
+fn apply_perf_cargo_features(cargo: &mut Cargo, args: &ArgsPerf) {
+    cargo.features.extend([
+        "ax-driver/virtio-blk".to_string(),
+        "ax-driver/virtio-net".to_string(),
+        "ax-driver/virtio-socket".to_string(),
+    ]);
+    cargo.features.sort();
+    cargo.features.dedup();
+    if perf_needs_debuginfo(args) {
+        cargo.env.insert("DWARF".to_string(), "y".to_string());
+    }
+    if perf_needs_frame_pointers(args) {
+        cargo.env.insert("BACKTRACE".to_string(), "y".to_string());
+    }
+    apply_perf_rustflags(cargo, args);
+}
+
+fn apply_perf_rustflags(cargo: &mut Cargo, args: &ArgsPerf) {
+    let mut flags = Vec::new();
+    if perf_needs_debuginfo(args) {
+        flags.push("-Cdebuginfo=2".to_string());
+        flags.push("-Cstrip=none".to_string());
+    }
+    if perf_needs_frame_pointers(args) {
+        flags.push("-Cforce-frame-pointers=yes".to_string());
+    }
+    if flags.is_empty() {
+        return;
+    }
+
+    cargo
+        .env
+        .insert("CARGO_ENCODED_RUSTFLAGS".to_string(), flags.join("\x1f"));
+    cargo.args.push("--config".to_string());
+    let rustflags = toml::Value::Array(flags.into_iter().map(toml::Value::String).collect());
+    cargo
+        .args
+        .push(format!("target.'{}'.rustflags={rustflags}", cargo.target));
 }
 
 fn validate_args(args: &ArgsPerf) -> anyhow::Result<()> {
@@ -117,33 +315,227 @@ fn validate_args(args: &ArgsPerf) -> anyhow::Result<()> {
     if args.max_depth == 0 {
         bail!("--max-depth must be greater than 0");
     }
+    if args.min_percent < 0.0 {
+        bail!("--min-percent must be non-negative");
+    }
     if matches!(args.format, PerfFormat::Pprof) {
         bail!("--format pprof is not supported yet; use --format folded, svg, or all");
+    }
+    if args
+        .shell_init_cmd
+        .as_deref()
+        .is_some_and(|cmd| cmd.trim().is_empty())
+    {
+        bail!("--shell-init-cmd must not be empty");
+    }
+    if args
+        .shell_prefix
+        .as_deref()
+        .is_some_and(|prefix| prefix.is_empty())
+    {
+        bail!("--shell-prefix must not be empty");
+    }
+    if args.host_perf && args.host_perf_events.trim().is_empty() {
+        bail!("--host-perf-events must not be empty when --host-perf is set");
+    }
+    if matches!(effective_callchain(args), PerfCallchain::Logical) {
+        bail!(
+            "--perf-callchain logical is not implemented yet; use --perf-callchain fp or \
+             --full-stack for frame-pointer unwinding"
+        );
+    }
+    if args.qperf_metrics {
+        eprintln!(
+            "qperf: --qperf-metrics parses QPERF_METRIC lines from guest stdout; this tools-only \
+             path does not enable kernel-side instrumentation automatically"
+        );
+    }
+    if args.include_user_symbols {
+        eprintln!(
+            "qperf: --include-user-symbols requested, but current analyzer resolves only the \
+             StarryOS kernel ELF; user symbols will remain unresolved unless they are present in \
+             the kernel image"
+        );
+    }
+    if args
+        .start_marker
+        .as_deref()
+        .is_some_and(|marker| marker.trim().is_empty())
+    {
+        bail!("--start-marker must not be empty");
+    }
+    if args
+        .stop_marker
+        .as_deref()
+        .is_some_and(|marker| marker.trim().is_empty())
+    {
+        bail!("--stop-marker must not be empty");
+    }
+    if args.workload_timeout == Some(0) {
+        bail!("--workload-timeout must be greater than 0");
     }
     Ok(())
 }
 
-fn prepare_outputs(root: &Path, arch: &str, out: Option<&Path>) -> anyhow::Result<PerfOutputs> {
-    let dir = out.map(PathBuf::from).unwrap_or_else(|| {
-        root.join("target")
-            .join("qperf")
-            .join(arch)
-            .join(chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string())
-    });
+fn host_time_enabled(args: &ArgsPerf) -> bool {
+    args.host_time || !args.no_host_time
+}
+
+fn flamegraph_min_percent(args: &ArgsPerf) -> f64 {
+    if args.no_truncate {
+        0.0
+    } else {
+        args.min_percent
+    }
+}
+
+fn effective_max_depth(args: &ArgsPerf) -> usize {
+    if args.full_stack {
+        args.max_depth.max(256)
+    } else {
+        args.max_depth
+    }
+}
+
+fn effective_callchain(args: &ArgsPerf) -> PerfCallchain {
+    if args.full_stack {
+        PerfCallchain::Fp
+    } else {
+        args.callchain.unwrap_or(PerfCallchain::Leaf)
+    }
+}
+
+fn perf_needs_debuginfo(args: &ArgsPerf) -> bool {
+    args.full_stack || args.debuginfo
+}
+
+fn perf_needs_frame_pointers(args: &ArgsPerf) -> bool {
+    args.full_stack
+        || args.force_frame_pointers
+        || matches!(effective_callchain(args), PerfCallchain::Fp)
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<OsString>,
+    active: bool,
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        match &self.previous {
+            Some(value) => {
+                // SAFETY: qperf runs this CLI flow serially and restores the process
+                // environment before returning to the caller.
+                unsafe { env::set_var(self.key, value) };
+            }
+            None => {
+                // SAFETY: qperf runs this CLI flow serially and restores the process
+                // environment before returning to the caller.
+                unsafe { env::remove_var(self.key) };
+            }
+        }
+    }
+}
+
+fn set_env_if_missing(key: &'static str, value: OsString) -> anyhow::Result<ScopedEnvVar> {
+    let previous = env::var_os(key);
+    if previous.as_ref().is_some_and(|value| !value.is_empty()) {
+        return Ok(ScopedEnvVar {
+            key,
+            previous,
+            active: false,
+        });
+    }
+    let path = PathBuf::from(&value);
+    fs::create_dir_all(&path)
+        .with_context(|| format!("failed to create {key} directory {}", path.display()))?;
+    // SAFETY: qperf runs this CLI flow serially before spawning worker threads that depend on
+    // axbuild paths.
+    unsafe { env::set_var(key, &value) };
+    Ok(ScopedEnvVar {
+        key,
+        previous,
+        active: true,
+    })
+}
+
+fn prepare_outputs(
+    root: &Path,
+    arch: &str,
+    case: &str,
+    out: Option<&Path>,
+    output_dir: Option<&Path>,
+) -> anyhow::Result<PerfOutputs> {
+    let (work_dir, dir) = if let Some(out) = out {
+        let dir = PathBuf::from(out);
+        let work_dir = dir
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| dir.clone());
+        (work_dir, dir)
+    } else {
+        let output_root = output_dir
+            .map(PathBuf::from)
+            .unwrap_or_else(|| root.join("target").join("qperf").join(case));
+        let work_dir = output_root.join("perf").join(arch).join("latest");
+        let dir = work_dir.join("qperf");
+        (work_dir, dir)
+    };
+    if out.is_none() && work_dir.exists() {
+        fs::remove_dir_all(&work_dir).with_context(|| {
+            format!(
+                "failed to remove previous qperf output directory {}",
+                work_dir.display()
+            )
+        })?;
+    }
     fs::create_dir_all(&dir)
         .with_context(|| format!("failed to create qperf output directory {}", dir.display()))?;
+    fs::create_dir_all(&work_dir).with_context(|| {
+        format!(
+            "failed to create qperf work directory {}",
+            work_dir.display()
+        )
+    })?;
     Ok(PerfOutputs {
+        work_dir: work_dir.clone(),
         raw: dir.join("qperf.bin"),
         folded: dir.join("stack.folded"),
         flamegraph: dir.join("flamegraph.svg"),
+        folded_boot: dir.join("stack.boot.folded"),
+        flamegraph_boot: dir.join("flamegraph.boot.svg"),
+        folded_workload: dir.join("stack.workload.folded"),
+        flamegraph_workload: dir.join("flamegraph.workload.svg"),
+        folded_post: dir.join("stack.post.folded"),
+        flamegraph_post: dir.join("flamegraph.post.svg"),
+        folded_focus: dir.join("stack.focus.folded"),
+        flamegraph_focus: dir.join("flamegraph.focus.svg"),
+        stack_depth_summary: dir.join("stack-depth-summary.csv"),
+        flamegraph_html: dir.join("flamegraph.html"),
         summary: dir.join("summary.txt"),
         qemu_config: dir.join("qemu.toml"),
+        host_time: dir.join("qemu.time.txt"),
+        host_perf: dir.join("qemu.perf.csv"),
+        resolve_stats: dir.join("resolve.stats.json"),
+        window: dir.join("window.json"),
+        qmp_socket: dir.join("qmp.sock"),
+        profile_stdout: work_dir.join("profile.stdout"),
+        profile_stderr: work_dir.join("profile.stderr"),
+        report_json: work_dir.join("report.json"),
+        report_md: work_dir.join("report.md"),
+        hotspots_csv: work_dir.join("hotspots.csv"),
+        hotspot_categories_csv: work_dir.join("hotspot_categories.csv"),
         dir,
     })
 }
 
-fn build_qperf_tools(root: &Path) -> anyhow::Result<QperfTools> {
+fn build_qperf_tools(root: &Path, analyzer_flamegraph: bool) -> anyhow::Result<QperfTools> {
     let manifest = root.join("tools/qperf/Cargo.toml");
+    let target_dir = root.join("tools/qperf/target");
     if !manifest.exists() {
         bail!(
             "qperf sources not found at {}; expected tools/qperf to be present",
@@ -156,18 +548,27 @@ fn build_qperf_tools(root: &Path) -> anyhow::Result<QperfTools> {
         .args(["build", "--manifest-path"])
         .arg(&manifest)
         .arg("--release")
+        .arg("--target-dir")
+        .arg(&target_dir)
         .exec()
         .context("failed to build qperf plugin")?;
 
-    Command::new("cargo")
+    let mut analyzer_build = Command::new("cargo");
+    analyzer_build
         .current_dir(root)
         .args(["build", "--manifest-path"])
-        .arg(&manifest)
-        .args(["--release", "-p", "qperf-analyzer"])
+        .arg(root.join("tools/qperf/analyzer/Cargo.toml"))
+        .arg("--release")
+        .arg("--target-dir")
+        .arg(&target_dir);
+    if analyzer_flamegraph {
+        analyzer_build.args(["--features", "flamegraph"]);
+    }
+    analyzer_build
         .exec()
         .context("failed to build qperf-analyzer")?;
 
-    let release_dir = root.join("tools/qperf/target/release");
+    let release_dir = target_dir.join("release");
     let tools = QperfTools {
         plugin: release_dir.join("libqperf.so"),
         analyzer: release_dir.join("qperf-analyzer"),
@@ -181,18 +582,59 @@ fn write_qemu_config(
     outputs: &PerfOutputs,
     tools: &QperfTools,
     args: &ArgsPerf,
+    arch: &str,
     qemu_args: Vec<String>,
+    text_range: Option<KernelTextRange>,
 ) -> anyhow::Result<()> {
     let mut perf_qemu_args = vec!["-plugin".to_string()];
-    perf_qemu_args.push(format!(
-        "{},freq={},max_depth={},queue_size={},out={}",
+    let mut plugin_params = format!(
+        "{},freq={},max_depth={},queue_size={},mode={},callchain={},out={}",
         tools.plugin.display(),
         args.freq,
-        args.max_depth,
+        effective_max_depth(args),
         QPERF_QUEUE_SIZE,
+        args.mode,
+        effective_callchain(args),
         outputs.raw.display()
+    );
+    plugin_params.push_str(&format!(
+        ",filter_kernel={}",
+        if args.kernel_filter { 1 } else { 0 }
     ));
+    if let Some(range) = text_range {
+        let start = range.virt.start;
+        let end = range.virt.end;
+        plugin_params.push_str(&format!(",filter_start=0x{start:x},filter_end=0x{end:x}"));
+        if let Some(phys) = range.phys {
+            let offset = range.virt.start.wrapping_sub(phys.start);
+            plugin_params.push_str(&format!(
+                ",filter_alias_start=0x{:x},filter_alias_end=0x{:x},filter_alias_offset=0x{:x}",
+                phys.start, phys.end, offset
+            ));
+        }
+    }
+    perf_qemu_args.push(plugin_params);
+    let mut qemu_args = direct_qemu_args(arch, qemu_args)?;
+    qemu_args.extend(args.qemu_args.iter().cloned());
+    if qemu_stdout_monitor_enabled(args) && !has_qemu_option(&qemu_args, "-qmp") {
+        qemu_args.extend([
+            "-qmp".to_string(),
+            format!("unix:{},server=on,wait=off", outputs.qmp_socket.display()),
+        ]);
+    }
     perf_qemu_args.extend(qemu_args);
+
+    let shell_init_cmd = args
+        .shell_init_cmd
+        .as_deref()
+        .map(str::trim)
+        .filter(|cmd| !cmd.is_empty())
+        .map(str::to_string);
+    let shell_prefix = shell_init_cmd.as_ref().map(|_| {
+        args.shell_prefix
+            .clone()
+            .unwrap_or_else(|| DEFAULT_STARRY_SHELL_PREFIX.to_string())
+    });
 
     let config = PerfQemuConfig {
         args: perf_qemu_args,
@@ -200,13 +642,32 @@ fn write_qemu_config(
         to_bin: true,
         success_regex: Vec::new(),
         fail_regex: vec![r"(?i)\bpanic(?:ked)?\b".to_string()],
-        shell_prefix: None,
-        shell_init_cmd: None,
+        shell_prefix,
+        shell_init_cmd,
         timeout: (args.timeout > 0).then_some(args.timeout),
+        start_marker: args.start_marker.clone(),
+        stop_marker: args.stop_marker.clone(),
+        workload_timeout: args.workload_timeout,
     };
     fs::write(&outputs.qemu_config, toml::to_string_pretty(&config)?)
         .with_context(|| format!("failed to write {}", outputs.qemu_config.display()))?;
     Ok(())
+}
+
+fn direct_qemu_args(arch: &str, mut args: Vec<String>) -> anyhow::Result<Vec<String>> {
+    match arch {
+        "riscv64" | "loongarch64" => {
+            if !has_qemu_option(&args, "-machine") {
+                args.splice(0..0, ["-machine".to_string(), "virt".to_string()]);
+            }
+        }
+        _ => bail!("qperf currently supports StarryOS riscv64 and loongarch64 only"),
+    }
+    Ok(args)
+}
+
+fn has_qemu_option(args: &[String], option: &str) -> bool {
+    args.iter().any(|arg| arg == option)
 }
 
 fn run_qemu_direct(
@@ -214,53 +675,889 @@ fn run_qemu_direct(
     args: &ArgsPerf,
     arch: &str,
     kernel_bin: &Path,
-) -> anyhow::Result<ExitStatus> {
+) -> anyhow::Result<QemuRun> {
     ensure_file(kernel_bin, "StarryOS kernel image")?;
     let qemu = qemu_executable(arch)?;
-    let qemu_args = qemu_args_from_config(&outputs.qemu_config)?;
+    let config = qemu_config_from_path(&outputs.qemu_config)?;
+    let qemu_args = config.args.clone();
+    let monitor_stdout = qemu_stdout_monitor_enabled(args);
 
-    let mut command = if args.timeout > 0 {
-        let mut command = Command::new("timeout");
-        command.arg(format!("{}s", args.timeout));
-        command.arg(qemu);
-        command
+    let mut command_args = if args.timeout > 0 && !monitor_stdout {
+        vec![
+            "timeout".to_string(),
+            "--signal=INT".to_string(),
+            "--kill-after=5s".to_string(),
+            format!("{}s", args.timeout),
+            qemu.to_string(),
+        ]
     } else {
-        Command::new(qemu)
+        vec![qemu.to_string()]
     };
+    command_args.extend(qemu_args);
+    command_args.push("-kernel".to_string());
+    command_args.push(kernel_bin.display().to_string());
 
-    command.args(qemu_args).arg("-kernel").arg(kernel_bin);
+    if args.host_perf {
+        if let Some(perf) = find_executable("perf") {
+            let mut wrapped = vec![
+                perf.display().to_string(),
+                "stat".to_string(),
+                "-x".to_string(),
+                ",".to_string(),
+                "-o".to_string(),
+                outputs.host_perf.display().to_string(),
+                "-e".to_string(),
+                args.host_perf_events.clone(),
+                "--".to_string(),
+            ];
+            wrapped.extend(command_args);
+            command_args = wrapped;
+        } else {
+            write_host_perf_unavailable(&outputs.host_perf, "perf not found in PATH")?;
+            eprintln!("qperf: --host-perf requested but `perf` was not found in PATH");
+        }
+    }
+
+    let mut command = Command::new(&command_args[0]);
+    command.args(&command_args[1..]);
     eprintln!("running qperf QEMU: {command:?}");
-    command.status().context("failed to spawn QEMU")
+    let host_wall_start = Instant::now();
+    let host_usage_start = child_resource_usage();
+    let qemu_run = if monitor_stdout {
+        run_qemu_with_stdout_monitor(command, &config, outputs, args.timeout)?
+    } else {
+        QemuRun {
+            status: command.status().context("failed to spawn QEMU")?,
+            window: window_report_from_config(&config),
+        }
+    };
+    if host_time_enabled(args) {
+        write_host_time_metrics(
+            &outputs.host_time,
+            host_wall_start.elapsed(),
+            host_usage_start,
+            child_resource_usage(),
+            &qemu_run.status,
+        )?;
+    }
+    write_window_report(&outputs.window, &qemu_run.window)?;
+    if !outputs.profile_stdout.exists() {
+        File::create(&outputs.profile_stdout)
+            .with_context(|| format!("failed to create {}", outputs.profile_stdout.display()))?;
+    }
+    if !outputs.profile_stderr.exists() {
+        File::create(&outputs.profile_stderr)
+            .with_context(|| format!("failed to create {}", outputs.profile_stderr.display()))?;
+    }
+    Ok(qemu_run)
 }
 
 fn qemu_executable(arch: &str) -> anyhow::Result<&'static str> {
-    match arch {
-        "riscv64" => Ok("qemu-system-riscv64"),
-        "loongarch64" => Ok("qemu-system-loongarch64"),
+    let name = match arch {
+        "riscv64" => "qemu-system-riscv64",
+        "loongarch64" => "qemu-system-loongarch64",
         _ => bail!("qperf currently supports StarryOS riscv64 and loongarch64 only"),
+    };
+    if find_executable(name).is_none() {
+        bail!(
+            "qperf requires `{name}` in PATH; install the matching QEMU system emulator or run \
+             the Docker-based harness perf-profile entrypoint"
+        );
+    }
+    Ok(name)
+}
+
+fn qemu_config_from_path(path: &Path) -> anyhow::Result<PerfQemuConfig> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("failed to read qperf QEMU config {}", path.display()))?;
+    toml::from_str(&text)
+        .with_context(|| format!("failed to parse qperf QEMU config {}", path.display()))
+}
+
+fn qemu_stdout_monitor_enabled(args: &ArgsPerf) -> bool {
+    args.shell_init_cmd
+        .as_deref()
+        .is_some_and(|cmd| !cmd.trim().is_empty())
+        || args.start_marker.is_some()
+        || args.stop_marker.is_some()
+        || args.workload_timeout.is_some()
+}
+
+fn window_report_from_config(config: &PerfQemuConfig) -> PerfWindowReport {
+    let enabled = config.start_marker.is_some()
+        || config.stop_marker.is_some()
+        || config.workload_timeout.is_some();
+    let mut report = PerfWindowReport {
+        enabled,
+        start_marker: config.start_marker.clone(),
+        stop_marker: config.stop_marker.clone(),
+        workload_timeout: config.workload_timeout,
+        method: if enabled {
+            "qperf_raw_elapsed_timestamp_filter".to_string()
+        } else {
+            "disabled".to_string()
+        },
+        ..PerfWindowReport::default()
+    };
+    if enabled && config.start_marker.is_none() {
+        report
+            .warnings
+            .push("start marker is not configured; boot samples are not excluded".to_string());
+    }
+    if config.workload_timeout.is_some() && config.start_marker.is_none() {
+        report
+            .warnings
+            .push("--workload-timeout requires a start marker to open the window".to_string());
+    }
+    report
+}
+
+fn run_qemu_with_stdout_monitor(
+    mut command: Command,
+    config: &PerfQemuConfig,
+    outputs: &PerfOutputs,
+    overall_timeout: u64,
+) -> anyhow::Result<QemuRun> {
+    let mut window_report = window_report_from_config(config);
+    let shell_init_cmd = config
+        .shell_init_cmd
+        .as_deref()
+        .map(str::trim)
+        .filter(|cmd| !cmd.is_empty());
+    if shell_init_cmd.is_some() {
+        command.stdin(Stdio::piped());
+    }
+    command.stdout(Stdio::piped());
+    let mut child = command.spawn().context("failed to spawn QEMU")?;
+    let mut stdin = child.stdin.take();
+    let stdout = child.stdout.take().context("failed to open QEMU stdout")?;
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut stdout = BufReader::new(stdout);
+        let mut buf = [0_u8; 1024];
+        loop {
+            match stdout.read(&mut buf) {
+                Ok(0) => break,
+                Ok(len) => {
+                    if tx.send(buf[..len].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let started = Instant::now();
+    let mut host_stdout = std::io::stdout().lock();
+    let mut profile_stdout = File::create(&outputs.profile_stdout)
+        .with_context(|| format!("failed to create {}", outputs.profile_stdout.display()))?;
+    let mut prompt_window = Vec::new();
+    let mut marker_window = Vec::new();
+    let mut injected = false;
+    let mut echo_disable_deadline = None;
+    let shell_prefix = config
+        .shell_prefix
+        .as_deref()
+        .unwrap_or(DEFAULT_STARRY_SHELL_PREFIX);
+    let prefix = shell_prefix.as_bytes();
+    let start_marker = config.start_marker.as_deref().map(str::as_bytes);
+    let stop_marker = config.stop_marker.as_deref().map(str::as_bytes);
+    let marker_monitoring = start_marker.is_some() || stop_marker.is_some();
+
+    loop {
+        if let Some(status) = child.try_wait().context("failed to poll QEMU")? {
+            if shell_init_cmd.is_some() && !injected {
+                window_report.warnings.push(format!(
+                    "shell prompt `{shell_prefix}` was not observed before QEMU exited"
+                ));
+                eprintln!(
+                    "qperf: shell prompt `{shell_prefix}` was not observed before QEMU exited"
+                );
+            }
+            finalize_window_warnings(&mut window_report);
+            return Ok(QemuRun {
+                status,
+                window: window_report,
+            });
+        }
+
+        match rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(chunk) => {
+                profile_stdout
+                    .write_all(&chunk)
+                    .context("failed to write qperf profile stdout")?;
+                host_stdout
+                    .write_all(&chunk)
+                    .context("failed to forward QEMU stdout")?;
+                host_stdout.flush().ok();
+                let elapsed = started.elapsed().as_secs_f64();
+
+                if let Some(cmd) = shell_init_cmd
+                    && !injected
+                    && echo_disable_deadline.is_none()
+                {
+                    prompt_window.extend_from_slice(&chunk);
+                    trim_window(&mut prompt_window, prefix.len().saturating_add(1024));
+                    if contains_subslice(&prompt_window, prefix) {
+                        let stdin = stdin.as_mut().context("failed to open QEMU stdin")?;
+                        if marker_monitoring {
+                            stdin
+                                .write_all(b"stty -echo 2>/dev/null || true\n")
+                                .context("failed to disable shell echo before qperf command")?;
+                            stdin.flush().ok();
+                            echo_disable_deadline =
+                                Some(Instant::now() + Duration::from_millis(150));
+                        } else {
+                            write_shell_init_command(stdin, cmd)?;
+                            injected = true;
+                            eprintln!(
+                                "qperf: injected shell init command after prompt `{shell_prefix}`"
+                            );
+                        }
+                    }
+                }
+
+                if start_marker.is_some() || stop_marker.is_some() {
+                    marker_window.extend_from_slice(&chunk);
+                    let keep = start_marker
+                        .into_iter()
+                        .chain(stop_marker)
+                        .map(<[u8]>::len)
+                        .max()
+                        .unwrap_or(0)
+                        .saturating_add(1024);
+                    trim_window(&mut marker_window, keep);
+                }
+
+                if window_report.start_time.is_none()
+                    && start_marker.is_some_and(|marker| contains_subslice(&marker_window, marker))
+                {
+                    window_report.start_time = Some(elapsed);
+                    eprintln!(
+                        "qperf: observed start marker `{}` at {elapsed:.6}s",
+                        config.start_marker.as_deref().unwrap_or("")
+                    );
+                }
+                if window_report.stop_time.is_none()
+                    && stop_marker.is_some_and(|marker| contains_subslice(&marker_window, marker))
+                {
+                    window_report.stop_time = Some(elapsed);
+                    update_window_duration(&mut window_report);
+                    request_qemu_stop(&mut child, outputs, &mut window_report, "stop marker")?;
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {}
+        }
+
+        if let (Some(cmd), Some(deadline)) = (shell_init_cmd, echo_disable_deadline)
+            && !injected
+            && Instant::now() >= deadline
+        {
+            let stdin = stdin.as_mut().context("failed to open QEMU stdin")?;
+            write_shell_init_command(stdin, cmd)?;
+            injected = true;
+            echo_disable_deadline = None;
+            eprintln!("qperf: injected shell init command after prompt `{shell_prefix}`");
+        }
+
+        let elapsed = started.elapsed().as_secs_f64();
+        if let (Some(start_time), Some(timeout)) =
+            (window_report.start_time, config.workload_timeout)
+            && window_report.stop_time.is_none()
+            && elapsed - start_time >= timeout as f64
+        {
+            window_report.stop_time = Some(elapsed);
+            window_report.truncated_by_timeout = true;
+            update_window_duration(&mut window_report);
+            window_report.warnings.push(format!(
+                "workload window timed out after {timeout}s without stop marker"
+            ));
+            request_qemu_stop(&mut child, outputs, &mut window_report, "workload timeout")?;
+            break;
+        }
+        if overall_timeout > 0 && elapsed >= overall_timeout as f64 {
+            window_report.warnings.push(format!(
+                "QEMU timed out after {overall_timeout}s before workload completed"
+            ));
+            request_qemu_stop(&mut child, outputs, &mut window_report, "overall timeout")?;
+            break;
+        }
+    }
+
+    let status = wait_for_child_exit(&mut child, Duration::from_secs(20))?;
+    if shell_init_cmd.is_some() && !injected {
+        window_report.warnings.push(format!(
+            "shell prompt `{shell_prefix}` was not observed before QEMU exited"
+        ));
+        eprintln!("qperf: shell prompt `{shell_prefix}` was not observed before QEMU exited");
+    }
+    finalize_window_warnings(&mut window_report);
+    Ok(QemuRun {
+        status,
+        window: window_report,
+    })
+}
+
+fn trim_window(window: &mut Vec<u8>, keep: usize) {
+    if window.len() > keep {
+        let drain = window.len() - keep;
+        window.drain(..drain);
     }
 }
 
-fn qemu_args_from_config(path: &Path) -> anyhow::Result<Vec<String>> {
-    let text = fs::read_to_string(path)
-        .with_context(|| format!("failed to read qperf QEMU config {}", path.display()))?;
-    let config: PerfQemuConfig = toml::from_str(&text)
-        .with_context(|| format!("failed to parse qperf QEMU config {}", path.display()))?;
-    Ok(config.args)
+fn write_shell_init_command(stdin: &mut impl Write, cmd: &str) -> anyhow::Result<()> {
+    stdin
+        .write_all(cmd.as_bytes())
+        .context("failed to write qperf shell init command")?;
+    stdin
+        .write_all(b"\n")
+        .context("failed to terminate qperf shell init command")?;
+    stdin.flush().ok();
+    Ok(())
 }
 
-fn run_analyzer(analyzer: &Path, elf: &Path, raw: &Path, folded: &Path) -> anyhow::Result<()> {
-    ensure_file(elf, "StarryOS kernel ELF")?;
-    ensure_file(raw, "qperf raw samples")?;
-    Command::new(analyzer)
-        .arg("-e")
-        .arg(elf)
-        .arg(raw)
-        .arg(folded)
-        .exec()
-        .context("failed to run qperf-analyzer")?;
-    ensure_file(folded, "folded stack output")?;
+fn update_window_duration(report: &mut PerfWindowReport) {
+    report.duration_sec = match (report.start_time, report.stop_time) {
+        (Some(start), Some(stop)) if stop >= start => Some(stop - start),
+        _ => None,
+    };
+}
+
+fn request_qemu_stop(
+    child: &mut std::process::Child,
+    outputs: &PerfOutputs,
+    report: &mut PerfWindowReport,
+    reason: &str,
+) -> anyhow::Result<()> {
+    if report.stop_requested {
+        return Ok(());
+    }
+    report.stop_requested = true;
+    match request_qmp_quit(&outputs.qmp_socket) {
+        Ok(()) => {
+            report.stop_method = Some("qmp_quit".to_string());
+            eprintln!("qperf: requested QEMU quit via QMP after {reason}");
+        }
+        Err(err) => {
+            report.warnings.push(format!(
+                "QMP quit failed after {reason}: {err}; falling back to SIGINT"
+            ));
+            interrupt_child(child)?;
+            report.stop_method = Some("sigint".to_string());
+            eprintln!("qperf: sent SIGINT to QEMU after {reason}");
+        }
+    }
     Ok(())
+}
+
+#[cfg(unix)]
+fn request_qmp_quit(socket: &Path) -> anyhow::Result<()> {
+    use std::os::unix::net::UnixStream;
+
+    let mut stream = UnixStream::connect(socket)
+        .with_context(|| format!("failed to connect QMP socket {}", socket.display()))?;
+    stream
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .ok();
+    stream
+        .set_write_timeout(Some(Duration::from_millis(200)))
+        .ok();
+    let mut buf = [0_u8; 512];
+    let _ = stream.read(&mut buf);
+    stream.write_all(b"{\"execute\":\"qmp_capabilities\"}\r\n")?;
+    let _ = stream.read(&mut buf);
+    stream.write_all(b"{\"execute\":\"quit\"}\r\n")?;
+    stream.flush()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn request_qmp_quit(_socket: &Path) -> anyhow::Result<()> {
+    bail!("QMP unix sockets are not supported on this host")
+}
+
+#[cfg(unix)]
+fn interrupt_child(child: &mut std::process::Child) -> anyhow::Result<()> {
+    let pid = child.id() as libc::pid_t;
+    if unsafe { libc::kill(pid, libc::SIGINT) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error()).context("failed to send SIGINT to QEMU")
+    }
+}
+
+#[cfg(not(unix))]
+fn interrupt_child(child: &mut std::process::Child) -> anyhow::Result<()> {
+    child.kill().context("failed to kill QEMU")
+}
+
+fn wait_for_child_exit(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> anyhow::Result<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().context("failed to poll QEMU after stop")? {
+            return Ok(status);
+        }
+        if Instant::now() >= deadline {
+            child.kill().context("failed to kill unresponsive QEMU")?;
+            return child.wait().context("failed to wait for killed QEMU");
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn finalize_window_warnings(report: &mut PerfWindowReport) {
+    if !report.enabled {
+        return;
+    }
+    if report.start_marker.is_some() && report.start_time.is_none() {
+        report
+            .warnings
+            .push("start marker was not observed; folded stacks include boot samples".to_string());
+    }
+    if report.start_time.is_some() && report.stop_marker.is_some() && report.stop_time.is_none() {
+        report
+            .warnings
+            .push("stop marker was not observed; workload window extends to QEMU exit".to_string());
+    }
+    update_window_duration(report);
+}
+
+fn write_window_report(path: &Path, report: &PerfWindowReport) -> anyhow::Result<()> {
+    let text = serde_json::to_string_pretty(report).context("failed to serialize qperf window")?;
+    fs::write(path, text).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+    needle.is_empty()
+        || haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+}
+
+fn write_host_time_metrics(
+    path: &Path,
+    elapsed: Duration,
+    usage_start: Option<ChildResourceUsage>,
+    usage_end: Option<ChildResourceUsage>,
+    status: &ExitStatus,
+) -> anyhow::Result<()> {
+    let mut file =
+        File::create(path).with_context(|| format!("failed to create {}", path.display()))?;
+    let elapsed_seconds = elapsed.as_secs_f64();
+    writeln!(file, "Elapsed time: {elapsed_seconds:.6}")?;
+    if let (Some(start), Some(end)) = (usage_start, usage_end) {
+        let usage = end.delta_since(start);
+        let user_seconds = usage.user_seconds();
+        let system_seconds = usage.system_seconds();
+        writeln!(file, "User time: {user_seconds:.6}")?;
+        writeln!(file, "System time: {system_seconds:.6}")?;
+        if elapsed_seconds > 0.0 {
+            let cpu_percent = (user_seconds + system_seconds) / elapsed_seconds * 100.0;
+            writeln!(file, "Percent of CPU this job got: {cpu_percent:.2}%")?;
+        }
+        writeln!(file, "Major page faults: {}", usage.major_faults)?;
+        writeln!(file, "Minor page faults: {}", usage.minor_faults)?;
+        writeln!(
+            file,
+            "Voluntary context switches: {}",
+            usage.voluntary_context_switches
+        )?;
+        writeln!(
+            file,
+            "Involuntary context switches: {}",
+            usage.involuntary_context_switches
+        )?;
+    } else {
+        writeln!(file, "User time: unavailable")?;
+        writeln!(file, "System time: unavailable")?;
+    }
+    writeln!(file, "Exit status: {}", exit_status_code(status))?;
+    Ok(())
+}
+
+fn write_host_perf_unavailable(path: &Path, reason: &str) -> anyhow::Result<()> {
+    let mut file =
+        File::create(path).with_context(|| format!("failed to create {}", path.display()))?;
+    writeln!(file, "# host perf unavailable: {reason}")?;
+    writeln!(
+        file,
+        "# host perf stat measures the host QEMU process; it is not a guest PMU counter"
+    )?;
+    Ok(())
+}
+
+fn exit_status_code(status: &ExitStatus) -> i32 {
+    status
+        .code()
+        .unwrap_or_else(|| if status.success() { 0 } else { 1 })
+}
+
+fn nonnegative_delta(after: i128, before: i128) -> i128 {
+    after.saturating_sub(before).max(0)
+}
+
+#[cfg(unix)]
+fn child_resource_usage() -> Option<ChildResourceUsage> {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    // SAFETY: getrusage initializes the provided rusage pointer when it returns 0.
+    if unsafe { libc::getrusage(libc::RUSAGE_CHILDREN, usage.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    // SAFETY: getrusage returned success, so usage is initialized.
+    let usage = unsafe { usage.assume_init() };
+    Some(ChildResourceUsage {
+        user_micros: timeval_micros(usage.ru_utime),
+        system_micros: timeval_micros(usage.ru_stime),
+        major_faults: usage.ru_majflt.into(),
+        minor_faults: usage.ru_minflt.into(),
+        voluntary_context_switches: usage.ru_nvcsw.into(),
+        involuntary_context_switches: usage.ru_nivcsw.into(),
+    })
+}
+
+#[cfg(unix)]
+fn timeval_micros(value: libc::timeval) -> i128 {
+    i128::from(value.tv_sec) * 1_000_000 + i128::from(value.tv_usec)
+}
+
+#[cfg(not(unix))]
+fn child_resource_usage() -> Option<ChildResourceUsage> {
+    None
+}
+
+struct AnalyzerRun<'a> {
+    analyzer: &'a Path,
+    elf: &'a Path,
+    raw: &'a Path,
+    folded: &'a Path,
+    flamegraph: &'a Path,
+    resolve_stats: &'a Path,
+    depth_summary: Option<&'a Path>,
+    generate_svg: bool,
+    top_n: usize,
+    start_sec: Option<f64>,
+    stop_sec: Option<f64>,
+    symbol_style: String,
+    demangle: bool,
+    focus: Option<&'a str>,
+    min_percent: f64,
+}
+
+fn run_analyzer(args: AnalyzerRun<'_>) -> anyhow::Result<()> {
+    ensure_file(args.elf, "StarryOS kernel ELF")?;
+    ensure_file(args.raw, "qperf raw samples")?;
+    let mut command = Command::new(args.analyzer);
+    command
+        .arg("resolve")
+        .arg("-e")
+        .arg(args.elf)
+        .arg(args.raw)
+        .arg(args.folded);
+    if args.top_n > 0 {
+        command.arg("--top").arg(args.top_n.to_string());
+    }
+    if let Some(start_sec) = args.start_sec {
+        command.arg("--start-sec").arg(format!("{start_sec:.9}"));
+    }
+    if let Some(stop_sec) = args.stop_sec {
+        command.arg("--stop-sec").arg(format!("{stop_sec:.9}"));
+    }
+    command
+        .arg("--symbol-style")
+        .arg(&args.symbol_style)
+        .arg("--min-percent")
+        .arg(args.min_percent.to_string());
+    if !args.demangle {
+        command.arg("--no-demangle");
+    }
+    if let Some(focus) = args.focus {
+        command.arg("--focus").arg(focus);
+    }
+    command.arg("--stats").arg(args.resolve_stats);
+    if let Some(depth_summary) = args.depth_summary {
+        command.arg("--depth-summary").arg(depth_summary);
+    }
+    if args.generate_svg {
+        command.arg("--flamegraph").arg(args.flamegraph);
+    }
+    command.exec().context("failed to run qperf-analyzer")?;
+    if !args.folded.exists() {
+        bail!("folded stack output not found at {}", args.folded.display());
+    }
+    Ok(())
+}
+
+fn generate_phase_flamegraphs(
+    tools: &QperfTools,
+    elf: &Path,
+    outputs: &PerfOutputs,
+    args: &ArgsPerf,
+    window: &PerfWindowReport,
+    generate_svg: bool,
+) -> anyhow::Result<()> {
+    if window.start_time.is_some() && window.stop_time.is_some() {
+        fs::copy(&outputs.folded, &outputs.folded_workload).with_context(|| {
+            format!(
+                "failed to copy workload folded stack to {}",
+                outputs.folded_workload.display()
+            )
+        })?;
+        if file_nonempty(&outputs.flamegraph) {
+            fs::copy(&outputs.flamegraph, &outputs.flamegraph_workload).with_context(|| {
+                format!(
+                    "failed to copy workload flamegraph to {}",
+                    outputs.flamegraph_workload.display()
+                )
+            })?;
+        }
+    }
+    if let Some(start_sec) = window.start_time {
+        run_analyzer(AnalyzerRun {
+            analyzer: &tools.analyzer,
+            elf,
+            raw: &outputs.raw,
+            folded: &outputs.folded_boot,
+            flamegraph: &outputs.flamegraph_boot,
+            resolve_stats: &outputs
+                .resolve_stats
+                .with_file_name("resolve.boot.stats.json"),
+            depth_summary: Some(
+                &outputs
+                    .stack_depth_summary
+                    .with_file_name("stack-depth-summary.boot.csv"),
+            ),
+            generate_svg,
+            top_n: 0,
+            start_sec: None,
+            stop_sec: Some(start_sec),
+            symbol_style: args.symbol_style.to_string(),
+            demangle: true,
+            focus: None,
+            min_percent: flamegraph_min_percent(args),
+        })?;
+    }
+    if let Some(stop_sec) = window.stop_time {
+        run_analyzer(AnalyzerRun {
+            analyzer: &tools.analyzer,
+            elf,
+            raw: &outputs.raw,
+            folded: &outputs.folded_post,
+            flamegraph: &outputs.flamegraph_post,
+            resolve_stats: &outputs
+                .resolve_stats
+                .with_file_name("resolve.post.stats.json"),
+            depth_summary: Some(
+                &outputs
+                    .stack_depth_summary
+                    .with_file_name("stack-depth-summary.post.csv"),
+            ),
+            generate_svg,
+            top_n: 0,
+            start_sec: Some(stop_sec),
+            stop_sec: None,
+            symbol_style: args.symbol_style.to_string(),
+            demangle: true,
+            focus: None,
+            min_percent: flamegraph_min_percent(args),
+        })?;
+    }
+    Ok(())
+}
+
+fn generate_focus_flamegraph(
+    tools: &QperfTools,
+    elf: &Path,
+    outputs: &PerfOutputs,
+    args: &ArgsPerf,
+    generate_svg: bool,
+) -> anyhow::Result<()> {
+    let Some(focus) = args.focus.as_deref() else {
+        return Ok(());
+    };
+    run_analyzer(AnalyzerRun {
+        analyzer: &tools.analyzer,
+        elf,
+        raw: &outputs.raw,
+        folded: &outputs.folded_focus,
+        flamegraph: &outputs.flamegraph_focus,
+        resolve_stats: &outputs
+            .resolve_stats
+            .with_file_name("resolve.focus.stats.json"),
+        depth_summary: Some(
+            &outputs
+                .stack_depth_summary
+                .with_file_name("stack-depth-summary.focus.csv"),
+        ),
+        generate_svg,
+        top_n: 0,
+        start_sec: None,
+        stop_sec: None,
+        symbol_style: args.symbol_style.to_string(),
+        demangle: true,
+        focus: Some(focus),
+        min_percent: flamegraph_min_percent(args),
+    })
+}
+
+fn write_flamegraph_html(
+    outputs: &PerfOutputs,
+    kind: PerfFlamegraphKind,
+    flamegraph_generated: bool,
+) -> anyhow::Result<()> {
+    if !matches!(kind, PerfFlamegraphKind::Html) || !flamegraph_generated {
+        return Ok(());
+    }
+    let svg = outputs
+        .flamegraph
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("flamegraph.svg");
+    let html = format!(
+        "<!doctype html><meta charset=\"utf-8\"><title>StarryOS qperf Flame \
+         Graph</title><style>body{{margin:0}}object{{width:100vw;height:100vh;border:0}}</\
+         style><object data=\"{svg}\" type=\"image/svg+xml\"></object>\n"
+    );
+    fs::write(&outputs.flamegraph_html, html)
+        .with_context(|| format!("failed to write {}", outputs.flamegraph_html.display()))
+}
+
+fn run_report_postprocess(
+    outputs: &PerfOutputs,
+    args: &ArgsPerf,
+    arch: &str,
+    returncode: i32,
+) -> anyhow::Result<()> {
+    let harness = workspace_harness_path(&outputs.work_dir)
+        .unwrap_or_else(|| PathBuf::from("tools/starry-syscall-harness/harness.py"));
+    if !harness.exists() {
+        eprintln!(
+            "qperf: harness postprocess script not found at {}; report.json/report.md not \
+             generated",
+            harness.display()
+        );
+        return Ok(());
+    }
+    let mut command = Command::new("python3");
+    command
+        .arg(&harness)
+        .arg("perf-postprocess")
+        .arg("--repo-root")
+        .arg(workspace_root_from_harness(&harness))
+        .arg("--arch")
+        .arg(arch)
+        .arg("--work-dir")
+        .arg(&outputs.work_dir)
+        .arg("--qperf-dir")
+        .arg(&outputs.dir)
+        .arg("--returncode")
+        .arg(returncode.to_string())
+        .arg("--timeout")
+        .arg(args.timeout.to_string())
+        .arg("--format")
+        .arg(format!("{:?}", args.format).to_ascii_lowercase())
+        .arg("--freq")
+        .arg(args.freq.to_string())
+        .arg("--max-depth")
+        .arg(effective_max_depth(args).to_string())
+        .arg("--mode")
+        .arg(args.mode.to_string())
+        .arg("--callchain")
+        .arg(effective_callchain(args).to_string())
+        .arg("--top")
+        .arg(args.top.to_string())
+        .arg("--min-percent")
+        .arg(args.min_percent.to_string())
+        .arg("--symbol-style")
+        .arg(args.symbol_style.to_string())
+        .arg("--profile-stdout")
+        .arg(&outputs.profile_stdout)
+        .arg("--profile-stderr")
+        .arg(&outputs.profile_stderr);
+    if args.debug {
+        command.arg("--debug");
+    }
+    if args.kernel_filter {
+        command.arg("--kernel-filter");
+    }
+    if host_time_enabled(args) {
+        command.arg("--host-time");
+    }
+    if args.host_perf {
+        command
+            .arg("--host-perf")
+            .arg("--host-perf-events")
+            .arg(&args.host_perf_events);
+    }
+    if let Some(cmd) = &args.shell_init_cmd {
+        command.arg("--shell-init-cmd").arg(cmd);
+    }
+    if let Some(prefix) = &args.shell_prefix {
+        command.arg("--shell-prefix").arg(prefix);
+    }
+    if let Some(marker) = &args.start_marker {
+        command.arg("--start-marker").arg(marker);
+    }
+    if let Some(marker) = &args.stop_marker {
+        command.arg("--stop-marker").arg(marker);
+    }
+    if let Some(timeout) = args.workload_timeout {
+        command.arg("--workload-timeout").arg(timeout.to_string());
+    }
+    if args.qperf_metrics {
+        command.arg("--qperf-metrics");
+    }
+    if args.full_stack {
+        command.arg("--full-stack");
+    }
+    if perf_needs_debuginfo(args) {
+        command.arg("--perf-debuginfo");
+    }
+    if perf_needs_frame_pointers(args) {
+        command.arg("--perf-force-frame-pointers");
+    }
+    if let Some(focus) = &args.focus {
+        command.arg("--focus").arg(focus);
+    }
+    if args.no_truncate {
+        command.arg("--no-truncate");
+    }
+    for qemu_arg in &args.qemu_args {
+        command.arg("--qemu-arg").arg(qemu_arg);
+    }
+    let status = command
+        .status()
+        .context("failed to run qperf report postprocess")?;
+    if !status.success() {
+        bail!("qperf report postprocess failed with {status}");
+    }
+    Ok(())
+}
+
+fn workspace_harness_path(work_dir: &Path) -> Option<PathBuf> {
+    let mut current = Some(work_dir);
+    while let Some(path) = current {
+        let candidate = path.join("tools/starry-syscall-harness/harness.py");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        current = path.parent();
+    }
+    None
+}
+
+fn workspace_root_from_harness(harness: &Path) -> PathBuf {
+    harness
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
 }
 
 fn try_generate_flamegraph(folded: &Path, svg: &Path) -> anyhow::Result<bool> {
@@ -311,15 +1608,21 @@ fn find_executable(name: &str) -> Option<PathBuf> {
     })
 }
 
-fn write_summary(
-    outputs: &PerfOutputs,
-    tools: &QperfTools,
-    elf: &Path,
-    arch: &str,
-    target: &str,
-    args: &ArgsPerf,
+struct SummaryInputs<'a> {
+    outputs: &'a PerfOutputs,
+    tools: &'a QperfTools,
+    elf: &'a Path,
+    arch: &'a str,
+    target: &'a str,
+    args: &'a ArgsPerf,
     flamegraph_generated: bool,
-) -> anyhow::Result<()> {
+    window: &'a PerfWindowReport,
+}
+
+fn write_summary(input: SummaryInputs<'_>) -> anyhow::Result<()> {
+    let outputs = input.outputs;
+    let args = input.args;
+    let window = input.window;
     let folded_lines = count_lines(&outputs.folded).unwrap_or(0);
     let plugin_summary = outputs.raw.with_extension("summary.txt");
     let plugin_summary_text = fs::read_to_string(plugin_summary).ok();
@@ -327,21 +1630,140 @@ fn write_summary(
     let mut file = File::create(&outputs.summary)
         .with_context(|| format!("failed to create {}", outputs.summary.display()))?;
     writeln!(file, "qperf_format_version = 1")?;
-    writeln!(file, "arch = {arch}")?;
-    writeln!(file, "target = {target}")?;
+    writeln!(file, "arch = {}", input.arch)?;
+    writeln!(file, "target = {}", input.target)?;
     writeln!(file, "frequency_hz = {}", args.freq)?;
-    writeln!(file, "max_stack_depth = {}", args.max_depth)?;
+    writeln!(file, "max_stack_depth = {}", effective_max_depth(args))?;
+    writeln!(file, "sampling_mode = {}", args.mode)?;
+    writeln!(file, "callchain_mode = {}", effective_callchain(args))?;
+    writeln!(file, "full_stack = {}", args.full_stack)?;
+    writeln!(file, "perf_debuginfo = {}", perf_needs_debuginfo(args))?;
+    writeln!(
+        file,
+        "perf_force_frame_pointers = {}",
+        perf_needs_frame_pointers(args)
+    )?;
+    writeln!(file, "case = {}", args.case)?;
+    writeln!(file, "symbol_style = {}", args.symbol_style)?;
+    writeln!(file, "flamegraph_kind = {}", args.flamegraph_kind)?;
+    writeln!(
+        file,
+        "flamegraph_min_percent = {}",
+        flamegraph_min_percent(args)
+    )?;
+    if let Some(focus) = args.focus.as_deref() {
+        writeln!(file, "focus = {focus}")?;
+    }
+    writeln!(file, "kernel_filter = {}", args.kernel_filter)?;
+    writeln!(file, "host_time = {}", host_time_enabled(args))?;
+    if host_time_enabled(args) {
+        writeln!(file, "host_time_output = {}", outputs.host_time.display())?;
+    }
+    writeln!(file, "host_perf = {}", args.host_perf)?;
+    if args.host_perf {
+        writeln!(file, "host_perf_events = {}", args.host_perf_events)?;
+        writeln!(file, "host_perf_output = {}", outputs.host_perf.display())?;
+        writeln!(
+            file,
+            "host_perf_note = host perf stat measures the QEMU process on the host; it is not a \
+             guest PMU cache/cycle counter"
+        )?;
+    }
+    if let Some(shell_init_cmd) = args.shell_init_cmd.as_deref() {
+        writeln!(file, "shell_init_cmd = {shell_init_cmd}")?;
+        writeln!(
+            file,
+            "shell_prefix = {}",
+            args.shell_prefix
+                .as_deref()
+                .unwrap_or(DEFAULT_STARRY_SHELL_PREFIX)
+        )?;
+    }
+    if let Some(start_marker) = args.start_marker.as_deref() {
+        writeln!(file, "start_marker = {start_marker}")?;
+    }
+    if let Some(stop_marker) = args.stop_marker.as_deref() {
+        writeln!(file, "stop_marker = {stop_marker}")?;
+    }
+    if let Some(workload_timeout) = args.workload_timeout {
+        writeln!(file, "workload_timeout = {workload_timeout}")?;
+    }
+    writeln!(file, "qperf_metrics = {}", args.qperf_metrics)?;
+    writeln!(file, "window_enabled = {}", window.enabled)?;
+    if let Some(start_time) = window.start_time {
+        writeln!(file, "window_start_time = {start_time:.9}")?;
+    }
+    if let Some(stop_time) = window.stop_time {
+        writeln!(file, "window_stop_time = {stop_time:.9}")?;
+    }
+    if let Some(duration) = window.duration_sec {
+        writeln!(file, "window_duration_sec = {duration:.9}")?;
+    }
+    writeln!(
+        file,
+        "window_truncated_by_timeout = {}",
+        window.truncated_by_timeout
+    )?;
+    writeln!(file, "window_report = {}", outputs.window.display())?;
+    writeln!(file, "resolve_stats = {}", outputs.resolve_stats.display())?;
+    if !args.qemu_args.is_empty() {
+        writeln!(file, "extra_qemu_args = {}", args.qemu_args.join(" "))?;
+    }
+    writeln!(
+        file,
+        "build_profile = {}",
+        if args.debug { "debug" } else { "release" }
+    )?;
     writeln!(file, "queue_size = {QPERF_QUEUE_SIZE}")?;
     writeln!(file, "timeout_seconds = {}", args.timeout)?;
-    writeln!(file, "kernel_elf = {}", elf.display())?;
-    writeln!(file, "plugin = {}", tools.plugin.display())?;
-    writeln!(file, "analyzer = {}", tools.analyzer.display())?;
+    writeln!(file, "kernel_elf = {}", input.elf.display())?;
+    writeln!(file, "plugin = {}", input.tools.plugin.display())?;
+    writeln!(file, "analyzer = {}", input.tools.analyzer.display())?;
     writeln!(file, "raw_samples = {}", outputs.raw.display())?;
     writeln!(file, "folded_stack = {}", outputs.folded.display())?;
+    writeln!(
+        file,
+        "stack_depth_summary = {}",
+        outputs.stack_depth_summary.display()
+    )?;
+    writeln!(
+        file,
+        "workload_folded_stack = {}",
+        outputs.folded_workload.display()
+    )?;
+    writeln!(
+        file,
+        "boot_folded_stack = {}",
+        outputs.folded_boot.display()
+    )?;
+    writeln!(
+        file,
+        "post_folded_stack = {}",
+        outputs.folded_post.display()
+    )?;
     writeln!(file, "folded_stack_lines = {folded_lines}")?;
-    writeln!(file, "flamegraph_generated = {flamegraph_generated}")?;
-    if flamegraph_generated {
+    writeln!(
+        file,
+        "flamegraph_generated = {}",
+        input.flamegraph_generated
+    )?;
+    if input.flamegraph_generated {
         writeln!(file, "flamegraph = {}", outputs.flamegraph.display())?;
+        writeln!(
+            file,
+            "workload_flamegraph = {}",
+            outputs.flamegraph_workload.display()
+        )?;
+        writeln!(
+            file,
+            "boot_flamegraph = {}",
+            outputs.flamegraph_boot.display()
+        )?;
+        writeln!(
+            file,
+            "post_flamegraph = {}",
+            outputs.flamegraph_post.display()
+        )?;
     }
     if let Some(plugin_summary_text) = plugin_summary_text {
         writeln!(file)?;
@@ -358,29 +1780,214 @@ fn write_summary(
     Ok(())
 }
 
-fn print_report(outputs: &PerfOutputs, flamegraph_generated: bool) {
+fn print_report(outputs: &PerfOutputs, args: &ArgsPerf) {
     println!("qperf report generated:");
-    println!("  output dir: {}", outputs.dir.display());
-    println!("  raw samples: {}", outputs.raw.display());
+    println!("  report: {}", outputs.report_md.display());
+    println!("  flamegraph: {}", outputs.flamegraph.display());
     println!("  folded stack: {}", outputs.folded.display());
-    if flamegraph_generated {
-        println!("  flamegraph: {}", outputs.flamegraph.display());
+    println!(
+        "  stack depth summary: {}",
+        outputs.stack_depth_summary.display()
+    );
+    println!("  json: {}", outputs.report_json.display());
+    println!("  callchain mode: {}", effective_callchain(args));
+    println!("  hotspots: {}", outputs.hotspots_csv.display());
+    println!(
+        "  hotspot categories: {}",
+        outputs.hotspot_categories_csv.display()
+    );
+    println!("  qperf dir: {}", outputs.dir.display());
+    println!("  raw samples: {}", outputs.raw.display());
+    if outputs.flamegraph_workload.exists() {
+        println!(
+            "  workload flamegraph: {}",
+            outputs.flamegraph_workload.display()
+        );
+    }
+    if outputs.flamegraph_boot.exists() {
+        println!("  boot flamegraph: {}", outputs.flamegraph_boot.display());
+    }
+    if outputs.flamegraph_post.exists() {
+        println!("  post flamegraph: {}", outputs.flamegraph_post.display());
+    }
+    if outputs.flamegraph_focus.exists() {
+        println!(
+            "  focused flamegraph: {}",
+            outputs.flamegraph_focus.display()
+        );
+    }
+    if outputs.flamegraph_html.exists() {
+        println!("  html flamegraph: {}", outputs.flamegraph_html.display());
+    }
+    println!("  qemu config: {}", outputs.qemu_config.display());
+    if outputs.host_time.exists() {
+        println!("  host time: {}", outputs.host_time.display());
+    }
+    if outputs.host_perf.exists() {
+        println!("  host perf: {}", outputs.host_perf.display());
+    }
+    if outputs.window.exists() {
+        println!("  window: {}", outputs.window.display());
     }
     println!("  summary: {}", outputs.summary.display());
+    println!(
+        "  compare hint: cargo starry perf-compare is not a cargo subcommand; use python3 \
+         tools/starry-syscall-harness/harness.py perf-compare --baseline {} --candidate \
+         <other-report.json>",
+        outputs.report_json.display()
+    );
 }
 
-fn kernel_elf_path(root: &Path, target: &str) -> PathBuf {
+fn kernel_elf_path(root: &Path, target: &str, debug: bool) -> PathBuf {
     root.join("target")
         .join(target)
-        .join("debug")
+        .join(if debug { "debug" } else { "release" })
         .join("starryos")
 }
 
-fn kernel_bin_path(root: &Path, target: &str) -> PathBuf {
+fn kernel_bin_path(root: &Path, target: &str, debug: bool) -> PathBuf {
     root.join("target")
         .join(target)
-        .join("debug")
+        .join(if debug { "debug" } else { "release" })
         .join("starryos.bin")
+}
+
+fn detect_kernel_text_range(
+    elf: &Path,
+    axconfig_path: Option<&Path>,
+) -> anyhow::Result<Option<KernelTextRange>> {
+    if !elf.exists() {
+        eprintln!(
+            "qperf: kernel ELF not found at {}, skipping .text range filter",
+            elf.display()
+        );
+        return Ok(None);
+    }
+    let data =
+        fs::read(elf).with_context(|| format!("failed to read kernel ELF {}", elf.display()))?;
+    let obj = object::File::parse(&*data)
+        .map_err(|err| anyhow::anyhow!("failed to parse kernel ELF: {err}"))?;
+    let mut virt: Option<AddressRange> = None;
+    for section in obj.sections() {
+        if !matches!(section.name().unwrap_or(""), ".head.text" | ".text") {
+            continue;
+        }
+        let start = section.address();
+        let size = section.size();
+        if start == 0 || size == 0 {
+            continue;
+        }
+        let end = start
+            .checked_add(size)
+            .context("kernel text section end address overflow")?;
+        virt = Some(match virt {
+            Some(range) => AddressRange {
+                start: range.start.min(start),
+                end: range.end.max(end),
+            },
+            None => AddressRange { start, end },
+        });
+    }
+
+    let Some(virt) = virt else {
+        eprintln!(
+            "qperf: could not find .head.text/.text sections in kernel ELF, address filter \
+             disabled"
+        );
+        return Ok(None);
+    };
+    let size = virt.end - virt.start;
+    let phys = detect_physical_text_range(virt, size, axconfig_path)?
+        .or_else(|| detect_low_address_text_alias(virt));
+    eprintln!(
+        "qperf: detected kernel text virtual range: 0x{:x}..0x{:x} ({size} bytes)",
+        virt.start, virt.end
+    );
+    if let Some(phys) = phys {
+        eprintln!(
+            "qperf: detected kernel text physical alias: 0x{:x}..0x{:x}",
+            phys.start, phys.end
+        );
+    }
+    Ok(Some(KernelTextRange { virt, phys }))
+}
+
+fn detect_physical_text_range(
+    virt: AddressRange,
+    size: u64,
+    axconfig_path: Option<&Path>,
+) -> anyhow::Result<Option<AddressRange>> {
+    let Some(axconfig_path) = axconfig_path else {
+        return Ok(None);
+    };
+    let Some((kernel_vaddr, kernel_paddr)) = read_kernel_base_addresses(axconfig_path)? else {
+        return Ok(None);
+    };
+    if virt.start < kernel_vaddr {
+        return Ok(None);
+    }
+    let phys_start = kernel_paddr
+        .checked_add(virt.start - kernel_vaddr)
+        .context("kernel .text physical address overflow")?;
+    let phys_end = phys_start
+        .checked_add(size)
+        .context("kernel .text physical end address overflow")?;
+    Ok(Some(AddressRange {
+        start: phys_start,
+        end: phys_end,
+    }))
+}
+
+fn detect_low_address_text_alias(virt: AddressRange) -> Option<AddressRange> {
+    const LOW_32BIT_MASK: u64 = 0x0000_0000_ffff_ffff;
+
+    if virt.end <= LOW_32BIT_MASK || virt.start & !LOW_32BIT_MASK == 0 {
+        return None;
+    }
+    let size = virt.end.checked_sub(virt.start)?;
+    let start = virt.start & LOW_32BIT_MASK;
+    let end = start.checked_add(size)?;
+    Some(AddressRange { start, end })
+}
+
+fn read_kernel_base_addresses(axconfig_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+    if !axconfig_path.exists() {
+        return Ok(None);
+    }
+    let text = fs::read_to_string(axconfig_path)
+        .with_context(|| format!("failed to read {}", axconfig_path.display()))?;
+    let config: toml::Value = toml::from_str(&text)
+        .with_context(|| format!("failed to parse {}", axconfig_path.display()))?;
+    let Some(plat) = config.get("plat").and_then(toml::Value::as_table) else {
+        return Ok(None);
+    };
+    let Some(kernel_vaddr) = plat.get("kernel-base-vaddr").and_then(parse_axconfig_uint) else {
+        return Ok(None);
+    };
+    let Some(kernel_paddr) = plat.get("kernel-base-paddr").and_then(parse_axconfig_uint) else {
+        return Ok(None);
+    };
+    Ok(Some((kernel_vaddr, kernel_paddr)))
+}
+
+fn parse_axconfig_uint(value: &toml::Value) -> Option<u64> {
+    match value {
+        toml::Value::Integer(value) => (*value).try_into().ok(),
+        toml::Value::String(value) => parse_u64_literal(value),
+        _ => None,
+    }
+}
+
+fn parse_u64_literal(value: &str) -> Option<u64> {
+    let compact = value.trim().replace('_', "");
+    if let Some(hex) = compact
+        .strip_prefix("0x")
+        .or_else(|| compact.strip_prefix("0X"))
+    {
+        u64::from_str_radix(hex, 16).ok()
+    } else {
+        compact.parse().ok()
+    }
 }
 
 fn ensure_file(path: &Path, label: &str) -> anyhow::Result<()> {

--- a/tools/qperf/analyzer/Cargo.toml
+++ b/tools/qperf/analyzer/Cargo.toml
@@ -4,8 +4,16 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+default = []
+flamegraph = ["inferno"]
+
 [dependencies]
 addr2line = "0.25.0"
 anyhow = "1.0.100"
 bincode.workspace = true
 clap = { version = "4.5.45", features = ["derive"] }
+inferno = { version = "0.12", optional = true, default-features = false }
+object = "0.37"
+regex = "1.12"
+rustc-demangle = "0.1"

--- a/tools/qperf/analyzer/src/main.rs
+++ b/tools/qperf/analyzer/src/main.rs
@@ -1,92 +1,873 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, BTreeSet, HashMap},
     fs::File,
-    io::{BufReader, BufWriter, Write},
-    path::PathBuf,
+    io::{BufRead, BufReader, BufWriter, Write},
+    path::{Path, PathBuf},
 };
 
 use anyhow::Context;
-use clap::Parser;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use object::{Object, ObjectSymbol};
+use regex::Regex;
 
 #[derive(Parser)]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[clap(value_name = "INPUT")]
+    input: Option<PathBuf>,
+    #[clap(value_name = "OUTPUT")]
+    output: Option<PathBuf>,
+    #[clap(long, short, value_name = "ELF")]
+    elf: Option<PathBuf>,
+    #[clap(long, value_name = "N", default_value_t = 0)]
+    top: usize,
+    #[clap(long, value_name = "SVG")]
+    flamegraph: Option<PathBuf>,
+    #[clap(long, value_name = "SECONDS")]
+    start_sec: Option<f64>,
+    #[clap(long, value_name = "SECONDS")]
+    stop_sec: Option<f64>,
+    #[clap(long, value_name = "JSON")]
+    stats: Option<PathBuf>,
+    /// Write selected stack-depth distribution as CSV.
+    #[clap(long, value_name = "CSV")]
+    depth_summary: Option<PathBuf>,
+    /// Folded-stack symbol style.
+    #[clap(long, value_enum, default_value_t = SymbolStyle::Full)]
+    symbol_style: SymbolStyle,
+    /// Disable Rust symbol demangling.
+    #[clap(long)]
+    no_demangle: bool,
+    /// Keep only samples whose resolved stack matches this regex.
+    #[clap(long, value_name = "REGEX")]
+    focus: Option<String>,
+    /// Inferno flamegraph minimum frame width.
+    #[clap(long, value_name = "PERCENT", default_value_t = 0.3)]
+    min_percent: f64,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Resolve symbols and produce folded stacks from qperf raw samples.
+    Resolve(ResolveArgs),
+    /// Compare two folded stack files and print top percentage deltas.
+    Diff(DiffArgs),
+}
+
+#[derive(Args)]
+struct ResolveArgs {
     #[clap(value_name = "INPUT")]
     input: PathBuf,
     #[clap(value_name = "OUTPUT")]
     output: PathBuf,
     #[clap(long, short, value_name = "ELF")]
     elf: PathBuf,
+    /// Print top N hottest functions to stderr.
+    #[clap(long, value_name = "N", default_value_t = 0)]
+    top: usize,
+    /// Generate flamegraph SVG when the analyzer was built with the flamegraph feature.
+    #[clap(long, value_name = "SVG")]
+    flamegraph: Option<PathBuf>,
+    /// Keep samples at or after this elapsed time in seconds.
+    #[clap(long, value_name = "SECONDS")]
+    start_sec: Option<f64>,
+    /// Keep samples before this elapsed time in seconds.
+    #[clap(long, value_name = "SECONDS")]
+    stop_sec: Option<f64>,
+    /// Write resolve/filter statistics as JSON.
+    #[clap(long, value_name = "JSON")]
+    stats: Option<PathBuf>,
+    /// Write selected stack-depth distribution as CSV.
+    #[clap(long, value_name = "CSV")]
+    depth_summary: Option<PathBuf>,
+    /// Folded-stack symbol style.
+    #[clap(long, value_enum, default_value_t = SymbolStyle::Full)]
+    symbol_style: SymbolStyle,
+    /// Disable Rust symbol demangling.
+    #[clap(long)]
+    no_demangle: bool,
+    /// Keep only samples whose resolved stack matches this regex.
+    #[clap(long, value_name = "REGEX")]
+    focus: Option<String>,
+    /// Inferno flamegraph minimum frame width.
+    #[clap(long, value_name = "PERCENT", default_value_t = 0.3)]
+    min_percent: f64,
+}
+
+#[derive(Args)]
+struct DiffArgs {
+    #[clap(long, value_name = "FILE")]
+    baseline: PathBuf,
+    #[clap(long, value_name = "FILE")]
+    compare: PathBuf,
+    #[clap(long, value_name = "SVG")]
+    flamegraph: Option<PathBuf>,
+    /// Print top N changed functions to stderr.
+    #[clap(long, value_name = "N", default_value_t = 20)]
+    top: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum SymbolStyle {
+    Full,
+    Short,
+    Module,
 }
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    match cli.command {
+        Some(Commands::Resolve(args)) => cmd_resolve(args),
+        Some(Commands::Diff(args)) => cmd_diff(args),
+        None => {
+            let input = cli.input.context("missing INPUT")?;
+            let output = cli.output.context("missing OUTPUT")?;
+            let elf = cli.elf.context("missing --elf")?;
+            cmd_resolve(ResolveArgs {
+                input,
+                output,
+                elf,
+                top: cli.top,
+                flamegraph: cli.flamegraph,
+                start_sec: cli.start_sec,
+                stop_sec: cli.stop_sec,
+                stats: cli.stats,
+                depth_summary: cli.depth_summary,
+                symbol_style: cli.symbol_style,
+                no_demangle: cli.no_demangle,
+                focus: cli.focus,
+                min_percent: cli.min_percent,
+            })
+        }
+    }
+}
 
-    let mut input = BufReader::new(File::open(&cli.input).context("Failed to open input file")?);
+#[derive(bincode::Decode)]
+struct SampleRecord {
+    elapsed_ns: u64,
+    pc: u64,
+    sp: u64,
+    fp: u64,
+    cpu: u32,
+    callchain: u8,
+    trace: Vec<u64>,
+}
 
-    let loader = addr2line::Loader::new(&cli.elf)
-        .map_err(|err| anyhow::anyhow!("Failed to create addr2line loader: {err}"))?;
+#[derive(bincode::Decode)]
+struct SampleRecordV2 {
+    elapsed_ns: u64,
+    trace: Vec<u64>,
+}
+
+struct DecodedRecord {
+    elapsed_ns: Option<u64>,
+    pc: Option<u64>,
+    sp: Option<u64>,
+    fp: Option<u64>,
+    cpu: Option<u32>,
+    callchain: Option<u8>,
+    trace: Vec<u64>,
+}
+
+#[derive(Default)]
+struct ResolveStats {
+    format_version: u32,
+    raw_records: u64,
+    selected_records: u64,
+    bad_records: u64,
+    total_frames: u64,
+    selected_frames: u64,
+    selected_leaf_records: u64,
+    selected_multi_frame_records: u64,
+    samples_with_pc: u64,
+    samples_with_sp: u64,
+    samples_with_fp: u64,
+    samples_with_cpu: u64,
+    max_depth: usize,
+    depth_histogram: BTreeMap<usize, u64>,
+    callchain_method: Option<String>,
+    samples_excluded_before: u64,
+    samples_excluded_after: u64,
+    first_sample_sec: Option<f64>,
+    last_sample_sec: Option<f64>,
+    start_sec: Option<f64>,
+    stop_sec: Option<f64>,
+    warning: Option<String>,
+}
+
+fn cmd_resolve(args: ResolveArgs) -> anyhow::Result<()> {
+    if let (Some(start), Some(stop)) = (args.start_sec, args.stop_sec)
+        && start >= stop
+    {
+        anyhow::bail!("--start-sec must be less than --stop-sec");
+    }
+
+    let elf_data = std::fs::read(&args.elf).context("failed to read ELF file")?;
+    let elf_obj = object::File::parse(&*elf_data)
+        .map_err(|err| anyhow::anyhow!("failed to parse ELF: {err}"))?;
+    let loader = addr2line::Loader::new(&args.elf)
+        .map_err(|err| anyhow::anyhow!("failed to create addr2line loader: {err}"))?;
+    let focus = args
+        .focus
+        .as_deref()
+        .map(Regex::new)
+        .transpose()
+        .context("invalid --focus regex")?;
 
     let mut output =
-        BufWriter::new(File::create(&cli.output).context("Failed to create output file")?);
+        BufWriter::new(File::create(&args.output).context("failed to create output file")?);
     let mut symbol_cache = HashMap::<u64, Vec<String>>::new();
-    let mut decoded = 0u64;
-    let mut bad_records = 0u64;
+    let mut hotspots: HashMap<String, u64> = HashMap::new();
+    let mut stats = ResolveStats {
+        start_sec: args.start_sec,
+        stop_sec: args.stop_sec,
+        ..ResolveStats::default()
+    };
+    let records = read_qperf_records(&args.input, &mut stats)?;
 
+    for record in records {
+        stats.raw_records += 1;
+        stats.total_frames += record.trace.len() as u64;
+        if let Some(elapsed_ns) = record.elapsed_ns {
+            let elapsed_sec = elapsed_ns as f64 / 1_000_000_000.0;
+            stats.first_sample_sec = Some(
+                stats
+                    .first_sample_sec
+                    .map_or(elapsed_sec, |current| current.min(elapsed_sec)),
+            );
+            stats.last_sample_sec = Some(
+                stats
+                    .last_sample_sec
+                    .map_or(elapsed_sec, |current| current.max(elapsed_sec)),
+            );
+            if args.start_sec.is_some_and(|start| elapsed_sec < start) {
+                stats.samples_excluded_before += 1;
+                continue;
+            }
+            if args.stop_sec.is_some_and(|stop| elapsed_sec >= stop) {
+                stats.samples_excluded_after += 1;
+                continue;
+            }
+        } else if args.start_sec.is_some() || args.stop_sec.is_some() {
+            stats.warning =
+                Some("input has no timestamps; elapsed-time filtering was not applied".to_string());
+        }
+        stats.selected_records += 1;
+        let raw_depth = record.trace.len().max(1);
+        *stats.depth_histogram.entry(raw_depth).or_insert(0) += 1;
+        stats.max_depth = stats.max_depth.max(raw_depth);
+        if raw_depth > 1 {
+            stats.selected_multi_frame_records += 1;
+        } else {
+            stats.selected_leaf_records += 1;
+        }
+        if record.pc.is_some_and(|pc| pc != 0) {
+            stats.samples_with_pc += 1;
+        }
+        if record.sp.is_some_and(|sp| sp != 0) {
+            stats.samples_with_sp += 1;
+        }
+        if record.fp.is_some_and(|fp| fp != 0) {
+            stats.samples_with_fp += 1;
+        }
+        if record.cpu.is_some() {
+            stats.samples_with_cpu += 1;
+        }
+        if let Some(method) = record.callchain.and_then(callchain_method_name) {
+            match stats.callchain_method.as_deref() {
+                None | Some("leaf") => stats.callchain_method = Some(method.to_string()),
+                Some(current) if current == method => {}
+                Some(_) => stats.callchain_method = Some("mixed".to_string()),
+            }
+        }
+        let mut result = vec![];
+        for (idx, ip) in record.trace.into_iter().enumerate() {
+            if ip == 0 || ip == u64::MAX {
+                continue;
+            }
+            let lookup_ip = if idx == 0 { ip } else { ip - 1 };
+            let symbols = symbol_cache.entry(lookup_ip).or_insert_with(|| {
+                resolve_symbols(
+                    &loader,
+                    &elf_obj,
+                    lookup_ip,
+                    !args.no_demangle,
+                    args.symbol_style,
+                )
+            });
+            result.extend(symbols.iter().cloned());
+        }
+        if result.is_empty() {
+            stats.bad_records += 1;
+            result.push("??".into());
+        }
+        if focus
+            .as_ref()
+            .is_some_and(|focus| !result.iter().any(|frame| focus.is_match(frame)))
+        {
+            continue;
+        }
+        stats.selected_frames += result.len() as u64;
+
+        for func in &result {
+            *hotspots.entry(func.clone()).or_insert(0) += 1;
+        }
+
+        result.reverse();
+        writeln!(output, "{} 1", result.join(";")).context("failed to write folded output")?;
+    }
+    output.flush().context("failed to flush folded output")?;
+
+    let total = hotspots.values().sum();
+    print_hotspots(&hotspots, total, args.top);
+    if let Some(stats_path) = args.stats {
+        write_resolve_stats(&stats_path, &stats)?;
+    }
+    if let Some(depth_summary_path) = args.depth_summary {
+        write_depth_summary(&depth_summary_path, &stats.depth_histogram)?;
+    }
+
+    if let Some(svg_path) = args.flamegraph
+        && file_nonempty(&args.output)
+    {
+        generate_flamegraph(&args.output, &svg_path, args.min_percent)?;
+    }
+
+    Ok(())
+}
+
+fn file_nonempty(path: &Path) -> bool {
+    path.metadata().is_ok_and(|metadata| metadata.len() > 0)
+}
+
+fn read_qperf_records(path: &Path, stats: &mut ResolveStats) -> anyhow::Result<Vec<DecodedRecord>> {
+    match read_qperf_records_v3(path) {
+        Ok(records) => {
+            stats.format_version = 3;
+            Ok(records)
+        }
+        Err(v3_err) => match read_qperf_records_v2(path) {
+            Ok(records) => {
+                stats.format_version = 2;
+                Ok(records)
+            }
+            Err(v2_err) => match read_qperf_records_v1(path) {
+                Ok(records) => {
+                    stats.format_version = 1;
+                    Ok(records)
+                }
+                Err(v1_err) => Err(v3_err).with_context(|| {
+                    format!(
+                        "failed to decode qperf input as v3 records; v2 fallback also failed: \
+                         {v2_err}; v1 fallback also failed: {v1_err}"
+                    )
+                }),
+            },
+        },
+    }
+}
+
+fn read_qperf_records_v3(path: &Path) -> anyhow::Result<Vec<DecodedRecord>> {
+    let mut input = BufReader::new(File::open(path).context("failed to open input file")?);
+    let mut records = Vec::new();
+    loop {
+        match bincode::decode_from_std_read(&mut input, bincode::config::standard()) {
+            Ok(SampleRecord {
+                elapsed_ns,
+                pc,
+                sp,
+                fp,
+                cpu,
+                callchain,
+                trace,
+            }) => records.push(DecodedRecord {
+                elapsed_ns: Some(elapsed_ns),
+                pc: Some(pc),
+                sp: (sp != 0).then_some(sp),
+                fp: (fp != 0).then_some(fp),
+                cpu: Some(cpu),
+                callchain: Some(callchain),
+                trace,
+            }),
+            Err(err) => {
+                if records.is_empty() {
+                    return Err(err).context("failed to decode first qperf v3 record");
+                }
+                eprintln!(
+                    "qperf-analyzer: stopped after {} v3 records: {err}",
+                    records.len()
+                );
+                break;
+            }
+        }
+    }
+    Ok(records)
+}
+
+fn read_qperf_records_v2(path: &Path) -> anyhow::Result<Vec<DecodedRecord>> {
+    let mut input = BufReader::new(File::open(path).context("failed to open input file")?);
+    let mut records = Vec::new();
+    loop {
+        match bincode::decode_from_std_read(&mut input, bincode::config::standard()) {
+            Ok(SampleRecordV2 { elapsed_ns, trace }) => records.push(DecodedRecord {
+                elapsed_ns: Some(elapsed_ns),
+                pc: trace.first().copied(),
+                sp: None,
+                fp: None,
+                cpu: None,
+                callchain: None,
+                trace,
+            }),
+            Err(err) => {
+                if records.is_empty() {
+                    return Err(err).context("failed to decode first qperf v2 record");
+                }
+                eprintln!(
+                    "qperf-analyzer: stopped after {} v2 records: {err}",
+                    records.len()
+                );
+                break;
+            }
+        }
+    }
+    Ok(records)
+}
+
+fn read_qperf_records_v1(path: &Path) -> anyhow::Result<Vec<DecodedRecord>> {
+    let mut input = BufReader::new(File::open(path).context("failed to open input file")?);
+    let mut records = Vec::new();
     loop {
         let trace: Vec<u64> =
             match bincode::decode_from_std_read(&mut input, bincode::config::standard()) {
                 Ok(trace) => trace,
                 Err(err) => {
-                    if decoded == 0 {
-                        return Err(err).context("Failed to decode first qperf record");
+                    if records.is_empty() {
+                        return Err(err).context("failed to decode first qperf v1 record");
                     }
                     eprintln!(
-                        "qperf-analyzer: stopped after {decoded} records ({bad_records} bad \
-                         records): {err}"
+                        "qperf-analyzer: stopped after {} v1 records: {err}",
+                        records.len()
                     );
                     break;
                 }
             };
-        decoded += 1;
-        let mut result = vec![];
-        for (i, ip) in trace.into_iter().enumerate() {
-            if ip == 0 || ip == u64::MAX {
-                continue;
-            }
-            let lookup_ip = if i == 0 { ip } else { ip - 1 };
-            let symbols = symbol_cache
-                .entry(lookup_ip)
-                .or_insert_with(|| resolve_symbols(&loader, lookup_ip));
-            result.extend(symbols.iter().cloned());
-        }
-        if result.is_empty() {
-            bad_records += 1;
-            result.push("??".into());
-        }
-
-        result.reverse();
-        writeln!(output, "{} 1", result.join(";")).context("Failed to write to output file")?;
+        records.push(DecodedRecord {
+            elapsed_ns: None,
+            pc: trace.first().copied(),
+            sp: None,
+            fp: None,
+            cpu: None,
+            callchain: None,
+            trace,
+        });
     }
-    output.flush().context("Failed to flush output file")?;
+    Ok(records)
+}
+
+fn callchain_method_name(value: u8) -> Option<&'static str> {
+    match value {
+        0 => Some("leaf"),
+        1 => Some("fp"),
+        _ => None,
+    }
+}
+
+fn write_resolve_stats(path: &Path, stats: &ResolveStats) -> anyhow::Result<()> {
+    let mut output = BufWriter::new(
+        File::create(path).with_context(|| format!("failed to create {}", path.display()))?,
+    );
+    writeln!(output, "{{")?;
+    writeln!(output, "  \"format_version\": {},", stats.format_version)?;
+    writeln!(output, "  \"raw_records\": {},", stats.raw_records)?;
+    writeln!(
+        output,
+        "  \"selected_records\": {},",
+        stats.selected_records
+    )?;
+    writeln!(output, "  \"bad_records\": {},", stats.bad_records)?;
+    writeln!(output, "  \"total_frames\": {},", stats.total_frames)?;
+    writeln!(output, "  \"selected_frames\": {},", stats.selected_frames)?;
+    writeln!(
+        output,
+        "  \"selected_leaf_records\": {},",
+        stats.selected_leaf_records
+    )?;
+    writeln!(
+        output,
+        "  \"selected_multi_frame_records\": {},",
+        stats.selected_multi_frame_records
+    )?;
+    writeln!(output, "  \"samples_with_pc\": {},", stats.samples_with_pc)?;
+    writeln!(output, "  \"samples_with_sp\": {},", stats.samples_with_sp)?;
+    writeln!(output, "  \"samples_with_fp\": {},", stats.samples_with_fp)?;
+    writeln!(
+        output,
+        "  \"samples_with_cpu\": {},",
+        stats.samples_with_cpu
+    )?;
+    writeln!(output, "  \"max_depth\": {},", stats.max_depth)?;
+    let avg_depth = if stats.selected_records > 0 {
+        stats.selected_frames as f64 / stats.selected_records as f64
+    } else {
+        0.0
+    };
+    writeln!(output, "  \"avg_depth\": {avg_depth:.9},")?;
+    let callchain_enabled = stats
+        .callchain_method
+        .as_deref()
+        .is_some_and(|method| method != "leaf");
+    let unwind_failed = if callchain_enabled {
+        stats
+            .selected_records
+            .saturating_sub(stats.selected_multi_frame_records)
+    } else {
+        0
+    };
+    writeln!(output, "  \"callchain\": {{")?;
+    writeln!(output, "    \"enabled\": {},", callchain_enabled)?;
+    writeln!(
+        output,
+        "    \"method\": {},",
+        json_optional_string(stats.callchain_method.as_deref())
+    )?;
+    writeln!(
+        output,
+        "    \"samples_with_fp\": {},",
+        stats.samples_with_fp
+    )?;
+    writeln!(
+        output,
+        "    \"unwind_success\": {},",
+        stats.selected_multi_frame_records
+    )?;
+    writeln!(output, "    \"unwind_failed\": {},", unwind_failed)?;
+    writeln!(output, "    \"avg_depth\": {avg_depth:.9},")?;
+    writeln!(output, "    \"max_depth\": {}", stats.max_depth)?;
+    writeln!(output, "  }},")?;
+    writeln!(
+        output,
+        "  \"samples_excluded_before\": {},",
+        stats.samples_excluded_before
+    )?;
+    writeln!(
+        output,
+        "  \"samples_excluded_after\": {},",
+        stats.samples_excluded_after
+    )?;
+    writeln!(
+        output,
+        "  \"first_sample_sec\": {},",
+        json_optional_f64(stats.first_sample_sec)
+    )?;
+    writeln!(
+        output,
+        "  \"last_sample_sec\": {},",
+        json_optional_f64(stats.last_sample_sec)
+    )?;
+    writeln!(
+        output,
+        "  \"start_sec\": {},",
+        json_optional_f64(stats.start_sec)
+    )?;
+    writeln!(
+        output,
+        "  \"stop_sec\": {},",
+        json_optional_f64(stats.stop_sec)
+    )?;
+    writeln!(
+        output,
+        "  \"warning\": {}",
+        json_optional_string(stats.warning.as_deref())
+    )?;
+    writeln!(output, "}}")?;
     Ok(())
 }
 
-fn resolve_symbols(loader: &addr2line::Loader, ip: u64) -> Vec<String> {
+fn write_depth_summary(path: &Path, histogram: &BTreeMap<usize, u64>) -> anyhow::Result<()> {
+    let mut output = BufWriter::new(
+        File::create(path).with_context(|| format!("failed to create {}", path.display()))?,
+    );
+    writeln!(output, "depth,samples")?;
+    for (depth, samples) in histogram {
+        writeln!(output, "{depth},{samples}")?;
+    }
+    Ok(())
+}
+
+fn json_optional_f64(value: Option<f64>) -> String {
+    value
+        .filter(|value| value.is_finite())
+        .map(|value| format!("{value:.9}"))
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn json_optional_string(value: Option<&str>) -> String {
+    value
+        .map(|value| format!("{:?}", value))
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn cmd_diff(args: DiffArgs) -> anyhow::Result<()> {
+    let baseline = parse_folded(&args.baseline)?;
+    let compare = parse_folded(&args.compare)?;
+    let all_keys: BTreeSet<&String> = baseline.keys().chain(compare.keys()).collect();
+    let baseline_total = baseline.values().sum::<u64>() as f64;
+    let compare_total = compare.values().sum::<u64>() as f64;
+    let mut diffs: Vec<(&String, f64, f64)> = Vec::new();
+
+    let diff_folded = args
+        .flamegraph
+        .as_ref()
+        .map(|svg| svg.with_extension("folded"));
+    let mut diff_output = diff_folded
+        .as_ref()
+        .map(File::create)
+        .transpose()
+        .context("failed to create diff folded output")?
+        .map(BufWriter::new);
+
+    for key in &all_keys {
+        let baseline_count = baseline.get(*key).copied().unwrap_or(0) as f64;
+        let compare_count = compare.get(*key).copied().unwrap_or(0) as f64;
+        let baseline_pct = percent(baseline_count, baseline_total);
+        let compare_pct = percent(compare_count, compare_total);
+        if baseline_count != compare_count {
+            diffs.push((key, baseline_pct, compare_pct));
+        }
+        if let Some(output) = diff_output.as_mut() {
+            writeln!(output, "{} {}", key, compare_count as u64)?;
+        }
+    }
+
+    diffs.sort_by(|a, b| {
+        let left = (a.2 - a.1).abs();
+        let right = (b.2 - b.1).abs();
+        right
+            .partial_cmp(&left)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let top = args.top.min(diffs.len());
+    if top > 0 {
+        eprintln!("\nTop {top} changed functions:");
+        eprintln!(
+            "{:<60} {:>10} {:>10} {:>10}",
+            "Function", "Base%", "Comp%", "Delta%"
+        );
+        eprintln!("{}", "-".repeat(95));
+        for (func, baseline_pct, compare_pct) in diffs.iter().take(top) {
+            let delta = compare_pct - baseline_pct;
+            eprintln!(
+                "{:<60} {:>9.2}% {:>9.2}% {:>+9.2}%",
+                truncate_str(func, 60),
+                baseline_pct,
+                compare_pct,
+                delta
+            );
+        }
+    }
+
+    if let (Some(folded), Some(svg)) = (diff_folded, args.flamegraph) {
+        if let Some(mut output) = diff_output {
+            output.flush().ok();
+        }
+        generate_flamegraph(&folded, &svg, 0.3)?;
+    }
+
+    Ok(())
+}
+
+fn parse_folded(path: &Path) -> anyhow::Result<HashMap<String, u64>> {
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut map = HashMap::new();
+    for line in BufReader::new(file).lines() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Some(pos) = line.rfind(' ') else {
+            continue;
+        };
+        let stack = &line[..pos];
+        let count = line[pos + 1..].parse().unwrap_or(1);
+        *map.entry(stack.to_string()).or_insert(0) += count;
+    }
+    Ok(map)
+}
+
+fn print_hotspots(hotspots: &HashMap<String, u64>, total: u64, top_n: usize) {
+    if top_n == 0 || total == 0 {
+        return;
+    }
+    let mut entries: Vec<_> = hotspots.iter().collect();
+    entries.sort_by(|a, b| b.1.cmp(a.1));
+
+    let top = top_n.min(entries.len());
+    eprintln!("\nTop {top} hottest functions (total samples: {total}):");
+    eprintln!("{:<60} {:>10} {:>10}", "Function", "Samples", "Percent");
+    eprintln!("{}", "-".repeat(82));
+    for (func, count) in entries.iter().take(top) {
+        let pct = **count as f64 / total as f64 * 100.0;
+        eprintln!("{:<60} {:>10} {:>9.2}%", truncate_str(func, 60), count, pct);
+    }
+}
+
+fn resolve_symbols(
+    loader: &addr2line::Loader,
+    elf_obj: &object::File<'_>,
+    ip: u64,
+    demangle: bool,
+    style: SymbolStyle,
+) -> Vec<String> {
     let mut result = Vec::new();
     let Ok(mut frames) = loader.find_frames(ip) else {
-        return vec![format!("0x{ip:x}")];
+        return symtab_fallback(elf_obj, ip, demangle, style);
     };
     while let Ok(Some(frame)) = frames.next() {
-        let func = frame
-            .function
-            .as_ref()
-            .and_then(|f| f.demangle().ok())
-            .unwrap_or("??".into())
-            .into_owned();
-        result.push(func);
+        let func = if demangle {
+            frame
+                .function
+                .as_ref()
+                .and_then(|func| func.demangle().ok())
+                .map(|name| name.into_owned())
+        } else {
+            frame
+                .function
+                .as_ref()
+                .and_then(|func| func.raw_name().ok())
+                .map(|name| name.into_owned())
+        }
+        .unwrap_or_else(|| "??".to_string());
+        result.push(format_symbol_style(&func, style));
     }
     if result.is_empty() {
-        result.push(format!("0x{ip:x}"));
+        symtab_fallback(elf_obj, ip, demangle, style)
+    } else {
+        result
     }
-    result
+}
+
+fn symtab_fallback(
+    elf_obj: &object::File<'_>,
+    ip: u64,
+    demangle: bool,
+    style: SymbolStyle,
+) -> Vec<String> {
+    let nearest = elf_obj
+        .symbols()
+        .filter_map(|symbol| {
+            if !symbol.is_definition() || symbol.kind() != object::SymbolKind::Text {
+                return None;
+            }
+            let addr = symbol.address();
+            if ip < addr {
+                return None;
+            }
+            let name = symbol.name().ok()?;
+            if should_skip_symbol_name(name) {
+                return None;
+            }
+            let offset = ip - addr;
+            Some((offset, format_symbol_name(name, offset, demangle, style)))
+        })
+        .min_by_key(|(offset, _)| *offset);
+
+    nearest
+        .map(|(_, name)| vec![name])
+        .unwrap_or_else(|| vec![format!("0x{ip:x}")])
+}
+
+fn should_skip_symbol_name(name: &str) -> bool {
+    name.starts_with(".L") || name == "$x"
+}
+
+fn demangle_symbol(name: &str, demangle: bool) -> String {
+    if demangle {
+        rustc_demangle::try_demangle(name)
+            .map(|name| name.to_string())
+            .unwrap_or_else(|_| name.to_string())
+    } else {
+        name.to_string()
+    }
+}
+
+fn format_symbol_style(name: &str, style: SymbolStyle) -> String {
+    match style {
+        SymbolStyle::Full => name.to_string(),
+        SymbolStyle::Short => name.rsplit("::").next().unwrap_or(name).to_string(),
+        SymbolStyle::Module => {
+            let mut parts: Vec<_> = name.split("::").collect();
+            if parts.len() <= 4 {
+                return name.to_string();
+            }
+            let tail = parts.split_off(parts.len() - 3);
+            format!("{}::{}", parts[0], tail.join("::"))
+        }
+    }
+}
+
+fn format_symbol_name(name: &str, offset: u64, demangle: bool, style: SymbolStyle) -> String {
+    let name = format_symbol_style(&demangle_symbol(name, demangle), style);
+    if offset == 0 {
+        name
+    } else {
+        format!("{name}+0x{offset:x}")
+    }
+}
+
+fn generate_flamegraph(
+    folded_path: &Path,
+    svg_path: &Path,
+    min_percent: f64,
+) -> anyhow::Result<()> {
+    #[cfg(feature = "flamegraph")]
+    {
+        let input = File::open(folded_path)
+            .with_context(|| format!("failed to open {}", folded_path.display()))?;
+        let output = File::create(svg_path)
+            .with_context(|| format!("failed to create {}", svg_path.display()))?;
+        let mut opts = inferno::flamegraph::Options::default();
+        opts.count_name = "samples".to_string();
+        opts.title = "StarryOS qperf Flame Graph".to_string();
+        opts.image_width = Some(3200);
+        opts.frame_height = 24;
+        opts.font_size = 13;
+        opts.min_width = min_percent.max(0.0);
+        opts.hash = true;
+        opts.deterministic = true;
+        inferno::flamegraph::from_reader(&mut opts, input, output)
+            .context("failed to generate flamegraph")?;
+        eprintln!("flamegraph written to {}", svg_path.display());
+        Ok(())
+    }
+    #[cfg(not(feature = "flamegraph"))]
+    {
+        eprintln!(
+            "flamegraph generation requires the qperf-analyzer flamegraph feature; use an \
+             external generator, for example: inferno-flamegraph < {} > {}",
+            folded_path.display(),
+            svg_path.display()
+        );
+        let _ = min_percent;
+        Ok(())
+    }
+}
+
+fn percent(value: f64, total: f64) -> f64 {
+    if total > 0.0 {
+        value / total * 100.0
+    } else {
+        0.0
+    }
+}
+
+fn truncate_str(value: &str, max_len: usize) -> &str {
+    if value.len() <= max_len {
+        value
+    } else {
+        &value[value.len() - max_len..]
+    }
 }

--- a/tools/qperf/examples/long_chain_flamegraph_demo.py
+++ b/tools/qperf/examples/long_chain_flamegraph_demo.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Generate a synthetic long-call-chain flamegraph demo.
+
+This script is intentionally synthetic: it demonstrates the SVG renderer's
+vertical expansion when folded stacks contain deep call chains. It is not a
+qperf measurement and should not be used for performance conclusions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+BASE_STACKS: list[tuple[list[str], int]] = [
+    (
+        [
+            "os::syscall::task::sys_execve",
+            "os::task::spawn_user_task",
+            "os::task::Task::exec",
+            "os::mm::memory_set::MemorySet::from_elf",
+            "os::mm::memory_set::MemorySet::map_area",
+            "alloc::sync::Arc<T,A>::drop_slow",
+            "core::ptr::drop_in_place<os::mm::memory_set::MemorySet>",
+            "core::ptr::drop_in_place<alloc::sync::Arc<spin::rw_lock::RwLock<os::mm::memory_set::MemorySet>>>",
+            "alloc::collections::btree::map::BTreeMap<K,V,A>::drop",
+            "alloc::collections::btree::node::NodeRef::drop",
+            "alloc::collections::btree::node::Handle::drop",
+            "core::ptr::drop_in_place<alloc::collections::btree::node::Handle<alloc::alloc::Global>>",
+            "core::mem::drop",
+            "os::mm::area::MapArea::drop",
+            "os::mm::page::Page::drop",
+            "ax_alloc::buddy_slab::GlobalAllocator::dealloc",
+        ],
+        5000,
+    ),
+    (
+        [
+            "os::syscall::fs::sys_read",
+            "starry_process::fd_manager::FileLike::read",
+            "ax_fs_ng::fs::ext4::Ext4File::read_at",
+            "rsext4::file::File::read_at",
+            "rsext4::cache::data_block::DataBlockCache::get",
+            "rsext4::cache::data_block::DataBlockCache::evict_lru",
+            "alloc::collections::btree::map::BTreeMap<K,V,A>::get",
+            "alloc::collections::btree::search::search_tree",
+            "rd_block::BlockDevice::read_blocks",
+            "ax_driver::virtio::block::VirtIoBlkDev::read_block",
+            "virtio_drivers::device::blk::VirtIOBlk::read_blocks",
+            "virtio_drivers::queue::VirtQueue::add_notify_wait_pop",
+            "virtio_drivers::queue::VirtQueue::add",
+            "virtio_drivers::transport::pci::PciTransport::notify",
+            "virtio_drivers::queue::VirtQueue::pop_used",
+        ],
+        3600,
+    ),
+    (
+        [
+            "os::syscall::net::sys_recvfrom",
+            "ax_net_ng::tcp::Socket::recv",
+            "smoltcp::socket::tcp::Socket::recv_slice",
+            "rd_net::VirtioNetDriver::receive",
+            "ax_driver::virtio::net::VirtIoNetDev::receive",
+            "virtio_drivers::device::net::VirtIONetRaw::receive",
+            "virtio_drivers::queue::VirtQueue::pop_used",
+            "ax_driver::virtio::net::RxBuffer::copy_within",
+            "compiler_builtins::mem::memmove",
+            "compiler_builtins::mem::memcpy",
+        ],
+        2600,
+    ),
+    (
+        [
+            "os::syscall::task::sys_waitpid",
+            "starry_process::thread::Thread::wait",
+            "ax_task::wait_queue::WaitQueue::wait_until",
+            "ax_task::run_queue::AxRunQueue::block_current",
+            "ax_task::run_queue::AxRunQueue::resched",
+            "ax_task::run_queue::AxRunQueue::switch_to",
+            "riscv::register::sstatus::set_spie",
+            "ax_hal::arch::context::TaskContext::switch",
+        ],
+        1800,
+    ),
+]
+
+
+def variant_stack(base: list[str], index: int) -> list[str]:
+    stack = list(base)
+    if "BTreeMap<K,V,A>::drop" in stack[-8]:
+        stack.insert(-4, f"alloc::collections::btree::node::drop_child::{index % 17}")
+    if index % 5 == 0:
+        stack.append("core::ptr::drop_in_place<alloc::boxed::Box<[u8]>>")
+    if index % 7 == 0:
+        stack.append("compiler_builtins::mem::memset")
+    if index % 11 == 0:
+        stack.insert(1, "os::task::current")
+    return stack
+
+
+def write_folded(path: Path, variants: int) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    max_depth = 0
+    total_samples = 0
+    with path.open("w", encoding="utf-8") as output:
+        for base, count in BASE_STACKS:
+            for index in range(variants):
+                stack = variant_stack(base, index)
+                sample_count = max(1, count // variants + (index % 13))
+                output.write(f"{';'.join(stack)} {sample_count}\n")
+                max_depth = max(max_depth, len(stack))
+                total_samples += sample_count
+    return max_depth, total_samples
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", default="target/qperf-long-chain-demo")
+    parser.add_argument("--variants", type=int, default=80)
+    parser.add_argument("--no-svg", action="store_true")
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    folded = out_dir / "stack.folded"
+    svg = out_dir / "flamegraph.svg"
+    max_depth, total_samples = write_folded(folded, args.variants)
+
+    if not args.no_svg:
+        subprocess.run(
+            [
+                "cargo",
+                "run",
+                "--manifest-path",
+                "tools/qperf/analyzer/Cargo.toml",
+                "--features",
+                "flamegraph",
+                "--",
+                "diff",
+                "--baseline",
+                str(folded),
+                "--compare",
+                str(folded),
+                "--top",
+                "0",
+                "--flamegraph",
+                str(svg),
+            ],
+            check=True,
+        )
+
+    print(f"folded: {folded}")
+    print(f"flamegraph: {svg}")
+    print(f"synthetic: true")
+    print(f"max_depth: {max_depth}")
+    print(f"total_samples: {total_samples}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/qperf/src/profiler.rs
+++ b/tools/qperf/src/profiler.rs
@@ -5,23 +5,94 @@ use std::{
     path::PathBuf,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     thread::spawn,
     time::{Duration, Instant},
 };
 
 use anyhow::{Context, bail};
-use crossbeam_channel::{Sender, TrySendError, bounded};
+use crossbeam_channel::{RecvTimeoutError, Sender, TrySendError, bounded};
 use qemu_plugin::{
     CallbackFlags, PluginId, TranslationBlock, VCPUIndex,
     install::{Args, Info, Value},
     plugin::{HasCallbacks, Register},
-    qemu_plugin_get_registers, qemu_plugin_read_memory_vaddr,
+    qemu_plugin_get_registers, qemu_plugin_read_memory_vaddr, qemu_plugin_register_atexit_cb,
 };
 use zerocopy::IntoBytes;
 
 use crate::reg::{AllRegs, Frame, Reg, Target};
+
+const MAX_FRAME_POINTER_DISTANCE: u64 = 16 * 1024 * 1024;
+
+#[derive(bincode::Encode)]
+struct SampleRecord {
+    elapsed_ns: u64,
+    pc: u64,
+    sp: u64,
+    fp: u64,
+    cpu: u32,
+    callchain: u8,
+    trace: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SamplingMode {
+    Tb,
+    Insn,
+}
+
+impl core::str::FromStr for SamplingMode {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "tb" => Ok(Self::Tb),
+            "insn" => Ok(Self::Insn),
+            _ => bail!("invalid sampling mode: {value}; expected 'tb' or 'insn'"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CallchainMode {
+    Leaf,
+    Fp,
+}
+
+impl CallchainMode {
+    fn as_raw(self) -> u8 {
+        match self {
+            Self::Leaf => 0,
+            Self::Fp => 1,
+        }
+    }
+
+    fn needs_registers(self) -> bool {
+        matches!(self, Self::Fp)
+    }
+}
+
+impl core::fmt::Display for CallchainMode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Leaf => "leaf",
+            Self::Fp => "fp",
+        })
+    }
+}
+
+impl core::str::FromStr for CallchainMode {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "leaf" => Ok(Self::Leaf),
+            "fp" | "frame-pointer" | "frame_pointer" => Ok(Self::Fp),
+            _ => bail!("invalid callchain mode: {value}; expected 'leaf' or 'fp'"),
+        }
+    }
+}
 
 #[derive(Debug)]
 struct PluginArgs {
@@ -29,6 +100,14 @@ struct PluginArgs {
     out: PathBuf,
     max_depth: usize,
     queue_size: usize,
+    mode: SamplingMode,
+    filter_start: Option<u64>,
+    filter_end: Option<u64>,
+    filter_alias_start: Option<u64>,
+    filter_alias_end: Option<u64>,
+    filter_alias_offset: Option<u64>,
+    filter_kernel: bool,
+    callchain: CallchainMode,
 }
 
 impl TryFrom<&Args> for PluginArgs {
@@ -63,17 +142,80 @@ impl TryFrom<&Args> for PluginArgs {
             .unwrap_or("qperf.bin".into());
         let max_depth = parse_usize_arg(args, "max_depth")?.unwrap_or(128);
         let queue_size = parse_usize_arg(args, "queue_size")?.unwrap_or(4096);
+        let mode = args
+            .parsed
+            .get("mode")
+            .map(|value| {
+                if let Value::String(value) = value {
+                    value.parse()
+                } else {
+                    bail!("invalid mode")
+                }
+            })
+            .transpose()?
+            .unwrap_or(SamplingMode::Tb);
+        let filter_start = parse_u64_hex_arg(args, "filter_start")?;
+        let filter_end = parse_u64_hex_arg(args, "filter_end")?;
+        let filter_alias_start = parse_u64_hex_arg(args, "filter_alias_start")?;
+        let filter_alias_end = parse_u64_hex_arg(args, "filter_alias_end")?;
+        let filter_alias_offset = parse_u64_hex_arg(args, "filter_alias_offset")?;
+        let filter_kernel = parse_bool_arg(args, "filter_kernel")?
+            .unwrap_or(filter_start.is_some() || filter_alias_start.is_some());
+        let callchain = args
+            .parsed
+            .get("callchain")
+            .map(|value| {
+                if let Value::String(value) = value {
+                    value.parse()
+                } else {
+                    bail!("invalid callchain")
+                }
+            })
+            .transpose()?
+            .unwrap_or(CallchainMode::Leaf);
         if max_depth == 0 {
             bail!("max_depth must be greater than 0");
         }
         if queue_size == 0 {
             bail!("queue_size must be greater than 0");
         }
+        if filter_start.is_some() != filter_end.is_some() {
+            bail!("filter_start and filter_end must be provided together");
+        }
+        if matches!((filter_start, filter_end), (Some(start), Some(end)) if start >= end) {
+            bail!("filter_start must be less than filter_end");
+        }
+        let alias_count = [
+            filter_alias_start.is_some(),
+            filter_alias_end.is_some(),
+            filter_alias_offset.is_some(),
+        ]
+        .into_iter()
+        .filter(|present| *present)
+        .count();
+        if alias_count != 0 && alias_count != 3 {
+            bail!(
+                "filter_alias_start, filter_alias_end, and filter_alias_offset must be provided \
+                 together"
+            );
+        }
+        if matches!((filter_alias_start, filter_alias_end), (Some(start), Some(end)) if start >= end)
+        {
+            bail!("filter_alias_start must be less than filter_alias_end");
+        }
         Ok(PluginArgs {
             freq,
             out,
             max_depth,
             queue_size,
+            mode,
+            filter_start,
+            filter_end,
+            filter_alias_start,
+            filter_alias_end,
+            filter_alias_offset,
+            filter_kernel,
+            callchain,
         })
     }
 }
@@ -93,21 +235,101 @@ fn parse_usize_arg(args: &Args, name: &str) -> anyhow::Result<Option<usize>> {
         .transpose()
 }
 
+fn parse_u64_hex_arg(args: &Args, name: &str) -> anyhow::Result<Option<u64>> {
+    args.parsed
+        .get(name)
+        .map(|value| {
+            if let Value::String(value) = value {
+                u64::from_str_radix(value.trim_start_matches("0x").trim_start_matches("0X"), 16)
+                    .with_context(|| format!("invalid {name}: expected hex address"))
+            } else {
+                bail!("invalid {name}: expected hex string")
+            }
+        })
+        .transpose()
+}
+
+fn parse_bool_arg(args: &Args, name: &str) -> anyhow::Result<Option<bool>> {
+    args.parsed
+        .get(name)
+        .map(|value| match value {
+            Value::Integer(value) => Ok(*value != 0),
+            Value::String(value) => match value.to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => Ok(true),
+                "0" | "false" | "no" | "off" => Ok(false),
+                _ => bail!("invalid {name}: expected boolean"),
+            },
+            _ => bail!("invalid {name}: expected boolean"),
+        })
+        .transpose()
+}
+
+fn callback_flags(callchain: CallchainMode) -> CallbackFlags {
+    if callchain.needs_registers() {
+        CallbackFlags::QEMU_PLUGIN_CB_R_REGS
+    } else {
+        CallbackFlags::QEMU_PLUGIN_CB_NO_REGS
+    }
+}
+
+fn update_max_atomic(value: &AtomicU64, candidate: u64) {
+    let mut current = value.load(Ordering::Relaxed);
+    while candidate > current {
+        match value.compare_exchange_weak(current, candidate, Ordering::Relaxed, Ordering::Relaxed)
+        {
+            Ok(_) => break,
+            Err(next) => current = next,
+        }
+    }
+}
+
 #[derive(Default)]
 struct Stats {
     samples: AtomicU64,
     dropped_samples: AtomicU64,
     sample_failures: AtomicU64,
+    samples_with_sp: AtomicU64,
+    samples_with_fp: AtomicU64,
+    unwind_success: AtomicU64,
+    unwind_failed_no_fp: AtomicU64,
+    unwind_failed_stack_read: AtomicU64,
+    unwind_failed_return_ip_unread: AtomicU64,
+    unwind_failed_non_monotonic_fp: AtomicU64,
+    unwind_failed_loop: AtomicU64,
+    total_frames: AtomicU64,
+    max_observed_depth: AtomicU64,
+    translated_blocks: AtomicU64,
+    translated_instructions: AtomicU64,
+    executed_blocks: AtomicU64,
+    executed_instructions: AtomicU64,
+    execute_callbacks: AtomicU64,
+}
+
+#[derive(Default)]
+struct SelectedRegs {
+    sp: Option<String>,
+    fp: Option<String>,
+    available: Vec<String>,
 }
 
 #[derive(Clone)]
 pub struct Profiler {
     target: Target,
-    tx: Sender<Vec<u64>>,
+    tx: Sender<SampleRecord>,
     intvl: Duration,
     max_depth: usize,
+    mode: SamplingMode,
+    filter_start: Option<u64>,
+    filter_end: Option<u64>,
+    filter_alias_start: Option<u64>,
+    filter_alias_end: Option<u64>,
+    filter_alias_offset: Option<u64>,
+    filter_kernel: bool,
+    callchain: CallchainMode,
+    started_at: Arc<Instant>,
     last: Arc<Mutex<Instant>>,
     regs: Arc<AllRegs>,
+    selected_regs: Arc<Mutex<SelectedRegs>>,
     stats: Arc<Stats>,
 }
 
@@ -118,51 +340,141 @@ impl Default for Profiler {
             tx: bounded(0).0,
             intvl: Duration::MAX,
             max_depth: 128,
+            mode: SamplingMode::Tb,
+            filter_start: None,
+            filter_end: None,
+            filter_alias_start: None,
+            filter_alias_end: None,
+            filter_alias_offset: None,
+            filter_kernel: false,
+            callchain: CallchainMode::Leaf,
+            started_at: Arc::new(Instant::now()),
             last: Arc::new(Mutex::new(Instant::now())),
             regs: Arc::default(),
+            selected_regs: Arc::default(),
             stats: Arc::default(),
         }
     }
 }
 
 impl Profiler {
-    fn sample(&mut self, ip: u64) -> qemu_plugin::Result<()> {
+    fn sample(&mut self, cpu: VCPUIndex, ip: u64) -> qemu_plugin::Result<()> {
         let now = Instant::now();
-        let Ok(mut last) = self.last.try_lock() else {
-            return Ok(());
-        };
-        if now.duration_since(*last) < self.intvl {
-            return Ok(());
+        {
+            let Ok(mut last) = self.last.try_lock() else {
+                return Ok(());
+            };
+            if now.duration_since(*last) < self.intvl {
+                return Ok(());
+            }
+            *last = now;
         }
-        *last = now;
 
         let mut ips = Vec::with_capacity(self.max_depth.min(16));
         ips.push(ip);
-        let mut fp = self.regs.read(self.target.reg(Reg::Fp))?;
-        let mut seen_fps = BTreeSet::new();
-
-        while fp > 0 && fp % 8 == 0 && ips.len() < self.max_depth {
-            if !seen_fps.insert(fp) {
-                break;
+        let sp = if self.callchain.needs_registers() {
+            self.regs
+                .read_first(self.target.reg_candidates(Reg::Sp))
+                .inspect(|_| {
+                    self.stats.samples_with_sp.fetch_add(1, Ordering::Relaxed);
+                })
+                .map(|(_, value)| value)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        let mut fp_value = 0;
+        if self.callchain == CallchainMode::Fp {
+            if !self.should_unwind_ip(ip) {
+                return self.emit_sample(now, cpu, ip, sp, fp_value, ips);
             }
-            let mut frame = Frame::default();
-            if qemu_plugin_read_memory_vaddr(fp - self.target.fp_offset(), frame.as_mut_bytes())
-                .is_err()
-            {
-                break;
+            let Ok((_, mut fp)) = self.regs.read_first(self.target.reg_candidates(Reg::Fp)) else {
+                self.stats
+                    .unwind_failed_no_fp
+                    .fetch_add(1, Ordering::Relaxed);
+                return self.emit_sample(now, cpu, ip, sp, fp_value, ips);
             };
-            if qemu_plugin_read_memory_vaddr(frame.ip, &mut [0; 8]).is_err() {
-                break;
+            fp_value = fp;
+            self.stats.samples_with_fp.fetch_add(1, Ordering::Relaxed);
+            if !plausible_initial_frame_pointer(sp, fp) {
+                self.stats
+                    .unwind_failed_non_monotonic_fp
+                    .fetch_add(1, Ordering::Relaxed);
+                return self.emit_sample(now, cpu, ip, sp, fp_value, ips);
             }
+            let mut seen_fps = BTreeSet::new();
 
-            ips.push(frame.ip);
-            if frame.fp <= fp {
-                break;
+            while fp >= self.target.fp_offset()
+                && fp.is_multiple_of(8)
+                && ips.len() < self.max_depth
+            {
+                if !seen_fps.insert(fp) {
+                    self.stats
+                        .unwind_failed_loop
+                        .fetch_add(1, Ordering::Relaxed);
+                    break;
+                }
+                let mut frame = Frame::default();
+                if qemu_plugin_read_memory_vaddr(fp - self.target.fp_offset(), frame.as_mut_bytes())
+                    .is_err()
+                {
+                    self.stats
+                        .unwind_failed_stack_read
+                        .fetch_add(1, Ordering::Relaxed);
+                    break;
+                };
+                let Some(frame_ip) = self.canonicalize_unwind_ip(frame.ip) else {
+                    self.stats
+                        .unwind_failed_return_ip_unread
+                        .fetch_add(1, Ordering::Relaxed);
+                    break;
+                };
+
+                ips.push(frame_ip);
+                if !plausible_next_frame_pointer(fp, frame.fp) {
+                    self.stats
+                        .unwind_failed_non_monotonic_fp
+                        .fetch_add(1, Ordering::Relaxed);
+                    break;
+                }
+                fp = frame.fp;
             }
-            fp = frame.fp;
+            if ips.len() > 1 {
+                self.stats.unwind_success.fetch_add(1, Ordering::Relaxed);
+            }
         }
 
-        match self.tx.try_send(ips) {
+        self.emit_sample(now, cpu, ip, sp, fp_value, ips)
+    }
+
+    fn emit_sample(
+        &mut self,
+        now: Instant,
+        cpu: VCPUIndex,
+        ip: u64,
+        sp: u64,
+        fp: u64,
+        ips: Vec<u64>,
+    ) -> qemu_plugin::Result<()> {
+        let depth = ips.len() as u64;
+        self.stats.total_frames.fetch_add(depth, Ordering::Relaxed);
+        update_max_atomic(&self.stats.max_observed_depth, depth);
+
+        let elapsed_ns = now
+            .duration_since(*self.started_at)
+            .as_nanos()
+            .min(u128::from(u64::MAX)) as u64;
+        let record = SampleRecord {
+            elapsed_ns,
+            pc: ip,
+            sp,
+            fp,
+            cpu,
+            callchain: self.callchain.as_raw(),
+            trace: ips,
+        };
+
+        match self.tx.try_send(record) {
             Ok(()) => {
                 self.stats.samples.fetch_add(1, Ordering::Relaxed);
             }
@@ -176,11 +488,86 @@ impl Profiler {
 
         Ok(())
     }
+
+    fn sample_ip_for(&self, ip: u64) -> Option<u64> {
+        if let Some(mapped) = self.canonicalize_ip(ip) {
+            return Some(mapped);
+        }
+        if self.filter_kernel {
+            return None;
+        }
+        Some(ip)
+    }
+
+    fn canonicalize_ip(&self, ip: u64) -> Option<u64> {
+        if let (Some(start), Some(end)) = (self.filter_start, self.filter_end)
+            && ip >= start
+            && ip < end
+        {
+            return Some(ip);
+        }
+        if let (Some(start), Some(end), Some(offset)) = (
+            self.filter_alias_start,
+            self.filter_alias_end,
+            self.filter_alias_offset,
+        ) && ip >= start
+            && ip < end
+        {
+            return Some(ip.wrapping_add(offset));
+        }
+        None
+    }
+
+    fn has_kernel_address_filter(&self) -> bool {
+        self.filter_start.is_some() || self.filter_alias_start.is_some()
+    }
+
+    fn should_unwind_ip(&self, ip: u64) -> bool {
+        !self.has_kernel_address_filter() || self.canonicalize_ip(ip).is_some()
+    }
+
+    fn canonicalize_unwind_ip(&self, ip: u64) -> Option<u64> {
+        if self.has_kernel_address_filter() {
+            self.canonicalize_ip(ip)
+        } else {
+            Some(ip)
+        }
+    }
+}
+
+fn plausible_initial_frame_pointer(sp: u64, fp: u64) -> bool {
+    fp != 0
+        && fp.is_multiple_of(8)
+        && fp > sp
+        && fp.saturating_sub(sp) <= MAX_FRAME_POINTER_DISTANCE
+}
+
+fn plausible_next_frame_pointer(current: u64, next: u64) -> bool {
+    next.is_multiple_of(8)
+        && next > current
+        && next.saturating_sub(current) <= MAX_FRAME_POINTER_DISTANCE
 }
 
 impl HasCallbacks for Profiler {
     fn on_vcpu_init(&mut self, _id: PluginId, _vcpu_id: VCPUIndex) -> qemu_plugin::Result<()> {
-        self.regs = Arc::new(qemu_plugin_get_registers()?.into());
+        let regs = AllRegs::from(qemu_plugin_get_registers()?);
+        let mut available = regs.names();
+        available.sort();
+        let selected = SelectedRegs {
+            sp: regs.find_name(self.target.reg_candidates(Reg::Sp)),
+            fp: regs.find_name(self.target.reg_candidates(Reg::Fp)),
+            available,
+        };
+        eprintln!(
+            "QPerf registers: sp={:?} fp={:?} available={}",
+            selected.sp,
+            selected.fp,
+            selected.available.join(",")
+        );
+        self.regs = Arc::new(regs);
+        if let Ok(mut shared) = self.selected_regs.lock() {
+            *shared = selected;
+        }
         Ok(())
     }
 
@@ -189,22 +576,58 @@ impl HasCallbacks for Profiler {
         _id: PluginId,
         tb: TranslationBlock,
     ) -> qemu_plugin::Result<()> {
-        const KERNEL_MASK: u64 = 1 << 63;
+        let Some(ip) = self.sample_ip_for(tb.vaddr()) else {
+            return Ok(());
+        };
 
-        let ip = tb.vaddr();
-        if ip & KERNEL_MASK != 0 {
-            tb.instructions().for_each(|insn| {
-                let ip = insn.vaddr();
+        match self.mode {
+            SamplingMode::Tb => {
+                let insns = tb.size() as u64;
+                self.stats.translated_blocks.fetch_add(1, Ordering::Relaxed);
+                self.stats
+                    .translated_instructions
+                    .fetch_add(insns, Ordering::Relaxed);
+                let stats = self.stats.clone();
                 let mut this = self.clone();
-                insn.register_execute_callback_flags(
-                    move |_| {
-                        if this.sample(ip).is_err() {
+                let flags = callback_flags(self.callchain);
+                tb.register_execute_callback_flags(
+                    move |cpu| {
+                        stats.executed_blocks.fetch_add(1, Ordering::Relaxed);
+                        stats
+                            .executed_instructions
+                            .fetch_add(insns, Ordering::Relaxed);
+                        stats.execute_callbacks.fetch_add(1, Ordering::Relaxed);
+                        if this.sample(cpu, ip).is_err() {
                             this.stats.sample_failures.fetch_add(1, Ordering::Relaxed);
                         }
                     },
-                    CallbackFlags::QEMU_PLUGIN_CB_R_REGS,
+                    flags,
                 );
-            });
+            }
+            SamplingMode::Insn => {
+                self.stats.translated_blocks.fetch_add(1, Ordering::Relaxed);
+                tb.instructions().for_each(|insn| {
+                    let Some(ip) = self.sample_ip_for(insn.vaddr()) else {
+                        return;
+                    };
+                    self.stats
+                        .translated_instructions
+                        .fetch_add(1, Ordering::Relaxed);
+                    let stats = self.stats.clone();
+                    let mut this = self.clone();
+                    let flags = callback_flags(self.callchain);
+                    insn.register_execute_callback_flags(
+                        move |cpu| {
+                            stats.executed_instructions.fetch_add(1, Ordering::Relaxed);
+                            stats.execute_callbacks.fetch_add(1, Ordering::Relaxed);
+                            if this.sample(cpu, ip).is_err() {
+                                this.stats.sample_failures.fetch_add(1, Ordering::Relaxed);
+                            }
+                        },
+                        flags,
+                    );
+                });
+            }
         }
 
         Ok(())
@@ -223,22 +646,86 @@ impl Register for Profiler {
         let (tx, rx) = bounded(args.queue_size);
         let stats = Arc::<Stats>::default();
         let writer_stats = stats.clone();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let writer_shutdown = shutdown.clone();
+        let writer_done = Arc::new(AtomicBool::new(false));
+        let writer_done_flag = writer_done.clone();
         let out = args.out.clone();
         let max_depth = args.max_depth;
         let freq = args.freq;
+        let mode = args.mode;
+        let filter_start = args.filter_start;
+        let filter_end = args.filter_end;
+        let filter_alias_start = args.filter_alias_start;
+        let filter_alias_end = args.filter_alias_end;
+        let filter_alias_offset = args.filter_alias_offset;
+        let filter_kernel = args.filter_kernel;
+        let callchain = args.callchain;
         let target = info.target_name.to_string();
+        let selected_regs = self.selected_regs.clone();
         spawn(move || {
-            while let Ok(event) = rx.recv() {
-                if bincode::encode_into_std_write(event, &mut file, bincode::config::standard())
-                    .is_err()
-                {
-                    writer_stats.sample_failures.fetch_add(1, Ordering::Relaxed);
-                    break;
+            loop {
+                match rx.recv_timeout(Duration::from_millis(50)) {
+                    Ok(event) => {
+                        if bincode::encode_into_std_write(
+                            event,
+                            &mut file,
+                            bincode::config::standard(),
+                        )
+                        .is_err()
+                        {
+                            writer_stats.sample_failures.fetch_add(1, Ordering::Relaxed);
+                            break;
+                        }
+                        let _ = file.flush();
+                    }
+                    Err(RecvTimeoutError::Timeout) => {
+                        if writer_shutdown.load(Ordering::Acquire) {
+                            break;
+                        }
+                    }
+                    Err(RecvTimeoutError::Disconnected) => break,
                 }
             }
             let _ = file.flush();
             if let Ok(mut summary) = File::create(&summary_path).map(BufWriter::new) {
-                let _ = writeln!(summary, "qperf_format_version = 1");
+                let selected_regs = selected_regs.lock().ok();
+                let _ = writeln!(summary, "qperf_format_version = 3");
+                let _ = writeln!(summary, "record_timestamp = elapsed_ns");
+                let _ = writeln!(
+                    summary,
+                    "record_fields = elapsed_ns,pc,sp,fp,cpu,callchain,trace"
+                );
+                let _ = writeln!(summary, "callchain_method = {callchain}");
+                let _ = writeln!(
+                    summary,
+                    "callchain_enabled = {}",
+                    callchain.needs_registers()
+                );
+                let _ = writeln!(
+                    summary,
+                    "selected_sp_register = {}",
+                    selected_regs
+                        .as_deref()
+                        .and_then(|regs| regs.sp.as_deref())
+                        .unwrap_or("unavailable")
+                );
+                let _ = writeln!(
+                    summary,
+                    "selected_fp_register = {}",
+                    selected_regs
+                        .as_deref()
+                        .and_then(|regs| regs.fp.as_deref())
+                        .unwrap_or("unavailable")
+                );
+                let _ = writeln!(
+                    summary,
+                    "available_registers = {}",
+                    selected_regs
+                        .as_deref()
+                        .map(|regs| regs.available.join(","))
+                        .unwrap_or_else(|| "unavailable".to_string())
+                );
                 let _ = writeln!(
                     summary,
                     "samples = {}",
@@ -254,18 +741,146 @@ impl Register for Profiler {
                     "sample_failures = {}",
                     writer_stats.sample_failures.load(Ordering::Relaxed)
                 );
+                let samples = writer_stats.samples.load(Ordering::Relaxed);
+                let total_frames = writer_stats.total_frames.load(Ordering::Relaxed);
+                let avg_depth = if samples > 0 {
+                    total_frames as f64 / samples as f64
+                } else {
+                    0.0
+                };
+                let _ = writeln!(
+                    summary,
+                    "samples_with_sp = {}",
+                    writer_stats.samples_with_sp.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "samples_with_fp = {}",
+                    writer_stats.samples_with_fp.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "unwind_success = {}",
+                    writer_stats.unwind_success.load(Ordering::Relaxed)
+                );
+                let unwind_failed = writer_stats.unwind_failed_no_fp.load(Ordering::Relaxed)
+                    + writer_stats
+                        .unwind_failed_stack_read
+                        .load(Ordering::Relaxed)
+                    + writer_stats
+                        .unwind_failed_return_ip_unread
+                        .load(Ordering::Relaxed)
+                    + writer_stats
+                        .unwind_failed_non_monotonic_fp
+                        .load(Ordering::Relaxed)
+                    + writer_stats.unwind_failed_loop.load(Ordering::Relaxed);
+                let _ = writeln!(summary, "unwind_failed = {unwind_failed}");
+                let _ = writeln!(
+                    summary,
+                    "unwind_failed_no_fp = {}",
+                    writer_stats.unwind_failed_no_fp.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "unwind_failed_stack_read = {}",
+                    writer_stats
+                        .unwind_failed_stack_read
+                        .load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "unwind_failed_return_ip_unread = {}",
+                    writer_stats
+                        .unwind_failed_return_ip_unread
+                        .load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "unwind_failed_non_monotonic_fp = {}",
+                    writer_stats
+                        .unwind_failed_non_monotonic_fp
+                        .load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "unwind_failed_loop = {}",
+                    writer_stats.unwind_failed_loop.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(summary, "total_frames = {total_frames}");
+                let _ = writeln!(summary, "avg_stack_depth = {avg_depth:.6}");
+                let _ = writeln!(
+                    summary,
+                    "max_observed_stack_depth = {}",
+                    writer_stats.max_observed_depth.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "translated_blocks = {}",
+                    writer_stats.translated_blocks.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "translated_instructions = {}",
+                    writer_stats.translated_instructions.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "executed_blocks = {}",
+                    writer_stats.executed_blocks.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "executed_instructions = {}",
+                    writer_stats.executed_instructions.load(Ordering::Relaxed)
+                );
+                let _ = writeln!(
+                    summary,
+                    "execute_callbacks = {}",
+                    writer_stats.execute_callbacks.load(Ordering::Relaxed)
+                );
                 let _ = writeln!(summary, "max_stack_depth = {max_depth}");
                 let _ = writeln!(summary, "frequency_hz = {freq}");
+                let _ = writeln!(summary, "sampling_mode = {mode:?}");
+                if let (Some(start), Some(end)) = (filter_start, filter_end) {
+                    let _ = writeln!(summary, "filter_start = 0x{start:x}");
+                    let _ = writeln!(summary, "filter_end = 0x{end:x}");
+                }
+                if let (Some(start), Some(end), Some(offset)) =
+                    (filter_alias_start, filter_alias_end, filter_alias_offset)
+                {
+                    let _ = writeln!(summary, "filter_alias_start = 0x{start:x}");
+                    let _ = writeln!(summary, "filter_alias_end = 0x{end:x}");
+                    let _ = writeln!(summary, "filter_alias_offset = 0x{offset:x}");
+                }
+                let _ = writeln!(summary, "filter_kernel = {filter_kernel}");
                 let _ = writeln!(summary, "arch = {target}");
                 let _ = writeln!(summary, "output = {}", out.display());
                 let _ = summary.flush();
             }
+            writer_done_flag.store(true, Ordering::Release);
         });
+        qemu_plugin_register_atexit_cb(id, move |_| {
+            shutdown.store(true, Ordering::Release);
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !writer_done.load(Ordering::Acquire) && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        })?;
 
         self.target = info.target_name.parse()?;
         self.tx = tx;
         self.intvl = Duration::from_secs_f64(1.0 / args.freq as f64);
         self.max_depth = args.max_depth;
+        self.mode = args.mode;
+        self.filter_start = args.filter_start;
+        self.filter_end = args.filter_end;
+        self.filter_alias_start = args.filter_alias_start;
+        self.filter_alias_end = args.filter_alias_end;
+        self.filter_alias_offset = args.filter_alias_offset;
+        self.filter_kernel = args.filter_kernel;
+        self.callchain = args.callchain;
+        self.started_at = Arc::new(Instant::now());
+        self.last = Arc::new(Mutex::new(Instant::now()));
         self.stats = stats;
 
         Ok(())

--- a/tools/qperf/src/reg.rs
+++ b/tools/qperf/src/reg.rs
@@ -20,6 +20,26 @@ impl AllRegs {
             .map(u64::from_le_bytes)
             .map_err(|v| anyhow!("Unexpected size for register {name}: {}", v.len()))
     }
+
+    pub fn find_name(&self, candidates: &[&'static str]) -> Option<String> {
+        candidates
+            .iter()
+            .find(|name| self.0.contains_key(**name))
+            .map(|name| (*name).to_string())
+    }
+
+    pub fn read_first(&self, candidates: &[&'static str]) -> anyhow::Result<(String, u64)> {
+        for name in candidates {
+            if self.0.contains_key(*name) {
+                return self.read(name).map(|value| ((*name).to_string(), value));
+            }
+        }
+        bail!("register not found; tried {}", candidates.join(", "))
+    }
+
+    pub fn names(&self) -> Vec<String> {
+        self.0.keys().cloned().collect()
+    }
 }
 
 impl From<Vec<RegisterDescriptor<'static>>> for AllRegs {
@@ -65,15 +85,15 @@ pub struct Frame {
 }
 
 impl Target {
-    pub fn reg(&self, reg: Reg) -> &'static str {
+    pub fn reg_candidates(&self, reg: Reg) -> &'static [&'static str] {
         match self {
             Target::Riscv64 => match reg {
-                Reg::Sp => "sp",
-                Reg::Fp => "fp",
+                Reg::Sp => &["sp", "x2"],
+                Reg::Fp => &["fp", "s0", "x8"],
             },
             Target::LoongArch64 => match reg {
-                Reg::Sp => "r3",
-                Reg::Fp => "r22",
+                Reg::Sp => &["r3", "sp"],
+                Reg::Fp => &["r22", "fp"],
             },
         }
     }

--- a/tools/starry-syscall-harness/README.md
+++ b/tools/starry-syscall-harness/README.md
@@ -1,0 +1,96 @@
+# StarryOS Syscall Harness
+
+This harness compares selected StarryOS syscall behavior with Linux, profiles StarryOS qperf hotspots, and emits reports that can guide focused fixes.
+
+All StarryOS build, QEMU, syscall probe, and qperf runs should stay inside the configured Docker image.
+
+## CLI
+
+```bash
+python3 tools/starry-syscall-harness/harness.py doctor
+python3 tools/starry-syscall-harness/harness.py discover --arch riscv64
+python3 tools/starry-syscall-harness/harness.py perf-profile --arch riscv64 --timeout 20 --format all
+python3 tools/starry-syscall-harness/harness.py perf-diff --baseline target/starry-syscall-harness/perf/riscv64/latest --compare target/starry-syscall-harness/perf/riscv64/latest
+```
+
+Reports are written under `target/starry-syscall-harness`.
+
+For day-to-day qperf profiling, prefer the cargo-integrated entrypoint:
+
+```bash
+cargo starry perf --case boot
+tools/starry-syscall-harness/scripts/qperf-smoke.sh blk-read
+```
+
+The harness `perf-profile` command remains the Docker-first compatibility
+entrypoint and now forwards flamegraph readability options such as
+`--symbol-style`, `--focus`, and `--no-truncate`.
+
+Useful qperf options:
+
+```bash
+python3 tools/starry-syscall-harness/harness.py perf-profile \
+  --arch riscv64 \
+  --timeout 20 \
+  --format folded \
+  --mode tb \
+  --host-time \
+  --host-perf \
+  --shell-init-cmd 'echo workload; sleep 1' \
+  --qemu-arg=-m \
+  --qemu-arg=768M
+```
+
+- `--mode tb` samples on translated-block execution and is the default low-overhead mode.
+- `--mode insn` samples on instruction callbacks and is much heavier.
+- `--host-time` records host wall time plus `RUSAGE_CHILDREN` user/system CPU time for the QEMU wrapper.
+- `--host-perf` tries to run `perf stat` around the host QEMU process. If `perf` is missing, the report records the reason and still runs qperf.
+- `--shell-init-cmd` injects a command after the guest shell prompt so profiles can cover a concrete workload.
+- `--qemu-arg` appends raw QEMU arguments; repeat it for options and values.
+
+## qperf Model And Metrics
+
+qperf is a QEMU TCG plugin, not host `perf`. It observes guest PCs and guest
+frame-pointer stacks through QEMU callbacks, writes `qperf.bin`, and resolves
+that data against the StarryOS kernel ELF into `stack.folded`, `flamegraph.svg`,
+`report.json`, and `report.md`.
+
+The plugin summary includes:
+
+- `samples`, `dropped_samples`, `sample_failures`
+- `translated_blocks`, `translated_instructions`
+- `executed_blocks`, `executed_instructions`, `execute_callbacks`
+
+`executed_instructions` is a QEMU guest-instruction count for the instrumented
+scope. In TB mode it is calculated as translated-block instruction count times
+block executions. It is not a hardware retired-instruction PMU counter.
+
+qperf does not provide precise guest hardware cycles or guest cache misses with
+the current QEMU plugin API. Host `perf stat` counters, when available, measure
+the host QEMU process, TCG, device emulation, and plugin overhead. Treat them as
+host-side context, not as guest PMU data.
+
+## Local UI
+
+The browser UI is optional and uses the same harness commands behind a local API:
+
+```bash
+python3 tools/starry-syscall-harness/harness.py ui --host 127.0.0.1 --port 8765 --open
+```
+
+The UI can start syscall scans, qperf profiling, perf diffs, and Doctor checks. It reads JSON reports and qperf flamegraphs from `target/starry-syscall-harness`.
+
+The `Knowledge` tab is independent from the execution jobs. It scans the local
+repository, builds an OS subsystem knowledge graph, highlights the graph nodes
+most related to the current coding task, and shows coarse/fine code explanations
+plus OS textbook-to-practice notes. See `docs/harness-os-knowledge-graph.md`.
+
+## MCP
+
+`mcp_server.py` exposes the CLI workflows as MCP tools:
+
+- `starry_syscall_doctor`
+- `starry_syscall_discover`
+- `starry_perf_profile`
+- `starry_perf_diff`
+- `starry_harness_ui_command`

--- a/tools/starry-syscall-harness/harness.py
+++ b/tools/starry-syscall-harness/harness.py
@@ -1,0 +1,2403 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_IMAGE = "ghcr.io/rcore-os/tgoskits-container:latest"
+PROBE_BEGIN = "STARRY_SYSCALL_PROBE_BEGIN"
+PROBE_END = "STARRY_SYSCALL_PROBE_END"
+CASE_RE = re.compile(r"^CASE\s+(?P<name>\S+)\s*(?P<body>.*)$")
+
+
+@dataclass(frozen=True)
+class ArchConfig:
+    target: str
+    cc: str
+    to_bin: bool
+    qemu_args: tuple[str, ...]
+
+
+ARCHES = {
+    "riscv64": ArchConfig(
+        target="riscv64gc-unknown-none-elf",
+        cc="riscv64-linux-musl-gcc",
+        to_bin=True,
+        qemu_args=("-nographic", "-cpu", "rv64"),
+    ),
+    "aarch64": ArchConfig(
+        target="aarch64-unknown-none-softfloat",
+        cc="aarch64-linux-musl-gcc",
+        to_bin=True,
+        qemu_args=("-nographic", "-cpu", "cortex-a53"),
+    ),
+    "loongarch64": ArchConfig(
+        target="loongarch64-unknown-none-softfloat",
+        cc="loongarch64-linux-musl-gcc",
+        to_bin=True,
+        qemu_args=("-machine", "virt", "-cpu", "la464", "-nographic", "-m", "128M"),
+    ),
+    "x86_64": ArchConfig(
+        target="x86_64-unknown-none",
+        cc="x86_64-linux-musl-gcc",
+        to_bin=False,
+        qemu_args=("-nographic",),
+    ),
+}
+
+
+def repo_root_from(start: Path) -> Path:
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "Cargo.toml").exists() and (candidate / "os/StarryOS").exists():
+            return candidate
+    raise SystemExit(f"cannot find tgoskits repo root from {start}")
+
+
+def script_repo_root() -> Path:
+    return repo_root_from(Path(__file__).resolve())
+
+
+def is_inside_docker() -> bool:
+    return os.environ.get("STARRY_SYSCALL_HARNESS_IN_DOCKER") == "1" or Path("/.dockerenv").exists()
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    capture: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(cmd), file=sys.stderr, flush=True)
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+        env=merged_env,
+    )
+    if check and result.returncode != 0:
+        if capture:
+            sys.stdout.write(result.stdout)
+            sys.stderr.write(result.stderr)
+        raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
+    return result
+
+
+def docker_reexec(repo_root: Path, image: str, argv: list[str]) -> int:
+    uid = os.getuid()
+    gid = os.getgid()
+    chown_paths = docker_chown_paths(argv)
+    script = (
+        'python3 tools/starry-syscall-harness/harness.py "$@"; '
+        "status=$?; "
+        f"chown -R {uid}:{gid} {' '.join(chown_paths)} 2>/dev/null || true; "
+        "exit $status"
+    )
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{repo_root}:/work",
+        "-w",
+        "/work",
+        "-e",
+        "STARRY_SYSCALL_HARNESS_IN_DOCKER=1",
+        image,
+        "bash",
+        "-lc",
+        script,
+        "starry-harness",
+    ]
+    cmd.extend(argv)
+    return run(cmd, cwd=repo_root, check=False).returncode
+
+
+def docker_chown_paths(argv: list[str]) -> list[str]:
+    paths = ["target/starry-syscall-harness", "tools/qperf/target"]
+    for index, arg in enumerate(argv):
+        value = None
+        if arg == "--output-dir" and index + 1 < len(argv):
+            value = argv[index + 1]
+        elif arg.startswith("--output-dir="):
+            value = arg.split("=", 1)[1]
+        if value and is_safe_relative_path(value):
+            paths.append(value)
+    return [shlex.quote(path) for path in dict.fromkeys(paths)]
+
+
+def is_safe_relative_path(value: str) -> bool:
+    path = Path(value)
+    return not path.is_absolute() and ".." not in path.parts
+
+
+def docker_tool_output(repo_root: Path, image: str, command: str) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{repo_root}:/work",
+            "-w",
+            "/work",
+            image,
+            "bash",
+            "-lc",
+            command,
+        ],
+        cwd=repo_root,
+        check=False,
+        capture=True,
+    )
+
+
+def command_exists(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def doctor(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    checks: list[dict[str, Any]] = []
+
+    docker_ok = command_exists("docker")
+    checks.append({"name": "docker", "ok": docker_ok})
+    if docker_ok:
+        image_check = run(
+            ["docker", "image", "inspect", args.image],
+            cwd=repo_root,
+            check=False,
+            capture=True,
+        )
+        checks.append({"name": args.image, "ok": image_check.returncode == 0})
+        tool_check = docker_tool_output(
+            repo_root,
+            args.image,
+            "command -v debugfs && command -v riscv64-linux-musl-gcc && command -v qemu-system-riscv64 && cargo --version",
+        )
+        checks.append(
+            {
+                "name": "container-tools",
+                "ok": tool_check.returncode == 0,
+                "output": (tool_check.stdout + tool_check.stderr).strip(),
+            }
+        )
+
+    report = {"repo_root": str(repo_root), "checks": checks}
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if all(item["ok"] for item in checks) else 1
+
+
+def parse_cases(output: str) -> dict[str, dict[str, str]]:
+    cases: dict[str, dict[str, str]] = {}
+    for line in output.splitlines():
+        match = CASE_RE.match(strip_ansi(line).strip())
+        if not match:
+            continue
+        fields: dict[str, str] = {}
+        for part in match.group("body").split():
+            if "=" not in part:
+                continue
+            key, value = part.split("=", 1)
+            fields[key] = value
+        cases[match.group("name")] = fields
+    return cases
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;?]*[ -/]*[@-~]", "", text)
+
+
+def compare_cases(
+    linux_cases: dict[str, dict[str, str]],
+    starry_cases: dict[str, dict[str, str]],
+) -> list[dict[str, Any]]:
+    differences: list[dict[str, Any]] = []
+    for name in sorted(set(linux_cases) | set(starry_cases)):
+        linux = linux_cases.get(name)
+        starry = starry_cases.get(name)
+        if linux != starry:
+            differences.append({"case": name, "linux": linux, "starry": starry})
+    return differences
+
+
+PERF_RULES = [
+    {
+        "id": "virtio_vsock_locking",
+        "patterns": ["vsock", "Vsock", "VSOCK"],
+        "files": [
+            "os/arceos/modules/axnet-ng/src/device/vsock.rs",
+            "os/arceos/modules/axnet-ng/src/vsock/connection_manager.rs",
+        ],
+        "strategy": "Inspect global vsock device/connection-manager lock hold time; split TX/RX paths or move long work outside global locks.",
+    },
+    {
+        "id": "virtio_net_shared_state",
+        "patterns": ["virtio", "net", "transmit", "receive", "TxQueue", "RxQueue"],
+        "files": [
+            "platform/axplat-dyn/src/drivers/net/virtio_pci.rs",
+            "platform/axplat-dyn/src/drivers/net/mod.rs",
+        ],
+        "strategy": "Inspect TX/RX shared locking and copy paths; prefer separate queue locks and reduce copies inside locked sections.",
+    },
+    {
+        "id": "virtio_block_sync_queue",
+        "patterns": ["virtio", "blk", "Block", "read_blocks", "write_blocks", "CmdQueue"],
+        "files": [
+            "platform/axplat-dyn/src/drivers/blk/virtio_pci.rs",
+            "platform/axplat-dyn/src/drivers/blk/mod.rs",
+        ],
+        "strategy": "Inspect synchronous queue lock hold time; separate metadata access from blocking I/O and batch adjacent requests when possible.",
+    },
+    {
+        "id": "lock_contention",
+        "patterns": ["Mutex", "lock", "spin", "wait"],
+        "files": ["components", "os/StarryOS", "os/arceos/modules"],
+        "strategy": "Measure lock ownership scope around the hot function; move allocation/copy/syscall work outside the critical section.",
+    },
+    {
+        "id": "copy_overhead",
+        "patterns": ["copy", "memcpy", "copy_from_slice", "read_exact", "write_all"],
+        "files": ["drivers", "platform", "os/StarryOS/kernel/src/syscall"],
+        "strategy": "Inspect repeated buffer copies in the hot path; prefer scatter-gather buffers or one-copy handoff where the driver API allows it.",
+    },
+]
+
+CATEGORY_RULES = [
+    {
+        "category": "virtqueue_add_notify_wait_pop",
+        "axis": "bottleneck",
+        "patterns": ["add_notify_wait_pop", "notify_wait_pop"],
+    },
+    {
+        "category": "virtqueue_add",
+        "axis": "bottleneck",
+        "patterns": ["virtqueue::add", "add_buf", "receive_begin", "transmit_begin"],
+    },
+    {
+        "category": "virtqueue_pop_complete",
+        "axis": "bottleneck",
+        "patterns": ["pop_used", "poll_used", "receive_complete", "transmit_complete", "complete"],
+    },
+    {
+        "category": "virtio_notify_kick",
+        "axis": "bottleneck",
+        "patterns": ["notify", "kick", "should_notify", "queue_notify"],
+    },
+    {
+        "category": "memcpy",
+        "axis": "bottleneck",
+        "patterns": ["memcpy", "copy_nonoverlapping", "copy_from_slice", "extend_from_slice"],
+    },
+    {
+        "category": "memmove",
+        "axis": "bottleneck",
+        "patterns": ["memmove", "copy_within"],
+    },
+    {
+        "category": "allocator",
+        "axis": "bottleneck",
+        "patterns": [
+            "ax_alloc",
+            "global_allocator",
+            "__rust_alloc",
+            "__rust_dealloc",
+            "alloc_pages",
+            "dealloc_pages",
+            "raw_vec",
+            "with_capacity",
+        ],
+    },
+    {
+        "category": "scheduler_wait_preempt",
+        "axis": "bottleneck",
+        "patterns": [
+            "ax_task",
+            "axtask",
+            "run_queue",
+            "yield_current",
+            "resched",
+            "waitqueue",
+            "preempt",
+            "schedule",
+        ],
+    },
+    {
+        "category": "lock_mutex_wait",
+        "axis": "bottleneck",
+        "patterns": [
+            "mutex",
+            "rwlock",
+            "spinnoirq",
+            "spinraw",
+            "kspin",
+            "lock_api",
+            "try_lock",
+            "kernel_guard",
+            "irqsave",
+        ],
+    },
+    {
+        "category": "pci_probe_transport",
+        "axis": "subsystem",
+        "patterns": [
+            "probe_pci",
+            "take_virtio_transport",
+            "virtio_pci::init",
+            "virtio_pci::probe",
+            "pciaddress",
+            "read_config",
+            "write_config",
+            "config_space",
+            "bar_info",
+            "probe_bar",
+        ],
+    },
+    {
+        "category": "net_inflight_btree",
+        "axis": "subsystem",
+        "patterns": ["tx_inflight", "rx_inflight"],
+        "all_patterns": [
+            ["btree", "ax_driver::virtio::net"],
+            ["btree", "virtionet"],
+            ["btree", "virtio_net"],
+        ],
+    },
+    {
+        "category": "block_io_path",
+        "axis": "subsystem",
+        "patterns": ["virtio_blk", "virtioblk", "rd_block", "blockqueue", "read_blocks", "write_blocks", "rsext4", "axfs"],
+    },
+    {
+        "category": "net_rx_tx_path",
+        "axis": "subsystem",
+        "patterns": ["virtio_net", "virtionet", "axnet", "smoltcp", "rxqueue", "txqueue", "transmit", "receive"],
+    },
+    {
+        "category": "vsock_tx_rx_path",
+        "axis": "subsystem",
+        "patterns": ["vsock", "virtiosocket", "rdif_vsock"],
+    },
+]
+
+
+def parse_kv_summary(path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    if not path.exists():
+        return data
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def parse_gnu_time_metrics(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    raw: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        raw[normalize_metric_key(key)] = value.strip()
+    metrics: dict[str, Any] = {"raw": raw}
+    numeric_keys = {
+        "user_time": "user_seconds",
+        "system_time": "system_seconds",
+        "percent_of_cpu_this_job_got": "cpu_percent",
+        "maximum_resident_set_size": "max_rss_kb",
+        "major_page_faults": "major_page_faults",
+        "minor_page_faults": "minor_page_faults",
+        "voluntary_context_switches": "voluntary_context_switches",
+        "involuntary_context_switches": "involuntary_context_switches",
+        "file_system_inputs": "file_system_inputs",
+        "file_system_outputs": "file_system_outputs",
+        "socket_messages_sent": "socket_messages_sent",
+        "socket_messages_received": "socket_messages_received",
+        "signals_delivered": "signals_delivered",
+        "page_size": "page_size_bytes",
+        "exit_status": "exit_status",
+    }
+    for raw_key, metric_key in numeric_keys.items():
+        if raw_key in raw:
+            metrics[metric_key] = parse_metric_number(raw[raw_key])
+    elapsed = raw.get("elapsed_time")
+    if elapsed:
+        metrics["elapsed_seconds"] = parse_elapsed_seconds(elapsed)
+    return metrics
+
+
+def normalize_metric_key(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"\([^)]*\)", "", value)
+    value = re.sub(r"[^a-z0-9]+", "_", value).strip("_")
+    return value
+
+
+def parse_metric_number(value: str) -> int | float | str:
+    text = value.strip().replace(",", "")
+    if text.endswith("%"):
+        text = text[:-1]
+    try:
+        if "." in text:
+            return float(text)
+        return int(text)
+    except ValueError:
+        return value
+
+
+def parse_elapsed_seconds(value: str) -> float | None:
+    text = value.strip()
+    try:
+        parts = [float(part) for part in text.split(":")]
+    except ValueError:
+        return None
+    if len(parts) == 3:
+        hours, minutes, seconds = parts
+        return hours * 3600 + minutes * 60 + seconds
+    if len(parts) == 2:
+        minutes, seconds = parts
+        return minutes * 60 + seconds
+    if len(parts) == 1:
+        return parts[0]
+    return None
+
+
+def parse_perf_stat_metrics(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    events: dict[str, dict[str, Any]] = {}
+    errors: list[str] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            errors.append(line.lstrip("# "))
+            continue
+        parts = line.split(",")
+        if len(parts) < 3:
+            errors.append(line)
+            continue
+        value_text, unit, event = parts[0].strip(), parts[1].strip(), parts[2].strip()
+        if not event:
+            errors.append(line)
+            continue
+        value = None if value_text in {"", "<not supported>", "<not counted>"} else parse_metric_number(value_text)
+        events[event] = {
+            "value": value,
+            "unit": unit,
+            "raw": line,
+        }
+    return {
+        "scope": "host_qemu_process",
+        "note": "perf stat measures the host QEMU process and wrapper overhead; it is not a guest PMU counter.",
+        "events": events,
+        "errors": errors,
+    }
+
+
+def load_json_file(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError as err:
+        return {"error": f"failed to parse {path}: {err}"}
+
+
+def parse_folded(path: Path, limit: int = 20) -> dict[str, Any]:
+    function_counts: dict[str, int] = {}
+    stack_counts: dict[str, int] = {}
+    category_counts: dict[str, int] = {}
+    category_stacks: dict[str, int] = {}
+    category_functions: dict[str, dict[str, int]] = {}
+    total = 0
+    total_frames = 0
+    if not path.exists():
+        return {
+            "total_samples": 0,
+            "top_functions": [],
+            "top_stacks": [],
+            "category_totals": [],
+        }
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            stack, count_text = line.rsplit(" ", 1)
+            count = int(count_text)
+        except ValueError:
+            stack = line
+            count = 1
+        total += count
+        stack_counts[stack] = stack_counts.get(stack, 0) + count
+        functions = [function for function in stack.split(";") if function]
+        total_frames += count * len(functions)
+        matched_categories = classify_stack(functions)
+        for category in matched_categories:
+            category_counts[category] = category_counts.get(category, 0) + count
+            category_stacks[category] = category_stacks.get(category, 0) + 1
+            per_function = category_functions.setdefault(category, {})
+            for function in functions:
+                if category_matches_function(category, function):
+                    per_function[function] = per_function.get(function, 0) + count
+        for function in functions:
+            if function:
+                function_counts[function] = function_counts.get(function, 0) + count
+
+    def entries(counts: dict[str, int], label: str, denominator: int) -> list[dict[str, Any]]:
+        ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:limit]
+        return [
+            {
+                label: name,
+                "samples": count,
+                "percent": round((count / denominator * 100.0) if denominator else 0.0, 4),
+            }
+            for name, count in ranked
+        ]
+
+    return {
+        "total_samples": total,
+        "total_frames": total_frames,
+        "top_functions": entries(function_counts, "function", total_frames),
+        "top_stacks": entries(stack_counts, "stack", total),
+        "category_totals": category_entries(
+            category_counts,
+            category_stacks,
+            category_functions,
+            total,
+            limit,
+        ),
+    }
+
+
+def normalize_symbol_for_category(value: str) -> str:
+    value = strip_ansi(value).lower()
+    value = re.sub(r"\+0x[0-9a-f]+", "", value)
+    return value
+
+
+def category_matches_function(category: str, function: str) -> bool:
+    normalized = normalize_symbol_for_category(function)
+    for rule in CATEGORY_RULES:
+        if rule["category"] == category:
+            return rule_matches_text(rule, normalized)
+    return False
+
+
+def classify_stack(functions: list[str]) -> list[str]:
+    normalized = "\n".join(normalize_symbol_for_category(function) for function in functions)
+    matched = []
+    for rule in CATEGORY_RULES:
+        if rule_matches_text(rule, normalized):
+            matched.append(rule["category"])
+    return matched
+
+
+def rule_matches_text(rule: dict[str, Any], text: str) -> bool:
+    if any(pattern in text for pattern in rule.get("patterns", [])):
+        return True
+    for group in rule.get("all_patterns", []):
+        if all(pattern in text for pattern in group):
+            return True
+    return False
+
+
+def category_entries(
+    counts: dict[str, int],
+    stacks: dict[str, int],
+    functions: dict[str, dict[str, int]],
+    total: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    axis_by_category = {rule["category"]: rule["axis"] for rule in CATEGORY_RULES}
+    items = []
+    for rule in CATEGORY_RULES:
+        category = rule["category"]
+        count = counts.get(category, 0)
+        top_functions = sorted(
+            functions.get(category, {}).items(),
+            key=lambda item: (-item[1], item[0]),
+        )[: min(limit, 10)]
+        items.append(
+            {
+                "category": category,
+                "axis": axis_by_category.get(category, "unknown"),
+                "mode": "inclusive_stack",
+                "samples": count,
+                "percent": round((count / total * 100.0) if total else 0.0, 4),
+                "matched_stacks": stacks.get(category, 0),
+                "top_functions": [
+                    {
+                        "function": name,
+                        "samples": samples,
+                        "percent": round((samples / total * 100.0) if total else 0.0, 4),
+                    }
+                    for name, samples in top_functions
+                ],
+            }
+        )
+    return sorted(items, key=lambda item: (-item["samples"], item["category"]))
+
+
+def parse_workload_stdout_metrics(output: str) -> dict[str, Any]:
+    text = strip_ansi(output).replace("\r", "\n")
+    metrics: dict[str, Any] = {
+        "custom": [],
+        "values": {},
+        "dd": [],
+        "wget": [],
+        "raw_metric_lines": [],
+    }
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for line in lines:
+        if line.startswith("QPERF_METRIC"):
+            parsed = parse_qperf_metric_line(line)
+            metrics["raw_metric_lines"].append(line)
+            if parsed:
+                metrics["custom"].append(parsed)
+                for key, value in parsed.get("fields", {}).items():
+                    metrics["values"][key] = value
+            continue
+        if line.startswith("QPERF_BEGIN") or line.startswith("QPERF_END"):
+            continue
+        dd = parse_dd_output_line(line)
+        if dd:
+            metrics["dd"].append(dd)
+        update_wget_metrics(metrics, line)
+    return metrics
+
+
+def parse_qperf_metric_line(line: str) -> dict[str, Any]:
+    try:
+        parts = shlex.split(line)
+    except ValueError:
+        parts = line.split()
+    if not parts or parts[0] != "QPERF_METRIC":
+        return {}
+    fields: dict[str, Any] = {}
+    labels: list[str] = []
+    for item in parts[1:]:
+        if "=" not in item:
+            labels.append(item)
+            continue
+        key, value = item.split("=", 1)
+        fields[normalize_metric_key(key)] = parse_metric_number(value)
+    return {"labels": labels, "fields": fields, "raw": line}
+
+
+def parse_dd_output_line(line: str) -> dict[str, Any] | None:
+    match = re.search(
+        r"(?P<bytes>[\d,]+)\s+bytes\b.*?\bcopied,\s*"
+        r"(?P<seconds>[0-9.]+)\s*s(?:ec(?:onds?)?)?,\s*"
+        r"(?P<rate>[0-9.]+)\s*(?P<unit>[KMGT]?i?B|[KMGT]?B)/s",
+        line,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    byte_count = int(match.group("bytes").replace(",", ""))
+    seconds = float(match.group("seconds"))
+    return {
+        "bytes": byte_count,
+        "elapsed_seconds": seconds,
+        "throughput_bytes_per_second": byte_count / seconds if seconds > 0 else None,
+        "reported_rate": float(match.group("rate")),
+        "reported_rate_unit": match.group("unit") + "/s",
+        "raw": line,
+    }
+
+
+def update_wget_metrics(metrics: dict[str, Any], line: str) -> None:
+    if "wget" not in metrics:
+        metrics["wget"] = []
+    current = metrics["wget"][-1] if metrics["wget"] else None
+    if "Length:" in line:
+        match = re.search(r"Length:\s*([\d,]+)", line)
+        if match:
+            current = {"raw_lines": []}
+            current["bytes"] = int(match.group(1).replace(",", ""))
+            metrics["wget"].append(current)
+    lower_line = line.lower()
+    is_wget_line = (
+        "connecting to " in lower_line
+        or "saving to " in lower_line
+        or ("%" in line and "|" in line)
+        or " saved " in lower_line
+        or lower_line.endswith(" saved")
+        or "saved [" in lower_line
+    )
+    if current is None and is_wget_line:
+        current = {"raw_lines": []}
+        metrics["wget"].append(current)
+    if current is None:
+        return
+    if current.get("saved") and not is_wget_line:
+        return
+    current.setdefault("raw_lines", []).append(line)
+    saved = re.search(r"saved\s+\[([\d,]+)(?:/[\d,]+)?\]", line, re.IGNORECASE)
+    if saved:
+        current["saved"] = True
+        current["saved_bytes"] = int(saved.group(1).replace(",", ""))
+        current.setdefault("bytes", current["saved_bytes"])
+    elif " saved" in lower_line:
+        current["saved"] = True
+    progress = re.search(
+        r"(?<!\d)100%.*\|\s*(?P<size>[0-9.]+)\s*(?P<unit>[KMGTkmgt]?)(?:i?B|B)?\b",
+        line,
+    )
+    if progress:
+        current["progress_size"] = progress.group("size") + progress.group("unit")
+        current.setdefault(
+            "bytes",
+            byte_size_to_int(float(progress.group("size")), progress.group("unit")),
+        )
+    elapsed = re.search(r"\bin\s+([0-9.]+)\s*([smh]?)\b", line)
+    if elapsed:
+        current["elapsed_seconds"] = elapsed_to_seconds(float(elapsed.group(1)), elapsed.group(2))
+    rate = re.search(r"\(([0-9.]+)\s*([KMGT]?i?B|[KMGT]?B)/s\)", line, re.IGNORECASE)
+    if rate:
+        current["reported_rate"] = float(rate.group(1))
+        current["reported_rate_unit"] = rate.group(2) + "/s"
+    if current.get("bytes") is not None and current.get("elapsed_seconds"):
+        current["throughput_bytes_per_second"] = current["bytes"] / current["elapsed_seconds"]
+
+
+def byte_size_to_int(value: float, unit: str) -> int:
+    match unit.lower():
+        case "k":
+            factor = 1024
+        case "m":
+            factor = 1024**2
+        case "g":
+            factor = 1024**3
+        case "t":
+            factor = 1024**4
+        case _:
+            factor = 1
+    return int(value * factor)
+
+
+def elapsed_to_seconds(value: float, unit: str) -> float:
+    match unit.lower():
+        case "h":
+            return value * 3600.0
+        case "m":
+            return value * 60.0
+        case _:
+            return value
+
+
+def workload_bytes(metrics: dict[str, Any]) -> int | None:
+    for dd in reversed(metrics.get("dd", [])):
+        if dd.get("bytes"):
+            return int(dd["bytes"])
+    for wget in reversed(metrics.get("wget", [])):
+        if wget.get("bytes"):
+            return int(wget["bytes"])
+        if wget.get("saved_bytes"):
+            return int(wget["saved_bytes"])
+    values = metrics.get("values") or {}
+    for key in ("workload_bytes", "bytes", "total_bytes"):
+        value = values.get(key)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return None
+
+
+def workload_elapsed_seconds(metrics: dict[str, Any], window: dict[str, Any]) -> float | None:
+    for dd in reversed(metrics.get("dd", [])):
+        if dd.get("elapsed_seconds") is not None:
+            return float(dd["elapsed_seconds"])
+    for wget in reversed(metrics.get("wget", [])):
+        if wget.get("elapsed_seconds") is not None:
+            return float(wget["elapsed_seconds"])
+    values = metrics.get("values") or {}
+    for key in ("workload_elapsed_seconds", "elapsed_seconds", "seconds"):
+        value = values.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+    if isinstance(window.get("duration_sec"), (int, float)):
+        return float(window["duration_sec"])
+    return None
+
+
+def complete_workload_metrics(metrics: dict[str, Any], window: dict[str, Any]) -> None:
+    window_elapsed = window.get("duration_sec")
+    if not isinstance(window_elapsed, (int, float)) or window_elapsed <= 0:
+        return
+    for wget in metrics.get("wget", []):
+        if wget.get("elapsed_seconds") is None and wget.get("saved") and wget.get("bytes"):
+            wget["elapsed_seconds"] = float(window_elapsed)
+            wget["elapsed_source"] = "marker_window"
+        if wget.get("throughput_bytes_per_second") is None and wget.get("bytes") and wget.get("elapsed_seconds"):
+            wget["throughput_bytes_per_second"] = wget["bytes"] / wget["elapsed_seconds"]
+
+
+def perf_fix_candidates(top_functions: list[dict[str, Any]], min_percent: float) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in top_functions:
+        function = item["function"]
+        percent = float(item["percent"])
+        if percent < min_percent:
+            continue
+        for rule in PERF_RULES:
+            if rule["id"] in seen:
+                continue
+            if any(pattern in function for pattern in rule["patterns"]):
+                seen.add(rule["id"])
+                candidates.append(
+                    {
+                        "id": rule["id"],
+                        "trigger": function,
+                        "samples": item["samples"],
+                        "percent": percent,
+                        "files": rule["files"],
+                        "strategy": rule["strategy"],
+                    }
+                )
+                break
+    return candidates
+
+
+def numeric_metric(data: dict[str, Any], key: str) -> int | float | None:
+    value = data.get(key)
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        parsed = parse_metric_number(value)
+        if isinstance(parsed, (int, float)):
+            return parsed
+    return None
+
+
+def compute_normalized_metrics(
+    hotspots: dict[str, Any],
+    plugin_summary: dict[str, str],
+    host_time_metrics: dict[str, Any],
+    host_perf_metrics: dict[str, Any],
+    workload_metrics: dict[str, Any],
+    window: dict[str, Any],
+) -> dict[str, Any]:
+    byte_count = workload_bytes(workload_metrics)
+    mb = (byte_count / 1_000_000.0) if byte_count else None
+    elapsed = workload_elapsed_seconds(workload_metrics, window)
+    host_elapsed = numeric_metric(host_time_metrics, "elapsed_seconds")
+    executed_instructions = numeric_metric(plugin_summary, "executed_instructions")
+    executed_blocks = numeric_metric(plugin_summary, "executed_blocks")
+    total_samples = hotspots.get("total_samples") or 0
+    normalized: dict[str, Any] = {
+        "workload_bytes": byte_count,
+        "workload_elapsed_seconds": elapsed,
+        "guest_instructions_per_MB": divide_or_none(executed_instructions, mb),
+        "guest_blocks_per_MB": divide_or_none(executed_blocks, mb),
+        "host_elapsed_sec_per_MB": divide_or_none(host_elapsed, mb),
+        "samples_per_MB": divide_or_none(total_samples, mb),
+        "category_samples_per_MB": {
+            item["category"]: divide_or_none(item.get("samples"), mb)
+            for item in hotspots.get("category_totals", [])
+        },
+    }
+    if elapsed:
+        normalized["samples_per_second"] = divide_or_none(total_samples, elapsed)
+    host_events = (host_perf_metrics.get("events") or {}) if isinstance(host_perf_metrics, dict) else {}
+    cycles = host_event_value(host_events, "cycles")
+    instructions = host_event_value(host_events, "instructions")
+    cache_misses = host_event_value(host_events, "cache-misses")
+    cache_refs = host_event_value(host_events, "cache-references")
+    normalized["host_ipc"] = divide_or_none(instructions, cycles)
+    normalized["host_cycles_per_sample"] = divide_or_none(cycles, total_samples)
+    normalized["host_instructions_per_sample"] = divide_or_none(instructions, total_samples)
+    normalized["host_cache_miss_percent"] = percent_or_none(cache_misses, cache_refs)
+    return normalized
+
+
+def divide_or_none(numerator: Any, denominator: Any) -> float | None:
+    if not isinstance(numerator, (int, float)) or not isinstance(denominator, (int, float)):
+        return None
+    if denominator == 0:
+        return None
+    return round(numerator / denominator, 6)
+
+
+def percent_or_none(numerator: Any, denominator: Any) -> float | None:
+    value = divide_or_none(numerator, denominator)
+    return round(value * 100.0, 6) if value is not None else None
+
+
+def host_event_value(events: dict[str, Any], name: str) -> int | float | None:
+    event = events.get(name) or {}
+    value = event.get("value")
+    return value if isinstance(value, (int, float)) else None
+
+
+def write_hotspots_csv(path: Path, hotspots: dict[str, Any]) -> None:
+    lines = ["kind,name,samples,percent"]
+    for item in hotspots["top_functions"]:
+        lines.append(f"function,{json.dumps(item['function'])},{item['samples']},{item['percent']}")
+    for item in hotspots["top_stacks"]:
+        lines.append(f"stack,{json.dumps(item['stack'])},{item['samples']},{item['percent']}")
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def write_hotspot_categories_csv(path: Path, hotspots: dict[str, Any]) -> None:
+    lines = ["category,axis,mode,samples,percent,matched_stacks,top_function"]
+    for item in hotspots.get("category_totals", []):
+        top_function = ""
+        if item.get("top_functions"):
+            top_function = item["top_functions"][0]["function"]
+        lines.append(
+            ",".join(
+                [
+                    json.dumps(item["category"]),
+                    json.dumps(item["axis"]),
+                    json.dumps(item["mode"]),
+                    str(item["samples"]),
+                    str(item["percent"]),
+                    str(item["matched_stacks"]),
+                    json.dumps(top_function),
+                ]
+            )
+        )
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def write_perf_markdown(path: Path, report: dict[str, Any]) -> None:
+    host_time = report.get("host_time_metrics") or {}
+    host_perf = report.get("host_perf_metrics") or {}
+    host_perf_events = (host_perf.get("events") or {}) if isinstance(host_perf, dict) else {}
+    workload = report.get("workload_metrics") or {}
+    normalized = report.get("normalized_metrics") or {}
+    window = report.get("window") or {}
+    callchain = report.get("callchain") or {}
+    lines = [
+        "# StarryOS qperf Performance Report",
+        "",
+        f"- arch: `{report['arch']}`",
+        f"- result: `{report['result']}`",
+        f"- samples: `{report['hotspots']['total_samples']}`",
+        f"- artifacts: `{report['artifacts']['work_dir']}`",
+    ]
+    if host_time.get("elapsed_seconds") is not None:
+        lines.append(f"- host elapsed seconds: `{host_time['elapsed_seconds']}`")
+    if host_time.get("user_seconds") is not None:
+        lines.append(f"- host user seconds: `{host_time['user_seconds']}`")
+    if host_time.get("system_seconds") is not None:
+        lines.append(f"- host system seconds: `{host_time['system_seconds']}`")
+    if window.get("enabled"):
+        lines.append(f"- workload window: `{window.get('start_time')}` -> `{window.get('stop_time')}`")
+        if window.get("truncated_by_timeout"):
+            lines.append("- workload window truncated by timeout: `true`")
+    if host_perf_events:
+        lines.extend(
+            [
+                "- host perf scope: `host_qemu_process`",
+                "- host perf note: `host perf stat measures the host QEMU process, not guest PMU counters`",
+            ]
+        )
+        for event_name in ("task-clock", "cycles", "instructions", "cache-references", "cache-misses"):
+            event = host_perf_events.get(event_name)
+            if event and event.get("value") is not None:
+                unit = f" {event['unit']}" if event.get("unit") else ""
+                lines.append(f"- host {event_name}: `{event['value']}{unit}`")
+    elif not report.get("parameters", {}).get("host_perf"):
+        lines.append("- host perf: `未启用 host perf`")
+    if normalized.get("workload_bytes") is not None:
+        lines.append(f"- workload bytes: `{normalized['workload_bytes']}`")
+    if normalized.get("workload_elapsed_seconds") is not None:
+        lines.append(f"- workload elapsed seconds: `{normalized['workload_elapsed_seconds']}`")
+    if normalized.get("samples_per_MB") is not None:
+        lines.append(f"- samples per MB: `{normalized['samples_per_MB']}`")
+    if callchain:
+        lines.append(f"- callchain mode: `{callchain.get('method')}`")
+        lines.append(f"- callchain avg depth: `{callchain.get('avg_depth')}`")
+        lines.append(f"- callchain max depth: `{callchain.get('max_depth')}`")
+        lines.append(f"- callchain unwind success: `{callchain.get('unwind_success')}`")
+    artifact_paths = report.get("artifacts") or {}
+    lines.extend(["", "## Artifacts", ""])
+    for label in (
+        "markdown",
+        "report",
+        "flamegraph",
+        "flamegraph_workload",
+        "flamegraph_boot",
+        "flamegraph_post",
+        "flamegraph_focus",
+        "flamegraph_html",
+        "folded",
+        "hotspots_csv",
+        "hotspot_categories_csv",
+        "summary_txt",
+        "stack_depth_summary",
+    ):
+        value = artifact_paths.get(label)
+        if value:
+            lines.append(f"- {label}: `{value}`")
+    lines.extend(
+        [
+            "",
+            "## Workload Metrics",
+            "",
+        ]
+    )
+    if workload.get("dd") or workload.get("wget") or workload.get("custom"):
+        if workload.get("dd"):
+            for item in workload["dd"]:
+                lines.append(
+                    f"- dd: `{item.get('bytes')}` bytes, `{item.get('elapsed_seconds')}` sec, "
+                    f"`{item.get('throughput_bytes_per_second')}` B/s"
+                )
+        if workload.get("wget"):
+            for item in workload["wget"]:
+                lines.append(
+                    f"- wget: `{item.get('bytes') or item.get('saved_bytes')}` bytes, "
+                    f"saved=`{item.get('saved')}`, elapsed=`{item.get('elapsed_seconds')}` sec"
+                )
+        if workload.get("values"):
+            preview = ", ".join(f"{key}={value}" for key, value in sorted(workload["values"].items())[:12])
+            lines.append(f"- QPERF_METRIC: `{preview}`")
+    else:
+        lines.append("No workload stdout metrics were parsed.")
+    lines.extend(
+        [
+            "",
+            "## Hotspot Categories",
+            "",
+            "| Category | Axis | Samples | Percent |",
+            "|---|---|---:|---:|",
+        ]
+    )
+    for item in report["hotspots"].get("category_totals", []):
+        lines.append(
+            f"| `{item['category']}` | `{item['axis']}` | {item['samples']} | {item['percent']:.2f}% |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Top Functions",
+            "",
+            "| Function | Samples | Percent |",
+            "|---|---:|---:|",
+        ]
+    )
+    for item in report["hotspots"]["top_functions"][:20]:
+        lines.append(f"| `{item['function']}` | {item['samples']} | {item['percent']:.2f}% |")
+    lines.extend(["", "## Fix Candidates", ""])
+    candidates = report.get("fix_candidates", [])
+    if candidates:
+        for candidate in candidates:
+            files = ", ".join(f"`{item}`" for item in candidate["files"])
+            lines.extend(
+                [
+                    f"### {candidate['id']}",
+                    "",
+                    f"- trigger: `{candidate['trigger']}`",
+                    f"- percent: `{candidate['percent']:.2f}%`",
+                    f"- files: {files}",
+                    f"- strategy: {candidate['strategy']}",
+                    "",
+                ]
+            )
+    else:
+        lines.append("No rule-based bottleneck fix candidates crossed the configured threshold.")
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def perf_work_dir(repo_root: Path, output_dir: str, arch: str) -> Path:
+    return repo_root / output_dir / "perf" / arch / "latest"
+
+
+def perf_profile_inside(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    work_dir = perf_work_dir(repo_root, args.output_dir, args.arch)
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    qperf_dir = work_dir / "qperf"
+    qperf_dir.mkdir(parents=True, exist_ok=True)
+
+    ensure_starry_qemu_defconfig(repo_root, args.arch)
+    command = [
+        "cargo",
+        "xtask",
+        "starry",
+        "perf",
+        "--arch",
+        args.arch,
+        "--timeout",
+        str(args.timeout),
+        "--format",
+        args.format,
+        "--freq",
+        str(args.freq),
+        "--max-depth",
+        str(args.max_depth),
+        "--mode",
+        args.mode,
+        "--perf-callchain",
+        args.callchain,
+        "--top",
+        str(args.top),
+        "--min-percent",
+        str(args.min_percent),
+        "--symbol-style",
+        args.symbol_style,
+        "--out",
+        str(qperf_dir),
+    ]
+    if args.debug:
+        command.append("--debug")
+    if args.kernel_filter:
+        command.append("--kernel-filter")
+    if args.host_time:
+        command.append("--host-time")
+    else:
+        command.append("--no-host-time")
+    if args.host_perf:
+        command.append("--host-perf")
+        command.extend(["--host-perf-events", args.host_perf_events])
+    if args.shell_init_cmd:
+        command.extend(["--shell-init-cmd", args.shell_init_cmd])
+    if args.shell_prefix:
+        command.extend(["--shell-prefix", args.shell_prefix])
+    if args.start_marker:
+        command.extend(["--start-marker", args.start_marker])
+    if args.stop_marker:
+        command.extend(["--stop-marker", args.stop_marker])
+    if args.workload_timeout is not None:
+        command.extend(["--workload-timeout", str(args.workload_timeout)])
+    if args.qperf_metrics:
+        command.append("--qperf-metrics")
+    if args.full_stack:
+        command.append("--full-stack")
+    if args.perf_debuginfo:
+        command.append("--perf-debuginfo")
+    if args.perf_force_frame_pointers:
+        command.append("--perf-force-frame-pointers")
+    if args.focus:
+        command.extend(["--focus", args.focus])
+    if args.no_truncate:
+        command.append("--no-truncate")
+    for qemu_arg in args.qemu_arg:
+        command.append(f"--qemu-arg={qemu_arg}")
+    run_result = run(command, cwd=repo_root, check=False, capture=True)
+    write_text(work_dir / "profile.stdout", run_result.stdout)
+    write_text(work_dir / "profile.stderr", run_result.stderr)
+
+    folded = qperf_dir / "stack.folded"
+    hotspots = parse_folded(folded, args.top)
+    summary = parse_kv_summary(qperf_dir / "summary.txt")
+    plugin_summary = parse_kv_summary(qperf_dir / "qperf.summary.txt")
+    host_time_metrics = parse_gnu_time_metrics(qperf_dir / "qemu.time.txt")
+    host_perf_metrics = parse_perf_stat_metrics(qperf_dir / "qemu.perf.csv") if args.host_perf else {
+        "enabled": False,
+        "note": "未启用 host perf",
+        "events": {},
+        "errors": [],
+    }
+    if args.host_perf:
+        host_perf_metrics["enabled"] = True
+    workload_metrics = parse_workload_stdout_metrics(run_result.stdout)
+    window = load_json_file(qperf_dir / "window.json")
+    if not window:
+        window = {
+            "enabled": bool(args.start_marker or args.stop_marker or args.workload_timeout),
+            "start_marker": args.start_marker,
+            "stop_marker": args.stop_marker,
+            "start_time": None,
+            "stop_time": None,
+            "duration_sec": None,
+            "workload_timeout": args.workload_timeout,
+            "truncated_by_timeout": False,
+            "boot_samples_excluded": None,
+            "warnings": [],
+            "method": "qperf_raw_elapsed_timestamp_filter" if (args.start_marker or args.stop_marker) else "disabled",
+        }
+    resolve_stats = load_json_file(qperf_dir / "resolve.stats.json")
+    if resolve_stats:
+        window["boot_samples_excluded"] = resolve_stats.get("samples_excluded_before")
+        window["post_window_samples_excluded"] = resolve_stats.get("samples_excluded_after")
+        if resolve_stats.get("warning"):
+            window.setdefault("warnings", []).append(resolve_stats["warning"])
+    if args.start_marker and not window.get("start_time"):
+        window.setdefault("warnings", []).append("start marker missing; report may include boot samples")
+    if args.stop_marker and not window.get("stop_time"):
+        window.setdefault("warnings", []).append("stop marker missing; report may include post-workload samples")
+    callchain = resolve_stats.get("callchain") if resolve_stats else None
+    if not callchain:
+        callchain = {
+            "enabled": args.callchain != "leaf",
+            "method": args.callchain,
+            "samples_with_fp": None,
+            "unwind_success": None,
+            "unwind_failed": None,
+            "avg_depth": None,
+            "max_depth": None,
+        }
+    complete_workload_metrics(workload_metrics, window)
+    normalized_metrics = compute_normalized_metrics(
+        hotspots,
+        plugin_summary,
+        host_time_metrics,
+        host_perf_metrics,
+        workload_metrics,
+        window,
+    )
+    candidates = perf_fix_candidates(hotspots["top_functions"], args.min_percent)
+    result = "ok" if run_result.returncode == 0 and hotspots["total_samples"] > 0 else "incomplete"
+    report = {
+        "arch": args.arch,
+        "result": result,
+        "returncode": run_result.returncode,
+        "parameters": {
+            "timeout": args.timeout,
+            "format": args.format,
+            "freq": args.freq,
+            "max_depth": args.max_depth,
+            "mode": args.mode,
+            "callchain": args.callchain,
+            "top": args.top,
+            "min_percent": args.min_percent,
+            "symbol_style": args.symbol_style,
+            "focus": args.focus,
+            "no_truncate": args.no_truncate,
+            "debug": args.debug,
+            "kernel_filter": args.kernel_filter,
+            "host_time": args.host_time,
+            "host_perf": args.host_perf,
+            "host_perf_events": args.host_perf_events,
+            "shell_init_cmd": args.shell_init_cmd,
+            "shell_prefix": args.shell_prefix,
+            "start_marker": args.start_marker,
+            "stop_marker": args.stop_marker,
+            "workload_timeout": args.workload_timeout,
+            "qperf_metrics": args.qperf_metrics,
+            "full_stack": args.full_stack,
+            "perf_debuginfo": args.perf_debuginfo,
+            "perf_force_frame_pointers": args.perf_force_frame_pointers,
+            "qemu_args": args.qemu_arg,
+        },
+        "window": window,
+        "resolve_stats": resolve_stats,
+        "callchain": callchain,
+        "hotspots": hotspots,
+        "summary": summary,
+        "plugin_summary": plugin_summary,
+        "host_time_metrics": host_time_metrics,
+        "host_perf_metrics": host_perf_metrics,
+        "workload_metrics": workload_metrics,
+        "normalized_metrics": normalized_metrics,
+        "fix_candidates": candidates,
+        "linux_alignment": {
+            "status": "baseline_required",
+            "note": "Provide a Linux workload baseline or a previous optimized folded stack to perf-diff for quantitative alignment.",
+        },
+        "artifacts": {
+            "work_dir": str(work_dir),
+            "qperf_dir": str(qperf_dir),
+            "report": str(work_dir / "report.json"),
+            "markdown": str(work_dir / "report.md"),
+            "hotspots_csv": str(work_dir / "hotspots.csv"),
+            "hotspot_categories_csv": str(work_dir / "hotspot_categories.csv"),
+            "profile_stdout": str(work_dir / "profile.stdout"),
+            "profile_stderr": str(work_dir / "profile.stderr"),
+            "raw_samples": str(qperf_dir / "qperf.bin"),
+            "folded": str(folded),
+            "flamegraph": str(qperf_dir / "flamegraph.svg"),
+            "flamegraph_workload": str(qperf_dir / "flamegraph.workload.svg"),
+            "flamegraph_boot": str(qperf_dir / "flamegraph.boot.svg"),
+            "flamegraph_post": str(qperf_dir / "flamegraph.post.svg"),
+            "flamegraph_focus": str(qperf_dir / "flamegraph.focus.svg"),
+            "flamegraph_html": str(qperf_dir / "flamegraph.html"),
+            "summary_txt": str(qperf_dir / "summary.txt"),
+            "stack_depth_summary": str(qperf_dir / "stack-depth-summary.csv"),
+            "plugin_summary": str(qperf_dir / "qperf.summary.txt"),
+            "qemu_config": str(qperf_dir / "qemu.toml"),
+            "host_time": str(qperf_dir / "qemu.time.txt"),
+            "host_perf": str(qperf_dir / "qemu.perf.csv"),
+            "window": str(qperf_dir / "window.json"),
+            "resolve_stats": str(qperf_dir / "resolve.stats.json"),
+        },
+    }
+    write_text(work_dir / "report.json", json.dumps(report, indent=2, sort_keys=True))
+    write_perf_markdown(work_dir / "report.md", report)
+    write_hotspots_csv(work_dir / "hotspots.csv", hotspots)
+    write_hotspot_categories_csv(work_dir / "hotspot_categories.csv", hotspots)
+    print_perf_summary(report)
+    return run_result.returncode
+
+
+def print_perf_summary(report: dict[str, Any]) -> None:
+    print(f"arch: {report['arch']}")
+    print(f"artifacts: {report['artifacts']['work_dir']}")
+    print(f"result: {report['result']}")
+    print(f"samples: {report['hotspots']['total_samples']}")
+    host_time = report.get("host_time_metrics") or {}
+    if host_time.get("elapsed_seconds") is not None:
+        print(f"host elapsed: {host_time['elapsed_seconds']}s")
+    host_perf = report.get("host_perf_metrics") or {}
+    perf_events = host_perf.get("events") or {}
+    if perf_events:
+        preview = []
+        for name in ("task-clock", "cycles", "instructions", "cache-misses"):
+            event = perf_events.get(name)
+            if event and event.get("value") is not None:
+                preview.append(f"{name}={event['value']}")
+        if preview:
+            print("host perf: " + ", ".join(preview))
+    for item in report["hotspots"]["top_functions"][:5]:
+        print(f"- {item['percent']:.2f}% {item['function']}")
+    if report["fix_candidates"]:
+        print("fix candidates:")
+        for candidate in report["fix_candidates"]:
+            print(f"- {candidate['id']}: {candidate['trigger']} ({candidate['percent']:.2f}%)")
+
+
+def perf_postprocess(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    work_dir = Path(args.work_dir)
+    if not work_dir.is_absolute():
+        work_dir = repo_root / work_dir
+    qperf_dir = Path(args.qperf_dir)
+    if not qperf_dir.is_absolute():
+        qperf_dir = repo_root / qperf_dir
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    stdout_path = Path(args.profile_stdout) if args.profile_stdout else work_dir / "profile.stdout"
+    stderr_path = Path(args.profile_stderr) if args.profile_stderr else work_dir / "profile.stderr"
+    stdout_text = stdout_path.read_text(encoding="utf-8", errors="replace") if stdout_path.exists() else ""
+    stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace") if stderr_path.exists() else ""
+    write_text(work_dir / "profile.stdout", stdout_text)
+    write_text(work_dir / "profile.stderr", stderr_text)
+
+    folded = qperf_dir / "stack.folded"
+    hotspots = parse_folded(folded, args.top)
+    summary = parse_kv_summary(qperf_dir / "summary.txt")
+    plugin_summary = parse_kv_summary(qperf_dir / "qperf.summary.txt")
+    host_time_metrics = parse_gnu_time_metrics(qperf_dir / "qemu.time.txt")
+    host_perf_metrics = parse_perf_stat_metrics(qperf_dir / "qemu.perf.csv") if args.host_perf else {
+        "enabled": False,
+        "note": "未启用 host perf",
+        "events": {},
+        "errors": [],
+    }
+    if args.host_perf:
+        host_perf_metrics["enabled"] = True
+    workload_metrics = parse_workload_stdout_metrics(stdout_text)
+    window = load_json_file(qperf_dir / "window.json")
+    if not window:
+        window = {
+            "enabled": bool(args.start_marker or args.stop_marker or args.workload_timeout),
+            "start_marker": args.start_marker,
+            "stop_marker": args.stop_marker,
+            "start_time": None,
+            "stop_time": None,
+            "duration_sec": None,
+            "workload_timeout": args.workload_timeout,
+            "truncated_by_timeout": False,
+            "boot_samples_excluded": None,
+            "warnings": [],
+            "method": "qperf_raw_elapsed_timestamp_filter" if (args.start_marker or args.stop_marker) else "disabled",
+        }
+    resolve_stats = load_json_file(qperf_dir / "resolve.stats.json")
+    if resolve_stats:
+        window["boot_samples_excluded"] = resolve_stats.get("samples_excluded_before")
+        window["post_window_samples_excluded"] = resolve_stats.get("samples_excluded_after")
+        if resolve_stats.get("warning"):
+            window.setdefault("warnings", []).append(resolve_stats["warning"])
+    if args.start_marker and not window.get("start_time"):
+        window.setdefault("warnings", []).append("start marker missing; report may include boot samples")
+    if args.stop_marker and not window.get("stop_time"):
+        window.setdefault("warnings", []).append("stop marker missing; report may include post-workload samples")
+    callchain = resolve_stats.get("callchain") if resolve_stats else None
+    if not callchain:
+        callchain = {
+            "enabled": args.callchain != "leaf",
+            "method": args.callchain,
+            "samples_with_fp": None,
+            "unwind_success": None,
+            "unwind_failed": None,
+            "avg_depth": None,
+            "max_depth": None,
+        }
+    complete_workload_metrics(workload_metrics, window)
+    normalized_metrics = compute_normalized_metrics(
+        hotspots,
+        plugin_summary,
+        host_time_metrics,
+        host_perf_metrics,
+        workload_metrics,
+        window,
+    )
+    candidates = perf_fix_candidates(hotspots["top_functions"], args.min_percent)
+    result = "ok" if args.returncode == 0 and hotspots["total_samples"] > 0 else "incomplete"
+    artifacts = {
+        "work_dir": str(work_dir),
+        "qperf_dir": str(qperf_dir),
+        "report": str(work_dir / "report.json"),
+        "markdown": str(work_dir / "report.md"),
+        "hotspots_csv": str(work_dir / "hotspots.csv"),
+        "hotspot_categories_csv": str(work_dir / "hotspot_categories.csv"),
+        "profile_stdout": str(work_dir / "profile.stdout"),
+        "profile_stderr": str(work_dir / "profile.stderr"),
+        "raw_samples": str(qperf_dir / "qperf.bin"),
+        "folded": str(folded),
+        "flamegraph": str(qperf_dir / "flamegraph.svg"),
+        "flamegraph_workload": str(qperf_dir / "flamegraph.workload.svg"),
+        "flamegraph_boot": str(qperf_dir / "flamegraph.boot.svg"),
+        "flamegraph_post": str(qperf_dir / "flamegraph.post.svg"),
+        "flamegraph_focus": str(qperf_dir / "flamegraph.focus.svg"),
+        "flamegraph_html": str(qperf_dir / "flamegraph.html"),
+        "summary_txt": str(qperf_dir / "summary.txt"),
+        "stack_depth_summary": str(qperf_dir / "stack-depth-summary.csv"),
+        "plugin_summary": str(qperf_dir / "qperf.summary.txt"),
+        "qemu_config": str(qperf_dir / "qemu.toml"),
+        "host_time": str(qperf_dir / "qemu.time.txt"),
+        "host_perf": str(qperf_dir / "qemu.perf.csv"),
+        "window": str(qperf_dir / "window.json"),
+        "resolve_stats": str(qperf_dir / "resolve.stats.json"),
+    }
+    report = {
+        "arch": args.arch,
+        "result": result,
+        "returncode": args.returncode,
+        "parameters": {
+            "timeout": args.timeout,
+            "format": args.format,
+            "freq": args.freq,
+            "max_depth": args.max_depth,
+            "mode": args.mode,
+            "callchain": args.callchain,
+            "top": args.top,
+            "min_percent": args.min_percent,
+            "symbol_style": getattr(args, "symbol_style", None),
+            "focus": getattr(args, "focus", None),
+            "no_truncate": getattr(args, "no_truncate", False),
+            "debug": args.debug,
+            "kernel_filter": args.kernel_filter,
+            "host_time": args.host_time,
+            "host_perf": args.host_perf,
+            "host_perf_events": args.host_perf_events,
+            "shell_init_cmd": args.shell_init_cmd,
+            "shell_prefix": args.shell_prefix,
+            "start_marker": args.start_marker,
+            "stop_marker": args.stop_marker,
+            "workload_timeout": args.workload_timeout,
+            "qperf_metrics": args.qperf_metrics,
+            "full_stack": args.full_stack,
+            "perf_debuginfo": args.perf_debuginfo,
+            "perf_force_frame_pointers": args.perf_force_frame_pointers,
+            "qemu_args": args.qemu_arg,
+        },
+        "window": window,
+        "resolve_stats": resolve_stats,
+        "callchain": callchain,
+        "hotspots": hotspots,
+        "summary": summary,
+        "plugin_summary": plugin_summary,
+        "host_time_metrics": host_time_metrics,
+        "host_perf_metrics": host_perf_metrics,
+        "workload_metrics": workload_metrics,
+        "normalized_metrics": normalized_metrics,
+        "fix_candidates": candidates,
+        "linux_alignment": {
+            "status": "baseline_required",
+            "note": "Provide a Linux workload baseline or a previous optimized folded stack to perf-diff for quantitative alignment.",
+        },
+        "artifacts": artifacts,
+    }
+    write_text(work_dir / "report.json", json.dumps(report, indent=2, sort_keys=True))
+    write_perf_markdown(work_dir / "report.md", report)
+    write_hotspots_csv(work_dir / "hotspots.csv", hotspots)
+    write_hotspot_categories_csv(work_dir / "hotspot_categories.csv", hotspots)
+    print_perf_summary(report)
+    return 0
+
+
+def perf_profile(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    if not args.no_docker and not is_inside_docker():
+        forwarded = [
+            "perf-profile",
+            "--repo-root",
+            "/work",
+            "--arch",
+            args.arch,
+            "--timeout",
+            str(args.timeout),
+            "--format",
+            args.format,
+            "--freq",
+            str(args.freq),
+            "--max-depth",
+            str(args.max_depth),
+            "--mode",
+            args.mode,
+            "--callchain",
+            args.callchain,
+            "--top",
+            str(args.top),
+            "--min-percent",
+            str(args.min_percent),
+            "--symbol-style",
+            args.symbol_style,
+            "--output-dir",
+            args.output_dir,
+            "--no-docker",
+        ]
+        if args.focus:
+            forwarded.extend(["--focus", args.focus])
+        if args.no_truncate:
+            forwarded.append("--no-truncate")
+        if args.debug:
+            forwarded.append("--debug")
+        if args.kernel_filter:
+            forwarded.append("--kernel-filter")
+        if args.host_time:
+            forwarded.append("--host-time")
+        if args.host_perf:
+            forwarded.append("--host-perf")
+            forwarded.extend(["--host-perf-events", args.host_perf_events])
+        if args.shell_init_cmd:
+            forwarded.extend(["--shell-init-cmd", args.shell_init_cmd])
+        if args.shell_prefix:
+            forwarded.extend(["--shell-prefix", args.shell_prefix])
+        if args.start_marker:
+            forwarded.extend(["--start-marker", args.start_marker])
+        if args.stop_marker:
+            forwarded.extend(["--stop-marker", args.stop_marker])
+        if args.workload_timeout is not None:
+            forwarded.extend(["--workload-timeout", str(args.workload_timeout)])
+        if args.qperf_metrics:
+            forwarded.append("--qperf-metrics")
+        if args.full_stack:
+            forwarded.append("--full-stack")
+        if args.perf_debuginfo:
+            forwarded.append("--perf-debuginfo")
+        if args.perf_force_frame_pointers:
+            forwarded.append("--perf-force-frame-pointers")
+        for qemu_arg in args.qemu_arg:
+            forwarded.append(f"--qemu-arg={qemu_arg}")
+        return docker_reexec(repo_root, args.image, forwarded)
+    return perf_profile_inside(args)
+
+
+def resolve_folded_path(path: Path) -> Path:
+    if path.is_file():
+        return path
+    candidates = [
+        path / "stack.folded",
+        path / "qperf" / "stack.folded",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"cannot find stack.folded under {path}")
+
+
+def perf_diff(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    baseline = resolve_folded_path(Path(args.baseline))
+    compare = resolve_folded_path(Path(args.compare))
+    baseline_hotspots = parse_folded(baseline, args.top)
+    compare_hotspots = parse_folded(compare, args.top)
+
+    baseline_counts = {item["function"]: item for item in baseline_hotspots["top_functions"]}
+    compare_counts = {item["function"]: item for item in compare_hotspots["top_functions"]}
+    changes: list[dict[str, Any]] = []
+    for name in sorted(set(baseline_counts) | set(compare_counts)):
+        base = baseline_counts.get(name, {"samples": 0, "percent": 0.0})
+        comp = compare_counts.get(name, {"samples": 0, "percent": 0.0})
+        changes.append(
+            {
+                "function": name,
+                "baseline_percent": base["percent"],
+                "compare_percent": comp["percent"],
+                "delta_percent": round(comp["percent"] - base["percent"], 4),
+                "baseline_samples": base["samples"],
+                "compare_samples": comp["samples"],
+            }
+        )
+    changes.sort(key=lambda item: abs(item["delta_percent"]), reverse=True)
+
+    out_dir = repo_root / args.output_dir / "perf-diff"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report = {
+        "baseline": str(baseline),
+        "compare": str(compare),
+        "top_changes": changes[: args.top],
+        "artifacts": {
+            "work_dir": str(out_dir),
+            "report": str(out_dir / "report.json"),
+        },
+    }
+    write_text(out_dir / "report.json", json.dumps(report, indent=2, sort_keys=True))
+    print(f"artifacts: {out_dir}")
+    for item in report["top_changes"][:10]:
+        print(
+            f"- {item['delta_percent']:+.2f}% {item['function']} "
+            f"({item['baseline_percent']:.2f}% -> {item['compare_percent']:.2f}%)"
+        )
+    return 0
+
+
+def resolve_perf_report_input(path: Path) -> dict[str, Any]:
+    source = path
+    report_path: Path | None = None
+    folded_path: Path | None = None
+    source_type = "unknown"
+    if path.is_file() and path.name == "report.json":
+        report_path = path
+        source_type = "report_json"
+    elif path.is_file():
+        folded_path = path
+        source_type = "folded"
+    else:
+        for candidate in [path / "report.json", path.parent / "report.json"]:
+            if candidate.exists():
+                report_path = candidate
+                source_type = "profile_dir"
+                break
+        for candidate in [path / "qperf" / "stack.folded", path / "stack.folded"]:
+            if candidate.exists():
+                folded_path = candidate
+                break
+    report = load_json_file(report_path) if report_path else {}
+    if folded_path is None and report:
+        artifact = (report.get("artifacts") or {}).get("folded")
+        if artifact and Path(artifact).exists():
+            folded_path = Path(artifact)
+        elif report_path:
+            for candidate in [
+                report_path.parent / "qperf" / "stack.folded",
+                report_path.parent / "stack.folded",
+            ]:
+                if candidate.exists():
+                    folded_path = candidate
+                    break
+    hotspots = None
+    if folded_path:
+        hotspots = parse_folded(folded_path, limit=10_000)
+    elif isinstance(report.get("hotspots"), dict):
+        hotspots = report.get("hotspots")
+    return {
+        "input": str(source),
+        "source_type": source_type,
+        "report_path": str(report_path) if report_path else None,
+        "folded_path": str(folded_path) if folded_path else None,
+        "report": report,
+        "hotspots": hotspots or {"total_samples": 0, "top_functions": [], "top_stacks": [], "category_totals": []},
+    }
+
+
+def perf_compare(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    baseline = resolve_perf_report_input(Path(args.baseline))
+    candidate = resolve_perf_report_input(Path(args.candidate or args.compare))
+    out_dir = repo_root / args.output_dir / "perf-compare"
+    if args.name:
+        out_dir = out_dir / args.name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics = compare_metric_entries(baseline, candidate)
+    top_changes = compare_hotspot_entries(
+        baseline["hotspots"].get("top_functions", []),
+        candidate["hotspots"].get("top_functions", []),
+        "function",
+        args.top,
+    )
+    category_changes = compare_category_entries(
+        baseline["hotspots"].get("category_totals", []),
+        candidate["hotspots"].get("category_totals", []),
+    )
+    compatibility = compare_compatibility(baseline, candidate)
+    conclusion = compare_conclusion(metrics)
+    report = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "baseline": compare_input_summary(baseline),
+        "candidate": compare_input_summary(candidate),
+        "compatibility": compatibility,
+        "conclusion": conclusion,
+        "metrics": metrics,
+        "top_changes": top_changes,
+        "category_changes": category_changes,
+        "artifacts": {
+            "work_dir": str(out_dir),
+            "json": str(out_dir / "compare.json"),
+            "markdown": str(out_dir / "compare.md"),
+            "csv": str(out_dir / "compare.csv"),
+        },
+    }
+    write_text(out_dir / "compare.json", json.dumps(report, indent=2, sort_keys=True))
+    write_compare_markdown(out_dir / "compare.md", report)
+    write_compare_csv(out_dir / "compare.csv", report)
+    print(f"artifacts: {out_dir}")
+    print(f"conclusion: {conclusion['label']}")
+    for item in metrics[:10]:
+        print(
+            f"- {item['group']}.{item['name']}: {format_na(item['baseline'])} -> "
+            f"{format_na(item['candidate'])} ({format_na(item['relative_change_percent'])}%)"
+        )
+    return 0
+
+
+def compare_input_summary(data: dict[str, Any]) -> dict[str, Any]:
+    report = data.get("report") or {}
+    return {
+        "input": data.get("input"),
+        "source_type": data.get("source_type"),
+        "report": data.get("report_path"),
+        "folded": data.get("folded_path"),
+        "arch": report.get("arch"),
+        "result": report.get("result"),
+        "parameters": report.get("parameters") or {},
+        "total_samples": data.get("hotspots", {}).get("total_samples", 0),
+    }
+
+
+def compare_compatibility(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    base_report = baseline.get("report") or {}
+    cand_report = candidate.get("report") or {}
+    base_params = base_report.get("parameters") or {}
+    cand_params = cand_report.get("parameters") or {}
+    keys = sorted(set(base_params) | set(cand_params))
+    parameter_diffs = {
+        key: {"baseline": base_params.get(key), "candidate": cand_params.get(key)}
+        for key in keys
+        if base_params.get(key) != cand_params.get(key)
+    }
+    warnings = []
+    if base_report.get("arch") != cand_report.get("arch"):
+        warnings.append("baseline and candidate arch differ")
+    if not baseline.get("report_path") or not candidate.get("report_path"):
+        warnings.append("one side is missing report.json; metadata comparison is incomplete")
+    return {
+        "same_arch": base_report.get("arch") == cand_report.get("arch"),
+        "parameter_diffs": parameter_diffs,
+        "warnings": warnings,
+    }
+
+
+def compare_metric_entries(baseline: dict[str, Any], candidate: dict[str, Any]) -> list[dict[str, Any]]:
+    base_report = baseline.get("report") or {}
+    cand_report = candidate.get("report") or {}
+    specs = [
+        ("workload", "throughput_bytes_per_second", "B/s", first_throughput),
+        ("workload", "elapsed_seconds", "s", lambda r: workload_elapsed_seconds(r.get("workload_metrics") or {}, r.get("window") or {})),
+        ("guest", "executed_instructions", "count", lambda r: numeric_metric(r.get("plugin_summary") or {}, "executed_instructions")),
+        ("guest", "executed_blocks", "count", lambda r: numeric_metric(r.get("plugin_summary") or {}, "executed_blocks")),
+        ("host", "elapsed_seconds", "s", lambda r: numeric_metric(r.get("host_time_metrics") or {}, "elapsed_seconds")),
+        ("host", "user_seconds", "s", lambda r: numeric_metric(r.get("host_time_metrics") or {}, "user_seconds")),
+        ("host", "system_seconds", "s", lambda r: numeric_metric(r.get("host_time_metrics") or {}, "system_seconds")),
+        ("samples", "total_samples", "count", lambda r: (r.get("hotspots") or {}).get("total_samples")),
+    ]
+    entries = [
+        compare_metric(group, name, unit, getter(base_report), getter(cand_report))
+        for group, name, unit, getter in specs
+    ]
+    for key in sorted(set(metric_values(base_report)) | set(metric_values(cand_report))):
+        entries.append(
+            compare_metric(
+                "virtio_counters",
+                key,
+                "count",
+                metric_values(base_report).get(key),
+                metric_values(cand_report).get(key),
+            )
+        )
+    for event in sorted(set(host_perf_values(base_report)) | set(host_perf_values(cand_report))):
+        entries.append(
+            compare_metric(
+                "host_perf",
+                event,
+                "",
+                host_perf_values(base_report).get(event),
+                host_perf_values(cand_report).get(event),
+            )
+        )
+    return entries
+
+
+def first_throughput(report: dict[str, Any]) -> int | float | None:
+    workload = report.get("workload_metrics") or {}
+    for key in ("dd", "wget"):
+        for item in reversed(workload.get(key, [])):
+            value = item.get("throughput_bytes_per_second")
+            if isinstance(value, (int, float)):
+                return value
+    return None
+
+
+def metric_values(report: dict[str, Any]) -> dict[str, Any]:
+    values = dict((report.get("workload_metrics") or {}).get("values") or {})
+    return {
+        key: value
+        for key, value in values.items()
+        if isinstance(value, (int, float))
+        and (
+            key.startswith("virt")
+            or "copy" in key
+            or "inflight" in key
+            or "depth" in key
+            or key.endswith("_bytes")
+        )
+    }
+
+
+def host_perf_values(report: dict[str, Any]) -> dict[str, Any]:
+    events = ((report.get("host_perf_metrics") or {}).get("events") or {})
+    return {
+        name: event.get("value")
+        for name, event in events.items()
+        if isinstance(event, dict) and isinstance(event.get("value"), (int, float))
+    }
+
+
+def compare_metric(group: str, name: str, unit: str, baseline: Any, candidate: Any) -> dict[str, Any]:
+    delta = None
+    relative = None
+    availability = "ok"
+    if not isinstance(baseline, (int, float)) or not isinstance(candidate, (int, float)):
+        availability = "missing"
+    else:
+        delta = candidate - baseline
+        if baseline != 0:
+            relative = delta / baseline * 100.0
+    return {
+        "group": group,
+        "name": name,
+        "unit": unit,
+        "baseline": baseline if isinstance(baseline, (int, float)) else None,
+        "candidate": candidate if isinstance(candidate, (int, float)) else None,
+        "delta": round(delta, 6) if isinstance(delta, (int, float)) else None,
+        "relative_change_percent": round(relative, 6) if isinstance(relative, (int, float)) else None,
+        "availability": availability,
+    }
+
+
+def compare_hotspot_entries(
+    baseline_items: list[dict[str, Any]],
+    candidate_items: list[dict[str, Any]],
+    key: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    baseline_by_name = {item[key]: item for item in baseline_items}
+    candidate_by_name = {item[key]: item for item in candidate_items}
+    changes = []
+    for name in sorted(set(baseline_by_name) | set(candidate_by_name)):
+        base = baseline_by_name.get(name, {"samples": 0, "percent": 0.0})
+        cand = candidate_by_name.get(name, {"samples": 0, "percent": 0.0})
+        presence = "common" if name in baseline_by_name and name in candidate_by_name else (
+            "added" if name in candidate_by_name else "removed"
+        )
+        changes.append(
+            {
+                "kind": key,
+                "name": name,
+                "baseline_samples": base["samples"],
+                "candidate_samples": cand["samples"],
+                "baseline_percent": base["percent"],
+                "candidate_percent": cand["percent"],
+                "delta_samples": cand["samples"] - base["samples"],
+                "delta_percent_points": round(cand["percent"] - base["percent"], 6),
+                "relative_change_percent": percent_delta(base["samples"], cand["samples"]),
+                "presence": presence,
+            }
+        )
+    changes.sort(key=lambda item: abs(item["delta_percent_points"]), reverse=True)
+    return changes[:limit]
+
+
+def compare_category_entries(
+    baseline_items: list[dict[str, Any]],
+    candidate_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return compare_hotspot_entries(baseline_items, candidate_items, "category", 100)
+
+
+def percent_delta(baseline: int | float, candidate: int | float) -> float | None:
+    if baseline == 0:
+        return None
+    return round((candidate - baseline) / baseline * 100.0, 6)
+
+
+def compare_conclusion(metrics: list[dict[str, Any]]) -> dict[str, str]:
+    by_name = {(item["group"], item["name"]): item for item in metrics}
+    throughput = by_name.get(("workload", "throughput_bytes_per_second"), {})
+    elapsed = by_name.get(("workload", "elapsed_seconds"), {})
+    evidence = []
+    if isinstance(throughput.get("relative_change_percent"), (int, float)):
+        change = throughput["relative_change_percent"]
+        evidence.append(f"throughput {change:+.2f}%")
+        if change <= -5.0:
+            return {"label": "退化", "evidence": "; ".join(evidence)}
+        if change >= 5.0:
+            return {"label": "明显改善", "evidence": "; ".join(evidence)}
+    if isinstance(elapsed.get("relative_change_percent"), (int, float)):
+        change = elapsed["relative_change_percent"]
+        evidence.append(f"elapsed {change:+.2f}%")
+        if change >= 5.0:
+            return {"label": "退化", "evidence": "; ".join(evidence)}
+        if change <= -5.0:
+            return {"label": "明显改善", "evidence": "; ".join(evidence)}
+    if evidence:
+        return {"label": "基本无变化", "evidence": "; ".join(evidence)}
+    return {"label": "数据不足", "evidence": "missing comparable workload throughput or elapsed metrics"}
+
+
+def write_compare_markdown(path: Path, report: dict[str, Any]) -> None:
+    lines = [
+        "# qperf A/B Compare",
+        "",
+        f"- conclusion: `{report['conclusion']['label']}`",
+        f"- evidence: `{report['conclusion']['evidence']}`",
+        f"- baseline: `{report['baseline']['input']}`",
+        f"- candidate: `{report['candidate']['input']}`",
+        "",
+        "## Metrics",
+        "",
+        "| Group | Metric | Baseline | Candidate | Delta | Change |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for item in report["metrics"]:
+        lines.append(
+            f"| `{item['group']}` | `{item['name']}` | {format_na(item['baseline'])} | "
+            f"{format_na(item['candidate'])} | {format_na(item['delta'])} | "
+            f"{format_na(item['relative_change_percent'])}% |"
+        )
+    lines.extend(["", "## Hotspot Categories", "", "| Category | Base% | Candidate% | Delta pp |", "|---|---:|---:|---:|"])
+    for item in report["category_changes"][:20]:
+        lines.append(
+            f"| `{item['name']}` | {item['baseline_percent']:.2f}% | "
+            f"{item['candidate_percent']:.2f}% | {item['delta_percent_points']:+.2f} |"
+        )
+    lines.extend(["", "## Top Function Changes", "", "| Function | Base% | Candidate% | Delta pp |", "|---|---:|---:|---:|"])
+    for item in report["top_changes"][:20]:
+        lines.append(
+            f"| `{item['name']}` | {item['baseline_percent']:.2f}% | "
+            f"{item['candidate_percent']:.2f}% | {item['delta_percent_points']:+.2f} |"
+        )
+    if report["compatibility"]["warnings"]:
+        lines.extend(["", "## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in report["compatibility"]["warnings"])
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def write_compare_csv(path: Path, report: dict[str, Any]) -> None:
+    lines = [
+        "row_type,group,name,unit,baseline,candidate,delta,relative_change_percent,baseline_samples,candidate_samples,baseline_percent,candidate_percent,delta_percent_points,presence,note"
+    ]
+    for item in report["metrics"]:
+        lines.append(
+            ",".join(
+                [
+                    "metric",
+                    json.dumps(item["group"]),
+                    json.dumps(item["name"]),
+                    json.dumps(item["unit"]),
+                    csv_value(item["baseline"]),
+                    csv_value(item["candidate"]),
+                    csv_value(item["delta"]),
+                    csv_value(item["relative_change_percent"]),
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    json.dumps(item["availability"]),
+                ]
+            )
+        )
+    for row_type, rows in (("category", report["category_changes"]), ("function", report["top_changes"])):
+        for item in rows:
+            lines.append(
+                ",".join(
+                    [
+                        row_type,
+                        "",
+                        json.dumps(item["name"]),
+                        "",
+                        "",
+                        "",
+                        "",
+                        csv_value(item["relative_change_percent"]),
+                        str(item["baseline_samples"]),
+                        str(item["candidate_samples"]),
+                        str(item["baseline_percent"]),
+                        str(item["candidate_percent"]),
+                        str(item["delta_percent_points"]),
+                        json.dumps(item["presence"]),
+                        "",
+                    ]
+                )
+            )
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def csv_value(value: Any) -> str:
+    return "" if value is None else json.dumps(value)
+
+
+def format_na(value: Any) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def compile_probe(repo_root: Path, work_dir: Path, arch: str) -> tuple[Path, Path]:
+    config = ARCHES[arch]
+    source = repo_root / "tools/starry-syscall-harness/probes/syscall_probe.c"
+    linux_bin = work_dir / "probe-linux"
+    starry_bin = work_dir / f"probe-{arch}"
+    run(["gcc", "-O2", "-Wall", "-Wextra", "-o", str(linux_bin), str(source)], cwd=repo_root)
+    run([config.cc, "-static", "-O2", "-Wall", "-Wextra", "-o", str(starry_bin), str(source)], cwd=repo_root)
+    return linux_bin, starry_bin
+
+
+def ensure_starry_qemu_defconfig(repo_root: Path, arch: str) -> None:
+    run(["cargo", "xtask", "starry", "defconfig", f"qemu-{arch}"], cwd=repo_root)
+
+
+def ensure_rootfs(repo_root: Path, arch: str) -> Path:
+    config = ARCHES[arch]
+    ensure_starry_qemu_defconfig(repo_root, arch)
+    run(["cargo", "xtask", "starry", "rootfs", "--arch", arch], cwd=repo_root)
+    candidates = [
+        repo_root / "tmp" / "axbuild" / "rootfs" / f"rootfs-{arch}-alpine.img",
+        repo_root / "target" / config.target / f"rootfs-{arch}.img",
+    ]
+    for rootfs in candidates:
+        if rootfs.exists():
+            return rootfs
+    raise FileNotFoundError(candidates[0])
+
+
+def inject_probe(rootfs: Path, probe: Path, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    run(["cp", "--reflink=auto", str(rootfs), str(output)], cwd=rootfs.parent)
+    command_file = output.parent / "debugfs.commands"
+    write_text(
+        command_file,
+        "\n".join(
+            [
+                "rm /root/syscall-probe",
+                f"write {probe} /root/syscall-probe",
+                "sif /root/syscall-probe mode 0100755",
+                "",
+            ]
+        ),
+    )
+    run(["debugfs", "-w", "-f", str(command_file), str(output)], cwd=output.parent)
+
+
+def write_qemu_config(path: Path, arch: str, disk_img: Path, timeout: int) -> None:
+    config = ARCHES[arch]
+    qemu_args = list(config.qemu_args)
+    qemu_args.extend(
+        [
+            "-device",
+            "virtio-blk-pci,drive=disk0",
+            "-drive",
+            f"id=disk0,if=none,format=raw,file={disk_img}",
+            "-device",
+            "virtio-net-pci,netdev=net0",
+            "-netdev",
+            "user,id=net0",
+        ]
+    )
+    rendered_args = ",\n".join(json.dumps(item) for item in qemu_args)
+    content = f"""args = [
+{rendered_args}
+]
+uefi = false
+to_bin = {str(config.to_bin).lower()}
+shell_prefix = "root@starry:"
+shell_init_cmd = "/root/syscall-probe"
+success_regex = ["(?m)^{PROBE_END}\\\\s*$"]
+fail_regex = ['(?i)\\bpanic(?:ked)?\\b']
+timeout = {timeout}
+"""
+    write_text(path, content)
+
+
+def run_starry_probe(
+    repo_root: Path,
+    arch: str,
+    qemu_config: Path,
+    rootfs: Path,
+) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            "cargo",
+            "xtask",
+            "starry",
+            "qemu",
+            "--arch",
+            arch,
+            "--qemu-config",
+            str(qemu_config),
+            "--rootfs",
+            str(rootfs),
+        ],
+        cwd=repo_root,
+        check=False,
+        capture=True,
+    )
+
+
+def print_summary(report: dict[str, Any]) -> None:
+    print(f"arch: {report['arch']}")
+    print(f"artifacts: {report['artifacts']['work_dir']}")
+    differences = report["differences"]
+    if not differences:
+        print("result: no syscall semantic differences detected")
+        return
+    print(f"result: {len(differences)} syscall semantic difference(s) detected")
+    for diff in differences:
+        print(f"- {diff['case']}")
+        print(f"  linux: {diff['linux']}")
+        print(f"  starry: {diff['starry']}")
+
+
+def discover_inside(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    arch = args.arch
+    if arch not in ARCHES:
+        raise SystemExit(f"unsupported arch {arch}; expected one of {', '.join(ARCHES)}")
+
+    out_root = repo_root / args.output_dir
+    work_dir = out_root / arch / "latest"
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    linux_bin, starry_bin = compile_probe(repo_root, work_dir, arch)
+    linux_run = run([str(linux_bin)], cwd=repo_root, check=True, capture=True)
+    write_text(work_dir / "linux.stdout", linux_run.stdout)
+    write_text(work_dir / "linux.stderr", linux_run.stderr)
+
+    base_rootfs = ensure_rootfs(repo_root, arch)
+    probe_rootfs = work_dir / f"rootfs-{arch}-probe.img"
+    inject_probe(base_rootfs, starry_bin, probe_rootfs)
+    qemu_config = work_dir / "qemu.toml"
+    write_qemu_config(qemu_config, arch, probe_rootfs, args.timeout)
+
+    starry_run = run_starry_probe(repo_root, arch, qemu_config, probe_rootfs)
+    starry_output = starry_run.stdout + starry_run.stderr
+    write_text(work_dir / "starry.stdout", starry_run.stdout)
+    write_text(work_dir / "starry.stderr", starry_run.stderr)
+
+    linux_cases = parse_cases(linux_run.stdout)
+    starry_cases = parse_cases(starry_output)
+    differences = compare_cases(linux_cases, starry_cases)
+    report = {
+        "arch": arch,
+        "returncode": {"starry_qemu": starry_run.returncode},
+        "linux": linux_cases,
+        "starry": starry_cases,
+        "differences": differences,
+        "markers": {
+            "starry_begin": PROBE_BEGIN in strip_ansi(starry_output),
+            "starry_end": PROBE_END in strip_ansi(starry_output),
+        },
+        "artifacts": {
+            "work_dir": str(work_dir),
+            "report": str(work_dir / "report.json"),
+            "qemu_config": str(qemu_config),
+            "rootfs": str(probe_rootfs),
+        },
+    }
+    write_text(work_dir / "report.json", json.dumps(report, indent=2, sort_keys=True))
+    print_summary(report)
+
+    if starry_run.returncode != 0:
+        return starry_run.returncode
+    if differences and args.fail_on_diff:
+        return 2
+    return 0
+
+
+def discover(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    if not args.no_docker and not is_inside_docker():
+        forwarded = [
+            "discover",
+            "--repo-root",
+            "/work",
+            "--arch",
+            args.arch,
+            "--timeout",
+            str(args.timeout),
+            "--output-dir",
+            args.output_dir,
+        ]
+        if args.fail_on_diff:
+            forwarded.append("--fail-on-diff")
+        forwarded.append("--no-docker")
+        return docker_reexec(repo_root, args.image, forwarded)
+    return discover_inside(args)
+
+
+def ui(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root)) if args.repo_root else script_repo_root()
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from ui_server import serve_ui
+
+    return serve_ui(repo_root, args.host, args.port, args.image, args.open)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="StarryOS syscall and qperf differential harness")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    doctor_parser = sub.add_parser("doctor", help="check Docker and harness prerequisites")
+    doctor_parser.add_argument("--repo-root")
+    doctor_parser.add_argument("--image", default=DEFAULT_IMAGE)
+    doctor_parser.set_defaults(func=doctor)
+
+    discover_parser = sub.add_parser("discover", help="run syscall probes against Linux and StarryOS")
+    discover_parser.add_argument("--repo-root")
+    discover_parser.add_argument("--arch", default="riscv64", choices=sorted(ARCHES))
+    discover_parser.add_argument("--image", default=DEFAULT_IMAGE)
+    discover_parser.add_argument("--timeout", type=int, default=120)
+    discover_parser.add_argument("--output-dir", default="target/starry-syscall-harness")
+    discover_parser.add_argument("--no-docker", action="store_true")
+    discover_parser.add_argument("--fail-on-diff", action="store_true")
+    discover_parser.set_defaults(func=discover)
+
+    perf_parser = sub.add_parser("perf-profile", help="run StarryOS qperf profiling in Docker")
+    perf_parser.add_argument("--repo-root")
+    perf_parser.add_argument("--arch", default="riscv64", choices=["riscv64", "loongarch64"])
+    perf_parser.add_argument("--image", default=DEFAULT_IMAGE)
+    perf_parser.add_argument("--timeout", type=int, default=20)
+    perf_parser.add_argument("--format", default="all", choices=["folded", "svg", "pprof", "all"])
+    perf_parser.add_argument("--freq", type=int, default=99)
+    perf_parser.add_argument("--max-depth", type=int, default=64)
+    perf_parser.add_argument("--mode", default="tb", choices=["tb", "insn"])
+    perf_parser.add_argument("--callchain", default="leaf", choices=["leaf", "fp", "logical"])
+    perf_parser.add_argument("--top", type=int, default=20)
+    perf_parser.add_argument("--min-percent", type=float, default=5.0)
+    perf_parser.add_argument("--symbol-style", default="full", choices=["full", "short", "module"])
+    perf_parser.add_argument("--focus")
+    perf_parser.add_argument("--no-truncate", action="store_true")
+    perf_parser.add_argument("--output-dir", default="target/starry-syscall-harness")
+    perf_parser.add_argument("--no-docker", action="store_true")
+    perf_parser.add_argument("--debug", action="store_true")
+    perf_parser.add_argument("--kernel-filter", action="store_true")
+    perf_parser.add_argument("--host-time", action="store_true")
+    perf_parser.add_argument("--host-perf", action="store_true")
+    perf_parser.add_argument(
+        "--host-perf-events",
+        default="task-clock,cycles,instructions,cache-references,cache-misses,context-switches,cpu-migrations,page-faults",
+    )
+    perf_parser.add_argument("--shell-init-cmd")
+    perf_parser.add_argument("--shell-prefix", default="root@starry:")
+    perf_parser.add_argument("--start-marker")
+    perf_parser.add_argument("--stop-marker")
+    perf_parser.add_argument("--workload-timeout", type=int)
+    perf_parser.add_argument("--qperf-metrics", action="store_true")
+    perf_parser.add_argument("--full-stack", action="store_true")
+    perf_parser.add_argument("--perf-debuginfo", action="store_true")
+    perf_parser.add_argument("--perf-force-frame-pointers", action="store_true")
+    perf_parser.add_argument("--qemu-arg", action="append", default=[])
+    perf_parser.set_defaults(func=perf_profile)
+
+    perf_post_parser = sub.add_parser("perf-postprocess", help="generate qperf report files from existing qperf artifacts")
+    perf_post_parser.add_argument("--repo-root")
+    perf_post_parser.add_argument("--arch", default="riscv64", choices=["riscv64", "loongarch64"])
+    perf_post_parser.add_argument("--work-dir", required=True)
+    perf_post_parser.add_argument("--qperf-dir", required=True)
+    perf_post_parser.add_argument("--profile-stdout")
+    perf_post_parser.add_argument("--profile-stderr")
+    perf_post_parser.add_argument("--returncode", type=int, default=0)
+    perf_post_parser.add_argument("--timeout", type=int, default=20)
+    perf_post_parser.add_argument("--format", default="all", choices=["folded", "svg", "pprof", "all"])
+    perf_post_parser.add_argument("--freq", type=int, default=99)
+    perf_post_parser.add_argument("--max-depth", type=int, default=128)
+    perf_post_parser.add_argument("--mode", default="tb", choices=["tb", "insn"])
+    perf_post_parser.add_argument("--callchain", default="leaf", choices=["leaf", "fp", "logical"])
+    perf_post_parser.add_argument("--top", type=int, default=80)
+    perf_post_parser.add_argument("--min-percent", type=float, default=0.3)
+    perf_post_parser.add_argument("--symbol-style", default="full", choices=["full", "short", "module"])
+    perf_post_parser.add_argument("--focus")
+    perf_post_parser.add_argument("--no-truncate", action="store_true")
+    perf_post_parser.add_argument("--debug", action="store_true")
+    perf_post_parser.add_argument("--kernel-filter", action="store_true")
+    perf_post_parser.add_argument("--host-time", action="store_true")
+    perf_post_parser.add_argument("--host-perf", action="store_true")
+    perf_post_parser.add_argument("--host-perf-events", default="task-clock,cycles,instructions,cache-references,cache-misses,context-switches,cpu-migrations,page-faults")
+    perf_post_parser.add_argument("--shell-init-cmd")
+    perf_post_parser.add_argument("--shell-prefix", default="root@starry:")
+    perf_post_parser.add_argument("--start-marker")
+    perf_post_parser.add_argument("--stop-marker")
+    perf_post_parser.add_argument("--workload-timeout", type=int)
+    perf_post_parser.add_argument("--qperf-metrics", action="store_true")
+    perf_post_parser.add_argument("--full-stack", action="store_true")
+    perf_post_parser.add_argument("--perf-debuginfo", action="store_true")
+    perf_post_parser.add_argument("--perf-force-frame-pointers", action="store_true")
+    perf_post_parser.add_argument("--qemu-arg", action="append", default=[])
+    perf_post_parser.set_defaults(func=perf_postprocess)
+
+    perf_diff_parser = sub.add_parser("perf-diff", help="compare two qperf folded stack outputs")
+    perf_diff_parser.add_argument("--repo-root")
+    perf_diff_parser.add_argument("--baseline", required=True)
+    perf_diff_parser.add_argument("--compare", required=True)
+    perf_diff_parser.add_argument("--top", type=int, default=20)
+    perf_diff_parser.add_argument("--output-dir", default="target/starry-syscall-harness")
+    perf_diff_parser.set_defaults(func=perf_diff)
+
+    perf_compare_parser = sub.add_parser("perf-compare", help="compare two qperf report.json/profile outputs")
+    perf_compare_parser.add_argument("--repo-root")
+    perf_compare_parser.add_argument("--baseline", required=True)
+    candidate_group = perf_compare_parser.add_mutually_exclusive_group(required=True)
+    candidate_group.add_argument("--candidate")
+    candidate_group.add_argument("--compare")
+    perf_compare_parser.add_argument("--top", type=int, default=20)
+    perf_compare_parser.add_argument("--name")
+    perf_compare_parser.add_argument("--output-dir", default="target/starry-syscall-harness")
+    perf_compare_parser.set_defaults(func=perf_compare)
+
+    ui_parser = sub.add_parser("ui", help="serve the optional local browser UI")
+    ui_parser.add_argument("--repo-root")
+    ui_parser.add_argument("--image", default=DEFAULT_IMAGE)
+    ui_parser.add_argument("--host", default="127.0.0.1")
+    ui_parser.add_argument("--port", type=int, default=8765)
+    ui_parser.add_argument("--open", action="store_true")
+    ui_parser.set_defaults(func=ui)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/starry-syscall-harness/knowledge_graph.py
+++ b/tools/starry-syscall-harness/knowledge_graph.py
@@ -1,0 +1,720 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from fnmatch import fnmatchcase
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+MAX_SCAN_FILES = 2600
+MAX_FILE_BYTES = 256 * 1024
+MAX_SYMBOLS_PER_NODE = 24
+MAX_HOT_FILES_PER_NODE = 10
+SYMBOL_RE = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?"
+    r"(?:(?:async|unsafe|const)\s+)?"
+    r"(?:(?:extern\s+\"[^\"]+\")\s+)?"
+    r"(?P<kind>fn|struct|enum|trait|impl|mod)\s+"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_:<>]*)?"
+)
+
+
+@dataclass(frozen=True)
+class KnowledgeNodeSpec:
+    id: str
+    label: str
+    layer: str
+    paths: tuple[str, ...]
+    keywords: tuple[str, ...]
+    summary: str
+    textbook: str
+    practice: str
+
+
+NODE_SPECS: tuple[KnowledgeNodeSpec, ...] = (
+    KnowledgeNodeSpec(
+        "starry_syscall",
+        "Linux syscall compatibility",
+        "Kernel API",
+        (
+            "os/StarryOS/kernel/src/syscall",
+            "tools/starry-syscall-harness/probes",
+            "components/axerrno",
+            "app-runlinuxapp/**",
+            "exercise-sysmap/**",
+        ),
+        ("syscall", "sys_read", "sys_write", "errno", "linux", "compat", "probe", "uapi"),
+        "Linux 兼容系统调用入口、参数校验、errno 映射和对拍探针。",
+        "系统调用是用户态进入内核态的受控门；课程里关注 trap、ABI、参数复制、错误码和副作用一致性。",
+        "StarryOS 通过 syscall 分发表和 harness Linux 对拍验证行为，修 syscall 时应优先让返回值、errno、文件状态和进程状态与 Linux 一致。",
+    ),
+    KnowledgeNodeSpec(
+        "task_process",
+        "Task / process lifecycle",
+        "Execution",
+        (
+            "components/starry-process",
+            "os/StarryOS/kernel/src/task",
+            "components/starry-signal",
+            "app-childtask/**",
+            "app-msgqueue/**",
+            "app-userprivilege/**",
+            "app-runlinuxapp/**",
+        ),
+        ("task", "process", "thread", "fork", "clone", "execve", "waitpid", "signal", "exit"),
+        "进程、线程、exec/wait/exit、signal 和 StarryOS 任务生命周期。",
+        "进程抽象连接地址空间、文件表、信号和调度实体；wait/exec/fork 是操作系统进程管理的核心接口。",
+        "相关代码通常同时影响 syscall 语义、调度等待、资源释放和 mm/file 表生命周期，改动后需要跑 syscall harness 和对应 qemu case。",
+    ),
+    KnowledgeNodeSpec(
+        "scheduler_sync",
+        "Scheduler / wait / synchronization",
+        "Execution",
+        (
+            "components/axsched",
+            "components/axpoll",
+            "components/kspin",
+            "components/kernel_guard",
+            "components/lockdep",
+            "app-childtask/**",
+            "app-msgqueue/**",
+            "app-fairsched/**",
+        ),
+        ("schedule", "scheduler", "wait", "waker", "mutex", "spin", "preempt", "poll", "lock", "condvar"),
+        "调度器、等待队列、poll/waker、锁和临界区。",
+        "课程里的调度与同步主题包括运行队列、阻塞/唤醒、临界区、死锁和优先级反转。",
+        "性能分析中 scheduler/wait/lock 热点常说明同步粒度或阻塞路径有问题；语义修复中要防止丢唤醒和错误持锁。",
+    ),
+    KnowledgeNodeSpec(
+        "memory_vm",
+        "Virtual memory / address space",
+        "Memory",
+        (
+            "components/starry-vm",
+            "os/StarryOS/kernel/src/mm",
+            "components/axcpu",
+            "components/someboot/src/mem",
+            "app-lazymapping/**",
+            "app-userprivilege/**",
+            "app-runlinuxapp/**",
+            "exercise-sysmap/**",
+        ),
+        ("memory", "vm", "vma", "page", "pte", "mmap", "munmap", "copy_from_user", "copy_to_user", "tlb"),
+        "虚拟内存、用户地址空间、页表、mmap 和用户态内存复制。",
+        "虚拟内存把进程地址空间映射到物理页；页表权限、缺页处理和用户/内核复制是安全边界。",
+        "改动时重点确认用户指针校验、页权限、跨页复制和生命周期；性能热点中 memory_set/drop 常对应地址空间释放或映射维护。",
+    ),
+    KnowledgeNodeSpec(
+        "allocator",
+        "Allocator / object lifetime",
+        "Memory",
+        ("modules/axalloc", "components/axklib", "components/linked_list_r4l", "exercise-altalloc/**", "exercise-hashmap/**"),
+        ("alloc", "allocator", "heap", "drop", "Arc", "Box", "Vec", "BTreeMap", "slab"),
+        "堆分配、集合生命周期、Arc/Box/Vec/BTreeMap 释放路径。",
+        "内核分配器负责管理有限物理内存；大量短生命周期对象会造成锁竞争、碎片和 cache miss。",
+        "qperf 中 allocator/drop 热点要结合调用栈判断来源，避免只替换分配器而忽略上层数据结构或批处理机会。",
+    ),
+    KnowledgeNodeSpec(
+        "vfs_io",
+        "VFS / file I/O",
+        "Storage",
+        (
+            "components/axfs-ng-vfs",
+            "components/axfs_crates",
+            "components/axio",
+            "os/StarryOS/kernel/src/fs",
+            "app-loadapp/**",
+            "exercise-ramfs-rename/**",
+            "exercise-sysmap/**",
+        ),
+        ("vfs", "file", "inode", "dentry", "read_at", "write_at", "open", "close", "fd", "pipe"),
+        "VFS 抽象、文件描述符、read/write/open/close 和通用 I/O 缓冲。",
+        "VFS 把系统调用与具体文件系统、设备和 pipe/socket 解耦；课程里关注文件描述符表、inode、路径解析和缓存。",
+        "I/O 性能任务要从 syscall 层沿 VFS 向下看，确认热点来自路径解析、缓存 miss、设备请求还是 copy。",
+    ),
+    KnowledgeNodeSpec(
+        "ext4_cache",
+        "rsext4 / block cache",
+        "Storage",
+        ("components/rsext4",),
+        ("ext4", "rsext4", "DataBlockCache", "Jbd2Dev", "cache", "readahead", "journal", "extent", "block"),
+        "rsext4 文件系统、data block cache、journal 包装设备和 ext4 元数据。",
+        "文件系统把文件偏移映射成磁盘块；缓存与预读利用局部性减少设备 I/O 次数。",
+        "本轮 virtio-blk 优化正落在这里：在 data block cache miss 时批量读取连续块，减少 4KiB 同步 virtqueue 请求。",
+    ),
+    KnowledgeNodeSpec(
+        "block_layer",
+        "Block layer / request queue",
+        "Storage",
+        (
+            "drivers/interface/rdif-block",
+            "drivers/blk/rd-block",
+            "drivers/ax-driver/src/block",
+            "app-readblk/**",
+            "app-loadapp/**",
+            "exercise-sysmap/**",
+        ),
+        ("block", "blk", "Block", "IQueue", "CmdQueue", "read_blocks", "submit_request", "request", "direct"),
+        "块设备接口、命令队列、同步/异步 read/write 请求封装。",
+        "块层把文件系统块请求转换为设备请求；队列深度和合并策略决定能否发挥设备并行性。",
+        "性能任务中应关注请求大小、同步等待、direct DMA 条件和 future/poll 路径，避免每 4KiB 都完整 kick/wait 一次。",
+    ),
+    KnowledgeNodeSpec(
+        "virtio_blk",
+        "virtio-blk driver",
+        "Device",
+        (
+            "drivers/ax-driver/src/virtio/block.rs",
+            "drivers/ax-driver/src/qperf_metrics.rs",
+            "app-readblk/**",
+            "app-loadapp/**",
+            "exercise-sysmap/**",
+        ),
+        ("virtio_blk", "VirtIOBlk", "virtqueue", "add_notify_wait_pop", "notify", "kick", "DMA", "queue depth"),
+        "StarryOS/ArceOS virtio-blk 适配、DMA buffer、virtqueue submit/wait/pop 和 qperf counters。",
+        "virtio 使用 virtqueue 在 guest/host 间传递描述符；性能关键是批量提交、减少 notify/kick、利用 queue depth。",
+        "qperf 已证明 blk 顺序读瓶颈是同步小 I/O 导致 add_notify_wait_pop/notify 过多；下一步可做 pending read 或真正异步队列化。",
+    ),
+    KnowledgeNodeSpec(
+        "net_stack",
+        "Network stack / socket path",
+        "Network",
+        ("drivers/ax-driver/src/net", "os/arceos/modules/axnet-ng", "os/StarryOS/kernel/src/net"),
+        ("net", "socket", "tcp", "udp", "rx", "tx", "packet", "recv", "send", "copy_within"),
+        "网络栈、socket syscall、RX/TX 数据路径和 packet buffer。",
+        "网络子系统把 socket API、协议栈和网卡驱动连接起来；吞吐常受 copy、buffer ownership 和锁影响。",
+        "后续 net 优化应重点验证 RX copy_within、TX staging copy、inflight 管理和 memcpy/memmove 分类是否下降。",
+    ),
+    KnowledgeNodeSpec(
+        "virtio_net",
+        "virtio-net driver",
+        "Device",
+        ("drivers/ax-driver/src/virtio/net.rs", "drivers/ax-driver/src/net", "drivers/interface"),
+        ("virtio_net", "VirtIONet", "rx", "tx", "copy_within", "staging", "BTreeMap", "inflight"),
+        "virtio-net RX/TX、staging copy、inflight descriptor 管理和 qperf counters。",
+        "virtio-net 同样基于 virtqueue；网络路径还要处理 buffer recycle、包边界和协议栈 ownership。",
+        "当前 counters 能看 RX/TX bytes、copy bytes 和 BTree/inflight 操作，适合做去 copy 和 BTreeMap 替换的 A/B。",
+    ),
+    KnowledgeNodeSpec(
+        "virtio_vsock",
+        "virtio-vsock / vhost-vsock",
+        "Device",
+        ("drivers/ax-driver/src/vsock", "os/arceos/modules/axnet-ng/src/device/vsock.rs"),
+        ("vsock", "vhost-vsock", "cid", "virtio_socket", "stream"),
+        "virtio-vsock/vhost-vsock 设备路径和环境依赖。",
+        "vsock 提供 guest/host 或 VM 间 socket-like 通信；实验依赖 host 暴露 `/dev/vhost-vsock`。",
+        "当前环境若缺 `/dev/vhost-vsock`，只能记录阻塞并给出补测命令，不能伪造 vsock 性能数据。",
+    ),
+    KnowledgeNodeSpec(
+        "interrupt_pci",
+        "PCI / interrupt / transport",
+        "Device",
+        (
+            "drivers/ax-driver/src/pci",
+            "drivers/intc",
+            "components/someboot/src/fdt",
+            "drivers/ax-driver/src/virtio",
+            "app-readpflash/**",
+            "app-readblk/**",
+            "app-loadapp/**",
+            "app-guest*/**",
+        ),
+        ("pci", "interrupt", "irq", "plic", "msix", "transport", "probe", "device tree", "fdt"),
+        "PCI/设备发现、中断控制器、virtio transport 和 probe 路径。",
+        "设备发现和中断把硬件资源映射给驱动；boot profile 中 PCI probe 热点不应污染 workload 数据面结论。",
+        "marker/window 的价值之一就是把 PCI probe 等启动成本从 blk/net workload 分析中排除。",
+    ),
+    KnowledgeNodeSpec(
+        "procfs_debug",
+        "procfs / debug observability",
+        "Observability",
+        ("os/StarryOS/kernel/src/pseudofs", "drivers/ax-driver/src/qperf_metrics.rs"),
+        ("procfs", "/proc", "qperf_metrics", "debug", "metric", "counter", "observability"),
+        "procfs debug 文件、qperf metrics 导出和 reset 机制。",
+        "操作系统常通过 procfs/sysfs/debugfs 暴露运行时状态；这些接口应稳定、低侵入、默认关闭重成本逻辑。",
+        "`/proc/qperf_metrics` 是本轮把 driver counters 合入 report.json 的最小侵入出口。",
+    ),
+    KnowledgeNodeSpec(
+        "qperf_tooling",
+        "qperf / harness / GUI",
+        "Tooling",
+        ("tools/qperf", "tools/starry-syscall-harness", "scripts/axbuild/src/starry/perf.rs", "docs/qperf"),
+        ("qperf", "harness", "flamegraph", "callchain", "marker", "perf-profile", "perf-compare", "knowledge graph"),
+        "qperf plugin/analyzer、harness CLI/MCP/UI、cargo starry perf 和报告生成。",
+        "性能工具链对应课程里的 measurement methodology：明确实验窗口、采样偏差、归一化指标和 A/B 对照。",
+        "本功能也属于这里：GUI 自动扫描仓库，生成 OS 知识图谱，把当前 coding 任务映射到相关子系统并给出讲解。",
+    ),
+    KnowledgeNodeSpec(
+        "unikernel_runtime",
+        "ArceOS unikernel apps",
+        "Curriculum",
+        (
+            "README.md",
+            "report.md",
+            "app-helloworld/**",
+            "app-collections/**",
+            "app-readpflash/**",
+            "app-childtask/**",
+            "app-msgqueue/**",
+            "app-fairsched/**",
+            "app-readblk/**",
+            "app-loadapp/**",
+            "exercise-printcolor/**",
+            "exercise-hashmap/**",
+            "exercise-altalloc/**",
+        ),
+        ("unikernel", "arceos", "axstd", "helloworld", "collections", "childtask", "msgqueue", "fairsched", "exercise"),
+        "ArceOS unikernel 教学应用和基础练习，覆盖启动、标准库、任务、调度、设备和集合/分配器。",
+        "Unikernel 把应用和内核库静态组合成一个专用系统镜像，教学重点是最小运行时、库化 OS 和按需启用组件。",
+        "tg-arceos-tutorial 中 `app-*` 和基础 `exercise-*` 就是从 Hello World 到任务、调度、设备、分配器的渐进式 unikernel 课程。",
+    ),
+    KnowledgeNodeSpec(
+        "monolithic_user",
+        "Monolithic kernel / user apps",
+        "Curriculum",
+        (
+            "app-userprivilege/**",
+            "app-lazymapping/**",
+            "app-runlinuxapp/**",
+            "exercise-sysmap/**",
+        ),
+        ("monolithic", "user", "privilege", "syscall", "elf", "mmap", "page fault", "linux app", "musl"),
+        "ArceOS 单体内核式用户态支持：特权级切换、用户地址空间、ELF 加载、Linux syscall 和 mmap。",
+        "单体内核课程主题包括用户/内核态隔离、系统调用 ABI、缺页异常、进程地址空间和可执行文件加载。",
+        "教程中的 `app-userprivilege`、`app-lazymapping`、`app-runlinuxapp` 和 `exercise-sysmap` 组成用户态支持学习路径。",
+    ),
+    KnowledgeNodeSpec(
+        "hypervisor_guest",
+        "Hypervisor / guest execution",
+        "Curriculum",
+        (
+            "app-guestmode/**",
+            "app-guestaspace/**",
+            "app-guestvdev/**",
+            "app-guestmonolithickernel/**",
+        ),
+        ("hypervisor", "guest", "vm exit", "nested page fault", "npf", "h-extension", "el2", "svm", "vcpu"),
+        "ArceOS hypervisor 教程应用，覆盖 guest mode、guest address space、virtual device 和 guest monolithic kernel。",
+        "虚拟化课程主题包括 guest/host 隔离、二阶段地址转换、VM entry/exit、虚拟设备和架构扩展。",
+        "教程中的 `app-guest*` 系列展示从最小 guest 到地址空间、虚拟设备、完整 guest kernel 的递进。",
+    ),
+    KnowledgeNodeSpec(
+        "tutorial_packaging",
+        "Tutorial bundle / scripts",
+        "Tooling",
+        ("README.md", "Cargo.toml", "report.md", "scripts/**", "bundle/**", "src/**"),
+        ("bundle", "cargo clone", "extract", "compress", "batch", "exercise", "app", "tutorial", "report"),
+        "教程聚合仓库的打包、解包、批量运行脚本和实验报告。",
+        "教学仓库工程化关注可复现分发、离线解包、批量验证和实验报告证据链。",
+        "维护该仓库时，根 README、`scripts/extract_crates.sh`、`scripts/compress_crates.sh`、批量脚本和 `report.md` 是首要入口。",
+    ),
+    KnowledgeNodeSpec(
+        "build_test",
+        "Build / rootfs / qemu tests",
+        "Tooling",
+        ("scripts/axbuild", "scripts/test", "test-suit", ".cargo", "*/xtask/**", "*/scripts/test.sh", "*/configs/**"),
+        ("cargo starry", "xtask", "rootfs", "qemu", "clippy", "test", "build", "target"),
+        "构建、rootfs、QEMU 运行、测试套件和 clippy/fmt 验证入口。",
+        "OS 工程实践离不开可复现构建和自动化测试；实验环境差异会直接影响性能结论。",
+        "StarryOS/QEMU/qperf 任务优先走 cargo starry 或 harness 入口，代码改动后要用 targeted clippy 和 smoke test 验证。",
+    ),
+)
+
+
+EDGES: tuple[tuple[str, str, str], ...] = (
+    ("starry_syscall", "task_process", "syscall creates/waits/exits tasks"),
+    ("starry_syscall", "memory_vm", "user pointer validation and mmap"),
+    ("starry_syscall", "vfs_io", "read/write/open route into VFS"),
+    ("task_process", "scheduler_sync", "tasks block, wake and schedule"),
+    ("task_process", "memory_vm", "process owns address space"),
+    ("vfs_io", "ext4_cache", "filesystem implementation"),
+    ("ext4_cache", "block_layer", "cached blocks become block device I/O"),
+    ("block_layer", "virtio_blk", "block requests submit to virtio-blk"),
+    ("virtio_blk", "interrupt_pci", "virtio transport and PCI probe"),
+    ("net_stack", "virtio_net", "net device backend"),
+    ("virtio_net", "interrupt_pci", "virtio transport and IRQ"),
+    ("net_stack", "virtio_vsock", "socket-like communication path"),
+    ("virtio_vsock", "interrupt_pci", "virtio/vhost transport"),
+    ("qperf_tooling", "procfs_debug", "metrics are exported through procfs"),
+    ("qperf_tooling", "virtio_blk", "qperf counters and categories explain blk bottlenecks"),
+    ("qperf_tooling", "virtio_net", "qperf counters and categories explain net bottlenecks"),
+    ("qperf_tooling", "build_test", "cargo starry perf and smoke scripts"),
+    ("build_test", "starry_syscall", "syscall harness validates Linux compatibility"),
+    ("tutorial_packaging", "unikernel_runtime", "bundle contains unikernel apps and exercises"),
+    ("tutorial_packaging", "monolithic_user", "bundle contains monolithic user-mode exercises"),
+    ("tutorial_packaging", "hypervisor_guest", "bundle contains hypervisor tutorial apps"),
+    ("unikernel_runtime", "scheduler_sync", "task and scheduling apps exercise axtask"),
+    ("unikernel_runtime", "allocator", "collections and allocator exercises teach memory management"),
+    ("monolithic_user", "starry_syscall", "Linux-like user apps depend on syscall ABI"),
+    ("monolithic_user", "memory_vm", "mmap and lazy mapping depend on address spaces"),
+    ("hypervisor_guest", "memory_vm", "guest address spaces depend on page tables"),
+    ("hypervisor_guest", "interrupt_pci", "guest devices and exits depend on traps and devices"),
+)
+
+
+IGNORE_PARTS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "target",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    ".mypy_cache",
+}
+
+SCAN_SUFFIXES = {".rs", ".toml", ".py", ".md", ".c", ".h", ".json"}
+
+
+def build_knowledge_graph(repo_root: Path, *, task: str = "", granularity: str = "coarse") -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    granularity = granularity if granularity in {"coarse", "fine"} else "coarse"
+    files = collect_files(repo_root)
+    task_context = current_task_context(repo_root, task)
+    nodes = [scan_node(repo_root, spec, files, task_context) for spec in NODE_SPECS]
+    nodes_by_id = {node["id"]: node for node in nodes}
+    for node in nodes:
+        node["degree"] = sum(1 for source, target, _ in EDGES if source == node["id"] or target == node["id"])
+    focused = select_focus_nodes(nodes)
+    focus_ids = {node["id"] for node in focused}
+    for node in nodes:
+        node["focus"] = node["id"] in focus_ids
+
+    return {
+        "generated_at": time.time(),
+        "repo_root": str(repo_root),
+        "granularity": granularity,
+        "scan": {
+            "files_seen": len(files),
+            "max_files": MAX_SCAN_FILES,
+            "suffixes": sorted(SCAN_SUFFIXES),
+        },
+        "task": {
+            "query": task,
+            "context_terms": task_context["terms"],
+            "changed_files": task_context["changed_files"],
+            "last_commit": task_context["last_commit"],
+            "focus_node_ids": [node["id"] for node in focused],
+        },
+        "graph": {
+            "nodes": nodes,
+            "edges": [
+                {
+                    "source": source,
+                    "target": target,
+                    "label": label,
+                    "focus": source in focus_ids or target in focus_ids,
+                }
+                for source, target, label in EDGES
+                if source in nodes_by_id and target in nodes_by_id
+            ],
+        },
+        "focus": build_focus_explanation(focused, task_context, granularity),
+    }
+
+
+def collect_files(repo_root: Path) -> list[Path]:
+    collected: list[Path] = []
+    roots = [repo_root / name for name in ("os", "components", "drivers", "scripts", "tools", "test-suit", "docs")]
+    roots.extend(sorted(repo_root.glob("app-*")))
+    roots.extend(sorted(repo_root.glob("exercise-*")))
+    for file_name in ("README.md", "Cargo.toml", "report.md", "book.toml", "src/SUMMARY.md", "src/lib.rs"):
+        path = repo_root / file_name
+        if path.is_file() and path.suffix in SCAN_SUFFIXES:
+            collected.append(path.relative_to(repo_root))
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if len(collected) >= MAX_SCAN_FILES:
+                return collected
+            if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+                continue
+            rel = path.relative_to(repo_root)
+            if any(part in IGNORE_PARTS for part in rel.parts):
+                continue
+            collected.append(rel)
+    return collected
+
+
+def scan_node(
+    repo_root: Path,
+    spec: KnowledgeNodeSpec,
+    files: list[Path],
+    task_context: dict[str, Any],
+) -> dict[str, Any]:
+    matched = [path for path in files if path_matches_spec(path, spec)]
+    total_lines = 0
+    symbols: list[dict[str, Any]] = []
+    hot_files: list[dict[str, Any]] = []
+    keyword_hits: dict[str, int] = {keyword: 0 for keyword in spec.keywords}
+
+    for rel in matched:
+        absolute = repo_root / rel
+        try:
+            size = absolute.stat().st_size
+        except OSError:
+            continue
+        if size > MAX_FILE_BYTES:
+            hot_files.append({"path": rel.as_posix(), "lines": None, "symbols": 0, "note": "skipped large file"})
+            continue
+        try:
+            text = absolute.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        lines = text.splitlines()
+        total_lines += len(lines)
+        file_symbols = extract_symbols(rel, lines)
+        for keyword in spec.keywords:
+            keyword_hits[keyword] += count_keyword(text, keyword)
+        if file_symbols and len(symbols) < MAX_SYMBOLS_PER_NODE:
+            symbols.extend(file_symbols[: max(0, MAX_SYMBOLS_PER_NODE - len(symbols))])
+        if len(hot_files) < MAX_HOT_FILES_PER_NODE:
+            hot_files.append({"path": rel.as_posix(), "lines": len(lines), "symbols": len(file_symbols)})
+
+    score = score_node(spec, matched, task_context, keyword_hits)
+    return {
+        "id": spec.id,
+        "label": spec.label,
+        "layer": spec.layer,
+        "summary": spec.summary,
+        "textbook": spec.textbook,
+        "practice": spec.practice,
+        "paths": list(spec.paths),
+        "keywords": list(spec.keywords),
+        "stats": {
+            "files": len(matched),
+            "lines": total_lines,
+            "symbols": len(symbols),
+            "keyword_hits": sum(keyword_hits.values()),
+        },
+        "hot_files": hot_files,
+        "symbols": symbols[:MAX_SYMBOLS_PER_NODE],
+        "task_score": score,
+        "matched_changed_files": [
+            path for path in task_context["changed_files"] if path_matches_spec(Path(path), spec)
+        ],
+    }
+
+
+def path_matches_spec(path: Path, spec: KnowledgeNodeSpec) -> bool:
+    rel = path.as_posix()
+    for base in spec.paths:
+        pattern = base.rstrip("/")
+        if any(char in pattern for char in "*?[]"):
+            if fnmatchcase(rel, pattern) or fnmatchcase(rel, pattern.rstrip("*").rstrip("/") + "/*"):
+                return True
+            continue
+        if rel == pattern or rel.startswith(pattern + "/"):
+            return True
+    return False
+
+
+def extract_symbols(path: Path, lines: list[str]) -> list[dict[str, Any]]:
+    symbols: list[dict[str, Any]] = []
+    for line_no, line in enumerate(lines, start=1):
+        match = SYMBOL_RE.match(line)
+        if not match:
+            continue
+        name = match.group("name") or "<anonymous>"
+        if name == "<anonymous>" and match.group("kind") != "impl":
+            continue
+        symbols.append(
+            {
+                "kind": match.group("kind"),
+                "name": name,
+                "path": path.as_posix(),
+                "line": line_no,
+            }
+        )
+        if len(symbols) >= 8:
+            break
+    return symbols
+
+
+def count_keyword(text: str, keyword: str) -> int:
+    if not keyword:
+        return 0
+    return text.lower().count(keyword.lower())
+
+
+def current_task_context(repo_root: Path, task: str) -> dict[str, Any]:
+    changed_files = unique_lines(
+        git_output(repo_root, ["diff", "--name-only"]) + git_output(repo_root, ["diff", "--cached", "--name-only"])
+    )
+    if not changed_files:
+        changed_files = unique_lines(git_output(repo_root, ["show", "--name-only", "--format=", "-1"]))
+    last_commit = " ".join(git_output(repo_root, ["log", "-1", "--pretty=%h %s"])[:1])
+    terms = tokenize(" ".join([task, last_commit, " ".join(changed_files)]))
+    return {
+        "raw": task,
+        "terms": terms[:80],
+        "changed_files": changed_files[:80],
+        "last_commit": last_commit,
+    }
+
+
+def git_output(repo_root: Path, args: list[str]) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def unique_lines(lines: list[str]) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for line in lines:
+        if line not in seen:
+            seen.add(line)
+            unique.append(line)
+    return unique
+
+
+def tokenize(text: str) -> list[str]:
+    tokens = re.findall(r"[A-Za-z0-9_./:-]+|[\u4e00-\u9fff]{2,}", text.lower())
+    stop = {"src", "rs", "toml", "md", "the", "and", "for", "with", "this", "that"}
+    return [token for token in tokens if len(token) >= 2 and token not in stop]
+
+
+def score_node(
+    spec: KnowledgeNodeSpec,
+    matched_files: list[Path],
+    task_context: dict[str, Any],
+    keyword_hits: dict[str, int],
+) -> int:
+    score = 0
+    terms = task_context["terms"]
+    changed_files = [Path(path) for path in task_context["changed_files"]]
+    for changed in changed_files:
+        if path_matches_spec(changed, spec):
+            score += 30
+    for term in terms:
+        normalized_term = normalize_token(term)
+        if any(
+            normalized_term in normalize_token(keyword) or normalize_token(keyword) in normalized_term
+            for keyword in spec.keywords
+        ):
+            score += 8
+        if normalized_term in normalize_token(spec.id) or normalized_term in normalize_token(spec.label):
+            score += 6
+        if any(normalized_term in normalize_token(path.as_posix()) for path in matched_files[:80]):
+            score += 2
+    score += min(sum(keyword_hits.values()) // 200, 10)
+    return score
+
+
+def normalize_token(text: str) -> str:
+    return text.lower().replace("-", "_").replace("/", "_").replace("::", "_")
+
+
+def select_focus_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    scored = sorted(nodes, key=lambda item: (item["task_score"], item["stats"]["files"]), reverse=True)
+    focus = [node for node in scored if node["task_score"] > 0][:5]
+    if focus:
+        return focus
+    return scored[:3]
+
+
+def build_focus_explanation(
+    focused: list[dict[str, Any]],
+    task_context: dict[str, Any],
+    granularity: str,
+) -> dict[str, Any]:
+    if not focused:
+        return {
+            "summary": "未识别到明确的 OS 子系统焦点。",
+            "code_explanation": [],
+            "os_explanation": [],
+            "coding_guidance": [],
+        }
+
+    summary = "当前任务最可能落在：" + "、".join(node["label"] for node in focused[:3])
+    code_explanation: list[str] = []
+    os_explanation: list[str] = []
+    coding_guidance: list[str] = []
+
+    for node in focused:
+        changed = node.get("matched_changed_files") or []
+        hot_files = [item["path"] for item in node.get("hot_files", [])[:5]]
+        symbol_names = [
+            f"{item['kind']} {item['name']} ({item['path']}:{item['line']})"
+            for item in node.get("symbols", [])[:8]
+        ]
+        if granularity == "fine":
+            code_explanation.append(
+                "\n".join(
+                    [
+                        f"{node['label']}: {node['summary']}",
+                        f"相关目录: {', '.join(node['paths'])}",
+                        f"当前任务命中文件: {', '.join(changed) if changed else '无未提交命中，参考最近提交或任务关键词'}",
+                        f"代表文件: {', '.join(hot_files) if hot_files else '未扫描到文件'}",
+                        f"代表符号: {', '.join(symbol_names) if symbol_names else '未提取到 Rust 符号'}",
+                    ]
+                )
+            )
+        else:
+            code_explanation.append(
+                f"{node['label']}: {node['summary']} 主要看 {', '.join(node['paths'][:3])}。"
+            )
+        os_explanation.append(f"{node['label']}: 课本知识是“{node['textbook']}”；在本仓库里的实践对应是“{node['practice']}”")
+        coding_guidance.extend(node_guidance(node))
+
+    if task_context["changed_files"]:
+        coding_guidance.insert(0, "当前工作区/最近提交涉及文件：" + ", ".join(task_context["changed_files"][:8]))
+    return {
+        "summary": summary,
+        "code_explanation": code_explanation,
+        "os_explanation": os_explanation,
+        "coding_guidance": unique_lines(coding_guidance)[:12],
+    }
+
+
+def node_guidance(node: dict[str, Any]) -> list[str]:
+    node_id = node["id"]
+    if node_id == "virtio_blk":
+        return [
+            "先看 qperf counters：notify/kick、add_notify_wait_pop、queue depth，再决定是减少请求数还是做异步队列化。",
+            "不要把 driver-visible queue depth 直接说成 ring-level 精确统计。",
+        ]
+    if node_id == "ext4_cache":
+        return [
+            "文件系统缓存改动需要同时验证顺序读、随机读和 cache 容量边界。",
+            "readahead 优化应观察 blk request 数下降是否抵消额外读放大。",
+        ]
+    if node_id == "starry_syscall":
+        return [
+            "系统调用语义修复应以 Linux probe 输出为准，避免弱化测试来隐藏差异。",
+            "改动后优先跑对应 arch 的 harness discover 或最小 qemu case。",
+        ]
+    if node_id == "memory_vm":
+        return [
+            "用户指针、页权限和跨页复制是内存相关 bug 的高风险点。",
+            "涉及地址空间生命周期时关注 drop 路径和调度切换时机。",
+        ]
+    if node_id in {"virtio_net", "net_stack"}:
+        return [
+            "net 优化先用 qperf counters 验证 RX/TX bytes、copy bytes 和 inflight 操作。",
+            "copy 优化需要确认 buffer ownership 和协议栈生命周期没有被破坏。",
+        ]
+    if node_id == "qperf_tooling":
+        return [
+            "工具链改动后至少做 py_compile、前端语法检查和一个 API smoke test。",
+            "报告里区分真实采样、后处理过滤、逻辑归因和 instrumentation counters。",
+        ]
+    return ["改动前先沿知识图谱查看上游 API、下游调用者和对应测试入口。"]

--- a/tools/starry-syscall-harness/mcp_server.py
+++ b/tools/starry-syscall-harness/mcp_server.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PROTOCOL_VERSION = "2024-11-05"
+
+
+def repo_root_from(start: Path) -> Path:
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "Cargo.toml").exists() and (candidate / "os/StarryOS").exists():
+            return candidate
+    raise SystemExit(f"cannot find tgoskits repo root from {start}")
+
+
+def script_repo_root() -> Path:
+    return repo_root_from(Path(__file__).resolve())
+
+
+def read_message() -> dict[str, Any] | None:
+    headers: dict[str, str] = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        key, _, value = line.decode("ascii").partition(":")
+        headers[key.lower()] = value.strip()
+    length = int(headers.get("content-length", "0"))
+    if length <= 0:
+        return None
+    return json.loads(sys.stdin.buffer.read(length).decode("utf-8"))
+
+
+def write_message(message: dict[str, Any]) -> None:
+    body = json.dumps(message, separators=(",", ":")).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"))
+    sys.stdout.buffer.write(body)
+    sys.stdout.buffer.flush()
+
+
+def tool_schema() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "starry_syscall_doctor",
+            "description": "Check Docker image and toolchain availability for the StarryOS syscall harness.",
+            "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "starry_syscall_discover",
+            "description": "Run Linux-vs-StarryOS syscall probes in Docker and return the differential report.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "arch": {
+                        "type": "string",
+                        "enum": ["riscv64", "aarch64", "loongarch64", "x86_64"],
+                        "default": "riscv64",
+                    },
+                    "timeout": {"type": "integer", "default": 120, "minimum": 1},
+                    "fail_on_diff": {"type": "boolean", "default": False},
+                },
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "starry_perf_profile",
+            "description": "Run StarryOS qperf profiling in Docker and return hotspot/fix-candidate report paths.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "arch": {
+                        "type": "string",
+                        "enum": ["riscv64", "loongarch64"],
+                        "default": "riscv64",
+                    },
+                    "timeout": {"type": "integer", "default": 20, "minimum": 1},
+                    "format": {
+                        "type": "string",
+                        "enum": ["folded", "svg", "pprof", "all"],
+                        "default": "all",
+                    },
+                    "freq": {"type": "integer", "default": 99, "minimum": 1},
+                    "max_depth": {"type": "integer", "default": 64, "minimum": 1},
+                    "mode": {"type": "string", "enum": ["tb", "insn"], "default": "tb"},
+                    "top": {"type": "integer", "default": 20, "minimum": 1},
+                    "min_percent": {"type": "number", "default": 5.0, "minimum": 0.0},
+                    "debug": {"type": "boolean", "default": False},
+                    "kernel_filter": {"type": "boolean", "default": False},
+                    "host_time": {"type": "boolean", "default": False},
+                    "host_perf": {"type": "boolean", "default": False},
+                    "host_perf_events": {
+                        "type": "string",
+                        "default": "task-clock,cycles,instructions,cache-references,cache-misses,context-switches,cpu-migrations,page-faults",
+                    },
+                    "shell_init_cmd": {"type": "string"},
+                    "shell_prefix": {"type": "string", "default": "root@starry:"},
+                    "qemu_args": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "default": [],
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "starry_perf_diff",
+            "description": "Compare two qperf folded stack outputs or profile directories.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "baseline": {"type": "string"},
+                    "compare": {"type": "string"},
+                    "top": {"type": "integer", "default": 20, "minimum": 1},
+                },
+                "required": ["baseline", "compare"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "starry_harness_ui_command",
+            "description": "Return the command for launching the optional local browser UI.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "host": {"type": "string", "default": "127.0.0.1"},
+                    "port": {"type": "integer", "default": 8765, "minimum": 0},
+                    "open": {"type": "boolean", "default": False},
+                },
+                "additionalProperties": False,
+            },
+        },
+    ]
+
+
+def run_harness(repo: Path, args: list[str]) -> tuple[int, str]:
+    cmd = ["python3", str(repo / "tools/starry-syscall-harness/harness.py"), *args]
+    result = subprocess.run(cmd, cwd=repo, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = result.stdout
+    if result.stderr:
+        output += "\n[stderr]\n" + result.stderr
+    return result.returncode, output[-12000:]
+
+
+def handle_tool_call(repo: Path, params: dict[str, Any]) -> dict[str, Any]:
+    name = params.get("name")
+    arguments = params.get("arguments") or {}
+    if name == "starry_syscall_doctor":
+        code, output = run_harness(repo, ["doctor", "--repo-root", str(repo)])
+    elif name == "starry_syscall_discover":
+        command = [
+            "discover",
+            "--repo-root",
+            str(repo),
+            "--arch",
+            arguments.get("arch", "riscv64"),
+            "--timeout",
+            str(arguments.get("timeout", 120)),
+        ]
+        if arguments.get("fail_on_diff", False):
+            command.append("--fail-on-diff")
+        code, output = run_harness(repo, command)
+    elif name == "starry_perf_profile":
+        command = [
+            "perf-profile",
+            "--repo-root",
+            str(repo),
+            "--arch",
+            arguments.get("arch", "riscv64"),
+            "--timeout",
+            str(arguments.get("timeout", 20)),
+            "--format",
+            arguments.get("format", "all"),
+            "--freq",
+            str(arguments.get("freq", 99)),
+            "--max-depth",
+            str(arguments.get("max_depth", 64)),
+            "--mode",
+            arguments.get("mode", "tb"),
+            "--top",
+            str(arguments.get("top", 20)),
+            "--min-percent",
+            str(arguments.get("min_percent", 5.0)),
+        ]
+        if arguments.get("debug", False):
+            command.append("--debug")
+        if arguments.get("kernel_filter", False):
+            command.append("--kernel-filter")
+        if arguments.get("host_time", False):
+            command.append("--host-time")
+        if arguments.get("host_perf", False):
+            command.append("--host-perf")
+            command.extend(
+                [
+                    "--host-perf-events",
+                    arguments.get(
+                        "host_perf_events",
+                        "task-clock,cycles,instructions,cache-references,cache-misses,context-switches,cpu-migrations,page-faults",
+                    ),
+                ]
+            )
+        if arguments.get("shell_init_cmd"):
+            command.extend(["--shell-init-cmd", arguments["shell_init_cmd"]])
+        if arguments.get("shell_prefix"):
+            command.extend(["--shell-prefix", arguments["shell_prefix"]])
+        for qemu_arg in arguments.get("qemu_args", []):
+            command.append(f"--qemu-arg={qemu_arg}")
+        code, output = run_harness(repo, command)
+    elif name == "starry_perf_diff":
+        command = [
+            "perf-diff",
+            "--repo-root",
+            str(repo),
+            "--baseline",
+            arguments["baseline"],
+            "--compare",
+            arguments["compare"],
+            "--top",
+            str(arguments.get("top", 20)),
+        ]
+        code, output = run_harness(repo, command)
+    elif name == "starry_harness_ui_command":
+        host = arguments.get("host", "127.0.0.1")
+        port = arguments.get("port", 8765)
+        command = [
+            "python3",
+            str(repo / "tools/starry-syscall-harness/harness.py"),
+            "ui",
+            "--repo-root",
+            str(repo),
+            "--host",
+            str(host),
+            "--port",
+            str(port),
+        ]
+        if arguments.get("open", False):
+            command.append("--open")
+        output = " ".join(command) + f"\nURL: http://{host}:{port}/"
+        code = 0
+    else:
+        return {
+            "content": [{"type": "text", "text": f"unknown tool: {name}"}],
+            "isError": True,
+        }
+    return {"content": [{"type": "text", "text": output}], "isError": code != 0}
+
+
+def serve(repo: Path) -> None:
+    while True:
+        message = read_message()
+        if message is None:
+            return
+        message_id = message.get("id")
+        method = message.get("method")
+        if method == "initialize":
+            write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": {
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": {"tools": {"listChanged": False}},
+                        "serverInfo": {
+                            "name": "starry-syscall-harness",
+                            "version": "0.1.0",
+                        },
+                    },
+                }
+            )
+        elif method == "tools/list":
+            write_message({"jsonrpc": "2.0", "id": message_id, "result": {"tools": tool_schema()}})
+        elif method == "tools/call":
+            write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": handle_tool_call(repo, message.get("params") or {}),
+                }
+            )
+        elif method == "ping":
+            write_message({"jsonrpc": "2.0", "id": message_id, "result": {}})
+        elif message_id is not None:
+            write_message({"jsonrpc": "2.0", "id": message_id, "result": {}})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MCP server for the StarryOS syscall harness")
+    parser.add_argument("--repo", default=None)
+    args = parser.parse_args()
+    repo = repo_root_from(Path(args.repo)) if args.repo else script_repo_root()
+    serve(repo)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/starry-syscall-harness/probes/syscall_probe.c
+++ b/tools/starry-syscall-harness/probes/syscall_probe.c
@@ -1,0 +1,194 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#ifndef SYS_memfd_create
+#if defined(__x86_64__)
+#define SYS_memfd_create 319
+#elif defined(__riscv)
+#define SYS_memfd_create 279
+#elif defined(__aarch64__)
+#define SYS_memfd_create 279
+#elif defined(__loongarch__)
+#define SYS_memfd_create 279
+#endif
+#endif
+
+#ifndef SYS_pwritev2
+#if defined(__x86_64__)
+#define SYS_pwritev2 328
+#elif defined(__riscv)
+#define SYS_pwritev2 287
+#elif defined(__aarch64__)
+#define SYS_pwritev2 287
+#elif defined(__loongarch__)
+#define SYS_pwritev2 287
+#endif
+#endif
+
+static int saved_errno(long ret)
+{
+    return ret < 0 ? errno : 0;
+}
+
+static void case_pipe2_invalid_flags(void)
+{
+    int fds[2] = {-1, -1};
+    errno = 0;
+    long ret = syscall(SYS_pipe2, fds, 0x80000000U);
+    int err = saved_errno(ret);
+    int created = ret == 0;
+    if (created) {
+        close(fds[0]);
+        close(fds[1]);
+    }
+
+    printf("CASE pipe2_invalid_flags ret=%ld errno=%d created=%d\n", ret, err, created);
+}
+
+static void case_eventfd2_invalid_flags(void)
+{
+    errno = 0;
+    long ret = syscall(SYS_eventfd2, 0, 0x80000000U);
+    int err = saved_errno(ret);
+    int created = ret >= 0;
+    if (created) {
+        close((int)ret);
+    }
+
+    printf("CASE eventfd2_invalid_flags ret=%ld errno=%d created=%d\n", ret, err, created);
+}
+
+static void case_memfd_create_invalid_flags(void)
+{
+#ifdef SYS_memfd_create
+    errno = 0;
+    long ret = syscall(SYS_memfd_create, "starry-probe", 0x80000000U);
+    int err = saved_errno(ret);
+    int created = ret >= 0;
+    if (created) {
+        close((int)ret);
+    }
+
+    printf("CASE memfd_create_invalid_flags ret=%ld errno=%d created=%d\n", ret, err, created);
+#else
+    printf("CASE memfd_create_invalid_flags skipped=1\n");
+#endif
+}
+
+static void case_dup3_same_fd(void)
+{
+    int fd = open("/dev/null", O_RDONLY);
+    if (fd < 0) {
+        printf("CASE dup3_same_fd setup_errno=%d\n", errno);
+        return;
+    }
+
+    errno = 0;
+    long ret = syscall(SYS_dup3, fd, fd, O_CLOEXEC);
+    int err = saved_errno(ret);
+    close(fd);
+
+    printf("CASE dup3_same_fd ret=%ld errno=%d\n", ret, err);
+}
+
+static void case_pwritev2_writes_data(void)
+{
+#ifdef SYS_pwritev2
+    char path[96];
+    snprintf(path, sizeof(path), "/tmp/starry-pwritev2-%ld", (long)getpid());
+    int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0600);
+    if (fd < 0) {
+        printf("CASE pwritev2_writes_data setup_errno=%d\n", errno);
+        return;
+    }
+
+    const char data[] = "XY";
+    struct iovec iov = {
+        .iov_base = (void *)data,
+        .iov_len = 2,
+    };
+    errno = 0;
+    long ret = syscall(SYS_pwritev2, fd, &iov, 1, 0, 0, 0);
+    int err = saved_errno(ret);
+
+    char read_buf[3] = {0, 0, 0};
+    lseek(fd, 0, SEEK_SET);
+    ssize_t read_ret = read(fd, read_buf, 2);
+    int read_err = read_ret < 0 ? errno : 0;
+    close(fd);
+    unlink(path);
+
+    printf(
+        "CASE pwritev2_writes_data ret=%ld errno=%d read_ret=%ld read_errno=%d data=%02x%02x\n",
+        ret,
+        err,
+        (long)read_ret,
+        read_err,
+        (unsigned char)read_buf[0],
+        (unsigned char)read_buf[1]);
+#else
+    printf("CASE pwritev2_writes_data skipped=1\n");
+#endif
+}
+
+static void case_ftruncate_readonly_fd(void)
+{
+    char path[96];
+    snprintf(path, sizeof(path), "/tmp/starry-ftruncate-%ld", (long)getpid());
+    int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY, 0600);
+    if (fd < 0) {
+        printf("CASE ftruncate_readonly_fd setup_errno=%d\n", errno);
+        return;
+    }
+    if (write(fd, "abc", 3) != 3) {
+        int setup_errno = errno;
+        close(fd);
+        unlink(path);
+        printf("CASE ftruncate_readonly_fd setup_errno=%d\n", setup_errno);
+        return;
+    }
+    close(fd);
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        int setup_errno = errno;
+        unlink(path);
+        printf("CASE ftruncate_readonly_fd setup_errno=%d\n", setup_errno);
+        return;
+    }
+
+    errno = 0;
+    int ret = ftruncate(fd, 1);
+    int err = saved_errno(ret);
+    int not_open_for_write = ret == -1 && (err == EBADF || err == EINVAL);
+    close(fd);
+    unlink(path);
+
+    printf("CASE ftruncate_readonly_fd ret=%d not_open_for_write=%d\n",
+           ret,
+           not_open_for_write);
+}
+
+int main(void)
+{
+    puts("STARRY_SYSCALL_PROBE_BEGIN");
+    case_pipe2_invalid_flags();
+    case_eventfd2_invalid_flags();
+    case_memfd_create_invalid_flags();
+    case_dup3_same_fd();
+    case_pwritev2_writes_data();
+    case_ftruncate_readonly_fd();
+    puts("STARRY_SYSCALL_PROBE_END");
+    fflush(stdout);
+    return 0;
+}

--- a/tools/starry-syscall-harness/scripts/qperf-smoke.sh
+++ b/tools/starry-syscall-harness/scripts/qperf-smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case_name=${1:-boot}
+
+case "$case_name" in
+  boot)
+    cargo starry perf --case boot --timeout 20
+    ;;
+  blk-read)
+    cargo starry perf \
+      --case blk-read \
+      --start-marker QPERF_BEGIN \
+      --stop-marker QPERF_END \
+      --workload-timeout 45 \
+      --workload 'echo QPERF_BEGIN:blk-read; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; echo QPERF_END:blk-read'
+    ;;
+  blk-read-metrics)
+    cargo starry perf \
+      --case blk-read-metrics \
+      --qperf-metrics \
+      --start-marker QPERF_BEGIN \
+      --stop-marker QPERF_END \
+      --workload-timeout 45 \
+      --workload 'echo reset > /proc/qperf_metrics; echo QPERF_BEGIN:blk-read-metrics; dd if=/usr/bin/lto-dump of=/dev/null bs=64k; cat /proc/qperf_metrics; echo QPERF_END:blk-read-metrics'
+    ;;
+  compare-self)
+    python3 tools/starry-syscall-harness/harness.py perf-compare \
+      --baseline target/qperf/blk-read/perf/riscv64/latest/report.json \
+      --candidate target/qperf/blk-read/perf/riscv64/latest/report.json \
+      --name blk-self-smoke \
+      --output-dir target/qperf/blk-read/compare-self
+    ;;
+  *)
+    cat >&2 <<'EOF'
+usage: tools/starry-syscall-harness/scripts/qperf-smoke.sh [boot|blk-read|blk-read-metrics|compare-self]
+EOF
+    exit 2
+    ;;
+esac

--- a/tools/starry-syscall-harness/ui_server.py
+++ b/tools/starry-syscall-harness/ui_server.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import mimetypes
+import shlex
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+import uuid
+import webbrowser
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from knowledge_graph import build_knowledge_graph
+
+
+DEFAULT_OUTPUT_DIR = "target/starry-syscall-harness"
+SYSCALL_ARCHES = ("aarch64", "loongarch64", "riscv64", "x86_64")
+PERF_ARCHES = ("loongarch64", "riscv64")
+PERF_FORMATS = ("all", "folded", "pprof", "svg")
+PERF_MODES = ("insn", "tb")
+MAX_LOG_LINES = 500
+MAX_REQUEST_BYTES = 1_000_000
+MAX_TEXT_FIELD_CHARS = 8192
+MAX_QEMU_ARGS = 256
+MAX_QEMU_ARG_CHARS = 4096
+
+
+class ApiError(Exception):
+    def __init__(self, status: HTTPStatus, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+@dataclass
+class Job:
+    id: str
+    kind: str
+    command: list[str]
+    log_path: Path
+    report_path: Path | None
+    created_at: float = field(default_factory=time.time)
+    started_at: float | None = None
+    finished_at: float | None = None
+    status: str = "queued"
+    returncode: int | None = None
+    output_tail: list[str] = field(default_factory=list)
+
+    def append_output(self, line: str) -> None:
+        self.output_tail.append(line.rstrip("\n"))
+        if len(self.output_tail) > MAX_LOG_LINES:
+            del self.output_tail[: len(self.output_tail) - MAX_LOG_LINES]
+
+    def to_json(self) -> dict[str, Any]:
+        duration = None
+        if self.started_at is not None:
+            end = self.finished_at if self.finished_at is not None else time.time()
+            duration = round(end - self.started_at, 2)
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "status": self.status,
+            "returncode": self.returncode,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "duration_sec": duration,
+            "command": self.command,
+            "log_path": str(self.log_path),
+            "report_path": str(self.report_path) if self.report_path else None,
+            "report_exists": bool(self.report_path and self.report_path.exists()),
+            "output": "\n".join(self.output_tail),
+        }
+
+
+class HarnessUiState:
+    def __init__(self, repo_root: Path, image: str) -> None:
+        self.repo_root = repo_root.resolve()
+        self.image = image
+        self.script = self.repo_root / "tools/starry-syscall-harness/harness.py"
+        self.web_root = self.repo_root / "tools/starry-syscall-harness/web"
+        self.artifact_root = self.repo_root / DEFAULT_OUTPUT_DIR
+        self.log_root = self.artifact_root / "ui/jobs"
+        self.log_root.mkdir(parents=True, exist_ok=True)
+        self.lock = threading.Lock()
+        self.jobs: dict[str, Job] = {}
+        self.knowledge_cache: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    def active_job(self) -> Job | None:
+        for job in self.jobs.values():
+            if job.status in {"queued", "running"}:
+                return job
+        return None
+
+    def status(self) -> dict[str, Any]:
+        with self.lock:
+            jobs = sorted(self.jobs.values(), key=lambda item: item.created_at, reverse=True)
+            active = self.active_job()
+        return {
+            "repo_root": str(self.repo_root),
+            "image": self.image,
+            "server_time": time.time(),
+            "active_job": active.to_json() if active else None,
+            "reports": {
+                "syscall": {arch: self.report_summary("syscall", arch) for arch in SYSCALL_ARCHES},
+                "perf": {arch: self.report_summary("perf", arch) for arch in PERF_ARCHES},
+                "perf_diff": self.report_summary("perf-diff", None),
+            },
+            "jobs": [job.to_json() for job in jobs[:20]],
+        }
+
+    def start_job(self, payload: dict[str, Any]) -> Job:
+        kind = require_choice(payload.get("kind"), ("doctor", "discover", "perf-profile", "perf-diff"), "kind")
+        with self.lock:
+            active = self.active_job()
+            if active:
+                raise ApiError(HTTPStatus.CONFLICT, f"job {active.id} is still {active.status}")
+            command, report_path = self.build_command(kind, payload)
+            job_id = uuid.uuid4().hex[:12]
+            job = Job(
+                id=job_id,
+                kind=kind,
+                command=command,
+                log_path=self.log_root / f"{job_id}.log",
+                report_path=report_path,
+            )
+            self.jobs[job_id] = job
+        thread = threading.Thread(target=self.run_job, args=(job,), daemon=True)
+        thread.start()
+        return job
+
+    def build_command(self, kind: str, payload: dict[str, Any]) -> tuple[list[str], Path | None]:
+        base = [sys.executable, str(self.script), kind, "--repo-root", str(self.repo_root)]
+        if kind == "doctor":
+            return base + ["--image", self.image], None
+
+        if kind == "discover":
+            arch = require_choice(payload.get("arch", "riscv64"), SYSCALL_ARCHES, "arch")
+            timeout = require_int(payload.get("timeout", 120), "timeout", minimum=1, maximum=3600)
+            command = [
+                *base,
+                "--arch",
+                arch,
+                "--image",
+                self.image,
+                "--timeout",
+                str(timeout),
+                "--output-dir",
+                DEFAULT_OUTPUT_DIR,
+            ]
+            if bool(payload.get("fail_on_diff", False)):
+                command.append("--fail-on-diff")
+            return command, self.syscall_report_path(arch)
+
+        if kind == "perf-profile":
+            arch = require_choice(payload.get("arch", "riscv64"), PERF_ARCHES, "arch")
+            timeout = require_int(payload.get("timeout", 20), "timeout", minimum=1, maximum=3600)
+            perf_format = require_choice(payload.get("format", "all"), PERF_FORMATS, "format")
+            freq = require_int(payload.get("freq", 99), "freq", minimum=1, maximum=100000)
+            max_depth = require_int(payload.get("max_depth", 64), "max_depth", minimum=1, maximum=1024)
+            mode = require_choice(payload.get("mode", "tb"), PERF_MODES, "mode")
+            top = require_int(payload.get("top", 20), "top", minimum=1, maximum=200)
+            min_percent = require_float(payload.get("min_percent", 5.0), "min_percent", minimum=0.0, maximum=100.0)
+            host_perf_events = optional_text(payload.get("host_perf_events"), "host_perf_events")
+            shell_init_cmd = optional_text(payload.get("shell_init_cmd"), "shell_init_cmd")
+            shell_prefix = optional_text(payload.get("shell_prefix"), "shell_prefix")
+            qemu_args = parse_qemu_args(payload.get("qemu_args"))
+            command = [
+                *base,
+                "--arch",
+                arch,
+                "--image",
+                self.image,
+                "--timeout",
+                str(timeout),
+                "--format",
+                perf_format,
+                "--freq",
+                str(freq),
+                "--max-depth",
+                str(max_depth),
+                "--mode",
+                mode,
+                "--top",
+                str(top),
+                "--min-percent",
+                str(min_percent),
+                "--output-dir",
+                DEFAULT_OUTPUT_DIR,
+            ]
+            if bool(payload.get("debug", False)):
+                command.append("--debug")
+            if bool(payload.get("kernel_filter", False)):
+                command.append("--kernel-filter")
+            if bool(payload.get("host_time", False)):
+                command.append("--host-time")
+            if bool(payload.get("host_perf", False)):
+                command.append("--host-perf")
+                if host_perf_events is not None:
+                    command.extend(["--host-perf-events", host_perf_events])
+            if shell_init_cmd is not None:
+                command.extend(["--shell-init-cmd", shell_init_cmd])
+            if shell_prefix is not None:
+                command.extend(["--shell-prefix", shell_prefix])
+            for qemu_arg in qemu_args:
+                command.append(f"--qemu-arg={qemu_arg}")
+            return command, self.perf_report_path(arch)
+
+        baseline = self.resolve_repo_path(str(payload.get("baseline", "")), required=True)
+        compare = self.resolve_repo_path(str(payload.get("compare", "")), required=True)
+        top = require_int(payload.get("top", 20), "top", minimum=1, maximum=200)
+        command = [
+            *base,
+            "--baseline",
+            str(baseline),
+            "--compare",
+            str(compare),
+            "--top",
+            str(top),
+            "--output-dir",
+            DEFAULT_OUTPUT_DIR,
+        ]
+        return command, self.perf_diff_report_path()
+
+    def run_job(self, job: Job) -> None:
+        with self.lock:
+            job.status = "running"
+            job.started_at = time.time()
+        job.log_path.parent.mkdir(parents=True, exist_ok=True)
+        returncode = 1
+        try:
+            with job.log_path.open("w", encoding="utf-8", errors="replace") as log_file:
+                process = subprocess.Popen(
+                    job.command,
+                    cwd=self.repo_root,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                )
+                assert process.stdout is not None
+                for line in process.stdout:
+                    log_file.write(line)
+                    log_file.flush()
+                    with self.lock:
+                        job.append_output(line)
+                returncode = process.wait()
+        except Exception as exc:  # noqa: BLE001 - surface unexpected worker failures in the UI.
+            with self.lock:
+                job.append_output(f"ui worker error: {exc}")
+        finally:
+            with self.lock:
+                job.returncode = returncode
+                job.finished_at = time.time()
+                job.status = "succeeded" if returncode == 0 else "failed"
+
+    def get_job(self, job_id: str) -> Job:
+        with self.lock:
+            job = self.jobs.get(job_id)
+        if not job:
+            raise ApiError(HTTPStatus.NOT_FOUND, f"unknown job {job_id}")
+        return job
+
+    def load_report(self, kind: str, arch: str | None) -> dict[str, Any]:
+        path = self.report_path(kind, arch)
+        if not path.exists():
+            raise ApiError(HTTPStatus.NOT_FOUND, f"report not found: {path}")
+        report = read_json(path)
+        if not isinstance(report, dict):
+            raise ApiError(HTTPStatus.INTERNAL_SERVER_ERROR, f"report is not a JSON object: {path}")
+        report["_ui"] = {
+            "report_path": str(path),
+            "report_url": self.file_url(path),
+            "artifacts": self.artifact_state(report.get("artifacts", {})),
+        }
+        return report
+
+    def load_knowledge_graph(
+        self,
+        task: str,
+        granularity: str,
+        *,
+        scan_root: str,
+        refresh: bool,
+    ) -> dict[str, Any]:
+        task = task.strip()
+        if len(task) > MAX_TEXT_FIELD_CHARS:
+            raise ApiError(HTTPStatus.BAD_REQUEST, f"task must be at most {MAX_TEXT_FIELD_CHARS} characters")
+        if granularity not in {"coarse", "fine"}:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "granularity must be coarse or fine")
+        root = self.resolve_knowledge_root(scan_root)
+        cache_key = (str(root), task, granularity)
+        with self.lock:
+            cached = self.knowledge_cache.get(cache_key)
+        if cached is not None and not refresh:
+            return cached
+        graph = build_knowledge_graph(root, task=task, granularity=granularity)
+        with self.lock:
+            self.knowledge_cache[cache_key] = graph
+        return graph
+
+    def resolve_knowledge_root(self, raw_path: str) -> Path:
+        if not raw_path.strip():
+            return self.repo_root
+        path = Path(raw_path.strip())
+        if not path.is_absolute():
+            path = self.repo_root / path
+        resolved = path.resolve(strict=False)
+        allowed_roots = (self.repo_root, self.repo_root.parent)
+        if not any(is_relative_to(resolved, allowed) for allowed in allowed_roots):
+            raise ApiError(
+                HTTPStatus.BAD_REQUEST,
+                f"knowledge graph scan root must stay under {self.repo_root} or {self.repo_root.parent}",
+            )
+        if not resolved.is_dir():
+            raise ApiError(HTTPStatus.BAD_REQUEST, f"knowledge graph scan root is not a directory: {resolved}")
+        return resolved
+
+    def artifact_state(self, artifacts: Any) -> dict[str, dict[str, Any]]:
+        if not isinstance(artifacts, dict):
+            return {}
+        state: dict[str, dict[str, Any]] = {}
+        for name, value in artifacts.items():
+            if not isinstance(value, str):
+                continue
+            try:
+                path = self.resolve_repo_path(value, required=False)
+            except ApiError:
+                continue
+            state[name] = {
+                "path": str(path),
+                "exists": path.exists(),
+                "is_file": path.is_file(),
+                "url": self.file_url(path) if path.is_file() else None,
+            }
+        return state
+
+    def report_summary(self, kind: str, arch: str | None) -> dict[str, Any]:
+        path = self.report_path(kind, arch)
+        summary: dict[str, Any] = {"path": str(path), "exists": path.exists()}
+        if not path.exists():
+            return summary
+        summary["mtime"] = path.stat().st_mtime
+        try:
+            report = read_json(path)
+            if kind == "syscall":
+                summary["differences"] = len(report.get("differences", []))
+                summary["markers"] = report.get("markers", {})
+            elif kind == "perf":
+                summary["result"] = report.get("result")
+                summary["samples"] = report.get("hotspots", {}).get("total_samples")
+                summary["fix_candidates"] = len(report.get("fix_candidates", []))
+                summary["host_elapsed_seconds"] = report.get("host_time_metrics", {}).get("elapsed_seconds")
+            elif kind == "perf-diff":
+                summary["top_changes"] = len(report.get("top_changes", []))
+        except (OSError, json.JSONDecodeError):
+            summary["error"] = "failed to read report"
+        return summary
+
+    def report_path(self, kind: str, arch: str | None) -> Path:
+        if kind == "syscall":
+            if not arch:
+                raise ApiError(HTTPStatus.BAD_REQUEST, "arch is required")
+            return self.syscall_report_path(require_choice(arch, SYSCALL_ARCHES, "arch"))
+        if kind == "perf":
+            if not arch:
+                raise ApiError(HTTPStatus.BAD_REQUEST, "arch is required")
+            return self.perf_report_path(require_choice(arch, PERF_ARCHES, "arch"))
+        if kind == "perf-diff":
+            return self.perf_diff_report_path()
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"unsupported report kind {kind}")
+
+    def syscall_report_path(self, arch: str) -> Path:
+        return self.artifact_root / arch / "latest/report.json"
+
+    def perf_report_path(self, arch: str) -> Path:
+        return self.artifact_root / "perf" / arch / "latest/report.json"
+
+    def perf_diff_report_path(self) -> Path:
+        return self.artifact_root / "perf-diff/report.json"
+
+    def resolve_repo_path(self, raw_path: str, *, required: bool) -> Path:
+        if not raw_path:
+            if required:
+                raise ApiError(HTTPStatus.BAD_REQUEST, "path is required")
+            return self.repo_root
+        path = Path(raw_path)
+        if path.is_absolute() and len(path.parts) >= 2 and path.parts[1] == "work":
+            path = self.repo_root.joinpath(*path.parts[2:])
+        elif not path.is_absolute():
+            path = self.repo_root / path
+        resolved = path.resolve(strict=False)
+        try:
+            resolved.relative_to(self.repo_root)
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, f"path escapes repo root: {raw_path}") from exc
+        if required and not resolved.exists():
+            raise ApiError(HTTPStatus.BAD_REQUEST, f"path does not exist: {resolved}")
+        return resolved
+
+    def resolve_artifact_file(self, raw_path: str) -> Path:
+        path = self.resolve_repo_path(raw_path, required=True)
+        try:
+            path.relative_to(self.artifact_root)
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.FORBIDDEN, "only harness artifacts can be served") from exc
+        if not path.is_file():
+            raise ApiError(HTTPStatus.NOT_FOUND, f"artifact is not a file: {path}")
+        return path
+
+    @staticmethod
+    def file_url(path: Path) -> str:
+        return "/api/file?path=" + urllib.parse.quote(str(path))
+
+
+def require_choice(value: Any, choices: tuple[str, ...], name: str) -> str:
+    if not isinstance(value, str) or value not in choices:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must be one of {', '.join(choices)}")
+    return value
+
+
+def require_int(value: Any, name: str, *, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must be an integer") from exc
+    if parsed < minimum or parsed > maximum:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must be between {minimum} and {maximum}")
+    return parsed
+
+
+def require_float(value: Any, name: str, *, minimum: float, maximum: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must be a number") from exc
+    if parsed < minimum or parsed > maximum:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must be between {minimum:g} and {maximum:g}")
+    return parsed
+
+
+def optional_text(value: Any, name: str, *, maximum: int = MAX_TEXT_FIELD_CHARS) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must be a string")
+    text = value.strip()
+    if not text:
+        return None
+    if len(text) > maximum:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must be at most {maximum} characters")
+    if "\x00" in text:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must not contain NUL bytes")
+    return text
+
+
+def parse_qemu_args(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        args = [require_qemu_arg(item, f"qemu_args[{index}]") for index, item in enumerate(value)]
+        return check_qemu_args([arg for arg in args if arg])
+    if not isinstance(value, str):
+        raise ApiError(HTTPStatus.BAD_REQUEST, "qemu_args must be a string or an array of strings")
+
+    text = optional_text(value, "qemu_args")
+    if text is None:
+        return []
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if len(lines) > 1:
+        return check_qemu_args([require_qemu_arg(line, "qemu_args") for line in lines])
+    try:
+        args = [require_qemu_arg(arg, "qemu_args") for arg in shlex.split(text, comments=False, posix=True)]
+        return check_qemu_args(args)
+    except ValueError as exc:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"qemu_args shell-like parse failed: {exc}") from exc
+
+
+def require_qemu_arg(value: Any, name: str) -> str:
+    if not isinstance(value, str):
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} must be a string")
+    arg = value.strip()
+    if not arg:
+        return ""
+    if len(arg) > MAX_QEMU_ARG_CHARS:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} entries must be at most {MAX_QEMU_ARG_CHARS} characters")
+    if "\x00" in arg or "\n" in arg or "\r" in arg:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"{name} entries must be single-line strings without NUL bytes")
+    return arg
+
+
+def check_qemu_args(args: list[str]) -> list[str]:
+    if len(args) > MAX_QEMU_ARGS:
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"qemu_args must contain at most {MAX_QEMU_ARGS} arguments")
+    return args
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
+
+
+def make_handler(state: HarnessUiState) -> type[BaseHTTPRequestHandler]:
+    class HarnessRequestHandler(BaseHTTPRequestHandler):
+        server_version = "StarryHarnessUI/1.0"
+
+        def do_GET(self) -> None:
+            try:
+                parsed = urllib.parse.urlparse(self.path)
+                if parsed.path == "/api/status":
+                    self.send_json(state.status())
+                    return
+                if parsed.path.startswith("/api/jobs/"):
+                    job_id = parsed.path.rsplit("/", 1)[-1]
+                    self.send_json(state.get_job(job_id).to_json())
+                    return
+                if parsed.path == "/api/report":
+                    query = urllib.parse.parse_qs(parsed.query)
+                    kind = query.get("kind", [""])[0]
+                    arch = query.get("arch", [None])[0]
+                    self.send_json(state.load_report(kind, arch))
+                    return
+                if parsed.path == "/api/knowledge-graph":
+                    query = urllib.parse.parse_qs(parsed.query)
+                    task = query.get("task", [""])[0]
+                    granularity = query.get("granularity", ["coarse"])[0]
+                    scan_root = query.get("repo_root", [""])[0]
+                    refresh = query.get("refresh", ["0"])[0] in {"1", "true", "yes"}
+                    self.send_json(
+                        state.load_knowledge_graph(task, granularity, scan_root=scan_root, refresh=refresh)
+                    )
+                    return
+                if parsed.path == "/api/file":
+                    query = urllib.parse.parse_qs(parsed.query)
+                    path = query.get("path", [""])[0]
+                    self.send_file(state.resolve_artifact_file(path))
+                    return
+                self.send_static(parsed.path)
+            except ApiError as exc:
+                self.send_json({"error": exc.message}, status=exc.status)
+            except Exception as exc:  # noqa: BLE001 - return useful local UI diagnostics.
+                self.send_json({"error": str(exc)}, status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        def do_POST(self) -> None:
+            try:
+                parsed = urllib.parse.urlparse(self.path)
+                if parsed.path != "/api/jobs":
+                    raise ApiError(HTTPStatus.NOT_FOUND, "unknown endpoint")
+                payload = self.read_json_body()
+                job = state.start_job(payload)
+                self.send_json(job.to_json(), status=HTTPStatus.ACCEPTED)
+            except ApiError as exc:
+                self.send_json({"error": exc.message}, status=exc.status)
+            except Exception as exc:  # noqa: BLE001 - return useful local UI diagnostics.
+                self.send_json({"error": str(exc)}, status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        def read_json_body(self) -> dict[str, Any]:
+            length_text = self.headers.get("Content-Length", "0")
+            try:
+                length = int(length_text)
+            except ValueError as exc:
+                raise ApiError(HTTPStatus.BAD_REQUEST, "invalid Content-Length") from exc
+            if length > MAX_REQUEST_BYTES:
+                raise ApiError(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "request body is too large")
+            raw = self.rfile.read(length)
+            try:
+                payload = json.loads(raw.decode("utf-8") if raw else "{}")
+            except json.JSONDecodeError as exc:
+                raise ApiError(HTTPStatus.BAD_REQUEST, "request body must be JSON") from exc
+            if not isinstance(payload, dict):
+                raise ApiError(HTTPStatus.BAD_REQUEST, "request body must be a JSON object")
+            return payload
+
+        def send_static(self, path: str) -> None:
+            if path == "/":
+                target = state.web_root / "index.html"
+            else:
+                relative = path.lstrip("/")
+                if "/" in relative:
+                    raise ApiError(HTTPStatus.NOT_FOUND, "static file not found")
+                target = state.web_root / relative
+            resolved = target.resolve(strict=False)
+            try:
+                resolved.relative_to(state.web_root)
+            except ValueError as exc:
+                raise ApiError(HTTPStatus.NOT_FOUND, "static file not found") from exc
+            if not resolved.is_file():
+                raise ApiError(HTTPStatus.NOT_FOUND, "static file not found")
+            self.send_file(resolved, cache_static=True)
+
+        def send_file(self, path: Path, *, cache_static: bool = False) -> None:
+            content_type = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+            data = path.read_bytes()
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Cache-Control", "max-age=60" if cache_static else "no-store")
+            self.end_headers()
+            self.wfile.write(data)
+
+        def send_json(self, payload: Any, *, status: HTTPStatus = HTTPStatus.OK) -> None:
+            data = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, fmt: str, *args: Any) -> None:
+            sys.stderr.write("[harness-ui] " + fmt % args + "\n")
+
+    return HarnessRequestHandler
+
+
+def serve_ui(repo_root: Path, host: str, port: int, image: str, open_browser: bool) -> int:
+    state = HarnessUiState(repo_root, image)
+    handler = make_handler(state)
+    server = ThreadingHTTPServer((host, port), handler)
+    url = f"http://{host}:{server.server_port}/"
+    print(f"StarryOS harness UI: {url}", flush=True)
+    print("Press Ctrl-C to stop.", flush=True)
+    if open_browser:
+        threading.Timer(0.3, lambda: webbrowser.open(url)).start()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopping StarryOS harness UI.", flush=True)
+    finally:
+        server.server_close()
+    return 0

--- a/tools/starry-syscall-harness/web/app.js
+++ b/tools/starry-syscall-harness/web/app.js
@@ -1,0 +1,826 @@
+const state = {
+  activeJobId: null,
+  pollTimer: null,
+  currentTab: "syscall",
+  knowledgeGraph: null,
+  selectedKnowledgeNode: null,
+};
+
+const $ = (id) => document.getElementById(id);
+
+async function api(path, options = {}) {
+  const response = await fetch(path, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload.error || `${response.status} ${response.statusText}`);
+  }
+  return payload;
+}
+
+function selectValue(id) {
+  return $(id).value;
+}
+
+function numberValue(id) {
+  return Number($(id).value);
+}
+
+function checked(id) {
+  return $(id).checked;
+}
+
+function textValue(id) {
+  return $(id).value.trim();
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function jsonCell(value) {
+  if (value === null || value === undefined) {
+    return '<span class="muted">missing</span>';
+  }
+  return `<code>${escapeHtml(JSON.stringify(value))}</code>`;
+}
+
+function setBusy(isBusy) {
+  document.querySelectorAll("button").forEach((button) => {
+    if (button.id !== "refresh-job" && button.id !== "refresh-all") {
+      button.disabled = isBusy;
+    }
+  });
+}
+
+function setActiveState(text, status = "idle") {
+  const pill = $("active-state");
+  pill.textContent = text;
+  pill.className = `status-pill ${status}`;
+}
+
+function summaryItem(label, value, className = "") {
+  return `
+    <div class="summary-item">
+      <div class="summary-label">${escapeHtml(label)}</div>
+      <div class="summary-value ${className}">${escapeHtml(value)}</div>
+    </div>`;
+}
+
+const SAMPLE_METRICS = [
+  { label: "Samples", keys: ["samples", "total_samples", "folded_stack_lines", "sample_count"] },
+  { label: "Dropped", keys: ["dropped", "dropped_samples", "samples_dropped", "dropped_count"] },
+  { label: "Sample failures", keys: ["sample_failures", "sample_failures_total", "failed_samples", "failures"] },
+];
+
+const PLUGIN_COUNTER_METRICS = [
+  ...SAMPLE_METRICS,
+  { label: "Exec insns", keys: ["executed_instructions"] },
+  { label: "Exec blocks", keys: ["executed_blocks"] },
+  { label: "Translated insns", keys: ["translated_instructions"] },
+  { label: "Translated blocks", keys: ["translated_blocks"] },
+  { label: "Callbacks", keys: ["execute_callbacks"] },
+];
+
+const HOST_METRICS = [
+  ...SAMPLE_METRICS,
+  { label: "Elapsed", keys: ["elapsed", "elapsed_sec", "elapsed_seconds", "elapsed_s", "wall_time", "wall_time_sec"] },
+  { label: "User", keys: ["user", "user_sec", "user_seconds", "user_time"] },
+  { label: "Sys", keys: ["sys", "sys_sec", "sys_seconds", "system", "system_sec", "system_time"] },
+  { label: "Max RSS", keys: ["max_rss", "max_rss_kb", "maximum_resident_set_size"] },
+];
+
+const HOST_PERF_METRICS = [
+  ...SAMPLE_METRICS,
+  { label: "Cycles", keys: ["cycles", "cpu-cycles", "cpu_cycles"] },
+  { label: "Instructions", keys: ["instructions"] },
+  { label: "Cache misses", keys: ["cache-misses", "cache_misses"] },
+  { label: "Task clock", keys: ["task-clock", "task_clock", "task_clock_ms"] },
+];
+
+const EXTRA_METRIC_LABELS = {
+  build_profile: "Build profile",
+  flamegraph_generated: "Flamegraph",
+  folded_stack_lines: "Samples",
+  frequency_hz: "Frequency",
+  kernel_filter: "Kernel filter",
+  max_rss: "Max RSS",
+  max_rss_kb: "Max RSS",
+  max_stack_depth: "Max depth",
+  plugin_summary: "Plugin summary",
+  qperf_format_version: "qperf format",
+  queue_size: "Queue size",
+  sampling_mode: "Mode",
+  timeout_seconds: "Timeout",
+  translated_blocks: "Translated blocks",
+  translated_instructions: "Translated insns",
+  executed_blocks: "Executed blocks",
+  executed_instructions: "Executed insns",
+  execute_callbacks: "Callbacks",
+};
+
+function metricObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
+
+function flattenPerfEvents(source) {
+  const object = metricObject(source);
+  if (!object) {
+    return null;
+  }
+  const flattened = {};
+  for (const [name, event] of Object.entries(object.events || {})) {
+    if (event && typeof event === "object" && event.value !== null && event.value !== undefined) {
+      flattened[name] = event.unit ? `${event.value} ${event.unit}` : event.value;
+    }
+  }
+  if (object.scope) {
+    flattened.scope = object.scope;
+  }
+  if (object.note) {
+    flattened.note = object.note;
+  }
+  if (Array.isArray(object.errors) && object.errors.length) {
+    flattened.errors = object.errors.join("; ");
+  }
+  return Object.keys(flattened).length ? flattened : object;
+}
+
+function metricLookup(source, keys) {
+  if (!source) {
+    return null;
+  }
+  for (const key of keys) {
+    if (
+      Object.prototype.hasOwnProperty.call(source, key) &&
+      source[key] !== null &&
+      source[key] !== undefined &&
+      source[key] !== ""
+    ) {
+      return { key, value: source[key] };
+    }
+  }
+  return null;
+}
+
+function firstMetric(sources, keys) {
+  for (const source of sources) {
+    const match = metricLookup(metricObject(source), keys);
+    if (match) {
+      return match.value;
+    }
+  }
+  return null;
+}
+
+function formatMetricValue(value) {
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? value.toLocaleString()
+      : value.toLocaleString(undefined, { maximumFractionDigits: 3 });
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  if (value && typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function humanMetricLabel(key) {
+  return EXTRA_METRIC_LABELS[key] || key.replaceAll("_", " ").replaceAll("-", " ");
+}
+
+function isExtraMetric(key, value) {
+  if (value === null || value === undefined || value === "" || typeof value === "object") {
+    return false;
+  }
+  const lower = key.toLowerCase();
+  return !(
+    lower.includes("path") ||
+    lower.endsWith("_dir") ||
+    ["analyzer", "flamegraph", "folded_stack", "kernel_elf", "plugin", "raw_samples"].includes(lower)
+  );
+}
+
+async function refreshStatus() {
+  const status = await api("/api/status");
+  $("repo-root").textContent = status.repo_root;
+  if (status.active_job) {
+    state.activeJobId = status.active_job.id;
+    setActiveState(`${status.active_job.kind}: ${status.active_job.status}`, "running");
+    setBusy(true);
+    schedulePoll();
+  } else {
+    setActiveState("idle");
+    setBusy(false);
+  }
+  return status;
+}
+
+async function loadReport(kind, arch) {
+  const query = new URLSearchParams({ kind });
+  if (arch) {
+    query.set("arch", arch);
+  }
+  return api(`/api/report?${query.toString()}`);
+}
+
+async function refreshReports() {
+  await Promise.allSettled([refreshSyscallReport(), refreshPerfReport(), refreshDiffReport()]);
+}
+
+async function refreshKnowledgeGraph(refresh = false) {
+  try {
+    $("kg-meta").textContent = "scanning repository";
+    const query = new URLSearchParams({
+      task: textValue("kg-task"),
+      repo_root: textValue("kg-repo-root"),
+      granularity: selectValue("kg-granularity"),
+      refresh: refresh ? "1" : "0",
+    });
+    const graph = await api(`/api/knowledge-graph?${query.toString()}`);
+    state.knowledgeGraph = graph;
+    state.selectedKnowledgeNode = null;
+    renderKnowledgeGraph(graph);
+  } catch (error) {
+    $("kg-meta").textContent = `scan failed: ${error}`;
+    $("kg-summary").innerHTML = summaryItem("Graph", "failed", "bad");
+    $("kg-graph").innerHTML = "";
+    $("kg-detail-title").textContent = "OS 知识图谱";
+    $("kg-detail-body").innerHTML = `<div class="brief-text bad">${escapeHtml(String(error))}</div>`;
+  }
+}
+
+async function refreshSyscallReport() {
+  try {
+    const report = await loadReport("syscall", selectValue("syscall-arch"));
+    renderSyscall(report);
+  } catch {
+    $("syscall-report-path").textContent = "no report";
+    $("syscall-summary").innerHTML = summaryItem("Diffs", "none");
+    $("syscall-diffs").innerHTML = emptyRow(3, "no syscall report");
+    $("syscall-brief").innerHTML = '<div class="brief-text">no repair context</div>';
+  }
+}
+
+function renderSyscall(report) {
+  const differences = report.differences || [];
+  $("syscall-report-path").textContent = report._ui.report_path;
+  $("syscall-summary").innerHTML = [
+    summaryItem("Arch", report.arch || "unknown"),
+    summaryItem("Diffs", differences.length, differences.length ? "bad" : "good"),
+    summaryItem("Begin marker", report.markers?.starry_begin ? "yes" : "no"),
+    summaryItem("End marker", report.markers?.starry_end ? "yes" : "no"),
+  ].join("");
+  $("syscall-diffs").innerHTML = differences.length
+    ? differences
+        .map(
+          (diff) => `
+            <tr>
+              <td><code>${escapeHtml(diff.case)}</code></td>
+              <td>${jsonCell(diff.linux)}</td>
+              <td>${jsonCell(diff.starry)}</td>
+            </tr>`,
+        )
+        .join("")
+    : emptyRow(3, "no semantic differences");
+  $("syscall-brief").innerHTML = renderSyscallBrief(differences);
+}
+
+function renderSyscallBrief(differences) {
+  if (!differences.length) {
+    return '<div class="brief-text good">Linux 对拍未发现语义差异。</div>';
+  }
+  return differences
+    .map(
+      (diff) => `
+        <div class="brief-block">
+          <div class="brief-title"><code>${escapeHtml(diff.case)}</code></div>
+          <div class="brief-text">以 Linux 字段为准修正 StarryOS 返回值、errno 或状态变更；优先检查对应 syscall 实现和参数校验路径。</div>
+        </div>`,
+    )
+    .join("");
+}
+
+async function refreshPerfReport() {
+  try {
+    const report = await loadReport("perf", selectValue("perf-arch"));
+    renderPerf(report);
+  } catch {
+    $("perf-report-path").textContent = "no report";
+    $("perf-summary").innerHTML = summaryItem("Samples", "none");
+    $("perf-metrics").innerHTML = "";
+    $("perf-functions").innerHTML = emptyRow(3, "no qperf report");
+    $("perf-candidates").innerHTML = '<div class="brief-text">no candidates</div>';
+    setFlamegraph(null, "no qperf report");
+  }
+}
+
+function renderPerf(report) {
+  const hotspots = report.hotspots || {};
+  const functions = hotspots.top_functions || [];
+  const samples = firstMetric(
+    [hotspots, report.plugin_summary, report.summary, report.host_time_metrics, report.host_perf_metrics],
+    ["total_samples", "samples", "folded_stack_lines", "sample_count"],
+  );
+  $("perf-report-path").textContent = report._ui.report_path;
+  $("perf-summary").innerHTML = [
+    summaryItem("Arch", report.arch || "unknown"),
+    summaryItem("Result", report.result || "unknown", report.result === "ok" ? "good" : "warn"),
+    summaryItem("Samples", samples ?? 0),
+    summaryItem("Candidates", (report.fix_candidates || []).length),
+  ].join("");
+  $("perf-metrics").innerHTML = renderPerfMetrics(report);
+  $("perf-functions").innerHTML = functions.length
+    ? functions
+        .map(
+          (item) => `
+            <tr>
+              <td><code>${escapeHtml(item.function)}</code></td>
+              <td>${escapeHtml(item.samples)}</td>
+              <td>${escapeHtml(Number(item.percent).toFixed(2))}%</td>
+            </tr>`,
+        )
+        .join("")
+    : emptyRow(3, "no hotspots");
+  $("perf-candidates").innerHTML = renderPerfCandidates(report.fix_candidates || []);
+  const flamegraph = report._ui.artifacts?.flamegraph;
+  setFlamegraph(
+    flamegraph?.exists ? flamegraph.url : null,
+    flamegraphMessage(report, flamegraph),
+  );
+}
+
+function renderPerfMetrics(report) {
+  return [
+    renderMetricGroup("Summary", metricObject(report.summary), SAMPLE_METRICS),
+    renderMetricGroup("Guest counters", metricObject(report.plugin_summary), PLUGIN_COUNTER_METRICS),
+    renderMetricGroup("Host time", metricObject(report.host_time_metrics), HOST_METRICS),
+    renderMetricGroup("Host perf", flattenPerfEvents(report.host_perf_metrics), HOST_PERF_METRICS),
+  ]
+    .filter(Boolean)
+    .join("");
+}
+
+function renderMetricGroup(title, source, specs) {
+  if (!source) {
+    return "";
+  }
+  const rows = [];
+  const usedKeys = new Set();
+  for (const spec of specs) {
+    const match = metricLookup(source, spec.keys);
+    if (match) {
+      usedKeys.add(match.key);
+      rows.push([spec.label, match.value]);
+    }
+  }
+  for (const [key, value] of Object.entries(source)) {
+    if (rows.length >= 12) {
+      break;
+    }
+    if (usedKeys.has(key) || !isExtraMetric(key, value)) {
+      continue;
+    }
+    rows.push([humanMetricLabel(key), value]);
+  }
+  if (!rows.length) {
+    return "";
+  }
+  return `
+    <section class="metric-group">
+      <h3>${escapeHtml(title)}</h3>
+      ${rows
+        .map(
+          ([label, value]) => `
+            <div class="metric-row">
+              <span class="metric-label">${escapeHtml(label)}</span>
+              <span class="metric-value">${escapeHtml(formatMetricValue(value))}</span>
+            </div>`,
+        )
+        .join("")}
+    </section>`;
+}
+
+function renderPerfCandidates(candidates) {
+  if (!candidates.length) {
+    return '<div class="brief-text">没有超过阈值的规则候选。</div>';
+  }
+  return candidates
+    .map(
+      (candidate) => `
+        <div class="brief-block">
+          <div class="brief-title">${escapeHtml(candidate.id)} · ${Number(candidate.percent).toFixed(2)}%</div>
+          <div class="brief-text">trigger: <code>${escapeHtml(candidate.trigger)}</code></div>
+          <div class="brief-text">${escapeHtml(candidate.strategy)}</div>
+          <div class="brief-text">${escapeHtml((candidate.files || []).join(", "))}</div>
+        </div>`,
+    )
+    .join("");
+}
+
+function flamegraphMessage(report, flamegraph) {
+  const format = report.parameters?.format || "unknown";
+  if (format === "folded") {
+    return "format folded did not request SVG";
+  }
+  if (flamegraph && !flamegraph.exists) {
+    return "flamegraph.svg was not generated; check profile.stderr";
+  }
+  return "no flamegraph";
+}
+
+function setFlamegraph(url, message = "no flamegraph") {
+  const frame = $("flamegraph-frame");
+  const empty = $("flamegraph-empty");
+  if (!url) {
+    frame.hidden = true;
+    frame.removeAttribute("src");
+    frame.style.width = "";
+    frame.style.height = "";
+    empty.textContent = message;
+    empty.hidden = false;
+    return;
+  }
+  frame.onload = resizeFlamegraphFrame;
+  frame.hidden = false;
+  frame.src = url;
+  empty.hidden = true;
+}
+
+function resizeFlamegraphFrame() {
+  const frame = $("flamegraph-frame");
+  const svg = frame.contentDocument?.documentElement;
+  const width = Number(svg?.getAttribute("width"));
+  const height = Number(svg?.getAttribute("height"));
+  if (Number.isFinite(width) && width > 0) {
+    frame.style.width = `${Math.max(width, 1600)}px`;
+  }
+  if (Number.isFinite(height) && height > 0) {
+    frame.style.height = `${Math.max(height + 20, 220)}px`;
+  }
+}
+
+async function refreshDiffReport() {
+  try {
+    const report = await loadReport("perf-diff", null);
+    renderDiff(report);
+  } catch {
+    $("diff-report-path").textContent = "no report";
+    $("diff-changes").innerHTML = emptyRow(4, "no diff report");
+  }
+}
+
+function renderDiff(report) {
+  $("diff-report-path").textContent = report._ui.report_path;
+  const changes = report.top_changes || [];
+  $("diff-changes").innerHTML = changes.length
+    ? changes
+        .map(
+          (item) => `
+            <tr>
+              <td><code>${escapeHtml(item.function)}</code></td>
+              <td>${escapeHtml(Number(item.baseline_percent).toFixed(2))}%</td>
+              <td>${escapeHtml(Number(item.compare_percent).toFixed(2))}%</td>
+              <td class="${item.delta_percent > 0 ? "bad" : item.delta_percent < 0 ? "good" : ""}">
+                ${escapeHtml(Number(item.delta_percent).toFixed(2))}%
+              </td>
+            </tr>`,
+        )
+        .join("")
+    : emptyRow(4, "no changes");
+}
+
+function renderKnowledgeGraph(graph) {
+  const allNodes = graph.graph?.nodes || [];
+  const focusIds = new Set(graph.task?.focus_node_ids || []);
+  const nodes = checked("kg-hide-empty")
+    ? allNodes.filter((node) => focusIds.has(node.id) || Number(node.stats?.files || 0) > 0)
+    : allNodes;
+  const visibleIds = new Set(nodes.map((node) => node.id));
+  const edges = (graph.graph?.edges || []).filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target));
+  $("kg-meta").textContent = `扫描仓库：${graph.repo_root} · ${new Date(graph.generated_at * 1000).toLocaleString()}`;
+  $("kg-summary").innerHTML = [
+    summaryItem("Repo", graph.repo_root?.split("/").filter(Boolean).at(-1) || "unknown"),
+    summaryItem("Nodes", nodes.length),
+    summaryItem("Edges", edges.length),
+    summaryItem("Scanned files", graph.scan?.files_seen ?? 0),
+    summaryItem("Focus", (graph.task?.focus_node_ids || []).join(", ") || "auto"),
+  ].join("");
+  drawKnowledgeSvg(nodes, edges, focusIds);
+  renderKnowledgeFocus(graph);
+}
+
+function drawKnowledgeSvg(nodes, edges, focusIds) {
+  const svg = $("kg-graph");
+  svg.innerHTML = "";
+  const width = 1180;
+  const layers = [...new Set(nodes.map((node) => node.layer))];
+  const rowHeight = 132;
+  const height = Math.max(420, layers.length * rowHeight + 50);
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  svg.setAttribute("width", width);
+  svg.setAttribute("height", height);
+
+  const byLayer = new Map(layers.map((layer) => [layer, nodes.filter((node) => node.layer === layer)]));
+  const positions = new Map();
+  layers.forEach((layer, row) => {
+    const layerNodes = byLayer.get(layer) || [];
+    const gap = width / (layerNodes.length + 1);
+    layerNodes.forEach((node, index) => {
+      positions.set(node.id, { x: Math.round(gap * (index + 1)), y: 48 + row * rowHeight });
+    });
+  });
+
+  const graphLayer = svgEl("g");
+  svg.appendChild(graphLayer);
+  for (const edge of edges) {
+    const source = positions.get(edge.source);
+    const target = positions.get(edge.target);
+    if (!source || !target) {
+      continue;
+    }
+    const line = svgEl("line", {
+      x1: source.x,
+      y1: source.y + 18,
+      x2: target.x,
+      y2: target.y - 18,
+      class: edge.focus ? "kg-edge focus" : "kg-edge",
+    });
+    graphLayer.appendChild(line);
+  }
+
+  layers.forEach((layer, row) => {
+    const label = svgEl("text", { x: 14, y: 52 + row * rowHeight, class: "kg-layer-label" });
+    label.textContent = layer;
+    graphLayer.appendChild(label);
+  });
+
+  for (const node of nodes) {
+    const pos = positions.get(node.id);
+    if (!pos) {
+      continue;
+    }
+    const group = svgEl("g", {
+      class: [
+        "kg-node",
+        focusIds.has(node.id) ? "focus" : "",
+        state.selectedKnowledgeNode === node.id ? "selected" : "",
+      ].join(" "),
+      tabindex: "0",
+    });
+    group.addEventListener("click", () => selectKnowledgeNode(node.id));
+    group.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        selectKnowledgeNode(node.id);
+      }
+    });
+    group.appendChild(svgEl("rect", { x: pos.x - 70, y: pos.y - 28, width: 140, height: 56, rx: 8 }));
+    const title = svgEl("text", { x: pos.x, y: pos.y - 4, class: "kg-node-title" });
+    title.textContent = shortNodeLabel(node.label);
+    const meta = svgEl("text", { x: pos.x, y: pos.y + 16, class: "kg-node-meta" });
+    meta.textContent = `${node.stats?.files ?? 0} files · ${node.task_score ?? 0}`;
+    group.appendChild(title);
+    group.appendChild(meta);
+    graphLayer.appendChild(group);
+  }
+}
+
+function svgEl(name, attributes = {}) {
+  const element = document.createElementNS("http://www.w3.org/2000/svg", name);
+  for (const [key, value] of Object.entries(attributes)) {
+    element.setAttribute(key, String(value));
+  }
+  return element;
+}
+
+function shortNodeLabel(label) {
+  const compact = String(label).replace("Linux ", "").replace(" driver", "").replace(" / ", "/");
+  return compact.length > 23 ? `${compact.slice(0, 21)}…` : compact;
+}
+
+function selectKnowledgeNode(nodeId) {
+  state.selectedKnowledgeNode = nodeId;
+  const graph = state.knowledgeGraph;
+  if (!graph) {
+    return;
+  }
+  drawKnowledgeSvg(graph.graph?.nodes || [], graph.graph?.edges || [], new Set(graph.task?.focus_node_ids || []));
+  const node = (graph.graph?.nodes || []).find((item) => item.id === nodeId);
+  if (node) {
+    renderKnowledgeNodeDetail(node);
+  }
+}
+
+function renderKnowledgeFocus(graph) {
+  $("kg-detail-title").textContent = "任务焦点";
+  const focusNodes = new Set(graph.task?.focus_node_ids || []);
+  const focusLabels = (graph.graph?.nodes || [])
+    .filter((node) => focusNodes.has(node.id))
+    .map((node) => node.label);
+  $("kg-detail-body").innerHTML = [
+    `<div class="brief-title">${escapeHtml(graph.focus?.summary || "未识别任务焦点")}</div>`,
+    `<div class="brief-text">焦点节点：${escapeHtml(focusLabels.join("、") || "无")}</div>`,
+    renderTextBlockList("代码讲解", graph.focus?.code_explanation || []),
+    renderTextBlockList("OS 课本知识 - 实践关联", graph.focus?.os_explanation || []),
+    renderTextBlockList("编码建议", graph.focus?.coding_guidance || []),
+  ].join("");
+}
+
+function renderKnowledgeNodeDetail(node) {
+  $("kg-detail-title").textContent = node.label;
+  const hotFiles = (node.hot_files || [])
+    .map((item) => `${item.path}${item.lines ? `:${item.lines} lines` : ""}`)
+    .join("\n");
+  const symbols = (node.symbols || [])
+    .map((item) => `${item.kind} ${item.name} · ${item.path}:${item.line}`)
+    .join("\n");
+  $("kg-detail-body").innerHTML = [
+    `<div class="brief-title">${escapeHtml(node.layer)} · score ${escapeHtml(node.task_score ?? 0)}</div>`,
+    `<div class="brief-text">${escapeHtml(node.summary)}</div>`,
+    renderMetricInline(node.stats || {}),
+    renderCodeBlock("相关目录", (node.paths || []).join("\n")),
+    renderCodeBlock("代表文件", hotFiles || "no files"),
+    renderCodeBlock("代表符号", symbols || "no symbols"),
+    `<div class="brief-block"><div class="brief-title">OS 课本知识</div><div class="brief-text">${escapeHtml(node.textbook)}</div></div>`,
+    `<div class="brief-block"><div class="brief-title">仓库实践关联</div><div class="brief-text">${escapeHtml(node.practice)}</div></div>`,
+  ].join("");
+}
+
+function renderMetricInline(stats) {
+  return `
+    <div class="kg-inline-stats">
+      <span>files ${escapeHtml(stats.files ?? 0)}</span>
+      <span>lines ${escapeHtml(stats.lines ?? 0)}</span>
+      <span>symbols ${escapeHtml(stats.symbols ?? 0)}</span>
+      <span>keyword hits ${escapeHtml(stats.keyword_hits ?? 0)}</span>
+    </div>`;
+}
+
+function renderTextBlockList(title, items) {
+  if (!items.length) {
+    return "";
+  }
+  return `
+    <div class="brief-block">
+      <div class="brief-title">${escapeHtml(title)}</div>
+      ${items.map((item) => `<div class="brief-text">${escapeHtml(item)}</div>`).join("")}
+    </div>`;
+}
+
+function renderCodeBlock(title, value) {
+  return `
+    <div class="brief-block">
+      <div class="brief-title">${escapeHtml(title)}</div>
+      <pre class="kg-code">${escapeHtml(value)}</pre>
+    </div>`;
+}
+
+function emptyRow(colspan, text) {
+  return `<tr><td class="muted" colspan="${colspan}">${escapeHtml(text)}</td></tr>`;
+}
+
+async function startJob(kind, payload = {}) {
+  const job = await api("/api/jobs", {
+    method: "POST",
+    body: JSON.stringify({ kind, ...payload }),
+  });
+  state.activeJobId = job.id;
+  renderJob(job);
+  setActiveState(`${job.kind}: ${job.status}`, "running");
+  setBusy(true);
+  showTab("jobs");
+  schedulePoll();
+}
+
+function schedulePoll() {
+  if (state.pollTimer) {
+    return;
+  }
+  state.pollTimer = window.setInterval(pollJob, 1000);
+}
+
+async function pollJob() {
+  if (!state.activeJobId) {
+    window.clearInterval(state.pollTimer);
+    state.pollTimer = null;
+    return;
+  }
+  try {
+    const job = await api(`/api/jobs/${state.activeJobId}`);
+    renderJob(job);
+    if (job.status !== "queued" && job.status !== "running") {
+      window.clearInterval(state.pollTimer);
+      state.pollTimer = null;
+      setActiveState(`${job.kind}: ${job.status}`, job.status);
+      setBusy(false);
+      await refreshStatus();
+      await refreshReports();
+    }
+  } catch (error) {
+    $("job-log").textContent = String(error);
+  }
+}
+
+function renderJob(job) {
+  $("job-meta").textContent = `${job.id} · ${job.kind} · ${job.status} · rc=${job.returncode ?? "running"}`;
+  $("job-log").textContent = [job.command.join(" "), "", job.output || ""].join("\n");
+}
+
+function showTab(tab) {
+  state.currentTab = tab;
+  document.querySelectorAll(".nav-tab").forEach((button) => {
+    button.classList.toggle("active", button.dataset.tab === tab);
+  });
+  document.querySelectorAll(".tab-panel").forEach((panel) => {
+    panel.classList.toggle("active", panel.id === `tab-${tab}`);
+  });
+}
+
+function bindEvents() {
+  document.querySelectorAll(".nav-tab").forEach((button) => {
+    button.addEventListener("click", () => showTab(button.dataset.tab));
+  });
+  $("refresh-all").addEventListener("click", async () => {
+    await refreshStatus();
+    await refreshReports();
+    await refreshKnowledgeGraph(false);
+  });
+  $("refresh-job").addEventListener("click", pollJob);
+  $("run-doctor").addEventListener("click", () => startJob("doctor"));
+  $("run-discover").addEventListener("click", () =>
+    startJob("discover", {
+      arch: selectValue("syscall-arch"),
+      timeout: numberValue("syscall-timeout"),
+      fail_on_diff: checked("syscall-fail-on-diff"),
+    }),
+  );
+  $("run-perf").addEventListener("click", () =>
+    startJob("perf-profile", {
+      arch: selectValue("perf-arch"),
+      timeout: numberValue("perf-timeout"),
+      format: selectValue("perf-format"),
+      mode: selectValue("perf-mode"),
+      freq: numberValue("perf-freq"),
+      max_depth: numberValue("perf-depth"),
+      top: numberValue("perf-top"),
+      min_percent: numberValue("perf-min-percent"),
+      host_time: checked("perf-host-time"),
+      host_perf: checked("perf-host-perf"),
+      host_perf_events: textValue("perf-host-perf-events"),
+      shell_init_cmd: textValue("perf-shell-init-cmd"),
+      shell_prefix: textValue("perf-shell-prefix"),
+      qemu_args: textValue("perf-qemu-args"),
+      debug: checked("perf-debug"),
+      kernel_filter: checked("perf-kernel-filter"),
+    }),
+  );
+  $("run-diff").addEventListener("click", () =>
+    startJob("perf-diff", {
+      baseline: selectValue("diff-baseline"),
+      compare: selectValue("diff-compare"),
+      top: numberValue("diff-top"),
+    }),
+  );
+  $("refresh-kg").addEventListener("click", () => refreshKnowledgeGraph(true));
+  $("kg-reset-focus").addEventListener("click", () => {
+    state.selectedKnowledgeNode = null;
+    if (state.knowledgeGraph) {
+      renderKnowledgeGraph(state.knowledgeGraph);
+    }
+  });
+  $("kg-task").addEventListener("change", () => refreshKnowledgeGraph(true));
+  $("kg-repo-root").addEventListener("change", () => refreshKnowledgeGraph(true));
+  $("kg-hide-empty").addEventListener("change", () => {
+    if (state.knowledgeGraph) {
+      renderKnowledgeGraph(state.knowledgeGraph);
+    }
+  });
+  $("kg-granularity").addEventListener("change", () => refreshKnowledgeGraph(true));
+  $("syscall-arch").addEventListener("change", refreshSyscallReport);
+  $("perf-arch").addEventListener("change", refreshPerfReport);
+}
+
+async function init() {
+  bindEvents();
+  await refreshStatus();
+  await refreshReports();
+  await refreshKnowledgeGraph(false);
+}
+
+init().catch((error) => {
+  setActiveState("error", "failed");
+  $("job-log").textContent = String(error);
+});

--- a/tools/starry-syscall-harness/web/index.html
+++ b/tools/starry-syscall-harness/web/index.html
@@ -1,0 +1,315 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>StarryOS Harness</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="topbar">
+        <div>
+          <h1>StarryOS Harness</h1>
+          <div class="meta-line" id="repo-root">repo loading</div>
+        </div>
+        <div class="top-actions">
+          <span class="status-pill" id="active-state">idle</span>
+          <button class="secondary" id="run-doctor" type="button">Doctor</button>
+          <button class="secondary" id="refresh-all" type="button">刷新</button>
+        </div>
+      </header>
+
+      <main class="main-grid">
+        <nav class="nav-tabs" aria-label="Harness workflows">
+          <button class="nav-tab active" data-tab="syscall" type="button">Syscall</button>
+          <button class="nav-tab" data-tab="perf" type="button">Performance</button>
+          <button class="nav-tab" data-tab="knowledge" type="button">Knowledge</button>
+          <button class="nav-tab" data-tab="diff" type="button">Diff</button>
+          <button class="nav-tab" data-tab="jobs" type="button">Jobs</button>
+        </nav>
+
+        <section class="workspace">
+          <section class="tab-panel active" id="tab-syscall">
+            <div class="panel-heading">
+              <div>
+                <h2>Syscall 扫描与修复上下文</h2>
+                <div class="meta-line" id="syscall-report-path">no report</div>
+              </div>
+              <button class="primary" id="run-discover" type="button">扫描/修复上下文</button>
+            </div>
+
+            <div class="control-grid compact">
+              <label>
+                <span>Arch</span>
+                <select id="syscall-arch">
+                  <option value="riscv64">riscv64</option>
+                  <option value="aarch64">aarch64</option>
+                  <option value="loongarch64">loongarch64</option>
+                  <option value="x86_64">x86_64</option>
+                </select>
+              </label>
+              <label>
+                <span>Timeout</span>
+                <input id="syscall-timeout" min="1" max="3600" type="number" value="120" />
+              </label>
+              <label class="checkbox-row">
+                <input id="syscall-fail-on-diff" type="checkbox" />
+                <span>diff 时返回失败</span>
+              </label>
+            </div>
+
+            <div class="summary-strip" id="syscall-summary"></div>
+            <div class="split-pane">
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Case</th>
+                      <th>Linux</th>
+                      <th>StarryOS</th>
+                    </tr>
+                  </thead>
+                  <tbody id="syscall-diffs"></tbody>
+                </table>
+              </div>
+              <section class="brief-panel">
+                <h3>修复上下文</h3>
+                <div id="syscall-brief"></div>
+              </section>
+            </div>
+          </section>
+
+          <section class="tab-panel" id="tab-perf">
+            <div class="panel-heading">
+              <div>
+                <h2>qperf 性能分析</h2>
+                <div class="meta-line" id="perf-report-path">no report</div>
+              </div>
+              <button class="primary" id="run-perf" type="button">分析热点</button>
+            </div>
+
+            <div class="control-grid">
+              <label>
+                <span>Arch</span>
+                <select id="perf-arch">
+                  <option value="riscv64">riscv64</option>
+                  <option value="loongarch64">loongarch64</option>
+                </select>
+              </label>
+              <label>
+                <span>Timeout</span>
+                <input id="perf-timeout" min="1" max="3600" type="number" value="20" />
+              </label>
+              <label>
+                <span>Format</span>
+                <select id="perf-format">
+                  <option value="all">all</option>
+                  <option value="svg">svg</option>
+                  <option value="folded">folded</option>
+                  <option value="pprof">pprof</option>
+                </select>
+              </label>
+              <label>
+                <span>Mode</span>
+                <select id="perf-mode">
+                  <option value="tb">tb</option>
+                  <option value="insn">insn</option>
+                </select>
+              </label>
+              <label>
+                <span>Freq</span>
+                <input id="perf-freq" min="1" max="100000" type="number" value="99" />
+              </label>
+              <label>
+                <span>Max depth</span>
+                <input id="perf-depth" min="1" max="1024" type="number" value="64" />
+              </label>
+              <label>
+                <span>Top</span>
+                <input id="perf-top" min="1" max="200" type="number" value="20" />
+              </label>
+              <label>
+                <span>Min %</span>
+                <input id="perf-min-percent" min="0" max="100" step="0.1" type="number" value="5" />
+              </label>
+              <label class="checkbox-row">
+                <input id="perf-host-time" type="checkbox" checked />
+                <span>host time</span>
+              </label>
+              <label class="checkbox-row">
+                <input id="perf-host-perf" type="checkbox" />
+                <span>host perf stat</span>
+              </label>
+              <label class="wide">
+                <span>Host perf events</span>
+                <input
+                  id="perf-host-perf-events"
+                  type="text"
+                  value="task-clock,cycles,instructions,cache-references,cache-misses,context-switches,cpu-migrations,page-faults"
+                />
+              </label>
+              <label class="wide">
+                <span>Shell init cmd</span>
+                <input id="perf-shell-init-cmd" type="text" placeholder="/root/syscall-probe" />
+              </label>
+              <label class="wide">
+                <span>Shell prefix</span>
+                <input id="perf-shell-prefix" type="text" value="root@starry:" />
+              </label>
+              <label class="full">
+                <span>QEMU args</span>
+                <textarea
+                  id="perf-qemu-args"
+                  placeholder="-m&#10;256M&#10;or: -m 256M -smp 2"
+                  rows="3"
+                ></textarea>
+              </label>
+              <label class="checkbox-row">
+                <input id="perf-debug" type="checkbox" />
+                <span>debug symbols</span>
+              </label>
+              <label class="checkbox-row">
+                <input id="perf-kernel-filter" type="checkbox" />
+                <span>kernel filter</span>
+              </label>
+            </div>
+
+            <div class="summary-strip" id="perf-summary"></div>
+            <div class="metrics-panel" id="perf-metrics"></div>
+            <div class="flamegraph-shell" id="flamegraph-shell">
+              <iframe class="flamegraph-frame" id="flamegraph-frame" title="qperf flamegraph"></iframe>
+              <div class="empty-state" id="flamegraph-empty">no flamegraph</div>
+            </div>
+
+            <div class="split-pane lower">
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Function</th>
+                      <th>Samples</th>
+                      <th>Percent</th>
+                    </tr>
+                  </thead>
+                  <tbody id="perf-functions"></tbody>
+                </table>
+              </div>
+              <section class="brief-panel">
+                <h3>瓶颈修复候选</h3>
+                <div id="perf-candidates"></div>
+              </section>
+            </div>
+          </section>
+
+          <section class="tab-panel" id="tab-knowledge">
+            <div class="panel-heading">
+              <div>
+                <h2>OS 知识图谱</h2>
+                <div class="meta-line" id="kg-meta">waiting for scan</div>
+              </div>
+              <button class="primary" id="refresh-kg" type="button">扫描图谱</button>
+            </div>
+
+            <div class="control-grid compact kg-controls">
+              <label class="wide">
+                <span>当前开发任务</span>
+                <input
+                  id="kg-task"
+                  type="text"
+                  value="qperf harness GUI OS 知识图谱"
+                  placeholder="例如：优化 virtio-blk read path / 修复 waitpid syscall / 分析 net RX copy"
+                />
+              </label>
+              <label class="wide">
+                <span>扫描仓库路径</span>
+                <input
+                  id="kg-repo-root"
+                  type="text"
+                  placeholder="默认当前仓库；例如 ../tg-arceos-tutorial"
+                />
+              </label>
+              <label class="checkbox-row">
+                <input id="kg-hide-empty" type="checkbox" checked />
+                <span>隐藏未命中节点</span>
+              </label>
+              <label>
+                <span>讲解粒度</span>
+                <select id="kg-granularity">
+                  <option value="coarse">粗粒度</option>
+                  <option value="fine">细粒度</option>
+                </select>
+              </label>
+            </div>
+
+            <div class="summary-strip" id="kg-summary"></div>
+            <div class="kg-layout">
+              <section class="kg-graph-panel">
+                <div class="kg-toolbar">
+                  <span class="meta-line">点击节点查看代码讲解与 OS 课本关联</span>
+                  <button class="secondary" id="kg-reset-focus" type="button">显示任务焦点</button>
+                </div>
+                <svg id="kg-graph" class="kg-graph" role="img" aria-label="OS knowledge graph"></svg>
+              </section>
+              <section class="brief-panel kg-detail">
+                <h3 id="kg-detail-title">任务焦点</h3>
+                <div id="kg-detail-body" class="brief-text">no knowledge graph</div>
+              </section>
+            </div>
+          </section>
+
+          <section class="tab-panel" id="tab-diff">
+            <div class="panel-heading">
+              <div>
+                <h2>性能差异</h2>
+                <div class="meta-line" id="diff-report-path">no report</div>
+              </div>
+              <button class="primary" id="run-diff" type="button">对比</button>
+            </div>
+
+            <div class="control-grid compact">
+              <label class="wide">
+                <span>Baseline</span>
+                <input id="diff-baseline" type="text" value="target/starry-syscall-harness/perf/riscv64/latest" />
+              </label>
+              <label class="wide">
+                <span>Compare</span>
+                <input id="diff-compare" type="text" value="target/starry-syscall-harness/perf/riscv64/latest" />
+              </label>
+              <label>
+                <span>Top</span>
+                <input id="diff-top" min="1" max="200" type="number" value="20" />
+              </label>
+            </div>
+            <div class="table-wrap full">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Function</th>
+                    <th>Baseline</th>
+                    <th>Compare</th>
+                    <th>Delta</th>
+                  </tr>
+                </thead>
+                <tbody id="diff-changes"></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="tab-panel" id="tab-jobs">
+            <div class="panel-heading">
+              <div>
+                <h2>任务日志</h2>
+                <div class="meta-line" id="job-meta">no job</div>
+              </div>
+              <button class="secondary" id="refresh-job" type="button">刷新日志</button>
+            </div>
+            <pre class="job-log" id="job-log"></pre>
+          </section>
+        </section>
+      </main>
+    </div>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/tools/starry-syscall-harness/web/styles.css
+++ b/tools/starry-syscall-harness/web/styles.css
@@ -1,0 +1,644 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7f6;
+  --surface: #ffffff;
+  --surface-2: #eef3f1;
+  --line: #d6dfda;
+  --text: #18211e;
+  --muted: #65716d;
+  --accent: #126c78;
+  --accent-strong: #0d5260;
+  --good: #1f7a4d;
+  --warn: #a96514;
+  --bad: #a64038;
+  --code: #f1f4f2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  letter-spacing: 0;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  min-height: 36px;
+  padding: 0 12px;
+  cursor: pointer;
+  background: var(--surface);
+  color: var(--text);
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+}
+
+button.primary:hover {
+  background: var(--accent-strong);
+}
+
+button.secondary:hover,
+.nav-tab:hover {
+  background: var(--surface-2);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  min-height: 72px;
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+h1 {
+  font-size: 20px;
+}
+
+h2 {
+  font-size: 18px;
+}
+
+h3 {
+  font-size: 14px;
+}
+
+.meta-line {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.status-pill {
+  min-height: 28px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 10px;
+  background: var(--surface-2);
+  color: var(--muted);
+}
+
+.status-pill.running {
+  color: var(--warn);
+  border-color: #e4c39a;
+  background: #fff6e8;
+}
+
+.status-pill.failed {
+  color: var(--bad);
+  border-color: #e7bbb6;
+  background: #fff0ef;
+}
+
+.status-pill.succeeded {
+  color: var(--good);
+  border-color: #a9d6bd;
+  background: #eefaf2;
+}
+
+.main-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 178px minmax(0, 1fr);
+  min-height: 0;
+}
+
+.nav-tabs {
+  border-right: 1px solid var(--line);
+  background: #fbfcfb;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nav-tab {
+  width: 100%;
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.nav-tab.active {
+  border-color: #9bc5ca;
+  background: #e9f5f6;
+  color: var(--accent-strong);
+}
+
+.workspace {
+  min-width: 0;
+  padding: 18px;
+}
+
+.tab-panel {
+  display: none;
+  min-width: 0;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.control-grid {
+  margin: 14px 0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.control-grid.compact {
+  grid-template-columns: repeat(3, minmax(140px, 220px));
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+label span {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+label.wide {
+  grid-column: span 2;
+}
+
+label.full {
+  grid-column: 1 / -1;
+}
+
+.checkbox-row {
+  flex-direction: row;
+  align-items: center;
+  min-height: 58px;
+}
+
+input,
+select,
+textarea {
+  min-height: 36px;
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--text);
+  padding: 7px 9px;
+}
+
+textarea {
+  min-height: 76px;
+  resize: vertical;
+  line-height: 1.4;
+}
+
+input[type="checkbox"] {
+  width: 16px;
+  min-height: 16px;
+}
+
+.summary-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.summary-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 10px;
+  min-height: 64px;
+}
+
+.summary-label {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.summary-value {
+  margin-top: 6px;
+  font-size: 18px;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.metrics-panel {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin: -4px 0 14px;
+}
+
+.metric-group {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 10px;
+  min-width: 0;
+}
+
+.metric-group h3 {
+  margin-bottom: 7px;
+}
+
+.metric-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 4px 0;
+  border-top: 1px solid var(--line);
+}
+
+.metric-row:first-of-type {
+  border-top: 0;
+}
+
+.metric-label {
+  color: var(--muted);
+}
+
+.metric-value {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.split-pane {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(300px, 0.8fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.split-pane.lower {
+  margin-top: 14px;
+}
+
+.table-wrap,
+.brief-panel,
+.flamegraph-shell {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.table-wrap {
+  overflow: auto;
+  max-height: 460px;
+}
+
+.table-wrap.full {
+  max-height: 620px;
+}
+
+table {
+  width: 100%;
+  min-width: 620px;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--line);
+  vertical-align: top;
+  text-align: left;
+}
+
+th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #f9fbfa;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+td code,
+.brief-panel code {
+  background: var(--code);
+  border-radius: 5px;
+  padding: 2px 4px;
+  overflow-wrap: anywhere;
+}
+
+.brief-panel {
+  padding: 12px;
+  min-height: 220px;
+}
+
+.brief-block {
+  border-top: 1px solid var(--line);
+  margin-top: 10px;
+  padding-top: 10px;
+}
+
+.brief-title {
+  font-weight: 650;
+  margin-bottom: 6px;
+}
+
+.brief-text {
+  color: var(--muted);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.flamegraph-shell {
+  position: relative;
+  min-height: 240px;
+  max-height: 70vh;
+  overflow: auto;
+}
+
+.flamegraph-frame {
+  display: block;
+  width: 3200px;
+  min-width: 100%;
+  height: 260px;
+  border: 0;
+  background: #ffffff;
+}
+
+.flamegraph-frame[hidden],
+.empty-state[hidden] {
+  display: none;
+}
+
+.kg-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(360px, 0.75fr);
+  gap: 14px;
+  align-items: stretch;
+}
+
+.kg-controls {
+  grid-template-columns: minmax(280px, 1fr) minmax(140px, 220px);
+}
+
+.kg-graph-panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  min-height: 620px;
+  overflow: auto;
+}
+
+.kg-toolbar {
+  min-height: 48px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.kg-graph {
+  display: block;
+  min-width: 1180px;
+  background:
+    linear-gradient(#ffffff, #ffffff),
+    repeating-linear-gradient(90deg, transparent 0, transparent 119px, #f4f7f5 120px);
+}
+
+.kg-edge {
+  stroke: #aebbb6;
+  stroke-width: 1.4;
+}
+
+.kg-edge.focus {
+  stroke: var(--accent);
+  stroke-width: 2.4;
+}
+
+.kg-layer-label {
+  fill: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.kg-node {
+  cursor: pointer;
+  outline: none;
+}
+
+.kg-node rect {
+  fill: #f8fbfa;
+  stroke: #b9c7c2;
+  stroke-width: 1.2;
+}
+
+.kg-node:hover rect,
+.kg-node.selected rect {
+  fill: #eaf6f6;
+  stroke: var(--accent);
+  stroke-width: 2.2;
+}
+
+.kg-node.focus rect {
+  fill: #fff7e9;
+  stroke: #d79a3a;
+  stroke-width: 2;
+}
+
+.kg-node-title,
+.kg-node-meta {
+  text-anchor: middle;
+  pointer-events: none;
+}
+
+.kg-node-title {
+  fill: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.kg-node-meta {
+  fill: var(--muted);
+  font-size: 10px;
+}
+
+.kg-detail {
+  max-height: 720px;
+  overflow: auto;
+}
+
+.kg-inline-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin: 12px 0;
+}
+
+.kg-inline-stats span {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #f9fbfa;
+  padding: 7px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.kg-code {
+  margin: 0;
+  padding: 9px;
+  border-radius: 7px;
+  background: var(--code);
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.empty-state {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  background: var(--surface);
+}
+
+.job-log {
+  min-height: 520px;
+  max-height: calc(100vh - 210px);
+  overflow: auto;
+  margin: 14px 0 0;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #111815;
+  color: #d7eadf;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.good {
+  color: var(--good);
+}
+
+.warn {
+  color: var(--warn);
+}
+
+.bad {
+  color: var(--bad);
+}
+
+@media (max-width: 980px) {
+  .main-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .nav-tabs {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+    flex-direction: row;
+    overflow: auto;
+  }
+
+  .nav-tab {
+    width: auto;
+    min-width: 118px;
+    text-align: center;
+  }
+
+  .control-grid,
+  .control-grid.compact,
+  .summary-strip,
+  .metrics-panel,
+  .split-pane,
+  .kg-layout,
+  .kg-controls {
+    grid-template-columns: 1fr;
+  }
+
+  label.wide,
+  label.full {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar,
+  .panel-heading {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .workspace {
+    padding: 12px;
+  }
+
+  .top-actions {
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
## 问题

当前 StarryOS 的 qperf 使用门槛较高，用户需要手动拼接 harness、QEMU plugin、analyzer、marker/window、flamegraph 等参数，导致性能采样和报告复现成本较高。同时，原有火焰图和 folded stack 更偏 leaf hotspot，缺少调用链、workload window、工程分类热点和对比报告等工具能力。

## 改动

- 在 `tools/qperf` 中扩展 QEMU TCG plugin 与 analyzer：
  - raw sample 增加版本化字段，保留 PC/SP/FP 等信息；
  - analyzer 支持 frame-pointer callchain、Rust demangle、symbol style、stack depth summary；
  - 输出 folded stack、SVG flamegraph、hotspot category、phase/focus flamegraph 等报告产物。
- 新增 `tools/starry-syscall-harness`：
  - 提供 `perf-profile`、`perf-postprocess`、`perf-compare` 等 CLI；
  - 支持 start/stop marker、workload timeout、host time/perf、workload stdout metric parsing；
  - 提供本地 UI、MCP server、syscall probe scaffold 和 OS 知识图谱静态扫描视图；
  - `--qperf-metrics` 在 tools 侧解析 guest stdout 中的 `QPERF_METRIC key=value`，不在本 PR 中强制启用内核/driver 侧插桩。
- 在 `scripts/axbuild` 中集成 `cargo starry perf` 和 `cargo starry run --perf`：
  - 默认生成 `target/qperf/<case>/perf/<arch>/latest/` 下的 report/json/csv/flamegraph/folded stack；
  - 暴露 freq、max-depth、callchain、flamegraph、marker、focus、host perf 等高级参数；
  - 保持不传 `--perf` 时原有 `cargo starry run` 行为不变。
- 增加文档：
  - qperf marker/metrics 使用说明；
  - cargo starry 集成说明；
  - flamegraph/callchain 设计与验证说明；
  - harness OS knowledge graph 使用说明。

## 设计逻辑

本 PR 将 qperf 和 harness 的主要实现放在 `tools/`，将用户入口放在现有 `scripts/axbuild` 的 `cargo starry` 子命令中，避免引入新的并行 CLI 体系。内核/driver 侧的 virtio counter 插桩和性能优化原型没有放入本 PR，后续可以拆成单独 PR；本 PR 只保留 tools 侧对 `QPERF_METRIC` 的解析与报告合并能力，便于被测分支自行导出指标。

## 验证

已在本地完成以下检查：

- `cargo fmt`
- `python3 -m py_compile tools/starry-syscall-harness/knowledge_graph.py tools/starry-syscall-harness/ui_server.py tools/starry-syscall-harness/harness.py tools/starry-syscall-harness/mcp_server.py`
- `node --check tools/starry-syscall-harness/web/app.js`
- `bash -n tools/starry-syscall-harness/scripts/qperf-smoke.sh`
- `git diff --check`
- `cargo xtask clippy --package axbuild`
- `cargo clippy --manifest-path tools/qperf/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo clippy --manifest-path tools/qperf/analyzer/Cargo.toml --all-targets --all-features -- -D warnings`

未在这个上游 PR 分支重新执行完整 QEMU profile；完整采样依赖本机 QEMU/rootfs/网络环境，文档中保留了手动 smoke 命令和已验证的报告格式说明。

## 范围说明

- 本 PR 刻意不包含生成的 flamegraph 图片、PPT、外部教程仓库分析结果和本地验证目录。
- 本 PR 不包含 virtio-blk/net 的性能优化补丁，也不包含内核侧 `/proc/qperf_metrics` 导出实现。
- 若需要完整 virtio counter 闭环，建议后续单独提交 driver/kernel instrumentation PR。
