### PR TITLE
fix(ax-task): clear delivered remote reschedule requests

### DIFF
--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -152,12 +152,12 @@ fn get_run_queue(index: usize) -> &'static mut AxRunQueue {
 #[cfg(all(feature = "smp", feature = "ipi"))]
 #[cfg_attr(all(test, feature = "host-test"), allow(dead_code))]
 fn request_current_reschedule() {
+    clear_remote_reschedule_pending_for_current_cpu();
     #[cfg(feature = "preempt")]
     if let Some(curr) = crate::current_may_uninit() {
         curr.set_force_resched_pending(true);
         return;
     }
-    clear_remote_reschedule_pending_for_current_cpu();
 }
 
 #[cfg(all(test, feature = "smp", feature = "ipi", feature = "host-test"))]
@@ -257,6 +257,7 @@ mod tests {
 
             curr.set_preempt_pending(false);
             curr.set_force_resched_pending(false);
+            super::REMOTE_RESCHEDULE_PENDING.store(true, Ordering::Release);
 
             super::request_current_reschedule();
 
@@ -268,10 +269,24 @@ mod tests {
                 !curr.preempt_pending_for_test(),
                 "remote IPI reschedule must not rely on ordinary RR preemption",
             );
+            assert!(
+                !super::REMOTE_RESCHEDULE_PENDING.load(Ordering::Acquire),
+                "remote IPI callback must clear the coalescing bit when it is delivered",
+            );
 
             curr.set_force_resched_pending(false);
             curr.set_preempt_pending(false);
         });
+
+        #[cfg(feature = "preempt")]
+        {
+            super::kick_remote_cpu(REMOTE_CPU);
+            assert_eq!(
+                super::REMOTE_RESCHEDULE_REQUESTS.load(Ordering::Acquire),
+                3,
+                "a delivered remote IPI must allow a later kick to enqueue a new callback",
+            );
+        }
 
         super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
         super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -156,7 +156,6 @@ fn request_current_reschedule() {
     #[cfg(feature = "preempt")]
     if let Some(curr) = crate::current_may_uninit() {
         curr.set_force_resched_pending(true);
-        return;
     }
 }
 


### PR DESCRIPTION
## 背景

Starry riscv64 SMP4 的 `bug-sched-affinity-pid` 测试会在反复 `sched_setaffinity` 后卡住。排查发现 remote reschedule IPI 在目标 CPU callback 已送达后，`REMOTE_RESCHEDULE_PENDING` coalescing 位没有立即清理；如果 pending 位继续保留，后续同 CPU 的 remote reschedule 会被 coalesce 掉，新的 IPI 不再投递，迁核/唤醒路径可能失去调度推进。

## 修改内容

- 在 `request_current_reschedule()` 入口清理当前 CPU 的 remote reschedule pending 位，让 pending 的生命周期对应“IPI 已投递但尚未送达”。
- 保留后续 task 消费 forced reschedule 时的清理作为幂等兜底，不再依赖它保证 liveness。
- 扩展 host-test 回归：模拟 IPI callback delivery 后确认 pending 被清除，并验证后续 remote kick 能重新入队。
- 移除 `preempt` 分支末尾多余的显式 `return`，修复 `hello(k230)` feature 组合下 `-D warnings` 触发的 clippy failure，不改变调度逻辑。

## 实现逻辑

`REMOTE_RESCHEDULE_PENDING` 只应该表示“remote IPI 已排队但 callback 尚未执行”。因此在 callback 入口先清除 pending，之后再按当前 CPU 的任务状态设置 forced reschedule；这样即使当前任务稍后才消费该 reschedule，新的 remote kick 也能重新入队。测试通过 host-test 模拟 pending 位、callback delivery 和再次 kick 的完整顺序，覆盖 coalescing 位的生命周期。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo clippy -p hello --no-default-features --features k230 -- -D warnings`
- `cargo xtask clippy --package ax-task`
- `cargo test -p ax-task --features 'multitask sched-rr smp ipi host-test' remote_reschedule_request_is_coalesced_and_forced -- --nocapture`
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp4/system/bug-sched-affinity-pid`