### PR TITLE
fix(axvisor): map qemu high mmio pci windows

### DIFF
--- a/os/axvisor/configs/vms/qemu/x86_64/linux-svm-smp1.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/linux-svm-smp1.toml
@@ -71,6 +71,10 @@ passthrough_devices = [
 # Passthrough addresses.
 # Base-GPA  Length.
 passthrough_addresses = [
+  # QEMU q35 may place PCI BARs around 0x8000_0000 or 0x8_0000_0000 on
+  # different hosts; both must be identity-mapped for guest PCI probing.
+  [0x8000_0000, 0x10_0000],
+  [0x8_0000_0000, 0x10_0000],
   # QEMU q35 low MMIO window needed by PCI/virtio-blk probing.
   [0xfe00_0000, 0x00c0_0000],
   # Linux probes a q35/ICH system MMIO page at 0xfed8_03c0 after the PIT/HLT path is fixed.

--- a/os/axvisor/configs/vms/qemu/x86_64/linux-vmx-smp1.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/linux-vmx-smp1.toml
@@ -71,6 +71,10 @@ passthrough_devices = [
 # Passthrough addresses.
 # Base-GPA  Length.
 passthrough_addresses = [
+  # QEMU q35 may place PCI BARs around 0x8000_0000 or 0x8_0000_0000 on
+  # different hosts; both must be identity-mapped for guest PCI probing.
+  [0x8000_0000, 0x10_0000],
+  [0x8_0000_0000, 0x10_0000],
   # QEMU q35 low MMIO window needed by PCI/virtio-blk probing.
   [0xfe00_0000, 0x00c0_0000],
   # Linux probes a q35/ICH system MMIO page after the PIT/HLT path is active.


### PR DESCRIPTION
## 问题

QEMU q35 在不同宿主机或设备组合下，可能把 virtio PCI BAR 分配到 `0x8000_0000` 附近，也可能分配到 `0x8_0000_0000` 附近。当前 AxVisor x86_64 Linux VM 配置没有同时覆盖这两段高 MMIO 窗口，guest Linux PCI probe 访问 BAR 时可能触碰未映射地址，导致设备探测不稳定。

## 修改

- 在 `linux-svm-smp1.toml` 中为 VM passthrough 增加 `0x8000_0000` 和 `0x8_0000_0000` 两段 MMIO identity mapping。
- 在 `linux-vmx-smp1.toml` 中同步加入相同映射，保持 SVM/VMX QEMU 配置一致。
- 在配置里保留注释，说明这两个窗口来自 QEMU q35 PCI BAR 分配差异。

## 方案逻辑

这次不改 PCI 枚举逻辑，只把 QEMU q35 已知可能使用的 BAR 窗口显式加入 guest MMIO 映射。这样 guest Linux 无论拿到 32-bit MMIO BAR 还是高位 64-bit prefetchable BAR，都能完成 probe。

## 验证

- `cargo fmt --check`
- `cargo xtask axvisor test qemu --arch x86_64 --list`
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case smoke-vmx`

另外尝试运行了：

- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case smoke-svm`

本机宿主不支持 SVM/NPT，测试在 guest 配置路径之前失败，日志显示 hardware virtualization is not supported，因此本地无法完成 SVM 端到端验证。
