### PR TITLE
fix(x86_64): reduce Starry userspace switch overhead

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -44,6 +44,7 @@ Current Axvisor LoongArch QEMU tests intentionally use the static `ax-hal/loonga
 - Allocate and align boot stack, per-CPU areas, secondary stacks, boot arguments, and page tables before enabling SMP.
 - Install trap vectors before enabling interrupts, timer interrupts, MMU faults, or secondary CPU execution.
 - On x86 QEMU, do not trust CPUID timing leaves unless the reported TSC frequency is plausible; some virtual CPU combinations expose invalid zero or tiny values. Prefer a trusted hypervisor timing leaf, then CPUID timing data, then PIT-based TSC calibration before falling back to processor base frequency.
+- On x86, enable `CR4.FSGSBASE` per CPU when CPUID advertises it so runtime TLS and inactive GS-base switches can use `RDFSBASE`/`WRFSBASE`/`RDGSBASE`/`WRGSBASE` instead of MSR reads and writes; keep the MSR fallback for older CPU models.
 - Build page tables for identity/firmware access, direct map, kernel high map, MMIO, and per-CPU data as the arch requires.
 - Flush TLB/cache and use architecture barriers around page table writes, boot argument writes, and secondary CPU release.
 - After `ExitBootServices`, do not call UEFI Boot Services. Retry only through the correct memory-map-key sequence before exit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,7 @@ jobs:
             command: target/debug/tg-xtask starry test qemu --arch x86_64
             cache_key: test-starry-x86_64
             container_image: base
+            container_options: --device /dev/kvm
             apk_region: us
             limit_to_owner: ""
             main_pr_only: false
@@ -697,6 +698,7 @@ jobs:
           && format('{0}:latest', needs.detect_changes.outputs.axvisor_lvz_container_image)
           || matrix.container_image
         }}
+      container_options: ${{ matrix.container_options || '' }}
       apk_region: ${{ matrix.apk_region || 'china' }}
       limit_to_owner: ${{ matrix.limit_to_owner }}
       main_pr_only: ${{ matrix.main_pr_only }}

--- a/.github/workflows/reusable-command.yml
+++ b/.github/workflows/reusable-command.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: ""
+      container_options:
+        description: Additional docker create options used when use_container is true.
+        required: false
+        type: string
+        default: ""
       apk_region:
         description: APK mirror region passed through to Starry prebuild flows.
         required: false
@@ -113,6 +118,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     container:
       image: ${{ inputs.container_image }}
+      options: ${{ inputs.container_options }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -183,6 +189,15 @@ jobs:
 
       - name: Show Rust version
         run: rustc --version
+
+      - name: Show KVM device
+        if: contains(inputs.container_options, '/dev/kvm')
+        shell: bash
+        run: |
+          set -eux
+          ls -l /dev/kvm
+          test -r /dev/kvm
+          test -w /dev/kvm
 
       - name: Run command
         shell: bash

--- a/components/axcpu/src/aarch64/asm.rs
+++ b/components/axcpu/src/aarch64/asm.rs
@@ -114,6 +114,12 @@ pub unsafe fn write_user_page_table(root_paddr: PhysAddr) {
     TTBR0_EL1.set(root_paddr.as_usize() as _);
 }
 
+/// Returns whether [`write_user_page_table`] flushes the current CPU's TLB.
+#[inline]
+pub const fn write_user_page_table_flushes_tlb() -> bool {
+    false
+}
+
 /// Flushes the TLB.
 ///
 /// If `vaddr` is [`None`], flushes the entire TLB. Otherwise, flushes the TLB

--- a/components/axcpu/src/loongarch64/asm.rs
+++ b/components/axcpu/src/loongarch64/asm.rs
@@ -66,6 +66,12 @@ pub unsafe fn write_user_page_table(root_paddr: PhysAddr) {
     pgdl::set_base(root_paddr.as_usize() as _);
 }
 
+/// Returns whether [`write_user_page_table`] flushes the current CPU's TLB.
+#[inline]
+pub const fn write_user_page_table_flushes_tlb() -> bool {
+    false
+}
+
 /// Writes the register to update the current page table root for kernel space
 /// (`PGDH`).
 ///

--- a/components/axcpu/src/riscv/asm.rs
+++ b/components/axcpu/src/riscv/asm.rs
@@ -77,6 +77,12 @@ pub unsafe fn write_user_page_table(root_paddr: PhysAddr) {
     unsafe { satp::set(satp::Mode::Sv39, 0, root_paddr.as_usize() >> 12) };
 }
 
+/// Returns whether [`write_user_page_table`] flushes the current CPU's TLB.
+#[inline]
+pub const fn write_user_page_table_flushes_tlb() -> bool {
+    false
+}
+
 /// Writes the register to update the current page table root for user space
 /// (`satp`).
 ///

--- a/components/axcpu/src/x86_64/asm.rs
+++ b/components/axcpu/src/x86_64/asm.rs
@@ -1,10 +1,19 @@
 //! Wrapper functions for assembly instructions.
 
-use core::arch::asm;
+use core::{
+    arch::asm,
+    sync::atomic::{AtomicU8, Ordering},
+};
 
 use ax_memory_addr::{MemoryAddr, PhysAddr, VirtAddr};
-use x86::{controlregs, msr, tlb};
+use x86::{bits64::segmentation, controlregs, cpuid::CpuId, msr, tlb};
 use x86_64::instructions::interrupts;
+
+const FSGSBASE_UNKNOWN: u8 = 0;
+const FSGSBASE_UNSUPPORTED: u8 = 1;
+const FSGSBASE_SUPPORTED: u8 = 2;
+
+static FSGSBASE_STATE: AtomicU8 = AtomicU8::new(FSGSBASE_UNKNOWN);
 
 /// Allows the current CPU to respond to interrupts.
 #[inline]
@@ -77,6 +86,12 @@ pub unsafe fn write_user_page_table(root_paddr: PhysAddr) {
     unsafe { controlregs::cr3_write(root_paddr.as_usize() as _) }
 }
 
+/// Returns whether [`write_user_page_table`] flushes the current CPU's TLB.
+#[inline]
+pub const fn write_user_page_table_flushes_tlb() -> bool {
+    true
+}
+
 /// Writes the register to update the current page table root for kernel space
 /// (`CR3`).
 ///
@@ -115,7 +130,11 @@ pub fn flush_tlb(vaddr: Option<VirtAddr>) {
 /// It is used to implement TLS (Thread Local Storage).
 #[inline]
 pub fn read_thread_pointer() -> usize {
-    unsafe { msr::rdmsr(msr::IA32_FS_BASE) as usize }
+    if fsgsbase_enabled() {
+        unsafe { segmentation::rdfsbase() as usize }
+    } else {
+        unsafe { msr::rdmsr(msr::IA32_FS_BASE) as usize }
+    }
 }
 
 /// Writes the thread pointer of the current CPU (`FS_BASE`).
@@ -127,7 +146,85 @@ pub fn read_thread_pointer() -> usize {
 /// This function is unsafe as it changes the CPU states.
 #[inline]
 pub unsafe fn write_thread_pointer(fs_base: usize) {
-    unsafe { msr::wrmsr(msr::IA32_FS_BASE, fs_base as u64) }
+    if fsgsbase_enabled() {
+        unsafe { segmentation::wrfsbase(fs_base as u64) };
+    } else {
+        unsafe { msr::wrmsr(msr::IA32_FS_BASE, fs_base as u64) };
+    }
+}
+
+/// Reads the inactive GS base, which `swapgs` will load on the next user entry.
+///
+/// # Safety
+///
+/// The FSGSBASE fast path temporarily swaps GS bases, so interrupts must stay
+/// disabled while this function runs.
+#[inline]
+pub unsafe fn read_inactive_gs_base() -> usize {
+    if fsgsbase_enabled() {
+        let gs_base: u64;
+        unsafe {
+            asm!(
+                "swapgs",
+                "rdgsbase {gs_base}",
+                "swapgs",
+                gs_base = out(reg) gs_base,
+                options(nostack, preserves_flags),
+            );
+        }
+        gs_base as usize
+    } else {
+        unsafe { msr::rdmsr(msr::IA32_KERNEL_GSBASE) as usize }
+    }
+}
+
+/// Writes the inactive GS base, which `swapgs` will load on the next user entry.
+///
+/// # Safety
+///
+/// This function is unsafe as it changes the CPU states. The FSGSBASE fast path
+/// temporarily swaps GS bases, so interrupts must stay disabled while it runs.
+#[inline]
+pub unsafe fn write_inactive_gs_base(gs_base: usize) {
+    if fsgsbase_enabled() {
+        unsafe {
+            asm!(
+                "swapgs",
+                "wrgsbase {gs_base}",
+                "swapgs",
+                gs_base = in(reg) gs_base as u64,
+                options(nostack, preserves_flags),
+            );
+        }
+    } else {
+        unsafe { msr::wrmsr(msr::IA32_KERNEL_GSBASE, gs_base as u64) };
+    }
+}
+
+#[inline]
+fn fsgsbase_enabled() -> bool {
+    match FSGSBASE_STATE.load(Ordering::Relaxed) {
+        FSGSBASE_SUPPORTED => true,
+        FSGSBASE_UNSUPPORTED => false,
+        _ => detect_fsgsbase_enabled(),
+    }
+}
+
+#[cold]
+fn detect_fsgsbase_enabled() -> bool {
+    let supported = CpuId::new()
+        .get_extended_feature_info()
+        .is_some_and(|info| info.has_fsgsbase())
+        && unsafe { controlregs::cr4() }.contains(controlregs::Cr4::CR4_ENABLE_FSGSBASE);
+    FSGSBASE_STATE.store(
+        if supported {
+            FSGSBASE_SUPPORTED
+        } else {
+            FSGSBASE_UNSUPPORTED
+        },
+        Ordering::Relaxed,
+    );
+    supported
 }
 
 #[cfg(feature = "uspace")]

--- a/components/axcpu/src/x86_64/uspace.rs
+++ b/components/axcpu/src/x86_64/uspace.rs
@@ -6,7 +6,7 @@ use ax_memory_addr::VirtAddr;
 use x86_64::{
     registers::{
         control::Cr2,
-        model_specific::{Efer, EferFlags, KernelGsBase, LStar, SFMask, Star},
+        model_specific::{Efer, EferFlags, LStar, SFMask, Star},
         rflags::RFlags,
     },
     structures::idt::ExceptionVector,
@@ -14,7 +14,9 @@ use x86_64::{
 
 use super::{
     TrapFrame,
-    asm::{read_thread_pointer, write_thread_pointer},
+    asm::{
+        read_inactive_gs_base, read_thread_pointer, write_inactive_gs_base, write_thread_pointer,
+    },
     gdt,
     trap::{IRQ_VECTOR_END, IRQ_VECTOR_START, LEGACY_SYSCALL_VECTOR, err_code_to_flags},
 };
@@ -87,11 +89,11 @@ impl UserContext {
 
         let kernel_fs_base = read_thread_pointer();
         unsafe { write_thread_pointer(self.fs_base as _) };
-        KernelGsBase::write(x86_64::VirtAddr::new_truncate(self.gs_base));
+        unsafe { write_inactive_gs_base(self.gs_base as _) };
 
         unsafe { enter_user(self) };
 
-        self.gs_base = KernelGsBase::read().as_u64();
+        self.gs_base = unsafe { read_inactive_gs_base() as _ };
         self.fs_base = read_thread_pointer() as _;
         unsafe { write_thread_pointer(kernel_fs_base) };
 

--- a/components/someboot/src/arch/x86_64/trap.rs
+++ b/components/someboot/src/arch/x86_64/trap.rs
@@ -83,6 +83,7 @@ pub fn trap_addr() -> usize {
 pub fn init_local() {
     mask_legacy_pic();
     enable_nxe();
+    enable_fsgsbase();
     enable_xsave_features();
     init_tsc_freq();
     init_lapic();
@@ -443,6 +444,19 @@ fn enable_nxe() {
     let efer = unsafe { rdmsr(IA32_EFER) } | IA32_EFER_NXE;
     unsafe {
         wrmsr(IA32_EFER, efer);
+    }
+}
+
+fn enable_fsgsbase() {
+    let Some(info) = CpuId::new().get_extended_feature_info() else {
+        return;
+    };
+    if !info.has_fsgsbase() {
+        return;
+    }
+
+    unsafe {
+        controlregs::cr4_write(controlregs::cr4() | controlregs::Cr4::CR4_ENABLE_FSGSBASE);
     }
 }
 

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -236,7 +236,9 @@ impl TaskInner {
         // SAFETY: we are the current task and no other thread touches our ctx.
         unsafe { (*self.ctx.get()).set_page_table_root(root) };
         unsafe { ax_hal::asm::write_user_page_table(root) };
-        ax_hal::asm::flush_tlb(None);
+        if !ax_hal::asm::write_user_page_table_flushes_tlb() {
+            ax_hal::asm::flush_tlb(None);
+        }
     }
 
     #[cfg(feature = "lockdep")]


### PR DESCRIPTION
## 问题

`starry qemu-smp1/system` 在 x86_64 CI 上明显慢于其他架构。对 CI 日志和本地运行结果做对比后，主要慢点不在单个用户程序本身，也不是测试脚本应当被规避的问题，而是大量短用户态程序之间的 fork/exec/wait/date 路径把 x86_64 内核态切换成本放大了。

对比其他架构后，x86_64 的热路径额外包含两类高成本操作：

1. 用户态进入/返回时通过 MSR 读写 `FS_BASE` 和 inactive `GS_BASE`。在 QEMU TCG 下 MSR 访问非常贵，Linux 也会在 CPU 支持时启用 `CR4.FSGSBASE` 并用 `RDFSBASE`/`WRFSBASE`/`RDGSBASE`/`WRGSBASE` 避开这条慢路径。
2. x86_64 写 `CR3` 本身已经 flush 当前 CPU TLB，但任务切换页表后又额外做了一次全 TLB flush，短进程密集场景下会反复付出重复成本。

这不是通过修改 test-suit 绕过的问题；测试只是暴露了内核 x86_64 用户态切换路径比其他架构更贵。

## 修改

- 在 someboot x86_64 per-CPU 初始化中，当 CPUID 报告 FSGSBASE 时启用 `CR4.FSGSBASE`。
- 在 ax-cpu x86_64 中优先用 FSGSBASE 指令读写 `FS_BASE` 和 inactive `GS_BASE`，保留 MSR fallback 以兼容旧 CPU。
- 在 ax-task 页表切换路径中区分 `write_user_page_table()` 是否已经 flush TLB：x86_64 写 CR3 后不再重复全 TLB flush，其他架构保持显式 flush。
- 给 Starry x86_64 QEMU 的 GitHub Actions 容器传入 `--device /dev/kvm`，并在日志中打印 `/dev/kvm` 状态，用于确认 GitHub-hosted container 是否能启用 KVM 加速。
- 更新 arch platform porting 说明，记录 x86_64 FSGSBASE per-CPU 初始化要求。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package ax-cpu`：28 checks passed
- `cargo xtask clippy --package ax-task`：18 checks passed
- `cargo xtask clippy --package someboot`：7 checks passed
- `git diff --check`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/syscall-test-uid-gid-re-setters`：PASS，`qemu run: 74.81s`
- workflow 变更本地验证：`git diff --check -- .github/workflows/ci.yml .github/workflows/reusable-command.yml`

补充观察：本地 TCG 对比中，同一重 syscall 单用例在启用/关闭 FSGSBASE 时 wall time 约为 16s vs 18s，说明 MSR 路径确实是 x86_64 特有开销来源之一；剩余差距还可能包含 x86_64 UEFI 启动、FPU save/restore、以及 CI 容器是否能使用 KVM 等成本，需要完整 CI 继续量化。
