### PR TITLE
fix(crab-usb): correct xHCI EP0 update and TT port selection

### DIFF
--- a/drivers/usb/usb-host/src/backend/kmod/xhci/device.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/device.rs
@@ -167,7 +167,7 @@ impl Device {
 
         let dci = Dci::CTRL;
         self.ctx.with_input(|input| {
-            let _ = input.control_mut().add_context_flag(1); // Endpoint 0 Context
+            input.control_mut().set_add_context_flag(1); // Endpoint 0 Context
 
             let endpoint = input.device_mut().endpoint_mut(dci.as_usize());
             endpoint.set_max_packet_size(packet_size);
@@ -242,7 +242,6 @@ impl Device {
 
                 while let Some(p) = parent_id {
                     let parent_hub = info.infos.get(&p).unwrap();
-                    tt_port = parent_hub.port_id;
                     if parent_hub.hub_depth == -1 {
                         break;
                     }
@@ -250,6 +249,7 @@ impl Device {
                         hs_parent = Some(p);
                         break;
                     }
+                    tt_port = parent_hub.port_id;
                     parent_id = parent_hub.parent;
                 }
 


### PR DESCRIPTION
## 问题

在 RK3588 / Orange Pi 5 Plus 的 StarryOS xHCI Host 路径下，USB Hub 后的设备枚举不稳定。实测中可能出现：

- CDC ACM 设备描述符异常，libusb 看到 `vid=0000 pid=0000 configs=0`
- Hub 后的 UVC/CDC 设备不可见
- usbfs 探测出现 `XHCI error: UsbTransactionError`

最终会导致用户态无法通过 usbfs/libusb 正常访问 UVC 摄像头或 CDC ACM 设备。

## 修改

本 PR 包含两处 xHCI 枚举修复：

1. Evaluate Context 更新 EP0 max packet size 时，改为真正设置 Endpoint 0 Context 的 Add Context Flag。

   原代码调用的是 `add_context_flag(1)`，这是 getter，只读取标志位，不会修改 Input Control Context。现在改为 `set_add_context_flag(1)`，确保控制器应用更新后的 EP0 Context。

2. 修正 Full-Speed/Low-Speed 设备挂在 High-Speed Hub 后时的 TT Port 选择。

   原逻辑在向上查找父 Hub 时过早覆盖 `tt_port`，导致直接 High-Speed 父 Hub 场景下 Parent Port Number 变成父 Hub 的上游端口。现在只在继续向上跨过中间 Hub 时更新 `tt_port`，保留目标设备接入 High-Speed Hub 的真实下游端口。