### PR TITLE
chore(repo): refine open PR review validation guidance

### DIFF
--- a/.claude/skills/review-open-prs/SKILL.md
+++ b/.claude/skills/review-open-prs/SKILL.md
@@ -22,15 +22,36 @@ Respect the global subagent policy: spawn subagents only when the user explicitl
    gh pr list --state open --limit 100 --json number,title,author,headRefName,headRepositoryOwner,baseRefName,updatedAt,isDraft,url,reviewDecision,mergeStateStatus,maintainerCanModify
    ```
 2. Exclude PRs authored by the current GitHub user.
-3. For each remaining PR, fetch latest commits, reviews, and changed files:
+3. For each remaining PR, fetch latest commits, reviews, changed files, and current-head CI/check status:
    ```bash
    gh api "repos/<owner>/<repo>/pulls/<pr>/commits?per_page=100"
    gh api "repos/<owner>/<repo>/pulls/<pr>/reviews?per_page=100"
    gh api "repos/<owner>/<repo>/pulls/<pr>/files?per_page=100"
+   gh pr checks <pr> --repo <owner>/<repo> --watch=false
    ```
 4. Mark a PR eligible when the current user has never reviewed it, or when the PR latest commit timestamp is newer than the current user's last submitted review timestamp. Compare against the latest commit date, not `updatedAt`, because comments, CI, or thread resolution can update a PR without code changes.
 5. Treat PRs already reviewed by the current user at the latest commit as excluded unless the user explicitly asks for a fresh pass of already-reviewed PRs.
 6. Keep a summary of excluded PRs and the reason: self-authored, already reviewed at latest commit, closed, skipped by user scope, or blocked by a stated constraint.
+
+## Validation Strategy
+
+Before dispatching an eligible PR, build a short validation plan from the current head's CI status, changed files, PR body, commits, and touched docs/runbooks.
+
+If all relevant CI checks already passed on the current head, do not rerun the same broad local CI-equivalent checks merely to duplicate that evidence. Treat successful CI as coverage evidence for the jobs it actually ran, and spend review time on:
+
+- PR body, README, docs, scripts, and config claims that describe a workflow not executed exactly by CI;
+- app, QEMU, rootfs, board-adjacent, tool-wrapper, packaging, symbolizer, or manual runbook flows whose command, architecture, preparation, or success marker differs from CI;
+- changed tests/configs that CI skipped because of path filters, matrix conditions, draft/branch restrictions, or expected skip behavior;
+- suspicious gaps where CI passed but did not exercise the changed behavior, new architecture, new case discovery, or documented user workflow.
+
+Still run local validation when CI is failing, missing, stale, suspicious, skipped for the changed surface, or when `review-single-pr` marks CI-missing manual runtime validation as a hard gate. For such runs, prefer the narrowest command that checks the uncovered claim instead of a whole-workspace repeat.
+
+Carry this plan into the per-PR review and final report. The report must distinguish:
+
+- `CI covered`: relevant successful check names or workflows that were accepted as remote evidence;
+- `CI-missing validated`: exact documented or PR-body workflow, local/manual command run, architecture or target, and observed postcondition;
+- `CI-missing not validated`: exact workflow or claim, why it was not run, and whether that limitation blocks approval;
+- `duplicative local checks skipped`: CI-equivalent local commands intentionally skipped because current-head CI already covered them.
 
 ## Dispatch
 
@@ -44,19 +65,23 @@ Context from $review-open-prs:
 - Draft status: <draft|ready>.
 - Merge state: <mergeStateStatus>; maintainer edits: <maintainerCanModify>.
 - Scope requested by user: <scope summary>.
+- Current-head CI summary: <success/failure/pending/skipped counts, relevant check names, stale/missing/suspicious notes>.
+- Validation plan: <CI covered evidence>; <CI-missing PR-body/docs workflows to validate>; <duplicative CI-equivalent local checks to skip>; <commands that still must run because CI is missing/failing/suspicious or review-single-pr requires them>.
 
-Review exactly this PR. Follow $review-single-pr for worktree setup, duplicate/superseded fix checks, conflict handling policy, local validation, Chinese inline comments, head-SHA freshness checks, and final APPROVE or REQUEST_CHANGES submission.
+Review exactly this PR. Follow $review-single-pr for worktree setup, duplicate/superseded fix checks, conflict handling policy, targeted validation, Chinese inline comments, head-SHA freshness checks, and final APPROVE or REQUEST_CHANGES submission. When current-head CI already passed for the relevant surface, do not rerun broad local CI-equivalent checks just to repeat CI; focus local/manual validation on PR-body and documentation workflows or changed behavior that CI did not execute exactly, and reflect that distinction in the review body.
 ```
 
 If workers or subagents are explicitly allowed, give each worker exactly one PR and one worktree. Worker prompts must say:
 
 - use `review-single-pr` for the actual review procedure;
-- perform read-only review plus local validation only;
+- perform read-only review plus targeted validation only;
+- skip broad local checks that only duplicate already-passing current-head CI, and instead validate CI-missing PR-body/docs workflows, suspicious skips, stale/missing/failing checks, or hard gates required by `review-single-pr`;
 - do not submit GitHub reviews;
 - do not push contributor branches unless explicitly assigned conflict-repair work, and then prefer local commit only with final push by the main agent;
 - return `APPROVE` or `REQUEST_CHANGES`;
 - provide `path`, `line`, `side=RIGHT`, and Chinese inline comment body for each blocking issue;
 - include commands run and exact failures;
+- report CI-covered evidence, CI-missing workflows validated, CI-missing workflows not validated with reasons, and CI-equivalent local checks skipped as duplicative;
 - identify missing reproduction tests for bug fixes.
 - clean temporary worktrees/files before returning, or report the path and reason when cleanup is unsafe.
 
@@ -72,6 +97,7 @@ End with a concise summary of:
 
 - reviewed PRs, decision, and key reason;
 - PRs excluded from review and why;
-- validation commands that failed or could not be run;
-- any PRs left for the author because of conflicts, missing maintainer edit permission, stale heads, or insufficient local/CI evidence;
+- for each reviewed PR: CI-covered evidence, CI-missing PR-body/docs workflows validated locally/manually, CI-missing workflows not validated and why, and CI-equivalent local checks skipped because current-head CI already passed;
+- validation commands that failed, could not be run, or revealed that a documented workflow does not match the PR's claim;
+- any PRs left for the author because of conflicts, missing maintainer edit permission, stale heads, CI gaps, or insufficient local/manual evidence for CI-missing flows;
 - temporary worktrees/files that could not be cleaned and why.


### PR DESCRIPTION
## 背景

`review-open-prs` 在调度单个 PR 审查时，原先只笼统要求本地验证，容易让已经在当前 PR head 通过 CI 的检查又被本地重复执行一遍。多 PR 审查时，这会消耗时间，并且没有突出真正需要人工确认的风险点：PR 描述、README、文档、脚本或 runbook 中 CI 没有精确覆盖的流程。

## 变更

- 在 `review-open-prs` 的 eligibility 阶段加入当前 head 的 CI/check 状态采集。
- 新增 `Validation Strategy`，明确当相关 CI 已经通过时，不重复运行 broad CI-equivalent 本地检查。
- 要求把审查重点放在 CI 未精确执行的 PR 描述和文档流程、app/QEMU/rootfs/tool-wrapper/manual runbook 等流程，以及 path filter、matrix、skip 等导致的覆盖缺口。
- 更新 dispatch 和 worker prompt，让每个 PR 都携带 CI 摘要与验证计划。
- 更新最终报告要求，区分 `CI covered`、`CI-missing validated`、`CI-missing not validated` 和 `duplicative local checks skipped`。

## 方案逻辑

这次改动保持 `review-open-prs` 作为多 PR 发现和调度层的定位，不放宽 `review-single-pr` 中对 CI 缺失流程的硬性验证要求。通过在调度前生成验证计划，审查者可以接受当前 head 已通过的 CI 作为对应覆盖证据，同时把本地或手动验证集中到 CI 覆盖不到、但 PR 描述或文档声称可用的流程上。最终报告也必须明确说明哪些检查由 CI 覆盖、哪些 CI 缺失流程被验证、哪些没有验证以及原因。

## 验证

- `git diff --check -- .claude/skills/review-open-prs/SKILL.md`

本次仅修改 Markdown skill 文档，未修改 Rust 代码或构建逻辑，因此没有运行 cargo fmt/clippy。