### PR TITLE
ci: pass tg-xtask binary between container jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,13 +296,13 @@ jobs:
             container_image: base
             fetch_depth: "1"
           - name: Run sync-lint
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
+            use_container: true
+            runs_on: '["ubuntu-latest"]'
             command: cargo xtask sync-lint --since "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}"
             cache_key: ""
             container_image: base
             fetch_depth: full
+            upload_xtask_bin_artifact: true
     uses: ./.github/workflows/reusable-command.yml
     with:
       runs_on: >-
@@ -329,6 +329,8 @@ jobs:
           || matrix.container_image
         }}
       fetch_depth: ${{ matrix.fetch_depth == 'full' && '0' || '1' }}
+      upload_xtask_bin_artifact: ${{ matrix.upload_xtask_bin_artifact || false }}
+      xtask_bin_artifact_name: tg-xtask-bin
 
   test_checks:
     name: ${{ matrix.name }}
@@ -380,47 +382,52 @@ jobs:
           - name: Test axvisor loongarch64 qemu
             use_container: true
             runs_on: '["ubuntu-latest"]'
-            command: cargo xtask axvisor test qemu --arch loongarch64
+            command: target/debug/tg-xtask axvisor test qemu --arch loongarch64
             cache_key: test-axvisor-loongarch64
             container_image: axvisor-lvz
             limit_to_owner: ""
             main_pr_only: false
+            download_xtask_bin_artifact: true
           - name: Test starry riscv64 qemu
             use_container: true
             runs_on: '["ubuntu-latest"]'
-            command: cargo xtask starry test qemu --arch riscv64
+            command: target/debug/tg-xtask starry test qemu --arch riscv64
             cache_key: test-starry-riscv64
             container_image: base
             apk_region: us
             limit_to_owner: ""
             main_pr_only: false
+            download_xtask_bin_artifact: true
           - name: Test starry aarch64 qemu
             use_container: true
             runs_on: '["ubuntu-latest"]'
-            command: cargo xtask starry test qemu --arch aarch64
+            command: target/debug/tg-xtask starry test qemu --arch aarch64
             cache_key: test-starry-aarch64
             container_image: base
             apk_region: us
             limit_to_owner: ""
             main_pr_only: false
+            download_xtask_bin_artifact: true
           - name: Test starry loongarch64 qemu
             use_container: true
             runs_on: '["ubuntu-latest"]'
-            command: cargo xtask starry test qemu --arch loongarch64
+            command: target/debug/tg-xtask starry test qemu --arch loongarch64
             cache_key: test-starry-loongarch64
             container_image: base
             apk_region: us
             limit_to_owner: ""
             main_pr_only: false
+            download_xtask_bin_artifact: true
           - name: Test starry x86_64 qemu
             use_container: true
             runs_on: '["ubuntu-latest"]'
-            command: cargo xtask starry test qemu --arch x86_64
+            command: target/debug/tg-xtask starry test qemu --arch x86_64
             cache_key: test-starry-x86_64
             container_image: base
             apk_region: us
             limit_to_owner: ""
             main_pr_only: false
+            download_xtask_bin_artifact: true
           - name: Test arceos x86_64 qemu
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
@@ -685,6 +692,15 @@ jobs:
       main_pr_only: ${{ matrix.main_pr_only }}
       fetch_depth: ${{ matrix.fetch_depth == 'full' && '0' || '1' }}
       timeout_minutes: ${{ matrix.timeout_minutes || 360 }}
+      download_xtask_bin_artifact: >-
+        ${{
+          matrix.download_xtask_bin_artifact
+          || (
+            matrix.self_hosted_owner != ''
+            && github.repository_owner != matrix.self_hosted_owner
+          )
+        }}
+      xtask_bin_artifact_name: tg-xtask-bin
     secrets:
       CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
 

--- a/.github/workflows/reusable-command.yml
+++ b/.github/workflows/reusable-command.yml
@@ -52,6 +52,21 @@ on:
         required: false
         type: number
         default: 360
+      upload_xtask_bin_artifact:
+        description: Upload the tg-xtask binary as a workflow artifact after the command succeeds.
+        required: false
+        type: boolean
+        default: false
+      download_xtask_bin_artifact:
+        description: Download and restore the tg-xtask binary artifact before running the command.
+        required: false
+        type: boolean
+        default: false
+      xtask_bin_artifact_name:
+        description: Artifact name used for the tarred tg-xtask binary.
+        required: false
+        type: string
+        default: tg-xtask-bin
     secrets:
       CLAW_API_KEY:
         required: false
@@ -150,11 +165,61 @@ jobs:
           shared-key: ${{ inputs.cache_key }}
           save-if: ${{ github.event_name == 'push' }}
 
+      - name: Download tg-xtask binary artifact
+        if: inputs.download_xtask_bin_artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.xtask_bin_artifact_name }}
+          path: ${{ runner.temp }}/xtask-bin
+
+      - name: Restore tg-xtask binary artifact
+        if: inputs.download_xtask_bin_artifact
+        shell: bash
+        run: |
+          set -eux
+          tar -xf "${RUNNER_TEMP}/xtask-bin/tg-xtask-bin.tar" -C "${GITHUB_WORKSPACE}"
+          chmod +x "${GITHUB_WORKSPACE}/target/debug/tg-xtask"
+          test -x "${GITHUB_WORKSPACE}/target/debug/tg-xtask"
+
       - name: Show Rust version
         run: rustc --version
 
       - name: Run command
+        shell: bash
         env:
           STARRY_APK_REGION: ${{ inputs.apk_region }}
           CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
-        run: ${{ inputs.command }}
+          REUSABLE_COMMAND: ${{ inputs.command }}
+          USE_XTASK_BIN: ${{ inputs.download_xtask_bin_artifact }}
+        run: |
+          set -eo pipefail
+
+          command_text="${REUSABLE_COMMAND}"
+          if [ "${USE_XTASK_BIN}" = "true" ] && [[ "${command_text}" != *$'\n'* ]]; then
+            if [[ "${command_text}" == "cargo xtask" || "${command_text}" == cargo\ xtask\ * ]]; then
+              command_text="target/debug/tg-xtask${command_text#cargo xtask}"
+            fi
+          fi
+
+          command_file="${RUNNER_TEMP}/reusable-command.sh"
+          printf '%s\n' "${command_text}" > "${command_file}"
+          echo "Resolved command:"
+          sed 's/^/+ /' "${command_file}"
+          bash -e -o pipefail "${command_file}"
+
+      - name: Package tg-xtask binary artifact
+        if: success() && inputs.upload_xtask_bin_artifact
+        shell: bash
+        run: |
+          set -eux
+          test -x target/debug/tg-xtask
+          tar -cf "${RUNNER_TEMP}/tg-xtask-bin.tar" target/debug/tg-xtask
+
+      - name: Upload tg-xtask binary artifact
+        if: success() && inputs.upload_xtask_bin_artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.xtask_bin_artifact_name }}
+          path: ${{ runner.temp }}/tg-xtask-bin.tar
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## 问题

`cargo xtask ...` 在 GitHub-hosted container job 中会为每个 job 重新编译 `tg-xtask`。之前尝试传递整棵 `target/` artifact，但 Cargo 仍会重新判定并编译，节省效果不稳定。

## 改动

- 在 `sync-lint` 的 GitHub-hosted container job 中继续使用 `cargo xtask sync-lint ...`，命令成功后把 `target/debug/tg-xtask` 单独打成 `tg-xtask-bin` artifact。
- 在后续实际跑在 GitHub-hosted container 上的 `test_checks` job 中下载并解包该 artifact，恢复 `target/debug/tg-xtask` 后直接复用这个二进制。
- 对 fork 下由 self-hosted fallback 到 `ubuntu-latest + container` 的 test job，也启用同一份 artifact，并在 reusable workflow 中把单行 `cargo xtask ...` 自动改写为 `target/debug/tg-xtask ...`。
- `run_host` 不参与该 artifact 传递，self-hosted/board/native host job 仍按原命令走 `cargo xtask ...`，避免 host/container 二进制环境差异。
- 保留原有 `Swatinem/rust-cache`，它继续缓存每个 job 的 Rust 依赖产物；artifact 只负责复用 `tg-xtask` 本身。

## 验证

本地已验证：

- `python3` + PyYAML 解析 `.github/workflows/ci.yml` 和 `.github/workflows/reusable-command.yml`
- wiring 断言确认旧完整 `target/` artifact 已删除，新 `tg-xtask-bin` 输入、下载、恢复、上传和 fallback 条件存在
- `git diff --check HEAD`
- `actionlint -ignore 'unexpected key "queue"' .github/workflows/ci.yml .github/workflows/reusable-command.yml`

在 `ZR233/tgoskits` 验证分支上已观察到：

- `Run sync-lint / run_container` 成功上传 `tg-xtask-bin`
- `Run clippy / run_container`、`Test with std / run_container`、`Test arceos x86_64 qemu / run_container`、`Test axvisor riscv64 qemu / run_container` 等 fallback container job 的 `Download tg-xtask binary artifact` 和 `Restore tg-xtask binary artifact` 均已进入并成功执行
- self-hosted/native host 对应 job 仍保持 host 路径，不下载 container binary
