### PR TITLE
chore(arceos): clean up Hermit remnants

### DIFF
--- a/apps/arceos/arce_agent/src/lineedit.rs
+++ b/apps/arceos/arce_agent/src/lineedit.rs
@@ -8,7 +8,7 @@
 //   - Insert in the middle of the line with redraw
 //   - Command history (Up / Down arrows)
 //
-// No external crate dependencies — works on ArceOS Hermit target.
+// No external crate dependencies; works with ArceOS std console builds.
 
 use std::io::{self, Read, Write};
 

--- a/apps/arceos/io_test/src/main.rs
+++ b/apps/arceos/io_test/src/main.rs
@@ -349,7 +349,7 @@ fn read_directory() -> io::Result<()> {
         println!("    已删除 test_dir 目录");
     }
     #[cfg(feature = "arceos")]
-    println!("    Hermit 下跳过递归删除目录");
+    println!("    ArceOS 下跳过递归删除目录");
 
     Ok(())
 }

--- a/apps/arceos/thread_test/src/main.rs
+++ b/apps/arceos/thread_test/src/main.rs
@@ -167,7 +167,7 @@ fn test_mutex_shared_data() {
 #[cfg(all(feature = "arceos", target_arch = "riscv64"))]
 fn test_atomic_operations() {
     println!("5. 原子操作测试:");
-    println!("riscv64 Hermit 环境跳过高并发原子操作测试。\n");
+    println!("riscv64 ArceOS 环境跳过高并发原子操作测试。\n");
 }
 
 #[cfg(not(all(feature = "arceos", target_arch = "riscv64")))]

--- a/os/arceos/api/arceos_posix_api/Cargo.toml
+++ b/os/arceos/api/arceos_posix_api/Cargo.toml
@@ -31,7 +31,6 @@ pipe = ["fd"]
 select = ["fd"]
 poll = ["fd"]
 epoll = ["fd"]
-use-hermit-types = []
 
 [dependencies]
 # ArceOS modules

--- a/os/arceos/api/arceos_posix_api/src/imp/fs.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/fs.rs
@@ -1,7 +1,8 @@
 use alloc::sync::Arc;
-use core::ffi::{c_char, c_int};
-#[cfg(not(feature = "use-hermit-types"))]
-use core::mem::size_of;
+use core::{
+    ffi::{c_char, c_int},
+    mem::size_of,
+};
 
 use ax_errno::{LinuxError, LinuxResult};
 use ax_fs_ng::fops::{FileAttrExt, OpenOptions};
@@ -19,11 +20,6 @@ pub struct Directory {
     inner: Mutex<ax_fs_ng::fops::Directory>,
 }
 
-// ============================================================================
-// Linux-style getdents64 implementation (for normal Linux targets)
-// ============================================================================
-
-#[cfg(not(feature = "use-hermit-types"))]
 #[repr(C, packed)]
 struct LinuxDirent64Head {
     d_ino: u64,
@@ -32,13 +28,11 @@ struct LinuxDirent64Head {
     d_type: u8,
 }
 
-#[cfg(not(feature = "use-hermit-types"))]
 struct DirBuffer<'a> {
     buf: &'a mut [u8],
     offset: usize,
 }
 
-#[cfg(not(feature = "use-hermit-types"))]
 impl<'a> DirBuffer<'a> {
     fn new(buf: &'a mut [u8]) -> Self {
         Self { buf, offset: 0 }
@@ -81,83 +75,6 @@ impl<'a> DirBuffer<'a> {
         true
     }
 }
-
-// ============================================================================
-// Hermit-style getdents64 implementation (for hermit targets)
-// ============================================================================
-
-#[cfg(feature = "use-hermit-types")]
-use core::mem;
-
-#[cfg(feature = "use-hermit-types")]
-struct HermitDirBuffer<'a> {
-    buf: &'a mut [u8],
-    offset: usize,
-}
-
-#[cfg(feature = "use-hermit-types")]
-impl<'a> HermitDirBuffer<'a> {
-    fn new(buf: &'a mut [u8]) -> Self {
-        Self { buf, offset: 0 }
-    }
-
-    fn used_len(&self) -> usize {
-        self.offset
-    }
-
-    fn remaining_space(&self) -> usize {
-        self.buf.len().saturating_sub(self.offset)
-    }
-
-    fn write_entry(&mut self, d_ino: u64, d_type: u8, name: &[u8]) -> bool {
-        // Hermit dirent64 structure layout:
-        // offset 0: d_ino (u64, 8 bytes)
-        // offset 8: d_off (i64, 8 bytes)
-        // offset 16: d_reclen (u16, 2 bytes)
-        // offset 18: d_type (u8, 1 byte)
-        // offset 19: d_name (variable-length null-terminated c_char array)
-        const NAME_OFFSET: usize = 19;
-
-        let name_len = name.len().min(255);
-        // Total size: fixed header (19 bytes) + name + null terminator
-        let dirent_len = NAME_OFFSET + name_len + 1;
-        // Align to dirent64 struct alignment (8 bytes for u64)
-        let reclen = dirent_len.next_multiple_of(mem::align_of::<ctypes::dirent64>());
-
-        if self.remaining_space() < reclen {
-            return false;
-        }
-
-        unsafe {
-            let entry_ptr = self.buf.as_mut_ptr().add(self.offset);
-
-            // Write fixed fields
-            let d_ino_ptr = entry_ptr.cast::<u64>();
-            d_ino_ptr.write_unaligned(d_ino);
-
-            let d_off_ptr = entry_ptr.add(8).cast::<i64>();
-            d_off_ptr.write_unaligned(0); // d_off is not meaningful in Hermit
-
-            let d_reclen_ptr = entry_ptr.add(16).cast::<u16>();
-            d_reclen_ptr.write_unaligned(reclen as u16);
-
-            let d_type_ptr = entry_ptr.add(18);
-            d_type_ptr.write(d_type);
-
-            // Write d_name (starting at offset 19)
-            let name_ptr = entry_ptr.add(NAME_OFFSET);
-            name_ptr.copy_from_nonoverlapping(name.as_ptr(), name_len);
-            name_ptr.add(name_len).write(0); // null terminator
-        }
-
-        self.offset += reclen;
-        true
-    }
-}
-
-// ============================================================================
-// Common file type conversion
-// ============================================================================
 
 fn file_type_to_d_type(ty: ax_fs_ng::fops::FileType) -> u8 {
     match ty {
@@ -342,7 +259,6 @@ pub fn sys_open(filename: *const c_char, flags: c_int, mode: ctypes::mode_t) -> 
 ///
 /// Reference: Starry OS implementation
 /// Return number of bytes written on success.
-#[cfg(not(feature = "use-hermit-types"))]
 pub unsafe fn sys_getdents64(fd: c_int, buf: *mut u8, len: usize) -> ctypes::ssize_t {
     debug!("sys_getdents64 (Linux) <= {fd} {:#x} {len}", buf as usize);
     syscall_body!(sys_getdents64, {
@@ -368,60 +284,6 @@ pub unsafe fn sys_getdents64(fd: c_int, buf: *mut u8, len: usize) -> ctypes::ssi
                 let d_type = file_type_to_d_type(entry.entry_type());
                 // Linux style: d_ino, d_off both present
                 if !dir_buf.write_entry(1, 0, d_type, entry.name_as_bytes()) {
-                    return Ok(dir_buf.used_len() as ctypes::ssize_t);
-                }
-            }
-        }
-
-        Ok(dir_buf.used_len() as ctypes::ssize_t)
-    })
-}
-
-// ============================================================================
-// Hermit-style sys_getdents64 (Hermit/BSD-like targets)
-// ============================================================================
-
-/// Read directory entries from `fd` into Hermit-style dirent64 buffer.
-///
-/// Reference: Hermit OS official implementation
-/// Parameters:
-/// - `fd`: File Descriptor of the directory in question.
-/// - `buf`: Memory for the kernel to store the filled `Dirent64` objects including
-///   the c-strings with the filenames.
-/// - `len`: Size of the memory region described by `buf` in bytes.
-///
-/// Return:
-/// The number of bytes read into `buf` on success. Zero indicates that no more
-/// entries remain and the directory's read position needs to be reset using `sys_lseek`.
-/// Negative numbers encode errors.
-#[cfg(feature = "use-hermit-types")]
-pub unsafe fn sys_getdents64(fd: c_int, buf: *mut u8, len: usize) -> ctypes::ssize_t {
-    debug!("sys_getdents64 (Hermit) <= {fd} {:#x} {len}", buf as usize);
-    syscall_body!(sys_getdents64, {
-        // Hermit ABI: null buffer or zero-sized buffer are invalid
-        if buf.is_null() || len == 0 {
-            return Err(LinuxError::EINVAL);
-        }
-
-        // Hermit returns EINVAL for invalid directory objects
-        let dir = Directory::from_fd(fd).map_err(|_| LinuxError::EINVAL)?;
-        let mut dir = dir.inner.lock();
-
-        let out = unsafe { core::slice::from_raw_parts_mut(buf, len) };
-        let mut dir_buf = HermitDirBuffer::new(out);
-
-        let mut entries: [ax_fs_ng::fops::DirEntry; 16] =
-            core::array::from_fn(|_| ax_fs_ng::fops::DirEntry::default());
-        loop {
-            let nr = dir.read_dir(&mut entries)?;
-            if nr == 0 {
-                break;
-            }
-
-            for entry in entries.iter().take(nr) {
-                let d_type = file_type_to_d_type(entry.entry_type());
-                // Hermit style: only d_ino and d_type, d_off is not meaningful
-                if !dir_buf.write_entry(1, d_type, entry.name_as_bytes()) {
                     return Ok(dir_buf.used_len() as ctypes::ssize_t);
                 }
             }

--- a/os/arceos/doc/std_support_readme.md
+++ b/os/arceos/doc/std_support_readme.md
@@ -7,8 +7,8 @@ the application enables its `arceos` feature to depend on `ax-std` directly, so
 `libc.a` only satisfies the fixed library name requested by the compiler; the
 real libc/syscall compatibility symbols come from `ax-std`.
 
-This path does not require changes to `rust-lang/rust`, and it does not use a
-Hermit target.
+This path does not require changes to `rust-lang/rust`; it uses built-in
+linux-musl targets directly.
 
 ## Run the std examples
 

--- a/scripts/axbuild/src/build.rs
+++ b/scripts/axbuild/src/build.rs
@@ -2941,7 +2941,7 @@ log = "Info"
     }
 
     #[test]
-    fn std_cargo_config_uses_linux_musl_wrapper_without_custom_cfg() {
+    fn std_cargo_config_uses_linux_musl_wrapper_with_plain_std_build() {
         let fake_dir = std_fake_lib_dir("x86_64-unknown-linux-musl").unwrap();
         let wrapper =
             std_linker_wrapper_path("x86_64-unknown-linux-musl", &fake_dir, false).unwrap();
@@ -2957,7 +2957,8 @@ log = "Info"
         assert!(config.contains(&wrapper.display().to_string()));
         assert!(!config.contains("relocation-model"));
         assert!(!config.contains("code-model"));
-        assert!(!config.contains("target_os = \"hermit\""));
+        assert!(!config.contains("--cfg"));
+        assert!(!config.contains("--check-cfg"));
     }
 
     #[test]


### PR DESCRIPTION
## 背景

ArceOS std 支持已经切换为直接使用内建 linux-musl target，但部分示例输出、注释、axbuild 单测名称/断言，以及 `ax-posix-api` 的 `getdents64` cfg 分支仍保留 Hermit 语境，容易让后续维护者误以为当前 std/POSIX 路径仍依赖 Hermit target 或 synthetic target_os。

## 修改内容

- 将 ArceOS std 示例中的 Hermit 旧称呼替换为 ArceOS/std console 语境。
- 更新 `os/arceos/doc/std_support_readme.md`，明确当前路径直接使用内建 linux-musl target。
- 调整 axbuild std Cargo config 单测名称和断言，从检查旧 Hermit cfg 改为检查 plain std build 不注入自定义 `--cfg`/`--check-cfg`。
- 移除 `ax-posix-api` 的 `use-hermit-types` feature，以及对应的 Hermit-style `getdents64` buffer/syscall 分支，让 `getdents64` 只保留当前 Linux-style dirent64 实现。

## 处理逻辑

这次清理只触碰项目自有源码、文档和测试断言。`Cargo.lock` 中的 `hermit-abi` 没有删除，因为它仍是上游依赖链中的 crate 名，不属于本项目遗留 feature 或配置。历史月报中的 `POSIX/hermit ABI` 描述也保留，因为它是在回顾历史 PR 背景，而不是当前代码路径。

## 验证

- `cargo fmt`
- `cargo test -p axbuild --lib build::tests::std_cargo_config_uses_linux_musl_wrapper_with_plain_std_build`
- `cargo xtask clippy --package axbuild`
- `cargo xtask clippy --package arceos-arce_agent --package arceos-io_test --package arceos-thread_test`
- `cargo xtask clippy --package ax-posix-api`
- `cargo check -p ax-posix-api --features fs`
- `rg -n "use-hermit-types|Hermit|hermit" os/arceos/api/arceos_posix_api`
- `git diff --check`