### PR TITLE
fix(starry): non-blocking tty serial read respects O_NONBLOCK

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/tty_serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty_serial.rs
@@ -9,10 +9,7 @@ use ax_errno::{AxError, LinuxError};
 use ax_kspin::SpinNoIrq;
 use ax_memory_addr::{PhysAddr, pa};
 use ax_sync::Mutex;
-use ax_task::{
-    IrqNotify,
-    future::{block_on, poll_io},
-};
+use ax_task::IrqNotify;
 use axfs_ng_vfs::{NodeFlags, VfsResult};
 use axpoll::{IoEvents, PollSet, Pollable};
 use bytemuck::AnyBitPattern;
@@ -254,15 +251,18 @@ impl DeviceOps for TtySerial {
         if buf.is_empty() {
             return Ok(0);
         }
-        block_on(poll_io(self, IoEvents::IN, false, || {
-            let mut rx = self.rx_buf.lock();
-            if rx.is_empty() {
-                return Err(AxError::WouldBlock);
-            }
-            let n = buf.len().min(rx.len());
-            rx.drain_into(&mut buf[..n]);
-            Ok(n)
-        }))
+        // Non-blocking drain only. The blocking/`O_NONBLOCK` semantics are
+        // handled one layer up in `File::read`, which wraps this in
+        // `poll_io(.., self.nonblocking(), ..)`. Blocking here too (the old
+        // `block_on(poll_io(.., false, ..))`) ignored the fd's `O_NONBLOCK`
+        // and made non-blocking reads of an idle UART hang forever.
+        let mut rx = self.rx_buf.lock();
+        if rx.is_empty() {
+            return Err(AxError::WouldBlock);
+        }
+        let n = buf.len().min(rx.len());
+        rx.drain_into(&mut buf[..n]);
+        Ok(n)
     }
 
     fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {


### PR DESCRIPTION
TtySerial::read_at wrapped its RX drain in an inner block_on(poll_io(.., non_blocking=false, ..)), hardcoding the blocking decision. Since File::read (file/fs.rs) already wraps device read_at in poll_io(.., self.nonblocking(), ..) using the fd's real O_NONBLOCK flag, the inner layer was both redundant and wrong: it overrode the upper layer's correct decision and forced every read to block, so a non-blocking read of an idle UART hung forever.