### PR TITLE
fix(starry): address fd table, wait, and timerfd regressions

### DIFF
--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -70,6 +70,7 @@ pub fn init(args: &[String], envs: &[String]) {
         Arc::new(Mutex::new(uspace)),
         Arc::default(),
         None,
+        pid,
         false,
     );
 

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -1,8 +1,7 @@
 use alloc::{format, string::ToString, sync::Arc};
 use core::{
     ffi::{c_char, c_int},
-    mem,
-    ops::{Deref, DerefMut},
+    ops::DerefMut,
 };
 
 use ax_errno::{AxError, AxResult};
@@ -376,12 +375,12 @@ pub fn sys_close_range(first: i32, last: i32, flags: u32) -> AxResult<isize> {
     let flags = CloseRangeFlags::from_bits(flags).ok_or(AxError::InvalidInput)?;
     debug!("sys_close_range <= fds: [{first}, {last}], flags: {flags:?}");
     if flags.contains(CloseRangeFlags::UNSHARE) {
-        // TODO: optimize
         let curr = current();
-        let mut scope = curr.as_thread().proc_data.scope.write();
-        let mut guard = FD_TABLE.scope_mut(&mut scope);
-        let old_files = mem::take(guard.deref_mut());
-        old_files.write().clone_from(old_files.read().deref());
+        let proc_data = &curr.as_thread().proc_data;
+        let new_files = Arc::new(spin::RwLock::new(FD_TABLE.read().clone()));
+        proc_data.with_current_scope_mut(|scope| {
+            *FD_TABLE.scope_mut(scope).deref_mut() = new_files;
+        });
     }
 
     let cloexec = flags.contains(CloseRangeFlags::CLOEXEC);

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -255,6 +255,7 @@ impl CloneArgs {
                 aspace,
                 signal_actions,
                 exit_signal,
+                curr_thread.tid(),
                 flags.contains(CloneFlags::VM),
             );
             proc_data.set_umask(old_proc_data.umask());

--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -19,7 +19,8 @@ use crate::{
     file::{PidFd, get_file_like},
     task::{
         AsThread, JobStatus, ProcessData, decode_wait_status, get_process_data, get_task,
-        get_zombie_cred, processes, remove_process, traced_zombies_for, unregister_zombie,
+        get_zombie_cred, is_zombie_clone_child, processes, remove_process, traced_zombies_for,
+        unregister_zombie, zombie_wait_parent_tid,
     },
 };
 
@@ -143,11 +144,65 @@ fn child_uid(child: &Process) -> u32 {
         .unwrap_or(0)
 }
 
-fn waitable_processes(proc: &Process, target: WaitTarget, tracer_pid: Pid) -> Vec<Arc<Process>> {
+#[derive(Debug, Clone, Copy)]
+struct WaitChildFilter {
+    wall: bool,
+    clone: bool,
+    no_thread: bool,
+}
+
+impl WaitChildFilter {
+    fn from_waitpid_options(options: &WaitPidOptions) -> Self {
+        Self {
+            wall: options.contains(WaitPidOptions::WALL),
+            clone: options.contains(WaitPidOptions::WCLONE),
+            no_thread: options.contains(WaitPidOptions::WNOTHREAD),
+        }
+    }
+
+    fn from_waitid_options(options: &WaitIdOptions) -> Self {
+        Self {
+            wall: options.contains(WaitIdOptions::WALL),
+            clone: options.contains(WaitIdOptions::WCLONE),
+            no_thread: options.contains(WaitIdOptions::WNOTHREAD),
+        }
+    }
+
+    fn matches_clone_kind(&self, is_clone_child: bool) -> bool {
+        self.wall || is_clone_child == self.clone
+    }
+
+    fn matches_process(&self, child: &Process, current_tid: Pid) -> bool {
+        if self.no_thread {
+            let wait_parent_tid = get_process_data(child.pid())
+                .ok()
+                .map(|data| data.wait_parent_tid)
+                .or_else(|| zombie_wait_parent_tid(child.pid()));
+            if wait_parent_tid != Some(current_tid) {
+                return false;
+            }
+        }
+
+        let is_clone_child = get_process_data(child.pid())
+            .ok()
+            .map(|data| data.is_clone_child())
+            .or_else(|| is_zombie_clone_child(child.pid()))
+            .unwrap_or(false);
+        self.matches_clone_kind(is_clone_child)
+    }
+}
+
+fn waitable_processes(
+    proc: &Process,
+    target: WaitTarget,
+    tracer_pid: Pid,
+    current_tid: Pid,
+    filter: WaitChildFilter,
+) -> Vec<Arc<Process>> {
     let mut candidates = proc
         .children()
         .into_iter()
-        .filter(|child| target.matches(child))
+        .filter(|child| target.matches(child) && filter.matches_process(child, current_tid))
         .collect::<Vec<_>>();
 
     for data in processes() {
@@ -155,6 +210,7 @@ fn waitable_processes(proc: &Process, target: WaitTarget, tracer_pid: Pid) -> Ve
         let proc = data.proc.clone();
         if traced
             && target.matches_process_or_thread(&proc)
+            && filter.matches_process(&proc, current_tid)
             && !candidates
                 .iter()
                 .any(|candidate| candidate.pid() == proc.pid())
@@ -165,6 +221,7 @@ fn waitable_processes(proc: &Process, target: WaitTarget, tracer_pid: Pid) -> Ve
 
     for zombie in traced_zombies_for(tracer_pid) {
         if target.matches(&zombie)
+            && filter.matches_process(&zombie, current_tid)
             && !candidates
                 .iter()
                 .any(|candidate| candidate.pid() == zombie.pid())
@@ -181,7 +238,8 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
     info!("sys_waitpid <= pid: {pid:?}, options: {options:?}");
 
     let curr = current();
-    let proc = &curr.as_thread().proc_data.proc;
+    let thr = curr.as_thread();
+    let proc = &thr.proc_data.proc;
 
     let target = if pid == -1 {
         WaitTarget::Any
@@ -193,7 +251,13 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
         WaitTarget::Pgid(-pid as _)
     };
 
-    let children = waitable_processes(proc, target, proc.pid());
+    let children = waitable_processes(
+        proc,
+        target,
+        proc.pid(),
+        thr.tid(),
+        WaitChildFilter::from_waitpid_options(&options),
+    );
     if children.is_empty() {
         return Err(AxError::from(LinuxError::ECHILD));
     }
@@ -300,7 +364,8 @@ pub fn sys_waitid(
     options: u32,
 ) -> AxResult<isize> {
     let curr = current();
-    let proc = &curr.as_thread().proc_data.proc;
+    let thr = curr.as_thread();
+    let proc = &thr.proc_data.proc;
 
     // Validate idtype
     let target = match idtype {
@@ -335,7 +400,13 @@ pub fn sys_waitid(
 
     info!("sys_waitid <= idtype: {idtype}, id: {id}, options: {options:?}");
 
-    let children = waitable_processes(proc, target, proc.pid());
+    let children = waitable_processes(
+        proc,
+        target,
+        proc.pid(),
+        thr.tid(),
+        WaitChildFilter::from_waitid_options(&options),
+    );
     if children.is_empty() {
         return Err(AxError::from(LinuxError::ECHILD));
     }

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -25,7 +25,7 @@ use extern_trait::extern_trait;
 use kernel_elf_parser::AuxEntry;
 use scope_local::{ActiveScope, Scope};
 use spin::RwLock;
-use starry_process::Process;
+use starry_process::{Pid, Process};
 use starry_signal::{
     SignalInfo, SignalSet, Signo,
     api::{ProcessSignalManager, SignalActions, ThreadSignalManager},
@@ -611,6 +611,12 @@ pub struct ProcessData {
     pub exec_lock: Mutex<()>,
     /// The exit signal of the thread
     pub exit_signal: Option<Signo>,
+    /// The thread in the parent thread group that created this process.
+    ///
+    /// Linux's `__WNOTHREAD` wait option restricts child selection to children
+    /// created by the calling thread, while the default wait may reap children
+    /// created by any thread in the same thread group.
+    pub wait_parent_tid: Pid,
 
     /// The process signal manager
     pub signal: Arc<ProcessSignalManager>,
@@ -736,6 +742,7 @@ impl ProcessData {
         aspace: Arc<Mutex<AddrSpace>>,
         signal_actions: Arc<SpinNoIrq<SignalActions>>,
         exit_signal: Option<Signo>,
+        wait_parent_tid: Pid,
         vm_aspace_shared: bool,
     ) -> Arc<Self> {
         let this = Arc::new(Self {
@@ -756,6 +763,7 @@ impl ProcessData {
             thread_exit_event: Arc::default(),
             exec_lock: Mutex::new(()),
             exit_signal,
+            wait_parent_tid,
 
             signal: Arc::new(ProcessSignalManager::new(
                 signal_actions,

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -839,6 +839,23 @@ impl ProcessData {
         crate::mm::release_process_slot(&aspace);
     }
 
+    /// Mutate the process scope from the current task.
+    ///
+    /// `TaskExt::on_enter` leaves the current task's active scope installed by
+    /// holding one read count on [`Self::scope`]. A syscall running in that task
+    /// must temporarily release that read count before taking the write side.
+    pub fn with_current_scope_mut<R>(&self, f: impl FnOnce(&mut Scope) -> R) -> R {
+        ActiveScope::set_global();
+        unsafe { self.scope.force_read_decrement() };
+        let mut scope = self.scope.write();
+        let ret = f(&mut scope);
+        drop(scope);
+        let scope = self.scope.read();
+        unsafe { ActiveScope::set(&scope) };
+        core::mem::forget(scope);
+        ret
+    }
+
     /// Get the top address of the user heap.
     pub fn get_heap_top(&self) -> usize {
         self.heap_top.load(Ordering::Acquire)

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -58,6 +58,8 @@ struct ZombieEntry {
     proc: Arc<Process>,
     cred: Arc<Cred>,
     ptrace_tracer_pid: Option<Pid>,
+    is_clone_child: bool,
+    wait_parent_tid: Pid,
 }
 
 /// Zombie processes: exited but not yet reaped by waitpid().
@@ -161,6 +163,8 @@ pub fn register_zombie(
     proc: Arc<Process>,
     cred: Arc<Cred>,
     ptrace_tracer_pid: Option<Pid>,
+    is_clone_child: bool,
+    wait_parent_tid: Pid,
 ) {
     ZOMBIE_TABLE.write().insert(
         pid,
@@ -168,6 +172,8 @@ pub fn register_zombie(
             proc,
             cred,
             ptrace_tracer_pid,
+            is_clone_child,
+            wait_parent_tid,
         },
     );
 }
@@ -199,6 +205,14 @@ pub fn get_zombie_process(pid: Pid) -> Option<Arc<Process>> {
 /// (and its `cred`) lives until the zombie is reaped by `waitpid`.
 pub fn get_zombie_cred(pid: Pid) -> Option<Arc<Cred>> {
     ZOMBIE_TABLE.read().get(&pid).map(|e| e.cred.clone())
+}
+
+pub fn is_zombie_clone_child(pid: Pid) -> Option<bool> {
+    ZOMBIE_TABLE.read().get(&pid).map(|e| e.is_clone_child)
+}
+
+pub fn zombie_wait_parent_tid(pid: Pid) -> Option<Pid> {
+    ZOMBIE_TABLE.read().get(&pid).map(|e| e.wait_parent_tid)
 }
 
 pub fn traced_zombies_for(tracer_pid: Pid) -> Vec<Arc<Process>> {
@@ -559,11 +573,15 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
         // after the task has been GC'd (mirrors Linux task_struct lifetime).
         let zombie_cred = thr.cred();
         let ptrace_tracer_pid = thr.proc_data.ptrace_tracer_pid();
+        let is_clone_child = thr.proc_data.is_clone_child();
+        let wait_parent_tid = thr.proc_data.wait_parent_tid;
         register_zombie(
             process.pid(),
             process.clone(),
             zombie_cred,
             ptrace_tracer_pid,
+            is_clone_child,
+            wait_parent_tid,
         );
         process.exit();
         if let Some(parent) = process.parent() {

--- a/test-suit/starryos/qemu-smp1/system/KNOWN_FAILS.md
+++ b/test-suit/starryos/qemu-smp1/system/KNOWN_FAILS.md
@@ -19,7 +19,6 @@ but the grouped CI runner only executes `/usr/bin/starry-test-suit/*`.
 - `test-splice`: offset and same-pipe edge cases.
 - `test-sync-file-range`: errno precedence for invalid fd plus invalid flags.
 - `test-tgsigqueueinfo`: queued thread signal delivery with `siginfo`.
-- `test-timerfd`: multi-reader single-consumer timerfd expiration semantics.
 - `test-uid-gid-direct-setters`: uid/gid setter boundary matrix semantics.
 - `test-uid-gid-groups`: user namespace `setgroups=deny` behavior.
 - `test-uid-gid-res-setters`: setresuid/setresgid boundary matrix semantics.

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-timerfd/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-timerfd/CMakeLists.txt
@@ -6,6 +6,4 @@ set(CMAKE_C_EXTENSIONS OFF)
 add_executable(test-timerfd src/main.c)
 target_include_directories(test-timerfd PRIVATE src)
 target_compile_options(test-timerfd PRIVATE -Wall -Wextra -Werror)
-# Build this stricter probe, but keep it out of the grouped CI pass condition
-# until timerfd's multi-reader single-consumer semantics are complete.
-install(TARGETS test-timerfd RUNTIME DESTINATION usr/bin/starry-known-fail)
+install(TARGETS test-timerfd RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-timerfd/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-timerfd/src/main.c
@@ -221,25 +221,23 @@ int main(void) {
     CHECK(bexp >= 1, "preserved expiration count >= 1 after failed read");
     close(bfd);
 
-    /* Concurrent-reader single-consumer semantics: a batch of pending
-     * expirations must be claimed in full by exactly one read(). Linux's
-     * timerfd_read takes the timerfd spinlock across the count clear so
-     * two parallel readers cannot both observe the same ticks. Reproduce
-     * by forking once parent + child share the same open file
-     * description, racing on a TFD_NONBLOCK read, and reporting their
-     * counts back through a pipe. The pre-fork accumulated count must
-     * equal the sum across both, and at most one side may have a
-     * non-zero result. */
+    /* Concurrent-reader single-consumer semantics: a pending expiration must
+     * be claimed in full by exactly one read(). Use a one-shot timer so no
+     * new tick can appear between the parent and child reads and make the
+     * test result depend only on timerfd count consumption. */
     int cfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
     CHECK(cfd >= 0, "create CLOCK_MONOTONIC TFD_NONBLOCK for concurrency");
     struct itimerspec cspec = {
-        .it_interval = {0, 10 * 1000 * 1000},  /* 10ms */
+        .it_interval = {0, 0},
         .it_value    = {0, 10 * 1000 * 1000},
     };
     CHECK_RET(timerfd_settime(cfd, 0, &cspec, NULL), 0,
-              "settime periodic 10ms for concurrency");
-    struct timespec accum_sleep = {.tv_sec = 0, .tv_nsec = 80 * 1000 * 1000};
-    nanosleep(&accum_sleep, NULL);
+              "settime oneshot 10ms for concurrency");
+
+    struct pollfd cpf = {.fd = cfd, .events = POLLIN};
+    int cpr = poll(&cpf, 1, 500);
+    CHECK(cpr == 1 && (cpf.revents & POLLIN),
+          "one-shot concurrency timer became readable");
 
     int pipefd[2];
     CHECK_RET(pipe(pipefd), 0, "pipe for concurrent-reader coordination");
@@ -267,10 +265,10 @@ int main(void) {
     read(pipefd[0], &child_got, sizeof(child_got));
     close(pipefd[0]);
     waitpid(pid, NULL, 0);
-    CHECK(parent_got > 0 || child_got > 0,
-          "at least one concurrent reader saw expirations");
+    CHECK(parent_got + child_got == 1,
+          "exactly one expiration consumed by concurrent readers");
     CHECK(parent_got == 0 || child_got == 0,
-          "single-consumer: only one reader observed the batch");
+          "single-consumer: only one reader observed the expiration");
     /* Disarm before close so any deferred timer task stops touching cfd. */
     struct itimerspec cdisarm = {.it_interval = {0, 0}, .it_value = {0, 0}};
     timerfd_settime(cfd, 0, &cdisarm, NULL);

--- a/test-suit/starryos/qemu-smp1/system/test-close-range/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-close-range/src/main.c
@@ -5,6 +5,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <sched.h>
 #include <string.h>
 #include <errno.h>
 
@@ -16,6 +19,12 @@ int __observe = 0;
 #ifndef CLOSE_RANGE_CLOEXEC
 #define CLOSE_RANGE_CLOEXEC (1U << 2)
 #endif
+
+#ifndef CLOSE_RANGE_UNSHARE
+#define CLOSE_RANGE_UNSHARE (1U << 1)
+#endif
+
+#define STACK_SIZE (64 * 1024)
 
 static int do_close_range(unsigned int first, unsigned int last, unsigned int flags)
 {
@@ -222,6 +231,66 @@ static int part_05_negative(void)
     return 0;
 }
 
+static int close_range_unshare_child(void *arg)
+{
+    int fd = (int)(long)arg;
+    int ret = do_close_range((unsigned int)fd, (unsigned int)fd, CLOSE_RANGE_UNSHARE);
+    if (ret != 0) {
+        _exit(10);
+    }
+    errno = 0;
+    if (fcntl(fd, F_GETFD) != -1 || errno != EBADF) {
+        _exit(11);
+    }
+    _exit(0);
+}
+
+/* Part 6: CLOSE_RANGE_UNSHARE must detach the fd table before closing. */
+static int part_06_unshare_keeps_parent_fd(void)
+{
+    unlink(TMPFILE);
+    CHECK_RET(create_temp_file("close_range_unshare"), 0,
+              "Part 6: create temp file");
+
+    int fd = open(TMPFILE, O_RDONLY);
+    CHECK_TRUE(fd >= 0, "Part 6: open shared fd");
+    if (fd < 0) {
+        unlink(TMPFILE);
+        return 1;
+    }
+
+    void *stack = mmap(NULL, STACK_SIZE, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK_TRUE(stack != MAP_FAILED, "Part 6: allocate clone stack");
+    if (stack == MAP_FAILED) {
+        safe_close(&fd);
+        unlink(TMPFILE);
+        return 1;
+    }
+
+    int child = clone(close_range_unshare_child, (char *)stack + STACK_SIZE,
+                      CLONE_FILES | SIGCHLD, (void *)(long)fd);
+    CHECK_TRUE(child >= 0, "Part 6: clone with CLONE_FILES");
+
+    int status = 0;
+    if (child >= 0) {
+        CHECK_TRUE(waitpid(child, &status, 0) == child,
+                   "Part 6: wait clone child");
+        CHECK_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0,
+                   "Part 6: child closed only its unshared fd table");
+    }
+
+    char buf[1] = {0};
+    errno = 0;
+    ssize_t n = read(fd, buf, sizeof(buf));
+    CHECK_TRUE(n == 1, "Part 6: parent fd remains readable after child unshare close");
+
+    safe_close(&fd);
+    munmap(stack, STACK_SIZE);
+    unlink(TMPFILE);
+    return 0;
+}
+
 int main(void)
 {
     TEST_START("close_range: semantic validation");
@@ -231,6 +300,7 @@ int main(void)
     part_03_empty_fd_range();
     part_04_cloexec();
     part_05_negative();
+    part_06_unshare_keeps_parent_fd();
 
     TEST_DONE();
 }

--- a/test-suit/starryos/qemu-smp1/system/test-wait-clone-options/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/test-wait-clone-options/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-wait-clone-options C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(test-wait-clone-options src/main.c)
+target_compile_options(test-wait-clone-options PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-wait-clone-options RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/test-wait-clone-options/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-wait-clone-options/src/main.c
@@ -1,0 +1,211 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef __WCLONE
+#define __WCLONE 0x80000000
+#endif
+#ifndef __WALL
+#define __WALL 0x40000000
+#endif
+
+#define STACK_SIZE (64 * 1024)
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static void sigusr1_handler(int signo)
+{
+    (void)signo;
+}
+
+static int exit_code_child(void *arg)
+{
+    _exit((int)(long)arg);
+}
+
+static pid_t spawn_clone_child(int exit_code, int exit_signal, void **stack_out)
+{
+    void *stack = mmap(NULL, STACK_SIZE, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (stack == MAP_FAILED) {
+        return -1;
+    }
+
+    pid_t pid = clone(exit_code_child, (char *)stack + STACK_SIZE, exit_signal,
+                      (void *)(long)exit_code);
+    if (pid < 0) {
+        munmap(stack, STACK_SIZE);
+        return -1;
+    }
+    *stack_out = stack;
+    return pid;
+}
+
+static int wait_for_exit(pid_t pid, int options, int expected_status,
+                         const char *name)
+{
+    int status = 0;
+    errno = 0;
+    pid_t got = waitpid(pid, &status, options);
+    if (got != pid) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "waitpid got=%ld errno=%d (%s), expected %ld",
+                 (long)got, errno, strerror(errno), (long)pid);
+        note_fail(name, buf);
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != expected_status) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "status=0x%x, expected exit %d", status,
+                 expected_status);
+        note_fail(name, buf);
+        return -1;
+    }
+    note_pass(name);
+    return 0;
+}
+
+static void cleanup_stack(void **stack)
+{
+    if (*stack != NULL && *stack != MAP_FAILED) {
+        munmap(*stack, STACK_SIZE);
+        *stack = NULL;
+    }
+}
+
+static void test_clone_filter_waitpid(void)
+{
+    void *sigchld_stack = NULL;
+    void *clone_stack = NULL;
+    pid_t sigchld_child = spawn_clone_child(21, SIGCHLD, &sigchld_stack);
+    pid_t clone_child = spawn_clone_child(22, SIGUSR1, &clone_stack);
+    if (sigchld_child < 0 || clone_child < 0) {
+        note_fail("setup waitpid clone filters", "clone failed");
+        if (sigchld_child > 0) waitpid(sigchld_child, NULL, __WALL);
+        if (clone_child > 0) waitpid(clone_child, NULL, __WALL);
+        cleanup_stack(&sigchld_stack);
+        cleanup_stack(&clone_stack);
+        return;
+    }
+
+    if (wait_for_exit(sigchld_child, 0, 21,
+                      "waitpid default reaps SIGCHLD child") != 0) {
+        waitpid(clone_child, NULL, __WALL);
+        cleanup_stack(&sigchld_stack);
+        cleanup_stack(&clone_stack);
+        return;
+    }
+
+    errno = 0;
+    int status = 0;
+    pid_t got = waitpid(clone_child, &status, WNOHANG);
+    if (got == -1 && errno == ECHILD) {
+        note_pass("waitpid default ignores non-SIGCHLD clone child");
+    } else {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "waitpid got=%ld status=0x%x errno=%d (%s)",
+                 (long)got, status, errno, strerror(errno));
+        note_fail("waitpid default ignores non-SIGCHLD clone child", buf);
+    }
+
+    wait_for_exit(clone_child, __WCLONE, 22,
+                  "waitpid __WCLONE reaps non-SIGCHLD clone child");
+    cleanup_stack(&sigchld_stack);
+    cleanup_stack(&clone_stack);
+}
+
+static void test_wall_waitpid(void)
+{
+    void *stack = NULL;
+    pid_t pid = spawn_clone_child(23, SIGUSR1, &stack);
+    if (pid < 0) {
+        note_fail("waitpid __WALL setup", "clone failed");
+        cleanup_stack(&stack);
+        return;
+    }
+    wait_for_exit(pid, __WALL, 23, "waitpid __WALL reaps clone child");
+    cleanup_stack(&stack);
+}
+
+static void test_waitid_clone_filter(void)
+{
+    void *stack = NULL;
+    pid_t pid = spawn_clone_child(24, SIGUSR1, &stack);
+    if (pid < 0) {
+        note_fail("waitid __WCLONE setup", "clone failed");
+        cleanup_stack(&stack);
+        return;
+    }
+
+    siginfo_t si;
+    memset(&si, 0, sizeof(si));
+    errno = 0;
+    int ret = waitid(P_PID, pid, &si, WEXITED | WNOHANG);
+    if (ret == -1 && errno == ECHILD) {
+        note_pass("waitid default ignores non-SIGCHLD clone child");
+    } else {
+        char buf[200];
+        snprintf(buf, sizeof(buf), "ret=%d si_pid=%ld errno=%d (%s)", ret,
+                 (long)si.si_pid, errno, strerror(errno));
+        note_fail("waitid default ignores non-SIGCHLD clone child", buf);
+    }
+
+    memset(&si, 0, sizeof(si));
+    errno = 0;
+    ret = waitid(P_PID, pid, &si, WEXITED | __WCLONE);
+    if (ret == 0 && si.si_pid == pid && si.si_code == CLD_EXITED &&
+        si.si_status == 24) {
+        note_pass("waitid __WCLONE reaps non-SIGCHLD clone child");
+    } else {
+        char buf[240];
+        snprintf(buf, sizeof(buf),
+                 "ret=%d si_pid=%ld si_code=%d si_status=%d errno=%d (%s)",
+                 ret, (long)si.si_pid, si.si_code, si.si_status, errno,
+                 strerror(errno));
+        note_fail("waitid __WCLONE reaps non-SIGCHLD clone child", buf);
+        waitpid(pid, NULL, __WALL);
+    }
+    cleanup_stack(&stack);
+}
+
+int main(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigusr1_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    sigset_t blocked;
+    sigemptyset(&blocked);
+    sigaddset(&blocked, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &blocked, NULL);
+
+    printf("=== test-wait-clone-options ===\n");
+    test_clone_filter_waitpid();
+    test_wall_waitpid();
+    test_waitid_clone_filter();
+    printf("=== test-wait-clone-options: passed=%d failed=%d ===\n",
+           passed, failed);
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
  ## Problem

  This PR fixes some issues in starry:

  1. `close_range(CLOSE_RANGE_UNSHARE)` did not properly unshare the fd table.
  2. `waitpid` / `waitid` did not filter waitable children according to `__WCLONE`, `__WALL`, and `__WNOTHREAD`.
  3. The timerfd concurrent-reader test used a periodic timer, so a new tick could arrive between parent/child reads and cause
  flaky failures.

  ## Changes

  - Create and switch to a private fd table for `CLOSE_RANGE_UNSHARE` before applying close/CLOEXEC operations.
  - Track each child’s clone-wait classification and creator parent tid, then apply the wait filter to live, zombie, and
  traced children.
  - Add `test-wait-clone-options` to cover `__WCLONE` and `__WALL` behavior.
  - Change the timerfd concurrent-reader probe to use a one-shot timer, making the single-consumer assertion deterministic.
  - Move the timerfd test from known-fail back into the normal `starry-test-suit`.
