### PR TITLE
feat(axplat-dyn): add LoongArch64 UEFI dynamic platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7570,6 +7570,7 @@ dependencies = [
  "ax-riscv-plic",
  "kernutil",
  "log",
+ "loongArch64",
  "mmio-api",
  "page-table-generic",
  "rdif-intc",

--- a/apps/arceos/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/arceos/build-aarch64-unknown-none-softfloat.toml
@@ -1,7 +1,6 @@
 features = []
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true
 
 [env]
 AX_GW = "10.0.2.2"

--- a/apps/arceos/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/arceos/build-loongarch64-unknown-none-softfloat.toml
@@ -3,6 +3,7 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
+plat_dyn = false
 
 [env]
 AX_GW = "10.0.2.2"

--- a/apps/arceos/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/arceos/build-riscv64gc-unknown-none-elf.toml
@@ -1,7 +1,6 @@
 features = []
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true
 
 [env]
 AX_GW = "10.0.2.2"

--- a/apps/arceos/build-x86_64-unknown-none.toml
+++ b/apps/arceos/build-x86_64-unknown-none.toml
@@ -3,7 +3,6 @@ features = [
 log = "Info"
 max_cpu_num = 1
 
-plat_dyn = true
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/apps/starry/claw-code/build-x86_64-unknown-none.toml
+++ b/apps/starry/claw-code/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/codex-cli/build-x86_64-unknown-none.toml
+++ b/apps/starry/codex-cli/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/deepseek-tui/build-x86_64-unknown-none.toml
+++ b/apps/starry/deepseek-tui/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/diffutils/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/diffutils/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/diffutils/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/diffutils/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/diffutils/build-x86_64-unknown-none.toml
+++ b/apps/starry/diffutils/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/kret/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/ebpf/kret/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/kret/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/ebpf/kret/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/ebpf/kret/build-x86_64-unknown-none.toml
+++ b/apps/starry/ebpf/kret/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/mytrace/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/ebpf/mytrace/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/mytrace/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/ebpf/mytrace/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/ebpf/mytrace/build-x86_64-unknown-none.toml
+++ b/apps/starry/ebpf/mytrace/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/profile/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/ebpf/profile/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/profile/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/ebpf/profile/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/ebpf/profile/build-x86_64-unknown-none.toml
+++ b/apps/starry/ebpf/profile/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/sched_trace/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/ebpf/sched_trace/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/sched_trace/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/ebpf/sched_trace/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/ebpf/sched_trace/build-x86_64-unknown-none.toml
+++ b/apps/starry/ebpf/sched_trace/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/syscall_count/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/ebpf/syscall_count/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/syscall_count/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/ebpf/syscall_count/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/ebpf/syscall_count/build-x86_64-unknown-none.toml
+++ b/apps/starry/ebpf/syscall_count/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/upb/build-x86_64-unknown-none.toml
+++ b/apps/starry/ebpf/upb/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ffmpeg/build-x86_64-unknown-none.toml
+++ b/apps/starry/ffmpeg/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
     "ax-driver/virtio-blk",
     "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/gcc/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/gcc/build-aarch64-unknown-none-softfloat.toml
@@ -6,4 +6,3 @@ features = [
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/gcc/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/gcc/build-riscv64gc-unknown-none-elf.toml
@@ -10,4 +10,3 @@ features = [
   "starry-kernel/input",
   "starry-kernel/vsock",
 ]
-plat_dyn = true

--- a/apps/starry/gcc/build-x86_64-unknown-none.toml
+++ b/apps/starry/gcc/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/gdb-smoke/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/gdb-smoke/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/git/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/git/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/git/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/git/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/git/build-x86_64-unknown-none.toml
+++ b/apps/starry/git/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/glibc-dynamic-smoke/build-x86_64-unknown-none.toml
+++ b/apps/starry/glibc-dynamic-smoke/build-x86_64-unknown-none.toml
@@ -7,5 +7,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "x86_64-unknown-none"

--- a/apps/starry/jcode/build-x86_64-unknown-none.toml
+++ b/apps/starry/jcode/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/k230-kpu-nncase/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/k230-kpu-nncase/build-riscv64gc-unknown-none-elf.toml
@@ -3,5 +3,4 @@ features = [
   "k230",
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/k230-qemu/qemu-k230/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/k230-qemu/qemu-k230/build-riscv64gc-unknown-none-elf.toml
@@ -3,5 +3,4 @@ features = [
   "k230",
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/llama-cpp/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/llama-cpp/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/llama-cpp/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/llama-cpp/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/llama-cpp/build-x86_64-unknown-none.toml
+++ b/apps/starry/llama-cpp/build-x86_64-unknown-none.toml
@@ -7,5 +7,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "x86_64-unknown-none"

--- a/apps/starry/mariadb/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/mariadb/build-aarch64-unknown-none-softfloat.toml
@@ -10,4 +10,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/mariadb/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/mariadb/build-riscv64gc-unknown-none-elf.toml
@@ -14,4 +14,3 @@ features = [
   "starry-kernel/input",
   "starry-kernel/vsock",
 ]
-plat_dyn = true

--- a/apps/starry/mariadb/build-x86_64-unknown-none.toml
+++ b/apps/starry/mariadb/build-x86_64-unknown-none.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/mosquitto/build-x86_64-unknown-none.toml
+++ b/apps/starry/mosquitto/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
     "ax-driver/virtio-blk",
     "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/musl-dynamic-smoke/build-x86_64-unknown-none.toml
+++ b/apps/starry/musl-dynamic-smoke/build-x86_64-unknown-none.toml
@@ -7,5 +7,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "x86_64-unknown-none"

--- a/apps/starry/mysql/build-x86_64-unknown-none.toml
+++ b/apps/starry/mysql/build-x86_64-unknown-none.toml
@@ -9,4 +9,3 @@ features = [
     "ax-driver/virtio-input",
     "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/nginx/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/nginx/build-riscv64gc-unknown-none-elf.toml
@@ -11,4 +11,3 @@ features = [
   "ax-driver/virtio-socket",
   "starry-kernel/input",
 ]
-plat_dyn = true

--- a/apps/starry/nginx/build-x86_64-unknown-none.toml
+++ b/apps/starry/nginx/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/openrc/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/openrc/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/openrc/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/openrc/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/openrc/build-x86_64-unknown-none.toml
+++ b/apps/starry/openrc/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/openssh/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/openssh/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/openssh/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/openssh/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/openssh/build-x86_64-unknown-none.toml
+++ b/apps/starry/openssh/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/orangepi-5-plus-uvc-rknn/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/orangepi-5-plus-uvc-rknn/build-aarch64-unknown-none-softfloat.toml
@@ -14,4 +14,3 @@ features = [
 ]
 log = "Warn"
 max_cpu_num = 1
-plat_dyn = true

--- a/apps/starry/orangepi-5-plus-uvc/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/orangepi-5-plus-uvc/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true

--- a/apps/starry/picoclaw-cli/build-x86_64-unknown-none.toml
+++ b/apps/starry/picoclaw-cli/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/pip/build-x86_64-unknown-none.toml
+++ b/apps/starry/pip/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
     "ax-driver/virtio-blk",
     "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/postgresql/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/postgresql/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/postgresql/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/postgresql/build-riscv64gc-unknown-none-elf.toml
@@ -10,5 +10,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/postgresql/build-x86_64-unknown-none.toml
+++ b/apps/starry/postgresql/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/qemu/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/qemu/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/qemu/build-x86_64-unknown-none.toml
+++ b/apps/starry/qemu/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/qemu/memtrack-backtrace/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/qemu/memtrack-backtrace/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/memtrack",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/qemu/memtrack-backtrace/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/qemu/memtrack-backtrace/build-riscv64gc-unknown-none-elf.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/memtrack",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/qemu/memtrack-backtrace/build-x86_64-unknown-none.toml
+++ b/apps/starry/qemu/memtrack-backtrace/build-x86_64-unknown-none.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-socket",
   "starry-kernel/memtrack",
 ]
-plat_dyn = true

--- a/apps/starry/qemu/nvme/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/qemu/nvme/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/qemu/nvme/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/qemu/nvme/build-riscv64gc-unknown-none-elf.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/qemu/nvme/build-x86_64-unknown-none.toml
+++ b/apps/starry/qemu/nvme/build-x86_64-unknown-none.toml
@@ -7,4 +7,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/redis/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/redis/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/redis/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/redis/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/redis/build-x86_64-unknown-none.toml
+++ b/apps/starry/redis/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/static-pie-test/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/static-pie-test/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/git-https/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/git-https/build-aarch64-unknown-none-softfloat.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/git-https/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/git-https/build-riscv64gc-unknown-none-elf.toml
@@ -10,5 +10,4 @@ features = [
   "starry-kernel/input",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/git-https/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/git-https/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git-remote/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/git-remote/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/git-remote/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/git-remote/build-riscv64gc-unknown-none-elf.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/input",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/git-remote/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/git-remote/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git-rename/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/git-rename/build-riscv64gc-unknown-none-elf.toml
@@ -13,4 +13,3 @@ features = [
   "starry-kernel/input",
   "starry-kernel/vsock",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git-rename/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/git-rename/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/git/build-riscv64gc-unknown-none-elf.toml
@@ -13,4 +13,3 @@ features = [
   "starry-kernel/input",
   "starry-kernel/vsock",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/git/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/stress/sqlite3-deep/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/sqlite3-deep/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket"
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/sqlite3-deep/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/sqlite3-deep/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/sqlite3-deep/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/sqlite3-deep/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket"
 ]
-plat_dyn = true

--- a/apps/starry/stress/sqlite3-smoke/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/sqlite3-smoke/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket"
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/sqlite3-smoke/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/sqlite3-smoke/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/sqlite3-smoke/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/sqlite3-smoke/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket"
 ]
-plat_dyn = true

--- a/apps/starry/stress/stress-ng-0/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/stress-ng-0/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/stress-ng-0/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/stress-ng-0/build-riscv64gc-unknown-none-elf.toml
@@ -10,5 +10,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/stress-ng-0/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/stress-ng-0/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/components/axcpu/src/exception_table.rs
+++ b/components/axcpu/src/exception_table.rs
@@ -3,85 +3,50 @@ use crate::TrapFrame;
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
 struct ExceptionTableEntry {
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64"
-    ))]
     from: i32,
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64"
-    ))]
     to: i32,
-    #[cfg(not(any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64"
-    )))]
-    from: usize,
-    #[cfg(not(any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64"
-    )))]
-    to: usize,
 }
 
 impl ExceptionTableEntry {
     #[inline]
     fn source_addr(&self) -> usize {
-        #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-        {
-            field_relative_addr(&self.from)
-        }
-
-        #[cfg(target_arch = "riscv64")]
-        {
-            let base = unsafe { _ex_table_start.as_ptr() } as isize;
-            (base + self.from as isize) as usize
-        }
-
-        #[cfg(not(any(
-            target_arch = "aarch64",
-            target_arch = "riscv64",
-            target_arch = "x86_64"
-        )))]
-        {
-            self.from
-        }
+        exception_addr(&self.from)
     }
 
     #[inline]
     fn to_addr(&self) -> usize {
-        #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-        {
-            field_relative_addr(&self.to)
-        }
-
-        #[cfg(target_arch = "riscv64")]
-        {
-            let base = unsafe { _ex_table_start.as_ptr() } as isize;
-            (base + self.to as isize) as usize
-        }
-
-        #[cfg(not(any(
-            target_arch = "aarch64",
-            target_arch = "riscv64",
-            target_arch = "x86_64"
-        )))]
-        {
-            self.to
-        }
+        exception_addr(&self.to)
     }
 }
 
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[inline]
-fn field_relative_addr(offset: &i32) -> usize {
-    let base = (offset as *const i32) as isize;
-    (base + *offset as isize) as usize
+fn exception_addr(offset: &i32) -> usize {
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "x86_64"
+    ))]
+    {
+        let base = (offset as *const i32) as isize;
+        (base + *offset as isize) as usize
+    }
+
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let base = unsafe { _ex_table_start.as_ptr() } as isize;
+        (base + *offset as isize) as usize
+    }
+
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "x86_64"
+    )))]
+    {
+        *offset as usize
+    }
 }
 
 unsafe extern "C" {

--- a/components/axcpu/src/loongarch64/macros.rs
+++ b/components/axcpu/src/loongarch64/macros.rs
@@ -74,9 +74,9 @@ macro_rules! include_asm_macros {
 
         .macro _asm_extable, from, to
             .pushsection __ex_table, "a"
-            .balign 8
-            .quad   \from
-            .quad   \to
+            .balign 4
+            .word   \from - .
+            .word   \to - .
             .popsection
         .endm
 

--- a/components/axcpu/src/loongarch64/trap.S
+++ b/components/axcpu/src/loongarch64/trap.S
@@ -24,7 +24,7 @@ exception_entry_base:
     andi    $t1, $t1, 0x3
     bnez    $t1, .Lexit_user
 
-    la.abs  $ra, .Ltrap_return
+    la.pcrel $ra, .Ltrap_return
     b       loongarch64_trap_handler
 
 .Lexit_user:

--- a/components/someboot/src/acpi/earlycon.rs
+++ b/components/someboot/src/acpi/earlycon.rs
@@ -36,51 +36,47 @@ fn deal_with_spsr(spsr: &PhysicalMapping<impl Handler, Spcr>) -> Option<()> {
     if let Some(freq) = spsr.uart_clock_frequency() {
         clock = freq.into();
     }
-    let mut vaddr = None;
-    let mut is_mmio = false;
 
-    match spsr.interface_type() {
+    let (vaddr, is_mmio) = match spsr.interface_type() {
         acpi::sdt::spcr::SpcrInterfaceType::Full16550
-        | acpi::sdt::spcr::SpcrInterfaceType::Generic16550 => {
-            match base_address.address_space {
-                AddressSpace::SystemIo => {
-                    #[cfg(target_arch = "x86_64")]
-                    {
-                        let mut uart = Ns16550::new_port(base_address.address as u16, clock);
-                        uart.open();
-                        let tx = uart.take_tx().unwrap();
-                        set_sender(tx);
-                    }
-                    #[cfg(not(target_arch = "x86_64"))]
-                    {
-                        println!("SPCR I/O port early console is only supported on x86_64.");
-                        return None;
-                    }
-                }
-                AddressSpace::SystemMemory => {
-                    let mapped = _fixmap_io(base_address.address as _);
-                    vaddr = Some(mapped);
-                    is_mmio = true;
-                    let mut uart = Ns16550::new_mmio(
-                        NonNull::new(mapped).unwrap(),
-                        clock,
-                        base_address.access_size as _,
-                    );
+        | acpi::sdt::spcr::SpcrInterfaceType::Generic16550 => match base_address.address_space {
+            AddressSpace::SystemIo => {
+                #[cfg(target_arch = "x86_64")]
+                {
+                    let mut uart = Ns16550::new_port(base_address.address as u16, clock);
                     uart.open();
                     let tx = uart.take_tx().unwrap();
                     set_sender(tx);
+                    (None, false)
                 }
-                space => {
-                    println!("Unsupported SPCR address space `{space:?}` for early console.");
+                #[cfg(not(target_arch = "x86_64"))]
+                {
+                    println!("SPCR I/O port early console is only supported on x86_64.");
                     return None;
                 }
-            };
-        }
+            }
+            AddressSpace::SystemMemory => {
+                let mapped = _fixmap_io(base_address.address as _);
+                let mut uart = Ns16550::new_mmio(
+                    NonNull::new(mapped).unwrap(),
+                    clock,
+                    base_address.access_size as _,
+                );
+                uart.open();
+                let tx = uart.take_tx().unwrap();
+                set_sender(tx);
+                (Some(mapped), true)
+            }
+            space => {
+                println!("Unsupported SPCR address space `{space:?}` for early console.");
+                return None;
+            }
+        },
         t => {
             println!("Unsupported SPCR interface type `{t:?}` for early console.");
             return None;
         }
-    }
+    };
 
     unsafe { crate::console::set_out(&SENDER) };
     unsafe {

--- a/components/someboot/src/arch/loongarch64/entry.rs
+++ b/components/someboot/src/arch/loongarch64/entry.rs
@@ -1,6 +1,6 @@
 use core::{arch::naked_asm, ffi::c_void};
 
-use crate::{arch::addrspace::*, entry::PrimaryCpuInitInfo};
+use crate::{ArchTrait, arch::addrspace::*, entry::PrimaryCpuInitInfo};
 
 static mut FW_ARG0: usize = 0;
 static mut FW_ARG1: usize = 0;
@@ -91,6 +91,7 @@ pub unsafe extern "C" fn kernel_entry(
 fn rust_main() -> ! {
     // 执行重定位，将所有地址从物理地址转换为虚拟地址
     super::relocate();
+    super::Arch::init_boot_tls();
     println!("LoongArch64 Rust kernel entry.");
 
     crate::mem::mmu::set_mmu_enabled();

--- a/components/someboot/src/arch/loongarch64/link.ld
+++ b/components/someboot/src/arch/loongarch64/link.ld
@@ -41,6 +41,13 @@ SECTIONS
     } :text
     . = __exception_vectors + 0x10000;
     __exception_vectors_end = .;
+
+    . = ALIGN(PAGE_SIZE);
+    .vectors : {
+        KEEP(*(.vectors))
+        KEEP(*(.vectors.*))
+    } :text
+
     . = ALIGN(PAGE_SIZE);
     _etext = .;
     _srodata = .; 

--- a/components/someboot/src/arch/loongarch64/mod.rs
+++ b/components/someboot/src/arch/loongarch64/mod.rs
@@ -27,6 +27,16 @@ pub use relocate::relocate;
 use crate::{ArchTrait, DCacheOp, efi_stub, irq::IrqId, power::CpuOnError};
 
 const MIN_TICKS: usize = 4;
+const BOOT_TLS_SIZE: usize = 64 * 1024;
+
+#[repr(C, align(16))]
+struct BootTls {
+    bytes: [u8; BOOT_TLS_SIZE],
+}
+
+static mut BOOT_TLS: BootTls = BootTls {
+    bytes: [0; BOOT_TLS_SIZE],
+};
 
 pub struct Arch;
 
@@ -43,6 +53,41 @@ impl ArchTrait for Arch {
     }
 
     fn post_allocator() {}
+
+    fn init_boot_tls() {
+        unsafe extern "C" {
+            fn _stdata();
+            fn _etdata();
+            fn _etbss();
+        }
+
+        let stdata = _stdata as *const () as usize;
+        let etdata = _etdata as *const () as usize;
+        let etbss = _etbss as *const () as usize;
+        if etdata < stdata || etbss < stdata {
+            return;
+        }
+
+        let tls_size = align_up(etbss - stdata, 16);
+        if tls_size > BOOT_TLS_SIZE {
+            return;
+        }
+
+        unsafe {
+            let boot_tls = core::ptr::addr_of_mut!(BOOT_TLS).cast::<u8>();
+            core::ptr::write_bytes(boot_tls, 0, tls_size);
+            core::ptr::copy_nonoverlapping(stdata as *const u8, boot_tls, etdata - stdata);
+            core::arch::asm!("move $tp, {}", in(reg) boot_tls as usize, options(nostack));
+        }
+    }
+
+    fn init_runtime_percpu_reg(cpu_idx: usize) {
+        if let Some(percpu) = crate::smp::percpu_data_ptr(cpu_idx) {
+            unsafe {
+                core::arch::asm!("move $r21, {}", in(reg) percpu as usize);
+            }
+        }
+    }
 
     fn per_cpu_trap_init(is_primary: bool) {
         trap::per_cpu_trap_init(is_primary);
@@ -249,4 +294,8 @@ impl ArchTrait for Arch {
         unsafe { crate::arch::entry::kernel_entry(1, null(), system_table) };
         unreachable!()
     }
+}
+
+const fn align_up(value: usize, align: usize) -> usize {
+    (value + align - 1) & !(align - 1)
 }

--- a/components/someboot/src/arch/loongarch64/trap.rs
+++ b/components/someboot/src/arch/loongarch64/trap.rs
@@ -598,8 +598,7 @@ global_asm!(
     "handle_exc_79:", "b handle_reserved_exception",
 
     ".balign VECSIZE",
-    ".global handle_tlb_refill",
-    "handle_tlb_refill:",
+    ".Lsomeboot_handle_tlb_refill:",
     "
     csrwr   $t0, 0x8B  // LOONGARCH_CSR_TLBRSAV - 保存 $t0
     csrrd   $t0, 0x1b  // LA_CSR_PGD - 读取页表基址

--- a/components/someboot/src/efi_stub/mod.rs
+++ b/components/someboot/src/efi_stub/mod.rs
@@ -1,6 +1,12 @@
 #[cfg(target_arch = "x86_64")]
 use core::arch::naked_asm;
-use core::{fmt::Write, ptr::null, sync::atomic::AtomicBool};
+use core::{
+    ffi::c_void,
+    fmt::Write,
+    mem::MaybeUninit,
+    ptr::{addr_of_mut, null},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 
 pub use uefi::Status;
 #[cfg(target_arch = "loongarch64")]
@@ -8,10 +14,9 @@ pub use uefi::runtime::ResetType;
 use uefi::{
     Result,
     boot::{self, MemoryDescriptor, MemoryType},
-    mem::memory_map::MemoryMap,
     prelude::*,
     proto::loaded_image::LoadedImage,
-    runtime::set_virtual_address_map,
+    runtime::{self, set_virtual_address_map},
     system::with_config_table,
     table::{self, cfg::ConfigTableEntry},
 };
@@ -23,8 +28,26 @@ use crate::{
     mem::{__io, __va},
 };
 
+const EFI_IMAGE_HANDLE_UNSET: usize = usize::MAX;
+const EXIT_BOOT_MEMORY_MAP_BUFFER_SIZE: usize = 128 * 1024;
+const EXIT_BOOT_MEMORY_MAP_DESCRIPTOR_CAPACITY: usize = 1024;
+const EXIT_BOOT_MEMORY_MAP_RETRIES: usize = 3;
+
+#[repr(align(8))]
+struct AlignedBytes<const N: usize>([u8; N]);
+
+static mut EXIT_BOOT_MEMORY_MAP_BUFFER: AlignedBytes<EXIT_BOOT_MEMORY_MAP_BUFFER_SIZE> =
+    AlignedBytes([0; EXIT_BOOT_MEMORY_MAP_BUFFER_SIZE]);
+static mut EXIT_BOOT_MEMORY_MAP_DESCRIPTORS: [MaybeUninit<MemoryDescriptor>;
+    EXIT_BOOT_MEMORY_MAP_DESCRIPTOR_CAPACITY] =
+    [const { MaybeUninit::uninit() }; EXIT_BOOT_MEMORY_MAP_DESCRIPTOR_CAPACITY];
+static EFI_IMAGE_HANDLE: AtomicUsize = AtomicUsize::new(EFI_IMAGE_HANDLE_UNSET);
+
 pub(crate) fn setup_service(system_table: *const ::core::ffi::c_void) {
     unsafe { table::set_system_table(system_table.cast()) };
+    if let Some(image_handle) = saved_image_handle() {
+        unsafe { boot::set_image_handle(image_handle) };
+    }
     setup_console();
     println!("UEFI console ok.");
     find_acpi_rsdp();
@@ -59,6 +82,7 @@ unsafe extern "C" fn efi_pe_entry_main(
     system_table: *const ::core::ffi::c_void,
 ) -> Status {
     unsafe {
+        save_image_handle(image_handle);
         boot::set_image_handle(image_handle);
         table::set_system_table(system_table.cast());
         setup_console();
@@ -89,8 +113,8 @@ pub unsafe extern "efiapi" fn efi_pe_entry(
 pub(crate) fn exit_boot_services() {
     println!("Exiting UEFI boot services...");
     UEFI_SERVICE_EXIT.store(true, core::sync::atomic::Ordering::Relaxed);
-    let mem_map = unsafe { boot::exit_boot_services(None) };
-    println!("Exited boot services, owned memory map obtained.");
+    let mem_map = unsafe { exit_boot_services_no_alloc() };
+    println!("Exited boot services, memory map obtained.");
 
     let mut new_map: heapless::Vec<MemoryDescriptor, 32> = heapless::Vec::new();
 
@@ -118,6 +142,125 @@ pub(crate) fn exit_boot_services() {
     }
 
     memmap::setup_memory_map(mem_map.entries());
+}
+
+struct ExitBootMemoryMap {
+    entries: &'static [MemoryDescriptor],
+}
+
+impl ExitBootMemoryMap {
+    fn entries(&self) -> core::slice::Iter<'static, MemoryDescriptor> {
+        self.entries.iter()
+    }
+}
+
+unsafe fn exit_boot_services_no_alloc() -> ExitBootMemoryMap {
+    let Some(system_table) = uefi::table::system_table_raw() else {
+        reset_on_exit_boot_services_failure(Status::INVALID_PARAMETER);
+    };
+    let boot_services = unsafe {
+        system_table
+            .as_ref()
+            .boot_services
+            .as_ref()
+            .unwrap_or_else(|| reset_on_exit_boot_services_failure(Status::INVALID_PARAMETER))
+    };
+    let Some(image_handle) = saved_image_handle() else {
+        reset_on_exit_boot_services_failure(Status::INVALID_PARAMETER);
+    };
+
+    let mut status = Status::SUCCESS;
+
+    for _ in 0..EXIT_BOOT_MEMORY_MAP_RETRIES {
+        let mut map_size = EXIT_BOOT_MEMORY_MAP_BUFFER_SIZE;
+        let mut map_key = 0;
+        let mut desc_size = 0;
+        let mut desc_version = 0;
+        let map_ptr =
+            unsafe { addr_of_mut!(EXIT_BOOT_MEMORY_MAP_BUFFER.0).cast::<MemoryDescriptor>() };
+
+        status = unsafe {
+            (boot_services.get_memory_map)(
+                &mut map_size,
+                map_ptr,
+                &mut map_key,
+                &mut desc_size,
+                &mut desc_version,
+            )
+        };
+        if status == Status::BUFFER_TOO_SMALL {
+            continue;
+        }
+        if status != Status::SUCCESS {
+            reset_on_exit_boot_services_failure(status);
+        }
+
+        status = unsafe { (boot_services.exit_boot_services)(image_handle.as_ptr(), map_key) };
+        if status == Status::SUCCESS {
+            let entries =
+                unsafe { copy_exit_boot_memory_map(map_ptr.cast_const(), map_size, desc_size) };
+            return ExitBootMemoryMap { entries };
+        }
+    }
+
+    reset_on_exit_boot_services_failure(status);
+}
+
+unsafe fn copy_exit_boot_memory_map(
+    src: *const MemoryDescriptor,
+    map_size: usize,
+    desc_size: usize,
+) -> &'static [MemoryDescriptor] {
+    assert!(
+        desc_size >= size_of::<MemoryDescriptor>(),
+        "UEFI memory descriptor size is too small"
+    );
+
+    let entry_count = map_size / desc_size;
+    assert!(
+        entry_count <= EXIT_BOOT_MEMORY_MAP_DESCRIPTOR_CAPACITY,
+        "UEFI memory map has too many entries"
+    );
+
+    let dst =
+        addr_of_mut!(EXIT_BOOT_MEMORY_MAP_DESCRIPTORS).cast::<MaybeUninit<MemoryDescriptor>>();
+    for index in 0..entry_count {
+        let entry = unsafe {
+            src.cast::<u8>()
+                .add(index * desc_size)
+                .cast::<MemoryDescriptor>()
+        };
+        unsafe { dst.add(index).write(MaybeUninit::new(entry.read())) };
+    }
+
+    unsafe { core::slice::from_raw_parts(dst.cast::<MemoryDescriptor>(), entry_count) }
+}
+
+fn save_image_handle(image_handle: Handle) {
+    EFI_IMAGE_HANDLE.store(image_handle.as_ptr() as usize, Ordering::Relaxed);
+}
+
+fn saved_image_handle() -> Option<Handle> {
+    let raw = EFI_IMAGE_HANDLE.load(Ordering::Relaxed);
+    if raw == EFI_IMAGE_HANDLE_UNSET {
+        return None;
+    }
+
+    unsafe { Handle::from_ptr(raw as *mut c_void) }
+}
+
+fn reset_on_exit_boot_services_failure(status: Status) -> ! {
+    unsafe {
+        if let Some(system_table) = uefi::table::system_table_raw()
+            && let Some(runtime_services) = system_table.as_ref().runtime_services.as_ref()
+        {
+            (runtime_services.reset_system)(runtime::ResetType::COLD, status, 0, null());
+        }
+    }
+
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 pub(crate) fn setup_console() {

--- a/components/someboot/src/lib.rs
+++ b/components/someboot/src/lib.rs
@@ -76,6 +76,9 @@ pub trait ArchTrait {
 
     fn post_allocator();
 
+    fn init_boot_tls() {}
+    fn init_runtime_percpu_reg(_cpu_idx: usize) {}
+
     fn per_cpu_trap_init(is_primary: bool);
     fn trap_addr() -> usize;
 
@@ -176,9 +179,9 @@ fn prime_entry() -> ! {
     }
 
     let entry = __someboot_main as *const () as usize;
-    let sp = crate::smp::cpu_meta(crate::smp::early_current_cpu_idx())
-        .unwrap()
-        .stack_top;
+    let cpu_idx = crate::smp::early_current_cpu_idx();
+    arch::Arch::init_runtime_percpu_reg(cpu_idx);
+    let sp = crate::smp::cpu_meta(cpu_idx).unwrap().stack_top;
     let sp = __percpu(sp);
     println!(
         "Jumping to main entry point at {:#x} with SP {:#p}",

--- a/docs/docs/build/build.md
+++ b/docs/docs/build/build.md
@@ -178,7 +178,7 @@ flowchart TD
     E --> F["注入 AX_CONFIG_PATH<br/>和 AX_PLATFORM 环境变量"]
 ```
 
-ArceOS 的平台配置（如内存布局、中断控制器地址、串口基地址等）由 `axbuild` 复用配置引擎库从平台包配置文件中合并生成 `.axconfig.toml`。在动态平台模式下（`plat_dyn = true`），这些配置由运行时动态加载；在静态模式下，必须在编译前预生成并注入 `AX_CONFIG_PATH` 环境变量，使得 OS 源码中的配置宏能在编译期读取配置。
+ArceOS 的平台配置（如内存布局、中断控制器地址、串口基地址等）由 `axbuild` 复用配置引擎库从平台包配置文件中合并生成 `.axconfig.toml`。动态平台模式是支持动态平台 target 的默认构建方式，配置可省略 `plat_dyn`；在静态模式下（`plat_dyn = false`），必须在编译前预生成并注入 `AX_CONFIG_PATH` 环境变量，使得 OS 源码中的配置宏能在编译期读取配置。
 
 ### 6a. 平台包解析
 
@@ -208,9 +208,9 @@ flowchart TD
 
 | 架构 | 默认平台包 |
 |------|-----------|
-| `aarch64` | 无静态默认平台；默认使用 `plat_dyn = true` |
-| `x86_64` | 无静态默认平台；默认使用 `plat_dyn = true` |
-| `riscv64` | 无静态默认平台；默认使用 `plat_dyn = true` |
+| `aarch64` | 无静态默认平台；默认使用动态平台 |
+| `x86_64` | 无静态默认平台；默认使用动态平台 |
+| `riscv64` | 无静态默认平台；默认使用动态平台 |
 | `loongarch64` | `ax-plat-loongarch64-qemu-virt` |
 
 **平台包命名规则**：

--- a/docs/docs/build/configuration.md
+++ b/docs/docs/build/configuration.md
@@ -64,7 +64,7 @@ flowchart TD
 
 除默认值差异外，各架构还有一些需要注意的特殊行为：
 
-- **plat_dyn**：`aarch64` 和 `riscv64` 支持 `plat_dyn = true`（动态平台加载），其他架构使用静态平台绑定
+- **plat_dyn**：省略时默认请求动态平台；`aarch64`、`x86_64`、`riscv64`、`loongarch64` 支持动态平台，只有显式写 `plat_dyn = false` 才请求静态平台绑定
 - **to_bin**：`x86_64` 不使用 `--bin`（直接生成 ELF 即可），其余架构默认将 ELF 转为 raw binary
 - **LoongArch QEMU**：运行 Axvisor loongarch64 时自动搜索 LVZ 版 QEMU（详见 [运行](./run#loongarch-特殊处理)）
 
@@ -77,9 +77,9 @@ flowchart TD
 | `aarch64` | `rootfs-aarch64-alpine.img` | 动态平台 | `aarch64-linux-musl` | `qemu-aarch64-static` |
 | `x86_64` | `rootfs-x86_64-alpine.img` | 动态平台 | `x86_64-linux-musl` | `qemu-x86_64-static` |
 | `riscv64` | `rootfs-riscv64-alpine.img` | 动态平台 | `riscv64-linux-musl` | `qemu-riscv64-static` |
-| `loongarch64` | `rootfs-loongarch64-alpine.img` | `loongarch64-qemu-virt` | `loongarch64-linux-musl` | `qemu-loongarch64-static` |
+| `loongarch64` | `rootfs-loongarch64-alpine.img` | 动态平台 | `loongarch64-linux-musl` | `qemu-loongarch64-static` |
 
-这些字段由 `CrossCompileSpec` 承载，被 StarryOS 和 Axvisor 的 C/Python 测试用例的 prebuild 环境和 CMake 交叉编译流程所使用。AArch64、RISC-V QEMU 和 x86_64 QEMU 默认不再绑定静态 StarryOS 平台，相关构建走动态平台路径。
+这些字段由 `CrossCompileSpec` 承载，被 StarryOS 和 Axvisor 的 C/Python 测试用例的 prebuild 环境和 CMake 交叉编译流程所使用。动态平台支持的 QEMU 构建默认不再绑定静态 StarryOS 平台；需要静态平台时，在构建配置中显式写 `plat_dyn = false`。
 
 ## Snapshot
 
@@ -104,7 +104,6 @@ Snapshot 机制解决了一个常见的工作流痛点：用户首次执行 `car
 package = "arceos-httpserver"
 arch = "aarch64"
 target = "aarch64-unknown-none-softfloat"
-plat_dyn = true
 
 [qemu]
 qemu_config = "test-suit/arceos/..."

--- a/docs/docs/development/arceos.md
+++ b/docs/docs/development/arceos.md
@@ -452,7 +452,6 @@ C 测试位于 `test-suit/arceos/c/`：helloworld, httpclient, memtest, pthread�
 features = ["ax-std"]
 log = "Warn"
 max_cpu_num = 4
-plat_dyn = true
 
 [env]
 AX_IP = "10.0.2.15"

--- a/docs/docs/development/axvisor.md
+++ b/docs/docs/development/axvisor.md
@@ -300,7 +300,6 @@ passthrough_devices = [["/"]]
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = ["ept-level-4", "ax-std/bus-mmio", "fs"]
 log = "Info"
-plat_dyn = true
 vm_configs = []   # 注意：默认为空，需手动指定或通过 setup_qemu.sh 生成
 ```
 

--- a/docs/docs/development/starryos.md
+++ b/docs/docs/development/starryos.md
@@ -438,7 +438,6 @@ features = [
   "ax-driver/virtio-net",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"
 ```
 

--- a/docs/starryos-self-compilation.md
+++ b/docs/starryos-self-compilation.md
@@ -213,7 +213,7 @@ cargo xtask starry test qemu --arch riscv64 --test-suite test-suit/starryos/self
 1. **`phys-memory-size` 硬编码 8GB**: 动态 RAM 检测因启动阶段地址空间不一致无法实现。标准 CI 测试使用默认内存配置，自编译需要 `-m 8G`。
 2. **自编译测试不在标准 CI 中运行**: 需要 8-12GB rootfs 镜像，仅支持本地手动测试。
 3. **SMP > 1 未验证**: ext4 `SpinNoPreempt` 死锁 workaround 为 SMP=1。x86_64 通过 KVM 加速弥补单核性能。
-4. **aarch64 引导已验证**: rootfs 准备 + 种子内核引导 + shell 可用均通过，完整编译因 TCG 模拟性能限制（预计 4-8h）未运行。需 `plat_dyn=true` + PIE 目标（`--config test-suit/starryos/qemu-smp1/build-aarch64-unknown-none-softfloat.toml`）。
+4. **aarch64 引导已验证**: rootfs 准备 + 种子内核引导 + shell 可用均通过，完整编译因 TCG 模拟性能限制（预计 4-8h）未运行。需动态平台默认配置 + PIE 目标（`--config test-suit/starryos/qemu-smp1/build-aarch64-unknown-none-softfloat.toml`）。
 5. **页面回收仅支持干净页**: 脏页在极端压力下作为最后手段回收（记录 warning），缺少脏页写回机制。
 
 ## 环境要求

--- a/os/StarryOS/configs/board/k230-canmv.toml
+++ b/os/StarryOS/configs/board/k230-canmv.toml
@@ -2,5 +2,4 @@ features = [
   "k230",
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
@@ -7,5 +7,4 @@ features = [
   "ax-driver/serial",
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/configs/board/orangepi-5-plus.toml
+++ b/os/StarryOS/configs/board/orangepi-5-plus.toml
@@ -14,4 +14,3 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 8
-plat_dyn = true

--- a/os/StarryOS/configs/board/qemu-aarch64.toml
+++ b/os/StarryOS/configs/board/qemu-aarch64.toml
@@ -9,5 +9,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/os/StarryOS/configs/board/qemu-loongarch64-uefi.toml
+++ b/os/StarryOS/configs/board/qemu-loongarch64-uefi.toml
@@ -1,0 +1,12 @@
+target = "loongarch64-unknown-none-softfloat"
+env = {}
+log = "Warn"
+features = [
+  "ax-hal/plat-dyn",
+  "axplat-dyn/efi",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/os/StarryOS/configs/board/qemu-riscv64.toml
+++ b/os/StarryOS/configs/board/qemu-riscv64.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/configs/board/qemu-x86_64.toml
+++ b/os/StarryOS/configs/board/qemu-x86_64.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/os/arceos/modules/axalloc/src/buddy_slab.rs
+++ b/os/arceos/modules/axalloc/src/buddy_slab.rs
@@ -45,14 +45,14 @@ impl<const PAGE_SIZE: usize> PercpuSlab<PAGE_SIZE> {
         }
     }
 
-    fn init(&mut self, cpu_id: usize) {
+    fn init_during_cpu_bringup(&mut self, cpu_id: usize) {
         let cpu_id = u16::try_from(cpu_id).expect("CPU id exceeds per-CPU slab range");
         assert!(
             self.cpu_id.is_none(),
             "per-CPU slab is already initialized on this CPU",
         );
         self.cpu_id = Some(cpu_id);
-        *self.inner.lock() = SlabAllocator::new();
+        *self.inner.get_mut() = SlabAllocator::new();
     }
 
     fn cpu_id_checked(&self) -> u16 {
@@ -374,12 +374,18 @@ pub fn global_allocator() -> &'static GlobalAllocator {
     &GLOBAL_ALLOCATOR
 }
 
-/// Initializes the per-CPU slab for the current CPU.
+/// Initializes the per-CPU slab for the current CPU during CPU bring-up.
 ///
 /// Must run after per-CPU storage is initialized and before scheduler, IPI, or
 /// IRQ paths can allocate on this CPU.
 pub fn init_percpu_slab(cpu_id: usize) {
-    PERCPU_SLAB.with_current(|slab| slab.init(cpu_id));
+    // Safety: while the CPU-local slab is still private to this CPU, initialize
+    // it directly instead of entering the runtime SpinNoIrq guard path.
+    unsafe {
+        PERCPU_SLAB
+            .current_ref_mut_raw()
+            .init_during_cpu_bringup(cpu_id)
+    };
 }
 
 /// Initializes the global allocator with the given memory region.

--- a/os/arceos/modules/axconfig/src/driver_dyn_config.rs
+++ b/os/arceos/modules/axconfig/src/driver_dyn_config.rs
@@ -38,8 +38,22 @@ mod arch {
     pub const KERNEL_BASE_VADDR: usize = 0xffff_8000_0000_0000;
 }
 
+#[cfg(target_arch = "loongarch64")]
+mod arch {
+    pub const ARCH: &str = "loongarch64";
+    pub const PACKAGE: &str = "axplat-dyn";
+    pub const PLATFORM: &str = "loongarch64-plat-dyn";
+    pub const TIMER_IRQ: usize = 11;
+    pub const IPI_IRQ: usize = 12;
+    pub const KERNEL_ASPACE_BASE: usize = 0x9000_0000_0000_0000;
+    pub const KERNEL_ASPACE_SIZE: usize = 0x0000_ffff_ffff_f000;
+    pub const KERNEL_BASE_PADDR: usize = 0x20_0000;
+    pub const KERNEL_BASE_VADDR: usize = 0x9000_0000_0020_0000;
+}
+
 #[cfg(not(any(
     target_arch = "aarch64",
+    target_arch = "loongarch64",
     target_arch = "riscv64",
     target_arch = "x86_64"
 )))]
@@ -135,5 +149,17 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     fn x86_64_dynamic_platform_uses_dedicated_ipi_vector() {
         assert_eq!(super::devices::IPI_IRQ, 0xf3);
+    }
+
+    #[test]
+    #[cfg(target_arch = "loongarch64")]
+    fn loongarch64_dynamic_platform_uses_arch_specific_config() {
+        assert_eq!(super::ARCH, "loongarch64");
+        assert_eq!(super::PACKAGE, "axplat-dyn");
+        assert_eq!(super::PLATFORM, "loongarch64-plat-dyn");
+        assert_eq!(super::devices::TIMER_IRQ, 11);
+        assert_eq!(super::devices::IPI_IRQ, 12);
+        assert_eq!(super::plat::KERNEL_ASPACE_BASE, 0x9000_0000_0000_0000);
+        assert_eq!(super::plat::KERNEL_BASE_VADDR, 0x9000_0000_0020_0000);
     }
 }

--- a/os/axvisor/configs/board/orangepi-5-plus.toml
+++ b/os/axvisor/configs/board/orangepi-5-plus.toml
@@ -5,6 +5,5 @@ features = [
   "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/phytiumpi.toml
+++ b/os/axvisor/configs/board/phytiumpi.toml
@@ -4,6 +4,5 @@ features = [
     "phytium-mci",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/qemu-aarch64.toml
+++ b/os/axvisor/configs/board/qemu-aarch64.toml
@@ -5,6 +5,5 @@ features = [
     "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/qemu-loongarch64.toml
+++ b/os/axvisor/configs/board/qemu-loongarch64.toml
@@ -8,5 +8,6 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
+plat_dyn = false
 target = "loongarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/qemu-riscv64.toml
+++ b/os/axvisor/configs/board/qemu-riscv64.toml
@@ -6,7 +6,6 @@ features = [
     "sstc"
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"
 vm_configs = []
 max_cpu_num = 4

--- a/os/axvisor/configs/board/qemu-x86_64-linux.toml
+++ b/os/axvisor/configs/board/qemu-x86_64-linux.toml
@@ -4,6 +4,5 @@ features = [
     "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = []

--- a/os/axvisor/configs/board/qemu-x86_64.toml
+++ b/os/axvisor/configs/board/qemu-x86_64.toml
@@ -5,6 +5,5 @@ features = [
     "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = []

--- a/os/axvisor/configs/board/rdk-s100.toml
+++ b/os/axvisor/configs/board/rdk-s100.toml
@@ -3,6 +3,5 @@ features = [
     "ept-level-4",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/roc-rk3568-pc.toml
+++ b/os/axvisor/configs/board/roc-rk3568-pc.toml
@@ -4,6 +4,5 @@ features = [
     "rockchip-sdhci",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/tac-e400.toml
+++ b/os/axvisor/configs/board/tac-e400.toml
@@ -3,6 +3,5 @@ features = [
     "ept-level-4",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/platforms/axplat-dyn/src/boot.rs
+++ b/platforms/axplat-dyn/src/boot.rs
@@ -11,25 +11,34 @@ fn main() -> ! {
         args = fdt;
     }
 
-    ax_plat::call_main(somehal::smp::early_current_cpu_idx(), args)
+    let cpu_idx = somehal::smp::early_current_cpu_idx();
+    ax_percpu::init_percpu_reg(cpu_idx);
+    ax_plat::call_main(cpu_idx, args)
 }
 
 #[somehal::secondary_entry]
 fn secondary_main() {
     #[cfg(feature = "smp")]
-    ax_plat::call_secondary_main(meta.cpu_idx);
+    {
+        ax_percpu::init_percpu_reg(meta.cpu_idx);
+        ax_plat::call_secondary_main(meta.cpu_idx);
+    }
 }
 
-pub fn boot_stack_bounds(cpu_id: usize) -> (VirtAddr, usize) {
-    let meta = somehal::smp::cpu_meta(cpu_id)
-        .unwrap_or_else(|| panic!("missing somehal PerCpuMeta for cpu_id {cpu_id}"));
+pub fn boot_stack_bounds(cpu_idx: usize) -> (VirtAddr, usize) {
+    let meta = somehal::smp::cpu_meta(cpu_idx)
+        .unwrap_or_else(|| panic!("missing somehal PerCpuMeta for cpu_idx {cpu_idx}"));
     let stack_size = somehal::mem::stack_size();
     (VirtAddr::from(meta.stack_top_virt - stack_size), stack_size)
 }
 
 pub struct Kernel;
 
-impl KernelOp for Kernel {}
+impl KernelOp for Kernel {
+    fn current_cpu_idx(&self) -> Option<usize> {
+        Some(ax_plat::percpu::this_cpu_id())
+    }
+}
 
 impl MmioOp for Kernel {
     fn ioremap(&self, addr: MmioAddr, size: usize) -> Result<MmioRaw, MapError> {

--- a/platforms/axplat-dyn/src/init.rs
+++ b/platforms/axplat-dyn/src/init.rs
@@ -10,8 +10,6 @@ impl InitIf for InitIfImpl {
     /// and performed earliest platform configuration and initialization (e.g.,
     /// early console, clocking).
     fn init_early(_cpu_id: usize, _dtb: usize) {
-        #[cfg(target_arch = "riscv64")]
-        somehal::arch::register_current_cpu_id(_cpu_id, ax_plat::percpu::this_cpu_id);
         ax_cpu::init::init_trap();
         #[cfg(all(target_arch = "aarch64", feature = "fp-simd"))]
         {
@@ -24,8 +22,6 @@ impl InitIf for InitIfImpl {
     /// Initializes the platform at the early stage for secondary cores.
     #[cfg(feature = "smp")]
     fn init_early_secondary(_cpu_id: usize) {
-        #[cfg(target_arch = "riscv64")]
-        somehal::arch::register_current_cpu_id(_cpu_id, ax_plat::percpu::this_cpu_id);
         ax_cpu::init::init_trap();
         #[cfg(all(target_arch = "aarch64", feature = "fp-simd"))]
         {

--- a/platforms/somehal/Cargo.toml
+++ b/platforms/somehal/Cargo.toml
@@ -41,6 +41,9 @@ ax-riscv-plic = { workspace = true }
 riscv.workspace = true
 sbi-rt = { workspace = true, features = ["legacy"] }
 
+[target.'cfg(target_arch = "loongarch64")'.dependencies]
+loongArch64 = "0.2"
+
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x2apic = "0.5"
 x86 = "0.52"

--- a/platforms/somehal/src/arch/aarch64/gic/mod.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/mod.rs
@@ -29,12 +29,18 @@ fn backend() -> GicBackend {
 }
 
 pub fn init_current_cpu() {
+    let cpu_idx = crate::cpu::current_cpu_idx()
+        .unwrap_or_else(|| panic!("current logical CPU index is not available for GIC init"));
+    init_cpu(cpu_idx);
+}
+
+pub fn init_cpu(cpu_idx: usize) {
     match backend() {
         GicBackend::V2 => v2::init_cpu(),
-        GicBackend::V3 => v3::init_cpu(),
+        GicBackend::V3 => v3::init_cpu(cpu_idx),
         GicBackend::None => {
             if v3::is_support_icc() {
-                v3::init_cpu();
+                v3::init_cpu(cpu_idx);
             } else {
                 v2::init_cpu();
             }
@@ -73,8 +79,8 @@ pub fn send_ipi(irq: rdrive::IrqId, target: crate::irq::IpiTarget) {
     }
 }
 
-fn hardware_cpu_id(cpu_id: usize) -> usize {
-    someboot::smp::cpu_idx_to_id(cpu_id).unwrap_or(cpu_id)
+fn hardware_cpu_id(cpu_idx: usize) -> usize {
+    someboot::smp::cpu_idx_to_id(cpu_idx).unwrap_or(cpu_idx)
 }
 
 #[unsafe(no_mangle)]

--- a/platforms/somehal/src/arch/aarch64/gic/v3.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/v3.rs
@@ -27,19 +27,19 @@ impl CpuInterfaceSlot {
         }
     }
 
-    unsafe fn set(&self, cpu_id: usize, cpu_if: CpuInterface) {
+    unsafe fn set(&self, cpu_idx: usize, cpu_if: CpuInterface) {
         let slot = unsafe { &mut *self.inner.get() };
         assert!(
             slot.is_none(),
-            "GICv3 CPU interface for CPU {cpu_id} is already initialized"
+            "GICv3 CPU interface for CPU index {cpu_idx} is already initialized"
         );
         *slot = Some(cpu_if);
     }
 
-    unsafe fn get(&self, cpu_id: usize) -> &CpuInterface {
-        unsafe { &*self.inner.get() }
-            .as_ref()
-            .unwrap_or_else(|| panic!("GICv3 CPU interface for CPU {cpu_id} is not initialized"))
+    unsafe fn get(&self, cpu_idx: usize) -> &CpuInterface {
+        unsafe { &*self.inner.get() }.as_ref().unwrap_or_else(|| {
+            panic!("GICv3 CPU interface for CPU index {cpu_idx} is not initialized")
+        })
     }
 }
 
@@ -86,7 +86,9 @@ fn probe_gic(info: FdtInfo<'_>, dev: PlatformDevice) -> Result<(), OnProbeError>
     super::set_backend(super::GicBackend::V3);
 
     init_cpu_interface_map();
-    init_cpu_interface(&gic, 0);
+    let cpu_idx =
+        crate::cpu::current_cpu_idx().unwrap_or_else(someboot::smp::early_current_cpu_idx);
+    init_cpu_interface(&gic, cpu_idx);
 
     dev.register(rdif_intc::Intc::new(gic));
 
@@ -125,8 +127,8 @@ pub fn send_ipi(raw: usize, target: crate::irq::IpiTarget) {
     let sgi = IntId::sgi(raw as u32);
     let target = match target {
         crate::irq::IpiTarget::Current { cpu_id: _ } => SGITarget::current(),
-        crate::irq::IpiTarget::Other { cpu_id } => {
-            SGITarget::list([affinity_from_mpidr(super::hardware_cpu_id(cpu_id))])
+        crate::irq::IpiTarget::Other { cpu_id: cpu_idx } => {
+            SGITarget::list([affinity_from_mpidr(super::hardware_cpu_id(cpu_idx))])
         }
         crate::irq::IpiTarget::AllExceptCurrent { .. } => SGITarget::All,
     };
@@ -142,22 +144,21 @@ fn affinity_from_mpidr(mpidr: usize) -> Affinity {
     }
 }
 
-pub fn init_cpu() {
-    let cpu_id = someboot::smp::early_current_cpu_idx();
-    with_gic(|gic| init_cpu_interface(gic, cpu_id));
+pub fn init_cpu(cpu_idx: usize) {
+    with_gic(|gic| init_cpu_interface(gic, cpu_idx));
 
     debug!("GICCv3 initialized");
 }
 
 fn init_cpu_interface_map() {
     let mut cpu_if = BTreeMap::new();
-    for cpu_id in 0..someboot::smp::cpu_count() {
-        cpu_if.insert(cpu_id, CpuInterfaceSlot::empty());
+    for cpu_idx in 0..someboot::smp::cpu_count() {
+        cpu_if.insert(cpu_idx, CpuInterfaceSlot::empty());
     }
     CPU_IF.init(cpu_if);
 }
 
-fn init_cpu_interface(gic: &Gic, cpu_id: usize) {
+fn init_cpu_interface(gic: &Gic, cpu_idx: usize) {
     let mut cpu = gic.cpu_interface();
     cpu.init_current_cpu().unwrap();
     #[cfg(feature = "hv")]
@@ -165,18 +166,19 @@ fn init_cpu_interface(gic: &Gic, cpu_id: usize) {
 
     // SAFETY: CPU_IF was preallocated during BSP probe. Each CPU initializes
     // only its own logical CPU slot before it can send SGIs through that slot.
-    unsafe { cpu_interface_slot(cpu_id).set(cpu_id, cpu) };
+    unsafe { cpu_interface_slot(cpu_idx).set(cpu_idx, cpu) };
 }
 
 fn current_cpu_interface() -> &'static CpuInterface {
-    let cpu_id = someboot::smp::early_current_cpu_idx();
+    let cpu_idx = crate::cpu::current_cpu_idx()
+        .unwrap_or_else(|| panic!("current logical CPU index is not available for GICv3 SGI"));
     // SAFETY: send_ipi is only valid after the current CPU has completed
     // interrupt-controller initialization and stored its CpuInterface.
-    unsafe { cpu_interface_slot(cpu_id).get(cpu_id) }
+    unsafe { cpu_interface_slot(cpu_idx).get(cpu_idx) }
 }
 
-fn cpu_interface_slot(cpu_id: usize) -> &'static CpuInterfaceSlot {
+fn cpu_interface_slot(cpu_idx: usize) -> &'static CpuInterfaceSlot {
     CPU_IF
-        .get(&cpu_id)
-        .unwrap_or_else(|| panic!("GICv3 CPU interface slot for CPU {cpu_id} is not registered"))
+        .get(&cpu_idx)
+        .unwrap_or_else(|| panic!("GICv3 CPU interface slot for CPU {cpu_idx} is not registered"))
 }

--- a/platforms/somehal/src/arch/aarch64/mod.rs
+++ b/platforms/somehal/src/arch/aarch64/mod.rs
@@ -24,8 +24,8 @@ impl PlatOp for Plat {
 
     fn secondary_init() {}
 
-    fn secondary_init_intc(_cpu_idx: usize) {
-        gic::init_current_cpu();
+    fn secondary_init_intc(cpu_idx: usize) {
+        gic::init_cpu(cpu_idx);
     }
 
     fn secondary_init_systick() {

--- a/platforms/somehal/src/arch/loongarch64/eiointc.rs
+++ b/platforms/somehal/src/arch/loongarch64/eiointc.rs
@@ -1,0 +1,188 @@
+use loongArch64::iocsr::{iocsr_read_d, iocsr_write_d, iocsr_write_w};
+use rdif_intc::Interface;
+use rdrive::{
+    DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
+};
+
+use super::irq_common::{EIOINTC_VECTOR_COUNT, eiointc_reg_bit, fdt_first_cell_vector};
+
+const EIOINTC_IRQ: usize = 3;
+
+const LOONGARCH_IOCSR_MISC_FUNC: usize = 0x420;
+const IOCSR_MISC_FUNC_EXT_IOI_EN: u64 = 1 << 48;
+
+const EIOINTC_REG_NODEMAP: usize = 0x14a0;
+const EIOINTC_REG_IPMAP: usize = 0x14c0;
+const EIOINTC_REG_ENABLE: usize = 0x1600;
+const EIOINTC_REG_BOUNCE: usize = 0x1680;
+const EIOINTC_REG_ISR: usize = 0x1800;
+const EIOINTC_REG_ROUTE: usize = 0x1c00;
+
+const VEC_COUNT_PER_REG: usize = 64;
+
+module_driver!(
+    name: "Loongson EIOINTC",
+    level: ProbeLevel::PreKernel,
+    priority: ProbePriority::INTC,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &[
+            "loongson,ls2k2000-eiointc",
+            "loongson,ls3a5000-eiointc",
+            "loongson,eiointc",
+        ],
+        on_probe: probe_eiointc
+    }],
+);
+
+pub fn set_irq_enable(irq: usize, enable: bool) {
+    with_eiointc("setting EIOINTC IRQ enable", |intc| {
+        if enable {
+            intc.enable_irq(irq);
+        } else {
+            intc.disable_irq(irq);
+        }
+    });
+}
+
+pub fn claim_irq() -> Option<usize> {
+    with_eiointc("claiming EIOINTC IRQ", |intc| intc.claim_irq()).flatten()
+}
+
+pub fn complete_irq(irq: usize) {
+    with_eiointc("completing EIOINTC IRQ", |intc| intc.complete_irq(irq));
+}
+
+fn probe_eiointc(_info: FdtInfo<'_>, dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let intc = EioIntc::new(EIOINTC_VECTOR_COUNT);
+    intc.init();
+    someboot::irq::irq_set_enable(someboot::irq::IrqId::new(EIOINTC_IRQ), true);
+    dev.register(rdif_intc::Intc::new(intc));
+    Ok(())
+}
+
+fn with_eiointc<R>(op: &str, f: impl FnOnce(&mut EioIntc) -> R) -> Option<R> {
+    if !rdrive::is_initialized() {
+        return None;
+    }
+
+    for intc in rdrive::get_list::<rdif_intc::Intc>() {
+        let Ok(intc) = intc.downcast::<EioIntc>() else {
+            continue;
+        };
+        let Ok(mut intc) = intc.try_lock() else {
+            warn!("failed to lock Loongson EIOINTC when {op}");
+            return None;
+        };
+        return Some(f(&mut intc));
+    }
+
+    warn!("Loongson EIOINTC is not registered when {op}");
+    None
+}
+
+struct EioIntc {
+    vectors: usize,
+}
+
+impl EioIntc {
+    const fn new(vectors: usize) -> Self {
+        Self { vectors }
+    }
+
+    fn init(&self) {
+        let misc = iocsr_read_d(LOONGARCH_IOCSR_MISC_FUNC);
+        iocsr_write_d(LOONGARCH_IOCSR_MISC_FUNC, misc | IOCSR_MISC_FUNC_EXT_IOI_EN);
+
+        let index = 0;
+
+        for i in 0..(self.vectors / 32) {
+            let data = ((1 << (i * 2 + 1)) << 16) | (1 << (i * 2));
+            iocsr_write_w(EIOINTC_REG_NODEMAP + i * 4, data);
+        }
+        for i in 0..(self.vectors / 32 / 4) {
+            let bit = 1 << (1 + index);
+            let data = bit | (bit << 8) | (bit << 16) | (bit << 24);
+            iocsr_write_w(EIOINTC_REG_IPMAP + i * 4, data);
+        }
+        for i in 0..(self.vectors / 4) {
+            let bit = 1;
+            let data = bit | (bit << 8) | (bit << 16) | (bit << 24);
+            iocsr_write_w(EIOINTC_REG_ROUTE + i * 4, data);
+        }
+        for i in 0..(self.vectors / 32) {
+            iocsr_write_w(EIOINTC_REG_BOUNCE + i * 4, u32::MAX);
+        }
+    }
+
+    fn enable_irq(&mut self, irq: usize) {
+        if !self.contains_irq(irq, "enable") {
+            return;
+        }
+
+        let (offset, bit) = eiointc_reg_bit(irq);
+        for base in [EIOINTC_REG_ENABLE, EIOINTC_REG_BOUNCE] {
+            let addr = base + offset;
+            iocsr_write_d(addr, iocsr_read_d(addr) | bit);
+        }
+    }
+
+    fn disable_irq(&mut self, irq: usize) {
+        if !self.contains_irq(irq, "disable") {
+            return;
+        }
+
+        let (offset, bit) = eiointc_reg_bit(irq);
+        let addr = EIOINTC_REG_ENABLE + offset;
+        iocsr_write_d(addr, iocsr_read_d(addr) & !bit);
+    }
+
+    fn claim_irq(&mut self) -> Option<usize> {
+        for i in 0..(self.vectors / VEC_COUNT_PER_REG) {
+            let flags = iocsr_read_d(EIOINTC_REG_ISR + i * 8);
+            if flags != 0 {
+                return Some(flags.trailing_zeros() as usize + VEC_COUNT_PER_REG * i);
+            }
+        }
+        None
+    }
+
+    fn complete_irq(&mut self, irq: usize) {
+        if !self.contains_irq(irq, "complete") {
+            return;
+        }
+
+        let (offset, bit) = eiointc_reg_bit(irq);
+        iocsr_write_d(EIOINTC_REG_ISR + offset, bit);
+    }
+
+    fn contains_irq(&self, irq: usize, op: &str) -> bool {
+        if irq < self.vectors {
+            true
+        } else {
+            warn!("skip {op} for out-of-range EIOINTC IRQ {irq}");
+            false
+        }
+    }
+}
+
+impl DriverGeneric for EioIntc {
+    fn name(&self) -> &str {
+        "Loongson EIOINTC"
+    }
+}
+
+impl Interface for EioIntc {
+    fn setup_irq_by_fdt(&mut self, irq_prop: &[u32]) -> rdrive::IrqId {
+        let Some(vector) = fdt_first_cell_vector(irq_prop) else {
+            warn!("empty EIOINTC interrupt specifier");
+            return 0usize.into();
+        };
+        if vector >= self.vectors {
+            warn!(
+                "EIOINTC interrupt vector {vector} exceeds vector count {}",
+                self.vectors
+            );
+        }
+        vector.into()
+    }
+}

--- a/platforms/somehal/src/arch/loongarch64/irq_common.rs
+++ b/platforms/somehal/src/arch/loongarch64/irq_common.rs
@@ -1,0 +1,46 @@
+pub const EIOINTC_VECTOR_COUNT: usize = 256;
+pub const PCH_PIC_VECTOR_COUNT: usize = 64;
+
+pub fn fdt_first_cell_vector(irq_prop: &[u32]) -> Option<usize> {
+    irq_prop.first().copied().map(|vector| vector as usize)
+}
+
+pub fn eiointc_reg_bit(irq: usize) -> (usize, u64) {
+    (irq / 64 * 8, 1u64 << (irq % 64))
+}
+
+pub fn pch_pic_reg_bit(irq: usize) -> (usize, u32) {
+    (irq / 32 * 4, 1u32 << (irq % 32))
+}
+
+#[cfg(all(test, any(unix, windows)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fdt_first_cell_vector_uses_first_specifier_cell() {
+        assert_eq!(fdt_first_cell_vector(&[0x2a]), Some(0x2a));
+        assert_eq!(fdt_first_cell_vector(&[0x11, 0x1]), Some(0x11));
+    }
+
+    #[test]
+    fn fdt_first_cell_vector_rejects_empty_specifier() {
+        assert_eq!(fdt_first_cell_vector(&[]), None);
+    }
+
+    #[test]
+    fn eiointc_reg_bit_splits_64_bit_registers() {
+        assert_eq!(eiointc_reg_bit(0), (0, 1));
+        assert_eq!(eiointc_reg_bit(63), (0, 1u64 << 63));
+        assert_eq!(eiointc_reg_bit(64), (8, 1));
+        assert_eq!(eiointc_reg_bit(255), (24, 1u64 << 63));
+    }
+
+    #[test]
+    fn pch_pic_reg_bit_splits_32_bit_registers() {
+        assert_eq!(pch_pic_reg_bit(0), (0, 1));
+        assert_eq!(pch_pic_reg_bit(31), (0, 1u32 << 31));
+        assert_eq!(pch_pic_reg_bit(32), (4, 1));
+        assert_eq!(pch_pic_reg_bit(63), (4, 1u32 << 31));
+    }
+}

--- a/platforms/somehal/src/arch/loongarch64/mod.rs
+++ b/platforms/somehal/src/arch/loongarch64/mod.rs
@@ -1,12 +1,117 @@
-use crate::common::PlatOp;
+use loongArch64::iocsr::{iocsr_read_w, iocsr_write_w};
+
+use crate::{common::PlatOp, irq::_handle_irq};
+
+mod eiointc;
+mod irq_common;
+mod pch_pic;
 
 pub struct Plat;
 
+const IOCSR_IPI_SEND_CPU_SHIFT: u32 = 16;
+const IOCSR_IPI_SEND_BLOCKING: u32 = 1 << 31;
+
+const IOCSR_IPI_STATUS: usize = 0x1000;
+const IOCSR_IPI_ENABLE: usize = 0x1004;
+const IOCSR_IPI_CLEAR: usize = 0x100c;
+const IOCSR_IPI_SEND: usize = 0x1040;
+
+const EIOINTC_IRQ: usize = 3;
+const IPI_IRQ: usize = 12;
+const IPI_VECTOR: u32 = 0;
+
+fn make_ipi_send_value(cpu_id: usize, vector: u32, blocking: bool) -> u32 {
+    let mut value = (cpu_id as u32) << IOCSR_IPI_SEND_CPU_SHIFT | vector;
+    if blocking {
+        value |= IOCSR_IPI_SEND_BLOCKING;
+    }
+    value
+}
+
+fn ack_pending_ipi() -> u32 {
+    let status = iocsr_read_w(IOCSR_IPI_STATUS);
+    if status != 0 {
+        iocsr_write_w(IOCSR_IPI_CLEAR, status);
+        trace!("IPI status = {status:#x}");
+    }
+    status
+}
+
 impl PlatOp for Plat {
-    fn irq_set_enable(_irq: rdrive::IrqId, _enable: bool) {}
+    fn irq_set_enable(irq: rdrive::IrqId, enable: bool) {
+        let raw = irq.raw();
+
+        if raw == someboot::irq::systimer_irq().raw() {
+            someboot::irq::irq_set_enable(someboot::irq::IrqId::new(raw), enable);
+            return;
+        }
+
+        if raw == IPI_IRQ {
+            let value = if enable { u32::MAX } else { 0 };
+            iocsr_write_w(IOCSR_IPI_ENABLE, value);
+            someboot::irq::irq_set_enable(someboot::irq::IrqId::new(raw), enable);
+            return;
+        }
+
+        eiointc::set_irq_enable(raw, enable);
+        pch_pic::set_irq_enable(raw, enable);
+    }
+
+    fn send_ipi(_irq: rdrive::IrqId, target: crate::irq::IpiTarget) {
+        match target {
+            crate::irq::IpiTarget::Current { cpu_id } | crate::irq::IpiTarget::Other { cpu_id } => {
+                Self::send_ipi_to_cpu(cpu_id);
+            }
+            crate::irq::IpiTarget::AllExceptCurrent { cpu_id, cpu_num } => {
+                for target_cpu in 0..cpu_num {
+                    if target_cpu != cpu_id {
+                        Self::send_ipi_to_cpu(target_cpu);
+                    }
+                }
+            }
+        }
+    }
 
     fn irq_handler() -> someboot::irq::IrqId {
-        todo!()
+        someboot::irq::systimer_irq()
+    }
+
+    fn irq_handler_with_raw(raw: usize) -> Option<someboot::irq::IrqId> {
+        let irq = match raw {
+            raw if raw == someboot::irq::systimer_irq().raw() => {
+                let irq = someboot::irq::IrqId::new(raw);
+                _handle_irq(raw.into());
+                someboot::timer::ack();
+                irq
+            }
+            IPI_IRQ => {
+                let mut status = ack_pending_ipi();
+                let irq = someboot::irq::IrqId::new(raw);
+                while status != 0 {
+                    let ipi_bit = status.trailing_zeros();
+                    status &= !(1 << ipi_bit);
+                    _handle_irq(raw.into());
+                }
+                irq
+            }
+            EIOINTC_IRQ => {
+                let Some(external) = eiointc::claim_irq() else {
+                    debug!("Spurious LoongArch EIOINTC interrupt");
+                    return None;
+                };
+                let irq = someboot::irq::IrqId::new(external);
+                _handle_irq(external.into());
+                eiointc::complete_irq(external);
+                irq
+            }
+            external => {
+                let irq = someboot::irq::IrqId::new(external);
+                _handle_irq(external.into());
+                irq
+            }
+        };
+
+        Some(irq)
     }
 
     fn systick_irq() -> rdrive::IrqId {
@@ -18,4 +123,11 @@ impl PlatOp for Plat {
     fn secondary_init_intc(_cpu_idx: usize) {}
 
     fn secondary_init_systick() {}
+
+    fn send_ipi_to_cpu(cpu_id: usize) {
+        iocsr_write_w(
+            IOCSR_IPI_SEND,
+            make_ipi_send_value(cpu_id, IPI_VECTOR, false),
+        );
+    }
 }

--- a/platforms/somehal/src/arch/loongarch64/pch_pic.rs
+++ b/platforms/somehal/src/arch/loongarch64/pch_pic.rs
@@ -1,0 +1,186 @@
+use rdif_intc::Interface;
+use rdrive::{
+    DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
+};
+
+use super::irq_common::{PCH_PIC_VECTOR_COUNT, fdt_first_cell_vector, pch_pic_reg_bit};
+use crate::{common::ioremap, setup::MmioRaw};
+
+const DEFAULT_PCH_PIC_SIZE: usize = 0x400;
+
+const PCH_PIC_MASK: usize = 0x20;
+const PCH_PIC_EDGE: usize = 0x60;
+const PCH_PIC_POL: usize = 0x3e0;
+const PCH_INT_HTVEC: usize = 0x200;
+
+module_driver!(
+    name: "Loongson PCH-PIC",
+    level: ProbeLevel::PreKernel,
+    priority: ProbePriority::INTC,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &[
+            "loongson,ls7a-pch-pic",
+            "loongson,pch-pic-1.0",
+            "loongson,pch-pic",
+        ],
+        on_probe: probe_pch_pic
+    }],
+);
+
+pub fn set_irq_enable(irq: usize, enable: bool) {
+    with_pch_pic("setting PCH-PIC IRQ enable", |pic| {
+        if enable {
+            pic.enable_irq(irq);
+        } else {
+            pic.disable_irq(irq);
+        }
+    });
+}
+
+fn probe_pch_pic(info: FdtInfo<'_>, dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let reg = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or_else(|| OnProbeError::other(format!("[{}] has no reg", info.node.name())))?;
+    let base_vector = info
+        .node
+        .as_node()
+        .get_property("loongson,pic-base-vec")
+        .and_then(|prop| prop.get_u32())
+        .unwrap_or(0) as usize;
+    let vector_count = info
+        .node
+        .as_node()
+        .get_property("loongson,pic-num-vecs")
+        .and_then(|prop| prop.get_u32())
+        .unwrap_or(PCH_PIC_VECTOR_COUNT as u32) as usize;
+    let mmio = ioremap(
+        reg.address,
+        reg.size.unwrap_or(DEFAULT_PCH_PIC_SIZE as u64) as usize,
+    )
+    .map_err(|err| OnProbeError::other(format!("failed to map PCH-PIC: {err:?}")))?;
+
+    let pic = PchPic::new(mmio, base_vector, vector_count);
+    pic.init();
+    dev.register(rdif_intc::Intc::new(pic));
+    Ok(())
+}
+
+fn with_pch_pic<R>(op: &str, f: impl FnOnce(&mut PchPic) -> R) -> Option<R> {
+    if !rdrive::is_initialized() {
+        return None;
+    }
+
+    for intc in rdrive::get_list::<rdif_intc::Intc>() {
+        let Ok(intc) = intc.downcast::<PchPic>() else {
+            continue;
+        };
+        let Ok(mut intc) = intc.try_lock() else {
+            warn!("failed to lock Loongson PCH-PIC when {op}");
+            return None;
+        };
+        return Some(f(&mut intc));
+    }
+
+    warn!("Loongson PCH-PIC is not registered when {op}");
+    None
+}
+
+struct PchPic {
+    mmio: MmioRaw,
+    base_vector: usize,
+    vector_count: usize,
+}
+
+impl PchPic {
+    fn new(mmio: MmioRaw, base_vector: usize, vector_count: usize) -> Self {
+        Self {
+            mmio,
+            base_vector,
+            vector_count,
+        }
+    }
+
+    fn init(&self) {
+        self.write_w(PCH_PIC_EDGE, 0);
+        self.write_w(PCH_PIC_EDGE + 4, 0);
+        self.write_w(PCH_PIC_POL, 0);
+        self.write_w(PCH_PIC_POL + 4, 0);
+    }
+
+    fn enable_irq(&mut self, irq: usize) {
+        let Some(input) = self.input_for_vector(irq, "enable") else {
+            return;
+        };
+        let (offset, bit) = pch_pic_reg_bit(input);
+
+        let addr = PCH_PIC_MASK + offset;
+        self.write_w(addr, self.read_w(addr) & !bit);
+        self.write_b(PCH_INT_HTVEC + input, irq as u8);
+    }
+
+    fn disable_irq(&mut self, irq: usize) {
+        let Some(input) = self.input_for_vector(irq, "disable") else {
+            return;
+        };
+        let (offset, bit) = pch_pic_reg_bit(input);
+        let addr = PCH_PIC_MASK + offset;
+        self.write_w(addr, self.read_w(addr) | bit);
+    }
+
+    fn input_for_vector(&self, vector: usize, op: &str) -> Option<usize> {
+        let Some(input) = vector.checked_sub(self.base_vector) else {
+            warn!(
+                "skip {op} for PCH-PIC vector {vector} below base {}",
+                self.base_vector
+            );
+            return None;
+        };
+
+        if input < self.vector_count {
+            Some(input)
+        } else {
+            warn!(
+                "skip {op} for out-of-range PCH-PIC vector {vector}, base {}, count {}",
+                self.base_vector, self.vector_count
+            );
+            None
+        }
+    }
+
+    fn read_w(&self, offset: usize) -> u32 {
+        self.mmio.read(offset)
+    }
+
+    fn write_w(&self, offset: usize, value: u32) {
+        self.mmio.write(offset, value);
+    }
+
+    fn write_b(&self, offset: usize, value: u8) {
+        self.mmio.write(offset, value);
+    }
+}
+
+impl DriverGeneric for PchPic {
+    fn name(&self) -> &str {
+        "Loongson PCH-PIC"
+    }
+}
+
+impl Interface for PchPic {
+    fn setup_irq_by_fdt(&mut self, irq_prop: &[u32]) -> rdrive::IrqId {
+        let Some(input) = fdt_first_cell_vector(irq_prop) else {
+            warn!("empty PCH-PIC interrupt specifier");
+            return self.base_vector.into();
+        };
+        if input >= self.vector_count {
+            warn!(
+                "PCH-PIC interrupt input {input} exceeds vector count {}",
+                self.vector_count
+            );
+        }
+        (self.base_vector + input).into()
+    }
+}

--- a/platforms/somehal/src/arch/riscv64/mod.rs
+++ b/platforms/somehal/src/arch/riscv64/mod.rs
@@ -4,10 +4,6 @@ mod plic;
 
 pub struct Plat;
 
-pub fn register_current_cpu_id(cpu_idx: usize, reader: fn() -> usize) {
-    plic::register_current_cpu_id(cpu_idx, reader);
-}
-
 pub(crate) fn claim_external_irq() -> Option<someboot::irq::IrqId> {
     plic::claim_external_irq()
 }

--- a/platforms/somehal/src/arch/riscv64/plic.rs
+++ b/platforms/somehal/src/arch/riscv64/plic.rs
@@ -1,9 +1,5 @@
 use alloc::{format, vec::Vec};
-use core::{
-    num::NonZeroU32,
-    ptr::NonNull,
-    sync::atomic::{AtomicPtr, Ordering},
-};
+use core::{num::NonZeroU32, ptr::NonNull};
 
 use ax_riscv_plic::{PLICRegs, Plic, PlicIrqHandler};
 use kernutil::StaticCell;
@@ -27,7 +23,6 @@ const DEFAULT_PRIORITY: u32 = 1;
 const DEFAULT_PLIC_SIZE: usize = 0x400_0000;
 
 static IRQ_HANDLER: StaticCell<RiscvPlicIrqHandler> = StaticCell::uninit();
-static CURRENT_CPU_ID: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
 
 module_driver!(
     name: "RISC-V PLIC",
@@ -45,10 +40,6 @@ module_driver!(
 
 pub fn systick_irq() -> rdrive::IrqId {
     S_TIMER.into()
-}
-
-pub fn register_current_cpu_id(_cpu_idx: usize, reader: fn() -> usize) {
-    CURRENT_CPU_ID.store(reader as *mut (), Ordering::Release);
 }
 
 pub fn irq_set_enable(irq: rdrive::IrqId, enable: bool) {
@@ -368,22 +359,12 @@ impl RiscvPlic {
 }
 
 fn current_context(context_by_cpu: &[Option<usize>]) -> Option<usize> {
-    let cpu_idx = current_cpu_idx()?;
+    let cpu_idx = crate::cpu::current_cpu_idx()?;
     context_by_cpu.get(cpu_idx).and_then(|ctx| *ctx)
 }
 
-fn current_cpu_idx() -> Option<usize> {
-    let reader = CURRENT_CPU_ID.load(Ordering::Acquire);
-    if !reader.is_null() {
-        let reader = unsafe { core::mem::transmute::<*mut (), fn() -> usize>(reader) };
-        return Some(reader());
-    }
-
-    someboot::smp::try_early_cpu_idx()
-}
-
 fn warn_missing_current_context() {
-    if let Some(cpu_idx) = current_cpu_idx() {
+    if let Some(cpu_idx) = crate::cpu::current_cpu_idx() {
         warn!("PLIC supervisor context for logical CPU {cpu_idx} is not found");
     } else {
         warn!("PLIC supervisor context for current logical CPU is not found");

--- a/platforms/somehal/src/cpu.rs
+++ b/platforms/somehal/src/cpu.rs
@@ -1,0 +1,12 @@
+//! Current CPU helpers shared by architecture backends.
+
+/// Returns the current logical CPU index.
+///
+/// This prefers the kernel runtime interface. Before the kernel can provide a
+/// runtime answer, it falls back to the early boot CPU-index convention exposed
+/// by `someboot`.
+pub fn current_cpu_idx() -> Option<usize> {
+    crate::setup::kernel()
+        .current_cpu_idx()
+        .or_else(someboot::smp::try_early_cpu_idx)
+}

--- a/platforms/somehal/src/lib.rs
+++ b/platforms/somehal/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 extern crate log;
 
 pub(crate) mod common;
+pub mod cpu;
 mod driver;
 pub mod irq;
 pub mod setup;
@@ -45,6 +46,15 @@ pub fn post_paging() {
     someboot::post_allocator();
     // note: irq controller should be initialized when probe.
     driver::rdrive_setup();
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn current_cpu_idx_api_is_arch_independent() {
+        let current = crate::cpu::current_cpu_idx();
+        let _current: Option<usize> = current;
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/platforms/somehal/src/setup.rs
+++ b/platforms/somehal/src/setup.rs
@@ -1,6 +1,12 @@
 pub use mmio_api::{MapError, MmioAddr, MmioOp, MmioRaw};
 
-pub trait KernelOp: MmioOp {}
+pub trait KernelOp: MmioOp {
+    /// Returns the current logical CPU index after the kernel has initialized
+    /// its runtime per-CPU state.
+    fn current_cpu_idx(&self) -> Option<usize> {
+        None
+    }
+}
 
 struct EmptyKernelOp;
 
@@ -25,6 +31,6 @@ pub(crate) fn set_kernel_op(op: &'static dyn KernelOp) {
     }
 }
 
-// pub(crate) fn kernel() -> &'static dyn KernelOp {
-//     unsafe { KERNEL_OP }
-// }
+pub(crate) fn kernel() -> &'static dyn KernelOp {
+    unsafe { KERNEL_OP }
+}

--- a/scripts/axbuild/src/arceos/build.rs
+++ b/scripts/axbuild/src/arceos/build.rs
@@ -27,9 +27,9 @@ pub(crate) struct ArceosBuildConfig {
 }
 
 impl ArceosBuildConfig {
-    fn default_for_target(target: &str) -> Self {
+    fn default_config() -> Self {
         Self {
-            build_info: ArceosBuildInfo::default_for_target(target),
+            build_info: ArceosBuildInfo::default(),
             app_c: None,
         }
     }
@@ -98,7 +98,7 @@ fn load_build_config_with_makefile_features_and_metadata(
     metadata: Option<&Metadata>,
 ) -> anyhow::Result<ArceosBuildConfig> {
     build::ensure_build_info(&request.build_info_path, || {
-        ArceosBuildConfig::default_for_target(&request.target)
+        ArceosBuildConfig::default_config()
     })?;
     let content = fs::read_to_string(&request.build_info_path)?;
     build::reject_removed_std_field(&request.build_info_path, &content)?;
@@ -108,12 +108,6 @@ fn load_build_config_with_makefile_features_and_metadata(
             request.build_info_path.display()
         )
     })?;
-    build::apply_target_defaults_if_plat_dyn_unspecified(
-        &mut config.build_info,
-        &request.target,
-        &content,
-    );
-
     if config.build_info.normalize_legacy_feature_aliases() {
         warn!(
             "normalizing legacy feature aliases in build config {}",
@@ -361,7 +355,7 @@ mod tests {
 
     #[test]
     fn resolves_dynamic_platform_features_and_args() {
-        let mut build_info = ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat");
+        let mut build_info = ArceosBuildInfo::default();
         build_info.resolve_features("arceos-helloworld", "aarch64-unknown-none-softfloat", true);
 
         assert!(build_info.features.contains(&"ax-std/plat-dyn".to_string()));
@@ -378,7 +372,7 @@ mod tests {
 
     #[test]
     fn resolves_non_dynamic_aarch64_to_defplat_without_static_default() {
-        let mut build_info = ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat");
+        let mut build_info = ArceosBuildInfo::default();
         build_info.resolve_features("arceos-helloworld", "aarch64-unknown-none-softfloat", false);
 
         assert!(build_info.features.contains(&"ax-hal/defplat".to_string()));
@@ -400,7 +394,7 @@ mod tests {
     #[test]
     fn preparing_c_app_non_dynamic_aarch64_without_custom_platform_fails() {
         let metadata = repo_metadata();
-        let mut build_info = ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat");
+        let mut build_info = ArceosBuildInfo::default();
         let result = build_info.prepare_non_dynamic_platform_for(
             "arceos-helloworld",
             "aarch64-unknown-none-softfloat",
@@ -483,7 +477,7 @@ mod tests {
 
         let build_info = load_build_info(&request).unwrap();
 
-        assert_eq!(build_info, ArceosBuildInfo::default_for_target("target"));
+        assert_eq!(build_info, ArceosBuildInfo::default());
         assert!(path.exists());
         assert!(
             fs::read_to_string(path)
@@ -723,6 +717,58 @@ AX_IP = "10.0.2.15"
     }
 
     #[test]
+    fn load_build_info_defaults_unspecified_loongarch64_to_dynamic_platform() {
+        let root = tempdir().unwrap();
+        let path = root
+            .path()
+            .join("build-loongarch64-unknown-none-softfloat.toml");
+        fs::write(
+            &path,
+            r#"
+features = ["ax-std"]
+log = "Warn"
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"
+"#,
+        )
+        .unwrap();
+        let request = request(
+            "arceos-test-suit",
+            "loongarch64-unknown-none-softfloat",
+            None,
+            path,
+        );
+
+        let build_info = load_build_info(&request).unwrap();
+
+        assert!(build_info.plat_dyn);
+
+        let metadata = repo_metadata();
+        let cargo = build_info
+            .into_prepared_base_cargo_config_with_metadata(
+                &request.package,
+                &request.target,
+                request.plat_dyn,
+                &metadata,
+            )
+            .unwrap();
+
+        assert!(cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+        assert!(
+            !cargo
+                .features
+                .contains(&"ax-std/loongarch64-qemu-virt".to_string())
+        );
+        assert!(
+            cargo
+                .target
+                .ends_with("scripts/targets/std/pie/loongarch64-unknown-linux-musl.json")
+        );
+    }
+
+    #[test]
     fn parse_makefile_features_splits_commas_whitespace_and_dedups() {
         assert_eq!(
             build::parse_makefile_features(" lockdep, sched-rr  lockdep\taxfeat/net "),
@@ -758,7 +804,7 @@ AX_IP = "10.0.2.15"
         let metadata = repo_metadata();
         let cargo = ArceosBuildInfo {
             features: vec!["lockdep".to_string()],
-            ..ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat")
+            ..ArceosBuildInfo::default()
         }
         .into_prepared_base_cargo_config_with_metadata(
             "arceos-helloworld",
@@ -779,22 +825,23 @@ AX_IP = "10.0.2.15"
     #[test]
     fn c_app_cargo_config_uses_builtin_bare_target_without_json_spec() {
         let root = tempdir().unwrap();
-        let build_config = root.path().join("build-x86_64-unknown-none.toml");
+        let build_config = root
+            .path()
+            .join("build-loongarch64-unknown-none-softfloat.toml");
         let build_info = ArceosBuildInfo {
             features: vec!["ax-std".to_string()],
-            plat_dyn: true,
-            ..ArceosBuildInfo::default_for_target("x86_64-unknown-none")
+            ..ArceosBuildInfo::default()
         };
         fs::write(&build_config, toml::to_string_pretty(&build_info).unwrap()).unwrap();
         let request = request(
             "arceos-helloworld",
-            "x86_64-unknown-none",
-            Some(true),
+            "loongarch64-unknown-none-softfloat",
+            Some(false),
             build_config,
         );
         let cargo = load_c_app_cargo_config(&request).unwrap();
 
-        assert_eq!(cargo.target, "x86_64-unknown-none");
+        assert_eq!(cargo.target, "loongarch64-unknown-none-softfloat");
         assert!(!cargo.env.contains_key("CARGO_UNSTABLE_JSON_TARGET_SPEC"));
         assert!(
             cargo
@@ -817,7 +864,7 @@ AX_IP = "10.0.2.15"
         let metadata = repo_metadata();
         let cargo = ArceosBuildInfo {
             max_cpu_num: Some(4),
-            ..ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat")
+            ..ArceosBuildInfo::default()
         }
         .into_prepared_base_cargo_config_with_metadata(
             &request.package,
@@ -834,7 +881,7 @@ AX_IP = "10.0.2.15"
     #[test]
     fn prepared_cargo_config_defaults_x86_64_to_dynamic_platform() {
         let metadata = repo_metadata();
-        let cargo = ArceosBuildInfo::default_for_target("x86_64-unknown-none")
+        let cargo = ArceosBuildInfo::default()
             .into_prepared_base_cargo_config_with_metadata(
                 "arceos-helloworld",
                 "x86_64-unknown-none",

--- a/scripts/axbuild/src/axvisor/board.rs
+++ b/scripts/axbuild/src/axvisor/board.rs
@@ -130,7 +130,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["fs", "ax-driver/rockchip-sdhci"]
 log = "Info"
-plat_dyn = true
 "#,
         );
         write_board(
@@ -141,7 +140,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["ept-level-4"]
 log = "Info"
-plat_dyn = true
 "#,
         );
         write_board(
@@ -152,7 +150,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "riscv64gc-unknown-none-elf"
 features = ["ept-level-4"]
 log = "Info"
-plat_dyn = true
 "#,
         );
 
@@ -172,7 +169,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["ax-driver/rockchip-soc"]
 log = "Info"
-plat_dyn = true
 "#,
         );
 

--- a/scripts/axbuild/src/axvisor/build.rs
+++ b/scripts/axbuild/src/axvisor/build.rs
@@ -56,8 +56,8 @@ impl AxvisorBoardFile {
     }
 }
 
-pub(crate) fn default_axvisor_build_info_for_target(target: &str) -> AxvisorBuildInfo {
-    let mut build_info = AxvisorBuildInfo::default_for_target(target);
+pub(crate) fn default_axvisor_build_info() -> AxvisorBuildInfo {
+    let mut build_info = AxvisorBuildInfo::default();
     build_info.features.clear();
     build_info
 }
@@ -272,8 +272,8 @@ fn reject_unsupported_nested_platform_features(
         .find(|feature| is_axvisor_plat_dyn_feature(feature))
     {
         return Err(anyhow!(
-            "Axvisor build configs must use `plat_dyn = true` instead of dynamic platform \
-             features; found `{feature}`"
+            "Axvisor build configs enable dynamic platforms by default; remove dynamic platform \
+             features from `features`; found `{feature}`"
         ));
     }
 
@@ -509,24 +509,13 @@ fn load_build_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<LoadedA
             let mut loaded = default_board
                 .config
                 .into_loaded(default_board.target.clone());
-            let content = fs::read_to_string(&default_board.path).map_err(|e| {
-                anyhow!(
-                    "failed to read Axvisor default board config {}: {e}",
-                    default_board.path.display()
-                )
-            })?;
-            crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-                &mut loaded.build_info,
-                &loaded.target,
-                &content,
-            );
             if let Some(smp) = request.smp {
                 loaded.build_info.max_cpu_num = Some(smp);
             }
             return Ok(loaded);
         }
 
-        let default_build_info = default_axvisor_build_info_for_target(&request.target);
+        let default_build_info = default_axvisor_build_info();
         fs::write(
             &request.build_info_path,
             toml::to_string_pretty(&default_build_info)?,
@@ -554,11 +543,6 @@ fn load_build_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<LoadedA
 
     if let Ok(board_config) = toml::from_str::<AxvisorBoardFile>(&content) {
         let mut loaded = board_config.into_loaded();
-        crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-            &mut loaded.build_info,
-            &loaded.target,
-            &content,
-        );
         if let Some(smp) = request.smp {
             loaded.build_info.max_cpu_num = Some(smp);
         }
@@ -566,12 +550,7 @@ fn load_build_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<LoadedA
     }
 
     toml::from_str::<AxvisorBuildInfo>(&content)
-        .map(|mut build_info| {
-            crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-                &mut build_info,
-                &request.target,
-                &content,
-            );
+        .map(|build_info| {
             let mut loaded = LoadedAxvisorBuildConfig {
                 build_info,
                 target: request.target.clone(),
@@ -692,7 +671,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["ept-level-4"]
 log = "Info"
-plat_dyn = true
 vm_configs = []
 "#,
         );
@@ -735,7 +713,6 @@ vm_configs = []
 env = {}
 features = ["fs", "ept-level-4"]
 log = "Info"
-plat_dyn = true
 "#,
         )
         .unwrap();
@@ -872,7 +849,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "x86_64-unknown-none"
 features = ["ept-level-4", "fs", "vmx"]
 log = "Info"
-plat_dyn = true
 vm_configs = []
 "#,
         );
@@ -1015,7 +991,7 @@ plat_dyn = false
     }
 
     #[test]
-    fn load_cargo_config_drops_static_platform_when_plat_dyn_is_enabled() {
+    fn load_cargo_config_drops_static_platform_when_plat_dyn_is_defaulted() {
         let root = tempdir().unwrap();
         let config_path = root.path().join(".build.toml");
         fs::write(
@@ -1024,7 +1000,6 @@ plat_dyn = false
 env = {}
 features = ["ax-hal/riscv64-sg2002", "fs"]
 log = "Info"
-plat_dyn = true
 "#,
         )
         .unwrap();
@@ -1034,7 +1009,7 @@ plat_dyn = true
             axvisor_dir: root.path().join("os/axvisor"),
             arch: "riscv64".to_string(),
             target: "riscv64gc-unknown-none-elf".to_string(),
-            plat_dyn: Some(true),
+            plat_dyn: None,
             smp: None,
             debug: false,
             build_info_path: config_path,
@@ -1064,7 +1039,6 @@ plat_dyn = true
 env = {}
 features = ["ax-driver/virtio-blk", "ept-level-4", "fs", "vmx"]
 log = "Info"
-plat_dyn = true
 "#,
         )
         .unwrap();
@@ -1095,6 +1069,42 @@ plat_dyn = true
                 .features
                 .contains(&"ax-driver/plat-static".to_string())
         );
+    }
+
+    #[test]
+    fn load_cargo_config_defaults_x86_to_dynamic_platform_when_omitted() {
+        let root = tempdir().unwrap();
+        let config_path = root.path().join(".build.toml");
+        fs::write(
+            &config_path,
+            r#"
+env = {}
+features = ["ept-level-4", "fs", "vmx"]
+log = "Info"
+"#,
+        )
+        .unwrap();
+
+        let cargo = load_cargo_config(&ResolvedAxvisorRequest {
+            package: AXVISOR_PACKAGE.to_string(),
+            axvisor_dir: root.path().join("os/axvisor"),
+            arch: "x86_64".to_string(),
+            target: "x86_64-unknown-none".to_string(),
+            plat_dyn: None,
+            smp: None,
+            debug: false,
+            build_info_path: config_path,
+            qemu_config: None,
+            uboot_config: None,
+            vmconfigs: vec![],
+        })
+        .unwrap();
+
+        assert!(cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+        assert!(cargo.features.contains(&"axvm/plat-dyn".to_string()));
+        assert!(cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
+        assert!(!cargo.features.contains(&"ax-hal/x86-qemu-q35".to_string()));
+        assert!(!cargo.features.contains(&"ax-hal/x86-pc".to_string()));
     }
 
     #[test]

--- a/scripts/axbuild/src/axvisor/config.rs
+++ b/scripts/axbuild/src/axvisor/config.rs
@@ -81,7 +81,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["fs", "ax-driver/rockchip-sdhci"]
 log = "Info"
-plat_dyn = true
 vm_configs = []
 "#,
         );
@@ -142,7 +141,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = []
 log = "Info"
-plat_dyn = true
 "#,
         );
         write_board(
@@ -153,7 +151,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["ax-driver/rockchip-soc"]
 log = "Info"
-plat_dyn = true
 "#,
         );
 
@@ -174,7 +171,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = []
 log = "Info"
-plat_dyn = true
 "#,
         );
 

--- a/scripts/axbuild/src/build.rs
+++ b/scripts/axbuild/src/build.rs
@@ -97,7 +97,10 @@ pub struct BuildInfo {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub axconfig_overrides: Vec<String>,
     /// Whether to use the dynamic platform linker flow when supported.
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(
+        default = "default_plat_dyn",
+        skip_serializing_if = "is_default_plat_dyn"
+    )]
     pub plat_dyn: bool,
 }
 
@@ -110,13 +113,6 @@ impl BuildInfo {
             .collect();
         self.features = features;
         self
-    }
-
-    pub fn default_for_target(target: &str) -> Self {
-        Self {
-            plat_dyn: defaults_to_platform_dynamic(target),
-            ..Self::default()
-        }
     }
 
     pub(crate) fn effective_plat_dyn(&self, target: &str, plat_dyn_override: Option<bool>) -> bool {
@@ -490,7 +486,7 @@ impl Default for BuildInfo {
             features: vec!["ax-std".to_string()],
             max_cpu_num: None,
             axconfig_overrides: Vec::new(),
-            plat_dyn: false,
+            plat_dyn: true,
         }
     }
 }
@@ -1173,27 +1169,6 @@ where
         .with_context(|| format!("failed to parse build info {}", path.display()))
 }
 
-pub(crate) fn apply_target_defaults_if_plat_dyn_unspecified(
-    build_info: &mut BuildInfo,
-    target: &str,
-    content: &str,
-) {
-    if build_info_declares_plat_dyn(content) {
-        return;
-    }
-
-    if target.starts_with("aarch64-") || target.starts_with("riscv64") {
-        build_info.plat_dyn = BuildInfo::default_for_target(target).plat_dyn;
-    }
-}
-
-fn build_info_declares_plat_dyn(content: &str) -> bool {
-    toml::from_str::<toml::Value>(content)
-        .ok()
-        .and_then(|value| value.as_table().cloned())
-        .is_some_and(|table| table.contains_key("plat_dyn") || table.contains_key("plat-dyn"))
-}
-
 pub(crate) fn reject_removed_std_field(path: &Path, contents: &str) -> anyhow::Result<()> {
     if let Ok(table) = toml::from_str::<toml::Table>(contents)
         && table.contains_key("std")
@@ -1222,8 +1197,12 @@ pub(crate) fn reject_arceos_app_c_field(path: &Path, contents: &str) -> anyhow::
     Ok(())
 }
 
-fn is_false(value: &bool) -> bool {
-    !*value
+fn default_plat_dyn() -> bool {
+    true
+}
+
+fn is_default_plat_dyn(value: &bool) -> bool {
+    *value
 }
 
 pub(crate) fn resolve_effective_plat_dyn(
@@ -1239,10 +1218,6 @@ fn supports_platform_dynamic(target: &str) -> bool {
         || target.starts_with("loongarch64-")
         || target.starts_with("riscv64")
         || target.starts_with("x86_64-")
-}
-
-fn defaults_to_platform_dynamic(target: &str) -> bool {
-    target.starts_with("aarch64-") || target.starts_with("riscv64") || target.starts_with("x86_64-")
 }
 
 fn default_to_bin_for_target(target: &str) -> bool {
@@ -2181,7 +2156,6 @@ mod tests {
     fn std_build_cargo_config_builds_fake_lib_before_app() {
         let metadata = repo_metadata();
         let cargo = BuildInfo {
-            plat_dyn: true,
             features: vec!["ax-std".to_string(), "fs".to_string(), "dns".to_string()],
             ..BuildInfo::default()
         }
@@ -2266,6 +2240,21 @@ AX_IP = "10.0.2.15"
             err.to_string().contains("uses removed `std` field"),
             "{err:#}"
         );
+    }
+
+    #[test]
+    fn build_info_omits_true_plat_dyn_and_serializes_false() {
+        let default = toml::to_string_pretty(&BuildInfo::default()).unwrap();
+
+        assert!(!default.contains("plat_dyn"));
+
+        let non_dynamic = BuildInfo {
+            plat_dyn: false,
+            ..BuildInfo::default()
+        };
+        let serialized = toml::to_string_pretty(&non_dynamic).unwrap();
+
+        assert!(serialized.contains("plat_dyn = false"));
     }
 
     #[test]
@@ -2388,7 +2377,7 @@ AX_IP = "10.0.2.15"
     fn std_build_aarch64_defaults_to_dynamic_platform() {
         let metadata = repo_metadata();
         let cargo = BuildInfo {
-            ..BuildInfo::default_for_target("aarch64-unknown-none-softfloat")
+            ..BuildInfo::default()
         }
         .into_prepared_base_cargo_config_with_metadata(
             "arceos-helloworld",
@@ -2422,7 +2411,7 @@ AX_IP = "10.0.2.15"
     #[test]
     fn std_build_config_preserves_backtrace_rustflags_from_env() {
         let metadata = repo_metadata();
-        let mut info = BuildInfo::default_for_target("x86_64-unknown-none");
+        let mut info = BuildInfo::default();
         info.env.insert("DWARF".to_string(), "y".to_string());
 
         let cargo = info
@@ -2912,7 +2901,7 @@ AX_IP = "10.0.2.15"
     fn std_build_dynamic_x86_64_prepares_binary_artifact() {
         let metadata = repo_metadata();
         let cargo = BuildInfo {
-            ..BuildInfo::default_for_target("x86_64-unknown-none")
+            ..BuildInfo::default()
         }
         .into_prepared_base_cargo_config_with_metadata(
             "arceos-helloworld",
@@ -2954,7 +2943,7 @@ AX_IP = "10.0.2.15"
     #[test]
     fn x86_64_defaults_to_dynamic_platform() {
         assert!(supports_platform_dynamic("x86_64-unknown-none"));
-        assert!(BuildInfo::default_for_target("x86_64-unknown-none").plat_dyn);
+        assert!(BuildInfo::default().plat_dyn);
         assert!(resolve_effective_plat_dyn(
             "x86_64-unknown-none",
             true,
@@ -2967,15 +2956,26 @@ AX_IP = "10.0.2.15"
     }
 
     #[test]
-    fn loongarch64_supports_explicit_dynamic_platform_without_defaulting_to_it() {
+    fn loongarch64_defaults_to_dynamic_platform_when_supported() {
         assert!(supports_platform_dynamic(
             "loongarch64-unknown-none-softfloat"
         ));
-        assert!(!BuildInfo::default_for_target("loongarch64-unknown-none-softfloat").plat_dyn);
+        assert!(BuildInfo::default().plat_dyn);
         assert!(resolve_effective_plat_dyn(
             "loongarch64-unknown-none-softfloat",
-            false,
-            Some(true)
+            true,
+            None
+        ));
+    }
+
+    #[test]
+    fn unsupported_targets_do_not_effectively_enable_dynamic_platform() {
+        assert!(!supports_platform_dynamic("armv7-unknown-none-eabi"));
+        assert!(BuildInfo::default().plat_dyn);
+        assert!(!resolve_effective_plat_dyn(
+            "armv7-unknown-none-eabi",
+            true,
+            None
         ));
     }
 

--- a/scripts/axbuild/src/build.rs
+++ b/scripts/axbuild/src/build.rs
@@ -1972,9 +1972,13 @@ fn resolve_defconfig_path(workspace_root: &Path) -> anyhow::Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
 
     use tempfile::tempdir;
+    use walkdir::WalkDir;
 
     use super::*;
 
@@ -2255,6 +2259,110 @@ AX_IP = "10.0.2.15"
         let serialized = toml::to_string_pretty(&non_dynamic).unwrap();
 
         assert!(serialized.contains("plat_dyn = false"));
+    }
+
+    fn declares_non_dynamic_platform(content: &str) -> bool {
+        toml::from_str::<toml::Table>(content)
+            .ok()
+            .and_then(|table| table.get("plat_dyn").and_then(|value| value.as_bool()))
+            == Some(false)
+    }
+
+    fn declares_static_platform(content: &str) -> bool {
+        let Ok(table) = toml::from_str::<toml::Table>(content) else {
+            return false;
+        };
+        let Some(features) = table.get("features").and_then(|value| value.as_array()) else {
+            return false;
+        };
+
+        features
+            .iter()
+            .filter_map(|feature| feature.as_str())
+            .any(is_static_platform_feature)
+    }
+
+    fn is_static_platform_feature(feature: &str) -> bool {
+        feature == "ax-driver/plat-static"
+            || ax_hal_platform_feature_name(feature, None)
+                .is_some_and(|platform| platform != "plat-dyn")
+    }
+
+    fn checked_in_build_config_roots(workspace: &Path) -> [PathBuf; 4] {
+        [
+            workspace.join("apps"),
+            workspace.join("os/StarryOS/configs/board"),
+            workspace.join("os/axvisor/configs/board"),
+            workspace.join("test-suit"),
+        ]
+    }
+
+    fn declares_default_dynamic_platform(content: &str) -> bool {
+        toml::from_str::<toml::Table>(content)
+            .ok()
+            .and_then(|table| table.get("plat_dyn").and_then(|value| value.as_bool()))
+            == Some(true)
+    }
+
+    fn checked_in_toml_files(
+        roots: impl IntoIterator<Item = PathBuf>,
+    ) -> impl Iterator<Item = PathBuf> {
+        roots.into_iter().flat_map(|root| {
+            WalkDir::new(root)
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_type().is_file())
+                .filter(|entry| {
+                    entry.path().extension().and_then(|ext| ext.to_str()) == Some("toml")
+                })
+                .map(|entry| entry.into_path())
+        })
+    }
+
+    #[test]
+    fn static_platform_configs_declare_non_dynamic_builds() {
+        let workspace = crate::context::workspace_root_path().unwrap();
+        let mut offenders = Vec::new();
+
+        for path in checked_in_toml_files(checked_in_build_config_roots(&workspace)) {
+            let content = fs::read_to_string(&path).unwrap();
+            if declares_static_platform(&content) && !declares_non_dynamic_platform(&content) {
+                offenders.push(
+                    path.strip_prefix(&workspace)
+                        .unwrap_or(&path)
+                        .display()
+                        .to_string(),
+                );
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "static platform configs must set `plat_dyn = false`: {offenders:#?}"
+        );
+    }
+
+    #[test]
+    fn checked_in_build_configs_do_not_declare_default_dynamic_builds() {
+        let workspace = crate::context::workspace_root_path().unwrap();
+        let mut offenders = Vec::new();
+
+        for path in checked_in_toml_files(checked_in_build_config_roots(&workspace)) {
+            let content = fs::read_to_string(&path).unwrap();
+            if declares_default_dynamic_platform(&content) {
+                offenders.push(
+                    path.strip_prefix(&workspace)
+                        .unwrap_or(&path)
+                        .display()
+                        .to_string(),
+                );
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "default dynamic configs should omit `plat_dyn = true`: {offenders:#?}"
+        );
     }
 
     #[test]

--- a/scripts/axbuild/src/build.rs
+++ b/scripts/axbuild/src/build.rs
@@ -1235,7 +1235,10 @@ pub(crate) fn resolve_effective_plat_dyn(
 }
 
 fn supports_platform_dynamic(target: &str) -> bool {
-    target.starts_with("aarch64-") || target.starts_with("riscv64") || target.starts_with("x86_64-")
+    target.starts_with("aarch64-")
+        || target.starts_with("loongarch64-")
+        || target.starts_with("riscv64")
+        || target.starts_with("x86_64-")
 }
 
 fn defaults_to_platform_dynamic(target: &str) -> bool {
@@ -2470,6 +2473,11 @@ AX_IP = "10.0.2.15"
                 false,
                 "scripts/targets/std/loongarch64-unknown-linux-musl.json",
             ),
+            (
+                "loongarch64-unknown-none-softfloat",
+                true,
+                "scripts/targets/std/pie/loongarch64-unknown-linux-musl.json",
+            ),
         ];
 
         for (bare_target, plat_dyn, expected_path) in cases {
@@ -2612,6 +2620,13 @@ AX_IP = "10.0.2.15"
                 "loongarch64",
                 64,
             ),
+            (
+                "loongarch64-unknown-linux-musl",
+                true,
+                "loongarch64-unknown-none",
+                "loongarch64",
+                64,
+            ),
         ] {
             let workspace = crate::context::workspace_root_path().unwrap();
             let std_path = workspace.join(std_target_json_path(std_target, plat_dyn));
@@ -2672,6 +2687,7 @@ AX_IP = "10.0.2.15"
             ("riscv64gc-unknown-linux-musl", false),
             ("riscv64gc-unknown-linux-musl", true),
             ("loongarch64-unknown-linux-musl", false),
+            ("loongarch64-unknown-linux-musl", true),
         ] {
             let path = crate::context::workspace_root_path()
                 .unwrap()
@@ -2701,6 +2717,7 @@ AX_IP = "10.0.2.15"
             ("riscv64gc-unknown-linux-musl", false, "_start", "-no-pie"),
             ("riscv64gc-unknown-linux-musl", true, "_head", "-pie"),
             ("loongarch64-unknown-linux-musl", false, "_start", "-no-pie"),
+            ("loongarch64-unknown-linux-musl", true, "_head", "-pie"),
         ];
 
         for (target, plat_dyn, entry, mode_arg) in cases {
@@ -2946,6 +2963,19 @@ AX_IP = "10.0.2.15"
         assert!(default_to_bin_for_target_config(
             "x86_64-unknown-none",
             true
+        ));
+    }
+
+    #[test]
+    fn loongarch64_supports_explicit_dynamic_platform_without_defaulting_to_it() {
+        assert!(supports_platform_dynamic(
+            "loongarch64-unknown-none-softfloat"
+        ));
+        assert!(!BuildInfo::default_for_target("loongarch64-unknown-none-softfloat").plat_dyn);
+        assert!(resolve_effective_plat_dyn(
+            "loongarch64-unknown-none-softfloat",
+            false,
+            Some(true)
         ));
     }
 

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -369,7 +369,7 @@ fn prepare_request_explicit_config_drops_snapshot_plat_dyn() {
 package = "from-snapshot"
 arch = "riscv64"
 target = "riscv64gc-unknown-none-elf"
-plat_dyn = true
+plat_dyn = false
 smp = 4
 
 [qemu]
@@ -561,7 +561,7 @@ fn prepare_axvisor_request_prefers_cli_over_snapshot() {
 config = "os/axvisor/.build.toml"
 arch = "riscv64"
 target = "riscv64gc-unknown-none-elf"
-plat_dyn = true
+plat_dyn = false
 vmconfigs = ["tmp/snapshot-vm.toml"]
 
 [qemu]

--- a/scripts/axbuild/src/starry/app.rs
+++ b/scripts/axbuild/src/starry/app.rs
@@ -963,7 +963,7 @@ mod tests {
             case_name,
             "build-aarch64-unknown-none-softfloat.toml",
             "target = \"aarch64-unknown-none-softfloat\"\nenv = {}\nfeatures = []\nlog = \
-             \"Info\"\nplat_dyn = true\n",
+             \"Info\"\n",
         );
     }
 
@@ -1026,7 +1026,7 @@ mod tests {
             root.path(),
             "demo",
             "build-aarch64-unknown-none-softfloat.toml",
-            "env = {}\nfeatures = []\nlog = \"Info\"\nplat_dyn = true\n",
+            "env = {}\nfeatures = []\nlog = \"Info\"\n",
         );
 
         let case = resolve_board_case(root.path(), "demo", None).unwrap();
@@ -1103,7 +1103,7 @@ mod tests {
             "demo",
             "build-aarch64-unknown-none-softfloat.toml",
             "target = \"aarch64-unknown-none-softfloat\"\nenv = {}\nfeatures = []\nlog = \
-             \"Info\"\nplat_dyn = true\n",
+             \"Info\"\n",
         );
         write_case_file(
             root.path(),

--- a/scripts/axbuild/src/starry/board.rs
+++ b/scripts/axbuild/src/starry/board.rs
@@ -200,7 +200,6 @@ target = "aarch64-unknown-none-softfloat"
 env = {}
 features = ["common"]
 log = "Info"
-plat_dyn = true
 "#,
         );
         write_board(
@@ -222,7 +221,6 @@ target = "riscv64gc-unknown-none-elf"
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = ["ax-driver/serial", "ax-driver/virtio-blk"]
 log = "Warn"
-plat_dyn = true
 "#,
         );
 

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -10,8 +10,8 @@ pub use crate::build::LogLevel;
 use crate::context::{ResolvedStarryRequest, STARRY_PACKAGE, starry_arch_for_target_checked};
 
 pub(crate) fn default_starry_build_info_for_target(target: &str) -> StarryBuildInfo {
-    let mut build_info = StarryBuildInfo::default_for_target(target);
-    if build_info.plat_dyn {
+    let mut build_info = StarryBuildInfo::default();
+    if build_info.effective_plat_dyn(target, None) {
         build_info.features = Vec::new();
     } else {
         build_info.features = vec!["qemu".to_string()];
@@ -63,17 +63,12 @@ pub(crate) fn load_build_info(request: &ResolvedStarryRequest) -> anyhow::Result
         })?;
         let content = std::fs::read_to_string(&request.build_info_path)?;
         crate::build::reject_arceos_app_c_field(&request.build_info_path, &content)?;
-        let mut build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
+        let build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
             format!(
                 "failed to parse build info {}",
                 request.build_info_path.display()
             )
         })?;
-        crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-            &mut build_info,
-            &request.target,
-            &content,
-        );
         build_info
     };
 
@@ -98,17 +93,12 @@ pub(crate) fn load_cargo_config(request: &ResolvedStarryRequest) -> anyhow::Resu
         })?;
         let content = std::fs::read_to_string(&request.build_info_path)?;
         crate::build::reject_arceos_app_c_field(&request.build_info_path, &content)?;
-        let mut build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
+        let build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
             format!(
                 "failed to parse build info {}",
                 request.build_info_path.display()
             )
         })?;
-        crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-            &mut build_info,
-            &request.target,
-            &content,
-        );
         build_info
     };
     crate::build::apply_makefile_features_with_metadata(

--- a/scripts/axbuild/src/starry/config.rs
+++ b/scripts/axbuild/src/starry/config.rs
@@ -156,7 +156,6 @@ target = "riscv64gc-unknown-none-elf"
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = ["ax-driver/serial", "ax-driver/virtio-blk"]
 log = "Warn"
-plat_dyn = true
 "#,
         );
         let existing_snapshot = StarryCommandSnapshot {
@@ -247,7 +246,6 @@ target = "riscv64gc-unknown-none-elf"
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = ["ax-driver/serial", "ax-driver/virtio-blk"]
 log = "Warn"
-plat_dyn = true
 "#,
         );
         let existing_snapshot = StarryCommandSnapshot {
@@ -305,7 +303,7 @@ plat_dyn = false
 
         let output = root.path().join("tmp/custom-starry.toml");
         fs::create_dir_all(output.parent().unwrap()).unwrap();
-        fs::write(&output, "plat_dyn = true\n").unwrap();
+        fs::write(&output, "log = \"Debug\"\n").unwrap();
 
         let board = ensure_default_build_config_for_target(
             root.path(),
@@ -315,6 +313,6 @@ plat_dyn = false
         .unwrap();
 
         assert!(board.is_none());
-        assert_eq!(fs::read_to_string(&output).unwrap(), "plat_dyn = true\n");
+        assert_eq!(fs::read_to_string(&output).unwrap(), "log = \"Debug\"\n");
     }
 }

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -105,7 +105,7 @@ pub(super) async fn load_patched_qemu_config(
         }
     };
 
-    let mode = rootfs_patch_mode(request, cargo);
+    let mode = rootfs_patch_mode(cargo);
     if let Some(rootfs) = explicit_rootfs {
         patch_qemu_rootfs_path_with_mode(&mut qemu, rootfs, mode);
     } else if apply_default_args {
@@ -283,15 +283,13 @@ pub(crate) fn patch_qemu_rootfs_path_with_mode(
     patch_rootfs(qemu, rootfs_path, mode);
 }
 
-fn rootfs_patch_mode(request: &ResolvedStarryRequest, cargo: &Cargo) -> RootfsPatchMode {
-    if request.plat_dyn == Some(true)
-        || cargo.features.iter().any(|feature| {
-            matches!(
-                feature.as_str(),
-                "plat-dyn" | "ax-feat/plat-dyn" | "ax-std/plat-dyn" | "starry-kernel/plat-dyn"
-            )
-        })
-    {
+fn rootfs_patch_mode(cargo: &Cargo) -> RootfsPatchMode {
+    if cargo.features.iter().any(|feature| {
+        matches!(
+            feature.as_str(),
+            "plat-dyn" | "ax-feat/plat-dyn" | "ax-std/plat-dyn" | "starry-kernel/plat-dyn"
+        )
+    }) {
         RootfsPatchMode::ReplaceDriveOnly
     } else {
         RootfsPatchMode::EnsureDiskBootNet

--- a/scripts/axbuild/src/starry/test.rs
+++ b/scripts/axbuild/src/starry/test.rs
@@ -402,7 +402,11 @@ impl Starry {
         )?;
         let mut request = Self::qemu_test_request(request);
         if let Some(default_board) = default_board {
-            request.plat_dyn = Some(default_board.build_info.plat_dyn);
+            request.plat_dyn = Some(
+                default_board
+                    .build_info
+                    .effective_plat_dyn(&default_board.target, None),
+            );
             request.build_info_override = Some(default_board.build_info);
         } else {
             anyhow::bail!(
@@ -2805,7 +2809,7 @@ mod tests {
     }
 
     #[test]
-    fn qemu_group_build_context_uses_group_plat_dyn_over_default_request() {
+    fn qemu_group_build_context_uses_omitted_group_plat_dyn_over_default_request() {
         let root = tempdir().unwrap();
         let build_config = root
             .path()
@@ -2814,7 +2818,7 @@ mod tests {
         fs::write(
             &build_config,
             "target = \"aarch64-unknown-none-softfloat\"\nenv = {}\nfeatures = [\"qemu\"]\nlog = \
-             \"Warn\"\nplat_dyn = true\n",
+             \"Warn\"\n",
         )
         .unwrap();
         let mut request = starry_request(

--- a/scripts/targets/std/pie/loongarch64-unknown-linux-musl.json
+++ b/scripts/targets/std/pie/loongarch64-unknown-linux-musl.json
@@ -1,0 +1,45 @@
+{
+  "abi": "softfloat",
+  "arch": "loongarch64",
+  "code-model": "medium",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "eh-frame-header": false,
+  "env": "musl",
+  "features": "-f,-d",
+  "has-thread-local": true,
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "lp64s",
+  "llvm-target": "loongarch64-unknown-none",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": "ArceOS std LoongArch64 musl identity with kernel PIE link style",
+    "host_tools": false,
+    "std": true,
+    "tier": 2
+  },
+  "os": "linux",
+  "panic-strategy": "abort",
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gnu-lld": [
+      "-pie",
+      "--gc-sections",
+      "-znorelro",
+      "-znostart-stop-gc",
+      "-Tlinker.x",
+      "-u",
+      "_head"
+    ]
+  },
+  "relocation-model": "pic",
+  "relro-level": "off",
+  "static-position-independent-executables": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-mcount": "_mcount",
+  "target-pointer-width": 64,
+  "tls-model": "initial-exec"
+}

--- a/test-suit/arceos/c/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/c/build-aarch64-unknown-none-softfloat.toml
@@ -13,8 +13,6 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 4
-plat_dyn = true
-
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/test-suit/arceos/c/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/c/build-loongarch64-unknown-none-softfloat.toml
@@ -13,6 +13,7 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 4
+plat_dyn = false
 
 [env]
 AX_GW = "10.0.2.2"

--- a/test-suit/arceos/c/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/arceos/c/build-riscv64gc-unknown-none-elf.toml
@@ -12,8 +12,6 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 4
-plat_dyn = true
-
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/test-suit/arceos/c/build-x86_64-unknown-none.toml
+++ b/test-suit/arceos/c/build-x86_64-unknown-none.toml
@@ -12,8 +12,6 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 4
-plat_dyn = true
-
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/rust/build-loongarch64-unknown-none-softfloat.toml
@@ -4,6 +4,7 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 4
+plat_dyn = false
 
 [env]
 AX_GW = "10.0.2.2"

--- a/test-suit/arceos/rust/build-x86_64-unknown-none.toml
+++ b/test-suit/arceos/rust/build-x86_64-unknown-none.toml
@@ -1,8 +1,6 @@
 features = []
 log = "Info"
 max_cpu_num = 4
-plat_dyn = true
-
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -5,6 +5,5 @@ features = [
   "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/orangepi-5-plus/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/board-phytiumpi/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-phytiumpi/build-aarch64-unknown-none-softfloat.toml
@@ -4,6 +4,5 @@ features = [
     "phytium-mci",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/phytiumpi/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/board-rdk-s100/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-rdk-s100/build-aarch64-unknown-none-softfloat.toml
@@ -3,6 +3,5 @@ features = [
     "ept-level-4",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/rdk-s100/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/board-roc-rk3568-pc/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-roc-rk3568-pc/build-aarch64-unknown-none-softfloat.toml
@@ -5,6 +5,5 @@ features = [
   "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/roc-rk3568-pc/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -5,6 +5,5 @@ features = [
     "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/qemu/aarch64/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml
@@ -8,4 +8,5 @@ features = [
 log = "Info"
 max_cpu_num = 1
 target = "loongarch64-unknown-none-softfloat"
+plat_dyn = false
 vm_configs = []

--- a/test-suit/axvisor/normal/qemu/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/axvisor/normal/qemu/build-riscv64gc-unknown-none-elf.toml
@@ -6,7 +6,6 @@ features = [
     "sstc"
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"
 vm_configs = ["os/axvisor/configs/vms/qemu/riscv64/linux-smp1.toml"]
 max_cpu_num = 4

--- a/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-svm.toml
+++ b/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-svm.toml
@@ -5,6 +5,5 @@ features = [
     "svm",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/linux-svm-smp1.toml"]

--- a/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-vmx.toml
+++ b/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-vmx.toml
@@ -6,6 +6,5 @@ features = [
     "vmx",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/linux-vmx-smp1.toml"]

--- a/test-suit/axvisor/uefi/qemu-nimbos/build-x86_64-unknown-none.toml
+++ b/test-suit/axvisor/uefi/qemu-nimbos/build-x86_64-unknown-none.toml
@@ -6,6 +6,5 @@ features = [
     "vmx",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = ["os/axvisor/tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml"]

--- a/test-suit/starryos/board-licheerv-nano-sg2002/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/board-licheerv-nano-sg2002/build-riscv64gc-unknown-none-elf.toml
@@ -10,4 +10,3 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true

--- a/test-suit/starryos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -14,4 +14,3 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true

--- a/test-suit/starryos/qemu-smp1/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu-smp1/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/test-suit/starryos/qemu-smp1/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/qemu-smp1/build-riscv64gc-unknown-none-elf.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/input",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/test-suit/starryos/qemu-smp1/build-x86_64-unknown-none.toml
+++ b/test-suit/starryos/qemu-smp1/build-x86_64-unknown-none.toml
@@ -10,4 +10,3 @@ features = [
   "ax-driver/xhci-pci",
   "starry-kernel/input",
 ]
-plat_dyn = true

--- a/test-suit/starryos/qemu-smp4/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu-smp4/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
 ]
 max_cpu_num = 4
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/test-suit/starryos/qemu-smp4/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/qemu-smp4/build-riscv64gc-unknown-none-elf.toml
@@ -10,5 +10,4 @@ features = [
 ]
 max_cpu_num = 4
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/test-suit/starryos/qemu-smp4/build-x86_64-unknown-none.toml
+++ b/test-suit/starryos/qemu-smp4/build-x86_64-unknown-none.toml
@@ -9,5 +9,4 @@ features = [
   "ax-driver/virtio-socket",
   "starry-kernel/input",
 ]
-plat_dyn = true
 max_cpu_num = 4


### PR DESCRIPTION
## 问题

当前动态平台路径已经覆盖 x86_64/aarch64/riscv64，但 LoongArch64 仍主要依赖静态 QEMU 平台；同时 axbuild 配置里大量 `plat_dyn = true` 已经变成冗余显式标记，容易让默认语义分散在配置文件、文档示例和构建逻辑之间。LoongArch64 Axvisor 动态 std 构建还会把 `loongarch_vcpu` 的 `.vectors` 当作 orphan section 放到 `.rodata` 同地址，导致链接失败。

CI 中还暴露出默认动态语义变化后的一个静态配置问题：带 `ax-hal/*` 静态平台或 `ax-driver/plat-static` 的 LoongArch test-suit/应用/board 配置如果省略 `plat_dyn = false`，会被默认动态路径注入 `ax-hal/plat-dyn`，从而和内建静态平台 feature 冲突。

## 修改

- 为 LoongArch64 补齐 UEFI 动态平台启动路径，接入 someboot/somehal，并在 axconfig/Starry board 配置中加入对应动态平台参数。
- 在 somehal 中加入 LoongArch64 中断控制器动态注册，拆分 CPU-local、EIOINTC、PCH-PIC 逻辑，并通过 rdrive/rdif-intc 注册。
- 调整 LoongArch64 异常表、trap 和 EFI stub 相关逻辑，复用现有动态平台启动路径。
- 修复 buddy-slab 相关初始化问题，避免为 LoongArch64 单独绕到 tlsf。
- 在 LoongArch64 someboot 链接脚本中显式放置 `.vectors`，让 Axvisor 的 VCPU 退出向量位于 text 区域、`.rodata` 之前。
- 重构 axbuild 的 `plat_dyn` 默认语义：省略即请求动态平台，只有显式 `plat_dyn = false` 才走静态；实际是否动态仍由 target 支持判断决定。
- 清理 apps、StarryOS、ArceOS、Axvisor、test-suit 和文档示例中冗余的 `plat_dyn = true`，保留显式静态配置。
- 补齐 LoongArch 静态配置的 `plat_dyn = false`，并加入 axbuild 回归测试，扫描 checked-in apps、board 和 test-suit 配置，防止静态平台 feature 再次省略该字段，也防止默认动态配置重新写出显式 `true`。

## 逻辑

动态平台的开关收敛到 `effective_plat_dyn(target, override)`，配置层只表达用户意图。这样支持动态平台的 target 默认进入动态构建，不支持动态平台的 target 不会被误带入动态路径；LoongArch64 则先落地 UEFI/UP 路径，SMP bring-up 保持后续工作。

LoongArch64 的动态链接脚本仍由 someboot/somehal 提供，所以虚拟化向量节也需要在这条链接链路中被显式接住；否则 lld 会按 orphan section 处理，和后续只读段产生重叠。

对仍走静态平台的 checked-in 配置，`plat_dyn = false` 是唯一显式标记。回归测试复用 axbuild 自己的 `ax-hal` 平台 feature 识别逻辑来发现静态配置，避免重新维护一份平台名单。

## 本地验证

- `cargo fmt`
- `cargo fmt --check`
- `cargo test -p axbuild`
- `cargo xtask clippy --package axbuild`
- `cargo xtask clippy --package someboot`
- `target/debug/tg-xtask arceos test qemu --arch loongarch64 --test-group rust --test-case all`
- `target/debug/tg-xtask arceos test qemu --arch loongarch64 --test-group c --test-case all`
- `target/debug/tg-xtask axvisor build -c test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml`
- `cargo xtask axvisor build -c test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml`
- `git diff --check`