### PR TITLE
fix(starry-kernel): align socket QoS options with Linux

### DIFF
--- a/apps/starry/git-ssh/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/git-ssh/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,10 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "qemu",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/git-ssh/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/git-ssh/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/git-ssh/git-ssh-test.sh
+++ b/apps/starry/git-ssh/git-ssh-test.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+set -eu
+
+SSHD_PID=""
+WORK=/tmp/git-ssh-test
+PORT=2222
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=3"
+export GIT_SSH_COMMAND="ssh $SSH_OPTS"
+export GIT_PAGER=cat
+export PAGER=cat
+export TERM=dumb
+
+cleanup() {
+    if [ -n "$SSHD_PID" ]; then
+        kill "$SSHD_PID" 2>/dev/null || true
+        wait "$SSHD_PID" 2>/dev/null || true
+    fi
+}
+
+fail() {
+    echo "GIT_SSH_TEST_FAILED"
+    if [ -f "$WORK/sshd.log" ]; then
+        echo "=== sshd log ==="
+        cat "$WORK/sshd.log"
+    fi
+    exit 1
+}
+
+trap cleanup EXIT
+
+install_packages() {
+    sed -i 's|https://|http://|' /etc/apk/repositories
+    apk add git openssh || {
+        apk update
+        apk add git openssh
+    }
+
+    git --version
+    ssh -V 2>&1
+}
+
+configure_ssh() {
+    mkdir -p "$WORK" /root/.ssh /run /var/run
+    chmod 700 /root/.ssh
+
+    rm -f /etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key.pub
+    ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+
+    rm -f /root/.ssh/id_ed25519 /root/.ssh/id_ed25519.pub
+    ssh-keygen -t ed25519 -f /root/.ssh/id_ed25519 -N ""
+    cat /root/.ssh/id_ed25519.pub > /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+
+    sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+    sed -i 's/^#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+    /usr/sbin/sshd -D -e -p "$PORT" -o ListenAddress=127.0.0.1 >"$WORK/sshd.log" 2>&1 &
+    SSHD_PID=$!
+}
+
+wait_for_ssh() {
+    i=0
+    while ! ssh $SSH_OPTS -p "$PORT" root@127.0.0.1 true >/dev/null 2>&1; do
+        i=$((i + 1))
+        if [ "$i" -ge 20 ]; then
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+config_user() {
+    repo=$1
+    git -C "$repo" config user.email "test@starry.os"
+    git -C "$repo" config user.name "Starry Git SSH"
+}
+
+prepare_repo() {
+    rm -rf "$WORK/repo"
+    mkdir -p "$WORK/repo"
+
+    git init --bare "$WORK/repo/src.git"
+    git -C "$WORK/repo/src.git" symbolic-ref HEAD refs/heads/main
+
+    git init -b main "$WORK/repo/seed"
+    config_user "$WORK/repo/seed"
+    printf 'base\n' > "$WORK/repo/seed/data.txt"
+    git -C "$WORK/repo/seed" add data.txt
+    git -C "$WORK/repo/seed" commit -m "seed"
+    git -C "$WORK/repo/seed" remote add origin "$WORK/repo/src.git"
+    git -C "$WORK/repo/seed" push origin main
+}
+
+run_git_ssh_remote() {
+    remote="ssh://root@127.0.0.1:$PORT$WORK/repo/src.git"
+
+    git ls-remote "$remote" refs/heads/main | grep refs/heads/main
+
+    git clone "$remote" "$WORK/repo/client"
+    git clone "$remote" "$WORK/repo/puller"
+
+    config_user "$WORK/repo/client"
+    printf 'from-client\n' >> "$WORK/repo/client/data.txt"
+    git -C "$WORK/repo/client" add data.txt
+    git -C "$WORK/repo/client" commit -m "client update"
+    git -C "$WORK/repo/client" push origin main
+
+    git -C "$WORK/repo/puller" fetch origin main
+    git -C "$WORK/repo/puller" pull --ff-only origin main
+    grep from-client "$WORK/repo/puller/data.txt"
+
+    if timeout 5 git ls-remote "ssh://root@127.0.0.1:3222$WORK/repo/src.git" >/tmp/git-ssh-closed-port.out 2>&1; then
+        echo "unexpected success for closed ssh port"
+        return 1
+    fi
+
+    if git ls-remote "ssh://root@127.0.0.1:$PORT$WORK/repo/missing.git" >/tmp/git-ssh-missing.out 2>&1; then
+        echo "unexpected success for missing ssh repo"
+        return 1
+    fi
+
+    echo "GIT_SSH_REMOTE_PASSED"
+}
+
+install_packages || fail
+configure_ssh || fail
+wait_for_ssh || fail
+prepare_repo || fail
+run_git_ssh_remote || fail
+
+echo "GIT_SSH_TEST_PASSED"

--- a/apps/starry/git-ssh/prebuild.sh
+++ b/apps/starry/git-ssh/prebuild.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+overlay_dir="${STARRY_OVERLAY_DIR:-}"
+
+if [[ -z "$overlay_dir" ]]; then
+    echo "error: STARRY_OVERLAY_DIR is required" >&2
+    exit 1
+fi
+
+install -Dm0755 "$app_dir/git-ssh-test.sh" "$overlay_dir/usr/bin/git-ssh-test.sh"

--- a/apps/starry/git-ssh/qemu-aarch64.toml
+++ b/apps/starry/git-ssh/qemu-aarch64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "cortex-a53",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/git-ssh-test.sh"
+success_regex = ["(?m)^GIT_SSH_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^GIT_SSH_TEST_FAILED\\s*$"]
+timeout = 900

--- a/apps/starry/git-ssh/qemu-riscv64.toml
+++ b/apps/starry/git-ssh/qemu-riscv64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-device",
+    "virtio-blk-pci,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/git-ssh-test.sh"
+success_regex = ["(?m)^GIT_SSH_TEST_PASSED\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', "(?m)^GIT_SSH_TEST_FAILED\\s*$"]
+timeout = 900

--- a/net/ax-net/Cargo.toml
+++ b/net/ax-net/Cargo.toml
@@ -41,6 +41,7 @@ features = [
   "medium-ip",
   "proto-ipv4",
   "proto-ipv6",
+  "packetmeta-id",
   "socket-raw",
   "socket-icmp",
   "socket-udp",

--- a/net/ax-net/src/general.rs
+++ b/net/ax-net/src/general.rs
@@ -15,7 +15,7 @@
 //! stack owners.
 
 use core::{
-    sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicI32, AtomicU8, AtomicU32, AtomicU64, Ordering},
     task::Waker,
     time::Duration,
 };
@@ -45,6 +45,9 @@ pub(crate) struct GeneralOptions {
     /// Bound interface id encoded as zero for "not bound".
     bound_if: AtomicU32,
 
+    /// IP_TOS value used by protocol sockets when marking outgoing packets.
+    ip_tos: AtomicU8,
+
     /// Socket type: SOCK_STREAM (1), SOCK_DGRAM (2), SOCK_RAW (3).
     socket_type: AtomicI32,
     /// Socket domain: AF_INET (2), AF_UNIX (1), AF_VSOCK (40).
@@ -66,6 +69,8 @@ impl GeneralOptions {
             recv_timeout_nanos: AtomicU64::new(0),
 
             bound_if: AtomicU32::new(0),
+
+            ip_tos: AtomicU8::new(0),
 
             socket_type: AtomicI32::new(socket_type),
             domain,
@@ -109,6 +114,16 @@ impl GeneralOptions {
         DeviceBinding {
             bound_if: (raw != 0).then_some(InterfaceId::new(raw)),
         }
+    }
+
+    /// Returns the IPv4 TOS / IPv6 traffic-class byte configured on this socket.
+    pub fn ip_tos(&self) -> u8 {
+        self.ip_tos.load(Ordering::Relaxed)
+    }
+
+    /// Updates the IPv4 TOS / IPv6 traffic-class byte configured on this socket.
+    pub fn set_ip_tos(&self, tos: u8) {
+        self.ip_tos.store(tos, Ordering::Relaxed);
     }
 
     /// Registers a waker with the service/device path for the bound interface.
@@ -197,6 +212,9 @@ impl Configurable for GeneralOptions {
             O::RecvErr(val) => {
                 **val = false;
             }
+            O::IpTos(tos) => {
+                **tos = self.ip_tos.load(Ordering::Relaxed);
+            }
             O::SocketType(t) => {
                 **t = self.socket_type.load(Ordering::Relaxed);
             }
@@ -247,6 +265,9 @@ impl Configurable for GeneralOptions {
             }
             O::RecvErr(_) => {
                 // TODO: Retrieve ICMP errors via errqueue
+            }
+            O::IpTos(tos) => {
+                self.set_ip_tos(*tos);
             }
             O::SocketType(_) | O::SocketProtocol(_) | O::SocketDomain(_) => {
                 // Read-only options

--- a/net/ax-net/src/general.rs
+++ b/net/ax-net/src/general.rs
@@ -50,6 +50,10 @@ pub(crate) struct GeneralOptions {
 
     /// IP_TOS value used by protocol sockets when marking outgoing packets.
     ip_tos: AtomicU8,
+    /// Whether recvmsg should report IPv4 TOS as IP_TOS ancillary data.
+    recv_tos: AtomicBool,
+    /// Whether recvmsg should report IPv6 traffic class as IPV6_TCLASS ancillary data.
+    recv_traffic_class: AtomicBool,
     /// SO_PRIORITY value. ax-net stores it for Linux compatibility; packet
     /// queue scheduling is not modeled yet.
     priority: AtomicI32,
@@ -77,6 +81,8 @@ impl GeneralOptions {
             bound_if: AtomicU32::new(0),
 
             ip_tos: AtomicU8::new(0),
+            recv_tos: AtomicBool::new(false),
+            recv_traffic_class: AtomicBool::new(false),
             priority: AtomicI32::new(0),
 
             socket_type: AtomicI32::new(socket_type),
@@ -131,6 +137,26 @@ impl GeneralOptions {
     /// Updates the IPv4 TOS / IPv6 traffic-class byte configured on this socket.
     pub fn set_ip_tos(&self, tos: u8) {
         self.ip_tos.store(tos & !IP_TOS_ECN_MASK, Ordering::Relaxed);
+    }
+
+    /// Returns whether IPv4 TOS ancillary data is enabled for receive calls.
+    pub fn recv_tos(&self) -> bool {
+        self.recv_tos.load(Ordering::Relaxed)
+    }
+
+    /// Updates whether IPv4 TOS ancillary data is enabled for receive calls.
+    pub fn set_recv_tos(&self, enabled: bool) {
+        self.recv_tos.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Returns whether IPv6 traffic-class ancillary data is enabled for receive calls.
+    pub fn recv_traffic_class(&self) -> bool {
+        self.recv_traffic_class.load(Ordering::Relaxed)
+    }
+
+    /// Updates whether IPv6 traffic-class ancillary data is enabled for receive calls.
+    pub fn set_recv_traffic_class(&self, enabled: bool) {
+        self.recv_traffic_class.store(enabled, Ordering::Relaxed);
     }
 
     /// Returns the Linux SO_PRIORITY value configured on this socket.
@@ -236,6 +262,12 @@ impl Configurable for GeneralOptions {
             O::IpTos(tos) => {
                 **tos = self.ip_tos.load(Ordering::Relaxed);
             }
+            O::RecvTos(enabled) => {
+                **enabled = self.recv_tos();
+            }
+            O::RecvTrafficClass(enabled) => {
+                **enabled = self.recv_traffic_class();
+            }
             O::Priority(priority) => {
                 **priority = self.priority();
             }
@@ -292,6 +324,12 @@ impl Configurable for GeneralOptions {
             }
             O::IpTos(tos) => {
                 self.set_ip_tos(*tos);
+            }
+            O::RecvTos(enabled) => {
+                self.set_recv_tos(*enabled);
+            }
+            O::RecvTrafficClass(enabled) => {
+                self.set_recv_traffic_class(*enabled);
             }
             O::Priority(priority) => {
                 self.set_priority(*priority)?;
@@ -358,5 +396,25 @@ mod tests {
 
         options.set_ip_tos(0xff);
         assert_eq!(options.ip_tos(), 0xfc);
+    }
+
+    #[test]
+    fn receive_qos_metadata_toggles_are_independent() {
+        let options = GeneralOptions::new(2, 2, 17);
+
+        assert!(!options.recv_tos());
+        assert!(!options.recv_traffic_class());
+
+        options.set_recv_tos(true);
+        assert!(options.recv_tos());
+        assert!(!options.recv_traffic_class());
+
+        options.set_recv_traffic_class(true);
+        assert!(options.recv_tos());
+        assert!(options.recv_traffic_class());
+
+        options.set_recv_tos(false);
+        assert!(!options.recv_tos());
+        assert!(options.recv_traffic_class());
     }
 }

--- a/net/ax-net/src/general.rs
+++ b/net/ax-net/src/general.rs
@@ -30,6 +30,9 @@ use crate::{
     options::{Configurable, GetSocketOption, SetSocketOption},
 };
 
+const SO_PRIORITY_UNPRIVILEGED_MAX: i32 = 6;
+const IP_TOS_ECN_MASK: u8 = 0x03;
+
 /// General options for all sockets.
 pub(crate) struct GeneralOptions {
     /// Whether the socket is non-blocking.
@@ -47,6 +50,9 @@ pub(crate) struct GeneralOptions {
 
     /// IP_TOS value used by protocol sockets when marking outgoing packets.
     ip_tos: AtomicU8,
+    /// SO_PRIORITY value. ax-net stores it for Linux compatibility; packet
+    /// queue scheduling is not modeled yet.
+    priority: AtomicI32,
 
     /// Socket type: SOCK_STREAM (1), SOCK_DGRAM (2), SOCK_RAW (3).
     socket_type: AtomicI32,
@@ -71,6 +77,7 @@ impl GeneralOptions {
             bound_if: AtomicU32::new(0),
 
             ip_tos: AtomicU8::new(0),
+            priority: AtomicI32::new(0),
 
             socket_type: AtomicI32::new(socket_type),
             domain,
@@ -123,7 +130,21 @@ impl GeneralOptions {
 
     /// Updates the IPv4 TOS / IPv6 traffic-class byte configured on this socket.
     pub fn set_ip_tos(&self, tos: u8) {
-        self.ip_tos.store(tos, Ordering::Relaxed);
+        self.ip_tos.store(tos & !IP_TOS_ECN_MASK, Ordering::Relaxed);
+    }
+
+    /// Returns the Linux SO_PRIORITY value configured on this socket.
+    pub fn priority(&self) -> i32 {
+        self.priority.load(Ordering::Relaxed)
+    }
+
+    /// Updates SO_PRIORITY using Linux's ordinary unprivileged range.
+    pub fn set_priority(&self, priority: i32) -> AxResult<()> {
+        if !(0..=SO_PRIORITY_UNPRIVILEGED_MAX).contains(&priority) {
+            return Err(AxError::from(LinuxError::EPERM));
+        }
+        self.priority.store(priority, Ordering::Relaxed);
+        Ok(())
     }
 
     /// Registers a waker with the service/device path for the bound interface.
@@ -215,6 +236,9 @@ impl Configurable for GeneralOptions {
             O::IpTos(tos) => {
                 **tos = self.ip_tos.load(Ordering::Relaxed);
             }
+            O::Priority(priority) => {
+                **priority = self.priority();
+            }
             O::SocketType(t) => {
                 **t = self.socket_type.load(Ordering::Relaxed);
             }
@@ -269,6 +293,9 @@ impl Configurable for GeneralOptions {
             O::IpTos(tos) => {
                 self.set_ip_tos(*tos);
             }
+            O::Priority(priority) => {
+                self.set_priority(*priority)?;
+            }
             O::SocketType(_) | O::SocketProtocol(_) | O::SocketDomain(_) => {
                 // Read-only options
                 return Err(AxError::from(LinuxError::ENOPROTOOPT));
@@ -301,5 +328,35 @@ mod tests {
 
         options.set_device_binding(DeviceBinding { bound_if: None });
         assert_eq!(options.device_binding(), DeviceBinding { bound_if: None });
+    }
+
+    #[test]
+    fn socket_priority_matches_unprivileged_linux_range() {
+        let options = GeneralOptions::new(1, 2, 6);
+
+        assert_eq!(options.priority(), 0);
+        options.set_priority(6).unwrap();
+        assert_eq!(options.priority(), 6);
+
+        assert_eq!(
+            options.set_priority(7).unwrap_err(),
+            AxError::from(LinuxError::EPERM)
+        );
+        assert_eq!(
+            options.set_priority(-1).unwrap_err(),
+            AxError::from(LinuxError::EPERM)
+        );
+        assert_eq!(options.priority(), 6);
+    }
+
+    #[test]
+    fn ip_tos_storage_masks_user_controlled_ecn_bits() {
+        let options = GeneralOptions::new(1, 2, 6);
+
+        options.set_ip_tos(0x2e);
+        assert_eq!(options.ip_tos(), 0x2c);
+
+        options.set_ip_tos(0xff);
+        assert_eq!(options.ip_tos(), 0xfc);
     }
 }

--- a/net/ax-net/src/ip_tos.rs
+++ b/net/ax-net/src/ip_tos.rs
@@ -1,0 +1,258 @@
+//! Per-socket egress IP_TOS handling.
+//!
+//! smoltcp exposes hop-limit setters on TCP/UDP sockets, but it does not expose
+//! an IP_TOS/traffic-class setter. ax-net therefore records socket-owned egress
+//! TOS policy and applies it to smoltcp-emitted IP packets at the router
+//! boundary, after the IP header has been generated and before the packet is
+//! handed to loopback or a concrete device.
+
+use ax_sync::Mutex;
+use hashbrown::HashMap;
+use smoltcp::wire::{
+    IpAddress, IpEndpoint, IpListenEndpoint, IpProtocol, IpVersion, Ipv4Packet, Ipv6Packet,
+    TcpPacket, UdpPacket,
+};
+use spin::LazyLock;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct EgressIpTosKey {
+    protocol: u8,
+    local_addr: Option<IpAddress>,
+    local_port: u16,
+    remote_addr: Option<IpAddress>,
+    remote_port: Option<u16>,
+}
+
+impl EgressIpTosKey {
+    pub(crate) fn exact(
+        protocol: IpProtocol,
+        local: IpEndpoint,
+        remote: IpEndpoint,
+    ) -> Option<Self> {
+        if local.port == 0 || remote.port == 0 {
+            return None;
+        }
+        Some(Self {
+            protocol: protocol.into(),
+            local_addr: Some(local.addr),
+            local_port: local.port,
+            remote_addr: Some(remote.addr),
+            remote_port: Some(remote.port),
+        })
+    }
+
+    pub(crate) fn listener(protocol: IpProtocol, local: IpListenEndpoint) -> Option<Self> {
+        if local.port == 0 {
+            return None;
+        }
+        Some(Self {
+            protocol: protocol.into(),
+            local_addr: local.addr,
+            local_port: local.port,
+            remote_addr: None,
+            remote_port: None,
+        })
+    }
+}
+
+static EGRESS_IP_TOS: LazyLock<Mutex<HashMap<EgressIpTosKey, u8>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub(crate) fn set_egress_ip_tos(key: EgressIpTosKey, tos: u8) {
+    let mut table = EGRESS_IP_TOS.lock();
+    if tos == 0 {
+        table.remove(&key);
+    } else {
+        table.insert(key, tos);
+    }
+}
+
+pub(crate) fn clear_egress_ip_tos(key: EgressIpTosKey) {
+    EGRESS_IP_TOS.lock().remove(&key);
+}
+
+pub(crate) fn apply_egress_ip_tos(packet: &mut [u8]) {
+    let tos = packet_egress_ip_tos(packet);
+    if tos != 0 {
+        apply_ip_tos(packet, tos);
+    }
+}
+
+pub(crate) fn apply_ip_tos(packet: &mut [u8], tos: u8) {
+    match IpVersion::of_packet(packet) {
+        Ok(IpVersion::Ipv4) => {
+            let Ok(mut packet) = Ipv4Packet::new_checked(packet) else {
+                return;
+            };
+            packet.set_dscp(tos >> 2);
+            packet.set_ecn(tos & 0x03);
+            packet.fill_checksum();
+        }
+        Ok(IpVersion::Ipv6) => {
+            let Ok(mut packet) = Ipv6Packet::new_checked(packet) else {
+                return;
+            };
+            packet.set_traffic_class(tos);
+        }
+        Err(_) => {}
+    }
+}
+
+fn packet_egress_ip_tos(packet: &[u8]) -> u8 {
+    let (protocol, local_addr, remote_addr, payload) = match IpVersion::of_packet(packet) {
+        Ok(IpVersion::Ipv4) => {
+            let Ok(packet) = Ipv4Packet::new_checked(packet) else {
+                return 0;
+            };
+            (
+                packet.next_header(),
+                IpAddress::Ipv4(packet.src_addr()),
+                IpAddress::Ipv4(packet.dst_addr()),
+                packet.payload(),
+            )
+        }
+        Ok(IpVersion::Ipv6) => {
+            let Ok(packet) = Ipv6Packet::new_checked(packet) else {
+                return 0;
+            };
+            (
+                packet.next_header(),
+                IpAddress::Ipv6(packet.src_addr()),
+                IpAddress::Ipv6(packet.dst_addr()),
+                packet.payload(),
+            )
+        }
+        Err(_) => return 0,
+    };
+
+    let (local_port, remote_port) = match protocol {
+        IpProtocol::Tcp => {
+            let Ok(packet) = TcpPacket::new_checked(payload) else {
+                return 0;
+            };
+            (packet.src_port(), packet.dst_port())
+        }
+        IpProtocol::Udp => {
+            let Ok(packet) = UdpPacket::new_checked(payload) else {
+                return 0;
+            };
+            (packet.src_port(), packet.dst_port())
+        }
+        _ => return 0,
+    };
+
+    egress_ip_tos(
+        protocol,
+        IpEndpoint {
+            addr: local_addr,
+            port: local_port,
+        },
+        IpEndpoint {
+            addr: remote_addr,
+            port: remote_port,
+        },
+    )
+}
+
+fn egress_ip_tos(protocol: IpProtocol, local: IpEndpoint, remote: IpEndpoint) -> u8 {
+    if local.port == 0 || remote.port == 0 {
+        return 0;
+    }
+
+    let table = EGRESS_IP_TOS.lock();
+    let protocol = protocol.into();
+    let candidates = [
+        EgressIpTosKey {
+            protocol,
+            local_addr: Some(local.addr),
+            local_port: local.port,
+            remote_addr: Some(remote.addr),
+            remote_port: Some(remote.port),
+        },
+        EgressIpTosKey {
+            protocol,
+            local_addr: None,
+            local_port: local.port,
+            remote_addr: Some(remote.addr),
+            remote_port: Some(remote.port),
+        },
+        EgressIpTosKey {
+            protocol,
+            local_addr: Some(local.addr),
+            local_port: local.port,
+            remote_addr: None,
+            remote_port: None,
+        },
+        EgressIpTosKey {
+            protocol,
+            local_addr: None,
+            local_port: local.port,
+            remote_addr: None,
+            remote_port: None,
+        },
+    ];
+
+    candidates
+        .iter()
+        .find_map(|key| table.get(key).copied())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use smoltcp::wire::Ipv4Address;
+
+    use super::*;
+
+    #[test]
+    fn exact_policy_takes_precedence_over_listener_policy() {
+        let local = IpEndpoint {
+            addr: IpAddress::Ipv4(Ipv4Address::new(192, 0, 2, 10)),
+            port: 41001,
+        };
+        let remote = IpEndpoint {
+            addr: IpAddress::Ipv4(Ipv4Address::new(198, 51, 100, 20)),
+            port: 22,
+        };
+        let listener = EgressIpTosKey::listener(
+            IpProtocol::Tcp,
+            IpListenEndpoint {
+                addr: None,
+                port: local.port,
+            },
+        )
+        .unwrap();
+        let exact = EgressIpTosKey::exact(IpProtocol::Tcp, local, remote).unwrap();
+
+        set_egress_ip_tos(listener, 0x10);
+        set_egress_ip_tos(exact, 0x48);
+        assert_eq!(egress_ip_tos(IpProtocol::Tcp, local, remote), 0x48);
+
+        clear_egress_ip_tos(exact);
+        assert_eq!(egress_ip_tos(IpProtocol::Tcp, local, remote), 0x10);
+        clear_egress_ip_tos(listener);
+    }
+
+    #[test]
+    fn apply_ip_tos_updates_ipv4_header_and_checksum() {
+        let mut packet = [0u8; 20];
+        {
+            let mut packet = Ipv4Packet::new_unchecked(&mut packet[..]);
+            packet.set_version(4);
+            packet.set_header_len(20);
+            packet.set_total_len(20);
+            packet.set_hop_limit(64);
+            packet.set_next_header(IpProtocol::Tcp);
+            packet.set_src_addr(Ipv4Address::new(192, 0, 2, 10));
+            packet.set_dst_addr(Ipv4Address::new(198, 51, 100, 20));
+            packet.fill_checksum();
+        }
+
+        apply_ip_tos(&mut packet, 0x2e);
+
+        let packet = Ipv4Packet::new_checked(&packet[..]).unwrap();
+        assert_eq!(packet.dscp(), 0x0b);
+        assert_eq!(packet.ecn(), 0x02);
+        assert!(packet.verify_checksum());
+    }
+}

--- a/net/ax-net/src/ip_tos.rs
+++ b/net/ax-net/src/ip_tos.rs
@@ -200,7 +200,7 @@ fn egress_ip_tos(protocol: IpProtocol, local: IpEndpoint, remote: IpEndpoint) ->
 
 #[cfg(test)]
 mod tests {
-    use smoltcp::wire::Ipv4Address;
+    use smoltcp::wire::{Ipv4Address, Ipv6Address};
 
     use super::*;
 
@@ -254,5 +254,24 @@ mod tests {
         assert_eq!(packet.dscp(), 0x0b);
         assert_eq!(packet.ecn(), 0x02);
         assert!(packet.verify_checksum());
+    }
+
+    #[test]
+    fn apply_ip_tos_updates_ipv6_traffic_class() {
+        let mut packet = [0u8; 40];
+        {
+            let mut packet = Ipv6Packet::new_unchecked(&mut packet[..]);
+            packet.set_version(6);
+            packet.set_payload_len(0);
+            packet.set_hop_limit(64);
+            packet.set_next_header(IpProtocol::Tcp);
+            packet.set_src_addr(Ipv6Address::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+            packet.set_dst_addr(Ipv6Address::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2));
+        }
+
+        apply_ip_tos(&mut packet, 0xb8);
+
+        let packet = Ipv6Packet::new_checked(&packet[..]).unwrap();
+        assert_eq!(packet.traffic_class(), 0xb8);
     }
 }

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -43,6 +43,7 @@ mod consts;
 mod device;
 mod dhcp_server;
 mod general;
+mod ip_tos;
 mod listen_table;
 /// Socket option types and the [`Configurable`](options::Configurable) trait.
 pub mod options;

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -51,6 +51,7 @@ mod orphan;
 /// Raw socket implementation.
 pub mod raw;
 mod router;
+mod rx_meta;
 mod service;
 mod socket;
 pub(crate) mod state;
@@ -107,8 +108,8 @@ pub use self::{
         set_ethernet_irq_registrar,
     },
     socket::{
-        CMsgData, RecvFlags, RecvOptions, SendFlags, SendOptions, Shutdown, Socket, SocketAddrEx,
-        SocketOps,
+        CMsgData, IpCmsg, RecvFlags, RecvOptions, SendFlags, SendOptions, Shutdown, Socket,
+        SocketAddrEx, SocketOps,
     },
 };
 

--- a/net/ax-net/src/options.rs
+++ b/net/ax-net/src/options.rs
@@ -176,6 +176,7 @@ define_options! {
     SocketProtocol(i32),
     SocketDomain(i32),
     BindToDevice(Option<InterfaceId>),
+    Priority(i32),
 
     // --- TCP level options (TCP_*) ----
     NoDelay(bool),

--- a/net/ax-net/src/options.rs
+++ b/net/ax-net/src/options.rs
@@ -188,6 +188,7 @@ define_options! {
 
     // ---- IP level options (IP_*) ----
     Ttl(u8),
+    IpTos(u8),
     RecvErr(bool),
 
     // ---- Extra options ----

--- a/net/ax-net/src/options.rs
+++ b/net/ax-net/src/options.rs
@@ -190,6 +190,8 @@ define_options! {
     // ---- IP level options (IP_*) ----
     Ttl(u8),
     IpTos(u8),
+    RecvTos(bool),
+    RecvTrafficClass(bool),
     RecvErr(bool),
 
     // ---- Extra options ----

--- a/net/ax-net/src/raw.rs
+++ b/net/ax-net/src/raw.rs
@@ -57,6 +57,7 @@ use crate::{
     consts::{RAW_RX_BUF_LEN, RAW_TX_BUF_LEN},
     general::GeneralOptions,
     get_control, interface_by_id,
+    ip_tos::apply_ip_tos,
     options::{Configurable, GetSocketOption, SetSocketOption},
     request_poll,
 };
@@ -408,6 +409,10 @@ impl SocketOps for RawSocket {
                     .send(header_len + payload_len)
                     .map_err(|_| AxError::WouldBlock)?;
                 header.emit(&mut *buf);
+                let ip_tos = self.general.ip_tos();
+                if ip_tos != 0 {
+                    apply_ip_tos(buf, ip_tos);
+                }
 
                 let written = src.read(&mut buf[header_len..])?;
                 if next_header == IpProtocol::Icmpv6 {

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -68,6 +68,7 @@ use crate::{
     config::{DeviceBinding, InterfaceId, RouteInfo},
     consts::{DEVICE_RX_QUEUE_SIZE, DEVICE_TX_QUEUE_SIZE, SOCKET_BUFFER_SIZE, STANDARD_MTU},
     device::{ArpEntry, Device},
+    ip_tos::apply_egress_ip_tos,
 };
 
 const DEVICE_RX_WORKER_BATCH: usize = 16;
@@ -682,6 +683,7 @@ impl Router {
             ..
         } = self;
         while let Ok((_, packet)) = tx_buffer.dequeue() {
+            apply_egress_ip_tos(packet);
             match IpVersion::of_packet(packet).expect("got invalid IP packet") {
                 IpVersion::Ipv4 => {
                     let packet = smoltcp::wire::Ipv4Packet::new_checked(packet)

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -53,7 +53,7 @@ use ax_task::WaitQueue;
 use axpoll::IoEvents;
 use smoltcp::{
     iface::SocketSet,
-    phy::{DeviceCapabilities, Medium},
+    phy::{DeviceCapabilities, Medium, PacketMeta},
     storage::PacketMetadata,
     time::Instant,
     wire::{
@@ -69,6 +69,7 @@ use crate::{
     consts::{DEVICE_RX_QUEUE_SIZE, DEVICE_TX_QUEUE_SIZE, SOCKET_BUFFER_SIZE, STANDARD_MTU},
     device::{ArpEntry, Device},
     ip_tos::apply_egress_ip_tos,
+    rx_meta::packet_meta_for_rx_packet,
 };
 
 const DEVICE_RX_WORKER_BATCH: usize = 16;
@@ -123,10 +124,32 @@ impl Rule {
     }
 }
 
-type PacketBuffer = smoltcp::storage::PacketBuffer<'static, InterfaceId>;
+#[derive(Debug, Clone, Copy)]
+struct RxMetadata {
+    interface_id: InterfaceId,
+    packet_meta: PacketMeta,
+}
+
+type RouterPacketBuffer = smoltcp::storage::PacketBuffer<'static, RxMetadata>;
+type DevicePacketBuffer = smoltcp::storage::PacketBuffer<'static, InterfaceId>;
+
 // TX metadata is created before route lookup; dispatch() selects the real
 // egress interface from the packet destination and route table.
 const TX_INTERFACE_PLACEHOLDER: InterfaceId = InterfaceId::new(0);
+
+fn rx_metadata(interface_id: InterfaceId, packet: &[u8]) -> RxMetadata {
+    RxMetadata {
+        interface_id,
+        packet_meta: packet_meta_for_rx_packet(packet),
+    }
+}
+
+fn tx_metadata() -> RxMetadata {
+    RxMetadata {
+        interface_id: TX_INTERFACE_PLACEHOLDER,
+        packet_meta: PacketMeta::default(),
+    }
+}
 
 /// Bounded FIFO used between the protocol core and per-device workers.
 struct BoundedPacketQueue<T> {
@@ -440,8 +463,8 @@ pub(crate) type SharedRouteTable = Arc<RwLock<RouteTable>>;
 
 /// Virtual smoltcp device that multiplexes all concrete devices.
 pub struct Router {
-    rx_buffer: PacketBuffer,
-    tx_buffer: PacketBuffer,
+    rx_buffer: RouterPacketBuffer,
+    tx_buffer: RouterPacketBuffer,
     queues: Arc<RouterQueues>,
     devices: Vec<Arc<DeviceHandle>>,
     table: SharedRouteTable,
@@ -449,11 +472,11 @@ pub struct Router {
 impl Router {
     /// Creates the virtual multi-device endpoint used by smoltcp.
     pub fn new(table: SharedRouteTable) -> Self {
-        let rx_buffer = PacketBuffer::new(
+        let rx_buffer = RouterPacketBuffer::new(
             vec![PacketMetadata::EMPTY; SOCKET_BUFFER_SIZE],
             vec![0u8; STANDARD_MTU * SOCKET_BUFFER_SIZE],
         );
-        let tx_buffer = PacketBuffer::new(
+        let tx_buffer = RouterPacketBuffer::new(
             vec![PacketMetadata::EMPTY; SOCKET_BUFFER_SIZE],
             vec![0u8; STANDARD_MTU * SOCKET_BUFFER_SIZE],
         );
@@ -612,7 +635,10 @@ impl Router {
             let bytes = packet.bytes.as_slice();
             snoop_tcp_packet(bytes, sockets);
             snoop(packet.interface_id, bytes);
-            let Ok(dst) = self.rx_buffer.enqueue(bytes.len(), packet.interface_id) else {
+            let Ok(dst) = self
+                .rx_buffer
+                .enqueue(bytes.len(), rx_metadata(packet.interface_id, bytes))
+            else {
                 warn!("Router RX buffer is full, dropping packet");
                 break;
             };
@@ -746,7 +772,7 @@ fn dispatch_link_local_fanout(
 }
 
 fn dispatch_unicast_packet(
-    rx_buffer: &mut PacketBuffer,
+    rx_buffer: &mut RouterPacketBuffer,
     devices: &[Arc<DeviceHandle>],
     table: &SharedRouteTable,
     src_addr: IpAddress,
@@ -775,13 +801,14 @@ fn dispatch_unicast_packet(
 
 /// Injects a loopback packet directly into the smoltcp-facing RX buffer.
 fn inject_loopback_rx_direct(
-    rx_buffer: &mut PacketBuffer,
+    rx_buffer: &mut RouterPacketBuffer,
     dst_addr: IpAddress,
     packet: &[u8],
     sockets: &mut SocketSet<'_>,
 ) -> bool {
     snoop_tcp_packet(packet, sockets);
-    let Ok(dst) = rx_buffer.enqueue(packet.len(), InterfaceId::LOOPBACK) else {
+    let Ok(dst) = rx_buffer.enqueue(packet.len(), rx_metadata(InterfaceId::LOOPBACK, packet))
+    else {
         warn!("Loopback: RX buffer full, dropping packet to {}", dst_addr);
         return false;
     };
@@ -837,7 +864,7 @@ fn device_tx_worker(device: Arc<DeviceHandle>) {
 
 /// Dedicated worker that polls one device and forwards packets to router RX.
 fn device_rx_worker(device: Arc<DeviceHandle>) {
-    let mut rx_buffer = PacketBuffer::new(
+    let mut rx_buffer = DevicePacketBuffer::new(
         vec![PacketMetadata::EMPTY; DEVICE_RX_WORKER_BATCH],
         vec![0u8; STANDARD_MTU * DEVICE_RX_WORKER_BATCH],
     );
@@ -887,7 +914,7 @@ fn device_rx_worker(device: Arc<DeviceHandle>) {
 }
 
 /// smoltcp TX token backed by the router's temporary TX buffer.
-pub struct TxToken<'a>(&'a mut PacketBuffer);
+pub struct TxToken<'a>(&'a mut RouterPacketBuffer);
 
 impl smoltcp::phy::TxToken for TxToken<'_> {
     fn consume<R, F>(self, len: usize, f: F) -> R
@@ -898,7 +925,7 @@ impl smoltcp::phy::TxToken for TxToken<'_> {
         // packet and selects the actual egress interface from the route table.
         f(self
             .0
-            .enqueue(len, TX_INTERFACE_PLACEHOLDER)
+            .enqueue(len, tx_metadata())
             .expect("This was checked before creating the TxToken"))
     }
 }
@@ -941,6 +968,7 @@ fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
 /// smoltcp RX token for one packet queued by the router.
 pub struct RxToken<'a> {
     interface_id: InterfaceId,
+    packet_meta: PacketMeta,
     packet: &'a [u8],
 }
 
@@ -951,6 +979,10 @@ impl<'a> smoltcp::phy::RxToken for RxToken<'a> {
     {
         let _ingress_if = self.interface_id;
         f(self.packet)
+    }
+
+    fn meta(&self) -> PacketMeta {
+        self.packet_meta
     }
 }
 
@@ -964,9 +996,10 @@ impl smoltcp::phy::Device for Router {
         } else {
             Some((
                 {
-                    let (interface_id, packet) = self.rx_buffer.dequeue().unwrap();
+                    let (metadata, packet) = self.rx_buffer.dequeue().unwrap();
                     RxToken {
-                        interface_id,
+                        interface_id: metadata.interface_id,
+                        packet_meta: metadata.packet_meta,
                         packet,
                     }
                 },

--- a/net/ax-net/src/rx_meta.rs
+++ b/net/ax-net/src/rx_meta.rs
@@ -1,0 +1,121 @@
+//! Ingress packet metadata carried through smoltcp.
+//!
+//! smoltcp exposes only a small packet metadata id. ax-net uses that id to
+//! carry Linux-visible receive-side QoS metadata from the router RX token to
+//! datagram sockets without keeping a side table.
+
+use smoltcp::{
+    phy::PacketMeta,
+    wire::{IpVersion, Ipv4Packet, Ipv6Packet},
+};
+
+const RX_QOS_META_MARK: u32 = 0xa7 << 24;
+const RX_QOS_META_MARK_MASK: u32 = 0xff << 24;
+const RX_QOS_META_VERSION_SHIFT: u32 = 8;
+
+/// Received IP traffic-class metadata that can be reported through recvmsg cmsg.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceivedTrafficClass {
+    /// IPv4 TOS byte.
+    Ipv4(u8),
+    /// IPv6 traffic-class byte.
+    Ipv6(u8),
+}
+
+/// Builds smoltcp packet metadata for one received IP packet.
+pub(crate) fn packet_meta_for_rx_packet(packet: &[u8]) -> PacketMeta {
+    let mut meta = PacketMeta::default();
+    if let Some(traffic_class) = traffic_class_from_packet(packet) {
+        meta.id = encode_traffic_class(traffic_class);
+    }
+    meta
+}
+
+/// Decodes receive-side traffic-class metadata from smoltcp packet metadata.
+pub(crate) fn received_traffic_class(meta: PacketMeta) -> Option<ReceivedTrafficClass> {
+    if meta.id & RX_QOS_META_MARK_MASK != RX_QOS_META_MARK {
+        return None;
+    }
+
+    let value = (meta.id & 0xff) as u8;
+    match (meta.id >> RX_QOS_META_VERSION_SHIFT) & 0xff {
+        4 => Some(ReceivedTrafficClass::Ipv4(value)),
+        6 => Some(ReceivedTrafficClass::Ipv6(value)),
+        _ => None,
+    }
+}
+
+fn traffic_class_from_packet(packet: &[u8]) -> Option<ReceivedTrafficClass> {
+    match IpVersion::of_packet(packet).ok()? {
+        IpVersion::Ipv4 => {
+            let packet = Ipv4Packet::new_checked(packet).ok()?;
+            Some(ReceivedTrafficClass::Ipv4(
+                (packet.dscp() << 2) | packet.ecn(),
+            ))
+        }
+        IpVersion::Ipv6 => {
+            let packet = Ipv6Packet::new_checked(packet).ok()?;
+            Some(ReceivedTrafficClass::Ipv6(packet.traffic_class()))
+        }
+    }
+}
+
+fn encode_traffic_class(traffic_class: ReceivedTrafficClass) -> u32 {
+    let (version, value) = match traffic_class {
+        ReceivedTrafficClass::Ipv4(value) => (4, value),
+        ReceivedTrafficClass::Ipv6(value) => (6, value),
+    };
+    RX_QOS_META_MARK | (version << RX_QOS_META_VERSION_SHIFT) | u32::from(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use smoltcp::wire::{IpProtocol, Ipv4Address, Ipv4Repr, Ipv6Address, Ipv6Repr};
+
+    use super::*;
+
+    #[test]
+    fn ipv4_tos_round_trips_through_packet_meta() {
+        let repr = Ipv4Repr {
+            src_addr: Ipv4Address::new(127, 0, 0, 1),
+            dst_addr: Ipv4Address::new(127, 0, 0, 1),
+            next_header: IpProtocol::Udp,
+            payload_len: 0,
+            hop_limit: 64,
+        };
+        let mut packet = [0; 20];
+        {
+            let mut packet = Ipv4Packet::new_unchecked(&mut packet[..]);
+            repr.emit(&mut packet, &Default::default());
+            packet.set_dscp(0x0b);
+            packet.set_ecn(0x02);
+        }
+
+        assert_eq!(
+            received_traffic_class(packet_meta_for_rx_packet(&packet)),
+            Some(ReceivedTrafficClass::Ipv4(0x2e))
+        );
+    }
+
+    #[test]
+    fn ipv6_traffic_class_round_trips_through_packet_meta() {
+        let repr = Ipv6Repr {
+            src_addr: Ipv6Address::LOCALHOST,
+            dst_addr: Ipv6Address::LOCALHOST,
+            next_header: IpProtocol::Udp,
+            payload_len: 0,
+            hop_limit: 64,
+        };
+        let mut packet = [0; 40];
+        {
+            let mut packet = Ipv6Packet::new_unchecked(&mut packet[..]);
+            repr.emit(&mut packet);
+            packet.set_traffic_class(0x2e);
+        }
+
+        assert_eq!(
+            received_traffic_class(packet_meta_for_rx_packet(&packet)),
+            Some(ReceivedTrafficClass::Ipv6(0x2e))
+        );
+    }
+}

--- a/net/ax-net/src/socket.rs
+++ b/net/ax-net/src/socket.rs
@@ -136,6 +136,15 @@ bitflags! {
 /// Type alias for ancillary control message data.
 pub type CMsgData = Box<dyn Any + Send + Sync>;
 
+/// IP ancillary data reported through `recvmsg`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpCmsg {
+    /// IPv4 TOS byte for `IP_RECVTOS`.
+    Ipv4Tos(u8),
+    /// IPv6 traffic-class byte for `IPV6_RECVTCLASS`.
+    Ipv6TrafficClass(u8),
+}
+
 /// Options for sending data to a socket.
 ///
 /// See [`SocketOps::send`].

--- a/net/ax-net/src/tcp.rs
+++ b/net/ax-net/src/tcp.rs
@@ -41,7 +41,7 @@ use smoltcp::{
     iface::SocketHandle,
     socket::tcp as smol,
     time::Duration,
-    wire::{IpEndpoint, IpListenEndpoint},
+    wire::{IpEndpoint, IpListenEndpoint, IpProtocol},
 };
 use spin::LazyLock;
 
@@ -53,6 +53,7 @@ use crate::{
     consts::{TCP_RX_BUF_LEN, TCP_TX_BUF_LEN},
     general::GeneralOptions,
     get_control, get_service, interface_by_id,
+    ip_tos::{EgressIpTosKey, clear_egress_ip_tos, set_egress_ip_tos},
     options::{Configurable, GetSocketOption, SetSocketOption, TcpInfo, TcpInfoOptions, TcpState},
     request_poll,
     state::*,
@@ -80,6 +81,8 @@ pub struct TcpSocket {
     bound_endpoint: Mutex<IpListenEndpoint>,
     /// Connected peer endpoint once established.
     peer_endpoint: Mutex<Option<IpEndpoint>>,
+    /// Currently registered egress IP_TOS policy for this TCP socket.
+    tos_key: Mutex<Option<EgressIpTosKey>>,
     /// Whether `bound_endpoint` is registered in `TCP_BOUND_PORTS`.
     bound_registered: AtomicBool,
 
@@ -118,6 +121,7 @@ impl TcpSocket {
             )),
             bound_endpoint: Mutex::new(empty_endpoint()),
             peer_endpoint: Mutex::new(None),
+            tos_key: Mutex::new(None),
             bound_registered: AtomicBool::new(false),
 
             general: GeneralOptions::new(1, 2, 6), // SOCK_STREAM
@@ -155,6 +159,7 @@ impl TcpSocket {
             handle,
             bound_endpoint: Mutex::new(empty_endpoint()),
             peer_endpoint: Mutex::new(Some(remote_endpoint)),
+            tos_key: Mutex::new(None),
             bound_registered: AtomicBool::new(false),
 
             general: GeneralOptions::new(1, 2, 6), // SOCK_STREAM
@@ -190,8 +195,59 @@ impl Default for TcpSocket {
 
 /// Private methods
 impl TcpSocket {
+    fn state(&self) -> State {
+        self.state.get()
+    }
+
+    #[inline]
+    fn is_listening(&self) -> bool {
+        self.state() == State::Listening
+    }
+
     fn with_smol_socket<R>(&self, f: impl FnOnce(&mut smol::Socket) -> R) -> R {
         SOCKET_SET.with_socket_mut::<smol::Socket, _, _>(self.handle, f)
+    }
+
+    fn egress_ip_tos_key(&self) -> Option<EgressIpTosKey> {
+        if self.is_listening() {
+            return EgressIpTosKey::listener(IpProtocol::Tcp, *self.bound_endpoint.lock());
+        }
+
+        let local = self
+            .with_smol_socket(|socket| socket.local_endpoint())
+            .or_else(|| {
+                let endpoint = *self.bound_endpoint.lock();
+                endpoint.addr.map(|addr| IpEndpoint {
+                    addr,
+                    port: endpoint.port,
+                })
+            });
+        let remote = self
+            .with_smol_socket(|socket| socket.remote_endpoint())
+            .or_else(|| *self.peer_endpoint.lock());
+
+        EgressIpTosKey::exact(IpProtocol::Tcp, local?, remote?)
+    }
+
+    fn sync_egress_ip_tos(&self) {
+        let key = self.egress_ip_tos_key();
+        let tos = self.general.ip_tos();
+        let mut tracked = self.tos_key.lock();
+        if *tracked != key {
+            if let Some(old) = *tracked {
+                clear_egress_ip_tos(old);
+            }
+            *tracked = key;
+        }
+        if let Some(key) = key {
+            set_egress_ip_tos(key, tos);
+        }
+    }
+
+    fn clear_tracked_egress_ip_tos(&self) {
+        if let Some(key) = self.tos_key.lock().take() {
+            clear_egress_ip_tos(key);
+        }
     }
 
     fn tcp_info_snapshot(&self) -> TcpInfo {
@@ -344,6 +400,12 @@ impl Configurable for TcpSocket {
     fn set_option_inner(&self, option: SetSocketOption) -> AxResult<bool> {
         use SetSocketOption as O;
 
+        if let O::IpTos(tos) = option {
+            self.general.set_ip_tos(*tos);
+            self.sync_egress_ip_tos();
+            return Ok(true);
+        }
+
         if self.general.set_option_inner(option)? {
             return Ok(true);
         }
@@ -465,6 +527,7 @@ impl SocketOps for TcpSocket {
                     LISTEN_TABLE.listen(bound_endpoint, backlog)
                 })?;
                 *self.bound_endpoint.lock() = bound_endpoint;
+                self.sync_egress_ip_tos();
                 if binding.bound_if.is_some() {
                     self.general.set_device_binding(binding);
                 }
@@ -495,6 +558,8 @@ impl SocketOps for TcpSocket {
                     accepted.local_endpoint,
                     accepted.remote_endpoint,
                 );
+                socket.general.set_ip_tos(self.general.ip_tos());
+                socket.sync_egress_ip_tos();
                 debug!(
                     "accepted connection from {}, {}",
                     accepted.handle, accepted.remote_endpoint
@@ -639,6 +704,7 @@ impl SocketOps for TcpSocket {
                         debug!("TCP socket {}: shutting down", self.handle);
                         socket.close();
                     });
+                    self.clear_tracked_egress_ip_tos();
                     self.unregister_bound_endpoint();
                     *self.bound_endpoint.lock() = empty_endpoint();
                     request_poll();
@@ -657,6 +723,7 @@ impl SocketOps for TcpSocket {
         if let Ok(guard) = self.state.lock(State::Listening) {
             guard.transit(State::Closed, || {
                 LISTEN_TABLE.unlisten(self.bound_endpoint()?);
+                self.clear_tracked_egress_ip_tos();
                 self.unregister_bound_endpoint();
                 *self.bound_endpoint.lock() = empty_endpoint();
                 request_poll();
@@ -790,6 +857,7 @@ impl Drop for TcpSocket {
         });
 
         // Unbind from API layer (port registry, etc.)
+        self.clear_tracked_egress_ip_tos();
         self.unregister_bound_endpoint();
 
         if should_orphan {
@@ -903,6 +971,7 @@ impl TcpSocket {
                         .set_device_binding(get_control().local_binding_for(&bound_endpoint)?);
                 }
                 // else: bound to specific IP, keep existing interface binding
+                self.sync_egress_ip_tos();
 
                 Ok(())
             })

--- a/net/ax-net/src/udp.rs
+++ b/net/ax-net/src/udp.rs
@@ -39,7 +39,7 @@ use smoltcp::{
     phy::PacketMeta,
     socket::udp::{self as smol, UdpMetadata},
     storage::PacketMetadata,
-    wire::{IpAddress, IpEndpoint, IpListenEndpoint},
+    wire::{IpAddress, IpEndpoint, IpListenEndpoint, IpProtocol},
 };
 use spin::RwLock;
 
@@ -50,6 +50,7 @@ use crate::{
     consts::{UDP_RX_BUF_LEN, UDP_TX_BUF_LEN},
     general::GeneralOptions,
     get_control, interface_by_id,
+    ip_tos::{EgressIpTosKey, clear_egress_ip_tos, set_egress_ip_tos},
     options::{Configurable, GetSocketOption, SetSocketOption},
     request_poll,
 };
@@ -75,6 +76,8 @@ pub struct UdpSocket {
 
     /// Shared socket options and blocking helpers.
     general: GeneralOptions,
+    /// Egress IP_TOS policies registered for recently used UDP destinations.
+    tos_keys: Mutex<Vec<EgressIpTosKey>>,
     /// MSG_MORE corking state: captures endpoint at first MSG_MORE
     /// so the merged datagram always goes to the correct peer.
     cork: Mutex<Option<CorkState>>,
@@ -92,6 +95,7 @@ impl UdpSocket {
             peer_addr: RwLock::new(None),
 
             general: GeneralOptions::new(2, 2, 17), // SOCK_DGRAM
+            tos_keys: Mutex::new(Vec::new()),
             cork: Mutex::new(None),
         }
     }
@@ -149,6 +153,44 @@ impl UdpSocket {
             Ok((self.source_for_remote(remote)?, true))
         }
     }
+
+    fn track_egress_ip_tos(&self, local_addr: Option<IpAddress>, remote: IpEndpoint) {
+        let tos = self.general.ip_tos();
+        if tos == 0 {
+            return;
+        }
+        let Some(local_addr) = local_addr else {
+            return;
+        };
+        let Some(local) = self.local_addr.read().map(|endpoint| IpEndpoint {
+            addr: local_addr,
+            port: endpoint.port,
+        }) else {
+            return;
+        };
+        let Some(key) = EgressIpTosKey::exact(IpProtocol::Udp, local, remote) else {
+            return;
+        };
+
+        let mut keys = self.tos_keys.lock();
+        if !keys.contains(&key) {
+            keys.push(key);
+        }
+        set_egress_ip_tos(key, tos);
+    }
+
+    fn sync_tracked_egress_ip_tos(&self) {
+        let tos = self.general.ip_tos();
+        for key in self.tos_keys.lock().iter().copied() {
+            set_egress_ip_tos(key, tos);
+        }
+    }
+
+    fn clear_tracked_egress_ip_tos(&self) {
+        for key in self.tos_keys.lock().drain(..) {
+            clear_egress_ip_tos(key);
+        }
+    }
 }
 
 impl Configurable for UdpSocket {
@@ -177,6 +219,12 @@ impl Configurable for UdpSocket {
 
     fn set_option_inner(&self, option: SetSocketOption) -> AxResult<bool> {
         use SetSocketOption as O;
+
+        if let O::IpTos(tos) = option {
+            self.general.set_ip_tos(*tos);
+            self.sync_tracked_egress_ip_tos();
+            return Ok(true);
+        }
 
         if self.general.set_option_inner(option)? {
             return Ok(true);
@@ -369,6 +417,7 @@ impl SocketOps for UdpSocket {
                 } else if !socket.can_send() {
                     Err(AxError::WouldBlock)
                 } else {
+                    self.track_egress_ip_tos(local_addr, endpoint);
                     // UDP allows zero-length payloads (IP header + UDP header only).
                     if payload_len == 0 {
                         socket
@@ -565,6 +614,7 @@ impl Default for UdpSocket {
 impl Drop for UdpSocket {
     fn drop(&mut self) {
         self.shutdown(Shutdown::Both).ok();
+        self.clear_tracked_egress_ip_tos();
         SOCKET_SET.remove(self.handle);
     }
 }

--- a/net/ax-net/src/udp.rs
+++ b/net/ax-net/src/udp.rs
@@ -24,7 +24,7 @@
 //! UDP send/recv operations request the shared net-poll worker after socket
 //! state changes. They do not run the interface poll loop directly.
 
-use alloc::{vec, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use core::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     task::Context,
@@ -44,7 +44,8 @@ use smoltcp::{
 use spin::RwLock;
 
 use crate::{
-    RecvFlags, RecvOptions, SOCKET_SET, SendFlags, SendOptions, Shutdown, SocketAddrEx, SocketOps,
+    IpCmsg, RecvFlags, RecvOptions, SOCKET_SET, SendFlags, SendOptions, Shutdown, SocketAddrEx,
+    SocketOps,
     addr::allocate_ephemeral_port,
     config::{DeviceBinding, InterfaceId},
     consts::{UDP_RX_BUF_LEN, UDP_TX_BUF_LEN},
@@ -53,6 +54,7 @@ use crate::{
     ip_tos::{EgressIpTosKey, clear_egress_ip_tos, set_egress_ip_tos},
     options::{Configurable, GetSocketOption, SetSocketOption},
     request_poll,
+    rx_meta::{ReceivedTrafficClass, received_traffic_class},
 };
 
 /// Buffered state for MSG_MORE corking: captures the target endpoint
@@ -528,6 +530,27 @@ impl SocketOps for UdpSocket {
                                 warn!("UDP message truncated: {} -> {} bytes", src.len(), read);
                                 if let Some(ref mut truncated) = options.truncated {
                                     **truncated = true;
+                                }
+                            }
+
+                            if let Some(cmsg) = options.cmsg.as_deref_mut()
+                                && let Some(traffic_class) = received_traffic_class(meta.meta)
+                            {
+                                match traffic_class {
+                                    ReceivedTrafficClass::Ipv4(tos)
+                                        if self.general.recv_traffic_class() =>
+                                    {
+                                        cmsg.push(Box::new(IpCmsg::Ipv6TrafficClass(tos)));
+                                    }
+                                    ReceivedTrafficClass::Ipv4(tos) if self.general.recv_tos() => {
+                                        cmsg.push(Box::new(IpCmsg::Ipv4Tos(tos)));
+                                    }
+                                    ReceivedTrafficClass::Ipv6(tclass)
+                                        if self.general.recv_traffic_class() =>
+                                    {
+                                        cmsg.push(Box::new(IpCmsg::Ipv6TrafficClass(tclass)));
+                                    }
+                                    _ => {}
                                 }
                             }
 

--- a/os/StarryOS/kernel/src/syscall/net/cmsg.rs
+++ b/os/StarryOS/kernel/src/syscall/net/cmsg.rs
@@ -61,47 +61,58 @@ pub struct CMsgBuilder<'a> {
     hdr: UserPtr<cmsghdr>,
     len: &'a mut usize,
     capacity: usize,
+    written: usize,
 }
 impl<'a> CMsgBuilder<'a> {
     pub fn new(msg: UserPtr<cmsghdr>, len: &'a mut usize) -> Self {
         let capacity = *len;
-        *len = 0;
         Self {
             hdr: msg,
             len,
             capacity,
+            written: 0,
         }
     }
 
-    pub fn push(
+    pub fn finish(self) {
+        *self.len = self.written;
+    }
+
+    pub fn push_sized(
         &mut self,
         level: u32,
         ty: u32,
+        body_len: usize,
         body: impl FnOnce(&mut [u8]) -> AxResult<usize>,
     ) -> AxResult<bool> {
         let Some(body_capacity) = self
             .capacity
-            .checked_sub(*self.len)
+            .checked_sub(self.written)
             .and_then(|remaining| cmsg_align_down(remaining).checked_sub(size_of::<cmsghdr>()))
         else {
             return Ok(false);
         };
+        if body_capacity < body_len {
+            return Ok(false);
+        }
 
+        let hdr_addr = self.hdr.address().as_usize();
         let hdr = self.hdr.get_as_mut()?;
         hdr.cmsg_level = level as _;
         hdr.cmsg_type = ty as _;
 
-        let data = UserPtr::<u8>::from(self.hdr.address().as_usize() + size_of::<cmsghdr>())
-            .get_as_mut_slice(body_capacity)?;
-        let body_len = body(data)?;
+        let data =
+            UserPtr::<u8>::from(hdr_addr + size_of::<cmsghdr>()).get_as_mut_slice(body_len)?;
+        let written = body(data)?;
+        debug_assert_eq!(written, body_len);
 
         let Some(cmsg_len) = size_of::<cmsghdr>().checked_add(body_len) else {
             return Err(AxError::InvalidInput);
         };
         hdr.cmsg_len = cmsg_len;
         let cmsg_space = cmsg_align(cmsg_len);
-        self.hdr = UserPtr::from(hdr as *const _ as usize + cmsg_space);
-        *self.len += cmsg_space;
+        self.hdr = UserPtr::from(hdr_addr + cmsg_space);
+        self.written += cmsg_space;
         Ok(true)
     }
 }

--- a/os/StarryOS/kernel/src/syscall/net/io.rs
+++ b/os/StarryOS/kernel/src/syscall/net/io.rs
@@ -3,13 +3,15 @@ use core::{net::Ipv4Addr, time::Duration};
 
 use ax_errno::{AxError, AxResult};
 use ax_io::prelude::*;
-use ax_net::{CMsgData, RecvFlags, RecvOptions, SendFlags, SendOptions, SocketAddrEx, SocketOps};
+use ax_net::{
+    CMsgData, IpCmsg, RecvFlags, RecvOptions, SendFlags, SendOptions, SocketAddrEx, SocketOps,
+};
 use ax_runtime::hal::time::wall_time;
 use linux_raw_sys::{
     general::timespec,
     net::{
-        MSG_DONTWAIT, MSG_PEEK, MSG_TRUNC, SCM_RIGHTS, SOL_SOCKET, cmsghdr, mmsghdr, msghdr,
-        sockaddr, socklen_t,
+        IP_TOS, IPPROTO_IPV6, IPV6_TCLASS, MSG_DONTWAIT, MSG_PEEK, MSG_TRUNC, SCM_RIGHTS,
+        SOL_SOCKET, cmsghdr, mmsghdr, msghdr, sockaddr, socklen_t,
     },
 };
 
@@ -25,6 +27,7 @@ use crate::{
 
 // Linux ABI for sendmmsg/recvmmsg limits vlen to UIO_MAXIOV (1024).
 const MMSG_MAX_VLEN: u32 = 1024;
+const PROTO_IP: u32 = linux_raw_sys::net::IPPROTO_IP as u32;
 
 fn parse_recvmmsg_timeout(timeout: UserConstPtr<timespec>) -> AxResult<Option<Duration>> {
     if timeout.is_null() {
@@ -150,7 +153,7 @@ fn recv_impl(
     flags: u32,
     addr: UserPtr<sockaddr>,
     addrlen: UserPtr<socklen_t>,
-    cmsg_builder: Option<CMsgBuilder>,
+    mut cmsg_builder: Option<CMsgBuilder>,
     truncated_out: &mut bool,
 ) -> AxResult<isize> {
     debug!("sys_recv <= fd: {fd}, flags: {flags}");
@@ -162,6 +165,9 @@ fn recv_impl(
                 addr.address().as_usize() as *mut sockaddr,
                 addrlen.get_as_mut()?,
             )?;
+        }
+        if let Some(builder) = cmsg_builder.take() {
+            builder.finish();
         }
         return Ok(recv as isize);
     }
@@ -188,6 +194,9 @@ fn recv_impl(
                     addr,
                     addrlen.get_as_mut()?,
                 )?;
+            }
+            if let Some(builder) = cmsg_builder.take() {
+                builder.finish();
             }
             return Ok(recv as isize);
         }
@@ -227,26 +236,52 @@ fn recv_impl(
 
     if let Some(mut builder) = cmsg_builder {
         for cmsg in cmsg {
-            let Ok(cmsg) = cmsg.downcast::<CMsg>() else {
-                warn!("received unexpected cmsg");
-                continue;
-            };
-
-            let pushed = match *cmsg {
-                CMsg::Rights { fds } => builder.push(SOL_SOCKET, SCM_RIGHTS, |data| {
-                    let mut written = 0;
-                    for (f, chunk) in fds.into_iter().zip(data.chunks_exact_mut(size_of::<i32>())) {
-                        let fd = add_file_like(f, false)?;
-                        chunk.copy_from_slice(&fd.to_ne_bytes());
-                        written += size_of::<i32>();
+            let pushed = match cmsg.downcast::<CMsg>() {
+                Ok(cmsg) => match *cmsg {
+                    CMsg::Rights { fds } => {
+                        let body_len = fds.len() * size_of::<i32>();
+                        builder.push_sized(SOL_SOCKET, SCM_RIGHTS, body_len, |data| {
+                            let mut written = 0;
+                            for (f, chunk) in
+                                fds.into_iter().zip(data.chunks_exact_mut(size_of::<i32>()))
+                            {
+                                let fd = add_file_like(f, false)?;
+                                chunk.copy_from_slice(&fd.to_ne_bytes());
+                                written += size_of::<i32>();
+                            }
+                            Ok(written)
+                        })?
                     }
-                    Ok(written)
-                })?,
+                },
+                Err(cmsg) => match cmsg.downcast::<IpCmsg>() {
+                    Ok(cmsg) => match *cmsg {
+                        IpCmsg::Ipv4Tos(tos) => {
+                            builder.push_sized(PROTO_IP, IP_TOS, 1, |data| {
+                                data[0] = tos;
+                                Ok(1)
+                            })?
+                        }
+                        IpCmsg::Ipv6TrafficClass(tclass) => builder.push_sized(
+                            IPPROTO_IPV6 as u32,
+                            IPV6_TCLASS,
+                            size_of::<i32>(),
+                            |data| {
+                                data.copy_from_slice(&i32::from(tclass).to_ne_bytes());
+                                Ok(size_of::<i32>())
+                            },
+                        )?,
+                    },
+                    Err(_) => {
+                        warn!("received unexpected cmsg");
+                        continue;
+                    }
+                },
             };
             if !pushed {
                 break;
             }
         }
+        builder.finish();
     }
 
     debug!("sys_recv => fd: {fd}, recv: {recv}");

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -6,8 +6,9 @@ use ax_net::{
     options::{Configurable, GetSocketOption, SetSocketOption, TcpInfo, TcpInfoOptions, TcpState},
 };
 use linux_raw_sys::net::{
-    IPPROTO_IPV6, IPV6_V6ONLY, TCP_INFO, TCPI_OPT_ECN, TCPI_OPT_ECN_SEEN, TCPI_OPT_SACK,
-    TCPI_OPT_SYN_DATA, TCPI_OPT_TIMESTAMPS, TCPI_OPT_WSCALE, socklen_t, tcp_info,
+    AF_INET6, IP_TOS, IPPROTO_IPV6, IPV6_TCLASS, IPV6_V6ONLY, TCP_INFO, TCPI_OPT_ECN,
+    TCPI_OPT_ECN_SEEN, TCPI_OPT_SACK, TCPI_OPT_SYN_DATA, TCPI_OPT_TIMESTAMPS, TCPI_OPT_WSCALE,
+    socklen_t, tcp_info,
 };
 use starry_vm::vm_write_slice;
 
@@ -20,11 +21,27 @@ const PROTO_TCP: u32 = linux_raw_sys::net::IPPROTO_TCP as u32;
 
 const PROTO_IP: u32 = linux_raw_sys::net::IPPROTO_IP as u32;
 
+const IP_TOS_ECN_MASK: u8 = 0x03;
+
 fn read_int_sockopt(optval: UserConstPtr<u8>, optlen: socklen_t) -> AxResult<i32> {
     if (optlen as usize) < size_of::<i32>() {
         return Err(AxError::InvalidInput);
     }
     Ok(*optval.cast::<i32>().get_as_ref()?)
+}
+
+fn normalize_ip_tos(value: i32) -> u8 {
+    (value as u8) & !IP_TOS_ECN_MASK
+}
+
+fn normalize_ipv6_tclass(value: i32) -> AxResult<u8> {
+    if value == -1 {
+        return Ok(0);
+    }
+    if !(0..=u8::MAX as i32).contains(&value) {
+        return Err(AxError::InvalidInput);
+    }
+    Ok(normalize_ip_tos(value))
 }
 
 fn read_bind_to_device(
@@ -155,6 +172,14 @@ fn write_tcp_info(socket: &Socket, optval: UserPtr<u8>, optlen: &mut socklen_t) 
     Ok(vm_write_slice(optval.as_ptr(), &raw_bytes[..write_len])?)
 }
 
+fn ensure_ipv6_socket(socket: &Socket) -> AxResult<()> {
+    if socket.ip_domain() == AF_INET6 {
+        Ok(())
+    } else {
+        Err(AxError::from(LinuxError::ENOPROTOOPT))
+    }
+}
+
 mod conv {
     use ax_errno::{AxError, AxResult};
     use ax_net::options::UnixCredentials;
@@ -240,6 +265,7 @@ macro_rules! call_dispatch {
             (SOL_SOCKET, SO_TYPE) => SocketType as Int<i32>,       // read-only
             (SOL_SOCKET, SO_PROTOCOL) => SocketProtocol as Int<i32>,// read-only
             (SOL_SOCKET, SO_DOMAIN) => SocketDomain as Int<i32>,   // read-only
+            (SOL_SOCKET, SO_PRIORITY) => Priority as Int<i32>,      // stored; qdisc/device priority is not modeled
 
             (PROTO_TCP, TCP_NODELAY) => NoDelay as IntBool,
             (PROTO_TCP, TCP_MAXSEG) => MaxSegment as Int<usize>,  // TODO: hardcoded 1460, get actual MSS
@@ -249,12 +275,10 @@ macro_rules! call_dispatch {
             (PROTO_TCP, TCP_USER_TIMEOUT) => TcpUserTimeout as Int<u32>,
 
             (PROTO_IP, IP_TTL) => Ttl as Int<u8>,
-            (PROTO_IP, IP_TOS) => IpTos as Int<u8>,
             (PROTO_IP, IP_RECVERR) => RecvErr as IntBool,  // TODO: hardcoded false, no errqueue support
             // ---- Not yet implemented (add as needed) ----
             // (SOL_SOCKET, SO_LINGER) => ...,         // TODO: needs close() linger semantics
             // (SOL_SOCKET, SO_REUSEPORT) => ...,     // TODO: needs kernel support
-            // (SOL_SOCKET, SO_PRIORITY) => ...,       // TODO: needs kernel support
             // (SOL_SOCKET, SO_RCVLOWAT) => ...,       // TODO: needs kernel support
             // (SOL_SOCKET, SO_SNDLOWAT) => ...,       // TODO: needs kernel support
             // (PROTO_TCP, TCP_CORK) => ...,           // TODO: needs smoltcp support
@@ -337,6 +361,21 @@ pub fn sys_getsockopt(
     if level == IPPROTO_IPV6 as u32 && optname == IPV6_V6ONLY {
         // TODO: Store and enforce IPV6_V6ONLY once native IPv6 sockets exist.
         *get::<i32>(optval, optlen)? = 0;
+        return Ok(0);
+    }
+
+    if level == PROTO_IP && optname == IP_TOS {
+        let mut tos = 0;
+        socket.get_option(GetSocketOption::IpTos(&mut tos))?;
+        *get::<i32>(optval, optlen)? = i32::from(tos);
+        return Ok(0);
+    }
+
+    if level == IPPROTO_IPV6 as u32 && optname == IPV6_TCLASS {
+        ensure_ipv6_socket(&socket)?;
+        let mut tclass = 0;
+        socket.get_option(GetSocketOption::IpTos(&mut tclass))?;
+        *get::<i32>(optval, optlen)? = i32::from(tclass);
         return Ok(0);
     }
 
@@ -428,6 +467,19 @@ pub fn sys_setsockopt(
     if level == IPPROTO_IPV6 as u32 && optname == IPV6_V6ONLY {
         // TODO: Store and enforce IPV6_V6ONLY once native IPv6 sockets exist.
         let _ = *get::<i32>(optval, optlen)?;
+        return Ok(0);
+    }
+
+    if level == PROTO_IP && optname == IP_TOS {
+        let tos = normalize_ip_tos(*get::<i32>(optval, optlen)?);
+        socket.set_option(SetSocketOption::IpTos(&tos))?;
+        return Ok(0);
+    }
+
+    if level == IPPROTO_IPV6 as u32 && optname == IPV6_TCLASS {
+        ensure_ipv6_socket(&socket)?;
+        let tclass = normalize_ipv6_tclass(*get::<i32>(optval, optlen)?)?;
+        socket.set_option(SetSocketOption::IpTos(&tclass))?;
         return Ok(0);
     }
 

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -6,9 +6,9 @@ use ax_net::{
     options::{Configurable, GetSocketOption, SetSocketOption, TcpInfo, TcpInfoOptions, TcpState},
 };
 use linux_raw_sys::net::{
-    AF_INET6, IP_TOS, IPPROTO_IPV6, IPV6_TCLASS, IPV6_V6ONLY, TCP_INFO, TCPI_OPT_ECN,
-    TCPI_OPT_ECN_SEEN, TCPI_OPT_SACK, TCPI_OPT_SYN_DATA, TCPI_OPT_TIMESTAMPS, TCPI_OPT_WSCALE,
-    socklen_t, tcp_info,
+    AF_INET6, IP_TOS, IPPROTO_IPV6, IPV6_RECVTCLASS, IPV6_TCLASS, IPV6_V6ONLY, TCP_INFO,
+    TCPI_OPT_ECN, TCPI_OPT_ECN_SEEN, TCPI_OPT_SACK, TCPI_OPT_SYN_DATA, TCPI_OPT_TIMESTAMPS,
+    TCPI_OPT_WSCALE, socklen_t, tcp_info,
 };
 use starry_vm::vm_write_slice;
 
@@ -275,6 +275,7 @@ macro_rules! call_dispatch {
             (PROTO_TCP, TCP_USER_TIMEOUT) => TcpUserTimeout as Int<u32>,
 
             (PROTO_IP, IP_TTL) => Ttl as Int<u8>,
+            (PROTO_IP, linux_raw_sys::net::IP_RECVTOS) => RecvTos as IntBool,
             (PROTO_IP, IP_RECVERR) => RecvErr as IntBool,  // TODO: hardcoded false, no errqueue support
             // ---- Not yet implemented (add as needed) ----
             // (SOL_SOCKET, SO_LINGER) => ...,         // TODO: needs close() linger semantics
@@ -379,6 +380,14 @@ pub fn sys_getsockopt(
         return Ok(0);
     }
 
+    if level == IPPROTO_IPV6 as u32 && optname == IPV6_RECVTCLASS {
+        ensure_ipv6_socket(&socket)?;
+        let mut enabled = false;
+        socket.get_option(GetSocketOption::RecvTrafficClass(&mut enabled))?;
+        *get::<i32>(optval, optlen)? = enabled as i32;
+        return Ok(0);
+    }
+
     if level == PROTO_TCP && optname == TCP_INFO {
         write_tcp_info(&socket, optval, optlen)?;
         return Ok(0);
@@ -480,6 +489,13 @@ pub fn sys_setsockopt(
         ensure_ipv6_socket(&socket)?;
         let tclass = normalize_ipv6_tclass(*get::<i32>(optval, optlen)?)?;
         socket.set_option(SetSocketOption::IpTos(&tclass))?;
+        return Ok(0);
+    }
+
+    if level == IPPROTO_IPV6 as u32 && optname == IPV6_RECVTCLASS {
+        ensure_ipv6_socket(&socket)?;
+        let enabled = *get::<i32>(optval, optlen)? != 0;
+        socket.set_option(SetSocketOption::RecvTrafficClass(&enabled))?;
         return Ok(0);
     }
 

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -249,6 +249,7 @@ macro_rules! call_dispatch {
             (PROTO_TCP, TCP_USER_TIMEOUT) => TcpUserTimeout as Int<u32>,
 
             (PROTO_IP, IP_TTL) => Ttl as Int<u8>,
+            (PROTO_IP, IP_TOS) => IpTos as Int<u8>,
             (PROTO_IP, IP_RECVERR) => RecvErr as IntBool,  // TODO: hardcoded false, no errqueue support
             // ---- Not yet implemented (add as needed) ----
             // (SOL_SOCKET, SO_LINGER) => ...,         // TODO: needs close() linger semantics
@@ -261,7 +262,6 @@ macro_rules! call_dispatch {
             // (PROTO_TCP, TCP_QUICKACK) => ...,       // TODO: needs kernel support
             // (PROTO_TCP, TCP_SYNCNT) => ...,         // TODO: needs kernel support
             // (PROTO_TCP, TCP_WINDOW_CLAMP) => ...,   // TODO: needs kernel support
-            // (PROTO_IP, IP_TOS) => ...,              // TODO: needs kernel support
             // (PROTO_IP, IP_OPTIONS) => ...,          // TODO: needs kernel support
             // (IPPROTO_IPV6, IPV6_V6ONLY) => ...,     // TODO: currently hardcoded inline
         }

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-recv-qos-cmsg/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-recv-qos-cmsg/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-recv-qos-cmsg C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-recv-qos-cmsg src/main.c)
+target_compile_options(bug-recv-qos-cmsg PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-recv-qos-cmsg RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-recv-qos-cmsg/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-recv-qos-cmsg/src/main.c
@@ -1,0 +1,347 @@
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#ifndef IP_RECVTOS
+#define IP_RECVTOS 13
+#endif
+
+#ifndef IPV6_RECVTCLASS
+#define IPV6_RECVTCLASS 66
+#endif
+
+#ifndef IPV6_TCLASS
+#define IPV6_TCLASS 67
+#endif
+
+struct cmsg_result {
+    int has_ip_tos;
+    int ip_tos;
+    int has_ipv6_tclass;
+    int ipv6_tclass;
+};
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static int expect_true(int condition, const char *name)
+{
+    if (condition) {
+        note_pass(name);
+        return 1;
+    }
+    note_fail(name, "condition is false");
+    return 0;
+}
+
+static void expect_sockopt_bool(int fd, int level, int optname, int value,
+                                const char *name)
+{
+    errno = 0;
+    if (setsockopt(fd, level, optname, &value, sizeof(value)) != 0) {
+        char detail[160];
+        snprintf(detail, sizeof(detail), "setsockopt errno=%d (%s)", errno,
+                 strerror(errno));
+        note_fail(name, detail);
+        return;
+    }
+
+    int got = -1;
+    socklen_t got_len = sizeof(got);
+    errno = 0;
+    if (getsockopt(fd, level, optname, &got, &got_len) == 0 &&
+        got_len == sizeof(got) && got == (value != 0)) {
+        note_pass(name);
+        return;
+    }
+
+    char detail[160];
+    snprintf(detail, sizeof(detail), "getsockopt got=%d len=%u errno=%d (%s)",
+             got, (unsigned)got_len, errno, strerror(errno));
+    note_fail(name, detail);
+}
+
+static void expect_sockopt_errno(int fd, int level, int optname, int value,
+                                 int expected_errno, const char *name)
+{
+    errno = 0;
+    int ret = setsockopt(fd, level, optname, &value, sizeof(value));
+    int saved_errno = errno;
+    if (ret == -1 && saved_errno == expected_errno) {
+        note_pass(name);
+        return;
+    }
+
+    char detail[160];
+    snprintf(detail, sizeof(detail),
+             "ret=%d errno=%d (%s), expected -1/%d", ret, saved_errno,
+             strerror(saved_errno), expected_errno);
+    note_fail(name, detail);
+}
+
+static int bind_udp4_loopback(int fd, struct sockaddr_in *addr)
+{
+    memset(addr, 0, sizeof(*addr));
+    addr->sin_family = AF_INET;
+    addr->sin_port = 0;
+    addr->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bind(fd, (struct sockaddr *)addr, sizeof(*addr)) != 0) {
+        return -1;
+    }
+
+    socklen_t len = sizeof(*addr);
+    return getsockname(fd, (struct sockaddr *)addr, &len);
+}
+
+static int bind_udp6_loopback(int fd, struct sockaddr_in6 *addr)
+{
+    memset(addr, 0, sizeof(*addr));
+    addr->sin6_family = AF_INET6;
+    addr->sin6_port = 0;
+    if (inet_pton(AF_INET6, "::1", &addr->sin6_addr) != 1) {
+        return -1;
+    }
+    if (bind(fd, (struct sockaddr *)addr, sizeof(*addr)) != 0) {
+        return -1;
+    }
+
+    socklen_t len = sizeof(*addr);
+    return getsockname(fd, (struct sockaddr *)addr, &len);
+}
+
+static void collect_cmsgs(struct msghdr *msg, struct cmsg_result *result)
+{
+    memset(result, 0, sizeof(*result));
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(msg);
+    if (cmsg != NULL) {
+        if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_TOS &&
+            cmsg->cmsg_len >= CMSG_LEN(1)) {
+            result->has_ip_tos = 1;
+            result->ip_tos = *(unsigned char *)CMSG_DATA(cmsg);
+        } else if (cmsg->cmsg_level == IPPROTO_IPV6 &&
+                   cmsg->cmsg_type == IPV6_TCLASS &&
+                   cmsg->cmsg_len >= CMSG_LEN(sizeof(int))) {
+            int value = -1;
+            memcpy(&value, CMSG_DATA(cmsg), sizeof(value));
+            result->has_ipv6_tclass = 1;
+            result->ipv6_tclass = value;
+        }
+    }
+}
+
+static int recv_one(int fd, const char *expected, struct cmsg_result *result)
+{
+    char data[32] = {0};
+    char cbuf[CMSG_SPACE(sizeof(int)) + CMSG_SPACE(1)] = {0};
+    struct iovec iov = {
+        .iov_base = data,
+        .iov_len = sizeof(data),
+    };
+    struct msghdr msg = {
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+        .msg_control = cbuf,
+        .msg_controllen = sizeof(cbuf),
+    };
+
+    ssize_t nread = -1;
+    for (int attempt = 0; attempt < 100; attempt++) {
+        errno = 0;
+        nread = recvmsg(fd, &msg, MSG_DONTWAIT);
+        if (nread >= 0 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
+            break;
+        }
+        usleep(10000);
+    }
+    if (nread != (ssize_t)strlen(expected) ||
+        memcmp(data, expected, strlen(expected)) != 0) {
+        char detail[180];
+        snprintf(detail, sizeof(detail), "recvmsg nread=%zd errno=%d (%s)",
+                 nread, errno, strerror(errno));
+        note_fail("recvmsg payload", detail);
+        return -1;
+    }
+    note_pass("recvmsg payload");
+    collect_cmsgs(&msg, result);
+    return 0;
+}
+
+static void test_option_toggles(void)
+{
+    int fd4 = socket(AF_INET, SOCK_DGRAM, 0);
+    int fd6 = socket(AF_INET6, SOCK_DGRAM, 0);
+    if (!expect_true(fd4 >= 0, "create AF_INET UDP socket") ||
+        !expect_true(fd6 >= 0, "create AF_INET6 UDP socket")) {
+        if (fd4 >= 0) {
+            close(fd4);
+        }
+        if (fd6 >= 0) {
+            close(fd6);
+        }
+        return;
+    }
+
+    expect_sockopt_bool(fd4, IPPROTO_IP, IP_RECVTOS, 1,
+                        "IP_RECVTOS enables on AF_INET");
+    expect_sockopt_bool(fd4, IPPROTO_IP, IP_RECVTOS, 0,
+                        "IP_RECVTOS disables on AF_INET");
+    expect_sockopt_errno(fd4, IPPROTO_IPV6, IPV6_RECVTCLASS, 1, ENOPROTOOPT,
+                         "AF_INET rejects IPV6_RECVTCLASS");
+
+    expect_sockopt_bool(fd6, IPPROTO_IP, IP_RECVTOS, 1,
+                        "IP_RECVTOS enables on AF_INET6");
+    expect_sockopt_bool(fd6, IPPROTO_IPV6, IPV6_RECVTCLASS, 1,
+                        "IPV6_RECVTCLASS enables on AF_INET6");
+    expect_sockopt_bool(fd6, IPPROTO_IPV6, IPV6_RECVTCLASS, 0,
+                        "IPV6_RECVTCLASS disables on AF_INET6");
+
+    close(fd4);
+    close(fd6);
+}
+
+static void test_ipv4_recvtos_cmsg(void)
+{
+    int rx = socket(AF_INET, SOCK_DGRAM, 0);
+    int tx = socket(AF_INET, SOCK_DGRAM, 0);
+    if (!expect_true(rx >= 0 && tx >= 0, "create IPv4 UDP pair")) {
+        if (rx >= 0) {
+            close(rx);
+        }
+        if (tx >= 0) {
+            close(tx);
+        }
+        return;
+    }
+
+    struct sockaddr_in addr;
+    if (!expect_true(bind_udp4_loopback(rx, &addr) == 0,
+                     "bind IPv4 UDP receiver to loopback")) {
+        close(rx);
+        close(tx);
+        return;
+    }
+
+    int tos = 0x2e;
+    expect_true(setsockopt(tx, IPPROTO_IP, IP_TOS, &tos, sizeof(tos)) == 0,
+                "set sender IP_TOS");
+
+    const char first[] = "no-cmsg";
+    expect_true(sendto(tx, first, strlen(first), 0, (struct sockaddr *)&addr,
+                       sizeof(addr)) == (ssize_t)strlen(first),
+                "send IPv4 datagram before IP_RECVTOS");
+    struct cmsg_result result;
+    if (recv_one(rx, first, &result) == 0) {
+        expect_true(!result.has_ip_tos && !result.has_ipv6_tclass,
+                    "IP_RECVTOS disabled returns no QoS cmsg");
+    }
+
+    int one = 1;
+    expect_true(setsockopt(rx, IPPROTO_IP, IP_RECVTOS, &one, sizeof(one)) == 0,
+                "enable receiver IP_RECVTOS");
+    const char second[] = "ip-tos";
+    expect_true(sendto(tx, second, strlen(second), 0, (struct sockaddr *)&addr,
+                       sizeof(addr)) == (ssize_t)strlen(second),
+                "send IPv4 datagram with IP_RECVTOS");
+    if (recv_one(rx, second, &result) == 0) {
+        expect_true(result.has_ip_tos && result.ip_tos == 0x2c,
+                    "recvmsg reports IP_TOS cmsg");
+        expect_true(!result.has_ipv6_tclass,
+                    "IPv4 IP_RECVTOS does not report IPV6_TCLASS");
+    }
+
+    close(rx);
+    close(tx);
+}
+
+static void test_ipv6_recvtclass_cmsg(void)
+{
+    int rx = socket(AF_INET6, SOCK_DGRAM, 0);
+    int tx = socket(AF_INET6, SOCK_DGRAM, 0);
+    if (!expect_true(rx >= 0 && tx >= 0, "create AF_INET6 UDP pair")) {
+        if (rx >= 0) {
+            close(rx);
+        }
+        if (tx >= 0) {
+            close(tx);
+        }
+        return;
+    }
+
+    struct sockaddr_in6 bind_addr;
+    if (!expect_true(bind_udp6_loopback(rx, &bind_addr) == 0,
+                     "bind AF_INET6 UDP receiver to ::1")) {
+        close(rx);
+        close(tx);
+        return;
+    }
+
+    struct sockaddr_in6 dst = bind_addr;
+    if (inet_pton(AF_INET6, "::ffff:127.0.0.1", &dst.sin6_addr) != 1) {
+        note_fail("build IPv4-mapped destination", "inet_pton failed");
+        close(rx);
+        close(tx);
+        return;
+    }
+
+    int tclass = 0x2e;
+    expect_true(setsockopt(tx, IPPROTO_IPV6, IPV6_TCLASS, &tclass,
+                           sizeof(tclass)) == 0,
+                "set sender IPV6_TCLASS");
+
+    int one = 1;
+    expect_true(setsockopt(rx, IPPROTO_IPV6, IPV6_RECVTCLASS, &one,
+                           sizeof(one)) == 0,
+                "enable receiver IPV6_RECVTCLASS");
+
+    const char payload[] = "ipv6-tclass";
+    expect_true(sendto(tx, payload, strlen(payload), 0, (struct sockaddr *)&dst,
+                       sizeof(dst)) == (ssize_t)strlen(payload),
+                "send AF_INET6 datagram through mapped loopback");
+
+    struct cmsg_result result;
+    if (recv_one(rx, payload, &result) == 0) {
+        expect_true(result.has_ipv6_tclass && result.ipv6_tclass == 0x2c,
+                    "recvmsg reports IPV6_TCLASS cmsg");
+        expect_true(!result.has_ip_tos,
+                    "IPV6_RECVTCLASS does not report IP_TOS cmsg");
+    }
+
+    close(rx);
+    close(tx);
+}
+
+int main(void)
+{
+    printf("=== bug-recv-qos-cmsg ===\n");
+
+    test_option_toggles();
+    test_ipv4_recvtos_cmsg();
+    test_ipv6_recvtclass_cmsg();
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_GROUPED_TEST_PASSED: bug-recv-qos-cmsg\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bug-recv-qos-cmsg\n");
+    return EXIT_FAILURE;
+}

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-socket-qos-options/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-socket-qos-options/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bug-socket-qos-options C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-socket-qos-options src/main.c)
+target_compile_options(bug-socket-qos-options PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-socket-qos-options RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-socket-qos-options/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-socket-qos-options/src/main.c
@@ -1,0 +1,155 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#ifndef IPV6_TCLASS
+#define IPV6_TCLASS 67
+#endif
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static void expect_set_get_int(int fd, int level, int optname, int value,
+                               int expected, const char *name)
+{
+    errno = 0;
+    int ret = setsockopt(fd, level, optname, &value, sizeof(value));
+    if (ret != 0) {
+        char detail[160];
+        snprintf(detail, sizeof(detail),
+                 "setsockopt ret=%d errno=%d (%s), expected success", ret,
+                 errno, strerror(errno));
+        note_fail(name, detail);
+        return;
+    }
+
+    int got = -1;
+    socklen_t got_len = sizeof(got);
+    errno = 0;
+    ret = getsockopt(fd, level, optname, &got, &got_len);
+    if (ret == 0 && got == expected && got_len == sizeof(got)) {
+        note_pass(name);
+        return;
+    }
+
+    char detail[180];
+    snprintf(detail, sizeof(detail),
+             "getsockopt ret=%d errno=%d (%s), got=%d len=%u, expected=%d",
+             ret, errno, strerror(errno), got, (unsigned)got_len, expected);
+    note_fail(name, detail);
+}
+
+static void expect_sockopt_errno(int fd, int level, int optname, int value,
+                                 int expected_errno, const char *name)
+{
+    errno = 0;
+    int ret = setsockopt(fd, level, optname, &value, sizeof(value));
+    int saved_errno = errno;
+    if (ret == -1 && saved_errno == expected_errno) {
+        note_pass(name);
+        return;
+    }
+
+    char detail[160];
+    snprintf(detail, sizeof(detail),
+             "ret=%d errno=%d (%s), expected -1/%d", ret, saved_errno,
+             strerror(saved_errno), expected_errno);
+    note_fail(name, detail);
+}
+
+static void test_ipv4_tos(void)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        note_fail("create AF_INET TCP socket", strerror(errno));
+        return;
+    }
+
+    expect_set_get_int(fd, IPPROTO_IP, IP_TOS, 0x2e, 0x2c,
+                       "IP_TOS masks user ECN bits");
+    expect_set_get_int(fd, IPPROTO_IP, IP_TOS, -1, 0xfc,
+                       "IP_TOS truncates negative int like Linux");
+    expect_set_get_int(fd, IPPROTO_IP, IP_TOS, 256, 0,
+                       "IP_TOS truncates values above 255");
+    expect_sockopt_errno(fd, IPPROTO_IPV6, IPV6_TCLASS, 0x20, ENOPROTOOPT,
+                         "AF_INET rejects IPV6_TCLASS");
+
+    close(fd);
+}
+
+static void test_ipv6_tclass(void)
+{
+    int fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) {
+        note_fail("create AF_INET6 TCP socket", strerror(errno));
+        return;
+    }
+
+    expect_set_get_int(fd, IPPROTO_IPV6, IPV6_TCLASS, 0x2e, 0x2c,
+                       "IPV6_TCLASS masks user ECN bits");
+    expect_set_get_int(fd, IPPROTO_IPV6, IPV6_TCLASS, -1, 0,
+                       "IPV6_TCLASS -1 resets to default");
+    expect_set_get_int(fd, IPPROTO_IPV6, IPV6_TCLASS, 255, 252,
+                       "IPV6_TCLASS accepts max byte value");
+    expect_sockopt_errno(fd, IPPROTO_IPV6, IPV6_TCLASS, 256, EINVAL,
+                         "IPV6_TCLASS rejects values above 255");
+    expect_sockopt_errno(fd, IPPROTO_IPV6, IPV6_TCLASS, -2, EINVAL,
+                         "IPV6_TCLASS rejects values below -1");
+
+    close(fd);
+}
+
+static void test_so_priority(void)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        note_fail("create SO_PRIORITY TCP socket", strerror(errno));
+        return;
+    }
+
+    expect_set_get_int(fd, SOL_SOCKET, SO_PRIORITY, 0, 0,
+                       "SO_PRIORITY accepts zero");
+    expect_set_get_int(fd, SOL_SOCKET, SO_PRIORITY, 6, 6,
+                       "SO_PRIORITY accepts unprivileged max");
+    expect_sockopt_errno(fd, SOL_SOCKET, SO_PRIORITY, 7, EPERM,
+                         "SO_PRIORITY rejects privileged value");
+    expect_sockopt_errno(fd, SOL_SOCKET, SO_PRIORITY, -1, EPERM,
+                         "SO_PRIORITY rejects negative value");
+
+    close(fd);
+}
+
+int main(void)
+{
+    printf("=== bug-socket-qos-options ===\n");
+
+    test_ipv4_tos();
+    test_ipv6_tclass();
+    test_so_priority();
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_GROUPED_TEST_PASSED: bug-socket-qos-options\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bug-socket-qos-options\n");
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

本 PR 修复 StarryOS 运行 OpenSSH/Git SSH remote 时暴露出的 socket QoS 兼容问题，并补齐一条收发两侧都能验证的 QoS 语义闭环。

OpenSSH client 在建立连接前会设置 `IP_TOS`，常见 Linux 用户态程序也会查询或设置 `IPV6_TCLASS`、`SO_PRIORITY`、`IP_RECVTOS`、`IPV6_RECVTCLASS` 这类 socket option。此前 Starry 的分发表和 ax-net 状态只覆盖了部分基础选项，出站 `IP_TOS` 没有真正进入 IP header，收包侧也不会通过 `recvmsg` control message 把 TOS / traffic class 交还给用户态。本 PR 补齐 syscall 分发、ax-net socket 状态、出站包修改、收包元数据传递和用户态回归测试。

## Commits

- `fix(ax-net): apply IP_TOS to outgoing packets`
- `test(starry): add git ssh remote app`
- `fix(starry-kernel): align socket QoS options with Linux`
- `fix(starry-kernel): report receive QoS cmsgs`

## What's included

- 在 Starry syscall socket option 分发中接入 `IP_TOS`，并按 Linux 行为处理 int 到 TOS byte 的截断和 ECN bit 屏蔽。
- 在 `ax-net` 中保存每个 socket 的 TOS/traffic-class 值，并在 TCP/UDP/raw 出站包路径应用到实际 IP header：
  - TCP 在 connect/listen/accept/drop 生命周期中维护出站 TOS 策略。
  - accept 得到的 TCP socket 继承 listener 的 TOS 设置。
  - UDP 在实际发送目标确定后，为非零 TOS 的目标 flow 注册出站策略。
  - IPv4 写入 DSCP/ECN 并重新计算 IPv4 header checksum。
  - IPv6 写入 traffic class。
- 补齐 `IPV6_TCLASS`：
  - 只允许在 AF_INET6 socket 上使用，AF_INET 返回 `ENOPROTOOPT`。
  - `-1` 重置为默认值 0。
  - `0..=255` 按 byte 接收并屏蔽 ECN bit。
  - 其他值返回 `EINVAL`。
- 补齐 `SO_PRIORITY` 的 socket option 兼容层：
  - 支持读写保存的 priority 值。
  - 普通范围 `0..=6` 成功。
  - 负数和需要权限的高优先级返回 `EPERM`。
  - 当前只建模 socket option 可见语义，不引入 qdisc/device 调度优先级。
- 补齐收包侧 QoS control message：
  - ax-net router 在 RX token 中携带收到的 IPv4 TOS / IPv6 traffic class 元数据。
  - UDP `recvmsg` 在启用 `IP_RECVTOS` 时返回 `(IPPROTO_IP, IP_TOS)` cmsg，body 为 1 byte。
  - UDP `recvmsg` 在启用 `IPV6_RECVTCLASS` 时返回 `(IPPROTO_IPV6, IPV6_TCLASS)` cmsg，body 为 `int`。
  - Starry 当前 AF_INET6 路径仍会经过 v4-mapped loopback，本 PR 在这条兼容路径上保持用户态请求的 cmsg 类型。
  - `recvmsg` 只在成功接收后写回 `msg_controllen`，避免 `MSG_DONTWAIT` 暂时返回 `EAGAIN` 时提前清零用户传入的 control buffer 容量。
- 新增 `apps/starry/git-ssh`，在 Alpine guest 内安装 Git/OpenSSH，启动本机 sshd，通过 `ssh://127.0.0.1:2222/...` 覆盖：
  - `git ls-remote`
  - `git clone`
  - `git push`
  - `git fetch`
  - `git pull --ff-only`
  - 关闭端口失败路径
  - 缺失 repo 失败路径
- 新增两个 grouped C 回归用例：
  - `bugfix-bug-socket-qos-options` 覆盖 `IP_TOS`、`IPV6_TCLASS`、`SO_PRIORITY` 的 Linux 边界值。
  - `bugfix-bug-recv-qos-cmsg` 覆盖 `IP_RECVTOS`、`IPV6_RECVTCLASS`、禁用路径、协议族错误路径、非阻塞 retry 和 `recvmsg` cmsg 内容。

## What's NOT included (deferred)

- 外部 SSH 服务器、SSH 认证矩阵、TLS/HTTPS remote、真实公网 writable remote。
- 完整 qdisc/device priority 调度模型；本 PR 只保证 socket option 层面的 Linux 兼容行为。
- TCP/raw 的 receive-side QoS cmsg；本次先覆盖 Git/OpenSSH 相关的出站路径，以及 UDP 上可稳定复现的收包 cmsg 语义。
- 抓包级 CI 验证；当前验证通过 Git/OpenSSH 用户态行为、socket option 回归用例、收包 cmsg 回归用例和 ax-net 单元测试覆盖。

## Changed files

- `net/ax-net/src/ip_tos.rs`
- `net/ax-net/src/rx_meta.rs`
- `net/ax-net/src/general.rs`
- `net/ax-net/src/options.rs`
- `net/ax-net/src/socket.rs`
- `net/ax-net/src/tcp.rs`
- `net/ax-net/src/udp.rs`
- `net/ax-net/src/raw.rs`
- `net/ax-net/src/router.rs`
- `os/StarryOS/kernel/src/syscall/net/opt.rs`
- `os/StarryOS/kernel/src/syscall/net/io.rs`
- `os/StarryOS/kernel/src/syscall/net/cmsg.rs`
- `apps/starry/git-ssh/*`
- `test-suit/starryos/qemu-smp1/system/bugfix-bug-socket-qos-options/*`
- `test-suit/starryos/qemu-smp1/system/bugfix-bug-recv-qos-cmsg/*`

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `sh -n apps/starry/git-ssh/git-ssh-test.sh`
- `bash -n apps/starry/git-ssh/prebuild.sh`
- `cc -Wall -Wextra -Werror -fsyntax-only test-suit/starryos/qemu-smp1/system/bugfix-bug-socket-qos-options/src/main.c`
- `cc -Wall -Wextra -Werror -fsyntax-only test-suit/starryos/qemu-smp1/system/bugfix-bug-recv-qos-cmsg/src/main.c`
- `cargo test -p ax-net --lib`
- `cargo xtask clippy --package ax-net`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry app qemu -t git-ssh --arch aarch64`
- `cargo xtask starry app qemu -t git-ssh --arch riscv64`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/bugfix-bug-socket-qos-options`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/bugfix-bug-recv-qos-cmsg`
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/bugfix-bug-recv-qos-cmsg`
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/test-unix-scm-rights`
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/test-unix-cmsg-byte-marks`

注：两个 x86_64 grouped 子用例本地验证时，宿主 QEMU 8.2.2 不支持当前配置中的 `qemu-xhci.msi` 属性；验证时临时使用不带该属性的本地 QEMU 参数，仓库配置未修改。