### PR TITLE
fix(starryos): stabilize proc mem monitor test

### DIFF
--- a/test-suit/starryos/qemu-smp1/system/proc-test-proc-mem-monitor/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/proc-test-proc-mem-monitor/src/main.c
@@ -660,6 +660,9 @@ static void test_fork_rw_file_read_child_write(long page_size)
             (ssize_t)sizeof(child_after_write)) {
             _exit(1);
         }
+        if (io_read_all(release[0], &byte, 1) != 1) {
+            _exit(1);
+        }
         close(notify[1]);
         close(release[0]);
         close(fd);
@@ -704,7 +707,6 @@ static void test_fork_rw_file_read_child_write(long page_size)
                (ssize_t)sizeof(child_after_write),
            "read child RSS after RW file COW write");
     close(notify[0]);
-    close(release[1]);
     expect(child_after_write.pid == child, "child pid matches after COW write");
 
     snprintf(child_status, sizeof(child_status), "/proc/%d/status", child);
@@ -737,6 +739,8 @@ static void test_fork_rw_file_read_child_write(long page_size)
                parent_anon_after_fork + page_kb * RSS_TOUCH_TOLERANCE,
            "parent RssAnon stable within tolerance after child COW write");
 
+    expect(io_write_all(release[1], "D", 1) == 1, "release fork RW file child after proc read");
+    close(release[1]);
     expect(waitpid(child, &status, 0) == child, "waitpid fork RW file child");
     expect(WIFEXITED(status) && WEXITSTATUS(status) == 0,
            "fork RW file child exits cleanly");


### PR DESCRIPTION
## 问题

CI 的 `Test starry riscv64 qemu / run_container` 在 `test-proc-mem-monitor` 中失败，失败点是 child 写入 COW 页后，child 自读的 `/proc/self/status` RSS 与 parent 随后读取 `/proc/<child>/status` 的 RSS 不一致。

根因是测例同步存在竞态：child 在把 post-COW RSS 结果写给 parent 后会立刻退出，parent 再去读取 `/proc/<child>/status` 时，可能已经碰到 child 进入退出或资源回收阶段，导致读取到的 RSS 状态不再对应 child 自读时的状态。

## 修改

- 在 child 写回 post-COW RSS 结果后，继续等待 parent 的释放信号。
- parent 保持 release pipe 打开，完成 `/proc/<child>/status` 与 parent RSS 校验后，再释放 child 退出。

这样可以保证两次比较都发生在 child 仍然存活、且处于同一测试阶段的状态下，避免把进程退出路径的时序差异误判为内存统计错误。

## 验证

- `cargo fmt`
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp1/system/proc-test-proc-mem-monitor`
- `cargo xtask starry test qemu --arch riscv64`
