### PR TITLE
feat(starry): add VisionFive2 board smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,6 +705,14 @@ jobs:
             container_image: ""
             limit_to_owner: rcore-os
             main_pr_only: false
+          - name: Test starry self-hosted board visionfive2
+            use_container: false
+            runs_on: '["self-hosted","linux","board"]'
+            command: cargo xtask starry test board --board visionfive2
+            cache_key: ""
+            container_image: ""
+            limit_to_owner: rcore-os
+            main_pr_only: false
     uses: ./.github/workflows/reusable-command.yml
     with:
       runs_on: >-

--- a/os/StarryOS/configs/board/visionfive2-board.toml
+++ b/os/StarryOS/configs/board/visionfive2-board.toml
@@ -1,0 +1,11 @@
+# Remote VisionFive2 runtime config. The build config is visionfive2.toml.
+board_type = "VisionFive2"
+# Current smoke frontier: dynamic boot reaches root-device discovery before
+# JH7110 block/rootfs support is available.
+success_regex = ["failed to determine root device from available block devices"]
+fail_regex = [
+  "(?i)segmentation fault",
+  "(?i)SIGSEGV",
+  "exit with code: 139",
+]
+timeout = 600

--- a/os/StarryOS/configs/board/visionfive2.toml
+++ b/os/StarryOS/configs/board/visionfive2.toml
@@ -1,0 +1,6 @@
+# Build-time config template for StarryOS on VisionFive2.
+target = "riscv64gc-unknown-none-elf"
+features = [
+  "ax-driver/serial",
+]
+log = "Info"

--- a/os/arceos/modules/axhal/src/mem.rs
+++ b/os/arceos/modules/axhal/src/mem.rs
@@ -1,5 +1,6 @@
 //! Physical memory management.
 
+use ax_memory_addr::MemoryAddr;
 pub use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, PhysAddrRange, VirtAddr, VirtAddrRange, pa, va};
 pub use ax_plat::mem::{
     MemRegionFlags, PhysMemRegion, kernel_aspace, mmio_ranges, phys_ram_ranges, phys_to_virt,
@@ -102,7 +103,16 @@ static ALL_MEM_REGIONS: LazyLock<Vec<PhysMemRegion, MAX_REGIONS>> = LazyLock::ne
     // Remove all reserved ranges from RAM ranges, and push the remaining as free memory
     reserved_ranges.sort_unstable_by_key(|&(start, _size)| start);
     ranges_difference(phys_ram_ranges(), &reserved_ranges, |(start, size)| {
-        push(PhysMemRegion::new_ram(start, size, "free memory"));
+        let end = start + size;
+        let aligned_start = PhysAddr::from_usize(start).align_up_4k().as_usize();
+        let aligned_end = PhysAddr::from_usize(end).align_down_4k().as_usize();
+        if aligned_start < aligned_end {
+            push(PhysMemRegion::new_ram(
+                aligned_start,
+                aligned_end - aligned_start,
+                "free memory",
+            ));
+        }
     })
     .inspect_err(|(a, b)| error!("Reserved memory region {a:#x?} overlaps with {b:#x?}"))
     .unwrap();

--- a/test-suit/starryos/board-visionfive2/boot/board-visionfive2.toml
+++ b/test-suit/starryos/board-visionfive2/boot/board-visionfive2.toml
@@ -1,0 +1,10 @@
+board_type = "VisionFive2"
+# Current smoke frontier: dynamic boot reaches root-device discovery before
+# JH7110 block/rootfs support is available.
+success_regex = ["failed to determine root device from available block devices"]
+fail_regex = [
+  "(?i)segmentation fault",
+  "(?i)SIGSEGV",
+  "exit with code: 139",
+]
+timeout = 600

--- a/test-suit/starryos/board-visionfive2/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/board-visionfive2/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,6 @@
+# Build-time config template for StarryOS on VisionFive2.
+target = "riscv64gc-unknown-none-elf"
+features = [
+  "ax-driver/serial",
+]
+log = "Info"


### PR DESCRIPTION
## 问题

StarryOS 目前没有 VisionFive2 的动态平台板级 smoke 覆盖。VisionFive2 板池已经可用，但现有配置只覆盖静态平台路径，动态启动过程中还会遇到非 4K 对齐的 reserved/free 内存边界，导致后续页级映射可能重叠。

## 修改

- 新增 `visionfive2` Starry 动态构建配置，只启用串口驱动并保持默认动态平台行为。
- 新增 VisionFive2 板级运行配置和 `test-suit/starryos/board-visionfive2` smoke case。
- smoke 成功条件先匹配当前本地验证到的最远启动进度：`failed to determine root device from available block devices`。这说明系统已经通过动态启动、VM、串口、调度、IRQ 和平台设备探测；MMC/rootfs 支持后续再单独推进。
- 修正 `axhal` 生成 free memory region 时的 4K 边界处理，把 reserved 差集后的 free 区间向内收敛到页边界，避免 VisionFive2 上非页对齐 reserved/free 边界被页级映射放大后重叠。
- 在 CI matrix 中增加 `cargo xtask starry test board --board visionfive2`，运行在 self-hosted board runner 上。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo xtask starry test board -l | rg -n "visionfive2|board-visionfive2"`
- `cargo xtask starry test board --board visionfive2`
- `cargo xtask clippy --package ax-hal`
- `cargo xtask starry build --config os/StarryOS/configs/board/visionfive2.toml`
