### PR TITLE
fix(starryos): relax riscv64 smoke timeout

### DIFF
--- a/test-suit/starryos/normal/qemu-smp1/smoke/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/smoke/qemu-riscv64.toml
@@ -19,4 +19,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "pwd && echo 'All tests passed!'"
 success_regex = ["(?m)^All tests passed!\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b']
-timeout = 5
+timeout = 15


### PR DESCRIPTION
## 问题

`Test starry riscv64 qemu` 在 CI 中偶发卡在 `smoke` 用例：系统已经启动到 Starry 用户态欢迎信息，但 `qemu-riscv64.toml` 只给了 5 秒超时，尚未等到 shell prompt 和 `All tests passed!` 就被判定为 `QEMU timed out after 5s`。

## 修改

将 `test-suit/starryos/normal/qemu-smp1/smoke/qemu-riscv64.toml` 的 timeout 从 5 秒调整为 15 秒，和 x86_64 smoke 用例保持一致。

## 方案逻辑

这次失败不是构建、rootfs 或 QEMU 启动失败：日志显示前置用例通过，`smoke` 也已经进入用户态。仅放宽该 riscv64 smoke 用例的超时预算，可以给 self-hosted runner 上的启动和 shell 交互留出余量，同时不引入全局 timeout scale，避免拖慢其它失败用例的反馈。

## 验证

- `STARRY_APK_REGION=us cargo xtask starry test qemu --arch riscv64 -c smoke`：通过，日志显示 `qemu config ... (timeout=15s)`，`smoke` 用时 1.77s 并匹配 `All tests passed!`。
- `STARRY_APK_REGION=us cargo xtask starry test qemu --arch riscv64`：已启动完整 normal 批量验证并推进到 `c-regression`，后因本次只需提交 timeout 修复而手动停止，未完整跑完。

TOML-only 修改，未运行 `cargo fmt` / clippy。