### PR TITLE
Issue 595 device foundation

### DIFF
--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -33,8 +33,8 @@ use riscv_vplic::VPlicGlobal;
 use x86_vlapic::{EmulatedIoApic, EmulatedPit, EmulatedSerialPort, IoApicInterrupt};
 
 use crate::{
-    AxVmDeviceConfig, DeviceBundle, DeviceRegistration, PollableDeviceOps,
-    range_alloc::RangeAllocator,
+    AxVmDeviceConfig, DeviceBuildContext, DeviceBundle, DeviceFactoryRegistry, DeviceRegistration,
+    PollableDeviceOps, range_alloc::RangeAllocator,
 };
 
 /// A set of emulated device types that can be accessed by a specific address range type.
@@ -221,9 +221,8 @@ fn panic_device_not_found(
 
 /// The implemention for AxVmDevices
 impl AxVmDevices {
-    /// According AxVmDeviceConfig to init the AxVmDevices
-    pub fn new(config: AxVmDeviceConfig) -> AxResult<Self> {
-        let mut this = Self {
+    fn empty() -> Self {
+        Self {
             emu_mmio_devices: AxEmuMmioDevices::new(),
             emu_sys_reg_devices: AxEmuSysRegDevices::new(),
             emu_port_devices: AxEmuPortDevices::new(),
@@ -235,14 +234,70 @@ impl AxVmDevices {
             #[cfg(target_arch = "x86_64")]
             x86_serial: None,
             ivc_channel: None,
-        };
+        }
+    }
+
+    /// According AxVmDeviceConfig to init the AxVmDevices
+    pub fn new(config: AxVmDeviceConfig) -> AxResult<Self> {
+        let mut this = Self::empty();
 
         Self::init(&mut this, &config.emu_configs)?;
         Ok(this)
     }
 
+    /// Builds devices with registered factories and explicit legacy fallbacks.
+    pub fn build_with_factories(
+        config: AxVmDeviceConfig,
+        factories: &DeviceFactoryRegistry,
+        context: &DeviceBuildContext<'_>,
+    ) -> AxResult<Self> {
+        let mut this = Self::empty();
+        for config in &config.emu_configs {
+            if factories.get(config.emu_type).is_some() {
+                this.register_factory_device(config, factories, context)?;
+            } else if Self::is_legacy_fallback(config.emu_type) {
+                Self::init(&mut this, core::slice::from_ref(config))?;
+            } else {
+                return ax_err!(
+                    Unsupported,
+                    format_args!(
+                        "no factory is registered for emulated device '{}' of type {}",
+                        config.name, config.emu_type
+                    )
+                );
+            }
+        }
+        Ok(this)
+    }
+
+    /// Builds and atomically registers one factory-managed device.
+    pub fn register_factory_device(
+        &mut self,
+        config: &EmulatedDeviceConfig,
+        factories: &DeviceFactoryRegistry,
+        context: &DeviceBuildContext<'_>,
+    ) -> AxResult {
+        let bundle = factories.build(config, context)?;
+        self.register_bundle(bundle)
+    }
+
+    fn is_legacy_fallback(device_type: EmulatedDeviceType) -> bool {
+        matches!(
+            device_type,
+            EmulatedDeviceType::InterruptController
+                | EmulatedDeviceType::Console
+                | EmulatedDeviceType::IVCChannel
+                | EmulatedDeviceType::GPPTRedistributor
+                | EmulatedDeviceType::GPPTDistributor
+                | EmulatedDeviceType::GPPTITS
+                | EmulatedDeviceType::X86IoApic
+                | EmulatedDeviceType::X86Pit
+                | EmulatedDeviceType::PPPTGlobal
+        )
+    }
+
     /// According the emu_configs to init every  specific device
-    fn init(this: &mut Self, emu_configs: &Vec<EmulatedDeviceConfig>) -> AxResult {
+    fn init(this: &mut Self, emu_configs: &[EmulatedDeviceConfig]) -> AxResult {
         for config in emu_configs {
             match config.emu_type {
                 EmulatedDeviceType::InterruptController => {

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -32,7 +32,10 @@ use riscv_vplic::VPlicGlobal;
 #[cfg(target_arch = "x86_64")]
 use x86_vlapic::{EmulatedIoApic, EmulatedPit, EmulatedSerialPort, IoApicInterrupt};
 
-use crate::{AxVmDeviceConfig, range_alloc::RangeAllocator};
+use crate::{
+    AxVmDeviceConfig, DeviceBundle, DeviceRegistration, PollableDeviceOps,
+    range_alloc::RangeAllocator,
+};
 
 /// A set of emulated device types that can be accessed by a specific address range type.
 pub struct AxEmuDevices<R: DeviceAddrRange> {
@@ -47,8 +50,13 @@ impl<R: DeviceAddrRange + 'static> AxEmuDevices<R> {
         }
     }
 
-    /// Adds a device to the set after validating its range.
-    pub fn add_dev(&mut self, dev: Arc<dyn BaseDeviceOps<R>>) -> AxResult {
+    fn validate_dev_against<'a>(
+        dev: &Arc<dyn BaseDeviceOps<R>>,
+        existing_devices: impl IntoIterator<Item = &'a Arc<dyn BaseDeviceOps<R>>>,
+    ) -> AxResult
+    where
+        R: 'a,
+    {
         let new_range = dev.address_range();
         let new_type = dev.emu_type();
 
@@ -64,11 +72,11 @@ impl<R: DeviceAddrRange + 'static> AxEmuDevices<R> {
             );
         }
 
-        for existing in &self.emu_devices {
+        for existing in existing_devices {
             let existing_range = existing.address_range();
             let existing_type = existing.emu_type();
 
-            if Arc::ptr_eq(existing, &dev) {
+            if Arc::ptr_eq(existing, dev) {
                 return ax_err!(
                     AlreadyExists,
                     format_args!(
@@ -108,8 +116,29 @@ impl<R: DeviceAddrRange + 'static> AxEmuDevices<R> {
             }
         }
 
+        Ok(())
+    }
+
+    /// Validates a group of devices without modifying this set.
+    fn validate_devices(&self, devices: &[Arc<dyn BaseDeviceOps<R>>]) -> AxResult {
+        for (index, device) in devices.iter().enumerate() {
+            Self::validate_dev_against(
+                device,
+                self.emu_devices.iter().chain(devices[..index].iter()),
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Adds a device to the set after validating its range.
+    pub fn add_dev(&mut self, dev: Arc<dyn BaseDeviceOps<R>>) -> AxResult {
+        self.validate_devices(core::slice::from_ref(&dev))?;
         self.emu_devices.push(dev);
         Ok(())
+    }
+
+    fn commit_devices(&mut self, devices: Vec<Arc<dyn BaseDeviceOps<R>>>) {
+        self.emu_devices.extend(devices);
     }
 
     // pub fn remove_dev(&mut self, ...)
@@ -153,6 +182,7 @@ pub struct AxVmDevices {
     emu_mmio_devices: AxEmuMmioDevices,
     emu_sys_reg_devices: AxEmuSysRegDevices,
     emu_port_devices: AxEmuPortDevices,
+    pollable_devices: Vec<Arc<dyn PollableDeviceOps>>,
     #[cfg(target_arch = "x86_64")]
     x86_ioapic: Option<Arc<EmulatedIoApic>>,
     #[cfg(target_arch = "x86_64")]
@@ -197,6 +227,7 @@ impl AxVmDevices {
             emu_mmio_devices: AxEmuMmioDevices::new(),
             emu_sys_reg_devices: AxEmuSysRegDevices::new(),
             emu_port_devices: AxEmuPortDevices::new(),
+            pollable_devices: Vec::new(),
             #[cfg(target_arch = "x86_64")]
             x86_ioapic: None,
             #[cfg(target_arch = "x86_64")]
@@ -489,19 +520,46 @@ impl AxVmDevices {
         }
     }
 
+    /// Registers a bundle atomically after validating all capabilities.
+    pub fn register_bundle(&mut self, bundle: DeviceBundle) -> AxResult {
+        self.emu_mmio_devices.validate_devices(&bundle.mmio)?;
+        self.emu_port_devices.validate_devices(&bundle.port)?;
+        self.emu_sys_reg_devices.validate_devices(&bundle.sysreg)?;
+
+        for (index, pollable) in bundle.pollable.iter().enumerate() {
+            if self
+                .pollable_devices
+                .iter()
+                .chain(bundle.pollable[..index].iter())
+                .any(|existing| Arc::ptr_eq(existing, pollable))
+            {
+                return ax_err!(
+                    AlreadyExists,
+                    "failed to register pollable device: the same capability is already registered"
+                );
+            }
+        }
+
+        self.emu_mmio_devices.commit_devices(bundle.mmio);
+        self.emu_port_devices.commit_devices(bundle.port);
+        self.emu_sys_reg_devices.commit_devices(bundle.sysreg);
+        self.pollable_devices.extend(bundle.pollable);
+        Ok(())
+    }
+
     /// Add a MMIO device to the device list
     pub fn add_mmio_dev(&mut self, dev: Arc<dyn BaseMmioDeviceOps>) -> AxResult {
-        self.emu_mmio_devices.add_dev(dev)
+        self.register_bundle(DeviceRegistration::Mmio(dev).into())
     }
 
     /// Add a system register device to the device list
     pub fn add_sys_reg_dev(&mut self, dev: Arc<dyn BaseSysRegDeviceOps>) -> AxResult {
-        self.emu_sys_reg_devices.add_dev(dev)
+        self.register_bundle(DeviceRegistration::SysReg(dev).into())
     }
 
     /// Add a port device to the device list
     pub fn add_port_dev(&mut self, dev: Arc<dyn BasePortDeviceOps>) -> AxResult {
-        self.emu_port_devices.add_dev(dev)
+        self.register_bundle(DeviceRegistration::Port(dev).into())
     }
 
     /// Iterates over the MMIO devices in the set.
@@ -517,6 +575,11 @@ impl AxVmDevices {
     /// Iterates over the port devices in the set.
     pub fn iter_port_dev(&self) -> impl Iterator<Item = &Arc<dyn BasePortDeviceOps>> {
         self.emu_port_devices.iter()
+    }
+
+    /// Iterates over devices that require periodic polling.
+    pub fn iter_pollable_dev(&self) -> impl Iterator<Item = &Arc<dyn PollableDeviceOps>> {
+        self.pollable_devices.iter()
     }
 
     /// Returns the guest vector programmed for an x86 IOAPIC GSI.

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -47,9 +47,69 @@ impl<R: DeviceAddrRange + 'static> AxEmuDevices<R> {
         }
     }
 
-    /// Adds a device to the set.
-    pub fn add_dev(&mut self, dev: Arc<dyn BaseDeviceOps<R>>) {
+    /// Adds a device to the set after validating its range.
+    pub fn add_dev(&mut self, dev: Arc<dyn BaseDeviceOps<R>>) -> AxResult {
+        let new_range = dev.address_range();
+        let new_type = dev.emu_type();
+
+        if new_range.is_empty() {
+            return ax_err!(
+                InvalidInput,
+                format_args!(
+                    "failed to register {} device type {} at range {new_range:#x}: range is empty \
+                     or invalid, possibly due to address overflow",
+                    R::BUS_NAME,
+                    new_type,
+                )
+            );
+        }
+
+        for existing in &self.emu_devices {
+            let existing_range = existing.address_range();
+            let existing_type = existing.emu_type();
+
+            if Arc::ptr_eq(existing, &dev) {
+                return ax_err!(
+                    AlreadyExists,
+                    format_args!(
+                        "failed to register {} device type {} at range {new_range:#x}: the same \
+                         device is already registered as type {} at range {existing_range:#x}",
+                        R::BUS_NAME,
+                        new_type,
+                        existing_type,
+                    )
+                );
+            }
+
+            if new_range == existing_range {
+                return ax_err!(
+                    AlreadyExists,
+                    format_args!(
+                        "failed to register {} device type {} at range {new_range:#x}: range is \
+                         already registered by device type {} at range {existing_range:#x}",
+                        R::BUS_NAME,
+                        new_type,
+                        existing_type,
+                    )
+                );
+            }
+
+            if new_range.overlaps(&existing_range) {
+                return ax_err!(
+                    AddrInUse,
+                    format_args!(
+                        "failed to register {} device type {} at range {new_range:#x}: overlaps \
+                         device type {} at range {existing_range:#x}",
+                        R::BUS_NAME,
+                        new_type,
+                        existing_type,
+                    )
+                );
+            }
+        }
+
         self.emu_devices.push(dev);
+        Ok(())
     }
 
     // pub fn remove_dev(&mut self, ...)
@@ -132,7 +192,7 @@ fn panic_device_not_found(
 /// The implemention for AxVmDevices
 impl AxVmDevices {
     /// According AxVmDeviceConfig to init the AxVmDevices
-    pub fn new(config: AxVmDeviceConfig) -> Self {
+    pub fn new(config: AxVmDeviceConfig) -> AxResult<Self> {
         let mut this = Self {
             emu_mmio_devices: AxEmuMmioDevices::new(),
             emu_sys_reg_devices: AxEmuSysRegDevices::new(),
@@ -146,18 +206,18 @@ impl AxVmDevices {
             ivc_channel: None,
         };
 
-        Self::init(&mut this, &config.emu_configs);
-        this
+        Self::init(&mut this, &config.emu_configs)?;
+        Ok(this)
     }
 
     /// According the emu_configs to init every  specific device
-    fn init(this: &mut Self, emu_configs: &Vec<EmulatedDeviceConfig>) {
+    fn init(this: &mut Self, emu_configs: &Vec<EmulatedDeviceConfig>) -> AxResult {
         for config in emu_configs {
             match config.emu_type {
                 EmulatedDeviceType::InterruptController => {
                     #[cfg(target_arch = "aarch64")]
                     {
-                        this.add_mmio_dev(Arc::new(Vgic::new()));
+                        this.add_mmio_dev(Arc::new(Vgic::new()))?;
                     }
                     #[cfg(not(target_arch = "aarch64"))]
                     {
@@ -197,7 +257,7 @@ impl AxVmDevices {
                                 addr.into(),
                                 Some(size),
                                 pcpu_id + i,
-                            )));
+                            )))?;
 
                             info!(
                                 "GPPT Redistributor initialized for vCPU {i} with base GPA \
@@ -220,7 +280,7 @@ impl AxVmDevices {
                         this.add_mmio_dev(Arc::new(arm_vgic::v3::vgicd::VGicD::new(
                             config.base_gpa.into(),
                             Some(config.length),
-                        )));
+                        )))?;
 
                         info!(
                             "GPPT Distributor initialized with base GPA {base_gpa:#x} and length \
@@ -253,7 +313,7 @@ impl AxVmDevices {
                             Some(config.length),
                             host_gits_base,
                             false,
-                        )));
+                        )))?;
 
                         info!(
                             "GPPT ITS initialized with base GPA {base_gpa:#x} and length \
@@ -283,7 +343,7 @@ impl AxVmDevices {
                             config.base_gpa.into(),
                             Some(config.length),
                             context_num, // Here only 1 core and should be cpu0
-                        )));
+                        )))?;
                         // PLIC Partial Passthrough Global.
                         info!(
                             "Partial PLIC Passthrough Global initialized with base GPA {:#x} and \
@@ -303,8 +363,8 @@ impl AxVmDevices {
                     #[cfg(target_arch = "x86_64")]
                     {
                         let serial = Arc::new(EmulatedSerialPort::new());
-                        this.x86_serial = Some(Arc::clone(&serial));
-                        this.add_port_dev(serial);
+                        this.add_port_dev(serial.clone())?;
+                        this.x86_serial = Some(serial);
                         info!("x86 16550 serial initialized for ports 0x3f8..=0x3ff");
                     }
                     #[cfg(not(target_arch = "x86_64"))]
@@ -322,8 +382,8 @@ impl AxVmDevices {
                             config.base_gpa.into(),
                             Some(config.length),
                         ));
-                        this.x86_ioapic = Some(Arc::clone(&ioapic));
-                        this.add_mmio_dev(ioapic);
+                        this.add_mmio_dev(ioapic.clone())?;
+                        this.x86_ioapic = Some(ioapic);
                         info!(
                             "x86 IO APIC initialized with base GPA {:#x} and length {:#x}",
                             config.base_gpa, config.length
@@ -341,8 +401,8 @@ impl AxVmDevices {
                     #[cfg(target_arch = "x86_64")]
                     {
                         let pit = Arc::new(EmulatedPit::new());
-                        this.x86_pit = Some(Arc::clone(&pit));
-                        this.add_port_dev(pit);
+                        this.add_port_dev(pit.clone())?;
+                        this.x86_pit = Some(pit);
                         info!("x86 PIT initialized for ports 0x40..=0x43 and 0x61");
                     }
                     #[cfg(not(target_arch = "x86_64"))]
@@ -378,6 +438,7 @@ impl AxVmDevices {
                 }
             }
         }
+        Ok(())
     }
 
     /// Allocates an IVC (Inter-VM Communication) channel of the specified size.
@@ -429,18 +490,18 @@ impl AxVmDevices {
     }
 
     /// Add a MMIO device to the device list
-    pub fn add_mmio_dev(&mut self, dev: Arc<dyn BaseMmioDeviceOps>) {
-        self.emu_mmio_devices.add_dev(dev);
+    pub fn add_mmio_dev(&mut self, dev: Arc<dyn BaseMmioDeviceOps>) -> AxResult {
+        self.emu_mmio_devices.add_dev(dev)
     }
 
     /// Add a system register device to the device list
-    pub fn add_sys_reg_dev(&mut self, dev: Arc<dyn BaseSysRegDeviceOps>) {
-        self.emu_sys_reg_devices.add_dev(dev);
+    pub fn add_sys_reg_dev(&mut self, dev: Arc<dyn BaseSysRegDeviceOps>) -> AxResult {
+        self.emu_sys_reg_devices.add_dev(dev)
     }
 
     /// Add a port device to the device list
-    pub fn add_port_dev(&mut self, dev: Arc<dyn BasePortDeviceOps>) {
-        self.emu_port_devices.add_dev(dev);
+    pub fn add_port_dev(&mut self, dev: Arc<dyn BasePortDeviceOps>) -> AxResult {
+        self.emu_port_devices.add_dev(dev)
     }
 
     /// Iterates over the MMIO devices in the set.

--- a/virtualization/axdevice/src/factory.rs
+++ b/virtualization/axdevice/src/factory.rs
@@ -1,0 +1,134 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Extensible construction of emulated devices from VM configuration.
+
+use alloc::{sync::Arc, vec::Vec};
+
+use ax_errno::{AxResult, ax_err};
+use axdevice_base::{InterruptTriggerMode, IrqLine};
+use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType};
+
+use crate::DeviceBundle;
+
+/// Resolves a VM-local interrupt line for a device under construction.
+pub trait IrqResolver: Send + Sync {
+    /// Resolves `line` with the requested trigger mode.
+    fn resolve_irq(&self, line: usize, trigger: InterruptTriggerMode) -> AxResult<IrqLine>;
+}
+
+/// VM-owned services available while a device factory is building a device.
+pub struct DeviceBuildContext<'a> {
+    irq_resolver: &'a dyn IrqResolver,
+}
+
+impl<'a> DeviceBuildContext<'a> {
+    /// Creates a device build context backed by `irq_resolver`.
+    pub const fn new(irq_resolver: &'a dyn IrqResolver) -> Self {
+        Self { irq_resolver }
+    }
+
+    /// Resolves a VM-local interrupt line.
+    pub fn resolve_irq(&self, line: usize, trigger: InterruptTriggerMode) -> AxResult<IrqLine> {
+        self.irq_resolver.resolve_irq(line, trigger)
+    }
+}
+
+/// Builds all capabilities contributed by one emulated device type.
+pub trait DeviceFactory: Send + Sync {
+    /// Returns the configuration type handled by this factory.
+    fn device_type(&self) -> EmulatedDeviceType;
+
+    /// Builds a device without modifying the destination device registry.
+    fn build(
+        &self,
+        config: &EmulatedDeviceConfig,
+        context: &DeviceBuildContext<'_>,
+    ) -> AxResult<DeviceBundle>;
+}
+
+/// A registry containing at most one factory for each emulated device type.
+#[derive(Default)]
+pub struct DeviceFactoryRegistry {
+    factories: Vec<(EmulatedDeviceType, Arc<dyn DeviceFactory>)>,
+}
+
+impl DeviceFactoryRegistry {
+    /// Creates an empty factory registry.
+    pub const fn new() -> Self {
+        Self {
+            factories: Vec::new(),
+        }
+    }
+
+    /// Registers a factory, rejecting a duplicate device type.
+    pub fn register(&mut self, factory: Arc<dyn DeviceFactory>) -> AxResult {
+        let device_type = factory.device_type();
+        if self.get(device_type).is_some() {
+            return ax_err!(
+                AlreadyExists,
+                format_args!("factory for device type {device_type} is already registered")
+            );
+        }
+        self.factories.push((device_type, factory));
+        Ok(())
+    }
+
+    /// Returns the factory registered for `device_type`.
+    pub fn get(&self, device_type: EmulatedDeviceType) -> Option<&dyn DeviceFactory> {
+        self.factories
+            .iter()
+            .find(|(registered_type, _)| *registered_type == device_type)
+            .map(|(_, factory)| factory.as_ref())
+    }
+
+    /// Builds a bundle for `config`.
+    pub fn build(
+        &self,
+        config: &EmulatedDeviceConfig,
+        context: &DeviceBuildContext<'_>,
+    ) -> AxResult<DeviceBundle> {
+        let Some(factory) = self.get(config.emu_type) else {
+            return ax_err!(
+                Unsupported,
+                format_args!(
+                    "no factory is registered for emulated device '{}' of type {}",
+                    config.name, config.emu_type
+                )
+            );
+        };
+        factory.build(config, context)
+    }
+}
+
+struct MetaDeviceFactory;
+
+impl DeviceFactory for MetaDeviceFactory {
+    fn device_type(&self) -> EmulatedDeviceType {
+        EmulatedDeviceType::Dummy
+    }
+
+    fn build(
+        &self,
+        _config: &EmulatedDeviceConfig,
+        _context: &DeviceBuildContext<'_>,
+    ) -> AxResult<DeviceBundle> {
+        Ok(DeviceBundle::new())
+    }
+}
+
+/// Registers device factories that do not depend on an architecture backend.
+pub fn register_builtin_factories(registry: &mut DeviceFactoryRegistry) -> AxResult {
+    registry.register(Arc::new(MetaDeviceFactory))
+}

--- a/virtualization/axdevice/src/lib.rs
+++ b/virtualization/axdevice/src/lib.rs
@@ -29,6 +29,7 @@ extern crate log;
 mod config;
 mod device;
 mod range_alloc;
+mod registration;
 
 pub use axdevice_base::{
     AccessWidth, BaseDeviceOps, BaseMmioDeviceOps, BasePortDeviceOps, BaseSysRegDeviceOps, Port,
@@ -37,6 +38,7 @@ pub use axdevice_base::{
 pub use axvm_types::GuestPhysAddr;
 pub use config::AxVmDeviceConfig;
 pub use device::{AxEmuDevices, AxVmDevices};
+pub use registration::{DeviceBundle, DeviceRegistration, PollableDeviceOps};
 #[cfg(target_arch = "x86_64")]
 pub use x86_vlapic::IoApicInterrupt;
 // pub use virtio_dev::*;

--- a/virtualization/axdevice/src/lib.rs
+++ b/virtualization/axdevice/src/lib.rs
@@ -28,6 +28,7 @@ extern crate log;
 
 mod config;
 mod device;
+mod factory;
 mod range_alloc;
 mod registration;
 
@@ -38,6 +39,10 @@ pub use axdevice_base::{
 pub use axvm_types::GuestPhysAddr;
 pub use config::AxVmDeviceConfig;
 pub use device::{AxEmuDevices, AxVmDevices};
+pub use factory::{
+    DeviceBuildContext, DeviceFactory, DeviceFactoryRegistry, IrqResolver,
+    register_builtin_factories,
+};
 pub use registration::{DeviceBundle, DeviceRegistration, PollableDeviceOps};
 #[cfg(target_arch = "x86_64")]
 pub use x86_vlapic::IoApicInterrupt;

--- a/virtualization/axdevice/src/registration.rs
+++ b/virtualization/axdevice/src/registration.rs
@@ -1,0 +1,100 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Transactional device registration types.
+
+use alloc::{sync::Arc, vec::Vec};
+
+use ax_errno::AxResult;
+use axdevice_base::{BaseMmioDeviceOps, BasePortDeviceOps, BaseSysRegDeviceOps};
+
+/// A device capability that can be polled by the VM runtime.
+pub trait PollableDeviceOps: Send + Sync {
+    /// Advances the device using the current monotonic time in nanoseconds.
+    fn poll(&self, now_ns: u64) -> AxResult;
+}
+
+/// One strongly typed capability contributed by a device.
+#[non_exhaustive]
+pub enum DeviceRegistration {
+    /// An MMIO access capability.
+    Mmio(Arc<dyn BaseMmioDeviceOps>),
+    /// A port I/O access capability.
+    Port(Arc<dyn BasePortDeviceOps>),
+    /// A system register access capability.
+    SysReg(Arc<dyn BaseSysRegDeviceOps>),
+    /// A capability that requires periodic polling.
+    Pollable(Arc<dyn PollableDeviceOps>),
+}
+
+/// A set of device capabilities that must be registered atomically.
+///
+/// The contained registration lists are private so callers cannot bypass
+/// [`DeviceRegistration`] when adding future capability kinds.
+#[derive(Default)]
+pub struct DeviceBundle {
+    pub(crate) mmio: Vec<Arc<dyn BaseMmioDeviceOps>>,
+    pub(crate) port: Vec<Arc<dyn BasePortDeviceOps>>,
+    pub(crate) sysreg: Vec<Arc<dyn BaseSysRegDeviceOps>>,
+    pub(crate) pollable: Vec<Arc<dyn PollableDeviceOps>>,
+}
+
+impl DeviceBundle {
+    /// Creates an empty bundle.
+    pub const fn new() -> Self {
+        Self {
+            mmio: Vec::new(),
+            port: Vec::new(),
+            sysreg: Vec::new(),
+            pollable: Vec::new(),
+        }
+    }
+
+    /// Creates a bundle containing one registration.
+    pub fn from_registration(registration: DeviceRegistration) -> Self {
+        let mut bundle = Self::new();
+        bundle.push(registration);
+        bundle
+    }
+
+    /// Adds one capability to this bundle.
+    pub fn push(&mut self, registration: DeviceRegistration) {
+        match registration {
+            DeviceRegistration::Mmio(device) => self.mmio.push(device),
+            DeviceRegistration::Port(device) => self.port.push(device),
+            DeviceRegistration::SysReg(device) => self.sysreg.push(device),
+            DeviceRegistration::Pollable(device) => self.pollable.push(device),
+        }
+    }
+
+    /// Adds one capability and returns the bundle for builder-style use.
+    pub fn with_registration(mut self, registration: DeviceRegistration) -> Self {
+        self.push(registration);
+        self
+    }
+
+    /// Returns whether this bundle contains no capabilities.
+    pub fn is_empty(&self) -> bool {
+        self.mmio.is_empty()
+            && self.port.is_empty()
+            && self.sysreg.is_empty()
+            && self.pollable.is_empty()
+    }
+}
+
+impl From<DeviceRegistration> for DeviceBundle {
+    fn from(registration: DeviceRegistration) -> Self {
+        Self::from_registration(registration)
+    }
+}

--- a/virtualization/axdevice_base/src/device.rs
+++ b/virtualization/axdevice_base/src/device.rs
@@ -134,12 +134,21 @@ impl Debug for SysRegAddr {
 pub trait DeviceAddr: Copy + Eq + Ord + core::fmt::Debug {}
 
 /// A range of device addresses. It may be contiguous or not.
-pub trait DeviceAddrRange {
+pub trait DeviceAddrRange: Copy + Eq + LowerHex {
     /// The address type of the range.
     type Addr: DeviceAddr;
 
+    /// The name of the device bus that uses this range type.
+    const BUS_NAME: &'static str;
+
     /// Returns whether the address range contains the given address.
     fn contains(&self, addr: Self::Addr) -> bool;
+
+    /// Returns whether the address range is empty or invalid.
+    fn is_empty(&self) -> bool;
+
+    /// Returns whether this address range overlaps another range.
+    fn overlaps(&self, other: &Self) -> bool;
 }
 
 impl DeviceAddr for GuestPhysAddr {}
@@ -147,8 +156,18 @@ impl DeviceAddr for GuestPhysAddr {}
 impl DeviceAddrRange for AddrRange<GuestPhysAddr> {
     type Addr = GuestPhysAddr;
 
+    const BUS_NAME: &'static str = "mmio";
+
     fn contains(&self, addr: Self::Addr) -> bool {
         Self::contains(*self, addr)
+    }
+
+    fn is_empty(&self) -> bool {
+        Self::is_empty(*self)
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        Self::overlaps(*self, *other)
     }
 }
 
@@ -175,8 +194,18 @@ impl SysRegAddrRange {
 impl DeviceAddrRange for SysRegAddrRange {
     type Addr = SysRegAddr;
 
+    const BUS_NAME: &'static str = "sys_reg";
+
     fn contains(&self, addr: Self::Addr) -> bool {
         addr.0 >= self.start.0 && addr.0 <= self.end.0
+    }
+
+    fn is_empty(&self) -> bool {
+        self.start > self.end
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        !self.is_empty() && !other.is_empty() && self.start <= other.end && other.start <= self.end
     }
 }
 
@@ -209,8 +238,18 @@ impl PortRange {
 impl DeviceAddrRange for PortRange {
     type Addr = Port;
 
+    const BUS_NAME: &'static str = "port";
+
     fn contains(&self, addr: Self::Addr) -> bool {
         addr.0 >= self.start.0 && addr.0 <= self.end.0
+    }
+
+    fn is_empty(&self) -> bool {
+        self.start > self.end
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        !self.is_empty() && !other.is_empty() && self.start <= other.end && other.start <= self.end
     }
 }
 

--- a/virtualization/axdevice_base/src/irq.rs
+++ b/virtualization/axdevice_base/src/irq.rs
@@ -1,0 +1,94 @@
+//! Architecture-independent interrupt line signaling.
+
+use alloc::sync::Arc;
+
+use ax_errno::{AxError, AxResult};
+use axvm_types::{InterruptTriggerMode, IrqLineId};
+
+/// Receives state changes and pulses from interrupt lines.
+///
+/// Implementations route the line operation to a VM-specific interrupt
+/// controller backend.
+pub trait IrqSink: Send + Sync {
+    /// Sets whether a level-triggered interrupt line is asserted.
+    fn set_level(&self, line: IrqLineId, asserted: bool) -> AxResult;
+
+    /// Delivers one pulse from an edge-triggered interrupt line.
+    fn pulse(&self, line: IrqLineId) -> AxResult;
+}
+
+/// A shareable interrupt line connected to an [`IrqSink`].
+///
+/// Clones share the same line identity, trigger mode, and sink.
+#[derive(Clone)]
+pub struct IrqLine(Arc<IrqLineInner>);
+
+struct IrqLineInner {
+    id: IrqLineId,
+    trigger: InterruptTriggerMode,
+    sink: Arc<dyn IrqSink>,
+}
+
+impl IrqLine {
+    /// Creates an interrupt line connected to `sink`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    ///
+    /// use axdevice_base::{AxResult, InterruptTriggerMode, IrqLine, IrqLineId, IrqSink};
+    ///
+    /// struct Sink;
+    ///
+    /// impl IrqSink for Sink {
+    ///     fn set_level(&self, _line: IrqLineId, _asserted: bool) -> AxResult {
+    ///         Ok(())
+    ///     }
+    ///
+    ///     fn pulse(&self, _line: IrqLineId) -> AxResult {
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let line = IrqLine::new(
+    ///     IrqLineId(4),
+    ///     InterruptTriggerMode::EdgeTriggered,
+    ///     Arc::new(Sink),
+    /// );
+    /// line.pulse().unwrap();
+    /// ```
+    pub fn new(id: IrqLineId, trigger: InterruptTriggerMode, sink: Arc<dyn IrqSink>) -> Self {
+        Self(Arc::new(IrqLineInner { id, trigger, sink }))
+    }
+
+    /// Asserts a level-triggered interrupt line.
+    ///
+    /// Returns [`AxError::InvalidInput`] for an edge-triggered line.
+    pub fn raise(&self) -> AxResult {
+        if self.0.trigger != InterruptTriggerMode::LevelTriggered {
+            return Err(AxError::InvalidInput);
+        }
+        self.0.sink.set_level(self.0.id, true)
+    }
+
+    /// Deasserts a level-triggered interrupt line.
+    ///
+    /// Returns [`AxError::InvalidInput`] for an edge-triggered line.
+    pub fn lower(&self) -> AxResult {
+        if self.0.trigger != InterruptTriggerMode::LevelTriggered {
+            return Err(AxError::InvalidInput);
+        }
+        self.0.sink.set_level(self.0.id, false)
+    }
+
+    /// Pulses an edge-triggered interrupt line.
+    ///
+    /// Returns [`AxError::InvalidInput`] for a level-triggered line.
+    pub fn pulse(&self) -> AxResult {
+        if self.0.trigger != InterruptTriggerMode::EdgeTriggered {
+            return Err(AxError::InvalidInput);
+        }
+        self.0.sink.pulse(self.0.id)
+    }
+}

--- a/virtualization/axdevice_base/src/lib.rs
+++ b/virtualization/axdevice_base/src/lib.rs
@@ -26,6 +26,8 @@
 //! - [`EmuDeviceType`]: Enumeration representing the type of emulator devices
 //!   (re-exported from `axvm-types` crate).
 //! - [`EmulatedDeviceConfig`]: Configuration structure for device initialization.
+//! - [`IrqLine`] and [`IrqSink`]: Architecture-independent interrupt line
+//!   signaling.
 //! - Trait aliases for specific device types:
 //!   - [`BaseMmioDeviceOps`]: For MMIO (Memory-Mapped I/O) devices.
 //!   - [`BaseSysRegDeviceOps`]: For system register devices.
@@ -85,15 +87,20 @@
 extern crate alloc;
 
 mod device;
+mod irq;
 
 use alloc::{string::String, sync::Arc, vec::Vec};
 use core::any::Any;
 
 pub use ax_errno::AxResult;
-pub use axvm_types::{EmulatedDeviceType as EmuDeviceType, GuestPhysAddr, GuestPhysAddrRange};
+pub use axvm_types::{
+    EmulatedDeviceType as EmuDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptTriggerMode,
+    IrqLineId,
+};
 pub use device::{
     AccessWidth, DeviceAddr, DeviceAddrRange, Port, PortRange, SysRegAddr, SysRegAddrRange,
 };
+pub use irq::{IrqLine, IrqSink};
 
 /// Represents the configuration of an emulated device for a virtual machine.
 ///

--- a/virtualization/axdevice_base/tests/irq.rs
+++ b/virtualization/axdevice_base/tests/irq.rs
@@ -1,0 +1,131 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex};
+
+use ax_errno::{AxError, AxResult};
+use axdevice_base::{InterruptTriggerMode, IrqLine, IrqLineId, IrqSink};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IrqEvent {
+    SetLevel(IrqLineId, bool),
+    Pulse(IrqLineId),
+}
+
+struct MockIrqSink {
+    events: Mutex<Vec<IrqEvent>>,
+    error: Option<AxError>,
+}
+
+impl MockIrqSink {
+    fn new(error: Option<AxError>) -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+            error,
+        }
+    }
+
+    fn events(&self) -> Vec<IrqEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl IrqSink for MockIrqSink {
+    fn set_level(&self, line: IrqLineId, asserted: bool) -> AxResult {
+        if let Some(error) = self.error {
+            return Err(error);
+        }
+        self.events
+            .lock()
+            .unwrap()
+            .push(IrqEvent::SetLevel(line, asserted));
+        Ok(())
+    }
+
+    fn pulse(&self, line: IrqLineId) -> AxResult {
+        if let Some(error) = self.error {
+            return Err(error);
+        }
+        self.events.lock().unwrap().push(IrqEvent::Pulse(line));
+        Ok(())
+    }
+}
+
+#[test]
+fn edge_line_pulses_sink() {
+    let sink = Arc::new(MockIrqSink::new(None));
+    let line = IrqLine::new(
+        IrqLineId(4),
+        InterruptTriggerMode::EdgeTriggered,
+        sink.clone(),
+    );
+
+    assert_eq!(line.pulse(), Ok(()));
+    assert_eq!(sink.events(), vec![IrqEvent::Pulse(IrqLineId(4))]);
+}
+
+#[test]
+fn level_line_raises_and_lowers_sink() {
+    let sink = Arc::new(MockIrqSink::new(None));
+    let line = IrqLine::new(
+        IrqLineId(33),
+        InterruptTriggerMode::LevelTriggered,
+        sink.clone(),
+    );
+
+    assert_eq!(line.raise(), Ok(()));
+    assert_eq!(line.lower(), Ok(()));
+    assert_eq!(
+        sink.events(),
+        vec![
+            IrqEvent::SetLevel(IrqLineId(33), true),
+            IrqEvent::SetLevel(IrqLineId(33), false),
+        ]
+    );
+}
+
+#[test]
+fn mismatched_line_operations_return_invalid_input() {
+    let sink = Arc::new(MockIrqSink::new(None));
+    let edge_line = IrqLine::new(
+        IrqLineId(4),
+        InterruptTriggerMode::EdgeTriggered,
+        sink.clone(),
+    );
+    let level_line = IrqLine::new(
+        IrqLineId(33),
+        InterruptTriggerMode::LevelTriggered,
+        sink.clone(),
+    );
+
+    assert_eq!(edge_line.raise(), Err(AxError::InvalidInput));
+    assert_eq!(edge_line.lower(), Err(AxError::InvalidInput));
+    assert_eq!(level_line.pulse(), Err(AxError::InvalidInput));
+    assert!(sink.events().is_empty());
+}
+
+#[test]
+fn sink_errors_are_propagated() {
+    let sink = Arc::new(MockIrqSink::new(Some(AxError::Io)));
+    let edge_line = IrqLine::new(
+        IrqLineId(4),
+        InterruptTriggerMode::EdgeTriggered,
+        sink.clone(),
+    );
+    let level_line = IrqLine::new(IrqLineId(33), InterruptTriggerMode::LevelTriggered, sink);
+
+    assert_eq!(edge_line.pulse(), Err(AxError::Io));
+    assert_eq!(level_line.raise(), Err(AxError::Io));
+    assert_eq!(level_line.lower(), Err(AxError::Io));
+}

--- a/virtualization/axvcpu/src/arch_vcpu.rs
+++ b/virtualization/axvcpu/src/arch_vcpu.rs
@@ -13,22 +13,9 @@
 // limitations under the License.
 
 use ax_errno::AxResult;
-use axvm_types::{GuestPhysAddr, HostPhysAddr, VCpuId, VMId};
+use axvm_types::{GuestPhysAddr, HostPhysAddr, InterruptTriggerMode, VCpuId, VMId};
 
 use crate::exit::AxVCpuExitReason;
-
-/// Interrupt trigger mode.
-///
-/// Represents the trigger mode of an interrupt in a platform-neutral way.
-/// Architectures that do not distinguish between edge and level triggering
-/// can ignore this parameter.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InterruptTriggerMode {
-    /// Edge-triggered interrupt.
-    EdgeTriggered,
-    /// Level-triggered interrupt.
-    LevelTriggered,
-}
 
 /// Architecture-specific virtual CPU trait definition.
 ///

--- a/virtualization/axvcpu/src/lib.rs
+++ b/virtualization/axvcpu/src/lib.rs
@@ -40,10 +40,10 @@ mod test; // Unit tests for VCpu functionality
 mod vcpu; // Main VCpu implementation and state management
 
 // Public API exports
-pub use arch_vcpu::{AxArchVCpu, InterruptTriggerMode}; // Architecture-specific VCpu trait
+pub use arch_vcpu::AxArchVCpu; // Architecture-specific VCpu trait
 pub use ax_page_table_entry::MappingFlags;
 pub use axdevice_base::{AccessWidth, Port, SysRegAddr};
-pub use axvm_types::{GuestPhysAddr, HostPhysAddr, VCpuId, VMId};
+pub use axvm_types::{GuestPhysAddr, HostPhysAddr, InterruptTriggerMode, VCpuId, VMId};
 pub use exit::{AxVCpuExitReason, NestedPageFaultInfo};
 pub use percpu::{AxArchPerCpu, AxPerCpu}; // Per-CPU state management types
 pub use vcpu::{

--- a/virtualization/axvm-types/src/lib.rs
+++ b/virtualization/axvm-types/src/lib.rs
@@ -35,6 +35,23 @@ pub type VCpuId = usize;
 /// Interrupt vector number injected into a guest.
 pub type InterruptVector = u8;
 
+/// Interrupt trigger mode.
+///
+/// Represents the trigger mode of an interrupt in a platform-neutral way.
+/// Architectures that do not distinguish between edge and level triggering
+/// can ignore this parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterruptTriggerMode {
+    /// Edge-triggered interrupt.
+    EdgeTriggered,
+    /// Level-triggered interrupt.
+    LevelTriggered,
+}
+
+/// Identifier of an interrupt line within a virtual machine.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IrqLineId(pub usize);
+
 /// The maximum number of virtual CPUs supported in a virtual machine.
 pub const MAX_VCPU_NUM: usize = 64;
 

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -329,7 +329,7 @@ impl AxVM {
         #[cfg_attr(not(target_arch = "aarch64"), expect(unused_mut))]
         let mut devices = axdevice::AxVmDevices::new(AxVmDeviceConfig {
             emu_configs: inner_mut.config.emu_devices().to_vec(),
-        });
+        })?;
 
         #[cfg(target_arch = "aarch64")]
         {
@@ -367,7 +367,7 @@ impl AxVM {
                 // FIXME: maybe let `axdevice` handle this automatically?
                 // how to let `axdevice` know whether the VM is in passthrough mode or not?
                 for dev in get_sysreg_device() {
-                    devices.add_sys_reg_dev(dev);
+                    devices.add_sys_reg_dev(dev)?;
                 }
             }
         }

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -14,12 +14,13 @@
 
 use std::sync::{Arc, Mutex};
 
-use ax_errno::AxResult;
+use ax_errno::{AxError, AxResult};
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axdevice::{AxVmDeviceConfig, AxVmDevices};
-use axdevice_base::{AccessWidth, BaseDeviceOps};
+use axdevice_base::{AccessWidth, BaseDeviceOps, Port, PortRange, SysRegAddr, SysRegAddrRange};
 use axvm_types::{
-    EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptVector, VCpuId, VMId,
+    EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptVector,
+    VCpuId, VMId,
 };
 use x86_vlapic::host::X86VlapicHostIf;
 
@@ -34,9 +35,13 @@ impl MockMmioDevice {
         let start = GuestPhysAddr::from(base);
         let end = GuestPhysAddr::from(base + len);
 
+        Self::with_range(name, GuestPhysAddrRange::new(start, end))
+    }
+
+    fn with_range(name: &str, range: GuestPhysAddrRange) -> Self {
         Self {
             name: String::from(name),
-            range: GuestPhysAddrRange::new(start, end),
+            range,
             last_write: Mutex::new(None),
         }
     }
@@ -71,16 +76,87 @@ impl BaseDeviceOps<GuestPhysAddrRange> for MockMmioDevice {
     }
 }
 
+struct MockPortDevice {
+    range: PortRange,
+}
+
+impl MockPortDevice {
+    fn new(start: u16, end: u16) -> Self {
+        Self {
+            range: PortRange::new(Port::new(start), Port::new(end)),
+        }
+    }
+}
+
+impl BaseDeviceOps<PortRange> for MockPortDevice {
+    fn address_range(&self) -> PortRange {
+        self.range
+    }
+
+    fn emu_type(&self) -> EmulatedDeviceType {
+        EmulatedDeviceType::Console
+    }
+
+    fn handle_read(&self, _addr: Port, _width: AccessWidth) -> AxResult<usize> {
+        Ok(0)
+    }
+
+    fn handle_write(&self, _addr: Port, _width: AccessWidth, _val: usize) -> AxResult {
+        Ok(())
+    }
+}
+
+struct MockSysRegDevice {
+    range: SysRegAddrRange,
+}
+
+impl MockSysRegDevice {
+    fn new(start: usize, end: usize) -> Self {
+        Self {
+            range: SysRegAddrRange::new(SysRegAddr::new(start), SysRegAddr::new(end)),
+        }
+    }
+}
+
+impl BaseDeviceOps<SysRegAddrRange> for MockSysRegDevice {
+    fn address_range(&self) -> SysRegAddrRange {
+        self.range
+    }
+
+    fn emu_type(&self) -> EmulatedDeviceType {
+        EmulatedDeviceType::InterruptController
+    }
+
+    fn handle_read(&self, _addr: SysRegAddr, _width: AccessWidth) -> AxResult<usize> {
+        Ok(0)
+    }
+
+    fn handle_write(&self, _addr: SysRegAddr, _width: AccessWidth, _val: usize) -> AxResult {
+        Ok(())
+    }
+}
+
+fn empty_devices() -> AxVmDevices {
+    AxVmDevices::new(AxVmDeviceConfig::new(vec![])).unwrap()
+}
+
+fn mmio_device(name: &str, start: usize, end: usize) -> Arc<MockMmioDevice> {
+    Arc::new(MockMmioDevice::with_range(
+        name,
+        GuestPhysAddrRange::new(start.into(), end.into()),
+    ))
+}
+
 #[test]
 fn test_mmio_dispatch_functionality() {
     let config = AxVmDeviceConfig::new(vec![]);
-    let mut devices = AxVmDevices::new(config);
+    let mut devices = AxVmDevices::new(config).unwrap();
 
     let base_addr = 0x1000_0000;
     let dev_size = 0x1000;
     let mock_dev = Arc::new(MockMmioDevice::new("TestDev", base_addr, dev_size));
 
-    devices.add_mmio_dev(mock_dev.clone());
+    devices.add_mmio_dev(mock_dev.clone()).unwrap();
 
     let write_offset = 0x40;
     let target_addr = GuestPhysAddr::from(base_addr + write_offset);
@@ -109,12 +185,168 @@ fn test_mmio_dispatch_functionality() {
 #[should_panic(expected = "emu_device not found")]
 fn test_mmio_panic_on_missing_device() {
     let config = AxVmDeviceConfig::new(vec![]);
-    let devices = AxVmDevices::new(config);
+    let devices = AxVmDevices::new(config).unwrap();
 
     let invalid_addr = GuestPhysAddr::from(0x9999_9999);
     let width = AccessWidth::try_from(4).unwrap();
 
     let _ = devices.handle_mmio_read(invalid_addr, width);
+}
+
+#[test]
+fn test_mmio_adjacent_ranges_are_allowed() {
+    let mut devices = empty_devices();
+
+    assert_eq!(
+        devices.add_mmio_dev(mmio_device("first", 0x1000, 0x2000)),
+        Ok(())
+    );
+    assert_eq!(
+        devices.add_mmio_dev(mmio_device("adjacent", 0x2000, 0x3000)),
+        Ok(())
+    );
+    assert_eq!(devices.iter_mmio_dev().count(), 2);
+}
+
+#[test]
+fn test_mmio_duplicate_and_overlapping_ranges_are_rejected_without_modification() {
+    let mut devices = empty_devices();
+    let existing = mmio_device("existing", 0x2000, 0x3000);
+
+    assert_eq!(devices.add_mmio_dev(existing.clone()), Ok(()));
+    assert_eq!(devices.add_mmio_dev(existing), Err(AxError::AlreadyExists));
+    assert_eq!(
+        devices.add_mmio_dev(mmio_device("same-range", 0x2000, 0x3000)),
+        Err(AxError::AlreadyExists)
+    );
+    assert_eq!(
+        devices.add_mmio_dev(mmio_device("partial-left", 0x1800, 0x2800)),
+        Err(AxError::AddrInUse)
+    );
+    assert_eq!(
+        devices.add_mmio_dev(mmio_device("partial-right", 0x2800, 0x3800)),
+        Err(AxError::AddrInUse)
+    );
+    assert_eq!(
+        devices.add_mmio_dev(mmio_device("contains", 0x1000, 0x4000)),
+        Err(AxError::AddrInUse)
+    );
+    assert_eq!(
+        devices.add_mmio_dev(mmio_device("contained", 0x2400, 0x2800)),
+        Err(AxError::AddrInUse)
+    );
+    assert_eq!(devices.iter_mmio_dev().count(), 1);
+}
+
+#[test]
+fn test_empty_and_wrapped_ranges_are_rejected() {
+    let mut devices = empty_devices();
+    let empty_mmio = Arc::new(MockMmioDevice::with_range(
+        "empty-mmio",
+        GuestPhysAddrRange::new(0x1000.into(), 0x1000.into()),
+    ));
+    let wrapped_mmio = Arc::new(MockMmioDevice::with_range(
+        "wrapped-mmio",
+        GuestPhysAddrRange {
+            start: (usize::MAX - 0xf).into(),
+            end: 0x10.into(),
+        },
+    ));
+    let invalid_port = Arc::new(MockPortDevice::new(0x400, 0x3ff));
+    let invalid_sysreg = Arc::new(MockSysRegDevice::new(0x101, 0x100));
+
+    assert_eq!(devices.add_mmio_dev(empty_mmio), Err(AxError::InvalidInput));
+    assert_eq!(
+        devices.add_mmio_dev(wrapped_mmio),
+        Err(AxError::InvalidInput)
+    );
+    assert_eq!(
+        devices.add_port_dev(invalid_port),
+        Err(AxError::InvalidInput)
+    );
+    assert_eq!(
+        devices.add_sys_reg_dev(invalid_sysreg),
+        Err(AxError::InvalidInput)
+    );
+    assert_eq!(devices.iter_mmio_dev().count(), 0);
+    assert_eq!(devices.iter_port_dev().count(), 0);
+    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+}
+
+#[test]
+fn test_port_inclusive_endpoint_overlap_is_rejected() {
+    let mut devices = empty_devices();
+
+    assert_eq!(
+        devices.add_port_dev(Arc::new(MockPortDevice::new(0x3f8, 0x3ff))),
+        Ok(())
+    );
+    assert_eq!(
+        devices.add_port_dev(Arc::new(MockPortDevice::new(0x3ff, 0x400))),
+        Err(AxError::AddrInUse)
+    );
+    assert_eq!(
+        devices.add_port_dev(Arc::new(MockPortDevice::new(0x400, 0x400))),
+        Ok(())
+    );
+    assert_eq!(devices.iter_port_dev().count(), 2);
+}
+
+#[test]
+fn test_sysreg_inclusive_endpoint_overlap_is_rejected() {
+    let mut devices = empty_devices();
+
+    assert_eq!(
+        devices.add_sys_reg_dev(Arc::new(MockSysRegDevice::new(0x100, 0x110))),
+        Ok(())
+    );
+    assert_eq!(
+        devices.add_sys_reg_dev(Arc::new(MockSysRegDevice::new(0x110, 0x120))),
+        Err(AxError::AddrInUse)
+    );
+    assert_eq!(
+        devices.add_sys_reg_dev(Arc::new(MockSysRegDevice::new(0x111, 0x120))),
+        Ok(())
+    );
+    assert_eq!(devices.iter_sys_reg_dev().count(), 2);
+}
+
+#[test]
+fn test_equal_address_values_on_different_buses_are_allowed() {
+    let mut devices = empty_devices();
+
+    assert_eq!(
+        devices.add_mmio_dev(mmio_device("mmio", 0x1000, 0x1001)),
+        Ok(())
+    );
+    assert_eq!(
+        devices.add_port_dev(Arc::new(MockPortDevice::new(0x1000, 0x1000))),
+        Ok(())
+    );
+    assert_eq!(
+        devices.add_sys_reg_dev(Arc::new(MockSysRegDevice::new(0x1000, 0x1000))),
+        Ok(())
+    );
+    assert_eq!(devices.iter_mmio_dev().count(), 1);
+    assert_eq!(devices.iter_port_dev().count(), 1);
+    assert_eq!(devices.iter_sys_reg_dev().count(), 1);
+}
+
+#[test]
+fn test_conflicting_device_config_returns_structured_error() {
+    let ioapic = EmulatedDeviceConfig {
+        name: String::from("ioapic"),
+        base_gpa: 0xfec0_0000,
+        length: 0x1000,
+        irq_id: 0,
+        emu_type: EmulatedDeviceType::X86IoApic,
+        cfg_list: vec![],
+    };
+
+    assert_eq!(
+        AxVmDevices::new(AxVmDeviceConfig::new(vec![ioapic.clone(), ioapic])).err(),
+        Some(AxError::AlreadyExists)
+    );
 }
 
 // Mock implementation for x86_vlapic host callbacks when running

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -16,7 +16,9 @@ use std::sync::{Arc, Mutex};
 
 use ax_errno::{AxError, AxResult};
 use ax_memory_addr::{PhysAddr, VirtAddr};
-use axdevice::{AxVmDeviceConfig, AxVmDevices};
+use axdevice::{
+    AxVmDeviceConfig, AxVmDevices, DeviceBundle, DeviceRegistration, PollableDeviceOps,
+};
 use axdevice_base::{AccessWidth, BaseDeviceOps, Port, PortRange, SysRegAddr, SysRegAddrRange};
 use axvm_types::{
     EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptVector,
@@ -108,6 +110,49 @@ impl BaseDeviceOps<PortRange> for MockPortDevice {
 
 struct MockSysRegDevice {
     range: SysRegAddrRange,
+}
+
+struct MockMmioPollableDevice {
+    range: GuestPhysAddrRange,
+    polled_at: Mutex<Vec<u64>>,
+}
+
+impl MockMmioPollableDevice {
+    fn new(start: usize, end: usize) -> Self {
+        Self {
+            range: GuestPhysAddrRange::new(start.into(), end.into()),
+            polled_at: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn polled_at(&self) -> Vec<u64> {
+        self.polled_at.lock().unwrap().clone()
+    }
+}
+
+impl BaseDeviceOps<GuestPhysAddrRange> for MockMmioPollableDevice {
+    fn address_range(&self) -> GuestPhysAddrRange {
+        self.range
+    }
+
+    fn emu_type(&self) -> EmulatedDeviceType {
+        EmulatedDeviceType::IVCChannel
+    }
+
+    fn handle_read(&self, _addr: GuestPhysAddr, _width: AccessWidth) -> AxResult<usize> {
+        Ok(0)
+    }
+
+    fn handle_write(&self, _addr: GuestPhysAddr, _width: AccessWidth, _val: usize) -> AxResult {
+        Ok(())
+    }
+}
+
+impl PollableDeviceOps for MockMmioPollableDevice {
+    fn poll(&self, now_ns: u64) -> AxResult {
+        self.polled_at.lock().unwrap().push(now_ns);
+        Ok(())
+    }
 }
 
 impl MockSysRegDevice {
@@ -347,6 +392,123 @@ fn test_conflicting_device_config_returns_structured_error() {
         AxVmDevices::new(AxVmDeviceConfig::new(vec![ioapic.clone(), ioapic])).err(),
         Some(AxError::AlreadyExists)
     );
+}
+
+#[test]
+fn test_bundle_registers_mmio_and_port_together() {
+    let mut devices = empty_devices();
+    let mut bundle = DeviceBundle::new();
+    bundle.push(DeviceRegistration::Mmio(mmio_device(
+        "bundle-mmio",
+        0x4000,
+        0x5000,
+    )));
+    bundle.push(DeviceRegistration::Port(Arc::new(MockPortDevice::new(
+        0x500, 0x50f,
+    ))));
+
+    assert_eq!(devices.register_bundle(bundle), Ok(()));
+    assert_eq!(devices.iter_mmio_dev().count(), 1);
+    assert_eq!(devices.iter_port_dev().count(), 1);
+    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+}
+
+#[test]
+fn test_bundle_internal_conflict_is_atomic() {
+    let mut devices = empty_devices();
+    let mut bundle = DeviceBundle::new();
+    bundle.push(DeviceRegistration::Mmio(mmio_device(
+        "bundle-first",
+        0x4000,
+        0x5000,
+    )));
+    bundle.push(DeviceRegistration::Mmio(mmio_device(
+        "bundle-overlap",
+        0x4800,
+        0x5800,
+    )));
+    bundle.push(DeviceRegistration::Port(Arc::new(MockPortDevice::new(
+        0x500, 0x50f,
+    ))));
+
+    assert_eq!(devices.register_bundle(bundle), Err(AxError::AddrInUse));
+    assert_eq!(devices.iter_mmio_dev().count(), 0);
+    assert_eq!(devices.iter_port_dev().count(), 0);
+    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+}
+
+#[test]
+fn test_bundle_existing_conflict_leaves_all_registries_unchanged() {
+    let mut devices = empty_devices();
+    devices
+        .add_port_dev(Arc::new(MockPortDevice::new(0x3f8, 0x3ff)))
+        .unwrap();
+
+    let counts_before = (
+        devices.iter_mmio_dev().count(),
+        devices.iter_port_dev().count(),
+        devices.iter_sys_reg_dev().count(),
+    );
+    let mut bundle = DeviceBundle::new();
+    bundle.push(DeviceRegistration::Mmio(mmio_device(
+        "bundle-mmio",
+        0x6000,
+        0x7000,
+    )));
+    bundle.push(DeviceRegistration::Port(Arc::new(MockPortDevice::new(
+        0x3ff, 0x400,
+    ))));
+    bundle.push(DeviceRegistration::SysReg(Arc::new(MockSysRegDevice::new(
+        0x200, 0x210,
+    ))));
+
+    assert_eq!(devices.register_bundle(bundle), Err(AxError::AddrInUse));
+    assert_eq!(
+        (
+            devices.iter_mmio_dev().count(),
+            devices.iter_port_dev().count(),
+            devices.iter_sys_reg_dev().count(),
+        ),
+        counts_before
+    );
+}
+
+#[test]
+fn test_pollable_and_mmio_capabilities_share_one_device() {
+    let mut devices = empty_devices();
+    let shared = Arc::new(MockMmioPollableDevice::new(0x8000, 0x9000));
+    let mut bundle = DeviceBundle::new();
+    bundle.push(DeviceRegistration::Mmio(shared.clone()));
+    bundle.push(DeviceRegistration::Pollable(shared.clone()));
+
+    assert_eq!(devices.register_bundle(bundle), Ok(()));
+    devices
+        .iter_pollable_dev()
+        .next()
+        .unwrap()
+        .poll(123_456)
+        .unwrap();
+
+    assert_eq!(devices.iter_mmio_dev().count(), 1);
+    assert_eq!(devices.iter_pollable_dev().count(), 1);
+    assert_eq!(shared.polled_at(), vec![123_456]);
+}
+
+#[test]
+fn test_duplicate_pollable_rejects_entire_bundle() {
+    let mut devices = empty_devices();
+    let shared = Arc::new(MockMmioPollableDevice::new(0xa000, 0xb000));
+    devices
+        .register_bundle(DeviceRegistration::Pollable(shared.clone()).into())
+        .unwrap();
+
+    let mut bundle = DeviceBundle::new();
+    bundle.push(DeviceRegistration::Mmio(shared.clone()));
+    bundle.push(DeviceRegistration::Pollable(shared));
+
+    assert_eq!(devices.register_bundle(bundle), Err(AxError::AlreadyExists));
+    assert_eq!(devices.iter_mmio_dev().count(), 0);
+    assert_eq!(devices.iter_pollable_dev().count(), 1);
 }
 
 // Mock implementation for x86_vlapic host callbacks when running

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -17,9 +17,14 @@ use std::sync::{Arc, Mutex};
 use ax_errno::{AxError, AxResult};
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axdevice::{
-    AxVmDeviceConfig, AxVmDevices, DeviceBundle, DeviceRegistration, PollableDeviceOps,
+    AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceBundle, DeviceFactory,
+    DeviceFactoryRegistry, DeviceRegistration, IrqResolver, PollableDeviceOps,
+    register_builtin_factories,
 };
-use axdevice_base::{AccessWidth, BaseDeviceOps, Port, PortRange, SysRegAddr, SysRegAddrRange};
+use axdevice_base::{
+    AccessWidth, BaseDeviceOps, InterruptTriggerMode, IrqLine, Port, PortRange, SysRegAddr,
+    SysRegAddrRange,
+};
 use axvm_types::{
     EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptVector,
     VCpuId, VMId,
@@ -190,6 +195,53 @@ fn mmio_device(name: &str, start: usize, end: usize) -> Arc<MockMmioDevice> {
         name,
         GuestPhysAddrRange::new(start.into(), end.into()),
     ))
+}
+
+fn device_config(
+    name: &str,
+    emu_type: EmulatedDeviceType,
+    base_gpa: usize,
+    length: usize,
+) -> EmulatedDeviceConfig {
+    EmulatedDeviceConfig {
+        name: String::from(name),
+        base_gpa,
+        length,
+        irq_id: 0,
+        emu_type,
+        cfg_list: vec![],
+    }
+}
+
+struct RejectingIrqResolver;
+
+impl IrqResolver for RejectingIrqResolver {
+    fn resolve_irq(&self, _line: usize, _trigger: InterruptTriggerMode) -> AxResult<IrqLine> {
+        Err(AxError::Unsupported)
+    }
+}
+
+struct MockMmioFactory;
+
+impl DeviceFactory for MockMmioFactory {
+    fn device_type(&self) -> EmulatedDeviceType {
+        EmulatedDeviceType::VirtioBlk
+    }
+
+    fn build(
+        &self,
+        config: &EmulatedDeviceConfig,
+        _context: &DeviceBuildContext<'_>,
+    ) -> AxResult<DeviceBundle> {
+        let Some(end) = config.base_gpa.checked_add(config.length) else {
+            return Err(AxError::InvalidInput);
+        };
+        if config.length == 0 {
+            return Err(AxError::InvalidInput);
+        }
+
+        Ok(DeviceRegistration::Mmio(mmio_device(&config.name, config.base_gpa, end)).into())
+    }
 }
 
 #[test]
@@ -509,6 +561,163 @@ fn test_duplicate_pollable_rejects_entire_bundle() {
     assert_eq!(devices.register_bundle(bundle), Err(AxError::AlreadyExists));
     assert_eq!(devices.iter_mmio_dev().count(), 0);
     assert_eq!(devices.iter_pollable_dev().count(), 1);
+}
+
+#[test]
+fn test_factory_registry_registers_and_finds_factory() {
+    let mut factories = DeviceFactoryRegistry::new();
+
+    assert_eq!(factories.register(Arc::new(MockMmioFactory)), Ok(()));
+    assert!(factories.get(EmulatedDeviceType::VirtioBlk).is_some());
+    assert!(factories.get(EmulatedDeviceType::VirtioNet).is_none());
+}
+
+#[test]
+fn test_factory_registry_rejects_duplicate_device_type() {
+    let mut factories = DeviceFactoryRegistry::new();
+
+    assert_eq!(factories.register(Arc::new(MockMmioFactory)), Ok(()));
+    assert_eq!(
+        factories.register(Arc::new(MockMmioFactory)),
+        Err(AxError::AlreadyExists)
+    );
+}
+
+#[test]
+fn test_missing_factory_returns_unsupported() {
+    let factories = DeviceFactoryRegistry::new();
+    let resolver = RejectingIrqResolver;
+    let context = DeviceBuildContext::new(&resolver);
+    let config = device_config(
+        "missing-console",
+        EmulatedDeviceType::VirtioConsole,
+        0x1000,
+        0x1000,
+    );
+
+    assert_eq!(
+        factories.build(&config, &context).err(),
+        Some(AxError::Unsupported)
+    );
+    assert_eq!(
+        AxVmDevices::build_with_factories(
+            AxVmDeviceConfig::new(vec![config]),
+            &factories,
+            &context,
+        )
+        .err(),
+        Some(AxError::Unsupported)
+    );
+}
+
+#[test]
+fn test_factory_build_registers_new_device_type_without_legacy_branch() {
+    let mut factories = DeviceFactoryRegistry::new();
+    factories.register(Arc::new(MockMmioFactory)).unwrap();
+    let resolver = RejectingIrqResolver;
+    let context = DeviceBuildContext::new(&resolver);
+    let base = 0x1_0000;
+    let devices = AxVmDevices::build_with_factories(
+        AxVmDeviceConfig::new(vec![device_config(
+            "factory-mmio",
+            EmulatedDeviceType::VirtioBlk,
+            base,
+            0x1000,
+        )]),
+        &factories,
+        &context,
+    )
+    .unwrap();
+
+    assert_eq!(devices.iter_mmio_dev().count(), 1);
+    assert_eq!(
+        devices
+            .handle_mmio_read(base.into(), AccessWidth::try_from(4).unwrap())
+            .unwrap(),
+        0xDEAD_BEEF
+    );
+}
+
+#[test]
+fn test_factory_validation_failure_leaves_devices_unchanged() {
+    let mut devices = empty_devices();
+    devices
+        .add_port_dev(Arc::new(MockPortDevice::new(0x3f8, 0x3ff)))
+        .unwrap();
+    let counts_before = (
+        devices.iter_mmio_dev().count(),
+        devices.iter_port_dev().count(),
+        devices.iter_sys_reg_dev().count(),
+    );
+    let mut factories = DeviceFactoryRegistry::new();
+    factories.register(Arc::new(MockMmioFactory)).unwrap();
+    let resolver = RejectingIrqResolver;
+    let context = DeviceBuildContext::new(&resolver);
+    let invalid = device_config(
+        "invalid-factory-mmio",
+        EmulatedDeviceType::VirtioBlk,
+        0x2_0000,
+        0,
+    );
+
+    assert_eq!(
+        devices.register_factory_device(&invalid, &factories, &context),
+        Err(AxError::InvalidInput)
+    );
+    assert_eq!(
+        (
+            devices.iter_mmio_dev().count(),
+            devices.iter_port_dev().count(),
+            devices.iter_sys_reg_dev().count(),
+        ),
+        counts_before
+    );
+}
+
+#[test]
+fn test_builtin_meta_factory_builds_dummy_config() {
+    let mut factories = DeviceFactoryRegistry::new();
+    register_builtin_factories(&mut factories).unwrap();
+    let resolver = RejectingIrqResolver;
+    let context = DeviceBuildContext::new(&resolver);
+    let devices = AxVmDevices::build_with_factories(
+        AxVmDeviceConfig::new(vec![device_config(
+            "metadata",
+            EmulatedDeviceType::Dummy,
+            0,
+            0,
+        )]),
+        &factories,
+        &context,
+    )
+    .unwrap();
+
+    assert_eq!(devices.iter_mmio_dev().count(), 0);
+    assert_eq!(devices.iter_port_dev().count(), 0);
+    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+}
+
+#[test]
+fn test_build_with_factories_preserves_legacy_ivc_config() {
+    let mut factories = DeviceFactoryRegistry::new();
+    register_builtin_factories(&mut factories).unwrap();
+    let resolver = RejectingIrqResolver;
+    let context = DeviceBuildContext::new(&resolver);
+    let devices = AxVmDevices::build_with_factories(
+        AxVmDeviceConfig::new(vec![device_config(
+            "ivc",
+            EmulatedDeviceType::IVCChannel,
+            0x4_0000,
+            0x2000,
+        )]),
+        &factories,
+        &context,
+    )
+    .unwrap();
+
+    assert_eq!(devices.iter_mmio_dev().count(), 0);
+    assert_eq!(devices.iter_port_dev().count(), 0);
+    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
 }
 
 // Mock implementation for x86_vlapic host callbacks when running


### PR DESCRIPTION
## 背景

本 PR 是 #595「设备与中断框架重构」的基础设施部分。目标是先建立稳定的设备构造、IRQ line 和注册边界，再分阶段迁移各架构的生产设备。

当前 `AxVmDevices::init` 直接依赖具体架构设备，并通过大型 `EmulatedDeviceType` 分支构建设备；MMIO、PIO、SysReg 注册也缺少统一冲突检查。本 PR 不完成全部设备迁移，而是提供后续迁移共同依赖的基础契约。

## 主要修改

- 将 `InterruptTriggerMode` 和 `IrqLineId` 移到通用类型层，并保留 `axvcpu` 的重新导出兼容路径。
- 在 `axdevice_base` 引入架构无关的 `IrqLine` / `IrqSink`：
  - level-triggered 设备使用 `raise` / `lower`；
  - edge-triggered 设备使用 `pulse`；
  - 触发模式错误和 sink 错误通过 `AxResult` 返回。
- 为 MMIO、PIO、SysReg 注册增加空范围、溢出、重复设备、同范围和重叠范围检查。
- 将 `add_*_dev()` 和 `AxVmDevices::new()` 改为返回 `AxResult`。
- 引入 `DeviceRegistration`、`DeviceBundle` 和 `PollableDeviceOps`，支持一个设备贡献多种能力。
- 引入 `DeviceFactory`、`DeviceFactoryRegistry`、`DeviceBuildContext` 和 `IrqResolver`。
- 增加工厂重复、工厂缺失、地址冲突、bundle 原子性、pollable 共享对象和错误传播测试。

## 工厂与事务注册边界

设备工厂只负责根据 `EmulatedDeviceConfig` 和 `DeviceBuildContext` 构造 `DeviceBundle`，不能直接修改 `AxVmDevices`。

`DeviceBuildContext` 只暴露 VM 所有的最小构造服务，例如解析 VM-local IRQ line；工厂不能访问完整 `AxVM`、当前 vCPU 或具体中断控制器。

`register_bundle` 使用 validate-all-then-commit-all：

1. 检查 bundle 内部以及它与现有 MMIO、PIO、SysReg、pollable 注册项的全部冲突。
2. 只有所有检查通过后才提交全部能力。

因此任一能力注册失败都不会遗留半注册设备。

`EmulatedDeviceType` 和旧构造路径暂时保留，以兼容现有 TOML 和尚未迁移的设备。新增设备应注册 factory，不应继续扩展 legacy `match`；每迁移一种生产设备，就删除对应 fallback 分支。

## 后续迁移

后续 PR 将在本基础上依次完成：

- 建立 VM 级 `InterruptFabric`，让 `DeviceBuildContext` 解析真实 VM-local IRQ line。
- RISC-V vPLIC 改用类型化 IRQ 操作，删除固定 GPA 加模拟 pending MMIO 写的注入路径。
- x86 vIOAPIC、PIT、串口和直通 IRQ 接入 factory、`IrqLine` 和通用 pollable 路径。
- 删除 `AxVmDevices` 中的 x86 具体设备缓存和专用访问器。
- AArch64 VGIC、GPPT Redistributor、Distributor 和 ITS 迁移到平台工厂及中断后端。
- LoongArch 中断注入接入统一 backend，并明确 edge/level 支持边界。
- 增加命名及多输出 IRQ 配置。
- 收尾设备访问错误处理，最终删除 legacy 构造分支和直接架构耦合。

## 非目标

- 不重新设计 `BaseDeviceOps` 的读写接口。
- 不引入完整 PCI 拓扑、BAR 分配、热插拔或 DMA/IOMMU 能力模型。
- 不把 MSI/MSI-X 强行建模为基础 IRQ line。
- 不在本 PR 中迁移依赖具体中断 backend 的生产设备。
- 不删除现有配置字段或旧构造路径。

## 验证

- `cargo fmt --check`
- `cargo clippy --manifest-path virtualization/axdevice_base/Cargo.toml --all-features -- -D warnings`
- `cargo clippy --manifest-path virtualization/axdevice/Cargo.toml --all-features -- -D warnings`
- `cargo test --manifest-path virtualization/axdevice_base/Cargo.toml --all-features`
- `cargo test --manifest-path virtualization/axdevice/Cargo.toml --all-features`
- `cargo test --manifest-path virtualization/test_crates/virtualization-tests/Cargo.toml --test axdevice`
- `cargo clippy --manifest-path virtualization/test_crates/virtualization-tests/Cargo.toml --tests -- -D warnings`
- `git diff --check origin/dev...HEAD`

## CI 状态

当前 upstream PR head 尚未生成 GitHub Actions workflow run。上述本地验证已通过；待 upstream CI 触发后再根据结果补充修复。


Part of #595.