### PR TITLE
fix(starry-mm): reject overflowing addr+length in mmap instead of wrapping

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -168,7 +168,19 @@ pub fn sys_mmap(
     };
 
     let aligned = addr.align_down(page_size);
-    let end = (addr + length).align_up(page_size);
+    // Guard against `addr + length` (and the page-size round-up that `align_up`
+    // performs internally as `raw_end + page_size - 1`) wrapping past the address
+    // space for pathological requests (e.g. MAP_FIXED with a near-max addr and a
+    // huge length). Linux rejects these with EINVAL up front. `checked_add`
+    // catches the first overflow; the `end < raw_end` check catches the case where
+    // `addr + length` itself didn't overflow but rounding up to the page boundary
+    // did — otherwise the wrapped value would flow into the length computation and
+    // the (non-FIXED) hint search below.
+    let raw_end = addr.checked_add(length).ok_or(AxError::InvalidInput)?;
+    let end = raw_end.align_up(page_size);
+    if end < raw_end {
+        return Err(AxError::InvalidInput);
+    }
     let mut length = end - aligned;
 
     let file = if anonymous {

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mmap-family/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mmap-family/c/src/main.c
@@ -91,6 +91,23 @@ int main(void)
                         MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0),
                    EEXIST, "mmap FIXED_NOREPLACE 覆盖已映射 → EEXIST");
 
+    /* mmap addr+length 溢出 → 被拒绝, 而非环绕成功 (回归)
+     * MAP_FIXED 指向接近地址空间顶端、`addr + length` 回绕的请求。关键不变量:
+     * 内核必须**拒绝**, 不能让 `(addr + length).align_up` 内部回绕成一个小值
+     * 再继续(length 下溢成超大、在低地址环绕落地)。修复用 `checked_add` +
+     * `end < raw_end` 双重校验。errno 上 Linux 此处给 ENOMEM(地址越界), starry
+     * 修复给 EINVAL(算术溢出); 两者都是合法拒绝, 故都接受 —— 真正回归的是
+     * "r == -1"(不得返回一个环绕后的有效地址)。直接走 syscall 层。*/
+    {
+        unsigned long near_top = ~0xFFFUL; /* 页对齐, 接近 usize::MAX */
+        errno = 0;
+        long r = syscall(SYS_mmap, (void *)near_top, (size_t)(8 * ps),
+                         PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, (off_t)0);
+        CHECK(r == -1 && (errno == EINVAL || errno == ENOMEM),
+              "mmap MAP_FIXED 且 addr+length 溢出 → 被拒(EINVAL/ENOMEM), 不环绕");
+    }
+
     /* ===================== mprotect ===================== */
 
     /* mprotect happy path: READ|WRITE → 0 */


### PR DESCRIPTION
## 这个改动做了什么

让 `sys_mmap` 在计算映射范围前对 `addr + length` 做溢出检查。

## 为什么要改

之前 `end = (addr + length).align_up(page_size)` 不做溢出检查。对 `addr + length` 超过 `usize` 上限的病态请求(例如 MAP_FIXED 传入接近最大值的 addr 加一个很大的 length),加法回绕,`length = end - aligned` 得到错误的小值/回绕值,在被后续 `validate_region` 兜住之前就已经算错。Linux 的 `do_mmap` 在入口直接用溢出检查返回 EINVAL。

## 怎么改的

改用 `addr.checked_add(length)`,溢出即返回 EINVAL,与本文件 `sys_mremap` 已有的 `checked_add` 处理一致。正常(非溢出)请求行为完全不变。

## 验证

- x86_64 内核编译通过;改动只在溢出分支引入 EINVAL,正常 mmap 路径结果不变。
