### PR TITLE
feat: runtime Wi-Fi AP/STA mode switch for AIC8800 on SG2002 (LicheeRV Nano)

### DIFF
--- a/apps/starry/picoclaw-cli/WIFI_SWITCH_DEMO.md
+++ b/apps/starry/picoclaw-cli/WIFI_SWITCH_DEMO.md
@@ -1,0 +1,80 @@
+# wifi_switch — runtime Wi-Fi AP↔STA switch demo
+
+A tiny userspace tool that drives StarryOS's wireless-extensions `ioctl` path
+to switch the `wlan0` interface (aic8800 on sg2002) between **SoftAP** and
+**Station** at runtime, without a reboot.
+
+It exercises the full control-plane chain added in `feat/wifi-mode-switch`:
+
+```
+wifi_switch (SIOCSIW* + COMMIT)
+  -> StarryOS socket ioctl  (kernel/src/file/wext.rs)
+  -> ax_net::reconfigure_wifi
+       -> rd_net::WifiControlHandle -> aic8800 WifiControl  (VIF teardown + switch)
+       -> Service::reconfigure_as_{ap,sta}                  (IP / DHCP role)
+```
+
+## Build (riscv64, static musl)
+
+Use the same cross toolchain as the other sg2002 rootfs binaries. In the
+build container (`tgoskits-sg2002`):
+
+```sh
+cd /workspace/apps/starry/picoclaw-cli
+/opt/riscv64-linux-musl-cross/bin/riscv64-linux-musl-gcc \
+    -static -O2 -Wall -Wextra -o wifi_switch wifi_switch.c
+```
+
+Produces a static-PIE riscv64 ELF.
+
+## Install onto the SD card
+
+Drop it into the StarryOS p3 rootfs at `/usr/bin/`, next to `tennis`,
+`test_motor`, etc. (see `docs/sd-card-build.md`):
+
+```sh
+sudo cp wifi_switch /tmp/sdpart/usr/bin/
+sudo chmod +x /tmp/sdpart/usr/bin/wifi_switch
+```
+
+## Run on the board
+
+```sh
+# Become an open SoftAP (default channel 6). This is the boot default too,
+# so use it to switch BACK to AP after testing STA.
+wifi_switch ap PicoClaw-Car
+wifi_switch ap PicoClaw-Car 11        # explicit channel
+
+# Join an existing network in station mode.
+wifi_switch sta MyHomeWifi mypassword # WPA2
+wifi_switch sta OpenCafeWifi          # open network
+```
+
+## How to tell it worked
+
+The boot default is SoftAP `PicoClaw-Car` on `192.168.50.1/24` with a DHCP
+server leasing `192.168.50.2`. A successful switch is observable as:
+
+1. **Kernel log** — each commit logs `wlan0: wifi mode switch complete` from
+   `ax_net::reconfigure_wifi`, preceded by the aic8800 link-layer lines
+   (`MM_REMOVE_IF`, then either `connected to '<ssid>'` for STA or
+   `AP started, APM_START_CFM=...` for AP), and the stack role line
+   (`dev N: reconfigured as STA, DHCP client enabled` /
+   `... reconfigured as AP 192.168.50.1/24, DHCP server lease 192.168.50.2`).
+
+2. **STA mode** — after `wifi_switch sta <ssid> <pass>`, the interface drops
+   its `192.168.50.1` SoftAP address and DHCP-discovers a new one from the
+   joined AP. Watch the log for `DHCP acquired address <x>`; then a client on
+   that LAN can be reached (e.g. `ping`/`wget` from the board).
+
+3. **AP mode** — after `wifi_switch ap PicoClaw-Car`, an external phone/laptop
+   sees the `PicoClaw-Car` SSID again and gets `192.168.50.2` by DHCP; it can
+   ping `192.168.50.1`.
+
+4. **Round trip** — `ap -> sta -> ap` should leave you back at a working SoftAP,
+   confirming repeated VIF teardown/bring-up is clean (the original goal of the
+   `MM_REMOVE_IF` teardown work).
+
+> Note: a non-zero exit with `ioctl 0x8b00 failed` means COMMIT was rejected —
+> check that all of mode/ssid (and channel for AP) were staged first, and read
+> the kernel log for the `reconfigure_wifi` failure reason.

--- a/apps/starry/picoclaw-cli/wifi_switch.c
+++ b/apps/starry/picoclaw-cli/wifi_switch.c
@@ -1,0 +1,179 @@
+/*
+ * wifi_switch — runtime Wi-Fi mode switch demo for StarryOS (sg2002 / aic8800).
+ *
+ * Drives the kernel's wireless-extensions ioctl path (see
+ * os/StarryOS/kernel/src/file/wext.rs) to switch the wlan0 interface between
+ * Station and SoftAP at runtime. Setters stage config; SIOCSIWCOMMIT applies it
+ * atomically (link-layer VIF teardown + switch + IP/DHCP role reconfig).
+ *
+ * Build (riscv64, musl static — matches the other sg2002 rootfs binaries):
+ *   riscv64-linux-musl-gcc -static -O2 -o wifi_switch wifi_switch.c
+ * Then drop it into the p3 rootfs at /usr/bin/wifi_switch (chmod +x) alongside
+ * tennis/test_motor/etc. See docs/sd-card-build.md.
+ *
+ * Usage on the board:
+ *   wifi_switch ap   <ssid> [channel]      # become open SoftAP (default ch 6)
+ *   wifi_switch sta  <ssid> [passphrase]   # join a network in station mode
+ *
+ * We deliberately avoid <linux/wireless.h> (the cross toolchain may lack it)
+ * and lay out `struct iwreq` by hand. The layout below MUST match wext.rs:
+ *   - ifr name      : offset 0,  16 bytes
+ *   - iwreq_data    : offset 16, 16-byte union
+ *   - MODE / FREQ   : first u32 of the union
+ *   - ESSID/ENCODE  : iw_point { void *pointer; __u16 length; __u16 flags; }
+ *                     pointer @ union+0 (8B on rv64), length @ union+8
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+/* Wireless-extensions ioctl numbers (from <linux/wireless.h>). */
+#define SIOCSIWCOMMIT     0x8B00
+#define SIOCSIWFREQ       0x8B04
+#define SIOCSIWMODE       0x8B06
+#define SIOCSIWESSID      0x8B1A
+#define SIOCSIWENCODEEXT  0x8B34
+
+/* iw_mode values. */
+#define IW_MODE_INFRA     2  /* Managed / Station */
+#define IW_MODE_MASTER    3  /* Master  / Access Point */
+
+#define IFNAMSIZ          16
+#define IW_ESSID_MAX_SIZE 32
+
+/* Hand-rolled iw_point: { void *pointer; __u16 length; __u16 flags; }. */
+struct iw_point_compat {
+    void    *pointer;
+    uint16_t length;
+    uint16_t flags;
+};
+
+/*
+ * Hand-rolled iwreq: 16-byte name union, then a 16-byte iwreq_data union.
+ * We only ever use the u32 field (mode/freq) or the iw_point field (essid/key).
+ */
+struct iwreq_compat {
+    char ifrn_name[IFNAMSIZ];
+    union {
+        uint32_t                mode;     /* SIOCSIWMODE / SIOCSIWFREQ */
+        struct iw_point_compat  essid;    /* SIOCSIWESSID / ...ENCODEEXT */
+        char                    pad[16];  /* keep the union exactly 16 bytes */
+    } u;
+};
+
+static int wext(int fd, unsigned long cmd, struct iwreq_compat *req) {
+    if (ioctl(fd, cmd, req) < 0) {
+        fprintf(stderr, "ioctl 0x%lx failed: %s\n", cmd, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+static void set_ifname(struct iwreq_compat *req, const char *ifname) {
+    memset(req, 0, sizeof(*req));
+    strncpy(req->ifrn_name, ifname, IFNAMSIZ - 1);
+}
+
+static int do_set_mode(int fd, const char *ifname, uint32_t mode) {
+    struct iwreq_compat req;
+    set_ifname(&req, ifname);
+    req.u.mode = mode;
+    return wext(fd, SIOCSIWMODE, &req);
+}
+
+static int do_set_essid(int fd, const char *ifname, const char *ssid) {
+    struct iwreq_compat req;
+    size_t len = strlen(ssid);
+    if (len > IW_ESSID_MAX_SIZE) {
+        fprintf(stderr, "ssid too long (max %d)\n", IW_ESSID_MAX_SIZE);
+        return -1;
+    }
+    set_ifname(&req, ifname);
+    req.u.essid.pointer = (void *)ssid;
+    req.u.essid.length = (uint16_t)len;
+    req.u.essid.flags = 1; /* SSID active */
+    return wext(fd, SIOCSIWESSID, &req);
+}
+
+static int do_set_key(int fd, const char *ifname, const char *pass) {
+    struct iwreq_compat req;
+    set_ifname(&req, ifname);
+    req.u.essid.pointer = (void *)pass;
+    req.u.essid.length = (uint16_t)strlen(pass);
+    req.u.essid.flags = 0;
+    return wext(fd, SIOCSIWENCODEEXT, &req);
+}
+
+static int do_set_channel(int fd, const char *ifname, uint32_t chan) {
+    struct iwreq_compat req;
+    set_ifname(&req, ifname);
+    req.u.mode = chan; /* wext.rs reads first u32 of the union as channel */
+    return wext(fd, SIOCSIWFREQ, &req);
+}
+
+static int do_commit(int fd, const char *ifname) {
+    struct iwreq_compat req;
+    set_ifname(&req, ifname);
+    return wext(fd, SIOCSIWCOMMIT, &req);
+}
+
+static void usage(const char *argv0) {
+    fprintf(stderr,
+        "usage:\n"
+        "  %s ap  <ssid> [channel]      become open SoftAP (default channel 6)\n"
+        "  %s sta <ssid> [passphrase]   join a network in station mode\n",
+        argv0, argv0);
+}
+
+int main(int argc, char **argv) {
+    const char *ifname = "wlan0";
+
+    if (argc < 3) {
+        usage(argv[0]);
+        return 2;
+    }
+
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        perror("socket");
+        return 1;
+    }
+
+    const char *mode = argv[1];
+    const char *ssid = argv[2];
+    int rc = 1;
+
+    if (strcmp(mode, "ap") == 0) {
+        uint32_t chan = (argc >= 4) ? (uint32_t)atoi(argv[3]) : 6;
+        printf("[wifi_switch] %s -> SoftAP ssid=\"%s\" channel=%u\n", ifname, ssid, chan);
+        if (do_set_mode(fd, ifname, IW_MODE_MASTER)) goto out;
+        if (do_set_essid(fd, ifname, ssid)) goto out;
+        if (do_set_channel(fd, ifname, chan)) goto out;
+        if (do_commit(fd, ifname)) goto out;
+        printf("[wifi_switch] SoftAP commit OK\n");
+        rc = 0;
+    } else if (strcmp(mode, "sta") == 0) {
+        const char *pass = (argc >= 4) ? argv[3] : "";
+        printf("[wifi_switch] %s -> Station ssid=\"%s\" (%s)\n",
+               ifname, ssid, pass[0] ? "wpa2" : "open");
+        if (do_set_mode(fd, ifname, IW_MODE_INFRA)) goto out;
+        if (do_set_essid(fd, ifname, ssid)) goto out;
+        if (pass[0] && do_set_key(fd, ifname, pass)) goto out;
+        if (do_commit(fd, ifname)) goto out;
+        printf("[wifi_switch] Station commit OK\n");
+        rc = 0;
+    } else {
+        usage(argv[0]);
+        rc = 2;
+    }
+
+out:
+    close(fd);
+    return rc;
+}

--- a/components/aic8800/src/fdrv/protocol/connection.rs
+++ b/components/aic8800/src/fdrv/protocol/connection.rs
@@ -265,3 +265,21 @@ pub fn send_mm_add_if_req_typed(
         Err(CmdError::InvalidResponse)
     }
 }
+
+/// 发送 MM_REMOVE_IF_REQ —— 释放固件侧的虚拟接口（VIF）。
+///
+/// 对应 Linux: struct mm_remove_if_req { u8_l inst_nbr; }（仅 1 字节，即 vif_idx）。
+/// MM_REMOVE_IF_CFM 无 payload。
+///
+/// 模式切换（STA↔AP）前必须调用，否则旧 VIF 在固件中永不释放，
+/// `vif_idx` 被新接口覆盖后会造成 VIF 泄漏与寻址错乱。
+pub fn send_mm_remove_if_req(
+    bus: &Arc<WifiBus>,
+    vif_idx: u8,
+    timeout_ms: u64,
+) -> Result<(), CmdError> {
+    let param = [vif_idx];
+    send_cmd(bus, MM_REMOVE_IF_REQ, TASK_MM, &param, timeout_ms)?;
+    log::debug!("[cmd_mgr] MM_REMOVE_IF done (vif_idx={})", vif_idx);
+    Ok(())
+}

--- a/components/aic8800/src/fdrv/protocol/mod.rs
+++ b/components/aic8800/src/fdrv/protocol/mod.rs
@@ -21,8 +21,8 @@ pub use config::{
     send_txpwr_ofst_req,
 };
 pub use connection::{
-    send_mm_add_if_req, send_mm_add_if_req_typed, send_sm_connect_req, send_sm_disconnect_req,
-    wait_for_indication,
+    send_mm_add_if_req, send_mm_add_if_req_typed, send_mm_remove_if_req, send_sm_connect_req,
+    send_sm_disconnect_req, wait_for_indication,
 };
 pub use key::{send_key_add_req, send_key_del_req};
 // 显式重导出 lmac_msg 中的协议定义

--- a/components/aic8800/src/fdrv/wifi/api.rs
+++ b/components/aic8800/src/fdrv/wifi/api.rs
@@ -31,9 +31,9 @@ use crate::{
         protocol::{
             lmac_msg::*, send_apm_stop_req, send_eapol_data_frame, send_get_mac_addr_req,
             send_me_chan_config_req, send_me_config_req, send_me_set_ps_mode_req,
-            send_mm_add_if_req, send_mm_add_if_req_typed, send_mm_set_filter_req,
-            send_mm_start_req, send_reset_req, send_rf_calib_req, send_set_control_port_req,
-            start_open_ap, wait_for_eapol,
+            send_mm_add_if_req, send_mm_add_if_req_typed, send_mm_remove_if_req,
+            send_mm_set_filter_req, send_mm_start_req, send_reset_req, send_rf_calib_req,
+            send_set_control_port_req, start_open_ap, wait_for_eapol,
         },
         wifi::manager::{self, build_wpa2_rsn_ie_from_ap, disconnect},
     },
@@ -225,6 +225,62 @@ impl WifiClient {
     // Phase 1: LMAC 配置
     // ================================================================
 
+    /// 释放当前固件侧 VIF，把驱动状态复位到「无接口」基线。
+    ///
+    /// 模式切换（STA↔AP）前的必备步骤：固件里一次只持有一个 VIF，
+    /// `bus.conn.vif_idx` 是其唯一真值（初值 `0xFF` 表示无 VIF）。若不先
+    /// 释放旧 VIF 就发起新一轮 `MM_ADD_IF`，旧 VIF 在固件中永不回收、
+    /// `vif_idx` 被覆盖，造成 VIF 泄漏与寻址错乱。
+    ///
+    /// 行为：
+    ///   1. 若处于 STA 已连接态，先尽力 `disconnect`（忽略错误，保证对端收到 deauth）；
+    ///   2. 若存在有效 VIF（`vif_idx != 0xFF`），发送 `MM_REMOVE_IF_REQ` 释放；
+    ///   3. 复位连接状态、`vif_idx`、`sta_idx` 与缓存的 MAC。
+    ///
+    /// 无有效 VIF 时为安全空操作（首次进入某模式即此情形）。
+    pub fn teardown_vif(&mut self, timeout_ms: u64) -> Result<(), WifiError> {
+        let vif_idx = self
+            .bus
+            .conn
+            .vif_idx
+            .load(core::sync::atomic::Ordering::Acquire);
+
+        if vif_idx == 0xFF {
+            // 无 VIF：首次进入,直接返回。
+            return Ok(());
+        }
+
+        // STA 已连接时先尽力断开,让对端收到 deauth（失败不阻断拆除）。
+        if self.get_status() == ConnectionStatus::Connected
+            && let Err(e) = disconnect(&self.bus, vif_idx, 3)
+        {
+            log::warn!(
+                "[WifiClient] teardown: best-effort disconnect failed: {:?}",
+                e
+            );
+        }
+
+        send_mm_remove_if_req(&self.bus, vif_idx, timeout_ms).map_err(WifiError::from)?;
+        log::info!("[WifiClient] teardown: removed vif_idx={}", vif_idx);
+
+        // 复位驱动侧状态到「无接口」基线。
+        self.bus
+            .conn
+            .set_status(crate::fdrv::core::STATUS_DISCONNECTED);
+        self.bus
+            .conn
+            .vif_idx
+            .store(0xFF, core::sync::atomic::Ordering::Release);
+        self.bus
+            .conn
+            .sta_idx
+            .store(0xFF, core::sync::atomic::Ordering::Release);
+        *self.bus.conn.ap_mac.lock() = None;
+        self.vif_idx = 0xFF;
+
+        Ok(())
+    }
+
     /// 执行完整 LMAC 配置（初始化后必须调用一次）
     ///
     /// 厂商 D80 序列 (rwnx_main.c):
@@ -246,6 +302,9 @@ impl WifiClient {
         chip: ChipVariant,
         timeout_ms: u64,
     ) -> Result<[u8; 6], WifiError> {
+        // 模式切换/重入：先释放可能存在的旧 VIF（AP 或上一轮 STA）。
+        self.teardown_vif(timeout_ms)?;
+
         send_rf_calib_req(&self.bus, chip, timeout_ms).map_err(WifiError::from)?;
 
         let mac = send_get_mac_addr_req(&self.bus, timeout_ms).map_err(WifiError::from)?;
@@ -299,6 +358,9 @@ impl WifiClient {
         timeout_ms: u64,
     ) -> Result<Vec<u8>, WifiError> {
         log::info!("[WifiClient] === start_ap_open START ===");
+
+        // 模式切换/重入：先释放可能存在的旧 VIF（上一轮 STA 或 AP）。
+        self.teardown_vif(timeout_ms)?;
 
         // ---- 基础 LMAC 配置 ----
         send_rf_calib_req(&self.bus, chip, timeout_ms).map_err(WifiError::from)?;

--- a/drivers/net/rd-net/src/lib.rs
+++ b/drivers/net/rd-net/src/lib.rs
@@ -185,11 +185,9 @@ impl Net {
     /// `Net` is consumed into a driver. Used to drive runtime Wi-Fi mode
     /// switching from a separate task/syscall context.
     pub fn wifi_control_handle(&self) -> Option<WifiControlHandle> {
-        self.wifi_control()
-            .is_some()
-            .then(|| WifiControlHandle {
-                inner: self.inner.clone(),
-            })
+        self.wifi_control().is_some().then(|| WifiControlHandle {
+            inner: self.inner.clone(),
+        })
     }
 }
 

--- a/drivers/net/rd-net/src/lib.rs
+++ b/drivers/net/rd-net/src/lib.rs
@@ -176,6 +176,57 @@ impl Net {
             inner: self.inner.clone(),
         }
     }
+
+    /// Detaches a standalone control-plane handle for this device.
+    ///
+    /// Returns `None` for a plain wired NIC. The handle clones the same
+    /// `Arc<NetInner>` the data plane uses (like [`Net::irq_handler`]), so the
+    /// control plane (STA/SoftAP switch, link policy) stays reachable *after*
+    /// `Net` is consumed into a driver. Used to drive runtime Wi-Fi mode
+    /// switching from a separate task/syscall context.
+    pub fn wifi_control_handle(&self) -> Option<WifiControlHandle> {
+        self.wifi_control()
+            .is_some()
+            .then(|| WifiControlHandle {
+                inner: self.inner.clone(),
+            })
+    }
+}
+
+/// Standalone handle to a device's wireless control plane.
+///
+/// Holds a clone of the device's `Arc<NetInner>`, so it keeps working after the
+/// originating [`Net`] has been consumed into a data-plane driver. See
+/// [`Net::wifi_control_handle`].
+pub struct WifiControlHandle {
+    inner: Arc<NetInner>,
+}
+
+unsafe impl Send for WifiControlHandle {}
+unsafe impl Sync for WifiControlHandle {}
+
+impl WifiControlHandle {
+    /// Access the wireless control plane.
+    ///
+    /// # Safety / concurrency
+    ///
+    /// This aliases the same `Interface` the data plane drives. The caller must
+    /// not invoke control operations concurrently with the device's RX/TX or
+    /// poll path on the same interface. In practice mode switching is issued
+    /// from a syscall/task context that is serialized against the stack's poll
+    /// task, never from inside an RX callback.
+    #[allow(clippy::mut_from_ref)]
+    pub fn wifi_control(&self) -> Option<&mut dyn WifiControl> {
+        let iface = unsafe { &mut **self.inner.interface.get() };
+        iface.wifi_control()
+    }
+
+    /// The device's current MAC address (may change across a mode switch as the
+    /// firmware re-creates its VIF).
+    pub fn mac_address(&self) -> [u8; 6] {
+        let iface = unsafe { &mut **self.inner.interface.get() };
+        iface.mac_address()
+    }
 }
 
 fn make_pool(

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -95,6 +95,15 @@ static SERVICE: Once<Mutex<Service>> = Once::new();
 static POLLING_INTERFACES: AtomicBool = AtomicBool::new(false);
 static POLL_AGAIN: AtomicBool = AtomicBool::new(false);
 
+/// Registry of wireless control-plane handles, keyed by interface name.
+///
+/// Populated when a wireless device is registered (the runtime captures a
+/// [`rd_net::WifiControlHandle`] before the `Net` is consumed into the data-plane
+/// driver). Lets runtime mode switching (e.g. a StarryOS wireless-extensions
+/// `ioctl`) reach the device's [`WifiControl`] by name.
+static WIFI_CONTROLS: LazyLock<Mutex<Vec<(alloc::string::String, rd_net::WifiControlHandle)>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
 /// Signalled by [`notify_oob_rx`] to wake the out-of-band RX poll task, for
 /// devices whose RX arrives outside the ethernet IRQ framework (e.g. SDIO).
 static OOB_RX_SIGNAL: PollSet = PollSet::new();
@@ -317,6 +326,98 @@ pub fn register_device_with_config(dev: Box<dyn EthernetDriver>, config: NetConf
     if config.dedicated_poll {
         start_oob_poll_task(config.name);
     }
+}
+
+/// Registers a wireless control-plane handle under an interface name.
+///
+/// Called by the runtime when adapting a wireless net device, *before* the
+/// `Net` is consumed into the data-plane driver, so the control plane stays
+/// reachable by name for runtime mode switching.
+pub fn register_wifi_control(name: &str, handle: rd_net::WifiControlHandle) {
+    let mut controls = WIFI_CONTROLS.lock();
+    if let Some(entry) = controls.iter_mut().find(|(n, _)| n == name) {
+        entry.1 = handle;
+    } else {
+        controls.push((name.into(), handle));
+    }
+}
+
+/// Target role for a runtime Wi-Fi mode switch.
+pub enum WifiMode<'a> {
+    /// Station: associate to `ssid`/`password`, then use DHCP for addressing.
+    Station { ssid: &'a str, password: &'a str },
+    /// Open SoftAP on `channel`, static `ip`/`prefix_len`, optionally running a
+    /// single-client DHCP server handing out `dhcp_client_ip`.
+    AccessPoint {
+        ssid: &'a [u8],
+        channel: u8,
+        ip: [u8; 4],
+        prefix_len: u8,
+        dhcp_client_ip: Option<[u8; 4]>,
+    },
+}
+
+/// Atomically switches a wireless interface between STA and SoftAP at runtime.
+///
+/// This is the single entry point the OS layer (e.g. a StarryOS wireless-
+/// extensions `SIOCSIWCOMMIT` handler) calls after staging the desired config.
+/// It performs the whole transition in order:
+///
+/// 1. Drive the link-layer switch through the device's `WifiControl` (the chip
+///    driver tears down the old VIF and brings up the new one).
+/// 2. Reconfigure this interface's IPv4 / DHCP role in the protocol stack
+///    (STA → DHCP client, AP → static IP + optional DHCP server).
+///
+/// Both halves run from the caller's task context, never from the RX poll
+/// task, so the blocking firmware command path cannot deadlock the stack.
+///
+/// Returns [`AxError::NoSuchDevice`] if `name` has no registered wireless
+/// control plane, or [`AxError::Unsupported`] if the link-layer switch fails.
+pub fn reconfigure_wifi(name: &str, mode: WifiMode<'_>) -> AxResult<()> {
+    // 1. Link-layer switch through the device control plane, plus the device's
+    //    (possibly new) MAC. The registry lock is released before touching the
+    //    stack service to avoid holding two locks across the blocking path.
+    let mac = {
+        let controls = WIFI_CONTROLS.lock();
+        let (_, handle) = controls
+            .iter()
+            .find(|(n, _)| n == name)
+            .ok_or(AxError::NoSuchDevice)?;
+        let ctrl = handle.wifi_control().ok_or(AxError::NoSuchDevice)?;
+        match &mode {
+            WifiMode::Station { ssid, password } => ctrl
+                .connect(ssid, password)
+                .map_err(|_| ax_err_type!(Unsupported, "wifi STA connect failed"))?,
+            WifiMode::AccessPoint { ssid, channel, .. } => ctrl
+                .start_ap_open(ssid, *channel)
+                .map_err(|_| ax_err_type!(Unsupported, "wifi SoftAP start failed"))?,
+        }
+        EthernetAddress(handle.mac_address())
+    };
+
+    // 2. Reconfigure the stack's IPv4 / DHCP role for this interface.
+    {
+        let mut service = get_service();
+        let dev = service.device_index(name).ok_or(AxError::NoSuchDevice)?;
+        match mode {
+            WifiMode::Station { .. } => service.reconfigure_as_sta(dev, mac),
+            WifiMode::AccessPoint {
+                ip,
+                prefix_len,
+                dhcp_client_ip,
+                ..
+            } => {
+                let server_ip = Ipv4Address::new(ip[0], ip[1], ip[2], ip[3]);
+                let client_ip = dhcp_client_ip.map(|c| Ipv4Address::new(c[0], c[1], c[2], c[3]));
+                service.reconfigure_as_ap(dev, server_ip, prefix_len, client_ip);
+            }
+        }
+    }
+
+    // Kick a poll so the new addressing takes effect immediately.
+    poll_interfaces();
+    info!("{name}: wifi mode switch complete");
+    Ok(())
 }
 
 /// Wakes the out-of-band RX poll task; intended as a device RX-data callback.

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -106,6 +106,11 @@ impl Router {
         self.devices.len() - 1
     }
 
+    /// Finds the index of a device by its interface name (e.g. `"wlan0"`).
+    pub fn device_index(&self, name: &str) -> Option<usize> {
+        self.devices.iter().position(|dev| dev.name() == name)
+    }
+
     pub fn set_ipv4_config(
         &mut self,
         dev: usize,

--- a/net/ax-net/src/service.rs
+++ b/net/ax-net/src/service.rs
@@ -245,6 +245,65 @@ impl Service {
         info!("dev {dev}: DHCP server enabled (lease {client_ip})");
     }
 
+    /// 按接口名查找设备索引(如 `"wlan0"`)。
+    pub fn device_index(&self, name: &str) -> Option<usize> {
+        self.router.device_index(name)
+    }
+
+    /// 运行时把某设备重配为 SoftAP 角色:静态 IP + 内置 DHCP 服务器。
+    ///
+    /// 清掉该设备旧的 DHCP 客户端状态,设置静态地址,并(可选)启动单客户端
+    /// DHCP 服务器。供 Wi-Fi 运行时 STA→AP 切换使用,链路层切换(teardown +
+    /// `start_ap_open`)由调用方在调用本方法前完成。
+    pub fn reconfigure_as_ap(
+        &mut self,
+        dev: usize,
+        server_ip: Ipv4Address,
+        prefix_len: u8,
+        client_ip: Option<Ipv4Address>,
+    ) {
+        // 若该设备此前是 DHCP 客户端,撤掉客户端状态及其获得的接口地址。
+        if self.dhcp.as_ref().is_some_and(|s| s.dev == dev) {
+            if let Some(addr) = self.dhcp.as_ref().and_then(|s| s.address) {
+                Self::set_interface_ipv4(&mut self.iface, Some(addr), None);
+            }
+            self.dhcp = None;
+        }
+
+        let cidr = Ipv4Cidr::new(server_ip, prefix_len);
+        self.router.set_ipv4_config(dev, Some(cidr), None);
+        Self::set_interface_ipv4(&mut self.iface, None, Some(cidr));
+
+        match client_ip {
+            Some(client_ip) => {
+                let subnet_mask = mask_from_prefix(prefix_len);
+                self.dhcp_server = Some(DhcpServer::new(dev, server_ip, client_ip, subnet_mask));
+                info!("dev {dev}: reconfigured as AP {cidr}, DHCP server lease {client_ip}");
+            }
+            None => {
+                self.dhcp_server = None;
+                info!("dev {dev}: reconfigured as AP {cidr} (no DHCP server)");
+            }
+        }
+    }
+
+    /// 运行时把某设备重配为 STA 角色:撤掉 AP 静态 IP / DHCP 服务器,
+    /// 改用 DHCP 客户端获取地址。链路层关联由调用方先行完成。
+    pub fn reconfigure_as_sta(&mut self, dev: usize, mac: EthernetAddress) {
+        // 撤掉该设备作为 AP 时的 DHCP 服务器与静态地址。
+        if self.dhcp_server.as_ref().is_some_and(|s| s.dev == dev) {
+            self.dhcp_server = None;
+        }
+        if let Some(cfg) = self.router.ipv4_config_for_dev(dev) {
+            Self::set_interface_ipv4(&mut self.iface, Some(cfg.address), None);
+        }
+        self.router.set_ipv4_config(dev, None, None);
+
+        // 启用 DHCP 客户端,从新 AP 获取地址。
+        self.dhcp = Some(DhcpState::new(dev, mac));
+        info!("dev {dev}: reconfigured as STA, DHCP client enabled");
+    }
+
     /// 唤醒所有设备的 RX 就绪(SDIO WiFi 带外收包后由 poll 任务调用)。
     pub fn wake_all_devices(&self) {
         self.router.wake_all_devices();
@@ -460,6 +519,17 @@ fn dhcp_transaction_id(mac: EthernetAddress) -> u32 {
 
 fn is_unicast_ipv4(addr: Ipv4Address) -> bool {
     addr != Ipv4Address::UNSPECIFIED && addr != Ipv4Address::BROADCAST && !addr.is_multicast()
+}
+
+/// 由前缀长度构造 IPv4 子网掩码(与 lib.rs 的 `prefix_to_mask` 等价,
+/// 这里独立提供以免暴露跨模块的私有函数)。
+fn mask_from_prefix(prefix_len: u8) -> Ipv4Address {
+    let bits: u32 = if prefix_len == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix_len.min(32) as u32)
+    };
+    Ipv4Address::from_bits(bits)
 }
 
 fn build_dhcp_packet(

--- a/os/StarryOS/kernel/src/file/mod.rs
+++ b/os/StarryOS/kernel/src/file/mod.rs
@@ -14,6 +14,7 @@ mod pidfd;
 mod pipe;
 pub mod signalfd;
 pub mod timerfd;
+mod wext;
 
 use alloc::{borrow::Cow, sync::Arc};
 use core::{ffi::c_int, time::Duration};

--- a/os/StarryOS/kernel/src/file/net.rs
+++ b/os/StarryOS/kernel/src/file/net.rs
@@ -324,7 +324,12 @@ impl FileLike for Socket {
                 };
                 write_ifreq_data(arg, &idx.to_ne_bytes())?;
             }
-            _ => return Err(AxError::NotATty),
+            _ => {
+                if super::wext::is_wext_ioctl(cmd) {
+                    return super::wext::handle(cmd, arg);
+                }
+                return Err(AxError::NotATty);
+            }
         }
         Ok(0)
     }

--- a/os/StarryOS/kernel/src/file/wext.rs
+++ b/os/StarryOS/kernel/src/file/wext.rs
@@ -1,0 +1,250 @@
+//! Linux wireless-extensions (WE) `ioctl` support for socket fds.
+//!
+//! Implements the small subset of the wireless extensions a userspace program
+//! (or the on-device HTTP control server) needs to switch a Wi-Fi interface
+//! between Station and SoftAP at runtime:
+//!
+//! - `SIOCSIWMODE`    — stage the target mode (Managed/STA vs Master/AP).
+//! - `SIOCSIWESSID`   — stage the SSID.
+//! - `SIOCSIWENCODEEXT` — stage the passphrase (STA) / open (AP).
+//! - `SIOCSIWFREQ`    — stage the channel (AP only).
+//! - `SIOCSIWCOMMIT`  — atomically apply the staged config via
+//!   [`ax_net::reconfigure_wifi`] (link-layer teardown + switch + IP/DHCP role).
+//!
+//! The `SIOCSIW*` setters never touch hardware; they only stage into a
+//! per-interface pending config. `SIOCSIWCOMMIT` performs the whole transition
+//! in one shot. This matches the "stage then commit" semantics chosen for this
+//! driver and keeps the switch atomic from the caller's point of view.
+
+use alloc::{string::String, vec::Vec};
+use core::mem::MaybeUninit;
+
+use ax_errno::{AxError, AxResult};
+use spin::Mutex;
+use starry_vm::{vm_read_slice, vm_write_slice};
+
+// ---------------------------------------------------------------------------
+// Wireless-extensions ioctl numbers (not provided by linux_raw_sys).
+// These are the fixed values from <linux/wireless.h>.
+// ---------------------------------------------------------------------------
+
+pub const SIOCSIWCOMMIT: u32 = 0x8B00;
+pub const SIOCSIWFREQ: u32 = 0x8B04;
+pub const SIOCSIWMODE: u32 = 0x8B06;
+pub const SIOCSIWESSID: u32 = 0x8B1A;
+pub const SIOCSIWENCODEEXT: u32 = 0x8B34;
+
+/// `iw_mode` values from <linux/wireless.h>.
+const IW_MODE_INFRA: u32 = 2; // Managed / Station
+const IW_MODE_MASTER: u32 = 3; // Master / Access Point
+
+/// Offsets within `struct iwreq` (size 32 on both 32/64-bit: 16-byte ifrn_name
+/// union followed by a 16-byte `union iwreq_data`).
+const IWREQ_NAME_LEN: usize = 16;
+const IWREQ_DATA_OFFSET: usize = 16;
+
+/// Max SSID length per the spec.
+const IW_ESSID_MAX_SIZE: usize = 32;
+
+/// Max passphrase we accept (WPA2 PSK is <= 63 chars).
+const MAX_PASSPHRASE: usize = 63;
+
+/// Board SoftAP addressing policy applied on a switch to Master mode.
+///
+/// Mirrors the boot-time SoftAP policy the board attaches in
+/// `ax-driver`'s aic8800 probe; kept here so a runtime switch to AP lands on
+/// the same subnet as the boot default.
+const AP_SERVER_IP: [u8; 4] = [192, 168, 50, 1];
+const AP_CLIENT_IP: [u8; 4] = [192, 168, 50, 2];
+const AP_PREFIX_LEN: u8 = 24;
+const AP_CHANNEL_DEFAULT: u8 = 6;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StagedMode {
+    Station,
+    AccessPoint,
+}
+
+/// Per-interface staged wireless config, applied on `SIOCSIWCOMMIT`.
+#[derive(Clone)]
+struct Pending {
+    ifname: String,
+    mode: Option<StagedMode>,
+    ssid: Option<Vec<u8>>,
+    passphrase: Option<String>,
+    channel: Option<u8>,
+}
+
+impl Pending {
+    fn new(ifname: String) -> Self {
+        Self {
+            ifname,
+            mode: None,
+            ssid: None,
+            passphrase: None,
+            channel: None,
+        }
+    }
+}
+
+/// Staged wireless config, keyed by interface name.
+///
+/// Wireless-extensions state is per-netdev in Linux (not per-fd): any socket fd
+/// can stage and commit for a given interface. We mirror that with a global
+/// table rather than per-`Socket` state.
+static PENDING: Mutex<Vec<Pending>> = Mutex::new(Vec::new());
+
+fn with_pending<R>(ifname: &str, f: impl FnOnce(&mut Pending) -> R) -> R {
+    let mut table = PENDING.lock();
+    if let Some(idx) = table.iter().position(|p| p.ifname == ifname) {
+        f(&mut table[idx])
+    } else {
+        table.push(Pending::new(ifname.into()));
+        let last = table.len() - 1;
+        f(&mut table[last])
+    }
+}
+
+fn take_pending(ifname: &str) -> Option<Pending> {
+    let mut table = PENDING.lock();
+    table
+        .iter()
+        .position(|p| p.ifname == ifname)
+        .map(|idx| table.swap_remove(idx))
+}
+
+// ---------------------------------------------------------------------------
+// iwreq parsing helpers
+// ---------------------------------------------------------------------------
+
+fn read_user_array<const N: usize>(ptr: *const u8) -> AxResult<[u8; N]> {
+    let mut buf = [MaybeUninit::<u8>::uninit(); N];
+    vm_read_slice(ptr, &mut buf)?;
+    Ok(buf.map(|v| unsafe { v.assume_init() }))
+}
+
+fn read_ifname(arg: usize) -> AxResult<String> {
+    let buf = read_user_array::<IWREQ_NAME_LEN>(arg as *const u8)?;
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8(buf[..end].to_vec()).map_err(|_| AxError::InvalidInput)
+}
+
+/// Reads the 16-byte `union iwreq_data` payload following the name.
+fn read_iwreq_data(arg: usize) -> AxResult<[u8; 16]> {
+    read_user_array::<16>((arg + IWREQ_DATA_OFFSET) as *const u8)
+}
+
+/// Reads a length-prefixed userspace buffer described by an `iw_point`
+/// (`{ void* pointer; u16 length; u16 flags; }`) embedded in `iwreq_data`.
+fn read_iw_point(arg: usize, max: usize) -> AxResult<Vec<u8>> {
+    let data = read_iwreq_data(arg)?;
+    let ptr = usize::from_ne_bytes(
+        data[..core::mem::size_of::<usize>()]
+            .try_into()
+            .map_err(|_| AxError::InvalidInput)?,
+    );
+    let len = u16::from_ne_bytes([data[8], data[9]]) as usize;
+    if ptr == 0 || len == 0 {
+        return Ok(Vec::new());
+    }
+    if len > max {
+        return Err(AxError::InvalidInput);
+    }
+    let mut buf = alloc::vec![MaybeUninit::<u8>::uninit(); len];
+    vm_read_slice(ptr as *const u8, &mut buf)?;
+    Ok(buf.into_iter().map(|v| unsafe { v.assume_init() }).collect())
+}
+
+// ---------------------------------------------------------------------------
+// ioctl entry
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if `cmd` is a wireless-extensions ioctl handled here.
+pub fn is_wext_ioctl(cmd: u32) -> bool {
+    matches!(
+        cmd,
+        SIOCSIWCOMMIT | SIOCSIWFREQ | SIOCSIWMODE | SIOCSIWESSID | SIOCSIWENCODEEXT
+    )
+}
+
+/// Handles a wireless-extensions `ioctl`. Setters stage config; `SIOCSIWCOMMIT`
+/// applies it. Returns `Ok(0)` on success.
+pub fn handle(cmd: u32, arg: usize) -> AxResult<usize> {
+    let ifname = read_ifname(arg)?;
+
+    match cmd {
+        SIOCSIWMODE => {
+            let data = read_iwreq_data(arg)?;
+            let mode = u32::from_ne_bytes([data[0], data[1], data[2], data[3]]);
+            let staged = match mode {
+                IW_MODE_INFRA => StagedMode::Station,
+                IW_MODE_MASTER => StagedMode::AccessPoint,
+                _ => return Err(AxError::InvalidInput),
+            };
+            with_pending(&ifname, |p| p.mode = Some(staged));
+        }
+        SIOCSIWESSID => {
+            let ssid = read_iw_point(arg, IW_ESSID_MAX_SIZE)?;
+            with_pending(&ifname, |p| p.ssid = Some(ssid));
+        }
+        SIOCSIWENCODEEXT => {
+            // We only need the passphrase bytes. `struct iw_encode_ext` carries
+            // the key at offset 24 with a preceding `u16 key_len` at offset 20;
+            // but userspace tools also place the key via the iw_point buffer.
+            // Accept the iw_point buffer as the raw passphrase for simplicity.
+            let key = read_iw_point(arg, MAX_PASSPHRASE)?;
+            let pass = String::from_utf8(key).map_err(|_| AxError::InvalidInput)?;
+            with_pending(&ifname, |p| p.passphrase = Some(pass));
+        }
+        SIOCSIWFREQ => {
+            // Interpret the first u32 of iwreq_data as a channel number (1..=14).
+            let data = read_iwreq_data(arg)?;
+            let chan = u32::from_ne_bytes([data[0], data[1], data[2], data[3]]);
+            if chan == 0 || chan > 14 {
+                return Err(AxError::InvalidInput);
+            }
+            with_pending(&ifname, |p| p.channel = Some(chan as u8));
+        }
+        SIOCSIWCOMMIT => return commit(&ifname),
+        _ => return Err(AxError::Unsupported),
+    }
+    Ok(0)
+}
+
+/// Applies the staged config for `ifname` atomically via the network stack.
+fn commit(ifname: &str) -> AxResult<usize> {
+    let pending = take_pending(ifname).ok_or(AxError::InvalidInput)?;
+    let mode = pending.mode.ok_or(AxError::InvalidInput)?;
+
+    match mode {
+        StagedMode::Station => {
+            let ssid = pending.ssid.ok_or(AxError::InvalidInput)?;
+            let ssid = core::str::from_utf8(&ssid).map_err(|_| AxError::InvalidInput)?;
+            let password = pending.passphrase.unwrap_or_default();
+            ax_net::reconfigure_wifi(ifname, ax_net::WifiMode::Station {
+                ssid,
+                password: &password,
+            })?;
+        }
+        StagedMode::AccessPoint => {
+            let ssid = pending.ssid.ok_or(AxError::InvalidInput)?;
+            let channel = pending.channel.unwrap_or(AP_CHANNEL_DEFAULT);
+            ax_net::reconfigure_wifi(ifname, ax_net::WifiMode::AccessPoint {
+                ssid: &ssid,
+                channel,
+                ip: AP_SERVER_IP,
+                prefix_len: AP_PREFIX_LEN,
+                dhcp_client_ip: Some(AP_CLIENT_IP),
+            })?;
+        }
+    }
+
+    Ok(0)
+}
+
+/// Silences unused-write-helper warnings if a setter that echoes data back is
+/// added later. Currently all WE setters here only stage, so no write-back.
+#[allow(dead_code)]
+fn _write_iwreq_data(arg: usize, data: &[u8]) -> AxResult<()> {
+    Ok(vm_write_slice((arg + IWREQ_DATA_OFFSET) as *mut u8, data)?)
+}

--- a/os/StarryOS/kernel/src/file/wext.rs
+++ b/os/StarryOS/kernel/src/file/wext.rs
@@ -152,7 +152,10 @@ fn read_iw_point(arg: usize, max: usize) -> AxResult<Vec<u8>> {
     }
     let mut buf = alloc::vec![MaybeUninit::<u8>::uninit(); len];
     vm_read_slice(ptr as *const u8, &mut buf)?;
-    Ok(buf.into_iter().map(|v| unsafe { v.assume_init() }).collect())
+    Ok(buf
+        .into_iter()
+        .map(|v| unsafe { v.assume_init() })
+        .collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -221,21 +224,27 @@ fn commit(ifname: &str) -> AxResult<usize> {
             let ssid = pending.ssid.ok_or(AxError::InvalidInput)?;
             let ssid = core::str::from_utf8(&ssid).map_err(|_| AxError::InvalidInput)?;
             let password = pending.passphrase.unwrap_or_default();
-            ax_net::reconfigure_wifi(ifname, ax_net::WifiMode::Station {
-                ssid,
-                password: &password,
-            })?;
+            ax_net::reconfigure_wifi(
+                ifname,
+                ax_net::WifiMode::Station {
+                    ssid,
+                    password: &password,
+                },
+            )?;
         }
         StagedMode::AccessPoint => {
             let ssid = pending.ssid.ok_or(AxError::InvalidInput)?;
             let channel = pending.channel.unwrap_or(AP_CHANNEL_DEFAULT);
-            ax_net::reconfigure_wifi(ifname, ax_net::WifiMode::AccessPoint {
-                ssid: &ssid,
-                channel,
-                ip: AP_SERVER_IP,
-                prefix_len: AP_PREFIX_LEN,
-                dhcp_client_ip: Some(AP_CLIENT_IP),
-            })?;
+            ax_net::reconfigure_wifi(
+                ifname,
+                ax_net::WifiMode::AccessPoint {
+                    ssid: &ssid,
+                    channel,
+                    ip: AP_SERVER_IP,
+                    prefix_len: AP_PREFIX_LEN,
+                    dhcp_client_ip: Some(AP_CLIENT_IP),
+                },
+            )?;
         }
     }
 

--- a/os/arceos/modules/axruntime/src/devices.rs
+++ b/os/arceos/modules/axruntime/src/devices.rs
@@ -221,6 +221,13 @@ fn adapt_net_device(
         None
     };
 
+    // Capture a standalone control-plane handle *before* the `Net` is consumed
+    // into the data-plane driver, so runtime mode switching can reach this
+    // device's `WifiControl` by name (see `ax_net::reconfigure_wifi`).
+    if let Some(handle) = net.wifi_control_handle() {
+        ax_net::register_wifi_control(name, handle);
+    }
+
     let driver = ax_net::RdNetDriver::new(name, net, irq_num)
         .unwrap_or_else(|err| panic!("failed to adapt net device {name}: {err:?}"));
     let driver = alloc::boxed::Box::new(driver) as alloc::boxed::Box<dyn ax_net::EthernetDriver>;


### PR DESCRIPTION
## 背景

本 PR 在 #1185(SG2002 AIC8800 Wi-Fi SoftAP)的基础上,为 `wlan0` 增加**运行时
AP↔STA 模式切换**能力:无需重启,即可在 SoftAP 与 Station 之间切换。切换通过标准
Linux wireless-extensions `ioctl` 路径驱动,网络栈保持 link-agnostic——所有无线
相关细节仍收敛在 `WifiControl` trait 之后,延续 #1185 的分层设计。

一次切换的完整控制面链路:

```
wifi_switch (SIOCSIW* + COMMIT)
  → StarryOS socket ioctl       (kernel/src/file/wext.rs)
  → ax_net::reconfigure_wifi
      → rd_net::WifiControlHandle → aic8800 WifiControl   (VIF 拆除 + 切换)
      → Service::reconfigure_as_{ap,sta}                  (IPv4 / DHCP 角色)
```

## 变更内容

**驱动层(aic8800 / rd-net)**

- `aic8800`:在重建 VIF 前执行 `MM_REMOVE_IF` 拆除 + `teardown_vif()`,使反复
  STA/AP 切换能干净复用同一个 `vif_idx`。
- `rd-net`:`WifiControlHandle` 在 `Net` 被数据面驱动接管之前克隆设备的
  `Arc<NetInner>`,使控制面在独立的 task/syscall 上下文中仍可达。

**网络栈集成(ax-net)**

- 新增按接口名索引的 `WIFI_CONTROLS` 注册表与 `reconfigure_wifi()` 入口。
- `Service::reconfigure_as_{ap,sta}` 仅切换 IPv4/DHCP 角色,不触碰链路细节。

**系统调用(StarryOS)**

- `wext.rs` 处理 `SIOCSIW{MODE,ESSID,ENCODEEXT,FREQ}`(暂存)+ `SIOCSIWCOMMIT`
  (经 `ax_net::reconfigure_wifi` 原子应用)。

**演示工具**

- `wifi_switch.c` 用户态工具 + `WIFI_SWITCH_DEMO.md`。

## 实现逻辑

模式切换被建模为"先暂存、后提交"的两阶段操作:`SIOCSIWMODE/ESSID/ENCODEEXT/FREQ`
只把目标参数暂存在内核侧,直到 `SIOCSIWCOMMIT` 才真正下发。提交时 `reconfigure_wifi`
先经 `WifiControl` 让 aic8800 拆除当前 VIF 并按新模式重建(STA 走真实 WPA2-PSK
四次握手,AP 则 `APM_START`),再由 `Service` 切换网络栈的 IPv4/DHCP 角色(STA 转
DHCP client,AP 恢复 `192.168.50.1/24` + 单客户端 DHCP server)。整个过程网络栈
不感知具体芯片,延续 #1185 的 link-agnostic 边界。

## 构建与验证

```bash
cargo xtask starry build -c os/StarryOS/configs/board/licheerv-nano-sg2002-wifi.toml
```

已在 SG2002 / LicheeRV Nano 实板验证(默认启动态为 SoftAP `PicoClaw-Car`,
`192.168.50.1/24`,单客户端 DHCP server 分配 `.2`):

- **AP→STA→AP 往返**:反复切换后 SoftAP 仍正常工作,VIF 拆除/重建干净,
  无 `vif_idx` 泄漏。
- **STA 连接 WPA2 网络**:完成真实 WPA2-PSK 四次握手并关联成功,经 DHCP
  client 获取地址,可 ping 通网关。
- **STA 连接开放网络**:无密码网络关联成功并获取 DHCP 地址。
- **AP 模式**:外部手机/笔记本可搜索到 `PicoClaw-Car`,经 DHCP 获得 `.2`,
  可 ping 通 `192.168.50.1`。

## 已知限制

- STA 关联走真实 WPA2-PSK 四次握手;**WPA3/SAE 尚未实现**。
- AP 与 STA 互斥,暂不支持并行 AP+STA。
