### PR TITLE
feat(starry-kernel): add x86_64 ptrace gdb support

### DIFF
--- a/components/axcpu/src/x86_64/context.rs
+++ b/components/axcpu/src/x86_64/context.rs
@@ -160,7 +160,7 @@ struct ContextSwitchFrame {
 /// See <https://www.felixcloutier.com/x86/fxsave> for more details.
 #[allow(missing_docs)]
 #[repr(C, align(16))]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct FxsaveArea {
     pub fcw: u16,
     pub fsw: u16,

--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -1,11 +1,8 @@
 use alloc::{sync::Arc, vec, vec::Vec};
-use core::mem::{MaybeUninit, size_of};
-#[cfg(any(
-    target_arch = "riscv64",
-    target_arch = "aarch64",
-    target_arch = "loongarch64"
-))]
-use core::slice;
+use core::{
+    mem::{MaybeUninit, size_of},
+    slice,
+};
 
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_memory_addr::{MemoryAddr, VirtAddr};
@@ -15,15 +12,11 @@ use starry_process::Pid;
 use starry_signal::Signo;
 use starry_vm::{VmMutPtr, VmPtr, vm_read_slice, vm_write_slice};
 
-#[cfg(any(
-    target_arch = "riscv64",
-    target_arch = "aarch64",
-    target_arch = "loongarch64"
-))]
-use crate::task::PtraceStopFpData;
 use crate::{
     mm::{AddrSpace, IoVec},
-    task::{AsThread, Cred, ProcessData, get_process_cred, get_process_data, get_task},
+    task::{
+        AsThread, Cred, ProcessData, PtraceStopFpData, get_process_cred, get_process_data, get_task,
+    },
 };
 
 const PTRACE_TRACEME: u32 = 0;
@@ -51,11 +44,6 @@ const PTRACE_SEIZE: u32 = 0x4206;
 const PTRACE_INTERRUPT: u32 = 0x4207;
 
 const NT_PRSTATUS: usize = 1;
-#[cfg(any(
-    target_arch = "riscv64",
-    target_arch = "aarch64",
-    target_arch = "loongarch64"
-))]
 const NT_FPREGSET: usize = 2;
 
 const PTRACE_O_TRACESYSGOOD: usize = 1;
@@ -86,12 +74,16 @@ type ArchUserRegs = RiscvUserRegs;
 type ArchUserRegs = Aarch64UserRegs;
 #[cfg(target_arch = "loongarch64")]
 type ArchUserRegs = LoongarchUserRegs;
+#[cfg(target_arch = "x86_64")]
+type ArchUserRegs = X8664UserRegs;
 #[cfg(target_arch = "riscv64")]
 type ArchFpRegs = RiscvFpRegs;
 #[cfg(target_arch = "aarch64")]
 type ArchFpRegs = Aarch64FpRegs;
 #[cfg(target_arch = "loongarch64")]
 type ArchFpRegs = LoongarchFpRegs;
+#[cfg(target_arch = "x86_64")]
+type ArchFpRegs = X8664FpRegs;
 
 #[cfg(target_arch = "riscv64")]
 #[repr(C)]
@@ -178,6 +170,44 @@ struct LoongarchFpRegs {
     fcc: u64,
     fcsr: u32,
 }
+
+#[cfg(target_arch = "x86_64")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct X8664UserRegs {
+    r15: u64,
+    r14: u64,
+    r13: u64,
+    r12: u64,
+    rbp: u64,
+    rbx: u64,
+    r11: u64,
+    r10: u64,
+    r9: u64,
+    r8: u64,
+    rax: u64,
+    rcx: u64,
+    rdx: u64,
+    rsi: u64,
+    rdi: u64,
+    orig_rax: u64,
+    rip: u64,
+    cs: u64,
+    eflags: u64,
+    rsp: u64,
+    ss: u64,
+    fs_base: u64,
+    gs_base: u64,
+    ds: u64,
+    es: u64,
+    fs: u64,
+    gs: u64,
+}
+
+#[cfg(target_arch = "x86_64")]
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct X8664FpRegs(ax_cpu::FxsaveArea);
 
 pub fn sys_ptrace(request: u32, pid: usize, addr: usize, data: usize) -> AxResult<isize> {
     info!("sys_ptrace <= request: {request}, pid: {pid}, addr: {addr:#x}, data: {data:#x}");
@@ -339,38 +369,16 @@ fn ptrace_getsiginfo(pid: usize, data: usize) -> AxResult<isize> {
         .ptrace_stop_siginfo_for(tid)
         .ok_or_else(|| AxError::from(LinuxError::ESRCH))?;
 
-    #[cfg(any(
-        target_arch = "riscv64",
-        target_arch = "aarch64",
-        target_arch = "loongarch64"
-    ))]
-    {
-        let bytes = unsafe {
-            slice::from_raw_parts(
-                (&siginfo.0 as *const linux_raw_sys::general::siginfo_t).cast::<u8>(),
-                size_of::<starry_signal::SignalInfo>(),
-            )
-        };
-        vm_write_slice(data as *mut u8, bytes)?;
-        Ok(0)
-    }
-
-    #[cfg(not(any(
-        target_arch = "riscv64",
-        target_arch = "aarch64",
-        target_arch = "loongarch64"
-    )))]
-    {
-        let _ = (data, siginfo);
-        Err(AxError::Unsupported)
-    }
+    let bytes = unsafe {
+        slice::from_raw_parts(
+            (&siginfo.0 as *const linux_raw_sys::general::siginfo_t).cast::<u8>(),
+            size_of::<starry_signal::SignalInfo>(),
+        )
+    };
+    vm_write_slice(data as *mut u8, bytes)?;
+    Ok(0)
 }
 
-#[cfg(any(
-    target_arch = "riscv64",
-    target_arch = "aarch64",
-    target_arch = "loongarch64"
-))]
 fn ptrace_setsiginfo(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
         return Err(AxError::InvalidInput);
@@ -384,24 +392,9 @@ fn ptrace_setsiginfo(pid: usize, data: usize) -> AxResult<isize> {
     Ok(0)
 }
 
-#[cfg(not(any(
-    target_arch = "riscv64",
-    target_arch = "aarch64",
-    target_arch = "loongarch64"
-)))]
-fn ptrace_setsiginfo(pid: usize, data: usize) -> AxResult<isize> {
-    let _ = (pid, data);
-    Err(AxError::Unsupported)
-}
-
 fn ptrace_getregset(pid: usize, addr: usize, data: usize) -> AxResult<isize> {
     match addr {
         NT_PRSTATUS => ptrace_getregset_prstatus(pid, data),
-        #[cfg(any(
-            target_arch = "riscv64",
-            target_arch = "aarch64",
-            target_arch = "loongarch64"
-        ))]
         NT_FPREGSET => ptrace_getregset_fpregset(pid, data),
         _ => Err(AxError::Unsupported),
     }
@@ -410,11 +403,6 @@ fn ptrace_getregset(pid: usize, addr: usize, data: usize) -> AxResult<isize> {
 fn ptrace_setregset(pid: usize, addr: usize, data: usize) -> AxResult<isize> {
     match addr {
         NT_PRSTATUS => ptrace_setregset_prstatus(pid, data),
-        #[cfg(any(
-            target_arch = "riscv64",
-            target_arch = "aarch64",
-            target_arch = "loongarch64"
-        ))]
         NT_FPREGSET => ptrace_setregset_fpregset(pid, data),
         _ => Err(AxError::Unsupported),
     }
@@ -423,7 +411,8 @@ fn ptrace_setregset(pid: usize, addr: usize, data: usize) -> AxResult<isize> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_getregs(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
@@ -443,7 +432,8 @@ fn ptrace_getregs(pid: usize, data: usize) -> AxResult<isize> {
 #[cfg(not(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 )))]
 fn ptrace_getregs(pid: usize, data: usize) -> AxResult<isize> {
     let _ = (pid, data);
@@ -453,7 +443,8 @@ fn ptrace_getregs(pid: usize, data: usize) -> AxResult<isize> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_setregs(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
@@ -466,14 +457,19 @@ fn ptrace_setregs(pid: usize, data: usize) -> AxResult<isize> {
 #[cfg(not(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 )))]
 fn ptrace_setregs(pid: usize, data: usize) -> AxResult<isize> {
     let _ = (pid, data);
     Err(AxError::Unsupported)
 }
 
-#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
+#[cfg(any(
+    target_arch = "riscv64",
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
+))]
 fn ptrace_getfpregs(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
         return Err(AxError::InvalidInput);
@@ -489,13 +485,21 @@ fn ptrace_getfpregs(pid: usize, data: usize) -> AxResult<isize> {
     Ok(0)
 }
 
-#[cfg(not(any(target_arch = "riscv64", target_arch = "loongarch64")))]
+#[cfg(not(any(
+    target_arch = "riscv64",
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
+)))]
 fn ptrace_getfpregs(pid: usize, data: usize) -> AxResult<isize> {
     let _ = (pid, data);
     Err(AxError::Unsupported)
 }
 
-#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
+#[cfg(any(
+    target_arch = "riscv64",
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
+))]
 fn ptrace_setfpregs(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
         return Err(AxError::InvalidInput);
@@ -504,7 +508,11 @@ fn ptrace_setfpregs(pid: usize, data: usize) -> AxResult<isize> {
     ptrace_write_stopped_fp_regs(pid, regs)
 }
 
-#[cfg(not(any(target_arch = "riscv64", target_arch = "loongarch64")))]
+#[cfg(not(any(
+    target_arch = "riscv64",
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
+)))]
 fn ptrace_setfpregs(pid: usize, data: usize) -> AxResult<isize> {
     let _ = (pid, data);
     Err(AxError::Unsupported)
@@ -576,7 +584,8 @@ fn ptrace_interrupt(pid: usize) -> AxResult<isize> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_getregset_prstatus(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
@@ -604,7 +613,8 @@ fn ptrace_getregset_prstatus(pid: usize, data: usize) -> AxResult<isize> {
 #[cfg(not(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 )))]
 fn ptrace_getregset_prstatus(pid: usize, data: usize) -> AxResult<isize> {
     let _ = (pid, data);
@@ -614,7 +624,8 @@ fn ptrace_getregset_prstatus(pid: usize, data: usize) -> AxResult<isize> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_setregset_prstatus(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
@@ -632,7 +643,8 @@ fn ptrace_setregset_prstatus(pid: usize, data: usize) -> AxResult<isize> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_read_stopped_user_regs(pid: usize) -> AxResult<ArchUserRegs> {
     let (tracee, tid) = ptrace_stopped_tracee_with_tid(pid)?;
@@ -645,7 +657,8 @@ fn ptrace_read_stopped_user_regs(pid: usize) -> AxResult<ArchUserRegs> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_read_user_regs(data: usize) -> AxResult<ArchUserRegs> {
     let mut regs = MaybeUninit::<ArchUserRegs>::uninit();
@@ -662,14 +675,15 @@ fn ptrace_read_user_regs(data: usize) -> AxResult<ArchUserRegs> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_write_stopped_user_regs(pid: usize, regs: ArchUserRegs) -> AxResult<isize> {
     let (tracee, tid) = ptrace_stopped_tracee_with_tid(pid)?;
     let mut uctx = tracee
         .ptrace_stop_user_context_for(tid)
         .ok_or_else(|| AxError::from(LinuxError::ESRCH))?;
-    regs.write_to(&mut uctx);
+    regs.write_to(&mut uctx)?;
     if !tracee.set_ptrace_stop_user_context_for(tid, uctx) {
         return Err(AxError::from(LinuxError::ESRCH));
     }
@@ -679,7 +693,8 @@ fn ptrace_write_stopped_user_regs(pid: usize, regs: ArchUserRegs) -> AxResult<is
 #[cfg(not(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 )))]
 fn ptrace_setregset_prstatus(pid: usize, data: usize) -> AxResult<isize> {
     let _ = (pid, data);
@@ -689,7 +704,8 @@ fn ptrace_setregset_prstatus(pid: usize, data: usize) -> AxResult<isize> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_getregset_fpregset(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
@@ -712,10 +728,22 @@ fn ptrace_getregset_fpregset(pid: usize, data: usize) -> AxResult<isize> {
     Ok(0)
 }
 
+#[cfg(not(any(
+    target_arch = "riscv64",
+    target_arch = "aarch64",
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
+)))]
+fn ptrace_getregset_fpregset(pid: usize, data: usize) -> AxResult<isize> {
+    let _ = (pid, data);
+    Err(AxError::Unsupported)
+}
+
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_setregset_fpregset(pid: usize, data: usize) -> AxResult<isize> {
     if data == 0 {
@@ -729,10 +757,22 @@ fn ptrace_setregset_fpregset(pid: usize, data: usize) -> AxResult<isize> {
     ptrace_write_stopped_fp_regs(pid, regs)
 }
 
+#[cfg(not(any(
+    target_arch = "riscv64",
+    target_arch = "aarch64",
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
+)))]
+fn ptrace_setregset_fpregset(pid: usize, data: usize) -> AxResult<isize> {
+    let _ = (pid, data);
+    Err(AxError::Unsupported)
+}
+
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_read_stopped_fp_regs(pid: usize) -> AxResult<ArchFpRegs> {
     let (tracee, tid) = ptrace_stopped_tracee_with_tid(pid)?;
@@ -745,7 +785,8 @@ fn ptrace_read_stopped_fp_regs(pid: usize) -> AxResult<ArchFpRegs> {
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_read_user_fpregs(data: usize) -> AxResult<ArchFpRegs> {
     let mut regs = MaybeUninit::<ArchFpRegs>::uninit();
@@ -759,11 +800,6 @@ fn ptrace_read_user_fpregs(data: usize) -> AxResult<ArchFpRegs> {
     Ok(unsafe { regs.assume_init() })
 }
 
-#[cfg(any(
-    target_arch = "riscv64",
-    target_arch = "aarch64",
-    target_arch = "loongarch64"
-))]
 fn ptrace_read_user_siginfo(data: usize) -> AxResult<linux_raw_sys::general::siginfo_t> {
     let mut siginfo = MaybeUninit::<linux_raw_sys::general::siginfo_t>::uninit();
     let bytes = unsafe {
@@ -776,11 +812,6 @@ fn ptrace_read_user_siginfo(data: usize) -> AxResult<linux_raw_sys::general::sig
     Ok(unsafe { siginfo.assume_init() })
 }
 
-#[cfg(any(
-    target_arch = "riscv64",
-    target_arch = "aarch64",
-    target_arch = "loongarch64"
-))]
 fn ptrace_siginfo_signo(siginfo: &linux_raw_sys::general::siginfo_t) -> AxResult<Signo> {
     let signo = unsafe { siginfo.__bindgen_anon_1.__bindgen_anon_1.si_signo };
     Signo::from_repr(signo as u8).ok_or(AxError::InvalidInput)
@@ -789,7 +820,8 @@ fn ptrace_siginfo_signo(siginfo: &linux_raw_sys::general::siginfo_t) -> AxResult
 #[cfg(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 ))]
 fn ptrace_write_stopped_fp_regs(pid: usize, regs: ArchFpRegs) -> AxResult<isize> {
     let (tracee, tid) = ptrace_stopped_tracee_with_tid(pid)?;
@@ -803,8 +835,10 @@ fn ptrace_write_stopped_fp_regs(pid: usize, regs: ArchFpRegs) -> AxResult<isize>
         fp_data.fcsr = regs.fcsr;
         fp_data
     };
-    #[cfg(not(target_arch = "loongarch64"))]
+    #[cfg(not(any(target_arch = "loongarch64", target_arch = "x86_64")))]
     let fp_data = PtraceStopFpData::from(regs);
+    #[cfg(target_arch = "x86_64")]
+    let fp_data = PtraceStopFpData(regs.0);
 
     if !tracee.set_ptrace_stop_fp_data_for(tid, fp_data) {
         return Err(AxError::from(LinuxError::ESRCH));
@@ -1044,6 +1078,16 @@ fn ptrace_stopped_tracee_with_tid(pid: usize) -> AxResult<(Arc<ProcessData>, u32
         .selected_ptrace_stop_tid()
         .ok_or_else(|| AxError::from(LinuxError::ESRCH))?;
     Ok((tracee, tid))
+}
+
+#[cfg(target_arch = "x86_64")]
+pub fn ptrace_setup_singlestep(
+    _tracee: &ProcessData,
+    _tid: Pid,
+    uctx: &mut ax_runtime::hal::cpu::uspace::UserContext,
+) {
+    const X86_EFLAGS_TF: u64 = 1 << 8;
+    uctx.rflags |= X86_EFLAGS_TF;
 }
 
 #[cfg(target_arch = "riscv64")]
@@ -1697,6 +1741,105 @@ pub fn ptrace_notify_vfork_done(parent_pid: Pid, parent_tid: Pid, child_pid: Pid
     true
 }
 
+#[cfg(target_arch = "x86_64")]
+fn sanitize_ptrace_x86_64_eflags(new_eflags: u64, current_eflags: u64) -> u64 {
+    const CF: u64 = 1 << 0;
+    const PF: u64 = 1 << 2;
+    const AF: u64 = 1 << 4;
+    const ZF: u64 = 1 << 6;
+    const SF: u64 = 1 << 7;
+    const TF: u64 = 1 << 8;
+    const DF: u64 = 1 << 10;
+    const OF: u64 = 1 << 11;
+    const RF: u64 = 1 << 16;
+    const AC: u64 = 1 << 18;
+    const ID: u64 = 1 << 21;
+    const USER_WRITABLE_MASK: u64 = CF | PF | AF | ZF | SF | TF | DF | OF | RF | AC | ID;
+    const RESERVED_BIT1: u64 = 1 << 1;
+
+    (current_eflags & !USER_WRITABLE_MASK) | (new_eflags & USER_WRITABLE_MASK) | RESERVED_BIT1
+}
+
+#[cfg(target_arch = "x86_64")]
+impl From<&ax_runtime::hal::cpu::uspace::UserContext> for X8664UserRegs {
+    fn from(uctx: &ax_runtime::hal::cpu::uspace::UserContext) -> Self {
+        Self {
+            r15: uctx.r15,
+            r14: uctx.r14,
+            r13: uctx.r13,
+            r12: uctx.r12,
+            rbp: uctx.rbp,
+            rbx: uctx.rbx,
+            r11: uctx.r11,
+            r10: uctx.r10,
+            r9: uctx.r9,
+            r8: uctx.r8,
+            rax: uctx.rax,
+            rcx: uctx.rcx,
+            rdx: uctx.rdx,
+            rsi: uctx.rsi,
+            rdi: uctx.rdi,
+            orig_rax: uctx.rax,
+            rip: uctx.rip,
+            cs: uctx.cs,
+            eflags: uctx.rflags,
+            rsp: uctx.rsp,
+            ss: uctx.ss,
+            fs_base: uctx.fs_base,
+            gs_base: uctx.gs_base,
+            ds: 0,
+            es: 0,
+            fs: 0,
+            gs: 0,
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl X8664UserRegs {
+    fn write_to(&self, uctx: &mut ax_runtime::hal::cpu::uspace::UserContext) -> AxResult<()> {
+        if self.cs != uctx.cs || self.ss != uctx.ss {
+            return Err(AxError::from(LinuxError::EINVAL));
+        }
+
+        uctx.r15 = self.r15;
+        uctx.r14 = self.r14;
+        uctx.r13 = self.r13;
+        uctx.r12 = self.r12;
+        uctx.rbp = self.rbp;
+        uctx.rbx = self.rbx;
+        uctx.r11 = self.r11;
+        uctx.r10 = self.r10;
+        uctx.r9 = self.r9;
+        uctx.r8 = self.r8;
+        uctx.rax = self.rax;
+        uctx.rcx = self.rcx;
+        uctx.rdx = self.rdx;
+        uctx.rsi = self.rsi;
+        uctx.rdi = self.rdi;
+        uctx.rip = self.rip;
+        uctx.rflags = sanitize_ptrace_x86_64_eflags(self.eflags, uctx.rflags);
+        uctx.rsp = self.rsp;
+        uctx.fs_base = self.fs_base;
+        uctx.gs_base = self.gs_base;
+        Ok(())
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl From<PtraceStopFpData> for X8664FpRegs {
+    fn from(data: PtraceStopFpData) -> Self {
+        Self(data.0)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl From<X8664FpRegs> for PtraceStopFpData {
+    fn from(regs: X8664FpRegs) -> Self {
+        Self(regs.0)
+    }
+}
+
 #[cfg(target_arch = "riscv64")]
 impl From<&ax_runtime::hal::cpu::uspace::UserContext> for RiscvUserRegs {
     fn from(uctx: &ax_runtime::hal::cpu::uspace::UserContext) -> Self {
@@ -1740,7 +1883,7 @@ impl From<&ax_runtime::hal::cpu::uspace::UserContext> for RiscvUserRegs {
 
 #[cfg(target_arch = "riscv64")]
 impl RiscvUserRegs {
-    fn write_to(&self, uctx: &mut ax_runtime::hal::cpu::uspace::UserContext) {
+    fn write_to(&self, uctx: &mut ax_runtime::hal::cpu::uspace::UserContext) -> AxResult<()> {
         uctx.sepc = self.pc;
         let r = &mut uctx.regs;
         r.ra = self.ra;
@@ -1774,6 +1917,7 @@ impl RiscvUserRegs {
         r.t4 = self.t4;
         r.t5 = self.t5;
         r.t6 = self.t6;
+        Ok(())
     }
 }
 
@@ -1811,11 +1955,12 @@ impl From<&ax_runtime::hal::cpu::uspace::UserContext> for Aarch64UserRegs {
 
 #[cfg(target_arch = "aarch64")]
 impl Aarch64UserRegs {
-    fn write_to(&self, uctx: &mut ax_runtime::hal::cpu::uspace::UserContext) {
+    fn write_to(&self, uctx: &mut ax_runtime::hal::cpu::uspace::UserContext) -> AxResult<()> {
         uctx.x = self.regs;
         uctx.sp = self.sp;
         uctx.elr = self.pc;
         uctx.spsr = self.pstate;
+        Ok(())
     }
 }
 
@@ -1891,7 +2036,7 @@ impl From<&ax_runtime::hal::cpu::uspace::UserContext> for LoongarchUserRegs {
 
 #[cfg(target_arch = "loongarch64")]
 impl LoongarchUserRegs {
-    fn write_to(&self, uctx: &mut ax_runtime::hal::cpu::uspace::UserContext) {
+    fn write_to(&self, uctx: &mut ax_runtime::hal::cpu::uspace::UserContext) -> AxResult<()> {
         let r = &mut uctx.regs;
         r.zero = 0;
         r.ra = self.regs[1] as usize;
@@ -1926,6 +2071,7 @@ impl LoongarchUserRegs {
         r.s7 = self.regs[30] as usize;
         r.s8 = self.regs[31] as usize;
         uctx.era = self.csr_era as usize;
+        Ok(())
     }
 }
 

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -785,10 +785,15 @@ pub struct PtraceStopFpData {
     pub fcsr: u32,
 }
 
+#[cfg(target_arch = "x86_64")]
+#[derive(Clone, Copy)]
+pub struct PtraceStopFpData(pub ax_cpu::FxsaveArea);
+
 #[cfg(not(any(
     target_arch = "riscv64",
     target_arch = "aarch64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
 )))]
 #[derive(Clone, Copy)]
 pub struct PtraceStopFpData;
@@ -1645,10 +1650,20 @@ impl ProcessData {
         );
     }
 
+    #[cfg(target_arch = "x86_64")]
+    pub fn save_current_fp_for_ptrace(&self, tid: u32) {
+        let mut state = ax_cpu::ExtendedState::default();
+        state.save();
+        self.ptrace_stop_fp_data
+            .lock()
+            .insert(tid, PtraceStopFpData(state.fxsave_area));
+    }
+
     #[cfg(not(any(
         target_arch = "riscv64",
         target_arch = "aarch64",
-        target_arch = "loongarch64"
+        target_arch = "loongarch64",
+        target_arch = "x86_64"
     )))]
     pub fn save_current_fp_for_ptrace(&self, _tid: u32) {}
 
@@ -1704,10 +1719,21 @@ impl ProcessData {
         fp_state.restore();
     }
 
+    #[cfg(target_arch = "x86_64")]
+    pub fn restore_current_fp_for_ptrace(&self, tid: u32, _uctx: &mut UserContext) {
+        let Some(fp) = self.ptrace_stop_fp_data.lock().remove(&tid) else {
+            return;
+        };
+
+        let state = ax_cpu::ExtendedState { fxsave_area: fp.0 };
+        state.restore();
+    }
+
     #[cfg(not(any(
         target_arch = "riscv64",
         target_arch = "aarch64",
-        target_arch = "loongarch64"
+        target_arch = "loongarch64",
+        target_arch = "x86_64"
     )))]
     pub fn restore_current_fp_for_ptrace(&self, _tid: u32, _uctx: &mut UserContext) {}
 

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -256,7 +256,8 @@ fn ptrace_stop_current_impl(
     #[cfg(any(
         target_arch = "riscv64",
         target_arch = "aarch64",
-        target_arch = "loongarch64"
+        target_arch = "loongarch64",
+        target_arch = "x86_64"
     ))]
     {
         thr.proc_data.save_current_fp_for_ptrace(tid);

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -36,11 +36,6 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                 if thr.proc_data.is_ptrace_singlestep_for(thr.tid())
                     && (thr.proc_data.is_ptrace_traceme() || thr.proc_data.is_ptrace_attached())
                 {
-                    #[cfg(any(
-                        target_arch = "riscv64",
-                        target_arch = "aarch64",
-                        target_arch = "loongarch64"
-                    ))]
                     crate::syscall::ptrace_setup_singlestep(&thr.proc_data, thr.tid(), &mut uctx);
                 }
 
@@ -140,6 +135,19 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                                 break 'exc;
                             }
                             _ => {}
+                        }
+                        #[cfg(target_arch = "x86_64")]
+                        if matches!(kind, ExceptionKind::Debug)
+                            && (thr.proc_data.is_ptrace_traceme()
+                                || thr.proc_data.is_ptrace_attached())
+                        {
+                            uctx.rflags &= !(1 << 8);
+                            thr.proc_data.set_ptrace_singlestep_for(thr.tid(), false);
+                            if let Some(_resume_sig) =
+                                ptrace_stop_current(thr, Signo::SIGTRAP, &mut uctx)
+                            {
+                                break 'exc;
+                            }
                         }
                         if matches!(kind, ExceptionKind::Breakpoint)
                             && (thr.proc_data.is_ptrace_traceme()

--- a/test-suit/starryos/qemu-smp1/system/test-ptrace-gdb/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/test-ptrace-gdb/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
-starry_arch_filtered_executable(test-ptrace-gdb "riscv64|aarch64|loongarch64" "test-ptrace-gdb skipped on unsupported architecture" src/main.c)
+starry_arch_filtered_executable(test-ptrace-gdb "x86_64|riscv64|aarch64|loongarch64" "test-ptrace-gdb skipped on unsupported architecture" src/main.c)
 target_compile_options(test-ptrace-gdb PRIVATE -Wall -Wextra -Werror)
 
 install(TARGETS test-ptrace-gdb RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/test-ptrace-gdb/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-ptrace-gdb/src/main.c
@@ -94,6 +94,7 @@
 #define ARCH_RISCV 0
 #define ARCH_AARCH64 0
 #define ARCH_LOONGARCH 0
+#define ARCH_X86_64 0
 
 #if defined(__riscv)
 #undef ARCH_RISCV
@@ -207,6 +208,64 @@ typedef struct loongarch_user_fpregs arch_user_fpregs;
 #define PTRACE_GDB_REG_A7(r) ((r)->regs[11])
 #define PTRACE_GDB_REG_S0(r) ((r)->regs[23])
 
+#elif defined(__x86_64__)
+#undef ARCH_X86_64
+#define ARCH_X86_64 1
+struct x86_64_user_regs {
+    uint64_t r15;
+    uint64_t r14;
+    uint64_t r13;
+    uint64_t r12;
+    uint64_t rbp;
+    uint64_t rbx;
+    uint64_t r11;
+    uint64_t r10;
+    uint64_t r9;
+    uint64_t r8;
+    uint64_t rax;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t orig_rax;
+    uint64_t rip;
+    uint64_t cs;
+    uint64_t eflags;
+    uint64_t rsp;
+    uint64_t ss;
+    uint64_t fs_base;
+    uint64_t gs_base;
+    uint64_t ds;
+    uint64_t es;
+    uint64_t fs;
+    uint64_t gs;
+};
+typedef struct x86_64_user_regs arch_user_regs;
+
+struct x86_64_user_fpregs {
+    uint16_t fcw;
+    uint16_t fsw;
+    uint16_t ftw;
+    uint16_t fop;
+    uint64_t fip;
+    uint64_t fdp;
+    uint32_t mxcsr;
+    uint32_t mxcsr_mask;
+    uint64_t st[16];
+    uint64_t xmm[32];
+    uint64_t padding[12];
+};
+typedef struct x86_64_user_fpregs arch_user_fpregs;
+
+#define PTRACE_GDB_REG_PC(r) ((r)->rip)
+#define PTRACE_GDB_REG_SP(r) ((r)->rsp)
+#define PTRACE_GDB_REG_A0(r) ((r)->rax)
+#define PTRACE_GDB_REG_A1(r) ((r)->rdi)
+#define PTRACE_GDB_REG_A2(r) ((r)->rdx)
+#define PTRACE_GDB_REG_A3(r) ((r)->rcx)
+#define PTRACE_GDB_REG_A7(r) ((r)->orig_rax)
+#define PTRACE_GDB_REG_S0(r) ((r)->rbp)
+
 #else
 #error "test-ptrace-gdb needs an architecture register layout"
 #endif
@@ -219,6 +278,8 @@ static void fpregs_set_f0(arch_user_fpregs *regs, unsigned long value)
     regs->vregs[0] = (__uint128_t)value;
 #elif ARCH_LOONGARCH
     regs->fpr[0] = value;
+#elif ARCH_X86_64
+    regs->xmm[0] = value;
 #endif
 }
 
@@ -230,6 +291,8 @@ static void fpregs_set_f1(arch_user_fpregs *regs, unsigned long value)
     regs->vregs[1] = (__uint128_t)value;
 #elif ARCH_LOONGARCH
     regs->fpr[1] = value;
+#elif ARCH_X86_64
+    regs->xmm[2] = value;
 #endif
 }
 
@@ -241,6 +304,8 @@ static unsigned long fpregs_get_f0(const arch_user_fpregs *regs)
     return (unsigned long)regs->vregs[0];
 #elif ARCH_LOONGARCH
     return regs->fpr[0];
+#elif ARCH_X86_64
+    return regs->xmm[0];
 #endif
 }
 
@@ -252,6 +317,8 @@ static unsigned long fpregs_get_f1(const arch_user_fpregs *regs)
     return (unsigned long)regs->vregs[1];
 #elif ARCH_LOONGARCH
     return regs->fpr[1];
+#elif ARCH_X86_64
+    return regs->xmm[2];
 #endif
 }
 
@@ -264,6 +331,8 @@ static unsigned long read_f0_bits(void)
     __asm__ volatile("fmov %0, d0" : "=r"(f0_bits));
 #elif ARCH_LOONGARCH
     __asm__ volatile("movfr2gr.d %0, $f0" : "=r"(f0_bits));
+#elif ARCH_X86_64
+    __asm__ volatile("movq %%xmm0, %0" : "=r"(f0_bits));
 #endif
     return f0_bits;
 }
@@ -550,6 +619,13 @@ __attribute__((naked, noinline, aligned(4))) static void ss_jirl_landing(void)
     __asm__ volatile(
         "addi.d $a2, $zero, 666\n"
         "break 0\n");
+}
+#elif ARCH_X86_64
+__attribute__((naked, noinline, aligned(4))) static void ss_step_target(void)
+{
+    __asm__ volatile(
+        "mov $123, %rax\n"
+        "int3\n");
 }
 #endif
 
@@ -1323,6 +1399,9 @@ __attribute__((naked, noinline, aligned(4))) static void setregs_pc_landing(void
 #elif ARCH_LOONGARCH
         "addi.d $a2, $zero, 77\n"
         "break 0\n"
+#elif ARCH_X86_64
+        "mov $77, %rdx\n"
+        "int3\n"
 #else
         "mov x2, #77\n"
         "brk #0\n"
@@ -1631,6 +1710,9 @@ __attribute__((naked, noinline, aligned(4))) static void legacy_setregs_landing(
 #elif ARCH_LOONGARCH
         "addi.d $a2, $zero, 88\n"
         "break 0\n"
+#elif ARCH_X86_64
+        "mov $88, %rdx\n"
+        "int3\n"
 #else
         "mov x2, #88\n"
         "brk #0\n"
@@ -1695,7 +1777,7 @@ static int test_legacy_regsets(void)
     }
     waitpid(pid, &status, 0);
 
-#if !(ARCH_RISCV || ARCH_LOONGARCH)
+#if !(ARCH_RISCV || ARCH_LOONGARCH || ARCH_X86_64)
     printf("  ok: legacy GETREGS/SETREGS work; legacy FPREGS skipped on this arch\n");
     return 0;
 #else
@@ -1956,6 +2038,26 @@ static long raw_clone_thread(void *stack_top)
         : "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a7)
         : "memory");
     return a0;
+#elif ARCH_X86_64
+    register long rax __asm__("rax") = SYS_clone;
+    register long rdi __asm__("rdi") =
+        CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD;
+    register long rsi __asm__("rsi") = (long)stack_top;
+    register long rdx __asm__("rdx") = 0;
+    register long r10 __asm__("r10") = 0;
+    register long r8 __asm__("r8") = 0;
+    __asm__ volatile(
+        "syscall\n"
+        "test %%rax, %%rax\n"
+        "jnz 1f\n"
+        "mov $60, %%rax\n"
+        "xor %%rdi, %%rdi\n"
+        "syscall\n"
+        "1:\n"
+        : "+r"(rax)
+        : "r"(rdi), "r"(rsi), "r"(rdx), "r"(r10), "r"(r8)
+        : "rcx", "r11", "memory");
+    return rax;
 #else
 #error "raw_clone_thread needs an architecture syscall sequence"
 #endif
@@ -1963,11 +2065,30 @@ static long raw_clone_thread(void *stack_top)
 
 static pid_t raw_clone_vfork_child_exit(void)
 {
+#if ARCH_X86_64
+    long rax = SYS_clone;
+    __asm__ volatile(
+        "xor %%r10d, %%r10d\n"
+        "xor %%r8d, %%r8d\n"
+        "xor %%r9d, %%r9d\n"
+        "syscall\n"
+        "test %%rax, %%rax\n"
+        "jnz 1f\n"
+        "mov $60, %%rax\n"
+        "xor %%rdi, %%rdi\n"
+        "syscall\n"
+        "1:\n"
+        : "+a"(rax)
+        : "D"((long)(CLONE_VM | CLONE_VFORK | SIGCHLD)), "S"(0L), "d"(0L)
+        : "rcx", "r8", "r9", "r10", "r11", "memory");
+    return (pid_t)rax;
+#else
     long ret = syscall(SYS_clone, CLONE_VM | CLONE_VFORK | SIGCHLD, 0, 0, 0, 0);
     if (ret == 0) {
         _exit(0);
     }
     return (pid_t)ret;
+#endif
 }
 
 static int test_traceclone_thread_event(void)


### PR DESCRIPTION
## 背景

此前 StarryOS 的用户态 GDB 初步支持已经覆盖 riscv64、aarch64 和 loongarch64。本 PR 在现有 ptrace/GDB 设计基础上补齐 x86_64 支持，使四个主要架构在 `test-ptrace-gdb` 覆盖范围内保持一致的支持力度。

## 修改内容

1. 补充 x86_64 用户寄存器与 FP regset 支持

- 增加 x86_64 `ArchUserRegs` / `ArchFpRegs` 映射。
- 支持 `PTRACE_GETREGS` / `PTRACE_SETREGS`。
- 支持 `PTRACE_GETREGSET` / `PTRACE_SETREGSET` 的 `NT_PRSTATUS` 和 `NT_FPREGSET`。
- 支持 legacy `PTRACE_GETFPREGS` / `PTRACE_SETFPREGS`，与 regset 语义复用。
- 使用 x86_64 `FxsaveArea` 保存和恢复 tracee 的 FP/SIMD 状态。

2. 补充 x86_64 single-step 支持

- x86_64 使用 `EFLAGS.TF` 实现 single-step。
- 在用户态返回路径中处理 `ExceptionKind::Debug`，清除 TF 并产生 ptrace `SIGTRAP` stop。
- 将 x86_64 的 `ptrace_setup_singlestep` 签名统一为和其他架构一致的形式，便于维护四架构共同路径。

3. 扩展 `test-ptrace-gdb`

- 将 `test-ptrace-gdb` 启用到 x86_64。
- 增加 x86_64 用户寄存器布局、FP/XMM 验证、single-step 落点、SETREGSET PC 修改、legacy regset、clone/vfork 事件验证。
- x86_64 vfork 测试使用 raw syscall，避免 vfork child 回到共享 C 调用栈造成非 ptrace 语义相关的干扰。

## 设计说明

本 PR 沿用现有 riscv64/aarch64/loongarch64 的 ptrace/GDB 支持模型：

- 不引入额外的 x86-only debug register / user area 兼容层。
- 不实现 `PTRACE_PEEKUSER` / `PTRACE_POKEUSER` / `GETFPXREGS` 等额外 Linux 兼容接口。
- 将 x86_64 纳入现有 `ArchUserRegs` / `ArchFpRegs` 抽象，保持四架构路径一致。
- 当前目标仍是 StarryOS 可用子集的用户态 GDB 支持，而不是完整 Linux ptrace 语义。

## 验证

已在 Docker 长期容器中验证：

```bash
docker exec tgoskits-dev cargo xtask clippy --package starry-kernel