### PR TITLE
refactor(ax-driver): remove redundant mmio cfg gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - Run `cargo fmt` after code edits.
 - For ArceOS, StarryOS, and Axvisor builds/tests/runs, prefer the `cargo xtask` command family instead of raw `cargo build`, `cargo test`, or `cargo run`.
 - If `cargo xtask` cannot satisfy a special configuration, inspect the `xtask` flow first and only then fall back to native Cargo commands with manually matched arguments.
+- When resolving rebase or merge conflicts, do not manually merge conflicted `Cargo.lock` contents. Resolve all other conflicts first, then regenerate `Cargo.lock` with Cargo and verify the generated lockfile.
 - For PRs, issues, review replies, discussions, and similar project-facing submissions, keep the language neutral and project-focused.
 - For PR titles, follow `type(scope): content` in Conventional Commits style. Prefer the main affected crate name as `scope` when one crate clearly dominates the change; for cross-cutting or infrastructure work, broader scopes such as `ci`, `repo`, or `docs` are acceptable.
 - PR title examples: `feat(axbuild): add Starry remote board test flow`, `fix(starry-process): correct tty session cleanup`, `chore(ci): split Starry self-hosted board matrix`.

--- a/drivers/ax-driver/src/lib.rs
+++ b/drivers/ax-driver/src/lib.rs
@@ -44,22 +44,6 @@ crate::model_register!(
 );
 
 pub mod error;
-#[cfg(any(
-    all(feature = "serial", plat_dyn),
-    all(any(target_arch = "aarch64", target_arch = "riscv64"), plat_dyn),
-    all(feature = "rockchip-soc", plat_dyn),
-    all(feature = "rockchip-pm", plat_dyn),
-    all(feature = "sg2002-placeholder", plat_dyn),
-    all(feature = "rockchip-dwmmc", plat_dyn),
-    all(feature = "rockchip-sdhci", plat_dyn),
-    all(feature = "phytium-mci", plat_dyn),
-    all(feature = "k230-sdhci", plat_dyn),
-    all(feature = "rk3588-pcie", plat_dyn),
-    all(feature = "rknpu", plat_dyn),
-    all(feature = "xhci-mmio", target_os = "none", plat_dyn),
-    all(feature = "xhci-pci", target_os = "none"),
-    all(virtio_dev, plat_dyn)
-))]
 pub mod mmio;
 
 #[cfg(feature = "block")]


### PR DESCRIPTION
## 问题

`ax-driver` 的 `mmio` 模块外层维护了一组与各驱动 feature 相关的条件编译判断，但这些判断已经与模块内部的功能拆分重复。继续保留外层条件会增加新增 MMIO 驱动 feature 时的同步成本，也容易让模块可见性与实际实现条件产生偏差。

## 修改

- 移除 `drivers/ax-driver/src/lib.rs` 中 `pub mod mmio` 外层的冗余 `cfg(any(...))` 判断。
- 保留 `mmio` 模块内部既有的条件编译边界，由具体驱动实现继续控制各自代码是否参与编译。

## 方案逻辑

这个调整只改变模块导出的外层门控，不引入新的运行时逻辑。`mmio` 作为驱动聚合模块保持可见后，具体 MMIO 设备仍然由各自 feature 和平台条件决定是否启用，从而减少重复配置并降低后续维护成本。

## 验证

- `cargo fmt --all -- --check`
- `cargo xtask clippy --package ax-driver`（41 个 feature 检查全部通过）
