### PR TITLE
test(starry): cover LoongArch timer rearm path

### DIFF
--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-loongarch-timer-rearm/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-loongarch-timer-rearm/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-loongarch-timer-rearm C)
+include(${CMAKE_CURRENT_LIST_DIR}/../common/starry_arch_filter.cmake)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+starry_arch_filtered_executable(
+    test-loongarch-timer-rearm
+    "loongarch64"
+    "test-loongarch-timer-rearm skipped on unsupported architecture"
+    src/main.c
+)
+target_include_directories(test-loongarch-timer-rearm PRIVATE ../common)
+target_compile_options(test-loongarch-timer-rearm PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-loongarch-timer-rearm RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-loongarch-timer-rearm/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-loongarch-timer-rearm/src/main.c
@@ -1,0 +1,71 @@
+#define _GNU_SOURCE
+
+#include "test_framework.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+static int sleep_for_ns(long ns)
+{
+    struct timespec ts = {
+        .tv_sec = ns / 1000000000L,
+        .tv_nsec = ns % 1000000000L,
+    };
+
+    while (nanosleep(&ts, &ts) != 0) {
+        if (errno != EINTR)
+            return -1;
+    }
+    return 0;
+}
+
+static int wait_timerfd_once(int fd)
+{
+    uint64_t expirations = 0;
+    ssize_t n = read(fd, &expirations, sizeof expirations);
+    return n == (ssize_t)sizeof expirations && expirations >= 1 ? 0 : -1;
+}
+
+int main(void)
+{
+    TEST_START("loongarch64 one-shot timer rearm");
+
+    /*
+     * LoongArch uses one-shot timer events. The IRQ path must acknowledge the
+     * current event before dispatching into code that programs the next event;
+     * otherwise a late ACK can clear a freshly pending event and leave sleeps
+     * or timerfd reads blocked forever. Short repeated sleeps exercise the
+     * kernel's timer reprogramming path without adding much wall-clock time.
+     */
+    for (int i = 0; i < 16; i++) {
+        char msg[96];
+        snprintf(msg, sizeof msg, "nanosleep rearm iteration %d completes", i);
+        CHECK(sleep_for_ns(2 * 1000 * 1000L) == 0, msg);
+    }
+
+    int fd = timerfd_create(CLOCK_MONOTONIC, 0);
+    CHECK(fd >= 0, "timerfd_create CLOCK_MONOTONIC succeeds");
+
+    struct itimerspec spec = {
+        .it_interval = {0, 0},
+        .it_value = {0, 3 * 1000 * 1000L},
+    };
+    for (int i = 0; fd >= 0 && i < 8; i++) {
+        char set_msg[96];
+        snprintf(set_msg, sizeof set_msg, "timerfd_settime one-shot iteration %d", i);
+        CHECK_RET(timerfd_settime(fd, 0, &spec, NULL), 0, set_msg);
+
+        char read_msg[96];
+        snprintf(read_msg, sizeof read_msg, "timerfd one-shot iteration %d expires", i);
+        CHECK(wait_timerfd_once(fd) == 0, read_msg);
+    }
+
+    if (fd >= 0)
+        close(fd);
+
+    TEST_DONE();
+}


### PR DESCRIPTION
## 问题

#1211 中提到 LoongArch 动态平台在 shell 后会出现 workload-independent 空转/卡住。根因是 LoongArch one-shot timer IRQ 的 ACK 顺序：如果在 `dispatch_irq()` / 动态平台 dispatch 之后才清当前 timer interrupt，dispatch 内部重新设置的下一次 one-shot 事件可能已经变成 pending，随后迟到的 ACK 会把这个新事件一起清掉，导致依赖 timer 的 sleep / timeout / timerfd 路径不再被唤醒。

当前 `dev` 已经在 LoongArch static 与 dynamic 平台路径中把 ACK 调整到了 dispatch 之前。本 PR 增加一个针对该行为的 Starry 回归用例，避免后续回退时只在长耗时 app 用例中才暴露。

## 修改

- 在 `test-suit/starryos/qemu-smp1/system` 增加 `bugfix-bug-loongarch-timer-rearm` 子用例。
- 用 `starry_arch_filtered_executable` 将真实测试限定在 `loongarch64`，其他架构编译为明确 skip。
- 测试内容覆盖两条会反复重新 arm one-shot timer 的路径：
  - 多轮短 `nanosleep()`，验证 sleep 能持续被 timer 唤醒。
  - 多轮 one-shot `timerfd_settime()` + blocking `read()`，验证重新 arm 后每次事件都能到达。

## 验证

- `cargo fmt`
- `cargo xtask starry test qemu --arch loongarch64 --test-case qemu-smp1/system/bugfix-bug-loongarch-timer-rearm`
  - 启动日志确认 `platform = loongarch64-plat-dyn`
  - 新增用例输出 `33 pass, 0 fail`
  - 匹配 `STARRY_GROUPED_TESTS_PASSED`
