### PR TITLE
fix(starry): widen loongarch64 user VA window to 128 TiB (match aarch64/x86_64)

### DIFF
--- a/os/StarryOS/kernel/src/config/loongarch64.rs
+++ b/os/StarryOS/kernel/src/config/loongarch64.rs
@@ -4,10 +4,25 @@ pub const KERNEL_STACK_SIZE: usize = 0x4_0000;
 /// The base address of the user space.
 pub const USER_SPACE_BASE: usize = 0x1000;
 /// The size of the user space.
-pub const USER_SPACE_SIZE: usize = 0x3f_ffff_f000;
+///
+/// 128 TiB, matching aarch64/x86_64 (#242). LoongArch LA64 uses a 4-level page
+/// table with a 48-bit VA (`page_table_multiarch` `LA64MetaData`: LEVELS=4,
+/// VA_MAX_BITS=48), so the low-half user window widens to the same
+/// `0x7fff_ffff_f000` as aarch64. The previous 256 GiB window predated the #242
+/// widen and was too small for high virtual reservations such as the JVM
+/// CompressedOops heap base (HotSpot probes 2 GiB → 4/32 GiB), which on loong
+/// landed above the old `0x40_0000_0000` top and was rejected by
+/// `AddrSpace::validate_region` (`NoMemory: address out of range`), hanging the
+/// multi-JDK language carpet. (riscv64 stays 256 GiB — it is Sv39, 39-bit VA.)
+pub const USER_SPACE_SIZE: usize = 0x7fff_ffff_f000;
 
 /// The highest address of the user stack.
-pub const USER_STACK_TOP: usize = 0x4_0000_0000;
+///
+/// Placed at 4 TiB (mirroring aarch64/x86_64, #242) so ~124 TiB of VA remains
+/// above the stack for large virtual reservations (JVM CompressedOops heap, Go
+/// arenas). The previous `0x4_0000_0000` (16 GiB) left no headroom above the
+/// stack within the old window.
+pub const USER_STACK_TOP: usize = 0x0400_0000_0000;
 /// The size of the user stack.
 pub const USER_STACK_SIZE: usize = 0x80_0000;
 

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-mmap-family/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-mmap-family/src/main.c
@@ -135,6 +135,28 @@ int main(void)
               "mmap MAP_FIXED 且 addr+length 溢出 → 被拒(EINVAL/ENOMEM), 不环绕");
     }
 
+    /* MAP_FIXED 预留在 256 GiB 之上的高地址 (回归: loongarch64 用户 VA 扩窗)
+     * loongarch64 旧用户 VA 窗口仅 256 GiB(顶 0x40_0000_0000); JVM HotSpot 的
+     * CompressedOops 堆 base 高地址预留会越界 → aspace 的 validate_region 以
+     * NoMemory("address out of range") 拒绝 → 应用侧无限重试 spin。把 loong 窗口
+     * 扩到 128 TiB(对齐 aarch64/x86_64, 其 PT 同为 4 级 48 位 VA)后, 1 TiB 处的
+     * MAP_FIXED 预留必须成功。riscv64 是 Sv39(256 GiB 窗口, 无法扩), 该高地址仍
+     * 应被拒, 故按架构区分断言。*/
+    {
+        void *hi = (void *)0x10000000000UL; /* 1 TiB, 页对齐, 远低于 4 TiB 用户栈顶 */
+        errno = 0;
+        void *r2 = mmap(hi, ps, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+#if defined(__riscv)
+        CHECK(r2 == MAP_FAILED,
+              "riscv64: 1 TiB MAP_FIXED 被拒 (Sv39 256 GiB 用户窗口)");
+#else
+        CHECK(r2 == hi,
+              "1 TiB MAP_FIXED 高地址预留成功 (128 TiB 用户窗口; loong 扩窗回归)");
+        if (r2 != MAP_FAILED) { munmap(r2, ps); }
+#endif
+    }
+
     /* ===================== mprotect ===================== */
 
     /* mprotect happy path: READ|WRITE → 0 */


### PR DESCRIPTION
## 问题
loongarch64 用户 VA 窗口仅 256 GiB(`USER_SPACE_SIZE=0x3f_ffff_f000`,顶 `0x40_0000_0000`)。多 JDK Java 负载下,HotSpot 的 CompressedOops 堆 base 高地址预留落在 256 GiB 之上 → `AddrSpace::validate_region` 以 `NoMemory("address out of range")` 拒绝 → 应用侧无限重试,进程 spin 卡死。

## 修复
loongarch64 LA64 与 aarch64/x86_64 同为 4 级页表、48 位 VA(`page_table_multiarch` `LA64MetaData`:`LEVELS=4`,`VA_MAX_BITS=48`),将用户低半区窗口扩到一致的 128 TiB(`USER_SPACE_SIZE → 0x7fff_ffff_f000`),并把 `USER_STACK_TOP` 上移到 4 TiB,为高位虚拟预留留出空间。riscv64 为 Sv39(39 位 VA),维持 256 GiB 不变。

## 回归测试
`syscall-test-mmap-family` 增一例:1 TiB 处的 `MAP_FIXED` 预留在 x86_64/aarch64/loongarch64(128 TiB 窗口)成功、在 riscv64(Sv39)被拒。修复前 loongarch64 此例失败,修复后通过;四架构单核 qemu10 starry 全组无回归。

## 备注
@ZR233 此修复是 loongarch64 上 Java(`apps/starry`)多 JDK 语言级测试通过的前置依赖:旧 256 GiB 窗口下该测试会因 JVM 高地址堆预留 spin 卡死;合入本 PR 后该测试在 loongarch64 单核 qemu10 starry 全过。
