### PR TITLE
fix(starry-net): accept oversized addrlen in netlink bind/connect

### DIFF
--- a/os/StarryOS/kernel/src/syscall/net/addr.rs
+++ b/os/StarryOS/kernel/src/syscall/net/addr.rs
@@ -103,7 +103,11 @@ pub fn read_netlink_addr(
     addr: UserConstPtr<sockaddr>,
     addrlen: socklen_t,
 ) -> AxResult<sockaddr_nl> {
-    if addrlen != size_of::<sockaddr_nl>() as socklen_t {
+    // Linux `netlink_bind`/`netlink_connect` reject only `addrlen < sizeof(sockaddr_nl)`;
+    // a larger length is accepted and the trailing bytes ignored. Callers commonly zero a
+    // `sockaddr_storage` and pass its full size, so requiring an exact match wrongly
+    // returned EINVAL for legitimate binds/connects. Read just the leading sockaddr_nl.
+    if (addrlen as usize) < size_of::<sockaddr_nl>() {
         return Err(AxError::InvalidInput);
     }
     let addr_nl = addr.cast::<sockaddr_nl>().get_as_ref()?;


### PR DESCRIPTION
## 这个改动做了什么

修正 AF_NETLINK 地址解析 `read_netlink_addr` 对 `addrlen` 的校验。

## 为什么要改

之前要求 `addrlen` 精确等于 `size_of::<sockaddr_nl>()`,否则返回 EINVAL。Linux 的 `netlink_bind`/`netlink_connect` 只拒绝 `addrlen < sizeof(sockaddr_nl)`,更大的长度被接受、多出的尾部字节忽略。

很多 AF_NETLINK 调用方(libnl、rtnetlink、容器网络探测)会清零一个 `sockaddr_storage` 再按其完整大小传入,精确匹配的检查会让这些合法的 bind/connect 误报 EINVAL。

## 怎么改的

把 `!=` 改成 `<`,只读取开头的 `sockaddr_nl`,与 Linux 行为对齐。

## 验证

- x86_64 内核编译通过。
