### PR TITLE
fix(ci): preserve queued dev CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ env:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/dev') }}
+  queue: max
 
 jobs:
   detect_changes:


### PR DESCRIPTION
## 问题

`dev` 分支连续 push 时，虽然现有配置已经避免取消正在运行的 dev push CI，但 GitHub Actions 的 concurrency 组默认只保留一个 pending run。新的 dev push 进入队列时，之前排队中的 CI 仍会被替换并标记为 cancelled。

## 修改

- 将 CI workflow 的 top-level concurrency 从条件化 `cancel-in-progress` 调整为 `queue: max`。
- 保持 concurrency group 仍按 `CI + ref` 隔离，不改变不同分支之间的调度边界。

## 逻辑

`queue: max` 让同一 concurrency group 内的 run 保留排队，而不是只保留最新的 pending run。这样 `dev` 分支每个 push CI 都会按顺序排队执行，不会因为后续 push 到来而替换前一个 pending CI。

## 本地验证

- 使用 Python/YAML 解析确认 `.github/workflows/ci.yml` 中 concurrency 为 `group + queue: max`，且不再包含 `cancel-in-progress`。
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`