### PR TITLE
fix(starry): provide /sys/fs/cgroup mount point in sysfs

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/sysfs.rs
+++ b/os/StarryOS/kernel/src/pseudofs/sysfs.rs
@@ -93,6 +93,19 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         );
         SimpleDir::new_maker(fs.clone(), Arc::new(kernel))
     });
+    // `/sys/fs/cgroup` is the mount point systemd lays its cgroup hierarchy on
+    // (it mounts tmpfs then cgroup2 here). On Linux the kernel provides this
+    // empty directory inside sysfs; once sysfs is mounted over /sys it shadows
+    // the rootfs's own /sys/fs/cgroup, so the mount point must exist here or
+    // `mount("/sys/fs/cgroup")` fails with ENOENT.
+    root.add("fs", {
+        let mut fs_dir = DirMapping::new();
+        fs_dir.add(
+            "cgroup",
+            SimpleDir::new_maker(fs.clone(), Arc::new(DirMapping::new())),
+        );
+        SimpleDir::new_maker(fs.clone(), Arc::new(fs_dir))
+    });
     SimpleDir::new_maker(fs.clone(), Arc::new(root))
 }
 

--- a/test-suit/starryos/qemu-smp1/system/c-regression-test-sysfs-class/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/c-regression-test-sysfs-class/src/main.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <sys/mount.h>
 #include <sys/stat.h>
 #include <limits.h>
 
@@ -81,6 +82,18 @@ int main(void)
               "/sys/class/graphics/fb0 应可 lstat");
     CHECK(S_ISLNK(st.st_mode),
           "/sys/class/graphics/fb0 应是软链");
+
+    /* /sys/fs/cgroup 必须由 sysfs 自身提供 —— sysfs 盖在 /sys 上后
+     * rootfs 里的同名目录不可见，systemd 在这里挂 cgroup 层级 */
+    CHECK_RET(stat("/sys/fs", &st), 0, "/sys/fs 应可 stat");
+    CHECK(S_ISDIR(st.st_mode), "/sys/fs 应是目录");
+    CHECK_RET(stat("/sys/fs/cgroup", &st), 0, "/sys/fs/cgroup 应可 stat");
+    CHECK(S_ISDIR(st.st_mode), "/sys/fs/cgroup 应是目录");
+
+    CHECK_RET(mount("none", "/sys/fs/cgroup", "tmpfs", 0, NULL), 0,
+              "tmpfs 应能挂载到 /sys/fs/cgroup");
+    CHECK_RET(umount2("/sys/fs/cgroup", 0), 0,
+              "应能卸载 /sys/fs/cgroup 上的 tmpfs");
 
     TEST_DONE();
 }


### PR DESCRIPTION
## 背景

在 StarryOS 上以 Debian trixie 的 systemd 作为 PID 1 启动时，首次 boot 暴露了若干内核问题。本 PR 修复其中之一：sysfs 缺少 `/sys/fs/cgroup` 挂载点，导致 systemd 无法建立 cgroup 层级。

## 现象

systemd 在 `/sys/fs/cgroup` 上挂载 tmpfs 时失败，`mount(2)` 返回 `ENOENT`（挂载点路径不存在）：

```text
Failed to mount tmpfs (type tmpfs) on /sys/fs/cgroup (...): No such file or directory
```

## 根因

手搓的 sysfs 根目录只暴露 `class` / `bus` / `devices` / `dev` / `kernel`，**没有 `fs/` 目录**。

systemd 早期把 sysfs 挂到 `/sys`，盖住了 rootfs 里 `mkdir` 出来的 `/sys/fs/cgroup`；而 sysfs 自身没有这个目录，挂载时路径解析即 `ENOENT`。真实 Linux 中 `/sys/fs/cgroup` 是内核在 sysfs 内提供的空目录。

## 修复

在 sysfs 中补 `fs/cgroup` 空目录作为挂载点（仿照已有的 `kernel/debug`），对齐 Linux 行为。

## 影响范围

仅向 sysfs 树新增一个空目录节点，不影响现有 `class` / `bus` / `devices` 等 libudev 相关结构。

## 测试

扩展现有用例 `qemu-smp1/system/c-regression-test-sysfs-class`，新增对挂载点的检查：`/sys/fs` 与 `/sys/fs/cgroup` 均存在且为目录，并验证可在 `/sys/fs/cgroup` 上挂载 / 卸载 tmpfs。修复前 `/sys/fs/cgroup` 不存在，相关检查会 FAIL。

```bash
cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system/c-regression-test-sysfs-class
```

## 验证

修复后 systemd 成功建立 cgroup 层级并打出欢迎语：

```text
Found cgroup2 on /sys/fs/cgroup/, full unified hierarchy
Unified cgroup hierarchy is located at /sys/fs/cgroup.
Welcome to Debian GNU/Linux 13 (trixie)!
```
