### PR TITLE
refactor(starry): load executables from a resolved Location instead of re-resolving the path

### DIFF
--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -57,7 +57,7 @@ pub fn init(args: &[String], envs: &[String]) {
         })
         .expect("Failed to create user address space");
 
-    let (entry_vaddr, ustack_top, auxv) = load_user_app(&mut uspace, None, args, envs)
+    let (entry_vaddr, ustack_top, auxv) = load_user_app(&mut uspace, loc, &args[0], args, envs)
         .unwrap_or_else(|e| panic!("Failed to load user app: {}", e));
 
     let uctx = UserContext::new(entry_vaddr.into(), ustack_top, 0);

--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -503,9 +503,7 @@ impl ElfLoader {
         Self(LRUCache::new())
     }
 
-    fn load(&mut self, uspace: &mut AddrSpace, path: &str) -> AxResult<LoadResult> {
-        let loc = FS_CONTEXT.lock().resolve(path)?;
-
+    fn load(&mut self, uspace: &mut AddrSpace, loc: Location) -> AxResult<LoadResult> {
         if !self.0.touch(|e| e.borrow_cache().location().ptr_eq(&loc)) {
             match ElfCacheEntry::load(loc)? {
                 Ok(e) => {
@@ -600,10 +598,19 @@ pub fn clear_elf_cache() {
 
 /// Load the user app to the user address space.
 ///
+/// The executable is identified by an already-resolved [`Location`] — the
+/// caller resolves and opens it once (mirroring Linux's `do_open_execat`,
+/// which honors `AT_SYMLINK_NOFOLLOW` at that single lookup), and this never
+/// re-resolves the main executable from its pathname. Interpreters reached
+/// through a `.sh` redirect or a `#!` shebang are resolved here by path, which
+/// is Linux's `open_exec(interp)` and legitimately follows symlinks.
+///
 /// # Arguments
 /// - `uspace`: The address space of the user app.
-/// - `args`: The arguments of the user app. The first argument is the path of
-///   the user app.
+/// - `loc`: The resolved executable to load.
+/// - `path`: The pathname the executable was invoked as, used for the `.sh`
+///   redirect and for the script name an interpreter receives in `argv`.
+/// - `args`: The arguments of the user app.
 /// - `envs`: The environment variables of the user app.
 ///
 /// # Returns
@@ -611,14 +618,11 @@ pub fn clear_elf_cache() {
 /// - The stack pointer of the user app.
 pub fn load_user_app(
     uspace: &mut AddrSpace,
-    path: Option<&str>,
+    loc: Location,
+    path: &str,
     args: &[String],
     envs: &[String],
 ) -> AxResult<(VirtAddr, VirtAddr, Vec<AuxEntry>)> {
-    let path = path
-        .or_else(|| args.first().map(String::as_str))
-        .ok_or(AxError::InvalidInput)?;
-
     // `/proc/self/exe` is available in procfs; busybox can `readlink` it
     // to re-exec itself as a shell on ENOEXEC, provided the busybox build
     // includes that fallback (Alpine's prebuilt binary may not).
@@ -626,10 +630,11 @@ pub fn load_user_app(
         let new_args: Vec<String> = iter::once("/bin/sh".to_owned())
             .chain(args.iter().cloned())
             .collect();
-        return load_user_app(uspace, None, &new_args, envs);
+        let sh = FS_CONTEXT.lock().resolve("/bin/sh")?;
+        return load_user_app(uspace, sh, "/bin/sh", &new_args, envs);
     }
 
-    let (entry, auxv) = match { ELF_LOADER.lock().load(uspace, path)? } {
+    let (entry, auxv) = match { ELF_LOADER.lock().load(uspace, loc)? } {
         Ok((entry, auxv)) => (entry, auxv),
         Err(data) => {
             if data.starts_with(b"#!") {
@@ -644,7 +649,10 @@ pub fn load_user_app(
                     .chain(iter::once(path.to_owned()))
                     .chain(args.iter().skip(1).cloned())
                     .collect();
-                return load_user_app(uspace, None, &new_args, envs);
+                // Open the interpreter by path (Linux's `open_exec` on the
+                // shebang interpreter) and load it as the new executable.
+                let interp = FS_CONTEXT.lock().resolve(&new_args[0])?;
+                return load_user_app(uspace, interp, &new_args[0], &new_args, envs);
             }
             return Err(AxError::InvalidExecutable);
         }

--- a/os/StarryOS/kernel/src/syscall/task/execve.rs
+++ b/os/StarryOS/kernel/src/syscall/task/execve.rs
@@ -119,7 +119,7 @@ pub fn sys_execve(
     let mut new_aspace = new_user_aspace_empty()?;
     copy_from_kernel(&mut new_aspace)?;
     let (entry_point, user_stack_base, auxv) =
-        match load_user_app(&mut new_aspace, Some(path.as_str()), &args, &envs) {
+        match load_user_app(&mut new_aspace, loc, &path, &args, &envs) {
             Ok(result) => result,
             Err(AxError::InvalidExecutable) => {
                 // ENOEXEC fallback: retry via /bin/sh.
@@ -133,7 +133,7 @@ pub fn sys_execve(
                 args = iter::once(String::from(shell_path))
                     .chain(args.iter().cloned())
                     .collect();
-                load_user_app(&mut new_aspace, None, &args, &envs)?
+                load_user_app(&mut new_aspace, shell_loc, shell_path, &args, &envs)?
             }
             Err(e) => return Err(e),
         };

--- a/test-suit/starryos/qemu-smp1/system/test-elf-loader-shebang/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/test-elf-loader-shebang/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-elf-loader-shebang C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-elf-loader-shebang src/main.c)
+target_include_directories(test-elf-loader-shebang PRIVATE src)
+target_compile_options(test-elf-loader-shebang PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-elf-loader-shebang RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/test-elf-loader-shebang/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-elf-loader-shebang/src/main.c
@@ -1,0 +1,105 @@
+// Regression guard for the StarryOS ELF loader's script-loading paths.
+//
+// `load_user_app` / `ElfLoader` load the executable from an already-resolved
+// `Location` (the caller resolves once, mirroring Linux's `do_open_execat`)
+// and resolve script interpreters internally. Two such interpreter paths are
+// exercised here by execve()-ing scripts *directly* — no shell in between, so
+// the kernel loader, not busybox, is what handles them:
+//
+//   - /tmp/loader-shebang     (no .sh suffix) -> kernel `#!` shebang branch:
+//       not an ELF, starts with "#!", so the loader resolves the interpreter
+//       (/bin/sh) via open_exec and loads it as the new image.
+//   - /tmp/loader-dotsh.sh    (.sh suffix)    -> kernel `.sh` redirect branch:
+//       the loader rewrites argv to "/bin/sh <path>" before any ELF load.
+//
+// Each child must exec the script and exit 0; only then is the final marker
+// printed. A loader regression makes a child fail to exec (non-zero / signal),
+// which prints a `FAIL:` line (caught by fail_regex) instead of the marker.
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int write_script(const char *path, const char *body) {
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+    if (fd < 0) {
+        perror("open");
+        return -1;
+    }
+    size_t len = strlen(body);
+    if (write(fd, body, len) != (ssize_t)len) {
+        perror("write");
+        close(fd);
+        return -1;
+    }
+    if (close(fd) < 0) {
+        perror("close");
+        return -1;
+    }
+    // Re-assert the exec bit in case the active umask cleared it at open().
+    if (chmod(path, 0755) < 0) {
+        perror("chmod");
+        return -1;
+    }
+    return 0;
+}
+
+// fork() + execve(path) directly; returns 0 iff the child exec'd and exited 0.
+static int run_exec(const char *path) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return -1;
+    }
+    if (pid == 0) {
+        char *argv[] = {(char *)path, NULL};
+        char *envp[] = {NULL};
+        execve(path, argv, envp);
+        // execve only returns on failure.
+        perror("execve");
+        _exit(127);
+    }
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) {
+        perror("waitpid");
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "child for %s did not exit cleanly (status=0x%x)\n", path,
+                status);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void) {
+    // No .sh suffix -> exercises the kernel `#!` shebang branch.
+    const char *shebang = "/tmp/loader-shebang";
+    // .sh suffix -> exercises the kernel `.sh` redirect branch.
+    const char *dotsh = "/tmp/loader-dotsh.sh";
+
+    if (write_script(shebang, "#!/bin/sh\necho SHEBANG_RAN\n") != 0) {
+        printf("FAIL: write shebang script\n");
+        return 1;
+    }
+    if (write_script(dotsh, "#!/bin/sh\necho DOTSH_RAN\n") != 0) {
+        printf("FAIL: write .sh script\n");
+        return 1;
+    }
+
+    if (run_exec(shebang) != 0) {
+        printf("FAIL: exec shebang script\n");
+        return 1;
+    }
+    if (run_exec(dotsh) != 0) {
+        printf("FAIL: exec .sh script\n");
+        return 1;
+    }
+
+    printf("ELF_LOADER_SHEBANG_OK\n");
+    return 0;
+}


### PR DESCRIPTION
## 背景

#1144（实现 `execveat`）在 review 中发现：`load_user_app` / `ElfLoader::load` 拿到调用方已解析的可执行文件后，又把它转成路径字符串**二次按路径解析**了一遍。这导致 `execveat(..., AT_SYMLINK_NOFOLLOW)` 的语义无法正确实现：第一次 `resolve_no_follow` 的结果在第二次普通解析时又把符号链接跟随了。

对照 Linux：`do_execveat_common` 在 `do_open_execat` 处只打开一次文件（`bprm->file`），`AT_SYMLINK_NOFOLLOW` 在那唯一一次 lookup 生效；之后 binfmt/ELF 加载全程只消费这个文件对象，从不按路径重新解析。本仓库的加载器偏离了这个模型。

本 PR 把加载器对齐到 Linux 的“解析一次、按对象加载”模型，作为 #1144 修复 `AT_SYMLINK_NOFOLLOW` 的前置重构。

## 改动

- **`ElfLoader::load`**：签名由 `path: &str` 改为 `loc: Location`，删掉内部那次 `FS_CONTEXT.resolve`，对应 `load_elf_binary` 直接读 `bprm->file`。
- **`load_user_app`**：改为接收调用方已解析的 `Location`，不再二次解析主可执行文件。脚本解释器（`#!` shebang、`.sh` 重定向）仍在加载器内部按路径解析，对应 Linux 的 `open_exec(interp)`，本就该跟随符号链接。
- **两处调用方**（`sys_execve`、init 启动路径 `entry.rs`）：原本都已 `resolve` 出 `Location` 仅用于取 name/exe_path、随后丢弃，现在把它透传进加载器，顺带消除各自的重复解析。
- **测试布局**：将新增 Starry 回归测试放到 `test-suit/starryos/qemu-smp1/system/test-elf-loader-shebang`，作为 `qemu-smp1/system` grouped C 子用例安装到 `/usr/bin/starry-test-suit`；不再使用已移除的 `normal/qemu-smp1/...` 旧测试分组，也不再为子用例单独维护 `qemu-*.toml`。

## 测试

新增的 `test-elf-loader-shebang` C 驱动会直接 `execve()` 两个脚本，分别命中加载器的两条解释器路径：

- 无 `.sh` 后缀的 `#!` 脚本：进入内核 shebang 分支；
- `.sh` 脚本：进入内核 `.sh` 重定向分支。

两个子进程都必须正常 exec 并退出 0，才打印成功标记，作为本次重构的回归护栏。单个子用例可通过以下命令运行：

```bash
cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/test-elf-loader-shebang
```

本次 rebase 到最新 `dev` 后已验证：

```bash
cargo fmt --check
cargo fmt
cargo xtask clippy --package starry-kernel
cmake -S test-suit/starryos/qemu-smp1/system -B target/local-checks/starry-system-test-elf-loader-shebang -DSTARRY_GROUPED_C_SUBCASES=test-elf-loader-shebang && cmake --build target/local-checks/starry-system-test-elf-loader-shebang
cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/test-elf-loader-shebang
```

其中 x86_64 QEMU 子用例输出了 `SHEBANG_RAN`、`DOTSH_RAN`、`ELF_LOADER_SHEBANG_OK` 和 `STARRY_GROUPED_TESTS_PASSED`。
