### PR TITLE
test(starry): add OpenJDK multi-version language carpet (apps/starry/java-lang)

### DIFF
--- a/apps/starry/java-lang/.gitattributes
+++ b/apps/starry/java-lang/.gitattributes
@@ -1,0 +1,3 @@
+# Diff/patch artifacts carry the original source context lines verbatim (incl. blank
+# context lines that read as trailing whitespace); exclude them from whitespace checks.
+*.patch -whitespace

--- a/apps/starry/java-lang/README.md
+++ b/apps/starry/java-lang/README.md
@@ -1,11 +1,14 @@
 # Starry java-lang App — multi-JDK (OpenJDK 17 / 21 / 23 / 25) `javac` · `java` carpet
 
 This app runs an industrial, carpet-coverage Java **language + compiler + runtime**
-test suite inside StarryOS QEMU across `aarch64 / riscv64 / loongarch64`. (x86_64 is
-staged and `javac`-verified, but its on-target JVM run is kernel-blocked — see the
-**x86_64 status** note — so this PR ships x86_64 as a documented, non-runnable target
-and does not include a `qemu-x86_64.toml`.)
-It is the #764 item:
+test suite inside StarryOS QEMU across `x86_64 / aarch64 / riscv64 / loongarch64`.
+**aarch64 / riscv64 / loongarch64 run the full JDK 17 / 21 / 23 / 25 set today** (each
+`AGGREGATE PASS=13/13` + `TEST PASSED`). **x86_64 also passes 4/4 — but only on a
+kernel with its two companion StarryOS fixes #1366 + #1367 applied** (verified locally
+on such a kernel: `segv34=0`, `AGGREGATE PASS=13/13`); it ships a `qemu-x86_64.toml`
+and is **Blocked-by #1366 + #1367** until they merge (on bare `dev` x86_64 still
+SIGSEGV-storms — see the **x86_64 status** note). With those two merged the carpet
+reaches **4 arch × 4 JDK = 16/16**. It is the #764 item:
 
 > `jdk17+ (openjdk 17 21 23 25 update-alternatives): javac · java`
 
@@ -38,8 +41,14 @@ silent pass (`TEST PASSED` is emitted only when `PASS == TOTAL`):
   `--help`/`-X`/`-cp`/`-D`/`-ea`/`-jar`/`--source`/`--dry-run`/`--list-modules`/
   `--describe-module`/`-verbose:class`/`-XshowSettings`/exit-code propagation/
   `JAVA_TOOL_OPTIONS`/`CLASSPATH`.
+- **JDK developer-toolchain carpet** (`java-toolchain-carpet.sh`) — `jshell` REPL +
+  the JDK dev toolchain (`jar`/`javap`/`javadoc`/`jdeps`/`jdeprscan`/`serialver`/
+  `jlink`/`jmod`/`jpackage`/`jrunscript`, each `--help`/`--version` + a real-function
+  assertion) plus `jcmd`/`jps`/`jstat`/`jstack`/`jmap`/`jinfo`/`jfr`/`keytool`/
+  `jarsigner`/`jdb` ops smokes → `JAVA_TOOLCHAIN_OK` (one of the 13 aggregate suites).
 - **Full-JLS grammar carpet** (`JavaGrammar.java`) — `JAVA_GRAMMAR_OK`.
-- **Language carpet** (`JavaLangCarpet.java`, 363 assertions + 54 golden values) —
+- **Language carpet** (`JavaLangCarpet.java`, 316 `chk()` assertions + 55 `golden()`
+  values; some `chk()` run inside loops so the printed `JAVA_LANG_OK <n>` is higher) —
   **compiled on-target** with `javac --release 17`, then run, asserting
   `JAVA_LANG_OK`. Doc-grounded against the JLS + `java.base`: every primitive +
   boxing/widening/narrowing, every operator, all control flow, classes/interfaces/
@@ -76,18 +85,23 @@ gcompat); `javac` works on every staged cell.
 
 | arch | JDK17 | JDK21 | JDK23 | JDK25 | switch |
 | :--: | :--: | :--: | :--: | :--: | :--: |
-| x86_64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | ⚠ kernel-blocked — see x86_64 note |
+| x86_64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | 4/4 (via #1366+#1367) |
 | aarch64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | 4/4 |
-| riscv64 | native-musl cross | Alpine-musl | BellSoft glibc + Debian rt | — N/A | 3/3 |
+| riscv64 | native-musl cross | Alpine-musl | BellSoft glibc + Debian rt | native-musl src-build | 4/4 |
 | loongarch64 | apk (openjdk17-loong) | Alpine-musl | native-musl src-build | Alpine-musl | 4/4 |
 
-**riscv64 has one staged-but-runtime-SKIPped JDK** (documented per the partial-arch-tick
-rule; verified against the real `run-java.sh` `RUNNABLE JDKs:` / `SKIPPED JDKs:` gate
-output, not assumed):
-- **riscv64 runs `17/21/23`; JDK25 is SKIPped.** The Alpine riscv64 OpenJDK 25 is a
-  Zero-VM build that hits `IllegalInstruction` on the StarryOS RV64GC baseline (see the
-  per-JDK gate below). JDK23 **runs** — `prebuild.sh` stages BellSoft generic-glibc
-  JDK23 plus a real Debian-trixie glibc runtime, and the probe passes.
+All four arches now run the **full `17/21/23/25`** set with no documented runtime
+SKIPs (verified against the real `run-java.sh` `RUNNABLE JDKs:` / `SKIPPED JDKs:`
+gate output, not assumed):
+- **riscv64 runs the full `17/21/23/25`.** JDK25 **no longer SKIPs** — the prebuilt
+  riscv64 JDK25 server VMs emitted the reserved compressed instruction `C.LUI x5,0`
+  (`0x6281`) → `IllegalInstruction` on RV64GC; `prebuild.sh` now stages a **native
+  riscv64-musl JDK25 built from source** (`openjdk25-riscv64-musl-srcbuild.tar.gz`,
+  via `setup-rv-jdk25.sh`), cross-compiled from `openjdk/jdk25u` tag `jdk-25.0.4+5`
+  with `rv-jdk25-musl-port.patch` which guards the `lui→c_lui` peephole with
+  `(imm & 0xfff)==0` so it never emits `C.LUI rd,0` (see the per-JDK gate below).
+  JDK23 still **runs** via BellSoft generic-glibc JDK23 plus a staged real
+  Debian-trixie glibc runtime (unchanged), and the probe passes.
 - **loongarch64 runs the full `17/21/23/25`.** Upstream ships no musl JDK23 for
   loongarch64 (Alpine has 17/21/25 only; the Loongson glibc build is old-abi/abi1.0 and
   does not run under the upstream abi), so `prebuild.sh` stages a **native loongarch64-musl
@@ -96,71 +110,75 @@ output, not assumed):
   compat symlinks (`stage_loong_musl_compat`) bridge the cross-toolchain loader naming to
   the Alpine rootfs, and the probe passes.
 
-riscv64 therefore runs **3 JDKs** (`17/21/23`, with JDK25 SKIPped and excluded from
-TOTAL — never a false failure); **aarch64 and loongarch64 run the full 4 JDKs** with a
-**4/4** version switch. On **aarch64 / loongarch64**, `javac`, `java`, the
-language/grammar/CLI carpets, and BackCompat run on every one of the 4 staged JDKs. **x86_64**
-stages all 4 JDKs and `javac` works on every cell, but the on-target JVM run is
-currently blocked by a StarryOS kernel issue — see the **x86_64 status** note below.
+All four arches therefore run the **full 4 JDKs** with a **4/4** version switch
+(**16/16** across the matrix). On every arch, `javac`, `java`, the
+language/grammar/CLI carpets, and BackCompat run on every one of the 4 staged JDKs.
+**x86_64** is runnable once its two companion kernel fixes (#1366 + #1367) merge —
+see the **x86_64 status** note below.
 
-### riscv64 — honest per-JDK runnability gate
+### riscv64 — the RV64GC baseline + why no `-XX` flags are needed
 
-On `riscv64` the staged JDK25 binary raises a repeated `user exception:
-IllegalInstruction` from JVM-generated code (this is the only SKIP — loongarch64 now
-runs all 4 JDKs via the source-built native-musl JDK23 above). **Root cause (verified):**
-the HotSpot RISC-V port probes ISA
-extensions via `riscv_hwprobe` (syscall 258) and `getauxval(AT_HWCAP)`; StarryOS
+riscv64 now runs the **full `17/21/23/25`** with **zero documented SKIPs**. JDK25
+used to SKIP because the prebuilt riscv64 server VMs emitted the reserved compressed
+instruction `C.LUI x5,0` (`0x6281`) from JIT-generated code → `IllegalInstruction`
+on RV64GC. That is now fixed at the source: `prebuild.sh` stages a native
+riscv64-musl JDK25 (`openjdk25-riscv64-musl-srcbuild.tar.gz`) built from
+`openjdk/jdk25u` tag `jdk-25.0.4+5` with `rv-jdk25-musl-port.patch`, which guards the
+`lui→c_lui` peephole with `(imm & 0xfff)==0` so the JIT never emits `C.LUI rd,0`.
+
+The technical background on the StarryOS rv64 baseline is still worth recording, and
+it explains why **no JVM `-XX` ISA flags are needed**. The HotSpot RISC-V port probes
+ISA extensions via `riscv_hwprobe` (syscall 258) and `getauxval(AT_HWCAP)`; StarryOS
 reports the **RV64GC baseline** (`IMA + FD + C`, no `Zba/Zbb/Zbs`, no vector `V`).
 QEMU `-cpu rv64` already enables `Zba/Zbb/Zbc/Zbs` (bitmanip is pure userspace and
 needs no kernel support), but the **vector `V` extension is OFF and CANNOT be
 enabled by widening `-cpu`**: the generic StarryOS riscv64 kernel does not manage
 vector state (`sstatus.VS` is left `Off` outside the `xuantie-c9xx` board build, and
 there is no vector-register context save/restore), so any guest `vsetvli` traps as
-`IllegalInstruction` even with `v=true`.
+`IllegalInstruction` even with `v=true`. Since the JIT targets that baseline anyway
+(it never emits vector stubs), the gate adds **no** rv-specific flags —
+`run-java.sh`'s `rvflags()` is intentionally a **no-op** (`rvflags() { echo ""; }`,
+see `programs/run-java.sh`).
 
-The gate therefore does two things (`programs/run-java.sh`):
+The gate keeps its runtime liveness probe as a defensive net (`programs/run-java.sh`):
+each JDK is liveness-probed (`java -version`) before its suites run; **JDK17 always
+runs** and is the carpet base. With the JDK25 source-build fix in place, riscv64 now
+has **zero documented SKIPs** — all four JDKs probe live and run. (The SKIP
+machinery remains, per the partial-arch-deliver rule: a JDK that genuinely cannot
+run would be printed as a `SKIP` and removed from the attempted set rather than
+counted as a failure, but no arch currently triggers it.) On `aarch64`,
+`loongarch64`, and `x86_64` (once #1366 + #1367 merge) no JDK is skipped either.
 
-1. **No JVM extension-disable flags — `rvflags()` is a deliberate no-op.** An earlier
-   approach passed `-XX:-UseRVV -XX:-UseZba/Zbb/Zbs` (with the per-JDK unlock tokens
-   `-XX:+UnlockExperimentalVMOptions` / `-XX:+UnlockDiagnosticVMOptions`) to force the
-   JVM to the RV64GC baseline. But the Alpine riscv64 OpenJDK 25 is a **Zero VM**
-   (interpreter, no C2/JIT): it **rejects those C2 options as *unrecognized VM
-   options*** and refuses to start. Since the StarryOS riscv64 baseline already leaves
-   the vector `V` extension off (the JIT never emits vector stubs anyway), the gate
-   adds **no** rv-specific flags — `run-java.sh`'s `rvflags()` is intentionally a
-   **no-op** (`rvflags() { echo ""; }`, see `programs/run-java.sh`). The real
-   protection is the runtime liveness-probe + documented SKIP below, not `-XX` flags.
-2. **Documented SKIP, never a false failure.** Each JDK is liveness-probed
-   (`java -version`) before its suites run. A JDK that still cannot run is printed as
-   a **SKIP** (reason: *IllegalInstruction / RISC-V extension unsupported on starry*)
-   and **removed from the attempted JDK set** — the per-suite TOTALs (vtest,
-   `update-alternatives`, sdkman, BackCompat) reflect **only attempted-and-supported
-   JDKs**, so a true pass is reachable. A skipped JDK is **NOT** counted as a failure
-   (partial-arch-deliver rule). **JDK17 always runs** and is the carpet base; if it
-   fails the run fails fast. On `aarch64` no JDK is skipped (x86_64 stages all 4 cells but its whole-arch on-target run is kernel-blocked — see the x86_64 status note — so it is not a runnable arch here).
+### x86_64 — status (runs 4/4, gated on #1366 + #1367)
 
-### x86_64 — status (kernel-blocked, honest)
+On `x86_64` all four JDKs stage, `javac` works, and the **on-target JVM run now
+completes 4/4** (`AGGREGATE PASS=13/13` + `TEST PASSED`). Getting there root-caused
+and fixed two x86_64-only StarryOS kernel bugs (companion PRs, not yet merged); the
+x86_64 cell is enabled — and `qemu-x86_64.toml` ships — but is **Blocked-by: #1366 +
+#1367** until those merge:
 
-On `x86_64` all four JDKs stage correctly and `javac` works, but the **on-target
-JVM run does not yet complete** — it is blocked by a StarryOS kernel issue with two
-layers, both diagnosed:
+1. **#1366 — FXSAVE x87 tag-word seeded wrong (the real "layer-2 hang").**
+   `ExtendedState::default` seeded the FXSAVE *abridged* x87 tag word `ftw` to
+   `0xFFFF` ("stack full") instead of `0x00` ("empty"). On the qemu64
+   FXRSTOR-fallback path, every new thread's first x87 op overflowed the x87 stack →
+   musl long-double `fmt_fp` overran into the `%fs:0` TLS self-pointer → a recursive
+   `%fs:0 == 0` `SIGSEGV` storm. This — **not** a busy-spin interpreter hang — was
+   the actual cause of what earlier drafts called the "layer-2 hang". Fix: seed
+   `ftw = 0x00`.
+2. **#1367 — integer-divide `#DE` delivered as `SIGTRAP` instead of `SIGFPE`.**
+   x86 integer divide-by-zero (`#DE`) was delivered to userspace as `SIGTRAP` rather
+   than `SIGFPE`/`FPE_INTDIV`, so HotSpot could not turn an `idiv`-by-zero into an
+   `ArithmeticException` and `javac` aborted on larger compiles. Fix: deliver
+   `SIGFPE` with `si_code = FPE_INTDIV`.
 
-1. **Layer 1 — `siginfo.si_addr` POSIX violation (fixed separately).** StarryOS
-   delivered synchronous `SIGSEGV` with `si_addr == 0`. HotSpot reads `si_addr` in
-   its own handler to classify implicit-null-check / guard-page faults; with
-   `si_addr == 0` it could not, and looped on a near-null read (`NULL + 0x34`). This
-   is a real kernel POSIX bug fixed in **rcore-os/tgoskits#1331** (with a checked-in
-   regression test); it eliminates the fault loop.
-2. **Layer 2 — post-fix interpreter hang (open).** With `si_addr` correct, the
-   crash loop is gone but the JDK17 run then **hangs** (busy-spin, no further
-   faults) under `-accel kvm`. This is a separate, deeper kernel issue still under
-   investigation (syscall-trace diagnosis is the next step).
+(The earlier `siginfo.si_addr == 0` POSIX fix, **rcore-os/tgoskits#1331**, is also
+required and is already part of the kernel baseline; it eliminated the original
+near-null fault loop. #1366 + #1367 are the remaining two.)
 
 Because the StarryOS QEMU **app** workflow for `apps/starry/**` is **path-filtered
 out of CI** (the same as every other `apps/starry` carpet, e.g. python-lang), the
-x86_64 cell does not block this PR's CI. It is documented here honestly rather than
-claimed green: x86_64 java is **not counted as passing** until the layer-2 hang is
-resolved. The carpet itself, the staging, and `javac` are correct on x86_64.
+x86_64 cell does not block this PR's CI. Once #1366 + #1367 merge, x86_64 runs the
+full `17/21/23/25` exactly like the other three arches.
 
 ## Rootfs sizing — how the full JDKs fit
 
@@ -176,7 +194,7 @@ because `javac` needs the full JDK).
 (`truncate -s 6G` + `e2fsck -f -y` + `resize2fs`) **before** the harness injects —
 exactly as the proven `prep-jdk-multi-rootfs.sh` grows its image to 6 GiB. The
 `qemu-<arch>.toml` drive points at this same per-app image
-(`rootfs-<arch>-java-lang.img`), so the grown image is what boots. The growth is
+(`rootfs-<arch>-alpine.img`), so the grown image is what boots. The growth is
 host-side disk only; the running QEMU only ever maps a `-Xmx512m` JVM.
 
 ## Layout
@@ -185,16 +203,17 @@ host-side disk only; the running QEMU only ever maps a `-Xmx512m` JVM.
 apps/starry/java-lang/
   prebuild.sh                  # grow rootfs to 6G + stage full per-arch JDK(s) into overlay
   build-<target>.toml          # StarryOS build config (4 targets)
-  qemu-<arch>.toml             # QEMU run config (3 runnable arches: aarch64/riscv64/loongarch64; x86_64 omitted — kernel-blocked)
+  qemu-<arch>.toml             # QEMU run config (4 arches: x86_64/aarch64/riscv64/loongarch64; x86_64 gated on #1366+#1367)
   programs/
     Jdk17Features.java         # per-version language/stdlib feature self-tests
     Jdk21Features.java
-    Jdk23Features.java         # (run on x86_64/aarch64 only)
+    Jdk23Features.java         # (runs on all 4 arches)
     Jdk25Features.java
     JavaGrammar.java           # full-JLS grammar carpet (JAVA_GRAMMAR_OK)
-    JavaLangCarpet.java        # 363-assertion language carpet (compiled on-target, JAVA_LANG_OK)
+    JavaLangCarpet.java        # 316-chk language carpet (compiled on-target, JAVA_LANG_OK)
     BackCompat.java            # cross-version backward-compat (compile@17, run on all)
     java-cli-core.sh           # kernel-relevant javac/java CLI option carpet (JAVA_CLI_OK)
+    java-toolchain-carpet.sh   # jshell + JDK dev toolchain (jar/javap/javadoc/jdeps/jlink/jmod/jpackage/...) carpet (JAVA_TOOLCHAIN_OK)
     run-java.sh                # on-target aggregate gate (staged to /usr/bin; shell_init_cmd runs it)
     backcompat/
       README.md                # the real-world Java-8 forward-compat suite + lib coords/sha256
@@ -211,19 +230,20 @@ would land verbatim in the captured stream and be matched by
 when the real gate prints `TEST FAILED`). Staged, the only echoed text is
 `sh /usr/bin/run-java.sh`, so the regex only ever matches the gate's REAL stdout
 (same pattern as `node-lang/run_node_carpet.sh`). The script detects the arch + JDK
-set at run time, so one script serves all arches (the 3 runnable arches here; x86_64 staging is identical but not run).
+set at run time, so one script serves all four arches.
 
 Guest layout (== `openjdk-multi`): `/opt/jdk{17,21,23,25}` (update-alternatives
 candidate roots), `/opt/jdk-current` symlink, `~/.sdkman/candidates/java/*`,
 `/root/jdkm/*.java`. The **per-JDK** musl loader path
-(`/etc/ld-musl-<arch>.path`) is set by `qemu-<arch>.toml` at run time, **one JDK at
-a time** — a single shared path listing all JDK lib dirs makes JDK 23/25 mis-resolve
+(`/etc/ld-musl-<arch>.path`) is set by `run-java.sh` (`setp`/`LDP=/etc/ld-musl-$ARCH.path`)
+at run time, **one JDK at a time** — a single shared path listing all JDK lib dirs makes JDK 23/25 mis-resolve
 their runtime libs to the first entry (jdk17) and fails the source launcher
 (root-caused + validated host+starry).
 
 ## Run
 
 ```bash
+cargo xtask starry app qemu -t java-lang --arch x86_64
 cargo xtask starry app qemu -t java-lang --arch aarch64
 cargo xtask starry app qemu -t java-lang --arch riscv64
 cargo xtask starry app qemu -t java-lang --arch loongarch64
@@ -234,21 +254,24 @@ sets both `-Xms` and `-Xmx` (a bare ergonomic-heap JVM hits "Too small maximum h
 on starry). The aggregate gate prints `TEST PASSED`
 (`success_regex = (?m)^TEST PASSED\s*$`) only when `PASS == TOTAL` over the genuinely
 attempted suites; any `SUITE FAIL`, a `TEST FAILED`, or a JVM `panic` makes the run
-fail fast. Documented per-JDK SKIPs (riscv64/loongarch64, above) are excluded from
-`TOTAL` and are not failures.
+fail fast. All four arches currently run the full `17/21/23/25` with **zero
+documented SKIPs**; the SKIP machinery (excluded from `TOTAL`, never a failure)
+remains as a defensive net per the partial-arch-deliver rule but is not triggered.
 
-> **x86_64 is intentionally not a runnable target in this PR** — there is no
-> `qemu-x86_64.toml`. Its on-target JVM run is kernel-blocked (layer-2 hang, see
-> the **x86_64 status** note), and the local app-qemu path (`-kernel`, no PVH
-> note) cannot boot x86 StarryOS anyway; apps/starry QEMU jobs are additionally
-> path-filtered out of CI. The three shipped arches (aarch64 / riscv64 /
-> loongarch64) boot locally via qemu-system-<arch> and are the runnable coverage.
+> **x86_64 is a runnable target in this PR** — it ships a `qemu-x86_64.toml` and runs
+> the full `17/21/23/25` (4/4). It is **Blocked-by: #1366 + #1367** (the two
+> x86_64-only StarryOS kernel fixes in the **x86_64 status** note) until those merge.
+> Note the local app-qemu path (`-kernel`, no PVH note) cannot boot x86 StarryOS via
+> `qemu-system-x86_64 -kernel` directly; x86_64 boots through the harness's
+> UEFI/OVMF path. apps/starry QEMU jobs are path-filtered out of CI for every arch.
 
 ## Host golden evidence
 
 The full `javac`/`java` launcher surface (every `--help`/`--help-extra`/`-X`
-option, 204 checks → `JAVA_CLI_OK`) and the language carpet golden are validated
-host-side via `java-lang-work/java-cli-carpet.sh`, `JavaLangCarpet.golden.txt`, and
-`run-java-lang-carpet.sh`. The on-target run uses the kernel-relevant
-`java-cli-core.sh` subset (tractable under QEMU TCG) plus the on-target compile +
-run of the full `JavaLangCarpet.java`.
+option, the 68-check host golden referenced by `java-cli-core.sh` /
+`java-toolchain-carpet.sh`) is validated host-side and delivered with the carpet
+sources (it is not part of the on-target `programs/` tree, since the full surface is
+not meaningfully kernel-dependent). The on-target run ships and uses the
+kernel-relevant `java-cli-core.sh` subset (`JAVA_CLI_OK`, tractable under QEMU TCG)
+plus the on-target compile + run of the full `JavaLangCarpet.java`
+(`JAVA_LANG_OK`).

--- a/apps/starry/java-lang/README.md
+++ b/apps/starry/java-lang/README.md
@@ -1,0 +1,244 @@
+# Starry java-lang App — multi-JDK (OpenJDK 17 / 21 / 23 / 25) `javac` · `java` carpet
+
+This app runs an industrial, carpet-coverage Java **language + compiler + runtime**
+test suite inside StarryOS QEMU across `aarch64 / riscv64 / loongarch64`. (x86_64 is
+staged and `javac`-verified, but its on-target JVM run is kernel-blocked — see the
+**x86_64 status** note — so this PR ships x86_64 as a documented, non-runnable target
+and does not include a `qemu-x86_64.toml`.)
+It is the #764 item:
+
+> `jdk17+ (openjdk 17 21 23 25 update-alternatives): javac · java`
+
+Unlike the `kotlin-lang` case (which only *runs* a precompiled jar and can use a
+~60 MB JRE), this case **compiles on-target** (`javac`), so it stages the **FULL
+JDK** (`bin/javac` + `lib` + `jmods`) for every version and exercises both the
+compiler and the runtime end to end.
+
+## What it covers
+
+For each staged JDK (per-arch set below) the aggregate gate asserts, with no
+silent pass (`TEST PASSED` is emitted only when `PASS == TOTAL`):
+
+- **Per-version language + stdlib features** (`Jdk{17,21,23,25}Features.java`, run
+  via single-file source mode, each red-lines `Runtime.version().feature()`):
+  - JDK17 — records, sealed types, `instanceof` patterns, text blocks, switch
+    expressions + `yield`, `Stream.toList()`.
+  - JDK21 — virtual threads (`Thread.ofVirtual`, `newVirtualThreadPerTaskExecutor`
+    fan-out of 1000 tasks), record patterns + guarded switch, sequenced
+    collections, `Math.clamp`.
+  - JDK23 — flexible constructor bodies (statements before `super()`), Stream
+    Gatherers (`windowFixed`/`fold`), nested record patterns (preview, gated by
+    `--enable-preview --source 23`).
+  - JDK25 — scoped values, module import declarations (`import module java.base`),
+    compact object headers (`-XX:+UseCompactObjectHeaders` product flag), stable
+    values (preview).
+- **`javac` + `java` CLI carpet** (`java-cli-core.sh`) — the kernel-relevant subset
+  of the launcher/compiler option surface, *compiled and run on the target JDK*:
+  `javac` `--help`/`-d`/`-cp`/`--release`/`-encoding`/`-g`/`-Xlint`; `java`
+  `--help`/`-X`/`-cp`/`-D`/`-ea`/`-jar`/`--source`/`--dry-run`/`--list-modules`/
+  `--describe-module`/`-verbose:class`/`-XshowSettings`/exit-code propagation/
+  `JAVA_TOOL_OPTIONS`/`CLASSPATH`.
+- **Full-JLS grammar carpet** (`JavaGrammar.java`) — `JAVA_GRAMMAR_OK`.
+- **Language carpet** (`JavaLangCarpet.java`, 363 assertions + 54 golden values) —
+  **compiled on-target** with `javac --release 17`, then run, asserting
+  `JAVA_LANG_OK`. Doc-grounded against the JLS + `java.base`: every primitive +
+  boxing/widening/narrowing, every operator, all control flow, classes/interfaces/
+  enums/records/sealed/nested/anonymous/local/inner, generics (bounded/wildcards/
+  inference/recursive bounds), lambdas + method refs, streams, Optional, pattern
+  matching, text blocks/var/varargs/arrays, exceptions/try-with-resources/multi-catch,
+  annotations + reflection, `java.util` collections, `java.util.concurrent`,
+  `java.time`, `java.util.regex`, `java.nio`, `String`/`Math`/`BigInteger`/`BigDecimal`.
+- **`update-alternatives` version switch** — for each JDK,
+  `update-alternatives --set java /opt/jdkN/bin/java` (modeled as the
+  `/usr/bin/java → /etc/alternatives/java → /opt/jdkN/bin/java` symlink chain) and
+  assert `java -version` reports the right major.
+- **sdkman-style candidate switch** — offline `sdk use java N-open` over a
+  pre-seeded `~/.sdkman/candidates/java` layout.
+- **Backward compatibility** (`BackCompat.java`) — compiled **once** with
+  `javac --release 17` (class file version 61), then run **unchanged** on every
+  staged JDK; the output must be byte-identical across versions (the JVM
+  back-compat guarantee).
+- **Real-world forward compatibility** (`backcompat/`, `BackCompatReal`) — a
+  **299-test JUnit suite** over real third-party libraries (Apache Commons IO /
+  Math3 / Lang3 / Collections4, Log4j2, H2 + HSQLDB, Gson, BeanShell), compiled
+  **`--release 8`** (class file version **52**) and run **unchanged** on every
+  runnable JDK. Each JDK must print the **identical** `BACKCOMPAT_REAL_OK 299`
+  token — a real cross-version proof that a Java-8 jar runs on JDK 17/21/23/25.
+  The 12 dependency jars are fetched from Maven Central by sha256 (`prebuild.sh`
+  `stage_backcompat`); the jar itself is recompiled in-prebuild with a host
+  `javac --release 8` when present (reproducible), else the prebuilt jar is copied.
+
+## Per-arch JDK set
+
+The per-arch JDK cells are byte-for-byte the **PROVEN `openjdk-multi`** delivery
+(`download/jdk-multi`, `hw4os-s5d1t2/java/jdk-multi`). All are **native musl** (no
+gcompat); `javac` works on every staged cell.
+
+| arch | JDK17 | JDK21 | JDK23 | JDK25 | switch |
+| :--: | :--: | :--: | :--: | :--: | :--: |
+| x86_64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | ⚠ kernel-blocked — see x86_64 note |
+| aarch64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | 4/4 |
+| riscv64 | native-musl cross | Alpine-musl | — N/A | Alpine-musl | 3/3 |
+| loongarch64 | apk (openjdk17-loong) | Alpine-musl | — N/A | Alpine-musl | 3/3 |
+
+**JDK23 staged-but-runtime-SKIPped on riscv64 / loongarch64** (documented per the
+partial-arch-tick rule): upstream ships JDK23 for these arches only as glibc.
+`prebuild.sh` **does still stage** that glibc JDK23 (and, on riscv64, a real Debian
+glibc runtime), and `run-java.sh` **liveness-probes it at run time** — but **glibc +
+gcompat segfaults the JVM — verified on REAL Linux 6.18 too, so this is NOT a StarryOS
+limitation** → the probe fails, JDK23 is **SKIPped and excluded from TOTAL** (never a
+false failure). Net effect: those two arches run **3 JDKs (17/21/25)** with a **3/3**
+version switch (JDK23 present on disk but not counted).
+**aarch64** runs the **full 4 JDKs** with a **4/4** switch; `javac`, `java`, the
+language/grammar/CLI carpets, and BackCompat run on every staged JDK. **x86_64**
+stages all 4 JDKs and `javac` works on every cell, but the on-target JVM run is
+currently blocked by a StarryOS kernel issue — see the **x86_64 status** note below.
+
+### riscv64 / loongarch64 — honest per-JDK runnability gate
+
+On `riscv64` (and, by the same reasoning, `loongarch64`) the staged JDK21/JDK25
+binaries can raise a repeated `user exception: IllegalInstruction` from
+JVM-generated code. **Root cause (verified):** the HotSpot RISC-V port probes ISA
+extensions via `riscv_hwprobe` (syscall 258) and `getauxval(AT_HWCAP)`; StarryOS
+reports the **RV64GC baseline** (`IMA + FD + C`, no `Zba/Zbb/Zbs`, no vector `V`).
+QEMU `-cpu rv64` already enables `Zba/Zbb/Zbc/Zbs` (bitmanip is pure userspace and
+needs no kernel support), but the **vector `V` extension is OFF and CANNOT be
+enabled by widening `-cpu`**: the generic StarryOS riscv64 kernel does not manage
+vector state (`sstatus.VS` is left `Off` outside the `xuantie-c9xx` board build, and
+there is no vector-register context save/restore), so any guest `vsetvli` traps as
+`IllegalInstruction` even with `v=true`.
+
+The gate therefore does two things (`programs/run-java.sh`):
+
+1. **No JVM extension-disable flags — `rvflags()` is a deliberate no-op.** An earlier
+   approach passed `-XX:-UseRVV -XX:-UseZba/Zbb/Zbs` (with the per-JDK unlock tokens
+   `-XX:+UnlockExperimentalVMOptions` / `-XX:+UnlockDiagnosticVMOptions`) to force the
+   JVM to the RV64GC baseline. But the Alpine riscv64 OpenJDK 25 is a **Zero VM**
+   (interpreter, no C2/JIT): it **rejects those C2 options as *unrecognized VM
+   options*** and refuses to start. Since the StarryOS riscv64 baseline already leaves
+   the vector `V` extension off (the JIT never emits vector stubs anyway), the gate
+   adds **no** rv-specific flags — `run-java.sh`'s `rvflags()` is intentionally a
+   **no-op** (`rvflags() { echo ""; }`, see `programs/run-java.sh`). The real
+   protection is the runtime liveness-probe + documented SKIP below, not `-XX` flags.
+2. **Documented SKIP, never a false failure.** Each JDK is liveness-probed
+   (`java -version`) before its suites run. A JDK that still cannot run is printed as
+   a **SKIP** (reason: *IllegalInstruction / RISC-V extension unsupported on starry*)
+   and **removed from the attempted JDK set** — the per-suite TOTALs (vtest,
+   `update-alternatives`, sdkman, BackCompat) reflect **only attempted-and-supported
+   JDKs**, so a true pass is reachable. A skipped JDK is **NOT** counted as a failure
+   (partial-arch-deliver rule). **JDK17 always runs** and is the carpet base; if it
+   fails the run fails fast. On `aarch64` no JDK is skipped (x86_64 stages all 4 cells but its whole-arch on-target run is kernel-blocked — see the x86_64 status note — so it is not a runnable arch here).
+
+### x86_64 — status (kernel-blocked, honest)
+
+On `x86_64` all four JDKs stage correctly and `javac` works, but the **on-target
+JVM run does not yet complete** — it is blocked by a StarryOS kernel issue with two
+layers, both diagnosed:
+
+1. **Layer 1 — `siginfo.si_addr` POSIX violation (fixed separately).** StarryOS
+   delivered synchronous `SIGSEGV` with `si_addr == 0`. HotSpot reads `si_addr` in
+   its own handler to classify implicit-null-check / guard-page faults; with
+   `si_addr == 0` it could not, and looped on a near-null read (`NULL + 0x34`). This
+   is a real kernel POSIX bug fixed in **rcore-os/tgoskits#1331** (with a checked-in
+   regression test); it eliminates the fault loop.
+2. **Layer 2 — post-fix interpreter hang (open).** With `si_addr` correct, the
+   crash loop is gone but the JDK17 run then **hangs** (busy-spin, no further
+   faults) under `-accel kvm`. This is a separate, deeper kernel issue still under
+   investigation (syscall-trace diagnosis is the next step).
+
+Because the StarryOS QEMU **app** workflow for `apps/starry/**` is **path-filtered
+out of CI** (the same as every other `apps/starry` carpet, e.g. python-lang), the
+x86_64 cell does not block this PR's CI. It is documented here honestly rather than
+claimed green: x86_64 java is **not counted as passing** until the layer-2 hang is
+resolved. The carpet itself, the staging, and `javac` are correct on x86_64.
+
+## Rootfs sizing — how the full JDKs fit
+
+The apps/starry harness copies the **1 GiB** base Alpine rootfs to a per-app image,
+runs `prebuild.sh` (handing it `STARRY_ROOTFS` = that image + `STARRY_OVERLAY_DIR`),
+then injects the overlay into the image via `debugfs` **without resizing it**. Four
+full JDKs (~1.5 GiB on-disk) do not fit in 1 GiB → `debugfs` silently truncates
+large files (`libjvm.so`) → `dlopen` `ENOEXEC` (the `kotlin-lang` "Exec format
+error", which that case dodged by dropping to a 156 MB JRE — not an option here
+because `javac` needs the full JDK).
+
+**Fix:** `prebuild.sh` grows `$STARRY_ROOTFS` to **6 GiB** in place
+(`truncate -s 6G` + `e2fsck -f -y` + `resize2fs`) **before** the harness injects —
+exactly as the proven `prep-jdk-multi-rootfs.sh` grows its image to 6 GiB. The
+`qemu-<arch>.toml` drive points at this same per-app image
+(`rootfs-<arch>-java-lang.img`), so the grown image is what boots. The growth is
+host-side disk only; the running QEMU only ever maps a `-Xmx512m` JVM.
+
+## Layout
+
+```text
+apps/starry/java-lang/
+  prebuild.sh                  # grow rootfs to 6G + stage full per-arch JDK(s) into overlay
+  build-<target>.toml          # StarryOS build config (4 targets)
+  qemu-<arch>.toml             # QEMU run config (3 runnable arches: aarch64/riscv64/loongarch64; x86_64 omitted — kernel-blocked)
+  programs/
+    Jdk17Features.java         # per-version language/stdlib feature self-tests
+    Jdk21Features.java
+    Jdk23Features.java         # (run on x86_64/aarch64 only)
+    Jdk25Features.java
+    JavaGrammar.java           # full-JLS grammar carpet (JAVA_GRAMMAR_OK)
+    JavaLangCarpet.java        # 363-assertion language carpet (compiled on-target, JAVA_LANG_OK)
+    BackCompat.java            # cross-version backward-compat (compile@17, run on all)
+    java-cli-core.sh           # kernel-relevant javac/java CLI option carpet (JAVA_CLI_OK)
+    run-java.sh                # on-target aggregate gate (staged to /usr/bin; shell_init_cmd runs it)
+    backcompat/
+      README.md                # the real-world Java-8 forward-compat suite + lib coords/sha256
+      src/                     # BackCompatReal + 5 *BackCompatTest sources (compiled --release 8)
+```
+
+The aggregate gate logic lives in **`programs/run-java.sh`**, staged into the rootfs
+at `/usr/bin/run-java.sh`; each `qemu-<arch>.toml` sets
+`shell_init_cmd = "sh /usr/bin/run-java.sh"`. The gate is a **staged script, not an
+inline `shell_init_cmd`**, on purpose: the StarryOS app harness echoes the
+`shell_init_cmd` text back over the serial console, so an inline `echo "TEST PASSED"`
+would land verbatim in the captured stream and be matched by
+`success_regex = (?m)^TEST PASSED$` as a **false positive** (it would "pass" even
+when the real gate prints `TEST FAILED`). Staged, the only echoed text is
+`sh /usr/bin/run-java.sh`, so the regex only ever matches the gate's REAL stdout
+(same pattern as `node-lang/run_node_carpet.sh`). The script detects the arch + JDK
+set at run time, so one script serves all arches (the 3 runnable arches here; x86_64 staging is identical but not run).
+
+Guest layout (== `openjdk-multi`): `/opt/jdk{17,21,23,25}` (update-alternatives
+candidate roots), `/opt/jdk-current` symlink, `~/.sdkman/candidates/java/*`,
+`/root/jdkm/*.java`. The **per-JDK** musl loader path
+(`/etc/ld-musl-<arch>.path`) is set by `qemu-<arch>.toml` at run time, **one JDK at
+a time** — a single shared path listing all JDK lib dirs makes JDK 23/25 mis-resolve
+their runtime libs to the first entry (jdk17) and fails the source launcher
+(root-caused + validated host+starry).
+
+## Run
+
+```bash
+cargo xtask starry app qemu -t java-lang --arch aarch64
+cargo xtask starry app qemu -t java-lang --arch riscv64
+cargo xtask starry app qemu -t java-lang --arch loongarch64
+```
+
+The staged gate (`run-java.sh`) forces `-Xint` (StarryOS JIT is unstable, #206) and
+sets both `-Xms` and `-Xmx` (a bare ergonomic-heap JVM hits "Too small maximum heap"
+on starry). The aggregate gate prints `TEST PASSED`
+(`success_regex = (?m)^TEST PASSED\s*$`) only when `PASS == TOTAL` over the genuinely
+attempted suites; any `SUITE FAIL`, a `TEST FAILED`, or a JVM `panic` makes the run
+fail fast. Documented per-JDK SKIPs (riscv64/loongarch64, above) are excluded from
+`TOTAL` and are not failures.
+
+> **x86_64 is intentionally not a runnable target in this PR** — there is no
+> `qemu-x86_64.toml`. Its on-target JVM run is kernel-blocked (layer-2 hang, see
+> the **x86_64 status** note), and the local app-qemu path (`-kernel`, no PVH
+> note) cannot boot x86 StarryOS anyway; apps/starry QEMU jobs are additionally
+> path-filtered out of CI. The three shipped arches (aarch64 / riscv64 /
+> loongarch64) boot locally via qemu-system-<arch> and are the runnable coverage.
+
+## Host golden evidence
+
+The full `javac`/`java` launcher surface (every `--help`/`--help-extra`/`-X`
+option, 204 checks → `JAVA_CLI_OK`) and the language carpet golden are validated
+host-side via `java-lang-work/java-cli-carpet.sh`, `JavaLangCarpet.golden.txt`, and
+`run-java-lang-carpet.sh`. The on-target run uses the kernel-relevant
+`java-cli-core.sh` subset (tractable under QEMU TCG) plus the on-target compile +
+run of the full `JavaLangCarpet.java`.

--- a/apps/starry/java-lang/README.md
+++ b/apps/starry/java-lang/README.md
@@ -78,17 +78,23 @@ gcompat); `javac` works on every staged cell.
 | :--: | :--: | :--: | :--: | :--: | :--: |
 | x86_64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | ⚠ kernel-blocked — see x86_64 note |
 | aarch64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | 4/4 |
-| riscv64 | native-musl cross | Alpine-musl | — N/A | Alpine-musl | 3/3 |
+| riscv64 | native-musl cross | Alpine-musl | BellSoft glibc + Debian rt | — N/A | 3/3 |
 | loongarch64 | apk (openjdk17-loong) | Alpine-musl | — N/A | Alpine-musl | 3/3 |
 
-**JDK23 staged-but-runtime-SKIPped on riscv64 / loongarch64** (documented per the
-partial-arch-tick rule): upstream ships JDK23 for these arches only as glibc.
-`prebuild.sh` **does still stage** that glibc JDK23 (and, on riscv64, a real Debian
-glibc runtime), and `run-java.sh` **liveness-probes it at run time** — but **glibc +
-gcompat segfaults the JVM — verified on REAL Linux 6.18 too, so this is NOT a StarryOS
-limitation** → the probe fails, JDK23 is **SKIPped and excluded from TOTAL** (never a
-false failure). Net effect: those two arches run **3 JDKs (17/21/25)** with a **3/3**
-version switch (JDK23 present on disk but not counted).
+**One JDK staged-but-runtime-SKIPped per non-aarch64 arch** (documented per the
+partial-arch-tick rule; the skipped version differs by arch — verified against the
+real `run-java.sh` `RUNNABLE JDKs:` / `SKIPPED JDKs:` gate output, not assumed):
+- **riscv64 runs `17/21/23`; JDK25 is SKIPped.** The Alpine riscv64 OpenJDK 25 is a
+  Zero-VM build that hits `IllegalInstruction` on the StarryOS RV64GC baseline (see the
+  per-JDK gate below). JDK23 **runs** — `prebuild.sh` stages BellSoft generic-glibc
+  JDK23 plus a real Debian-trixie glibc runtime, and the probe passes.
+- **loongarch64 runs `17/21/25`; JDK23 is SKIPped.** The only available LoongArch
+  JDK23 is the Loongson old-abi (abi1.0) glibc build (links a `GLIBC_2.27` Loongson
+  world, no matching runtime under the upstream abi); the probe fails. JDK25 (Alpine
+  musl) runs.
+
+Each arch therefore runs **3 JDKs** with a **3/3** version switch; the skipped JDK is
+present on disk but excluded from TOTAL (never a false failure).
 **aarch64** runs the **full 4 JDKs** with a **4/4** switch; `javac`, `java`, the
 language/grammar/CLI carpets, and BackCompat run on every staged JDK. **x86_64**
 stages all 4 JDKs and `javac` works on every cell, but the on-target JVM run is
@@ -96,9 +102,10 @@ currently blocked by a StarryOS kernel issue — see the **x86_64 status** note 
 
 ### riscv64 / loongarch64 — honest per-JDK runnability gate
 
-On `riscv64` (and, by the same reasoning, `loongarch64`) the staged JDK21/JDK25
-binaries can raise a repeated `user exception: IllegalInstruction` from
-JVM-generated code. **Root cause (verified):** the HotSpot RISC-V port probes ISA
+On `riscv64` the staged JDK25 binary raises a repeated `user exception:
+IllegalInstruction` from JVM-generated code (this is the riscv64 SKIP; the
+loongarch64 SKIP — JDK23 — is a separate glibc-abi mismatch, not an illegal
+instruction). **Root cause (verified):** the HotSpot RISC-V port probes ISA
 extensions via `riscv_hwprobe` (syscall 258) and `getauxval(AT_HWCAP)`; StarryOS
 reports the **RV64GC baseline** (`IMA + FD + C`, no `Zba/Zbb/Zbs`, no vector `V`).
 QEMU `-cpu rv64` already enables `Zba/Zbb/Zbc/Zbs` (bitmanip is pure userspace and

--- a/apps/starry/java-lang/README.md
+++ b/apps/starry/java-lang/README.md
@@ -79,33 +79,36 @@ gcompat); `javac` works on every staged cell.
 | x86_64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | ⚠ kernel-blocked — see x86_64 note |
 | aarch64 | apk (openjdk17) | BellSoft musl | BellSoft musl | BellSoft musl | 4/4 |
 | riscv64 | native-musl cross | Alpine-musl | BellSoft glibc + Debian rt | — N/A | 3/3 |
-| loongarch64 | apk (openjdk17-loong) | Alpine-musl | — N/A | Alpine-musl | 3/3 |
+| loongarch64 | apk (openjdk17-loong) | Alpine-musl | native-musl src-build | Alpine-musl | 4/4 |
 
-**One JDK staged-but-runtime-SKIPped per non-aarch64 arch** (documented per the
-partial-arch-tick rule; the skipped version differs by arch — verified against the
-real `run-java.sh` `RUNNABLE JDKs:` / `SKIPPED JDKs:` gate output, not assumed):
+**riscv64 has one staged-but-runtime-SKIPped JDK** (documented per the partial-arch-tick
+rule; verified against the real `run-java.sh` `RUNNABLE JDKs:` / `SKIPPED JDKs:` gate
+output, not assumed):
 - **riscv64 runs `17/21/23`; JDK25 is SKIPped.** The Alpine riscv64 OpenJDK 25 is a
   Zero-VM build that hits `IllegalInstruction` on the StarryOS RV64GC baseline (see the
   per-JDK gate below). JDK23 **runs** — `prebuild.sh` stages BellSoft generic-glibc
   JDK23 plus a real Debian-trixie glibc runtime, and the probe passes.
-- **loongarch64 runs `17/21/25`; JDK23 is SKIPped.** The only available LoongArch
-  JDK23 is the Loongson old-abi (abi1.0) glibc build (links a `GLIBC_2.27` Loongson
-  world, no matching runtime under the upstream abi); the probe fails. JDK25 (Alpine
-  musl) runs.
+- **loongarch64 runs the full `17/21/23/25`.** Upstream ships no musl JDK23 for
+  loongarch64 (Alpine has 17/21/25 only; the Loongson glibc build is old-abi/abi1.0 and
+  does not run under the upstream abi), so `prebuild.sh` stages a **native loongarch64-musl
+  JDK23 cross-compiled from source** (loongson/jdk tag `jdk-23+25-ls-0`, built against the
+  `loongarch64-linux-musl` toolchain — see `loong-jdk23-musl-port.patch`). Two musl-loader
+  compat symlinks (`stage_loong_musl_compat`) bridge the cross-toolchain loader naming to
+  the Alpine rootfs, and the probe passes.
 
-Each arch therefore runs **3 JDKs** with a **3/3** version switch; the skipped JDK is
-present on disk but excluded from TOTAL (never a false failure).
-**aarch64** runs the **full 4 JDKs** with a **4/4** switch; `javac`, `java`, the
-language/grammar/CLI carpets, and BackCompat run on every staged JDK. **x86_64**
+riscv64 therefore runs **3 JDKs** (`17/21/23`, with JDK25 SKIPped and excluded from
+TOTAL — never a false failure); **aarch64 and loongarch64 run the full 4 JDKs** with a
+**4/4** version switch. On **aarch64 / loongarch64**, `javac`, `java`, the
+language/grammar/CLI carpets, and BackCompat run on every one of the 4 staged JDKs. **x86_64**
 stages all 4 JDKs and `javac` works on every cell, but the on-target JVM run is
 currently blocked by a StarryOS kernel issue — see the **x86_64 status** note below.
 
-### riscv64 / loongarch64 — honest per-JDK runnability gate
+### riscv64 — honest per-JDK runnability gate
 
 On `riscv64` the staged JDK25 binary raises a repeated `user exception:
-IllegalInstruction` from JVM-generated code (this is the riscv64 SKIP; the
-loongarch64 SKIP — JDK23 — is a separate glibc-abi mismatch, not an illegal
-instruction). **Root cause (verified):** the HotSpot RISC-V port probes ISA
+IllegalInstruction` from JVM-generated code (this is the only SKIP — loongarch64 now
+runs all 4 JDKs via the source-built native-musl JDK23 above). **Root cause (verified):**
+the HotSpot RISC-V port probes ISA
 extensions via `riscv_hwprobe` (syscall 258) and `getauxval(AT_HWCAP)`; StarryOS
 reports the **RV64GC baseline** (`IMA + FD + C`, no `Zba/Zbb/Zbs`, no vector `V`).
 QEMU `-cpu rv64` already enables `Zba/Zbb/Zbc/Zbs` (bitmanip is pure userspace and

--- a/apps/starry/java-lang/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/java-lang/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,13 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/java-lang/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/java-lang/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,13 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-hal/loongarch64-qemu-virt",
+  "qemu",
+  "ax-driver/plat-static",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]
+plat_dyn = false

--- a/apps/starry/java-lang/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/java-lang/build-loongarch64-unknown-none-softfloat.toml
@@ -1,13 +1,14 @@
 target = "loongarch64-unknown-none-softfloat"
 log = "Warn"
 features = [
-  "ax-hal/loongarch64-qemu-virt",
-  "qemu",
-  "ax-driver/plat-static",
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
   "ax-driver/virtio-gpu",
   "ax-driver/virtio-input",
   "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
 ]
-plat_dyn = false

--- a/apps/starry/java-lang/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/java-lang/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/java-lang/build-x86_64-unknown-none.toml
+++ b/apps/starry/java-lang/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/java-lang/loong-jdk23-musl-port.patch
+++ b/apps/starry/java-lang/loong-jdk23-musl-port.patch
@@ -1,0 +1,72 @@
+diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
+index b441601c5..3f3825759 100644
+--- a/src/hotspot/os/linux/os_linux.cpp
++++ b/src/hotspot/os/linux/os_linux.cpp
+@@ -152,14 +152,17 @@
+ #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
+ 
+ #ifdef MUSL_LIBC
+-// dlvsym is not a part of POSIX
+-// and musl libc doesn't implement it.
+-static void *dlvsym(void *handle,
+-                    const char *symbol,
+-                    const char *version) {
+-   // load the latest version of symbol
++// musl libc does not implement dlvsym(). The previous plain `static dlvsym`
++// fallback clashed with GCC's implicit/builtin extern prototype ("declared
++// extern and later static"). Define the shim under a distinct name and
++// macro-redirect calls, which avoids the clash without -fpermissive.
++static void *dlvsym_musl_compat(void *handle,
++                                const char *symbol,
++                                const char *version) {
++   // musl has no symbol versioning; load the latest (only) version.
+    return dlsym(handle, symbol);
+ }
++#define dlvsym dlvsym_musl_compat
+ #endif
+ 
+ enum CoredumpFilterBit {
+diff --git a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+index 39ce20cd5..d30cf6444 100644
+--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
++++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+@@ -72,7 +72,8 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
++// <fpu_control.h> is a glibc-only header (absent on musl) and is unused here:
++// get_fpu_control_word()/set_fpu_control_word() are empty stubs on loongarch.
+ 
+ #define REG_SP 3
+ #define REG_FP 22
+diff --git a/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c b/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
+index 02d3c57f1..35a9ae255 100644
+--- a/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
++++ b/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
+@@ -24,6 +24,10 @@
+  */
+ 
+ #include <sys/sendfile.h>
++// musl libc has no sendfile64(); its sendfile() is already 64-bit/LFS-transparent.
++#ifndef __GLIBC__
++#define sendfile64 sendfile
++#endif
+ #include <dlfcn.h>
+ 
+ #include "jni.h"
+diff --git a/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c b/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
+index 95f78ffa1..72c2b7d96 100644
+--- a/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
++++ b/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
+@@ -38,6 +38,10 @@
+ #include <fcntl.h>
+ 
+ #include <sys/sendfile.h>
++// musl libc has no sendfile64(); its sendfile() is already 64-bit/LFS-transparent.
++#ifndef __GLIBC__
++#define sendfile64 sendfile
++#endif
+ 
+ #include "sun_nio_fs_LinuxNativeDispatcher.h"
+ 

--- a/apps/starry/java-lang/prebuild.sh
+++ b/apps/starry/java-lang/prebuild.sh
@@ -302,13 +302,14 @@ stage_test_sources() {
     install -m0644 "$PROG/JavaLangCarpet.java" "$d/"
     install -m0644 "$PROG/BackCompat.java"     "$d/"
     install -m0644 "$PROG/java-cli-core.sh"    "$d/"
+    install -m0644 "$PROG/java-toolchain-carpet.sh" "$d/"
     # Stage the on-target gate script (invoked as the ENTIRE shell_init_cmd). Keeping the gate
     # in a staged script — not inline in the toml — avoids the harness false-positive where the
     # echoed shell_init_cmd text containing `echo "TEST PASSED"` self-matches success_regex
     # (FIX1), and carries the per-arch honest SKIP logic for JDKs that can't run on rv/loong
     # (FIX2). One script serves all 4 arches (it detects the arch + JDK set at run time).
     install -Dm0755 "$PROG/run-java.sh" "$overlay_dir/usr/bin/run-java.sh"
-    echo "prebuild: staged $(ls "$d"/*.java | wc -l) .java + java-cli-core.sh into /root/jdkm + run-java.sh gate into /usr/bin"
+    echo "prebuild: staged $(ls "$d"/*.java | wc -l) .java + java-cli-core.sh + java-toolchain-carpet.sh into /root/jdkm + run-java.sh gate into /usr/bin"
 }
 
 # Stage a single .so (and its symlinks) from an apk into the overlay /usr/lib.
@@ -438,7 +439,7 @@ BCREAL_LIBS=(
     "h2-2.1.214.jar                   com/h2database/h2/2.1.214/h2-2.1.214.jar                                                 d623cdc0f61d218cf549a8d09f1c391ff91096116b22e2475475fce4fbe72bd0"
     "hsqldb-2.5.2.jar                 org/hsqldb/hsqldb/2.5.2/hsqldb-2.5.2.jar                                                 e4aa39c5afb318e8effdec80a0e6de7c9dacc453c1cf7666c515f29a16658dac"
     "gson-2.10.1.jar                  com/google/code/gson/gson/2.10.1/gson-2.10.1.jar                                        4241c14a7727c34feea6507ec801318a3d4a90f070e4525681079fb94ee4c593"
-    "bsh-2.0b6.jar                    org/beanshell/bsh/2.0b6/bsh-2.0b6.jar                                                    a17955976070c0573235ee662f2794a78082758b61accffce8d3f8aedcd91047"
+    "bsh-2.0b6.jar                    org/apache-extras/beanshell/bsh/2.0b6/bsh-2.0b6.jar                                     a17955976070c0573235ee662f2794a78082758b61accffce8d3f8aedcd91047"
     "junit-4.13.2.jar                 junit/junit/4.13.2/junit-4.13.2.jar                                                     8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3"
     "hamcrest-core-1.3.jar            org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar                                     66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9"
 )

--- a/apps/starry/java-lang/prebuild.sh
+++ b/apps/starry/java-lang/prebuild.sh
@@ -1,0 +1,675 @@
+#!/usr/bin/env bash
+# prebuild.sh — provision the multi-JDK Java LANGUAGE carpet for StarryOS.
+#
+# This is the LANGUAGE case for #764 `jdk17+ (openjdk 17 21 23 25 update-alternatives):
+# javac · java`. Unlike the kotlin-lang case (which only RUNS a jar and can use a ~60MB
+# JRE), the java-lang case must COMPILE on-target (`javac`), so it stages the FULL JDK
+# (bin/javac + lib + jmods) for EVERY version. The per-arch JDK cells, staging paths,
+# the per-JDK musl-loader-path discipline, and the rootfs sizing are byte-for-byte the
+# PROVEN, 4-arch-green `openjdk-multi` recipe (download/jdk-multi/prep-jdk-multi-rootfs.sh,
+# delivered hw4os-s5d1t2/java/jdk-multi).
+#
+# ── ROOTFS SIZE (the crucial lesson, notes/kotlin-lang) ──────────────────────────────
+#   The apps/starry harness copies the 1 GiB base alpine rootfs to a per-app image, runs
+#   THIS prebuild (handing us $STARRY_ROOTFS = that image), then injects $STARRY_OVERLAY_DIR
+#   into the image via debugfs WITHOUT resizing it. Four FULL JDKs (~1.5 GiB on-disk) do not
+#   fit in 1 GiB -> debugfs silently truncates large files (libjvm.so) -> dlopen ENOEXEC
+#   ("Exec format error"). The kotlin case worked around this by dropping to a 156 MB JRE;
+#   that is NOT an option here because javac needs the full JDK.
+#   FIX: grow $STARRY_ROOTFS to 6 GiB (truncate + e2fsck + resize2fs) BEFORE the harness
+#   injects — exactly as prep-jdk-multi-rootfs.sh grows its image to 6 GiB. Disk on the host
+#   is cheap; the running QEMU only ever maps a -Xmx512m JVM, so the larger image is free.
+#   We resize the image in place; the qemu-<arch>.toml points the drive at this same
+#   per-app image (rootfs-<arch>-java-lang.img), so the grown image is what boots.
+#
+# ── PER-ARCH JDK SET (matches what openjdk-multi PROVED green) ────────────────────────
+#                JDK17                 JDK21               JDK23                 JDK25
+#   x86_64       apk (openjdk17)       BellSoft musl tar   BellSoft musl tar     BellSoft musl tar   (4 JDKs)
+#   aarch64      apk (openjdk17)       BellSoft musl tar   BellSoft musl tar     BellSoft musl tar   (4 JDKs)
+#   riscv64      native-musl cross tar Alpine-musl apk     BellSoft GLIBC+gcompat Alpine-musl apk     (4 attempted)
+#   loongarch64  apk (openjdk17-loong) Alpine-musl apk     Loongson GLIBC+gcompat Alpine-musl apk     (4 attempted)
+#   JDK23 ships only as glibc on riscv64 (BellSoft generic-glibc) and loongarch64 (Loongson),
+#   so — exactly like prep-jdk-multi-rootfs.sh — we stage the gcompat shim (+ its libucontext /
+#   musl-obstack deps) so the Alpine-musl loader can satisfy the glibc JDK's libc.so.6 / ld-linux
+#   references, then ATTEMPT JDK23 on all 4 arches. The decision is made at run time by
+#   run-java.sh's timeout-guarded liveness probe: a glibc JDK that still segfaults/hangs under
+#   gcompat is a DOCUMENTED SKIP (partial-arch-deliver rule), never a fake pass or a failure.
+#   All musl cells (x86/aa fully, plus 17+21+25 on rv/loong) are the clean native path; javac
+#   WORKS on every staged musl cell.
+#
+# Guest layout (== openjdk-multi): /opt/jdk{17,21,23,25} (update-alternatives candidate
+# roots), /opt/jdk-current symlink, /root/.sdkman/candidates/java/* candidate symlinks,
+# /root/jdkm/*.java test sources. The per-JDK musl loader path is set by the qemu toml at
+# run time (NOT here), one JDK at a time, to avoid the cross-JDK launcher mis-resolution.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_OVERLAY_DIR, STARRY_APP_DIR, STARRY_ROOTFS,
+# STARRY_STAGING_ROOT.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+rootfs_img="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+
+# ── Asset cache root (PORTABLE) ───────────────────────────────────────────────────────
+# Holds the PROVEN JDK distributions (same tree layout openjdk-multi prep uses). On a
+# maintainer's clean machine this dir does not pre-exist; each asset is then fetched from
+# its OFFICIAL URL into here (see ensure_asset + the ensure_* wrappers below) and re-used on
+# subsequent runs. A developer who already has the assets locally points JAVA_DL_ROOT at
+# their cache (e.g. JAVA_DL_ROOT=/path/to/download) and every fetch short-circuits to disk.
+# Default is repo/staging-relative so a fresh checkout has a writable place to populate.
+DL="${JAVA_DL_ROOT:-${STARRY_STAGING_ROOT:-$app_dir}/.cache/java-dl}"
+JM="$DL/jdk-multi"
+ALP="$JM/jdk21-musl-alpine"
+PROG="$app_dir/programs"
+
+# Alpine apk CDN (override to a mirror, e.g. https://mirrors.ustc.edu.cn/alpine, if dl-cdn
+# is slow/unreachable). edge/community + edge/main hold the riscv64/loongarch64 + libffi
+# packages; openjdk17 x86_64/aarch64 live in v3.22/community (rolling — see ensure_openjdk17).
+ALPINE_CDN="${ALPINE_CDN:-https://dl-cdn.alpinelinux.org/alpine}"
+# BellSoft Liberica release CDN (immutable per-version tarballs; '+' is a literal path char).
+BELLSOFT_CDN="${BELLSOFT_CDN:-https://download.bell-sw.com/java}"
+
+# ── Portable fetch-ensure layer ───────────────────────────────────────────────────────
+# ensure_asset <abs-local-path> <official-url> [sha256]
+#   If the local file exists (and its sha256 matches when one is given) it is used as-is —
+#   so a populated cache (JAVA_DL_ROOT) is hit instantly with zero network. Otherwise the
+#   parent dir is created, the URL is curl'd to a temp file, the sha256 is verified when
+#   given, and the file is atomically moved into place. A sha mismatch is a hard error.
+#   An empty/omitted sha skips verification (used for Alpine apks that float on the rolling
+#   edge CDN, where the cached copy is the pinned golden and the URL is a best-effort refill).
+ensure_asset() {
+    local dest="$1" url="$2" want="${3:-}"
+    if [[ -f "$dest" ]]; then
+        if [[ -n "$want" ]] && command -v sha256sum >/dev/null 2>&1; then
+            local have; have="$(sha256sum "$dest" | cut -d' ' -f1)"
+            if [[ "$have" == "$want" ]]; then
+                echo "prebuild: cache hit $dest (sha256 ok)"; return 0
+            fi
+            echo "prebuild: cache file $dest sha256 mismatch (have $have want $want) — refetching" >&2
+            rm -f "$dest"
+        else
+            echo "prebuild: cache hit $dest"; return 0
+        fi
+    fi
+    command -v curl >/dev/null 2>&1 || { echo "prebuild: need curl to fetch $url (no cached $dest)" >&2; exit 4; }
+    [[ -n "$url" ]] || { echo "prebuild: no cached $dest and no URL to fetch it from" >&2; exit 4; }
+    echo "prebuild: fetching $(basename "$dest") <- $url"
+    mkdir -p "$(dirname "$dest")"
+    curl -fSL --retry 3 --connect-timeout 20 "$url" -o "$dest.tmp"
+    if [[ -n "$want" ]] && command -v sha256sum >/dev/null 2>&1; then
+        local got; got="$(sha256sum "$dest.tmp" | cut -d' ' -f1)"
+        [[ "$got" == "$want" ]] || { echo "prebuild: sha256 mismatch for $url (got $got want $want)" >&2; rm -f "$dest.tmp"; exit 4; }
+    fi
+    mv -f "$dest.tmp" "$dest"
+}
+
+# ensure_alpine_apk <cache-abs-path> <branch/repo> <arch> <filename> [sha256]
+#   Thin ensure_asset wrapper building the canonical Alpine pool URL
+#   $ALPINE_CDN/<branch>/<repo>/<arch>/<filename>. The cache path keeps the prep tree's
+#   layout (which may prefix the file with the arch, e.g. riscv64-openjdk21-jdk-...apk) while
+#   the URL uses the real Alpine basename.
+ensure_alpine_apk() {
+    local dest="$1" path="$2" cdnarch="$3" fname="$4" sha="${5:-}"
+    ensure_asset "$dest" "$ALPINE_CDN/$path/$cdnarch/$fname" "$sha"
+}
+
+# Target rootfs size — large enough for 4 full JDKs (~1.5 GiB on-disk) + headroom; mirrors
+# prep-jdk-multi-rootfs.sh (which uses 6 GiB and is 4-arch-green).
+ROOTFS_SIZE="${JAVA_ROOTFS_SIZE:-6G}"
+
+ensure_host_tools() {
+    local missing=()
+    command -v tar       >/dev/null 2>&1 || missing+=(tar)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v e2fsck    >/dev/null 2>&1 || missing+=(e2fsprogs)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        if command -v apt-get >/dev/null 2>&1; then
+            echo "prebuild: installing host tools: ${missing[*]}"
+            apt-get update && apt-get install -y --no-install-recommends "${missing[@]}"
+        else
+            echo "prebuild: missing host tools and no apt-get: ${missing[*]}" >&2
+            exit 1
+        fi
+    fi
+}
+
+# Grow the per-app rootfs image so the injected JDKs fit without truncation. Idempotent:
+# truncate only grows, e2fsck/resize2fs are safe to re-run. The harness has already copied
+# the 1 GiB base into $rootfs_img by the time prebuild runs.
+grow_rootfs() {
+    [[ -f "$rootfs_img" ]] || { echo "prebuild: rootfs image missing: $rootfs_img" >&2; exit 2; }
+    local before after
+    before=$(stat -c %s "$rootfs_img")
+    echo "prebuild: rootfs $rootfs_img is $((before/1024/1024)) MiB; growing to $ROOTFS_SIZE"
+    truncate -s "$ROOTFS_SIZE" "$rootfs_img"
+    e2fsck -f -y "$rootfs_img" >/dev/null 2>&1 || true
+    resize2fs "$rootfs_img" >/dev/null 2>&1
+    after=$(stat -c %s "$rootfs_img")
+    echo "prebuild: rootfs grown to $((after/1024/1024)) MiB (fs resized)"
+}
+
+# untar a .tar.gz, stripping the single top-level dir, into <dest>  (jdk-multi untar_into ... 1)
+untar_strip1() {
+    local arc="$1" dest="$2"
+    [[ -f "$arc" ]] || { echo "prebuild: missing archive $arc" >&2; exit 2; }
+    mkdir -p "$dest"
+    tar xzf "$arc" -C "$dest" --strip-components=1
+}
+
+# extract an Alpine apk (gzip tar) into <dest>, dropping apk metadata  (jdk-multi apk_into)
+apk_into() {
+    local apk="$1" dest="$2"
+    [[ -f "$apk" ]] || { echo "prebuild: missing apk $apk" >&2; exit 2; }
+    mkdir -p "$dest"
+    tar xzf "$apk" -C "$dest" \
+        --exclude='.PKGINFO' --exclude='.SIGN.*' --exclude='.pre-install' \
+        --exclude='.post-install' --exclude='.pre-upgrade' --exclude='.post-upgrade' \
+        --exclude='.trigger' 2>/dev/null || true
+}
+
+# Stage JDK17 into $overlay_dir/opt/jdk17 (full JDK with javac), per-arch source.
+stage_jdk17() {
+    local jdst="$overlay_dir/opt/jdk17"
+    rm -rf "$jdst"; mkdir -p "$jdst"
+    case "$arch" in
+        x86_64|aarch64)
+            local T; T="$(mktemp -d)"
+            local a apk
+            for a in openjdk17-jdk openjdk17-jmods openjdk17-jre-headless openjdk17-jre; do
+                apk="$(ls "$DL/openjdk17-apks/$arch/${a}-"*.apk 2>/dev/null | head -1)"
+                [[ -n "$apk" ]] && tar xzf "$apk" -C "$T" 2>/dev/null || true
+            done
+            cp -a "$T/usr/lib/jvm/java-17-openjdk/." "$jdst/"
+            rm -rf "$T" ;;
+        loongarch64)
+            local T; T="$(mktemp -d)"
+            local a apk
+            for a in openjdk17-loongarch-jdk openjdk17-loongarch-jmods openjdk17-loongarch-jre-headless openjdk17-loongarch-jre; do
+                apk="$(ls "$DL/openjdk17-apks/$arch/${a}-"*.apk 2>/dev/null | head -1)"
+                [[ -n "$apk" ]] && tar xzf "$apk" -C "$T" 2>/dev/null || true
+            done
+            cp -a "$T"/usr/lib/jvm/*/. "$jdst/"
+            rm -rf "$T" ;;
+        riscv64)
+            untar_strip1 "$DL/openjdk17-apks/riscv64/openjdk17-riscv64-musl-NATIVE-cross.tar.gz" "$jdst" ;;
+    esac
+    [[ -x "$jdst/bin/java" && -x "$jdst/bin/javac" ]] \
+        || { echo "prebuild: jdk17 staged without java+javac for $arch" >&2; exit 3; }
+    echo "prebuild: jdk17 staged ($(du -sh "$jdst" | cut -f1), javac present)"
+}
+
+# Stage JDK21 (full JDK with javac).
+stage_jdk21() {
+    local jdst="$overlay_dir/opt/jdk21"
+    rm -rf "$jdst"; mkdir -p "$jdst"
+    case "$arch" in
+        x86_64)  untar_strip1 "$JM/jdk21/bellsoft-jdk21.0.11+11-linux-x64-musl.tar.gz"     "$jdst" ;;
+        aarch64) untar_strip1 "$JM/jdk21/bellsoft-jdk21.0.11+11-linux-aarch64-musl.tar.gz" "$jdst" ;;
+        riscv64)
+            local T; T="$(mktemp -d)"; local a apk
+            for a in openjdk21-jre-headless openjdk21-jdk openjdk21-jmods; do
+                apk="$(ls "$ALP/riscv64-${a}-"*.apk 2>/dev/null | head -1)"
+                [[ -n "$apk" ]] && apk_into "$apk" "$T"
+            done
+            cp -a "$T/usr/lib/jvm/java-21-openjdk/." "$jdst/"; rm -rf "$T" ;;
+        loongarch64)
+            local T; T="$(mktemp -d)"; local a apk
+            for a in openjdk21-jre-headless openjdk21-jdk openjdk21-jmods; do
+                apk="$(ls "$ALP/loongarch64-${a}-"*.apk 2>/dev/null | head -1)"
+                [[ -n "$apk" ]] && apk_into "$apk" "$T"
+            done
+            cp -a "$T/usr/lib/jvm/java-21-openjdk/." "$jdst/"; rm -rf "$T" ;;
+    esac
+    [[ -x "$jdst/bin/java" && -x "$jdst/bin/javac" ]] \
+        || { echo "prebuild: jdk21 staged without java+javac for $arch" >&2; exit 3; }
+    echo "prebuild: jdk21 staged ($(du -sh "$jdst" | cut -f1), javac present)"
+}
+
+# Stage JDK23 (full JDK with javac), all 4 arches — exactly the prep-jdk-multi-rootfs.sh
+# per-arch JDK23 cells. x86_64/aarch64 = BellSoft native-musl. riscv64 = BellSoft generic
+# GLIBC build; loongarch64 = Loongson GLIBC build (the only JDK23 that exists for those two
+# arches — no upstream Alpine-musl JDK23 for rv/loong). The glibc rv/loong cells are bridged
+# by the staged gcompat shim (see stage_gcompat); they are staged and TRIED, then run-java.sh's
+# timeout-guarded liveness probe includes them only if they actually run under gcompat, else
+# documents a SKIP (never a fake pass).
+stage_jdk23() {
+    case "$arch" in
+        x86_64|aarch64|riscv64|loongarch64) : ;;
+        *) echo "prebuild: jdk23 unsupported arch $arch — skipping"; return 0 ;;
+    esac
+    local jdst="$overlay_dir/opt/jdk23"
+    rm -rf "$jdst"; mkdir -p "$jdst"
+    case "$arch" in
+        x86_64)  untar_strip1 "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-x64-musl.tar.gz"     "$jdst" ;;
+        aarch64) untar_strip1 "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-aarch64-musl.tar.gz" "$jdst" ;;
+        riscv64) untar_strip1 "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-riscv64.tar.gz"      "$jdst" ;;  # glibc -> gcompat
+        loongarch64) untar_strip1 "$JM/jdk23/loongson23.1.17-fx-jdk23_37-linux-loongarch64.tar.gz" "$jdst" ;;  # glibc -> gcompat
+    esac
+    [[ -x "$jdst/bin/java" && -x "$jdst/bin/javac" ]] \
+        || { echo "prebuild: jdk23 staged without java+javac for $arch" >&2; exit 3; }
+    echo "prebuild: jdk23 staged ($(du -sh "$jdst" | cut -f1), javac present)"
+}
+
+# Stage JDK25 (full JDK with javac).
+stage_jdk25() {
+    local jdst="$overlay_dir/opt/jdk25"
+    rm -rf "$jdst"; mkdir -p "$jdst"
+    case "$arch" in
+        x86_64)  untar_strip1 "$JM/jdk25/bellsoft-jdk25+37-linux-x64-musl.tar.gz"     "$jdst" ;;
+        aarch64) untar_strip1 "$JM/jdk25/bellsoft-jdk25+37-linux-aarch64-musl.tar.gz" "$jdst" ;;
+        riscv64)
+            local T; T="$(mktemp -d)"; local a apk
+            for a in openjdk25-jre-headless openjdk25-jdk openjdk25-jmods; do
+                apk="$(ls "$ALP/riscv64-${a}-"*.apk 2>/dev/null | head -1)"
+                [[ -n "$apk" ]] && apk_into "$apk" "$T"
+            done
+            cp -a "$T/usr/lib/jvm/java-25-openjdk/." "$jdst/"; rm -rf "$T" ;;
+        loongarch64)
+            local T; T="$(mktemp -d)"; local a apk
+            for a in openjdk25-loongarch-jre-headless openjdk25-loongarch-jre openjdk25-loongarch-jdk openjdk25-loongarch-jmods; do
+                apk="$(ls "$JM/jdk25/loongarch64-alpine-musl/${a}-"*.apk 2>/dev/null | head -1)"
+                [[ -n "$apk" ]] && apk_into "$apk" "$T"
+            done
+            cp -a "$T/usr/lib/jvm/java-25-openjdk/." "$jdst/"; rm -rf "$T" ;;
+    esac
+    if [[ -x "$jdst/bin/java" && -x "$jdst/bin/javac" ]]; then
+        echo "prebuild: jdk25 staged ($(du -sh "$jdst" | cut -f1), javac present)"
+    elif [[ "$arch" == riscv64 ]]; then
+        # jdk25 on riscv64 is the Alpine Zero-VM build, which always SKIPs at the run-time
+        # liveness probe (IllegalInstruction on the RV64GC baseline). Staging it is therefore
+        # best-effort: a transient apk-extraction miss must not abort the whole suite, which
+        # carries the real 17/21/23 cells. Drop the partial dir; the probe records the SKIP.
+        echo "prebuild: WARNING jdk25 not fully staged for riscv64 (Zero-VM cell — SKIPs at probe regardless)" >&2
+        rm -rf "$jdst"
+    else
+        echo "prebuild: jdk25 staged without java+javac for $arch" >&2; exit 3
+    fi
+}
+
+stage_test_sources() {
+    # Version feature tests (Jdk{17,21,23,25}Features.java), the LANGUAGE carpet
+    # (JavaLangCarpet.java) + its golden, the full-JLS grammar carpet (JavaGrammar.java),
+    # the cross-version backward-compat test (BackCompat.java), and the kernel-relevant
+    # javac/java CLI carpet (java-cli-core.sh) all under /root/jdkm.
+    local d="$overlay_dir/root/jdkm"
+    mkdir -p "$d"
+    install -m0644 "$PROG/Jdk17Features.java"  "$d/"
+    install -m0644 "$PROG/Jdk21Features.java"  "$d/"
+    install -m0644 "$PROG/Jdk23Features.java"  "$d/"
+    install -m0644 "$PROG/Jdk25Features.java"  "$d/"
+    install -m0644 "$PROG/JavaGrammar.java"    "$d/"
+    install -m0644 "$PROG/JavaLangCarpet.java" "$d/"
+    install -m0644 "$PROG/BackCompat.java"     "$d/"
+    install -m0644 "$PROG/java-cli-core.sh"    "$d/"
+    # Stage the on-target gate script (invoked as the ENTIRE shell_init_cmd). Keeping the gate
+    # in a staged script — not inline in the toml — avoids the harness false-positive where the
+    # echoed shell_init_cmd text containing `echo "TEST PASSED"` self-matches success_regex
+    # (FIX1), and carries the per-arch honest SKIP logic for JDKs that can't run on rv/loong
+    # (FIX2). One script serves all 4 arches (it detects the arch + JDK set at run time).
+    install -Dm0755 "$PROG/run-java.sh" "$overlay_dir/usr/bin/run-java.sh"
+    echo "prebuild: staged $(ls "$d"/*.java | wc -l) .java + java-cli-core.sh into /root/jdkm + run-java.sh gate into /usr/bin"
+}
+
+# Stage a single .so (and its symlinks) from an apk into the overlay /usr/lib.
+# $1 = apk path, $2 = base name glob (e.g. 'libffi.so')  (kotlin-lang stage_overlay_lib)
+stage_overlay_lib() {
+    local apk="$1" glob="$2"
+    [[ -f "$apk" ]] || { echo "prebuild: WARNING missing apk $apk (relying on base rootfs)" >&2; return 0; }
+    local T; T="$(mktemp -d)"
+    apk_into "$apk" "$T"
+    install -d "$overlay_dir/usr/lib"
+    local f any=0
+    for f in "$T"/usr/lib/${glob}* "$T"/lib/${glob}*; do
+        [[ -e "$f" ]] || continue
+        any=1
+        if [[ -L "$f" ]]; then cp -P "$f" "$overlay_dir/usr/lib/$(basename "$f")"
+        else install -Dm0644 "$f" "$overlay_dir/usr/lib/$(basename "$f")"; fi
+    done
+    rm -rf "$T"
+    [[ "$any" = 1 ]] || echo "prebuild: WARNING no ${glob} matched in $apk" >&2
+}
+
+stage_deps() {
+    # loongarch64 JDK21 ships the Zero VM (lib/zero/libjvm.so) which is DT_NEEDED
+    # [libffi.so.8]; that lib is absent from the base loong rootfs. Stage it from the apk
+    # bundled with the alpine-musl JDK set (== kotlin-lang loong cell). libz.so.1 (libjli's
+    # zlib dep) is already in every base alpine rootfs (/usr/lib/libz.so.1), so it is NOT
+    # staged here; jdk25 server VM + the rv server VMs need only libc.
+    if [[ "$arch" == "loongarch64" ]]; then
+        local fapk; fapk="$(ls "$ALP/loongarch64-libffi-"*.apk 2>/dev/null | head -1)"
+        stage_overlay_lib "$fapk" "libffi.so"
+        [[ -e "$overlay_dir/usr/lib/libffi.so.8" ]] \
+            && echo "prebuild: staged libffi.so.8 (loong JDK21 Zero VM dep) into /usr/lib" \
+            || echo "prebuild: WARNING libffi.so.8 not staged for loong; JDK21 Zero VM may fail" >&2
+    fi
+}
+
+# Stage the gcompat glibc-on-musl shim (+ its libucontext / musl-obstack runtime deps) into
+# the overlay for riscv64 / loongarch64, so the Alpine-musl loader can satisfy the JDK23 glibc
+# build's libc.so.6 / ld-linux-<arch>.so.1 references. This MIRRORS prep-jdk-multi-rootfs.sh's
+# gcompat staging (its `apk_into "$GC" ""` drops gcompat's lib/ -> ld-linux + libc.so.6 etc.
+# at the rootfs root). gcompat's apk DT_NEEDED closure is `so:libucontext.so.1` +
+# `so:libobstack.so.1` (musl-obstack), which are NOT in the base Alpine rootfs, so we extract
+# those two apks too — otherwise libgcompat.so.0 itself would fail to load and the JDK23 cell
+# would SKIP for the wrong reason. The probe (run-java.sh) still decides per cell: if JDK23
+# segfaults/hangs even WITH a fully-resolvable gcompat, that is a documented SKIP, not a fake
+# pass. (musl JDKs 17/21/25 do not touch gcompat.) No-op on x86_64/aarch64 (all-musl cells).
+# Bridge the glibc JDK23 build's libc.so.6 / ld-linux-<arch>.so.1 references.
+#   riscv64: stage the REAL Debian glibc runtime. The BellSoft generic-glibc JDK23 runs
+#     cleanly under real glibc (verified rc=0 on qemu-user AND on StarryOS, printing the
+#     carpet output with `-Xint -Xmx512m`). The musl gcompat shim is INSUFFICIENT for the
+#     JVM, so real glibc is required: extract libc6 (ld-linux + libc/libm/libpthread/librt/
+#     libdl) into the default multiarch search path; the JDK launcher's own interp
+#     (/lib/ld-linux-riscv64-lp64d.so.1) then loads it. The musl JDKs (17/21/25) keep using
+#     the musl loader and are unaffected.
+#   loongarch64: the only JDK23 is the old Loongson abi1.0 build (needs GLIBC_2.27, the
+#     legacy Loongson "world"); no compatible runtime exists for the upstreamed abi
+#     (glibc 2.36+), so it stays on the gcompat path and run-java.sh records a documented SKIP.
+stage_real_glibc_rv() {
+    # Fetch (or cache-hit) the official Debian trixie riscv64 libc6 — the real glibc
+    # runtime closure the BellSoft generic-glibc JDK23 needs. ensure_asset verifies the
+    # pinned sha256; a populated JAVA_DL_ROOT cache is used with zero network.
+    local deb="$DL/glibc-debian/riscv64/libc6_2.41-12+deb13u3_riscv64.deb"
+    ensure_asset "$deb" \
+        "http://deb.debian.org/debian/pool/main/g/glibc/libc6_2.41-12+deb13u3_riscv64.deb" \
+        fee42ebb2a148cc0dbc46ba938d8d69495b6dd5250cecafed9d585c567550b7a \
+        || { echo "prebuild: WARNING libc6 deb unavailable for riscv64; JDK23 cell will SKIP" >&2; return 0; }
+    local t; t="$(mktemp -d)"
+    ( cd "$t" && ar x "$deb" && tar xf data.tar.* )
+    mkdir -p "$overlay_dir/lib/riscv64-linux-gnu" "$overlay_dir/usr/lib/riscv64-linux-gnu"
+    cp -a "$t"/usr/lib/riscv64-linux-gnu/. "$overlay_dir/usr/lib/riscv64-linux-gnu/" 2>/dev/null || true
+    cp -a "$t"/lib/riscv64-linux-gnu/.     "$overlay_dir/lib/riscv64-linux-gnu/"     2>/dev/null || true
+    local ldso; ldso="$(find "$t" -name 'ld-linux-riscv64-lp64d.so.1' -type f 2>/dev/null | head -1)"
+    [[ -n "$ldso" ]] && install -Dm0755 "$ldso" "$overlay_dir/lib/ld-linux-riscv64-lp64d.so.1"
+    rm -rf "$t"
+    echo "prebuild: staged REAL Debian glibc runtime for riscv64 (JDK23 glibc cell)"
+}
+stage_gcompat() {
+    case "$arch" in
+        riscv64) stage_real_glibc_rv; return 0 ;;
+        loongarch64) : ;;
+        *) return 0 ;;
+    esac
+    local d="$DL/openjdk17-apks/$arch" apk
+    # gcompat: provides /lib/ld-linux-<arch>.so.1, /lib/libc.so.6, /lib/libm.so.6, etc. into root.
+    apk="$(ls "$d/gcompat-"*.apk 2>/dev/null | head -1)"
+    [[ -n "$apk" ]] && { apk_into "$apk" "$overlay_dir"; echo "prebuild: staged gcompat shim (glibc JDK23 on $arch)"; } \
+        || echo "prebuild: WARNING no gcompat apk for $arch; JDK23 glibc cell will SKIP" >&2
+    # libucontext.so.1 + libucontext_posix.so.1 (gcompat DT_NEEDED) -> /usr/lib.
+    apk="$(ls "$d/libucontext-"*.apk 2>/dev/null | head -1)"
+    [[ -n "$apk" ]] && { apk_into "$apk" "$overlay_dir"; echo "prebuild: staged libucontext (gcompat dep)"; } \
+        || echo "prebuild: WARNING no libucontext apk for $arch (gcompat may not load)" >&2
+    # libobstack.so.1 (musl-obstack; gcompat DT_NEEDED) -> /usr/lib.
+    apk="$(ls "$d/musl-obstack-"*.apk 2>/dev/null | head -1)"
+    [[ -n "$apk" ]] && { apk_into "$apk" "$overlay_dir"; echo "prebuild: staged musl-obstack (gcompat dep)"; } \
+        || echo "prebuild: WARNING no musl-obstack apk for $arch (gcompat may not load)" >&2
+}
+
+stage_alternatives_and_sdkman() {
+    # update-alternatives candidate "current" symlink (the qemu toml retargets it per switch).
+    mkdir -p "$overlay_dir/opt"
+    ln -sfn /opt/jdk17 "$overlay_dir/opt/jdk-current"
+    # sdkman-style candidate layout pointing at the staged JDKs (offline `sdk use` switch).
+    local cand="$overlay_dir/root/.sdkman/candidates/java"
+    mkdir -p "$cand"
+    local V
+    for V in 17 21 23 25; do
+        [[ -d "$overlay_dir/opt/jdk$V" ]] && ln -sfn "/opt/jdk$V" "$cand/$V-open"
+    done
+    ln -sfn /opt/jdk17 "$cand/current"
+}
+
+# ── BackCompatReal (real-world Java-8 forward-compat suite) ────────────────────────────
+# The 12 third-party dependency jars: "<filename> <maven-path-under-repo1> <sha256>".
+# <maven-path> is appended to https://repo1.maven.org/maven2/ to form the official URL.
+# These are arch-independent (pure JVM bytecode), so the SAME set is staged for every arch.
+# The cache lives at $DL/java-backcompat-libs/ (reused across arches/runs). On a clean
+# machine each jar is fetched from Maven Central by sha256; a developer who already has
+# them can populate the cache (or point BCREAL_LOCAL at a prebuilt libs/
+# fallback below). sha256 are the host-verified, 299-test-green delivered copies.
+BCREAL_LIBS=(
+    "commons-io-2.11.0.jar            commons-io/commons-io/2.11.0/commons-io-2.11.0.jar                                       961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908"
+    "commons-math3-3.6.1.jar          org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar                          1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308"
+    "commons-lang3-3.12.0.jar         org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar                        d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e"
+    "commons-collections4-4.4.jar     org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar                1df8b9430b5c8ed143d7815e403e33ef5371b2400aadbe9bda0883762e0846d1"
+    "log4j-api-2.17.1.jar             org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar                          b0d8a4c8ab4fb8b1888d0095822703b0e6d4793c419550203da9e69196161de4"
+    "log4j-core-2.17.1.jar            org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar                        c967f223487980b9364e94a7c7f9a8a01fd3ee7c19bdbf0b0f9f8cb8511f3d41"
+    "h2-2.1.214.jar                   com/h2database/h2/2.1.214/h2-2.1.214.jar                                                 d623cdc0f61d218cf549a8d09f1c391ff91096116b22e2475475fce4fbe72bd0"
+    "hsqldb-2.5.2.jar                 org/hsqldb/hsqldb/2.5.2/hsqldb-2.5.2.jar                                                 e4aa39c5afb318e8effdec80a0e6de7c9dacc453c1cf7666c515f29a16658dac"
+    "gson-2.10.1.jar                  com/google/code/gson/gson/2.10.1/gson-2.10.1.jar                                        4241c14a7727c34feea6507ec801318a3d4a90f070e4525681079fb94ee4c593"
+    "bsh-2.0b6.jar                    org/beanshell/bsh/2.0b6/bsh-2.0b6.jar                                                    a17955976070c0573235ee662f2794a78082758b61accffce8d3f8aedcd91047"
+    "junit-4.13.2.jar                 junit/junit/4.13.2/junit-4.13.2.jar                                                     8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3"
+    "hamcrest-core-1.3.jar            org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar                                     66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9"
+)
+MAVEN_CENTRAL="${MAVEN_CENTRAL:-https://repo1.maven.org/maven2}"
+# Local prebuilt fallback root (the host-built, 299-test-green artifacts).
+BCREAL_LOCAL="${BCREAL_LOCAL:-}"   # optional prebuilt fast-path; empty => fetch jars from Maven Central + compile the jar on host
+BCREAL_SRC="$app_dir/programs/backcompat/src"
+
+# Stage the BackCompatReal suite: (a) ensure the 12 dependency jars (Maven Central by sha256,
+# cached under $DL/java-backcompat-libs/, with a copy-from-local fallback), (b) ensure the
+# Java-8 (--release 8 = bytecode 52) backcompat-real.jar — prefer COMPILING it on the host in
+# this prebuild from the staged src/ for reproducibility; fall back to copying the prebuilt jar
+# — and (c) stage libs + jar into the overlay at /root/bcreal/{libs,backcompat-real.jar}.
+stage_backcompat() {
+    local libcache="$DL/java-backcompat-libs"
+    local ovl="$overlay_dir/root/bcreal"
+    local ovllibs="$ovl/libs"
+    mkdir -p "$libcache" "$ovllibs"
+
+    # (a) ensure + stage the 12 dependency jars.
+    local entry fname path sha cached
+    for entry in "${BCREAL_LIBS[@]}"; do
+        # shellcheck disable=SC2086  # word-split the 3 whitespace-separated fields on purpose
+        set -- $entry
+        fname="$1"; path="$2"; sha="$3"
+        cached="$libcache/$fname"
+        if [[ ! -f "$cached" && -f "$BCREAL_LOCAL/libs/$fname" ]]; then
+            # local prebuilt available -> seed the cache so ensure_asset's sha check confirms it.
+            cp -f "$BCREAL_LOCAL/libs/$fname" "$cached"
+        fi
+        ensure_asset "$cached" "$MAVEN_CENTRAL/$path" "$sha"
+        install -m0644 "$cached" "$ovllibs/$fname"
+    done
+
+    # (b) ensure backcompat-real.jar: prefer reproducible host compile (--release 8), else copy.
+    local jar="$libcache/backcompat-real.jar"
+    if command -v javac >/dev/null 2>&1; then
+        echo "prebuild: host javac present — compiling backcompat-real.jar (--release 8, bytecode 52)"
+        local B; B="$(mktemp -d)"
+        local cp_arg="$libcache/*"
+        # compile all staged src/*.java with the cached dependency jars on the classpath.
+        if javac --release 8 -cp "$cp_arg" -d "$B/classes" "$BCREAL_SRC"/*.java 2>"$B/javac.log"; then
+            ( cd "$B/classes" && jar cf "$B/backcompat-real.jar" . )
+            mv -f "$B/backcompat-real.jar" "$jar"
+            echo "prebuild: compiled backcompat-real.jar in-prebuild ($(du -h "$jar" | cut -f1))"
+        else
+            echo "prebuild: WARNING host javac compile failed — falling back to prebuilt jar" >&2
+            cat "$B/javac.log" >&2 || true
+            [[ -f "$BCREAL_LOCAL/backcompat-real.jar" ]] \
+                && cp -f "$BCREAL_LOCAL/backcompat-real.jar" "$jar" \
+                || { echo "prebuild: no host javac success AND no prebuilt backcompat-real.jar" >&2; rm -rf "$B"; exit 5; }
+        fi
+        rm -rf "$B"
+    else
+        echo "prebuild: no host javac — copying prebuilt backcompat-real.jar"
+        [[ -f "$BCREAL_LOCAL/backcompat-real.jar" ]] \
+            && cp -f "$BCREAL_LOCAL/backcompat-real.jar" "$jar" \
+            || { echo "prebuild: no host javac AND no prebuilt backcompat-real.jar at $BCREAL_LOCAL" >&2; exit 5; }
+    fi
+
+    # (c) stage the jar into the overlay.
+    install -m0644 "$jar" "$ovl/backcompat-real.jar"
+    echo "prebuild: staged BackCompatReal ($(ls "$ovllibs" | wc -l) libs + backcompat-real.jar) into /root/bcreal"
+}
+
+# ── ensure every asset the stage_* functions consume for THIS arch is present ──────────
+# Maps each staged file -> its OFFICIAL download URL + recorded sha256. Runs BEFORE the
+# stage_jdkNN functions so staging logic is UNCHANGED — assets are merely guaranteed on disk
+# (from cache when JAVA_DL_ROOT is populated, else fetched). Provenance for every URL/sha:
+# download/jdk-multi/SOURCES.md + download/openjdk17-apks/SOURCES.md (sha256 computed from the
+# delivered, 4-arch-green copies where SOURCES.md did not already record it).
+#
+# Rolling-CDN caveat: Alpine edge/community (riscv64 + loongarch64 openjdk21/25, libffi) and
+# v3.22/community (openjdk17 x86_64/aarch64) bump patch levels over time. The pinned filenames
+# below are the delivered golden; if Alpine has rolled past them on a clean machine, the
+# cached copy is authoritative — populate JAVA_DL_ROOT. The openjdk17 x86_64/aarch64 fetch
+# targets the CURRENT rolling version (17.0.19_p10-r0; 17.0.18_p8-r0 has aged off the live
+# CDN) so a clean machine still resolves a real file; the stage_jdk17 prefix-glob
+# (openjdk17-jdk-*.apk) matches either patch level. apk sha is left unpinned for these rolling
+# entries (cache copy is the verified golden; URL is a best-effort refill).
+JDK17_X86AA_VER="${JDK17_X86AA_VER:-17.0.19_p10-r0}"  # current Alpine v3.22 community openjdk17
+ensure_assets() {
+    case "$arch" in
+        x86_64|aarch64)
+            local d="$DL/openjdk17-apks/$arch" a
+            # openjdk17 full JDK apks (jdk + jmods + jre-headless + jre); rolling, unpinned sha.
+            # If ANY patch level of the component apk is already cached, the stage_jdk17
+            # prefix-glob (openjdk17-${a}-*.apk) will consume it, so skip the fetch entirely —
+            # this keeps a populated JAVA_DL_ROOT (which holds the pinned 17.0.18_p8-r0 golden)
+            # network-free even though that exact version has aged off the live Alpine CDN.
+            for a in jdk jmods jre-headless jre; do
+                if compgen -G "$d/openjdk17-${a}-"'*.apk' >/dev/null 2>&1; then
+                    echo "prebuild: cache has openjdk17-${a} apk (stage-glob match) — skip fetch"
+                    continue
+                fi
+                ensure_alpine_apk "$d/openjdk17-${a}-${JDK17_X86AA_VER}.apk" \
+                    v3.22/community "$arch" "openjdk17-${a}-${JDK17_X86AA_VER}.apk"
+            done ;;
+        loongarch64)
+            local d="$DL/openjdk17-apks/loongarch64"
+            # openjdk17-loongarch native variant apks (edge/community; sha256 from local golden).
+            ensure_alpine_apk "$d/openjdk17-loongarch-jdk-17.0.17_p10-r0.apk"          edge/community loongarch64 openjdk17-loongarch-jdk-17.0.17_p10-r0.apk          e55611f2280854e9bc4e76785b51decf840015d26888f3c4eb15df9d603cc49c
+            ensure_alpine_apk "$d/openjdk17-loongarch-jmods-17.0.17_p10-r0.apk"        edge/community loongarch64 openjdk17-loongarch-jmods-17.0.17_p10-r0.apk        d9ad8763f8d7a13b5ce2618444bc5fcc43081b9c20fed50ee50cedb9f1eedbc1
+            ensure_alpine_apk "$d/openjdk17-loongarch-jre-headless-17.0.17_p10-r0.apk" edge/community loongarch64 openjdk17-loongarch-jre-headless-17.0.17_p10-r0.apk 42ae887f2099d44bbaa7531dad11d29da47796ba06637e1259427d5e2a55d80d
+            ensure_alpine_apk "$d/openjdk17-loongarch-jre-17.0.17_p10-r0.apk"          edge/community loongarch64 openjdk17-loongarch-jre-17.0.17_p10-r0.apk          9f867f80ce79cbffe51623e38b3085cb62e6d0d98e459425d8452a24e275f26f ;;
+        riscv64)
+            # openjdk17 riscv64: NATIVE-musl build self-compiled from openjdk/riscv-port-jdk17u
+            # (no upstream vendor ships musl+riscv64 JDK17 — see openjdk17-apks/SOURCES.md §riscv64
+            # + source-build/BUILD_FROM_SOURCE.md). No official prebuilt URL exists; this asset
+            # MUST be supplied via cache (JAVA_DL_ROOT) or rebuilt from source.
+            ensure_asset "$DL/openjdk17-apks/riscv64/openjdk17-riscv64-musl-NATIVE-cross.tar.gz" \
+                "${JDK17_RISCV_TAR_URL:-}" \
+                e321cfef413a133e4b11680f9166565f57a576e613803b23a79159b22703336b ;;
+    esac
+
+    # JDK21 — BellSoft musl tars (x86_64/aarch64); Alpine edge/community apks (riscv64/loongarch64).
+    case "$arch" in
+        x86_64)  ensure_asset "$JM/jdk21/bellsoft-jdk21.0.11+11-linux-x64-musl.tar.gz" \
+                    "$BELLSOFT_CDN/21.0.11+11/bellsoft-jdk21.0.11+11-linux-x64-musl.tar.gz" \
+                    5326af096fb1b943b4819ae2a51cbe3bfd4de45e4d1803d3fe3db2a6c8c8b125 ;;
+        aarch64) ensure_asset "$JM/jdk21/bellsoft-jdk21.0.11+11-linux-aarch64-musl.tar.gz" \
+                    "$BELLSOFT_CDN/21.0.11+11/bellsoft-jdk21.0.11+11-linux-aarch64-musl.tar.gz" \
+                    6118fce93eb0f595b3ed48252a43e6610fd550b42b7740701212369cd934ce5a ;;
+        riscv64)
+            ensure_alpine_apk "$ALP/riscv64-openjdk21-jre-headless-21.0.11_p10-r0.apk" edge/community riscv64 openjdk21-jre-headless-21.0.11_p10-r0.apk
+            ensure_alpine_apk "$ALP/riscv64-openjdk21-jdk-21.0.11_p10-r0.apk"          edge/community riscv64 openjdk21-jdk-21.0.11_p10-r0.apk
+            ensure_alpine_apk "$ALP/riscv64-openjdk21-jmods-21.0.11_p10-r0.apk"        edge/community riscv64 openjdk21-jmods-21.0.11_p10-r0.apk ;;
+        loongarch64)
+            ensure_alpine_apk "$ALP/loongarch64-openjdk21-jre-headless-21.0.11_p10-r0.apk" edge/community loongarch64 openjdk21-jre-headless-21.0.11_p10-r0.apk
+            ensure_alpine_apk "$ALP/loongarch64-openjdk21-jdk-21.0.11_p10-r0.apk"          edge/community loongarch64 openjdk21-jdk-21.0.11_p10-r0.apk
+            ensure_alpine_apk "$ALP/loongarch64-openjdk21-jmods-21.0.11_p10-r0.apk"        edge/community loongarch64 openjdk21-jmods-21.0.11_p10-r0.apk ;;
+    esac
+
+    # JDK23 — BellSoft musl tars (x86_64/aarch64); BellSoft generic-glibc tar (riscv64);
+    # Loongson glibc full tar (loongarch64). The rv/loong glibc cells are bridged by the
+    # gcompat shim staged below; stage_jdk23 + run-java.sh's probe attempt them on all 4 arches.
+    case "$arch" in
+        x86_64)  ensure_asset "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-x64-musl.tar.gz" \
+                    "$BELLSOFT_CDN/23.0.2+9/bellsoft-jdk23.0.2+9-linux-x64-musl.tar.gz" \
+                    16f67aed6d6564f3bec7b5904ccc35f48b1b9dddf32540b47975eb1c155603ce ;;
+        aarch64) ensure_asset "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-aarch64-musl.tar.gz" \
+                    "$BELLSOFT_CDN/23.0.2+9/bellsoft-jdk23.0.2+9-linux-aarch64-musl.tar.gz" \
+                    40b39d58eb66598f46245e85a34bd1271cd1ddf077fa2d4357a5377cda7c8b59 ;;
+        riscv64) ensure_asset "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-riscv64.tar.gz" \
+                    "$BELLSOFT_CDN/23.0.2+9/bellsoft-jdk23.0.2+9-linux-riscv64.tar.gz" \
+                    912dbba0e3dca9b0981891dda8746d221bd78f0346a46cb5027c70503952add4 ;;  # glibc -> gcompat
+        loongarch64)
+            # Loongson 'loongsonNN-fx-jdk' glibc full tar — Loongson ships no stable github
+            # release for this asset (see jdk-multi/SOURCES.md §0); supply via cache or set
+            # JDK23_LOONG_TAR_URL to a maintainer-hosted copy.
+            ensure_asset "$JM/jdk23/loongson23.1.17-fx-jdk23_37-linux-loongarch64.tar.gz" \
+                "${JDK23_LOONG_TAR_URL:-}" \
+                55e4ab6a285962a24f2a916720899bcac0ce2838a63d44e75359aa49300fe8c9 ;;
+    esac
+
+    # JDK25 — BellSoft musl tars (x86_64/aarch64); Alpine edge/community apks (riscv64);
+    # Alpine edge/community LoongArch native C2-JIT variant (loongarch64).
+    case "$arch" in
+        x86_64)  ensure_asset "$JM/jdk25/bellsoft-jdk25+37-linux-x64-musl.tar.gz" \
+                    "$BELLSOFT_CDN/25+37/bellsoft-jdk25+37-linux-x64-musl.tar.gz" \
+                    c39d961788095b7facc97d88cbf5c26e2b88b2df30438c0b0e5e637a44e708ef ;;
+        aarch64) ensure_asset "$JM/jdk25/bellsoft-jdk25+37-linux-aarch64-musl.tar.gz" \
+                    "$BELLSOFT_CDN/25+37/bellsoft-jdk25+37-linux-aarch64-musl.tar.gz" \
+                    0d0aae364e44768059358434fe8bfe2aaa209866586c9f38842fec6f03f363c3 ;;
+        riscv64)
+            ensure_alpine_apk "$ALP/riscv64-openjdk25-jre-headless-25.0.3_p9-r1.apk" edge/community riscv64 openjdk25-jre-headless-25.0.3_p9-r1.apk
+            ensure_alpine_apk "$ALP/riscv64-openjdk25-jdk-25.0.3_p9-r1.apk"          edge/community riscv64 openjdk25-jdk-25.0.3_p9-r1.apk
+            ensure_alpine_apk "$ALP/riscv64-openjdk25-jmods-25.0.3_p9-r1.apk"        edge/community riscv64 openjdk25-jmods-25.0.3_p9-r1.apk ;;
+        loongarch64)
+            local g="$JM/jdk25/loongarch64-alpine-musl"
+            ensure_alpine_apk "$g/openjdk25-loongarch-jre-headless-25.0.1_p8-r1.apk" edge/community loongarch64 openjdk25-loongarch-jre-headless-25.0.1_p8-r1.apk 28e19f2c14d8137d9e767347ef61953af99fec263a1374e6221d4d22b8ef3796
+            ensure_alpine_apk "$g/openjdk25-loongarch-jre-25.0.1_p8-r1.apk"          edge/community loongarch64 openjdk25-loongarch-jre-25.0.1_p8-r1.apk          a8ab4d738501c5ff3a8257d2c9e85684200dd5275b097efe0cadaa80693dddb6
+            ensure_alpine_apk "$g/openjdk25-loongarch-jdk-25.0.1_p8-r1.apk"          edge/community loongarch64 openjdk25-loongarch-jdk-25.0.1_p8-r1.apk          4e1c4d1aada0a4f524ec5200ec705cb0c7769fe77e0f5d7ccf998becafce61df
+            ensure_alpine_apk "$g/openjdk25-loongarch-jmods-25.0.1_p8-r1.apk"        edge/community loongarch64 openjdk25-loongarch-jmods-25.0.1_p8-r1.apk        cb6886b8f3f5306f2f509c542d94a1adba523e08881a1fc73a762da7ce3b5fc0 ;;
+    esac
+
+    # loongarch64 JDK21 Zero VM dep: libffi.so.8 (edge/main; sha256 from local golden).
+    if [[ "$arch" == "loongarch64" ]]; then
+        ensure_alpine_apk "$ALP/loongarch64-libffi-3.5.2-r1.apk" edge/main loongarch64 libffi-3.5.2-r1.apk \
+            f81152fb8a31cc7e3a3e32602b4278d1c1d2dcfeecf4a58ef47afa5237db924f
+    fi
+
+    # gcompat glibc-on-musl shim + its runtime deps (libucontext, musl-obstack), for the
+    # riscv64 / loongarch64 glibc JDK23 cell — same gcompat staging prep-jdk-multi-rootfs.sh
+    # uses (it stages gcompat alone; we additionally fetch its DT_NEEDED libucontext/obstack so
+    # libgcompat.so.0 actually loads). All three live in Alpine edge/main; sha256 from the local
+    # golden in download/openjdk17-apks/<arch>/. Consumed by stage_gcompat() for rv/loong only.
+    case "$arch" in
+        riscv64)
+            local g="$DL/openjdk17-apks/riscv64"
+            ensure_alpine_apk "$g/gcompat-1.1.0-r4.apk"       edge/main riscv64 gcompat-1.1.0-r4.apk \
+                caab16a14d67186db08a40970e3ff00925cc0267ea5546591f9298126b3637eb
+            ensure_alpine_apk "$g/libucontext-1.5.1-r0.apk"   edge/main riscv64 libucontext-1.5.1-r0.apk \
+                5cea6f66a7e23ebdd0d2d31f7958fca4cd75812dd4f4c92e2c94bedd95e6aadc
+            ensure_alpine_apk "$g/musl-obstack-1.2.3-r2.apk"  edge/main riscv64 musl-obstack-1.2.3-r2.apk \
+                98081e0015a726db622fbc9da8bc8af744ab75eb31b6ba1590d4cdf36bdf5cff ;;
+        loongarch64)
+            local g="$DL/openjdk17-apks/loongarch64"
+            ensure_alpine_apk "$g/gcompat-1.1.0-r4.apk"       edge/main loongarch64 gcompat-1.1.0-r4.apk \
+                76719a89dddba800681cd8f3192d3298f5af6873cd72506f14d22bcc34cc9d8c
+            ensure_alpine_apk "$g/libucontext-1.5.1-r0.apk"   edge/main loongarch64 libucontext-1.5.1-r0.apk \
+                593431039c826f706359071f44362dc8ca50fcbddcaab0171ade1aaacd90491e
+            ensure_alpine_apk "$g/musl-obstack-1.2.3-r2.apk"  edge/main loongarch64 musl-obstack-1.2.3-r2.apk \
+                1db9aa304eebdce0d7d18c9e850e2dc4ecfb927c436ad6ea881ae5f4a35112ff ;;
+    esac
+}
+
+main() {
+    case "$arch" in x86_64|aarch64|riscv64|loongarch64) ;; *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;; esac
+    ensure_host_tools
+    ensure_assets
+    grow_rootfs
+
+    stage_jdk17
+    stage_jdk21
+    stage_jdk23   # all 4 arches; rv/loong are glibc -> bridged by stage_gcompat
+    stage_jdk25
+    stage_gcompat # rv/loong gcompat shim (+ libucontext/musl-obstack) for the glibc JDK23
+    stage_deps    # loong JDK21 Zero VM libffi.so.8
+    stage_test_sources
+    stage_alternatives_and_sdkman
+    stage_backcompat  # real-world Java-8 (--release 8) forward-compat suite into /root/bcreal
+
+    echo "prebuild: java-lang overlay ready for $arch — staged JDKs:"
+    local V
+    for V in 17 21 23 25; do
+        if [[ -x "$overlay_dir/opt/jdk$V/bin/javac" ]]; then
+            echo "  /opt/jdk$V  javac+java OK ($(du -sh "$overlay_dir/opt/jdk$V" | cut -f1))"
+        fi
+    done
+    echo "prebuild: total overlay $(du -sh "$overlay_dir" | cut -f1)"
+}
+
+main "$@"

--- a/apps/starry/java-lang/prebuild.sh
+++ b/apps/starry/java-lang/prebuild.sh
@@ -27,11 +27,14 @@
 #   x86_64       apk (openjdk17)       BellSoft musl tar   BellSoft musl tar     BellSoft musl tar   (4 JDKs)
 #   aarch64      apk (openjdk17)       BellSoft musl tar   BellSoft musl tar     BellSoft musl tar   (4 JDKs)
 #   riscv64      native-musl cross tar Alpine-musl apk     BellSoft GLIBC+gcompat Alpine-musl apk     (4 attempted)
-#   loongarch64  apk (openjdk17-loong) Alpine-musl apk     Loongson GLIBC+gcompat Alpine-musl apk     (4 attempted)
-#   JDK23 ships only as glibc on riscv64 (BellSoft generic-glibc) and loongarch64 (Loongson),
-#   so — exactly like prep-jdk-multi-rootfs.sh — we stage the gcompat shim (+ its libucontext /
-#   musl-obstack deps) so the Alpine-musl loader can satisfy the glibc JDK's libc.so.6 / ld-linux
-#   references, then ATTEMPT JDK23 on all 4 arches. The decision is made at run time by
+#   loongarch64  apk (openjdk17-loong) Alpine-musl apk     native-musl SRC-BUILD  Alpine-musl apk     (4 JDKs)
+#   JDK23 has no prebuilt musl build for riscv64/loongarch64. riscv64 uses BellSoft generic-glibc
+#   bridged by a real Debian glibc runtime; loongarch64 cross-compiles a native musl JDK23 from
+#   source (setup-loong-jdk23.sh, loong-jdk23-musl-port.patch) so it needs no glibc/gcompat at all.
+#   For the riscv64 glibc cell we stage a real Debian glibc runtime closure so the JDK's own
+#   ld-linux interp can satisfy its libc.so.6 references; loongarch64's native-musl JDK23 just
+#   needs the musl-loader compat symlinks (stage_loong_musl_compat). JDK23 is ATTEMPTED on all 4
+#   arches and the decision is made at run time by
 #   run-java.sh's timeout-guarded liveness probe: a glibc JDK that still segfaults/hangs under
 #   gcompat is a DOCUMENTED SKIP (partial-arch-deliver rule), never a fake pass or a failure.
 #   All musl cells (x86/aa fully, plus 17+21+25 on rv/loong) are the clean native path; javac
@@ -228,9 +231,10 @@ stage_jdk21() {
 
 # Stage JDK23 (full JDK with javac), all 4 arches — exactly the prep-jdk-multi-rootfs.sh
 # per-arch JDK23 cells. x86_64/aarch64 = BellSoft native-musl. riscv64 = BellSoft generic
-# GLIBC build; loongarch64 = Loongson GLIBC build (the only JDK23 that exists for those two
-# arches — no upstream Alpine-musl JDK23 for rv/loong). The glibc rv/loong cells are bridged
-# by the staged gcompat shim (see stage_gcompat); they are staged and TRIED, then run-java.sh's
+# GLIBC build (bridged by a real Debian glibc runtime); loongarch64 = a NATIVE loongarch64-musl
+# JDK23 cross-built FROM SOURCE (setup-loong-jdk23.sh) — no prebuilt musl JDK23 exists for loong
+# and the Loongson build is old-abi glibc. riscv64 is staged + TRIED via its glibc bridge; loong's
+# musl JDK23 just needs the stage_loong_musl_compat symlinks. Then run-java.sh's
 # timeout-guarded liveness probe includes them only if they actually run under gcompat, else
 # documents a SKIP (never a fake pass).
 stage_jdk23() {
@@ -244,7 +248,7 @@ stage_jdk23() {
         x86_64)  untar_strip1 "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-x64-musl.tar.gz"     "$jdst" ;;
         aarch64) untar_strip1 "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-aarch64-musl.tar.gz" "$jdst" ;;
         riscv64) untar_strip1 "$JM/jdk23/bellsoft-jdk23.0.2+9-linux-riscv64.tar.gz"      "$jdst" ;;  # glibc -> gcompat
-        loongarch64) untar_strip1 "$JM/jdk23/loongson23.1.17-fx-jdk23_37-linux-loongarch64.tar.gz" "$jdst" ;;  # glibc -> gcompat
+        loongarch64) untar_strip1 "$JM/jdk23/openjdk23-loongarch64-musl-srcbuild.tar.gz" "$jdst" ;;  # native musl (cross-built from loongson/jdk tag jdk-23+25-ls-0; see loong-jdk23-musl-port.patch)
     esac
     [[ -x "$jdst/bin/java" && -x "$jdst/bin/javac" ]] \
         || { echo "prebuild: jdk23 staged without java+javac for $arch" >&2; exit 3; }
@@ -364,9 +368,9 @@ stage_deps() {
 #     libdl) into the default multiarch search path; the JDK launcher's own interp
 #     (/lib/ld-linux-riscv64-lp64d.so.1) then loads it. The musl JDKs (17/21/25) keep using
 #     the musl loader and are unaffected.
-#   loongarch64: the only JDK23 is the old Loongson abi1.0 build (needs GLIBC_2.27, the
-#     legacy Loongson "world"); no compatible runtime exists for the upstreamed abi
-#     (glibc 2.36+), so it stays on the gcompat path and run-java.sh records a documented SKIP.
+#   loongarch64: NOT on the gcompat path — its JDK23 is a NATIVE loongarch64-musl build
+#     cross-compiled from source (setup-loong-jdk23.sh), so it runs directly on the Alpine-musl
+#     rootfs and only needs the stage_loong_musl_compat loader symlinks; it RUNS (no SKIP).
 stage_real_glibc_rv() {
     # Fetch (or cache-hit) the official Debian trixie riscv64 libc6 — the real glibc
     # runtime closure the BellSoft generic-glibc JDK23 needs. ensure_asset verifies the
@@ -386,10 +390,23 @@ stage_real_glibc_rv() {
     rm -rf "$t"
     echo "prebuild: staged REAL Debian glibc runtime for riscv64 (JDK23 glibc cell)"
 }
+# loongarch64: the source-built native-musl JDK23 (cross-compiled from loongson/jdk
+# jdk-23+25-ls-0 with loongarch64-linux-musl) names its loader the cross-toolchain way —
+# interp /lib64/ld-musl-loongarch-lp64d.so.1, NEEDED libc.so — whereas the Alpine loongarch64
+# rootfs ships musl as /lib/ld-musl-loongarch64.so.1 (+ libc.musl-loongarch64.so.1). It is the
+# same musl loongarch64-lp64d ABI; bridge the names with two symlinks so the JDK23 binaries can
+# exec (otherwise `java` fails ENOENT on its missing interpreter). JDK17/21/25 are Alpine-musl
+# and already use the rootfs loader, so they are unaffected.
+stage_loong_musl_compat() {
+    install -d "$overlay_dir/lib64" "$overlay_dir/lib"
+    ln -sf /lib/ld-musl-loongarch64.so.1 "$overlay_dir/lib64/ld-musl-loongarch-lp64d.so.1"
+    ln -sf ld-musl-loongarch64.so.1      "$overlay_dir/lib/libc.so"
+    echo "prebuild: staged loong musl-loader compat symlinks (native-musl source-built JDK23)"
+}
 stage_gcompat() {
     case "$arch" in
         riscv64) stage_real_glibc_rv; return 0 ;;
-        loongarch64) : ;;
+        loongarch64) stage_loong_musl_compat; return 0 ;;
         *) return 0 ;;
     esac
     local d="$DL/openjdk17-apks/$arch" apk
@@ -587,12 +604,20 @@ ensure_assets() {
                     "$BELLSOFT_CDN/23.0.2+9/bellsoft-jdk23.0.2+9-linux-riscv64.tar.gz" \
                     912dbba0e3dca9b0981891dda8746d221bd78f0346a46cb5027c70503952add4 ;;  # glibc -> gcompat
         loongarch64)
-            # Loongson 'loongsonNN-fx-jdk' glibc full tar — Loongson ships no stable github
-            # release for this asset (see jdk-multi/SOURCES.md §0); supply via cache or set
-            # JDK23_LOONG_TAR_URL to a maintainer-hosted copy.
-            ensure_asset "$JM/jdk23/loongson23.1.17-fx-jdk23_37-linux-loongarch64.tar.gz" \
-                "${JDK23_LOONG_TAR_URL:-}" \
-                55e4ab6a285962a24f2a916720899bcac0ce2838a63d44e75359aa49300fe8c9 ;;
+            # JDK23 for loongarch64 has NO usable prebuilt musl distribution: upstream/Alpine
+            # ship no musl JDK23 for loong (only 17/21/25), and the Loongson tar is old-abi
+            # (abi1.0) glibc that does not run under the upstream abi. We therefore cross-compile
+            # a NATIVE loongarch64-musl JDK23 from source (loongson/jdk tag jdk-23+25-ls-0). The
+            # resulting tarball is not downloadable, so the maintainer builds it once with
+            # apps/starry/java-lang/setup-loong-jdk23.sh (applies loong-jdk23-musl-port.patch).
+            # prebuild only verifies it is present and errors with a clear pointer otherwise.
+            [[ -f "$JM/jdk23/openjdk23-loongarch64-musl-srcbuild.tar.gz" ]] || {
+                echo "prebuild: ERROR missing $JM/jdk23/openjdk23-loongarch64-musl-srcbuild.tar.gz" >&2
+                echo "prebuild:   build it once: bash apps/starry/java-lang/setup-loong-jdk23.sh" >&2
+                echo "prebuild:   (cross-compiles loongson/jdk jdk-23+25-ls-0 -> loongarch64-musl; see loong-jdk23-musl-port.patch)" >&2
+                exit 4
+            }
+            echo "prebuild: jdk23 loongarch64 = native-musl source-build (openjdk23-loongarch64-musl-srcbuild.tar.gz present)" ;;
     esac
 
     # JDK25 — BellSoft musl tars (x86_64/aarch64); Alpine edge/community apks (riscv64);

--- a/apps/starry/java-lang/prebuild.sh
+++ b/apps/starry/java-lang/prebuild.sh
@@ -20,7 +20,7 @@
 #   injects — exactly as prep-jdk-multi-rootfs.sh grows its image to 6 GiB. Disk on the host
 #   is cheap; the running QEMU only ever maps a -Xmx512m JVM, so the larger image is free.
 #   We resize the image in place; the qemu-<arch>.toml points the drive at this same
-#   per-app image (rootfs-<arch>-java-lang.img), so the grown image is what boots.
+#   per-app image (rootfs-<arch>-alpine.img), so the grown image is what boots.
 #
 # ── PER-ARCH JDK SET (matches what openjdk-multi PROVED green) ────────────────────────
 #                JDK17                 JDK21               JDK23                 JDK25
@@ -42,7 +42,7 @@
 #
 # Guest layout (== openjdk-multi): /opt/jdk{17,21,23,25} (update-alternatives candidate
 # roots), /opt/jdk-current symlink, /root/.sdkman/candidates/java/* candidate symlinks,
-# /root/jdkm/*.java test sources. The per-JDK musl loader path is set by the qemu toml at
+# /root/jdkm/*.java test sources. The per-JDK musl loader path is set by run-java.sh at
 # run time (NOT here), one JDK at a time, to avoid the cross-JDK launcher mis-resolution.
 #
 # Env from the app runner: STARRY_ARCH, STARRY_OVERLAY_DIR, STARRY_APP_DIR, STARRY_ROOTFS,
@@ -262,13 +262,7 @@ stage_jdk25() {
     case "$arch" in
         x86_64)  untar_strip1 "$JM/jdk25/bellsoft-jdk25+37-linux-x64-musl.tar.gz"     "$jdst" ;;
         aarch64) untar_strip1 "$JM/jdk25/bellsoft-jdk25+37-linux-aarch64-musl.tar.gz" "$jdst" ;;
-        riscv64)
-            local T; T="$(mktemp -d)"; local a apk
-            for a in openjdk25-jre-headless openjdk25-jdk openjdk25-jmods; do
-                apk="$(ls "$ALP/riscv64-${a}-"*.apk 2>/dev/null | head -1)"
-                [[ -n "$apk" ]] && apk_into "$apk" "$T"
-            done
-            cp -a "$T/usr/lib/jvm/java-25-openjdk/." "$jdst/"; rm -rf "$T" ;;
+        riscv64) untar_strip1 "$JM/jdk25/openjdk25-riscv64-musl-srcbuild.tar.gz" "$jdst" ;;  # native musl server VM (cross-built from openjdk/jdk25u tag jdk-25.0.4+5; the lui->c.lui peephole is guarded (imm & 0xfff)==0 so it never emits the reserved C.LUI x5,0 that traps the BellSoft build — see apps/starry/java-lang/setup-rv-jdk25.sh / rv-jdk25-musl-port.patch)
         loongarch64)
             local T; T="$(mktemp -d)"; local a apk
             for a in openjdk25-loongarch-jre-headless openjdk25-loongarch-jre openjdk25-loongarch-jdk openjdk25-loongarch-jmods; do
@@ -279,13 +273,6 @@ stage_jdk25() {
     esac
     if [[ -x "$jdst/bin/java" && -x "$jdst/bin/javac" ]]; then
         echo "prebuild: jdk25 staged ($(du -sh "$jdst" | cut -f1), javac present)"
-    elif [[ "$arch" == riscv64 ]]; then
-        # jdk25 on riscv64 is the Alpine Zero-VM build, which always SKIPs at the run-time
-        # liveness probe (IllegalInstruction on the RV64GC baseline). Staging it is therefore
-        # best-effort: a transient apk-extraction miss must not abort the whole suite, which
-        # carries the real 17/21/23 cells. Drop the partial dir; the probe records the SKIP.
-        echo "prebuild: WARNING jdk25 not fully staged for riscv64 (Zero-VM cell — SKIPs at probe regardless)" >&2
-        rm -rf "$jdst"
     else
         echo "prebuild: jdk25 staged without java+javac for $arch" >&2; exit 3
     fi
@@ -630,9 +617,17 @@ ensure_assets() {
                     "$BELLSOFT_CDN/25+37/bellsoft-jdk25+37-linux-aarch64-musl.tar.gz" \
                     0d0aae364e44768059358434fe8bfe2aaa209866586c9f38842fec6f03f363c3 ;;
         riscv64)
-            ensure_alpine_apk "$ALP/riscv64-openjdk25-jre-headless-25.0.3_p9-r1.apk" edge/community riscv64 openjdk25-jre-headless-25.0.3_p9-r1.apk
-            ensure_alpine_apk "$ALP/riscv64-openjdk25-jdk-25.0.3_p9-r1.apk"          edge/community riscv64 openjdk25-jdk-25.0.3_p9-r1.apk
-            ensure_alpine_apk "$ALP/riscv64-openjdk25-jmods-25.0.3_p9-r1.apk"        edge/community riscv64 openjdk25-jmods-25.0.3_p9-r1.apk ;;
+            # jdk25 riscv64 = native riscv64-musl SERVER VM, cross-built from source: prebuilt
+            # riscv64 JDK25 server VMs trap on the RV64GC baseline (BellSoft emits a reserved
+            # C.LUI x5,0; Alpine ships only a Zero VM). Build once with
+            # apps/starry/java-lang/setup-rv-jdk25.sh (openjdk/jdk25u jdk-25.0.4+5; the lui->c.lui
+            # peephole is guarded (imm & 0xfff)==0 by rv-jdk25-musl-port.patch so it never emits C.LUI x5,0).
+            [[ -f "$JM/jdk25/openjdk25-riscv64-musl-srcbuild.tar.gz" ]] || {
+                echo "prebuild: ERROR missing $JM/jdk25/openjdk25-riscv64-musl-srcbuild.tar.gz" >&2
+                echo "prebuild:   build it once: bash apps/starry/java-lang/setup-rv-jdk25.sh" >&2
+                exit 4
+            }
+            echo "prebuild: jdk25 riscv64 = native-musl source-build (openjdk25-riscv64-musl-srcbuild.tar.gz present)" ;;
         loongarch64)
             local g="$JM/jdk25/loongarch64-alpine-musl"
             ensure_alpine_apk "$g/openjdk25-loongarch-jre-headless-25.0.1_p8-r1.apk" edge/community loongarch64 openjdk25-loongarch-jre-headless-25.0.1_p8-r1.apk 28e19f2c14d8137d9e767347ef61953af99fec263a1374e6221d4d22b8ef3796

--- a/apps/starry/java-lang/programs/BackCompat.java
+++ b/apps/starry/java-lang/programs/BackCompat.java
@@ -1,0 +1,46 @@
+// BackCompat.java — Java backward-compatibility test for the openjdk-multi case (#764).
+// Compiled ONCE with javac --release 17 (class file version 61), then run UNCHANGED on
+// JDK 17 / 21 / 23 / 25. A newer JVM must run older bytecode and produce byte-identical
+// output (the JVM backward-compatibility guarantee). Uses only JDK17-level language +
+// stdlib so the SAME .class is valid on every target JDK. Deterministic output.
+import java.util.*;
+import java.util.stream.*;
+
+public class BackCompat {
+    // JDK16/17 record
+    record Point(int x, int y) { int sum() { return x + y; } }
+    // JDK17 sealed
+    sealed interface Shape permits Circle, Square {}
+    record Circle(int r) implements Shape {}
+    record Square(int s) implements Shape {}
+    static int area(Shape sh) {
+        // JDK16/17 instanceof patterns (pattern-switch is JDK21+, so use if-else to stay 17-clean)
+        if (sh instanceof Circle c) return 3 * c.r() * c.r();
+        if (sh instanceof Square q) return q.s() * q.s();
+        return -1;
+    }
+
+    public static void main(String[] a) {
+        var out = new StringBuilder();
+        // record
+        out.append("REC=").append(new Point(3, 4).sum()).append(';');
+        // sealed + switch-expr
+        out.append("AREA=").append(area(new Circle(2)) + area(new Square(3))).append(';');
+        // text block (JDK15+)
+        String tb = """
+            line1
+            line2""";
+        out.append("TB=").append(tb.lines().count()).append(';');
+        // instanceof pattern (JDK16+)
+        Object o = "hello";
+        out.append("PAT=").append(o instanceof String s ? s.length() : -1).append(';');
+        // Stream.toList (JDK16+)
+        out.append("STREAM=").append(Stream.of(1, 2, 3, 4).filter(x -> x % 2 == 0).toList()).append(';');
+        // var + collections + math
+        var m = new TreeMap<String, Integer>();
+        m.put("b", 2); m.put("a", 1);
+        out.append("MAP=").append(m).append(';');
+        // deterministic, version-independent
+        System.out.println("BACKCOMPAT_RUN=" + out);
+    }
+}

--- a/apps/starry/java-lang/programs/JavaGrammar.java
+++ b/apps/starry/java-lang/programs/JavaGrammar.java
@@ -1,0 +1,264 @@
+// JavaGrammar.java — full-JLS language-grammar carpet for StarryOS java-lang (#764).
+// Exercises the Java language grammar item-by-item (literals, operators, control
+// flow, type declarations, generics, functional, exceptions, concurrency,
+// reflection, initializers, arrays). Stable features through JDK 17 (the LTS
+// baseline); version-specific deltas (records/sealed in 17, virtual threads in
+// 21, etc.) are additionally covered by Jdk{17,21,23,25}Features.java.
+//
+// Run:  java JavaGrammar.java   (single-file source mode)
+// Prints JAVA_GRAMMAR_OK on the last line iff every assertion passed.
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+import java.util.stream.*;
+import java.lang.annotation.*;
+import java.lang.reflect.*;
+
+public class JavaGrammar {
+    static int pass = 0, fail = 0;
+    static void chk(String name, boolean cond) {
+        if (cond) { pass++; }
+        else { fail++; System.out.println("  FAIL " + name); }
+    }
+
+    // ---- annotations (declaration, retention, repeatable, type annotation) ----
+    @Retention(RetentionPolicy.RUNTIME) @interface Tag { String value(); }
+    @Retention(RetentionPolicy.RUNTIME) @interface Tags { Mark[] value(); }
+    @Retention(RetentionPolicy.RUNTIME) @Repeatable(Tags.class) @interface Mark { String value(); }
+    @Tag("cls") static class Annotated {}
+    @Mark("a") @Mark("b") static class Repeated {}
+
+    // ---- generics: bounded type param + wildcards + generic method ----
+    static <T extends Comparable<T>> T max(List<T> xs) {
+        T m = xs.get(0);
+        for (T x : xs) if (x.compareTo(m) > 0) m = x;
+        return m;
+    }
+    static double sum(List<? extends Number> xs) {
+        double s = 0; for (Number n : xs) s += n.doubleValue(); return s;
+    }
+
+    // ---- enum with body + abstract method ----
+    enum Op {
+        ADD { int apply(int a, int b) { return a + b; } },
+        MUL { int apply(int a, int b) { return a * b; } };
+        abstract int apply(int a, int b);
+    }
+
+    // ---- record + compact constructor ----
+    record Frac(int num, int den) {
+        Frac { if (den == 0) throw new IllegalArgumentException("den=0"); }
+        double val() { return (double) num / den; }
+    }
+
+    // ---- sealed hierarchy ----
+    sealed interface Node permits Leaf, Branch {}
+    record Leaf(int v) implements Node {}
+    record Branch(Node l, Node r) implements Node {}
+    static int total(Node n) {
+        if (n instanceof Leaf lf) return lf.v();
+        if (n instanceof Branch b) return total(b.l()) + total(b.r());
+        throw new IllegalStateException();
+    }
+
+    // ---- interface: default / static / private methods ----
+    interface Greeter {
+        String name();
+        default String hi() { return prefix() + name(); }
+        static Greeter of(String n) { return () -> n; }
+        private String prefix() { return "hi "; }
+    }
+
+    // ---- custom exception + AutoCloseable for try-with-resources ----
+    static class Res implements AutoCloseable {
+        final StringBuilder log; Res(StringBuilder l){ log = l; log.append("open;"); }
+        public void close(){ log.append("close;"); }
+    }
+
+    // ---- static + instance initializers ----
+    static int sinit; static { sinit = 42; }
+    int iinit; { iinit = 7; }
+
+    static void literals() {
+        int dec = 1_000_000, hex = 0xFF, oct = 0_17, bin = 0b1010;
+        long big = 9_000_000_000L;
+        double d = 1.5e3, hexf = 0x1.8p1;   // hex float = 3.0
+        float f = 2.5f;
+        char uni = 'A';                // 'A'
+        boolean t = true;
+        String s = "a\tb";
+        String block = """
+            line1
+            line2""";
+        chk("lit_underscore_dec", dec == 1000000);
+        chk("lit_hex", hex == 255);
+        chk("lit_octal", oct == 15);
+        chk("lit_binary", bin == 10);
+        chk("lit_long", big == 9000000000L);
+        chk("lit_double_exp", d == 1500.0);
+        chk("lit_hex_float", hexf == 3.0);
+        chk("lit_float", f == 2.5f);
+        chk("lit_char_unicode", uni == 'A');
+        chk("lit_bool", t);
+        chk("lit_string_escape", s.length() == 3 && s.charAt(1) == '\t');
+        chk("lit_text_block", block.equals("line1\nline2"));
+        chk("lit_null", ((Object) null) == null);
+    }
+
+    static void operators() {
+        chk("op_arith", 7 / 2 == 3 && 7 % 2 == 1 && 2 * 3 + 1 == 7);
+        chk("op_bitwise", (0b1100 & 0b1010) == 0b1000 && (0b1100 | 0b1010) == 0b1110
+                && (0b1100 ^ 0b1010) == 0b0110 && (~0) == -1);
+        chk("op_shift", (1 << 4) == 16 && (-8 >> 1) == -4 && (-1 >>> 28) == 15);
+        chk("op_relational", 1 < 2 && 2 <= 2 && 3 > 2 && 3 >= 3 && 1 != 2 && 2 == 2);
+        chk("op_logical", (true && true) && (false || true) && !false);
+        int x = 5;
+        x += 3;    // 8
+        x -= 1;    // 7
+        x *= 3;    // 21
+        x /= 2;    // 10
+        x %= 7;    // 3
+        x <<= 2;   // 12
+        x >>= 1;   // 6
+        x &= 0xE;  // 6
+        x |= 1;    // 7
+        x ^= 2;    // 5
+        chk("op_compound_assign", x == 5);
+        chk("op_ternary", (3 > 2 ? "y" : "n").equals("y"));
+        Object o = "str";
+        chk("op_instanceof", o instanceof String);
+        int a = 1; int b = a++ + ++a;   // 1 + 3
+        chk("op_inc_dec", a == 3 && b == 4);
+    }
+
+    static void controlFlow() {
+        int sum = 0; for (int i = 0; i < 5; i++) sum += i;
+        chk("ctrl_for", sum == 10);
+        int n = 0; while (n < 3) n++;
+        chk("ctrl_while", n == 3);
+        int m = 0; do { m++; } while (m < 2);
+        chk("ctrl_do_while", m == 2);
+        int es = 0; for (int v : new int[]{1, 2, 3}) es += v;
+        chk("ctrl_enhanced_for", es == 6);
+        String r; switch (2) { case 1: r = "a"; break; case 2: r = "b"; break; default: r = "z"; }
+        chk("ctrl_switch_stmt", r.equals("b"));
+        int code = switch (3) { case 1, 2 -> 10; case 3 -> { int y = 30; yield y; } default -> 0; };
+        chk("ctrl_switch_expr_yield", code == 30);
+        int found = -1;
+        outer: for (int i = 0; i < 3; i++) for (int j = 0; j < 3; j++) if (i + j == 3) { found = i * 10 + j; break outer; }
+        chk("ctrl_labeled_break", found == 12);
+    }
+
+    static void exceptions() {
+        StringBuilder log = new StringBuilder();
+        try (Res a = new Res(log); Res b = new Res(log)) { log.append("body;"); }
+        chk("exc_try_with_resources", log.toString().equals("open;open;body;close;close;"));
+        String caught = "";
+        try { throw new NumberFormatException("x"); }
+        catch (IllegalStateException | NumberFormatException e) { caught = e.getClass().getSimpleName(); }
+        chk("exc_multi_catch", caught.equals("NumberFormatException"));
+        boolean fin = false;
+        try { int z = 1 / 0; } catch (ArithmeticException e) { } finally { fin = true; }
+        chk("exc_finally", fin);
+    }
+
+    static void genericsFunctional() {
+        chk("gen_bounded_method", max(List.of(3, 9, 4)) == 9);
+        chk("gen_wildcard", sum(List.of(1, 2, 3.5)) == 6.5);
+        List<Integer> xs = List.of(1, 2, 3, 4, 5);
+        int evens = (int) xs.stream().filter(i -> i % 2 == 0).count();
+        chk("stream_filter", evens == 2);
+        List<Integer> doubled = xs.stream().map(i -> i * 2).collect(Collectors.toList());
+        chk("stream_map_collect", doubled.equals(List.of(2, 4, 6, 8, 10)));
+        int red = xs.stream().reduce(0, Integer::sum);
+        chk("stream_reduce_methodref", red == 15);
+        List<Integer> tl = xs.stream().limit(2).toList();
+        chk("stream_toList", tl.equals(List.of(1, 2)));
+        Optional<Integer> first = xs.stream().filter(i -> i > 3).findFirst();
+        chk("optional", first.isPresent() && first.get() == 4);
+        Function<Integer, Integer> inc = i -> i + 1;
+        BiFunction<Integer, Integer, Integer> add = Integer::sum;
+        Supplier<String> sup = String::new;
+        chk("lambda_methodref_ctor", inc.apply(4) == 5 && add.apply(2, 3) == 5 && sup.get().isEmpty());
+        Runnable rr = () -> {};
+        chk("functional_iface", rr != null);
+    }
+
+    static void typesAndNesting() {
+        chk("record_compact_ctor", new Frac(1, 2).val() == 0.5);
+        boolean threw = false;
+        try { new Frac(1, 0); } catch (IllegalArgumentException e) { threw = true; }
+        chk("record_compact_validate", threw);
+        chk("sealed_hierarchy", total(new Branch(new Leaf(3), new Branch(new Leaf(4), new Leaf(5)))) == 12);
+        chk("enum_abstract_body", Op.ADD.apply(2, 3) == 5 && Op.MUL.apply(2, 3) == 6);
+        chk("interface_default_static_private", Greeter.of("sky").hi().equals("hi sky"));
+        // anonymous class
+        Greeter anon = new Greeter() { public String name() { return "anon"; } };
+        chk("anonymous_class", anon.hi().equals("hi anon"));
+        // local class
+        class Local { int v() { return 99; } }
+        chk("local_class", new Local().v() == 99);
+        // var + autoboxing
+        var list = new ArrayList<Integer>(); list.add(5);
+        int unboxed = list.get(0);
+        chk("var_and_autoboxing", unboxed == 5);
+        // varargs
+        chk("varargs", varsum(1, 2, 3, 4) == 10);
+        // multidim array + initializer
+        int[][] grid = {{1, 2}, {3, 4}};
+        chk("array_multidim_init", grid[1][1] == 4 && grid.length == 2);
+        // initializers ran
+        chk("static_initializer", sinit == 42);
+        chk("instance_initializer", new JavaGrammar().iinit == 7);
+    }
+    static int varsum(int... xs) { int s = 0; for (int x : xs) s += x; return s; }
+
+    static void annotationsReflection() throws Exception {
+        Tag tg = Annotated.class.getAnnotation(Tag.class);
+        chk("annotation_runtime", tg != null && tg.value().equals("cls"));
+        Mark[] marks = Repeated.class.getAnnotationsByType(Mark.class);
+        chk("annotation_repeatable", marks.length == 2 && marks[0].value().equals("a"));
+        Method mm = JavaGrammar.class.getDeclaredMethod("varsum", int[].class);
+        chk("reflection_method", mm.getReturnType() == int.class);
+        Object res = mm.invoke(null, (Object) new int[]{2, 3});
+        chk("reflection_invoke", ((Integer) res) == 5);
+        Class<?> c = Class.forName("java.lang.String");
+        chk("reflection_forname", c.getSimpleName().equals("String"));
+    }
+
+    static void concurrency() throws Exception {
+        AtomicInteger counter = new AtomicInteger(0);
+        int N = 8;
+        CountDownLatch latch = new CountDownLatch(N);
+        ExecutorService ex = Executors.newFixedThreadPool(4);
+        for (int i = 0; i < N; i++) ex.submit(() -> { counter.incrementAndGet(); latch.countDown(); });
+        latch.await(30, TimeUnit.SECONDS);
+        ex.shutdown();
+        chk("concurrency_executor_atomic", counter.get() == N);
+        CompletableFuture<Integer> cf = CompletableFuture.supplyAsync(() -> 20).thenApply(v -> v + 1);
+        chk("concurrency_completablefuture", cf.get(30, TimeUnit.SECONDS) == 21);
+        // synchronized + volatile smoke
+        final Object lock = new Object();
+        int[] acc = {0};
+        Thread th = new Thread(() -> { synchronized (lock) { acc[0]++; } });
+        th.start(); th.join();
+        chk("concurrency_thread_synchronized", acc[0] == 1);
+    }
+
+    public static void main(String[] args) throws Exception {
+        int major = Runtime.version().feature();
+        System.out.println("java grammar carpet on feature version " + major);
+        literals();
+        operators();
+        controlFlow();
+        exceptions();
+        genericsFunctional();
+        typesAndNesting();
+        annotationsReflection();
+        concurrency();
+        System.out.println("grammar: " + pass + " passed, " + fail + " failed");
+        System.out.println(fail == 0 ? "JAVA_GRAMMAR_OK" : "JAVA_GRAMMAR_FAIL");
+        if (fail != 0) System.exit(1);
+    }
+}

--- a/apps/starry/java-lang/programs/JavaLangCarpet.java
+++ b/apps/starry/java-lang/programs/JavaLangCarpet.java
@@ -1,0 +1,1054 @@
+// JavaLangCarpet.java — CARPET-LEVEL Java language + core stdlib test for StarryOS #764.
+//
+// Doc-grounded against the Java Language Specification (docs.oracle.com/javase/specs JLS)
+// and the java.base API. Exhaustively exercises, item-by-item:
+//   - every primitive/reference type + boxing/unboxing/caching/widening/narrowing
+//   - every operator (arithmetic/bitwise/shift/relational/logical/ternary/compound/inc-dec/instanceof)
+//   - all control flow (if/for/while/do/enhanced-for/switch-stmt/switch-expr+yield/labeled break/continue)
+//   - classes/interfaces/enums/records/sealed/nested/anonymous/local/inner classes
+//   - generics (bounded type params, wildcards, generic methods, inference, recursive bounds)
+//   - lambdas + method refs (static/instance/ctor/unbound) + functional interfaces
+//   - streams (map/filter/reduce/collect/flatMap/grouping/partitioning/stats/iterate/generate/takeWhile)
+//   - Optional, switch + pattern matching (instanceof patterns; JDK21+ switch patterns reflection-gated)
+//   - text blocks, var, varargs, multidim arrays, initializers
+//   - exceptions / try-with-resources / multi-catch / finally / custom exceptions / chaining
+//   - annotations + reflection (runtime retention, repeatable, getMethod, invoke, Class.forName)
+//   - java.util collections (List/Map/Set/Deque/Queue/TreeMap/TreeSet/PriorityQueue/LinkedHashMap/EnumSet/Comparator)
+//   - java.util.concurrent (ExecutorService/CompletableFuture/locks/atomics/ConcurrentHashMap/CountDownLatch/Semaphore)
+//   - java.time (LocalDate/LocalDateTime/Duration/Period/Instant/ChronoUnit/DateTimeFormatter)
+//   - java.util.regex (Pattern/Matcher/groups/named groups/split/replace/results)
+//   - java.nio basics (charsets/ByteBuffer/Base64)
+//   - String/StringBuilder/Math/BigInteger/BigDecimal/Character/Integer/Long/Double
+//
+// GOLDEN-CAPTURE MODEL: every expected value below was captured by RUNNING a probe on host
+// first (never hand-guessed). In addition to in-code chk() assertions the test also emits a
+// deterministic GOLDEN block (golden(name,value)) whose stdout is captured on host as golden.txt;
+// the on-target check is byte-identical output. Output is 100% deterministic — no wall-clock,
+// no hash/map iteration order (all maps printed via TreeMap or insertion-ordered LinkedHashMap),
+// no addresses, no scheduling-dependent ordering.
+//
+// VERSION MODEL (RELOPT bridge): host has javac 21 + java 17. Compile with
+//   javac --release 17 JavaLangCarpet.java       (class file version 61, JDK17-clean)
+// then run on java 17. JDK21+ language features cannot be in a --release 17 class, so JDK21+
+// *stdlib* deltas (List.getFirst/getLast/reversed, Math.clamp, Thread.ofVirtual, SequencedCollection)
+// are reached via REFLECTION and only execute when Runtime.version().feature() >= 21 (on
+// StarryOS JDK21/23/25). On java 17 they report ABSENT and are counted as version-gated skips,
+// not failures. JDK21+ language *syntax* (record patterns, switch patterns, virtual threads) lives
+// in the separate Jdk21Features.java compiled with --release 21 in the openjdk-multi rootfs.
+//
+// Run:  java JavaLangCarpet.java          (single-file source mode)
+//       java -cp <dir> JavaLangCarpet     (compiled)
+// Prints "JAVA_LANG_OK <count>" on the last line iff every assertion passed.
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.concurrent.locks.*;
+import java.util.function.*;
+import java.util.stream.*;
+import java.lang.annotation.*;
+import java.lang.reflect.*;
+import java.math.*;
+import java.time.*;
+import java.time.format.*;
+import java.time.temporal.*;
+import java.util.regex.*;
+import java.nio.*;
+import java.nio.charset.*;
+
+public class JavaLangCarpet {
+    static int pass = 0, fail = 0, gated = 0;
+    static final StringBuilder GOLD = new StringBuilder();
+
+    static void chk(String name, boolean cond) {
+        if (cond) { pass++; }
+        else { fail++; System.out.println("  FAIL " + name); }
+    }
+    // golden(): record + assert a deterministic value. The "GOLD=" lines form the
+    // output==golden cross-check; the chk() makes a single-file run self-validating too.
+    static void golden(String name, Object value) {
+        String s = String.valueOf(value);
+        GOLD.append("GOLD ").append(name).append('=').append(s).append('\n');
+        pass++; // emitting a golden line is itself a covered check
+    }
+
+    // ====================================================================== //
+    //  Declarations used across modules                                       //
+    // ====================================================================== //
+
+    // ---- annotations: runtime retention, members, repeatable, defaults ----
+    @Retention(RetentionPolicy.RUNTIME) @interface Tag { String value(); int n() default 0; }
+    @Retention(RetentionPolicy.RUNTIME) @interface Marks { Mark[] value(); }
+    @Retention(RetentionPolicy.RUNTIME) @Repeatable(Marks.class) @interface Mark { String value(); }
+    @Tag(value = "cls", n = 5) static class Annotated {}
+    @Mark("a") @Mark("b") @Mark("c") static class Repeated {}
+
+    // ---- generics: bounded, recursive bound, wildcards, generic method ----
+    static <T extends Comparable<T>> T max(List<T> xs) {
+        T m = xs.get(0);
+        for (T x : xs) if (x.compareTo(m) > 0) m = x;
+        return m;
+    }
+    static double sumNums(List<? extends Number> xs) {
+        double s = 0; for (Number n : xs) s += n.doubleValue(); return s;
+    }
+    static void addInts(List<? super Integer> xs) { xs.add(1); xs.add(2); }
+    static <A, B> List<B> mapAll(List<A> in, Function<A, B> f) {
+        List<B> out = new ArrayList<>(); for (A a : in) out.add(f.apply(a)); return out;
+    }
+    // generic class with bound
+    static class Box<T extends Number> {
+        final T v; Box(T v) { this.v = v; }
+        double dbl() { return v.doubleValue() * 2; }
+    }
+    // recursive generic bound + self-type
+    static class Holder<T extends Holder<T>> { int depth() { return 1; } }
+
+    // ---- enum: fields, ctor, abstract body, values/valueOf/ordinal/name ----
+    enum Planet {
+        MERCURY(3.30e23, 2.44e6), EARTH(5.97e24, 6.37e6);
+        final double mass, radius;
+        Planet(double m, double r) { mass = m; radius = r; }
+        double gravity() { return 6.67e-11 * mass / (radius * radius); }
+    }
+    enum Op {
+        ADD { int apply(int a, int b) { return a + b; } },
+        SUB { int apply(int a, int b) { return a - b; } },
+        MUL { int apply(int a, int b) { return a * b; } };
+        abstract int apply(int a, int b);
+    }
+
+    // ---- records: compact ctor, custom accessor, static, nested, generic ----
+    record Frac(int num, int den) {
+        Frac { if (den == 0) throw new IllegalArgumentException("den=0"); }
+        double val() { return (double) num / den; }
+        static Frac half() { return new Frac(1, 2); }
+    }
+    record Pair<A, B>(A first, B second) {}
+
+    // ---- sealed hierarchy + permits + record implementations ----
+    sealed interface Expr permits Num, Add, Mul {}
+    record Num(int v) implements Expr {}
+    record Add(Expr l, Expr r) implements Expr {}
+    record Mul(Expr l, Expr r) implements Expr {}
+    static int eval(Expr e) {
+        if (e instanceof Num n) return n.v();
+        if (e instanceof Add a) return eval(a.l()) + eval(a.r());
+        if (e instanceof Mul m) return eval(m.l()) * eval(m.r());
+        throw new IllegalStateException();
+    }
+
+    // ---- interface: default / static / private / private static methods ----
+    interface Greeter {
+        String name();
+        default String hi() { return prefix() + name(); }
+        static Greeter of(String n) { return () -> n; }
+        private String prefix() { return base() + " "; }
+        private static String base() { return "hi"; }
+    }
+    // ---- functional interface (SAM) ----
+    @FunctionalInterface interface TriFn<A, B, C, R> { R apply(A a, B b, C c); }
+
+    // ---- AutoCloseable for try-with-resources ordering ----
+    static class Res implements AutoCloseable {
+        final StringBuilder log; final String id;
+        Res(StringBuilder l, String id) { this.log = l; this.id = id; log.append("open" + id + ";"); }
+        public void close() { log.append("close" + id + ";"); }
+    }
+
+    // ---- inner (non-static) class capturing outer instance ----
+    int outerField = 1000;
+    class Inner { int read() { return outerField + 1; } }
+
+    // ---- static + instance initializers, blank finals ----
+    static final int SINIT; static { SINIT = 21 * 2; }
+    final int iinit; { iinit = 7; }
+    JavaLangCarpet() {}
+
+    // ====================================================================== //
+    //  MODULE 01 — literals                                                   //
+    // ====================================================================== //
+    static void mLiterals() {
+        int dec = 1_000_000, hex = 0xFF, oct = 0_17, bin = 0b1010_1010;
+        long lng = 9_000_000_000L, lhex = 0xCAFE_BABEL;
+        double d = 1.5e3, hexf = 0x1.8p1, neg = -2.5E-2;
+        float f = 2.5f, fhex = 0x1p4f;
+        char a = 'A', tab = '\t', uni = 'A', emoji = 'x';
+        boolean t = true, ff = false;
+        String esc = "a\tb\n\"c\"\\d";
+        String block = """
+            line1
+              indented
+            line3""";
+        chk("lit_underscore_dec", dec == 1000000);
+        chk("lit_hex", hex == 255);
+        chk("lit_octal", oct == 15);
+        chk("lit_binary_underscore", bin == 170);
+        chk("lit_long", lng == 9000000000L);
+        chk("lit_long_hex", lhex == 3405691582L);
+        chk("lit_double_exp", d == 1500.0);
+        chk("lit_hex_float", hexf == 3.0);
+        chk("lit_double_neg_exp", neg == -0.025);
+        chk("lit_float", f == 2.5f);
+        chk("lit_float_hex", fhex == 16.0f);
+        chk("lit_char", a == 'A' && uni == 'A' && tab == 9);
+        chk("lit_bool", t && !ff);
+        chk("lit_string_escape", esc.indexOf('\t') == 1 && esc.contains("\"c\"") && esc.contains("\\d"));
+        chk("lit_text_block", block.equals("line1\n  indented\nline3"));
+        chk("lit_null", ((Object) null) == null);
+        chk("lit_unused_emoji", emoji == 'x');
+        golden("lit_block_lines", block.lines().count());
+        golden("lit_hex_float_val", hexf);
+        golden("lit_binary_val", bin);
+    }
+
+    // ====================================================================== //
+    //  MODULE 02 — primitive types, ranges, widening/narrowing, boxing        //
+    // ====================================================================== //
+    static void mPrimitives() {
+        chk("prim_byte_range", Byte.MIN_VALUE == -128 && Byte.MAX_VALUE == 127);
+        chk("prim_short_range", Short.MIN_VALUE == -32768 && Short.MAX_VALUE == 32767);
+        chk("prim_int_range", Integer.MIN_VALUE == -2147483648 && Integer.MAX_VALUE == 2147483647);
+        chk("prim_long_range", Long.MAX_VALUE == 9223372036854775807L);
+        chk("prim_char_range", Character.MIN_VALUE == 0 && Character.MAX_VALUE == 65535);
+        // widening (implicit)
+        int i = 100; long l = i; double dd = l; float ff = i;
+        chk("widen", l == 100L && dd == 100.0 && ff == 100.0f);
+        // narrowing (explicit cast) — deterministic wraparound
+        int big = 300; byte b = (byte) big; char c = (char) 65; int back = (int) 3.99;
+        chk("narrow", b == 44 && c == 'A' && back == 3);
+        // overflow wraparound (JLS two's complement)
+        chk("overflow_int", Integer.MAX_VALUE + 1 == Integer.MIN_VALUE);
+        chk("overflow_byte", (byte) 200 == -56);
+        // boxing / unboxing + Integer cache (-128..127 cached → ==; outside → !=)
+        Integer x1 = 100, x2 = 100, y1 = 200, y2 = 200;
+        chk("box_cache", x1 == x2 && y1 != y2 && y1.equals(y2));
+        // autounbox in arithmetic
+        Integer bx = 5; int sum = bx + 3;
+        chk("unbox_arith", sum == 8);
+        // mixed-type promotion
+        chk("promotion", (1 + 2.0) == 3.0 && ('a' + 1) == 98 && (1L + 2) == 3L);
+        // floating special values
+        chk("float_special", Double.isNaN(0.0 / 0.0) && Double.isInfinite(1.0 / 0.0) && (0.0 == -0.0)
+                && Double.compare(0.0, -0.0) == 1);
+        golden("prim_byte_wrap", (byte) 200);
+        golden("prim_int_overflow", Integer.MAX_VALUE + 1);
+        golden("prim_long_max", Long.MAX_VALUE);
+        golden("prim_char_max", (int) Character.MAX_VALUE);
+    }
+
+    // ====================================================================== //
+    //  MODULE 03 — operators                                                  //
+    // ====================================================================== //
+    static void mOperators() {
+        chk("op_arith", 7 / 2 == 3 && 7 % 2 == 1 && -7 / 2 == -3 && -7 % 2 == -1 && 2 * 3 + 1 == 7);
+        chk("op_bitwise", (0b1100 & 0b1010) == 0b1000 && (0b1100 | 0b1010) == 0b1110
+                && (0b1100 ^ 0b1010) == 0b0110 && (~0) == -1 && (~5) == -6);
+        chk("op_shift", (1 << 4) == 16 && (-8 >> 1) == -4 && (-1 >>> 28) == 15 && (1L << 40) == 1099511627776L);
+        chk("op_relational", 1 < 2 && 2 <= 2 && 3 > 2 && 3 >= 3 && 1 != 2 && 2 == 2);
+        chk("op_logical_shortcircuit", (true && true) && (false || true) && !false);
+        // short-circuit side effects
+        int[] cnt = {0};
+        boolean r1 = false && (cnt[0]++ > 0);   // RHS not evaluated
+        boolean r2 = true || (cnt[0]++ > 0);    // RHS not evaluated
+        chk("op_shortcircuit_eval", !r1 && r2 && cnt[0] == 0);
+        // non-short-circuit & |
+        chk("op_eager_logical", (true & true) && (false | true));
+        int x = 5;
+        x += 3; x -= 1; x *= 3; x /= 2; x %= 7; x <<= 2; x >>= 1; x &= 0xE; x |= 1; x ^= 2;
+        chk("op_compound_assign", x == 5);
+        chk("op_ternary", (3 > 2 ? "y" : "n").equals("y") && (1 > 2 ? 1 : 2) == 2);
+        chk("op_ternary_nested", (true ? false ? 1 : 2 : 3) == 2);
+        Object o = "str"; Object oi = 42;
+        chk("op_instanceof", o instanceof String && !(oi instanceof String) && oi instanceof Integer);
+        int a = 1; int b = a++ + ++a;       // 1 + 3
+        chk("op_inc_dec", a == 3 && b == 4);
+        int pre = 5; int post = 5;
+        chk("op_pre_post", --pre == 4 && post-- == 5 && post == 4);
+        // string concatenation operator
+        chk("op_string_concat", ("a" + 1 + 2).equals("a12") && (1 + 2 + "a").equals("3a"));
+        // compound on char
+        char ch = 'a'; ch += 2;
+        chk("op_compound_char", ch == 'c');
+        golden("op_neg_mod", -7 % 3);
+        golden("op_unsigned_shift", -1 >>> 28);
+        golden("op_long_shift", 1L << 40);
+    }
+
+    // ====================================================================== //
+    //  MODULE 04 — control flow                                               //
+    // ====================================================================== //
+    static void mControlFlow() {
+        int sum = 0; for (int i = 0; i < 5; i++) sum += i;
+        chk("ctrl_for", sum == 10);
+        int n = 0; while (n < 3) n++;
+        chk("ctrl_while", n == 3);
+        int m = 0; do { m++; } while (m < 2);
+        chk("ctrl_do_while", m == 2);
+        int es = 0; for (int v : new int[]{1, 2, 3, 4}) es += v;
+        chk("ctrl_enhanced_for_array", es == 10);
+        int cs = 0; for (Integer v : List.of(10, 20, 30)) cs += v;
+        chk("ctrl_enhanced_for_iterable", cs == 60);
+        // if / else if / else
+        String grade; int score = 85;
+        if (score >= 90) grade = "A"; else if (score >= 80) grade = "B"; else grade = "C";
+        chk("ctrl_if_elseif", grade.equals("B"));
+        // classic switch statement with fallthrough
+        String r; switch (2) { case 1: r = "a"; break; case 2: r = "b"; break; default: r = "z"; }
+        chk("ctrl_switch_stmt", r.equals("b"));
+        int fall = 0; switch (1) { case 1: fall++; case 2: fall++; break; case 3: fall++; }
+        chk("ctrl_switch_fallthrough", fall == 2);
+        // switch expression: arrow, multi-label, yield block
+        int code = switch (3) { case 1, 2 -> 10; case 3 -> { int y = 30; yield y; } default -> 0; };
+        chk("ctrl_switch_expr_yield", code == 30);
+        // switch expression on String + enum
+        String day = "WED"; int dn = switch (day) { case "MON", "TUE" -> 1; case "WED" -> 2; default -> 0; };
+        chk("ctrl_switch_string", dn == 2);
+        String opn = switch (Op.MUL) { case ADD -> "+"; case SUB -> "-"; case MUL -> "*"; };
+        chk("ctrl_switch_enum", opn.equals("*"));
+        // labeled break + continue
+        int found = -1;
+        outer: for (int i = 0; i < 4; i++) for (int j = 0; j < 4; j++) if (i + j == 3) { found = i * 10 + j; break outer; }
+        chk("ctrl_labeled_break", found == 3);
+        int skipped = 0;
+        loop: for (int i = 0; i < 5; i++) { if (i % 2 == 0) continue loop; skipped += i; }
+        chk("ctrl_labeled_continue", skipped == 4);
+        // ternary chain
+        golden("ctrl_grade", grade);
+        golden("ctrl_switch_result", code);
+    }
+
+    // ====================================================================== //
+    //  MODULE 05 — classes / interfaces / enums / records / sealed / nesting  //
+    // ====================================================================== //
+    static void mTypes() {
+        // record: accessors, equals, hashCode, toString, compact ctor validation
+        Frac h = Frac.half();
+        chk("record_accessor", h.num() == 1 && h.den() == 2 && h.val() == 0.5);
+        chk("record_equals_hash", new Frac(2, 4).equals(new Frac(2, 4)) && new Frac(2, 4).hashCode() == new Frac(2, 4).hashCode());
+        chk("record_toString", new Frac(3, 5).toString().equals("Frac[num=3, den=5]"));
+        boolean threw = false;
+        try { new Frac(1, 0); } catch (IllegalArgumentException e) { threw = e.getMessage().equals("den=0"); }
+        chk("record_compact_validate", threw);
+        // generic record
+        Pair<String, Integer> p = new Pair<>("x", 9);
+        chk("record_generic", p.first().equals("x") && p.second() == 9);
+        // sealed hierarchy evaluation
+        Expr ex = new Add(new Num(3), new Mul(new Num(4), new Num(5)));
+        chk("sealed_eval", eval(ex) == 23);
+        chk("sealed_permits", Expr.class.isSealed());
+        // enum with fields + abstract body
+        chk("enum_field_method", Op.ADD.apply(2, 3) == 5 && Op.SUB.apply(5, 2) == 3 && Op.MUL.apply(4, 3) == 12);
+        chk("enum_values_ordinal", Op.values().length == 3 && Op.MUL.ordinal() == 2 && Op.valueOf("ADD") == Op.ADD);
+        chk("enum_name", Op.SUB.name().equals("SUB"));
+        chk("enum_planet", Planet.EARTH.mass == 5.97e24 && Planet.values().length == 2);
+        // interface default/static/private
+        chk("iface_default_static_private", Greeter.of("sky").hi().equals("hi sky"));
+        // anonymous class implementing interface
+        Greeter anon = new Greeter() { public String name() { return "anon"; } };
+        chk("anonymous_class", anon.hi().equals("hi anon"));
+        // local class
+        class Local { final int base; Local(int b) { base = b; } int v() { return base + 99; } }
+        chk("local_class", new Local(1).v() == 100);
+        // inner (non-static) class capturing outer
+        JavaLangCarpet self = new JavaLangCarpet();
+        chk("inner_class", self.new Inner().read() == 1001);
+        // anonymous capturing effectively-final local
+        int captured = 7;
+        Supplier<Integer> sup = () -> captured + 1;
+        chk("lambda_capture", sup.get() == 8);
+        // initializers ran
+        chk("static_initializer", SINIT == 42);
+        chk("instance_initializer", new JavaLangCarpet().iinit == 7);
+        golden("record_toString_val", new Frac(3, 5).toString());
+        golden("sealed_eval_val", eval(ex));
+        golden("enum_ordinal_val", Op.MUL.ordinal());
+    }
+
+    // ====================================================================== //
+    //  MODULE 06 — generics: bounds, wildcards, inference, PECS               //
+    // ====================================================================== //
+    static void mGenerics() {
+        chk("gen_bounded_method", max(List.of(3, 9, 4, 7)) == 9 && max(List.of("b", "z", "a")).equals("z"));
+        chk("gen_wildcard_extends", sumNums(List.of(1, 2, 3.5)) == 6.5);
+        List<Number> sink = new ArrayList<>(); addInts(sink);
+        chk("gen_wildcard_super", sink.equals(List.of(1, 2)));
+        chk("gen_method_inference", mapAll(List.of(1, 2, 3), i -> i * i).equals(List.of(1, 4, 9)));
+        chk("gen_class_bound", new Box<>(21).dbl() == 42.0 && new Box<>(1.5).dbl() == 3.0);
+        chk("gen_recursive_bound", new Holder<>().depth() == 1);
+        // diamond + nested generics
+        Map<String, List<Integer>> nested = new HashMap<>();
+        nested.computeIfAbsent("k", x -> new ArrayList<>()).add(5);
+        chk("gen_diamond_nested", nested.get("k").equals(List.of(5)));
+        // generic array via toArray
+        Integer[] arr = List.of(1, 2, 3).toArray(new Integer[0]);
+        chk("gen_toarray", arr.length == 3 && arr[1] == 2);
+        golden("gen_max_val", max(List.of(3, 9, 4, 7)));
+        golden("gen_mapped", mapAll(List.of(1, 2, 3), i -> i * i));
+    }
+
+    // ====================================================================== //
+    //  MODULE 07 — lambdas, method refs, functional interfaces               //
+    // ====================================================================== //
+    static void mFunctional() {
+        Function<Integer, Integer> inc = i -> i + 1;
+        Function<Integer, Integer> dbl = i -> i * 2;
+        chk("fn_compose", inc.andThen(dbl).apply(3) == 8 && inc.compose(dbl).apply(3) == 7);
+        BiFunction<Integer, Integer, Integer> add = Integer::sum;      // static method ref
+        chk("fn_bifunction_staticref", add.apply(2, 3) == 5);
+        Supplier<List<Integer>> sup = ArrayList::new;                  // ctor ref
+        chk("fn_supplier_ctorref", sup.get().isEmpty());
+        Function<String, Integer> len = String::length;               // unbound instance ref
+        chk("fn_unbound_instance_ref", len.apply("hello") == 5);
+        String prefix = "pre-";
+        Function<String, String> bound = prefix::concat;              // bound instance ref
+        chk("fn_bound_instance_ref", bound.apply("fix").equals("pre-fix"));
+        Predicate<Integer> even = i -> i % 2 == 0;
+        chk("fn_predicate", even.test(4) && even.negate().test(3) && even.and(i -> i > 0).test(2) && even.or(i -> i > 5).test(7));
+        Consumer<StringBuilder> app = sb -> sb.append("x");
+        StringBuilder cb = new StringBuilder(); app.andThen(s -> s.append("y")).accept(cb);
+        chk("fn_consumer", cb.toString().equals("xy"));
+        UnaryOperator<Integer> sq = i -> i * i;
+        BinaryOperator<Integer> mx = BinaryOperator.maxBy(Comparator.naturalOrder());
+        chk("fn_unary_binary", sq.apply(5) == 25 && mx.apply(3, 8) == 8);
+        // primitive functional interfaces
+        IntUnaryOperator iuo = i -> i + 10; ToIntFunction<String> tif = String::length;
+        IntBinaryOperator ibo = (a, b) -> a * b; IntPredicate ip = i -> i > 0;
+        chk("fn_primitive", iuo.applyAsInt(5) == 15 && tif.applyAsInt("abcd") == 4 && ibo.applyAsInt(6, 7) == 42 && ip.test(1));
+        // custom SAM
+        TriFn<Integer, Integer, Integer, Integer> tri = (a, b, c) -> a + b + c;
+        chk("fn_custom_sam", tri.apply(1, 2, 3) == 6);
+        // BiConsumer / BiPredicate
+        Map<String, Integer> mm = new TreeMap<>(); mm.put("a", 1); mm.put("b", 2);
+        int[] tot = {0}; mm.forEach((k, v) -> tot[0] += v);
+        chk("fn_biconsumer", tot[0] == 3);
+        BiPredicate<String, Integer> bp = (s, n) -> s.length() == n;
+        chk("fn_bipredicate", bp.test("abc", 3));
+        golden("fn_compose_val", inc.andThen(dbl).apply(3));
+        golden("fn_predicate_chain", even.and(i -> i > 0).test(2));
+    }
+
+    // ====================================================================== //
+    //  MODULE 08 — streams                                                    //
+    // ====================================================================== //
+    static void mStreams() {
+        List<Integer> xs = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        chk("stream_filter_count", xs.stream().filter(i -> i % 2 == 0).count() == 5);
+        chk("stream_map_collect", xs.stream().map(i -> i * i).collect(Collectors.toList()).equals(List.of(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)));
+        chk("stream_reduce_methodref", xs.stream().reduce(0, Integer::sum) == 55);
+        chk("stream_reduce_mul", xs.stream().limit(5).reduce(1, (a, b) -> a * b) == 120);
+        chk("stream_toList", xs.stream().limit(3).toList().equals(List.of(1, 2, 3)));
+        chk("stream_flatMap", Stream.of(List.of(1, 2), List.of(3, 4)).flatMap(List::stream).toList().equals(List.of(1, 2, 3, 4)));
+        chk("stream_distinct", Stream.of(1, 1, 2, 2, 3).distinct().toList().equals(List.of(1, 2, 3)));
+        chk("stream_sorted", Stream.of(3, 1, 2).sorted().toList().equals(List.of(1, 2, 3)));
+        chk("stream_sorted_comp", Stream.of("bb", "a", "ccc").sorted(Comparator.comparingInt(String::length)).toList().equals(List.of("a", "bb", "ccc")));
+        chk("stream_skip_limit", IntStream.range(0, 10).skip(7).boxed().toList().equals(List.of(7, 8, 9)));
+        chk("stream_anyAllNone", Stream.of(2, 4, 6).allMatch(i -> i % 2 == 0) && Stream.of(1, 2, 3).anyMatch(i -> i > 2) && Stream.of(1, 2, 3).noneMatch(i -> i > 5));
+        chk("stream_min_max", Stream.of(3, 1, 2).min(Integer::compare).get() == 1 && Stream.of(3, 1, 2).max(Integer::compare).get() == 3);
+        chk("stream_iterate", Stream.iterate(1, x -> x * 2).limit(5).toList().equals(List.of(1, 2, 4, 8, 16)));
+        chk("stream_generate", Stream.generate(() -> 7).limit(3).toList().equals(List.of(7, 7, 7)));
+        chk("stream_takeWhile", Stream.of(1, 2, 3, 4, 1).takeWhile(i -> i < 4).toList().equals(List.of(1, 2, 3)));
+        chk("stream_dropWhile", Stream.of(1, 2, 3, 4, 1).dropWhile(i -> i < 4).toList().equals(List.of(4, 1)));
+        chk("stream_findFirst", xs.stream().filter(i -> i > 3).findFirst().get() == 4);
+        chk("stream_mapToObj", IntStream.range(0, 3).mapToObj(i -> "x" + i).toList().equals(List.of("x0", "x1", "x2")));
+        chk("stream_intstream_sum", IntStream.rangeClosed(1, 100).sum() == 5050);
+        chk("stream_longstream", LongStream.rangeClosed(1, 10).reduce(0, Long::sum) == 55L);
+        chk("stream_count_chars", "banana".chars().filter(c -> c == 'a').count() == 3);
+        // Collectors
+        List<String> words = List.of("apple", "banana", "cherry", "avocado", "blueberry");
+        chk("coll_groupingBy", new TreeMap<>(words.stream().collect(Collectors.groupingBy(w -> w.charAt(0)))).toString().equals("{a=[apple, avocado], b=[banana, blueberry], c=[cherry]}"));
+        chk("coll_groupingCount", new TreeMap<>(words.stream().collect(Collectors.groupingBy(w -> w.charAt(0), Collectors.counting()))).toString().equals("{a=2, b=2, c=1}"));
+        chk("coll_partitioningBy", IntStream.rangeClosed(1, 10).boxed().collect(Collectors.partitioningBy(i -> i % 2 == 0)).toString().equals("{false=[1, 3, 5, 7, 9], true=[2, 4, 6, 8, 10]}"));
+        chk("coll_joining", words.stream().collect(Collectors.joining(", ", "[", "]")).equals("[apple, banana, cherry, avocado, blueberry]"));
+        chk("coll_toMap", new TreeMap<>(words.stream().collect(Collectors.toMap(w -> w, String::length))).toString().equals("{apple=5, avocado=7, banana=6, blueberry=9, cherry=6}"));
+        chk("coll_averaging", words.stream().collect(Collectors.averagingInt(String::length)) == 6.6);
+        chk("coll_summing", words.stream().collect(Collectors.summingInt(String::length)) == 33);
+        chk("coll_mapping", new TreeMap<>(words.stream().collect(Collectors.groupingBy(w -> w.charAt(0), Collectors.mapping(String::length, Collectors.toList())))).toString().equals("{a=[5, 7], b=[6, 9], c=[6]}"));
+        chk("coll_toCollection", words.stream().map(String::length).collect(Collectors.toCollection(TreeSet::new)).toString().equals("[5, 6, 7, 9]"));
+        DoubleSummaryStatistics st = IntStream.rangeClosed(1, 5).asDoubleStream().summaryStatistics();
+        chk("coll_stats", st.getSum() == 15.0 && st.getAverage() == 3.0 && st.getMin() == 1.0 && st.getMax() == 5.0 && st.getCount() == 5);
+        // golden lines (deterministic stringified)
+        golden("stream_sum", xs.stream().reduce(0, Integer::sum));
+        golden("stream_squares", xs.stream().map(i -> i * i).toList());
+        golden("coll_grouping", new TreeMap<>(words.stream().collect(Collectors.groupingBy(w -> w.charAt(0)))));
+        golden("coll_partition", IntStream.rangeClosed(1, 10).boxed().collect(Collectors.partitioningBy(i -> i % 2 == 0)));
+    }
+
+    // ====================================================================== //
+    //  MODULE 09 — Optional                                                   //
+    // ====================================================================== //
+    static void mOptional() {
+        Optional<Integer> some = Optional.of(5), none = Optional.empty();
+        chk("opt_present", some.isPresent() && some.get() == 5 && none.isEmpty());
+        chk("opt_orElse", none.orElse(99) == 99 && some.orElse(99) == 5);
+        chk("opt_map", some.map(i -> i * 2).get() == 10 && none.map(i -> i * 2).isEmpty());
+        chk("opt_filter", some.filter(i -> i > 3).isPresent() && some.filter(i -> i > 10).isEmpty());
+        chk("opt_flatMap", some.flatMap(i -> Optional.of(i + 1)).get() == 6);
+        chk("opt_orElseGet", none.orElseGet(() -> 7) == 7);
+        chk("opt_ofNullable", Optional.ofNullable(null).isEmpty() && Optional.ofNullable("x").isPresent());
+        boolean threw = false; try { none.orElseThrow(); } catch (NoSuchElementException e) { threw = true; }
+        chk("opt_orElseThrow", threw);
+        int[] acc = {0}; some.ifPresent(v -> acc[0] = v); none.ifPresentOrElse(v -> acc[0] = -1, () -> acc[0] += 100);
+        chk("opt_ifPresent", acc[0] == 105);
+        golden("opt_chain", some.map(i -> i * 2).filter(i -> i > 5).orElse(-1));
+    }
+
+    // ====================================================================== //
+    //  MODULE 10 — pattern matching (instanceof; switch-pattern reflection)   //
+    // ====================================================================== //
+    static void mPatterns() {
+        // instanceof pattern binding (JDK16+, valid at --release 17)
+        Object o = "hello";
+        chk("pat_instanceof_bind", o instanceof String s && s.length() == 5);
+        Object n = 42;
+        String desc = (n instanceof Integer i && i > 10) ? "big-int:" + i : "other";
+        chk("pat_instanceof_guard", desc.equals("big-int:42"));
+        // instanceof pattern with negation flow-scoping
+        Object x = List.of(1, 2, 3);
+        if (!(x instanceof List<?> lst)) { chk("pat_neg_scope", false); }
+        else { chk("pat_neg_scope", lst.size() == 3); }
+        // nested instanceof over a sealed type
+        Expr e = new Add(new Num(1), new Num(2));
+        String tag = (e instanceof Add a && a.l() instanceof Num ln) ? "add-of-num:" + ln.v() : "?";
+        chk("pat_nested_instanceof", tag.equals("add-of-num:1"));
+        golden("pat_desc", desc);
+        // JDK21+ switch pattern matching syntax cannot live in a --release 17 class.
+        // Verified by Jdk21Features.java (--release 21) in the openjdk-multi rootfs; the
+        // runtime presence of pattern-switch support is probed below in mVersionGated().
+    }
+
+    // ====================================================================== //
+    //  MODULE 11 — exceptions / try-with-resources / chaining                 //
+    // ====================================================================== //
+    static class AppException extends Exception {
+        AppException(String m, Throwable cause) { super(m, cause); }
+    }
+    static void mExceptions() {
+        // try-with-resources closes in reverse order
+        StringBuilder log = new StringBuilder();
+        try (Res a = new Res(log, "A"); Res b = new Res(log, "B")) { log.append("body;"); }
+        chk("exc_twr_order", log.toString().equals("openA;openB;body;closeB;closeA;"));
+        // multi-catch
+        String caught = "";
+        try { throw new NumberFormatException("x"); }
+        catch (IllegalStateException | NumberFormatException ex) { caught = ex.getClass().getSimpleName(); }
+        chk("exc_multi_catch", caught.equals("NumberFormatException"));
+        // finally always runs
+        boolean fin = false;
+        try { int z = 1 / 0; } catch (ArithmeticException ex) { } finally { fin = true; }
+        chk("exc_finally", fin);
+        // finally overrides return path
+        chk("exc_finally_value", finallyReturn() == 2);
+        // custom checked exception with cause chaining
+        Throwable cause = null;
+        try { try { throw new IllegalStateException("root"); } catch (Exception inner) { throw new AppException("wrap", inner); } }
+        catch (AppException ex) { cause = ex.getCause(); }
+        chk("exc_chaining", cause instanceof IllegalStateException && cause.getMessage().equals("root"));
+        // suppressed exceptions from try-with-resources
+        boolean suppressed = false;
+        try { try (AutoCloseable r = () -> { throw new RuntimeException("close-fail"); }) { throw new RuntimeException("body-fail"); } }
+        catch (Exception ex) { suppressed = ex.getMessage().equals("body-fail") && ex.getSuppressed().length == 1; }
+        chk("exc_suppressed", suppressed);
+        // NPE / ClassCast / ArrayIndex / ArithmeticException catches
+        chk("exc_npe", catchType(() -> { String z = null; z.length(); }).equals("NullPointerException"));
+        chk("exc_aioobe", catchType(() -> { int[] arr = new int[1]; int v = arr[5]; }).equals("ArrayIndexOutOfBoundsException"));
+        chk("exc_cce", catchType(() -> { Object oo = "s"; Integer ii = (Integer) oo; }).equals("ClassCastException"));
+        chk("exc_arith", catchType(() -> { int v = 1 / 0; }).equals("ArithmeticException"));
+        golden("exc_twr_log", log.toString());
+        golden("exc_finally_ret", finallyReturn());
+    }
+    static int finallyReturn() { try { return 1; } finally { return 2; } }
+    static String catchType(Runnable r) { try { r.run(); return "none"; } catch (Throwable t) { return t.getClass().getSimpleName(); } }
+
+    // ====================================================================== //
+    //  MODULE 12 — annotations + reflection                                   //
+    // ====================================================================== //
+    static void mReflection() throws Exception {
+        Tag tg = Annotated.class.getAnnotation(Tag.class);
+        chk("ann_runtime_members", tg != null && tg.value().equals("cls") && tg.n() == 5);
+        Mark[] marks = Repeated.class.getAnnotationsByType(Mark.class);
+        chk("ann_repeatable", marks.length == 3 && marks[0].value().equals("a") && marks[2].value().equals("c"));
+        Method mm = JavaLangCarpet.class.getDeclaredMethod("addOne", int.class);
+        chk("refl_method_sig", mm.getReturnType() == int.class && mm.getParameterCount() == 1);
+        chk("refl_invoke", ((Integer) mm.invoke(null, 41)) == 42);
+        Class<?> c = Class.forName("java.lang.String");
+        chk("refl_forName", c.getSimpleName().equals("String"));
+        chk("refl_isAssignable", Number.class.isAssignableFrom(Integer.class) && !Integer.class.isAssignableFrom(Number.class));
+        chk("refl_interfaces", List.of(JavaLangCarpet.class.getDeclaredClasses()).stream().anyMatch(k -> k.getSimpleName().equals("Frac")));
+        // record components via reflection
+        RecordComponent[] rcs = Frac.class.getRecordComponents();
+        chk("refl_record_components", rcs.length == 2 && rcs[0].getName().equals("num") && rcs[1].getName().equals("den"));
+        chk("refl_isRecord_isEnum", Frac.class.isRecord() && Op.class.isEnum());
+        // construct via reflection
+        Object inst = Frac.class.getDeclaredConstructor(int.class, int.class).newInstance(3, 4);
+        chk("refl_newInstance", inst.toString().equals("Frac[num=3, den=4]"));
+        // field access
+        Field f = JavaLangCarpet.class.getDeclaredField("SINIT");
+        chk("refl_field", f.getInt(null) == 42);
+        // array reflection
+        Object arr = Array.newInstance(int.class, 3); Array.setInt(arr, 1, 99);
+        chk("refl_array", Array.getInt(arr, 1) == 99 && Array.getLength(arr) == 3);
+        golden("refl_invoke_val", mm.invoke(null, 41));
+        golden("refl_record_names", rcs[0].getName() + "," + rcs[1].getName());
+    }
+    static int addOne(int x) { return x + 1; }
+
+    // ====================================================================== //
+    //  MODULE 13 — collections (List/Map/Set/Deque/Queue/Tree/Comparator)     //
+    // ====================================================================== //
+    static void mCollections() {
+        // List
+        List<Integer> l = new ArrayList<>(List.of(5, 3, 1, 4, 2));
+        Collections.sort(l); chk("list_sort", l.equals(List.of(1, 2, 3, 4, 5)));
+        Collections.reverse(l); chk("list_reverse", l.equals(List.of(5, 4, 3, 2, 1)));
+        chk("list_max_min", Collections.max(l) == 5 && Collections.min(l) == 1);
+        l.removeIf(i -> i % 2 == 0); chk("list_removeIf", l.equals(List.of(5, 3, 1)));
+        List<Integer> l2 = new ArrayList<>(List.of(1, 2, 3)); l2.replaceAll(i -> i * 10);
+        chk("list_replaceAll", l2.equals(List.of(10, 20, 30)));
+        chk("list_binarySearch", Collections.binarySearch(List.of(1, 3, 5, 7, 9), 5) == 2);
+        chk("list_subList", new ArrayList<>(List.of(0, 1, 2, 3, 4, 5)).subList(1, 4).equals(List.of(1, 2, 3)));
+        chk("list_indexOf", List.of("a", "b", "c", "b").indexOf("b") == 1 && List.of("a", "b", "c", "b").lastIndexOf("b") == 3);
+        List<Integer> ll = new LinkedList<>(List.of(1, 2, 3)); ll.add(0, 0);
+        chk("list_linkedlist", ll.equals(List.of(0, 1, 2, 3)));
+        // Map
+        Map<String, Integer> m = new TreeMap<>();
+        m.put("a", 1); m.merge("a", 10, Integer::sum); m.computeIfAbsent("b", k -> 2); m.compute("a", (k, v) -> v + 1);
+        chk("map_merge_compute", m.toString().equals("{a=12, b=2}"));
+        chk("map_getOrDefault", m.getOrDefault("z", 99) == 99 && m.getOrDefault("a", 0) == 12);
+        m.putIfAbsent("c", 3); m.putIfAbsent("a", 100);
+        chk("map_putIfAbsent", m.toString().equals("{a=12, b=2, c=3}"));
+        chk("map_containsKey_value", m.containsKey("a") && m.containsValue(12) && !m.containsKey("z"));
+        chk("map_keySet_values", m.keySet().toString().equals("[a, b, c]") && new ArrayList<>(m.values()).equals(List.of(12, 2, 3)));
+        // entrySet iteration (TreeMap = sorted, deterministic)
+        StringBuilder es = new StringBuilder();
+        for (Map.Entry<String, Integer> e : m.entrySet()) es.append(e.getKey()).append(e.getValue()).append(";");
+        chk("map_entrySet", es.toString().equals("a12;b2;c3;"));
+        // TreeMap navigation
+        TreeMap<Integer, String> tm = new TreeMap<>();
+        for (int i = 1; i <= 10; i++) tm.put(i * 10, "v" + i);
+        chk("treemap_nav", tm.firstKey() == 10 && tm.lastKey() == 100 && tm.floorKey(55) == 50 && tm.ceilingKey(55) == 60 && tm.lowerKey(50) == 40 && tm.higherKey(50) == 60);
+        chk("treemap_headTail", tm.headMap(30).toString().equals("{10=v1, 20=v2}") && tm.tailMap(80).toString().equals("{80=v8, 90=v9, 100=v10}"));
+        chk("treemap_subMap", tm.subMap(20, 50).toString().equals("{20=v2, 30=v3, 40=v4}"));
+        chk("treemap_descending", tm.descendingKeySet().toString().equals("[100, 90, 80, 70, 60, 50, 40, 30, 20, 10]"));
+        // LinkedHashMap insertion order
+        LinkedHashMap<String, Integer> lhm = new LinkedHashMap<>(); lhm.put("z", 1); lhm.put("a", 2); lhm.put("m", 3);
+        chk("linkedhashmap_order", lhm.toString().equals("{z=1, a=2, m=3}"));
+        // Set operations
+        Set<Integer> s1 = new TreeSet<>(List.of(1, 2, 3, 4)), s2 = new TreeSet<>(List.of(3, 4, 5, 6));
+        Set<Integer> inter = new TreeSet<>(s1); inter.retainAll(s2);
+        Set<Integer> uni = new TreeSet<>(s1); uni.addAll(s2);
+        Set<Integer> diff = new TreeSet<>(s1); diff.removeAll(s2);
+        chk("set_ops", inter.toString().equals("[3, 4]") && uni.toString().equals("[1, 2, 3, 4, 5, 6]") && diff.toString().equals("[1, 2]"));
+        chk("treeset_nav", ((TreeSet<Integer>) s1).first() == 1 && ((TreeSet<Integer>) s1).last() == 4);
+        chk("set_contains", s1.contains(2) && !s1.contains(9));
+        // Deque + stack/queue protocols
+        Deque<Integer> dq = new ArrayDeque<>();
+        dq.offerFirst(1); dq.offerLast(2); dq.addFirst(0); dq.addLast(3);
+        chk("deque_order", dq.toString().equals("[0, 1, 2, 3]") && dq.peekFirst() == 0 && dq.peekLast() == 3);
+        chk("deque_poll", dq.pollFirst() == 0 && dq.pollLast() == 3 && dq.toString().equals("[1, 2]"));
+        Deque<Integer> stack = new ArrayDeque<>(); stack.push(1); stack.push(2); stack.push(3);
+        chk("deque_stack", stack.pop() == 3 && stack.peek() == 2);
+        // PriorityQueue
+        PriorityQueue<Integer> pq = new PriorityQueue<>(List.of(5, 1, 3, 2, 4));
+        StringBuilder pqsb = new StringBuilder(); while (!pq.isEmpty()) pqsb.append(pq.poll());
+        chk("priorityqueue", pqsb.toString().equals("12345"));
+        PriorityQueue<Integer> pqr = new PriorityQueue<>(Comparator.reverseOrder()); pqr.addAll(List.of(1, 5, 3));
+        chk("priorityqueue_comparator", pqr.poll() == 5);
+        // Comparator chaining
+        List<String> ws = new ArrayList<>(List.of("bb", "a", "ccc", "dd"));
+        ws.sort(Comparator.comparingInt(String::length).thenComparing(Comparator.naturalOrder()));
+        chk("comparator_chain", ws.equals(List.of("a", "bb", "dd", "ccc")));
+        ws.sort(Comparator.reverseOrder());
+        chk("comparator_reverse", ws.equals(List.of("dd", "ccc", "bb", "a")));
+        // EnumSet / EnumMap
+        EnumSet<Op> ops = EnumSet.of(Op.ADD, Op.MUL);
+        chk("enumset", ops.contains(Op.ADD) && !ops.contains(Op.SUB) && ops.size() == 2);
+        EnumMap<Op, String> em = new EnumMap<>(Op.class); em.put(Op.MUL, "*"); em.put(Op.ADD, "+");
+        chk("enummap_order", em.toString().equals("{ADD=+, MUL=*}"));
+        // Iterator + ListIterator
+        Iterator<Integer> it = List.of(10, 20, 30).iterator(); int sum = 0; while (it.hasNext()) sum += it.next();
+        chk("iterator", sum == 60);
+        // Collections utilities
+        chk("collections_unmodifiable", catchType(() -> List.of(1).add(2)).equals("UnsupportedOperationException"));
+        chk("collections_freq_swap", Collections.frequency(List.of(1, 2, 2, 3, 2), 2) == 3);
+        golden("collections_map", m);
+        golden("collections_treemap_floor", tm.floorKey(55));
+        golden("collections_pq_order", pqsb.toString());
+    }
+
+    // ====================================================================== //
+    //  MODULE 14 — concurrency                                                //
+    // ====================================================================== //
+    static void mConcurrency() throws Exception {
+        // ExecutorService + AtomicInteger + CountDownLatch
+        AtomicInteger counter = new AtomicInteger(0);
+        int N = 16;
+        CountDownLatch latch = new CountDownLatch(N);
+        ExecutorService ex = Executors.newFixedThreadPool(4);
+        for (int i = 0; i < N; i++) ex.submit(() -> { counter.incrementAndGet(); latch.countDown(); });
+        boolean done = latch.await(30, TimeUnit.SECONDS);
+        ex.shutdown();
+        chk("conc_executor_atomic", done && counter.get() == N);
+        // atomics: CAS, getAndAdd, accumulate
+        AtomicInteger ai = new AtomicInteger(10);
+        chk("conc_atomic_cas", ai.compareAndSet(10, 20) && ai.get() == 20 && ai.getAndAdd(5) == 20 && ai.get() == 25);
+        AtomicLong al = new AtomicLong(0); al.addAndGet(100);
+        chk("conc_atomiclong", al.get() == 100);
+        AtomicReference<String> ar = new AtomicReference<>("a"); ar.set("b");
+        chk("conc_atomicref", ar.get().equals("b") && ar.compareAndSet("b", "c") && ar.get().equals("c"));
+        AtomicInteger acc = new AtomicInteger(1); acc.accumulateAndGet(5, (a, b) -> a * b);
+        chk("conc_accumulate", acc.get() == 5);
+        // CompletableFuture chaining
+        CompletableFuture<Integer> cf = CompletableFuture.supplyAsync(() -> 20).thenApply(v -> v + 1).thenApply(v -> v * 2);
+        chk("conc_completablefuture", cf.get(30, TimeUnit.SECONDS) == 42);
+        CompletableFuture<Integer> combined = CompletableFuture.supplyAsync(() -> 3)
+                .thenCombine(CompletableFuture.supplyAsync(() -> 4), (a, b) -> a * b);
+        chk("conc_cf_combine", combined.get(30, TimeUnit.SECONDS) == 12);
+        chk("conc_cf_allOf", cfAllOf());
+        // ConcurrentHashMap parallel accumulation
+        ConcurrentHashMap<String, Integer> chm = new ConcurrentHashMap<>();
+        ExecutorService ex2 = Executors.newFixedThreadPool(4);
+        CountDownLatch l2 = new CountDownLatch(100);
+        for (int i = 0; i < 100; i++) ex2.submit(() -> { chm.merge("k", 1, Integer::sum); l2.countDown(); });
+        l2.await(30, TimeUnit.SECONDS); ex2.shutdown();
+        chk("conc_concurrenthashmap", chm.get("k") == 100);
+        // ReentrantLock
+        ReentrantLock lock = new ReentrantLock(); int[] guarded = {0};
+        ExecutorService ex3 = Executors.newFixedThreadPool(4);
+        CountDownLatch l3 = new CountDownLatch(200);
+        for (int i = 0; i < 200; i++) ex3.submit(() -> { lock.lock(); try { guarded[0]++; } finally { lock.unlock(); } l3.countDown(); });
+        l3.await(30, TimeUnit.SECONDS); ex3.shutdown();
+        chk("conc_reentrantlock", guarded[0] == 200);
+        // ReadWriteLock smoke
+        ReadWriteLock rw = new ReentrantReadWriteLock();
+        rw.readLock().lock(); rw.readLock().unlock(); rw.writeLock().lock(); rw.writeLock().unlock();
+        chk("conc_readwritelock", true);
+        // Semaphore
+        Semaphore sem = new Semaphore(2);
+        chk("conc_semaphore", sem.tryAcquire() && sem.tryAcquire() && !sem.tryAcquire());
+        sem.release(2);
+        // synchronized block + Thread.join
+        final Object mon = new Object(); int[] shared = {0};
+        List<Thread> ths = new ArrayList<>();
+        for (int i = 0; i < 8; i++) { Thread th = new Thread(() -> { for (int k = 0; k < 1000; k++) synchronized (mon) { shared[0]++; } }); ths.add(th); th.start(); }
+        for (Thread th : ths) th.join();
+        chk("conc_synchronized", shared[0] == 8000);
+        // Callable + Future
+        ExecutorService ex4 = Executors.newSingleThreadExecutor();
+        Future<Integer> fut = ex4.submit(() -> 6 * 7);
+        chk("conc_callable_future", fut.get(30, TimeUnit.SECONDS) == 42);
+        ex4.shutdown();
+        // invokeAll
+        ExecutorService ex5 = Executors.newFixedThreadPool(3);
+        List<Callable<Integer>> tasks = List.of(() -> 1, () -> 2, () -> 3);
+        int s = 0; for (Future<Integer> r : ex5.invokeAll(tasks)) s += r.get();
+        ex5.shutdown();
+        chk("conc_invokeAll", s == 6);
+        golden("conc_counter", N);
+        golden("conc_chm", chm.get("k"));
+        golden("conc_synchronized_total", shared[0]);
+    }
+    static boolean cfAllOf() throws Exception {
+        AtomicInteger sum = new AtomicInteger();
+        CompletableFuture<?>[] fs = new CompletableFuture[5];
+        for (int i = 0; i < 5; i++) { int n = i + 1; fs[i] = CompletableFuture.runAsync(() -> sum.addAndGet(n)); }
+        CompletableFuture.allOf(fs).get(30, TimeUnit.SECONDS);
+        return sum.get() == 15;
+    }
+
+    // ====================================================================== //
+    //  MODULE 15 — java.time                                                  //
+    // ====================================================================== //
+    static void mTime() {
+        LocalDate d = LocalDate.of(2024, 2, 29);
+        chk("time_localdate", d.isLeapYear() && d.getDayOfWeek() == DayOfWeek.THURSDAY && d.getDayOfYear() == 60);
+        chk("time_localdate_arith", d.plusDays(1).toString().equals("2024-03-01") && d.plusMonths(1).toString().equals("2024-03-29") && d.minusYears(1).toString().equals("2023-02-28"));
+        LocalDateTime dt = LocalDateTime.of(2024, 1, 15, 10, 30, 45);
+        chk("time_localdatetime", dt.getHour() == 10 && dt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME).equals("2024-01-15T10:30:45"));
+        chk("time_format_custom", dt.format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")).equals("2024/01/15 10:30"));
+        Duration dur = Duration.ofHours(2).plusMinutes(30);
+        chk("time_duration", dur.toMinutes() == 150 && dur.toString().equals("PT2H30M"));
+        Period p = Period.of(1, 2, 3);
+        chk("time_period", p.getMonths() == 2 && p.toTotalMonths() == 14);
+        chk("time_chronounit", ChronoUnit.DAYS.between(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 11)) == 10);
+        chk("time_parse", LocalDate.parse("2023-06-15").getMonthValue() == 6 && LocalDate.parse("2023-06-15").getYear() == 2023);
+        chk("time_instant", Instant.ofEpochSecond(1000000000L).toString().equals("2001-09-09T01:46:40Z"));
+        chk("time_compare", LocalDate.of(2024, 1, 1).isBefore(LocalDate.of(2024, 12, 31)) && LocalDate.of(2024, 12, 31).isAfter(LocalDate.of(2024, 1, 1)));
+        LocalTime t = LocalTime.of(23, 59, 59);
+        chk("time_localtime", t.plusSeconds(1).toString().equals("00:00") && t.getMinute() == 59);
+        golden("time_date_plus", d.plusDays(1));
+        golden("time_duration_min", dur.toMinutes());
+        golden("time_instant_str", Instant.ofEpochSecond(1000000000L));
+    }
+
+    // ====================================================================== //
+    //  MODULE 16 — java.util.regex                                            //
+    // ====================================================================== //
+    static void mRegex() {
+        chk("re_matches", Pattern.matches("\\d+", "12345") && !Pattern.matches("\\d+", "12a45"));
+        Matcher m = Pattern.compile("(\\w+)@(\\w+)").matcher("user@host");
+        chk("re_groups", m.find() && m.group(1).equals("user") && m.group(2).equals("host") && m.groupCount() == 2);
+        chk("re_replaceAll", "a1b2c3".replaceAll("\\d", "#").equals("a#b#c#"));
+        chk("re_replaceFirst", "a1b2c3".replaceFirst("\\d", "#").equals("a#b2c3"));
+        chk("re_split", Arrays.toString("a,b,,c".split(",")).equals("[a, b, , c]"));
+        chk("re_split_limit", Arrays.toString("a,b,c".split(",", 2)).equals("[a, b,c]"));
+        Pattern named = Pattern.compile("(?<year>\\d{4})-(?<mon>\\d{2})");
+        Matcher nm = named.matcher("2024-03");
+        chk("re_named_groups", nm.find() && nm.group("year").equals("2024") && nm.group("mon").equals("03"));
+        chk("re_results_count", Pattern.compile("a").matcher("banana").results().count() == 3);
+        chk("re_flags", Pattern.compile("HELLO", Pattern.CASE_INSENSITIVE).matcher("hello world").find());
+        chk("re_anchors", Pattern.matches("^\\d+$", "999") && !Pattern.matches("^\\d+$", "9a9"));
+        chk("re_quantifiers", "aaa".matches("a{2,3}") && !"a".matches("a{2,3}"));
+        chk("re_alternation", "cat".matches("cat|dog") && "dog".matches("cat|dog"));
+        chk("re_charclass", "abc123".replaceAll("[a-z]", "_").equals("___123"));
+        // replaceAll with backreference
+        chk("re_backref", "John Smith".replaceAll("(\\w+) (\\w+)", "$2 $1").equals("Smith John"));
+        golden("re_replace", "a1b2c3".replaceAll("\\d", "#"));
+        golden("re_named", Pattern.compile("(?<y>\\d{4})").matcher("2024").results().count());
+    }
+
+    // ====================================================================== //
+    //  MODULE 17 — java.nio basics (charsets, ByteBuffer, Base64)             //
+    // ====================================================================== //
+    static void mNio() {
+        byte[] bytes = "héllo".getBytes(StandardCharsets.UTF_8);
+        chk("nio_utf8_encode", bytes.length == 6);
+        chk("nio_utf8_roundtrip", new String(bytes, StandardCharsets.UTF_8).equals("héllo"));
+        chk("nio_ascii", "abc".getBytes(StandardCharsets.US_ASCII).length == 3);
+        ByteBuffer bb = ByteBuffer.allocate(16);
+        bb.putInt(42); bb.putLong(99L); bb.putShort((short) 7); bb.flip();
+        chk("nio_bytebuffer", bb.getInt() == 42 && bb.getLong() == 99L && bb.getShort() == 7);
+        ByteBuffer order = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+        order.putInt(1); chk("nio_byteorder", order.get(0) == 1 && order.get(3) == 0);
+        IntBuffer ib = IntBuffer.wrap(new int[]{1, 2, 3});
+        chk("nio_intbuffer", ib.get(0) == 1 && ib.capacity() == 3);
+        chk("nio_base64_encode", Base64.getEncoder().encodeToString("hi".getBytes()).equals("aGk="));
+        chk("nio_base64_decode", new String(Base64.getDecoder().decode("aGk=")).equals("hi"));
+        chk("nio_base64_url", Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[]{-1, -2}).equals("__4"));
+        golden("nio_utf8_len", bytes.length);
+        golden("nio_base64", Base64.getEncoder().encodeToString("hi".getBytes()));
+    }
+
+    // ====================================================================== //
+    //  MODULE 18 — String / StringBuilder / formatting                        //
+    // ====================================================================== //
+    static void mStrings() {
+        String s = "Hello, World";
+        chk("str_basic", s.length() == 12 && s.toUpperCase().equals("HELLO, WORLD") && s.toLowerCase().equals("hello, world") && s.substring(7).equals("World"));
+        chk("str_index", s.indexOf("o") == 4 && s.lastIndexOf("o") == 8 && s.indexOf("z") == -1);
+        chk("str_replace_contains", s.replace("l", "L").equals("HeLLo, WorLd") && s.contains("World") && s.startsWith("Hello") && s.endsWith("World"));
+        chk("str_trim_strip", "  trim  ".trim().equals("trim") && "  x  ".strip().equals("x") && "  y".stripLeading().equals("y") && "y  ".stripTrailing().equals("y"));
+        chk("str_join_repeat", String.join("-", "a", "b", "c").equals("a-b-c") && "ab".repeat(3).equals("ababab"));
+        chk("str_split", "a,b,c".split(",").length == 3 && "a".split(",").length == 1);
+        chk("str_format", String.format("%05d|%.2f|%x|%s", 42, 3.14159, 255, "hi").equals("00042|3.14|ff|hi"));
+        chk("str_format_flags", String.format("%,d", 1234567).equals("1,234,567") && String.format("%+d", 5).equals("+5") && String.format("%-5d|", 3).equals("3    |"));
+        chk("str_format_misc", String.format("%b|%c|%o", true, 65, 8).equals("true|A|10") && String.format("%e", 12345.678).equals("1.234568e+04"));
+        chk("str_char", s.charAt(1) == 'e' && Arrays.toString("Hi".toCharArray()).equals("[H, i]"));
+        chk("str_compare", "Hello".compareTo("World") == -15 && "abc".compareTo("abc") == 0 && "HELLO".equalsIgnoreCase("hello"));
+        chk("str_lines_blank", "a\nb\nc".lines().count() == 3 && "  ".isBlank() && "".isEmpty() && !"x".isEmpty());
+        chk("str_replaceFirst_matches", "abcabc".replaceFirst("a", "X").equals("Xbcabc") && "12.5".matches("\\d+\\.\\d+"));
+        chk("str_unicode", "résumé".length() == 6 && (int) "café".charAt(3) == 233);
+        chk("str_valueOf", String.valueOf(42).equals("42") && String.valueOf(true).equals("true") && String.valueOf(3.14).equals("3.14"));
+        chk("str_parse", Integer.parseInt("123") == 123 && Double.parseDouble("3.14") == 3.14 && Long.parseLong("9999999999") == 9999999999L);
+        chk("str_chars_codepoints", "abc".chars().sum() == 294 && "AB".codePointAt(0) == 65);
+        chk("str_format_named", "Template %s has %d items".formatted("x", 5).equals("Template x has 5 items"));
+        // StringBuilder
+        StringBuilder sb = new StringBuilder("abc");
+        sb.append("def").insert(0, "X").reverse();
+        chk("sb_append_insert_reverse", sb.toString().equals("fedcbaX") && sb.length() == 7);
+        StringBuilder sb2 = new StringBuilder("hello");
+        sb2.deleteCharAt(0).delete(0, 1).replace(0, 1, "Z").setCharAt(1, 'Y');
+        chk("sb_delete_replace_set", sb2.toString().equals("ZYo"));
+        StringBuilder sb3 = new StringBuilder(); for (int i = 0; i < 5; i++) sb3.append(i);
+        chk("sb_loop", sb3.toString().equals("01234") && sb3.charAt(2) == '2' && sb3.indexOf("3") == 3);
+        golden("str_format_val", String.format("%05d|%.2f|%x", 42, 3.14159, 255));
+        golden("str_sb_val", new StringBuilder("abc").append("def").reverse().toString());
+        golden("str_unicode_cp", (int) "café".charAt(3));
+    }
+
+    // ====================================================================== //
+    //  MODULE 19 — Math / BigInteger / BigDecimal / number classes            //
+    // ====================================================================== //
+    static void mMath() {
+        chk("math_basic", Math.max(3, 7) == 7 && Math.min(3, 7) == 3 && Math.abs(-5) == 5 && Math.abs(-5.5) == 5.5);
+        chk("math_pow_sqrt", Math.pow(2, 10) == 1024.0 && Math.sqrt(144) == 12.0 && Math.cbrt(27) == 3.0);
+        chk("math_round", Math.round(2.5) == 3 && Math.round(-2.5) == -2 && Math.round(2.4) == 2);
+        chk("math_ceil_floor", Math.ceil(2.1) == 3.0 && Math.floor(2.9) == 2.0);
+        chk("math_floorMod_floorDiv", Math.floorMod(-7, 3) == 2 && Math.floorDiv(-7, 3) == -3);
+        chk("math_hypot", Math.hypot(3, 4) == 5.0);
+        chk("math_exact", Math.addExact(2000000000, 100000000) == 2100000000L && Math.toIntExact(123L) == 123 && Math.multiplyExact(1000, 1000) == 1000000);
+        chk("math_exact_throws", catchType(() -> Math.addExact(Integer.MAX_VALUE, 1)).equals("ArithmeticException"));
+        chk("math_log_exp", Math.log(Math.E) == 1.0 && Math.log10(1000) == 3.0 && Math.exp(0) == 1.0);
+        chk("math_signum", Math.signum(-5.0) == -1.0 && Math.signum(5.0) == 1.0 && Math.signum(0.0) == 0.0);
+        // Integer / Long bit ops
+        chk("int_bits", Integer.bitCount(255) == 8 && Integer.numberOfLeadingZeros(1) == 31 && Integer.numberOfTrailingZeros(8) == 3);
+        chk("int_highest_lowest", Integer.highestOneBit(100) == 64 && Integer.lowestOneBit(12) == 4 && Integer.reverse(1) == Integer.MIN_VALUE);
+        chk("int_parse_radix", Integer.parseInt("FF", 16) == 255 && Integer.toBinaryString(10).equals("1010") && Integer.toHexString(255).equals("ff") && Integer.toOctalString(8).equals("10"));
+        chk("long_bits", Long.bitCount(255L) == 8 && Long.numberOfTrailingZeros(1024L) == 10);
+        // BigInteger
+        chk("bigint_pow", new BigInteger("2").pow(100).toString().equals("1267650600228229401496703205376"));
+        chk("bigint_gcd", new BigInteger("48").gcd(new BigInteger("36")).intValue() == 12);
+        chk("bigint_modpow", new BigInteger("3").modPow(new BigInteger("4"), new BigInteger("5")).intValue() == 1);
+        chk("bigint_factorial", factorial(20).toString().equals("2432902008176640000"));
+        chk("bigint_arith", new BigInteger("100").add(new BigInteger("50")).intValue() == 150 && new BigInteger("100").multiply(new BigInteger("3")).intValue() == 300);
+        chk("bigint_compare", new BigInteger("1000").compareTo(new BigInteger("999")) > 0 && BigInteger.TEN.equals(BigInteger.valueOf(10)));
+        chk("bigint_isprime", new BigInteger("17").isProbablePrime(20) && !new BigInteger("18").isProbablePrime(20));
+        // BigDecimal
+        chk("bigdec_divide", new BigDecimal("1").divide(new BigDecimal("3"), 10, RoundingMode.HALF_UP).toString().equals("0.3333333333"));
+        chk("bigdec_scale", new BigDecimal("2.500").stripTrailingZeros().toPlainString().equals("2.5"));
+        chk("bigdec_add_exact", new BigDecimal("0.1").add(new BigDecimal("0.2")).toString().equals("0.3"));
+        chk("bigdec_compare", new BigDecimal("1.0").compareTo(new BigDecimal("1.00")) == 0 && new BigDecimal("1.0").equals(new BigDecimal("1.0")));
+        chk("bigdec_round", new BigDecimal("3.14159").setScale(2, RoundingMode.HALF_UP).toString().equals("3.14"));
+        golden("math_floorMod", Math.floorMod(-7, 3));
+        golden("bigint_pow_100", new BigInteger("2").pow(100));
+        golden("bigint_factorial_20", factorial(20));
+        golden("bigdec_div", new BigDecimal("1").divide(new BigDecimal("3"), 10, RoundingMode.HALF_UP));
+        golden("bigdec_sum", new BigDecimal("0.1").add(new BigDecimal("0.2")));
+    }
+    static BigInteger factorial(int n) { BigInteger r = BigInteger.ONE; for (int i = 2; i <= n; i++) r = r.multiply(BigInteger.valueOf(i)); return r; }
+
+    // ====================================================================== //
+    //  MODULE 20 — arrays                                                     //
+    // ====================================================================== //
+    static void mArrays() {
+        int[] arr = {5, 3, 1, 4, 2};
+        int[] copy = Arrays.copyOf(arr, 3);
+        int[] sorted = arr.clone(); Arrays.sort(sorted);
+        chk("arr_sort_copy", Arrays.toString(sorted).equals("[1, 2, 3, 4, 5]") && Arrays.toString(copy).equals("[5, 3, 1]"));
+        chk("arr_binarySearch", Arrays.binarySearch(sorted, 3) == 2 && Arrays.stream(arr).sum() == 15);
+        chk("arr_deep", Arrays.deepToString(new int[][]{{1, 2}, {3, 4}}).equals("[[1, 2], [3, 4]]"));
+        int[] fill = new int[3]; Arrays.fill(fill, 7);
+        chk("arr_fill", Arrays.toString(fill).equals("[7, 7, 7]"));
+        chk("arr_equals", Arrays.equals(new int[]{1, 2}, new int[]{1, 2}) && !Arrays.equals(new int[]{1}, new int[]{2}));
+        chk("arr_copyOfRange", Arrays.toString(Arrays.copyOfRange(new int[]{0, 1, 2, 3, 4}, 1, 4)).equals("[1, 2, 3]"));
+        String[] sa = {"b", "a", "c"}; Arrays.sort(sa);
+        chk("arr_string_sort", Arrays.toString(sa).equals("[a, b, c]"));
+        Integer[] boxed = Arrays.stream(arr).boxed().toArray(Integer[]::new);
+        chk("arr_boxed_stream", Arrays.toString(boxed).equals("[5, 3, 1, 4, 2]"));
+        // multidim + jagged
+        int[][] grid = {{1, 2, 3}, {4, 5}, {6}};
+        chk("arr_jagged", grid.length == 3 && grid[0].length == 3 && grid[2].length == 1 && grid[1][1] == 5);
+        // array default values
+        int[] zeros = new int[3]; boolean[] bools = new boolean[2]; String[] nulls = new String[2];
+        chk("arr_defaults", zeros[0] == 0 && !bools[0] && nulls[0] == null);
+        // 3D array
+        int[][][] cube = new int[2][2][2]; cube[1][1][1] = 8;
+        chk("arr_3d", cube[1][1][1] == 8 && cube[0][0][0] == 0);
+        // Arrays.asList + setAll
+        int[] gen = new int[5]; Arrays.setAll(gen, i -> i * i);
+        chk("arr_setAll", Arrays.toString(gen).equals("[0, 1, 4, 9, 16]"));
+        golden("arr_sorted", Arrays.toString(sorted));
+        golden("arr_jagged_total", Arrays.stream(grid).mapToInt(a -> a.length).sum());
+        golden("arr_setAll_val", Arrays.toString(gen));
+    }
+
+    // ====================================================================== //
+    //  MODULE 21 — version-gated JDK21+ stdlib (reflection; runs on JDK21+)    //
+    // ====================================================================== //
+    static void mVersionGated() throws Exception {
+        int feat = Runtime.version().feature();
+        // SequencedCollection.getFirst/getLast (JDK21)
+        List<Integer> list = new ArrayList<>(List.of(10, 20, 30));
+        gatedListGetFirst(list, feat);
+        // SequencedCollection.reversed (JDK21)
+        gatedListReversed(list, feat);
+        // Math.clamp(long,long,long) (JDK21)
+        gatedMathClamp(feat);
+        // Thread.ofVirtual / virtual threads (JDK21)
+        gatedVirtualThreads(feat);
+        // Stream.mapMulti (JDK16+ actually, but exercise via reflection-safe path)
+        gatedStreamGatherers(feat);
+    }
+    static void gatedListGetFirst(List<Integer> list, int feat) throws Exception {
+        try {
+            Method gf = List.class.getMethod("getFirst");
+            Method gl = List.class.getMethod("getLast");
+            int first = (Integer) gf.invoke(list), last = (Integer) gl.invoke(list);
+            chk("v21_getFirst_getLast", first == 10 && last == 30);
+            golden("v21_getFirst", first);
+        } catch (NoSuchMethodException e) {
+            chk("v21_getFirst_getLast_gated", feat < 21); gated++;
+        }
+    }
+    static void gatedListReversed(List<Integer> list, int feat) throws Exception {
+        try {
+            Method rev = List.class.getMethod("reversed");
+            Object r = rev.invoke(list);
+            chk("v21_reversed", r.toString().equals("[30, 20, 10]"));
+        } catch (NoSuchMethodException e) {
+            chk("v21_reversed_gated", feat < 21); gated++;
+        }
+    }
+    static void gatedMathClamp(int feat) throws Exception {
+        try {
+            Method clamp = Math.class.getMethod("clamp", long.class, long.class, long.class);
+            long c1 = (Long) clamp.invoke(null, 15L, 0L, 10L);
+            long c2 = (Long) clamp.invoke(null, -5L, 0L, 10L);
+            long c3 = (Long) clamp.invoke(null, 5L, 0L, 10L);
+            chk("v21_math_clamp", c1 == 10 && c2 == 0 && c3 == 5);
+            golden("v21_clamp", c1);
+        } catch (NoSuchMethodException e) {
+            chk("v21_math_clamp_gated", feat < 21); gated++;
+        }
+    }
+    static void gatedVirtualThreads(int feat) throws Exception {
+        try {
+            Method ofVirtual = Thread.class.getMethod("ofVirtual");
+            Object builder = ofVirtual.invoke(null);
+            // start(Runnable) is declared on the EXPORTED interface java.lang.Thread.Builder,
+            // not on the (non-accessible) concrete VirtualThreadBuilder impl. Reflect the
+            // interface method so it works without --add-opens.
+            AtomicInteger ai = new AtomicInteger(0);
+            Runnable task = ai::incrementAndGet;
+            Class<?> builderIface = Class.forName("java.lang.Thread$Builder");
+            Method startM = builderIface.getMethod("start", Runnable.class);
+            Object th = startM.invoke(builder, task);
+            ((Thread) th).join();
+            chk("v21_virtual_thread", ai.get() == 1);
+        } catch (NoSuchMethodException e) {
+            chk("v21_virtual_thread_gated", feat < 21); gated++;
+        }
+    }
+    static void gatedStreamGatherers(int feat) throws Exception {
+        // Stream.Gatherers is JDK22+/24 stable. Probe class presence only.
+        try {
+            Class<?> g = Class.forName("java.util.stream.Gatherers");
+            chk("v22_gatherers_present", g != null);
+        } catch (ClassNotFoundException e) {
+            chk("v22_gatherers_gated", feat < 22); gated++;
+        }
+    }
+
+    // ====================================================================== //
+    //  main                                                                   //
+    // ====================================================================== //
+    public static void main(String[] args) throws Exception {
+        int feat = Runtime.version().feature();
+        System.out.println("JavaLangCarpet on feature version " + feat);
+        mLiterals();
+        mPrimitives();
+        mOperators();
+        mControlFlow();
+        mTypes();
+        mGenerics();
+        mFunctional();
+        mStreams();
+        mOptional();
+        mPatterns();
+        mExceptions();
+        mReflection();
+        mCollections();
+        mConcurrency();
+        mTime();
+        mRegex();
+        mNio();
+        mStrings();
+        mMath();
+        mArrays();
+        mVersionGated();
+        // Emit the deterministic GOLDEN block (output==golden cross-check).
+        System.out.print(GOLD);
+        System.out.println("carpet: " + pass + " passed, " + fail + " failed, " + gated + " version-gated");
+        if (fail == 0) System.out.println("JAVA_LANG_OK " + pass);
+        else { System.out.println("JAVA_LANG_FAIL"); System.exit(1); }
+    }
+}

--- a/apps/starry/java-lang/programs/Jdk17Features.java
+++ b/apps/starry/java-lang/programs/Jdk17Features.java
@@ -1,0 +1,96 @@
+// Jdk17Features.java — JDK 17 (LTS) language/stdlib feature self-test.
+// Run via single-file source mode:  java Jdk17Features.java
+// Prints "JDK17_OK" on the last line ONLY if every assertion passed AND the
+// running JVM reports major version 17. Any failure throws -> no JDK17_OK.
+//
+// Features exercised (all STABLE/final in 17):
+//   * records (JEP 395)
+//   * sealed classes/interfaces (JEP 409)
+//   * pattern matching for instanceof (JEP 394)
+//   * text blocks (JEP 378)
+//   * switch expressions with arrow + yield (JEP 361)
+//   * Stream.toList() (added in 16, stable in 17)
+import java.util.List;
+import java.util.stream.Stream;
+
+public class Jdk17Features {
+    // --- records ---
+    record Point(int x, int y) {
+        int manhattan() { return Math.abs(x) + Math.abs(y); }
+    }
+
+    // --- sealed interface + permitted record/finals implementations ---
+    sealed interface Shape permits Circle, Square {}
+    record Circle(double r) implements Shape {}
+    record Square(double side) implements Shape {}
+
+    static double area(Shape s) {
+        // switch expression (arrow form) + pattern-matching-ish dispatch via instanceof
+        if (s instanceof Circle c) {            // pattern matching for instanceof binds `c`
+            return Math.PI * c.r() * c.r();
+        } else if (s instanceof Square sq) {
+            return sq.side() * sq.side();
+        }
+        throw new IllegalStateException("unreachable (sealed)");
+    }
+
+    enum Day { MON, TUE, SAT, SUN }
+
+    static String kind(Day d) {
+        // switch expression returning a value, with yield in a block arm
+        return switch (d) {
+            case SAT, SUN -> "weekend";
+            case MON, TUE -> {
+                String s = "week";
+                yield s + "day";
+            }
+        };
+    }
+
+    static void check(boolean cond, String what) {
+        if (!cond) throw new AssertionError("JDK17 FAIL: " + what);
+    }
+
+    public static void main(String[] args) {
+        // version red-line: must actually be running on JDK 17.
+        int major = Runtime.version().feature();
+        System.out.println("running feature version = " + major);
+        check(major == 17, "expected JVM feature version 17, got " + major);
+
+        // records: components, equals, hashCode, accessors
+        Point p1 = new Point(3, -4);
+        Point p2 = new Point(3, -4);
+        check(p1.equals(p2), "record equals");
+        check(p1.hashCode() == p2.hashCode(), "record hashCode");
+        check(p1.x() == 3 && p1.y() == -4, "record accessors");
+        check(p1.manhattan() == 7, "record method");
+        check(p1.toString().equals("Point[x=3, y=-4]"), "record toString");
+
+        // sealed + pattern matching for instanceof
+        check(Math.abs(area(new Square(3)) - 9.0) < 1e-9, "sealed Square area");
+        check(area(new Circle(1)) > 3.14 && area(new Circle(1)) < 3.15, "sealed Circle area");
+
+        // switch expression
+        check(kind(Day.SAT).equals("weekend"), "switch weekend");
+        check(kind(Day.MON).equals("weekday"), "switch weekday yield");
+
+        // text block (JEP 378) — incidental whitespace stripped, \n line endings
+        String tb = """
+                line1
+                line2
+                """;
+        check(tb.equals("line1\nline2\n"), "text block content");
+
+        // Stream.toList() — returns an unmodifiable list
+        List<Integer> evens = Stream.of(1, 2, 3, 4, 5, 6)
+                .filter(n -> n % 2 == 0)
+                .map(n -> n * n)
+                .toList();
+        check(evens.equals(List.of(4, 16, 36)), "Stream.toList content");
+        boolean immutable;
+        try { evens.add(99); immutable = false; } catch (UnsupportedOperationException e) { immutable = true; }
+        check(immutable, "Stream.toList immutable");
+
+        System.out.println("JDK17_OK");
+    }
+}

--- a/apps/starry/java-lang/programs/Jdk21Features.java
+++ b/apps/starry/java-lang/programs/Jdk21Features.java
@@ -1,0 +1,99 @@
+// Jdk21Features.java — JDK 21 (LTS) language/stdlib feature self-test.
+// Run via single-file source mode:  java Jdk21Features.java
+// Prints "JDK21_OK" only if every assertion passed AND the running JVM is 21.
+//
+// Features exercised (all FINAL in 21, no --enable-preview needed):
+//   * virtual threads (JEP 444) — Thread.ofVirtual + newVirtualThreadPerTaskExecutor  ⭐
+//   * record patterns (JEP 440) — deconstruction in instanceof + switch
+//   * pattern matching for switch (JEP 441) incl. guarded patterns (when)
+//   * sequenced collections (JEP 431) — SequencedCollection / getFirst / getLast / reversed
+//   * Math.clamp (added in 21)
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.SequencedCollection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class Jdk21Features {
+    record Point(int x, int y) {}
+    sealed interface Shape permits Box, Dot {}
+    record Box(Point lo, Point hi) implements Shape {}
+    record Dot(Point at) implements Shape {}
+
+    // record patterns + pattern matching for switch + guarded patterns
+    static String describe(Object o) {
+        return switch (o) {
+            case Box(Point(var x1, var y1), Point(var x2, var y2)) when (x2 - x1) == (y2 - y1) ->
+                    "square-box(" + (x2 - x1) + ")";
+            case Box(Point lo, Point hi) -> "box(" + lo.x() + "," + lo.y() + "->" + hi.x() + "," + hi.y() + ")";
+            case Dot(Point(var x, var y)) -> "dot(" + x + "," + y + ")";
+            case Integer i when i < 0 -> "neg-int";
+            case Integer i -> "int(" + i + ")";
+            case null -> "null";
+            default -> "other";
+        };
+    }
+
+    static void check(boolean cond, String what) {
+        if (!cond) throw new AssertionError("JDK21 FAIL: " + what);
+    }
+
+    public static void main(String[] args) throws Exception {
+        int major = Runtime.version().feature();
+        System.out.println("running feature version = " + major);
+        check(major == 21, "expected JVM feature version 21, got " + major);
+
+        // --- virtual threads via Thread.ofVirtual ---
+        AtomicLong counter = new AtomicLong();
+        Thread vt = Thread.ofVirtual().name("vt-probe").start(() -> counter.incrementAndGet());
+        vt.join();
+        check(vt.isVirtual(), "Thread.ofVirtual is virtual");
+        check(counter.get() == 1, "virtual thread ran once");
+
+        // --- virtual thread per-task executor: fan out 1000 tasks ---
+        long expected = 0;
+        try (ExecutorService ex = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<Integer>> fs = new ArrayList<>();
+            for (int i = 1; i <= 1000; i++) {
+                final int n = i;
+                fs.add(ex.submit(() -> n));
+            }
+            long got = 0;
+            for (Future<Integer> f : fs) got += f.get();
+            expected = 1000L * 1001L / 2L;
+            check(got == expected, "vthread executor sum (" + got + " != " + expected + ")");
+        }
+        System.out.println("vthreads summed 1..1000 = " + expected);
+
+        // --- record patterns + guarded switch ---
+        check(describe(new Box(new Point(0, 0), new Point(5, 5))).equals("square-box(5)"), "guarded square-box");
+        check(describe(new Box(new Point(0, 0), new Point(5, 2))).equals("box(0,0->5,2)"), "record-pattern box");
+        check(describe(new Dot(new Point(7, 9))).equals("dot(7,9)"), "nested record pattern dot");
+        check(describe(-3).equals("neg-int"), "guarded neg int");
+        check(describe(42).equals("int(42)"), "int pattern");
+        check(describe(null).equals("null"), "null case label");
+        check(describe("hi").equals("other"), "default case");
+
+        // --- sequenced collections ---
+        SequencedCollection<String> sc = new ArrayList<>(List.of("a", "b", "c"));
+        check(sc.getFirst().equals("a"), "SequencedCollection getFirst");
+        check(sc.getLast().equals("c"), "SequencedCollection getLast");
+        sc.addFirst("z");
+        sc.addLast("y");
+        check(sc.getFirst().equals("z") && sc.getLast().equals("y"), "addFirst/addLast");
+        check(sc.reversed().getFirst().equals("y"), "reversed view");
+        LinkedHashSet<Integer> ls = new LinkedHashSet<>(List.of(10, 20, 30));
+        check(ls.getFirst() == 10 && ls.getLast() == 30, "SequencedSet first/last");
+
+        // --- Math.clamp ---
+        check(Math.clamp(15, 0, 10) == 10, "clamp high");
+        check(Math.clamp(-5, 0, 10) == 0, "clamp low");
+        check(Math.clamp(7, 0, 10) == 7, "clamp mid");
+        check(Math.clamp(3.5, 0.0, 1.0) == 1.0, "clamp double");
+
+        System.out.println("JDK21_OK");
+    }
+}

--- a/apps/starry/java-lang/programs/Jdk23Features.java
+++ b/apps/starry/java-lang/programs/Jdk23Features.java
@@ -1,0 +1,88 @@
+// Jdk23Features.java — JDK 23 language/stdlib feature self-test.
+// Run via single-file source mode WITH preview enabled (23's headline features
+// are preview, so this is the honest way to exercise them):
+//     java --enable-preview --source 23 Jdk23Features.java
+// Prints "JDK23_OK" only if every assertion passed AND the running JVM is 23.
+//
+// Features exercised:
+//   STABLE (final in 23, no preview needed; run anyway under the same JVM):
+//     * records + nested record patterns in switch (final since 21)
+//     * Stream.mapMulti (final since 16)  — flatten-ish stable stream op
+//   PREVIEW in 23 (gated by --enable-preview --source 23):
+//     * Flexible Constructor Bodies (JEP 482, 2nd preview) — statements before super()
+//     * Stream Gatherers (JEP 473, 2nd preview) — Stream::gather + Gatherers.windowFixed/fold
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Gatherers;
+import java.util.stream.Stream;
+
+public class Jdk23Features {
+
+    // --- PREVIEW: Flexible Constructor Bodies (statements before super()) ---
+    static class Base {
+        final int v;
+        Base(int v) { this.v = v; }
+    }
+    static class Validated extends Base {
+        final String label;
+        Validated(int x, String label) {
+            // prologue runs BEFORE super() — validate + transform args
+            if (x < 0) throw new IllegalArgumentException("must be >= 0");
+            String l = label == null ? "anon" : label.trim();
+            int doubled = x * 2;
+            super(doubled);           // super() no longer required to be first
+            this.label = l;           // epilogue after super()
+        }
+    }
+
+    // --- STABLE: nested record patterns (final since 21) ---
+    record Pair(int a, int b) {}
+    static int sumPair(Object o) {
+        return switch (o) {
+            case Pair(int a, int b) -> a + b;
+            default -> -1;
+        };
+    }
+
+    static void check(boolean cond, String what) {
+        if (!cond) throw new AssertionError("JDK23 FAIL: " + what);
+    }
+
+    public static void main(String[] args) {
+        int major = Runtime.version().feature();
+        System.out.println("running feature version = " + major);
+        check(major == 23, "expected JVM feature version 23, got " + major);
+
+        // PREVIEW: flexible constructor bodies
+        Validated ok = new Validated(21, "  hello  ");
+        check(ok.v == 42, "flexible-ctor prologue computed super arg");
+        check(ok.label.equals("hello"), "flexible-ctor epilogue set field");
+        boolean threw = false;
+        try { new Validated(-1, "x"); } catch (IllegalArgumentException e) { threw = true; }
+        check(threw, "flexible-ctor prologue validation rejects bad arg before super()");
+
+        // PREVIEW: Stream Gatherers — fixed windows
+        List<List<Integer>> windows = Stream.of(1, 2, 3, 4, 5)
+                .gather(Gatherers.windowFixed(2))
+                .toList();
+        check(windows.equals(List.of(List.of(1, 2), List.of(3, 4), List.of(5))), "Gatherers.windowFixed");
+        // PREVIEW: Gatherers.fold — running fold to a single accumulated value
+        List<Integer> folded = Stream.of(1, 2, 3, 4)
+                .gather(Gatherers.fold(() -> 0, Integer::sum))
+                .toList();
+        check(folded.equals(List.of(10)), "Gatherers.fold sum");
+
+        // STABLE: nested record pattern in switch
+        check(sumPair(new Pair(3, 4)) == 7, "record pattern switch");
+        check(sumPair("nope") == -1, "record pattern default");
+
+        // STABLE: Stream.mapMulti (final since 16) — expand each n into n copies
+        List<Integer> expanded = new ArrayList<>();
+        Stream.of(1, 2, 3).<Integer>mapMulti((n, consumer) -> {
+            for (int i = 0; i < n; i++) consumer.accept(n);
+        }).forEach(expanded::add);
+        check(expanded.equals(List.of(1, 2, 2, 3, 3, 3)), "Stream.mapMulti");
+
+        System.out.println("JDK23_OK");
+    }
+}

--- a/apps/starry/java-lang/programs/Jdk25Features.java
+++ b/apps/starry/java-lang/programs/Jdk25Features.java
@@ -1,0 +1,81 @@
+// Jdk25Features.java — JDK 25 (LTS) language/stdlib feature self-test.
+// Run via single-file source mode WITH preview enabled (StableValue is preview
+// in 25; the other features are final but run fine under --enable-preview):
+//     java --enable-preview --source 25 Jdk25Features.java
+// The shell harness ALSO runs this program a second time with
+//     -XX:+UseCompactObjectHeaders
+// to prove the JVM accepts the compact-object-headers flag and object layout
+// still works (the program reads the flag via the diagnostic VM bean / arg).
+// Prints "JDK25_OK" only if every assertion passed AND the running JVM is 25.
+//
+// Features exercised:
+//   FINAL in 25:
+//     * Scoped Values (JEP 506) — ScopedValue.where(...).call(...) / .get()  ⭐
+//     * Module Import Declarations (JEP 511) — `import module java.base`
+//     * Compact Object Headers (JEP 519) — product flag -XX:+UseCompactObjectHeaders
+//   PREVIEW in 25 (gated by --enable-preview --source 25):
+//     * Stable Values (JEP 502) — StableValue.of() + orElseSet (compute-once)
+import module java.base;              // FINAL in 25: imports the whole java.base module's exported packages
+import module java.management;        // FINAL in 25: another module import (ManagementFactory for VM args)
+
+public class Jdk25Features {
+    // Scoped value shared down the call chain (replacement for ThreadLocal in structured code)
+    static final ScopedValue<String> USER = ScopedValue.newInstance();
+
+    static String greet() {
+        // reads the value bound by the enclosing ScopedValue.where(...) scope
+        return "hello " + USER.get();
+    }
+
+    static void check(boolean cond, String what) {
+        if (!cond) throw new AssertionError("JDK25 FAIL: " + what);
+    }
+
+    public static void main(String[] args) throws Exception {
+        int major = Runtime.version().feature();
+        System.out.println("running feature version = " + major);
+        check(major == 25, "expected JVM feature version 25, got " + major);
+
+        // --- FINAL: module import declarations ---
+        // List / ArrayList / Map / stream types are all usable unqualified via `import module java.base`.
+        List<Integer> nums = new ArrayList<>(List.of(3, 1, 2));
+        Collections.sort(nums);
+        check(nums.equals(List.of(1, 2, 3)), "module-import: Collections.sort on unqualified List");
+        Map<String, Integer> m = new HashMap<>();
+        m.put("a", 1);
+        check(m.get("a") == 1, "module-import: HashMap usable unqualified");
+        long evens = nums.stream().filter(n -> n % 2 == 0).count();   // java.util.stream via module import
+        check(evens == 1, "module-import: stream() usable");
+
+        // --- FINAL: scoped values ---
+        String r = ScopedValue.where(USER, "alice").call(Jdk25Features::greet);
+        check(r.equals("hello alice"), "ScopedValue bound value visible in callee");
+        // outside the scope the value is unbound
+        boolean unbound = false;
+        try { USER.get(); } catch (Exception e) { unbound = true; }
+        check(unbound, "ScopedValue unbound outside where()");
+        // nesting rebinds
+        String nested = ScopedValue.where(USER, "outer").call(() ->
+                ScopedValue.where(USER, "inner").call(Jdk25Features::greet));
+        check(nested.equals("hello inner"), "ScopedValue nested rebind");
+
+        // --- FINAL: compact object headers runtime flag self-report ---
+        // The harness runs us with/without -XX:+UseCompactObjectHeaders. We read the
+        // effective flag from the VM args and assert objects still behave either way.
+        boolean compact = ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+                .anyMatch(a -> a.contains("UseCompactObjectHeaders"));
+        Object[] probe = new Object[1000];
+        for (int i = 0; i < probe.length; i++) probe[i] = "obj-" + i;     // allocate w/ active header layout
+        check(probe[999].equals("obj-999"), "object identity intact under header layout");
+        check(probe[0].hashCode() != 0 || probe[0].hashCode() == 0, "identity hashCode computable");  // always true; exercises header hash slot
+        System.out.println("compact-object-headers flag present = " + compact);
+
+        // --- PREVIEW: stable values (compute-once, then immutable) ---
+        StableValue<Integer> answer = StableValue.of();
+        int first = answer.orElseSet(() -> { return 6 * 7; });
+        int second = answer.orElseSet(() -> { throw new IllegalStateException("supplier must not run twice"); });
+        check(first == 42 && second == 42, "StableValue computes once and caches");
+
+        System.out.println("JDK25_OK");
+    }
+}

--- a/apps/starry/java-lang/programs/backcompat/README.md
+++ b/apps/starry/java-lang/programs/backcompat/README.md
@@ -1,0 +1,50 @@
+# BackCompatReal — real-world Java-8 forward-compatibility suite
+
+This is the **real** backward-compatibility leg of the `java-lang` carpet. Unlike
+`programs/BackCompat.java` (a small JDK17-bytecode self-test), `BackCompatReal`
+proves the JVM's *forward-compatibility* guarantee against **real third-party
+libraries** compiled to **Java 8 bytecode (class-file major version 52)**: a jar
+built with `javac --release 8` must run **unchanged** on JDK 17 / 21 / 23 / 25.
+
+## What it is
+
+- `src/BackCompatReal.java` — the JUnit runner `main()`. Drives the 5 per-library
+  `*BackCompatTest` classes through `JUnitCore` and prints, on zero failures,
+  exactly `BACKCOMPAT_REAL_OK 299` (the token the gate asserts), or
+  `BACKCOMPAT_REAL_FAIL` on any failure.
+- `src/CommonsBackCompatTest.java` — Apache Commons IO 2.11.0 / Math3 3.6.1 /
+  Lang3 3.12.0 / Collections4 4.4.
+- `src/LoggingBackCompatTest.java` — Log4j2 (api + core) 2.17.1.
+- `src/SqlBackCompatTest.java` — H2 2.1.214 + HSQLDB 2.5.2 (embedded JDBC).
+- `src/JsonBackCompatTest.java` — Gson 2.10.1.
+- `src/ScriptBackCompatTest.java` — BeanShell (bsh) 2.0b6.
+
+299 JUnit tests total, host-verified, deterministic.
+
+## Compiled `--release 8` = bytecode 52
+
+The suite is compiled with `--release 8` so the emitted class files are **major
+version 52** (Java 8). That is the whole point: a Java-8 jar that runs on JDK
+17/21/23/25 is the cross-version backward-compat proof. `prebuild.sh`
+`stage_backcompat()` recompiles `src/*.java` on the host with
+`javac --release 8 -cp libs/*` when a host `javac` is available (reproducible
+build), else copies the prebuilt `backcompat-real.jar`. The 12 dependency jars are
+fetched from Maven Central by sha256 (or copied from the local cache) and staged,
+together with the jar, into the overlay at `/root/bcreal/{libs,backcompat-real.jar}`.
+
+## Library coordinates (Maven Central) + sha256
+
+| jar | Maven coordinate | sha256 |
+| :-- | :-- | :-- |
+| commons-io-2.11.0.jar | commons-io:commons-io:2.11.0 | 961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908 |
+| commons-math3-3.6.1.jar | org.apache.commons:commons-math3:3.6.1 | 1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308 |
+| commons-lang3-3.12.0.jar | org.apache.commons:commons-lang3:3.12.0 | d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e |
+| commons-collections4-4.4.jar | org.apache.commons:commons-collections4:4.4 | 1df8b9430b5c8ed143d7815e403e33ef5371b2400aadbe9bda0883762e0846d1 |
+| log4j-api-2.17.1.jar | org.apache.logging.log4j:log4j-api:2.17.1 | b0d8a4c8ab4fb8b1888d0095822703b0e6d4793c419550203da9e69196161de4 |
+| log4j-core-2.17.1.jar | org.apache.logging.log4j:log4j-core:2.17.1 | c967f223487980b9364e94a7c7f9a8a01fd3ee7c19bdbf0b0f9f8cb8511f3d41 |
+| h2-2.1.214.jar | com.h2database:h2:2.1.214 | d623cdc0f61d218cf549a8d09f1c391ff91096116b22e2475475fce4fbe72bd0 |
+| hsqldb-2.5.2.jar | org.hsqldb:hsqldb:2.5.2 | e4aa39c5afb318e8effdec80a0e6de7c9dacc453c1cf7666c515f29a16658dac |
+| gson-2.10.1.jar | com.google.code.gson:gson:2.10.1 | 4241c14a7727c34feea6507ec801318a3d4a90f070e4525681079fb94ee4c593 |
+| bsh-2.0b6.jar | org.beanshell:bsh:2.0b6 | a17955976070c0573235ee662f2794a78082758b61accffce8d3f8aedcd91047 |
+| junit-4.13.2.jar | junit:junit:4.13.2 | 8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3 |
+| hamcrest-core-1.3.jar | org.hamcrest:hamcrest-core:1.3 | 66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9 |

--- a/apps/starry/java-lang/programs/backcompat/src/BackCompatReal.java
+++ b/apps/starry/java-lang/programs/backcompat/src/BackCompatReal.java
@@ -1,0 +1,80 @@
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+/**
+ * Comprehensive Java-8 backward-compat suite runner.
+ *
+ * Compiled with --release 8 (bytecode major version 52) so that the produced
+ * jar runs forward-compatibly on newer JREs (17, 21). This main() drives all
+ * per-library *BackCompatTest classes through JUnitCore and reports per-class
+ * and total results.
+ *
+ * On zero failures it prints exactly:  BACKCOMPAT_REAL_OK <total>
+ * On any failure it prints:            BACKCOMPAT_REAL_FAIL  + details
+ */
+public class BackCompatReal {
+
+    private static final Class<?>[] SUITE = new Class<?>[] {
+        CommonsBackCompatTest.class,
+        LoggingBackCompatTest.class,
+        SqlBackCompatTest.class,
+        JsonBackCompatTest.class,
+        ScriptBackCompatTest.class
+    };
+
+    public static void main(String[] args) {
+        int totalRun = 0;
+        int totalFailures = 0;
+        int totalIgnored = 0;
+        boolean anyFailure = false;
+        StringBuilder failureDetails = new StringBuilder();
+
+        for (Class<?> testClass : SUITE) {
+            Result result = JUnitCore.runClasses(testClass);
+            int run = result.getRunCount();
+            int fail = result.getFailureCount();
+            int ignored = result.getIgnoreCount();
+            totalRun += run;
+            totalFailures += fail;
+            totalIgnored += ignored;
+
+            System.out.println(testClass.getSimpleName()
+                    + " -> Tests run: " + run
+                    + ", Failures: " + fail
+                    + ", Ignored: " + ignored);
+
+            if (fail > 0) {
+                anyFailure = true;
+                for (Failure f : result.getFailures()) {
+                    failureDetails.append("  [")
+                            .append(testClass.getSimpleName())
+                            .append("] ")
+                            .append(f.getTestHeader())
+                            .append(" : ")
+                            .append(f.getMessage())
+                            .append(System.lineSeparator());
+                    Throwable ex = f.getException();
+                    if (ex != null) {
+                        failureDetails.append("      ")
+                                .append(ex.getClass().getName())
+                                .append(System.lineSeparator());
+                    }
+                }
+            }
+        }
+
+        System.out.println("------------------------------------------------------------");
+        System.out.println("TOTAL -> Tests run: " + totalRun
+                + ", Failures: " + totalFailures
+                + ", Ignored: " + totalIgnored);
+
+        if (!anyFailure) {
+            System.out.println("BACKCOMPAT_REAL_OK " + totalRun);
+        } else {
+            System.out.println("BACKCOMPAT_REAL_FAIL");
+            System.out.print(failureDetails.toString());
+            System.exit(1);
+        }
+    }
+}

--- a/apps/starry/java-lang/programs/backcompat/src/CommonsBackCompatTest.java
+++ b/apps/starry/java-lang/programs/backcompat/src/CommonsBackCompatTest.java
@@ -1,0 +1,575 @@
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.commons.collections4.Bag;
+import org.apache.commons.collections4.BidiMap;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.SortedBag;
+import org.apache.commons.collections4.bag.HashBag;
+import org.apache.commons.collections4.bag.TreeBag;
+import org.apache.commons.collections4.bidimap.DualHashBidiMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.commons.math3.fraction.Fraction;
+import org.apache.commons.math3.linear.Array2DRowRealMatrix;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.DecompositionSolver;
+import org.apache.commons.math3.linear.LUDecomposition;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.RealVector;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.util.ArithmeticUtils;
+import org.apache.commons.math3.util.CombinatoricsUtils;
+import org.junit.Test;
+
+/**
+ * Java-8 backward-compatibility carpet for the Apache Commons library group.
+ *
+ * Libraries under test (all Java-8-era, pure-Java):
+ *   - commons-io           2.11.0
+ *   - commons-math3        3.6.1
+ *   - commons-lang3        3.12.0
+ *   - commons-collections4 4.4
+ *
+ * Compiled with --release 8 (bytecode major 52). Uses ONLY Java 8 APIs so the
+ * SAME .class runs identically on JDK 17/21/23/25. Every test uses fixed inputs
+ * and asserts exact values (deterministic). RandomStringUtils uses a fixed-seed
+ * java.util.Random so its output is reproducible across JVMs.
+ */
+public class CommonsBackCompatTest {
+
+    // ============================================================
+    // commons-io  (IOUtils / FileUtils / FilenameUtils)
+    // ============================================================
+
+    private static final byte[] FIXED_BYTES =
+            "Hello, Commons-IO!\nLine2\nLine3".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    public void ioUtils_toByteArray_fromStream() throws IOException {
+        InputStream in = new ByteArrayInputStream(FIXED_BYTES);
+        byte[] out = IOUtils.toByteArray(in);
+        assertArrayEquals(FIXED_BYTES, out);
+        assertEquals(FIXED_BYTES.length, out.length);
+    }
+
+    @Test
+    public void ioUtils_toString_charset() throws IOException {
+        InputStream in = new ByteArrayInputStream(FIXED_BYTES);
+        String s = IOUtils.toString(in, StandardCharsets.UTF_8);
+        assertEquals("Hello, Commons-IO!\nLine2\nLine3", s);
+    }
+
+    @Test
+    public void ioUtils_readLines() throws IOException {
+        InputStream in = new ByteArrayInputStream(FIXED_BYTES);
+        List<String> lines = IOUtils.readLines(in, StandardCharsets.UTF_8);
+        assertEquals(3, lines.size());
+        assertEquals("Hello, Commons-IO!", lines.get(0));
+        assertEquals("Line2", lines.get(1));
+        assertEquals("Line3", lines.get(2));
+    }
+
+    @Test
+    public void ioUtils_copy_streamToStream() throws IOException {
+        InputStream in = new ByteArrayInputStream(FIXED_BYTES);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        int n = IOUtils.copy(in, bos);
+        assertEquals(FIXED_BYTES.length, n);
+        assertArrayEquals(FIXED_BYTES, bos.toByteArray());
+    }
+
+    @Test
+    public void ioUtils_toCharArray() throws IOException {
+        char[] chars = IOUtils.toCharArray(new StringReader("abcXYZ"));
+        assertArrayEquals(new char[] { 'a', 'b', 'c', 'X', 'Y', 'Z' }, chars);
+    }
+
+    @Test
+    public void ioUtils_contentEquals() throws IOException {
+        InputStream a = new ByteArrayInputStream(FIXED_BYTES);
+        InputStream b = new ByteArrayInputStream(FIXED_BYTES.clone());
+        assertTrue(IOUtils.contentEquals(a, b));
+        InputStream c = new ByteArrayInputStream(FIXED_BYTES);
+        InputStream d = new ByteArrayInputStream("different".getBytes(StandardCharsets.UTF_8));
+        assertFalse(IOUtils.contentEquals(c, d));
+    }
+
+    @Test
+    public void fileUtils_writeRead_roundTrip() throws IOException {
+        File tmp = File.createTempFile("commons-bc-", ".txt");
+        tmp.deleteOnExit();
+        try {
+            FileUtils.writeByteArrayToFile(tmp, FIXED_BYTES);
+            assertEquals(FIXED_BYTES.length, tmp.length());
+            byte[] back = FileUtils.readFileToByteArray(tmp);
+            assertArrayEquals(FIXED_BYTES, back);
+            String str = FileUtils.readFileToString(tmp, StandardCharsets.UTF_8);
+            assertEquals("Hello, Commons-IO!\nLine2\nLine3", str);
+        } finally {
+            FileUtils.deleteQuietly(tmp);
+        }
+        assertFalse(tmp.exists());
+    }
+
+    @Test
+    public void fileUtils_writeLines_andReadLines() throws IOException {
+        File tmp = File.createTempFile("commons-bc-lines-", ".txt");
+        tmp.deleteOnExit();
+        try {
+            List<String> data = Arrays.asList("alpha", "beta", "gamma");
+            FileUtils.writeLines(tmp, "UTF-8", data);
+            List<String> back = FileUtils.readLines(tmp, StandardCharsets.UTF_8);
+            assertEquals(data, back);
+        } finally {
+            FileUtils.deleteQuietly(tmp);
+        }
+    }
+
+    @Test
+    public void fileUtils_byteCountToDisplaySize() {
+        assertEquals("1 KB", FileUtils.byteCountToDisplaySize(1024L));
+        assertEquals("1 MB", FileUtils.byteCountToDisplaySize(1024L * 1024L));
+        assertEquals("1 GB", FileUtils.byteCountToDisplaySize(1024L * 1024L * 1024L));
+        assertEquals("512 bytes", FileUtils.byteCountToDisplaySize(512L));
+    }
+
+    @Test
+    public void filenameUtils_pathManipulation() {
+        assertEquals("txt", FilenameUtils.getExtension("/a/b/c/file.txt"));
+        assertEquals("file", FilenameUtils.getBaseName("/a/b/c/file.txt"));
+        assertEquals("file.txt", FilenameUtils.getName("/a/b/c/file.txt"));
+        assertEquals("/a/b/c/", FilenameUtils.getFullPath("/a/b/c/file.txt"));
+        assertEquals("/foo/baz.txt", FilenameUtils.normalize("/foo/bar/../baz.txt"));
+        assertEquals("a/b/file", FilenameUtils.removeExtension("a/b/file.log"));
+    }
+
+    // ============================================================
+    // commons-math3 (linear solve / stats / Fraction / combinatorics)
+    // ============================================================
+
+    @Test
+    public void math3_solveLinearSystem() {
+        // Solve:  2x + 3y = 8 ;  3x + 4y = 11  ->  x = 1, y = 2
+        RealMatrix coeff = new Array2DRowRealMatrix(new double[][] {
+                { 2.0, 3.0 },
+                { 3.0, 4.0 }
+        });
+        DecompositionSolver solver = new LUDecomposition(coeff).getSolver();
+        RealVector constants = new ArrayRealVector(new double[] { 8.0, 11.0 });
+        RealVector solution = solver.solve(constants);
+        assertEquals(1.0, solution.getEntry(0), 1e-9);
+        assertEquals(2.0, solution.getEntry(1), 1e-9);
+    }
+
+    @Test
+    public void math3_matrixDeterminantAndMultiply() {
+        RealMatrix m = new Array2DRowRealMatrix(new double[][] {
+                { 2.0, 3.0 },
+                { 3.0, 4.0 }
+        });
+        // det = 2*4 - 3*3 = -1
+        assertEquals(-1.0, new LUDecomposition(m).getDeterminant(), 1e-9);
+
+        RealMatrix a = new Array2DRowRealMatrix(new double[][] { { 1, 2 }, { 3, 4 } });
+        RealMatrix b = new Array2DRowRealMatrix(new double[][] { { 5, 6 }, { 7, 8 } });
+        RealMatrix p = a.multiply(b); // [[19,22],[43,50]]
+        assertEquals(19.0, p.getEntry(0, 0), 1e-9);
+        assertEquals(22.0, p.getEntry(0, 1), 1e-9);
+        assertEquals(43.0, p.getEntry(1, 0), 1e-9);
+        assertEquals(50.0, p.getEntry(1, 1), 1e-9);
+    }
+
+    @Test
+    public void math3_descriptiveStatistics() {
+        double[] data = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
+        DescriptiveStatistics ds = new DescriptiveStatistics();
+        for (double d : data) {
+            ds.addValue(d);
+        }
+        assertEquals(10, ds.getN());
+        assertEquals(5.5, ds.getMean(), 1e-9);
+        assertEquals(1.0, ds.getMin(), 1e-9);
+        assertEquals(10.0, ds.getMax(), 1e-9);
+        assertEquals(55.0, ds.getSum(), 1e-9);
+        // sample variance of 1..10 = 9.166666...
+        assertEquals(9.166666666666666, ds.getVariance(), 1e-9);
+        assertEquals(5.5, ds.getPercentile(50), 1e-9);
+    }
+
+    @Test
+    public void math3_fractionArithmetic() {
+        Fraction half = new Fraction(1, 2);
+        Fraction third = new Fraction(1, 3);
+        Fraction sum = half.add(third); // 5/6
+        assertEquals(5, sum.getNumerator());
+        assertEquals(6, sum.getDenominator());
+
+        Fraction product = half.multiply(third); // 1/6
+        assertEquals(1, product.getNumerator());
+        assertEquals(6, product.getDenominator());
+
+        Fraction diff = half.subtract(third); // 1/6
+        assertEquals(1, diff.getNumerator());
+        assertEquals(6, diff.getDenominator());
+
+        Fraction reduced = Fraction.getReducedFraction(4, 8); // 1/2
+        assertEquals(1, reduced.getNumerator());
+        assertEquals(2, reduced.getDenominator());
+
+        assertEquals(0.5, half.doubleValue(), 1e-12);
+    }
+
+    @Test
+    public void math3_combinatorics() {
+        assertEquals(120L, CombinatoricsUtils.factorial(5));
+        assertEquals(10L, CombinatoricsUtils.binomialCoefficient(5, 2));
+        assertEquals(252L, CombinatoricsUtils.binomialCoefficient(10, 5));
+        assertEquals(1L, CombinatoricsUtils.factorial(0));
+    }
+
+    @Test
+    public void math3_arithmeticUtils() {
+        assertEquals(12, ArithmeticUtils.lcm(4, 6));
+        assertEquals(6, ArithmeticUtils.gcd(12, 18));
+        assertEquals(1024L, ArithmeticUtils.pow(2L, 10));
+        assertTrue(ArithmeticUtils.isPowerOfTwo(64L));
+        assertFalse(ArithmeticUtils.isPowerOfTwo(65L));
+    }
+
+    @Test
+    public void math3_vectorOperations() {
+        RealVector v1 = new ArrayRealVector(new double[] { 1.0, 2.0, 3.0 });
+        RealVector v2 = new ArrayRealVector(new double[] { 4.0, 5.0, 6.0 });
+        assertEquals(32.0, v1.dotProduct(v2), 1e-9); // 4+10+18
+        RealVector sum = v1.add(v2);
+        assertEquals(5.0, sum.getEntry(0), 1e-9);
+        assertEquals(7.0, sum.getEntry(1), 1e-9);
+        assertEquals(9.0, sum.getEntry(2), 1e-9);
+        assertEquals(Math.sqrt(14.0), v1.getNorm(), 1e-9);
+    }
+
+    // ============================================================
+    // commons-lang3 (StringUtils / WordUtils / Escape / ArrayUtils ...)
+    // ============================================================
+
+    @Test
+    public void lang3_stringUtils_basics() {
+        assertTrue(StringUtils.isBlank("   "));
+        assertFalse(StringUtils.isBlank(" x "));
+        assertTrue(StringUtils.isEmpty(""));
+        assertEquals("abc", StringUtils.trimToEmpty("  abc  "));
+        assertEquals("", StringUtils.trimToEmpty(null));
+        assertEquals("abc", StringUtils.defaultString(null, "abc"));
+        assertEquals("Hello", StringUtils.capitalize("hello"));
+        assertEquals("hELLO", StringUtils.swapCase("Hello"));
+        assertEquals("olleh", StringUtils.reverse("hello"));
+    }
+
+    @Test
+    public void lang3_stringUtils_joinSplit() {
+        assertEquals("a,b,c", StringUtils.join(new String[] { "a", "b", "c" }, ','));
+        assertEquals("1-2-3", StringUtils.join(Arrays.asList(1, 2, 3), "-"));
+        String[] parts = StringUtils.split("a,b,,c", ',');
+        assertArrayEquals(new String[] { "a", "b", "c" }, parts);
+        String[] kept = StringUtils.splitPreserveAllTokens("a,b,,c", ',');
+        assertArrayEquals(new String[] { "a", "b", "", "c" }, kept);
+    }
+
+    @Test
+    public void lang3_stringUtils_searchCount() {
+        assertEquals(3, StringUtils.countMatches("ababab", "a"));
+        assertEquals(2, StringUtils.countMatches("aaaa", "aa")); // non-overlapping
+        assertTrue(StringUtils.containsIgnoreCase("Hello World", "WORLD"));
+        assertEquals("xxbcd", StringUtils.replaceChars("aabcd", "a", "x"));
+        assertEquals("hello world", StringUtils.replace("hello_world", "_", " "));
+        assertEquals(4, StringUtils.indexOf("hello", "o"));
+    }
+
+    @Test
+    public void lang3_stringUtils_padAbbreviate() {
+        assertEquals("00042", StringUtils.leftPad("42", 5, '0'));
+        assertEquals("42   ", StringUtils.rightPad("42", 5));
+        assertEquals("  ab  ", StringUtils.center("ab", 6));
+        assertEquals("abcdefg...", StringUtils.abbreviate("abcdefghijklmnop", 10));
+        assertEquals("abc", StringUtils.repeat("abc", 1));
+        assertEquals("xyxyxy", StringUtils.repeat("xy", 3));
+    }
+
+    @Test
+    public void lang3_stringUtils_difference_levenshtein() {
+        assertEquals(3, StringUtils.getLevenshteinDistance("kitten", "sitting"));
+        assertEquals("You are funny", StringUtils.difference("I am hungry", "You are funny"));
+        assertEquals("", StringUtils.difference("same", "same"));
+    }
+
+    @Test
+    public void lang3_wordUtils() {
+        assertEquals("I Am Fine", WordUtils.capitalize("i am fine"));
+        assertEquals("I Am Fine", WordUtils.capitalizeFully("i AM fInE"));
+        assertEquals("i am fine", WordUtils.uncapitalize("I Am Fine"));
+        assertEquals("THE DOG", WordUtils.capitalize("the dog").toUpperCase());
+        assertEquals("Hello\nWorld", WordUtils.wrap("Hello World", 5));
+    }
+
+    @Test
+    public void lang3_stringEscapeUtils() {
+        assertEquals("&lt;a&gt;&amp;&quot;", StringEscapeUtils.escapeHtml4("<a>&\""));
+        assertEquals("<a>&\"", StringEscapeUtils.unescapeHtml4("&lt;a&gt;&amp;&quot;"));
+        assertEquals("line1\\nline2", StringEscapeUtils.escapeJava("line1\nline2"));
+        assertEquals("line1\nline2", StringEscapeUtils.unescapeJava("line1\\nline2"));
+        assertEquals("&lt;tag&gt;", StringEscapeUtils.escapeXml10("<tag>"));
+        assertEquals("\"a,b\"", StringEscapeUtils.escapeCsv("a,b"));
+    }
+
+    @Test
+    public void lang3_arrayUtils() {
+        int[] arr = { 1, 2, 3, 4, 5 };
+        assertTrue(ArrayUtils.contains(arr, 3));
+        assertFalse(ArrayUtils.contains(arr, 9));
+        assertEquals(2, ArrayUtils.indexOf(arr, 3));
+        int[] reversed = arr.clone();
+        ArrayUtils.reverse(reversed);
+        assertArrayEquals(new int[] { 5, 4, 3, 2, 1 }, reversed);
+        int[] added = ArrayUtils.add(arr, 6);
+        assertArrayEquals(new int[] { 1, 2, 3, 4, 5, 6 }, added);
+        int[] removed = ArrayUtils.remove(arr, 0);
+        assertArrayEquals(new int[] { 2, 3, 4, 5 }, removed);
+        int[] sub = ArrayUtils.subarray(arr, 1, 4);
+        assertArrayEquals(new int[] { 2, 3, 4 }, sub);
+        assertTrue(ArrayUtils.isEmpty(new int[0]));
+        assertEquals(5, ArrayUtils.getLength(arr));
+    }
+
+    @Test
+    public void lang3_arrayUtils_toObjectAndPrimitive() {
+        Integer[] boxed = ArrayUtils.toObject(new int[] { 1, 2, 3 });
+        assertArrayEquals(new Integer[] { 1, 2, 3 }, boxed);
+        int[] unboxed = ArrayUtils.toPrimitive(new Integer[] { 4, 5, 6 });
+        assertArrayEquals(new int[] { 4, 5, 6 }, unboxed);
+    }
+
+    @Test
+    public void lang3_mutable() {
+        MutableInt mi = new MutableInt(10);
+        mi.increment();
+        assertEquals(11, mi.intValue());
+        mi.add(4);
+        assertEquals(15, mi.intValue());
+        mi.subtract(5);
+        assertEquals(10, mi.intValue());
+        mi.setValue(100);
+        assertEquals(100, mi.intValue());
+    }
+
+    @Test
+    public void lang3_tuples() {
+        Pair<String, Integer> p = ImmutablePair.of("key", 42);
+        assertEquals("key", p.getLeft());
+        assertEquals(Integer.valueOf(42), p.getRight());
+        assertEquals("(key,42)", p.toString());
+
+        Triple<String, Integer, Boolean> t = Triple.of("a", 1, true);
+        assertEquals("a", t.getLeft());
+        assertEquals(Integer.valueOf(1), t.getMiddle());
+        assertEquals(Boolean.TRUE, t.getRight());
+    }
+
+    @Test
+    public void lang3_numberUtils() {
+        assertEquals(42, NumberUtils.toInt("42"));
+        assertEquals(-1, NumberUtils.toInt("not-a-number", -1));
+        assertEquals(3.14, NumberUtils.toDouble("3.14"), 1e-12);
+        assertTrue(NumberUtils.isCreatable("123"));
+        assertTrue(NumberUtils.isCreatable("0x1F"));
+        assertFalse(NumberUtils.isCreatable("12.34.56"));
+        assertEquals(9, NumberUtils.max(3, 9, 1));
+        assertEquals(1, NumberUtils.min(3, 9, 1));
+    }
+
+    @Test
+    public void lang3_booleanUtils() {
+        assertTrue(BooleanUtils.toBoolean("yes"));
+        assertTrue(BooleanUtils.toBoolean("true"));
+        assertFalse(BooleanUtils.toBoolean("no"));
+        assertEquals("yes", BooleanUtils.toStringYesNo(true));
+        assertEquals("off", BooleanUtils.toStringOnOff(false));
+        assertTrue(BooleanUtils.and(new boolean[] { true, true, true }));
+        assertFalse(BooleanUtils.and(new boolean[] { true, false, true }));
+        assertTrue(BooleanUtils.or(new boolean[] { false, false, true }));
+    }
+
+    @Test
+    public void lang3_randomStringUtils_fixedSeedDeterministic() {
+        // RandomStringUtils with an explicit fixed-seed Random => reproducible.
+        Random rng1 = new Random(123456789L);
+        String s1 = RandomStringUtils.random(20, 0, 0, true, true, null, rng1);
+        Random rng2 = new Random(123456789L);
+        String s2 = RandomStringUtils.random(20, 0, 0, true, true, null, rng2);
+        assertEquals(s1, s2);
+        assertEquals(20, s1.length());
+        // Explicit fixed char-set over a fixed seed is reproducible across JVMs.
+        Random rng3 = new Random(42L);
+        char[] charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+        String a = RandomStringUtils.random(16, 0, charset.length, false, false, charset, rng3);
+        Random rng4 = new Random(42L);
+        String b = RandomStringUtils.random(16, 0, charset.length, false, false, charset, rng4);
+        assertEquals(a, b);
+        assertEquals(16, a.length());
+        String universe = new String(charset);
+        for (char c : a.toCharArray()) {
+            assertTrue("char out of fixed set: " + c, universe.indexOf(c) >= 0);
+        }
+    }
+
+    // ============================================================
+    // commons-collections4 (Bag / BidiMap / MultiValuedMap / utils)
+    // ============================================================
+
+    @Test
+    public void collections4_hashBag() {
+        Bag<String> bag = new HashBag<String>();
+        bag.add("apple", 3);
+        bag.add("banana", 2);
+        bag.add("apple"); // now 4 apples
+        assertEquals(4, bag.getCount("apple"));
+        assertEquals(2, bag.getCount("banana"));
+        assertEquals(6, bag.size());
+        assertEquals(0, bag.getCount("cherry"));
+        Set<String> uniques = bag.uniqueSet();
+        assertEquals(2, uniques.size());
+        assertTrue(uniques.contains("apple"));
+        assertTrue(uniques.contains("banana"));
+        bag.remove("apple", 1);
+        assertEquals(3, bag.getCount("apple"));
+    }
+
+    @Test
+    public void collections4_treeBag_sorted() {
+        SortedBag<String> bag = new TreeBag<String>();
+        bag.add("gamma", 1);
+        bag.add("alpha", 2);
+        bag.add("beta", 3);
+        assertEquals("alpha", bag.first());
+        assertEquals("gamma", bag.last());
+        assertEquals(2, bag.getCount("alpha"));
+        assertEquals(6, bag.size());
+        // uniqueSet of a TreeBag is sorted
+        List<String> order = new ArrayList<String>(bag.uniqueSet());
+        assertEquals(Arrays.asList("alpha", "beta", "gamma"), order);
+    }
+
+    @Test
+    public void collections4_dualHashBidiMap() {
+        BidiMap<String, Integer> map = new DualHashBidiMap<String, Integer>();
+        map.put("one", 1);
+        map.put("two", 2);
+        map.put("three", 3);
+        assertEquals(Integer.valueOf(2), map.get("two"));
+        assertEquals("two", map.getKey(2));
+        BidiMap<Integer, String> inverse = map.inverseBidiMap();
+        assertEquals("three", inverse.get(3));
+        // Re-putting an existing value re-maps uniquely (BidiMap invariant).
+        map.put("uno", 1);
+        assertNull(map.get("one"));
+        assertEquals(Integer.valueOf(1), map.get("uno"));
+        assertEquals("uno", map.getKey(1));
+    }
+
+    @Test
+    public void collections4_multiValuedMap() {
+        MultiValuedMap<String, Integer> mm = new ArrayListValuedHashMap<String, Integer>();
+        mm.put("a", 1);
+        mm.put("a", 2);
+        mm.put("a", 3);
+        mm.put("b", 10);
+        Collection<Integer> aVals = mm.get("a");
+        assertEquals(3, aVals.size());
+        assertTrue(aVals.contains(1));
+        assertTrue(aVals.contains(2));
+        assertTrue(aVals.contains(3));
+        assertEquals(1, mm.get("b").size());
+        assertEquals(4, mm.size()); // total entries
+        assertEquals(2, mm.keySet().size());
+        assertTrue(mm.containsKey("a"));
+        assertFalse(mm.containsKey("z"));
+    }
+
+    @Test
+    public void collections4_collectionUtils_setOps() {
+        List<Integer> a = Arrays.asList(1, 2, 3, 4);
+        List<Integer> b = Arrays.asList(3, 4, 5, 6);
+        Collection<Integer> union = CollectionUtils.union(a, b);
+        Collection<Integer> inter = CollectionUtils.intersection(a, b);
+        Collection<Integer> diff = CollectionUtils.subtract(a, b);
+
+        TreeSet<Integer> unionSet = new TreeSet<Integer>(union);
+        assertEquals(new TreeSet<Integer>(Arrays.asList(1, 2, 3, 4, 5, 6)), unionSet);
+
+        TreeSet<Integer> interSet = new TreeSet<Integer>(inter);
+        assertEquals(new TreeSet<Integer>(Arrays.asList(3, 4)), interSet);
+
+        TreeSet<Integer> diffSet = new TreeSet<Integer>(diff);
+        assertEquals(new TreeSet<Integer>(Arrays.asList(1, 2)), diffSet);
+    }
+
+    @Test
+    public void collections4_collectionUtils_predicatesAndMisc() {
+        List<Integer> nums = Arrays.asList(2, 4, 6, 8);
+        boolean allEven = CollectionUtils.matchesAll(nums, n -> n % 2 == 0);
+        assertTrue(allEven);
+        assertEquals(4, CollectionUtils.countMatches(nums, n -> n > 0));
+        assertEquals(2, CollectionUtils.countMatches(nums, n -> n > 4));
+        assertTrue(CollectionUtils.isEqualCollection(
+                Arrays.asList(1, 2, 3), Arrays.asList(3, 2, 1)));
+        assertFalse(CollectionUtils.isEmpty(nums));
+        assertTrue(CollectionUtils.isEmpty(new ArrayList<Integer>()));
+        Object item = CollectionUtils.get(nums, 3);
+        assertEquals(Integer.valueOf(8), item);
+    }
+
+    @Test
+    public void collections4_collectionUtils_transformSelect() {
+        List<Integer> src = Arrays.asList(1, 2, 3, 4, 5);
+        Collection<Integer> doubled = CollectionUtils.collect(src, n -> n * 2);
+        assertEquals(Arrays.asList(2, 4, 6, 8, 10), new ArrayList<Integer>(doubled));
+        Collection<Integer> selected = CollectionUtils.select(src, n -> n % 2 == 1);
+        assertEquals(new TreeSet<Integer>(Arrays.asList(1, 3, 5)),
+                new TreeSet<Integer>(selected));
+        assertNotNull(CollectionUtils.find(src, n -> n == 3));
+        assertNull(CollectionUtils.find(src, n -> n == 99));
+    }
+}

--- a/apps/starry/java-lang/programs/backcompat/src/JsonBackCompatTest.java
+++ b/apps/starry/java-lang/programs/backcompat/src/JsonBackCompatTest.java
@@ -1,0 +1,1003 @@
+import static org.junit.Assert.*;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.LongSerializationPolicy;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.annotations.Since;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Comprehensive, deterministic JUnit4 carpet for the Json library group (Gson 2.10.1).
+ *
+ * Java-8-only source (compiled with --release 8, bytecode 52). Runs identically on
+ * JDK 17/21/23/25. No Nashorn/JAXB/CORBA. All inputs are fixed literals and all
+ * assertions check exact JSON strings or parsed field values, so the suite is
+ * fully deterministic (Gson preserves declared field order for reflective POJOs and
+ * insertion order for LinkedHashMap / JsonObject).
+ */
+public class JsonBackCompatTest {
+
+    // ----------------------------------------------------------------
+    // Fixed model classes (declared field order => stable serialization)
+    // ----------------------------------------------------------------
+
+    enum Color { RED, GREEN, BLUE }
+
+    static class Point {
+        int x;
+        int y;
+        Point() {}
+        Point(int x, int y) { this.x = x; this.y = y; }
+    }
+
+    static class Person {
+        String name;
+        int age;
+        boolean active;
+        Person() {}
+        Person(String name, int age, boolean active) {
+            this.name = name; this.age = age; this.active = active;
+        }
+    }
+
+    static class Nested {
+        String label;
+        Point origin;
+        List<Integer> values;
+        Nested() {}
+        Nested(String label, Point origin, List<Integer> values) {
+            this.label = label; this.origin = origin; this.values = values;
+        }
+    }
+
+    static class Renamed {
+        @SerializedName("first_name")
+        String firstName;
+        @SerializedName(value = "id", alternate = {"identifier", "key"})
+        int id;
+        Renamed() {}
+        Renamed(String firstName, int id) { this.firstName = firstName; this.id = id; }
+    }
+
+    static class WithEnum {
+        String name;
+        Color color;
+        WithEnum() {}
+        WithEnum(String name, Color color) { this.name = name; this.color = color; }
+    }
+
+    static class ExposeModel {
+        @Expose
+        String shown;
+        @Expose(serialize = false, deserialize = true)
+        String inOnly;
+        @Expose(serialize = true, deserialize = false)
+        String outOnly;
+        String hidden; // no @Expose
+        ExposeModel() {}
+        ExposeModel(String shown, String inOnly, String outOnly, String hidden) {
+            this.shown = shown; this.inOnly = inOnly; this.outOnly = outOnly; this.hidden = hidden;
+        }
+    }
+
+    static class VersionedModel {
+        String stable;
+        @Since(2.0)
+        String newer;
+        VersionedModel() {}
+        VersionedModel(String stable, String newer) { this.stable = stable; this.newer = newer; }
+    }
+
+    static class TransientModel {
+        int kept;
+        transient int dropped;
+        static int staticField = 99;
+        TransientModel() {}
+        TransientModel(int kept, int dropped) { this.kept = kept; this.dropped = dropped; }
+    }
+
+    static class NullableModel {
+        String present;
+        String absent; // null
+        NullableModel() {}
+        NullableModel(String present, String absent) { this.present = present; this.absent = absent; }
+    }
+
+    // A type with a registered custom (de)serializer
+    static class Money {
+        long cents;
+        Money() {}
+        Money(long cents) { this.cents = cents; }
+    }
+
+    // ----------------------------------------------------------------
+    // 1. Basic serialization of a flat POJO -> exact JSON
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testSerializeFlatPojoExactJson() {
+        Gson gson = new Gson();
+        Person p = new Person("Ada", 36, true);
+        assertEquals("{\"name\":\"Ada\",\"age\":36,\"active\":true}", gson.toJson(p));
+    }
+
+    @Test
+    public void testSerializePointExactJson() {
+        Gson gson = new Gson();
+        assertEquals("{\"x\":3,\"y\":-7}", gson.toJson(new Point(3, -7)));
+    }
+
+    // ----------------------------------------------------------------
+    // 2. Deserialization of a flat POJO
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testDeserializeFlatPojo() {
+        Gson gson = new Gson();
+        Person p = gson.fromJson("{\"name\":\"Grace\",\"age\":40,\"active\":false}", Person.class);
+        assertEquals("Grace", p.name);
+        assertEquals(40, p.age);
+        assertFalse(p.active);
+    }
+
+    @Test
+    public void testDeserializeIgnoresUnknownFields() {
+        Gson gson = new Gson();
+        Person p = gson.fromJson("{\"name\":\"Lin\",\"age\":21,\"active\":true,\"extra\":42}", Person.class);
+        assertEquals("Lin", p.name);
+        assertEquals(21, p.age);
+        assertTrue(p.active);
+    }
+
+    @Test
+    public void testRoundTripPojo() {
+        Gson gson = new Gson();
+        Person original = new Person("Knuth", 86, true);
+        String json = gson.toJson(original);
+        Person back = gson.fromJson(json, Person.class);
+        assertEquals(original.name, back.name);
+        assertEquals(original.age, back.age);
+        assertEquals(original.active, back.active);
+    }
+
+    // ----------------------------------------------------------------
+    // 3. Nested objects + lists
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testSerializeNestedExactJson() {
+        Gson gson = new Gson();
+        Nested n = new Nested("box", new Point(1, 2), Arrays.asList(10, 20, 30));
+        assertEquals("{\"label\":\"box\",\"origin\":{\"x\":1,\"y\":2},\"values\":[10,20,30]}", gson.toJson(n));
+    }
+
+    @Test
+    public void testDeserializeNested() {
+        Gson gson = new Gson();
+        Nested n = gson.fromJson(
+                "{\"label\":\"cell\",\"origin\":{\"x\":5,\"y\":6},\"values\":[7,8]}", Nested.class);
+        assertEquals("cell", n.label);
+        assertEquals(5, n.origin.x);
+        assertEquals(6, n.origin.y);
+        assertEquals(Arrays.asList(7, 8), n.values);
+    }
+
+    @Test
+    public void testSerializeListOfPojos() {
+        Gson gson = new Gson();
+        List<Point> pts = Arrays.asList(new Point(0, 0), new Point(1, 1));
+        assertEquals("[{\"x\":0,\"y\":0},{\"x\":1,\"y\":1}]", gson.toJson(pts));
+    }
+
+    // ----------------------------------------------------------------
+    // 4. Maps (LinkedHashMap => stable key order)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testSerializeMapExactJson() {
+        Gson gson = new Gson();
+        Map<String, Integer> m = new LinkedHashMap<String, Integer>();
+        m.put("a", 1);
+        m.put("b", 2);
+        m.put("c", 3);
+        assertEquals("{\"a\":1,\"b\":2,\"c\":3}", gson.toJson(m));
+    }
+
+    @Test
+    public void testDeserializeMapWithTypeToken() {
+        Gson gson = new Gson();
+        Type t = new TypeToken<Map<String, Integer>>() {}.getType();
+        Map<String, Integer> m = gson.fromJson("{\"x\":10,\"y\":20}", t);
+        assertEquals(Integer.valueOf(10), m.get("x"));
+        assertEquals(Integer.valueOf(20), m.get("y"));
+        assertEquals(2, m.size());
+    }
+
+    // ----------------------------------------------------------------
+    // 5. Enums
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testSerializeEnum() {
+        Gson gson = new Gson();
+        assertEquals("\"GREEN\"", gson.toJson(Color.GREEN));
+    }
+
+    @Test
+    public void testSerializeEnumInsidePojo() {
+        Gson gson = new Gson();
+        WithEnum w = new WithEnum("flag", Color.BLUE);
+        assertEquals("{\"name\":\"flag\",\"color\":\"BLUE\"}", gson.toJson(w));
+    }
+
+    @Test
+    public void testDeserializeEnum() {
+        Gson gson = new Gson();
+        WithEnum w = gson.fromJson("{\"name\":\"q\",\"color\":\"RED\"}", WithEnum.class);
+        assertEquals("q", w.name);
+        assertEquals(Color.RED, w.color);
+    }
+
+    @Test
+    public void testDeserializeEnumDirect() {
+        Gson gson = new Gson();
+        assertEquals(Color.BLUE, gson.fromJson("\"BLUE\"", Color.class));
+    }
+
+    // ----------------------------------------------------------------
+    // 6. @SerializedName (rename + alternate)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testSerializedNameSerialize() {
+        Gson gson = new Gson();
+        Renamed r = new Renamed("Joan", 7);
+        assertEquals("{\"first_name\":\"Joan\",\"id\":7}", gson.toJson(r));
+    }
+
+    @Test
+    public void testSerializedNameDeserialize() {
+        Gson gson = new Gson();
+        Renamed r = gson.fromJson("{\"first_name\":\"Edsger\",\"id\":99}", Renamed.class);
+        assertEquals("Edsger", r.firstName);
+        assertEquals(99, r.id);
+    }
+
+    @Test
+    public void testSerializedNameAlternate() {
+        Gson gson = new Gson();
+        Renamed r1 = gson.fromJson("{\"first_name\":\"A\",\"identifier\":11}", Renamed.class);
+        assertEquals(11, r1.id);
+        Renamed r2 = gson.fromJson("{\"first_name\":\"B\",\"key\":22}", Renamed.class);
+        assertEquals(22, r2.id);
+    }
+
+    // ----------------------------------------------------------------
+    // 7. Pretty printing
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testPrettyPrinting() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String json = gson.toJson(new Point(8, 9));
+        // Gson pretty printer uses 2-space indent and \n newlines.
+        assertEquals("{\n  \"x\": 8,\n  \"y\": 9\n}", json);
+    }
+
+    @Test
+    public void testPrettyPrintingNested() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Nested n = new Nested("p", new Point(1, 2), Arrays.asList(3, 4));
+        String expected =
+                "{\n" +
+                "  \"label\": \"p\",\n" +
+                "  \"origin\": {\n" +
+                "    \"x\": 1,\n" +
+                "    \"y\": 2\n" +
+                "  },\n" +
+                "  \"values\": [\n" +
+                "    3,\n" +
+                "    4\n" +
+                "  ]\n" +
+                "}";
+        assertEquals(expected, gson.toJson(n));
+    }
+
+    // ----------------------------------------------------------------
+    // 8. serializeNulls
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testNullsOmittedByDefault() {
+        Gson gson = new Gson();
+        assertEquals("{\"present\":\"v\"}", gson.toJson(new NullableModel("v", null)));
+    }
+
+    @Test
+    public void testSerializeNullsEnabled() {
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        assertEquals("{\"present\":\"v\",\"absent\":null}", gson.toJson(new NullableModel("v", null)));
+    }
+
+    // ----------------------------------------------------------------
+    // 9. transient / static fields excluded
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testTransientAndStaticExcluded() {
+        Gson gson = new Gson();
+        assertEquals("{\"kept\":5}", gson.toJson(new TransientModel(5, 6)));
+    }
+
+    @Test
+    public void testExcludeFieldsWithModifiers() {
+        // explicitly exclude transient + static (default Gson behaviour, verified)
+        Gson gson = new GsonBuilder()
+                .excludeFieldsWithModifiers(java.lang.reflect.Modifier.TRANSIENT,
+                                            java.lang.reflect.Modifier.STATIC)
+                .create();
+        assertEquals("{\"kept\":12}", gson.toJson(new TransientModel(12, 34)));
+    }
+
+    // ----------------------------------------------------------------
+    // 10. FieldNamingPolicy
+    // ----------------------------------------------------------------
+
+    static class CamelModel {
+        String firstName = "v1";
+        int totalCount = 5;
+    }
+
+    @Test
+    public void testFieldNamingLowerCaseWithUnderscores() {
+        Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+        assertEquals("{\"first_name\":\"v1\",\"total_count\":5}", gson.toJson(new CamelModel()));
+    }
+
+    @Test
+    public void testFieldNamingUpperCamelCase() {
+        Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
+                .create();
+        assertEquals("{\"FirstName\":\"v1\",\"TotalCount\":5}", gson.toJson(new CamelModel()));
+    }
+
+    @Test
+    public void testFieldNamingUpperCamelCaseWithSpaces() {
+        Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES)
+                .create();
+        assertEquals("{\"First Name\":\"v1\",\"Total Count\":5}", gson.toJson(new CamelModel()));
+    }
+
+    @Test
+    public void testFieldNamingLowerCaseWithDashes() {
+        Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DASHES)
+                .create();
+        assertEquals("{\"first-name\":\"v1\",\"total-count\":5}", gson.toJson(new CamelModel()));
+    }
+
+    // ----------------------------------------------------------------
+    // 11. @Expose with excludeFieldsWithoutExposeAnnotation
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testExposeSerialize() {
+        Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+        // serialize=true fields: shown, outOnly ; inOnly is serialize=false ; hidden not exposed
+        assertEquals("{\"shown\":\"s\",\"outOnly\":\"o\"}",
+                gson.toJson(new ExposeModel("s", "i", "o", "h")));
+    }
+
+    @Test
+    public void testExposeDeserialize() {
+        Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+        ExposeModel m = gson.fromJson(
+                "{\"shown\":\"S\",\"inOnly\":\"I\",\"outOnly\":\"O\",\"hidden\":\"H\"}",
+                ExposeModel.class);
+        assertEquals("S", m.shown);   // deserialize=true
+        assertEquals("I", m.inOnly);  // deserialize=true
+        assertNull(m.outOnly);        // deserialize=false
+        assertNull(m.hidden);         // not exposed
+    }
+
+    // ----------------------------------------------------------------
+    // 12. @Since + version
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testVersionExcludesNewerField() {
+        Gson gson = new GsonBuilder().setVersion(1.0).create();
+        assertEquals("{\"stable\":\"a\"}", gson.toJson(new VersionedModel("a", "b")));
+    }
+
+    @Test
+    public void testVersionIncludesNewerField() {
+        Gson gson = new GsonBuilder().setVersion(2.0).create();
+        assertEquals("{\"stable\":\"a\",\"newer\":\"b\"}", gson.toJson(new VersionedModel("a", "b")));
+    }
+
+    // ----------------------------------------------------------------
+    // 13. ExclusionStrategy
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testCustomExclusionStrategy() {
+        ExclusionStrategy strat = new ExclusionStrategy() {
+            @Override public boolean shouldSkipField(FieldAttributes f) {
+                return "age".equals(f.getName());
+            }
+            @Override public boolean shouldSkipClass(Class<?> clazz) {
+                return false;
+            }
+        };
+        Gson gson = new GsonBuilder().setExclusionStrategies(strat).create();
+        assertEquals("{\"name\":\"Z\",\"active\":true}", gson.toJson(new Person("Z", 50, true)));
+    }
+
+    // ----------------------------------------------------------------
+    // 14. TypeToken for generic collections (round-trip)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testTypeTokenListOfStrings() {
+        Gson gson = new Gson();
+        Type t = new TypeToken<List<String>>() {}.getType();
+        List<String> list = gson.fromJson("[\"a\",\"b\",\"c\"]", t);
+        assertEquals(Arrays.asList("a", "b", "c"), list);
+    }
+
+    @Test
+    public void testTypeTokenListOfPojos() {
+        Gson gson = new Gson();
+        Type t = new TypeToken<List<Point>>() {}.getType();
+        List<Point> list = gson.fromJson("[{\"x\":1,\"y\":2},{\"x\":3,\"y\":4}]", t);
+        assertEquals(2, list.size());
+        assertEquals(1, list.get(0).x);
+        assertEquals(4, list.get(1).y);
+    }
+
+    @Test
+    public void testTypeTokenNestedGenerics() {
+        Gson gson = new Gson();
+        Type t = new TypeToken<Map<String, List<Integer>>>() {}.getType();
+        Map<String, List<Integer>> m = gson.fromJson("{\"a\":[1,2],\"b\":[3]}", t);
+        assertEquals(Arrays.asList(1, 2), m.get("a"));
+        assertEquals(Arrays.asList(3), m.get("b"));
+    }
+
+    @Test
+    public void testTypeTokenGetType() {
+        TypeToken<List<Long>> tt = new TypeToken<List<Long>>() {};
+        assertEquals("java.util.List<java.lang.Long>", tt.getType().toString());
+        assertEquals(List.class, tt.getRawType());
+    }
+
+    // ----------------------------------------------------------------
+    // 15. Custom TypeAdapter (streaming) registration
+    // ----------------------------------------------------------------
+
+    static class MoneyAdapter extends TypeAdapter<Money> {
+        @Override public void write(JsonWriter out, Money value) throws IOException {
+            if (value == null) { out.nullValue(); return; }
+            // serialize as decimal string "1.23"
+            out.value(String.format("%d.%02d", value.cents / 100, Math.abs(value.cents % 100)));
+        }
+        @Override public Money read(JsonReader in) throws IOException {
+            String s = in.nextString();
+            int dot = s.indexOf('.');
+            long whole = Long.parseLong(s.substring(0, dot));
+            long frac = Long.parseLong(s.substring(dot + 1));
+            return new Money(whole * 100 + frac);
+        }
+    }
+
+    @Test
+    public void testCustomTypeAdapterSerialize() {
+        Gson gson = new GsonBuilder().registerTypeAdapter(Money.class, new MoneyAdapter()).create();
+        assertEquals("\"12.34\"", gson.toJson(new Money(1234)));
+    }
+
+    @Test
+    public void testCustomTypeAdapterDeserialize() {
+        Gson gson = new GsonBuilder().registerTypeAdapter(Money.class, new MoneyAdapter()).create();
+        Money m = gson.fromJson("\"5.06\"", Money.class);
+        assertEquals(506, m.cents);
+    }
+
+    // ----------------------------------------------------------------
+    // 16. Custom JsonSerializer / JsonDeserializer (tree model)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testCustomJsonSerializer() {
+        JsonSerializer<Money> ser = new JsonSerializer<Money>() {
+            @Override public JsonElement serialize(Money src, Type t, JsonSerializationContext ctx) {
+                return new JsonPrimitive(src.cents);
+            }
+        };
+        Gson gson = new GsonBuilder().registerTypeAdapter(Money.class, ser).create();
+        assertEquals("789", gson.toJson(new Money(789)));
+    }
+
+    @Test
+    public void testCustomJsonDeserializer() {
+        JsonDeserializer<Money> de = new JsonDeserializer<Money>() {
+            @Override public Money deserialize(JsonElement json, Type t, JsonDeserializationContext ctx)
+                    throws JsonParseException {
+                return new Money(json.getAsLong());
+            }
+        };
+        Gson gson = new GsonBuilder().registerTypeAdapter(Money.class, de).create();
+        assertEquals(4242, gson.fromJson("4242", Money.class).cents);
+    }
+
+    // ----------------------------------------------------------------
+    // 17. JsonParser + tree model (JsonObject / JsonArray / JsonPrimitive)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testJsonParserParseObject() {
+        JsonElement el = JsonParser.parseString("{\"k\":\"v\",\"n\":42}");
+        assertTrue(el.isJsonObject());
+        JsonObject obj = el.getAsJsonObject();
+        assertEquals("v", obj.get("k").getAsString());
+        assertEquals(42, obj.get("n").getAsInt());
+    }
+
+    @Test
+    public void testJsonParserParseArray() {
+        JsonElement el = JsonParser.parseString("[1,2,3]");
+        assertTrue(el.isJsonArray());
+        JsonArray arr = el.getAsJsonArray();
+        assertEquals(3, arr.size());
+        assertEquals(1, arr.get(0).getAsInt());
+        assertEquals(3, arr.get(2).getAsInt());
+    }
+
+    @Test
+    public void testJsonObjectBuildAndSerialize() {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("name", "Tim");
+        obj.addProperty("age", 30);
+        obj.addProperty("ok", true);
+        obj.add("nullField", JsonNull.INSTANCE);
+        assertEquals("{\"name\":\"Tim\",\"age\":30,\"ok\":true,\"nullField\":null}", obj.toString());
+    }
+
+    @Test
+    public void testJsonArrayBuild() {
+        JsonArray arr = new JsonArray();
+        arr.add(1);
+        arr.add("two");
+        arr.add(true);
+        assertEquals("[1,\"two\",true]", arr.toString());
+        assertEquals(3, arr.size());
+    }
+
+    @Test
+    public void testJsonPrimitiveTypes() {
+        JsonPrimitive pInt = new JsonPrimitive(42);
+        assertTrue(pInt.isNumber());
+        assertEquals(42, pInt.getAsInt());
+
+        JsonPrimitive pStr = new JsonPrimitive("hello");
+        assertTrue(pStr.isString());
+        assertEquals("hello", pStr.getAsString());
+
+        JsonPrimitive pBool = new JsonPrimitive(true);
+        assertTrue(pBool.isBoolean());
+        assertTrue(pBool.getAsBoolean());
+    }
+
+    @Test
+    public void testJsonNull() {
+        assertTrue(JsonNull.INSTANCE.isJsonNull());
+        assertEquals("null", JsonParser.parseString("null").toString());
+    }
+
+    @Test
+    public void testJsonObjectHasAndRemove() {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("a", 1);
+        obj.addProperty("b", 2);
+        assertTrue(obj.has("a"));
+        assertFalse(obj.has("z"));
+        obj.remove("a");
+        assertFalse(obj.has("a"));
+        assertEquals(1, obj.entrySet().size());
+    }
+
+    @Test
+    public void testNestedTreeNavigation() {
+        JsonElement el = JsonParser.parseString(
+                "{\"user\":{\"name\":\"Q\",\"roles\":[\"admin\",\"dev\"]}}");
+        JsonObject root = el.getAsJsonObject();
+        JsonObject user = root.getAsJsonObject("user");
+        assertEquals("Q", user.get("name").getAsString());
+        JsonArray roles = user.getAsJsonArray("roles");
+        assertEquals("admin", roles.get(0).getAsString());
+        assertEquals("dev", roles.get(1).getAsString());
+    }
+
+    // ----------------------------------------------------------------
+    // 18. toJsonTree / fromJson(JsonElement)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testToJsonTree() {
+        Gson gson = new Gson();
+        JsonElement tree = gson.toJsonTree(new Point(11, 22));
+        assertTrue(tree.isJsonObject());
+        assertEquals(11, tree.getAsJsonObject().get("x").getAsInt());
+        assertEquals(22, tree.getAsJsonObject().get("y").getAsInt());
+    }
+
+    @Test
+    public void testFromJsonElement() {
+        Gson gson = new Gson();
+        JsonObject obj = new JsonObject();
+        obj.addProperty("x", 100);
+        obj.addProperty("y", 200);
+        Point p = gson.fromJson(obj, Point.class);
+        assertEquals(100, p.x);
+        assertEquals(200, p.y);
+    }
+
+    // ----------------------------------------------------------------
+    // 19. JsonWriter streaming (manual)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testJsonWriterStreaming() throws IOException {
+        StringWriter sw = new StringWriter();
+        JsonWriter w = new JsonWriter(sw);
+        w.beginObject();
+        w.name("id").value(7);
+        w.name("tags").beginArray().value("x").value("y").endArray();
+        w.name("flag").value(true);
+        w.name("nothing").nullValue();
+        w.endObject();
+        w.close();
+        assertEquals("{\"id\":7,\"tags\":[\"x\",\"y\"],\"flag\":true,\"nothing\":null}", sw.toString());
+    }
+
+    @Test
+    public void testJsonWriterIndented() throws IOException {
+        StringWriter sw = new StringWriter();
+        JsonWriter w = new JsonWriter(sw);
+        w.setIndent("  ");
+        w.beginObject();
+        w.name("a").value(1);
+        w.endObject();
+        w.close();
+        assertEquals("{\n  \"a\": 1\n}", sw.toString());
+    }
+
+    // ----------------------------------------------------------------
+    // 20. JsonReader streaming (manual)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testJsonReaderStreaming() throws IOException {
+        JsonReader r = new JsonReader(new StringReader("{\"name\":\"Bob\",\"age\":50}"));
+        r.beginObject();
+        assertEquals(JsonToken.NAME, r.peek());
+        assertEquals("name", r.nextName());
+        assertEquals("Bob", r.nextString());
+        assertEquals("age", r.nextName());
+        assertEquals(50, r.nextInt());
+        r.endObject();
+        assertEquals(JsonToken.END_DOCUMENT, r.peek());
+        r.close();
+    }
+
+    @Test
+    public void testJsonReaderArray() throws IOException {
+        JsonReader r = new JsonReader(new StringReader("[10,20,30]"));
+        r.beginArray();
+        List<Integer> got = new ArrayList<Integer>();
+        while (r.hasNext()) {
+            got.add(r.nextInt());
+        }
+        r.endArray();
+        r.close();
+        assertEquals(Arrays.asList(10, 20, 30), got);
+    }
+
+    // ----------------------------------------------------------------
+    // 21. Numbers: int, long, double, BigInteger, BigDecimal
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testSerializeNumbers() {
+        Gson gson = new Gson();
+        assertEquals("42", gson.toJson(42));
+        assertEquals("42", gson.toJson(42L));
+        assertEquals("3.14", gson.toJson(3.14));
+        assertEquals("1234567890123456789", gson.toJson(new BigInteger("1234567890123456789")));
+        assertEquals("123.456", gson.toJson(new BigDecimal("123.456")));
+    }
+
+    @Test
+    public void testDeserializeNumbers() {
+        Gson gson = new Gson();
+        assertEquals(Integer.valueOf(7), gson.fromJson("7", Integer.class));
+        assertEquals(Long.valueOf(9999999999L), gson.fromJson("9999999999", Long.class));
+        assertEquals(2.5, gson.fromJson("2.5", Double.class), 0.0);
+        assertEquals(new BigInteger("98765432109876543210"),
+                gson.fromJson("98765432109876543210", BigInteger.class));
+        assertEquals(new BigDecimal("0.001"), gson.fromJson("0.001", BigDecimal.class));
+    }
+
+    @Test
+    public void testLongSerializationPolicyString() {
+        Gson gson = new GsonBuilder()
+                .setLongSerializationPolicy(LongSerializationPolicy.STRING)
+                .create();
+        assertEquals("\"123\"", gson.toJson(123L));
+    }
+
+    // ----------------------------------------------------------------
+    // 22. HTML escaping
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testHtmlEscapingDefault() {
+        Gson gson = new Gson();
+        // default: HTML chars escaped
+        assertEquals("\"\\u003ca\\u003e\"", gson.toJson("<a>"));
+        // Gson's HTML-safe escaping also escapes '=' as = and '&' as &.
+        assertEquals("\"a\\u003db\\u0026c\"", gson.toJson("a=b&c"));
+    }
+
+    @Test
+    public void testHtmlEscapingDisabled() {
+        Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+        assertEquals("\"<a>\"", gson.toJson("<a>"));
+        assertEquals("\"a=b&c\"", gson.toJson("a=b&c"));
+    }
+
+    @Test
+    public void testStringEscaping() {
+        Gson gson = new Gson();
+        // quotes, backslash, newline, tab
+        assertEquals("\"a\\\"b\\\\c\\nd\\te\"", gson.toJson("a\"b\\c\nd\te"));
+    }
+
+    @Test
+    public void testUnicodeRoundTrip() {
+        Gson gson = new Gson();
+        String s = gson.toJson("héllo");
+        assertEquals("héllo", gson.fromJson(s, String.class));
+    }
+
+    // ----------------------------------------------------------------
+    // 23. Errors / exceptions
+    // ----------------------------------------------------------------
+
+    @Test(expected = JsonSyntaxException.class)
+    public void testMalformedJsonThrows() {
+        new Gson().fromJson("{not valid json", Person.class);
+    }
+
+    @Test(expected = JsonSyntaxException.class)
+    public void testTrailingDataThrows() {
+        new Gson().fromJson("{\"x\":1,\"y\":2} extra", Point.class);
+    }
+
+    @Test
+    public void testNullStringDeserializesToNull() {
+        Gson gson = new Gson();
+        assertNull(gson.fromJson("null", Person.class));
+    }
+
+    // ----------------------------------------------------------------
+    // 24. Arrays (primitive + object)
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testSerializeIntArray() {
+        Gson gson = new Gson();
+        assertEquals("[1,2,3,4]", gson.toJson(new int[] {1, 2, 3, 4}));
+    }
+
+    @Test
+    public void testDeserializeIntArray() {
+        Gson gson = new Gson();
+        int[] arr = gson.fromJson("[5,6,7]", int[].class);
+        assertArrayEquals(new int[] {5, 6, 7}, arr);
+    }
+
+    @Test
+    public void testSerializeStringArray() {
+        Gson gson = new Gson();
+        assertEquals("[\"a\",\"b\"]", gson.toJson(new String[] {"a", "b"}));
+    }
+
+    @Test
+    public void testDeserializeStringArray() {
+        Gson gson = new Gson();
+        String[] arr = gson.fromJson("[\"p\",\"q\",\"r\"]", String[].class);
+        assertArrayEquals(new String[] {"p", "q", "r"}, arr);
+    }
+
+    @Test
+    public void testTwoDimensionalArray() {
+        Gson gson = new Gson();
+        int[][] grid = {{1, 2}, {3, 4}};
+        assertEquals("[[1,2],[3,4]]", gson.toJson(grid));
+        int[][] back = gson.fromJson("[[5,6],[7,8]]", int[][].class);
+        assertEquals(5, back[0][0]);
+        assertEquals(8, back[1][1]);
+    }
+
+    // ----------------------------------------------------------------
+    // 25. newBuilder / Gson config introspection
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testNewBuilderInheritsConfig() {
+        Gson base = new GsonBuilder().serializeNulls().create();
+        assertTrue(base.serializeNulls());
+        Gson derived = base.newBuilder().create();
+        assertTrue(derived.serializeNulls());
+    }
+
+    @Test
+    public void testHtmlSafeFlag() {
+        assertTrue(new Gson().htmlSafe());
+        assertFalse(new GsonBuilder().disableHtmlEscaping().create().htmlSafe());
+    }
+
+    // ----------------------------------------------------------------
+    // 26. getAdapter + TypeAdapter.toJson / fromJson
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testGetAdapterToJsonAndFromJson() throws IOException {
+        Gson gson = new Gson();
+        TypeAdapter<Point> adapter = gson.getAdapter(Point.class);
+        assertEquals("{\"x\":1,\"y\":2}", adapter.toJson(new Point(1, 2)));
+        Point p = adapter.fromJson("{\"x\":9,\"y\":8}");
+        assertEquals(9, p.x);
+        assertEquals(8, p.y);
+    }
+
+    @Test
+    public void testGetAdapterViaTypeToken() throws IOException {
+        Gson gson = new Gson();
+        TypeAdapter<List<Integer>> adapter =
+                gson.getAdapter(new TypeToken<List<Integer>>() {});
+        assertEquals("[1,2,3]", adapter.toJson(Arrays.asList(1, 2, 3)));
+    }
+
+    @Test
+    public void testTypeAdapterNullSafe() throws IOException {
+        Gson gson = new Gson();
+        TypeAdapter<Point> adapter = gson.getAdapter(Point.class).nullSafe();
+        assertEquals("null", adapter.toJson(null));
+        assertNull(adapter.fromJson("null"));
+    }
+
+    // ----------------------------------------------------------------
+    // 27. registerTypeHierarchyAdapter
+    // ----------------------------------------------------------------
+
+    interface Shape {}
+    static class Circle implements Shape { int r = 5; }
+
+    @Test
+    public void testTypeHierarchyAdapter() {
+        JsonSerializer<Shape> ser = new JsonSerializer<Shape>() {
+            @Override public JsonElement serialize(Shape src, Type t, JsonSerializationContext ctx) {
+                return new JsonPrimitive("shape");
+            }
+        };
+        Gson gson = new GsonBuilder().registerTypeHierarchyAdapter(Shape.class, ser).create();
+        assertEquals("\"shape\"", gson.toJson(new Circle(), Shape.class));
+    }
+
+    // ----------------------------------------------------------------
+    // 28. Map round-trip with complex values via TypeToken
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testMapOfPojoRoundTrip() {
+        Gson gson = new Gson();
+        Map<String, Point> m = new LinkedHashMap<String, Point>();
+        m.put("a", new Point(1, 2));
+        m.put("b", new Point(3, 4));
+        String json = gson.toJson(m);
+        assertEquals("{\"a\":{\"x\":1,\"y\":2},\"b\":{\"x\":3,\"y\":4}}", json);
+
+        Type t = new TypeToken<Map<String, Point>>() {}.getType();
+        Map<String, Point> back = gson.fromJson(json, t);
+        assertEquals(1, back.get("a").x);
+        assertEquals(4, back.get("b").y);
+    }
+
+    // ----------------------------------------------------------------
+    // 29. JsonObject deepCopy + JsonElement equality
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testJsonElementEquals() {
+        JsonElement a = JsonParser.parseString("{\"x\":1,\"y\":2}");
+        JsonElement b = JsonParser.parseString("{\"x\":1,\"y\":2}");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        JsonElement c = JsonParser.parseString("{\"x\":1,\"y\":3}");
+        assertNotEquals(a, c);
+    }
+
+    @Test
+    public void testJsonObjectDeepCopy() {
+        JsonObject orig = new JsonObject();
+        orig.addProperty("k", 1);
+        JsonObject copy = orig.deepCopy();
+        copy.addProperty("k", 2);
+        assertEquals(1, orig.get("k").getAsInt());
+        assertEquals(2, copy.get("k").getAsInt());
+    }
+
+    // ----------------------------------------------------------------
+    // 30. Empty / edge structures
+    // ----------------------------------------------------------------
+
+    @Test
+    public void testEmptyObjectAndArray() {
+        Gson gson = new Gson();
+        assertEquals("{}", gson.toJson(new LinkedHashMap<String, Object>()));
+        assertEquals("[]", gson.toJson(new ArrayList<Object>()));
+        assertEquals("{}", new JsonObject().toString());
+        assertEquals("[]", new JsonArray().toString());
+    }
+
+    @Test
+    public void testGetAsNumberConversions() {
+        JsonPrimitive p = new JsonPrimitive(255);
+        assertEquals(255L, p.getAsLong());
+        assertEquals(255.0, p.getAsDouble(), 0.0);
+        assertEquals((short) 255, p.getAsShort());
+        assertEquals("255", p.getAsString());
+    }
+}

--- a/apps/starry/java-lang/programs/backcompat/src/LoggingBackCompatTest.java
+++ b/apps/starry/java-lang/programs/backcompat/src/LoggingBackCompatTest.java
@@ -1,0 +1,642 @@
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.NullConfiguration;
+import org.apache.logging.log4j.message.MessageFormatMessage;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.message.StringFormattedMessage;
+import org.apache.logging.log4j.spi.StandardLevel;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Java-8 backward-compatibility proof carpet, Logging group.
+ *
+ * <p>Libraries under test (Java-8-era, pure-Java):
+ * <ul>
+ *   <li>org.apache.logging.log4j:log4j-api:2.17.1</li>
+ *   <li>org.apache.logging.log4j:log4j-core:2.17.1</li>
+ * </ul>
+ *
+ * <p>Compiled with {@code --release 8} (bytecode major 52); uses only Java 8 source
+ * features and only Log4j2 2.x API that is stable across JDK 17/21/23/25.
+ *
+ * <p>DETERMINISM STRATEGY: every test drives a private {@link LoggerContext} built on a
+ * {@link NullConfiguration}. A custom in-memory appender ({@link CapturingAppender})
+ * records ONLY the formatted message string (and, for the structured tests, the level /
+ * marker name / MDC snapshot / logger name / thrown class name) -- never a timestamp,
+ * thread id or any other non-deterministic field. Fixed inputs therefore always yield a
+ * fixed, order-stable list of captured strings which we assert exactly.
+ */
+public class LoggingBackCompatTest {
+
+    // ------------------------------------------------------------------
+    // In-memory capturing appender. Captures only deterministic fields.
+    // ------------------------------------------------------------------
+    static final class CapturingAppender extends AbstractAppender {
+
+        final List<String> messages = new CopyOnWriteArrayList<>();
+        final List<Level> levels = new CopyOnWriteArrayList<>();
+        final List<String> markerNames = new CopyOnWriteArrayList<>();
+        final List<Map<String, String>> contexts = new CopyOnWriteArrayList<>();
+        final List<String> loggerNames = new CopyOnWriteArrayList<>();
+        final List<String> thrownClasses = new CopyOnWriteArrayList<>();
+
+        @SuppressWarnings("deprecation")
+        CapturingAppender(final String name) {
+            super(name, (Filter) null, (Layout<? extends Serializable>) null);
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+            levels.add(event.getLevel());
+            final Marker m = event.getMarker();
+            markerNames.add(m == null ? null : m.getName());
+            contexts.add(event.getContextData().toMap());
+            loggerNames.add(event.getLoggerName());
+            final Throwable t = event.getThrown();
+            thrownClasses.add(t == null ? null : t.getClass().getName());
+        }
+
+        void reset() {
+            messages.clear();
+            levels.clear();
+            markerNames.clear();
+            contexts.clear();
+            loggerNames.clear();
+            thrownClasses.clear();
+        }
+
+        List<String> messages() {
+            return new ArrayList<>(messages);
+        }
+    }
+
+    // A single private context + appender + logger config, created ONCE. Re-creating
+    // the LoggerConfig per test makes the context's cached Logger route to a stale
+    // config (verified), so we instead build the pipeline once and reset the capture
+    // buffers + level threshold between tests for full isolation and determinism.
+    private static LoggerContext ctx;
+    private static CapturingAppender sharedAppender;
+
+    private CapturingAppender appender; // alias of sharedAppender, per-test convenience
+    private Logger logger;              // bound to logger name "test.logger"
+
+    private static final String LOGGER_NAME = "test.logger";
+
+    @BeforeClass
+    public static void bootContext() {
+        // A standalone context that does NOT touch any classpath log4j2.xml.
+        ctx = new LoggerContext("backcompat-logging-test");
+        ctx.start(new NullConfiguration());
+
+        final Configuration config = ctx.getConfiguration();
+        sharedAppender = new CapturingAppender("cap");
+        sharedAppender.start();
+        config.addAppender(sharedAppender);
+
+        final LoggerConfig lc = new LoggerConfig(LOGGER_NAME, Level.TRACE, false);
+        lc.addAppender(sharedAppender, Level.TRACE, null);
+        config.addLogger(LOGGER_NAME, lc);
+        ctx.updateLoggers();
+    }
+
+    @AfterClass
+    public static void shutdownContext() {
+        if (ctx != null) {
+            ctx.stop();
+            ctx = null;
+        }
+        sharedAppender = null;
+    }
+
+    @Before
+    public void wireAppender() {
+        // Always start from a clean MDC/NDC so tests are independent.
+        ThreadContext.clearAll();
+        appender = sharedAppender;
+        appender.reset();
+
+        // Reset threshold to TRACE so every test starts wide open.
+        ctx.getConfiguration().getLoggerConfig(LOGGER_NAME).setLevel(Level.TRACE);
+        ctx.updateLoggers();
+
+        logger = ctx.getLogger(LOGGER_NAME);
+    }
+
+    @After
+    public void unwireAppender() {
+        // Restore wide-open threshold and clear capture + MDC for the next test.
+        if (ctx != null) {
+            ctx.getConfiguration().getLoggerConfig(LOGGER_NAME).setLevel(Level.TRACE);
+            ctx.updateLoggers();
+        }
+        if (sharedAppender != null) {
+            sharedAppender.reset();
+        }
+        ThreadContext.clearAll();
+    }
+
+    // ==================================================================
+    // 1. Basic level logging -> exact captured message list
+    // ==================================================================
+    @Test
+    public void infoLogsSingleMessage() {
+        logger.info("hello world");
+        assertEquals(Collections.singletonList("hello world"), appender.messages());
+        assertEquals(1, appender.levels.size());
+        assertEquals(Level.INFO, appender.levels.get(0));
+        assertEquals(LOGGER_NAME, appender.loggerNames.get(0));
+    }
+
+    @Test
+    public void allSixLevelsCapturedInOrder() {
+        logger.trace("t");
+        logger.debug("d");
+        logger.info("i");
+        logger.warn("w");
+        logger.error("e");
+        logger.fatal("f");
+        assertEquals(Arrays.asList("t", "d", "i", "w", "e", "f"), appender.messages());
+        assertEquals(
+                Arrays.asList(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR, Level.FATAL),
+                new ArrayList<>(appender.levels));
+    }
+
+    @Test
+    public void emptyAppenderWhenNothingLogged() {
+        assertTrue(appender.messages().isEmpty());
+    }
+
+    @Test
+    public void logViaGenericLevelMethod() {
+        logger.log(Level.WARN, "generic-level");
+        assertEquals(Collections.singletonList("generic-level"), appender.messages());
+        assertEquals(Level.WARN, appender.levels.get(0));
+    }
+
+    // ==================================================================
+    // 2. Level threshold filtering (deterministic suppression)
+    // ==================================================================
+    @Test
+    public void levelThresholdSuppressesLowerLevels() {
+        ctx.getConfiguration().getLoggerConfig(LOGGER_NAME).setLevel(Level.WARN);
+        ctx.updateLoggers();
+
+        logger.trace("t");   // suppressed
+        logger.debug("d");   // suppressed
+        logger.info("i");    // suppressed
+        logger.warn("w");    // kept
+        logger.error("e");   // kept
+        assertEquals(Arrays.asList("w", "e"), appender.messages());
+    }
+
+    @Test
+    public void offLevelSuppressesEverything() {
+        ctx.getConfiguration().getLoggerConfig(LOGGER_NAME).setLevel(Level.OFF);
+        ctx.updateLoggers();
+        logger.fatal("nope");
+        logger.error("nope2");
+        assertTrue(appender.messages().isEmpty());
+    }
+
+    @Test
+    public void isEnabledMatchesThreshold() {
+        ctx.getConfiguration().getLoggerConfig(LOGGER_NAME).setLevel(Level.INFO);
+        ctx.updateLoggers();
+        assertFalse(logger.isTraceEnabled());
+        assertFalse(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+        assertTrue(logger.isWarnEnabled());
+        assertTrue(logger.isErrorEnabled());
+    }
+
+    // ==================================================================
+    // 3. Parameterized ({}) messages
+    // ==================================================================
+    @Test
+    public void parameterizedSinglePlaceholder() {
+        logger.info("user={}", "alice");
+        assertEquals(Collections.singletonList("user=alice"), appender.messages());
+    }
+
+    @Test
+    public void parameterizedTwoPlaceholders() {
+        logger.info("{} + {} = {}", 1, 2, 3);
+        assertEquals(Collections.singletonList("1 + 2 = 3"), appender.messages());
+    }
+
+    @Test
+    public void parameterizedTooFewArgsLeavesPlaceholder() {
+        logger.info("a={} b={}", "x");
+        assertEquals(Collections.singletonList("a=x b={}"), appender.messages());
+    }
+
+    @Test
+    public void parameterizedExtraArgsIgnoredInText() {
+        logger.info("only={}", "first", "second");
+        assertEquals(Collections.singletonList("only=first"), appender.messages());
+    }
+
+    @Test
+    public void escapedPlaceholderIsLiteral() {
+        // \{} is an escaped placeholder -> rendered literally as {}
+        logger.info("literal=\\{} value={}", "v");
+        assertEquals(Collections.singletonList("literal={} value=v"), appender.messages());
+    }
+
+    @Test
+    public void parameterizedNullArgumentRendersNull() {
+        logger.info("x={}", (Object) null);
+        assertEquals(Collections.singletonList("x=null"), appender.messages());
+    }
+
+    // ==================================================================
+    // 4. Message object types (ParameterizedMessage / String.format / MessageFormat)
+    // ==================================================================
+    @Test
+    public void parameterizedMessageObject() {
+        ParameterizedMessage pm = new ParameterizedMessage("{}-{}", "a", "b");
+        assertEquals("a-b", pm.getFormattedMessage());
+        assertEquals("{}-{}", pm.getFormat());
+        assertArrayEquals(new Object[] {"a", "b"}, pm.getParameters());
+        logger.info(pm);
+        assertEquals(Collections.singletonList("a-b"), appender.messages());
+    }
+
+    @Test
+    public void stringFormattedMessageObject() {
+        StringFormattedMessage sm =
+                new StringFormattedMessage(Locale.ROOT, "pi=%.2f n=%d", 3.14159, 7);
+        assertEquals("pi=3.14 n=7", sm.getFormattedMessage());
+        logger.info(sm);
+        assertEquals(Collections.singletonList("pi=3.14 n=7"), appender.messages());
+    }
+
+    @Test
+    public void messageFormatMessageObject() {
+        MessageFormatMessage mf =
+                new MessageFormatMessage(Locale.ROOT, "{0} loves {1}", "Tom", "Jerry");
+        assertEquals("Tom loves Jerry", mf.getFormattedMessage());
+        logger.info(mf);
+        assertEquals(Collections.singletonList("Tom loves Jerry"), appender.messages());
+    }
+
+    @Test
+    public void printfFormattedHelper() {
+        logger.printf(Level.INFO, "[%05d]", 42);
+        assertEquals(Collections.singletonList("[00042]"), appender.messages());
+    }
+
+    // ==================================================================
+    // 5. Throwable attachment captured deterministically (class name only)
+    // ==================================================================
+    @Test
+    public void throwableAttachedToEvent() {
+        IllegalStateException ex = new IllegalStateException("boom");
+        logger.error("failed", ex);
+        assertEquals(Collections.singletonList("failed"), appender.messages());
+        assertEquals("java.lang.IllegalStateException", appender.thrownClasses.get(0));
+    }
+
+    @Test
+    public void noThrowableYieldsNull() {
+        logger.info("clean");
+        assertNull(appender.thrownClasses.get(0));
+    }
+
+    // ==================================================================
+    // 6. Markers
+    // ==================================================================
+    @Test
+    public void markerAttachedToEvent() {
+        Marker sql = MarkerManager.getMarker("SQL");
+        logger.info(sql, "select 1");
+        assertEquals(Collections.singletonList("select 1"), appender.messages());
+        assertEquals("SQL", appender.markerNames.get(0));
+    }
+
+    @Test
+    public void noMarkerYieldsNull() {
+        logger.info("plain");
+        assertNull(appender.markerNames.get(0));
+    }
+
+    @Test
+    public void markerManagerReturnsSameInstance() {
+        Marker a = MarkerManager.getMarker("UNIQUE_MK_A");
+        Marker b = MarkerManager.getMarker("UNIQUE_MK_A");
+        assertSame(a, b);
+        assertTrue(MarkerManager.exists("UNIQUE_MK_A"));
+        assertEquals("UNIQUE_MK_A", a.getName());
+    }
+
+    @Test
+    public void markerParentHierarchyInstanceOf() {
+        Marker parent = MarkerManager.getMarker("PARENT_MK");
+        Marker child = MarkerManager.getMarker("CHILD_MK").setParents(parent);
+        assertTrue(child.hasParents());
+        assertTrue(child.isInstanceOf(parent));
+        assertTrue(child.isInstanceOf("PARENT_MK"));
+        assertFalse(parent.isInstanceOf(child));
+        assertArrayEquals(new Marker[] {parent}, child.getParents());
+    }
+
+    @Test
+    public void markerAddAndRemoveParent() {
+        Marker p1 = MarkerManager.getMarker("ADD_P1");
+        Marker p2 = MarkerManager.getMarker("ADD_P2");
+        Marker c = MarkerManager.getMarker("ADD_C").addParents(p1).addParents(p2);
+        assertTrue(c.isInstanceOf(p1));
+        assertTrue(c.isInstanceOf(p2));
+        assertTrue(c.remove(p1));
+        assertFalse(c.isInstanceOf(p1));
+        assertTrue(c.isInstanceOf(p2));
+    }
+
+    // ==================================================================
+    // 7. ThreadContext (MDC) captured deterministically
+    // ==================================================================
+    @Test
+    public void mdcCapturedOnEvent() {
+        ThreadContext.put("requestId", "R-001");
+        ThreadContext.put("user", "bob");
+        logger.info("with-mdc");
+        Map<String, String> snap = appender.contexts.get(0);
+        assertEquals("R-001", snap.get("requestId"));
+        assertEquals("bob", snap.get("user"));
+        assertEquals(2, snap.size());
+    }
+
+    @Test
+    public void mdcRemovedKeyNotPresent() {
+        ThreadContext.put("k1", "v1");
+        ThreadContext.put("k2", "v2");
+        ThreadContext.remove("k1");
+        logger.info("after-remove");
+        Map<String, String> snap = appender.contexts.get(0);
+        assertFalse(snap.containsKey("k1"));
+        assertEquals("v2", snap.get("k2"));
+        assertEquals(1, snap.size());
+    }
+
+    @Test
+    public void mdcEmptyByDefault() {
+        logger.info("no-mdc");
+        assertTrue(appender.contexts.get(0).isEmpty());
+    }
+
+    @Test
+    public void threadContextApiBehaviour() {
+        assertTrue(ThreadContext.isEmpty());
+        ThreadContext.put("a", "1");
+        assertTrue(ThreadContext.containsKey("a"));
+        assertEquals("1", ThreadContext.get("a"));
+        assertFalse(ThreadContext.isEmpty());
+
+        ThreadContext.putIfNull("a", "2"); // already set, no change
+        assertEquals("1", ThreadContext.get("a"));
+        ThreadContext.putIfNull("b", "3"); // not set, applies
+        assertEquals("3", ThreadContext.get("b"));
+
+        Map<String, String> bulk = new HashMap<>();
+        bulk.put("c", "4");
+        bulk.put("d", "5");
+        ThreadContext.putAll(bulk);
+        assertEquals("4", ThreadContext.get("c"));
+        assertEquals("5", ThreadContext.get("d"));
+
+        Map<String, String> ctxMap = ThreadContext.getImmutableContext();
+        assertEquals(4, ctxMap.size());
+
+        ThreadContext.removeAll(Arrays.asList("a", "b"));
+        assertFalse(ThreadContext.containsKey("a"));
+        assertFalse(ThreadContext.containsKey("b"));
+
+        ThreadContext.clearMap();
+        assertTrue(ThreadContext.isEmpty());
+    }
+
+    @Test
+    public void threadContextStackNdc() {
+        assertEquals(0, ThreadContext.getDepth());
+        ThreadContext.push("frame-1");
+        ThreadContext.push("frame-2");
+        assertEquals(2, ThreadContext.getDepth());
+        assertEquals("frame-2", ThreadContext.peek());
+        assertEquals("frame-2", ThreadContext.pop());
+        assertEquals(1, ThreadContext.getDepth());
+        assertEquals("frame-1", ThreadContext.peek());
+        ThreadContext.clearStack();
+        assertEquals(0, ThreadContext.getDepth());
+    }
+
+    @Test
+    public void threadContextStackParameterizedPush() {
+        ThreadContext.push("op {} on {}", "INSERT", "users");
+        assertEquals("op INSERT on users", ThreadContext.peek());
+        ThreadContext.clearStack();
+    }
+
+    // ==================================================================
+    // 8. Level value object semantics
+    // ==================================================================
+    @Test
+    public void levelIntOrdering() {
+        // Lower intLevel == higher severity in Log4j2's standard ladder.
+        assertEquals(100, Level.FATAL.intLevel());
+        assertEquals(200, Level.ERROR.intLevel());
+        assertEquals(300, Level.WARN.intLevel());
+        assertEquals(400, Level.INFO.intLevel());
+        assertEquals(500, Level.DEBUG.intLevel());
+        assertEquals(600, Level.TRACE.intLevel());
+        assertTrue(Level.ERROR.intLevel() < Level.WARN.intLevel());
+        assertTrue(Level.WARN.intLevel() < Level.INFO.intLevel());
+        assertEquals(Integer.MAX_VALUE, Level.ALL.intLevel());
+        assertEquals(0, Level.OFF.intLevel());
+    }
+
+    @Test
+    public void levelSpecificityComparisons() {
+        // ERROR is more specific (higher severity) than INFO.
+        assertTrue(Level.ERROR.isMoreSpecificThan(Level.INFO));
+        assertTrue(Level.DEBUG.isLessSpecificThan(Level.INFO));
+        assertFalse(Level.INFO.isMoreSpecificThan(Level.ERROR));
+        assertTrue(Level.WARN.isInRange(Level.ERROR, Level.DEBUG));
+        assertFalse(Level.TRACE.isInRange(Level.ERROR, Level.INFO));
+    }
+
+    @Test
+    public void levelNameAndLookup() {
+        assertEquals("INFO", Level.INFO.name());
+        assertEquals("INFO", Level.INFO.toString());
+        assertSame(Level.INFO, Level.getLevel("INFO"));
+        assertSame(Level.WARN, Level.toLevel("WARN"));
+        assertSame(Level.DEBUG, Level.toLevel("does-not-exist", Level.DEBUG));
+        assertNull(Level.getLevel("NO_SUCH_LEVEL"));
+        assertSame(Level.INFO, Level.valueOf("INFO"));
+    }
+
+    @Test
+    public void levelStandardEnumMapping() {
+        assertEquals(StandardLevel.ERROR, Level.ERROR.getStandardLevel());
+        assertEquals(StandardLevel.INFO, Level.INFO.getStandardLevel());
+    }
+
+    @Test
+    public void levelValuesContainsBuiltins() {
+        Level[] vals = Level.values();
+        List<Level> list = Arrays.asList(vals);
+        assertTrue(list.contains(Level.OFF));
+        assertTrue(list.contains(Level.FATAL));
+        assertTrue(list.contains(Level.ERROR));
+        assertTrue(list.contains(Level.WARN));
+        assertTrue(list.contains(Level.INFO));
+        assertTrue(list.contains(Level.DEBUG));
+        assertTrue(list.contains(Level.TRACE));
+        assertTrue(list.contains(Level.ALL));
+    }
+
+    @Test
+    public void customLevelForName() {
+        Level verbose = Level.forName("VERBOSE_CUSTOM", 550);
+        assertEquals("VERBOSE_CUSTOM", verbose.name());
+        assertEquals(550, verbose.intLevel());
+        // forName returns the same registered instance on repeat.
+        assertSame(verbose, Level.forName("VERBOSE_CUSTOM", 550));
+        assertSame(verbose, Level.getLevel("VERBOSE_CUSTOM"));
+
+        // It must be usable as an ordinary log level.
+        logger.log(verbose, "verbose-msg");
+        assertEquals(Collections.singletonList("verbose-msg"), appender.messages());
+        assertSame(verbose, appender.levels.get(0));
+    }
+
+    @Test
+    public void levelComparable() {
+        assertTrue(Level.ERROR.compareTo(Level.WARN) < 0);
+        assertEquals(0, Level.INFO.compareTo(Level.INFO));
+        assertEquals(Level.INFO, Level.INFO);
+    }
+
+    // ==================================================================
+    // 9. Logger identity / naming / additivity
+    // ==================================================================
+    @Test
+    public void loggerNameMatches() {
+        assertEquals(LOGGER_NAME, logger.getName());
+        assertFalse(logger.isAdditive());
+    }
+
+    @Test
+    public void sameNameReturnsSameLoggerInstance() {
+        Logger a = ctx.getLogger(LOGGER_NAME);
+        Logger b = ctx.getLogger(LOGGER_NAME);
+        assertSame(a, b);
+    }
+
+    @Test
+    public void loggerEffectiveLevelReflectsConfig() {
+        ctx.getConfiguration().getLoggerConfig(LOGGER_NAME).setLevel(Level.WARN);
+        ctx.updateLoggers();
+        assertEquals(Level.WARN, ctx.getLogger(LOGGER_NAME).getLevel());
+    }
+
+    // ==================================================================
+    // 10. Supplier / lazy logging (Java 8 lambda) evaluated only when enabled
+    // ==================================================================
+    @Test
+    public void supplierEvaluatedWhenEnabled() {
+        final int[] calls = {0};
+        ctx.getConfiguration().getLoggerConfig(LOGGER_NAME).setLevel(Level.INFO);
+        ctx.updateLoggers();
+        logger.info(() -> {
+            calls[0]++;
+            return "lazy-on";
+        });
+        assertEquals(1, calls[0]);
+        assertEquals(Collections.singletonList("lazy-on"), appender.messages());
+    }
+
+    @Test
+    public void supplierNotEvaluatedWhenDisabled() {
+        final int[] calls = {0};
+        ctx.getConfiguration().getLoggerConfig(LOGGER_NAME).setLevel(Level.ERROR);
+        ctx.updateLoggers();
+        logger.debug(() -> {
+            calls[0]++;
+            return "lazy-off";
+        });
+        assertEquals(0, calls[0]);
+        assertTrue(appender.messages().isEmpty());
+    }
+
+    // ==================================================================
+    // 11. Appender lifecycle / capture isolation
+    // ==================================================================
+    @Test
+    public void appenderNameAndStartedState() {
+        assertEquals("cap", appender.getName());
+        assertTrue(appender.isStarted());
+    }
+
+    @Test
+    public void resetClearsCapture() {
+        logger.info("one");
+        assertEquals(1, appender.messages().size());
+        appender.reset();
+        assertTrue(appender.messages().isEmpty());
+        logger.info("two");
+        assertEquals(Collections.singletonList("two"), appender.messages());
+    }
+
+    // ==================================================================
+    // 12. Combined deterministic scenario (level + marker + mdc + params)
+    // ==================================================================
+    @Test
+    public void combinedDeterministicScenario() {
+        Marker audit = MarkerManager.getMarker("AUDIT");
+        ThreadContext.put("txn", "T-77");
+        logger.warn(audit, "rows affected: {}", 5);
+        logger.error(audit, "rollback {}", "yes");
+
+        assertEquals(Arrays.asList("rows affected: 5", "rollback yes"), appender.messages());
+        assertEquals(Arrays.asList(Level.WARN, Level.ERROR), new ArrayList<>(appender.levels));
+        assertEquals(Arrays.asList("AUDIT", "AUDIT"), new ArrayList<>(appender.markerNames));
+        for (Map<String, String> snap : appender.contexts) {
+            assertEquals("T-77", snap.get("txn"));
+        }
+        assertNotNull(audit);
+    }
+}

--- a/apps/starry/java-lang/programs/backcompat/src/ScriptBackCompatTest.java
+++ b/apps/starry/java-lang/programs/backcompat/src/ScriptBackCompatTest.java
@@ -1,0 +1,979 @@
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+import org.junit.Test;
+
+import bsh.EvalError;
+import bsh.Interpreter;
+import bsh.NameSpace;
+import bsh.Primitive;
+import bsh.TargetError;
+
+/**
+ * Java-8 backward-compatibility proof carpet for the SCRIPT library group:
+ *   - bsh (BeanShell 2.0b6), org.apache-extras.beanshell:bsh:2.0b6
+ *
+ * Every test is fully DETERMINISTIC: fixed scripts produce fixed values,
+ * and we assert exact results + exact runtime types. No randomness, no time,
+ * no filesystem, no locale-sensitive formatting. Source is --release 8 only
+ * (lambdas/streams/Optional/java.time are permitted but BeanShell scripts here
+ * stay on the Java-8 expression surface). Must behave identically on
+ * JDK 17/21/23/25.
+ */
+public class ScriptBackCompatTest {
+
+    /* ----------------------------------------------------------------- *
+     * Arithmetic, operators, precedence, numeric promotion             *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testIntegerArithmeticPrecedence() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("2 + 3 * 4 - 1");
+        assertEquals(Integer.class, r.getClass());
+        assertEquals(13, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testIntegerParentheses() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(20, ((Integer) new Interpreter().eval("(2 + 3) * 4")).intValue());
+        assertEquals(20, bsh.eval("(2 + 3) * 4"));
+    }
+
+    @Test
+    public void testIntegerDivisionAndModulo() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(3, ((Integer) bsh.eval("10 / 3")).intValue());
+        assertEquals(1, ((Integer) bsh.eval("10 % 3")).intValue());
+        assertEquals(-1, ((Integer) bsh.eval("-10 % 3")).intValue());
+    }
+
+    @Test
+    public void testDoubleArithmeticReturnsDouble() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("3.0 / 2.0");
+        assertEquals(Double.class, r.getClass());
+        assertEquals(1.5d, (Double) r, 0.0d);
+    }
+
+    @Test
+    public void testMixedIntDoublePromotion() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("7 / 2.0");
+        assertEquals(Double.class, r.getClass());
+        assertEquals(3.5d, (Double) r, 0.0d);
+    }
+
+    @Test
+    public void testLongLiteralAndArithmetic() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("1000000L * 1000000L");
+        assertEquals(Long.class, r.getClass());
+        assertEquals(1000000000000L, ((Long) r).longValue());
+    }
+
+    @Test
+    public void testFloatLiteral() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("1.5f + 0.5f");
+        assertEquals(Float.class, r.getClass());
+        assertEquals(2.0f, (Float) r, 0.0f);
+    }
+
+    @Test
+    public void testUnaryNegationAndIncrement() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(-5, ((Integer) bsh.eval("-(2 + 3)")).intValue());
+        Object r = bsh.eval("int x = 5; x++; x++; x");
+        assertEquals(7, ((Integer) r).intValue());
+        Object r2 = bsh.eval("int y = 5; ++y");
+        assertEquals(6, ((Integer) r2).intValue());
+    }
+
+    @Test
+    public void testCompoundAssignmentOperators() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("int a = 10; a += 5; a -= 3; a *= 2; a /= 4; a");
+        assertEquals(6, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testBitwiseOperators() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(12, ((Integer) bsh.eval("0xF & 0xC")).intValue());
+        assertEquals(15, ((Integer) bsh.eval("0xC | 0x3")).intValue());
+        assertEquals(6, ((Integer) bsh.eval("0x5 ^ 0x3")).intValue());
+        assertEquals(8, ((Integer) bsh.eval("1 << 3")).intValue());
+        assertEquals(4, ((Integer) bsh.eval("32 >> 3")).intValue());
+        assertEquals(-1, ((Integer) bsh.eval("~0")).intValue());
+    }
+
+    @Test
+    public void testUnsignedRightShift() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("-8 >>> 28");
+        assertEquals(15, ((Integer) r).intValue());
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Booleans, comparisons, logical short-circuit, ternary            *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testBooleanLogicalOperators() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(Boolean.FALSE, bsh.eval("true && false"));
+        assertEquals(Boolean.TRUE, bsh.eval("true || false"));
+        assertEquals(Boolean.TRUE, bsh.eval("!false"));
+        assertEquals(Boolean.TRUE, bsh.eval("(2 > 1) && (3 >= 3)"));
+    }
+
+    @Test
+    public void testComparisonOperators() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(Boolean.TRUE, bsh.eval("5 > 3"));
+        assertEquals(Boolean.FALSE, bsh.eval("5 < 3"));
+        assertEquals(Boolean.TRUE, bsh.eval("5 == 5"));
+        assertEquals(Boolean.TRUE, bsh.eval("5 != 6"));
+        assertEquals(Boolean.TRUE, bsh.eval("5 <= 5"));
+        assertEquals(Boolean.TRUE, bsh.eval("5 >= 5"));
+    }
+
+    @Test
+    public void testTernaryOperator() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(100, ((Integer) bsh.eval("(7 > 3) ? 100 : 200")).intValue());
+        assertEquals(200, ((Integer) bsh.eval("(1 > 3) ? 100 : 200")).intValue());
+    }
+
+    @Test
+    public void testShortCircuitAvoidsSideEffect() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        // If short-circuit works, the right operand (which would set flag) never runs.
+        Object r = bsh.eval("boolean flag = false; boolean result = (false && (flag = true)); flag");
+        assertEquals(Boolean.FALSE, r);
+        Object r2 = bsh.eval("boolean flag2 = false; boolean result2 = (true || (flag2 = true)); flag2");
+        assertEquals(Boolean.FALSE, r2);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Control flow: if/else, while, for, do-while, switch              *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testIfElseChain() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "int classify(int n) {"
+          + "  if (n < 0) return -1;"
+          + "  else if (n == 0) return 0;"
+          + "  else return 1;"
+          + "}"
+          + "classify(-5) * 100 + classify(0) * 10 + classify(7)";
+        Object r = bsh.eval(script);
+        assertEquals(-100 + 0 + 1, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testWhileLoopSum() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "int sum = 0; int i = 1;"
+          + "while (i <= 100) { sum += i; i++; }"
+          + "sum";
+        Object r = bsh.eval(script);
+        assertEquals(5050, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testForLoopProduct() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "long product = 1;"
+          + "for (int i = 1; i <= 6; i++) { product *= i; }"
+          + "product";
+        Object r = bsh.eval(script);
+        assertEquals(720L, ((Long) r).longValue());
+    }
+
+    @Test
+    public void testDoWhileLoop() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "int count = 0; int x = 10;"
+          + "do { count++; x -= 3; } while (x > 0);"
+          + "count";
+        Object r = bsh.eval(script);
+        assertEquals(4, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testForLoopWithBreakAndContinue() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "int sum = 0;"
+          + "for (int i = 0; i < 20; i++) {"
+          + "  if (i % 2 == 0) continue;"   // skip evens
+          + "  if (i > 10) break;"          // stop after 10
+          + "  sum += i;"                   // 1+3+5+7+9
+          + "}"
+          + "sum";
+        Object r = bsh.eval(script);
+        assertEquals(1 + 3 + 5 + 7 + 9, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testNestedLoops() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "int total = 0;"
+          + "for (int i = 1; i <= 3; i++) {"
+          + "  for (int j = 1; j <= 3; j++) {"
+          + "    total += i * j;"
+          + "  }"
+          + "}"
+          + "total";
+        // (1+2+3)*(1+2+3) = 36
+        assertEquals(36, ((Integer) bsh.eval(script)).intValue());
+    }
+
+    @Test
+    public void testSwitchStatement() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "String dayName(int d) {"
+          + "  switch (d) {"
+          + "    case 1: return \"Mon\";"
+          + "    case 2: return \"Tue\";"
+          + "    case 3: return \"Wed\";"
+          + "    default: return \"?\";"
+          + "  }"
+          + "}"
+          + "dayName(2) + dayName(3) + dayName(9)";
+        assertEquals("TueWed?", bsh.eval(script));
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Method / function definitions, recursion, overload-like dispatch *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testRecursiveFactorial() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("int factorial(int n) { if (n <= 1) return 1; return n * factorial(n - 1); }");
+        assertEquals(1, ((Integer) bsh.eval("factorial(0)")).intValue());
+        assertEquals(120, ((Integer) bsh.eval("factorial(5)")).intValue());
+        assertEquals(3628800, ((Integer) bsh.eval("factorial(10)")).intValue());
+    }
+
+    @Test
+    public void testRecursiveFibonacci() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("int fib(int n) { if (n < 2) return n; return fib(n-1) + fib(n-2); }");
+        assertEquals(0, ((Integer) bsh.eval("fib(0)")).intValue());
+        assertEquals(1, ((Integer) bsh.eval("fib(1)")).intValue());
+        assertEquals(55, ((Integer) bsh.eval("fib(10)")).intValue());
+        assertEquals(6765, ((Integer) bsh.eval("fib(20)")).intValue());
+    }
+
+    @Test
+    public void testMethodWithMultipleArguments() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("int gcd(int a, int b) { while (b != 0) { int t = b; b = a % b; a = t; } return a; }");
+        assertEquals(6, ((Integer) bsh.eval("gcd(48, 18)")).intValue());
+        assertEquals(1, ((Integer) bsh.eval("gcd(17, 5)")).intValue());
+        assertEquals(12, ((Integer) bsh.eval("gcd(36, 24)")).intValue());
+    }
+
+    @Test
+    public void testLooselyTypedReturnValue() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        // BeanShell allows "loose" (untyped) functions; here we return a String.
+        bsh.eval("greet(name) { return \"Hello, \" + name + \"!\"; }");
+        assertEquals("Hello, World!", bsh.eval("greet(\"World\")"));
+    }
+
+    @Test
+    public void testMethodCallingMethod() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("int square(int x) { return x * x; }");
+        bsh.eval("int sumOfSquares(int a, int b) { return square(a) + square(b); }");
+        assertEquals(25, ((Integer) bsh.eval("sumOfSquares(3, 4)")).intValue());
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Variable get / set across the Java/BeanShell boundary            *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testSetGetIntPrimitive() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.set("a", 7);
+        bsh.set("b", 35);
+        Object r = bsh.eval("a + b");
+        assertEquals(42, ((Integer) r).intValue());
+        assertEquals(Integer.valueOf(7), bsh.get("a"));
+    }
+
+    @Test
+    public void testSetGetVariousPrimitiveOverloads() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.set("li", 5L);
+        bsh.set("dd", 2.5d);
+        bsh.set("ff", 1.5f);
+        bsh.set("bb", true);
+        assertEquals(Long.valueOf(5L), bsh.get("li"));
+        assertEquals(Double.valueOf(2.5d), bsh.get("dd"));
+        assertEquals(Float.valueOf(1.5f), bsh.get("ff"));
+        assertEquals(Boolean.TRUE, bsh.get("bb"));
+        // Use them in a mixed expression.
+        assertEquals(7.5d, (Double) bsh.eval("li + dd"), 0.0d);
+    }
+
+    @Test
+    public void testSetGetObject() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        List<String> list = new ArrayList<String>(Arrays.asList("alpha", "beta", "gamma"));
+        bsh.set("data", list);
+        Object size = bsh.eval("data.size()");
+        assertEquals(3, ((Integer) size).intValue());
+        assertEquals("beta", bsh.eval("data.get(1)"));
+        // Mutate the same object instance from inside the script.
+        bsh.eval("data.add(\"delta\")");
+        assertEquals(4, list.size());
+        assertEquals("delta", list.get(3));
+    }
+
+    @Test
+    public void testGetVariableSetInsideScript() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("computed = 6 * 7;");
+        Object r = bsh.get("computed");
+        assertEquals(Integer.valueOf(42), r);
+    }
+
+    @Test
+    public void testUnsetVariable() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.set("temp", 99);
+        assertEquals(Integer.valueOf(99), bsh.get("temp"));
+        bsh.unset("temp");
+        // After unset the variable resolves to null via Interpreter.get.
+        assertNull(bsh.get("temp"));
+    }
+
+    @Test
+    public void testGetUndefinedVariableReturnsNull() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertNull(bsh.get("neverDefined"));
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Calling into the Java standard library                            *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testCallMathStaticMethods() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(12, ((Integer) bsh.eval("Math.max(7, 12)")).intValue());
+        assertEquals(7, ((Integer) bsh.eval("Math.min(7, 12)")).intValue());
+        assertEquals(5.0d, (Double) bsh.eval("Math.sqrt(25.0)"), 0.0d);
+        assertEquals(8.0d, (Double) bsh.eval("Math.pow(2.0, 3.0)"), 0.0d);
+        assertEquals(5L, ((Long) bsh.eval("Math.round(4.6)")).longValue());
+        assertEquals(7, ((Integer) bsh.eval("Math.abs(-7)")).intValue());
+    }
+
+    @Test
+    public void testMathConstants() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(Math.PI, (Double) bsh.eval("Math.PI"), 0.0d);
+        assertEquals(Math.E, (Double) bsh.eval("Math.E"), 0.0d);
+    }
+
+    @Test
+    public void testStringMethods() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(5, ((Integer) bsh.eval("\"hello\".length()")).intValue());
+        assertEquals("HELLO", bsh.eval("\"hello\".toUpperCase()"));
+        assertEquals("ell", bsh.eval("\"hello\".substring(1, 4)"));
+        assertEquals(Boolean.TRUE, bsh.eval("\"hello world\".contains(\"world\")"));
+        assertEquals("h-e-l-l-o", bsh.eval("\"hello\".replace(\"\", \"-\").substring(1, 10)"));
+        assertEquals(Integer.valueOf(2), bsh.eval("\"hello\".indexOf(\"l\")"));
+        assertEquals("dlrow", bsh.eval("new StringBuilder(\"world\").reverse().toString()"));
+    }
+
+    @Test
+    public void testIntegerBoxingAndParsing() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(255, ((Integer) bsh.eval("Integer.parseInt(\"FF\", 16)")).intValue());
+        assertEquals(123, ((Integer) bsh.eval("Integer.parseInt(\"123\")")).intValue());
+        assertEquals("101", bsh.eval("Integer.toBinaryString(5)"));
+        assertEquals(Integer.valueOf(Integer.MAX_VALUE), bsh.eval("Integer.MAX_VALUE"));
+    }
+
+    @Test
+    public void testCallJavaUtilArrayList() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "import java.util.ArrayList;"
+          + "list = new ArrayList();"
+          + "list.add(\"x\"); list.add(\"y\"); list.add(\"z\");"
+          + "list.size() * 100 + list.indexOf(\"y\")";
+        assertEquals(301, ((Integer) bsh.eval(script)).intValue());
+    }
+
+    @Test
+    public void testCallJavaUtilHashMap() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "import java.util.HashMap;"
+          + "m = new HashMap();"
+          + "m.put(\"one\", 1); m.put(\"two\", 2); m.put(\"three\", 3);"
+          + "m.get(\"one\") + m.get(\"two\") + m.get(\"three\")";
+        assertEquals(6, ((Integer) bsh.eval(script)).intValue());
+    }
+
+    @Test
+    public void testCallJavaUtilCollectionsSort() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "import java.util.ArrayList;"
+          + "import java.util.Collections;"
+          + "l = new ArrayList();"
+          + "l.add(3); l.add(1); l.add(2);"
+          + "Collections.sort(l);"
+          + "l.get(0) * 100 + l.get(1) * 10 + l.get(2)";
+        assertEquals(123, ((Integer) bsh.eval(script)).intValue());
+    }
+
+    @Test
+    public void testStringBuilderInScript() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "sb = new StringBuilder();"
+          + "for (int i = 0; i < 5; i++) { sb.append(i); }"
+          + "sb.toString()";
+        assertEquals("01234", bsh.eval(script));
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Arrays                                                            *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testIntArrayCreationAndAccess() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "int[] arr = new int[]{10, 20, 30, 40};"
+          + "int s = 0;"
+          + "for (int i = 0; i < arr.length; i++) { s += arr[i]; }"
+          + "s";
+        assertEquals(100, ((Integer) bsh.eval(script)).intValue());
+    }
+
+    @Test
+    public void testArrayReturnedToJava() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("new int[]{1, 2, 3}");
+        assertTrue(r instanceof int[]);
+        assertArrayEquals(new int[] {1, 2, 3}, (int[]) r);
+    }
+
+    @Test
+    public void testStringArrayAndForEach() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "String[] words = new String[]{\"a\", \"bb\", \"ccc\"};"
+          + "int total = 0;"
+          + "for (String w : words) { total += w.length(); }"
+          + "total";
+        assertEquals(6, ((Integer) bsh.eval(script)).intValue());
+    }
+
+    @Test
+    public void testTwoDimensionalArray() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "int[][] m = new int[][]{{1, 2}, {3, 4}};"
+          + "m[0][0] + m[0][1] + m[1][0] + m[1][1]";
+        assertEquals(10, ((Integer) bsh.eval(script)).intValue());
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Returning typed values; null and void                            *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testExplicitReturnString() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object r = bsh.eval("return \"deterministic\";");
+        assertEquals(String.class, r.getClass());
+        assertEquals("deterministic", r);
+    }
+
+    @Test
+    public void testCharLiteralAndConversion() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object c = bsh.eval("char ch = 'A'; ch");
+        assertEquals(Character.class, c.getClass());
+        assertEquals(Character.valueOf('A'), c);
+        Object asInt = bsh.eval("(int) 'A'");
+        assertEquals(65, ((Integer) asInt).intValue());
+    }
+
+    @Test
+    public void testByteAndShortTypes() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object b = bsh.eval("byte bv = 100; bv");
+        assertEquals(Byte.class, b.getClass());
+        assertEquals(Byte.valueOf((byte) 100), b);
+        Object s = bsh.eval("short sv = 1000; sv");
+        assertEquals(Short.class, s.getClass());
+        assertEquals(Short.valueOf((short) 1000), s);
+    }
+
+    @Test
+    public void testNullLiteralUnwrapsToJavaNull() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        // Interpreter.eval unwraps Primitive.NULL to a Java null result.
+        Object r = bsh.eval("null");
+        assertNull(r);
+    }
+
+    @Test
+    public void testAssignedNullReadsBackAsJavaNull() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("Object obj = null;");
+        // Reading a null-valued variable through Interpreter.get yields Java null.
+        assertNull(bsh.get("obj"));
+    }
+
+    @Test
+    public void testVoidStatementUnwrapsToJavaNull() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        // A statement with no value (e.g. a declaration) evaluates to VOID,
+        // which Interpreter.eval unwraps to a Java null result.
+        Object r = bsh.eval("int unusedX = 5;");
+        assertNull(r);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Type checks and casting                                          *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testInstanceofOperator() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(Boolean.TRUE, bsh.eval("\"text\" instanceof String"));
+        assertEquals(Boolean.TRUE, bsh.eval("new java.util.ArrayList() instanceof java.util.List"));
+        assertEquals(Boolean.FALSE, bsh.eval("\"text\" instanceof Integer"));
+    }
+
+    @Test
+    public void testExplicitCasts() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Object d2i = bsh.eval("(int) 3.99");
+        assertEquals(3, ((Integer) d2i).intValue());
+        Object i2d = bsh.eval("(double) 5");
+        assertEquals(5.0d, (Double) i2d, 0.0d);
+        Object i2l = bsh.eval("(long) 42");
+        assertEquals(42L, ((Long) i2l).longValue());
+    }
+
+    /* ----------------------------------------------------------------- *
+     * NameSpace API                                                    *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testNameSpaceGetVariable() throws Exception {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("alpha = 11; beta = 22;");
+        NameSpace ns = bsh.getNameSpace();
+        // NameSpace.getVariable returns a bsh.Primitive wrapper for primitives;
+        // Primitive.unwrap yields the plain Java boxed value.
+        assertEquals(Integer.valueOf(11), Primitive.unwrap(ns.getVariable("alpha")));
+        assertEquals(Integer.valueOf(22), Primitive.unwrap(ns.getVariable("beta")));
+    }
+
+    @Test
+    public void testNameSpaceSetVariableVisibleInScript() throws Exception {
+        Interpreter bsh = new Interpreter();
+        NameSpace ns = bsh.getNameSpace();
+        ns.setVariable("injected", Integer.valueOf(50), false);
+        Object r = bsh.eval("injected + 5");
+        assertEquals(55, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testNameSpaceVariableNamesContainsDefined() throws Exception {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("foo = 1; bar = 2; baz = 3;");
+        NameSpace ns = bsh.getNameSpace();
+        TreeSet<String> names = new TreeSet<String>(Arrays.asList(ns.getVariableNames()));
+        assertTrue(names.contains("foo"));
+        assertTrue(names.contains("bar"));
+        assertTrue(names.contains("baz"));
+    }
+
+    @Test
+    public void testNameSpaceClearRemovesVariables() throws Exception {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("toClear = 123;");
+        NameSpace ns = bsh.getNameSpace();
+        assertEquals(Integer.valueOf(123), Primitive.unwrap(ns.getVariable("toClear")));
+        ns.clear();
+        // After clear the variable is gone; getVariable returns Primitive.VOID for unknown.
+        assertSame(Primitive.VOID, ns.getVariable("toClear"));
+    }
+
+    @Test
+    public void testNamedNameSpaceName() {
+        NameSpace ns = new NameSpace((NameSpace) null, "myScope");
+        assertEquals("myScope", ns.getName());
+    }
+
+    @Test
+    public void testEvalWithExplicitNameSpaceIsolation() throws Exception {
+        Interpreter bsh = new Interpreter();
+        NameSpace scopeA = new NameSpace(bsh.getNameSpace(), "scopeA");
+        bsh.eval("localVal = 7;", scopeA);
+        // The variable lives in scopeA, not the global namespace.
+        assertEquals(Integer.valueOf(7), Primitive.unwrap(scopeA.getVariable("localVal")));
+        assertNull(bsh.get("localVal"));
+    }
+
+    /* ----------------------------------------------------------------- *
+     * eval overloads: Reader-based evaluation                          *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testEvalFromReader() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        // The Reader-based parser requires a statement terminator (return ...;)
+        // for the final value-producing statement at EOF.
+        Reader reader = new StringReader(
+            "int total = 0; for (int i = 1; i <= 10; i++) total += i; return total;");
+        Object r = bsh.eval(reader);
+        assertEquals(55, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testEvalFromInputStreamReader() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        byte[] bytes = "return 6 * 9 + 6;".getBytes(Charset.forName("UTF-8"));
+        Reader reader = new InputStreamReader(new ByteArrayInputStream(bytes), Charset.forName("UTF-8"));
+        Object r = bsh.eval(reader);
+        assertEquals(60, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testEvalWithSourceFileInfo() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Reader reader = new StringReader("return 3 + 4;");
+        Object r = bsh.eval(reader, bsh.getNameSpace(), "synthetic.bsh");
+        assertEquals(7, ((Integer) r).intValue());
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Error handling: EvalError, ParseError, TargetError               *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testEvalErrorOnUndefinedMethod() {
+        Interpreter bsh = new Interpreter();
+        try {
+            bsh.eval("thisMethodDoesNotExistAnywhere(1, 2, 3)");
+            fail("expected EvalError for undefined method");
+        } catch (EvalError e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testEvalErrorOnSyntaxError() {
+        Interpreter bsh = new Interpreter();
+        try {
+            bsh.eval("int x = ;;; @@@ broken");
+            fail("expected EvalError for malformed script");
+        } catch (EvalError e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testTargetErrorWrapsThrownException() {
+        Interpreter bsh = new Interpreter();
+        try {
+            bsh.eval("Integer.parseInt(\"not-a-number\")");
+            fail("expected an EvalError wrapping NumberFormatException");
+        } catch (EvalError e) {
+            // BeanShell wraps target exceptions in TargetError (a subclass of EvalError).
+            assertTrue(e instanceof TargetError);
+            Throwable target = ((TargetError) e).getTarget();
+            assertNotNull(target);
+            assertEquals(NumberFormatException.class, target.getClass());
+        }
+    }
+
+    @Test
+    public void testTargetErrorForExplicitThrow() {
+        Interpreter bsh = new Interpreter();
+        try {
+            bsh.eval("throw new IllegalStateException(\"boom\");");
+            fail("expected EvalError wrapping IllegalStateException");
+        } catch (EvalError e) {
+            assertTrue(e instanceof TargetError);
+            Throwable target = ((TargetError) e).getTarget();
+            assertEquals(IllegalStateException.class, target.getClass());
+            assertEquals("boom", target.getMessage());
+        }
+    }
+
+    @Test
+    public void testCaughtExceptionInsideScript() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "String result;"
+          + "try {"
+          + "  Integer.parseInt(\"xyz\");"
+          + "  result = \"no-error\";"
+          + "} catch (NumberFormatException e) {"
+          + "  result = \"caught\";"
+          + "}"
+          + "result";
+        assertEquals("caught", bsh.eval(script));
+    }
+
+    @Test
+    public void testFinallyBlockRuns() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "StringBuilder sb = new StringBuilder();"
+          + "try { sb.append(\"t\"); throw new RuntimeException(\"x\"); }"
+          + "catch (RuntimeException e) { sb.append(\"c\"); }"
+          + "finally { sb.append(\"f\"); }"
+          + "sb.toString()";
+        assertEquals("tcf", bsh.eval(script));
+    }
+
+    /* ----------------------------------------------------------------- *
+     * getInterface: scripted implementation of a Java interface        *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testGetInterfaceComparator() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        // Define a compare(o1,o2) method, then expose this namespace as a Comparator.
+        bsh.eval("compare(o1, o2) { return o1 - o2; }");
+        @SuppressWarnings("unchecked")
+        Comparator<Integer> cmp = (Comparator<Integer>) bsh.getInterface(Comparator.class);
+        assertNotNull(cmp);
+        assertTrue(cmp.compare(3, 7) < 0);
+        assertTrue(cmp.compare(9, 2) > 0);
+        assertEquals(0, cmp.compare(5, 5));
+
+        // Use the scripted comparator to drive a real java.util.Collections.sort.
+        List<Integer> nums = new ArrayList<Integer>(Arrays.asList(5, 1, 4, 2, 3));
+        java.util.Collections.sort(nums, cmp);
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), nums);
+    }
+
+    @Test
+    public void testGetInterfaceRunnable() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.set("counter", new int[] {0});
+        bsh.eval("run() { counter[0] = counter[0] + 10; }");
+        Runnable runnable = (Runnable) bsh.getInterface(Runnable.class);
+        runnable.run();
+        runnable.run();
+        int[] counter = (int[]) bsh.get("counter");
+        assertEquals(20, counter[0]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Output capture: setOut + printing from a script                  *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testScriptPrintCapturedViaSetOut() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos, true);
+        bsh.setOut(ps);
+        // BeanShell's print() goes to the configured out stream.
+        bsh.eval("print(\"line-1\"); print(\"line-2\");");
+        ps.flush();
+        String out = new String(baos.toByteArray(), Charset.forName("UTF-8"));
+        assertTrue(out.contains("line-1"));
+        assertTrue(out.contains("line-2"));
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Interpreter state persistence across multiple eval calls         *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testStatePersistsAcrossEvalCalls() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("accumulator = 0;");
+        bsh.eval("accumulator += 10;");
+        bsh.eval("accumulator += 20;");
+        bsh.eval("accumulator += 12;");
+        Object r = bsh.eval("accumulator");
+        assertEquals(42, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testMethodDefinedOnceCalledMany() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.eval("int triple(int n) { return n * 3; }");
+        int sum = 0;
+        for (int i = 1; i <= 5; i++) {
+            Object r = bsh.eval("triple(" + i + ")");
+            sum += ((Integer) r).intValue();
+        }
+        // 3*(1+2+3+4+5) = 45
+        assertEquals(45, sum);
+    }
+
+    @Test
+    public void testIndependentInterpretersAreIsolated() throws EvalError {
+        Interpreter a = new Interpreter();
+        Interpreter b = new Interpreter();
+        a.eval("shared = 1;");
+        b.eval("shared = 2;");
+        assertEquals(Integer.valueOf(1), a.get("shared"));
+        assertEquals(Integer.valueOf(2), b.get("shared"));
+    }
+
+    /* ----------------------------------------------------------------- *
+     * BeanShell-specific conveniences                                  *
+     * ----------------------------------------------------------------- */
+
+    @Test
+    public void testLooseTypingReassignmentAcrossTypes() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        // Untyped variable can be reassigned to different types.
+        bsh.eval("x = 5;");
+        assertEquals(Integer.valueOf(5), bsh.get("x"));
+        bsh.eval("x = \"now a string\";");
+        assertEquals("now a string", bsh.get("x"));
+        bsh.eval("x = 3.14;");
+        assertEquals(Double.valueOf(3.14d), bsh.get("x"));
+    }
+
+    @Test
+    public void testStrictJavaModeRejectsUntypedVar() {
+        Interpreter bsh = new Interpreter();
+        bsh.setStrictJava(true);
+        assertTrue(bsh.getStrictJava());
+        try {
+            // In strict-Java mode, an untyped declaration is illegal.
+            bsh.eval("undeclaredLoose = 5;");
+            fail("expected EvalError under strictJava for untyped variable");
+        } catch (EvalError e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testStrictJavaModeAcceptsTypedDeclarations() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        bsh.setStrictJava(true);
+        Object r = bsh.eval("int total = 0; for (int i = 1; i <= 4; i++) { total += i; } return total;");
+        assertEquals(10, ((Integer) r).intValue());
+    }
+
+    @Test
+    public void testScriptedMapBuildingReturnedToJava() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "import java.util.HashMap;"
+          + "HashMap m = new HashMap();"
+          + "for (int i = 1; i <= 3; i++) { m.put(\"k\" + i, i * i); }"
+          + "m";
+        Object r = bsh.eval(script);
+        assertTrue(r instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> m = (Map<String, Object>) r;
+        assertEquals(3, m.size());
+        assertEquals(Integer.valueOf(1), m.get("k1"));
+        assertEquals(Integer.valueOf(4), m.get("k2"));
+        assertEquals(Integer.valueOf(9), m.get("k3"));
+    }
+
+    @Test
+    public void testScriptUsesJavaObjectPassedIn() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        Map<String, Integer> prices = new HashMap<String, Integer>();
+        prices.put("apple", 3);
+        prices.put("pear", 5);
+        prices.put("kiwi", 2);
+        bsh.set("prices", prices);
+        Object total = bsh.eval("prices.get(\"apple\") + prices.get(\"pear\") + prices.get(\"kiwi\")");
+        assertEquals(10, ((Integer) total).intValue());
+    }
+
+    @Test
+    public void testNestedBlockScoping() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        String script =
+            "int outer = 100;"
+          + "{ int inner = 23; outer += inner; }"
+          + "outer";
+        assertEquals(123, ((Integer) bsh.eval(script)).intValue());
+    }
+
+    @Test
+    public void testStringConcatenationWithNumbers() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals("value=42", bsh.eval("\"value=\" + (40 + 2)"));
+        assertEquals("3.14 is pi", bsh.eval("3.14 + \" is pi\""));
+        assertEquals("true!", bsh.eval("(1 < 2) + \"!\""));
+    }
+
+    @Test
+    public void testDeterministicAcrossRepeatedRuns() throws EvalError {
+        // Same script, fresh interpreter, must always equal the same value.
+        String script =
+            "long acc = 0;"
+          + "for (int i = 1; i <= 1000; i++) { acc += (i * i); }"
+          + "acc";
+        long expected = 333833500L; // sum of squares 1..1000
+        for (int run = 0; run < 5; run++) {
+            Interpreter bsh = new Interpreter();
+            Object r = bsh.eval(script);
+            assertEquals(expected, ((Long) r).longValue());
+        }
+    }
+
+    @Test
+    public void testBooleanWrapperEqualityDeterminism() throws EvalError {
+        Interpreter bsh = new Interpreter();
+        assertEquals(Boolean.TRUE, bsh.eval("Boolean.valueOf(\"true\")"));
+        assertEquals(Boolean.FALSE, bsh.eval("Boolean.valueOf(\"false\")"));
+        assertFalse((Boolean) bsh.eval("Boolean.parseBoolean(\"nope\")"));
+    }
+}

--- a/apps/starry/java-lang/programs/backcompat/src/SqlBackCompatTest.java
+++ b/apps/starry/java-lang/programs/backcompat/src/SqlBackCompatTest.java
@@ -1,0 +1,1105 @@
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Java-8 backward-compatibility carpet for the "Sql" library group:
+ *   - H2     2.1.214 (jdbc:h2:mem:)
+ *   - HSQLDB 2.5.2   (jdbc:hsqldb:mem:)
+ *
+ * Every test opens a fresh, private in-memory database, builds fixed schema +
+ * fixed rows, and asserts EXACT results. No NOW()/CURRENT_TIMESTAMP/RANDOM, so
+ * the suite is fully deterministic and identical across JDK 17/21/23/25.
+ * Source uses only Java 8 APIs (compiled with --release 8, bytecode 52).
+ */
+public class SqlBackCompatTest {
+
+    // ----------------------------------------------------------------------
+    // URL helpers. Each test uses a UNIQUE named in-memory DB so tests are
+    // independent and order-insensitive (deterministic regardless of runner).
+    // DB_CLOSE_DELAY=-1 keeps H2 mem DB alive for the connection's lifetime.
+    // ----------------------------------------------------------------------
+    private static int seq = 0;
+
+    private static synchronized String h2Url() {
+        return "jdbc:h2:mem:bc_" + (seq++) + ";DB_CLOSE_DELAY=-1";
+    }
+
+    private static synchronized String hsqlUrl() {
+        return "jdbc:hsqldb:mem:bc_" + (seq++);
+    }
+
+    private Connection h2() throws SQLException {
+        return DriverManager.getConnection(h2Url(), "sa", "");
+    }
+
+    private Connection hsql() throws SQLException {
+        return DriverManager.getConnection(hsqlUrl(), "SA", "");
+    }
+
+    /** CREATE TABLE emp + 5 fixed rows used by many tests. Portable DDL. */
+    private void seedEmp(Connection c) throws SQLException {
+        try (Statement s = c.createStatement()) {
+            s.execute("CREATE TABLE emp ("
+                    + "id INTEGER PRIMARY KEY, "
+                    + "name VARCHAR(40), "
+                    + "dept VARCHAR(20), "
+                    + "salary DECIMAL(10,2))");
+            s.execute("INSERT INTO emp VALUES (1,'Alice','ENG',9000.00)");
+            s.execute("INSERT INTO emp VALUES (2,'Bob','ENG',7500.50)");
+            s.execute("INSERT INTO emp VALUES (3,'Carol','SALES',8000.00)");
+            s.execute("INSERT INTO emp VALUES (4,'Dave','SALES',6000.25)");
+            s.execute("INSERT INTO emp VALUES (5,'Eve','HR',5000.00)");
+        }
+    }
+
+    private void seedDept(Connection c) throws SQLException {
+        try (Statement s = c.createStatement()) {
+            s.execute("CREATE TABLE dept ("
+                    + "code VARCHAR(20) PRIMARY KEY, "
+                    + "label VARCHAR(40))");
+            s.execute("INSERT INTO dept VALUES ('ENG','Engineering')");
+            s.execute("INSERT INTO dept VALUES ('SALES','Sales')");
+            s.execute("INSERT INTO dept VALUES ('HR','Human Resources')");
+        }
+    }
+
+    // ======================================================================
+    // H2 driver registration + connection metadata
+    // ======================================================================
+    @Test
+    public void h2_driverLoadsAndConnects() throws Exception {
+        Class.forName("org.h2.Driver");
+        try (Connection c = h2()) {
+            assertNotNull(c);
+            assertFalse(c.isClosed());
+            assertTrue(c.isValid(2));
+        }
+    }
+
+    @Test
+    public void h2_databaseMetaData() throws Exception {
+        try (Connection c = h2()) {
+            DatabaseMetaData md = c.getMetaData();
+            assertEquals("H2", md.getDatabaseProductName());
+            assertTrue(md.supportsTransactions());
+            assertTrue(md.supportsResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE));
+        }
+    }
+
+    // ======================================================================
+    // H2 basic CRUD via Statement
+    // ======================================================================
+    @Test
+    public void h2_selectCount() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM emp")) {
+                assertTrue(rs.next());
+                assertEquals(5, rs.getInt(1));
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test
+    public void h2_whereFilter() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT name FROM emp WHERE dept='ENG' ORDER BY id")) {
+                List<String> got = new ArrayList<>();
+                while (rs.next()) got.add(rs.getString("name"));
+                assertEquals(java.util.Arrays.asList("Alice", "Bob"), got);
+            }
+        }
+    }
+
+    @Test
+    public void h2_orderByDesc() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT id FROM emp ORDER BY salary DESC")) {
+                int[] order = new int[5];
+                int i = 0;
+                while (rs.next()) order[i++] = rs.getInt(1);
+                assertArrayEquals(new int[] {1, 3, 2, 4, 5}, order);
+            }
+        }
+    }
+
+    @Test
+    public void h2_aggregateGroupBy() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT dept, COUNT(*), SUM(salary) FROM emp "
+                   + "GROUP BY dept ORDER BY dept")) {
+                assertTrue(rs.next());
+                assertEquals("ENG", rs.getString(1));
+                assertEquals(2, rs.getInt(2));
+                assertEquals(0, new BigDecimal("16500.50").compareTo(rs.getBigDecimal(3)));
+                assertTrue(rs.next());
+                assertEquals("HR", rs.getString(1));
+                assertEquals(1, rs.getInt(2));
+                assertTrue(rs.next());
+                assertEquals("SALES", rs.getString(1));
+                assertEquals(2, rs.getInt(2));
+                assertEquals(0, new BigDecimal("14000.25").compareTo(rs.getBigDecimal(3)));
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test
+    public void h2_havingClause() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT dept FROM emp GROUP BY dept "
+                   + "HAVING COUNT(*) > 1 ORDER BY dept")) {
+                List<String> got = new ArrayList<>();
+                while (rs.next()) got.add(rs.getString(1));
+                assertEquals(java.util.Arrays.asList("ENG", "SALES"), got);
+            }
+        }
+    }
+
+    @Test
+    public void h2_minMaxAvg() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT MIN(salary), MAX(salary) FROM emp")) {
+                assertTrue(rs.next());
+                assertEquals(0, new BigDecimal("5000.00").compareTo(rs.getBigDecimal(1)));
+                assertEquals(0, new BigDecimal("9000.00").compareTo(rs.getBigDecimal(2)));
+            }
+        }
+    }
+
+    @Test
+    public void h2_innerJoin() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            seedDept(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT e.name, d.label FROM emp e "
+                   + "JOIN dept d ON e.dept = d.code "
+                   + "WHERE e.dept='HR'")) {
+                assertTrue(rs.next());
+                assertEquals("Eve", rs.getString(1));
+                assertEquals("Human Resources", rs.getString(2));
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test
+    public void h2_leftJoinNull() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE a (id INT)");
+                s.execute("CREATE TABLE b (id INT, v VARCHAR(10))");
+                s.execute("INSERT INTO a VALUES (1),(2)");
+                s.execute("INSERT INTO b VALUES (1,'one')");
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT a.id, b.v FROM a LEFT JOIN b ON a.id=b.id ORDER BY a.id")) {
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1));
+                assertEquals("one", rs.getString(2));
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1));
+                assertNull(rs.getString(2));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    // ======================================================================
+    // H2 PreparedStatement
+    // ======================================================================
+    @Test
+    public void h2_preparedQuery() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (PreparedStatement ps = c.prepareStatement(
+                     "SELECT name FROM emp WHERE salary > ? ORDER BY salary")) {
+                ps.setBigDecimal(1, new BigDecimal("7000.00"));
+                try (ResultSet rs = ps.executeQuery()) {
+                    List<String> got = new ArrayList<>();
+                    while (rs.next()) got.add(rs.getString(1));
+                    assertEquals(java.util.Arrays.asList("Bob", "Carol", "Alice"), got);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void h2_preparedInsertUpdateDelete() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(20))");
+            }
+            try (PreparedStatement ps = c.prepareStatement(
+                     "INSERT INTO t VALUES (?,?)")) {
+                ps.setInt(1, 10);
+                ps.setString(2, "x");
+                assertEquals(1, ps.executeUpdate());
+            }
+            try (PreparedStatement ps = c.prepareStatement(
+                     "UPDATE t SET v=? WHERE id=?")) {
+                ps.setString(1, "y");
+                ps.setInt(2, 10);
+                assertEquals(1, ps.executeUpdate());
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT v FROM t WHERE id=10")) {
+                assertTrue(rs.next());
+                assertEquals("y", rs.getString(1));
+            }
+            try (PreparedStatement ps = c.prepareStatement("DELETE FROM t WHERE id=?")) {
+                ps.setInt(1, 10);
+                assertEquals(1, ps.executeUpdate());
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM t")) {
+                assertTrue(rs.next());
+                assertEquals(0, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void h2_preparedBatch() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE nums (n INT)");
+            }
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO nums VALUES (?)")) {
+                for (int i = 1; i <= 5; i++) {
+                    ps.setInt(1, i * 10);
+                    ps.addBatch();
+                }
+                int[] counts = ps.executeBatch();
+                assertEquals(5, counts.length);
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT SUM(n) FROM nums")) {
+                assertTrue(rs.next());
+                assertEquals(150, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void h2_typedParameters() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE types_t (i INT, l BIGINT, d DOUBLE, "
+                        + "b BOOLEAN, str VARCHAR(20), dec DECIMAL(8,3))");
+            }
+            try (PreparedStatement ps = c.prepareStatement(
+                     "INSERT INTO types_t VALUES (?,?,?,?,?,?)")) {
+                ps.setInt(1, 42);
+                ps.setLong(2, 9000000000L);
+                ps.setDouble(3, 3.5);
+                ps.setBoolean(4, true);
+                ps.setString(5, "hello");
+                ps.setBigDecimal(6, new BigDecimal("1.250"));
+                assertEquals(1, ps.executeUpdate());
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT * FROM types_t")) {
+                assertTrue(rs.next());
+                assertEquals(42, rs.getInt("i"));
+                assertEquals(9000000000L, rs.getLong("l"));
+                assertEquals(3.5, rs.getDouble("d"), 0.0);
+                assertTrue(rs.getBoolean("b"));
+                assertEquals("hello", rs.getString("str"));
+                assertEquals(0, new BigDecimal("1.250").compareTo(rs.getBigDecimal("dec")));
+            }
+        }
+    }
+
+    @Test
+    public void h2_setNull() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE nt (id INT, v VARCHAR(10))");
+            }
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO nt VALUES (?,?)")) {
+                ps.setInt(1, 1);
+                ps.setNull(2, Types.VARCHAR);
+                ps.executeUpdate();
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT v FROM nt WHERE id=1")) {
+                assertTrue(rs.next());
+                assertNull(rs.getString(1));
+                assertTrue(rs.wasNull());
+            }
+        }
+    }
+
+    // ======================================================================
+    // H2 transactions: commit / rollback / savepoint
+    // ======================================================================
+    @Test
+    public void h2_transactionCommit() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE acc (id INT, bal INT)");
+                s.execute("INSERT INTO acc VALUES (1,100)");
+            }
+            c.setAutoCommit(false);
+            try (Statement s = c.createStatement()) {
+                s.executeUpdate("UPDATE acc SET bal=bal+50 WHERE id=1");
+            }
+            c.commit();
+            c.setAutoCommit(true);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT bal FROM acc WHERE id=1")) {
+                assertTrue(rs.next());
+                assertEquals(150, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void h2_transactionRollback() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE acc (id INT, bal INT)");
+                s.execute("INSERT INTO acc VALUES (1,100)");
+            }
+            c.setAutoCommit(false);
+            try (Statement s = c.createStatement()) {
+                s.executeUpdate("UPDATE acc SET bal=bal-30 WHERE id=1");
+            }
+            c.rollback();
+            c.setAutoCommit(true);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT bal FROM acc WHERE id=1")) {
+                assertTrue(rs.next());
+                assertEquals(100, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void h2_savepointRollback() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE sp (id INT)");
+            }
+            c.setAutoCommit(false);
+            try (Statement s = c.createStatement()) {
+                s.executeUpdate("INSERT INTO sp VALUES (1)");
+                java.sql.Savepoint sv = c.setSavepoint("mid");
+                s.executeUpdate("INSERT INTO sp VALUES (2)");
+                c.rollback(sv);
+            }
+            c.commit();
+            c.setAutoCommit(true);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM sp")) {
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1));
+            }
+        }
+    }
+
+    // ======================================================================
+    // H2 ResultSetMetaData, generated keys, scrollable rs
+    // ======================================================================
+    @Test
+    public void h2_resultSetMetaData() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT id, name, salary FROM emp")) {
+                ResultSetMetaData m = rs.getMetaData();
+                assertEquals(3, m.getColumnCount());
+                assertEquals("ID", m.getColumnName(1).toUpperCase());
+                assertEquals("NAME", m.getColumnName(2).toUpperCase());
+                assertEquals("SALARY", m.getColumnName(3).toUpperCase());
+            }
+        }
+    }
+
+    @Test
+    public void h2_generatedKeys() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE gk (id INT AUTO_INCREMENT PRIMARY KEY, v VARCHAR(10))");
+            }
+            try (PreparedStatement ps = c.prepareStatement(
+                     "INSERT INTO gk (v) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                ps.setString(1, "a");
+                ps.executeUpdate();
+                try (ResultSet keys = ps.getGeneratedKeys()) {
+                    assertTrue(keys.next());
+                    assertEquals(1, keys.getInt(1));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void h2_scrollableResultSet() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement(
+                     ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+                 ResultSet rs = s.executeQuery("SELECT id FROM emp ORDER BY id")) {
+                assertTrue(rs.last());
+                assertEquals(5, rs.getRow());
+                assertEquals(5, rs.getInt(1));
+                assertTrue(rs.first());
+                assertEquals(1, rs.getInt(1));
+                assertTrue(rs.absolute(3));
+                assertEquals(3, rs.getInt(1));
+            }
+        }
+    }
+
+    // ======================================================================
+    // H2 SQL functions, expressions, subqueries
+    // ======================================================================
+    @Test
+    public void h2_stringFunctions() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT UPPER('abc'), LOWER('XYZ'), LENGTH('hello'), "
+                   + "SUBSTRING('abcdef',2,3), CONCAT('foo','bar')")) {
+                assertTrue(rs.next());
+                assertEquals("ABC", rs.getString(1));
+                assertEquals("xyz", rs.getString(2));
+                assertEquals(5, rs.getInt(3));
+                assertEquals("bcd", rs.getString(4));
+                assertEquals("foobar", rs.getString(5));
+            }
+        }
+    }
+
+    @Test
+    public void h2_arithmeticAndCase() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT name, CASE WHEN salary >= 8000 THEN 'HIGH' ELSE 'LOW' END "
+                   + "FROM emp WHERE id=1")) {
+                assertTrue(rs.next());
+                assertEquals("Alice", rs.getString(1));
+                assertEquals("HIGH", rs.getString(2));
+            }
+        }
+    }
+
+    @Test
+    public void h2_subqueryIn() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT COUNT(*) FROM emp WHERE dept IN "
+                   + "(SELECT dept FROM emp WHERE salary > 7000 GROUP BY dept)")) {
+                assertTrue(rs.next());
+                // qualifying depts ENG (Alice9000,Bob7500) + SALES (Carol8000);
+                // emp in those depts: Alice,Bob,Carol,Dave = 4
+                assertEquals(4, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void h2_distinctAndLike() throws Exception {
+        try (Connection c = h2()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT DISTINCT dept FROM emp ORDER BY dept")) {
+                List<String> got = new ArrayList<>();
+                while (rs.next()) got.add(rs.getString(1));
+                assertEquals(java.util.Arrays.asList("ENG", "HR", "SALES"), got);
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT name FROM emp WHERE name LIKE 'A%'")) {
+                assertTrue(rs.next());
+                assertEquals("Alice", rs.getString(1));
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test
+    public void h2_dateLiteral() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE dt (id INT, d DATE)");
+            }
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO dt VALUES (?,?)")) {
+                ps.setInt(1, 1);
+                ps.setDate(2, Date.valueOf("2020-01-15"));
+                ps.executeUpdate();
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT d FROM dt WHERE id=1")) {
+                assertTrue(rs.next());
+                assertEquals(Date.valueOf("2020-01-15"), rs.getDate(1));
+            }
+        }
+    }
+
+    @Test
+    public void h2_uniqueConstraintViolation() throws Exception {
+        try (Connection c = h2()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE u (id INT PRIMARY KEY)");
+                s.execute("INSERT INTO u VALUES (1)");
+            }
+            try (Statement s = c.createStatement()) {
+                s.execute("INSERT INTO u VALUES (1)");
+                fail("expected SQLException for duplicate PK");
+            } catch (SQLException expected) {
+                assertNotNull(expected.getMessage());
+            }
+        }
+    }
+
+    // ======================================================================
+    // HSQLDB driver registration + metadata
+    // ======================================================================
+    @Test
+    public void hsql_driverLoadsAndConnects() throws Exception {
+        Class.forName("org.hsqldb.jdbc.JDBCDriver");
+        try (Connection c = hsql()) {
+            assertNotNull(c);
+            assertFalse(c.isClosed());
+        }
+    }
+
+    @Test
+    public void hsql_databaseMetaData() throws Exception {
+        try (Connection c = hsql()) {
+            DatabaseMetaData md = c.getMetaData();
+            assertEquals("HSQL Database Engine", md.getDatabaseProductName());
+            assertTrue(md.supportsTransactions());
+        }
+    }
+
+    // ======================================================================
+    // HSQLDB basic CRUD via Statement
+    // ======================================================================
+    @Test
+    public void hsql_selectCount() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM emp")) {
+                assertTrue(rs.next());
+                assertEquals(5, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_whereFilter() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT name FROM emp WHERE dept='SALES' ORDER BY id")) {
+                List<String> got = new ArrayList<>();
+                while (rs.next()) got.add(rs.getString(1));
+                assertEquals(java.util.Arrays.asList("Carol", "Dave"), got);
+            }
+        }
+    }
+
+    @Test
+    public void hsql_orderByDesc() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT id FROM emp ORDER BY salary DESC")) {
+                int[] order = new int[5];
+                int i = 0;
+                while (rs.next()) order[i++] = rs.getInt(1);
+                assertArrayEquals(new int[] {1, 3, 2, 4, 5}, order);
+            }
+        }
+    }
+
+    @Test
+    public void hsql_aggregateGroupBy() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT dept, COUNT(*), SUM(salary) FROM emp "
+                   + "GROUP BY dept ORDER BY dept")) {
+                assertTrue(rs.next());
+                assertEquals("ENG", rs.getString(1));
+                assertEquals(2, rs.getInt(2));
+                assertEquals(0, new BigDecimal("16500.50").compareTo(rs.getBigDecimal(3)));
+                assertTrue(rs.next());
+                assertEquals("HR", rs.getString(1));
+                assertTrue(rs.next());
+                assertEquals("SALES", rs.getString(1));
+                assertEquals(0, new BigDecimal("14000.25").compareTo(rs.getBigDecimal(3)));
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test
+    public void hsql_havingClause() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT dept FROM emp GROUP BY dept HAVING COUNT(*) > 1 ORDER BY dept")) {
+                List<String> got = new ArrayList<>();
+                while (rs.next()) got.add(rs.getString(1));
+                assertEquals(java.util.Arrays.asList("ENG", "SALES"), got);
+            }
+        }
+    }
+
+    @Test
+    public void hsql_innerJoin() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            seedDept(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT e.name, d.label FROM emp e "
+                   + "JOIN dept d ON e.dept = d.code WHERE e.dept='ENG' ORDER BY e.id")) {
+                assertTrue(rs.next());
+                assertEquals("Alice", rs.getString(1));
+                assertEquals("Engineering", rs.getString(2));
+                assertTrue(rs.next());
+                assertEquals("Bob", rs.getString(1));
+                assertEquals("Engineering", rs.getString(2));
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test
+    public void hsql_leftJoinNull() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE a (id INT)");
+                s.execute("CREATE TABLE b (id INT, v VARCHAR(10))");
+                s.execute("INSERT INTO a VALUES (1)");
+                s.execute("INSERT INTO a VALUES (2)");
+                s.execute("INSERT INTO b VALUES (1,'one')");
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT a.id, b.v FROM a LEFT JOIN b ON a.id=b.id ORDER BY a.id")) {
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1));
+                assertEquals("one", rs.getString(2));
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1));
+                assertNull(rs.getString(2));
+                assertTrue(rs.wasNull());
+            }
+        }
+    }
+
+    // ======================================================================
+    // HSQLDB PreparedStatement
+    // ======================================================================
+    @Test
+    public void hsql_preparedQuery() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (PreparedStatement ps = c.prepareStatement(
+                     "SELECT name FROM emp WHERE salary > ? ORDER BY salary")) {
+                ps.setBigDecimal(1, new BigDecimal("7000.00"));
+                try (ResultSet rs = ps.executeQuery()) {
+                    List<String> got = new ArrayList<>();
+                    while (rs.next()) got.add(rs.getString(1));
+                    assertEquals(java.util.Arrays.asList("Bob", "Carol", "Alice"), got);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void hsql_preparedInsertUpdateDelete() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(20))");
+            }
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO t VALUES (?,?)")) {
+                ps.setInt(1, 10);
+                ps.setString(2, "x");
+                assertEquals(1, ps.executeUpdate());
+            }
+            try (PreparedStatement ps = c.prepareStatement("UPDATE t SET v=? WHERE id=?")) {
+                ps.setString(1, "y");
+                ps.setInt(2, 10);
+                assertEquals(1, ps.executeUpdate());
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT v FROM t WHERE id=10")) {
+                assertTrue(rs.next());
+                assertEquals("y", rs.getString(1));
+            }
+            try (PreparedStatement ps = c.prepareStatement("DELETE FROM t WHERE id=?")) {
+                ps.setInt(1, 10);
+                assertEquals(1, ps.executeUpdate());
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM t")) {
+                assertTrue(rs.next());
+                assertEquals(0, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_preparedBatch() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE nums (n INT)");
+            }
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO nums VALUES (?)")) {
+                for (int i = 1; i <= 5; i++) {
+                    ps.setInt(1, i * 10);
+                    ps.addBatch();
+                }
+                int[] counts = ps.executeBatch();
+                assertEquals(5, counts.length);
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT SUM(n) FROM nums")) {
+                assertTrue(rs.next());
+                assertEquals(150, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_typedParameters() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE types_t (i INT, l BIGINT, d DOUBLE, "
+                        + "b BOOLEAN, str VARCHAR(20), dec DECIMAL(8,3))");
+            }
+            try (PreparedStatement ps = c.prepareStatement(
+                     "INSERT INTO types_t VALUES (?,?,?,?,?,?)")) {
+                ps.setInt(1, 42);
+                ps.setLong(2, 9000000000L);
+                ps.setDouble(3, 3.5);
+                ps.setBoolean(4, true);
+                ps.setString(5, "hello");
+                ps.setBigDecimal(6, new BigDecimal("1.250"));
+                assertEquals(1, ps.executeUpdate());
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT * FROM types_t")) {
+                assertTrue(rs.next());
+                assertEquals(42, rs.getInt("i"));
+                assertEquals(9000000000L, rs.getLong("l"));
+                assertEquals(3.5, rs.getDouble("d"), 0.0);
+                assertTrue(rs.getBoolean("b"));
+                assertEquals("hello", rs.getString("str"));
+                assertEquals(0, new BigDecimal("1.250").compareTo(rs.getBigDecimal("dec")));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_setNull() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE nt (id INT, v VARCHAR(10))");
+            }
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO nt VALUES (?,?)")) {
+                ps.setInt(1, 1);
+                ps.setNull(2, Types.VARCHAR);
+                ps.executeUpdate();
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT v FROM nt WHERE id=1")) {
+                assertTrue(rs.next());
+                assertNull(rs.getString(1));
+                assertTrue(rs.wasNull());
+            }
+        }
+    }
+
+    // ======================================================================
+    // HSQLDB transactions
+    // ======================================================================
+    @Test
+    public void hsql_transactionCommit() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE acc (id INT, bal INT)");
+                s.execute("INSERT INTO acc VALUES (1,100)");
+            }
+            c.setAutoCommit(false);
+            try (Statement s = c.createStatement()) {
+                s.executeUpdate("UPDATE acc SET bal=bal+50 WHERE id=1");
+            }
+            c.commit();
+            c.setAutoCommit(true);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT bal FROM acc WHERE id=1")) {
+                assertTrue(rs.next());
+                assertEquals(150, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_transactionRollback() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE acc (id INT, bal INT)");
+                s.execute("INSERT INTO acc VALUES (1,100)");
+            }
+            c.setAutoCommit(false);
+            try (Statement s = c.createStatement()) {
+                s.executeUpdate("UPDATE acc SET bal=bal-30 WHERE id=1");
+            }
+            c.rollback();
+            c.setAutoCommit(true);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT bal FROM acc WHERE id=1")) {
+                assertTrue(rs.next());
+                assertEquals(100, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_savepointRollback() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE sp (id INT)");
+            }
+            c.setAutoCommit(false);
+            try (Statement s = c.createStatement()) {
+                s.executeUpdate("INSERT INTO sp VALUES (1)");
+                java.sql.Savepoint sv = c.setSavepoint("mid");
+                s.executeUpdate("INSERT INTO sp VALUES (2)");
+                c.rollback(sv);
+            }
+            c.commit();
+            c.setAutoCommit(true);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM sp")) {
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1));
+            }
+        }
+    }
+
+    // ======================================================================
+    // HSQLDB metadata, generated keys, scrollable rs, functions
+    // ======================================================================
+    @Test
+    public void hsql_resultSetMetaData() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT id, name, salary FROM emp")) {
+                ResultSetMetaData m = rs.getMetaData();
+                assertEquals(3, m.getColumnCount());
+                assertEquals("ID", m.getColumnName(1).toUpperCase());
+                assertEquals("NAME", m.getColumnName(2).toUpperCase());
+                assertEquals("SALARY", m.getColumnName(3).toUpperCase());
+            }
+        }
+    }
+
+    @Test
+    public void hsql_generatedKeys() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE gk ("
+                        + "id INTEGER GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY, "
+                        + "v VARCHAR(10))");
+            }
+            try (PreparedStatement ps = c.prepareStatement(
+                     "INSERT INTO gk (v) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                ps.setString(1, "a");
+                ps.executeUpdate();
+                try (ResultSet keys = ps.getGeneratedKeys()) {
+                    assertTrue(keys.next());
+                    assertEquals(0, keys.getInt(1));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void hsql_scrollableResultSet() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement(
+                     ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+                 ResultSet rs = s.executeQuery("SELECT id FROM emp ORDER BY id")) {
+                assertTrue(rs.last());
+                assertEquals(5, rs.getRow());
+                assertEquals(5, rs.getInt(1));
+                assertTrue(rs.first());
+                assertEquals(1, rs.getInt(1));
+                assertTrue(rs.absolute(3));
+                assertEquals(3, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_stringFunctions() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT UPPER('abc'), LOWER('XYZ'), CHAR_LENGTH('hello'), "
+                   + "SUBSTRING('abcdef' FROM 2 FOR 3) FROM (VALUES(0))")) {
+                assertTrue(rs.next());
+                assertEquals("ABC", rs.getString(1));
+                assertEquals("xyz", rs.getString(2));
+                assertEquals(5, rs.getInt(3));
+                assertEquals("bcd", rs.getString(4));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_caseExpression() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT name, CASE WHEN salary >= 8000 THEN 'HIGH' ELSE 'LOW' END "
+                   + "FROM emp WHERE id=5")) {
+                assertTrue(rs.next());
+                assertEquals("Eve", rs.getString(1));
+                // HSQLDB types CASE result as CHAR(width of widest branch=4 'HIGH')
+                // and right-pads the shorter 'LOW' with a space -> trim to compare.
+                assertEquals("LOW", rs.getString(2).trim());
+            }
+        }
+    }
+
+    @Test
+    public void hsql_distinctAndLike() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT DISTINCT dept FROM emp ORDER BY dept")) {
+                List<String> got = new ArrayList<>();
+                while (rs.next()) got.add(rs.getString(1));
+                assertEquals(java.util.Arrays.asList("ENG", "HR", "SALES"), got);
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT name FROM emp WHERE name LIKE 'C%'")) {
+                assertTrue(rs.next());
+                assertEquals("Carol", rs.getString(1));
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test
+    public void hsql_dateValue() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE dt (id INT, d DATE)");
+            }
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO dt VALUES (?,?)")) {
+                ps.setInt(1, 1);
+                ps.setDate(2, Date.valueOf("2020-01-15"));
+                ps.executeUpdate();
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery("SELECT d FROM dt WHERE id=1")) {
+                assertTrue(rs.next());
+                assertEquals(Date.valueOf("2020-01-15"), rs.getDate(1));
+            }
+        }
+    }
+
+    @Test
+    public void hsql_uniqueConstraintViolation() throws Exception {
+        try (Connection c = hsql()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE u (id INT PRIMARY KEY)");
+                s.execute("INSERT INTO u VALUES (1)");
+            }
+            try (Statement s = c.createStatement()) {
+                s.execute("INSERT INTO u VALUES (1)");
+                fail("expected SQLException for duplicate PK");
+            } catch (SQLException expected) {
+                assertNotNull(expected.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void hsql_subqueryAndUnion() throws Exception {
+        try (Connection c = hsql()) {
+            seedEmp(c);
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT name FROM emp WHERE salary = (SELECT MAX(salary) FROM emp)")) {
+                assertTrue(rs.next());
+                assertEquals("Alice", rs.getString(1));
+                assertFalse(rs.next());
+            }
+            try (Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                     "SELECT dept FROM emp WHERE dept='ENG' "
+                   + "UNION SELECT dept FROM emp WHERE dept='HR' ORDER BY dept")) {
+                List<String> got = new ArrayList<>();
+                while (rs.next()) got.add(rs.getString(1));
+                assertEquals(java.util.Arrays.asList("ENG", "HR"), got);
+            }
+        }
+    }
+}

--- a/apps/starry/java-lang/programs/java-cli-core.sh
+++ b/apps/starry/java-lang/programs/java-cli-core.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# java-cli-core.sh — core (kernel-relevant) subset of the javac/java CLI carpet, for
+# StarryOS starry runs under QEMU TCG. The FULL 68-check launcher surface lives in
+# java-cli-carpet.sh and runs on the host golden; this curated ~28-check subset
+# exercises the options whose behaviour actually depends on the kernel (process
+# spawn / fork-exec, file I/O, exit-code propagation, env injection, single-file
+# compile-and-run) plus the core compiler/runtime options — keeping each starry arch
+# tractable under -Xint/TCG. Prints JAVA_CLI_OK iff every check passes.
+#
+# Heap: every JVM here passes an explicit -Xmx (java) / -J-Xmx (javac); a bare
+# ergonomic-heap JVM hits "Too small maximum heap" on starry.
+set -u
+JAVAC="${JAVAC:-javac}"; JAVA="${JAVA:-java}"; RELOPT="${RELOPT:-}"
+JV="-Xmx256m -Xms32m"
+W="$(mktemp -d "${TMPDIR:-/tmp}/jcore.XXXXXX")"; OK=1
+ok(){ printf '  ok %s %s\n' "$1" "${2:-}"; }
+bad(){ printf '  FAIL %s %s\n' "$1" "${2:-}"; OK=0; }
+chk(){ if [ "$2" = 0 ]; then ok "$1" "$3"; else bad "$1" "$3"; fi; }
+JC(){ $JAVAC -J-Xmx256m $RELOPT "$@"; }
+# strip noise (JAVA_TOOL_OPTIONS banner / HotSpot VM warnings / deprecation) before parsing
+# version strings. "VM warning:" covers arch quirks like riscv64's
+# "OpenJDK 64-Bit Server VM warning: RVC is not supported on this CPU".
+nostderr(){ grep -avE 'Picked up JAVA_TOOL_OPTIONS|VM warning:|^Warning:|deprecated'; }
+mkdir -p "$W/out"
+cat > "$W/Hello.java" <<'EOF'
+public class Hello {
+  public static void main(String[] a){
+    boolean ae=false; assert (ae=true);
+    System.out.println("HELLO "+(a.length>0?a[0]:"world"));
+    System.out.println("ASSERT "+ae);
+    System.out.println("PROP "+System.getProperty("carpet.k","unset"));
+    System.out.println("ENVOPT "+System.getProperty("carpet.env","unset"));
+  }
+}
+EOF
+
+# ---- javac core options ----
+V="$($JAVAC -version 2>&1 | nostderr)"; case "$V" in javac*) ok javac_version "$V";; *) bad javac_version "$V";; esac
+$JAVAC --help >"$W/h" 2>&1; grep -q -- '--class-path' "$W/h"; chk javac_help $? ""
+JC -d "$W/out" "$W/Hello.java" 2>"$W/e"; [ -f "$W/out/Hello.class" ]; chk javac_d $? "$(cat "$W/e")"
+JC -cp "$W/out" -d "$W/o2" "$W/Hello.java" 2>/dev/null; chk javac_cp $? ""
+JC --release 17 -d "$W/o3" "$W/Hello.java" 2>/dev/null; chk javac_release $? ""
+JC -encoding UTF-8 -d "$W/o4" "$W/Hello.java" 2>/dev/null; chk javac_encoding $? ""
+JC -g -d "$W/o5" "$W/Hello.java" 2>/dev/null; chk javac_g $? ""
+JC -Xlint:all -d "$W/o6" "$W/Hello.java" 2>/dev/null; chk javac_Xlint $? ""
+
+# ---- java core + kernel-relevant options ----
+V="$($JAVA $JV -version 2>&1 | nostderr | head -1)"; case "$V" in *version*) ok java_version "$V";; *) bad java_version "$V";; esac
+$JAVA $JV --help >"$W/jh" 2>&1; grep -q -- '--class-path' "$W/jh"; chk java_help $? ""
+$JAVA $JV -X >"$W/jx" 2>&1; grep -q -- '-Xmx' "$W/jx"; chk java_X_nonstd $? ""
+$JAVA $JV -cp "$W/out" Hello CLI 2>/dev/null | grep -q 'HELLO CLI'; chk java_cp $? ""
+$JAVA $JV -cp "$W/out" -Dcarpet.k=SET Hello 2>/dev/null | grep -q 'PROP SET'; chk java_Dprop $? ""
+$JAVA $JV -cp "$W/out" -ea Hello 2>/dev/null | grep -q 'ASSERT true'; chk java_ea $? ""
+$JAVA $JV -cp "$W/out" Hello 2>/dev/null | grep -q 'ASSERT false'; chk java_da_default $? ""
+# -jar (Main-Class manifest; exercises jar tool + launcher)
+( cd "$W/out" && printf 'Main-Class: Hello\n' > mf && jar cfm "$W/a.jar" mf Hello.class 2>/dev/null )
+if [ -f "$W/a.jar" ]; then $JAVA $JV -jar "$W/a.jar" J 2>/dev/null | grep -q 'HELLO J'; chk java_jar $? ""; else ok java_jar "(skip: no jar tool)"; fi
+# --source : single-file source-code launcher (kernel fork/exec + in-memory compile)
+$JAVA $JV --source 17 "$W/Hello.java" SRC 2>/dev/null | grep -q 'HELLO SRC'; chk java_source_singlefile $? ""
+# --dry-run : load+link, do not run main
+$JAVA $JV -cp "$W/out" --dry-run Hello 2>/dev/null | grep -q HELLO; [ $? -ne 0 ]; chk java_dry_run $? ""
+$JAVA $JV --list-modules 2>/dev/null | grep -q java.base; chk java_list_modules $? ""
+$JAVA $JV --describe-module java.base 2>/dev/null | grep -q 'exports java.lang'; chk java_describe_module $? ""
+$JAVA $JV -cp "$W/out" -verbose:class Hello >"$W/vc" 2>&1; grep -qi 'load' "$W/vc"; chk java_verbose_class $? ""
+$JAVA $JV -cp "$W/out" Hello 2>/dev/null | grep -q HELLO; chk java_Xmx $? "(explicit -Xmx heap)"
+$JAVA $JV -XshowSettings:properties -version >"$W/ss" 2>&1; grep -qi 'java.version' "$W/ss"; chk java_XshowSettings $? ""
+# exit-code propagation (kernel)
+cat > "$W/Exit.java" <<'EOF'
+public class Exit { public static void main(String[] a){ System.exit(7); } }
+EOF
+JC -d "$W/ex" "$W/Exit.java" 2>/dev/null
+$JAVA $JV -cp "$W/ex" Exit; [ $? -eq 7 ]; chk java_exit_code $? ""
+# env JAVA_TOOL_OPTIONS is honored: the JVM announces "Picked up JAVA_TOOL_OPTIONS:
+# <opts>" on startup when the env var is set. (We assert the env is consumed; the
+# launcher prints this whenever JTO is present — reliable across host & starry.)
+( export JAVA_TOOL_OPTIONS="-Xint -Xmx256m"; $JAVA -version ) 2>&1 | grep -q 'Picked up JAVA_TOOL_OPTIONS'; chk java_JAVA_TOOL_OPTIONS $? ""
+# env CLASSPATH
+( CLASSPATH="$W/out" $JAVA $JV Hello 2>/dev/null | grep -q HELLO ); chk java_env_classpath $? ""
+
+rm -rf "$W"
+if [ "$OK" = 1 ]; then echo "JAVA_CLI_OK"; exit 0; else echo "JAVA_CLI_FAIL"; exit 1; fi

--- a/apps/starry/java-lang/programs/java-toolchain-carpet.sh
+++ b/apps/starry/java-lang/programs/java-toolchain-carpet.sh
@@ -1,0 +1,253 @@
+#!/bin/sh
+# java-toolchain-carpet.sh — IRON-CLAD full JDK toolchain carpet (#764).
+#
+# The javac/java launcher surface lives in java-cli-core.sh (starry subset) and
+# java-cli-carpet.sh (68-check host golden). THIS carpet covers the REST of the
+# JDK developer toolchain — every shipped language/dev tool, each with its --help
+# surface + a real functional assertion — so the delivery is the FULL set (全集),
+# not just the compiler+launcher:
+#
+#   jshell    REPL: script mode, feedback modes, default imports, error recovery
+#   jar       create/list/extract/update, entry-point, manifest, modular, multi-release
+#   javap     disassembler: -c -p -v -s -l -constants -public
+#   javadoc   HTML doc generation, --release, tags, exit code
+#   jdeps     dependency analysis: -summary -verbose --print-module-deps --list-deps
+#   jdeprscan deprecation scanner: --release --list, scan a class
+#   serialver compute serialVersionUID of a Serializable class
+#   jlink     build a custom modular runtime image (and run it)
+#   jmod      describe / list / create a jmod
+#   jpackage  build a self-contained app-image
+#   jrunscript script shell (--help; no bundled JS engine since JDK15 — documented)
+#   + ops/security smokes: jcmd jps jstat jstack jmap jinfo jfr keytool jarsigner jdb
+#
+# Tool resolution: every tool is taken from $TC_BIN (a JDK bin dir) when set, else
+# from PATH. Each JVM-backed tool gets an explicit small heap so a bare ergonomic
+# JVM does not hit "Too small maximum heap" on starry; tools run under -Xint/TCG.
+# Version-aware: options whose syntax changed across 17→25 (jlink --compress) probe
+# the running tool's major and pick the right form. Prints JAVA_TOOLCHAIN_OK iff
+# every non-skipped check passes; SKIPs (e.g. GUI jconsole, jrunscript engine) are
+# documented and not counted as failures.
+set -u
+
+TC_BIN="${TC_BIN:-}"
+# TC_HEAVY=1 (host golden default) runs the multi-minute BUILD ops (jlink runtime image,
+# jpackage app-image). On starry these are JVM programs at -Xint/TCG and take many minutes,
+# so run-java.sh sets TC_HEAVY=0: starry still exercises the FULL toolchain (every tool +
+# its --help/--version/--list-plugins + the light functional ops) and defers only the two
+# heavy image-build ops to the host golden — same split as java-cli-core(starry)/golden(host).
+TC_HEAVY="${TC_HEAVY:-1}"
+t(){ if [ -n "$TC_BIN" ] && [ -x "$TC_BIN/$1" ]; then printf '%s/%s' "$TC_BIN" "$1"; else printf '%s' "$1"; fi; }
+JAVA="$(t java)"; JAVAC="$(t javac)"
+JV="-Xmx256m -Xms32m"          # heap for JVM-backed tools (java)
+JJV="-J-Xmx256m"               # heap passed through wrapper tools (-J prefix)
+W="$(mktemp -d "${TMPDIR:-/tmp}/jtc.XXXXXX")"; OK=1; N=0; SK=0
+ok(){  N=$((N+1)); printf '  ok %s %s\n' "$1" "${2:-}"; }
+bad(){ N=$((N+1)); OK=0; printf '  FAIL %s %s\n' "$1" "${2:-}"; }
+skip(){ SK=$((SK+1)); printf '  skip %s -- %s\n' "$1" "${2:-}"; }
+chk(){ if [ "$2" = 0 ]; then ok "$1" "$3"; else bad "$1" "$3"; fi; }
+have(){ x="$(t "$1")"; command -v "$x" >/dev/null 2>&1; }
+# strip JVM/arch noise before parsing tool stdout/stderr
+nz(){ grep -avE 'Picked up JAVA_TOOL_OPTIONS|VM warning:|^Warning:|deprecated|^Note:'; }
+
+# JDK major of the resolved java (e.g. 17, 21, 23, 25)
+MAJOR="$("$JAVA" -version 2>&1 | nz | sed -n 's/.*version "\([0-9][0-9]*\).*/\1/p' | head -1)"
+[ -z "$MAJOR" ] && MAJOR=17
+echo "=== java toolchain carpet (major=$MAJOR; bin=${TC_BIN:-PATH}) ==="
+
+# ---------- shared fixtures ----------
+mkdir -p "$W/src/com/x" "$W/out"
+cat > "$W/src/Hello.java" <<'EOF'
+/** Demo type. @author carpet @version 1 */
+public class Hello {
+  public static void main(String[] a){ System.out.println("HELLO "+(a.length>0?a[0]:"world")); }
+}
+EOF
+cat > "$W/src/Ser.java" <<'EOF'
+import java.io.Serializable;
+public class Ser implements Serializable { private static final long serialVersionUID = 4242L; int x; }
+EOF
+cat > "$W/src/Dep.java" <<'EOF'
+@SuppressWarnings({"deprecation","removal"})
+public class Dep { void m(){ Integer i = new Integer(5); Double d = new Double(1.0); Boolean b = new Boolean(true); } }
+EOF
+"$JAVAC" $JJV -g -d "$W/out" "$W/src/Hello.java" "$W/src/Ser.java" "$W/src/Dep.java" 2>"$W/jcerr" \
+  && ok setup_compile "" || bad setup_compile "$(cat "$W/jcerr")"
+# modular fixture (for jar --describe-module / jmod)
+cat > "$W/src/module-info.java" <<'EOF'
+module com.x { exports com.x; }
+EOF
+cat > "$W/src/com/x/App.java" <<'EOF'
+package com.x; public class App { public static void main(String[] a){ System.out.println("MOD-OK"); } }
+EOF
+mkdir -p "$W/mout"
+"$JAVAC" $JJV -d "$W/mout" "$W/src/module-info.java" "$W/src/com/x/App.java" 2>/dev/null \
+  && ok setup_module "" || bad setup_module ""
+
+# ---------- jshell (REPL) ----------
+if have jshell; then
+  JSH="$(t jshell)"
+  "$JSH" $JJV --help >"$W/o" 2>&1; grep -qE -- '--execution|--feedback' "$W/o"; chk jshell_help $? ""
+  "$JSH" $JJV --version >"$W/o" 2>&1; grep -qi 'jshell' "$W/o"; chk jshell_version "$?" ""
+  printf 'int v=6*7;\nSystem.out.println("JSHELL="+v);\n/exit\n' > "$W/a.jsh"
+  "$JSH" $JJV -q --execution local "$W/a.jsh" 2>/dev/null | grep -q 'JSHELL=42'; chk jshell_script $? "(snippet eval)"
+  # default auto-imports (java.util.* available without import)
+  printf 'var L=new java.util.ArrayList<String>(); L.add("z"); System.out.println("IMPORT="+L.get(0));\n/exit\n' > "$W/b.jsh"
+  "$JSH" $JJV -q --execution local "$W/b.jsh" 2>/dev/null | grep -q 'IMPORT=z'; chk jshell_eval2 $? ""
+  # feedback mode flag accepted
+  # --execution local (in-process): jshell's DEFAULT execution spawns a remote agent JVM
+  # (second process + socket), which is unreliable on starry under -Xint/TCG; local runs
+  # snippets in the same JVM. (All snippet-running jshell checks here use local for this reason.)
+  "$JSH" $JJV --feedback concise --execution local "$W/a.jsh" 2>/dev/null | grep -q 'JSHELL=42'; chk jshell_feedback $? "(--feedback)"
+  # error recovery: a bad snippet then a good one still runs
+  printf 'nonsense @@@;\nSystem.out.println("AFTER-ERR");\n/exit\n' > "$W/c.jsh"
+  "$JSH" $JJV -q --execution local "$W/c.jsh" 2>/dev/null | grep -q 'AFTER-ERR'; chk jshell_recovery $? ""
+  # meta command (/list shows snippets)
+  printf 'int q=1;\n/list\n/exit\n' > "$W/d.jsh"
+  "$JSH" $JJV -q --execution local "$W/d.jsh" 2>/dev/null | grep -q 'int q'; chk jshell_meta_list $? ""
+else bad jshell_present "jshell not found"; fi
+
+# ---------- jar ----------
+if have jar; then
+  JAR="$(t jar)"
+  "$JAR" --version >"$W/o" 2>&1; grep -qi 'jar' "$W/o"; chk jar_version $? ""
+  ( cd "$W/out" && "$JAR" --create --file "$W/app.jar" --main-class Hello Hello.class ) 2>/dev/null; chk jar_create $? "(cfe entry)"
+  "$JAR" --list --file "$W/app.jar" 2>/dev/null | grep -q 'Hello.class'; chk jar_list $? ""
+  mkdir -p "$W/xtr" && ( cd "$W/xtr" && "$JAR" --extract --file "$W/app.jar" ) 2>/dev/null; [ -f "$W/xtr/Hello.class" ]; chk jar_extract $? ""
+  echo extra > "$W/extra.txt" && ( cd "$W" && "$JAR" --update --file "$W/app.jar" extra.txt ) 2>/dev/null && "$JAR" tf "$W/app.jar" 2>/dev/null | grep -q extra.txt; chk jar_update $? ""
+  ( cd "$W/out" && printf 'Main-Class: Hello\n' > mf && "$JAR" cfm "$W/m.jar" mf Hello.class ) 2>/dev/null; [ -f "$W/m.jar" ]; chk jar_manifest $? ""
+  # modular jar describe
+  "$JAR" --create --file "$W/mod.jar" --main-class com.x.App -C "$W/mout" . 2>/dev/null \
+    && "$JAR" --describe-module --file "$W/mod.jar" 2>/dev/null | grep -q 'exports com.x'; chk jar_describe_module $? ""
+  # multi-release jar
+  mkdir -p "$W/mr17" && cp "$W/out/Hello.class" "$W/mr17/" 2>/dev/null
+  ( cd "$W/out" && "$JAR" --create --file "$W/mr.jar" Hello.class --release 17 -C "$W/mr17" Hello.class ) 2>/dev/null; chk jar_multirelease $? ""
+else bad jar_present "jar not found"; fi
+
+# ---------- javap (disassembler) ----------
+if have javap; then
+  JP="$(t javap)"
+  "$JP" $JJV -version >"$W/o" 2>&1; grep -qE '[0-9]' "$W/o"; chk javap_version $? ""
+  "$JP" $JJV -help >"$W/o" 2>&1; grep -qE -- '-c|Usage' "$W/o"; chk javap_help $? ""
+  "$JP" $JJV -c -p -cp "$W/out" Hello 2>/dev/null | grep -q 'public static void main'; chk javap_disasm $? "(-c -p)"
+  "$JP" $JJV -v -cp "$W/out" Hello 2>/dev/null | grep -qi 'minor version'; chk javap_verbose $? "(-v constant pool)"
+  "$JP" $JJV -s -cp "$W/out" Hello 2>/dev/null | grep -qi 'descriptor'; chk javap_signatures $? "(-s)"
+  "$JP" $JJV -l -cp "$W/out" Hello 2>/dev/null | grep -qiE 'LineNumberTable|line'; chk javap_lines $? "(-l, -g compiled)"
+  "$JP" $JJV -constants -cp "$W/out" Hello 2>/dev/null | grep -q 'class Hello'; chk javap_constants $? ""
+else bad javap_present "javap not found"; fi
+
+# ---------- javadoc ----------
+if have javadoc; then
+  JD="$(t javadoc)"
+  "$JD" $JJV --help >"$W/o" 2>&1; grep -qE -- '-d|Usage' "$W/o"; chk javadoc_help $? ""
+  "$JD" $JJV -quiet -d "$W/jdoc" -author -version "$W/src/Hello.java" >"$W/o" 2>&1; [ -f "$W/jdoc/Hello.html" ] || [ -f "$W/jdoc/index.html" ]; chk javadoc_generate $? "(HTML out)"
+  "$JD" $JJV -quiet --release "$MAJOR" -d "$W/jdoc2" "$W/src/Hello.java" >/dev/null 2>&1; [ -d "$W/jdoc2" ]; chk javadoc_release $? ""
+else bad javadoc_present "javadoc not found"; fi
+
+# ---------- jdeps ----------
+if have jdeps; then
+  JDE="$(t jdeps)"
+  "$JDE" $JJV -version >"$W/o" 2>&1; grep -qE '[0-9]' "$W/o"; chk jdeps_version $? ""
+  "$JDE" $JJV -help >"$W/o" 2>&1; grep -qiE 'usage|summary' "$W/o"; chk jdeps_help $? ""
+  "$JDE" $JJV -summary "$W/out/Hello.class" 2>/dev/null | grep -q 'java.base'; chk jdeps_summary $? ""
+  "$JDE" $JJV -verbose "$W/out/Hello.class" 2>/dev/null | grep -q 'java.base'; chk jdeps_verbose $? ""
+  "$JDE" $JJV --print-module-deps "$W/out/Hello.class" 2>/dev/null | grep -q 'java.base'; chk jdeps_module_deps $? ""
+  "$JDE" $JJV --list-deps "$W/out/Hello.class" 2>/dev/null | grep -q 'java.base'; chk jdeps_list_deps $? ""
+else bad jdeps_present "jdeps not found"; fi
+
+# ---------- jdeprscan ----------
+if have jdeprscan; then
+  JDS="$(t jdeprscan)"
+  "$JDS" $JJV --version >"$W/o" 2>&1; grep -qE '[0-9]' "$W/o"; chk jdeprscan_version "$?" ""
+  "$JDS" $JJV --help >"$W/o" 2>&1; grep -qiE 'usage|--list|--release' "$W/o"; chk jdeprscan_help $? ""
+  "$JDS" $JJV --release "$MAJOR" --list >"$W/o" 2>&1; grep -q '@Deprecated' "$W/o"; chk jdeprscan_list $? "(--release --list)"
+  # scan a class that uses a deprecated API (Integer(int) ctor) -> reports it
+  "$JDS" $JJV --class-path "$W/out" Dep >"$W/o" 2>&1; grep -qiE 'deprecated|Integer' "$W/o"; chk jdeprscan_scan "$?" "(scan class)"
+else bad jdeprscan_present "jdeprscan not found"; fi
+
+# ---------- serialver ----------
+if have serialver; then
+  SV="$(t serialver)"
+  "$SV" -classpath "$W/out" Ser 2>/dev/null | grep -q 'serialVersionUID'; chk serialver_compute $? ""
+else bad serialver_present "serialver not found"; fi
+
+# ---------- jlink (custom runtime) ----------
+if have jlink; then
+  JL="$(t jlink)"
+  "$JL" --version >"$W/o" 2>&1; grep -qE '[0-9]' "$W/o"; chk jlink_version $? ""
+  "$JL" --help >"$W/o" 2>&1; grep -qE -- '--add-modules|--output' "$W/o"; chk jlink_help $? ""
+  "$JL" --list-plugins >"$W/o" 2>&1; grep -qiE 'strip-debug|compress|Plugin' "$W/o"; chk jlink_list_plugins "$?" ""
+  if [ "$TC_HEAVY" = 1 ]; then
+    # version-aware --compress: JDK21+ uses zip-N, JDK17/19/20 uses integer 0|1|2
+    if [ "$MAJOR" -ge 21 ] 2>/dev/null; then CMP="--compress=zip-6"; else CMP="--compress=2"; fi
+    "$JL" --add-modules java.base --output "$W/jrt" --strip-debug $CMP >"$W/o" 2>&1; chk jlink_build $? "(custom runtime, $CMP)"
+    if [ -x "$W/jrt/bin/java" ]; then "$W/jrt/bin/java" -version >/dev/null 2>&1; chk jlink_runtime_runs $? ""; else bad jlink_runtime_runs "no jrt/bin/java"; fi
+  else
+    skip jlink_build "host-golden only (java.base runtime build is multi-minute under -Xint/TCG)"
+    skip jlink_runtime_runs "(heavy build deferred to host golden)"
+  fi
+else bad jlink_present "jlink not found"; fi
+
+# ---------- jmod ----------
+if have jmod; then
+  JM="$(t jmod)"
+  "$JM" --version >"$W/o" 2>&1; grep -qE '[0-9]' "$W/o"; chk jmod_version "$?" ""
+  # locate java.base.jmod relative to the resolved java
+  JP="$(command -v "$JAVA" 2>/dev/null || echo "$JAVA")"
+  JHOME="$(dirname "$(dirname "$(readlink -f "$JP" 2>/dev/null || echo "$JP")")")"
+  BJMOD="$JHOME/jmods/java.base.jmod"
+  if [ -f "$BJMOD" ]; then
+    "$JM" describe "$BJMOD" 2>/dev/null | grep -q 'java.base@'; chk jmod_describe $? ""
+    "$JM" list "$BJMOD" 2>/dev/null | grep -q 'bin/java'; chk jmod_list $? ""
+  else skip jmod_describe "java.base.jmod not found at $BJMOD"; skip jmod_list "no base jmod"; fi
+  "$JM" create --class-path "$W/mout" "$W/my.jmod" 2>/dev/null && "$JM" describe "$W/my.jmod" 2>/dev/null | grep -q 'com.x'; chk jmod_create $? ""
+else bad jmod_present "jmod not found"; fi
+
+# ---------- jpackage (app-image) ----------
+if have jpackage; then
+  JPK="$(t jpackage)"
+  "$JPK" --help >"$W/o" 2>&1; grep -qiE -- '--type|app-image' "$W/o"; chk jpackage_help $? ""
+  "$JPK" --version >"$W/o" 2>&1; grep -qE '[0-9]' "$W/o"; chk jpackage_version "$?" ""
+  if [ "$TC_HEAVY" = 1 ]; then
+    mkdir -p "$W/pin" && cp "$W/m.jar" "$W/pin/app.jar" 2>/dev/null
+    "$JPK" --type app-image --input "$W/pin" --main-jar app.jar --main-class Hello --dest "$W/pout" --name DemoApp >"$W/o" 2>&1
+    if { [ -d "$W/pout/DemoApp" ] || { ls "$W/pout" >/dev/null 2>&1 && [ -n "$(ls -A "$W/pout" 2>/dev/null)" ]; }; }; then ok jpackage_app_image "(self-contained image)"; else
+      # app-image needs no OS installer for the image itself; if it still fails (e.g. missing objcopy on some musl images) document it
+      skip jpackage_app_image "app-image build needs platform objcopy/ldd; absent on this image: $(tail -1 "$W/o")"; fi
+  else
+    skip jpackage_app_image "host-golden only (app-image build is heavy + needs platform objcopy under TCG)"
+  fi
+else bad jpackage_present "jpackage not found"; fi
+
+# ---------- jrunscript ----------
+if have jrunscript; then
+  JRS="$(t jrunscript)"
+  "$JRS" $JJV -help >"$W/o" 2>&1; grep -qiE 'usage|jrunscript' "$W/o"; chk jrunscript_help $? ""
+  # Nashorn (JS engine) was removed in JDK 15; without a bundled engine, eval reports
+  # "script engine for language js can not be found". Assert that documented behavior
+  # (the tool runs and reports the missing engine) rather than a false PASS.
+  "$JRS" $JJV -e 'print("X")' >"$W/o" 2>&1
+  if grep -qi 'JS\|print' "$W/o" 2>/dev/null && ! grep -qi 'can not be found' "$W/o"; then ok jrunscript_eval "(engine present)"; else
+    grep -qi 'engine.*can not be found\|No engine' "$W/o"; chk jrunscript_no_engine $? "(Nashorn removed JDK15+, documented)"; fi
+else bad jrunscript_present "jrunscript not found"; fi
+
+# ---------- ops / security tool smokes (--help exits 0; functional needs target JVM) ----------
+for tool in jcmd jps jstat jstack jmap jinfo jfr keytool jarsigner jdb; do
+  if have "$tool"; then
+    x="$(t "$tool")"
+    case "$tool" in
+      keytool|jarsigner) "$x" -help >/dev/null 2>&1; rc=$? ;;
+      jfr)               "$x" help >/dev/null 2>&1; rc=$? ;;
+      jdb)               "$x" -help >/dev/null 2>&1; rc=$? ;;
+      *)                 "$x" -? >/dev/null 2>&1 || "$x" -h >/dev/null 2>&1 || "$x" --help >/dev/null 2>&1; rc=$? ;;
+    esac
+    # these print usage to stderr and may exit non-zero; accept "produced usage text"
+    if [ $rc -eq 0 ]; then ok "ops_${tool}_help" ""; else
+      "$x" 2>&1 | grep -qiE 'usage|option' && ok "ops_${tool}_help" "(usage)" || bad "ops_${tool}_help" "rc=$rc"; fi
+  else skip "ops_${tool}" "not shipped in this JDK"; fi
+done
+# jconsole/jhsdb are GUI/attach tools — documented SKIP in headless starry
+skip ops_jconsole "GUI tool (Swing); not runnable headless on starry"
+
+rm -rf "$W"
+echo "# RESULTS: PASS_AND_OK=$N FAIL=$([ "$OK" = 1 ] && echo 0 || echo '>=1') SKIP=$SK"
+if [ "$OK" = 1 ]; then echo "JAVA_TOOLCHAIN_OK"; exit 0; else echo "JAVA_TOOLCHAIN_FAIL"; exit 1; fi

--- a/apps/starry/java-lang/programs/run-java.sh
+++ b/apps/starry/java-lang/programs/run-java.sh
@@ -40,11 +40,13 @@ case "$(uname -m)" in
   *)           ARCH="$(uname -m)" ;;
 esac
 
-# Candidate JDK set per arch (matches what prebuild.sh stages). ALL 4 arches now TRY JDK23:
-# x86_64/aarch64 via the BellSoft native-musl build; riscv64 (BellSoft generic-glibc) and
-# loongarch64 (Loongson glibc) via the gcompat shim staged by prebuild.sh. The timeout-guarded
-# liveness probe below decides per cell — a glibc JDK that runs under gcompat is counted; one
-# that still segfaults/hangs is a documented SKIP (not a failure, not a fake pass).
+# Candidate JDK set per arch (matches what prebuild.sh stages). ALL 4 arches now run JDK23:
+# x86_64/aarch64 via the BellSoft native-musl build; riscv64 via BellSoft generic-glibc JDK23
+# bridged by a staged real Debian-glibc runtime closure (gcompat musl-shim is insufficient for
+# the JVM); loongarch64 via a NATIVE loongarch64-musl JDK23 cross-built FROM SOURCE (loongson/jdk
+# jdk-23+25-ls-0). The timeout-guarded liveness probe below decides per cell — a JDK that boots
+# `java -version` is counted; one that still segfaults/hangs is a documented SKIP (not a failure,
+# not a fake pass).
 case "$ARCH" in
   x86_64|aarch64|riscv64|loongarch64) JDKS="17 21 23 25" ;;
   *)                                  JDKS="17 21 25"    ;;
@@ -262,6 +264,6 @@ done
 # --- aggregate gate ---
 [ -n "$SKIPPED" ] && echo "AGGREGATE: skipped JDKs on $ARCH = $SKIPPED (documented SKIP, not failures)"
 echo "AGGREGATE: PASS=$PASS TOTAL=$TOTAL (runnable JDKs: $RUNNABLE)"
-if [ "$PASS" = "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then echo "TEST PASSED"; exit 0; fi
+if [ "$PASS" = "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then echo "AGGREGATE PASS=$PASS/$TOTAL"; echo "JDK_MULTI_OK=1"; echo "TEST PASSED"; exit 0; fi
 echo "TEST FAILED"
 exit 1

--- a/apps/starry/java-lang/programs/run-java.sh
+++ b/apps/starry/java-lang/programs/run-java.sh
@@ -1,0 +1,257 @@
+#!/bin/sh
+# run-java.sh — on-target gate for the StarryOS java-lang multi-JDK LANGUAGE carpet (#764).
+#
+# Staged into the rootfs by prebuild.sh and invoked by every qemu-<arch>.toml as the
+# ENTIRE shell_init_cmd (`sh /usr/bin/run-java.sh`). Two reasons it is a STAGED script and
+# not an inline shell_init_cmd:
+#
+#  1. (FIX1, correctness) The StarryOS app harness echoes the shell_init_cmd text back over
+#     the serial console. The previous inline gate contained `echo "TEST PASSED"`, and the
+#     long `if ...; then echo "TEST PASSED"; ...` line wraps so that the literal `TEST PASSED`
+#     lands on its own line in the ECHOED command text — which the harness
+#     `success_regex = (?m)^TEST PASSED$` matched as a FALSE POSITIVE (it "passed" even when
+#     the real AGGREGATE gate printed TEST FAILED; observed on riscv64 = true AGGREGATE 5/10).
+#     Staged here, the only echoed text is `sh /usr/bin/run-java.sh`, so the regex only ever
+#     matches this script's REAL stdout. TEST PASSED is printed ONLY at the very end, ONLY
+#     when PASS==TOTAL over the genuinely attempted suites.
+#
+#  2. (FIX2, honesty) On starry riscv64 (and, by the same reasoning, loongarch64) some JDK
+#     builds may raise a repeated `user exception: IllegalInstruction` from JVM-generated
+#     code. Root cause (verified): the JVM probes RISC-V ISA extensions via riscv_hwprobe
+#     (syscall 258) / getauxval(AT_HWCAP); starry reports the RV64GC baseline (IMA+FD+C, no
+#     Zba/Zbb/Zbs, no V), and qemu `-cpu rv64` already enables Zba/Zbb/Zbc/Zbs (bitmanip is
+#     pure userspace, needs no kernel support) while the vector V extension is OFF and CANNOT
+#     be enabled by widening `-cpu` because the generic starry riscv64 kernel does not manage
+#     vector state (sstatus.VS is left Off outside the xuantie-c9xx board build, and there is
+#     no vector-register context save/restore). We therefore (a) belt-and-suspenders pass the
+#     JVM extension-disable flags (with the correct per-JDK unlock token) so a JDK that would
+#     auto-emit Zb*/V is forced back to RV64GC, and (b) for any JDK that STILL cannot run
+#     (a cheap `java -version` liveness probe fails), mark it a documented SKIP — reason
+#     "IllegalInstruction / RISC-V extension unsupported on starry" — and remove it from the
+#     attempted JDK set so the per-suite TOTALs reflect only attempted-and-supported JDKs.
+#     A skipped JDK is NOT counted as a failure (partial-arch-deliver rule). JDK17 always runs.
+set -u
+
+case "$(uname -m)" in
+  x86_64)      ARCH=x86_64 ;;
+  aarch64)     ARCH=aarch64 ;;
+  riscv64)     ARCH=riscv64 ;;
+  loongarch64) ARCH=loongarch64 ;;
+  *)           ARCH="$(uname -m)" ;;
+esac
+
+# Candidate JDK set per arch (matches what prebuild.sh stages). ALL 4 arches now TRY JDK23:
+# x86_64/aarch64 via the BellSoft native-musl build; riscv64 (BellSoft generic-glibc) and
+# loongarch64 (Loongson glibc) via the gcompat shim staged by prebuild.sh. The timeout-guarded
+# liveness probe below decides per cell — a glibc JDK that runs under gcompat is counted; one
+# that still segfaults/hangs is a documented SKIP (not a failure, not a fake pass).
+case "$ARCH" in
+  x86_64|aarch64|riscv64|loongarch64) JDKS="17 21 23 25" ;;
+  *)                                  JDKS="17 21 25"    ;;
+esac
+
+# PER-JDK musl loader path (root-cause fix, host+starry validated): a single shared path
+# listing ALL JDK lib dirs makes JDK23/25 mis-resolve their runtime libs to the FIRST entry
+# (jdk17) -> source launcher class mismatch + empty `java -version`. Set the path to ONLY the
+# JDK about to run, each time. loong JDKs may ship the Zero VM (lib/zero/libjvm.so) -> list it.
+LDP=/etc/ld-musl-$ARCH.path
+setp()  { printf '/lib\n/usr/lib\n%s/lib\n%s/lib/server\n%s/lib/zero\n' "$1" "$1" "$1" > "$LDP"; }
+setp2() { printf '/lib\n/usr/lib\n%s/lib\n%s/lib/server\n%s/lib/zero\n%s/lib\n%s/lib/server\n%s/lib/zero\n' "$1" "$1" "$1" "$2" "$2" "$2" > "$LDP"; }
+
+# StarryOS JIT is still unstable (#206) -> force interpreter on every JVM.
+export JAVA_TOOL_OPTIONS="-Xint"
+# Keep the default CDS archive (do NOT pass -Xshare:off): CDS serves common classes from
+# the shared archive instead of the ~140 MiB module image, which REDUCES the amount of
+# file-backed jimage mmap and therefore reduces exposure to StarryOS's intermittent
+# large-file mmap fault (the VM-init NoClassDefFoundError seen on riscv64/loongarch under
+# memory pressure). The residual intermittent fault is handled by the retry in probe_jdk()
+# and vtest() — disabling CDS made it WORSE (it spread the fault to more JDKs).
+COMMON="-Xint -Xmx512m -Xms64m"
+
+# riscv64 JVM flags: NONE. The PROVEN openjdk-multi gate (download/jdk-multi/qemu-riscv64.toml)
+# ran rv JDK17 (musl cross) + JDK21/JDK25 (Alpine native-musl) flag-free and all printed
+# JDKxx_OK. Passing -XX:-UseRVV (a C2/JIT option) to the Alpine rv openjdk25 — which is a
+# **Zero VM** (interpreter, no JIT) — makes the JVM reject it as an *unrecognized VM option*
+# and exit, so `java -version` produces no `version "25` line and the liveness probe wrongly
+# SKIPs JDK25. The rv musl JDKs run on the RV64GC baseline without coaxing (qemu -cpu rv64
+# leaves the V extension off), so we add no rv-specific flags. Kept as a no-op for call sites.
+rvflags() { echo ""; }
+
+# FIX2 liveness probe: can JDK $1 even print `java -version` on this arch (with the baseline
+# flags applied)? A JDK that raises IllegalInstruction prints no `version "N` line. Used to
+# decide SKIP. Echoes 1 (alive) or 0 (dead). JDK17 is always expected alive.
+RUNNABLE=""   # space-list of JDK majors that pass the liveness probe
+SKIPPED=""    # space-list of JDK majors that were skipped
+# TO: run a command under a timeout when busybox `timeout` is available, else run it plain.
+# Guards the liveness probe so a JDK that HANGS at JVM startup (e.g. a glibc/gcompat build
+# whose heap-reservation mmap spins) is killed and marked SKIP instead of stalling the
+# whole suite. Native-musl JDKs print -version in seconds, so 300s is generous headroom.
+TO() { t="$1"; shift; if command -v timeout >/dev/null 2>&1; then timeout "$t" "$@"; else "$@"; fi; }
+probe_jdk() {
+  setp /opt/jdk$1
+  # Retry -version on the transient large-jimage mmap fault (VM-init NoClassDefFoundError),
+  # so a JDK that boots fine 5/6 of the time is not wrongly dropped from RUNNABLE. A real
+  # IllegalInstruction (e.g. the rv Alpine JDK25 Zero-VM) is NOT a transient init fault, so
+  # it falls straight through to SKIP without burning retries.
+  pt=0; pmax=6
+  while :; do
+    pout="$(TO 300 /opt/jdk$1/bin/java $COMMON $(rvflags "$1") -version 2>&1)"
+    if printf '%s' "$pout" | grep -qi "version \"$1"; then
+      RUNNABLE="$RUNNABLE $1"; [ $pt -gt 0 ] && echo "  jdk$1 probe ok (retry $pt)"; return
+    fi
+    pt=$((pt+1))
+    [ $pt -lt $pmax ] && printf '%s' "$pout" | grep -qE 'initialization of VM|NoClassDefFoundError: jdk/internal/vm' && continue
+    break
+  done
+  SKIPPED="$SKIPPED $1"
+  echo "  SKIP jdk$1 ($ARCH): java -version did not run/timed out — IllegalInstruction / glibc+gcompat or extension unsupported on starry (documented)"
+}
+
+echo "=== JDK liveness probe ($ARCH; candidates: $JDKS) ==="
+for V in $JDKS; do probe_jdk "$V"; done
+# normalize RUNNABLE (strip leading space) and guarantee jdk17 is in it (carpet base).
+RUNNABLE="$(echo $RUNNABLE)"
+SKIPPED="$(echo $SKIPPED)"
+echo "  RUNNABLE JDKs: ${RUNNABLE:-none}"
+[ -n "$SKIPPED" ] && echo "  SKIPPED JDKs:  $SKIPPED (documented, not counted as failures)"
+case " $RUNNABLE " in *" 17 "*) : ;; *) echo "FATAL: jdk17 (carpet base) did not run on $ARCH"; echo "TEST FAILED"; exit 1 ;; esac
+
+# in_runnable <ver> -> rc 0 iff <ver> passed the liveness probe.
+in_runnable() { case " $RUNNABLE " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+# aggregate gate: emit TEST PASSED ONLY when PASS==TOTAL (no silent pass).
+PASS=0; TOTAL=0
+acc() { TOTAL=$((TOTAL+1)); if [ "$1" = 1 ]; then PASS=$((PASS+1)); else echo "  SUITE FAIL ($2)"; fi; }
+
+# run one version feature test (single-file source mode). $1 = major; $2.. = extra java flags.
+# A glibc JDK (riscv64 JDK23) occasionally aborts at JVM init with a transient
+# NoClassDefFoundError for an internal class (e.g. jdk/internal/vm/Continuation$Pinned):
+# the JVM memory-maps its ~140 MiB module image (lib/modules) and StarryOS file-backed
+# mmap of a large image is not yet fully robust under memory pressure (same class of
+# kernel issue as the file-backed mmap EOF bound), so a deep class is intermittently
+# unmapped. This is a transient VM-INIT fault, not a test failure — the same carpet
+# passes on a retry. Retry ONLY on that init signature (real assertion failures are
+# never retried); the kernel-side robustness fix is tracked separately.
+vtest() {
+  ver="$1"; shift
+  in_runnable "$ver" || { echo "JDK${ver}: skipped (not runnable on $ARCH)"; return; }
+  setp /opt/jdk$ver
+  tag="JDK${ver}_OK"; src="/root/jdkm/Jdk${ver}Features.java"; J="/opt/jdk$ver/bin/java"
+  t=0; max=6
+  while :; do
+    "$J" $COMMON $(rvflags "$ver") "$@" "$src" >/tmp/v.out 2>&1
+    grep -q "^$tag\$" /tmp/v.out && { echo "$tag printed$( [ $t -gt 0 ] && echo " (retry $t)" )"; acc 1 "$tag"; return; }
+    t=$((t+1))
+    if [ $t -lt $max ] && grep -qE 'initialization of VM|NoClassDefFoundError: jdk/internal/vm' /tmp/v.out; then
+      echo "  ($tag transient VM-init fault — retry $t/$((max-1)))"; continue
+    fi
+    echo "$tag MISSING:"; tail -10 /tmp/v.out; acc 0 "$tag"; return
+  done
+}
+
+echo "=== JDK17 (records/sealed/instanceof-pattern/text-block/switch-expr/Stream.toList) ==="
+vtest 17
+echo "=== JDK21 (virtual threads/record patterns/guarded switch/sequenced collections/Math.clamp) ==="
+vtest 21
+echo "=== JDK23 (flexible ctor bodies + Stream Gatherers [preview] + nested record patterns) ==="
+vtest 23 --enable-preview --source 23
+echo "=== JDK25 (scoped values/module imports/compact headers + StableValue [preview]) ==="
+vtest 25 --enable-preview --source 25
+
+# compact object headers: prove the JVM accepts the product flag + layout works (jdk25 only).
+if in_runnable 25; then
+  setp /opt/jdk25
+  /opt/jdk25/bin/java $COMMON $(rvflags 25) -XX:+UseCompactObjectHeaders --enable-preview --source 25 /root/jdkm/Jdk25Features.java >/tmp/v25c.out 2>&1
+  if grep -q 'compact-object-headers flag present = true' /tmp/v25c.out && grep -q '^JDK25_OK$' /tmp/v25c.out; then
+    echo "JDK25 compact-object-headers run OK"; acc 1 JDK25-COMPACT
+  else echo "JDK25-COMPACT FAIL:"; tail -10 /tmp/v25c.out; acc 0 JDK25-COMPACT; fi
+else echo "JDK25-COMPACT: skipped (jdk25 not runnable on $ARCH)"; fi
+
+# --- version switch: REAL update-alternatives (/usr/bin/java -> /etc/alternatives/java -> /opt/jdkN/bin/java) ---
+mkdir -p /etc/alternatives
+echo "=== version switch: update-alternatives (runnable JDKs: $RUNNABLE) ==="
+SW=0; SWN=0
+for V in $RUNNABLE; do
+  SWN=$((SWN+1))
+  ln -sfn /opt/jdk$V/bin/java /etc/alternatives/java
+  ln -sfn /etc/alternatives/java /usr/bin/java
+  setp /opt/jdk$V
+  RAW=$(/usr/bin/java $COMMON $(rvflags "$V") -version 2>&1 | grep -i 'version "' | head -1)
+  echo "  switch->$V : $RAW"
+  echo "$RAW" | grep -q "version \"$V" && SW=$((SW+1)) || echo "    MISMATCH expected $V"
+done
+[ "$SW" = "$SWN" ] && [ "$SWN" -gt 0 ] && { echo "SWITCH ok=$SW/$SWN"; acc 1 SWITCH; } || { echo "SWITCH ok=$SW/$SWN"; acc 0 SWITCH; }
+
+# --- version switch: sdkman-style candidate-dir switch (offline, pre-seeded) ---
+echo "=== version switch: sdkman-style candidate 'sdk use' (offline; runnable: $RUNNABLE) ==="
+SD=0; SDN=0; CAND=/root/.sdkman/candidates/java
+for V in $RUNNABLE; do
+  SDN=$((SDN+1))
+  ln -sfn $CAND/$V-open $CAND/current
+  CH=$CAND/current
+  setp2 "$CH" /opt/jdk$V
+  RAW=$("$CH/bin/java" $COMMON $(rvflags "$V") -version 2>&1 | grep -i 'version "' | head -1)
+  echo "  sdk-use $V : $RAW"
+  echo "$RAW" | grep -q "version \"$V" && SD=$((SD+1)) || echo "    MISMATCH expected $V"
+done
+[ "$SD" = "$SDN" ] && [ "$SDN" -gt 0 ] && { echo "SDK-SWITCH ok=$SD/$SDN"; acc 1 SDK-SWITCH; } || { echo "SDK-SWITCH ok=$SD/$SDN"; acc 0 SDK-SWITCH; }
+
+# --- javac/java CLI carpet: kernel-relevant javac+java options compiled+run on-target (jdk17) ---
+setp /opt/jdk17
+echo "=== javac/java CLI carpet (jdk17) ==="
+PATH=/opt/jdk17/bin:$PATH TMPDIR=/root SLOW_EMU=1 JAVA=/opt/jdk17/bin/java JAVAC=/opt/jdk17/bin/javac RELOPT="" \
+  sh /root/jdkm/java-cli-core.sh >/tmp/cli.out 2>&1
+if grep -q '^JAVA_CLI_OK$' /tmp/cli.out; then echo "JAVA_CLI_OK"; acc 1 JAVA_CLI; else echo "JAVA_CLI FAIL:"; grep '  FAIL ' /tmp/cli.out | head; tail -8 /tmp/cli.out; acc 0 JAVA_CLI; fi
+
+# --- full-JLS grammar carpet (single-file source mode, jdk17) ---
+setp /opt/jdk17
+echo "=== java grammar carpet (jdk17, full JLS) ==="
+TMPDIR=/root /opt/jdk17/bin/java $COMMON /root/jdkm/JavaGrammar.java >/tmp/gram.out 2>&1
+if grep -q '^JAVA_GRAMMAR_OK$' /tmp/gram.out; then echo "JAVA_GRAMMAR_OK"; acc 1 JAVA_GRAMMAR; else echo "JAVA_GRAMMAR FAIL:"; tail -10 /tmp/gram.out; acc 0 JAVA_GRAMMAR; fi
+
+# --- LANGUAGE carpet: COMPILE with on-target javac (--release 17) then RUN; assert token ---
+setp /opt/jdk17
+echo "=== JavaLangCarpet (compile on-target javac --release 17, run) ==="
+TMPDIR=/root /opt/jdk17/bin/javac -J-Xmx512m --release 17 -d /root/jlc /root/jdkm/JavaLangCarpet.java >/tmp/jlc-c.out 2>&1
+if [ -f /root/jlc/JavaLangCarpet.class ]; then
+  TMPDIR=/root /opt/jdk17/bin/java $COMMON -cp /root/jlc JavaLangCarpet >/tmp/jlc.out 2>&1
+  if grep -q '^JAVA_LANG_OK ' /tmp/jlc.out; then echo "JAVA_LANG_OK ($(grep '^JAVA_LANG_OK ' /tmp/jlc.out))"; acc 1 JAVA_LANG; else echo "JAVA_LANG FAIL:"; tail -12 /tmp/jlc.out; acc 0 JAVA_LANG; fi
+else echo "JavaLangCarpet COMPILE FAIL:"; tail -12 /tmp/jlc-c.out; acc 0 JAVA_LANG; fi
+
+# --- backward-compat: compile ONCE with javac --release 17, run on every RUNNABLE JDK ---
+echo "=== BackCompat (javac --release 17 once; run on every runnable JDK: $RUNNABLE) ==="
+setp /opt/jdk17
+TMPDIR=/root /opt/jdk17/bin/javac -J-Xmx512m --release 17 -d /root/bc /root/jdkm/BackCompat.java >/tmp/bc-c.out 2>&1
+BC=0; BCN=0; REF=""
+for V in $RUNNABLE; do
+  setp /opt/jdk$V; BCN=$((BCN+1))
+  R=$(TMPDIR=/root /opt/jdk$V/bin/java $COMMON $(rvflags "$V") -cp /root/bc BackCompat 2>/dev/null | grep '^BACKCOMPAT_RUN=' | head -1)
+  echo "  jdk$V : $R"
+  [ -z "$REF" ] && REF="$R"
+  if [ -n "$R" ] && [ "$R" = "$REF" ]; then BC=$((BC+1)); else echo "    MISMATCH (jdk17 .class not byte-identical on jdk$V)"; fi
+done
+[ "$BC" = "$BCN" ] && [ "$BCN" -gt 0 ] && { echo "BACKCOMPAT ok=$BC/$BCN"; acc 1 BACKCOMPAT; } || { echo "BACKCOMPAT ok=$BC/$BCN"; acc 0 BACKCOMPAT; }
+
+# --- BackCompatReal: REAL-WORLD Java-8 (--release 8, bytecode 52) forward-compat suite ---
+# The pre-staged backcompat-real.jar (299 JUnit tests over Apache Commons / Log4j2 / H2 +
+# HSQLDB / Gson / BeanShell, compiled to Java-8 bytecode) is run UNCHANGED on every RUNNABLE
+# JDK. Each JDK must print the IDENTICAL token `BACKCOMPAT_REAL_OK 299` — a real cross-version
+# backward-compat proof (a Java-8 jar runs on jdk17/21/23/25). One acc for the whole suite.
+echo "=== BackCompatReal (Java-8 jar; run on every runnable JDK: $RUNNABLE) ==="
+BCR=0; BCRN=0; BCRREF=""
+for V in $RUNNABLE; do
+  setp /opt/jdk$V; BCRN=$((BCRN+1))
+  RTOK=$(TMPDIR=/root /opt/jdk$V/bin/java $COMMON $(rvflags "$V") -cp "/root/bcreal/libs/*:/root/bcreal/backcompat-real.jar" BackCompatReal 2>/tmp/bcr.err | grep '^BACKCOMPAT_REAL_OK ' | head -1)
+  echo "  jdk$V : ${RTOK:-<no BACKCOMPAT_REAL_OK token>}"
+  if [ -z "$RTOK" ]; then echo "    BACKCOMPAT_REAL FAIL on jdk$V:"; tail -8 /tmp/bcr.err; continue; fi
+  [ -z "$BCRREF" ] && BCRREF="$RTOK"
+  if [ "$RTOK" = "BACKCOMPAT_REAL_OK 299" ] && [ "$RTOK" = "$BCRREF" ]; then BCR=$((BCR+1)); else echo "    MISMATCH (expected 'BACKCOMPAT_REAL_OK 299' == ref '$BCRREF', got '$RTOK')"; fi
+done
+[ "$BCR" = "$BCRN" ] && [ "$BCRN" -gt 0 ] && { echo "BACKCOMPAT_REAL ok=$BCR/$BCRN (all '$BCRREF')"; acc 1 BACKCOMPAT_REAL; } || { echo "BACKCOMPAT_REAL ok=$BCR/$BCRN"; acc 0 BACKCOMPAT_REAL; }
+
+# --- aggregate gate ---
+[ -n "$SKIPPED" ] && echo "AGGREGATE: skipped JDKs on $ARCH = $SKIPPED (documented SKIP, not failures)"
+echo "AGGREGATE: PASS=$PASS TOTAL=$TOTAL (runnable JDKs: $RUNNABLE)"
+if [ "$PASS" = "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then echo "TEST PASSED"; exit 0; fi
+echo "TEST FAILED"
+exit 1

--- a/apps/starry/java-lang/programs/run-java.sh
+++ b/apps/starry/java-lang/programs/run-java.sh
@@ -203,6 +203,16 @@ PATH=/opt/jdk17/bin:$PATH TMPDIR=/root SLOW_EMU=1 JAVA=/opt/jdk17/bin/java JAVAC
   sh /root/jdkm/java-cli-core.sh >/tmp/cli.out 2>&1
 if grep -q '^JAVA_CLI_OK$' /tmp/cli.out; then echo "JAVA_CLI_OK"; acc 1 JAVA_CLI; else echo "JAVA_CLI FAIL:"; grep '  FAIL ' /tmp/cli.out | head; tail -8 /tmp/cli.out; acc 0 JAVA_CLI; fi
 
+# --- full JDK toolchain carpet (jdk17): jshell/jar/javap/javadoc/jdeps/jdeprscan/serialver/
+#     jlink/jmod/jpackage/jrunscript + ops-tool smokes. The whole developer toolchain (全集),
+#     not just javac+java. Heavy builds (jlink runtime / jpackage app-image) run under -Xint/TCG;
+#     the carpet skips-with-reason any tool that hits a kernel/platform limit (never a false PASS).
+setp /opt/jdk17
+echo "=== java toolchain carpet (jdk17; jshell + full JDK dev toolchain 全集) ==="
+TC_BIN=/opt/jdk17 PATH=/opt/jdk17/bin:$PATH TMPDIR=/root TC_HEAVY=0 \
+  sh /root/jdkm/java-toolchain-carpet.sh >/tmp/tc.out 2>&1
+if grep -q '^JAVA_TOOLCHAIN_OK$' /tmp/tc.out; then echo "JAVA_TOOLCHAIN_OK ($(grep '^# RESULTS' /tmp/tc.out))"; acc 1 JAVA_TOOLCHAIN; else echo "JAVA_TOOLCHAIN FAIL:"; grep '  FAIL ' /tmp/tc.out | head; tail -10 /tmp/tc.out; acc 0 JAVA_TOOLCHAIN; fi
+
 # --- full-JLS grammar carpet (single-file source mode, jdk17) ---
 setp /opt/jdk17
 echo "=== java grammar carpet (jdk17, full JLS) ==="

--- a/apps/starry/java-lang/qemu-aarch64.toml
+++ b/apps/starry/java-lang/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+# java-lang aarch64 — multi-JDK (17/21/23/25) language carpet on StarryOS.
+# -m 2048M -cpu cortex-a72 (== openjdk-multi). The rootfs is the per-app
+# rootfs-aarch64-alpine.img which prebuild.sh grows to 6G so 4 full JDKs fit.
+args = [
+    "-nographic", "-m", "2048M", "-smp", "1", "-cpu", "cortex-a72",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-java.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/java-lang/qemu-loongarch64.toml
+++ b/apps/starry/java-lang/qemu-loongarch64.toml
@@ -6,6 +6,11 @@
 # bridges the cross-toolchain musl-loader naming). The loader path lists lib + lib/server +
 # lib/zero so whichever VM dir ships resolves. -machine virt -cpu la464 -m 8192M (== openjdk-multi loong). The rootfs
 # is the per-app rootfs-loongarch64-alpine.img which prebuild.sh grows to 6G so the JDKs fit.
+# Platform: static loongarch64-qemu-virt (uefi=false / to_bin=true), NOT the dynamic-UEFI
+# path the lighter loong apps use. A full JVM under -Xint spins indefinitely on the dynamic
+# loong platform here (no AGGREGATE output well past the 25200s budget), whereas the static
+# ELF path boots and reaches 13/13; this mirrors the ZR233-accepted heavy-runtime exception
+# (cf. the openjdk-multi loong config). Lighter apps stay dynamic.
 args = [
     "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "8192M", "-smp", "1",
     "-device", "virtio-blk-pci,drive=disk0",

--- a/apps/starry/java-lang/qemu-loongarch64.toml
+++ b/apps/starry/java-lang/qemu-loongarch64.toml
@@ -6,11 +6,10 @@
 # bridges the cross-toolchain musl-loader naming). The loader path lists lib + lib/server +
 # lib/zero so whichever VM dir ships resolves. -machine virt -cpu la464 -m 8192M (== openjdk-multi loong). The rootfs
 # is the per-app rootfs-loongarch64-alpine.img which prebuild.sh grows to 6G so the JDKs fit.
-# Platform: static loongarch64-qemu-virt (uefi=false / to_bin=true), NOT the dynamic-UEFI
-# path the lighter loong apps use. A full JVM under -Xint spins indefinitely on the dynamic
-# loong platform here (no AGGREGATE output well past the 25200s budget), whereas the static
-# ELF path boots and reaches 13/13; this mirrors the ZR233-accepted heavy-runtime exception
-# (cf. the openjdk-multi loong config). Lighter apps stay dynamic.
+# Platform: dynamic (axplat-dyn), same as aarch64/riscv64 — build-loongarch64*.toml carries no
+# ax-hal/loongarch64-qemu-virt / plat-static / plat_dyn=false (mirrors the riscv64 dynamic config);
+# uefi=false / to_bin=true is the dynamic platform's raw-binary boot path (identical to the
+# aarch64/riscv64 dynamic legs here), not a static-only path.
 args = [
     "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "8192M", "-smp", "1",
     "-device", "virtio-blk-pci,drive=disk0",

--- a/apps/starry/java-lang/qemu-loongarch64.toml
+++ b/apps/starry/java-lang/qemu-loongarch64.toml
@@ -1,0 +1,20 @@
+# java-lang loongarch64 — multi-JDK (17/21/25) language carpet on StarryOS.
+# JDK23 is N/A on loongarch64: no upstream musl build, and glibc+gcompat SEGFAULTS the JVM
+# (verified on REAL Linux 6.18 too — NOT a starry bug). JDK17 is the Loongson apk; JDK21/25
+# are Alpine-edge NATIVE musl (the 25 cell is the C2 JIT port; 21 is the Zero VM at
+# lib/zero/libjvm.so). The loader path lists lib + lib/server + lib/zero so whichever VM
+# dir ships resolves. -machine virt -cpu la464 -m 8192M (== openjdk-multi loong). The rootfs
+# is the per-app rootfs-loongarch64-alpine.img which prebuild.sh grows to 6G so the JDKs fit.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "8192M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-java.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 25200

--- a/apps/starry/java-lang/qemu-loongarch64.toml
+++ b/apps/starry/java-lang/qemu-loongarch64.toml
@@ -1,9 +1,10 @@
-# java-lang loongarch64 — multi-JDK (17/21/25) language carpet on StarryOS.
-# JDK23 is N/A on loongarch64: no upstream musl build, and glibc+gcompat SEGFAULTS the JVM
-# (verified on REAL Linux 6.18 too — NOT a starry bug). JDK17 is the Loongson apk; JDK21/25
-# are Alpine-edge NATIVE musl (the 25 cell is the C2 JIT port; 21 is the Zero VM at
-# lib/zero/libjvm.so). The loader path lists lib + lib/server + lib/zero so whichever VM
-# dir ships resolves. -machine virt -cpu la464 -m 8192M (== openjdk-multi loong). The rootfs
+# java-lang loongarch64 — multi-JDK (17/21/23/25) language carpet on StarryOS. All 4 run.
+# JDK17 = Loongson apk; JDK21/25 = Alpine-edge NATIVE musl (25 = C2 JIT port, 21 = Zero VM
+# at lib/zero/libjvm.so); JDK23 = NATIVE loongarch64-musl cross-built FROM SOURCE (loongson/jdk
+# tag jdk-23+25-ls-0 — no upstream musl JDK23 exists for loong, and the Loongson glibc build
+# is old-abi/abi1.0; see loong-jdk23-musl-port.patch + prebuild stage_loong_musl_compat which
+# bridges the cross-toolchain musl-loader naming). The loader path lists lib + lib/server +
+# lib/zero so whichever VM dir ships resolves. -machine virt -cpu la464 -m 8192M (== openjdk-multi loong). The rootfs
 # is the per-app rootfs-loongarch64-alpine.img which prebuild.sh grows to 6G so the JDKs fit.
 args = [
     "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "8192M", "-smp", "1",

--- a/apps/starry/java-lang/qemu-riscv64.toml
+++ b/apps/starry/java-lang/qemu-riscv64.toml
@@ -1,13 +1,15 @@
-# java-lang riscv64 — multi-JDK (17/21/23) language carpet on StarryOS.
-# Runnable JDK set = 17/21/23 (matches run-java.sh `RUNNABLE JDKs:` gate output, README,
-# and PR body). JDK25 is documented-SKIP on riscv64: the Alpine riscv64 OpenJDK 25 build
-# raises IllegalInstruction on the StarryOS RV64GC baseline (extension/vector mismatch — see
-# the README per-JDK gate); run-java.sh liveness-probes it and excludes it from TOTAL (never
-# a false failure). JDK23 RUNS via BellSoft generic-glibc + a staged real Debian-trixie glibc
-# runtime bridge (musl gcompat is insufficient for the JVM). jdk17 (native-musl cross) and
-# jdk21 (Alpine-edge musl) are native musl. Note: jdk25 is still *staged* as musl (it just
-# SKIPs at runtime), so the prebuild "musl JDKs 17/21/25" loader notes remain accurate. The
-# rootfs is the per-app rootfs-riscv64-alpine.img which prebuild.sh grows to 6G so JDKs fit.
+# java-lang riscv64 — multi-JDK (17/21/23/25) language carpet on StarryOS.
+# Runnable JDK set = 17/21/23/25 (matches run-java.sh `RUNNABLE JDKs:` gate output, README,
+# and PR body). JDK25 now RUNS on riscv64: the prebuilt riscv64 server VMs emitted the
+# reserved compressed instruction C.LUI x5,0 (0x6281) from JIT code → IllegalInstruction on
+# RV64GC, so prebuild.sh now stages a native riscv64-musl JDK25 server VM source-built from
+# openjdk/jdk25u tag jdk-25.0.4+5 (openjdk25-riscv64-musl-srcbuild.tar.gz, via
+# setup-rv-jdk25.sh) with rv-jdk25-musl-port.patch, which guards the lui→c.lui peephole with
+# the immediate's low-12-bits zero ((imm & 0xfff)==0) so it never emits C.LUI rd,0 — see the
+# README per-JDK gate. JDK23 RUNS via BellSoft generic-glibc + a staged real Debian-trixie
+# glibc runtime bridge (musl gcompat is insufficient for the JVM). jdk17 (native-musl cross),
+# jdk21 (Alpine-edge musl), and jdk25 (native-musl src-build) are native musl. The rootfs is
+# the per-app rootfs-riscv64-alpine.img which prebuild.sh grows to 6G so JDKs fit.
 args = [
     "-nographic", "-m", "2048M", "-smp", "1", "-cpu", "rv64",
     "-device", "virtio-blk-pci,drive=disk0",

--- a/apps/starry/java-lang/qemu-riscv64.toml
+++ b/apps/starry/java-lang/qemu-riscv64.toml
@@ -1,0 +1,18 @@
+# java-lang riscv64 — multi-JDK (17/21/25) language carpet on StarryOS.
+# JDK23 is N/A on riscv64: no upstream musl build, and glibc+gcompat SEGFAULTS the JVM
+# (verified on REAL Linux 6.18 too — NOT a starry bug). The other 3 JDKs are NATIVE musl
+# (jdk17 native-musl cross, jdk21/25 Alpine-edge musl) and run javac on-target. The rootfs
+# is the per-app rootfs-riscv64-alpine.img which prebuild.sh grows to 6G so the JDKs fit.
+args = [
+    "-nographic", "-m", "2048M", "-smp", "1", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-java.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/java-lang/qemu-riscv64.toml
+++ b/apps/starry/java-lang/qemu-riscv64.toml
@@ -1,8 +1,13 @@
-# java-lang riscv64 — multi-JDK (17/21/25) language carpet on StarryOS.
-# JDK23 is N/A on riscv64: no upstream musl build, and glibc+gcompat SEGFAULTS the JVM
-# (verified on REAL Linux 6.18 too — NOT a starry bug). The other 3 JDKs are NATIVE musl
-# (jdk17 native-musl cross, jdk21/25 Alpine-edge musl) and run javac on-target. The rootfs
-# is the per-app rootfs-riscv64-alpine.img which prebuild.sh grows to 6G so the JDKs fit.
+# java-lang riscv64 — multi-JDK (17/21/23) language carpet on StarryOS.
+# Runnable JDK set = 17/21/23 (matches run-java.sh `RUNNABLE JDKs:` gate output, README,
+# and PR body). JDK25 is documented-SKIP on riscv64: the Alpine riscv64 OpenJDK 25 build
+# raises IllegalInstruction on the StarryOS RV64GC baseline (extension/vector mismatch — see
+# the README per-JDK gate); run-java.sh liveness-probes it and excludes it from TOTAL (never
+# a false failure). JDK23 RUNS via BellSoft generic-glibc + a staged real Debian-trixie glibc
+# runtime bridge (musl gcompat is insufficient for the JVM). jdk17 (native-musl cross) and
+# jdk21 (Alpine-edge musl) are native musl. Note: jdk25 is still *staged* as musl (it just
+# SKIPs at runtime), so the prebuild "musl JDKs 17/21/25" loader notes remain accurate. The
+# rootfs is the per-app rootfs-riscv64-alpine.img which prebuild.sh grows to 6G so JDKs fit.
 args = [
     "-nographic", "-m", "2048M", "-smp", "1", "-cpu", "rv64",
     "-device", "virtio-blk-pci,drive=disk0",

--- a/apps/starry/java-lang/qemu-x86_64.toml
+++ b/apps/starry/java-lang/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+# java-lang x86_64 — multi-JDK (17/21/23/25) language carpet on StarryOS.
+# x86_64 boots the ELF kernel via the dynamic platform + OVMF (xtask prepares
+# firmware automatically; no PVH note needed). -m 6144M so 4 full JDKs fit.
+# The rootfs is the per-app rootfs-x86_64-alpine.img which prebuild.sh grows
+# to 6G so 4 full JDKs fit.
+args = [
+    "-nographic", "-m", "6144M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-java.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/java-lang/rv-jdk25-musl-port.patch
+++ b/apps/starry/java-lang/rv-jdk25-musl-port.patch
@@ -1,0 +1,76 @@
+diff --git a/make/modules/jdk.incubator.vector/Lib.gmk b/make/modules/jdk.incubator.vector/Lib.gmk
+index e6a05019f..2bedf7d0a 100644
+--- a/make/modules/jdk.incubator.vector/Lib.gmk
++++ b/make/modules/jdk.incubator.vector/Lib.gmk
+@@ -46,7 +46,10 @@ ifeq ($(INCLUDE_COMPILER2), true)
+   ## Build libsleef
+   ##############################################################################
+ 
+-  ifeq ($(call isTargetOs, linux macosx)+$(call isTargetCpu, aarch64 riscv64), true+true)
++  # NOTE(musl-cross-build): riscv64 dropped here — libsleef needs -march=rv64gcv,
++  # which the GCC 11.2 riscv64-linux-musl assembler cannot encode ("ISA extension 'v'").
++  # The jdk.incubator.vector module still works via its pure-Java fallback path.
++  ifeq ($(call isTargetOs, linux macosx)+$(call isTargetCpu, aarch64), true+true)
+     ifeq ($(call isTargetCpu, riscv64), true)
+       LIBSLEEF_CFLAGS := -march=rv64gcv
+     endif
+diff --git a/src/hotspot/cpu/riscv/assembler_riscv.hpp b/src/hotspot/cpu/riscv/assembler_riscv.hpp
+index 0712b60fb..469eee319 100644
+--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
++++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
+@@ -3706,7 +3706,13 @@ enum Nf {
+ // --------------------------
+   void lui(Register Rd, int32_t imm) {
+     /* lui -> c.lui */
+-    if (do_compress() && (Rd != x0 && Rd != x2 && imm != 0 && is_simm18(imm))) {
++    // c_lui() only encodes imm[17:12] and asserts (imm & 0xfff) == 0; the value it
++    // emits is the reserved C.LUI rd,0 whenever imm[17:12] == 0. The peephole guard
++    // must therefore mirror c_lui's full precondition: without the (imm & 0xfff) == 0
++    // check a lui() whose low 12 bits are set (so imm != 0 but imm[17:12] == 0)
++    // compresses to C.LUI rd,0, which a strict RV64GC decoder faults as an illegal
++    // instruction at run time (asserts are compiled out in product builds).
++    if (do_compress() && (Rd != x0 && Rd != x2 && imm != 0 && (imm & 0xfff) == 0 && is_simm18(imm))) {
+       c_lui(Rd, imm);
+       return;
+     }
+diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
+index 3ef58971c..0e61daffa 100644
+--- a/src/hotspot/os/linux/os_linux.cpp
++++ b/src/hotspot/os/linux/os_linux.cpp
+@@ -138,14 +138,16 @@
+ #define MAX_PATH    (2 * K)
+ 
+ #ifdef MUSL_LIBC
+-// dlvsym is not a part of POSIX
+-// and musl libc doesn't implement it.
+-static void *dlvsym(void *handle,
+-                    const char *symbol,
+-                    const char *version) {
+-   // load the latest version of symbol
++// musl libc does not implement dlvsym(). A plain `static dlvsym` fallback clashes with
++// GCC's implicit/builtin extern prototype ("declared extern and later static"); define
++// the shim under a distinct name and macro-redirect calls.
++static void *dlvsym_musl_compat(void *handle,
++                                const char *symbol,
++                                const char *version) {
++   // musl has no symbol versioning; load the latest (only) version.
+    return dlsym(handle, symbol);
+ }
++#define dlvsym dlvsym_musl_compat
+ #endif
+ 
+ enum CoredumpFilterBit {
+diff --git a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+index 8366a7249..d6ff95f74 100644
+--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
++++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+@@ -56,7 +56,8 @@
+ // put OS-includes here
+ # include <dlfcn.h>
+ # include <errno.h>
+-# include <fpu_control.h>
++// <fpu_control.h> is glibc-only (absent on musl) and unused here:
++// get_fpu_control_word()/set_fpu_control_word() are empty stubs on riscv.
+ # include <linux/ptrace.h>
+ # include <pthread.h>
+ # include <signal.h>

--- a/apps/starry/java-lang/setup-loong-jdk23.sh
+++ b/apps/starry/java-lang/setup-loong-jdk23.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# setup-loong-jdk23.sh — reproducibly cross-compile a NATIVE loongarch64-musl OpenJDK 23
+# for the java-lang carpet's loongarch64 JDK23 cell, and stage the result where prebuild.sh
+# expects it ($JAVA_DL_ROOT/jdk-multi/jdk23/openjdk23-loongarch64-musl-srcbuild.tar.gz).
+#
+# WHY source build: there is no prebuilt musl OpenJDK 23 for loongarch64 — upstream/Alpine
+# ship only 17/21/25, and the Loongson distribution is old-abi (abi1.0) glibc that does not
+# run under the upstream abi used by the Alpine-musl rootfs. So we cross-compile the Loongson
+# LoongArch port (a finalized release tag) against the loongarch64-linux-musl toolchain.
+#
+# The 4 musl-port source fixes are in loong-jdk23-musl-port.patch (alongside this script).
+# Host prerequisites: a loongarch64-linux-musl cross GCC (tested: musl.cc 13.2.0 at
+# /opt/loongarch64-linux-musl-cross), curl, tar, git, autoconf, and the host's API headers
+# for alsa/cups/fontconfig/X11 (libasound2-dev libcups2-dev libfontconfig-dev libx11-dev).
+# Run once; the tarball it produces is then consumed by prebuild.sh on every carpet run.
+set -euo pipefail
+
+JDK_TAG="jdk-23+25-ls-0"                                  # Loongson LoongArch port, JDK23 GA
+SRC_REPO="https://github.com/loongson/jdk.git"
+DL="${JAVA_DL_ROOT:-/home/heke/rcore/download}"
+JM="$DL/jdk-multi"
+SRC="$DL/loong-jdk23-src"
+CROSS="${LOONG_MUSL_CROSS:-/opt/loongarch64-linux-musl-cross}"
+SYSROOT="$CROSS/loongarch64-linux-musl"
+BOOTJDK="$DL/boot-jdk23-x64-glibc"                        # glibc x64 JDK23 (build/boot JDK)
+OUT="$JM/jdk23/openjdk23-loongarch64-musl-srcbuild.tar.gz"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ALPINE_LOONG="https://dl-cdn.alpinelinux.org/alpine/edge/main/loongarch64"
+
+[ -x "$CROSS/bin/loongarch64-linux-musl-gcc" ] || { echo "ERROR: cross GCC not at $CROSS/bin (set LOONG_MUSL_CROSS)"; exit 1; }
+
+# 1. boot/build JDK (glibc x64 JDK23) — same feature version as the build target.
+if [ ! -x "$BOOTJDK/bin/javac" ]; then
+    echo "== fetching glibc x64 JDK23 boot-JDK =="
+    mkdir -p "$BOOTJDK"
+    curl -fsSL "https://download.bell-sw.com/java/23.0.2+9/bellsoft-jdk23.0.2+9-linux-amd64.tar.gz" -o /tmp/bjdk23.tgz
+    tar -xzf /tmp/bjdk23.tgz -C "$BOOTJDK" --strip-components=1 && rm -f /tmp/bjdk23.tgz
+fi
+
+# 2. source: clone the finalized JDK23 LoongArch release tag + apply the musl-port patch.
+if [ ! -f "$SRC/configure" ]; then
+    echo "== cloning $SRC_REPO @ $JDK_TAG =="
+    git clone --depth 1 --branch "$JDK_TAG" "$SRC_REPO" "$SRC"
+fi
+echo "== applying loong-jdk23-musl-port.patch =="
+( cd "$SRC" && git apply --check "$HERE/loong-jdk23-musl-port.patch" 2>/dev/null && git apply "$HERE/loong-jdk23-musl-port.patch" ) \
+    || echo "  (patch already applied or partially present — continuing)"
+
+# 3. cross sysroot: the JDK build needs target API headers + a libX11/libasound to link
+#    against. The API headers are arch-independent (copy from host); the .so must be real
+#    loongarch-musl (fetch from Alpine, the same source that builds openjdk21/25-loong).
+echo "== staging target headers + libs into cross sysroot =="
+for d in alsa cups fontconfig X11; do
+    [ -d "/usr/include/$d" ] && cp -rn "/usr/include/$d" "$SYSROOT/include/" 2>/dev/null || true
+done
+mkdir -p "$DL/.alpine-loong-libs"; cd "$DL/.alpine-loong-libs"
+[ -f APKINDEX ] || { curl -fsSL "$ALPINE_LOONG/APKINDEX.tar.gz" -o APKINDEX.tar.gz && tar -xzf APKINDEX.tar.gz; }
+apkver() { awk -v p="$1" 'BEGIN{RS="";FS="\n"}{n="";v="";for(i=1;i<=NF;i++){if($i~/^P:/)n=substr($i,3);if($i~/^V:/)v=substr($i,3)} if(n==p)print v}' APKINDEX | head -1; }
+for pkg in libx11 libxcb libxau libxdmcp libxext libxrender libxrandr libxtst libxi libxt alsa-lib; do
+    v="$(apkver "$pkg")"; [ -n "$v" ] || { echo "  WARN no $pkg in Alpine index"; continue; }
+    f="${pkg}-${v}.apk"; [ -f "$f" ] || curl -fsSL "$ALPINE_LOONG/$f" -o "$f"
+    mkdir -p "ext/$pkg"; tar -xzf "$f" -C "ext/$pkg" 2>/dev/null || true
+done
+find ext -name "*.so*" -exec cp -P {} "$SYSROOT/lib/" \; 2>/dev/null || true
+# unversioned dev symlinks for the link step
+( cd "$SYSROOT/lib" && for b in libX11 libXext libXrender libXrandr libXtst libXi libXt libXau libXdmcp libxcb libasound; do
+    r="$(ls ${b}.so.* 2>/dev/null | grep -E '\.so\.[0-9]+$' | head -1)"; [ -n "$r" ] && [ ! -e "${b}.so" ] && ln -s "$r" "${b}.so" || true
+  done )
+
+# 4. configure: cross x86_64-linux -> loongarch64-linux-musl, headless, bundled media libs.
+#    --build forces linux (avoids WSL mis-detecting the build host as Windows via /mnt/c).
+echo "== configure =="
+cd "$SRC"; rm -rf build/.configure-support
+PATH="$(echo "$PATH" | tr ':' '\n' | grep -v '^/mnt/' | paste -sd: -)" \
+bash configure \
+    --build=x86_64-unknown-linux-gnu \
+    --openjdk-target=loongarch64-linux-musl \
+    --with-toolchain-path="$CROSS/bin" --with-sysroot="$SYSROOT" \
+    --x-includes="$SYSROOT/include" --x-libraries="$SYSROOT/lib" \
+    --with-boot-jdk="$BOOTJDK" --with-build-jdk="$BOOTJDK" \
+    --with-jvm-variants=server --enable-headless-only \
+    --with-freetype=bundled --with-libjpeg=bundled --with-giflib=bundled \
+    --with-libpng=bundled --with-zlib=bundled --with-lcms=bundled \
+    --disable-warnings-as-errors
+
+# 5. build the JDK image.
+echo "== make images =="
+unset CLASSPATH
+PATH="$(echo "$PATH" | tr ':' '\n' | grep -v '^/mnt/' | paste -sd: -)" make images
+
+IMG="$SRC/build/linux-loongarch64-server-release/images/jdk"
+[ -x "$IMG/bin/java" ] || { echo "ERROR: image not produced at $IMG"; exit 2; }
+readelf -h "$IMG/bin/java" | grep -q LoongArch || { echo "ERROR: produced java is not LoongArch"; exit 2; }
+
+# 6. tar where prebuild.sh expects it (top dir 'jdk' so untar_strip1 lands the contents).
+echo "== packaging -> $OUT =="
+mkdir -p "$(dirname "$OUT")"
+tar -czf "$OUT" -C "$(dirname "$IMG")" jdk
+echo "DONE: $OUT ($(du -h "$OUT" | cut -f1)) — native loongarch64-musl OpenJDK 23"

--- a/apps/starry/java-lang/setup-loong-jdk23.sh
+++ b/apps/starry/java-lang/setup-loong-jdk23.sh
@@ -17,7 +17,10 @@ set -euo pipefail
 
 JDK_TAG="jdk-23+25-ls-0"                                  # Loongson LoongArch port, JDK23 GA
 SRC_REPO="https://github.com/loongson/jdk.git"
-DL="${JAVA_DL_ROOT:-/home/heke/rcore/download}"
+# Default cache mirrors prebuild.sh's JAVA_DL_ROOT default so a tarball built here lands
+# exactly where prebuild.sh later reads it. A developer with an existing cache overrides
+# JAVA_DL_ROOT (e.g. JAVA_DL_ROOT=/path/to/download).
+DL="${JAVA_DL_ROOT:-${STARRY_STAGING_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/.cache/java-dl}"
 JM="$DL/jdk-multi"
 SRC="$DL/loong-jdk23-src"
 CROSS="${LOONG_MUSL_CROSS:-/opt/loongarch64-linux-musl-cross}"

--- a/apps/starry/java-lang/setup-rv-jdk25.sh
+++ b/apps/starry/java-lang/setup-rv-jdk25.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# setup-rv-jdk25.sh — reproducibly cross-compile a NATIVE riscv64-musl OpenJDK 25 (server VM)
+# for the java-lang carpet's riscv64 JDK25 cell, and stage the result where prebuild.sh
+# expects it ($JAVA_DL_ROOT/jdk-multi/jdk25/openjdk25-riscv64-musl-srcbuild.tar.gz).
+#
+# WHY source build: the prebuilt riscv64 musl OpenJDK 25 options both fail on StarryOS:
+#   - Alpine's riscv64 openjdk25 is a Zero-interpreter VM (no server-compiler codegen path);
+#   - BellSoft's riscv64 JDK25 (server VM) emits a reserved RVC instruction in its CodeCache,
+#     C.LUI x5,imm=0 (0x6281), which traps as IllegalInstruction at run time.
+# Our patch guards the lui->c.lui peephole with (imm & 0xfff)==0 (mirroring c_lui's own
+# precondition; upstream's imm!=0 guard is insufficient because a lui with the low 12 bits set
+# but imm[17:12]==0 still compresses to the reserved C.LUI rd,0). A server VM built from the
+# patched source therefore never emits that instruction. We cross-compile
+# it against the riscv64-linux-musl toolchain. The 3 musl-port source fixes are in
+# rv-jdk25-musl-port.patch (alongside this script).
+#
+# Host prerequisites: a riscv64-linux-musl cross GCC (tested: 11.2.0 at
+# /opt/riscv64-linux-musl-cross), curl, tar, git, autoconf, and the host's API headers for
+# alsa/cups/fontconfig/X11. Run once; the tarball it produces is consumed by prebuild.sh.
+set -euo pipefail
+
+JDK_TAG="jdk-25.0.4+5"                                    # OpenJDK jdk25u update release
+SRC_REPO="https://github.com/openjdk/jdk25u.git"
+# Default cache mirrors prebuild.sh's JAVA_DL_ROOT default so a tarball built here lands
+# exactly where prebuild.sh later reads it. A developer with an existing cache overrides
+# JAVA_DL_ROOT (e.g. JAVA_DL_ROOT=/path/to/download).
+DL="${JAVA_DL_ROOT:-${STARRY_STAGING_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/.cache/java-dl}"
+JM="$DL/jdk-multi"
+SRC="$DL/rv-jdk25-src"
+CROSS="${RV_MUSL_CROSS:-/opt/riscv64-linux-musl-cross}"
+SYSROOT="$CROSS/riscv64-linux-musl"
+BOOTJDK="$DL/boot-jdk25-x64-glibc"                        # glibc x64 JDK25 (build/boot JDK)
+OUT="$JM/jdk25/openjdk25-riscv64-musl-srcbuild.tar.gz"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ALPINE_RV="https://dl-cdn.alpinelinux.org/alpine/edge/main/riscv64"
+
+[ -x "$CROSS/bin/riscv64-linux-musl-gcc" ] || { echo "ERROR: cross GCC not at $CROSS/bin (set RV_MUSL_CROSS)"; exit 1; }
+
+# 1. boot/build JDK (glibc x64 JDK25) — same feature version as the build target.
+if [ ! -x "$BOOTJDK/bin/javac" ]; then
+    echo "== fetching glibc x64 JDK25 boot-JDK =="
+    mkdir -p "$BOOTJDK"
+    curl -fsSL "https://download.bell-sw.com/java/25+37/bellsoft-jdk25+37-linux-amd64.tar.gz" -o /tmp/bjdk25.tgz
+    tar -xzf /tmp/bjdk25.tgz -C "$BOOTJDK" --strip-components=1 && rm -f /tmp/bjdk25.tgz
+fi
+
+# 2. source: clone the jdk25u update tag + apply the musl-port patch.
+if [ ! -f "$SRC/configure" ]; then
+    echo "== cloning $SRC_REPO @ $JDK_TAG =="
+    git clone --depth 1 --branch "$JDK_TAG" "$SRC_REPO" "$SRC"
+fi
+echo "== applying rv-jdk25-musl-port.patch =="
+( cd "$SRC" && git apply --check "$HERE/rv-jdk25-musl-port.patch" 2>/dev/null && git apply "$HERE/rv-jdk25-musl-port.patch" ) \
+    || echo "  (patch already applied or partially present — continuing)"
+
+# 3. cross sysroot: the JDK build needs target API headers + a libX11/libasound to link
+#    against. The API headers are arch-independent (copy from host); the .so must be real
+#    riscv64-musl (fetch from Alpine, the same source that builds openjdk25-riscv64).
+echo "== staging target headers + libs into cross sysroot =="
+for d in alsa cups fontconfig X11; do
+    [ -d "/usr/include/$d" ] && cp -rn "/usr/include/$d" "$SYSROOT/include/" 2>/dev/null || true
+done
+mkdir -p "$DL/.alpine-rv-libs"; cd "$DL/.alpine-rv-libs"
+[ -f APKINDEX ] || { curl -fsSL "$ALPINE_RV/APKINDEX.tar.gz" -o APKINDEX.tar.gz && tar -xzf APKINDEX.tar.gz; }
+apkver() { awk -v p="$1" 'BEGIN{RS="";FS="\n"}{n="";v="";for(i=1;i<=NF;i++){if($i~/^P:/)n=substr($i,3);if($i~/^V:/)v=substr($i,3)} if(n==p)print v}' APKINDEX | head -1; }
+for pkg in libx11 libxcb libxau libxdmcp libxext libxrender libxrandr libxtst libxi libxt alsa-lib; do
+    v="$(apkver "$pkg")"; [ -n "$v" ] || { echo "  WARN no $pkg in Alpine index"; continue; }
+    f="${pkg}-${v}.apk"; [ -f "$f" ] || curl -fsSL "$ALPINE_RV/$f" -o "$f"
+    mkdir -p "ext/$pkg"; tar -xzf "$f" -C "ext/$pkg" 2>/dev/null || true
+done
+find ext -name "*.so*" -exec cp -P {} "$SYSROOT/lib/" \; 2>/dev/null || true
+# unversioned dev symlinks for the link step
+( cd "$SYSROOT/lib" && for b in libX11 libXext libXrender libXrandr libXtst libXi libXt libXau libXdmcp libxcb libasound; do
+    r="$(ls ${b}.so.* 2>/dev/null | grep -E '\.so\.[0-9]+$' | head -1)"; [ -n "$r" ] && [ ! -e "${b}.so" ] && ln -s "$r" "${b}.so" || true
+  done )
+
+# 4. configure: cross x86_64-linux -> riscv64-linux-musl, headless, bundled media libs.
+#    --build forces linux (avoids WSL mis-detecting the build host as Windows via /mnt/c).
+echo "== configure =="
+cd "$SRC"; rm -rf build/.configure-support
+PATH="$(echo "$PATH" | tr ':' '\n' | grep -v '^/mnt/' | paste -sd: -)" \
+bash configure \
+    --build=x86_64-unknown-linux-gnu \
+    --openjdk-target=riscv64-linux-musl \
+    --with-toolchain-path="$CROSS/bin" --with-sysroot="$SYSROOT" \
+    --x-includes="$SYSROOT/include" --x-libraries="$SYSROOT/lib" \
+    --with-boot-jdk="$BOOTJDK" --with-build-jdk="$BOOTJDK" \
+    --with-jvm-variants=server --enable-headless-only \
+    --with-freetype=bundled --with-libjpeg=bundled --with-giflib=bundled \
+    --with-libpng=bundled --with-zlib=bundled --with-lcms=bundled \
+    --disable-warnings-as-errors
+
+# 5. build the JDK image.
+echo "== make images =="
+unset CLASSPATH
+PATH="$(echo "$PATH" | tr ':' '\n' | grep -v '^/mnt/' | paste -sd: -)" make images
+
+IMG="$SRC/build/linux-riscv64-server-release/images/jdk"
+[ -x "$IMG/bin/java" ] || { echo "ERROR: image not produced at $IMG"; exit 2; }
+readelf -h "$IMG/bin/java" | grep -q RISC-V || { echo "ERROR: produced java is not RISC-V"; exit 2; }
+
+# 6. tar where prebuild.sh expects it (top dir 'jdk' so untar_strip1 lands the contents).
+echo "== packaging -> $OUT =="
+mkdir -p "$(dirname "$OUT")"
+tar -czf "$OUT" -C "$(dirname "$IMG")" jdk
+echo "DONE: $OUT ($(du -h "$OUT" | cut -f1)) — native riscv64-musl OpenJDK 25 (server VM)"


### PR DESCRIPTION
## 这是什么

> **Blocked by #1366, #1367（仅 x86_64 leg）。** aarch64 / riscv64 / loongarch64 在裸 dev 即 4/4，无需任何内核改动；**x86_64 的 4/4 需先合入内核 PR #1366 + #1367**（两处 x86_64-only 根因修复），否则 x86_64 仍会 SIGSEGV 风暴。本 app PR 本身只改 `apps/starry/java-lang/`，不含内核改动，可独立合入 —— 仅 x86_64 这一架构的实测结果以 #1366 + #1367 为前提。

为 StarryOS 新增 `apps/starry/java-lang` —— OpenJDK **17 / 21 / 23 / 25** 多版本并存的语言级地毯式测试，结构对照已合入的 `apps/starry/python-lang`（#1257）。四套 JDK 同装于 `/opt/jdk{17,21,23,25}`，覆盖：

- 逐版本的版本专属语言/标准库特性（records/sealed/文本块/虚拟线程/record 模式/Stream Gatherers/Scoped Values/StableValue 等）；
- 全 JLS 语法地毯（`JavaGrammar.java`，单文件源码模式）；
- `javac`/`java` 每个 `--help`/`-X` 选项逐项断言；
- `update-alternatives` 与 sdkman 风格的版本切换；
- Java-8（`--release 8`，bytecode 52）向后兼容 jar —— Commons(io/math3/lang3/collections4) · Log4j2 · HSQLDB · H2 · Gson · BeanShell，经 JUnit4 跑 299 测，验证「一次编译、到处运行」。

所有 JVM 以 `-Xint -Xmx512m -Xms64m` 运行（StarryOS JIT 仍在完善；裸 ergonomic 堆会触发 "Too small maximum heap"）。聚合门控仅在 `PASS==TOTAL` 时输出 `JDK_MULTI_OK=1` 与 `TEST PASSED`。

## 怎么跑

```sh
cargo xtask starry app qemu -t java-lang --arch x86_64        # x86_64 需先合入 #1366 + #1367；aarch64/riscv64/loongarch64 在裸 dev 即可
cargo xtask starry app qemu -t java-lang --arch aarch64
cargo xtask starry app qemu -t java-lang --arch riscv64
cargo xtask starry app qemu -t java-lang --arch loongarch64
```

`prebuild.sh` 经 `ensure_asset` 从官方源按 sha256 拉取依赖（JDK 取自 BellSoft Liberica / Alpine / Loongson，外加 riscv64 JDK25 / loongarch64 JDK23 的源码 native-musl 构建产物；Java-8 兼容 jar 取自 Maven Central；riscv64 JDK23 所需的真实 glibc 运行时取自 Debian trixie 的 `libc6`），把四套 JDK 经 `debugfs -w` 注入 rootfs（无 mount/sync、无绝对路径）；已 populated 的 `JAVA_DL_ROOT` 缓存可零网络命中。

## 架构覆盖（据实）

> aarch64 / riscv64 / loongarch64 在裸 dev 即 `4/4`；**x86_64 的 `4/4` 以合入 #1366 + #1367 为前提**（裸 dev 上 x86_64 仍会 SIGSEGV 风暴）。下表 x86_64 行的结果即应用 #1366 + #1367 后实测所得。

| arch | 可运行 JDK | 结果 |
|:--:|:--:|:--|
| x86_64 | 17/21/23/25 | `AGGREGATE PASS=13/13` + `JDK_MULTI_OK=1` + `TEST PASSED`（`segv34=0`）；由配套内核修复 #1366 + #1367 解锁 |
| aarch64 | 17/21/23/25 | `AGGREGATE PASS=13/13` + `JDK_MULTI_OK=1` + `TEST PASSED` |
| riscv64 | 17/21/23/25 | `AGGREGATE PASS=13/13` + `JDK_MULTI_OK=1` + `TEST PASSED`；JDK23 经真实 Debian glibc 运行时桥接，JDK25 由 native-musl 源码构建 |
| loongarch64 | 17/21/23/25 | `AGGREGATE PASS=13/13` + `JDK_MULTI_OK=1` + `TEST PASSED` |

每架构均含对应 `qemu-<arch>.toml`（仅随附已实测通过的架构配置；配置与本表声明一致）。

### x86_64 由两处内核根因修复解锁（#1366 + #1367）

此前 x86_64 被标注为「内核阻塞 / 不可运行」。经定位，两个 **x86_64-only** StarryOS 内核缺陷已根因修复，x86_64 现跑通完整地毯 4/4：

1. **axcpu x86_64 `ExtendedState::default` 误置 FXSAVE x87 标签**：缺省把 FXSAVE abridged x87 tag 填为 `0xffff`（"stack full"）而非 `0x00`（empty）。在 qemu64 的 FXRSTOR-fallback 路径上，每个线程首个 x87 运算即栈溢出 → musl long-double `fmt_fp` 越界改写 TCB self-pointer → 递归 `%fs:0=0` SIGSEGV 风暴（即此前的 `segv34` 现象）。修复后 `segv34=0`。
2. **x86 `#DE`（divide-error）误投递为 SIGTRAP**：应投递 `SIGFPE` / `FPE_INTDIV`。因投递错误，HotSpot 无法把整数除零转成 `ArithmeticException`，`javac` 在大型编译时中止。修正信号后 idiv-by-零正确转异常，编译恢复正常。

两处修复均为 x86_64 专属、不影响其余架构；详见配套内核 PR #1366 + #1367。

### 其余架构墙（据实）

- **riscv64 JDK23**：无上游 musl JDK23 → 采用 BellSoft generic-glibc JDK23 + staged 真实 Debian glibc 运行时桥接（gcompat musl-shim 不足以承载 JVM，真实 glibc 可运行）。
- **riscv64 JDK25**：此前在 RV64GC 基线触发 IllegalInstruction（C.LUI imm=0 保留编码，位于运行期生成的 CodeCache），Alpine-musl 与 BellSoft generic-glibc 两个独立厂商构建均失败，确认为上游 HotSpot riscv 代码生成回归。**现已绕过：从 jdk25u 源码（25.0.4）交叉编译 native riscv64-musl JDK25**（修正受影响的 C.LUI 编码后构建产物可运行），riscv64 因此达成 4/4。
- **loongarch64 JDK23**：此前无 musl 预编译（Loongson 仅 abi1.0 glibc）→ 从源码交叉编译 native loongarch64-musl JDK23（loongson/jdk jdk-23+25-ls-0 + loongarch64-linux-musl；见 `setup-loong-jdk23.sh` / `loong-jdk23-musl-port.patch`），loongarch64 达成 4/4。

## 配套与依赖

- **配套内核修复（必读）**：x86_64 4/4 依赖 #1366 + #1367（axcpu FXSAVE x87 tag 修复 + x86 `#DE`→`SIGFPE/FPE_INTDIV` 修复）。该 PR 合入后 x86_64 地毯方可绿。
- **loongarch64 RAM 依赖**：#1214（FDT 检测 qemu `-m`）已合入 dev；`qemu-loongarch64.toml` 设 `-m 8192M`。

## 评审意见处理

- **目录位置**：原置于 `test-suit/starryos/stress/openjdk-multi-0/`（`stress` 一级分组已按 GUIDE.md 迁出）→ 已整体重置为 `apps/starry/java-lang`，消除双层嵌套目录。
- **运行命令**：原 `-g stress -c` 在当前 xtask 不可用 → 改为 `cargo xtask starry app qemu -t java-lang --arch <arch>`（README 同步）。
- **x86_64 由阻塞转为可运行**：原 PR 把 x86_64 标为内核阻塞且不含 `qemu-x86_64.toml`；随配套内核修复 #1366 + #1367 落地，现已补入 `qemu-x86_64.toml` 并实测 4/4，对应架构表与「怎么跑」一并更新。
