### PR TITLE
fix(starry): keep tmpfs directory cookies stable

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/tmp.rs
+++ b/os/StarryOS/kernel/src/pseudofs/tmp.rs
@@ -1,5 +1,12 @@
 use alloc::{borrow::ToOwned, string::String, sync::Arc, vec::Vec};
-use core::{any::Any, borrow::Borrow, cmp::Ordering, task::Context, time::Duration};
+use core::{
+    any::Any,
+    borrow::Borrow,
+    cmp::Ordering,
+    sync::atomic::{AtomicU64, Ordering as AtomicOrdering},
+    task::Context,
+    time::Duration,
+};
 
 use ax_kspin::SpinNoIrq;
 use ax_sync::Mutex;
@@ -183,12 +190,14 @@ struct DirContent {
     // SpinNoIrq guards, so this per-directory map must not use a blocking
     // mutex.
     entries: SpinNoIrq<HashMap<FileName, InodeRef>>,
+    next_cookie: AtomicU64,
 }
 
 impl Default for DirContent {
     fn default() -> Self {
         Self {
             entries: SpinNoIrq::new(HashMap::new()),
+            next_cookie: AtomicU64::new(3),
         }
     }
 }
@@ -250,11 +259,11 @@ impl Inode {
             let mut entries = dir.entries.lock_nested(dir_entries_subclass);
             entries.insert(
                 ".".into(),
-                InodeRef::new(fs.clone(), ino, NodeType::Directory),
+                InodeRef::new(fs.clone(), ino, NodeType::Directory, 1),
             );
             entries.insert(
                 "..".into(),
-                InodeRef::new(fs.clone(), parent.unwrap_or(ino), NodeType::Directory),
+                InodeRef::new(fs.clone(), parent.unwrap_or(ino), NodeType::Directory, 2),
             );
         }
         result
@@ -279,12 +288,18 @@ struct InodeRef {
     fs: Arc<MemoryFs>,
     ino: u64,
     node_type: NodeType,
+    cookie: u64,
 }
 
 impl InodeRef {
-    pub fn new(fs: Arc<MemoryFs>, ino: u64, node_type: NodeType) -> Self {
+    pub fn new(fs: Arc<MemoryFs>, ino: u64, node_type: NodeType, cookie: u64) -> Self {
         fs.get(ino).metadata.lock().nlink += 1;
-        Self { fs, ino, node_type }
+        Self {
+            fs,
+            ino,
+            node_type,
+            cookie,
+        }
     }
 
     fn get(&self) -> Arc<Inode> {
@@ -452,10 +467,12 @@ impl Pollable for MemoryNode {
 impl DirNodeOps for MemoryNode {
     fn read_dir(&self, offset: u64, sink: &mut dyn DirEntrySink) -> VfsResult<usize> {
         let dir = self.inode.as_dir()?;
-        let offset = usize::try_from(offset).unwrap_or(usize::MAX);
         let entries = loop {
             let entries = dir.entries.lock();
-            let count = entries.len().saturating_sub(offset);
+            let count = entries
+                .values()
+                .filter(|entry| offset == 0 || entry.cookie >= offset)
+                .count();
             drop(entries);
 
             let mut snapshot = Vec::new();
@@ -464,19 +481,27 @@ impl DirNodeOps for MemoryNode {
                 .map_err(|_| VfsError::NoMemory)?;
 
             let entries = dir.entries.lock();
-            if entries.len().saturating_sub(offset) > snapshot.capacity() {
+            let live_count = entries
+                .values()
+                .filter(|entry| offset == 0 || entry.cookie >= offset)
+                .count();
+            if live_count > snapshot.capacity() {
                 continue;
             }
-            for (i, (name, entry)) in entries.iter().enumerate().skip(offset) {
+            for (name, entry) in entries.iter() {
+                if offset != 0 && entry.cookie < offset {
+                    continue;
+                }
                 let (ino, node_type) = entry.metadata_for_readdir();
-                snapshot.push((name.0.clone(), ino, node_type, i as u64 + 1));
+                snapshot.push((entry.cookie, name.0.clone(), ino, node_type));
             }
+            snapshot.sort_by_key(|(cookie, ..)| *cookie);
             break snapshot;
         };
 
         let mut count = 0;
-        for (name, ino, node_type, next_offset) in entries {
-            if !sink.accept(name.as_ref(), ino, node_type, next_offset) {
+        for (cookie, name, ino, node_type) in entries {
+            if !sink.accept(name.as_ref(), ino, node_type, cookie + 1) {
                 return Ok(count);
             }
             count += 1;
@@ -517,9 +542,10 @@ impl DirNodeOps for MemoryNode {
             gid,
             TMPFS_NESTED_DIR_ENTRIES_SUBCLASS,
         );
+        let cookie = dir.next_cookie.fetch_add(1, AtomicOrdering::Relaxed);
         entries.insert(
             name.into(),
-            InodeRef::new(self.fs.clone(), inode.ino, node_type),
+            InodeRef::new(self.fs.clone(), inode.ino, node_type, cookie),
         );
         self.new_entry(name, node_type, inode)
     }
@@ -535,9 +561,10 @@ impl DirNodeOps for MemoryNode {
         }
         let inode = target.inode.clone();
         let node_type = inode.metadata.lock().node_type;
+        let cookie = dir.next_cookie.fetch_add(1, AtomicOrdering::Relaxed);
         entries.insert(
             name.into(),
-            InodeRef::new(self.fs.clone(), inode.ino, node_type),
+            InodeRef::new(self.fs.clone(), inode.ino, node_type, cookie),
         );
         self.new_entry(name, node_type, inode)
     }
@@ -553,7 +580,7 @@ impl DirNodeOps for MemoryNode {
             let inode = entry.get();
             match (&inode.content, is_dir) {
                 (NodeContent::Dir(_), false) => return Err(VfsError::IsADirectory),
-                (NodeContent::Dir(DirContent { entries }), true)
+                (NodeContent::Dir(DirContent { entries, .. }), true)
                     if entries.lock_nested(TMPFS_NESTED_DIR_ENTRIES_SUBCLASS).len() > 2 =>
                 {
                     return Err(VfsError::DirectoryNotEmpty);
@@ -585,10 +612,19 @@ impl DirNodeOps for MemoryNode {
             let mut entries = self.inode.as_dir()?.entries.lock();
             entries.remove(src_name).ok_or(VfsError::NotFound)?
         };
+        let dst_dir = dst_node.inode.as_dir()?;
+        let cookie = dst_dir.next_cookie.fetch_add(1, AtomicOrdering::Relaxed);
+        let moved_entry = InodeRef::new(
+            src_entry.fs.clone(),
+            src_entry.ino,
+            src_entry.node_type,
+            cookie,
+        );
         let overwritten = {
-            let mut entries = dst_node.inode.as_dir()?.entries.lock();
-            entries.insert(dst_name.into(), src_entry)
+            let mut entries = dst_dir.entries.lock();
+            entries.insert(dst_name.into(), moved_entry)
         };
+        drop(src_entry);
         if let Some(entry) = overwritten {
             Self::clear_dir_entries(&entry.get());
             drop(entry);

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-dir-cookie-unlink-rmdir/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-dir-cookie-unlink-rmdir/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-dir-cookie-unlink-rmdir C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-dir-cookie-unlink-rmdir src/main.c)
+target_compile_options(bug-dir-cookie-unlink-rmdir PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-dir-cookie-unlink-rmdir RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-dir-cookie-unlink-rmdir/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-dir-cookie-unlink-rmdir/src/main.c
@@ -1,0 +1,210 @@
+/*
+ * bug-dir-cookie-unlink-rmdir: getdents64 offsets must remain stable while
+ * userland deletes entries from the directory being iterated.
+ *
+ * Tools such as rm -rf read a batch of directory entries, unlink those names,
+ * then continue getdents64 from the returned d_off. Filesystems must therefore
+ * return stable directory cookies. Count-based offsets can skip live entries
+ * after deletion and make the final rmdir fail with ENOTEMPTY.
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_getdents64
+#if defined(__x86_64__)
+#define SYS_getdents64 217
+#elif defined(__aarch64__)
+#define SYS_getdents64 61
+#elif defined(__riscv)
+#define SYS_getdents64 61
+#elif defined(__loongarch64)
+#define SYS_getdents64 61
+#endif
+#endif
+
+struct linux_dirent64 {
+    uint64_t d_ino;
+    int64_t d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[];
+};
+
+static int fail_errno(const char *phase, const char *path)
+{
+    printf("FAIL: %s path=%s errno=%d (%s)\n", phase, path, errno, strerror(errno));
+    printf("STARRY_GROUPED_TEST_FAILED: bug-dir-cookie-unlink-rmdir\n");
+    return 1;
+}
+
+static int fail_msg(const char *phase, const char *path, const char *msg)
+{
+    printf("FAIL: %s path=%s %s\n", phase, path, msg);
+    printf("STARRY_GROUPED_TEST_FAILED: bug-dir-cookie-unlink-rmdir\n");
+    return 1;
+}
+
+static int make_files(const char *dir, const char *prefix, int count)
+{
+    char path[160];
+
+    for (int i = 0; i < count; i++) {
+        snprintf(path, sizeof(path), "%s/%s%04d", dir, prefix, i);
+        int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (fd < 0) {
+            return fail_errno("create file", path);
+        }
+        if (write(fd, "x", 1) != 1) {
+            close(fd);
+            return fail_errno("write file", path);
+        }
+        close(fd);
+    }
+    return 0;
+}
+
+static int remove_by_batched_getdents(const char *dir)
+{
+    char buf[80];
+    int fd = open(dir, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        return fail_errno("open directory", dir);
+    }
+
+    for (;;) {
+        int nread = (int)syscall(SYS_getdents64, fd, buf, sizeof(buf));
+        if (nread < 0) {
+            close(fd);
+            return fail_errno("getdents64", dir);
+        }
+        if (nread == 0) {
+            break;
+        }
+
+        for (int pos = 0; pos < nread;) {
+            struct linux_dirent64 *d = (struct linux_dirent64 *)(void *)(buf + pos);
+            if (d->d_reclen == 0 || pos + d->d_reclen > nread) {
+                close(fd);
+                return fail_msg("parse dirent", dir, "invalid reclen");
+            }
+            if (strcmp(d->d_name, ".") != 0 && strcmp(d->d_name, "..") != 0) {
+                if (unlinkat(fd, d->d_name, 0) != 0) {
+                    close(fd);
+                    return fail_errno("unlinkat", d->d_name);
+                }
+            }
+            pos += d->d_reclen;
+        }
+    }
+
+    close(fd);
+    return 0;
+}
+
+static int run_case(const char *label, const char *dir)
+{
+    const int count = 160;
+
+    printf("[TEST] %s dir=%s count=%d\n", label, dir, count);
+    rmdir(dir);
+    if (mkdir(dir, 0755) != 0) {
+        return fail_errno("mkdir", dir);
+    }
+    if (make_files(dir, "f", count) != 0) {
+        return 1;
+    }
+    if (remove_by_batched_getdents(dir) != 0) {
+        return 1;
+    }
+    if (rmdir(dir) != 0) {
+        return fail_errno("rmdir after batched unlink", dir);
+    }
+    printf("PASS: %s batched getdents64 unlink rmdir\n", label);
+    return 0;
+}
+
+static int run_rename_case(const char *label, const char *src_dir, const char *dst_dir)
+{
+    const int count = 64;
+    char old_path[160];
+    char new_path[160];
+
+    printf("[TEST] %s rename dir-cookie src=%s dst=%s count=%d\n", label, src_dir, dst_dir,
+           count);
+    rmdir(src_dir);
+    rmdir(dst_dir);
+    if (mkdir(src_dir, 0755) != 0) {
+        return fail_errno("mkdir src", src_dir);
+    }
+    if (mkdir(dst_dir, 0755) != 0) {
+        return fail_errno("mkdir dst", dst_dir);
+    }
+    if (make_files(src_dir, "s", count) != 0 || make_files(dst_dir, "d", count) != 0) {
+        return 1;
+    }
+
+    for (int i = 0; i < count; i++) {
+        snprintf(old_path, sizeof(old_path), "%s/s%04d", src_dir, i);
+        snprintf(new_path, sizeof(new_path), "%s/r%04d", dst_dir, i);
+        if (rename(old_path, new_path) != 0) {
+            return fail_errno("rename into dst", old_path);
+        }
+    }
+
+    if (rmdir(src_dir) != 0) {
+        return fail_errno("rmdir emptied src", src_dir);
+    }
+    if (remove_by_batched_getdents(dst_dir) != 0) {
+        return 1;
+    }
+    if (rmdir(dst_dir) != 0) {
+        return fail_errno("rmdir dst after renamed batched unlink", dst_dir);
+    }
+    printf("PASS: %s rename cookie remains unique after batched unlink\n", label);
+    return 0;
+}
+
+int main(void)
+{
+    char tmpfs_dir[96];
+    char rootfs_dir[96];
+    char tmpfs_src[96];
+    char tmpfs_dst[96];
+    char rootfs_src[96];
+    char rootfs_dst[96];
+    long pid = (long)getpid();
+
+    printf("=== bug-dir-cookie-unlink-rmdir ===\n");
+
+    snprintf(tmpfs_dir, sizeof(tmpfs_dir), "/tmp/bug_dir_cookie_tmpfs_%ld", pid);
+    snprintf(rootfs_dir, sizeof(rootfs_dir), "/root/bug_dir_cookie_ext4_%ld", pid);
+    snprintf(tmpfs_src, sizeof(tmpfs_src), "/tmp/bug_dir_cookie_rename_src_%ld", pid);
+    snprintf(tmpfs_dst, sizeof(tmpfs_dst), "/tmp/bug_dir_cookie_rename_dst_%ld", pid);
+    snprintf(rootfs_src, sizeof(rootfs_src), "/root/bug_dir_cookie_rename_src_%ld", pid);
+    snprintf(rootfs_dst, sizeof(rootfs_dst), "/root/bug_dir_cookie_rename_dst_%ld", pid);
+
+    if (run_case("tmpfs", tmpfs_dir) != 0) {
+        return 1;
+    }
+    if (run_case("rootfs", rootfs_dir) != 0) {
+        return 1;
+    }
+    if (run_rename_case("tmpfs", tmpfs_src, tmpfs_dst) != 0) {
+        return 1;
+    }
+    if (run_rename_case("rootfs", rootfs_src, rootfs_dst) != 0) {
+        return 1;
+    }
+
+    printf("STARRY_GROUPED_TEST_PASSED: bug-dir-cookie-unlink-rmdir\n");
+    return 0;
+}


### PR DESCRIPTION
## 问题

StarryOS tmpfs 的 `read_dir` 之前把 `getdents64` 的 offset 当作当前 `HashMap` 枚举下标使用。用户态工具会读取一批目录项、删除这些项、再用上一批返回的 `d_off` 继续读取；如果目录项在两次读取之间被删除，下标会重新压缩，后续 live entries 可能被跳过，最终表现为 `rm -rf` / batched unlink 后 `rmdir` 仍返回 `ENOTEMPTY`。

## 修复

- 给每个 tmpfs 目录维护单调递增的 per-directory cookie。
- `.` / `..` 固定使用 cookie 1/2，普通目录项从 3 开始分配。
- `read_dir` 按 cookie 过滤和排序，并返回 `cookie + 1` 作为下一次 offset。
- rename 到目标目录时重新分配目标目录 cookie，避免目标目录内 cookie 冲突。

## 为什么范围只在 tmpfs

当前 `dev` 里的 rsext4/ext4 `read_dir` 已经使用目录项 byte offset 作为 cookie，并且仍保留 `sync_to_disk()` 持久化边界。本 PR 不修改 ext4/rsext4 的写回语义。

## 测试

- `cargo fmt --check`
- `git diff --check`
- 新增 `bugfix-bug-dir-cookie-unlink-rmdir` system 回归测试，覆盖边 `getdents64` 边删除以及 rename 后批量删除。

补充：本地尝试过 `cargo check -p starry-kernel`，但当前 host-target 检查在 baseline 的 `ax-percpu` 符号宏处失败，未到达本 PR 修改的 tmpfs 代码路径。
