### PR TITLE
feat(starry): add /dev/kmsg write-side device

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/kmsg.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/kmsg.rs
@@ -1,0 +1,83 @@
+//! `/dev/kmsg` — kernel log device (char major 1, minor 11).
+//!
+//! Write side only: a writer emits log records here before any userspace
+//! logger exists. Each `write()` is one record; we parse its optional
+//! `<priority>` prefix the way Linux's `devkmsg_write()` does and forward the
+//! message to the kernel log so it reaches the console.
+//!
+//! The read side (history replay) is not implemented yet; `read_at` returns
+//! EOF.
+
+use core::any::Any;
+
+use axfs_ng_vfs::{NodeFlags, VfsResult};
+
+use crate::pseudofs::DeviceOps;
+
+/// Level used when a record carries no valid `<priority>` prefix. Linux falls
+/// back to `default_message_loglevel`; `6` (`LOG_INFO`) is the closest sane
+/// default for forwarded userspace messages.
+const DEFAULT_LEVEL: u8 = 6;
+
+/// `/dev/kmsg` device. Stateless: like Linux, each `write()` is one record.
+pub(crate) struct Kmsg;
+
+impl Kmsg {
+    /// Split a kmsg record into `(severity, message)`.
+    ///
+    /// Mirrors Linux `devkmsg_write()`: if the record starts with `<`, parse
+    /// the following decimal digits as the syslog priority
+    /// (`facility << 3 | severity`) and accept it only when a `>` immediately
+    /// follows the digits. The severity is the low 3 bits. Anything else (no
+    /// `<`, no digits, or a non-`>` terminator) is not a prefix and the whole
+    /// record is the message with the default level.
+    fn parse(buf: &[u8]) -> (u8, &[u8]) {
+        if let [b'<', rest @ ..] = buf {
+            let digits = rest.iter().take_while(|c| c.is_ascii_digit()).count();
+            if digits > 0 && rest.get(digits) == Some(&b'>') {
+                let mut priority: u64 = 0;
+                for &c in &rest[..digits] {
+                    priority = priority
+                        .saturating_mul(10)
+                        .saturating_add((c - b'0') as u64);
+                }
+                return ((priority & 7) as u8, &rest[digits + 1..]);
+            }
+        }
+        (DEFAULT_LEVEL, buf)
+    }
+}
+
+impl DeviceOps for Kmsg {
+    fn read_at(&self, _buf: &mut [u8], _offset: u64) -> VfsResult<usize> {
+        Ok(0)
+    }
+
+    fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {
+        let (severity, msg) = Self::parse(buf);
+        // The record layer (here, axlog) terminates each line, so drop a
+        // single trailing newline to avoid emitting a blank line after it.
+        let msg = msg.strip_suffix(b"\n").unwrap_or(msg);
+        let text = core::str::from_utf8(msg).unwrap_or("<kmsg: invalid utf-8>");
+        match severity {
+            // EMERG / ALERT / CRIT / ERR
+            0..=3 => error!("{text}"),
+            // WARNING
+            4 => warn!("{text}"),
+            // NOTICE / INFO
+            5 | 6 => info!("{text}"),
+            // DEBUG (and anything out of range)
+            _ => debug!("{text}"),
+        }
+        // Always report the whole record consumed, as Linux does.
+        Ok(buf.len())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn flags(&self) -> NodeFlags {
+        NodeFlags::NON_CACHEABLE | NodeFlags::STREAM
+    }
+}

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -11,6 +11,7 @@ pub mod event;
 mod fb;
 #[cfg(feature = "sg2002")]
 mod irq_byte_ring;
+mod kmsg;
 #[cfg(feature = "k230-kpu")]
 mod kpu;
 #[cfg(feature = "dev-log")]
@@ -331,6 +332,17 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
             NodeType::CharacterDevice,
             DeviceId::new(10, 1024),
             Arc::new(CpuDmaLatency),
+        ),
+    );
+    // /dev/kmsg — standard char major 1, minor 11 (LANANA memory-device major,
+    // same group as null/zero/random above).
+    root.add(
+        "kmsg",
+        Device::new(
+            fs.clone(),
+            NodeType::CharacterDevice,
+            DeviceId::new(1, 11),
+            Arc::new(kmsg::Kmsg),
         ),
     );
     root.add(

--- a/test-suit/starryos/qemu-smp1/system/test-dev-kmsg/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/test-dev-kmsg/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(test_dev_kmsg C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-dev-kmsg src/main.c)
+target_compile_options(test-dev-kmsg PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-dev-kmsg RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/test-dev-kmsg/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/test-dev-kmsg/src/main.c
@@ -1,0 +1,93 @@
+/*
+ * test-dev-kmsg — /dev/kmsg write-side device (char major 1, minor 11).
+ *
+ * The kernel exposes /dev/kmsg so an early userspace logger (e.g. systemd with
+ * log_target=kmsg) can emit records before any journal exists; each write() is
+ * one record and its optional <priority> prefix is parsed like Linux's
+ * devkmsg_write(). Only the write side exists for now: the read side has no
+ * history ring yet and must report EOF rather than an error.
+ *
+ * This is the kernel-side regression for the /dev/kmsg write path.
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+static int write_record(int fd, const char *rec)
+{
+    size_t len = strlen(rec);
+    ssize_t n = write(fd, rec, len);
+    if (n != (ssize_t)len) {
+        printf("TEST FAILED: write %zd bytes, expected %zu: %s\n", n, len,
+               strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    /* Node identity: a char device at the standard 1:11. */
+    struct stat st;
+    if (stat("/dev/kmsg", &st) != 0) {
+        printf("TEST FAILED: stat /dev/kmsg: %s\n", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    if (!S_ISCHR(st.st_mode)) {
+        printf("TEST FAILED: /dev/kmsg is not a character device\n");
+        return EXIT_FAILURE;
+    }
+    if (major(st.st_rdev) != 1 || minor(st.st_rdev) != 11) {
+        printf("TEST FAILED: /dev/kmsg rdev is %u:%u, expected 1:11\n",
+               major(st.st_rdev), minor(st.st_rdev));
+        return EXIT_FAILURE;
+    }
+
+    int wfd = open("/dev/kmsg", O_WRONLY);
+    if (wfd < 0) {
+        printf("TEST FAILED: open /dev/kmsg O_WRONLY: %s\n", strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    /* A record with a <priority> prefix, like systemd emits. */
+    if (write_record(wfd, "<6>starry kmsg test: prefixed record\n") != 0) {
+        close(wfd);
+        return EXIT_FAILURE;
+    }
+    /* A record with no prefix must still be fully consumed. */
+    if (write_record(wfd, "starry kmsg test: plain record\n") != 0) {
+        close(wfd);
+        return EXIT_FAILURE;
+    }
+    /* A record without a trailing newline is one record too. */
+    if (write_record(wfd, "<4>starry kmsg test: no trailing newline") != 0) {
+        close(wfd);
+        return EXIT_FAILURE;
+    }
+    close(wfd);
+
+    /* Read side has no history ring yet: read must report EOF, not an error. */
+    int rfd = open("/dev/kmsg", O_RDONLY);
+    if (rfd < 0) {
+        printf("TEST FAILED: open /dev/kmsg O_RDONLY: %s\n", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    char buf[64];
+    ssize_t n = read(rfd, buf, sizeof(buf));
+    close(rfd);
+    if (n != 0) {
+        printf("TEST FAILED: read /dev/kmsg returned %zd, expected 0 (EOF)\n", n);
+        return EXIT_FAILURE;
+    }
+
+    puts("TEST PASSED");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
新增 /dev/kmsg 字符设备（char major 1, minor 11），用于在 journald 等用户态
日志服务就绪前承接早期日志（如 systemd 以 log_target=kmsg 启动时的输出）。

- 每次 write() 作为一条记录，按 Linux devkmsg_write() 的方式解析可选的
  <priority> 前缀：紧跟数字后必须是 '>' 才视为前缀，severity 取低 3 位；
  无前缀或格式非法时回退到默认 level，随后转发到 axlog 落到 console
- 仅实现写侧；读侧尚无历史 ring buffer，read() 返回 EOF（不报错）
- 节点复用现有 devfs DeviceOps 框架，与 null/zero/random 同属 major 1
- 新增 qemu-smp1/system/test-dev-kmsg 用例，覆盖：节点身份(S_ISCHR + 1:11)、
  带前缀/无前缀/无换行记录的完整写入、读侧 EOF 语义