### PR TITLE
fix(starry-kernel): align membarrier commands with Linux UAPI

### DIFF
--- a/os/StarryOS/kernel/src/syscall/sync/membarrier.rs
+++ b/os/StarryOS/kernel/src/syscall/sync/membarrier.rs
@@ -2,26 +2,30 @@ use core::sync::atomic::{Ordering, fence};
 
 use ax_errno::{AxError, AxResult};
 use ax_task::current;
+use linux_raw_sys::general::membarrier_cmd;
 
 use crate::task::AsThread;
 
 /// Memory barrier commands
-const MEMBARRIER_CMD_QUERY: i32 = 0;
-const MEMBARRIER_CMD_GLOBAL: i32 = 1;
-const MEMBARRIER_CMD_GLOBAL_EXPEDITED: i32 = 2;
-const MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED: i32 = 3;
-const MEMBARRIER_CMD_PRIVATE_EXPEDITED: i32 = 4;
-const MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED: i32 = 5;
+const MEMBARRIER_CMD_QUERY: i32 = membarrier_cmd::MEMBARRIER_CMD_QUERY as i32;
+const MEMBARRIER_CMD_GLOBAL: i32 = membarrier_cmd::MEMBARRIER_CMD_GLOBAL as i32;
+const MEMBARRIER_CMD_GLOBAL_EXPEDITED: i32 = membarrier_cmd::MEMBARRIER_CMD_GLOBAL_EXPEDITED as i32;
+const MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED: i32 =
+    membarrier_cmd::MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED as i32;
+const MEMBARRIER_CMD_PRIVATE_EXPEDITED: i32 =
+    membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED as i32;
+const MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED: i32 =
+    membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED as i32;
 
-const MEMBARRIER_STATE_PRIVATE_EXPEDITED: u32 = 1 << 0;
-const MEMBARRIER_STATE_GLOBAL_EXPEDITED: u32 = 1 << 1;
+const MEMBARRIER_STATE_PRIVATE_EXPEDITED: u32 = MEMBARRIER_CMD_PRIVATE_EXPEDITED as u32;
+const MEMBARRIER_STATE_GLOBAL_EXPEDITED: u32 = MEMBARRIER_CMD_GLOBAL_EXPEDITED as u32;
 
 /// Supported command flags for query
-const SUPPORTED_COMMANDS: i32 = (1 << MEMBARRIER_CMD_GLOBAL)
-    | (1 << MEMBARRIER_CMD_GLOBAL_EXPEDITED)
-    | (1 << MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED)
-    | (1 << MEMBARRIER_CMD_PRIVATE_EXPEDITED)
-    | (1 << MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED);
+const SUPPORTED_COMMANDS: i32 = MEMBARRIER_CMD_GLOBAL
+    | MEMBARRIER_CMD_GLOBAL_EXPEDITED
+    | MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED
+    | MEMBARRIER_CMD_PRIVATE_EXPEDITED
+    | MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED;
 
 fn smp_mb() {
     fence(Ordering::SeqCst);
@@ -46,6 +50,10 @@ pub fn sys_membarrier(cmd: i32, flags: u32, _cpu_id: i32) -> AxResult<isize> {
             Ok(0)
         }
         MEMBARRIER_CMD_GLOBAL_EXPEDITED => {
+            let proc_data = current().as_thread().proc_data.clone();
+            if proc_data.membarrier_state() & MEMBARRIER_STATE_GLOBAL_EXPEDITED == 0 {
+                return Err(AxError::OperationNotPermitted);
+            }
             smp_mb();
             Ok(0)
         }

--- a/test-suit/starryos/qemu-smp1/system/test-membarrier/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-membarrier/src/main.c
@@ -12,13 +12,13 @@ int __fail = 0;
 int __skip = 0;
 int __observe = 0;
 
-/* membarrier command constants matching the StarryOS implementation */
+/* membarrier command constants from Linux UAPI */
 #define MEMBARRIER_CMD_QUERY                     0
-#define MEMBARRIER_CMD_GLOBAL                    1
-#define MEMBARRIER_CMD_GLOBAL_EXPEDITED          2
-#define MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED 3
-#define MEMBARRIER_CMD_PRIVATE_EXPEDITED         4
-#define MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED 5
+#define MEMBARRIER_CMD_GLOBAL                    (1 << 0)
+#define MEMBARRIER_CMD_GLOBAL_EXPEDITED          (1 << 1)
+#define MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED (1 << 2)
+#define MEMBARRIER_CMD_PRIVATE_EXPEDITED         (1 << 3)
+#define MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED (1 << 4)
 
 /* These are NOT supported by current StarryOS impl */
 #define MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE     32
@@ -27,12 +27,11 @@ int __observe = 0;
 #define MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ 256
 
 /*
- * Expected SUPPORTED_COMMANDS bitmask from the StarryOS implementation:
- * (1 << GLOBAL) | (1 << GLOBAL_EXPEDITED) |
- * (1 << REGISTER_GLOBAL_EXPEDITED) | (1 << PRIVATE_EXPEDITED) |
- * (1 << REGISTER_PRIVATE_EXPEDITED) = 0b111110 = 62
+ * Expected SUPPORTED_COMMANDS bitmask from Linux UAPI command values:
+ * GLOBAL | GLOBAL_EXPEDITED | REGISTER_GLOBAL_EXPEDITED |
+ * PRIVATE_EXPEDITED | REGISTER_PRIVATE_EXPEDITED = 0b11111 = 31
  */
-#define EXPECTED_SUPPORTED_MASK 62
+#define EXPECTED_SUPPORTED_MASK 31
 
 static int membarrier(int cmd, unsigned flags, int cpu_id)
 {
@@ -44,9 +43,9 @@ static bool query_advertises(int cmd)
     long ret = membarrier(MEMBARRIER_CMD_QUERY, 0, 0);
     if (ret < 0)
         return false;
-    if (cmd < 0 || cmd >= (int)(8 * sizeof(long)))
+    if (cmd <= 0 || (cmd & (cmd - 1)) != 0)
         return false;
-    return (ret & (1L << cmd)) != 0;
+    return (ret & cmd) != 0;
 }
 
 static void part_01_query(void)
@@ -56,31 +55,29 @@ static void part_01_query(void)
     if (ret < 0)
         return;
 
-    CHECK((ret & (1 << MEMBARRIER_CMD_QUERY)) == 0,
+    CHECK((ret & MEMBARRIER_CMD_QUERY) == 0,
           "QUERY does not include QUERY bit itself");
 
-    CHECK((ret & (1 << MEMBARRIER_CMD_GLOBAL)) != 0,
-          "QUERY advertises GLOBAL (bit 1)");
+    CHECK((ret & MEMBARRIER_CMD_GLOBAL) != 0,
+          "QUERY advertises GLOBAL");
 
-    CHECK((ret & (1 << MEMBARRIER_CMD_GLOBAL_EXPEDITED)) != 0,
-          "QUERY advertises GLOBAL_EXPEDITED (bit 2)");
+    CHECK((ret & MEMBARRIER_CMD_GLOBAL_EXPEDITED) != 0,
+          "QUERY advertises GLOBAL_EXPEDITED");
 
-    CHECK((ret & (1 << MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED)) != 0,
-          "QUERY advertises REGISTER_GLOBAL_EXPEDITED (bit 3)");
+    CHECK((ret & MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED) != 0,
+          "QUERY advertises REGISTER_GLOBAL_EXPEDITED");
 
-    CHECK((ret & (1 << MEMBARRIER_CMD_PRIVATE_EXPEDITED)) != 0,
-          "QUERY advertises PRIVATE_EXPEDITED (bit 4)");
+    CHECK((ret & MEMBARRIER_CMD_PRIVATE_EXPEDITED) != 0,
+          "QUERY advertises PRIVATE_EXPEDITED");
 
-    CHECK((ret & (1 << MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED)) != 0,
-          "QUERY advertises REGISTER_PRIVATE_EXPEDITED (bit 5)");
+    CHECK((ret & MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED) != 0,
+          "QUERY advertises REGISTER_PRIVATE_EXPEDITED");
 
     CHECK(ret == EXPECTED_SUPPORTED_MASK,
-          "QUERY returns exact expected bitmask (62)");
+          "QUERY returns exact expected bitmask (31)");
 
-    CHECK((ret & (1UL << MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE)) == 0,
+    CHECK((ret & MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE) == 0,
           "QUERY does NOT advertise PRIVATE_EXPEDITED_SYNC_CORE (not implemented)");
-    /* RSEQ=128 cannot be tested with bit shift on 64-bit long;
-     * the return value is a 64-bit mask and RSEQ is beyond its range anyway. */
 }
 
 static void part_02_flags_are_rejected(void)
@@ -112,6 +109,8 @@ static void part_03_global_commands(void)
 {
     CHECK_RET(membarrier(MEMBARRIER_CMD_GLOBAL, 0, 0), 0,
               "GLOBAL with flags=0 returns 0");
+    CHECK_ERR(membarrier(MEMBARRIER_CMD_GLOBAL_EXPEDITED, 0, 0), EPERM,
+              "GLOBAL_EXPEDITED before registration returns EPERM");
     CHECK_RET(membarrier(MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED, 0, 0), 0,
               "REGISTER_GLOBAL_EXPEDITED succeeds");
     CHECK_RET(membarrier(MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED, 0, 0), 0,


### PR DESCRIPTION
# fix(starry-kernel): align membarrier commands with Linux UAPI

## 问题

StarryOS 当前的 `membarrier` 命令号实现使用了连续整数 `0..5`，并在 `QUERY` 返回值中使用 `1 << cmd` 生成支持掩码。这和 Linux UAPI 不一致。

Linux 的 `membarrier_cmd` 除了 `QUERY = 0` 之外，其余命令本身就是 bitmask：

- `GLOBAL = 1 << 0`
- `GLOBAL_EXPEDITED = 1 << 1`
- `REGISTER_GLOBAL_EXPEDITED = 1 << 2`
- `PRIVATE_EXPEDITED = 1 << 3`
- `REGISTER_PRIVATE_EXPEDITED = 1 << 4`

因此 StarryOS 原先返回的 `QUERY` 掩码是 `62`，而符合 Linux UAPI 的支持掩码应为 `31`。这会导致依赖 `membarrier` 查询结果的用户态程序判断错误，进而走到不符合预期的同步路径。

另外，`PRIVATE_EXPEDITED` 已经要求先执行对应的 register 命令，否则返回 `EPERM`；但 `GLOBAL_EXPEDITED` 原先没有做同样的注册状态检查，和 Linux 语义以及当前 private expedited 的实现不一致。

## 修改

本 PR 做了两部分修改：

1. 修正 StarryOS `membarrier` 命令号和查询掩码

   - 改为直接使用 `linux_raw_sys::general::membarrier_cmd` 中的 Linux UAPI 常量。
   - `SUPPORTED_COMMANDS` 直接按命令 bitmask 做 OR，不再使用 `1 << cmd`。
   - 注册状态位也改为使用对应 expedited 命令的 bitmask，避免本地自定义编号和 UAPI 语义再次偏离。

2. 补齐 `GLOBAL_EXPEDITED` 注册语义

   - `MEMBARRIER_CMD_GLOBAL_EXPEDITED` 在执行前检查 `MEMBARRIER_STATE_GLOBAL_EXPEDITED`。
   - 未注册时返回 `EPERM`。
   - 执行 `MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED` 后再调用则正常返回 `0`。

同时更新了 `test-membarrier`：

- 测试中的命令常量改为 Linux UAPI bitmask。
- `QUERY` 期望值从 `62` 改为 `31`。
- 增加 `GLOBAL_EXPEDITED` 注册前返回 `EPERM` 的覆盖。
- 保留注册后成功、重复注册幂等、unsupported command 返回 `EINVAL` 等检查。

## 修复逻辑

`membarrier(MEMBARRIER_CMD_QUERY, 0, 0)` 返回的是“支持的命令集合”，这个集合本身就是 Linux UAPI 定义的命令 bitmask。原实现把命令号当作顺序编号，再额外左移一次，会把支持集合整体错位。

修复后，内核和测试都以 Linux UAPI 为唯一来源，避免 StarryOS 内部常量和用户态 libc / raw syscall 使用的常量不一致。

`GLOBAL_EXPEDITED` 的注册检查和 `PRIVATE_EXPEDITED` 保持一致：先注册 capability，再允许执行 expedited barrier。这样可以防止未注册状态下直接走 expedited 命令，也让测试能覆盖该语义。

## 验证

已在本地 Docker 环境中验证：

```sh
cargo fmt
cargo xtask clippy --package starry-kernel
cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/test-membarrier
```

结果：

- `starry-kernel` clippy：14/14 checks passed
- `test-membarrier`：39 pass, 0 fail
- `cargo xtask starry test qemu ...`：all starry qemu tests passed
