### PR TITLE
test(starry): add git remote stress probes

### DIFF
--- a/test-suit/starryos/stress/git-remote/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/stress/git-remote/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,16 @@
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/rtc",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+plat_dyn = true
+target = "aarch64-unknown-none-softfloat"

--- a/test-suit/starryos/stress/git-remote/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/stress/git-remote/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,14 @@
+target = "loongarch64-unknown-none-softfloat"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = [
+  "ax-hal/loongarch64-qemu-virt",
+  "qemu",
+  "ax-driver/plat-static",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]
+plat_dyn = false

--- a/test-suit/starryos/stress/git-remote/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/stress/git-remote/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,15 @@
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+features = [
+  "ax-feat/rtc",
+  "ax-driver/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+]
+log = "Warn"
+plat_dyn = true
+target = "riscv64gc-unknown-none-elf"

--- a/test-suit/starryos/stress/git-remote/build-x86_64-unknown-none.toml
+++ b/test-suit/starryos/stress/git-remote/build-x86_64-unknown-none.toml
@@ -1,0 +1,14 @@
+target = "x86_64-unknown-none"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = [
+  "ax-hal/x86-pc",
+  "qemu",
+  "ax-driver/plat-static",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]
+plat_dyn = false

--- a/test-suit/starryos/stress/git-remote/qemu-aarch64.toml
+++ b/test-suit/starryos/stress/git-remote/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-cpu", "cortex-a53",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sed -i 's|https://|http://|' /etc/apk/repositories; (apk add git git-daemon || (apk update && apk add git git-daemon)) && /usr/bin/probe-remote-clone.sh || printf 'GIT_REMOTE_%s\\n' HAS_FAILURES"
+success_regex = ["(?m)^GIT_REMOTE_ALL_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^\S+_HAS_FAILURES\s*$']
+timeout = 600

--- a/test-suit/starryos/stress/git-remote/qemu-loongarch64.toml
+++ b/test-suit/starryos/stress/git-remote/qemu-loongarch64.toml
@@ -1,0 +1,17 @@
+args = [
+    "-machine", "virt",
+    "-cpu", "la464",
+    "-nographic",
+    "-m", "1G",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+to_bin = false
+uefi = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sed -i 's|https://|http://|' /etc/apk/repositories; (apk add git git-daemon || (apk update && apk add git git-daemon)) && /usr/bin/probe-remote-clone.sh || printf 'GIT_REMOTE_%s\\n' HAS_FAILURES"
+success_regex = ["(?m)^GIT_REMOTE_ALL_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^\S+_HAS_FAILURES\s*$']
+timeout = 600

--- a/test-suit/starryos/stress/git-remote/qemu-riscv64.toml
+++ b/test-suit/starryos/stress/git-remote/qemu-riscv64.toml
@@ -1,0 +1,16 @@
+args = [
+    "-nographic",
+    "-m", "512M",
+    "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sed -i 's|https://|http://|' /etc/apk/repositories; (apk add git git-daemon || (apk update && apk add git git-daemon)) && /usr/bin/probe-remote-clone.sh || printf 'GIT_REMOTE_%s\\n' HAS_FAILURES"
+success_regex = ["(?m)^GIT_REMOTE_ALL_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^\S+_HAS_FAILURES\s*$']
+timeout = 600

--- a/test-suit/starryos/stress/git-remote/qemu-x86_64.toml
+++ b/test-suit/starryos/stress/git-remote/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sed -i 's|https://|http://|' /etc/apk/repositories; (apk add git git-daemon || (apk update && apk add git git-daemon)) && /usr/bin/probe-remote-clone.sh || printf 'GIT_REMOTE_%s\\n' HAS_FAILURES"
+success_regex = ["(?m)^GIT_REMOTE_ALL_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^\S+_HAS_FAILURES\s*$']
+timeout = 600

--- a/test-suit/starryos/stress/git-remote/sh/probe-remote-clone.sh
+++ b/test-suit/starryos/stress/git-remote/sh/probe-remote-clone.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+# git remote probe: deterministic git:// URL served inside the guest.
+PASS=0
+FAIL=0
+ROOT=/tmp/git-remote-test
+PORT=9418
+HOST=127.0.0.1
+REMOTE="git://$HOST:$PORT/src.git"
+
+section() {
+    echo
+    echo "=== $1 ==="
+}
+
+pass() {
+    echo "PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+cleanup() {
+    if [ -n "$DAEMON_PID" ]; then
+        kill "$DAEMON_PID" >/dev/null 2>&1 || true
+        wait "$DAEMON_PID" >/dev/null 2>&1 || true
+    fi
+}
+
+trap cleanup EXIT INT TERM
+
+rm -rf "$ROOT"
+mkdir -p "$ROOT"
+
+section "prep bare repo"
+git init --bare "$ROOT/src.git" >/dev/null 2>&1
+git -C "$ROOT/src.git" config daemon.receivepack true
+mkdir -p "$ROOT/work"
+cd "$ROOT/work" || exit 1
+git init >/dev/null 2>&1
+git config user.name "T"
+git config user.email "t@t.com"
+git checkout -b main >/dev/null 2>&1
+echo "hello from remote clone" > readme.txt
+git add readme.txt
+git commit -m "init" >/dev/null 2>&1
+git remote add origin "$ROOT/src.git"
+if git push -u origin main >/dev/null 2>"$ROOT/push.err"; then
+    pass "prepared bare source repository"
+else
+    fail "prepare push failed: $(cat "$ROOT/push.err")"
+fi
+git -C "$ROOT/src.git" symbolic-ref HEAD refs/heads/main
+cd "$ROOT" || exit 1
+
+section "start git daemon"
+git daemon \
+    --reuseaddr \
+    --export-all \
+    --enable=receive-pack \
+    --base-path="$ROOT" \
+    --listen="$HOST" \
+    --port="$PORT" \
+    "$ROOT" >"$ROOT/git-daemon.log" 2>&1 &
+DAEMON_PID=$!
+sleep 1
+
+if kill -0 "$DAEMON_PID" >/dev/null 2>&1; then
+    pass "git daemon started"
+else
+    fail "git daemon failed to start: $(cat "$ROOT/git-daemon.log")"
+fi
+
+section "1. git ls-remote git://"
+if git ls-remote "$REMOTE" refs/heads/main >"$ROOT/ls-remote.out" 2>"$ROOT/ls-remote.err" &&
+    grep -q "refs/heads/main" "$ROOT/ls-remote.out"; then
+    pass "git ls-remote over git://"
+else
+    fail "git ls-remote over git:// failed: $(cat "$ROOT/ls-remote.err")"
+fi
+
+section "2. git clone git://"
+if git clone "$REMOTE" "$ROOT/clone-remote" >"$ROOT/clone.out" 2>"$ROOT/clone.err" &&
+    [ -d "$ROOT/clone-remote/.git" ] &&
+    grep -q "hello from remote clone" "$ROOT/clone-remote/readme.txt"; then
+    pass "git clone remote URL"
+else
+    fail "git clone remote URL failed: $(cat "$ROOT/clone.err")"
+fi
+
+section "3. clone into existing empty dir from git://"
+mkdir -p "$ROOT/existing-empty"
+if git clone "$REMOTE" "$ROOT/existing-empty" >"$ROOT/clone-empty.out" 2>"$ROOT/clone-empty.err" &&
+    grep -q "hello from remote clone" "$ROOT/existing-empty/readme.txt"; then
+    pass "git clone remote URL into existing empty dir"
+else
+    fail "git clone remote URL into existing empty dir failed: $(cat "$ROOT/clone-empty.err")"
+fi
+
+section "4. clone from closed port should fail"
+if git clone "git://$HOST:19418/src.git" "$ROOT/closed-port" >"$ROOT/closed-port.out" 2>"$ROOT/closed-port.err"; then
+    fail "git clone from closed port unexpectedly succeeded"
+else
+    pass "git clone from closed port fails"
+fi
+
+section "5. git fetch from git://"
+cd "$ROOT/work" || exit 1
+echo "second commit" >> readme.txt
+git add readme.txt
+git commit -m "second" >/dev/null 2>&1
+git push origin main >/dev/null 2>"$ROOT/push-second.err"
+if [ $? -ne 0 ]; then
+    fail "prepare second commit failed: $(cat "$ROOT/push-second.err")"
+else
+    if git -C "$ROOT/clone-remote" fetch origin main >"$ROOT/fetch.out" 2>"$ROOT/fetch.err" &&
+        git -C "$ROOT/clone-remote" show --quiet --format=%s FETCH_HEAD | grep -q "second"; then
+        pass "git fetch remote URL"
+    else
+        fail "git fetch remote URL failed: $(cat "$ROOT/fetch.err")"
+    fi
+fi
+
+section "6. git pull from git://"
+git clone "$REMOTE" "$ROOT/pull-client" >"$ROOT/pull-clone.out" 2>"$ROOT/pull-clone.err"
+if [ $? -ne 0 ]; then
+    fail "prepare pull client failed: $(cat "$ROOT/pull-clone.err")"
+else
+    cd "$ROOT/work" || exit 1
+    echo "third commit" >> readme.txt
+    git add readme.txt
+    git commit -m "third" >/dev/null 2>&1
+    git push origin main >/dev/null 2>"$ROOT/push-third.err"
+    if [ $? -ne 0 ]; then
+        fail "prepare third commit failed: $(cat "$ROOT/push-third.err")"
+    elif git -C "$ROOT/pull-client" pull --ff-only origin main >"$ROOT/pull.out" 2>"$ROOT/pull.err" &&
+        grep -q "third commit" "$ROOT/pull-client/readme.txt"; then
+        pass "git pull remote URL"
+    else
+        fail "git pull remote URL failed: $(cat "$ROOT/pull.err")"
+    fi
+fi
+
+section "7. git push to git://"
+git clone "$REMOTE" "$ROOT/push-client" >"$ROOT/push-clone.out" 2>"$ROOT/push-clone.err"
+if [ $? -ne 0 ]; then
+    fail "prepare push client failed: $(cat "$ROOT/push-clone.err")"
+else
+    cd "$ROOT/push-client" || exit 1
+    git config user.name "T"
+    git config user.email "t@t.com"
+    echo "client push" > pushed.txt
+    git add pushed.txt
+    git commit -m "client-push" >/dev/null 2>&1
+    if git push origin main >"$ROOT/push-remote.out" 2>"$ROOT/push-remote.err" &&
+        git --git-dir="$ROOT/src.git" show main:pushed.txt | grep -q "client push"; then
+        pass "git push remote URL"
+    else
+        fail "git push remote URL failed: $(cat "$ROOT/push-remote.err")"
+    fi
+fi
+
+echo
+echo "RESULT: PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -eq 0 ]; then
+    echo "GIT_REMOTE_CLONE_ALL_PASSED"
+    echo "GIT_REMOTE_FETCH_ALL_PASSED"
+    echo "GIT_REMOTE_PULL_ALL_PASSED"
+    echo "GIT_REMOTE_PUSH_ALL_PASSED"
+    echo "GIT_REMOTE_ALL_PASSED"
+else
+    echo "GIT_REMOTE_HAS_FAILURES"
+fi
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary

本 PR 在 StarryOS stress 测试中新增 Git remote URL 覆盖，用于验证 Git 在 guest 内通过 socket/network 路径访问 remote repository 的核心操作。

## Commits

- `test(starry): add git remote stress probes`

## What's included

- 新增 `test-suit/starryos/stress/git-remote/`。
- 在 guest 内初始化 bare repository，并启动本地 `git daemon`。
- 使用 `git://127.0.0.1:9418/src.git` 作为 deterministic remote URL，避免依赖公网服务。
- 覆盖以下 Git 操作：
  - `git ls-remote`
  - `git clone`
  - clone 到已有空目录
  - 连接关闭端口的失败路径
  - `git fetch`
  - `git pull --ff-only`
  - `git push`
- 为 `x86_64`、`aarch64`、`riscv64`、`loongarch64` 添加 QEMU 配置和 build 配置。

## Changed files

- `test-suit/starryos/stress/git-remote/build-*.toml`
- `test-suit/starryos/stress/git-remote/qemu-*.toml`
- `test-suit/starryos/stress/git-remote/sh/probe-remote-clone.sh`

## Testing

- `sh -n test-suit/starryos/stress/git-remote/sh/probe-remote-clone.sh`
- `git diff --check -- test-suit/starryos/stress/git-remote`
- `cargo xtask starry test qemu --stress -l`
- `cargo xtask starry test qemu --arch x86_64 --stress -c git-remote`
- `cargo xtask starry test qemu --arch aarch64 --stress -c git-remote`
- `cargo xtask starry test qemu --arch riscv64 --stress -c git-remote`
- `cargo xtask starry test qemu --arch loongarch64 --stress -c git-remote`
