### PR TITLE
fix(starry-kernel): avoid patching crates.io ax-errno

### DIFF
--- a/.claude/skills/review-single-pr/SKILL.md
+++ b/.claude/skills/review-single-pr/SKILL.md
@@ -178,6 +178,24 @@ Do not accept "success path" tests that silently skip on unexpected failure, suc
 
 Do not accept changes that simplify, skip, or weaken existing CI/test requirements unless the PR clearly justifies an equivalent or stronger replacement and the replacement is validated. Treat as blocking when a PR removes cases from normal groups, narrows architectures, loosens `success_regex`/`fail_regex`, converts failures into skips/timeouts, changes workflow path filters so relevant tests no longer run, or moves coverage from CI into an opt-in/manual path without preserving normal regression coverage.
 
+### Crates.io Patch And Dependency Boundaries
+
+When a PR touches `Cargo.toml`, `Cargo.lock`, dependency metadata, duplicate crate versions, third-party dependency APIs, or error-boundary code, inspect whether it adds, changes, or relies on a `[patch.crates-io]` override. Do not approve PRs that patch any crates.io dependency to a local path, fork, or git revision. This includes, but is not limited to, redirects like `[patch.crates-io] ax-errno = { path = "components/axerrno" }`.
+
+Normal workspace dependency declarations, such as a workspace member using `{ path = "...", version = "..." }`, are not the same as a crates.io patch. The blocking case is overriding crates.io resolution for a dependency that another crate expects to get from the registry.
+
+The preferred fix is to keep third-party dependencies using their normal crates.io resolution and adapt only at the local boundary:
+
+- use the dependency crate's exported public types, traits, error types, or result aliases instead of referencing or replacing that dependency's internal dependency paths;
+- add a crate-private adapter near the boundary when local code needs a local type, error, trait object, or ABI representation;
+- replace implicit `?` conversions that cross dependency-local and workspace-local types with explicit `.map_err(...)`, `TryFrom`, wrapper newtypes, or a crate-private extension trait;
+- keep dependency-facing trait/API code in the dependency's own exported types when it is still implementing or satisfying that dependency's public boundary;
+- if the dependency itself is wrong, prefer an upstream fix or a normal dependency upgrade path, not a workspace-level crates.io patch in the PR.
+
+For error-type mismatches, convert through stable public information exposed by the dependency. For example, when the dependency exports an errno-bearing error, convert the public code into the local errno/error type at the boundary and provide an explicit fallback for unknown values.
+
+For the known `kbpf-basic`/Starry eBPF case, the review should suggest this shape instead of accepting an `ax-errno` patch: keep `kbpf-basic` on crates.io `ax-errno`; use `kbpf_basic::BpfError` and `kbpf_basic::BpfResult`; add a crate-private eBPF error adapter that converts `err.code()` into local `ax_errno::LinuxError` and then `ax_errno::AxError`; use that adapter in Starry eBPF/perf entry points that return local `AxResult`.
+
 ## Duplicate And Overlap Analysis
 
 This analysis is required for every PR, not only bug fixes. Its purpose is to avoid approving duplicate implementations, stale rework, superseded fixes, or PRs that unknowingly conflict with another open PR.
@@ -235,6 +253,23 @@ cargo xtask axvisor build ... --vmconfigs <config>
 
 If `cargo xtask` does not cover a special configuration, inspect the relevant `xtask` help or source before falling back to native Cargo with matched arguments. Record exact commands and failures.
 
+For dependency metadata changes, inspect dependency resolution instead of relying only on the diff. Check for any crates.io patch first, then inspect the affected dependency subtree:
+
+```bash
+rg -n '\[patch\.crates-io\]' -g 'Cargo.toml' .
+cargo metadata --format-version=1 | jq -r '.packages[] | [.name,.version,.source,.manifest_path] | @tsv' | rg '<affected-crate>'
+cargo tree -p <affected-package> | rg '<affected-crate>|<boundary-crate>'
+```
+
+For the `kbpf-basic`/`ax-errno` example, useful focused checks are:
+
+```bash
+cargo metadata --format-version=1 | jq -r '.packages[] | select(.name=="ax-errno") | [.version,.source,.manifest_path] | @tsv'
+cargo tree -p starry-kernel | sed -n '/kbpf-basic v0.5.7/,+12p'
+```
+
+The expected result for that example is that local workspace crates still use local `components/axerrno`, while `kbpf-basic` resolves its own crates.io `ax-errno` and local Starry eBPF/perf code performs explicit error conversion at the boundary.
+
 For StarryOS grouped QEMU cases, verify that new `test_commands` are actually discovered and installed into the guest overlay. A `qemu-*.toml` command such as `/usr/bin/<test>` must correspond to a case/subcase asset path that the runner discovers and builds. Running the containing grouped case is the preferred check, for example `cargo xtask starry test qemu --arch x86_64 -c syscall`. Treat `/usr/bin/<test>: not found`, `status=127`, skipped discovery, unbuilt asset directories, unreliable `success_regex`/`fail_regex`, or tests that accept both broken and fixed behavior as blocking.
 
 For bugfix tests in grouped cases, inspect the new test's assertions as well as running the case. A grouped case passing is not sufficient when the new test accepts both the fixed behavior and the broken behavior.
@@ -279,6 +314,7 @@ Treat these as blocking unless clearly non-blocking:
 - a claimed non-board validation method is not actually reproducible or does not match the claimed coverage/result;
 - `success_regex` or `fail_regex` cannot reliably classify the intended StarryOS case result;
 - bug fixes lack meaningful reproduction coverage;
+- the PR adds, changes, or relies on `[patch.crates-io]` to redirect any crates.io dependency to a local path, fork, or git revision, instead of adapting through the dependency's exported public API or an explicit local boundary adapter;
 - merge conflicts are unresolved, conflict repair resurrects outdated base APIs instead of adapting PR intent to current base, or the repaired head was not revalidated after push;
 - StarryOS app-support PRs place app workflows under `test-suit/starryos/normal` instead of `apps/starry`, or place syscall/bugfix semantic coverage only under `apps/starry` instead of the matching normal test-suit case;
 - the implementation is a test-only or fake fix that does not implement the intended behavior;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ version = "1.0.3"
 dependencies = [
  "ax-api",
  "ax-driver",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-feat",
  "ax-hal",
  "ax-io",
@@ -577,7 +577,7 @@ name = "arm_vcpu"
 version = "0.5.9"
 dependencies = [
  "aarch64-cpu 11.2.0",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-percpu",
  "axaddrspace",
  "axdevice_base",
@@ -594,7 +594,7 @@ version = "0.4.10"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "aarch64_sysreg",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "axaddrspace",
@@ -694,7 +694,7 @@ dependencies = [
 name = "ax-alloc"
 version = "0.7.2"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "ax-percpu",
@@ -711,7 +711,7 @@ dependencies = [
 name = "ax-allocator"
 version = "0.5.2"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax_slab_allocator",
  "bitmap-allocator",
  "buddy_system_allocator 0.10.0",
@@ -729,7 +729,7 @@ dependencies = [
  "ax-config",
  "ax-display",
  "ax-dma",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-feat",
  "ax-fs",
  "ax-hal",
@@ -872,7 +872,7 @@ dependencies = [
  "ax-alloc",
  "ax-arm-pl031",
  "ax-crate-interface",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kernel-guard",
  "ax-kspin",
  "axklib",
@@ -925,6 +925,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ax-errno"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984a5bfdec820bd61a2cec72b0e3cf6359bc9d4aa1fdc7a4b13fc5d5a14cfa81"
+dependencies = [
+ "log",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "ax-feat"
 version = "0.5.16"
 dependencies = [
@@ -952,7 +962,7 @@ name = "ax-fs"
 version = "0.5.14"
 dependencies = [
  "ax-cap-access",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-fs-devfs",
  "ax-fs-ramfs",
  "ax-fs-vfs",
@@ -980,7 +990,7 @@ name = "ax-fs-ng"
 version = "0.5.15"
 dependencies = [
  "ax-alloc",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-hal",
  "ax-io",
  "ax-kspin",
@@ -1014,7 +1024,7 @@ dependencies = [
 name = "ax-fs-vfs"
 version = "0.3.11"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "bitflags 2.11.1",
  "log",
 ]
@@ -1118,7 +1128,7 @@ version = "0.3.7"
 name = "ax-io"
 version = "0.5.7"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "heapless 0.9.3",
  "memchr",
 ]
@@ -1162,7 +1172,7 @@ name = "ax-libc"
 version = "0.5.15"
 dependencies = [
  "ax-driver",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-feat",
  "ax-hal",
  "ax-io",
@@ -1204,7 +1214,7 @@ version = "0.6.8"
 name = "ax-memory-set"
 version = "0.6.9"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-memory-addr",
 ]
 
@@ -1213,7 +1223,7 @@ name = "ax-mm"
 version = "0.5.15"
 dependencies = [
  "ax-alloc",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-hal",
  "ax-kspin",
  "ax-lazyinit",
@@ -1227,7 +1237,7 @@ dependencies = [
 name = "ax-net"
 version = "0.5.14"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-hal",
  "ax-io",
  "ax-lazyinit",
@@ -1247,7 +1257,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "ax-config",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-fs-ng",
  "ax-hal",
  "ax-io",
@@ -1284,7 +1294,7 @@ name = "ax-page-table-multiarch"
 version = "0.8.10"
 dependencies = [
  "arrayvec",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-memory-addr",
  "ax-page-table-entry",
  "bitmaps",
@@ -1552,7 +1562,7 @@ version = "0.5.16"
 dependencies = [
  "ax-alloc",
  "ax-config",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-feat",
  "ax-fs",
  "ax-hal",
@@ -1585,7 +1595,7 @@ dependencies = [
  "ax-ctor-bare",
  "ax-display",
  "ax-driver",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-fs",
  "ax-fs-ng",
  "ax-hal",
@@ -1632,7 +1642,7 @@ name = "ax-std"
 version = "0.5.15"
 dependencies = [
  "ax-api",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-feat",
  "ax-io",
  "ax-kspin",
@@ -1660,7 +1670,7 @@ dependencies = [
  "ax-config",
  "ax-cpumask",
  "ax-crate-interface",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-hal",
  "ax-ipi",
  "ax-kernel-guard",
@@ -1698,7 +1708,7 @@ name = "axaddrspace"
 version = "0.5.11"
 dependencies = [
  "assert_matches",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-lazyinit",
  "ax-memory-addr",
@@ -1777,7 +1787,7 @@ name = "axdevice"
 version = "0.4.10"
 dependencies = [
  "arm_vgic",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "axaddrspace",
@@ -1794,7 +1804,7 @@ dependencies = [
 name = "axdevice_base"
 version = "0.4.11"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "axaddrspace",
  "axvmconfig",
  "serde",
@@ -1824,7 +1834,7 @@ dependencies = [
 name = "axfs-ng-vfs"
 version = "0.4.2"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "axpoll",
  "bitflags 2.11.1",
@@ -1839,7 +1849,7 @@ dependencies = [
 name = "axhvc"
 version = "0.4.8"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
 ]
 
 [[package]]
@@ -1859,7 +1869,7 @@ name = "axklib"
 version = "0.5.9"
 dependencies = [
  "ax-alloc",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-memory-addr",
  "dma-api",
  "irq-framework",
@@ -1872,7 +1882,7 @@ name = "axnsproxy"
 version = "0.1.0"
 dependencies = [
  "ax-config",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "linux-raw-sys 0.12.1",
  "log",
@@ -1891,7 +1901,7 @@ dependencies = [
  "ax-config-macros",
  "ax-cpu",
  "ax-driver",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-memory-addr",
  "ax-percpu",
  "ax-plat",
@@ -1971,7 +1981,7 @@ dependencies = [
 name = "axvcpu"
 version = "0.5.9"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "ax-percpu",
@@ -1990,7 +2000,7 @@ dependencies = [
  "ax-cpumask",
  "ax-crate-interface",
  "ax-driver",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-hal",
  "ax-kernel-guard",
  "ax-kspin",
@@ -2060,7 +2070,7 @@ dependencies = [
  "arm_vcpu",
  "arm_vgic",
  "ax-cpumask",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "ax-page-table-entry",
@@ -2084,7 +2094,7 @@ dependencies = [
 name = "axvmconfig"
 version = "0.5.2"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "clap",
  "enumerable",
  "env_logger",
@@ -5022,7 +5032,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c066bb7997a6daf34a35ad2790570f32f33677dec17538781bbaff4be2248e"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 2.11.1",
  "int-enum",
  "log",
@@ -5312,7 +5322,7 @@ dependencies = [
 name = "loongarch_vcpu"
 version = "0.5.3"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "ax-page-table-multiarch",
@@ -7052,7 +7062,7 @@ name = "riscv_vcpu"
 version = "0.5.9"
 dependencies = [
  "ax-crate-interface",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-memory-addr",
  "ax-page-table-entry",
  "axaddrspace",
@@ -7076,7 +7086,7 @@ dependencies = [
 name = "riscv_vplic"
 version = "0.4.12"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "axaddrspace",
  "axdevice_base",
@@ -7669,7 +7679,7 @@ name = "sg2002-tpu"
 version = "0.1.2"
 dependencies = [
  "ax-dma",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "log",
@@ -8031,7 +8041,7 @@ dependencies = [
  "ax-display",
  "ax-dma",
  "ax-driver",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-feat",
  "ax-fs-ng",
  "ax-input",
@@ -8120,7 +8130,7 @@ name = "starry-signal"
 version = "0.7.0"
 dependencies = [
  "ax-cpu",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "bitflags 2.11.1",
  "cfg-if",
@@ -8137,7 +8147,7 @@ dependencies = [
 name = "starry-vm"
 version = "0.5.9"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "bytemuck",
  "extern-trait",
 ]
@@ -10222,7 +10232,7 @@ name = "x86_vcpu"
 version = "0.5.9"
 dependencies = [
  "ax-crate-interface",
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "ax-page-table-entry",
@@ -10248,7 +10258,7 @@ dependencies = [
 name = "x86_vlapic"
 version = "0.4.10"
 dependencies = [
- "ax-errno",
+ "ax-errno 0.6.0",
  "ax-kspin",
  "ax-memory-addr",
  "axaddrspace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,9 +364,3 @@ simple-ahci = "0.1.1-preview.1"
 bcm2835-sdhci = "0.1.1-preview.1"
 ixgbe-driver = "0.1.1-preview.1"
 x86 = "0.52"
-
-# `kbpf-basic` depends on `ax-errno` from crates.io; redirect it to our own
-# workspace copy so the kernel and kbpf-basic share a single `ax-errno`
-# (otherwise `BpfError`/`AxError` would be two distinct types).
-[patch.crates-io]
-ax-errno = { path = "components/axerrno" }

--- a/os/StarryOS/kernel/src/ebpf/error.rs
+++ b/os/StarryOS/kernel/src/ebpf/error.rs
@@ -1,0 +1,19 @@
+//! Error adapters for the `kbpf-basic` boundary.
+
+use ax_errno::{AxError, LinuxError};
+
+pub(crate) fn bpf_err_to_ax(err: kbpf_basic::BpfError) -> AxError {
+    LinuxError::try_from(err.code())
+        .map(AxError::from)
+        .unwrap_or_else(|_| AxError::from(LinuxError::EINVAL))
+}
+
+pub(crate) trait BpfResultExt<T> {
+    fn into_ax_result(self) -> ax_errno::AxResult<T>;
+}
+
+impl<T> BpfResultExt<T> for kbpf_basic::BpfResult<T> {
+    fn into_ax_result(self) -> ax_errno::AxResult<T> {
+        self.map_err(bpf_err_to_ax)
+    }
+}

--- a/os/StarryOS/kernel/src/ebpf/mod.rs
+++ b/os/StarryOS/kernel/src/ebpf/mod.rs
@@ -31,6 +31,7 @@ use kbpf_basic::{
     raw_tracepoint::BpfRawTracePointArg,
 };
 
+pub(crate) mod error;
 pub mod map;
 pub mod prog;
 pub mod transform;
@@ -38,7 +39,7 @@ pub mod transform;
 pub use transform::EbpfKernelAuxiliary;
 
 use crate::{
-    ebpf::{map::create_map, prog::load_prog},
+    ebpf::{error::BpfResultExt, map::create_map, prog::load_prog},
     file::add_file_like,
     mm::VmBytes,
     perf::raw_tracepoint::bpf_raw_tracepoint_open,
@@ -75,8 +76,8 @@ fn read_bpf_attr(uattr: usize, size: u32) -> AxResult<bpf_attr> {
 }
 
 fn handle_map_create(attr: &bpf_attr) -> AxResult<isize> {
-    let meta = BpfMapMeta::try_from(attr)?;
-    let map = create_map(meta)?;
+    let meta = BpfMapMeta::try_from(attr).into_ax_result()?;
+    let map = create_map(meta).into_ax_result()?;
     // Linux always creates bpf object fds with `O_CLOEXEC`
     // (`anon_inode_getfd(..., O_CLOEXEC)` in `kernel/bpf/syscall.c`).
     let fd = add_file_like(Arc::new(map), true)?;
@@ -84,8 +85,8 @@ fn handle_map_create(attr: &bpf_attr) -> AxResult<isize> {
 }
 
 fn handle_prog_load(attr: &bpf_attr) -> AxResult<isize> {
-    let mut meta = BpfProgMeta::try_from_bpf_attr::<EbpfKernelAuxiliary>(attr)?;
-    let prog = load_prog(&mut meta)?;
+    let mut meta = BpfProgMeta::try_from_bpf_attr::<EbpfKernelAuxiliary>(attr).into_ax_result()?;
+    let prog = load_prog(&mut meta).into_ax_result()?;
     // bpf prog fds are close-on-exec in Linux as well; see `handle_map_create`.
     let fd = add_file_like(Arc::new(prog), true)?;
     Ok(fd as isize)
@@ -93,42 +94,43 @@ fn handle_prog_load(attr: &bpf_attr) -> AxResult<isize> {
 
 fn handle_map_update(attr: &bpf_attr) -> AxResult<isize> {
     let arg = BpfMapUpdateArg::from(attr);
-    bpf_map_update_elem::<EbpfKernelAuxiliary>(arg)?;
+    bpf_map_update_elem::<EbpfKernelAuxiliary>(arg).into_ax_result()?;
     Ok(0)
 }
 
 fn handle_map_lookup(attr: &bpf_attr) -> AxResult<isize> {
     let arg = BpfMapUpdateArg::from(attr);
-    bpf_lookup_elem::<EbpfKernelAuxiliary>(arg)?;
+    bpf_lookup_elem::<EbpfKernelAuxiliary>(arg).into_ax_result()?;
     Ok(0)
 }
 
 fn handle_map_delete(attr: &bpf_attr) -> AxResult<isize> {
     let arg = BpfMapUpdateArg::from(attr);
-    bpf_map_delete_elem::<EbpfKernelAuxiliary>(arg)?;
+    bpf_map_delete_elem::<EbpfKernelAuxiliary>(arg).into_ax_result()?;
     Ok(0)
 }
 
 fn handle_map_get_next_key(attr: &bpf_attr) -> AxResult<isize> {
     let arg = BpfMapGetNextKeyArg::from(attr);
-    bpf_map_get_next_key::<EbpfKernelAuxiliary>(arg)?;
+    bpf_map_get_next_key::<EbpfKernelAuxiliary>(arg).into_ax_result()?;
     Ok(0)
 }
 
 fn handle_map_freeze(attr: &bpf_attr) -> AxResult<isize> {
     let map_fd = unsafe { attr.__bindgen_anon_2.map_fd };
-    bpf_map_freeze::<EbpfKernelAuxiliary>(map_fd)?;
+    bpf_map_freeze::<EbpfKernelAuxiliary>(map_fd).into_ax_result()?;
     Ok(0)
 }
 
 fn handle_map_lookup_and_delete(attr: &bpf_attr) -> AxResult<isize> {
     let arg = BpfMapUpdateArg::from(attr);
-    bpf_map_lookup_and_delete_elem::<EbpfKernelAuxiliary>(arg)?;
+    bpf_map_lookup_and_delete_elem::<EbpfKernelAuxiliary>(arg).into_ax_result()?;
     Ok(0)
 }
 
 fn handle_raw_tracepoint_open(attr: &bpf_attr) -> AxResult<isize> {
-    let arg = BpfRawTracePointArg::try_from_bpf_attr::<EbpfKernelAuxiliary>(attr)?;
+    let arg =
+        BpfRawTracePointArg::try_from_bpf_attr::<EbpfKernelAuxiliary>(attr).into_ax_result()?;
     bpf_raw_tracepoint_open(arg)
 }
 

--- a/os/StarryOS/kernel/src/perf/bpf.rs
+++ b/os/StarryOS/kernel/src/perf/bpf.rs
@@ -23,7 +23,7 @@ use rbpf::EbpfVmRaw;
 
 use super::PerfEventOps;
 use crate::{
-    ebpf::{BPF_HELPER_FUN_SET, prog::BpfProg},
+    ebpf::{BPF_HELPER_FUN_SET, error::BpfResultExt, prog::BpfProg},
     file::FileLike,
 };
 
@@ -55,9 +55,7 @@ impl BpfPerfEventWrapper {
             // — Linux behavior on EINVAL would alarm libbpf-style readers.
             return Ok(());
         }
-        self.inner
-            .write_event(data)
-            .map_err(|_| AxError::InvalidInput)?;
+        self.inner.write_event(data).into_ax_result()?;
         if self.inner.enabled() {
             self.poll_ready.wake();
         }
@@ -73,12 +71,12 @@ impl Debug for BpfPerfEventWrapper {
 
 impl PerfEventOps for BpfPerfEventWrapper {
     fn enable(&mut self) -> AxResult<()> {
-        self.inner.enable().map_err(|_| AxError::InvalidInput)?;
+        self.inner.enable().into_ax_result()?;
         Ok(())
     }
 
     fn disable(&mut self) -> AxResult<()> {
-        self.inner.disable().map_err(|_| AxError::InvalidInput)?;
+        self.inner.disable().into_ax_result()?;
         Ok(())
     }
 

--- a/os/StarryOS/kernel/src/perf/mod.rs
+++ b/os/StarryOS/kernel/src/perf/mod.rs
@@ -31,7 +31,7 @@ use kbpf_basic::{
 };
 
 use crate::{
-    ebpf::transform::EbpfKernelAuxiliary,
+    ebpf::{error::BpfResultExt, transform::EbpfKernelAuxiliary},
     file::{FileLike, Kstat, add_file_like, get_file_like},
     mm::VmBytes,
 };
@@ -160,7 +160,7 @@ pub fn perf_event_open(
 ) -> AxResult<isize> {
     let args =
         PerfProbeArgs::try_from_perf_attr::<EbpfKernelAuxiliary>(attr, pid, cpu, group_fd, flags)
-            .map_err(|_| AxError::InvalidInput)?;
+            .into_ax_result()?;
     let event: Box<dyn PerfEventOps> = match args.type_ {
         PerfTypeId::PERF_TYPE_KPROBE => Box::new(kprobe::perf_event_open_kprobe(args)?),
         PerfTypeId::PERF_TYPE_SOFTWARE => Box::new(bpf::perf_event_open_bpf(args)),


### PR DESCRIPTION
## 问题

当前根 `Cargo.toml` 通过 `[patch.crates-io]` 将 crates.io 的 `ax-errno` 重定向到本地 `components/axerrno`，用于让 `kbpf-basic` 和本地内核共享同一个错误类型。这会改变第三方依赖的 crates.io 解析结果，也让后续 PR 容易继续用 patch 来解决依赖边界类型不一致的问题。

## 修改内容

- 移除根 `Cargo.toml` 中的 `[patch.crates-io] ax-errno`，并更新 `Cargo.lock`，让 `kbpf-basic` 继续解析自己的 crates.io `ax-errno`。
- 在 Starry eBPF 模块新增 crate-private 错误适配层，把 `kbpf_basic::BpfError` 通过 `err.code()` 转换成本地 `ax_errno::LinuxError`，再转换为本地 `ax_errno::AxError`，未知 errno 回退到本地 `EINVAL`。
- 在 Starry eBPF/perf 进入本地 `AxResult` 的边界处显式调用转换，避免依赖 `?` 跨两个不同来源的 `ax-errno` 类型隐式传播。
- 更新 `review-single-pr` 技能：审查 PR 时将任意新增、修改或依赖 `[patch.crates-io]` 重定向 crates.io 依赖的做法视为阻塞问题，并建议通过依赖导出的公开类型和本地边界适配解决。

## 方案逻辑

第三方依赖应保持其正常的 crates.io 依赖解析；本地内核只在自己的 API 边界把第三方库导出的错误类型转换成本地错误类型。这样既避免 patch 全局依赖图，也保留了本地 `AxResult` 对外接口不变。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package starry-kernel`：12 个检查全部通过
- `rg -n '\[patch\.crates-io\]' -g 'Cargo.toml' .`：未发现 `[patch.crates-io]`
- `cargo metadata --format-version=1 | jq -r '.packages[] | select(.name=="ax-errno") | [.version,.source,.manifest_path] | @tsv'`：确认同时存在本地 `components/axerrno` 和 registry `ax-errno`
- `cargo tree -p starry-kernel | sed -n '/kbpf-basic v0.5.7/,+12p'`：确认 `kbpf-basic` 依赖自己的 `ax-errno v0.6.0`
- `git diff --check`