### PR TITLE
feat(axbuild): use ITS companion files for Starry uImage

### DIFF
--- a/docs/docs/build/commands.md
+++ b/docs/docs/build/commands.md
@@ -25,7 +25,7 @@ cargo xtask <cmd>  →  cargo run -p tg-xtask -- <cmd>  →  axbuild::run()
 | `cargo xtask board ...` | `cargo board ...` | 板卡管理快捷入口 |
 | `cargo xtask ...` | `cargo xtask ...` | 其他命令无额外别名 |
 
-以下文档统一使用 `cargo xtask` 前缀，实际使用时可替换为对应的别名。例如：
+本文大多数通用命令仍展示 `cargo xtask` 前缀；StarryOS 快速上手和板卡配置流程优先展示 `cargo starry` 别名。实际使用时两种写法可以互换。例如：
 
 ```bash
 # 以下两条命令等价
@@ -107,12 +107,22 @@ cargo xtask starry <subcommand> [options]
 | `app list` | 列出 `apps/starry/` 下发现的可运行应用 |
 | `app run` | 构建并运行 `apps/starry/` 下发现的应用 |
 | `app board` | 在远程板卡上运行应用 |
-| `quick-start` | 常见平台便捷入口 |
+| `quick-start` | 旧版常见平台便捷入口，后续会废弃 |
 | `rootfs` | 下载 rootfs 到 target 目录 |
 | `defconfig` | 生成默认板卡配置 |
 | `config ls` | 列出可用板卡名称 |
 
-`quick-start` 提供常见 QEMU 平台和 Orange Pi 5 Plus 的简化工作流，每个平台包含 `build` 和 `run` 两阶段：
+推荐的 StarryOS 配置流程是先查看支持的板卡名称，再选择默认配置，后续直接执行常规子命令：
+
+```bash
+cargo starry config ls
+cargo starry defconfig <board>
+cargo starry build
+```
+
+`cargo starry defconfig <board>` 会把对应板卡配置复制到默认构建配置位置，并更新 StarryOS 命令快照。之后 `cargo starry build`、`cargo starry qemu`、`cargo starry uboot`、`cargo starry board` 等命令会沿用该配置。`quick-start` 是旧版便捷入口，保留用于兼容已有脚本，后续会废弃；新文档和新流程不再推荐使用它。
+
+旧版 `quick-start` 每个平台包含 `build` 和 `run` 两阶段：
 
 | 子命令 | 说明 |
 |--------|------|

--- a/docs/docs/quickstart/overview.md
+++ b/docs/docs/quickstart/overview.md
@@ -106,10 +106,11 @@ qemu-system-loongarch64 --version
 
 ## 3. 命令入口
 
-TGOSKits 当前通过 `cargo xtask` 统一封装各系统的常用命令。无论是快速启动、测试套件还是镜像准备，优先从这一入口进入，通常最接近仓库当前的维护方式。当前仓库推荐通过 `cargo xtask` 统一调度：
+TGOSKits 当前通过 `cargo xtask` 统一封装各系统的常用命令，同时在 `.cargo/config.toml` 中提供了 `cargo arceos`、`cargo starry`、`cargo axvisor` 等快捷别名。StarryOS 快速上手推荐直接使用 `cargo starry`：先用 `config ls` 查看支持的板卡，再用 `defconfig <board>` 选择配置，后续继续执行 `build`、`qemu`、`uboot`、`board` 或测试命令。
 
 ```bash
 cargo xtask --help
+cargo starry --help
 ```
 
 常见入口如下：
@@ -117,7 +118,7 @@ cargo xtask --help
 | 目标 | 文档 | 常用命令 |
 |------|------|----------|
 | ArceOS | [ArceOS 快速上手](./arceos) | `cargo xtask arceos qemu ...` |
-| StarryOS | [StarryOS 快速上手](./starryos) | `cargo xtask starry qemu ...` |
+| StarryOS | [StarryOS 快速上手](./starryos) | `cargo starry config ls` / `cargo starry defconfig <board>` |
 | Axvisor | [Axvisor 快速上手](./axvisor) | `cargo xtask axvisor test qemu ...` |
 
 环境确认无误后，可以直接进入具体系统的快速上手页面。每一页都会给出当前项目中可用的最短命令路径，而不是抽象的概念说明。

--- a/docs/docs/quickstart/starryos.md
+++ b/docs/docs/quickstart/starryos.md
@@ -6,137 +6,178 @@ title: "StarryOS 快速上手"
 
 # StarryOS 快速上手
 
-StarryOS 的最短启动路径通常包含 rootfs。当前 `qemu` 路径会在缺少 rootfs 时自动补齐，也可以显式先执行 `rootfs`。
+StarryOS 的快速上手建议先选择板卡配置，再执行常规构建或运行命令。`cargo starry config ls` 用于查看当前支持的板卡名称，`cargo starry defconfig <board>` 会把选中的板卡配置写入默认构建配置并记录到 StarryOS 命令快照，后续 `cargo starry build`、`cargo starry qemu`、`cargo starry uboot` 或 `cargo starry board` 会沿用这份配置。
 
 ```mermaid
 flowchart LR
-  A[准备 rootfs] --> B[cargo xtask starry qemu]
-  B --> C{单次启动通过?}
-  C -- 是 --> D[测试套件]
-  C -- 否 --> E[检查环境 / rootfs]
-  E --> A
+  A[cargo starry config ls] --> B[cargo starry defconfig board]
+  B --> C[cargo starry qemu / build / board]
+  C --> D{单次启动通过?}
+  D -- 是 --> E[测试套件]
+  D -- 否 --> F[检查环境 / rootfs / 板卡连接]
+  F --> A
 ```
 
-## 1. 快速启动
+## 1. 选择板卡配置
 
-StarryOS 的快速启动比 ArceOS 多了一层 rootfs 资产准备，因此这里同时给出“一步运行”和“显式分步”两种方式。第一次上手时，任选其一即可。
+先查看仓库当前支持的 StarryOS 板卡配置：
 
-### 1.1 RISC-V 64
+```bash
+cargo starry config ls
+```
+
+输出中的名称可以直接传给 `defconfig`：
+
+```bash
+cargo starry defconfig <board>
+```
+
+完成 `defconfig` 后，后续命令通常不需要再重复传 `--config`、`--target` 或 `--arch`。`quick-start` 是旧的便捷入口，后续会废弃；新的快速上手路径请使用 `config ls`、`defconfig` 和常规 `cargo starry` 子命令。
+
+## 2. QEMU 快速启动
+
+StarryOS 的 QEMU 启动通常包含 rootfs。当前 `qemu` 路径会在缺少 rootfs 时自动补齐，也可以显式先执行 `rootfs`。
+
+### 2.1 RISC-V 64
 
 `riscv64` 仍然是最适合作为首条验证路径的架构。它在文档和测试套件中都较常用，适合先确认 rootfs 和 QEMU 路径是否已经接通。
 
 推荐第一次从 `riscv64` 开始：
 
 ```bash
-cargo xtask starry qemu --target riscv64gc-unknown-none-elf
+cargo starry defconfig qemu-riscv64
+cargo starry qemu
 ```
 
 或显式分步执行：
 
 ```bash
-cargo xtask starry rootfs --arch riscv64
-cargo xtask starry qemu --target riscv64gc-unknown-none-elf
+cargo starry defconfig qemu-riscv64
+cargo starry rootfs --arch riscv64
+cargo starry build
+cargo starry qemu
 ```
 
-### 1.2 AArch64
+### 2.2 AArch64
 
 如果后续会继续关注板级路径或与 Axvisor 的 AArch64 环境对齐，可以尽快补跑这一条。它也是 StarryOS 当前非常重要的一条验证路径。
 
 ```bash
-cargo xtask starry qemu --target aarch64-unknown-none-softfloat
+cargo starry defconfig qemu-aarch64
+cargo starry qemu
 ```
 
 分步执行：
 
 ```bash
-cargo xtask starry rootfs --arch aarch64
-cargo xtask starry qemu --target aarch64-unknown-none-softfloat
+cargo starry defconfig qemu-aarch64
+cargo starry rootfs --arch aarch64
+cargo starry build
+cargo starry qemu
 ```
 
-### 1.3 x86_64
+### 2.3 x86_64
 
 `x86_64` 适合作为 PC 类平台的补充验证路径。命令和其它架构基本一致，差异主要体现在目标 triple 和对应的 QEMU 配置上。
 
 ```bash
-cargo xtask starry qemu --target x86_64-unknown-none
+cargo starry defconfig qemu-x86_64
+cargo starry qemu
 ```
 
 分步执行：
 
 ```bash
-cargo xtask starry rootfs --arch x86_64
-cargo xtask starry qemu --target x86_64-unknown-none
+cargo starry defconfig qemu-x86_64
+cargo starry rootfs --arch x86_64
+cargo starry build
+cargo starry qemu
 ```
 
-### 1.4 LoongArch64
+### 2.4 LoongArch64
 
 LoongArch64 路径更适合在主流架构已经跑通之后再验证。这样出现问题时，也更容易区分是环境问题还是实验性架构路径带来的差异。
 
 ```bash
-cargo xtask starry qemu --target loongarch64-unknown-none-softfloat
+cargo starry defconfig qemu-loongarch64
+cargo starry qemu
 ```
 
 分步执行：
 
 ```bash
-cargo xtask starry rootfs --arch loongarch64
-cargo xtask starry qemu --target loongarch64-unknown-none-softfloat
+cargo starry defconfig qemu-loongarch64
+cargo starry rootfs --arch loongarch64
+cargo starry build
+cargo starry qemu
 ```
 
 > `starry rootfs` 当前使用 `--arch`，不是 `--target`。  
 > `starry qemu` 的 `--target` 可接受完整 target triple，也可接受简写架构名。
 
-### 1.5 LicheeRV-Nano-SG2002
+## 3. 开发板快速启动
+
+### 3.1 LicheeRV-Nano-SG2002
 
 LicheeRV-Nano-SG2002 当前走 U-Boot 串口启动路径，适合在已经烧录并能正常进入 Linux 的开发板上验证 StarryOS。StarryOS 直接使用板上的 Linux 原生 ext4 根文件系统，默认根分区为 `root=/dev/mmcblk0p2`，不需要再单独制作 Starry rootfs 分区。
 
-本地开发板启动使用 `quick-start`。默认串口配置来自 `os/StarryOS/configs/board/licheerv-nano-sg2002-uboot.toml`，默认串口是 `/dev/ttyUSB0`，波特率为 `115200`：
+先选择 SG2002 构建配置：
 
 ```bash
-# 只构建 SG2002 StarryOS
-cargo xtask starry quick-start licheerv-nano-sg2002 build
-
-# 构建并通过本地串口上传、启动
-cargo xtask starry quick-start licheerv-nano-sg2002 run
-
-# 如需指定串口
-cargo xtask starry quick-start licheerv-nano-sg2002 run --serial /dev/ttyUSB1
+cargo starry defconfig licheerv-nano-sg2002
+cargo starry build
 ```
 
-这条路径会构建 `riscv64gc-unknown-none-elf` 目标，并由 ostool 生成 FIT image，通过 U-Boot 的 `loady` 串口传输到 `fit_load_addr = 0x82200000`，再执行 `bootm 0x82200000`。内核入口地址为 `kernel_load_addr = 0x80200000`。
-
-远端 CI / 板卡服务器启动使用 board test 入口：
+本地 U-Boot 串口启动使用常规 `uboot` 子命令。默认串口配置来自 `os/StarryOS/configs/board/licheerv-nano-sg2002-uboot.toml`，默认串口是 `/dev/ttyUSB0`，波特率为 `115200`：
 
 ```bash
-cargo xtask starry test board --board licheerv-nano-sg2002 --server <ip> --port <port>
+cargo starry uboot \
+  --uboot-config os/StarryOS/configs/board/licheerv-nano-sg2002-uboot.toml
+```
+
+这条路径会构建 `riscv64gc-unknown-none-elf` 目标，并根据 SG2002 的 ITS 模板生成 FIT image，随后通过 U-Boot 的 `loady` 串口传输到 `fit_load_addr = 0x82200000`，再执行 `bootm 0x82200000`。内核入口地址为 `kernel_load_addr = 0x80200000`。
+
+远端板卡服务器启动使用常规 `board` 子命令：
+
+```bash
+cargo starry board \
+  --board-config os/StarryOS/configs/board/licheerv-nano-sg2002-board.toml \
+  --server <ip> \
+  --port <port>
+```
+
+如果要运行完整板级测试，再使用 test-suit 入口：
+
+```bash
+cargo starry test board --board licheerv-nano-sg2002 --server <ip> --port <port>
 ```
 
 这里的 `--board licheerv-nano-sg2002` 用于选择 `test-suit/starryos` 下的 LicheeRV-Nano-SG2002 用例；实际向 ostool-server 申请的物理板卡类型写在用例配置中，当前同样为 `LicheeRV-Nano-SG2002`。
 
-## 2. 测试入口
+## 4. 测试入口
 
 StarryOS 除了单次启动外，更常见的验证方式是直接进入测试套件。这里的命令会读取 `test-suit/starryos` 下的用例配置并运行；迁出的压力测试通过 Starry app 命令显式选择。
 
 ```bash
 # 全部 test-suit QEMU 测试
-cargo xtask starry test qemu --target riscv64gc-unknown-none-elf
+cargo starry test qemu --target riscv64gc-unknown-none-elf
 
 # 压力测试
-cargo xtask starry app qemu -t stress/git --arch riscv64
+cargo starry app qemu -t stress/git --arch riscv64
 
 # 仅运行指定用例
-cargo xtask starry test qemu --target aarch64-unknown-none-softfloat -c qemu-smp1/system
+cargo starry test qemu --target aarch64-unknown-none-softfloat -c qemu-smp1/system
 
 # 其他架构
-cargo xtask starry test qemu --target x86_64-unknown-none
-cargo xtask starry test qemu --target loongarch64-unknown-none-softfloat
+cargo starry test qemu --target x86_64-unknown-none
+cargo starry test qemu --target loongarch64-unknown-none-softfloat
 ```
 
 如果需要板测：
 
 ```bash
-cargo xtask starry test board --board orangepi-5-plus --server <ip> --port <port>
-cargo xtask starry test board --board licheerv-nano-sg2002 --server <ip> --port <port>
+cargo starry test board --board orangepi-5-plus --server <ip> --port <port>
+cargo starry test board --board licheerv-nano-sg2002 --server <ip> --port <port>
 ```
 
 详细说明见：[StarryOS 测试套件设计](/docs/build/test/starry)

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002-wifi.its
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002-wifi.its
@@ -1,0 +1,32 @@
+/dts-v1/;
+
+/ {
+    description = "StarryOS Wi-Fi for LicheeRV Nano SG2002";
+    #address-cells = <1>;
+
+    images {
+        kernel {
+            description = "StarryOS Wi-Fi kernel";
+            data = /incbin/("${kernel_bin}");
+            type = "kernel";
+            arch = "riscv";
+            os = "linux";
+            compression = "none";
+            load = <0x80200000>;
+            entry = <0x80200000>;
+
+            hash {
+                algo = "sha256";
+            };
+        };
+    };
+
+    configurations {
+        default = "config";
+
+        config {
+            description = "StarryOS SG2002 Wi-Fi";
+            kernel = "kernel";
+        };
+    };
+};

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002-wifi.toml
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002-wifi.toml
@@ -1,4 +1,3 @@
-env = { UIMAGE = "y" }
 features = [
   "starry-kernel/sg2002-wifi",
   "axplat-dyn/thead-mae",

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002.its
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002.its
@@ -1,0 +1,32 @@
+/dts-v1/;
+
+/ {
+    description = "StarryOS for LicheeRV Nano SG2002";
+    #address-cells = <1>;
+
+    images {
+        kernel {
+            description = "StarryOS kernel";
+            data = /incbin/("${kernel_bin}");
+            type = "kernel";
+            arch = "riscv";
+            os = "linux";
+            compression = "none";
+            load = <0x80200000>;
+            entry = <0x80200000>;
+
+            hash {
+                algo = "sha256";
+            };
+        };
+    };
+
+    configurations {
+        default = "config";
+
+        config {
+            description = "StarryOS SG2002";
+            kernel = "kernel";
+        };
+    };
+};

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
@@ -1,4 +1,3 @@
-env = { UIMAGE = "y" }
 features = [
   "starry-kernel/sg2002",
   "axplat-dyn/thead-mae",

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -186,38 +186,7 @@ fn patch_starry_cargo_config(
             .or_insert_with(|| platform.to_string());
     }
 
-    if cargo.env.get("UIMAGE").map(|v| v.as_str()) == Some("y") {
-        validate_uimage_generation(cargo, &request.arch)?;
-    }
-
     Ok(())
-}
-
-fn uimg_arch_for(arch: &str) -> String {
-    match arch {
-        "aarch64" => "arm64".to_string(),
-        "riscv64" => "riscv".to_string(),
-        other => other.to_string(),
-    }
-}
-
-fn validate_uimage_generation(cargo: &Cargo, arch: &str) -> anyhow::Result<()> {
-    if cargo.env.contains_key("AX_CONFIG_PATH") {
-        return Ok(());
-    }
-
-    if !uses_dynamic_platform(&cargo.features) {
-        return Err(anyhow::anyhow!(
-            "AX_CONFIG_PATH is required for UIMAGE generation"
-        ));
-    }
-
-    match arch {
-        "aarch64" | "riscv64" => Ok(()),
-        other => Err(anyhow::anyhow!(
-            "AX_CONFIG_PATH is required for UIMAGE generation on {other}"
-        )),
-    }
 }
 
 pub(crate) async fn build_starry_artifact(
@@ -241,7 +210,7 @@ pub(crate) async fn build_starry_artifact(
 pub(crate) fn postprocess_starry_artifact(
     workspace_root: &Path,
     request: &ResolvedStarryRequest,
-    cargo: &Cargo,
+    _cargo: &Cargo,
     build_output: &ostool::build::CargoBuildOutput,
 ) -> anyhow::Result<()> {
     let elf = build_output.elf_path();
@@ -249,8 +218,13 @@ pub(crate) fn postprocess_starry_artifact(
     generate_kallsyms(elf)?;
     refresh_bin_if_present(elf)?;
 
-    if cargo.env.get("UIMAGE").map(|v| v.as_str()) == Some("y") {
-        generate_uimage(workspace_root, cargo, &request.arch, elf)?;
+    if let Some(plan) = uimage_generation_plan(
+        &request.build_info_path,
+        &request.arch,
+        &request.target,
+        elf,
+    ) {
+        generate_uimage_from_its(workspace_root, &plan, &request.arch, &request.target, elf)?;
     }
 
     Ok(())
@@ -383,50 +357,113 @@ fn refresh_bin_if_present(kernel_elf: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn generate_uimage(
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UimageGenerationPlan {
+    source_its: PathBuf,
+    rendered_its: PathBuf,
+    kernel_bin: PathBuf,
+    output_uimg: PathBuf,
+}
+
+pub(crate) fn uimage_its_path_for_config(config_path: &Path) -> PathBuf {
+    config_path.with_extension("its")
+}
+
+fn uimage_generation_plan(
+    config_path: &Path,
+    _arch: &str,
+    _target: &str,
+    kernel_elf: &Path,
+) -> Option<UimageGenerationPlan> {
+    let source_its = uimage_its_path_for_config(config_path);
+    source_its.exists().then(|| {
+        let rendered_its = temp_file_path(kernel_elf, "uimage.its")
+            .expect("kernel ELF path should have a valid parent and filename");
+        let kernel_bin = kernel_elf.with_extension("bin");
+        let output_uimg = kernel_bin.with_extension("uimg");
+        UimageGenerationPlan {
+            source_its,
+            rendered_its,
+            kernel_bin,
+            output_uimg,
+        }
+    })
+}
+
+fn generate_uimage_from_its(
     workspace_root: &Path,
-    cargo: &Cargo,
+    plan: &UimageGenerationPlan,
     arch: &str,
+    target: &str,
     kernel_elf: &Path,
 ) -> anyhow::Result<()> {
-    let bin = kernel_elf.with_extension("bin");
-    if !bin.exists() {
-        refresh_bin_if_present(kernel_elf)?;
-    }
-    if !bin.exists() {
-        bail!(
-            "kernel BIN is required for UIMAGE generation: {}",
-            bin.display()
-        );
-    }
-    let uimg = bin.with_extension("uimg");
-    let paddr = uimage_load_paddr(cargo, arch)?;
-    let stage = StageLog::start(format!(
-        "starry uImage arch={} load={} bin={} out={}",
+    refresh_bin(kernel_elf, &plan.kernel_bin)?;
+    render_uimage_its_template(
+        &plan.source_its,
+        &plan.rendered_its,
+        kernel_elf,
+        &plan.kernel_bin,
         arch,
-        paddr,
-        bin.display(),
-        uimg.display()
+        target,
+    )?;
+    let stage = StageLog::start(format!(
+        "starry uImage arch={} its={} out={}",
+        arch,
+        plan.source_its.display(),
+        plan.output_uimg.display()
     ));
-    Command::new("mkimage")
+    let result = Command::new("mkimage")
         .current_dir(workspace_root)
-        .arg("-A")
-        .arg(uimg_arch_for(arch))
-        .arg("-O")
-        .arg("linux")
-        .arg("-T")
-        .arg("kernel")
-        .arg("-C")
-        .arg("none")
-        .arg("-a")
-        .arg(&paddr)
-        .arg("-d")
-        .arg(&bin)
-        .arg(&uimg)
+        .args(mkimage_args_for_its(&plan.rendered_its, &plan.output_uimg))
         .exec()
-        .with_context(|| format!("failed to generate {}", uimg.display()))?;
+        .with_context(|| format!("failed to generate {}", plan.output_uimg.display()));
+    let cleanup = fs::remove_file(&plan.rendered_its)
+        .with_context(|| format!("failed to remove {}", plan.rendered_its.display()));
+    result?;
+    cleanup?;
     stage.done();
     Ok(())
+}
+
+fn refresh_bin(kernel_elf: &Path, bin: &Path) -> anyhow::Result<()> {
+    let stage = StageLog::start(format!("starry bin refresh {}", bin.display()));
+    Command::new("rust-objcopy")
+        .arg("--strip-all")
+        .arg("-O")
+        .arg("binary")
+        .arg(kernel_elf)
+        .arg(bin)
+        .exec()
+        .with_context(|| format!("failed to refresh {}", bin.display()))?;
+    stage.done();
+    Ok(())
+}
+
+fn render_uimage_its_template(
+    template: &Path,
+    rendered: &Path,
+    kernel_elf: &Path,
+    kernel_bin: &Path,
+    arch: &str,
+    target: &str,
+) -> anyhow::Result<()> {
+    let content = fs::read_to_string(template)
+        .with_context(|| format!("failed to read {}", template.display()))?;
+    let rendered_content = content
+        .replace("${kernel_bin}", &kernel_bin.display().to_string())
+        .replace("${kernel_elf}", &kernel_elf.display().to_string())
+        .replace("${arch}", arch)
+        .replace("${target}", target);
+    fs::write(rendered, rendered_content)
+        .with_context(|| format!("failed to write {}", rendered.display()))
+}
+
+fn mkimage_args_for_its(rendered_its: &Path, output_uimg: &Path) -> Vec<String> {
+    vec![
+        "-f".to_string(),
+        rendered_its.display().to_string(),
+        output_uimg.display().to_string(),
+    ]
 }
 
 fn ensure_kallsyms_tools() -> anyhow::Result<()> {
@@ -546,48 +583,6 @@ fn temp_file_path(path: &Path, suffix: &str) -> anyhow::Result<PathBuf> {
         .and_then(|name| name.to_str())
         .ok_or_else(|| anyhow!("invalid path filename: {}", path.display()))?;
     Ok(parent.join(format!(".{name}.{suffix}.{}.tmp", std::process::id())))
-}
-
-fn uimage_load_paddr(cargo: &Cargo, arch: &str) -> anyhow::Result<String> {
-    if let Some(config_path) = cargo.env.get("AX_CONFIG_PATH") {
-        return axconfig_kernel_base_paddr(Path::new(config_path));
-    }
-
-    if !uses_dynamic_platform(&cargo.features) {
-        return Err(anyhow::anyhow!(
-            "AX_CONFIG_PATH is required for UIMAGE generation"
-        ));
-    }
-
-    match arch {
-        "aarch64" => Ok("0x200000".to_string()),
-        "riscv64" => Ok("0x80200000".to_string()),
-        other => Err(anyhow::anyhow!(
-            "AX_CONFIG_PATH is required for UIMAGE generation on {other}"
-        )),
-    }
-}
-
-fn axconfig_kernel_base_paddr(path: &Path) -> anyhow::Result<String> {
-    let output = Command::new("ax-config-gen")
-        .arg(path)
-        .arg("-r")
-        .arg("plat.kernel-base-paddr")
-        .output()
-        .with_context(|| format!("failed to read kernel base paddr from {}", path.display()))?;
-    if !output.status.success() {
-        bail!("ax-config-gen exited with status {}", output.status);
-    }
-    let paddr = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .replace('_', "");
-    if paddr.is_empty() {
-        bail!(
-            "ax-config-gen returned empty plat.kernel-base-paddr for {}",
-            path.display()
-        );
-    }
-    Ok(paddr)
 }
 
 fn remove_qemu_feature_for_dynamic_platform(cargo: &mut Cargo) {

--- a/scripts/axbuild/src/starry/build/tests.rs
+++ b/scripts/axbuild/src/starry/build/tests.rs
@@ -4,7 +4,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ostool::build::config::Cargo;
 use tempfile::tempdir;
 
 use super::*;
@@ -408,49 +407,90 @@ fn riscv64_has_no_starry_default_platform() {
 }
 
 #[test]
-fn uimage_load_paddr_uses_dynamic_riscv64_fallback_without_axconfig() {
-    let cargo = Cargo {
-        env: HashMap::new(),
-        target: "scripts/targets/std/pie/riscv64gc-unknown-linux-musl.json".to_string(),
-        package: STARRY_PACKAGE.to_string(),
-        bin: None,
-        features: vec!["plat-dyn".to_string()],
-        log: None,
-        extra_config: None,
-        profile: None,
-        disable_someboot_build_config: true,
-        args: Vec::new(),
-        pre_build_cmds: Vec::new(),
-        post_build_cmds: Vec::new(),
-        to_bin: true,
-    };
+fn uimage_its_path_for_config_uses_same_basename_with_its_extension() {
+    let path = uimage_its_path_for_config(Path::new("os/StarryOS/configs/board/foo.toml"));
 
-    assert_eq!(uimage_load_paddr(&cargo, "riscv64").unwrap(), "0x80200000");
+    assert_eq!(path, PathBuf::from("os/StarryOS/configs/board/foo.its"));
 }
 
 #[test]
-fn uimage_load_paddr_uses_axconfig_when_available() {
-    let cargo = Cargo {
-        env: HashMap::from([(
-            "AX_CONFIG_PATH".to_string(),
-            "/tmp/generated.axconfig.toml".to_string(),
-        )]),
-        target: "riscv64gc-unknown-none-elf".to_string(),
-        package: STARRY_PACKAGE.to_string(),
-        bin: None,
-        features: vec!["plat-dyn".to_string()],
-        log: None,
-        extra_config: None,
-        profile: None,
-        disable_someboot_build_config: true,
-        args: Vec::new(),
-        pre_build_cmds: Vec::new(),
-        post_build_cmds: Vec::new(),
-        to_bin: true,
-    };
+fn uimage_generation_plan_is_absent_without_companion_its() {
+    let root = tempdir().unwrap();
+    let config = root.path().join("board/foo.toml");
+    fs::create_dir_all(config.parent().unwrap()).unwrap();
+    fs::write(&config, "target = \"riscv64gc-unknown-none-elf\"\n").unwrap();
+    let elf = root.path().join("target/kernel.elf");
 
-    let err = uimage_load_paddr(&cargo, "riscv64").unwrap_err();
-    assert!(err.to_string().contains("ax-config-gen"));
+    assert!(
+        uimage_generation_plan(&config, "riscv64", "riscv64gc-unknown-none-elf", &elf).is_none()
+    );
+}
+
+#[test]
+fn uimage_generation_plan_uses_mkimage_f_for_companion_its() {
+    let root = tempdir().unwrap();
+    let config = root.path().join("board/foo.toml");
+    fs::create_dir_all(config.parent().unwrap()).unwrap();
+    fs::write(&config, "target = \"riscv64gc-unknown-none-elf\"\n").unwrap();
+    fs::write(
+        root.path().join("board/foo.its"),
+        "kernel = \"${kernel_bin}\";\n",
+    )
+    .unwrap();
+    let elf = root.path().join("target/kernel.elf");
+
+    let plan = uimage_generation_plan(&config, "riscv64", "riscv64gc-unknown-none-elf", &elf)
+        .expect("companion ITS should request uImage generation");
+
+    assert_eq!(plan.source_its, root.path().join("board/foo.its"));
+    assert_eq!(
+        plan.rendered_its.parent(),
+        Some(root.path().join("target").as_path())
+    );
+    let rendered_name = plan.rendered_its.file_name().unwrap().to_string_lossy();
+    assert!(rendered_name.starts_with(".kernel.elf.uimage.its."));
+    assert!(rendered_name.ends_with(".tmp"));
+    assert_eq!(plan.kernel_bin, root.path().join("target/kernel.bin"));
+    assert_eq!(plan.output_uimg, root.path().join("target/kernel.uimg"));
+    assert_eq!(
+        mkimage_args_for_its(&plan.rendered_its, &plan.output_uimg),
+        vec![
+            "-f".to_string(),
+            plan.rendered_its.display().to_string(),
+            plan.output_uimg.display().to_string(),
+        ]
+    );
+}
+
+#[test]
+fn render_uimage_its_template_replaces_build_placeholders() {
+    let root = tempdir().unwrap();
+    let template = root.path().join("foo.its");
+    let rendered = root.path().join("rendered.its");
+    let kernel_elf = root.path().join("target/kernel.elf");
+    let kernel_bin = root.path().join("target/kernel.bin");
+    fs::write(
+        &template,
+        "bin=${kernel_bin}\nelf=${kernel_elf}\narch=${arch}\ntarget=${target}\n",
+    )
+    .unwrap();
+
+    render_uimage_its_template(
+        &template,
+        &rendered,
+        &kernel_elf,
+        &kernel_bin,
+        "riscv64",
+        "riscv64gc-unknown-none-elf",
+    )
+    .unwrap();
+
+    let output = fs::read_to_string(rendered).unwrap();
+    assert!(output.contains(&format!("bin={}", kernel_bin.display())));
+    assert!(output.contains(&format!("elf={}", kernel_elf.display())));
+    assert!(output.contains("arch=riscv64"));
+    assert!(output.contains("target=riscv64gc-unknown-none-elf"));
+    assert!(!output.contains("${"));
 }
 
 #[test]
@@ -584,26 +624,4 @@ fn ensure_starry_bin_arg_keeps_existing_bin_arg() {
     ensure_starry_bin_arg(&mut args, STARRY_PACKAGE, &metadata).unwrap();
 
     assert_eq!(args, vec!["--bin".to_string(), "starryos".to_string()]);
-}
-
-#[test]
-fn patch_starry_cargo_config_validates_uimage_without_shell_post_build() {
-    let request = request(
-        PathBuf::from("/tmp/.build.toml"),
-        "riscv64",
-        "riscv64gc-unknown-none-elf",
-    );
-    let mut build_info = default_starry_build_info_for_target(&request.target);
-    build_info.env.insert("UIMAGE".to_string(), "y".to_string());
-    let mut cargo = build_info.into_base_cargo_config_with_log(
-        request.package.clone(),
-        request.target.clone(),
-        StarryBuildInfo::build_cargo_args(&request.target, &[]),
-    );
-    cargo.features.push("plat-dyn".to_string());
-
-    let metadata = crate::build::workspace_metadata().unwrap();
-    patch_starry_cargo_config(&mut cargo, &request, &metadata).unwrap();
-
-    assert!(cargo.post_build_cmds.is_empty());
 }

--- a/scripts/axbuild/src/starry/config.rs
+++ b/scripts/axbuild/src/starry/config.rs
@@ -48,6 +48,23 @@ fn write_board_to_build_config(build_config_path: &Path, board: &Board) -> anyho
             build_config_path.display()
         )
     })?;
+    copy_companion_its(&board.path, build_config_path)?;
+    Ok(())
+}
+
+fn copy_companion_its(src_config: &Path, dst_config: &Path) -> anyhow::Result<()> {
+    let src_its = src_config.with_extension("its");
+    if !src_its.exists() {
+        return Ok(());
+    }
+    let dst_its = dst_config.with_extension("its");
+    fs::copy(&src_its, &dst_its).map_err(|e| {
+        anyhow!(
+            "failed to copy Starry uImage ITS {} to {}: {e}",
+            src_its.display(),
+            dst_its.display()
+        )
+    })?;
     Ok(())
 }
 
@@ -230,6 +247,29 @@ plat_dyn = false
         assert!(err.contains("unknown Starry board `missing`"));
         assert!(err.contains(&board::board_dir(root.path()).unwrap().display().to_string()));
         assert!(err.contains("qemu-aarch64"));
+    }
+
+    #[test]
+    fn write_defconfig_copies_companion_its_with_matching_output_basename() {
+        let root = tempdir().unwrap();
+        write_workspace(root.path());
+        let source = write_board(
+            root.path(),
+            "licheerv-nano-sg2002",
+            r#"
+target = "riscv64gc-unknown-none-elf"
+features = ["sg2002"]
+log = "Info"
+"#,
+        );
+        fs::write(source.with_extension("its"), "ITS_TEMPLATE").unwrap();
+
+        let build_config_path = write_defconfig(root.path(), "licheerv-nano-sg2002").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(build_config_path.with_extension("its")).unwrap(),
+            "ITS_TEMPLATE"
+        );
     }
 
     #[test]

--- a/scripts/axbuild/src/starry/quick_start.rs
+++ b/scripts/axbuild/src/starry/quick_start.rs
@@ -264,11 +264,32 @@ fn copy_template(src: &Path, dst: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn copy_build_template(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    copy_template(src, dst)?;
+    copy_companion_its(src, dst)
+}
+
+fn copy_companion_its(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    let src_its = src.with_extension("its");
+    if !src_its.exists() {
+        return Ok(());
+    }
+    let dst_its = dst.with_extension("its");
+    fs::copy(&src_its, &dst_its).with_context(|| {
+        format!(
+            "failed to copy {} to {}",
+            src_its.display(),
+            dst_its.display()
+        )
+    })?;
+    Ok(())
+}
+
 pub fn refresh_qemu_build_config(
     workspace_root: &Path,
     platform: QuickQemuPlatform,
 ) -> anyhow::Result<()> {
-    copy_template(
+    copy_build_template(
         &qemu_build_config_path(workspace_root, platform),
         &tmp_qemu_build_config_path(workspace_root, platform),
     )?;
@@ -287,7 +308,7 @@ pub fn ensure_qemu_build_config(
 }
 
 pub fn refresh_orangepi_configs(workspace_root: &Path) -> anyhow::Result<()> {
-    copy_template(
+    copy_build_template(
         &orangepi_build_config_path(workspace_root),
         &tmp_orangepi_build_config_path(workspace_root),
     )?;
@@ -299,7 +320,7 @@ pub fn refresh_orangepi_configs(workspace_root: &Path) -> anyhow::Result<()> {
 }
 
 pub fn refresh_sg2002_config(workspace_root: &Path) -> anyhow::Result<()> {
-    copy_template(
+    copy_build_template(
         &sg2002_build_config_path(workspace_root),
         &tmp_sg2002_build_config_path(workspace_root),
     )?;
@@ -313,7 +334,7 @@ pub fn refresh_sg2002_config(workspace_root: &Path) -> anyhow::Result<()> {
 pub fn ensure_sg2002_config(workspace_root: &Path) -> anyhow::Result<()> {
     let build_cfg = tmp_sg2002_build_config_path(workspace_root);
     if !build_cfg.exists() {
-        copy_template(&sg2002_build_config_path(workspace_root), &build_cfg)?;
+        copy_build_template(&sg2002_build_config_path(workspace_root), &build_cfg)?;
     }
     let run_cfg = tmp_sg2002_uboot_config_path(workspace_root);
     if !run_cfg.exists() {
@@ -326,7 +347,7 @@ pub fn ensure_orangepi_configs(workspace_root: &Path) -> anyhow::Result<()> {
     let build_cfg = tmp_orangepi_build_config_path(workspace_root);
     let run_cfg = tmp_orangepi_uboot_config_path(workspace_root);
     if !build_cfg.exists() {
-        copy_template(&orangepi_build_config_path(workspace_root), &build_cfg)?;
+        copy_build_template(&orangepi_build_config_path(workspace_root), &build_cfg)?;
     }
     if !run_cfg.exists() {
         copy_template(&orangepi_uboot_config_path(workspace_root), &run_cfg)?;
@@ -477,6 +498,17 @@ mod tests {
         .unwrap();
     }
 
+    fn write_sg2002_build_template(root: &Path) {
+        let path = sg2002_build_config_path(root);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "target = \"riscv64gc-unknown-none-elf\"\nfeatures = [\"sg2002\"]\nlog = \"Info\"\n",
+        )
+        .unwrap();
+        fs::write(path.with_extension("its"), "ITS_TEMPLATE").unwrap();
+    }
+
     #[test]
     fn prepare_orangepi_uboot_config_keeps_existing_tmp_without_overrides() {
         let root = tempdir().unwrap();
@@ -555,5 +587,35 @@ mod tests {
         assert_eq!(value["kernel_load_addr"].as_str(), Some("0x80200000"));
         assert_eq!(value["fit_load_addr"].as_str(), Some("0x82200000"));
         assert_eq!(value["dtb_file"].as_str(), Some("sg2002.dtb"));
+    }
+
+    #[test]
+    fn refresh_sg2002_config_copies_companion_its() {
+        let root = tempdir().unwrap();
+        write_sg2002_build_template(root.path());
+        write_sg2002_uboot_template(root.path());
+
+        refresh_sg2002_config(root.path()).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(tmp_sg2002_build_config_path(root.path()).with_extension("its"))
+                .unwrap(),
+            "ITS_TEMPLATE"
+        );
+    }
+
+    #[test]
+    fn ensure_sg2002_config_copies_companion_its_for_missing_tmp_build_config() {
+        let root = tempdir().unwrap();
+        write_sg2002_build_template(root.path());
+        write_sg2002_uboot_template(root.path());
+
+        ensure_sg2002_config(root.path()).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(tmp_sg2002_build_config_path(root.path()).with_extension("its"))
+                .unwrap(),
+            "ITS_TEMPLATE"
+        );
     }
 }


### PR DESCRIPTION
## 背景

StarryOS SG2002 构建此前通过 `env = { UIMAGE = "y" }` 触发 uImage 生成，构建逻辑里还内置了架构映射和加载地址等历史分支。这个开关不够直观，也让板卡 uImage 配置和构建配置耦合在 TOML 环境变量中。

## 修改内容

- 将 StarryOS uImage 触发方式改为同目录同名 `.its` 模板：例如 `foo.toml` 存在对应 `foo.its` 时，`cargo starry build --config foo.toml` 会同时生成 `kernel.uimg`。
- 构建时渲染 ITS 模板，支持 `${kernel_bin}`、`${kernel_elf}`、`${arch}`、`${target}` 占位符，并通过 `mkimage -f <rendered.its> <kernel.uimg>` 生成 uImage。
- 移除 `UIMAGE=y` 相关检查、内置 uImage 架构和加载地址推导逻辑。
- 为 SG2002 与 SG2002 Wi-Fi 添加 ITS 模板，并从对应 TOML 中移除 `env = { UIMAGE = "y" }`。
- `defconfig` 与 quick-start 复制板卡 TOML 时同步复制并重命名 companion ITS。
- 更新 StarryOS 快速上手文档，推荐 `cargo starry config ls` 查看支持板卡、`cargo starry defconfig <board>` 选择配置，后续使用 `cargo starry build`、`cargo starry board` 等常规命令；`quick-start` 标记为旧版兼容入口。

## 验证

- `cargo fmt`
- `cargo test -p axbuild starry::build::tests`
- `cargo test -p axbuild starry::config::tests`
- `cargo test -p axbuild starry::quick_start::tests`
- `cargo xtask clippy --package axbuild`
- `git diff --check`
- 使用 SG2002 ITS 模板和 dummy kernel 执行 `mkimage -f` / `mkimage -l` 冒烟验证
