### PR TITLE
fix(starry): wait for shell in OrangePi boot test

### DIFF
--- a/test-suit/starryos/board-orangepi-5-plus/boot/board-orangepi-5-plus.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/boot/board-orangepi-5-plus.toml
@@ -1,3 +1,6 @@
 board_type = "OrangePi-5-Plus"
-success_regex = ["(?m)^.*DWC xHCI driver initialized successfully for usb@fc400000.*$"]
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "echo 'STARRY_ORANGEPI_BOOT_OK'"
+success_regex = ["(?m)^STARRY_ORANGEPI_BOOT_OK\\s*$"]
 fail_regex = ['(?i)\bpanic(?:ked)?\b']
+timeout = 300


### PR DESCRIPTION
## 问题

OrangePi-5-Plus Starry boot 板测原先只匹配 USB xHCI 初始化日志。该日志出现时系统仍可能没有进入可交互 shell，导致测试过早判定成功，覆盖不到后续启动流程。

## 修改

- 为该 board case 增加 `shell_prefix`，等待 Starry shell 出现后再发送命令。
- 使用 `echo 'STARRY_ORANGEPI_BOOT_OK'` 作为明确成功标记。
- 将 `success_regex` 改为匹配该成功标记，并设置 300 秒超时。

## 验证

- `cargo fmt --check`
- `cargo xtask starry test board --board orangepi-5-plus --list`
- `cargo xtask starry test board --board orangepi-5-plus --test-case boot`
