### PR TITLE
fix(someboot): split MMU enable and relocation state

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -48,6 +48,9 @@ Current Axvisor LoongArch QEMU tests intentionally use the static `ax-hal/loonga
 - On AArch64, keep the someboot `hv` feature scoped to the EL2 kernel path. For non-`hv` EL1 boot, choose the EL1 arch timer at runtime from the boot EL: use CNTP when EL2 is available and CNTV when EL2 is unavailable, and keep the FDT timer interrupt index consistent with the selected mode.
 - Build page tables for identity/firmware access, direct map, kernel high map, MMIO, and per-CPU data as the arch requires.
 - Flush TLB/cache and use architecture barriers around page table writes, boot argument writes, and secondary CPU release.
+- Treat hardware MMU enablement, direct-map/kernel-space addressability, and final kernel relocation as separate states. Generic relocation detection should use the final `VM_LOAD_ADDRESS`, not the broader arch kernel/direct-map range; for example AArch64 `hv` builds can use `PAGE_OFFSET = 0`, and LoongArch DMW can make RAM addressable before execution reaches the final high mapping.
+- On AArch64, keep the SCTLR.M enable to relocated-entry branch window free of UART logging. Address helpers must not switch to relocated addresses while still executing on the pre-relocation path.
+- On LoongArch, do not treat the DMW direct-map window as final kernel relocation. Address helpers may use DMW for early direct mapping, but relocated-kernel checks should only become true after execution reaches the final `VM_LOAD_ADDRESS` high mapping.
 - After `ExitBootServices`, do not call UEFI Boot Services. Retry only through the correct memory-map-key sequence before exit.
 
 ## SMP Bring-Up Rules

--- a/components/someboot/src/arch/aarch64/mod.rs
+++ b/components/someboot/src/arch/aarch64/mod.rs
@@ -153,7 +153,7 @@ impl ArchTrait for Arch {
     }
 
     fn virt_to_phys(vaddr: *const u8) -> usize {
-        if is_mmu_enabled() {
+        if crate::mem::mmu::is_kernel_relocated() {
             if percpu_va_range().contains(&(vaddr as usize)) {
                 vaddr as usize - 0xFF00_0000_0000 - PAGE_OFFSET
             } else if vaddr as usize >= VM_LOAD_ADDRESS {
@@ -195,6 +195,10 @@ impl ArchTrait for Arch {
 
     fn kernel_space() -> core::ops::Range<usize> {
         PAGE_OFFSET..usize::MAX
+    }
+
+    fn is_mmu_enabled() -> bool {
+        elx::is_mmu_enabled()
     }
 
     fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), crate::power::CpuOnError> {

--- a/components/someboot/src/arch/aarch64/paging/mod.rs
+++ b/components/someboot/src/arch/aarch64/paging/mod.rs
@@ -30,10 +30,10 @@ pub fn enable_mmu() -> ! {
     let v_sp = meta.stack_top_virt;
     let v_entry = __kimage_va(mmu_entry_phys) as usize;
 
-    println!("Enabling MMU...");
+    // Do not touch the debug UART in this final pre-relocation window. Some
+    // boards can leave the early UART TX FIFO full here, and any console access
+    // after SCTLR.M is set can also observe software MMU state too early.
     setup_sctlr();
-    println!("MMU enabled, jumping to {v_entry:#x}, sp={v_sp:#x}");
-    crate::mem::mmu::set_mmu_enabled();
 
     super::relocate::reset();
     dsb(barrier::SY);

--- a/components/someboot/src/arch/loongarch64/entry.rs
+++ b/components/someboot/src/arch/loongarch64/entry.rs
@@ -158,7 +158,6 @@ fn efi_entry() {
 }
 
 pub(crate) fn mmu_entry() -> ! {
-    crate::mem::mmu::set_mmu_enabled();
     println!("MMU ok...");
     crate::prime_entry()
 }

--- a/components/someboot/src/arch/loongarch64/mod.rs
+++ b/components/someboot/src/arch/loongarch64/mod.rs
@@ -297,6 +297,10 @@ impl ArchTrait for Arch {
         addrspace::PAGE_OFFSET..usize::MAX
     }
 
+    fn is_mmu_enabled() -> bool {
+        crmd::read().pg()
+    }
+
     fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
         power::cpu_on(hartid, entry, arg)
     }

--- a/components/someboot/src/arch/loongarch64/paging.rs
+++ b/components/someboot/src/arch/loongarch64/paging.rs
@@ -243,7 +243,6 @@ pub fn enable_mmu_secondary(cpu_meta_paddr: usize) -> ! {
     unsafe {
         core::arch::asm!("csrwr {}, {}", in(reg) crmd_bits, const 0x0);
     }
-    crate::mem::mmu::set_mmu_enabled();
     jump_to_secondary_entry(cpu_meta_paddr, meta.stack_top_virt, meta.entry_virt)
 }
 

--- a/components/someboot/src/arch/riscv64/mod.rs
+++ b/components/someboot/src/arch/riscv64/mod.rs
@@ -227,7 +227,7 @@ impl ArchTrait for Arch {
         let vaddr = vaddr as usize;
         #[cfg(any(uspace, hv))]
         {
-            if mmu::is_mmu_enabled() {
+            if mmu::is_kernel_relocated() {
                 if percpu_va_range().contains(&vaddr) {
                     return vaddr - addrspace::PERCPU_BASE;
                 }
@@ -244,6 +244,10 @@ impl ArchTrait for Arch {
 
     fn kernel_space() -> core::ops::Range<usize> {
         addrspace::PAGE_OFFSET..usize::MAX
+    }
+
+    fn is_mmu_enabled() -> bool {
+        satp_mode() != 0
     }
 
     fn kernel_page_table() -> PageTableInfo {
@@ -441,17 +445,30 @@ pub(crate) fn disable_local_irqs() {
 }
 
 pub(crate) fn current_page_table() -> PageTableInfo {
-    let satp: usize;
-    unsafe {
-        core::arch::asm!("csrr {satp}, satp", satp = out(reg) satp, options(nostack, preserves_flags));
-    }
-    let mode = satp >> 60;
+    let satp = read_satp();
+    let mode = satp_mode_from(satp);
     let addr = if mode == 0 {
         KERNEL_PAGE_TABLE_ADDR.load(Ordering::Relaxed)
     } else {
         (satp & ((1usize << 44) - 1)) << 12
     };
     PageTableInfo { asid: 0, addr }
+}
+
+fn read_satp() -> usize {
+    let satp: usize;
+    unsafe {
+        core::arch::asm!("csrr {satp}, satp", satp = out(reg) satp, options(nostack, preserves_flags));
+    }
+    satp
+}
+
+fn satp_mode() -> usize {
+    satp_mode_from(read_satp())
+}
+
+fn satp_mode_from(satp: usize) -> usize {
+    satp >> 60
 }
 
 pub(crate) fn write_satp(root_paddr: usize) {

--- a/components/someboot/src/arch/riscv64/paging.rs
+++ b/components/someboot/src/arch/riscv64/paging.rs
@@ -23,7 +23,6 @@ pub fn enable_mmu() -> ! {
     println!("Enabling MMU...");
 
     super::write_satp(crate::mem::mmu::boot_table_addr());
-    crate::mem::mmu::set_mmu_enabled();
 
     println!("MMU enabled, jumping to {v_entry:#x}, sp={v_sp:#x}");
 
@@ -44,7 +43,6 @@ pub fn enable_mmu_secondary(cpu_meta_paddr: usize) -> ! {
     let v_entry = meta.entry_virt;
 
     super::write_satp(meta.boot_table_paddr);
-    crate::mem::mmu::set_mmu_enabled();
 
     unsafe {
         asm!(

--- a/components/someboot/src/arch/x86_64/mod.rs
+++ b/components/someboot/src/arch/x86_64/mod.rs
@@ -19,7 +19,7 @@ pub use relocate::relocate;
 
 use crate::{
     ArchTrait, DCacheOp,
-    mem::{PageTableInfo, mmu},
+    mem::{self, PageTableInfo},
     power::CpuOnError,
 };
 
@@ -30,7 +30,7 @@ impl ArchTrait for Arch {
     type Console = console::Console;
 
     fn _va(paddr: usize) -> *mut u8 {
-        if mmu::is_mmu_enabled() {
+        if mem::mmu::is_kernel_relocated() {
             paddr.wrapping_add(addrspace::PHYS_VIRT_OFFSET) as *mut u8
         } else {
             paddr as *mut u8
@@ -88,6 +88,10 @@ impl ArchTrait for Arch {
 
     fn kernel_space() -> core::ops::Range<usize> {
         addrspace::KERNEL_SPACE_BASE..usize::MAX
+    }
+
+    fn is_mmu_enabled() -> bool {
+        unsafe { x86::controlregs::cr0().contains(x86::controlregs::Cr0::CR0_ENABLE_PAGING) }
     }
 
     fn kernel_page_table() -> PageTableInfo {

--- a/components/someboot/src/arch/x86_64/paging.rs
+++ b/components/someboot/src/arch/x86_64/paging.rs
@@ -133,7 +133,6 @@ pub fn enable_mmu() -> ! {
     let v_entry = __kimage_va(super::entry::mmu_entry as *const () as usize) as usize;
     println!("x86_64 switching CR3 and resetting relocations before high-half jump");
 
-    crate::mem::mmu::set_mmu_enabled();
     super::relocate::reset();
 
     unsafe {

--- a/components/someboot/src/console/mod.rs
+++ b/components/someboot/src/console/mod.rs
@@ -219,9 +219,29 @@ unsafe impl Sync for EarlyconSenderCell {}
 
 impl Con for EarlyconSenderCell {
     fn write_bytes(&self, bytes: &[u8]) -> usize {
+        const MAX_NO_PROGRESS_SPINS: usize = 1 << 20;
+
         unsafe {
             if let Some(ref mut sender) = *self.0.get() {
-                sender.write_bytes(bytes)
+                let mut written = 0;
+                let mut no_progress_spins = 0;
+                while written < bytes.len() {
+                    let n = sender.write_bytes(&bytes[written..]);
+                    if n == 0 {
+                        no_progress_spins += 1;
+                        if no_progress_spins >= MAX_NO_PROGRESS_SPINS {
+                            // Early console output is best-effort. If the UART
+                            // stops accepting bytes, report the rest as
+                            // consumed so boot does not hang inside logging.
+                            return bytes.len();
+                        }
+                        core::hint::spin_loop();
+                        continue;
+                    }
+                    no_progress_spins = 0;
+                    written += n;
+                }
+                written
             } else {
                 // No sender available, simply return the length of bytes to indicate all bytes "written"
                 bytes.len()

--- a/components/someboot/src/lib.rs
+++ b/components/someboot/src/lib.rs
@@ -86,6 +86,11 @@ pub trait ArchTrait {
     fn virt_to_phys(vaddr: *const u8) -> usize;
 
     fn kernel_space() -> core::ops::Range<usize>;
+    fn is_kernel_relocated_at(addr: usize) -> bool {
+        (crate::consts::VM_LOAD_ADDRESS..usize::MAX).contains(&addr)
+    }
+
+    fn is_mmu_enabled() -> bool;
 
     fn kernel_page_table() -> PageTableInfo;
     fn set_kernel_page_table(val: PageTableInfo);

--- a/components/someboot/src/mem/mmu.rs
+++ b/components/someboot/src/mem/mmu.rs
@@ -10,7 +10,6 @@ pub type ArchPte = <<crate::arch::Arch as crate::ArchTrait>::P as page_table_gen
 
 static BOOT_TABLE: StaticCell<ArchPageTable<Ram>> = StaticCell::uninit();
 pub static mut BOOT_TABLE_ADDR: usize = 0;
-static mut MMU_ENABLED: bool = false;
 
 pub(crate) fn new_boot_table() -> ArchPageTable<Ram> {
     ArchPageTable::<Ram>::new(Ram).unwrap()
@@ -35,12 +34,18 @@ pub(crate) fn boot_table_addr() -> usize {
     unsafe { BOOT_TABLE_ADDR }
 }
 
-pub(crate) fn is_mmu_enabled() -> bool {
-    unsafe { MMU_ENABLED }
+pub fn is_mmu_enabled() -> bool {
+    <crate::arch::Arch as crate::ArchTrait>::is_mmu_enabled()
 }
 
-pub(crate) fn set_mmu_enabled() {
-    unsafe { MMU_ENABLED = true };
+pub(crate) fn is_kernel_relocated() -> bool {
+    if crate::consts::VM_LOAD_ADDRESS == crate::consts::KERNEL_LOAD_ADDRESS {
+        return true;
+    }
+
+    <crate::arch::Arch as crate::ArchTrait>::is_kernel_relocated_at(
+        is_kernel_relocated as *const () as usize,
+    )
 }
 
 pub trait PageTableOp {

--- a/components/someboot/src/mem/mod.rs
+++ b/components/someboot/src/mem/mod.rs
@@ -89,7 +89,7 @@ pub fn dcache_range(op: DCacheOp, addr: *const u8, size: usize) {
 
 /// 物理RAM实际转换为的内核虚拟地址
 pub fn phys_to_virt(paddr: usize) -> *mut u8 {
-    if mmu::is_mmu_enabled() {
+    if mmu::is_kernel_relocated() {
         if kimage_range().contains(&paddr) {
             __kimage_va(paddr)
         } else if percpu_range().contains(&paddr) {
@@ -109,7 +109,7 @@ pub fn virt_to_phys(vaddr: *const u8) -> usize {
 }
 
 pub(crate) fn _fixmap_io(paddr: usize) -> *mut u8 {
-    if mmu::is_mmu_enabled() {
+    if mmu::is_kernel_relocated() {
         __io(paddr)
     } else {
         paddr as *mut u8


### PR DESCRIPTION
## 背景

AArch64 在打开 SCTLR.M 到跳转高地址入口之间仍处在很脆弱的过渡窗口；这段路径如果继续走早期串口输出，可能因为 UART FIFO 满而卡住。同时，原来的 `someboot::mem::mmu::is_mmu_enabled()` 使用软件全局变量，语义同时承担“硬件 MMU 已开启”和“内核已经切到重定向后的虚拟地址”，容易让地址转换辅助函数过早返回高地址。

这类问题不是某个单独架构的特例：direct-map / kernel-space 地址范围可能比最终内核映像虚拟地址更宽。例如 AArch64 `hv` 构建下 `PAGE_OFFSET = 0`，LoongArch DMW 也会在最终高地址跳转前提供直映窗口。因此 relocated 判断必须表达“当前执行地址已经落入最终 `VM_LOAD_ADDRESS` 内核映像窗口”，而不是“当前地址可被某个 kernel/direct-map 范围覆盖”。

## 修改

- 将 `mem::mmu::is_mmu_enabled()` 改为只表示当前 CPU 硬件 MMU/分页状态：
  - x86_64 读取 CR0 paging 位；
  - riscv64 读取 satp mode；
  - aarch64 读取 SCTLR M 位；
  - loongarch64 读取 CRMD.PG。
- 新增 `mem::mmu::is_kernel_relocated()`，用于表示当前执行流是否已经到达重定向后的内核映像地址空间。
- 将 `ArchTrait::is_kernel_relocated_at()` 的默认语义泛化为检查当前函数地址是否位于最终 `VM_LOAD_ADDRESS..`，避免各架构把 direct-map / kernel-space 误当成 relocated。
- 删除 `MMU_ENABLED` 软件全局状态和所有 `set_mmu_enabled()` 调用，避免在“页表已生效但还没跳转高地址”的窗口提前切换地址转换语义。
- 将 `phys_to_virt()`、`_fixmap_io()`、x86_64 `_va()`、aarch64/riscv64 地址反查等地址转换消费者改用 `is_kernel_relocated()`。
- 保留 riscv64 `kernel_page_table()` / `set_kernel_page_table()` 对 `is_mmu_enabled()` 的使用，因为这里关心的是 satp 是否生效。
- AArch64 MMU enable 到高地址入口跳转之间不再打印串口日志，避免 MMU 切换窗口的 console stall。
- 更新架构移植说明，记录硬件 MMU、direct-map/kernel-space 可达性、最终内核 relocation 三者必须分开判断。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo xtask clippy --package someboot`
- `cargo xtask axvisor test qemu --arch aarch64`
- `cargo xtask arceos test qemu --arch aarch64`
- `cargo xtask arceos test qemu --arch loongarch64`

其中本地复现到 axvisor aarch64 在 per-CPU 初始化阶段因 relocated 误判卡住；泛化为 `VM_LOAD_ADDRESS` 判断后，axvisor aarch64 QEMU 能启动 guest Linux 并匹配 `guest test pass!`。