### PR TITLE
fix(starry): prepopulate cold user pages before copy

### DIFF
--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -100,9 +100,9 @@ fn check_null_terminated<T: PartialEq + Default>(
             // it below.
             let ptr = unsafe { start.add(len) };
             while ptr as usize >= page.as_ptr() as usize {
-                // We cannot prepare `aspace` outside of the loop, since holding
-                // aspace requires a mutex which would be required on page
-                // fault, and page faults can trigger inside the loop.
+                // Prepare only the page containing the next byte so the
+                // volatile read below does not fault while the aspace lock is
+                // not held.
 
                 // TODO: this is inefficient, but we have to do this instead of
                 // querying the page table since the page might has not been
@@ -121,15 +121,15 @@ fn check_null_terminated<T: PartialEq + Default>(
                 if unsafe { aspace_arc.raw() }.is_owned_by_current() {
                     return Err(AxError::BadAddress);
                 }
-                let aspace = aspace_arc.lock();
+                let mut aspace = aspace_arc.lock();
                 if !aspace.can_access_range(page, PAGE_SIZE_4K, access_flags) {
                     return Err(AxError::BadAddress);
                 }
+                aspace.populate_area(page, PAGE_SIZE_4K, access_flags)?;
 
                 page += PAGE_SIZE_4K;
             }
 
-            // This might trigger a page fault
             // SAFETY: The pointer is valid and points to a valid memory region.
             if unsafe { ptr.read_volatile() } == zero {
                 break;
@@ -400,6 +400,40 @@ fn ensure_thread_context(op: &str, start: usize, len: usize) -> VmResult {
     }
 }
 
+fn prepare_user_memory(
+    op: &str,
+    start: usize,
+    len: usize,
+    access_flags: MappingFlags,
+) -> VmResult {
+    check_access(start, len)?;
+    if len == 0 {
+        return Ok(());
+    }
+    ensure_thread_context(op, start, len)?;
+
+    let start = VirtAddr::from(start);
+    let end = start + len;
+    let page_start = start.align_down_4k();
+    let page_end = end.align_up_4k();
+
+    let curr = current();
+    let thr = curr.try_as_thread().ok_or(VmError::AccessDenied)?;
+    let aspace_arc = thr.proc_data.aspace();
+    if unsafe { aspace_arc.raw() }.is_owned_by_current() {
+        return Err(VmError::AccessDenied);
+    }
+
+    let mut aspace = aspace_arc.lock();
+    if !aspace.can_access_range(start, len, access_flags) {
+        return Err(VmError::AccessDenied);
+    }
+
+    aspace
+        .populate_area(page_start, page_end - page_start, access_flags)
+        .map_err(|_| VmError::AccessDenied)
+}
+
 #[extern_trait]
 unsafe impl VmIo for Vm {
     fn new() -> Self {
@@ -410,8 +444,7 @@ unsafe impl VmIo for Vm {
         if buf.is_empty() {
             return Ok(());
         }
-        check_access(start, buf.len())?;
-        ensure_thread_context("read", start, buf.len())?;
+        prepare_user_memory("read", start, buf.len(), MappingFlags::READ)?;
         let failed_at = access_user_memory(|| unsafe {
             user_copy(buf.as_mut_ptr() as *mut _, start as _, buf.len())
         });
@@ -426,8 +459,7 @@ unsafe impl VmIo for Vm {
         if buf.is_empty() {
             return Ok(());
         }
-        check_access(start, buf.len())?;
-        ensure_thread_context("write", start, buf.len())?;
+        prepare_user_memory("write", start, buf.len(), MappingFlags::WRITE)?;
         let failed_at = access_user_memory(|| unsafe {
             user_copy(start as _, buf.as_ptr() as *const _, buf.len())
         });

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -400,12 +400,7 @@ fn ensure_thread_context(op: &str, start: usize, len: usize) -> VmResult {
     }
 }
 
-fn prepare_user_memory(
-    op: &str,
-    start: usize,
-    len: usize,
-    access_flags: MappingFlags,
-) -> VmResult {
+fn prepare_user_memory(op: &str, start: usize, len: usize, access_flags: MappingFlags) -> VmResult {
     check_access(start, len)?;
     if len == 0 {
         return Ok(());

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-usercopy-cold-page/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-usercopy-cold-page/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-usercopy-cold-page C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-usercopy-cold-page src/main.c)
+target_compile_options(bug-usercopy-cold-page PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bug-usercopy-cold-page RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-usercopy-cold-page/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-usercopy-cold-page/src/main.c
@@ -91,12 +91,39 @@ static void expect_read_into_cold_page(void)
     munmap(buf, 4096);
 }
 
+static void expect_empty_path_from_cold_page(void)
+{
+    char *path = cold_page();
+    if (path == NULL) {
+        note_fail("mmap cold empty path page", strerror(errno));
+        return;
+    }
+
+    errno = 0;
+    int fd = open(path, O_RDONLY);
+    if (fd < 0 && errno == ENOENT) {
+        note_pass("open reads empty path from untouched anonymous page");
+    } else {
+        char detail[192];
+        snprintf(detail, sizeof(detail),
+                 "fd=%d errno=%d (%s), expected ENOENT",
+                 fd, errno, strerror(errno));
+        note_fail("open cold empty path", detail);
+        if (fd >= 0) {
+            close(fd);
+        }
+    }
+
+    munmap(path, 4096);
+}
+
 int main(void)
 {
     printf("=== bug-usercopy-cold-page ===\n");
 
     expect_getcwd_into_cold_page();
     expect_read_into_cold_page();
+    expect_empty_path_from_cold_page();
 
     printf("=== Results: %d passed, %d failed ===\n", passed, failed);
     if (failed == 0) {

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-usercopy-cold-page/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-usercopy-cold-page/src/main.c
@@ -1,0 +1,109 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static void *cold_page(void)
+{
+    void *ptr = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (ptr == MAP_FAILED) {
+        return NULL;
+    }
+    return ptr;
+}
+
+static void expect_getcwd_into_cold_page(void)
+{
+    char *buf = cold_page();
+    if (buf == NULL) {
+        note_fail("mmap cold getcwd page", strerror(errno));
+        return;
+    }
+
+    if (chdir("/tmp") != 0) {
+        note_fail("chdir /tmp", strerror(errno));
+        munmap(buf, 4096);
+        return;
+    }
+
+    errno = 0;
+    char *ret = getcwd(buf, 4096);
+    if (ret == buf && strcmp(buf, "/tmp") == 0) {
+        note_pass("getcwd writes to untouched anonymous page");
+    } else {
+        char detail[192];
+        snprintf(detail, sizeof(detail),
+                 "ret=%p errno=%d (%s) buf='%s'",
+                 (void *)ret, errno, strerror(errno), ret != NULL ? buf : "");
+        note_fail("getcwd cold page", detail);
+    }
+
+    munmap(buf, 4096);
+}
+
+static void expect_read_into_cold_page(void)
+{
+    char *buf = cold_page();
+    if (buf == NULL) {
+        note_fail("mmap cold read page", strerror(errno));
+        return;
+    }
+
+    int fd = open("/dev/zero", O_RDONLY);
+    if (fd < 0) {
+        note_fail("open /dev/zero", strerror(errno));
+        munmap(buf, 4096);
+        return;
+    }
+
+    errno = 0;
+    ssize_t nread = read(fd, buf, 128);
+    if (nread == 128 && buf[0] == 0 && buf[127] == 0) {
+        note_pass("read writes to untouched anonymous page");
+    } else {
+        char detail[192];
+        snprintf(detail, sizeof(detail),
+                 "nread=%zd errno=%d (%s) first=%d last=%d",
+                 nread, errno, strerror(errno), buf[0], buf[127]);
+        note_fail("read cold page", detail);
+    }
+
+    close(fd);
+    munmap(buf, 4096);
+}
+
+int main(void)
+{
+    printf("=== bug-usercopy-cold-page ===\n");
+
+    expect_getcwd_into_cold_page();
+    expect_read_into_cold_page();
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+
+    printf("SOME TESTS FAILED\n");
+    return 1;
+}


### PR DESCRIPTION
## 问题

部分 syscall 会把用户提供的冷匿名页作为输入/输出 buffer，例如：

- `read(fd, cold_page, len)` 写入还未实际分配物理页的匿名映射；
- `getcwd(cold_page, len)` 向冷页写字符串；
- `open(cold_page, ...)` 从冷页读取空字符串路径。

原路径只做了地址范围检查，随后在 `user_copy` 或 volatile string read 中触发页错误。这样容易把 fault 处理推迟到不合适的位置，表现为错误的 `EFAULT` 或内核页错误路径风险。

## 修复

- 在 `VmIo::read/write` 前新增 `prepare_user_memory`，按实际读写方向检查并 populate 覆盖页。
- 对 null-terminated user string 检查，在逐页扫描前 populate 当前页，避免读取冷页时才 fault。
- 保留已有的非线程上下文和 aspace lock 自持有保护。

## 测试

- `cargo fmt --check`
- `git diff --check`
- `cc -std=gnu11 -Wall -Wextra -Werror -fsyntax-only test-suit/starryos/qemu-smp1/system/bugfix-bug-usercopy-cold-page/src/main.c`
- 新增 `bugfix-bug-usercopy-cold-page` system 回归测试，覆盖 `getcwd`、`read /dev/zero`、`open` 访问 untouched anonymous page。
