### PR TITLE
fix(starry): report ENOSYS for the unimplemented new mount API

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -879,12 +879,16 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg3() as _,
         ),
 
+        // The new mount API (fsopen/fsconfig/fsmount/move_mount, plus
+        // fspick/open_tree) is not implemented. Report ENOSYS instead of
+        // handing back a dummy fd: systemd probes this API and only falls back
+        // to the classic mount(2) — which we do support — when the entry point
+        // reports "not supported". A fake fd traps it into the new path, where
+        // the follow-up fsconfig then hard-fails and aborts the mount.
+        Sysno::fsopen | Sysno::fspick | Sysno::open_tree => Err(AxError::Unsupported),
+
         // dummy fds
-        Sysno::userfaultfd
-        | Sysno::fsopen
-        | Sysno::fspick
-        | Sysno::open_tree
-        | Sysno::memfd_secret => sys_dummy_fd(sysno),
+        Sysno::userfaultfd | Sysno::memfd_secret => sys_dummy_fd(sysno),
 
         Sysno::bpf => crate::ebpf::sys_bpf(uctx.arg0() as _, uctx.arg1(), uctx.arg2() as _),
         Sysno::perf_event_open => crate::perf::sys_perf_event_open(

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-mount-api-enosys/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-mount-api-enosys/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-new-mount-api-enosys C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-new-mount-api-enosys src/main.c)
+target_compile_options(bug-new-mount-api-enosys PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-new-mount-api-enosys RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-mount-api-enosys/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-mount-api-enosys/src/main.c
@@ -1,0 +1,70 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_open_tree
+#define SYS_open_tree 428
+#endif
+#ifndef SYS_fsopen
+#define SYS_fsopen 430
+#endif
+#ifndef SYS_fspick
+#define SYS_fspick 433
+#endif
+
+static int passed;
+static int failed;
+
+static void check(int condition, const char *message)
+{
+    if (condition) {
+        ++passed;
+        printf("PASS: %s\n", message);
+    } else {
+        ++failed;
+        printf("FAIL: %s\n", message);
+    }
+}
+
+static void expect_enosys(const char *name, long ret, int saved_errno)
+{
+    char message[128];
+
+    snprintf(message, sizeof(message), "%s fails with ENOSYS", name);
+    check(ret == -1 && saved_errno == ENOSYS, message);
+    if (ret >= 0) {
+        printf("INFO: %s unexpectedly returned fd %ld\n", name, ret);
+        close((int)ret);
+    } else if (saved_errno != ENOSYS) {
+        printf("INFO: %s errno: %s\n", name, strerror(saved_errno));
+    }
+}
+
+int main(void)
+{
+    long ret;
+
+    errno = 0;
+    ret = syscall(SYS_fsopen, "tmpfs", 0);
+    expect_enosys("fsopen", ret, errno);
+
+    errno = 0;
+    ret = syscall(SYS_fspick, AT_FDCWD, "/", 0);
+    expect_enosys("fspick", ret, errno);
+
+    errno = 0;
+    ret = syscall(SYS_open_tree, AT_FDCWD, "/", 0);
+    expect_enosys("open_tree", ret, errno);
+
+    printf("RESULT: %d passed / %d failed\n", passed, failed);
+    if (failed == 0) {
+        printf("TEST PASSED\n");
+        return 0;
+    }
+    return 1;
+}


### PR DESCRIPTION
## 背景

在 StarryOS 上以 Debian trixie 的 systemd 作为 PID 1 启动时，首次 boot 暴露了若干内核问题。本 PR 修复其中之一：新挂载 API 的桩实现误导了 systemd 的能力探测，使其无法回退到经典 `mount(2)`。

## 现象

systemd 在早期挂载 cgroup 层级时直接失败并退出（PID 1 退出 → 内核 panic）：

```text
Dummy fd created: fsopen
Unimplemented syscall: fsconfig (tid=1)
Failed to mount tmpfs (type tmpfs) on /sys/fs/cgroup (...): No such file or directory
[!!!!!!] Failed to mount cgroup v1 hierarchy.
Exiting PID 1...
```

## 根因

`fsopen` / `fspick` / `open_tree` 经 `sys_dummy_fd` 返回一个**假 fd（表示成功）**。于是 systemd 认为内核支持新挂载 API（`fsopen → fsconfig → fsmount → move_mount`），继续调用未实现的 `fsconfig` 并失败；又因为入口 `fsopen` "成功"了，systemd **不会回退**到经典 `mount(2)`——而后者 StarryOS 是支持的。

`sys_dummy_fd` 本身已对 qemu 进程特判返回 `Unsupported`（注释写明"要对 qemu 诚实，它会自动 fallback"），systemd 同理，只是没有被诚实对待。

## 修复

让 `fsopen` / `fspick` / `open_tree` 返回 `AxError::Unsupported`（映射为 `ENOSYS`）。systemd 检测到新挂载 API 不可用后即回退到经典 `mount(2)`。`fsconfig` / `fsmount` / `move_mount` 本就落到默认分支返回 ENOSYS，行为现在一致。

## 测试

新增回归用例 `qemu-smp1/system/bugfix-bug-mount-api-enosys`：断言 `fsopen` / `fspick` / `open_tree` 均返回 `-1` 且 `errno == ENOSYS`。修复前返回 dummy fd（≥ 0）会 FAIL，从而钉住该行为。


