### PR TITLE
feat(loongarch64): support dynamic UEFI platform boot

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: arch-platform-porting
+description: Add, adapt, debug, or review architecture/platform support for ArceOS, StarryOS, Axvisor, someboot, dynamic UEFI platform boot, SMP startup, QEMU boot configs, target JSON files, axbuild arch mapping, axcpu trap/context code, axplat-dyn, somehal, and LoongArch/x86/aarch64/riscv platform bring-up issues.
+---
+
+# Arch Platform Porting
+
+Use this skill when adding or fixing an architecture, switching QEMU cases to dynamic UEFI platform boot, enabling SMP in someboot, debugging early boot hangs, or validating ArceOS/StarryOS/Axvisor on a new arch/platform path.
+
+For detailed pitfalls and debugging notes from the LoongArch dynamic UEFI/SMP bring-up, read `references/boot-debugging.md` when the task touches early boot, trap vectors, MMU, SMP, UEFI exit, or Axvisor LVZ QEMU.
+
+Current Axvisor LoongArch QEMU tests intentionally use the static `ax-hal/loongarch64-qemu-virt` platform, non-UEFI QEMU boot, and an ELF kernel image without BIN conversion. Treat Axvisor LoongArch dynamic UEFI bring-up as a separate task unless the user explicitly asks to change that platform mode.
+
+## First Pass
+
+1. Identify the layer that is changing: target spec, axbuild, test-suit config, someboot, axcpu, axplat-dyn/somehal, device driver, or OS config.
+2. Inspect the closest working architecture first. For dynamic UEFI paths, compare with x86_64 before inventing new behavior.
+3. Trace the full boot contract from QEMU args to kernel entry. Do not assume a QEMU config change is enough if the firmware, target ABI, loader, and runtime platform disagree.
+4. Prefer `cargo xtask` flows for ArceOS, StarryOS, and Axvisor. If a special QEMU/container setup needs raw commands, inspect the xtask path and match its arguments.
+5. Keep temporary debug markers out of the final patch unless the user explicitly asks to retain them.
+
+## Porting Checklist
+
+- **Target and toolchain**: add or verify `scripts/targets` specs, target triple, panic strategy, relocation model, code model, ABI, soft-float setting, musl/std support, linker, objcopy, and `rust-src` availability.
+- **Build system**: wire arch/target mapping in `scripts/axbuild`, dynamic platform defaults, feature propagation, kernel format conversion, UEFI/to-bin behavior, rootfs handling, and per-OS test discovery.
+- **QEMU and firmware**: verify QEMU binary, machine type, CPU, SMP count, pflash/OVMF files, serial console, disk/rootfs device, `-snapshot`, debug flags, timeout, and success/fail regexes.
+- **someboot arch layer**: implement or audit entry, relocation, BSS clearing, stack setup, memory map parsing, paging, trap vectors, timer, IRQ, power, SMP, and address translation.
+- **CPU runtime**: update `components/axcpu/src/<arch>` for trap entry, context switch, user/kernel context, syscall return path, FP/SIMD state, and per-CPU assumptions.
+- **Platform bridge**: update `platforms/axplat-dyn`, `platforms/somehal`, platform config, memory regions, IRQ routing, timer source, power operations, and CPU boot operations.
+- **Page tables and memory**: check PTE flags, huge page support, direct map, kernel high map, MMIO map, TLB/cache barriers, and early `phys_to_virt` behavior before MMU state is fully recorded.
+- **Drivers and rootfs**: check PCI command bits, MMIO/iomap, DMA address width, virtio transport, block device visibility, rootfs patching, and console/input feature flags.
+- **OS configs and test cases**: update ArceOS, StarryOS, and Axvisor configs only for validated architectures. Keep `qemu-<arch>.toml` runtime config separate from `build-*.toml`.
+
+## someboot Must-Haves
+
+- Preserve the firmware entry ABI. UEFI entry carries `image_handle` and `system_table`; direct boot paths use different arguments.
+- Establish an early console before risky transitions, then ensure a post-UEFI/post-MMU console path exists without Boot Services.
+- Capture the memory map and kernel image physical range before address translation helpers depend on them.
+- Treat relocated symbols carefully. After relocation or high-half switch, use runtime-safe symbol address helpers instead of raw compile-time addresses.
+- Clear BSS exactly once and after preserving any entry data that lives there.
+- Allocate and align boot stack, per-CPU areas, secondary stacks, boot arguments, and page tables before enabling SMP.
+- Install trap vectors before enabling interrupts, timer interrupts, MMU faults, or secondary CPU execution.
+- Build page tables for identity/firmware access, direct map, kernel high map, MMIO, and per-CPU data as the arch requires.
+- Flush TLB/cache and use architecture barriers around page table writes, boot argument writes, and secondary CPU release.
+- After `ExitBootServices`, do not call UEFI Boot Services. Retry only through the correct memory-map-key sequence before exit.
+
+## SMP Bring-Up Rules
+
+1. Discover enabled CPUs from firmware data and keep firmware IDs separate from logical CPU IDs.
+2. Bound-check CPU indices and avoid assuming hart/apic/mpidr/cpuid values are dense.
+3. Prepare one boot argument block per secondary CPU with stack, page table, kernel entry, per-CPU base, and logical ID.
+4. Flush boot arguments and page tables before `cpu_on`.
+5. In the secondary path, initialize arch address windows, stack, per-CPU register, page table state, trap vectors, timer, and interrupt state before entering generic secondary code.
+6. Debug secondary failure with physical-address markers first; serial logging may not work until the secondary has its own mapping and trap state.
+
+## Validation Ladder
+
+Run the smallest useful check first, then climb:
+
+```bash
+cargo test -p axbuild --lib
+cargo xtask arceos test qemu --arch <arch>
+cargo xtask starry test qemu --arch <arch>
+cargo xtask axvisor test qemu --list --arch <arch>
+cargo xtask axvisor test qemu --arch <arch> --test-group normal --test-case smoke
+```
+
+For LoongArch Axvisor LVZ validation, use the repository LVZ container and build `xtask` inside the container so embedded Cargo paths match the mounted workspace:
+
+```bash
+docker run --rm -v "$PWD:/workspace" -w /workspace \
+  ghcr.io/rcore-os/tgoskits-container-axvisor-lvz:latest \
+  bash -lc 'cargo xtask axvisor test qemu --arch loongarch64 --test-group normal --test-case smoke'
+```
+
+When Rust logic changes, also run the relevant targeted clippy command, usually:
+
+```bash
+cargo fmt
+cargo xtask clippy --package axbuild
+cargo xtask clippy --package someboot
+```
+
+Adjust the package list to match the crates touched.
+
+## Debugging Workflow
+
+1. Locate the last reliable print or machine state transition: UEFI entry, memory map, `ExitBootServices`, relocation, MMU enable, trap vector install, secondary release, first kernel print.
+2. Add temporary byte-sized serial or MMIO markers around the transition. Remove them after finding the cause.
+3. Use QEMU debug flags such as `-d int,cpu_reset,guest_errors` and `-S -s` when xtask exposes or can be patched to pass them.
+4. Inspect symbols and generated images with `llvm-objdump`, `readelf`, and map files. Confirm runtime addresses, not only link addresses.
+5. Compare with local Linux architecture code for ordering of MMU, trap, SMP, and cache/TLB barriers when uncertain. First search for a local Linux source tree, then inspect the matching `arch/<linux-arch>` directory; do not assume a fixed path.
+6. Turn the root cause into a regression test or a focused QEMU case when practical.
+
+## Common Failure Signals
+
+- Hangs after `Exiting UEFI boot services...`: suspect stale memory map key, no post-exit console, wrong handoff address, MMU switch, or exception before trap vectors are valid.
+- Fetch/load/store fault at high-half address: suspect kernel high map, direct map, DMW/window config, relocation offset, or wrong symbol address basis.
+- TLB refill recursion or silent reset: suspect TLB refill entry physical address, trap vector mapping, stack mapping, or missing TLB flush.
+- Secondary CPU never prints: suspect firmware CPU ID mapping, boot args cache visibility, secondary stack, per-CPU base, page table root, or per-secondary trap setup.
+- Starry boots but interactive/system tests fail: suspect rootfs staging, input/console features, CPR/tty sizing assumptions, or success regex mismatches.
+- Virtio block/rootfs missing: suspect PCI command enable, MMIO mapping, DMA address translation, virtio transport selection, or rootfs patch path.
+- Axvisor only fails in LVZ container: verify container QEMU path, OVMF path, target toolchain, KVM/LVZ flags, and whether xtask was built inside the mounted workspace.
+
+## Completion Criteria
+
+- The change is validated at the smallest affected layer and at least one end-to-end QEMU path for the target OS.
+- Temporary debug markers, QEMU one-offs, and local-only paths are removed or documented as intentional.
+- `qemu-<arch>.toml`, `build-*.toml`, and OS configs only advertise architectures that were actually validated.
+- New target/container/firmware requirements are documented in the relevant skill, test-suit guide, or docs page.
+- If the task changes architecture boot logic, someboot startup order, UEFI handoff, SMP bring-up, dynamic platform contracts, target JSON assumptions, or the recommended debugging flow, update this skill or `references/boot-debugging.md` in the same change.

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -1,0 +1,138 @@
+# Boot Debugging Reference
+
+This reference captures project-specific lessons from enabling LoongArch dynamic UEFI platform boot, someboot SMP, StarryOS tests, and Axvisor LVZ smoke testing.
+
+## Layer Map
+
+| Layer | Typical files | What must agree |
+| --- | --- | --- |
+| Target spec | `scripts/targets/**/<triple>.json` | ABI, soft-float, relocation model, linker, panic, std/musl support |
+| Build orchestration | `scripts/axbuild/src/{build.rs,context,test/qemu.rs,*}` | arch to target mapping, features, UEFI mode, QEMU command, rootfs image |
+| Test data | `test-suit/{arceos,starryos,axvisor}/**` | runtime TOML, build TOML, regexes, SMP count, firmware mode |
+| Bootloader | `components/someboot/src/**` | entry ABI, relocation, memory map, paging, trap, SMP, power |
+| CPU runtime | `components/axcpu/src/<arch>/**` | trap frame layout, context switch, FP/SIMD, user return |
+| Dynamic platform | `platforms/{axplat-dyn,somehal}/**` | runtime memory/IRQ/timer/power facts from firmware |
+| Drivers | `drivers/**`, `patches/virtio-drivers/**` | MMIO/iomap, DMA, PCI command bits, virtio transport |
+
+When a boot failure appears in a high layer, still audit lower-layer contracts. For example, a Starry rootfs failure can be caused by PCI command bits, and an Axvisor hang can be caused by a someboot post-UEFI handoff.
+
+## Dynamic UEFI Platform Notes
+
+- Dynamic platform means the platform facts come from firmware/runtime discovery through `someboot`, `somehal`, and `axplat-dyn`. It does not remove the need for arch-specific page table, trap, timer, IRQ, and power code.
+- Match the x86_64 dynamic UEFI path first: firmware disk layout, `to_bin` behavior, pflash/OVMF handling, and handoff expectations.
+- Keep dynamic platform features aligned across `ax-std`, `ax-hal`, `ax-driver`, `axvm`, and the OS package. A partial `plat-dyn` feature set often compiles but fails after device or memory init.
+- For std/musl targets, derive the initial JSON from a known Rust target where possible, then minimally adjust ABI, linker, relocation model, and soft-float. A `none-softfloat` target passing does not prove musl/std ABI correctness.
+- Prefer runtime memory map data over board constants. Any early helper such as `phys_to_virt` must be valid for the phase where it is called.
+
+## someboot Startup Checklist
+
+Use this order when auditing an early boot port:
+
+1. Entry preserves firmware arguments and records them before BSS or relocation can destroy them.
+2. Early serial output works before `ExitBootServices`.
+3. Firmware memory map is captured, classified, and converted into the kernel memory model.
+4. Kernel image physical range, load offset, and high-half range are known before address translation helpers are used.
+5. Page tables or arch direct-map windows cover the currently executing code, boot stack, page tables, kernel high map, MMIO, and boot data.
+6. Trap vectors are installed using the address form required by the architecture at that moment.
+7. MMU enable is followed by the required barrier, TLB flush, and an address-basis-safe jump.
+8. Post-MMU console and panic paths are usable.
+9. Per-CPU data and secondary boot stacks are allocated and initialized.
+10. Secondary CPU release happens only after boot arguments and page tables are visible to other CPUs.
+
+## LoongArch Lessons
+
+- TLB refill entry and general exception entry use different registers and may require different address forms. Do not reuse a high-half virtual symbol where a physical TLB refill vector is required.
+- Relocated symbols must be resolved relative to the running image. In the LoongArch SMP path, the secondary exception vector had to use a runtime symbol helper such as `sym_running_addr!(__exception_vectors)`, while the TLB refill entry needed the corresponding physical address.
+- A secondary CPU can fault before it has a working serial path. Put markers before and after DMW setup, stack switch, page table register setup, trap-vector setup, and jump to the common secondary entry.
+- Initialize trap vectors on every CPU, not only the boot CPU.
+- Flush or barrier boot arguments before `cpu_on`; otherwise secondaries can observe stale stack, page table, or per-CPU data.
+- Keep logical CPU ID mapping separate from firmware CPU IDs. LoongArch CPU IDs in firmware data are not guaranteed to be dense array indices.
+- Compare ordering with local Linux architecture code when uncertain. For LoongArch, useful topics include DMW setup, CSR write ordering, TLB refill vector, exception entry, SMP boot argument handoff, and cache/TLB barriers.
+
+## Finding Local Linux Source
+
+When Linux behavior is useful as an architecture reference, look for a local kernel tree before relying on memory or online search:
+
+```bash
+find "$PWD" "$PWD/.." "$HOME" /home -maxdepth 4 -type f -name Makefile \
+  -path '*/linux*/Makefile' 2>/dev/null
+```
+
+Verify a candidate by checking for a top-level `Makefile`, `Kconfig`, and the target architecture directory. Common directory names differ from Rust target names:
+
+| Project arch | Linux arch directory |
+| --- | --- |
+| `loongarch64` | `arch/loongarch` |
+| `x86_64` | `arch/x86` |
+| `aarch64` | `arch/arm64` |
+| `riscv64` | `arch/riscv` |
+
+Search the local tree with `rg` before opening large files. Good first patterns include `setup_arch`, `start_kernel`, `smp_prepare_cpus`, `secondary_start`, `cpu_up`, `set_exception`, `tlb`, `fixmap`, and architecture-specific CSR/register names.
+
+## Axvisor LVZ Container Notes
+
+Use the LVZ container for LoongArch Axvisor validation because host QEMU may not include the needed LVZ support:
+
+```bash
+docker run --rm -v "$PWD:/workspace" -w /workspace \
+  ghcr.io/rcore-os/tgoskits-container-axvisor-lvz:latest \
+  bash -lc 'cargo xtask axvisor test qemu --arch loongarch64 --test-group normal --test-case smoke'
+```
+
+Important details:
+
+- Build and run `cargo xtask` inside the container. A host-built `target/debug/tg-xtask` can embed a host `CARGO_MANIFEST_DIR` path that does not exist inside `/workspace`.
+- Check `/opt/qemu-lvz/bin/qemu-system-loongarch64`, OVMF files under `/tmp/ostool/ovmf/loongarch64`, and the musl toolchain before assuming the kernel is at fault.
+- If output reaches `Exiting UEFI boot services...` and stops before the next someboot print, instrument immediately before and after `ExitBootServices`, memory map handoff, first post-exit console call, and MMU/trap setup.
+- Container success still needs host-independent documentation if the CI or developer flow depends on that image.
+
+## QEMU Debugging Patterns
+
+- Add `-S -s` to stop at reset and attach GDB when the failure is before the first reliable print.
+- Add `-d int,cpu_reset,guest_errors` to capture traps, resets, and invalid guest accesses.
+- Use short serial markers for phase isolation. Example phases: `E` for UEFI entry, `M` for memory map, `X` before exit boot services, `x` after exit, `P` before paging, `p` after paging, `T` after trap vectors, `S` before secondary release.
+- Remove markers before finalizing unless they become intentional diagnostics.
+- If QEMU is launched by `ostool`, patch the local ostool or xtask wrapper temporarily rather than hand-assembling a different command line. The reproduced command must remain faithful to the failing path.
+
+## Symptom Triage
+
+| Symptom | First suspects |
+| --- | --- |
+| Stops at or after UEFI exit | memory map key, Boot Services call after exit, post-exit console, handoff address, trap before vectors |
+| Immediate reset after MMU enable | wrong page table root, missing identity/current mapping, bad barrier/TLB flush, invalid jump target |
+| High-half fetch fault | kernel high map, relocation offset, symbol address basis, direct-map window |
+| TLB refill recursion | TLB refill vector address, stack mapping, refill handler mapping, CSR ordering |
+| Secondary CPU silent | `cpu_on` argument, cache flush, stack, per-CPU base, trap setup, logical CPU ID mapping |
+| ArceOS works but Starry fails | rootfs staging, std/musl ABI, console/input feature, tty assumptions, CPR sizing |
+| Starry shell works but grouped tests fail | generated runner path, copied assets, success regex, `shell_init_cmd` versus `test_commands` |
+| Axvisor build works but QEMU hangs | firmware/OVMF path, LVZ QEMU, guest image/rootfs, dynamic platform memory map, post-UEFI transition |
+| Virtio block missing | PCI command enable, virtio transport, MMIO map, DMA translation, rootfs disk args |
+
+## Validation Recipe From This Bring-Up
+
+These commands form a practical ladder for LoongArch dynamic platform work:
+
+```bash
+cargo test -p axbuild --lib
+cargo xtask arceos test qemu --arch loongarch64
+cargo xtask starry test qemu --arch loongarch64
+docker run --rm -v "$PWD:/workspace" -w /workspace \
+  ghcr.io/rcore-os/tgoskits-container-axvisor-lvz:latest \
+  bash -lc 'cargo xtask axvisor test qemu --list --arch loongarch64'
+docker run --rm -v "$PWD:/workspace" -w /workspace \
+  ghcr.io/rcore-os/tgoskits-container-axvisor-lvz:latest \
+  bash -lc 'cargo xtask axvisor test qemu --arch loongarch64 --test-group normal --test-case smoke'
+```
+
+If logic changed in the relevant crates, run targeted clippy after formatting:
+
+```bash
+cargo fmt
+cargo xtask clippy --package axbuild
+cargo xtask clippy --package someboot
+cargo xtask clippy --package ax-cpu
+cargo xtask clippy --package axplat-dyn
+cargo xtask clippy --package ax-driver
+```
+
+Adjust the package set to the actual diff. Documentation-only skill updates do not require clippy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@
 - Use `board-linux-starry-debug` when a physical-board workflow needs Linux-side deployment or inspection before running StarryOS or ArceOS, including `board connect` IP discovery, SSH/rsync while holding a board lease, explicit `sync` before rebooting into StarryOS, diagnosing StarryOS `not found` for files copied into the Linux rootfs, or comparing Linux-visible and StarryOS-visible board rootfs state.
 - `crates-io-owner`: project-local skill at `.claude/skills/crates-io-owner/SKILL.md`
 - Use `crates-io-owner` when the user wants to add or verify `github:rcore-os:crates-io` for branch-added crates, asks which new crates still need the crates.io team owner, or explicitly wants `cargo owner` used instead of `Cargo.toml` metadata.
+- `arch-platform-porting`: project-local skill at `.claude/skills/arch-platform-porting/SKILL.md`
+- Use `arch-platform-porting` when the user wants to add, adapt, debug, or review architecture/platform support for ArceOS, StarryOS, Axvisor, someboot, dynamic UEFI platform boot, SMP startup, QEMU boot configs, target JSON files, axbuild arch mapping, axcpu trap/context code, axplat-dyn, somehal, or LoongArch/x86/aarch64/riscv platform bring-up issues.
 
 ## Other Requirements
 
@@ -40,3 +42,4 @@
 - Before submitting a PR, locally validate the CI flow as much as practical, excluding only physical board tests and self-hosted test flows unless the user explicitly asks to run them. Changes unrelated to building or testing, such as documentation-only updates, do not require local CI validation.
 - After adding or changing commits on a PR branch, update the PR description so it stays synchronized with the committed changes.
 - Do not insert agent-related labels, signatures, branding, or other advertisement-style wording such as `codex`, `agent`, `AI`, or similar self-promotional tags unless the user explicitly requests it.
+- When changing architecture boot logic, someboot startup order, UEFI handoff, SMP bring-up, dynamic platform contracts, target JSON assumptions, or the recommended debugging flow, update `.claude/skills/arch-platform-porting/SKILL.md` or its references in the same change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7571,6 +7571,7 @@ dependencies = [
  "ax-riscv-plic",
  "kernutil",
  "log",
+ "loongArch64",
  "mmio-api",
  "page-table-generic",
  "rdif-intc",

--- a/apps/arceos/arce_agent/qemu-loongarch64.toml
+++ b/apps/arceos/arce_agent/qemu-loongarch64.toml
@@ -1,6 +1,6 @@
 args = ["-machine", "virt", "-cpu", "la464", "-m", "128M", "-smp", "1", "-nographic", "-device", "virtio-blk-pci,drive=disk0", "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/arceos/arce_agent/disk.img", "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0", "-serial", "mon:stdio"]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["ArceAgent smoke test ready"]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]
 timeout = 30

--- a/apps/arceos/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/arceos/build-aarch64-unknown-none-softfloat.toml
@@ -1,7 +1,6 @@
 features = []
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true
 
 [env]
 AX_GW = "10.0.2.2"

--- a/apps/arceos/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/arceos/build-loongarch64-unknown-none-softfloat.toml
@@ -1,6 +1,4 @@
-features = [
-  "ax-hal/loongarch64-qemu-virt",
-]
+features = []
 log = "Info"
 max_cpu_num = 1
 

--- a/apps/arceos/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/arceos/build-riscv64gc-unknown-none-elf.toml
@@ -1,7 +1,6 @@
 features = []
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true
 
 [env]
 AX_GW = "10.0.2.2"

--- a/apps/arceos/build-x86_64-unknown-none.toml
+++ b/apps/arceos/build-x86_64-unknown-none.toml
@@ -3,7 +3,6 @@ features = [
 log = "Info"
 max_cpu_num = 1
 
-plat_dyn = true
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/apps/arceos/helloworld/qemu-loongarch64.toml
+++ b/apps/arceos/helloworld/qemu-loongarch64.toml
@@ -1,5 +1,5 @@
 args = ["-machine", "virt", "-cpu", "la464", "-m", "128M", "-smp", "1", "-nographic", "-device", "virtio-blk-pci,drive=disk0", "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/arceos/helloworld/disk.img", "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0", "-serial", "mon:stdio"]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["Hello, world!"]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]

--- a/apps/arceos/httpclient/qemu-loongarch64.toml
+++ b/apps/arceos/httpclient/qemu-loongarch64.toml
@@ -1,6 +1,6 @@
 args = ["-machine", "virt", "-cpu", "la464", "-m", "128M", "-smp", "1", "-nographic", "-device", "virtio-blk-pci,drive=disk0", "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/arceos/httpclient/disk.img", "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0", "-serial", "mon:stdio"]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["HTTP client tests run OK!"]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]
 timeout = 60

--- a/apps/arceos/httpserver/qemu-loongarch64.toml
+++ b/apps/arceos/httpserver/qemu-loongarch64.toml
@@ -1,6 +1,6 @@
 args = ["-machine", "virt", "-cpu", "la464", "-m", "128M", "-smp", "1", "-nographic", "-device", "virtio-blk-pci,drive=disk0", "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/arceos/httpserver/disk.img", "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0", "-serial", "mon:stdio"]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["HTTP server smoke test ready"]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]
 timeout = 60

--- a/apps/arceos/io_test/qemu-loongarch64.toml
+++ b/apps/arceos/io_test/qemu-loongarch64.toml
@@ -1,6 +1,6 @@
 args = ["-machine", "virt", "-cpu", "la464", "-m", "128M", "-smp", "1", "-nographic", "-device", "virtio-blk-pci,drive=disk0", "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/arceos/io_test/disk.img", "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0", "-serial", "mon:stdio"]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["=== 所有测试完成 ==="]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b", "Error \\{"]
 timeout = 120

--- a/apps/arceos/shell/qemu-loongarch64.toml
+++ b/apps/arceos/shell/qemu-loongarch64.toml
@@ -1,5 +1,5 @@
 args = ["-machine", "virt", "-cpu", "la464", "-m", "128M", "-smp", "1", "-nographic", "-device", "virtio-blk-pci,drive=disk0", "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/arceos/shell/disk.img", "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0", "-serial", "mon:stdio"]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["Available commands:"]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]

--- a/apps/arceos/thread_test/qemu-loongarch64.toml
+++ b/apps/arceos/thread_test/qemu-loongarch64.toml
@@ -1,6 +1,6 @@
 args = ["-machine", "virt", "-cpu", "la464", "-m", "128M", "-smp", "1", "-nographic", "-device", "virtio-blk-pci,drive=disk0", "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/arceos/thread_test/disk.img", "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0", "-serial", "mon:stdio"]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["=== 所有测试完成 ==="]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]
 timeout = 120

--- a/apps/arceos/tokio_test/qemu-loongarch64.toml
+++ b/apps/arceos/tokio_test/qemu-loongarch64.toml
@@ -1,6 +1,6 @@
 args = ["-machine", "virt", "-cpu", "la464", "-m", "128M", "-smp", "1", "-nographic", "-device", "virtio-blk-pci,drive=disk0", "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/arceos/tokio_test/disk.img", "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0", "-serial", "mon:stdio"]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["=== 所有 Tokio 测试完成 ==="]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]
 timeout = 120

--- a/apps/starry/claw-code/build-x86_64-unknown-none.toml
+++ b/apps/starry/claw-code/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/codex-cli/build-x86_64-unknown-none.toml
+++ b/apps/starry/codex-cli/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/deepseek-tui/build-x86_64-unknown-none.toml
+++ b/apps/starry/deepseek-tui/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/diffutils/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/diffutils/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/diffutils/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/diffutils/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/diffutils/build-x86_64-unknown-none.toml
+++ b/apps/starry/diffutils/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/ebpf/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ebpf/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/ebpf/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/ebpf/build-x86_64-unknown-none.toml
+++ b/apps/starry/ebpf/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/ffmpeg/build-x86_64-unknown-none.toml
+++ b/apps/starry/ffmpeg/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
     "ax-driver/virtio-blk",
     "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/gcc/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/gcc/build-aarch64-unknown-none-softfloat.toml
@@ -6,4 +6,3 @@ features = [
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/gcc/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/gcc/build-riscv64gc-unknown-none-elf.toml
@@ -10,4 +10,3 @@ features = [
   "starry-kernel/input",
   "starry-kernel/vsock",
 ]
-plat_dyn = true

--- a/apps/starry/gcc/build-x86_64-unknown-none.toml
+++ b/apps/starry/gcc/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/gdb-smoke/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/gdb-smoke/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/git/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/git/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/git/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/git/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/git/build-x86_64-unknown-none.toml
+++ b/apps/starry/git/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/glibc-dynamic-smoke/build-x86_64-unknown-none.toml
+++ b/apps/starry/glibc-dynamic-smoke/build-x86_64-unknown-none.toml
@@ -7,5 +7,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "x86_64-unknown-none"

--- a/apps/starry/jcode/build-x86_64-unknown-none.toml
+++ b/apps/starry/jcode/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/k230-kpu-nncase/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/k230-kpu-nncase/build-riscv64gc-unknown-none-elf.toml
@@ -3,5 +3,4 @@ features = [
   "k230",
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/k230-qemu/qemu-k230/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/k230-qemu/qemu-k230/build-riscv64gc-unknown-none-elf.toml
@@ -3,5 +3,4 @@ features = [
   "k230",
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/llama-cpp/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/llama-cpp/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/llama-cpp/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/llama-cpp/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/llama-cpp/build-x86_64-unknown-none.toml
+++ b/apps/starry/llama-cpp/build-x86_64-unknown-none.toml
@@ -7,5 +7,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "x86_64-unknown-none"

--- a/apps/starry/mariadb/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/mariadb/build-aarch64-unknown-none-softfloat.toml
@@ -10,4 +10,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/mariadb/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/mariadb/build-riscv64gc-unknown-none-elf.toml
@@ -14,4 +14,3 @@ features = [
   "starry-kernel/input",
   "starry-kernel/vsock",
 ]
-plat_dyn = true

--- a/apps/starry/mariadb/build-x86_64-unknown-none.toml
+++ b/apps/starry/mariadb/build-x86_64-unknown-none.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/mosquitto/build-x86_64-unknown-none.toml
+++ b/apps/starry/mosquitto/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
     "ax-driver/virtio-blk",
     "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/musl-dynamic-smoke/build-x86_64-unknown-none.toml
+++ b/apps/starry/musl-dynamic-smoke/build-x86_64-unknown-none.toml
@@ -7,5 +7,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "x86_64-unknown-none"

--- a/apps/starry/mysql/build-x86_64-unknown-none.toml
+++ b/apps/starry/mysql/build-x86_64-unknown-none.toml
@@ -9,4 +9,3 @@ features = [
     "ax-driver/virtio-input",
     "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/nginx/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/nginx/build-riscv64gc-unknown-none-elf.toml
@@ -11,4 +11,3 @@ features = [
   "ax-driver/virtio-socket",
   "starry-kernel/input",
 ]
-plat_dyn = true

--- a/apps/starry/nginx/build-x86_64-unknown-none.toml
+++ b/apps/starry/nginx/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/openrc/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/openrc/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/openrc/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/openrc/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/openrc/build-x86_64-unknown-none.toml
+++ b/apps/starry/openrc/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/openssh/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/openssh/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/openssh/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/openssh/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/openssh/build-x86_64-unknown-none.toml
+++ b/apps/starry/openssh/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/orangepi-5-plus-uvc-rknn/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/orangepi-5-plus-uvc-rknn/build-aarch64-unknown-none-softfloat.toml
@@ -14,4 +14,3 @@ features = [
 ]
 log = "Warn"
 max_cpu_num = 1
-plat_dyn = true

--- a/apps/starry/orangepi-5-plus-uvc/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/orangepi-5-plus-uvc/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true

--- a/apps/starry/picoclaw-cli/build-x86_64-unknown-none.toml
+++ b/apps/starry/picoclaw-cli/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/pip/build-x86_64-unknown-none.toml
+++ b/apps/starry/pip/build-x86_64-unknown-none.toml
@@ -5,4 +5,3 @@ features = [
     "ax-driver/virtio-blk",
     "ax-driver/virtio-net",
 ]
-plat_dyn = true

--- a/apps/starry/postgresql/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/postgresql/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/postgresql/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/postgresql/build-riscv64gc-unknown-none-elf.toml
@@ -10,5 +10,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/postgresql/build-x86_64-unknown-none.toml
+++ b/apps/starry/postgresql/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/qemu/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/qemu/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/qemu/build-x86_64-unknown-none.toml
+++ b/apps/starry/qemu/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/qemu/memtrack-backtrace/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/qemu/memtrack-backtrace/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/memtrack",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/qemu/memtrack-backtrace/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/qemu/memtrack-backtrace/build-riscv64gc-unknown-none-elf.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/memtrack",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/qemu/memtrack-backtrace/build-x86_64-unknown-none.toml
+++ b/apps/starry/qemu/memtrack-backtrace/build-x86_64-unknown-none.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-socket",
   "starry-kernel/memtrack",
 ]
-plat_dyn = true

--- a/apps/starry/qemu/nvme/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/qemu/nvme/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/qemu/nvme/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/qemu/nvme/build-riscv64gc-unknown-none-elf.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/qemu/nvme/build-x86_64-unknown-none.toml
+++ b/apps/starry/qemu/nvme/build-x86_64-unknown-none.toml
@@ -7,4 +7,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/redis/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/redis/build-aarch64-unknown-none-softfloat.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/redis/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/redis/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/redis/build-x86_64-unknown-none.toml
+++ b/apps/starry/redis/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/static-pie-test/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/static-pie-test/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/git-https/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/git-https/build-aarch64-unknown-none-softfloat.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/git-https/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/git-https/build-riscv64gc-unknown-none-elf.toml
@@ -10,5 +10,4 @@ features = [
   "starry-kernel/input",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/git-https/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/git-https/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git-remote/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/git-remote/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/git-remote/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/git-remote/build-riscv64gc-unknown-none-elf.toml
@@ -11,5 +11,4 @@ features = [
   "starry-kernel/input",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/git-remote/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/git-remote/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git-rename/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/git-rename/build-riscv64gc-unknown-none-elf.toml
@@ -13,4 +13,3 @@ features = [
   "starry-kernel/input",
   "starry-kernel/vsock",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git-rename/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/git-rename/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/git/build-riscv64gc-unknown-none-elf.toml
@@ -13,4 +13,3 @@ features = [
   "starry-kernel/input",
   "starry-kernel/vsock",
 ]
-plat_dyn = true

--- a/apps/starry/stress/git/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/git/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/apps/starry/stress/sqlite3-deep/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/sqlite3-deep/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket"
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/sqlite3-deep/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/sqlite3-deep/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/sqlite3-deep/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/sqlite3-deep/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket"
 ]
-plat_dyn = true

--- a/apps/starry/stress/sqlite3-smoke/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/sqlite3-smoke/build-aarch64-unknown-none-softfloat.toml
@@ -8,5 +8,4 @@ features = [
   "ax-driver/virtio-socket"
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/sqlite3-smoke/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/sqlite3-smoke/build-riscv64gc-unknown-none-elf.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/sqlite3-smoke/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/sqlite3-smoke/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket"
 ]
-plat_dyn = true

--- a/apps/starry/stress/stress-ng-0/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/stress/stress-ng-0/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/stress/stress-ng-0/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/stress/stress-ng-0/build-riscv64gc-unknown-none-elf.toml
@@ -10,5 +10,4 @@ features = [
   "ax-driver/virtio-socket",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/stress/stress-ng-0/build-x86_64-unknown-none.toml
+++ b/apps/starry/stress/stress-ng-0/build-x86_64-unknown-none.toml
@@ -8,4 +8,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/components/axcpu/src/exception_table.rs
+++ b/components/axcpu/src/exception_table.rs
@@ -3,85 +3,50 @@ use crate::TrapFrame;
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
 struct ExceptionTableEntry {
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64"
-    ))]
     from: i32,
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64"
-    ))]
     to: i32,
-    #[cfg(not(any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64"
-    )))]
-    from: usize,
-    #[cfg(not(any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64"
-    )))]
-    to: usize,
 }
 
 impl ExceptionTableEntry {
     #[inline]
     fn source_addr(&self) -> usize {
-        #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-        {
-            field_relative_addr(&self.from)
-        }
-
-        #[cfg(target_arch = "riscv64")]
-        {
-            let base = unsafe { _ex_table_start.as_ptr() } as isize;
-            (base + self.from as isize) as usize
-        }
-
-        #[cfg(not(any(
-            target_arch = "aarch64",
-            target_arch = "riscv64",
-            target_arch = "x86_64"
-        )))]
-        {
-            self.from
-        }
+        exception_addr(&self.from)
     }
 
     #[inline]
     fn to_addr(&self) -> usize {
-        #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-        {
-            field_relative_addr(&self.to)
-        }
-
-        #[cfg(target_arch = "riscv64")]
-        {
-            let base = unsafe { _ex_table_start.as_ptr() } as isize;
-            (base + self.to as isize) as usize
-        }
-
-        #[cfg(not(any(
-            target_arch = "aarch64",
-            target_arch = "riscv64",
-            target_arch = "x86_64"
-        )))]
-        {
-            self.to
-        }
+        exception_addr(&self.to)
     }
 }
 
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[inline]
-fn field_relative_addr(offset: &i32) -> usize {
-    let base = (offset as *const i32) as isize;
-    (base + *offset as isize) as usize
+fn exception_addr(offset: &i32) -> usize {
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "x86_64"
+    ))]
+    {
+        let base = (offset as *const i32) as isize;
+        (base + *offset as isize) as usize
+    }
+
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let base = unsafe { _ex_table_start.as_ptr() } as isize;
+        (base + *offset as isize) as usize
+    }
+
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "x86_64"
+    )))]
+    {
+        *offset as usize
+    }
 }
 
 unsafe extern "C" {

--- a/components/axcpu/src/loongarch64/context.rs
+++ b/components/axcpu/src/loongarch64/context.rs
@@ -261,7 +261,11 @@ pub struct TaskContext {
 impl TaskContext {
     /// Creates a new default context for a new task.
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            #[cfg(feature = "uspace")]
+            pgdl: crate::asm::read_user_page_table().as_usize(),
+            ..Default::default()
+        }
     }
 
     /// Initializes the context for a new task, with the given entry point and

--- a/components/axcpu/src/loongarch64/macros.rs
+++ b/components/axcpu/src/loongarch64/macros.rs
@@ -24,6 +24,8 @@ macro_rules! include_asm_macros {
         .equ LA_CSR_DMW1,          0x181
 
         .equ KSAVE_KSP,            0x30
+        .equ KSAVE_T0,             0x31
+        .equ KSAVE_T1,             0x32
 
         .macro STD rd, rj, off
             st.d   \rd, \rj, \off*8
@@ -74,9 +76,9 @@ macro_rules! include_asm_macros {
 
         .macro _asm_extable, from, to
             .pushsection __ex_table, "a"
-            .balign 8
-            .quad   \from
-            .quad   \to
+            .balign 4
+            .word   \from - .
+            .word   \to - .
             .popsection
         .endm
 

--- a/components/axcpu/src/loongarch64/trap.S
+++ b/components/axcpu/src/loongarch64/trap.S
@@ -2,13 +2,25 @@
 .balign 4096
 .global exception_entry_base
 exception_entry_base:
-    csrwr   $sp, KSAVE_KSP
-    bnez    $sp, .Ltrap_entry
+    csrwr   $t0, KSAVE_T0
+    csrwr   $t1, KSAVE_T1
 
-    csrrd   $sp, KSAVE_KSP
+    csrrd   $t1, LA_CSR_PRMD
+    andi    $t1, $t1, 0x3
+    move    $t0, $sp
+    bnez    $t1, .Ltrap_from_user
+
+    csrwr   $t0, KSAVE_KSP
     addi.d  $sp, $sp, -{trapframe_size}
+    b       .Ltrap_stack_ready
 
-.Ltrap_entry:
+.Ltrap_from_user:
+    csrrd   $sp, KSAVE_KSP
+    csrwr   $t0, KSAVE_KSP
+
+.Ltrap_stack_ready:
+    csrrd   $t0, KSAVE_T0
+    csrrd   $t1, KSAVE_T1
     PUSH_GENERAL_REGS
 
     csrrd   $t0, KSAVE_KSP
@@ -24,7 +36,7 @@ exception_entry_base:
     andi    $t1, $t1, 0x3
     bnez    $t1, .Lexit_user
 
-    la.abs  $ra, .Ltrap_return
+    la.pcrel $ra, .Ltrap_return
     b       loongarch64_trap_handler
 
 .Lexit_user:

--- a/components/someboot/build.rs
+++ b/components/someboot/build.rs
@@ -121,9 +121,11 @@ impl Build {
         self.kernel_vaddr = 0xffff_ffff_8000_0000;
 
         let kernel_load_vaddr = self.kernel_vaddr as usize;
+        let kernel_load_paddr = self.kernel_paddr as usize;
 
         let ld = include_str!("src/arch/loongarch64/link.ld")
-            .replace("${kernel_load_vaddr}", &format!("{kernel_load_vaddr:#x}"));
+            .replace("${kernel_load_vaddr}", &format!("{kernel_load_vaddr:#x}"))
+            .replace("${kernel_load_paddr}", &format!("{kernel_load_paddr:#x}"));
 
         println!("cargo:rerun-if-changed={ld_src}");
         println!("cargo:rustc-cfg=efi");

--- a/components/someboot/src/acpi/earlycon.rs
+++ b/components/someboot/src/acpi/earlycon.rs
@@ -36,51 +36,47 @@ fn deal_with_spsr(spsr: &PhysicalMapping<impl Handler, Spcr>) -> Option<()> {
     if let Some(freq) = spsr.uart_clock_frequency() {
         clock = freq.into();
     }
-    let mut vaddr = None;
-    let mut is_mmio = false;
 
-    match spsr.interface_type() {
+    let (vaddr, is_mmio) = match spsr.interface_type() {
         acpi::sdt::spcr::SpcrInterfaceType::Full16550
-        | acpi::sdt::spcr::SpcrInterfaceType::Generic16550 => {
-            match base_address.address_space {
-                AddressSpace::SystemIo => {
-                    #[cfg(target_arch = "x86_64")]
-                    {
-                        let mut uart = Ns16550::new_port(base_address.address as u16, clock);
-                        uart.open();
-                        let tx = uart.take_tx().unwrap();
-                        set_sender(tx);
-                    }
-                    #[cfg(not(target_arch = "x86_64"))]
-                    {
-                        println!("SPCR I/O port early console is only supported on x86_64.");
-                        return None;
-                    }
-                }
-                AddressSpace::SystemMemory => {
-                    let mapped = _fixmap_io(base_address.address as _);
-                    vaddr = Some(mapped);
-                    is_mmio = true;
-                    let mut uart = Ns16550::new_mmio(
-                        NonNull::new(mapped).unwrap(),
-                        clock,
-                        base_address.access_size as _,
-                    );
+        | acpi::sdt::spcr::SpcrInterfaceType::Generic16550 => match base_address.address_space {
+            AddressSpace::SystemIo => {
+                #[cfg(target_arch = "x86_64")]
+                {
+                    let mut uart = Ns16550::new_port(base_address.address as u16, clock);
                     uart.open();
                     let tx = uart.take_tx().unwrap();
                     set_sender(tx);
+                    (None, false)
                 }
-                space => {
-                    println!("Unsupported SPCR address space `{space:?}` for early console.");
+                #[cfg(not(target_arch = "x86_64"))]
+                {
+                    println!("SPCR I/O port early console is only supported on x86_64.");
                     return None;
                 }
-            };
-        }
+            }
+            AddressSpace::SystemMemory => {
+                let mapped = _fixmap_io(base_address.address as _);
+                let mut uart = Ns16550::new_mmio(
+                    NonNull::new(mapped).unwrap(),
+                    clock,
+                    base_address.access_size as _,
+                );
+                uart.open();
+                let tx = uart.take_tx().unwrap();
+                set_sender(tx);
+                (Some(mapped), true)
+            }
+            space => {
+                println!("Unsupported SPCR address space `{space:?}` for early console.");
+                return None;
+            }
+        },
         t => {
             println!("Unsupported SPCR interface type `{t:?}` for early console.");
             return None;
         }
-    }
+    };
 
     unsafe { crate::console::set_out(&SENDER) };
     unsafe {

--- a/components/someboot/src/arch/loongarch64/entry.rs
+++ b/components/someboot/src/arch/loongarch64/entry.rs
@@ -1,10 +1,47 @@
-use core::{arch::naked_asm, ffi::c_void};
+use core::{arch::naked_asm, ffi::c_void, mem::offset_of};
 
-use crate::{arch::addrspace::*, entry::PrimaryCpuInitInfo};
+use crate::{
+    ArchTrait, arch::addrspace::*, entry::PrimaryCpuInitInfo, power::CpuOnError, smp::PerCpuMeta,
+};
 
 static mut FW_ARG0: usize = 0;
 static mut FW_ARG1: usize = 0;
 static mut FW_ARG2: usize = 0;
+
+const MAX_SECONDARY_BOOT_ARGS: usize = 256;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct SecondaryBootArg {
+    hartid: usize,
+    arg: usize,
+}
+
+impl SecondaryBootArg {
+    const EMPTY: Self = Self {
+        hartid: usize::MAX,
+        arg: 0,
+    };
+}
+
+static mut SECONDARY_BOOT_ARGS: [SecondaryBootArg; MAX_SECONDARY_BOOT_ARGS] =
+    [SecondaryBootArg::EMPTY; MAX_SECONDARY_BOOT_ARGS];
+
+pub(crate) fn set_secondary_boot_arg(hartid: usize, arg: usize) -> Result<(), CpuOnError> {
+    let entries = core::ptr::addr_of_mut!(SECONDARY_BOOT_ARGS).cast::<SecondaryBootArg>();
+    for idx in 0..MAX_SECONDARY_BOOT_ARGS {
+        let entry = unsafe { entries.add(idx) };
+        let stored_hartid = unsafe { (*entry).hartid };
+        if stored_hartid == hartid || stored_hartid == usize::MAX {
+            unsafe {
+                (*entry).hartid = hartid;
+                (*entry).arg = arg;
+            }
+            return Ok(());
+        }
+    }
+    Err(CpuOnError::InvalidParameters)
+}
 
 #[unsafe(no_mangle)]
 #[unsafe(naked)]
@@ -23,21 +60,22 @@ pub unsafe extern "C" fn kernel_entry(
         li.d        $t0, {CSR_DMW2_INIT} // 0x9
         csrwr       $t0, {LOONGARCH_CSR_DMW2}
 ",
-    // Enable PG
-"
-        li.w		$t0, 0xb0		    // PLV=0, IE=0, PG=1
-        csrwr		$r12, {LOONGARCH_CSR_CRMD}
-        li.w		$r12, 0x04		    // PLV=0, PIE=1, PWE=0
-        csrwr		$r12, {LOONGARCH_CSR_PRMD}
-        li.w		$r12, 0x00		    // FPE=0, SXE=0, ASXE=0, BTE=0
-        csrwr		$t0, {LOONGARCH_CSR_EUEN}
-",
     // JUMP_TO_VIRT_ADDR
 "
         li.d        $t0, {CACHE_BASE}
         pcaddi      $t1, 0
 	    bstrins.d   $t0, $t1, ({DMW_PABITS} - 1), 0
         jirl        $zero, $t0, 0xc
+",
+
+    // Enable PG after jumping into the DMW-mapped address range.
+"
+        li.w		$t0, 0xb0		    // PLV=0, IE=0, PG=1
+        csrwr		$t0, {LOONGARCH_CSR_CRMD}
+        li.w		$r12, 0x04		    // PLV=0, PIE=1, PWE=0
+        csrwr		$r12, {LOONGARCH_CSR_PRMD}
+        li.w		$t0, 0x00		    // FPE=0, SXE=0, ASXE=0, BTE=0
+        csrwr		$t0, {LOONGARCH_CSR_EUEN}
 ",
 
 "
@@ -91,9 +129,9 @@ pub unsafe extern "C" fn kernel_entry(
 fn rust_main() -> ! {
     // 执行重定位，将所有地址从物理地址转换为虚拟地址
     super::relocate();
+    super::Arch::init_boot_tls();
     println!("LoongArch64 Rust kernel entry.");
 
-    crate::mem::mmu::set_mmu_enabled();
     if is_boot_from_uefi() {
         efi_entry();
     }
@@ -120,6 +158,7 @@ fn efi_entry() {
 }
 
 pub(crate) fn mmu_entry() -> ! {
+    crate::mem::mmu::set_mmu_enabled();
     println!("MMU ok...");
     crate::prime_entry()
 }
@@ -128,8 +167,60 @@ fn is_boot_from_uefi() -> bool {
     unsafe { FW_ARG0 == 1 }
 }
 
+#[unsafe(naked)]
 pub(crate) unsafe extern "C" fn _secondary_entry(_arg: usize) -> ! {
-    loop {
-        core::hint::spin_loop();
-    }
+    naked_asm!(
+        "
+        li.d        $t0, {dmw0_init}
+        csrwr       $t0, {csr_dmw0}
+        li.d        $t0, {dmw1_init}
+        csrwr       $t0, {csr_dmw1}
+        li.d        $t0, {dmw2_init}
+        csrwr       $t0, {csr_dmw2}
+
+        csrrd       $a0, {csr_cpuid}
+        la.pcrel    $t0, {secondary_boot_args}
+        li.d        $t1, {max_secondary_boot_args}
+    1:
+        ld.d        $t2, $t0, {boot_arg_hartid_offset}
+        ld.d        $t3, $t0, {boot_arg_arg_offset}
+        beq         $t2, $a0, 2f
+        addi.d      $t0, $t0, {boot_arg_size}
+        addi.d      $t1, $t1, -1
+        bnez        $t1, 1b
+
+        li.w        $t0,  0x1028
+        iocsrrd.d   $t3,  $t0
+        beqz        $t3, 3f
+    2:
+        move        $a0, $t3
+
+        li.d        $t0, {page_offset}
+        add.d       $t1, $a0, $t0
+        ld.d        $sp, $t1, {stack_top_offset}
+        add.d       $sp, $sp, $t0
+
+        ibar        0
+        dbar        0
+        bl          {enable_mmu_secondary}
+    3:
+        idle        0
+        b           3b
+        ",
+        dmw0_init = const CSR_DMW0_INIT,
+        dmw1_init = const CSR_DMW1_INIT,
+        dmw2_init = const CSR_DMW2_INIT,
+        csr_dmw0 = const 0x180,
+        csr_dmw1 = const 0x181,
+        csr_dmw2 = const 0x182,
+        csr_cpuid = const 0x20,
+        secondary_boot_args = sym SECONDARY_BOOT_ARGS,
+        max_secondary_boot_args = const MAX_SECONDARY_BOOT_ARGS,
+        boot_arg_hartid_offset = const offset_of!(SecondaryBootArg, hartid),
+        boot_arg_arg_offset = const offset_of!(SecondaryBootArg, arg),
+        boot_arg_size = const core::mem::size_of::<SecondaryBootArg>(),
+        page_offset = const PAGE_OFFSET,
+        stack_top_offset = const offset_of!(PerCpuMeta, stack_top),
+        enable_mmu_secondary = sym super::paging::enable_mmu_secondary,
+    )
 }

--- a/components/someboot/src/arch/loongarch64/head.rs
+++ b/components/someboot/src/arch/loongarch64/head.rs
@@ -2,7 +2,7 @@ use core::arch::naked_asm;
 
 // use super::entry::kernel_entry;
 use crate::{
-    arch::addrspace::{VM_LOAD_ADDRESS, to_phys},
+    arch::addrspace::KERNEL_LOAD_ADDRESS,
     efi_stub::{efi_pe_entry, pe::*},
 };
 
@@ -109,7 +109,7 @@ pub unsafe extern "C" fn _head() {
 
         dos_signature = const IMAGE_DOS_SIGNATURE,
         linux_pe_magic = const LINUX_PE_MAGIC,
-        phys_link_kaddr = const to_phys(VM_LOAD_ADDRESS),
+        phys_link_kaddr = const KERNEL_LOAD_ADDRESS,
         efi_pe_entry = sym efi_pe_entry,
         image_nt_signature = const IMAGE_NT_SIGNATURE,
         file_machine = const IMAGE_FILE_MACHINE_LOONGARCH64,

--- a/components/someboot/src/arch/loongarch64/link.ld
+++ b/components/someboot/src/arch/loongarch64/link.ld
@@ -4,10 +4,11 @@
  */
 PECOFF_FILE_ALIGN = 0x200;
 VM_LOAD_ADDRESS = ${kernel_load_vaddr};
+KERNEL_LOAD_ADDRESS = ${kernel_load_paddr};
 
 PROVIDE(PAGE_SIZE = 0x1000);
 /* Provide default stack size if not defined */
-PROVIDE(STACK_SIZE = 0x4000);
+PROVIDE(STACK_SIZE = 0x40000);
 
 OUTPUT_ARCH(loongarch)
 ENTRY(kernel_entry)
@@ -41,6 +42,13 @@ SECTIONS
     } :text
     . = __exception_vectors + 0x10000;
     __exception_vectors_end = .;
+
+    . = ALIGN(PAGE_SIZE);
+    .vectors : {
+        KEEP(*(.vectors))
+        KEEP(*(.vectors.*))
+    } :text
+
     . = ALIGN(PAGE_SIZE);
     _etext = .;
     _srodata = .; 
@@ -60,7 +68,7 @@ SECTIONS
 
         . = ALIGN(PAGE_SIZE);
         __percpu_start = .;
-        *(.percpu_data .percpu_data.*)
+        *(.percpu_data .percpu_data.* .percpu .percpu.*)
         __percpu_end = .;
     }
     .rela.dyn : ALIGN(8) {
@@ -128,7 +136,7 @@ SECTIONS
     .stab 0 : { *(.stab) } .stabstr 0 : { *(.stabstr) } .stab.excl 0 : { *(.stab.excl) } .stab.exclstr 0 : { *(.stab.exclstr) } .stab.index 0 : { *(.stab.index) } .stab.indexstr 0 : { *(.stab.indexstr) }
     .debug 0 : { *(.debug) } .line 0 : { *(.line) } .debug_srcinfo 0 : { *(.debug_srcinfo) } .debug_sfnames 0 : { *(.debug_sfnames) } .debug_aranges 0 : { *(.debug_aranges) } .debug_pubnames 0 : { *(.debug_pubnames) } .debug_info 0 : { *(.debug_info .gnu.linkonce.wi.*) } .debug_abbrev 0 : { *(.debug_abbrev) } .debug_line 0 : { *(.debug_line) } .debug_frame 0 : { *(.debug_frame) } .debug_str 0 : { *(.debug_str) } .debug_loc 0 : { *(.debug_loc) } .debug_macinfo 0 : { *(.debug_macinfo) } .debug_pubtypes 0 : { *(.debug_pubtypes) } .debug_ranges 0 : { *(.debug_ranges) } .debug_weaknames 0 : { *(.debug_weaknames) } .debug_funcnames 0 : { *(.debug_funcnames) } .debug_typenames 0 : { *(.debug_typenames) } .debug_varnames 0 : { *(.debug_varnames) } .debug_gnu_pubnames 0 : { *(.debug_gnu_pubnames) } .debug_gnu_pubtypes 0 : { *(.debug_gnu_pubtypes) } .debug_types 0 : { *(.debug_types) } .debug_addr 0 : { *(.debug_addr) } .debug_line_str 0 : { *(.debug_line_str) } .debug_loclists 0 : { *(.debug_loclists) } .debug_macro 0 : { *(.debug_macro) } .debug_names 0 : { *(.debug_names) } .debug_rnglists 0 : { *(.debug_rnglists) } .debug_str_offsets 0 : { *(.debug_str_offsets) }
     .comment 0 : { *(.comment) } .symtab 0 : { *(.symtab) } .strtab 0 : { *(.strtab) } .shstrtab 0 : { *(.shstrtab) }
-    _kernel_entry = ABSOLUTE(kernel_entry & 0xffffffffffff);
+    _kernel_entry = ABSOLUTE(KERNEL_LOAD_ADDRESS + (kernel_entry - _head));
     _kernel_asize = ABSOLUTE(_end   - _head);
     _kernel_fsize = ABSOLUTE(_edata - _head);
     _kernel_vsize = ABSOLUTE(_end   - _etext);

--- a/components/someboot/src/arch/loongarch64/mod.rs
+++ b/components/someboot/src/arch/loongarch64/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod entry;
 mod head;
 pub(crate) mod irq;
 mod paging;
+mod power;
 pub(crate) mod pte;
 mod register;
 mod relocate;
@@ -27,6 +28,16 @@ pub use relocate::relocate;
 use crate::{ArchTrait, DCacheOp, efi_stub, irq::IrqId, power::CpuOnError};
 
 const MIN_TICKS: usize = 4;
+const BOOT_TLS_SIZE: usize = 64 * 1024;
+
+#[repr(C, align(16))]
+struct BootTls {
+    bytes: [u8; BOOT_TLS_SIZE],
+}
+
+static mut BOOT_TLS: BootTls = BootTls {
+    bytes: [0; BOOT_TLS_SIZE],
+};
 
 pub struct Arch;
 
@@ -43,6 +54,41 @@ impl ArchTrait for Arch {
     }
 
     fn post_allocator() {}
+
+    fn init_boot_tls() {
+        unsafe extern "C" {
+            fn _stdata();
+            fn _etdata();
+            fn _etbss();
+        }
+
+        let stdata = _stdata as *const () as usize;
+        let etdata = _etdata as *const () as usize;
+        let etbss = _etbss as *const () as usize;
+        if etdata < stdata || etbss < stdata {
+            return;
+        }
+
+        let tls_size = align_up(etbss - stdata, 16);
+        if tls_size > BOOT_TLS_SIZE {
+            return;
+        }
+
+        unsafe {
+            let boot_tls = core::ptr::addr_of_mut!(BOOT_TLS).cast::<u8>();
+            core::ptr::write_bytes(boot_tls, 0, tls_size);
+            core::ptr::copy_nonoverlapping(stdata as *const u8, boot_tls, etdata - stdata);
+            core::arch::asm!("move $tp, {}", in(reg) boot_tls as usize, options(nostack));
+        }
+    }
+
+    fn init_runtime_percpu_reg(cpu_idx: usize) {
+        if let Some(percpu) = crate::smp::percpu_data_ptr(cpu_idx) {
+            unsafe {
+                core::arch::asm!("move $r21, {}", in(reg) percpu as usize);
+            }
+        }
+    }
 
     fn per_cpu_trap_init(is_primary: bool) {
         trap::per_cpu_trap_init(is_primary);
@@ -76,7 +122,10 @@ impl ArchTrait for Arch {
         tcfg::set_init_val(ticks);
         // 清除可能存在的中断
         ticlr::clear_timer_interrupt();
-        // 不在这里 enable，让调用者通过 systimer_enable() 来使能
+        // Arm the one-shot event. Linux and the static LoongArch platform both
+        // program the next event with TCFG.EN set; leaving it disabled stalls
+        // timer-based sleeps after the first reprogram.
+        tcfg::set_en(true);
     }
 
     fn systimer_ack() {
@@ -183,7 +232,12 @@ impl ArchTrait for Arch {
     }
 
     fn virt_to_phys(vaddr: *const u8) -> usize {
-        addrspace::to_phys(vaddr as usize)
+        let vaddr = vaddr as usize;
+        if vaddr >= addrspace::VM_LOAD_ADDRESS {
+            crate::mem::__kimage_va_to_pa(vaddr as *const u8)
+        } else {
+            addrspace::to_phys(vaddr)
+        }
     }
 
     #[cfg(uspace)]
@@ -230,11 +284,11 @@ impl ArchTrait for Arch {
     }
 
     fn kernel_space() -> core::ops::Range<usize> {
-        0xFFFF_0000_0000_0000..usize::MAX
+        addrspace::PAGE_OFFSET..usize::MAX
     }
 
-    fn cpu_on(_hartid: usize, _entry: usize, _arg: usize) -> Result<(), CpuOnError> {
-        Err(CpuOnError::NotSupported)
+    fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
+        power::cpu_on(hartid, entry, arg)
     }
 
     fn dcache_range(_op: DCacheOp, _addr: usize, _size: usize) {
@@ -249,4 +303,8 @@ impl ArchTrait for Arch {
         unsafe { crate::arch::entry::kernel_entry(1, null(), system_table) };
         unreachable!()
     }
+}
+
+const fn align_up(value: usize, align: usize) -> usize {
+    (value + align - 1) & !(align - 1)
 }

--- a/components/someboot/src/arch/loongarch64/paging.rs
+++ b/components/someboot/src/arch/loongarch64/paging.rs
@@ -5,7 +5,7 @@
 
 use core::arch::naked_asm;
 
-use loongArch64::register::{pgdh, pgdl, pwch::*, pwcl::*, stlbps};
+use loongArch64::register::{MemoryAccessType, crmd, pgdh, pgdl, pwch::*, pwcl::*, stlbps};
 use num_align::NumAlign;
 use page_table_generic::{MapConfig, MemAttributes, PteConfig, TableMeta, VirtAddr};
 
@@ -16,6 +16,7 @@ use crate::{
     console::print_mapping,
     consts::PAGE_SIZE,
     mem::{__kimage_va, __va, MB, PageTableInfo},
+    smp::PerCpuMeta,
 };
 
 /// 4KB 页大小的 PS 值
@@ -39,8 +40,7 @@ pub const PTE_INDEX_BITS: usize = PAGE_SHIFT - 3;
 #[inline(always)]
 pub fn local_flush_tlb_all() {
     unsafe {
-        // invtlb op=0x0 (无效化所有 TLB)
-        core::arch::asm!("dbar 0; invtlb 0x00, $r0, $r0", options(nomem, nostack));
+        core::arch::asm!("dbar 0; tlbflush", options(nomem, nostack));
     }
 }
 
@@ -221,6 +221,42 @@ pub fn relocate_kernel_to_vm_code() -> ! {
 
     relocate_kernel(v_entry, v_sp);
     unreachable!()
+}
+
+pub fn enable_mmu_secondary(cpu_meta_paddr: usize) -> ! {
+    let meta = unsafe {
+        let meta_va = super::addrspace::to_cache(cpu_meta_paddr);
+        &*(meta_va as *const PerCpuMeta)
+    };
+    pgdh::set_base(meta.boot_table_paddr);
+    pgdl::set_base(meta.boot_table_paddr);
+    setup();
+    super::trap::init_entries_for_secondary();
+
+    let mut crmd_bits = crmd::read().raw();
+    crmd_bits &= !(1 << 3);
+    crmd_bits |= 1 << 4;
+    crmd_bits &= !(0b11 << 5);
+    crmd_bits |= (MemoryAccessType::CoherentCached as usize) << 5;
+    crmd_bits &= !(0b11 << 7);
+    crmd_bits |= (MemoryAccessType::CoherentCached as usize) << 7;
+    unsafe {
+        core::arch::asm!("csrwr {}, {}", in(reg) crmd_bits, const 0x0);
+    }
+    crate::mem::mmu::set_mmu_enabled();
+    jump_to_secondary_entry(cpu_meta_paddr, meta.stack_top_virt, meta.entry_virt)
+}
+
+#[unsafe(naked)]
+extern "C" fn jump_to_secondary_entry(_arg: usize, _sp: usize, _entry: usize) -> ! {
+    naked_asm!(
+        "
+        ibar 0
+        dbar 0
+        move $sp, $a1
+        jr $a2
+        "
+    )
 }
 
 #[unsafe(naked)]

--- a/components/someboot/src/arch/loongarch64/power.rs
+++ b/components/someboot/src/arch/loongarch64/power.rs
@@ -1,0 +1,17 @@
+use loongArch64::ipi::{csr_mail_send, send_ipi_single};
+
+use crate::{arch::addrspace, power::CpuOnError};
+
+const ACTION_BOOT_CPU: u32 = 1;
+
+pub(crate) fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
+    let entry = addrspace::to_cache(entry);
+    super::entry::set_secondary_boot_arg(hartid, arg)?;
+    unsafe {
+        core::arch::asm!("dbar 0", options(nomem, nostack));
+    }
+    csr_mail_send(arg as u64, hartid, 1);
+    csr_mail_send(entry as u64, hartid, 0);
+    send_ipi_single(hartid, ACTION_BOOT_CPU);
+    Ok(())
+}

--- a/components/someboot/src/arch/loongarch64/trap.rs
+++ b/components/someboot/src/arch/loongarch64/trap.rs
@@ -6,8 +6,9 @@ use loongArch64::register::{
 };
 
 use crate::{
-    arch::{addrspace::to_phys, context::TrapFrame, register::csr},
+    arch::{context::TrapFrame, register::csr},
     irq::IrqId,
+    mem::virt_to_phys,
 };
 
 /// LoongArch Exception Codes
@@ -141,17 +142,22 @@ unsafe extern "C" {
 }
 
 fn eentry_addr() -> usize {
-    __exception_vectors as *const () as usize
+    sym_running_addr!(__exception_vectors)
 }
 
 fn tlbrentry_addr() -> usize {
-    let addr = eentry_addr() + 80 * VECSIZE;
-    to_phys(addr)
+    virt_to_phys((eentry_addr() + 80 * VECSIZE) as *const u8)
 }
 
-pub fn per_cpu_trap_init(_is_primary: bool) {
+pub fn per_cpu_trap_init(is_primary: bool) {
     setup_vint_size();
-    configure_exception_vector();
+    configure_exception_vector(is_primary);
+}
+
+pub(crate) fn init_entries_for_secondary() {
+    setup_vint_size();
+    eentry::set_eentry(eentry_addr());
+    tlbrentry::set_tlbrentry(tlbrentry_addr());
 }
 
 fn setup_vint_size() {
@@ -160,15 +166,21 @@ fn setup_vint_size() {
 }
 
 /// 配置异常向量
-fn configure_exception_vector() {
+fn configure_exception_vector(verbose: bool) {
     let eentry_addr = eentry_addr();
-    println!("Setting EENTRY to {:#x}", eentry_addr);
+    if verbose {
+        println!("Setting EENTRY to {:#x}", eentry_addr);
+    }
     eentry::set_eentry(eentry_addr);
     let val = eentry::read().eentry();
-    println!("EENTRY set to {:#x}", val);
+    if verbose {
+        println!("EENTRY set to {:#x}", val);
+    }
 
     let tlbrentry_addr = tlbrentry_addr();
-    println!("Setting TLBRENTRY to {:#x}", tlbrentry_addr);
+    if verbose {
+        println!("Setting TLBRENTRY to {:#x}", tlbrentry_addr);
+    }
     tlbrentry::set_tlbrentry(tlbrentry_addr);
 }
 
@@ -598,8 +610,7 @@ global_asm!(
     "handle_exc_79:", "b handle_reserved_exception",
 
     ".balign VECSIZE",
-    ".global handle_tlb_refill",
-    "handle_tlb_refill:",
+    ".Lsomeboot_handle_tlb_refill:",
     "
     csrwr   $t0, 0x8B  // LOONGARCH_CSR_TLBRSAV - 保存 $t0
     csrrd   $t0, 0x1b  // LA_CSR_PGD - 读取页表基址

--- a/components/someboot/src/efi_stub/mod.rs
+++ b/components/someboot/src/efi_stub/mod.rs
@@ -1,6 +1,12 @@
 #[cfg(target_arch = "x86_64")]
 use core::arch::naked_asm;
-use core::{fmt::Write, ptr::null, sync::atomic::AtomicBool};
+use core::{
+    ffi::c_void,
+    fmt::Write,
+    mem::MaybeUninit,
+    ptr::{addr_of_mut, null},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 
 pub use uefi::Status;
 #[cfg(target_arch = "loongarch64")]
@@ -8,10 +14,9 @@ pub use uefi::runtime::ResetType;
 use uefi::{
     Result,
     boot::{self, MemoryDescriptor, MemoryType},
-    mem::memory_map::MemoryMap,
     prelude::*,
     proto::loaded_image::LoadedImage,
-    runtime::set_virtual_address_map,
+    runtime::{self, set_virtual_address_map},
     system::with_config_table,
     table::{self, cfg::ConfigTableEntry},
 };
@@ -23,8 +28,26 @@ use crate::{
     mem::{__io, __va},
 };
 
+const EFI_IMAGE_HANDLE_UNSET: usize = usize::MAX;
+const EXIT_BOOT_MEMORY_MAP_BUFFER_SIZE: usize = 128 * 1024;
+const EXIT_BOOT_MEMORY_MAP_DESCRIPTOR_CAPACITY: usize = 1024;
+const EXIT_BOOT_MEMORY_MAP_RETRIES: usize = 3;
+
+#[repr(align(8))]
+struct AlignedBytes<const N: usize>([u8; N]);
+
+static mut EXIT_BOOT_MEMORY_MAP_BUFFER: AlignedBytes<EXIT_BOOT_MEMORY_MAP_BUFFER_SIZE> =
+    AlignedBytes([0; EXIT_BOOT_MEMORY_MAP_BUFFER_SIZE]);
+static mut EXIT_BOOT_MEMORY_MAP_DESCRIPTORS: [MaybeUninit<MemoryDescriptor>;
+    EXIT_BOOT_MEMORY_MAP_DESCRIPTOR_CAPACITY] =
+    [const { MaybeUninit::uninit() }; EXIT_BOOT_MEMORY_MAP_DESCRIPTOR_CAPACITY];
+static EFI_IMAGE_HANDLE: AtomicUsize = AtomicUsize::new(EFI_IMAGE_HANDLE_UNSET);
+
 pub(crate) fn setup_service(system_table: *const ::core::ffi::c_void) {
     unsafe { table::set_system_table(system_table.cast()) };
+    if let Some(image_handle) = saved_image_handle() {
+        unsafe { boot::set_image_handle(image_handle) };
+    }
     setup_console();
     println!("UEFI console ok.");
     find_acpi_rsdp();
@@ -59,6 +82,7 @@ unsafe extern "C" fn efi_pe_entry_main(
     system_table: *const ::core::ffi::c_void,
 ) -> Status {
     unsafe {
+        save_image_handle(image_handle);
         boot::set_image_handle(image_handle);
         table::set_system_table(system_table.cast());
         setup_console();
@@ -89,8 +113,8 @@ pub unsafe extern "efiapi" fn efi_pe_entry(
 pub(crate) fn exit_boot_services() {
     println!("Exiting UEFI boot services...");
     UEFI_SERVICE_EXIT.store(true, core::sync::atomic::Ordering::Relaxed);
-    let mem_map = unsafe { boot::exit_boot_services(None) };
-    println!("Exited boot services, owned memory map obtained.");
+    let mem_map = unsafe { exit_boot_services_no_alloc() };
+    println!("Exited boot services, memory map obtained.");
 
     let mut new_map: heapless::Vec<MemoryDescriptor, 32> = heapless::Vec::new();
 
@@ -118,6 +142,125 @@ pub(crate) fn exit_boot_services() {
     }
 
     memmap::setup_memory_map(mem_map.entries());
+}
+
+struct ExitBootMemoryMap {
+    entries: &'static [MemoryDescriptor],
+}
+
+impl ExitBootMemoryMap {
+    fn entries(&self) -> core::slice::Iter<'static, MemoryDescriptor> {
+        self.entries.iter()
+    }
+}
+
+unsafe fn exit_boot_services_no_alloc() -> ExitBootMemoryMap {
+    let Some(system_table) = uefi::table::system_table_raw() else {
+        reset_on_exit_boot_services_failure(Status::INVALID_PARAMETER);
+    };
+    let boot_services = unsafe {
+        system_table
+            .as_ref()
+            .boot_services
+            .as_ref()
+            .unwrap_or_else(|| reset_on_exit_boot_services_failure(Status::INVALID_PARAMETER))
+    };
+    let Some(image_handle) = saved_image_handle() else {
+        reset_on_exit_boot_services_failure(Status::INVALID_PARAMETER);
+    };
+
+    let mut status = Status::SUCCESS;
+
+    for _ in 0..EXIT_BOOT_MEMORY_MAP_RETRIES {
+        let mut map_size = EXIT_BOOT_MEMORY_MAP_BUFFER_SIZE;
+        let mut map_key = 0;
+        let mut desc_size = 0;
+        let mut desc_version = 0;
+        let map_ptr =
+            unsafe { addr_of_mut!(EXIT_BOOT_MEMORY_MAP_BUFFER.0).cast::<MemoryDescriptor>() };
+
+        status = unsafe {
+            (boot_services.get_memory_map)(
+                &mut map_size,
+                map_ptr,
+                &mut map_key,
+                &mut desc_size,
+                &mut desc_version,
+            )
+        };
+        if status == Status::BUFFER_TOO_SMALL {
+            continue;
+        }
+        if status != Status::SUCCESS {
+            reset_on_exit_boot_services_failure(status);
+        }
+
+        status = unsafe { (boot_services.exit_boot_services)(image_handle.as_ptr(), map_key) };
+        if status == Status::SUCCESS {
+            let entries =
+                unsafe { copy_exit_boot_memory_map(map_ptr.cast_const(), map_size, desc_size) };
+            return ExitBootMemoryMap { entries };
+        }
+    }
+
+    reset_on_exit_boot_services_failure(status);
+}
+
+unsafe fn copy_exit_boot_memory_map(
+    src: *const MemoryDescriptor,
+    map_size: usize,
+    desc_size: usize,
+) -> &'static [MemoryDescriptor] {
+    assert!(
+        desc_size >= size_of::<MemoryDescriptor>(),
+        "UEFI memory descriptor size is too small"
+    );
+
+    let entry_count = map_size / desc_size;
+    assert!(
+        entry_count <= EXIT_BOOT_MEMORY_MAP_DESCRIPTOR_CAPACITY,
+        "UEFI memory map has too many entries"
+    );
+
+    let dst =
+        addr_of_mut!(EXIT_BOOT_MEMORY_MAP_DESCRIPTORS).cast::<MaybeUninit<MemoryDescriptor>>();
+    for index in 0..entry_count {
+        let entry = unsafe {
+            src.cast::<u8>()
+                .add(index * desc_size)
+                .cast::<MemoryDescriptor>()
+        };
+        unsafe { dst.add(index).write(MaybeUninit::new(entry.read())) };
+    }
+
+    unsafe { core::slice::from_raw_parts(dst.cast::<MemoryDescriptor>(), entry_count) }
+}
+
+fn save_image_handle(image_handle: Handle) {
+    EFI_IMAGE_HANDLE.store(image_handle.as_ptr() as usize, Ordering::Relaxed);
+}
+
+fn saved_image_handle() -> Option<Handle> {
+    let raw = EFI_IMAGE_HANDLE.load(Ordering::Relaxed);
+    if raw == EFI_IMAGE_HANDLE_UNSET {
+        return None;
+    }
+
+    unsafe { Handle::from_ptr(raw as *mut c_void) }
+}
+
+fn reset_on_exit_boot_services_failure(status: Status) -> ! {
+    unsafe {
+        if let Some(system_table) = uefi::table::system_table_raw()
+            && let Some(runtime_services) = system_table.as_ref().runtime_services.as_ref()
+        {
+            (runtime_services.reset_system)(runtime::ResetType::COLD, status, 0, null());
+        }
+    }
+
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 pub(crate) fn setup_console() {

--- a/components/someboot/src/lib.rs
+++ b/components/someboot/src/lib.rs
@@ -76,6 +76,9 @@ pub trait ArchTrait {
 
     fn post_allocator();
 
+    fn init_boot_tls() {}
+    fn init_runtime_percpu_reg(_cpu_idx: usize) {}
+
     fn per_cpu_trap_init(is_primary: bool);
     fn trap_addr() -> usize;
 
@@ -176,9 +179,9 @@ fn prime_entry() -> ! {
     }
 
     let entry = __someboot_main as *const () as usize;
-    let sp = crate::smp::cpu_meta(crate::smp::early_current_cpu_idx())
-        .unwrap()
-        .stack_top;
+    let cpu_idx = crate::smp::early_current_cpu_idx();
+    arch::Arch::init_runtime_percpu_reg(cpu_idx);
+    let sp = crate::smp::cpu_meta(cpu_idx).unwrap().stack_top;
     let sp = __percpu(sp);
     println!(
         "Jumping to main entry point at {:#x} with SP {:#p}",

--- a/components/someboot/src/mem/mod.rs
+++ b/components/someboot/src/mem/mod.rs
@@ -97,6 +97,8 @@ pub fn phys_to_virt(paddr: usize) -> *mut u8 {
         } else {
             __va(paddr)
         }
+    } else if cfg!(target_arch = "loongarch64") {
+        __va(paddr)
     } else {
         paddr as *mut u8
     }

--- a/components/someboot/src/smp/legacy.rs
+++ b/components/someboot/src/smp/legacy.rs
@@ -2,7 +2,7 @@ use super::{
     __cpu_id_list, PerCpuMeta, align_up_pow2, alloc_percpu_region, cpu_count, meta_align,
     percpu_data_range, percpu_link_range, percpu_region_align, set_percpu_range,
 };
-use crate::mem::{__kimage_va, __percpu, phys_to_virt, stack_size};
+use crate::mem::{__kimage_va, __percpu, phys_to_virt, stack_size, virt_to_phys};
 
 fn meta_offset() -> usize {
     let link_size = percpu_link_range().len();
@@ -53,7 +53,9 @@ pub fn alloc_percpu() {
         percpu_data_range().end
     );
 
-    let entry_virt = __kimage_va(super::super::entry::secondary_entry as *const () as usize);
+    let link_phys_start = virt_to_phys(link_range.start as *const u8);
+    let entry_phys = virt_to_phys(super::super::entry::secondary_entry as *const () as *const u8);
+    let entry_virt = __kimage_va(entry_phys);
 
     for (idx, hard_id) in __cpu_id_list().enumerate() {
         let cpu_percpu_start = percpu_data_range().start + idx * percpu_size;
@@ -62,7 +64,7 @@ pub fn alloc_percpu() {
         );
         unsafe {
             core::ptr::copy_nonoverlapping(
-                phys_to_virt(link_range.start) as *const u8,
+                phys_to_virt(link_phys_start) as *const u8,
                 phys_to_virt(cpu_percpu_start),
                 link_size,
             );
@@ -105,10 +107,10 @@ pub(crate) fn cpu_meta_addr(idx: usize) -> Option<usize> {
     Some(base + meta_offset())
 }
 
-pub(crate) fn percpu_data_ptr(idx: usize) -> Option<*mut u8> {
+pub(crate) fn percpu_data_phys(idx: usize) -> Option<usize> {
     let base = percpu_data_range().start + idx * percpu_data_size();
     if base >= percpu_data_range().end {
         return None;
     }
-    Some(phys_to_virt(base))
+    Some(base)
 }

--- a/components/someboot/src/smp/mod.rs
+++ b/components/someboot/src/smp/mod.rs
@@ -100,8 +100,12 @@ pub(crate) fn cpu_meta_addr(idx: usize) -> Option<usize> {
     layout::cpu_meta_addr(idx)
 }
 
+pub(crate) fn percpu_data_phys(idx: usize) -> Option<usize> {
+    layout::percpu_data_phys(idx)
+}
+
 pub fn percpu_data_ptr(idx: usize) -> Option<*mut u8> {
-    layout::percpu_data_ptr(idx)
+    percpu_data_phys(idx).map(__percpu)
 }
 
 /// Returns the current hardware CPU ID from the early boot register convention.

--- a/components/someboot/src/smp/prealloc.rs
+++ b/components/someboot/src/smp/prealloc.rs
@@ -2,7 +2,7 @@ use super::{
     __cpu_id_list, PerCpuMeta, align_up_pow2, alloc_percpu_region, cpu_count, meta_align,
     percpu_data_range, percpu_link_range, percpu_region_align, set_percpu_range,
 };
-use crate::mem::{__kimage_va, __percpu, phys_to_virt, stack_size};
+use crate::mem::{__kimage_va, __percpu, phys_to_virt, stack_size, virt_to_phys};
 
 struct LayoutInfo {
     meta_region_offset: usize,
@@ -112,7 +112,9 @@ pub fn alloc_percpu() {
         percpu_data_range().start + layout.data_region_offset
     );
 
-    let entry_virt = __kimage_va(super::super::entry::secondary_entry as *const () as usize);
+    let link_phys_start = virt_to_phys(link_range.start as *const u8);
+    let entry_phys = virt_to_phys(super::super::entry::secondary_entry as *const () as *const u8);
+    let entry_virt = __kimage_va(entry_phys);
 
     for (idx, hard_id) in __cpu_id_list().enumerate() {
         let cpu_data_start = cpu_data_start(idx).unwrap();
@@ -127,7 +129,7 @@ pub fn alloc_percpu() {
         );
         unsafe {
             core::ptr::copy_nonoverlapping(
-                phys_to_virt(link_range.start) as *const u8,
+                phys_to_virt(link_phys_start) as *const u8,
                 phys_to_virt(cpu_data_start),
                 link_size,
             );
@@ -166,7 +168,6 @@ pub(crate) fn cpu_meta_addr(idx: usize) -> Option<usize> {
     cpu_meta_start(idx)
 }
 
-pub(crate) fn percpu_data_ptr(idx: usize) -> Option<*mut u8> {
-    let base = cpu_data_start(idx)?;
-    Some(phys_to_virt(base))
+pub(crate) fn percpu_data_phys(idx: usize) -> Option<usize> {
+    cpu_data_start(idx)
 }

--- a/docs/docs/build/build.md
+++ b/docs/docs/build/build.md
@@ -178,7 +178,7 @@ flowchart TD
     E --> F["注入 AX_CONFIG_PATH<br/>和 AX_PLATFORM 环境变量"]
 ```
 
-ArceOS 的平台配置（如内存布局、中断控制器地址、串口基地址等）由 `axbuild` 复用配置引擎库从平台包配置文件中合并生成 `.axconfig.toml`。在动态平台模式下（`plat_dyn = true`），这些配置由运行时动态加载；在静态模式下，必须在编译前预生成并注入 `AX_CONFIG_PATH` 环境变量，使得 OS 源码中的配置宏能在编译期读取配置。
+ArceOS 的平台配置（如内存布局、中断控制器地址、串口基地址等）由 `axbuild` 复用配置引擎库从平台包配置文件中合并生成 `.axconfig.toml`。动态平台模式是支持动态平台 target 的默认构建方式，配置可省略 `plat_dyn`；在静态模式下（`plat_dyn = false`），必须在编译前预生成并注入 `AX_CONFIG_PATH` 环境变量，使得 OS 源码中的配置宏能在编译期读取配置。
 
 ### 6a. 平台包解析
 
@@ -208,9 +208,9 @@ flowchart TD
 
 | 架构 | 默认平台包 |
 |------|-----------|
-| `aarch64` | 无静态默认平台；默认使用 `plat_dyn = true` |
-| `x86_64` | 无静态默认平台；默认使用 `plat_dyn = true` |
-| `riscv64` | 无静态默认平台；默认使用 `plat_dyn = true` |
+| `aarch64` | 无静态默认平台；默认使用动态平台 |
+| `x86_64` | 无静态默认平台；默认使用动态平台 |
+| `riscv64` | 无静态默认平台；默认使用动态平台 |
 | `loongarch64` | `ax-plat-loongarch64-qemu-virt` |
 
 **平台包命名规则**：

--- a/docs/docs/build/configuration.md
+++ b/docs/docs/build/configuration.md
@@ -64,7 +64,7 @@ flowchart TD
 
 除默认值差异外，各架构还有一些需要注意的特殊行为：
 
-- **plat_dyn**：`aarch64` 和 `riscv64` 支持 `plat_dyn = true`（动态平台加载），其他架构使用静态平台绑定
+- **plat_dyn**：省略时默认请求动态平台；`aarch64`、`x86_64`、`riscv64`、`loongarch64` 支持动态平台，只有显式写 `plat_dyn = false` 才请求静态平台绑定
 - **to_bin**：`x86_64` 不使用 `--bin`（直接生成 ELF 即可），其余架构默认将 ELF 转为 raw binary
 - **LoongArch QEMU**：运行 Axvisor loongarch64 时自动搜索 LVZ 版 QEMU（详见 [运行](./run#loongarch-特殊处理)）
 
@@ -77,9 +77,9 @@ flowchart TD
 | `aarch64` | `rootfs-aarch64-alpine.img` | 动态平台 | `aarch64-linux-musl` | `qemu-aarch64-static` |
 | `x86_64` | `rootfs-x86_64-alpine.img` | 动态平台 | `x86_64-linux-musl` | `qemu-x86_64-static` |
 | `riscv64` | `rootfs-riscv64-alpine.img` | 动态平台 | `riscv64-linux-musl` | `qemu-riscv64-static` |
-| `loongarch64` | `rootfs-loongarch64-alpine.img` | `loongarch64-qemu-virt` | `loongarch64-linux-musl` | `qemu-loongarch64-static` |
+| `loongarch64` | `rootfs-loongarch64-alpine.img` | 动态平台 | `loongarch64-linux-musl` | `qemu-loongarch64-static` |
 
-这些字段由 `CrossCompileSpec` 承载，被 StarryOS 和 Axvisor 的 C/Python 测试用例的 prebuild 环境和 CMake 交叉编译流程所使用。AArch64、RISC-V QEMU 和 x86_64 QEMU 默认不再绑定静态 StarryOS 平台，相关构建走动态平台路径。
+这些字段由 `CrossCompileSpec` 承载，被 StarryOS 和 Axvisor 的 C/Python 测试用例的 prebuild 环境和 CMake 交叉编译流程所使用。动态平台支持的 QEMU 构建默认不再绑定静态 StarryOS 平台；需要静态平台时，在构建配置中显式写 `plat_dyn = false`。
 
 ## Snapshot
 
@@ -104,7 +104,6 @@ Snapshot 机制解决了一个常见的工作流痛点：用户首次执行 `car
 package = "arceos-httpserver"
 arch = "aarch64"
 target = "aarch64-unknown-none-softfloat"
-plat_dyn = true
 
 [qemu]
 qemu_config = "test-suit/arceos/..."

--- a/docs/docs/development/arceos.md
+++ b/docs/docs/development/arceos.md
@@ -452,7 +452,6 @@ C 测试位于 `test-suit/arceos/c/`：helloworld, httpclient, memtest, pthread�
 features = ["ax-std"]
 log = "Warn"
 max_cpu_num = 4
-plat_dyn = true
 
 [env]
 AX_IP = "10.0.2.15"

--- a/docs/docs/development/axvisor.md
+++ b/docs/docs/development/axvisor.md
@@ -300,7 +300,6 @@ passthrough_devices = [["/"]]
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = ["ept-level-4", "ax-std/bus-mmio", "fs"]
 log = "Info"
-plat_dyn = true
 vm_configs = []   # 注意：默认为空，需手动指定或通过 setup_qemu.sh 生成
 ```
 

--- a/docs/docs/development/starryos.md
+++ b/docs/docs/development/starryos.md
@@ -438,7 +438,6 @@ features = [
   "ax-driver/virtio-net",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"
 ```
 

--- a/docs/starryos-self-compilation.md
+++ b/docs/starryos-self-compilation.md
@@ -213,7 +213,7 @@ cargo xtask starry test qemu --arch riscv64 --test-suite test-suit/starryos/self
 1. **`phys-memory-size` 硬编码 8GB**: 动态 RAM 检测因启动阶段地址空间不一致无法实现。标准 CI 测试使用默认内存配置，自编译需要 `-m 8G`。
 2. **自编译测试不在标准 CI 中运行**: 需要 8-12GB rootfs 镜像，仅支持本地手动测试。
 3. **SMP > 1 未验证**: ext4 `SpinNoPreempt` 死锁 workaround 为 SMP=1。x86_64 通过 KVM 加速弥补单核性能。
-4. **aarch64 引导已验证**: rootfs 准备 + 种子内核引导 + shell 可用均通过，完整编译因 TCG 模拟性能限制（预计 4-8h）未运行。需 `plat_dyn=true` + PIE 目标（`--config test-suit/starryos/qemu-smp1/build-aarch64-unknown-none-softfloat.toml`）。
+4. **aarch64 引导已验证**: rootfs 准备 + 种子内核引导 + shell 可用均通过，完整编译因 TCG 模拟性能限制（预计 4-8h）未运行。需动态平台默认配置 + PIE 目标（`--config test-suit/starryos/qemu-smp1/build-aarch64-unknown-none-softfloat.toml`）。
 5. **页面回收仅支持干净页**: 脏页在极端压力下作为最后手段回收（记录 warning），缺少脏页写回机制。
 
 ## 环境要求

--- a/drivers/ax-driver/src/pci/mod.rs
+++ b/drivers/ax-driver/src/pci/mod.rs
@@ -5,6 +5,8 @@ use alloc::sync::Arc;
 use heapless::Vec as ArrayVec;
 use mmio_api::MmioOp;
 #[cfg(virtio_dev)]
+use pcie::CommandRegister;
+#[cfg(virtio_dev)]
 use rdrive::probe::pci::{Endpoint, EndpointRc};
 use rdrive::{
     PlatformDevice,
@@ -287,12 +289,26 @@ pub fn take_virtio_transport(
         return Err(OnProbeError::NotMatch);
     }
 
+    enable_virtio_pci_command(endpoint);
+
     let mut root = PciRoot::new(EndpointConfigAccess::new(bdf, endpoint.take()));
     PciTransport::new::<VirtIoHalImpl, _>(&mut root, bdf).map_err(|err| {
         OnProbeError::other(format!(
             "failed to create VirtIO PCI transport at {bdf}: {err:?}"
         ))
     })
+}
+
+#[cfg(virtio_dev)]
+fn enable_virtio_pci_command(endpoint: &mut EndpointRc) {
+    endpoint.update_command(|mut command| {
+        command.insert(
+            CommandRegister::IO_ENABLE
+                | CommandRegister::MEMORY_ENABLE
+                | CommandRegister::BUS_MASTER_ENABLE,
+        );
+        command
+    });
 }
 
 #[cfg(virtio_dev)]

--- a/os/StarryOS/configs/board/k230-canmv.toml
+++ b/os/StarryOS/configs/board/k230-canmv.toml
@@ -2,5 +2,4 @@ features = [
   "k230",
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
@@ -7,5 +7,4 @@ features = [
   "ax-driver/serial",
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/configs/board/orangepi-5-plus.toml
+++ b/os/StarryOS/configs/board/orangepi-5-plus.toml
@@ -14,4 +14,3 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 8
-plat_dyn = true

--- a/os/StarryOS/configs/board/qemu-aarch64.toml
+++ b/os/StarryOS/configs/board/qemu-aarch64.toml
@@ -9,5 +9,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/os/StarryOS/configs/board/qemu-loongarch64-uefi.toml
+++ b/os/StarryOS/configs/board/qemu-loongarch64-uefi.toml
@@ -1,14 +1,13 @@
-env = {AX_IP = "10.0.2.15", AX_GW = "10.0.2.2"}
+target = "loongarch64-unknown-none-softfloat"
+env = {}
+log = "Warn"
 features = [
-  "ax-feat/rtc",
-  "ax-driver/serial",
+  "ax-hal/plat-dyn",
+  "axplat-dyn/efi",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
   "ax-driver/virtio-gpu",
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
-  "ax-driver/xhci-pci",
   "starry-kernel/input",
 ]
-log = "Warn"
-target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/configs/board/qemu-riscv64.toml
+++ b/os/StarryOS/configs/board/qemu-riscv64.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/configs/board/qemu-x86_64.toml
+++ b/os/StarryOS/configs/board/qemu-x86_64.toml
@@ -9,4 +9,3 @@ features = [
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
 ]
-plat_dyn = true

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
@@ -6,10 +6,7 @@ use spin::LazyLock;
 
 use super::{
     Tty,
-    terminal::{
-        WindowSize,
-        ldisc::{ProcessMode, TtyConfig, TtyRead, TtyWrite},
-    },
+    terminal::ldisc::{ProcessMode, TtyConfig, TtyRead, TtyWrite},
 };
 
 pub type NTtyDriver = Tty<Console, Console>;
@@ -51,17 +48,16 @@ unsafe fn handle_console_input_raw_irq(
 }
 
 fn new_n_tty() -> Arc<NTtyDriver> {
-    // Synchronously query the connected terminal's dimensions before the
-    // poll-reader task is spawned so TIOCGWINSZ reports the real host
-    // terminal size.  TUI applications (e.g. ratatui-based clients) use the
-    // size both to lay out panels and to map mouse-event coordinates;
-    // returning a stale fallback misplaces the UI and leaves clicks/scroll
-    // outside the rendered widgets.  Falls back silently to the default
-    // 24x80 if the host terminal does not support CPR.
     let terminal = {
         let t = super::terminal::Terminal::default();
+
+        // Synchronously querying the connected terminal only works when the
+        // firmware/serial path can reliably supply a cursor-position response.
+        // Dynamic-platform QEMU tests run under ostool pipes, so keep the
+        // default 24x80 fallback there instead of stalling early Starry boot.
+        #[cfg(not(feature = "plat-dyn"))]
         if let Some((rows, cols)) = query_console_size() {
-            *t.window_size.lock() = WindowSize {
+            *t.window_size.lock() = super::terminal::WindowSize {
                 ws_row: rows,
                 ws_col: cols,
                 ws_xpixel: 0,
@@ -94,6 +90,7 @@ fn new_n_tty() -> Arc<NTtyDriver> {
 /// Called once during NTTY initialisation, before the polling reader
 /// task is spawned, so there is no concurrent consumer racing on the
 /// UART receive FIFO.
+#[cfg(not(feature = "plat-dyn"))]
 fn query_console_size() -> Option<(u16, u16)> {
     ax_runtime::hal::console::write_bytes(b"\x1b7\x1b[9999;9999H\x1b[6n\x1b8");
 
@@ -123,11 +120,12 @@ fn query_console_size() -> Option<(u16, u16)> {
         core::hint::spin_loop();
     }
 
-    if len == 0 {
-        return None;
-    }
+    parse_console_size_response(&buf[..len])
+}
 
-    let r_pos = buf[..len].iter().rposition(|&b| b == b'R')?;
+#[cfg(any(test, not(feature = "plat-dyn")))]
+fn parse_console_size_response(buf: &[u8]) -> Option<(u16, u16)> {
+    let r_pos = buf.iter().rposition(|&b| b == b'R')?;
     let escape_pos = buf[..r_pos].windows(2).rposition(|w| w == b"\x1b[")?;
     let inner = core::str::from_utf8(&buf[escape_pos + 2..r_pos]).ok()?;
     let mut parts = inner.splitn(2, ';');
@@ -154,4 +152,17 @@ fn console_irq_mode() -> Option<ProcessMode> {
 
     ax_runtime::hal::console::set_input_irq_enabled(true);
     Some(ProcessMode::InterruptDriven(CONSOLE_INPUT_SOURCE.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_console_size_response;
+
+    #[test]
+    fn parses_cursor_position_response() {
+        assert_eq!(
+            parse_console_size_response(b"\x1b7\x1b[24;80R\x1b8"),
+            Some((24, 80))
+        );
+    }
 }

--- a/os/arceos/modules/axalloc/src/buddy_slab.rs
+++ b/os/arceos/modules/axalloc/src/buddy_slab.rs
@@ -45,14 +45,14 @@ impl<const PAGE_SIZE: usize> PercpuSlab<PAGE_SIZE> {
         }
     }
 
-    fn init(&mut self, cpu_id: usize) {
+    fn init_during_cpu_bringup(&mut self, cpu_id: usize) {
         let cpu_id = u16::try_from(cpu_id).expect("CPU id exceeds per-CPU slab range");
         assert!(
             self.cpu_id.is_none(),
             "per-CPU slab is already initialized on this CPU",
         );
         self.cpu_id = Some(cpu_id);
-        *self.inner.lock() = SlabAllocator::new();
+        *self.inner.get_mut() = SlabAllocator::new();
     }
 
     fn cpu_id_checked(&self) -> u16 {
@@ -374,12 +374,18 @@ pub fn global_allocator() -> &'static GlobalAllocator {
     &GLOBAL_ALLOCATOR
 }
 
-/// Initializes the per-CPU slab for the current CPU.
+/// Initializes the per-CPU slab for the current CPU during CPU bring-up.
 ///
 /// Must run after per-CPU storage is initialized and before scheduler, IPI, or
 /// IRQ paths can allocate on this CPU.
 pub fn init_percpu_slab(cpu_id: usize) {
-    PERCPU_SLAB.with_current(|slab| slab.init(cpu_id));
+    // Safety: while the CPU-local slab is still private to this CPU, initialize
+    // it directly instead of entering the runtime SpinNoIrq guard path.
+    unsafe {
+        PERCPU_SLAB
+            .current_ref_mut_raw()
+            .init_during_cpu_bringup(cpu_id)
+    };
 }
 
 /// Initializes the global allocator with the given memory region.

--- a/os/arceos/modules/axconfig/src/driver_dyn_config.rs
+++ b/os/arceos/modules/axconfig/src/driver_dyn_config.rs
@@ -38,8 +38,22 @@ mod arch {
     pub const KERNEL_BASE_VADDR: usize = 0xffff_8000_0000_0000;
 }
 
+#[cfg(target_arch = "loongarch64")]
+mod arch {
+    pub const ARCH: &str = "loongarch64";
+    pub const PACKAGE: &str = "axplat-dyn";
+    pub const PLATFORM: &str = "loongarch64-plat-dyn";
+    pub const TIMER_IRQ: usize = 11;
+    pub const IPI_IRQ: usize = 12;
+    pub const KERNEL_ASPACE_BASE: usize = 0x9000_0000_0000_0000;
+    pub const KERNEL_ASPACE_SIZE: usize = 0x0000_ffff_ffff_f000;
+    pub const KERNEL_BASE_PADDR: usize = 0x20_0000;
+    pub const KERNEL_BASE_VADDR: usize = 0x9000_0000_0020_0000;
+}
+
 #[cfg(not(any(
     target_arch = "aarch64",
+    target_arch = "loongarch64",
     target_arch = "riscv64",
     target_arch = "x86_64"
 )))]
@@ -135,5 +149,17 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     fn x86_64_dynamic_platform_uses_dedicated_ipi_vector() {
         assert_eq!(super::devices::IPI_IRQ, 0xf3);
+    }
+
+    #[test]
+    #[cfg(target_arch = "loongarch64")]
+    fn loongarch64_dynamic_platform_uses_arch_specific_config() {
+        assert_eq!(super::ARCH, "loongarch64");
+        assert_eq!(super::PACKAGE, "axplat-dyn");
+        assert_eq!(super::PLATFORM, "loongarch64-plat-dyn");
+        assert_eq!(super::devices::TIMER_IRQ, 11);
+        assert_eq!(super::devices::IPI_IRQ, 12);
+        assert_eq!(super::plat::KERNEL_ASPACE_BASE, 0x9000_0000_0000_0000);
+        assert_eq!(super::plat::KERNEL_BASE_VADDR, 0x9000_0000_0020_0000);
     }
 }

--- a/os/axvisor/configs/board/orangepi-5-plus.toml
+++ b/os/axvisor/configs/board/orangepi-5-plus.toml
@@ -5,6 +5,5 @@ features = [
   "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/phytiumpi.toml
+++ b/os/axvisor/configs/board/phytiumpi.toml
@@ -4,6 +4,5 @@ features = [
     "phytium-mci",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/qemu-aarch64.toml
+++ b/os/axvisor/configs/board/qemu-aarch64.toml
@@ -5,6 +5,5 @@ features = [
     "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/qemu-loongarch64.toml
+++ b/os/axvisor/configs/board/qemu-loongarch64.toml
@@ -1,12 +1,11 @@
 env = {AX_IP = "10.0.2.15", AX_GW = "10.0.2.2"}
 features = [
-  "ax-hal/loongarch64-qemu-virt",
   "ax-driver/virtio-blk",
-  "ax-driver/plat-static",
   "ept-level-4",
   "fs",
 ]
 log = "Info"
 max_cpu_num = 1
+plat_dyn = false
 target = "loongarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/qemu-riscv64.toml
+++ b/os/axvisor/configs/board/qemu-riscv64.toml
@@ -6,7 +6,6 @@ features = [
     "sstc"
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"
 vm_configs = []
 max_cpu_num = 4

--- a/os/axvisor/configs/board/qemu-x86_64-linux.toml
+++ b/os/axvisor/configs/board/qemu-x86_64-linux.toml
@@ -4,6 +4,5 @@ features = [
     "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = []

--- a/os/axvisor/configs/board/qemu-x86_64.toml
+++ b/os/axvisor/configs/board/qemu-x86_64.toml
@@ -5,6 +5,5 @@ features = [
     "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = []

--- a/os/axvisor/configs/board/rdk-s100.toml
+++ b/os/axvisor/configs/board/rdk-s100.toml
@@ -3,6 +3,5 @@ features = [
     "ept-level-4",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/roc-rk3568-pc.toml
+++ b/os/axvisor/configs/board/roc-rk3568-pc.toml
@@ -4,6 +4,5 @@ features = [
     "rockchip-sdhci",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/configs/board/tac-e400.toml
+++ b/os/axvisor/configs/board/tac-e400.toml
@@ -3,6 +3,5 @@ features = [
     "ept-level-4",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = []

--- a/os/axvisor/src/fdt/create.rs
+++ b/os/axvisor/src/fdt/create.rs
@@ -26,6 +26,7 @@ use ax_memory_addr::MemoryAddr;
 use fdt_parser::{Fdt, Node};
 
 use super::vm_fdt::{FdtWriter, FdtWriterNode};
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use crate::images::load_vm_image_from_memory;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use axvm::AxVMRef;

--- a/platforms/axplat-dyn/src/boot.rs
+++ b/platforms/axplat-dyn/src/boot.rs
@@ -11,25 +11,34 @@ fn main() -> ! {
         args = fdt;
     }
 
-    ax_plat::call_main(somehal::smp::early_current_cpu_idx(), args)
+    let cpu_idx = somehal::smp::early_current_cpu_idx();
+    ax_percpu::init_percpu_reg(cpu_idx);
+    ax_plat::call_main(cpu_idx, args)
 }
 
 #[somehal::secondary_entry]
 fn secondary_main() {
     #[cfg(feature = "smp")]
-    ax_plat::call_secondary_main(meta.cpu_idx);
+    {
+        ax_percpu::init_percpu_reg(meta.cpu_idx);
+        ax_plat::call_secondary_main(meta.cpu_idx);
+    }
 }
 
-pub fn boot_stack_bounds(cpu_id: usize) -> (VirtAddr, usize) {
-    let meta = somehal::smp::cpu_meta(cpu_id)
-        .unwrap_or_else(|| panic!("missing somehal PerCpuMeta for cpu_id {cpu_id}"));
+pub fn boot_stack_bounds(cpu_idx: usize) -> (VirtAddr, usize) {
+    let meta = somehal::smp::cpu_meta(cpu_idx)
+        .unwrap_or_else(|| panic!("missing somehal PerCpuMeta for cpu_idx {cpu_idx}"));
     let stack_size = somehal::mem::stack_size();
     (VirtAddr::from(meta.stack_top_virt - stack_size), stack_size)
 }
 
 pub struct Kernel;
 
-impl KernelOp for Kernel {}
+impl KernelOp for Kernel {
+    fn current_cpu_idx(&self) -> Option<usize> {
+        Some(ax_plat::percpu::this_cpu_id())
+    }
+}
 
 impl MmioOp for Kernel {
     fn ioremap(&self, addr: MmioAddr, size: usize) -> Result<MmioRaw, MapError> {

--- a/platforms/axplat-dyn/src/init.rs
+++ b/platforms/axplat-dyn/src/init.rs
@@ -10,28 +10,16 @@ impl InitIf for InitIfImpl {
     /// and performed earliest platform configuration and initialization (e.g.,
     /// early console, clocking).
     fn init_early(_cpu_id: usize, _dtb: usize) {
-        #[cfg(target_arch = "riscv64")]
-        somehal::arch::register_current_cpu_id(_cpu_id, ax_plat::percpu::this_cpu_id);
         ax_cpu::init::init_trap();
-        #[cfg(all(target_arch = "aarch64", feature = "fp-simd"))]
-        {
-            ax_cpu::asm::enable_fp();
-            debug!("axplat-dyn: fp/simd enabled");
-        }
+        enable_fp_simd();
         somehal::timer::enable();
     }
 
     /// Initializes the platform at the early stage for secondary cores.
     #[cfg(feature = "smp")]
     fn init_early_secondary(_cpu_id: usize) {
-        #[cfg(target_arch = "riscv64")]
-        somehal::arch::register_current_cpu_id(_cpu_id, ax_plat::percpu::this_cpu_id);
         ax_cpu::init::init_trap();
-        #[cfg(all(target_arch = "aarch64", feature = "fp-simd"))]
-        {
-            ax_cpu::asm::enable_fp();
-            debug!("axplat-dyn: secondary fp/simd enabled");
-        }
+        enable_fp_simd();
         somehal::timer::enable();
     }
 
@@ -51,3 +39,23 @@ impl InitIf for InitIfImpl {
         somehal::timer::irq_enable();
     }
 }
+
+#[cfg(all(
+    feature = "fp-simd",
+    any(target_arch = "aarch64", target_arch = "loongarch64")
+))]
+fn enable_fp_simd() {
+    ax_cpu::asm::enable_fp();
+    #[cfg(target_arch = "loongarch64")]
+    {
+        ax_cpu::asm::enable_lsx();
+        ax_cpu::asm::enable_lasx();
+    }
+    debug!("axplat-dyn: fp/simd enabled");
+}
+
+#[cfg(not(all(
+    feature = "fp-simd",
+    any(target_arch = "aarch64", target_arch = "loongarch64")
+)))]
+fn enable_fp_simd() {}

--- a/platforms/somehal/Cargo.toml
+++ b/platforms/somehal/Cargo.toml
@@ -41,6 +41,9 @@ ax-riscv-plic = { workspace = true }
 riscv.workspace = true
 sbi-rt = { workspace = true, features = ["legacy"] }
 
+[target.'cfg(target_arch = "loongarch64")'.dependencies]
+loongArch64 = "0.2"
+
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x2apic = "0.5"
 x86 = "0.52"

--- a/platforms/somehal/src/arch/aarch64/gic/mod.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/mod.rs
@@ -29,12 +29,18 @@ fn backend() -> GicBackend {
 }
 
 pub fn init_current_cpu() {
+    let cpu_idx = crate::cpu::current_cpu_idx()
+        .unwrap_or_else(|| panic!("current logical CPU index is not available for GIC init"));
+    init_cpu(cpu_idx);
+}
+
+pub fn init_cpu(cpu_idx: usize) {
     match backend() {
         GicBackend::V2 => v2::init_cpu(),
-        GicBackend::V3 => v3::init_cpu(),
+        GicBackend::V3 => v3::init_cpu(cpu_idx),
         GicBackend::None => {
             if v3::is_support_icc() {
-                v3::init_cpu();
+                v3::init_cpu(cpu_idx);
             } else {
                 v2::init_cpu();
             }
@@ -73,8 +79,8 @@ pub fn send_ipi(irq: rdrive::IrqId, target: crate::irq::IpiTarget) {
     }
 }
 
-fn hardware_cpu_id(cpu_id: usize) -> usize {
-    someboot::smp::cpu_idx_to_id(cpu_id).unwrap_or(cpu_id)
+fn hardware_cpu_id(cpu_idx: usize) -> usize {
+    someboot::smp::cpu_idx_to_id(cpu_idx).unwrap_or(cpu_idx)
 }
 
 #[unsafe(no_mangle)]

--- a/platforms/somehal/src/arch/aarch64/gic/v3.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/v3.rs
@@ -27,19 +27,19 @@ impl CpuInterfaceSlot {
         }
     }
 
-    unsafe fn set(&self, cpu_id: usize, cpu_if: CpuInterface) {
+    unsafe fn set(&self, cpu_idx: usize, cpu_if: CpuInterface) {
         let slot = unsafe { &mut *self.inner.get() };
         assert!(
             slot.is_none(),
-            "GICv3 CPU interface for CPU {cpu_id} is already initialized"
+            "GICv3 CPU interface for CPU index {cpu_idx} is already initialized"
         );
         *slot = Some(cpu_if);
     }
 
-    unsafe fn get(&self, cpu_id: usize) -> &CpuInterface {
-        unsafe { &*self.inner.get() }
-            .as_ref()
-            .unwrap_or_else(|| panic!("GICv3 CPU interface for CPU {cpu_id} is not initialized"))
+    unsafe fn get(&self, cpu_idx: usize) -> &CpuInterface {
+        unsafe { &*self.inner.get() }.as_ref().unwrap_or_else(|| {
+            panic!("GICv3 CPU interface for CPU index {cpu_idx} is not initialized")
+        })
     }
 }
 
@@ -86,7 +86,9 @@ fn probe_gic(info: FdtInfo<'_>, dev: PlatformDevice) -> Result<(), OnProbeError>
     super::set_backend(super::GicBackend::V3);
 
     init_cpu_interface_map();
-    init_cpu_interface(&gic, 0);
+    let cpu_idx =
+        crate::cpu::current_cpu_idx().unwrap_or_else(someboot::smp::early_current_cpu_idx);
+    init_cpu_interface(&gic, cpu_idx);
 
     dev.register(rdif_intc::Intc::new(gic));
 
@@ -125,8 +127,8 @@ pub fn send_ipi(raw: usize, target: crate::irq::IpiTarget) {
     let sgi = IntId::sgi(raw as u32);
     let target = match target {
         crate::irq::IpiTarget::Current { cpu_id: _ } => SGITarget::current(),
-        crate::irq::IpiTarget::Other { cpu_id } => {
-            SGITarget::list([affinity_from_mpidr(super::hardware_cpu_id(cpu_id))])
+        crate::irq::IpiTarget::Other { cpu_id: cpu_idx } => {
+            SGITarget::list([affinity_from_mpidr(super::hardware_cpu_id(cpu_idx))])
         }
         crate::irq::IpiTarget::AllExceptCurrent { .. } => SGITarget::All,
     };
@@ -142,22 +144,21 @@ fn affinity_from_mpidr(mpidr: usize) -> Affinity {
     }
 }
 
-pub fn init_cpu() {
-    let cpu_id = someboot::smp::early_current_cpu_idx();
-    with_gic(|gic| init_cpu_interface(gic, cpu_id));
+pub fn init_cpu(cpu_idx: usize) {
+    with_gic(|gic| init_cpu_interface(gic, cpu_idx));
 
     debug!("GICCv3 initialized");
 }
 
 fn init_cpu_interface_map() {
     let mut cpu_if = BTreeMap::new();
-    for cpu_id in 0..someboot::smp::cpu_count() {
-        cpu_if.insert(cpu_id, CpuInterfaceSlot::empty());
+    for cpu_idx in 0..someboot::smp::cpu_count() {
+        cpu_if.insert(cpu_idx, CpuInterfaceSlot::empty());
     }
     CPU_IF.init(cpu_if);
 }
 
-fn init_cpu_interface(gic: &Gic, cpu_id: usize) {
+fn init_cpu_interface(gic: &Gic, cpu_idx: usize) {
     let mut cpu = gic.cpu_interface();
     cpu.init_current_cpu().unwrap();
     #[cfg(feature = "hv")]
@@ -165,18 +166,19 @@ fn init_cpu_interface(gic: &Gic, cpu_id: usize) {
 
     // SAFETY: CPU_IF was preallocated during BSP probe. Each CPU initializes
     // only its own logical CPU slot before it can send SGIs through that slot.
-    unsafe { cpu_interface_slot(cpu_id).set(cpu_id, cpu) };
+    unsafe { cpu_interface_slot(cpu_idx).set(cpu_idx, cpu) };
 }
 
 fn current_cpu_interface() -> &'static CpuInterface {
-    let cpu_id = someboot::smp::early_current_cpu_idx();
+    let cpu_idx = crate::cpu::current_cpu_idx()
+        .unwrap_or_else(|| panic!("current logical CPU index is not available for GICv3 SGI"));
     // SAFETY: send_ipi is only valid after the current CPU has completed
     // interrupt-controller initialization and stored its CpuInterface.
-    unsafe { cpu_interface_slot(cpu_id).get(cpu_id) }
+    unsafe { cpu_interface_slot(cpu_idx).get(cpu_idx) }
 }
 
-fn cpu_interface_slot(cpu_id: usize) -> &'static CpuInterfaceSlot {
+fn cpu_interface_slot(cpu_idx: usize) -> &'static CpuInterfaceSlot {
     CPU_IF
-        .get(&cpu_id)
-        .unwrap_or_else(|| panic!("GICv3 CPU interface slot for CPU {cpu_id} is not registered"))
+        .get(&cpu_idx)
+        .unwrap_or_else(|| panic!("GICv3 CPU interface slot for CPU {cpu_idx} is not registered"))
 }

--- a/platforms/somehal/src/arch/aarch64/mod.rs
+++ b/platforms/somehal/src/arch/aarch64/mod.rs
@@ -24,8 +24,8 @@ impl PlatOp for Plat {
 
     fn secondary_init() {}
 
-    fn secondary_init_intc(_cpu_idx: usize) {
-        gic::init_current_cpu();
+    fn secondary_init_intc(cpu_idx: usize) {
+        gic::init_cpu(cpu_idx);
     }
 
     fn secondary_init_systick() {

--- a/platforms/somehal/src/arch/loongarch64/eiointc.rs
+++ b/platforms/somehal/src/arch/loongarch64/eiointc.rs
@@ -1,0 +1,188 @@
+use loongArch64::iocsr::{iocsr_read_d, iocsr_write_d, iocsr_write_w};
+use rdif_intc::Interface;
+use rdrive::{
+    DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
+};
+
+use super::irq_common::{EIOINTC_VECTOR_COUNT, eiointc_reg_bit, fdt_first_cell_vector};
+
+const EIOINTC_IRQ: usize = 3;
+
+const LOONGARCH_IOCSR_MISC_FUNC: usize = 0x420;
+const IOCSR_MISC_FUNC_EXT_IOI_EN: u64 = 1 << 48;
+
+const EIOINTC_REG_NODEMAP: usize = 0x14a0;
+const EIOINTC_REG_IPMAP: usize = 0x14c0;
+const EIOINTC_REG_ENABLE: usize = 0x1600;
+const EIOINTC_REG_BOUNCE: usize = 0x1680;
+const EIOINTC_REG_ISR: usize = 0x1800;
+const EIOINTC_REG_ROUTE: usize = 0x1c00;
+
+const VEC_COUNT_PER_REG: usize = 64;
+
+module_driver!(
+    name: "Loongson EIOINTC",
+    level: ProbeLevel::PreKernel,
+    priority: ProbePriority::INTC,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &[
+            "loongson,ls2k2000-eiointc",
+            "loongson,ls3a5000-eiointc",
+            "loongson,eiointc",
+        ],
+        on_probe: probe_eiointc
+    }],
+);
+
+pub fn set_irq_enable(irq: usize, enable: bool) {
+    with_eiointc("setting EIOINTC IRQ enable", |intc| {
+        if enable {
+            intc.enable_irq(irq);
+        } else {
+            intc.disable_irq(irq);
+        }
+    });
+}
+
+pub fn claim_irq() -> Option<usize> {
+    with_eiointc("claiming EIOINTC IRQ", |intc| intc.claim_irq()).flatten()
+}
+
+pub fn complete_irq(irq: usize) {
+    with_eiointc("completing EIOINTC IRQ", |intc| intc.complete_irq(irq));
+}
+
+fn probe_eiointc(_info: FdtInfo<'_>, dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let intc = EioIntc::new(EIOINTC_VECTOR_COUNT);
+    intc.init();
+    someboot::irq::irq_set_enable(someboot::irq::IrqId::new(EIOINTC_IRQ), true);
+    dev.register(rdif_intc::Intc::new(intc));
+    Ok(())
+}
+
+fn with_eiointc<R>(op: &str, f: impl FnOnce(&mut EioIntc) -> R) -> Option<R> {
+    if !rdrive::is_initialized() {
+        return None;
+    }
+
+    for intc in rdrive::get_list::<rdif_intc::Intc>() {
+        let Ok(intc) = intc.downcast::<EioIntc>() else {
+            continue;
+        };
+        let Ok(mut intc) = intc.try_lock() else {
+            warn!("failed to lock Loongson EIOINTC when {op}");
+            return None;
+        };
+        return Some(f(&mut intc));
+    }
+
+    warn!("Loongson EIOINTC is not registered when {op}");
+    None
+}
+
+struct EioIntc {
+    vectors: usize,
+}
+
+impl EioIntc {
+    const fn new(vectors: usize) -> Self {
+        Self { vectors }
+    }
+
+    fn init(&self) {
+        let misc = iocsr_read_d(LOONGARCH_IOCSR_MISC_FUNC);
+        iocsr_write_d(LOONGARCH_IOCSR_MISC_FUNC, misc | IOCSR_MISC_FUNC_EXT_IOI_EN);
+
+        let index = 0;
+
+        for i in 0..(self.vectors / 32) {
+            let data = ((1 << (i * 2 + 1)) << 16) | (1 << (i * 2));
+            iocsr_write_w(EIOINTC_REG_NODEMAP + i * 4, data);
+        }
+        for i in 0..(self.vectors / 32 / 4) {
+            let bit = 1 << (1 + index);
+            let data = bit | (bit << 8) | (bit << 16) | (bit << 24);
+            iocsr_write_w(EIOINTC_REG_IPMAP + i * 4, data);
+        }
+        for i in 0..(self.vectors / 4) {
+            let bit = 1;
+            let data = bit | (bit << 8) | (bit << 16) | (bit << 24);
+            iocsr_write_w(EIOINTC_REG_ROUTE + i * 4, data);
+        }
+        for i in 0..(self.vectors / 32) {
+            iocsr_write_w(EIOINTC_REG_BOUNCE + i * 4, u32::MAX);
+        }
+    }
+
+    fn enable_irq(&mut self, irq: usize) {
+        if !self.contains_irq(irq, "enable") {
+            return;
+        }
+
+        let (offset, bit) = eiointc_reg_bit(irq);
+        for base in [EIOINTC_REG_ENABLE, EIOINTC_REG_BOUNCE] {
+            let addr = base + offset;
+            iocsr_write_d(addr, iocsr_read_d(addr) | bit);
+        }
+    }
+
+    fn disable_irq(&mut self, irq: usize) {
+        if !self.contains_irq(irq, "disable") {
+            return;
+        }
+
+        let (offset, bit) = eiointc_reg_bit(irq);
+        let addr = EIOINTC_REG_ENABLE + offset;
+        iocsr_write_d(addr, iocsr_read_d(addr) & !bit);
+    }
+
+    fn claim_irq(&mut self) -> Option<usize> {
+        for i in 0..(self.vectors / VEC_COUNT_PER_REG) {
+            let flags = iocsr_read_d(EIOINTC_REG_ISR + i * 8);
+            if flags != 0 {
+                return Some(flags.trailing_zeros() as usize + VEC_COUNT_PER_REG * i);
+            }
+        }
+        None
+    }
+
+    fn complete_irq(&mut self, irq: usize) {
+        if !self.contains_irq(irq, "complete") {
+            return;
+        }
+
+        let (offset, bit) = eiointc_reg_bit(irq);
+        iocsr_write_d(EIOINTC_REG_ISR + offset, bit);
+    }
+
+    fn contains_irq(&self, irq: usize, op: &str) -> bool {
+        if irq < self.vectors {
+            true
+        } else {
+            warn!("skip {op} for out-of-range EIOINTC IRQ {irq}");
+            false
+        }
+    }
+}
+
+impl DriverGeneric for EioIntc {
+    fn name(&self) -> &str {
+        "Loongson EIOINTC"
+    }
+}
+
+impl Interface for EioIntc {
+    fn setup_irq_by_fdt(&mut self, irq_prop: &[u32]) -> rdrive::IrqId {
+        let Some(vector) = fdt_first_cell_vector(irq_prop) else {
+            warn!("empty EIOINTC interrupt specifier");
+            return 0usize.into();
+        };
+        if vector >= self.vectors {
+            warn!(
+                "EIOINTC interrupt vector {vector} exceeds vector count {}",
+                self.vectors
+            );
+        }
+        vector.into()
+    }
+}

--- a/platforms/somehal/src/arch/loongarch64/irq_common.rs
+++ b/platforms/somehal/src/arch/loongarch64/irq_common.rs
@@ -1,0 +1,46 @@
+pub const EIOINTC_VECTOR_COUNT: usize = 256;
+pub const PCH_PIC_VECTOR_COUNT: usize = 64;
+
+pub fn fdt_first_cell_vector(irq_prop: &[u32]) -> Option<usize> {
+    irq_prop.first().copied().map(|vector| vector as usize)
+}
+
+pub fn eiointc_reg_bit(irq: usize) -> (usize, u64) {
+    (irq / 64 * 8, 1u64 << (irq % 64))
+}
+
+pub fn pch_pic_reg_bit(irq: usize) -> (usize, u32) {
+    (irq / 32 * 4, 1u32 << (irq % 32))
+}
+
+#[cfg(all(test, any(unix, windows)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fdt_first_cell_vector_uses_first_specifier_cell() {
+        assert_eq!(fdt_first_cell_vector(&[0x2a]), Some(0x2a));
+        assert_eq!(fdt_first_cell_vector(&[0x11, 0x1]), Some(0x11));
+    }
+
+    #[test]
+    fn fdt_first_cell_vector_rejects_empty_specifier() {
+        assert_eq!(fdt_first_cell_vector(&[]), None);
+    }
+
+    #[test]
+    fn eiointc_reg_bit_splits_64_bit_registers() {
+        assert_eq!(eiointc_reg_bit(0), (0, 1));
+        assert_eq!(eiointc_reg_bit(63), (0, 1u64 << 63));
+        assert_eq!(eiointc_reg_bit(64), (8, 1));
+        assert_eq!(eiointc_reg_bit(255), (24, 1u64 << 63));
+    }
+
+    #[test]
+    fn pch_pic_reg_bit_splits_32_bit_registers() {
+        assert_eq!(pch_pic_reg_bit(0), (0, 1));
+        assert_eq!(pch_pic_reg_bit(31), (0, 1u32 << 31));
+        assert_eq!(pch_pic_reg_bit(32), (4, 1));
+        assert_eq!(pch_pic_reg_bit(63), (4, 1u32 << 31));
+    }
+}

--- a/platforms/somehal/src/arch/loongarch64/mod.rs
+++ b/platforms/somehal/src/arch/loongarch64/mod.rs
@@ -1,12 +1,117 @@
-use crate::common::PlatOp;
+use loongArch64::iocsr::{iocsr_read_w, iocsr_write_w};
+
+use crate::{common::PlatOp, irq::_handle_irq};
+
+mod eiointc;
+mod irq_common;
+mod pch_pic;
 
 pub struct Plat;
 
+const IOCSR_IPI_SEND_CPU_SHIFT: u32 = 16;
+const IOCSR_IPI_SEND_BLOCKING: u32 = 1 << 31;
+
+const IOCSR_IPI_STATUS: usize = 0x1000;
+const IOCSR_IPI_ENABLE: usize = 0x1004;
+const IOCSR_IPI_CLEAR: usize = 0x100c;
+const IOCSR_IPI_SEND: usize = 0x1040;
+
+const EIOINTC_IRQ: usize = 3;
+const IPI_IRQ: usize = 12;
+const IPI_VECTOR: u32 = 0;
+
+fn make_ipi_send_value(cpu_id: usize, vector: u32, blocking: bool) -> u32 {
+    let mut value = (cpu_id as u32) << IOCSR_IPI_SEND_CPU_SHIFT | vector;
+    if blocking {
+        value |= IOCSR_IPI_SEND_BLOCKING;
+    }
+    value
+}
+
+fn ack_pending_ipi() -> u32 {
+    let status = iocsr_read_w(IOCSR_IPI_STATUS);
+    if status != 0 {
+        iocsr_write_w(IOCSR_IPI_CLEAR, status);
+        trace!("IPI status = {status:#x}");
+    }
+    status
+}
+
 impl PlatOp for Plat {
-    fn irq_set_enable(_irq: rdrive::IrqId, _enable: bool) {}
+    fn irq_set_enable(irq: rdrive::IrqId, enable: bool) {
+        let raw = irq.raw();
+
+        if raw == someboot::irq::systimer_irq().raw() {
+            someboot::irq::irq_set_enable(someboot::irq::IrqId::new(raw), enable);
+            return;
+        }
+
+        if raw == IPI_IRQ {
+            let value = if enable { u32::MAX } else { 0 };
+            iocsr_write_w(IOCSR_IPI_ENABLE, value);
+            someboot::irq::irq_set_enable(someboot::irq::IrqId::new(raw), enable);
+            return;
+        }
+
+        eiointc::set_irq_enable(raw, enable);
+        pch_pic::set_irq_enable(raw, enable);
+    }
+
+    fn send_ipi(_irq: rdrive::IrqId, target: crate::irq::IpiTarget) {
+        match target {
+            crate::irq::IpiTarget::Current { cpu_id } | crate::irq::IpiTarget::Other { cpu_id } => {
+                Self::send_ipi_to_cpu(cpu_id);
+            }
+            crate::irq::IpiTarget::AllExceptCurrent { cpu_id, cpu_num } => {
+                for target_cpu in 0..cpu_num {
+                    if target_cpu != cpu_id {
+                        Self::send_ipi_to_cpu(target_cpu);
+                    }
+                }
+            }
+        }
+    }
 
     fn irq_handler() -> someboot::irq::IrqId {
-        todo!()
+        someboot::irq::systimer_irq()
+    }
+
+    fn irq_handler_with_raw(raw: usize) -> Option<someboot::irq::IrqId> {
+        let irq = match raw {
+            raw if raw == someboot::irq::systimer_irq().raw() => {
+                let irq = someboot::irq::IrqId::new(raw);
+                _handle_irq(raw.into());
+                someboot::timer::ack();
+                irq
+            }
+            IPI_IRQ => {
+                let mut status = ack_pending_ipi();
+                let irq = someboot::irq::IrqId::new(raw);
+                while status != 0 {
+                    let ipi_bit = status.trailing_zeros();
+                    status &= !(1 << ipi_bit);
+                    _handle_irq(raw.into());
+                }
+                irq
+            }
+            EIOINTC_IRQ => {
+                let Some(external) = eiointc::claim_irq() else {
+                    debug!("Spurious LoongArch EIOINTC interrupt");
+                    return None;
+                };
+                let irq = someboot::irq::IrqId::new(external);
+                _handle_irq(external.into());
+                eiointc::complete_irq(external);
+                irq
+            }
+            external => {
+                let irq = someboot::irq::IrqId::new(external);
+                _handle_irq(external.into());
+                irq
+            }
+        };
+
+        Some(irq)
     }
 
     fn systick_irq() -> rdrive::IrqId {
@@ -18,4 +123,11 @@ impl PlatOp for Plat {
     fn secondary_init_intc(_cpu_idx: usize) {}
 
     fn secondary_init_systick() {}
+
+    fn send_ipi_to_cpu(cpu_id: usize) {
+        iocsr_write_w(
+            IOCSR_IPI_SEND,
+            make_ipi_send_value(cpu_id, IPI_VECTOR, false),
+        );
+    }
 }

--- a/platforms/somehal/src/arch/loongarch64/pch_pic.rs
+++ b/platforms/somehal/src/arch/loongarch64/pch_pic.rs
@@ -1,0 +1,186 @@
+use rdif_intc::Interface;
+use rdrive::{
+    DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
+};
+
+use super::irq_common::{PCH_PIC_VECTOR_COUNT, fdt_first_cell_vector, pch_pic_reg_bit};
+use crate::{common::ioremap, setup::MmioRaw};
+
+const DEFAULT_PCH_PIC_SIZE: usize = 0x400;
+
+const PCH_PIC_MASK: usize = 0x20;
+const PCH_PIC_EDGE: usize = 0x60;
+const PCH_PIC_POL: usize = 0x3e0;
+const PCH_INT_HTVEC: usize = 0x200;
+
+module_driver!(
+    name: "Loongson PCH-PIC",
+    level: ProbeLevel::PreKernel,
+    priority: ProbePriority::INTC,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &[
+            "loongson,ls7a-pch-pic",
+            "loongson,pch-pic-1.0",
+            "loongson,pch-pic",
+        ],
+        on_probe: probe_pch_pic
+    }],
+);
+
+pub fn set_irq_enable(irq: usize, enable: bool) {
+    with_pch_pic("setting PCH-PIC IRQ enable", |pic| {
+        if enable {
+            pic.enable_irq(irq);
+        } else {
+            pic.disable_irq(irq);
+        }
+    });
+}
+
+fn probe_pch_pic(info: FdtInfo<'_>, dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let reg = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or_else(|| OnProbeError::other(format!("[{}] has no reg", info.node.name())))?;
+    let base_vector = info
+        .node
+        .as_node()
+        .get_property("loongson,pic-base-vec")
+        .and_then(|prop| prop.get_u32())
+        .unwrap_or(0) as usize;
+    let vector_count = info
+        .node
+        .as_node()
+        .get_property("loongson,pic-num-vecs")
+        .and_then(|prop| prop.get_u32())
+        .unwrap_or(PCH_PIC_VECTOR_COUNT as u32) as usize;
+    let mmio = ioremap(
+        reg.address,
+        reg.size.unwrap_or(DEFAULT_PCH_PIC_SIZE as u64) as usize,
+    )
+    .map_err(|err| OnProbeError::other(format!("failed to map PCH-PIC: {err:?}")))?;
+
+    let pic = PchPic::new(mmio, base_vector, vector_count);
+    pic.init();
+    dev.register(rdif_intc::Intc::new(pic));
+    Ok(())
+}
+
+fn with_pch_pic<R>(op: &str, f: impl FnOnce(&mut PchPic) -> R) -> Option<R> {
+    if !rdrive::is_initialized() {
+        return None;
+    }
+
+    for intc in rdrive::get_list::<rdif_intc::Intc>() {
+        let Ok(intc) = intc.downcast::<PchPic>() else {
+            continue;
+        };
+        let Ok(mut intc) = intc.try_lock() else {
+            warn!("failed to lock Loongson PCH-PIC when {op}");
+            return None;
+        };
+        return Some(f(&mut intc));
+    }
+
+    warn!("Loongson PCH-PIC is not registered when {op}");
+    None
+}
+
+struct PchPic {
+    mmio: MmioRaw,
+    base_vector: usize,
+    vector_count: usize,
+}
+
+impl PchPic {
+    fn new(mmio: MmioRaw, base_vector: usize, vector_count: usize) -> Self {
+        Self {
+            mmio,
+            base_vector,
+            vector_count,
+        }
+    }
+
+    fn init(&self) {
+        self.write_w(PCH_PIC_EDGE, 0);
+        self.write_w(PCH_PIC_EDGE + 4, 0);
+        self.write_w(PCH_PIC_POL, 0);
+        self.write_w(PCH_PIC_POL + 4, 0);
+    }
+
+    fn enable_irq(&mut self, irq: usize) {
+        let Some(input) = self.input_for_vector(irq, "enable") else {
+            return;
+        };
+        let (offset, bit) = pch_pic_reg_bit(input);
+
+        let addr = PCH_PIC_MASK + offset;
+        self.write_w(addr, self.read_w(addr) & !bit);
+        self.write_b(PCH_INT_HTVEC + input, irq as u8);
+    }
+
+    fn disable_irq(&mut self, irq: usize) {
+        let Some(input) = self.input_for_vector(irq, "disable") else {
+            return;
+        };
+        let (offset, bit) = pch_pic_reg_bit(input);
+        let addr = PCH_PIC_MASK + offset;
+        self.write_w(addr, self.read_w(addr) | bit);
+    }
+
+    fn input_for_vector(&self, vector: usize, op: &str) -> Option<usize> {
+        let Some(input) = vector.checked_sub(self.base_vector) else {
+            warn!(
+                "skip {op} for PCH-PIC vector {vector} below base {}",
+                self.base_vector
+            );
+            return None;
+        };
+
+        if input < self.vector_count {
+            Some(input)
+        } else {
+            warn!(
+                "skip {op} for out-of-range PCH-PIC vector {vector}, base {}, count {}",
+                self.base_vector, self.vector_count
+            );
+            None
+        }
+    }
+
+    fn read_w(&self, offset: usize) -> u32 {
+        self.mmio.read(offset)
+    }
+
+    fn write_w(&self, offset: usize, value: u32) {
+        self.mmio.write(offset, value);
+    }
+
+    fn write_b(&self, offset: usize, value: u8) {
+        self.mmio.write(offset, value);
+    }
+}
+
+impl DriverGeneric for PchPic {
+    fn name(&self) -> &str {
+        "Loongson PCH-PIC"
+    }
+}
+
+impl Interface for PchPic {
+    fn setup_irq_by_fdt(&mut self, irq_prop: &[u32]) -> rdrive::IrqId {
+        let Some(input) = fdt_first_cell_vector(irq_prop) else {
+            warn!("empty PCH-PIC interrupt specifier");
+            return self.base_vector.into();
+        };
+        if input >= self.vector_count {
+            warn!(
+                "PCH-PIC interrupt input {input} exceeds vector count {}",
+                self.vector_count
+            );
+        }
+        (self.base_vector + input).into()
+    }
+}

--- a/platforms/somehal/src/arch/riscv64/mod.rs
+++ b/platforms/somehal/src/arch/riscv64/mod.rs
@@ -4,10 +4,6 @@ mod plic;
 
 pub struct Plat;
 
-pub fn register_current_cpu_id(cpu_idx: usize, reader: fn() -> usize) {
-    plic::register_current_cpu_id(cpu_idx, reader);
-}
-
 pub(crate) fn claim_external_irq() -> Option<someboot::irq::IrqId> {
     plic::claim_external_irq()
 }

--- a/platforms/somehal/src/arch/riscv64/plic.rs
+++ b/platforms/somehal/src/arch/riscv64/plic.rs
@@ -1,9 +1,5 @@
 use alloc::{format, vec::Vec};
-use core::{
-    num::NonZeroU32,
-    ptr::NonNull,
-    sync::atomic::{AtomicPtr, Ordering},
-};
+use core::{num::NonZeroU32, ptr::NonNull};
 
 use ax_riscv_plic::{PLICRegs, Plic, PlicIrqHandler};
 use kernutil::StaticCell;
@@ -27,7 +23,6 @@ const DEFAULT_PRIORITY: u32 = 1;
 const DEFAULT_PLIC_SIZE: usize = 0x400_0000;
 
 static IRQ_HANDLER: StaticCell<RiscvPlicIrqHandler> = StaticCell::uninit();
-static CURRENT_CPU_ID: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
 
 module_driver!(
     name: "RISC-V PLIC",
@@ -45,10 +40,6 @@ module_driver!(
 
 pub fn systick_irq() -> rdrive::IrqId {
     S_TIMER.into()
-}
-
-pub fn register_current_cpu_id(_cpu_idx: usize, reader: fn() -> usize) {
-    CURRENT_CPU_ID.store(reader as *mut (), Ordering::Release);
 }
 
 pub fn irq_set_enable(irq: rdrive::IrqId, enable: bool) {
@@ -368,22 +359,12 @@ impl RiscvPlic {
 }
 
 fn current_context(context_by_cpu: &[Option<usize>]) -> Option<usize> {
-    let cpu_idx = current_cpu_idx()?;
+    let cpu_idx = crate::cpu::current_cpu_idx()?;
     context_by_cpu.get(cpu_idx).and_then(|ctx| *ctx)
 }
 
-fn current_cpu_idx() -> Option<usize> {
-    let reader = CURRENT_CPU_ID.load(Ordering::Acquire);
-    if !reader.is_null() {
-        let reader = unsafe { core::mem::transmute::<*mut (), fn() -> usize>(reader) };
-        return Some(reader());
-    }
-
-    someboot::smp::try_early_cpu_idx()
-}
-
 fn warn_missing_current_context() {
-    if let Some(cpu_idx) = current_cpu_idx() {
+    if let Some(cpu_idx) = crate::cpu::current_cpu_idx() {
         warn!("PLIC supervisor context for logical CPU {cpu_idx} is not found");
     } else {
         warn!("PLIC supervisor context for current logical CPU is not found");

--- a/platforms/somehal/src/cpu.rs
+++ b/platforms/somehal/src/cpu.rs
@@ -1,0 +1,12 @@
+//! Current CPU helpers shared by architecture backends.
+
+/// Returns the current logical CPU index.
+///
+/// This prefers the kernel runtime interface. Before the kernel can provide a
+/// runtime answer, it falls back to the early boot CPU-index convention exposed
+/// by `someboot`.
+pub fn current_cpu_idx() -> Option<usize> {
+    crate::setup::kernel()
+        .current_cpu_idx()
+        .or_else(someboot::smp::try_early_cpu_idx)
+}

--- a/platforms/somehal/src/lib.rs
+++ b/platforms/somehal/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 extern crate log;
 
 pub(crate) mod common;
+pub mod cpu;
 mod driver;
 pub mod irq;
 pub mod setup;
@@ -45,6 +46,15 @@ pub fn post_paging() {
     someboot::post_allocator();
     // note: irq controller should be initialized when probe.
     driver::rdrive_setup();
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn current_cpu_idx_api_is_arch_independent() {
+        let current = crate::cpu::current_cpu_idx();
+        let _current: Option<usize> = current;
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/platforms/somehal/src/setup.rs
+++ b/platforms/somehal/src/setup.rs
@@ -1,6 +1,12 @@
 pub use mmio_api::{MapError, MmioAddr, MmioOp, MmioRaw};
 
-pub trait KernelOp: MmioOp {}
+pub trait KernelOp: MmioOp {
+    /// Returns the current logical CPU index after the kernel has initialized
+    /// its runtime per-CPU state.
+    fn current_cpu_idx(&self) -> Option<usize> {
+        None
+    }
+}
 
 struct EmptyKernelOp;
 
@@ -25,6 +31,6 @@ pub(crate) fn set_kernel_op(op: &'static dyn KernelOp) {
     }
 }
 
-// pub(crate) fn kernel() -> &'static dyn KernelOp {
-//     unsafe { KERNEL_OP }
-// }
+pub(crate) fn kernel() -> &'static dyn KernelOp {
+    unsafe { KERNEL_OP }
+}

--- a/scripts/axbuild/src/arceos/build.rs
+++ b/scripts/axbuild/src/arceos/build.rs
@@ -27,9 +27,9 @@ pub(crate) struct ArceosBuildConfig {
 }
 
 impl ArceosBuildConfig {
-    fn default_for_target(target: &str) -> Self {
+    fn default_config() -> Self {
         Self {
-            build_info: ArceosBuildInfo::default_for_target(target),
+            build_info: ArceosBuildInfo::default(),
             app_c: None,
         }
     }
@@ -98,7 +98,7 @@ fn load_build_config_with_makefile_features_and_metadata(
     metadata: Option<&Metadata>,
 ) -> anyhow::Result<ArceosBuildConfig> {
     build::ensure_build_info(&request.build_info_path, || {
-        ArceosBuildConfig::default_for_target(&request.target)
+        ArceosBuildConfig::default_config()
     })?;
     let content = fs::read_to_string(&request.build_info_path)?;
     build::reject_removed_std_field(&request.build_info_path, &content)?;
@@ -108,12 +108,6 @@ fn load_build_config_with_makefile_features_and_metadata(
             request.build_info_path.display()
         )
     })?;
-    build::apply_target_defaults_if_plat_dyn_unspecified(
-        &mut config.build_info,
-        &request.target,
-        &content,
-    );
-
     if config.build_info.normalize_legacy_feature_aliases() {
         warn!(
             "normalizing legacy feature aliases in build config {}",
@@ -361,7 +355,7 @@ mod tests {
 
     #[test]
     fn resolves_dynamic_platform_features_and_args() {
-        let mut build_info = ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat");
+        let mut build_info = ArceosBuildInfo::default();
         build_info.resolve_features("arceos-helloworld", "aarch64-unknown-none-softfloat", true);
 
         assert!(build_info.features.contains(&"ax-std/plat-dyn".to_string()));
@@ -378,7 +372,7 @@ mod tests {
 
     #[test]
     fn resolves_non_dynamic_aarch64_to_defplat_without_static_default() {
-        let mut build_info = ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat");
+        let mut build_info = ArceosBuildInfo::default();
         build_info.resolve_features("arceos-helloworld", "aarch64-unknown-none-softfloat", false);
 
         assert!(build_info.features.contains(&"ax-hal/defplat".to_string()));
@@ -400,7 +394,7 @@ mod tests {
     #[test]
     fn preparing_c_app_non_dynamic_aarch64_without_custom_platform_fails() {
         let metadata = repo_metadata();
-        let mut build_info = ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat");
+        let mut build_info = ArceosBuildInfo::default();
         let result = build_info.prepare_non_dynamic_platform_for(
             "arceos-helloworld",
             "aarch64-unknown-none-softfloat",
@@ -483,7 +477,7 @@ mod tests {
 
         let build_info = load_build_info(&request).unwrap();
 
-        assert_eq!(build_info, ArceosBuildInfo::default_for_target("target"));
+        assert_eq!(build_info, ArceosBuildInfo::default());
         assert!(path.exists());
         assert!(
             fs::read_to_string(path)
@@ -723,6 +717,58 @@ AX_IP = "10.0.2.15"
     }
 
     #[test]
+    fn load_build_info_defaults_unspecified_loongarch64_to_dynamic_platform() {
+        let root = tempdir().unwrap();
+        let path = root
+            .path()
+            .join("build-loongarch64-unknown-none-softfloat.toml");
+        fs::write(
+            &path,
+            r#"
+features = ["ax-std"]
+log = "Warn"
+
+[env]
+AX_GW = "10.0.2.2"
+AX_IP = "10.0.2.15"
+"#,
+        )
+        .unwrap();
+        let request = request(
+            "arceos-test-suit",
+            "loongarch64-unknown-none-softfloat",
+            None,
+            path,
+        );
+
+        let build_info = load_build_info(&request).unwrap();
+
+        assert!(build_info.plat_dyn);
+
+        let metadata = repo_metadata();
+        let cargo = build_info
+            .into_prepared_base_cargo_config_with_metadata(
+                &request.package,
+                &request.target,
+                request.plat_dyn,
+                &metadata,
+            )
+            .unwrap();
+
+        assert!(cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+        assert!(
+            !cargo
+                .features
+                .contains(&"ax-std/loongarch64-qemu-virt".to_string())
+        );
+        assert!(
+            cargo
+                .target
+                .ends_with("scripts/targets/std/pie/loongarch64-unknown-linux-musl.json")
+        );
+    }
+
+    #[test]
     fn parse_makefile_features_splits_commas_whitespace_and_dedups() {
         assert_eq!(
             build::parse_makefile_features(" lockdep, sched-rr  lockdep\taxfeat/net "),
@@ -758,7 +804,7 @@ AX_IP = "10.0.2.15"
         let metadata = repo_metadata();
         let cargo = ArceosBuildInfo {
             features: vec!["lockdep".to_string()],
-            ..ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat")
+            ..ArceosBuildInfo::default()
         }
         .into_prepared_base_cargo_config_with_metadata(
             "arceos-helloworld",
@@ -779,22 +825,23 @@ AX_IP = "10.0.2.15"
     #[test]
     fn c_app_cargo_config_uses_builtin_bare_target_without_json_spec() {
         let root = tempdir().unwrap();
-        let build_config = root.path().join("build-x86_64-unknown-none.toml");
+        let build_config = root
+            .path()
+            .join("build-loongarch64-unknown-none-softfloat.toml");
         let build_info = ArceosBuildInfo {
             features: vec!["ax-std".to_string()],
-            plat_dyn: true,
-            ..ArceosBuildInfo::default_for_target("x86_64-unknown-none")
+            ..ArceosBuildInfo::default()
         };
         fs::write(&build_config, toml::to_string_pretty(&build_info).unwrap()).unwrap();
         let request = request(
             "arceos-helloworld",
-            "x86_64-unknown-none",
-            Some(true),
+            "loongarch64-unknown-none-softfloat",
+            Some(false),
             build_config,
         );
         let cargo = load_c_app_cargo_config(&request).unwrap();
 
-        assert_eq!(cargo.target, "x86_64-unknown-none");
+        assert_eq!(cargo.target, "loongarch64-unknown-none-softfloat");
         assert!(!cargo.env.contains_key("CARGO_UNSTABLE_JSON_TARGET_SPEC"));
         assert!(
             cargo
@@ -817,7 +864,7 @@ AX_IP = "10.0.2.15"
         let metadata = repo_metadata();
         let cargo = ArceosBuildInfo {
             max_cpu_num: Some(4),
-            ..ArceosBuildInfo::default_for_target("aarch64-unknown-none-softfloat")
+            ..ArceosBuildInfo::default()
         }
         .into_prepared_base_cargo_config_with_metadata(
             &request.package,
@@ -834,7 +881,7 @@ AX_IP = "10.0.2.15"
     #[test]
     fn prepared_cargo_config_defaults_x86_64_to_dynamic_platform() {
         let metadata = repo_metadata();
-        let cargo = ArceosBuildInfo::default_for_target("x86_64-unknown-none")
+        let cargo = ArceosBuildInfo::default()
             .into_prepared_base_cargo_config_with_metadata(
                 "arceos-helloworld",
                 "x86_64-unknown-none",

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -262,7 +262,7 @@ impl ArceOS {
             None => None,
         };
         if let Some(qemu) = qemu.as_mut() {
-            crate::test::qemu::apply_dynamic_x86_64_qemu_boot(qemu, cargo);
+            crate::test::qemu::apply_dynamic_platform_qemu_boot(qemu, cargo);
         }
         Ok(qemu)
     }
@@ -379,7 +379,7 @@ impl ArceOS {
                 )
             })?;
         let output = self.build_c_app_request(&request, app_dir, app_name)?;
-        crate::test::qemu::apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        crate::test::qemu::apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
         ensure_qemu_runtime_assets(self.app.workspace_root(), &qemu)?;
         self.app
             .prepare_elf_artifact(output.elf_path, qemu.to_bin)

--- a/scripts/axbuild/src/arceos/rootfs.rs
+++ b/scripts/axbuild/src/arceos/rootfs.rs
@@ -52,7 +52,7 @@ pub(super) async fn qemu_with_explicit_rootfs(
         .load_qemu_config(&request, &cargo)
         .await?
         .unwrap_or_default();
-    qemu_test::apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+    qemu_test::apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
     patch_qemu_rootfs(&mut qemu, &rootfs);
     qemu_test::apply_smp_qemu_arg(&mut qemu, request.smp);
     arceos

--- a/scripts/axbuild/src/arceos/test.rs
+++ b/scripts/axbuild/src/arceos/test.rs
@@ -1436,7 +1436,7 @@ async fn build_and_run_c_test(
     );
     let output = cbuild::build_c_app(&workspace_root, &request, &input)?;
     let mut qemu = qemu_config;
-    qemu_test::apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+    qemu_test::apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
     ensure_qemu_runtime_assets(arceos.app.workspace_root(), &qemu)?;
     let _host_http_server = qemu_test::load_qemu_case_host_http_server(&test.qemu_config_path)?
         .as_ref()

--- a/scripts/axbuild/src/axvisor/board.rs
+++ b/scripts/axbuild/src/axvisor/board.rs
@@ -130,7 +130,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["fs", "ax-driver/rockchip-sdhci"]
 log = "Info"
-plat_dyn = true
 "#,
         );
         write_board(
@@ -141,7 +140,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["ept-level-4"]
 log = "Info"
-plat_dyn = true
 "#,
         );
         write_board(
@@ -152,7 +150,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "riscv64gc-unknown-none-elf"
 features = ["ept-level-4"]
 log = "Info"
-plat_dyn = true
 "#,
         );
 
@@ -172,7 +169,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["ax-driver/rockchip-soc"]
 log = "Info"
-plat_dyn = true
 "#,
         );
 

--- a/scripts/axbuild/src/axvisor/build.rs
+++ b/scripts/axbuild/src/axvisor/build.rs
@@ -56,8 +56,8 @@ impl AxvisorBoardFile {
     }
 }
 
-pub(crate) fn default_axvisor_build_info_for_target(target: &str) -> AxvisorBuildInfo {
-    let mut build_info = AxvisorBuildInfo::default_for_target(target);
+pub(crate) fn default_axvisor_build_info() -> AxvisorBuildInfo {
+    let mut build_info = AxvisorBuildInfo::default();
     build_info.features.clear();
     build_info
 }
@@ -272,8 +272,8 @@ fn reject_unsupported_nested_platform_features(
         .find(|feature| is_axvisor_plat_dyn_feature(feature))
     {
         return Err(anyhow!(
-            "Axvisor build configs must use `plat_dyn = true` instead of dynamic platform \
-             features; found `{feature}`"
+            "Axvisor build configs enable dynamic platforms by default; remove dynamic platform \
+             features from `features`; found `{feature}`"
         ));
     }
 
@@ -509,24 +509,13 @@ fn load_build_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<LoadedA
             let mut loaded = default_board
                 .config
                 .into_loaded(default_board.target.clone());
-            let content = fs::read_to_string(&default_board.path).map_err(|e| {
-                anyhow!(
-                    "failed to read Axvisor default board config {}: {e}",
-                    default_board.path.display()
-                )
-            })?;
-            crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-                &mut loaded.build_info,
-                &loaded.target,
-                &content,
-            );
             if let Some(smp) = request.smp {
                 loaded.build_info.max_cpu_num = Some(smp);
             }
             return Ok(loaded);
         }
 
-        let default_build_info = default_axvisor_build_info_for_target(&request.target);
+        let default_build_info = default_axvisor_build_info();
         fs::write(
             &request.build_info_path,
             toml::to_string_pretty(&default_build_info)?,
@@ -554,11 +543,6 @@ fn load_build_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<LoadedA
 
     if let Ok(board_config) = toml::from_str::<AxvisorBoardFile>(&content) {
         let mut loaded = board_config.into_loaded();
-        crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-            &mut loaded.build_info,
-            &loaded.target,
-            &content,
-        );
         if let Some(smp) = request.smp {
             loaded.build_info.max_cpu_num = Some(smp);
         }
@@ -566,12 +550,7 @@ fn load_build_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<LoadedA
     }
 
     toml::from_str::<AxvisorBuildInfo>(&content)
-        .map(|mut build_info| {
-            crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-                &mut build_info,
-                &request.target,
-                &content,
-            );
+        .map(|build_info| {
             let mut loaded = LoadedAxvisorBuildConfig {
                 build_info,
                 target: request.target.clone(),
@@ -692,7 +671,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["ept-level-4"]
 log = "Info"
-plat_dyn = true
 vm_configs = []
 "#,
         );
@@ -735,7 +713,6 @@ vm_configs = []
 env = {}
 features = ["fs", "ept-level-4"]
 log = "Info"
-plat_dyn = true
 "#,
         )
         .unwrap();
@@ -872,7 +849,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "x86_64-unknown-none"
 features = ["ept-level-4", "fs", "vmx"]
 log = "Info"
-plat_dyn = true
 vm_configs = []
 "#,
         );
@@ -1015,7 +991,7 @@ plat_dyn = false
     }
 
     #[test]
-    fn load_cargo_config_drops_static_platform_when_plat_dyn_is_enabled() {
+    fn load_cargo_config_drops_static_platform_when_plat_dyn_is_defaulted() {
         let root = tempdir().unwrap();
         let config_path = root.path().join(".build.toml");
         fs::write(
@@ -1024,7 +1000,6 @@ plat_dyn = false
 env = {}
 features = ["ax-hal/riscv64-sg2002", "fs"]
 log = "Info"
-plat_dyn = true
 "#,
         )
         .unwrap();
@@ -1034,7 +1009,7 @@ plat_dyn = true
             axvisor_dir: root.path().join("os/axvisor"),
             arch: "riscv64".to_string(),
             target: "riscv64gc-unknown-none-elf".to_string(),
-            plat_dyn: Some(true),
+            plat_dyn: None,
             smp: None,
             debug: false,
             build_info_path: config_path,
@@ -1064,7 +1039,6 @@ plat_dyn = true
 env = {}
 features = ["ax-driver/virtio-blk", "ept-level-4", "fs", "vmx"]
 log = "Info"
-plat_dyn = true
 "#,
         )
         .unwrap();
@@ -1095,6 +1069,42 @@ plat_dyn = true
                 .features
                 .contains(&"ax-driver/plat-static".to_string())
         );
+    }
+
+    #[test]
+    fn load_cargo_config_defaults_x86_to_dynamic_platform_when_omitted() {
+        let root = tempdir().unwrap();
+        let config_path = root.path().join(".build.toml");
+        fs::write(
+            &config_path,
+            r#"
+env = {}
+features = ["ept-level-4", "fs", "vmx"]
+log = "Info"
+"#,
+        )
+        .unwrap();
+
+        let cargo = load_cargo_config(&ResolvedAxvisorRequest {
+            package: AXVISOR_PACKAGE.to_string(),
+            axvisor_dir: root.path().join("os/axvisor"),
+            arch: "x86_64".to_string(),
+            target: "x86_64-unknown-none".to_string(),
+            plat_dyn: None,
+            smp: None,
+            debug: false,
+            build_info_path: config_path,
+            qemu_config: None,
+            uboot_config: None,
+            vmconfigs: vec![],
+        })
+        .unwrap();
+
+        assert!(cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+        assert!(cargo.features.contains(&"axvm/plat-dyn".to_string()));
+        assert!(cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
+        assert!(!cargo.features.contains(&"ax-hal/x86-qemu-q35".to_string()));
+        assert!(!cargo.features.contains(&"ax-hal/x86-pc".to_string()));
     }
 
     #[test]

--- a/scripts/axbuild/src/axvisor/config.rs
+++ b/scripts/axbuild/src/axvisor/config.rs
@@ -81,7 +81,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["fs", "ax-driver/rockchip-sdhci"]
 log = "Info"
-plat_dyn = true
 vm_configs = []
 "#,
         );
@@ -142,7 +141,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = []
 log = "Info"
-plat_dyn = true
 "#,
         );
         write_board(
@@ -153,7 +151,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = ["ax-driver/rockchip-soc"]
 log = "Info"
-plat_dyn = true
 "#,
         );
 
@@ -174,7 +171,6 @@ env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 target = "aarch64-unknown-none-softfloat"
 features = []
 log = "Info"
-plat_dyn = true
 "#,
         );
 

--- a/scripts/axbuild/src/axvisor/rootfs.rs
+++ b/scripts/axbuild/src/axvisor/rootfs.rs
@@ -69,7 +69,7 @@ pub(super) async fn load_patched_qemu_config(
         axvisor.app.workspace_root(),
         explicit_rootfs,
     )?;
-    qemu_test::apply_dynamic_x86_64_qemu_boot(&mut qemu, cargo);
+    qemu_test::apply_dynamic_platform_qemu_boot(&mut qemu, cargo);
     Ok(qemu)
 }
 

--- a/scripts/axbuild/src/axvisor/test.rs
+++ b/scripts/axbuild/src/axvisor/test.rs
@@ -619,7 +619,7 @@ impl Axvisor {
                         case.case.display_name
                     )
                 })?;
-            test_qemu::apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+            test_qemu::apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
             test_qemu::validate_grouped_qemu_commands(&qemu, &case.case, "Axvisor")?;
             prepared.push(PreparedAxvisorQemuCase { case, qemu });
         }
@@ -698,7 +698,7 @@ impl Axvisor {
         rootfs::patch_qemu_rootfs_path(&mut qemu, &prepared_assets.rootfs_path);
         qemu.args.extend(prepared_assets.extra_qemu_args.clone());
         let cargo = build::load_cargo_config(request)?;
-        test_qemu::apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        test_qemu::apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
         Ok((qemu, prepared_assets))
     }
 

--- a/scripts/axbuild/src/build.rs
+++ b/scripts/axbuild/src/build.rs
@@ -97,7 +97,10 @@ pub struct BuildInfo {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub axconfig_overrides: Vec<String>,
     /// Whether to use the dynamic platform linker flow when supported.
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(
+        default = "default_plat_dyn",
+        skip_serializing_if = "is_default_plat_dyn"
+    )]
     pub plat_dyn: bool,
 }
 
@@ -110,13 +113,6 @@ impl BuildInfo {
             .collect();
         self.features = features;
         self
-    }
-
-    pub fn default_for_target(target: &str) -> Self {
-        Self {
-            plat_dyn: defaults_to_platform_dynamic(target),
-            ..Self::default()
-        }
     }
 
     pub(crate) fn effective_plat_dyn(&self, target: &str, plat_dyn_override: Option<bool>) -> bool {
@@ -490,7 +486,7 @@ impl Default for BuildInfo {
             features: vec!["ax-std".to_string()],
             max_cpu_num: None,
             axconfig_overrides: Vec::new(),
-            plat_dyn: false,
+            plat_dyn: true,
         }
     }
 }
@@ -1173,27 +1169,6 @@ where
         .with_context(|| format!("failed to parse build info {}", path.display()))
 }
 
-pub(crate) fn apply_target_defaults_if_plat_dyn_unspecified(
-    build_info: &mut BuildInfo,
-    target: &str,
-    content: &str,
-) {
-    if build_info_declares_plat_dyn(content) {
-        return;
-    }
-
-    if target.starts_with("aarch64-") || target.starts_with("riscv64") {
-        build_info.plat_dyn = BuildInfo::default_for_target(target).plat_dyn;
-    }
-}
-
-fn build_info_declares_plat_dyn(content: &str) -> bool {
-    toml::from_str::<toml::Value>(content)
-        .ok()
-        .and_then(|value| value.as_table().cloned())
-        .is_some_and(|table| table.contains_key("plat_dyn") || table.contains_key("plat-dyn"))
-}
-
 pub(crate) fn reject_removed_std_field(path: &Path, contents: &str) -> anyhow::Result<()> {
     if let Ok(table) = toml::from_str::<toml::Table>(contents)
         && table.contains_key("std")
@@ -1222,8 +1197,12 @@ pub(crate) fn reject_arceos_app_c_field(path: &Path, contents: &str) -> anyhow::
     Ok(())
 }
 
-fn is_false(value: &bool) -> bool {
-    !*value
+fn default_plat_dyn() -> bool {
+    true
+}
+
+fn is_default_plat_dyn(value: &bool) -> bool {
+    *value
 }
 
 pub(crate) fn resolve_effective_plat_dyn(
@@ -1235,11 +1214,10 @@ pub(crate) fn resolve_effective_plat_dyn(
 }
 
 fn supports_platform_dynamic(target: &str) -> bool {
-    target.starts_with("aarch64-") || target.starts_with("riscv64") || target.starts_with("x86_64-")
-}
-
-fn defaults_to_platform_dynamic(target: &str) -> bool {
-    target.starts_with("aarch64-") || target.starts_with("riscv64") || target.starts_with("x86_64-")
+    target.starts_with("aarch64-")
+        || target.starts_with("loongarch64-")
+        || target.starts_with("riscv64")
+        || target.starts_with("x86_64-")
 }
 
 fn default_to_bin_for_target(target: &str) -> bool {
@@ -1247,7 +1225,8 @@ fn default_to_bin_for_target(target: &str) -> bool {
 }
 
 fn default_to_bin_for_target_config(target: &str, plat_dyn: bool) -> bool {
-    default_to_bin_for_target(target) || (plat_dyn && target.starts_with("x86_64-"))
+    default_to_bin_for_target(target)
+        || (plat_dyn && (target.starts_with("x86_64-") || target.starts_with("loongarch64-")))
 }
 
 fn normalize_legacy_feature_alias(feature: &str) -> String {
@@ -1994,9 +1973,13 @@ fn resolve_defconfig_path(workspace_root: &Path) -> anyhow::Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
 
     use tempfile::tempdir;
+    use walkdir::WalkDir;
 
     use super::*;
 
@@ -2178,7 +2161,6 @@ mod tests {
     fn std_build_cargo_config_builds_fake_lib_before_app() {
         let metadata = repo_metadata();
         let cargo = BuildInfo {
-            plat_dyn: true,
             features: vec!["ax-std".to_string(), "fs".to_string(), "dns".to_string()],
             ..BuildInfo::default()
         }
@@ -2262,6 +2244,125 @@ AX_IP = "10.0.2.15"
         assert!(
             err.to_string().contains("uses removed `std` field"),
             "{err:#}"
+        );
+    }
+
+    #[test]
+    fn build_info_omits_true_plat_dyn_and_serializes_false() {
+        let default = toml::to_string_pretty(&BuildInfo::default()).unwrap();
+
+        assert!(!default.contains("plat_dyn"));
+
+        let non_dynamic = BuildInfo {
+            plat_dyn: false,
+            ..BuildInfo::default()
+        };
+        let serialized = toml::to_string_pretty(&non_dynamic).unwrap();
+
+        assert!(serialized.contains("plat_dyn = false"));
+    }
+
+    fn declares_non_dynamic_platform(content: &str) -> bool {
+        toml::from_str::<toml::Table>(content)
+            .ok()
+            .and_then(|table| table.get("plat_dyn").and_then(|value| value.as_bool()))
+            == Some(false)
+    }
+
+    fn declares_static_platform(content: &str) -> bool {
+        let Ok(table) = toml::from_str::<toml::Table>(content) else {
+            return false;
+        };
+        let Some(features) = table.get("features").and_then(|value| value.as_array()) else {
+            return false;
+        };
+
+        features
+            .iter()
+            .filter_map(|feature| feature.as_str())
+            .any(is_static_platform_feature)
+    }
+
+    fn is_static_platform_feature(feature: &str) -> bool {
+        feature == "ax-driver/plat-static"
+            || ax_hal_platform_feature_name(feature, None)
+                .is_some_and(|platform| platform != "plat-dyn")
+    }
+
+    fn checked_in_build_config_roots(workspace: &Path) -> [PathBuf; 4] {
+        [
+            workspace.join("apps"),
+            workspace.join("os/StarryOS/configs/board"),
+            workspace.join("os/axvisor/configs/board"),
+            workspace.join("test-suit"),
+        ]
+    }
+
+    fn declares_default_dynamic_platform(content: &str) -> bool {
+        toml::from_str::<toml::Table>(content)
+            .ok()
+            .and_then(|table| table.get("plat_dyn").and_then(|value| value.as_bool()))
+            == Some(true)
+    }
+
+    fn checked_in_toml_files(
+        roots: impl IntoIterator<Item = PathBuf>,
+    ) -> impl Iterator<Item = PathBuf> {
+        roots.into_iter().flat_map(|root| {
+            WalkDir::new(root)
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_type().is_file())
+                .filter(|entry| {
+                    entry.path().extension().and_then(|ext| ext.to_str()) == Some("toml")
+                })
+                .map(|entry| entry.into_path())
+        })
+    }
+
+    #[test]
+    fn static_platform_configs_declare_non_dynamic_builds() {
+        let workspace = crate::context::workspace_root_path().unwrap();
+        let mut offenders = Vec::new();
+
+        for path in checked_in_toml_files(checked_in_build_config_roots(&workspace)) {
+            let content = fs::read_to_string(&path).unwrap();
+            if declares_static_platform(&content) && !declares_non_dynamic_platform(&content) {
+                offenders.push(
+                    path.strip_prefix(&workspace)
+                        .unwrap_or(&path)
+                        .display()
+                        .to_string(),
+                );
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "static platform configs must set `plat_dyn = false`: {offenders:#?}"
+        );
+    }
+
+    #[test]
+    fn checked_in_build_configs_do_not_declare_default_dynamic_builds() {
+        let workspace = crate::context::workspace_root_path().unwrap();
+        let mut offenders = Vec::new();
+
+        for path in checked_in_toml_files(checked_in_build_config_roots(&workspace)) {
+            let content = fs::read_to_string(&path).unwrap();
+            if declares_default_dynamic_platform(&content) {
+                offenders.push(
+                    path.strip_prefix(&workspace)
+                        .unwrap_or(&path)
+                        .display()
+                        .to_string(),
+                );
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "default dynamic configs should omit `plat_dyn = true`: {offenders:#?}"
         );
     }
 
@@ -2385,7 +2486,7 @@ AX_IP = "10.0.2.15"
     fn std_build_aarch64_defaults_to_dynamic_platform() {
         let metadata = repo_metadata();
         let cargo = BuildInfo {
-            ..BuildInfo::default_for_target("aarch64-unknown-none-softfloat")
+            ..BuildInfo::default()
         }
         .into_prepared_base_cargo_config_with_metadata(
             "arceos-helloworld",
@@ -2419,7 +2520,7 @@ AX_IP = "10.0.2.15"
     #[test]
     fn std_build_config_preserves_backtrace_rustflags_from_env() {
         let metadata = repo_metadata();
-        let mut info = BuildInfo::default_for_target("x86_64-unknown-none");
+        let mut info = BuildInfo::default();
         info.env.insert("DWARF".to_string(), "y".to_string());
 
         let cargo = info
@@ -2469,6 +2570,11 @@ AX_IP = "10.0.2.15"
                 "loongarch64-unknown-none-softfloat",
                 false,
                 "scripts/targets/std/loongarch64-unknown-linux-musl.json",
+            ),
+            (
+                "loongarch64-unknown-none-softfloat",
+                true,
+                "scripts/targets/std/pie/loongarch64-unknown-linux-musl.json",
             ),
         ];
 
@@ -2612,6 +2718,13 @@ AX_IP = "10.0.2.15"
                 "loongarch64",
                 64,
             ),
+            (
+                "loongarch64-unknown-linux-musl",
+                true,
+                "loongarch64-unknown-none",
+                "loongarch64",
+                64,
+            ),
         ] {
             let workspace = crate::context::workspace_root_path().unwrap();
             let std_path = workspace.join(std_target_json_path(std_target, plat_dyn));
@@ -2672,6 +2785,7 @@ AX_IP = "10.0.2.15"
             ("riscv64gc-unknown-linux-musl", false),
             ("riscv64gc-unknown-linux-musl", true),
             ("loongarch64-unknown-linux-musl", false),
+            ("loongarch64-unknown-linux-musl", true),
         ] {
             let path = crate::context::workspace_root_path()
                 .unwrap()
@@ -2701,6 +2815,7 @@ AX_IP = "10.0.2.15"
             ("riscv64gc-unknown-linux-musl", false, "_start", "-no-pie"),
             ("riscv64gc-unknown-linux-musl", true, "_head", "-pie"),
             ("loongarch64-unknown-linux-musl", false, "_start", "-no-pie"),
+            ("loongarch64-unknown-linux-musl", true, "_head", "-pie"),
         ];
 
         for (target, plat_dyn, entry, mode_arg) in cases {
@@ -2895,7 +3010,7 @@ AX_IP = "10.0.2.15"
     fn std_build_dynamic_x86_64_prepares_binary_artifact() {
         let metadata = repo_metadata();
         let cargo = BuildInfo {
-            ..BuildInfo::default_for_target("x86_64-unknown-none")
+            ..BuildInfo::default()
         }
         .into_prepared_base_cargo_config_with_metadata(
             "arceos-helloworld",
@@ -2937,7 +3052,7 @@ AX_IP = "10.0.2.15"
     #[test]
     fn x86_64_defaults_to_dynamic_platform() {
         assert!(supports_platform_dynamic("x86_64-unknown-none"));
-        assert!(BuildInfo::default_for_target("x86_64-unknown-none").plat_dyn);
+        assert!(BuildInfo::default().plat_dyn);
         assert!(resolve_effective_plat_dyn(
             "x86_64-unknown-none",
             true,
@@ -2946,6 +3061,34 @@ AX_IP = "10.0.2.15"
         assert!(default_to_bin_for_target_config(
             "x86_64-unknown-none",
             true
+        ));
+    }
+
+    #[test]
+    fn loongarch64_defaults_to_dynamic_platform_when_supported() {
+        assert!(supports_platform_dynamic(
+            "loongarch64-unknown-none-softfloat"
+        ));
+        assert!(BuildInfo::default().plat_dyn);
+        assert!(resolve_effective_plat_dyn(
+            "loongarch64-unknown-none-softfloat",
+            true,
+            None
+        ));
+        assert!(default_to_bin_for_target_config(
+            "loongarch64-unknown-none-softfloat",
+            true
+        ));
+    }
+
+    #[test]
+    fn unsupported_targets_do_not_effectively_enable_dynamic_platform() {
+        assert!(!supports_platform_dynamic("armv7-unknown-none-eabi"));
+        assert!(BuildInfo::default().plat_dyn);
+        assert!(!resolve_effective_plat_dyn(
+            "armv7-unknown-none-eabi",
+            true,
+            None
         ));
     }
 

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -369,7 +369,7 @@ fn prepare_request_explicit_config_drops_snapshot_plat_dyn() {
 package = "from-snapshot"
 arch = "riscv64"
 target = "riscv64gc-unknown-none-elf"
-plat_dyn = true
+plat_dyn = false
 smp = 4
 
 [qemu]
@@ -561,7 +561,7 @@ fn prepare_axvisor_request_prefers_cli_over_snapshot() {
 config = "os/axvisor/.build.toml"
 arch = "riscv64"
 target = "riscv64gc-unknown-none-elf"
-plat_dyn = true
+plat_dyn = false
 vmconfigs = ["tmp/snapshot-vm.toml"]
 
 [qemu]

--- a/scripts/axbuild/src/starry/app.rs
+++ b/scripts/axbuild/src/starry/app.rs
@@ -964,7 +964,7 @@ mod tests {
             case_name,
             "build-aarch64-unknown-none-softfloat.toml",
             "target = \"aarch64-unknown-none-softfloat\"\nenv = {}\nfeatures = []\nlog = \
-             \"Info\"\nplat_dyn = true\n",
+             \"Info\"\n",
         );
     }
 
@@ -1027,7 +1027,7 @@ mod tests {
             root.path(),
             "demo",
             "build-aarch64-unknown-none-softfloat.toml",
-            "env = {}\nfeatures = []\nlog = \"Info\"\nplat_dyn = true\n",
+            "env = {}\nfeatures = []\nlog = \"Info\"\n",
         );
 
         let case = resolve_board_case(root.path(), "demo", None).unwrap();
@@ -1104,7 +1104,7 @@ mod tests {
             "demo",
             "build-aarch64-unknown-none-softfloat.toml",
             "target = \"aarch64-unknown-none-softfloat\"\nenv = {}\nfeatures = []\nlog = \
-             \"Info\"\nplat_dyn = true\n",
+             \"Info\"\n",
         );
         write_case_file(
             root.path(),

--- a/scripts/axbuild/src/starry/board.rs
+++ b/scripts/axbuild/src/starry/board.rs
@@ -200,7 +200,6 @@ target = "aarch64-unknown-none-softfloat"
 env = {}
 features = ["common"]
 log = "Info"
-plat_dyn = true
 "#,
         );
         write_board(
@@ -222,7 +221,6 @@ target = "riscv64gc-unknown-none-elf"
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = ["ax-driver/serial", "ax-driver/virtio-blk"]
 log = "Warn"
-plat_dyn = true
 "#,
         );
 

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -10,8 +10,8 @@ pub use crate::build::LogLevel;
 use crate::context::{ResolvedStarryRequest, STARRY_PACKAGE, starry_arch_for_target_checked};
 
 pub(crate) fn default_starry_build_info_for_target(target: &str) -> StarryBuildInfo {
-    let mut build_info = StarryBuildInfo::default_for_target(target);
-    if build_info.plat_dyn {
+    let mut build_info = StarryBuildInfo::default();
+    if build_info.effective_plat_dyn(target, None) {
         build_info.features = Vec::new();
     } else {
         build_info.features = vec!["qemu".to_string()];
@@ -63,17 +63,12 @@ pub(crate) fn load_build_info(request: &ResolvedStarryRequest) -> anyhow::Result
         })?;
         let content = std::fs::read_to_string(&request.build_info_path)?;
         crate::build::reject_arceos_app_c_field(&request.build_info_path, &content)?;
-        let mut build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
+        let build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
             format!(
                 "failed to parse build info {}",
                 request.build_info_path.display()
             )
         })?;
-        crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-            &mut build_info,
-            &request.target,
-            &content,
-        );
         build_info
     };
 
@@ -98,17 +93,12 @@ pub(crate) fn load_cargo_config(request: &ResolvedStarryRequest) -> anyhow::Resu
         })?;
         let content = std::fs::read_to_string(&request.build_info_path)?;
         crate::build::reject_arceos_app_c_field(&request.build_info_path, &content)?;
-        let mut build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
+        let build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
             format!(
                 "failed to parse build info {}",
                 request.build_info_path.display()
             )
         })?;
-        crate::build::apply_target_defaults_if_plat_dyn_unspecified(
-            &mut build_info,
-            &request.target,
-            &content,
-        );
         build_info
     };
     crate::build::apply_makefile_features_with_metadata(

--- a/scripts/axbuild/src/starry/config.rs
+++ b/scripts/axbuild/src/starry/config.rs
@@ -156,7 +156,6 @@ target = "riscv64gc-unknown-none-elf"
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = ["ax-driver/serial", "ax-driver/virtio-blk"]
 log = "Warn"
-plat_dyn = true
 "#,
         );
         let existing_snapshot = StarryCommandSnapshot {
@@ -247,7 +246,6 @@ target = "riscv64gc-unknown-none-elf"
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 features = ["ax-driver/serial", "ax-driver/virtio-blk"]
 log = "Warn"
-plat_dyn = true
 "#,
         );
         let existing_snapshot = StarryCommandSnapshot {
@@ -305,7 +303,7 @@ plat_dyn = false
 
         let output = root.path().join("tmp/custom-starry.toml");
         fs::create_dir_all(output.parent().unwrap()).unwrap();
-        fs::write(&output, "plat_dyn = true\n").unwrap();
+        fs::write(&output, "log = \"Debug\"\n").unwrap();
 
         let board = ensure_default_build_config_for_target(
             root.path(),
@@ -315,6 +313,6 @@ plat_dyn = false
         .unwrap();
 
         assert!(board.is_none());
-        assert_eq!(fs::read_to_string(&output).unwrap(), "plat_dyn = true\n");
+        assert_eq!(fs::read_to_string(&output).unwrap(), "log = \"Debug\"\n");
     }
 }

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -105,13 +105,13 @@ pub(super) async fn load_patched_qemu_config(
         }
     };
 
-    let mode = rootfs_patch_mode(request, cargo);
+    let mode = rootfs_patch_mode(cargo);
     if let Some(rootfs) = explicit_rootfs {
         patch_qemu_rootfs_path_with_mode(&mut qemu, rootfs, mode);
     } else if apply_default_args {
         patch_qemu_rootfs(&mut qemu, request, starry.app.workspace_root(), None, mode)?;
     }
-    qemu_test::apply_dynamic_x86_64_qemu_boot(&mut qemu, cargo);
+    qemu_test::apply_dynamic_platform_qemu_boot(&mut qemu, cargo);
     qemu_test::apply_smp_qemu_arg(&mut qemu, request.smp);
 
     Ok(qemu)
@@ -283,15 +283,13 @@ pub(crate) fn patch_qemu_rootfs_path_with_mode(
     patch_rootfs(qemu, rootfs_path, mode);
 }
 
-fn rootfs_patch_mode(request: &ResolvedStarryRequest, cargo: &Cargo) -> RootfsPatchMode {
-    if request.plat_dyn == Some(true)
-        || cargo.features.iter().any(|feature| {
-            matches!(
-                feature.as_str(),
-                "plat-dyn" | "ax-feat/plat-dyn" | "ax-std/plat-dyn" | "starry-kernel/plat-dyn"
-            )
-        })
-    {
+fn rootfs_patch_mode(cargo: &Cargo) -> RootfsPatchMode {
+    if cargo.features.iter().any(|feature| {
+        matches!(
+            feature.as_str(),
+            "plat-dyn" | "ax-feat/plat-dyn" | "ax-std/plat-dyn" | "starry-kernel/plat-dyn"
+        )
+    }) {
         RootfsPatchMode::ReplaceDriveOnly
     } else {
         RootfsPatchMode::EnsureDiskBootNet

--- a/scripts/axbuild/src/starry/test.rs
+++ b/scripts/axbuild/src/starry/test.rs
@@ -683,7 +683,11 @@ impl Starry {
         )?;
         let mut request = Self::qemu_test_request(request);
         if let Some(default_board) = default_board {
-            request.plat_dyn = Some(default_board.build_info.plat_dyn);
+            request.plat_dyn = Some(
+                default_board
+                    .build_info
+                    .effective_plat_dyn(&default_board.target, None),
+            );
             request.build_info_override = Some(default_board.build_info);
         } else {
             anyhow::bail!(
@@ -936,7 +940,7 @@ impl Starry {
                     ("phase", "prepare-qemu-config".to_string()),
                 ],
             );
-            qemu_test::apply_dynamic_x86_64_qemu_boot(&mut qemu, cargo);
+            qemu_test::apply_dynamic_platform_qemu_boot(&mut qemu, cargo);
             Self::rewrite_qemu_case_managed_rootfs_paths(self.app.workspace_root(), &mut qemu)?;
             let rootfs_path =
                 Self::qemu_case_rootfs_path(self.app.workspace_root(), &qemu, default_rootfs_path)?;
@@ -1209,7 +1213,7 @@ impl Starry {
                 ("phase", "apply-dynamic-boot".to_string()),
             ],
         );
-        qemu_test::apply_dynamic_x86_64_qemu_boot(&mut qemu, cargo);
+        qemu_test::apply_dynamic_platform_qemu_boot(&mut qemu, cargo);
         timing_stage.finish();
         let timing_stage = timing::TimingStage::new(
             "qemu-case",
@@ -3732,7 +3736,7 @@ install(TARGETS test-uid-gid-re-setters RUNTIME DESTINATION usr/bin/starry-test-
     }
 
     #[test]
-    fn qemu_group_build_context_uses_group_plat_dyn_over_default_request() {
+    fn qemu_group_build_context_uses_omitted_group_plat_dyn_over_default_request() {
         let root = tempdir().unwrap();
         let build_config = root
             .path()
@@ -3741,7 +3745,7 @@ install(TARGETS test-uid-gid-re-setters RUNTIME DESTINATION usr/bin/starry-test-
         fs::write(
             &build_config,
             "target = \"aarch64-unknown-none-softfloat\"\nenv = {}\nfeatures = [\"qemu\"]\nlog = \
-             \"Warn\"\nplat_dyn = true\n",
+             \"Warn\"\n",
         )
         .unwrap();
         let mut request = starry_request(

--- a/scripts/axbuild/src/test/qemu.rs
+++ b/scripts/axbuild/src/test/qemu.rs
@@ -991,19 +991,30 @@ pub(crate) fn apply_smp_qemu_arg(qemu: &mut QemuConfig, smp: Option<usize>) {
     QemuArgsMut::new(&mut qemu.args).set_option_value("-smp", cpu_num.to_string());
 }
 
-pub(crate) fn apply_dynamic_x86_64_qemu_boot(qemu: &mut QemuConfig, cargo: &Cargo) {
-    if !cargo_uses_dynamic_x86_64_platform(cargo) {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DynamicPlatformBootArch {
+    X86_64,
+    LoongArch64,
+}
+
+pub(crate) fn apply_dynamic_platform_qemu_boot(qemu: &mut QemuConfig, cargo: &Cargo) {
+    let Some(arch) = cargo_dynamic_platform_boot_arch(cargo) else {
         return;
-    }
+    };
 
     qemu.uefi = true;
     qemu.to_bin = true;
+    apply_drive_snapshot_without_global_snapshot(qemu);
+
+    if arch != DynamicPlatformBootArch::X86_64 {
+        return;
+    }
+
     ensure_uefi_drive_bus(qemu);
     keep_qemu_default_devices_for_uefi(qemu);
     disable_unneeded_default_x86_64_devices(qemu);
     disable_dynamic_x86_64_five_level_paging(qemu);
     enable_dynamic_x86_64_nested_virtualization_features(qemu, cargo);
-    apply_drive_snapshot_without_global_snapshot(qemu);
     apply_dynamic_x86_64_qemu_debug_args(qemu);
 }
 
@@ -1174,14 +1185,29 @@ fn ensure_drive_snapshot_on(drive: &mut String) {
     }
 }
 
-pub(crate) fn cargo_uses_dynamic_x86_64_platform(cargo: &Cargo) -> bool {
-    cargo_target_is_dynamic_x86_64(&cargo.target)
-        && cargo_dynamic_platform_features(cargo).any(dynamic_platform_feature)
+fn cargo_dynamic_platform_boot_arch(cargo: &Cargo) -> Option<DynamicPlatformBootArch> {
+    if !cargo_dynamic_platform_features(cargo).any(dynamic_platform_feature) {
+        return None;
+    }
+
+    if cargo_target_is_dynamic_x86_64(&cargo.target) {
+        Some(DynamicPlatformBootArch::X86_64)
+    } else if cargo_target_is_dynamic_loongarch64(&cargo.target) {
+        Some(DynamicPlatformBootArch::LoongArch64)
+    } else {
+        None
+    }
 }
 
 fn cargo_target_is_dynamic_x86_64(target: &str) -> bool {
     let target = target.strip_suffix(".json").unwrap_or(target);
     target.ends_with("x86_64-unknown-none") || target.ends_with("x86_64-unknown-linux-musl")
+}
+
+fn cargo_target_is_dynamic_loongarch64(target: &str) -> bool {
+    let target = target.strip_suffix(".json").unwrap_or(target);
+    target.ends_with("loongarch64-unknown-none-softfloat")
+        || target.ends_with("loongarch64-unknown-linux-musl")
 }
 
 fn dynamic_platform_feature(feature: &str) -> bool {
@@ -1572,7 +1598,7 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert!(qemu.uefi);
         assert!(qemu.to_bin);
@@ -1594,7 +1620,7 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert!(qemu.uefi);
         assert!(qemu.to_bin);
@@ -1622,7 +1648,7 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert_eq!(
             qemu.args,
@@ -1636,6 +1662,84 @@ mod tests {
                 "none",
                 "-vga",
                 "none"
+            ]
+        );
+    }
+
+    #[test]
+    fn dynamic_loongarch64_cargo_uses_uefi_bin_qemu_boot() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _debug = TempEnvVar::unset(DYNAMIC_X86_64_QEMU_DEBUG_ENV);
+        let cargo = Cargo {
+            target: "loongarch64-unknown-none-softfloat".to_string(),
+            features: vec!["dyn-plat".to_string()],
+            to_bin: true,
+            ..Default::default()
+        };
+        let mut qemu = QemuConfig {
+            uefi: false,
+            to_bin: false,
+            ..Default::default()
+        };
+
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
+
+        assert!(qemu.uefi);
+        assert!(qemu.to_bin);
+    }
+
+    #[test]
+    fn dynamic_loongarch64_std_cargo_uses_uefi_bin_qemu_boot() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _debug = TempEnvVar::unset(DYNAMIC_X86_64_QEMU_DEBUG_ENV);
+        let cargo = Cargo {
+            target: "scripts/targets/std/pie/loongarch64-unknown-linux-musl.json".to_string(),
+            features: vec!["plat-dyn".to_string()],
+            to_bin: true,
+            ..Default::default()
+        };
+        let mut qemu = QemuConfig {
+            uefi: false,
+            to_bin: false,
+            ..Default::default()
+        };
+
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
+
+        assert!(qemu.uefi);
+        assert!(qemu.to_bin);
+    }
+
+    #[test]
+    fn dynamic_loongarch64_qemu_boot_converts_global_snapshot_to_drive_snapshots() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _debug = TempEnvVar::unset(DYNAMIC_X86_64_QEMU_DEBUG_ENV);
+        let cargo = Cargo {
+            target: "scripts/targets/std/pie/loongarch64-unknown-linux-musl.json".to_string(),
+            features: vec!["plat-dyn".to_string()],
+            to_bin: true,
+            ..Default::default()
+        };
+        let mut qemu = QemuConfig {
+            args: vec![
+                "-machine".to_string(),
+                "virt".to_string(),
+                "-snapshot".to_string(),
+                "-drive".to_string(),
+                "id=disk0,format=raw,file=rootfs.img".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
+
+        assert_eq!(
+            qemu.args,
+            [
+                "-machine",
+                "virt",
+                "-drive",
+                "id=disk0,format=raw,file=rootfs.img,snapshot=on"
             ]
         );
     }
@@ -1658,7 +1762,7 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert_eq!(
             qemu.args,
@@ -1685,7 +1789,7 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert_eq!(
             qemu.args,
@@ -1713,8 +1817,8 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert_eq!(
             qemu.args,
@@ -1746,8 +1850,8 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert_eq!(
             qemu.args,
@@ -1784,7 +1888,7 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert_eq!(
             qemu.args,
@@ -1814,7 +1918,7 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert_eq!(
             qemu.args,
@@ -1847,10 +1951,34 @@ mod tests {
             ..Default::default()
         };
 
-        apply_dynamic_x86_64_qemu_boot(&mut qemu, &cargo);
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
 
         assert!(!qemu.uefi);
         assert!(!qemu.to_bin);
+    }
+
+    #[test]
+    fn non_dynamic_loongarch64_cargo_keeps_existing_qemu_boot() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _debug = TempEnvVar::set(DYNAMIC_X86_64_QEMU_DEBUG_ENV, "1");
+        let cargo = Cargo {
+            target: "scripts/targets/std/pie/loongarch64-unknown-linux-musl.json".to_string(),
+            features: vec![],
+            to_bin: false,
+            ..Default::default()
+        };
+        let mut qemu = QemuConfig {
+            uefi: false,
+            to_bin: false,
+            args: vec!["-snapshot".to_string()],
+            ..Default::default()
+        };
+
+        apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
+
+        assert!(!qemu.uefi);
+        assert!(!qemu.to_bin);
+        assert_eq!(qemu.args, ["-snapshot"]);
     }
 
     #[test]

--- a/scripts/targets/std/pie/loongarch64-unknown-linux-musl.json
+++ b/scripts/targets/std/pie/loongarch64-unknown-linux-musl.json
@@ -1,0 +1,45 @@
+{
+  "abi": "softfloat",
+  "arch": "loongarch64",
+  "code-model": "medium",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "eh-frame-header": false,
+  "env": "musl",
+  "features": "-f,-d",
+  "has-thread-local": true,
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "lp64s",
+  "llvm-target": "loongarch64-unknown-none",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": "ArceOS std LoongArch64 musl identity with kernel PIE link style",
+    "host_tools": false,
+    "std": true,
+    "tier": 2
+  },
+  "os": "linux",
+  "panic-strategy": "abort",
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gnu-lld": [
+      "-pie",
+      "--gc-sections",
+      "-znorelro",
+      "-znostart-stop-gc",
+      "-Tlinker.x",
+      "-u",
+      "_head"
+    ]
+  },
+  "relocation-model": "pic",
+  "relro-level": "off",
+  "static-position-independent-executables": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-mcount": "_mcount",
+  "target-pointer-width": 64,
+  "tls-model": "initial-exec"
+}

--- a/test-suit/arceos/c/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/c/build-aarch64-unknown-none-softfloat.toml
@@ -13,8 +13,6 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 4
-plat_dyn = true
-
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/test-suit/arceos/c/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/c/build-loongarch64-unknown-none-softfloat.toml
@@ -8,7 +8,7 @@ features = [
     "pipe",
     "epoll",
     "net",
-    "ax-driver/plat-static",
+    "ax-driver/plat-dyn",
     "ax-driver/virtio-net",
 ]
 log = "Info"

--- a/test-suit/arceos/c/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/arceos/c/build-riscv64gc-unknown-none-elf.toml
@@ -12,8 +12,6 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 4
-plat_dyn = true
-
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/test-suit/arceos/c/build-x86_64-unknown-none.toml
+++ b/test-suit/arceos/c/build-x86_64-unknown-none.toml
@@ -12,8 +12,6 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 4
-plat_dyn = true
-
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/test-suit/arceos/c/qemu-loongarch64.toml
+++ b/test-suit/arceos/c/qemu-loongarch64.toml
@@ -8,7 +8,7 @@ args = [
     "-nographic",
 ]
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["ArceOS C test suite run OK!"]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b", "ARCEOS_C_TEST_FAIL"]
 timeout = 120

--- a/test-suit/arceos/rust/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/rust/build-loongarch64-unknown-none-softfloat.toml
@@ -1,6 +1,5 @@
 features = [
-    "ax-hal/loongarch64-qemu-virt",
-    "ax-driver/plat-static",
+    "ax-driver/plat-dyn",
 ]
 log = "Info"
 max_cpu_num = 4

--- a/test-suit/arceos/rust/build-x86_64-unknown-none.toml
+++ b/test-suit/arceos/rust/build-x86_64-unknown-none.toml
@@ -1,8 +1,6 @@
 features = []
 log = "Info"
 max_cpu_num = 4
-plat_dyn = true
-
 [env]
 AX_GW = "10.0.2.2"
 AX_IP = "10.0.2.15"

--- a/test-suit/arceos/rust/qemu-loongarch64.toml
+++ b/test-suit/arceos/rust/qemu-loongarch64.toml
@@ -21,7 +21,7 @@ args = [
 
 timeout = 120
 uefi = false
-to_bin = false
+to_bin = true
 success_regex = ["ArceOS test suite run OK!"]
 fail_regex = ["(?i)\\bpanic(?:ked)?\\b", "ARCEOS_TEST_FAIL"]
 

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -5,6 +5,5 @@ features = [
   "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/orangepi-5-plus/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/board-phytiumpi/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-phytiumpi/build-aarch64-unknown-none-softfloat.toml
@@ -4,6 +4,5 @@ features = [
     "phytium-mci",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/phytiumpi/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/board-rdk-s100/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-rdk-s100/build-aarch64-unknown-none-softfloat.toml
@@ -3,6 +3,5 @@ features = [
     "ept-level-4",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/rdk-s100/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/board-roc-rk3568-pc/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-roc-rk3568-pc/build-aarch64-unknown-none-softfloat.toml
@@ -5,6 +5,5 @@ features = [
   "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/roc-rk3568-pc/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -5,6 +5,5 @@ features = [
     "fs",
 ]
 log = "Info"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"
 vm_configs = ["os/axvisor/configs/vms/qemu/aarch64/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml
@@ -1,11 +1,11 @@
 env = {AX_IP = "10.0.2.15", AX_GW = "10.0.2.2"}
 features = [
   "ax-driver/virtio-blk",
-  "ax-driver/plat-static",
   "ept-level-4",
   "fs",
 ]
 log = "Info"
 max_cpu_num = 1
+plat_dyn = false
 target = "loongarch64-unknown-none-softfloat"
 vm_configs = []

--- a/test-suit/axvisor/normal/qemu/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/axvisor/normal/qemu/build-riscv64gc-unknown-none-elf.toml
@@ -6,7 +6,6 @@ features = [
     "sstc"
 ]
 log = "Info"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"
 vm_configs = ["os/axvisor/configs/vms/qemu/riscv64/linux-smp1.toml"]
 max_cpu_num = 4

--- a/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-svm.toml
+++ b/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-svm.toml
@@ -5,6 +5,5 @@ features = [
     "svm",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/linux-svm-smp1.toml"]

--- a/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-vmx.toml
+++ b/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-vmx.toml
@@ -6,6 +6,5 @@ features = [
     "vmx",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/linux-vmx-smp1.toml"]

--- a/test-suit/axvisor/uefi/qemu-nimbos/build-x86_64-unknown-none.toml
+++ b/test-suit/axvisor/uefi/qemu-nimbos/build-x86_64-unknown-none.toml
@@ -6,6 +6,5 @@ features = [
     "vmx",
 ]
 log = "Info"
-plat_dyn = true
 target = "x86_64-unknown-none"
 vm_configs = ["os/axvisor/tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml"]

--- a/test-suit/starryos/board-licheerv-nano-sg2002/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/board-licheerv-nano-sg2002/build-riscv64gc-unknown-none-elf.toml
@@ -10,4 +10,3 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true

--- a/test-suit/starryos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -14,4 +14,3 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
-plat_dyn = true

--- a/test-suit/starryos/qemu-smp1/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu-smp1/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
   "starry-kernel/vsock",
 ]
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/test-suit/starryos/qemu-smp1/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu-smp1/build-loongarch64-unknown-none-softfloat.toml
@@ -2,13 +2,10 @@ target = "loongarch64-unknown-none-softfloat"
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 log = "Warn"
 features = [
-  "ax-hal/loongarch64-qemu-virt",
-  "qemu",
-  "ax-driver/plat-static",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
   "ax-driver/virtio-gpu",
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
+  "starry-kernel/input",
 ]
-plat_dyn = false

--- a/test-suit/starryos/qemu-smp1/build-x86_64-unknown-none.toml
+++ b/test-suit/starryos/qemu-smp1/build-x86_64-unknown-none.toml
@@ -10,4 +10,3 @@ features = [
   "ax-driver/xhci-pci",
   "starry-kernel/input",
 ]
-plat_dyn = true

--- a/test-suit/starryos/qemu-smp4/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu-smp4/build-aarch64-unknown-none-softfloat.toml
@@ -12,5 +12,4 @@ features = [
 ]
 max_cpu_num = 4
 log = "Warn"
-plat_dyn = true
 target = "aarch64-unknown-none-softfloat"

--- a/test-suit/starryos/qemu-smp4/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu-smp4/build-loongarch64-unknown-none-softfloat.toml
@@ -2,14 +2,11 @@ target = "loongarch64-unknown-none-softfloat"
 env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
 log = "Warn"
 features = [
-  "ax-hal/loongarch64-qemu-virt",
-  "qemu",
-  "ax-driver/plat-static",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
   "ax-driver/virtio-gpu",
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
+  "starry-kernel/input",
 ]
-plat_dyn = false
 max_cpu_num = 4

--- a/test-suit/starryos/qemu-smp4/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/qemu-smp4/build-riscv64gc-unknown-none-elf.toml
@@ -10,5 +10,4 @@ features = [
 ]
 max_cpu_num = 4
 log = "Warn"
-plat_dyn = true
 target = "riscv64gc-unknown-none-elf"

--- a/test-suit/starryos/qemu-smp4/build-x86_64-unknown-none.toml
+++ b/test-suit/starryos/qemu-smp4/build-x86_64-unknown-none.toml
@@ -9,5 +9,4 @@ features = [
   "ax-driver/virtio-socket",
   "starry-kernel/input",
 ]
-plat_dyn = true
 max_cpu_num = 4


### PR DESCRIPTION
## 背景

LoongArch 的 ArceOS/StarryOS 动态 UEFI 平台支持需要和现有静态平台、Axvisor LVZ 静态启动路径共存。Axvisor LoongArch 动态 UEFI handoff 仍作为后续独立任务处理，本次保留 Axvisor LoongArch QEMU 默认静态平台验证路径，同时继续推进 ArceOS/StarryOS 的 LoongArch 动态平台基础能力。

## 改动

- 增加 LoongArch 动态平台构建、someboot UEFI/SMP 启动、somehal/axplat-dyn/axbuild 相关支持。
- 将 ArceOS/StarryOS 的 LoongArch QEMU 用例切到动态 UEFI 平台，并补齐 target/config/rootfs/QEMU 处理。
- 保留 Axvisor LoongArch QEMU 静态平台：board 和 test-suit 配置均显式 `plat_dyn = false`，继续走 `ax-hal/loongarch64-qemu-virt`、非 UEFI QEMU `-kernel` ELF 启动。
- 整理 dynamic platform 默认配置表达：默认 dynamic 的配置省略 `plat_dyn = true`，静态平台配置必须显式 `plat_dyn = false`。
- 补充 LoongArch 用户态 trap 恢复、VirtIO PCI command enable、早期 per-CPU slab 初始化和 Starry 动态平台 console size probe 保护等运行时修复。
- 补充 `arch-platform-porting` 项目技能和启动调试参考，记录架构/平台迁移、someboot 启动顺序、SMP、QEMU 调试和 Axvisor LoongArch 当前策略。

## 方案逻辑

动态平台默认能力放在 axbuild/axplat-dyn/someboot/somehal 层统一处理；各系统用 build/qemu 配置选择是否走动态 UEFI。ArceOS/StarryOS LoongArch 继续验证动态平台路径；Axvisor LoongArch 本次仍以 LVZ/静态平台作为默认可验证路径，后续动态 UEFI handoff 另开任务排查。

提交历史已按 review 边界整理为平台运行时、someboot 启动、axcpu trap、axbuild/config、Axvisor 静态保护、通用修复、Starry console 修复和项目技能文档几层，便于逐层审查。

## 本地验证

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p axbuild --lib`，622 passed
- `cargo xtask clippy --package axbuild`
- `cargo xtask axvisor test qemu --list --arch loongarch64`，发现 `normal/smoke`
- `docker run --rm -v "$PWD:/workspace" -v /tmp/.tgos-images:/tmp/.tgos-images -w /workspace ghcr.io/rcore-os/tgoskits-container-axvisor-lvz:latest bash -lc 'cargo xtask axvisor test qemu --arch loongarch64 --test-group normal --test-case smoke'`，PASS；日志确认 `AX_PLATFORM=loongarch64-qemu-virt`，features 使用 `ax-hal/loongarch64-qemu-virt`，QEMU 使用 `-kernel .../release/axvisor`。