### PR TITLE
fix(loongarch64): ack timer irq before dispatch

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -90,7 +90,8 @@ Adjust the package list to match the crates touched.
 3. Use QEMU debug flags such as `-d int,cpu_reset,guest_errors` and `-S -s` when xtask exposes or can be patched to pass them.
 4. Inspect symbols and generated images with `llvm-objdump`, `readelf`, and map files. Confirm runtime addresses, not only link addresses.
 5. Compare with local Linux architecture code for ordering of MMU, trap, SMP, and cache/TLB barriers when uncertain. First search for a local Linux source tree, then inspect the matching `arch/<linux-arch>` directory; do not assume a fixed path.
-6. Turn the root cause into a regression test or a focused QEMU case when practical.
+6. On one-shot timer platforms, verify the IRQ handler acknowledges the current timer interrupt before dispatching into code that reprograms the next event. In particular, LoongArch timer handlers must not clear `TICLR` after `_handle_irq()` / `dispatch_irq()`, because the timer tick path may already have armed a near-deadline event and a late acknowledge can clear the freshly-pending interrupt, leaving timer-based sleeps stuck.
+7. Turn the root cause into a regression test or a focused QEMU case when practical.
 
 ## Common Failure Signals
 

--- a/platforms/ax-plat-loongarch64-qemu-virt/src/irq.rs
+++ b/platforms/ax-plat-loongarch64-qemu-virt/src/irq.rs
@@ -121,34 +121,40 @@ impl IrqIf for IrqIfImpl {
 
         trace!("IRQ {irq:?}");
 
-        if let IrqType::Ipi = irq {
-            let mut status = iocsr_read_w(IOCSR_IPI_STATUS);
-            if status != 0 {
-                iocsr_write_w(IOCSR_IPI_CLEAR, status);
-                trace!("IPI status = {:#x}", status);
+        match irq {
+            IrqType::Timer => {
+                // Clear the interrupt before dispatching. The timer handler
+                // programs the next one-shot event; clearing afterwards can
+                // drop a freshly-pending event and leave sleepers blocked.
+                ticlr::clear_timer_interrupt();
+                if !dispatch_irq(irq.as_usize()).handled {
+                    debug!("Unhandled IRQ {irq:?}");
+                }
+            }
+            IrqType::Ipi => {
+                let mut status = iocsr_read_w(IOCSR_IPI_STATUS);
+                if status != 0 {
+                    iocsr_write_w(IOCSR_IPI_CLEAR, status);
+                    trace!("IPI status = {:#x}", status);
 
-                while status != 0 {
-                    let vector = status.trailing_zeros() as usize;
-                    status &= !(1 << vector);
-                    if !dispatch_irq(irq.as_usize()).handled {
-                        warn!("Unhandled IRQ {irq:?}");
+                    while status != 0 {
+                        let vector = status.trailing_zeros() as usize;
+                        status &= !(1 << vector);
+                        if !dispatch_irq(irq.as_usize()).handled {
+                            warn!("Unhandled IRQ {irq:?}");
+                        }
                     }
                 }
             }
-        } else {
-            if !dispatch_irq(irq.as_usize()).handled {
-                debug!("Unhandled IRQ {irq:?}");
+            IrqType::Io | IrqType::Ex(_) => {
+                if !dispatch_irq(irq.as_usize()).handled {
+                    debug!("Unhandled IRQ {irq:?}");
+                }
             }
         }
 
-        match irq {
-            IrqType::Timer => {
-                ticlr::clear_timer_interrupt();
-            }
-            IrqType::Ex(irq) => {
-                eiointc::complete_irq(irq);
-            }
-            _ => {}
+        if let IrqType::Ex(irq) = irq {
+            eiointc::complete_irq(irq);
         }
 
         Some(irq.as_usize())

--- a/platforms/somehal/src/arch/loongarch64/mod.rs
+++ b/platforms/somehal/src/arch/loongarch64/mod.rs
@@ -80,8 +80,12 @@ impl PlatOp for Plat {
         let irq = match raw {
             raw if raw == someboot::irq::systimer_irq().raw() => {
                 let irq = someboot::irq::IrqId::new(raw);
-                _handle_irq(raw.into());
+                // Clear the current timer interrupt before dispatching. The
+                // dispatch path reprograms the next one-shot timer; clearing
+                // afterwards can drop a newly-arrived timer edge and strand
+                // timer-based sleeps.
                 someboot::timer::ack();
+                _handle_irq(raw.into());
                 irq
             }
             IPI_IRQ => {


### PR DESCRIPTION
## 问题

`starry test qemu --arch loongarch64` 在 CI 中概率性超时，最近失败点出现在 signal 相关 system tests 中，例如 `test-pidfd-send-signal` 和 `test-rt_sigpending`。继续对比日志后发现，卡住点并不固定在某个 signal syscall，而是共同发生在 signal 操作后进入 `usleep` / `nanosleep` 等 timer-based sleep 后不再被唤醒。

## 修改

- 调整动态 LoongArch 平台的 timer IRQ 处理顺序：先 acknowledge 当前 timer interrupt，再进入 `_handle_irq()`。
- 同步调整静态 `ax-plat-loongarch64-qemu-virt` 的 timer IRQ 处理顺序：先清 `TICLR`，再 dispatch timer IRQ。
- 在架构移植调试 skill 中补充 one-shot timer IRQ ACK 顺序排查规则。

## 逻辑

LoongArch timer 当前作为 one-shot timer 使用。timer IRQ dispatch 路径会重新 arm 下一次 timer event。如果在 dispatch 之后才清 `TICLR`，当下一次 near-deadline event 已经变为 pending 时，这个 late acknowledge 可能把新事件也清掉，导致等待 timer 的任务无法再被唤醒，从而表现为概率性 hang。

因此 timer IRQ 需要先清掉本次 interrupt，再进入会重新编程下一次 one-shot timer 的 dispatch 路径。这样不会把 dispatch 期间新 arm 出来的 pending timer event 清掉。

## 验证

- `cargo fmt --all -- --check`
- `cargo xtask clippy --package somehal`
- `cargo xtask clippy --package ax-plat-loongarch64-qemu-virt`
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/syscall-test-rt_sigpending`，顺序压力 5 次通过
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/syscall-test-pidfd-send-signal`，顺序压力 5 次通过
- `cargo xtask starry test qemu --arch loongarch64`，`qemu-smp1/system` 和 `qemu-smp4/system` 均通过
