### PR TITLE
fix(rknpu): honor GEM cache flags for mmap

### DIFF
--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -2,11 +2,11 @@ use alloc::vec::Vec;
 
 use log::info;
 use rdrive::{probe::OnProbeError, register::ProbeFdt};
-use rockchip_npu::{Rknpu, RknpuConfig, RknpuType};
 pub use rockchip_npu::{
-    RknpuAction,
+    GemBufferInfo, GemCachePolicy, RknpuAction,
     ioctrl::{RknpuMemCreate, RknpuMemMap, RknpuMemSync, RknpuSubmit},
 };
+use rockchip_npu::{Rknpu, RknpuConfig, RknpuType};
 use rockchip_pm::{PowerDomain, RockchipPM};
 
 use crate::mmio::iomap;
@@ -82,6 +82,10 @@ pub fn is_available() -> bool {
 
 pub fn obj_addr_and_size(handle: u32) -> Result<(usize, usize), Error> {
     with_npu(|npu| npu.get_obj_addr_and_size(handle).ok_or(Error::NotFound))
+}
+
+pub fn buffer_info(handle: u32) -> Result<GemBufferInfo, Error> {
+    with_npu(|npu| npu.get_buffer_info(handle).ok_or(Error::NotFound))
 }
 
 pub fn submit(args: &mut RknpuSubmit) -> Result<(), Error> {

--- a/drivers/npu/rockchip-npu/src/gem.rs
+++ b/drivers/npu/rockchip-npu/src/gem.rs
@@ -7,9 +7,45 @@ use crate::{
     ioctrl::{RknpuMemCreate, RknpuMemSync},
 };
 
+const RKNPU_MEM_CACHEABLE: u32 = 1 << 1;
+const RKNPU_MEM_WRITE_COMBINE: u32 = 1 << 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GemCachePolicy {
+    NonCacheable,
+    Cacheable,
+    WriteCombine,
+}
+
+impl GemCachePolicy {
+    fn from_flags(flags: u32) -> Self {
+        if flags & RKNPU_MEM_CACHEABLE != 0 {
+            Self::Cacheable
+        } else if flags & RKNPU_MEM_WRITE_COMBINE != 0 {
+            Self::WriteCombine
+        } else {
+            Self::NonCacheable
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GemBufferInfo {
+    pub obj_addr: usize,
+    pub dma_addr: u64,
+    pub size: usize,
+    pub flags: u32,
+    pub cache_policy: GemCachePolicy,
+}
+
+struct GemBuffer {
+    data: ContiguousArray<u8>,
+    flags: u32,
+}
+
 pub struct GemPool {
     dma: DeviceDma,
-    pool: BTreeMap<u32, ContiguousArray<u8>>,
+    pool: BTreeMap<u32, GemBuffer>,
     handle_counter: u32,
 }
 
@@ -39,29 +75,44 @@ impl GemPool {
         args.sram_size = data.len() as _;
         args.dma_addr = data.dma_addr().as_u64();
         args.obj_addr = data.as_ptr().as_ptr() as _;
-        self.pool.insert(args.handle, data);
+        self.pool.insert(
+            args.handle,
+            GemBuffer {
+                data,
+                flags: args.flags,
+            },
+        );
         Ok(())
+    }
+
+    pub fn get_buffer_info(&self, handle: u32) -> Option<GemBufferInfo> {
+        self.pool.get(&handle).map(|buffer| GemBufferInfo {
+            obj_addr: buffer.data.as_ptr().as_ptr() as usize,
+            dma_addr: buffer.data.dma_addr().as_u64(),
+            size: buffer.data.len(),
+            flags: buffer.flags,
+            cache_policy: GemCachePolicy::from_flags(buffer.flags),
+        })
     }
 
     /// Get the physical address and size of the memory object.
     pub fn get_phys_addr_and_size(&self, handle: u32) -> Option<(u64, usize)> {
-        self.pool
-            .get(&handle)
-            .map(|data| (data.dma_addr().as_u64(), data.len()))
+        self.get_buffer_info(handle)
+            .map(|info| (info.dma_addr, info.size))
     }
 
     /// Get the CPU-visible virtual address and size of the memory object.
     pub fn get_obj_addr_and_size(&self, handle: u32) -> Option<(usize, usize)> {
-        self.pool
-            .get(&handle)
-            .map(|data| (data.as_ptr().as_ptr() as usize, data.len()))
+        self.get_buffer_info(handle)
+            .map(|info| (info.obj_addr, info.size))
     }
 
     pub fn sync(&mut self, args: &mut RknpuMemSync) -> Result<(), RknpuError> {
         const RKNPU_MEM_SYNC_TO_DEVICE: u32 = 1 << 0;
         const RKNPU_MEM_SYNC_FROM_DEVICE: u32 = 1 << 1;
 
-        let Some((data, base_offset)) = self.pool.values_mut().find_map(|data| {
+        let Some((data, base_offset)) = self.pool.values_mut().find_map(|buffer| {
+            let data = &mut buffer.data;
             let base = data.as_ptr().as_ptr() as u64;
             let end = base.checked_add(data.bytes_len() as u64)?;
             (args.obj_addr >= base && args.obj_addr < end).then_some((data, args.obj_addr - base))
@@ -97,15 +148,15 @@ impl GemPool {
     }
 
     pub fn comfirm_write_all(&mut self) -> Result<(), RknpuError> {
-        for data in self.pool.values_mut() {
-            data.prepare_for_device_all();
+        for buffer in self.pool.values_mut() {
+            buffer.data.prepare_for_device_all();
         }
         Ok(())
     }
 
     pub fn prepare_read_all(&mut self) -> Result<(), RknpuError> {
-        for data in self.pool.values_mut() {
-            data.complete_for_cpu_all();
+        for buffer in self.pool.values_mut() {
+            buffer.data.complete_for_cpu_all();
         }
         Ok(())
     }

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -767,7 +767,7 @@ pub fn drm_version(data: &mut [u8]) -> VfsResult<()> {
         let ret = drm_copy_field(
             data.date as *mut u8,
             &mut data.date_len,
-            DRM1_DATE.as_ptr() as *const u8,
+            DRM1_DATE.as_ptr().cast(),
         );
         if let Err(e) = ret {
             warn!("[drm_version] Failed to copy driver date: {:?}", e);

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -8,7 +8,9 @@ use core::{
     task::Context,
 };
 
-use ax_driver::rknpu::{self, RknpuAction, RknpuMemCreate, RknpuMemMap, RknpuMemSync, RknpuSubmit};
+use ax_driver::rknpu::{
+    self, GemCachePolicy, RknpuAction, RknpuMemCreate, RknpuMemMap, RknpuMemSync, RknpuSubmit,
+};
 use ax_errno::{AxError, AxResult};
 use ax_memory_addr::PhysAddrRange;
 use ax_runtime::hal::{cpu::asm::user_copy, mem::virt_to_phys, time::monotonic_time_nanos};
@@ -221,17 +223,32 @@ impl DeviceOps for Card1 {
             warn!("card1: mmap could not resolve handle {handle}");
             return DeviceMmap::None;
         };
-        DeviceMmap::Physical(exported.range, None)
+        exported.device_mmap_kind()
     }
 }
 
 struct ExportedGemBuffer {
     range: PhysAddrRange,
+    cache_policy: GemCachePolicy,
 }
 
 impl ExportedGemBuffer {
-    fn new(range: PhysAddrRange) -> Self {
-        Self { range }
+    fn new(range: PhysAddrRange, cache_policy: GemCachePolicy) -> Self {
+        Self {
+            range,
+            cache_policy,
+        }
+    }
+
+    fn device_mmap_kind(&self) -> DeviceMmap {
+        match self.cache_policy {
+            GemCachePolicy::Cacheable => DeviceMmap::PhysicalCached(self.range, None),
+            // Starry does not expose a write-combine PTE mode yet; keep it
+            // non-cacheable instead of accidentally upgrading it to cached.
+            GemCachePolicy::NonCacheable | GemCachePolicy::WriteCombine => {
+                DeviceMmap::Physical(self.range, None)
+            }
+        }
     }
 }
 
@@ -241,7 +258,7 @@ impl FileLike for ExportedGemBuffer {
     }
 
     fn device_mmap(&self, _offset: u64, _length: u64) -> AxResult<DeviceMmap> {
-        Ok(DeviceMmap::Physical(self.range, None))
+        Ok(self.device_mmap_kind())
     }
 }
 
@@ -266,13 +283,14 @@ fn map_handle_from_offset(offset: u64) -> Option<u32> {
 }
 
 fn exported_gem_buffer(handle: u32) -> AxResult<ExportedGemBuffer> {
-    let (obj_addr, size) = rknpu::obj_addr_and_size(handle)
+    let info = rknpu::buffer_info(handle)
         .map_err(map_rknpu_err)
         .map_err(|_| AxError::NotFound)?;
-    let paddr = virt_to_phys(obj_addr.into());
-    Ok(ExportedGemBuffer::new(PhysAddrRange::from_start_size(
-        paddr, size,
-    )))
+    let paddr = virt_to_phys(info.obj_addr.into());
+    Ok(ExportedGemBuffer::new(
+        PhysAddrRange::from_start_size(paddr, info.size),
+        info.cache_policy,
+    ))
 }
 
 fn map_rknpu_err(err: rknpu::Error) -> VfsError {
@@ -694,7 +712,27 @@ mod tests {
     #[test]
     fn exported_buffer_reports_physical_device_mmap() {
         let range = PhysAddrRange::from_start_size(0x1234_5000.into(), 0x4000);
-        let exported = ExportedGemBuffer::new(range);
+        let exported = ExportedGemBuffer::new(range, GemCachePolicy::Cacheable);
+
+        assert!(
+            matches!(exported.device_mmap(0, 0).unwrap(), DeviceMmap::PhysicalCached(actual, None) if actual == range)
+        );
+    }
+
+    #[test]
+    fn exported_buffer_defaults_to_uncached_device_mmap() {
+        let range = PhysAddrRange::from_start_size(0x1234_5000.into(), 0x4000);
+        let exported = ExportedGemBuffer::new(range, GemCachePolicy::NonCacheable);
+
+        assert!(
+            matches!(exported.device_mmap(0, 0).unwrap(), DeviceMmap::Physical(actual, None) if actual == range)
+        );
+    }
+
+    #[test]
+    fn exported_buffer_maps_write_combine_as_uncached_without_wc_pte_support() {
+        let range = PhysAddrRange::from_start_size(0x1234_5000.into(), 0x4000);
+        let exported = ExportedGemBuffer::new(range, GemCachePolicy::WriteCombine);
 
         assert!(
             matches!(exported.device_mmap(0, 0).unwrap(), DeviceMmap::Physical(actual, None) if actual == range)
@@ -726,11 +764,7 @@ pub fn drm_version(data: &mut [u8]) -> VfsResult<()> {
         }
 
         // Copy driver date
-        let ret = drm_copy_field(
-            data.date as *mut u8,
-            &mut data.date_len,
-            DRM1_DATE.as_ptr() as *const u8,
-        );
+        let ret = drm_copy_field(data.date as *mut u8, &mut data.date_len, DRM1_DATE.as_ptr());
         if let Err(e) = ret {
             warn!("[drm_version] Failed to copy driver date: {:?}", e);
             return Err(VfsError::InvalidData);

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -764,7 +764,11 @@ pub fn drm_version(data: &mut [u8]) -> VfsResult<()> {
         }
 
         // Copy driver date
-        let ret = drm_copy_field(data.date as *mut u8, &mut data.date_len, DRM1_DATE.as_ptr());
+        let ret = drm_copy_field(
+            data.date as *mut u8,
+            &mut data.date_len,
+            DRM1_DATE.as_ptr() as *const u8,
+        );
         if let Err(e) = ret {
             warn!("[drm_version] Failed to copy driver date: {:?}", e);
             return Err(VfsError::InvalidData);

--- a/os/StarryOS/kernel/src/pseudofs/device.rs
+++ b/os/StarryOS/kernel/src/pseudofs/device.rs
@@ -31,6 +31,12 @@ pub enum DeviceMmap {
     /// [`LinearBackend`] so userspace can't observe freed memory if
     /// the device drops the buffer before munmap.
     Physical(PhysAddrRange, Option<Arc<dyn Any + Send + Sync>>),
+    /// Maps to cacheable physical RAM.
+    ///
+    /// This is for DMA buffers that are normal memory and whose driver/runtime
+    /// performs explicit cache maintenance around device access.
+    #[cfg(feature = "rknpu")]
+    PhysicalCached(PhysAddrRange, Option<Arc<dyn Any + Send + Sync>>),
     /// Maps to an already offset-resolved physical address range.
     ///
     /// This is for file descriptors whose mmap offset is a selector rather than

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -214,6 +214,8 @@ pub fn sys_mmap(
                     .as_ref()
                     .expect("file-backed mmap has cached device_mmap")
                 {
+                    #[cfg(feature = "rknpu")]
+                    Ok(DeviceMmap::PhysicalCached(..)) => false,
                     Ok(DeviceMmap::Physical(..))
                     | Ok(DeviceMmap::PhysicalResolved(..))
                     | Ok(DeviceMmap::PhysicalPages(..))
@@ -338,6 +340,22 @@ pub fn sys_mmap(
                             None => Backend::new_linear(start, pa_va_offset, true),
                         }
                     }
+                    #[cfg(feature = "rknpu")]
+                    Ok(DeviceMmap::PhysicalCached(mut range, retain)) => {
+                        range.start += offset;
+                        if range.is_empty() {
+                            return Err(AxError::InvalidInput);
+                        }
+                        length = length.min(range.size().align_down(page_size));
+                        let pa_va_offset =
+                            start.as_usize() as isize - range.start.as_usize() as isize;
+                        match retain {
+                            Some(retain) => {
+                                Backend::new_linear_anchored(start, pa_va_offset, true, retain)
+                            }
+                            None => Backend::new_linear(start, pa_va_offset, true),
+                        }
+                    }
                     Ok(DeviceMmap::PhysicalResolved(range, retain)) => {
                         mapping_flags |= MappingFlags::UNCACHED;
                         if range.is_empty() {
@@ -400,6 +418,25 @@ pub fn sys_mmap(
                                     }
                                     DeviceMmap::Physical(range, retain) => {
                                         mapping_flags |= MappingFlags::UNCACHED;
+                                        if range.is_empty() {
+                                            return Err(AxError::InvalidInput);
+                                        }
+                                        length =
+                                            capped_device_map_len(length, range.size(), page_size);
+                                        let pa_va_offset = start.as_usize() as isize
+                                            - range.start.as_usize() as isize;
+                                        match retain {
+                                            Some(retain) => Backend::new_linear_anchored(
+                                                start,
+                                                pa_va_offset,
+                                                true,
+                                                retain,
+                                            ),
+                                            None => Backend::new_linear(start, pa_va_offset, true),
+                                        }
+                                    }
+                                    #[cfg(feature = "rknpu")]
+                                    DeviceMmap::PhysicalCached(range, retain) => {
                                         if range.is_empty() {
                                             return Err(AxError::InvalidInput);
                                         }


### PR DESCRIPTION
## 问题

StarryOS 的 RKNPU GEM buffer 在 mmap 到用户态时，原先统一按 non-cacheable 映射处理，没有根据`RKNPU_MEM_CREATE.flags` 区分 cache 策略。

对比 Linux RKNPU 驱动行为，当前实现会让 RKNN runtime 创建的 cacheable buffer 无法利用正常 cached 映射，导致用户态输入路径存在额外性能损耗。

## 修改

- 在 `rockchip-npu` 的 GEM pool 中保存 `RKNPU_MEM_CREATE.flags`，并对外暴露 `GemBufferInfo` 和`GemCachePolicy`。
- 在 `ax-driver` 中增加查询 GEM buffer 信息的接口。
- 在 StarryOS `/dev/dri/card1` mmap/export 路径中，根据 GEM cache policy 选择 mmap 类型。
- 新增 `DeviceMmap::PhysicalCached`，用于表示 cacheable 物理内存映射。
- 在 `sys_mmap` 中支持 `PhysicalCached`，使其不再被强制加上 `UNCACHED` 映射属性。
- 对 `WRITE_COMBINE` 暂时保守映射为 non-cacheable，因为当前 StarryOS 尚未提供 write-combine PTE 映射模式。