### PR TITLE
Disable LTO in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["arceos", "kernel"]
 categories = ["os", "no-std"]
 
 [profile.release]
-lto = true
+lto = false
 
 [workspace]
 resolver = "3"


### PR DESCRIPTION
Based on the experience of [asterinas](https://github.com/asterinas/asterinas), This profile is optimized for maximum runtime performance, (achieving a 2% reduction in latency for the getpid system call). However, enabling LTO significantly increases compilation times, approximately doubling them compared to when LTO is not enabled. Therefore, I believe that disabling LTO by default is a better option.