### PR TITLE
fix(wifi): D80 (V3) EAPOL TX + SDIO bus timeout recovery for AIC8800 on SG2002

### DIFF
--- a/apps/starry/picoclaw-cli/.gitignore
+++ b/apps/starry/picoclaw-cli/.gitignore
@@ -1,0 +1,2 @@
+# Compiled wifi_switch demo binary (built from wifi_switch.c via musl-gcc)
+/wifi_switch

--- a/components/aic8800/src/fdrv/core/sdio_transport.rs
+++ b/components/aic8800/src/fdrv/core/sdio_transport.rs
@@ -10,7 +10,8 @@ use spin::Mutex;
 
 use crate::{
     common::{
-        ChipVariant, SDIOWIFI_BLOCK_CNT_REG, SDIOWIFI_FLOW_CTRL_Q1_REG_V3, SDIOWIFI_FLOW_CTRL_REG,
+        ChipVariant, SDIOWIFI_BLOCK_CNT_REG, SDIOWIFI_BYTEMODE_LEN_REG,
+        SDIOWIFI_BYTEMODE_LEN_REG_V3, SDIOWIFI_FLOW_CTRL_Q1_REG_V3, SDIOWIFI_FLOW_CTRL_REG,
         SDIOWIFI_FLOWCTRL_MASK, SDIOWIFI_INTR_CONFIG_REG, SDIOWIFI_INTR_ENABLE_REG_V3,
         SDIOWIFI_MISC_INT_STATUS_REG_V3, SDIOWIFI_RD_FIFO_ADDR, SDIOWIFI_RD_FIFO_ADDR_V3,
         SDIOWIFI_SLEEP_REG_V3, SDIOWIFI_V3_SLEEP_READY_BIT, SDIOWIFI_V3_WAKEUP_VALUE,
@@ -65,6 +66,15 @@ impl SdioTransport {
             SDIOWIFI_RD_FIFO_ADDR_V3
         } else {
             SDIOWIFI_RD_FIFO_ADDR
+        }
+    }
+
+    /// byte-mode 长度寄存器:V3 收帧走 byte 模式时,此寄存器值 ×4 即为字节长度。
+    pub fn bytemode_len_reg(&self) -> u32 {
+        if self.is_v3 {
+            SDIOWIFI_BYTEMODE_LEN_REG_V3
+        } else {
+            SDIOWIFI_BYTEMODE_LEN_REG
         }
     }
 

--- a/components/aic8800/src/fdrv/crypto/wpa2.rs
+++ b/components/aic8800/src/fdrv/crypto/wpa2.rs
@@ -592,11 +592,15 @@ impl Wpa2Handshake {
 
         if has_ack && !has_mic {
             // M1: ACK=1, MIC=0
-            log::debug!("[wpa2] === Processing M1 ===");
+            log::debug!(
+                "[wpa2] === M1 === key_info=0x{:04x} replay={:02x?}",
+                hdr.key_info,
+                hdr.replay_counter
+            );
             self.process_m1(&hdr, eapol)
         } else if has_ack && has_mic && has_install && has_enc {
             // M3: ACK=1, MIC=1, Install=1, EncKeyData=1
-            log::debug!("[wpa2] === Processing M3 ===");
+            log::debug!("[wpa2] === M3 === key_info=0x{:04x}", hdr.key_info);
             self.process_m3(&hdr, eapol)
         } else {
             log::warn!(
@@ -643,8 +647,10 @@ impl Wpa2Handshake {
 
         self.state = HandshakeState::M2Sent;
         log::debug!(
-            "[wpa2] M2 built ({} bytes), MIC={:02x?}...",
+            "[wpa2] M2 built ({} bytes), snonce={:02x?}.. anonce={:02x?}.. MIC={:02x?}",
             m2.len(),
+            &self.snonce[..4],
+            &self.anonce[..4],
             &mic[..4]
         );
 

--- a/components/aic8800/src/fdrv/protocol/cmd.rs
+++ b/components/aic8800/src/fdrv/protocol/cmd.rs
@@ -12,7 +12,7 @@ use alloc::{sync::Arc, vec, vec::Vec};
 use core::{sync::atomic::Ordering, task::Poll};
 
 use crate::{
-    common::{SDIO_TYPE_CFG_CMD_RSP, SDIOWIFI_WR_FIFO_ADDR},
+    common::SDIO_TYPE_CFG_CMD_RSP,
     fdrv::{
         consts::*,
         core::bus::{BusState, WifiBus},
@@ -351,11 +351,18 @@ fn calculate_eapol_frame_layout(eapol_len: usize) -> EapolFrameLayout {
     }
 }
 
-fn fill_sdio_header_for_eapol(buf: &mut [u8], layout: &EapolFrameLayout) {
+fn fill_sdio_header_for_eapol(buf: &mut [u8], layout: &EapolFrameLayout, is_v3: bool) {
     buf[0] = (layout.sdio_hdr_len & 0xFF) as u8;
     buf[1] = ((layout.sdio_hdr_len >> 8) & 0x0F) as u8;
     buf[2] = 0x01; // SDIO_TYPE_DATA
-    buf[3] = 0x00;
+    // V3(D80)固件校验 SDIO header 第 4 字节的 CRC8;V2(8801)恒为 0。
+    // 与 build_data_frame/build_cmd_frame 的逻辑保持一致——之前这里漏了 V3
+    // 分支,EAPOL 帧在 D80 上因 CRC 校验失败被固件静默丢弃,导致 M2 发不出去。
+    buf[3] = if is_v3 {
+        crate::common::crc8_ponl_107(&buf[0..3])
+    } else {
+        0x00
+    };
 }
 
 fn fill_hostdesc_for_eapol(
@@ -381,6 +388,7 @@ fn build_eapol_frame_buffer(
     eapol: &[u8],
     vif_idx: u8,
     sta_idx: u8,
+    is_v3: bool,
 ) -> Vec<u8> {
     const SDIO_HEADER_LEN: usize = 4;
     const HOSTDESC_SIZE: usize = 28;
@@ -388,7 +396,7 @@ fn build_eapol_frame_buffer(
     let layout = calculate_eapol_frame_layout(eapol.len());
     let mut buf = vec![0u8; layout.final_len];
 
-    fill_sdio_header_for_eapol(&mut buf, &layout);
+    fill_sdio_header_for_eapol(&mut buf, &layout, is_v3);
     fill_hostdesc_for_eapol(
         &mut buf[SDIO_HEADER_LEN..SDIO_HEADER_LEN + HOSTDESC_SIZE],
         layout.payload_len,
@@ -425,7 +433,10 @@ fn send_eapol_frame_to_sdio(bus: &Arc<WifiBus>, buf: &[u8]) -> Result<(), CmdErr
         return Err(e);
     }
 
-    if let Err(e) = transport.write_fifo(1, SDIOWIFI_WR_FIFO_ADDR, buf) {
+    // V3(D80)的写 FIFO 地址是 0x10,V2(8801)是 0x07。必须用 transport 的
+    // V3 感知方法,与 CMD/DATA/MGMT 帧路径一致——之前这里写死了 V2 常量,
+    // 导致 D80 上 M2 被写到错误 SDIO 地址,固件收不到,4 次握手卡死。
+    if let Err(e) = transport.write_fifo(1, transport.wr_fifo_addr(), buf) {
         log::error!("[cmd_mgr] EAPOL TX write_fifo failed: {:?}", e);
         transport.unmask_card_irq();
         return Err(CmdError::SdioError);
@@ -446,6 +457,13 @@ pub fn send_eapol_data_frame(
     vif_idx: u8,
     sta_idx: u8,
 ) -> Result<(), CmdError> {
-    let buf = build_eapol_frame_buffer(dst_mac, src_mac, eapol, vif_idx, sta_idx);
+    let buf = build_eapol_frame_buffer(
+        dst_mac,
+        src_mac,
+        eapol,
+        vif_idx,
+        sta_idx,
+        bus.transport.is_v3(),
+    );
     send_eapol_frame_to_sdio(bus, &buf)
 }

--- a/components/aic8800/src/fdrv/thread/rx.rs
+++ b/components/aic8800/src/fdrv/thread/rx.rs
@@ -10,8 +10,8 @@ use crate::{
     common::{SDIO_TYPE_CFG, SDIO_TYPE_CFG_CMD_RSP, SDIO_TYPE_CFG_DATA_CFM, SDIO_TYPE_CFG_PRINT},
     fdrv::{
         consts::{
-            ETH_P_PAE, MAX_PKT_LEN, RX_ALIGNMENT, RX_HWHRD_LEN, SDIO_OTHER_INTERRUPT,
-            SDIOWIFI_FUNC_BLOCKSIZE,
+            BLOCK_COUNT_MASK, ETH_P_PAE, MAX_PKT_LEN, RX_ALIGNMENT, RX_HWHRD_LEN,
+            SDIO_OTHER_INTERRUPT, SDIOWIFI_FUNC_BLOCKSIZE,
         },
         core::bus::{BusState, WifiBus},
     },
@@ -104,7 +104,7 @@ pub fn start(bus: Arc<WifiBus>) {
 /// # 返回
 /// (block_cnt, should_continue) - 读取的块计数和是否应该继续处理
 fn read_block_count_with_retry(bus: &WifiBus, other_int_retries: &mut u32) -> (u8, bool) {
-    let block_cnt = {
+    let intstatus = {
         match bus.transport.read_byte(1, bus.transport.block_cnt_reg()) {
             Ok(v) => v,
             Err(e) => {
@@ -114,7 +114,7 @@ fn read_block_count_with_retry(bus: &WifiBus, other_int_retries: &mut u32) -> (u
         }
     };
 
-    if block_cnt & SDIO_OTHER_INTERRUPT != 0 {
+    if intstatus & SDIO_OTHER_INTERRUPT != 0 {
         *other_int_retries += 1;
         if *other_int_retries > 3 {
             log::trace!(
@@ -125,30 +125,83 @@ fn read_block_count_with_retry(bus: &WifiBus, other_int_retries: &mut u32) -> (u
         }
         log::trace!(
             "[wifi-rx] SDIO_OTHER_INTERRUPT (0x{:02x}), re-read",
-            block_cnt
+            intstatus
         );
         return (0, true); // 继续重试
     }
 
-    (block_cnt, true)
+    // V3(D80)下 0x04 是多功能 MISC_INT_STATUS 寄存器:bit7=SDIO_OTHER_INTERRUPT
+    // (上面已处理),其余位的语义不是简单的"块数",而是 func1/func2 队列 + byte/block
+    // 模式的复合编码(详见 resolve_rx_data_len)。这里只剥掉中断位,把原始 intstatus
+    // 交给 resolve_rx_data_len 按厂商逻辑解析,不能在此直接 `& 0x7F` 当块数——例如
+    // intstatus==120(0x78)是 func1 的 byte-mode 哨兵,而非 120 个块。
+    (intstatus, true)
+}
+
+/// 按厂商 V3 驱动逻辑(radxa aicwf_sdio.c hal_irqhandler 的 D80 分支)解析一帧的
+/// 真实字节长度。返回 0 表示无数据。
+///
+/// V3(D80)逻辑:
+///   intmaskf2 = intstatus | (1<<3)
+///   if intmaskf2 > 120:        // func2 队列
+///       if intmaskf2 == 127:   byte mode -> data_len = reg[0x05] * 4
+///       else:                  block mode -> data_len = (intstatus & 0x07) * 512
+///   else:                      // func1 队列
+///       if intstatus == 120:   byte mode -> data_len = reg[0x05] * 4
+///       else:                  block mode -> data_len = (intstatus & 0x7F) * 512
+///
+/// V2(8801)逻辑:data_len = (intstatus & 0x7F) * 512(intstatus<64 直接块模式,
+/// 这里统一按块数 ×512,与现有行为一致)。
+fn resolve_rx_data_len(bus: &WifiBus, intstatus: u8) -> usize {
+    if !bus.transport.is_v3() {
+        return (intstatus & BLOCK_COUNT_MASK) as usize * SDIOWIFI_FUNC_BLOCKSIZE;
+    }
+
+    let read_bytemode_len = || -> usize {
+        match bus.transport.read_byte(1, bus.transport.bytemode_len_reg()) {
+            // 厂商 aicwf_sdio_intr_get_len_bytemode:data_len = byte_len * 4
+            // (byte_len <= 128 → 最大 512 字节);只读 0x05,不读 0x06(MSB)。
+            Ok(byte_len) => byte_len as usize * 4,
+            Err(e) => {
+                log::error!("[wifi-rx] read bytemode_len failed: {:?}", e);
+                0
+            }
+        }
+    };
+
+    // 厂商 aicwf_sdio.c D80 分支(LYU4662/aic8800-sdio-linux-1.0)逐字对应。
+    // 注意:block 模式下读完 0x04 必须立刻读 FIFO,中间不能插 CMD52;
+    // 只有 byte 模式(120/127 哨兵)才允许读一次 0x05。
+    let intmaskf2 = intstatus | (1 << 3);
+    if intmaskf2 > 120 {
+        // func2 队列
+        if intmaskf2 == 127 {
+            read_bytemode_len()
+        } else {
+            (intstatus & 0x07) as usize * SDIOWIFI_FUNC_BLOCKSIZE
+        }
+    } else {
+        // func1 队列
+        if intstatus == 120 {
+            read_bytemode_len()
+        } else {
+            (intstatus & 0x7F) as usize * SDIOWIFI_FUNC_BLOCKSIZE
+        }
+    }
 }
 
 /// 读取 FIFO 数据
 ///
-/// 将大的 CMD53 多块传输拆分为较小的段，避免 1-bit SDIO 模式下
-/// 单次传输 block 数量过多导致 SDHCI 控制器超时。
-const MAX_BLOCKS_PER_CMD53: usize = 1;
-
-fn read_fifo_data(bus: &WifiBus, block_cnt: u8) -> Option<Vec<u8>> {
-    let total = block_cnt as usize;
-    let data_len = total * SDIOWIFI_FUNC_BLOCKSIZE;
+/// `data_len` 是 resolve_rx_data_len 解析出的真实字节长度(block 模式为 512 的整数倍,
+/// byte 模式可为任意 ≤512 的字节数)。按 512 字节分段读,避免 1-bit SDIO 模式下单次
+/// CMD53 传输 block 数量过多导致 SDHCI 控制器超时;最后不足 512 的尾段以 byte 模式读
+/// (底层 read_fifo 对非 512 对齐长度自动走 byte-mode CMD53)。
+fn read_fifo_data(bus: &WifiBus, data_len: usize) -> Option<Vec<u8>> {
     let mut buf = vec![0u8; data_len];
     let mut offset = 0;
-    let mut remaining = total;
 
-    while remaining > 0 {
-        let chunk = core::cmp::min(remaining, MAX_BLOCKS_PER_CMD53);
-        let chunk_len = chunk * SDIOWIFI_FUNC_BLOCKSIZE;
+    while offset < data_len {
+        let chunk_len = core::cmp::min(data_len - offset, SDIOWIFI_FUNC_BLOCKSIZE);
 
         if let Err(e) = bus.transport.read_fifo(
             1,
@@ -156,16 +209,15 @@ fn read_fifo_data(bus: &WifiBus, block_cnt: u8) -> Option<Vec<u8>> {
             &mut buf[offset..offset + chunk_len],
         ) {
             log::error!(
-                "[wifi-rx] read_fifo failed at block {}/{}: {:?}",
-                total - remaining,
-                total,
+                "[wifi-rx] read_fifo failed at offset {}/{}: {:?}",
+                offset,
+                data_len,
                 e
             );
             return None;
         }
 
         offset += chunk_len;
-        remaining -= chunk;
     }
 
     Some(buf)
@@ -187,21 +239,31 @@ fn process_rx_frames(bus: &WifiBus) {
             // ISR 触发了，继续读取（不 break）
         }
 
-        let (block_cnt, should_continue) = read_block_count_with_retry(bus, &mut other_int_retries);
+        let (intstatus, should_continue) = read_block_count_with_retry(bus, &mut other_int_retries);
         if !should_continue {
             break;
         }
 
-        if block_cnt == 0 {
+        if intstatus == 0 {
             break;
         }
 
-        log::trace!("[wifi-rx] block_cnt=0x{:02x}, reading FIFO", block_cnt);
-
         other_int_retries = 0;
 
+        // 按厂商 V3 逻辑解析真实字节长度(区分 func1/func2 + byte/block 模式)
+        let data_len = resolve_rx_data_len(bus, intstatus);
+        if data_len == 0 {
+            break;
+        }
+
+        log::trace!(
+            "[wifi-rx] intstatus=0x{:02x}, data_len={} bytes, reading FIFO",
+            intstatus,
+            data_len
+        );
+
         // 读取 FIFO 数据
-        let Some(buf) = read_fifo_data(bus, block_cnt) else {
+        let Some(buf) = read_fifo_data(bus, data_len) else {
             break;
         };
 
@@ -496,6 +558,17 @@ fn process_data_frame(bus: &WifiBus, data_payload: &[u8], pkt_len: usize, _mpdu_
     let fc0 = mpdu[0];
     let fc1 = mpdu[1];
 
+    // 802.11 帧控制字段(data/mgmt/子类型)。trace 级:AP 模式下每个周围
+    // beacon 都会进来,info 刷屏会拖死 RX 线程、错过 Auth/Assoc 握手。
+    log::trace!(
+        "[wifi-rx] 80211 fc0=0x{:02x} fc1=0x{:02x} data={} mgmt={} pkt_len={}",
+        fc0,
+        fc1,
+        is_80211_data_frame(fc0),
+        is_80211_mgmt_frame(fc0),
+        pkt_len
+    );
+
     if !is_80211_data_frame(fc0) {
         // AP 模式：管理帧(Auth/Assoc 等)由固件转发上来，处理握手。
         if is_80211_mgmt_frame(fc0) {
@@ -528,6 +601,15 @@ fn process_data_frame(bus: &WifiBus, data_payload: &[u8], pkt_len: usize, _mpdu_
     };
 
     let payload_start = llc_offset + 8;
+
+    log::trace!(
+        "[wifi-rx] DATA ethertype=0x{:04x} (EAPOL={}) hdr_len={} crypto={} pkt_len={}",
+        ethertype,
+        ethertype == ETH_P_PAE,
+        hdr_len,
+        crypto_hdr_len,
+        pkt_len
+    );
 
     if ethertype == ETH_P_PAE {
         process_eapol_frame(bus, mpdu, payload_start, pkt_len);
@@ -621,6 +703,18 @@ fn dispatch_frames(bus: &WifiBus, buf: &[u8]) {
 
         let pkt_type = buf[offset + 2] & 0x7F;
         let is_cfg = (pkt_type & SDIO_TYPE_CFG) == SDIO_TYPE_CFG;
+
+        // 跳过 PRINT(idle 刷屏的固件 debug 帧)。trace 级:AP 模式每个周围
+        // beacon 都会进来,info 刷屏会拖死 RX 线程。
+        if !(is_cfg && pkt_type == SDIO_TYPE_CFG_PRINT) {
+            log::trace!(
+                "[wifi-rx] frame off={} pkt_len={} type=0x{:02x} is_cfg={}",
+                offset,
+                pkt_len,
+                pkt_type,
+                is_cfg
+            );
+        }
 
         if !is_cfg {
             // ========== DATA 帧 ==========

--- a/components/aic8800/src/fdrv/thread/tx.rs
+++ b/components/aic8800/src/fdrv/thread/tx.rs
@@ -83,7 +83,7 @@ fn process_cmd_tx(bus: &WifiBus) -> bool {
         return false;
     }
 
-    log::warn!("[wifi-tx] process_cmd_tx: found pending CMD");
+    log::trace!("[wifi-tx] process_cmd_tx: found pending CMD");
 
     let cmd_buf = bus.cmd.pending.lock().take();
     let Some(mut cmd) = cmd_buf else {
@@ -92,7 +92,7 @@ fn process_cmd_tx(bus: &WifiBus) -> bool {
 
     bus.cmd.pending_flag.store(false, Ordering::Release);
 
-    log::warn!(
+    log::trace!(
         "[wifi-tx] CMD frame header: [{:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} \
          {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}]",
         cmd.first().unwrap_or(&0),
@@ -173,7 +173,7 @@ fn process_data_tx(bus: &WifiBus) -> bool {
 
     // 未连接则清空队列
     if vif_idx == 0xFF {
-        log::warn!("[wifi-tx] process_data_tx: vif=0xFF, draining queue");
+        log::trace!("[wifi-tx] process_data_tx: vif=0xFF, draining queue");
         while let Some(_) = bus.tx.queue.lock().pop_front() {
             bus.tx.pktcnt.fetch_sub(1, Ordering::AcqRel);
         }
@@ -255,7 +255,7 @@ fn send_single_data_frame(
             log::error!("[wifi-tx] MGMT write_fifo failed: {:?}", e);
             return false;
         }
-        log::info!(
+        log::debug!(
             "[wifi-tx] MGMT frame sent ({} bytes 802.11)",
             frame.data.len()
         );
@@ -277,7 +277,7 @@ fn send_single_data_frame(
         Err(_) => return false,
     };
 
-    log::warn!(
+    log::trace!(
         "[wifi-tx] DATA TX: dst={:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x} etype=0x{:04x} len={}",
         eth_frame[0],
         eth_frame[1],
@@ -473,7 +473,7 @@ fn tx_process(bus: &WifiBus) -> bool {
     let pending_cmd = bus.cmd.pending_flag.load(Ordering::Acquire);
     let pending_data = bus.tx.pktcnt.load(Ordering::Acquire);
     if pending_cmd || pending_data > 0 {
-        log::warn!(
+        log::trace!(
             "[wifi-tx] tx_process: pending_cmd={} pending_data={}",
             pending_cmd,
             pending_data
@@ -531,7 +531,7 @@ pub fn enqueue_mgmt_frame(bus: &WifiBus, mgmt_frame: Vec<u8>) -> Result<(), TxEr
     drop(queue);
 
     let cnt = bus.tx.pktcnt.fetch_add(1, Ordering::AcqRel) + 1;
-    log::warn!("[wifi-tx] enqueue: pktcnt={}", cnt);
+    log::trace!("[wifi-tx] enqueue: pktcnt={}", cnt);
     bus.tx.wake_pollset.wake();
     Ok(())
 }

--- a/components/aic8800/src/fdrv/wifi/api.rs
+++ b/components/aic8800/src/fdrv/wifi/api.rs
@@ -618,10 +618,32 @@ impl WifiClient {
             let eapol =
                 wait_for_eapol(&self.bus, timeout_ms).map_err(|_| WifiError::ConnectionTimeout)?;
 
+            log::debug!(
+                "[wpa2] wait_for_eapol got {} bytes, vif={} sta_idx={}",
+                eapol.len(),
+                self.vif_idx,
+                sta_idx
+            );
             match handshake.process_eapol(&eapol) {
                 Ok(HandshakeAction::SendM2(m2)) => {
-                    send_eapol_data_frame(&self.bus, bssid, &own_mac, &m2, self.vif_idx, sta_idx)
-                        .map_err(|e| WifiError::OperationFailed(format!("Send M2 failed: {:?}", e)))?;
+                    log::debug!("[wpa2] sending M2 ({} bytes) -> {:02x?}", m2.len(), bssid);
+                    match send_eapol_data_frame(
+                        &self.bus,
+                        bssid,
+                        &own_mac,
+                        &m2,
+                        self.vif_idx,
+                        sta_idx,
+                    ) {
+                        Ok(()) => log::debug!("[wpa2] M2 send_eapol_data_frame returned Ok"),
+                        Err(e) => {
+                            log::error!("[wpa2] M2 send failed: {:?}", e);
+                            return Err(WifiError::OperationFailed(format!(
+                                "Send M2 failed: {:?}",
+                                e
+                            )));
+                        }
+                    }
                 }
                 Ok(HandshakeAction::Completed(result)) => {
                     // 安装 PTK

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -162,6 +162,12 @@ impl CviSdhci {
             pres,
             sts
         );
+        // 超时后总线可能仍处于 DAT-busy(PRES bit1 DATA_INHIBIT 置位),若不复位
+        // DAT 线状态机,后续任何数据命令的 wait_data_idle 都会一直超时,整条 SDIO
+        // 总线被焊死(连 WiFi 模式切回 AP 也起不来)。这里对齐错误中断分支:清残留
+        // INT_STATUS 并复位 DAT 线,让总线能从一次读超时中恢复。
+        self.write::<u16>(SDHCI_INT_STATUS_NORM, sts);
+        self.reset_dat_line();
         Err(SdioError::Timeout)
     }
 
@@ -677,7 +683,10 @@ impl SdioHost for CviSdhci {
     }
 
     fn read_fifo(&self, func: u8, addr: u32, buf: &mut [u8]) -> Result<(), SdioError> {
-        self.cmd53_read_fixed(func, addr, buf, 512, true)
+        // 512 对齐的走 block 模式;非对齐(如 V3 byte-mode 收帧的 byte_len*4)且 ≤512
+        // 的走 byte 模式 CMD53。调用方(aic8800 rx)已保证单次 ≤512。
+        let use_blk = buf.len().is_multiple_of(SDIO_DEFAULT_BLOCK_SIZE as usize);
+        self.cmd53_read_fixed(func, addr, buf, 512, use_blk)
     }
 
     fn read_fifo_inc(&self, func: u8, addr: u32, buf: &mut [u8]) -> Result<(), SdioError> {


### PR DESCRIPTION
## 概述

在已合入的 AIC8800 SoftAP(#1185)与运行时 AP↔STA 模式切换(#1266)基础上,修复了在 **D80(V3)芯片 + CV1800 SDIO host** 上暴露的几个底层问题,使 WPA2 STA 连接与 AP↔STA 来回切换在真机上稳定可用。

## 改动内容

### 1. D80 (V3) EAPOL 发送修复
EAPOL 帧此前与 CMD/DATA/MGMT 帧的 V3 处理逻辑不一致,导致 WPA2 四次握手在 D80 上卡死:
- **SDIO header 第 4 字节**:V3 固件会校验 CRC8,V2 恒为 0。此前 EAPOL 路径漏了 V3 分支,M2 因 CRC 校验失败被固件静默丢弃。现改为与 `build_data_frame` 一致按 `is_v3` 填 `crc8_ponl_107`。
- **write_fifo 地址**:V3 是 `0x10`,V2 是 `0x07`。此前 EAPOL 路径写死了 V2 常量,D80 上 M2 被写到错误 SDIO 地址。现改用 transport 的 `wr_fifo_addr()`,与其他帧路径一致。

### 2. SDIO 总线超时恢复 (sdhci-cv1800)
- 读超时后清残留 `INT_STATUS` 并复位 DAT 线。此前一次读超时会让 `DATA_INHIBIT` 一直置位,整条 SDIO 总线被焊死——后续任何数据命令的 `wait_data_idle` 持续超时,表现为"STA 会话后 AP 起不来 / 模式切回失败"。现对齐错误中断分支的恢复逻辑。
- `read_fifo`:512 对齐走 block 模式,非对齐(V3 byte-mode 收帧的 `byte_len*4`,≤512)走 byte 模式 CMD53。
- `sdio_transport.rs`:新增 V3 感知的 `bytemode_len_reg()` 辅助方法。

### 3. RX/TX 热路径日志级别整理
- **tx.rs**:#1185 中 `process_cmd_tx` / CMD header dump / `process_data_tx` / `tx_process` / `enqueue` 等为逐帧 `warn!`/`info!`,默认 info 级别下持续刷屏。本 PR 降为 `trace!`/`debug!`。AP 模式 RX 过滤器会收下周围所有 beacon,逐帧日志经 UART 输出会拖死收发线程,导致客户端 Auth/Assoc 帧来不及处理。
- **rx.rs**:本 PR 新增的逐帧诊断点(802.11 帧控制字段 / DATA ethertype / 聚合帧偏移)**直接以 `trace!` 落地**,默认 info 不打印,仅排障时开启。
- 按连接触发的事件(Auth from / AssocReq / control port)保留在 `info`。

## 测试

真机验证(LicheeRV Nano / SG2002 + AIC8800 D80):
- ✅ STA 连接 WPA2 AP(四次握手完成,此前 M2 卡死)
- ✅ STA → AP 运行时切换后,手机连入 SoftAP:Auth / Assoc / DHCP / ARP / SSH 全通
- ✅ `aic8800`、`sdhci-cv1800` crate 对 dev 顶端编译通过,`cargo fmt --check` 与 `cargo xtask clippy`(`-D warnings`)均通过

## 备注
- 顺带将编译产物 `wifi_switch` 加入 `.gitignore`(仅跟踪 `wifi_switch.c` 源码)。
