### PR TITLE
fix(ax-task): force reschedule on remote IPI kick

### DIFF
--- a/components/axsched/src/tests.rs
+++ b/components/axsched/src/tests.rs
@@ -83,3 +83,32 @@ macro_rules! def_test_sched {
 def_test_sched!(fifo, FifoScheduler::<usize>, FifoTask::<usize>);
 def_test_sched!(rr, RRScheduler::<usize, 5>, RRTask::<usize, 5>);
 def_test_sched!(cfs, CFScheduler::<usize>, CFSTask::<usize>);
+
+#[test]
+fn rr_preempt_preserves_slice_but_forced_reschedule_rotates() {
+    use alloc::sync::Arc;
+
+    use crate::{BaseScheduler, RRScheduler, RRTask};
+
+    let mut scheduler = RRScheduler::<usize, 5>::new();
+    let current = Arc::new(RRTask::<usize, 5>::new(0));
+    let remote = Arc::new(RRTask::<usize, 5>::new(1));
+    scheduler.add_task(remote.clone());
+    scheduler.put_prev_task(current.clone(), true);
+    assert_eq!(
+        *scheduler.pick_next_task().unwrap().inner(),
+        0,
+        "ordinary RR preemption preserves the current task's remaining slice",
+    );
+
+    let mut scheduler = RRScheduler::<usize, 5>::new();
+    let current = Arc::new(RRTask::<usize, 5>::new(0));
+    let remote = Arc::new(RRTask::<usize, 5>::new(1));
+    scheduler.add_task(remote);
+    scheduler.put_prev_task(current, false);
+    assert_eq!(
+        *scheduler.pick_next_task().unwrap().inner(),
+        1,
+        "forced remote reschedule must rotate the current task behind queued work",
+    );
+}

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -218,12 +218,15 @@ fn kick_remote_cpu(cpu_id: usize) {
 mod tests {
     use core::sync::atomic::Ordering;
 
+    // Host-test mode collapses per-CPU state into process-global statics, so
+    // keep the shared pending/count assertions in one test.
     #[test]
-    fn remote_cpu_kick_requests_reschedule() {
+    fn remote_reschedule_request_is_coalesced_and_forced() {
         const REMOTE_CPU: usize = 1;
 
         super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);
         super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
+
         super::kick_remote_cpu(REMOTE_CPU);
 
         assert_eq!(
@@ -231,15 +234,6 @@ mod tests {
             1,
             "remote CPU kicks must enqueue a scheduler-visible reschedule request",
         );
-    }
-
-    #[test]
-    fn remote_cpu_kick_coalesces_reschedule_request() {
-        const REMOTE_CPU: usize = 1;
-
-        super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);
-        super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
-        super::kick_remote_cpu(REMOTE_CPU);
         super::kick_remote_cpu(REMOTE_CPU);
 
         assert_eq!(
@@ -247,23 +241,17 @@ mod tests {
             1,
             "remote CPU kicks should coalesce identical pending reschedule requests",
         );
-    }
 
-    #[test]
-    fn remote_reschedule_callback_without_deferred_request_clears_pending() {
-        super::REMOTE_RESCHEDULE_PENDING.store(true, Ordering::Release);
+        super::clear_remote_reschedule_pending_for_current_cpu();
+        super::kick_remote_cpu(REMOTE_CPU);
 
-        super::request_current_reschedule();
-
-        assert!(
-            !super::REMOTE_RESCHEDULE_PENDING.load(Ordering::Acquire),
-            "callbacks that cannot defer a reschedule must clear the coalescing bit",
+        assert_eq!(
+            super::REMOTE_RESCHEDULE_REQUESTS.load(Ordering::Acquire),
+            2,
+            "remote CPU kicks must be accepted again after the pending bit is cleared",
         );
-    }
 
-    #[cfg(feature = "preempt")]
-    #[test]
-    fn remote_reschedule_callback_requests_forced_reschedule() {
+        #[cfg(feature = "preempt")]
         crate::tests::run_in_test_scheduler(|| {
             let curr = crate::current();
 
@@ -280,7 +268,13 @@ mod tests {
                 !curr.preempt_pending_for_test(),
                 "remote IPI reschedule must not rely on ordinary RR preemption",
             );
+
+            curr.set_force_resched_pending(false);
+            curr.set_preempt_pending(false);
         });
+
+        super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
+        super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);
     }
 }
 

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -2,6 +2,8 @@ use alloc::{collections::VecDeque, sync::Arc};
 use core::mem::MaybeUninit;
 #[cfg(feature = "smp")]
 use core::ptr::NonNull;
+#[cfg(all(feature = "smp", feature = "ipi"))]
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use ax_hal::percpu::this_cpu_id;
 use ax_kernel_guard::BaseGuard;
@@ -148,12 +150,137 @@ fn get_run_queue(index: usize) -> &'static mut AxRunQueue {
 }
 
 #[cfg(all(feature = "smp", feature = "ipi"))]
+#[cfg_attr(all(test, feature = "host-test"), allow(dead_code))]
+fn request_current_reschedule() {
+    #[cfg(feature = "preempt")]
+    if let Some(curr) = crate::current_may_uninit() {
+        curr.set_force_resched_pending(true);
+        return;
+    }
+    clear_remote_reschedule_pending_for_current_cpu();
+}
+
+#[cfg(all(test, feature = "smp", feature = "ipi", feature = "host-test"))]
+static REMOTE_RESCHEDULE_REQUESTS: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(all(
+    feature = "smp",
+    feature = "ipi",
+    not(all(test, feature = "host-test"))
+))]
+static REMOTE_RESCHEDULE_PENDING: [AtomicBool; ax_config::plat::MAX_CPU_NUM] =
+    [const { AtomicBool::new(false) }; ax_config::plat::MAX_CPU_NUM];
+
+#[cfg(all(test, feature = "smp", feature = "ipi", feature = "host-test"))]
+static REMOTE_RESCHEDULE_PENDING: AtomicBool = AtomicBool::new(false);
+
+#[cfg(all(feature = "smp", feature = "ipi"))]
+pub(crate) fn clear_remote_reschedule_pending_for_current_cpu() {
+    #[cfg(not(all(test, feature = "host-test")))]
+    REMOTE_RESCHEDULE_PENDING[this_cpu_id()].store(false, Ordering::Release);
+    #[cfg(all(test, feature = "host-test"))]
+    REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
+}
+
+#[cfg(all(
+    feature = "smp",
+    feature = "ipi",
+    not(all(test, feature = "host-test"))
+))]
+fn request_remote_reschedule(cpu_id: usize) {
+    if !REMOTE_RESCHEDULE_PENDING[cpu_id].swap(true, Ordering::AcqRel) {
+        ax_ipi::run_on_cpu(cpu_id, request_current_reschedule);
+    }
+}
+
+#[cfg(all(test, feature = "smp", feature = "ipi", feature = "host-test"))]
+fn request_remote_reschedule(cpu_id: usize) {
+    let _ = cpu_id;
+    // Host tests run with one dummy CPU and a no-op send_ipi(), so record the
+    // scheduler-visible request that a real ax-ipi callback would carry.
+    if !REMOTE_RESCHEDULE_PENDING.swap(true, Ordering::AcqRel) {
+        REMOTE_RESCHEDULE_REQUESTS.fetch_add(1, Ordering::Release);
+    }
+}
+
+#[cfg(all(feature = "smp", feature = "ipi"))]
 fn kick_remote_cpu(cpu_id: usize) {
     if cpu_id != this_cpu_id() {
-        ax_hal::irq::send_ipi(
-            ax_hal::irq::IPI_IRQ,
-            ax_hal::irq::IpiTarget::Other { cpu_id },
+        // axruntime's IPI handler only drains ax-ipi callbacks. A bare hardware
+        // IPI can wake an idle CPU, but it does not ask a running remote CPU to
+        // reschedule after a task is queued there.
+        request_remote_reschedule(cpu_id);
+    }
+}
+
+#[cfg(all(test, feature = "smp", feature = "ipi", feature = "host-test"))]
+mod tests {
+    use core::sync::atomic::Ordering;
+
+    #[test]
+    fn remote_cpu_kick_requests_reschedule() {
+        const REMOTE_CPU: usize = 1;
+
+        super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);
+        super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
+        super::kick_remote_cpu(REMOTE_CPU);
+
+        assert_eq!(
+            super::REMOTE_RESCHEDULE_REQUESTS.load(Ordering::Acquire),
+            1,
+            "remote CPU kicks must enqueue a scheduler-visible reschedule request",
         );
+    }
+
+    #[test]
+    fn remote_cpu_kick_coalesces_reschedule_request() {
+        const REMOTE_CPU: usize = 1;
+
+        super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);
+        super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
+        super::kick_remote_cpu(REMOTE_CPU);
+        super::kick_remote_cpu(REMOTE_CPU);
+
+        assert_eq!(
+            super::REMOTE_RESCHEDULE_REQUESTS.load(Ordering::Acquire),
+            1,
+            "remote CPU kicks should coalesce identical pending reschedule requests",
+        );
+    }
+
+    #[test]
+    fn remote_reschedule_callback_without_deferred_request_clears_pending() {
+        super::REMOTE_RESCHEDULE_PENDING.store(true, Ordering::Release);
+
+        super::request_current_reschedule();
+
+        assert!(
+            !super::REMOTE_RESCHEDULE_PENDING.load(Ordering::Acquire),
+            "callbacks that cannot defer a reschedule must clear the coalescing bit",
+        );
+    }
+
+    #[cfg(feature = "preempt")]
+    #[test]
+    fn remote_reschedule_callback_requests_forced_reschedule() {
+        crate::tests::run_in_test_scheduler(|| {
+            let curr = crate::current();
+
+            curr.set_preempt_pending(false);
+            curr.set_force_resched_pending(false);
+
+            super::request_current_reschedule();
+
+            assert!(
+                curr.force_resched_pending_for_test(),
+                "remote IPI reschedule must request forced rotation",
+            );
+            assert!(
+                !curr.preempt_pending_for_test(),
+                "remote IPI reschedule must not rely on ordinary RR preemption",
+            );
+        });
     }
 }
 
@@ -446,6 +573,32 @@ impl<G: BaseGuard> CurrentRunQueueRef<'_, G> {
             self.inner.resched();
         } else {
             curr.set_preempt_pending(true);
+        }
+    }
+
+    #[cfg(feature = "preempt")]
+    pub fn force_resched(&mut self) {
+        let curr = &self.current_task;
+        assert!(curr.is_running());
+
+        let can_preempt = curr.can_preempt(1);
+        trace!(
+            "current task is forced to reschedule: {}, allow={}",
+            curr.id_name(),
+            can_preempt
+        );
+        if can_preempt {
+            #[cfg(feature = "smp")]
+            if !curr.cpumask().get(self.inner.cpu_id) {
+                self.migrate_current_to_affinity();
+                return;
+            }
+
+            self.inner
+                .put_task_with_state(curr.clone(), TaskState::Running, false);
+            self.inner.resched();
+        } else {
+            curr.set_force_resched_pending(true);
         }
     }
 

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -106,6 +106,8 @@ pub struct TaskInner {
     #[cfg(feature = "preempt")]
     need_resched: AtomicBool,
     #[cfg(feature = "preempt")]
+    force_resched: AtomicBool,
+    #[cfg(feature = "preempt")]
     preempt_disable_count: AtomicUsize,
 
     interrupted: AtomicBool,
@@ -362,6 +364,8 @@ impl TaskInner {
             #[cfg(feature = "preempt")]
             need_resched: AtomicBool::new(false),
             #[cfg(feature = "preempt")]
+            force_resched: AtomicBool::new(false),
+            #[cfg(feature = "preempt")]
             preempt_disable_count: AtomicUsize::new(0),
             interrupted: AtomicBool::new(false),
             interrupt_waker: AtomicWaker::new(),
@@ -491,6 +495,36 @@ impl TaskInner {
 
     #[inline]
     #[cfg(feature = "preempt")]
+    pub(crate) fn set_force_resched_pending(&self, pending: bool) {
+        self.force_resched.store(pending, Ordering::Release)
+    }
+
+    #[inline]
+    #[cfg(feature = "preempt")]
+    fn force_resched_pending(&self) -> bool {
+        self.force_resched.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    #[cfg(all(test, feature = "preempt"))]
+    pub(crate) fn preempt_pending_for_test(&self) -> bool {
+        self.need_resched.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    #[cfg(all(test, feature = "preempt"))]
+    pub(crate) fn force_resched_pending_for_test(&self) -> bool {
+        self.force_resched_pending()
+    }
+
+    #[inline]
+    #[cfg(feature = "preempt")]
+    fn take_force_resched_pending(&self) -> bool {
+        self.force_resched.swap(false, Ordering::AcqRel)
+    }
+
+    #[inline]
+    #[cfg(feature = "preempt")]
     pub(crate) fn preempt_count(&self) -> usize {
         self.preempt_disable_count.load(Ordering::Acquire)
     }
@@ -520,11 +554,17 @@ impl TaskInner {
     fn current_check_preempt_pending() {
         use ax_kernel_guard::NoPreemptIrqSave;
         let curr = crate::current();
-        if curr.need_resched.load(Ordering::Acquire) && curr.can_preempt(0) {
+        if (curr.force_resched_pending() || curr.need_resched.load(Ordering::Acquire))
+            && curr.can_preempt(0)
+        {
             // Note: if we want to print log msg during `preempt_resched`, we have to
             // disable preemption here, because the ax-log may cause preemption.
             let mut rq = crate::current_run_queue::<NoPreemptIrqSave>();
-            if curr.need_resched.load(Ordering::Acquire) {
+            if curr.take_force_resched_pending() {
+                #[cfg(all(feature = "smp", feature = "ipi"))]
+                crate::run_queue::clear_remote_reschedule_pending_for_current_cpu();
+                rq.force_resched()
+            } else if curr.need_resched.load(Ordering::Acquire) {
                 rq.preempt_resched()
             }
         }

--- a/os/arceos/modules/axtask/src/tests.rs
+++ b/os/arceos/modules/axtask/src/tests.rs
@@ -20,7 +20,7 @@ type TestJob = (Box<dyn FnOnce() + Send + 'static>, mpsc::Sender<TestResult>);
 
 static TEST_WORKER: OnceLock<mpsc::Sender<TestJob>> = OnceLock::new();
 
-fn run_in_test_scheduler<F>(f: F)
+pub(crate) fn run_in_test_scheduler<F>(f: F)
 where
     F: FnOnce() + Send + 'static,
 {

--- a/test-suit/starryos/qemu-smp4/system/affinity-bug-sched-affinity-pid/src/main.c
+++ b/test-suit/starryos/qemu-smp4/system/affinity-bug-sched-affinity-pid/src/main.c
@@ -9,9 +9,19 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-static void fail(const char *msg)
+#define ITERATIONS 20
+#define WAIT_RETRIES 10000
+
+static void fail_at(const char *msg, int iter)
 {
-    printf("TEST FAILED: %s: %s\n", msg, strerror(errno));
+    printf("TEST FAILED: iter=%d: %s: %s\n", iter, msg, strerror(errno));
+    fflush(stdout);
+    abort();
+}
+
+static void fail_msg_at(const char *msg, int iter)
+{
+    printf("TEST FAILED: iter=%d: %s\n", iter, msg);
     fflush(stdout);
     abort();
 }
@@ -36,19 +46,41 @@ static void require_only_cpu(const cpu_set_t *set, int cpu, const char *msg)
     }
 }
 
-int main(void)
+static void reap_killed_child(pid_t child, int iter)
 {
-    setbuf(stdout, NULL);
-    printf("TEST START: sched affinity respects pid\n");
+    int status;
 
-    cpu_set_t parent_cpu0 = single_cpu(0);
-    if (sched_setaffinity(0, sizeof(parent_cpu0), &parent_cpu0) != 0) {
-        fail("set parent affinity to CPU0");
+    if (kill(child, SIGKILL) != 0) {
+        fail_at("kill child", iter);
+    }
+
+    for (int i = 0; i < WAIT_RETRIES; i++) {
+        pid_t waited = waitpid(child, &status, WNOHANG);
+        if (waited == child) {
+            return;
+        }
+        if (waited < 0) {
+            fail_at("waitpid child", iter);
+        }
+        sched_yield();
+    }
+
+    fail_msg_at("child did not exit after SIGKILL", iter);
+}
+
+static void run_iteration(int iter)
+{
+    int parent_cpu = iter & 1;
+    int child_cpu = parent_cpu ^ 1;
+
+    cpu_set_t parent_set = single_cpu(parent_cpu);
+    if (sched_setaffinity(0, sizeof(parent_set), &parent_set) != 0) {
+        fail_at("set parent affinity", iter);
     }
 
     pid_t child = fork();
     if (child < 0) {
-        fail("fork");
+        fail_at("fork", iter);
     }
     if (child == 0) {
         for (;;) {
@@ -57,30 +89,39 @@ int main(void)
         _exit(0);
     }
 
-    cpu_set_t child_cpu1 = single_cpu(1);
-    if (sched_setaffinity(child, sizeof(child_cpu1), &child_cpu1) != 0) {
+    cpu_set_t child_set = single_cpu(child_cpu);
+    if (sched_setaffinity(child, sizeof(child_set), &child_set) != 0) {
         kill(child, SIGKILL);
-        fail("set child affinity to CPU1");
+        fail_at("set child affinity", iter);
     }
 
     cpu_set_t observed_child;
     CPU_ZERO(&observed_child);
     if (sched_getaffinity(child, sizeof(observed_child), &observed_child) != 0) {
         kill(child, SIGKILL);
-        fail("get child affinity");
+        fail_at("get child affinity", iter);
     }
-    require_only_cpu(&observed_child, 1, "child affinity should be CPU1");
+    require_only_cpu(&observed_child, child_cpu, "child affinity should match requested CPU");
 
     cpu_set_t observed_parent;
     CPU_ZERO(&observed_parent);
     if (sched_getaffinity(0, sizeof(observed_parent), &observed_parent) != 0) {
         kill(child, SIGKILL);
-        fail("get parent affinity");
+        fail_at("get parent affinity", iter);
     }
-    require_only_cpu(&observed_parent, 0, "parent affinity should stay CPU0");
+    require_only_cpu(&observed_parent, parent_cpu, "parent affinity should match requested CPU");
 
-    kill(child, SIGKILL);
-    waitpid(child, NULL, 0);
+    reap_killed_child(child, iter);
+}
+
+int main(void)
+{
+    setbuf(stdout, NULL);
+    printf("TEST START: sched affinity respects pid\n");
+
+    for (int i = 0; i < ITERATIONS; i++) {
+        run_iteration(i);
+    }
 
     printf("TEST PASSED\n");
     return 0;

--- a/test-suit/starryos/qemu-smp4/system/affinity-bug-sched-affinity-pid/src/main.c
+++ b/test-suit/starryos/qemu-smp4/system/affinity-bug-sched-affinity-pid/src/main.c
@@ -26,6 +26,12 @@ static void fail_msg_at(const char *msg, int iter)
     abort();
 }
 
+static void phase_at(int iter, const char *phase)
+{
+    printf("ITER %d %s\n", iter, phase);
+    fflush(stdout);
+}
+
 static cpu_set_t single_cpu(int cpu)
 {
     cpu_set_t set;
@@ -74,9 +80,11 @@ static void run_iteration(int iter)
     int child_cpu = parent_cpu ^ 1;
 
     cpu_set_t parent_set = single_cpu(parent_cpu);
+    phase_at(iter, "parent-setaffinity begin");
     if (sched_setaffinity(0, sizeof(parent_set), &parent_set) != 0) {
         fail_at("set parent affinity", iter);
     }
+    phase_at(iter, "parent-setaffinity done");
 
     pid_t child = fork();
     if (child < 0) {
@@ -90,10 +98,12 @@ static void run_iteration(int iter)
     }
 
     cpu_set_t child_set = single_cpu(child_cpu);
+    phase_at(iter, "child-setaffinity begin");
     if (sched_setaffinity(child, sizeof(child_set), &child_set) != 0) {
         kill(child, SIGKILL);
         fail_at("set child affinity", iter);
     }
+    phase_at(iter, "child-setaffinity done");
 
     cpu_set_t observed_child;
     CPU_ZERO(&observed_child);
@@ -111,7 +121,9 @@ static void run_iteration(int iter)
     }
     require_only_cpu(&observed_parent, parent_cpu, "parent affinity should match requested CPU");
 
+    phase_at(iter, "wait begin");
     reap_killed_child(child, iter);
+    phase_at(iter, "wait done");
 }
 
 int main(void)


### PR DESCRIPTION
## 问题

`qemu-smp4/system` 中的 `bug-sched-affinity-pid` 可能在输出 `TEST START: sched affinity respects pid` 后长时间无进展。该用例首先会执行 `sched_setaffinity(0, ..., CPU0)`，当当前任务运行在非目标 CPU 时，会进入 axtask 的 affinity migration / remote runqueue kick 路径。

此前 `kick_remote_cpu()` 只发送裸硬件 IPI，而 `axruntime` 的 IPI handler 只消费 `ax_ipi` callback 队列。裸 IPI 没有 callback，因此目标 CPU 即使收到中断，也没有 scheduler-visible 的调度请求。若只设置普通 `preempt_pending`，在 Starry 使用的 RR 调度器下仍可能重新选中当前任务：当前任务时间片未耗尽时，`put_prev_task(..., preempt=true)` 会把它插回队首，新入队任务仍要依赖后续 timer tick 或主动 yield。

## 修改

- 为 `TaskInner` 增加独立的 `force_resched` pending 状态，和普通 `need_resched` 分离。
- 将远端 runqueue kick 改为通过 `ax_ipi::run_on_cpu()` 投递 callback；callback 不跳过 idle task，而是在目标 CPU 上设置 forced reschedule 请求。
- 在 `current_check_preempt_pending()` 中优先消费 forced request，并清除对应 CPU 的 coalescing bit。
- 新增 `force_resched()` 路径，使用 `put_task_with_state(..., preempt=false)`，使 RR 当前任务重置时间片并进入队尾，从而让已经入队的远端任务无需等待下一次 timer tick。
- 为远端 reschedule callback 增加 per-CPU pending bit，避免短时间多次远端入队堆积一批等价 callback。
- 将 remote reschedule host checks 合并为一个测试，并在测试结束时恢复共享 pending/request/current preempt 状态，避免 Rust 并行测试读写同一组全局原子导致随机失败。
- 增强 `bug-sched-affinity-pid`：在一次 QEMU 启动中循环 20 次执行 `parent setaffinity -> fork -> child setaffinity -> kill -> bounded WNOHANG waitpid`，并输出每轮 `parent-setaffinity`、`child-setaffinity`、`wait` 阶段 marker，避免再次变成 1800 秒静默挂起。

## 回归覆盖

- `remote_reschedule_request_is_coalesced_and_forced`：验证 remote kick 会产生 scheduler-visible 请求、重复 kick 会被 pending bit 合并、pending 清除后可再次请求，并验证 IPI callback 设置 forced request 而不是普通 `preempt_pending`。
- `rr_preempt_preserves_slice_but_forced_reschedule_rotates`：固定 RR 语义，证明 `preempt=true` 会继续选当前任务，而 `preempt=false` 才会把 queued task 选出来。
- Starry SMP C case 循环 20 次，覆盖 issue 原始路径，并在每个关键 syscall 前后打印阶段 marker。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package ax-task`
- `cargo test -p ax-task --features "sched-rr smp ipi host-test" remote_reschedule_request_is_coalesced_and_forced -- --nocapture`
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp4/system`
- `cargo xtask starry test qemu --arch riscv64`

最后一项本地完整通过，包含 `qemu-smp1/system` 与 `qemu-smp4/system` 两组；`qemu-smp4/system` 中 `bug-sched-affinity-pid` 输出 20 轮阶段 marker 后通过。

Fixes #1215