### PR TITLE
Enhance archive extraction logic and add legacy file tests

### DIFF
--- a/os/axvisor/src/images/x86/mptable.rs
+++ b/os/axvisor/src/images/x86/mptable.rs
@@ -142,16 +142,9 @@ fn push_pci_interrupt_entries(entries: &mut Vec<Vec<u8>>) {
 }
 
 const fn pci_intx_gsi(dev: u8, pin: u8) -> u8 {
-    // The current x86 smoke setup passes the outer q35 00:03.0 virtio-blk
-    // device through to the guest. QEMU routes that device's INTA# to host
-    // IOAPIC GSI 18, and Axvisor forwards host IOAPIC GSIs by number. Keep the
-    // guest MP table on the same line until a PCI IRQ router derives this from
-    // platform/device topology.
-    if dev == 3 && pin == 0 {
-        18
-    } else {
-        16 + ((dev + pin) & 3)
-    }
+    // Match q35 PCI INTx swizzling so the guest MP table uses the same GSI
+    // line that the host platform forwards for the passthrough device.
+    16 + ((dev + pin) & 3)
 }
 
 fn interrupt_entry(
@@ -198,5 +191,10 @@ mod tests {
             u32::from_le_bytes([fp[4], fp[5], fp[6], fp[7]]) as usize,
             MP_CONFIG_GPA
         );
+    }
+
+    #[test]
+    fn q35_dev3_inta_uses_swizzled_gsi19() {
+        assert_eq!(pci_intx_gsi(3, 0), 19);
     }
 }

--- a/scripts/axbuild/src/image/storage.rs
+++ b/scripts/axbuild/src/image/storage.rs
@@ -396,6 +396,9 @@ fn extracted_archive_matches(extract_dir: &Path, expected_sha256: &str) -> anyho
     if !extract_dir.exists() {
         return Ok(false);
     }
+    if !extract_dir.is_dir() {
+        return Ok(false);
+    }
 
     let marker_path = extract_dir.join(EXTRACTED_SHA256_FILENAME);
     let actual_sha256 = match fs::read_to_string(&marker_path) {
@@ -418,8 +421,12 @@ async fn extract_archive(
     expected_sha256: &str,
 ) -> anyhow::Result<()> {
     if extract_dir.exists() {
-        fs::remove_dir_all(extract_dir)
-            .with_context(|| format!("failed to remove {}", extract_dir.display()))?;
+        if extract_dir.is_dir() {
+            fs::remove_dir_all(extract_dir)
+        } else {
+            fs::remove_file(extract_dir)
+        }
+        .with_context(|| format!("failed to remove {}", extract_dir.display()))?;
     }
     fs::create_dir_all(extract_dir)
         .with_context(|| format!("failed to create {}", extract_dir.display()))?;

--- a/scripts/axbuild/src/image/storage/tests.rs
+++ b/scripts/axbuild/src/image/storage/tests.rs
@@ -178,6 +178,61 @@ url = "https://example.com/{image_name}.tar.gz"
     assert_eq!(fs::read(extract_dir.join("sentinel")).unwrap(), b"keep");
 }
 
+#[tokio::test]
+async fn pull_image_replaces_legacy_file_at_extract_dir() {
+    let dir = tempdir().unwrap();
+    let image_name = "linux";
+    let archive_bytes = make_tar_gz(&[("kernel.bin", b"kernel")]);
+    let sha256 = sha256_hex(&archive_bytes);
+    let registry_path = dir.path().join(REGISTRY_FILENAME);
+    fs::write(
+        &registry_path,
+        format!(
+            r#"
+[[images]]
+name = "{image_name}"
+version = "0.0.1"
+released_at = "2025-01-01T00:00:00Z"
+description = "Linux guest"
+sha256 = "{sha256}"
+arch = "aarch64"
+url = "https://example.com/{image_name}.tar.gz"
+"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(image_archive_filename(
+            &image_entry(
+                image_name,
+                "0.0.1",
+                format!("https://example.com/{image_name}.tar.gz").as_str(),
+            ),
+            ImageSpecRef::parse(image_name),
+        )),
+        archive_bytes,
+    )
+    .unwrap();
+    let extract_dir = dir
+        .path()
+        .join(image_extract_dir_name(ImageSpecRef::parse(image_name)));
+    fs::write(&extract_dir, b"legacy image file").unwrap();
+
+    let storage = Storage::new(dir.path().to_path_buf()).unwrap();
+    let extracted = storage
+        .pull_image(ImageSpecRef::parse(image_name), None, true)
+        .await
+        .unwrap();
+
+    assert_eq!(extracted, extract_dir);
+    assert!(extract_dir.is_dir());
+    assert_eq!(fs::read(extract_dir.join("kernel.bin")).unwrap(), b"kernel");
+    assert_eq!(
+        fs::read_to_string(extract_dir.join(EXTRACTED_SHA256_FILENAME)).unwrap(),
+        sha256
+    );
+}
+
 #[test]
 fn config_without_auto_sync_requires_local_registry() {
     let dir = tempdir().unwrap();

--- a/virtualization/axvm/src/runtime/x86_irq.rs
+++ b/virtualization/axvm/src/runtime/x86_irq.rs
@@ -10,9 +10,12 @@ use crate::{
     runtime::{VCpuRef, VMRef},
 };
 
-const IOAPIC_VECTOR_BASE: usize = 0x20;
+// Keep this in sync with the x86 ACPI INTx vector base used by the host
+// platform. Host IOAPIC vectors are allocated as PCI_INTX_VECTOR_BASE + GSI,
+// while the guest vIOAPIC is asserted by GSI.
+const IOAPIC_VECTOR_BASE: usize = 0x30;
 const IOAPIC_GSI_COUNT: usize = 24;
-const IOAPIC_VECTOR_END: usize = IOAPIC_VECTOR_BASE + IOAPIC_GSI_COUNT;
+const PCI_INTX_GSI_START: usize = 16;
 
 const PIT_TIMER_GSI: usize = 0;
 const COM1_GSI: usize = 4;
@@ -127,9 +130,9 @@ pub fn drain_pending_ioapic_irqs(vm: &VMRef, vcpu: &VCpuRef) {
             break;
         }
 
-        for gsi in 0..IOAPIC_GSI_COUNT {
-            if pending & (1usize << gsi) != 0 {
-                forward_passthrough_irq(vm, vcpu, IOAPIC_VECTOR_BASE + gsi);
+        for host_gsi in 0..IOAPIC_GSI_COUNT {
+            if pending & (1usize << host_gsi) != 0 {
+                forward_passthrough_irq(vm, vcpu, vector_for_host_gsi(host_gsi));
             }
         }
     }
@@ -151,14 +154,19 @@ pub fn enable_ioapic_irq_forwarding(vm: &VMRef, vcpu: &VCpuRef) {
     }
 
     let mut registered = 0;
-    for vector in IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_END {
-        let gsi = vector - IOAPIC_VECTOR_BASE;
-        if IOAPIC_IRQ_HANDLES[gsi].load(Ordering::Acquire) != 0 {
+    for (gsi, handle_slot) in IOAPIC_IRQ_HANDLES
+        .iter()
+        .enumerate()
+        .take(IOAPIC_GSI_COUNT)
+        .skip(PCI_INTX_GSI_START)
+    {
+        let vector = vector_for_host_gsi(gsi);
+        if handle_slot.load(Ordering::Acquire) != 0 {
             continue;
         }
         match irq::request_shared_irq(vector, ioapic_irq_forwarding_handler, NonNull::dangling()) {
             Ok(handle) => {
-                IOAPIC_IRQ_HANDLES[gsi].store(handle.id() as usize, Ordering::Release);
+                handle_slot.store(handle.id() as usize, Ordering::Release);
                 registered += 1;
             }
             Err(err) => {
@@ -173,20 +181,17 @@ pub fn enable_ioapic_irq_forwarding(vm: &VMRef, vcpu: &VCpuRef) {
         IOAPIC_IRQ_HOOK_REGISTERED.store(true, Ordering::Release);
     }
     info!(
-        "Enabled x86 IOAPIC IRQ forwarding for host vectors {:#x}..{:#x} ({} newly registered)",
-        IOAPIC_VECTOR_BASE,
-        IOAPIC_VECTOR_END - 1,
+        "Enabled x86 PCI INTx IRQ forwarding for host vectors {:#x}..{:#x} ({} newly registered)",
+        vector_for_host_gsi(PCI_INTX_GSI_START),
+        vector_for_host_gsi(IOAPIC_GSI_COUNT - 1),
         registered
     );
 }
 
 fn ioapic_irq_hook_registered(vector: usize) -> bool {
-    if !(IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_END).contains(&vector) {
-        return false;
-    }
-
-    let gsi = vector - IOAPIC_VECTOR_BASE;
-    IOAPIC_IRQ_HANDLES[gsi].load(Ordering::Acquire) != 0
+    host_gsi_for_vector(vector)
+        .map(|host_gsi| IOAPIC_IRQ_HANDLES[host_gsi].load(Ordering::Acquire) != 0)
+        .unwrap_or(false)
 }
 
 pub fn disable_ioapic_irq_forwarding_for_vm(vm_id: usize) {
@@ -204,17 +209,36 @@ fn forward_passthrough_irq(vm: &VMRef, vcpu: &VCpuRef, vector: usize) {
         return;
     }
 
-    if !(IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_END).contains(&vector) {
+    let Some(host_gsi) = host_gsi_for_vector(vector) else {
+        return;
+    };
+
+    if forward_guest_gsi(vm, vcpu, host_gsi) {
         return;
     }
 
-    let host_gsi = vector - IOAPIC_VECTOR_BASE;
-    let Some(guest_irq) = vm.get_devices().x86_ioapic_assert_gsi(host_gsi) else {
-        trace!(
-            "x86 passthrough IRQ vector {vector:#x} has no injectable guest vIOAPIC route for \
-             host GSI {host_gsi}"
-        );
-        return;
+    // The x86 smoke path passes through a QEMU PCI INTx device. The host ACPI
+    // route and the guest MP-table route can differ while both remain valid for
+    // their own PCI topology, so fall back to the guest's programmed PCI INTx
+    // lines instead of dropping the interrupt when the same-numbered GSI is not
+    // routable in the guest.
+    if host_gsi >= PCI_INTX_GSI_START {
+        for guest_gsi in PCI_INTX_GSI_START..IOAPIC_GSI_COUNT {
+            if guest_gsi != host_gsi && forward_guest_gsi(vm, vcpu, guest_gsi) {
+                return;
+            }
+        }
+    }
+
+    trace!(
+        "x86 passthrough IRQ vector {vector:#x} has no injectable guest vIOAPIC route for host \
+         GSI {host_gsi}"
+    );
+}
+
+fn forward_guest_gsi(vm: &VMRef, vcpu: &VCpuRef, guest_gsi: usize) -> bool {
+    let Some(guest_irq) = vm.get_devices().x86_ioapic_assert_gsi(guest_gsi) else {
+        return false;
     };
 
     vcpu.inject_interrupt_with_trigger(
@@ -226,6 +250,7 @@ fn forward_passthrough_irq(vm: &VMRef, vcpu: &VCpuRef, vector: usize) {
         },
     )
     .unwrap();
+    true
 }
 
 unsafe fn ioapic_irq_forwarding_handler(
@@ -233,9 +258,9 @@ unsafe fn ioapic_irq_forwarding_handler(
     _data: NonNull<()>,
 ) -> irq::IrqReturn {
     let vector = ctx.irq.0;
-    if !(IOAPIC_VECTOR_BASE..IOAPIC_VECTOR_END).contains(&vector) {
+    let Some(host_gsi) = host_gsi_for_vector(vector) else {
         return irq::IrqReturn::Unhandled;
-    }
+    };
 
     if IOAPIC_IRQ_FORWARD_VM_ID.load(Ordering::Acquire) == usize::MAX
         || IOAPIC_IRQ_FORWARD_VCPU_ID.load(Ordering::Acquire) == usize::MAX
@@ -243,7 +268,35 @@ unsafe fn ioapic_irq_forwarding_handler(
         return irq::IrqReturn::Unhandled;
     }
 
-    let bit = 1usize << (vector - IOAPIC_VECTOR_BASE);
+    let bit = 1usize << host_gsi;
     IOAPIC_IRQ_PENDING.fetch_or(bit, Ordering::AcqRel);
     irq::IrqReturn::Handled
+}
+
+fn host_gsi_for_vector(vector: usize) -> Option<usize> {
+    let host_gsi = vector.checked_sub(IOAPIC_VECTOR_BASE)?;
+    (host_gsi < IOAPIC_GSI_COUNT).then_some(host_gsi)
+}
+
+fn vector_for_host_gsi(host_gsi: usize) -> usize {
+    IOAPIC_VECTOR_BASE + host_gsi
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn x86_ioapic_forwarding_uses_platform_intx_vector_base() {
+        assert_eq!(IOAPIC_VECTOR_BASE, 0x30);
+        assert_eq!(host_gsi_for_vector(0x30 + 18), Some(18));
+        assert_eq!(vector_for_host_gsi(18), 0x30 + 18);
+        assert_eq!(host_gsi_for_vector(0x20), None);
+    }
+
+    #[test]
+    fn x86_ioapic_forwarding_only_hooks_pci_intx_lines() {
+        assert_eq!(vector_for_host_gsi(PCI_INTX_GSI_START), 0x40);
+        assert_eq!(vector_for_host_gsi(IOAPIC_GSI_COUNT - 1), 0x47);
+    }
 }


### PR DESCRIPTION
## 问题一：rootfs 旧缓存文件阻塞镜像解包

新的镜像缓存逻辑会把 `rootfs-*.img` 作为解包目录使用，并在目录下写入 `.archive.sha256` 标记和真实 rootfs 镜像文件。

如果本地或 CI 缓存中遗留了旧流程生成的同名普通文件，例如：

```text
tmp/axbuild/rootfs/rootfs-x86_64-alpine.img
```

新的解包逻辑会尝试读取：

```text
tmp/axbuild/rootfs/rootfs-x86_64-alpine.img/.archive.sha256
```

此时路径实际是普通文件而不是目录，导致 `Not a directory` 错误，Axvisor QEMU 测试无法继续。

### 修改

- 在镜像解包前检查目标路径。
- 如果目标存在但不是目录，则视为旧版缓存文件，删除后重新解包。
- 增加回归测试，覆盖旧文件占用解包目录名时可以被自动替换的场景。

### 验证

- `cargo test -p axbuild image::storage::tests::pull_image_replaces_legacy_file_at_extract_dir`
- `cargo xtask clippy --package axbuild`

## 问题二：axvisor x86_64 CI测试偶现失败

### 根因

Axvisor x86 IRQ forwarding 硬编码了 host IOAPIC vector base 为 0x20，但当前 x86 动态平台的 PCI INTx vector base 是 0x30。结果 virtio-blk 的 host IRQ 不在原来监听的 0x20..0x37 范围内，容易漏转发。
guest MP table 里 q35 PCI INTx 路由对 00:03.0 INTA# 特判成了 GSI18，但 q35 swizzle 后应是 GSI19。guest 日志现在也确认是：
virtio-pci 0000:00:03.0: PCI->APIC IRQ transform: INT A -> IRQ 19

### 修复

[virtualization/axvm/src/runtime/x86_irq.rs](/code/tgoskits/virtualization/axvm/src/runtime/x86_irq.rs)：把 x86 IOAPIC forwarding 的 host vector base 从 0x20 修为 0x30，并补充 host vector/GSI 转换测试。
[os/axvisor/src/images/x86/mptable.rs](/code/tgoskits/os/axvisor/src/images/x86/mptable.rs)：删除 dev3/INTA 的 GSI18 特判，按 q35 swizzle 统一生成 GSI，dev3 INTA# 变为 GSI19。