### PR TITLE
fix(axcpu): preserve AVX state across x86_64 context switch (XSAVE)

### DIFF
--- a/components/axcpu/src/x86_64/context.rs
+++ b/components/axcpu/src/x86_64/context.rs
@@ -157,6 +157,9 @@ struct ContextSwitchFrame {
 /// A 512-byte memory region for the FXSAVE/FXRSTOR instruction to save and
 /// restore the x87 FPU, MMX, XMM, and MXCSR registers.
 ///
+/// This is also the legacy region (offset 0..512) at the head of the
+/// XSAVE/XRSTOR area, so it doubles as the start of [`XsaveArea`].
+///
 /// See <https://www.felixcloutier.com/x86/fxsave> for more details.
 #[allow(missing_docs)]
 #[repr(C, align(16))]
@@ -177,40 +180,121 @@ pub struct FxsaveArea {
 
 const _: () = assert!(core::mem::size_of::<FxsaveArea>() == 512);
 
+/// Size of the per-task XSAVE/XRSTOR area, in bytes.
+///
+/// The boot path ([`enable_xsave_features`]) only ever enables the x87, SSE,
+/// and AVX components in `XCR0` (it never enables AVX-512, MPX, or PKRU), so the
+/// largest XSAVE layout we must hold is the 512-byte legacy region, the 64-byte
+/// XSAVE header, and the 256-byte AVX (`YMM_Hi128`) component. 1024 bytes covers
+/// that with headroom and is a multiple of the required 64-byte alignment.
+///
+/// [`enable_xsave_features`]: ../../../someboot/src/arch/x86_64/trap.rs
+const XSAVE_AREA_SIZE: usize = 1024;
+
+/// A 64-byte-aligned memory region for the XSAVE/XRSTOR instructions, which save
+/// and restore the full `XCR0`-enabled extended state (x87, SSE/XMM, and the
+/// upper 128 bits of the AVX `YMM` registers that FXSAVE/FXRSTOR drop).
+///
+/// The first 512 bytes share the legacy [`FxsaveArea`] layout, so the FXSAVE
+/// fallback path (CPUs/VMs without XSAVE, e.g. the default `qemu64` model) reads
+/// and writes the same region.
+///
+/// See <https://www.felixcloutier.com/x86/xsave> for more details.
+#[repr(C, align(64))]
+struct XsaveArea {
+    /// Legacy region, identical in layout to the FXSAVE/FXRSTOR area.
+    legacy: FxsaveArea,
+    /// XSAVE header (`XSTATE_BV`, `XCOMP_BV`, reserved) plus the extended
+    /// component area. A zeroed header marks every component as being in its
+    /// initial state, which is the correct starting point for a fresh task.
+    rest: [u8; XSAVE_AREA_SIZE - 512],
+}
+
+const _: () = assert!(core::mem::size_of::<XsaveArea>() == XSAVE_AREA_SIZE);
+
 /// Extended state of a task, such as FP/SIMD states.
+///
+/// On context switch the state is saved/restored with XSAVE/XRSTOR when the boot
+/// path enabled `CR4.OSXSAVE` (so that the AVX `YMM` upper halves are preserved),
+/// and falls back to FXSAVE/FXRSTOR otherwise.
 pub struct ExtendedState {
-    /// Memory region for the FXSAVE/FXRSTOR instruction.
-    pub fxsave_area: FxsaveArea,
+    area: XsaveArea,
 }
 
 #[cfg(feature = "fp-simd")]
 impl ExtendedState {
+    /// Provides access to the legacy FXSAVE region for compatibility with code
+    /// that inspects the x87/SSE state directly.
+    #[inline]
+    pub fn fxsave_area(&self) -> &FxsaveArea {
+        &self.area.legacy
+    }
+
+    /// Returns `true` when the boot path enabled XSAVE state management
+    /// (`CR4.OSXSAVE`), which is the single source of truth for whether
+    /// XSAVE/XRSTOR (and reading `XCR0` via `XGETBV`) are safe to use.
+    #[inline]
+    fn xsave_enabled() -> bool {
+        // SAFETY: reading CR4 from ring 0 is always well-defined.
+        let cr4 = unsafe { x86::controlregs::cr4() };
+        cr4.contains(x86::controlregs::Cr4::CR4_ENABLE_OS_XSAVE)
+    }
+
+    /// The set of state components to save/restore, i.e. the `XCR0` mask the
+    /// boot path programmed. Only valid to call when [`Self::xsave_enabled`].
+    #[inline]
+    fn xsave_mask() -> u64 {
+        // SAFETY: `CR4.OSXSAVE` is set (checked by the caller), so XGETBV is
+        // well-defined and will not #UD.
+        unsafe { x86::controlregs::xcr0().bits() }
+    }
+
     /// Saves the current extended states from CPU to this structure.
     #[inline]
     pub fn save(&mut self) {
-        unsafe { core::arch::x86_64::_fxsave64(&mut self.fxsave_area as *mut _ as *mut u8) }
+        let ptr = &mut self.area as *mut _ as *mut u8;
+        if Self::xsave_enabled() {
+            // SAFETY: `area` is 64-byte aligned and large enough for the
+            // XCR0-enabled state (x87/SSE/AVX); the mask matches XCR0.
+            unsafe { core::arch::x86_64::_xsave64(ptr, Self::xsave_mask()) }
+        } else {
+            // SAFETY: `area` starts with the 16-byte-aligned legacy FXSAVE region.
+            unsafe { core::arch::x86_64::_fxsave64(ptr) }
+        }
     }
 
     /// Restores the extended states from this structure to CPU.
     #[inline]
     pub fn restore(&self) {
-        unsafe { core::arch::x86_64::_fxrstor64(&self.fxsave_area as *const _ as *const u8) }
+        let ptr = &self.area as *const _ as *const u8;
+        if Self::xsave_enabled() {
+            // SAFETY: `area` was populated by `_xsave64` (or zero-initialized,
+            // which XRSTOR reads as the components' initial state) with a header
+            // consistent with the XCR0 mask used here.
+            unsafe { core::arch::x86_64::_xrstor64(ptr, Self::xsave_mask()) }
+        } else {
+            // SAFETY: `area` starts with the 16-byte-aligned legacy FXSAVE region.
+            unsafe { core::arch::x86_64::_fxrstor64(ptr) }
+        }
     }
 
     /// Returns the extended state with initialized values.
     pub const fn default() -> Self {
-        let mut area: FxsaveArea = unsafe { core::mem::MaybeUninit::zeroed().assume_init() };
-        area.fcw = 0x37f;
-        area.ftw = 0xffff;
-        area.mxcsr = 0x1f80;
-        Self { fxsave_area: area }
+        // Zeroing the whole area gives XRSTOR an all-initial XSAVE header
+        // (XSTATE_BV = 0) so the first restore loads each component's default
+        // state; the legacy fields below seed the FXSAVE fallback path too.
+        let mut area: XsaveArea = unsafe { core::mem::MaybeUninit::zeroed().assume_init() };
+        area.legacy.fcw = 0x37f;
+        area.legacy.ftw = 0xffff;
+        area.legacy.mxcsr = 0x1f80;
+        Self { area }
     }
 }
 
 impl fmt::Debug for ExtendedState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("ExtendedState")
-            .field("fxsave_area", &self.fxsave_area)
+            .field("fxsave_area", &self.area.legacy)
             .finish()
     }
 }

--- a/test-suit/starryos/qemu-smp1/system/test-x86-avx-ctxsw/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/test-x86-avx-ctxsw/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-x86-avx-ctxsw C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-x86-avx-ctxsw src/main.c)
+target_include_directories(test-x86-avx-ctxsw PRIVATE src)
+target_compile_options(test-x86-avx-ctxsw PRIVATE -Wall -Wextra -pthread)
+target_link_options(test-x86-avx-ctxsw PRIVATE -pthread)
+
+# The inline asm names ymm registers; allow AVX codegen on x86_64 so the YMM
+# clobbers are accepted. Other architectures compile the skip path.
+if(CMAKE_C_COMPILER_TARGET MATCHES "x86_64")
+    target_compile_options(test-x86-avx-ctxsw PRIVATE -mavx)
+endif()
+
+install(TARGETS test-x86-avx-ctxsw RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/test-x86-avx-ctxsw/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-x86-avx-ctxsw/src/main.c
@@ -1,0 +1,208 @@
+/*
+ * test_x86_avx_ctxsw.c — AVX YMM upper-128 state must survive context switches.
+ *
+ * The x86_64 boot path enables XCR0.AVX, so userspace freely uses the 256-bit
+ * YMM registers. The kernel therefore has to save/restore the *full* extended
+ * state on every task switch. FXSAVE/FXRSTOR only cover x87 + SSE (the low 128
+ * bits, XMM); they silently drop the upper 128 bits of each YMM. If the kernel
+ * uses FXSAVE-only context switching while XCR0.AVX is on, the YMM upper halves
+ * get corrupted whenever a thread is descheduled and rescheduled — which crashes
+ * every AVX-using program (e.g. the JVM) with SIGSEGV in user code. The fix
+ * switches the context-switch save/restore to XSAVE/XRSTOR with the live XCR0
+ * mask (gated on CR4.OSXSAVE, FXSAVE fallback otherwise).
+ *
+ * This test loads a known sentinel into the UPPER 128 bits of a YMM register and
+ * keeps that value LIVE across many forced context switches (sched_yield in a
+ * tight loop while busy sibling threads also clobber YMM with their own
+ * patterns), then verifies the upper half is intact. To keep the value live
+ * across the kernel boundary it never leaves an inline-asm block: the AVX ABI
+ * mandates `vzeroupper` before ordinary calls, and any libc/syscall wrapper would
+ * clobber YMM, so the yields are issued as raw inline `syscall`s inside the same
+ * asm region that holds the sentinel.
+ *
+ * On the FXSAVE-only baseline this FAILs (upper half comes back corrupted); with
+ * the XSAVE fix it PASSes. CPUID-gated: runs the AVX path only when the CPU
+ * advertises XSAVE + AVX (the system group's qemu-x86_64.toml uses
+ * -cpu Haswell,+avx) and skips cleanly otherwise. x86-only; other arches skip.
+ */
+
+#include "test_framework.h"
+
+#if defined(__x86_64__)
+
+#include <cpuid.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+
+/* Number of sibling threads that continuously clobber YMM with their own
+ * patterns, maximizing the chance the scheduler swaps the main thread out while
+ * its sentinel is live. */
+#define NOISE_THREADS 4
+
+/* Number of forced context switches the main thread drives while holding the
+ * sentinel live. Large enough to span many scheduler ticks. */
+#define YIELD_ROUNDS 20000
+
+static atomic_int stop_noise = 0;
+
+/* Each sibling thread spins, repeatedly broadcasting a distinct 256-bit pattern
+ * into *every* YMM register (ymm0..ymm15) and yielding, so that whenever it runs
+ * it overwrites the upper 128 bits of the same register the main thread holds its
+ * sentinel in. If the kernel restores the main thread's full YMM state correctly,
+ * this noise is harmless; if it only restores the low 128 bits (FXSAVE/FXRSTOR),
+ * the main thread will read back this noise pattern in its sentinel's upper half.
+ * Dirtying all 16 registers is what makes the FXSAVE-only regression observable
+ * regardless of which YMM register the sentinel lives in. */
+static void *noise_thread(void *arg)
+{
+    uint64_t seed = (uint64_t)(uintptr_t)arg * 0x9E3779B97F4A7C15ULL;
+    /* A 32-byte pattern; its upper 128 bits differ from the main sentinel. */
+    uint64_t pat[4] = {seed ^ 0x1111111111111111ULL, seed ^ 0x2222222222222222ULL,
+                       seed ^ 0x5555555555555555ULL, seed ^ 0x6666666666666666ULL};
+    while (!atomic_load_explicit(&stop_noise, memory_order_relaxed)) {
+        __asm__ volatile(
+            "vmovdqu (%0), %%ymm0\n\t"
+            "vmovdqa %%ymm0, %%ymm1\n\t"
+            "vmovdqa %%ymm0, %%ymm2\n\t"
+            "vmovdqa %%ymm0, %%ymm3\n\t"
+            "vmovdqa %%ymm0, %%ymm4\n\t"
+            "vmovdqa %%ymm0, %%ymm5\n\t"
+            "vmovdqa %%ymm0, %%ymm6\n\t"
+            "vmovdqa %%ymm0, %%ymm7\n\t"
+            "vmovdqa %%ymm0, %%ymm8\n\t"
+            "vmovdqa %%ymm0, %%ymm9\n\t"
+            "vmovdqa %%ymm0, %%ymm10\n\t"
+            "vmovdqa %%ymm0, %%ymm11\n\t"
+            "vmovdqa %%ymm0, %%ymm12\n\t"
+            "vmovdqa %%ymm0, %%ymm13\n\t"
+            "vmovdqa %%ymm0, %%ymm14\n\t"
+            "vmovdqa %%ymm0, %%ymm15\n\t"
+            :
+            : "r"(pat)
+            : "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6", "ymm7",
+              "ymm8", "ymm9", "ymm10", "ymm11", "ymm12", "ymm13", "ymm14",
+              "ymm15", "memory");
+        __asm__ volatile("syscall"
+                         :
+                         : "a"(SYS_sched_yield)
+                         : "rcx", "r11", "memory");
+    }
+    return NULL;
+}
+
+/*
+ * Hold a sentinel live in ymm15's UPPER 128 bits across YIELD_ROUNDS context
+ * switches, then store ymm15 out for inspection. The whole sequence — load,
+ * yields, store — stays inside one asm block so the compiler never spills,
+ * clobbers, or `vzeroupper`s the live YMM value, and the yields are raw inline
+ * `syscall`s so no libc wrapper touches YMM.
+ *
+ * `out` receives the 32 bytes of ymm15 after the yields. We seed ymm15 from a
+ * 32-byte source whose UPPER 128 bits carry the sentinel and whose LOWER 128
+ * bits carry an unrelated value, so we can distinguish "upper half preserved"
+ * from "whole register zeroed/garbage".
+ */
+static void hold_ymm_across_switches(const uint64_t src[4], uint64_t out[4],
+                                     long rounds)
+{
+    register long r __asm__("rbx") =
+        rounds; /* callee-saved: survives the syscalls */
+    __asm__ volatile(
+        "vmovdqu (%[src]), %%ymm15\n\t" /* ymm15 = sentinel (upper) + low */
+        "1:\n\t"
+        "mov %[ynr], %%eax\n\t" /* sched_yield, live ymm15 across it */
+        "syscall\n\t"
+        "dec %[rounds]\n\t"
+        "jnz 1b\n\t"
+        "vmovdqu %%ymm15, (%[out])\n\t" /* read back ymm15 after the switches */
+        : [rounds] "+r"(r)
+        : [src] "r"(src), [out] "r"(out), [ynr] "i"(SYS_sched_yield)
+        : "rax", "rcx", "r11", "ymm15", "memory");
+}
+
+int main(void)
+{
+    TEST_START("AVX YMM upper-128 survives context switch (XSAVE)");
+
+    unsigned int eax, ebx, ecx, edx;
+    if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
+        CHECK(1, "CPUID leaf 1 unavailable: AVX context-switch test skipped");
+        TEST_DONE();
+    }
+    int has_xsave = (ecx >> 26) & 1;
+    int has_osxsave = (ecx >> 27) & 1;
+    int has_avx = (ecx >> 28) & 1;
+    if (!has_xsave || !has_avx) {
+        /* No XSAVE/AVX (e.g. default qemu64): the kernel correctly leaves XCR0
+         * off and userspace must not use YMM, so there is nothing to preserve. */
+        CHECK(1, "CPU has no XSAVE/AVX: AVX context-switch test skipped");
+        TEST_DONE();
+    }
+
+    /* OSXSAVE reflects CR4.OSXSAVE, the precondition for the kernel to use
+     * XSAVE/XRSTOR on context switch at all. */
+    CHECK(has_osxsave, "CR4.OSXSAVE enabled by kernel (XSAVE-based ctxsw possible)");
+
+    /* Start sibling threads that keep dirtying YMM with their own patterns. */
+    pthread_t noise[NOISE_THREADS];
+    int spawned = 0;
+    for (int i = 0; i < NOISE_THREADS; i++) {
+        if (pthread_create(&noise[i], NULL, noise_thread,
+                           (void *)(uintptr_t)(i + 1)) == 0) {
+            spawned++;
+        }
+    }
+    CHECK(spawned > 0, "spawned at least one YMM-clobbering sibling thread");
+
+    /*
+     * Sentinel: upper 128 bits are a recognizable non-zero pattern, lower 128
+     * bits are a different recognizable pattern. FXSAVE preserves the lower half
+     * but drops the upper half, so a buggy kernel returns the correct low 128
+     * bits with a corrupted (zeroed or sibling-pattern) upper 128 bits — a clear,
+     * unambiguous signature of the FXSAVE-only regression.
+     */
+    static const uint64_t sentinel[4] = {
+        0x0F1E2D3C4B5A6978ULL, /* low[0] */
+        0x8796A5B4C3D2E1F0ULL, /* low[1] */
+        0xCAFEBABEDEADBEEFULL, /* high[0] — upper 128 bits */
+        0x0123456789ABCDEFULL, /* high[1] — upper 128 bits */
+    };
+    uint64_t result[4] = {0, 0, 0, 0};
+
+    hold_ymm_across_switches(sentinel, result, YIELD_ROUNDS);
+
+    atomic_store_explicit(&stop_noise, 1, memory_order_relaxed);
+    for (int i = 0; i < spawned; i++) {
+        pthread_join(noise[i], NULL);
+    }
+
+    /* Sanity: the low 128 bits (the FXSAVE-covered part) must always survive. */
+    CHECK(result[0] == sentinel[0] && result[1] == sentinel[1],
+          "YMM lower 128 bits preserved across context switches");
+
+    /* The crux: the upper 128 bits must survive too. This is what FXSAVE-only
+     * context switching corrupts and what the XSAVE fix preserves. */
+    int upper_ok = (result[2] == sentinel[2] && result[3] == sentinel[3]);
+    if (!upper_ok) {
+        printf("  upper-128 expected %016llx %016llx, got %016llx %016llx\n",
+               (unsigned long long)sentinel[2], (unsigned long long)sentinel[3],
+               (unsigned long long)result[2], (unsigned long long)result[3]);
+    }
+    CHECK(upper_ok,
+          "YMM upper 128 bits preserved across context switches (XSAVE fix)");
+
+    TEST_DONE();
+}
+
+#else /* !__x86_64__ */
+
+int main(void)
+{
+    TEST_START("AVX YMM upper-128 survives context switch (XSAVE)");
+    CHECK(1, "non-x86_64: AVX context-switch test skipped");
+    TEST_DONE();
+}
+
+#endif

--- a/test-suit/starryos/qemu-smp1/system/test-x86-avx-ctxsw/src/test_framework.h
+++ b/test-suit/starryos/qemu-smp1/system/test-x86-avx-ctxsw/src/test_framework.h
@@ -1,0 +1,85 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                      \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",         \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno, strerror(errno));\
+        __fail++;                                                       \
+    }                                                                   \
+} while(0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);              \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
## 背景与问题

x86_64 的任务上下文在切换时用 FXSAVE/FXRSTOR 保存/恢复 FP/SIMD 状态，而 FXSAVE 只覆盖 x87 与 SSE（即 XMM，YMM 的低 128 位）。每 CPU 的启动路径（someboot 的 `enable_xsave_features`）会按 CPUID 开启 `CR4.OSXSAVE` 并把 AVX 加入 `XCR0`，因此用户态可以自由使用 256 位的 YMM 寄存器。

这样就出现了不一致：内核开启了 AVX 状态，却只用 FXSAVE 保存上下文。FXSAVE 不保存任何 YMM 的高 128 位，FXRSTOR 也不恢复它们，于是只要一个线程被换出再换回，它的 YMM 高 128 位就会被其他线程留下的内容污染。任何重度使用 AVX 的程序（例如 JVM）都会因此在用户态读到被破坏的 YMM 值，进而 SIGSEGV 崩溃。

## 修复

将上下文切换的保存/恢复改为 XSAVE/XRSTOR，使用启动路径实际写入的 `XCR0` 作为状态掩码（通过 XGETBV 读取），从而精确覆盖被启用的 x87/SSE/AVX 状态，是 FXSAVE 覆盖范围的超集。

- 仅在 `CR4.OSXSAVE` 置位时走 XSAVE/XRSTOR 路径；该位是“XSAVE 是否可安全使用”的唯一判据。
- 对没有 XSAVE 的 CPU/虚拟机型号（如默认的 `qemu64`）保留 FXSAVE/FXRSTOR 回退路径，其读写的正是 XSAVE 区头部 512 字节的 legacy 区域，布局与 FXSAVE 区一致。
- XSAVE 区域 64 字节对齐并零初始化，使 XRSTOR 读到一个全初始态的 XSAVE 头部，作为新任务的正确起点。

影响文件：`components/axcpu/src/x86_64/context.rs`。

## 回归测试

新增 `test-suit/starryos/qemu-smp1/system/test-x86-avx-ctxsw`，作为 `qemu-smp1/system` 分组下的 C 子测例，产物安装到 `usr/bin/starry-test-suit`，由分组 runner 在 `cargo xtask starry test qemu --arch x86_64` 中发现并执行。

测试逻辑：

- 把一个已知 sentinel 写入某个 YMM 寄存器的高 128 位，并在一段紧凑循环里持续 `sched_yield` 触发大量上下文切换，期间让多个兄弟线程不断把自己的 pattern 广播写满全部 16 个 YMM 寄存器（覆盖同一寄存器的高 128 位）。
- 整个“载入 sentinel → 多次 yield → 读回”过程都留在同一个内联汇编块里，yield 以原始内联 `syscall` 发起，从而规避 AVX ABI 在普通调用前插入 `vzeroupper` 以及 libc 包装函数破坏 YMM 的问题，确保 sentinel 在切换间始终存活。
- 切换结束后分别校验 YMM 低 128 位与高 128 位是否完好。
- 通过 CPUID 门控：只有在 CPU 同时支持 XSAVE 与 AVX 时才走 AVX 校验（分组配置使用 `-cpu Haswell,+avx`），否则打印 skip 标记并通过；非 x86 架构也直接 skip。

该测试是真正的回归守卫：

- 在 FXSAVE-only 基线上 **失败**——低 128 位完好，但高 128 位读回的是兄弟线程的 pattern 而非 sentinel（`expected cafebabedeadbeef 0123456789abcdef, got 2d88b3b0a87ca501 1ebb80839b4f9632`），子测例返回非零，分组 runner 输出 `STARRY_GROUPED_TEST_FAILED` 被 `fail_regex` 命中。
- 应用本修复后 **通过**——4/4 断言全过，输出 `STARRY_GROUPED_TESTS_PASSED` 命中 `success_regex`。
