### PR TITLE
refactor(axvm): route RISC-V IRQs through vPLIC backend

### DIFF
--- a/virtualization/axvm/src/arch.rs
+++ b/virtualization/axvm/src/arch.rs
@@ -124,17 +124,10 @@ mod x86_64 {
 mod riscv64 {
     use ax_crate_interface::impl_interface;
     use ax_memory_addr::{PhysAddr, VirtAddr};
-    #[cfg(feature = "plat-dyn")]
-    use axdevice_base::AccessWidth;
-    #[cfg(feature = "plat-dyn")]
-    use axvm_types::GuestPhysAddr;
     use riscv_vcpu::host::RiscvVcpuHostIf;
     use riscv_vplic::host::RiscvVplicHostIf;
 
     use crate::host::{HostMemory, default_host};
-
-    #[cfg(feature = "plat-dyn")]
-    const GUEST_PLIC_PADDR: usize = 0x0c00_0000;
 
     struct RiscvVcpuHostIfImpl;
 
@@ -172,19 +165,7 @@ mod riscv64 {
         };
 
         let Some(injected) = crate::manager::with_vm(vm_id, |vm| {
-            let Some(vplic) = vm
-                .get_devices()
-                .find_mmio_dev(GuestPhysAddr::from_usize(GUEST_PLIC_PADDR))
-            else {
-                warn!("VM[{vm_id}] has no virtual PLIC device");
-                return false;
-            };
-
-            let reg_offset = riscv_vplic::PLIC_PENDING_OFFSET + (irq_id / 32) * 4;
-            let addr = GuestPhysAddr::from_usize(GUEST_PLIC_PADDR + reg_offset);
-            let val: u32 = 1 << (irq_id % 32);
-
-            if let Err(err) = vplic.handle_write(addr, AccessWidth::Dword, val as _) {
+            if let Err(err) = vm.interrupt_fabric().pulse(irq_id) {
                 warn!("failed to inject RISC-V virtual IRQ {irq_id}: {err:?}");
                 return false;
             }

--- a/virtualization/axvm/src/irq/mod.rs
+++ b/virtualization/axvm/src/irq/mod.rs
@@ -21,6 +21,9 @@ use axdevice::IrqResolver;
 use axdevice_base::{InterruptTriggerMode, IrqLine, IrqLineId, IrqSink};
 use axvm_types::VMInterruptMode;
 
+#[cfg(target_arch = "riscv64")]
+pub(crate) mod riscv;
+
 /// Resolves device interrupt lines against one VM's interrupt backend.
 ///
 /// The fabric owns only the backend capability. It never owns or references the
@@ -61,6 +64,33 @@ impl InterruptFabric {
         self.sink.is_some()
     }
 
+    fn sink_for_line(&self, line: usize) -> AxResult<&Arc<dyn IrqSink>> {
+        let Some(sink) = &self.sink else {
+            if self.mode == VMInterruptMode::NoIrq {
+                return ax_err!(
+                    InvalidInput,
+                    format_args!("cannot signal IRQ line {line}: the VM interrupt mode is NoIrq")
+                );
+            }
+            return ax_err!(
+                Unsupported,
+                format_args!("cannot signal IRQ line {line}: no VM interrupt backend is installed")
+            );
+        };
+        Ok(sink)
+    }
+
+    /// Sets the asserted state of a VM-local interrupt line.
+    pub fn set_level(&self, line: usize, asserted: bool) -> AxResult {
+        self.sink_for_line(line)?
+            .set_level(IrqLineId(line), asserted)
+    }
+
+    /// Delivers one pulse on a VM-local interrupt line.
+    pub fn pulse(&self, line: usize) -> AxResult {
+        self.sink_for_line(line)?.pulse(IrqLineId(line))
+    }
+
     pub(crate) fn validate_mode(&self, mode: VMInterruptMode) -> AxResult {
         if self.mode != mode {
             return ax_err!(
@@ -83,20 +113,10 @@ impl Default for InterruptFabric {
 
 impl IrqResolver for InterruptFabric {
     fn resolve_irq(&self, line: usize, trigger: InterruptTriggerMode) -> AxResult<IrqLine> {
-        let Some(sink) = &self.sink else {
-            if self.mode == VMInterruptMode::NoIrq {
-                return ax_err!(
-                    InvalidInput,
-                    format_args!("cannot resolve IRQ line {line}: the VM interrupt mode is NoIrq")
-                );
-            }
-            return ax_err!(
-                Unsupported,
-                format_args!(
-                    "cannot resolve IRQ line {line}: no VM interrupt backend is installed"
-                )
-            );
-        };
-        Ok(IrqLine::new(IrqLineId(line), trigger, sink.clone()))
+        Ok(IrqLine::new(
+            IrqLineId(line),
+            trigger,
+            self.sink_for_line(line)?.clone(),
+        ))
     }
 }

--- a/virtualization/axvm/src/irq/riscv.rs
+++ b/virtualization/axvm/src/irq/riscv.rs
@@ -1,0 +1,146 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RISC-V virtual PLIC interrupt backend.
+
+use alloc::sync::Arc;
+
+use ax_errno::{AxResult, ax_err};
+use axdevice::{
+    DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceFactoryRegistry, DeviceRegistration,
+};
+use axdevice_base::{IrqLineId, IrqSink};
+use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, VMInterruptMode};
+use riscv_vplic::{
+    PLIC_CONTEXT_CLAIM_COMPLETE_OFFSET, PLIC_CONTEXT_CTRL_OFFSET, PLIC_CONTEXT_STRIDE, VPlicGlobal,
+};
+
+use super::InterruptFabric;
+
+struct RiscvPlicIrqSink {
+    vplic: Arc<VPlicGlobal>,
+}
+
+impl IrqSink for RiscvPlicIrqSink {
+    fn set_level(&self, line: IrqLineId, asserted: bool) -> AxResult {
+        if asserted {
+            self.vplic.set_pending(line.0)
+        } else {
+            self.vplic.clear_pending(line.0)
+        }
+    }
+
+    fn pulse(&self, line: IrqLineId) -> AxResult {
+        self.vplic.set_pending(line.0)
+    }
+}
+
+struct RiscvPlicFactory {
+    base_gpa: usize,
+    length: usize,
+    contexts_num: usize,
+    vplic: Arc<VPlicGlobal>,
+}
+
+impl DeviceFactory for RiscvPlicFactory {
+    fn device_type(&self) -> EmulatedDeviceType {
+        EmulatedDeviceType::PPPTGlobal
+    }
+
+    fn build(
+        &self,
+        config: &EmulatedDeviceConfig,
+        _context: &DeviceBuildContext<'_>,
+    ) -> AxResult<DeviceBundle> {
+        if config.base_gpa != self.base_gpa
+            || config.length != self.length
+            || config.cfg_list.as_slice() != [self.contexts_num]
+        {
+            return ax_err!(
+                InvalidInput,
+                format_args!(
+                    "virtual PLIC configuration changed while building device '{}'",
+                    config.name
+                )
+            );
+        }
+        Ok(DeviceRegistration::Mmio(self.vplic.clone()).into())
+    }
+}
+
+fn validate_vplic_config(config: &EmulatedDeviceConfig) -> AxResult<usize> {
+    let [contexts_num] = config.cfg_list.as_slice() else {
+        return ax_err!(
+            InvalidInput,
+            format_args!(
+                "virtual PLIC device '{}' requires exactly one context-count argument",
+                config.name
+            )
+        );
+    };
+    let context_end = contexts_num
+        .checked_mul(PLIC_CONTEXT_STRIDE)
+        .and_then(|offset| offset.checked_add(PLIC_CONTEXT_CTRL_OFFSET))
+        .and_then(|offset| offset.checked_add(PLIC_CONTEXT_CLAIM_COMPLETE_OFFSET))
+        .and_then(|offset| config.base_gpa.checked_add(offset))
+        .ok_or(ax_errno::AxError::InvalidInput)?;
+    let region_end = config
+        .base_gpa
+        .checked_add(config.length)
+        .ok_or(ax_errno::AxError::InvalidInput)?;
+    if region_end <= context_end {
+        return ax_err!(
+            InvalidInput,
+            format_args!(
+                "virtual PLIC device '{}' range [{:#x}, {:#x}) does not cover {} contexts",
+                config.name, config.base_gpa, region_end, contexts_num
+            )
+        );
+    }
+    Ok(*contexts_num)
+}
+
+pub(crate) fn configure(
+    factories: &mut DeviceFactoryRegistry,
+    mode: VMInterruptMode,
+    configs: &[EmulatedDeviceConfig],
+) -> AxResult<InterruptFabric> {
+    let mut vplic_configs = configs
+        .iter()
+        .filter(|config| config.emu_type == EmulatedDeviceType::PPPTGlobal);
+    let Some(config) = vplic_configs.next() else {
+        return Ok(InterruptFabric::new(mode));
+    };
+    if vplic_configs.next().is_some() {
+        return ax_err!(
+            AlreadyExists,
+            "a VM can register only one virtual PLIC global controller"
+        );
+    }
+
+    let contexts_num = validate_vplic_config(config)?;
+    let vplic = Arc::new(VPlicGlobal::new(
+        config.base_gpa.into(),
+        Some(config.length),
+        contexts_num,
+    ));
+    factories.register(Arc::new(RiscvPlicFactory {
+        base_gpa: config.base_gpa,
+        length: config.length,
+        contexts_num,
+        vplic: vplic.clone(),
+    }))?;
+
+    InterruptFabric::with_sink(mode, Arc::new(RiscvPlicIrqSink { vplic }))
+}

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -220,7 +220,20 @@ impl AxVM {
     pub fn init(&self) -> AxResult {
         let mut factories = DeviceFactoryRegistry::new();
         register_builtin_factories(&mut factories)?;
-        self.init_with_factories(&factories, InterruptFabric::new(self.interrupt_mode()))
+        let interrupt_mode = self.interrupt_mode();
+        #[cfg(target_arch = "riscv64")]
+        let interrupt_fabric = {
+            let inner_mut = self.inner_mut.lock();
+            crate::irq::riscv::configure(
+                &mut factories,
+                interrupt_mode,
+                inner_mut.config.emu_devices(),
+            )?
+        };
+        #[cfg(not(target_arch = "riscv64"))]
+        let interrupt_fabric = InterruptFabric::new(interrupt_mode);
+
+        self.init_with_factories(&factories, interrupt_fabric)
     }
 
     /// Sets up the VM with explicit device factories and an interrupt fabric.

--- a/virtualization/riscv_vplic/src/devops_impl.rs
+++ b/virtualization/riscv_vplic/src/devops_impl.rs
@@ -2,18 +2,74 @@
 //!
 //! Implements the `BaseDeviceOps` trait for MMIO read/write handling.
 
-use ax_errno::AxResult;
+use ax_errno::{AxResult, ax_err};
 use axdevice_base::{AccessWidth, BaseDeviceOps, DeviceAddrRange, EmuDeviceType};
 use axvm_types::{GuestPhysAddrRange, HostPhysAddr};
 use bitmaps::Bitmap;
 
 use crate::{consts::*, utils::*, vplic::VPlicGlobal};
 
+#[cfg(target_arch = "riscv64")]
 const VCAUSE_INTERRUPT_BIT: usize = 1usize << (usize::BITS - 1);
+#[cfg(target_arch = "riscv64")]
 const VCAUSE_VS_TIMER: usize = VCAUSE_INTERRUPT_BIT | 5;
 const PLIC_PENDING_WORDS: usize = PLIC_NUM_SOURCES / 32;
 
 impl VPlicGlobal {
+    fn validate_irq_id(irq_id: usize) -> AxResult {
+        if irq_id == 0 || irq_id >= PLIC_NUM_SOURCES {
+            return ax_err!(
+                InvalidInput,
+                format_args!(
+                    "invalid PLIC source ID {irq_id}; valid source IDs are 1..{}",
+                    PLIC_NUM_SOURCES - 1
+                )
+            );
+        }
+        Ok(())
+    }
+
+    fn validate_assigned_irq(&self, irq_id: usize) -> AxResult {
+        Self::validate_irq_id(irq_id)?;
+
+        let assigned_irqs = self.assigned_irqs.lock();
+        if !assigned_irqs.is_empty() && !assigned_irqs.get(irq_id) {
+            return ax_err!(
+                PermissionDenied,
+                format_args!("PLIC source ID {irq_id} is not assigned to this virtual PLIC")
+            );
+        }
+        Ok(())
+    }
+
+    fn update_pending_irq(&self, irq_id: usize, pending: bool) -> AxResult {
+        self.validate_assigned_irq(irq_id)?;
+        self.pending_irqs.lock().set(irq_id, pending);
+        Ok(())
+    }
+
+    /// Marks one interrupt source as pending.
+    ///
+    /// Source ID 0 and IDs outside the PLIC source range are rejected. An
+    /// empty assignment bitmap preserves the existing unrestricted behavior;
+    /// once assignments are populated, only assigned sources are accepted.
+    pub fn set_pending(&self, irq_id: usize) -> AxResult {
+        self.update_pending_irq(irq_id, true)?;
+        self.sync_all_guest_contexts_vseip()
+    }
+
+    /// Clears the pending state of one interrupt source.
+    pub fn clear_pending(&self, irq_id: usize) -> AxResult {
+        self.update_pending_irq(irq_id, false)?;
+        self.sync_all_guest_contexts_vseip()
+    }
+
+    /// Returns whether one interrupt source is pending.
+    pub fn is_pending(&self, irq_id: usize) -> AxResult<bool> {
+        self.validate_assigned_irq(irq_id)?;
+        Ok(self.pending_irqs.lock().get(irq_id))
+    }
+
     /// Reads the priority of an interrupt source from the host PLIC.
     fn irq_priority(&self, irq_id: usize) -> AxResult<u32> {
         let addr = HostPhysAddr::from_usize(
@@ -23,6 +79,7 @@ impl VPlicGlobal {
     }
 
     /// Reads the priority threshold configured for a PLIC context.
+    #[cfg(target_arch = "riscv64")]
     fn context_threshold(&self, context_id: usize) -> AxResult<u32> {
         let addr = HostPhysAddr::from_usize(
             self.host_plic_addr.as_usize()
@@ -91,6 +148,7 @@ impl VPlicGlobal {
     }
 
     /// Returns the next IRQ that should assert VSEIP for this context.
+    #[cfg(target_arch = "riscv64")]
     fn next_deliverable_irq(&self, context_id: usize) -> AxResult<Option<usize>> {
         let threshold = self.context_threshold(context_id)?;
         let candidate_irqs = self.pending_inactive_irqs();
@@ -128,6 +186,7 @@ impl VPlicGlobal {
     }
 
     /// Recomputes whether VSEIP should remain asserted for one context.
+    #[cfg(target_arch = "riscv64")]
     fn sync_vseip(&self, context_id: usize) -> AxResult<()> {
         // VSEIP should track whether this context still has a deliverable
         // external interrupt, not merely whether some pending bit is set.
@@ -147,6 +206,11 @@ impl VPlicGlobal {
                 riscv_h::register::hvip::clear_vseip();
             }
         }
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "riscv64"))]
+    fn sync_vseip(&self, _context_id: usize) -> AxResult<()> {
         Ok(())
     }
 
@@ -271,19 +335,16 @@ impl BaseDeviceOps<GuestPhysAddrRange> for VPlicGlobal {
                 }
                 let val = val as u32;
                 let mut bit_mask: u32 = 1;
-                let mut pending_irqs = self.pending_irqs.lock();
                 for i in 0..32 {
                     if (val & bit_mask) != 0 {
                         let irq_id = reg_index * 32 + i;
                         if irq_id != 0 {
-                            // Set the pending bit.
-                            pending_irqs.set(irq_id, true);
+                            self.update_pending_irq(irq_id, true)?;
                         }
                     }
                     bit_mask <<= 1;
                 }
 
-                drop(pending_irqs);
                 self.sync_all_guest_contexts_vseip()
             }
             // enable
@@ -332,6 +393,7 @@ impl BaseDeviceOps<GuestPhysAddrRange> for VPlicGlobal {
                 }
                 let mut active_irqs = self.active_irqs.lock();
                 if !active_irqs.get(irq_id) {
+                    drop(active_irqs);
                     return self.sync_vseip(context_id);
                 }
 

--- a/virtualization/riscv_vplic/tests/vplic_tests.rs
+++ b/virtualization/riscv_vplic/tests/vplic_tests.rs
@@ -1,7 +1,33 @@
+use ax_crate_interface::impl_interface;
+use ax_errno::AxError;
+use ax_memory_addr::{PhysAddr, VirtAddr};
+use axdevice_base::{AccessWidth, BaseDeviceOps};
 use axvm_types::GuestPhysAddr;
 use riscv_vplic::{
-    PLIC_CONTEXT_CLAIM_COMPLETE_OFFSET, PLIC_CONTEXT_CTRL_OFFSET, PLIC_CONTEXT_STRIDE, VPlicGlobal,
+    PLIC_CONTEXT_CLAIM_COMPLETE_OFFSET, PLIC_CONTEXT_CTRL_OFFSET, PLIC_CONTEXT_STRIDE,
+    PLIC_ENABLE_OFFSET, PLIC_ENABLE_STRIDE, PLIC_NUM_SOURCES, PLIC_PENDING_OFFSET,
+    PLIC_PRIORITY_OFFSET, VPlicGlobal, host::RiscvVplicHostIf,
 };
+
+const HOST_PLIC_BASE: usize = 0x0c00_0000;
+const HOST_PLIC_SIZE: usize = 0x40_0000;
+
+#[repr(align(8))]
+struct AlignedHostPlic([u8; HOST_PLIC_SIZE]);
+
+static mut HOST_PLIC: AlignedHostPlic = AlignedHostPlic([0; HOST_PLIC_SIZE]);
+
+struct TestRiscvVplicHostIf;
+
+#[impl_interface]
+impl RiscvVplicHostIf for TestRiscvVplicHostIf {
+    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+        let offset = paddr.as_usize() - HOST_PLIC_BASE;
+        assert!(offset < HOST_PLIC_SIZE);
+        let base = unsafe { core::ptr::addr_of_mut!(HOST_PLIC.0).cast::<u8>() };
+        VirtAddr::from(unsafe { base.add(offset) } as usize)
+    }
+}
 
 /// Calculate minimum required size for VPlicGlobal with given contexts
 fn calculate_min_size(contexts_num: usize) -> usize {
@@ -64,4 +90,89 @@ fn test_vplic_global_bitmaps_initialized_empty() {
     assert!(vplic.assigned_irqs.lock().is_empty());
     assert!(vplic.pending_irqs.lock().is_empty());
     assert!(vplic.active_irqs.lock().is_empty());
+}
+
+#[test]
+fn test_typed_pending_api_is_visible_through_mmio() {
+    let addr = GuestPhysAddr::from(HOST_PLIC_BASE);
+    let vplic = VPlicGlobal::new(addr, Some(HOST_PLIC_SIZE), 2);
+
+    vplic.set_pending(33).unwrap();
+
+    assert!(vplic.is_pending(33).unwrap());
+    assert_eq!(
+        vplic
+            .handle_read(addr + PLIC_PENDING_OFFSET + 4, AccessWidth::Dword)
+            .unwrap(),
+        1 << 1
+    );
+
+    vplic.clear_pending(33).unwrap();
+    assert!(!vplic.is_pending(33).unwrap());
+}
+
+#[test]
+fn test_pending_api_rejects_reserved_unassigned_and_out_of_range_sources() {
+    let vplic = VPlicGlobal::new(GuestPhysAddr::from(HOST_PLIC_BASE), Some(HOST_PLIC_SIZE), 2);
+
+    assert_eq!(vplic.set_pending(0), Err(AxError::InvalidInput));
+    assert_eq!(
+        vplic.set_pending(PLIC_NUM_SOURCES),
+        Err(AxError::InvalidInput)
+    );
+
+    vplic.assigned_irqs.lock().set(5, true);
+    assert_eq!(vplic.set_pending(6), Err(AxError::PermissionDenied));
+    assert_eq!(vplic.set_pending(5), Ok(()));
+}
+
+#[test]
+fn test_claim_and_complete_move_irq_between_pending_and_active() {
+    let addr = GuestPhysAddr::from(HOST_PLIC_BASE);
+    let vplic = VPlicGlobal::new(addr, Some(HOST_PLIC_SIZE), 2);
+    let irq_id = 7;
+    let context_id = 1;
+
+    vplic
+        .handle_write(
+            addr + PLIC_PRIORITY_OFFSET + irq_id * 4,
+            AccessWidth::Dword,
+            1,
+        )
+        .unwrap();
+    vplic
+        .handle_write(
+            addr + PLIC_ENABLE_OFFSET + context_id * PLIC_ENABLE_STRIDE,
+            AccessWidth::Dword,
+            1 << irq_id,
+        )
+        .unwrap();
+    vplic.set_pending(irq_id).unwrap();
+
+    let claim_addr = addr
+        + PLIC_CONTEXT_CTRL_OFFSET
+        + context_id * PLIC_CONTEXT_STRIDE
+        + PLIC_CONTEXT_CLAIM_COMPLETE_OFFSET;
+    assert_eq!(
+        vplic.handle_read(claim_addr, AccessWidth::Dword).unwrap(),
+        irq_id
+    );
+    assert!(!vplic.is_pending(irq_id).unwrap());
+    assert!(vplic.active_irqs.lock().get(irq_id));
+
+    vplic
+        .handle_write(claim_addr, AccessWidth::Dword, irq_id)
+        .unwrap();
+    assert!(!vplic.active_irqs.lock().get(irq_id));
+}
+
+#[test]
+fn test_virtual_plic_instances_and_guest_addresses_are_independent() {
+    let first = VPlicGlobal::new(GuestPhysAddr::from(0x0c00_0000), Some(HOST_PLIC_SIZE), 2);
+    let second = VPlicGlobal::new(GuestPhysAddr::from(0x1c00_0000), Some(HOST_PLIC_SIZE), 2);
+
+    first.set_pending(11).unwrap();
+
+    assert!(first.is_pending(11).unwrap());
+    assert!(!second.is_pending(11).unwrap());
 }

--- a/virtualization/test_crates/virtualization-tests/tests/axvm_irq.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axvm_irq.rs
@@ -227,6 +227,25 @@ fn test_interrupt_fabric_preserves_event_order() {
 }
 
 #[test]
+fn test_interrupt_fabric_can_signal_backend_directly() {
+    let sink = Arc::new(RecordingIrqSink::default());
+    let fabric = InterruptFabric::with_sink(VMInterruptMode::Emulated, sink.clone()).unwrap();
+
+    fabric.set_level(21, true).unwrap();
+    fabric.set_level(21, false).unwrap();
+    fabric.pulse(22).unwrap();
+
+    assert_eq!(
+        sink.events(),
+        vec![
+            IrqEvent::SetLevel(IrqLineId(21), true),
+            IrqEvent::SetLevel(IrqLineId(21), false),
+            IrqEvent::Pulse(IrqLineId(22)),
+        ]
+    );
+}
+
+#[test]
 fn test_factory_device_emits_irq_through_interrupt_fabric() {
     let (fabric, sink) = recording_fabric(VMInterruptMode::Emulated);
     let devices = {


### PR DESCRIPTION
## 背景

这是 #1273 之后 Issue #595 的下一个 stacked PR。#1273 已合并，本 PR 已 rebase 到当前 upstream `dev`：`f307ee93277c784b32b8833f9681e3a8b5100a69`。

## 范围

本 PR 只覆盖阶段 6：把 RISC-V vPLIC backend 接入 VM-local `InterruptFabric`。

- 为 `InterruptFabric` 增加直接 `set_level` / `pulse` 操作，供架构注入路径使用。
- 新增 RISC-V vPLIC IRQ sink/factory，将虚拟 PLIC 与当前 VM fabric 连接。
- 将 RISC-V host virtual IRQ injection 从固定 guest PLIC GPA + pending MMIO write 改为 `vm.interrupt_fabric().pulse(irq_id)`。
- 为 `riscv_vplic` 增加 typed pending API，并复用 pending 更新路径。
- 添加 vPLIC pending/claim/complete/隔离测试和 fabric direct signaling 测试。


## 不包含：

- x86 / AArch64 / LoongArch backend 迁移。
- 命名/多输出 IRQ 配置。

## 验证

- PR3 patch 已在本地对 upstream `dev@f307ee93277c784b32b8833f9681e3a8b5100a69` 快照通过 `git apply --check`。
- 由于本地 git transport 连接 `github.com:443` 仍不稳定，本次 rebase/publish 使用 GitHub REST 快照与 ref 更新完成。
- 完整 cargo/CI 结果等待 upstream draft PR 跑完。

Part of #595.