### PR TITLE
fix(axvm): skip host PIT IRQ forwarding hook

### DIFF
--- a/virtualization/axvm/src/runtime/x86_irq.rs
+++ b/virtualization/axvm/src/runtime/x86_irq.rs
@@ -24,6 +24,16 @@ static IOAPIC_IRQ_PENDING: AtomicUsize = AtomicUsize::new(0);
 static IOAPIC_IRQ_HANDLES: [AtomicUsize; IOAPIC_GSI_COUNT] =
     [const { AtomicUsize::new(0) }; IOAPIC_GSI_COUNT];
 
+fn should_register_ioapic_irq_hook(vector: usize) -> bool {
+    (IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_END).contains(&vector)
+        && vector != IOAPIC_VECTOR_BASE + PIT_TIMER_GSI
+}
+
+fn ioapic_irq_hook_vectors() -> impl Iterator<Item = usize> {
+    (IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_END)
+        .filter(|vector| should_register_ioapic_irq_hook(*vector))
+}
+
 pub fn forward_passthrough_irq_from_vmexit(vm: &VMRef, vcpu: &VCpuRef, vector: usize) {
     if vector == IOAPIC_VECTOR_BASE + PIT_TIMER_GSI {
         return;
@@ -151,7 +161,7 @@ pub fn enable_ioapic_irq_forwarding(vm: &VMRef, vcpu: &VCpuRef) {
     }
 
     let mut registered = 0;
-    for vector in IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_END {
+    for vector in ioapic_irq_hook_vectors() {
         let gsi = vector - IOAPIC_VECTOR_BASE;
         if IOAPIC_IRQ_HANDLES[gsi].load(Ordering::Acquire) != 0 {
             continue;
@@ -173,9 +183,11 @@ pub fn enable_ioapic_irq_forwarding(vm: &VMRef, vcpu: &VCpuRef) {
         IOAPIC_IRQ_HOOK_REGISTERED.store(true, Ordering::Release);
     }
     info!(
-        "Enabled x86 IOAPIC IRQ forwarding for host vectors {:#x}..{:#x} ({} newly registered)",
+        "Enabled x86 IOAPIC IRQ forwarding for host vectors {:#x}..{:#x}, excluding PIT vector \
+         {:#x} ({} newly registered)",
         IOAPIC_VECTOR_BASE,
         IOAPIC_VECTOR_END - 1,
+        IOAPIC_VECTOR_BASE + PIT_TIMER_GSI,
         registered
     );
 }
@@ -246,4 +258,43 @@ unsafe fn ioapic_irq_forwarding_handler(
     let bit = 1usize << (vector - IOAPIC_VECTOR_BASE);
     IOAPIC_IRQ_PENDING.fetch_or(bit, Ordering::AcqRel);
     irq::IrqReturn::Handled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        COM1_GSI, IOAPIC_GSI_COUNT, IOAPIC_VECTOR_BASE, PIT_TIMER_GSI, ioapic_irq_hook_vectors,
+        should_register_ioapic_irq_hook,
+    };
+
+    #[test]
+    fn host_pit_vector_uses_synthetic_injection_not_irq_hook() {
+        assert!(!should_register_ioapic_irq_hook(
+            IOAPIC_VECTOR_BASE + PIT_TIMER_GSI
+        ));
+    }
+
+    #[test]
+    fn other_ioapic_vectors_still_register_forwarding_hooks() {
+        assert!(should_register_ioapic_irq_hook(
+            IOAPIC_VECTOR_BASE + COM1_GSI
+        ));
+        assert!(should_register_ioapic_irq_hook(IOAPIC_VECTOR_BASE + 18));
+        assert!(should_register_ioapic_irq_hook(
+            IOAPIC_VECTOR_BASE + IOAPIC_GSI_COUNT - 1
+        ));
+        assert!(!should_register_ioapic_irq_hook(
+            IOAPIC_VECTOR_BASE + IOAPIC_GSI_COUNT
+        ));
+    }
+
+    #[test]
+    fn hook_vector_iterator_matches_registration_policy() {
+        for vector in IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_BASE + IOAPIC_GSI_COUNT {
+            assert_eq!(
+                ioapic_irq_hook_vectors().any(|hook| hook == vector),
+                should_register_ioapic_irq_hook(vector)
+            );
+        }
+    }
 }


### PR DESCRIPTION
## 问题与根因

Issue #1230 跟踪的是 x86_64 CI 中 `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx` 的超时。失败日志里出现过 `failed to request x86 IOAPIC forwarding IRQ action for vector 0x20: Busy`，后续也表现为 guest Linux 已进入 shell 但测试成功标记没有稳定输出。

根因是 `axvm` 在开启 x86 IOAPIC passthrough IRQ forwarding 时，会尝试为 `IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_END` 的所有 host vector 注册 shared IRQ hook。`IOAPIC_VECTOR_BASE` 是 `0x20`，而动态 x86 平台上 host APIC timer 也使用 vector `0x20`，并且该 timer IRQ 已经通过非 shared 的 percpu IRQ 注册，因此这里再次申请 shared IRQ 会返回 `Busy`。

同时，guest PIT/GSI0 在现有实现中已经走 synthetic PIT 注入路径：`forward_passthrough_irq_from_vmexit` 会跳过 `IOAPIC_VECTOR_BASE + PIT_TIMER_GSI`，`inject_due_pit_irq0` 会负责按需注入 PIT IRQ。因此为 GSI0/PIT 注册 host IRQ hook 不但不需要，还会和 host timer vector 冲突。

## 修改内容

- 为 x86 IOAPIC IRQ forwarding 增加注册策略函数，只为需要真实 host IRQ hook 的 vector 注册 hook。
- 明确跳过 `IOAPIC_VECTOR_BASE + PIT_TIMER_GSI`，避免申请 host vector `0x20` 的 shared IRQ。
- 保留其它 IOAPIC vector 的转发 hook，例如 COM1/GSI4 和 virtio-blk/GSI18 仍会注册。
- 更新日志，明确说明注册范围会排除 PIT vector，避免后续排查误读。
- 增加 `x86_irq` 单元测试，覆盖 PIT vector 跳过、其它 vector 保持注册，以及 iterator 与策略函数一致性。

## 回归证据

- 红灯验证：在只加入 `host_pit_vector_uses_synthetic_injection_not_irq_hook` 测试、尚未修复注册范围时，`cargo test -p axvm host_pit_vector_uses_synthetic_injection_not_irq_hook --features vmx` 会因为 PIT vector 仍被判定为可注册而失败。
- 绿灯验证：修复后，同一策略测试通过，并且 `x86_irq::tests` 全部通过。

## 本地验证

- `cargo fmt --check`：通过
- `cargo test -p axvm x86_irq::tests --features vmx`：3 个测试全部通过
- `cargo xtask clippy --package axvm`：8 个 feature 组合全部通过
- `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx`：`smoke-vmx` 通过，guest Linux 输出并匹配 `guest linux test pass!`

Fixes #1230