### PR TITLE
feat(riscv64): compute dynamic kernel load address from _head

### DIFF
--- a/components/someboot/src/arch/riscv64/entry.rs
+++ b/components/someboot/src/arch/riscv64/entry.rs
@@ -70,11 +70,12 @@ fn primary_entry(fdt_addr: usize) -> ! {
     <<super::Arch as crate::ArchTrait>::Console as crate::console::ArchConsoleOps>::init();
     println!("RISC-V64 SBI kernel entry.");
 
-    let kernel_start = super::kernel_load_address();
+    let kernel_code_start_lma = ext_sym_addr!(_head);
+    let kernel_code_end_lma = ext_sym_addr!(__kernel_code_end);
 
     crate::entry::primary_init_early(PrimaryCpuInitInfo {
-        kernel_start: kernel_start.into(),
-        kernel_end: (__kernel_code_end as *const () as usize).into(),
+        kernel_start: kernel_code_start_lma.into(),
+        kernel_end: kernel_code_end_lma.into(),
         kernel_start_link: crate::consts::VM_LOAD_ADDRESS.into(),
     });
     super::paging::enable_mmu()

--- a/components/someboot/src/arch/riscv64/mod.rs
+++ b/components/someboot/src/arch/riscv64/mod.rs
@@ -18,7 +18,6 @@ pub use relocate::apply as relocate;
 
 use crate::{
     ArchTrait, DCacheOp,
-    consts::KERNEL_LOAD_ADDRESS,
     mem::{PageTableInfo, mmu},
     power::CpuOnError,
 };
@@ -420,10 +419,6 @@ impl ArchTrait for Arch {
     unsafe fn efi_enter_kernel(_system_table: *const ::core::ffi::c_void) -> bool {
         false
     }
-}
-
-pub(crate) fn kernel_load_address() -> usize {
-    KERNEL_LOAD_ADDRESS
 }
 
 pub(crate) fn current_page_table() -> PageTableInfo {

--- a/os/StarryOS/configs/board/k230-canmv.toml
+++ b/os/StarryOS/configs/board/k230-canmv.toml
@@ -1,4 +1,3 @@
-env = { SOMEBOOT_RISCV64_KERNEL_LOAD_PADDR = "0x08200000" }
 features = [
   "k230",
 ]

--- a/test-suit/starryos/k230-qemu/qemu-k230/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/k230-qemu/qemu-k230/build-riscv64gc-unknown-none-elf.toml
@@ -1,4 +1,3 @@
-env = { SOMEBOOT_RISCV64_KERNEL_LOAD_PADDR = "0x08200000" }
 features = [
   "k230",
 ]


### PR DESCRIPTION
## 问题

RISC-V64 动态平台启动时，someboot 的重定位偏移已经通过运行时 `_head - VM_LOAD_ADDRESS` 计算，但传给早期内存初始化的 `kernel_start` 仍来自构建期 `KERNEL_LOAD_ADDRESS`。这会让不同板卡通过构建配置覆写加载地址，例如 K230 需要额外设置 `SOMEBOOT_RISCV64_KERNEL_LOAD_PADDR`。

## 修改

- 将 RISC-V64 someboot 的 `PrimaryCpuInitInfo.kernel_start` 改为运行时 `ext_sym_addr!(_head)`。
- 将 `kernel_end` 同步改为运行时 `ext_sym_addr!(__kernel_code_end)`，与 aarch64 的处理方式保持一致。
- 删除不再使用的 `kernel_load_address()` helper 和 `KERNEL_LOAD_ADDRESS` 引用。
- 移除 K230 构建配置中的 `SOMEBOOT_RISCV64_KERNEL_LOAD_PADDR` 覆盖。
- 保留 SG2002 board/U-Boot 运行配置中的 `kernel_load_addr`、`fit_load_addr`、`bootm_addr`，这些地址仍用于外部加载镜像。

## 方案逻辑

RISC-V64 的 relocation 逻辑本身已经依赖运行时 `_head` 计算 load offset，因此早期内存初始化也应使用同一运行时地址源。这样 KImage 预留、映射和 `VM_LOAD_OFFSET` 都由实际加载位置决定，而不是由构建期物理地址常量决定。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package someboot`
- `cargo test -p axbuild starry::build`
- `cargo test -p axbuild starry::quick_start`
- `cargo xtask starry build --target riscv64gc-unknown-none-elf --config os/StarryOS/configs/board/qemu-riscv64.toml`
- `cargo xtask starry test board --test-group normal --test-case boot --board licheerv-nano-sg2002`