### PR TITLE
test(starryos): retry uid gid getter waits on EINTR

### DIFF
--- a/test-suit/starryos/qemu-smp1/system/syscall-test-uid-gid-getters/src/getgid.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-uid-gid-getters/src/getgid.c
@@ -32,7 +32,10 @@
 
 static int waitpid_safely(pid_t pid, int *status)
 {
-    pid_t r = waitpid(pid, status, 0);
+    pid_t r;
+    do {
+        r = waitpid(pid, status, 0);
+    } while (r < 0 && errno == EINTR);
     return r == pid ? 0 : -1;
 }
 

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-uid-gid-getters/src/getuid.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-uid-gid-getters/src/getuid.c
@@ -11,7 +11,10 @@
 /* small inline helper */
 static int waitpid_safely(pid_t pid, int *status)
 {
-    pid_t r = waitpid(pid, status, 0);
+    pid_t r;
+    do {
+        r = waitpid(pid, status, 0);
+    } while (r < 0 && errno == EINTR);
     return r == pid ? 0 : -1;
 }
 

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-uid-gid-getters/src/matrix.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-uid-gid-getters/src/matrix.c
@@ -218,7 +218,11 @@ static uint32_t expected_0arg(getter_kind_t g, cred_state_t s,
 
 static int waitpid_safely(pid_t pid, int *st)
 {
-    return waitpid(pid, st, 0) == pid ? 0 : -1;
+    pid_t r;
+    do {
+        r = waitpid(pid, st, 0);
+    } while (r < 0 && errno == EINTR);
+    return r == pid ? 0 : -1;
 }
 
 /* ── 矩阵 1: 0-arg getter (4 syscall × 8 state × 2 mode = 64 case) ── */

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-uid-gid-getters/src/uid32_no_trunc.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-uid-gid-getters/src/uid32_no_trunc.c
@@ -34,7 +34,10 @@
 
 static int waitpid_safely(pid_t pid, int *status)
 {
-    pid_t r = waitpid(pid, status, 0);
+    pid_t r;
+    do {
+        r = waitpid(pid, status, 0);
+    } while (r < 0 && errno == EINTR);
     return r == pid ? 0 : -1;
 }
 


### PR DESCRIPTION
## 背景

`syscall-test-uid-gid-getters` 会在多个子用例里 fork 子进程后等待退出。CI 中 LoongArch Starry QEMU 曾出现 `waitpid()` 被信号打断并返回 `-1/EINTR` 的情况，测试 helper 直接把它当成失败，导致与被测 uid/gid getter 行为无关的偶发失败。

## 修改

- 在 `getuid.c`、`getgid.c`、`matrix.c`、`uid32_no_trunc.c` 的 `waitpid_safely()` 中对 `EINTR` 做重试。
- 保持原有等待目标 pid 和返回值语义不变，仅避免信号中断造成误判。

## 验证

- `cargo fmt --check`
- `git diff --check origin/dev...HEAD`
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/syscall-test-uid-gid-getters`
