### PR TITLE
fix(ci): preflight self-hosted runner prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,7 @@ jobs:
           - name: Test axvisor self-hosted x86_64
             use_container: false
             runs_on: '["self-hosted","linux","intel","kvm"]'
+            require_kvm: true
             command: cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx
             cache_key: ""
             container_image: ""
@@ -572,6 +573,7 @@ jobs:
           - name: Test axvisor self-hosted x86_64 UEFI
             use_container: false
             runs_on: '["self-hosted","linux","intel","kvm"]'
+            require_kvm: true
             timeout_minutes: 20
             command: |
               sudo apt-get update
@@ -605,6 +607,7 @@ jobs:
           - name: Test axloader HTTP smoke
             use_container: false
             runs_on: '["self-hosted","linux","intel","kvm"]'
+            require_kvm: true
             timeout_minutes: 20
             command: |
               rustup target add x86_64-unknown-uefi
@@ -744,6 +747,7 @@ jobs:
           || (matrix.fetch_depth == 'full' && '0' || '1')
         }}
       timeout_minutes: ${{ matrix.timeout_minutes || 360 }}
+      require_kvm: ${{ matrix.require_kvm || false }}
       download_xtask_bin_artifact: >-
         ${{
           matrix.download_xtask_bin_artifact

--- a/.github/workflows/reusable-command.yml
+++ b/.github/workflows/reusable-command.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: number
         default: 360
+      require_kvm:
+        description: Require readable and writable /dev/kvm on self-hosted host jobs.
+        required: false
+        type: boolean
+        default: false
       upload_xtask_bin_artifact:
         description: Upload the tg-xtask binary as a workflow artifact after the command succeeds.
         required: false
@@ -85,6 +90,88 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: ${{ inputs.fetch_depth }}
+
+      - name: Preflight self-hosted host runner
+        if: contains(inputs.runs_on, 'self-hosted')
+        shell: bash
+        env:
+          REQUIRED_RUNNER_LABELS: ${{ inputs.runs_on }}
+          REQUIRE_KVM: ${{ inputs.require_kvm }}
+        run: |
+          set -euo pipefail
+
+          failures=0
+
+          record_error() {
+            echo "::error::$1"
+            failures=1
+          }
+
+          require_command() {
+            local name="$1"
+            if command -v "${name}" >/dev/null 2>&1; then
+              echo "${name}: $(command -v "${name}")"
+            else
+              record_error "required command '${name}' was not found in PATH"
+            fi
+          }
+
+          {
+            echo "## Self-hosted runner preflight"
+            echo ""
+            echo "- Runner: \`${RUNNER_NAME:-unknown}\`"
+            echo "- OS/arch: \`${RUNNER_OS:-unknown}/${RUNNER_ARCH:-unknown}\`"
+            echo "- Required labels: \`${REQUIRED_RUNNER_LABELS}\`"
+            echo "- KVM required: \`${REQUIRE_KVM}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          echo "Runner name: ${RUNNER_NAME:-unknown}"
+          echo "Runner OS/arch: ${RUNNER_OS:-unknown}/${RUNNER_ARCH:-unknown}"
+          echo "Required labels: ${REQUIRED_RUNNER_LABELS}"
+          echo "PATH=${PATH}"
+          echo "User: $(id -un 2>/dev/null || whoami 2>/dev/null || echo unknown)"
+          echo "Groups: $(id -nG 2>/dev/null || groups 2>/dev/null || echo unknown)"
+
+          require_command rustc
+          require_command cargo
+
+          if command -v rustc >/dev/null 2>&1; then
+            rustc -vV
+          fi
+          if command -v cargo >/dev/null 2>&1; then
+            cargo -V
+          fi
+
+          if [ "${REQUIRE_KVM}" = "true" ]; then
+            if [ -e /dev/kvm ]; then
+              ls -l /dev/kvm || true
+              if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+                record_error "/dev/kvm exists but is not readable and writable by the runner user"
+              fi
+            else
+              record_error "/dev/kvm does not exist on this runner"
+            fi
+
+            if command -v lsmod >/dev/null 2>&1; then
+              lsmod | grep -E '^kvm' || echo "::warning::lsmod did not report loaded kvm modules"
+            elif [ -r /proc/modules ]; then
+              grep -E '^kvm' /proc/modules || echo "::warning::/proc/modules did not report loaded kvm modules"
+            else
+              echo "::warning::unable to inspect loaded kvm modules"
+            fi
+
+            if [ -r /proc/cpuinfo ]; then
+              awk -F ': *' '/^(vendor_id|CPU implementer)/ { print "CPU vendor/implementer: " $2; exit }' /proc/cpuinfo || true
+            fi
+          fi
+
+          if [ "${failures}" -ne 0 ]; then
+            {
+              echo ""
+              echo "Preflight failed before the test command ran. Check the runner label assignment, PATH, Rust toolchain installation, and KVM device permissions."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
 
       - name: Restore Rust cache
         if: inputs.cache_key != ''


### PR DESCRIPTION
## 问题

#813 记录了 self-hosted `run_host` 类 CI 在正式测试前因为 runner 基础环境不满足约定而失败的问题：有些 runner 缺少 `rustc`/`cargo`，有些标记为 `intel,kvm` 的 runner 没有可用 `/dev/kvm` 或权限不正确。失败原本会晚到 QEMU 或测试命令内部才暴露，日志不够直接。

## 修改

- 在 `.github/workflows/reusable-command.yml` 的 host 执行路径新增 self-hosted preflight：
  - 只在 `runs_on` 包含 `self-hosted` 时执行；
  - 检查 `rustc`、`cargo` 是否在 GitHub Actions service 的 `PATH` 中可见，并输出 `rustc -vV`、`cargo -V`；
  - 输出 runner 名称、OS/arch、要求标签、当前用户与用户组，方便维护者定位具体 runner。
- 新增 `require_kvm` workflow_call 输入，用于需要 KVM 的 self-hosted job：
  - 检查 `/dev/kvm` 是否存在且对 runner 用户可读写；
  - 输出 `/dev/kvm` 权限、KVM 模块线索和 CPU vendor/implementer；
  - 失败时在测试命令运行前用 `::error::` 和 step summary 明确指出前置条件问题。
- 在 `ci.yml` 中只给 `self-hosted/linux/intel/kvm` 的 x86_64 VMX/UEFI/axloader 项设置 `require_kvm: true`，避免普通 self-hosted/board 任务误要求 KVM。
- 保留现有矩阵 `fail-fast` 行为不变，使前置条件失败仍能快速停止相关矩阵，避免浪费 CI 资源。

## 验证

- `python3` 解析 `.github/workflows/ci.yml` 和 `.github/workflows/reusable-command.yml` 成功。
- 从 workflow 中提取 preflight shell 后执行：
  - `bash -n /tmp/self-hosted-preflight.sh`
  - `REQUIRE_KVM=false` 本地 dry run 通过。
  - `REQUIRE_KVM=true` 本地 dry run 通过，并确认 `/dev/kvm` 可用。
- `/tmp/actionlint/actionlint -ignore 'unexpected key "queue"' .github/workflows/ci.yml .github/workflows/reusable-command.yml` 通过。
  - 这里忽略的是仓库既有 `concurrency.queue: max` 对当前 actionlint 版本的报错，不是本 PR 新增内容。
- `git diff --check` 通过。

Fixes #813