### PR TITLE
fix(sdhci-host): preserve fifo irq error status

### DIFF
--- a/drivers/blk/sdhci-host/src/command.rs
+++ b/drivers/blk/sdhci-host/src/command.rs
@@ -194,14 +194,28 @@ impl Sdhci {
         (normal, error)
     }
 
-    pub(crate) fn take_fifo_irq_status(&mut self, mask: u16) -> u16 {
+    pub(crate) fn take_fifo_irq_status(&mut self, mask: u16) -> (u16, u16) {
         let normal_hw = self.read_u16(REG_NORMAL_INT_STATUS);
+        let consume_error = mask & NORMAL_INT_ERROR != 0;
+        let error_hw = if consume_error && normal_hw & NORMAL_INT_ERROR != 0 {
+            self.read_u16(REG_ERROR_INT_STATUS)
+        } else {
+            0
+        };
         let consume_normal = normal_hw & mask;
         if consume_normal != 0 {
             self.write_u16(REG_NORMAL_INT_STATUS, consume_normal);
         }
+        if error_hw != 0 {
+            self.write_u16(REG_ERROR_INT_STATUS, error_hw);
+        }
 
-        take_cached_irq_status(&mut self.irq_pending_normal, normal_hw, mask)
+        let normal = take_cached_irq_status(&mut self.irq_pending_normal, normal_hw, mask);
+        let error = self.irq_pending_error | error_hw;
+        if consume_error && error != 0 && normal & NORMAL_INT_ERROR != 0 {
+            self.irq_pending_error = 0;
+        }
+        (normal, error)
     }
 
     fn translate_error_bits(&self, err: u16, cmd_index: u8) -> Error {
@@ -480,6 +494,31 @@ mod tests {
             0,
             "transfer completion belongs to the data-complete poll step"
         );
+    }
+
+    #[test]
+    fn fifo_status_consumes_irq_cached_error_bits() {
+        let mut regs = FakeRegs([0; 0x100]);
+        let base = NonNull::new(regs.0.as_mut_ptr()).unwrap();
+        let mut host = unsafe { Sdhci::new(base) };
+        host.irq_pending_normal = NORMAL_INT_ERROR;
+        host.irq_pending_error = ERROR_INT_DATA_TIMEOUT;
+
+        let (status, error) =
+            host.take_fifo_irq_status(NORMAL_INT_BUFFER_READ_READY | NORMAL_INT_ERROR);
+
+        assert_ne!(
+            status & NORMAL_INT_ERROR,
+            0,
+            "FIFO poll must observe error status cached by the IRQ handler"
+        );
+        assert_ne!(
+            error & ERROR_INT_DATA_TIMEOUT,
+            0,
+            "FIFO poll must preserve error bits after the IRQ handler clears hardware status"
+        );
+        assert_eq!(host.irq_pending_normal & NORMAL_INT_ERROR, 0);
+        assert_eq!(host.irq_pending_error, 0);
     }
 
     #[test]

--- a/drivers/blk/sdhci-host/src/dma.rs
+++ b/drivers/blk/sdhci-host/src/dma.rs
@@ -1057,9 +1057,10 @@ fn poll_fifo_read_step(
         return host.poll_data_complete_with_adma(cmd_index, phase);
     }
 
-    let status = host.take_fifo_irq_status(NORMAL_INT_BUFFER_READ_READY | NORMAL_INT_ERROR);
+    let (status, error) =
+        host.take_fifo_irq_status(NORMAL_INT_BUFFER_READ_READY | NORMAL_INT_ERROR);
     if status & NORMAL_INT_BUFFER_READ_READY == 0 {
-        return poll_fifo_status(host, status, cmd_index, phase, true);
+        return poll_fifo_status(host, status, error, cmd_index, phase, true);
     }
 
     let end = (*offset + block_size).min(len);
@@ -1089,9 +1090,10 @@ fn poll_fifo_write_step(
         return host.poll_data_complete_with_adma(cmd_index, phase);
     }
 
-    let status = host.take_fifo_irq_status(NORMAL_INT_BUFFER_WRITE_READY | NORMAL_INT_ERROR);
+    let (status, error) =
+        host.take_fifo_irq_status(NORMAL_INT_BUFFER_WRITE_READY | NORMAL_INT_ERROR);
     if status & NORMAL_INT_BUFFER_WRITE_READY == 0 {
-        return poll_fifo_status(host, status, cmd_index, phase, false);
+        return poll_fifo_status(host, status, error, cmd_index, phase, false);
     }
 
     let end = (*offset + block_size).min(len);
@@ -1110,6 +1112,7 @@ fn poll_fifo_write_step(
 fn poll_fifo_status(
     host: &mut Sdhci,
     status: u16,
+    error: u16,
     cmd_index: u8,
     phase: Phase,
     read: bool,
@@ -1118,17 +1121,22 @@ fn poll_fifo_status(
         return Ok(BlockPoll::Pending);
     }
 
+    log::info!(
+        "sdhci: data buffer cached status CMD{} normal={:#06x} error={:#06x}",
+        cmd_index,
+        status,
+        error
+    );
     host.log_status("data buffer error", cmd_index);
-    let err = host.read_u16(REG_ERROR_INT_STATUS);
     host.write_u16(REG_NORMAL_INT_STATUS, NORMAL_INT_CLEAR_ALL);
     host.write_u16(REG_ERROR_INT_STATUS, ERROR_INT_CLEAR_ALL);
     let _ = host.reset_cmd();
     let _ = host.reset_dat();
     let ctx = ErrorContext::for_cmd(phase, cmd_index);
     Err(
-        if err & (ERROR_INT_DATA_TIMEOUT | ERROR_INT_CMD_TIMEOUT) != 0 {
+        if error & (ERROR_INT_DATA_TIMEOUT | ERROR_INT_CMD_TIMEOUT) != 0 {
             Error::Timeout(ctx)
-        } else if err & (ERROR_INT_DATA_CRC | ERROR_INT_CMD_CRC) != 0 {
+        } else if error & (ERROR_INT_DATA_CRC | ERROR_INT_CMD_CRC) != 0 {
             Error::Crc(ctx)
         } else if read {
             Error::ReadError(ctx)


### PR DESCRIPTION
## 问题

SDHCI FIFO 传输在 IRQ handler 已经读取并清除硬件 error status 后，task-side FIFO poll 只消费 normal status。这样如果中断路径先看到 `NORMAL_INT_ERROR` 并清掉硬件错误寄存器，后续 FIFO poll 再从硬件 error register 读取时可能已经拿不到原始错误位，导致 timeout/CRC 等具体错误被丢失。

## 修改

- `take_fifo_irq_status()` 同时返回 normal status 和 error status。
- 当 mask 包含 `NORMAL_INT_ERROR` 时，同步消费 IRQ cache 中的 error bits，并在需要时清除硬件 error status。
- FIFO read/write poll 在处理 error status 时使用缓存后的 error bits 判断 timeout、CRC 或泛化读写错误。
- 增加单测覆盖 IRQ cache 中的 error bit 被 FIFO poll 正确观察和消费的场景。

## 方案逻辑

中断路径可以先于 task-side poll 清设备中断源，因此错误信息必须作为 host-local 状态缓存保留下来。task-side poll 再统一消费缓存并推进状态机，这样既符合“中断同步状态，任务推进流程”的模型，也避免重复读取已经被 W1C 清掉的硬件状态。

## 验证

- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `cargo test -p sdhci-host`
- `cargo xtask clippy --package sdhci-host`
