### PR TITLE
fix(somehal): send x86 helper IPI on IPI vector

### DIFF
--- a/platforms/somehal/src/arch/x86_64/mod.rs
+++ b/platforms/somehal/src/arch/x86_64/mod.rs
@@ -15,6 +15,7 @@ use crate::common::PlatOp;
 pub struct Plat;
 
 const APIC_TIMER_VECTOR: usize = 0x20;
+const APIC_IPI_VECTOR: usize = 0xf3;
 const LAPIC_REG_EOI: u32 = 0x0b0;
 const LAPIC_REG_ICR_LOW: u32 = 0x300;
 const LAPIC_REG_ICR_HIGH: u32 = 0x310;
@@ -264,7 +265,7 @@ impl PlatOp for Plat {
 
     fn send_ipi_to_cpu(cpu_id: usize) {
         Self::send_ipi(
-            APIC_TIMER_VECTOR.into(),
+            APIC_IPI_VECTOR.into(),
             crate::irq::IpiTarget::Other { cpu_id },
         );
     }


### PR DESCRIPTION
# fix(somehal): send x86 helper IPI on IPI vector

## 问题

Agent 检查工作时发现一处可能是 bug 的地方。x86_64 dynamic platform 的 `IPI_IRQ` 定义为 `0xf3`，runtime 也用该 IRQ 注册 `ipi_irq_handler`。但 `somehal` 的 x86 `send_ipi_to_cpu()` helper 错误发送了 LAPIC timer vector `0x20`，导致 helper 路径的 IPI 会被分派为 systimer IRQ，而不是进入 IPI handler。

## 修改

- 在 `platforms/somehal/src/arch/x86_64/mod.rs` 增加 `APIC_IPI_VECTOR = 0xf3`。
- 将 `send_ipi_to_cpu()` 从发送 `APIC_TIMER_VECTOR` 改为发送 `APIC_IPI_VECTOR`。
- 保持 timer vector `0x20` 的原有用途不变。

## 影响

- 修复 x86 helper-based IPI 的分派语义。
- 避免 IPI 被误当作 LAPIC timer interrupt 处理。
- 不影响正常 timer IRQ 路径。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package somehal`
