### PR TITLE
chore(ci): update workflow concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,91 @@ env:
   CARGO_TERM_COLOR: always
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{
+      github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
+      && format('ci-{0}-{1}', github.workflow, github.ref)
+      || format('ci-{0}-{1}', github.workflow, github.run_id)
+    }}
   queue: max
 
 jobs:
+  cancel_stale_runs:
+    name: Cancel stale CI runs
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Cancel older queued or running runs
+        if: github.event_name == 'pull_request' || github.ref != 'refs/heads/dev'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_RUN_NUMBER: ${{ github.run_number }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+        run: |
+          set -uo pipefail
+
+          statuses=(queued in_progress waiting requested)
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            selector='select(
+              .run_number < (env.CURRENT_RUN_NUMBER | tonumber)
+              and any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
+            )'
+          else
+            selector='select(
+              .run_number < (env.CURRENT_RUN_NUMBER | tonumber)
+              and .head_branch == env.REF_NAME
+              and .event != "pull_request"
+              and .event != "pull_request_target"
+            )'
+          fi
+
+          cancel_run() {
+            local run_id="$1"
+            local run_number="$2"
+            local run_url="$3"
+
+            if gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" >/dev/null; then
+              echo "Canceled stale CI run #${run_number}: ${run_url}"
+            else
+              echo "::warning::Failed to cancel stale CI run #${run_number}: ${run_url}"
+            fi
+          }
+
+          for status in "${statuses[@]}"; do
+            runs="$(
+              gh api \
+                --paginate \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?status=${status}&per_page=100" \
+                --jq ".workflow_runs[] | ${selector} | [.id, .run_number, .html_url] | @tsv" 2>api-error.log
+            )"
+            gh_status=$?
+
+            if [ "$gh_status" -ne 0 ]; then
+              while IFS= read -r line; do
+                echo "::warning::Failed to query stale CI runs with status '${status}': ${line}"
+              done < api-error.log
+              rm -f api-error.log
+              continue
+            fi
+            rm -f api-error.log
+
+            while IFS=$'\t' read -r run_id run_number run_url; do
+              if [ -n "$run_id" ]; then
+                cancel_run "$run_id" "$run_number" "$run_url"
+              fi
+            done <<< "$runs"
+          done
+
   detect_changes:
     name: Detect changed paths
+    needs: cancel_stale_runs
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,6 +12,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: release-plz-${{ github.ref }}
+  queue: max
+
 jobs:
   release-plz-release:
     name: Release-plz release
@@ -48,9 +52,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
     steps:
       - *checkout
       - *install-rust

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -39,12 +39,14 @@ flowchart TB
 | `pull_request` | 同上 |
 | `workflow_dispatch` | 手动触发，仅用于发布容器镜像（`base` / `axvisor-lvz` / `both`），不执行 CI 检查 |
 
-同一 `ref` 上新的触发会取消正在运行的旧任务（`concurrency.cancel-in-progress: true`）。
+`dev` 分支的 `push` 和手动触发使用 `concurrency.queue: max` 串行排队运行，避免多个 dev CI 同时占用 runner。其他分支、`main` 分支、PR 以及非 `dev` 手动触发不会进入 dev 队列；新 run 会在最早的 `cancel_stale_runs` 阶段取消同一分支或同一 PR 上仍在 queued/running 的旧 CI run。
 
 ## 执行流水线
 
 ```text
-detect_changes
+cancel_stale_runs
+  |
+  `-- detect_changes
   |
   +-- [ci_checks == true]
   |     `-- static_checks (fmt || sync-lint)    fail-fast: true


### PR DESCRIPTION
## 问题

当前主 CI 在同一 ref 上统一使用排队策略，无法满足 `dev` 分支和其他分支不同的并发需求：`dev` 需要顺序排队运行，而普通分支和 PR 更适合让新任务尽快开始，并取消旧的重复任务。`release-plz` 也只有部分 job 设置了并发控制，不能保证整个 release workflow 按 ref 顺序排队。

## 改动

- 调整 `CI` workflow 的顶层 concurrency：`dev` 非 PR run 使用稳定 group 并保留 `queue: max`；非 `dev` 和 PR run 使用按 `run_id` 唯一的 group，避免被 workflow 级队列阻塞。
- 新增 `cancel_stale_runs` job，并让 `detect_changes` 依赖它；该 job 会在非 `dev` 或 PR run 的最早阶段取消同一分支或同一 PR 上旧的 queued/running CI run。
- 将 `Release-plz` 改为 workflow 级 `queue: max`，让 release/release-pr 两个 job 共享同一 ref 队列。
- 更新 CI 文档，说明 `dev` 排队、非 `dev` 取消旧任务的分支化并发策略。

## 方案逻辑

`queue: max` 和 `cancel-in-progress: true` 不能组合在同一个 concurrency 配置中，因此 CI 使用两层处理：`dev` 继续由 workflow concurrency 负责排队；其他 run 使用唯一 concurrency group 立即启动，再由早期 job 调 GitHub Actions API 取消同一逻辑 ref/PR 的旧 run。这样既保留 `dev` 的顺序执行，又避免普通分支和 PR 长时间排队占用资源。

## 验证

- `actionlint v1.7.12 -ignore 'unexpected key "queue"' .github/workflows/ci.yml .github/workflows/release-plz.yml`
- `git diff --check`
- PyYAML 解析两个 workflow，并确认 CI/release 的 queue wiring 与 job 依赖符合预期。
- 在 fork 分支连续 push 验证：新 CI run 的 `Cancel stale CI runs` job 成功，旧 CI run 被取消。
