### PR TITLE
fix(axvisor): avoid SVM guest timer calibration stall

### DIFF
--- a/os/axvisor/configs/vms/qemu/x86_64/linux-svm-smp1.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/linux-svm-smp1.toml
@@ -27,10 +27,9 @@ kernel_path = "/guest/linux/linux-qemu"
 kernel_load_addr = 0x20_0000
 # Whether to enable BIOS boot flow.
 enable_bios = false
-# SVM phase-1 smoke keeps a dedicated command line so later stages can
-# adjust SVM bring-up independently from the VMX baseline.
-
-cmdline = "console=ttyS0 root=/dev/vda rw rootwait devtmpfs.mount=1 init=/sbin/getty acpi=off pci=conf1 pci=nomsi nox2apic tsc=unstable initcall_blacklist=ahci_pci_driver_init,i8042_init -- -n -l /bin/sh -L 115200 ttyS0 dumb"
+# Linux direct boot needs an explicit cmdline; keep no_timer_check from the old
+# default to avoid PIT/HPET calibration stalls when Linux marks the TSC unstable.
+cmdline = "console=ttyS0 root=/dev/vda rw rootwait devtmpfs.mount=1 init=/sbin/getty acpi=off pci=conf1 pci=nomsi nox2apic tsc=unstable no_timer_check initcall_blacklist=ahci_pci_driver_init,i8042_init -- -n -l /bin/sh -L 115200 ttyS0 dumb"
 
 ## The path of the disk image.
 # disk_path = ""

--- a/scripts/axbuild/src/axvisor/test.rs
+++ b/scripts/axbuild/src/axvisor/test.rs
@@ -1646,6 +1646,22 @@ mod tests {
     }
 
     #[test]
+    fn x86_linux_direct_boot_configs_keep_timer_calibration_bypass() {
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for path in [
+            "os/axvisor/configs/vms/qemu/x86_64/linux-vmx-smp1.toml",
+            "os/axvisor/configs/vms/qemu/x86_64/linux-svm-smp1.toml",
+        ] {
+            let content = fs::read_to_string(workspace_root.join(path)).unwrap();
+            assert!(
+                content.contains("no_timer_check"),
+                "{path} should keep no_timer_check to avoid x86 Linux guest timer calibration \
+                 stalls"
+            );
+        }
+    }
+
+    #[test]
     fn ignores_qemu_only_build_groups_when_discovering_board_tests() {
         let root = tempdir().unwrap();
         write_qemu_build_config(


### PR DESCRIPTION
## 问题

`Test axvisor x86_64 svm hosted` 在 AMD hosted runner 上运行 `smoke-svm` 时，Linux guest 能启动并挂载 rootfs，但没有进入测试期望的 shell marker，最终 QEMU 在 180s 后超时。

对比 VMX 直启 Linux guest 配置后，SVM 配置缺少 `no_timer_check`。VMX 配置中已有该参数，用于避免 Linux 在 TSC 被标记为 unstable 时卡在 PIT/HPET timer calibration 路径。

## 修改

- 在 `linux-svm-smp1.toml` 的 guest cmdline 中补上 `no_timer_check`，与 VMX x86 Linux direct boot 配置保持一致。
- 更新 SVM 配置注释，说明该参数用于规避 timer calibration stall。
- 增加 axbuild 单元测试，检查 VMX/SVM x86 Linux direct boot 配置都保留 `no_timer_check`，避免后续回退。

## 验证

- `cargo fmt`
- `cargo test -p axbuild x86_linux_direct_boot_configs_keep_timer_calibration_bypass -- --nocapture`
- `cargo xtask clippy --package axbuild`
- `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm --list`
- `git diff --check`

本地机器为 Intel CPU，无法直接复现 AMD SVM hosted QEMU 用例；完整 `smoke-svm` 需要依赖 GitHub Actions 的 AMD hosted runner 验证。