### PR TITLE
fix(axbuild): tighten incremental clippy selection

### DIFF
--- a/scripts/axbuild/src/clippy.rs
+++ b/scripts/axbuild/src/clippy.rs
@@ -396,9 +396,6 @@ impl ClippyCheck {
                 feature.clone(),
             ],
         };
-        if matches!(self.deps_mode, ClippyDepsMode::NoDeps) {
-            args.insert(1, "--no-deps".into());
-        }
         if self.package == AXSTD_STD_PACKAGE
             && matches!(&self.kind, ClippyCheckKind::Feature(feature) if feature == AXSTD_STD_DEFAULT_FEATURE)
         {
@@ -410,6 +407,9 @@ impl ClippyCheck {
                 "--features".into(),
                 AXSTD_STD_CLIPPY_FEATURES.into(),
             ];
+        }
+        if matches!(self.deps_mode, ClippyDepsMode::NoDeps) {
+            args.insert(1, "--no-deps".into());
         }
         if let Some(target) = &self.target {
             args.extend(["--target".into(), target.clone()]);
@@ -1651,6 +1651,34 @@ mod tests {
         assert_eq!(
             check.cargo_args(),
             vec!["clippy", "-p", "alpha", "--", "-D", "warnings"]
+        );
+    }
+
+    #[test]
+    fn axstd_default_feature_no_deps_check_keeps_no_deps_flag() {
+        let check = ClippyCheck {
+            package: AXSTD_STD_PACKAGE.into(),
+            kind: ClippyCheckKind::Feature(AXSTD_STD_DEFAULT_FEATURE.into()),
+            deps_mode: ClippyDepsMode::NoDeps,
+            target: None,
+            env: Vec::new(),
+            axconfig_override: None,
+        };
+
+        assert_eq!(
+            check.cargo_args(),
+            vec![
+                "clippy",
+                "--no-deps",
+                "-p",
+                AXSTD_STD_PACKAGE,
+                "--no-default-features",
+                "--features",
+                AXSTD_STD_CLIPPY_FEATURES,
+                "--",
+                "-D",
+                "warnings",
+            ]
         );
     }
 

--- a/scripts/axbuild/src/support/git.rs
+++ b/scripts/axbuild/src/support/git.rs
@@ -12,6 +12,7 @@ use toml::Value;
 const ROOT_MANIFEST: &str = "Cargo.toml";
 const WORKSPACE_TABLE: &str = "workspace";
 const WORKSPACE_DEPENDENCIES_TABLE: &str = "dependencies";
+const ZERO_SINCE_REF: &str = "0000000000000000000000000000000000000000";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum IncrementalPackageSelection {
@@ -109,15 +110,32 @@ fn resolve_since_diff_base(workspace_root: &Path, since: &str) -> anyhow::Result
     if since.is_empty() {
         bail!("since ref is empty");
     }
-    if since == "0000000000000000000000000000000000000000" {
+    if since == ZERO_SINCE_REF {
         let diff_base = infer_zero_since_diff_base(workspace_root)
             .context("failed to infer diff base for zero since ref")?;
         println!("input ref `{since}` is zero; inferred `{diff_base}` as incremental diff base");
         return Ok(diff_base);
     }
 
-    let since_commit = git_commit_for_ref(workspace_root, since)
-        .with_context(|| format!("failed to resolve `{since}` to a commit"))?;
+    let since_commit = match git_commit_for_ref(workspace_root, since) {
+        Ok(commit) => commit,
+        Err(err) if is_unresolved_commit_sha_candidate(since) => {
+            let diff_base = infer_zero_since_diff_base(workspace_root).with_context(|| {
+                format!(
+                    "failed to infer diff base for unresolved input ref `{since}` after commit \
+                     resolution failed: {err:#}"
+                )
+            })?;
+            println!(
+                "input ref `{since}` could not be resolved; inferred `{diff_base}` as incremental \
+                 diff base"
+            );
+            return Ok(diff_base);
+        }
+        Err(err) => {
+            return Err(err).with_context(|| format!("failed to resolve `{since}` to a commit"));
+        }
+    };
     if git_ref_is_ancestor_of_head(workspace_root, &since_commit)? {
         println!("using input ref `{since}` (`{since_commit}`) as incremental diff base");
         return Ok(since_commit);
@@ -130,6 +148,12 @@ fn resolve_since_diff_base(workspace_root: &Path, since: &str) -> anyhow::Result
          `{merge_base}` as incremental diff base"
     );
     Ok(merge_base)
+}
+
+fn is_unresolved_commit_sha_candidate(since: &str) -> bool {
+    since.len() == 40
+        && since != ZERO_SINCE_REF
+        && since.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn infer_zero_since_diff_base(workspace_root: &Path) -> anyhow::Result<String> {
@@ -510,7 +534,6 @@ impl PackagePathIndex {
                     RootManifestChange::Hard => return Ok(ChangedPackages::Full { path }),
                     RootManifestChange::LocalWorkspaceDependencies(dependencies) => {
                         packages.extend(dependencies);
-                        soft_global_inputs.push(path);
                     }
                 }
                 continue;
@@ -620,22 +643,27 @@ fn classify_root_manifest_change(
     let old_dependencies = workspace_dependencies(&old);
     let new_dependencies = workspace_dependencies(&new);
     let mut changed = BTreeSet::new();
-    for dependency in old_dependencies
+    for dependency_key in old_dependencies
         .keys()
         .chain(new_dependencies.keys())
         .collect::<BTreeSet<_>>()
     {
-        let old_dependency = old_dependencies.get(dependency.as_str());
-        let new_dependency = new_dependencies.get(dependency.as_str());
+        let old_dependency = old_dependencies.get(dependency_key.as_str());
+        let new_dependency = new_dependencies.get(dependency_key.as_str());
         if old_dependency == new_dependency {
             continue;
         }
-        if !old_dependency.is_some_and(is_local_workspace_dependency)
-            && !new_dependency.is_some_and(is_local_workspace_dependency)
-        {
+        let old_package = old_dependency.and_then(|dependency| {
+            local_workspace_dependency_package_name(dependency_key, dependency)
+        });
+        let new_package = new_dependency.and_then(|dependency| {
+            local_workspace_dependency_package_name(dependency_key, dependency)
+        });
+        if old_package.is_none() && new_package.is_none() {
             return Ok(RootManifestChange::Hard);
         }
-        changed.insert(dependency.to_string());
+        changed.extend(old_package);
+        changed.extend(new_package);
     }
 
     Ok(RootManifestChange::LocalWorkspaceDependencies(changed))
@@ -665,6 +693,24 @@ fn is_local_workspace_dependency(dependency: &Value) -> bool {
         .as_table()
         .and_then(|table| table.get("path"))
         .is_some_and(Value::is_str)
+}
+
+fn local_workspace_dependency_package_name(
+    dependency_key: &str,
+    dependency: &Value,
+) -> Option<String> {
+    if !is_local_workspace_dependency(dependency) {
+        return None;
+    }
+
+    Some(
+        dependency
+            .as_table()
+            .and_then(|table| table.get("package"))
+            .and_then(Value::as_str)
+            .unwrap_or(dependency_key)
+            .to_string(),
+    )
 }
 
 fn normalize_git_path(path: PathBuf) -> anyhow::Result<PathBuf> {
@@ -1123,6 +1169,109 @@ mod tests {
     }
 
     #[test]
+    fn unresolved_push_before_sha_resolves_like_new_branch_since() {
+        let root = tempfile::tempdir().unwrap();
+        run_git(root.path(), &["init"]);
+        run_git(root.path(), &["config", "user.email", "test@example.com"]);
+        run_git(root.path(), &["config", "user.name", "Test User"]);
+
+        std::fs::write(root.path().join("file.txt"), "base\n").unwrap();
+        run_git(root.path(), &["add", "file.txt"]);
+        run_git(root.path(), &["commit", "-m", "base"]);
+        let base = git_stdout(root.path(), &["rev-parse", "HEAD"]);
+        run_git(
+            root.path(),
+            &["update-ref", "refs/remotes/origin/dev", &base],
+        );
+
+        run_git(root.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(root.path().join("feature.txt"), "feature 1\n").unwrap();
+        run_git(root.path(), &["add", "feature.txt"]);
+        run_git(root.path(), &["commit", "-m", "feature 1"]);
+        std::fs::write(root.path().join("feature.txt"), "feature 2\n").unwrap();
+        run_git(root.path(), &["commit", "-am", "feature 2"]);
+        let head = git_stdout(root.path(), &["rev-parse", "HEAD"]);
+        run_git(
+            root.path(),
+            &["update-ref", "refs/remotes/origin/feature", &head],
+        );
+
+        assert_eq!(
+            resolve_since_diff_base(root.path(), "1111111111111111111111111111111111111111")
+                .unwrap(),
+            base
+        );
+    }
+
+    #[test]
+    fn unresolved_push_before_sha_without_remote_refs_returns_error() {
+        let root = tempfile::tempdir().unwrap();
+        run_git(root.path(), &["init"]);
+        run_git(root.path(), &["config", "user.email", "test@example.com"]);
+        run_git(root.path(), &["config", "user.name", "Test User"]);
+
+        std::fs::write(root.path().join("file.txt"), "base\n").unwrap();
+        run_git(root.path(), &["add", "file.txt"]);
+        run_git(root.path(), &["commit", "-m", "base"]);
+
+        let err = resolve_since_diff_base(root.path(), "1111111111111111111111111111111111111111")
+            .unwrap_err();
+
+        assert!(
+            format!("{err:#}").contains("no remote refs remain"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn unresolved_named_ref_does_not_use_push_before_sha_fallback() {
+        let root = tempfile::tempdir().unwrap();
+        run_git(root.path(), &["init"]);
+        run_git(root.path(), &["config", "user.email", "test@example.com"]);
+        run_git(root.path(), &["config", "user.name", "Test User"]);
+
+        std::fs::write(root.path().join("file.txt"), "base\n").unwrap();
+        run_git(root.path(), &["add", "file.txt"]);
+        run_git(root.path(), &["commit", "-m", "base"]);
+        let base = git_stdout(root.path(), &["rev-parse", "HEAD"]);
+        run_git(
+            root.path(),
+            &["update-ref", "refs/remotes/origin/dev", &base],
+        );
+
+        let err = resolve_since_diff_base(root.path(), "missing-branch").unwrap_err();
+
+        assert!(
+            format!("{err:#}").contains("failed to resolve `missing-branch` to a commit"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn unresolved_short_sha_does_not_use_push_before_sha_fallback() {
+        let root = tempfile::tempdir().unwrap();
+        run_git(root.path(), &["init"]);
+        run_git(root.path(), &["config", "user.email", "test@example.com"]);
+        run_git(root.path(), &["config", "user.name", "Test User"]);
+
+        std::fs::write(root.path().join("file.txt"), "base\n").unwrap();
+        run_git(root.path(), &["add", "file.txt"]);
+        run_git(root.path(), &["commit", "-m", "base"]);
+        let base = git_stdout(root.path(), &["rev-parse", "HEAD"]);
+        run_git(
+            root.path(),
+            &["update-ref", "refs/remotes/origin/dev", &base],
+        );
+
+        let err = resolve_since_diff_base(root.path(), "1111111").unwrap_err();
+
+        assert!(
+            format!("{err:#}").contains("failed to resolve `1111111` to a commit"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
     fn zero_since_root_manifest_change_uses_inferred_base() {
         let (root, metadata, workspace_packages) = test_workspace();
         run_git(root.path(), &["init"]);
@@ -1438,6 +1587,74 @@ mod tests {
     }
 
     #[test]
+    fn root_cargo_toml_semantic_noop_selects_no_packages() {
+        let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha"]
+
+            [workspace.dependencies]
+            alpha = { version = "0.1.0", path = "crates/alpha" }
+        "#;
+        let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha"]
+
+            [workspace.dependencies]
+            # Comment-only edits should not force all clippy packages.
+            alpha = { version = "0.1.0", path = "crates/alpha" }
+        "#;
+        let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+        assert_eq!(
+            change,
+            RootManifestChange::LocalWorkspaceDependencies(BTreeSet::new())
+        );
+
+        let (root, metadata, workspace_packages) = test_workspace();
+        let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+            root.path(),
+            &metadata,
+            &workspace_packages,
+            [PathBuf::from("Cargo.toml")],
+            Some(change),
+        )
+        .unwrap();
+
+        assert_eq!(
+            selected,
+            IncrementalPackageSelection::Packages {
+                changed: Vec::new(),
+                affected: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn root_cargo_toml_semantic_noop_keeps_incremental_package_selection() {
+        let (root, metadata, workspace_packages) = test_workspace();
+        let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+            root.path(),
+            &metadata,
+            &workspace_packages,
+            [
+                PathBuf::from("Cargo.toml"),
+                PathBuf::from("crates/beta/src/lib.rs"),
+            ],
+            Some(RootManifestChange::LocalWorkspaceDependencies(
+                BTreeSet::new(),
+            )),
+        )
+        .unwrap();
+
+        assert_eq!(
+            selected,
+            IncrementalPackageSelection::Packages {
+                changed: vec!["beta".into()],
+                affected: vec!["beta".into(), "gamma".into()],
+            }
+        );
+    }
+
+    #[test]
     fn root_cargo_toml_workspace_dependency_change_skips_removed_packages() {
         let (root, metadata, workspace_packages) = test_workspace();
         let selected = select_incremental_packages_for_paths_with_root_manifest_change(
@@ -1457,6 +1674,59 @@ mod tests {
                 changed: vec!["beta".into()],
                 affected: vec!["beta".into(), "gamma".into()],
             }
+        );
+    }
+
+    #[test]
+    fn root_manifest_classifier_uses_package_name_for_local_dependency_alias() {
+        let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha"]
+
+            [workspace.dependencies]
+            alpha_alias = { version = "0.1.0", path = "crates/alpha", package = "alpha" }
+        "#;
+        let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha"]
+
+            [workspace.dependencies]
+            alpha_alias = { version = "0.2.0", path = "crates/alpha", package = "alpha" }
+        "#;
+
+        let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+
+        assert_eq!(
+            change,
+            RootManifestChange::LocalWorkspaceDependencies(BTreeSet::from(["alpha".to_string()]))
+        );
+    }
+
+    #[test]
+    fn root_manifest_classifier_tracks_local_dependency_alias_package_change() {
+        let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta"]
+
+            [workspace.dependencies]
+            local_alias = { version = "0.1.0", path = "crates/alpha", package = "alpha" }
+        "#;
+        let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta"]
+
+            [workspace.dependencies]
+            local_alias = { version = "0.1.0", path = "crates/beta", package = "beta" }
+        "#;
+
+        let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+
+        assert_eq!(
+            change,
+            RootManifestChange::LocalWorkspaceDependencies(BTreeSet::from([
+                "alpha".to_string(),
+                "beta".to_string()
+            ]))
         );
     }
 


### PR DESCRIPTION
## 背景

近期 `cargo xtask clippy --since` 在部分 CI 场景下会退化为全量检查，尤其是 push/force-push 后 `github.event.before` 指向的旧提交无法解析时，会直接 fallback 到 full workspace。另有两个增量选择边界会导致检查范围不够准确：root `Cargo.toml` 的语义无变化可能仍触发全量，以及 `[workspace.dependencies]` 使用 alias 时会按依赖 key 而不是真实 package name 选择 crate。

## 修改内容

- 对不可解析的非零 40 位 SHA 使用与 zero-since 相同的 remote refs 推断逻辑，避免 push 场景因为旧 `before` 不可达而直接全量 clippy。
- 保持 fallback 边界收紧：named ref、短 SHA、没有可用 remote refs 的情况仍然报错，不静默选择任意基线。
- root `Cargo.toml` 仅发生语义无变化或注释级变化时不再触发 full workspace；若同时有 package 文件变更，则继续按 package 增量选择。
- workspace dependency alias 使用 `package = "..."` 指向的真实 workspace package，alias 切换本地 package 时同时覆盖旧、新 package。
- 保留 `ax-std` default/std-compat 特例下的 `--no-deps` 行为，避免 targeted clippy 在该分支丢失 no-deps 语义。

## 验证

- `cargo fmt --all`
- `cargo test -p axbuild`
- `git diff --check`
- `cargo xtask clippy --package axbuild`
