### PR TITLE
fix(codex-cli): align Starry QEMU examples

### DIFF
--- a/apps/starry/codex-cli/README.md
+++ b/apps/starry/codex-cli/README.md
@@ -30,7 +30,7 @@ apps/starry/codex-cli/prepare_codex_rootfs.sh \
 ```bash
 cargo xtask starry qemu \
   --arch x86_64 \
-  --qemu-config apps/starry/codex-cli/qemu-x86_64-codex-help.toml \
+  --qemu-config apps/starry/codex-cli/qemu-x86_64.toml \
   --rootfs tmp/axbuild/rootfs/rootfs-x86_64-alpine.img
 ```
 
@@ -98,6 +98,7 @@ cd /tmp/tgoskits-demo
 git clone --depth 1 --branch dev https://github.com/rcore-os/tgoskits.git repo
 cd repo
 codex exec \
+  -m gpt-5.4 \
   --dangerously-bypass-approvals-and-sandbox \
   -C /tmp/tgoskits-demo/repo \
   'Please read this repository and briefly describe its StarryOS syscall test structure. Answer in Simplified Chinese.'

--- a/apps/starry/codex-cli/prepare_codex_rootfs.sh
+++ b/apps/starry/codex-cli/prepare_codex_rootfs.sh
@@ -227,7 +227,7 @@ echo "  $rootfs"
 echo
 echo "Run the offline help example with:"
 echo "  cargo xtask starry qemu --arch x86_64 \\"
-echo "    --qemu-config apps/starry/codex-cli/qemu-x86_64-codex-help.toml \\"
+echo "    --qemu-config apps/starry/codex-cli/qemu-x86_64.toml \\"
 echo "    --rootfs $display_rootfs"
 if [[ -n "$auth_json" ]]; then
     echo

--- a/apps/starry/codex-cli/qemu-x86_64-codex-syscall-hunt.toml
+++ b/apps/starry/codex-cli/qemu-x86_64-codex-syscall-hunt.toml
@@ -100,6 +100,7 @@ EOF
 codex exec \
   --dangerously-bypass-approvals-and-sandbox \
   --color never \
+  -m gpt-5.4 \
   -C /tmp/tgoskits-syscall-hunt/repo \
   --output-last-message /tmp/codex-tgoskits-syscall-hunt.txt \
   "$(cat /tmp/tgoskits-syscall-hunt-prompt.txt)"


### PR DESCRIPTION
问题：
- Codex CLI 的 Starry 离线示例同时存在 README 和 prepare_codex_rootfs.sh 两个操作入口。此前 README 已改为仓库当前存在的 qemu-x86_64.toml，但脚本结束提示仍输出不存在的 qemu-x86_64-codex-help.toml，用户按脚本提示执行会直接失败。
- 在线 syscall-hunt 示例默认模型在当前登录环境下也无法直接运行。

修改：
- 将 README 中的离线 QEMU 示例统一为 apps/starry/codex-cli/qemu-x86_64.toml。
- 将 prepare_codex_rootfs.sh 结束提示中的离线运行命令同步更新为 qemu-x86_64.toml，保证脚本输出和 README 一致。
- 让在线 QEMU 配置及手动交互命令显式使用 gpt-5.4。

说明：
- 离线示例需要保证文档、脚本提示和仓库内实际存在的配置文件完全一致，这样用户无论从 README 还是准备脚本进入，都能执行同一条可用命令。
- 在线示例显式指定模型，是为了避免当前账号环境下默认模型不可用带来的额外失败。
