### PR TITLE
fix(starryos): bound signal interrupt qemu test wait

### DIFF
--- a/scripts/axbuild/src/starry/test/tests/system_case_tests.rs
+++ b/scripts/axbuild/src/starry/test/tests/system_case_tests.rs
@@ -138,6 +138,31 @@ fn starry_system_grouped_qemu_configs_report_subcase_timing() {
 }
 
 #[test]
+fn signal_interrupt_eintr_subcase_bounds_child_wait() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let source_path = workspace_root
+        .join("test-suit/starryos/qemu-smp1/system/test-signal-interrupt-eintr/src/main.c");
+    let source = fs::read_to_string(&source_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", source_path.display()));
+
+    assert!(
+        source.contains("poll(&pfd, 1, -1)") && source.matches("kill(child, SIGUSR1)").count() >= 2,
+        "{} must preserve the poll EINTR check and retry SIGUSR1 while the child is still running",
+        source_path.display()
+    );
+    assert!(
+        source.contains("TEST_TIMEOUT_MS") && source.contains("WNOHANG"),
+        "{} must bound the parent wait for the interruptible child",
+        source_path.display()
+    );
+    assert!(
+        !source.contains("waitpid(child, &status, 0)"),
+        "{} must not let a stuck child consume the whole grouped QEMU timeout",
+        source_path.display()
+    );
+}
+
+#[test]
 fn zombie_bugfix_commands_are_in_system_grouped_qemu_case() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let system_dir = workspace_root.join("test-suit/starryos/qemu-smp1/system");

--- a/test-suit/starryos/qemu-smp1/system/test-signal-interrupt-eintr/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-signal-interrupt-eintr/src/main.c
@@ -21,6 +21,9 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#define TEST_TIMEOUT_MS 5000
+#define WAIT_POLL_INTERVAL_US 10000
+
 static volatile sig_atomic_t got_usr1 = 0;
 
 static void on_usr1(int signo)
@@ -127,8 +130,38 @@ int main(void)
     }
 
     int status = 0;
-    if (waitpid(child, &status, 0) != child) {
-        perror("parent: waitpid");
+    int waited_ms = 0;
+    pid_t waited = 0;
+    while (waited_ms < TEST_TIMEOUT_MS) {
+        waited = waitpid(child, &status, WNOHANG);
+        if (waited == child) {
+            break;
+        }
+        if (waited < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            perror("parent: waitpid");
+            return 1;
+        }
+        usleep(WAIT_POLL_INTERVAL_US);
+        waited_ms += WAIT_POLL_INTERVAL_US / 1000;
+        if (kill(child, SIGUSR1) != 0) {
+            if (errno == ESRCH) {
+                continue;
+            }
+            perror("parent: retry kill(SIGUSR1)");
+            kill(child, SIGKILL);
+            waitpid(child, NULL, 0);
+            return 1;
+        }
+    }
+
+    if (waited != child) {
+        fprintf(stderr, "FAIL: child did not exit after SIGUSR1 within %d ms\n",
+                TEST_TIMEOUT_MS);
+        kill(child, SIGKILL);
+        waitpid(child, NULL, 0);
         return 1;
     }
 


### PR DESCRIPTION
## 问题

`test-signal-interrupt-eintr` 中父子进程通过 pipe 做 ready 同步，但子进程写出 ready 后才进入 `poll(-1)`。在 aarch64 QEMU 上，父进程可能在子进程真正阻塞前就完成 `SIGUSR1` 投递，导致子进程随后进入无限 `poll`，最终整个 `qemu-smp1/system` 只能等待 1800 秒 QEMU 超时。

## 修改

- 保留原用例验证的 `poll(-1)` 被 `SIGUSR1` 打断并返回 `EINTR` 的行为。
- 将父进程的 `waitpid` 改成带 `WNOHANG` 的有界等待，并在子进程仍未退出时重复发送 `SIGUSR1`。
- 如果 5 秒内仍未完成，父进程会杀掉子进程并明确失败，避免单个子用例拖完整个 grouped QEMU 超时。
- 为 `axbuild` 增加回归检查，要求该 Starry system 子用例继续保留 `poll` 断言、重复投递信号和有界等待。

## 验证

- `cargo test -p axbuild signal_interrupt_eintr_subcase_bounds_child_wait`
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system/test-signal-interrupt-eintr`
- `cargo xtask clippy --package axbuild`
- `git diff --check HEAD~1..HEAD`