### PR TITLE
fix(starry): assign the init process real PID 1

### DIFF
--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -55,7 +55,16 @@ pub fn init(args: &[String], envs: &[String]) {
     let mut task = new_user_task(&name, uctx, 0);
     task.ctx_mut().set_page_table_root(uspace.page_table_root());
 
-    let pid = task.id().as_u64() as Pid;
+    // PID 1 must really be 1: the init process is the root of the process
+    // hierarchy and userspace (e.g. systemd's `getpid() == 1` system-manager
+    // check) relies on it. The scheduler task id is an internal counter that is
+    // already past 1 by the time we spawn the user init (kernel helper tasks
+    // took the low ids), so we pin the user-visible pid/tid to 1 and leave the
+    // scheduler id untouched. `Thread::tid` is already decoupled from the
+    // scheduler id (see its field doc), so this only requires the table keys to
+    // follow the thread tid rather than `task.id()`.
+    const INIT_PID: Pid = 1;
+    let pid = INIT_PID;
     let proc = Process::new_init(pid);
     proc.add_thread(pid);
 

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -17,6 +17,8 @@ use ax_runtime::hal::cpu::uspace::UserContext;
 use starry_signal::Signo;
 use syscalls::Sysno;
 
+use crate::task::AsThread;
+
 pub use self::{
     fs::*, io_mpx::*, ipc::*, mm::*, net::*, ns::*, resources::*, signal::*, sync::*, sys::*,
     task::*, time::*,
@@ -947,7 +949,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::timer_delete => sys_timer_delete(uctx.arg0() as _),
 
         _ => {
-            let tid = ax_task::current().id().as_u64() as u32;
+            let tid = ax_task::current().as_thread().tid();
             warn!("Unimplemented syscall: {sysno} (tid={tid})");
             Err(AxError::Unsupported)
         }

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -17,8 +17,6 @@ use ax_runtime::hal::cpu::uspace::UserContext;
 use starry_signal::Signo;
 use syscalls::Sysno;
 
-use crate::task::AsThread;
-
 pub use self::{
     fs::*, io_mpx::*, ipc::*, mm::*, net::*, ns::*, resources::*, signal::*, sync::*, sys::*,
     task::*, time::*,

--- a/os/StarryOS/kernel/src/syscall/signal.rs
+++ b/os/StarryOS/kernel/src/syscall/signal.rs
@@ -177,7 +177,7 @@ pub fn sys_kill(pid: i32, signo: u32) -> AxResult<isize> {
                     // self-signals so `kill(getpid(), SIGSTOP)` cannot return
                     // to userspace and race into the next syscall before this
                     // thread observes the stop.
-                    send_signal_to_thread(None, curr.id().as_u64() as Pid, Some(sig))?;
+                    send_signal_to_thread(None, thread.tid() as Pid, Some(sig))?;
                 } else {
                     send_signal_to_process(pid as _, Some(sig))?;
                 }

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -372,7 +372,10 @@ impl CloneArgs {
         }
 
         let parent_pid = curr.as_thread().proc_data.proc.pid();
-        let parent_tid = curr.id().as_u64() as Pid;
+        // The user-visible tid, not the scheduler id: they diverge for the init
+        // process (pid/tid pinned to 1, scheduler id higher). Signal delivery
+        // and ptrace below look this up in the tid-keyed task table.
+        let parent_tid = curr.as_thread().tid() as Pid;
         let ptrace_event = if flags.contains(CloneFlags::THREAD) {
             super::ptrace::PTRACE_EVENT_CLONE
         } else if flags.contains(CloneFlags::VFORK) {

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -88,12 +88,17 @@ pub fn cleanup_task_tables() {
 /// Add the task, the thread and possibly its process, process group and session
 /// to the corresponding tables.
 pub fn add_task_to_table(task: &AxTaskRef) {
-    let tid = task.id().as_u64() as Pid;
+    // Key by the user-visible thread tid, not the scheduler `task.id()`. The two
+    // are equal for every task except the init process, whose pid/tid is pinned
+    // to 1 while its scheduler id stays at whatever the allocator handed out
+    // (see `entry::init`). All tid lookups (signals, get_task, ptrace) go
+    // through this table, so they must agree with `Thread::tid`.
+    let proc_data = &task.as_thread().proc_data;
+    let tid = task.as_thread().tid() as Pid;
 
     let mut task_table = TASK_TABLE.write();
     task_table.insert(tid, task);
 
-    let proc_data = &task.as_thread().proc_data;
     let proc = &proc_data.proc;
     let pid = proc.pid();
     let mut proc_table = PROCESS_TABLE.write();

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -19,7 +19,7 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
             let curr = ax_task::current();
 
             if let Some(tid) = (set_child_tid as *mut Pid).nullable() {
-                tid.vm_write(curr.id().as_u64() as Pid).ok();
+                tid.vm_write(curr.as_thread().tid() as Pid).ok();
             }
 
             info!("Enter user space: ip={:#x}, sp={:#x}", uctx.ip(), uctx.sp());

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-proc-init-pid/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-proc-init-pid/src/main.c
@@ -1,6 +1,9 @@
+#define _POSIX_C_SOURCE 200809L
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -81,6 +84,24 @@ int main(void)
     check(nread > 0, "/proc/1/cmdline is non-empty");
     if (nread <= 0) {
         printf("INFO: read /proc/1/cmdline failed: %s\n", strerror(errno));
+    }
+
+    errno = 0;
+    check(kill(1, 0) == 0, "kill(1, 0) finds a real process at PID 1");
+    if (errno != 0) {
+        printf("INFO: kill(1, 0) errno: %s\n", strerror(errno));
+    }
+
+    errno = 0;
+    check(getpgid(1) == 1, "getpgid(1) returns 1 (init leads process group 1)");
+    if (errno != 0) {
+        printf("INFO: getpgid(1) errno: %s\n", strerror(errno));
+    }
+
+    errno = 0;
+    check(getsid(1) == 1, "getsid(1) returns 1 (init leads session 1)");
+    if (errno != 0) {
+        printf("INFO: getsid(1) errno: %s\n", strerror(errno));
     }
 
     printf("RESULT: %d passed / %d failed\n", passed, failed);


### PR DESCRIPTION


将 init 进程的 pid/tid 钉为 1，与调度器 id 解耦（`Thread::tid` 本就支持 与调度器 id 不同）。`add_task_to_table` 等"拿调度器 id 当 tid"的站点改用 `Thread::tid`，使 TASK_TABLE 的 key 与用户可见 tid 一致。