### PR TITLE
fix(ci): bump smoke-vmx QEMU timeout 180→600s for self-hosted KVM runner

### DIFF
--- a/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-vmx.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-vmx.toml
@@ -22,7 +22,7 @@ args = [
   "-m",
   "512M",
 ]
-timeout = 180
+timeout = 600
 fail_regex = [
   "(?i)\\bpanic(?:ked)?\\b",
   "(?i)kernel panic",


### PR DESCRIPTION
Self-hosted runner smoke-vmx test times out at 180s when KVM is slow/misconfigured, causing fail-fast cascade that cancels all starry/arceos QEMU tests.

The test only boots a Linux guest and prints a success line — 180s is too tight for self-hosted hardware with flaky KVM.

Bump to 600s.

@ZR233