### PR TITLE
fix(starry): reprogram timer for short deadlines

### DIFF
--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -438,7 +438,7 @@ pub(crate) fn init_percpu_irq(cpu_id: usize) {
             .expect("failed to register IPI IRQ handler");
     }
 
-    update_timer(ax_hal::time::irq_num());
+    init_timer();
 }
 
 #[cfg(all(feature = "irq", feature = "ipi"))]
@@ -455,18 +455,58 @@ const PERIODIC_INTERVAL_NANOS: u64 = ax_hal::time::NANOS_PER_SEC / ax_config::TI
 
 #[cfg(feature = "irq")]
 #[ax_percpu::def_percpu]
-static NEXT_DEADLINE: u64 = 0;
+static NEXT_PERIODIC_DEADLINE_NANOS: u64 = 0;
 
 #[cfg(feature = "irq")]
-fn update_timer(_irq_num: usize) {
+fn init_timer() {
     let now_ns = ax_hal::time::monotonic_time_nanos();
-    // Safety: we have disabled preemption in IRQ handler.
-    let mut deadline = unsafe { NEXT_DEADLINE.read_current_raw() };
-    if now_ns >= deadline {
-        deadline = now_ns + PERIODIC_INTERVAL_NANOS;
+    unsafe {
+        NEXT_PERIODIC_DEADLINE_NANOS
+            .write_current_raw(now_ns.saturating_add(PERIODIC_INTERVAL_NANOS));
     }
-    unsafe { NEXT_DEADLINE.write_current_raw(deadline + PERIODIC_INTERVAL_NANOS) };
+    program_next_timer();
+}
+
+#[cfg(feature = "irq")]
+fn advance_periodic_timer(now_ns: u64) -> bool {
+    let mut deadline = unsafe { NEXT_PERIODIC_DEADLINE_NANOS.read_current_raw() };
+    if deadline == 0 {
+        unsafe {
+            NEXT_PERIODIC_DEADLINE_NANOS
+                .write_current_raw(now_ns.saturating_add(PERIODIC_INTERVAL_NANOS));
+        }
+        return false;
+    }
+    if now_ns < deadline {
+        return false;
+    }
+
+    while deadline <= now_ns {
+        deadline = deadline.saturating_add(PERIODIC_INTERVAL_NANOS);
+        if deadline == u64::MAX {
+            break;
+        }
+    }
+    unsafe { NEXT_PERIODIC_DEADLINE_NANOS.write_current_raw(deadline) };
+    true
+}
+
+#[cfg(feature = "irq")]
+fn program_next_timer() {
+    let mut deadline = unsafe { NEXT_PERIODIC_DEADLINE_NANOS.read_current_raw() };
+    if deadline == 0 {
+        let now_ns = ax_hal::time::monotonic_time_nanos();
+        deadline = now_ns.saturating_add(PERIODIC_INTERVAL_NANOS);
+        unsafe { NEXT_PERIODIC_DEADLINE_NANOS.write_current_raw(deadline) };
+    }
+    #[cfg(feature = "multitask")]
+    if let Some(task_deadline) = ax_task::next_timer_deadline_nanos() {
+        deadline = core::cmp::min(deadline, task_deadline);
+    }
+
     ax_hal::time::set_oneshot_timer(deadline);
+    #[cfg(feature = "multitask")]
+    ax_task::note_programmed_timer_deadline_nanos(deadline);
 }
 
 #[cfg(feature = "irq")]
@@ -474,9 +514,14 @@ unsafe fn timer_irq_handler(
     ctx: ax_hal::irq::IrqContext,
     _data: core::ptr::NonNull<()>,
 ) -> ax_hal::irq::IrqReturn {
-    update_timer(ctx.irq.0);
+    let _ = ctx;
     #[cfg(feature = "multitask")]
-    ax_task::on_timer_tick();
+    let scheduler_tick = advance_periodic_timer(ax_hal::time::monotonic_time_nanos());
+    #[cfg(not(feature = "multitask"))]
+    let _ = advance_periodic_timer(ax_hal::time::monotonic_time_nanos());
+    #[cfg(feature = "multitask")]
+    ax_task::on_timer_irq(scheduler_tick);
+    program_next_timer();
     ax_hal::irq::IrqReturn::Handled
 }
 

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -166,11 +166,32 @@ pub fn init_scheduler_secondary(stack_ptr: VirtAddr, stack_size: usize) {
 #[cfg(feature = "irq")]
 #[cfg_attr(doc, doc(cfg(feature = "irq")))]
 pub fn on_timer_tick() {
+    on_timer_irq(true);
+}
+
+/// Handles a hardware timer interrupt.
+#[cfg(feature = "irq")]
+#[cfg_attr(doc, doc(cfg(feature = "irq")))]
+pub fn on_timer_irq(scheduler_tick: bool) {
     use ax_kernel_guard::NoOp;
-    crate::timers::check_events();
-    // Since irq and preemption are both disabled here,
-    // we can get current run queue with the default `ax_kernel_guard::NoOp`.
-    current_run_queue::<NoOp>().scheduler_timer_tick();
+    crate::timers::check_events(scheduler_tick);
+    if scheduler_tick {
+        // Since irq and preemption are both disabled here,
+        // we can get current run queue with the default `ax_kernel_guard::NoOp`.
+        current_run_queue::<NoOp>().scheduler_timer_tick();
+    }
+}
+
+#[cfg(feature = "irq")]
+#[doc(hidden)]
+pub fn next_timer_deadline_nanos() -> Option<u64> {
+    crate::timers::next_deadline_nanos()
+}
+
+#[cfg(feature = "irq")]
+#[doc(hidden)]
+pub fn note_programmed_timer_deadline_nanos(deadline_nanos: u64) {
+    crate::timers::note_programmed_deadline_nanos(deadline_nanos);
 }
 
 /// Adds the given task to the run queue, returns the task reference.

--- a/os/arceos/modules/axtask/src/future/time.rs
+++ b/os/arceos/modules/axtask/src/future/time.rs
@@ -57,6 +57,11 @@ impl TimerRuntime {
         self.wheel.remove(key);
     }
 
+    #[cfg(feature = "irq")]
+    fn next_deadline(&self) -> Option<TimeValue> {
+        self.wheel.keys().next().map(|key| key.deadline)
+    }
+
     fn wake(&mut self) {
         if self.wheel.is_empty() {
             return;
@@ -84,6 +89,11 @@ percpu_static! {
 pub(crate) fn check_timer_events() {
     // SAFETY: only called in timer::check_events
     unsafe { TIMER_RUNTIME.current_ref_mut_raw() }.wake();
+}
+
+#[cfg(feature = "irq")]
+pub(crate) fn next_timer_deadline() -> Option<TimeValue> {
+    with_current(|r| r.next_deadline())
 }
 
 fn with_current<R>(f: impl FnOnce(&mut TimerRuntime) -> R) -> R {
@@ -119,6 +129,8 @@ pub async fn sleep(duration: Duration) {
 pub async fn sleep_until(deadline: TimeValue) {
     let key = with_current(|r| r.add(deadline));
     if let Some(key) = key {
+        #[cfg(feature = "irq")]
+        crate::timers::maybe_reprogram_timer(deadline);
         TimerFuture(key).await;
     }
 }

--- a/os/arceos/modules/axtask/src/timers.rs
+++ b/os/arceos/modules/axtask/src/timers.rs
@@ -14,6 +14,7 @@ static TIMER_TICKET_ID: AtomicU64 = AtomicU64::new(1);
 percpu_static! {
     TIMER_LIST: TimerList<TaskWakeupEvent> = TimerList::new(),
     TIMER_CALLBACKS: Vec<Box<dyn Fn(TimeValue) + Send + Sync>> = Vec::new(),
+    PROGRAMMED_DEADLINE_NANOS: u64 = 0,
 }
 
 struct TaskWakeupEvent {
@@ -73,19 +74,51 @@ fn check_callbacks() {
     }
 }
 
+fn deadline_to_nanos(deadline: TimeValue) -> u64 {
+    deadline.as_nanos().min(u64::MAX as u128) as u64
+}
+
+pub(crate) fn note_programmed_deadline_nanos(deadline_nanos: u64) {
+    unsafe { PROGRAMMED_DEADLINE_NANOS.write_current_raw(deadline_nanos) };
+}
+
+pub(crate) fn maybe_reprogram_timer(deadline: TimeValue) {
+    let deadline_nanos = deadline_to_nanos(deadline);
+    let _g = NoPreemptIrqSave::new();
+    let programmed = unsafe { PROGRAMMED_DEADLINE_NANOS.read_current_raw() };
+    if programmed == 0 || deadline_nanos < programmed {
+        unsafe { PROGRAMMED_DEADLINE_NANOS.write_current_raw(deadline_nanos) };
+        ax_hal::time::set_oneshot_timer(deadline_nanos);
+    }
+}
+
+pub(crate) fn next_deadline_nanos() -> Option<u64> {
+    let timer_list_deadline = unsafe { TIMER_LIST.current_ref_raw() }.next_deadline();
+    let future_deadline = crate::future::next_timer_deadline();
+
+    match (timer_list_deadline, future_deadline) {
+        (Some(a), Some(b)) => Some(deadline_to_nanos(core::cmp::min(a, b))),
+        (Some(deadline), None) | (None, Some(deadline)) => Some(deadline_to_nanos(deadline)),
+        (None, None) => None,
+    }
+}
+
 pub(crate) fn set_alarm_wakeup(deadline: TimeValue, task: AxTaskRef) {
     let _g = NoPreemptIrqSave::new();
     TIMER_LIST.with_current(|timer_list| {
         let ticket_id = TIMER_TICKET_ID.fetch_add(1, Ordering::AcqRel);
         task.set_timer_ticket(ticket_id);
         timer_list.set(deadline, TaskWakeupEvent { ticket_id, task });
-    })
+    });
+    maybe_reprogram_timer(deadline);
 }
 
 // SAFETY: only called in timer irq handler, so irq and preemption are
 // both disabled here.
-pub fn check_events() {
-    check_callbacks();
+pub fn check_events(run_callbacks: bool) {
+    if run_callbacks {
+        check_callbacks();
+    }
     loop {
         let now = monotonic_time();
         let event = unsafe {

--- a/scripts/axbuild/src/test/qemu.rs
+++ b/scripts/axbuild/src/test/qemu.rs
@@ -1163,8 +1163,15 @@ fn dynamic_x86_64_nested_virtualization_features(cargo: &Cargo) -> &'static [&'s
         )
     }) {
         &["svm", "npt", "nrip-save"]
-    } else {
+    } else if cargo.features.iter().any(|feature| {
+        matches!(
+            feature.as_str(),
+            "vmx" | "axvm/vmx" | "x86_vcpu/vmx" | "x86-vcpu/vmx"
+        )
+    }) {
         &["vmx-ept", "vmx-unrestricted-guest", "vmx-flexpriority"]
+    } else {
+        &[]
     }
 }
 
@@ -1877,9 +1884,40 @@ mod tests {
             qemu.args,
             [
                 "-cpu",
-                "host,+x2apic,-la57,+vmx-ept,+vmx-unrestricted-guest,+vmx-flexpriority",
+                "host,+x2apic,-la57",
                 "-machine",
                 "q35",
+                "-net",
+                "none",
+                "-vga",
+                "none"
+            ]
+        );
+    }
+
+    #[test]
+    fn dynamic_x86_64_qemu_boot_enables_vmx_nested_features_for_vmx_backend() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _debug = TempEnvVar::unset(DYNAMIC_X86_64_QEMU_DEBUG_ENV);
+        let cargo = Cargo {
+            target: "scripts/targets/pie/x86_64-unknown-none.json".to_string(),
+            features: vec!["dyn-plat".to_string(), "vmx".to_string()],
+            to_bin: true,
+            ..Default::default()
+        };
+        let mut qemu = QemuConfig {
+            args: vec!["-cpu".to_string(), "host".to_string()],
+            ..Default::default()
+        };
+
+        apply_dynamic_platform_qemu_boot_with_kvm_probe(&mut qemu, &cargo, || false);
+        apply_dynamic_platform_qemu_boot_with_kvm_probe(&mut qemu, &cargo, || false);
+
+        assert_eq!(
+            qemu.args,
+            [
+                "-cpu",
+                "host,-la57,+vmx-ept,+vmx-unrestricted-guest,+vmx-flexpriority",
                 "-net",
                 "none",
                 "-vga",


### PR DESCRIPTION
## 问题

Starry x86_64 QEMU CI 明显慢于其他架构，尤其是 smp4 下 timerfd 相关测试。排查后确认 x86_64 的基础时间频率并没有明显错误：`clock_gettime`、含固定 sleep 的 `vfork` 测试以及 someboot 的 TSC 探测路径都显示时间推进合理。真正被放大的路径是短 deadline 只依赖 100Hz periodic tick 触发，1ms 级 timerfd 唤醒在 x86_64 smp4 下会等待过粗的周期 tick。

## 修改

- 在 axruntime 的 timer IRQ 路径中维护 periodic tick deadline，并将硬件 one-shot timer 编程到 periodic tick 和 axtask 最近任务/异步定时器 deadline 的较早者。
- 在 axtask 中暴露最近 timer deadline，并在新增更早 deadline 时即时重编程硬件 timer。
- 将 timer IRQ 处理拆成 `scheduler_tick` 和普通短 deadline IRQ，避免每个短 one-shot IRQ 都触发 100Hz 调度 tick/回调逻辑。
- 调整 dynamic x86_64 QEMU CPU flags：只有显式启用 vmx/svm 后端时才添加 nested virtualization flags，普通 Starry 动态平台启动不再默认带 VMX 扩展。

## 效果

本地单例 `qemu-smp4/test-timerfd-efault-wake` 对比：

- x86_64 KVM：修复前 guest elapsed 约 129s / qemu-run 约 135.9s，修复后 guest elapsed 约 85s / qemu-run 约 91.4s。
- x86_64 强制 TCG：修复前 guest elapsed 约 50s / qemu-run 约 56s，修复后 guest elapsed 约 17s / qemu-run 约 26.1s。
- riscv64 同单例 guest elapsed 约 18s / qemu-run 约 21.95s。

因此 CI 类无 KVM/TCG 场景已经基本回到 riscv64 同量级；剩余 KVM 差距更像 x86_64 Q35/UEFI/KVM APIC timer 路径的额外开销，而不是时钟频率探测错误。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package ax-task`
- `cargo xtask clippy --package ax-runtime`
- `cargo xtask clippy --package axbuild`
- `cargo test -p axbuild dynamic_x86_64_qemu_boot -- --nocapture`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp4/test-timerfd-efault-wake`
