### PR TITLE
feat(starry-proc): add common /proc/sys and /proc/filesystems stub files

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -1101,6 +1101,15 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
             Ok("proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\n")
         }),
     );
+    // /proc/filesystems — list of registered filesystem types. Tools like
+    // `mount`/`findmnt` and some container runtimes read it to decide what they
+    // can mount; absence (ENOENT) made those probes fail.
+    root.add(
+        "filesystems",
+        SimpleFile::new_regular(fs.clone(), || {
+            Ok("nodev\tsysfs\nnodev\tproc\nnodev\ttmpfs\nnodev\tdevtmpfs\n\text4\n")
+        }),
+    );
     root.add(
         "stat",
         SimpleFile::new_regular(fs.clone(), || Ok(render_stat())),
@@ -1191,6 +1200,50 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
             );
 
             SimpleDir::new_maker(fs.clone(), Arc::new(kernel))
+        });
+
+        // /proc/sys/vm — read-only constants several runtimes probe at startup.
+        // `max_map_count` in particular is read by Elasticsearch/Lucene and some
+        // JVMs as a preflight check; its absence (ENOENT) trips those checks.
+        sys.add("vm", {
+            let mut vm = DirMapping::new();
+            vm.add(
+                "overcommit_memory",
+                SimpleFile::new_regular(fs.clone(), || Ok("0\n")),
+            );
+            vm.add(
+                "max_map_count",
+                SimpleFile::new_regular(fs.clone(), || Ok("65530\n")),
+            );
+            SimpleDir::new_maker(fs.clone(), Arc::new(vm))
+        });
+
+        // /proc/sys/fs — file-descriptor limits some servers read to size tables.
+        sys.add("fs", {
+            let mut fs_sys = DirMapping::new();
+            fs_sys.add(
+                "file-max",
+                SimpleFile::new_regular(fs.clone(), || Ok("1048576\n")),
+            );
+            fs_sys.add(
+                "nr_open",
+                SimpleFile::new_regular(fs.clone(), || Ok("1048576\n")),
+            );
+            SimpleDir::new_maker(fs.clone(), Arc::new(fs_sys))
+        });
+
+        // /proc/sys/net/core/somaxconn — listen-backlog clamp some servers read.
+        sys.add("net", {
+            let mut net = DirMapping::new();
+            net.add("core", {
+                let mut core = DirMapping::new();
+                core.add(
+                    "somaxconn",
+                    SimpleFile::new_regular(fs.clone(), || Ok("4096\n")),
+                );
+                SimpleDir::new_maker(fs.clone(), Arc::new(core))
+            });
+            SimpleDir::new_maker(fs.clone(), Arc::new(net))
         });
 
         SimpleDir::new_maker(fs.clone(), Arc::new(sys))

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-procfs-sysctl/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-procfs-sysctl/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-procfs-sysctl C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-procfs-sysctl src/main.c)
+target_compile_options(test-procfs-sysctl PRIVATE -Wall -Wextra)
+target_link_options(test-procfs-sysctl PRIVATE -static)
+
+install(TARGETS test-procfs-sysctl RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-procfs-sysctl/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-procfs-sysctl/c/src/main.c
@@ -1,0 +1,68 @@
+/*
+ * test_procfs_sysctl.c — presence and plausibility of the common /proc/sys and
+ * /proc/filesystems stub files.
+ *
+ * Several runtimes read these at startup (Elasticsearch/Lucene reads
+ * max_map_count; servers read somaxconn / file-max; tools enumerate
+ * /proc/filesystems). They used to be ENOENT on StarryOS; the fix adds them as
+ * read-only stubs. The test asserts each is openable, non-empty and has a
+ * plausible value, so it passes on both a real Linux host and StarryOS without
+ * pinning the exact stub numbers.
+ */
+
+#include "test_framework.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+/* Read a whole small file into buf (NUL-terminated). Returns bytes read, or -1. */
+static long slurp(const char *path, char *buf, size_t cap)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return -1;
+    }
+    ssize_t n = read(fd, buf, cap - 1);
+    close(fd);
+    if (n < 0) {
+        return -1;
+    }
+    buf[n] = '\0';
+    return (long)n;
+}
+
+/* Assert `path` is readable and its content parses as a non-negative integer. */
+static void check_uint_file(const char *path, int positive)
+{
+    char buf[64];
+    long n = slurp(path, buf, sizeof(buf));
+    CHECK(n > 0, path);
+    if (n > 0) {
+        char *end = NULL;
+        long v = strtol(buf, &end, 10);
+        CHECK(end != buf && v >= 0 && (!positive || v > 0),
+              path /* value is a plausible non-negative integer */);
+    }
+}
+
+int main(void)
+{
+    TEST_START("procfs sysctl stubs");
+
+    /* /proc/filesystems: readable and lists ext4 (the rootfs type). */
+    {
+        char buf[512];
+        long n = slurp("/proc/filesystems", buf, sizeof(buf));
+        CHECK(n > 0, "/proc/filesystems readable");
+        CHECK(n > 0 && strstr(buf, "ext4") != NULL,
+              "/proc/filesystems lists ext4");
+    }
+
+    check_uint_file("/proc/sys/vm/overcommit_memory", 0);
+    check_uint_file("/proc/sys/vm/max_map_count", 1);
+    check_uint_file("/proc/sys/fs/file-max", 1);
+    check_uint_file("/proc/sys/fs/nr_open", 1);
+    check_uint_file("/proc/sys/net/core/somaxconn", 1);
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-procfs-sysctl/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-procfs-sysctl/c/src/test_framework.h
@@ -1,0 +1,86 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno)); \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno,     \
+               strerror(errno));                                        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
## 这个改动做了什么

为 `/proc` 增加一组运行时常用的只读配置文件。

## 为什么要改

不少程序启动时读取这些路径,在 StarryOS 上它们返回 ENOENT,导致预检失败或退化:

- `/proc/sys/vm/max_map_count` — Elasticsearch/Lucene、部分 JVM 启动预检读取,缺失会报错;
- `/proc/sys/vm/overcommit_memory`、`/proc/sys/fs/{file-max,nr_open}`、`/proc/sys/net/core/somaxconn` — 服务端读取系统上限/默认值;
- `/proc/filesystems` — `mount`/`findmnt`、部分容器运行时读取它判断可挂载类型。

## 怎么改的

在 `proc.rs` 的 `builder()` 里新增这些只读常量文件,取值为常见 Linux 默认(`max_map_count=65530`、`somaxconn=4096`、`file-max/nr_open=1048576`、`overcommit_memory=0`)。全部沿用现有 `SimpleFile::new_regular` 静态字符串范式,只读、零状态。未触及 `/proc/sys/kernel` 子树。

## 验证

- x86_64 内核编译通过;新增节点与现有 `pid_max`/`mounts` 同范式。
