### PR TITLE
fix(ci): update ostool to 0.23.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5518,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "ostool"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8a92d73cae88dc8b23722af3df1cafa57db301f27556f004689201addc0394"
+checksum = "501bb135aae07ff4b1e4144958daa4fda1b1759dc16118f7b1acada4fa8e0c1e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,7 @@ lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = "0.12"
 atomic-waker = { version = "1.1", default-features = false }
-ostool = { version = "0.23.1" }
+ostool = { version = "0.23.2" }
 riscv = { version = "0.16.1", default-features = false }
 sbi-rt = { version = "0.0.4", default-features = false }
 uefi = "0.37.0"


### PR DESCRIPTION
## 问题

`ostool 0.23.1` 引入后，`Test starry self-hosted board orangepi-5-plus` 在匹配到 `DWC xHCI driver initialized successfully for usb@fc400000` 成功日志后，稳定失败在 serial websocket 写入阶段，表现为 `failed to write serial websocket bytes: broken pipe`。

## 修改

- 将 workspace 中的 `ostool` 依赖从 `0.23.1` 更新到 `0.23.2`。
- 同步更新 `Cargo.lock` 中 `ostool` 的版本和 checksum。

## 方案逻辑

`0.23.2` 包含上游对 U-Boot/serial websocket 退出路径的修复。本仓库侧不需要额外 API 适配，更新依赖后 `axbuild` 能够正常编译并使用新版本 `ostool`。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package axbuild`
- `cargo xtask starry test board -c boot --board orangepi-5-plus`
  - 命中 `DWC xHCI driver initialized successfully for usb@fc400000` 成功模式
  - 最终输出 `ok: boot/orangepi-5-plus`
  - 未再出现 `failed to write serial websocket bytes: broken pipe`
- `cargo xtask starry test board --board orangepi-5-plus`
  - 本地 OrangePi-5-Plus 上完整 board matrix 已通过
