### PR TITLE
fix(ax-task): prioritize ready poll_io before interrupt

### DIFF
--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -3,6 +3,8 @@ use core::{future::poll_fn, task::Poll};
 use ax_errno::{AxError, AxResult};
 use axpoll::{IoEvents, Pollable};
 
+use crate::current;
+
 /// A helper to wrap a synchronous non-blocking I/O function into an
 /// asynchronous function.
 ///
@@ -20,28 +22,34 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
     non_blocking: bool,
     mut f: F,
 ) -> AxResult<T> {
-    super::interruptible(poll_fn(move |cx| match f() {
-        Ok(value) => Poll::Ready(Ok(value)),
-        Err(AxError::WouldBlock) => {
-            // Register the waker unconditionally before returning WouldBlock.
-            // A non-blocking connect(2) returns EINPROGRESS; the caller then
-            // uses epoll to wait for EPOLLOUT (connection complete).  If we
-            // skip registration for non-blocking callers, the TCP stack has
-            // no waker to call when the handshake finishes, so epoll never
-            // receives the EPOLLOUT notification and the connection stalls.
-            pollable.register(cx, events);
-            if non_blocking {
-                return Poll::Ready(Err(AxError::WouldBlock));
-            }
-            match f() {
-                Ok(value) => Poll::Ready(Ok(value)),
-                Err(AxError::WouldBlock) => Poll::Pending,
-                Err(e) => Poll::Ready(Err(e)),
-            }
+    let curr = current();
+    poll_fn(move |cx| {
+        match f() {
+            Ok(value) => return Poll::Ready(Ok(value)),
+            Err(AxError::WouldBlock) => {}
+            Err(e) => return Poll::Ready(Err(e)),
         }
-        Err(e) => Poll::Ready(Err(e)),
-    }))
-    .await?
+
+        // Register before the post-registration retry. A non-blocking
+        // connect(2) returns EINPROGRESS; the caller then uses epoll to wait
+        // for EPOLLOUT. If we skip registration for non-blocking callers, the
+        // TCP stack has no waker to call when the handshake finishes.
+        pollable.register(cx, events);
+
+        match f() {
+            Ok(value) => Poll::Ready(Ok(value)),
+            Err(AxError::WouldBlock) if non_blocking => Poll::Ready(Err(AxError::WouldBlock)),
+            Err(AxError::WouldBlock) => {
+                if curr.poll_interrupt(cx).is_ready() {
+                    Poll::Ready(Err(AxError::Interrupted))
+                } else {
+                    Poll::Pending
+                }
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    })
+    .await
 }
 
 /// Registers a waker for the given IRQ number.

--- a/os/arceos/modules/axtask/src/tests.rs
+++ b/os/arceos/modules/axtask/src/tests.rs
@@ -1,9 +1,15 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "irq")]
+use std::sync::{Arc, Barrier};
 use std::{
     panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
-    sync::{Arc, Barrier, OnceLock, mpsc},
+    sync::{OnceLock, mpsc},
+    task::Context,
     thread,
 };
+
+use ax_errno::{AxError, AxResult};
+use axpoll::{IoEvents, Pollable};
 
 #[cfg(feature = "irq")]
 use crate::IrqNotify;
@@ -36,10 +42,107 @@ where
     }
 }
 
+struct CountingPollable {
+    polls: AtomicUsize,
+    registers: AtomicUsize,
+}
+
+impl CountingPollable {
+    fn new() -> Self {
+        Self {
+            polls: AtomicUsize::new(0),
+            registers: AtomicUsize::new(0),
+        }
+    }
+
+    fn poll_count(&self) -> usize {
+        self.polls.load(Ordering::Relaxed)
+    }
+
+    fn register_count(&self) -> usize {
+        self.registers.load(Ordering::Relaxed)
+    }
+}
+
+impl Pollable for CountingPollable {
+    fn poll(&self) -> IoEvents {
+        self.polls.fetch_add(1, Ordering::Relaxed);
+        IoEvents::OUT
+    }
+
+    fn register(&self, _context: &mut Context<'_>, _events: IoEvents) {
+        self.registers.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 #[cfg(any(feature = "lockdep", feature = "preempt"))]
 const RAW_TASK_STACK_SIZE: usize = 0x10000;
 #[cfg(not(any(feature = "lockdep", feature = "preempt")))]
 const RAW_TASK_STACK_SIZE: usize = 0x1000;
+
+#[test]
+fn poll_io_ready_operation_wins_over_pending_interrupt() {
+    run_in_test_scheduler(|| {
+        let curr = current();
+        let pollable = CountingPollable::new();
+        let calls = AtomicUsize::new(0);
+        curr.interrupt();
+
+        let result = crate::future::block_on(crate::future::poll_io(
+            &pollable,
+            IoEvents::OUT,
+            false,
+            || -> AxResult<usize> {
+                calls.fetch_add(1, Ordering::Relaxed);
+                Ok(5)
+            },
+        ));
+
+        assert_eq!(result, Ok(5));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(pollable.poll_count(), 0);
+        assert_eq!(pollable.register_count(), 0);
+        assert_eq!(curr.take_interrupt(), true);
+    });
+}
+
+#[test]
+fn poll_io_blocked_operation_observes_pending_interrupt() {
+    run_in_test_scheduler(|| {
+        let curr = current();
+        curr.interrupt();
+
+        let result = crate::future::block_on(crate::future::poll_io(
+            &CountingPollable::new(),
+            IoEvents::OUT,
+            false,
+            || -> AxResult<usize> { Err(AxError::WouldBlock) },
+        ));
+
+        assert_eq!(result, Err(AxError::Interrupted));
+        assert_eq!(curr.take_interrupt(), false);
+    });
+}
+
+#[test]
+fn poll_io_nonblocking_wouldblock_wins_over_pending_interrupt() {
+    run_in_test_scheduler(|| {
+        let curr = current();
+        let pollable = CountingPollable::new();
+        curr.interrupt();
+
+        let result = crate::future::block_on(crate::future::poll_io(
+            &pollable,
+            IoEvents::OUT,
+            true,
+            || -> AxResult<usize> { Err(AxError::WouldBlock) },
+        ));
+
+        assert_eq!(result, Err(AxError::WouldBlock));
+        assert_eq!(pollable.register_count(), 1);
+        assert_eq!(curr.take_interrupt(), true);
+    });
+}
 
 #[test]
 fn test_sched_fifo() {


### PR DESCRIPTION
## 问题

Issue #1332 记录了 Starry loongarch64 QEMU 中 `bug-tcp-send-no-epoll-notify` 偶发在非阻塞 TCP `write()` 上返回 `EINTR` 的失败。该测试本身没有主动设置信号，目标是验证 loopback TCP 写入后 peer 端 epoll readiness 能被唤醒，因此不能通过放宽测试或在测试里简单重试 `EINTR` 来掩盖问题。

根因在 `axtask::future::poll_io`：旧实现把整个 poll future 包在 `interruptible(...)` 外层。这样当前 task 只要有 pending interrupt，就会在真正调用同步 I/O closure 前直接返回 `AxError::Interrupted`，最终漏到用户态成为 `EINTR`。对于已经 ready 的 I/O，应该先尝试实际操作；只有真实 blocking wait 才应该被 interrupt 打断。

Fixes #1332

## 修改

- 调整 `poll_io` 的执行顺序：
  - 先调用同步 I/O closure，ready 或其它非 `WouldBlock` 错误立即返回；
  - 遇到 `WouldBlock` 后先注册 poller，再重试一次，避免丢失唤醒；
  - 非阻塞调用在重试后仍 `WouldBlock` 时返回 `WouldBlock`，并保留 pending interrupt；
  - 只有 blocking 调用在重试后仍 `WouldBlock` 时，才检查并消费 task interrupt，返回 `Interrupted`。
- 新增 `poll_io` 单测，稳定覆盖：
  - ready I/O 必须优先于 pending interrupt，且 closure 必须被实际调用；
  - blocking WouldBlock 会观察并消费 pending interrupt；
  - nonblocking WouldBlock 不被 pending interrupt 改写，并且仍注册 poller，保留 nonblocking connect/epoll 的唤醒语义。

## 验证

- `cargo fmt`
- `cargo test --package ax-task --features multitask,host-test -- poll_io_ --nocapture`
- `cargo xtask clippy --package ax-task`
- `git diff --check`
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/bugfix-bug-tcp-send-no-epoll-notify`

额外做过红绿验证：临时恢复旧 `poll_io` 顺序后，`poll_io_ready_operation_wins_over_pending_interrupt` 稳定失败为 `Err(AxErrorKind::Interrupted)`；恢复修复后同组测试通过。