### PR TITLE
fix(axfs-ng): zero the partial last page when truncating a file shorter

### DIFF
--- a/os/arceos/modules/axfs-ng/src/highlevel/file.rs
+++ b/os/arceos/modules/axfs-ng/src/highlevel/file.rs
@@ -902,12 +902,34 @@ impl CachedFile {
                 let old_page_offset = (old_len - page_start) as usize;
                 let new_page_offset = (len - page_start).min(PAGE_SIZE as u64) as usize;
                 page.data()[old_page_offset..new_page_offset].fill(0);
+                // Mark dirty so the zeroed gap is written back: ext4 `set_len`
+                // only updates `i_size`, it does not clear the bytes on disk, so
+                // a clean eviction + reload would otherwise resurrect stale data.
+                page.dirty = true;
             }
-        } else if old_last_page > new_last_page {
-            // For truncating, we need to remove all pages that are beyond the
-            // new length
-            // TODO(mivik): can this be more efficient?
+        } else if len < old_len {
             let mut guard = self.shared.page_cache.lock();
+            // Linux `truncate(len)` zeroes the tail of the partial last page, so a
+            // later extend or `mmap` reads those bytes as zero. Without this, a
+            // shrink that leaves a partial last page (e.g. sqlite's
+            // `ftruncate(<-shm>, 3)`) keeps stale bytes there; a subsequent mmap of
+            // the regrown file then sees the stale tail, so a fresh reader trusts a
+            // stale wal-index header instead of recovering (juicefs sqlite WAL
+            // cross-process reopen failure). This branch also covers shrinking
+            // within a single page, where neither old branch ran at all.
+            let tail = (len % PAGE_SIZE as u64) as usize;
+            if tail != 0
+                && let Some(page) = guard.get_mut(&new_last_page)
+            {
+                page.data()[tail..].fill(0);
+                // Mark dirty so the zeroed tail is written back: ext4 `set_len`
+                // updates `i_size` but leaves the on-disk bytes past it intact, so
+                // a clean eviction + reload (or mmap fault) would otherwise reload
+                // the stale tail from disk.
+                page.dirty = true;
+            }
+            // Remove all pages that are wholly beyond the new length.
+            // TODO(mivik): can this be more efficient?
             let keys = guard
                 .iter()
                 .map(|(k, _)| *k)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-ftruncate/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-ftruncate/c/src/main.c
@@ -356,5 +356,41 @@ int main(void)
         close(p[1]);
     }
 
+    /* ================================================================
+     * 收缩后再扩展: 原页尾部必须读作 \0 (回归)
+     * 写满一页 0xAA -> 收缩到 100 字节 -> 再扩回 4096。Linux 在收缩时把
+     * 部分末页 [100, 4096) 的尾部清零, 因此 regrow 后这段读作 \0。旧
+     * starry 只改文件长度、漏清 page-cache 中已驻留页的尾部, 导致 regrow
+     * 后读到残留的 0xAA(sqlite WAL 跨进程 reopen 据此读到脏 header 而崩)。
+     * ================================================================ */
+    {
+        char tmpl[] = "/tmp/test-ftruncate-XXXXXX";
+        int fd = mkstemp(tmpl);
+        CHECK(fd >= 0, "mkstemp 应成功 (shrink-regrow tail)");
+
+        char page[4096];
+        memset(page, 0xAA, sizeof(page));
+        CHECK_RET(write(fd, page, sizeof(page)), 4096, "写满一页 0xAA");
+        CHECK_RET(call_ftruncate(fd, 100), 0, "收缩到 100 字节");
+        CHECK_RET(call_ftruncate(fd, 4096), 0, "再扩回 4096 字节");
+
+        char back[4096];
+        memset(back, 0xFF, sizeof(back));
+        ssize_t n = pread(fd, back, sizeof(back), 0);
+        CHECK(n == 4096, "pread 整页回读");
+        int tail_zero = 1;
+        for (int i = 100; i < 4096; i++) {
+            if (back[i] != 0) {
+                tail_zero = 0;
+                break;
+            }
+        }
+        CHECK(tail_zero,
+              "收缩-扩展后原页尾部 [100,4096) 必须为全零 (无脏残留)");
+
+        close(fd);
+        unlink(tmpl);
+    }
+
     TEST_DONE();
 }


### PR DESCRIPTION
## 这个改动做了什么

`CachedFile::set_len` 在把文件**收缩**时,清零新最后一页(部分页)中新长度之后的尾部,对齐 Linux `truncate` 语义。

## 为什么要改

之前的收缩分支只删除"整页超过新长度"的页缓存页,不清零新最后一页的尾部;当收缩仍落在同一页内(`old_last_page == new_last_page`)时,两个分支都不进、完全不处理。

Linux `truncate(len)` 会立即把 `len` 所在页中 `len` 之后的字节清零,使随后的扩展或 `mmap` 读到这些字节为零。缺这一步时,留下部分尾页的收缩会把陈旧字节留在那里,之后对重新增长的文件 `mmap` 就读到陈旧尾部。

**真实影响**:这是 sqlite WAL 跨进程重开在本平台失败的根因。sqlite 第一个连接经 dead-man-switch 流程对 `-shm` 做 `ftruncate(3)` 触发 wal-index 重建后 `mmap` 该 `-shm`:Linux 上重映射读到零 → wal-index 头无效 → `walIndexRecover` 从 `-wal` 重建;本平台尾部残留陈旧 wal-index 头(校验通过)→ 不重建 → 空视图("database is not formatted")。以 sqlite 为元数据引擎的 juicefs 即因此 `format` 后跨进程 `status` 读回失败。

## 怎么改的

收缩时(`len < old_len`)先把新最后一页中 `len % PAGE_SIZE` 之后的尾部清零(若该页在缓存中),再删除完全超过新长度的页;同时覆盖此前完全未处理的"页内收缩"。

## 验证

- x86_64 内核编译通过。
- 最小复现(sqlite WAL `PRAGMA journal_mode=WAL` + 进程A写不checkpoint + 进程B重开读):修前 starry `READ_FAIL: no such table`,修后 `READ_OK`(与 Linux 一致);插桩 sqlite 确认修后进入 `walIndexRecover`。
- juicefs 1.3.1 x86_64:修前 3/4(RT 失败),修后 **4/4**(VER/FMT/RT/BADGER 全过)。
