### PR TITLE
fix(starry-kernel): improve multiarch GDB ptrace support

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -23,7 +23,7 @@ use starry_vm::{VmMutPtr, VmPtr, vm_read_slice, vm_write_slice};
 use crate::task::PtraceStopFpData;
 use crate::{
     mm::{AddrSpace, IoVec},
-    task::{AsThread, ProcessData, get_process_data, get_task},
+    task::{AsThread, Cred, ProcessData, get_process_cred, get_process_data, get_task},
 };
 
 const PTRACE_TRACEME: u32 = 0;
@@ -275,8 +275,7 @@ fn ptrace_attach(pid: usize) -> AxResult<isize> {
     if tracee.is_ptrace_traceme() || tracee.is_ptrace_attached() {
         return Err(AxError::from(LinuxError::EPERM));
     }
-    let is_child = tracee.proc.parent().is_some_and(|p| p.pid() == tracer_pid);
-    if !is_child {
+    if !ptrace_may_attach(tracer_pid, tracee_pid, &tracee)? {
         return Err(AxError::from(LinuxError::EPERM));
     }
     tracee.set_ptrace_tracer_pid(tracer_pid);
@@ -474,7 +473,7 @@ fn ptrace_setregs(pid: usize, data: usize) -> AxResult<isize> {
     Err(AxError::Unsupported)
 }
 
-#[cfg(target_arch = "riscv64")]
+#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
 fn ptrace_getfpregs(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
         return Err(AxError::InvalidInput);
@@ -482,21 +481,21 @@ fn ptrace_getfpregs(pid: usize, data: usize) -> AxResult<isize> {
     let regs = ptrace_read_stopped_fp_regs(pid)?;
     let bytes = unsafe {
         slice::from_raw_parts(
-            (&regs as *const RiscvFpRegs).cast::<u8>(),
-            size_of::<RiscvFpRegs>(),
+            (&regs as *const ArchFpRegs).cast::<u8>(),
+            size_of::<ArchFpRegs>(),
         )
     };
     vm_write_slice(data as *mut u8, bytes)?;
     Ok(0)
 }
 
-#[cfg(not(target_arch = "riscv64"))]
+#[cfg(not(any(target_arch = "riscv64", target_arch = "loongarch64")))]
 fn ptrace_getfpregs(pid: usize, data: usize) -> AxResult<isize> {
     let _ = (pid, data);
     Err(AxError::Unsupported)
 }
 
-#[cfg(target_arch = "riscv64")]
+#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
 fn ptrace_setfpregs(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
         return Err(AxError::InvalidInput);
@@ -505,7 +504,7 @@ fn ptrace_setfpregs(pid: usize, data: usize) -> AxResult<isize> {
     ptrace_write_stopped_fp_regs(pid, regs)
 }
 
-#[cfg(not(target_arch = "riscv64"))]
+#[cfg(not(any(target_arch = "riscv64", target_arch = "loongarch64")))]
 fn ptrace_setfpregs(pid: usize, data: usize) -> AxResult<isize> {
     let _ = (pid, data);
     Err(AxError::Unsupported)
@@ -521,13 +520,40 @@ fn ptrace_seize(pid: usize, _addr: usize) -> AxResult<isize> {
     if tracee.is_ptrace_traceme() || tracee.is_ptrace_attached() {
         return Err(AxError::from(LinuxError::EPERM));
     }
-    let is_child = tracee.proc.parent().is_some_and(|p| p.pid() == tracer_pid);
-    if !is_child {
+    if !ptrace_may_attach(tracer_pid, tracee_pid, &tracee)? {
         return Err(AxError::from(LinuxError::EPERM));
     }
     tracee.set_ptrace_tracer_pid(tracer_pid);
     tracee.set_ptrace_attached();
     Ok(0)
+}
+
+fn ptrace_may_attach(tracer_pid: Pid, tracee_pid: Pid, tracee: &ProcessData) -> AxResult<bool> {
+    if tracee.proc.parent().is_some_and(|p| p.pid() == tracer_pid) {
+        return Ok(true);
+    }
+
+    let tracer_cred = get_process_cred(tracer_pid)?;
+    if tracer_cred.has_cap_sys_ptrace() {
+        return Ok(true);
+    }
+
+    if tracee.dumpable() != 1 {
+        return Ok(false);
+    }
+
+    let tracee_cred = get_process_cred(tracee_pid)?;
+    Ok(ptrace_creds_match_for_attach(&tracer_cred, &tracee_cred))
+}
+
+fn ptrace_creds_match_for_attach(tracer: &Cred, tracee: &Cred) -> bool {
+    tracer.uid == tracee.uid
+        && tracer.euid == tracee.euid
+        && tracer.suid == tracee.suid
+        && tracer.fsuid == tracee.fsuid
+        && tracer.uid == tracer.euid
+        && tracer.uid == tracer.suid
+        && tracer.uid == tracer.fsuid
 }
 
 fn ptrace_interrupt(pid: usize) -> AxResult<isize> {
@@ -1084,7 +1110,6 @@ pub fn ptrace_setup_singlestep(
     uctx: &mut ax_runtime::hal::cpu::uspace::UserContext,
 ) {
     let pc = uctx.ip();
-    let next_insn_addr = pc.wrapping_add(4);
     let aspace = tracee.aspace();
     let mut aspace = aspace.lock();
 
@@ -1495,6 +1520,17 @@ fn loongarch_next_pc(
     uctx: &ax_runtime::hal::cpu::uspace::UserContext,
 ) -> usize {
     match insn >> 26 {
+        0x10 | 0x11 => {
+            let rj = ((insn >> 5) & 0x1f) as usize;
+            let imm = ((insn & 0x1f) << 16) | ((insn >> 10) & 0xffff);
+            let is_nonzero = insn >> 26 == 0x11;
+            let take = (loongarch_reg(uctx, rj) != 0) == is_nonzero;
+            if take {
+                ptrace_add_offset(pc, ptrace_sign_extend(imm, 21) << 2)
+            } else {
+                pc.wrapping_add(4)
+            }
+        }
         0x13 => {
             let rj = ((insn >> 5) & 0x1f) as usize;
             let offset = ptrace_sign_extend((insn >> 10) & 0xffff, 16) << 2;

--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -1093,6 +1093,14 @@ pub fn ptrace_setup_singlestep(
         let _ = ptrace_write_u32_unlocked(&mut aspace, saved_addr, saved_insn as u32);
     }
 
+    let current_insn = match ptrace_read_u32_unlocked(&aspace, pc) {
+        Ok(insn) => insn,
+        Err(_) => {
+            tracee.set_ptrace_ss_saved_insn_for(tid, None);
+            return;
+        }
+    };
+    let next_insn_addr = aarch64_next_pc(current_insn, pc, uctx);
     let orig_insn = match ptrace_read_u32_unlocked(&aspace, next_insn_addr) {
         Ok(insn) => insn,
         Err(_) => {
@@ -1117,7 +1125,7 @@ pub fn ptrace_setup_singlestep(
     tid: Pid,
     uctx: &mut ax_runtime::hal::cpu::uspace::UserContext,
 ) {
-    let next_insn_addr = uctx.ip().wrapping_add(4);
+    let pc = uctx.ip();
     let aspace = tracee.aspace();
     let mut aspace = aspace.lock();
 
@@ -1126,6 +1134,14 @@ pub fn ptrace_setup_singlestep(
         let _ = ptrace_write_u32_unlocked(&mut aspace, saved_addr, saved_insn as u32);
     }
 
+    let current_insn = match ptrace_read_u32_unlocked(&aspace, pc) {
+        Ok(insn) => insn,
+        Err(_) => {
+            tracee.set_ptrace_ss_saved_insn_for(tid, None);
+            return;
+        }
+    };
+    let next_insn_addr = loongarch_next_pc(current_insn, pc, uctx);
     let orig_insn = match ptrace_read_u32_unlocked(&aspace, next_insn_addr) {
         Ok(insn) => insn,
         Err(_) => {
@@ -1356,6 +1372,198 @@ fn riscv_reg(uctx: &ax_runtime::hal::cpu::uspace::UserContext, index: usize) -> 
         29 => uctx.regs.t4,
         30 => uctx.regs.t5,
         31 => uctx.regs.t6,
+        _ => 0,
+    }
+}
+
+#[cfg(any(target_arch = "aarch64", target_arch = "loongarch64"))]
+fn ptrace_sign_extend(value: u32, bits: u32) -> isize {
+    let shift = usize::BITS - bits;
+    ((value as usize) << shift) as isize >> shift
+}
+
+#[cfg(any(target_arch = "aarch64", target_arch = "loongarch64"))]
+fn ptrace_add_offset(base: usize, offset: isize) -> usize {
+    if offset >= 0 {
+        base.wrapping_add(offset as usize)
+    } else {
+        base.wrapping_sub((-offset) as usize)
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn aarch64_next_pc(
+    insn: u32,
+    pc: usize,
+    uctx: &ax_runtime::hal::cpu::uspace::UserContext,
+) -> usize {
+    if insn & 0x7c00_0000 == 0x1400_0000 {
+        return ptrace_add_offset(pc, ptrace_sign_extend(insn & 0x03ff_ffff, 26) << 2);
+    }
+
+    if insn & 0xff00_0010 == 0x5400_0000 {
+        let cond = (insn & 0xf) as u8;
+        let offset = ptrace_sign_extend((insn >> 5) & 0x7ffff, 19) << 2;
+        return if aarch64_condition_holds(cond, uctx.spsr) {
+            ptrace_add_offset(pc, offset)
+        } else {
+            pc.wrapping_add(4)
+        };
+    }
+
+    if insn & 0x7e00_0000 == 0x3400_0000 {
+        let rt = (insn & 0x1f) as usize;
+        let value = aarch64_reg(uctx, rt);
+        let is_64bit = insn & (1 << 31) != 0;
+        let is_nonzero = insn & (1 << 24) != 0;
+        let value_is_zero = if is_64bit {
+            value == 0
+        } else {
+            (value as u32) == 0
+        };
+        let take = value_is_zero != is_nonzero;
+        let offset = ptrace_sign_extend((insn >> 5) & 0x7ffff, 19) << 2;
+        return if take {
+            ptrace_add_offset(pc, offset)
+        } else {
+            pc.wrapping_add(4)
+        };
+    }
+
+    if insn & 0x7e00_0000 == 0x3600_0000 {
+        let rt = (insn & 0x1f) as usize;
+        let bit_pos = (((insn >> 31) & 0x1) << 5) | ((insn >> 19) & 0x1f);
+        let bit_is_set = ((aarch64_reg(uctx, rt) >> bit_pos) & 1) != 0;
+        let take_if_set = insn & (1 << 24) != 0;
+        let offset = ptrace_sign_extend((insn >> 5) & 0x3fff, 14) << 2;
+        return if bit_is_set == take_if_set {
+            ptrace_add_offset(pc, offset)
+        } else {
+            pc.wrapping_add(4)
+        };
+    }
+
+    if insn & 0xffff_fc1f == 0xd61f_0000
+        || insn & 0xffff_fc1f == 0xd63f_0000
+        || insn & 0xffff_fc1f == 0xd65f_0000
+    {
+        return aarch64_reg(uctx, ((insn >> 5) & 0x1f) as usize);
+    }
+
+    pc.wrapping_add(4)
+}
+
+#[cfg(target_arch = "aarch64")]
+fn aarch64_condition_holds(cond: u8, pstate: u64) -> bool {
+    let n = pstate & (1 << 31) != 0;
+    let z = pstate & (1 << 30) != 0;
+    let c = pstate & (1 << 29) != 0;
+    let v = pstate & (1 << 28) != 0;
+
+    match cond {
+        0x0 => z,
+        0x1 => !z,
+        0x2 => c,
+        0x3 => !c,
+        0x4 => n,
+        0x5 => !n,
+        0x6 => v,
+        0x7 => !v,
+        0x8 => c && !z,
+        0x9 => !c || z,
+        0xa => n == v,
+        0xb => n != v,
+        0xc => !z && n == v,
+        0xd => z || n != v,
+        _ => true,
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn aarch64_reg(uctx: &ax_runtime::hal::cpu::uspace::UserContext, index: usize) -> usize {
+    if index < 31 {
+        uctx.x[index] as usize
+    } else {
+        0
+    }
+}
+
+#[cfg(target_arch = "loongarch64")]
+fn loongarch_next_pc(
+    insn: u32,
+    pc: usize,
+    uctx: &ax_runtime::hal::cpu::uspace::UserContext,
+) -> usize {
+    match insn >> 26 {
+        0x13 => {
+            let rj = ((insn >> 5) & 0x1f) as usize;
+            let offset = ptrace_sign_extend((insn >> 10) & 0xffff, 16) << 2;
+            ptrace_add_offset(loongarch_reg(uctx, rj), offset)
+        }
+        0x14 | 0x15 => {
+            let imm = ((insn & 0x3ff) << 16) | ((insn >> 10) & 0xffff);
+            ptrace_add_offset(pc, ptrace_sign_extend(imm, 26) << 2)
+        }
+        0x16..=0x1b => {
+            let rj = ((insn >> 5) & 0x1f) as usize;
+            let rd = (insn & 0x1f) as usize;
+            let lhs = loongarch_reg(uctx, rj);
+            let rhs = loongarch_reg(uctx, rd);
+            let take = match insn >> 26 {
+                0x16 => lhs == rhs,
+                0x17 => lhs != rhs,
+                0x18 => (lhs as isize) < (rhs as isize),
+                0x19 => (lhs as isize) >= (rhs as isize),
+                0x1a => lhs < rhs,
+                0x1b => lhs >= rhs,
+                _ => false,
+            };
+            let offset = ptrace_sign_extend((insn >> 10) & 0xffff, 16) << 2;
+            if take {
+                ptrace_add_offset(pc, offset)
+            } else {
+                pc.wrapping_add(4)
+            }
+        }
+        _ => pc.wrapping_add(4),
+    }
+}
+
+#[cfg(target_arch = "loongarch64")]
+fn loongarch_reg(uctx: &ax_runtime::hal::cpu::uspace::UserContext, index: usize) -> usize {
+    match index {
+        0 => 0,
+        1 => uctx.regs.ra,
+        2 => uctx.regs.tp,
+        3 => uctx.regs.sp,
+        4 => uctx.regs.a0,
+        5 => uctx.regs.a1,
+        6 => uctx.regs.a2,
+        7 => uctx.regs.a3,
+        8 => uctx.regs.a4,
+        9 => uctx.regs.a5,
+        10 => uctx.regs.a6,
+        11 => uctx.regs.a7,
+        12 => uctx.regs.t0,
+        13 => uctx.regs.t1,
+        14 => uctx.regs.t2,
+        15 => uctx.regs.t3,
+        16 => uctx.regs.t4,
+        17 => uctx.regs.t5,
+        18 => uctx.regs.t6,
+        19 => uctx.regs.t7,
+        20 => uctx.regs.t8,
+        21 => uctx.regs.u0,
+        22 => uctx.regs.fp,
+        23 => uctx.regs.s0,
+        24 => uctx.regs.s1,
+        25 => uctx.regs.s2,
+        26 => uctx.regs.s3,
+        27 => uctx.regs.s4,
+        28 => uctx.regs.s5,
+        29 => uctx.regs.s6,
+        30 => uctx.regs.s7,
+        31 => uctx.regs.s8,
         _ => 0,
     }
 }

--- a/os/StarryOS/kernel/src/task/cred.rs
+++ b/os/StarryOS/kernel/src/task/cred.rs
@@ -78,6 +78,12 @@ impl Cred {
         self.euid == 0
     }
 
+    /// Check whether this credential may inspect another process
+    /// (equivalent to `CAP_SYS_PTRACE` — approximated as euid == 0).
+    pub fn has_cap_sys_ptrace(&self) -> bool {
+        self.euid == 0
+    }
+
     /// Check whether this credential has the privilege to change file
     /// ownership (equivalent to `CAP_CHOWN` — approximated as fsuid == 0,
     /// since this is a filesystem capability).

--- a/test-suit/starryos/qemu-smp1/system/test-ptrace-gdb/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-ptrace-gdb/src/main.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/prctl.h>
 #include <sys/ptrace.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>
@@ -43,6 +44,9 @@
 #endif
 #ifndef PTRACE_ATTACH
 #define PTRACE_ATTACH 16
+#endif
+#ifndef PTRACE_SEIZE
+#define PTRACE_SEIZE 0x4206
 #endif
 #ifndef PTRACE_KILL
 #define PTRACE_KILL 8
@@ -511,6 +515,28 @@ __attribute__((naked, noinline, aligned(4))) static void ss_blt_target(void)
         "break 0\n");
 }
 
+__attribute__((naked, noinline, aligned(4))) static void ss_beqz_target(void)
+{
+    __asm__ volatile(
+        "beqz $a0, 1f\n"
+        "addi.d $a2, $zero, 111\n"
+        "break 0\n"
+        "1:\n"
+        "addi.d $a2, $zero, 777\n"
+        "break 0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_bnez_target(void)
+{
+    __asm__ volatile(
+        "bnez $a0, 1f\n"
+        "addi.d $a2, $zero, 111\n"
+        "break 0\n"
+        "1:\n"
+        "addi.d $a2, $zero, 888\n"
+        "break 0\n");
+}
+
 __attribute__((naked, noinline, aligned(4))) static void ss_jirl_target(void)
 {
     __asm__ volatile(
@@ -728,6 +754,16 @@ static int test_singlestep(void)
     }
     if (check_singlestep_stops_before_target_side_effect(
             pid, &regs, (unsigned long)ss_blt_target, 3, 9, 0, 0, 555)
+        != 0) {
+        return 1;
+    }
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_beqz_target, 0, 0, 0, 0, 777)
+        != 0) {
+        return 1;
+    }
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_bnez_target, 5, 0, 0, 0, 888)
         != 0) {
         return 1;
     }
@@ -966,6 +1002,225 @@ static int test_attach(void)
         return 1;
     }
     printf("  ok: detached, child exited 42\n");
+    return 0;
+}
+
+static int test_same_uid_sibling_attach(void)
+{
+    printf("test 4b: same-uid sibling PTRACE_ATTACH\n");
+
+    int ready_pipe[2];
+    int release_pipe[2];
+    if (pipe(ready_pipe) != 0) {
+        return fail("same-uid ready pipe");
+    }
+    if (pipe(release_pipe) != 0) {
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
+        return fail("same-uid release pipe");
+    }
+
+    pid_t tracee = fork();
+    if (tracee < 0) {
+        return fail("fork same-uid tracee");
+    }
+    if (tracee == 0) {
+        close(ready_pipe[0]);
+        close(release_pipe[1]);
+        if (setresuid(1000, 1000, 1000) != 0) {
+            _exit(100);
+        }
+        if (prctl(PR_SET_DUMPABLE, 1) != 0 || prctl(PR_GET_DUMPABLE) != 1) {
+            _exit(102);
+        }
+        char c = 'T';
+        if (write(ready_pipe[1], &c, 1) != 1) {
+            _exit(101);
+        }
+        close(ready_pipe[1]);
+        wait_for_release_then_exit(release_pipe[0], 43);
+    }
+
+    close(ready_pipe[1]);
+    char c;
+    if (read(ready_pipe[0], &c, 1) != 1) {
+        kill(tracee, SIGKILL);
+        close(ready_pipe[0]);
+        close(release_pipe[0]);
+        close(release_pipe[1]);
+        waitpid(tracee, NULL, 0);
+        return fail("read same-uid tracee ready pipe");
+    }
+    close(ready_pipe[0]);
+
+    pid_t tracer = fork();
+    if (tracer < 0) {
+        kill(tracee, SIGKILL);
+        close(release_pipe[0]);
+        close(release_pipe[1]);
+        waitpid(tracee, NULL, 0);
+        return fail("fork same-uid tracer");
+    }
+    if (tracer == 0) {
+        close(release_pipe[0]);
+        if (setresuid(1000, 1000, 1000) != 0) {
+            _exit(110);
+        }
+        if (ptrace(PTRACE_ATTACH, tracee, NULL, NULL) != 0) {
+            _exit(111);
+        }
+
+        int status = 0;
+        if (waitpid(tracee, &status, 0) != tracee) {
+            ptrace(PTRACE_KILL, tracee, NULL, NULL);
+            _exit(112);
+        }
+        if (!WIFSTOPPED(status) || WSTOPSIG(status) != SIGSTOP) {
+            ptrace(PTRACE_KILL, tracee, NULL, NULL);
+            _exit(113);
+        }
+        if (ptrace(PTRACE_DETACH, tracee, NULL, NULL) != 0) {
+            ptrace(PTRACE_KILL, tracee, NULL, NULL);
+            _exit(114);
+        }
+        char release = 'R';
+        if (write(release_pipe[1], &release, 1) != 1) {
+            _exit(115);
+        }
+        close(release_pipe[1]);
+        _exit(0);
+    }
+
+    close(release_pipe[0]);
+    int tracer_status = 0;
+    if (waitpid(tracer, &tracer_status, 0) != tracer) {
+        kill(tracee, SIGKILL);
+        close(release_pipe[1]);
+        waitpid(tracee, NULL, 0);
+        return fail("wait same-uid tracer");
+    }
+    if (!WIFEXITED(tracer_status) || WEXITSTATUS(tracer_status) != 0) {
+        printf("FAIL: same-uid sibling tracer status=%#x\n", tracer_status);
+        kill(tracee, SIGKILL);
+        close(release_pipe[1]);
+        waitpid(tracee, NULL, 0);
+        return 1;
+    }
+    close(release_pipe[1]);
+
+    int tracee_status = 0;
+    if (waitpid(tracee, &tracee_status, 0) != tracee || !WIFEXITED(tracee_status)
+        || WEXITSTATUS(tracee_status) != 43) {
+        printf("FAIL: same-uid sibling tracee status=%#x\n", tracee_status);
+        return 1;
+    }
+
+    printf("  ok: non-parent same-uid tracer attached and detached\n");
+    return 0;
+}
+
+static int test_same_uid_sibling_attach_rejects_nondumpable(void)
+{
+    printf("test 4c: same-uid sibling attach rejects nondumpable tracee\n");
+
+    int ready_pipe[2];
+    int release_pipe[2];
+    if (pipe(ready_pipe) != 0) {
+        return fail("nondumpable ready pipe");
+    }
+    if (pipe(release_pipe) != 0) {
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
+        return fail("nondumpable release pipe");
+    }
+
+    pid_t tracee = fork();
+    if (tracee < 0) {
+        return fail("fork nondumpable tracee");
+    }
+    if (tracee == 0) {
+        close(ready_pipe[0]);
+        close(release_pipe[1]);
+        if (setresuid(1000, 1000, 1000) != 0) {
+            _exit(100);
+        }
+        if (prctl(PR_GET_DUMPABLE) != 0) {
+            _exit(101);
+        }
+        char c = 'N';
+        if (write(ready_pipe[1], &c, 1) != 1) {
+            _exit(102);
+        }
+        close(ready_pipe[1]);
+        wait_for_release_then_exit(release_pipe[0], 44);
+    }
+
+    close(ready_pipe[1]);
+    char c;
+    if (read(ready_pipe[0], &c, 1) != 1) {
+        kill(tracee, SIGKILL);
+        close(ready_pipe[0]);
+        close(release_pipe[0]);
+        close(release_pipe[1]);
+        waitpid(tracee, NULL, 0);
+        return fail("read nondumpable tracee ready pipe");
+    }
+    close(ready_pipe[0]);
+
+    pid_t tracer = fork();
+    if (tracer < 0) {
+        kill(tracee, SIGKILL);
+        close(release_pipe[0]);
+        close(release_pipe[1]);
+        waitpid(tracee, NULL, 0);
+        return fail("fork nondumpable tracer");
+    }
+    if (tracer == 0) {
+        close(release_pipe[0]);
+        if (setresuid(1000, 1000, 1000) != 0) {
+            _exit(110);
+        }
+        errno = 0;
+        if (ptrace(PTRACE_ATTACH, tracee, NULL, NULL) == 0 || errno != EPERM) {
+            _exit(111);
+        }
+        errno = 0;
+        if (ptrace(PTRACE_SEIZE, tracee, NULL, NULL) == 0 || errno != EPERM) {
+            _exit(112);
+        }
+        char release = 'R';
+        if (write(release_pipe[1], &release, 1) != 1) {
+            _exit(113);
+        }
+        close(release_pipe[1]);
+        _exit(0);
+    }
+
+    close(release_pipe[0]);
+    int tracer_status = 0;
+    if (waitpid(tracer, &tracer_status, 0) != tracer) {
+        kill(tracee, SIGKILL);
+        close(release_pipe[1]);
+        waitpid(tracee, NULL, 0);
+        return fail("wait nondumpable tracer");
+    }
+    if (!WIFEXITED(tracer_status) || WEXITSTATUS(tracer_status) != 0) {
+        printf("FAIL: nondumpable sibling tracer status=%#x\n", tracer_status);
+        kill(tracee, SIGKILL);
+        close(release_pipe[1]);
+        waitpid(tracee, NULL, 0);
+        return 1;
+    }
+    close(release_pipe[1]);
+
+    int tracee_status = 0;
+    if (waitpid(tracee, &tracee_status, 0) != tracee || !WIFEXITED(tracee_status)
+        || WEXITSTATUS(tracee_status) != 44) {
+        printf("FAIL: nondumpable sibling tracee status=%#x\n", tracee_status);
+        return 1;
+    }
+
+    printf("  ok: non-parent same-uid tracer cannot attach nondumpable target\n");
     return 0;
 }
 
@@ -1440,7 +1695,7 @@ static int test_legacy_regsets(void)
     }
     waitpid(pid, &status, 0);
 
-#if !ARCH_RISCV
+#if !(ARCH_RISCV || ARCH_LOONGARCH)
     printf("  ok: legacy GETREGS/SETREGS work; legacy FPREGS skipped on this arch\n");
     return 0;
 #else
@@ -1455,8 +1710,7 @@ static int test_legacy_regsets(void)
         }
         raise(SIGSTOP);
 
-        unsigned long f0_bits = 0;
-        __asm__ volatile("fmv.x.d %0, f0" : "=r"(f0_bits));
+        unsigned long f0_bits = read_f0_bits();
         _exit(f0_bits == 0x4010000000000000UL ? 42 : 1);
     }
 
@@ -1465,25 +1719,26 @@ static int test_legacy_regsets(void)
         return 1;
     }
 
-    struct riscv_user_fpregs fpregs;
+    arch_user_fpregs fpregs;
     memset(&fpregs, 0, sizeof(fpregs));
     if (ptrace(PTRACE_GETFPREGS, pid, NULL, &fpregs) != 0) {
         return fail("legacy getfpregs");
     }
-    fpregs.f[0] = 0x4010000000000000UL;
-    fpregs.f[2] = 0x12345678UL;
+    fpregs_set_f0(&fpregs, 0x4010000000000000UL);
+    fpregs_set_f1(&fpregs, 0x12345678UL);
     if (ptrace(PTRACE_SETFPREGS, pid, NULL, &fpregs) != 0) {
         return fail("legacy setfpregs");
     }
 
-    struct riscv_user_fpregs fpregs2;
+    arch_user_fpregs fpregs2;
     memset(&fpregs2, 0, sizeof(fpregs2));
     if (ptrace(PTRACE_GETFPREGS, pid, NULL, &fpregs2) != 0) {
         return fail("legacy getfpregs after set");
     }
-    if (fpregs2.f[0] != 0x4010000000000000UL || fpregs2.f[2] != 0x12345678UL) {
-        printf("FAIL: legacy fpregs mismatch f0=%#lx f2=%#lx\n",
-               fpregs2.f[0], fpregs2.f[2]);
+    if (fpregs_get_f0(&fpregs2) != 0x4010000000000000UL
+        || fpregs_get_f1(&fpregs2) != 0x12345678UL) {
+        printf("FAIL: legacy fpregs mismatch f0=%#lx f1=%#lx\n",
+               fpregs_get_f0(&fpregs2), fpregs_get_f1(&fpregs2));
         return 1;
     }
 
@@ -2062,6 +2317,18 @@ int main(void)
     }
 
     if (test_attach() == 0) {
+        pass++;
+    } else {
+        fail_count++;
+    }
+
+    if (test_same_uid_sibling_attach() == 0) {
+        pass++;
+    } else {
+        fail_count++;
+    }
+
+    if (test_same_uid_sibling_attach_rejects_nondumpable() == 0) {
         pass++;
     } else {
         fail_count++;

--- a/test-suit/starryos/qemu-smp1/system/test-ptrace-gdb/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-ptrace-gdb/src/main.c
@@ -134,6 +134,8 @@ struct riscv_user_fpregs {
     unsigned long f[32];
     unsigned long fcsr;
 };
+typedef struct riscv_user_fpregs arch_user_fpregs;
+
 #define PTRACE_GDB_REG_PC(r) ((r)->pc)
 #define PTRACE_GDB_REG_SP(r) ((r)->sp)
 #define PTRACE_GDB_REG_A0(r) ((r)->a0)
@@ -153,6 +155,14 @@ struct aarch64_user_regs {
     unsigned long pstate;
 };
 typedef struct aarch64_user_regs arch_user_regs;
+
+struct aarch64_user_fpregs {
+    __uint128_t vregs[32];
+    uint32_t fpsr;
+    uint32_t fpcr;
+    uint32_t reserved[2];
+};
+typedef struct aarch64_user_fpregs arch_user_fpregs;
 
 #define PTRACE_GDB_REG_PC(r) ((r)->pc)
 #define PTRACE_GDB_REG_SP(r) ((r)->sp)
@@ -177,6 +187,13 @@ _Static_assert(sizeof(struct loongarch_user_regs) == 45 * sizeof(unsigned long),
                "loongarch NT_PRSTATUS must match Linux user_pt_regs");
 typedef struct loongarch_user_regs arch_user_regs;
 
+struct loongarch_user_fpregs {
+    unsigned long fpr[32];
+    unsigned long fcc;
+    uint32_t fcsr;
+};
+typedef struct loongarch_user_fpregs arch_user_fpregs;
+
 #define PTRACE_GDB_REG_PC(r) ((r)->csr_era)
 #define PTRACE_GDB_REG_SP(r) ((r)->regs[3])
 #define PTRACE_GDB_REG_A0(r) ((r)->regs[4])
@@ -189,6 +206,63 @@ typedef struct loongarch_user_regs arch_user_regs;
 #else
 #error "test-ptrace-gdb needs an architecture register layout"
 #endif
+
+static void fpregs_set_f0(arch_user_fpregs *regs, unsigned long value)
+{
+#if ARCH_RISCV
+    regs->f[0] = value;
+#elif ARCH_AARCH64
+    regs->vregs[0] = (__uint128_t)value;
+#elif ARCH_LOONGARCH
+    regs->fpr[0] = value;
+#endif
+}
+
+static void fpregs_set_f1(arch_user_fpregs *regs, unsigned long value)
+{
+#if ARCH_RISCV
+    regs->f[1] = value;
+#elif ARCH_AARCH64
+    regs->vregs[1] = (__uint128_t)value;
+#elif ARCH_LOONGARCH
+    regs->fpr[1] = value;
+#endif
+}
+
+static unsigned long fpregs_get_f0(const arch_user_fpregs *regs)
+{
+#if ARCH_RISCV
+    return regs->f[0];
+#elif ARCH_AARCH64
+    return (unsigned long)regs->vregs[0];
+#elif ARCH_LOONGARCH
+    return regs->fpr[0];
+#endif
+}
+
+static unsigned long fpregs_get_f1(const arch_user_fpregs *regs)
+{
+#if ARCH_RISCV
+    return regs->f[1];
+#elif ARCH_AARCH64
+    return (unsigned long)regs->vregs[1];
+#elif ARCH_LOONGARCH
+    return regs->fpr[1];
+#endif
+}
+
+static unsigned long read_f0_bits(void)
+{
+    unsigned long f0_bits = 0;
+#if ARCH_RISCV
+    __asm__ volatile("fmv.x.d %0, f0" : "=r"(f0_bits));
+#elif ARCH_AARCH64
+    __asm__ volatile("fmov %0, d0" : "=r"(f0_bits));
+#elif ARCH_LOONGARCH
+    __asm__ volatile("movfr2gr.d %0, $f0" : "=r"(f0_bits));
+#endif
+    return f0_bits;
+}
 
 static int fail(const char *msg)
 {
@@ -341,18 +415,115 @@ __attribute__((naked, noinline, aligned(4))) static void ss_c_jr_landing(void)
         "addi a2, zero, 777\n"
         "ebreak\n");
 }
-#else
+#elif ARCH_AARCH64
 __attribute__((naked, noinline, aligned(4))) static void ss_step_target(void)
 {
     __asm__ volatile(
-#if ARCH_LOONGARCH
-        "addi.d $a0, $zero, 123\n"
-        "break 0\n"
-#else
         "mov x0, #123\n"
+        "brk #0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_b_target(void)
+{
+    __asm__ volatile(
+        "b 1f\n"
+        "mov x2, #111\n"
         "brk #0\n"
-#endif
-    );
+        "1:\n"
+        "mov x2, #222\n"
+        "brk #0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_cbz_target(void)
+{
+    __asm__ volatile(
+        "cbz x0, 1f\n"
+        "mov x2, #111\n"
+        "brk #0\n"
+        "1:\n"
+        "mov x2, #333\n"
+        "brk #0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_tbnz_target(void)
+{
+    __asm__ volatile(
+        "tbnz x0, #0, 1f\n"
+        "mov x2, #111\n"
+        "brk #0\n"
+        "1:\n"
+        "mov x2, #444\n"
+        "brk #0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_br_target(void)
+{
+    __asm__ volatile(
+        "br x3\n"
+        "mov x2, #111\n"
+        "brk #0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_br_landing(void)
+{
+    __asm__ volatile(
+        "mov x2, #555\n"
+        "brk #0\n");
+}
+#elif ARCH_LOONGARCH
+__attribute__((naked, noinline, aligned(4))) static void ss_step_target(void)
+{
+    __asm__ volatile(
+        "addi.d $a0, $zero, 123\n"
+        "break 0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_b_target(void)
+{
+    __asm__ volatile(
+        "b 1f\n"
+        "addi.d $a2, $zero, 222\n"
+        "break 0\n"
+        "1:\n"
+        "addi.d $a2, $zero, 333\n"
+        "break 0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_beq_target(void)
+{
+    __asm__ volatile(
+        "beq $a0, $a1, 1f\n"
+        "addi.d $a2, $zero, 111\n"
+        "break 0\n"
+        "1:\n"
+        "addi.d $a2, $zero, 444\n"
+        "break 0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_blt_target(void)
+{
+    __asm__ volatile(
+        "blt $a0, $a1, 1f\n"
+        "addi.d $a2, $zero, 111\n"
+        "break 0\n"
+        "1:\n"
+        "addi.d $a2, $zero, 555\n"
+        "break 0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_jirl_target(void)
+{
+    __asm__ volatile(
+        "jirl $zero, $a3, 0\n"
+        "addi.d $a2, $zero, 111\n"
+        "break 0\n");
+}
+
+__attribute__((naked, noinline, aligned(4))) static void ss_jirl_landing(void)
+{
+    __asm__ volatile(
+        "addi.d $a2, $zero, 666\n"
+        "break 0\n");
 }
 #endif
 
@@ -367,7 +538,7 @@ static int wait_sigtrap(pid_t pid)
     return 0;
 }
 
-#if ARCH_RISCV
+#if ARCH_RISCV || ARCH_AARCH64 || ARCH_LOONGARCH
 static int check_singlestep_stops_before_target_side_effect(pid_t pid,
                                                            arch_user_regs *regs,
                                                            unsigned long pc,
@@ -522,6 +693,50 @@ static int test_singlestep(void)
         != 0) {
         return 1;
     }
+    #elif ARCH_AARCH64
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_b_target, 0, 0, 0, 0, 222)
+        != 0) {
+        return 1;
+    }
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_cbz_target, 0, 0, 0, 0, 333)
+        != 0) {
+        return 1;
+    }
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_tbnz_target, 1, 0, 0, 0, 444)
+        != 0) {
+        return 1;
+    }
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_br_target, 0, 0, 0,
+            (unsigned long)ss_br_landing, 555)
+        != 0) {
+        return 1;
+    }
+    #elif ARCH_LOONGARCH
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_b_target, 0, 0, 0, 0, 333)
+        != 0) {
+        return 1;
+    }
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_beq_target, 7, 7, 0, 0, 444)
+        != 0) {
+        return 1;
+    }
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_blt_target, 3, 9, 0, 0, 555)
+        != 0) {
+        return 1;
+    }
+    if (check_singlestep_stops_before_target_side_effect(
+            pid, &regs, (unsigned long)ss_jirl_target, 0, 0, 0,
+            (unsigned long)ss_jirl_landing, 666)
+        != 0) {
+        return 1;
+    }
     #endif
 
     if (ptrace(PTRACE_KILL, pid, NULL, NULL) != 0) {
@@ -530,6 +745,10 @@ static int test_singlestep(void)
     waitpid(pid, &status, 0);
     #if ARCH_RISCV
     printf("  ok: singlestep handled 32-bit and compressed control-flow instructions\n");
+    #elif ARCH_AARCH64
+    printf("  ok: singlestep handled aarch64 branch and register-branch instructions\n");
+    #elif ARCH_LOONGARCH
+    printf("  ok: singlestep handled loongarch64 branch and jirl instructions\n");
     #else
     printf("  ok: singlestep handled a known sequential instruction\n");
     #endif
@@ -585,10 +804,6 @@ static int test_fpregs(void)
 {
     printf("test 3: NT_FPREGSET get/set\n");
 
-#if !ARCH_RISCV
-    printf("  SKIP: NT_FPREGSET write-back test is riscv-only for now\n");
-    return 0;
-#else
     pid_t pid = fork();
     if (pid < 0) {
         return fail("fork");
@@ -600,8 +815,7 @@ static int test_fpregs(void)
         }
         raise(SIGSTOP);
 
-        unsigned long f0_bits = 0;
-        __asm__ volatile("fmv.x.d %0, f0" : "=r"(f0_bits));
+        unsigned long f0_bits = read_f0_bits();
         _exit(f0_bits == 0x4008000000000000UL ? 42 : 1);
     }
 
@@ -611,7 +825,7 @@ static int test_fpregs(void)
         return 1;
     }
 
-    struct riscv_user_fpregs fpregs;
+    arch_user_fpregs fpregs;
     struct iovec iov = {.iov_base = &fpregs, .iov_len = sizeof(fpregs)};
     if (ptrace(PTRACE_GETREGSET, pid, (void *)NT_FPREGSET, &iov) != 0) {
         printf("  SKIP: NT_FPREGSET not supported (errno=%d)\n", errno);
@@ -621,32 +835,29 @@ static int test_fpregs(void)
     }
 
     int all_zero = 1;
-    for (int i = 0; i < 32; i++) {
-        if (fpregs.f[i] != 0) {
-            all_zero = 0;
-            break;
-        }
+    if (fpregs_get_f0(&fpregs) != 0 || fpregs_get_f1(&fpregs) != 0) {
+        all_zero = 0;
     }
-    printf("  ok: NT_FPREGSET read, %s, fcsr=%#lx, iov_len=%zu\n",
+    printf("  ok: NT_FPREGSET read, %s, iov_len=%zu\n",
            all_zero ? "all-zero (FP unused)" : "has non-zero values",
-           fpregs.fcsr, (size_t)iov.iov_len);
+           (size_t)iov.iov_len);
 
-    fpregs.f[0] = 0x4008000000000000UL;
-    fpregs.f[1] = 0xCAFEBABEu;
+    fpregs_set_f0(&fpregs, 0x4008000000000000UL);
+    fpregs_set_f1(&fpregs, 0xCAFEBABEu);
     iov.iov_len = sizeof(fpregs);
     if (ptrace(PTRACE_SETREGSET, pid, (void *)NT_FPREGSET, &iov) != 0) {
         return fail("setregset fpregs");
     }
 
-    struct riscv_user_fpregs fpregs2;
+    arch_user_fpregs fpregs2;
     iov.iov_base = &fpregs2;
     iov.iov_len = sizeof(fpregs2);
     if (ptrace(PTRACE_GETREGSET, pid, (void *)NT_FPREGSET, &iov) != 0) {
         return fail("getregset fpregs after set");
     }
-    if (fpregs2.f[0] != 0x4008000000000000UL || fpregs2.f[1] != 0xCAFEBABEu) {
+    if (fpregs_get_f0(&fpregs2) != 0x4008000000000000UL || fpregs_get_f1(&fpregs2) != 0xCAFEBABEu) {
         printf("FAIL: fpregs write-back mismatch: f[0]=%#lx f[1]=%#lx\n",
-               fpregs2.f[0], fpregs2.f[1]);
+               fpregs_get_f0(&fpregs2), fpregs_get_f1(&fpregs2));
         return 1;
     }
     printf("  ok: NT_FPREGSET write and read-back match\n");
@@ -661,7 +872,6 @@ static int test_fpregs(void)
     }
     printf("  ok: NT_FPREGSET restored f0 into tracee execution state\n");
     return 0;
-#endif
 }
 
 static void wait_for_release_then_exit(int fd, int exit_code)


### PR DESCRIPTION
## 问题

当前 StarryOS 的 GDB/ptrace 多架构支持已经具备 riscv64 baseline，但 aarch64/loongarch64 仍有一些 usable subset 层面的缺口：

- aarch64/loongarch64 `PTRACE_SINGLESTEP` 对分支/跳转 next-PC 覆盖不完整。
- FP/SIMD regset 需要验证写回后确实恢复到 tracee 执行态。
- LoongArch 缺少 legacy `PTRACE_GETFPREGS` / `PTRACE_SETFPREGS`。
- `PTRACE_ATTACH` / `PTRACE_SEIZE` 仍偏 child-only，不能覆盖普通同 UID、dumpable 非父子进程 attach 场景。

## 修改内容

- 增强 aarch64 `PTRACE_SINGLESTEP` next-PC 处理，覆盖常见分支、条件分支、寄存器跳转和返回。
- 增强 loongarch64 `PTRACE_SINGLESTEP` next-PC 处理，覆盖常见分支、`jirl/ret`，并补充 `beqz/bnez`。
- 补充 riscv64/aarch64/loongarch64 FP/SIMD regset 写回到 tracee 执行态的测试。
- 为 loongarch64 支持 legacy `PTRACE_GETFPREGS` / `PTRACE_SETFPREGS`，并复用 `NT_FPREGSET` 的 stopped FP state 读写路径。
- 为 `PTRACE_ATTACH` / `PTRACE_SEIZE` 增加同 UID 非父子进程 attach 权限判断：
  - child tracee 保持原行为；
  - root 近似具备 `CAP_SYS_PTRACE`；
  - 普通进程要求 tracee `dumpable == 1`，且 tracer/tracee 凭证匹配。
- 扩展 `test-ptrace-gdb` focused case，覆盖上述路径：
  - dumpable=1 的同 UID sibling attach 正例；
  - dumpable=0 时 `PTRACE_ATTACH` / `PTRACE_SEIZE` 返回 `EPERM` 的负例。

## 验证

- `cargo fmt --all`
- `git diff --check`
- Docker 内 `cargo xtask clippy --package starry-kernel`：15/15 通过
- Docker 内三架构交叉编译 `test-ptrace-gdb`
- Docker 内 loongarch64 focused QEMU：
  `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/test-ptrace-gdb`
- Docker 内 riscv64 focused QEMU：
  `cargo xtask starry test qemu --arch riscv64 -c qemu-smp1/system/test-ptrace-gdb`

loongarch64 focused case 结果：`DONE: 19 pass, 0 fail`。
riscv64 focused case 结果：`DONE: 20 pass, 0 fail`。