### PR TITLE
fix(ci): reduce Starry grouped QEMU overhead

### DIFF
--- a/components/someboot/src/arch/x86_64/trap.rs
+++ b/components/someboot/src/arch/x86_64/trap.rs
@@ -3,6 +3,10 @@ use core::{
     sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
 };
 
+use acpi::{
+    address::{AddressSpace, GenericAddress},
+    sdt::fadt::Fadt,
+};
 use page_table_generic::PhysAddr;
 use x86::{
     bits64::{rflags, segmentation::Descriptor64},
@@ -40,8 +44,11 @@ const PIT_SPEAKER_ENABLE: u8 = 0x02;
 const PIT_CHANNEL2_OUT: u8 = 0x20;
 const PIT_MODE0_CHANNEL2: u8 = 0xb0;
 const PIT_TICK_RATE_HZ: u64 = 1_193_182;
-const TSC_PIT_CALIBRATION_MS: u64 = 50;
-const TSC_PIT_MAX_POLL_COUNT: usize = 5_000_000;
+const ACPI_PM_TIMER_HZ: u64 = 3_579_545;
+const TSC_CALIBRATION_MS: u64 = 50;
+const TSC_CALIBRATION_ROUNDS: usize = 3;
+const TSC_CALIBRATION_MAX_POLL_COUNT: usize = 10_000_000;
+const TSC_CALIBRATION_MAX_JITTER_PCT: u64 = 10;
 const MIN_VALID_TSC_FREQ_HZ: u64 = 10_000_000;
 const MAX_VALID_TSC_FREQ_HZ: u64 = 10_000_000_000;
 
@@ -173,15 +180,18 @@ fn init_tsc_freq() {
     }
 
     let cpuid = CpuId::new();
-    let freq_hz = hypervisor_tsc_freq_hz(&cpuid)
-        .or_else(|| cpuid_tsc_freq_hz(&cpuid))
-        .or_else(pit_calibrate_tsc_freq_hz)
-        .or_else(|| processor_base_freq_hz(&cpuid))
+    let (freq_hz, source) = hypervisor_tsc_freq_hz(&cpuid)
+        .map(|freq| (freq, "hypervisor"))
+        .or_else(|| cpuid_tsc_freq_hz(&cpuid).map(|freq| (freq, "cpuid.15")))
+        .or_else(|| acpi_pm_timer_calibrate_tsc_freq_hz().map(|freq| (freq, "acpi-pm-timer")))
+        .or_else(|| pit_calibrate_tsc_freq_hz().map(|freq| (freq, "pit")))
+        .or_else(|| processor_base_freq_hz(&cpuid).map(|freq| (freq, "cpuid-base")))
         .unwrap_or_else(|| {
             let fallback = 1_000_000_000u64;
             warn!("x86_64 TSC frequency unavailable, fallback to {fallback} Hz");
-            fallback
+            (fallback, "fallback")
         });
+    debug!("x86_64 TSC frequency from {source}: {freq_hz} Hz");
     let has_deadline = cpuid
         .get_feature_info()
         .is_some_and(|info| info.has_tsc_deadline());
@@ -212,21 +222,7 @@ fn hypervisor_tsc_freq_hz(cpuid: &CpuId) -> Option<u64> {
 fn cpuid_tsc_freq_hz(cpuid: &CpuId) -> Option<u64> {
     cpuid
         .get_tsc_info()
-        .and_then(|info| {
-            if let Some(freq) = info.tsc_frequency().and_then(valid_tsc_freq_hz) {
-                return Some(freq);
-            }
-
-            let numerator = info.numerator();
-            let denominator = info.denominator();
-            if numerator == 0 || denominator == 0 {
-                return None;
-            }
-
-            let base_hz = processor_base_freq_hz(cpuid)? as u128;
-            let crystal_hz = base_hz * denominator as u128 / numerator as u128;
-            Some((crystal_hz * numerator as u128 / denominator as u128) as u64)
-        })
+        .and_then(|info| info.tsc_frequency())
         .and_then(valid_tsc_freq_hz)
 }
 
@@ -237,8 +233,63 @@ fn processor_base_freq_hz(cpuid: &CpuId) -> Option<u64> {
         .and_then(valid_tsc_freq_hz)
 }
 
+struct AcpiPmTimer {
+    gas: GenericAddress,
+    mask: u32,
+}
+
+impl AcpiPmTimer {
+    fn detect() -> Option<Self> {
+        let tables = crate::acpi::tables().ok()?;
+        let fadt_mapping = tables.find_tables::<Fadt>().next()?;
+        let fadt = &*fadt_mapping;
+        let gas = fadt.pm_timer_block().ok()??;
+        if gas.bit_offset != 0 {
+            return None;
+        }
+        match gas.address_space {
+            AddressSpace::SystemIo if gas.address <= u16::MAX as u64 => {}
+            AddressSpace::SystemMemory => {}
+            _ => return None,
+        }
+
+        let mask = if { fadt.flags }.pm_timer_is_32_bit() {
+            u32::MAX
+        } else {
+            0x00ff_ffff
+        };
+        Some(Self { gas, mask })
+    }
+
+    fn read(&self) -> Option<u32> {
+        let value = match self.gas.address_space {
+            AddressSpace::SystemIo => unsafe { x86::io::inl(self.gas.address as u16) },
+            AddressSpace::SystemMemory => {
+                let ptr = phys_to_virt(self.gas.address as usize).cast::<u32>();
+                unsafe { ptr.read_volatile() }
+            }
+            _ => return None,
+        };
+        Some(value & self.mask)
+    }
+}
+
+fn acpi_pm_timer_calibrate_tsc_freq_hz() -> Option<u64> {
+    let timer = AcpiPmTimer::detect()?;
+    let target_ticks = (ACPI_PM_TIMER_HZ * TSC_CALIBRATION_MS / 1_000) as u32;
+    calibrated_tsc_freq_hz(|| timer.read(), timer.mask, target_ticks, ACPI_PM_TIMER_HZ)
+}
+
 fn pit_calibrate_tsc_freq_hz() -> Option<u64> {
-    let latch = ((PIT_TICK_RATE_HZ * TSC_PIT_CALIBRATION_MS) / 1_000) as u16;
+    let mut samples = [0u64; TSC_CALIBRATION_ROUNDS];
+    for sample in &mut samples {
+        *sample = pit_calibrate_tsc_freq_sample_hz()?;
+    }
+    select_stable_calibration_sample(&samples)
+}
+
+fn pit_calibrate_tsc_freq_sample_hz() -> Option<u64> {
+    let latch = ((PIT_TICK_RATE_HZ * TSC_CALIBRATION_MS) / 1_000) as u16;
 
     unsafe {
         let control = x86::io::inb(PIT_CONTROL_PORT);
@@ -254,7 +305,7 @@ fn pit_calibrate_tsc_freq_hz() -> Option<u64> {
     let start = ticks_now();
     let mut end = start;
     let mut done = false;
-    for _ in 0..TSC_PIT_MAX_POLL_COUNT {
+    for _ in 0..TSC_CALIBRATION_MAX_POLL_COUNT {
         if unsafe { x86::io::inb(PIT_CONTROL_PORT) } & PIT_CHANNEL2_OUT != 0 {
             end = ticks_now();
             done = true;
@@ -270,8 +321,83 @@ fn pit_calibrate_tsc_freq_hz() -> Option<u64> {
 
     end.wrapping_sub(start)
         .checked_mul(1_000)?
-        .checked_div(TSC_PIT_CALIBRATION_MS)
+        .checked_div(TSC_CALIBRATION_MS)
         .and_then(valid_tsc_freq_hz)
+}
+
+fn calibrated_tsc_freq_hz<F>(
+    mut read_counter: F,
+    counter_mask: u32,
+    target_ticks: u32,
+    counter_freq_hz: u64,
+) -> Option<u64>
+where
+    F: FnMut() -> Option<u32>,
+{
+    let mut samples = [0u64; TSC_CALIBRATION_ROUNDS];
+    for sample in &mut samples {
+        *sample = calibrated_tsc_freq_sample_hz(
+            &mut read_counter,
+            counter_mask,
+            target_ticks,
+            counter_freq_hz,
+        )?;
+    }
+    select_stable_calibration_sample(&samples)
+}
+
+fn calibrated_tsc_freq_sample_hz<F>(
+    read_counter: &mut F,
+    counter_mask: u32,
+    target_ticks: u32,
+    counter_freq_hz: u64,
+) -> Option<u64>
+where
+    F: FnMut() -> Option<u32>,
+{
+    let start_counter = read_counter()?;
+    let start_tsc = ticks_now();
+    let mut end_tsc = start_tsc;
+    let mut elapsed_counter = 0;
+    let mut done = false;
+
+    for _ in 0..TSC_CALIBRATION_MAX_POLL_COUNT {
+        let now_counter = read_counter()?;
+        elapsed_counter = now_counter.wrapping_sub(start_counter) & counter_mask;
+        if elapsed_counter >= target_ticks {
+            end_tsc = ticks_now();
+            done = true;
+            break;
+        }
+        spin_loop();
+    }
+
+    if !done || elapsed_counter == 0 {
+        return None;
+    }
+
+    let elapsed_tsc = end_tsc.wrapping_sub(start_tsc);
+    let freq = (elapsed_tsc as u128)
+        .checked_mul(counter_freq_hz as u128)?
+        .checked_div(elapsed_counter as u128)?;
+    u64::try_from(freq).ok().and_then(valid_tsc_freq_hz)
+}
+
+fn select_stable_calibration_sample(samples: &[u64]) -> Option<u64> {
+    let mut min = u64::MAX;
+    let mut max = 0;
+    for &sample in samples {
+        min = min.min(sample);
+        max = max.max(sample);
+    }
+
+    if min == u64::MAX {
+        return None;
+    }
+    if max.saturating_sub(min) > min / 100 * TSC_CALIBRATION_MAX_JITTER_PCT {
+        return None;
+    }
+    Some(min)
 }
 
 fn init_idt_once() {

--- a/scripts/axbuild/src/starry/test.rs
+++ b/scripts/axbuild/src/starry/test.rs
@@ -2554,7 +2554,7 @@ mod tests {
     }
 
     #[test]
-    fn starry_system_grouped_qemu_configs_report_subcase_timing() {
+    fn starry_system_grouped_qemu_configs_use_low_overhead_runner_markers() {
         let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
 
         for group in ["qemu-smp1", "qemu-smp4"] {
@@ -2574,24 +2574,23 @@ mod tests {
                     .unwrap_or_default();
 
                 assert!(
-                    command.contains("STARRY_SYSTEM_TEST_TIMING_BEGIN"),
-                    "{} must start a grouped subcase timing section",
+                    command.contains("STARRY_SYSTEM_TEST_BEGIN: $bin"),
+                    "{} must report when each grouped subcase starts",
                     path.display()
                 );
                 assert!(
-                    command.contains("STARRY_SYSTEM_TEST_TIMING: elapsed_s="),
-                    "{} must report per-subcase elapsed seconds",
+                    command.contains("STARRY_SYSTEM_TEST_PASSED: $bin"),
+                    "{} must report each grouped subcase pass marker",
                     path.display()
                 );
                 assert!(
-                    command.contains("status=passed bin=")
-                        && command.contains("status=failed bin="),
-                    "{} must include pass/fail status in timing lines",
+                    !command.contains("$(date") && !command.contains("timing_file"),
+                    "{} must avoid per-subcase timing commands in the guest runner",
                     path.display()
                 );
                 assert!(
-                    command.contains("STARRY_SYSTEM_TEST_TIMING_END"),
-                    "{} must end a grouped subcase timing section",
+                    !command.contains("STARRY_SYSTEM_TEST_TIMING"),
+                    "{} must not emit grouped timing lines from the low-overhead runner",
                     path.display()
                 );
                 let failure_branch = command.find("else\n").unwrap_or_else(|| {
@@ -2608,13 +2607,14 @@ mod tests {
                             path.display()
                         )
                     });
-                let status_failed_position =
-                    failure_command.find("status=failed").unwrap_or_else(|| {
+                let status_failed_position = failure_command
+                    .find("$system_fail_marker")
+                    .unwrap_or_else(|| {
                         panic!("{} must mark failed grouped subcases", path.display())
                     });
                 assert!(
                     exit_status_position < status_failed_position,
-                    "{} must capture `$?` before assigning shell variables in the failure branch",
+                    "{} must capture `$?` before printing grouped failure state",
                     path.display()
                 );
                 assert!(
@@ -2748,11 +2748,11 @@ mod tests {
                 && script.contains("APK_CURL_EQUIVALENCE_TEST_FAILED")
                 && script.contains("curl --connect-timeout")
                 && script.contains("10.0.2.2")
-                && script.contains("20971520")
+                && script.contains("4194304")
                 && script.contains("sha256sum -c")
                 && script
-                    .contains("48b6fb8f1c2fec38d030604889d674722c4af237733c913b698400b59c9294b4"),
-            "{} must download the local 20MiB HTTP fixture, write it to disk, then read it back \
+                    .contains("299285fc41a44cdb038b9fdaf494c76ca9d0c866672b2b266c1a0c17dda60a05"),
+            "{} must download the local 4MiB HTTP fixture, write it to disk, then read it back \
              and compare sha256",
             script_path.display()
         );
@@ -2790,7 +2790,7 @@ mod tests {
                 host_http_server
                     .get("body_size")
                     .and_then(toml::Value::as_integer),
-                Some(20 * 1024 * 1024)
+                Some(4 * 1024 * 1024)
             );
             assert_eq!(
                 host_http_server

--- a/scripts/axbuild/src/starry/test.rs
+++ b/scripts/axbuild/src/starry/test.rs
@@ -2748,11 +2748,11 @@ mod tests {
                 && script.contains("APK_CURL_EQUIVALENCE_TEST_FAILED")
                 && script.contains("curl --connect-timeout")
                 && script.contains("10.0.2.2")
-                && script.contains("4194304")
+                && script.contains("1048576")
                 && script.contains("sha256sum -c")
                 && script
-                    .contains("299285fc41a44cdb038b9fdaf494c76ca9d0c866672b2b266c1a0c17dda60a05"),
-            "{} must download the local 4MiB HTTP fixture, write it to disk, then read it back \
+                    .contains("9bc1b2a288b26af7257a36277ae3816a7d4f16e89c1e7e77d0a5c48bad62b360"),
+            "{} must download the local 1MiB HTTP fixture, write it to disk, then read it back \
              and compare sha256",
             script_path.display()
         );
@@ -2790,7 +2790,7 @@ mod tests {
                 host_http_server
                     .get("body_size")
                     .and_then(toml::Value::as_integer),
-                Some(4 * 1024 * 1024)
+                Some(1024 * 1024)
             );
             assert_eq!(
                 host_http_server

--- a/scripts/axbuild/src/test/qemu.rs
+++ b/scripts/axbuild/src/test/qemu.rs
@@ -1144,11 +1144,16 @@ fn disable_dynamic_x86_64_five_level_paging(qemu: &mut QemuConfig) {
 }
 
 fn enable_dynamic_x86_64_nested_virtualization_features(qemu: &mut QemuConfig, cargo: &Cargo) {
+    let features = dynamic_x86_64_nested_virtualization_features(cargo);
+    if features.is_empty() {
+        return;
+    }
+
     for index in 0..qemu.args.len() {
         if qemu.args.get(index).is_some_and(|arg| arg == "-cpu")
             && let Some(cpu) = qemu.args.get_mut(index + 1)
         {
-            for feature in dynamic_x86_64_nested_virtualization_features(cargo) {
+            for feature in features {
                 enable_qemu_cpu_feature(cpu, feature);
             }
         }
@@ -1163,8 +1168,15 @@ fn dynamic_x86_64_nested_virtualization_features(cargo: &Cargo) -> &'static [&'s
         )
     }) {
         &["svm", "npt", "nrip-save"]
-    } else {
+    } else if cargo.features.iter().any(|feature| {
+        matches!(
+            feature.as_str(),
+            "vmx" | "axvm/vmx" | "x86_vcpu/vmx" | "x86-vcpu/vmx"
+        )
+    }) {
         &["vmx-ept", "vmx-unrestricted-guest", "vmx-flexpriority"]
+    } else {
+        &[]
     }
 }
 
@@ -1851,7 +1863,7 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_x86_64_qemu_boot_disables_five_level_paging_cpu_feature() {
+    fn dynamic_x86_64_qemu_boot_disables_five_level_paging_without_default_nested_features() {
         let _guard = ENV_LOCK.lock().unwrap();
         let _debug = TempEnvVar::unset(DYNAMIC_X86_64_QEMU_DEBUG_ENV);
         let cargo = Cargo {
@@ -1877,9 +1889,40 @@ mod tests {
             qemu.args,
             [
                 "-cpu",
-                "host,+x2apic,-la57,+vmx-ept,+vmx-unrestricted-guest,+vmx-flexpriority",
+                "host,+x2apic,-la57",
                 "-machine",
                 "q35",
+                "-net",
+                "none",
+                "-vga",
+                "none"
+            ]
+        );
+    }
+
+    #[test]
+    fn dynamic_x86_64_qemu_boot_enables_vmx_nested_features_for_vmx_backend() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _debug = TempEnvVar::unset(DYNAMIC_X86_64_QEMU_DEBUG_ENV);
+        let cargo = Cargo {
+            target: "scripts/targets/pie/x86_64-unknown-none.json".to_string(),
+            features: vec!["dyn-plat".to_string(), "vmx".to_string()],
+            to_bin: true,
+            ..Default::default()
+        };
+        let mut qemu = QemuConfig {
+            args: vec!["-cpu".to_string(), "host".to_string()],
+            ..Default::default()
+        };
+
+        apply_dynamic_platform_qemu_boot_with_kvm_probe(&mut qemu, &cargo, || false);
+        apply_dynamic_platform_qemu_boot_with_kvm_probe(&mut qemu, &cargo, || false);
+
+        assert_eq!(
+            qemu.args,
+            [
+                "-cpu",
+                "host,-la57,+vmx-ept,+vmx-unrestricted-guest,+vmx-flexpriority",
                 "-net",
                 "none",
                 "-vga",

--- a/test-suit/starryos/qemu-smp1/system/apk-curl-equivalence/src/apk-curl-equivalence.sh
+++ b/test-suit/starryos/qemu-smp1/system/apk-curl-equivalence/src/apk-curl-equivalence.sh
@@ -3,8 +3,8 @@ set -eu
 
 payload=/tmp/apk-curl-equivalence-payload.bin
 payload_sum=/tmp/apk-curl-equivalence-payload.sha256
-payload_size=4194304
-payload_sha256=299285fc41a44cdb038b9fdaf494c76ca9d0c866672b2b266c1a0c17dda60a05
+payload_size=1048576
+payload_sha256=9bc1b2a288b26af7257a36277ae3816a7d4f16e89c1e7e77d0a5c48bad62b360
 
 fail() {
     echo "APK_CURL_EQUIVALENCE_TEST_FAILED: $1"

--- a/test-suit/starryos/qemu-smp1/system/apk-curl-equivalence/src/apk-curl-equivalence.sh
+++ b/test-suit/starryos/qemu-smp1/system/apk-curl-equivalence/src/apk-curl-equivalence.sh
@@ -3,8 +3,8 @@ set -eu
 
 payload=/tmp/apk-curl-equivalence-payload.bin
 payload_sum=/tmp/apk-curl-equivalence-payload.sha256
-payload_size=20971520
-payload_sha256=48b6fb8f1c2fec38d030604889d674722c4af237733c913b698400b59c9294b4
+payload_size=4194304
+payload_sha256=299285fc41a44cdb038b9fdaf494c76ca9d0c866672b2b266c1a0c17dda60a05
 
 fail() {
     echo "APK_CURL_EQUIVALENCE_TEST_FAILED: $1"

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-ext4-dir-ops/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-ext4-dir-ops/src/main.c
@@ -26,6 +26,9 @@ struct linux_dirent64 {
 };
 
 #define BASE "/root/bug-ext4-dir-ops-test"
+#define RENAME_MANY_FILE_COUNT 8
+#define READDIR_DELETE_FILE_COUNT 8
+#define RM_RF_FILE_COUNT 8
 
 /* ========== 辅助函数 ========== */
 
@@ -546,20 +549,21 @@ static void test_rename_many_files(void)
 
     CHECK(mkdir(dir, 0755) == 0, "mkdir pkg");
 
-    /* create 20 files */
+    /* create enough files to exercise multi-entry directory handling */
     int ok = 1;
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < RENAME_MANY_FILE_COUNT; i++) {
         snprintf(path, sizeof(path), "%s/file_%02d.py", dir, i);
         snprintf(content, sizeof(content), "# file %d\n", i);
         if (write_file(path, content) < 0)
             ok = 0;
     }
-    CHECK(ok, "created 20 files");
+    CHECK(ok, "created files for rename-many test");
 
-    CHECK_RET(rename(dir, renamed), 0, "rename pkg -> ~pkg (20 files)");
+    CHECK_RET(rename(dir, renamed), 0, "rename pkg -> ~pkg (many files)");
 
-    /* readdir must see all 20 files */
-    CHECK(count_dir_entries(renamed) == 20, "readdir ~pkg sees all 20 files");
+    /* readdir must see all files */
+    CHECK(count_dir_entries(renamed) == RENAME_MANY_FILE_COUNT,
+          "readdir ~pkg sees all renamed files");
 
     /* delete all files, then rmdir */
     DIR *d = opendir(renamed);
@@ -597,20 +601,20 @@ static void test_readdir_offset_after_delete(void)
     snprintf(dir, sizeof(dir), "%s/readdir_del", BASE);
     CHECK(mkdir(dir, 0755) == 0, "mkdir readdir_del");
 
-    /* Create 30 files */
+    /* Create enough files to force multiple getdents calls with a tiny buffer. */
     int ok = 1;
-    for (int i = 0; i < 30; i++) {
+    for (int i = 0; i < READDIR_DELETE_FILE_COUNT; i++) {
         snprintf(path, sizeof(path), "%s/f%02d", dir, i);
         snprintf(content, sizeof(content), "%d\n", i);
         if (write_file(path, content) < 0)
             ok = 0;
     }
-    CHECK(ok, "created 30 files");
+    CHECK(ok, "created files for read-delete loop");
 
     /*
      * Read-delete loop: tiny buffer forces 1 entry per getdents64 call.
      * After reading each entry, delete it immediately. If offset tracking
-     * is correct, we'll see all 30 entries. If buggy, entries get skipped.
+     * is correct, we'll see all entries. If buggy, entries get skipped.
      */
     int dfd = open(dir, O_RDONLY | O_DIRECTORY);
     CHECK(dfd >= 0, "open dir for read-delete loop");
@@ -640,8 +644,8 @@ static void test_readdir_offset_after_delete(void)
     }
     close(dfd);
 
-    CHECK(total_deleted == 30,
-          "read-delete loop: all 30 files deleted");
+    CHECK(total_deleted == READDIR_DELETE_FILE_COUNT,
+          "read-delete loop: all files deleted");
     CHECK(rounds > 1,
           "read-delete loop: needed multiple getdents calls (bug trigger)");
 
@@ -664,8 +668,8 @@ static void test_rm_rf_pattern(void)
     snprintf(dir, sizeof(dir), "%s/rmrf", BASE);
     CHECK(mkdir(dir, 0755) == 0, "mkdir rmrf");
 
-    /* Create 30 files */
-    for (int i = 0; i < 30; i++) {
+    /* Create enough files to force multiple batched getdents calls. */
+    for (int i = 0; i < RM_RF_FILE_COUNT; i++) {
         snprintf(path, sizeof(path), "%s/f%02d", dir, i);
         snprintf(content, sizeof(content), "%d\n", i);
         write_file(path, content);
@@ -715,8 +719,8 @@ static void test_rm_rf_pattern(void)
     }
     close(dfd);
 
-    CHECK(total_deleted == 30,
-          "rm-rf pattern: all 30 files deleted");
+    CHECK(total_deleted == RM_RF_FILE_COUNT,
+          "rm-rf pattern: all files deleted");
     CHECK(rounds > 1,
           "rm-rf pattern: needed multiple getdents calls");
 

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-ext4-dir-ops/src/test_framework.h
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-ext4-dir-ops/src/test_framework.h
@@ -31,7 +31,6 @@ static int __fail = 0;
 /* 检查条件为真 */
 #define CHECK(cond, msg) do {                                           \
     if (cond) {                                                         \
-        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
         __pass++;                                                       \
     } else {                                                            \
         printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
@@ -46,8 +45,6 @@ static int __fail = 0;
     long _r = (long)(call);                                             \
     long _e = (long)(expected);                                         \
     if (_r == _e) {                                                     \
-        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
-               __FILE__, __LINE__, msg, _r);                            \
         __pass++;                                                       \
     } else {                                                            \
         printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
@@ -61,8 +58,6 @@ static int __fail = 0;
     errno = 0;                                                          \
     long _r = (long)(call);                                             \
     if (_r == -1 && errno == (exp_errno)) {                             \
-        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
-               __FILE__, __LINE__, msg, errno);                         \
         __pass++;                                                       \
     } else {                                                            \
         printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \

--- a/test-suit/starryos/qemu-smp1/system/qemu-aarch64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-aarch64.toml
@@ -38,45 +38,18 @@ found=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
     found=1
-    start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
-        exit_status=0
+        echo "STARRY_SYSTEM_TEST_PASSED: $bin"
     else
         exit_status=$?
-        status=failed
         failed=1
-    fi
-    end=$(date +%s 2>/dev/null || printf 0)
-    elapsed_s=$((end - start))
-    if [ "$elapsed_s" -lt 0 ]; then
-        elapsed_s=0
-    fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
-        echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
-    else
-        echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
+        echo "$system_fail_marker: $bin status=$exit_status"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    sort -nr "$timing_file" | head -n 20 | while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done
-fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
 if [ "$found" -ne 1 ]; then
     echo "$group_fail_marker: no system tests found"
     exit 1
@@ -95,5 +68,5 @@ timeout = 1800
 [host_http_server]
 bind = "127.0.0.1"
 port = 18381
-body_size = 20971520
+body_size = 4194304
 body_byte = 97

--- a/test-suit/starryos/qemu-smp1/system/qemu-aarch64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-aarch64.toml
@@ -68,5 +68,5 @@ timeout = 1800
 [host_http_server]
 bind = "127.0.0.1"
 port = 18381
-body_size = 4194304
+body_size = 1048576
 body_byte = 97

--- a/test-suit/starryos/qemu-smp1/system/qemu-loongarch64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-loongarch64.toml
@@ -30,45 +30,18 @@ found=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
     found=1
-    start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
-        exit_status=0
+        echo "STARRY_SYSTEM_TEST_PASSED: $bin"
     else
         exit_status=$?
-        status=failed
         failed=1
-    fi
-    end=$(date +%s 2>/dev/null || printf 0)
-    elapsed_s=$((end - start))
-    if [ "$elapsed_s" -lt 0 ]; then
-        elapsed_s=0
-    fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
-        echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
-    else
-        echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
+        echo "$system_fail_marker: $bin status=$exit_status"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    sort -nr "$timing_file" | head -n 20 | while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done
-fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
 if [ "$found" -ne 1 ]; then
     echo "$group_fail_marker: no system tests found"
     exit 1
@@ -87,5 +60,5 @@ timeout = 1800
 [host_http_server]
 bind = "127.0.0.1"
 port = 18383
-body_size = 20971520
+body_size = 4194304
 body_byte = 97

--- a/test-suit/starryos/qemu-smp1/system/qemu-loongarch64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-loongarch64.toml
@@ -60,5 +60,5 @@ timeout = 1800
 [host_http_server]
 bind = "127.0.0.1"
 port = 18383
-body_size = 4194304
+body_size = 1048576
 body_byte = 97

--- a/test-suit/starryos/qemu-smp1/system/qemu-riscv64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-riscv64.toml
@@ -38,45 +38,18 @@ found=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
     found=1
-    start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
-        exit_status=0
+        echo "STARRY_SYSTEM_TEST_PASSED: $bin"
     else
         exit_status=$?
-        status=failed
         failed=1
-    fi
-    end=$(date +%s 2>/dev/null || printf 0)
-    elapsed_s=$((end - start))
-    if [ "$elapsed_s" -lt 0 ]; then
-        elapsed_s=0
-    fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
-        echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
-    else
-        echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
+        echo "$system_fail_marker: $bin status=$exit_status"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    sort -nr "$timing_file" | head -n 20 | while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done
-fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
 if [ "$found" -ne 1 ]; then
     echo "$group_fail_marker: no system tests found"
     exit 1
@@ -95,5 +68,5 @@ timeout = 1800
 [host_http_server]
 bind = "127.0.0.1"
 port = 18382
-body_size = 20971520
+body_size = 4194304
 body_byte = 97

--- a/test-suit/starryos/qemu-smp1/system/qemu-riscv64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-riscv64.toml
@@ -68,5 +68,5 @@ timeout = 1800
 [host_http_server]
 bind = "127.0.0.1"
 port = 18382
-body_size = 4194304
+body_size = 1048576
 body_byte = 97

--- a/test-suit/starryos/qemu-smp1/system/qemu-x86_64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-x86_64.toml
@@ -68,5 +68,5 @@ timeout = 1800
 [host_http_server]
 bind = "127.0.0.1"
 port = 18380
-body_size = 4194304
+body_size = 1048576
 body_byte = 97

--- a/test-suit/starryos/qemu-smp1/system/qemu-x86_64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-x86_64.toml
@@ -38,45 +38,18 @@ found=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
     found=1
-    start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
-        exit_status=0
+        echo "STARRY_SYSTEM_TEST_PASSED: $bin"
     else
         exit_status=$?
-        status=failed
         failed=1
-    fi
-    end=$(date +%s 2>/dev/null || printf 0)
-    elapsed_s=$((end - start))
-    if [ "$elapsed_s" -lt 0 ]; then
-        elapsed_s=0
-    fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
-        echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
-    else
-        echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
+        echo "$system_fail_marker: $bin status=$exit_status"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    sort -nr "$timing_file" | head -n 20 | while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done
-fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
 if [ "$found" -ne 1 ]; then
     echo "$group_fail_marker: no system tests found"
     exit 1
@@ -95,5 +68,5 @@ timeout = 1800
 [host_http_server]
 bind = "127.0.0.1"
 port = 18380
-body_size = 20971520
+body_size = 4194304
 body_byte = 97

--- a/test-suit/starryos/qemu-smp4/system/qemu-aarch64.toml
+++ b/test-suit/starryos/qemu-smp4/system/qemu-aarch64.toml
@@ -24,45 +24,18 @@ found=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
     found=1
-    start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
-        exit_status=0
+        echo "STARRY_SYSTEM_TEST_PASSED: $bin"
     else
         exit_status=$?
-        status=failed
         failed=1
-    fi
-    end=$(date +%s 2>/dev/null || printf 0)
-    elapsed_s=$((end - start))
-    if [ "$elapsed_s" -lt 0 ]; then
-        elapsed_s=0
-    fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
-        echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
-    else
-        echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
+        echo "$system_fail_marker: $bin status=$exit_status"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    sort -nr "$timing_file" | head -n 20 | while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done
-fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
 if [ "$found" -ne 1 ]; then
     echo "$group_fail_marker: no SMP system tests found"
     exit 1

--- a/test-suit/starryos/qemu-smp4/system/qemu-loongarch64.toml
+++ b/test-suit/starryos/qemu-smp4/system/qemu-loongarch64.toml
@@ -26,45 +26,18 @@ found=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
     found=1
-    start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
-        exit_status=0
+        echo "STARRY_SYSTEM_TEST_PASSED: $bin"
     else
         exit_status=$?
-        status=failed
         failed=1
-    fi
-    end=$(date +%s 2>/dev/null || printf 0)
-    elapsed_s=$((end - start))
-    if [ "$elapsed_s" -lt 0 ]; then
-        elapsed_s=0
-    fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
-        echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
-    else
-        echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
+        echo "$system_fail_marker: $bin status=$exit_status"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    sort -nr "$timing_file" | head -n 20 | while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done
-fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
 if [ "$found" -ne 1 ]; then
     echo "$group_fail_marker: no SMP system tests found"
     exit 1

--- a/test-suit/starryos/qemu-smp4/system/qemu-riscv64.toml
+++ b/test-suit/starryos/qemu-smp4/system/qemu-riscv64.toml
@@ -26,45 +26,18 @@ found=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
     found=1
-    start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
-        exit_status=0
+        echo "STARRY_SYSTEM_TEST_PASSED: $bin"
     else
         exit_status=$?
-        status=failed
         failed=1
-    fi
-    end=$(date +%s 2>/dev/null || printf 0)
-    elapsed_s=$((end - start))
-    if [ "$elapsed_s" -lt 0 ]; then
-        elapsed_s=0
-    fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
-        echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
-    else
-        echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
+        echo "$system_fail_marker: $bin status=$exit_status"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    sort -nr "$timing_file" | head -n 20 | while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done
-fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
 if [ "$found" -ne 1 ]; then
     echo "$group_fail_marker: no SMP system tests found"
     exit 1

--- a/test-suit/starryos/qemu-smp4/system/qemu-x86_64.toml
+++ b/test-suit/starryos/qemu-smp4/system/qemu-x86_64.toml
@@ -22,45 +22,18 @@ found=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
     found=1
-    start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
-        exit_status=0
+        echo "STARRY_SYSTEM_TEST_PASSED: $bin"
     else
         exit_status=$?
-        status=failed
         failed=1
-    fi
-    end=$(date +%s 2>/dev/null || printf 0)
-    elapsed_s=$((end - start))
-    if [ "$elapsed_s" -lt 0 ]; then
-        elapsed_s=0
-    fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
-        echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
-    else
-        echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
+        echo "$system_fail_marker: $bin status=$exit_status"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    sort -nr "$timing_file" | head -n 20 | while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done
-fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
 if [ "$found" -ne 1 ]; then
     echo "$group_fail_marker: no SMP system tests found"
     exit 1


### PR DESCRIPTION
## 问题

#1245 已修复 x86 Starry QEMU 的 IRQ/timer 主问题后，CI 中 `qemu-smp1/system` 仍有明显长尾，尤其 x86_64。近期 CI 日志显示，剩余开销主要来自 grouped runner 和少数重型子用例；进一步本地排查还发现 x86 TSC 频率初始化会在硬件校准前信任 CPUID/base 频率，虚拟化环境一旦给出不精确的 base MHz，就会把 Starry 的 timeout 类测试整体拉慢。

- grouped runner 在 guest 内为每个子用例执行 `date`、写 timing 文件、排序输出，数百个子用例会放大固定开销；
- `bug-ext4-dir-ops` 在 x86 CI 中单项可达到数百秒，主要是大量 ext4 元数据操作和逐条 PASS 串口输出叠加；
- `apk-curl-equivalence` 的目标是验证 curl 下载、落盘、读回和 sha256 等价性，不是吞吐 benchmark，过大的 HTTP fixture 会拉长 QEMU usernet/guest 文件 I/O；
- x86 动态平台默认给所有 dyn-plat QEMU 启用 VMX 嵌套虚拟化 CPU feature，但 Starry 常规测试并不需要这些 feature，CI/TCG 路径会产生额外兼容和模拟成本；
- x86 `someboot` TSC 初始化原先会在 PIT/ACPI 等硬件参考校准前使用 CPUID.16/base 频率，和 Linux 更谨慎的 TSC 校准策略不一致。

## 修改

1. 精简 `qemu-smp1/system` 和 `qemu-smp4/system` 四个架构的 grouped runner：
   - 保留 `STARRY_SYSTEM_TEST_BEGIN` / `STARRY_SYSTEM_TEST_PASSED` / `STARRY_SYSTEM_TEST_FAILED` / `STARRY_GROUPED_TESTS_PASSED` 等稳定 marker；
   - 保留失败时立即捕获 `$?` 并最终返回非零状态；
   - 移除 guest 内 per-subcase `date`、临时 timing 文件、sort/head 汇总。

2. 收敛 `apk-curl-equivalence` fixture：
   - host HTTP payload 从 4MiB 调整到 1MiB；
   - 同步更新脚本中的 payload size 和 sha256；
   - 同步更新 x86_64、aarch64、riscv64、loongarch64 的 `host_http_server.body_size`；
   - 保留 curl 下载、文件大小、sha256、落盘读回校验语义。

3. 收敛 `bug-ext4-dir-ops` 重型路径：
   - 将多文件 rename/read-delete/rm-rf 场景中的文件数量改为常量 8；
   - 保留 `rounds > 1` 断言，确保仍触发多轮 getdents/read-delete 的回归条件；
   - 仅在该私有 test framework 中移除成功路径逐条 PASS 输出，失败路径和最终 `DONE: pass/fail` 摘要保持不变。

4. 调整 x86 动态平台 QEMU CPU feature：
   - 默认 dyn-plat 不再自动注入 VMX nested feature；
   - 只有显式启用 `vmx`/`svm` 相关 cargo feature 时才注入对应 CPU feature；
   - 保留 `-la57` 处理，并补充 VMX/SVM/默认路径单测。

5. 修复 x86 TSC 频率选择顺序：
   - 优先使用 hypervisor 明确报告的 TSC 频率和 CPUID.15 crystal ratio 推导出的真实 TSC；
   - 增加 ACPI PM Timer 参考校准，直接解析 FADT PM timer GAS 并在 `someboot` 内自行读取 SystemIO/SystemMemory；
   - PIT 校准保留为硬件后备，并增加多轮采样和 jitter sanity check；
   - CPUID.16/base 频率降级为最后兜底，避免虚拟化环境把 processor base MHz 误当作真实 TSC。

6. 更新 axbuild 回归断言：
   - grouped system 配置必须使用低开销 marker runner；
   - 不再允许 guest 内 timing 命令重新出现；
   - apk-curl 用例必须匹配新的 1MiB fixture。

## 逻辑

`AXBUILD_TIMING` 仍然提供 case 级别的 host 侧耗时；如果以后需要子用例性能诊断，应优先在 host runner 侧做低开销统计，而不是在 guest 中为每个子用例 fork `date` 并排序。

`apk-curl-equivalence` 的核心语义是“下载同一份 host fixture，写入 guest 文件，再读回并校验 sha256”。1MiB 已足够覆盖 curl、QEMU usernet、guest 文件写读和 sha256 校验，避免把 CI 变成网络/磁盘吞吐测试。

`bug-ext4-dir-ops` 保留了目录 rename、多轮 getdents、读目录同时删除等 bug 触发条件，但减少重复样本数量和成功日志输出。这样失败时仍有明确定位信息，成功时不再把 x86 CI 的串口和 ext4 元数据路径打成慢长尾。

x86 nested virtualization feature 改为按需启用，避免 Starry 常规 dyn-plat 测试为 Axvisor/虚拟化后端承担不必要的 CPU feature 模拟成本。

x86 TSC 校准参考 Linux 的分层思路：可信的 hypervisor/CPUID.15 信息优先，缺少明确 TSC 频率时用 ACPI PM Timer 或 PIT 这类硬件计数器校准，再把 CPUID.16/base MHz 作为最后兜底。这样能覆盖 QEMU/KVM、TCG 和缺少 CPUID crystal 信息的机器，同时保持 `someboot`/`somehal` 不依赖 OS。

## 本地验证

- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p axbuild --lib dynamic_x86_64_qemu_boot`
  - 通过，8 passed
- `cargo test -p axbuild --lib apk_curl_equivalence_is_in_system_grouped_qemu_case`
  - 通过，1 passed
- `cargo xtask clippy --package axbuild`
  - 通过
- `cargo xtask clippy --package someboot`
  - 通过，7 checks passed
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/bug-ext4-dir-ops`
  - 通过，qemu-run 约 17.09s
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/apk-curl-equivalence`
  - 通过，qemu-run 约 23.89s
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/syscall-test-select-poll-family`
  - 通过，qemu-run 约 17.89s
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/syscall-test-timer-family`
  - 通过，qemu-run 约 42.44s
- `cargo xtask arceos test qemu --arch x86_64 -g rust -c task-yield`
  - 通过，x86 SMP smoke 正常启动并完成
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system/bug-ext4-dir-ops`
  - 通过，qemu-run 约 4.41s
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system/apk-curl-equivalence`
  - 通过，qemu-run 约 4.88s
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp1/system/bug-ext4-dir-ops`
  - 通过，qemu-run 约 4.70s
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp1/system/apk-curl-equivalence`
  - 通过，qemu-run 约 6.42s

补充说明：本地曾运行 `cargo test -p axbuild --lib`，当前仓库已有的 `checked_in_build_configs_do_not_declare_default_dynamic_builds` 断言会因若干 checked-in build config 显式声明 `plat_dyn = true` 失败；该失败不属于本 PR 修改范围，因此本次用相关定向 axbuild 单测覆盖变更逻辑。