### PR TITLE
feat(starry-kernel): expose process memory stats via /proc

### DIFF
--- a/os/StarryOS/kernel/src/mm/mod.rs
+++ b/os/StarryOS/kernel/src/mm/mod.rs
@@ -4,5 +4,6 @@ mod access;
 mod aspace;
 mod io;
 mod loader;
+mod stats;
 
-pub use self::{access::*, aspace::*, io::*, loader::*};
+pub use self::{access::*, aspace::*, io::*, loader::*, stats::*};

--- a/os/StarryOS/kernel/src/mm/stats.rs
+++ b/os/StarryOS/kernel/src/mm/stats.rs
@@ -1,0 +1,338 @@
+//! Process memory statistics derived from VMA metadata.
+//!
+//! Plan1 collects virtual-size metrics by iterating mapped areas without a
+//! page-table walk. Real RSS accounting (populate/unmap counters or PTE walk)
+//! is deferred to Plan2; until then see the `FIXME(plan2-rss)` in [`Self::collect`].
+
+use alloc::{format, string::String};
+
+use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr};
+use ax_runtime::hal::paging::MappingFlags;
+
+use super::AddrSpace;
+
+const STACK_VMA_NAME: &str = "[stack]";
+const HEAP_VMA_NAME: &str = "[heap]";
+
+/// Per-process memory counters aggregated from VMA metadata.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProcessMemStats {
+    /// Total virtual size in pages (sum of all VMA sizes).
+    pub vss_pages: u64,
+    /// Executable VMA pages excluding the stack mapping.
+    pub text_pages: u64,
+    /// Writable data VMA pages excluding stack and pure executable regions.
+    pub data_pages: u64,
+    /// Stack VMA pages (`[stack]` name or USER_STACK range).
+    pub stack_pages: u64,
+    /// File-backed executable VMA pages (VmExe approximation).
+    pub exe_pages: u64,
+    /// Virtual page count of mappings whose backend reports `shared == true`.
+    ///
+    /// This feeds `/proc/[pid]/statm` field 3 (`shared`). It is **not** Linux
+    /// resident shared memory (no mapcount/PTE walk): it only sums the virtual
+    /// size of MAP_SHARED / memfd-shared / `SharedBackend` VMAs, matching the
+    /// coarse Linux approximation where `statm shared` counts file+shmem
+    /// resident pages rather than true proportional sharing.
+    pub shared_vss_pages: u64,
+    /// Resident set size in pages (`statm resident`, `stat` field 24, VmRSS).
+    ///
+    /// Invariant: `resident_pages <= vss_pages`. Plan2 should populate this from
+    /// incremental counters or a PTE walk; Plan1 temporarily mirrors VSS (see
+    /// `collect()` FIXME).
+    pub resident_pages: u64,
+    /// Lowest executable mapping start (stat `start_code`).
+    pub start_code: u64,
+    /// Highest executable mapping end (stat `end_code`).
+    pub end_code: u64,
+    /// Stack region start (stat `start_stack`).
+    pub start_stack: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VmaClass {
+    Stack,
+    Text,
+    Data,
+    Other,
+}
+
+fn user_stack_range() -> (usize, usize) {
+    let top = crate::config::USER_STACK_TOP;
+    let size = crate::config::USER_STACK_SIZE;
+    (top.saturating_sub(size), top)
+}
+
+fn is_stack_vma(path: &str, start: VirtAddr) -> bool {
+    if path == STACK_VMA_NAME {
+        return true;
+    }
+    let (stack_start, stack_end) = user_stack_range();
+    let start = start.as_usize();
+    start >= stack_start && start < stack_end
+}
+
+fn is_named_anon(path: &str) -> bool {
+    path == STACK_VMA_NAME || path == HEAP_VMA_NAME
+}
+
+fn classify_vma(path: &str, flags: MappingFlags, start: VirtAddr) -> VmaClass {
+    if is_stack_vma(path, start) {
+        return VmaClass::Stack;
+    }
+    if flags.contains(MappingFlags::EXECUTE) {
+        return VmaClass::Text;
+    }
+    if flags.contains(MappingFlags::WRITE) {
+        return VmaClass::Data;
+    }
+    VmaClass::Other
+}
+
+fn accumulate_vma(
+    stats: &mut ProcessMemStats,
+    pages: u64,
+    path: &str,
+    flags: MappingFlags,
+    start: VirtAddr,
+    end: VirtAddr,
+    shared: bool,
+) {
+    stats.vss_pages += pages;
+    if shared {
+        stats.shared_vss_pages += pages;
+    }
+
+    let class = classify_vma(path, flags, start);
+    match class {
+        VmaClass::Stack => stats.stack_pages += pages,
+        VmaClass::Text => {
+            stats.text_pages += pages;
+            if !path.is_empty() && !is_named_anon(path) {
+                stats.exe_pages += pages;
+            }
+            let start = start.as_usize() as u64;
+            let end = end.as_usize() as u64;
+            if stats.start_code == 0 || start < stats.start_code {
+                stats.start_code = start;
+            }
+            if end > stats.end_code {
+                stats.end_code = end;
+            }
+        }
+        VmaClass::Data => stats.data_pages += pages,
+        VmaClass::Other => {}
+    }
+
+    if class == VmaClass::Stack && stats.start_stack == 0 {
+        stats.start_stack = start.as_usize() as u64;
+    }
+}
+
+impl ProcessMemStats {
+    /// Collect memory statistics by iterating the address-space VMA list.
+    pub fn collect(aspace: &AddrSpace) -> Self {
+        let mut stats = Self::default();
+        for area in aspace.areas() {
+            let pages = (area.size() / PAGE_SIZE_4K) as u64;
+            let flags = area.flags();
+            let file_info = area
+                .backend()
+                .file_info()
+                .unwrap_or(super::BackendFileInfo {
+                    path: String::new(),
+                    offset: None,
+                    inode: None,
+                    dev: None,
+                    shared: false,
+                });
+            accumulate_vma(
+                &mut stats,
+                pages,
+                &file_info.path,
+                flags,
+                area.start(),
+                area.end(),
+                file_info.shared,
+            );
+        }
+        // FIXME(plan2-rss): replace with real RSS from mm counters or PTE walk.
+        // Plan1 intentionally sets resident = VSS as an honest upper bound for
+        // lazily populated file-backed mappings; do not treat equality as API contract.
+        stats.resident_pages = stats.vss_pages;
+        stats
+    }
+
+    /// Virtual size in bytes (`stat` field 23).
+    pub const fn vsize_bytes(&self) -> u64 {
+        self.vss_pages * PAGE_SIZE_4K as u64
+    }
+
+    /// Resident set size in pages (`stat` field 24).
+    pub const fn rss_pages(&self) -> i64 {
+        self.resident_pages as i64
+    }
+
+    /// Render `/proc/[pid]/statm` (size resident shared text lib data dirty).
+    pub fn format_statm(&self) -> String {
+        format!(
+            "{} {} {} {} 0 {} 0\n",
+            self.vss_pages,
+            self.resident_pages,
+            self.shared_vss_pages,
+            self.text_pages,
+            self.data_pages,
+        )
+    }
+
+    /// Render Vm* lines for `/proc/[pid]/status` (kB, Linux `task_mem` layout).
+    pub fn format_status_vm_lines(&self) -> String {
+        let page_kb = PAGE_SIZE_4K as u64 / 1024;
+        let vss_kb = self.vss_pages * page_kb;
+        let resident_kb = self.resident_pages * page_kb;
+        let data_kb = self.data_pages * page_kb;
+        let stack_kb = self.stack_pages * page_kb;
+        let exe_kb = self.exe_pages * page_kb;
+        format!(
+            "VmPeak:\t{vss_kb} kB\nVmSize:\t{vss_kb} kB\nVmLck:\t0 kB\nVmPin:\t0 \
+             kB\nVmHWM:\t{resident_kb} kB\nVmRSS:\t{resident_kb} kB\nRssAnon:\t0 kB\nRssFile:\t0 \
+             kB\nRssShmem:\t0 kB\nVmData:\t{data_kb} kB\nVmStk:\t{stack_kb} kB\nVmExe:\t{exe_kb} \
+             kB\nVmLib:\t0 kB\nVmPTE:\t0 kB\nVmSwap:\t0 kB\n"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_stack_by_name() {
+        assert_eq!(
+            classify_vma(
+                STACK_VMA_NAME,
+                MappingFlags::READ | MappingFlags::WRITE,
+                VirtAddr::from(0x1000),
+            ),
+            VmaClass::Stack,
+        );
+    }
+
+    #[test]
+    fn classify_stack_by_address_range() {
+        let (stack_start, _) = user_stack_range();
+        assert_eq!(
+            classify_vma(
+                "",
+                MappingFlags::READ | MappingFlags::WRITE,
+                VirtAddr::from(stack_start + PAGE_SIZE_4K),
+            ),
+            VmaClass::Stack,
+        );
+    }
+
+    #[test]
+    fn classify_text_and_data() {
+        assert_eq!(
+            classify_vma(
+                "",
+                MappingFlags::READ | MappingFlags::EXECUTE,
+                VirtAddr::from(0)
+            ),
+            VmaClass::Text,
+        );
+        assert_eq!(
+            classify_vma(
+                "",
+                MappingFlags::READ | MappingFlags::WRITE,
+                VirtAddr::from(0)
+            ),
+            VmaClass::Data,
+        );
+    }
+
+    #[test]
+    fn accumulate_mixed_vmas() {
+        let mut stats = ProcessMemStats::default();
+        accumulate_vma(
+            &mut stats,
+            4,
+            STACK_VMA_NAME,
+            MappingFlags::READ | MappingFlags::WRITE,
+            VirtAddr::from(crate::config::USER_STACK_TOP - crate::config::USER_STACK_SIZE),
+            VirtAddr::from(crate::config::USER_STACK_TOP),
+            false,
+        );
+        accumulate_vma(
+            &mut stats,
+            2,
+            "/bin/app",
+            MappingFlags::READ | MappingFlags::EXECUTE,
+            VirtAddr::from(0x1000),
+            VirtAddr::from(0x3000),
+            false,
+        );
+        accumulate_vma(
+            &mut stats,
+            3,
+            HEAP_VMA_NAME,
+            MappingFlags::READ | MappingFlags::WRITE,
+            VirtAddr::from(crate::config::USER_HEAP_BASE),
+            VirtAddr::from(crate::config::USER_HEAP_BASE + 3 * PAGE_SIZE_4K),
+            false,
+        );
+
+        assert_eq!(stats.vss_pages, 9);
+        assert_eq!(stats.stack_pages, 4);
+        assert_eq!(stats.text_pages, 2);
+        assert_eq!(stats.exe_pages, 2);
+        assert_eq!(stats.data_pages, 3);
+        assert_eq!(stats.start_code, 0x1000);
+        assert_eq!(stats.end_code, 0x3000);
+    }
+
+    #[test]
+    fn format_statm_matches_linux_field_order() {
+        let stats = ProcessMemStats {
+            vss_pages: 100,
+            text_pages: 10,
+            data_pages: 40,
+            stack_pages: 20,
+            exe_pages: 8,
+            shared_vss_pages: 5,
+            resident_pages: 100,
+            ..Default::default()
+        };
+        assert_eq!(stats.format_statm(), "100 100 5 10 0 40 0\n");
+    }
+
+    #[test]
+    fn format_status_vm_lines_use_kilobytes() {
+        let stats = ProcessMemStats {
+            vss_pages: 256,
+            data_pages: 64,
+            stack_pages: 32,
+            exe_pages: 16,
+            resident_pages: 256,
+            ..Default::default()
+        };
+        let lines = stats.format_status_vm_lines();
+        assert!(lines.contains("VmSize:\t1024 kB\n"));
+        assert!(lines.contains("VmRSS:\t1024 kB\n"));
+        assert!(lines.contains("VmData:\t256 kB\n"));
+        assert!(lines.contains("VmStk:\t128 kB\n"));
+        assert!(lines.contains("VmExe:\t64 kB\n"));
+    }
+
+    #[test]
+    fn resident_never_exceeds_vss() {
+        let stats = ProcessMemStats {
+            vss_pages: 42,
+            resident_pages: 30,
+            ..Default::default()
+        };
+        assert!(stats.resident_pages <= stats.vss_pages);
+        assert_eq!(stats.rss_pages(), 30);
+        assert_eq!(stats.vsize_bytes(), 42 * PAGE_SIZE_4K as u64);
+    }
+}

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -16,7 +16,6 @@ use core::{
 };
 
 use ax_lazyinit::LazyInit;
-use ax_memory_addr::PAGE_SIZE_4K;
 use ax_runtime::hal::{
     paging::MappingFlags,
     time::{monotonic_time, wall_time},
@@ -30,7 +29,7 @@ use zerocopy::IntoBytes;
 
 use crate::{
     file::FD_TABLE,
-    mm::BackendFileInfo,
+    mm::{BackendFileInfo, ProcessMemStats},
     pseudofs::{
         DirMaker, DirMapping, NodeOpsMux, RwFile, SeqObject, SimpleDir, SimpleDirOps, SimpleFile,
         SimpleFileOperation, SimpleFs, SpecialFsFile,
@@ -106,12 +105,16 @@ fn render_meminfo() -> String {
         + usages.get(ax_alloc::UsageKind::Dma)
         + usages.get(ax_alloc::UsageKind::Global);
     let cached = usages.get(ax_alloc::UsageKind::PageCache);
+    let page_tables = usages.get(ax_alloc::UsageKind::PageTable);
+    let anon_pages = usages.get(ax_alloc::UsageKind::VirtMem);
     let free = total.saturating_sub(used);
 
     let total_kb = total / 1024;
     let free_kb = free / 1024;
     let cached_kb = cached / 1024;
     let available_kb = free_kb + cached_kb;
+    let page_tables_kb = page_tables / 1024;
+    let anon_pages_kb = anon_pages / 1024;
 
     format!(
         "MemTotal:       {total_kb:>10} kB\n\
@@ -124,7 +127,7 @@ fn render_meminfo() -> String {
          SwapFree:                0 kB\n\
          Dirty:                   0 kB\n\
          Writeback:               0 kB\n\
-         AnonPages:               0 kB\n\
+         AnonPages:      {anon_pages_kb:>10} kB\n\
          Mapped:                  0 kB\n\
          Shmem:                   0 kB\n\
          KReclaimable:            0 kB\n\
@@ -132,7 +135,7 @@ fn render_meminfo() -> String {
          SReclaimable:            0 kB\n\
          SUnreclaim:              0 kB\n\
          KernelStack:             0 kB\n\
-         PageTables:              0 kB\n\
+         PageTables:     {page_tables_kb:>10} kB\n\
          NFS_Unstable:            0 kB\n\
          Bounce:                  0 kB\n\
          WritebackTmp:            0 kB\n\
@@ -368,6 +371,7 @@ fn task_status(task: &AxTaskRef) -> String {
     let thread = task.as_thread();
     let cred = thread.cred();
     let num_threads = thread.proc_data.proc.threads().len() as u32;
+    let mem = ProcessMemStats::collect(&thread.proc_data.aspace().lock());
     render_task_status(
         thread.proc_data.proc.pid(),
         thread.tid() as u64,
@@ -375,6 +379,7 @@ fn task_status(task: &AxTaskRef) -> String {
         num_threads,
         task.cpumask(),
         ax_runtime::hal::cpu_num(),
+        &mem,
     )
 }
 
@@ -385,6 +390,7 @@ fn render_task_status(
     num_threads: u32,
     cpumask: AxCpuMask,
     cpu_num: usize,
+    mem: &ProcessMemStats,
 ) -> String {
     let cpus_allowed = format_cpumask_hex(cpumask, cpu_num);
     let cpus_allowed_list = format_cpumask_list(cpumask, cpu_num);
@@ -396,6 +402,7 @@ fn render_task_status(
         num_threads,
         &cpus_allowed,
         &cpus_allowed_list,
+        mem,
     )
 }
 
@@ -407,6 +414,7 @@ fn render_task_status_fields(
     num_threads: u32,
     cpus_allowed: &str,
     cpus_allowed_list: &str,
+    mem: &ProcessMemStats,
 ) -> String {
     // NOTE: `Threads:\t<n>` is REQUIRED by psutil. `Process.num_threads()`
     // does `int(re.compile(br'Threads:\t(\d+)').findall(data)[0])`, which
@@ -421,12 +429,14 @@ fn render_task_status_fields(
         Uid:\t{}\t{}\t{}\t{}\n\
         Gid:\t{}\t{}\t{}\t{}\n\
         Threads:\t{num_threads}\n\
+        {vm_lines}\
         Cpus_allowed:\t{cpus_allowed}\n\
         Cpus_allowed_list:\t{cpus_allowed_list}\n\
         Mems_allowed:\t1\n\
         Mems_allowed_list:\t0",
         cred.uid, cred.euid, cred.suid, cred.fsuid,
         cred.gid, cred.egid, cred.sgid, cred.fsgid,
+        vm_lines = mem.format_status_vm_lines(),
     )
 }
 
@@ -701,12 +711,11 @@ fn render_thread_maps(task: &WeakAxTaskRef) -> VfsResult<String> {
 /// `Process.as_dict()`), crashing any `process_iter` (glances / top-likes).
 ///
 /// `size` (VSS) is summed exactly from the mapped areas. `resident` (RSS) is
-/// reported as the full VSS — an honest upper bound rather than a fabricated
-/// figure; StarryOS' file-backed areas are lazily/cache populated, so a precise
-/// per-page page-table walk for every process on every refresh would be far too
-/// expensive under emulation. `shared`/`lib`/`dirty` are 0 (Linux also reports 0
-/// for `lib`/`dirty` since 2.6); `text` and `data` are derived from the areas'
-/// executable / writable flags.
+/// currently the VSS upper bound (see `mm/stats.rs` `FIXME(plan2-rss)`); Plan2
+/// will report real resident pages. `shared` is the virtual size of shared
+/// backends (not Linux mapcount sharing). `lib`/`dirty` are 0 (Linux also
+/// reports 0 for `lib`/`dirty` since 2.6); `text` and `data` are derived from
+/// the areas' executable / writable flags.
 fn render_thread_statm(task: &WeakAxTaskRef) -> VfsResult<String> {
     let task = match task.upgrade() {
         Some(t) => t,
@@ -715,25 +724,7 @@ fn render_thread_statm(task: &WeakAxTaskRef) -> VfsResult<String> {
 
     let aspace_arc = task.as_thread().proc_data.aspace();
     let mm = aspace_arc.lock();
-
-    let mut size_pages: u64 = 0;
-    let mut text_pages: u64 = 0;
-    let mut data_pages: u64 = 0;
-    for area in mm.areas() {
-        let pages = (area.size() / PAGE_SIZE_4K) as u64;
-        size_pages += pages;
-        let flags = area.flags();
-        if flags.contains(MappingFlags::EXECUTE) {
-            text_pages += pages;
-        } else if flags.contains(MappingFlags::WRITE) {
-            data_pages += pages;
-        }
-    }
-
-    // size resident shared text lib data dirty
-    Ok(format!(
-        "{size_pages} {size_pages} 0 {text_pages} 0 {data_pages} 0\n"
-    ))
+    Ok(ProcessMemStats::collect(&mm).format_statm())
 }
 
 fn render_thread_auxv(task: &AxTaskRef) -> Vec<u8> {
@@ -799,6 +790,7 @@ impl SimpleDirOps for ThreadDir {
                         let thread = task.as_thread();
                         let cred = thread.cred();
                         let num_threads = thread.proc_data.proc.threads().len() as u32;
+                        let mem = ProcessMemStats::collect(&thread.proc_data.aspace().lock());
                         Ok(render_task_status(
                             pid,
                             pid as u64,
@@ -806,6 +798,7 @@ impl SimpleDirOps for ThreadDir {
                             num_threads,
                             task.cpumask(),
                             ax_runtime::hal::cpu_num(),
+                            &mem,
                         ))
                     } else {
                         Ok(task_status(&task))
@@ -1299,7 +1292,15 @@ mod tests {
         collect_cpu_presence, format_cpu_presence_hex, format_cpu_presence_list,
         render_task_status_fields,
     };
-    use crate::task::Cred;
+    use crate::{mm::ProcessMemStats, task::Cred};
+
+    fn sample_mem_stats() -> ProcessMemStats {
+        ProcessMemStats {
+            vss_pages: 128,
+            resident_pages: 128,
+            ..Default::default()
+        }
+    }
 
     fn legacy_render_task_status(tgid: u32, pid: u64) -> String {
         format!(
@@ -1321,6 +1322,7 @@ mod tests {
             1,
             &cpus_allowed,
             &cpus_allowed_list,
+            &sample_mem_stats(),
         )
     }
 
@@ -1373,11 +1375,42 @@ mod tests {
         let cpu_presence = collect_cpu_presence([0usize], 1);
         let cpus_allowed = format_cpu_presence_hex(&cpu_presence);
         let cpus_allowed_list = format_cpu_presence_list(&cpu_presence);
-        let status =
-            render_task_status_fields(1, 1, &Cred::root(), 3, &cpus_allowed, &cpus_allowed_list);
+        let status = render_task_status_fields(
+            1,
+            1,
+            &Cred::root(),
+            3,
+            &cpus_allowed,
+            &cpus_allowed_list,
+            &sample_mem_stats(),
+        );
 
         assert!(status.contains("Threads:\t3\n"));
         // Tab-separated, exactly as the psutil regex expects (not space).
         assert!(!status.contains("Threads: 3"));
+    }
+
+    #[test]
+    fn status_includes_vm_size_from_mem_stats() {
+        let cpu_presence = collect_cpu_presence([0usize], 1);
+        let cpus_allowed = format_cpu_presence_hex(&cpu_presence);
+        let cpus_allowed_list = format_cpu_presence_list(&cpu_presence);
+        let mem = ProcessMemStats {
+            vss_pages: 128,
+            resident_pages: 128,
+            ..Default::default()
+        };
+        let status = render_task_status_fields(
+            1,
+            1,
+            &Cred::root(),
+            1,
+            &cpus_allowed,
+            &cpus_allowed_list,
+            &mem,
+        );
+
+        assert!(status.contains("VmSize:\t512 kB\n"));
+        assert!(status.contains("VmRSS:\t512 kB\n"));
     }
 }

--- a/os/StarryOS/kernel/src/task/stat.rs
+++ b/os/StarryOS/kernel/src/task/stat.rs
@@ -4,7 +4,10 @@ use ax_errno::AxResult;
 use ax_task::{TaskInner, TaskState};
 use starry_signal::Signo;
 
-use crate::task::{AsThread, task_cpu_time};
+use crate::{
+    mm::ProcessMemStats,
+    task::{AsThread, task_cpu_time},
+};
 
 /// Represents the `/proc/[pid]/stat` file.
 ///
@@ -93,6 +96,8 @@ impl TaskStat {
         let cutime = (cutime_tv.as_millis() / 10) as u64;
         let cstime = (cstime_tv.as_millis() / 10) as u64;
 
+        let mem = ProcessMemStats::collect(&proc_data.aspace().lock());
+
         Ok(Self {
             pid,
             comm: comm.to_owned(),
@@ -105,6 +110,12 @@ impl TaskStat {
             cutime,
             cstime,
             num_threads: proc.threads().len() as u32,
+            vsize: mem.vsize_bytes(),
+            rss: mem.rss_pages(),
+            start_code: mem.start_code,
+            end_code: mem.end_code,
+            start_stack: mem.start_stack,
+            start_brk: proc_data.get_heap_top() as u64,
             exit_signal: proc_data.exit_signal.unwrap_or(Signo::SIGCHLD) as u8,
             processor: task.cpu_id(),
             exit_code: proc.exit_code(),

--- a/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/c/CMakeLists.txt
+++ b/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-proc-mem-monitor C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(test-proc-mem-monitor src/main.c)
+target_compile_options(test-proc-mem-monitor PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-proc-mem-monitor RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/c/src/main.c
+++ b/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/c/src/main.c
@@ -1,0 +1,356 @@
+/*
+ * test-proc-mem-monitor: validate process memory monitoring via /proc.
+ *
+ * Covers user-space scenarios used by psutil, top, and glances:
+ *   - /proc/self/status  VmSize / VmRSS / VmData / VmStk
+ *   - /proc/self/statm   seven-field layout and cross-field consistency
+ *   - /proc/self/stat    vsize (bytes) and rss (pages) consistency
+ *   - mmap growth        statm size increases after anonymous mapping
+ *   - /proc/<child>      parent reads child memory stats after fork()
+ *   - /proc/meminfo      PageTables field is parseable (allocator-backed)
+ *
+ * Long-term invariants (must hold in Plan1 and Plan2):
+ *   - VmRSS > 0, VmSize > 0, VmRSS <= VmSize
+ *   - statm resident > 0, statm size > 0, resident <= size
+ *   - stat vsize == statm size * page_size; stat rss == statm resident
+ *   - statm size (pages) == VmSize (kB) converted with sysconf(_SC_PAGESIZE)
+ *
+ * Do NOT assert VmRSS == VmSize or resident == size: Plan2 real RSS may be
+ * strictly less than VSS. Equality today is a temporary Plan1 upper-bound
+ * shortcut, not a permanent kernel/userspace contract.
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+enum { MMAP_PROBE_SIZE = 2 * 1024 * 1024 };
+
+static void expect(int condition, const char *message)
+{
+    if (!condition) {
+        fputs("FAIL: ", stderr);
+        fputs(message, stderr);
+        fputc('\n', stderr);
+        abort();
+    }
+}
+
+static long read_status_kb_from(const char *path, const char *key)
+{
+    FILE *fp = fopen(path, "r");
+    expect(fp != NULL, path);
+
+    char line[256];
+    char prefix[64];
+    int found = 0;
+    long value = -1;
+
+    snprintf(prefix, sizeof(prefix), "%s:\t", key);
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        if (strncmp(line, prefix, strlen(prefix)) != 0) {
+            continue;
+        }
+        expect(sscanf(line + strlen(prefix), "%ld kB", &value) == 1, key);
+        found = 1;
+        break;
+    }
+
+    fclose(fp);
+    expect(found, "missing status key");
+    return value;
+}
+
+static long read_status_pid_from(const char *path, const char *key)
+{
+    FILE *fp = fopen(path, "r");
+    expect(fp != NULL, path);
+
+    char line[256];
+    char prefix[64];
+    int found = 0;
+    long value = -1;
+
+    snprintf(prefix, sizeof(prefix), "%s:\t", key);
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        if (strncmp(line, prefix, strlen(prefix)) != 0) {
+            continue;
+        }
+        expect(sscanf(line + strlen(prefix), "%ld", &value) == 1, key);
+        found = 1;
+        break;
+    }
+
+    fclose(fp);
+    expect(found, "missing status pid key");
+    return value;
+}
+
+static void read_statm_fields_from(
+    const char *path,
+    unsigned long *size,
+    unsigned long *resident,
+    unsigned long *shared,
+    unsigned long *text,
+    unsigned long *data
+)
+{
+    FILE *fp = fopen(path, "r");
+    expect(fp != NULL, path);
+
+    unsigned long lib = 0;
+    unsigned long dirty = 0;
+    int n = fscanf(
+        fp,
+        "%lu %lu %lu %lu %lu %lu %lu",
+        size,
+        resident,
+        shared,
+        text,
+        &lib,
+        data,
+        &dirty
+    );
+    fclose(fp);
+
+    expect(n == 7, "statm must expose seven integer fields");
+}
+
+static unsigned long read_stat_field_after_comm_from(const char *path, unsigned token_index)
+{
+    FILE *fp = fopen(path, "r");
+    expect(fp != NULL, path);
+
+    char line[4096];
+    expect(fgets(line, sizeof(line), fp) != NULL, "read proc stat");
+    fclose(fp);
+
+    char *cursor = strchr(line, ')');
+    expect(cursor != NULL, "stat comm field");
+    cursor += 2;
+    while (*cursor == ' ') {
+        cursor++;
+    }
+
+    for (unsigned i = 0; i < token_index; i++) {
+        cursor = strchr(cursor, ' ');
+        expect(cursor != NULL, "stat field index out of range");
+        do {
+            cursor++;
+        } while (*cursor == ' ');
+    }
+
+    unsigned long value = 0;
+    expect(sscanf(cursor, "%lu", &value) == 1, "parse stat field");
+    return value;
+}
+
+static long read_meminfo_kb(const char *key)
+{
+    FILE *fp = fopen("/proc/meminfo", "r");
+    expect(fp != NULL, "open /proc/meminfo");
+
+    char line[256];
+    char prefix[64];
+    int found = 0;
+    long value = -1;
+
+    snprintf(prefix, sizeof(prefix), "%s:", key);
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        if (strncmp(line, prefix, strlen(prefix)) != 0) {
+            continue;
+        }
+        expect(sscanf(line + strlen(prefix), "%ld kB", &value) == 1, key);
+        found = 1;
+        break;
+    }
+
+    fclose(fp);
+    expect(found, "missing meminfo key");
+    return value;
+}
+
+static void test_self_proc_memory(long page_size)
+{
+    long vm_size_kb = 0;
+    long vm_rss_kb = 0;
+    long vm_data_kb = 0;
+    long vm_stk_kb = 0;
+    unsigned long statm_size = 0;
+    unsigned long statm_resident = 0;
+    unsigned long statm_shared = 0;
+    unsigned long statm_text = 0;
+    unsigned long statm_data = 0;
+    unsigned long statm_size_after = 0;
+    unsigned long vsize = 0;
+    unsigned long rss = 0;
+    void *probe = MAP_FAILED;
+
+    vm_size_kb = read_status_kb_from("/proc/self/status", "VmSize");
+    vm_rss_kb = read_status_kb_from("/proc/self/status", "VmRSS");
+    vm_data_kb = read_status_kb_from("/proc/self/status", "VmData");
+    vm_stk_kb = read_status_kb_from("/proc/self/status", "VmStk");
+    expect(vm_size_kb > 0, "VmSize must be positive");
+    expect(vm_rss_kb > 0, "VmRSS must be positive");
+    expect(vm_data_kb >= 0, "VmData must be non-negative");
+    expect(vm_stk_kb > 0, "VmStk must be positive");
+    expect(vm_rss_kb <= vm_size_kb, "VmRSS must not exceed VmSize");
+
+    read_statm_fields_from(
+        "/proc/self/statm",
+        &statm_size,
+        &statm_resident,
+        &statm_shared,
+        &statm_text,
+        &statm_data
+    );
+    expect(statm_size > 0, "statm size must be positive");
+    expect(statm_resident > 0, "statm resident must be positive");
+    expect(statm_resident <= statm_size, "statm resident must not exceed size");
+    expect(statm_size == (unsigned long)vm_size_kb * 1024UL / (unsigned long)page_size,
+           "statm size matches VmSize");
+
+    vsize = read_stat_field_after_comm_from("/proc/self/stat", 20);
+    rss = read_stat_field_after_comm_from("/proc/self/stat", 21);
+    expect(vsize > 0, "stat vsize must be positive");
+    expect(vsize == statm_size * (unsigned long)page_size, "stat vsize matches statm size");
+    expect(rss == statm_resident, "stat rss pages match statm resident");
+
+    probe = mmap(NULL, MMAP_PROBE_SIZE, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    expect(probe != MAP_FAILED, "mmap probe mapping");
+
+    read_statm_fields_from(
+        "/proc/self/statm",
+        &statm_size_after,
+        &statm_resident,
+        &statm_shared,
+        &statm_text,
+        &statm_data
+    );
+    expect(statm_size_after >= statm_size + MMAP_PROBE_SIZE / (unsigned long)page_size,
+           "statm size grows after mmap");
+
+    munmap(probe, MMAP_PROBE_SIZE);
+}
+
+static void test_child_proc_memory(long page_size, unsigned long parent_statm_size)
+{
+    int notify[2];
+    int release[2];
+    expect(pipe(notify) == 0, "notify pipe for fork sync");
+    expect(pipe(release) == 0, "release pipe for fork sync");
+
+    pid_t child = fork();
+    expect(child >= 0, "fork child for /proc/<pid> probe");
+
+    if (child == 0) {
+        void *child_map = mmap(NULL, MMAP_PROBE_SIZE, PROT_READ | PROT_WRITE,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (child_map == MAP_FAILED) {
+            _exit(1);
+        }
+
+        close(notify[0]);
+        close(release[1]);
+
+        pid_t self = getpid();
+        if (write(notify[1], &self, sizeof(self)) != (ssize_t)sizeof(self)) {
+            _exit(1);
+        }
+        close(notify[1]);
+
+        char byte = 0;
+        if (read(release[0], &byte, 1) != 1) {
+            _exit(1);
+        }
+        close(release[0]);
+        munmap(child_map, MMAP_PROBE_SIZE);
+        _exit(0);
+    }
+
+    close(notify[1]);
+    close(release[0]);
+
+    pid_t reported_pid = -1;
+    expect(read(notify[0], &reported_pid, sizeof(reported_pid)) == (ssize_t)sizeof(reported_pid),
+           "read child pid from pipe");
+    close(notify[0]);
+    expect(reported_pid == child, "child reports its own pid");
+
+    char child_status[64];
+    char child_statm[64];
+    snprintf(child_status, sizeof(child_status), "/proc/%d/status", child);
+    snprintf(child_statm, sizeof(child_statm), "/proc/%d/statm", child);
+
+    expect(read_status_pid_from(child_status, "Pid") == (long)child,
+           "child status Pid matches fork return");
+    expect(read_status_pid_from(child_status, "Tgid") == (long)child,
+           "child status Tgid matches fork return");
+    expect(read_status_kb_from(child_status, "VmSize") > 0,
+           "child VmSize must be positive");
+    expect(read_status_kb_from(child_status, "VmRSS") > 0,
+           "child VmRSS must be positive");
+
+    unsigned long child_size = 0;
+    unsigned long child_resident = 0;
+    unsigned long child_shared = 0;
+    unsigned long child_text = 0;
+    unsigned long child_data = 0;
+    read_statm_fields_from(
+        child_statm,
+        &child_size,
+        &child_resident,
+        &child_shared,
+        &child_text,
+        &child_data
+    );
+    expect(child_size > parent_statm_size, "child statm size exceeds parent baseline");
+    expect(child_resident > 0, "child statm resident must be positive");
+    expect(child_resident <= child_size, "child statm resident must not exceed size");
+    expect(child_size == (unsigned long)read_status_kb_from(child_status, "VmSize")
+                              * 1024UL / (unsigned long)page_size,
+           "child statm size matches VmSize");
+
+    char byte = 1;
+    expect(write(release[1], &byte, 1) == 1, "release child from pipe sync");
+    close(release[1]);
+
+    int status = 0;
+    expect(waitpid(child, &status, 0) == child, "waitpid reaps child");
+    expect(WIFEXITED(status) && WEXITSTATUS(status) == 0, "child exits cleanly");
+}
+
+int main(void)
+{
+    long page_size = 0;
+    unsigned long parent_statm_size = 0;
+    unsigned long parent_statm_resident = 0;
+    unsigned long parent_statm_shared = 0;
+    unsigned long parent_statm_text = 0;
+    unsigned long parent_statm_data = 0;
+
+    page_size = sysconf(_SC_PAGESIZE);
+    expect(page_size > 0, "sysconf(_SC_PAGESIZE) must be positive");
+
+    read_statm_fields_from(
+        "/proc/self/statm",
+        &parent_statm_size,
+        &parent_statm_resident,
+        &parent_statm_shared,
+        &parent_statm_text,
+        &parent_statm_data
+    );
+
+    test_self_proc_memory(page_size);
+    test_child_proc_memory(page_size, parent_statm_size);
+    expect(read_meminfo_kb("PageTables") >= 0, "PageTables field is parseable");
+
+    puts("TEST PASSED");
+    return 0;
+}

--- a/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/qemu-aarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/qemu-aarch64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-proc-mem-monitor"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', 'FAIL:']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/qemu-loongarch64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+  "-machine",
+  "virt",
+  "-cpu",
+  "la464",
+  "-nographic",
+  "-m",
+  "512M",
+  "-device",
+  "virtio-blk-pci,drive=disk0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+  "-device",
+  "virtio-net-pci,netdev=net0",
+  "-netdev",
+  "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-proc-mem-monitor"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', 'FAIL:']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/qemu-riscv64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-proc-mem-monitor"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', 'FAIL:']
+timeout = 60

--- a/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/qemu-x86_64.toml
+++ b/test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/test-proc-mem-monitor"
+success_regex = ["(?m)^TEST PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', 'FAIL:']
+timeout = 60


### PR DESCRIPTION
## 问题

StarryOS 的 `/proc` 进程内存接口不完整：`/proc/[pid]/status` 缺少 VmSize/VmRSS 等字段，`/proc/[pid]/stat` 的 `vsize`/`rss` 恒为 0，`/proc/meminfo` 中 PageTables/AnonPages 等硬编码为 0。psutil、top 等用户态工具无法获取有意义的进程内存信息。

## 方案（Plan1）

基于 VMA 元数据聚合虚拟内存统计，**不做页表遍历**，零 `AddrSpace` 结构扩展：

1. 新增 `ProcessMemStats`（`mm/stats.rs`），遍历 VMA 汇总 VSS/text/data/stack/exe
2. 接线 `/proc/[pid]/status`（Vm* 行）、`statm`、`stat` 内存字段
3. `meminfo` 从 `ax_alloc` 填充 PageTables、AnonPages
4. Plan1 将 `resident` 报告为 VSS 上界（`FIXME(plan2-rss)`），Plan2 再引入真实 RSS 计数

## 变更

- **测试提交** `test(starryos): add proc memory monitor QEMU integration tests`
  - `test-suit/starryos/normal/qemu-smp1/proc/test-proc-mem-monitor/`
  - 覆盖 `/proc/self` 与 `fork` 后 `/proc/<child>` 的 status/statm/stat/meminfo
  - 断言长期不变量（RSS ≤ VSS、跨字段一致性），不绑定 `resident == size`

- **实现提交** `feat(starry-kernel): expose process memory stats via /proc`
  - `os/StarryOS/kernel/src/mm/stats.rs`（新建）
  - `proc.rs`、`task/stat.rs`、`mm/mod.rs`

## 测试计划

- [x] `cargo xtask clippy --package starry-kernel`
- [x] `cargo xtask starry test qemu --arch riscv64 -c proc/test-proc-mem-monitor`
- [x] riscv64 normal 全量 64/64 case 通过（含本用例）
- [ ] aarch64 / x86_64 / loongarch64 全量（CI 矩阵）
- [ ] 板级测试（不适用）


Made with [Cursor](https://cursor.com)