### PR TITLE
feat(starry): enhance VmPeak & VmHWM 

### DIFF
--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -17,6 +17,8 @@ use ax_runtime::hal::{
 };
 use ax_sync::Mutex;
 
+use crate::mm::ProcessVmStat;
+
 mod backend;
 
 pub use self::backend::*;
@@ -47,6 +49,9 @@ pub struct AddrSpace {
     /// transient clones from `ProcessData::aspace()` and is not reliable for
     /// SMP teardown decisions.
     pub(crate) process_slots: AtomicUsize,
+    /// All VmX counters for this address space.  Maintained automatically by
+    /// `map`, `unmap`, `clear`, and `try_clone`; never touch from outside mm/.
+    pub vm_stat: ProcessVmStat,
 }
 
 impl AddrSpace {
@@ -92,6 +97,7 @@ impl AddrSpace {
             areas: MemorySet::new(),
             pt: PageTable::try_new().map_err(|_| AxError::NoMemory)?,
             process_slots: AtomicUsize::new(0),
+            vm_stat: ProcessVmStat::new(),
         })
     }
 
@@ -155,6 +161,7 @@ impl AddrSpace {
             Backend::new_linear(start_vaddr, offset, false),
         );
         self.areas.map(area, &mut self.pt, false)?;
+        self.vm_stat.on_map((size / PAGE_SIZE_4K) as u64);
         Ok(())
     }
 
@@ -170,6 +177,7 @@ impl AddrSpace {
 
         let area = MemoryArea::new(start, size, flags, backend);
         self.areas.map(area, &mut self.pt, false)?;
+        self.vm_stat.on_map((size / PAGE_SIZE_4K) as u64);
         if populate {
             self.populate_area(start, size, flags)?;
         }
@@ -284,8 +292,22 @@ impl AddrSpace {
     pub fn unmap(&mut self, start: VirtAddr, size: usize) -> AxResult {
         self.validate_region(start, size)?;
 
+        // Compute the actual mapped bytes being removed (unmap is already O(n)).
+        let end = start + size;
+        let removed_pages: u64 = self
+            .areas
+            .iter()
+            .filter(|a| a.start() < end && a.end() > start)
+            .map(|a| {
+                let lo = a.start().max(start);
+                let hi = a.end().min(end);
+                ((hi - lo) / PAGE_SIZE_4K) as u64
+            })
+            .sum();
+
         crate::syscall::memfd_on_aspace_unmap_range(self, start, size);
         self.areas.unmap(start, size, &mut self.pt)?;
+        self.vm_stat.on_unmap(removed_pages);
         Ok(())
     }
 
@@ -293,8 +315,21 @@ impl AddrSpace {
     pub fn unmap_metadata(&mut self, start: VirtAddr, size: usize) -> AxResult {
         self.validate_region(start, size)?;
 
+        let end = start + size;
+        let removed_pages: u64 = self
+            .areas
+            .iter()
+            .filter(|a| a.start() < end && a.end() > start)
+            .map(|a| {
+                let lo = a.start().max(start);
+                let hi = a.end().min(end);
+                ((hi - lo) / PAGE_SIZE_4K) as u64
+            })
+            .sum();
+
         crate::syscall::memfd_on_aspace_unmap_range(self, start, size);
         self.areas.unmap_metadata(start, size)?;
+        self.vm_stat.on_unmap(removed_pages);
         Ok(())
     }
 
@@ -369,6 +404,7 @@ impl AddrSpace {
         }
         self.areas
             .extend_area(addr, additional_size, &mut self.pt)?;
+        self.vm_stat.on_map((additional_size / PAGE_SIZE_4K) as u64);
         Ok(())
     }
 
@@ -444,6 +480,7 @@ impl AddrSpace {
     pub fn clear(&mut self) {
         crate::syscall::memfd_release_all_shared_writable_counts_for_aspace(self);
         self.areas.clear(&mut self.pt).unwrap();
+        self.vm_stat.on_clear();
     }
 
     /// Checks whether an access to the specified memory region is valid.
@@ -570,6 +607,11 @@ impl AddrSpace {
             }
             crate::syscall::memfd_on_after_map(&guard, start);
         }
+        // Seed the child's vm_stat from the parent: the child's address space
+        // is a copy of the parent's, so its current VSS equals the parent's,
+        // and its starting watermarks inherit the parent's peaks (Linux fork
+        // semantics: child mm->hiwater_vm = parent mm->total_vm at fork time).
+        guard.vm_stat.seed_from(&self.vm_stat);
         drop(guard);
 
         Ok(new_aspace)

--- a/os/StarryOS/kernel/src/mm/mod.rs
+++ b/os/StarryOS/kernel/src/mm/mod.rs
@@ -5,5 +5,6 @@ mod aspace;
 mod io;
 mod loader;
 mod stats;
+mod vm_stat;
 
-pub use self::{access::*, aspace::*, io::*, loader::*, stats::*};
+pub use self::{access::*, aspace::*, io::*, loader::*, stats::*, vm_stat::*};

--- a/os/StarryOS/kernel/src/mm/stats.rs
+++ b/os/StarryOS/kernel/src/mm/stats.rs
@@ -41,6 +41,12 @@ pub struct ProcessMemStats {
     /// incremental counters or a PTE walk; Plan1 temporarily mirrors VSS (see
     /// `collect()` FIXME).
     pub resident_pages: u64,
+    /// Peak virtual address space in pages (VmPeak). Sourced from the
+    /// per-process atomic watermark updated on every successful map.
+    pub peak_pages: u64,
+    /// Peak resident set size in pages (VmHWM). Sourced from the
+    /// per-process atomic watermark updated on every successful map.
+    pub hwm_pages: u64,
     /// Lowest executable mapping start (stat `start_code`).
     pub start_code: u64,
     /// Highest executable mapping end (stat `end_code`).
@@ -131,6 +137,9 @@ fn accumulate_vma(
 
 impl ProcessMemStats {
     /// Collect memory statistics by iterating the address-space VMA list.
+    ///
+    /// Current VSS / VMA breakdown comes from a VMA walk; watermarks are
+    /// read directly from [`AddrSpace::vm_stat`] in O(1).
     pub fn collect(aspace: &AddrSpace) -> Self {
         let mut stats = Self::default();
         for area in aspace.areas() {
@@ -157,9 +166,12 @@ impl ProcessMemStats {
             );
         }
         // FIXME(plan2-rss): replace with real RSS from mm counters or PTE walk.
-        // Plan1 intentionally sets resident = VSS as an honest upper bound for
-        // lazily populated file-backed mappings; do not treat equality as API contract.
         stats.resident_pages = stats.vss_pages;
+        // Watermarks come from the O(1) atomic counters in vm_stat; the
+        // .max(current) floor handles the first collect after a fresh fork
+        // before any new mapping has updated the child's watermarks.
+        stats.peak_pages = aspace.vm_stat.peak_vss_pages().max(stats.vss_pages);
+        stats.hwm_pages = aspace.vm_stat.peak_rss_pages().max(stats.resident_pages);
         stats
     }
 
@@ -188,14 +200,16 @@ impl ProcessMemStats {
     /// Render Vm* lines for `/proc/[pid]/status` (kB, Linux `task_mem` layout).
     pub fn format_status_vm_lines(&self) -> String {
         let page_kb = PAGE_SIZE_4K as u64 / 1024;
+        let peak_kb = self.peak_pages * page_kb;
         let vss_kb = self.vss_pages * page_kb;
+        let hwm_kb = self.hwm_pages * page_kb;
         let resident_kb = self.resident_pages * page_kb;
         let data_kb = self.data_pages * page_kb;
         let stack_kb = self.stack_pages * page_kb;
         let exe_kb = self.exe_pages * page_kb;
         format!(
-            "VmPeak:\t{vss_kb} kB\nVmSize:\t{vss_kb} kB\nVmLck:\t0 kB\nVmPin:\t0 \
-             kB\nVmHWM:\t{resident_kb} kB\nVmRSS:\t{resident_kb} kB\nRssAnon:\t0 kB\nRssFile:\t0 \
+            "VmPeak:\t{peak_kb} kB\nVmSize:\t{vss_kb} kB\nVmLck:\t0 kB\nVmPin:\t0 \
+             kB\nVmHWM:\t{hwm_kb} kB\nVmRSS:\t{resident_kb} kB\nRssAnon:\t0 kB\nRssFile:\t0 \
              kB\nRssShmem:\t0 kB\nVmData:\t{data_kb} kB\nVmStk:\t{stack_kb} kB\nVmExe:\t{exe_kb} \
              kB\nVmLib:\t0 kB\nVmPTE:\t0 kB\nVmSwap:\t0 kB\n"
         )
@@ -314,10 +328,14 @@ mod tests {
             stack_pages: 32,
             exe_pages: 16,
             resident_pages: 256,
+            peak_pages: 512,
+            hwm_pages: 256,
             ..Default::default()
         };
         let lines = stats.format_status_vm_lines();
+        assert!(lines.contains("VmPeak:\t2048 kB\n"));
         assert!(lines.contains("VmSize:\t1024 kB\n"));
+        assert!(lines.contains("VmHWM:\t1024 kB\n"));
         assert!(lines.contains("VmRSS:\t1024 kB\n"));
         assert!(lines.contains("VmData:\t256 kB\n"));
         assert!(lines.contains("VmStk:\t128 kB\n"));

--- a/os/StarryOS/kernel/src/mm/vm_stat.rs
+++ b/os/StarryOS/kernel/src/mm/vm_stat.rs
@@ -1,0 +1,129 @@
+//! Per-address-space virtual memory accounting (VmX).
+//!
+//! [`ProcessVmStat`] is the single authoritative source for all VmX counters.
+//! It lives inside [`super::AddrSpace`] and is maintained automatically by
+//! `map` / `unmap` / `clear` / `try_clone`, so no syscall handler needs to
+//! touch it manually.
+//!
+//! # Counter categories
+//!
+//! | Category | Fields | Update rule |
+//! |---|---|---|
+//! | Current (O(1) atomic) | `vss_pages` | +size on map, -size on unmap/clear |
+//! | High-water marks | `peak_vss_pages`, `peak_rss_pages` | `fetch_max` on map |
+//! | RSS (Plan2) | `rss_pages` | reserved, always 0 until Plan2 |
+//!
+//! Current VSS is maintained as an `AtomicI64` (signed) so that a
+//! double-unmap or a race never wraps to u64::MAX; it is always read as
+//! `max(0, value)`.
+
+use core::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+/// All VmX accounting for one address space.
+///
+/// Fields are intentionally private; use the provided methods to read or
+/// update them.  This ensures the monotonicity invariant on the high-water
+/// marks is maintained by construction.
+pub struct ProcessVmStat {
+    // ── Current counters (O(1), updated on every map/unmap) ──────────────
+    /// Current virtual size in pages (VmSize).  Signed to catch underflow bugs.
+    vss_pages: AtomicI64,
+
+    // ── High-water marks (monotonically non-decreasing) ──────────────────
+    /// Peak virtual size in pages (VmPeak).
+    peak_vss_pages: AtomicU64,
+    /// Peak resident set size in pages (VmHWM).
+    /// Plan1: mirrors peak_vss.  Plan2: replace with real RSS tracking.
+    peak_rss_pages: AtomicU64,
+    // ── RSS placeholder (Plan2) ───────────────────────────────────────────
+    // When Plan2 lands, add `rss_pages: AtomicI64` here and update it in the
+    // page-fault / reclaim paths.  High-water update should then use real RSS.
+}
+
+impl ProcessVmStat {
+    pub const fn new() -> Self {
+        Self {
+            vss_pages: AtomicI64::new(0),
+            peak_vss_pages: AtomicU64::new(0),
+            peak_rss_pages: AtomicU64::new(0),
+        }
+    }
+
+    // ── Read accessors ────────────────────────────────────────────────────
+
+    /// Current VSS in pages (VmSize).
+    #[inline]
+    pub fn vss_pages(&self) -> u64 {
+        self.vss_pages.load(Ordering::Relaxed).max(0) as u64
+    }
+
+    /// Peak VSS in pages (VmPeak).
+    #[inline]
+    pub fn peak_vss_pages(&self) -> u64 {
+        self.peak_vss_pages.load(Ordering::Relaxed)
+    }
+
+    /// Peak RSS in pages (VmHWM).
+    #[inline]
+    pub fn peak_rss_pages(&self) -> u64 {
+        self.peak_rss_pages.load(Ordering::Relaxed)
+    }
+
+    // ── Mutation (called only by AddrSpace) ───────────────────────────────
+
+    /// Account for `pages` newly mapped pages and update high-water marks.
+    ///
+    /// Must be called **after** the mapping succeeds so that a failed map does
+    /// not advance the watermarks.
+    #[inline]
+    pub(super) fn on_map(&self, pages: u64) {
+        let new_vss = self
+            .vss_pages
+            .fetch_add(pages as i64, Ordering::Relaxed)
+            .max(0) as u64
+            + pages;
+        // Plan1: RSS == VSS.  Plan2: pass real RSS here instead.
+        self.peak_vss_pages.fetch_max(new_vss, Ordering::Relaxed);
+        self.peak_rss_pages.fetch_max(new_vss, Ordering::Relaxed);
+    }
+
+    /// Account for `pages` unmapped pages.  High-water marks are never lowered.
+    #[inline]
+    pub(super) fn on_unmap(&self, pages: u64) {
+        self.vss_pages.fetch_sub(pages as i64, Ordering::Relaxed);
+    }
+
+    /// Reset all counters to zero (exec / address-space teardown).
+    ///
+    /// High-water marks are also reset: Linux resets VmPeak/VmHWM on `execve`
+    /// because the new image starts a fresh `mm_struct`.
+    #[inline]
+    pub(super) fn on_clear(&self) {
+        self.vss_pages.store(0, Ordering::Relaxed);
+        self.peak_vss_pages.store(0, Ordering::Relaxed);
+        self.peak_rss_pages.store(0, Ordering::Relaxed);
+    }
+
+    /// Seed this stat from a parent's snapshot (used when `try_clone` builds
+    /// the child address space for `fork`/`clone`).
+    ///
+    /// The child inherits the parent's current VSS as its starting watermarks,
+    /// matching Linux: the child's `mm_struct` starts with `hiwater_vm` set to
+    /// the copied `total_vm`.
+    #[inline]
+    pub(super) fn seed_from(&self, parent: &Self) {
+        let vss = parent.vss_pages();
+        self.vss_pages.store(vss as i64, Ordering::Relaxed);
+        // Child's peaks start at current VSS (the copied address space size).
+        self.peak_vss_pages
+            .store(parent.peak_vss_pages().max(vss), Ordering::Relaxed);
+        self.peak_rss_pages
+            .store(parent.peak_rss_pages().max(vss), Ordering::Relaxed);
+    }
+}
+
+impl Default for ProcessVmStat {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/os/StarryOS/kernel/src/syscall/mm/brk.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/brk.rs
@@ -53,10 +53,10 @@ pub fn sys_brk(addr: usize) -> AxResult<isize> {
         let expand_start = VirtAddr::from(initial_heap_end.max(current_top_aligned));
         let expand_size = new_top_aligned.saturating_sub(expand_start.as_usize());
 
-        if expand_size > 0
-            && proc_data
-                .aspace()
-                .lock()
+        if expand_size > 0 {
+            let aspace_arc = proc_data.aspace();
+            let mut aspace = aspace_arc.lock();
+            if aspace
                 .map(
                     expand_start,
                     expand_size,
@@ -65,8 +65,10 @@ pub fn sys_brk(addr: usize) -> AxResult<isize> {
                     Backend::new_alloc(expand_start, PageSize::Size4K, "[heap]"),
                 )
                 .is_err()
-        {
-            return Ok(current_top as isize);
+            {
+                return Ok(current_top as isize);
+            }
+            drop(aspace);
         }
     } else if new_top_aligned < current_top_aligned {
         // Only unmap pages beyond the initially mapped heap region.

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -303,6 +303,7 @@ pub fn sys_mmap(
             );
             let populate = map_flags.contains(MmapFlags::POPULATE);
             aspace.map(start, map_length, ion_mapping_flags, populate, backend)?;
+            drop(aspace);
             info!(
                 "Ion buffer mmap success: vaddr=0x{:x}, length={}",
                 start.as_usize(),
@@ -483,6 +484,7 @@ pub fn sys_mmap(
 
     let populate = map_flags.contains(MmapFlags::POPULATE);
     aspace.map(start, length, mapping_flags, populate, backend)?;
+    drop(aspace);
 
     Ok(start.as_usize() as _)
 }

--- a/test-suit/starryos/qemu-smp1/system/proc-test-vmpeak-hwm/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/proc-test-vmpeak-hwm/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-vmpeak-hwm C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-vmpeak-hwm src/main.c)
+target_include_directories(test-vmpeak-hwm PRIVATE src ${CMAKE_CURRENT_SOURCE_DIR}/../common)
+target_compile_options(test-vmpeak-hwm PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-vmpeak-hwm RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/proc-test-vmpeak-hwm/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/proc-test-vmpeak-hwm/src/main.c
@@ -1,0 +1,145 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef MREMAP_MAYMOVE
+#define MREMAP_MAYMOVE 1
+#endif
+
+static long read_status_kb(const char *key)
+{
+    FILE *fp = fopen("/proc/self/status", "r");
+    CHECK(fp != NULL, "open /proc/self/status");
+
+    char line[256];
+    char prefix[64];
+    long value = -1;
+    int found = 0;
+
+    snprintf(prefix, sizeof(prefix), "%s:\t", key);
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        if (strncmp(line, prefix, strlen(prefix)) != 0) {
+            continue;
+        }
+        CHECK(sscanf(line + strlen(prefix), "%ld kB", &value) == 1, key);
+        found = 1;
+        break;
+    }
+
+    fclose(fp);
+    CHECK(found, "missing Vm field");
+    return value;
+}
+
+static void touch_pages(unsigned char *ptr, size_t len, size_t page_size)
+{
+    for (size_t off = 0; off < len; off += page_size) {
+        ptr[off] = (unsigned char)(off / page_size);
+    }
+}
+
+static void test_mmap_highwater(size_t page_size)
+{
+    const size_t len = 32 * 1024 * 1024;
+    unsigned long before_peak = (unsigned long)read_status_kb("VmPeak");
+    unsigned long before_hwm = (unsigned long)read_status_kb("VmHWM");
+    unsigned char *map = mmap(NULL, len, PROT_READ | PROT_WRITE,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(map != MAP_FAILED, "mmap anonymous region");
+    if (map == MAP_FAILED) {
+        return;
+    }
+
+    touch_pages(map, len, page_size);
+
+    unsigned long after_peak = (unsigned long)read_status_kb("VmPeak");
+    unsigned long after_hwm = (unsigned long)read_status_kb("VmHWM");
+    CHECK(after_peak > before_peak, "VmPeak grows after mmap");
+    CHECK(after_hwm > before_hwm, "VmHWM grows after mmap");
+
+    CHECK(munmap(map, len) == 0, "munmap mmap region");
+    unsigned long post_peak = (unsigned long)read_status_kb("VmPeak");
+    unsigned long post_hwm = (unsigned long)read_status_kb("VmHWM");
+    CHECK(post_peak == after_peak, "VmPeak does not fall after munmap");
+    CHECK(post_hwm == after_hwm, "VmHWM does not fall after munmap");
+}
+
+static void test_brk_highwater(size_t page_size)
+{
+    unsigned long before_peak = (unsigned long)read_status_kb("VmPeak");
+    unsigned long before_hwm = (unsigned long)read_status_kb("VmHWM");
+    unsigned long base = (unsigned long)syscall(SYS_brk, 0);
+    unsigned long target = base + 16 * (unsigned long)page_size;
+    long ret = syscall(SYS_brk, (void *)target);
+    CHECK(ret == (long)target, "raw brk expands heap");
+    if (ret != (long)target) {
+        return;
+    }
+
+    touch_pages((unsigned char *)base, target - base, page_size);
+
+    unsigned long after_peak = (unsigned long)read_status_kb("VmPeak");
+    unsigned long after_hwm = (unsigned long)read_status_kb("VmHWM");
+    CHECK(after_peak >= before_peak, "VmPeak does not fall after brk");
+    CHECK(after_hwm >= before_hwm, "VmHWM does not fall after brk");
+
+    CHECK(syscall(SYS_brk, (void *)base) == (long)base,
+          "raw brk restores original break");
+}
+
+static void test_mremap_highwater(size_t page_size)
+{
+    const size_t from_len = page_size;
+    const size_t to_len = 16 * 1024 * 1024;
+    unsigned long before_peak = (unsigned long)read_status_kb("VmPeak");
+    unsigned long before_hwm = (unsigned long)read_status_kb("VmHWM");
+    unsigned char *map = mmap(NULL, from_len, PROT_READ | PROT_WRITE,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(map != MAP_FAILED, "mmap base page for mremap");
+    if (map == MAP_FAILED) {
+        return;
+    }
+
+    touch_pages(map, from_len, page_size);
+
+    unsigned char *grown = mremap(map, from_len, to_len, MREMAP_MAYMOVE);
+    CHECK(grown != MAP_FAILED, "mremap grows mapping");
+    if (grown == MAP_FAILED) {
+        munmap(map, from_len);
+        return;
+    }
+
+    touch_pages(grown, to_len, page_size);
+
+    unsigned long after_peak = (unsigned long)read_status_kb("VmPeak");
+    unsigned long after_hwm = (unsigned long)read_status_kb("VmHWM");
+    CHECK(after_peak > before_peak, "VmPeak grows after mremap");
+    CHECK(after_hwm > before_hwm, "VmHWM grows after mremap");
+
+    CHECK(munmap(grown, to_len) == 0, "munmap mremap region");
+    unsigned long post_peak = (unsigned long)read_status_kb("VmPeak");
+    unsigned long post_hwm = (unsigned long)read_status_kb("VmHWM");
+    CHECK(post_peak == after_peak, "VmPeak does not fall after mremap munmap");
+    CHECK(post_hwm == after_hwm, "VmHWM does not fall after mremap munmap");
+}
+
+int main(void)
+{
+    long page_size = sysconf(_SC_PAGESIZE);
+    CHECK(page_size > 0, "sysconf(_SC_PAGESIZE) must be positive");
+
+    TEST_START("vmpeak-hwm");
+    CHECK(read_status_kb("VmPeak") > 0, "VmPeak must be positive");
+    CHECK(read_status_kb("VmHWM") > 0, "VmHWM must be positive");
+
+    test_mremap_highwater((size_t)page_size);
+    test_mmap_highwater((size_t)page_size);
+    test_brk_highwater((size_t)page_size);
+
+    TEST_DONE();
+}


### PR DESCRIPTION
# StarryOS /proc VmPeak 与 VmHWM 实现

## 背景

StarryOS 的 `/proc/[pid]/status` 已经输出 Vm* 字段，但 `VmPeak` 和 `VmHWM` 直接跟随当前 `VmSize` / `VmRSS` 结果，进程释放映射后峰值也会下降，不符合 Linux 中高水位线单调不下降的语义。

这会影响依赖 `/proc/self/status` 判断进程历史最大虚拟内存和历史最大驻留内存的程序，也让 `mmap`、`mremap`、`brk` 等内存变化路径缺少可回归验证。

## 方案

在 StarryOS 地址空间 `AddrSpace` 内新增统一的进程虚拟内存统计对象 `ProcessVmStat`，由地址空间的映射生命周期自动维护 VmX 计数，而不是让 syscall 处理路径手动维护。

核心思路如下：

1. 当前虚拟内存页数在成功 `map` / `extend_area` 后增加，在 `unmap` / `unmap_metadata` 后按实际移除的映射范围减少，在 `clear` 时重置。
2. `VmPeak` 使用 `peak_vss_pages` 记录历史最大虚拟地址空间页数，只在映射增长路径中通过高水位更新，不随 unmap 降低。
3. `VmHWM` 当前阶段仍沿用 Plan1 语义，跟随虚拟内存统计作为 RSS 上界；后续真实 RSS 统计落地后可切换为真实驻留集高水位。
4. `fork` / `clone` 复制地址空间时，通过 `seed_from` 让子进程继承父进程当前地址空间大小作为初始统计基线，并保留合理的峰值语义。
5. `/proc/[pid]/status` 渲染时继续通过 VMA 遍历获取当前 VmSize / VmRSS / VmData / VmStk / VmExe，同时从 `AddrSpace::vm_stat` O(1) 读取 `VmPeak` 和 `VmHWM`。

## 改动

最后两次提交包含以下改动：

1. `fix(starry-kernel): track proc vm watermarks`

   引入 `os/StarryOS/kernel/src/mm/vm_stat.rs`，新增 `ProcessVmStat`，使用原子计数维护当前 VSS、峰值 VSS 和峰值 RSS。`vss_pages` 使用有符号原子值，避免异常重复 unmap 时出现无符号下溢。

2. `AddrSpace` 集成 VmX 统计

   `os/StarryOS/kernel/src/mm/aspace/mod.rs` 在 `map`、`extend_area`、`unmap`、`unmap_metadata`、`clear`、`try_clone` 中维护 `vm_stat`。unmap 路径先按待删除范围和现有 VMA 的交集计算实际移除页数，再更新当前 VSS，避免按请求长度错误扣减。

3. `/proc` 内存状态输出修正

   `os/StarryOS/kernel/src/mm/stats.rs` 在 `ProcessMemStats` 中新增 `peak_pages` 和 `hwm_pages`，`format_status_vm_lines` 改为使用这两个高水位字段输出 `VmPeak` / `VmHWM`，并补充格式化单元测试覆盖。

4. mmap / brk 锁生命周期调整

   `os/StarryOS/kernel/src/syscall/mm/brk.rs` 和 `os/StarryOS/kernel/src/syscall/mm/mmap.rs` 在映射成功后显式释放地址空间锁，避免后续流程继续持有锁导致不必要的锁生命周期延长。

5. 新增 StarryOS 回归测例

   新增 `test-suit/starryos/qemu-smp1/system/proc-test-vmpeak-hwm`，测试程序读取 `/proc/self/status` 中的 `VmPeak` 和 `VmHWM`，覆盖 `mmap`、`mremap`、`brk` 三类增长路径，并验证释放映射后 `VmPeak` / `VmHWM` 不下降。

## 本地验证

已完成以下本地验证：

1. Linux 下该 case 测试通过。
2. 四个架构的该 case 测例通过。
3. 一次 `cargo xtask starry test qemu --target riscv64gc-unknown-none-elf` 通过。
