### PR TITLE
feat(starry): add block I/O bench app

### DIFF
--- a/apps/starry/block-io-bench/README.md
+++ b/apps/starry/block-io-bench/README.md
@@ -9,12 +9,21 @@ Run it with:
 cargo xtask starry app qemu -t block-io-bench --arch x86_64
 ```
 
+To compare the same workload through the NVMe QEMU device model, run:
+
+```bash
+cargo xtask starry app qemu \
+  -t block-io-bench \
+  --arch x86_64 \
+  --qemu-config qemu-x86_64-nvme.toml
+```
+
 The app injects a static `/usr/bin/block-io-bench` binary and a small shell
 wrapper into a managed Alpine rootfs. The wrapper runs several benchmark rounds
 and prints machine-readable log lines:
 
 ```text
-BLOCK_BENCH_CONFIG path=/root/block-io-bench-app rounds=5 bytes=4194304 block_bytes=4096
+BLOCK_BENCH_CONFIG path=/root/block-io-bench-app rounds=5 bytes=4194304 block_bytes=4096 fsync=1
 BLOCK_BENCH_ROUND op=write round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
 BLOCK_BENCH_ROUND op=read round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
 BLOCK_BENCH_RESULT op=write round=5 bytes=4194304 elapsed_us=... mib_s=... checksum=...
@@ -30,6 +39,13 @@ blocks. Override these from the QEMU shell environment when needed:
 BLOCK_BENCH_ROUNDS=7 \
 BLOCK_BENCH_BYTES=8388608 \
 BLOCK_BENCH_BLOCK_BYTES=4096 \
+BLOCK_BENCH_FSYNC=1 \
 BLOCK_BENCH_PATH=/root/custom-block-io-bench \
 /usr/bin/block-io-bench.sh
 ```
+
+The default `qemu-x86_64.toml` uses `virtio-blk-pci`; the
+`qemu-x86_64-nvme.toml` variant uses `nvme,serial=starry-block-io-bench` and
+sets `BLOCK_BENCH_FSYNC=0`, because the current QEMU NVMe path reports an I/O
+error for the app's per-round `fsync` flush. The `BLOCK_BENCH_CONFIG` line
+includes `fsync=...` so comparison logs keep this difference explicit.

--- a/apps/starry/block-io-bench/README.md
+++ b/apps/starry/block-io-bench/README.md
@@ -1,0 +1,35 @@
+# block-io-bench
+
+`block-io-bench` is an operator-facing StarryOS QEMU app for collecting simple
+filesystem read/write throughput numbers from the current root block device.
+
+Run it with:
+
+```bash
+cargo xtask starry app qemu -t block-io-bench --arch x86_64
+```
+
+The app injects a static `/usr/bin/block-io-bench` binary and a small shell
+wrapper into a managed Alpine rootfs. The wrapper runs several benchmark rounds
+and prints machine-readable log lines:
+
+```text
+BLOCK_BENCH_CONFIG path=/root/block-io-bench-app rounds=5 bytes=4194304 block_bytes=4096
+BLOCK_BENCH_ROUND op=write round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
+BLOCK_BENCH_ROUND op=read round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
+BLOCK_BENCH_RESULT op=write round=5 bytes=4194304 elapsed_us=... mib_s=... checksum=...
+BLOCK_BENCH_RESULT op=read round=5 bytes=4194304 elapsed_us=... mib_s=... checksum=...
+BLOCK_BENCH_APP_PASSED
+```
+
+The `BLOCK_BENCH_RESULT` lines report the median elapsed time across all rounds.
+The default workload uses five rounds, a 4 MiB file per round, and 4 KiB I/O
+blocks. Override these from the QEMU shell environment when needed:
+
+```sh
+BLOCK_BENCH_ROUNDS=7 \
+BLOCK_BENCH_BYTES=8388608 \
+BLOCK_BENCH_BLOCK_BYTES=4096 \
+BLOCK_BENCH_PATH=/root/custom-block-io-bench \
+/usr/bin/block-io-bench.sh
+```

--- a/apps/starry/block-io-bench/block-io-bench.c
+++ b/apps/starry/block-io-bench/block-io-bench.c
@@ -1,0 +1,273 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define DEFAULT_BASE_PATH "/root/block-io-bench"
+#define DEFAULT_BYTES (4ULL * 1024ULL * 1024ULL)
+#define DEFAULT_BLOCK_BYTES (4ULL * 1024ULL)
+#define DEFAULT_ROUNDS 5U
+#define MAX_ROUNDS 32U
+
+struct bench_config {
+    const char *base_path;
+    uint64_t bytes;
+    size_t block_bytes;
+    unsigned rounds;
+};
+
+struct bench_sample {
+    uint64_t elapsed_us;
+};
+
+static void usage(const char *program) {
+    fprintf(stderr,
+            "usage: %s [--path BASE] [--bytes BYTES] [--block-bytes BYTES] [--rounds N]\n",
+            program);
+}
+
+static uint64_t parse_u64(const char *name, const char *value, uint64_t min) {
+    char *end = NULL;
+    errno = 0;
+    unsigned long long parsed = strtoull(value, &end, 0);
+    if (errno != 0 || end == value || *end != '\0' || parsed < min) {
+        fprintf(stderr, "invalid %s: %s\n", name, value);
+        exit(2);
+    }
+    return (uint64_t)parsed;
+}
+
+static struct bench_config parse_args(int argc, char **argv) {
+    struct bench_config config = {
+        .base_path = DEFAULT_BASE_PATH,
+        .bytes = DEFAULT_BYTES,
+        .block_bytes = DEFAULT_BLOCK_BYTES,
+        .rounds = DEFAULT_ROUNDS,
+    };
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--path") == 0 && i + 1 < argc) {
+            config.base_path = argv[++i];
+        } else if (strcmp(argv[i], "--bytes") == 0 && i + 1 < argc) {
+            config.bytes = parse_u64("bytes", argv[++i], 1);
+        } else if (strcmp(argv[i], "--block-bytes") == 0 && i + 1 < argc) {
+            config.block_bytes = (size_t)parse_u64("block-bytes", argv[++i], 1);
+        } else if (strcmp(argv[i], "--rounds") == 0 && i + 1 < argc) {
+            config.rounds = (unsigned)parse_u64("rounds", argv[++i], 1);
+            if (config.rounds > MAX_ROUNDS) {
+                fprintf(stderr, "rounds must be <= %u\n", MAX_ROUNDS);
+                exit(2);
+            }
+        } else if (strcmp(argv[i], "--help") == 0) {
+            usage(argv[0]);
+            exit(0);
+        } else {
+            usage(argv[0]);
+            exit(2);
+        }
+    }
+
+    if (config.bytes % config.block_bytes != 0) {
+        fprintf(stderr, "bytes must be a multiple of block-bytes\n");
+        exit(2);
+    }
+    return config;
+}
+
+static uint64_t now_us(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        perror("clock_gettime");
+        exit(1);
+    }
+    return (uint64_t)ts.tv_sec * 1000000ULL + (uint64_t)ts.tv_nsec / 1000ULL;
+}
+
+static void fill_buffer(uint8_t *buf, size_t len, unsigned round, uint64_t offset) {
+    for (size_t i = 0; i < len; i++) {
+        buf[i] = (uint8_t)(((offset + i) * 131ULL + (uint64_t)round * 17ULL) & 0xffU);
+    }
+}
+
+static uint64_t checksum_buffer(const uint8_t *buf, size_t len) {
+    uint64_t sum = 0;
+    for (size_t i = 0; i < len; i++) {
+        sum += buf[i];
+    }
+    return sum;
+}
+
+static void checked_write_all(int fd, const uint8_t *buf, size_t len) {
+    size_t done = 0;
+    while (done < len) {
+        ssize_t ret = write(fd, buf + done, len - done);
+        if (ret < 0) {
+            perror("write");
+            exit(1);
+        }
+        if (ret == 0) {
+            fprintf(stderr, "write returned zero\n");
+            exit(1);
+        }
+        done += (size_t)ret;
+    }
+}
+
+static void checked_read_all(int fd, uint8_t *buf, size_t len) {
+    size_t done = 0;
+    while (done < len) {
+        ssize_t ret = read(fd, buf + done, len - done);
+        if (ret < 0) {
+            perror("read");
+            exit(1);
+        }
+        if (ret == 0) {
+            fprintf(stderr, "short read: %zu/%zu\n", done, len);
+            exit(1);
+        }
+        done += (size_t)ret;
+    }
+}
+
+static int compare_samples(const void *a, const void *b) {
+    const struct bench_sample *lhs = a;
+    const struct bench_sample *rhs = b;
+    return (lhs->elapsed_us > rhs->elapsed_us) - (lhs->elapsed_us < rhs->elapsed_us);
+}
+
+static struct bench_sample median_sample(const struct bench_sample *samples, unsigned rounds) {
+    struct bench_sample sorted[MAX_ROUNDS];
+    memcpy(sorted, samples, rounds * sizeof(sorted[0]));
+    qsort(sorted, rounds, sizeof(sorted[0]), compare_samples);
+    return sorted[rounds / 2];
+}
+
+static uint64_t mib_s_x100(uint64_t bytes, uint64_t elapsed_us) {
+    if (elapsed_us == 0) {
+        return 0;
+    }
+    return bytes * 100000000ULL / (1024ULL * 1024ULL) / elapsed_us;
+}
+
+static void print_speed(const char *prefix, const char *op, unsigned round, uint64_t bytes,
+                        uint64_t elapsed_us, uint64_t checksum) {
+    uint64_t speed = mib_s_x100(bytes, elapsed_us);
+    printf("%s op=%s round=%u bytes=%llu elapsed_us=%llu mib_s=%llu.%02llu checksum=%llu\n",
+           prefix, op, round, (unsigned long long)bytes, (unsigned long long)elapsed_us,
+           (unsigned long long)(speed / 100), (unsigned long long)(speed % 100),
+           (unsigned long long)checksum);
+    fflush(stdout);
+}
+
+static void bench_path(char *path, size_t len, const char *base_path, unsigned round) {
+    int written = snprintf(path, len, "%s-%u.dat", base_path, round);
+    if (written < 0 || (size_t)written >= len) {
+        fprintf(stderr, "bench path too long: %s\n", base_path);
+        exit(1);
+    }
+}
+
+static uint64_t run_write_round(const struct bench_config *config, uint8_t *buf, unsigned round,
+                                const char *path) {
+    int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+    if (fd < 0) {
+        perror("open write");
+        exit(1);
+    }
+
+    printf("BLOCK_BENCH_PROGRESS phase=write round=%u path=%s\n", round, path);
+    fflush(stdout);
+
+    uint64_t start = now_us();
+    for (uint64_t done = 0; done < config->bytes; done += config->block_bytes) {
+        fill_buffer(buf, config->block_bytes, round, done);
+        checked_write_all(fd, buf, config->block_bytes);
+    }
+    printf("BLOCK_BENCH_PROGRESS phase=fsync round=%u path=%s\n", round, path);
+    fflush(stdout);
+    if (fsync(fd) != 0) {
+        perror("fsync");
+        exit(1);
+    }
+    uint64_t end = now_us();
+
+    if (close(fd) != 0) {
+        perror("close write");
+        exit(1);
+    }
+    return end - start;
+}
+
+static uint64_t run_read_round(const struct bench_config *config, uint8_t *buf, unsigned round,
+                               const char *path, uint64_t *checksum) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        perror("open read");
+        exit(1);
+    }
+
+    printf("BLOCK_BENCH_PROGRESS phase=read round=%u path=%s\n", round, path);
+    fflush(stdout);
+
+    uint64_t start = now_us();
+    for (uint64_t done = 0; done < config->bytes; done += config->block_bytes) {
+        checked_read_all(fd, buf, config->block_bytes);
+        *checksum += checksum_buffer(buf, config->block_bytes);
+    }
+    uint64_t end = now_us();
+
+    if (close(fd) != 0) {
+        perror("close read");
+        exit(1);
+    }
+    return end - start;
+}
+
+int main(int argc, char **argv) {
+    struct bench_config config = parse_args(argc, argv);
+    uint8_t *buf = malloc(config.block_bytes);
+    if (buf == NULL) {
+        perror("malloc");
+        return 1;
+    }
+
+    printf("BLOCK_BENCH_CONFIG path=%s rounds=%u bytes=%llu block_bytes=%zu\n",
+           config.base_path, config.rounds, (unsigned long long)config.bytes, config.block_bytes);
+    fflush(stdout);
+
+    struct bench_sample write_samples[MAX_ROUNDS];
+    struct bench_sample read_samples[MAX_ROUNDS];
+    uint64_t checksum = 0;
+
+    for (unsigned round = 0; round < config.rounds; round++) {
+        char path[256];
+        bench_path(path, sizeof(path), config.base_path, round);
+        unlink(path);
+
+        uint64_t write_us = run_write_round(&config, buf, round, path);
+        write_samples[round].elapsed_us = write_us;
+        print_speed("BLOCK_BENCH_ROUND", "write", round, config.bytes, write_us, checksum);
+
+        uint64_t read_us = run_read_round(&config, buf, round, path, &checksum);
+        read_samples[round].elapsed_us = read_us;
+        print_speed("BLOCK_BENCH_ROUND", "read", round, config.bytes, read_us, checksum);
+
+        unlink(path);
+    }
+
+    struct bench_sample write_median = median_sample(write_samples, config.rounds);
+    struct bench_sample read_median = median_sample(read_samples, config.rounds);
+    print_speed("BLOCK_BENCH_RESULT", "write", config.rounds, config.bytes,
+                write_median.elapsed_us, checksum);
+    print_speed("BLOCK_BENCH_RESULT", "read", config.rounds, config.bytes,
+                read_median.elapsed_us, checksum);
+
+    free(buf);
+    return 0;
+}

--- a/apps/starry/block-io-bench/block-io-bench.c
+++ b/apps/starry/block-io-bench/block-io-bench.c
@@ -20,6 +20,7 @@ struct bench_config {
     uint64_t bytes;
     size_t block_bytes;
     unsigned rounds;
+    int fsync_enabled;
 };
 
 struct bench_sample {
@@ -28,7 +29,8 @@ struct bench_sample {
 
 static void usage(const char *program) {
     fprintf(stderr,
-            "usage: %s [--path BASE] [--bytes BYTES] [--block-bytes BYTES] [--rounds N]\n",
+            "usage: %s [--path BASE] [--bytes BYTES] [--block-bytes BYTES] [--rounds N] "
+            "[--no-fsync]\n",
             program);
 }
 
@@ -49,6 +51,7 @@ static struct bench_config parse_args(int argc, char **argv) {
         .bytes = DEFAULT_BYTES,
         .block_bytes = DEFAULT_BLOCK_BYTES,
         .rounds = DEFAULT_ROUNDS,
+        .fsync_enabled = 1,
     };
 
     for (int i = 1; i < argc; i++) {
@@ -64,6 +67,8 @@ static struct bench_config parse_args(int argc, char **argv) {
                 fprintf(stderr, "rounds must be <= %u\n", MAX_ROUNDS);
                 exit(2);
             }
+        } else if (strcmp(argv[i], "--no-fsync") == 0) {
+            config.fsync_enabled = 0;
         } else if (strcmp(argv[i], "--help") == 0) {
             usage(argv[0]);
             exit(0);
@@ -189,11 +194,13 @@ static uint64_t run_write_round(const struct bench_config *config, uint8_t *buf,
         fill_buffer(buf, config->block_bytes, round, done);
         checked_write_all(fd, buf, config->block_bytes);
     }
-    printf("BLOCK_BENCH_PROGRESS phase=fsync round=%u path=%s\n", round, path);
-    fflush(stdout);
-    if (fsync(fd) != 0) {
-        perror("fsync");
-        exit(1);
+    if (config->fsync_enabled) {
+        printf("BLOCK_BENCH_PROGRESS phase=fsync round=%u path=%s\n", round, path);
+        fflush(stdout);
+        if (fsync(fd) != 0) {
+            perror("fsync");
+            exit(1);
+        }
     }
     uint64_t end = now_us();
 
@@ -237,8 +244,9 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    printf("BLOCK_BENCH_CONFIG path=%s rounds=%u bytes=%llu block_bytes=%zu\n",
-           config.base_path, config.rounds, (unsigned long long)config.bytes, config.block_bytes);
+    printf("BLOCK_BENCH_CONFIG path=%s rounds=%u bytes=%llu block_bytes=%zu fsync=%d\n",
+           config.base_path, config.rounds, (unsigned long long)config.bytes, config.block_bytes,
+           config.fsync_enabled);
     fflush(stdout);
 
     struct bench_sample write_samples[MAX_ROUNDS];

--- a/apps/starry/block-io-bench/block-io-bench.sh
+++ b/apps/starry/block-io-bench/block-io-bench.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -u
+
+rounds="${BLOCK_BENCH_ROUNDS:-5}"
+bytes="${BLOCK_BENCH_BYTES:-4194304}"
+block_bytes="${BLOCK_BENCH_BLOCK_BYTES:-4096}"
+path="${BLOCK_BENCH_PATH:-/root/block-io-bench-app}"
+
+echo "BLOCK_BENCH_APP_START rounds=$rounds bytes=$bytes block_bytes=$block_bytes path=$path"
+
+/usr/bin/block-io-bench \
+    --rounds "$rounds" \
+    --bytes "$bytes" \
+    --block-bytes "$block_bytes" \
+    --path "$path"
+status=$?
+
+echo "BLOCK_BENCH_APP_DONE rc=$status"
+if [ "$status" -eq 0 ]; then
+    echo "BLOCK_BENCH_APP_PASSED"
+else
+    echo "BLOCK_BENCH_APP_FAILED"
+fi
+exit "$status"

--- a/apps/starry/block-io-bench/block-io-bench.sh
+++ b/apps/starry/block-io-bench/block-io-bench.sh
@@ -5,14 +5,27 @@ rounds="${BLOCK_BENCH_ROUNDS:-5}"
 bytes="${BLOCK_BENCH_BYTES:-4194304}"
 block_bytes="${BLOCK_BENCH_BLOCK_BYTES:-4096}"
 path="${BLOCK_BENCH_PATH:-/root/block-io-bench-app}"
+fsync="${BLOCK_BENCH_FSYNC:-1}"
+fsync_args=""
 
-echo "BLOCK_BENCH_APP_START rounds=$rounds bytes=$bytes block_bytes=$block_bytes path=$path"
+case "$fsync" in
+0 | false | False | FALSE | no | No | NO)
+    fsync=0
+    fsync_args="--no-fsync"
+    ;;
+*)
+    fsync=1
+    ;;
+esac
+
+echo "BLOCK_BENCH_APP_START rounds=$rounds bytes=$bytes block_bytes=$block_bytes path=$path fsync=$fsync"
 
 /usr/bin/block-io-bench \
     --rounds "$rounds" \
     --bytes "$bytes" \
     --block-bytes "$block_bytes" \
-    --path "$path"
+    --path "$path" \
+    $fsync_args
 status=$?
 
 echo "BLOCK_BENCH_APP_DONE rc=$status"

--- a/apps/starry/block-io-bench/build-x86_64-unknown-none.toml
+++ b/apps/starry/block-io-bench/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/block-io-bench/build-x86_64-unknown-none.toml
+++ b/apps/starry/block-io-bench/build-x86_64-unknown-none.toml
@@ -1,6 +1,7 @@
 target = "x86_64-unknown-none"
 log = "Warn"
 features = [
+  "ax-driver/nvme",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
   "ax-driver/virtio-gpu",

--- a/apps/starry/block-io-bench/prebuild.sh
+++ b/apps/starry/block-io-bench/prebuild.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+overlay_dir="${STARRY_OVERLAY_DIR:-}"
+
+if [[ -z "$overlay_dir" ]]; then
+    echo "error: STARRY_OVERLAY_DIR is required" >&2
+    exit 1
+fi
+
+case "$STARRY_ARCH" in
+    x86_64)
+        compilers=(
+            x86_64-linux-musl-gcc
+            musl-gcc
+            x86_64-linux-gnu-gcc
+            gcc
+        )
+        ;;
+    *)
+        echo "ERROR: unsupported arch for block-io-bench app: $STARRY_ARCH" >&2
+        exit 1
+        ;;
+esac
+
+cc=""
+for candidate in "${compilers[@]}"; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        cc="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$cc" ]]; then
+    echo "ERROR: no C compiler found for $STARRY_ARCH" >&2
+    exit 1
+fi
+
+build_dir="$(mktemp -d)"
+trap 'rm -rf "$build_dir"' EXIT
+
+"$cc" \
+    -std=c11 \
+    -O2 \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -static \
+    "$app_dir/block-io-bench.c" \
+    -o "$build_dir/block-io-bench"
+
+install -Dm0755 "$build_dir/block-io-bench" "$overlay_dir/usr/bin/block-io-bench"
+install -Dm0755 "$app_dir/block-io-bench.sh" "$overlay_dir/usr/bin/block-io-bench.sh"

--- a/apps/starry/block-io-bench/qemu-x86_64-nvme.toml
+++ b/apps/starry/block-io-bench/qemu-x86_64-nvme.toml
@@ -1,0 +1,27 @@
+args = [
+    "-machine",
+    "q35",
+    "-nographic",
+    "-m",
+    "512M",
+    "-drive",
+    "id=nvm,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device",
+    "nvme,serial=starry-block-io-bench,drive=nvm",
+    "-snapshot",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "BLOCK_BENCH_FSYNC=0 /usr/bin/block-io-bench.sh"
+success_regex = [
+    "(?m)^BLOCK_BENCH_APP_PASSED\\s*$",
+]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)segmentation fault",
+    "(?i)kernel panic",
+    "(?i)panicked at",
+    "(?m)^BLOCK_BENCH_APP_FAILED\\s*$",
+]
+timeout = 300

--- a/apps/starry/block-io-bench/qemu-x86_64.toml
+++ b/apps/starry/block-io-bench/qemu-x86_64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-snapshot",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/block-io-bench.sh"
+success_regex = [
+    "(?m)^BLOCK_BENCH_APP_PASSED\\s*$",
+]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)segmentation fault",
+    "(?i)kernel panic",
+    "(?i)panicked at",
+    "(?m)^BLOCK_BENCH_APP_FAILED\\s*$",
+]
+timeout = 300


### PR DESCRIPTION
## 背景

当前需要一个独立的 Starry app 示例，用于快速测量 QEMU 环境下 root block device 的文件系统读写性能，并输出方便脚本解析的日志，便于后续对比不同块设备路径或 runtime 改动的影响。

## 修改内容

- 新增 `apps/starry/block-io-bench` QEMU app。
- `prebuild.sh` 在宿主侧编译静态 C benchmark，并注入 `/usr/bin/block-io-bench` 与 `/usr/bin/block-io-bench.sh`。
- benchmark 默认运行 5 轮，每轮写入并读取一个 4 MiB 文件，块大小 4 KiB；默认 virtio 配置执行 per-round `fsync`。
- 新增 `BLOCK_BENCH_FSYNC` / `--no-fsync` 开关，日志会在 `BLOCK_BENCH_CONFIG` 中输出 `fsync=...`，便于区分对比语义。
- 新增 NVMe QEMU 配置 `qemu-x86_64-nvme.toml`，使用 `nvme,serial=starry-block-io-bench,drive=nvm` 作为 root block device。
- x86_64 build 配置同时启用 `ax-driver/virtio-blk` 与 `ax-driver/nvme`，便于同一个 app 对比两种 QEMU device model。
- 输出稳定的机器可读日志：
  - `BLOCK_BENCH_CONFIG ... fsync=...`
  - `BLOCK_BENCH_ROUND op=write/read ...`
  - `BLOCK_BENCH_RESULT op=write/read ...`
  - `BLOCK_BENCH_APP_PASSED`
- 新增 README，说明 virtio/NVMe 运行命令和可通过环境变量覆盖 rounds、bytes、block size、path、fsync。

## 设计说明

- app 使用 `cargo xtask starry app qemu -t block-io-bench --arch x86_64` 直接运行，保持 operator-facing workflow，不进入 test-suit CI 分组。
- QEMU config 不写死派生 rootfs 文件路径，交给 app runner 注入 overlay 后 patch 默认 managed rootfs，避免派生 rootfs 名被二次当作 registry image 拉取。
- `success_regex` 只匹配最终 `BLOCK_BENCH_APP_PASSED`，避免 write/read 中间结果提前触发成功。
- NVMe 配置默认设置 `BLOCK_BENCH_FSYNC=0`。原因是当前 QEMU NVMe 路径在 app 的 per-round `fsync` 上会返回 I/O error；这里先把吞吐对比跑通，并通过 `fsync=0` 日志字段明确标注该差异。

## 本地对比结果

| 配置 | QEMU 设备 | completion | fsync | median write MiB/s | median read MiB/s | 日志 |
| --- | --- | --- | --- | ---: | ---: | --- |
| `qemu-x86_64.toml` | `virtio-blk-pci` | polling fallback | 1 | 15.25 | 744.46 | `/tmp/starry-block-io-bench-virtio-latest.log` |
| `qemu-x86_64-nvme.toml` | `nvme,serial=starry-block-io-bench` | IRQ-driven | 0 | 12.59 | 764.37 | `/tmp/starry-block-io-bench-nvme-latest.log` |

关键日志片段：

```text
# virtio
BLOCK_BENCH_CONFIG path=/root/block-io-bench-app rounds=5 bytes=4194304 block_bytes=4096 fsync=1
BLOCK_BENCH_RESULT op=write round=5 bytes=4194304 elapsed_us=262221 mib_s=15.25 checksum=2673868800
BLOCK_BENCH_RESULT op=read round=5 bytes=4194304 elapsed_us=5373 mib_s=744.46 checksum=2673868800
BLOCK_BENCH_APP_PASSED

# nvme
rdif filesystem block device nvme registered with IRQ-driven completion
BLOCK_BENCH_CONFIG path=/root/block-io-bench-app rounds=5 bytes=4194304 block_bytes=4096 fsync=0
BLOCK_BENCH_RESULT op=write round=5 bytes=4194304 elapsed_us=317554 mib_s=12.59 checksum=2673868800
BLOCK_BENCH_RESULT op=read round=5 bytes=4194304 elapsed_us=5233 mib_s=764.37 checksum=2673868800
BLOCK_BENCH_APP_PASSED
```

## 验证

- `bash -n apps/starry/block-io-bench/prebuild.sh apps/starry/block-io-bench/block-io-bench.sh`
- `x86_64-linux-musl-gcc -static -O2 -std=c11 -Wall -Wextra -Werror apps/starry/block-io-bench/block-io-bench.c -o /tmp/block-io-bench-test && /tmp/block-io-bench-test --rounds 2 --bytes 8192 --block-bytes 1024 --path /tmp/block-io-bench-test --no-fsync`
- `cargo fmt --check`
- `git diff --check`
- `cargo xtask starry app list --kind qemu | rg 'block-io-bench'`
- `cargo xtask clippy --package axbuild`
- `cargo xtask starry app qemu -t block-io-bench --arch x86_64`
- `cargo xtask starry app qemu -t block-io-bench --arch x86_64 --qemu-config qemu-x86_64-nvme.toml`