### PR TITLE
fix(ci): enable KVM and eliminate unnecessary TLB flush for x86_64 StarryOS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,7 @@ jobs:
             command: target/debug/tg-xtask starry test qemu --arch x86_64
             cache_key: test-starry-x86_64
             container_image: base
+            kvm: true
             apk_region: us
             limit_to_owner: ""
             main_pr_only: false

--- a/.github/workflows/reusable-command.yml
+++ b/.github/workflows/reusable-command.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: ""
+      kvm:
+        description: Pass /dev/kvm into the container (x86_64 KVM acceleration).
+        required: false
+        type: boolean
+        default: false
       apk_region:
         description: APK mirror region passed through to Starry prebuild flows.
         required: false
@@ -116,6 +121,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      options: ${{ inputs.kvm && '--device /dev/kvm' || '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/memory/page_table_multiarch/src/bits64.rs
+++ b/memory/page_table_multiarch/src/bits64.rs
@@ -644,6 +644,15 @@ impl<'a, M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64Cursor
         self.flusher = TlbFlusher::Full;
     }
 
+    /// Clears any pending TLB flush without performing it.
+    ///
+    /// Useful when the cursor has modified a page table that is not the
+    /// currently-loaded one (e.g. a new address space created for fork/exec).
+    /// In that situation a TLB flush would evict valid entries for no benefit.
+    pub fn clear_flush(&mut self) {
+        self.flusher = TlbFlusher::None;
+    }
+
     /// Flushes the TLB according to the recorded flush requests.
     pub fn flush(&mut self) {
         #[cfg(not(docsrs))]

--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -55,11 +55,17 @@ pub fn copy_from_kernel(_aspace: &mut AddrSpace) -> AxResult {
         // (aarch64: TTBR0_EL1, LoongArch64: PGDL), so there is no need to copy the
         // kernel portion to the user page table.
         let kspace = ax_mm::kernel_aspace().lock();
-        _aspace.page_table_mut().cursor().copy_from(
-            kspace.page_table(),
-            kspace.base(),
-            kspace.size(),
-        );
+        let mut cursor = _aspace.page_table_mut().cursor();
+        cursor.copy_from(kspace.page_table(), kspace.base(), kspace.size());
+        // The cursor sets TlbFlusher::Full inside copy_from, which would flush the
+        // TLB when the cursor is dropped. However, we are modifying a page table
+        // that is NOT currently loaded on this CPU (it belongs to a new address
+        // space created for fork/exec). A full TLB flush here is both unnecessary
+        // and harmful — it evicts valid entries from the current CPU's TLB,
+        // forcing expensive page-table walks on every subsequent memory access
+        // until the TLB repopulates. This is particularly costly under QEMU TCG
+        // emulation. Suppress the flush.
+        cursor.clear_flush();
     }
     Ok(())
 }


### PR DESCRIPTION
## 问题

x86_64 StarryOS QEMU 测试明显比其他架构慢（~28 min vs aarch64 ~9 min），每个子测例（用户态程序退出→启动）耗时 ~3.5s，而 aarch64 仅 ~0.4s。

## 根因分析

**主因：CI 中 x86_64 运行在 TCG 软件模拟模式，未启用 KVM 硬件加速**

CI 日志确认：`qemu-system-x86_64: warning: TCG doesn't support requested feature`。代码已有 KVM 探测逻辑（`apply_x86_64_kvm_accel_if_available` 检查 `/dev/kvm`），但容器内无法访问该设备。TCG 模式下 x86_64 指令模拟比 aarch64 指令模拟慢 ~3-8x。

**次因：`copy_from_kernel()` 每次触发不必要的全量 TLB flush**

x86_64 的 fork/exec 每次创建新地址空间时需要复制内核页表（aarch64 因 TTBR0/TTBR1 分离无需此操作）。`copy_from` 设置 `TlbFlusher::Full`，cursor drop 时执行完整 TLB flush。但被修改的是新进程页表，不是当前 CPU 页表，flush 完全不必要且有害——清除当前 CPU 有效 TLB 条目，后续内存访问需昂贵页表遍历。

## 修复

| 文件 | 修改 |
|------|------|
| `.github/workflows/reusable-command.yml` | 新增 `kvm` 输入参数，控制容器是否传递 `/dev/kvm` |
| `.github/workflows/ci.yml` | x86_64 StarryOS 测试启用 `kvm: true` |
| `memory/page_table_multiarch/src/bits64.rs` | page table cursor 新增 `clear_flush()` 方法 |
| `os/StarryOS/kernel/src/mm/loader.rs` | `copy_from_kernel()` 调用 `clear_flush()` 避免不必要 TLB flush |

## 预期效果

- **KVM 加速**：从 TCG 切换到 KVM，性能预计提升 10-50x，测试时间从 ~28 min 降至 1-3 min
- **消除 TLB flush**：每次 fork/exec 减少一次不必要的全量 TLB flush，对 TCG 和裸机均有益