### PR TITLE
docs(review): strengthen PR review requirements

### DIFF
--- a/.claude/skills/review-single-pr/SKILL.md
+++ b/.claude/skills/review-single-pr/SKILL.md
@@ -11,6 +11,8 @@ This skill is a normative review specification, not a suggestion list. When it t
 
 Do not submit `APPROVE`, `REQUEST_CHANGES`, a no-submit summary, or any PR-facing comment from only the frontmatter, title, partial sections, memory, or a previous review. If context or time pressure prevents reading the full skill, state that limitation and do not claim a complete `review-single-pr` review.
 
+After reading the full skill, create a review todo/checklist before deciding or submitting any outcome. The checklist must cover all applicable merge-readiness requirements from this skill, including PR metadata and intake, review threads and CI, worktree setup, merge-conflict handling when applicable, review focus, duplicate and overlap analysis, validation, blocking findings, submission rules, reviewer assignment, and cleanup. Verify each item one by one as satisfied, not applicable with a concrete reason, or blocking with evidence; do not collapse the checklist into a generic "tests passed" statement.
+
 When requirements overlap, apply the stricter rule. If skipping a requirement is necessary because it is inapplicable or impossible, record the concrete reason and evidence in the review body or user summary.
 
 ## Goal
@@ -211,7 +213,7 @@ Review the PR against its stated intent, the current base branch, existing proje
 - `starry-test-suit` rules when StarryOS test cases or `qemu-*.toml` files change.
 - `cross-kernel-driver` architecture rules when portable driver crates or driver glue change.
 
-For bug fixes, require a reproduction test that fails before the fix and passes after it unless the environment makes that impossible. For raw syscall fixes, prefer direct `syscall(SYS_...)` coverage when libc wrappers could mask return values or errno.
+For bug fixes (修复 bug), require a regression or reproduction test that fails on the unfixed behavior and passes only after the fix unless concrete evidence shows the environment makes such a test impossible. The reviewer must verify this from the test code, author-provided red/green evidence, or local red/green validation when practical. If the PR fixes a bug but lacks a post-fix-only regression test and no concrete impossibility is documented, treat that as blocking. For raw syscall fixes, prefer direct `syscall(SYS_...)` coverage when libc wrappers could mask return values or errno.
 
 For PRs that add StarryOS app support, separate operator-facing app scenarios from CI-oriented semantic coverage:
 
@@ -387,7 +389,7 @@ Treat these as blocking unless clearly non-blocking:
 - a PR has no test changes and lacks a reproducible non-board validation method in the PR body or commit messages;
 - a claimed non-board validation method is not actually reproducible or does not match the claimed coverage/result;
 - `success_regex` or `fail_regex` cannot reliably classify the intended StarryOS case result;
-- bug fixes lack meaningful reproduction coverage;
+- a bug-fix PR lacks a regression or reproduction test that fails on the unfixed behavior and passes only after the fix, unless concrete evidence shows such a test is impossible;
 - the PR adds, changes, or relies on any `[patch.crates-io]` override, instead of using normal dependency resolution, an upstream fix, a dependency upgrade, or an explicit local boundary adapter;
 - merge conflicts are unresolved, conflict repair resurrects outdated base APIs instead of adapting PR intent to current base, or the repaired head was not revalidated after push;
 - StarryOS app-support PRs place app workflows under `test-suit/starryos/normal` instead of `apps/starry`, or place syscall/bugfix semantic coverage only under `apps/starry` instead of the matching normal test-suit case;
@@ -448,7 +450,7 @@ Review body must explain in Chinese:
 - duplicate and overlap analysis: base-branch evidence checked, related open PRs inspected, and why the PR is distinct, complementary, duplicate, conflicting, or superseded;
 - conflict handling status when applicable: conflicted files, resolution logic, validation after repair, and whether a repair commit was pushed or the work was intentionally kept as a dry run;
 - for PR-related CI failures, the failing check, failure mode, and expected fix direction;
-- reproduction coverage status for bug fixes;
+- reproduction coverage status for bug fixes, including whether the regression test fails on the unfixed behavior and passes only after the fix;
 - unresolved review conversations that were resolved, and conversations intentionally left open and why;
 - any behavior that remains unimplemented, partial, or should be completed in future work;
 - any known environment limitation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@
 - For ArceOS, StarryOS, and Axvisor builds/tests/runs, prefer the `cargo xtask` command family instead of raw `cargo build`, `cargo test`, or `cargo run`.
 - If `cargo xtask` cannot satisfy a special configuration, inspect the `xtask` flow first and only then fall back to native Cargo commands with manually matched arguments.
 - When resolving rebase or merge conflicts, do not manually merge conflicted `Cargo.lock` contents. Resolve all other conflicts first, then regenerate `Cargo.lock` with Cargo and verify the generated lockfile.
+- When reviewing a PR, fully read (完整阅读) `.claude/skills/review-single-pr/SKILL.md` before judging merge readiness, drafting comments, approving, requesting changes, or posting a no-submit summary.
+- During PR review, build a todo/checklist from the full `review-single-pr` requirements and verify each applicable merge requirement one by one. Mark each item as satisfied, not applicable with a concrete reason, or blocking with evidence.
 - For PRs, issues, review replies, discussions, and similar project-facing submissions, keep the language neutral and project-focused.
 - For PR titles, follow `type(scope): content` in Conventional Commits style. Prefer the main affected crate name as `scope` when one crate clearly dominates the change; for cross-cutting or infrastructure work, broader scopes such as `ci`, `repo`, or `docs` are acceptable.
 - PR title examples: `feat(axbuild): add Starry remote board test flow`, `fix(starry-process): correct tty session cleanup`, `chore(ci): split Starry self-hosted board matrix`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ Board-level platform crates: `axplat-dyn` (dynamic dispatch), `somehal`, `riscv6
 
 - PR titles: Conventional Commits `type(scope): content`, e.g. `feat(axbuild): add board test flow`, `fix(starry-process): correct tty cleanup`
 - PR titles in English, bodies in Chinese
+- For any PR review, fully read (完整阅读) `.claude/skills/review-single-pr/SKILL.md` first; `AGENTS.md` and that skill are the review source of truth.
+- Before deciding merge readiness, create a todo/checklist from the full `review-single-pr` requirements and verify each applicable item as satisfied, not applicable with reason, or blocking with evidence.
 - Do not silence clippy warnings with `allow`; fix the root cause
 - Do not add agent/AI branding or signatures to commits/PRs
 - Read and strictly follow all conventions in AGENTS.md


### PR DESCRIPTION
## 问题

当前 PR 审查规范已经存在于 `.claude/skills/review-single-pr/SKILL.md`，但项目记忆没有明确要求在审查 PR 前完整阅读该规范，也没有把基于规范逐项建立 todo/checklist 作为硬性流程。对于 bug 修复类 PR，现有表述也可以进一步明确为必须具备“修复后才能通过”的回归/复现测例。

## 修改

- 在 `AGENTS.md` 中增加 PR 审查约束：审查前必须完整阅读 `.claude/skills/review-single-pr/SKILL.md`，并基于完整规范建立 todo/checklist，逐项确认合并要求。
- 在 `CLAUDE.md` 中增加相同约束，确保 Claude 项目记忆与 `AGENTS.md` 和 `review-single-pr` 技能保持一致。
- 在 `review-single-pr` 技能的 `Normative Use` 中明确要求：读取完整技能后、提交任何审查结论前，必须创建并逐项验证 merge-readiness checklist。
- 强化 bug 修复要求：bug-fix PR 必须包含一个在未修复行为上失败、修复后才通过的 regression/reproduction test；除非有具体证据证明无法添加，否则视为阻塞问题。

## 方案逻辑

`.claude/skills/review-single-pr/SKILL.md` 继续作为唯一完整 PR 审查规范，避免新增文档副本导致规则漂移。项目记忆只放短约束，负责把未来审查流程导向该规范；具体执行细节仍集中在 skill 中维护。

## 验证

- `git diff HEAD~1..HEAD --check`
- `rg -n "fully read|完整阅读|todo|checklist|regression|fails.*passes|修复" AGENTS.md CLAUDE.md .claude/skills/review-single-pr/SKILL.md`

本次仅修改 Markdown 项目记忆和 skill 文档，不涉及 Rust 逻辑或 crate 变更，因此未运行 `cargo fmt` / `cargo clippy`。