### PR TITLE
ci(starry-toml): raise smoke-test QEMU timeout to 30s on aarch64/riscv64/loongarch64

### DIFF
--- a/test-suit/starryos/normal/qemu-smp1/smoke/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/smoke/qemu-aarch64.toml
@@ -19,4 +19,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "pwd && echo 'All tests passed!'"
 success_regex = ["(?m)^All tests passed!\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b']
-timeout = 5
+timeout = 30

--- a/test-suit/starryos/normal/qemu-smp1/smoke/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/smoke/qemu-loongarch64.toml
@@ -21,4 +21,4 @@ shell_prefix = "root@starry:"
 success_regex = ["(?m)^All tests passed!\\s*$"]
 to_bin = true
 uefi = false
-timeout = 5
+timeout = 30

--- a/test-suit/starryos/normal/qemu-smp1/smoke/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/smoke/qemu-riscv64.toml
@@ -19,4 +19,4 @@ shell_prefix = "root@starry:"
 shell_init_cmd = "pwd && echo 'All tests passed!'"
 success_regex = ["(?m)^All tests passed!\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b']
-timeout = 5
+timeout = 30


### PR DESCRIPTION
## 这个改动做了什么

把 `normal/qemu-smp1/smoke` 测试在 aarch64/loongarch64 的 QEMU 超时从 5 秒提到 30 秒，并在当前 `dev` 已经通过 #1127 将 riscv64 提到 15 秒的基础上，继续把 riscv64 的 smoke 超时提到 30 秒。

## 为什么要改

smoke 测试只做 `pwd && echo 'All tests passed!'`，但这三个架构在 CI 上跑纯 TCG，负载高时仅 boot 到 shell 就可能超过原来的短超时。日志特征是先匹配到 `All tests passed!`，随后因 QEMU timeout 使该架构的 starry qemu job 变红，并可能经 matrix fail-fast 连带取消同批其它仍在跑的 job。结果会让与 smoke 无关的 PR 被这一项 flake 影响。

x86_64 的 smoke 已是 15s 且稳定；这次把另外三个慢架构统一到 30s，避免因 CI 机器负载波动误判失败。

## 怎么改的

仅调整 smoke `timeout` 上限，不改测试命令、成功断言或失败断言。合并当前 `dev` 时，`qemu-riscv64.toml` 与 #1127 的 15s 改动产生冲突，已按本 PR 目标保留为 30s。