### PR TITLE
fix(axtask): use monotonic deadlines for sleeps

### DIFF
--- a/net/ax-net/src/service.rs
+++ b/net/ax-net/src/service.rs
@@ -4,7 +4,7 @@ use core::{
     task::{Context, Waker},
 };
 
-use ax_hal::time::{NANOS_PER_MICROS, TimeValue, wall_time_nanos};
+use ax_hal::time::{NANOS_PER_MICROS, TimeValue, monotonic_time_nanos, wall_time_nanos};
 use ax_task::future::sleep_until;
 use smoltcp::{
     iface::{Interface, SocketSet},
@@ -22,7 +22,7 @@ use crate::{
 };
 
 fn now() -> Instant {
-    Instant::from_micros_const((wall_time_nanos() / NANOS_PER_MICROS) as i64)
+    Instant::from_micros_const((monotonic_time_nanos() / NANOS_PER_MICROS) as i64)
 }
 
 pub struct Service {

--- a/os/StarryOS/kernel/src/file/timerfd.rs
+++ b/os/StarryOS/kernel/src/file/timerfd.rs
@@ -9,18 +9,14 @@
 //! background task (via `ax_task::spawn_raw`) that owns a weak reference to
 //! the Timerfd. The task loops, reading the current deadline under the state
 //! lock, then parks on whichever fires first: the deadline (via
-//! `sleep_until`) or an "arm event" poked by `settime` / `Drop`. One task
+//! `timeout_at_wall`) or an "arm event" poked by `settime` / `Drop`. One task
 //! per timerfd over its whole lifetime — no per-settime stack leak.
 //!
 //! Missed-tick coalescing: if the scheduler delays the task by N intervals,
 //! `read` returns the full count (Linux semantics).
 //!
 //! Caveats vs. Linux:
-//!   - This kernel has no true wall clock; `wall_time()` is monotonic. An
-//!     absolute `CLOCK_REALTIME` deadline is interpreted against the same
-//!     timebase as `CLOCK_MONOTONIC` (so a Unix-epoch absolute time will
-//!     fire immediately, matching the "deadline in the past" rule). Clock
-//!     stepping doesn't exist, so `TFD_TIMER_CANCEL_ON_SET` is a no-op.
+//!   - Clock stepping doesn't exist, so `TFD_TIMER_CANCEL_ON_SET` is a no-op.
 
 use alloc::{
     borrow::{Cow, ToOwned},
@@ -35,7 +31,7 @@ use core::{
 use ax_errno::{AxError, AxResult};
 use ax_runtime::hal::time::{TimeValue, monotonic_time, wall_time};
 use ax_sync::Mutex;
-use ax_task::future::{block_on, poll_io, timeout_at};
+use ax_task::future::{block_on, poll_io, timeout_at_wall};
 use axpoll::{IoEvents, PollSet, Pollable};
 use event_listener::{Event, listener};
 
@@ -71,7 +67,7 @@ pub struct Timerfd {
     /// The clock domain the user passed to `timerfd_create`. Used by
     /// `settime(TFD_TIMER_ABSTIME)` to translate a user-supplied
     /// absolute deadline (which is always in this domain) into the
-    /// internal `wall_time` domain that the timer wheel runs against.
+    /// internal wall-time domain before arming the monotonic timer wheel.
     clockid: u32,
     state: Mutex<State>,
     expire_count: AtomicU64,
@@ -239,10 +235,10 @@ async fn run_timer(weak: alloc::sync::Weak<Timerfd>) {
                 listener.await;
             }
             Some(dl) => {
-                // Race the deadline against an arm_event (new settime or
-                // shutdown). `timeout_at` returns Err(Elapsed) on deadline,
-                // Ok(()) if the listener fires first.
-                let fired_timer = timeout_at(Some(dl), listener).await.is_err();
+                // Race the wall-clock deadline against an arm_event (new
+                // settime or shutdown). `timeout_at_wall` returns
+                // Err(Elapsed) on deadline, Ok(()) if the listener fires first.
+                let fired_timer = timeout_at_wall(Some(dl), listener).await.is_err();
                 if !fired_timer {
                     // State changed; loop to re-read.
                     continue;

--- a/os/StarryOS/kernel/src/syscall/fs/aio.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/aio.rs
@@ -23,7 +23,7 @@ use ax_runtime::hal::{
 use ax_sync::Mutex;
 use ax_task::{
     WaitQueue,
-    future::{block_on, interruptible, timeout_at},
+    future::{block_on, interruptible, timeout_at_wall},
 };
 use axpoll::{IoEvents, PollSet};
 use linux_raw_sys::general::timespec;
@@ -1082,7 +1082,7 @@ fn wait_for_completion(
         }
     });
 
-    match block_on(interruptible(timeout_at(deadline, wait))) {
+    match block_on(interruptible(timeout_at_wall(deadline, wait))) {
         Ok(Ok(())) => Ok(true),
         Ok(Err(_)) => Ok(false),
         Err(_) => Err(AxError::Interrupted),

--- a/os/StarryOS/kernel/src/task/timer.rs
+++ b/os/StarryOS/kernel/src/task/timer.rs
@@ -7,7 +7,7 @@ use ax_kspin::SpinNoIrq as Mutex;
 use ax_runtime::hal::time::{NANOS_PER_SEC, TimeValue, monotonic_time_nanos, wall_time};
 use ax_task::{
     WeakAxTaskRef, current,
-    future::{block_on, timeout_at},
+    future::{block_on, timeout_at_wall},
 };
 use event_listener::{Event, listener};
 use spin::LazyLock;
@@ -319,7 +319,7 @@ async fn alarm_task() {
             {
                 continue;
             }
-            let _ = timeout_at(Some(deadline), listener).await;
+            let _ = timeout_at_wall(Some(deadline), listener).await;
         }
     }
 }

--- a/os/arceos/api/arceos_api/src/lib.rs
+++ b/os/arceos/api/arceos_api/src/lib.rs
@@ -126,7 +126,7 @@ pub mod task {
     }
 
     define_api! {
-        /// Current task is going to sleep, it will be woken up at the given deadline.
+        /// Current task is going to sleep, it will be woken up at the given monotonic deadline.
         ///
         /// If the feature `multitask` is not enabled, it uses busy-wait instead
         pub fn ax_sleep_until(deadline: crate::time::AxTimeValue);

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -283,10 +283,11 @@ pub(crate) fn yield_now_unchecked() {
 ///
 /// If the feature `irq` is not enabled, it uses busy-wait instead.
 pub fn sleep(dur: core::time::Duration) {
-    sleep_until(ax_hal::time::wall_time() + dur);
+    sleep_until(ax_hal::time::monotonic_time() + dur);
 }
 
 /// Current task is going to sleep, it will be woken up at the given deadline.
+/// The deadline is measured against the monotonic clock.
 ///
 /// If the feature `irq` is not enabled, it uses busy-wait instead.
 pub fn sleep_until(deadline: ax_hal::time::TimeValue) {

--- a/os/arceos/modules/axtask/src/api_s.rs
+++ b/os/arceos/modules/axtask/src/api_s.rs
@@ -16,7 +16,7 @@ pub fn sleep(dur: core::time::Duration) {
 }
 
 /// For single-task situation, we just busy wait until reaching the given
-/// deadline.
+/// monotonic deadline.
 pub fn sleep_until(deadline: ax_hal::time::TimeValue) {
     ax_hal::time::busy_wait_until(deadline);
 }

--- a/os/arceos/modules/axtask/src/future/time.rs
+++ b/os/arceos/modules/axtask/src/future/time.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 use ax_errno::AxError;
-use ax_hal::time::{TimeValue, wall_time};
+use ax_hal::time::{TimeValue, monotonic_time, wall_time};
 use futures_util::{FutureExt, select_biased};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -30,7 +30,7 @@ impl TimerRuntime {
     }
 
     fn add(&mut self, deadline: TimeValue) -> Option<TimerKey> {
-        if deadline <= wall_time() {
+        if deadline <= monotonic_time() {
             return None;
         }
 
@@ -62,7 +62,7 @@ impl TimerRuntime {
             return;
         }
 
-        let now = wall_time();
+        let now = monotonic_time();
 
         let pending = self.wheel.split_off(&TimerKey {
             deadline: now,
@@ -112,10 +112,10 @@ impl Drop for TimerFuture {
 
 /// Waits until `duration` has elapsed.
 pub async fn sleep(duration: Duration) {
-    sleep_until(wall_time() + duration).await
+    sleep_until(monotonic_time() + duration).await
 }
 
-/// Waits until `deadline` is reached.
+/// Waits until the monotonic `deadline` is reached.
 pub async fn sleep_until(deadline: TimeValue) {
     let key = with_current(|r| r.add(deadline));
     if let Some(key) = key {
@@ -147,13 +147,13 @@ pub async fn timeout<F: IntoFuture>(
     f: F,
 ) -> Result<F::Output, Elapsed> {
     timeout_at(
-        duration.and_then(|x| x.checked_add(ax_hal::time::wall_time())),
+        duration.and_then(|x| x.checked_add(ax_hal::time::monotonic_time())),
         f,
     )
     .await
 }
 
-/// Requires a `Future` to complete before the specified deadline.
+/// Requires a `Future` to complete before the specified monotonic deadline.
 pub async fn timeout_at<F: IntoFuture>(
     deadline: Option<TimeValue>,
     f: F,
@@ -165,5 +165,25 @@ pub async fn timeout_at<F: IntoFuture>(
         }
     } else {
         Ok(f.await)
+    }
+}
+
+/// Requires a `Future` to complete before the specified wall-clock deadline.
+pub async fn timeout_at_wall<F: IntoFuture>(
+    deadline: Option<TimeValue>,
+    f: F,
+) -> Result<F::Output, Elapsed> {
+    timeout_at(deadline.map(wall_deadline_to_monotonic), f).await
+}
+
+fn wall_deadline_to_monotonic(deadline: TimeValue) -> TimeValue {
+    let now_wall = wall_time();
+    let now_mono = monotonic_time();
+    if deadline <= now_wall {
+        now_mono
+    } else {
+        now_mono
+            .checked_add(deadline - now_wall)
+            .unwrap_or(TimeValue::MAX)
     }
 }

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -555,8 +555,7 @@ impl<G: BaseGuard> CurrentRunQueueRef<'_, G> {
         assert!(curr.is_running());
         assert!(!curr.is_idle());
 
-        let now = ax_hal::time::wall_time();
-        if now < deadline {
+        while ax_hal::time::monotonic_time() < deadline {
             crate::timers::set_alarm_wakeup(deadline, curr.clone());
             curr.set_state(TaskState::Blocked);
             self.inner.resched();

--- a/os/arceos/modules/axtask/src/timers.rs
+++ b/os/arceos/modules/axtask/src/timers.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec::Vec};
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use ax_hal::time::{TimeValue, wall_time};
+use ax_hal::time::{TimeValue, monotonic_time};
 use ax_kernel_guard::{NoOp, NoPreemptIrqSave};
 use ax_timer_list::{TimerEvent, TimerList};
 
@@ -69,7 +69,7 @@ where
 
 fn check_callbacks() {
     for callback in unsafe { TIMER_CALLBACKS.current_ref_raw().iter() } {
-        callback(wall_time());
+        callback(monotonic_time());
     }
 }
 
@@ -87,7 +87,7 @@ pub(crate) fn set_alarm_wakeup(deadline: TimeValue, task: AxTaskRef) {
 pub fn check_events() {
     check_callbacks();
     loop {
-        let now = wall_time();
+        let now = monotonic_time();
         let event = unsafe {
             // Safety: IRQs are disabled at this time.
             TIMER_LIST.current_ref_mut_raw()

--- a/os/arceos/modules/axtask/src/wait_queue.rs
+++ b/os/arceos/modules/axtask/src/wait_queue.rs
@@ -110,17 +110,25 @@ impl WaitQueue {
         crate::api::might_sleep();
         let mut rq = current_run_queue::<NoPreemptIrqSave>();
         let curr = crate::current();
-        let deadline = ax_hal::time::wall_time() + dur;
+        let deadline = ax_hal::time::monotonic_time() + dur;
         debug!(
             "task wait_timeout: {} deadline={:?}",
             curr.id_name(),
             deadline
         );
-        crate::timers::set_alarm_wakeup(deadline, curr.clone());
+        let timeout = loop {
+            crate::timers::set_alarm_wakeup(deadline, curr.clone());
+            rq.blocked_resched(self.queue.lock());
 
-        rq.blocked_resched(self.queue.lock());
-
-        let timeout = curr.in_wait_queue(); // still in the wait queue, must have timed out
+            // Still in the wait queue means the timer path woke us. Re-check
+            // the monotonic deadline so an early wake cannot truncate sleeps.
+            if !curr.in_wait_queue() {
+                break false;
+            }
+            if ax_hal::time::monotonic_time() >= deadline {
+                break true;
+            }
+        };
 
         // Always try to remove the task from the timer list.
         self.cancel_events(curr, true);
@@ -139,18 +147,16 @@ impl WaitQueue {
     {
         crate::api::might_sleep();
         let curr = crate::current();
-        let deadline = ax_hal::time::wall_time() + dur;
+        let deadline = ax_hal::time::monotonic_time() + dur;
         debug!(
             "task wait_timeout: {}, deadline={:?}",
             curr.id_name(),
             deadline
         );
-        crate::timers::set_alarm_wakeup(deadline, curr.clone());
-
         let mut timeout = true;
         loop {
             let mut rq = current_run_queue::<NoPreemptIrqSave>();
-            if ax_hal::time::wall_time() >= deadline {
+            if ax_hal::time::monotonic_time() >= deadline {
                 break;
             }
             let wq = self.queue.lock();
@@ -159,6 +165,7 @@ impl WaitQueue {
                 break;
             }
 
+            crate::timers::set_alarm_wakeup(deadline, curr.clone());
             rq.blocked_resched(wq);
             // Preemption may occur here.
         }

--- a/os/arceos/ulib/axstd/src/thread/mod.rs
+++ b/os/arceos/ulib/axstd/src/thread/mod.rs
@@ -30,10 +30,11 @@ pub fn exit(exit_code: i32) -> ! {
 /// If one of `multitask` or `irq` features is not enabled, it uses busy-wait
 /// instead.
 pub fn sleep(dur: core::time::Duration) {
-    sleep_until(ax_api::time::ax_wall_time() + dur);
+    sleep_until(ax_api::time::ax_monotonic_time() + dur);
 }
 
 /// Current thread is going to sleep, it will be woken up at the given deadline.
+/// The deadline is measured against the monotonic clock.
 ///
 /// If one of `multitask` or `irq` features is not enabled, it uses busy-wait
 /// instead.

--- a/os/arceos/ulib/axstd/src/time.rs
+++ b/os/arceos/ulib/axstd/src/time.rs
@@ -13,7 +13,7 @@ pub struct Instant(AxTimeValue);
 impl Instant {
     /// Returns an instant corresponding to "now".
     pub fn now() -> Instant {
-        Instant(ax_api::time::ax_wall_time())
+        Instant(ax_api::time::ax_monotonic_time())
     }
 
     /// Returns the amount of time elapsed from another instant to this one,

--- a/platforms/ax-plat/src/time.rs
+++ b/platforms/ax-plat/src/time.rs
@@ -69,12 +69,12 @@ pub fn wall_time() -> TimeValue {
 
 /// Busy waiting for the given duration.
 pub fn busy_wait(dur: Duration) {
-    busy_wait_until(wall_time() + dur);
+    busy_wait_until(monotonic_time() + dur);
 }
 
-/// Busy waiting until reaching the given deadline.
+/// Busy waiting until reaching the given monotonic deadline.
 pub fn busy_wait_until(deadline: TimeValue) {
-    while wall_time() < deadline {
+    while monotonic_time() < deadline {
         core::hint::spin_loop();
     }
 }


### PR DESCRIPTION
## 问题

GitHub Actions 中 `cargo xtask arceos test qemu --arch riscv64` 曾在 `task-sleep` 用例里偶发失败：线程 sleep 返回后，`Instant::elapsed()` 观察到的时间不足预期。根因是相对 sleep、`Instant`、timer wheel 和若干 timeout 路径混用了 `wall_time()`，而这些语义应该绑定到不会因 RTC 初始化或系统时间调整而跳变的 monotonic clock。

推送到 ZR233 分支后，Starry aarch64 QEMU 的 `bug-epollet-second-chunk` 又暴露出同一类边界问题：`axtask::sleep_until` 已经切到 monotonic deadline，但 `ax-net` 的 smoltcp `Instant` 仍由 `wall_time_nanos()` 生成，`iface.poll_at(now())` 返回的 deadline 会被直接传给 monotonic `sleep_until()`。这会把网络协议栈的下一次 poll 定时器排到错误时间域，导致 loopback TCP/epoll 场景下后续数据到达不能及时驱动网络栈 poll。

## 修改

- 将 ArceOS 的相对 sleep、`Instant::now()`、busy-wait、wait queue timeout、timer wheel 和 async timeout 统一改为 monotonic deadline。
- 为 `sleep_until`、`timeout_at` 等接口补充 monotonic deadline 语义说明。
- 新增 `timeout_at_wall`，在进入 monotonic timer wheel 前把 wall-clock absolute deadline 转换为 monotonic deadline。
- 将 StarryOS 的 timerfd、alarm、AIO 等 wall-clock deadline 调用点切到 `timeout_at_wall`，保留用户态实时钟语义。
- 在 wait queue / run queue 的 timeout 路径里重新检查 monotonic deadline，避免提前唤醒截断 sleep。
- 将 `ax-net` 的 smoltcp 内部 `now()` 改为基于 `monotonic_time_nanos()`，让 `poll_at()` deadline 与 `sleep_until()` 使用同一时间基准；DHCP transaction id 仍保留 wall time 作为扰动来源。

## 修复逻辑

相对时间、elapsed 计算、内核 timer wheel 和协议栈内部 timer 都必须基于 monotonic clock；实时钟只适合 calendar/realtime 语义。这个 PR 把 timer wheel 的内部时基固定为 monotonic，并在 StarryOS 需要处理 wall-clock absolute deadline 的边界处做显式转换，避免把 wall deadline 直接塞进 monotonic timer wheel。

网络栈的 `smoltcp::time::Instant` 同样是内部经过时间，不是日历时间。统一到 monotonic 后，`iface.poll_at()` 给出的下一次协议栈 poll deadline 才能被 `axtask::sleep_until()` 正确解释，避免 TCP/epoll 依赖网络 poll timer 的场景漏唤醒。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo xtask clippy --package ax-task --package ax-std --package ax-plat --package starry-kernel`
- `cargo xtask clippy --package ax-net --package starry-kernel`
- `cargo xtask arceos test qemu --arch riscv64`
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system/bug-epollet-second-chunk`
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system/bug-tcp-send-no-epoll-notify`
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system/syscall-test-epoll`

说明：`qemu-smp1/system/syscall-test-epoll-eventfd` 当前会安装到 `/usr/bin/starry-known-fail`，而 system runner 只扫描 `/usr/bin/starry-test-suit`，因此单独指定该 case 会以 `no system tests found` 结束，没有执行到测试体。