### PR TITLE
test(starry): add grouped step markers

### DIFF
--- a/scripts/axbuild/src/test/case.rs
+++ b/scripts/axbuild/src/test/case.rs
@@ -37,6 +37,7 @@ const CASE_CMAKE_TOOLCHAIN_FILE_NAME: &str = "cmake-toolchain.cmake";
 const CASE_APK_CACHE_DIR_NAME: &str = "apk-cache";
 const CASE_SH_DIR_NAME: &str = "sh";
 const CASE_ROOTFS_COPY_NAME: &str = "case-rootfs.img";
+const GROUPED_RUNNER_SCRIPT_FORMAT_VERSION: &str = "grouped-runner-step-markers-v1";
 const PYTHON_PIPELINE_CACHE_VERSION: &str = "python-apk-v1";
 const RUST_PIPELINE_CACHE_VERSION: &str = "rust-cross-v1";
 /// QEMU global snapshot flag — all disk writes go to a temporary file and are
@@ -629,6 +630,7 @@ fn case_asset_cache_key(
 }
 
 fn hash_grouped_runner_config(hasher: &mut Sha256, config: &GroupedCaseRunnerConfig) {
+    hash_token(hasher, GROUPED_RUNNER_SCRIPT_FORMAT_VERSION);
     hash_token(hasher, &config.runner_name);
     hash_token(hasher, &config.runner_path);
     match &config.autorun_profile_script {
@@ -811,16 +813,25 @@ pub(crate) fn write_grouped_case_runner_script(
     let runner_path = dest_dir.join(&config.runner_name);
 
     let mut body = String::new();
-    body.push_str("failed=0\n");
+    body.push_str(&format!(
+        "failed=0\ntotal={}\nstep=0\n",
+        test_commands.len()
+    ));
     for command in test_commands {
         let quoted = shell_single_quote(command);
-        let begin = shell_single_quote(&format!("{}: {command}", config.begin_marker));
-        let passed = shell_single_quote(&format!("{}: {command}", config.passed_marker));
-        let failed = shell_single_quote(&format!("{}: {command}", config.failed_marker));
+        let command_label = shell_single_quote(command);
+        let begin = shell_single_quote(&config.begin_marker);
+        let passed = shell_single_quote(&config.passed_marker);
+        let failed = shell_single_quote(&config.failed_marker);
         body.push_str(&format!(
-            "printf '%s\\n' {begin}\nif sh -c {quoted}; then\n\tprintf '%s\\n' \
-             {passed}\nelse\n\tstatus=$?\n\tprintf '%s status=%s\\n' {failed} \
-             \"$status\"\n\tfailed=1\nfi\n"
+            "step=$((step + 1))\nnow=$(date +%s 2>/dev/null || printf unknown)\nprintf '%s: \
+             step=%s/%s epoch=%s command=%s\\n' {begin} \"$step\" \"$total\" \"$now\" \
+             {command_label}\nif sh -c {quoted}; then\n\tnow=$(date +%s 2>/dev/null || printf \
+             unknown)\n\tprintf '%s: step=%s/%s epoch=%s status=0 command=%s\\n' {passed} \
+             \"$step\" \"$total\" \"$now\" {command_label}\nelse\n\tstatus=$?\n\tnow=$(date +%s \
+             2>/dev/null || printf unknown)\n\tprintf '%s: step=%s/%s epoch=%s status=%s \
+             command=%s\\n' {failed} \"$step\" \"$total\" \"$now\" \"$status\" \
+             {command_label}\n\tfailed=1\nfi\n"
         ));
     }
     let all_passed = shell_single_quote(&config.all_passed_marker);
@@ -1083,8 +1094,16 @@ mod tests {
 
         let runner = overlay.join("usr/bin/suite-run-case-tests");
         let content = fs::read_to_string(&runner).unwrap();
-        assert!(content.contains("SUITE_GROUPED_TEST_BEGIN: /usr/bin/alpha"));
-        assert!(content.contains("SUITE_GROUPED_TEST_FAILED: /usr/bin/beta --flag"));
+        assert!(content.contains("total=2"));
+        assert!(content.contains("step=$((step + 1))"));
+        assert!(content.contains("printf '%s: step=%s/%s epoch=%s command=%s\\n'"));
+        assert!(content.contains("printf '%s: step=%s/%s epoch=%s status=0 command=%s\\n'"));
+        assert!(content.contains("printf '%s: step=%s/%s epoch=%s status=%s command=%s\\n'"));
+        assert!(content.contains("'SUITE_GROUPED_TEST_BEGIN'"));
+        assert!(content.contains("'SUITE_GROUPED_TEST_PASSED'"));
+        assert!(content.contains("'SUITE_GROUPED_TEST_FAILED'"));
+        assert!(content.contains("'/usr/bin/alpha'"));
+        assert!(content.contains("'/usr/bin/beta --flag'"));
         assert!(content.contains("SUITE_GROUPED_TESTS_PASSED"));
     }
 

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -99,7 +99,7 @@ test-suit/starryos/
 | `c` | case 目录下存在 `c/` | 使用 CMake 交叉编译，安装产物到 rootfs overlay |
 | `sh` | case 目录下存在 `sh/` | 将 shell 脚本注入 `/usr/bin/` |
 | `python` | case 目录下存在 `python/` | 在 staging rootfs 中安装 `python3`，并注入 `.py` 文件 |
-| `grouped` | `qemu-<arch>.toml` 中存在 `test_commands` | 构建子目录中的 C subcase，生成 `/usr/bin/starry-run-case-tests` 顺序执行命令 |
+| `grouped` | `qemu-<arch>.toml` 中存在 `test_commands` | 构建子目录中的 C subcase，生成 `/usr/bin/starry-run-case-tests` 顺序执行命令，并为每个命令打印步骤标记 |
 
 Pipeline case 会创建每个 case 独立的 rootfs 副本，并把注入后的 rootfs 缓存在：
 
@@ -215,7 +215,14 @@ success_regex = ["(?m)^STARRY_GROUPED_TESTS_PASSED\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^STARRY_GROUPED_TEST_FAILED:']
 ```
 
-运行器会稳定排序子目录、构建 C subcase，并注入 `/usr/bin/starry-run-case-tests`。
+运行器会稳定排序子目录、构建 C subcase，并注入 `/usr/bin/starry-run-case-tests`。每个命令执行前后都会打印带 `step=当前/总数`、`epoch=`、`status=` 和 `command=` 的标记，例如：
+
+```text
+STARRY_GROUPED_TEST_BEGIN: step=1/2 epoch=... command=/usr/bin/test-a
+STARRY_GROUPED_TEST_PASSED: step=1/2 epoch=... status=0 command=/usr/bin/test-a
+```
+
+如果 grouped case 超时，CI 日志中最后一个 `STARRY_GROUPED_TEST_BEGIN` 通常就是卡住的子命令。
 目前 grouped Rust subcase 还不支持。
 
 ## Shell 和 Python 用例


### PR DESCRIPTION
## Problem                                                                                                                       
                                                                                                                                   
  When a Starry grouped QEMU case hangs or times out in CI, the log usually only shows that the whole grouped case did not finish. 
  It is hard to tell which `test_commands` entry caused the problem.                                                               
                                                                                                                                   
  ## Changes                                                                                                                       
                                                                                                                                   
  - Add per-command markers to the grouped runner:                                                                                 
    - `STARRY_GROUPED_TEST_BEGIN: step=current/total epoch=... command=...`                                                        
    - `STARRY_GROUPED_TEST_PASSED: step=current/total epoch=... status=0 command=...`                                              
    - `STARRY_GROUPED_TEST_FAILED: step=current/total epoch=... status=<code> command=...`                                         
  - Include the grouped runner script format version in the rootfs cache key, so old injected rootfs images are not reused.        
  - Update `test-suit/starryos/GUIDE.md` to document the grouped case step markers and timeout debugging workflow.                 
                                                                                                                                   
  ## Rationale                                                                                                                     
                                                                                                                                   
  - The `test_commands` execution order is unchanged.                                                                              
  - Each command is still executed through the existing `sh -c <command>` path.                                                    
  - The final success marker remains `STARRY_GROUPED_TESTS_PASSED`.                                                                
  - Failed commands still emit lines starting with `STARRY_GROUPED_TEST_FAILED:`.                                                  
  - Therefore, CI success/failure regex semantics remain unchanged; the change only adds more diagnostic fields.