### PR TITLE
chore(axbuild): pin ostool runtime bin fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2542,7 +2542,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3577,7 +3577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4643,7 +4643,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5493,7 +5493,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5731,9 +5731,9 @@ dependencies = [
 
 [[package]]
 name = "ostool"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d0470fd8561e21f458d865490c928ebff45c0e1037a45f634a527acb8f15ff"
+checksum = "637f9dd8bdcee533498e64beb11d10aee8f1fa3a5322e52c67d48bfe75c6742b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7129,7 +7129,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7142,7 +7142,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7201,7 +7201,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7761,7 +7761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8245,7 +8245,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8255,7 +8255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9643,7 +9643,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10228,9 +10228,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2542,7 +2542,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3577,7 +3577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3778,8 +3778,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 [[package]]
 name = "fitimage"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92edd7c1c55efd27b5a17dd6d505affafcfe48dfaed7423d4c4ae7361e56a7d8"
+source = "git+https://github.com/drivercraft/ostool.git?rev=f3192dda953dcfc9ed25ac67d4af52a0cfc6363b#f3192dda953dcfc9ed25ac67d4af52a0cfc6363b"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4643,7 +4642,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4748,8 +4747,7 @@ dependencies = [
 [[package]]
 name = "jkconfig"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cbaedffb63dabcbab61e23e0adc1fc7bc0d7420f2f56124e2bc0002d9274ab"
+source = "git+https://github.com/drivercraft/ostool.git?rev=f3192dda953dcfc9ed25ac67d4af52a0cfc6363b#f3192dda953dcfc9ed25ac67d4af52a0cfc6363b"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5493,7 +5491,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5732,8 +5730,7 @@ dependencies = [
 [[package]]
 name = "ostool"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637f9dd8bdcee533498e64beb11d10aee8f1fa3a5322e52c67d48bfe75c6742b"
+source = "git+https://github.com/drivercraft/ostool.git?rev=f3192dda953dcfc9ed25ac67d4af52a0cfc6363b#f3192dda953dcfc9ed25ac67d4af52a0cfc6363b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6310,7 +6307,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7129,7 +7126,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7142,7 +7139,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7201,7 +7198,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7761,7 +7758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8245,7 +8242,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8255,7 +8252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8987,8 +8984,7 @@ dependencies = [
 [[package]]
 name = "uboot-shell"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2237321472e37a34980340e0a6f8ba406167fb010209ead2f0e594bdfb718e02"
+source = "git+https://github.com/drivercraft/ostool.git?rev=f3192dda953dcfc9ed25ac67d4af52a0cfc6363b#f3192dda953dcfc9ed25ac67d4af52a0cfc6363b"
 dependencies = [
  "colored",
  "futures",
@@ -9643,7 +9639,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9770,7 +9766,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9779,16 +9775,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9806,31 +9793,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -9849,22 +9819,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9873,22 +9831,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9897,22 +9843,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9921,22 +9855,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b763acdc1d85c36d61acf97a59938f23202d0e8efe45e8759de10c02db242744"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "log",
  "pci_types",
@@ -238,6 +238,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arceos-affinity"
@@ -551,7 +560,7 @@ name = "arm-gic-driver"
 version = "0.17.2"
 dependencies = [
  "aarch64-cpu 11.2.0",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "enum_dispatch",
  "log",
  "paste",
@@ -564,7 +573,7 @@ name = "arm-scmi-rs"
 version = "0.1.3"
 dependencies = [
  "aarch64-cpu-ext",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
  "mbarrier",
  "nb",
@@ -755,7 +764,7 @@ dependencies = [
 name = "ax-cap-access"
 version = "0.3.5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -998,7 +1007,7 @@ dependencies = [
  "ax-sync",
  "axfs-ng-vfs",
  "axpoll",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "chrono",
  "intrusive-collections",
@@ -1026,7 +1035,7 @@ name = "ax-fs-vfs"
 version = "0.3.11"
 dependencies = [
  "ax-errno 0.6.0",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
 ]
 
@@ -1257,7 +1266,7 @@ dependencies = [
  "ax-task",
  "axfs-ng-vfs",
  "axpoll",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "enum_dispatch",
  "event-listener",
@@ -1276,7 +1285,7 @@ version = "0.8.10"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "ax-memory-addr",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "x86_64",
 ]
 
@@ -1326,7 +1335,7 @@ dependencies = [
  "ax-memory-addr",
  "ax-percpu",
  "ax-plat-macros",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "const-str",
  "irq-framework",
  "rdrive",
@@ -1416,7 +1425,7 @@ dependencies = [
  "ax-percpu",
  "ax-plat",
  "axklib",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "heapless 0.9.3",
  "log",
  "multiboot",
@@ -1441,7 +1450,7 @@ dependencies = [
  "ax-percpu",
  "ax-plat",
  "axklib",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "heapless 0.9.3",
  "log",
  "multiboot",
@@ -1615,7 +1624,7 @@ dependencies = [
  "axin",
  "axvm-types",
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "lazy_static",
  "log",
@@ -1723,7 +1732,7 @@ version = "0.1.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf1c27753a96a0f835cca49e6fb354912107d018c905d13c7eff39be757eb5a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
 ]
 
@@ -1734,7 +1743,7 @@ dependencies = [
  "ax-errno 0.6.0",
  "ax-kspin",
  "axpoll",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "hashbrown 0.16.1",
  "inherit-methods-macro",
@@ -1815,7 +1824,7 @@ name = "axpoll"
 version = "0.3.10"
 dependencies = [
  "ax-kspin",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "futures",
  "linux-raw-sys 0.12.1",
  "spin 0.12.0",
@@ -2045,7 +2054,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2063,7 +2072,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2144,9 +2153,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmap-allocator"
@@ -2253,6 +2262,12 @@ dependencies = [
  "chrono",
  "libc",
 ]
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-unit"
@@ -2414,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2542,7 +2557,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2725,7 +2740,7 @@ name = "crab-usb"
 version = "0.9.4"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossbeam",
  "crossbeam-skiplist",
  "dma-api",
@@ -2895,7 +2910,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -2911,7 +2926,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -3577,7 +3592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3675,6 +3690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,7 +3744,7 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "ffmpeg-sys-next",
  "libc",
 ]
@@ -3778,7 +3799,8 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 [[package]]
 name = "fitimage"
 version = "0.1.4"
-source = "git+https://github.com/drivercraft/ostool.git?rev=f3192dda953dcfc9ed25ac67d4af52a0cfc6363b#f3192dda953dcfc9ed25ac67d4af52a0cfc6363b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92edd7c1c55efd27b5a17dd6d505affafcfe48dfaed7423d4c4ae7361e56a7d8"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4642,7 +4664,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4747,7 +4769,8 @@ dependencies = [
 [[package]]
 name = "jkconfig"
 version = "0.2.4"
-source = "git+https://github.com/drivercraft/ostool.git?rev=f3192dda953dcfc9ed25ac67d4af52a0cfc6363b#f3192dda953dcfc9ed25ac67d4af52a0cfc6363b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4cbaedffb63dabcbab61e23e0adc1fc7bc0d7420f2f56124e2bc0002d9274ab"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4892,7 +4915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c066bb7997a6daf34a35ad2790570f32f33677dec17538781bbaff4be2248e"
 dependencies = [
  "ax-errno 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "int-enum",
  "log",
  "lru 0.18.0",
@@ -4925,7 +4948,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4947,7 +4970,7 @@ checksum = "a5d13c9132595e1b16ba64390fc23a19ab0f9b940a144445bdd270854e61f544"
 dependencies = [
  "ax-errno 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield-struct 0.13.0",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "goblin",
  "int-enum",
@@ -5077,6 +5100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libudev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5125,7 +5154,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5163,9 +5192,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loongArch64"
@@ -5174,7 +5203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "236e72a07bb26b68662f7cc9dcb58cea50cf5e3d8b698e1b51ff7c36d633dd92"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5468,7 +5497,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5491,7 +5520,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5729,8 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "ostool"
-version = "0.22.0"
-source = "git+https://github.com/drivercraft/ostool.git?rev=f3192dda953dcfc9ed25ac67d4af52a0cfc6363b#f3192dda953dcfc9ed25ac67d4af52a0cfc6363b"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada76a46f68ee817f9c32b8374939b7d456eb6165654284e2f28e8db89585ca4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5797,13 +5827,37 @@ dependencies = [
 name = "page-table-generic"
 version = "0.7.3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "env_logger",
  "heapless 0.9.3",
  "log",
  "num-align",
  "thiserror 2.0.18",
  "tock-registers 0.10.1",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5848,7 +5902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c2a105c657261a938ff68ee231c199a3d80eef33976004829de761ef5b1a9b"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5856,7 +5910,7 @@ name = "pcie"
 version = "0.6.2"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fdt-edit",
  "log",
  "mmio-api",
@@ -6092,7 +6146,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613142bc127747febf3eae56e000f1be431756a6eaa8d3f060f9144d938e798c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "itertools 0.14.0",
 ]
 
@@ -6307,7 +6361,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6432,9 +6486,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -6442,22 +6496,26 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "compact_str 0.9.1",
- "hashbrown 0.16.1",
+ "critical-section",
+ "hashbrown 0.17.1",
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.16.4",
- "strum 0.27.2",
+ "lru 0.18.0",
+ "palette",
+ "serde",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -6466,9 +6524,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm 0.29.0",
@@ -6478,9 +6536,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -6488,9 +6546,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -6498,18 +6556,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -6530,7 +6589,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6663,7 +6722,7 @@ dependencies = [
 name = "rdif-serial"
 version = "0.7.2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "futures",
  "heapless 0.9.3",
  "rdif-base",
@@ -6742,7 +6801,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6909,7 +6968,7 @@ version = "0.4.8"
 dependencies = [
  "bare-metal",
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
  "riscv",
 ]
@@ -6936,7 +6995,7 @@ dependencies = [
  "axvcpu",
  "axvm-types",
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "log",
  "memoffset",
@@ -7021,7 +7080,7 @@ name = "rockchip-npu"
 version = "0.2.2"
 dependencies = [
  "aarch64-cpu-ext",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dma-api",
  "log",
  "mbarrier",
@@ -7047,7 +7106,7 @@ name = "rockchip-soc"
 version = "0.3.1"
 dependencies = [
  "ax-kspin",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dma-api",
  "enum_dispatch",
  "fdt-edit",
@@ -7064,7 +7123,7 @@ name = "rsext4"
 version = "0.5.0"
 dependencies = [
  "ax-kspin",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
 ]
 
@@ -7122,7 +7181,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -7135,11 +7194,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7198,7 +7257,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7295,7 +7354,7 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "785b91fcc41c7426fc07510be49ed1db44f002b45d45c175ec7f155c3cd447a9"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7382,7 +7441,7 @@ dependencies = [
 name = "sdmmc-protocol"
 version = "0.1.2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "embedded-hal",
  "log",
 ]
@@ -7399,7 +7458,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7529,7 +7588,7 @@ version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -7766,7 +7825,7 @@ name = "some-serial"
 version = "0.5.0"
 dependencies = [
  "ax-kspin",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "enum_dispatch",
  "fdt-edit",
  "heapless 0.9.3",
@@ -7791,7 +7850,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "buddy_system_allocator 0.12.0",
  "byte-unit",
  "byteorder",
@@ -7903,7 +7962,7 @@ version = "0.4.1-preview.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d994a3a25a5cc4a895b200bd00d8e757515f21f9c21647bd4e9a8e572a326f1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
 ]
 
@@ -7944,7 +8003,7 @@ dependencies = [
  "axnsproxy",
  "axplat-dyn",
  "axpoll",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bitmaps",
  "bytemuck",
  "cfg-if",
@@ -8014,7 +8073,7 @@ dependencies = [
  "ax-cpu",
  "ax-errno 0.6.0",
  "ax-kspin",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "derive_more",
  "event-listener",
@@ -8200,7 +8259,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8242,7 +8301,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8252,7 +8311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8284,7 +8343,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -8803,7 +8862,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8967,7 +9026,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d293f51425981fdb1b766beae254dbb711a17e8c4b549dc69b9b7ee0d478d5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "rustversion",
  "x86",
 ]
@@ -8978,13 +9037,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cceed8939ba6ebde9d1e8a603b3c7f1a239a3db22e1ff465ed71ddca7a7d66"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "uboot-shell"
 version = "0.2.4"
-source = "git+https://github.com/drivercraft/ostool.git?rev=f3192dda953dcfc9ed25ac67d4af52a0cfc6363b#f3192dda953dcfc9ed25ac67d4af52a0cfc6363b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2237321472e37a34980340e0a6f8ba406167fb010209ead2f0e594bdfb718e02"
 dependencies = [
  "colored",
  "futures",
@@ -9013,7 +9073,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66ab9569afdd1e33a31d8002343aa1df594f055347b1a66136bf9dd6cbc3ec37"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "log",
  "ptr_meta 0.3.1",
@@ -9040,7 +9100,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3775e5934877acaef4b00f254f252df1e2266903c31e51455c117f4f2824eda"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "uguid",
 ]
 
@@ -9289,7 +9349,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdc1c628cdd8ce7c3b9e65a8ed550d0338e9ef9f911e729666f1cce097de2f7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "enumn",
  "log",
  "safe-mmio",
@@ -9489,7 +9549,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -9639,7 +9699,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9766,7 +9826,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9775,7 +9835,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -9793,14 +9862,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9819,10 +9905,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9831,10 +9929,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9843,10 +9953,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9855,10 +9977,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -9942,7 +10076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -10018,7 +10152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7841fa0098ceb15c567d93d3fae292c49e10a7662b4936d5f6a9728594555ba"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "const_fn",
  "rustversion",
  "volatile 0.4.6",
@@ -10046,7 +10180,7 @@ dependencies = [
  "axvcpu",
  "axvm-types",
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "log",
  "memoffset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ mmio-api = { version = "0.2.2", path = "memory/mmio-api" }
 lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = "0.12"
-ostool = { version = "0.22" }
+ostool = { git = "https://github.com/drivercraft/ostool.git", rev = "f3192dda953dcfc9ed25ac67d4af52a0cfc6363b" }
 riscv = { version = "0.16.1", default-features = false }
 sbi-rt = { version = "0.0.4", default-features = false }
 uefi = "0.37.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ mmio-api = { version = "0.2.2", path = "memory/mmio-api" }
 lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = "0.12"
-ostool = { version = "0.21" }
+ostool = { version = "0.22" }
 riscv = { version = "0.16.1", default-features = false }
 sbi-rt = { version = "0.0.4", default-features = false }
 uefi = "0.37.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ mmio-api = { version = "0.2.2", path = "memory/mmio-api" }
 lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = "0.12"
-ostool = { git = "https://github.com/drivercraft/ostool.git", rev = "f3192dda953dcfc9ed25ac67d4af52a0cfc6363b" }
+ostool = { version = "0.22.1" }
 riscv = { version = "0.16.1", default-features = false }
 sbi-rt = { version = "0.0.4", default-features = false }
 uefi = "0.37.0"

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -239,7 +239,6 @@ impl ArceOS {
         let mut qemu = match request.qemu_config.as_deref() {
             Some(path) => self
                 .app
-                .tool_mut()
                 .read_qemu_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some)?,
@@ -259,7 +258,6 @@ impl ArceOS {
         match request.uboot_config.as_deref() {
             Some(path) => self
                 .app
-                .tool_mut()
                 .read_uboot_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some),

--- a/scripts/axbuild/src/axvisor/mod.rs
+++ b/scripts/axbuild/src/axvisor/mod.rs
@@ -374,7 +374,6 @@ impl Axvisor {
         match request.uboot_config.as_deref() {
             Some(path) => self
                 .app
-                .tool_mut()
                 .read_uboot_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some),
@@ -390,14 +389,12 @@ impl Axvisor {
         match board_config_path {
             Some(path) => {
                 self.app
-                    .tool_mut()
                     .read_board_run_config_from_path_for_cargo(cargo, path)
                     .await
             }
             None => {
                 let workspace_root = self.app.workspace_root().to_path_buf();
                 self.app
-                    .tool_mut()
                     .ensure_board_run_config_in_dir_for_cargo(cargo, &workspace_root)
                     .await
             }

--- a/scripts/axbuild/src/axvisor/rootfs.rs
+++ b/scripts/axbuild/src/axvisor/rootfs.rs
@@ -58,7 +58,6 @@ pub(super) async fn load_patched_qemu_config(
     });
     let mut qemu = axvisor
         .app
-        .tool_mut()
         .read_qemu_config_from_path_for_cargo(cargo, &config_path)
         .await?;
     patch_qemu_rootfs(

--- a/scripts/axbuild/src/axvisor/test.rs
+++ b/scripts/axbuild/src/axvisor/test.rs
@@ -452,12 +452,7 @@ impl Axvisor {
         let cargo = build::load_cargo_config(&request)?;
         let base_uboot = match request.uboot_config.as_deref() {
             Some(_) => self.load_uboot_config(&request, &cargo).await?,
-            None => Some(
-                self.app
-                    .tool_mut()
-                    .ensure_uboot_config_for_cargo(&cargo)
-                    .await?,
-            ),
+            None => Some(self.app.ensure_uboot_config_for_cargo(&cargo).await?),
         };
         let board_config = self
             .load_board_config(&cargo, Some(board_test_config.as_path()))
@@ -604,7 +599,6 @@ impl Axvisor {
             )?;
             let qemu = self
                 .app
-                .tool_mut()
                 .read_qemu_config_from_path_for_cargo(&cargo, &case.case.qemu_config_path)
                 .await
                 .with_context(|| {

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -8,12 +8,15 @@ use std::{
 use anyhow::Context;
 use log::info;
 use ostool::{
-    Tool, ToolConfig,
-    board::{RunBoardOptions, config::BoardRunConfig},
-    build::{CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs, config::Cargo},
+    board::{self as ostool_board, RunBoardOptions, config::BoardRunConfig},
+    build::{
+        self as ostool_build, CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs,
+        config::{BuildConfig, BuildSystem, Cargo},
+    },
+    invocation::{Invocation, InvocationOptions},
     run::{
-        qemu::{QemuConfig, RunQemuOptions},
-        uboot::UbootConfig,
+        qemu::{self as ostool_qemu, QemuConfig, RunQemuOptions},
+        uboot::{self as ostool_uboot, UbootConfig},
     },
 };
 
@@ -69,7 +72,7 @@ fn snapshot_store_disabled() -> bool {
 }
 
 pub struct AppContext {
-    tool: Tool,
+    invocation: Invocation,
     build_config_path: Option<PathBuf>,
     root: PathBuf,
     member_dirs: HashMap<String, PathBuf>,
@@ -84,9 +87,10 @@ impl AppContext {
 
         info!("Workspace root: {}", workspace_root.display());
 
-        let tool = Tool::new(ToolConfig::default()).context("failed to initialize ostool")?;
+        let invocation = Self::new_invocation(&workspace_root, false)
+            .context("failed to initialize ostool invocation")?;
         Ok(Self {
-            tool,
+            invocation,
             build_config_path: None,
             root: workspace_root,
             member_dirs: HashMap::new(),
@@ -97,10 +101,6 @@ impl AppContext {
 
     pub(crate) fn workspace_root(&self) -> &Path {
         &self.root
-    }
-
-    pub(crate) fn tool_mut(&mut self) -> &mut Tool {
-        &mut self.tool
     }
 
     pub(crate) fn workspace_member_dir(&mut self, package: &str) -> anyhow::Result<&Path> {
@@ -126,7 +126,8 @@ impl AppContext {
     ) -> anyhow::Result<()> {
         self.set_build_config_path(build_config_path);
         let _env_guard = EnvRestoreGuard::set(&cargo.env);
-        self.tool.cargo_build(&cargo).await
+        let build_config_path = self.build_config_path.clone();
+        ostool_build::cargo_build(&mut self.invocation, &cargo, build_config_path.as_deref()).await
     }
 
     pub(crate) async fn prepare_elf_artifact(
@@ -134,7 +135,7 @@ impl AppContext {
         elf_path: PathBuf,
         to_bin: bool,
     ) -> anyhow::Result<()> {
-        self.tool.prepare_elf_artifact(elf_path, to_bin).await
+        self.invocation.prepare_elf_artifact(elf_path, to_bin).await
     }
 
     pub(crate) async fn qemu(
@@ -146,17 +147,18 @@ impl AppContext {
         let _env_guard = EnvRestoreGuard::set(&cargo.env);
         let _path_guard = self.scoped_qemu_path(&cargo)?;
         self.set_build_config_path(build_config_path);
-        self.tool
-            .cargo_run(
-                &cargo,
-                &CargoRunnerKind::Qemu(Box::new(CargoQemuRunnerArgs {
-                    qemu,
-                    debug: self.debug,
-                    dtb_dump: false,
-                    show_output: true,
-                })),
-            )
-            .await
+        let build_config_path = self.build_config_path.clone();
+        ostool_build::cargo_run(
+            &mut self.invocation,
+            &cargo,
+            build_config_path.as_deref(),
+            &CargoRunnerKind::Qemu(Box::new(CargoQemuRunnerArgs {
+                qemu,
+                debug: self.debug,
+                dtb_dump: false,
+            })),
+        )
+        .await
     }
 
     pub(crate) async fn run_qemu(
@@ -171,15 +173,13 @@ impl AppContext {
             .map(crate::support::backtrace_output_capture::BacktraceOutputCaptureGuard::install)
             .transpose()
             .context("failed to install backtrace block output capture")?;
-        self.tool
-            .run_qemu(
-                &qemu,
-                RunQemuOptions {
-                    dtb_dump: false,
-                    show_output: true,
-                },
-            )
-            .await
+        self.activate_cargo_build_context(cargo)?;
+        ostool_qemu::run_qemu(
+            &mut self.invocation,
+            &qemu,
+            RunQemuOptions { dtb_dump: false },
+        )
+        .await
     }
 
     pub(crate) async fn run_prepared_qemu(
@@ -192,15 +192,12 @@ impl AppContext {
             .map(crate::support::backtrace_output_capture::BacktraceOutputCaptureGuard::install)
             .transpose()
             .context("failed to install backtrace block output capture")?;
-        self.tool
-            .run_qemu(
-                &qemu,
-                RunQemuOptions {
-                    dtb_dump: false,
-                    show_output: true,
-                },
-            )
-            .await
+        ostool_qemu::run_qemu(
+            &mut self.invocation,
+            &qemu,
+            RunQemuOptions { dtb_dump: false },
+        )
+        .await
     }
 
     pub(crate) async fn uboot(
@@ -211,15 +208,14 @@ impl AppContext {
     ) -> anyhow::Result<()> {
         let _env_guard = EnvRestoreGuard::set(&cargo.env);
         self.set_build_config_path(build_config_path);
-        self.tool
-            .cargo_run(
-                &cargo,
-                &CargoRunnerKind::Uboot(Box::new(CargoUbootRunnerArgs {
-                    uboot,
-                    show_output: true,
-                })),
-            )
-            .await
+        let build_config_path = self.build_config_path.clone();
+        ostool_build::cargo_run(
+            &mut self.invocation,
+            &cargo,
+            build_config_path.as_deref(),
+            &CargoRunnerKind::Uboot(Box::new(CargoUbootRunnerArgs { uboot })),
+        )
+        .await
     }
 
     pub(crate) async fn board(
@@ -231,9 +227,15 @@ impl AppContext {
     ) -> anyhow::Result<()> {
         let _env_guard = EnvRestoreGuard::set(&cargo.env);
         self.set_build_config_path(build_config_path);
-        self.tool
-            .cargo_run_board(&cargo, &board_config, options)
-            .await
+        let build_config_path = self.build_config_path.clone();
+        ostool_board::cargo_run_board(
+            &mut self.invocation,
+            &cargo,
+            build_config_path.as_deref(),
+            &board_config,
+            options,
+        )
+        .await
     }
 
     pub(crate) fn set_debug_mode(&mut self, debug: bool) -> anyhow::Result<()> {
@@ -241,21 +243,74 @@ impl AppContext {
             return Ok(());
         }
 
-        self.tool = Tool::new(ToolConfig {
-            debug,
-            ..ToolConfig::default()
-        })?;
+        self.invocation = Self::new_invocation(&self.root, debug)
+            .context("failed to reinitialize ostool invocation")?;
         self.debug = debug;
-
-        self.tool
-            .set_build_config_path(self.build_config_path.clone());
 
         Ok(())
     }
 
+    pub(crate) async fn read_qemu_config_from_path_for_cargo(
+        &self,
+        cargo: &Cargo,
+        path: &Path,
+    ) -> anyhow::Result<QemuConfig> {
+        ostool_qemu::read_config_from_path_for_cargo(&self.invocation, cargo, path).await
+    }
+
+    pub(crate) async fn read_uboot_config_from_path_for_cargo(
+        &self,
+        cargo: &Cargo,
+        path: &Path,
+    ) -> anyhow::Result<UbootConfig> {
+        ostool_uboot::read_config_from_path_for_cargo(&self.invocation, cargo, path).await
+    }
+
+    pub(crate) async fn ensure_uboot_config_for_cargo(
+        &self,
+        cargo: &Cargo,
+    ) -> anyhow::Result<UbootConfig> {
+        ostool_uboot::ensure_config_for_cargo(&self.invocation, cargo).await
+    }
+
+    pub(crate) async fn read_board_run_config_from_path_for_cargo(
+        &self,
+        cargo: &Cargo,
+        path: &Path,
+    ) -> anyhow::Result<BoardRunConfig> {
+        ostool_board::read_run_config_from_path_for_cargo(&self.invocation, cargo, path).await
+    }
+
+    pub(crate) async fn ensure_board_run_config_in_dir_for_cargo(
+        &self,
+        cargo: &Cargo,
+        dir: &Path,
+    ) -> anyhow::Result<BoardRunConfig> {
+        ostool_board::ensure_run_config_in_dir_for_cargo(&self.invocation, cargo, dir).await
+    }
+
     fn set_build_config_path(&mut self, path: PathBuf) {
-        self.build_config_path = Some(path.clone());
-        self.tool.set_build_config_path(Some(path));
+        self.build_config_path = Some(path);
+    }
+
+    fn activate_cargo_build_context(&mut self, cargo: &Cargo) -> anyhow::Result<()> {
+        let build_config_path = self.build_config_path.clone();
+        ostool_build::activate_build_config(
+            &mut self.invocation,
+            &BuildConfig {
+                system: BuildSystem::Cargo(cargo.clone()),
+            },
+            build_config_path.as_deref(),
+        )
+    }
+
+    fn new_invocation(workspace_root: &Path, debug: bool) -> anyhow::Result<Invocation> {
+        Invocation::new(InvocationOptions::new(
+            Some(workspace_root.join("Cargo.toml")),
+            None,
+            None,
+            debug,
+        ))
     }
 
     fn scoped_qemu_path(&self, cargo: &Cargo) -> anyhow::Result<PathRestoreGuard> {

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -7,20 +7,46 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 
-use ostool::{Tool, ToolConfig};
+use ostool::invocation::{Invocation, InvocationOptions};
 use tempfile::tempdir;
 
 use super::*;
 
 fn test_app_context(root: &Path) -> AppContext {
     AppContext {
-        tool: Tool::new(ToolConfig::default()).unwrap(),
+        invocation: test_invocation(root),
         build_config_path: None,
         root: root.to_path_buf(),
         member_dirs: HashMap::from([("axvisor".to_string(), root.join("os/axvisor"))]),
         original_path: env::var_os("PATH").unwrap_or_default(),
         debug: false,
     }
+}
+
+fn test_invocation(root: &Path) -> Invocation {
+    let manifest_path = root.join("Cargo.toml");
+    if !manifest_path.exists() {
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/lib.rs"), "").unwrap();
+        fs::write(
+            &manifest_path,
+            r#"[package]
+name = "test-workspace"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+"#,
+        )
+        .unwrap();
+    }
+    Invocation::new(InvocationOptions::new(
+        Some(manifest_path),
+        None,
+        None,
+        false,
+    ))
+    .unwrap()
 }
 
 fn resolve_arceos_build_info_path(

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -407,7 +407,6 @@ impl Starry {
             let cargo = build::load_cargo_config(&request)?;
             let mut qemu = self
                 .app
-                .tool_mut()
                 .read_qemu_config_from_path_for_cargo(&cargo, &test_case.qemu_config_path)
                 .await?;
             rootfs::patch_rootfs(
@@ -442,7 +441,6 @@ impl Starry {
         let asset_config = test::starry_case_asset_config();
         let mut qemu = self
             .app
-            .tool_mut()
             .read_qemu_config_from_path_for_cargo(&cargo, &test_case.qemu_config_path)
             .await?;
         qemu_case::apply_grouped_qemu_config(&mut qemu, &test_case, &asset_config.grouped_runner);
@@ -563,7 +561,6 @@ impl Starry {
         match request.uboot_config.as_deref() {
             Some(path) => self
                 .app
-                .tool_mut()
                 .read_uboot_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some),
@@ -579,14 +576,12 @@ impl Starry {
         match board_config_path {
             Some(path) => {
                 self.app
-                    .tool_mut()
                     .read_board_run_config_from_path_for_cargo(cargo, path)
                     .await
             }
             None => {
                 let workspace_root = self.app.workspace_root().to_path_buf();
                 self.app
-                    .tool_mut()
                     .ensure_board_run_config_in_dir_for_cargo(cargo, &workspace_root)
                     .await
             }

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -90,7 +90,6 @@ pub(super) async fn load_patched_qemu_config(
         Some(path) => {
             starry
                 .app
-                .tool_mut()
                 .read_qemu_config_from_path_for_cargo(cargo, path)
                 .await?
         }
@@ -101,7 +100,6 @@ pub(super) async fn load_patched_qemu_config(
             );
             starry
                 .app
-                .tool_mut()
                 .read_qemu_config_from_path_for_cargo(cargo, &path)
                 .await?
         }

--- a/scripts/axbuild/src/starry/test.rs
+++ b/scripts/axbuild/src/starry/test.rs
@@ -754,7 +754,6 @@ impl Starry {
         for starry_case in cases {
             let mut qemu = self
                 .app
-                .tool_mut()
                 .read_qemu_config_from_path_for_cargo(cargo, &starry_case.case.qemu_config_path)
                 .await
                 .with_context(|| {


### PR DESCRIPTION
## 问题

`ostool` 0.22 调整了调用接口，`axbuild` 需要从旧的 `Tool` / `ToolConfig` 入口迁移到新的 `Invocation` 和模块级入口函数。

升级到 crates.io `ostool` 0.22 后，AxVisor self-hosted board CI 在 U-Boot 启动阶段崩溃。对比成功运行后确认差异是旧流程会先把 ELF 转成 `axvisor.bin`，而 0.22 运行路径可能把 ELF 直接作为 FIT kernel 传给 U-Boot，导致板端跳转到非 raw image 内容。

## 改动

- 将 `axbuild` 中的 ostool 调用改为使用新的 `Invocation` 和模块级入口函数。
- 为 `AppContext` 增加 qemu、uboot、board 配置读取封装，保留现有调用侧语义。
- 更新 `context` 单测辅助 manifest，适配新接口初始化需要。
- 将工作区 `ostool` 依赖固定到 `drivercraft/ostool` 修复 commit：`f3192dda953dcfc9ed25ac67d4af52a0cfc6363b`。
- 该 ostool 修复来自 drivercraft/ostool#125：U-Boot/board/UEFI QEMU 运行路径会在内部自动准备所需 BIN，调用方不再需要手动依赖 `to_bin`。
- 更新 `Cargo.lock`，让 `ostool`、`fitimage`、`jkconfig`、`uboot-shell` 使用同一 ostool git revision。

## 逻辑

这次变更把 ostool 的初始化集中到 `AppContext`，各 build/test/run 流程只通过上下文读取配置或调用对应入口函数，避免业务流程继续持有旧的可变 tool handle。

board CI 崩溃的根因在 ostool 0.22 的 runtime artifact 选择：U-Boot/FIT 场景必须使用 raw BIN，而不是 ELF。tgoskits 侧固定到带修复的 ostool commit 后，board 流程会在获取板卡 session 前重新输出 `Converting ELF to BIN format`，并生成 `target/aarch64-unknown-none-softfloat/release/axvisor.bin`。

## 验证

- `cargo fmt --check`
- `cargo xtask clippy --package axbuild`
- `cargo test -p axbuild`
- `timeout 900s cargo xtask axvisor test board --board roc-rk3568-pc-linux`
  - 本地已确认生成 `target/aarch64-unknown-none-softfloat/release/axvisor.bin`。
  - 本地没有 board server，命令随后停在 `failed to acquire board type \`ROC-RK3568-PC\`` / `http://localhost:2999/api/v1/sessions`，真实板卡启动结果以 GitHub Actions 为准。
