### PR TITLE
fix(crab-usb): ignore xHCI ISO ring xrun events

### DIFF
--- a/drivers/usb/usb-host/src/backend/kmod/xhci/transfer.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/transfer.rs
@@ -1,6 +1,6 @@
 use alloc::{collections::BTreeMap, sync::Arc};
 
-use xhci::ring::trb::event::TransferEvent;
+use xhci::ring::trb::event::{CompletionCode, TransferEvent};
 
 use super::{reg::XhciRegistersShared, ring::SendRing, sync::IrqLock};
 use crate::{BusAddr, queue::Finished};
@@ -42,6 +42,19 @@ impl TransferResultHandler {
     /// the map. The IRQ hot path uses `force_use` and only touches the
     /// pre-registered queue completion slot, then wakes queue-local waiters.
     pub unsafe fn set_finished(&self, slot_id: u8, ep_id: u8, ptr: BusAddr, res: TransferEvent) {
+        // xHCI reports ISO ring underrun/overrun when the periodic ring is
+        // empty. Linux treats these as ring xrun events, not TD completions.
+        if is_iso_ring_xrun(res) {
+            trace!(
+                "xhci: ignore ISO ring xrun event slot={} ep={} ptr={:#x} code={:?}",
+                slot_id,
+                ep_id,
+                ptr.raw(),
+                res.completion_code()
+            );
+            return;
+        }
+
         let queue_id = TransQueueId { slot_id, ep_id };
         if let Some(q) = unsafe { self.inner.force_use().get(&queue_id) } {
             trace!(
@@ -65,4 +78,11 @@ impl TransferResultHandler {
             );
         }
     }
+}
+
+fn is_iso_ring_xrun(event: TransferEvent) -> bool {
+    matches!(
+        event.completion_code(),
+        Ok(CompletionCode::RingUnderrun | CompletionCode::RingOverrun)
+    )
 }


### PR DESCRIPTION
  ## Problem

  The xHCI interrupt path can report `RingUnderrun` or `RingOverrun` for ISO endpoints when the periodic ring is empty. These
  events describe ISO ring xrun state rather than a normal transfer descriptor completion.

  Dispatching them through the normal transfer completion path can produce misleading queue completions or warnings for
  endpoint queues.

  ## Changes

  - Detect `CompletionCode::RingUnderrun` and `CompletionCode::RingOverrun` in the xHCI transfer event handler.
  - Ignore those ISO ring xrun events before normal transfer completion dispatch.
  - Keep a trace log so the event is still visible during debugging without waking or completing queue-local waiters.
