### PR TITLE
feat(drivers): add K230 KPU driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4957,6 +4957,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "k230-kpu"
+version = "0.1.0"
+
+[[package]]
 name = "kapi"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,6 +288,7 @@ rdif-timer = { version = "0.6.1", path = "drivers/interface/rdif-timer" }
 rdif-vsock = { version = "0.1.0", path = "drivers/interface/rdif-vsock" }
 rk3588-pci = { version = "0.2.0", path = "drivers/pci/rk3588-pci" }
 rockchip-npu = { version = "0.2.1", path = "drivers/npu/rockchip-npu" }
+k230-kpu = { version = "0.1.0", path = "drivers/npu/k230-kpu" }
 realtek-rtl8125 = { version = "0.2.0", path = "drivers/net/realtek-rtl8125" }
 rockchip-pm = { version = "0.4.3", path = "drivers/soc/rockchip/rockchip-pm" }
 rockchip-soc = { version = "0.3.0", path = "drivers/soc/rockchip/rockchip-soc" }

--- a/drivers/npu/k230-kpu/Cargo.toml
+++ b/drivers/npu/k230-kpu/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "k230-kpu"
+version = "0.1.0"
+repository = "https://github.com/rcore-os/tgoskits"
+description = "Register-level driver for the Kendryte K230 KPU."
+keywords = ["arceos", "starryos", "k230", "kpu", "npu"]
+categories = ["embedded", "no-std", "hardware-support"]
+edition.workspace = true
+authors = ["rcore-os developers"]
+license.workspace = true
+
+[dependencies]
+
+[package.metadata.docs.rs]
+targets = ["riscv64gc-unknown-none-elf"]

--- a/drivers/npu/k230-kpu/include/k230_kpu_uapi.h
+++ b/drivers/npu/k230-kpu/include/k230_kpu_uapi.h
@@ -1,0 +1,77 @@
+#ifndef K230_KPU_UAPI_H
+#define K230_KPU_UAPI_H
+
+#include <stdint.h>
+
+#define KPU_DEVICE_PATH "/dev/kpu"
+#define KPU_DEVICE_ALIAS_PATH "/dev/kpu0"
+
+#define KPU_IOC_GET_STATUS 0x4b00u
+#define KPU_IOC_CLEAR 0x4b01u
+#define KPU_IOC_PROGRAM_COMMAND 0x4b02u
+#define KPU_IOC_START 0x4b03u
+#define KPU_IOC_RUN 0x4b04u
+#define KPU_IOC_WAIT_DONE 0x4b05u
+#define KPU_IOC_GET_INFO 0x4b06u
+#define KPU_IOC_GET_IRQ_COUNT 0x4b07u
+
+#define KPU_MMAP_CFG_OFFSET 0x0ull
+#define KPU_MMAP_L2_OFFSET 0x1000ull
+#define KPU_MMAP_FAKE_OUTPUT_OFFSET 0x2000ull
+#define KPU_MMAP_RUNTIME_RDATA_OFFSET 0x3000ull
+#define KPU_MMAP_RUNTIME_COMMAND_OFFSET 0x4000ull
+#define KPU_MMAP_RUNTIME_DIRECT_IO_OFFSET 0x5000ull
+#define KPU_MMAP_RUNTIME_DDR_OFFSET 0x6000ull
+
+#define KPU_CFG_PADDR 0x80400000ull
+#define KPU_L2_PADDR 0x80000000ull
+#define KPU_FAKE_OUTPUT_PADDR 0x10090000ull
+#define KPU_RUNTIME_RDATA_PADDR 0x10000000ull
+#define KPU_RUNTIME_COMMAND_PADDR 0x10190000ull
+#define KPU_RUNTIME_DIRECT_IO_PADDR 0x10500000ull
+#define KPU_RUNTIME_DDR_PADDR 0x3c000000ull
+
+#define KPU_RUNTIME_RDATA_BASE 0x10000020ull
+#define KPU_RUNTIME_FUNCTION_COMMAND_PADDR 0x1032b020ull
+#define KPU_RUNTIME_ARG_TABLE_PADDR 0x80000000ull
+#define KPU_RUNTIME_DIRECT_SOURCE_PADDR 0x10500020ull
+#define KPU_RUNTIME_DIRECT_OUTPUT_PADDR 0x10501020ull
+
+#define KPU_CFG_SIZE 0x800u
+#define KPU_L2_SIZE 0x200000u
+#define KPU_FAKE_OUTPUT_SIZE 0x100000u
+#define KPU_RUNTIME_RDATA_SIZE 0x90000u
+#define KPU_RUNTIME_COMMAND_SIZE 0x370000u
+#define KPU_RUNTIME_DIRECT_IO_SIZE 0xb00000u
+#define KPU_RUNTIME_DDR_SIZE 0x4000000u
+
+#define KPU_IRQ_NONE 0xffffffffu
+#define KPU_INFO_F_FDT 0x1u
+#define KPU_INFO_F_IRQ_WAIT 0x2u
+#define KPU_INFO_F_FAKE_OUTPUT 0x4u
+#define KPU_INFO_F_RUNTIME_SCRATCH 0x8u
+
+#define KPU_COMMAND_START 0x100u
+#define KPU_COMMAND_END 0x104u
+#define KPU_COMMAND_HI 0x108u
+#define KPU_CONTROL 0x128u
+#define KPU_STATUS_LO 0x130u
+#define KPU_STATUS_HI 0x134u
+
+#define KPU_DONE_STATUS 0x0000000400000004ull
+
+struct k230_kpu_command_range {
+    uint64_t start_paddr;
+    uint64_t end_paddr;
+};
+
+struct k230_kpu_info {
+    uint64_t cfg_paddr;
+    uint64_t cfg_size;
+    uint64_t l2_paddr;
+    uint64_t l2_size;
+    uint32_t irq;
+    uint32_t flags;
+};
+
+#endif

--- a/drivers/npu/k230-kpu/src/lib.rs
+++ b/drivers/npu/k230-kpu/src/lib.rs
@@ -1,0 +1,306 @@
+#![no_std]
+
+use core::{hint::spin_loop, ptr};
+
+pub const KPU_CFG_PADDR: usize = 0x8040_0000;
+pub const KPU_CFG_SIZE: usize = 0x800;
+pub const KPU_L2_PADDR: usize = 0x8000_0000;
+pub const KPU_L2_SIZE: usize = 0x20_0000;
+pub const KPU_IRQ: usize = 189;
+pub const KPU_FAKE_OUTPUT_PADDR: usize = 0x1009_0000;
+pub const KPU_FAKE_OUTPUT_SIZE: usize = 0x10_0000;
+pub const KPU_RUNTIME_RDATA_PADDR: usize = 0x1000_0000;
+pub const KPU_RUNTIME_RDATA_SIZE: usize = 0x9_0000;
+pub const KPU_RUNTIME_COMMAND_PADDR: usize = 0x1019_0000;
+pub const KPU_RUNTIME_COMMAND_SIZE: usize = 0x37_0000;
+pub const KPU_RUNTIME_DIRECT_IO_PADDR: usize = 0x1050_0000;
+pub const KPU_RUNTIME_DIRECT_IO_SIZE: usize = 0xb0_0000;
+pub const KPU_RUNTIME_DDR_PADDR: usize = 0x3c00_0000;
+pub const KPU_RUNTIME_DDR_SIZE: usize = 0x400_0000;
+
+pub const KPU_RUNTIME_RDATA_BASE: usize = 0x1000_0020;
+pub const KPU_RUNTIME_FUNCTION_COMMAND_PADDR: usize = 0x1032_b020;
+pub const KPU_RUNTIME_ARG_TABLE_PADDR: usize = KPU_L2_PADDR;
+pub const KPU_RUNTIME_DIRECT_SOURCE_PADDR: usize = 0x1050_0020;
+pub const KPU_RUNTIME_DIRECT_OUTPUT_PADDR: usize = 0x1050_1020;
+
+pub const COMMAND_START: usize = 0x100;
+pub const COMMAND_END: usize = 0x104;
+pub const COMMAND_HI: usize = 0x108;
+pub const CONTROL: usize = 0x128;
+pub const STATUS_LO: usize = 0x130;
+pub const STATUS_HI: usize = 0x134;
+
+pub const CONTROL_CLEAR: u32 = 0x4;
+pub const CONTROL_START: u32 = 0x9;
+pub const DONE_STATUS: u64 = 0x0000_0004_0000_0004;
+
+pub const KPU_IOC_GET_STATUS: u32 = 0x4b00;
+pub const KPU_IOC_CLEAR: u32 = 0x4b01;
+pub const KPU_IOC_PROGRAM_COMMAND: u32 = 0x4b02;
+pub const KPU_IOC_START: u32 = 0x4b03;
+pub const KPU_IOC_RUN: u32 = 0x4b04;
+pub const KPU_IOC_WAIT_DONE: u32 = 0x4b05;
+pub const KPU_IOC_GET_INFO: u32 = 0x4b06;
+pub const KPU_IOC_GET_IRQ_COUNT: u32 = 0x4b07;
+
+pub const KPU_MMAP_CFG_OFFSET: u64 = 0;
+pub const KPU_MMAP_L2_OFFSET: u64 = 0x1000;
+pub const KPU_MMAP_FAKE_OUTPUT_OFFSET: u64 = 0x2000;
+pub const KPU_MMAP_RUNTIME_RDATA_OFFSET: u64 = 0x3000;
+pub const KPU_MMAP_RUNTIME_COMMAND_OFFSET: u64 = 0x4000;
+pub const KPU_MMAP_RUNTIME_DIRECT_IO_OFFSET: u64 = 0x5000;
+pub const KPU_MMAP_RUNTIME_DDR_OFFSET: u64 = 0x6000;
+
+pub const KPU_IRQ_NONE: u32 = u32::MAX;
+pub const KPU_INFO_F_FDT: u32 = 0x1;
+pub const KPU_INFO_F_IRQ_WAIT: u32 = 0x2;
+pub const KPU_INFO_F_FAKE_OUTPUT: u32 = 0x4;
+pub const KPU_INFO_F_RUNTIME_SCRATCH: u32 = 0x8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    CommandRangeCrosses4G,
+    CommandRangeEmpty,
+    TimedOut,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandRange {
+    pub start_paddr: u64,
+    pub end_paddr: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KpuInfo {
+    pub cfg_paddr: u64,
+    pub cfg_size: u64,
+    pub l2_paddr: u64,
+    pub l2_size: u64,
+    pub irq: u32,
+    pub flags: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Kpu {
+    base_vaddr: usize,
+}
+
+impl Kpu {
+    /// # Safety
+    ///
+    /// `base_vaddr` must point to a valid mapped K230 KPU CFG MMIO window.
+    pub const unsafe fn new(base_vaddr: usize) -> Self {
+        Self { base_vaddr }
+    }
+
+    pub fn program_command(&self, range: CommandRange) -> Result<(), Error> {
+        let (start, end, hi) = command_words(range)?;
+        self.write_reg(COMMAND_START, start);
+        self.write_reg(COMMAND_END, end);
+        self.write_reg(COMMAND_HI, hi);
+        Ok(())
+    }
+
+    pub fn run_command(&self, range: CommandRange) -> Result<(), Error> {
+        self.clear_done();
+        self.program_command(range)?;
+        self.start();
+        Ok(())
+    }
+
+    pub fn clear_done(&self) {
+        self.write_reg(CONTROL, CONTROL_CLEAR);
+    }
+
+    pub fn start(&self) {
+        self.write_reg(CONTROL, CONTROL_START);
+    }
+
+    pub fn status(&self) -> u64 {
+        let lo = self.read_reg(STATUS_LO) as u64;
+        let hi = self.read_reg(STATUS_HI) as u64;
+        (hi << 32) | lo
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.status() & DONE_STATUS == DONE_STATUS
+    }
+
+    pub fn wait_done(&self, poll_limit: usize) -> Result<(), Error> {
+        for _ in 0..poll_limit {
+            if self.is_done() {
+                return Ok(());
+            }
+            spin_loop();
+        }
+        Err(Error::TimedOut)
+    }
+
+    pub fn read_reg(&self, offset: usize) -> u32 {
+        unsafe { ptr::read_volatile((self.base_vaddr + offset) as *const u32) }
+    }
+
+    pub fn write_reg(&self, offset: usize, value: u32) {
+        unsafe { ptr::write_volatile((self.base_vaddr + offset) as *mut u32, value) }
+    }
+}
+
+pub fn command_words(range: CommandRange) -> Result<(u32, u32, u32), Error> {
+    if range.start_paddr >= range.end_paddr {
+        return Err(Error::CommandRangeEmpty);
+    }
+    if range.start_paddr >> 32 != range.end_paddr >> 32 {
+        return Err(Error::CommandRangeCrosses4G);
+    }
+    Ok((
+        range.start_paddr as u32,
+        range.end_paddr as u32,
+        (range.start_paddr >> 32) as u32,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UAPI_HEADER: &str = include_str!("../include/k230_kpu_uapi.h");
+
+    fn define_value(name: &str) -> Option<&'static str> {
+        UAPI_HEADER.lines().find_map(|line| {
+            let mut parts = line.split_whitespace();
+            (parts.next()? == "#define" && parts.next()? == name)
+                .then(|| parts.next().unwrap_or(""))
+        })
+    }
+
+    fn assert_define(name: &str, expected: &str) {
+        assert_eq!(define_value(name), Some(expected), "UAPI define {name}");
+    }
+
+    #[test]
+    fn command_words_accept_same_4g_window() {
+        assert_eq!(
+            command_words(CommandRange {
+                start_paddr: 0x1_0000_1000,
+                end_paddr: 0x1_0000_2000,
+            }),
+            Ok((0x1000, 0x2000, 0x1))
+        );
+    }
+
+    #[test]
+    fn command_words_reject_empty_range() {
+        assert_eq!(
+            command_words(CommandRange {
+                start_paddr: 0x1000,
+                end_paddr: 0x1000,
+            }),
+            Err(Error::CommandRangeEmpty)
+        );
+    }
+
+    #[test]
+    fn command_words_reject_crossing_4g_window() {
+        assert_eq!(
+            command_words(CommandRange {
+                start_paddr: 0xffff_ff00,
+                end_paddr: 0x1_0000_0100,
+            }),
+            Err(Error::CommandRangeCrosses4G)
+        );
+    }
+
+    #[test]
+    fn uapi_header_matches_rust_constants() {
+        assert_eq!(core::mem::size_of::<CommandRange>(), 16);
+        assert_eq!(core::mem::offset_of!(CommandRange, start_paddr), 0);
+        assert_eq!(core::mem::offset_of!(CommandRange, end_paddr), 8);
+
+        assert_define("KPU_IOC_GET_STATUS", "0x4b00u");
+        assert_define("KPU_IOC_CLEAR", "0x4b01u");
+        assert_define("KPU_IOC_PROGRAM_COMMAND", "0x4b02u");
+        assert_define("KPU_IOC_START", "0x4b03u");
+        assert_define("KPU_IOC_RUN", "0x4b04u");
+        assert_define("KPU_IOC_WAIT_DONE", "0x4b05u");
+        assert_define("KPU_IOC_GET_INFO", "0x4b06u");
+        assert_define("KPU_IOC_GET_IRQ_COUNT", "0x4b07u");
+        assert_define("KPU_MMAP_CFG_OFFSET", "0x0ull");
+        assert_define("KPU_MMAP_L2_OFFSET", "0x1000ull");
+        assert_define("KPU_MMAP_FAKE_OUTPUT_OFFSET", "0x2000ull");
+        assert_define("KPU_MMAP_RUNTIME_RDATA_OFFSET", "0x3000ull");
+        assert_define("KPU_MMAP_RUNTIME_COMMAND_OFFSET", "0x4000ull");
+        assert_define("KPU_MMAP_RUNTIME_DIRECT_IO_OFFSET", "0x5000ull");
+        assert_define("KPU_MMAP_RUNTIME_DDR_OFFSET", "0x6000ull");
+        assert_define("KPU_CFG_PADDR", "0x80400000ull");
+        assert_define("KPU_L2_PADDR", "0x80000000ull");
+        assert_define("KPU_FAKE_OUTPUT_PADDR", "0x10090000ull");
+        assert_define("KPU_RUNTIME_RDATA_PADDR", "0x10000000ull");
+        assert_define("KPU_RUNTIME_COMMAND_PADDR", "0x10190000ull");
+        assert_define("KPU_RUNTIME_DIRECT_IO_PADDR", "0x10500000ull");
+        assert_define("KPU_RUNTIME_DDR_PADDR", "0x3c000000ull");
+        assert_define("KPU_RUNTIME_RDATA_BASE", "0x10000020ull");
+        assert_define("KPU_RUNTIME_FUNCTION_COMMAND_PADDR", "0x1032b020ull");
+        assert_define("KPU_RUNTIME_ARG_TABLE_PADDR", "0x80000000ull");
+        assert_define("KPU_RUNTIME_DIRECT_SOURCE_PADDR", "0x10500020ull");
+        assert_define("KPU_RUNTIME_DIRECT_OUTPUT_PADDR", "0x10501020ull");
+        assert_define("KPU_CFG_SIZE", "0x800u");
+        assert_define("KPU_L2_SIZE", "0x200000u");
+        assert_define("KPU_FAKE_OUTPUT_SIZE", "0x100000u");
+        assert_define("KPU_RUNTIME_RDATA_SIZE", "0x90000u");
+        assert_define("KPU_RUNTIME_COMMAND_SIZE", "0x370000u");
+        assert_define("KPU_RUNTIME_DIRECT_IO_SIZE", "0xb00000u");
+        assert_define("KPU_RUNTIME_DDR_SIZE", "0x4000000u");
+        assert_define("KPU_IRQ_NONE", "0xffffffffu");
+        assert_define("KPU_INFO_F_FDT", "0x1u");
+        assert_define("KPU_INFO_F_IRQ_WAIT", "0x2u");
+        assert_define("KPU_INFO_F_FAKE_OUTPUT", "0x4u");
+        assert_define("KPU_INFO_F_RUNTIME_SCRATCH", "0x8u");
+        assert_define("KPU_COMMAND_START", "0x100u");
+        assert_define("KPU_COMMAND_END", "0x104u");
+        assert_define("KPU_COMMAND_HI", "0x108u");
+        assert_define("KPU_CONTROL", "0x128u");
+        assert_define("KPU_STATUS_LO", "0x130u");
+        assert_define("KPU_STATUS_HI", "0x134u");
+        assert_define("KPU_DONE_STATUS", "0x0000000400000004ull");
+
+        assert_eq!(KPU_IOC_GET_STATUS, 0x4b00);
+        assert_eq!(KPU_IOC_CLEAR, 0x4b01);
+        assert_eq!(KPU_IOC_PROGRAM_COMMAND, 0x4b02);
+        assert_eq!(KPU_IOC_START, 0x4b03);
+        assert_eq!(KPU_IOC_RUN, 0x4b04);
+        assert_eq!(KPU_IOC_WAIT_DONE, 0x4b05);
+        assert_eq!(KPU_IOC_GET_INFO, 0x4b06);
+        assert_eq!(KPU_IOC_GET_IRQ_COUNT, 0x4b07);
+        assert_eq!(KPU_MMAP_CFG_OFFSET, 0);
+        assert_eq!(KPU_MMAP_L2_OFFSET, 0x1000);
+        assert_eq!(KPU_MMAP_FAKE_OUTPUT_OFFSET, 0x2000);
+        assert_eq!(KPU_CFG_PADDR, 0x8040_0000);
+        assert_eq!(KPU_L2_PADDR, 0x8000_0000);
+        assert_eq!(KPU_FAKE_OUTPUT_PADDR, 0x1009_0000);
+        assert_eq!(KPU_CFG_SIZE, 0x800);
+        assert_eq!(KPU_L2_SIZE, 0x20_0000);
+        assert_eq!(KPU_FAKE_OUTPUT_SIZE, 0x10_0000);
+        assert_eq!(KPU_IRQ_NONE, u32::MAX);
+        assert_eq!(KPU_INFO_F_FDT, 0x1);
+        assert_eq!(KPU_INFO_F_IRQ_WAIT, 0x2);
+        assert_eq!(KPU_INFO_F_FAKE_OUTPUT, 0x4);
+        assert_eq!(COMMAND_START, 0x100);
+        assert_eq!(COMMAND_END, 0x104);
+        assert_eq!(COMMAND_HI, 0x108);
+        assert_eq!(CONTROL, 0x128);
+        assert_eq!(STATUS_LO, 0x130);
+        assert_eq!(STATUS_HI, 0x134);
+        assert_eq!(DONE_STATUS, 0x0000_0004_0000_0004);
+
+        assert_eq!(core::mem::size_of::<KpuInfo>(), 40);
+        assert_eq!(core::mem::offset_of!(KpuInfo, cfg_paddr), 0);
+        assert_eq!(core::mem::offset_of!(KpuInfo, cfg_size), 8);
+        assert_eq!(core::mem::offset_of!(KpuInfo, l2_paddr), 16);
+        assert_eq!(core::mem::offset_of!(KpuInfo, l2_size), 24);
+        assert_eq!(core::mem::offset_of!(KpuInfo, irq), 32);
+        assert_eq!(core::mem::offset_of!(KpuInfo, flags), 36);
+    }
+}


### PR DESCRIPTION
## 背景/问题

K230 的 NPU 在官方资料和 QEMU model 中称为 KPU。后续 StarryOS `/dev/kpu`、KPU smoke、NNCase runtime demo 都需要一层可复用的寄存器级 driver core 来统一 KPU MMIO、command range、done status、runtime window 和用户态 UAPI 常量。

本 PR 是 K230 KPU/NPU 适配拆分提交的第二层，只新增独立 no_std driver crate，不接入 StarryOS devfs，也不引入 QEMU case 或真实模型资产，避免把 driver core 和 OS glue 混在同一个 review 单元中。

## 主要修改

- 新增 `drivers/npu/k230-kpu` no_std crate，并加入 workspace 与 workspace dependencies。
- 封装 K230 KPU CFG/L2/IRQ、fake output、runtime rdata、runtime command、runtime direct I/O、runtime DDR 等窗口常量。
- 提供 `CommandRange`、`KpuInfo` 和 `Kpu` 寄存器级接口：
  - `program_command()` 写入 command start/end/high register。
  - `run_command()` 完成 clear、program、start 的最小启动序列。
  - `status()`、`is_done()`、`wait_done()` 读取和等待 QEMU KPU done status。
- 新增 `include/k230_kpu_uapi.h`，用于后续 StarryOS 用户态 smoke/demo 共享 ioctl、mmap offset、窗口和结构体定义。
- 增加 crate 单测，校验 command range 编码、非法范围拒绝，以及 Rust 常量与 C UAPI header 的同步关系。

## 设计理由

- Driver crate 保持 no_std 和 OS independent，只包含硬件寄存器、地址窗口、状态轮询和 C ABI 形状；FDT probe、iomap、IRQ wait queue、devfs 注册等 OS glue 留到后续 PR。
- KPU command range 要求 start/end 位于同一个 4GiB high word，因此在 driver core 中集中检查，避免后续 `/dev/kpu` ioctl 或用户态 demo 重复实现并产生不一致行为。
- C UAPI header 与 Rust 常量放在同一个 crate 中，并用单测检查同步，后续 test-suit C case 可以直接复用 header，不需要手写另一套魔数。
- runtime window 常量先在 driver crate 固化，后续 StarryOS `/dev/kpu` mmap 和 NNCase compat shim 可以共用同一套地址布局。

## 验证

已在 Docker/Linux 环境验证：

```bash
cargo fmt
cargo test -p k230-kpu
cargo xtask clippy --package k230-kpu
git diff --check
```

关键结果：

```text
running 4 tests
4 passed; 0 failed

[1/1] k230-kpu (base, target: riscv64gc-unknown-none-elf)
ok: k230-kpu
all clippy checks passed
```

## 已知限制

- 本 PR 只提交 K230 KPU 寄存器级 driver core 和 UAPI 常量。
- StarryOS `/dev/kpu`、ioctl/mmap 实现、IRQ-backed wait、KPU smoke QEMU case 会在后续 PR 中提交。
- NNCase runtime demo、真实 `.kmodel` 加载和 YOLOv8n 应用层展示不在本 PR 范围内。