### PR TITLE
feat(starry): support reboot syscall

### DIFF
--- a/components/someboot/src/arch/aarch64/mod.rs
+++ b/components/someboot/src/arch/aarch64/mod.rs
@@ -104,6 +104,10 @@ impl ArchTrait for Arch {
         power::shutdown()
     }
 
+    fn reset() -> ! {
+        power::reset()
+    }
+
     fn secondary_entry_fn_address() -> *const () {
         _secondary_entry as *const ()
     }

--- a/components/someboot/src/arch/aarch64/power.rs
+++ b/components/someboot/src/arch/aarch64/power.rs
@@ -67,6 +67,25 @@ pub fn shutdown() -> ! {
     }
 }
 
+// Reset the system through PSCI.
+pub fn reset() -> ! {
+    if !METHOD.is_init() {
+        loop {
+            wfi();
+        }
+    }
+
+    if let Err(e) = match *METHOD {
+        Method::Smc => psci::system_reset::<Smc>(),
+        Method::Hvc => psci::system_reset::<Hvc>(),
+    } {
+        println!("Failed to reset: {e}");
+    }
+    loop {
+        wfi();
+    }
+}
+
 pub(crate) fn cpu_on(
     cpu_id: u64,
     entry: u64,

--- a/components/someboot/src/arch/loongarch64/mod.rs
+++ b/components/someboot/src/arch/loongarch64/mod.rs
@@ -154,6 +154,16 @@ impl ArchTrait for Arch {
         }
     }
 
+    fn reset() -> ! {
+        if efi_stub::is_uefi_available() {
+            efi_stub::reset(efi_stub::ResetType::COLD, efi_stub::Status::SUCCESS, None);
+        }
+
+        loop {
+            spin_loop();
+        }
+    }
+
     fn secondary_entry_fn_address() -> *const () {
         _secondary_entry as *const ()
     }

--- a/components/someboot/src/arch/riscv64/mod.rs
+++ b/components/someboot/src/arch/riscv64/mod.rs
@@ -281,6 +281,15 @@ impl ArchTrait for Arch {
         }
     }
 
+    fn reset() -> ! {
+        let _ = sbi::system_reset_reboot();
+        loop {
+            unsafe {
+                core::arch::asm!("wfi", options(nomem, nostack, preserves_flags));
+            }
+        }
+    }
+
     fn secondary_entry_fn_address() -> *const () {
         _secondary_entry as *const ()
     }

--- a/components/someboot/src/arch/riscv64/sbi.rs
+++ b/components/someboot/src/arch/riscv64/sbi.rs
@@ -41,6 +41,15 @@ pub fn system_reset_shutdown() -> Result<(), isize> {
     }
 }
 
+pub fn system_reset_reboot() -> Result<(), isize> {
+    let ret = sbi_rt::system_reset(sbi_rt::ColdReboot, sbi_rt::NoReason);
+    if ret.error == 0 {
+        Ok(())
+    } else {
+        Err(ret.error as isize)
+    }
+}
+
 pub fn detect_timebase_frequency() -> Option<usize> {
     let fdt_ptr = crate::fdt::fdt_addr()?;
     let fdt = unsafe { fdt_raw::Fdt::from_ptr(fdt_ptr).ok()? };

--- a/components/someboot/src/arch/x86_64/mod.rs
+++ b/components/someboot/src/arch/x86_64/mod.rs
@@ -119,6 +119,17 @@ impl ArchTrait for Arch {
         }
     }
 
+    fn reset() -> ! {
+        unsafe {
+            x86::irq::disable();
+            x86::io::outb(0x64, 0xfe);
+        }
+
+        loop {
+            unsafe { x86::halt() };
+        }
+    }
+
     fn secondary_entry_fn_address() -> *const () {
         _secondary_entry as *const ()
     }

--- a/components/someboot/src/lib.rs
+++ b/components/someboot/src/lib.rs
@@ -95,6 +95,9 @@ pub trait ArchTrait {
     fn set_user_page_table(val: PageTableInfo);
 
     fn shutdown() -> !;
+    fn reset() -> ! {
+        Self::shutdown()
+    }
     fn secondary_entry_fn_address() -> *const ();
     fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError>;
 

--- a/components/someboot/src/power.rs
+++ b/components/someboot/src/power.rs
@@ -8,6 +8,10 @@ pub fn shutdown() -> ! {
     crate::arch::Arch::shutdown()
 }
 
+pub fn reset() -> ! {
+    crate::arch::Arch::reset()
+}
+
 pub fn cpu_on(cpu_idx: usize) -> Result<(), CpuOnError> {
     let entry = secondary_entry_addr();
     debug!("Secondary entry address: {entry:#x}");

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -771,6 +771,12 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::setdomainname => sys_setdomainname(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::sysinfo => sys_sysinfo(uctx.arg0() as _),
         Sysno::syslog => sys_syslog(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
+        Sysno::reboot => sys_reboot(
+            uctx.arg0() as _,
+            uctx.arg1() as _,
+            uctx.arg2() as _,
+            uctx.arg3(),
+        ),
         Sysno::getrandom => sys_getrandom(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         Sysno::seccomp => sys_seccomp(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         #[cfg(target_arch = "riscv64")]

--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -1,7 +1,7 @@
 use alloc::{sync::Arc, vec, vec::Vec};
 use core::{ffi::c_char, mem::MaybeUninit};
 
-use ax_errno::{AxError, AxResult};
+use ax_errno::{AxError, AxResult, LinuxError};
 use ax_fs_ng::vfs::FS_CONTEXT;
 use ax_sync::Mutex;
 use ax_task::current;
@@ -55,6 +55,17 @@ const SECCOMP_RET_KILL_THREAD: u32 = 0x0000_0000;
 const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
 const SECCOMP_RET_LOG: u32 = 0x7ffc_0000;
 const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
+const LINUX_REBOOT_MAGIC1: u32 = 0xfee1_dead;
+const LINUX_REBOOT_MAGIC2: u32 = 0x2812_1969;
+const LINUX_REBOOT_MAGIC2A: u32 = 0x0512_1996;
+const LINUX_REBOOT_MAGIC2B: u32 = 0x1604_1998;
+const LINUX_REBOOT_MAGIC2C: u32 = 0x2011_2000;
+const LINUX_REBOOT_CMD_RESTART: u32 = 0x0123_4567;
+const LINUX_REBOOT_CMD_RESTART2: u32 = 0xa1b2_c3d4;
+const LINUX_REBOOT_CMD_CAD_ON: u32 = 0x89ab_cdef;
+const LINUX_REBOOT_CMD_CAD_OFF: u32 = 0x0000_0000;
+const LINUX_REBOOT_CMD_HALT: u32 = 0xcdef_0123;
+const LINUX_REBOOT_CMD_POWER_OFF: u32 = 0x4321_fedc;
 
 struct SyslogState {
     buffer: HeapRb<u8>,
@@ -114,6 +125,37 @@ impl SyslogState {
 
 static SYSLOG_STATE: spin::LazyLock<Mutex<SyslogState>> =
     spin::LazyLock::new(|| Mutex::new(SyslogState::new()));
+
+pub fn sys_reboot(magic: u32, magic2: u32, cmd: u32, _arg: usize) -> AxResult<isize> {
+    if !current().as_thread().cred().has_cap_sys_boot() {
+        return Err(AxError::from(LinuxError::EPERM));
+    }
+
+    if magic != LINUX_REBOOT_MAGIC1
+        || !matches!(
+            magic2,
+            LINUX_REBOOT_MAGIC2
+                | LINUX_REBOOT_MAGIC2A
+                | LINUX_REBOOT_MAGIC2B
+                | LINUX_REBOOT_MAGIC2C
+        )
+    {
+        return Err(AxError::from(LinuxError::EINVAL));
+    }
+
+    match cmd {
+        LINUX_REBOOT_CMD_CAD_ON | LINUX_REBOOT_CMD_CAD_OFF => Ok(0),
+        LINUX_REBOOT_CMD_RESTART | LINUX_REBOOT_CMD_RESTART2 => {
+            let _ = ax_fs_ng::shutdown_filesystems();
+            ax_runtime::hal::power::system_reset()
+        }
+        LINUX_REBOOT_CMD_HALT | LINUX_REBOOT_CMD_POWER_OFF => {
+            let _ = ax_fs_ng::shutdown_filesystems();
+            ax_runtime::hal::power::system_off()
+        }
+        _ => Err(AxError::from(LinuxError::EINVAL)),
+    }
+}
 
 /// Mirror of Linux kernel `uid_valid()` / `make_kuid()` rejection: any caller-
 /// supplied UID/GID of `(uid_t)-1` (`u32::MAX`) is invalid outside the NOCHG

--- a/os/StarryOS/kernel/src/task/cred.rs
+++ b/os/StarryOS/kernel/src/task/cred.rs
@@ -9,7 +9,7 @@ use alloc::sync::Arc;
 
 use linux_raw_sys::general::{
     CAP_CHOWN, CAP_FOWNER, CAP_LAST_CAP, CAP_NET_RAW, CAP_SETGID, CAP_SETPCAP, CAP_SETUID,
-    CAP_SYS_ADMIN, CAP_SYS_NICE, CAP_SYS_RESOURCE,
+    CAP_SYS_ADMIN, CAP_SYS_BOOT, CAP_SYS_NICE, CAP_SYS_RESOURCE,
 };
 
 const CAP_MASK: u64 = (1u64 << (CAP_LAST_CAP + 1)) - 1;
@@ -182,6 +182,12 @@ impl Cred {
     /// operations (equivalent to `CAP_SYS_ADMIN`).
     pub fn has_cap_sys_admin(&self) -> bool {
         self.has_cap(CAP_SYS_ADMIN)
+    }
+
+    /// Check whether this credential may reboot the system
+    /// (equivalent to `CAP_SYS_BOOT`).
+    pub fn has_cap_sys_boot(&self) -> bool {
+        self.has_cap(CAP_SYS_BOOT)
     }
 
     /// Check whether this credential may inspect another process

--- a/os/arceos/modules/axhal/src/dummy.rs
+++ b/os/arceos/modules/axhal/src/dummy.rs
@@ -119,6 +119,10 @@ impl PowerIf for DummyPower {
         unimplemented!()
     }
 
+    fn system_reset() -> ! {
+        unimplemented!()
+    }
+
     fn cpu_num() -> usize {
         1
     }

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -64,7 +64,7 @@ pub mod console {
 pub mod power {
     #[cfg(feature = "smp")]
     pub use ax_plat::power::cpu_boot;
-    pub use ax_plat::power::system_off;
+    pub use ax_plat::power::{system_off, system_reset};
 }
 
 /// Trap handling.

--- a/platforms/ax-plat-loongarch64-qemu-virt/src/power.rs
+++ b/platforms/ax-plat-loongarch64-qemu-virt/src/power.rs
@@ -32,6 +32,10 @@ impl PowerIf for PowerImpl {
         }
     }
 
+    fn system_reset() -> ! {
+        Self::system_off()
+    }
+
     /// Get the number of CPU cores available on this platform.
     fn cpu_num() -> usize {
         crate::config::plat::MAX_CPU_NUM

--- a/platforms/ax-plat-riscv64-sg2002/src/power.rs
+++ b/platforms/ax-plat-riscv64-sg2002/src/power.rs
@@ -30,6 +30,15 @@ impl PowerIf for PowerImpl {
         }
     }
 
+    fn system_reset() -> ! {
+        info!("Resetting...");
+        sbi_rt::system_reset(sbi_rt::ColdReboot, sbi_rt::NoReason);
+        warn!("It should reset!");
+        loop {
+            ax_cpu::asm::halt();
+        }
+    }
+
     fn cpu_num() -> usize {
         crate::config::plat::MAX_CPU_NUM
     }

--- a/platforms/ax-plat-riscv64-visionfive2/src/power.rs
+++ b/platforms/ax-plat-riscv64-visionfive2/src/power.rs
@@ -31,6 +31,15 @@ impl PowerIf for PowerImpl {
         }
     }
 
+    fn system_reset() -> ! {
+        info!("Resetting...");
+        sbi_rt::system_reset(sbi_rt::ColdReboot, sbi_rt::NoReason);
+        warn!("It should reset!");
+        loop {
+            ax_cpu::asm::halt();
+        }
+    }
+
     fn cpu_num() -> usize {
         crate::config::plat::MAX_CPU_NUM
     }

--- a/platforms/ax-plat/src/power.rs
+++ b/platforms/ax-plat/src/power.rs
@@ -14,6 +14,9 @@ pub trait PowerIf {
     /// Shutdown the whole system.
     fn system_off() -> !;
 
+    /// Reset the whole system.
+    fn system_reset() -> !;
+
     /// Get the number of CPU cores available on this platform.
     ///
     /// The platform should either get this value statically from its

--- a/platforms/axplat-dyn/src/power.rs
+++ b/platforms/axplat-dyn/src/power.rs
@@ -19,6 +19,11 @@ impl PowerIf for PowerImpl {
         somehal::power::shutdown()
     }
 
+    /// Reset the whole system.
+    fn system_reset() -> ! {
+        somehal::power::reset()
+    }
+
     /// Get the number of CPU cores available on this platform.
     fn cpu_num() -> usize {
         somehal::smp::cpu_meta_list().count()


### PR DESCRIPTION
StarryOS 目前缺少 reboot(2) 系统调用支持，用户态执行 reboot -f 后无法通过系统调用触发平台重启；同时底层 HAL 只有关机接口，没有统一的系统重启抽象。

## 改动

- 为 StarryOS 添加 reboot(2) syscall 分发与实现。
- 按 Linux 语义校验 reboot magic、cmd，并检查 CAP_SYS_BOOT。
- 支持 RESTART / RESTART2 触发系统重启，HALT / POWER_OFF 触发关机，CAD_ON / CAD_OFF 作为 no-op 成功返回。
- 在 ax-plat / axhal 中增加 system_reset() 电源接口。
- 为动态平台接入 someboot reset。
- 为 aarch64、riscv64、x86_64、loongarch64 补充对应 reset 路径。
