### PR TITLE
fix(ci): limit self-hosted checkout depth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,17 @@ jobs:
           && format('{0}:latest', needs.detect_changes.outputs.base_container_image)
           || matrix.container_image
         }}
-      fetch_depth: ${{ matrix.fetch_depth == 'full' && '0' || '1' }}
+      fetch_depth: >-
+        ${{
+          contains(matrix.runs_on, 'self-hosted')
+          && !(
+            matrix.self_hosted_owner != ''
+            && github.repository_owner != matrix.self_hosted_owner
+          )
+          && matrix.fetch_depth == 'full'
+          && '2'
+          || (matrix.fetch_depth == 'full' && '0' || '1')
+        }}
       upload_xtask_bin_artifact: ${{ matrix.upload_xtask_bin_artifact || false }}
       xtask_bin_artifact_name: tg-xtask-bin
 
@@ -690,7 +700,17 @@ jobs:
       apk_region: ${{ matrix.apk_region || 'china' }}
       limit_to_owner: ${{ matrix.limit_to_owner }}
       main_pr_only: ${{ matrix.main_pr_only }}
-      fetch_depth: ${{ matrix.fetch_depth == 'full' && '0' || '1' }}
+      fetch_depth: >-
+        ${{
+          contains(matrix.runs_on, 'self-hosted')
+          && !(
+            matrix.self_hosted_owner != ''
+            && github.repository_owner != matrix.self_hosted_owner
+          )
+          && matrix.fetch_depth == 'full'
+          && '2'
+          || (matrix.fetch_depth == 'full' && '0' || '1')
+        }}
       timeout_minutes: ${{ matrix.timeout_minutes || 360 }}
       download_xtask_bin_artifact: >-
         ${{


### PR DESCRIPTION
## 问题

self-hosted CI job 里复用 `fetch_depth: full` 时会触发完整 Git 历史拉取，历史较大时会消耗较多网络流量。`cargo xtask clippy --since` 需要一定的提交历史来做增量选择，但常见 PR merge commit 或单提交 push 场景并不需要完整历史。

## 修改

- 在 `static_checks` 和 `test_checks` 调用 reusable workflow 时，对实际运行在 self-hosted runner 上且原本要求 full history 的 job，将 `fetch_depth` 收敛为 `2`。
- 保持普通 GitHub runner 上的 `fetch_depth: full` 语义不变，继续让 `sync-lint --since` 等增量检查可以访问完整历史。
- 保持其他 self-hosted 测试 job 的浅克隆行为为默认 depth 1。

## 逻辑

`cargo xtask clippy --since` 在找不到 diff base 时会退化为全工作区 clippy，而不是直接失败。self-hosted 上使用 depth 2 可以覆盖 PR merge commit 和单提交 push 的常见增量场景，同时避免拉取完整历史。多提交 push 如果 `github.event.before` 超出浅克隆范围，仍会按现有 xtask 逻辑退化为全量 clippy。

## 验证

- `python3` + PyYAML 解析 `.github/workflows/ci.yml` 通过
- `git diff --check -- .github/workflows/ci.yml` 通过

本次仅修改 GitHub Actions workflow，未修改 Rust crate，因此未运行 `cargo fmt` / `cargo clippy`。
