### PR TITLE
fix(lockdep): resolve Starry lock order regressions

### DIFF
--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -28,6 +28,7 @@ pub use self::{
 };
 
 type MovedPage = (VirtAddr, VirtAddr, PhysAddr, MappingFlags, PageSize, bool);
+const CLONED_ADDR_SPACE_LOCK_SUBCLASS: u32 = 1;
 
 fn rollback_moved_pages(cursor: &mut PageTableCursor, moved_pages: &[MovedPage]) {
     for &(src_va, dst_va, paddr, flags, page_size, dst_newly_mapped) in moved_pages.iter().rev() {
@@ -582,7 +583,10 @@ impl AddrSpace {
         let new_aspace = Arc::new(Mutex::new(Self::new_empty(self.base(), self.size())?));
         let new_aspace_clone = new_aspace.clone();
 
-        let mut guard = new_aspace.lock_nested(1);
+        // The caller holds the source AddrSpace lock while this fresh AddrSpace
+        // is being populated. The new lock is not published yet, so this is a
+        // structured source -> cloned-address-space nesting.
+        let mut guard = new_aspace.lock_nested(CLONED_ADDR_SPACE_LOCK_SUBCLASS);
         let child_rss = guard.rss() as *const MemoryAccounting;
         let child_acct = unsafe { &*child_rss };
         let parent_acct = &self.rss;

--- a/os/StarryOS/kernel/src/task/futex.rs
+++ b/os/StarryOS/kernel/src/task/futex.rs
@@ -17,7 +17,7 @@ use core::{
 
 use ax_errno::AxResult;
 use ax_memory_addr::VirtAddr;
-use ax_sync::Mutex;
+use ax_sync::{LockdepMutexExt, Mutex};
 use ax_task::{
     current,
     future::{self, block_on, interruptible},
@@ -28,6 +28,8 @@ use crate::{
     mm::{AddrSpace, Backend, SharedPages},
     task::{AsThread, ProcessData},
 };
+
+const NESTED_WAIT_QUEUE_LOCK_SUBCLASS: u32 = 1;
 
 /// Wait queue used by futex.
 #[derive(Default)]
@@ -240,7 +242,7 @@ impl WaitQueue {
         match core::ptr::from_ref(self).cmp(&core::ptr::from_ref(target)) {
             Ordering::Less => {
                 let mut src = self.inner.lock();
-                let mut dst = target.inner.lock();
+                let mut dst = target.inner.lock_nested(NESTED_WAIT_QUEUE_LOCK_SUBCLASS);
                 let wake_second = condition.take().expect("condition used once")()?;
                 Self::wake_locked(&mut src.queue, wake_count, u32::MAX, &mut wakers);
                 if wake_second {
@@ -249,7 +251,7 @@ impl WaitQueue {
             }
             Ordering::Greater => {
                 let mut dst = target.inner.lock();
-                let mut src = self.inner.lock();
+                let mut src = self.inner.lock_nested(NESTED_WAIT_QUEUE_LOCK_SUBCLASS);
                 let wake_second = condition.take().expect("condition used once")()?;
                 Self::wake_locked(&mut src.queue, wake_count, u32::MAX, &mut wakers);
                 if wake_second {
@@ -330,7 +332,7 @@ impl WaitQueue {
         let count = match core::ptr::from_ref(self).cmp(&core::ptr::from_ref(target)) {
             Ordering::Less => {
                 let mut src = self.inner.lock();
-                let mut dst = target.inner.lock();
+                let mut dst = target.inner.lock_nested(NESTED_WAIT_QUEUE_LOCK_SUBCLASS);
                 if !condition.take().expect("condition used once")()? {
                     return Ok(None);
                 }
@@ -346,7 +348,7 @@ impl WaitQueue {
             }
             Ordering::Greater => {
                 let mut dst = target.inner.lock();
-                let mut src = self.inner.lock();
+                let mut src = self.inner.lock_nested(NESTED_WAIT_QUEUE_LOCK_SUBCLASS);
                 if !condition.take().expect("condition used once")()? {
                     return Ok(None);
                 }

--- a/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
@@ -707,17 +707,20 @@ impl BlockDeviceHandle {
     ) -> Option<bool> {
         loop {
             match result {
-                Ok(RequestStatus::Pending) => match self.pending.lock().finish_pending_poll(key) {
-                    PollProgress::Pending | PollProgress::Complete => return Some(false),
-                    PollProgress::Repoll => {
-                        let submitted = self
-                            .pending
-                            .lock()
-                            .request(key)
-                            .map(|request| request.submitted_request())?;
-                        result = self.poll_request(submitted.queue_id, submitted.request_id);
+                Ok(RequestStatus::Pending) => {
+                    let progress = self.pending.lock().finish_pending_poll(key);
+                    match progress {
+                        PollProgress::Pending | PollProgress::Complete => return Some(false),
+                        PollProgress::Repoll => {
+                            let submitted = self
+                                .pending
+                                .lock()
+                                .request(key)
+                                .map(|request| request.submitted_request())?;
+                            result = self.poll_request(submitted.queue_id, submitted.request_id);
+                        }
                     }
-                },
+                }
                 Ok(RequestStatus::Complete) => {
                     let task_id = self.pending.lock().complete(key, Ok(()));
                     self.wake_completed_request(key, task_id);

--- a/os/arceos/modules/axfs-ng/src/file/cache.rs
+++ b/os/arceos/modules/axfs-ng/src/file/cache.rs
@@ -731,7 +731,6 @@ impl CachedFile {
 
     /// Reads data from the file at `offset` into `dst`.
     pub fn read_at(&self, mut dst: impl Write + IoBufMut, offset: u64) -> VfsResult<usize> {
-        let _io = self.shared.io_lock.lock();
         let len = self.shared.len();
         let end = offset.saturating_add(dst.remaining_mut() as u64).min(len);
         if end <= offset {
@@ -749,12 +748,16 @@ impl CachedFile {
             let chunk_len = (end - page_start).min(PAGE_SIZE as u64) as usize - page_offset;
 
             {
+                let _io = self.shared.io_lock.lock();
                 let mut guard = self.shared.page_cache.lock();
                 let page = self.page_or_insert(file, &mut guard, pn, true)?.0;
                 scratch.data()[..chunk_len]
                     .copy_from_slice(&page.data()[page_offset..page_offset + chunk_len]);
             }
 
+            // `dst` may point at user memory. Copy after releasing cached-file
+            // locks so a user page fault can take AddrSpace without creating a
+            // cached-I/O -> AddrSpace lock order.
             dst.write_all(&scratch.data()[..chunk_len])?;
             read += chunk_len;
             current += chunk_len as u64;


### PR DESCRIPTION
  ## Problem

  Running StarryOS tests with `lockdep` enabled exposed several lock-order issues:

  - Fork/clone address-space duplication takes the source AddrSpace lock and then the newly created AddrSpace lock, but this  structured nesting was not annotated.
  - Futex requeue/wait paths can take nested wait queue locks, which lockdep may classify as same-class recursive locking
  without an explicit subclass.
  - `ax-fs-ng` cached reads held cached-file locks while writing into the destination buffer. If that buffer points to user
  memory, the copy can fault and acquire AddrSpace, creating a cached I/O/page cache -> AddrSpace edge.
  - The ax-fs-ng block runtime repoll path could keep the pending lock held across repoll, creating unnecessary lock-order
  risk.

  ## Changes

  - Annotate cloned AddrSpace locking with a nested lock subclass.
  - Annotate nested futex wait queue locking with a nested lock subclass.
  - Narrow `CachedFile::read_at()` locking so cached data is copied into a scratch page while holding cached-file locks, then
  copied to the destination after releasing them.
  - Release the ax-fs-ng block runtime pending lock before repolling.
