### PR TITLE
feat(vfs): pass uid/gid through creation path to filesystem nodes

### DIFF
--- a/components/axfs-ng-vfs/src/mount.rs
+++ b/components/axfs-ng-vfs/src/mount.rs
@@ -574,13 +574,15 @@ impl Location {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<Self> {
         if self.is_readonly() {
             return Err(VfsError::ReadOnlyFilesystem);
         }
         self.entry
             .as_dir()?
-            .create(name, node_type, permission)
+            .create(name, node_type, permission, uid, gid)
             .map(|entry| self.wrap(entry))
     }
 

--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -8,8 +8,7 @@ use hashbrown::HashMap;
 
 use super::DirEntry;
 use crate::{
-    MetadataUpdate, Mountpoint, Mutex, MutexGuard, NodeOps, NodePermission, NodeType, VfsError,
-    VfsResult,
+    Mountpoint, Mutex, MutexGuard, NodeOps, NodePermission, NodeType, VfsError, VfsResult,
     path::{DOT, DOTDOT, MAX_NAME_LEN, verify_entry_name},
 };
 
@@ -79,6 +78,8 @@ pub trait DirNodeOps: NodeOps {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<DirEntry>;
 
     /// Creates a link to a node.
@@ -277,9 +278,11 @@ impl DirNode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
         children: &mut DirChildren,
     ) -> VfsResult<DirEntry> {
-        let entry = self.ops.create(name, node_type, permission)?;
+        let entry = self.ops.create(name, node_type, permission, uid, gid)?;
         if self.ops.is_cacheable() {
             children.insert(name.to_owned(), entry.clone());
         }
@@ -292,9 +295,11 @@ impl DirNode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<DirEntry> {
         verify_entry_name(name)?;
-        self.create_locked(name, node_type, permission, &mut self.cache.lock())
+        self.create_locked(name, node_type, permission, uid, gid, &mut self.cache.lock())
     }
 
     fn lock_both_cache<'a>(
@@ -395,14 +400,15 @@ impl DirNode {
             Err(err) if err.canonicalize() == VfsError::NotFound && options.create => {}
             Err(err) => return Err(err),
         }
-        let entry =
-            self.create_locked(name, options.node_type, options.permission, &mut children)?;
-        if options.user.is_some() {
-            entry.update_metadata(MetadataUpdate {
-                owner: options.user,
-                ..Default::default()
-            })?;
-        }
+        let (uid, gid) = options.user.unwrap_or((0, 0));
+        let entry = self.create_locked(
+            name,
+            options.node_type,
+            options.permission,
+            uid,
+            gid,
+            &mut children,
+        )?;
         Ok(entry)
     }
 

--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -299,7 +299,14 @@ impl DirNode {
         gid: u32,
     ) -> VfsResult<DirEntry> {
         verify_entry_name(name)?;
-        self.create_locked(name, node_type, permission, uid, gid, &mut self.cache.lock())
+        self.create_locked(
+            name,
+            node_type,
+            permission,
+            uid,
+            gid,
+            &mut self.cache.lock(),
+        )
     }
 
     fn lock_both_cache<'a>(

--- a/components/rsext4/src/dir/mkdir.rs
+++ b/components/rsext4/src/dir/mkdir.rs
@@ -33,6 +33,8 @@ fn mkdir_internal<B: BlockDevice>(
     fs: &mut Ext4FileSystem,
     path: &str,
     existing_ok: bool,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<Ext4Inode> {
     let has_checksum = ext4_superblock_has_metadata_csum(&fs.superblock);
     let norm_path = split_paren_child_and_tranlatevalid(path);
@@ -67,7 +69,7 @@ fn mkdir_internal<B: BlockDevice>(
     for part in parts.iter().take(parts.len().saturating_sub(1)) {
         cur_path.push('/');
         cur_path.push_str(part);
-        ensure_directory(device, fs, &cur_path)?;
+        ensure_directory(device, fs, &cur_path, uid, gid)?;
     }
 
     let child = parts.last().unwrap().to_string();
@@ -162,6 +164,8 @@ fn mkdir_internal<B: BlockDevice>(
     );
     build_file_block_mapping_with_inode_num(fs, &mut new_inode, new_dir_ino, &[data_block], device);
     let mut create_update = Ext4InodeMetadataUpdate::create(dir_mode);
+    create_update.uid = Some(uid);
+    create_update.gid = Some(gid);
     if fs
         .superblock
         .has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_PROJECT)
@@ -198,15 +202,28 @@ pub(crate) fn ensure_directory<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     path: &str,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<Ext4Inode> {
-    mkdir_internal(device, fs, path, true)
+    mkdir_internal(device, fs, path, true, uid, gid)
 }
 
-/// Creates a directory and any missing parent directories.
+/// Creates a directory and any missing parent directories (root-owned).
 pub fn mkdir<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     path: &str,
 ) -> Ext4Result<Ext4Inode> {
-    mkdir_internal(device, fs, path, false)
+    mkdir_internal(device, fs, path, false, 0, 0)
+}
+
+/// Creates a directory with explicit uid/gid ownership.
+pub fn mkdir_with_owner<B: BlockDevice>(
+    device: &mut Jbd2Dev<B>,
+    fs: &mut Ext4FileSystem,
+    path: &str,
+    uid: u32,
+    gid: u32,
+) -> Ext4Result<Ext4Inode> {
+    mkdir_internal(device, fs, path, false, uid, gid)
 }

--- a/components/rsext4/src/dir/mod.rs
+++ b/components/rsext4/src/dir/mod.rs
@@ -10,5 +10,5 @@ pub use bootstrap::{create_lost_found_directory, create_root_directory_entry};
 pub use insert::insert_dir_entry;
 pub use lookup::get_inode_with_num;
 pub(crate) use mkdir::ensure_directory;
-pub use mkdir::mkdir;
+pub use mkdir::{mkdir, mkdir_with_owner};
 pub use path::split_paren_child_and_tranlatevalid;

--- a/components/rsext4/src/file/create.rs
+++ b/components/rsext4/src/file/create.rs
@@ -25,11 +25,24 @@ fn discard_unpublished_inode<B: BlockDevice>(
     }
 }
 
+/// Create a symbolic link (root-owned).
 pub fn create_symbol_link<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     src_path: &str,
     dst_path: &str,
+) -> Ext4Result<()> {
+    create_symbol_link_with_owner(device, fs, src_path, dst_path, 0, 0)
+}
+
+/// Create a symbolic link with explicit uid/gid ownership.
+pub fn create_symbol_link_with_owner<B: BlockDevice>(
+    device: &mut Jbd2Dev<B>,
+    fs: &mut Ext4FileSystem,
+    src_path: &str,
+    dst_path: &str,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<()> {
     // Validate the source and destination before allocating the new symlink.
     let src_norm = split_paren_child_and_tranlatevalid(src_path);
@@ -142,6 +155,8 @@ pub fn create_symbol_link<B: BlockDevice>(
     }
 
     let mut create_update = Ext4InodeMetadataUpdate::create(symlink_mode);
+    create_update.uid = Some(uid);
+    create_update.gid = Some(gid);
     if fs
         .superblock
         .has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_PROJECT)
@@ -167,13 +182,26 @@ pub fn create_symbol_link<B: BlockDevice>(
     Ok(())
 }
 
-/// Create a file entry, creating missing parent directories on demand.
+/// Create a file entry, creating missing parent directories on demand (root-owned).
 pub fn mkfile<B: BlockDevice>(
     device: &mut Jbd2Dev<B>,
     fs: &mut Ext4FileSystem,
     path: &str,
     initial_data: Option<&[u8]>,
     file_type: Option<u8>,
+) -> Ext4Result<Ext4Inode> {
+    mkfile_with_owner(device, fs, path, initial_data, file_type, 0, 0)
+}
+
+/// Create a file entry with explicit uid/gid ownership.
+pub fn mkfile_with_owner<B: BlockDevice>(
+    device: &mut Jbd2Dev<B>,
+    fs: &mut Ext4FileSystem,
+    path: &str,
+    initial_data: Option<&[u8]>,
+    file_type: Option<u8>,
+    uid: u32,
+    gid: u32,
 ) -> Ext4Result<Ext4Inode> {
     // Normalize first so all later path splitting uses one canonical form.
     let norm_path = split_paren_child_and_tranlatevalid(path);
@@ -203,7 +231,7 @@ pub fn mkfile<B: BlockDevice>(
     };
 
     // Create missing parent directories before allocating the file inode.
-    ensure_directory(device, fs, &parent)?;
+    ensure_directory(device, fs, &parent, uid, gid)?;
 
     // Reload the parent inode after directory creation so we use the final
     // parent metadata and inode number.
@@ -327,6 +355,8 @@ pub fn mkfile<B: BlockDevice>(
     }
 
     let mut create_update = Ext4InodeMetadataUpdate::create(imode);
+    create_update.uid = Some(uid);
+    create_update.gid = Some(gid);
     if fs
         .superblock
         .has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_PROJECT)

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -31,9 +31,7 @@ mod link;
 mod rename;
 
 pub use blocks::build_file_block_mapping_with_inode_num;
-pub use create::{
-    create_symbol_link, create_symbol_link_with_owner, mkfile, mkfile_with_owner,
-};
+pub use create::{create_symbol_link, create_symbol_link_with_owner, mkfile, mkfile_with_owner};
 pub use delete::{delete_dir, delete_file, is_dir_empty, unlink};
 pub use io::{read_file, truncate, write_file, write_inode_data};
 pub use link::link;

--- a/components/rsext4/src/file/mod.rs
+++ b/components/rsext4/src/file/mod.rs
@@ -31,7 +31,9 @@ mod link;
 mod rename;
 
 pub use blocks::build_file_block_mapping_with_inode_num;
-pub use create::{create_symbol_link, mkfile};
+pub use create::{
+    create_symbol_link, create_symbol_link_with_owner, mkfile, mkfile_with_owner,
+};
 pub use delete::{delete_dir, delete_file, is_dir_empty, unlink};
 pub use io::{read_file, truncate, write_file, write_inode_data};
 pub use link::link;

--- a/components/rsext4/src/lib.rs
+++ b/components/rsext4/src/lib.rs
@@ -23,14 +23,15 @@ pub use config::{
     INODE_CACHE_MAX, JBD2_BUFFER_MAX, LOG_BLOCK_SIZE, RESERVED_GDT_BLOCKS, RESERVED_INODES,
     SUPERBLOCK_OFFSET, SUPERBLOCK_SIZE,
 };
-pub use dir::mkdir;
+pub use dir::{mkdir, mkdir_with_owner};
 pub use disknode::{Ext4TimeSpec, Ext4Timestamp};
 // Re-export the unified error model.
 pub use error::{Errno, Ext4Error, Ext4Result};
 pub use ext4::{Ext4FileSystem, find_file, mkfs, mount, umount};
 pub use file::{
-    create_symbol_link, delete_dir, delete_file, is_dir_empty, link, mkfile, mv, read_file, rename,
-    truncate, unlink, write_file, write_inode_data,
+    create_symbol_link, create_symbol_link_with_owner, delete_dir, delete_file, is_dir_empty, link,
+    mkfile, mkfile_with_owner, mv, read_file, rename, truncate, unlink, write_file,
+    write_inode_data,
 };
 pub use metadata::{chmod, chown, set_flags, set_project, utimens};
 

--- a/os/StarryOS/kernel/src/pseudofs/cgroup.rs
+++ b/os/StarryOS/kernel/src/pseudofs/cgroup.rs
@@ -220,6 +220,8 @@ impl DirNodeOps for CgroupDir {
         name: &str,
         node_type: NodeType,
         _permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         if crate::cgroup::is_interface_file_name(name) {
             return Err(VfsError::AlreadyExists);

--- a/os/StarryOS/kernel/src/pseudofs/dir.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dir.rs
@@ -225,6 +225,8 @@ impl<O: SimpleDirOps> DirNodeOps for SimpleDir<O> {
         _name: &str,
         _node_type: NodeType,
         _permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         Err(VfsError::OperationNotPermitted)
     }

--- a/os/StarryOS/kernel/src/pseudofs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/mod.rs
@@ -70,7 +70,7 @@ pub fn tmp_tmpfs() -> Option<Arc<tmp::MemoryFs>> {
 
 fn mount_at(fs: &FsContext, path: &str, mount_fs: Filesystem) -> LinuxResult<()> {
     if fs.resolve(path).is_err() {
-        fs.create_dir(path, DIR_PERMISSION)?;
+        fs.create_dir(path, DIR_PERMISSION, 0, 0)?;
     }
     fs.resolve(path)?.mount(&mount_fs)?;
     info!("Mounted {} at {}", mount_fs.name(), path);

--- a/os/StarryOS/kernel/src/pseudofs/tmp.rs
+++ b/os/StarryOS/kernel/src/pseudofs/tmp.rs
@@ -82,6 +82,8 @@ impl MemoryFs {
             None,
             NodeType::Directory,
             NodePermission::from_bits_truncate(0o755),
+            0,
+            0,
         );
         *handle.root.lock() = Some(DirEntry::new_dir(
             |this| DirNode::new(MemoryNode::new(handle.clone(), root_ino, Some(this))),
@@ -98,8 +100,14 @@ impl MemoryFs {
     ///
     /// The returned entry is not inserted into any directory, so it has no
     /// path-based lookup and is kept alive solely by the returned handle(s).
-    pub fn create_anonymous_file(self: &Arc<Self>, name: &str, perm: NodePermission) -> DirEntry {
-        let inode = Inode::new(self, None, NodeType::RegularFile, perm);
+    pub fn create_anonymous_file(
+        self: &Arc<Self>,
+        name: &str,
+        perm: NodePermission,
+        uid: u32,
+        gid: u32,
+    ) -> DirEntry {
+        let inode = Inode::new(self, None, NodeType::RegularFile, perm, uid, gid);
         DirEntry::new_file(
             FileNode::new(MemoryNode::new(self.clone(), inode, None)),
             NodeType::RegularFile,
@@ -173,6 +181,8 @@ impl Inode {
         parent: Option<u64>,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> Arc<Inode> {
         let mut inodes = fs.inodes.lock();
         let entry = inodes.vacant_entry();
@@ -183,8 +193,8 @@ impl Inode {
             nlink: 0,
             mode: permission,
             node_type,
-            uid: 0,
-            gid: 0,
+            uid,
+            gid,
             size: 0,
             // Linux's tmpfs reports PAGE_SIZE so userspace sees a nonzero
             // st_blksize; several libcs rely on this being > 0.
@@ -431,6 +441,8 @@ impl DirNodeOps for MemoryNode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<DirEntry> {
         let dir = self.inode.as_dir()?;
         let mut entries = dir.entries.lock();
@@ -438,7 +450,14 @@ impl DirNodeOps for MemoryNode {
         if entries.contains_key(name) {
             return Err(VfsError::AlreadyExists);
         }
-        let inode = Inode::new(&self.fs, Some(self.inode.ino), node_type, permission);
+        let inode = Inode::new(
+            &self.fs,
+            Some(self.inode.ino),
+            node_type,
+            permission,
+            uid,
+            gid,
+        );
         entries.insert(name.into(), InodeRef::new(self.fs.clone(), inode.ino));
         self.new_entry(name, node_type, inode)
     }

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -148,11 +148,14 @@ pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize
 
     let mode = mode & !thread.proc_data.umask();
     let mode = NodePermission::from_bits_truncate(mode as u16);
+    let cred = thread.cred();
+    let uid = cred.fsuid;
+    let gid = cred.fsgid;
 
     // call tp:trace_sys_mkdirat
     trace_sys_mkdirat(&path, mode.bits());
 
-    let result = with_fs(dirfd, |fs| match fs.create_dir(&path, mode) {
+    let result = with_fs(dirfd, |fs| match fs.create_dir(&path, mode, uid, gid) {
         Ok(_) => Ok(0),
         // mkdir on an existing path should report EEXIST.
         // Use no-follow lookup so dangling symlinks are treated as existing
@@ -196,12 +199,17 @@ pub fn sys_mknodat(dirfd: i32, path: *const c_char, mode: u32, dev: u64) -> Resu
         _ => return Err(AxError::InvalidInput),
     };
 
+    let cred = thread.cred();
+    let uid = cred.fsuid;
+    let gid = cred.fsgid;
     let res = with_fs(dirfd, |fs| {
         let (dir, name) = fs.resolve_nonexistent(Path::new(&path))?;
         let loc = dir.create(
             name,
             node_type,
             NodePermission::from_bits_truncate(perm as u16),
+            uid,
+            gid,
         )?;
 
         // If device node, set rdev via update_metadata
@@ -420,8 +428,11 @@ pub fn sys_symlinkat(
     let linkpath = vm_load_string(linkpath)?;
     debug!("sys_symlinkat <= target: {target:?}, new_dirfd: {new_dirfd}, linkpath: {linkpath:?}");
 
+    let cred = current().as_thread().cred();
+    let uid = cred.fsuid;
+    let gid = cred.fsgid;
     with_fs(new_dirfd, |fs| {
-        fs.symlink(target, linkpath)?;
+        fs.symlink(target, linkpath, uid, gid)?;
         Ok(0)
     })
 }

--- a/os/StarryOS/kernel/src/syscall/fs/memfd.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/memfd.rs
@@ -21,7 +21,9 @@ use crate::{
     },
     mm::vm_load_string,
     pseudofs,
+    task::AsThread,
 };
+use ax_task::current;
 
 /// `MFD_ALLOW_SEALING` — bit 1. `linux-raw-sys` does not export it on every
 /// target, so define locally.
@@ -64,9 +66,12 @@ pub fn sys_memfd_create(name: *const c_char, flags: u32) -> AxResult<isize> {
 
     let fs = FS_CONTEXT.lock();
     let mountpoint = fs.resolve(mount_path)?.mountpoint().clone();
+    let cred = current().as_thread().cred();
     let entry = tmpfs.create_anonymous_file(
         &name_str,
         axfs_ng_vfs::NodePermission::from_bits_truncate(0o666),
+        cred.fsuid,
+        cred.fsgid,
     );
     let loc = axfs_ng_vfs::Location::new(mountpoint, entry);
 

--- a/os/StarryOS/kernel/src/syscall/fs/memfd.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/memfd.rs
@@ -3,6 +3,7 @@ use core::ffi::c_char;
 
 use ax_errno::{AxError, AxResult};
 use ax_fs::{FS_CONTEXT, OpenOptions};
+use ax_task::current;
 use linux_raw_sys::general::{MFD_CLOEXEC, O_RDWR};
 
 pub(crate) use crate::file::memfd::{
@@ -23,7 +24,6 @@ use crate::{
     pseudofs,
     task::AsThread,
 };
-use ax_task::current;
 
 /// `MFD_ALLOW_SEALING` — bit 1. `linux-raw-sys` does not export it on every
 /// target, so define locally.

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/lwext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/lwext4/inode.rs
@@ -208,6 +208,8 @@ impl DirNodeOps for Inode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         let inode_type = match node_type {
             NodeType::Fifo => InodeType::Fifo,

--- a/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/ext4/rsext4/inode.rs
@@ -501,6 +501,8 @@ impl DirNodeOps for Inode {
         name: &str,
         node_type: NodeType,
         permission: NodePermission,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<DirEntry> {
         let Some(dir_path) = self.dir_path().ok() else {
             return Err(VfsError::InvalidInput);
@@ -517,10 +519,11 @@ impl DirNodeOps for Inode {
             }
 
             if node_type == NodeType::Directory {
-                rsext4::mkdir(dev, fs, &path).map_err(into_vfs_err)?;
+                rsext4::mkdir_with_owner(dev, fs, &path, uid, gid).map_err(into_vfs_err)?;
             } else {
                 let file_type = vfs_type_to_dir_entry(node_type).ok_or(VfsError::InvalidData)?;
-                rsext4::mkfile(dev, fs, &path, None, Some(file_type)).map_err(into_vfs_err)?;
+                rsext4::mkfile_with_owner(dev, fs, &path, None, Some(file_type), uid, gid)
+                    .map_err(into_vfs_err)?;
             };
 
             let (ino, _inode) = rsext4::dir::get_inode_with_num(fs, dev, &path)

--- a/os/arceos/modules/axfs-ng/src/fs/fat/dir.rs
+++ b/os/arceos/modules/axfs-ng/src/fs/fat/dir.rs
@@ -152,6 +152,8 @@ impl DirNodeOps for FatDirNode {
         name: &str,
         node_type: NodeType,
         _permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         let mut fs = self.fs.lock();
         let dir = self.inner.borrow(&fs);

--- a/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/fs.rs
@@ -315,7 +315,13 @@ impl FsContext {
     }
 
     /// Creates a new, empty directory at the provided path.
-    pub fn create_dir(&self, path: impl AsRef<Path>, mode: NodePermission) -> VfsResult<Location> {
+    pub fn create_dir(
+        &self,
+        path: impl AsRef<Path>,
+        mode: NodePermission,
+        uid: u32,
+        gid: u32,
+    ) -> VfsResult<Location> {
         let path = path.as_ref();
         // Empty path should return NotFound, not InvalidInput
         if path.as_str().is_empty() {
@@ -337,7 +343,7 @@ impl FsContext {
             }
             Err(e) => return Err(e),
         };
-        dir.create(name, NodeType::Directory, mode)
+        dir.create(name, NodeType::Directory, mode, uid, gid)
     }
 
     /// Creates a new hard link on the filesystem.
@@ -356,12 +362,14 @@ impl FsContext {
         &self,
         target: impl AsRef<str>,
         link_path: impl AsRef<Path>,
+        uid: u32,
+        gid: u32,
     ) -> VfsResult<Location> {
         let (dir, name) = self.resolve_nonexistent(link_path.as_ref())?;
         if dir.lookup_no_follow(name).is_ok() {
             return Err(VfsError::AlreadyExists);
         }
-        let symlink = dir.create(name, NodeType::Symlink, NodePermission::default())?;
+        let symlink = dir.create(name, NodeType::Symlink, NodePermission::default(), uid, gid)?;
         symlink.entry().as_file()?.set_symlink(target.as_ref())?;
         Ok(symlink)
     }

--- a/os/arceos/modules/axnet-ng/src/lib.rs
+++ b/os/arceos/modules/axnet-ng/src/lib.rs
@@ -220,7 +220,7 @@ fn dhcp_bootstrap() {
 #[cfg(test)]
 pub(crate) mod test_support {
     use alloc::boxed::Box;
-    use std::sync::Once;
+    use std::sync::{Mutex as StdMutex, MutexGuard, Once};
 
     use ax_sync::Mutex;
     use smoltcp::wire::{IpAddress, Ipv4Address, Ipv4Cidr};
@@ -236,6 +236,12 @@ pub(crate) mod test_support {
     pub(crate) const PEER_MASK: u32 = 1 << 1;
     pub(crate) const LOCAL_ADDR: Ipv4Address = Ipv4Address::new(192, 0, 2, 10);
     pub(crate) const PEER_ADDR: Ipv4Address = Ipv4Address::new(198, 51, 100, 20);
+
+    static NETWORK_TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    pub(crate) fn network_test_guard() -> MutexGuard<'static, ()> {
+        NETWORK_TEST_LOCK.lock().unwrap()
+    }
 
     pub(crate) fn init_split_route_network() {
         static INIT: Once = Once::new();

--- a/os/arceos/modules/axnet-ng/src/tcp.rs
+++ b/os/arceos/modules/axnet-ng/src/tcp.rs
@@ -801,11 +801,15 @@ mod tests {
     use super::*;
     use crate::{
         options::{Configurable, SetSocketOption},
-        test_support::{LOCAL_ADDR, LOCAL_MASK, PEER_ADDR, PEER_MASK, init_split_route_network},
+        test_support::{
+            LOCAL_ADDR, LOCAL_MASK, PEER_ADDR, PEER_MASK, init_split_route_network,
+            network_test_guard,
+        },
     };
 
     #[test]
     fn connect_uses_peer_route_for_device_mask() {
+        let _guard = network_test_guard();
         init_split_route_network();
 
         let socket = TcpSocket::new();

--- a/os/arceos/modules/axnet-ng/src/udp.rs
+++ b/os/arceos/modules/axnet-ng/src/udp.rs
@@ -500,11 +500,12 @@ mod tests {
 
     use super::*;
     use crate::test_support::{
-        LOCAL_ADDR, LOCAL_MASK, PEER_ADDR, PEER_MASK, init_split_route_network,
+        LOCAL_ADDR, LOCAL_MASK, PEER_ADDR, PEER_MASK, init_split_route_network, network_test_guard,
     };
 
     #[test]
     fn connect_uses_peer_route_for_device_mask() {
+        let _guard = network_test_guard();
         init_split_route_network();
 
         let socket = UdpSocket::new();

--- a/test-suit/arceos/rust/task/lockdep/src/main.rs
+++ b/test-suit/arceos/rust/task/lockdep/src/main.rs
@@ -381,6 +381,8 @@ impl DirNodeOps for TestDir {
         _name: &str,
         _node_type: NodeType,
         _permission: NodePermission,
+        _uid: u32,
+        _gid: u32,
     ) -> VfsResult<DirEntry> {
         Err(VfsError::Unsupported)
     }

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/CMakeLists.txt
@@ -5,3 +5,4 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -static -Wall -Wextra")
 
 add_executable(test-vfs-ownership src/main.c)
+install(TARGETS test-vfs-ownership RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(test-vfs-ownership C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -static -Wall -Wextra")
+
+add_executable(test-vfs-ownership src/main.c)

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/main.c
@@ -1,0 +1,240 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "test_framework.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+/* Linux syscall numbers */
+#ifndef SYS_setresuid
+#define SYS_setresuid 147
+#endif
+#ifndef SYS_setresgid
+#define SYS_setresgid 170
+#endif
+
+static int switch_user(uid_t uid, gid_t gid) {
+    if (syscall(SYS_setresgid, gid, gid, (gid_t)0) != 0) {
+        fprintf(stderr, "setresgid(%u) failed: %s\n", gid, strerror(errno));
+        return -1;
+    }
+    if (syscall(SYS_setresuid, uid, uid, (uid_t)0) != 0) {
+        fprintf(stderr, "setresuid(%u) failed: %s\n", uid, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+static int check_owner(const char *path, uid_t expected_uid, gid_t expected_gid) {
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        fprintf(stderr, "stat(%s) failed: %s\n", path, strerror(errno));
+        return -1;
+    }
+    if (st.st_uid != expected_uid) {
+        fprintf(stderr, "%s: expected uid=%u got uid=%u\n",
+                path, expected_uid, st.st_uid);
+        return -1;
+    }
+    if (st.st_gid != expected_gid) {
+        fprintf(stderr, "%s: expected gid=%u got gid=%u\n",
+                path, expected_gid, st.st_gid);
+        return -1;
+    }
+    return 0;
+}
+
+static int check_owner_fd(int fd, uid_t expected_uid, gid_t expected_gid) {
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        fprintf(stderr, "fstat(fd=%d) failed: %s\n", fd, strerror(errno));
+        return -1;
+    }
+    if (st.st_uid != expected_uid) {
+        fprintf(stderr, "fd=%d: expected uid=%u got uid=%u\n",
+                fd, expected_uid, st.st_uid);
+        return -1;
+    }
+    if (st.st_gid != expected_gid) {
+        fprintf(stderr, "fd=%d: expected gid=%u got gid=%u\n",
+                fd, expected_gid, st.st_gid);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void) {
+    TEST_START("vfs-ownership");
+
+    char path_buf[256];
+    int fd;
+    uid_t test_uid = 70;
+    gid_t test_gid = 70;
+
+    /* ── Root-created files on tmpfs ─────────────────────── */
+    const char *tmp_dir = "/tmp/vfs-owner-test-XXXXXX";
+    char *dir_template = strdup(tmp_dir);
+    if (!mkdtemp(dir_template)) {
+        perror("mkdtemp");
+        return 1;
+    }
+
+    snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    FILE *f = fopen(path_buf, "w");
+    CHECK(f != NULL, "create file as root (tmpfs)");
+    if (f) fclose(f);
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root file uid/gid (tmpfs)");
+
+    snprintf(path_buf, sizeof(path_buf), "%s/root_dir", dir_template);
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as root (tmpfs)");
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root dir uid/gid (tmpfs)");
+
+    /* ── Root-created files on ext4 rootfs ───────────────── */
+    const char *root_test_dir = "/root/vfs-owner-ext4-test";
+    rmdir(root_test_dir);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_dir", root_test_dir);
+    rmdir(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    unlink(path_buf);
+
+    CHECK_RET(mkdir(root_test_dir, 0755), 0, "create ext4 test dir");
+
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    fd = open(path_buf, O_CREAT | O_WRONLY, 0644);
+    CHECK(fd >= 0, "create file as root (ext4)");
+    if (fd >= 0) close(fd);
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root file uid/gid (ext4)");
+
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_dir", root_test_dir);
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as root (ext4)");
+    CHECK_RET(check_owner(path_buf, 0, 0), 0, "root dir uid/gid (ext4)");
+
+    /* ── Non-root (uid=70, gid=70) created files ────────── */
+    CHECK_RET(switch_user(test_uid, test_gid), 0, "switch to uid=70");
+    CHECK(geteuid() == test_uid, "effective uid is 70");
+    CHECK(getegid() == test_gid, "effective gid is 70");
+
+    /* tmpfs */
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_file", dir_template);
+    f = fopen(path_buf, "w");
+    CHECK(f != NULL, "create file as uid 70 (tmpfs)");
+    if (f) fclose(f);
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "uid 70 file owner (tmpfs)");
+
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_dir", dir_template);
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as uid 70 (tmpfs)");
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "uid 70 dir owner (tmpfs)");
+
+    /* ext4 rootfs */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_file", root_test_dir);
+    fd = open(path_buf, O_CREAT | O_WRONLY, 0644);
+    CHECK(fd >= 0, "create file as uid 70 (ext4)");
+    if (fd >= 0) close(fd);
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "uid 70 file owner (ext4)");
+
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_dir", root_test_dir);
+    CHECK_RET(mkdir(path_buf, 0755), 0, "create dir as uid 70 (ext4)");
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "uid 70 dir owner (ext4)");
+
+    /* ── Ownership persists after switch back to root ───── */
+    switch_user(0, 0);
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_file", dir_template);
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "persist: uid 70 tmpfs file still owned by 70");
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_file", root_test_dir);
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "persist: uid 70 ext4 file still owned by 70");
+
+    /* ── chown by root ──────────────────────────────────── */
+    /* ext4 file */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    CHECK_RET(chown(path_buf, 100, 200), 0, "root chown ext4 file to 100:200");
+    CHECK_RET(check_owner(path_buf, 100, 200), 0,
+              "ext4 file ownership changed to 100:200");
+
+    /* ext4 dir */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_dir", root_test_dir);
+    CHECK_RET(chown(path_buf, 100, 200), 0, "root chown ext4 dir to 100:200");
+    CHECK_RET(check_owner(path_buf, 100, 200), 0,
+              "ext4 dir ownership changed to 100:200");
+
+    /* tmpfs file */
+    snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    CHECK_RET(chown(path_buf, 50, 60), 0, "root chown tmpfs file to 50:60");
+    CHECK_RET(check_owner(path_buf, 50, 60), 0,
+              "tmpfs file ownership changed to 50:60");
+
+    /* chown back to root */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    CHECK_RET(chown(path_buf, 0, 0), 0, "root chown ext4 file back to 0:0");
+    CHECK_RET(check_owner(path_buf, 0, 0), 0,
+              "ext4 file ownership restored to 0:0");
+
+    /* ── fchown by root ─────────────────────────────────── */
+    snprintf(path_buf, sizeof(path_buf), "%s/fchown_test", dir_template);
+    fd = open(path_buf, O_CREAT | O_WRONLY, 0644);
+    CHECK(fd >= 0, "create file for fchown test");
+    CHECK_RET(fchown(fd, 77, 88), 0, "root fchown to 77:88");
+    CHECK_RET(check_owner_fd(fd, 77, 88), 0, "fstat confirms fchown 77:88");
+    close(fd);
+
+    /* ── Non-root cannot chown another user's file ──────── */
+    switch_user(test_uid, test_gid);
+    snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    CHECK_ERR(chown(path_buf, 42, 42), EPERM,
+              "uid 70 chown root-owned file → EPERM");
+    CHECK_RET(check_owner(path_buf, 50, 60), 0,
+              "root-owned file unchanged after denied chown");
+
+    /* Non-root cannot give away own file */
+    snprintf(path_buf, sizeof(path_buf), "%s/chown_self", dir_template);
+    f = fopen(path_buf, "w");
+    CHECK(f != NULL, "create self-owned file as uid 70");
+    if (f) fclose(f);
+    CHECK_ERR(chown(path_buf, 999, 999), EPERM,
+              "uid 70 cannot give away file to uid 999");
+    CHECK_RET(check_owner(path_buf, test_uid, test_gid), 0,
+              "self-owned file unchanged after denied chown");
+
+    /* ── Cleanup ────────────────────────────────────────── */
+    switch_user(0, 0);
+    /* tmpfs */
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_file", dir_template);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/root_file", dir_template);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/chown_self", dir_template);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/fchown_test", dir_template);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/postgres_dir", dir_template);
+    rmdir(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/root_dir", dir_template);
+    rmdir(path_buf);
+    rmdir(dir_template);
+    free(dir_template);
+    /* ext4 */
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_file", root_test_dir);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_file", root_test_dir);
+    unlink(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_dir", root_test_dir);
+    rmdir(path_buf);
+    snprintf(path_buf, sizeof(path_buf), "%s/ext4_noroot_dir", root_test_dir);
+    rmdir(path_buf);
+    rmdir(root_test_dir);
+
+    TEST_DONE();
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/main.c
@@ -9,23 +9,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <sys/syscall.h>
 #include <unistd.h>
 
-/* Linux syscall numbers */
-#ifndef SYS_setresuid
-#define SYS_setresuid 147
-#endif
-#ifndef SYS_setresgid
-#define SYS_setresgid 170
-#endif
-
 static int switch_user(uid_t uid, gid_t gid) {
-    if (syscall(SYS_setresgid, gid, gid, (gid_t)0) != 0) {
+    if (setresgid(gid, gid, (gid_t)0) != 0) {
         fprintf(stderr, "setresgid(%u) failed: %s\n", gid, strerror(errno));
         return -1;
     }
-    if (syscall(SYS_setresuid, uid, uid, (uid_t)0) != 0) {
+    if (setresuid(uid, uid, (uid_t)0) != 0) {
         fprintf(stderr, "setresuid(%u) failed: %s\n", uid, strerror(errno));
         return -1;
     }

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/c/src/test_framework.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);       \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+#define TEST_START(name)                                                \
+    printf("================================================\n");      \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");      \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");    \
+    return __fail > 0 ? 1 : 0

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-vfs-ownership"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-loongarch64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-cpu", "la464",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-vfs-ownership"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+args = [
+    "-nographic", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-vfs-ownership"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-x86_64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-cpu", "qemu64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-vfs-ownership"
+success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)FAIL']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/test-vfs-ownership/qemu-x86_64.toml
@@ -8,7 +8,7 @@ args = [
     "-netdev", "user,id=net0",
 ]
 uefi = false
-to_bin = true
+to_bin = false
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/test-vfs-ownership"
 success_regex = ["(?m)DONE: \\d+ pass, 0 fail"]


### PR DESCRIPTION
## Summary

Pass caller credentials (fsuid/fsgid) through the VFS creation path so that newly created files and directories carry the correct ownership. This is required for Linux applications that check file ownership, such as PostgreSQL `initdb`.

## Problem

Before this PR, file/directory ownership was silently dropped: the VFS `DirNodeOps::create` trait did not accept uid/gid parameters, so every newly created file appeared owned by root regardless of which user created it.

## Changes

### VFS layer (`axfs-ng-vfs`)
- `DirNodeOps::create` trait gains `uid: u32, gid: u32` parameters
- `DirNode::create` / `create_locked` / `open_file` pass uid/gid through
- `Mountpoint::create` accepts and forwards uid/gid

### High-level FS (`axfs-ng`)
- `FsContext::create_dir` and `symlink` accept and forward uid/gid

### rsext4 backend
- `mkdir_internal`, `mkdir`, `mkfile`, `create_symbol_link` accept uid/gid and store on the ext4 inode via `Ext4InodeMetadataUpdate`
- `ensure_directory` passes caller uid/gid instead of hardcoding (0,0)
- Added `_with_owner` variants for production callers; original names remain as root-owned convenience wrappers

### Other backends and pseudo filesystems
- **lwext4, FAT**: accept uid/gid in the trait signature (these filesystems do not support Unix ownership)
- **cgroupfs, pseudofs, tmpfs**: updated to match the new trait signature and preserve ownership where metadata exists
- **arceos-lockdep test fake**: updated the `DirNodeOps::create` implementation used by the lockdep test so ArceOS QEMU builds cover the new signature

### memfd
- `sys_memfd_create` passes caller fsuid/fsgid to the anonymous tmpfs inode

### Syscall handlers
- `mkdirat`, `mknodat`, `symlinkat`: read `cred.fsuid`/`cred.fsgid` and pass to VFS
- `openat` already handled this via `flags_to_options` -> `OpenOptions.user`

### Test: `test-vfs-ownership`
Behavior-driven C test covering ownership behavior across tmpfs and ext4:
- File/directory ownership persistence on both filesystems
- Root-created entries owned by uid=0; non-root entries owned by uid=70
- Ownership persists across process identity switches
- `chown` by root succeeds; non-root chown of another user's file -> `EPERM`
- `fchown` via fd succeeds; non-root cannot give away own file
- QEMU configs for all four architectures

## Validation

- `cargo fmt --all -- --check`
- `cargo xtask sync-lint --since <base>`
- `cargo xtask clippy --since <base>`
- `cargo xtask clippy --package ax-net-ng`
- `cargo xtask clippy --package arceos-lockdep`
- `cargo xtask starry test qemu --arch x86_64 -c test-vfs-ownership`
- `cargo xtask arceos test qemu --arch loongarch64 -p arceos-lockdep`

## Files changed

28 files, +536 -40
