### PR TITLE
feat(ax-runtime): prefer UEFI RTC on dynamic platform

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -40,7 +40,7 @@ Current Axvisor LoongArch QEMU tests intentionally use the static `ax-hal/loonga
 - Capture the memory map and kernel image physical range before address translation helpers depend on them.
 - Treat relocated symbols carefully. After relocation or high-half switch, use runtime-safe symbol address helpers instead of raw compile-time addresses.
 - Clear BSS exactly once and after preserving any entry data that lives there.
-- On LoongArch OVMF, capture the EFI FDT configuration table as well as ACPI RSDP. QEMU exposes LS7A RTC through the preserved FDT node `loongson,ls7a-rtc`; its ACPI DSDT may not contain a `LOON0001` RTC device.
+- On LoongArch OVMF, capture the EFI FDT configuration table as well as ACPI RSDP for firmware-described devices, but do not rediscover RTC in someboot/somehal through those tables. The dynamic UEFI RTC path should first use the UEFI Runtime Service `GetTime`; LS7A RTC nodes such as `loongson,ls7a-rtc` and ACPI `LOON0001` belong to the `ax-driver` fallback path when firmware RTC is unavailable.
 - Allocate and align boot stack, per-CPU areas, secondary stacks, boot arguments, and page tables before enabling SMP.
 - Install trap vectors before enabling interrupts, timer interrupts, MMU faults, or secondary CPU execution.
 - On x86 QEMU, do not trust CPUID timing leaves unless the reported TSC frequency is plausible; some virtual CPU combinations expose invalid zero or tiny values. Prefer a trusted hypervisor timing leaf, then CPUID timing data, then PIT-based TSC calibration before falling back to processor base frequency.

--- a/components/someboot/Cargo.toml
+++ b/components/someboot/Cargo.toml
@@ -55,6 +55,7 @@ aarch64-cpu = "11"
 aarch64-cpu-ext = "0.1"
 kasm-aarch64 = { workspace = true }
 smccc = "0.2"
+uefi.workspace = true
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 uefi.workspace = true

--- a/components/someboot/src/efi_stub/mod.rs
+++ b/components/someboot/src/efi_stub/mod.rs
@@ -383,7 +383,6 @@ mod tests {
     }
 }
 
-#[cfg(target_arch = "loongarch64")]
 pub fn is_uefi_available() -> bool {
     uefi::table::system_table_raw().is_some()
 }

--- a/components/someboot/src/lib.rs
+++ b/components/someboot/src/lib.rs
@@ -43,6 +43,7 @@ pub(crate) mod fdt;
 pub mod irq;
 pub mod mem;
 pub mod power;
+pub mod rtc;
 pub mod smp;
 pub mod timer;
 

--- a/components/someboot/src/rtc.rs
+++ b/components/someboot/src/rtc.rs
@@ -1,0 +1,181 @@
+#[cfg(any(efi, test))]
+const NANOS_PER_SEC: u64 = 1_000_000_000;
+#[cfg(any(efi, test))]
+const SECS_PER_DAY: i64 = 86_400;
+#[cfg(any(efi, test))]
+const UEFI_MIN_YEAR: i32 = 1900;
+#[cfg(any(efi, test))]
+const UEFI_MAX_YEAR: i32 = 9999;
+
+#[cfg(any(efi, test))]
+struct DateTimeParts {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+    nanosecond: u32,
+    timezone_minutes: Option<i16>,
+}
+
+/// Returns the current firmware wall-clock time as Unix epoch nanoseconds.
+pub fn epoch_time_nanos() -> Option<u64> {
+    epoch_time_nanos_impl()
+}
+
+#[cfg(efi)]
+fn epoch_time_nanos_impl() -> Option<u64> {
+    if !crate::efi_stub::is_uefi_available() {
+        return None;
+    }
+
+    let time = uefi::runtime::get_time().ok()?;
+    time.is_valid().ok()?;
+    datetime_to_epoch_nanos(DateTimeParts {
+        year: time.year(),
+        month: time.month(),
+        day: time.day(),
+        hour: time.hour(),
+        minute: time.minute(),
+        second: time.second(),
+        nanosecond: time.nanosecond(),
+        timezone_minutes: time.time_zone(),
+    })
+}
+
+#[cfg(not(efi))]
+fn epoch_time_nanos_impl() -> Option<u64> {
+    None
+}
+
+#[cfg(any(efi, test))]
+fn datetime_to_epoch_nanos(datetime: DateTimeParts) -> Option<u64> {
+    let year = i32::from(datetime.year);
+    let month = u32::from(datetime.month);
+    let day = u32::from(datetime.day);
+    let hour = u32::from(datetime.hour);
+    let minute = u32::from(datetime.minute);
+    let second = u32::from(datetime.second);
+
+    if !(UEFI_MIN_YEAR..=UEFI_MAX_YEAR).contains(&year)
+        || !(1..=12).contains(&month)
+        || !(1..=days_in_month(year, month)?).contains(&day)
+        || hour >= 24
+        || minute >= 60
+        || second >= 60
+        || datetime.nanosecond >= NANOS_PER_SEC as u32
+    {
+        return None;
+    }
+
+    let days_since_epoch = days_from_civil(year, month, day)?;
+    let seconds_of_day = i64::from(hour) * 3_600 + i64::from(minute) * 60 + i64::from(second);
+    let timezone_offset = i64::from(datetime.timezone_minutes.unwrap_or(0)) * 60;
+    let epoch_seconds = days_since_epoch
+        .checked_mul(SECS_PER_DAY)?
+        .checked_add(seconds_of_day)?
+        .checked_sub(timezone_offset)?;
+
+    if epoch_seconds < 0 {
+        return None;
+    }
+
+    let epoch_seconds = u64::try_from(epoch_seconds).ok()?;
+    epoch_seconds
+        .checked_mul(NANOS_PER_SEC)?
+        .checked_add(u64::from(datetime.nanosecond))
+}
+
+#[cfg(any(efi, test))]
+fn days_in_month(year: i32, month: u32) -> Option<u32> {
+    Some(match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => return None,
+    })
+}
+
+#[cfg(any(efi, test))]
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+#[cfg(any(efi, test))]
+fn days_from_civil(year: i32, month: u32, day: u32) -> Option<i64> {
+    let year = year - i32::from(month <= 2);
+    let era = year.div_euclid(400);
+    let year_of_era = year - era * 400;
+    let month = i32::try_from(month).ok()?;
+    let day = i32::try_from(day).ok()?;
+    let day_of_year = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    Some(i64::from(era) * 146_097 + i64::from(day_of_era) - 719_468)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn datetime_to_nanos(
+        year: u16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        nanosecond: u32,
+        timezone_minutes: Option<i16>,
+    ) -> Option<u64> {
+        datetime_to_epoch_nanos(DateTimeParts {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            nanosecond,
+            timezone_minutes,
+        })
+    }
+
+    #[test]
+    fn converts_utc_datetime_to_epoch_nanos() {
+        assert_eq!(
+            datetime_to_nanos(2024, 1, 2, 3, 4, 5, 6, None),
+            Some(1_704_164_645_000_000_006)
+        );
+    }
+
+    #[test]
+    fn accepts_leap_day() {
+        assert_eq!(
+            datetime_to_nanos(2024, 2, 29, 0, 0, 0, 0, None),
+            Some(1_709_164_800_000_000_000)
+        );
+    }
+
+    #[test]
+    fn applies_uefi_timezone_offset_minutes() {
+        assert_eq!(
+            datetime_to_nanos(2024, 1, 2, 3, 4, 5, 0, Some(480)),
+            Some(1_704_135_845_000_000_000)
+        );
+    }
+
+    #[test]
+    fn treats_unspecified_timezone_as_utc() {
+        assert_eq!(datetime_to_nanos(1970, 1, 1, 0, 0, 0, 0, None), Some(0));
+    }
+
+    #[test]
+    fn rejects_invalid_datetime_fields() {
+        assert_eq!(datetime_to_nanos(2023, 2, 29, 0, 0, 0, 0, None), None);
+        assert_eq!(
+            datetime_to_nanos(2024, 1, 1, 0, 0, 0, 1_000_000_000, None),
+            None
+        );
+    }
+}

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -23,7 +23,7 @@ irq = [
 ]
 multitask = ["ax-task/multitask"]
 paging = ["ax-hal/paging", "dep:ax-mm", "dep:axklib"]
-rtc = ["ax-driver/rtc"]
+rtc = ["ax-hal/rtc", "ax-driver/rtc"]
 smp = ["ax-hal/smp", "ax-task?/smp"]
 stack-guard-page = ["multitask", "paging", "ax-task/stack-guard-page"]
 stack-protector = []

--- a/platforms/axplat-dyn/src/generic_timer.rs
+++ b/platforms/axplat-dyn/src/generic_timer.rs
@@ -37,6 +37,22 @@ pub fn try_init_epoch_offset(epoch_time_nanos: u64) -> bool {
         .is_ok()
 }
 
+#[cfg(all(feature = "rtc", target_arch = "loongarch64"))]
+pub(crate) fn try_init_epoch_offset_from_firmware() -> bool {
+    let Some(epoch_time_nanos) = somehal::rtc::epoch_time_nanos() else {
+        debug!("axplat-dyn: firmware RTC is not available");
+        return false;
+    };
+
+    if try_init_epoch_offset(epoch_time_nanos) {
+        info!("axplat-dyn: initialized wall clock from firmware RTC");
+        true
+    } else {
+        debug!("axplat-dyn: firmware RTC skipped because epoch offset is already initialized");
+        false
+    }
+}
+
 struct GenericTimer;
 
 #[impl_plat_interface]

--- a/platforms/axplat-dyn/src/init.rs
+++ b/platforms/axplat-dyn/src/init.rs
@@ -28,6 +28,8 @@ impl InitIf for InitIfImpl {
     /// platform configuration and initialization.
     fn init_later(_cpu_id: usize, _dtb: usize) {
         somehal::post_paging();
+        #[cfg(all(feature = "rtc", target_arch = "loongarch64"))]
+        crate::generic_timer::try_init_epoch_offset_from_firmware();
         somehal::timer::irq_enable();
     }
 

--- a/platforms/somehal/src/lib.rs
+++ b/platforms/somehal/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod common;
 pub mod cpu;
 mod driver;
 pub mod irq;
+pub mod rtc;
 pub mod setup;
 
 pub use page_table_generic::{PagingError, PagingResult};

--- a/platforms/somehal/src/rtc.rs
+++ b/platforms/somehal/src/rtc.rs
@@ -1,0 +1,4 @@
+/// Returns the current firmware wall-clock time as Unix epoch nanoseconds.
+pub fn epoch_time_nanos() -> Option<u64> {
+    someboot::rtc::epoch_time_nanos()
+}


### PR DESCRIPTION
## 问题

LoongArch 动态 UEFI 启动路径下，someboot/somehal 不应该为了 RTC 再走一遍 ACPI/FDT 设备发现；UEFI firmware 已经提供 Runtime Service `GetTime` 时，应优先用固件时间初始化 wall clock。只有固件 RTC 不可用时，才回落到 `ax-driver` 的 RTC 驱动探测。

## 改动

- 在 `someboot` 新增 `rtc::epoch_time_nanos()`，通过 UEFI Runtime `GetTime` 获取时间，并完成日期合法性、闰年、纳秒和 timezone offset 处理。
- 在 `somehal` 新增 RTC 转发接口，只暴露 firmware RTC，不通过 ACPI/FDT 重新发现 RTC。
- 在 `axplat-dyn::init_later()` 中，在 `somehal::post_paging()` 后、设备驱动探测前尝试用 firmware RTC 初始化 epoch offset；实际消费该 firmware RTC 的路径限定在 LoongArch 动态平台，避免改变 x86_64 动态 UEFI 启动路径。
- 调整 `ax-runtime/rtc` feature，同时启用 `ax-hal/rtc` 与 `ax-driver/rtc`，保证顺序为 firmware first、driver fallback。
- 保留 `ax-driver` 现有 Loongson RTC 逻辑作为 fallback，并更新 arch porting 说明，明确 FDT/ACPI RTC 只属于 driver fallback 路径。
- 将 `someboot` 的 UEFI 时间转换 helper 限定在 `efi` 或测试构建中启用，避免非 EFI 构建产生无用代码 warning。

## 验证

- `cargo fmt`
- `cargo test -p someboot --lib`
- `cargo test -p ax-driver --features rtc time::`
- `cargo test -p ax-runtime --lib --features plat-dyn`
- `cargo xtask clippy --package someboot`
- `cargo xtask clippy --package somehal`
- `cargo xtask clippy --package axplat-dyn`
- `cargo xtask clippy --package ax-runtime`
- `cargo xtask clippy --package ax-driver`
- `cargo xtask arceos test qemu --arch x86_64`
- `timeout 420s cargo xtask starry test qemu --arch riscv64 -c qemu-smp4/system/affinity-bug-sched-affinity-pid`
- `timeout 90s cargo xtask starry qemu --config os/StarryOS/configs/board/qemu-loongarch64-uefi.toml`
  - QEMU 成功进入 Starry shell。
  - 启动日志打印 `Boot at 2026-06-17 07:03:17... UTC`，确认 LoongArch UEFI 路径没有回落到 1970。
- GitHub Actions CI：最新 run `27685505784` 全部通过。