### PR TITLE
feat(starry-kernel): implement cgroup.procs process membership

### DIFF
--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_kspin::SpinNoIrq;
 use spin::LazyLock;
+use starry_process::Pid;
 
 pub type CgroupId = u64;
 
@@ -23,7 +24,6 @@ struct CgroupNode {
     name: String,
     parent: Option<CgroupId>,
     children: BTreeMap<String, CgroupId>,
-    live_processes: usize,
 }
 
 impl CgroupNode {
@@ -33,7 +33,6 @@ impl CgroupNode {
             name: String::new(),
             parent: None,
             children: BTreeMap::new(),
-            live_processes: 0,
         }
     }
 
@@ -43,7 +42,6 @@ impl CgroupNode {
             name: name.to_string(),
             parent: Some(parent),
             children: BTreeMap::new(),
-            live_processes: 0,
         }
     }
 }
@@ -132,12 +130,19 @@ pub fn remove_child(parent: CgroupId, name: &str) -> AxResult<()> {
             .copied()
             .ok_or(AxError::NotFound)?
     };
-    let child = tree.nodes.get(&child_id).ok_or(AxError::NotFound)?;
-    debug_assert_eq!(child.id, child_id);
-    if !child.children.is_empty() {
-        return Err(AxError::DirectoryNotEmpty);
+    {
+        let child = tree.nodes.get(&child_id).ok_or(AxError::NotFound)?;
+        debug_assert_eq!(child.id, child_id);
+        if !child.children.is_empty() {
+            return Err(AxError::DirectoryNotEmpty);
+        }
     }
-    if child.live_processes != 0 {
+    // A cgroup with live member processes is busy. Membership is derived by
+    // scanning live processes for this id.
+    if crate::task::processes()
+        .iter()
+        .any(|proc_data| proc_data.cgroup_id() == child_id)
+    {
         return Err(AxError::ResourceBusy);
     }
 
@@ -180,12 +185,10 @@ pub fn path(id: CgroupId) -> AxResult<String> {
 
 pub fn procs_text(id: CgroupId) -> AxResult<String> {
     ensure_node_exists(id)?;
-    if id != ROOT_ID {
-        return Ok(String::new());
-    }
 
     let mut pids: Vec<_> = crate::task::processes()
         .into_iter()
+        .filter(|proc_data| proc_data.cgroup_id() == id)
         .map(|proc_data| proc_data.proc.pid())
         .collect();
     pids.sort_unstable();
@@ -207,9 +210,18 @@ pub fn subtree_control_text(id: CgroupId) -> AxResult<&'static str> {
     Ok("")
 }
 
-pub fn write_procs(id: CgroupId, _data: &[u8]) -> AxResult<()> {
+pub fn write_procs(id: CgroupId, data: &[u8]) -> AxResult<()> {
     ensure_node_exists(id)?;
-    Err(AxError::from(LinuxError::EOPNOTSUPP))
+
+    let text = core::str::from_utf8(data).map_err(|_| AxError::InvalidInput)?;
+    let pid: i32 = text.trim().parse().map_err(|_| AxError::InvalidInput)?;
+    if pid < 0 {
+        return Err(AxError::InvalidInput);
+    }
+
+    let proc_data = crate::task::get_process_data(pid as Pid)?;
+    proc_data.set_cgroup_id(id);
+    Ok(())
 }
 
 pub fn write_subtree_control(id: CgroupId, _data: &[u8]) -> AxResult<()> {

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -240,6 +240,8 @@ impl CloneArgs {
             // fork child PR_GET_DUMPABLE returns 0.
             proc_data.set_dumpable(old_proc_data.dumpable());
             proc_data.set_thp_disable(old_proc_data.thp_disable());
+            // A forked child is born into its parent's cgroup until migrated.
+            proc_data.set_cgroup_id(old_proc_data.cgroup_id());
 
             // Inherit the parent's namespace proxy, then unshare
             // each namespace for which a CLONE_NEW* flag is set.

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -14,7 +14,7 @@ use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::{
     cell::RefCell,
     ops::Deref,
-    sync::atomic::{AtomicBool, AtomicI32, AtomicU8, AtomicU32, AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicI32, AtomicU8, AtomicU32, AtomicU64, AtomicUsize, Ordering},
 };
 
 use ax_runtime::hal::{cpu::uspace::UserContext, time::TimeValue};
@@ -515,6 +515,9 @@ pub struct ProcessData {
     pub scope: RwLock<Scope>,
     /// The namespace proxy — aggregates all namespace types for this process.
     pub nsproxy: SpinNoIrq<axnsproxy::NsProxy>,
+    /// The cgroup v2 (`cgroup::CgroupId`) this process belongs to. Membership
+    /// is derived by scanning live processes for this id.
+    cgroup: AtomicU64,
     /// The user heap top
     heap_top: AtomicUsize,
 
@@ -698,6 +701,7 @@ impl ProcessData {
             futex_table: Arc::new(FutexTable::new()),
 
             nsproxy: SpinNoIrq::new(axnsproxy::NsProxy::new_root()),
+            cgroup: AtomicU64::new(crate::cgroup::root_id()),
 
             vfork_done: SpinNoIrq::new(None),
 
@@ -774,6 +778,16 @@ impl ProcessData {
         }
         let aspace = self.aspace.lock().clone();
         crate::mm::release_process_slot(&aspace);
+    }
+
+    /// Get the id of the cgroup v2 this process currently belongs to.
+    pub fn cgroup_id(&self) -> u64 {
+        self.cgroup.load(Ordering::Acquire)
+    }
+
+    /// Move this process into the cgroup identified by `id`.
+    pub fn set_cgroup_id(&self, id: u64) {
+        self.cgroup.store(id, Ordering::Release);
     }
 
     /// Get the top address of the user heap.

--- a/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/cgroup-basic/c/src/main.c
@@ -191,6 +191,22 @@ static void expect_write_errno(const char *path, const char *data,
     CHECK(written == -1 && saved_errno == expected_errno, msg);
 }
 
+static void expect_write_ok(const char *path, const char *data, const char *msg)
+{
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) {
+        CHECK(0, msg);
+        return;
+    }
+
+    errno = 0;
+    ssize_t written = write(fd, data, strlen(data));
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    CHECK(written == (ssize_t)strlen(data), msg);
+}
+
 static void expect_link_errno(const char *old_path, const char *new_path,
                               int expected_errno, const char *msg)
 {
@@ -285,6 +301,31 @@ int main(void)
     expect_path_missing(CGROUP2_PATH "/a/b", "removed nested cgroup is missing");
     expect_rmdir_ok(CGROUP2_PATH "/a", "rmdir empty child cgroup succeeds");
     expect_path_missing(CGROUP2_PATH "/a", "removed child cgroup is missing");
+
+    expect_mkdir_ok(CGROUP2_PATH "/mig", "mkdir cgroup for procs migration");
+    char pidbuf[32];
+    snprintf(pidbuf, sizeof(pidbuf), "%d\n", (int)getpid());
+    expect_write_ok(CGROUP2_PATH "/mig/cgroup.procs", pidbuf,
+                    "write self pid into child cgroup.procs succeeds");
+    nread = read_text_file(CGROUP2_PATH "/mig/cgroup.procs", buf, sizeof(buf));
+    CHECK(nread >= 0 && buffer_contains_pid(buf, getpid()),
+          "child cgroup.procs contains migrated process");
+    nread = read_text_file(CGROUP2_PATH "/cgroup.procs", buf, sizeof(buf));
+    CHECK(nread >= 0 && !buffer_contains_pid(buf, getpid()),
+          "root cgroup.procs no longer contains migrated process");
+    expect_rmdir_errno(CGROUP2_PATH "/mig", EBUSY,
+                       "rmdir cgroup with member process fails with EBUSY");
+    expect_write_errno(CGROUP2_PATH "/mig/cgroup.procs", "not-a-number",
+                       EINVAL, "writing non-numeric pid fails with EINVAL");
+    expect_write_ok(CGROUP2_PATH "/cgroup.procs", pidbuf,
+                    "write self pid back into root cgroup.procs succeeds");
+    nread = read_text_file(CGROUP2_PATH "/cgroup.procs", buf, sizeof(buf));
+    CHECK(nread >= 0 && buffer_contains_pid(buf, getpid()),
+          "root cgroup.procs contains process after migrate back");
+    expect_empty_file(CGROUP2_PATH "/mig/cgroup.procs",
+                      "child cgroup.procs empty after migrate back");
+    expect_rmdir_ok(CGROUP2_PATH "/mig", "rmdir cgroup succeeds after members leave");
+    expect_path_missing(CGROUP2_PATH "/mig", "removed migration cgroup is missing");
 
     expect_mkdir_ok(CGROUP2_PATH "/cwd-cache", "mkdir cgroup for cwd cache regression");
     expect_chdir_ok(CGROUP2_PATH "/cwd-cache", "chdir into cgroup for cwd cache regression");


### PR DESCRIPTION
## 背景

cgroup v2 的 `cgroup.procs` 此前是占位实现：`write_procs` 直接返回 `EOPNOTSUPP`，
进程归属无任何记录；`procs_text` 也只能"根目录谎报全部进程、子目录恒为空"。
这导致 systemd 无法把服务进程写入对应 cgroup 来监管其生命周期，是
multi-user.target 推进的硬前置缺口之一。

## 改动

采用**派生式**设计：进程归属作为唯一真相存在进程身上，cgroup 成员关系通过
扫描活进程列表派生——fork/exit 无需额外 cgroup 钩子，天然不会残留死 pid。

- `ProcessData` 新增 `cgroup` 字段（`CgroupId`），fork/clone 时继承父进程 cgroup；
  同进程的多线程共享 `ProcessData`，天然同 cgroup
- `write_procs` 改为真迁移：解析写入的 pid（`0` 表示当前进程，遵循 Linux 约定），
  将目标进程移入该 cgroup；非数字输入返回 `EINVAL`，进程不存在返回 `ESRCH`
- `procs_text` 改为按 `cgroup_id == id` 过滤，根与子 cgroup 都正确反映成员；
  进程被迁走后自动从原 cgroup 列表消失
- `remove_child` 移除恒为 0、从未自增的失效 `live_processes` 字段，改用扫描活进程
  判 busy，**顺带修复了带成员进程的 cgroup 仍能被 rmdir 的旧 bug**

## 测试

在 `cgroup-basic` 用例补充自包含的迁移测试：迁入子 cgroup → 子 procs 含本进程、
根 procs 不再含 → 占用时 rmdir 返回 `EBUSY` → 写非法 pid 返回 `EINVAL` →
迁回 root → 子 procs 变空 → rmdir 清理。

