### PR TITLE
fix(arceos-test-suit): read full host http response

### DIFF
--- a/test-suit/arceos/rust/src/net/loopback.rs
+++ b/test-suit/arceos/rust/src/net/loopback.rs
@@ -72,9 +72,17 @@ fn test_host_http_client() {
         .expect("failed to send host HTTP request");
 
     let mut buf = [0; 512];
-    let len = stream
-        .read(&mut buf)
-        .expect("failed to read host HTTP response");
+    let mut len = 0;
+    while len < buf.len() {
+        let read_len = stream
+            .read(&mut buf[len..])
+            .expect("failed to read host HTTP response");
+        if read_len == 0 {
+            break;
+        }
+        len += read_len;
+    }
+    assert_ne!(len, 0, "host HTTP response was empty");
     let response = core::str::from_utf8(&buf[..len]).expect("host HTTP response was not utf8");
     assert!(
         response.contains("HTTP/1.1 200 OK"),


### PR DESCRIPTION
## 问题

ArceOS `net-loopback` 测例访问 host HTTP fixture 时只读取一次响应，在宿主机或 QEMU 网络分片时可能只拿到部分 HTTP body，导致测例偶发误判失败。

## 修改

- 循环读取 host HTTP 响应，直到连接关闭或达到预期响应内容。
- 保留原有响应内容校验，避免只因为读到 header 或部分 body 就提前结束。

## 验证

- `cargo fmt --check`
- `cargo xtask arceos test qemu --arch x86_64 --test-group rust --test-case net-loopback`
