### PR TITLE
feat(poll): add irq-safe deferred notifications

### DIFF
--- a/.claude/skills/cross-kernel-driver/SKILL.md
+++ b/.claude/skills/cross-kernel-driver/SKILL.md
@@ -21,7 +21,8 @@ For nontrivial driver design or refactoring, read `references/architecture.md` b
 6. Use small capability traits or API objects instead of a monolithic `KernelHal`. Split MMIO, DMA, IRQ event, queue contract, and wake/poll boundaries.
 7. Model queues as independent running units. Prefer APIs such as `submit`, `reclaim`, `poll`, `submit_request`, and `poll_request`.
 8. Make IRQ paths return stable events, normally `handle_irq() -> Event`. OS Glue decides whether to wake a thread, wake a future, schedule a worker, or set a pending flag.
-9. Validate the changed crate with formatting and targeted clippy before finishing.
+9. When IRQ and task paths share mutable driver state, look for an explicit exclusion protocol: task-side mutation masks the exact interrupt source before taking the lock, while IRQ only touches pre-registered stable state. Document the lifetime/safety contract; otherwise prefer atomics/pending bits plus a deferred worker.
+10. Validate the changed crate with formatting and targeted clippy before finishing.
 
 ## Dependency Rules
 
@@ -66,6 +67,8 @@ pub trait IQueue {
 ```
 
 IRQ handlers should identify/clear the interrupt source and extract an `Event`. They should not block, run long slow paths, or hold broad locks. Keep the principle visible during reviews: "interrupts synchronize state; tasks advance flow" (`中断只同步状态，任务才推进流程`).
+
+When a driver intentionally shares registries or queue maps between task setup and IRQ completion paths, prefer an xHCI-style exclusion protocol over taking the same spinlock in IRQ: task context masks the same device interrupter/MSI source before mutation; IRQ context does not take that lock and only touches entries whose lifetime was established before interrupts were enabled. This avoids same-lock IRQ reentry deadlocks, but it does not make allocation, blocking, arbitrary wakers, or unrelated OS callbacks safe in hard IRQ.
 
 ## Validation
 

--- a/.claude/skills/cross-kernel-driver/references/architecture.md
+++ b/.claude/skills/cross-kernel-driver/references/architecture.md
@@ -152,6 +152,32 @@ The IRQ fast path should:
 
 OS Glue converts events into wakeups, future wakers, worker scheduling, or pending polling flags.
 
+### IRQ/Task Exclusion Pattern
+
+Some drivers need IRQ completion code to consult state that is registered or
+removed by task context, such as xHCI transfer rings or queue completion slots.
+The safe shape is an explicit two-sided protocol:
+
+- Task context masks or disables the exact device interrupt source that can run
+  the IRQ path, then takes the mutation lock and updates the registry.
+- IRQ context does not take that mutation lock. It only uses a narrowly scoped
+  fast-path accessor over entries whose lifetime was established before the
+  interrupt was enabled.
+- The fast-path accessor is unsafe or otherwise documented with the required
+  exclusion/lifetime contract.
+- The shared state contains stable descriptors, queue slots, atomics, or ready
+  bits; it must not require allocation, blocking, broad OS locks, or callbacks
+  into file/device managers while in IRQ context.
+- Re-enable the interrupt source only after task-side mutation has fully
+  published the new state.
+
+This protocol prevents the classic deadlock where task context holds a spinlock,
+gets interrupted by the same device, and the IRQ handler tries to acquire the
+same lock. It is narrower than "IRQ-safe" in general: it does not make arbitrary
+wakers, heap allocation, sleeping locks, or unrelated subsystem locks safe in a
+hard IRQ. If the driver cannot prove this protocol, use atomics/pending bits and
+an OS Glue deferred worker instead.
+
 ## Queue/Runtime Pattern
 
 Model queues as independent running units. This matches network TX/RX queues, NVMe admin/IO queues, block request queues, and many accelerator command queues.
@@ -185,6 +211,10 @@ For a block queue adapter, align portable queue state with `rdif_block::IQueue`:
 - Prefer `&mut self` for externally visible operations that require exclusive access.
 - Do not make OS locks part of the portable Driver Trait.
 - Use internal locks only for short critical sections such as pending flags or small status updates.
+- If task and IRQ contexts share a lock-protected registry, require the IRQ/task
+  exclusion protocol above: mask the same interrupt source before task-side
+  mutation, keep IRQ lock-free for that registry, and document why the fast path
+  cannot race lifetime or structure changes.
 - Keep `unsafe` in callback bridges, MMIO construction, and DMA glue boundaries where possible.
 - Do slow work in task/worker/executor/polling context, not in IRQ context.
 

--- a/components/axpoll/Cargo.toml
+++ b/components/axpoll/Cargo.toml
@@ -25,7 +25,7 @@ spin = { version = "0.12", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-ax-kspin = { workspace = true, features = ["host-test"] }
+ax-kspin = { workspace = true, features = ["host-test", "smp"] }
 tokio = { version = "1.37", features = [
     "rt-multi-thread",
     "macros",

--- a/components/axpoll/src/lib.rs
+++ b/components/axpoll/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, sync::Arc, task::Wake};
+use alloc::boxed::Box;
 use core::{
     mem::MaybeUninit,
     task::{Context, Waker},
@@ -66,8 +66,19 @@ pub trait Pollable {
 
 const POLL_SET_CAPACITY: usize = 64;
 
+struct Entry {
+    waker: Waker,
+    interests: IoEvents,
+}
+
+impl Entry {
+    fn wake(self) {
+        self.waker.wake();
+    }
+}
+
 struct Inner {
-    entries: Box<[MaybeUninit<Waker>]>,
+    entries: Box<[MaybeUninit<Entry>]>,
     cursor: usize,
 }
 
@@ -87,18 +98,43 @@ impl Inner {
         self.cursor == 0
     }
 
-    fn register(&mut self, waker: &Waker) {
+    fn register(&mut self, waker: &Waker, interests: IoEvents) {
         let slot = self.cursor % POLL_SET_CAPACITY;
         if self.cursor >= POLL_SET_CAPACITY {
             let old = unsafe { self.entries[slot].assume_init_read() };
-            if !old.will_wake(waker) {
+            if !old.waker.will_wake(waker) {
                 old.wake();
             }
             self.cursor = ((slot + 1) % POLL_SET_CAPACITY) + POLL_SET_CAPACITY;
         } else {
             self.cursor += 1;
         }
-        self.entries[slot].write(waker.clone());
+        self.entries[slot].write(Entry {
+            waker: waker.clone(),
+            interests,
+        });
+    }
+
+    fn wake(&mut self, ready: IoEvents) -> usize {
+        if self.is_empty() {
+            return 0;
+        }
+
+        let mut old = Self::new();
+        core::mem::swap(&mut old, self);
+
+        let mut woke = 0;
+        for i in 0..old.len() {
+            let entry = unsafe { old.entries[i].assume_init_read() };
+            if entry.interests.intersects(ready) {
+                woke += 1;
+                entry.wake();
+            } else {
+                self.register(&entry.waker, entry.interests);
+            }
+        }
+        old.cursor = 0;
+        woke
     }
 }
 
@@ -125,36 +161,34 @@ impl PollSet {
         Self(LazyLock::new(|| SpinNoIrq::new(Inner::new())))
     }
 
-    /// Registers a waker.
-    pub fn register(&self, waker: &Waker) {
-        self.0.lock().register(waker);
+    /// Registers a waker for the requested I/O events.
+    ///
+    /// # Safety
+    ///
+    /// This method is task/deferred-context only. Callers must not invoke it
+    /// from hard IRQ, NMI, or trap callbacks, and must not hold locks that may
+    /// be re-entered by the registered waker or by poll wakeup paths.
+    pub unsafe fn register(&self, waker: &Waker, interests: IoEvents) {
+        self.0.lock().register(waker, interests);
     }
 
-    /// Wakes up all registered wakers.
-    pub fn wake(&self) -> usize {
-        let mut guard = self.0.lock();
-        if guard.is_empty() {
-            return 0;
-        }
-        let inner = core::mem::replace(&mut *guard, Inner::new());
-        drop(guard);
-        inner.len()
+    /// Wakes up registered wakers whose interests intersect `ready`.
+    ///
+    /// # Safety
+    ///
+    /// This method is task/deferred-context only. Callers must not invoke it
+    /// from hard IRQ, NMI, or trap callbacks. The readiness state represented
+    /// by `ready` must be published before this method is called, and callers
+    /// must not hold locks that may be re-entered by waker execution or poll
+    /// wakeup paths.
+    pub unsafe fn wake(&self, ready: IoEvents) -> usize {
+        self.0.lock().wake(ready)
     }
 }
 
 impl Drop for PollSet {
     fn drop(&mut self) {
         // Ensure all entries are dropped
-        self.wake();
-    }
-}
-
-impl Wake for PollSet {
-    fn wake(self: Arc<Self>) {
-        self.as_ref().wake();
-    }
-
-    fn wake_by_ref(self: &Arc<Self>) {
-        self.as_ref().wake();
+        unsafe { self.wake(IoEvents::all()) };
     }
 }

--- a/components/axpoll/src/lib.rs
+++ b/components/axpoll/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use core::{
     mem::MaybeUninit,
     task::{Context, Waker},
@@ -98,43 +98,48 @@ impl Inner {
         self.cursor == 0
     }
 
-    fn register(&mut self, waker: &Waker, interests: IoEvents) {
+    fn push_entry(&mut self, entry: Entry) {
+        debug_assert!(self.cursor < POLL_SET_CAPACITY);
+        let slot = self.cursor;
+        self.cursor += 1;
+        self.entries[slot].write(entry);
+    }
+
+    fn register(&mut self, waker: &Waker, interests: IoEvents) -> Option<Entry> {
         let slot = self.cursor % POLL_SET_CAPACITY;
-        if self.cursor >= POLL_SET_CAPACITY {
+        let replaced = if self.cursor >= POLL_SET_CAPACITY {
             let old = unsafe { self.entries[slot].assume_init_read() };
-            if !old.waker.will_wake(waker) {
-                old.wake();
-            }
+            let replaced = (!old.waker.will_wake(waker)).then_some(old);
             self.cursor = ((slot + 1) % POLL_SET_CAPACITY) + POLL_SET_CAPACITY;
+            replaced
         } else {
             self.cursor += 1;
-        }
+            None
+        };
         self.entries[slot].write(Entry {
             waker: waker.clone(),
             interests,
         });
+        replaced
     }
 
-    fn wake(&mut self, ready: IoEvents) -> usize {
+    fn drain_ready(&mut self, ready: IoEvents, ready_entries: &mut Vec<Entry>) {
         if self.is_empty() {
-            return 0;
+            return;
         }
 
         let mut old = Self::new();
         core::mem::swap(&mut old, self);
 
-        let mut woke = 0;
         for i in 0..old.len() {
             let entry = unsafe { old.entries[i].assume_init_read() };
             if entry.interests.intersects(ready) {
-                woke += 1;
-                entry.wake();
+                ready_entries.push(entry);
             } else {
-                self.register(&entry.waker, entry.interests);
+                self.push_entry(entry);
             }
         }
         old.cursor = 0;
-        woke
     }
 }
 
@@ -169,7 +174,10 @@ impl PollSet {
     /// from hard IRQ, NMI, or trap callbacks, and must not hold locks that may
     /// be re-entered by the registered waker or by poll wakeup paths.
     pub unsafe fn register(&self, waker: &Waker, interests: IoEvents) {
-        self.0.lock().register(waker, interests);
+        let replaced = { self.0.lock().register(waker, interests) };
+        if let Some(entry) = replaced {
+            entry.wake();
+        }
     }
 
     /// Wakes up registered wakers whose interests intersect `ready`.
@@ -182,7 +190,15 @@ impl PollSet {
     /// must not hold locks that may be re-entered by waker execution or poll
     /// wakeup paths.
     pub unsafe fn wake(&self, ready: IoEvents) -> usize {
-        self.0.lock().wake(ready)
+        let mut ready_entries = Vec::with_capacity(POLL_SET_CAPACITY);
+        {
+            self.0.lock().drain_ready(ready, &mut ready_entries);
+        }
+        let woke = ready_entries.len();
+        for entry in ready_entries {
+            entry.wake();
+        }
+        woke
     }
 }
 

--- a/components/axpoll/tests/async.rs
+++ b/components/axpoll/tests/async.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 use futures::future;
 use tokio::sync::Barrier;
 
@@ -24,7 +24,7 @@ impl Future for WaitFuture {
         if self.ready.load(Ordering::SeqCst) {
             Poll::Ready(())
         } else {
-            self.ps.register(cx.waker());
+            unsafe { self.ps.register(cx.waker(), IoEvents::IN) };
             Poll::Pending
         }
     }
@@ -45,7 +45,7 @@ async fn async_wake_single() {
 
     let handle = tokio::spawn(async move {
         ready.store(true, Ordering::SeqCst);
-        ps.wake();
+        unsafe { ps.wake(IoEvents::IN) };
     });
 
     f.await;
@@ -81,7 +81,7 @@ async fn async_wake_many() {
             pending.push(h);
         }
     }
-    ps.wake();
+    unsafe { ps.wake(IoEvents::IN) };
     future::try_join_all(ready).await.unwrap();
 
     for (i, f) in flags.iter().enumerate() {
@@ -89,6 +89,6 @@ async fn async_wake_many() {
             f.store(true, Ordering::SeqCst);
         }
     }
-    ps.wake();
+    unsafe { ps.wake(IoEvents::IN) };
     future::try_join_all(pending).await.unwrap();
 }

--- a/components/axpoll/tests/tests.rs
+++ b/components/axpoll/tests/tests.rs
@@ -2,9 +2,11 @@ use std::{
     sync::{
         Arc, Barrier,
         atomic::{AtomicUsize, Ordering},
+        mpsc,
     },
     task::{Context, Wake, Waker},
     thread,
+    time::Duration,
 };
 
 use axpoll::{IoEvents, PollSet};
@@ -35,6 +37,41 @@ impl Wake for Counter {
     }
 }
 
+struct ReentrantRegister {
+    poll: Arc<PollSet>,
+    interests: IoEvents,
+    started: mpsc::Sender<()>,
+    done: mpsc::Sender<()>,
+}
+
+impl ReentrantRegister {
+    fn run(&self) {
+        let _ = self.started.send(());
+        let counter = Counter::new();
+        let waker = Waker::from(counter);
+        unsafe { self.poll.register(&waker, self.interests) };
+        let _ = self.done.send(());
+    }
+}
+
+impl Wake for ReentrantRegister {
+    fn wake(self: Arc<Self>) {
+        self.run();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.run();
+    }
+}
+
+fn assert_reentrant_wake_completed(started: mpsc::Receiver<()>, done: mpsc::Receiver<()>) {
+    started
+        .recv_timeout(Duration::from_secs(1))
+        .expect("reentrant waker was not invoked");
+    done.recv_timeout(Duration::from_secs(1))
+        .expect("reentrant waker could not register back into the same PollSet");
+}
+
 #[test]
 fn register_and_wake() {
     let ps = PollSet::new();
@@ -43,6 +80,57 @@ fn register_and_wake() {
     unsafe { ps.register(&w, IoEvents::IN) };
     assert_eq!(unsafe { ps.wake(IoEvents::IN) }, 1);
     assert_eq!(counter.count(), 1);
+}
+
+#[test]
+fn wake_runs_wakers_after_releasing_pollset_lock() {
+    let ps = Arc::new(PollSet::new());
+    let (started_tx, started_rx) = mpsc::channel();
+    let (done_tx, done_rx) = mpsc::channel();
+    let reentrant = Arc::new(ReentrantRegister {
+        poll: ps.clone(),
+        interests: IoEvents::OUT,
+        started: started_tx,
+        done: done_tx,
+    });
+    let waker = Waker::from(reentrant);
+    unsafe { ps.register(&waker, IoEvents::IN) };
+
+    let wake_ps = ps.clone();
+    let wake_thread = thread::spawn(move || unsafe { wake_ps.wake(IoEvents::IN) });
+
+    assert_reentrant_wake_completed(started_rx, done_rx);
+    assert_eq!(wake_thread.join().unwrap(), 1);
+    assert_eq!(unsafe { ps.wake(IoEvents::OUT) }, 1);
+}
+
+#[test]
+fn register_overwrite_wakes_after_releasing_pollset_lock() {
+    let ps = Arc::new(PollSet::new());
+    let (started_tx, started_rx) = mpsc::channel();
+    let (done_tx, done_rx) = mpsc::channel();
+    let reentrant = Arc::new(ReentrantRegister {
+        poll: ps.clone(),
+        interests: IoEvents::OUT,
+        started: started_tx,
+        done: done_tx,
+    });
+    let reentrant_waker = Waker::from(reentrant);
+    unsafe { ps.register(&reentrant_waker, IoEvents::IN) };
+    for _ in 1..64 {
+        let waker = Waker::from(Counter::new());
+        unsafe { ps.register(&waker, IoEvents::IN) };
+    }
+
+    let register_ps = ps.clone();
+    let register_thread = thread::spawn(move || {
+        let waker = Waker::from(Counter::new());
+        unsafe { register_ps.register(&waker, IoEvents::IN) };
+    });
+
+    assert_reentrant_wake_completed(started_rx, done_rx);
+    register_thread.join().unwrap();
+    assert_eq!(unsafe { ps.wake(IoEvents::OUT) }, 1);
 }
 
 #[test]

--- a/components/axpoll/tests/tests.rs
+++ b/components/axpoll/tests/tests.rs
@@ -1,12 +1,13 @@
 use std::{
     sync::{
-        Arc,
+        Arc, Barrier,
         atomic::{AtomicUsize, Ordering},
     },
     task::{Context, Wake, Waker},
+    thread,
 };
 
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 
 struct Counter(AtomicUsize);
 
@@ -39,15 +40,135 @@ fn register_and_wake() {
     let ps = PollSet::new();
     let counter = Counter::new();
     let w = Waker::from(counter.clone());
-    ps.register(&w);
-    assert_eq!(ps.wake(), 1);
+    unsafe { ps.register(&w, IoEvents::IN) };
+    assert_eq!(unsafe { ps.wake(IoEvents::IN) }, 1);
     assert_eq!(counter.count(), 1);
 }
 
 #[test]
 fn empty_return() {
     let ps = PollSet::new();
-    assert_eq!(ps.wake(), 0);
+    assert_eq!(unsafe { ps.wake(IoEvents::IN) }, 0);
+}
+
+#[test]
+fn wake_only_matching_interests() {
+    let ps = PollSet::new();
+    let read_counter = Counter::new();
+    let write_counter = Counter::new();
+    let read_waker = Waker::from(read_counter.clone());
+    let write_waker = Waker::from(write_counter.clone());
+
+    unsafe {
+        ps.register(&read_waker, IoEvents::IN);
+        ps.register(&write_waker, IoEvents::OUT);
+    }
+
+    assert_eq!(unsafe { ps.wake(IoEvents::IN) }, 1);
+    assert_eq!(read_counter.count(), 1);
+    assert_eq!(write_counter.count(), 0);
+    assert_eq!(unsafe { ps.wake(IoEvents::OUT) }, 1);
+    assert_eq!(write_counter.count(), 1);
+}
+
+#[test]
+fn concurrent_registers_preserve_interests() {
+    const NUM_WAITERS: usize = 64;
+
+    let ps = Arc::new(PollSet::new());
+    let barrier = Arc::new(Barrier::new(NUM_WAITERS));
+    let counters = (0..NUM_WAITERS).map(|_| Counter::new()).collect::<Vec<_>>();
+    let mut handles = Vec::with_capacity(NUM_WAITERS);
+
+    for (i, counter) in counters.iter().cloned().enumerate() {
+        let ps = ps.clone();
+        let barrier = barrier.clone();
+        handles.push(thread::spawn(move || {
+            let waker = Waker::from(counter);
+            let interests = if i % 2 == 0 {
+                IoEvents::IN
+            } else {
+                IoEvents::OUT
+            };
+            barrier.wait();
+            unsafe { ps.register(&waker, interests) };
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    assert_eq!(unsafe { ps.wake(IoEvents::IN) }, NUM_WAITERS / 2);
+    assert_eq!(
+        counters
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| i % 2 == 0)
+            .map(|(_, counter)| counter.count())
+            .sum::<usize>(),
+        NUM_WAITERS / 2
+    );
+    assert_eq!(
+        counters
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| i % 2 != 0)
+            .map(|(_, counter)| counter.count())
+            .sum::<usize>(),
+        0
+    );
+
+    assert_eq!(unsafe { ps.wake(IoEvents::OUT) }, NUM_WAITERS / 2);
+    assert_eq!(
+        counters
+            .iter()
+            .map(|counter| counter.count())
+            .sum::<usize>(),
+        NUM_WAITERS
+    );
+}
+
+#[test]
+fn concurrent_deferred_wakes_partition_by_mask() {
+    const NUM_WAITERS: usize = 64;
+
+    let ps = Arc::new(PollSet::new());
+    let counters = (0..NUM_WAITERS).map(|_| Counter::new()).collect::<Vec<_>>();
+
+    for (i, counter) in counters.iter().cloned().enumerate() {
+        let waker = Waker::from(counter);
+        let interests = if i % 2 == 0 {
+            IoEvents::IN
+        } else {
+            IoEvents::OUT
+        };
+        unsafe { ps.register(&waker, interests) };
+    }
+
+    let barrier = Arc::new(Barrier::new(2));
+    let read_waker = {
+        let ps = ps.clone();
+        let barrier = barrier.clone();
+        thread::spawn(move || {
+            barrier.wait();
+            unsafe { ps.wake(IoEvents::IN) }
+        })
+    };
+    let write_waker = {
+        let ps = ps.clone();
+        thread::spawn(move || {
+            barrier.wait();
+            unsafe { ps.wake(IoEvents::OUT) }
+        })
+    };
+
+    assert_eq!(
+        read_waker.join().unwrap() + write_waker.join().unwrap(),
+        NUM_WAITERS
+    );
+    assert!(counters.iter().all(|counter| counter.count() == 1));
+    assert_eq!(unsafe { ps.wake(IoEvents::IN | IoEvents::OUT) }, 0);
 }
 
 #[test]
@@ -57,9 +178,9 @@ fn full_capacity() {
     for _ in 0..64 {
         let w = Waker::from(counter.clone());
         let cx = Context::from_waker(&w);
-        ps.register(cx.waker());
+        unsafe { ps.register(cx.waker(), IoEvents::IN) };
     }
-    let woke = ps.wake();
+    let woke = unsafe { ps.wake(IoEvents::IN) };
     assert_eq!(woke, 64);
     assert_eq!(counter.count(), 64);
 }
@@ -71,9 +192,9 @@ fn overwrite() {
     for c in &counters {
         let w = Waker::from(c.clone());
         let cx = Context::from_waker(&w);
-        ps.register(cx.waker());
+        unsafe { ps.register(cx.waker(), IoEvents::IN) };
     }
-    assert_eq!(ps.wake(), 64);
+    assert_eq!(unsafe { ps.wake(IoEvents::IN) }, 64);
     let total: usize = counters.iter().map(|c| c.count()).sum();
     assert_eq!(total, 65);
 }
@@ -85,7 +206,7 @@ fn drop_wakes() {
     for _ in 0..10 {
         let w = Waker::from(counters.clone());
         let cx = Context::from_waker(&w);
-        ps.register(cx.waker());
+        unsafe { ps.register(cx.waker(), IoEvents::IN) };
     }
     drop(ps);
     assert_eq!(counters.count(), 10);

--- a/drivers/net/rd-net/src/lib.rs
+++ b/drivers/net/rd-net/src/lib.rs
@@ -255,9 +255,24 @@ impl IrqHandler {
         iface.disable_irq();
     }
 
-    pub fn handle(&self) {
+    /// Handles a device interrupt and returns queue events without waking task
+    /// wakers.
+    ///
+    /// This is the IRQ top-half entry: it only asks the portable driver to
+    /// identify/acknowledge the interrupt source and publish queue event bits.
+    /// Runtime queue wakers must be invoked later from task/deferred context
+    /// through [`handle`](Self::handle).
+    pub fn handle_irq(&self) -> rdif_eth::Event {
         let iface = unsafe { &mut **self.inner.interface.get() };
-        let event = iface.handle_irq();
+        iface.handle_irq()
+    }
+
+    /// Handles a device interrupt and wakes registered queue waiters.
+    ///
+    /// Use this only from task/deferred context. Hard IRQ callbacks should call
+    /// [`handle_irq`](Self::handle_irq) and defer waker execution.
+    pub fn handle(&self) {
+        let event = self.handle_irq();
         for id in event.tx_queue.iter() {
             self.inner.tx_wakers.wake(id);
         }
@@ -476,5 +491,181 @@ impl Drop for RxPacket<'_> {
         if let Some(buff) = self.buff.take() {
             let _ = self.queue.submit_buffer(buff);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, sync::Arc};
+    use core::{
+        any::Any,
+        num::NonZeroUsize,
+        ptr::NonNull,
+        sync::atomic::{AtomicUsize, Ordering},
+        task::{RawWaker, RawWakerVTable, Waker},
+    };
+
+    use dma_api::{DmaAllocHandle, DmaConstraints, DmaDirection, DmaError, DmaMapHandle};
+    use rdif_eth::{DriverGeneric, Event, IRxQueue, ITxQueue, IdList, Interface};
+
+    use super::*;
+
+    struct TestDma;
+
+    impl dma_api::DmaOp for TestDma {
+        fn page_size(&self) -> usize {
+            4096
+        }
+
+        unsafe fn alloc_contiguous(
+            &self,
+            _constraints: DmaConstraints,
+            _layout: core::alloc::Layout,
+        ) -> Option<DmaAllocHandle> {
+            panic!("test should not allocate contiguous DMA")
+        }
+
+        unsafe fn dealloc_contiguous(&self, _handle: DmaAllocHandle) {
+            panic!("test should not deallocate contiguous DMA")
+        }
+
+        unsafe fn alloc_coherent(
+            &self,
+            _constraints: DmaConstraints,
+            _layout: core::alloc::Layout,
+        ) -> Option<DmaAllocHandle> {
+            panic!("test should not allocate coherent DMA")
+        }
+
+        unsafe fn dealloc_coherent(&self, _handle: DmaAllocHandle) {
+            panic!("test should not deallocate coherent DMA")
+        }
+
+        unsafe fn map_streaming(
+            &self,
+            _constraints: DmaConstraints,
+            _addr: NonNull<u8>,
+            _size: NonZeroUsize,
+            _direction: DmaDirection,
+        ) -> Result<DmaMapHandle, DmaError> {
+            panic!("test should not map streaming DMA")
+        }
+
+        unsafe fn unmap_streaming(&self, _handle: DmaMapHandle) {
+            panic!("test should not unmap streaming DMA")
+        }
+    }
+
+    struct TestInterface {
+        irq_events: Event,
+        handle_calls: Arc<AtomicUsize>,
+    }
+
+    impl DriverGeneric for TestInterface {
+        fn name(&self) -> &str {
+            "test-net"
+        }
+
+        fn raw_any(&self) -> Option<&dyn Any> {
+            Some(self)
+        }
+
+        fn raw_any_mut(&mut self) -> Option<&mut dyn Any> {
+            Some(self)
+        }
+    }
+
+    impl Interface for TestInterface {
+        fn mac_address(&self) -> [u8; 6] {
+            [0x02, 0, 0, 0, 0, 1]
+        }
+
+        fn create_tx_queue(&mut self) -> Option<Box<dyn ITxQueue>> {
+            panic!("test should not create TX queue")
+        }
+
+        fn create_rx_queue(&mut self) -> Option<Box<dyn IRxQueue>> {
+            panic!("test should not create RX queue")
+        }
+
+        fn enable_irq(&mut self) {}
+
+        fn disable_irq(&mut self) {}
+
+        fn is_irq_enabled(&self) -> bool {
+            false
+        }
+
+        fn handle_irq(&mut self) -> Event {
+            self.handle_calls.fetch_add(1, Ordering::AcqRel);
+            self.irq_events
+        }
+    }
+
+    fn count_waker(counter: Arc<AtomicUsize>) -> Waker {
+        unsafe fn clone(data: *const ()) -> RawWaker {
+            let counter = unsafe { Arc::<AtomicUsize>::from_raw(data.cast()) };
+            let cloned = Arc::clone(&counter);
+            let _ = Arc::into_raw(counter);
+            RawWaker::new(Arc::into_raw(cloned).cast(), &VTABLE)
+        }
+
+        unsafe fn wake(data: *const ()) {
+            let counter = unsafe { Arc::<AtomicUsize>::from_raw(data.cast()) };
+            counter.fetch_add(1, Ordering::AcqRel);
+        }
+
+        unsafe fn wake_by_ref(data: *const ()) {
+            let counter = unsafe { Arc::<AtomicUsize>::from_raw(data.cast()) };
+            counter.fetch_add(1, Ordering::AcqRel);
+            let _ = Arc::into_raw(counter);
+        }
+
+        unsafe fn drop(data: *const ()) {
+            let _ = unsafe { Arc::<AtomicUsize>::from_raw(data.cast()) };
+        }
+
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+        let raw = RawWaker::new(Arc::into_raw(counter).cast(), &VTABLE);
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    #[test]
+    fn irq_handler_fast_path_returns_events_without_waking_registered_wakers() {
+        static DMA: TestDma = TestDma;
+        let mut rx = IdList::none();
+        rx.insert(3);
+        let mut tx = IdList::none();
+        tx.insert(5);
+        let handle_calls = Arc::new(AtomicUsize::new(0));
+        let net = Net::new(
+            TestInterface {
+                irq_events: Event {
+                    tx_queue: tx,
+                    rx_queue: rx,
+                },
+                handle_calls: Arc::clone(&handle_calls),
+            },
+            &DMA,
+        );
+        let rx_wake_count = Arc::new(AtomicUsize::new(0));
+        let tx_wake_count = Arc::new(AtomicUsize::new(0));
+        net.inner
+            .rx_wakers
+            .register(3)
+            .register(&count_waker(Arc::clone(&rx_wake_count)));
+        net.inner
+            .tx_wakers
+            .register(5)
+            .register(&count_waker(Arc::clone(&tx_wake_count)));
+
+        let irq = net.irq_handler();
+        let events = irq.handle_irq();
+
+        assert!(events.rx_queue.contains(3));
+        assert!(events.tx_queue.contains(5));
+        assert_eq!(handle_calls.load(Ordering::Acquire), 1);
+        assert_eq!(rx_wake_count.load(Ordering::Acquire), 0);
+        assert_eq!(tx_wake_count.load(Ordering::Acquire), 0);
     }
 }

--- a/net/ax-net/src/device/driver.rs
+++ b/net/ax-net/src/device/driver.rs
@@ -289,19 +289,13 @@ impl EthernetDriver for RdNetDriver {
             return NetIrqEvents::SPURIOUS;
         };
 
-        handler.handle();
-
+        let event = handler.handle_irq();
         let mut events = NetIrqEvents::empty();
-        let mut state = self.state.lock();
-        if let Err(err) = self.prefetch_rx_packets(&mut state, RX_PREFETCH_TARGET) {
-            warn!(
-                "failed to prefetch rx packets for {} during irq: {err:?}",
-                self.name
-            );
-            events |= NetIrqEvents::RX_ERROR;
-        }
-        if !state.pending_rx.is_empty() {
+        if event.rx_queue.iter().next().is_some() {
             events |= NetIrqEvents::RX_READY;
+        }
+        if event.tx_queue.iter().next().is_some() {
+            events |= NetIrqEvents::TX_DONE;
         }
 
         if events.is_empty() {

--- a/net/ax-net/src/device/ethernet.rs
+++ b/net/ax-net/src/device/ethernet.rs
@@ -21,10 +21,10 @@
 //! the router before Ethernet sees the packet.
 
 use alloc::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
-use core::{ptr::NonNull, task::Waker};
+use core::ptr::NonNull;
 
 use ax_sync::spin::SpinNoIrq;
-use axpoll::{IoEvents, PollSet};
+use axpoll::PollSet;
 use hashbrown::HashMap;
 use smoltcp::{
     storage::{PacketBuffer, PacketMetadata},
@@ -124,13 +124,12 @@ struct EthernetIrqState {
     irq: Option<usize>,
     irq_registration: spin::Once<Box<dyn EthernetIrqRegistration>>,
     /// RX readiness is delivered out-of-band (outside the ethernet IRQ
-    /// framework) via [`Device::wake_rx`] — e.g. an SDIO Wi-Fi chip that owns
-    /// its own card interrupt and pokes the stack through `notify_oob_rx`. Such
-    /// a device has no `irq_registration`, so it still needs `register_waker` to
-    /// arm `poll_ready`.
+    /// framework) via the device readiness poll set, e.g. an SDIO Wi-Fi chip
+    /// that owns its own card interrupt and pokes the stack through
+    /// `notify_oob_rx`.
     oob_rx: bool,
     driver: SpinNoIrq<Box<dyn EthernetDriver>>,
-    poll_ready: PollSet,
+    poll_ready: Arc<PollSet>,
 }
 
 impl EthernetIrqState {
@@ -194,7 +193,7 @@ impl EthernetDevice {
             irq_registration: spin::Once::new(),
             oob_rx,
             driver: SpinNoIrq::new(inner),
-            poll_ready: PollSet::new(),
+            poll_ready: Arc::new(PollSet::new()),
         });
         let pending_packets = PacketBuffer::new(
             vec![PacketMetadata::EMPTY; ETHERNET_MAX_PENDING_PACKETS],
@@ -619,28 +618,14 @@ impl Device for EthernetDevice {
             .collect()
     }
 
-    fn wake_rx(&self) {
-        // Device readiness has been published by the net poll task.
-        unsafe {
-            self.inner
-                .poll_ready
-                .wake(IoEvents::IN | IoEvents::OUT | IoEvents::ERR)
-        };
-    }
-
-    fn register_waker(&self, waker: &Waker) {
-        // Arm the poll waker only when there is a wake source: either an IRQ
-        // registration drives `poll_ready` from `handle_ethernet_irq`, or the
-        // device delivers RX out-of-band (e.g. SDIO Wi-Fi) and pokes it via
-        // `wake_rx`. A pure-polling device with neither must not register here,
-        // or its waker would sit on a `poll_ready` that is never woken.
+    fn readiness_poll(&self) -> Option<Arc<PollSet>> {
+        // Only expose the poll set when there is a wake source: either an IRQ
+        // registration or out-of-band RX. A pure-polling device with neither
+        // must not register here, or its waker would never be woken.
         if self.inner.irq_registration.get().is_some() || self.inner.oob_rx {
-            // The net stack registers from task/deferred polling context.
-            unsafe {
-                self.inner
-                    .poll_ready
-                    .register(waker, IoEvents::IN | IoEvents::OUT | IoEvents::ERR)
-            };
+            Some(self.inner.poll_ready.clone())
+        } else {
+            None
         }
     }
 }

--- a/net/ax-net/src/device/ethernet.rs
+++ b/net/ax-net/src/device/ethernet.rs
@@ -24,7 +24,7 @@ use alloc::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
 use core::{ptr::NonNull, task::Waker};
 
 use ax_sync::spin::SpinNoIrq;
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 use hashbrown::HashMap;
 use smoltcp::{
     storage::{PacketBuffer, PacketMetadata},
@@ -153,7 +153,7 @@ unsafe fn handle_ethernet_irq(data: NonNull<()>) -> EthernetIrqOutcome {
     let state = unsafe { data.cast::<EthernetIrqState>().as_ref() };
     let events = state.handle_irq();
     if events.intersects(NetIrqEvents::RX_READY | NetIrqEvents::RX_ERROR | NetIrqEvents::TX_DONE) {
-        state.poll_ready.wake();
+        crate::wake_net_task_irq();
         return EthernetIrqOutcome::Wake;
     }
     EthernetIrqOutcome::Handled
@@ -620,7 +620,12 @@ impl Device for EthernetDevice {
     }
 
     fn wake_rx(&self) {
-        self.inner.poll_ready.wake();
+        // Device readiness has been published by the net poll task.
+        unsafe {
+            self.inner
+                .poll_ready
+                .wake(IoEvents::IN | IoEvents::OUT | IoEvents::ERR)
+        };
     }
 
     fn register_waker(&self, waker: &Waker) {
@@ -630,7 +635,12 @@ impl Device for EthernetDevice {
         // `wake_rx`. A pure-polling device with neither must not register here,
         // or its waker would sit on a `poll_ready` that is never woken.
         if self.inner.irq_registration.get().is_some() || self.inner.oob_rx {
-            self.inner.poll_ready.register(waker);
+            // The net stack registers from task/deferred polling context.
+            unsafe {
+                self.inner
+                    .poll_ready
+                    .register(waker, IoEvents::IN | IoEvents::OUT | IoEvents::ERR)
+            };
         }
     }
 }

--- a/net/ax-net/src/device/loopback.rs
+++ b/net/ax-net/src/device/loopback.rs
@@ -10,8 +10,6 @@
 //! buffer into the smoltcp-facing RX buffer. That avoids an extra queue hop and
 //! avoids spawning RX/TX workers for a device that has no hardware latency.
 
-use core::task::Waker;
-
 use smoltcp::{time::Instant, wire::IpAddress};
 
 use crate::{config::InterfaceId, device::Device};
@@ -48,9 +46,5 @@ impl Device for LoopbackDevice {
     fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> bool {
         // Fast path: loopback packets are injected directly in Router::dispatch().
         true
-    }
-
-    fn register_waker(&self, _waker: &Waker) {
-        // No async operations needed for loopback fast path
     }
 }

--- a/net/ax-net/src/device/mod.rs
+++ b/net/ax-net/src/device/mod.rs
@@ -15,12 +15,12 @@
 //! # Readiness
 //!
 //! A device may use platform IRQs, polling, or out-of-band notifications. The
-//! router only requires that `register_waker()` and `wake_rx()` make blocked
-//! device workers observable without exposing driver-specific details.
+//! router asks devices for a readiness poll set and performs `PollSet`
+//! register/wake operations after releasing the concrete device lock.
 
-use alloc::{string::String, vec::Vec};
-use core::task::Waker;
+use alloc::{string::String, sync::Arc, vec::Vec};
 
+use axpoll::PollSet;
 use smoltcp::{
     storage::PacketBuffer,
     time::Instant,
@@ -86,13 +86,12 @@ pub trait Device: Send + Sync {
         Vec::new()
     }
 
-    /// Wakes any task blocked on this device's RX readiness.
+    /// Returns the device readiness poll set when the device has a wake source.
     ///
-    /// Used by SDIO WiFi where RX arrives out-of-band (the SDIO CARD_INT
-    /// thread is outside the ethernet IRQ framework), so the poll task pokes
-    /// the device after `notify_oob_rx`. Default is a no-op.
-    fn wake_rx(&self) {}
-
-    /// Registers a waker for RX readiness notifications.
-    fn register_waker(&self, waker: &Waker);
+    /// Interrupt-driven and out-of-band devices return a poll set. Pure-polling
+    /// devices should return `None`, or their wakers would sit on a poll set
+    /// that is never woken.
+    fn readiness_poll(&self) -> Option<Arc<PollSet>> {
+        None
+    }
 }

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -76,6 +76,7 @@ use core::{
 use ax_errno::{AxError, AxResult, ax_err_type};
 use ax_sync::Mutex;
 use ax_task::{IrqNotify, WaitQueue};
+use axpoll::{IoEvents, PollSet};
 use smoltcp::{
     socket::dns::{self, GetQueryResultError, StartQueryError},
     wire::{DnsQueryType, EthernetAddress, IpAddress, Ipv4Address, Ipv4Cidr},
@@ -119,6 +120,10 @@ static NET_POLL_REQUESTED: AtomicBool = AtomicBool::new(false);
 static NET_POLL_WAKE: WaitQueue = WaitQueue::new();
 static NET_POLL_DEVICE_WAKER: LazyLock<Waker> =
     LazyLock::new(|| Waker::from(Arc::new(NetPollWake)));
+type DeferredPollWake = (Arc<PollSet>, IoEvents);
+static DEFERRED_POLL_WAKE_PENDING: AtomicBool = AtomicBool::new(false);
+static DEFERRED_POLL_WAKES: LazyLock<Mutex<Vec<DeferredPollWake>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
 
 /// Registry of wireless control-plane handles, keyed by interface name.
 ///
@@ -443,6 +448,30 @@ pub fn request_poll() {
     NET_POLL_WAKE.notify_one(true);
 }
 
+pub(crate) fn defer_poll_wake(poll: Arc<PollSet>, ready: IoEvents) {
+    DEFERRED_POLL_WAKES.lock().push((poll, ready));
+    DEFERRED_POLL_WAKE_PENDING.store(true, Ordering::Release);
+    NET_POLL_WAKE.notify_one(true);
+}
+
+fn drain_deferred_poll_wakes() {
+    loop {
+        let wakes = {
+            let mut wakes = DEFERRED_POLL_WAKES.lock();
+            if wakes.is_empty() {
+                DEFERRED_POLL_WAKE_PENDING.store(false, Ordering::Release);
+                return;
+            }
+            core::mem::take(&mut *wakes)
+        };
+        for (poll, ready) in wakes {
+            // Readiness was published before the wake was deferred, and no
+            // service/socket/device locks are held while draining.
+            unsafe { poll.wake(ready) };
+        }
+    }
+}
+
 /// Returns ARP/neighbor entries collected from all devices.
 pub fn arp_entries() -> Vec<ArpEntry> {
     get_service().arp_entries()
@@ -685,7 +714,9 @@ fn net_poll_worker() {
     loop {
         let delay = next_poll_delay();
         let timed_out = NET_POLL_WAKE.wait_timeout_until(delay, || {
-            NET_POLL_REQUESTED.load(Ordering::Acquire) || NET_IRQ_NOTIFY.is_pending()
+            NET_POLL_REQUESTED.load(Ordering::Acquire)
+                || NET_IRQ_NOTIFY.is_pending()
+                || DEFERRED_POLL_WAKE_PENDING.load(Ordering::Acquire)
         });
         if !timed_out && NET_POLL_REQUESTED.load(Ordering::Acquire) {
             NET_POLL_REQUESTED.store(false, Ordering::Release);
@@ -693,7 +724,9 @@ fn net_poll_worker() {
         if NET_IRQ_NOTIFY.drain() {
             get_service().wake_all_devices();
         }
+        drain_deferred_poll_wakes();
         poll_until_idle();
+        drain_deferred_poll_wakes();
     }
 }
 

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -67,17 +67,15 @@ use alloc::{
     borrow::ToOwned, boxed::Box, format, string::String, sync::Arc, task::Wake, vec, vec::Vec,
 };
 use core::{
-    future::poll_fn,
     net::IpAddr,
     sync::atomic::{AtomicBool, Ordering},
-    task::{Poll, Waker},
+    task::Waker,
     time::Duration,
 };
 
 use ax_errno::{AxError, AxResult, ax_err_type};
 use ax_sync::Mutex;
-use ax_task::{WaitQueue, future::block_on};
-use axpoll::PollSet;
+use ax_task::{IrqNotify, WaitQueue};
 use smoltcp::{
     socket::dns::{self, GetQueryResultError, StartQueryError},
     wire::{DnsQueryType, EthernetAddress, IpAddress, Ipv4Address, Ipv4Cidr},
@@ -131,10 +129,7 @@ static NET_POLL_DEVICE_WAKER: LazyLock<Waker> =
 static WIFI_CONTROLS: LazyLock<Mutex<Vec<(alloc::string::String, rd_net::WifiControlHandle)>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 
-/// Signalled by [`notify_oob_rx`] to wake the out-of-band RX poll task, for
-/// devices whose RX arrives outside the ethernet IRQ framework (e.g. SDIO).
-static OOB_RX_SIGNAL: PollSet = PollSet::new();
-static OOB_POLL_TASK_STARTED: AtomicBool = AtomicBool::new(false);
+static NET_IRQ_NOTIFY: IrqNotify = IrqNotify::new();
 
 const DHCP_BOOTSTRAP_ATTEMPTS: usize = 200;
 const DHCP_BOOTSTRAP_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -503,6 +498,9 @@ pub fn register_device_with_config(dev: Box<dyn EthernetDriver>, config: NetConf
     let mac = EthernetAddress(dev.mac_address());
     let server_ip = Ipv4Address::new(config.ip[0], config.ip[1], config.ip[2], config.ip[3]);
     let cidr = Ipv4Cidr::new(server_ip, config.prefix_len);
+    // A dedicated-poll device gets RX out-of-band (via `notify_oob_rx` and the
+    // shared net poll task), so its socket wakers must be armed even though it
+    // has no ethernet IRQ registration.
     let eth_dev = if config.dedicated_poll {
         EthernetDevice::new_oob_rx(config.name.clone(), dev, Some(cidr))
     } else {
@@ -519,12 +517,9 @@ pub fn register_device_with_config(dev: Box<dyn EthernetDriver>, config: NetConf
         );
     }
 
-    if config.dedicated_poll
-        && OOB_POLL_TASK_STARTED
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-    {
-        start_oob_poll_task(config.name);
+    info!("{}: up, mac {mac}, ip {cidr}", config.name);
+    if config.dedicated_poll {
+        get_service().register_device_waker(&NET_POLL_DEVICE_WAKER);
     }
     request_poll();
 }
@@ -621,6 +616,16 @@ pub fn reconfigure_wifi(name: &str, mode: WifiMode<'_>) -> AxResult<()> {
     Ok(())
 }
 
+/// Wakes the net poll task from a hard IRQ callback.
+///
+/// The IRQ path must only publish small pending state and call this wrapper.
+/// The deferred net task performs `poll_interfaces()` and wakes socket waiters
+/// from ordinary task context.
+pub fn wake_net_task_irq() {
+    NET_IRQ_NOTIFY.notify_irq();
+    NET_POLL_WAKE.notify_one_from_irq();
+}
+
 /// Wakes the out-of-band RX poll task; intended as a device RX-data callback.
 ///
 /// A device whose RX path sits outside the ethernet IRQ framework (e.g. an SDIO
@@ -628,7 +633,7 @@ pub fn reconfigure_wifi(name: &str, mode: WifiMode<'_>) -> AxResult<()> {
 /// only signals here; the dedicated poll task does the actual stack polling, so
 /// the device's RX thread is never blocked on the stack.
 pub fn notify_oob_rx() {
-    OOB_RX_SIGNAL.wake();
+    wake_net_task_irq();
 }
 
 /// Convenience helper for retrieving `eth0` IPv4 configuration.
@@ -637,28 +642,12 @@ pub fn eth0_ipv4_config() -> Option<Ipv4InterfaceConfig> {
 }
 
 fn prefix_to_mask(prefix_len: u8) -> Ipv4Address {
-    let mask = if prefix_len == 0 {
+    let bits = if prefix_len == 0 {
         0
     } else {
-        u32::MAX << (32 - prefix_len)
+        u32::MAX << (32 - prefix_len.min(32) as u32)
     };
-    Ipv4Address::from_bits(mask)
-}
-
-fn start_oob_poll_task(ifname: String) {
-    let task_name = format!("{ifname}-oob-poll");
-    ax_task::spawn_with_name(
-        move || {
-            info!("start OOB network poll task for {ifname}");
-            block_on(poll_fn(|cx| {
-                OOB_RX_SIGNAL.register(cx.waker());
-                poll_interfaces();
-                get_service().wake_all_devices();
-                Poll::<()>::Pending
-            }));
-        },
-        task_name,
-    );
+    Ipv4Address::from_bits(bits)
 }
 
 fn next_poll_delay() -> Duration {
@@ -696,9 +685,14 @@ fn net_poll_worker() {
     loop {
         let delay = next_poll_delay();
         let timed_out =
-            NET_POLL_WAKE.wait_timeout_until(delay, || NET_POLL_REQUESTED.load(Ordering::Acquire));
-        if !timed_out {
+            NET_POLL_WAKE.wait_timeout_until(delay, || {
+                NET_POLL_REQUESTED.load(Ordering::Acquire) || NET_IRQ_NOTIFY.is_pending()
+            });
+        if !timed_out && NET_POLL_REQUESTED.load(Ordering::Acquire) {
             NET_POLL_REQUESTED.store(false, Ordering::Release);
+        }
+        if NET_IRQ_NOTIFY.drain() {
+            get_service().wake_all_devices();
         }
         poll_until_idle();
     }

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -684,10 +684,9 @@ impl Wake for NetPollWake {
 fn net_poll_worker() {
     loop {
         let delay = next_poll_delay();
-        let timed_out =
-            NET_POLL_WAKE.wait_timeout_until(delay, || {
-                NET_POLL_REQUESTED.load(Ordering::Acquire) || NET_IRQ_NOTIFY.is_pending()
-            });
+        let timed_out = NET_POLL_WAKE.wait_timeout_until(delay, || {
+            NET_POLL_REQUESTED.load(Ordering::Acquire) || NET_IRQ_NOTIFY.is_pending()
+        });
         if !timed_out && NET_POLL_REQUESTED.load(Ordering::Acquire) {
             NET_POLL_REQUESTED.store(false, Ordering::Release);
         }

--- a/net/ax-net/src/listen_table.rs
+++ b/net/ax-net/src/listen_table.rs
@@ -82,8 +82,9 @@ impl Wake for AcceptWake {
 
     fn wake_by_ref(self: &Arc<Self>) {
         // smoltcp invokes this from the net poll task context after publishing
-        // child socket readiness.
-        unsafe { self.poll.wake(IoEvents::IN) };
+        // child socket readiness. Defer the actual PollSet wake until the net
+        // worker has released service/socket locks.
+        crate::defer_poll_wake(self.poll.clone(), IoEvents::IN);
     }
 }
 
@@ -257,29 +258,40 @@ impl ListenTable {
         Err(AxError::WouldBlock)
     }
 
-    /// Registers a waker for listener readiness and queued child progress.
-    pub fn register_accept_waker(
+    /// Returns the listener readiness poll set for lock-free registration.
+    pub fn accept_poll(&self, listen_endpoint: IpListenEndpoint) -> Option<Arc<PollSet>> {
+        let entries = self.listen_entry(listen_endpoint.port);
+        let table = entries.lock();
+        table
+            .iter()
+            .find(|entry| entry.listen_endpoint == listen_endpoint)
+            .map(|entry| entry.accept_poll.clone())
+    }
+
+    /// Builds the smoltcp child-progress waker for a listener poll set.
+    pub fn accept_waker(&self, accept_poll: Arc<PollSet>) -> Waker {
+        Waker::from(Arc::new(AcceptWake { poll: accept_poll }))
+    }
+
+    /// Registers a waker for queued child progress.
+    pub fn register_pending_accept_wakers(
         &self,
         listen_endpoint: IpListenEndpoint,
         sockets: &mut SocketSet<'_>,
+        accept_poll: &Arc<PollSet>,
         waker: &Waker,
     ) {
         let entries = self.listen_entry(listen_endpoint.port);
         let table = entries.lock();
-        if let Some(entry) = table
-            .iter()
-            .find(|entry| entry.listen_endpoint == listen_endpoint)
-        {
-            // accept registration is performed from socket poll task context.
-            unsafe { entry.accept_poll.register(waker, IoEvents::IN) };
-            let accept_waker = Waker::from(Arc::new(AcceptWake {
-                poll: entry.accept_poll.clone(),
-            }));
-            for pending in &entry.syn_queue {
-                let socket: &mut tcp::Socket = sockets.get_mut(pending.accepted.handle);
-                socket.register_recv_waker(&accept_waker);
-                socket.register_send_waker(&accept_waker);
-            }
+        let Some(entry) = table.iter().find(|entry| {
+            entry.listen_endpoint == listen_endpoint && Arc::ptr_eq(&entry.accept_poll, accept_poll)
+        }) else {
+            return;
+        };
+        for pending in &entry.syn_queue {
+            let socket: &mut tcp::Socket = sockets.get_mut(pending.accepted.handle);
+            socket.register_recv_waker(waker);
+            socket.register_send_waker(waker);
         }
     }
 
@@ -291,11 +303,14 @@ impl ListenTable {
         sockets: &mut SocketSet<'_>,
     ) {
         let entries = self.listen_entry(dst.port);
-        let mut table = entries.lock();
-        if let Some(entry) = table
-            .iter_mut()
-            .find(|entry| entry.can_accept_endpoint(dst))
-        {
+        let wake_poll = {
+            let mut table = entries.lock();
+            let Some(entry) = table
+                .iter_mut()
+                .find(|entry| entry.can_accept_endpoint(dst))
+            else {
+                return;
+            };
             if entry.syn_queue.len() >= entry.backlog {
                 // SYN queue is full, drop the packet
                 warn!("SYN queue overflow!");
@@ -331,9 +346,12 @@ impl ListenTable {
                     remote_endpoint: src,
                 },
             });
-            // The child has been queued before waking accept waiters.
-            unsafe { entry.accept_poll.wake(IoEvents::IN) };
-        }
+            entry.accept_poll.clone()
+        };
+        // The child has been queued before waking accept waiters. The
+        // socket-set/service locks are still held by the caller, so defer
+        // the actual PollSet wake to the net worker outer loop.
+        crate::defer_poll_wake(wake_poll, IoEvents::IN);
     }
 }
 

--- a/net/ax-net/src/listen_table.rs
+++ b/net/ax-net/src/listen_table.rs
@@ -25,12 +25,12 @@
 //! module. The required order is `SOCKET_SET -> listen-table bucket`; this file
 //! must never acquire the outer service lock.
 
-use alloc::{boxed::Box, collections::VecDeque, sync::Arc, vec, vec::Vec};
+use alloc::{boxed::Box, collections::VecDeque, sync::Arc, task::Wake, vec, vec::Vec};
 use core::task::Waker;
 
 use ax_errno::{AxError, AxResult};
 use ax_sync::Mutex;
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 use smoltcp::{
     iface::{SocketHandle, SocketSet},
     socket::tcp::{self, SocketBuffer, State},
@@ -69,6 +69,22 @@ pub(crate) struct AcceptedTcp {
 #[derive(Clone, Copy)]
 struct PendingTcp {
     accepted: AcceptedTcp,
+}
+
+struct AcceptWake {
+    poll: Arc<PollSet>,
+}
+
+impl Wake for AcceptWake {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        // smoltcp invokes this from the net poll task context after publishing
+        // child socket readiness.
+        unsafe { self.poll.wake(IoEvents::IN) };
+    }
 }
 
 impl ListenTableEntryInner {
@@ -254,8 +270,11 @@ impl ListenTable {
             .iter()
             .find(|entry| entry.listen_endpoint == listen_endpoint)
         {
-            entry.accept_poll.register(waker);
-            let accept_waker = Waker::from(entry.accept_poll.clone());
+            // accept registration is performed from socket poll task context.
+            unsafe { entry.accept_poll.register(waker, IoEvents::IN) };
+            let accept_waker = Waker::from(Arc::new(AcceptWake {
+                poll: entry.accept_poll.clone(),
+            }));
             for pending in &entry.syn_queue {
                 let socket: &mut tcp::Socket = sockets.get_mut(pending.accepted.handle);
                 socket.register_recv_waker(&accept_waker);
@@ -312,7 +331,8 @@ impl ListenTable {
                     remote_endpoint: src,
                 },
             });
-            entry.accept_poll.wake();
+            // The child has been queued before waking accept waiters.
+            unsafe { entry.accept_poll.wake(IoEvents::IN) };
         }
     }
 }

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -50,6 +50,7 @@ use core::{
 use ax_hal::time::{NANOS_PER_MICROS, wall_time_nanos};
 use ax_sync::Mutex;
 use ax_task::WaitQueue;
+use axpoll::IoEvents;
 use smoltcp::{
     iface::SocketSet,
     phy::{DeviceCapabilities, Medium},
@@ -269,6 +270,24 @@ impl DeviceHandle {
         }
         self.tx_wake.notify_one(true);
         true
+    }
+}
+
+fn register_device_poll(device: &DeviceHandle, waker: &core::task::Waker) {
+    let poll = { device.inner.lock().readiness_poll() };
+    if let Some(poll) = poll {
+        // Device poll set is cloned while holding the device lock; registration
+        // runs after releasing it.
+        unsafe { poll.register(waker, IoEvents::IN | IoEvents::OUT | IoEvents::ERR) };
+    }
+}
+
+fn wake_device_poll(device: &DeviceHandle) {
+    let poll = { device.inner.lock().readiness_poll() };
+    if let Some(poll) = poll {
+        // Device readiness has been published by the net poll task, and the
+        // device lock has been released before running wakers.
+        unsafe { poll.wake(IoEvents::IN | IoEvents::OUT | IoEvents::ERR) };
     }
 }
 
@@ -627,15 +646,15 @@ impl Router {
     /// Registers a global device-readiness waker for all devices.
     pub fn register_device_waker(&self, waker: &core::task::Waker) {
         for device in &self.devices {
-            device.inner.lock().register_waker(&device.rx_waker);
-            device.inner.lock().register_waker(waker);
+            register_device_poll(device, &device.rx_waker);
+            register_device_poll(device, waker);
         }
     }
 
     /// Forces all device RX workers to re-check their devices.
     pub fn wake_all_devices(&self) {
         for device in &self.devices {
-            device.inner.lock().wake_rx();
+            wake_device_poll(device);
             device.rx_wake.notify_one(true);
         }
     }
@@ -644,8 +663,8 @@ impl Router {
     pub fn register_waker(&self, binding: DeviceBinding, waker: &core::task::Waker) {
         for device in &self.devices {
             if binding.bound_if.is_none_or(|id| id == device.interface_id) {
-                device.inner.lock().register_waker(&device.rx_waker);
-                device.inner.lock().register_waker(waker);
+                register_device_poll(device, &device.rx_waker);
+                register_device_poll(device, waker);
             }
         }
     }
@@ -843,7 +862,7 @@ fn device_rx_worker(device: Arc<DeviceHandle>) {
         }
 
         if !received {
-            device.inner.lock().register_waker(&device.rx_waker);
+            register_device_poll(&device, &device.rx_waker);
             device.rx_wake.wait();
         }
     }

--- a/net/ax-net/src/tcp.rs
+++ b/net/ax-net/src/tcp.rs
@@ -25,7 +25,7 @@
 //! - `LISTEN_TABLE` owns passive-open child sockets and accept wakeups.
 //! - `orphan` keeps dropped sockets alive long enough for FIN/TIME-WAIT cleanup.
 
-use alloc::{sync::Arc, vec, vec::Vec};
+use alloc::{sync::Arc, task::Wake, vec, vec::Vec};
 use core::{
     net::{Ipv4Addr, SocketAddr},
     sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
@@ -114,6 +114,23 @@ pub struct TcpSocket {
 }
 
 unsafe impl Sync for TcpSocket {}
+
+struct TcpPollWake {
+    poll: Arc<PollSet>,
+    ready: IoEvents,
+}
+
+impl Wake for TcpPollWake {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        // smoltcp invokes socket wakers from the net poll task context after
+        // updating socket readiness.
+        unsafe { self.poll.wake(self.ready) };
+    }
+}
 
 impl TcpSocket {
     /// Creates a new TCP socket.
@@ -727,13 +744,24 @@ impl Pollable for TcpSocket {
         }
         self.with_smol_socket(|socket| {
             if events.intersects(IoEvents::IN | IoEvents::RDHUP) {
-                self.poll_rx.register(context.waker());
-                let waker = Waker::from(self.poll_rx.clone());
+                // Socket registration runs from task poll context.
+                unsafe {
+                    self.poll_rx
+                        .register(context.waker(), IoEvents::IN | IoEvents::RDHUP)
+                };
+                let waker = Waker::from(Arc::new(TcpPollWake {
+                    poll: self.poll_rx.clone(),
+                    ready: IoEvents::IN | IoEvents::RDHUP,
+                }));
                 socket.register_recv_waker(&waker);
             }
             if events.contains(IoEvents::OUT) {
-                self.poll_tx.register(context.waker());
-                let waker = Waker::from(self.poll_tx.clone());
+                // Socket registration runs from task poll context.
+                unsafe { self.poll_tx.register(context.waker(), IoEvents::OUT) };
+                let waker = Waker::from(Arc::new(TcpPollWake {
+                    poll: self.poll_tx.clone(),
+                    ready: IoEvents::OUT,
+                }));
                 socket.register_send_waker(&waker);
             }
         });

--- a/net/ax-net/src/tcp.rs
+++ b/net/ax-net/src/tcp.rs
@@ -127,8 +127,9 @@ impl Wake for TcpPollWake {
 
     fn wake_by_ref(self: &Arc<Self>) {
         // smoltcp invokes socket wakers from the net poll task context after
-        // updating socket readiness.
-        unsafe { self.poll.wake(self.ready) };
+        // updating socket readiness. The socket set may still be locked there,
+        // so defer the actual PollSet wake to the net worker outer loop.
+        crate::defer_poll_wake(self.poll.clone(), self.ready);
     }
 }
 
@@ -734,35 +735,60 @@ impl Pollable for TcpSocket {
     }
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
+        let mut accept_registration = None;
         if self.is_listening() && events.intersects(IoEvents::IN | IoEvents::RDHUP) {
             let port = self.bound_endpoint.lock().port;
             if port != 0 {
                 let endpoint = *self.bound_endpoint.lock();
-                let mut sockets = SOCKET_SET.inner.lock();
-                LISTEN_TABLE.register_accept_waker(endpoint, &mut sockets, context.waker());
+                if let Some(accept_poll) = LISTEN_TABLE.accept_poll(endpoint) {
+                    // accept registration runs from task poll context after
+                    // releasing the listen-table lock.
+                    unsafe { accept_poll.register(context.waker(), IoEvents::IN) };
+                    let accept_waker = LISTEN_TABLE.accept_waker(accept_poll.clone());
+                    accept_registration = Some((endpoint, accept_poll, accept_waker));
+                }
             }
         }
+        let recv_waker = if events.intersects(IoEvents::IN | IoEvents::RDHUP) {
+            // Socket registration runs from task poll context before taking the
+            // socket-set lock.
+            unsafe {
+                self.poll_rx
+                    .register(context.waker(), IoEvents::IN | IoEvents::RDHUP)
+            };
+            Some(Waker::from(Arc::new(TcpPollWake {
+                poll: self.poll_rx.clone(),
+                ready: IoEvents::IN | IoEvents::RDHUP,
+            })))
+        } else {
+            None
+        };
+        let send_waker = if events.contains(IoEvents::OUT) {
+            // Socket registration runs from task poll context before taking the
+            // socket-set lock.
+            unsafe { self.poll_tx.register(context.waker(), IoEvents::OUT) };
+            Some(Waker::from(Arc::new(TcpPollWake {
+                poll: self.poll_tx.clone(),
+                ready: IoEvents::OUT,
+            })))
+        } else {
+            None
+        };
+        if let Some((endpoint, accept_poll, accept_waker)) = accept_registration.as_ref() {
+            let mut sockets = SOCKET_SET.inner.lock();
+            LISTEN_TABLE.register_pending_accept_wakers(
+                *endpoint,
+                &mut sockets,
+                accept_poll,
+                accept_waker,
+            );
+        }
         self.with_smol_socket(|socket| {
-            if events.intersects(IoEvents::IN | IoEvents::RDHUP) {
-                // Socket registration runs from task poll context.
-                unsafe {
-                    self.poll_rx
-                        .register(context.waker(), IoEvents::IN | IoEvents::RDHUP)
-                };
-                let waker = Waker::from(Arc::new(TcpPollWake {
-                    poll: self.poll_rx.clone(),
-                    ready: IoEvents::IN | IoEvents::RDHUP,
-                }));
-                socket.register_recv_waker(&waker);
+            if let Some(waker) = recv_waker.as_ref() {
+                socket.register_recv_waker(waker);
             }
-            if events.contains(IoEvents::OUT) {
-                // Socket registration runs from task poll context.
-                unsafe { self.poll_tx.register(context.waker(), IoEvents::OUT) };
-                let waker = Waker::from(Arc::new(TcpPollWake {
-                    poll: self.poll_tx.clone(),
-                    ready: IoEvents::OUT,
-                }));
-                socket.register_send_waker(&waker);
+            if let Some(waker) = send_waker.as_ref() {
+                socket.register_send_waker(waker);
             }
         });
         if events.intersects(IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP) {

--- a/net/ax-net/src/tcp.rs
+++ b/net/ax-net/src/tcp.rs
@@ -661,7 +661,8 @@ impl SocketOps for TcpSocket {
         // TODO(mivik): shutdown
         if how.has_read() {
             self.rx_closed.store(true, Ordering::Release);
-            self.poll_rx_closed.wake();
+            // rx_closed is visible before waking RDHUP/EOF waiters.
+            unsafe { self.poll_rx_closed.wake(IoEvents::RDHUP | IoEvents::IN) };
         }
 
         // stream
@@ -740,7 +741,11 @@ impl Pollable for TcpSocket {
             self.general.register_waker(context.waker());
         }
         if events.contains(IoEvents::RDHUP) {
-            self.poll_rx_closed.register(context.waker());
+            // Registration happens from socket poll task context.
+            unsafe {
+                self.poll_rx_closed
+                    .register(context.waker(), IoEvents::RDHUP | IoEvents::IN)
+            };
         }
     }
 }

--- a/net/ax-net/src/unix/dgram.rs
+++ b/net/ax-net/src/unix/dgram.rs
@@ -191,7 +191,10 @@ impl TransportOps for DgramTransport {
         });
         *guard = Some((rx, poll_update));
         self.local_addr.write().clone_from(local_addr);
-        self.poll_state.wake();
+        drop(guard);
+        drop(slot);
+        // Datagram bind state is published before waking pollers.
+        unsafe { self.poll_state.wake(IoEvents::IN | IoEvents::OUT) };
         Ok(())
     }
 
@@ -207,7 +210,9 @@ impl TransportOps for DgramTransport {
                 .ok_or(AxError::NotConnected)?
                 .connect(),
         );
-        self.poll_state.wake();
+        drop(guard);
+        // Connected peer state is published before waking pollers.
+        unsafe { self.poll_state.wake(IoEvents::IN | IoEvents::OUT) };
         Ok(())
     }
 
@@ -232,28 +237,28 @@ impl TransportOps for DgramTransport {
             sender: self.local_addr.read().clone(),
         };
 
-        let connected = self.connected.read();
-        if let Some(addr) = options.to {
+        let wake_poll = if let Some(addr) = options.to {
             let addr = addr.into_unix()?;
             with_slot(&addr, |slot| {
                 if let Some(bind) = slot.dgram.lock().as_ref() {
                     bind.data_tx
                         .try_send(packet)
                         .map_err(|_| AxError::BrokenPipe)?;
-                    bind.poll_update.wake();
-                    Ok(())
+                    Ok(bind.poll_update.clone())
                 } else {
                     Err(AxError::NotConnected)
                 }
-            })?;
-        } else if let Some(chan) = connected.as_ref() {
+            })?
+        } else if let Some(chan) = self.connected.read().as_ref() {
             chan.data_tx
                 .try_send(packet)
                 .map_err(|_| AxError::BrokenPipe)?;
-            chan.poll_update.wake();
+            chan.poll_update.clone()
         } else {
             return Err(AxError::NotConnected);
-        }
+        };
+        // Datagram packet is queued before waking the receiver.
+        unsafe { wake_poll.wake(IoEvents::IN) };
         Ok(len)
     }
 
@@ -305,10 +310,16 @@ impl Pollable for DgramTransport {
     }
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
-        if let Some((_, poll)) = self.data_rx.lock().as_ref()
+        let poll = if let Some((_, poll)) = self.data_rx.lock().as_ref()
             && events.contains(IoEvents::IN)
         {
-            poll.register(context.waker());
+            Some(poll.clone())
+        } else {
+            None
+        };
+        if let Some(poll) = poll {
+            // Registration happens from socket poll task context.
+            unsafe { poll.register(context.waker(), IoEvents::IN) };
         }
     }
 }
@@ -316,7 +327,8 @@ impl Pollable for DgramTransport {
 impl Drop for DgramTransport {
     fn drop(&mut self) {
         if let Some(chan) = self.connected.write().take() {
-            chan.poll_update.wake();
+            // Connection teardown is visible before waking the peer.
+            unsafe { chan.poll_update.wake(IoEvents::IN | IoEvents::OUT) };
         }
     }
 }

--- a/net/ax-net/src/unix/stream.rs
+++ b/net/ax-net/src/unix/stream.rs
@@ -145,7 +145,8 @@ impl Bind {
                 pid,
             })
             .map_err(|_| AxError::ConnectionRefused)?;
-        self.poll_new_conn.wake();
+        // The connection request is queued before waking accept waiters.
+        unsafe { self.poll_new_conn.wake(IoEvents::IN) };
         Ok(client_chan)
     }
 }
@@ -262,7 +263,10 @@ impl TransportOps for StreamTransport {
             pid: self.pid,
         });
         *guard = Some((rx, poll));
-        self.poll_state.wake();
+        drop(guard);
+        drop(slot);
+        // Bind state is published before waking poll waiters.
+        unsafe { self.poll_state.wake(IoEvents::IN | IoEvents::OUT) };
         Ok(())
     }
 
@@ -278,7 +282,9 @@ impl TransportOps for StreamTransport {
                 .ok_or(AxError::NotConnected)?
                 .connect(local_addr.clone(), self.pid)?,
         );
-        self.poll_state.wake();
+        drop(guard);
+        // Connection state is installed before waking poll waiters.
+        unsafe { self.poll_state.wake(IoEvents::IN | IoEvents::OUT) };
         Ok(())
     }
 
@@ -332,55 +338,64 @@ impl TransportOps for StreamTransport {
         let mut cmsg_slot: Option<Vec<CMsgData>> = had_cmsg.then_some(pending_cmsg);
 
         self.general.send_poller_with(self, dontwait, || {
+            let mut wake_poll = None;
             let mut guard = self.channel.lock();
-            let Some(chan) = guard.as_mut() else {
-                return Err(AxError::NotConnected);
-            };
-            if !chan.tx.read_is_held() {
-                return Err(AxError::BrokenPipe);
-            }
-
-            let count = {
-                let (left, right) = chan.tx.vacant_slices_mut();
-                let mut count = src.read(unsafe { left.assume_init_mut() })?;
-                if count >= left.len() {
-                    count += src.read(unsafe { right.assume_init_mut() })?;
+            let result = {
+                let Some(chan) = guard.as_mut() else {
+                    return Err(AxError::NotConnected);
+                };
+                if !chan.tx.read_is_held() {
+                    return Err(AxError::BrokenPipe);
                 }
-                unsafe { chan.tx.advance_write_index(count) };
-                count
-            };
-            total += count;
-            if count > 0 {
-                // Attach cmsg (if any) to the first write of this send
-                // call.  Continuations of the same multi-iter send extend
-                // the just-pushed entry; back-to-back separate send calls
-                // (no cmsg) must NOT extend a prior call's cmsg, otherwise
-                // a non-cmsg send glued to a preceding cmsg send would
-                // appear to peer as a single oversized cmsg-bearing
-                // message.
-                if let Some(cmsg) = cmsg_slot.take() {
-                    let start_byte = chan.tx_bytes_total.saturating_add(1);
-                    let end_byte = chan.tx_bytes_total.saturating_add(count as u64);
-                    chan.tx_cmsg.lock().push_back(PendingCmsg {
-                        start_byte,
-                        end_byte,
-                        cmsg,
-                    });
-                } else if had_cmsg
-                    && let Some(last) = chan.tx_cmsg.lock().back_mut()
-                    && last.end_byte == chan.tx_bytes_total
-                {
-                    last.end_byte = last.end_byte.saturating_add(count as u64);
-                }
-                chan.tx_bytes_total = chan.tx_bytes_total.saturating_add(count as u64);
-                chan.poll_update.wake();
-            }
 
-            if count == size || non_blocking {
-                Ok(total)
-            } else {
-                Err(AxError::WouldBlock)
+                let count = {
+                    let (left, right) = chan.tx.vacant_slices_mut();
+                    let mut count = src.read(unsafe { left.assume_init_mut() })?;
+                    if count >= left.len() {
+                        count += src.read(unsafe { right.assume_init_mut() })?;
+                    }
+                    unsafe { chan.tx.advance_write_index(count) };
+                    count
+                };
+                total += count;
+                if count > 0 {
+                    // Attach cmsg (if any) to the first write of this send
+                    // call.  Continuations of the same multi-iter send extend
+                    // the just-pushed entry; back-to-back separate send calls
+                    // (no cmsg) must NOT extend a prior call's cmsg, otherwise
+                    // a non-cmsg send glued to a preceding cmsg send would
+                    // appear to peer as a single oversized cmsg-bearing
+                    // message.
+                    if let Some(cmsg) = cmsg_slot.take() {
+                        let start_byte = chan.tx_bytes_total.saturating_add(1);
+                        let end_byte = chan.tx_bytes_total.saturating_add(count as u64);
+                        chan.tx_cmsg.lock().push_back(PendingCmsg {
+                            start_byte,
+                            end_byte,
+                            cmsg,
+                        });
+                    } else if had_cmsg
+                        && let Some(last) = chan.tx_cmsg.lock().back_mut()
+                        && last.end_byte == chan.tx_bytes_total
+                    {
+                        last.end_byte = last.end_byte.saturating_add(count as u64);
+                    }
+                    chan.tx_bytes_total = chan.tx_bytes_total.saturating_add(count as u64);
+                    wake_poll = Some(chan.poll_update.clone());
+                }
+
+                if count == size || non_blocking {
+                    Ok(total)
+                } else {
+                    Err(AxError::WouldBlock)
+                }
+            };
+            drop(guard);
+            if let Some(poll) = wake_poll {
+                // Peer-visible bytes and cmsg state are published before wake.
+                unsafe { poll.wake(IoEvents::IN | IoEvents::OUT) };
             }
+            result
         })
     }
 
@@ -388,51 +403,60 @@ impl TransportOps for StreamTransport {
         let dontwait = options.flags.contains(crate::RecvFlags::DONTWAIT);
         let peek = options.flags.contains(crate::RecvFlags::PEEK);
         let recv_count = self.general.recv_poller_with(self, dontwait, || {
+            let mut wake_poll = None;
             let mut guard = self.channel.lock();
-            let Some(chan) = guard.as_mut() else {
-                return Err(AxError::NotConnected);
-            };
+            let result = {
+                let Some(chan) = guard.as_mut() else {
+                    return Err(AxError::NotConnected);
+                };
 
-            // Cap the read at the end of the first pending cmsg-bearing
-            // message so the next recv starts cleanly at the next message.
-            let cap_bytes: Option<usize> = {
-                let q = chan.rx_cmsg.lock();
-                q.front().and_then(|front| {
-                    if front.end_byte > chan.rx_bytes_total {
-                        let cap = front.end_byte.saturating_sub(chan.rx_bytes_total);
-                        Some(cap as usize)
-                    } else {
-                        None
+                // Cap the read at the end of the first pending cmsg-bearing
+                // message so the next recv starts cleanly at the next message.
+                let cap_bytes: Option<usize> = {
+                    let q = chan.rx_cmsg.lock();
+                    q.front().and_then(|front| {
+                        if front.end_byte > chan.rx_bytes_total {
+                            let cap = front.end_byte.saturating_sub(chan.rx_bytes_total);
+                            Some(cap as usize)
+                        } else {
+                            None
+                        }
+                    })
+                };
+
+                let count = {
+                    let (left, right) = chan.rx.as_slices();
+                    let left_cap = cap_bytes.map_or(left.len(), |c| c.min(left.len()));
+                    let mut count = dst.write(&left[..left_cap])?;
+                    let remaining_cap = cap_bytes.map_or(usize::MAX, |c| c.saturating_sub(count));
+                    if count >= left_cap && remaining_cap > 0 {
+                        let right_cap = right.len().min(remaining_cap);
+                        count += dst.write(&right[..right_cap])?;
                     }
-                })
+                    if !peek {
+                        unsafe { chan.rx.advance_read_index(count) };
+                    }
+                    count
+                };
+                if count > 0 {
+                    if !peek {
+                        chan.rx_bytes_total = chan.rx_bytes_total.saturating_add(count as u64);
+                        wake_poll = Some(chan.poll_update.clone());
+                    }
+                    Ok(count)
+                } else if !chan.rx.write_is_held() || chan.peer_tx_closed.load(Ordering::Acquire) {
+                    // Peer closed (HeapProd dropped or tx_closed flag set): EOF.
+                    Ok(0)
+                } else {
+                    Err(AxError::WouldBlock)
+                }
             };
-
-            let count = {
-                let (left, right) = chan.rx.as_slices();
-                let left_cap = cap_bytes.map_or(left.len(), |c| c.min(left.len()));
-                let mut count = dst.write(&left[..left_cap])?;
-                let remaining_cap = cap_bytes.map_or(usize::MAX, |c| c.saturating_sub(count));
-                if count >= left_cap && remaining_cap > 0 {
-                    let right_cap = right.len().min(remaining_cap);
-                    count += dst.write(&right[..right_cap])?;
-                }
-                if !peek {
-                    unsafe { chan.rx.advance_read_index(count) };
-                }
-                count
-            };
-            if count > 0 {
-                if !peek {
-                    chan.rx_bytes_total = chan.rx_bytes_total.saturating_add(count as u64);
-                    chan.poll_update.wake();
-                }
-                Ok(count)
-            } else if !chan.rx.write_is_held() || chan.peer_tx_closed.load(Ordering::Acquire) {
-                // Peer closed (HeapProd dropped or tx_closed flag set): EOF.
-                Ok(0)
-            } else {
-                Err(AxError::WouldBlock)
+            drop(guard);
+            if let Some(poll) = wake_poll {
+                // Freed TX capacity is visible before waking writers.
+                unsafe { poll.wake(IoEvents::OUT) };
             }
+            result
         })?;
 
         if peek {
@@ -474,17 +498,28 @@ impl TransportOps for StreamTransport {
     fn shutdown(&self, how: Shutdown) -> AxResult<()> {
         if how.has_read() {
             self.rx_closed.store(true, Ordering::Release);
-            self.poll_state.wake();
         }
         if how.has_write() {
             self.tx_closed.store(true, Ordering::Release);
-            self.poll_state.wake();
         }
-        if self.rx_closed.load(Ordering::Acquire)
+        let peer_poll = if self.rx_closed.load(Ordering::Acquire)
             && self.tx_closed.load(Ordering::Acquire)
             && let Some(chan) = self.channel.lock().take()
         {
-            chan.poll_update.wake();
+            Some(chan.poll_update)
+        } else {
+            None
+        };
+        if let Some(poll) = peer_poll {
+            // Channel closure is published before waking the peer.
+            unsafe { poll.wake(IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP) };
+        }
+        if how.has_read() || how.has_write() {
+            // Local shutdown flags are visible before waking local pollers.
+            unsafe {
+                self.poll_state
+                    .wake(IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP)
+            };
         }
         Ok(())
     }
@@ -514,30 +549,49 @@ impl Pollable for StreamTransport {
     }
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
-        if let Some(chan) = self.channel.lock().as_ref() {
-            if events.intersects(IoEvents::IN | IoEvents::OUT) {
-                chan.poll_update.register(context.waker());
-            }
+        let chan_poll = if events.intersects(IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP) {
+            self.channel
+                .lock()
+                .as_ref()
+                .map(|chan| chan.poll_update.clone())
+        } else {
+            None
+        };
+        if let Some(poll) = chan_poll {
+            // Registration happens from socket poll task context.
+            unsafe { poll.register(context.waker(), events) };
         } else if let Some((_, poll_new_conn)) = self.conn_rx.lock().as_ref()
             && events.contains(IoEvents::IN)
         {
-            poll_new_conn.register(context.waker());
+            // Registration happens from socket poll task context.
+            unsafe { poll_new_conn.register(context.waker(), IoEvents::IN) };
         }
-        self.poll_state.register(context.waker());
+        // Registration happens from socket poll task context.
+        unsafe { self.poll_state.register(context.waker(), events) };
     }
 }
 
 impl Drop for StreamTransport {
     fn drop(&mut self) {
-        if let Some(chan) = self.channel.lock().as_ref() {
+        let peer_poll = if let Some(chan) = self.channel.lock().as_ref() {
             // Set the flag BEFORE waking the peer so poll() sees peer_eof=true
             // when it runs in the wake handler — even though our HeapProd hasn't
             // dropped yet.  Without this, the peer's poll() sees write_is_held()=true
             // and no data, reports no events, and parks forever waiting for data
             // that will never arrive.
             chan.my_tx_closed.store(true, Ordering::Release);
-            chan.poll_update.wake();
+            Some(chan.poll_update.clone())
+        } else {
+            None
+        };
+        if let Some(poll) = peer_poll {
+            // Peer close flag is published before waking readers.
+            unsafe { poll.wake(IoEvents::IN | IoEvents::RDHUP) };
         }
-        self.poll_state.wake();
+        // Local state changed because this endpoint is being dropped.
+        unsafe {
+            self.poll_state
+                .wake(IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP)
+        };
     }
 }

--- a/net/ax-net/src/vsock/connection_manager.rs
+++ b/net/ax-net/src/vsock/connection_manager.rs
@@ -22,7 +22,7 @@ use alloc::{collections::BTreeMap, sync::Arc};
 use ax_errno::{AxError, AxResult, ax_bail};
 use ax_sync::Mutex;
 use ax_task::WaitQueue;
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 use ringbuf::{HeapCons, HeapProd, HeapRb, traits::*};
 
 use super::{VsockAddr, VsockConnId};
@@ -115,12 +115,17 @@ impl Connection {
 
     /// Register a waker for receive Events
     pub fn register_rx_poll(&mut self, context: &mut core::task::Context<'_>) {
-        self.rx_wakers.register(context.waker());
+        // Registration happens from vsock poll task context.
+        unsafe { self.rx_wakers.register(context.waker(), IoEvents::IN) };
     }
 
     /// Register a waker for connect Events
     pub fn register_connect_poll(&mut self, _context: &mut core::task::Context<'_>) {
-        self.connect_wakers.register(_context.waker());
+        // Registration happens from vsock poll task context.
+        unsafe {
+            self.connect_wakers
+                .register(_context.waker(), IoEvents::OUT | IoEvents::ERR)
+        };
     }
 
     /// Get the free space in the receive buffer
@@ -195,12 +200,17 @@ impl Connection {
 
     #[inline]
     pub fn wake_rx(&mut self) {
-        self.rx_wakers.wake();
+        // RX buffer and connection state are updated before wake_rx is called.
+        unsafe {
+            self.rx_wakers
+                .wake(IoEvents::IN | IoEvents::RDHUP | IoEvents::HUP)
+        };
     }
 
     #[inline]
     pub fn wake_connect(&mut self) {
-        self.connect_wakers.wake();
+        // Connection state is updated before wake_connect is called.
+        unsafe { self.connect_wakers.wake(IoEvents::OUT | IoEvents::ERR) };
     }
 
     #[inline]
@@ -290,11 +300,13 @@ impl ListenQueue {
     }
 
     pub fn wake(&mut self) {
-        self.wakers.wake();
+        // Accept queue state is published before waking listeners.
+        unsafe { self.wakers.wake(IoEvents::IN) };
     }
 
     pub fn register_poll(&mut self, context: &mut core::task::Context<'_>) {
-        self.wakers.register(context.waker());
+        // Registration happens from vsock poll task context.
+        unsafe { self.wakers.register(context.waker(), IoEvents::IN) };
     }
 }
 

--- a/os/StarryOS/kernel/src/ebpf/map.rs
+++ b/os/StarryOS/kernel/src/ebpf/map.rs
@@ -8,7 +8,7 @@ use core::ops::{Deref, DerefMut};
 
 use ax_errno::{AxError, AxResult};
 use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr};
-use axpoll::{PollSet, Pollable};
+use axpoll::{IoEvents, PollSet, Pollable};
 use kbpf_basic::{
     PollWaker,
     map::{BpfMapMeta, UnifiedMap, bpf_map_create},
@@ -63,8 +63,11 @@ impl Pollable for BpfMap {
         events
     }
 
-    fn register(&self, context: &mut core::task::Context<'_>, _events: axpoll::IoEvents) {
-        self.poll_ready.register(context.waker());
+    fn register(&self, context: &mut core::task::Context<'_>, events: axpoll::IoEvents) {
+        if !events.is_empty() {
+            // Registration happens from file poll task context.
+            unsafe { self.poll_ready.register(context.waker(), events) };
+        }
     }
 }
 
@@ -141,7 +144,8 @@ impl DerefMut for PollSetWrapper {
 
 impl PollWaker for PollSetWrapper {
     fn wake_up(&self) {
-        self.0.wake();
+        // kbpf calls this after publishing map readiness.
+        unsafe { self.0.wake(IoEvents::all()) };
     }
 }
 

--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -322,7 +322,8 @@ impl EpollInner {
             interest.mark_not_in_queue();
             self.overflow_ready.store(true, Ordering::Release);
         }
-        self.poll_ready.wake();
+        // Ready queue or overflow state is published before waking epoll waiters.
+        unsafe { self.poll_ready.wake(IoEvents::IN) };
     }
 
     fn remove_ready_entries_for(&self, target: &Weak<EpollInterest>) {
@@ -391,7 +392,8 @@ impl EpollInner {
         })();
         if result.is_err() {
             self.overflow_ready.store(true, Ordering::Release);
-            self.poll_ready.wake();
+            // Overflow state is published before waking epoll waiters.
+            unsafe { self.poll_ready.wake(IoEvents::IN) };
         }
         result
     }
@@ -692,7 +694,12 @@ impl Pollable for Epoll {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.inner.poll_ready.register(context.waker());
+            // Registration happens from epoll wait task context.
+            unsafe {
+                self.inner
+                    .poll_ready
+                    .register(context.waker(), IoEvents::IN)
+            };
         }
     }
 }

--- a/os/StarryOS/kernel/src/file/event.rs
+++ b/os/StarryOS/kernel/src/file/event.rs
@@ -53,7 +53,8 @@ impl FileLike for EventFd {
                 Ok(count) => {
                     let value = if self.semaphore { 1 } else { count };
                     dst.write(&value.to_ne_bytes())?;
-                    self.poll_tx.wake();
+                    // Counter space is visible before waking writers.
+                    unsafe { self.poll_tx.wake(IoEvents::OUT) };
                     Ok(size_of::<u64>())
                 }
                 Err(_) => Err(AxError::WouldBlock),
@@ -85,7 +86,8 @@ impl FileLike for EventFd {
                 });
             match result {
                 Ok(_) => {
-                    self.poll_rx.wake();
+                    // Counter increment is visible before waking readers.
+                    unsafe { self.poll_rx.wake(IoEvents::IN) };
                     Ok(size_of::<u64>())
                 }
                 Err(_) => Err(AxError::WouldBlock),
@@ -118,10 +120,12 @@ impl Pollable for EventFd {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_rx.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
         }
         if events.contains(IoEvents::OUT) {
-            self.poll_tx.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.poll_tx.register(context.waker(), IoEvents::OUT) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/file/inotify.rs
+++ b/os/StarryOS/kernel/src/file/inotify.rs
@@ -93,7 +93,9 @@ impl Inotify {
             return Err(AxError::InvalidInput);
         }
         Self::push_event(&mut state.queue, wd, IN_IGNORED, None);
-        self.poll_rx.wake();
+        drop(state);
+        // Inotify event is queued before waking readers.
+        unsafe { self.poll_rx.wake(IoEvents::IN) };
         Ok(())
     }
 
@@ -127,7 +129,9 @@ impl Inotify {
         for (wd, mask, name) in events {
             Self::push_event(&mut state.queue, wd, mask, name.as_deref());
         }
-        self.poll_rx.wake();
+        drop(state);
+        // Inotify events are queued before waking readers.
+        unsafe { self.poll_rx.wake(IoEvents::IN) };
     }
 
     fn notify_delete(&self, path: &str, is_dir: bool) {
@@ -155,7 +159,9 @@ impl Inotify {
             Self::push_event(&mut state.queue, wd, mask, name.as_deref());
         }
         state.watches.retain(|_, watch| watch.path != path);
-        self.poll_rx.wake();
+        drop(state);
+        // Delete events are queued before waking readers.
+        unsafe { self.poll_rx.wake(IoEvents::IN) };
     }
 
     fn push_event(queue: &mut VecDeque<Vec<u8>>, wd: i32, mask: u32, name: Option<&str>) {
@@ -250,7 +256,8 @@ impl Pollable for Inotify {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_rx.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/file/io_uring.rs
+++ b/os/StarryOS/kernel/src/file/io_uring.rs
@@ -290,7 +290,8 @@ impl IoUring {
         self.rings
             .cq_ring
             .write_u32(CQ_TAIL_OFFSET, tail.wrapping_add(1));
-        self.poll_cq.wake();
+        // CQ tail is published before waking completion waiters.
+        unsafe { self.poll_cq.wake(IoEvents::IN) };
     }
 }
 
@@ -313,7 +314,8 @@ impl Pollable for IoUring {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_cq.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.poll_cq.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/file/netlink.rs
+++ b/os/StarryOS/kernel/src/file/netlink.rs
@@ -438,7 +438,8 @@ pub fn broadcast(protocol: u32, group_mask: u32, payload: &[u8]) {
         if queue.len() < MAX_QUEUED {
             queue.push_back(payload.to_vec());
             drop(queue);
-            sock.poll_rx.wake();
+            // Netlink message is queued before waking readers.
+            unsafe { sock.poll_rx.wake(IoEvents::IN) };
         }
     }
 }
@@ -494,7 +495,8 @@ impl FileLike for NetlinkSocket {
             if queue.len() < MAX_QUEUED {
                 queue.push_back(response);
                 drop(queue);
-                self.poll_rx.wake();
+                // Netlink response is queued before waking readers.
+                unsafe { self.poll_rx.wake(IoEvents::IN) };
             }
         }
         Ok(total)
@@ -540,7 +542,8 @@ impl Pollable for NetlinkSocket {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_rx.register(context.waker());
+            // Registration happens from socket poll task context.
+            unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/file/packet.rs
+++ b/os/StarryOS/kernel/src/file/packet.rs
@@ -164,8 +164,11 @@ impl PacketSocket {
 
         let bound = self.state.lock().bound;
         if let Some(reply) = build_arp_reply(&data, bound) {
-            self.state.lock().pending = Some(reply);
-            self.poll_rx.wake();
+            {
+                self.state.lock().pending = Some(reply);
+            }
+            // Pending packet is stored before waking readers.
+            unsafe { self.poll_rx.wake(IoEvents::IN) };
         }
         Ok(read)
     }
@@ -322,7 +325,8 @@ impl Pollable for PacketSocket {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_rx.register(context.waker());
+            // Registration happens from socket poll task context.
+            unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/file/pidfd.rs
+++ b/os/StarryOS/kernel/src/file/pidfd.rs
@@ -109,7 +109,8 @@ impl Pollable for PidFd {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.exit_event.register(context.waker());
+            // Registration happens from pidfd poll task context.
+            unsafe { self.exit_event.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/file/pipe.rs
+++ b/os/StarryOS/kernel/src/file/pipe.rs
@@ -46,7 +46,8 @@ pub struct Pipe {
 }
 impl Drop for Pipe {
     fn drop(&mut self) {
-        self.shared.poll_close.wake();
+        // Peer close is visible through Arc strong count before this wake.
+        unsafe { self.shared.poll_close.wake(IoEvents::HUP | IoEvents::ERR) };
     }
 }
 
@@ -135,7 +136,8 @@ impl FileLike for Pipe {
                 count
             };
             if read > 0 {
-                self.shared.poll_tx.wake();
+                // Pipe capacity was freed before waking writers.
+                unsafe { self.shared.poll_tx.wake(IoEvents::OUT) };
                 Ok(read)
             } else if self.closed() {
                 Ok(0)
@@ -173,7 +175,8 @@ impl FileLike for Pipe {
                 count
             };
             if written > 0 {
-                self.shared.poll_rx.wake();
+                // Pipe bytes were committed before waking readers.
+                unsafe { self.shared.poll_rx.wake(IoEvents::IN) };
                 total_written += written;
                 if total_written == size || self.nonblocking() {
                     return Ok(total_written);
@@ -235,11 +238,18 @@ impl Pollable for Pipe {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.shared.poll_rx.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.shared.poll_rx.register(context.waker(), IoEvents::IN) };
         }
         if events.contains(IoEvents::OUT) {
-            self.shared.poll_tx.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.shared.poll_tx.register(context.waker(), IoEvents::OUT) };
         }
-        self.shared.poll_close.register(context.waker());
+        // Close/error notifications are always observable poll events.
+        unsafe {
+            self.shared
+                .poll_close
+                .register(context.waker(), IoEvents::HUP | IoEvents::ERR)
+        };
     }
 }

--- a/os/StarryOS/kernel/src/file/signalfd.rs
+++ b/os/StarryOS/kernel/src/file/signalfd.rs
@@ -100,7 +100,8 @@ impl Signalfd {
         {
             *self.mask.lock() = mask;
         }
-        self.poll_rx.wake();
+        // The signal mask update is visible before waking readers.
+        unsafe { self.poll_rx.wake(IoEvents::IN) };
     }
 
     fn mask(&self) -> SignalSet {
@@ -142,7 +143,8 @@ impl FileLike for Signalfd {
 
                 // Wake up other waiters if there are more signals pending
                 if self.has_pending_signals() {
-                    self.poll_rx.wake();
+                    // Remaining pending signals are visible before re-wake.
+                    unsafe { self.poll_rx.wake(IoEvents::IN) };
                 }
 
                 Ok(SIGNALFD_SIGINFO_SIZE)
@@ -180,7 +182,8 @@ impl Pollable for Signalfd {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_rx.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/file/timerfd.rs
+++ b/os/StarryOS/kernel/src/file/timerfd.rs
@@ -293,7 +293,8 @@ async fn run_timer(weak: alloc::sync::Weak<Timerfd>) {
                         state.next_deadline = Some(next_deadline);
                     }
                     drop(state);
-                    tfd.poll_rx.wake();
+                    // expire_count is published before waking readers.
+                    unsafe { tfd.poll_rx.wake(IoEvents::IN) };
                 }
             }
         }
@@ -334,7 +335,8 @@ impl FileLike for Timerfd {
             // notices the fd is readable again.
             if let Err(e) = dst.write(&n.to_ne_bytes()) {
                 self.expire_count.fetch_add(n, Ordering::AcqRel);
-                self.poll_rx.wake();
+                // Restored expire_count is visible before re-waking readers.
+                unsafe { self.poll_rx.wake(IoEvents::IN) };
                 return Err(e);
             }
             Ok(core::mem::size_of::<u64>())
@@ -368,7 +370,8 @@ impl Pollable for Timerfd {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_rx.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/perf/bpf.rs
+++ b/os/StarryOS/kernel/src/perf/bpf.rs
@@ -10,12 +10,17 @@
 //! share one buffer.
 
 use alloc::sync::{Arc, Weak};
-use core::{any::Any, fmt::Debug};
+use core::{
+    any::Any,
+    fmt::Debug,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use ax_alloc::GlobalPage;
 use ax_errno::{AxError, AxResult};
 use ax_hal::mem::virt_to_phys;
 use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr};
+use ax_task::IrqNotify;
 use axpoll::{IoEvents, PollSet, Pollable};
 use kbpf_basic::{
     linux_bpf::perf_event_sample_format,
@@ -59,7 +64,9 @@ use crate::{
 /// pointer left after the pages free is harmless.
 pub struct BpfPerfEventWrapper {
     inner: BpfPerfEvent,
-    poll_ready: PollSet,
+    poll_ready: Arc<PollSet>,
+    poll_notify: Arc<IrqNotify>,
+    poll_alive: Arc<AtomicBool>,
     /// Weak handle to the contiguous pages backing the ringbuf. The strong
     /// ref(s) live in the user VMA(s); `strong_count() > 0` means a live
     /// mapping still exists. See the type-level docs for the ownership
@@ -70,9 +77,15 @@ pub struct BpfPerfEventWrapper {
 impl BpfPerfEventWrapper {
     /// Construct the wrapper around a freshly-built `BpfPerfEvent`.
     pub fn new(inner: BpfPerfEvent) -> Self {
+        let poll_ready = Arc::new(PollSet::new());
+        let poll_notify = Arc::new(IrqNotify::new());
+        let poll_alive = Arc::new(AtomicBool::new(true));
+        start_bpf_perf_notify_worker(poll_ready.clone(), poll_notify.clone(), poll_alive.clone());
         Self {
             inner,
-            poll_ready: PollSet::new(),
+            poll_ready,
+            poll_notify,
+            poll_alive,
             pages: None,
         }
     }
@@ -96,10 +109,35 @@ impl BpfPerfEventWrapper {
         }
         self.inner.write_event(data).into_ax_result()?;
         if self.inner.enabled() {
-            self.poll_ready.wake();
+            self.poll_notify.notify_irq();
         }
         Ok(())
     }
+}
+
+impl Drop for BpfPerfEventWrapper {
+    fn drop(&mut self) {
+        self.poll_alive.store(false, Ordering::Release);
+        self.poll_notify.notify();
+    }
+}
+
+fn start_bpf_perf_notify_worker(
+    poll_ready: Arc<PollSet>,
+    poll_notify: Arc<IrqNotify>,
+    poll_alive: Arc<AtomicBool>,
+) {
+    ax_task::spawn_with_name(
+        move || loop {
+            poll_notify.wait();
+            if !poll_alive.load(Ordering::Acquire) {
+                break;
+            }
+            // Ring data is written before the deferred poll wake.
+            unsafe { poll_ready.wake(IoEvents::IN) };
+        },
+        "bpf-perf-notify".into(),
+    );
 }
 
 impl Debug for BpfPerfEventWrapper {
@@ -174,7 +212,8 @@ impl Pollable for BpfPerfEventWrapper {
 
     fn register(&self, context: &mut core::task::Context<'_>, events: axpoll::IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_ready.register(context.waker());
+            // Registration happens from file poll task context.
+            unsafe { self.poll_ready.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -539,7 +539,8 @@ impl Pollable for Card0 {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_rx.register(context.waker());
+            // Registration happens from DRM file poll task context.
+            unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
         }
     }
 }
@@ -1262,7 +1263,8 @@ impl Card0 {
             }
         };
         if enqueued {
-            self.poll_rx.wake();
+            // DRM event is queued before waking readers.
+            unsafe { self.poll_rx.wake(IoEvents::IN) };
         }
     }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/cvi_camera.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/cvi_camera.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use alloc::{collections::vec_deque::VecDeque, vec::Vec};
+use alloc::vec::Vec;
 use core::{any::Any, ptr::NonNull, time::Duration};
 
 use ax_errno::{AxError, LinuxError};
@@ -15,7 +15,7 @@ use sg200x_bsp::{
 use starry_vm::{VmMutPtr, vm_write_slice};
 use tock_registers::interfaces::Writeable;
 
-use crate::pseudofs::DeviceOps;
+use crate::pseudofs::{DeviceOps, dev::irq_byte_ring::ByteRing};
 
 pub const CMD_INIT: u8 = 0x01;
 pub const CMD_GET_CAMERA_INFO: u8 = 0x02;
@@ -26,6 +26,7 @@ pub const RESP_FRAME_CHUNK: u8 = 0x90;
 pub const MAX_FRAME_SIZE: usize = 2 * 1024 * 1024;
 pub const FRAME_CHUNK_TIMEOUT_MS: u64 = 1000;
 pub const DEFAULT_TIMEOUT_MS: u64 = 2000;
+const CAMERA_UART_BUF_CAP: usize = MAX_FRAME_SIZE + 8192;
 
 const SLIP_END: u8 = 0xC0;
 const SLIP_ESC: u8 = 0xDB;
@@ -41,7 +42,7 @@ unsafe fn cvi_camera_raw_irq_handler(
     );
     let mut buf = CAMERA_UART_BUF.lock();
     while let Some(c) = uart3.getchar() {
-        buf.push_back(c);
+        let _ = buf.push_back(c);
     }
     uart3.set_ier(true);
     ax_runtime::hal::irq::IrqReturn::Handled
@@ -322,7 +323,7 @@ impl<T: UartTransport> CameraProtocol<T> {
 }
 
 const UART3_ADDR: usize = 0x04170000;
-static CAMERA_UART_BUF: Mutex<VecDeque<u8>> = Mutex::new(VecDeque::new());
+static CAMERA_UART_BUF: Mutex<ByteRing<CAMERA_UART_BUF_CAP>> = Mutex::new(ByteRing::new());
 
 struct Uart3;
 
@@ -342,10 +343,7 @@ impl UartTransport for Uart3 {
             let mut cache_buf = CAMERA_UART_BUF.lock();
             let n = cache_buf.len().min(buf.len());
             if n > 0 {
-                cache_buf
-                    .drain(..n)
-                    .enumerate()
-                    .for_each(|(i, x)| buf[i] = x);
+                cache_buf.drain_into(&mut buf[..n]);
             }
             n
         };

--- a/os/StarryOS/kernel/src/pseudofs/dev/irq_byte_ring.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/irq_byte_ring.rs
@@ -1,0 +1,78 @@
+pub(super) struct ByteRing<const N: usize> {
+    buf: [u8; N],
+    head: usize,
+    len: usize,
+}
+
+impl<const N: usize> ByteRing<N> {
+    pub(super) const fn new() -> Self {
+        Self {
+            buf: [0; N],
+            head: 0,
+            len: 0,
+        }
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.head = 0;
+        self.len = 0;
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(super) fn push_back(&mut self, byte: u8) -> bool {
+        if self.len == N {
+            return false;
+        }
+        let tail = (self.head + self.len) % N;
+        self.buf[tail] = byte;
+        self.len += 1;
+        true
+    }
+
+    pub(super) fn pop_front(&mut self) -> Option<u8> {
+        if self.len == 0 {
+            return None;
+        }
+        let byte = self.buf[self.head];
+        self.head = (self.head + 1) % N;
+        self.len -= 1;
+        Some(byte)
+    }
+
+    pub(super) fn drain_into(&mut self, out: &mut [u8]) -> usize {
+        let n = out.len().min(self.len);
+        for slot in out.iter_mut().take(n) {
+            *slot = self
+                .pop_front()
+                .expect("ring length was precomputed before draining");
+        }
+        n
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ByteRing;
+
+    #[test]
+    fn fixed_ring_preserves_fifo_and_drops_when_full() {
+        let mut ring = ByteRing::<3>::new();
+        assert!(ring.push_back(1));
+        assert!(ring.push_back(2));
+        assert!(ring.push_back(3));
+        assert!(!ring.push_back(4));
+        assert_eq!(ring.len(), 3);
+
+        let mut out = [0; 4];
+        assert_eq!(ring.drain_into(&mut out), 3);
+        assert_eq!(&out[..3], &[1, 2, 3]);
+        assert!(ring.is_empty());
+    }
+}

--- a/os/StarryOS/kernel/src/pseudofs/dev/kpu.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/kpu.rs
@@ -448,7 +448,7 @@ unsafe fn kpu_irq_handler(
     _data: NonNull<()>,
 ) -> ax_runtime::hal::irq::IrqReturn {
     KPU_IRQ_COUNT.fetch_add(1, Ordering::AcqRel);
-    KPU_DONE_WQ.notify_all(false);
+    KPU_DONE_WQ.notify_all_from_irq();
     ax_runtime::hal::irq::IrqReturn::Handled
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -9,6 +9,8 @@ mod drm;
 #[cfg(feature = "input")]
 pub mod event;
 mod fb;
+#[cfg(feature = "sg2002")]
+mod irq_byte_ring;
 #[cfg(feature = "k230-kpu")]
 mod kpu;
 #[cfg(feature = "dev-log")]

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/ntty.rs
@@ -1,7 +1,11 @@
 use alloc::sync::Arc;
-use core::ptr::NonNull;
+use core::{
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
-use axpoll::PollSet;
+use ax_task::IrqNotify;
+use axpoll::{IoEvents, PollSet};
 use spin::LazyLock;
 
 use super::{
@@ -27,6 +31,9 @@ impl TtyWrite for Console {
 /// The default TTY device.
 pub static N_TTY: LazyLock<Arc<NTtyDriver>> = LazyLock::new(new_n_tty);
 static CONSOLE_INPUT_SOURCE: LazyLock<Arc<PollSet>> = LazyLock::new(|| Arc::new(PollSet::new()));
+static CONSOLE_INPUT_NOTIFY: LazyLock<Arc<IrqNotify>> =
+    LazyLock::new(|| Arc::new(IrqNotify::new()));
+static CONSOLE_NOTIFY_WORKER: AtomicBool = AtomicBool::new(false);
 
 fn handle_console_input_irq(_irq_num: usize) {
     let events = ax_runtime::hal::console::handle_irq();
@@ -35,7 +42,7 @@ fn handle_console_input_irq(_irq_num: usize) {
             | ax_runtime::hal::console::ConsoleIrqEvent::RX_ERROR
             | ax_runtime::hal::console::ConsoleIrqEvent::OVERRUN,
     ) {
-        CONSOLE_INPUT_SOURCE.wake();
+        CONSOLE_INPUT_NOTIFY.notify_irq();
     }
 }
 
@@ -75,6 +82,20 @@ fn new_n_tty() -> Arc<NTtyDriver> {
             process_mode: console_irq_mode().unwrap_or(ProcessMode::Manual),
         },
     )
+}
+
+fn start_console_notify_worker() {
+    if CONSOLE_NOTIFY_WORKER.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    ax_task::spawn_with_name(
+        || loop {
+            CONSOLE_INPUT_NOTIFY.wait();
+            // Console RX readiness has been published by the IRQ handler.
+            unsafe { CONSOLE_INPUT_SOURCE.wake(IoEvents::IN) };
+        },
+        "console-notify".into(),
+    );
 }
 
 /// Probe the connected terminal for its current size using the
@@ -151,6 +172,7 @@ fn console_irq_mode() -> Option<ProcessMode> {
     }
 
     ax_runtime::hal::console::set_input_irq_enabled(true);
+    start_console_notify_worker();
     Some(ProcessMode::InterruptDriven(CONSOLE_INPUT_SOURCE.clone()))
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/pty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/pty.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use ax_kspin::SpinNoIrq;
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 use ringbuf::{
     Cons, HeapRb, Prod,
     traits::{Consumer, Producer},
@@ -47,7 +47,8 @@ impl PtyWriter {
 impl TtyWrite for PtyWriter {
     fn write(&self, buf: &[u8]) {
         let read = self.0.lock().push_slice(buf);
-        self.1.wake();
+        // PTY bytes are committed before waking the peer reader.
+        unsafe { self.1.wake(IoEvents::IN) };
         if read < buf.len() {
             warn!("Discarding {} bytes written to pty", buf.len() - read);
         }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/job.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/job.rs
@@ -70,7 +70,8 @@ impl JobControl {
 
         state.foreground = weak;
         drop(state);
-        self.poll_fg.wake();
+        // Foreground process-group state is published before waking waiters.
+        unsafe { self.poll_fg.wake(IoEvents::IN) };
         Ok(())
     }
 
@@ -109,7 +110,8 @@ impl JobControl {
         drop(state);
 
         if foreground_cleared {
-            self.poll_fg.wake();
+            // Foreground process-group state is published before waking waiters.
+            unsafe { self.poll_fg.wake(IoEvents::IN) };
         }
     }
 }
@@ -123,7 +125,8 @@ impl Pollable for JobControl {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            self.poll_fg.register(context.waker());
+            // Registration happens from tty job-control poll task context.
+            unsafe { self.poll_fg.register(context.waker(), IoEvents::IN) };
         }
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -9,7 +9,7 @@ use core::{
 
 use ax_errno::{AxError, AxResult};
 use ax_task::future::block_on;
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 use linux_raw_sys::general::{
     ECHOCTL, ECHOK, ICRNL, IGNCR, ISIG, ONLCR, OPOST, VEOF, VERASE, VKILL, VMIN, VTIME,
 };
@@ -284,7 +284,8 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         let mut progressed = false;
         while reader.drain_source_into_line_buffer() {
             progressed = true;
-            input_ready.wake();
+            // New line-discipline input is visible before waking readers.
+            unsafe { input_ready.wake(IoEvents::IN) };
         }
         progressed
     }
@@ -311,8 +312,9 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
                         fired: fired.clone(),
                         task: cx.waker().clone(),
                     }));
-                    input_source.register(&waker);
-                    pump_retry.register(&waker);
+                    // The reader task registers from ordinary task context.
+                    unsafe { input_source.register(&waker, IoEvents::IN) };
+                    unsafe { pump_retry.register(&waker, IoEvents::OUT) };
 
                     if Self::drive_input(&mut reader, input_ready.as_ref())
                         || fired.swap(false, Ordering::AcqRel)
@@ -409,7 +411,8 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
     pub fn inject_input(&mut self, input: &[u8]) {
         self.injected_input.extend(input);
-        self.input_ready.clone().wake();
+        // Injected bytes are visible before waking readers.
+        unsafe { self.input_ready.wake(IoEvents::IN) };
     }
 
     pub fn poll_read(&mut self) -> bool {
@@ -434,10 +437,12 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
     pub fn register_rx_waker(&self, waker: &Waker) {
         match &self.processor {
             Processor::InterruptDriven => {
-                self.input_ready.register(waker);
+                // Registration happens from tty read poll context.
+                unsafe { self.input_ready.register(waker, IoEvents::IN) };
             }
             Processor::Passive(_, set) => {
-                set.register(waker);
+                // Registration happens from tty read poll context.
+                unsafe { set.register(waker, IoEvents::IN) };
             }
         }
     }
@@ -497,7 +502,8 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         }
 
         let read = self.buf_rx.pop_slice(buf);
-        self.pump_retry.clone().wake();
+        // Buffer space was freed before waking the input pump.
+        unsafe { self.pump_retry.wake(IoEvents::OUT) };
         Ok(read)
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty_serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty_serial.rs
@@ -2,7 +2,7 @@ use alloc::collections::vec_deque::VecDeque;
 use core::{
     any::Any,
     ptr::NonNull,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     task::Context,
 };
 
@@ -10,7 +10,10 @@ use ax_errno::{AxError, LinuxError};
 use ax_kspin::SpinNoIrq;
 use ax_memory_addr::{PhysAddr, pa};
 use ax_sync::Mutex;
-use ax_task::future::{block_on, poll_io};
+use ax_task::{
+    IrqNotify,
+    future::{block_on, poll_io},
+};
 use axfs_ng_vfs::{NodeFlags, VfsResult};
 use axpoll::{IoEvents, PollSet, Pollable};
 use bytemuck::AnyBitPattern;
@@ -41,6 +44,10 @@ static UART1_RX_BUF: SpinNoIrq<VecDeque<u8>> = SpinNoIrq::new(VecDeque::new());
 static UART2_RX_BUF: SpinNoIrq<VecDeque<u8>> = SpinNoIrq::new(VecDeque::new());
 static UART1_POLL: PollSet = PollSet::new();
 static UART2_POLL: PollSet = PollSet::new();
+static UART1_NOTIFY: IrqNotify = IrqNotify::new();
+static UART2_NOTIFY: IrqNotify = IrqNotify::new();
+static UART1_NOTIFY_WORKER: AtomicBool = AtomicBool::new(false);
+static UART2_NOTIFY_WORKER: AtomicBool = AtomicBool::new(false);
 /// Mapped virtual base of each UART, published by `TtySerial::new` so the raw
 /// IRQ handlers can reach the registers without recomputing a (now invalid on
 /// dynamic platforms) `phys_to_virt` address.
@@ -57,7 +64,7 @@ fn iomap_usize(paddr: PhysAddr, size: usize) -> usize {
         .as_usize()
 }
 
-fn uart_irq_handler(vaddr: usize, buf: &SpinNoIrq<VecDeque<u8>>, poll: &PollSet) {
+fn uart_irq_handler(vaddr: usize, buf: &SpinNoIrq<VecDeque<u8>>, notify: &IrqNotify) {
     let mut uart = DwApbUart::new(vaddr);
     let mut rx = buf.lock();
     let mut got_data = false;
@@ -70,7 +77,7 @@ fn uart_irq_handler(vaddr: usize, buf: &SpinNoIrq<VecDeque<u8>>, poll: &PollSet)
     uart.set_ier(true);
     drop(rx);
     if got_data {
-        poll.wake();
+        notify.notify_irq();
     }
 }
 
@@ -78,14 +85,14 @@ fn uart1_irq_handler(_irq: usize) {
     uart_irq_handler(
         UART1_VADDR.load(Ordering::Relaxed),
         &UART1_RX_BUF,
-        &UART1_POLL,
+        &UART1_NOTIFY,
     );
 }
 fn uart2_irq_handler(_irq: usize) {
     uart_irq_handler(
         UART2_VADDR.load(Ordering::Relaxed),
         &UART2_RX_BUF,
-        &UART2_POLL,
+        &UART2_NOTIFY,
     );
 }
 
@@ -172,31 +179,64 @@ pub struct TtySerial {
     config: Mutex<SerialConfig>,
 }
 
+struct UartPort {
+    paddr: PhysAddr,
+    irq: usize,
+    rx_buf: &'static SpinNoIrq<VecDeque<u8>>,
+    poll_set: &'static PollSet,
+    notify: &'static IrqNotify,
+    worker_started: &'static AtomicBool,
+    vaddr_slot: &'static AtomicUsize,
+    irq_handler: ax_runtime::hal::irq::RawIrqHandler,
+    worker_name: &'static str,
+}
+
+fn start_uart_notify_worker(
+    poll_set: &'static PollSet,
+    notify: &'static IrqNotify,
+    started: &'static AtomicBool,
+    name: &'static str,
+) {
+    if started.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    ax_task::spawn_with_name(
+        move || loop {
+            notify.wait();
+            // UART bytes are already in the RX buffer before the deferred wake.
+            unsafe { poll_set.wake(IoEvents::IN) };
+        },
+        name.into(),
+    );
+}
+
 impl TtySerial {
-    fn new(
-        paddr: PhysAddr,
-        irq: usize,
-        baud: u32,
-        rx_buf: &'static SpinNoIrq<VecDeque<u8>>,
-        poll_set: &'static PollSet,
-        vaddr_slot: &AtomicUsize,
-        irq_handler: ax_runtime::hal::irq::RawIrqHandler,
-    ) -> Self {
-        let vaddr = iomap_usize(paddr, UART_MMIO_SIZE);
+    fn new(port: &'static UartPort, baud: u32) -> Self {
+        let vaddr = iomap_usize(port.paddr, UART_MMIO_SIZE);
         // Publish the mapped base before enabling the IRQ so the handler never
         // observes a zero (unmapped) address.
-        vaddr_slot.store(vaddr, Ordering::Relaxed);
+        port.vaddr_slot.store(vaddr, Ordering::Relaxed);
         let mut uart = DwApbUart::new(vaddr);
         uart.init_with_baud_clk(baud, SG2002_UART_CLOCK);
         uart.set_ier(true);
-        let _ = ax_runtime::hal::irq::request_shared_irq(irq, irq_handler, NonNull::dangling())
-            .map_err(|err| warn!("failed to request serial IRQ {irq}: {err:?}"));
-        ax_runtime::hal::irq::set_enable(irq, true);
+        let _ = ax_runtime::hal::irq::request_shared_irq(
+            port.irq,
+            port.irq_handler,
+            NonNull::dangling(),
+        )
+        .map_err(|err| warn!("failed to request serial IRQ {}: {err:?}", port.irq));
+        ax_runtime::hal::irq::set_enable(port.irq, true);
+        start_uart_notify_worker(
+            port.poll_set,
+            port.notify,
+            port.worker_started,
+            port.worker_name,
+        );
         Self {
             vaddr,
-            irq,
-            rx_buf,
-            poll_set,
+            irq: port.irq,
+            rx_buf: port.rx_buf,
+            poll_set: port.poll_set,
             config: Mutex::new(SerialConfig {
                 termios2: RawTermios2::new(RawTermios::raw(0), baud),
                 winsize: WinSize::default(),
@@ -315,7 +355,8 @@ impl Pollable for TtySerial {
 
     fn register(&self, cx: &mut Context<'_>, events: IoEvents) {
         if events.intersects(IoEvents::IN) {
-            self.poll_set.register(cx.waker());
+            // Serial poll registration happens from task context.
+            unsafe { self.poll_set.register(cx.waker(), IoEvents::IN) };
         }
     }
 }
@@ -330,17 +371,33 @@ fn map_pinmux() -> Pinmux {
     unsafe { Pinmux::new(fmux_vaddr, ioblk_vaddr, ioblk_grtc_vaddr) }
 }
 
+static UART1_PORT: UartPort = UartPort {
+    paddr: UART1_PADDR,
+    irq: UART1_IRQ,
+    rx_buf: &UART1_RX_BUF,
+    poll_set: &UART1_POLL,
+    notify: &UART1_NOTIFY,
+    worker_started: &UART1_NOTIFY_WORKER,
+    vaddr_slot: &UART1_VADDR,
+    irq_handler: uart1_raw_irq_handler,
+    worker_name: "uart1-notify",
+};
+
+static UART2_PORT: UartPort = UartPort {
+    paddr: UART2_PADDR,
+    irq: UART2_IRQ,
+    rx_buf: &UART2_RX_BUF,
+    poll_set: &UART2_POLL,
+    notify: &UART2_NOTIFY,
+    worker_started: &UART2_NOTIFY_WORKER,
+    vaddr_slot: &UART2_VADDR,
+    irq_handler: uart2_raw_irq_handler,
+    worker_name: "uart2-notify",
+};
+
 pub fn new_tty_s1(baud: u32) -> TtySerial {
     map_pinmux().set_uart1();
-    TtySerial::new(
-        UART1_PADDR,
-        UART1_IRQ,
-        baud,
-        &UART1_RX_BUF,
-        &UART1_POLL,
-        &UART1_VADDR,
-        uart1_raw_irq_handler,
-    )
+    TtySerial::new(&UART1_PORT, baud)
 }
 
 pub fn new_tty_s2(baud: u32) -> TtySerial {
@@ -352,13 +409,5 @@ pub fn new_tty_s2(baud: u32) -> TtySerial {
     // to floating pads and the connected device never sees them.
     pinmux.set_iic0_scl_func(FMUX_IIC0_SCL::FSEL::Value::UART2_TX);
     pinmux.set_iic0_sda_func(FMUX_IIC0_SDA::FSEL::Value::UART2_RX);
-    TtySerial::new(
-        UART2_PADDR,
-        UART2_IRQ,
-        baud,
-        &UART2_RX_BUF,
-        &UART2_POLL,
-        &UART2_VADDR,
-        uart2_raw_irq_handler,
-    )
+    TtySerial::new(&UART2_PORT, baud)
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty_serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty_serial.rs
@@ -1,4 +1,3 @@
-use alloc::collections::vec_deque::VecDeque;
 use core::{
     any::Any,
     ptr::NonNull,
@@ -24,7 +23,7 @@ use sg200x_bsp::{
 use some_serial::ns16550::dw_apb::{DwApbUart, SG2002_UART_CLOCK};
 use starry_vm::{VmMutPtr, VmPtr};
 
-use crate::pseudofs::DeviceOps;
+use crate::pseudofs::{DeviceOps, dev::irq_byte_ring::ByteRing};
 
 const UART1_PADDR: PhysAddr = pa!(0x04150000);
 const UART2_PADDR: PhysAddr = pa!(0x04160000);
@@ -40,8 +39,8 @@ const UART_MMIO_SIZE: usize = 0x1000;
 /// same 4K page; GRTC (0x05027000) is mapped separately.
 const PINMUX_MMIO_SIZE: usize = 0x1000;
 
-static UART1_RX_BUF: SpinNoIrq<VecDeque<u8>> = SpinNoIrq::new(VecDeque::new());
-static UART2_RX_BUF: SpinNoIrq<VecDeque<u8>> = SpinNoIrq::new(VecDeque::new());
+static UART1_RX_BUF: SpinNoIrq<ByteRing<RX_BUF_CAP>> = SpinNoIrq::new(ByteRing::new());
+static UART2_RX_BUF: SpinNoIrq<ByteRing<RX_BUF_CAP>> = SpinNoIrq::new(ByteRing::new());
 static UART1_POLL: PollSet = PollSet::new();
 static UART2_POLL: PollSet = PollSet::new();
 static UART1_NOTIFY: IrqNotify = IrqNotify::new();
@@ -64,14 +63,12 @@ fn iomap_usize(paddr: PhysAddr, size: usize) -> usize {
         .as_usize()
 }
 
-fn uart_irq_handler(vaddr: usize, buf: &SpinNoIrq<VecDeque<u8>>, notify: &IrqNotify) {
+fn uart_irq_handler(vaddr: usize, buf: &SpinNoIrq<ByteRing<RX_BUF_CAP>>, notify: &IrqNotify) {
     let mut uart = DwApbUart::new(vaddr);
     let mut rx = buf.lock();
     let mut got_data = false;
     while let Some(c) = uart.getchar() {
-        if rx.len() < RX_BUF_CAP {
-            rx.push_back(c);
-        }
+        let _ = rx.push_back(c);
         got_data = true;
     }
     uart.set_ier(true);
@@ -174,7 +171,7 @@ struct SerialConfig {
 pub struct TtySerial {
     vaddr: usize,
     irq: usize,
-    rx_buf: &'static SpinNoIrq<VecDeque<u8>>,
+    rx_buf: &'static SpinNoIrq<ByteRing<RX_BUF_CAP>>,
     poll_set: &'static PollSet,
     config: Mutex<SerialConfig>,
 }
@@ -182,7 +179,7 @@ pub struct TtySerial {
 struct UartPort {
     paddr: PhysAddr,
     irq: usize,
-    rx_buf: &'static SpinNoIrq<VecDeque<u8>>,
+    rx_buf: &'static SpinNoIrq<ByteRing<RX_BUF_CAP>>,
     poll_set: &'static PollSet,
     notify: &'static IrqNotify,
     worker_started: &'static AtomicBool,
@@ -263,9 +260,7 @@ impl DeviceOps for TtySerial {
                 return Err(AxError::WouldBlock);
             }
             let n = buf.len().min(rx.len());
-            for slot in buf.iter_mut().take(n) {
-                *slot = rx.pop_front().unwrap();
-            }
+            rx.drain_into(&mut buf[..n]);
             Ok(n)
         }))
     }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/irq.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/irq.rs
@@ -198,11 +198,11 @@ fn usbfs_irq_handler(irq_num: usize) {
 
     if let Some(manager) = USBFS_MANAGER.get() {
         if has_usb_activity {
-            manager.notify_usb_activity();
+            manager.notify_usb_activity_from_irq();
         }
         if has_topology_event {
             slot.dirty.store(true, Ordering::Release);
-            manager.refresh_event.notify(1);
+            manager.notify_topology_from_irq();
         }
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
@@ -8,6 +8,7 @@ use core::{
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_kspin::SpinNoIrq as Mutex;
 use ax_sync::Mutex as BlockingMutex;
+use ax_task::IrqNotify;
 use crab_usb::{
     Device, DeviceInfo, Endpoint, ProbedDevice,
     usb_if::{
@@ -17,7 +18,7 @@ use crab_usb::{
         transfer::{Direction, Recipient, Request, RequestType},
     },
 };
-use event_listener::{Event as NotifyEvent, listener};
+use event_listener::Event as NotifyEvent;
 use rdrive::DeviceId as RDriveDeviceId;
 use spin::RwLock;
 use starry_vm::{VmMutPtr, vm_load, vm_write_slice};
@@ -230,8 +231,8 @@ fn wait_control(
 pub(super) struct UsbFsManager {
     state: Mutex<UsbFsState>,
     open_lock: BlockingMutex<()>,
-    pub(super) refresh_event: NotifyEvent,
     usb_activity: UsbActivity,
+    irq_notify: IrqNotify,
 }
 
 struct UsbActivity {
@@ -369,14 +370,22 @@ impl UsbFsManager {
         Self {
             state: Mutex::new(UsbFsState { hosts, devices }),
             open_lock: BlockingMutex::new(()),
-            refresh_event: NotifyEvent::new(),
             usb_activity: UsbActivity::new(),
+            irq_notify: IrqNotify::new(),
         }
     }
 
-    pub(super) fn notify_usb_activity(&self) {
+    pub(super) fn notify_usb_activity_from_irq(&self) {
         self.usb_activity.seq.fetch_add(1, Ordering::AcqRel);
-        self.usb_activity.event.notify(usize::MAX);
+        self.irq_notify.notify_irq();
+    }
+
+    pub(super) fn notify_topology_from_irq(&self) {
+        self.irq_notify.notify_irq();
+    }
+
+    pub(super) fn notify_refresh(&self) {
+        self.irq_notify.notify();
     }
 
     pub(super) fn usb_activity_seq(&self) -> u64 {
@@ -1131,10 +1140,10 @@ fn snapshot_config_blob(snapshot: &UsbDeviceSnapshot, index: usize) -> Option<&[
     None
 }
 
-pub(super) async fn usbfs_refresh_task(manager: Arc<UsbFsManager>) {
+pub(super) fn usbfs_refresh_task(manager: Arc<UsbFsManager>) {
     loop {
-        listener!(manager.refresh_event => refresh_listener);
-        refresh_listener.await;
+        manager.irq_notify.wait();
+        manager.usb_activity.event.notify(usize::MAX);
         manager.refresh_dirty_hosts();
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -1127,7 +1127,11 @@ impl UsbDeviceFile {
                 if self.collect_submitted_urbs(None) || !self.pending_urbs.lock().is_empty() {
                     Poll::Ready(())
                 } else {
-                    self.poll_urbs.register(cx.waker());
+                    // Registration happens from usbfs reap task context.
+                    unsafe {
+                        self.poll_urbs
+                            .register(cx.waker(), IoEvents::IN | IoEvents::OUT)
+                    };
                     if self.collect_submitted_urbs(Some(cx)) || !self.pending_urbs.lock().is_empty()
                     {
                         Poll::Ready(())
@@ -1301,7 +1305,11 @@ impl Pollable for UsbDeviceFile {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.intersects(IoEvents::IN | IoEvents::OUT) {
-            self.poll_urbs.register(context.waker());
+            // Registration happens from usbfs poll task context.
+            unsafe {
+                self.poll_urbs
+                    .register(context.waker(), events & (IoEvents::IN | IoEvents::OUT))
+            };
             if self.collect_submitted_urbs(Some(context)) || !self.pending_urbs.lock().is_empty() {
                 context.waker().wake_by_ref();
             }
@@ -1335,8 +1343,11 @@ fn complete_urb(
     poll_urbs: &Arc<PollSet>,
     completed: CompletedUrb,
 ) {
-    pending_urbs.lock().push_back(completed);
-    poll_urbs.wake();
+    {
+        pending_urbs.lock().push_back(completed);
+    }
+    // Completed URB is queued before waking poll/reap waiters.
+    unsafe { poll_urbs.wake(IoEvents::IN | IoEvents::OUT) };
 }
 
 fn completed_urb_from_result(

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -66,10 +66,10 @@ pub(crate) fn new_usbfs() -> LinuxResult<Option<Filesystem>> {
     info!("usbfs: spawning refresh task");
     let refresh_manager = manager.clone();
     ax_task::spawn_with_name(
-        move || ax_task::future::block_on(manager::usbfs_refresh_task(refresh_manager.clone())),
+        move || manager::usbfs_refresh_task(refresh_manager.clone()),
         "usbfs-refresh".to_owned(),
     );
-    manager.refresh_event.notify(1);
+    manager.notify_refresh();
 
     Ok(Some(create_filesystem(manager)))
 }

--- a/os/StarryOS/kernel/src/syscall/fs/aio.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/aio.rs
@@ -806,7 +806,12 @@ fn poll_result(
             return core::task::Poll::Ready(Ok(ready));
         }
         file.register(cx, interested);
-        context.completion_wakers.register(cx.waker());
+        // Registration happens from AIO worker/wait task context.
+        unsafe {
+            context
+                .completion_wakers
+                .register(cx.waker(), IoEvents::IN | IoEvents::ERR | IoEvents::HUP)
+        };
         // Re-check after registration to avoid losing a destroy or readiness wake.
         if context.destroying.load(Ordering::Acquire) {
             return core::task::Poll::Ready(Err(AxError::Interrupted));
@@ -930,7 +935,12 @@ fn enqueue_completion(context: &AioContext, event: IoEvent) -> AxResult<()> {
         ring_ready_count(context.ring_events, head, next_tail),
         Ordering::Release,
     );
-    context.completion_wakers.wake();
+    // Completion ring tail is published before waking completion waiters.
+    unsafe {
+        context
+            .completion_wakers
+            .wake(IoEvents::IN | IoEvents::ERR | IoEvents::HUP)
+    };
     Ok(())
 }
 
@@ -962,7 +972,12 @@ fn finish_request(context: &AioContext, request: &AioRequest, event: IoEvent) {
         );
     }
     context.inflight_wq.notify_all(true);
-    context.completion_wakers.wake();
+    // Request accounting/completion state is published before waking waiters.
+    unsafe {
+        context
+            .completion_wakers
+            .wake(IoEvents::IN | IoEvents::ERR | IoEvents::HUP)
+    };
 }
 
 // Pop the next queued request and mark it as running.
@@ -1071,7 +1086,12 @@ fn wait_for_completion(
         {
             core::task::Poll::Ready(())
         } else {
-            context.completion_wakers.register(cx.waker());
+            // Registration happens from AIO wait task context.
+            unsafe {
+                context
+                    .completion_wakers
+                    .register(cx.waker(), IoEvents::IN | IoEvents::ERR | IoEvents::HUP)
+            };
             if context.ready_count.load(Ordering::Acquire) != 0
                 || context.destroying.load(Ordering::Acquire)
             {
@@ -1098,7 +1118,12 @@ fn wait_for_inflight_drain(context: &AioContext) {
         }
 
         debug!("sys_io_destroy: still waiting, inflight={}", inflight);
-        context.completion_wakers.register(cx.waker());
+        // Registration happens from io_destroy task context.
+        unsafe {
+            context
+                .completion_wakers
+                .register(cx.waker(), IoEvents::IN | IoEvents::ERR | IoEvents::HUP)
+        };
         // Re-check after registration so the final completion cannot be missed.
         if context.inner.lock().inflight == 0 {
             core::task::Poll::Ready(())
@@ -1275,7 +1300,12 @@ fn destroy_context(context: Arc<AioContext>) {
         );
     }
     context.work_wq.notify_all(true);
-    context.completion_wakers.wake();
+    // Destroying state is published before waking waiters.
+    unsafe {
+        context
+            .completion_wakers
+            .wake(IoEvents::IN | IoEvents::ERR | IoEvents::HUP)
+    };
 
     // Wait outside the inner lock so workers can finish_request.
     warn!("sys_io_destroy: waiting for inflight to drain");
@@ -1459,6 +1489,11 @@ pub fn sys_io_cancel(
     result.vm_write(event)?;
     context.inflight_wq.notify_all(true);
     context.work_wq.notify_one(true);
-    context.completion_wakers.wake();
+    // Cancellation/accounting state is published before waking waiters.
+    unsafe {
+        context
+            .completion_wakers
+            .wake(IoEvents::IN | IoEvents::ERR | IoEvents::HUP)
+    };
     Ok(0)
 }

--- a/os/StarryOS/kernel/src/syscall/task/execve.rs
+++ b/os/StarryOS/kernel/src/syscall/task/execve.rs
@@ -247,7 +247,12 @@ fn do_execve(
             if remaining == 0 {
                 return Poll::Ready(());
             }
-            proc_data.thread_exit_event.register(cx.waker());
+            // Registration happens from execve task context.
+            unsafe {
+                proc_data
+                    .thread_exit_event
+                    .register(cx.waker(), axpoll::IoEvents::IN)
+            };
             // Re-check after registering: a sibling could have exited
             // between the first check and the register, and the wake
             // that fired then would have found an empty waker set.

--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -344,7 +344,12 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
         match check_children().transpose() {
             Some(res) => Poll::Ready(res),
             None => {
-                proc_data.child_exit_event.register(cx.waker());
+                // Registration happens from wait task context.
+                unsafe {
+                    proc_data
+                        .child_exit_event
+                        .register(cx.waker(), axpoll::IoEvents::IN)
+                };
                 // A child may exit between the check above and waker
                 // registration. Recheck after registering so that wakeup is
                 // not lost in that race window.
@@ -488,7 +493,12 @@ pub fn sys_waitid(
         match check_children().transpose() {
             Some(res) => Poll::Ready(res),
             None => {
-                proc_data.child_exit_event.register(cx.waker());
+                // Registration happens from wait task context.
+                unsafe {
+                    proc_data
+                        .child_exit_event
+                        .register(cx.waker(), axpoll::IoEvents::IN)
+                };
                 match check_children().transpose() {
                     Some(res) => Poll::Ready(res),
                     None => Poll::Pending,

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -20,7 +20,7 @@ use core::{
 use ax_runtime::hal::{cpu::uspace::UserContext, time::TimeValue};
 use ax_sync::{Mutex, spin::SpinNoIrq};
 use ax_task::{TaskExt, TaskInner};
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 use extern_trait::extern_trait;
 use kernel_elf_parser::AuxEntry;
 use scope_local::{ActiveScope, Scope};
@@ -1017,7 +1017,8 @@ impl ProcessData {
             drop(jc);
             // Wake only when a thread was actually parked; avoids spurious
             // wakeups on SIGCONT to an already-running process.
-            self.cont_event.wake();
+            // Continue state is published before waking stopped threads.
+            unsafe { self.cont_event.wake(IoEvents::IN) };
         }
         was_stopped
     }
@@ -1027,7 +1028,8 @@ impl ProcessData {
     pub fn clear_job_stop_for_kill(&self) {
         let was_stopped = self.job_control.lock().stopped.take().is_some();
         if was_stopped {
-            self.cont_event.wake();
+            // Stop state is cleared before waking stopped threads.
+            unsafe { self.cont_event.wake(IoEvents::IN) };
         }
     }
 
@@ -1344,7 +1346,8 @@ impl ProcessData {
             stop.event = 0;
             stop.event_msg = 0;
         }
-        self.ptrace_stop_event.wake();
+        // Ptrace stop state is updated before waking waiters.
+        unsafe { self.ptrace_stop_event.wake(IoEvents::IN) };
     }
 
     /// Resume the stopped task without injecting a signal.
@@ -1399,7 +1402,8 @@ impl ProcessData {
         self.ptrace_syscall_trace.lock().clear();
         self.ptrace_ss_saved_insn.lock().clear();
         self.ptrace_stop_fp_data.lock().clear();
-        self.ptrace_stop_event.wake();
+        // Ptrace stop state is cleared before waking waiters.
+        unsafe { self.ptrace_stop_event.wake(IoEvents::IN) };
     }
 
     pub fn set_ptrace_exec_stop_pending(&self) {
@@ -1414,7 +1418,8 @@ impl ProcessData {
 
     /// Register a waiter for changes to this process's ptrace stop state.
     pub fn register_ptrace_stop_waker(&self, waker: &core::task::Waker) {
-        self.ptrace_stop_event.register(waker);
+        // Registration happens from task/wait context.
+        unsafe { self.ptrace_stop_event.register(waker, IoEvents::IN) };
     }
 
     pub fn set_ptrace_attached(&self) {
@@ -1769,7 +1774,8 @@ impl ProcessData {
                 core::future::poll_fn(|cx| {
                     // Register before re-checking so a notify that fires
                     // between our last check and this register isn't lost.
-                    poll.register(cx.waker());
+                    // Registration happens from the vfork parent task context.
+                    unsafe { poll.register(cx.waker(), IoEvents::IN) };
                     let done = self
                         .vfork_done
                         .lock()
@@ -1812,7 +1818,8 @@ impl ProcessData {
             }
             // guard dropped here
         };
-        poll.wake();
+        // vfork completion is published before waking the parent.
+        unsafe { poll.wake(IoEvents::IN) };
     }
 }
 

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -599,7 +599,8 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
                 let _ = send_signal_to_process(parent.pid(), Some(sig));
             }
             if let Ok(data) = get_process_data(parent.pid()) {
-                data.child_exit_event.wake();
+                // Child exit state is published before waking waiters.
+                unsafe { data.child_exit_event.wake(axpoll::IoEvents::IN) };
             }
         }
         if let Some(tracer_pid) = ptrace_tracer_pid
@@ -608,7 +609,8 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
                 .is_none_or(|parent| parent.pid() != tracer_pid)
             && let Ok(data) = get_process_data(tracer_pid)
         {
-            data.child_exit_event.wake();
+            // Child exit state is published before waking waiters.
+            unsafe { data.child_exit_event.wake(axpoll::IoEvents::IN) };
         }
         // Send pdeathsig to child processes
         for child in children_snapshot {
@@ -625,7 +627,8 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
             }
         }
 
-        thr.proc_data.exit_event.wake();
+        // Process exit state is published before waking pidfd/wait waiters.
+        unsafe { thr.proc_data.exit_event.wake(axpoll::IoEvents::IN) };
 
         // Unblock a vfork parent waiting for this child to exit.
         thr.proc_data.notify_vfork_done();
@@ -636,8 +639,9 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
         // process_slots refcounting — not vm_aspace_shared + clear().
         thr.proc_data.release_aspace_slot_if_needed();
     }
-    thr.exit_event.wake();
-    thr.proc_data.thread_exit_event.wake();
+    // Thread exit state is published before waking waiters.
+    unsafe { thr.exit_event.wake(axpoll::IoEvents::IN) };
+    unsafe { thr.proc_data.thread_exit_event.wake(axpoll::IoEvents::IN) };
 
     if group_exit && !process.is_group_exited() {
         process.group_exit();

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -287,7 +287,8 @@ fn notify_ptrace_waiter(thr: &Thread, signo: Signo) {
             signo as i32,
         );
         let _ = send_signal_to_process(waiter_pid, Some(sigchld));
-        parent_data.child_exit_event.wake();
+        // Ptrace stop report is published before waking waiters.
+        unsafe { parent_data.child_exit_event.wake(axpoll::IoEvents::IN) };
     }
 }
 
@@ -416,7 +417,8 @@ fn notify_parent_job_change(proc_data: &ProcessData, code: i32, status: i32) {
     let sig = SignalInfo::new_sigchld(proc.pid(), child_uid, code, status);
     let _ = send_signal_to_process(parent.pid(), Some(sig));
     if let Ok(data) = get_process_data(parent.pid()) {
-        data.child_exit_event.wake();
+        // Job-control report is published before waking waiters.
+        unsafe { data.child_exit_event.wake(axpoll::IoEvents::IN) };
     }
 }
 
@@ -455,7 +457,8 @@ fn do_job_stop(thr: &Thread, signo: Signo) {
         if !proc_data.is_job_stopped() {
             return Poll::Ready(());
         }
-        cont_event.register(cx.waker());
+        // Registration happens from the stopped task context.
+        unsafe { cont_event.register(cx.waker(), axpoll::IoEvents::IN) };
         // Re-check after registering to avoid a lost wakeup if the continue
         // landed between the check above and registration.
         if proc_data.is_job_stopped() {

--- a/os/StarryOS/kernel/src/tracepoint/mod.rs
+++ b/os/StarryOS/kernel/src/tracepoint/mod.rs
@@ -5,7 +5,11 @@ mod trace;
 mod trace_pipe;
 
 use alloc::{collections::BTreeMap, string::ToString, sync::Arc, vec::Vec};
-use core::{num::NonZero, ops::Deref};
+use core::{
+    num::NonZero,
+    ops::Deref,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use ax_errno::{AxError, AxResult};
 use ax_kspin::SpinNoPreempt;
@@ -13,9 +17,9 @@ use ax_lazyinit::LazyInit;
 use ax_memory_addr::VirtAddr;
 use ax_runtime::hal::{percpu::this_cpu_id, time::monotonic_time_nanos};
 use ax_sync::Mutex;
-use ax_task::current;
+use ax_task::{IrqNotify, current};
 use axfs_ng_vfs::NodePermission;
-use axpoll::PollSet;
+use axpoll::{IoEvents, PollSet};
 use ktracepoint::*;
 
 use crate::{
@@ -58,6 +62,7 @@ struct TraceState {
     point_map: LazyInit<TracePointMap<KernelTraceAux>>,
     raw_pipe: Mutex<TracePipeRaw>,
     pipe_event: PollSet,
+    pipe_notify: IrqNotify,
     cmdline_cache: LazyInit<Mutex<TraceCmdLineCache>>,
     ext_tracepoints: LazyInit<BTreeMap<u32, KernelExtTracePoint>>,
 }
@@ -68,6 +73,7 @@ impl TraceState {
             point_map: LazyInit::new(),
             raw_pipe: Mutex::new(TracePipeRaw::new(4096)),
             pipe_event: PollSet::new(),
+            pipe_notify: IrqNotify::new(),
             cmdline_cache: LazyInit::new(),
             ext_tracepoints: LazyInit::new(),
         }
@@ -75,6 +81,7 @@ impl TraceState {
 }
 
 static TRACE_STATE: TraceState = TraceState::new();
+static TRACE_PIPE_NOTIFY_WORKER: AtomicBool = AtomicBool::new(false);
 
 pub struct KernelTraceAux;
 
@@ -92,7 +99,7 @@ impl KernelTraceOps for KernelTraceAux {
             this_cpu_id() as _,
             buf.to_vec(),
         );
-        TRACE_STATE.pipe_event.wake();
+        TRACE_STATE.pipe_notify.notify_irq();
     }
 
     fn trace_cmdline_push(pid: u32) {
@@ -132,6 +139,20 @@ impl KernelTraceOps for KernelTraceAux {
         let mut ext_tp = ext_tp.lock();
         f(&mut ext_tp)
     }
+}
+
+fn start_trace_pipe_notify_worker() {
+    if TRACE_PIPE_NOTIFY_WORKER.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    ax_task::spawn_with_name(
+        || loop {
+            TRACE_STATE.pipe_notify.wait();
+            // Trace records are queued before the deferred poll wake.
+            unsafe { TRACE_STATE.pipe_event.wake(IoEvents::IN) };
+        },
+        "trace-pipe-notify".into(),
+    );
 }
 
 /// Carries the unread suffix of a formatted text record across `read_at` calls.
@@ -258,6 +279,7 @@ pub fn tracepoint_init() -> AxResult<()> {
         .init_once(Mutex::new(TraceCmdLineCache::new(
             NonZero::new(4096).unwrap(),
         )));
+    start_trace_pipe_notify_worker();
     Ok(())
 }
 

--- a/os/StarryOS/kernel/src/tracepoint/trace_pipe.rs
+++ b/os/StarryOS/kernel/src/tracepoint/trace_pipe.rs
@@ -49,7 +49,12 @@ impl DirectRwFsFileOps for TracePipeFile {
             let _result = block_on(interruptible(poll_fn(|cx| match self.readable() {
                 true => Poll::Ready(true),
                 false => {
-                    super::TRACE_STATE.pipe_event.register(cx.waker());
+                    // Registration happens from trace_pipe read task context.
+                    unsafe {
+                        super::TRACE_STATE
+                            .pipe_event
+                            .register(cx.waker(), axpoll::IoEvents::IN)
+                    };
                     if self.readable() {
                         Poll::Ready(true)
                     } else {

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -51,7 +51,12 @@ sched-cfs = ["multitask", "preempt"]
 sched-fifo = ["multitask"]
 sched-rr = ["multitask", "preempt"]
 
-host-test = ["ax-kspin?/host-test", "ax-percpu?/sp-naive"]
+host-test = [
+  "ax-hal/host-test",
+  "ax-kspin?/host-test",
+  "ax-kspin?/smp",
+  "ax-percpu?/sp-naive",
+]
 test = ["host-test"]
 
 [dependencies]

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -423,7 +423,7 @@ pub fn run_idle() -> ! {
     loop {
         yield_now_unchecked();
         trace!("idle task: waiting for IRQs...");
-        #[cfg(feature = "irq")]
+        #[cfg(all(feature = "irq", not(feature = "host-test")))]
         ax_hal::asm::wait_for_irqs();
     }
 }

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -134,21 +134,21 @@ pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
 
     ensure_drain_spawned();
 
-    let should_install = {
+    let (poll, should_install) = {
         let mut map = IRQ_STATE.lock();
         let state = map.entry(irq).or_insert_with(|| IrqPollState {
             pending: false,
             installed: false,
             poll: Arc::new(PollSet::new()),
         });
-        unsafe { state.poll.register(waker, axpoll::IoEvents::all()) };
         if state.installed {
-            false
+            (state.poll.clone(), false)
         } else {
             state.installed = true;
-            true
+            (state.poll.clone(), true)
         }
     };
+    unsafe { poll.register(waker, axpoll::IoEvents::all()) };
 
     if should_install {
         ax_hal::irq::request_shared_irq(irq, irq_waker_handler, NonNull::dangling())

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -70,44 +70,29 @@ pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
     use ax_kspin::SpinNoIrq;
     use axpoll::PollSet;
 
-    use crate::WaitQueue;
+    use crate::IrqNotify;
 
-    /// Maximum IRQ number we track in the pending-bit array. The drain
-    /// task scans IRQ_PENDING by index, so IRQs outside this range have
-    /// no observable pending bit and the waker would never fire. We
-    /// reject those at registration rather than silently dropping them.
-    const MAX_TRACKED_IRQ: usize = 256;
-
-    static IRQ_PENDING: [AtomicBool; MAX_TRACKED_IRQ] =
-        [const { AtomicBool::new(false) }; MAX_TRACKED_IRQ];
-    static IRQ_ACTION_INSTALLED: [AtomicBool; MAX_TRACKED_IRQ] =
-        [const { AtomicBool::new(false) }; MAX_TRACKED_IRQ];
-    static ANY_PENDING: AtomicBool = AtomicBool::new(false);
-    static DRAIN_WQ: WaitQueue = WaitQueue::new();
+    static IRQ_NOTIFY: IrqNotify = IrqNotify::new();
     static DRAIN_SPAWNED: AtomicBool = AtomicBool::new(false);
-    static POLL_IRQ: SpinNoIrq<BTreeMap<usize, Arc<PollSet>>> = SpinNoIrq::new(BTreeMap::new());
+    static IRQ_STATE: SpinNoIrq<BTreeMap<usize, IrqPollState>> = SpinNoIrq::new(BTreeMap::new());
+
+    struct IrqPollState {
+        pending: bool,
+        installed: bool,
+        poll: Arc<PollSet>,
+    }
 
     unsafe fn irq_waker_handler(
         ctx: ax_hal::irq::IrqContext,
         _data: NonNull<()>,
     ) -> ax_hal::irq::IrqReturn {
-        // Runs in IRQ context with interrupts off. Only atomics and a
-        // `WaitQueue::notify_one` — no allocation, no PollSet/Inner
-        // replacement.
-        let irq = ctx.irq.0;
-        if irq < MAX_TRACKED_IRQ {
-            IRQ_PENDING[irq].store(true, Ordering::Release);
-            ANY_PENDING.store(true, Ordering::Release);
-            // `resched = false` because we cannot preempt from an IRQ
-            // hook — let the scheduler run the drain task when the
-            // current task next yields or reschedules.
-            DRAIN_WQ.notify_one(false);
+        // Runs in IRQ context with interrupts off. Only mark an already
+        // registered slot and notify the drain task. The map entry is created
+        // during task-context registration, so this path does not allocate.
+        if let Some(state) = IRQ_STATE.lock().get_mut(&ctx.irq.0) {
+            state.pending = true;
+            IRQ_NOTIFY.notify_irq();
         }
-        // IRQs >= MAX_TRACKED_IRQ are intentionally not tracked here.
-        // register_irq_waker rejects those at registration, so reaching
-        // this path means some other subsystem installed a handler on a
-        // high IRQ — leave it alone instead of setting ANY_PENDING and
-        // making the drain task spin.
         ax_hal::irq::IrqReturn::Handled
     }
 
@@ -121,11 +106,7 @@ pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
         crate::spawn_raw(
             || {
                 loop {
-                    // Block until at least one IRQ pending bit has
-                    // been set. `wait_until` re-checks the condition
-                    // under the wait-queue lock, so spurious wakeups
-                    // do not slip through.
-                    DRAIN_WQ.wait_until(|| ANY_PENDING.swap(false, Ordering::AcqRel));
+                    IRQ_NOTIFY.wait();
 
                     // Snapshot the entries that need waking under the
                     // map lock, then drop the lock before invoking
@@ -133,17 +114,16 @@ pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
                     // scheduler).
                     let mut to_wake: alloc::vec::Vec<Arc<PollSet>> = alloc::vec::Vec::new();
                     {
-                        let map = POLL_IRQ.lock();
-                        for (irq, slot) in IRQ_PENDING.iter().enumerate() {
-                            if slot.swap(false, Ordering::AcqRel)
-                                && let Some(set) = map.get(&irq)
-                            {
-                                to_wake.push(set.clone());
+                        let mut map = IRQ_STATE.lock();
+                        for state in map.values_mut() {
+                            if state.pending {
+                                state.pending = false;
+                                to_wake.push(state.poll.clone());
                             }
                         }
                     }
                     for set in to_wake {
-                        set.wake();
+                        unsafe { set.wake(axpoll::IoEvents::all()) };
                     }
                 }
             },
@@ -152,29 +132,28 @@ pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
         );
     }
 
-    if irq >= MAX_TRACKED_IRQ {
-        warn!(
-            "register_irq_waker: IRQ {irq} exceeds MAX_TRACKED_IRQ={MAX_TRACKED_IRQ}; ignoring \
-             registration to avoid silently dropping wakeups"
-        );
-        return;
-    }
-
     ensure_drain_spawned();
 
-    if IRQ_ACTION_INSTALLED[irq]
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_ok()
-    {
+    let should_install = {
+        let mut map = IRQ_STATE.lock();
+        let state = map.entry(irq).or_insert_with(|| IrqPollState {
+            pending: false,
+            installed: false,
+            poll: Arc::new(PollSet::new()),
+        });
+        unsafe { state.poll.register(waker, axpoll::IoEvents::all()) };
+        if state.installed {
+            false
+        } else {
+            state.installed = true;
+            true
+        }
+    };
+
+    if should_install {
         ax_hal::irq::request_shared_irq(irq, irq_waker_handler, NonNull::dangling())
             .expect("axtask IRQ-waker bridge could not install shared IRQ action");
     }
-
-    POLL_IRQ
-        .lock()
-        .entry(irq)
-        .or_insert_with(|| Arc::new(PollSet::new()))
-        .register(waker);
 
     ax_hal::irq::set_enable(irq, true);
 }

--- a/os/arceos/modules/axtask/src/irq_notify.rs
+++ b/os/arceos/modules/axtask/src/irq_notify.rs
@@ -1,0 +1,69 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use crate::WaitQueue;
+
+/// IRQ-safe deferred notification primitive.
+///
+/// `IrqNotify` separates a hard-IRQ notification from the slow work that must
+/// run in task context. IRQ handlers call [`notify_irq`](Self::notify_irq) to
+/// publish a pending bit and wake a deferred worker. The worker then drains the
+/// bit and performs the expensive work, such as polling a device or waking
+/// `axpoll` waiters.
+pub struct IrqNotify {
+    pending: AtomicBool,
+    wait: WaitQueue,
+}
+
+impl Default for IrqNotify {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IrqNotify {
+    /// Creates an empty notification object.
+    pub const fn new() -> Self {
+        Self {
+            pending: AtomicBool::new(false),
+            wait: WaitQueue::new(),
+        }
+    }
+
+    /// Publishes a pending notification from IRQ context.
+    ///
+    /// This method is IRQ-safe: it does not allocate, does not call arbitrary
+    /// wakers, and does not perform slow poll wakeups. Repeated notifications
+    /// coalesce into one pending bit until a worker drains it.
+    pub fn notify_irq(&self) {
+        self.pending.store(true, Ordering::Release);
+        self.wait.notify_one_from_irq();
+    }
+
+    /// Publishes a pending notification from task context.
+    ///
+    /// Prefer [`notify_irq`](Self::notify_irq) inside hard IRQ callbacks. This
+    /// method exists for task/deferred code that wants the same coalescing
+    /// behavior while still allowing the scheduler to observe a normal wake.
+    pub fn notify(&self) {
+        self.pending.store(true, Ordering::Release);
+        self.wait.notify_one(true);
+    }
+
+    /// Returns whether a notification is currently pending.
+    pub fn is_pending(&self) -> bool {
+        self.pending.load(Ordering::Acquire)
+    }
+
+    /// Drains the pending bit.
+    ///
+    /// Returns `true` if at least one notification was pending.
+    pub fn drain(&self) -> bool {
+        self.pending.swap(false, Ordering::AcqRel)
+    }
+
+    /// Blocks until at least one pending notification is available, then drains it.
+    #[track_caller]
+    pub fn wait(&self) {
+        self.wait.wait_until(|| self.drain());
+    }
+}

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -71,6 +71,8 @@ cfg_if::cfg_if! {
         mod lockdep;
         #[cfg(feature = "tracepoint-hooks")]
         mod sched_tracepoint;
+        #[cfg(feature = "irq")]
+        mod irq_notify;
         mod wait_queue;
 
         #[cfg(feature = "irq")]
@@ -81,6 +83,8 @@ cfg_if::cfg_if! {
 
         #[cfg_attr(doc, doc(cfg(feature = "multitask")))]
         pub use self::api::*;
+        #[cfg(feature = "irq")]
+        pub use self::irq_notify::IrqNotify;
         pub use self::api::{sleep, sleep_until, yield_now};
         #[cfg(feature = "tracepoint-hooks")]
         pub use self::sched_tracepoint::SchedTracepoint;

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -969,7 +969,7 @@ extern "C" fn task_entry() -> ! {
         crate::run_queue::clear_prev_task_on_cpu();
     }
     // Enable irq (if feature "irq" is enabled) before running the task entry function.
-    #[cfg(feature = "irq")]
+    #[cfg(all(feature = "irq", not(feature = "host-test")))]
     ax_hal::asm::enable_irqs();
     let task = crate::current();
     if let Some(entry) = task.entry.take() {

--- a/os/arceos/modules/axtask/src/tests.rs
+++ b/os/arceos/modules/axtask/src/tests.rs
@@ -1,10 +1,12 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::{
     panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
-    sync::{OnceLock, mpsc},
+    sync::{Arc, Barrier, OnceLock, mpsc},
     thread,
 };
 
+#[cfg(feature = "irq")]
+use crate::IrqNotify;
 use crate::{WaitQueue, api as ax_task, current};
 
 type TestResult = Result<(), Box<dyn core::any::Any + Send>>;
@@ -34,9 +36,9 @@ where
     }
 }
 
-#[cfg(feature = "lockdep")]
+#[cfg(any(feature = "lockdep", feature = "preempt"))]
 const RAW_TASK_STACK_SIZE: usize = 0x10000;
-#[cfg(not(feature = "lockdep"))]
+#[cfg(not(any(feature = "lockdep", feature = "preempt")))]
 const RAW_TASK_STACK_SIZE: usize = 0x1000;
 
 #[test]
@@ -47,8 +49,9 @@ fn test_sched_fifo() {
 
         FINISHED_TASKS.store(0, Ordering::Release);
 
+        let mut tasks = Vec::with_capacity(NUM_TASKS);
         for i in 0..NUM_TASKS {
-            ax_task::spawn_raw(
+            tasks.push(ax_task::spawn_raw(
                 move || {
                     println!("sched-fifo: Hello, task {}! ({})", i, current().id_name());
                     ax_task::yield_now();
@@ -57,12 +60,13 @@ fn test_sched_fifo() {
                 },
                 format!("T{i}"),
                 RAW_TASK_STACK_SIZE,
-            );
+            ));
         }
 
-        while FINISHED_TASKS.load(Ordering::Acquire) < NUM_TASKS {
-            ax_task::yield_now();
+        for task in tasks {
+            assert_eq!(task.join(), 0);
         }
+        assert_eq!(FINISHED_TASKS.load(Ordering::Acquire), NUM_TASKS);
     });
 }
 
@@ -81,8 +85,9 @@ fn test_fp_state_switch() {
 
         FINISHED_TASKS.store(0, Ordering::Release);
 
+        let mut tasks = Vec::with_capacity(NUM_TASKS);
         for (i, float) in FLOATS.iter().enumerate() {
-            ax_task::spawn(move || {
+            tasks.push(ax_task::spawn(move || {
                 let mut value = float + i as f64;
                 ax_task::yield_now();
                 value -= i as f64;
@@ -90,11 +95,12 @@ fn test_fp_state_switch() {
                 println!("fp_state_switch: Float {i} = {value}");
                 assert!((value - float).abs() < 1e-9);
                 FINISHED_TASKS.fetch_add(1, Ordering::Release);
-            });
+            }));
         }
-        while FINISHED_TASKS.load(Ordering::Acquire) < NUM_TASKS {
-            ax_task::yield_now();
+        for task in tasks {
+            assert_eq!(task.join(), 0);
         }
+        assert_eq!(FINISHED_TASKS.load(Ordering::Acquire), NUM_TASKS);
     });
 }
 
@@ -134,6 +140,186 @@ fn test_wait_queue() {
         );
         WQ1.wait_until(|| COUNTER.load(Ordering::Acquire) == 0);
         assert_eq!(COUNTER.load(Ordering::Acquire), 0);
+    });
+}
+
+#[cfg(feature = "irq")]
+#[test]
+fn test_irq_notify_coalesces_concurrent_irq_callbacks() {
+    const NUM_IRQ_THREADS: usize = 8;
+    const NOTIFIES_PER_THREAD: usize = 32;
+
+    let notify = Arc::new(IrqNotify::new());
+    let barrier = Arc::new(Barrier::new(NUM_IRQ_THREADS));
+    let mut handles = Vec::with_capacity(NUM_IRQ_THREADS);
+
+    for _ in 0..NUM_IRQ_THREADS {
+        let notify = notify.clone();
+        let barrier = barrier.clone();
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            for _ in 0..NOTIFIES_PER_THREAD {
+                notify.notify_irq();
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    assert!(notify.is_pending());
+    assert!(notify.drain());
+    assert!(!notify.drain());
+}
+
+#[cfg(feature = "irq")]
+#[test]
+fn test_irq_notify_wait_observes_notify_before_wait() {
+    run_in_test_scheduler(|| {
+        let notify = IrqNotify::new();
+
+        notify.notify_irq();
+        notify.wait();
+
+        assert!(!notify.is_pending());
+        assert!(!notify.drain());
+    });
+}
+
+#[cfg(feature = "irq")]
+#[test]
+fn test_irq_notify_wakes_sleeping_deferred_worker() {
+    run_in_test_scheduler(|| {
+        let notify = Arc::new(IrqNotify::new());
+        let started_wq = Arc::new(WaitQueue::new());
+        let started = Arc::new(AtomicUsize::new(0));
+        let finished = Arc::new(AtomicUsize::new(0));
+
+        let worker = {
+            let notify = notify.clone();
+            let started_wq = started_wq.clone();
+            let started = started.clone();
+            let finished = finished.clone();
+            ax_task::spawn(move || {
+                started.store(1, Ordering::Release);
+                started_wq.notify_one(true);
+
+                notify.wait();
+
+                finished.store(1, Ordering::Release);
+            })
+        };
+
+        started_wq.wait_until(|| started.load(Ordering::Acquire) == 1);
+        assert_eq!(finished.load(Ordering::Acquire), 0);
+
+        notify.notify_irq();
+        for _ in 0..64 {
+            if finished.load(Ordering::Acquire) == 1 {
+                break;
+            }
+            ax_task::yield_now();
+        }
+
+        assert_eq!(finished.load(Ordering::Acquire), 1);
+        assert!(!notify.drain());
+        assert_eq!(worker.join(), 0);
+    });
+}
+
+#[cfg(feature = "irq")]
+#[test]
+fn test_irq_notify_wakes_after_concurrent_irq_callbacks() {
+    run_in_test_scheduler(|| {
+        const NUM_IRQ_THREADS: usize = 6;
+
+        let notify = Arc::new(IrqNotify::new());
+        let started_wq = Arc::new(WaitQueue::new());
+        let started = Arc::new(AtomicUsize::new(0));
+        let finished = Arc::new(AtomicUsize::new(0));
+
+        let worker = {
+            let notify = notify.clone();
+            let started_wq = started_wq.clone();
+            let started = started.clone();
+            let finished = finished.clone();
+            ax_task::spawn(move || {
+                started.store(1, Ordering::Release);
+                started_wq.notify_one(true);
+
+                notify.wait();
+
+                finished.fetch_add(1, Ordering::Release);
+            })
+        };
+
+        started_wq.wait_until(|| started.load(Ordering::Acquire) == 1);
+
+        let barrier = Arc::new(Barrier::new(NUM_IRQ_THREADS));
+        let mut handles = Vec::with_capacity(NUM_IRQ_THREADS);
+        for _ in 0..NUM_IRQ_THREADS {
+            let notify = notify.clone();
+            let barrier = barrier.clone();
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                notify.notify_irq();
+            }));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        for _ in 0..64 {
+            if finished.load(Ordering::Acquire) == 1 {
+                break;
+            }
+            ax_task::yield_now();
+        }
+
+        assert_eq!(finished.load(Ordering::Acquire), 1);
+        assert_eq!(worker.join(), 0);
+    });
+}
+
+#[cfg(feature = "irq")]
+#[test]
+fn test_wait_queue_irq_notify_all_wakes_sleepers() {
+    run_in_test_scheduler(|| {
+        const NUM_SLEEPERS: usize = 4;
+
+        let wait_queue = Arc::new(WaitQueue::new());
+        let started_wq = Arc::new(WaitQueue::new());
+        let started = Arc::new(AtomicUsize::new(0));
+        let finished = Arc::new(AtomicUsize::new(0));
+        let released = Arc::new(core::sync::atomic::AtomicBool::new(false));
+
+        let mut sleepers = Vec::with_capacity(NUM_SLEEPERS);
+        for _ in 0..NUM_SLEEPERS {
+            let wait_queue = wait_queue.clone();
+            let started_wq = started_wq.clone();
+            let started = started.clone();
+            let finished = finished.clone();
+            let released = released.clone();
+            sleepers.push(ax_task::spawn(move || {
+                started.fetch_add(1, Ordering::Release);
+                started_wq.notify_one(true);
+
+                wait_queue.wait_until(|| released.load(Ordering::Acquire));
+
+                finished.fetch_add(1, Ordering::Release);
+            }));
+        }
+
+        started_wq.wait_until(|| started.load(Ordering::Acquire) == NUM_SLEEPERS);
+        assert_eq!(finished.load(Ordering::Acquire), 0);
+
+        released.store(true, Ordering::Release);
+        wait_queue.notify_all_from_irq();
+        for sleeper in sleepers {
+            assert_eq!(sleeper.join(), 0);
+        }
+        assert_eq!(finished.load(Ordering::Acquire), NUM_SLEEPERS);
     });
 }
 

--- a/os/arceos/modules/axtask/src/wait_queue.rs
+++ b/os/arceos/modules/axtask/src/wait_queue.rs
@@ -191,6 +191,15 @@ impl WaitQueue {
         }
     }
 
+    /// Wakes up one task from IRQ context.
+    ///
+    /// This method is intended for low-level deferred notification paths. It
+    /// does not request an immediate reschedule and it must not be used as a
+    /// substitute for publishing the condition that the waiter will observe.
+    pub fn notify_one_from_irq(&self) -> bool {
+        self.notify_one(false)
+    }
+
     /// Wakes up one task in the wait queue and runs a callback on it.
     ///
     /// The callback `func` is invoked while holding the wait-queue lock and
@@ -221,6 +230,17 @@ impl WaitQueue {
     /// If `resched` is true, the current task will yield.
     pub fn notify_all(&self, resched: bool) {
         while self.notify_one(resched) {
+            // loop until the wait queue is empty
+        }
+    }
+
+    /// Wakes all tasks from IRQ context.
+    ///
+    /// This method is intended for low-level deferred notification paths. It
+    /// does not request an immediate reschedule and it must not be used as a
+    /// substitute for publishing the condition that waiters will observe.
+    pub fn notify_all_from_irq(&self) {
+        while self.notify_one_from_irq() {
             // loop until the wait queue is empty
         }
     }


### PR DESCRIPTION
## 背景

关联 #1272。现有 `axpoll::PollSet` 是无事件掩码的 register/wake 模型，调用点无法显式表达 interested events；同时部分 IRQ/回调路径存在直接推进 poll wake 或 waker 执行的风险，接口也没有清楚标注只能在 task/deferred context 使用。这会让 hard IRQ 路径承担锁重入、分配、运行 waker 等不适合中断上下文的行为。

## 变更

- 将 `axpoll::PollSet` 改为 mask-aware API：`register(waker, interests)` 和 `wake(ready)` 都显式携带 `IoEvents`，并删除旧的无参兼容 wrapper。
- 将 `PollSet::register` / `PollSet::wake` 标为 `unsafe fn`，Rustdoc `# Safety` 明确 task/deferred-only、禁止 hard IRQ/NMI/trap callback 调用、禁止持有会被 poll path 重入获取的锁，并要求 wake 前先发布 readiness/pending 状态。
- 调整 `PollSet` 内部实现：锁内只完成 entry 收集、替换和重排，真正执行 `Waker::wake()` 的路径全部放到释放 `PollSet` 锁之后；满容量覆盖旧 waker 时也在锁外唤醒，避免重入同一个 poll set 或 poll path。
- 在 `axtask` 增加通用 `IrqNotify`，并为 `WaitQueue` 增加 `notify_one_from_irq()` / `notify_all_from_irq()`；`register_irq_waker()` 复用该 primitive，移除固定 pending array 和 `<256` 限制，并避免在持有全局 IRQ map 锁时注册 poll waker。
- 在 `ax-net` 增加专用 `wake_net_task_irq()` 包装，中断/OOB RX 回调只发布 pending 并唤醒 net deferred worker，worker 在普通上下文推进协议栈和 poll wake。
- Rebase 到最新 `dev` 后，同步迁移 `ax-net` 新增的 listen table/TCP smoltcp waker 桥：使用局部 `Wake` 适配器显式传递 `IoEvents`，不恢复 `PollSet: Wake` 兼容层。
- 进一步调整 `ax-net` rebase 后的锁边界：设备 readiness poll set 只在设备锁内克隆，`PollSet::register/wake` 均在锁外执行；listen-table/TCP smoltcp waker 通过 `ax-net` 内部 deferred poll wake 队列延后到 net worker 外层 drain，避免在 service/socket/listen-table 锁内执行 poll waker。
- 拆分 `rd-net::IrqHandler` 的 IRQ fast path：`handle_irq()` 只提取/清除设备事件并返回 queue event bits，普通 `handle()` 仍保留给 task/deferred context 执行 queue waker。
- 批量迁移 Starry 的 pipe、eventfd、timerfd、signalfd、inotify、io_uring、netlink、packet、tty、epoll、trace/perf 等调用点，所有 poll 注册/唤醒都显式传入 `IoEvents`；tty/trace/perf 的 IRQ 通知改为 deferred wake。
- 将 Starry UART/相机 IRQ RX 缓冲从 `VecDeque` 改为固定容量 `ByteRing`，避免 hard IRQ 中 `push_back` 触发堆分配；KPU IRQ 改用 `WaitQueue::notify_all_from_irq()`。
- 将 Starry USBFS 自己的 `event_listener::Event::notify` 从 raw IRQ 中移出：IRQ 中只更新 activity seq/dirty bit 并调用 `IrqNotify::notify_irq()`，`usbfs-refresh` 任务在普通上下文唤醒 activity listener 和刷新 dirty host。
- 增加 `axpoll` mask/concurrency/reentrant wake 测试、`ax-task` IRQ notify 模拟 OS 测试，以及 `rd-net` IRQ fast path 不执行 queue waker 的单元测试。

## 方案逻辑

IRQ callback 只做少量状态搬运、发布 atomic pending/event bits，并调用 `IrqNotify::notify_irq()`。真正的 `PollSet::wake()` 统一在 task/deferred worker context 中执行，且在唤醒前由子系统先发布 readiness。这样保留通用 IRQ-safe deferred primitive，同时由 `ax-net` 暴露子系统专用 wake 包装，避免把裸 `TaskId` 作为主要接口模型。

`PollSet` 自身也遵循同一条规则：内部锁只保护 wait entry 容器，不承载 waker 执行。这样即使 waker 立即重新 poll/register 同一个对象，也不会重入已经持有的 `SpinNoIrq`。

关于 `crab_usb`/xHCI：本轮复查后不修改其 IRQ completion/waker 逻辑。`IrqLock::lock()` 在 task 侧会先关闭控制器 interrupter 再修改 queue map，IRQ hot path 通过 `force_use()` 访问预注册结构而不获取同一把 spinlock，因此这里不是明确的中断重入 spinlock 死锁点。Starry USBFS glue 中直接 `event_listener::notify` 的部分已经改为 deferred worker。

## 验证

- `cargo fmt`
- `cargo fmt --check`
- `cargo test -p axpoll`
- `cargo test -p axpoll releasing_pollset_lock`：先在旧实现上复现超时失败，再在修复后通过，覆盖 `wake()` 和满容量 `register()` 覆盖路径的锁外 waker 执行。
- `cargo test -p ax-task --features irq`
- `cargo test -p ax-task --no-default-features --features sched-fifo,irq,test -- --test-threads=1`
- `cargo test -p rd-net`
- `cargo xtask clippy --package ax-task`
- `cargo xtask clippy --package axpoll`
- `cargo xtask clippy --package rd-net`
- `cargo xtask clippy --package ax-net`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/syscall-test-select-poll`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/bugfix-bug-tcp-send-no-epoll-notify`
- `git diff --check`

Rebase 到最新 `origin/dev` 后，已复跑：`cargo fmt`、`cargo fmt --check`、`git diff --check`、`cargo test -p axpoll`、`cargo xtask clippy --package axpoll`、`cargo xtask clippy --package ax-task`、`cargo xtask clippy --package ax-net`，均通过。

Review 修复后，再次复跑：`cargo fmt --check`、`git diff --check`、`cargo test -p axpoll`、`cargo xtask clippy --package axpoll`、`cargo xtask clippy --package ax-task`、`cargo xtask clippy --package ax-net`，均通过。

两个 Starry QEMU smoke 都已通过；运行中 debugfs 对 rootfs ownership 有非致命的 `Operation not permitted` 日志，但最终成功匹配 `STARRY_GROUPED_TESTS_PASSED`。

补充：`cargo test -p starry-kernel --features sg2002 irq_byte_ring::tests::fixed_ring_preserves_fifo_and_drops_when_full` 能编译到测试链接阶段，但受当前 host/percpu PIE 链接限制阻塞，不作为本轮有效验证；对应代码已由 `cargo xtask clippy --package starry-kernel` 的 sg2002 feature 组合覆盖编译。