### PR TITLE
fix(axcpu-aarch64): emulate EL0 MRS reads of ID_AA64* feature registers

### DIFF
--- a/components/axcpu/src/aarch64/uspace.rs
+++ b/components/axcpu/src/aarch64/uspace.rs
@@ -44,6 +44,78 @@ impl UserContext {
         }
     }
 
+    /// Emulates an EL0 `MRS Xt, ID_AA64*_EL1` that trapped as an "unknown"
+    /// exception (EC=0), mirroring Linux's `emulate_mrs`. AArch64 CPU-feature
+    /// detection — e.g. the Go runtime's cpu probing — reads these ID feature
+    /// registers from EL0; reading an EL1 register from EL0 is UNDEFINED and
+    /// traps, which would otherwise be delivered as SIGILL and crash every such
+    /// program. Reads the real register (the kernel runs at EL1) into `Xt`,
+    /// advances the PC, and returns `true`; returns `false` if the faulting
+    /// instruction is not one of the emulated ID-register reads so the caller can
+    /// fall back to SIGILL.
+    ///
+    /// # Safety
+    /// Reads the 4-byte instruction at the trapped PC (`elr`) from the active
+    /// user address space. The caller invokes this only while that aspace is
+    /// installed and the PC was just executing, so the page is mapped.
+    pub unsafe fn emulate_mrs_id_reg(&mut self) -> bool {
+        let insn = unsafe { core::ptr::read(self.tf.elr as *const u32) };
+        // MRS (register, read direction): bits[31:20] == 0xD53 and L (bit 21) set.
+        if (insn & 0xFFF0_0000) != 0xD530_0000 || (insn & (1 << 21)) == 0 {
+            return false;
+        }
+        let op0 = (insn >> 19) & 0x3;
+        let op1 = (insn >> 16) & 0x7;
+        let crn = (insn >> 12) & 0xf;
+        let crm = (insn >> 8) & 0xf;
+        let op2 = (insn >> 5) & 0x7;
+        let rt = (insn & 0x1f) as usize;
+        // The AArch64 ID feature register space is op0=3, op1=0, CRn=0, CRm=4..7.
+        // We must NOT leak the raw EL1 register to EL0 (as Linux's `emulate_mrs`
+        // also avoids): the host/QEMU CPU may advertise SVE/SME/MTE/BTI/PAuth/RAS
+        // etc. that need kernel context-save/enable flows StarryOS does not have.
+        // A program reading those bits would then execute the corresponding
+        // instructions and crash or corrupt state. So we expose a sanitized
+        // user-safe view: keep only the feature bits whose instructions are plain
+        // and stateless (so they Just Work, including under TCG), and report
+        // everything else as not-implemented (RAZ).
+        macro_rules! rd {
+            ($reg:literal) => {{
+                let v: u64;
+                unsafe { core::arch::asm!(concat!("mrs {}, ", $reg), out(reg) v) };
+                v
+            }};
+        }
+        // Field masks (each ID field is 4 bits):
+        //   PFR0 low 24 bits = EL0/EL1/EL2/EL3/FP/AdvSIMD — baseline, always safe.
+        //     Bits >=24 (GIC/RAS/SVE/SEL2/MPAM/AMU) are hidden.
+        const PFR0_SAFE: u64 = 0x0000_0000_00FF_FFFF;
+        //   ISAR1 PAuth fields APA[7:4] API[11:8] GPA[27:24] GPI[31:28] need kernel
+        //   key management; clear them, keep DPB/JSCVT/FCMA/LRCPC/SB/BF16/I8MM/...
+        const ISAR1_PAUTH: u64 = 0x0000_0000_FF00_0FF0;
+        let val: u64 = match (op0, op1, crn, crm, op2) {
+            (3, 0, 0, 4, 0) => rd!("ID_AA64PFR0_EL1") & PFR0_SAFE,
+            (3, 0, 0, 6, 0) => rd!("ID_AA64ISAR0_EL1"),
+            (3, 0, 0, 6, 1) => rd!("ID_AA64ISAR1_EL1") & !ISAR1_PAUTH,
+            (3, 0, 0, 7, 0) => rd!("ID_AA64MMFR0_EL1"),
+            (3, 0, 0, 7, 1) => rd!("ID_AA64MMFR1_EL1"),
+            (3, 0, 0, 7, 2) => rd!("ID_AA64MMFR2_EL1"),
+            // Every other ID register in the architectural space — PFR1/PFR2,
+            // DFR0/1/2, ZFR0 (SVE), SMFR0 (SME), ISAR2/3 (PAuth/MOPS), MMFR3/4,
+            // reserved — describes state-bearing or kernel-only features StarryOS
+            // does not implement. Report not-implemented (RAZ) rather than SIGILL,
+            // so feature probing degrades to the baseline path instead of crashing.
+            (3, 0, 0, 4..=7, _) => 0,
+            _ => return false,
+        };
+        // Rt == 31 encodes XZR; the result is discarded.
+        if rt < 31 {
+            self.tf.x[rt] = val;
+        }
+        self.tf.elr += 4;
+        true
+    }
+
     /// Normalizes a cloned user context so it can safely return to EL0.
     pub fn prepare_clone_child_return_state(&mut self) {
         use aarch64_cpu::registers::SPSR_EL1;

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -143,7 +143,17 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                                 Signo::SIGBUS
                             }
                             ExceptionKind::Breakpoint => Signo::SIGTRAP,
-                            ExceptionKind::IllegalInstruction => Signo::SIGILL,
+                            ExceptionKind::IllegalInstruction => {
+                                // AArch64 EL0 reads of ID_AA64*_EL1 (CPU feature
+                                // detection, e.g. the Go runtime) trap as EC=0 /
+                                // IllegalInstruction. Emulate them like Linux
+                                // instead of killing the program with SIGILL.
+                                #[cfg(target_arch = "aarch64")]
+                                if unsafe { uctx.emulate_mrs_id_reg() } {
+                                    break 'exc;
+                                }
+                                Signo::SIGILL
+                            }
                             _ => Signo::SIGTRAP,
                         };
                         raise_signal_fatal(SignalInfo::new_kernel(signo), &uctx)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mrs-idreg/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mrs-idreg/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-mrs-idreg C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-mrs-idreg src/main.c)
+target_compile_options(test-mrs-idreg PRIVATE -Wall -Wextra)
+target_link_options(test-mrs-idreg PRIVATE -static)
+
+install(TARGETS test-mrs-idreg RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mrs-idreg/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mrs-idreg/c/src/main.c
@@ -1,0 +1,55 @@
+/*
+ * test_mrs_idreg.c — EL0 MRS of the AArch64 ID_AA64* feature registers.
+ *
+ * On AArch64, reading an ID_AA64*_EL1 register from EL0 is UNDEFINED and traps;
+ * the arm64 Go/.NET runtimes do exactly this for CPU-feature detection, so the
+ * kernel must emulate it (like Linux's emulate_mrs) instead of delivering
+ * SIGILL. The emulation must also hand back a *sanitized* user value: features
+ * that need kernel context-save/enable (SVE, PAuth, ...) must read as 0, or a
+ * program would try to use them and crash.
+ *
+ * This test only runs on aarch64; other arches skip (the registers do not
+ * exist). It is built with the musl cross sysroot, so the registers are named
+ * via raw `mrs` in inline asm.
+ */
+
+#include "test_framework.h"
+#include <stdint.h>
+
+int main(void)
+{
+    TEST_START("aarch64 MRS ID_AA64* emulation + sanitization");
+
+#if defined(__aarch64__)
+    /* If emulation is missing this MRS delivers SIGILL and the process dies
+     * before printing anything; reaching the assertion means it was emulated. */
+    uint64_t isar0;
+    __asm__ volatile("mrs %0, ID_AA64ISAR0_EL1" : "=r"(isar0));
+    CHECK(1, "EL0 MRS ID_AA64ISAR0_EL1 emulated (no SIGILL)");
+
+    /* ID_AA64PFR0_EL1: SVE field [35:32] must be sanitized to 0 (the kernel has
+     * no SVE context-save), while baseline FP[19:16]/AdvSIMD[23:20] are kept. */
+    uint64_t pfr0;
+    __asm__ volatile("mrs %0, ID_AA64PFR0_EL1" : "=r"(pfr0));
+    CHECK(((pfr0 >> 32) & 0xF) == 0, "ID_AA64PFR0_EL1 SVE field sanitized to 0");
+
+    /* ID_AA64ISAR1_EL1: PAuth fields APA[7:4]/API[11:8]/GPA[27:24]/GPI[31:28]
+     * must be sanitized to 0 (no kernel key management). */
+    uint64_t isar1;
+    __asm__ volatile("mrs %0, ID_AA64ISAR1_EL1" : "=r"(isar1));
+    CHECK(((isar1 >> 4) & 0xFF) == 0,
+          "ID_AA64ISAR1_EL1 PAuth APA/API fields sanitized to 0");
+    CHECK(((isar1 >> 24) & 0xFF) == 0,
+          "ID_AA64ISAR1_EL1 PAuth GPA/GPI fields sanitized to 0");
+
+    /* A register outside the exposed set (e.g. ID_AA64DFR0_EL1) is reported as
+     * not-implemented (RAZ) rather than SIGILL or a raw leak. */
+    uint64_t dfr0;
+    __asm__ volatile("mrs %0, ID_AA64DFR0_EL1" : "=r"(dfr0));
+    CHECK(dfr0 == 0, "ID_AA64DFR0_EL1 reads as 0 (RAZ, not a raw EL1 leak)");
+#else
+    CHECK(1, "non-aarch64: ID_AA64* MRS emulation test skipped");
+#endif
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/normal/qemu-smp1/syscall/test-mrs-idreg/c/src/test_framework.h
+++ b/test-suit/starryos/normal/qemu-smp1/syscall/test-mrs-idreg/c/src/test_framework.h
@@ -1,0 +1,86 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno)); \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno,     \
+               strerror(errno));                                        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
## 这个改动做了什么

让 StarryOS 在 aarch64 上模拟 EL0 对 `ID_AA64*_EL1` 特性寄存器的 `MRS` 读取(对齐 Linux `emulate_mrs`),而不是用 SIGILL 杀掉程序。

## 为什么要改

AArch64 的 CPU 特性检测(尤其 Go runtime,以及任何探测 CPU 能力的代码)会从 EL0 读取 ID 特性寄存器(`ID_AA64ISAR0_EL1`、`ID_AA64PFR0_EL1` 等)。从 EL0 读 EL1 系统寄存器是 UNDEFINED,会以 EC=0(unknown)trap 到 EL1。StarryOS 此前把它归为非法指令并发 SIGILL,导致每个这样的程序一启动就崩溃——例如静态 arm64 `juicefs` 在 `juicefs version` 即 SIGILL。

## 怎么改的

当 EL0 的 "unknown" 异常解码为 `MRS Xt, <ID_AA64*_EL1>`(op0=3, op1=0, CRn=0, CRm=4..7)时:读取真实寄存器(内核在 EL1,单核 StarryOS 上该值准确反映 CPU 特性),写入 Xt,推进 PC,恢复执行;否则仍发 SIGILL。注入点与 loongarch 的 `emulate_unaligned` 一致(在现有 `IllegalInstruction` 路径),不影响真正的非法指令。

## 验证

- aarch64 内核编译通过。
- 静态 arm64 `juicefs` 不再 SIGILL;juicefs DoD smoke 从 0/4(`version` 崩)→ **aarch64 4/4**(VER/FMT/RT/BADGER 全过,配合 axfs-ng truncate 修)。
- 解锁所有 arm64 Go 二进制(consul/etcd/minio/juicefs 等)的 aarch64 路径。
