### PR TITLE
chore(ci): add cargo publish dry-run check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,14 @@ jobs:
             cache_key: ""
             container_image: base
             fetch_depth: "1"
+          - name: Check cargo publish dry-run
+            use_container: false
+            runs_on: '["self-hosted","linux","qcs"]'
+            self_hosted_owner: rcore-os
+            command: cargo publish --workspace --dry-run --no-verify
+            cache_key: ""
+            container_image: base
+            fetch_depth: "1"
           - name: Run sync-lint
             use_container: true
             runs_on: '["ubuntu-latest"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,15 +291,9 @@ jobs:
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
-            command: cargo fmt --all -- --check
-            cache_key: ""
-            container_image: base
-            fetch_depth: "1"
-          - name: Check cargo publish dry-run
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo publish --workspace --dry-run --no-verify
+            command: |
+              cargo fmt --all -- --check
+              cargo publish --workspace --dry-run --no-verify
             cache_key: ""
             container_image: base
             fetch_depth: "1"

--- a/os/StarryOS/lkm/hello/Cargo.toml
+++ b/os/StarryOS/lkm/hello/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hello"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 ax-feat = { workspace = true, features = ["ext-ld", "fs-ng-times", "irq"] }


### PR DESCRIPTION
## 问题

当前 CI 只有格式化等静态检查，没有在 PR 阶段覆盖 workspace crate 的发布前打包检查。这样容易遗漏 `Cargo.toml` 元数据、包内容、publish 开关等发布相关问题。

同时 `os/StarryOS/lkm/hello` 是示例内核模块，不应该作为 crates.io 发布目标参与 workspace publish 检查。

## 修改

- 在 CI 的 static checks 中，紧跟 `cargo fmt --all -- --check` 增加 `cargo publish --workspace --dry-run --no-verify`。
- 给 `os/StarryOS/lkm/hello` 增加 `publish = false`，避免示例 LKM 被纳入发布目标。

这里使用 `--no-verify` 是因为当前 workspace 直接执行完整 `cargo publish --workspace --dry-run` 会在 verify 阶段触发既有 LoongArch 依赖的 host inline asm 编译问题；本次 CI 检查先覆盖发布打包、manifest 和上传前 dry-run 流程，避免把已有跨架构 verify 问题作为这次 CI 增量的阻塞点。

## 验证

- `cargo fmt --all -- --check`
- `cargo xtask clippy --package hello`：8 checks passed
- `git diff --cached --check`
- `cargo publish --workspace --dry-run --no-verify --allow-dirty`

补充：本地也尝试过不带 `--no-verify` 的 `cargo publish --workspace --dry-run`，失败点为 `loongArch64 0.2.6` 在 host verify 下 inline asm register class 编译错误，因此 CI 命令采用 `--no-verify`。
