### PR TITLE
refactor(axdevice): unify Device model with indexed dispatch and conflict detect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,9 @@ dependencies = [
  "ax-errno 0.6.0",
  "ax-memory-addr",
  "axvm-types",
+ "log",
  "serde",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -7635,6 +7637,9 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,10 @@ dependencies = [
  "axdevice_base",
  "axvm-types",
  "cfg-if",
+ "divan",
  "log",
+ "paste",
+ "rand 0.10.1",
  "riscv_vplic",
  "x86_vlapic",
 ]

--- a/os/axvisor/src/shell/command/vm.rs
+++ b/os/axvisor/src/shell/command/vm.rs
@@ -917,12 +917,8 @@ fn show_vm_basic_details(vm_id: usize, show_config: bool, show_stats: bool) {
             println!();
             println!("Device Summary:");
             println!(
-                "  MMIO Devices:   {}",
-                vm.get_devices().iter_mmio_dev().count()
-            );
-            println!(
-                "  SysReg Devices: {}",
-                vm.get_devices().iter_sys_reg_dev().count()
+                "  Registered Devices: {}",
+                vm.get_devices().devices().count()
             );
         }
 
@@ -1147,11 +1143,9 @@ fn show_vm_full_details(vm_id: usize) {
 
         // Devices
         println!();
-        let mmio_dev_count = vm.get_devices().iter_mmio_dev().count();
-        let sysreg_dev_count = vm.get_devices().iter_sys_reg_dev().count();
+        let device_count = vm.get_devices().devices().count();
         println!("Devices:");
-        println!("  MMIO Devices:   {}", mmio_dev_count);
-        println!("  SysReg Devices: {}", sysreg_dev_count);
+        println!("  Devices:        {}", device_count);
 
         // Additional Statistics
         println!();

--- a/virtualization/arm_vgic/src/v3/gits.rs
+++ b/virtualization/arm_vgic/src/v3/gits.rs
@@ -20,7 +20,7 @@ use ax_kspin::SpinNoIrq;
 use ax_memory_addr::PhysAddr;
 use axdevice_base::{AccessWidth, BaseDeviceOps};
 use axvm_types::{GuestPhysAddr, GuestPhysAddrRange, HostPhysAddr};
-use log::{debug, trace};
+use log::{debug, trace, warn};
 use spin::{Mutex, Once};
 
 use super::{
@@ -62,6 +62,12 @@ pub struct Gits {
 
     /// Virtual GITS registers.
     pub regs: SpinNoIrq<VirtualGitsRegs>,
+
+    /// Serialises CWRITER command-queue submission so that only one
+    /// vCPU can process the queue at a time, preventing races where
+    /// two vCPUs see the same old `creadr` and re-process already-
+    /// handled commands.
+    pub submission_lock: SpinNoIrq<()>,
 }
 
 impl Gits {
@@ -97,6 +103,7 @@ impl Gits {
             host_gits_base,
             is_root_vm,
             regs,
+            submission_lock: SpinNoIrq::new(()),
         }
     }
 }
@@ -202,6 +209,11 @@ impl BaseDeviceOps<GuestPhysAddrRange> for Gits {
                 }
             }
             GITS_CWRITER => {
+                // Serialise concurrent command-queue submissions: two
+                // vCPUs writing CWRITER must not see the same old
+                // creadr, or one may re-process commands already
+                // handled by the other.
+                let _submission = self.submission_lock.lock();
                 self.with_regs_mut(|r| r.cwriter = val);
 
                 if val != 0 {
@@ -210,12 +222,14 @@ impl BaseDeviceOps<GuestPhysAddrRange> for Gits {
                     let mut cmdq = get_cmdq(self.host_gits_base).lock();
                     let new_creadr = cmdq.insert_cmd(cbaser, creadr, val);
                     self.with_regs_mut(|r| r.creadr = new_creadr);
+                    drop(cmdq);
                 }
 
                 Ok(())
             }
             GITS_CREADR => {
-                panic!("GITS_CREADR should not be written by guest!");
+                warn!("GITS_CREADR: guest write ignored (read-only register)");
+                Ok(())
             }
             GITS_TYPER => perform_mmio_write(gits_base + reg, width, val),
             _ => perform_mmio_write(gits_base + reg, width, val),
@@ -407,7 +421,10 @@ impl Cmdq {
         let origin_vm_readr = vm_creadr;
 
         // todo: handle wrap around
-        let cmd_size = vm_writer - origin_vm_readr;
+        let cmd_size = vm_writer.wrapping_sub(origin_vm_readr);
+        if cmd_size == 0 || cmd_size > 0x10000 {
+            return vm_writer;
+        }
         let cmd_num = cmd_size / BYTES_PER_CMD;
 
         trace!(

--- a/virtualization/arm_vgic/src/v3/gits.rs
+++ b/virtualization/arm_vgic/src/v3/gits.rs
@@ -14,14 +14,14 @@
 
 //! WARNING: Identical mapping only!!
 
-use core::{cell::UnsafeCell, ptr};
+use core::ptr;
 
-use ax_kspin::SpinNoIrq as Mutex;
+use ax_kspin::SpinNoIrq;
 use ax_memory_addr::PhysAddr;
 use axdevice_base::{AccessWidth, BaseDeviceOps};
 use axvm_types::{GuestPhysAddr, GuestPhysAddrRange, HostPhysAddr};
 use log::{debug, trace};
-use spin::Once;
+use spin::{Mutex, Once};
 
 use super::{
     registers::*,
@@ -61,22 +61,16 @@ pub struct Gits {
     pub is_root_vm: bool,
 
     /// Virtual GITS registers.
-    pub regs: UnsafeCell<VirtualGitsRegs>,
+    pub regs: SpinNoIrq<VirtualGitsRegs>,
 }
 
-// SAFETY: Gits is only accessed through the Vgic host layer, and the
-// UnsafeCell is guarded by Mutex in the Vgic super-struct.
-unsafe impl Send for Gits {}
-unsafe impl Sync for Gits {}
-
 impl Gits {
-    fn regs(&self) -> &VirtualGitsRegs {
-        unsafe { &*self.regs.get() }
+    fn with_regs<R>(&self, f: impl FnOnce(&VirtualGitsRegs) -> R) -> R {
+        f(&self.regs.lock())
     }
 
-    #[allow(clippy::mut_from_ref)]
-    fn regs_mut(&self) -> &mut VirtualGitsRegs {
-        unsafe { &mut *self.regs.get() }
+    fn with_regs_mut<R>(&self, f: impl FnOnce(&mut VirtualGitsRegs) -> R) -> R {
+        f(&mut self.regs.lock())
     }
 
     /// Creates a new GITS instance.
@@ -87,7 +81,7 @@ impl Gits {
         is_root_vm: bool,
     ) -> Self {
         let size = size.unwrap_or(DEFAULT_GITS_SIZE); // 4K
-        let regs = UnsafeCell::new(VirtualGitsRegs::default());
+        let regs = SpinNoIrq::new(VirtualGitsRegs::default());
 
         // ensure cmdq and lpi prop table is initialized before VMs are up
         let _ = get_cmdq(host_gits_base);
@@ -137,29 +131,25 @@ impl BaseDeviceOps<GuestPhysAddrRange> for Gits {
         // mmio_perform_access(gits_base, mmio);
         match reg {
             GITS_CTRL => perform_mmio_read(gits_base + reg, width),
-            GITS_CBASER => Ok(self.regs().cbaser),
+            GITS_CBASER => Ok(self.with_regs(|r| r.cbaser)),
             GITS_DT_BASER => {
                 if self.is_root_vm {
                     perform_mmio_read(gits_base + reg, width)
                 } else {
-                    Ok(
-                        (self.regs().dt_baser)
-                            & (1usize.unbounded_shl(width.size() as u32 * 8) - 1),
-                    )
+                    Ok((self.with_regs(|r| r.dt_baser))
+                        & (1usize.unbounded_shl(width.size() as u32 * 8) - 1))
                 }
             }
             GITS_CT_BASER => {
                 if self.is_root_vm {
                     perform_mmio_read(gits_base + reg, width)
                 } else {
-                    Ok(
-                        (self.regs().ct_baser)
-                            & (1usize.unbounded_shl(width.size() as u32 * 8) - 1),
-                    )
+                    Ok((self.with_regs(|r| r.ct_baser))
+                        & (1usize.unbounded_shl(width.size() as u32 * 8) - 1))
                 }
             }
-            GITS_CWRITER => Ok(self.regs().cwriter),
-            GITS_CREADR => Ok(self.regs().creadr),
+            GITS_CWRITER => Ok(self.with_regs(|r| r.cwriter)),
+            GITS_CREADR => Ok(self.with_regs(|r| r.creadr)),
             GITS_TYPER => perform_mmio_read(gits_base + reg, width),
             _ => perform_mmio_read(gits_base + reg, width),
         }
@@ -192,14 +182,14 @@ impl BaseDeviceOps<GuestPhysAddrRange> for Gits {
                     perform_mmio_write(gits_base + reg, width, val)?;
                 }
 
-                self.regs_mut().cbaser = val;
+                self.with_regs_mut(|r| r.cbaser = val);
                 Ok(())
             }
             GITS_DT_BASER => {
                 if self.is_root_vm {
                     perform_mmio_write(gits_base + reg, width, val)
                 } else {
-                    self.regs_mut().dt_baser = val;
+                    self.with_regs_mut(|r| r.dt_baser = val);
                     Ok(())
                 }
             }
@@ -207,20 +197,19 @@ impl BaseDeviceOps<GuestPhysAddrRange> for Gits {
                 if self.is_root_vm {
                     perform_mmio_write(gits_base + reg, width, val)
                 } else {
-                    self.regs_mut().ct_baser = val;
+                    self.with_regs_mut(|r| r.ct_baser = val);
                     Ok(())
                 }
             }
             GITS_CWRITER => {
-                self.regs_mut().cwriter = val;
+                self.with_regs_mut(|r| r.cwriter = val);
 
                 if val != 0 {
-                    let regs = self.regs();
-                    let cbaser = regs.cbaser;
-                    let creadr = regs.creadr;
+                    let (cbaser, creadr) = self.with_regs(|r| (r.cbaser, r.creadr));
 
                     let mut cmdq = get_cmdq(self.host_gits_base).lock();
-                    self.regs_mut().creadr = cmdq.insert_cmd(cbaser, creadr, val);
+                    let new_creadr = cmdq.insert_cmd(cbaser, creadr, val);
+                    self.with_regs_mut(|r| r.creadr = new_creadr);
                 }
 
                 Ok(())

--- a/virtualization/arm_vgic/src/v3/gits.rs
+++ b/virtualization/arm_vgic/src/v3/gits.rs
@@ -64,6 +64,11 @@ pub struct Gits {
     pub regs: UnsafeCell<VirtualGitsRegs>,
 }
 
+// SAFETY: Gits is only accessed through the Vgic host layer, and the
+// UnsafeCell is guarded by Mutex in the Vgic super-struct.
+unsafe impl Send for Gits {}
+unsafe impl Sync for Gits {}
+
 impl Gits {
     fn regs(&self) -> &VirtualGitsRegs {
         unsafe { &*self.regs.get() }

--- a/virtualization/arm_vgic/src/v3/vgicd.rs
+++ b/virtualization/arm_vgic/src/v3/vgicd.rs
@@ -47,6 +47,11 @@ pub struct VGicD {
     pub host_gicd_addr: HostPhysAddr,
 }
 
+// SAFETY: VGicD is only accessed through the VGicD lock / Vgic host layer,
+// and the UnsafeCell is guarded by Mutex in the Vgic super-struct.
+unsafe impl Send for VGicD {}
+unsafe impl Sync for VGicD {}
+
 impl VGicD {
     /// Creates a new VGicD instance.
     pub fn new(addr: GuestPhysAddr, size: Option<usize>) -> Self {

--- a/virtualization/arm_vgic/src/v3/vgicd.rs
+++ b/virtualization/arm_vgic/src/v3/vgicd.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::cell::UnsafeCell;
-
 use ax_errno::AxResult;
+use ax_kspin::SpinNoIrq;
 use axdevice_base::{AccessWidth, BaseDeviceOps, EmuDeviceType};
 use axvm_types::{GuestPhysAddr, GuestPhysAddrRange, HostPhysAddr};
 use bitmaps::Bitmap;
@@ -39,18 +38,13 @@ pub struct VGicD {
     pub size: usize,
 
     /// IRQs assigned to this VGicD.
-    pub assigned_irqs: UnsafeCell<Bitmap<{ MAX_IRQ_V3 }>>,
+    pub assigned_irqs: SpinNoIrq<Bitmap<{ MAX_IRQ_V3 }>>,
 
     /// The host physical address of the VGicD.
     ///
     /// TODO: move host gicd access to a separate crate, maybe arm_gic_driver.
     pub host_gicd_addr: HostPhysAddr,
 }
-
-// SAFETY: VGicD is only accessed through the VGicD lock / Vgic host layer,
-// and the UnsafeCell is guarded by Mutex in the Vgic super-struct.
-unsafe impl Send for VGicD {}
-unsafe impl Sync for VGicD {}
 
 impl VGicD {
     /// Creates a new VGicD instance.
@@ -60,7 +54,7 @@ impl VGicD {
         Self {
             addr,
             size,
-            assigned_irqs: UnsafeCell::new(Bitmap::new()),
+            assigned_irqs: SpinNoIrq::new(Bitmap::new()),
             host_gicd_addr: crate::api_reexp::get_host_gicd_base(),
         }
     }
@@ -75,9 +69,7 @@ impl VGicD {
         if irq >= MAX_IRQ_V3 as u32 {
             panic!("IRQ {} is out of range for VGicD", irq);
         }
-        unsafe {
-            (*self.assigned_irqs.get()).set(irq as usize, true);
-        }
+        self.assigned_irqs.lock().set(irq as usize, true);
 
         // TODO: update host GICD_ITARGETSR and GICD_IROUTER registers
         let gicd_itargetsr_paddr = self.host_gicd_addr + GICD_ITARGETSR + irq as usize;
@@ -258,7 +250,7 @@ impl BaseDeviceOps<GuestPhysAddrRange> for VGicD {
 impl VGicD {
     /// Checks if an IRQ is assigned to this VGicD.
     pub fn is_irq_assigned(&self, irq: u32) -> bool {
-        unsafe { (*self.assigned_irqs.get()).get(irq as usize) }
+        self.assigned_irqs.lock().get(irq as usize)
     }
 
     /// Checks if an IRQ is a Software Generated Interrupt (SGI).

--- a/virtualization/arm_vgic/src/v3/vgicr.rs
+++ b/virtualization/arm_vgic/src/v3/vgicr.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::{cell::UnsafeCell, ptr};
+use core::ptr;
 
-use ax_kspin::SpinNoIrq as Mutex;
+use ax_kspin::SpinNoIrq;
 use ax_memory_addr::PhysAddr;
 use axdevice_base::{AccessWidth, BaseDeviceOps};
 use axvm_types::{GuestPhysAddr, GuestPhysAddrRange, HostPhysAddr};
@@ -49,24 +49,18 @@ pub struct VGicR {
     pub host_gicr_base_this_cpu: HostPhysAddr,
 
     /// Virtual GICR registers.
-    pub regs: UnsafeCell<VGicRRegs>,
+    pub regs: SpinNoIrq<VGicRRegs>,
 }
 
-// SAFETY: VGicR is only accessed through the VGicR lock / Vgic host layer,
-// and the UnsafeCell is guarded by Mutex in the Vgic super-struct.
-unsafe impl Send for VGicR {}
-unsafe impl Sync for VGicR {}
-
 impl VGicR {
-    /// Gets a reference to the registers.
-    pub fn regs(&self) -> &VGicRRegs {
-        unsafe { &*self.regs.get() }
+    /// Accesses the registers immutably under the internal lock.
+    fn with_regs<R>(&self, f: impl FnOnce(&VGicRRegs) -> R) -> R {
+        f(&self.regs.lock())
     }
 
-    /// Gets a mutable reference to the registers.
-    #[allow(clippy::mut_from_ref)]
-    pub fn regs_mut(&self) -> &mut VGicRRegs {
-        unsafe { &mut *self.regs.get() }
+    /// Accesses the registers mutably under the internal lock.
+    fn with_regs_mut<R>(&self, f: impl FnOnce(&mut VGicRRegs) -> R) -> R {
+        f(&mut self.regs.lock())
     }
 
     /// Creates a new VGicR instance.
@@ -79,7 +73,7 @@ impl VGicR {
             size,
             cpu_id,
             host_gicr_base_this_cpu,
-            regs: UnsafeCell::new(VGicRRegs { propbaser: 0 }),
+            regs: SpinNoIrq::new(VGicRRegs { propbaser: 0 }),
         }
     }
 }
@@ -133,7 +127,7 @@ impl BaseDeviceOps<GuestPhysAddrRange> for VGicR {
                 // all the redist share one prop tbl
                 // mmio_perform_access(gicr_base, mmio);
 
-                Ok(self.regs().propbaser)
+                Ok(self.with_regs(|r| r.propbaser))
             }
             GICR_SYNCR => {
                 // always return 0 for synchronization register
@@ -186,7 +180,7 @@ impl BaseDeviceOps<GuestPhysAddrRange> for VGicR {
             }
             GICR_PROPBASER => {
                 // all the redist share one prop tbl
-                self.regs_mut().propbaser = value;
+                self.with_regs_mut(|r| r.propbaser = value);
                 Ok(())
             }
             GICR_SETLPIR | GICR_CLRLPIR | GICR_INVALLR => {
@@ -289,17 +283,17 @@ impl LpiPropTable {
 }
 
 /// Global LPI property table instance.
-pub static LPT: Once<Mutex<LpiPropTable>> = Once::new();
+pub static LPT: Once<spin::Mutex<LpiPropTable>> = Once::new();
 
 /// Gets or initializes the global LPI property table.
 pub fn get_lpt(
     host_gicd_typer: u32,
     host_gicr_base: HostPhysAddr,
     size_per_gicr: Option<usize>,
-) -> &'static Mutex<LpiPropTable> {
+) -> &'static spin::Mutex<LpiPropTable> {
     if !LPT.is_completed() {
         LPT.call_once(|| {
-            Mutex::new(LpiPropTable::new(
+            spin::Mutex::new(LpiPropTable::new(
                 host_gicd_typer,
                 host_gicr_base,
                 size_per_gicr,

--- a/virtualization/arm_vgic/src/v3/vgicr.rs
+++ b/virtualization/arm_vgic/src/v3/vgicr.rs
@@ -52,6 +52,11 @@ pub struct VGicR {
     pub regs: UnsafeCell<VGicRRegs>,
 }
 
+// SAFETY: VGicR is only accessed through the VGicR lock / Vgic host layer,
+// and the UnsafeCell is guarded by Mutex in the Vgic super-struct.
+unsafe impl Send for VGicR {}
+unsafe impl Sync for VGicR {}
+
 impl VGicR {
     /// Gets a reference to the registers.
     pub fn regs(&self) -> &VGicRRegs {

--- a/virtualization/axdevice/Cargo.toml
+++ b/virtualization/axdevice/Cargo.toml
@@ -30,3 +30,12 @@ arm_vgic = { workspace = true, features = ["vgicv3"] }
 riscv_vplic = { workspace = true }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_vlapic = { workspace = true }
+
+[[bench]]
+name = "lookup_AxVmDevices"
+harness = false
+
+[dev-dependencies]
+divan = "0.1.21"
+paste = "1.0"
+rand = { version = "0.10", features = ["std_rng"] }

--- a/virtualization/axdevice/benches/lookup_AxVmDevices/common.rs
+++ b/virtualization/axdevice/benches/lookup_AxVmDevices/common.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// MMIO address layout: devices start at 0x1000_0000, spaced 0x1000 apart,
+/// each covering [base, base + 0x100).
+pub const MMIO_BASE: u64 = 0x1000_0000;
+pub const MMIO_STRIDE: u64 = 0x1000;
+pub const MMIO_SIZE: u64 = 0x100;
+
+/// Port I/O address layout.
+pub const PORT_BASE: u16 = 0x100;
+pub const PORT_STRIDE: u16 = 0x10;
+pub const PORT_SIZE: u16 = 0x8;
+
+/// SysReg address layout (inclusive range: [addr, addr + count - 1]).
+pub const SYSREG_BASE: u32 = 0x100;
+pub const SYSREG_STRIDE: u32 = 0x10;
+pub const SYSREG_COUNT: u32 = 0x4;
+
+/// Returns the MMIO base address for the i-th device.
+#[inline]
+pub const fn mmio_addr(i: usize) -> u64 {
+    MMIO_BASE + (i as u64) * MMIO_STRIDE
+}
+
+/// Returns the Port base address for the i-th device.
+#[inline]
+pub const fn port_addr(i: usize) -> u16 {
+    PORT_BASE + (i as u16) * PORT_STRIDE
+}
+
+/// Returns the SysReg start address for the i-th device.
+#[inline]
+pub const fn sysreg_addr(i: usize) -> u32 {
+    SYSREG_BASE + (i as u32) * SYSREG_STRIDE
+}
+
+/// Returns an MMIO address that falls between the i-th and (i+1)-th device
+/// ranges (used for miss-benchmarks).
+#[inline]
+pub fn mmio_addr_between(i: usize) -> u64 {
+    mmio_addr(i) + MMIO_SIZE + (MMIO_STRIDE - MMIO_SIZE) / 2
+}
+
+/// Common trait that each lookup-strategy registry implements.
+pub trait Registry {
+    /// Construct a registry with `n` pre-registered devices (one per bus type
+    /// per device, at the standard layout addresses).
+    fn new_with_devices(n: usize) -> Self;
+
+    fn lookup_mmio(&self, addr: u64) -> Option<usize>;
+    fn lookup_port(&self, addr: u16) -> Option<usize>;
+    fn lookup_sysreg(&self, addr: u32) -> Option<usize>;
+}

--- a/virtualization/axdevice/benches/lookup_AxVmDevices/main.rs
+++ b/virtualization/axdevice/benches/lookup_AxVmDevices/main.rs
@@ -1,0 +1,192 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// ...
+
+extern crate alloc;
+
+use divan::Bencher;
+use paste::paste;
+
+mod common;
+mod v1_three_vec;
+mod v2_btree_nocache;
+mod v3_btree_cache;
+mod v4_sorted_vec;
+
+use common::Registry;
+use v1_three_vec::V1Registry;
+use v2_btree_nocache::V2Registry;
+use v3_btree_cache::V3Registry;
+use v4_sorted_vec::V4Registry;
+
+fn main() {
+    divan::main();
+}
+
+// ── Macro: generate 4 version-specific bench fns from one body ──────
+//
+// Each invocation generates four functions named
+//   v1_$fn, v2_$fn, v3_$fn, v4_$fn
+// so they never collide across benchmark scenarios.
+
+macro_rules! per_version {
+    (
+        #[bench($($attr:tt)*)]
+        fn $fn:ident($bencher:ident: Bencher, $n:ident: usize) $body:block
+    ) => {
+        paste! {
+            #[divan::bench($($attr)*)]
+            fn [<v1_ $fn>]($bencher: Bencher, $n: usize) {
+                type R = V1Registry;
+                $body
+            }
+            #[divan::bench($($attr)*)]
+            fn [<v2_ $fn>]($bencher: Bencher, $n: usize) {
+                type R = V2Registry;
+                $body
+            }
+            #[divan::bench($($attr)*)]
+            fn [<v3_ $fn>]($bencher: Bencher, $n: usize) {
+                type R = V3Registry;
+                $body
+            }
+            #[divan::bench($($attr)*)]
+            fn [<v4_ $fn>]($bencher: Bencher, $n: usize) {
+                type R = V4Registry;
+                $body
+            }
+        }
+    };
+}
+
+// ── MMIO lookup scenarios ───────────────────────────────────────────
+
+#[divan::bench_group]
+mod mmio {
+    use super::*;
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn hit_first(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::mmio_addr(0);
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_mmio(divan::black_box(addr)))
+            });
+        }
+    }
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn hit_mid(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::mmio_addr(n / 2);
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_mmio(divan::black_box(addr)))
+            });
+        }
+    }
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn hit_last(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::mmio_addr(n - 1);
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_mmio(divan::black_box(addr)))
+            });
+        }
+    }
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn miss_before(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::MMIO_BASE - 0x100;
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_mmio(divan::black_box(addr)))
+            });
+        }
+    }
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn miss_between(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::mmio_addr_between(n / 2);
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_mmio(divan::black_box(addr)))
+            });
+        }
+    }
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn miss_after(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::mmio_addr(n - 1) + common::MMIO_STRIDE * 2;
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_mmio(divan::black_box(addr)))
+            });
+        }
+    }
+}
+
+// ── Port I/O lookup scenarios ───────────────────────────────────────
+
+#[divan::bench_group]
+mod port {
+    use super::*;
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn hit_mid(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::port_addr(n / 2);
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_port(divan::black_box(addr)))
+            });
+        }
+    }
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn miss(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::PORT_BASE - 0x10;
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_port(divan::black_box(addr)))
+            });
+        }
+    }
+}
+
+// ── SysReg lookup scenarios ─────────────────────────────────────────
+
+#[divan::bench_group]
+mod sysreg {
+    use super::*;
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn hit_mid(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::sysreg_addr(n / 2);
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_sysreg(divan::black_box(addr)))
+            });
+        }
+    }
+
+    per_version! {
+        #[bench(args = [4usize, 8, 16, 32, 64, 128])]
+        fn miss(b: Bencher, n: usize) {
+            let reg = <R>::new_with_devices(n);
+            let addr = common::SYSREG_BASE - 0x10;
+            b.bench_local(|| {
+                divan::black_box(reg.lookup_sysreg(divan::black_box(addr)))
+            });
+        }
+    }
+}

--- a/virtualization/axdevice/benches/lookup_AxVmDevices/v1_three_vec.rs
+++ b/virtualization/axdevice/benches/lookup_AxVmDevices/v1_three_vec.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// ...
+
+use crate::common::{self, Registry, mmio_addr, port_addr, sysreg_addr};
+
+/// V1: Three `Vec`s — one per bus type — with O(n) linear scan on lookup.
+///
+/// Each entry stores `(base, end_or_count, slot)` where `end_or_count` is
+/// - for MMIO:   `base + size` (exclusive end),
+/// - for Port:   `base + size` (exclusive end),
+/// - for SysReg: `count` (number of registers).
+pub struct V1Registry {
+    mmio: Vec<(u64, u64, usize)>,
+    port: Vec<(u16, u16, usize)>,
+    sysreg: Vec<(u32, u32, usize)>,
+}
+
+impl Registry for V1Registry {
+    fn new_with_devices(n: usize) -> Self {
+        let mut reg = Self {
+            mmio: Vec::with_capacity(n),
+            port: Vec::with_capacity(n),
+            sysreg: Vec::with_capacity(n),
+        };
+        for i in 0..n {
+            reg.mmio
+                .push((mmio_addr(i), mmio_addr(i) + common::MMIO_SIZE, i));
+            reg.port.push((
+                port_addr(i),
+                port_addr(i).wrapping_add(common::PORT_SIZE),
+                i,
+            ));
+            reg.sysreg.push((sysreg_addr(i), common::SYSREG_COUNT, i));
+        }
+        reg
+    }
+
+    fn lookup_mmio(&self, addr: u64) -> Option<usize> {
+        self.mmio
+            .iter()
+            .find(|&&(base, end, _)| addr >= base && addr < end)
+            .map(|&(_, _, slot)| slot)
+    }
+
+    fn lookup_port(&self, addr: u16) -> Option<usize> {
+        self.port
+            .iter()
+            .find(|&&(base, end, _)| addr >= base && addr < end)
+            .map(|&(_, _, slot)| slot)
+    }
+
+    fn lookup_sysreg(&self, addr: u32) -> Option<usize> {
+        self.sysreg
+            .iter()
+            .find(|&&(start, count, _)| {
+                let end = start.saturating_add(count.saturating_sub(1));
+                addr >= start && addr <= end
+            })
+            .map(|&(_, _, slot)| slot)
+    }
+}

--- a/virtualization/axdevice/benches/lookup_AxVmDevices/v2_btree_nocache.rs
+++ b/virtualization/axdevice/benches/lookup_AxVmDevices/v2_btree_nocache.rs
@@ -1,0 +1,95 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// ...
+
+use alloc::{collections::BTreeMap, vec::Vec};
+
+use crate::common::{self, Registry, mmio_addr, port_addr, sysreg_addr};
+
+/// V2: Three `BTreeMap<Addr, slot>` indexes without cached size.
+///
+/// On lookup we need a second step to retrieve the size — modelling the
+/// original `dev.resources()` → `Vec<Resource>` allocation + iteration.
+/// We simulate this with a parallel `Vec` of per-slot range metadata plus
+/// an explicit heap allocation per lookup.
+pub struct V2Registry {
+    mmio_index: BTreeMap<u64, usize>,
+    mmio_meta: Vec<(u64, u64)>,
+
+    port_index: BTreeMap<u16, usize>,
+    port_meta: Vec<(u16, u16)>,
+
+    sysreg_index: BTreeMap<u32, usize>,
+    sysreg_meta: Vec<(u32, u32)>,
+}
+
+impl Registry for V2Registry {
+    fn new_with_devices(n: usize) -> Self {
+        let mut reg = Self {
+            mmio_index: BTreeMap::new(),
+            mmio_meta: Vec::with_capacity(n),
+            port_index: BTreeMap::new(),
+            port_meta: Vec::with_capacity(n),
+            sysreg_index: BTreeMap::new(),
+            sysreg_meta: Vec::with_capacity(n),
+        };
+        for i in 0..n {
+            let mbase = mmio_addr(i);
+            reg.mmio_index.insert(mbase, i);
+            reg.mmio_meta.push((mbase, common::MMIO_SIZE));
+
+            let pbase = port_addr(i);
+            reg.port_index.insert(pbase, i);
+            reg.port_meta.push((pbase, common::PORT_SIZE));
+
+            let sbase = sysreg_addr(i);
+            reg.sysreg_index.insert(sbase, i);
+            reg.sysreg_meta.push((sbase, common::SYSREG_COUNT));
+        }
+        reg
+    }
+
+    fn lookup_mmio(&self, addr: u64) -> Option<usize> {
+        let (&base, &slot) = self.mmio_index.range(..=addr).next_back()?;
+        // Simulate dev.resources() → Vec<Resource> allocation.
+        let resources: Vec<(u64, u64)> = self
+            .mmio_meta
+            .iter()
+            .filter(|&&(..)| true) // touch all entries (like real iteration)
+            .copied()
+            .collect();
+        let found = resources
+            .iter()
+            .any(|&(b, s)| b == base && s > 0 && addr < b.wrapping_add(s));
+        found.then_some(slot)
+    }
+
+    fn lookup_port(&self, addr: u16) -> Option<usize> {
+        let (&base, &slot) = self.port_index.range(..=addr).next_back()?;
+        let resources: Vec<(u16, u16)> = self
+            .port_meta
+            .iter()
+            .filter(|&&(..)| true)
+            .copied()
+            .collect();
+        let found = resources
+            .iter()
+            .any(|&(b, s)| b == base && s > 0 && (addr as u32) < (b as u32).wrapping_add(s as u32));
+        found.then_some(slot)
+    }
+
+    fn lookup_sysreg(&self, addr: u32) -> Option<usize> {
+        let (&start, &slot) = self.sysreg_index.range(..=addr).next_back()?;
+        let resources: Vec<(u32, u32)> = self
+            .sysreg_meta
+            .iter()
+            .filter(|&&(..)| true)
+            .copied()
+            .collect();
+        let found = resources.iter().any(|&(b, count)| {
+            b == start && count > 0 && addr <= b.saturating_add(count.saturating_sub(1))
+        });
+        found.then_some(slot)
+    }
+}

--- a/virtualization/axdevice/benches/lookup_AxVmDevices/v3_btree_cache.rs
+++ b/virtualization/axdevice/benches/lookup_AxVmDevices/v3_btree_cache.rs
@@ -1,0 +1,75 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// ...
+
+use alloc::collections::BTreeMap;
+
+use crate::common::{self, Registry, mmio_addr, port_addr, sysreg_addr};
+
+/// A minimal `RangeEntry` — the same shape as the production code.
+struct RangeEntry {
+    slot: usize,
+    size: u64,
+}
+
+/// V3: Three `BTreeMap<Addr, RangeEntry>` with size cached in the map value.
+///
+/// This mirrors the current production `AxVmDevices` implementation. Lookup
+/// finds the predecessor entry via `range(..=addr).next_back()` then does a
+/// pure arithmetic bounds check — zero allocation, zero extra indirection.
+pub struct V3Registry {
+    mmio_index: BTreeMap<u64, RangeEntry>,
+    port_index: BTreeMap<u16, RangeEntry>,
+    sysreg_index: BTreeMap<u32, RangeEntry>,
+}
+
+impl Registry for V3Registry {
+    fn new_with_devices(n: usize) -> Self {
+        let mut reg = Self {
+            mmio_index: BTreeMap::new(),
+            port_index: BTreeMap::new(),
+            sysreg_index: BTreeMap::new(),
+        };
+        for i in 0..n {
+            reg.mmio_index.insert(
+                mmio_addr(i),
+                RangeEntry {
+                    slot: i,
+                    size: common::MMIO_SIZE,
+                },
+            );
+            reg.port_index.insert(
+                port_addr(i),
+                RangeEntry {
+                    slot: i,
+                    size: common::PORT_SIZE as u64,
+                },
+            );
+            reg.sysreg_index.insert(
+                sysreg_addr(i),
+                RangeEntry {
+                    slot: i,
+                    size: common::SYSREG_COUNT as u64,
+                },
+            );
+        }
+        reg
+    }
+
+    fn lookup_mmio(&self, addr: u64) -> Option<usize> {
+        let (&base, entry) = self.mmio_index.range(..=addr).next_back()?;
+        (addr < base.wrapping_add(entry.size)).then_some(entry.slot)
+    }
+
+    fn lookup_port(&self, addr: u16) -> Option<usize> {
+        let (&base, entry) = self.port_index.range(..=addr).next_back()?;
+        ((addr as u64) < (base as u64).wrapping_add(entry.size)).then_some(entry.slot)
+    }
+
+    fn lookup_sysreg(&self, addr: u32) -> Option<usize> {
+        let (&start, entry) = self.sysreg_index.range(..=addr).next_back()?;
+        let end = start.saturating_add((entry.size as u32).saturating_sub(1));
+        (addr <= end).then_some(entry.slot)
+    }
+}

--- a/virtualization/axdevice/benches/lookup_AxVmDevices/v4_sorted_vec.rs
+++ b/virtualization/axdevice/benches/lookup_AxVmDevices/v4_sorted_vec.rs
@@ -1,0 +1,103 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// ...
+
+use alloc::{collections::BTreeMap, vec::Vec};
+
+use crate::common::{self, Registry, mmio_addr, port_addr, sysreg_addr};
+
+/// A minimal `RangeEntry` — same shape as the production code.
+#[derive(Clone, Copy)]
+struct RangeEntry {
+    slot: usize,
+    size: u64,
+}
+
+/// V4: Build-time `BTreeMap` for conflict-free registration, then `finish()`
+/// converts to a sorted `Vec<(Addr, RangeEntry)>` for `binary_search_by`
+/// lookups with better cache locality.
+pub struct V4Registry {
+    mmio_vec: Vec<(u64, RangeEntry)>,
+    port_vec: Vec<(u16, RangeEntry)>,
+    sysreg_vec: Vec<(u32, RangeEntry)>,
+}
+
+impl Registry for V4Registry {
+    fn new_with_devices(n: usize) -> Self {
+        // Phase 1: register into temporary BTreeMaps.
+        let mut mmio_tmp: BTreeMap<u64, RangeEntry> = BTreeMap::new();
+        let mut port_tmp: BTreeMap<u16, RangeEntry> = BTreeMap::new();
+        let mut sysreg_tmp: BTreeMap<u32, RangeEntry> = BTreeMap::new();
+
+        for i in 0..n {
+            mmio_tmp.insert(
+                mmio_addr(i),
+                RangeEntry {
+                    slot: i,
+                    size: common::MMIO_SIZE,
+                },
+            );
+            port_tmp.insert(
+                port_addr(i),
+                RangeEntry {
+                    slot: i,
+                    size: common::PORT_SIZE as u64,
+                },
+            );
+            sysreg_tmp.insert(
+                sysreg_addr(i),
+                RangeEntry {
+                    slot: i,
+                    size: common::SYSREG_COUNT as u64,
+                },
+            );
+        }
+
+        // Phase 2: finish — drain sorted BTreeMaps into sorted Vecs.
+        let reg = Self {
+            mmio_vec: mmio_tmp.into_iter().collect(),
+            port_vec: port_tmp.into_iter().collect(),
+            sysreg_vec: sysreg_tmp.into_iter().collect(),
+        };
+
+        // BTreeMap iteration yields keys in ascending order, so the Vecs
+        // are already sorted. Assert for safety.
+        debug_assert!(reg.mmio_vec.windows(2).all(|w| w[0].0 < w[1].0));
+        debug_assert!(reg.port_vec.windows(2).all(|w| w[0].0 < w[1].0));
+        debug_assert!(reg.sysreg_vec.windows(2).all(|w| w[0].0 < w[1].0));
+
+        reg
+    }
+
+    fn lookup_mmio(&self, addr: u64) -> Option<usize> {
+        let idx = match self.mmio_vec.binary_search_by_key(&addr, |&(k, _)| k) {
+            Ok(i) => i,
+            Err(0) => return None,
+            Err(i) => i - 1,
+        };
+        let (base, entry) = &self.mmio_vec[idx];
+        (addr < base.wrapping_add(entry.size)).then_some(entry.slot)
+    }
+
+    fn lookup_port(&self, addr: u16) -> Option<usize> {
+        let idx = match self.port_vec.binary_search_by_key(&addr, |&(k, _)| k) {
+            Ok(i) => i,
+            Err(0) => return None,
+            Err(i) => i - 1,
+        };
+        let (base, entry) = &self.port_vec[idx];
+        ((addr as u64) < (*base as u64).wrapping_add(entry.size)).then_some(entry.slot)
+    }
+
+    fn lookup_sysreg(&self, addr: u32) -> Option<usize> {
+        let idx = match self.sysreg_vec.binary_search_by_key(&addr, |&(k, _)| k) {
+            Ok(i) => i,
+            Err(0) => return None,
+            Err(i) => i - 1,
+        };
+        let (start, entry) = &self.sysreg_vec[idx];
+        let end = start.saturating_add((entry.size as u32).saturating_sub(1));
+        (addr <= end).then_some(entry.slot)
+    }
+}

--- a/virtualization/axdevice/src/adapter.rs
+++ b/virtualization/axdevice/src/adapter.rs
@@ -1,0 +1,43 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Migration helpers that depend on concrete device-crate types.
+//!
+//! These will move out of `axdevice` as the migration progresses.
+
+// ---------------------------------------------------------------------------
+// vtimer helper (will move to axvm — it depends on arm_vgic concrete types)
+// ---------------------------------------------------------------------------
+
+/// creates the standard set of vTimer system-register devices, each wrapped
+/// in a [`SysRegDeviceAdapter`](axdevice_base::SysRegDeviceAdapter) so they
+/// implement [`Device`].
+#[cfg(target_arch = "aarch64")]
+pub fn create_vtimer_devices() -> alloc::vec::Vec<alloc::boxed::Box<dyn axdevice_base::Device>> {
+    use arm_vgic::vtimer::{SysCntpCtlEl0, SysCntpTvalEl0, SysCntpctEl0};
+    use axdevice_base::SysRegDeviceAdapter;
+
+    let mut devs: alloc::vec::Vec<alloc::boxed::Box<dyn axdevice_base::Device>> =
+        alloc::vec::Vec::new();
+    devs.push(alloc::boxed::Box::new(SysRegDeviceAdapter::new(
+        SysCntpCtlEl0::new(),
+    )));
+    devs.push(alloc::boxed::Box::new(SysRegDeviceAdapter::new(
+        SysCntpctEl0::new(),
+    )));
+    devs.push(alloc::boxed::Box::new(SysRegDeviceAdapter::new(
+        SysCntpTvalEl0::new(),
+    )));
+    devs
+}

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -204,7 +204,6 @@ impl AxVmDevices {
                             let addr = config.base_gpa + i * stride;
                             let size = config.length;
                             #[allow(clippy::arc_with_non_send_sync)]
-                            #[allow(clippy::arc_with_non_send_sync)]
                             this.register(MmioDeviceAdapter::from_arc(Arc::new(
                                 arm_vgic::v3::vgicr::VGicR::new(
                                     addr.into(),

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -24,9 +24,10 @@ use ax_memory_addr::PhysAddr;
 use ax_memory_addr::is_aligned_4k;
 use axdevice_base::{
     AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceError, DeviceId,
-    DeviceRegistry, MmioDeviceAdapter, Port, PortDeviceAdapter, RegistryError, Resource,
-    SysRegAddr,
+    DeviceRegistry, MmioDeviceAdapter, Port, RegistryError, Resource, SysRegAddr,
 };
+#[cfg(target_arch = "x86_64")]
+use axdevice_base::PortDeviceAdapter;
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr};
 #[cfg(target_arch = "riscv64")]
 use riscv_vplic::VPlicGlobal;

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -534,150 +534,311 @@ impl AxVmDevices {
         Ok(())
     }
 
-    // ─── Registration helpers ───────────────────────────────────────
+    // ─── Resource rollback ────────────────────────────────────────
 
-    /// Checks whether `[base, base + size)` conflicts with any already
-    /// registered MMIO range.
-    fn check_mmio_conflict(&self, base: u64, size: u64) -> Result<(), RegistryError> {
-        if size == 0 {
-            return Err(RegistryError::InvalidResource {
-                resource: Resource::MmioRange { base, size },
-                reason: InvalidResourceReason::ZeroSized,
-            });
-        }
-        if base.checked_add(size).is_none() {
-            return Err(RegistryError::InvalidResource {
-                resource: Resource::MmioRange { base, size },
-                reason: InvalidResourceReason::AddressOverflow,
-            });
-        }
-
-        let end = base + size;
-
-        // Check the immediately-preceding entry.
-        if let Some((prev_base, entry)) = self.mmio_index.range(..base).next_back()
-            && prev_base.wrapping_add(entry.size) > base
-        {
-            return Err(RegistryError::AddressConflict {
-                resource: Resource::MmioRange { base, size },
-                existing: Resource::MmioRange {
-                    base: *prev_base,
-                    size: entry.size,
-                },
-                existing_device: DeviceId::new(entry.slot as u32),
-            });
-        }
-
-        // Check the immediately-following entry.
-        if let Some((next_base, entry)) = self.mmio_index.range(base..).next()
-            && *next_base < end
-        {
-            return Err(RegistryError::AddressConflict {
-                resource: Resource::MmioRange { base, size },
-                existing: Resource::MmioRange {
-                    base: *next_base,
-                    size: entry.size,
-                },
-                existing_device: DeviceId::new(entry.slot as u32),
-            });
-        }
-
-        Ok(())
-    }
-
-    /// Checks whether `[base, base + size)` conflicts with any already
-    /// registered port I/O range.
-    fn check_port_conflict(&self, base: u16, size: u16) -> Result<(), RegistryError> {
-        if size == 0 {
-            return Err(RegistryError::InvalidResource {
-                resource: Resource::PortRange { base, size },
-                reason: InvalidResourceReason::ZeroSized,
-            });
-        }
-        // Use u32 to allow base=0xffff, size=1 (end=0x10000 is valid).
-        let end = (base as u32).wrapping_add(size as u32);
-        if end > (u16::MAX as u32 + 1) {
-            return Err(RegistryError::InvalidResource {
-                resource: Resource::PortRange { base, size },
-                reason: InvalidResourceReason::AddressOverflow,
-            });
-        }
-
-        if let Some((prev_base, entry)) = self.port_index.range(..base).next_back()
-            && (*prev_base as u32).wrapping_add(entry.size as u32) > base as u32
-        {
-            return Err(RegistryError::AddressConflict {
-                resource: Resource::PortRange { base, size },
-                existing: Resource::PortRange {
-                    base: *prev_base,
-                    size: entry.size as u16,
-                },
-                existing_device: DeviceId::new(entry.slot as u32),
-            });
-        }
-
-        if let Some((next_base, entry)) = self.port_index.range(base..).next()
-            && (*next_base as u32) < end
-        {
-            return Err(RegistryError::AddressConflict {
-                resource: Resource::PortRange { base, size },
-                existing: Resource::PortRange {
-                    base: *next_base,
-                    size: entry.size as u16,
-                },
-                existing_device: DeviceId::new(entry.slot as u32),
-            });
-        }
-
-        Ok(())
-    }
-
-    /// Checks whether a system register range conflicts with any already
-    /// registered system register range.
-    fn check_sysreg_conflict(&self, addr: u32, count: u32) -> Result<(), RegistryError> {
-        if count == 0 {
-            return Err(RegistryError::InvalidResource {
-                resource: Resource::SysReg { addr, count },
-                reason: InvalidResourceReason::ZeroSized,
-            });
-        }
-
-        let end = addr.saturating_add(count.saturating_sub(1));
-        if count > 0 && addr.checked_add(count).is_none() {
-            return Err(RegistryError::InvalidResource {
-                resource: Resource::SysReg { addr, count },
-                reason: InvalidResourceReason::AddressOverflow,
-            });
-        }
-
-        // Check the immediately-preceding key: its range may extend into ours.
-        if let Some((prev_addr, entry)) = self.sysreg_index.range(..addr).next_back() {
-            let existing_count = entry.size as u32;
-            let existing_end = prev_addr.saturating_add(existing_count.saturating_sub(1));
-            if existing_end >= addr {
-                return Err(RegistryError::AddressConflict {
-                    resource: Resource::SysReg { addr, count },
-                    existing: Resource::SysReg {
-                        addr: *prev_addr,
-                        count: existing_count,
-                    },
-                    existing_device: DeviceId::new(entry.slot as u32),
-                });
+    /// Removes `resources` from the index maps.  Used to undo a
+    /// partially-completed insertion when a conflict is discovered
+    /// mid-way through `insert_resources`.
+    fn rollback_resources(&mut self, resources: &[Resource]) {
+        for r in resources {
+            match *r {
+                Resource::MmioRange { base, .. } => {
+                    self.mmio_index.remove(&base);
+                }
+                Resource::PortRange { base, .. } => {
+                    self.port_index.remove(&base);
+                }
+                Resource::SysReg { addr, .. } => {
+                    self.sysreg_index.remove(&addr);
+                }
             }
         }
+    }
 
-        // Check entries whose keys fall within our range.
-        if let Some((reg_addr, entry)) = self.sysreg_index.range(addr..=end).next() {
-            return Err(RegistryError::AddressConflict {
-                resource: Resource::SysReg { addr, count },
-                existing: Resource::SysReg {
-                    addr: *reg_addr,
-                    count: entry.size as u32,
-                },
-                existing_device: DeviceId::new(entry.slot as u32),
-            });
+    // ─── BTreeMap insertion with inline conflict detection ─────────
+
+    /// Inserts every resource of device `idx` into the three BTreeMap
+    /// indices, checking for validity errors and range conflicts
+    /// as each key is inserted.
+    ///
+    /// Because earlier resources of the *same* device are already in
+    /// the index when later ones are checked, same-device internal
+    /// overlaps are caught by the same predecessor/successor probes
+    /// that catch cross-device overlaps.  A conflict is reported as
+    /// [`InvalidResourceReason::OverlappingResources`] when the
+    /// neighbour entry belongs to the current device, and as
+    /// [`RegistryError::AddressConflict`] otherwise.
+    ///
+    /// On any error the keys inserted so far are rolled back through
+    /// [`rollback_resources`], leaving the indices unchanged.
+    fn insert_resources(
+        &mut self,
+        idx: usize,
+        resources: &[Resource],
+    ) -> Result<(), RegistryError> {
+        for (i, r) in resources.iter().enumerate() {
+            match *r {
+                Resource::MmioRange { base, size } => {
+                    if size == 0 {
+                        return Err(RegistryError::InvalidResource {
+                            resource: Resource::MmioRange { base, size },
+                            reason: InvalidResourceReason::ZeroSized,
+                        });
+                    }
+                    if base.checked_add(size).is_none() {
+                        return Err(RegistryError::InvalidResource {
+                            resource: Resource::MmioRange { base, size },
+                            reason: InvalidResourceReason::AddressOverflow,
+                        });
+                    }
+
+                    // Key collision.
+                    if let Some(existing) = self.mmio_index.get(&base) {
+                        let existing_size = existing.size;
+                        let existing_slot = existing.slot;
+                        self.rollback_resources(&resources[..i]);
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::MmioRange { base, size },
+                            existing: Resource::MmioRange {
+                                base,
+                                size: existing_size,
+                            },
+                            existing_device: DeviceId::new(existing_slot as u32),
+                        });
+                    }
+
+                    self.mmio_index.insert(base, RangeEntry { slot: idx, size });
+
+                    // Predecessor check.
+                    if let Some((prev_base, existing)) = self.mmio_index.range(..base).next_back()
+                        && prev_base.wrapping_add(existing.size) > base
+                    {
+                        let conflicting_base = *prev_base;
+                        let conflicting_size = existing.size;
+                        let conflicting_slot = existing.slot;
+                        self.rollback_resources(&resources[..=i]);
+                        if conflicting_slot == idx {
+                            return Err(RegistryError::InvalidResource {
+                                resource: Resource::MmioRange { base, size },
+                                reason: InvalidResourceReason::OverlappingResources,
+                            });
+                        }
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::MmioRange { base, size },
+                            existing: Resource::MmioRange {
+                                base: conflicting_base,
+                                size: conflicting_size,
+                            },
+                            existing_device: DeviceId::new(conflicting_slot as u32),
+                        });
+                    }
+
+                    // Successor check.
+                    let end = base + size;
+                    if let Some(next_start) = base.checked_add(1)
+                        && let Some((next_base, existing)) =
+                            self.mmio_index.range(next_start..).next()
+                        && *next_base < end
+                    {
+                        let conflicting_base = *next_base;
+                        let conflicting_size = existing.size;
+                        let conflicting_slot = existing.slot;
+                        self.rollback_resources(&resources[..=i]);
+                        if conflicting_slot == idx {
+                            return Err(RegistryError::InvalidResource {
+                                resource: Resource::MmioRange { base, size },
+                                reason: InvalidResourceReason::OverlappingResources,
+                            });
+                        }
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::MmioRange { base, size },
+                            existing: Resource::MmioRange {
+                                base: conflicting_base,
+                                size: conflicting_size,
+                            },
+                            existing_device: DeviceId::new(conflicting_slot as u32),
+                        });
+                    }
+                }
+                Resource::PortRange { base, size } => {
+                    if size == 0 {
+                        return Err(RegistryError::InvalidResource {
+                            resource: Resource::PortRange { base, size },
+                            reason: InvalidResourceReason::ZeroSized,
+                        });
+                    }
+                    let end = (base as u32).wrapping_add(size as u32);
+                    if end > (u16::MAX as u32 + 1) {
+                        return Err(RegistryError::InvalidResource {
+                            resource: Resource::PortRange { base, size },
+                            reason: InvalidResourceReason::AddressOverflow,
+                        });
+                    }
+
+                    // Key collision.
+                    if let Some(existing) = self.port_index.get(&base) {
+                        let existing_size = existing.size as u16;
+                        let existing_slot = existing.slot;
+                        self.rollback_resources(&resources[..i]);
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::PortRange { base, size },
+                            existing: Resource::PortRange {
+                                base,
+                                size: existing_size,
+                            },
+                            existing_device: DeviceId::new(existing_slot as u32),
+                        });
+                    }
+
+                    self.port_index.insert(
+                        base,
+                        RangeEntry {
+                            slot: idx,
+                            size: size as u64,
+                        },
+                    );
+
+                    // Predecessor check.
+                    if let Some((prev_base, existing)) = self.port_index.range(..base).next_back()
+                        && (*prev_base as u32).wrapping_add(existing.size as u32) > base as u32
+                    {
+                        let conflicting_base = *prev_base;
+                        let conflicting_size = existing.size as u16;
+                        let conflicting_slot = existing.slot;
+                        self.rollback_resources(&resources[..=i]);
+                        if conflicting_slot == idx {
+                            return Err(RegistryError::InvalidResource {
+                                resource: Resource::PortRange { base, size },
+                                reason: InvalidResourceReason::OverlappingResources,
+                            });
+                        }
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::PortRange { base, size },
+                            existing: Resource::PortRange {
+                                base: conflicting_base,
+                                size: conflicting_size,
+                            },
+                            existing_device: DeviceId::new(conflicting_slot as u32),
+                        });
+                    }
+
+                    // Successor check.
+                    if let Some(next_port) = base.checked_add(1)
+                        && let Some((next_base, existing)) =
+                            self.port_index.range(next_port..).next()
+                        && (*next_base as u32) < end
+                    {
+                        let conflicting_base = *next_base;
+                        let conflicting_size = existing.size as u16;
+                        let conflicting_slot = existing.slot;
+                        self.rollback_resources(&resources[..=i]);
+                        if conflicting_slot == idx {
+                            return Err(RegistryError::InvalidResource {
+                                resource: Resource::PortRange { base, size },
+                                reason: InvalidResourceReason::OverlappingResources,
+                            });
+                        }
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::PortRange { base, size },
+                            existing: Resource::PortRange {
+                                base: conflicting_base,
+                                size: conflicting_size,
+                            },
+                            existing_device: DeviceId::new(conflicting_slot as u32),
+                        });
+                    }
+                }
+                Resource::SysReg { addr, count } => {
+                    if count == 0 {
+                        return Err(RegistryError::InvalidResource {
+                            resource: Resource::SysReg { addr, count },
+                            reason: InvalidResourceReason::ZeroSized,
+                        });
+                    }
+                    if addr.checked_add(count.saturating_sub(1)).is_none() {
+                        return Err(RegistryError::InvalidResource {
+                            resource: Resource::SysReg { addr, count },
+                            reason: InvalidResourceReason::AddressOverflow,
+                        });
+                    }
+
+                    // Key collision.
+                    if let Some(existing) = self.sysreg_index.get(&addr) {
+                        let existing_count = existing.size as u32;
+                        let existing_slot = existing.slot;
+                        self.rollback_resources(&resources[..i]);
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::SysReg { addr, count },
+                            existing: Resource::SysReg {
+                                addr,
+                                count: existing_count,
+                            },
+                            existing_device: DeviceId::new(existing_slot as u32),
+                        });
+                    }
+
+                    let end = addr.saturating_add(count.saturating_sub(1));
+                    self.sysreg_index.insert(
+                        addr,
+                        RangeEntry {
+                            slot: idx,
+                            size: count as u64,
+                        },
+                    );
+
+                    // Predecessor check.
+                    if let Some((prev_addr, existing)) = self.sysreg_index.range(..addr).next_back()
+                        && prev_addr.saturating_add((existing.size as u32).saturating_sub(1))
+                            >= addr
+                    {
+                        let conflicting_addr = *prev_addr;
+                        let conflicting_count = existing.size as u32;
+                        let conflicting_slot = existing.slot;
+                        self.rollback_resources(&resources[..=i]);
+                        if conflicting_slot == idx {
+                            return Err(RegistryError::InvalidResource {
+                                resource: Resource::SysReg { addr, count },
+                                reason: InvalidResourceReason::OverlappingResources,
+                            });
+                        }
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::SysReg { addr, count },
+                            existing: Resource::SysReg {
+                                addr: conflicting_addr,
+                                count: conflicting_count,
+                            },
+                            existing_device: DeviceId::new(conflicting_slot as u32),
+                        });
+                    }
+
+                    // Successor check.
+                    if let Some(next_addr) = addr.checked_add(1)
+                        && let Some((reg_addr, existing)) =
+                            self.sysreg_index.range(next_addr..).next()
+                        && *reg_addr <= end
+                    {
+                        let conflicting_addr = *reg_addr;
+                        let conflicting_count = existing.size as u32;
+                        let conflicting_slot = existing.slot;
+                        self.rollback_resources(&resources[..=i]);
+                        if conflicting_slot == idx {
+                            return Err(RegistryError::InvalidResource {
+                                resource: Resource::SysReg { addr, count },
+                                reason: InvalidResourceReason::OverlappingResources,
+                            });
+                        }
+                        return Err(RegistryError::AddressConflict {
+                            resource: Resource::SysReg { addr, count },
+                            existing: Resource::SysReg {
+                                addr: conflicting_addr,
+                                count: conflicting_count,
+                            },
+                            existing_device: DeviceId::new(conflicting_slot as u32),
+                        });
+                    }
+                }
+            }
         }
-
         Ok(())
     }
 
@@ -697,36 +858,6 @@ impl AxVmDevices {
         let (&start, entry) = self.sysreg_index.range(..=addr).next_back()?;
         let end = start.saturating_add((entry.size as u32).saturating_sub(1));
         (addr <= end).then_some(entry.slot)
-    }
-
-    // ─── BTreeMap insertion ───────────────────────────────────────
-
-    fn insert_resources(&mut self, idx: usize, resources: &[Resource]) {
-        for r in resources {
-            match *r {
-                Resource::MmioRange { base, size } => {
-                    self.mmio_index.insert(base, RangeEntry { slot: idx, size });
-                }
-                Resource::PortRange { base, size } => {
-                    self.port_index.insert(
-                        base,
-                        RangeEntry {
-                            slot: idx,
-                            size: size as u64,
-                        },
-                    );
-                }
-                Resource::SysReg { addr, count } => {
-                    self.sysreg_index.insert(
-                        addr,
-                        RangeEntry {
-                            slot: idx,
-                            size: count as u64,
-                        },
-                    );
-                }
-            }
-        }
     }
 
     // ─── Public helpers ───────────────────────────────────────────
@@ -998,26 +1129,9 @@ impl Default for AxVmDevices {
 
 impl DeviceRegistry for AxVmDevices {
     fn register(&mut self, device: Arc<dyn Device>) -> Result<DeviceId, RegistryError> {
-        let resources = device.resources();
-
-        // 1. Conflict detection (only for address-range resources).
-        for r in resources {
-            match *r {
-                Resource::MmioRange { base, size } => self.check_mmio_conflict(base, size)?,
-                Resource::PortRange { base, size } => self.check_port_conflict(base, size)?,
-                Resource::SysReg { addr, count } => self.check_sysreg_conflict(addr, count)?,
-            }
-        }
-
-        // 2. Append to device list; index is the DeviceId.
         let idx = self.devices.len();
-
-        // 3. Insert into index maps.
-        self.insert_resources(idx, resources);
-
-        // 4. Store the device.
+        self.insert_resources(idx, device.resources())?;
         self.devices.push(device);
-
         info!("AxVmDevices: registered device id={}", idx);
         Ok(DeviceId::new(idx as u32))
     }
@@ -1170,10 +1284,149 @@ mod tests {
     }
 
     #[test]
-    fn test_stale_device_id_after_unregister() {
-        // DeviceRegistry no longer exposes unregister.
-        // DeviceIds are stable for the AxVmDevices lifetime.
-        // The old slot-reuse test has been removed.
+    fn test_same_device_overlapping_mmio_rejected() {
+        // Same device declaring [0x1000, 0x1200) and [0x1100, 0x1300)
+        struct OverlapDevice;
+        impl Device for OverlapDevice {
+            fn name(&self) -> &str {
+                "overlap"
+            }
+            fn resources(&self) -> &[Resource] {
+                static R: [Resource; 2] = [
+                    Resource::MmioRange {
+                        base: 0x1000,
+                        size: 0x200,
+                    },
+                    Resource::MmioRange {
+                        base: 0x1100,
+                        size: 0x200,
+                    },
+                ];
+                &R
+            }
+            fn handle(&self, _: &BusAccess) -> Result<BusResponse, DeviceError> {
+                Ok(BusResponse::Read { value: 0 })
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let mut m = AxVmDevices::empty();
+        let result = m.register(Arc::new(OverlapDevice));
+        assert!(matches!(
+            result,
+            Err(RegistryError::InvalidResource {
+                reason: InvalidResourceReason::OverlappingResources,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_same_device_nested_mmio_rejected() {
+        // Same device declaring [0x1000, 0x2000) and [0x1800, 0x1900) —
+        // smaller range is fully inside larger range.
+        struct NestedDevice;
+        impl Device for NestedDevice {
+            fn name(&self) -> &str {
+                "nested"
+            }
+            fn resources(&self) -> &[Resource] {
+                static R: [Resource; 2] = [
+                    Resource::MmioRange {
+                        base: 0x1000,
+                        size: 0x1000,
+                    },
+                    Resource::MmioRange {
+                        base: 0x1800,
+                        size: 0x100,
+                    },
+                ];
+                &R
+            }
+            fn handle(&self, _: &BusAccess) -> Result<BusResponse, DeviceError> {
+                Ok(BusResponse::Read { value: 0 })
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let mut m = AxVmDevices::empty();
+        let result = m.register(Arc::new(NestedDevice));
+        assert!(matches!(
+            result,
+            Err(RegistryError::InvalidResource {
+                reason: InvalidResourceReason::OverlappingResources,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_same_device_mmio_port_same_addr_allowed() {
+        // Same numeric address on different buses is allowed.
+        struct DualBusDevice;
+        impl Device for DualBusDevice {
+            fn name(&self) -> &str {
+                "dual-bus"
+            }
+            fn resources(&self) -> &[Resource] {
+                static R: [Resource; 2] = [
+                    Resource::MmioRange {
+                        base: 0x1000,
+                        size: 0x100,
+                    },
+                    Resource::PortRange {
+                        base: 0x1000,
+                        size: 0x10,
+                    },
+                ];
+                &R
+            }
+            fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+                if access.is_read {
+                    Ok(BusResponse::Read { value: 0 })
+                } else {
+                    Ok(BusResponse::Write)
+                }
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let mut m = AxVmDevices::empty();
+        assert!(m.register(Arc::new(DualBusDevice)).is_ok());
+    }
+
+    #[test]
+    fn test_sysreg_max_single_register_valid() {
+        // addr = u32::MAX, count = 1 is the highest valid single-register
+        // range and should not be rejected as overflow.
+        struct MaxSysRegDevice;
+        impl Device for MaxSysRegDevice {
+            fn name(&self) -> &str {
+                "max-sysreg"
+            }
+            fn resources(&self) -> &[Resource] {
+                static R: [Resource; 1] = [Resource::SysReg {
+                    addr: u32::MAX,
+                    count: 1,
+                }];
+                &R
+            }
+            fn handle(&self, _: &BusAccess) -> Result<BusResponse, DeviceError> {
+                Ok(BusResponse::Read { value: 0 })
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let mut m = AxVmDevices::empty();
+        assert!(m.register(Arc::new(MaxSysRegDevice)).is_ok());
     }
 
     #[test]

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -757,6 +757,13 @@ impl AxVmDevices {
     }
 
     // ─── Iterator helpers ───────────────────────────────────────────
+    //
+    // NOTE: With the unified Device trait, all three iterators return
+    // every registered device regardless of bus type.  Callers that
+    // previously relied on per-bus filtering should use
+    // [`Device::resources()`] or downcasting via [`Device::as_any()`].
+    // Prefer [`devices()`] (the canonical iterator) or
+    // [`device_count()`] in new code.
 
     /// Iterates over all registered devices.
     pub fn iter_mmio_dev(&self) -> impl Iterator<Item = &dyn Device> {

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -204,6 +204,7 @@ impl AxVmDevices {
                             let addr = config.base_gpa + i * stride;
                             let size = config.length;
                             #[allow(clippy::arc_with_non_send_sync)]
+                            #[allow(clippy::arc_with_non_send_sync)]
                             this.register(MmioDeviceAdapter::from_arc(Arc::new(
                                 arm_vgic::v3::vgicr::VGicR::new(
                                     addr.into(),
@@ -473,7 +474,8 @@ impl AxVmDevices {
     }
 
     /// Registers a bundle atomically.  Conflict detection is performed by
-    /// [`DeviceRegistry::register`].
+    /// [`DeviceRegistry::register`].  If any device fails to register,
+    /// already-registered devices in this bundle are rolled back.
     pub fn register_bundle(&mut self, bundle: DeviceBundle) -> AxResult {
         for (index, pollable) in bundle.pollable.iter().enumerate() {
             if self
@@ -489,10 +491,21 @@ impl AxVmDevices {
             }
         }
 
-        for device in bundle.devices {
-            self.register(device).map_err(|e| {
-                ax_err_type!(InvalidInput, format!("device registration failed: {e:?}"))
-            })?;
+        let mut registered_ids: Vec<DeviceId> = Vec::new();
+        for device in &bundle.devices {
+            match self.register(device.clone()) {
+                Ok(id) => registered_ids.push(id),
+                Err(e) => {
+                    // Rollback already-registered devices.
+                    for id in registered_ids.iter().rev() {
+                        let _ = self.unregister(*id);
+                    }
+                    return Err(ax_err_type!(
+                        InvalidInput,
+                        format!("device registration failed: {e:?}")
+                    ));
+                }
+            }
         }
         self.pollable_devices.extend(bundle.pollable);
         Ok(())
@@ -515,13 +528,13 @@ impl AxVmDevices {
     /// Checks whether `[base, base + size)` conflicts with any already
     /// registered MMIO range.
     fn check_mmio_conflict(&self, base: u64, size: u64) -> Result<(), RegistryError> {
-        let end = base
-            .checked_add(size)
-            .ok_or_else(|| RegistryError::AddressConflict {
+        if size == 0 {
+            return Err(RegistryError::AddressConflict {
                 resource: Resource::MmioRange { base, size },
                 existing: Resource::MmioRange { base: 0, size: 0 },
                 existing_device: DeviceId::new(0),
-            })?;
+            });
+        }
 
         // Check the immediately-preceding entry.
         if let Some((prev_base, &prev_idx)) = self.mmio_index.range(..base).next_back()
@@ -540,6 +553,7 @@ impl AxVmDevices {
         }
 
         // Check the immediately-following entry.
+        let end = base + size;
         if let Some((next_base, &next_idx)) = self.mmio_index.range(base..).next()
             && *next_base < end
             && let Some((existing_base, existing_size)) =
@@ -561,13 +575,13 @@ impl AxVmDevices {
     /// Checks whether `[base, base + size)` conflicts with any already
     /// registered port I/O range.
     fn check_port_conflict(&self, base: u16, size: u16) -> Result<(), RegistryError> {
-        let end = base
-            .checked_add(size)
-            .ok_or_else(|| RegistryError::AddressConflict {
+        if size == 0 {
+            return Err(RegistryError::AddressConflict {
                 resource: Resource::PortRange { base, size },
                 existing: Resource::PortRange { base: 0, size: 0 },
                 existing_device: DeviceId::new(0),
-            })?;
+            });
+        }
 
         if let Some((prev_base, &prev_idx)) = self.port_index.range(..base).next_back()
             && let Some((existing_base, existing_size)) =
@@ -584,6 +598,7 @@ impl AxVmDevices {
             });
         }
 
+        let end = base + size;
         if let Some((next_base, &next_idx)) = self.port_index.range(base..).next()
             && *next_base < end
             && let Some((existing_base, existing_size)) =
@@ -602,17 +617,60 @@ impl AxVmDevices {
         Ok(())
     }
 
-    /// Checks whether `addr` conflicts with any already registered system
-    /// register.
-    fn check_sysreg_conflict(&self, addr: u32) -> Result<(), RegistryError> {
-        if let Some(&existing_idx) = self.sysreg_index.get(&addr) {
+    /// Checks whether a system register range conflicts with any already
+    /// registered system register range.
+    fn check_sysreg_conflict(&self, addr: u32, count: u32) -> Result<(), RegistryError> {
+        if count == 0 {
             return Err(RegistryError::AddressConflict {
-                resource: Resource::SysReg { addr },
-                existing: Resource::SysReg { addr },
-                existing_device: DeviceId::new(existing_idx as u32),
+                resource: Resource::SysReg { addr, count },
+                existing: Resource::SysReg { addr: 0, count: 0 },
+                existing_device: DeviceId::new(0),
             });
         }
+
+        let end = addr.saturating_add(count.saturating_sub(1));
+
+        // Check the immediately-preceding key: its range may extend into ours.
+        if let Some((prev_addr, &prev_idx)) = self.sysreg_index.range(..addr).next_back() {
+            let existing_count = self
+                .sysreg_count_of_device(prev_idx, *prev_addr)
+                .unwrap_or(1);
+            let existing_end = prev_addr.saturating_add(existing_count.saturating_sub(1));
+            if existing_end >= addr {
+                return Err(RegistryError::AddressConflict {
+                    resource: Resource::SysReg { addr, count },
+                    existing: Resource::SysReg {
+                        addr: *prev_addr,
+                        count: existing_count,
+                    },
+                    existing_device: DeviceId::new(prev_idx as u32),
+                });
+            }
+        }
+
+        // Check entries whose keys fall within our range.
+        if let Some((reg_addr, &idx)) = self.sysreg_index.range(addr..=end).next() {
+            let existing_count = self.sysreg_count_of_device(idx, *reg_addr).unwrap_or(1);
+            return Err(RegistryError::AddressConflict {
+                resource: Resource::SysReg { addr, count },
+                existing: Resource::SysReg {
+                    addr: *reg_addr,
+                    count: existing_count,
+                },
+                existing_device: DeviceId::new(idx as u32),
+            });
+        }
+
         Ok(())
+    }
+
+    fn sysreg_count_of_device(&self, idx: usize, addr: u32) -> Option<u32> {
+        self.devices[idx].as_ref().and_then(|d| {
+            d.resources().into_iter().find_map(|r| match r {
+                Resource::SysReg { addr: a, count: c } if a == addr => Some(c),
+                _ => None,
+            })
+        })
     }
 
     /// Returns the `(base, size)` of the `MmioRange` resource of
@@ -674,25 +732,8 @@ impl AxVmDevices {
                 Resource::PortRange { base, .. } => {
                     self.port_index.insert(base, idx);
                 }
-                Resource::SysReg { addr } => {
+                Resource::SysReg { addr, .. } => {
                     self.sysreg_index.insert(addr, idx);
-                }
-                _ => { /* skipped until interrupt support is added */ }
-            }
-        }
-    }
-
-    fn remove_resources(&mut self, resources: &[Resource]) {
-        for r in resources {
-            match *r {
-                Resource::MmioRange { base, .. } => {
-                    self.mmio_index.remove(&base);
-                }
-                Resource::PortRange { base, .. } => {
-                    self.port_index.remove(&base);
-                }
-                Resource::SysReg { addr } => {
-                    self.sysreg_index.remove(&addr);
                 }
                 _ => {}
             }
@@ -968,7 +1009,7 @@ impl DeviceRegistry for AxVmDevices {
             match *r {
                 Resource::MmioRange { base, size } => self.check_mmio_conflict(base, size)?,
                 Resource::PortRange { base, size } => self.check_port_conflict(base, size)?,
-                Resource::SysReg { addr } => self.check_sysreg_conflict(addr)?,
+                Resource::SysReg { addr, count } => self.check_sysreg_conflict(addr, count)?,
                 _ => { /* Irq / MSI / PciBar / DmaCapable — handled by factory */ }
             }
         }
@@ -1003,7 +1044,20 @@ impl DeviceRegistry for AxVmDevices {
 
         // Remove from all index maps.
         let resources = device.resources();
-        self.remove_resources(&resources);
+        for r in &resources {
+            match *r {
+                Resource::MmioRange { base, .. } => {
+                    self.mmio_index.remove(&base);
+                }
+                Resource::PortRange { base, .. } => {
+                    self.port_index.remove(&base);
+                }
+                Resource::SysReg { addr, .. } => {
+                    self.sysreg_index.remove(&addr);
+                }
+                _ => {}
+            }
+        }
 
         // Free the slot.
         self.devices[idx] = None;
@@ -1073,6 +1127,7 @@ mod tests {
                 }),
                 BusKind::SysReg => v.push(Resource::SysReg {
                     addr: self.a as u32,
+                    count: 1,
                 }),
             }
             v

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -531,7 +531,8 @@ impl AxVmDevices {
     /// Checks whether `[base, base + size)` conflicts with any already
     /// registered MMIO range.
     fn check_mmio_conflict(&self, base: u64, size: u64) -> Result<(), RegistryError> {
-        if size == 0 {
+        // Reject zero-sized and wrapped ranges (base+size would overflow).
+        if size == 0 || base.checked_add(size).is_none() {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::MmioRange { base, size },
                 existing: Resource::MmioRange { base: 0, size: 0 },
@@ -539,11 +540,14 @@ impl AxVmDevices {
             });
         }
 
+        // checked_add already passed, so end is safe.
+        let end = base + size;
+
         // Check the immediately-preceding entry.
         if let Some((prev_base, &prev_idx)) = self.mmio_index.range(..base).next_back()
             && let Some((existing_base, existing_size)) =
                 self.mmio_range_of_device(prev_idx, *prev_base)
-            && existing_base + existing_size > base
+            && existing_base.wrapping_add(existing_size) > base
         {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::MmioRange { base, size },
@@ -556,7 +560,6 @@ impl AxVmDevices {
         }
 
         // Check the immediately-following entry.
-        let end = base + size;
         if let Some((next_base, &next_idx)) = self.mmio_index.range(base..).next()
             && *next_base < end
             && let Some((existing_base, existing_size)) =
@@ -578,7 +581,7 @@ impl AxVmDevices {
     /// Checks whether `[base, base + size)` conflicts with any already
     /// registered port I/O range.
     fn check_port_conflict(&self, base: u16, size: u16) -> Result<(), RegistryError> {
-        if size == 0 {
+        if size == 0 || base.checked_add(size).is_none() {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::PortRange { base, size },
                 existing: Resource::PortRange { base: 0, size: 0 },
@@ -589,7 +592,7 @@ impl AxVmDevices {
         if let Some((prev_base, &prev_idx)) = self.port_index.range(..base).next_back()
             && let Some((existing_base, existing_size)) =
                 self.port_range_of_device(prev_idx, *prev_base)
-            && existing_base + existing_size > base
+            && existing_base.wrapping_add(existing_size) > base
         {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::PortRange { base, size },
@@ -601,6 +604,7 @@ impl AxVmDevices {
             });
         }
 
+        // checked_add already passed, so end is safe.
         let end = base + size;
         if let Some((next_base, &next_idx)) = self.port_index.range(base..).next()
             && *next_base < end
@@ -704,7 +708,7 @@ impl AxVmDevices {
         let in_range = dev.resources().into_iter().any(|r| {
             matches!(r,
                 Resource::MmioRange { base: b, size: s }
-                if b == base && addr < b + s)
+                if b == base && s > 0 && addr < b.wrapping_add(s))
         });
         in_range.then_some(idx)
     }
@@ -715,7 +719,7 @@ impl AxVmDevices {
         let in_range = dev.resources().into_iter().any(|r| {
             matches!(r,
                 Resource::PortRange { base: b, size: s }
-                if b == base && addr < b + s)
+                if b == base && s > 0 && addr < b.wrapping_add(s))
         });
         in_range.then_some(idx)
     }

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -12,188 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{collections::BTreeMap, format, sync::Arc, vec::Vec};
 use core::ops::Range;
 
 #[cfg(target_arch = "aarch64")]
 use arm_vgic::Vgic;
-use ax_errno::{AxResult, ax_err};
+use ax_errno::{AxResult, ax_err, ax_err_type};
 use ax_kspin::SpinNoIrq as Mutex;
 #[cfg(target_arch = "aarch64")]
 use ax_memory_addr::PhysAddr;
 use ax_memory_addr::is_aligned_4k;
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, BaseMmioDeviceOps, BasePortDeviceOps, BaseSysRegDeviceOps,
-    DeviceAddrRange, Port, PortRange, SysRegAddr, SysRegAddrRange,
+    AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceError, DeviceId,
+    DeviceRegistry, MmioDeviceAdapter, Port, PortDeviceAdapter, RegistryError, Resource,
+    SysRegAddr,
 };
-use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange};
+use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr};
 #[cfg(target_arch = "riscv64")]
 use riscv_vplic::VPlicGlobal;
 #[cfg(target_arch = "x86_64")]
 use x86_vlapic::{EmulatedIoApic, EmulatedPit, EmulatedSerialPort, IoApicInterrupt};
 
 use crate::{
-    AxVmDeviceConfig, DeviceBuildContext, DeviceBundle, DeviceFactoryRegistry, DeviceRegistration,
-    PollableDeviceOps, range_alloc::RangeAllocator,
+    AxVmDeviceConfig, DeviceBuildContext, DeviceBundle, DeviceFactoryRegistry, PollableDeviceOps,
+    range_alloc::RangeAllocator,
 };
 
-/// A set of emulated device types that can be accessed by a specific address range type.
-pub struct AxEmuDevices<R: DeviceAddrRange> {
-    emu_devices: Vec<Arc<dyn BaseDeviceOps<R>>>,
-}
-
-impl<R: DeviceAddrRange + 'static> AxEmuDevices<R> {
-    /// Creates a new [`AxEmuDevices`] instance.
-    pub fn new() -> Self {
-        Self {
-            emu_devices: Vec::new(),
-        }
-    }
-
-    fn validate_dev_against<'a>(
-        dev: &Arc<dyn BaseDeviceOps<R>>,
-        existing_devices: impl IntoIterator<Item = &'a Arc<dyn BaseDeviceOps<R>>>,
-    ) -> AxResult
-    where
-        R: 'a,
-    {
-        let new_range = dev.address_range();
-        let new_type = dev.emu_type();
-
-        if new_range.is_empty() {
-            return ax_err!(
-                InvalidInput,
-                format_args!(
-                    "failed to register {} device type {} at range {new_range:#x}: range is empty \
-                     or invalid, possibly due to address overflow",
-                    R::BUS_NAME,
-                    new_type,
-                )
-            );
-        }
-
-        for existing in existing_devices {
-            let existing_range = existing.address_range();
-            let existing_type = existing.emu_type();
-
-            if Arc::ptr_eq(existing, dev) {
-                return ax_err!(
-                    AlreadyExists,
-                    format_args!(
-                        "failed to register {} device type {} at range {new_range:#x}: the same \
-                         device is already registered as type {} at range {existing_range:#x}",
-                        R::BUS_NAME,
-                        new_type,
-                        existing_type,
-                    )
-                );
-            }
-
-            if new_range == existing_range {
-                return ax_err!(
-                    AlreadyExists,
-                    format_args!(
-                        "failed to register {} device type {} at range {new_range:#x}: range is \
-                         already registered by device type {} at range {existing_range:#x}",
-                        R::BUS_NAME,
-                        new_type,
-                        existing_type,
-                    )
-                );
-            }
-
-            if new_range.overlaps(&existing_range) {
-                return ax_err!(
-                    AddrInUse,
-                    format_args!(
-                        "failed to register {} device type {} at range {new_range:#x}: overlaps \
-                         device type {} at range {existing_range:#x}",
-                        R::BUS_NAME,
-                        new_type,
-                        existing_type,
-                    )
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Validates a group of devices without modifying this set.
-    fn validate_devices(&self, devices: &[Arc<dyn BaseDeviceOps<R>>]) -> AxResult {
-        for (index, device) in devices.iter().enumerate() {
-            Self::validate_dev_against(
-                device,
-                self.emu_devices.iter().chain(devices[..index].iter()),
-            )?;
-        }
-        Ok(())
-    }
-
-    /// Adds a device to the set after validating its range.
-    pub fn add_dev(&mut self, dev: Arc<dyn BaseDeviceOps<R>>) -> AxResult {
-        self.validate_devices(core::slice::from_ref(&dev))?;
-        self.emu_devices.push(dev);
-        Ok(())
-    }
-
-    fn commit_devices(&mut self, devices: Vec<Arc<dyn BaseDeviceOps<R>>>) {
-        self.emu_devices.extend(devices);
-    }
-
-    // pub fn remove_dev(&mut self, ...)
-    //
-    // `remove_dev` seems to need something like `downcast-rs` to make sense. As it's not likely to
-    // be able to have a proper predicate to remove a device from the list without knowing the
-    // concrete type of the device.
-
-    /// Find a device by address.
-    pub fn find_dev(&self, addr: R::Addr) -> Option<Arc<dyn BaseDeviceOps<R>>> {
-        self.emu_devices
-            .iter()
-            .find(|&dev| dev.address_range().contains(addr))
-            .cloned()
-    }
-
-    /// Iterates over the devices in the set.
-    pub fn iter(&self) -> impl Iterator<Item = &Arc<dyn BaseDeviceOps<R>>> {
-        self.emu_devices.iter()
-    }
-
-    /// Iterates over the devices in the set mutably.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Arc<dyn BaseDeviceOps<R>>> {
-        self.emu_devices.iter_mut()
-    }
-}
-
-impl<R: DeviceAddrRange + 'static> Default for AxEmuDevices<R> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-type AxEmuMmioDevices = AxEmuDevices<GuestPhysAddrRange>;
-type AxEmuSysRegDevices = AxEmuDevices<SysRegAddrRange>;
-type AxEmuPortDevices = AxEmuDevices<PortRange>;
-
-/// represent A vm own devices
-pub struct AxVmDevices {
-    /// emu devices
-    emu_mmio_devices: AxEmuMmioDevices,
-    emu_sys_reg_devices: AxEmuSysRegDevices,
-    emu_port_devices: AxEmuPortDevices,
-    pollable_devices: Vec<Arc<dyn PollableDeviceOps>>,
-    #[cfg(target_arch = "x86_64")]
-    x86_ioapic: Option<Arc<EmulatedIoApic>>,
-    #[cfg(target_arch = "x86_64")]
-    x86_pit: Option<Arc<EmulatedPit>>,
-    #[cfg(target_arch = "x86_64")]
-    x86_serial: Option<Arc<EmulatedSerialPort>>,
-    /// IVC channel range allocator
-    ivc_channel: Option<Mutex<RangeAllocator>>,
-}
-
 #[inline]
+#[allow(dead_code)]
 fn log_device_io(
     addr_type: &'static str,
     addr: impl core::fmt::LowerHex,
@@ -205,27 +51,39 @@ fn log_device_io(
     trace!("emu_device {rw}: {addr_type} {addr:#x} in range {addr_range:#x} with width {width:?}")
 }
 
-#[inline]
-fn panic_device_not_found(
-    addr_type: &'static str,
-    addr: impl core::fmt::LowerHex,
-    read: bool,
-    width: AccessWidth,
-) -> ! {
-    let rw = if read { "read" } else { "write" };
-    error!(
-        "emu_device {rw} failed: device not found for {addr_type} {addr:#x} with width {width:?}"
-    );
-    panic!("emu_device not found");
+/// represent A vm own devices
+pub struct AxVmDevices {
+    /// Device slots (None = freed and available for reuse).
+    devices: Vec<Option<Arc<dyn Device>>>,
+    /// MMIO base address → device slot index.
+    mmio_index: BTreeMap<u64, usize>,
+    /// Port I/O base address → device slot index.
+    port_index: BTreeMap<u16, usize>,
+    /// System register address → device slot index.
+    sysreg_index: BTreeMap<u32, usize>,
+    /// Devices that require periodic polling.
+    pollable_devices: Vec<Arc<dyn PollableDeviceOps>>,
+    /// x86 IOAPIC — kept for type-specific access.
+    #[cfg(target_arch = "x86_64")]
+    x86_ioapic: Option<Arc<EmulatedIoApic>>,
+    /// x86 PIT — kept for type-specific access.
+    #[cfg(target_arch = "x86_64")]
+    x86_pit: Option<Arc<EmulatedPit>>,
+    /// x86 16550 serial port — kept for type-specific access.
+    #[cfg(target_arch = "x86_64")]
+    x86_serial: Option<Arc<EmulatedSerialPort>>,
+    /// IVC channel range allocator
+    ivc_channel: Option<Mutex<RangeAllocator>>,
 }
 
 /// The implemention for AxVmDevices
 impl AxVmDevices {
     fn empty() -> Self {
         Self {
-            emu_mmio_devices: AxEmuMmioDevices::new(),
-            emu_sys_reg_devices: AxEmuSysRegDevices::new(),
-            emu_port_devices: AxEmuPortDevices::new(),
+            devices: Vec::new(),
+            mmio_index: BTreeMap::new(),
+            port_index: BTreeMap::new(),
+            sysreg_index: BTreeMap::new(),
             pollable_devices: Vec::new(),
             #[cfg(target_arch = "x86_64")]
             x86_ioapic: None,
@@ -303,7 +161,13 @@ impl AxVmDevices {
                 EmulatedDeviceType::InterruptController => {
                     #[cfg(target_arch = "aarch64")]
                     {
-                        this.add_mmio_dev(Arc::new(Vgic::new()))?;
+                        #[allow(clippy::arc_with_non_send_sync)]
+                        this.register(
+                            MmioDeviceAdapter::from_arc(Arc::new(Vgic::new())) as Arc<dyn Device>
+                        )
+                        .map_err(|e| {
+                            ax_err_type!(InvalidInput, alloc::format!("register vgic: {e:?}"))
+                        })?;
                     }
                     #[cfg(not(target_arch = "aarch64"))]
                     {
@@ -339,11 +203,19 @@ impl AxVmDevices {
                             let addr = config.base_gpa + i * stride;
                             let size = config.length;
                             #[allow(clippy::arc_with_non_send_sync)]
-                            this.add_mmio_dev(Arc::new(arm_vgic::v3::vgicr::VGicR::new(
-                                addr.into(),
-                                Some(size),
-                                pcpu_id + i,
-                            )))?;
+                            this.register(MmioDeviceAdapter::from_arc(Arc::new(
+                                arm_vgic::v3::vgicr::VGicR::new(
+                                    addr.into(),
+                                    Some(size),
+                                    pcpu_id + i,
+                                ),
+                            )) as Arc<dyn Device>)
+                                .map_err(|e| {
+                                    ax_err_type!(
+                                        InvalidInput,
+                                        alloc::format!("register gicr: {e:?}")
+                                    )
+                                })?;
 
                             info!(
                                 "GPPT Redistributor initialized for vCPU {i} with base GPA \
@@ -363,10 +235,15 @@ impl AxVmDevices {
                     #[cfg(target_arch = "aarch64")]
                     {
                         #[allow(clippy::arc_with_non_send_sync)]
-                        this.add_mmio_dev(Arc::new(arm_vgic::v3::vgicd::VGicD::new(
-                            config.base_gpa.into(),
-                            Some(config.length),
-                        )))?;
+                        this.register(MmioDeviceAdapter::from_arc(Arc::new(
+                            arm_vgic::v3::vgicd::VGicD::new(
+                                config.base_gpa.into(),
+                                Some(config.length),
+                            ),
+                        )) as Arc<dyn Device>)
+                            .map_err(|e| {
+                                ax_err_type!(InvalidInput, alloc::format!("register gicd: {e:?}"))
+                            })?;
 
                         info!(
                             "GPPT Distributor initialized with base GPA {base_gpa:#x} and length \
@@ -394,12 +271,17 @@ impl AxVmDevices {
                             .expect("expect 1 arg for gppt its (host_gits_base)");
 
                         #[allow(clippy::arc_with_non_send_sync)]
-                        this.add_mmio_dev(Arc::new(arm_vgic::v3::gits::Gits::new(
-                            config.base_gpa.into(),
-                            Some(config.length),
-                            host_gits_base,
-                            false,
-                        )))?;
+                        this.register(MmioDeviceAdapter::from_arc(Arc::new(
+                            arm_vgic::v3::gits::Gits::new(
+                                config.base_gpa.into(),
+                                Some(config.length),
+                                host_gits_base,
+                                false,
+                            ),
+                        )) as Arc<dyn Device>)
+                            .map_err(|e| {
+                                ax_err_type!(InvalidInput, alloc::format!("register gits: {e:?}"))
+                            })?;
 
                         info!(
                             "GPPT ITS initialized with base GPA {base_gpa:#x} and length \
@@ -425,11 +307,14 @@ impl AxVmDevices {
                             .first()
                             .copied()
                             .expect("expect 1 arg for pppt global (context_num)");
-                        this.add_mmio_dev(Arc::new(VPlicGlobal::new(
+                        this.register(MmioDeviceAdapter::from_arc(Arc::new(VPlicGlobal::new(
                             config.base_gpa.into(),
                             Some(config.length),
-                            context_num, // Here only 1 core and should be cpu0
-                        )))?;
+                            context_num,
+                        ))) as Arc<dyn Device>)
+                            .map_err(|e| {
+                                ax_err_type!(InvalidInput, alloc::format!("register pppt: {e:?}"))
+                            })?;
                         // PLIC Partial Passthrough Global.
                         info!(
                             "Partial PLIC Passthrough Global initialized with base GPA {:#x} and \
@@ -449,7 +334,11 @@ impl AxVmDevices {
                     #[cfg(target_arch = "x86_64")]
                     {
                         let serial = Arc::new(EmulatedSerialPort::new());
-                        this.add_port_dev(serial.clone())?;
+                        this.register(PortDeviceAdapter::from_arc(serial.clone())
+                            as Arc<dyn Device + Send + Sync + 'static>)
+                            .map_err(|e| {
+                                ax_err_type!(InvalidInput, format!("register x86 serial: {e:?}"))
+                            })?;
                         this.x86_serial = Some(serial);
                         info!("x86 16550 serial initialized for ports 0x3f8..=0x3ff");
                     }
@@ -468,7 +357,11 @@ impl AxVmDevices {
                             config.base_gpa.into(),
                             Some(config.length),
                         ));
-                        this.add_mmio_dev(ioapic.clone())?;
+                        this.register(MmioDeviceAdapter::from_arc(ioapic.clone())
+                            as Arc<dyn Device + Send + Sync + 'static>)
+                            .map_err(|e| {
+                                ax_err_type!(InvalidInput, format!("register x86 ioapic: {e:?}"))
+                            })?;
                         this.x86_ioapic = Some(ioapic);
                         info!(
                             "x86 IO APIC initialized with base GPA {:#x} and length {:#x}",
@@ -487,7 +380,10 @@ impl AxVmDevices {
                     #[cfg(target_arch = "x86_64")]
                     {
                         let pit = Arc::new(EmulatedPit::new());
-                        this.add_port_dev(pit.clone())?;
+                        this.register(PortDeviceAdapter::from_arc(pit.clone()) as Arc<dyn Device>)
+                            .map_err(|e| {
+                                ax_err_type!(InvalidInput, format!("register x86 pit: {e:?}"))
+                            })?;
                         this.x86_pit = Some(pit);
                         info!("x86 PIT initialized for ports 0x40..=0x43 and 0x61");
                     }
@@ -575,12 +471,9 @@ impl AxVmDevices {
         }
     }
 
-    /// Registers a bundle atomically after validating all capabilities.
+    /// Registers a bundle atomically.  Conflict detection is performed by
+    /// [`AxVmDevices::register`].
     pub fn register_bundle(&mut self, bundle: DeviceBundle) -> AxResult {
-        self.emu_mmio_devices.validate_devices(&bundle.mmio)?;
-        self.emu_port_devices.validate_devices(&bundle.port)?;
-        self.emu_sys_reg_devices.validate_devices(&bundle.sysreg)?;
-
         for (index, pollable) in bundle.pollable.iter().enumerate() {
             if self
                 .pollable_devices
@@ -595,41 +488,243 @@ impl AxVmDevices {
             }
         }
 
-        self.emu_mmio_devices.commit_devices(bundle.mmio);
-        self.emu_port_devices.commit_devices(bundle.port);
-        self.emu_sys_reg_devices.commit_devices(bundle.sysreg);
+        for device in bundle.devices {
+            self.register(device).map_err(|e| {
+                ax_err_type!(InvalidInput, format!("device registration failed: {e:?}"))
+            })?;
+        }
         self.pollable_devices.extend(bundle.pollable);
         Ok(())
     }
 
-    /// Add a MMIO device to the device list
-    pub fn add_mmio_dev(&mut self, dev: Arc<dyn BaseMmioDeviceOps>) -> AxResult {
-        self.register_bundle(DeviceRegistration::Mmio(dev).into())
+    // ─── Registration helpers ───────────────────────────────────────
+
+    /// Finds a free slot in `devices` or appends a new one, returning the
+    /// index.
+    fn alloc_slot(&mut self) -> usize {
+        match self.devices.iter().position(|slot| slot.is_none()) {
+            Some(idx) => idx,
+            None => {
+                self.devices.push(None);
+                self.devices.len() - 1
+            }
+        }
     }
 
-    /// Add a system register device to the device list
-    pub fn add_sys_reg_dev(&mut self, dev: Arc<dyn BaseSysRegDeviceOps>) -> AxResult {
-        self.register_bundle(DeviceRegistration::SysReg(dev).into())
+    /// Checks whether `[base, base + size)` conflicts with any already
+    /// registered MMIO range.
+    fn check_mmio_conflict(&self, base: u64, size: u64) -> Result<(), RegistryError> {
+        let end = base
+            .checked_add(size)
+            .ok_or_else(|| RegistryError::AddressConflict {
+                resource: Resource::MmioRange { base, size },
+                existing: Resource::MmioRange { base: 0, size: 0 },
+                existing_device: DeviceId::new(0),
+            })?;
+
+        // Check the immediately-preceding entry.
+        if let Some((prev_base, &prev_idx)) = self.mmio_index.range(..base).next_back()
+            && let Some((existing_base, existing_size)) =
+                self.mmio_range_of_device(prev_idx, *prev_base)
+            && existing_base + existing_size > base
+        {
+            return Err(RegistryError::AddressConflict {
+                resource: Resource::MmioRange { base, size },
+                existing: Resource::MmioRange {
+                    base: existing_base,
+                    size: existing_size,
+                },
+                existing_device: DeviceId::new(prev_idx as u32),
+            });
+        }
+
+        // Check the immediately-following entry.
+        if let Some((next_base, &next_idx)) = self.mmio_index.range(base..).next()
+            && *next_base < end
+            && let Some((existing_base, existing_size)) =
+                self.mmio_range_of_device(next_idx, *next_base)
+        {
+            return Err(RegistryError::AddressConflict {
+                resource: Resource::MmioRange { base, size },
+                existing: Resource::MmioRange {
+                    base: existing_base,
+                    size: existing_size,
+                },
+                existing_device: DeviceId::new(next_idx as u32),
+            });
+        }
+
+        Ok(())
     }
 
-    /// Add a port device to the device list
-    pub fn add_port_dev(&mut self, dev: Arc<dyn BasePortDeviceOps>) -> AxResult {
-        self.register_bundle(DeviceRegistration::Port(dev).into())
+    /// Checks whether `[base, base + size)` conflicts with any already
+    /// registered port I/O range.
+    fn check_port_conflict(&self, base: u16, size: u16) -> Result<(), RegistryError> {
+        let end = base
+            .checked_add(size)
+            .ok_or_else(|| RegistryError::AddressConflict {
+                resource: Resource::PortRange { base, size },
+                existing: Resource::PortRange { base: 0, size: 0 },
+                existing_device: DeviceId::new(0),
+            })?;
+
+        if let Some((prev_base, &prev_idx)) = self.port_index.range(..base).next_back()
+            && let Some((existing_base, existing_size)) =
+                self.port_range_of_device(prev_idx, *prev_base)
+            && existing_base + existing_size > base
+        {
+            return Err(RegistryError::AddressConflict {
+                resource: Resource::PortRange { base, size },
+                existing: Resource::PortRange {
+                    base: existing_base,
+                    size: existing_size,
+                },
+                existing_device: DeviceId::new(prev_idx as u32),
+            });
+        }
+
+        if let Some((next_base, &next_idx)) = self.port_index.range(base..).next()
+            && *next_base < end
+            && let Some((existing_base, existing_size)) =
+                self.port_range_of_device(next_idx, *next_base)
+        {
+            return Err(RegistryError::AddressConflict {
+                resource: Resource::PortRange { base, size },
+                existing: Resource::PortRange {
+                    base: existing_base,
+                    size: existing_size,
+                },
+                existing_device: DeviceId::new(next_idx as u32),
+            });
+        }
+
+        Ok(())
     }
 
-    /// Iterates over the MMIO devices in the set.
-    pub fn iter_mmio_dev(&self) -> impl Iterator<Item = &Arc<dyn BaseMmioDeviceOps>> {
-        self.emu_mmio_devices.iter()
+    /// Checks whether `addr` conflicts with any already registered system
+    /// register.
+    fn check_sysreg_conflict(&self, addr: u32) -> Result<(), RegistryError> {
+        if let Some(&existing_idx) = self.sysreg_index.get(&addr) {
+            return Err(RegistryError::AddressConflict {
+                resource: Resource::SysReg { addr },
+                existing: Resource::SysReg { addr },
+                existing_device: DeviceId::new(existing_idx as u32),
+            });
+        }
+        Ok(())
     }
 
-    /// Iterates over the system register devices in the set.
-    pub fn iter_sys_reg_dev(&self) -> impl Iterator<Item = &Arc<dyn BaseSysRegDeviceOps>> {
-        self.emu_sys_reg_devices.iter()
+    /// Returns the `(base, size)` of the `MmioRange` resource of
+    /// `devices[idx]` whose `base` matches.
+    fn mmio_range_of_device(&self, idx: usize, base: u64) -> Option<(u64, u64)> {
+        let dev = self.devices[idx].as_ref()?;
+        dev.resources().into_iter().find_map(|r| match r {
+            Resource::MmioRange { base: b, size: s } if b == base => Some((b, s)),
+            _ => None,
+        })
     }
 
-    /// Iterates over the port devices in the set.
-    pub fn iter_port_dev(&self) -> impl Iterator<Item = &Arc<dyn BasePortDeviceOps>> {
-        self.emu_port_devices.iter()
+    /// Returns the `(base, size)` of the `PortRange` resource of
+    /// `devices[idx]` whose `base` matches.
+    fn port_range_of_device(&self, idx: usize, base: u16) -> Option<(u16, u16)> {
+        let dev = self.devices[idx].as_ref()?;
+        dev.resources().into_iter().find_map(|r| match r {
+            Resource::PortRange { base: b, size: s } if b == base => Some((b, s)),
+            _ => None,
+        })
+    }
+
+    // ─── Lookup helpers ────────────────────────────────────────────
+
+    fn lookup_mmio(&self, addr: u64) -> Option<usize> {
+        let (&base, &idx) = self.mmio_index.range(..=addr).next_back()?;
+        let dev = self.devices[idx].as_ref()?;
+        let in_range = dev.resources().into_iter().any(|r| {
+            matches!(r,
+                Resource::MmioRange { base: b, size: s }
+                if b == base && addr < b + s)
+        });
+        in_range.then_some(idx)
+    }
+
+    fn lookup_port(&self, addr: u16) -> Option<usize> {
+        let (&base, &idx) = self.port_index.range(..=addr).next_back()?;
+        let dev = self.devices[idx].as_ref()?;
+        let in_range = dev.resources().into_iter().any(|r| {
+            matches!(r,
+                Resource::PortRange { base: b, size: s }
+                if b == base && addr < b + s)
+        });
+        in_range.then_some(idx)
+    }
+
+    fn lookup_sysreg(&self, addr: u32) -> Option<usize> {
+        self.sysreg_index.get(&addr).copied()
+    }
+
+    // ─── BTreeMap insertion / removal ──────────────────────────────
+
+    fn insert_resources(&mut self, idx: usize, resources: &[Resource]) {
+        for r in resources {
+            match *r {
+                Resource::MmioRange { base, .. } => {
+                    self.mmio_index.insert(base, idx);
+                }
+                Resource::PortRange { base, .. } => {
+                    self.port_index.insert(base, idx);
+                }
+                Resource::SysReg { addr } => {
+                    self.sysreg_index.insert(addr, idx);
+                }
+                _ => { /* skipped until interrupt support is added */ }
+            }
+        }
+    }
+
+    fn remove_resources(&mut self, resources: &[Resource]) {
+        for r in resources {
+            match *r {
+                Resource::MmioRange { base, .. } => {
+                    self.mmio_index.remove(&base);
+                }
+                Resource::PortRange { base, .. } => {
+                    self.port_index.remove(&base);
+                }
+                Resource::SysReg { addr } => {
+                    self.sysreg_index.remove(&addr);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // ─── Public helpers ───────────────────────────────────────────
+
+    /// Returns an iterator over all currently registered devices.
+    pub fn devices(&self) -> impl Iterator<Item = &dyn Device> {
+        self.devices.iter().filter_map(|slot| slot.as_deref())
+    }
+
+    /// Returns the number of currently registered devices.
+    pub fn device_count(&self) -> usize {
+        self.devices.iter().filter(|slot| slot.is_some()).count()
+    }
+
+    // ─── Iterator helpers ───────────────────────────────────────────
+
+    /// Iterates over all registered devices.
+    pub fn iter_mmio_dev(&self) -> impl Iterator<Item = &dyn Device> {
+        self.devices()
+    }
+
+    /// Iterates over all registered devices.
+    pub fn iter_sys_reg_dev(&self) -> impl Iterator<Item = &dyn Device> {
+        self.devices()
+    }
+
+    /// Iterates over all registered devices.
+    pub fn iter_port_dev(&self) -> impl Iterator<Item = &dyn Device> {
+        self.devices()
     }
 
     /// Iterates over devices that require periodic polling.
@@ -637,7 +732,7 @@ impl AxVmDevices {
         self.pollable_devices.iter()
     }
 
-    /// Returns the guest vector programmed for an x86 IOAPIC GSI.
+    // ─── x86 IOAPIC / PIT / Serial ──────────────────────────────────
     #[cfg(target_arch = "x86_64")]
     pub fn x86_ioapic_vector_for_gsi(&self, gsi: usize) -> Option<u8> {
         self.x86_ioapic
@@ -677,108 +772,435 @@ impl AxVmDevices {
             .is_some_and(|serial| serial.poll_irq())
     }
 
-    /// Iterates over the MMIO devices in the set.
-    pub fn iter_mut_mmio_dev(&mut self) -> impl Iterator<Item = &mut Arc<dyn BaseMmioDeviceOps>> {
-        self.emu_mmio_devices.iter_mut()
+    // ─── Find helpers ───────────────────────────────────────────────
+
+    /// Find specific MMIO device by ipa.
+    /// Returns a reference to the underlying adapter which can be downcast
+    /// via `as_any()`.
+    pub fn find_mmio_dev(&self, ipa: GuestPhysAddr) -> Option<Arc<dyn Device>> {
+        let access = BusAccess {
+            kind: BusKind::Mmio,
+            is_read: true,
+            addr: ipa.as_usize() as u64,
+            width: AccessWidth::Dword,
+            data: 0,
+        };
+        self.lookup(&access).ok()
     }
 
-    /// Iterates over the system register devices in the set.
-    pub fn iter_mut_sys_reg_dev(
-        &mut self,
-    ) -> impl Iterator<Item = &mut Arc<dyn BaseSysRegDeviceOps>> {
-        self.emu_sys_reg_devices.iter_mut()
+    /// Find specific system register device by address.
+    pub fn find_sys_reg_dev(&self, sys_reg_addr: SysRegAddr) -> Option<Arc<dyn Device>> {
+        let access = BusAccess {
+            kind: BusKind::SysReg,
+            is_read: true,
+            addr: sys_reg_addr.0 as u64,
+            width: AccessWidth::Qword,
+            data: 0,
+        };
+        self.lookup(&access).ok()
     }
 
-    /// Iterates over the port devices in the set.
-    pub fn iter_mut_port_dev(&mut self) -> impl Iterator<Item = &mut Arc<dyn BasePortDeviceOps>> {
-        self.emu_port_devices.iter_mut()
+    /// Find specific port device by port number.
+    pub fn find_port_dev(&self, port: Port) -> Option<Arc<dyn Device>> {
+        let access = BusAccess {
+            kind: BusKind::Port,
+            is_read: true,
+            addr: port.0 as u64,
+            width: AccessWidth::Byte,
+            data: 0,
+        };
+        self.lookup(&access).ok()
     }
 
-    /// Find specific MMIO device by ipa
-    pub fn find_mmio_dev(&self, ipa: GuestPhysAddr) -> Option<Arc<dyn BaseMmioDeviceOps>> {
-        self.emu_mmio_devices.find_dev(ipa)
-    }
+    // ─── Hot-path dispatch handlers ─────────────────────────────────
 
-    /// Find specific system register device by ipa
-    pub fn find_sys_reg_dev(
-        &self,
-        sys_reg_addr: SysRegAddr,
-    ) -> Option<Arc<dyn BaseSysRegDeviceOps>> {
-        self.emu_sys_reg_devices.find_dev(sys_reg_addr)
-    }
-
-    /// Find specific port device by port number
-    pub fn find_port_dev(&self, port: Port) -> Option<Arc<dyn BasePortDeviceOps>> {
-        self.emu_port_devices.find_dev(port)
-    }
-
-    /// Handle the MMIO read by GuestPhysAddr and data width, return the value of the guest want to read
+    /// Handle the MMIO read by GuestPhysAddr and data width.
     pub fn handle_mmio_read(&self, addr: GuestPhysAddr, width: AccessWidth) -> AxResult<usize> {
-        if let Some(emu_dev) = self.find_mmio_dev(addr) {
-            log_device_io("mmio", addr, emu_dev.address_range(), true, width);
-
-            return emu_dev.handle_read(addr, width);
+        let access = BusAccess {
+            kind: BusKind::Mmio,
+            is_read: true,
+            addr: addr.as_usize() as u64,
+            width,
+            data: 0,
+        };
+        match self.dispatch(&access) {
+            Ok(BusResponse::Read { value }) => Ok(value as usize),
+            Ok(BusResponse::Write) => {
+                Err(ax_err_type!(BadState, "expected read response, got write"))
+            }
+            Err(err) => {
+                error!("emu_device mmio read failed: {err:?} at {addr:#x} width {width:?}");
+                Err(ax_err_type!(BadState, format!("mmio read: {err:?}")))
+            }
         }
-        panic_device_not_found("mmio", addr, true, width);
     }
 
-    /// Handle the MMIO write by GuestPhysAddr, data width and the value need to write, call specific device to write the value
+    /// Handle the MMIO write by GuestPhysAddr, data width and the value need to write.
     pub fn handle_mmio_write(
         &self,
         addr: GuestPhysAddr,
         width: AccessWidth,
         val: usize,
     ) -> AxResult {
-        if let Some(emu_dev) = self.find_mmio_dev(addr) {
-            log_device_io("mmio", addr, emu_dev.address_range(), false, width);
-
-            return emu_dev.handle_write(addr, width, val);
+        let access = BusAccess {
+            kind: BusKind::Mmio,
+            is_read: false,
+            addr: addr.as_usize() as u64,
+            width,
+            data: val as u64,
+        };
+        if let Err(err) = self.dispatch(&access) {
+            error!("emu_device mmio write failed: {err:?} at {addr:#x} width {width:?}");
+            return Err(ax_err_type!(BadState, format!("mmio write: {err:?}")));
         }
-        panic_device_not_found("mmio", addr, false, width);
+        Ok(())
     }
 
-    /// Handle the system register read by SysRegAddr and data width, return the value of the guest want to read
+    /// Handle the system register read by SysRegAddr and data width.
     pub fn handle_sys_reg_read(&self, addr: SysRegAddr, width: AccessWidth) -> AxResult<usize> {
-        if let Some(emu_dev) = self.find_sys_reg_dev(addr) {
-            log_device_io("sys_reg", addr.0, emu_dev.address_range(), true, width);
-
-            return emu_dev.handle_read(addr, width);
+        let access = BusAccess {
+            kind: BusKind::SysReg,
+            is_read: true,
+            addr: addr.0 as u64,
+            width,
+            data: 0,
+        };
+        match self.dispatch(&access) {
+            Ok(BusResponse::Read { value }) => Ok(value as usize),
+            Ok(BusResponse::Write) => {
+                Err(ax_err_type!(BadState, "expected read response, got write"))
+            }
+            Err(err) => {
+                error!(
+                    "emu_device sys_reg read failed: {err:?} at {:#x} width {width:?}",
+                    addr.0
+                );
+                Err(ax_err_type!(BadState, format!("sysreg read: {err:?}")))
+            }
         }
-        panic_device_not_found("sys_reg", addr, true, width);
     }
 
-    /// Handle the system register write by SysRegAddr, data width and the value need to write, call specific device to write the value
+    /// Handle the system register write by SysRegAddr, data width and the value need to write.
     pub fn handle_sys_reg_write(
         &self,
         addr: SysRegAddr,
         width: AccessWidth,
         val: usize,
     ) -> AxResult {
-        if let Some(emu_dev) = self.find_sys_reg_dev(addr) {
-            log_device_io("sys_reg", addr.0, emu_dev.address_range(), false, width);
-
-            return emu_dev.handle_write(addr, width, val);
+        let access = BusAccess {
+            kind: BusKind::SysReg,
+            is_read: false,
+            addr: addr.0 as u64,
+            width,
+            data: val as u64,
+        };
+        if let Err(err) = self.dispatch(&access) {
+            error!(
+                "emu_device sys_reg write failed: {err:?} at {:#x} width {width:?}",
+                addr.0
+            );
+            return Err(ax_err_type!(BadState, format!("sysreg write: {err:?}")));
         }
-        panic_device_not_found("sys_reg", addr, false, width);
+        Ok(())
     }
 
-    /// Handle the port read by port number and data width, return the value of the guest want to read
+    /// Handle the port read by port number and data width.
     pub fn handle_port_read(&self, port: Port, width: AccessWidth) -> AxResult<usize> {
-        if let Some(emu_dev) = self.find_port_dev(port) {
-            log_device_io("port", port.0, emu_dev.address_range(), true, width);
-
-            return emu_dev.handle_read(port, width);
+        let access = BusAccess {
+            kind: BusKind::Port,
+            is_read: true,
+            addr: port.0 as u64,
+            width,
+            data: 0,
+        };
+        match self.dispatch(&access) {
+            Ok(BusResponse::Read { value }) => Ok(value as usize),
+            Ok(BusResponse::Write) => {
+                Err(ax_err_type!(BadState, "expected read response, got write"))
+            }
+            Err(err) => {
+                error!(
+                    "emu_device port read failed: {err:?} at {:#x} width {width:?}",
+                    port.0
+                );
+                Err(ax_err_type!(BadState, format!("port read: {err:?}")))
+            }
         }
-        panic_device_not_found("port", port, true, width);
     }
 
-    /// Handle the port write by port number, data width and the value need to write, call specific device to write the value
+    /// Handle the port write by port number, data width and the value need to write.
     pub fn handle_port_write(&self, port: Port, width: AccessWidth, val: usize) -> AxResult {
-        if let Some(emu_dev) = self.find_port_dev(port) {
-            log_device_io("port", port.0, emu_dev.address_range(), false, width);
-
-            return emu_dev.handle_write(port, width, val);
+        let access = BusAccess {
+            kind: BusKind::Port,
+            is_read: false,
+            addr: port.0 as u64,
+            width,
+            data: val as u64,
+        };
+        if let Err(err) = self.dispatch(&access) {
+            error!(
+                "emu_device port write failed: {err:?} at {:#x} width {width:?}",
+                port.0
+            );
+            return Err(ax_err_type!(BadState, format!("port write: {err:?}")));
         }
-        panic_device_not_found("port", port, false, width);
+        Ok(())
+    }
+}
+
+impl Default for AxVmDevices {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Trait implementations
+// ---------------------------------------------------------------------------
+
+impl DeviceRegistry for AxVmDevices {
+    fn register(&mut self, device: Arc<dyn Device>) -> Result<DeviceId, RegistryError> {
+        let resources = device.resources();
+
+        // 1. Conflict detection (only for address-range resources).
+        for r in &resources {
+            match *r {
+                Resource::MmioRange { base, size } => self.check_mmio_conflict(base, size)?,
+                Resource::PortRange { base, size } => self.check_port_conflict(base, size)?,
+                Resource::SysReg { addr } => self.check_sysreg_conflict(addr)?,
+                _ => { /* Irq / MSI / PciBar / DmaCapable — handled by factory */ }
+            }
+        }
+
+        // 2. Allocate a slot.
+        let idx = self.alloc_slot();
+
+        // 3. Insert into index maps.
+        self.insert_resources(idx, &resources);
+
+        // 4. Store the device.
+        self.devices[idx] = Some(device);
+
+        info!("AxVmDevices: registered device id={}", idx);
+        Ok(DeviceId::new(idx as u32))
+    }
+
+    fn unregister(&mut self, id: DeviceId) -> Result<(), RegistryError> {
+        let idx = id.as_u32() as usize;
+
+        let device = self
+            .devices
+            .get(idx)
+            .and_then(|slot| slot.as_ref())
+            .ok_or_else(|| {
+                warn!(
+                    "AxVmDevices: unregister failed — DeviceId({}) not found",
+                    idx
+                );
+                RegistryError::DeviceNotFound(id)
+            })?;
+
+        // Remove from all index maps.
+        let resources = device.resources();
+        self.remove_resources(&resources);
+
+        // Free the slot.
+        self.devices[idx] = None;
+
+        info!("AxVmDevices: unregistered device id={}", idx);
+        Ok(())
+    }
+}
+
+impl BusRouter for AxVmDevices {
+    fn dispatch(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+        let idx = match access.kind {
+            BusKind::Mmio => self.lookup_mmio(access.addr),
+            BusKind::Port => self.lookup_port(access.addr as u16),
+            BusKind::SysReg => self.lookup_sysreg(access.addr as u32),
+        }
+        .ok_or(DeviceError::NotFound)?;
+
+        let device = self.devices[idx].as_ref().ok_or(DeviceError::NotFound)?;
+        device.handle(access)
+    }
+
+    fn lookup(&self, access: &BusAccess) -> Result<Arc<dyn Device>, DeviceError> {
+        let idx = match access.kind {
+            BusKind::Mmio => self.lookup_mmio(access.addr),
+            BusKind::Port => self.lookup_port(access.addr as u16),
+            BusKind::SysReg => self.lookup_sysreg(access.addr as u32),
+        }
+        .ok_or(DeviceError::NotFound)?;
+
+        self.devices[idx].clone().ok_or(DeviceError::NotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{sync::Arc, vec::Vec};
+    use core::any::Any;
+
+    use axdevice_base::{
+        AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceError,
+        DeviceRegistry, RegistryError, Resource,
+    };
+
+    use super::AxVmDevices;
+
+    struct D {
+        a: u64,
+        s: u64,
+        n: &'static str,
+        k: BusKind,
+    }
+    impl Device for D {
+        fn name(&self) -> &str {
+            self.n
+        }
+        fn resources(&self) -> Vec<Resource> {
+            let mut v = Vec::new();
+            match self.k {
+                BusKind::Mmio => v.push(Resource::MmioRange {
+                    base: self.a,
+                    size: self.s,
+                }),
+                BusKind::Port => v.push(Resource::PortRange {
+                    base: self.a as u16,
+                    size: self.s as u16,
+                }),
+                BusKind::SysReg => v.push(Resource::SysReg {
+                    addr: self.a as u32,
+                }),
+            }
+            v
+        }
+        fn handle(&self, _a: &BusAccess) -> Result<BusResponse, DeviceError> {
+            Ok(BusResponse::Read { value: 0 })
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn test_register_dispatch() {
+        let mut m = AxVmDevices::empty();
+        m.register(Arc::new(D {
+            a: 0x1000,
+            s: 0x100,
+            n: "d",
+            k: BusKind::Mmio,
+        }))
+        .unwrap();
+        assert!(
+            m.dispatch(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: true,
+                addr: 0x1050,
+                width: AccessWidth::Dword,
+                data: 0
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_overlap() {
+        let mut m = AxVmDevices::empty();
+        m.register(Arc::new(D {
+            a: 0x1000,
+            s: 0x200,
+            n: "a",
+            k: BusKind::Mmio,
+        }))
+        .unwrap();
+        assert!(matches!(
+            m.register(Arc::new(D {
+                a: 0x1100,
+                s: 0x100,
+                n: "b",
+                k: BusKind::Mmio
+            })),
+            Err(RegistryError::AddressConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn test_reuse() {
+        let mut m = AxVmDevices::empty();
+        let id = m
+            .register(Arc::new(D {
+                a: 0x1000,
+                s: 0x100,
+                n: "a",
+                k: BusKind::Mmio,
+            }))
+            .unwrap();
+        m.unregister(id).unwrap();
+        assert_eq!(
+            id,
+            m.register(Arc::new(D {
+                a: 0x2000,
+                s: 0x100,
+                n: "b",
+                k: BusKind::Mmio
+            }))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_not_found() {
+        assert!(matches!(
+            AxVmDevices::empty().dispatch(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: true,
+                addr: 0xdead,
+                width: AccessWidth::Dword,
+                data: 0
+            }),
+            Err(DeviceError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn test_port_sysreg() {
+        let mut m = AxVmDevices::empty();
+        m.register(Arc::new(D {
+            a: 0x80,
+            s: 4,
+            n: "p",
+            k: BusKind::Port,
+        }))
+        .unwrap();
+        m.register(Arc::new(D {
+            a: 0xC000,
+            s: 4,
+            n: "s",
+            k: BusKind::SysReg,
+        }))
+        .unwrap();
+        assert!(
+            m.dispatch(&BusAccess {
+                kind: BusKind::Port,
+                is_read: true,
+                addr: 0x80,
+                width: AccessWidth::Byte,
+                data: 0
+            })
+            .is_ok()
+        );
+        assert!(
+            m.dispatch(&BusAccess {
+                kind: BusKind::SysReg,
+                is_read: true,
+                addr: 0xC000,
+                width: AccessWidth::Qword,
+                data: 0
+            })
+            .is_ok()
+        );
     }
 }

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -1055,8 +1055,9 @@ mod tests {
 
     use axdevice_base::{
         AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceError,
-        DeviceRegistry, InvalidResourceReason, RegistryError, Resource,
+        DeviceRegistry, InvalidResourceReason, Port, RegistryError, Resource, SysRegAddr,
     };
+    use axvm_types::GuestPhysAddr;
 
     use super::AxVmDevices;
 
@@ -1170,8 +1171,49 @@ mod tests {
 
     #[test]
     fn test_stale_device_id_after_unregister() {
-        // No unregister API; DeviceIds are stable per AxVmDevices lifetime.
+        // DeviceRegistry no longer exposes unregister.
+        // DeviceIds are stable for the AxVmDevices lifetime.
         // The old slot-reuse test has been removed.
+    }
+
+    #[test]
+    fn test_read_request_rejects_write_response() {
+        // A device that incorrectly returns BusResponse::Write for a read
+        // should cause the handle_*_read methods to return an error.
+        struct WriteOnlyDevice;
+        impl Device for WriteOnlyDevice {
+            fn name(&self) -> &str {
+                "write-only"
+            }
+            fn resources(&self) -> &[Resource] {
+                static R: [Resource; 1] = [Resource::MmioRange {
+                    base: 0x1000,
+                    size: 0x100,
+                }];
+                &R
+            }
+            fn handle(&self, _access: &BusAccess) -> Result<BusResponse, DeviceError> {
+                Ok(BusResponse::Write)
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let mut m = AxVmDevices::empty();
+        m.register(Arc::new(WriteOnlyDevice)).unwrap();
+
+        // handle_mmio_read should detect the mismatched response.
+        let result = m.handle_mmio_read(GuestPhysAddr::from(0x1000), AccessWidth::Dword);
+        assert!(result.is_err());
+
+        // handle_sys_reg_read should also detect it.
+        let result = m.handle_sys_reg_read(SysRegAddr::new(0x1000), AccessWidth::Qword);
+        assert!(result.is_err());
+
+        // handle_port_read should also detect it.
+        let result = m.handle_port_read(Port::new(0x1000), AccessWidth::Byte);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1278,15 +1320,32 @@ mod tests {
     }
 
     #[test]
-    fn test_port_overflow_returns_invalid_resource() {
+    fn test_access_across_resource_boundary() {
+        // Access that starts inside a device's range but with a larger
+        // width still dispatches to the matching device.
         let mut m = AxVmDevices::empty();
-        let result = m.register(Arc::new(D::new_port(0xffff, 2, "port-overflow")));
-        assert!(matches!(
-            result,
-            Err(RegistryError::InvalidResource {
-                reason: InvalidResourceReason::AddressOverflow,
-                ..
+        m.register(Arc::new(D::new_mmio(0x1000, 0x8, "small")))
+            .unwrap();
+        assert!(
+            m.dispatch(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: false,
+                addr: 0x1004,
+                width: AccessWidth::Qword,
+                data: 0,
             })
+            .is_ok()
+        );
+        // 0x1008 == base + size — NotFound.
+        assert!(matches!(
+            m.dispatch(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: true,
+                addr: 0x1008,
+                width: AccessWidth::Dword,
+                data: 0
+            }),
+            Err(DeviceError::NotFound)
         ));
     }
 }

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -473,7 +473,7 @@ impl AxVmDevices {
     }
 
     /// Registers a bundle atomically.  Conflict detection is performed by
-    /// [`AxVmDevices::register`].
+    /// [`DeviceRegistry::register`].
     pub fn register_bundle(&mut self, bundle: DeviceBundle) -> AxResult {
         for (index, pollable) in bundle.pollable.iter().enumerate() {
             if self

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -26,7 +26,8 @@ use ax_memory_addr::is_aligned_4k;
 use axdevice_base::PortDeviceAdapter;
 use axdevice_base::{
     AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceError, DeviceId,
-    DeviceRegistry, MmioDeviceAdapter, Port, RegistryError, Resource, SysRegAddr,
+    DeviceRegistry, InvalidResourceReason, MmioDeviceAdapter, Port, RegistryError, Resource,
+    SysRegAddr,
 };
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr};
 #[cfg(target_arch = "riscv64")]
@@ -52,16 +53,22 @@ fn log_device_io(
     trace!("emu_device {rw}: {addr_type} {addr:#x} in range {addr_range:#x} with width {width:?}")
 }
 
+/// Internal range entry cached in the index maps.
+struct RangeEntry {
+    slot: usize,
+    size: u64,
+}
+
 /// represent A vm own devices
 pub struct AxVmDevices {
-    /// Device slots (None = freed and available for reuse).
-    devices: Vec<Option<Arc<dyn Device>>>,
-    /// MMIO base address → device slot index.
-    mmio_index: BTreeMap<u64, usize>,
-    /// Port I/O base address → device slot index.
-    port_index: BTreeMap<u16, usize>,
-    /// System register address → device slot index.
-    sysreg_index: BTreeMap<u32, usize>,
+    /// Registered devices (append-only; index is the DeviceId).
+    devices: Vec<Arc<dyn Device>>,
+    /// MMIO base address → range entry (slot, size).
+    mmio_index: BTreeMap<u64, RangeEntry>,
+    /// Port I/O base address → range entry (slot, size).
+    port_index: BTreeMap<u16, RangeEntry>,
+    /// System register address → range entry (slot, count).
+    sysreg_index: BTreeMap<u32, RangeEntry>,
     /// Devices that require periodic polling.
     pollable_devices: Vec<Arc<dyn PollableDeviceOps>>,
     /// x86 IOAPIC — kept for type-specific access.
@@ -472,9 +479,9 @@ impl AxVmDevices {
         }
     }
 
-    /// Registers a bundle atomically.  Conflict detection is performed by
-    /// [`DeviceRegistry::register`].  If any device fails to register,
-    /// already-registered devices in this bundle are rolled back.
+    /// Registers a bundle atomically.  If any device fails to register,
+    /// already-registered devices in this bundle are rolled back via
+    /// `pop()` + index-key removal.
     pub fn register_bundle(&mut self, bundle: DeviceBundle) -> AxResult {
         for (index, pollable) in bundle.pollable.iter().enumerate() {
             if self
@@ -490,19 +497,32 @@ impl AxVmDevices {
             }
         }
 
-        let mut registered_ids: Vec<DeviceId> = Vec::new();
+        let saved_len = self.devices.len();
         for device in &bundle.devices {
             match self.register(device.clone()) {
-                Ok(id) => registered_ids.push(id),
+                Ok(_id) => {}
                 Err(e) => {
+                    // Rollback: pop back to saved_len, remove from index maps.
+                    while self.devices.len() > saved_len {
+                        let popped = self.devices.pop().unwrap();
+                        for r in popped.resources() {
+                            match *r {
+                                Resource::MmioRange { base, .. } => {
+                                    self.mmio_index.remove(&base);
+                                }
+                                Resource::PortRange { base, .. } => {
+                                    self.port_index.remove(&base);
+                                }
+                                Resource::SysReg { addr, .. } => {
+                                    self.sysreg_index.remove(&addr);
+                                }
+                            }
+                        }
+                    }
                     let kind = match &e {
                         RegistryError::AddressConflict { .. } => ax_errno::AxError::AddrInUse,
                         _ => ax_errno::AxError::InvalidInput,
                     };
-                    // Rollback already-registered devices.
-                    for id in registered_ids.iter().rev() {
-                        let _ = self.unregister(*id);
-                    }
                     return Err(ax_err_type!(
                         kind,
                         format!("device registration failed: {e:?}")
@@ -516,62 +536,49 @@ impl AxVmDevices {
 
     // ─── Registration helpers ───────────────────────────────────────
 
-    /// Finds a free slot in `devices` or appends a new one, returning the
-    /// index.
-    fn alloc_slot(&mut self) -> usize {
-        match self.devices.iter().position(|slot| slot.is_none()) {
-            Some(idx) => idx,
-            None => {
-                self.devices.push(None);
-                self.devices.len() - 1
-            }
-        }
-    }
-
     /// Checks whether `[base, base + size)` conflicts with any already
     /// registered MMIO range.
     fn check_mmio_conflict(&self, base: u64, size: u64) -> Result<(), RegistryError> {
-        // Reject zero-sized and wrapped ranges (base+size would overflow).
-        if size == 0 || base.checked_add(size).is_none() {
-            return Err(RegistryError::AddressConflict {
+        if size == 0 {
+            return Err(RegistryError::InvalidResource {
                 resource: Resource::MmioRange { base, size },
-                existing: Resource::MmioRange { base: 0, size: 0 },
-                existing_device: DeviceId::new(0),
+                reason: InvalidResourceReason::ZeroSized,
+            });
+        }
+        if base.checked_add(size).is_none() {
+            return Err(RegistryError::InvalidResource {
+                resource: Resource::MmioRange { base, size },
+                reason: InvalidResourceReason::AddressOverflow,
             });
         }
 
-        // checked_add already passed, so end is safe.
         let end = base + size;
 
         // Check the immediately-preceding entry.
-        if let Some((prev_base, &prev_idx)) = self.mmio_index.range(..base).next_back()
-            && let Some((existing_base, existing_size)) =
-                self.mmio_range_of_device(prev_idx, *prev_base)
-            && existing_base.wrapping_add(existing_size) > base
+        if let Some((prev_base, entry)) = self.mmio_index.range(..base).next_back()
+            && prev_base.wrapping_add(entry.size) > base
         {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::MmioRange { base, size },
                 existing: Resource::MmioRange {
-                    base: existing_base,
-                    size: existing_size,
+                    base: *prev_base,
+                    size: entry.size,
                 },
-                existing_device: DeviceId::new(prev_idx as u32),
+                existing_device: DeviceId::new(entry.slot as u32),
             });
         }
 
         // Check the immediately-following entry.
-        if let Some((next_base, &next_idx)) = self.mmio_index.range(base..).next()
+        if let Some((next_base, entry)) = self.mmio_index.range(base..).next()
             && *next_base < end
-            && let Some((existing_base, existing_size)) =
-                self.mmio_range_of_device(next_idx, *next_base)
         {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::MmioRange { base, size },
                 existing: Resource::MmioRange {
-                    base: existing_base,
-                    size: existing_size,
+                    base: *next_base,
+                    size: entry.size,
                 },
-                existing_device: DeviceId::new(next_idx as u32),
+                existing_device: DeviceId::new(entry.slot as u32),
             });
         }
 
@@ -581,43 +588,44 @@ impl AxVmDevices {
     /// Checks whether `[base, base + size)` conflicts with any already
     /// registered port I/O range.
     fn check_port_conflict(&self, base: u16, size: u16) -> Result<(), RegistryError> {
-        if size == 0 || base.checked_add(size).is_none() {
-            return Err(RegistryError::AddressConflict {
+        if size == 0 {
+            return Err(RegistryError::InvalidResource {
                 resource: Resource::PortRange { base, size },
-                existing: Resource::PortRange { base: 0, size: 0 },
-                existing_device: DeviceId::new(0),
+                reason: InvalidResourceReason::ZeroSized,
+            });
+        }
+        // Use u32 to allow base=0xffff, size=1 (end=0x10000 is valid).
+        let end = (base as u32).wrapping_add(size as u32);
+        if end > (u16::MAX as u32 + 1) {
+            return Err(RegistryError::InvalidResource {
+                resource: Resource::PortRange { base, size },
+                reason: InvalidResourceReason::AddressOverflow,
             });
         }
 
-        if let Some((prev_base, &prev_idx)) = self.port_index.range(..base).next_back()
-            && let Some((existing_base, existing_size)) =
-                self.port_range_of_device(prev_idx, *prev_base)
-            && existing_base.wrapping_add(existing_size) > base
+        if let Some((prev_base, entry)) = self.port_index.range(..base).next_back()
+            && (*prev_base as u32).wrapping_add(entry.size as u32) > base as u32
         {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::PortRange { base, size },
                 existing: Resource::PortRange {
-                    base: existing_base,
-                    size: existing_size,
+                    base: *prev_base,
+                    size: entry.size as u16,
                 },
-                existing_device: DeviceId::new(prev_idx as u32),
+                existing_device: DeviceId::new(entry.slot as u32),
             });
         }
 
-        // checked_add already passed, so end is safe.
-        let end = base + size;
-        if let Some((next_base, &next_idx)) = self.port_index.range(base..).next()
-            && *next_base < end
-            && let Some((existing_base, existing_size)) =
-                self.port_range_of_device(next_idx, *next_base)
+        if let Some((next_base, entry)) = self.port_index.range(base..).next()
+            && (*next_base as u32) < end
         {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::PortRange { base, size },
                 existing: Resource::PortRange {
-                    base: existing_base,
-                    size: existing_size,
+                    base: *next_base,
+                    size: entry.size as u16,
                 },
-                existing_device: DeviceId::new(next_idx as u32),
+                existing_device: DeviceId::new(entry.slot as u32),
             });
         }
 
@@ -628,20 +636,23 @@ impl AxVmDevices {
     /// registered system register range.
     fn check_sysreg_conflict(&self, addr: u32, count: u32) -> Result<(), RegistryError> {
         if count == 0 {
-            return Err(RegistryError::AddressConflict {
+            return Err(RegistryError::InvalidResource {
                 resource: Resource::SysReg { addr, count },
-                existing: Resource::SysReg { addr: 0, count: 0 },
-                existing_device: DeviceId::new(0),
+                reason: InvalidResourceReason::ZeroSized,
             });
         }
 
         let end = addr.saturating_add(count.saturating_sub(1));
+        if count > 0 && addr.checked_add(count).is_none() {
+            return Err(RegistryError::InvalidResource {
+                resource: Resource::SysReg { addr, count },
+                reason: InvalidResourceReason::AddressOverflow,
+            });
+        }
 
         // Check the immediately-preceding key: its range may extend into ours.
-        if let Some((prev_addr, &prev_idx)) = self.sysreg_index.range(..addr).next_back() {
-            let existing_count = self
-                .sysreg_count_of_device(prev_idx, *prev_addr)
-                .unwrap_or(1);
+        if let Some((prev_addr, entry)) = self.sysreg_index.range(..addr).next_back() {
+            let existing_count = entry.size as u32;
             let existing_end = prev_addr.saturating_add(existing_count.saturating_sub(1));
             if existing_end >= addr {
                 return Err(RegistryError::AddressConflict {
@@ -650,102 +661,70 @@ impl AxVmDevices {
                         addr: *prev_addr,
                         count: existing_count,
                     },
-                    existing_device: DeviceId::new(prev_idx as u32),
+                    existing_device: DeviceId::new(entry.slot as u32),
                 });
             }
         }
 
         // Check entries whose keys fall within our range.
-        if let Some((reg_addr, &idx)) = self.sysreg_index.range(addr..=end).next() {
-            let existing_count = self.sysreg_count_of_device(idx, *reg_addr).unwrap_or(1);
+        if let Some((reg_addr, entry)) = self.sysreg_index.range(addr..=end).next() {
             return Err(RegistryError::AddressConflict {
                 resource: Resource::SysReg { addr, count },
                 existing: Resource::SysReg {
                     addr: *reg_addr,
-                    count: existing_count,
+                    count: entry.size as u32,
                 },
-                existing_device: DeviceId::new(idx as u32),
+                existing_device: DeviceId::new(entry.slot as u32),
             });
         }
 
         Ok(())
     }
 
-    fn sysreg_count_of_device(&self, idx: usize, addr: u32) -> Option<u32> {
-        self.devices[idx].as_ref().and_then(|d| {
-            d.resources().into_iter().find_map(|r| match r {
-                Resource::SysReg { addr: a, count: c } if a == addr => Some(c),
-                _ => None,
-            })
-        })
-    }
-
-    /// Returns the `(base, size)` of the `MmioRange` resource of
-    /// `devices[idx]` whose `base` matches.
-    fn mmio_range_of_device(&self, idx: usize, base: u64) -> Option<(u64, u64)> {
-        let dev = self.devices[idx].as_ref()?;
-        dev.resources().into_iter().find_map(|r| match r {
-            Resource::MmioRange { base: b, size: s } if b == base => Some((b, s)),
-            _ => None,
-        })
-    }
-
-    /// Returns the `(base, size)` of the `PortRange` resource of
-    /// `devices[idx]` whose `base` matches.
-    fn port_range_of_device(&self, idx: usize, base: u16) -> Option<(u16, u16)> {
-        let dev = self.devices[idx].as_ref()?;
-        dev.resources().into_iter().find_map(|r| match r {
-            Resource::PortRange { base: b, size: s } if b == base => Some((b, s)),
-            _ => None,
-        })
-    }
-
     // ─── Lookup helpers ────────────────────────────────────────────
 
     fn lookup_mmio(&self, addr: u64) -> Option<usize> {
-        let (&base, &idx) = self.mmio_index.range(..=addr).next_back()?;
-        let dev = self.devices[idx].as_ref()?;
-        let in_range = dev.resources().into_iter().any(|r| {
-            matches!(r,
-                Resource::MmioRange { base: b, size: s }
-                if b == base && s > 0 && addr < b.wrapping_add(s))
-        });
-        in_range.then_some(idx)
+        let (&base, entry) = self.mmio_index.range(..=addr).next_back()?;
+        (addr < base.wrapping_add(entry.size)).then_some(entry.slot)
     }
 
     fn lookup_port(&self, addr: u16) -> Option<usize> {
-        let (&base, &idx) = self.port_index.range(..=addr).next_back()?;
-        let dev = self.devices[idx].as_ref()?;
-        let in_range = dev.resources().into_iter().any(|r| {
-            matches!(r,
-                Resource::PortRange { base: b, size: s }
-                if b == base && s > 0 && addr < b.wrapping_add(s))
-        });
-        in_range.then_some(idx)
+        let (&base, entry) = self.port_index.range(..=addr).next_back()?;
+        ((addr as u64) < (base as u64).wrapping_add(entry.size)).then_some(entry.slot)
     }
 
     fn lookup_sysreg(&self, addr: u32) -> Option<usize> {
-        let (&start, &idx) = self.sysreg_index.range(..=addr).next_back()?;
-        let count = self.sysreg_count_of_device(idx, start)?;
-        let end = start.saturating_add(count.saturating_sub(1));
-        (addr <= end).then_some(idx)
+        let (&start, entry) = self.sysreg_index.range(..=addr).next_back()?;
+        let end = start.saturating_add((entry.size as u32).saturating_sub(1));
+        (addr <= end).then_some(entry.slot)
     }
 
-    // ─── BTreeMap insertion / removal ──────────────────────────────
+    // ─── BTreeMap insertion ───────────────────────────────────────
 
     fn insert_resources(&mut self, idx: usize, resources: &[Resource]) {
         for r in resources {
             match *r {
-                Resource::MmioRange { base, .. } => {
-                    self.mmio_index.insert(base, idx);
+                Resource::MmioRange { base, size } => {
+                    self.mmio_index.insert(base, RangeEntry { slot: idx, size });
                 }
-                Resource::PortRange { base, .. } => {
-                    self.port_index.insert(base, idx);
+                Resource::PortRange { base, size } => {
+                    self.port_index.insert(
+                        base,
+                        RangeEntry {
+                            slot: idx,
+                            size: size as u64,
+                        },
+                    );
                 }
-                Resource::SysReg { addr, .. } => {
-                    self.sysreg_index.insert(addr, idx);
+                Resource::SysReg { addr, count } => {
+                    self.sysreg_index.insert(
+                        addr,
+                        RangeEntry {
+                            slot: idx,
+                            size: count as u64,
+                        },
+                    );
                 }
-                _ => {}
             }
         }
     }
@@ -754,12 +733,12 @@ impl AxVmDevices {
 
     /// Returns an iterator over all currently registered devices.
     pub fn devices(&self) -> impl Iterator<Item = &dyn Device> {
-        self.devices.iter().filter_map(|slot| slot.as_deref())
+        self.devices.iter().map(|slot| &**slot)
     }
 
     /// Returns the number of currently registered devices.
     pub fn device_count(&self) -> usize {
-        self.devices.iter().filter(|slot| slot.is_some()).count()
+        self.devices.len()
     }
 
     // ─── Iterator helpers ───────────────────────────────────────────
@@ -1022,65 +1001,25 @@ impl DeviceRegistry for AxVmDevices {
         let resources = device.resources();
 
         // 1. Conflict detection (only for address-range resources).
-        for r in &resources {
+        for r in resources {
             match *r {
                 Resource::MmioRange { base, size } => self.check_mmio_conflict(base, size)?,
                 Resource::PortRange { base, size } => self.check_port_conflict(base, size)?,
                 Resource::SysReg { addr, count } => self.check_sysreg_conflict(addr, count)?,
-                _ => { /* Irq / MSI / PciBar / DmaCapable — handled by factory */ }
             }
         }
 
-        // 2. Allocate a slot.
-        let idx = self.alloc_slot();
+        // 2. Append to device list; index is the DeviceId.
+        let idx = self.devices.len();
 
         // 3. Insert into index maps.
-        self.insert_resources(idx, &resources);
+        self.insert_resources(idx, resources);
 
         // 4. Store the device.
-        self.devices[idx] = Some(device);
+        self.devices.push(device);
 
         info!("AxVmDevices: registered device id={}", idx);
         Ok(DeviceId::new(idx as u32))
-    }
-
-    fn unregister(&mut self, id: DeviceId) -> Result<(), RegistryError> {
-        let idx = id.as_u32() as usize;
-
-        let device = self
-            .devices
-            .get(idx)
-            .and_then(|slot| slot.as_ref())
-            .ok_or_else(|| {
-                warn!(
-                    "AxVmDevices: unregister failed — DeviceId({}) not found",
-                    idx
-                );
-                RegistryError::DeviceNotFound(id)
-            })?;
-
-        // Remove from all index maps.
-        let resources = device.resources();
-        for r in &resources {
-            match *r {
-                Resource::MmioRange { base, .. } => {
-                    self.mmio_index.remove(&base);
-                }
-                Resource::PortRange { base, .. } => {
-                    self.port_index.remove(&base);
-                }
-                Resource::SysReg { addr, .. } => {
-                    self.sysreg_index.remove(&addr);
-                }
-                _ => {}
-            }
-        }
-
-        // Free the slot.
-        self.devices[idx] = None;
-
-        info!("AxVmDevices: unregistered device id={}", idx);
-        Ok(())
     }
 }
 
@@ -1093,7 +1032,7 @@ impl BusRouter for AxVmDevices {
         }
         .ok_or(DeviceError::NotFound)?;
 
-        let device = self.devices[idx].as_ref().ok_or(DeviceError::NotFound)?;
+        let device = &self.devices[idx];
         device.handle(access)
     }
 
@@ -1105,49 +1044,52 @@ impl BusRouter for AxVmDevices {
         }
         .ok_or(DeviceError::NotFound)?;
 
-        self.devices[idx].clone().ok_or(DeviceError::NotFound)
+        Ok(Arc::clone(&self.devices[idx]))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::{sync::Arc, vec::Vec};
+    use alloc::sync::Arc;
     use core::any::Any;
 
     use axdevice_base::{
         AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceError,
-        DeviceRegistry, RegistryError, Resource,
+        DeviceRegistry, InvalidResourceReason, RegistryError, Resource,
     };
 
     use super::AxVmDevices;
 
     struct D {
-        a: u64,
-        s: u64,
+        resources: alloc::vec::Vec<Resource>,
         n: &'static str,
-        k: BusKind,
+    }
+    impl D {
+        fn new_mmio(a: u64, s: u64, n: &'static str) -> Self {
+            Self {
+                resources: alloc::vec![Resource::MmioRange { base: a, size: s }],
+                n,
+            }
+        }
+        fn new_port(base: u16, size: u16, n: &'static str) -> Self {
+            Self {
+                resources: alloc::vec![Resource::PortRange { base, size }],
+                n,
+            }
+        }
+        fn new_sysreg(addr: u32, n: &'static str) -> Self {
+            Self {
+                resources: alloc::vec![Resource::SysReg { addr, count: 1 }],
+                n,
+            }
+        }
     }
     impl Device for D {
         fn name(&self) -> &str {
             self.n
         }
-        fn resources(&self) -> Vec<Resource> {
-            let mut v = Vec::new();
-            match self.k {
-                BusKind::Mmio => v.push(Resource::MmioRange {
-                    base: self.a,
-                    size: self.s,
-                }),
-                BusKind::Port => v.push(Resource::PortRange {
-                    base: self.a as u16,
-                    size: self.s as u16,
-                }),
-                BusKind::SysReg => v.push(Resource::SysReg {
-                    addr: self.a as u32,
-                    count: 1,
-                }),
-            }
-            v
+        fn resources(&self) -> &[Resource] {
+            &self.resources
         }
         fn handle(&self, _a: &BusAccess) -> Result<BusResponse, DeviceError> {
             Ok(BusResponse::Read { value: 0 })
@@ -1160,13 +1102,8 @@ mod tests {
     #[test]
     fn test_register_dispatch() {
         let mut m = AxVmDevices::empty();
-        m.register(Arc::new(D {
-            a: 0x1000,
-            s: 0x100,
-            n: "d",
-            k: BusKind::Mmio,
-        }))
-        .unwrap();
+        m.register(Arc::new(D::new_mmio(0x1000, 0x100, "d")))
+            .unwrap();
         assert!(
             m.dispatch(&BusAccess {
                 kind: BusKind::Mmio,
@@ -1182,46 +1119,12 @@ mod tests {
     #[test]
     fn test_overlap() {
         let mut m = AxVmDevices::empty();
-        m.register(Arc::new(D {
-            a: 0x1000,
-            s: 0x200,
-            n: "a",
-            k: BusKind::Mmio,
-        }))
-        .unwrap();
+        m.register(Arc::new(D::new_mmio(0x1000, 0x200, "a")))
+            .unwrap();
         assert!(matches!(
-            m.register(Arc::new(D {
-                a: 0x1100,
-                s: 0x100,
-                n: "b",
-                k: BusKind::Mmio
-            })),
+            m.register(Arc::new(D::new_mmio(0x1100, 0x100, "b"))),
             Err(RegistryError::AddressConflict { .. })
         ));
-    }
-
-    #[test]
-    fn test_reuse() {
-        let mut m = AxVmDevices::empty();
-        let id = m
-            .register(Arc::new(D {
-                a: 0x1000,
-                s: 0x100,
-                n: "a",
-                k: BusKind::Mmio,
-            }))
-            .unwrap();
-        m.unregister(id).unwrap();
-        assert_eq!(
-            id,
-            m.register(Arc::new(D {
-                a: 0x2000,
-                s: 0x100,
-                n: "b",
-                k: BusKind::Mmio
-            }))
-            .unwrap()
-        );
     }
 
     #[test]
@@ -1241,20 +1144,8 @@ mod tests {
     #[test]
     fn test_port_sysreg() {
         let mut m = AxVmDevices::empty();
-        m.register(Arc::new(D {
-            a: 0x80,
-            s: 4,
-            n: "p",
-            k: BusKind::Port,
-        }))
-        .unwrap();
-        m.register(Arc::new(D {
-            a: 0xC000,
-            s: 4,
-            n: "s",
-            k: BusKind::SysReg,
-        }))
-        .unwrap();
+        m.register(Arc::new(D::new_port(0x80, 4, "p"))).unwrap();
+        m.register(Arc::new(D::new_sysreg(0xC000, "s"))).unwrap();
         assert!(
             m.dispatch(&BusAccess {
                 kind: BusKind::Port,
@@ -1275,5 +1166,127 @@ mod tests {
             })
             .is_ok()
         );
+    }
+
+    #[test]
+    fn test_stale_device_id_after_unregister() {
+        // No unregister API; DeviceIds are stable per AxVmDevices lifetime.
+        // The old slot-reuse test has been removed.
+    }
+
+    #[test]
+    fn test_write_request_returns_write_response() {
+        struct RwDevice;
+        impl Device for RwDevice {
+            fn name(&self) -> &str {
+                "rw"
+            }
+            fn resources(&self) -> &[Resource] {
+                static R: [Resource; 1] = [Resource::MmioRange {
+                    base: 0x1000,
+                    size: 0x100,
+                }];
+                &R
+            }
+            fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+                if access.is_read {
+                    Ok(BusResponse::Read { value: 0 })
+                } else {
+                    Ok(BusResponse::Write)
+                }
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let mut m = AxVmDevices::empty();
+        m.register(Arc::new(RwDevice)).unwrap();
+        let resp = m
+            .dispatch(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: false,
+                addr: 0x1000,
+                width: AccessWidth::Dword,
+                data: 0x42,
+            })
+            .unwrap();
+        assert!(matches!(resp, BusResponse::Write));
+    }
+
+    #[test]
+    fn test_port_max_address_valid() {
+        let mut m = AxVmDevices::empty();
+        m.register(Arc::new(D::new_port(0xffff, 1, "max-port")))
+            .unwrap();
+        assert!(
+            m.dispatch(&BusAccess {
+                kind: BusKind::Port,
+                is_read: true,
+                addr: 0xffff,
+                width: AccessWidth::Byte,
+                data: 0
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_zero_size_returns_invalid_resource() {
+        let mut m = AxVmDevices::empty();
+        let result = m.register(Arc::new(D::new_mmio(0x1000, 0, "zero")));
+        assert!(matches!(
+            result,
+            Err(RegistryError::InvalidResource {
+                reason: InvalidResourceReason::ZeroSized,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_mmio_overflow_returns_invalid_resource() {
+        struct OverflowDevice;
+        impl Device for OverflowDevice {
+            fn name(&self) -> &str {
+                "overflow"
+            }
+            fn resources(&self) -> &[Resource] {
+                static R: [Resource; 1] = [Resource::MmioRange {
+                    base: u64::MAX - 1,
+                    size: 4,
+                }];
+                &R
+            }
+            fn handle(&self, _: &BusAccess) -> Result<BusResponse, DeviceError> {
+                Err(DeviceError::NotFound)
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let mut m = AxVmDevices::empty();
+        let result = m.register(Arc::new(OverflowDevice));
+        assert!(matches!(
+            result,
+            Err(RegistryError::InvalidResource {
+                reason: InvalidResourceReason::AddressOverflow,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_port_overflow_returns_invalid_resource() {
+        let mut m = AxVmDevices::empty();
+        let result = m.register(Arc::new(D::new_port(0xffff, 2, "port-overflow")));
+        assert!(matches!(
+            result,
+            Err(RegistryError::InvalidResource {
+                reason: InvalidResourceReason::AddressOverflow,
+                ..
+            })
+        ));
     }
 }

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -725,7 +725,10 @@ impl AxVmDevices {
     }
 
     fn lookup_sysreg(&self, addr: u32) -> Option<usize> {
-        self.sysreg_index.get(&addr).copied()
+        let (&start, &idx) = self.sysreg_index.range(..=addr).next_back()?;
+        let count = self.sysreg_count_of_device(idx, start)?;
+        let end = start.saturating_add(count.saturating_sub(1));
+        (addr <= end).then_some(idx)
     }
 
     // ─── BTreeMap insertion / removal ──────────────────────────────

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -874,27 +874,9 @@ impl AxVmDevices {
 
     // ─── Iterator helpers ───────────────────────────────────────────
     //
-    // NOTE: With the unified Device trait, all three iterators return
-    // every registered device regardless of bus type.  Callers that
-    // previously relied on per-bus filtering should use
-    // [`Device::resources()`] or downcasting via [`Device::as_any()`].
-    // Prefer [`devices()`] (the canonical iterator) or
-    // [`device_count()`] in new code.
-
-    /// Iterates over all registered devices.
-    pub fn iter_mmio_dev(&self) -> impl Iterator<Item = &dyn Device> {
-        self.devices()
-    }
-
-    /// Iterates over all registered devices.
-    pub fn iter_sys_reg_dev(&self) -> impl Iterator<Item = &dyn Device> {
-        self.devices()
-    }
-
-    /// Iterates over all registered devices.
-    pub fn iter_port_dev(&self) -> impl Iterator<Item = &dyn Device> {
-        self.devices()
-    }
+    // NOTE: With the unified Device trait, [`devices()`] is the
+    // canonical iterator.  Use [`Device::resources()`] or
+    // [`Device::as_any()`] for per-bus filtering in new code.
 
     /// Iterates over devices that require periodic polling.
     pub fn iter_pollable_dev(&self) -> impl Iterator<Item = &Arc<dyn PollableDeviceOps>> {
@@ -1141,8 +1123,16 @@ impl BusRouter for AxVmDevices {
     fn dispatch(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
         let idx = match access.kind {
             BusKind::Mmio => self.lookup_mmio(access.addr),
-            BusKind::Port => self.lookup_port(access.addr as u16),
-            BusKind::SysReg => self.lookup_sysreg(access.addr as u32),
+            BusKind::Port => {
+                let port = u16::try_from(access.addr)
+                    .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
+                self.lookup_port(port)
+            }
+            BusKind::SysReg => {
+                let reg = u32::try_from(access.addr)
+                    .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
+                self.lookup_sysreg(reg)
+            }
         }
         .ok_or(DeviceError::NotFound)?;
 
@@ -1153,8 +1143,16 @@ impl BusRouter for AxVmDevices {
     fn lookup(&self, access: &BusAccess) -> Result<Arc<dyn Device>, DeviceError> {
         let idx = match access.kind {
             BusKind::Mmio => self.lookup_mmio(access.addr),
-            BusKind::Port => self.lookup_port(access.addr as u16),
-            BusKind::SysReg => self.lookup_sysreg(access.addr as u32),
+            BusKind::Port => {
+                let port = u16::try_from(access.addr)
+                    .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
+                self.lookup_port(port)
+            }
+            BusKind::SysReg => {
+                let reg = u32::try_from(access.addr)
+                    .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
+                self.lookup_sysreg(reg)
+            }
         }
         .ok_or(DeviceError::NotFound)?;
 
@@ -1433,16 +1431,28 @@ mod tests {
     fn test_read_request_rejects_write_response() {
         // A device that incorrectly returns BusResponse::Write for a read
         // should cause the handle_*_read methods to return an error.
+        // The device declares a resource on each bus so that the lookup
+        // actually finds it instead of returning NotFound.
         struct WriteOnlyDevice;
         impl Device for WriteOnlyDevice {
             fn name(&self) -> &str {
                 "write-only"
             }
             fn resources(&self) -> &[Resource] {
-                static R: [Resource; 1] = [Resource::MmioRange {
-                    base: 0x1000,
-                    size: 0x100,
-                }];
+                static R: [Resource; 3] = [
+                    Resource::MmioRange {
+                        base: 0x1000,
+                        size: 0x100,
+                    },
+                    Resource::PortRange {
+                        base: 0x1000,
+                        size: 0x10,
+                    },
+                    Resource::SysReg {
+                        addr: 0x1000,
+                        count: 1,
+                    },
+                ];
                 &R
             }
             fn handle(&self, _access: &BusAccess) -> Result<BusResponse, DeviceError> {

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -496,12 +496,16 @@ impl AxVmDevices {
             match self.register(device.clone()) {
                 Ok(id) => registered_ids.push(id),
                 Err(e) => {
+                    let kind = match &e {
+                        RegistryError::AddressConflict { .. } => ax_errno::AxError::AddrInUse,
+                        _ => ax_errno::AxError::InvalidInput,
+                    };
                     // Rollback already-registered devices.
                     for id in registered_ids.iter().rev() {
                         let _ = self.unregister(*id);
                     }
                     return Err(ax_err_type!(
-                        InvalidInput,
+                        kind,
                         format!("device registration failed: {e:?}")
                     ));
                 }

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -22,12 +22,12 @@ use ax_kspin::SpinNoIrq as Mutex;
 #[cfg(target_arch = "aarch64")]
 use ax_memory_addr::PhysAddr;
 use ax_memory_addr::is_aligned_4k;
+#[cfg(target_arch = "x86_64")]
+use axdevice_base::PortDeviceAdapter;
 use axdevice_base::{
     AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceError, DeviceId,
     DeviceRegistry, MmioDeviceAdapter, Port, RegistryError, Resource, SysRegAddr,
 };
-#[cfg(target_arch = "x86_64")]
-use axdevice_base::PortDeviceAdapter;
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr};
 #[cfg(target_arch = "riscv64")]
 use riscv_vplic::VPlicGlobal;

--- a/virtualization/axdevice/src/lib.rs
+++ b/virtualization/axdevice/src/lib.rs
@@ -36,7 +36,7 @@ mod registration;
 #[cfg(target_arch = "aarch64")]
 pub use adapter::create_vtimer_devices;
 pub use axdevice_base::{
-    AccessWidth, BaseDeviceOps, BaseMmioDeviceOps, BasePortDeviceOps, BaseSysRegDeviceOps,
+    AccessWidth, BaseDeviceOps, BaseMmioDeviceOps, BasePortDeviceOps, BaseSysRegDeviceOps, Device,
     MmioDeviceAdapter, Port, PortDeviceAdapter, SysRegAddr, SysRegDeviceAdapter,
 };
 pub use axvm_types::GuestPhysAddr;

--- a/virtualization/axdevice/src/lib.rs
+++ b/virtualization/axdevice/src/lib.rs
@@ -26,19 +26,22 @@ extern crate alloc;
 #[macro_use]
 extern crate log;
 
+mod adapter;
 mod config;
 mod device;
 mod factory;
 mod range_alloc;
 mod registration;
 
+#[cfg(target_arch = "aarch64")]
+pub use adapter::create_vtimer_devices;
 pub use axdevice_base::{
-    AccessWidth, BaseDeviceOps, BaseMmioDeviceOps, BasePortDeviceOps, BaseSysRegDeviceOps, Port,
-    SysRegAddr,
+    AccessWidth, BaseDeviceOps, BaseMmioDeviceOps, BasePortDeviceOps, BaseSysRegDeviceOps,
+    MmioDeviceAdapter, Port, PortDeviceAdapter, SysRegAddr, SysRegDeviceAdapter,
 };
 pub use axvm_types::GuestPhysAddr;
 pub use config::AxVmDeviceConfig;
-pub use device::{AxEmuDevices, AxVmDevices};
+pub use device::AxVmDevices;
 pub use factory::{
     DeviceBuildContext, DeviceFactory, DeviceFactoryRegistry, IrqResolver,
     register_builtin_factories,

--- a/virtualization/axdevice/src/registration.rs
+++ b/virtualization/axdevice/src/registration.rs
@@ -17,7 +17,7 @@
 use alloc::{sync::Arc, vec::Vec};
 
 use ax_errno::AxResult;
-use axdevice_base::{BaseMmioDeviceOps, BasePortDeviceOps, BaseSysRegDeviceOps};
+use axdevice_base::Device;
 
 /// A device capability that can be polled by the VM runtime.
 pub trait PollableDeviceOps: Send + Sync {
@@ -28,12 +28,8 @@ pub trait PollableDeviceOps: Send + Sync {
 /// One strongly typed capability contributed by a device.
 #[non_exhaustive]
 pub enum DeviceRegistration {
-    /// An MMIO access capability.
-    Mmio(Arc<dyn BaseMmioDeviceOps>),
-    /// A port I/O access capability.
-    Port(Arc<dyn BasePortDeviceOps>),
-    /// A system register access capability.
-    SysReg(Arc<dyn BaseSysRegDeviceOps>),
+    /// A device implementing the unified [`Device`] trait.
+    Device(Arc<dyn Device>),
     /// A capability that requires periodic polling.
     Pollable(Arc<dyn PollableDeviceOps>),
 }
@@ -44,9 +40,7 @@ pub enum DeviceRegistration {
 /// [`DeviceRegistration`] when adding future capability kinds.
 #[derive(Default)]
 pub struct DeviceBundle {
-    pub(crate) mmio: Vec<Arc<dyn BaseMmioDeviceOps>>,
-    pub(crate) port: Vec<Arc<dyn BasePortDeviceOps>>,
-    pub(crate) sysreg: Vec<Arc<dyn BaseSysRegDeviceOps>>,
+    pub(crate) devices: Vec<Arc<dyn Device>>,
     pub(crate) pollable: Vec<Arc<dyn PollableDeviceOps>>,
 }
 
@@ -54,9 +48,7 @@ impl DeviceBundle {
     /// Creates an empty bundle.
     pub const fn new() -> Self {
         Self {
-            mmio: Vec::new(),
-            port: Vec::new(),
-            sysreg: Vec::new(),
+            devices: Vec::new(),
             pollable: Vec::new(),
         }
     }
@@ -71,9 +63,7 @@ impl DeviceBundle {
     /// Adds one capability to this bundle.
     pub fn push(&mut self, registration: DeviceRegistration) {
         match registration {
-            DeviceRegistration::Mmio(device) => self.mmio.push(device),
-            DeviceRegistration::Port(device) => self.port.push(device),
-            DeviceRegistration::SysReg(device) => self.sysreg.push(device),
+            DeviceRegistration::Device(device) => self.devices.push(device),
             DeviceRegistration::Pollable(device) => self.pollable.push(device),
         }
     }
@@ -86,10 +76,7 @@ impl DeviceBundle {
 
     /// Returns whether this bundle contains no capabilities.
     pub fn is_empty(&self) -> bool {
-        self.mmio.is_empty()
-            && self.port.is_empty()
-            && self.sysreg.is_empty()
-            && self.pollable.is_empty()
+        self.devices.is_empty() && self.pollable.is_empty()
     }
 }
 

--- a/virtualization/axdevice_base/Cargo.toml
+++ b/virtualization/axdevice_base/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["no-std", "virtualization"]
 license = "Apache-2.0"
 
 [dependencies]
+log = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+spin = "0.10"
 
 # ArceOS and AxVisor crates.
 ax-errno = { workspace = true }

--- a/virtualization/axdevice_base/src/adapter.rs
+++ b/virtualization/axdevice_base/src/adapter.rs
@@ -111,13 +111,6 @@ where
     }
 }
 
-// SAFETY: The inner device uses internal synchronisation (e.g. `Mutex`,
-// `UnsafeCell` with proper barriers) and has been safely shared across
-// threads in the existing codebase via `Arc`.
-// The bounds match what the concrete device types satisfy.
-unsafe impl<T: Send + Sync> Send for MmioDeviceAdapter<T> {}
-unsafe impl<T: Send + Sync> Sync for MmioDeviceAdapter<T> {}
-
 impl<T: Send + Sync + 'static> Device for MmioDeviceAdapter<T>
 where
     T: BaseDeviceOps<crate::GuestPhysAddrRange>,
@@ -199,9 +192,6 @@ where
     }
 }
 
-unsafe impl<T: Send + Sync> Send for SysRegDeviceAdapter<T> {}
-unsafe impl<T: Send + Sync> Sync for SysRegDeviceAdapter<T> {}
-
 impl<T: Send + Sync + 'static> Device for SysRegDeviceAdapter<T>
 where
     T: BaseDeviceOps<SysRegAddrRange>,
@@ -282,9 +272,6 @@ where
         &self.inner
     }
 }
-
-unsafe impl<T: Send + Sync> Send for PortDeviceAdapter<T> {}
-unsafe impl<T: Send + Sync> Sync for PortDeviceAdapter<T> {}
 
 impl<T: Send + Sync + 'static> Device for PortDeviceAdapter<T>
 where

--- a/virtualization/axdevice_base/src/adapter.rs
+++ b/virtualization/axdevice_base/src/adapter.rs
@@ -60,7 +60,7 @@ where
     /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
     pub fn from_arc(device: Arc<T>) -> Arc<dyn Device>
     where
-        T: 'static,
+        T: Send + Sync + 'static,
         T: BaseDeviceOps<crate::GuestPhysAddrRange>,
     {
         Arc::new(Self {
@@ -78,11 +78,11 @@ where
 // SAFETY: The inner device uses internal synchronisation (e.g. `Mutex`,
 // `UnsafeCell` with proper barriers) and has been safely shared across
 // threads in the existing codebase via `Arc`.
-// All concrete device types are `Send + Sync`.
-unsafe impl<T> Send for MmioDeviceAdapter<T> {}
-unsafe impl<T> Sync for MmioDeviceAdapter<T> {}
+// The bounds match what the concrete device types satisfy.
+unsafe impl<T: Send + Sync> Send for MmioDeviceAdapter<T> {}
+unsafe impl<T: Send + Sync> Sync for MmioDeviceAdapter<T> {}
 
-impl<T: Send + 'static> Device for MmioDeviceAdapter<T>
+impl<T: Send + Sync + 'static> Device for MmioDeviceAdapter<T>
 where
     T: BaseDeviceOps<crate::GuestPhysAddrRange>,
 {
@@ -93,7 +93,12 @@ where
     fn resources(&self) -> Vec<Resource> {
         let range = self.inner.address_range();
         let base = range.start.as_usize() as u64;
-        let size = (range.end.as_usize() - range.start.as_usize()) as u64;
+        let size = if range.end.as_usize() >= range.start.as_usize() {
+            (range.end.as_usize() - range.start.as_usize()) as u64
+        } else {
+            // Wrapped address range — the caller will reject size=0.
+            0
+        };
         alloc::vec![Resource::MmioRange { base, size }]
     }
 
@@ -145,7 +150,7 @@ where
     /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
     pub fn from_arc(device: Arc<T>) -> Arc<dyn Device>
     where
-        T: 'static,
+        T: Send + Sync + 'static,
         T: BaseDeviceOps<SysRegAddrRange>,
     {
         Arc::new(Self {
@@ -160,10 +165,10 @@ where
     }
 }
 
-unsafe impl<T> Send for SysRegDeviceAdapter<T> {}
-unsafe impl<T> Sync for SysRegDeviceAdapter<T> {}
+unsafe impl<T: Send + Sync> Send for SysRegDeviceAdapter<T> {}
+unsafe impl<T: Send + Sync> Sync for SysRegDeviceAdapter<T> {}
 
-impl<T: Send + 'static> Device for SysRegDeviceAdapter<T>
+impl<T: Send + Sync + 'static> Device for SysRegDeviceAdapter<T>
 where
     T: BaseDeviceOps<SysRegAddrRange>,
 {
@@ -173,9 +178,13 @@ where
 
     fn resources(&self) -> Vec<Resource> {
         let range = self.inner.address_range();
-        alloc::vec![Resource::SysReg {
-            addr: range.start.0 as u32
-        }]
+        let addr = range.start.0 as u32;
+        let count = if range.end.0 >= range.start.0 {
+            (range.end.0 - range.start.0) as u32 + 1
+        } else {
+            0
+        };
+        alloc::vec![Resource::SysReg { addr, count }]
     }
 
     fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
@@ -226,7 +235,7 @@ where
     /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
     pub fn from_arc(device: Arc<T>) -> Arc<dyn Device>
     where
-        T: 'static,
+        T: Send + Sync + 'static,
         T: BaseDeviceOps<PortRange>,
     {
         Arc::new(Self {
@@ -241,10 +250,10 @@ where
     }
 }
 
-unsafe impl<T> Send for PortDeviceAdapter<T> {}
-unsafe impl<T> Sync for PortDeviceAdapter<T> {}
+unsafe impl<T: Send + Sync> Send for PortDeviceAdapter<T> {}
+unsafe impl<T: Send + Sync> Sync for PortDeviceAdapter<T> {}
 
-impl<T: Send + 'static> Device for PortDeviceAdapter<T>
+impl<T: Send + Sync + 'static> Device for PortDeviceAdapter<T>
 where
     T: BaseDeviceOps<PortRange>,
 {
@@ -255,7 +264,12 @@ where
     fn resources(&self) -> Vec<Resource> {
         let range = self.inner.address_range();
         let base = range.start.0;
-        let size = (range.end.0 - range.start.0).wrapping_add(1);
+        let size = if range.end.0 >= range.start.0 {
+            (range.end.0 - range.start.0).wrapping_add(1)
+        } else {
+            // Empty or wrapped range — the caller will reject size=0.
+            0
+        };
         alloc::vec![Resource::PortRange { base, size }]
     }
 

--- a/virtualization/axdevice_base/src/adapter.rs
+++ b/virtualization/axdevice_base/src/adapter.rs
@@ -351,12 +351,7 @@ mod tests {
         fn handle_read(&self, _addr: GuestPhysAddr, _width: AccessWidth) -> AxResult<usize> {
             Ok(self.read_val)
         }
-        fn handle_write(
-            &self,
-            _addr: GuestPhysAddr,
-            _width: AccessWidth,
-            _val: usize,
-        ) -> AxResult {
+        fn handle_write(&self, _addr: GuestPhysAddr, _width: AccessWidth, _val: usize) -> AxResult {
             Ok(())
         }
     }

--- a/virtualization/axdevice_base/src/adapter.rs
+++ b/virtualization/axdevice_base/src/adapter.rs
@@ -1,0 +1,343 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Adapters that wrap the old [`BaseDeviceOps`](crate::BaseDeviceOps)
+//! implementations so they can be registered into an `AxVmDevices` that
+//! expects the new [`Device`](crate::Device) trait.
+//!
+//! These adapters are intended as a migration aid.  Once each device is
+//! rewritten to implement `Device` natively the corresponding adapter can
+//! be removed.
+
+use alloc::{string::String, sync::Arc, vec::Vec};
+use core::any::Any;
+
+use crate::{
+    BaseDeviceOps, Device, EmuDeviceType, GuestPhysAddr, Resource,
+    device::{BusAccess, BusResponse, DeviceError, Port, PortRange, SysRegAddr, SysRegAddrRange},
+};
+
+fn type_name(emu_type: EmuDeviceType) -> String {
+    alloc::format!("{:?}-adapter", emu_type)
+}
+
+// ---------------------------------------------------------------------------
+// MmioDeviceAdapter
+// ---------------------------------------------------------------------------
+
+/// Wraps an old-style [`BaseDeviceOps<GuestPhysAddrRange>`] device so that it
+/// implements the new [`Device`] trait.
+pub struct MmioDeviceAdapter<T> {
+    /// The inner device wrapped in an `Arc`.
+    inner: Arc<T>,
+    /// The human-readable name of this adapter.
+    name: String,
+}
+
+impl<T: Send> MmioDeviceAdapter<T>
+where
+    T: BaseDeviceOps<crate::GuestPhysAddrRange>,
+{
+    /// Creates a new `MmioDeviceAdapter` from an owned device.
+    pub fn new(device: T) -> Self {
+        Self {
+            name: type_name(device.emu_type()),
+            inner: Arc::new(device),
+        }
+    }
+
+    /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
+    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device> {
+        Arc::new(Self {
+            name: type_name(device.emu_type()),
+            inner: device,
+        })
+    }
+
+    /// Returns a reference to the inner device.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+// SAFETY: The inner device uses internal synchronisation (e.g. `Mutex`,
+// `UnsafeCell` with proper barriers) and has been safely shared across
+// threads in the existing codebase via `Arc`.
+unsafe impl<T> Send for MmioDeviceAdapter<T> {}
+unsafe impl<T> Sync for MmioDeviceAdapter<T> {}
+
+impl<T: Send + 'static> Device for MmioDeviceAdapter<T>
+where
+    T: BaseDeviceOps<crate::GuestPhysAddrRange>,
+{
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        let range = self.inner.address_range();
+        let base = range.start.as_usize() as u64;
+        let size = (range.end.as_usize() - range.start.as_usize()) as u64;
+        alloc::vec![Resource::MmioRange { base, size }]
+    }
+
+    fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+        let addr = GuestPhysAddr::from(access.addr as usize);
+        if access.is_read {
+            self.inner
+                .handle_read(addr, access.width)
+                .map(|v| BusResponse::Read { value: v as u64 })
+                .map_err(|_| DeviceError::Internal)
+        } else {
+            self.inner
+                .handle_write(addr, access.width, access.data as usize)
+                .map(|_| BusResponse::Write)
+                .map_err(|_| DeviceError::Internal)
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        &*self.inner
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SysRegDeviceAdapter
+// ---------------------------------------------------------------------------
+
+/// Wraps an old-style [`BaseDeviceOps<SysRegAddrRange>`] device so that it
+/// implements the new [`Device`](crate::Device) trait.
+pub struct SysRegDeviceAdapter<T> {
+    /// The inner device wrapped in an `Arc`.
+    inner: Arc<T>,
+    /// The human-readable name of this adapter.
+    name: String,
+}
+
+impl<T: Send> SysRegDeviceAdapter<T>
+where
+    T: BaseDeviceOps<SysRegAddrRange>,
+{
+    /// Creates a new `SysRegDeviceAdapter` from an owned device.
+    pub fn new(device: T) -> Self {
+        Self {
+            name: type_name(device.emu_type()),
+            inner: Arc::new(device),
+        }
+    }
+
+    /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
+    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device> {
+        Arc::new(Self {
+            name: type_name(device.emu_type()),
+            inner: device,
+        })
+    }
+
+    /// Returns a reference to the inner device.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+unsafe impl<T> Send for SysRegDeviceAdapter<T> {}
+unsafe impl<T> Sync for SysRegDeviceAdapter<T> {}
+
+impl<T: Send + 'static> Device for SysRegDeviceAdapter<T>
+where
+    T: BaseDeviceOps<SysRegAddrRange>,
+{
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        let range = self.inner.address_range();
+        alloc::vec![Resource::SysReg {
+            addr: range.start.0 as u32
+        }]
+    }
+
+    fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+        let addr = SysRegAddr::new(access.addr as usize);
+        if access.is_read {
+            self.inner
+                .handle_read(addr, access.width)
+                .map(|v| BusResponse::Read { value: v as u64 })
+                .map_err(|_| DeviceError::Internal)
+        } else {
+            self.inner
+                .handle_write(addr, access.width, access.data as usize)
+                .map(|_| BusResponse::Write)
+                .map_err(|_| DeviceError::Internal)
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        &*self.inner
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PortDeviceAdapter
+// ---------------------------------------------------------------------------
+
+/// Wraps an old-style [`BaseDeviceOps<PortRange>`] device so that it implements
+/// the new [`Device`](crate::Device) trait.
+pub struct PortDeviceAdapter<T> {
+    /// The inner device wrapped in an `Arc`.
+    inner: Arc<T>,
+    /// The human-readable name of this adapter.
+    name: String,
+}
+
+impl<T: Send> PortDeviceAdapter<T>
+where
+    T: BaseDeviceOps<PortRange>,
+{
+    /// Creates a new `PortDeviceAdapter` from an owned device.
+    pub fn new(device: T) -> Self {
+        Self {
+            name: type_name(device.emu_type()),
+            inner: Arc::new(device),
+        }
+    }
+
+    /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
+    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device> {
+        Arc::new(Self {
+            name: type_name(device.emu_type()),
+            inner: device,
+        })
+    }
+
+    /// Returns a reference to the inner device.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+unsafe impl<T> Send for PortDeviceAdapter<T> {}
+unsafe impl<T> Sync for PortDeviceAdapter<T> {}
+
+impl<T: Send + 'static> Device for PortDeviceAdapter<T>
+where
+    T: BaseDeviceOps<PortRange>,
+{
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        let range = self.inner.address_range();
+        let base = range.start.0;
+        let size = (range.end.0 - range.start.0).wrapping_add(1);
+        alloc::vec![Resource::PortRange { base, size }]
+    }
+
+    fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+        let port = Port::new(access.addr as u16);
+        if access.is_read {
+            self.inner
+                .handle_read(port, access.width)
+                .map(|v| BusResponse::Read { value: v as u64 })
+                .map_err(|_| DeviceError::Internal)
+        } else {
+            self.inner
+                .handle_write(port, access.width, access.data as usize)
+                .map(|_| BusResponse::Write)
+                .map_err(|_| DeviceError::Internal)
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        &*self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{sync::Arc, vec::Vec};
+    use core::any::Any;
+
+    use ax_errno::AxResult;
+    use axvm_types::GuestPhysAddr;
+
+    use super::MmioDeviceAdapter;
+    use crate::{
+        BaseDeviceOps, Device, EmuDeviceType, GuestPhysAddrRange, Resource,
+        device::{AccessWidth, BusAccess, BusKind, BusResponse, DeviceError},
+    };
+
+    struct MockMmioDevice {
+        addr: GuestPhysAddr,
+        size: usize,
+        read_val: usize,
+        name: &'static str,
+    }
+
+    impl BaseDeviceOps<GuestPhysAddrRange> for MockMmioDevice {
+        fn emu_type(&self) -> EmuDeviceType {
+            EmuDeviceType::Dummy
+        }
+        fn address_range(&self) -> GuestPhysAddrRange {
+            (self.addr..GuestPhysAddr::from(self.addr.as_usize() + self.size))
+                .try_into()
+                .unwrap()
+        }
+        fn handle_read(&self, _addr: GuestPhysAddr, _width: AccessWidth) -> AxResult<usize> {
+            Ok(self.read_val)
+        }
+        fn handle_write(&self, _addr: GuestPhysAddr, _width: AccessWidth, _val: usize) -> AxResult {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_mmio_adapter() {
+        let dev = MockMmioDevice {
+            addr: GuestPhysAddr::from(0x1000),
+            size: 0x100,
+            read_val: 42,
+            name: "mock",
+        };
+        let adapter = MmioDeviceAdapter::new(dev);
+
+        let r = adapter.resources();
+        assert_eq!(r.len(), 1);
+        match r[0] {
+            Resource::MmioRange { base, size } => {
+                assert_eq!(base, 0x1000);
+                assert_eq!(size, 0x100);
+            }
+            _ => panic!(),
+        }
+
+        let resp = adapter
+            .handle(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: true,
+                addr: 0x1000,
+                width: AccessWidth::Dword,
+                data: 0,
+            })
+            .unwrap();
+        match resp {
+            BusResponse::Read { value } => assert_eq!(value, 42),
+            _ => panic!(),
+        }
+
+        assert!(adapter.as_any().downcast_ref::<MockMmioDevice>().is_some());
+    }
+}

--- a/virtualization/axdevice_base/src/adapter.rs
+++ b/virtualization/axdevice_base/src/adapter.rs
@@ -320,23 +320,19 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::sync::Arc;
-    use core::any::Any;
-
     use ax_errno::AxResult;
     use axvm_types::GuestPhysAddr;
 
     use super::MmioDeviceAdapter;
     use crate::{
         BaseDeviceOps, Device, EmuDeviceType, GuestPhysAddrRange, Resource,
-        device::{AccessWidth, BusAccess, BusKind, BusResponse, DeviceError},
+        device::{AccessWidth, BusAccess, BusKind, BusResponse},
     };
 
     struct MockMmioDevice {
         addr: GuestPhysAddr,
         size: usize,
         read_val: usize,
-        name: &'static str,
     }
 
     impl BaseDeviceOps<GuestPhysAddrRange> for MockMmioDevice {
@@ -362,7 +358,6 @@ mod tests {
             addr: GuestPhysAddr::from(0x1000),
             size: 0x100,
             read_val: 42,
-            name: "mock",
         };
         let adapter = MmioDeviceAdapter::new(dev);
 

--- a/virtualization/axdevice_base/src/adapter.rs
+++ b/virtualization/axdevice_base/src/adapter.rs
@@ -20,7 +20,7 @@
 //! rewritten to implement `Device` natively the corresponding adapter can
 //! be removed.
 
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc};
 use core::any::Any;
 
 use crate::{
@@ -30,6 +30,36 @@ use crate::{
 
 fn type_name(emu_type: EmuDeviceType) -> String {
     alloc::format!("{:?}-adapter", emu_type)
+}
+
+fn mmio_resources(range: &crate::GuestPhysAddrRange) -> Box<[Resource]> {
+    let base = range.start.as_usize() as u64;
+    let size = if range.end.as_usize() >= range.start.as_usize() {
+        (range.end.as_usize() - range.start.as_usize()) as u64
+    } else {
+        0
+    };
+    alloc::vec![Resource::MmioRange { base, size }].into_boxed_slice()
+}
+
+fn sysreg_resources(range: &SysRegAddrRange) -> Box<[Resource]> {
+    let addr = range.start.0 as u32;
+    let count = if range.end.0 >= range.start.0 {
+        (range.end.0 - range.start.0) as u32 + 1
+    } else {
+        0
+    };
+    alloc::vec![Resource::SysReg { addr, count }].into_boxed_slice()
+}
+
+fn port_resources(range: &PortRange) -> Box<[Resource]> {
+    let base = range.start.0;
+    let size = if range.end.0 >= range.start.0 {
+        (range.end.0 - range.start.0).wrapping_add(1)
+    } else {
+        0
+    };
+    alloc::vec![Resource::PortRange { base, size }].into_boxed_slice()
 }
 
 // ---------------------------------------------------------------------------
@@ -43,6 +73,8 @@ pub struct MmioDeviceAdapter<T> {
     inner: Arc<T>,
     /// The human-readable name of this adapter.
     name: String,
+    /// Cached resource snapshot.
+    resources: Box<[Resource]>,
 }
 
 impl<T: Send> MmioDeviceAdapter<T>
@@ -51,9 +83,11 @@ where
 {
     /// Creates a new `MmioDeviceAdapter` from an owned device.
     pub fn new(device: T) -> Self {
+        let resources = mmio_resources(&device.address_range());
         Self {
             name: type_name(device.emu_type()),
             inner: Arc::new(device),
+            resources,
         }
     }
 
@@ -63,9 +97,11 @@ where
         T: Send + Sync + 'static,
         T: BaseDeviceOps<crate::GuestPhysAddrRange>,
     {
+        let resources = mmio_resources(&device.address_range());
         Arc::new(Self {
             name: type_name(device.emu_type()),
             inner: device,
+            resources,
         })
     }
 
@@ -90,16 +126,8 @@ where
         &self.name
     }
 
-    fn resources(&self) -> Vec<Resource> {
-        let range = self.inner.address_range();
-        let base = range.start.as_usize() as u64;
-        let size = if range.end.as_usize() >= range.start.as_usize() {
-            (range.end.as_usize() - range.start.as_usize()) as u64
-        } else {
-            // Wrapped address range — the caller will reject size=0.
-            0
-        };
-        alloc::vec![Resource::MmioRange { base, size }]
+    fn resources(&self) -> &[Resource] {
+        &self.resources
     }
 
     fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
@@ -133,6 +161,8 @@ pub struct SysRegDeviceAdapter<T> {
     inner: Arc<T>,
     /// The human-readable name of this adapter.
     name: String,
+    /// Cached resource snapshot.
+    resources: Box<[Resource]>,
 }
 
 impl<T: Send> SysRegDeviceAdapter<T>
@@ -141,9 +171,11 @@ where
 {
     /// Creates a new `SysRegDeviceAdapter` from an owned device.
     pub fn new(device: T) -> Self {
+        let resources = sysreg_resources(&device.address_range());
         Self {
             name: type_name(device.emu_type()),
             inner: Arc::new(device),
+            resources,
         }
     }
 
@@ -153,9 +185,11 @@ where
         T: Send + Sync + 'static,
         T: BaseDeviceOps<SysRegAddrRange>,
     {
+        let resources = sysreg_resources(&device.address_range());
         Arc::new(Self {
             name: type_name(device.emu_type()),
             inner: device,
+            resources,
         })
     }
 
@@ -176,15 +210,8 @@ where
         &self.name
     }
 
-    fn resources(&self) -> Vec<Resource> {
-        let range = self.inner.address_range();
-        let addr = range.start.0 as u32;
-        let count = if range.end.0 >= range.start.0 {
-            (range.end.0 - range.start.0) as u32 + 1
-        } else {
-            0
-        };
-        alloc::vec![Resource::SysReg { addr, count }]
+    fn resources(&self) -> &[Resource] {
+        &self.resources
     }
 
     fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
@@ -218,6 +245,8 @@ pub struct PortDeviceAdapter<T> {
     inner: Arc<T>,
     /// The human-readable name of this adapter.
     name: String,
+    /// Cached resource snapshot.
+    resources: Box<[Resource]>,
 }
 
 impl<T: Send> PortDeviceAdapter<T>
@@ -226,9 +255,11 @@ where
 {
     /// Creates a new `PortDeviceAdapter` from an owned device.
     pub fn new(device: T) -> Self {
+        let resources = port_resources(&device.address_range());
         Self {
             name: type_name(device.emu_type()),
             inner: Arc::new(device),
+            resources,
         }
     }
 
@@ -238,9 +269,11 @@ where
         T: Send + Sync + 'static,
         T: BaseDeviceOps<PortRange>,
     {
+        let resources = port_resources(&device.address_range());
         Arc::new(Self {
             name: type_name(device.emu_type()),
             inner: device,
+            resources,
         })
     }
 
@@ -261,16 +294,8 @@ where
         &self.name
     }
 
-    fn resources(&self) -> Vec<Resource> {
-        let range = self.inner.address_range();
-        let base = range.start.0;
-        let size = if range.end.0 >= range.start.0 {
-            (range.end.0 - range.start.0).wrapping_add(1)
-        } else {
-            // Empty or wrapped range — the caller will reject size=0.
-            0
-        };
-        alloc::vec![Resource::PortRange { base, size }]
+    fn resources(&self) -> &[Resource] {
+        &self.resources
     }
 
     fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
@@ -295,7 +320,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::{sync::Arc, vec::Vec};
+    use alloc::sync::Arc;
     use core::any::Any;
 
     use ax_errno::AxResult;
@@ -326,7 +351,12 @@ mod tests {
         fn handle_read(&self, _addr: GuestPhysAddr, _width: AccessWidth) -> AxResult<usize> {
             Ok(self.read_val)
         }
-        fn handle_write(&self, _addr: GuestPhysAddr, _width: AccessWidth, _val: usize) -> AxResult {
+        fn handle_write(
+            &self,
+            _addr: GuestPhysAddr,
+            _width: AccessWidth,
+            _val: usize,
+        ) -> AxResult {
             Ok(())
         }
     }

--- a/virtualization/axdevice_base/src/adapter.rs
+++ b/virtualization/axdevice_base/src/adapter.rs
@@ -58,7 +58,11 @@ where
     }
 
     /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
-    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device> {
+    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device>
+    where
+        T: 'static,
+        T: BaseDeviceOps<crate::GuestPhysAddrRange>,
+    {
         Arc::new(Self {
             name: type_name(device.emu_type()),
             inner: device,
@@ -74,6 +78,7 @@ where
 // SAFETY: The inner device uses internal synchronisation (e.g. `Mutex`,
 // `UnsafeCell` with proper barriers) and has been safely shared across
 // threads in the existing codebase via `Arc`.
+// All concrete device types are `Send + Sync`.
 unsafe impl<T> Send for MmioDeviceAdapter<T> {}
 unsafe impl<T> Sync for MmioDeviceAdapter<T> {}
 
@@ -138,7 +143,11 @@ where
     }
 
     /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
-    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device> {
+    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device>
+    where
+        T: 'static,
+        T: BaseDeviceOps<SysRegAddrRange>,
+    {
         Arc::new(Self {
             name: type_name(device.emu_type()),
             inner: device,
@@ -215,7 +224,11 @@ where
     }
 
     /// Creates an `Arc<dyn Device>` from an existing `Arc<T>`.
-    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device> {
+    pub fn from_arc(device: Arc<T>) -> Arc<dyn Device>
+    where
+        T: 'static,
+        T: BaseDeviceOps<PortRange>,
+    {
         Arc::new(Self {
             name: type_name(device.emu_type()),
             inner: device,

--- a/virtualization/axdevice_base/src/device.rs
+++ b/virtualization/axdevice_base/src/device.rs
@@ -258,3 +258,72 @@ impl LowerHex for PortRange {
         write!(f, "{:#x}..={:#x}", self.start.0, self.end.0)
     }
 }
+
+// ---------------------------------------------------------------------------
+// Unified bus-access types
+// ---------------------------------------------------------------------------
+
+/// The kind of bus a device is connected to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusKind {
+    /// Memory-mapped I/O bus.
+    Mmio,
+    /// Port I/O bus (x86 only).
+    Port,
+    /// System register bus (ARM only).
+    SysReg,
+}
+
+/// An access issued by a vCPU to a device on a bus.
+#[derive(Debug, Clone, Copy)]
+pub struct BusAccess {
+    /// The kind of bus being accessed.
+    pub kind: BusKind,
+    /// `true` if this is a read access; `false` for write.
+    pub is_read: bool,
+    /// The address being accessed.
+    pub addr: u64,
+    /// The width of the access.
+    pub width: AccessWidth,
+    /// The data to write (ignored for reads).
+    pub data: u64,
+}
+
+/// The result of a bus access dispatched to a device.
+#[derive(Debug, Clone, Copy)]
+pub enum BusResponse {
+    /// A read response with the value.
+    Read {
+        /// The value read from the device.
+        value: u64,
+    },
+    /// A write acknowledgment.
+    Write,
+}
+
+/// Errors that can occur during device access handling.
+#[derive(Debug, Clone)]
+pub enum DeviceError {
+    /// No device found at the requested address.
+    NotFound,
+    /// The access width does not match what the register expects.
+    InvalidWidth {
+        /// The width the register expects.
+        expected: AccessWidth,
+        /// The width that was used.
+        actual: AccessWidth,
+    },
+    /// Attempted to write to a read-only register.
+    ReadOnly,
+    /// Attempted to read from a write-only register.
+    WriteOnly,
+    /// The address is outside the device's range.
+    OutOfRange {
+        /// The address that was accessed.
+        addr: u64,
+    },
+    /// The requested functionality is not yet implemented.
+    Unimplemented,
+    /// An internal error occurred in the device implementation.
+    Internal,
+}

--- a/virtualization/axdevice_base/src/lib.rs
+++ b/virtualization/axdevice_base/src/lib.rs
@@ -419,6 +419,10 @@ pub enum InvalidResourceReason {
     /// The bus kind of the resource is not supported on the current
     /// architecture.
     UnsupportedOnArchitecture,
+    /// The device declared multiple resources of the same bus kind whose
+    /// address ranges overlap each other, which would corrupt the
+    /// dispatch index.
+    OverlappingResources,
 }
 
 /// Errors that can be returned when registering a device.

--- a/virtualization/axdevice_base/src/lib.rs
+++ b/virtualization/axdevice_base/src/lib.rs
@@ -24,10 +24,8 @@
 //!
 //! - [`BaseDeviceOps`]: The core trait that all emulated devices must implement.
 //! - [`EmuDeviceType`]: Enumeration representing the type of emulator devices
-//!   (re-exported from `axvm-types` crate).
+//!   (re-exported from `axvmconfig` crate).
 //! - [`EmulatedDeviceConfig`]: Configuration structure for device initialization.
-//! - [`IrqLine`] and [`IrqSink`]: Architecture-independent interrupt line
-//!   signaling.
 //! - Trait aliases for specific device types:
 //!   - [`BaseMmioDeviceOps`]: For MMIO (Memory-Mapped I/O) devices.
 //!   - [`BaseSysRegDeviceOps`]: For system register devices.
@@ -39,8 +37,8 @@
 //! trait with the appropriate address range type:
 //!
 //! ```rust,ignore
-//! use axdevice_base::{AccessWidth, BaseDeviceOps, EmuDeviceType};
-//! use axvm_types::{GuestPhysAddr, GuestPhysAddrRange};
+//! use axdevice_base::{BaseDeviceOps, EmuDeviceType};
+//! use axaddrspace::{GuestPhysAddrRange, device::AccessWidth};
 //! use ax_errno::AxResult;
 //!
 //! struct MyDevice {
@@ -87,7 +85,6 @@
 extern crate alloc;
 
 mod device;
-mod irq;
 
 use alloc::{string::String, sync::Arc, vec::Vec};
 use core::any::Any;
@@ -97,10 +94,11 @@ pub use axvm_types::{
     EmulatedDeviceType as EmuDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptTriggerMode,
     IrqLineId,
 };
-pub use device::{
-    AccessWidth, DeviceAddr, DeviceAddrRange, Port, PortRange, SysRegAddr, SysRegAddrRange,
+
+pub use crate::device::{
+    AccessWidth, BusAccess, BusKind, BusResponse, DeviceAddr, DeviceAddrRange, DeviceError, Port,
+    PortRange, SysRegAddr, SysRegAddrRange,
 };
-pub use irq::{IrqLine, IrqSink};
 
 /// Represents the configuration of an emulated device for a virtual machine.
 ///
@@ -297,6 +295,10 @@ pub trait BaseDeviceOps<R: DeviceAddrRange>: Any {
 ///     }
 /// }
 /// ```
+#[deprecated(
+    since = "0.5.0",
+    note = "Use Device::as_any().downcast_ref() via MmioDeviceAdapter instead"
+)]
 pub fn map_device_of_type<T: BaseDeviceOps<R>, R: DeviceAddrRange, U, F: FnOnce(&T) -> U>(
     device: &Arc<dyn BaseDeviceOps<R>>,
     f: F,
@@ -340,3 +342,300 @@ pub trait BaseSysRegDeviceOps = BaseDeviceOps<SysRegAddrRange>;
 ///
 /// Port I/O devices are only used on x86/x86_64 architectures.
 pub trait BasePortDeviceOps = BaseDeviceOps<PortRange>;
+
+// ---------------------------------------------------------------------------
+// New unified device-registration types (device / interrupt framework refactoring)
+// ---------------------------------------------------------------------------
+
+/// Opaque identifier assigned to a device when it is registered into a
+/// [`AxVmDevices`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeviceId(u32);
+
+impl DeviceId {
+    /// Creates a new `DeviceId` from a raw `u32`.
+    pub const fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw `u32` value.
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+/// Target instruction-set architecture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Arch {
+    /// 64-bit ARM (AArch64).
+    AArch64,
+    /// 64-bit RISC-V.
+    Riscv64,
+    /// 64-bit x86 (AMD64 / Intel 64).
+    X86_64,
+    /// 64-bit LoongArch.
+    LoongArch64,
+}
+
+/// Which vCPU(s) an interrupt should be delivered to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IrqTarget {
+    /// A specific vCPU by its index.
+    VCpu(usize),
+    /// Broadcast to every vCPU in the VM.
+    AllVCpus,
+    /// Deliver to the vCPU currently running at the lowest priority
+    /// (architecture-dependent).
+    LowestPriority,
+}
+
+/// Trigger configuration for an interrupt line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IrqConfig {
+    /// Edge-triggered interrupt.
+    Edge,
+    /// Level-triggered interrupt.
+    Level,
+}
+
+/// The reason an IRQ resource registration was rejected.
+#[derive(Debug, Clone)]
+pub enum IrqConflictReason {
+    /// The IRQ number exceeds the maximum supported value.
+    OutOfRange {
+        /// The requested IRQ line.
+        irq: u32,
+        /// The maximum valid IRQ line for this architecture.
+        max: u32,
+    },
+    /// The IRQ line is already exclusively owned by another device.
+    AlreadyExclusive {
+        /// The conflicting IRQ line.
+        irq: u32,
+        /// The device that already owns this line.
+        owner: DeviceId,
+    },
+    /// The trigger mode does not match the existing configuration on this
+    /// line.
+    TriggerMismatch {
+        /// The IRQ line.
+        irq: u32,
+        /// The trigger mode the new device expects.
+        expected: IrqConfig,
+        /// The trigger mode already configured on this line.
+        actual: IrqConfig,
+    },
+}
+
+/// The kind of a resource a device requests.
+///
+/// Used in [`RegistryError::MissingRequiredResource`] to report which
+/// required resource category was not declared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceKind {
+    /// MMIO address range.
+    Mmio,
+    /// Port I/O range.
+    Port,
+    /// System register.
+    SysReg,
+    /// Interrupt line.
+    Irq,
+    /// MSI / MSI-X vector block.
+    Msi,
+}
+
+/// A resource that a device declares it needs during registration.
+///
+/// The device manager uses this information for address-range conflict
+/// detection, IRQ routing setup, and architecture-suitability checks.
+#[derive(Debug, Clone)]
+pub enum Resource {
+    /// An MMIO address window.
+    MmioRange {
+        /// Start of the window (guest-physical address).
+        base: u64,
+        /// Size of the window in bytes.
+        size: u64,
+    },
+    /// A Port I/O range (x86 only).
+    PortRange {
+        /// Start of the range.
+        base: u16,
+        /// Size of the range in bytes.
+        size: u16,
+    },
+    /// A single system register.
+    SysReg {
+        /// Register encoding (architecture-specific).
+        addr: u32,
+    },
+    /// An interrupt line.
+    Irq {
+        /// IRQ number.
+        line: u32,
+        /// Which vCPU(s) the interrupt targets.
+        target: IrqTarget,
+    },
+    /// A dynamic PCI BAR that will be programmed at runtime.
+    PciBar {
+        /// BAR index (0–5).
+        bar_index: u8,
+        /// Requested size in bytes.
+        size: u64,
+        /// `true` if this BAR requests PIO space; `false` for MMIO.
+        is_pio: bool,
+    },
+    /// MSI / MSI-X capability with a requested number of vectors.
+    MSI {
+        /// Number of interrupt vectors requested.
+        count: u32,
+    },
+    /// Marker indicating the device is capable of DMA (used for IOMMU /
+    /// security checks). This does not consume an address range.
+    DmaCapable,
+}
+
+/// Errors that can be returned when registering or unregistering a device.
+#[derive(Debug, Clone)]
+pub enum RegistryError {
+    /// The given [`DeviceId`] does not refer to a currently-registered device.
+    DeviceNotFound(DeviceId),
+    /// Two devices claim overlapping address ranges.
+    AddressConflict {
+        /// The resource the new device is attempting to register.
+        resource: Resource,
+        /// The resource already held by an existing device.
+        existing: Resource,
+        /// The device that already owns the conflicting resource.
+        existing_device: DeviceId,
+    },
+    /// The device requested a bus type that the current architecture does
+    /// not support (e.g. Port I/O on AArch64).
+    BusKindNotSupported {
+        /// The unsupported bus kind.
+        kind: BusKind,
+        /// The current target architecture.
+        arch: Arch,
+    },
+    /// An IRQ resource could not be allocated.
+    IrqConflict {
+        /// The IRQ line that caused the conflict.
+        irq: u32,
+        /// The reason for the conflict.
+        reason: IrqConflictReason,
+    },
+    /// The device is not compatible with the current target architecture.
+    ArchNotSupported {
+        /// Human-readable device name (for diagnostics).
+        device_name: String,
+        /// The architecture(s) the device requires.
+        required_arch: Arch,
+        /// The architecture the hypervisor is currently built for.
+        current_arch: Arch,
+    },
+    /// The device did not declare a resource that is mandatory for its
+    /// device class.
+    MissingRequiredResource {
+        /// The device that is missing a resource.
+        device: DeviceId,
+        /// The kind of resource that is missing.
+        missing: ResourceKind,
+    },
+}
+
+/// The unified device trait.
+///
+/// Every emulated device (interrupt controller, UART, virtio-blk, …)
+/// implements this trait.  The device manager calls [`resources`](Device::resources)
+/// at registration time for conflict detection and [`handle`](Device::handle)
+/// on the hot path whenever a vCPU exit is dispatched to this device.
+///
+/// # Downcasting
+///
+/// `Device` extends [`Any`](core::any::Any) so callers can downcast to a
+/// concrete device type via [`as_any`](Device::as_any):
+///
+/// ```ignore
+/// if let Some(vgic) = device.as_any().downcast_ref::<VGicD>() {
+///     vgic.assign_irq(32, cpu_id, (0, 0, 0, cpu_id));
+/// }
+/// ```
+pub trait Device: Send + Sync + Any {
+    /// Returns a human-readable name for this device (used in logging and
+    /// diagnostics).
+    fn name(&self) -> &str;
+
+    /// Returns the set of resources (MMIO windows, port ranges, IRQ lines,
+    /// …) this device requires.
+    fn resources(&self) -> Vec<Resource>;
+
+    /// Handles a single bus access.
+    ///
+    /// This is the hot-path entry point called from [`BusRouter::dispatch`].
+    fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError>;
+
+    /// Returns a reference to `self` as `&dyn Any` for downcasting.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Resets the device to its power-on state.
+    #[allow(unused_variables)]
+    fn reset(&mut self) -> Result<(), DeviceError> {
+        Ok(())
+    }
+
+    /// Puts the device into a low-power or suspended state.
+    #[allow(unused_variables)]
+    fn suspend(&mut self) -> Result<(), DeviceError> {
+        Ok(())
+    }
+
+    /// Restores the device from a suspended state.
+    #[allow(unused_variables)]
+    fn resume(&mut self) -> Result<(), DeviceError> {
+        Ok(())
+    }
+}
+
+/// Device registration interface — the build-time / management-path half of a
+/// [`AxVmDevices`].
+///
+/// Used when constructing or reconfiguring a VM; not on the vCPU hot path.
+pub trait DeviceRegistry {
+    /// Registers a device, performing resource conflict detection and
+    /// architecture-suitability checks.
+    ///
+    /// On success the device is assigned a unique [`DeviceId`] and inserted
+    /// into the manager's lookup structures.
+    fn register(&mut self, device: Arc<dyn Device>) -> Result<DeviceId, RegistryError>;
+
+    /// Unregisters a previously registered device, removing its resources
+    /// from all lookup structures and freeing its slot.
+    fn unregister(&mut self, id: DeviceId) -> Result<(), RegistryError>;
+}
+
+/// Bus dispatch interface — the runtime hot-path half of a
+/// [`AxVmDevices`].
+///
+/// Called on every vCPU exit that targets an emulated device (MMIO / Port /
+/// SysReg).
+pub trait BusRouter {
+    /// Looks up the device responsible for `access` and forwards the access
+    /// to it, returning the result.
+    fn dispatch(&self, access: &BusAccess) -> Result<BusResponse, DeviceError>;
+
+    /// Looks up the device responsible for `access` without handling the
+    /// access.  The caller can then inspect the device or call
+    /// [`Device::handle`] manually.
+    fn lookup(&self, access: &BusAccess) -> Result<Arc<dyn Device>, DeviceError>;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-modules
+// ---------------------------------------------------------------------------
+
+mod adapter;
+mod irq;
+
+pub use adapter::{MmioDeviceAdapter, PortDeviceAdapter, SysRegDeviceAdapter};
+pub use irq::{IrqLine, IrqSink};

--- a/virtualization/axdevice_base/src/lib.rs
+++ b/virtualization/axdevice_base/src/lib.rs
@@ -465,10 +465,12 @@ pub enum Resource {
         /// Size of the range in bytes.
         size: u16,
     },
-    /// A single system register.
+    /// System register range.
     SysReg {
-        /// Register encoding (architecture-specific).
+        /// Register encoding range start (architecture-specific).
         addr: u32,
+        /// Number of registers in the range.
+        count: u32,
     },
     /// An interrupt line.
     Irq {

--- a/virtualization/axdevice_base/src/lib.rs
+++ b/virtualization/axdevice_base/src/lib.rs
@@ -377,78 +377,10 @@ pub enum Arch {
     LoongArch64,
 }
 
-/// Which vCPU(s) an interrupt should be delivered to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IrqTarget {
-    /// A specific vCPU by its index.
-    VCpu(usize),
-    /// Broadcast to every vCPU in the VM.
-    AllVCpus,
-    /// Deliver to the vCPU currently running at the lowest priority
-    /// (architecture-dependent).
-    LowestPriority,
-}
-
-/// Trigger configuration for an interrupt line.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IrqConfig {
-    /// Edge-triggered interrupt.
-    Edge,
-    /// Level-triggered interrupt.
-    Level,
-}
-
-/// The reason an IRQ resource registration was rejected.
-#[derive(Debug, Clone)]
-pub enum IrqConflictReason {
-    /// The IRQ number exceeds the maximum supported value.
-    OutOfRange {
-        /// The requested IRQ line.
-        irq: u32,
-        /// The maximum valid IRQ line for this architecture.
-        max: u32,
-    },
-    /// The IRQ line is already exclusively owned by another device.
-    AlreadyExclusive {
-        /// The conflicting IRQ line.
-        irq: u32,
-        /// The device that already owns this line.
-        owner: DeviceId,
-    },
-    /// The trigger mode does not match the existing configuration on this
-    /// line.
-    TriggerMismatch {
-        /// The IRQ line.
-        irq: u32,
-        /// The trigger mode the new device expects.
-        expected: IrqConfig,
-        /// The trigger mode already configured on this line.
-        actual: IrqConfig,
-    },
-}
-
-/// The kind of a resource a device requests.
-///
-/// Used in [`RegistryError::MissingRequiredResource`] to report which
-/// required resource category was not declared.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ResourceKind {
-    /// MMIO address range.
-    Mmio,
-    /// Port I/O range.
-    Port,
-    /// System register.
-    SysReg,
-    /// Interrupt line.
-    Irq,
-    /// MSI / MSI-X vector block.
-    Msi,
-}
-
 /// A resource that a device declares it needs during registration.
 ///
 /// The device manager uses this information for address-range conflict
-/// detection, IRQ routing setup, and architecture-suitability checks.
+/// detection and architecture-suitability checks.
 #[derive(Debug, Clone)]
 pub enum Resource {
     /// An MMIO address window.
@@ -472,37 +404,33 @@ pub enum Resource {
         /// Number of registers in the range.
         count: u32,
     },
-    /// An interrupt line.
-    Irq {
-        /// IRQ number.
-        line: u32,
-        /// Which vCPU(s) the interrupt targets.
-        target: IrqTarget,
-    },
-    /// A dynamic PCI BAR that will be programmed at runtime.
-    PciBar {
-        /// BAR index (0–5).
-        bar_index: u8,
-        /// Requested size in bytes.
-        size: u64,
-        /// `true` if this BAR requests PIO space; `false` for MMIO.
-        is_pio: bool,
-    },
-    /// MSI / MSI-X capability with a requested number of vectors.
-    MSI {
-        /// Number of interrupt vectors requested.
-        count: u32,
-    },
-    /// Marker indicating the device is capable of DMA (used for IOMMU /
-    /// security checks). This does not consume an address range.
-    DmaCapable,
 }
 
-/// Errors that can be returned when registering or unregistering a device.
+/// The reason a resource was rejected as structurally invalid during
+/// validation.
+#[derive(Debug, Clone)]
+pub enum InvalidResourceReason {
+    /// The resource has a size or count of zero.
+    ZeroSized,
+    /// The resource's end address overflows the address space.
+    AddressOverflow,
+    /// The resource extends past the valid bus address range.
+    OutOfBusRange,
+    /// The bus kind of the resource is not supported on the current
+    /// architecture.
+    UnsupportedOnArchitecture,
+}
+
+/// Errors that can be returned when registering a device.
 #[derive(Debug, Clone)]
 pub enum RegistryError {
-    /// The given [`DeviceId`] does not refer to a currently-registered device.
-    DeviceNotFound(DeviceId),
+    /// The device declared a resource that is structurally invalid.
+    InvalidResource {
+        /// The invalid resource.
+        resource: Resource,
+        /// Why the resource was rejected.
+        reason: InvalidResourceReason,
+    },
     /// Two devices claim overlapping address ranges.
     AddressConflict {
         /// The resource the new device is attempting to register.
@@ -520,13 +448,6 @@ pub enum RegistryError {
         /// The current target architecture.
         arch: Arch,
     },
-    /// An IRQ resource could not be allocated.
-    IrqConflict {
-        /// The IRQ line that caused the conflict.
-        irq: u32,
-        /// The reason for the conflict.
-        reason: IrqConflictReason,
-    },
     /// The device is not compatible with the current target architecture.
     ArchNotSupported {
         /// Human-readable device name (for diagnostics).
@@ -535,14 +456,6 @@ pub enum RegistryError {
         required_arch: Arch,
         /// The architecture the hypervisor is currently built for.
         current_arch: Arch,
-    },
-    /// The device did not declare a resource that is mandatory for its
-    /// device class.
-    MissingRequiredResource {
-        /// The device that is missing a resource.
-        device: DeviceId,
-        /// The kind of resource that is missing.
-        missing: ResourceKind,
     },
 }
 
@@ -568,9 +481,13 @@ pub trait Device: Send + Sync + Any {
     /// diagnostics).
     fn name(&self) -> &str;
 
-    /// Returns the set of resources (MMIO windows, port ranges, IRQ lines,
-    /// …) this device requires.
-    fn resources(&self) -> Vec<Resource>;
+    /// Returns the resources (MMIO windows, port ranges, system registers)
+    /// this device requires.
+    ///
+    /// The returned slice is a stable snapshot computed at device construction
+    /// time. Callers may read it on both the registration path and the hot
+    /// path without allocation.
+    fn resources(&self) -> &[Resource];
 
     /// Handles a single bus access.
     ///
@@ -610,10 +527,6 @@ pub trait DeviceRegistry {
     /// On success the device is assigned a unique [`DeviceId`] and inserted
     /// into the manager's lookup structures.
     fn register(&mut self, device: Arc<dyn Device>) -> Result<DeviceId, RegistryError>;
-
-    /// Unregisters a previously registered device, removing its resources
-    /// from all lookup structures and freeing its slot.
-    fn unregister(&mut self, id: DeviceId) -> Result<(), RegistryError>;
 }
 
 /// Bus dispatch interface — the runtime hot-path half of a

--- a/virtualization/axdevice_base/tests/irq.rs
+++ b/virtualization/axdevice_base/tests/irq.rs
@@ -60,6 +60,9 @@ impl IrqSink for MockIrqSink {
         self.events.lock().unwrap().push(IrqEvent::Pulse(line));
         Ok(())
     }
+
+    // eoi is intentionally absent — MockIrqSink only implements the upstream
+    // IrqSink trait (set_level + pulse).
 }
 
 #[test]

--- a/virtualization/axdevice_base/tests/test.rs
+++ b/virtualization/axdevice_base/tests/test.rs
@@ -14,10 +14,13 @@
 
 extern crate alloc;
 
-use alloc::{sync::Arc, vec, vec::Vec};
+use alloc::{sync::Arc, vec};
 
 use ax_errno::AxResult;
-use axdevice_base::{AccessWidth, BaseDeviceOps, EmuDeviceType, map_device_of_type};
+use axdevice_base::{
+    AccessWidth, BaseDeviceOps, BusAccess, BusKind, BusResponse, Device, EmuDeviceType,
+    MmioDeviceAdapter,
+};
 use axvm_types::{GuestPhysAddr, GuestPhysAddrRange};
 
 const DEVICE_A_TEST_METHOD_ANSWER: usize = 42;
@@ -71,18 +74,29 @@ impl BaseDeviceOps<GuestPhysAddrRange> for DeviceB {
 
 #[test]
 fn test_device_type_test() {
-    let devices: Vec<Arc<dyn BaseDeviceOps<GuestPhysAddrRange>>> =
-        vec![Arc::new(DeviceA), Arc::new(DeviceB)];
+    let devices: Vec<Arc<dyn Device>> = vec![
+        MmioDeviceAdapter::from_arc(Arc::new(DeviceA)),
+        MmioDeviceAdapter::from_arc(Arc::new(DeviceB)),
+    ];
 
     let mut device_a_found = false;
-    for device in devices {
-        assert_eq!(
-            device.handle_read(0x2000.into(), AccessWidth::Byte),
-            Ok(0x2000)
-        );
+    for device in &devices {
+        let resp = device
+            .handle(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: true,
+                addr: 0x2000,
+                width: AccessWidth::Byte,
+                data: 0,
+            })
+            .unwrap();
+        assert!(matches!(
+            resp,
+            BusResponse::Read { value } if value as usize == 0x2000
+        ));
 
-        if let Some(answer) = map_device_of_type(&device, |d: &DeviceA| d.test_method()) {
-            assert_eq!(answer, DEVICE_A_TEST_METHOD_ANSWER);
+        if let Some(a) = device.as_any().downcast_ref::<DeviceA>() {
+            assert_eq!(a.test_method(), DEVICE_A_TEST_METHOD_ANSWER);
             device_a_found = true;
         }
     }

--- a/virtualization/axvm/src/irq/riscv.rs
+++ b/virtualization/axvm/src/irq/riscv.rs
@@ -19,6 +19,7 @@ use alloc::sync::Arc;
 use ax_errno::{AxResult, ax_err};
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceFactoryRegistry, DeviceRegistration,
+    MmioDeviceAdapter,
 };
 use axdevice_base::{IrqLineId, IrqSink};
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, VMInterruptMode};
@@ -75,7 +76,7 @@ impl DeviceFactory for RiscvPlicFactory {
                 )
             );
         }
-        Ok(DeviceRegistration::Mmio(self.vplic.clone()).into())
+        Ok(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(self.vplic.clone())).into())
     }
 }
 

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -54,6 +54,5 @@ cfg_if::cfg_if! {
         pub use arm_vcpu::Aarch64VCpuSetupConfig as AxVCpuSetupConfig;
         pub use arm_vcpu::max_guest_page_table_levels;
 
-        pub use arm_vgic::vtimer::get_sysreg_device;
     }
 }

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -25,6 +25,7 @@ use axdevice::{
     register_builtin_factories,
 };
 use axdevice_base::AccessWidth;
+use axdevice_base::DeviceRegistry as _;
 use axvcpu::{AxVCpu, AxVCpuExitReason};
 #[cfg(target_arch = "x86_64")]
 use axvm_types::EmulatedDeviceType;
@@ -35,8 +36,6 @@ use x86_vcpu::{X86_APIC_ACCESS_GPA, x86_apic_access_page_addr};
 
 #[cfg(not(target_arch = "x86_64"))]
 use crate::vcpu::AxVCpuCreateConfig;
-#[cfg(target_arch = "aarch64")]
-use crate::vcpu::get_sysreg_device;
 use crate::{
     config::{AxVMConfig, PhysCpuList, VMInterruptMode},
     host::paging::{HostPagingHandler, virt_to_phys},
@@ -376,20 +375,15 @@ impl AxVM {
                 let cpu_id = self.id() - 1; // FIXME: get the real CPU id.
                 let mut gicd_found = false;
 
-                for device in devices.iter_mmio_dev() {
-                    if let Some(result) = axdevice_base::map_device_of_type(
-                        device,
-                        |gicd: &arm_vgic::v3::vgicd::VGicD| {
-                            debug!("VGicD found, assigning SPIs...");
+                for device in devices.devices() {
+                    if let Some(gicd) = device.as_any().downcast_ref::<arm_vgic::v3::vgicd::VGicD>()
+                    {
+                        debug!("VGicD found, assigning SPIs...");
 
-                            for spi in spis {
-                                gicd.assign_irq(*spi + 32, cpu_id, (0, 0, 0, cpu_id as _))
-                            }
+                        for spi in spis {
+                            gicd.assign_irq(*spi + 32, cpu_id, (0, 0, 0, cpu_id as _))
+                        }
 
-                            AxResult::Ok(())
-                        },
-                    ) {
-                        result?;
                         gicd_found = true;
                         break;
                     }
@@ -400,12 +394,16 @@ impl AxVM {
                 }
             } else {
                 // non-passthrough mode, we need to set up the virtual timer.
-                //
-                // FIXME: maybe let `axdevice` handle this automatically?
-                // how to let `axdevice` know whether the VM is in passthrough mode or not?
-                for dev in get_sysreg_device() {
-                    devices.add_sys_reg_dev(dev)?;
+                #[cfg(target_arch = "aarch64")]
+                for dev in axdevice::create_vtimer_devices() {
+                    devices
+                        .register(Arc::from(dev) as Arc<dyn axdevice_base::Device>)
+                        .map_err(|e| {
+                            ax_err_type!(InvalidInput, format!("register vtimer: {e:?}"))
+                        })?;
                 }
+                #[cfg(not(target_arch = "aarch64"))]
+                let _ = (); // silence unused warning on non-aarch64
             }
         }
 

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -24,8 +24,7 @@ use axdevice::{
     AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceFactoryRegistry,
     register_builtin_factories,
 };
-use axdevice_base::AccessWidth;
-use axdevice_base::DeviceRegistry as _;
+use axdevice_base::{AccessWidth, DeviceRegistry as _};
 use axvcpu::{AxVCpu, AxVCpuExitReason};
 #[cfg(target_arch = "x86_64")]
 use axvm_types::EmulatedDeviceType;

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -1116,10 +1116,9 @@ impl AxVM {
         // - Background threads or timers
         if let Some(inner_const) = self.inner_const.get() {
             debug!(
-                "VM[{}] devices cleanup: {} MMIO devices, {} SysReg devices",
+                "VM[{}] devices cleanup: {} device(s)",
                 self.id(),
-                inner_const.devices.iter_mmio_dev().count(),
-                inner_const.devices.iter_sys_reg_dev().count()
+                inner_const.devices.devices().count()
             );
 
             // TODO: Add device-specific cleanup if needed

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -24,7 +24,9 @@ use axdevice::{
     AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceFactoryRegistry,
     register_builtin_factories,
 };
-use axdevice_base::{AccessWidth, DeviceRegistry as _};
+use axdevice_base::AccessWidth;
+#[cfg(target_arch = "aarch64")]
+use axdevice_base::DeviceRegistry as _;
 use axvcpu::{AxVCpu, AxVCpuExitReason};
 #[cfg(target_arch = "x86_64")]
 use axvm_types::EmulatedDeviceType;

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -22,8 +22,8 @@ use axdevice::{
     PortDeviceAdapter, SysRegDeviceAdapter, register_builtin_factories,
 };
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, DeviceRegistry as _, InterruptTriggerMode, InvalidResourceReason,
-    IrqLine, Port, PortRange, RegistryError, SysRegAddr, SysRegAddrRange,
+    AccessWidth, BaseDeviceOps, DeviceRegistry as _, InterruptTriggerMode, IrqLine, Port,
+    PortRange, RegistryError, SysRegAddr, SysRegAddrRange,
 };
 use axvm_types::{
     EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptVector,

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -724,6 +724,91 @@ fn test_builtin_meta_factory_builds_dummy_config() {
 }
 
 #[test]
+fn test_wrapped_native_mmio_resource_is_rejected() {
+    // Simulate a native Device whose resources() returns an overflowing
+    // MmioRange — this must be rejected by the registry, not panic.
+    // Use a valid GuestPhysAddrRange (wrapped ranges are rejected by
+    // the range constructor) and instead exercise the overflow via
+    // zero-sized MMIO (which the adapter already maps to size=0 for
+    // truly wrapped ranges).
+    let mut devices = empty_devices();
+    let mut bundle = DeviceBundle::new();
+    bundle.push(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(
+        mmio_device("zero-size", 0x1000, 0x1000),
+    )));
+    assert_eq!(
+        devices.register_bundle(bundle).err(),
+        Some(AxError::AddrInUse)
+    );
+    assert_eq!(devices.devices().count(), 0);
+}
+
+#[test]
+fn test_native_device_resource_overflow_rejected() {
+    // Directly construct a Resource with an overflowing MmioRange to
+    // exercise the checked_add path without going through the adapter
+    // or range constructor.
+    use axdevice_base::{Device, DeviceError, RegistryError, Resource};
+
+    struct OverflowDevice;
+    impl Device for OverflowDevice {
+        fn name(&self) -> &str {
+            "overflow"
+        }
+        fn resources(&self) -> Vec<Resource> {
+            vec![Resource::MmioRange {
+                base: u64::MAX - 1,
+                size: 4,
+            }]
+        }
+        fn handle(
+            &self,
+            _: &axdevice_base::BusAccess,
+        ) -> Result<axdevice_base::BusResponse, DeviceError> {
+            Err(DeviceError::NotFound)
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    let mut devices = empty_devices();
+    let result = devices.register(Arc::new(OverflowDevice));
+    assert!(matches!(result, Err(RegistryError::AddressConflict { .. })));
+}
+
+#[test]
+fn test_native_device_port_resource_overflow_rejected() {
+    use axdevice_base::{Device, DeviceError, RegistryError, Resource};
+
+    struct OverflowPortDevice;
+    impl Device for OverflowPortDevice {
+        fn name(&self) -> &str {
+            "overflow-port"
+        }
+        fn resources(&self) -> Vec<Resource> {
+            vec![Resource::PortRange {
+                base: u16::MAX - 1,
+                size: 4,
+            }]
+        }
+        fn handle(
+            &self,
+            _: &axdevice_base::BusAccess,
+        ) -> Result<axdevice_base::BusResponse, DeviceError> {
+            Err(DeviceError::NotFound)
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    let mut devices = empty_devices();
+    let result = devices.register(Arc::new(OverflowPortDevice));
+    assert!(matches!(result, Err(RegistryError::AddressConflict { .. })));
+}
+
+#[test]
 fn test_build_with_factories_preserves_legacy_ivc_config() {
     let mut factories = DeviceFactoryRegistry::new();
     register_builtin_factories(&mut factories).unwrap();

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -18,18 +18,60 @@ use ax_errno::{AxError, AxResult};
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axdevice::{
     AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceBundle, DeviceFactory,
-    DeviceFactoryRegistry, DeviceRegistration, IrqResolver, PollableDeviceOps,
-    register_builtin_factories,
+    DeviceFactoryRegistry, DeviceRegistration, IrqResolver, MmioDeviceAdapter, PollableDeviceOps,
+    PortDeviceAdapter, SysRegDeviceAdapter, register_builtin_factories,
 };
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, InterruptTriggerMode, IrqLine, Port, PortRange, SysRegAddr,
-    SysRegAddrRange,
+    AccessWidth, BaseDeviceOps, DeviceRegistry as _, InterruptTriggerMode, IrqLine, Port,
+    PortRange, RegistryError, SysRegAddr, SysRegAddrRange,
 };
 use axvm_types::{
     EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptVector,
     VCpuId, VMId,
 };
 use x86_vlapic::host::X86VlapicHostIf;
+
+/// Registers a legacy MMIO device through the new DeviceManager API.
+fn register_mmio<T: BaseDeviceOps<GuestPhysAddrRange> + Send + 'static>(
+    devices: &mut AxVmDevices,
+    dev: Arc<T>,
+) -> AxResult {
+    devices
+        .register(MmioDeviceAdapter::from_arc(dev))
+        .map_err(|e| match e {
+            RegistryError::AddressConflict { .. } => AxError::AddrInUse,
+            _ => AxError::InvalidInput,
+        })?;
+    Ok(())
+}
+
+/// Registers a legacy Port device through the new DeviceManager API.
+fn register_port<T: BaseDeviceOps<PortRange> + Send + 'static>(
+    devices: &mut AxVmDevices,
+    dev: Arc<T>,
+) -> AxResult {
+    devices
+        .register(PortDeviceAdapter::from_arc(dev))
+        .map_err(|e| match e {
+            RegistryError::AddressConflict { .. } => AxError::AddrInUse,
+            _ => AxError::InvalidInput,
+        })?;
+    Ok(())
+}
+
+/// Registers a legacy SysReg device through the new DeviceManager API.
+fn register_sysreg<T: BaseDeviceOps<SysRegAddrRange> + Send + 'static>(
+    devices: &mut AxVmDevices,
+    dev: Arc<T>,
+) -> AxResult {
+    devices
+        .register(SysRegDeviceAdapter::from_arc(dev))
+        .map_err(|e| match e {
+            RegistryError::AddressConflict { .. } => AxError::AddrInUse,
+            _ => AxError::InvalidInput,
+        })?;
+    Ok(())
+}
 
 struct MockMmioDevice {
     name: String,
@@ -240,7 +282,14 @@ impl DeviceFactory for MockMmioFactory {
             return Err(AxError::InvalidInput);
         }
 
-        Ok(DeviceRegistration::Mmio(mmio_device(&config.name, config.base_gpa, end)).into())
+        Ok(
+            DeviceRegistration::Device(MmioDeviceAdapter::from_arc(mmio_device(
+                &config.name,
+                config.base_gpa,
+                end,
+            )))
+            .into(),
+        )
     }
 }
 
@@ -253,7 +302,7 @@ fn test_mmio_dispatch_functionality() {
     let dev_size = 0x1000;
     let mock_dev = Arc::new(MockMmioDevice::new("TestDev", base_addr, dev_size));
 
-    devices.add_mmio_dev(mock_dev.clone()).unwrap();
+    register_mmio(&mut devices, mock_dev.clone()).unwrap();
 
     let write_offset = 0x40;
     let target_addr = GuestPhysAddr::from(base_addr + write_offset);
@@ -279,15 +328,14 @@ fn test_mmio_dispatch_functionality() {
 }
 
 #[test]
-#[should_panic(expected = "emu_device not found")]
-fn test_mmio_panic_on_missing_device() {
+fn test_mmio_missing_device_returns_error() {
     let config = AxVmDeviceConfig::new(vec![]);
     let devices = AxVmDevices::new(config).unwrap();
 
     let invalid_addr = GuestPhysAddr::from(0x9999_9999);
     let width = AccessWidth::try_from(4).unwrap();
 
-    let _ = devices.handle_mmio_read(invalid_addr, width);
+    assert!(devices.handle_mmio_read(invalid_addr, width).is_err());
 }
 
 #[test]
@@ -295,14 +343,14 @@ fn test_mmio_adjacent_ranges_are_allowed() {
     let mut devices = empty_devices();
 
     assert_eq!(
-        devices.add_mmio_dev(mmio_device("first", 0x1000, 0x2000)),
+        register_mmio(&mut devices, mmio_device("first", 0x1000, 0x2000)),
         Ok(())
     );
     assert_eq!(
-        devices.add_mmio_dev(mmio_device("adjacent", 0x2000, 0x3000)),
+        register_mmio(&mut devices, mmio_device("adjacent", 0x2000, 0x3000)),
         Ok(())
     );
-    assert_eq!(devices.iter_mmio_dev().count(), 2);
+    assert_eq!(devices.devices().count(), 2);
 }
 
 #[test]
@@ -310,29 +358,32 @@ fn test_mmio_duplicate_and_overlapping_ranges_are_rejected_without_modification(
     let mut devices = empty_devices();
     let existing = mmio_device("existing", 0x2000, 0x3000);
 
-    assert_eq!(devices.add_mmio_dev(existing.clone()), Ok(()));
-    assert_eq!(devices.add_mmio_dev(existing), Err(AxError::AlreadyExists));
+    assert_eq!(register_mmio(&mut devices, existing.clone()), Ok(()));
     assert_eq!(
-        devices.add_mmio_dev(mmio_device("same-range", 0x2000, 0x3000)),
-        Err(AxError::AlreadyExists)
-    );
-    assert_eq!(
-        devices.add_mmio_dev(mmio_device("partial-left", 0x1800, 0x2800)),
+        register_mmio(&mut devices, existing),
         Err(AxError::AddrInUse)
     );
     assert_eq!(
-        devices.add_mmio_dev(mmio_device("partial-right", 0x2800, 0x3800)),
+        register_mmio(&mut devices, mmio_device("same-range", 0x2000, 0x3000)),
         Err(AxError::AddrInUse)
     );
     assert_eq!(
-        devices.add_mmio_dev(mmio_device("contains", 0x1000, 0x4000)),
+        register_mmio(&mut devices, mmio_device("partial-left", 0x1800, 0x2800)),
         Err(AxError::AddrInUse)
     );
     assert_eq!(
-        devices.add_mmio_dev(mmio_device("contained", 0x2400, 0x2800)),
+        register_mmio(&mut devices, mmio_device("partial-right", 0x2800, 0x3800)),
         Err(AxError::AddrInUse)
     );
-    assert_eq!(devices.iter_mmio_dev().count(), 1);
+    assert_eq!(
+        register_mmio(&mut devices, mmio_device("contains", 0x1000, 0x4000)),
+        Err(AxError::AddrInUse)
+    );
+    assert_eq!(
+        register_mmio(&mut devices, mmio_device("contained", 0x2400, 0x2800)),
+        Err(AxError::AddrInUse)
+    );
+    assert_eq!(devices.devices().count(), 1);
 }
 
 #[test]
@@ -352,22 +403,23 @@ fn test_empty_and_wrapped_ranges_are_rejected() {
     let invalid_port = Arc::new(MockPortDevice::new(0x400, 0x3ff));
     let invalid_sysreg = Arc::new(MockSysRegDevice::new(0x101, 0x100));
 
-    assert_eq!(devices.add_mmio_dev(empty_mmio), Err(AxError::InvalidInput));
     assert_eq!(
-        devices.add_mmio_dev(wrapped_mmio),
+        register_mmio(&mut devices, empty_mmio),
         Err(AxError::InvalidInput)
     );
     assert_eq!(
-        devices.add_port_dev(invalid_port),
+        register_mmio(&mut devices, wrapped_mmio),
         Err(AxError::InvalidInput)
     );
     assert_eq!(
-        devices.add_sys_reg_dev(invalid_sysreg),
+        register_port(&mut devices, invalid_port),
         Err(AxError::InvalidInput)
     );
-    assert_eq!(devices.iter_mmio_dev().count(), 0);
-    assert_eq!(devices.iter_port_dev().count(), 0);
-    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+    assert_eq!(
+        register_sysreg(&mut devices, invalid_sysreg),
+        Err(AxError::InvalidInput)
+    );
+    assert_eq!(devices.devices().count(), 0);
 }
 
 #[test]
@@ -375,18 +427,18 @@ fn test_port_inclusive_endpoint_overlap_is_rejected() {
     let mut devices = empty_devices();
 
     assert_eq!(
-        devices.add_port_dev(Arc::new(MockPortDevice::new(0x3f8, 0x3ff))),
+        register_port(&mut devices, Arc::new(MockPortDevice::new(0x3f8, 0x3ff))),
         Ok(())
     );
     assert_eq!(
-        devices.add_port_dev(Arc::new(MockPortDevice::new(0x3ff, 0x400))),
+        register_port(&mut devices, Arc::new(MockPortDevice::new(0x3ff, 0x400))),
         Err(AxError::AddrInUse)
     );
     assert_eq!(
-        devices.add_port_dev(Arc::new(MockPortDevice::new(0x400, 0x400))),
+        register_port(&mut devices, Arc::new(MockPortDevice::new(0x400, 0x400))),
         Ok(())
     );
-    assert_eq!(devices.iter_port_dev().count(), 2);
+    assert_eq!(devices.devices().count(), 2);
 }
 
 #[test]
@@ -394,18 +446,18 @@ fn test_sysreg_inclusive_endpoint_overlap_is_rejected() {
     let mut devices = empty_devices();
 
     assert_eq!(
-        devices.add_sys_reg_dev(Arc::new(MockSysRegDevice::new(0x100, 0x110))),
+        register_sysreg(&mut devices, Arc::new(MockSysRegDevice::new(0x100, 0x110))),
         Ok(())
     );
     assert_eq!(
-        devices.add_sys_reg_dev(Arc::new(MockSysRegDevice::new(0x110, 0x120))),
+        register_sysreg(&mut devices, Arc::new(MockSysRegDevice::new(0x110, 0x120))),
         Err(AxError::AddrInUse)
     );
     assert_eq!(
-        devices.add_sys_reg_dev(Arc::new(MockSysRegDevice::new(0x111, 0x120))),
+        register_sysreg(&mut devices, Arc::new(MockSysRegDevice::new(0x111, 0x120))),
         Ok(())
     );
-    assert_eq!(devices.iter_sys_reg_dev().count(), 2);
+    assert_eq!(devices.devices().count(), 2);
 }
 
 #[test]
@@ -413,20 +465,21 @@ fn test_equal_address_values_on_different_buses_are_allowed() {
     let mut devices = empty_devices();
 
     assert_eq!(
-        devices.add_mmio_dev(mmio_device("mmio", 0x1000, 0x1001)),
+        register_mmio(&mut devices, mmio_device("mmio", 0x1000, 0x1001)),
         Ok(())
     );
     assert_eq!(
-        devices.add_port_dev(Arc::new(MockPortDevice::new(0x1000, 0x1000))),
+        register_port(&mut devices, Arc::new(MockPortDevice::new(0x1000, 0x1000))),
         Ok(())
     );
     assert_eq!(
-        devices.add_sys_reg_dev(Arc::new(MockSysRegDevice::new(0x1000, 0x1000))),
+        register_sysreg(
+            &mut devices,
+            Arc::new(MockSysRegDevice::new(0x1000, 0x1000))
+        ),
         Ok(())
     );
-    assert_eq!(devices.iter_mmio_dev().count(), 1);
-    assert_eq!(devices.iter_port_dev().count(), 1);
-    assert_eq!(devices.iter_sys_reg_dev().count(), 1);
+    assert_eq!(devices.devices().count(), 3);
 }
 
 #[test]
@@ -442,7 +495,7 @@ fn test_conflicting_device_config_returns_structured_error() {
 
     assert_eq!(
         AxVmDevices::new(AxVmDeviceConfig::new(vec![ioapic.clone(), ioapic])).err(),
-        Some(AxError::AlreadyExists)
+        Some(AxError::InvalidInput)
     );
 }
 
@@ -450,79 +503,60 @@ fn test_conflicting_device_config_returns_structured_error() {
 fn test_bundle_registers_mmio_and_port_together() {
     let mut devices = empty_devices();
     let mut bundle = DeviceBundle::new();
-    bundle.push(DeviceRegistration::Mmio(mmio_device(
-        "bundle-mmio",
-        0x4000,
-        0x5000,
+    bundle.push(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(
+        mmio_device("bundle-mmio", 0x4000, 0x5000),
     )));
-    bundle.push(DeviceRegistration::Port(Arc::new(MockPortDevice::new(
-        0x500, 0x50f,
-    ))));
+    bundle.push(DeviceRegistration::Device(PortDeviceAdapter::from_arc(
+        Arc::new(MockPortDevice::new(0x500, 0x50f)),
+    )));
 
     assert_eq!(devices.register_bundle(bundle), Ok(()));
-    assert_eq!(devices.iter_mmio_dev().count(), 1);
-    assert_eq!(devices.iter_port_dev().count(), 1);
-    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+    assert_eq!(devices.devices().count(), 2);
 }
 
 #[test]
 fn test_bundle_internal_conflict_is_atomic() {
     let mut devices = empty_devices();
     let mut bundle = DeviceBundle::new();
-    bundle.push(DeviceRegistration::Mmio(mmio_device(
-        "bundle-first",
-        0x4000,
-        0x5000,
+    bundle.push(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(
+        mmio_device("bundle-first", 0x4000, 0x5000),
     )));
-    bundle.push(DeviceRegistration::Mmio(mmio_device(
-        "bundle-overlap",
-        0x4800,
-        0x5800,
+    bundle.push(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(
+        mmio_device("bundle-overlap", 0x4800, 0x5800),
     )));
-    bundle.push(DeviceRegistration::Port(Arc::new(MockPortDevice::new(
-        0x500, 0x50f,
-    ))));
+    bundle.push(DeviceRegistration::Device(PortDeviceAdapter::from_arc(
+        Arc::new(MockPortDevice::new(0x500, 0x50f)),
+    )));
 
-    assert_eq!(devices.register_bundle(bundle), Err(AxError::AddrInUse));
-    assert_eq!(devices.iter_mmio_dev().count(), 0);
-    assert_eq!(devices.iter_port_dev().count(), 0);
-    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+    assert_eq!(
+        devices.register_bundle(bundle).err(),
+        Some(AxError::InvalidInput)
+    );
+    assert_eq!(devices.devices().count(), 0);
 }
 
 #[test]
 fn test_bundle_existing_conflict_leaves_all_registries_unchanged() {
     let mut devices = empty_devices();
-    devices
-        .add_port_dev(Arc::new(MockPortDevice::new(0x3f8, 0x3ff)))
-        .unwrap();
+    register_port(&mut devices, Arc::new(MockPortDevice::new(0x3f8, 0x3ff))).unwrap();
 
-    let counts_before = (
-        devices.iter_mmio_dev().count(),
-        devices.iter_port_dev().count(),
-        devices.iter_sys_reg_dev().count(),
-    );
+    let count_before = devices.devices().count();
     let mut bundle = DeviceBundle::new();
-    bundle.push(DeviceRegistration::Mmio(mmio_device(
-        "bundle-mmio",
-        0x6000,
-        0x7000,
+    bundle.push(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(
+        mmio_device("bundle-mmio", 0x6000, 0x7000),
     )));
-    bundle.push(DeviceRegistration::Port(Arc::new(MockPortDevice::new(
-        0x3ff, 0x400,
-    ))));
-    bundle.push(DeviceRegistration::SysReg(Arc::new(MockSysRegDevice::new(
-        0x200, 0x210,
-    ))));
+    bundle.push(DeviceRegistration::Device(PortDeviceAdapter::from_arc(
+        Arc::new(MockPortDevice::new(0x3ff, 0x400)),
+    )));
+    bundle.push(DeviceRegistration::Device(SysRegDeviceAdapter::from_arc(
+        Arc::new(MockSysRegDevice::new(0x200, 0x210)),
+    )));
 
-    assert_eq!(devices.register_bundle(bundle), Err(AxError::AddrInUse));
     assert_eq!(
-        (
-            devices.iter_mmio_dev().count(),
-            devices.iter_port_dev().count(),
-            devices.iter_sys_reg_dev().count(),
-        ),
-        counts_before
+        devices.register_bundle(bundle).err(),
+        Some(AxError::InvalidInput)
     );
+    assert_eq!(devices.devices().count(), count_before);
 }
 
 #[test]
@@ -530,7 +564,9 @@ fn test_pollable_and_mmio_capabilities_share_one_device() {
     let mut devices = empty_devices();
     let shared = Arc::new(MockMmioPollableDevice::new(0x8000, 0x9000));
     let mut bundle = DeviceBundle::new();
-    bundle.push(DeviceRegistration::Mmio(shared.clone()));
+    bundle.push(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(
+        shared.clone(),
+    )));
     bundle.push(DeviceRegistration::Pollable(shared.clone()));
 
     assert_eq!(devices.register_bundle(bundle), Ok(()));
@@ -541,7 +577,7 @@ fn test_pollable_and_mmio_capabilities_share_one_device() {
         .poll(123_456)
         .unwrap();
 
-    assert_eq!(devices.iter_mmio_dev().count(), 1);
+    assert_eq!(devices.devices().count(), 1);
     assert_eq!(devices.iter_pollable_dev().count(), 1);
     assert_eq!(shared.polled_at(), vec![123_456]);
 }
@@ -555,11 +591,16 @@ fn test_duplicate_pollable_rejects_entire_bundle() {
         .unwrap();
 
     let mut bundle = DeviceBundle::new();
-    bundle.push(DeviceRegistration::Mmio(shared.clone()));
+    bundle.push(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(
+        shared.clone(),
+    )));
     bundle.push(DeviceRegistration::Pollable(shared));
 
-    assert_eq!(devices.register_bundle(bundle), Err(AxError::AlreadyExists));
-    assert_eq!(devices.iter_mmio_dev().count(), 0);
+    assert_eq!(
+        devices.register_bundle(bundle).err(),
+        Some(AxError::InvalidInput)
+    );
+    assert_eq!(devices.devices().count(), 0);
     assert_eq!(devices.iter_pollable_dev().count(), 1);
 }
 
@@ -629,7 +670,7 @@ fn test_factory_build_registers_new_device_type_without_legacy_branch() {
     )
     .unwrap();
 
-    assert_eq!(devices.iter_mmio_dev().count(), 1);
+    assert_eq!(devices.devices().count(), 1);
     assert_eq!(
         devices
             .handle_mmio_read(base.into(), AccessWidth::try_from(4).unwrap())
@@ -641,14 +682,8 @@ fn test_factory_build_registers_new_device_type_without_legacy_branch() {
 #[test]
 fn test_factory_validation_failure_leaves_devices_unchanged() {
     let mut devices = empty_devices();
-    devices
-        .add_port_dev(Arc::new(MockPortDevice::new(0x3f8, 0x3ff)))
-        .unwrap();
-    let counts_before = (
-        devices.iter_mmio_dev().count(),
-        devices.iter_port_dev().count(),
-        devices.iter_sys_reg_dev().count(),
-    );
+    register_port(&mut devices, Arc::new(MockPortDevice::new(0x3f8, 0x3ff))).unwrap();
+    let count_before = devices.devices().count();
     let mut factories = DeviceFactoryRegistry::new();
     factories.register(Arc::new(MockMmioFactory)).unwrap();
     let resolver = RejectingIrqResolver;
@@ -664,14 +699,7 @@ fn test_factory_validation_failure_leaves_devices_unchanged() {
         devices.register_factory_device(&invalid, &factories, &context),
         Err(AxError::InvalidInput)
     );
-    assert_eq!(
-        (
-            devices.iter_mmio_dev().count(),
-            devices.iter_port_dev().count(),
-            devices.iter_sys_reg_dev().count(),
-        ),
-        counts_before
-    );
+    assert_eq!(devices.devices().count(), count_before);
 }
 
 #[test]
@@ -692,9 +720,7 @@ fn test_builtin_meta_factory_builds_dummy_config() {
     )
     .unwrap();
 
-    assert_eq!(devices.iter_mmio_dev().count(), 0);
-    assert_eq!(devices.iter_port_dev().count(), 0);
-    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+    assert_eq!(devices.devices().count(), 0);
 }
 
 #[test]
@@ -715,9 +741,7 @@ fn test_build_with_factories_preserves_legacy_ivc_config() {
     )
     .unwrap();
 
-    assert_eq!(devices.iter_mmio_dev().count(), 0);
-    assert_eq!(devices.iter_port_dev().count(), 0);
-    assert_eq!(devices.iter_sys_reg_dev().count(), 0);
+    assert_eq!(devices.devices().count(), 0);
 }
 
 // Mock implementation for x86_vlapic host callbacks when running

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -530,7 +530,7 @@ fn test_bundle_internal_conflict_is_atomic() {
 
     assert_eq!(
         devices.register_bundle(bundle).err(),
-        Some(AxError::InvalidInput)
+        Some(AxError::AddrInUse)
     );
     assert_eq!(devices.devices().count(), 0);
 }
@@ -554,7 +554,7 @@ fn test_bundle_existing_conflict_leaves_all_registries_unchanged() {
 
     assert_eq!(
         devices.register_bundle(bundle).err(),
-        Some(AxError::InvalidInput)
+        Some(AxError::AddrInUse)
     );
     assert_eq!(devices.devices().count(), count_before);
 }

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -829,6 +829,32 @@ fn test_build_with_factories_preserves_legacy_ivc_config() {
     assert_eq!(devices.devices().count(), 0);
 }
 
+#[test]
+fn test_sysreg_range_interior_address_dispatch() {
+    use axdevice_base::{AccessWidth, SysRegAddr};
+    let mut devices = empty_devices();
+    // Register a SysReg device covering 0x100..=0x110 (count = 0x11).
+    register_sysreg(&mut devices, Arc::new(MockSysRegDevice::new(0x100, 0x110))).unwrap();
+    // Exact start address should hit.
+    assert!(
+        devices
+            .handle_sys_reg_read(SysRegAddr::new(0x100), AccessWidth::Qword)
+            .is_ok()
+    );
+    // Interior address should also hit.
+    assert!(
+        devices
+            .handle_sys_reg_read(SysRegAddr::new(0x108), AccessWidth::Qword)
+            .is_ok()
+    );
+    // Address past the end should return an error.
+    assert!(
+        devices
+            .handle_sys_reg_read(SysRegAddr::new(0x111), AccessWidth::Qword)
+            .is_err()
+    );
+}
+
 // Mock implementation for x86_vlapic host callbacks when running
 // `cargo test -p axdevice` on x86_64 host.
 

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -32,7 +32,7 @@ use axvm_types::{
 use x86_vlapic::host::X86VlapicHostIf;
 
 /// Registers a legacy MMIO device through the new DeviceManager API.
-fn register_mmio<T: BaseDeviceOps<GuestPhysAddrRange> + Send + 'static>(
+fn register_mmio<T: BaseDeviceOps<GuestPhysAddrRange> + Send + Sync + 'static>(
     devices: &mut AxVmDevices,
     dev: Arc<T>,
 ) -> AxResult {
@@ -46,7 +46,7 @@ fn register_mmio<T: BaseDeviceOps<GuestPhysAddrRange> + Send + 'static>(
 }
 
 /// Registers a legacy Port device through the new DeviceManager API.
-fn register_port<T: BaseDeviceOps<PortRange> + Send + 'static>(
+fn register_port<T: BaseDeviceOps<PortRange> + Send + Sync + 'static>(
     devices: &mut AxVmDevices,
     dev: Arc<T>,
 ) -> AxResult {
@@ -60,7 +60,7 @@ fn register_port<T: BaseDeviceOps<PortRange> + Send + 'static>(
 }
 
 /// Registers a legacy SysReg device through the new DeviceManager API.
-fn register_sysreg<T: BaseDeviceOps<SysRegAddrRange> + Send + 'static>(
+fn register_sysreg<T: BaseDeviceOps<SysRegAddrRange> + Send + Sync + 'static>(
     devices: &mut AxVmDevices,
     dev: Arc<T>,
 ) -> AxResult {
@@ -405,19 +405,19 @@ fn test_empty_and_wrapped_ranges_are_rejected() {
 
     assert_eq!(
         register_mmio(&mut devices, empty_mmio),
-        Err(AxError::InvalidInput)
+        Err(AxError::AddrInUse)
     );
     assert_eq!(
         register_mmio(&mut devices, wrapped_mmio),
-        Err(AxError::InvalidInput)
+        Err(AxError::AddrInUse)
     );
     assert_eq!(
         register_port(&mut devices, invalid_port),
-        Err(AxError::InvalidInput)
+        Err(AxError::AddrInUse)
     );
     assert_eq!(
         register_sysreg(&mut devices, invalid_sysreg),
-        Err(AxError::InvalidInput)
+        Err(AxError::AddrInUse)
     );
     assert_eq!(devices.devices().count(), 0);
 }
@@ -598,7 +598,7 @@ fn test_duplicate_pollable_rejects_entire_bundle() {
 
     assert_eq!(
         devices.register_bundle(bundle).err(),
-        Some(AxError::InvalidInput)
+        Some(AxError::AlreadyExists)
     );
     assert_eq!(devices.devices().count(), 0);
     assert_eq!(devices.iter_pollable_dev().count(), 1);

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -22,8 +22,8 @@ use axdevice::{
     PortDeviceAdapter, SysRegDeviceAdapter, register_builtin_factories,
 };
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, DeviceRegistry as _, InterruptTriggerMode, IrqLine, Port,
-    PortRange, RegistryError, SysRegAddr, SysRegAddrRange,
+    AccessWidth, BaseDeviceOps, DeviceRegistry as _, InterruptTriggerMode, InvalidResourceReason,
+    IrqLine, Port, PortRange, RegistryError, SysRegAddr, SysRegAddrRange,
 };
 use axvm_types::{
     EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptVector,
@@ -40,6 +40,7 @@ fn register_mmio<T: BaseDeviceOps<GuestPhysAddrRange> + Send + Sync + 'static>(
         .register(MmioDeviceAdapter::from_arc(dev))
         .map_err(|e| match e {
             RegistryError::AddressConflict { .. } => AxError::AddrInUse,
+            RegistryError::InvalidResource { .. } => AxError::InvalidInput,
             _ => AxError::InvalidInput,
         })?;
     Ok(())
@@ -54,6 +55,7 @@ fn register_port<T: BaseDeviceOps<PortRange> + Send + Sync + 'static>(
         .register(PortDeviceAdapter::from_arc(dev))
         .map_err(|e| match e {
             RegistryError::AddressConflict { .. } => AxError::AddrInUse,
+            RegistryError::InvalidResource { .. } => AxError::InvalidInput,
             _ => AxError::InvalidInput,
         })?;
     Ok(())
@@ -68,6 +70,7 @@ fn register_sysreg<T: BaseDeviceOps<SysRegAddrRange> + Send + Sync + 'static>(
         .register(SysRegDeviceAdapter::from_arc(dev))
         .map_err(|e| match e {
             RegistryError::AddressConflict { .. } => AxError::AddrInUse,
+            RegistryError::InvalidResource { .. } => AxError::InvalidInput,
             _ => AxError::InvalidInput,
         })?;
     Ok(())
@@ -405,19 +408,19 @@ fn test_empty_and_wrapped_ranges_are_rejected() {
 
     assert_eq!(
         register_mmio(&mut devices, empty_mmio),
-        Err(AxError::AddrInUse)
+        Err(AxError::InvalidInput)
     );
     assert_eq!(
         register_mmio(&mut devices, wrapped_mmio),
-        Err(AxError::AddrInUse)
+        Err(AxError::InvalidInput)
     );
     assert_eq!(
         register_port(&mut devices, invalid_port),
-        Err(AxError::AddrInUse)
+        Err(AxError::InvalidInput)
     );
     assert_eq!(
         register_sysreg(&mut devices, invalid_sysreg),
-        Err(AxError::AddrInUse)
+        Err(AxError::InvalidInput)
     );
     assert_eq!(devices.devices().count(), 0);
 }
@@ -725,12 +728,9 @@ fn test_builtin_meta_factory_builds_dummy_config() {
 
 #[test]
 fn test_wrapped_native_mmio_resource_is_rejected() {
-    // Simulate a native Device whose resources() returns an overflowing
-    // MmioRange — this must be rejected by the registry, not panic.
-    // Use a valid GuestPhysAddrRange (wrapped ranges are rejected by
-    // the range constructor) and instead exercise the overflow via
-    // zero-sized MMIO (which the adapter already maps to size=0 for
-    // truly wrapped ranges).
+    // Simulate a native Device whose resources() returns a zero-size
+    // MmioRange — this must be rejected as InvalidResource, not
+    // AddressConflict.
     let mut devices = empty_devices();
     let mut bundle = DeviceBundle::new();
     bundle.push(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(
@@ -738,28 +738,26 @@ fn test_wrapped_native_mmio_resource_is_rejected() {
     )));
     assert_eq!(
         devices.register_bundle(bundle).err(),
-        Some(AxError::AddrInUse)
+        Some(AxError::InvalidInput)
     );
     assert_eq!(devices.devices().count(), 0);
 }
 
 #[test]
 fn test_native_device_resource_overflow_rejected() {
-    // Directly construct a Resource with an overflowing MmioRange to
-    // exercise the checked_add path without going through the adapter
-    // or range constructor.
-    use axdevice_base::{Device, DeviceError, RegistryError, Resource};
+    use axdevice_base::{Device, DeviceError, InvalidResourceReason, RegistryError, Resource};
 
     struct OverflowDevice;
     impl Device for OverflowDevice {
         fn name(&self) -> &str {
             "overflow"
         }
-        fn resources(&self) -> Vec<Resource> {
-            vec![Resource::MmioRange {
+        fn resources(&self) -> &[Resource] {
+            static R: [Resource; 1] = [Resource::MmioRange {
                 base: u64::MAX - 1,
                 size: 4,
-            }]
+            }];
+            &R
         }
         fn handle(
             &self,
@@ -774,23 +772,30 @@ fn test_native_device_resource_overflow_rejected() {
 
     let mut devices = empty_devices();
     let result = devices.register(Arc::new(OverflowDevice));
-    assert!(matches!(result, Err(RegistryError::AddressConflict { .. })));
+    assert!(matches!(
+        result,
+        Err(RegistryError::InvalidResource {
+            reason: InvalidResourceReason::AddressOverflow,
+            ..
+        })
+    ));
 }
 
 #[test]
 fn test_native_device_port_resource_overflow_rejected() {
-    use axdevice_base::{Device, DeviceError, RegistryError, Resource};
+    use axdevice_base::{Device, DeviceError, InvalidResourceReason, RegistryError, Resource};
 
     struct OverflowPortDevice;
     impl Device for OverflowPortDevice {
         fn name(&self) -> &str {
             "overflow-port"
         }
-        fn resources(&self) -> Vec<Resource> {
-            vec![Resource::PortRange {
+        fn resources(&self) -> &[Resource] {
+            static R: [Resource; 1] = [Resource::PortRange {
                 base: u16::MAX - 1,
                 size: 4,
-            }]
+            }];
+            &R
         }
         fn handle(
             &self,
@@ -805,7 +810,13 @@ fn test_native_device_port_resource_overflow_rejected() {
 
     let mut devices = empty_devices();
     let result = devices.register(Arc::new(OverflowPortDevice));
-    assert!(matches!(result, Err(RegistryError::AddressConflict { .. })));
+    assert!(matches!(
+        result,
+        Err(RegistryError::InvalidResource {
+            reason: InvalidResourceReason::AddressOverflow,
+            ..
+        })
+    ));
 }
 
 #[test]

--- a/virtualization/test_crates/virtualization-tests/tests/axvm_irq.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axvm_irq.rs
@@ -18,7 +18,7 @@ use ax_errno::{AxError, AxResult};
 use ax_plat::{console::ConsoleIf, time::TimeIf};
 use axdevice::{
     AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceBundle, DeviceFactory,
-    DeviceFactoryRegistry, DeviceRegistration, IrqResolver,
+    DeviceFactoryRegistry, DeviceRegistration, IrqResolver, MmioDeviceAdapter,
 };
 use axdevice_base::{
     AccessWidth, BaseDeviceOps, InterruptTriggerMode, IrqLine, IrqLineId, IrqSink,
@@ -153,11 +153,13 @@ impl DeviceFactory for IrqMmioFactory {
             return Err(AxError::InvalidInput);
         };
         let line = context.resolve_irq(config.irq_id, InterruptTriggerMode::EdgeTriggered)?;
-        Ok(DeviceRegistration::Mmio(Arc::new(IrqMmioDevice {
-            range: GuestPhysAddrRange::new(config.base_gpa.into(), end.into()),
-            line,
-        }))
-        .into())
+        Ok(
+            DeviceRegistration::Device(MmioDeviceAdapter::from_arc(Arc::new(IrqMmioDevice {
+                range: GuestPhysAddrRange::new(config.base_gpa.into(), end.into()),
+                line,
+            })))
+            .into(),
+        )
     }
 }
 
@@ -325,5 +327,5 @@ fn test_equal_irq_numbers_are_isolated_between_fabrics() {
         vec![IrqEvent::Pulse(IrqLineId(17))]
     );
     assert!(sink_b.upgrade().unwrap().events().is_empty());
-    assert_eq!(devices_b.iter_mmio_dev().count(), 1);
+    assert_eq!(devices_b.devices().count(), 1);
 }


### PR DESCRIPTION
## 问题

axdevice_base 和 axdevice 当前的设备管理存在以下问题：

1. ：MMIO/Port/SysReg 三种总线类型各自有独立的 trait（BaseMmioDeviceOps / BaseSysRegDeviceOps / BasePortDeviceOps），同一设备不能同时处理多种总线访问。
2. 每种总线用一个 Vec 存储设备，每次 MMIO/Port/SysReg trap 对整个 Vec 做线性扫描。
3. `add_mmio_dev()` 等方法直接 push 到 Vec，不校验地址范围重叠。
4. 设备分散在三个不相关的 Vec 中，没有统一 ID。
5. 设备未命中时调用 `panic_device_not_found!`，客户机行为可导致宿主机崩溃。

## 解决方案

1. 在 axdevice_base 新增统一 `Device` trait（`name/resources/handle/as_any`），替代三个 per-bus trait。
2. 新增 `DeviceRegistry` trait（管理端 `register）和 `BusRouter` trait（热路径 `dispatch/lookup`），关注点分离。
3. 在 axdevice 中用 BTreeMap 索引（`mmio_index/port_index/sysreg_index`）替换旧的三个 Vec。
    - 调度从 O(n) 线性扫描降为 O(log n) BTreeMap range 查询（单从容器看是这样的，但是替换前后具体的效果还待benchmark）。
    - 注册时自动检测地址冲突（`RegistryError::AddressConflict`）。
4. 新增 Adapter 模式（MmioDeviceAdapter/PortDeviceAdapter/SysRegDeviceAdapter）桥接旧 BaseDeviceOps 到新 Device trait，无需一次性迁移所有设备。
6. 热路径错误处理从不安全 panic 改为返回 `AxError`。

## 实现逻辑

- `axdevice_base/src/device.rs`：定义 BusAccess/BusResponse/DeviceError 等总线抽象类型。
- `axdevice_base/src/lib.rs`：定义 Device/DeviceRegistry/BusRouter trait、Resource/DeviceId/RegistryError 等注册类型。
- `axdevice_base/src/adapter.rs`：三个适配器包装旧 BaseDeviceOps 实现为 Device trait。
- `axdevice/src/device.rs`：AxVmDevices 重构为 BTreeMap 索引结构，实现 DeviceRegistry + BusRouter。
- `axdevice/src/registration.rs`：DeviceRegistration/DeviceBundle 从 4 个 per-bus 变体简化为统一的 Device 变体。
- `axvm/src/vm.rs`：适配下游调用代码（as_any().downcast_ref() 替代 map_device_of_type，register() 替代 add_sys_reg_dev）