### PR TITLE
fix(starry-mm): make mlock fault the range in and report ENOMEM on holes

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -853,6 +853,46 @@ pub fn sys_mlock(addr: usize, length: usize) -> AxResult<isize> {
     sys_mlock2(addr, length, 0)
 }
 
-pub fn sys_mlock2(_addr: usize, _length: usize, _flags: u32) -> AxResult<isize> {
+pub fn sys_mlock2(addr: usize, length: usize, flags: u32) -> AxResult<isize> {
+    // Linux `mlock2` accepts only `flags == 0` or `MLOCK_ONFAULT`; any other bit
+    // is rejected with EINVAL and must produce no populate/fault side effect.
+    const MLOCK_ONFAULT: u32 = 0x01;
+    if flags & !MLOCK_ONFAULT != 0 {
+        return Err(AxError::InvalidInput);
+    }
+    if length == 0 {
+        return Ok(0);
+    }
+    let aligned = addr.align_down(PageSize::Size4K);
+    // `checked_add` guards `addr + length`, but `align_up` itself adds
+    // `PAGE_SIZE - 1` internally and can still wrap a near-`usize::MAX` end to a
+    // small value; detect that wrap (end < raw_end) and reject, as Linux rejects
+    // an out-of-range mlock with EINVAL rather than locking a tiny wrapped range.
+    let raw_end = addr.checked_add(length).ok_or(AxError::InvalidInput)?;
+    let end = raw_end.align_up(PageSize::Size4K);
+    if end < raw_end {
+        return Err(AxError::InvalidInput);
+    }
+    let size = end - aligned;
+
+    let curr = current();
+    let aspace_arc = curr.as_thread().proc_data.aspace();
+    let mut aspace = aspace_arc.lock();
+    let start = VirtAddr::from(aligned);
+    if flags & MLOCK_ONFAULT != 0 {
+        // MLOCK_ONFAULT: lock the range but bring pages in lazily (no eager
+        // fault). Still report ENOMEM if the range has an unmapped hole, as
+        // Linux does. An empty access mask makes `can_access_range` a pure
+        // contiguous-coverage check.
+        if !aspace.can_access_range(start, size, MappingFlags::empty()) {
+            return Err(AxError::NoMemory);
+        }
+    } else {
+        // Plain mlock (flags == 0): honor the "fault now" contract by faulting
+        // the whole range in, reporting ENOMEM on any unmapped page. On this
+        // no-swap kernel the faulted pages then stay resident, satisfying mlock's
+        // residency guarantee. `populate_area` is the MAP_POPULATE primitive.
+        aspace.populate_area(start, size, MappingFlags::READ)?;
+    }
     Ok(0)
 }

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mlock2/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mlock2/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-mlock2 C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-mlock2 src/main.c)
+target_compile_options(test-mlock2 PRIVATE -Wall -Wextra)
+target_link_options(test-mlock2 PRIVATE -static)
+
+install(TARGETS test-mlock2 RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mlock2/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mlock2/c/src/main.c
@@ -1,0 +1,63 @@
+/*
+ * test_mlock2.c — mlock(2) / mlock2(2) / munlock(2) boundary semantics.
+ *
+ * Regression for the fix that turned the mlock family from a pure `Ok(0)` stub
+ * into a real implementation: it now (a) rejects unknown mlock2 flags with
+ * EINVAL, (b) faults the range in / verifies coverage and reports ENOMEM on an
+ * unmapped hole, and (c) rejects an addr+length that overflows the address
+ * space instead of wrapping.
+ *
+ * mlock2 / MLOCK_ONFAULT are not in the musl cross sysroot, so the constant and
+ * the raw syscall are used directly to keep the test self-contained.
+ */
+
+#include "test_framework.h"
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+
+#ifndef MLOCK_ONFAULT
+#define MLOCK_ONFAULT 0x01u
+#endif
+
+static long raw_mlock2(const void *addr, size_t len, unsigned int flags)
+{
+    return syscall(SYS_mlock2, addr, len, flags);
+}
+
+int main(void)
+{
+    TEST_START("mlock/mlock2/munlock");
+
+    long ps = sysconf(_SC_PAGESIZE);
+
+    char *p = mmap(NULL, ps, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(p != MAP_FAILED, "mmap one RW page");
+
+    /* flags == 0: lock succeeds (fix faults the range in) */
+    CHECK_RET(raw_mlock2(p, ps, 0), 0, "mlock2(flags=0) → 0");
+
+    /* MLOCK_ONFAULT is the only other accepted flag */
+    CHECK_RET(raw_mlock2(p, ps, MLOCK_ONFAULT), 0, "mlock2(MLOCK_ONFAULT) → 0");
+
+    /* any unknown flag bit → EINVAL (was silently accepted by the old stub) */
+    CHECK_ERR(raw_mlock2(p, ps, 0xFFu), EINVAL, "mlock2(unknown flags) → EINVAL");
+
+    /* (munlock is a separate syscall not covered by this fix; omitted here.) */
+    munmap(p, ps);
+
+    /* mlock over [mapped][hole][mapped] → ENOMEM (man 2 mlock: some pages of the
+     * range are not mapped). The old stub returned 0 here. */
+    char *hole = mmap(NULL, 3 * ps, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(hole != MAP_FAILED, "mmap 3 pages for hole test");
+    if (hole != MAP_FAILED) {
+        CHECK_RET(munmap(hole + ps, ps), 0, "munmap middle page (punch hole)");
+        CHECK_ERR(mlock(hole, 3 * ps), ENOMEM, "mlock over a hole → ENOMEM");
+        munmap(hole, ps);
+        munmap(hole + 2 * ps, ps);
+    }
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mlock2/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mlock2/c/src/test_framework.h
@@ -1,0 +1,86 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno)); \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno,     \
+               strerror(errno));                                        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
## 这个改动做了什么

让 `mlock`/`mlock2` 真正把范围 fault 进来,并对范围内未映射的页返回 ENOMEM。

## 为什么要改

之前 `sys_mlock2` 无条件返回 `Ok(0)` —— 既不 fault 页面,也不对完全未映射的范围报错。这是 fake success:依赖 mlock "fault now + 锁定" 语义、或期望对非法范围得到 ENOMEM 的程序会被静默误导。

## 怎么改的

调用 `populate_area`(即 MAP_POPULATE 使用的同一原语):把 `[addr, addr+len)` 整段 fault 进来,范围内存在未映射页时返回 ENOMEM,与 Linux mlock 行为一致。本内核无 swap,fault 进来的页随后保持常驻,满足 mlock 的常驻保证。区间用 `checked_add` 防溢出。MCL_* / MLOCK_ONFAULT 等 flag 细节暂不建模。

## 验证

- x86_64 内核编译通过;`populate_area` 是 MAP_POPULATE 已在用的成熟路径。
