### PR TITLE
fix(claw-code): respect managed rootfs image paths

### DIFF
--- a/apps/starry/claw-code/prebuild.sh
+++ b/apps/starry/claw-code/prebuild.sh
@@ -11,6 +11,19 @@ WORKSPACE="${STARRY_WORKSPACE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &&
 ROOTFS_DIR="$WORKSPACE/tmp/axbuild/rootfs"
 OVERLAY="${STARRY_OVERLAY_DIR:-$WORKSPACE/tmp/axbuild/starry-app/claw-code/overlay}"
 
+rootfs_image_file() {
+    local path="$1"
+    if [ -d "$path" ]; then
+        local name
+        name="$(basename "$path")"
+        if [ -f "$path/$name" ]; then
+            printf '%s\n' "$path/$name"
+            return
+        fi
+    fi
+    printf '%s\n' "$path"
+}
+
 echo "=== 1. Build claw from source ==="
 if [ -f "$CLAW_BIN" ]; then
     echo "claw binary cached at $CLAW_BIN"
@@ -32,13 +45,19 @@ else
 fi
 
 echo "=== 2. Prepare rootfs ==="
-# The app framework may have created rootfs-x86_64-claw-code.img via fs::copy,
-# which can leave a stale lock preventing QEMU from opening it.  Delete the
-# target first, then copy the base alpine image afresh.
-ALPINE_IMG="$ROOTFS_DIR/rootfs-x86_64-alpine.img"
-CLAW_IMG="$ROOTFS_DIR/rootfs-x86_64-claw-code.img"
-rm -f "$CLAW_IMG"
-cp "$ALPINE_IMG" "$CLAW_IMG"
+# The app framework passes the canonical per-app image path through
+# STARRY_ROOTFS. Older cached rootfs storage may leave a directory at the
+# legacy tmp/axbuild/rootfs/*.img path, so resolve image-storage directories to
+# their contained image file instead of assuming flat files.
+BASE_ROOTFS="${STARRY_BASE_ROOTFS:-$ROOTFS_DIR/rootfs-${STARRY_ARCH:-x86_64}-alpine.img}"
+APP_ROOTFS="${STARRY_ROOTFS:-$ROOTFS_DIR/rootfs-${STARRY_ARCH:-x86_64}-claw-code.img}"
+ALPINE_IMG="$(rootfs_image_file "$BASE_ROOTFS")"
+CLAW_IMG="$(rootfs_image_file "$APP_ROOTFS")"
+if [ "$ALPINE_IMG" != "$CLAW_IMG" ]; then
+    mkdir -p "$(dirname "$CLAW_IMG")"
+    rm -rf "$CLAW_IMG"
+    cp "$ALPINE_IMG" "$CLAW_IMG"
+fi
 
 echo "=== 3. Inject claw into rootfs ==="
 inject_claw() {
@@ -48,7 +67,6 @@ inject_claw() {
     debugfs -w "$img" -R "write $CLAW_BIN /usr/bin/claw"
     debugfs -w "$img" -R "sif /usr/bin/claw mode 0100755"
 }
-inject_claw "$ALPINE_IMG"
 inject_claw "$CLAW_IMG"
 
 echo "Injected claw into rootfs"

--- a/scripts/axbuild/src/starry/app/tests/qemu.rs
+++ b/scripts/axbuild/src/starry/app/tests/qemu.rs
@@ -1,4 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use tempfile::tempdir;
 
@@ -226,5 +231,63 @@ fn app_qemu_test_case_preserves_host_symbolize_success_regex() {
             .as_ref()
             .map(|config| (config.bind.as_str(), config.port)),
         Some(("127.0.0.1", 18382))
+    );
+}
+
+#[test]
+fn claw_code_prebuild_replaces_stale_rootfs_directory() {
+    let root = tempdir().unwrap();
+    let workspace = root.path();
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("axbuild manifest should live under scripts/axbuild")
+        .to_path_buf();
+    let script = repo.join("apps/starry/claw-code/prebuild.sh");
+
+    let cache = workspace.join("cache");
+    let bin = cache.join("claw");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(&bin, b"fake claw").unwrap();
+
+    let tools = workspace.join("tools");
+    fs::create_dir_all(&tools).unwrap();
+    let debugfs = tools.join("debugfs");
+    fs::write(
+        &debugfs,
+        "#!/usr/bin/env bash\nif [ \"$1\" = \"-w\" ]; then test -f \"$2\"; fi\nexit 0\n",
+    )
+    .unwrap();
+    fs::set_permissions(&debugfs, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let rootfs_dir = workspace.join("tmp/axbuild/rootfs");
+    let default_rootfs = rootfs_dir.join("rootfs-x86_64-alpine.img");
+    let app_rootfs = rootfs_dir.join("rootfs-x86_64-claw-code.img");
+    fs::create_dir_all(&default_rootfs).unwrap();
+    fs::write(
+        default_rootfs.join("rootfs-x86_64-alpine.img"),
+        b"base rootfs",
+    )
+    .unwrap();
+    fs::create_dir_all(&app_rootfs).unwrap();
+
+    let path = format!("{}:{}", tools.display(), std::env::var("PATH").unwrap());
+    let status = Command::new("bash")
+        .arg(&script)
+        .current_dir(repo.join("apps/starry/claw-code"))
+        .env("CLAW_CACHE_DIR", &cache)
+        .env("STARRY_WORKSPACE", workspace)
+        .env("STARRY_ROOTFS", &app_rootfs)
+        .env("STARRY_OVERLAY_DIR", workspace.join("overlay"))
+        .env("PATH", path)
+        .status()
+        .unwrap();
+
+    assert!(status.success());
+    assert!(app_rootfs.is_file());
+    assert_eq!(fs::read(&app_rootfs).unwrap(), b"base rootfs");
+    assert_eq!(
+        fs::read(default_rootfs.join("rootfs-x86_64-alpine.img")).unwrap(),
+        b"base rootfs"
     );
 }


### PR DESCRIPTION
## 问题与根因

Issue #1385 中 `starry-apps` CI 在 `claw-code` 的 prebuild 阶段失败，错误为：

```text
rm: cannot remove '.../tmp/axbuild/rootfs/rootfs-x86_64-claw-code.img': Is a directory
```

根因是 `axbuild` 的 Starry app 框架已经把 rootfs 缓存迁移到 managed image 目录布局，并通过 `STARRY_ROOTFS` 传入每个 app 的规范镜像路径；但 `apps/starry/claw-code/prebuild.sh` 仍然硬编码旧的 `tmp/axbuild/rootfs/rootfs-x86_64-*.img` 平面文件路径，并直接对 app rootfs 路径执行 `rm -f` / `cp`。当旧路径实际是 managed image 目录时，`rm -f` 会在 QEMU 启动前失败。

脚本还会同时把 `claw` 注入 base Alpine rootfs 和 app rootfs，这会污染共享 base image，不符合每个 app 使用独立 rootfs 的约定。

## 修复内容

- 让 `claw-code` prebuild 优先使用 app 框架传入的 `STARRY_ROOTFS`，并按 `STARRY_ARCH` 生成 fallback 路径，避免继续硬编码 x86_64 的旧布局。
- 增加 managed rootfs 目录解析逻辑：当 `*.img` 路径是目录时，解析到其中同名镜像文件。
- 复制 base rootfs 到 app rootfs 时使用解析后的真实镜像文件路径，并能替换旧的 stale directory。
- 只向 app rootfs 注入 `claw`，不再修改共享 Alpine base rootfs。
- 在 `axbuild` 测试中增加回归覆盖，构造 stale app rootfs directory 和 managed base rootfs directory，并用假的 `debugfs` 验证注入目标必须是文件。

## 回归证据

新增测试在旧实现下会复现 issue 中同类失败：

```text
rm: cannot remove '.../tmp/axbuild/rootfs/rootfs-x86_64-claw-code.img': Is a directory
```

修复后同一测试通过，并确认：

- stale app rootfs directory 被替换为镜像文件；
- base rootfs 内容保持不变；
- 注入目标是 app rootfs 文件。

## 本地验证

```bash
cargo fmt -- --check

git diff --check

cargo test --package axbuild starry::app::qemu::tests::claw_code_prebuild_replaces_stale_rootfs_directory -- --nocapture

cargo xtask clippy --package axbuild
```

以上命令均通过。

另外使用 fake cached `claw` 跑原始路径验证：

```bash
CLAW_CACHE_DIR=/tmp/claw-code-fake-cache cargo xtask starry app qemu -t claw-code --arch x86_64
```

该命令已越过原先失败的 `=== 2. Prepare rootfs ===` / rootfs 注入阶段，完成 StarryOS 构建并启动到 `claw-code` 交互 shell。由于该 app 的 `qemu-x86_64.toml` 配置为 `timeout = 0` 且没有 `success_regex`，命令会停在交互 shell 中，本地验证在看到 shell 提示后手动终止。

Fixes #1385