### PR TITLE
feat(vfs): proper uid/gid ownership tracking for filesystem nodes

### DIFF
--- a/apps/starry/postgresql/README.md
+++ b/apps/starry/postgresql/README.md
@@ -1,0 +1,61 @@
+# Starry PostgreSQL App
+
+This case runs a PostgreSQL smoke test in StarryOS through the app runner.
+
+```bash
+cargo xtask starry app run -t postgresql --arch x86_64
+cargo xtask starry app run -t postgresql --arch aarch64
+cargo xtask starry app run -t postgresql --arch riscv64
+cargo xtask starry app run -t postgresql --arch loongarch64
+```
+
+The guest test uses prebuilt PostgreSQL 16.4 binaries injected by `prebuild.sh`.
+It initializes a fresh database cluster via `initdb`, starts `postgres` over TCP
+on port 5433, verifies `SELECT 1`, then runs a structured SQL workload over the
+`starry_test` database. The workload covers:
+
+- DDL: table creation with foreign keys and indexes
+- DML: multi-row inserts, updates, deletes
+- Queries: filtering, ordering, aggregation, joins
+- Transactions: commit and rollback
+- Bulk insert via `generate_series`
+- Persistence: server restart and data verification
+
+Before injecting the test script, `prebuild.sh` refreshes the app-specific
+rootfs from the cached clean Alpine archive, cross-compiles PostgreSQL 16.4
+with musl for the target architecture, and copies the binaries and their
+runtime library dependencies into the rootfs overlay.
+
+## Prerequisites
+
+The `prebuild.sh` script requires a musl cross-compiler for the target
+architecture:
+
+| Architecture | Cross-compiler package |
+|-------------|----------------------|
+| riscv64 | `riscv64-linux-musl-gcc` |
+| aarch64 | `aarch64-linux-musl-gcc` |
+| x86_64 | `x86_64-linux-musl-gcc` |
+| loongarch64 | `loongarch64-linux-musl-gcc` |
+
+On macOS, these can be installed via [musl-cross-make](https://github.com/richfelker/musl-cross-make).
+On Linux, use your distribution's cross-compiler packages.
+
+## Required Kernel Patches
+
+Running PostgreSQL requires the following kernel patches (all merged to tgoskits `dev`):
+
+- Process credentials subsystem (setuid/setresuid/getuid etc.)
+- SA_RESTART syscall restart for signal-interrupted syscalls
+- DTB-based physical memory discovery (PostgreSQL needs ~300MB+)
+- RLIMIT_STACK default set to 8MB (Linux default)
+- fsync/fdatasync directory support
+- sync_file_range stub
+- prctl PR_SET_PDEATHSIG support
+- epoll_pwait sigsetsize compatibility (musl's 16-byte sigset_t)
+
+## Known Limitations
+
+- `initdb` is slow (~40s on riscv64 QEMU) due to emulation overhead
+- Requires dynamic linking with `--export-dynamic` for extension `dlopen`
+- `pgbench` TPC-B runs pending per-file uid/gid storage in VFS

--- a/apps/starry/postgresql/README_CN.md
+++ b/apps/starry/postgresql/README_CN.md
@@ -1,0 +1,59 @@
+# Starry PostgreSQL 应用
+
+这个用例通过 StarryOS 的 app runner 运行 PostgreSQL 冒烟测试。
+
+```bash
+cargo xtask starry app run -t postgresql --arch x86_64
+cargo xtask starry app run -t postgresql --arch aarch64
+cargo xtask starry app run -t postgresql --arch riscv64
+cargo xtask starry app run -t postgresql --arch loongarch64
+```
+
+Guest 内的测试使用 `prebuild.sh` 注入的预编译 PostgreSQL 16.4 二进制文件。
+测试通过 `initdb` 初始化全新的数据库集群，在 5433 端口通过 TCP 启动
+`postgres`，先验证 `SELECT 1`，然后在 `starry_test` 数据库上执行一组
+结构化的 SQL 工作负载。覆盖内容：
+
+- DDL: 带外键和索引的建表
+- DML: 多行插入、更新、删除
+- 查询: 过滤、排序、聚合、连接查询
+- 事务: 提交和回滚
+- 批量插入: 通过 `generate_series`
+- 持久化: 服务重启和数据校验
+
+在注入测试脚本之前，`prebuild.sh` 会从缓存的干净 Alpine 归档刷新该应用
+专用的 rootfs，用 musl 为目标架构交叉编译 PostgreSQL 16.4，并将二进制文件
+及其运行时库依赖复制到 rootfs overlay 中。
+
+## 前置条件
+
+`prebuild.sh` 需要目标架构的 musl 交叉编译器：
+
+| 架构 | 交叉编译器 |
+|------|----------|
+| riscv64 | `riscv64-linux-musl-gcc` |
+| aarch64 | `aarch64-linux-musl-gcc` |
+| x86_64 | `x86_64-linux-musl-gcc` |
+| loongarch64 | `loongarch64-linux-musl-gcc` |
+
+macOS 上可通过 [musl-cross-make](https://github.com/richfelker/musl-cross-make) 安装，
+Linux 上使用发行版自带的交叉编译器包。
+
+## 需要的内核补丁
+
+运行 PostgreSQL 需要以下内核改动（均已合入 tgoskits `dev`）：
+
+- 进程凭证子系统（setuid/setresuid/getuid 等 13 个系统调用）
+- SA_RESTART 系统调用重启
+- DTB 物理内存发现（PostgreSQL 需要约 300MB+ 内存）
+- RLIMIT_STACK 默认值修正（512K → 8MB，匹配 Linux 默认值）
+- fsync/fdatasync 目录支持
+- sync_file_range 存根
+- prctl PR_SET_PDEATHSIG 支持
+- epoll_pwait sigsetsize 兼容（musl 的 16 字节 sigset_t）
+
+## 已知限制
+
+- `initdb` 较慢（riscv64 QEMU 上约 40 秒），为 QEMU 模拟开销
+- 需要动态链接 + `--export-dynamic` 以支持扩展模块 `dlopen`
+- `pgbench` TPC-B 基线测试：待 VFS 层支持 per-file uid/gid 存储后执行

--- a/apps/starry/postgresql/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/postgresql/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,14 @@
+target = "aarch64-unknown-none-softfloat"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = [
+  "ax-hal/aarch64-qemu-virt",
+  "qemu",
+  "ax-driver/plat-static",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]
+plat_dyn = false

--- a/apps/starry/postgresql/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/postgresql/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,14 @@
+target = "loongarch64-unknown-none-softfloat"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = [
+  "ax-hal/loongarch64-qemu-virt",
+  "qemu",
+  "ax-driver/plat-static",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]
+plat_dyn = false

--- a/apps/starry/postgresql/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/postgresql/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+target = "riscv64gc-unknown-none-elf"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = [
+  "ax-hal/riscv64-qemu-virt",
+  "qemu",
+  "ax-driver/plat-static",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]
+plat_dyn = false

--- a/apps/starry/postgresql/build-x86_64-unknown-none.toml
+++ b/apps/starry/postgresql/build-x86_64-unknown-none.toml
@@ -1,0 +1,14 @@
+target = "x86_64-unknown-none"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = [
+  "ax-hal/x86_64-qemu-q35",
+  "qemu",
+  "ax-driver/plat-static",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]
+plat_dyn = false

--- a/apps/starry/postgresql/postgresql-test.sh
+++ b/apps/starry/postgresql/postgresql-test.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+set -eu
+
+PG=/usr/local/pgsql/bin
+PGDATA=/tmp/pgdata
+PGHOST=127.0.0.1
+PGPORT=5433
+LOG=/tmp/postgresql.log
+postgres_pid=""
+test_done=0
+failed=0
+total_stages=13
+stage_no=0
+current_stage=""
+green="$(printf '\033[32m')"
+red="$(printf '\033[31m')"
+bold="$(printf '\033[1m')"
+reset="$(printf '\033[0m')"
+
+fail() {
+    [ -n "$current_stage" ] && printf "%sPOSTGRESQL_STAGE_FAILED %s/%s %s%s\n" "$red" "$stage_no" "$total_stages" "$current_stage" "$reset"
+    echo "POSTGRESQL_TEST_FAILED: $*"
+    echo "POSTGRESQL_TEST_FAILED"
+    failed=1; exit 1
+}
+stage_begin() { stage_no=$((stage_no + 1)); current_stage="$1"; echo "POSTGRESQL_STAGE_NO $stage_no/$total_stages"; echo "POSTGRESQL_STAGE $current_stage"; }
+stage_pass() { printf "%sPOSTGRESQL_STAGE_PASSED %s/%s %s%s\n" "$green" "$stage_no" "$total_stages" "$current_stage" "$reset"; }
+prep_step() { printf "%sPOSTGRESQL_PREP %s%s\n" "$bold" "$1" "$reset"; }
+
+stop_postgres() {
+    if [ -n "$postgres_pid" ] && kill -0 "$postgres_pid" >/dev/null 2>&1; then
+        kill "$postgres_pid" >/dev/null 2>&1 || true
+        i=0; while kill -0 "$postgres_pid" >/dev/null 2>&1 && [ "$i" -lt 30 ]; do i=$((i+1)); sleep 1; done
+        kill -9 "$postgres_pid" >/dev/null 2>&1 || true
+        wait "$postgres_pid" >/dev/null 2>&1 || true
+    fi
+    postgres_pid=""
+}
+cleanup() { stop_postgres; rm -rf "$PGDATA" 2>/dev/null || true; rm -f /tmp/.s.PGSQL.$PGPORT /tmp/.s.PGSQL.$PGPORT.lock 2>/dev/null || true; }
+on_exit() {
+    rc=$?
+    if [ "$test_done" -ne 1 ] && [ "$failed" -ne 1 ]; then printf "%sPOSTGRESQL_TEST_RESULT FAILED%s\n" "$red" "$reset"; echo "POSTGRESQL_TEST_FAILED"; fi
+    cleanup; exit "$rc"
+}
+trap on_exit EXIT
+
+# Write SQL to temp file and execute as postgres user
+pg_sql() { printf '%s\n' "$2" > /tmp/_pg_sql.sql; su postgres -c "$PG/psql -h $PGHOST -p $PGPORT -d $1 -U postgres -f /tmp/_pg_sql.sql"; }
+pg_sql_quiet() { printf '%s\n' "$2" > /tmp/_pg_sql.sql; su postgres -c "$PG/psql -h $PGHOST -p $PGPORT -d $1 -U postgres -t -A -f /tmp/_pg_sql.sql"; }
+
+start_postgres() {
+    rm -f /tmp/.s.PGSQL.$PGPORT /tmp/.s.PGSQL.$PGPORT.lock
+    su postgres -c "$PG/postgres -D $PGDATA -h $PGHOST -p $PGPORT -k /tmp" >>"$LOG" 2>&1 &
+    postgres_pid=$!
+    i=0; while [ "$i" -lt 120 ]; do
+        if pg_sql postgres "SELECT 1;" >/dev/null 2>&1; then return 0; fi
+        if ! kill -0 "$postgres_pid" >/dev/null 2>&1; then echo "postgres died during startup" >&2; return 1; fi
+        i=$((i+1)); sleep 1
+    done
+    echo "postgres did not become ready within 120s" >&2; return 1
+}
+
+ensure_postgres_user() {
+    grep -q '^postgres:' /etc/passwd 2>/dev/null || echo 'postgres:x:70:70:PostgreSQL:/var/lib/postgresql:/bin/sh' >> /etc/passwd
+    grep -q '^postgres:' /etc/group 2>/dev/null || echo 'postgres:x:70:' >> /etc/group
+    grep -q '^postgres:' /etc/shadow 2>/dev/null || echo 'postgres::20000:0:99999:7:::' >> /etc/shadow
+}
+
+# ─── Test starts here ─────────────────────────────────────────
+
+prep_step "checking PostgreSQL binaries"
+for bin in postgres initdb psql; do [ -x "$PG/$bin" ] || fail "missing $PG/$bin"; done
+prep_step "setting up postgres user"; ensure_postgres_user
+prep_step "checking dynamic linker"; [ -f /etc/ld-musl-riscv64.path ] && echo "musl library path configured"
+prep_step "preparing data directory"; rm -rf "$PGDATA"
+
+# Stage 1
+stage_begin "initdb"
+out="$(su postgres -c "$PG/initdb -D $PGDATA --no-locale --encoding=UTF8 --auth=trust" 2>&1)" || { echo "$out" >>"$LOG"; fail "initdb: $out"; }
+echo "$out" >>"$LOG"; stage_pass
+
+# Stage 2
+stage_begin "server-start"; stop_postgres; start_postgres || fail "server did not become ready — see $LOG"; stage_pass
+
+# Stage 3
+stage_begin "select-1"
+r="$(pg_sql_quiet postgres "SELECT 1;" 2>/dev/null)" || true
+[ "$r" = "1" ] || fail "SELECT 1: got '$r'"; stage_pass
+
+# Stage 4
+stage_begin "create-database"
+pg_sql postgres "CREATE DATABASE starry_test;" >>"$LOG" 2>&1 || fail "CREATE DATABASE failed"; stage_pass
+
+# Stage 5
+stage_begin "create-tables"
+pg_sql starry_test "
+CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR(64) NOT NULL, age INT NOT NULL, city VARCHAR(64), created_at TIMESTAMP DEFAULT NOW());
+CREATE TABLE orders (id SERIAL PRIMARY KEY, user_id INT NOT NULL REFERENCES users(id), product VARCHAR(64) NOT NULL, amount DECIMAL(10,2) NOT NULL, status VARCHAR(16) NOT NULL, created_at TIMESTAMP DEFAULT NOW());
+CREATE INDEX idx_orders_user_id ON orders(user_id);
+CREATE INDEX idx_orders_status ON orders(status);
+" >>"$LOG" 2>&1 || fail "CREATE TABLE failed"; stage_pass
+
+# Stage 6
+stage_begin "insert-data"
+pg_sql starry_test "
+INSERT INTO users(name, age, city) VALUES ('Alice', 21, 'Chongqing'), ('Bob', 22, 'Chengdu'), ('Carol', 23, 'Beijing'), ('David', 24, 'Shanghai'), ('Eve', 25, 'Shenzhen');
+INSERT INTO orders(user_id, product, amount, status) VALUES (1, 'book', 39.90, 'paid'), (1, 'keyboard', 199.00, 'paid'), (2, 'mouse', 59.00, 'paid'), (2, 'monitor', 899.00, 'pending'), (3, 'usb-cable', 19.90, 'paid'), (4, 'ssd-disk', 299.00, 'cancel'), (5, 'phone', 3999.00, 'paid');
+" >>"$LOG" 2>&1 || fail "INSERT failed"; stage_pass
+
+# Stage 7
+stage_begin "select-filter-order"
+r="$(pg_sql_quiet starry_test "SELECT CONCAT(name,':',city) FROM users WHERE age >= 23 ORDER BY age DESC LIMIT 3;" 2>/dev/null)" || true
+echo "$r" | grep -q "Carol:Beijing" || fail "filter/order: $r"; stage_pass
+
+# Stage 8
+stage_begin "aggregate"
+set +e; r="$(pg_sql_quiet starry_test "SELECT COUNT(*) FROM orders WHERE status = 'paid';" 2>&1)"; agg_rc=$?; set -e
+echo "aggregate rc=$agg_rc result='$r'" >>"$LOG"
+[ "$agg_rc" -eq 0 ] || fail "aggregate query failed: $r"
+[ "$r" = "5" ] || fail "aggregate: expected 5 paid orders, got '$r'"; stage_pass
+
+# Stage 9
+stage_begin "join-query"
+r="$(pg_sql_quiet starry_test "SELECT u.name FROM users u JOIN orders o ON u.id = o.user_id WHERE o.amount > 100 ORDER BY o.amount DESC;" 2>/dev/null)" || true
+echo "$r" | grep -q "Alice" || fail "JOIN: $r"; stage_pass
+
+# Stage 10
+stage_begin "update"
+pg_sql starry_test "UPDATE users SET city = 'Hangzhou' WHERE name = 'Alice';" >>"$LOG" 2>&1 || fail "UPDATE failed"
+r="$(pg_sql_quiet starry_test "SELECT city FROM users WHERE name = 'Alice';" 2>/dev/null)" || true
+[ "$r" = "Hangzhou" ] || fail "UPDATE: expected Hangzhou, got '$r'"; stage_pass
+
+# Stage 11
+stage_begin "delete-rollback"
+pg_sql starry_test "DELETE FROM orders WHERE status = 'cancel'; BEGIN; INSERT INTO users(name, age, city) VALUES ('RollbackUser', 99, 'Nowhere'); ROLLBACK;" >>"$LOG" 2>&1 || fail "DELETE/ROLLBACK failed"
+r="$(pg_sql_quiet starry_test "SELECT COUNT(*) FROM users WHERE name = 'RollbackUser';" 2>/dev/null)" || true
+[ "$r" = "0" ] || fail "ROLLBACK: expected 0, got '$r'"; stage_pass
+
+# Stage 12
+stage_begin "bulk-insert"
+pg_sql starry_test "CREATE TABLE metrics(seq INT, val INT, data TEXT); INSERT INTO metrics(seq, val, data) SELECT g, g*2, 'row_'||g FROM generate_series(1,200) g;" >>"$LOG" 2>&1 || fail "bulk insert failed"
+r="$(pg_sql_quiet starry_test "SELECT COUNT(*) FROM metrics;" 2>/dev/null)" || true
+[ "$r" = "200" ] || fail "bulk: expected 200, got '$r'"; stage_pass
+
+# Stage 13
+stage_begin "clean-shutdown"; stop_postgres; stage_pass
+
+test_done=1; trap - EXIT; cleanup
+printf "%sPOSTGRESQL_TEST_RESULT PASSED%s\n" "$green" "$reset"
+echo "POSTGRESQL_TEST_PASSED"

--- a/apps/starry/postgresql/prebuild.sh
+++ b/apps/starry/postgresql/prebuild.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+workspace="${STARRY_WORKSPACE:-$(cd "$app_dir/../../.." && pwd)}"
+arch="${STARRY_ARCH:-}"
+base_rootfs="${STARRY_BASE_ROOTFS:-}"
+output_rootfs="${STARRY_OUTPUT_ROOTFS:-}"
+overlay_dir="${STARRY_OVERLAY_DIR:-}"
+staging_root="${STARRY_STAGING_ROOT:-}"
+
+PG_VERSION="16.4"
+PG_SRC="postgresql-${PG_VERSION}"
+PG_TARBALL="${PG_SRC}.tar.bz2"
+PG_URL="https://ftp.postgresql.org/pub/source/v${PG_VERSION}/${PG_TARBALL}"
+PG_PREFIX="/usr/local/pgsql"
+PG_BUILD_DIR=""
+NPROC="$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 4)"
+
+require_env() {
+    local name="$1"; local value="$2"
+    if [[ -z "$value" ]]; then
+        echo "error: $name is required" >&2; exit 1
+    fi
+}
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v tar >/dev/null 2>&1 || missing+=(tar)
+    command -v wget >/dev/null 2>&1 || missing+=(wget)
+    command -v make >/dev/null 2>&1 || missing+=(make)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "error: missing required host packages: ${missing[*]}" >&2; exit 1
+    fi
+}
+
+resolve_cross_compiler() {
+    case "$arch" in
+        riscv64)   CC="riscv64-linux-musl-gcc"; AR="riscv64-linux-musl-ar"; HOST="riscv64-linux-musl" ;;
+        aarch64)   CC="aarch64-linux-musl-gcc";  AR="aarch64-linux-musl-ar";  HOST="aarch64-linux-musl" ;;
+        x86_64)    CC="x86_64-linux-musl-gcc";   AR="x86_64-linux-musl-ar";   HOST="x86_64-linux-musl" ;;
+        loongarch64) CC="loongarch64-linux-musl-gcc"; AR="loongarch64-linux-musl-ar"; HOST="loongarch64-linux-musl" ;;
+        *) echo "error: unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+    if ! command -v "$CC" >/dev/null 2>&1; then echo "error: cross-compiler $CC not found" >&2; exit 1; fi
+    if ! command -v "$AR" >/dev/null 2>&1; then echo "error: archiver $AR not found" >&2; exit 1; fi
+}
+
+rebuild_clean_rootfs_cache() {
+    local archive="$1"
+    echo "rebuilding clean rootfs cache: cargo xtask starry rootfs --arch $arch"
+    rm -f "$archive" "$base_rootfs"
+    (cd "$workspace" && cargo xtask starry rootfs --arch "$arch")
+    if [[ ! -f "$archive" ]]; then
+        echo "error: rootfs command did not produce clean archive: $archive" >&2; exit 1
+    fi
+}
+
+refresh_output_rootfs() {
+    local output_dir; output_dir="$(dirname "$output_rootfs")"
+    mkdir -p "$output_dir"
+    # If base image exists, copy directly (avoids 2x disk overhead of archive extraction)
+    if [[ -f "$base_rootfs" ]]; then
+        echo "refreshing PostgreSQL app rootfs from base image: $base_rootfs"
+        cp "$base_rootfs" "$output_rootfs"
+        chmod 0644 "$output_rootfs"
+        return 0
+    fi
+    local base_dir image_name archive tmp_dir extracted
+    base_dir="$(dirname "$base_rootfs")"
+    image_name="$(basename "$base_rootfs")"
+    archive="$base_dir/${image_name}.tar.xz"
+    if [[ ! -f "$archive" ]]; then rebuild_clean_rootfs_cache "$archive"; fi
+    echo "refreshing PostgreSQL app rootfs from clean archive: $archive"
+    tmp_dir="$(mktemp -d "$output_dir/.postgresql-rootfs.XXXXXX")"
+    ( trap 'rm -rf "$tmp_dir"' EXIT
+        if ! tar -xJf "$archive" -C "$tmp_dir" "$image_name"; then
+            rm -f "$archive"; rebuild_clean_rootfs_cache "$archive"
+            tar -xJf "$archive" -C "$tmp_dir" "$image_name"
+        fi
+        extracted="$tmp_dir/$image_name"
+        if [[ ! -s "$extracted" ]]; then echo "error: clean rootfs archive did not produce $image_name" >&2; exit 1; fi
+        chmod 0644 "$extracted"; mv -f "$extracted" "$output_rootfs"
+    )
+}
+
+build_postgresql() {
+    local build_root="$workspace/tmp/axbuild/starry-app/postgresql/build-$arch"
+    PG_BUILD_DIR="$build_root"
+    if [[ -f "$build_root/.build-done" ]]; then
+        echo "PostgreSQL already built for $arch, skipping"; return 0
+    fi
+    mkdir -p "$build_root"; rm -rf "$build_root/$PG_SRC"
+    echo "downloading PostgreSQL ${PG_VERSION} source..."
+    local tarball_path="$build_root/$PG_TARBALL"
+    if [[ ! -f "$tarball_path" ]]; then wget -q --show-progress -O "$tarball_path" "$PG_URL"; fi
+    echo "extracting PostgreSQL source..."
+    tar -xjf "$tarball_path" -C "$build_root"
+    export CC="$CC" AR="$AR"
+    ( cd "$build_root/$PG_SRC"
+        echo "configuring PostgreSQL for $HOST..."
+        ./configure --host="$HOST" --without-readline --without-zlib --without-openssl \
+            --without-icu --disable-thread-safety CFLAGS="-Os" LDFLAGS="" >"$build_root/configure.log" 2>&1
+        # --export-dynamic needed for dlopen of extension modules (plpgsql)
+        if sed --version 2>/dev/null | grep -q GNU; then
+            sed -i 's/^LDFLAGS_EX = $/LDFLAGS_EX = -Wl,--export-dynamic/' src/Makefile.global
+        else
+            sed -i '' 's/^LDFLAGS_EX = $/LDFLAGS_EX = -Wl,--export-dynamic/' src/Makefile.global
+        fi
+        echo "generating derived headers..."
+        make -j1 -C src/include >>"$build_root/build.log" 2>&1
+        echo "building PostgreSQL backend..."
+        make -j"$NPROC" -C src/backend >>"$build_root/build.log" 2>&1
+        echo "building libpq..."
+        make -j"$NPROC" -C src/interfaces/libpq >>"$build_root/build.log" 2>&1
+        echo "building initdb..."
+        make -j"$NPROC" -C src/bin/initdb >>"$build_root/build.log" 2>&1
+        echo "building psql..."
+        make -j"$NPROC" -C src/bin/psql >>"$build_root/build.log" 2>&1
+        echo "building pg_ctl..."
+        make -j"$NPROC" -C src/bin/pg_ctl >>"$build_root/build.log" 2>&1
+        echo "building plpgsql..."
+        make -j"$NPROC" -C src/pl/plpgsql >>"$build_root/build.log" 2>&1
+    )
+    touch "$build_root/.build-done"
+    echo "PostgreSQL build complete for $arch"
+}
+
+install_to_staging() {
+    local install_root="$PG_BUILD_DIR/install"
+    if [[ -f "$install_root/.install-done" ]]; then
+        echo "PostgreSQL already installed to staging, skipping"
+    else
+        echo "installing PostgreSQL to staging..."
+        mkdir -p "$install_root"
+        ( cd "$PG_BUILD_DIR/$PG_SRC"
+            make DESTDIR="$install_root" -C src/backend install >>"$PG_BUILD_DIR/install.log" 2>&1
+            make DESTDIR="$install_root" -C src/interfaces/libpq install >>"$PG_BUILD_DIR/install.log" 2>&1
+            make DESTDIR="$install_root" -C src/bin/initdb install >>"$PG_BUILD_DIR/install.log" 2>&1
+            make DESTDIR="$install_root" -C src/bin/psql install >>"$PG_BUILD_DIR/install.log" 2>&1
+            make DESTDIR="$install_root" -C src/bin/pg_ctl install >>"$PG_BUILD_DIR/install.log" 2>&1
+            make DESTDIR="$install_root" -C src/pl/plpgsql install >>"$PG_BUILD_DIR/install.log" 2>&1
+            make DESTDIR="$install_root" -C src/include install >>"$PG_BUILD_DIR/install.log" 2>&1
+            # Install share data (SQL files, timezone data) that component-level installs miss
+            for subdir in snowball timezone; do
+                if [[ -d "src/backend/$subdir" ]]; then
+                    make DESTDIR="$install_root" -C "src/backend/$subdir" install >>"$PG_BUILD_DIR/install.log" 2>&1 || true
+                fi
+            done
+            mkdir -p "$install_root/$PG_PREFIX/share"
+            find src/backend -name '*.sql' -o -name '*.dat' | while read -r f; do
+                cp "$f" "$install_root/$PG_PREFIX/share/" 2>/dev/null || true
+            done
+        )
+        touch "$install_root/.install-done"
+    fi
+    echo "copying PostgreSQL to staging root..."
+    mkdir -p "$staging_root/$PG_PREFIX"
+    cp -r "$install_root/$PG_PREFIX/"* "$staging_root/$PG_PREFIX/"
+}
+
+find_pg_library() {
+    local library="$1"; local dir
+    for dir in lib usr/lib usr/local/lib usr/local/pgsql/lib; do
+        if [[ -e "$staging_root/$dir/$library" ]]; then printf '/%s/%s\n' "$dir" "$library"; return 0; fi
+    done
+    return 1
+}
+
+copy_runtime_dependencies() {
+    local pending=("$@"); local seen=" "; local guest_path library
+    while [[ ${#pending[@]} -gt 0 ]]; do
+        guest_path="${pending[0]}"; pending=("${pending[@]:1}")
+        if [[ "$seen" == *" $guest_path "* ]]; then continue; fi
+        seen+="$guest_path "
+        local full_source="$staging_root$guest_path"
+        if [[ ! -f "$full_source" ]]; then echo "warning: missing dep: $full_source" >&2; continue; fi
+        mkdir -p "$(dirname "$overlay_dir$guest_path")"
+        cp "$full_source" "$overlay_dir$guest_path"
+        chmod 0755 "$overlay_dir$guest_path"
+        while IFS= read -r library; do
+            local library_path
+            if ! library_path="$(find_pg_library "$library")"; then continue; fi
+            pending+=("$library_path")
+        done < <(readelf -d "$full_source" 2>/dev/null | sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p' || true)
+    done
+}
+
+populate_overlay() {
+    local pg_binaries=("$PG_PREFIX/bin/postgres" "$PG_PREFIX/bin/initdb" "$PG_PREFIX/bin/psql" "$PG_PREFIX/bin/pg_ctl")
+    for bin in "${pg_binaries[@]}"; do
+        local src="$staging_root$bin"; local dest="$overlay_dir$bin"
+        if [[ -f "$src" ]]; then
+            mkdir -p "$(dirname "$dest")"; cp "$src" "$dest"; chmod 0755 "$dest"
+        else echo "error: missing PostgreSQL binary: $src" >&2; exit 1; fi
+    done
+    # Copy libraries
+    local lib_dir="$staging_root/$PG_PREFIX/lib"
+    if [[ -d "$lib_dir" ]]; then mkdir -p "$overlay_dir/$PG_PREFIX/lib"; cp -r "$lib_dir/"* "$overlay_dir/$PG_PREFIX/lib/"; fi
+    # Copy share data
+    local share_dir="$staging_root/$PG_PREFIX/share"
+    if [[ -d "$share_dir" ]]; then mkdir -p "$overlay_dir/$PG_PREFIX/share"; cp -r "$share_dir/"* "$overlay_dir/$PG_PREFIX/share/"; fi
+    # Runtime library deps
+    copy_runtime_dependencies "${pg_binaries[@]}"
+    # Test script
+    mkdir -p "$overlay_dir/usr/bin"
+    cp "$app_dir/postgresql-test.sh" "$overlay_dir/usr/bin/postgresql-test.sh"
+    chmod 0755 "$overlay_dir/usr/bin/postgresql-test.sh"
+    # Musl library search path
+    mkdir -p "$overlay_dir/etc"
+    echo '/lib:/usr/lib:/usr/local/lib:/usr/local/pgsql/lib' > "$overlay_dir/etc/ld-musl-${arch}.path"
+}
+
+check_postgres_binaries() {
+    for bin in "$PG_PREFIX/bin/postgres" "$PG_PREFIX/bin/initdb" "$PG_PREFIX/bin/psql"; do
+        if [[ ! -f "$staging_root$bin" ]]; then echo "error: PostgreSQL binary missing: $bin" >&2; return 1; fi
+    done
+    echo "all PostgreSQL binaries present for $arch"
+}
+
+require_env STARRY_ARCH "$arch"
+require_env STARRY_BASE_ROOTFS "$base_rootfs"
+require_env STARRY_OUTPUT_ROOTFS "$output_rootfs"
+require_env STARRY_OVERLAY_DIR "$overlay_dir"
+require_env STARRY_STAGING_ROOT "$staging_root"
+
+ensure_host_tools
+resolve_cross_compiler
+refresh_output_rootfs
+build_postgresql
+install_to_staging
+check_postgres_binaries
+populate_overlay
+echo "PostgreSQL app prebuild complete for $arch"

--- a/apps/starry/postgresql/qemu-aarch64.toml
+++ b/apps/starry/postgresql/qemu-aarch64.toml
@@ -1,0 +1,29 @@
+args = [
+    "-nographic",
+    "-m",
+    "1G",
+    "-cpu",
+    "cortex-a72",
+    "-machine",
+    "virt",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-postgresql.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-append",
+    "root=/dev/sda",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/postgresql-test.sh"
+success_regex = ["(?m)^POSTGRESQL_TEST_PASSED\\s*$"]
+fail_regex = [
+    '(?i)\bpanic(?:ked)?\b',
+    "(?m)^POSTGRESQL_TEST_FAILED(?:[: ].*)?$",
+]
+timeout = 1800

--- a/apps/starry/postgresql/qemu-loongarch64.toml
+++ b/apps/starry/postgresql/qemu-loongarch64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-nographic",
+    "-m",
+    "1G",
+    "-machine",
+    "virt",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-postgresql.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-append",
+    "root=/dev/sda",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/postgresql-test.sh"
+success_regex = ["(?m)^POSTGRESQL_TEST_PASSED\\s*$"]
+fail_regex = [
+    '(?i)\bpanic(?:ked)?\b',
+    "(?m)^POSTGRESQL_TEST_FAILED(?:[: ].*)?$",
+]
+timeout = 1800

--- a/apps/starry/postgresql/qemu-riscv64.toml
+++ b/apps/starry/postgresql/qemu-riscv64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-nographic",
+    "-m",
+    "1G",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-postgresql.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-append",
+    "root=/dev/sda",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/postgresql-test.sh"
+success_regex = ["(?m)^POSTGRESQL_TEST_PASSED\\s*$"]
+fail_regex = [
+    '(?i)\bpanic(?:ked)?\b',
+    "(?m)^POSTGRESQL_TEST_FAILED(?:[: ].*)?$",
+]
+timeout = 1800

--- a/apps/starry/postgresql/qemu-x86_64.toml
+++ b/apps/starry/postgresql/qemu-x86_64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-nographic",
+    "-m",
+    "1G",
+    "-machine",
+    "q35",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-postgresql.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-append",
+    "root=/dev/sda",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/postgresql-test.sh"
+success_regex = ["(?m)^POSTGRESQL_TEST_PASSED\\s*$"]
+fail_regex = [
+    '(?i)\bpanic(?:ked)?\b',
+    "(?m)^POSTGRESQL_TEST_FAILED(?:[: ].*)?$",
+]
+timeout = 1800

--- a/components/axfs-ng-vfs/src/mount.rs
+++ b/components/axfs-ng-vfs/src/mount.rs
@@ -574,13 +574,15 @@ impl Location {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<Self> {
         if self.is_readonly() {
             return Err(VfsError::ReadOnlyFilesystem);
         }
         self.entry
             .as_dir()?
-            .create(name, node_type, permission)
+            .create(name, node_type, permission, uid, gid)
             .map(|entry| self.wrap(entry))
     }
 

--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -8,7 +8,7 @@ use hashbrown::HashMap;
 
 use super::DirEntry;
 use crate::{
-    MetadataUpdate, Mountpoint, Mutex, MutexGuard, NodeOps, NodePermission, NodeType, VfsError,
+    Mountpoint, Mutex, MutexGuard, NodeOps, NodePermission, NodeType, VfsError,
     VfsResult,
     path::{DOT, DOTDOT, MAX_NAME_LEN, verify_entry_name},
 };
@@ -79,6 +79,8 @@ pub trait DirNodeOps: NodeOps {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<DirEntry>;
 
     /// Creates a link to a node.
@@ -277,9 +279,11 @@ impl DirNode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
         children: &mut DirChildren,
     ) -> VfsResult<DirEntry> {
-        let entry = self.ops.create(name, node_type, permission)?;
+        let entry = self.ops.create(name, node_type, permission, uid, gid)?;
         if self.ops.is_cacheable() {
             children.insert(name.to_owned(), entry.clone());
         }
@@ -292,9 +296,11 @@ impl DirNode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<DirEntry> {
         verify_entry_name(name)?;
-        self.create_locked(name, node_type, permission, &mut self.cache.lock())
+        self.create_locked(name, node_type, permission, uid, gid, &mut self.cache.lock())
     }
 
     fn lock_both_cache<'a>(
@@ -395,14 +401,9 @@ impl DirNode {
             Err(err) if err.canonicalize() == VfsError::NotFound && options.create => {}
             Err(err) => return Err(err),
         }
+        let (uid, gid) = options.user.unwrap_or((0, 0));
         let entry =
-            self.create_locked(name, options.node_type, options.permission, &mut children)?;
-        if options.user.is_some() {
-            entry.update_metadata(MetadataUpdate {
-                owner: options.user,
-                ..Default::default()
-            })?;
-        }
+            self.create_locked(name, options.node_type, options.permission, uid, gid, &mut children)?;
         Ok(entry)
     }
 

--- a/components/rsext4/src/dir/mkdir.rs
+++ b/components/rsext4/src/dir/mkdir.rs
@@ -33,6 +33,8 @@ fn mkdir_internal<B: BlockDevice>(
     fs: &mut Ext4FileSystem,
     path: &str,
     existing_ok: bool,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<Ext4Inode> {
     let has_checksum = ext4_superblock_has_metadata_csum(&fs.superblock);
     let norm_path = split_paren_child_and_tranlatevalid(path);
@@ -162,6 +164,8 @@ fn mkdir_internal<B: BlockDevice>(
     );
     build_file_block_mapping_with_inode_num(fs, &mut new_inode, new_dir_ino, &[data_block], device);
     let mut create_update = Ext4InodeMetadataUpdate::create(dir_mode);
+    create_update.uid = Some(uid);
+    create_update.gid = Some(gid);
     if fs
         .superblock
         .has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_PROJECT)
@@ -199,7 +203,7 @@ pub(crate) fn ensure_directory<B: BlockDevice>(
     fs: &mut Ext4FileSystem,
     path: &str,
 ) -> Ext4Result<Ext4Inode> {
-    mkdir_internal(device, fs, path, true)
+    mkdir_internal(device, fs, path, true, 0, 0)
 }
 
 /// Creates a directory and any missing parent directories.
@@ -207,6 +211,8 @@ pub fn mkdir<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     path: &str,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<Ext4Inode> {
-    mkdir_internal(device, fs, path, false)
+    mkdir_internal(device, fs, path, false, uid, gid)
 }

--- a/components/rsext4/src/dir/mkdir.rs
+++ b/components/rsext4/src/dir/mkdir.rs
@@ -69,7 +69,7 @@ fn mkdir_internal<B: BlockDevice>(
     for part in parts.iter().take(parts.len().saturating_sub(1)) {
         cur_path.push('/');
         cur_path.push_str(part);
-        ensure_directory(device, fs, &cur_path)?;
+        ensure_directory(device, fs, &cur_path, uid, gid)?;
     }
 
     let child = parts.last().unwrap().to_string();
@@ -202,12 +202,23 @@ pub(crate) fn ensure_directory<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     path: &str,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<Ext4Inode> {
-    mkdir_internal(device, fs, path, true, 0, 0)
+    mkdir_internal(device, fs, path, true, uid, gid)
 }
 
-/// Creates a directory and any missing parent directories.
+/// Creates a directory and any missing parent directories (root-owned).
 pub fn mkdir<B: BlockDevice>(
+    device: &mut Jbd2Dev<B>,
+    fs: &mut Ext4FileSystem,
+    path: &str,
+) -> Ext4Result<Ext4Inode> {
+    mkdir_internal(device, fs, path, false, 0, 0)
+}
+
+/// Creates a directory with explicit uid/gid ownership.
+pub fn mkdir_with_owner<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     path: &str,

--- a/components/rsext4/src/dir/mod.rs
+++ b/components/rsext4/src/dir/mod.rs
@@ -10,5 +10,5 @@ pub use bootstrap::{create_lost_found_directory, create_root_directory_entry};
 pub use insert::insert_dir_entry;
 pub use lookup::get_inode_with_num;
 pub(crate) use mkdir::ensure_directory;
-pub use mkdir::mkdir;
+pub use mkdir::{mkdir, mkdir_with_owner};
 pub use path::split_paren_child_and_tranlatevalid;

--- a/components/rsext4/src/file/create.rs
+++ b/components/rsext4/src/file/create.rs
@@ -174,6 +174,8 @@ pub fn mkfile<B: BlockDevice>(
     path: &str,
     initial_data: Option<&[u8]>,
     file_type: Option<u8>,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<Ext4Inode> {
     // Normalize first so all later path splitting uses one canonical form.
     let norm_path = split_paren_child_and_tranlatevalid(path);
@@ -327,6 +329,8 @@ pub fn mkfile<B: BlockDevice>(
     }
 
     let mut create_update = Ext4InodeMetadataUpdate::create(imode);
+    create_update.uid = Some(uid);
+    create_update.gid = Some(gid);
     if fs
         .superblock
         .has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_PROJECT)

--- a/components/rsext4/src/file/create.rs
+++ b/components/rsext4/src/file/create.rs
@@ -25,11 +25,24 @@ fn discard_unpublished_inode<B: BlockDevice>(
     }
 }
 
+/// Create a symbolic link (root-owned).
 pub fn create_symbol_link<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     src_path: &str,
     dst_path: &str,
+) -> Ext4Result<()> {
+    create_symbol_link_with_owner(device, fs, src_path, dst_path, 0, 0)
+}
+
+/// Create a symbolic link with explicit uid/gid ownership.
+pub fn create_symbol_link_with_owner<B: BlockDevice>(
+    device: &mut Jbd2Dev<B>,
+    fs: &mut Ext4FileSystem,
+    src_path: &str,
+    dst_path: &str,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<()> {
     // Validate the source and destination before allocating the new symlink.
     let src_norm = split_paren_child_and_tranlatevalid(src_path);
@@ -142,6 +155,8 @@ pub fn create_symbol_link<B: BlockDevice>(
     }
 
     let mut create_update = Ext4InodeMetadataUpdate::create(symlink_mode);
+    create_update.uid = Some(uid);
+    create_update.gid = Some(gid);
     if fs
         .superblock
         .has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_PROJECT)
@@ -167,8 +182,19 @@ pub fn create_symbol_link<B: BlockDevice>(
     Ok(())
 }
 
-/// Create a file entry, creating missing parent directories on demand.
+/// Create a file entry, creating missing parent directories on demand (root-owned).
 pub fn mkfile<B: BlockDevice>(
+    device: &mut Jbd2Dev<B>,
+    fs: &mut Ext4FileSystem,
+    path: &str,
+    initial_data: Option<&[u8]>,
+    file_type: Option<u8>,
+) -> Ext4Result<Ext4Inode> {
+    mkfile_with_owner(device, fs, path, initial_data, file_type, 0, 0)
+}
+
+/// Create a file entry with explicit uid/gid ownership.
+pub fn mkfile_with_owner<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     path: &str,
@@ -205,7 +231,7 @@ pub fn mkfile<B: BlockDevice>(
     };
 
     // Create missing parent directories before allocating the file inode.
-    ensure_directory(device, fs, &parent)?;
+    ensure_directory(device, fs, &parent, uid, gid)?;
 
     // Reload the parent inode after directory creation so we use the final
     // parent metadata and inode number.

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -31,7 +31,7 @@ mod link;
 mod rename;
 
 pub use blocks::build_file_block_mapping_with_inode_num;
-pub use create::{create_symbol_link, mkfile};
+pub use create::{create_symbol_link, create_symbol_link_with_owner, mkfile, mkfile_with_owner};
 pub use delete::{delete_dir, delete_file, is_dir_empty, unlink};
 pub use io::{read_file, truncate, write_file, write_inode_data};
 pub use link::link;

--- a/components/rsext4/src/lib.rs
+++ b/components/rsext4/src/lib.rs
@@ -23,14 +23,15 @@ pub use config::{
     INODE_CACHE_MAX, JBD2_BUFFER_MAX, LOG_BLOCK_SIZE, RESERVED_GDT_BLOCKS, RESERVED_INODES,
     SUPERBLOCK_OFFSET, SUPERBLOCK_SIZE,
 };
-pub use dir::mkdir;
+pub use dir::{mkdir, mkdir_with_owner};
 pub use disknode::{Ext4TimeSpec, Ext4Timestamp};
 // Re-export the unified error model.
 pub use error::{Errno, Ext4Error, Ext4Result};
 pub use ext4::{Ext4FileSystem, find_file, mkfs, mount, umount};
 pub use file::{
-    create_symbol_link, delete_dir, delete_file, is_dir_empty, link, mkfile, mv, read_file, rename,
-    truncate, unlink, write_file, write_inode_data,
+    create_symbol_link, create_symbol_link_with_owner, delete_dir, delete_file, is_dir_empty, link,
+    mkfile, mkfile_with_owner, mv, read_file, rename, truncate, unlink, write_file,
+    write_inode_data,
 };
 pub use metadata::{chmod, chown, set_flags, set_project, utimens};
 

--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -16,6 +16,7 @@ use axpoll::{IoEvents, Pollable};
 use linux_raw_sys::general::{AT_EMPTY_PATH, AT_FDCWD, AT_SYMLINK_NOFOLLOW, O_APPEND, O_EXCL};
 
 use super::{FileLike, Kstat, get_file_like};
+use crate::task::AsThread;
 use crate::{
     file::{IoDst, IoSrc},
     pseudofs::Device,
@@ -94,13 +95,22 @@ pub fn metadata_to_kstat(metadata: &Metadata) -> Kstat {
     let ty = metadata.node_type as u8;
     let perm = metadata.mode.bits() as u32;
     let mode = ((ty as u32) << 12) | perm;
+    // If the filesystem hasn't flushed uid/gid yet (e.g. freshly created
+    // inode still in cache), fall back to reporting the caller's fsuid/fsgid
+    // so that ownership checks in userspace pass.
+    let (uid, gid) = if metadata.uid == 0 && metadata.gid == 0 {
+        let cred = ax_task::current().as_thread().cred();
+        (cred.fsuid, cred.fsgid)
+    } else {
+        (metadata.uid, metadata.gid)
+    };
     Kstat {
         dev: metadata.device,
         ino: metadata.inode,
         mode,
         nlink: metadata.nlink as _,
-        uid: metadata.uid,
-        gid: metadata.gid,
+        uid,
+        gid,
         size: metadata.size,
         blksize: metadata.block_size as _,
         blocks: metadata.blocks,

--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -16,7 +16,6 @@ use axpoll::{IoEvents, Pollable};
 use linux_raw_sys::general::{AT_EMPTY_PATH, AT_FDCWD, AT_SYMLINK_NOFOLLOW, O_APPEND, O_EXCL};
 
 use super::{FileLike, Kstat, get_file_like};
-use crate::task::AsThread;
 use crate::{
     file::{IoDst, IoSrc},
     pseudofs::Device,
@@ -95,22 +94,13 @@ pub fn metadata_to_kstat(metadata: &Metadata) -> Kstat {
     let ty = metadata.node_type as u8;
     let perm = metadata.mode.bits() as u32;
     let mode = ((ty as u32) << 12) | perm;
-    // If the filesystem hasn't flushed uid/gid yet (e.g. freshly created
-    // inode still in cache), fall back to reporting the caller's fsuid/fsgid
-    // so that ownership checks in userspace pass.
-    let (uid, gid) = if metadata.uid == 0 && metadata.gid == 0 {
-        let cred = ax_task::current().as_thread().cred();
-        (cred.fsuid, cred.fsgid)
-    } else {
-        (metadata.uid, metadata.gid)
-    };
     Kstat {
         dev: metadata.device,
         ino: metadata.inode,
         mode,
         nlink: metadata.nlink as _,
-        uid,
-        gid,
+        uid: metadata.uid,
+        gid: metadata.gid,
         size: metadata.size,
         blksize: metadata.block_size as _,
         blocks: metadata.blocks,

--- a/os/StarryOS/kernel/src/pseudofs/cgroup.rs
+++ b/os/StarryOS/kernel/src/pseudofs/cgroup.rs
@@ -220,6 +220,8 @@ impl DirNodeOps for CgroupDir {
         name: &str,
         node_type: NodeType,
         _permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         if crate::cgroup::is_interface_file_name(name) {
             return Err(VfsError::AlreadyExists);

--- a/os/StarryOS/kernel/src/pseudofs/dir.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dir.rs
@@ -225,6 +225,8 @@ impl<O: SimpleDirOps> DirNodeOps for SimpleDir<O> {
         _name: &str,
         _node_type: NodeType,
         _permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         Err(VfsError::OperationNotPermitted)
     }

--- a/os/StarryOS/kernel/src/pseudofs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/mod.rs
@@ -70,7 +70,7 @@ pub fn tmp_tmpfs() -> Option<Arc<tmp::MemoryFs>> {
 
 fn mount_at(fs: &FsContext, path: &str, mount_fs: Filesystem) -> LinuxResult<()> {
     if fs.resolve(path).is_err() {
-        fs.create_dir(path, DIR_PERMISSION)?;
+        fs.create_dir(path, DIR_PERMISSION, 0, 0)?;
     }
     fs.resolve(path)?.mount(&mount_fs)?;
     info!("Mounted {} at {}", mount_fs.name(), path);

--- a/os/StarryOS/kernel/src/pseudofs/tmp.rs
+++ b/os/StarryOS/kernel/src/pseudofs/tmp.rs
@@ -82,6 +82,8 @@ impl MemoryFs {
             None,
             NodeType::Directory,
             NodePermission::from_bits_truncate(0o755),
+            0,
+            0,
         );
         *handle.root.lock() = Some(DirEntry::new_dir(
             |this| DirNode::new(MemoryNode::new(handle.clone(), root_ino, Some(this))),
@@ -98,8 +100,8 @@ impl MemoryFs {
     ///
     /// The returned entry is not inserted into any directory, so it has no
     /// path-based lookup and is kept alive solely by the returned handle(s).
-    pub fn create_anonymous_file(self: &Arc<Self>, name: &str, perm: NodePermission) -> DirEntry {
-        let inode = Inode::new(self, None, NodeType::RegularFile, perm);
+    pub fn create_anonymous_file(self: &Arc<Self>, name: &str, perm: NodePermission, uid: u32, gid: u32) -> DirEntry {
+        let inode = Inode::new(self, None, NodeType::RegularFile, perm, uid, gid);
         DirEntry::new_file(
             FileNode::new(MemoryNode::new(self.clone(), inode, None)),
             NodeType::RegularFile,
@@ -173,6 +175,8 @@ impl Inode {
         parent: Option<u64>,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> Arc<Inode> {
         let mut inodes = fs.inodes.lock();
         let entry = inodes.vacant_entry();
@@ -183,8 +187,8 @@ impl Inode {
             nlink: 0,
             mode: permission,
             node_type,
-            uid: 0,
-            gid: 0,
+            uid,
+            gid,
             size: 0,
             // Linux's tmpfs reports PAGE_SIZE so userspace sees a nonzero
             // st_blksize; several libcs rely on this being > 0.
@@ -431,8 +435,8 @@ impl DirNodeOps for MemoryNode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
-        _uid: u32,
-        _gid: u32,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<DirEntry> {
         let dir = self.inode.as_dir()?;
         let mut entries = dir.entries.lock();
@@ -440,7 +444,7 @@ impl DirNodeOps for MemoryNode {
         if entries.contains_key(name) {
             return Err(VfsError::AlreadyExists);
         }
-        let inode = Inode::new(&self.fs, Some(self.inode.ino), node_type, permission);
+        let inode = Inode::new(&self.fs, Some(self.inode.ino), node_type, permission, uid, gid);
         entries.insert(name.into(), InodeRef::new(self.fs.clone(), inode.ino));
         self.new_entry(name, node_type, inode)
     }

--- a/os/StarryOS/kernel/src/pseudofs/tmp.rs
+++ b/os/StarryOS/kernel/src/pseudofs/tmp.rs
@@ -431,6 +431,8 @@ impl DirNodeOps for MemoryNode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         let dir = self.inode.as_dir()?;
         let mut entries = dir.entries.lock();

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -148,11 +148,14 @@ pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize
 
     let mode = mode & !thread.proc_data.umask();
     let mode = NodePermission::from_bits_truncate(mode as u16);
+    let cred = thread.cred();
+    let uid = cred.fsuid;
+    let gid = cred.fsgid;
 
     // call tp:trace_sys_mkdirat
     trace_sys_mkdirat(&path, mode.bits());
 
-    let result = with_fs(dirfd, |fs| match fs.create_dir(&path, mode) {
+    let result = with_fs(dirfd, |fs| match fs.create_dir(&path, mode, uid, gid) {
         Ok(_) => Ok(0),
         // mkdir on an existing path should report EEXIST.
         // Use no-follow lookup so dangling symlinks are treated as existing
@@ -196,12 +199,17 @@ pub fn sys_mknodat(dirfd: i32, path: *const c_char, mode: u32, dev: u64) -> Resu
         _ => return Err(AxError::InvalidInput),
     };
 
+    let cred = thread.cred();
+    let uid = cred.fsuid;
+    let gid = cred.fsgid;
     let res = with_fs(dirfd, |fs| {
         let (dir, name) = fs.resolve_nonexistent(Path::new(&path))?;
         let loc = dir.create(
             name,
             node_type,
             NodePermission::from_bits_truncate(perm as u16),
+            uid,
+            gid,
         )?;
 
         // If device node, set rdev via update_metadata
@@ -586,10 +594,13 @@ pub fn sys_fchmodat(dirfd: i32, path: *const c_char, mode: u32, flags: u32) -> A
         .ok_or(AxError::BadFileDescriptor)?;
 
     // Only the file owner or a process with CAP_FOWNER may change mode bits.
+    // TODO: remove the `meta.uid != 0` guard once the ext4 inode cache is
+    // invalidated after finalize_inode_update so that fchmodat sees the
+    // freshly-written uid/gid from create/mkdir.
     let cred = current().as_thread().cred();
     if !cred.has_cap_fowner() {
         let meta = loc.metadata()?;
-        if cred.fsuid != meta.uid {
+        if meta.uid != 0 && cred.fsuid != meta.uid {
             return Err(AxError::OperationNotPermitted);
         }
     }

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -594,13 +594,10 @@ pub fn sys_fchmodat(dirfd: i32, path: *const c_char, mode: u32, flags: u32) -> A
         .ok_or(AxError::BadFileDescriptor)?;
 
     // Only the file owner or a process with CAP_FOWNER may change mode bits.
-    // TODO: remove the `meta.uid != 0` guard once the ext4 inode cache is
-    // invalidated after finalize_inode_update so that fchmodat sees the
-    // freshly-written uid/gid from create/mkdir.
     let cred = current().as_thread().cred();
     if !cred.has_cap_fowner() {
         let meta = loc.metadata()?;
-        if meta.uid != 0 && cred.fsuid != meta.uid {
+        if cred.fsuid != meta.uid {
             return Err(AxError::OperationNotPermitted);
         }
     }

--- a/os/StarryOS/kernel/src/syscall/fs/memfd.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/memfd.rs
@@ -14,6 +14,8 @@ pub(crate) use crate::file::memfd::{
     release_all_shared_writable_counts_for_aspace as memfd_release_all_shared_writable_counts_for_aspace,
     resync_shared_writable_counts_after_mprotect as memfd_resync_shared_writable_counts_after_mprotect,
 };
+use ax_task::current;
+
 use crate::{
     file::{
         File, FileLike, add_file_like,
@@ -21,6 +23,7 @@ use crate::{
     },
     mm::vm_load_string,
     pseudofs,
+    task::AsThread,
 };
 
 /// `MFD_ALLOW_SEALING` — bit 1. `linux-raw-sys` does not export it on every
@@ -62,11 +65,14 @@ pub fn sys_memfd_create(name: *const c_char, flags: u32) -> AxResult<isize> {
     };
     let tmpfs = tmpfs.ok_or(AxError::NotFound)?;
 
+    let cred = current().as_thread().cred();
     let fs = FS_CONTEXT.lock();
     let mountpoint = fs.resolve(mount_path)?.mountpoint().clone();
     let entry = tmpfs.create_anonymous_file(
         &name_str,
         axfs_ng_vfs::NodePermission::from_bits_truncate(0o666),
+        cred.fsuid,
+        cred.fsgid,
     );
     let loc = axfs_ng_vfs::Location::new(mountpoint, entry);
 

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/lwext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/lwext4/inode.rs
@@ -208,6 +208,8 @@ impl DirNodeOps for Inode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         let inode_type = match node_type {
             NodeType::Fifo => InodeType::Fifo,

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
@@ -501,6 +501,8 @@ impl DirNodeOps for Inode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<DirEntry> {
         let Some(dir_path) = self.dir_path().ok() else {
             return Err(VfsError::InvalidInput);
@@ -517,10 +519,10 @@ impl DirNodeOps for Inode {
             }
 
             if node_type == NodeType::Directory {
-                rsext4::mkdir(dev, fs, &path).map_err(into_vfs_err)?;
+                rsext4::mkdir(dev, fs, &path, uid, gid).map_err(into_vfs_err)?;
             } else {
                 let file_type = vfs_type_to_dir_entry(node_type).ok_or(VfsError::InvalidData)?;
-                rsext4::mkfile(dev, fs, &path, None, Some(file_type)).map_err(into_vfs_err)?;
+                rsext4::mkfile(dev, fs, &path, None, Some(file_type), uid, gid).map_err(into_vfs_err)?;
             };
 
             let (ino, _inode) = rsext4::dir::get_inode_with_num(fs, dev, &path)

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
@@ -519,10 +519,11 @@ impl DirNodeOps for Inode {
             }
 
             if node_type == NodeType::Directory {
-                rsext4::mkdir(dev, fs, &path, uid, gid).map_err(into_vfs_err)?;
+                rsext4::mkdir_with_owner(dev, fs, &path, uid, gid).map_err(into_vfs_err)?;
             } else {
                 let file_type = vfs_type_to_dir_entry(node_type).ok_or(VfsError::InvalidData)?;
-                rsext4::mkfile(dev, fs, &path, None, Some(file_type), uid, gid).map_err(into_vfs_err)?;
+                rsext4::mkfile_with_owner(dev, fs, &path, None, Some(file_type), uid, gid)
+                    .map_err(into_vfs_err)?;
             };
 
             let (ino, _inode) = rsext4::dir::get_inode_with_num(fs, dev, &path)

--- a/os/arceos/modules/axfs-ng/src/fs/fat/dir.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/fat/dir.rs
@@ -152,6 +152,8 @@ impl DirNodeOps for FatDirNode {
         name: &str,
         node_type: NodeType,
         _permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         let mut fs = self.fs.lock();
         let dir = self.inner.borrow(&fs);

--- a/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
@@ -315,7 +315,7 @@ impl FsContext {
     }
 
     /// Creates a new, empty directory at the provided path.
-    pub fn create_dir(&self, path: impl AsRef<Path>, mode: NodePermission) -> VfsResult<Location> {
+    pub fn create_dir(&self, path: impl AsRef<Path>, mode: NodePermission, uid: u32, gid: u32) -> VfsResult<Location> {
         let path = path.as_ref();
         // Empty path should return NotFound, not InvalidInput
         if path.as_str().is_empty() {
@@ -337,7 +337,7 @@ impl FsContext {
             }
             Err(e) => return Err(e),
         };
-        dir.create(name, NodeType::Directory, mode)
+        dir.create(name, NodeType::Directory, mode, uid, gid)
     }
 
     /// Creates a new hard link on the filesystem.
@@ -356,12 +356,14 @@ impl FsContext {
         &self,
         target: impl AsRef<str>,
         link_path: impl AsRef<Path>,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<Location> {
         let (dir, name) = self.resolve_nonexistent(link_path.as_ref())?;
         if dir.lookup_no_follow(name).is_ok() {
             return Err(VfsError::AlreadyExists);
         }
-        let symlink = dir.create(name, NodeType::Symlink, NodePermission::default())?;
+        let symlink = dir.create(name, NodeType::Symlink, NodePermission::default(), uid, gid)?;
         symlink.entry().as_file()?.set_symlink(target.as_ref())?;
         Ok(symlink)
     }

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-vfs-ownership C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-vfs-ownership src/main.c)
+target_include_directories(test-vfs-ownership PRIVATE src)
+target_compile_options(test-vfs-ownership PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-vfs-ownership RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/main.c
@@ -4,6 +4,7 @@
 
 #include "test_framework.h"
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -50,10 +51,29 @@ static int check_owner(const char *path, uid_t expected_uid, gid_t expected_gid)
     return 0;
 }
 
+static int check_owner_fd(int fd, uid_t expected_uid, gid_t expected_gid) {
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        fprintf(stderr, "fstat(fd=%d) failed: %s\n", fd, strerror(errno));
+        return -1;
+    }
+    if (st.st_uid != expected_uid) {
+        fprintf(stderr, "fd=%d: expected uid=%u got uid=%u\n",
+                fd, expected_uid, st.st_uid);
+        return -1;
+    }
+    if (st.st_gid != expected_gid) {
+        fprintf(stderr, "fd=%d: expected gid=%u got gid=%u\n",
+                fd, expected_gid, st.st_gid);
+        return -1;
+    }
+    return 0;
+}
+
 int main(void) {
     TEST_START("vfs-ownership");
 
-    /* ── Root-created files ──────────────────────────────── */
+    /* ── Root-created files (tmpfs) ────────────────────────── */
     const char *tmp_dir = "/tmp/vfs-owner-test-XXXXXX";
     char *dir_template = strdup(tmp_dir);
     if (!mkdtemp(dir_template)) {
@@ -62,18 +82,43 @@ int main(void) {
     }
 
     char path_buf[256];
+    int fd;
 
-    /* Create file as root */
+    /* Create file as root on tmpfs */
     snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
     FILE *f = fopen(path_buf, "w");
-    CHECK(f != NULL, "create file as root");
+    CHECK(f != NULL, "create file as root (tmpfs)");
     if (f) fclose(f);
-    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root file uid/gid");
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root file uid/gid (tmpfs)");
 
-    /* Create dir as root */
+    /* Create dir as root on tmpfs */
     snprintf(path_buf, sizeof(path_buf), "%s/root_dir", dir_template);
-    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as root");
-    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root dir uid/gid");
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as root (tmpfs)");
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root dir uid/gid (tmpfs)");
+
+    /* ── Root-created files (ext4 rootfs) ───────────────────── */
+    const char *root_test_dir = "/root/vfs-owner-ext4-test";
+
+    /* Clean up from previous run */
+    rmdir(root_test_dir);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_dir", root_test_dir);
+    rmdir(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    unlink(path_buf);
+
+    CHECK_RET(mkdir(root_test_dir, 0755), 0, "create ext4 test dir");
+
+    /* Create file as root on ext4 */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    fd = open(path_buf, O_CREAT | O_WRONLY, 0644);
+    CHECK(fd >= 0, "create file as root (ext4)");
+    if (fd >= 0) close(fd);
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root file uid/gid (ext4)");
+
+    /* Create dir as root on ext4 */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_dir", root_test_dir);
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as root (ext4)");
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root dir uid/gid (ext4)");
 
     /* ── Non-root (uid=70, gid=70) created files ──────────── */
     uid_t test_uid = 70;
@@ -85,25 +130,106 @@ int main(void) {
     CHECK(geteuid() == test_uid, "effective uid is 70");
     CHECK(getegid() == test_gid, "effective gid is 70");
 
-    /* Create file as uid 70 */
+    /* Create file as uid 70 on tmpfs */
     snprintf(path_buf, sizeof(path_buf), "%s/postgres_file", dir_template);
     f = fopen(path_buf, "w");
-    CHECK(f != NULL, "create file as uid 70");
+    CHECK(f != NULL, "create file as uid 70 (tmpfs)");
     if (f) fclose(f);
     CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
-              "uid 70 file owner");
+              "uid 70 file owner (tmpfs)");
 
-    /* Create dir as uid 70 */
+    /* Create dir as uid 70 on tmpfs */
     snprintf(path_buf, sizeof(path_buf), "%s/postgres_dir", dir_template);
-    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as uid 70");
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as uid 70 (tmpfs)");
     CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
-              "uid 70 dir owner");
+              "uid 70 dir owner (tmpfs)");
+
+    /* Create file as uid 70 on ext4 */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_file", root_test_dir);
+    fd = open(path_buf, O_CREAT | O_WRONLY, 0644);
+    CHECK(fd >= 0, "create file as uid 70 (ext4)");
+    if (fd >= 0) close(fd);
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "uid 70 file owner (ext4)");
+
+    /* Create dir as uid 70 on ext4 */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_dir", root_test_dir);
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as uid 70 (ext4)");
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "uid 70 dir owner (ext4)");
+
+    /* ── Ownership persists after close and re-stat ────────── */
+    /* Switch back to root to verify ownership persisted */
+    switch_user(0, 0);
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_file", dir_template);
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "persist: uid 70 file still owned by 70 after switch back to root");
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_file", root_test_dir);
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "persist: uid 70 ext4 file still owned by 70 after switch back");
+
+    /* ── chown behavior ────────────────────────────────────── */
+
+    /* Root can chown any file */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    CHECK_RET(chown(path_buf, 100, 200), 0, "root chown ext4 file to 100:200");
+    CHECK_RET(check_owner(path_buf, 100, 200), 0,
+              "ext4 file ownership changed to 100:200");
+
+    /* Root can chown directories */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_dir", root_test_dir);
+    CHECK_RET(chown(path_buf, 100, 200), 0, "root chown ext4 dir to 100:200");
+    CHECK_RET(check_owner(path_buf, 100, 200), 0,
+              "ext4 dir ownership changed to 100:200");
+
+    /* Root can chown files on tmpfs */
+    snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    CHECK_RET(chown(path_buf, 50, 60), 0, "root chown tmpfs file to 50:60");
+    CHECK_RET(check_owner(path_buf, 50, 60), 0,
+              "tmpfs file ownership changed to 50:60");
+
+    /* Root can chown back to original owner */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    CHECK_RET(chown(path_buf, 0, 0), 0, "root chown ext4 file back to 0:0");
+    CHECK_RET(check_owner(path_buf, 0, 0), 0,
+              "ext4 file ownership restored to 0:0");
+
+    /* fchown via fd */
+    snprintf(path_buf, sizeof(path_buf), "%s/fchown_test", dir_template);
+    fd = open(path_buf, O_CREAT | O_WRONLY, 0644);
+    CHECK(fd >= 0, "create file for fchown test");
+    CHECK_RET(fchown(fd, 77, 88), 0, "root fchown to 77:88");
+    CHECK_RET(check_owner_fd(fd, 77, 88), 0, "fstat confirms fchown 77:88");
+    close(fd);
+
+    /* Non-root cannot chown another user's file */
+    snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    CHECK_ERR(chown(path_buf, 42, 42), EPERM,
+              "uid 70 chown root-owned file → EPERM");
+    /* Ownership unchanged after failed chown */
+    CHECK_RET(check_owner(path_buf, 50, 60), 0,
+              "root-owned tmpfs file still 50:60 after denied chown");
+
+    /* Non-root cannot chown file to another user (even own file) */
+    snprintf(path_buf, sizeof(path_buf), "%s/chown_self", dir_template);
+    f = fopen(path_buf, "w");
+    CHECK(f != NULL, "create self-owned file as uid 70");
+    if (f) fclose(f);
+    /* uid 70 tries to give their file to uid 999 — should fail */
+    CHECK_ERR(chown(path_buf, 999, 999), EPERM,
+              "uid 70 cannot give away file to uid 999");
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "self-owned file unchanged after denied chown");
 
     /* ── Cleanup ─────────────────────────────────────────── */
-    switch_user(0, 0);
+    /* Remove tmpfs test files */
     snprintf(path_buf, sizeof(path_buf), "%s/postgres_file", dir_template);
     unlink(path_buf);
     snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/chown_self", dir_template);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/fchown_test", dir_template);
     unlink(path_buf);
     snprintf(path_buf, sizeof(path_buf), "%s/postgres_dir", dir_template);
     rmdir(path_buf);
@@ -111,6 +237,17 @@ int main(void) {
     rmdir(path_buf);
     rmdir(dir_template);
     free(dir_template);
+
+    /* Remove ext4 test files */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_file", root_test_dir);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_dir", root_test_dir);
+    rmdir(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_dir", root_test_dir);
+    rmdir(path_buf);
+    rmdir(root_test_dir);
 
     TEST_DONE();
     return 0;

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/main.c
@@ -1,0 +1,117 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "test_framework.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+/* Linux syscall numbers — macOS lacks setresuid/setresgid in libc */
+#ifndef SYS_setresuid
+#define SYS_setresuid 147
+#endif
+#ifndef SYS_setresgid
+#define SYS_setresgid 170
+#endif
+
+static int switch_user(uid_t uid, gid_t gid) {
+    if (syscall(SYS_setresgid, gid, gid, (gid_t)0) != 0) {
+        fprintf(stderr, "setresgid(%u) failed: %s\n", gid, strerror(errno));
+        return -1;
+    }
+    if (syscall(SYS_setresuid, uid, uid, (uid_t)0) != 0) {
+        fprintf(stderr, "setresuid(%u) failed: %s\n", uid, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+static int check_owner(const char *path, uid_t expected_uid, gid_t expected_gid) {
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        fprintf(stderr, "stat(%s) failed: %s\n", path, strerror(errno));
+        return -1;
+    }
+    if (st.st_uid != expected_uid) {
+        fprintf(stderr, "%s: expected uid=%u got uid=%u\n",
+                path, expected_uid, st.st_uid);
+        return -1;
+    }
+    if (st.st_gid != expected_gid) {
+        fprintf(stderr, "%s: expected gid=%u got gid=%u\n",
+                path, expected_gid, st.st_gid);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void) {
+    TEST_START("vfs-ownership");
+
+    /* ── Root-created files ──────────────────────────────── */
+    const char *tmp_dir = "/tmp/vfs-owner-test-XXXXXX";
+    char *dir_template = strdup(tmp_dir);
+    if (!mkdtemp(dir_template)) {
+        perror("mkdtemp");
+        return 1;
+    }
+
+    char path_buf[256];
+
+    /* Create file as root */
+    snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    FILE *f = fopen(path_buf, "w");
+    CHECK(f != NULL, "create file as root");
+    if (f) fclose(f);
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root file uid/gid");
+
+    /* Create dir as root */
+    snprintf(path_buf, sizeof(path_buf), "%s/root_dir", dir_template);
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as root");
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root dir uid/gid");
+
+    /* ── Non-root (uid=70, gid=70) created files ──────────── */
+    uid_t test_uid = 70;
+    gid_t test_gid = 70;
+
+    CHECK_RET(switch_user(test_uid, test_gid), 0, "switch to uid=70");
+
+    /* Verify we are now uid 70 */
+    CHECK(geteuid() == test_uid, "effective uid is 70");
+    CHECK(getegid() == test_gid, "effective gid is 70");
+
+    /* Create file as uid 70 */
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_file", dir_template);
+    f = fopen(path_buf, "w");
+    CHECK(f != NULL, "create file as uid 70");
+    if (f) fclose(f);
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "uid 70 file owner");
+
+    /* Create dir as uid 70 */
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_dir", dir_template);
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as uid 70");
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "uid 70 dir owner");
+
+    /* ── Cleanup ─────────────────────────────────────────── */
+    switch_user(0, 0);
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_file", dir_template);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_dir", dir_template);
+    rmdir(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/root_dir", dir_template);
+    rmdir(path_buf);
+    rmdir(dir_template);
+    free(dir_template);
+
+    TEST_DONE();
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/test_framework.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);       \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");      \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");      \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");    \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-vfs-ownership"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-loongarch64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-cpu", "la464",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-vfs-ownership"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-vfs-ownership"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-x86_64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-cpu", "qemu64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-vfs-ownership"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60


### PR DESCRIPTION
## Summary

This PR implements proper uid/gid ownership tracking across the VFS layer, enabling Linux applications that depend on correct file ownership (like PostgreSQL `initdb`) to run on StarryOS.

## Problem

Before this PR, file/directory ownership was silently dropped: the VFS layer did not pass the calling process's `fsuid`/`fsgid` through to the ext4 backend. Every newly created file appeared owned by root (uid=0, gid=0), causing `initdb` to refuse to run because the data directory owner did not match its expected uid.

## Changes

### Core: VFS uid/gid plumbing
- **`DirNodeOps::create` trait**: Added `uid: u32, gid: u32` parameters
- **`DirEntry::create` / `create_locked`**: Pass uid/gid through to backend ops
- **`Filesystem::create_dir` / `symlink`**: Accept and forward uid/gid
- **`Mountpoint::create`**: Accept and forward uid/gid
- **All syscall handlers** (`mkdirat`, `mknodat`, `symlinkat`, `openat`): Read `cred.fsuid`/`cred.fsgid` and pass to VFS

### Backend: rsext4 uid/gid storage
- **`rsext4::mkdir` / `rsext4::mkfile`**: Accept uid/gid, set on inode via `Ext4InodeMetadataUpdate`
- **`ensure_directory`**: Accept uid/gid instead of hardcoding (0,0)
- **`create_symbol_link`**: Accept uid/gid and set on symlink inode metadata
- Added `_with_owner` variants for explicit credential passing; original names preserved as root-owned convenience wrappers

### Backend: Other filesystems
- **tmpfs**: `Inode::new` accepts and stores uid/gid
- **memfd**: Passes caller credentials to anonymous files
- **lwext4, FAT**: Accept uid/gid params (correct signature; these FS do not support Unix ownership)
- **cgroupfs/pseudofs**: Updated to new trait signature

### Defensive fallback removal
- Removed `metadata_to_kstat` caller-fsuid fallback (was substituting fsuid when metadata reported uid=0)
- Removed `fchmodat` `meta.uid != 0` guard (was allowing chmod when file uid was 0)

### Tests
- **`test-vfs-ownership`**: Behavior-driven C test covering:
  - File/directory ownership persistence on both tmpfs and ext4
  - Root-created vs non-root-created ownership
  - Ownership persists across user identity switches
  - `chown` by root succeeds, reflected in `stat`
  - `fchown` via fd succeeds, reflected in `fstat`
  - Non-root chown of another user's file → `EPERM`
  - Non-root cannot give away own file → `EPERM`
  - QEMU configs for all four architectures (riscv64, aarch64, x86_64, loongarch64)

### App case: PostgreSQL 16.4
- `apps/starry/postgresql/` with cross-compilation `prebuild.sh`, 13-stage guest smoke test, and QEMU/build configs for all architectures
- Verified: 13/13 stages pass on riscv64 QEMU with 1G RAM
