### PR TITLE
test(arceos): relax remote wake progress timeout

### DIFF
--- a/test-suit/arceos/rust/src/task/wait_queue_remote_wake.rs
+++ b/test-suit/arceos/rust/src/task/wait_queue_remote_wake.rs
@@ -19,7 +19,7 @@ static DONE: AtomicBool = AtomicBool::new(false);
 static SLEEPER_CPU: AtomicUsize = AtomicUsize::new(usize::MAX);
 
 const WAITER_ENQUEUE_RETRIES: usize = 1024;
-const REMOTE_WAKE_PROGRESS_TIMEOUT: Duration = Duration::from_millis(100);
+const REMOTE_WAKE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn pin_current_to_cpu(cpu_id: usize) {
     assert!(


### PR DESCRIPTION
## 问题

`task-wait-queue-remote-wake` 用例会在多核环境下验证跨 CPU wait queue 唤醒。当前进度等待超时只有 100ms，在 QEMU/CI 负载较高或首次调度较慢时，唤醒路径本身可能正常，但测试仍可能因为等待余量过小而偶发失败。

## 修改

- 将 `REMOTE_WAKE_PROGRESS_TIMEOUT` 从 100ms 放宽到 1s。
- 保持等待队列逻辑、唤醒流程和断言不变，只增加测试对调度抖动的容忍度。

## 方案逻辑

这个测试关注的是远端唤醒能否推进 sleeper，而不是调度必须在 100ms 内完成。1s 仍然能及时发现真正卡死的问题，同时降低 QEMU/CI 调度波动导致的误报。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo xtask arceos test qemu --arch x86_64 --test-group rust --test-case task-wait-queue-remote-wake`
