### PR TITLE
fix(axbuild): improve qemu and rootfs robustness on macOS

### DIFF
--- a/scripts/axbuild/src/arceos/build.rs
+++ b/scripts/axbuild/src/arceos/build.rs
@@ -217,6 +217,7 @@ pub(crate) fn load_arceos_build_config(path: &Path) -> anyhow::Result<ArceosBuil
 }
 
 pub(crate) fn load_arceos_build_mode(path: &Path) -> anyhow::Result<ArceosBuildMode> {
+    build::ensure_build_info(path, ArceosBuildConfig::default_config)?;
     let config = load_arceos_build_config(path)?;
     match config.app_c {
         Some(app_c) => resolve_app_c_mode(path, &app_c),

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeSet,
+    fs::File,
     path::{Path, PathBuf},
     process::Command as StdCommand,
 };
@@ -22,7 +23,7 @@ pub(super) fn ensure_qemu_runtime_assets(
     qemu: &QemuConfig,
 ) -> anyhow::Result<()> {
     let mut seen = BTreeSet::new();
-    for image in qemu_runtime_disk_images(qemu) {
+    for image in qemu_runtime_disk_images(workspace_root, qemu) {
         if !seen.insert(image.clone()) {
             continue;
         }
@@ -57,20 +58,92 @@ fn ensure_fat32_image(image: &Path, size: &str, recreate: bool) -> anyhow::Resul
             .then_some(())
             .ok_or_else(|| anyhow::anyhow!("`{name}` exited with non-zero status"))
     };
-    ran(StdCommand::new("truncate").args(["-s", size]).arg(image))?;
-    ran(StdCommand::new("mkfs.fat")
-        .args(["-F", "32"])
-        .arg(image)
-        .stdout(std::process::Stdio::null()))?;
+
+    if command_exists("truncate") {
+        ran(StdCommand::new("truncate").args(["-s", size]).arg(image))?;
+    } else {
+        let bytes = parse_size_to_bytes(size)?;
+        let file = File::create(image)
+            .with_context(|| format!("failed to create runtime image {}", image.display()))?;
+        file.set_len(bytes)
+            .with_context(|| format!("failed to resize runtime image {}", image.display()))?;
+    }
+
+    if command_exists("mkfs.fat") {
+        ran(StdCommand::new("mkfs.fat")
+            .args(["-F", "32"])
+            .arg(image)
+            .stdout(std::process::Stdio::null()))?;
+    } else {
+        warn!(
+            "`mkfs.fat` not found in PATH; runtime disk image {} will be an unformatted raw file",
+            image.display()
+        );
+    }
+
     println!("{msg} ... done");
     Ok(())
 }
 
-fn qemu_runtime_disk_images(qemu: &QemuConfig) -> Vec<PathBuf> {
+fn parse_size_to_bytes(size: &str) -> anyhow::Result<u64> {
+    let trimmed = size.trim();
+    let number = trimmed
+        .trim_end_matches(|c: char| c.is_ascii_alphabetic())
+        .trim();
+    let value: u64 = number
+        .parse()
+        .with_context(|| format!("invalid disk image size `{size}`"))?;
+
+    let suffix = trimmed[number.len()..].trim().to_ascii_lowercase();
+    let unit = match suffix.as_str() {
+        "" | "b" => 1,
+        "k" | "kb" => 1024,
+        "m" | "mb" => 1024 * 1024,
+        "g" | "gb" => 1024 * 1024 * 1024,
+        _ => {
+            anyhow::bail!("unsupported disk image size suffix `{suffix}` in `{size}`");
+        }
+    };
+
+    value
+        .checked_mul(unit)
+        .with_context(|| format!("disk image size `{size}` is too large"))
+}
+
+fn command_exists(command: &str) -> bool {
+    let command_name = format!("{command}{}", std::env::consts::EXE_SUFFIX);
+    std::env::var_os("PATH")
+        .map(|path| {
+            std::env::split_paths(&path).any(|dir| {
+                let candidate = dir.join(&command_name);
+                candidate.is_file()
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn qemu_runtime_disk_images(workspace_root: &Path, qemu: &QemuConfig) -> Vec<PathBuf> {
     crate::rootfs::qemu::drive_file_paths(qemu)
         .into_iter()
+        .map(|path| expand_workspace_path(workspace_root, &path))
         .filter(|path| path.file_name().and_then(|name| name.to_str()) == Some("disk.img"))
         .collect()
+}
+
+fn expand_workspace_path(workspace_root: &Path, path: &Path) -> PathBuf {
+    let Some(raw) = path.to_str() else {
+        return path.to_path_buf();
+    };
+
+    if raw == "${workspace}" {
+        return workspace_root.to_path_buf();
+    }
+
+    if let Some(relative) = raw.strip_prefix("${workspace}/") {
+        return workspace_root.join(relative);
+    }
+
+    path.to_path_buf()
 }
 
 fn should_recreate_runtime_image(workspace_root: &Path, image: &Path) -> bool {
@@ -259,7 +332,20 @@ impl ArceOS {
                 .read_qemu_config_from_path_for_cargo(cargo, path)
                 .await
                 .map(Some)?,
-            None => None,
+            None => {
+                let default_path = self
+                    .app
+                    .workspace_member_dir(&request.package)?
+                    .join(format!("qemu-{}.toml", request.arch));
+                if default_path.exists() {
+                    self.app
+                        .read_qemu_config_from_path_for_cargo(cargo, &default_path)
+                        .await
+                        .map(Some)?
+                } else {
+                    None
+                }
+            }
         };
         if let Some(qemu) = qemu.as_mut() {
             crate::test::qemu::apply_dynamic_platform_qemu_boot(qemu, cargo);
@@ -436,6 +522,7 @@ mod tests {
 
     #[test]
     fn qemu_runtime_disk_images_finds_disk_img_drive_paths() {
+        let workspace = Path::new("/workspace");
         let qemu = QemuConfig {
             args: vec![
                 "-drive".to_string(),
@@ -447,8 +534,29 @@ mod tests {
         };
 
         assert_eq!(
-            qemu_runtime_disk_images(&qemu),
+            qemu_runtime_disk_images(workspace, &qemu),
             vec![PathBuf::from("/tmp/case/disk.img")]
+        );
+    }
+
+    #[test]
+    fn qemu_runtime_disk_images_expands_workspace_placeholder() {
+        let workspace = Path::new("/workspace");
+        let qemu = QemuConfig {
+            args: vec![
+                "-drive".to_string(),
+                "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/apps/\
+                 arceos/helloworld/disk.img"
+                    .to_string(),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            qemu_runtime_disk_images(workspace, &qemu),
+            vec![PathBuf::from(
+                "/workspace/tmp/axbuild/runtime-assets/apps/arceos/helloworld/disk.img"
+            )]
         );
     }
 

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -155,12 +155,19 @@ pub mod cbuild;
 pub mod rootfs;
 pub mod test;
 
+pub(super) struct LoadedQemuConfig {
+    config: Option<QemuConfig>,
+    config_path: Option<PathBuf>,
+}
+
 fn start_qemu_host_http_server(
     request: &ResolvedBuildRequest,
+    qemu_config_path: Option<&Path>,
 ) -> anyhow::Result<Option<HostHttpServerGuard>> {
     request
         .qemu_config
         .as_deref()
+        .or(qemu_config_path)
         .map(crate::test::qemu::load_qemu_case_host_http_server)
         .transpose()?
         .flatten()
@@ -325,32 +332,41 @@ impl ArceOS {
         &mut self,
         request: &ResolvedBuildRequest,
         cargo: &Cargo,
-    ) -> anyhow::Result<Option<ostool::run::qemu::QemuConfig>> {
-        let mut qemu = match request.qemu_config.as_deref() {
-            Some(path) => self
-                .app
-                .read_qemu_config_from_path_for_cargo(cargo, path)
-                .await
-                .map(Some)?,
+    ) -> anyhow::Result<LoadedQemuConfig> {
+        let (mut qemu, config_path) = match request.qemu_config.as_deref() {
+            Some(path) => (
+                self.app
+                    .read_qemu_config_from_path_for_cargo(cargo, path)
+                    .await
+                    .map(Some)?,
+                Some(path.to_path_buf()),
+            ),
             None => {
                 let default_path = self
                     .app
                     .workspace_member_dir(&request.package)?
                     .join(format!("qemu-{}.toml", request.arch));
                 if default_path.exists() {
-                    self.app
-                        .read_qemu_config_from_path_for_cargo(cargo, &default_path)
-                        .await
-                        .map(Some)?
+                    (
+                        self.app
+                            .read_qemu_config_from_path_for_cargo(cargo, &default_path)
+                            .await
+                            .map(Some)?,
+                        Some(default_path),
+                    )
                 } else {
-                    None
+                    (None, None)
                 }
             }
         };
         if let Some(qemu) = qemu.as_mut() {
             crate::test::qemu::apply_dynamic_platform_qemu_boot(qemu, cargo);
         }
-        Ok(qemu)
+
+        Ok(LoadedQemuConfig {
+            config: qemu,
+            config_path,
+        })
     }
 
     async fn load_uboot_config(
@@ -387,12 +403,15 @@ impl ArceOS {
         cargo: Cargo,
     ) -> anyhow::Result<()> {
         self.app.set_debug_mode(request.debug)?;
-        let qemu = self.load_qemu_config(&request, &cargo).await?;
-        if let Some(qemu) = qemu.as_ref() {
+        let loaded_qemu = self.load_qemu_config(&request, &cargo).await?;
+        if let Some(qemu) = loaded_qemu.config.as_ref() {
             ensure_qemu_runtime_assets(self.app.workspace_root(), qemu)?;
         }
-        let _host_http_server = start_qemu_host_http_server(&request)?;
-        self.app.qemu(cargo, request.build_info_path, qemu).await
+        let _host_http_server =
+            start_qemu_host_http_server(&request, loaded_qemu.config_path.as_deref())?;
+        self.app
+            .qemu(cargo, request.build_info_path, loaded_qemu.config)
+            .await
     }
 
     async fn run_build_request(&mut self, request: ResolvedBuildRequest) -> anyhow::Result<()> {
@@ -455,22 +474,21 @@ impl ArceOS {
         self.app.set_debug_mode(request.debug)?;
         let request = c_app_internal_request(&request);
         let cargo = build::load_c_app_cargo_config(&request)?;
-        let mut qemu = self
-            .load_qemu_config(&request, &cargo)
-            .await?
-            .with_context(|| {
-                format!(
-                    "ArceOS C app config {} requires an explicit qemu config",
-                    request.build_info_path.display()
-                )
-            })?;
+        let loaded_qemu = self.load_qemu_config(&request, &cargo).await?;
+        let mut qemu = loaded_qemu.config.with_context(|| {
+            format!(
+                "ArceOS C app config {} requires an explicit qemu config",
+                request.build_info_path.display()
+            )
+        })?;
         let output = self.build_c_app_request(&request, app_dir, app_name)?;
         crate::test::qemu::apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
         ensure_qemu_runtime_assets(self.app.workspace_root(), &qemu)?;
         self.app
             .prepare_elf_artifact(output.elf_path, qemu.to_bin)
             .await?;
-        let _host_http_server = start_qemu_host_http_server(&request)?;
+        let _host_http_server =
+            start_qemu_host_http_server(&request, loaded_qemu.config_path.as_deref())?;
         self.app.run_prepared_qemu(qemu, None).await
     }
 
@@ -601,7 +619,39 @@ body = "fixture"
             uboot_config: None,
         };
 
-        let guard = start_qemu_host_http_server(&request).unwrap();
+        let guard = start_qemu_host_http_server(&request, None).unwrap();
+
+        assert!(guard.is_some());
+    }
+
+    #[test]
+    fn qemu_request_starts_host_http_server_from_fallback_qemu_config_path() {
+        let root = tempdir().unwrap();
+        let qemu_config = root.path().join("qemu-x86_64.toml");
+        std::fs::write(
+            &qemu_config,
+            r#"
+args = []
+
+[host_http_server]
+port = 0
+body = "fixture"
+"#,
+        )
+        .unwrap();
+        let request = ResolvedBuildRequest {
+            package: "arceos-httpclient".to_string(),
+            arch: "x86_64".to_string(),
+            target: "x86_64-unknown-none".to_string(),
+            plat_dyn: Some(true),
+            smp: Some(1),
+            debug: false,
+            build_info_path: root.path().join("build.toml"),
+            qemu_config: None,
+            uboot_config: None,
+        };
+
+        let guard = start_qemu_host_http_server(&request, Some(&qemu_config)).unwrap();
 
         assert!(guard.is_some());
     }

--- a/scripts/axbuild/src/arceos/rootfs.rs
+++ b/scripts/axbuild/src/arceos/rootfs.rs
@@ -51,6 +51,7 @@ pub(super) async fn qemu_with_explicit_rootfs(
     let mut qemu = arceos
         .load_qemu_config(&request, &cargo)
         .await?
+        .config
         .unwrap_or_default();
     qemu_test::apply_dynamic_platform_qemu_boot(&mut qemu, &cargo);
     patch_qemu_rootfs(&mut qemu, &rootfs);

--- a/scripts/axbuild/src/arceos/test.rs
+++ b/scripts/axbuild/src/arceos/test.rs
@@ -727,6 +727,7 @@ async fn prepare_rust_qemu_cases(
         let mut qemu = arceos
             .load_qemu_config(&request, &cargo)
             .await?
+            .config
             .with_context(|| {
                 format!(
                     "failed to load ArceOS qemu config for case `{}`",

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -3,6 +3,7 @@ use std::{
     env,
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
+    process::Command as StdCommand,
 };
 
 use anyhow::Context;
@@ -323,6 +324,7 @@ impl AppContext {
     fn scoped_qemu_path(&self, cargo: &Cargo) -> anyhow::Result<PathRestoreGuard> {
         let guard = PathRestoreGuard::new(self.original_path.clone());
         guard.restore();
+        configure_rust_objcopy_path()?;
         if should_use_loongarch_lvz_for(&cargo.package, &cargo.target) {
             configure_loongarch_qemu_path(&self.root)?;
         }
@@ -391,6 +393,67 @@ impl Drop for PathRestoreGuard {
 
 fn should_use_loongarch_lvz_for(package: &str, target: &str) -> bool {
     package == "axvisor" && target.contains("loongarch64")
+}
+
+fn configure_rust_objcopy_path() -> anyhow::Result<()> {
+    if is_command_in_path("rust-objcopy") {
+        return Ok(());
+    }
+
+    let Some(bin_dir) = rust_toolchain_bin_dir() else {
+        return Ok(());
+    };
+
+    let objcopy = bin_dir.join(format!("rust-objcopy{}", env::consts::EXE_SUFFIX));
+    if !objcopy.is_file() {
+        return Ok(());
+    }
+
+    prepend_dir_to_path(&bin_dir)?;
+    info!(
+        "PATH-prepended Rust toolchain bin for rust-objcopy: {}",
+        bin_dir.display()
+    );
+    Ok(())
+}
+
+fn rust_toolchain_bin_dir() -> Option<PathBuf> {
+    let sysroot = command_stdout("rustc", &["--print", "sysroot"])?;
+    let version_verbose = command_stdout("rustc", &["-vV"])?;
+    let host = version_verbose
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))?;
+
+    Some(
+        PathBuf::from(sysroot)
+            .join("lib")
+            .join("rustlib")
+            .join(host)
+            .join("bin"),
+    )
+}
+
+fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
+    let output = StdCommand::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8(output.stdout).ok()?;
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn is_command_in_path(command: &str) -> bool {
+    let command_name = format!("{command}{}", env::consts::EXE_SUFFIX);
+    env::var_os("PATH")
+        .map(|path| {
+            env::split_paths(&path).any(|dir| {
+                let candidate = dir.join(&command_name);
+                candidate.is_file()
+            })
+        })
+        .unwrap_or(false)
 }
 
 fn configure_loongarch_qemu_path(workspace_root: &Path) -> anyhow::Result<()> {

--- a/scripts/axbuild/src/starry/rootfs.rs
+++ b/scripts/axbuild/src/starry/rootfs.rs
@@ -8,11 +8,13 @@ use std::{
     fs,
     io::{Read, Seek, SeekFrom},
     path::{Path, PathBuf},
+    process::Command,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, bail};
 use clap::Args;
+use log::warn;
 use ostool::{build::config::Cargo, run::qemu::QemuConfig};
 
 use super::{Starry, apk, build};
@@ -155,6 +157,14 @@ pub(crate) async fn ensure_qemu_rootfs_ready(
 }
 
 pub(crate) fn ensure_apk_region_in_rootfs(rootfs_img: &Path) -> anyhow::Result<()> {
+    if !debugfs_available() {
+        warn!(
+            "`debugfs` is unavailable; skipping rootfs repository/resolver injection for {}",
+            rootfs_img.display()
+        );
+        return Ok(());
+    }
+
     if !looks_like_ext_image(rootfs_img)? {
         return Ok(());
     }
@@ -171,6 +181,10 @@ pub(crate) fn ensure_apk_region_in_rootfs(rootfs_img: &Path) -> anyhow::Result<(
 
 fn sync_qemu_slirp_resolver_in_rootfs(rootfs_img: &Path) -> anyhow::Result<()> {
     replace_rootfs_text_file_if_changed(rootfs_img, "/etc/resolv.conf", QEMU_SLIRP_RESOLV_CONF)
+}
+
+fn debugfs_available() -> bool {
+    Command::new("debugfs").arg("-V").output().is_ok()
 }
 
 fn replace_rootfs_text_file_if_changed(


### PR DESCRIPTION
在 macOS 本地执行 ArceOS/Starry 流程时，存在多处环境相关失败：首次缺失 ArceOS build 配置会直接报错；未显式传入 qemu 配置时无法提前生成 runtime disk；部分主机缺少 rust-objcopy、mkfs.fat、debugfs 导致流程中断。

变更：

ArceOS build 模式加载前自动确保 build 配置存在，避免首次运行读取失败。
ArceOS qemu 流程增强 runtime disk 处理：
支持展开 ${workspace} 路径占位符。
未显式传入 qemu 配置时，回退读取包目录默认 qemu-<arch>.toml。
缺少 truncate 时使用文件长度方式创建镜像；缺少 mkfs.fat 时降级为 raw 文件并告警。 QEMU 运行前补齐 rust-objcopy 可发现路径：
若 PATH 中缺失 rust-objcopy，自动尝试注入当前 Rust toolchain rustlib bin 目录。 Starry rootfs 注入流程增强：
当系统无 debugfs 时跳过注入并输出 warning，不再中断 rootfs 准备。