### PR TITLE
chore(axbuild): update ostool to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4035,6 +4035,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpboot-protocol"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d964553e2288469f481533e85f9cfceee99a2d73c354c09ac4097e08d890813b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,9 +5517,9 @@ dependencies = [
 
 [[package]]
 name = "ostool"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada76a46f68ee817f9c32b8374939b7d456eb6165654284e2f28e8db89585ca4"
+checksum = "4d8a92d73cae88dc8b23722af3df1cafa57db301f27556f004689201addc0394"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5522,6 +5532,7 @@ dependencies = [
  "env_logger",
  "fitimage",
  "futures",
+ "httpboot-protocol",
  "indicatif",
  "jkconfig 0.2.4",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,7 @@ lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = "0.12"
 atomic-waker = { version = "1.1", default-features = false }
-ostool = { version = "0.22.1" }
+ostool = { version = "0.23.1" }
 riscv = { version = "0.16.1", default-features = false }
 sbi-rt = { version = "0.0.4", default-features = false }
 uefi = "0.37.0"


### PR DESCRIPTION
## 问题

`axbuild` 目前通过 workspace 依赖固定使用 `ostool 0.22.1`。为了跟进 `ostool 0.23` 线，需要更新依赖版本并确认现有 `axbuild` 构建/运行入口仍可用。

## 改动

- 将 workspace 中的 `ostool` 版本从 `0.22.1` 更新到 `0.23.1`。
- 重新生成 `Cargo.lock` 中对应解析结果，带入 `ostool 0.23.1` 新增依赖 `httpboot-protocol 0.1.1`。

## 实现逻辑

1. 先确认 `ostool` 只通过 `axbuild` 进入本仓库主要构建链路。
2. 仅更新 workspace 依赖版本和 lockfile，避免混入无关重构。
3. 使用 `cargo xtask clippy --package axbuild` 验证 0.23 API 对当前 `axbuild` 调用面兼容。
4. 额外执行一次 `arceos-helloworld` 的 x86_64 构建，覆盖 `ostool` 实际执行 cargo build 与 ELF/BIN 产物转换的路径。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package axbuild`
- `cargo xtask clippy --since origin/dev`
- `cargo xtask sync-lint --since origin/dev`
- `cargo xtask test`
- `cargo xtask arceos build --package arceos-helloworld --config apps/arceos/build-x86_64-unknown-none.toml --arch x86_64`

补充说明：`cargo test -p axbuild` 当前会因 `origin/dev` 已存在的 checked-in build config 显式声明默认值 `plat_dyn = true` 而失败，本 PR 没有修改这些配置文件，未将该基线清理混入本次依赖升级。