### PR TITLE
chore(ci): trigger baseline CI run on clean dev

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,4 @@
+// CI baseline check: trigger full CI on clean dev to isolate a flaky board job.
 #![cfg_attr(not(any(windows, unix)), no_main)]
 #![cfg_attr(not(any(windows, unix)), no_std)]
 


### PR DESCRIPTION
No functional change — a comment in the host-only xtask entrypoint to run full CI on an unmodified dev tree, isolating whether the phytiumpi axvisor board timeout is a flaky board job rather than a regression.