### PR TITLE
feat(starry): add axbuild kmod support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3907,6 +3907,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hello"
+version = "0.1.0"
+dependencies = [
+ "ax-driver",
+ "ax-feat",
+ "ax-hal",
+ "ax-std",
+ "axplat-dyn",
+ "kmod-tools",
+ "starry-kernel",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4552,9 +4565,9 @@ version = "0.1.0"
 
 [[package]]
 name = "kapi"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93505ad306e00dcd1b283c328110de980a1b1ac00e127c0eba192cf5500159d9"
+checksum = "e7a45f2d7730c66d1398167a73cf26cf254192a767576e425a81f15281e502ff"
 dependencies = [
  "axerrno",
  "kmod-tools",
@@ -4584,9 +4597,9 @@ dependencies = [
 
 [[package]]
 name = "kbindings"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753ac4e7753fa007b8f7828d0e01e9ececa48b689460e6380fb36bbf74654a8d"
+checksum = "4909c2528b527061d0636840365c17af53faaa896464ba65af64968489d0d29f"
 
 [[package]]
 name = "kbpf-basic"
@@ -4634,9 +4647,9 @@ dependencies = [
 
 [[package]]
 name = "kmacro-tools"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf3202c44ae67bf2647146a753b2b09e9b48db0fd5db1686f595b6682e7ca72"
+checksum = "43164c46baef040239e350cbcd8d34c5feed8f07dd7440af247a2e1d63011550"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4645,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "kmod-loader"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d13c9132595e1b16ba64390fc23a19ab0f9b940a144445bdd270854e61f544"
+checksum = "f00753deadc0983c645949e945722c3a8223956d9ed956704847a70a6e6bbddb"
 dependencies = [
  "ax-errno 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield-struct 0.13.0",
@@ -4663,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "kmod-tools"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80053048fd6814e4fcd5bda5f23a88d2deffb5d70ac7544f8312f706296c503e"
+checksum = "a1c2ce9a13048e88cb75f273f8a08ebd9f1b41870fef1fed016849277bc4445e"
 dependencies = [
  "kbindings",
  "kmacro-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,8 +114,10 @@ members = [
     "tools/qperf",
     "tools/qperf/analyzer",
     "xtask",
+    "os/StarryOS/lkm/*",
 ]
 exclude = [
+    "os/StarryOS/lkm/linux-hello",
     "virtualization/test_crates",
 ]
 
@@ -314,3 +316,4 @@ simple-ahci = "0.1.1-preview.1"
 bcm2835-sdhci = "0.1.1-preview.1"
 ixgbe-driver = "0.1.1-preview.1"
 x86 = "0.52"
+kmod-tools = "0.3"

--- a/os/StarryOS/docs/kmod-axbuild-migration.md
+++ b/os/StarryOS/docs/kmod-axbuild-migration.md
@@ -1,0 +1,260 @@
+# StarryOS kmod axbuild migration
+
+This document records the migration plan for building StarryOS loadable kernel
+modules in the tgoskits axbuild flow.
+
+## Background
+
+The upstream StarryOS kmod build flow is Makefile-based:
+
+1. Discover module crates under `modules/`.
+2. Re-enter the normal kernel build scripts with `KMOD=y APP=<module>`.
+3. Compile the module crate with the same target, features, target directory,
+   rustflags, and `.axconfig.toml` as the kernel build.
+4. Convert the module crate rlib into an ET_REL `.ko` with:
+
+   ```text
+   rust-lld -flavor gnu -r -T modules/kmod-linker.ld \
+       -o <module>.ko --whole-archive lib<module>.rlib \
+       --strip-debug --build-id=none --gc-sections -no-pie
+   ```
+
+The important property is not the Makefile itself. The important property is
+that the module build shares the same kernel build context, so Cargo can reuse
+the same compiled `starry-kernel`, `ax-feat`, platform, and ArceOS dependency
+artifacts whenever the compilation inputs match.
+
+The existing tgoskits `cargo xtask starry kmod build` implementation bypassed
+that context by directly running `cargo build --manifest-path`. That loses the
+Starry-specific target JSON, generated axconfig, feature normalization, platform
+selection, and kallsyms-compatible kernel configuration, so it is not a correct
+migration of the upstream flow.
+
+## Target design
+
+Treat kmod building as a Starry build mode, not as a separate Cargo shortcut.
+
+The `starry kmod build` command should:
+
+1. Accept the same build selectors as `starry build`: `--config`, `--arch`,
+   `--target`, `--smp`, and `--debug`.
+2. Resolve those selectors through the normal Starry request path.
+3. Load the normal Starry Cargo configuration with `build::load_cargo_config`.
+4. Clone that Cargo configuration for each module package.
+5. Change only the package/bin/output-specific fields needed for module
+   compilation:
+   - set `package` to the module package name,
+   - clear the `starryos` binary selection,
+   - disable ELF-to-bin conversion,
+   - remove Starry kernel-only kallsyms and uimage post-processing hooks.
+6. Keep the target, features, Cargo args, and environment intact. In
+   particular, preserve `AX_CONFIG_PATH`, `AX_PLATFORM`, `AX_ARCH`,
+   `AX_TARGET`, `SMP`, target JSON arguments, and build-std arguments.
+7. Locate the produced module rlib from Cargo metadata, then partial-link it
+   with `os/StarryOS/scripts/kmod-linker.ld`.
+8. Write `.ko` files next to the kernel ELF under `target/<target>/release/`.
+
+Module discovery uses `os/StarryOS/lkm` as the default tree. `--module <path>`
+can point either at one module crate or at a directory to scan recursively.
+
+## Runtime contract
+
+The kernel side already provides the kmod loader, syscall glue, shim symbols,
+and kallsyms-backed symbol resolution. A valid `.ko` is expected to remain a
+relocatable ELF with unresolved symbols that are resolved at load time through
+the in-kernel kallsyms table.
+
+The kernel image itself must still be built by the normal Starry axbuild flow so
+the `.kallsyms` section is generated before testing positive module loading.
+
+### LTO and exported Rust symbols
+
+StarryOS kmods currently rely on exact kallsyms lookup for undefined symbols in
+the module ELF. This includes not only explicit kernel shim symbols such as
+`write_char`, but also Rust `core` and `alloc` symbols that the module crate may
+reference after normal Rust code generation.
+
+Workspace-level `lto = true` is incompatible with that assumption. During the
+final kernel link, LLVM treats the kernel as a closed-world binary. Symbols that
+are not needed by the kernel's own final call graph may be inlined,
+internalized, renamed, or removed entirely. The kmod is not part of that final
+LTO unit, so future runtime references from `.ko` files are invisible to the
+optimizer.
+
+A concrete failure mode is a module referencing a Rust formatting symbol such
+as:
+
+```text
+_RNvMs5_NtNtC..._4core3fmt8buildersNtB5_9DebugList5entry
+```
+
+If the kernel ELF no longer contains the same global symbol after LTO, the
+symbol is absent from `.kallsyms` and `insmod` fails with `unknown symbol in
+module`. Even if an equivalent implementation remains in the kernel as a local
+or LTO-renamed symbol, the loader cannot use it because kallsyms resolution is
+an exact string match.
+
+When investigating this class of failure, do not change the module
+implementation first. Check the symbol contract directly:
+
+```sh
+rust-nm -u target/<target>/release/<module>.ko
+rust-nm -n target/<target>/release/starryos
+```
+
+The undefined symbol name in the `.ko` must exist as the same global symbol in
+the kernel ELF. A different Rust crate disambiguator in the mangled name means
+the module and kernel were not built against the same exported Rust symbol set.
+
+The required rule is therefore to build both the Starry kernel image and its
+modules with release LTO disabled. This repository currently sets the workspace
+release profile to:
+
+```toml
+[profile.release]
+lto = false
+```
+
+Do not enable workspace or command-line release LTO for kernel images that are
+expected to load `.ko` files. Building only the module with LTO disabled cannot
+restore symbols that were already removed from a kernel ELF built with release
+LTO.
+
+## Rootfs integration
+
+Module image installation uses the existing axbuild rootfs injection helpers
+instead of reintroducing sudo mount/copy logic. Pass `--rootfs <image>` to
+`starry kmod build` to install the produced modules into the image. The guest
+path is:
+
+```text
+/modules/<module>.ko
+```
+
+The rootfs injection step may create a short-lived overlay directory in the
+system temporary directory, but it is removed automatically after injection and
+is not a build artifact.
+
+Example:
+
+```sh
+cargo xtask starry kmod build --arch riscv64 \
+    -m os/StarryOS/lkm/hello \
+    --rootfs tmp/axbuild/rootfs/kmod-test-riscv64.img
+```
+
+## Validation
+
+Minimum validation after implementation:
+
+1. Build the kernel with release LTO disabled:
+
+   ```sh
+   cargo xtask starry build --arch <arch>
+   ```
+
+   This step is required even if modules are built separately. The kernel ELF
+   must be generated with release LTO disabled; otherwise Rust `core`/`alloc`
+   symbols needed by modules may be absent from `.kallsyms`.
+
+2. Build the module with the same Starry selectors:
+
+   ```sh
+   cargo xtask starry kmod build --arch <arch> -m os/StarryOS/lkm/hello
+   ```
+
+   The resulting `.ko` is written next to the kernel ELF:
+
+   ```text
+   target/<target>/release/starryos
+   target/<target>/release/hello.ko
+   ```
+
+3. Inspect the module ELF:
+
+   ```sh
+   rust-readobj --file-headers target/<target>/release/hello.ko
+   rust-nm -u target/<target>/release/hello.ko
+   ```
+
+   The file must be an ET_REL relocatable ELF. Undefined symbols are expected,
+   because they are resolved by the kernel loader through kallsyms.
+
+4. Compare module undefined symbols against the kernel ELF before changing the
+   module implementation:
+
+   ```sh
+   rust-nm -u target/<target>/release/hello.ko
+   rust-nm -n target/<target>/release/starryos
+   ```
+
+   Every required `.ko` symbol that is not provided by the module itself must
+   have the same global symbol name in the kernel ELF. In particular, Rust
+   mangled symbols must have the same crate disambiguator.
+
+5. Validate rootfs integration when testing `insmod`:
+
+   ```sh
+   cargo xtask starry kmod build --arch <arch> \
+       -m os/StarryOS/lkm/hello \
+       --rootfs <rootfs.img>
+   ```
+
+   The module should appear in the guest as:
+
+   ```text
+   /modules/hello.ko
+   ```
+
+6. Run a positive loader test in the guest:
+
+   ```sh
+   insmod /modules/hello.ko
+   rmmod hello
+   ```
+
+   The expected result is that `insmod` resolves all undefined symbols, the
+   module init function runs, and `rmmod` unloads the module successfully.
+
+## Quick start
+
+If `tmp/axbuild/config/starryos/build-<target>.toml` does not exist, the Starry
+build and kmod commands generate it from the default qemu board config for the
+selected target. This is required for dynamic-platform targets such as riscv64,
+because the plain target default does not contain the virtio and driver
+features needed by QEMU.
+
+1. Ensure the rootfs image exists at `tmp/axbuild/rootfs/rootfs-<target>-alpine.img`. If not, build it with:
+
+```sh
+cargo xtask starry rootfs --arch <arch>
+```
+
+2. Build the module with the same Starry selectors and inject it into the rootfs:
+
+```sh
+cargo xtask starry kmod build --arch riscv64 \
+    -m os/StarryOS/lkm/hello \
+    --rootfs tmp/axbuild/rootfs/rootfs-riscv64-alpine.img/rootfs-riscv64-alpine.img
+```
+
+3. Build and boot the kernel with QEMU and the injected rootfs:
+
+```sh
+cargo xtask starry qemu --arch riscv64
+```
+
+4. Run a positive loader test in the guest:
+
+```sh
+insmod /modules/hello.ko
+rmmod hello
+```
+
+
+## kmod app migration 
+
+| kmod        | x86_64             | riscv64            | aarch64            | loongarch64        |
+| ----------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| hello       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| linux-hello |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/os/StarryOS/docs/kmod-axbuild-migration.md
+++ b/os/StarryOS/docs/kmod-axbuild-migration.md
@@ -252,7 +252,7 @@ rmmod hello
 ```
 
 
-## kmod app migration 
+## kmod app migration
 
 | kmod        | x86_64             | riscv64            | aarch64            | loongarch64        |
 | ----------- | ------------------ | ------------------ | ------------------ | ------------------ |

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -138,8 +138,8 @@ ax-ipi = { workspace = true }
 static-keys = "0.8"
 ddebug = "0.5"
 kprobe = "0.6"
-kmod = { version = "0.2", package = "kmod-tools" }
-kmod-loader = "0.2.1"
+kmod = { version = "0.3", package = "kmod-tools" }
+kmod-loader = "0.3"
 lwprintf-rs = "0.3"
 some-serial = { workspace = true, optional = true }
 sg200x-bsp = { workspace = true, optional = true }

--- a/os/StarryOS/kernel/src/kmod/kshim.rs
+++ b/os/StarryOS/kernel/src/kmod/kshim.rs
@@ -1,0 +1,12 @@
+//! Compatibility symbols for Linux C modules.
+
+#[cfg(target_arch = "x86_64")]
+mod x86_64 {
+    use kmod::capi_fn;
+
+    #[capi_fn]
+    #[unsafe(naked)]
+    unsafe extern "C" fn __x86_return_thunk() {
+        core::arch::naked_asm!("ret");
+    }
+}

--- a/os/StarryOS/kernel/src/kmod/mod.rs
+++ b/os/StarryOS/kernel/src/kmod/mod.rs
@@ -24,13 +24,11 @@ use alloc::{
     string::{String, ToString},
 };
 
-use ax_alloc::{UsageKind, global_allocator};
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_kspin::SpinNoPreempt;
-use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr};
+use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr, VirtAddrRange};
 use ax_runtime::hal::{
     cpu::asm::{flush_icache_all, flush_tlb},
-    mem::{phys_to_virt, virt_to_phys},
     paging::{MappingFlags, PageSize},
 };
 use kmod_loader::{KernelModuleHelper, ModuleLoader, ModuleOwner, SectionMemOps};
@@ -56,13 +54,12 @@ fn section_perms_to_mapping_flags(perms: kmod_loader::SectionPerm) -> MappingFla
 /// Owned region of physical frames mapped into the kernel address space.
 /// Implements `kmod_loader::SectionMemOps` so the loader can write code /
 /// data into the section and later re-protect it.
-struct KmodMem {
-    paddr: PhysAddr,
+struct KmodMemSection {
     vaddr: VirtAddr,
     num_pages: usize,
 }
 
-impl SectionMemOps for KmodMem {
+impl SectionMemOps for KmodMemSection {
     fn as_mut_ptr(&mut self) -> *mut u8 {
         self.vaddr.as_mut_ptr()
     }
@@ -81,53 +78,56 @@ impl SectionMemOps for KmodMem {
     }
 }
 
-impl Drop for KmodMem {
+impl Drop for KmodMemSection {
     fn drop(&mut self) {
         let total = PAGE_SIZE_4K * self.num_pages;
-
-        // While the module was live, `change_perms()` re-protected its sections
-        // (e.g. `.text` → RX, `.rodata` → RO) in the kernel address space. The
-        // global page allocator only maintains a free-page list — it never
-        // touches the kernel PTEs — so handing back still-RO/RX pages would
-        // corrupt a later reuse: `alloc_kmod_frames()`'s zeroing `write_bytes()`
-        // would fault on a read-only page, or a non-writable page would be
-        // handed to some other kernel object. Restore a plain RW mapping (and
-        // flush the now-stale TLB entries) before returning the frames.
-        let restored = {
-            let kspace = ax_mm::kernel_aspace();
-            let mut guard = kspace.lock();
-            guard
-                .protect(self.vaddr, total, MappingFlags::READ | MappingFlags::WRITE)
-                .is_ok()
-        };
-        if !restored {
-            // Don't silently return RO/RX pages to the general allocator pool;
-            // leak them instead so a later allocation can't fault on them.
-            error!(
-                "kmod: failed to restore RW mapping for module section at {:#x} ({} pages); \
-                 leaking frames",
-                self.vaddr.as_usize(),
-                self.num_pages
-            );
-            return;
-        }
+        ax_mm::kernel_aspace()
+            .lock()
+            .unmap(self.vaddr, total)
+            .unwrap_or_else(|_| {
+                error!(
+                    "kmod: failed to unmap module section at {:#x} ({} pages)",
+                    self.vaddr.as_usize(),
+                    self.num_pages
+                );
+            });
         crate::mm::flush_tlb_range(self.vaddr, total);
-
-        let vaddr = phys_to_virt(self.paddr);
-        global_allocator().dealloc_pages(vaddr.as_usize(), self.num_pages, UsageKind::Global);
     }
 }
 
-fn alloc_kmod_frames(num_pages: usize) -> AxResult<(PhysAddr, VirtAddr)> {
+unsafe extern "C" {
+    fn _ekernel();
+}
+
+fn alloc_kmod_frames(num_pages: usize) -> AxResult<VirtAddr> {
     let page_size = PageSize::Size4K as usize;
     let total = page_size * num_pages;
-    let vaddr_usize = global_allocator()
-        .alloc_pages(num_pages, page_size, UsageKind::Global)
-        .map_err(|_| AxError::NoMemory)?;
-    let vaddr = VirtAddr::from(vaddr_usize);
-    // SAFETY: just-allocated, page-aligned region of `total` bytes.
+    // TODO: use a proper allocator here. For now we just find a free virtual address
+    // const KMOD_ALLOC_SIZE: usize = 1024 * 1024 * 1024 * 2;
+    let kernel_end = (_ekernel as *const () as usize).align_up_4k();
+    // The kernel virtual address space is laid out like this:
+    // ┌──────────────────────────────┐
+    // │       Free for modules       │
+    // ├──────────────────────────────┤
+    // │       Kernel text/data       │ high addresses
+    // ├──────────────────────────────┤
+    // Try to find a free virtual address range within 2 GiB of the kernel end, to stay within reach of 32-bit relative relocations.
+    let kmod_alloc_start = VirtAddr::from_usize(kernel_end);
+    let vaddr = {
+        let kspace = ax_mm::kernel_aspace();
+        let mut guard = kspace.lock();
+        let vaddr = guard
+            .find_free_area(
+                kmod_alloc_start,
+                total,
+                VirtAddrRange::new(guard.base(), guard.end()),
+            )
+            .expect("kmod vmalloc: failed to find free area for module section");
+        guard.map_alloc(vaddr, total, MappingFlags::READ | MappingFlags::WRITE, true)?;
+        vaddr
+    };
     unsafe { core::ptr::write_bytes(vaddr.as_mut_ptr(), 0, total) };
-    Ok((virt_to_phys(vaddr), vaddr))
+    Ok(vaddr)
 }
 
 fn linux_code_to_ax_error(code: i32) -> AxError {
@@ -143,12 +143,8 @@ impl KernelModuleHelper for KmodHelper {
             "kmod vmalloc size must be page-aligned"
         );
         let num_pages = size / PAGE_SIZE_4K;
-        let (paddr, vaddr) = alloc_kmod_frames(num_pages).expect("kmod vmalloc: out of memory");
-        Box::new(KmodMem {
-            paddr,
-            vaddr,
-            num_pages,
-        })
+        let vaddr = alloc_kmod_frames(num_pages).expect("kmod vmalloc: out of memory");
+        Box::new(KmodMemSection { vaddr, num_pages })
     }
 
     fn resolve_symbol(name: &str) -> Option<usize> {

--- a/os/StarryOS/kernel/src/kmod/mod.rs
+++ b/os/StarryOS/kernel/src/kmod/mod.rs
@@ -16,6 +16,7 @@
 //! `perf::kprobe` resolves names against.
 
 mod kprint;
+mod kshim;
 
 use alloc::{
     boxed::Box,
@@ -119,7 +120,7 @@ fn alloc_kmod_frames(num_pages: usize) -> AxResult<VirtAddr> {
                 total,
                 VirtAddrRange::new(guard.base(), guard.end()),
             )
-            .expect("kmod vmalloc: failed to find free area for module section");
+            .ok_or(AxError::NoMemory)?;
         guard.map_alloc(vaddr, total, MappingFlags::READ | MappingFlags::WRITE, true)?;
         vaddr
     };

--- a/os/StarryOS/kernel/src/kmod/mod.rs
+++ b/os/StarryOS/kernel/src/kmod/mod.rs
@@ -102,8 +102,6 @@ unsafe extern "C" {
 fn alloc_kmod_frames(num_pages: usize) -> AxResult<VirtAddr> {
     let page_size = PageSize::Size4K as usize;
     let total = page_size * num_pages;
-    // TODO: use a proper allocator here. For now we just find a free virtual address
-    // const KMOD_ALLOC_SIZE: usize = 1024 * 1024 * 1024 * 2;
     let kernel_end = (_ekernel as *const () as usize).align_up_4k();
     // The kernel virtual address space is laid out like this:
     // ┌──────────────────────────────┐
@@ -111,7 +109,6 @@ fn alloc_kmod_frames(num_pages: usize) -> AxResult<VirtAddr> {
     // ├──────────────────────────────┤
     // │       Kernel text/data       │ high addresses
     // ├──────────────────────────────┤
-    // Try to find a free virtual address range within 2 GiB of the kernel end, to stay within reach of 32-bit relative relocations.
     let kmod_alloc_start = VirtAddr::from_usize(kernel_end);
     let vaddr = {
         let kspace = ax_mm::kernel_aspace();

--- a/os/StarryOS/lkm/README.md
+++ b/os/StarryOS/lkm/README.md
@@ -1,0 +1,160 @@
+# StarryOS Loadable Kernel Modules
+
+This directory contains loadable kernel modules (`.ko`) used by StarryOS.
+
+`cargo xtask starry kmod build` discovers modules under this directory by
+default. It supports two module forms:
+
+- Rust kmods: a Cargo package with `Cargo.toml`, for example `hello/`.
+- Linux C kmods: a Kbuild `Makefile` with `obj-m`, for example `linux-hello/`.
+
+This document focuses on Rust kmods.
+
+## Rust Module Layout
+
+A Rust kmod is a normal workspace package:
+
+```text
+os/StarryOS/lkm/<module>/
+├── Cargo.toml
+└── src/
+    └── lib.rs
+```
+
+The crate is compiled as a library first. axbuild then partial-links the
+produced `rlib` into an ET_REL `.ko` with
+`os/StarryOS/scripts/kmod-linker.ld`.
+
+The module source should be `no_std`:
+
+```rust
+#![no_std]
+
+use kmod_tools::{exit_fn, init_fn, module};
+
+#[init_fn]
+fn init() -> i32 {
+    0
+}
+
+#[exit_fn]
+fn exit() {}
+
+module!(
+    name: "my_module",
+    license: "GPL",
+    description: "My StarryOS module",
+    version: "0.1.0",
+);
+```
+
+Use `extern "C"` declarations for kernel shim symbols that are resolved
+through StarryOS kallsyms at load time.
+
+## Required Dependencies
+
+A Rust kmod should use workspace dependencies so the module and kernel are built
+from the same crate graph:
+
+```toml
+[dependencies]
+kmod-tools.workspace = true
+starry-kernel = { workspace = true, features = [...] }
+ax-feat = { workspace = true, features = [...] }
+ax-std = { workspace = true, features = [...] }
+```
+
+Add lower-level ArceOS crates such as `ax-hal`, `ax-driver`, or `axplat-dyn`
+only when the module directly uses their APIs or forwards their features.
+
+Do not depend on a different version of `starry-kernel`, `ax-std`, `ax-feat`,
+or platform crates. A Rust kmod may contain undefined Rust `core`/`alloc` and
+kernel symbols that must match the kernel ELF exactly.
+
+## Feature Rule
+
+The Rust kmod feature set must be compatible with the kernel that will load it.
+In practice, the module's effective Starry/ArceOS feature requirements should
+be a subset of, or equal to, the kernel build's enabled capabilities; when in
+doubt, make the module package expose the same board/platform features as
+`starryos` and forward them to the same crates.
+
+For example, if the kernel is built with a dynamic platform feature such as
+`plat-dyn`, the module package should also provide and forward `plat-dyn`:
+
+```toml
+[features]
+default = []
+plat-dyn = ["dep:axplat-dyn", "starry-kernel/plat-dyn"]
+smp = ["ax-feat/smp", "axplat-dyn?/smp", "ax-hal/smp"]
+```
+
+The same applies to board and device features. If a module needs a symbol or
+type behind `starry-kernel/input`, `starry-kernel/vsock`, `ax-driver/rknpu`, or
+similar feature gates, the kernel must be built with compatible support.
+
+`cargo xtask starry kmod build` starts from the normal Starry build selectors
+(`--arch`, `--target`, `--config`, `--smp`, `--debug`) and reuses the resolved
+Cargo target, generated axconfig, environment, and normalized feature set. The
+module's package features are then applied on top of that context.
+
+## LTO Requirement
+
+Release LTO must remain disabled for kernels that load Rust kmods. With LTO,
+the final kernel link can inline, internalize, rename, or remove Rust symbols
+that are not needed by the kernel's own closed-world call graph. A module that
+later references the original symbol name will then fail kallsyms resolution at
+`insmod` time.
+
+This repository currently sets:
+
+```toml
+[profile.release]
+lto = false
+```
+
+Do not enable workspace or command-line release LTO for kmod-capable kernel
+images.
+
+## Build
+
+Build the kernel first:
+
+```sh
+cargo xtask starry build --arch <arch>
+```
+
+Then build one module:
+
+```sh
+cargo xtask starry kmod build --arch <arch> -m os/StarryOS/lkm/hello
+```
+
+Or build all modules under this directory:
+
+```sh
+cargo xtask starry kmod build --arch <arch> --all
+```
+
+The resulting `.ko` files are written next to the Starry kernel ELF under the
+Cargo target directory, for example:
+
+```text
+target/<target>/release/hello.ko
+```
+
+Use `--rootfs <image>` to inject built modules into `/modules/` in a rootfs
+image.
+
+## Symbol Checks
+
+If a module fails to load with an unknown symbol, compare the module's
+undefined symbols with the kernel ELF:
+
+```sh
+rust-nm -u target/<target>/release/<module>.ko
+rust-nm -n target/<target>/release/starryos
+```
+
+The unresolved module symbol must exist in the kernel ELF with the exact same
+name.

--- a/os/StarryOS/lkm/hello/Cargo.toml
+++ b/os/StarryOS/lkm/hello/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "hello"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+ax-feat = { workspace = true, features = ["ext-ld", "fs-ng-times", "irq"] }
+ax-driver.workspace = true
+ax-hal.workspace = true
+axplat-dyn = { workspace = true, optional = true }
+starry-kernel = { workspace = true, features = ["dev-log", "ext4"] }
+ax-std = { workspace = true, features = ["ext-ld", "fs", "multitask", "irq"] }
+
+kmod-tools.workspace = true
+
+[features]
+default = []
+myplat = ["ax-feat/myplat"]
+qemu = [
+  "ax-feat/defplat",
+  "ax-feat/irq",
+  "ax-feat/rtc",
+  "ax-feat/display",
+  "starry-kernel/input",
+  "starry-kernel/vsock", # auxilary features
+]
+smp = ["ax-feat/smp", "axplat-dyn?/smp", "ax-hal/smp"]
+
+sg2002 = ["ax-hal/riscv64-sg2002", "starry-kernel/sg2002"]
+sg2002-dyn = [
+  "plat-dyn",
+  "axplat-dyn/thead-mae",
+  "starry-kernel/sg2002",
+  "ax-driver/sg2002-placeholder",
+]
+k230 = [
+  "plat-dyn",
+  "starry-kernel/k230-kpu",
+  "ax-driver/k230-sdhci",
+  "ax-driver/serial",
+]
+plat-dyn = ["dep:axplat-dyn", "starry-kernel/plat-dyn"]
+
+rknpu = ["ax-driver/rknpu", "starry-kernel/rknpu"]
+vf2 = ["ax-hal/riscv64-visionfive2"]

--- a/os/StarryOS/lkm/hello/src/lib.rs
+++ b/os/StarryOS/lkm/hello/src/lib.rs
@@ -1,0 +1,42 @@
+#![no_std]
+extern crate alloc;
+use alloc::vec;
+
+use kmod_tools::{exit_fn, init_fn, module};
+
+unsafe extern "C" {
+    fn write_char(c: u8);
+}
+
+struct Writer;
+
+impl core::fmt::Write for Writer {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        for &b in s.as_bytes() {
+            unsafe { write_char(b) };
+        }
+        Ok(())
+    }
+}
+
+#[init_fn]
+pub fn hello_init() -> i32 {
+    let mut writer = Writer;
+    core::fmt::write(&mut writer, format_args!("Hello, Kernel Module!\n")).unwrap();
+    let v = vec![1, 2, 3, 4, 5];
+    core::fmt::write(&mut writer, format_args!("Vector contents: {:?}\n", v)).unwrap();
+    0
+}
+
+#[exit_fn]
+fn hello_exit() {
+    let mut writer = Writer;
+    core::fmt::write(&mut writer, format_args!("Goodbye, Kernel Module!\n")).unwrap();
+}
+
+module!(
+    name: "hello",
+    license: "GPL",
+    description: "A simple hello world kernel module",
+    version: "0.1.0",
+);

--- a/os/StarryOS/lkm/linux-hello/Makefile
+++ b/os/StarryOS/lkm/linux-hello/Makefile
@@ -1,0 +1,18 @@
+obj-m += linux-hello.o
+
+# remove _mcount section
+ccflags-remove-y += -pg
+ccflags-remove-y += -fpatchable-function-entry=%
+
+# StarryOS does not provide Linux x86 retbleed return thunk symbols. Host
+# Kbuild enables this flag when CONFIG_RETHUNK=y, which makes the module emit
+# jumps to __x86_return_thunk. Use normal function returns for this compatibility
+# module so StarryOS can resolve all external symbols itself.
+ccflags-remove-y += -mfunction-return=thunk-extern
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	strip -g  linux-hello.ko
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/os/StarryOS/lkm/linux-hello/Makefile
+++ b/os/StarryOS/lkm/linux-hello/Makefile
@@ -8,7 +8,7 @@ ccflags-remove-y += -fpatchable-function-entry=%
 # Kbuild enables this flag when CONFIG_RETHUNK=y, which makes the module emit
 # jumps to __x86_return_thunk. Use normal function returns for this compatibility
 # module so StarryOS can resolve all external symbols itself.
-ccflags-remove-y += -mfunction-return=thunk-extern
+# ccflags-remove-y += -mfunction-return=thunk-extern
 
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules

--- a/os/StarryOS/lkm/linux-hello/linux-hello.c
+++ b/os/StarryOS/lkm/linux-hello/linux-hello.c
@@ -1,0 +1,34 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Your Name");
+MODULE_DESCRIPTION("A simple Hello World kernel module");
+MODULE_VERSION("0.1");
+
+
+static int my_int = 100;
+module_param(my_int, int, 0644);
+MODULE_PARM_DESC(my_int, "An integer parameter");
+
+static char *my_string = "default";
+module_param(my_string, charp, 0644);
+MODULE_PARM_DESC(my_string, "A string parameter");
+
+
+static int __init hello_init(void)
+{
+    printk(KERN_INFO "Module parameter my_int: %d\n", my_int);
+    printk(KERN_INFO "Module parameter my_string: %s\n", my_string);
+    printk(KERN_INFO "Hello, World!\n");
+    return 0;
+}
+
+static void __exit hello_exit(void)
+{
+    printk(KERN_INFO "Goodbye, World!\n");
+}
+
+module_init(hello_init);
+module_exit(hello_exit);

--- a/os/StarryOS/starryos/linker.ld
+++ b/os/StarryOS/starryos/linker.ld
@@ -22,6 +22,12 @@ SECTIONS {
         __stop_tracepoint = .;
     }
 
+    .kmod_export : {
+        __start_kmod_export = .;
+        KEEP(*(.kmod_export .kmod_export.*))
+        __stop_kmod_export = .;
+    }
+
     .kallsyms : ALIGN(4K) {
         __kallsyms_start = .;
         . += 8M; /* reserve space for kallsyms, can be recycled */

--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1" }
 sha2 = { version = "0.10" }
 tar = { version = "0.4" }
+tempfile = "3"
 tokio = { version = "1.0", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"] }
 toml.workspace = true
 tracing = "0.1"
@@ -55,6 +56,3 @@ windows-sys = { version = "0.59", features = [
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-[dev-dependencies]
-tempfile = "3"

--- a/scripts/axbuild/src/image/config.rs
+++ b/scripts/axbuild/src/image/config.rs
@@ -25,9 +25,9 @@ pub struct ImageConfig {
 }
 
 impl ImageConfig {
-    pub fn new_default() -> Self {
+    pub fn new_default(base_dir: &Path) -> Self {
         Self {
-            local_storage: std::env::temp_dir().join(".tgos-images"),
+            local_storage: crate::context::axbuild_tmp_dir(base_dir).join("rootfs"),
             registry: DEFAULT_REGISTRY_URL.to_string(),
             auto_sync: true,
             auto_sync_threshold: DEFAULT_AUTO_SYNC_THRESHOLD,
@@ -42,7 +42,7 @@ impl ImageConfig {
         let path = Self::get_config_file_path(base_dir);
 
         let mut config = if !path.exists() {
-            let config = Self::new_default();
+            let config = Self::new_default(base_dir);
             Self::write_config(base_dir, &config)?;
             config
         } else {
@@ -136,7 +136,8 @@ mod tests {
 
         let config = ImageConfig::read_config(dir.path()).unwrap();
 
-        assert_eq!(config, ImageConfig::new_default());
+        assert_eq!(config, ImageConfig::new_default(dir.path()));
+        assert_eq!(config.local_storage, dir.path().join("tmp/axbuild/rootfs"));
         assert_eq!(
             ImageConfig::get_config_file_path(dir.path()),
             dir.path().join("tmp/axbuild/.image.toml")

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -838,6 +838,30 @@ log = "Info"
     }
 
     #[test]
+    fn load_cargo_config_keeps_pie_target_for_non_kmod_plat_dyn_request() {
+        let mut request = request(
+            PathBuf::from("/tmp/.build.toml"),
+            "aarch64",
+            "aarch64-unknown-none-softfloat",
+        );
+        request.build_info_override = Some(StarryBuildInfo {
+            plat_dyn: true,
+            features: vec!["ax-driver/virtio-blk".to_string()],
+            ..default_starry_build_info_for_target("aarch64-unknown-none-softfloat")
+        });
+
+        let cargo = load_cargo_config(&request).unwrap();
+
+        assert!(
+            cargo
+                .target
+                .ends_with("scripts/targets/std/pie/aarch64-unknown-linux-musl.json"),
+            "expected pie target, got {}",
+            cargo.target
+        );
+    }
+
+    #[test]
     fn resolve_build_info_path_supports_starry_subworkspace_root() {
         let root = tempdir().unwrap();
         let starry_dir = root.path().join("starryos");

--- a/scripts/axbuild/src/starry/kmod.rs
+++ b/scripts/axbuild/src/starry/kmod.rs
@@ -1,28 +1,32 @@
-//! `cargo xtask starry kmod build` — build a StarryOS loadable kernel
-//! module (`.ko`) from a Rust crate without involving make/Makefile.
+//! `cargo xtask starry kmod build` — build StarryOS loadable kernel modules.
 //!
-//! Replaces the upstream `Starry-OS/StarryOS:ebpf-kmod`
-//! `modules/kmod.mk` + `make/build.mk` pipeline (per
-//! `WORKFLOW_EBPF_LKM_MIGRATION.md §5.3` — "do **not** introduce
-//! `Makefile`, `make/`, or `modules/kmod.mk`"). The build flow is:
+//! The important part of the upstream Makefile flow is not Make itself. It is
+//! that modules are compiled with the same target, features, generated
+//! axconfig, and Cargo target directory as the kernel. This implementation
+//! derives a normal Starry Cargo config first, then switches only the package
+//! and output handling for each module crate before partial-linking the module
+//! rlib into an ET_REL `.ko`.
 //!
-//! 1. Run `cargo build --release -p <module>` against the kernel target
-//!    triple, producing an rlib archive.
-//! 2. Invoke the GNU `ld` linker with `-r` (partial / relocatable link)
-//!    and the StarryOS kmod linker script
-//!    (`os/StarryOS/scripts/kmod-linker.ld`), turning the rlib into a
-//!    `.ko` ELF.
-//! 3. Drop the result into `target/<arch>/kmod/<module>.ko`.
+//! C modules built with Linux Kbuild are intentionally host-only here. axbuild
+//! calls the module directory's own Makefile only when the selected Starry
+//! architecture matches the host architecture.
 
 use std::{
+    fs, io,
     path::{Path, PathBuf},
     process::Command,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, bail};
+use cargo_metadata::{Metadata, Package, TargetKind};
 use clap::{Args, Subcommand};
+use ostool::build::config::{Cargo, CargoBuildProfile};
 
-use crate::starry::Starry;
+use crate::{
+    context::SnapshotPersistence,
+    starry::{ArgsBuild, Starry, build},
+};
 
 /// Top-level CLI args for `cargo xtask starry kmod ...`.
 #[derive(Args)]
@@ -40,9 +44,8 @@ pub enum KmodCommand {
 
 #[derive(Args)]
 pub struct ArgsKmodBuild {
-    /// Target arch (`aarch64` / `riscv64` / `x86_64` / `loongarch64`).
-    #[arg(long, default_value = "x86_64")]
-    pub arch: String,
+    #[command(flatten)]
+    pub build: ArgsBuild,
 
     /// Path to a module crate (or directory containing module crates,
     /// auto-discovered via `Cargo.toml` lookup, depth ≤ 10). May be
@@ -50,9 +53,13 @@ pub struct ArgsKmodBuild {
     #[arg(short = 'm', long, value_name = "PATH")]
     pub module: Vec<PathBuf>,
 
-    /// Build every module crate under `os/StarryOS/modules/`.
+    /// Build every module crate under `os/StarryOS/lkm/`.
     #[arg(long, conflicts_with = "module")]
     pub all: bool,
+
+    /// Inject built modules into this rootfs image under `/modules/`.
+    #[arg(long, value_name = "IMAGE")]
+    pub rootfs: Option<PathBuf>,
 }
 
 impl Starry {
@@ -65,12 +72,19 @@ impl Starry {
 
     async fn kmod_build(&mut self, args: ArgsKmodBuild) -> Result<()> {
         let workspace_root = self.app.workspace_root().to_path_buf();
-        let module_paths = collect_module_paths(&workspace_root, &args)?;
-        if module_paths.is_empty() {
+        let modules = collect_modules(&workspace_root, &args)?;
+        if modules.is_empty() {
             bail!("no module crates found (use `--module <path>` or `--all`)");
         }
 
-        let target_triple = target_triple_for_arch(&args.arch)?;
+        let request =
+            self.prepare_request((&args.build).into(), None, None, SnapshotPersistence::Store)?;
+        self.ensure_default_build_config_for_request(&request, "kmod")?;
+        self.app.set_debug_mode(request.debug)?;
+        let base_cargo = build::load_cargo_config(&request)?;
+        let metadata = crate::build::cached_workspace_metadata()
+            .context("failed to load workspace metadata")?;
+
         let linker_script = workspace_root.join("os/StarryOS/scripts/kmod-linker.ld");
         if !linker_script.exists() {
             bail!(
@@ -79,36 +93,52 @@ impl Starry {
             );
         }
 
-        let out_root = workspace_root.join(format!("target/{}/kmod", args.arch));
-        std::fs::create_dir_all(&out_root)
-            .with_context(|| format!("create {}", out_root.display()))?;
+        let profile = cargo_profile_dir(&base_cargo, request.debug);
+        let target_dir = cargo_target_output_dir(&workspace_root, &base_cargo.target, profile)?;
+        std::fs::create_dir_all(&target_dir)
+            .with_context(|| format!("create {}", target_dir.display()))?;
 
-        for module_path in module_paths {
-            build_one_module(
-                &workspace_root,
-                &module_path,
-                target_triple,
-                &linker_script,
-                &out_root,
-            )?;
+        let mut built_modules = Vec::new();
+        for module in modules {
+            match module {
+                ModuleSpec::Rust(module_path) => {
+                    let ko_path = build_one_rust_module(
+                        &workspace_root,
+                        &module_path,
+                        &base_cargo,
+                        request.debug,
+                        metadata,
+                        &linker_script,
+                        &target_dir,
+                    )?;
+                    built_modules.push(ko_path);
+                }
+                ModuleSpec::LinuxC(module_path) => {
+                    if let Some(ko_paths) =
+                        build_one_linux_c_module(&module_path, &request.arch, &target_dir)?
+                    {
+                        built_modules.extend(ko_paths);
+                    }
+                }
+            }
+        }
+
+        if let Some(rootfs) = args.rootfs {
+            inject_modules_into_rootfs(&workspace_root, &rootfs, &built_modules)?;
         }
         Ok(())
     }
 }
 
-fn target_triple_for_arch(arch: &str) -> Result<&'static str> {
-    Ok(match arch {
-        "x86_64" => "x86_64-unknown-none",
-        "aarch64" => "aarch64-unknown-none-softfloat",
-        "riscv64" => "riscv64gc-unknown-none-elf",
-        "loongarch64" => "loongarch64-unknown-none-softfloat",
-        other => bail!("unsupported arch: {other}"),
-    })
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum ModuleSpec {
+    Rust(PathBuf),
+    LinuxC(PathBuf),
 }
 
-fn collect_module_paths(workspace_root: &Path, args: &ArgsKmodBuild) -> Result<Vec<PathBuf>> {
-    if args.all {
-        let modules_dir = workspace_root.join("os/StarryOS/modules");
+fn collect_modules(workspace_root: &Path, args: &ArgsKmodBuild) -> Result<Vec<ModuleSpec>> {
+    if args.all || args.module.is_empty() {
+        let modules_dir = workspace_root.join("os/StarryOS/lkm");
         if !modules_dir.exists() {
             return Ok(Vec::new());
         }
@@ -123,15 +153,19 @@ fn collect_module_paths(workspace_root: &Path, args: &ArgsKmodBuild) -> Result<V
             workspace_root.join(raw)
         };
         if resolved.join("Cargo.toml").exists() {
-            paths.push(resolved);
+            paths.push(ModuleSpec::Rust(resolved));
+        } else if is_linux_c_module_dir(&resolved)? {
+            paths.push(ModuleSpec::LinuxC(resolved));
         } else {
             paths.extend(discover_modules(&resolved)?);
         }
     }
+    paths.sort();
+    paths.dedup();
     Ok(paths)
 }
 
-fn discover_modules(root: &Path) -> Result<Vec<PathBuf>> {
+fn discover_modules(root: &Path) -> Result<Vec<ModuleSpec>> {
     let mut out = Vec::new();
     discover_modules_inner(root, 0, &mut out)?;
     out.sort();
@@ -139,12 +173,16 @@ fn discover_modules(root: &Path) -> Result<Vec<PathBuf>> {
     Ok(out)
 }
 
-fn discover_modules_inner(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) -> Result<()> {
+fn discover_modules_inner(dir: &Path, depth: usize, out: &mut Vec<ModuleSpec>) -> Result<()> {
     if depth > 10 {
         return Ok(());
     }
     if dir.join("Cargo.toml").exists() {
-        out.push(dir.to_path_buf());
+        out.push(ModuleSpec::Rust(dir.to_path_buf()));
+        return Ok(());
+    }
+    if is_linux_c_module_dir(dir)? {
+        out.push(ModuleSpec::LinuxC(dir.to_path_buf()));
         return Ok(());
     }
     if !dir.is_dir() {
@@ -160,53 +198,46 @@ fn discover_modules_inner(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) -> R
     Ok(())
 }
 
-fn build_one_module(
+fn is_linux_c_module_dir(dir: &Path) -> Result<bool> {
+    let makefile = dir.join("Makefile");
+    if !makefile.exists() {
+        return Ok(false);
+    }
+    let content = fs::read_to_string(&makefile)
+        .with_context(|| format!("failed to read {}", makefile.display()))?;
+    Ok(content
+        .lines()
+        .map(str::trim)
+        .any(|line| !line.starts_with('#') && line.starts_with("obj-m")))
+}
+
+fn build_one_rust_module(
     workspace_root: &Path,
     module_path: &Path,
-    target_triple: &str,
+    base_cargo: &Cargo,
+    debug: bool,
+    metadata: &Metadata,
     linker_script: &Path,
     out_dir: &Path,
-) -> Result<()> {
+) -> Result<PathBuf> {
     let cargo_toml = module_path.join("Cargo.toml");
     if !cargo_toml.exists() {
         bail!("missing {}", cargo_toml.display());
     }
-    let module_name = module_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .with_context(|| format!("invalid module path {}", module_path.display()))?
-        .to_string();
+    let package = package_for_manifest(metadata, &cargo_toml)?;
+    let lib_name = lib_target_name(package)?;
+    let module_name = package.name.to_string();
 
-    println!("[kmod] building {module_name} for {target_triple}");
+    println!("[kmod] building {module_name} for {}", base_cargo.target);
 
-    // Step 1: cargo build the module crate into an rlib.
-    let status = Command::new("cargo")
-        .args(["build", "--release", "--manifest-path"])
-        .arg(&cargo_toml)
-        .arg("--target")
-        .arg(target_triple)
-        .current_dir(workspace_root)
-        .status()
-        .with_context(|| format!("invoke cargo build for {module_name}"))?;
-    if !status.success() {
-        bail!("cargo build failed for {module_name}");
-    }
+    let module_cargo = module_cargo_config(base_cargo, package, debug);
+    cargo_build_module_rlib(workspace_root, &module_cargo, debug)?;
 
-    // Step 2: locate the produced rlib. `cargo build` puts rlibs at
-    // `target/<triple>/release/lib<crate>.rlib`. We expect the module
-    // crate's lib name to match the module's file_name (most kmod
-    // examples are set up that way).
-    let rlib_name = format!("lib{}.rlib", module_name.replace('-', "_"));
-    let rlib_path = workspace_root
-        .join("target")
-        .join(target_triple)
-        .join("release")
-        .join(&rlib_name);
+    let profile = cargo_profile_dir(&module_cargo, debug);
+    let rlib_path = cargo_target_output_dir(workspace_root, &module_cargo.target, profile)?
+        .join(format!("lib{}.rlib", rust_crate_file_stem(lib_name)));
     if !rlib_path.exists() {
-        bail!(
-            "expected rlib not found at {} — does the crate's [lib] name match the directory name?",
-            rlib_path.display()
-        );
+        bail!("expected module rlib not found at {}", rlib_path.display());
     }
 
     // Step 3: partial-link into a .ko via the kmod linker script.
@@ -216,7 +247,7 @@ fn build_one_module(
     let (linker, lead_args): (String, &[&str]) = match std::env::var("KMOD_LINKER") {
         Ok(l) => (l, &[]),
         Err(_) => {
-            let (prog, args) = pick_linker(target_triple);
+            let (prog, args) = pick_linker(&module_cargo.target);
             (prog.into(), args)
         }
     };
@@ -242,7 +273,367 @@ fn build_one_module(
     }
 
     println!("[kmod] wrote {}", ko_path.display());
+    Ok(ko_path)
+}
+
+fn build_one_linux_c_module(
+    module_path: &Path,
+    starry_arch: &str,
+    out_dir: &Path,
+) -> Result<Option<Vec<PathBuf>>> {
+    let host_arch = normalized_host_arch();
+    if host_arch != starry_arch {
+        println!(
+            "[kmod] skipping Linux C module {}: Starry arch `{}` does not match host arch `{}`",
+            module_path.display(),
+            starry_arch,
+            host_arch
+        );
+        return Ok(None);
+    }
+
+    let makefile = module_path.join("Makefile");
+    let module_names = linux_c_module_names(&makefile)?;
+    if module_names.is_empty() {
+        bail!("no obj-m entries found in {}", makefile.display());
+    }
+
+    println!("[kmod] building Linux C module {}", module_path.display());
+    let status = Command::new("make")
+        .args(linux_c_module_make_args(module_path))
+        .status()
+        .with_context(|| format!("invoke Makefile for {}", module_path.display()))?;
+    if !status.success() {
+        bail!(
+            "Linux C module Makefile failed for {}",
+            module_path.display()
+        );
+    }
+
+    let mut built = Vec::new();
+    for module_name in module_names {
+        let source_ko = module_path.join(format!("{module_name}.ko"));
+        if !source_ko.exists() {
+            bail!(
+                "expected Linux C module not found at {}",
+                source_ko.display()
+            );
+        }
+        let ko_path = out_dir.join(format!("{module_name}.ko"));
+        fs::copy(&source_ko, &ko_path).with_context(|| {
+            format!(
+                "failed to copy {} to {}",
+                source_ko.display(),
+                ko_path.display()
+            )
+        })?;
+        println!("[kmod] wrote {}", ko_path.display());
+        built.push(ko_path);
+    }
+
+    clean_linux_c_module(module_path)?;
+    Ok(Some(built))
+}
+
+fn linux_c_module_make_args(module_path: &Path) -> Vec<String> {
+    vec![
+        "-C".to_string(),
+        module_path.display().to_string(),
+        format!("PWD={}", module_path.display()),
+    ]
+}
+
+fn clean_linux_c_module(module_path: &Path) -> Result<()> {
+    println!("[kmod] cleaning Linux C module {}", module_path.display());
+    let status = Command::new("make")
+        .args(linux_c_module_make_args(module_path))
+        .arg("clean")
+        .status()
+        .with_context(|| format!("invoke Makefile clean for {}", module_path.display()))?;
+    if !status.success() {
+        bail!(
+            "Linux C module Makefile clean failed for {}",
+            module_path.display()
+        );
+    }
     Ok(())
+}
+
+fn normalized_host_arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        "riscv64" => "riscv64",
+        "loongarch64" => "loongarch64",
+        _ => std::env::consts::ARCH,
+    }
+}
+
+fn linux_c_module_names(makefile: &Path) -> Result<Vec<String>> {
+    let content = fs::read_to_string(makefile)
+        .with_context(|| format!("failed to read {}", makefile.display()))?;
+    let mut names = Vec::new();
+    for line in content.lines() {
+        let line = line.split('#').next().unwrap_or("").trim();
+        if !line.starts_with("obj-m") {
+            continue;
+        }
+        let Some((_, value)) = line
+            .split_once("+=")
+            .or_else(|| line.split_once(":="))
+            .or_else(|| line.split_once('='))
+        else {
+            continue;
+        };
+        for object in value.split_whitespace() {
+            let Some(name) = object.strip_suffix(".o") else {
+                continue;
+            };
+            if !name.is_empty() {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
+fn module_cargo_config(base: &Cargo, package: &Package, debug: bool) -> Cargo {
+    let mut cargo = base.clone();
+    cargo.package = package.name.to_string();
+    cargo.bin = None;
+    cargo.to_bin = false;
+    cargo.pre_build_cmds.clear();
+    cargo.post_build_cmds.clear();
+    remove_arg_value(&mut cargo.args, "--bin");
+    cargo.features = module_features(&cargo, package, debug);
+    cargo
+}
+
+fn module_features(cargo: &Cargo, package: &Package, debug: bool) -> Vec<String> {
+    let mut features = cargo.features.clone();
+    if let Some(log) = &cargo.log
+        && package.dependencies.iter().any(|dep| dep.name == "log")
+    {
+        features.push(format!(
+            "log/{}max_level_{}",
+            if effective_profile(cargo, debug) == CargoBuildProfile::Debug {
+                ""
+            } else {
+                "release_"
+            },
+            format!("{log:?}").to_lowercase()
+        ));
+    }
+    features.sort();
+    features.dedup();
+    features
+}
+
+fn remove_arg_value(args: &mut Vec<String>, key: &str) {
+    let mut out = Vec::with_capacity(args.len());
+    {
+        let mut iter = args.drain(..);
+        while let Some(arg) = iter.next() {
+            if arg == key {
+                let _ = iter.next();
+                continue;
+            }
+            out.push(arg);
+        }
+    }
+    *args = out;
+}
+
+fn cargo_build_module_rlib(workspace_root: &Path, cargo: &Cargo, debug: bool) -> Result<()> {
+    if let Some(extra_config) = &cargo.extra_config
+        && (extra_config.starts_with("http://") || extra_config.starts_with("https://"))
+    {
+        bail!("URL Cargo extra_config is not supported for kmod builds: {extra_config}");
+    }
+
+    let mut command = Command::new("cargo");
+    command
+        .arg("build")
+        .arg("-p")
+        .arg(&cargo.package)
+        .arg("--target")
+        .arg(&cargo.target)
+        .arg("-Z")
+        .arg("unstable-options")
+        .arg("--target-dir")
+        .arg(workspace_root.join("target"));
+
+    if let Some(extra_config) = &cargo.extra_config {
+        command.arg("--config").arg(extra_config);
+    }
+
+    if !cargo.features.is_empty() {
+        command.arg("--features").arg(cargo.features.join(","));
+    }
+
+    command.args(&cargo.args);
+
+    if effective_profile(cargo, debug) == CargoBuildProfile::Release {
+        command.arg("--release");
+    }
+
+    command.current_dir(workspace_root);
+    command.envs(&cargo.env);
+
+    let status = command
+        .status()
+        .with_context(|| format!("invoke cargo build for {}", cargo.package))?;
+    if !status.success() {
+        bail!("cargo build failed for {}", cargo.package);
+    }
+    Ok(())
+}
+
+fn effective_profile(cargo: &Cargo, debug: bool) -> CargoBuildProfile {
+    cargo.profile.unwrap_or(if debug {
+        CargoBuildProfile::Debug
+    } else {
+        CargoBuildProfile::Release
+    })
+}
+
+fn cargo_profile_dir(cargo: &Cargo, debug: bool) -> &'static str {
+    match effective_profile(cargo, debug) {
+        CargoBuildProfile::Debug => "debug",
+        CargoBuildProfile::Release => "release",
+    }
+}
+
+fn cargo_target_output_dir(
+    workspace_root: &Path,
+    cargo_target: &str,
+    profile: &str,
+) -> Result<PathBuf> {
+    let target_name = Path::new(cargo_target)
+        .file_stem()
+        .or_else(|| Path::new(cargo_target).file_name())
+        .and_then(|s| s.to_str())
+        .with_context(|| format!("invalid Cargo target `{cargo_target}`"))?;
+    Ok(workspace_root
+        .join("target")
+        .join(target_name)
+        .join(profile))
+}
+
+fn package_for_manifest<'a>(metadata: &'a Metadata, cargo_toml: &Path) -> Result<&'a Package> {
+    let wanted = cargo_toml
+        .canonicalize()
+        .with_context(|| format!("canonicalize {}", cargo_toml.display()))?;
+    metadata
+        .packages
+        .iter()
+        .find(|package| package.manifest_path.as_std_path() == wanted)
+        .with_context(|| {
+            format!(
+                "module manifest {} is not a workspace package",
+                cargo_toml.display()
+            )
+        })
+}
+
+fn lib_target_name(package: &Package) -> Result<&str> {
+    package
+        .targets
+        .iter()
+        .find(|target| {
+            target
+                .kind
+                .iter()
+                .any(|kind| matches!(kind, TargetKind::Lib))
+        })
+        .map(|target| target.name.as_str())
+        .with_context(|| format!("package `{}` does not define a lib target", package.name))
+}
+
+fn rust_crate_file_stem(name: &str) -> String {
+    name.replace('-', "_")
+}
+
+fn inject_modules_into_rootfs(
+    workspace_root: &Path,
+    rootfs: &Path,
+    modules: &[PathBuf],
+) -> Result<()> {
+    if modules.is_empty() {
+        return Ok(());
+    }
+    let rootfs = if rootfs.is_absolute() {
+        rootfs.to_path_buf()
+    } else {
+        workspace_root.join(rootfs)
+    };
+    if !rootfs.exists() {
+        bail!("rootfs image not found: {}", rootfs.display());
+    }
+
+    let overlay_dir = TempOverlayDir::new()?;
+    let modules_dir = overlay_dir.path().join("modules");
+    fs::create_dir_all(&modules_dir)
+        .with_context(|| format!("failed to create {}", modules_dir.display()))?;
+
+    for module in modules {
+        let file_name = module
+            .file_name()
+            .with_context(|| format!("invalid module path {}", module.display()))?;
+        let dest = modules_dir.join(file_name);
+        fs::copy(module, &dest).with_context(|| {
+            format!("failed to copy {} to {}", module.display(), dest.display())
+        })?;
+    }
+
+    crate::rootfs::inject::inject_overlay(&rootfs, overlay_dir.path())?;
+    println!(
+        "[kmod] injected {} module(s) into {}:/modules",
+        modules.len(),
+        rootfs.display()
+    );
+    Ok(())
+}
+
+struct TempOverlayDir {
+    path: PathBuf,
+}
+
+impl TempOverlayDir {
+    fn new() -> Result<Self> {
+        let base = std::env::temp_dir();
+        let pid = std::process::id();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+
+        for attempt in 0..100 {
+            let path = base.join(format!("axbuild-kmod-overlay-{pid}-{nanos}-{attempt}"));
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(err) => {
+                    return Err(err)
+                        .with_context(|| format!("failed to create {}", path.display()));
+                }
+            }
+        }
+
+        bail!("failed to create a unique temporary kmod overlay directory");
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempOverlayDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
 }
 
 /// Linker (and any leading args) for the partial-link (`-r`) step.
@@ -257,4 +648,131 @@ fn build_one_module(
 /// variable (e.g. to a GNU `ld`), in which case no flavor args are injected.
 fn pick_linker(_target_triple: &str) -> (&'static str, &'static [&'static str]) {
     ("rust-lld", &["-flavor", "gnu"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remove_arg_value_removes_bin_and_value() {
+        let mut args = vec![
+            "-Z".to_string(),
+            "build-std=core,alloc".to_string(),
+            "--bin".to_string(),
+            "starryos".to_string(),
+            "--message-format".to_string(),
+            "json".to_string(),
+        ];
+
+        remove_arg_value(&mut args, "--bin");
+
+        assert_eq!(
+            args,
+            vec![
+                "-Z".to_string(),
+                "build-std=core,alloc".to_string(),
+                "--message-format".to_string(),
+                "json".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn cargo_target_output_dir_uses_json_file_stem() {
+        let path = cargo_target_output_dir(
+            Path::new("/ws"),
+            "scripts/targets/std/riscv64gc-unknown-linux-musl.json",
+            "release",
+        )
+        .unwrap();
+
+        assert_eq!(
+            path,
+            Path::new("/ws")
+                .join("target")
+                .join("riscv64gc-unknown-linux-musl")
+                .join("release")
+        );
+    }
+
+    #[test]
+    fn rust_crate_file_stem_replaces_hyphens() {
+        assert_eq!(rust_crate_file_stem("my-module"), "my_module");
+    }
+
+    #[test]
+    fn linux_c_module_names_parse_obj_m_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let makefile = dir.path().join("Makefile");
+        fs::write(
+            &makefile,
+            r#"
+obj-m += linux-hello.o
+obj-m += second.o # comment
+ccflags-remove-y += -pg
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            linux_c_module_names(&makefile).unwrap(),
+            vec!["linux-hello".to_string(), "second".to_string()]
+        );
+    }
+
+    #[test]
+    fn discover_modules_finds_rust_and_linux_c_modules() {
+        let dir = tempfile::tempdir().unwrap();
+        let rust_module = dir.path().join("rust-module");
+        let c_module = dir.path().join("linux-module");
+        fs::create_dir_all(&rust_module).unwrap();
+        fs::create_dir_all(&c_module).unwrap();
+        fs::write(rust_module.join("Cargo.toml"), "[package]\nname = \"m\"\n").unwrap();
+        fs::write(c_module.join("Makefile"), "obj-m += linux-hello.o\n").unwrap();
+
+        let modules = discover_modules(dir.path()).unwrap();
+
+        assert!(modules.contains(&ModuleSpec::Rust(rust_module)));
+        assert!(modules.contains(&ModuleSpec::LinuxC(c_module)));
+    }
+
+    #[test]
+    fn linux_c_module_skips_when_arch_differs_from_host() {
+        let module = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let mismatched_arch = match normalized_host_arch() {
+            "x86_64" => "aarch64",
+            _ => "x86_64",
+        };
+
+        let built = build_one_linux_c_module(module.path(), mismatched_arch, out.path()).unwrap();
+
+        assert!(built.is_none());
+    }
+
+    #[test]
+    fn linux_c_make_args_pass_module_pwd_for_makefile_pwd_users() {
+        let module_path = Path::new("/ws/os/StarryOS/lkm/linux-hello");
+        let mut clean_args = linux_c_module_make_args(module_path);
+        clean_args.push("clean".to_string());
+
+        assert_eq!(
+            linux_c_module_make_args(module_path),
+            vec![
+                "-C".to_string(),
+                "/ws/os/StarryOS/lkm/linux-hello".to_string(),
+                "PWD=/ws/os/StarryOS/lkm/linux-hello".to_string()
+            ]
+        );
+        assert_eq!(
+            clean_args,
+            vec![
+                "-C".to_string(),
+                "/ws/os/StarryOS/lkm/linux-hello".to_string(),
+                "PWD=/ws/os/StarryOS/lkm/linux-hello".to_string(),
+                "clean".to_string()
+            ]
+        );
+    }
 }

--- a/scripts/axbuild/src/starry/kmod.rs
+++ b/scripts/axbuild/src/starry/kmod.rs
@@ -12,10 +12,9 @@
 //! architecture matches the host architecture.
 
 use std::{
-    fs, io,
+    fs,
     path::{Path, PathBuf},
     process::Command,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, bail};
@@ -573,7 +572,10 @@ fn inject_modules_into_rootfs(
         bail!("rootfs image not found: {}", rootfs.display());
     }
 
-    let overlay_dir = TempOverlayDir::new()?;
+    let overlay_dir = tempfile::Builder::new()
+        .prefix("axbuild-kmod-overlay-")
+        .tempdir()
+        .context("failed to create temporary kmod overlay directory")?;
     let modules_dir = overlay_dir.path().join("modules");
     fs::create_dir_all(&modules_dir)
         .with_context(|| format!("failed to create {}", modules_dir.display()))?;
@@ -595,45 +597,6 @@ fn inject_modules_into_rootfs(
         rootfs.display()
     );
     Ok(())
-}
-
-struct TempOverlayDir {
-    path: PathBuf,
-}
-
-impl TempOverlayDir {
-    fn new() -> Result<Self> {
-        let base = std::env::temp_dir();
-        let pid = std::process::id();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or_default();
-
-        for attempt in 0..100 {
-            let path = base.join(format!("axbuild-kmod-overlay-{pid}-{nanos}-{attempt}"));
-            match fs::create_dir(&path) {
-                Ok(()) => return Ok(Self { path }),
-                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
-                Err(err) => {
-                    return Err(err)
-                        .with_context(|| format!("failed to create {}", path.display()));
-                }
-            }
-        }
-
-        bail!("failed to create a unique temporary kmod overlay directory");
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl Drop for TempOverlayDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
 }
 
 /// Linker (and any leading args) for the partial-link (`-r`) step.

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -352,6 +352,7 @@ impl Starry {
     async fn build(&mut self, args: ArgsBuild) -> anyhow::Result<()> {
         let request =
             self.prepare_request((&args).into(), None, None, SnapshotPersistence::Store)?;
+        self.ensure_default_build_config_for_request(&request, "build")?;
         self.run_build_request(request).await
     }
 
@@ -362,17 +363,7 @@ impl Starry {
             None,
             SnapshotPersistence::Store,
         )?;
-        if let Some(board) = config::ensure_default_build_config_for_target(
-            self.app.workspace_root(),
-            &request.target,
-            &request.build_info_path,
-        )? {
-            println!(
-                "generated missing Starry qemu build config {} from board {}",
-                request.build_info_path.display(),
-                board.name
-            );
-        }
+        self.ensure_default_build_config_for_request(&request, "qemu")?;
         if let Some(rootfs) = args.rootfs {
             rootfs::qemu_with_explicit_rootfs(self, request, rootfs).await
         } else {
@@ -697,6 +688,25 @@ impl Starry {
             self.app.store_starry_snapshot(&snapshot)?;
         }
         Ok(request)
+    }
+
+    pub(super) fn ensure_default_build_config_for_request(
+        &self,
+        request: &ResolvedStarryRequest,
+        command: &str,
+    ) -> anyhow::Result<()> {
+        if let Some(board) = config::ensure_default_build_config_for_target(
+            self.app.workspace_root(),
+            &request.target,
+            &request.build_info_path,
+        )? {
+            println!(
+                "generated missing Starry {command} build config {} from board {}",
+                request.build_info_path.display(),
+                board.name
+            );
+        }
+        Ok(())
     }
 
     fn quick_start_build_args(arch: &str, config: PathBuf) -> StarryCliArgs {

--- a/scripts/targets/std/loongarch64-unknown-linux-musl.json
+++ b/scripts/targets/std/loongarch64-unknown-linux-musl.json
@@ -1,7 +1,7 @@
 {
   "abi": "softfloat",
   "arch": "loongarch64",
-  "code-model": "medium",
+  "code-model": "small",
   "crt-objects-fallback": "false",
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
   "eh-frame-header": false,

--- a/scripts/targets/std/pie/loongarch64-unknown-linux-musl.json
+++ b/scripts/targets/std/pie/loongarch64-unknown-linux-musl.json
@@ -1,7 +1,7 @@
 {
   "abi": "softfloat",
   "arch": "loongarch64",
-  "code-model": "medium",
+  "code-model": "small",
   "crt-objects-fallback": "false",
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
   "eh-frame-header": false,


### PR DESCRIPTION
- add StarryOS kmod build flow to axbuild
- build Rust kmods with the resolved Starry target, features, axconfig, and environment
- support Linux C kmods through module Makefiles when host arch matches target arch
- write `.ko` files next to the kernel ELF and support rootfs injection
- add kmod examples and module authoring documentation under os/StarryOS/lkm
- preserve kmod export anchors through a dedicated linker section
- update kmod dependencies to 0.3
- set LoongArch64 std target code model to small
- move default managed rootfs storage into tmp/axbuild/rootfs

Important notes:
- Rust kmods must share the kernel build context; otherwise Rust/core/alloc symbols and platform features can diverge from the kernel ELF.
- Release LTO must stay disabled for kernels expected to load Rust kmods.
- Linux C kmods are built only for matching host/Starry architectures because the sample Makefile uses the host Linux Kbuild tree.
- LoongArch64 std targets use `code-model = small` to match Linux's LoongArch Rust kernel build, which passes `-Ccode-model=small` through KBUILD_RUSTFLAGS. Keeping this in the target JSON makes the code model a property of the target instead of an axbuild-only special case.
- The rootfs cache no longer defaults to /tmp. That path is volatile on WSL, CI, tmpfs-backed hosts, and after reboot, which causes downloaded rootfs images to disappear and makes local StarryOS testing unnecessarily non-reproducible. Storing managed images under the workspace tmp directory keeps the cache tied to the checkout, persistent across reboot, easy to inspect, and easy to clean.
- TGOS_IMAGE_LOCAL_STORAGE still allows users to opt into a shared cache path.