### PR TITLE
fix(tui): set TERM in init.sh so TUI applications(e.g. top) can start

### DIFF
--- a/apps/starry/top/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/top/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,10 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "qemu",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/top/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/top/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,13 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-hal/loongarch64-qemu-virt",
+  "qemu",
+  "ax-driver/plat-static",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]
+plat_dyn = false

--- a/apps/starry/top/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/top/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/top/build-x86_64-unknown-none.toml
+++ b/apps/starry/top/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/top/prebuild.sh
+++ b/apps/starry/top/prebuild.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+overlay_dir="${STARRY_OVERLAY_DIR:-}"
+
+if [[ -z "$overlay_dir" ]]; then
+    echo "error: STARRY_OVERLAY_DIR is required" >&2
+    exit 1
+fi
+
+install -Dm0755 "$app_dir/top-test.sh" "$overlay_dir/usr/bin/top-test.sh"

--- a/apps/starry/top/qemu-aarch64.toml
+++ b/apps/starry/top/qemu-aarch64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/top-test.sh"
+success_regex = ["(?m)^TOP_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^TOP_TEST_FAILED\\s*$"]
+timeout = 300

--- a/apps/starry/top/qemu-loongarch64.toml
+++ b/apps/starry/top/qemu-loongarch64.toml
@@ -1,0 +1,24 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/top-test.sh"
+success_regex = ["(?m)^TOP_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^TOP_TEST_FAILED\\s*$"]
+timeout = 300

--- a/apps/starry/top/qemu-riscv64.toml
+++ b/apps/starry/top/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/top-test.sh"
+success_regex = ["(?m)^TOP_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^TOP_TEST_FAILED\\s*$"]
+timeout = 300

--- a/apps/starry/top/qemu-x86_64.toml
+++ b/apps/starry/top/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/top-test.sh"
+success_regex = ["(?m)^TOP_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^TOP_TEST_FAILED\\s*$"]
+timeout = 300

--- a/apps/starry/top/top-test.sh
+++ b/apps/starry/top/top-test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+echo "=== install procps ==="
+apk add procps || { echo "TOP_TEST_FAILED"; exit 1; }
+
+echo "=== test top requires TERM ==="
+output="/tmp/top_output.txt"
+top -n 1 > "$output" 2> /dev/null
+
+if [ -s "$output" ]; then
+	rm -f "$output"
+	echo "TOP_TEST_PASSED"
+else
+	rm -f "$output"
+	echo "TOP_TEST_FAILED: top produced no output (TERM may not be set)"
+	exit 1
+fi

--- a/os/StarryOS/starryos/src/init.sh
+++ b/os/StarryOS/starryos/src/init.sh
@@ -3,6 +3,7 @@
 export HOME=/root
 export USER=root
 export HOSTNAME=starry
+export TERM=xterm-256color
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 printf "Welcome to \033[96m\033[1mStarry OS\033[0m!\n"


### PR DESCRIPTION
#  Summary

 StarryOS 的 `init.sh` 缺少 TERM 环境变量，导致 top 等 TUI 应用程序启动时无法正确识别终端类型而报错退出。此 PR 在 `init.sh` 中添加 `export TERM=xterm-256color`，使 TUI 应用能正常启动。
