### PR TITLE
fix(axbuild): support symlinks in overlay-to-rootfs injection

### DIFF
--- a/scripts/axbuild/src/rootfs/inject.rs
+++ b/scripts/axbuild/src/rootfs/inject.rs
@@ -158,7 +158,7 @@ fn collect_overlay_debugfs_commands(
         .with_context(|| format!("failed to read {}", current_dir.display()))?;
     entries.sort_by_key(|left| left.file_name());
 
-    // First pass:  directories and regular files (symlinks need their targets to
+    // First pass: directories and regular files (symlinks need their targets to
     // exist first, because debugfs `symlink` validates the target).
     for entry in &entries {
         let file_name = PathBuf::from(entry.file_name());

--- a/scripts/axbuild/src/rootfs/inject.rs
+++ b/scripts/axbuild/src/rootfs/inject.rs
@@ -158,7 +158,7 @@ fn collect_overlay_debugfs_commands(
         .with_context(|| format!("failed to read {}", current_dir.display()))?;
     entries.sort_by_key(|left| left.file_name());
 
-    // First pass: directories and regular files (symlinks need their targets to
+    // First pass:  directories and regular files (symlinks need their targets to
     // exist first, because debugfs `symlink` validates the target).
     for entry in &entries {
         let file_name = PathBuf::from(entry.file_name());

--- a/scripts/axbuild/src/rootfs/inject.rs
+++ b/scripts/axbuild/src/rootfs/inject.rs
@@ -158,7 +158,9 @@ fn collect_overlay_debugfs_commands(
         .with_context(|| format!("failed to read {}", current_dir.display()))?;
     entries.sort_by_key(|left| left.file_name());
 
-    for entry in entries {
+    // First pass: directories and regular files (symlinks need their targets to
+    // exist first, because debugfs `symlink` validates the target).
+    for entry in &entries {
         let file_name = PathBuf::from(entry.file_name());
         let relative_path = relative_dir.join(&file_name);
         let file_type = entry
@@ -171,9 +173,15 @@ fn collect_overlay_debugfs_commands(
             continue;
         }
 
+        if file_type.is_symlink() {
+            // Defer symlinks to second pass
+            continue;
+        }
+
         ensure!(
             file_type.is_file(),
-            "unsupported overlay entry `{}`; only regular files and directories are supported",
+            "unsupported overlay entry `{}`; only regular files, directories, and symlinks are \
+             supported",
             entry.path().display()
         );
         commands.push(format!("rm /{}", relative_path.display()));
@@ -191,6 +199,37 @@ fn collect_overlay_debugfs_commands(
                 "sif /{} mode 0{:o}",
                 relative_path.display(),
                 metadata.permissions().mode()
+            ));
+        }
+    }
+
+    // Second pass: symlinks (now all targets exist).
+    // debugfs symlink syntax (v1.47.0): symlink <link_path> <target_content>
+    // The 1st argument is where to create the symlink, the 2nd is what it
+    // points to (contrary to the man page which swaps them).
+    for entry in &entries {
+        let file_name = PathBuf::from(entry.file_name());
+        let relative_path = relative_dir.join(&file_name);
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to inspect {}", entry.path().display()))?;
+
+        if file_type.is_symlink() {
+            let host_target = fs::read_link(entry.path())
+                .with_context(|| format!("failed to read symlink {}", entry.path().display()))?;
+            // Convert relative symlink target to absolute guest path so the
+            // resulting symlink resolves correctly from any CWD.
+            let guest_filespec = if host_target.is_relative() {
+                let guest_dir = Path::new("/").join(relative_dir);
+                guest_dir.join(&host_target)
+            } else {
+                host_target.clone()
+            };
+            commands.push(format!("rm /{}", relative_path.display()));
+            commands.push(format!(
+                "symlink /{} {}",
+                relative_path.display(),
+                guest_filespec.display()
             ));
         }
     }
@@ -288,5 +327,49 @@ mod tests {
         assert!(commands.contains(&"mkdir /usr/bin".to_string()));
         assert!(commands.contains(&format!("write {} /usr/bin/test-bin", binary.display())));
         assert!(commands.contains(&"sif /usr/bin/test-bin mode 0100755".to_string()));
+    }
+
+    /// Symlinks are written after regular files (two-pass) with the correct
+    /// debugfs syntax: `symlink <link_path> <target_content>`.
+    /// Relative targets are converted to absolute guest paths.
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_are_emitted_after_regular_files() {
+        use std::os::unix;
+
+        let root = tempdir().unwrap();
+        let overlay_dir = root.path().join("overlay");
+        let lib = overlay_dir.join("usr/lib");
+        fs::create_dir_all(&lib).unwrap();
+
+        // ldconfig-style chain: libfoo.so -> libfoo.so.1 -> libfoo.so.1.2.0
+        fs::write(lib.join("libfoo.so.1.2.0"), b"elf").unwrap();
+        unix::fs::symlink("libfoo.so.1.2.0", lib.join("libfoo.so.1")).unwrap();
+        unix::fs::symlink("libfoo.so.1", lib.join("libfoo.so")).unwrap();
+
+        let mut commands = Vec::new();
+        collect_overlay_debugfs_commands(&overlay_dir, Path::new(""), &mut commands).unwrap();
+
+        let write_pos = commands
+            .iter()
+            .position(|c| c.contains("libfoo.so.1.2.0") && c.starts_with("write "))
+            .unwrap();
+        let sym1_pos = commands
+            .iter()
+            .position(|c| c == "symlink /usr/lib/libfoo.so.1 /usr/lib/libfoo.so.1.2.0")
+            .unwrap();
+        let sym0_pos = commands
+            .iter()
+            .position(|c| c == "symlink /usr/lib/libfoo.so /usr/lib/libfoo.so.1")
+            .unwrap();
+
+        assert!(
+            sym1_pos > write_pos,
+            "symlink must be second pass, after its target"
+        );
+        assert!(
+            sym0_pos > write_pos,
+            "symlink must be second pass, after its target"
+        );
     }
 }


### PR DESCRIPTION
在移植sdl应用时，包构建时候出现bug。原来是有symlink文件，但是系统构建的时候不支持将symlink也一并写入rsext4。现在添加相关支持，并且在下面添加测试

## Summary

`inject_overlay` 使用 `debugfs` 将 overlay 目录写入 ext4 根文件系统镜像时，只支持普通文件和目录，**不支持 symlink**。Alpine 包管理器通过 `ldconfig` 创建的标准动态库 symlink 链（`libGL.so → libGL.so.1 → libGL.so.1.2.0`）在注入过程中全部丢失，导致 `dlopen("libGL.so.1")` 找不到文件。

## Root Cause

`collect_overlay_debugfs_commands` 只有 `is_dir()` 和 `is_file()` 分支，symlink 触发 `ensure!` 报错退出。

## Fix

三个子问题：

1. **新增 `is_symlink()` 分支** — 通过 `debugfs symlink` 创建 symlink

2. **两遍遍历** — 条目按文件名排序后 symlink 可能排在 target 前面。`debugfs symlink` 要求 target 已存在于文件系统中，所以第一遍只写目录和常规文件，第二遍创建 symlink

3. **debugfs symlink 参数顺序** — v1.47.0 实际语法是 `symlink <link_path> <target_content>`，与 man page 相反。同时将相对路径 target 转为访客绝对路径

## Test

`cargo test --package axbuild -- rootfs::inject`

