### PR TITLE
feat(ax-driver): add VisionFive2 dynamic rtc and mmc

### DIFF
--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -39,6 +39,12 @@ Use this order when auditing an early boot port:
 9. Per-CPU data and secondary boot stacks are allocated and initialized.
 10. Secondary CPU release happens only after boot arguments and page tables are visible to other CPUs.
 
+## RISC-V FDT SMP Notes
+
+- Enumerate only CPU nodes that firmware marks available. A missing `status` property is usable, `status = "okay"`/`"ok"` is usable, and `status = "disabled"` must be skipped.
+- Keep FDT `reg` hart IDs as firmware CPU IDs and map them onto dense logical CPU IDs separately. On VisionFive2, `cpu@0` is a disabled S7 management hart while the usable U74 cores are `cpu@1` through `cpu@4`; full-core boot should therefore start from hart 1 and bring up harts 2-4, not fall back to single-core mode.
+- If a RISC-V board traps when secondaries are released, dump `/cpus` from the boot FDT before changing `max_cpu_num`; disabled or non-OS CPU nodes are a common cause of `cpu_on` targeting the wrong hart.
+
 ## LoongArch Lessons
 
 - TLB refill entry and general exception entry use different registers and may require different address forms. Do not reuse a high-half virtual symbol where a physical TLB refill vector is required.

--- a/components/someboot/src/fdt/mod.rs
+++ b/components/someboot/src/fdt/mod.rs
@@ -71,17 +71,109 @@ pub(crate) fn save_fdt() {
     }
 }
 
-fn cpu_nodes() -> Option<impl Iterator<Item = fdt_raw::Node<'static>>> {
-    let fdt = fdt_base()?;
-    let iter = fdt.find_children_by_path("/cpus");
-    Some(iter.filter(|n| n.name().starts_with("cpu@")))
+fn cpu_nodes_from_fdt<'a>(fdt: fdt_raw::Fdt<'a>) -> impl Iterator<Item = fdt_raw::Node<'a>> + 'a {
+    fdt.find_children_by_path("/cpus")
+        .filter(|node| is_cpu_node_available(node))
+}
+
+fn cpu_id_list_from_fdt<'a>(fdt: fdt_raw::Fdt<'a>) -> impl Iterator<Item = usize> + 'a {
+    cpu_nodes_from_fdt(fdt).filter_map(|node| {
+        node.reg()
+            .and_then(|mut regs| regs.next())
+            .map(|reg| reg.address as usize)
+    })
 }
 
 pub fn cpu_id_list() -> Option<impl Iterator<Item = usize>> {
-    Some(cpu_nodes()?.map(|node| {
-        node.reg()
-            .and_then(|mut r| r.next())
-            .map(|reg| reg.address as usize)
-            .unwrap_or(0)
-    }))
+    Some(cpu_id_list_from_fdt(fdt_base()?))
+}
+
+fn is_cpu_node_available(node: &fdt_raw::Node<'_>) -> bool {
+    node.name().starts_with("cpu@")
+        && matches!(node.find_property_str("device_type"), None | Some("cpu"))
+        && matches!(
+            node.find_property_str("status"),
+            None | Some("okay") | Some("ok")
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, vec::Vec};
+
+    use fdt_edit::{Fdt, Node, NodeId, Property};
+
+    use super::*;
+
+    #[test]
+    fn cpu_id_list_skips_disabled_cpu_nodes() {
+        let fdt = minimal_cpu_fdt();
+        let fdt_data = fdt.encode();
+        let raw = fdt_raw::Fdt::from_bytes(fdt_data.as_ref()).expect("parse test fdt");
+
+        let cpu_ids: Vec<_> = cpu_id_list_from_fdt(raw).collect();
+
+        assert_eq!(cpu_ids.as_slice(), &[1, 2, 3, 4]);
+    }
+
+    fn minimal_cpu_fdt() -> Fdt {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        let cpus = fdt.add_node(root, Node::new("cpus"));
+        fdt.node_mut(cpus)
+            .unwrap()
+            .set_property(prop_u32s("#address-cells", &[1]));
+        fdt.node_mut(cpus)
+            .unwrap()
+            .set_property(prop_u32s("#size-cells", &[0]));
+
+        add_cpu(&mut fdt, cpus, 0, Some("disabled"), true);
+        add_cpu(&mut fdt, cpus, 1, None, true);
+        add_cpu(&mut fdt, cpus, 2, Some("okay"), true);
+        add_cpu(&mut fdt, cpus, 3, Some("ok"), true);
+        add_cpu(&mut fdt, cpus, 4, None, true);
+        add_cpu(&mut fdt, cpus, 5, None, false);
+        fdt
+    }
+
+    fn add_cpu(fdt: &mut Fdt, parent: NodeId, hart_id: u32, status: Option<&str>, with_reg: bool) {
+        let cpu = fdt.add_node(parent, Node::new(&format!("cpu@{hart_id}")));
+        fdt.node_mut(cpu)
+            .unwrap()
+            .set_property(prop_str("device_type", "cpu"));
+        fdt.node_mut(cpu)
+            .unwrap()
+            .set_property(prop_strs("compatible", &["riscv"]));
+        if with_reg {
+            fdt.node_mut(cpu)
+                .unwrap()
+                .set_property(prop_u32s("reg", &[hart_id]));
+        }
+        if let Some(status) = status {
+            fdt.node_mut(cpu)
+                .unwrap()
+                .set_property(prop_str("status", status));
+        }
+    }
+
+    fn prop_u32s(name: &str, values: &[u32]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        Property::new(name, data)
+    }
+
+    fn prop_str(name: &str, value: &str) -> Property {
+        prop_strs(name, &[value])
+    }
+
+    fn prop_strs(name: &str, values: &[&str]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(value.as_bytes());
+            data.push(0);
+        }
+        Property::new(name, data)
+    }
 }

--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -101,6 +101,13 @@ rockchip-dwmmc = [
     "dep:sdmmc-protocol",
     "sdmmc-protocol/sdio",
 ]
+starfive-jh7110-dwmmc = [
+    "block",
+    "plat-dyn",
+    "dep:dwmmc-host",
+    "dep:sdmmc-protocol",
+    "sdmmc-protocol/sdio",
+]
 rk3588-pcie = [
     "pci",
     "plat-dyn",

--- a/drivers/ax-driver/src/block/mod.rs
+++ b/drivers/ax-driver/src/block/mod.rs
@@ -4,7 +4,8 @@ mod binding;
     feature = "k230-sdhci",
     feature = "phytium-mci",
     feature = "rockchip-dwmmc",
-    feature = "rockchip-sdhci"
+    feature = "rockchip-sdhci",
+    feature = "starfive-jh7110-dwmmc"
 ))]
 pub(crate) mod sdmmc;
 #[allow(unused)]
@@ -30,6 +31,8 @@ mod rockchip;
 pub mod rockchip_mmc;
 #[cfg(feature = "rockchip-dwmmc")]
 pub mod rockchip_sd;
+#[cfg(feature = "starfive-jh7110-dwmmc")]
+pub mod starfive_mmc;
 
 #[cfg(sync_block_dev)]
 use alloc::{boxed::Box, sync::Arc};

--- a/drivers/ax-driver/src/block/sdmmc.rs
+++ b/drivers/ax-driver/src/block/sdmmc.rs
@@ -48,7 +48,12 @@ impl SdmmcBlockConfig {
         }
     }
 
-    #[cfg(any(feature = "rockchip-sdhci", feature = "phytium-mci", test))]
+    #[cfg(any(
+        feature = "rockchip-sdhci",
+        feature = "phytium-mci",
+        feature = "starfive-jh7110-dwmmc",
+        test
+    ))]
     pub(crate) fn fifo(name: &'static str, capacity_blocks: u64, irq_driven: bool) -> Self {
         Self {
             name,
@@ -608,7 +613,7 @@ pub(crate) fn submit_sdhci_write_request(
     Ok(BlockRequestId::new(usize::from(id)))
 }
 
-#[cfg(feature = "rockchip-dwmmc")]
+#[cfg(any(feature = "rockchip-dwmmc", feature = "starfive-jh7110-dwmmc"))]
 impl SdmmcBlockHost for dwmmc_host::DwMmc {
     type Request = dwmmc_host::BlockRequest;
     type Slot = dwmmc_host::BlockRequestSlot;

--- a/drivers/ax-driver/src/block/shared.rs
+++ b/drivers/ax-driver/src/block/shared.rs
@@ -44,7 +44,8 @@ impl<T> SharedDriver<T> {
         feature = "k230-sdhci",
         feature = "phytium-mci",
         feature = "rockchip-dwmmc",
-        feature = "rockchip-sdhci"
+        feature = "rockchip-sdhci",
+        feature = "starfive-jh7110-dwmmc"
     ))]
     pub(crate) fn try_with_mut<R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R> {
         let mut guard = self.inner.try_enter()?;

--- a/drivers/ax-driver/src/block/starfive_mmc.rs
+++ b/drivers/ax-driver/src/block/starfive_mmc.rs
@@ -1,0 +1,173 @@
+use alloc::format;
+use core::time::Duration;
+
+use dwmmc_host::DwMmc;
+use log::{info, warn};
+use rdrive::{
+    probe::OnProbeError,
+    register::{FdtInfo, ProbeFdt},
+};
+use sdmmc_protocol::{
+    Error, OperationPoll,
+    error::Phase,
+    sdio::{CardInfo, SdioInitScratch, SdioSdmmc},
+};
+
+use crate::{
+    block::{
+        ProbeFdtBlock, SharedDriver,
+        sdmmc::{SdmmcBlockConfig, SdmmcBlockDevice},
+    },
+    mmio::iomap,
+};
+
+const STARFIVE_JH7110_MMC1_BASE: u64 = 0x1602_0000;
+const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
+
+type StarFiveDwMmc = SdioSdmmc<DwMmc>;
+
+crate::model_register!(
+    name: "StarFive JH7110 MMC",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["starfive,jh7110-mmc"],
+            on_probe: probe
+        }
+    ],
+);
+
+fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let info = probe.info();
+    let base_reg = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or(OnProbeError::other(format!(
+            "[{}] has no reg",
+            info.node.name()
+        )))?;
+
+    let address = base_reg.address;
+    let mmio_size = base_reg.size.unwrap_or(0x1000);
+    if address != STARFIVE_JH7110_MMC1_BASE {
+        info!(
+            "starfive-jh7110-dwmmc: skipping non-microSD controller {} at {:#x}",
+            info.node.name(),
+            address
+        );
+        return Err(OnProbeError::NotMatch);
+    }
+
+    info!(
+        "starfive-jh7110-dwmmc probe: node={}, addr={:#x}, size={:#x}",
+        info.node.name(),
+        address,
+        mmio_size
+    );
+    let mmio_base = iomap(address as usize, mmio_size as usize)?;
+
+    let mut host = unsafe { DwMmc::new(mmio_base) };
+    host.set_reference_clock(reference_clock(info));
+
+    info!("starfive-jh7110-dwmmc: reset controller");
+    host.reset_and_init()
+        .map_err(|err| init_error(address, mmio_size, err))?;
+
+    info!("starfive-jh7110-dwmmc: initialize card");
+    let mut sd = SdioSdmmc::new(host);
+    sd.set_sd_speed_selection_enabled(false);
+    let card_info = poll_card_init(&mut sd).map_err(|err| {
+        warn!("starfive-jh7110-dwmmc: card init failed: {:?}", err);
+        card_init_error(address, mmio_size, err)
+    })?;
+    info!(
+        "starfive-jh7110-dwmmc card: kind={:?} high_capacity={} rca={} ocr={:#010x} \
+         capacity_blocks={:?} cid={} ext_csd={}",
+        card_info.kind,
+        card_info.high_capacity,
+        card_info.rca,
+        card_info.ocr,
+        card_info.capacity_blocks,
+        card_info.cid.is_some(),
+        card_info.ext_csd.is_some()
+    );
+
+    let raw = SharedDriver::new(sd);
+    let dev = SdmmcBlockDevice::new(
+        raw,
+        SdmmcBlockConfig::fifo(
+            "starfive-jh7110-mmc",
+            card_info.capacity_blocks.unwrap_or(0),
+            false,
+        ),
+    );
+    let irq = probe.register_block(dev)?;
+    info!("starfive-jh7110-mmc block device registered irq={:?}", irq);
+    Ok(())
+}
+
+fn reference_clock(info: &FdtInfo<'_>) -> u32 {
+    let clock = info
+        .find_clk_by_name("ciu")
+        .map(|clk| clk.select().unwrap_or(0));
+    info!(
+        "starfive-jh7110-dwmmc: using {} Hz ciu reference clock hint {:?}",
+        DWMMC_STABLE_REFERENCE_CLOCK, clock
+    );
+    DWMMC_STABLE_REFERENCE_CLOCK
+}
+
+fn poll_card_init(sd: &mut StarFiveDwMmc) -> Result<CardInfo, Error> {
+    let mut scratch = SdioInitScratch::new();
+    let mut request = sd.submit_init(&mut scratch)?;
+    loop {
+        match sd.poll_init_request(&mut request)? {
+            OperationPoll::Pending => {
+                if request.take_needs_pace() {
+                    axklib::time::busy_wait(Duration::from_millis(10));
+                } else {
+                    core::hint::spin_loop();
+                }
+            }
+            OperationPoll::Complete(info) => return Ok(info),
+            _ => return Err(Error::UnsupportedCommand),
+        }
+    }
+}
+
+fn init_error(address: u64, size: u64, err: Error) -> OnProbeError {
+    OnProbeError::other(format!(
+        "failed to initialize StarFive JH7110 DWMMC device at [PA:{:?}, SZ:0x{:x}): {err:?}",
+        address, size
+    ))
+}
+
+fn card_init_error(address: u64, size: u64, err: Error) -> OnProbeError {
+    if is_absent_card_init_error(err) {
+        warn!(
+            "starfive-jh7110-dwmmc: no responsive card at [PA:{:?}, SZ:0x{:x}); skipping \
+             controller: {err:?}",
+            address, size
+        );
+        return OnProbeError::NotMatch;
+    }
+
+    init_error(address, size, err)
+}
+
+fn is_absent_card_init_error(err: Error) -> bool {
+    match err {
+        Error::NoCard => true,
+        Error::Timeout(ctx) | Error::Crc(ctx) | Error::BadResponse(ctx) => {
+            ctx.cmd.is_some()
+                && matches!(
+                    ctx.phase,
+                    Phase::CommandSend | Phase::ResponseWait | Phase::Init
+                )
+        }
+        _ => false,
+    }
+}

--- a/drivers/ax-driver/src/time/mod.rs
+++ b/drivers/ax-driver/src/time/mod.rs
@@ -5,7 +5,12 @@ use rdrive::probe::OnProbeError;
 mod cmos;
 #[cfg(any(test, target_arch = "x86_64"))]
 mod cmos_decode;
-#[cfg(any(test, target_arch = "loongarch64", target_arch = "x86_64"))]
+#[cfg(any(
+    test,
+    target_arch = "loongarch64",
+    target_arch = "riscv64",
+    target_arch = "x86_64"
+))]
 mod datetime;
 #[cfg(any(
     target_arch = "aarch64",
@@ -21,6 +26,10 @@ mod loongson;
 mod loongson_decode;
 #[cfg(target_arch = "aarch64")]
 mod pl031;
+#[cfg(target_arch = "riscv64")]
+mod starfive;
+#[cfg(any(test, target_arch = "riscv64"))]
+mod starfive_decode;
 
 fn init_epoch_offset(node_name: &str, unix_timestamp: u64) -> Result<(), OnProbeError> {
     if unix_timestamp == 0 {

--- a/drivers/ax-driver/src/time/starfive.rs
+++ b/drivers/ax-driver/src/time/starfive.rs
@@ -1,0 +1,43 @@
+use core::ptr::read_volatile;
+
+use rdrive::probe::OnProbeError;
+
+use super::{
+    fdt::{FdtProbe, map_first_reg},
+    init_epoch_offset,
+    starfive_decode::decode_rtc_datetime,
+};
+
+const RTC_TIME_OFFSET: usize = 0x3c;
+const RTC_DATE_OFFSET: usize = 0x40;
+
+crate::model_register!(
+    name: "StarFive JH7110 RTC",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["starfive,jh7110-rtc"],
+            on_probe: probe
+        }
+    ],
+);
+
+fn probe(probe: FdtProbe<'_>) -> Result<(), OnProbeError> {
+    let info = probe.info();
+    let mmio_base = map_first_reg(info)?;
+    let unix_timestamp = read_unix_timestamp(info.node.name(), mmio_base.as_ptr())?;
+    init_epoch_offset(info.node.name(), unix_timestamp)
+}
+
+fn read_unix_timestamp(node_name: &str, base: *mut u8) -> Result<u64, OnProbeError> {
+    let time_reg = unsafe { read_volatile(base.add(RTC_TIME_OFFSET).cast::<u32>()) };
+    let date_reg = unsafe { read_volatile(base.add(RTC_DATE_OFFSET).cast::<u32>()) };
+
+    decode_rtc_datetime(time_reg, date_reg).ok_or_else(|| {
+        OnProbeError::other(alloc::format!(
+            "[{node_name}] has invalid RTC time/date registers: time={time_reg:#010x}, \
+             date={date_reg:#010x}"
+        ))
+    })
+}

--- a/drivers/ax-driver/src/time/starfive_decode.rs
+++ b/drivers/ax-driver/src/time/starfive_decode.rs
@@ -1,0 +1,75 @@
+use super::datetime::datetime_to_unix_timestamp;
+
+const RTC_SEC_SHIFT: u32 = 0;
+const RTC_SEC_MASK: u32 = 0x7f;
+const RTC_MIN_SHIFT: u32 = 7;
+const RTC_MIN_MASK: u32 = 0x7f;
+const RTC_HOUR_SHIFT: u32 = 14;
+const RTC_HOUR_MASK: u32 = 0x7f;
+const RTC_DAY_SHIFT: u32 = 0;
+const RTC_DAY_MASK: u32 = 0x3f;
+const RTC_MONTH_SHIFT: u32 = 6;
+const RTC_MONTH_MASK: u32 = 0x1f;
+const RTC_YEAR_SHIFT: u32 = 11;
+const RTC_YEAR_MASK: u32 = 0xff;
+
+pub(super) fn decode_rtc_datetime(time_reg: u32, date_reg: u32) -> Option<u64> {
+    let second = (time_reg >> RTC_SEC_SHIFT) & RTC_SEC_MASK;
+    let minute = (time_reg >> RTC_MIN_SHIFT) & RTC_MIN_MASK;
+    let hour = (time_reg >> RTC_HOUR_SHIFT) & RTC_HOUR_MASK;
+    let day = (date_reg >> RTC_DAY_SHIFT) & RTC_DAY_MASK;
+    let month = (date_reg >> RTC_MONTH_SHIFT) & RTC_MONTH_MASK;
+    let year_since_2000 = (date_reg >> RTC_YEAR_SHIFT) & RTC_YEAR_MASK;
+
+    if !(1..=99).contains(&year_since_2000) {
+        return None;
+    }
+
+    let year = 2000 + year_since_2000 as i32;
+    datetime_to_unix_timestamp(year, month, day, hour, minute, second)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_rtc_datetime;
+
+    fn time_reg(hour: u32, minute: u32, second: u32) -> u32 {
+        second | (minute << 7) | (hour << 14)
+    }
+
+    fn date_reg(year_since_2000: u32, month: u32, day: u32) -> u32 {
+        day | (month << 6) | (year_since_2000 << 11)
+    }
+
+    #[test]
+    fn decodes_valid_wall_clock() {
+        assert_eq!(
+            decode_rtc_datetime(time_reg(8, 34, 56), date_reg(25, 6, 12)),
+            Some(1_749_717_296)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_month_and_day() {
+        assert_eq!(
+            decode_rtc_datetime(time_reg(8, 34, 56), date_reg(25, 13, 12)),
+            None
+        );
+        assert_eq!(
+            decode_rtc_datetime(time_reg(8, 34, 56), date_reg(25, 2, 30)),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_years_outside_jh7110_range() {
+        assert_eq!(
+            decode_rtc_datetime(time_reg(8, 34, 56), date_reg(0, 6, 12)),
+            None
+        );
+        assert_eq!(
+            decode_rtc_datetime(time_reg(8, 34, 56), date_reg(100, 6, 12)),
+            None
+        );
+    }
+}

--- a/os/StarryOS/configs/board/visionfive2-board.toml
+++ b/os/StarryOS/configs/board/visionfive2-board.toml
@@ -1,11 +1,12 @@
 # Remote VisionFive2 runtime config. The build config is visionfive2.toml.
 board_type = "VisionFive2"
-# Current smoke frontier: dynamic boot reaches root-device discovery before
-# JH7110 block/rootfs support is available.
-success_regex = ["failed to determine root device from available block devices"]
+shell_prefix = "root@starry:"
+shell_init_cmd = "echo STARRY_VISIONFIVE2_SHELL_OK"
+success_regex = ["(?m)^STARRY_VISIONFIVE2_SHELL_OK\\s*$"]
 fail_regex = [
   "(?i)segmentation fault",
   "(?i)SIGSEGV",
   "exit with code: 139",
+  "failed to determine root device from available block devices",
 ]
 timeout = 600

--- a/os/StarryOS/configs/board/visionfive2.toml
+++ b/os/StarryOS/configs/board/visionfive2.toml
@@ -1,6 +1,9 @@
 # Build-time config template for StarryOS on VisionFive2.
 target = "riscv64gc-unknown-none-elf"
 features = [
+  "ax-feat/rtc",
+  "ax-driver/rtc",
   "ax-driver/serial",
+  "ax-driver/starfive-jh7110-dwmmc",
 ]
 log = "Info"

--- a/test-suit/starryos/board-visionfive2/boot/board-visionfive2.toml
+++ b/test-suit/starryos/board-visionfive2/boot/board-visionfive2.toml
@@ -1,10 +1,11 @@
 board_type = "VisionFive2"
-# Current smoke frontier: dynamic boot reaches root-device discovery before
-# JH7110 block/rootfs support is available.
-success_regex = ["failed to determine root device from available block devices"]
+shell_prefix = "root@starry:"
+shell_init_cmd = "echo STARRY_VISIONFIVE2_SHELL_OK"
+success_regex = ["(?m)^STARRY_VISIONFIVE2_SHELL_OK\\s*$"]
 fail_regex = [
   "(?i)segmentation fault",
   "(?i)SIGSEGV",
   "exit with code: 139",
+  "failed to determine root device from available block devices",
 ]
 timeout = 600

--- a/test-suit/starryos/board-visionfive2/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/board-visionfive2/build-riscv64gc-unknown-none-elf.toml
@@ -1,6 +1,9 @@
 # Build-time config template for StarryOS on VisionFive2.
 target = "riscv64gc-unknown-none-elf"
 features = [
+  "ax-feat/rtc",
+  "ax-driver/rtc",
   "ax-driver/serial",
+  "ax-driver/starfive-jh7110-dwmmc",
 ]
 log = "Info"


### PR DESCRIPTION
## 问题

VisionFive2 动态平台此前只能探测串口，StarryOS 无法通过 FDT 动态发现 JH7110 RTC/MMC，也无法从板载 MMC rootfs 完整启动到 shell。直接按动态平台路径启动会停在 root device 选择之前；同时 VisionFive2 FDT 中 `cpu@0` 是 disabled 的 S7 管理核，如果不处理会在全核启动时误尝试启动 hart0。

## 修改内容

- 在 `ax-driver` 增加 `starfive,jh7110-rtc` 动态 probe，读取 JH7110 RTC `TIME`/`DATE` 寄存器并初始化 wall-clock epoch；日期解码拆成纯函数并补充单测。
- 在 `ax-driver` 增加 `starfive-jh7110-dwmmc` feature 和 `starfive,jh7110-mmc` block probe，基于现有 `dwmmc-host`、`sdmmc-protocol` 和 `SdmmcBlockDevice`，首版使用 FIFO/polling，优先支持 `mmc@16020000` microSD。
- 修正 someboot 的 RISC-V FDT CPU 枚举：跳过 disabled CPU node，避免 VisionFive2 的 S7 hart0 参与 StarryOS SMP bring-up，保留 U74 harts 全核启动。
- 适配最新 `dev` 的 Starry tty 串口框架：不改 someboot 串口路径，不引入 early `alloc`/`Box`；Starry 运行期由 `/dev/console` 绑定到动态探测出的 `ttyS0`。
- 更新 VisionFive2 Starry build/test 配置，启用 RTC、serial、JH7110 DWMMC，并把板测成功判据改为 shell marker `STARRY_VISIONFIVE2_SHELL_OK`。
- 更新架构移植调试文档，记录 RISC-V FDT SMP 枚举不要用 `max_cpu_num = 1` 规避 disabled hart 的约束。

## 方案说明

MMC 首版刻意保持保守：依赖 U-Boot/OpenSBI 预初始化 clock/reset，使用 DW-MMC FIFO/polling 路径，暂不引入 StarFive clock/reset/IRQ/IDMAC glue。RTC 只负责读当前时间初始化 epoch，不实现 alarm、set time 和 IRQ；本次实板上 RTC 寄存器为 0 时会降级跳过，不影响 MMC rootfs 和 shell 验收。这样先把 VisionFive2 动态平台的 rootfs 和 shell 启动路径打通，后续可在需要时再补完整 SoC clock/reset glue。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package ax-driver`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask clippy --package starryos`
- `cargo xtask clippy --package someboot`
- `cargo test -p ax-driver --features rtc --lib starfive_decode`
- `cargo test -p someboot --lib`
- `cargo xtask starry build --arch riscv64 --config os/StarryOS/configs/board/visionfive2.toml`
- `cargo xtask starry test board --board visionfive2`

物理板验证中确认：

- `smp = 4`
- CPU hard id 为 `0x1..0x4`，未启动 disabled hart0
- `Secondary CPU 1/2/3 init OK`
- `/dev/console bound to ttyS0`
- `starfive-jh7110-mmc` 成功注册并挂载 ext4 rootfs
- shell 中成功输出并匹配 `STARRY_VISIONFIVE2_SHELL_OK`