### PR TITLE
fix(starry): validate arch_prctl SET_FS/SET_GS address

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/thread.rs
+++ b/os/StarryOS/kernel/src/syscall/task/thread.rs
@@ -91,9 +91,7 @@ pub fn sys_arch_prctl(
     // the kernel or is non-canonical).
     const USER_SPACE_END: usize = crate::config::USER_SPACE_BASE + crate::config::USER_SPACE_SIZE;
     let check_addr = |addr: usize| {
-        use crate::config::USER_SPACE_BASE;
-
-        if !(USER_SPACE_BASE..USER_SPACE_END).contains(&addr) {
+        if !(0..USER_SPACE_END).contains(&addr) {
             return Err(AxError::OperationNotPermitted);
         }
         Ok(())

--- a/os/StarryOS/kernel/src/syscall/task/thread.rs
+++ b/os/StarryOS/kernel/src/syscall/task/thread.rs
@@ -86,14 +86,26 @@ pub fn sys_arch_prctl(
     let code = ArchPrctlCode::try_from(code).map_err(|_| AxError::InvalidInput)?;
     debug!("sys_arch_prctl: code = {code:?}, addr = {addr:#x}");
 
+    // Reject addresses outside the canonical user-space range (the
+    // high-half of the 48-bit virtual address space is reserved for
+    // the kernel or is non-canonical).
+    const USER_SPACE_END: usize = crate::config::USER_SPACE_BASE + crate::config::USER_SPACE_SIZE;
+    let check_addr = |addr: usize| {
+        use crate::config::USER_SPACE_BASE;
+
+        if !(USER_SPACE_BASE..USER_SPACE_END).contains(&addr) {
+            return Err(AxError::OperationNotPermitted);
+        }
+        Ok(())
+    };
+
     match code {
-        // According to Linux implementation, SetFs & SetGs does not return
-        // error at all
         ArchPrctlCode::GetFs => {
             (addr as *mut usize).vm_write(uctx.tls())?;
             Ok(0)
         }
         ArchPrctlCode::SetFs => {
+            check_addr(addr)?;
             uctx.set_tls(addr);
             Ok(0)
         }
@@ -102,6 +114,7 @@ pub fn sys_arch_prctl(
             Ok(0)
         }
         ArchPrctlCode::SetGs => {
+            check_addr(addr)?;
             uctx.gs_base = addr as _;
             Ok(0)
         }

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -144,10 +144,10 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                             }
                             ExceptionKind::Breakpoint => Signo::SIGTRAP,
                             ExceptionKind::IllegalInstruction => Signo::SIGILL,
-                            _ => Signo::SIGTRAP,
+                            _ => Signo::SIGSEGV,
                         };
                         raise_signal_fatal(SignalInfo::new_kernel(signo), &uctx)
-                            .expect("Failed to send SIGTRAP");
+                            .expect("Failed to send signal");
                     }
                     r => {
                         warn!("Unexpected return reason: {r:?}");

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -143,6 +143,7 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                                 Signo::SIGBUS
                             }
                             ExceptionKind::Breakpoint => Signo::SIGTRAP,
+                            ExceptionKind::Debug => Signo::SIGTRAP,
                             ExceptionKind::IllegalInstruction => Signo::SIGILL,
                             _ => Signo::SIGSEGV,
                         };

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-arch-prctl C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-arch-prctl src/main.c)
+target_include_directories(test-arch-prctl PRIVATE src)
+target_compile_options(test-arch-prctl PRIVATE -Wall -Wextra)
+target_link_options(test-arch-prctl PRIVATE -static)
+
+install(TARGETS test-arch-prctl RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/src/main.c
@@ -513,6 +513,59 @@ static void test_gp_delivers_sigsegv(void)
     }
 }
 
+/* 13. Verify that a user-mode #DB (Debug Exception / single-step trap)
+ *     delivers SIGTRAP, not SIGSEGV. The kernel must distinguish #DB
+ *     from protection faults (#GP/#SS/#NP/#TS) which go to SIGSEGV.
+ *     Run in a child that sets TF (Trap Flag) and executes a NOP to
+ *     trigger a single-step debug trap. */
+static void test_debug_delivers_sigtrap(void)
+{
+    printf("--- #DB delivers SIGTRAP (fork) ---\n");
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        printf("  FAIL | fork() failed, errno=%d (%s)\n",
+               errno, strerror(errno));
+        __fail++;
+        return;
+    }
+
+    if (pid == 0) {
+        /* ---- child: set TF, next instruction triggers #DB ---- */
+        unsigned long flags;
+        __asm__ volatile("pushfq\npopq %0" : "=r"(flags));
+        flags |= (1UL << 8); /* X86_EFLAGS_TF */
+        __asm__ volatile("pushq %0\npopfq\nnop" : : "r"(flags) : "flags");
+        /* not reached if #DB fires */
+        _exit(0);
+    }
+
+    /* ---- parent ---- */
+    int status;
+    waitpid(pid, &status, 0);
+
+    if (WIFSIGNALED(status)) {
+        int sig = WTERMSIG(status);
+        if (sig == SIGTRAP) {
+            printf("  PASS | #DB delivered SIGTRAP (signal=%d)\n", sig);
+            __pass++;
+        } else if (sig == SIGSEGV) {
+            printf("  FAIL | #DB delivered SIGSEGV (signal=%d) — debug trap misrouted\n", sig);
+            __fail++;
+        } else {
+            printf("  FAIL | #DB delivered unexpected signal=%d, expected SIGTRAP\n", sig);
+            __fail++;
+        }
+    } else if (WIFEXITED(status)) {
+        printf("  FAIL | single-step did not fault (exit=%d)\n",
+               WEXITSTATUS(status));
+        __fail++;
+    } else {
+        printf("  FAIL | unexpected child status (status=%d)\n", status);
+        __fail++;
+    }
+}
+
 /* ============================================================
  * MAIN
  * ============================================================ */
@@ -538,6 +591,7 @@ int main(void)
     test_eperm_invalid_address_set();
     test_low_address_set_fs_gs();
     test_gp_delivers_sigsegv();
+    test_debug_delivers_sigtrap();
 
     TEST_DONE();
 }

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/src/main.c
@@ -30,6 +30,8 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
+#include <signal.h>
 
 #if defined(__x86_64__)
 
@@ -352,6 +354,165 @@ static void test_eperm_invalid_address_set(void)
     }
 }
 
+/* 11. Low-address ARCH_SET_FS / ARCH_SET_GS via fork.
+ *     Linux allows base addresses 0, 1, 0xfff, 0x1000 for both
+ *     FS and GS — only the upper canonical boundary is checked.
+ *     Run in a child process to avoid corrupting the runner's TLS
+ *     (FS base) and the GS base used by the test framework. */
+static void test_low_address_set_fs_gs(void)
+{
+    printf("--- Low address ARCH_SET_FS / ARCH_SET_GS (fork) ---\n");
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        printf("  FAIL | fork() failed, errno=%d (%s)\n",
+               errno, strerror(errno));
+        __fail++;
+        return;
+    }
+
+    if (pid == 0) {
+        /* ---- child ---- */
+        unsigned long low_addrs[] = {0, 1, 0xfff, 0x1000};
+        int n_low = sizeof(low_addrs) / sizeof(low_addrs[0]);
+        int failed = 0;
+
+        /* save original bases so we can restore before exit */
+        unsigned long orig_fs = 0, orig_gs = 0;
+        int have_fs = 0, have_gs = 0;
+
+        if (raw_arch_prctl_ptr(ARCH_GET_FS, &orig_fs) == 0)
+            have_fs = 1;
+        if (raw_arch_prctl_ptr(ARCH_GET_GS, &orig_gs) == 0)
+            have_gs = 1;
+
+        /* ARCH_SET_FS with low addresses */
+        for (int i = 0; i < n_low; i++) {
+            errno = 0;
+            long ret = raw_arch_prctl(ARCH_SET_FS, low_addrs[i]);
+            if (ret != 0) {
+                printf("  FAIL | ARCH_SET_FS(0x%lx) returned %ld, errno=%d (%s)\n",
+                       low_addrs[i], ret, errno, strerror(errno));
+                failed = 1;
+                continue;
+            }
+            /* verify with ARCH_GET_FS */
+            unsigned long verify = 0;
+            if (raw_arch_prctl_ptr(ARCH_GET_FS, &verify) == 0) {
+                if (verify != low_addrs[i]) {
+                    printf("  FAIL | ARCH_SET_FS(0x%lx) but GET returned 0x%lx\n",
+                           low_addrs[i], verify);
+                    failed = 1;
+                } else {
+                    printf("  PASS | ARCH_SET_FS(0x%lx) succeeded\n",
+                           low_addrs[i]);
+                }
+            }
+        }
+
+        /* ARCH_SET_GS with low addresses */
+        for (int i = 0; i < n_low; i++) {
+            errno = 0;
+            long ret = raw_arch_prctl(ARCH_SET_GS, low_addrs[i]);
+            if (ret == -1 && errno == EINVAL) {
+                printf("  info | ARCH_SET_GS disabled by kernel, skip remaining\n");
+                break;
+            }
+            if (ret != 0) {
+                printf("  FAIL | ARCH_SET_GS(0x%lx) returned %ld, errno=%d (%s)\n",
+                       low_addrs[i], ret, errno, strerror(errno));
+                failed = 1;
+                continue;
+            }
+            /* verify with ARCH_GET_GS */
+            unsigned long verify = 0;
+            if (raw_arch_prctl_ptr(ARCH_GET_GS, &verify) == 0) {
+                if (verify != low_addrs[i]) {
+                    printf("  FAIL | ARCH_SET_GS(0x%lx) but GET returned 0x%lx\n",
+                           low_addrs[i], verify);
+                    failed = 1;
+                } else {
+                    printf("  PASS | ARCH_SET_GS(0x%lx) succeeded\n",
+                           low_addrs[i]);
+                }
+            }
+        }
+
+        /* restore original bases */
+        if (have_fs)
+            raw_arch_prctl(ARCH_SET_FS, orig_fs);
+        if (have_gs)
+            raw_arch_prctl(ARCH_SET_GS, orig_gs);
+
+        _exit(failed ? 1 : 0);
+    }
+
+    /* ---- parent ---- */
+    int status;
+    waitpid(pid, &status, 0);
+
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        printf("  PASS | low-address ARCH_SET_FS / ARCH_SET_GS all passed in child\n");
+        __pass++;
+    } else {
+        printf("  FAIL | low-address tests failed in child (exit=%d, sig=%d)\n",
+               WIFEXITED(status) ? WEXITSTATUS(status) : -1,
+               WIFSIGNALED(status) ? WTERMSIG(status) : 0);
+        __fail++;
+    }
+}
+
+/* 12. Verify that a user-mode #GP (General Protection Fault) delivers
+ *     SIGSEGV, not SIGTRAP. The kernel maps unrecognised exception
+ *     types to SIGSEGV (matching Linux/POSIX); before the fix these
+ *     were incorrectly mapped to SIGTRAP.
+ *     Run in a child that executes a privileged instruction (CLI)
+ *     from ring 3 to reliably trigger #GP. */
+static void test_gp_delivers_sigsegv(void)
+{
+    printf("--- #GP delivers SIGSEGV (fork) ---\n");
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        printf("  FAIL | fork() failed, errno=%d (%s)\n",
+               errno, strerror(errno));
+        __fail++;
+        return;
+    }
+
+    if (pid == 0) {
+        /* ---- child: trigger #GP via privileged instruction ---- */
+        __asm__ volatile("cli");
+        /* not reached if #GP fires */
+        _exit(0);
+    }
+
+    /* ---- parent ---- */
+    int status;
+    waitpid(pid, &status, 0);
+
+    if (WIFSIGNALED(status)) {
+        int sig = WTERMSIG(status);
+        if (sig == SIGSEGV) {
+            printf("  PASS | #GP delivered SIGSEGV (signal=%d)\n", sig);
+            __pass++;
+        } else if (sig == SIGTRAP) {
+            printf("  FAIL | #GP delivered SIGTRAP (signal=%d) — old buggy behavior\n", sig);
+            __fail++;
+        } else {
+            printf("  FAIL | #GP delivered unexpected signal=%d, expected SIGSEGV\n", sig);
+            __fail++;
+        }
+    } else if (WIFEXITED(status)) {
+        printf("  FAIL | privileged instruction did not fault (exit=%d)\n",
+               WEXITSTATUS(status));
+        __fail++;
+    } else {
+        printf("  FAIL | unexpected child status (status=%d)\n", status);
+        __fail++;
+    }
+}
+
 /* ============================================================
  * MAIN
  * ============================================================ */
@@ -375,6 +536,8 @@ int main(void)
     test_einval_invalid_op();
     test_efault_bad_pointer();
     test_eperm_invalid_address_set();
+    test_low_address_set_fs_gs();
+    test_gp_delivers_sigsegv();
 
     TEST_DONE();
 }

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/src/main.c
@@ -1,0 +1,393 @@
+/*
+ * test-arch-prctl.c - Test cases for arch_prctl(2) syscall (x86_64 only)
+ *
+ * Covers all arch_prctl subfunctions defined in asm/prctl.h:
+ *   - ARCH_SET_CPUID (0x1012) / ARCH_GET_CPUID (0x1011)
+ *   - ARCH_SET_FS    (0x1002) / ARCH_GET_FS    (0x1003)
+ *   - ARCH_SET_GS    (0x1001) / ARCH_GET_GS    (0x1004)
+ *
+ * Error cases tested:
+ *   EINVAL - invalid op code
+ *   EFAULT - bad pointer argument for GET operations
+ *   EPERM  - address outside process address space for SET operations
+ *   ENODEV - CPUID faulting not supported by hardware (handled gracefully)
+ *
+ * Note: ARCH_SET_FS is only tested as a no-op (set-to-same-value)
+ * because FS is used by the threading library for TLS.
+ * ARCH_SET_GS may be disabled in some kernels (handled gracefully).
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "test_framework.h"
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+
+#if defined(__x86_64__)
+
+/*
+ * arch_prctl subfunction codes from arch/x86/include/uapi/asm/prctl.h.
+ * Defined manually to avoid depending on <asm/prctl.h> which may not
+ * be available in all cross-compilation sysroots.
+ */
+#define ARCH_SET_GS    0x1001
+#define ARCH_SET_FS    0x1002
+#define ARCH_GET_FS    0x1003
+#define ARCH_GET_GS    0x1004
+#define ARCH_GET_CPUID 0x1011
+#define ARCH_SET_CPUID 0x1012
+
+/* arch_prctl is accessed via syscall(2) — no glibc/musl wrapper exists */
+static long raw_arch_prctl(int op, unsigned long addr)
+{
+    return syscall(SYS_arch_prctl, op, addr);
+}
+
+static long raw_arch_prctl_ptr(int op, unsigned long *addr)
+{
+    return syscall(SYS_arch_prctl, op, addr);
+}
+
+static char gs_test_buf[4096] __attribute__((aligned(4096)));
+
+/* ============================================================
+ * Happy-path tests
+ * ============================================================ */
+
+/* 1. ARCH_GET_CPUID — read the cpuid enable/disable flag */
+static void test_get_cpuid(void)
+{
+    printf("--- ARCH_GET_CPUID ---\n");
+
+    errno = 0;
+    long ret = raw_arch_prctl(ARCH_GET_CPUID, 0);
+
+    if (ret == -1) {
+        CHECK(ret == -1, "ARCH_GET_CPUID returns -1 (may be ENOSYS)");
+        printf("  info | ARCH_GET_CPUID errno=%d (%s)\n", errno, strerror(errno));
+        return;
+    }
+
+    CHECK(ret == 0 || ret == 1, "ARCH_GET_CPUID returns 0 or 1");
+    printf("  info | ARCH_GET_CPUID = %ld (%s)\n",
+           ret, ret == 1 ? "enabled" : "disabled");
+}
+
+/* 2. ARCH_SET_CPUID(1) — explicitly enable cpuid (no-op if already
+ *    enabled). Returns ENODEV if hardware lacks CPUID faulting. */
+static void test_set_cpuid_enable(void)
+{
+    printf("--- ARCH_SET_CPUID(enable) ---\n");
+
+    errno = 0;
+    long ret = raw_arch_prctl(ARCH_SET_CPUID, 1);
+
+    if (ret == 0) {
+        CHECK_RET(ret, 0, "ARCH_SET_CPUID(1) succeeds");
+    } else if (ret == -1 && errno == ENODEV) {
+        CHECK(ret == -1 && errno == ENODEV,
+              "ARCH_SET_CPUID(1) fails with ENODEV (HW lacks CPUID faulting)");
+        return;
+    } else if (ret == -1) {
+        CHECK(ret == -1, "ARCH_SET_CPUID(1) returns -1");
+        printf("  info | ARCH_SET_CPUID(1) errno=%d (%s)\n", errno, strerror(errno));
+        return;
+    }
+
+    errno = 0;
+    long state = raw_arch_prctl(ARCH_GET_CPUID, 0);
+    if (state != -1) {
+        CHECK(state == 1, "ARCH_GET_CPUID confirms cpuid is enabled");
+    }
+}
+
+/* 3. ARCH_SET_CPUID(0) disable → ARCH_GET_CPUID → re-enable */
+static void test_set_cpuid_disable_reenable(void)
+{
+    printf("--- ARCH_SET_CPUID(disable/re-enable) ---\n");
+
+    errno = 0;
+    long ret = raw_arch_prctl(ARCH_SET_CPUID, 0);
+
+    if (ret == -1 && errno == ENODEV) {
+        printf("  info | ARCH_SET_CPUID not supported (ENODEV), skip disable test\n");
+        CHECK(ret == -1 && errno == ENODEV,
+              "ARCH_SET_CPUID(0) fails with ENODEV");
+        return;
+    }
+    if (ret == -1) {
+        printf("  info | ARCH_SET_CPUID not supported, skip disable test\n");
+        CHECK(ret == -1, "ARCH_SET_CPUID(0) returns -1");
+        return;
+    }
+
+    CHECK_RET(ret, 0, "ARCH_SET_CPUID(0) succeeds");
+
+    errno = 0;
+    long state = raw_arch_prctl(ARCH_GET_CPUID, 0);
+    if (state != -1) {
+        CHECK(state == 0, "ARCH_GET_CPUID returns 0 (disabled)");
+    }
+
+    errno = 0;
+    ret = raw_arch_prctl(ARCH_SET_CPUID, 1);
+    CHECK_RET(ret, 0, "ARCH_SET_CPUID(1) re-enables cpuid");
+
+    errno = 0;
+    state = raw_arch_prctl(ARCH_GET_CPUID, 0);
+    if (state != -1) {
+        CHECK(state == 1, "ARCH_GET_CPUID returns 1 (re-enabled)");
+    }
+}
+
+/* 4. ARCH_GET_FS — read current FS base register */
+static void test_get_fs(void)
+{
+    printf("--- ARCH_GET_FS ---\n");
+
+    unsigned long fs_base = 0;
+    errno = 0;
+    long ret = raw_arch_prctl_ptr(ARCH_GET_FS, &fs_base);
+
+    if (ret == 0) {
+        CHECK_RET(ret, 0, "ARCH_GET_FS succeeds");
+        CHECK(fs_base != 0, "FS base is non-zero (TLS pointer)");
+        printf("  info | FS base = 0x%lx\n", fs_base);
+    } else {
+        CHECK(ret == -1, "ARCH_GET_FS returns -1");
+        printf("  info | ARCH_GET_FS errno=%d (%s)\n", errno, strerror(errno));
+    }
+}
+
+/* 5. ARCH_SET_FS(current) — set FS to its current value (safe no-op) */
+static void test_set_fs_same(void)
+{
+    printf("--- ARCH_SET_FS (set to same) ---\n");
+
+    unsigned long orig_fs = 0;
+    errno = 0;
+    long ret = raw_arch_prctl_ptr(ARCH_GET_FS, &orig_fs);
+    if (ret != 0) {
+        printf("  info | ARCH_GET_FS failed, skip ARCH_SET_FS test\n");
+        CHECK(ret == -1, "ARCH_GET_FS prerequisite failed");
+        return;
+    }
+
+    errno = 0;
+    ret = raw_arch_prctl(ARCH_SET_FS, orig_fs);
+
+    if (ret == 0) {
+        CHECK_RET(ret, 0, "ARCH_SET_FS(same base) succeeds");
+
+        unsigned long new_fs = 0;
+        errno = 0;
+        ret = raw_arch_prctl_ptr(ARCH_GET_FS, &new_fs);
+        if (ret == 0) {
+            CHECK(new_fs == orig_fs, "FS base unchanged after set-to-same");
+        }
+    } else if (ret == -1 && (errno == EPERM || errno == EINVAL)) {
+        CHECK(errno == EPERM || errno == EINVAL,
+              "ARCH_SET_FS(same base) returns EPERM or EINVAL (kernel restricted)");
+    } else {
+        CHECK(ret == -1, "ARCH_SET_FS(same base) returns -1");
+        printf("  info | ARCH_SET_FS errno=%d (%s)\n", errno, strerror(errno));
+    }
+}
+
+/* 6. ARCH_GET_GS — read current GS base register */
+static void test_get_gs(void)
+{
+    printf("--- ARCH_GET_GS ---\n");
+
+    unsigned long gs_base = 0;
+    errno = 0;
+    long ret = raw_arch_prctl_ptr(ARCH_GET_GS, &gs_base);
+
+    if (ret == 0) {
+        CHECK_RET(ret, 0, "ARCH_GET_GS succeeds");
+        printf("  info | GS base = 0x%lx\n", gs_base);
+    } else {
+        CHECK(ret == -1, "ARCH_GET_GS returns -1");
+        printf("  info | ARCH_GET_GS errno=%d (%s)\n", errno, strerror(errno));
+    }
+}
+
+/* 7. ARCH_SET_GS → ARCH_GET_GS round-trip.
+ *    ARCH_SET_GS may be disabled in some kernels (EINVAL). */
+static void test_set_get_gs(void)
+{
+    printf("--- ARCH_SET_GS / ARCH_GET_GS round-trip ---\n");
+
+    unsigned long orig_gs = 0;
+    errno = 0;
+    long ret = raw_arch_prctl_ptr(ARCH_GET_GS, &orig_gs);
+    if (ret != 0) {
+        printf("  info | ARCH_GET_GS failed, skip ARCH_SET_GS test\n");
+        CHECK(ret == -1, "ARCH_GET_GS prerequisite failed");
+        return;
+    }
+
+    unsigned long new_base = (unsigned long)(uintptr_t)gs_test_buf;
+    errno = 0;
+    ret = raw_arch_prctl(ARCH_SET_GS, new_base);
+
+    if (ret == -1 && errno == EINVAL) {
+        printf("  info | ARCH_SET_GS is disabled in this kernel (EINVAL)\n");
+        CHECK(errno == EINVAL,
+              "ARCH_SET_GS fails with EINVAL (kernel may disable GS writes)");
+        return;
+    }
+    if (ret == -1) {
+        printf("  info | ARCH_SET_GS errno=%d (%s)\n", errno, strerror(errno));
+        CHECK(ret == -1, "ARCH_SET_GS returns -1");
+        return;
+    }
+
+    CHECK_RET(ret, 0, "ARCH_SET_GS succeeds");
+
+    unsigned long verify_gs = 0;
+    errno = 0;
+    ret = raw_arch_prctl_ptr(ARCH_GET_GS, &verify_gs);
+    if (ret == 0) {
+        CHECK(verify_gs == new_base,
+              "ARCH_GET_GS returns the buffer address we set");
+    }
+
+    errno = 0;
+    ret = raw_arch_prctl(ARCH_SET_GS, orig_gs);
+    if (ret == 0) {
+        CHECK_RET(ret, 0, "ARCH_SET_GS(original) restores GS base");
+    } else {
+        printf("  info | restore GS base failed, errno=%d (%s)\n",
+               errno, strerror(errno));
+    }
+}
+
+/* ============================================================
+ * Error-path tests
+ * ============================================================ */
+
+/* 8. EINVAL — invalid op codes */
+static void test_einval_invalid_op(void)
+{
+    printf("--- EINVAL on invalid op ---\n");
+
+    CHECK_ERR(raw_arch_prctl(0, 0), EINVAL,
+              "op=0 returns EINVAL");
+
+    CHECK_ERR(raw_arch_prctl(-1, 0), EINVAL,
+              "op=-1 (large unsigned) returns EINVAL");
+
+    CHECK_ERR(raw_arch_prctl(0x9999, 0), EINVAL,
+              "op=0x9999 (unknown) returns EINVAL");
+
+    errno = 0;
+    long ret = raw_arch_prctl(0x2001, (unsigned long)(uintptr_t)gs_test_buf);
+    if (ret == -1) {
+        CHECK(errno == EINVAL || errno == ENOSYS || errno == EPERM
+              || errno == EEXIST,
+              "op=0x2001 (ARCH_MAP_VDSO_X32) fails cleanly");
+    }
+}
+
+/* 9. EFAULT — invalid pointer for GET operations */
+static void test_efault_bad_pointer(void)
+{
+    printf("--- EFAULT on bad pointer ---\n");
+
+    CHECK_ERR(raw_arch_prctl_ptr(ARCH_GET_FS, NULL), EFAULT,
+              "ARCH_GET_FS(NULL) returns EFAULT");
+
+    CHECK_ERR(raw_arch_prctl_ptr(ARCH_GET_GS, NULL), EFAULT,
+              "ARCH_GET_GS(NULL) returns EFAULT");
+
+    unsigned long *bad_ptr = (unsigned long *)-1;
+    CHECK_ERR(raw_arch_prctl_ptr(ARCH_GET_FS, bad_ptr), EFAULT,
+              "ARCH_GET_FS(-1) returns EFAULT");
+
+    CHECK_ERR(raw_arch_prctl_ptr(ARCH_GET_GS, bad_ptr), EFAULT,
+              "ARCH_GET_GS(-1) returns EFAULT");
+}
+
+/* 10. EPERM — address outside process address space for SET operations.
+ *     The kernel checks whether the address is in the canonical userspace
+ *     range (below TASK_SIZE_MAX, ~0x00007fffffffffff on 47-bit).
+ *     Addresses with the high bit set are non-canonical userspace. */
+static void test_eperm_invalid_address_set(void)
+{
+    printf("--- EPERM on invalid address ---\n");
+
+    unsigned long bad_addr = 0x8000000000000000UL;
+
+    errno = 0;
+    long ret = raw_arch_prctl(ARCH_SET_GS, bad_addr);
+    if (ret == -1 && (errno == EPERM || errno == EINVAL)) {
+        CHECK(errno == EPERM || errno == EINVAL,
+              "ARCH_SET_GS(non-canonical addr) returns EPERM or EINVAL");
+    } else if (ret == -1) {
+        CHECK(ret == -1, "ARCH_SET_GS(non-canonical addr) returns -1");
+        printf("  info | errno=%d (%s)\n", errno, strerror(errno));
+    } else {
+        CHECK(ret == -1, "ARCH_SET_GS(non-canonical addr) should have failed");
+    }
+
+    errno = 0;
+    ret = raw_arch_prctl(ARCH_SET_FS, bad_addr);
+    if (ret == -1 && (errno == EPERM || errno == EINVAL)) {
+        CHECK(errno == EPERM || errno == EINVAL,
+              "ARCH_SET_FS(non-canonical addr) returns EPERM or EINVAL");
+    } else if (ret == -1) {
+        CHECK(ret == -1, "ARCH_SET_FS(non-canonical addr) returns -1");
+        printf("  info | errno=%d (%s)\n", errno, strerror(errno));
+    } else {
+        CHECK(ret == -1, "ARCH_SET_FS(non-canonical addr) should have failed");
+    }
+}
+
+/* ============================================================
+ * MAIN
+ * ============================================================ */
+
+int main(void)
+{
+    TEST_START("arch_prctl syscall");
+
+    memset(gs_test_buf, 0xAB, sizeof(gs_test_buf));
+
+    test_get_cpuid();
+    test_set_cpuid_enable();
+    test_set_cpuid_disable_reenable();
+
+    test_get_fs();
+    test_set_fs_same();
+
+    test_get_gs();
+    test_set_get_gs();
+
+    test_einval_invalid_op();
+    test_efault_bad_pointer();
+    test_eperm_invalid_address_set();
+
+    TEST_DONE();
+}
+
+#else  /* ! __x86_64__ */
+
+int main(void)
+{
+    TEST_START("arch_prctl syscall");
+
+    printf("  SKIP: arch_prctl is x86_64 specific, not available on this architecture\n");
+
+    TEST_DONE();
+}
+
+#endif /* __x86_64__ */

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-arch-prctl/c/src/test_framework.h
@@ -1,0 +1,86 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno)); \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno,     \
+               strerror(errno));                                        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
## Problem
1. `arch_prctl(ARCH_SET_FS, addr)` and `ARCH_SET_GS` accepted any address
   without validation, including non-canonical addresses such as
   `0x8000000000000000`. Linux rejects these with `EPERM`.
See [Linux implementation](https://github.com/torvalds/linux/blob/f5e5d3509bffb95c6648eb9795f7f236852ae62d/arch/x86/kernel/process_64.c#L866-L898)
2. Protection exceptions triggered from user space (`#GP`, `#SS`, `#NP`,
   `#TS`, etc.) were delivered as `SIGTRAP`. Linux and POSIX deliver
   `SIGSEGV` for these faults.
## Changes
### `thread.rs` — address validation for ARCH_SET_FS / ARCH_SET_GS
Added `check_addr` that rejects addresses at or above
`USER_SPACE_BASE + USER_SPACE_SIZE` (`0x8000_0000_0000`, the canonical
boundary for 47-bit x86-64 user space) with
`AxError::OperationNotPermitted` → `EPERM`. Both `ARCH_SET_FS` and
`ARCH_SET_GS` now pass through this check.
Also removed an incorrect comment claiming "SetFs & SetGs does not return
error at all".
### `user.rs` — exception signal mapping
Changed the fallback signal for `ExceptionKind::Other` (which covers
`#GP`, `#SS`, `#NP`, `#TS`, and other protection faults) from
`SIGTRAP` to `SIGSEGV`, matching Linux behavior.
## Future Work: CPUID Faulting
The analysis of Linux's `arch_prctl` and `set_cpuid_faulting()`
implementations identified a clear path toward real CPUID faulting
support. The plan is:
1. **Hardware detection** — Detect CPUID faulting support by reading
   `CPUID.(EAX=1).ECX[31]` on Intel or `CPUID.(EAX=8000_0001).ECX[1]`
   on AMD. Run lazily on first access to avoid interfering with very
   early boot.
2. **Per-thread state** — Store a `cpuid_enabled: bool` field on
   `UserContext` (default `true`), inherited on clone, reset on execve.
   Wire `ARCH_SET_CPUID` / `ARCH_GET_CPUID` to this field.
3. **MSR management** — In `UserContext::run()`, toggle the appropriate
   MSR before entering and after returning from user space:
   - Intel: `IA32_MISC_FEATURES_ENABLES` (`0x140`) bit 0
   - AMD: `MSR_K7_HWCR` (`0xC001_0015`) bit 1
   Since these MSRs only affect CPL > 0, kernel-mode CPUID is never
   affected.
4. **Exception handling** — No changes needed. When CPUID faulting is
   enabled and a user process executes `CPUID`, the hardware raises
   `#GP(0)`, which (after this PR) already maps to `SIGSEGV`.
   User-space signal handlers can inspect the faulting instruction and
   emulate CPUID if desired.