### PR TITLE
fix(ax-driver): serialize virtio-net queue access

### DIFF
--- a/drivers/ax-driver/src/virtio/net.rs
+++ b/drivers/ax-driver/src/virtio/net.rs
@@ -3,6 +3,7 @@ extern crate alloc;
 use alloc::{boxed::Box, collections::BTreeMap, format, sync::Arc};
 use core::{
     cell::UnsafeCell,
+    hint::spin_loop,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -99,24 +100,26 @@ impl<T: VirtIoTransport> rd_net::Interface for VirtIoNetDevice<T> {
     }
 
     fn handle_irq(&mut self) -> Event {
-        self.inner.with_irq(|inner| {
-            let _ = inner.raw.ack_interrupt();
+        self.inner
+            .with_irq(|inner| {
+                let _ = inner.raw.ack_interrupt();
 
-            let mut event = Event::none();
-            if inner.raw.poll_transmit().is_some() {
-                event.tx_queue.insert(0);
-            }
-            if inner.raw.poll_receive().is_some() {
-                event.rx_queue.insert(0);
-            }
-            event
-        })
+                let mut event = Event::none();
+                if inner.raw.poll_transmit().is_some() {
+                    event.tx_queue.insert(0);
+                }
+                if inner.raw.poll_receive().is_some() {
+                    event.rx_queue.insert(0);
+                }
+                event
+            })
+            .unwrap_or_else(Event::none)
     }
 }
 
 struct VirtioNetInnerCell<T: VirtIoTransport> {
     inner: UnsafeCell<NetInner<T>>,
-    task_active: AtomicBool,
+    access_active: AtomicBool,
 }
 
 unsafe impl<T: VirtIoTransport> Send for VirtioNetInnerCell<T> {}
@@ -126,42 +129,48 @@ impl<T: VirtIoTransport> VirtioNetInnerCell<T> {
     fn new(inner: NetInner<T>) -> Self {
         Self {
             inner: UnsafeCell::new(inner),
-            task_active: AtomicBool::new(false),
+            access_active: AtomicBool::new(false),
         }
     }
 
     fn with_task<R>(&self, f: impl FnOnce(&mut NetInner<T>) -> R) -> R {
         let _guard = NoPreemptIrqSave::new();
-        let _active = TaskAccessFlag::enter(&self.task_active);
-        // SAFETY: task-side callers enter with local IRQ/preemption disabled,
-        // and upper rd-net users serialize queue/device calls with SpinNoIrq.
+        let _active = VirtioNetAccessGuard::enter_task(&self.access_active);
+        // SAFETY: `access_active` serializes all mutable access to the shared
+        // raw transport. Task-side callers also keep local IRQ/preemption off.
         f(unsafe { &mut *self.inner.get() })
     }
 
-    fn with_irq<R>(&self, f: impl FnOnce(&mut NetInner<T>) -> R) -> R {
-        debug_assert!(
-            !self.task_active.load(Ordering::Acquire),
-            "virtio-net IRQ access interrupted task access"
-        );
-        // SAFETY: IRQ-side access never waits on a task lock. The task side
-        // excludes local IRQ reentry while it mutates the shared raw queues.
-        f(unsafe { &mut *self.inner.get() })
+    fn with_irq<R>(&self, f: impl FnOnce(&mut NetInner<T>) -> R) -> Option<R> {
+        let _active = VirtioNetAccessGuard::try_enter_irq(&self.access_active)?;
+        // SAFETY: `access_active` serializes IRQ-side access with task-side
+        // queue operations without making the IRQ handler wait.
+        Some(f(unsafe { &mut *self.inner.get() }))
     }
 }
 
-struct TaskAccessFlag<'a>(&'a AtomicBool);
+struct VirtioNetAccessGuard<'a>(&'a AtomicBool);
 
-impl<'a> TaskAccessFlag<'a> {
-    fn enter(active: &'a AtomicBool) -> Self {
-        debug_assert!(
-            !active.swap(true, Ordering::AcqRel),
-            "virtio-net inner task access is already active"
-        );
+impl<'a> VirtioNetAccessGuard<'a> {
+    fn enter_task(active: &'a AtomicBool) -> Self {
+        while active
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            spin_loop();
+        }
         Self(active)
     }
+
+    fn try_enter_irq(active: &'a AtomicBool) -> Option<Self> {
+        active
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .ok()
+            .map(|_| Self(active))
+    }
 }
 
-impl Drop for TaskAccessFlag<'_> {
+impl Drop for VirtioNetAccessGuard<'_> {
     fn drop(&mut self) {
         self.0.store(false, Ordering::Release);
     }
@@ -353,5 +362,23 @@ fn map_net_error(err: VirtIoError) -> NetError {
         other => NetError::Other(Box::new(rd_net::KError::Unknown(virtio::map_virtio_error(
             other,
         )))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::sync::atomic::AtomicBool;
+
+    use super::VirtioNetAccessGuard;
+
+    #[test]
+    fn irq_access_is_rejected_while_task_access_is_active() {
+        let active = AtomicBool::new(false);
+        let task_guard = VirtioNetAccessGuard::enter_task(&active);
+
+        assert!(VirtioNetAccessGuard::try_enter_irq(&active).is_none());
+
+        drop(task_guard);
+        assert!(VirtioNetAccessGuard::try_enter_irq(&active).is_some());
     }
 }

--- a/drivers/ax-driver/src/virtio/net.rs
+++ b/drivers/ax-driver/src/virtio/net.rs
@@ -100,20 +100,18 @@ impl<T: VirtIoTransport> rd_net::Interface for VirtIoNetDevice<T> {
     }
 
     fn handle_irq(&mut self) -> Event {
-        self.inner
-            .with_irq(|inner| {
-                let _ = inner.raw.ack_interrupt();
+        self.inner.with_irq(|inner| {
+            let _ = inner.raw.ack_interrupt();
 
-                let mut event = Event::none();
-                if inner.raw.poll_transmit().is_some() {
-                    event.tx_queue.insert(0);
-                }
-                if inner.raw.poll_receive().is_some() {
-                    event.rx_queue.insert(0);
-                }
-                event
-            })
-            .unwrap_or_else(Event::none)
+            let mut event = Event::none();
+            if inner.raw.poll_transmit().is_some() {
+                event.tx_queue.insert(0);
+            }
+            if inner.raw.poll_receive().is_some() {
+                event.rx_queue.insert(0);
+            }
+            event
+        })
     }
 }
 
@@ -141,11 +139,11 @@ impl<T: VirtIoTransport> VirtioNetInnerCell<T> {
         f(unsafe { &mut *self.inner.get() })
     }
 
-    fn with_irq<R>(&self, f: impl FnOnce(&mut NetInner<T>) -> R) -> Option<R> {
-        let _active = VirtioNetAccessGuard::try_enter_irq(&self.access_active)?;
+    fn with_irq<R>(&self, f: impl FnOnce(&mut NetInner<T>) -> R) -> R {
+        let _active = VirtioNetAccessGuard::enter_irq(&self.access_active);
         // SAFETY: `access_active` serializes IRQ-side access with task-side
-        // queue operations without making the IRQ handler wait.
-        Some(f(unsafe { &mut *self.inner.get() }))
+        // queue operations while preserving interrupt acknowledgment.
+        f(unsafe { &mut *self.inner.get() })
     }
 }
 
@@ -153,6 +151,14 @@ struct VirtioNetAccessGuard<'a>(&'a AtomicBool);
 
 impl<'a> VirtioNetAccessGuard<'a> {
     fn enter_task(active: &'a AtomicBool) -> Self {
+        Self::enter(active)
+    }
+
+    fn enter_irq(active: &'a AtomicBool) -> Self {
+        Self::enter(active)
+    }
+
+    fn enter(active: &'a AtomicBool) -> Self {
         while active
             .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
@@ -160,13 +166,6 @@ impl<'a> VirtioNetAccessGuard<'a> {
             spin_loop();
         }
         Self(active)
-    }
-
-    fn try_enter_irq(active: &'a AtomicBool) -> Option<Self> {
-        active
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .ok()
-            .map(|_| Self(active))
     }
 }
 
@@ -367,18 +366,38 @@ fn map_net_error(err: VirtIoError) -> NetError {
 
 #[cfg(test)]
 mod tests {
-    use core::sync::atomic::AtomicBool;
+    extern crate std;
+
+    use core::sync::atomic::{AtomicBool, Ordering};
+    use std::{
+        sync::{Arc, mpsc},
+        thread,
+        time::Duration,
+    };
 
     use super::VirtioNetAccessGuard;
 
     #[test]
-    fn irq_access_is_rejected_while_task_access_is_active() {
-        let active = AtomicBool::new(false);
+    fn irq_access_waits_for_task_access_to_finish() {
+        let active = Arc::new(AtomicBool::new(false));
+        let irq_entered = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = mpsc::channel();
         let task_guard = VirtioNetAccessGuard::enter_task(&active);
 
-        assert!(VirtioNetAccessGuard::try_enter_irq(&active).is_none());
+        let irq_active = Arc::clone(&active);
+        let irq_entered_clone = Arc::clone(&irq_entered);
+        let irq_thread = thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let _irq_guard = VirtioNetAccessGuard::enter_irq(&irq_active);
+            irq_entered_clone.store(true, Ordering::Release);
+        });
+
+        started_rx.recv().unwrap();
+        thread::sleep(Duration::from_millis(20));
+        assert!(!irq_entered.load(Ordering::Acquire));
 
         drop(task_guard);
-        assert!(VirtioNetAccessGuard::try_enter_irq(&active).is_some());
+        irq_thread.join().unwrap();
+        assert!(irq_entered.load(Ordering::Acquire));
     }
 }

--- a/test-suit/starryos/qemu-smp1/system/bugfix-bug-tcp-nonblocking-connect-so-error/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/bugfix-bug-tcp-nonblocking-connect-so-error/src/main.c
@@ -32,6 +32,56 @@ static struct sockaddr_in loopback_addr(void) {
     return addr;
 }
 
+static int poll_retry(struct pollfd *fds, nfds_t nfds, int timeout_ms) {
+    for (;;) {
+        int ret = poll(fds, nfds, timeout_ms);
+        if (ret < 0 && errno == EINTR) {
+            continue;
+        }
+        return ret;
+    }
+}
+
+static ssize_t read_retry(int fd, void *buf, size_t len) {
+    for (;;) {
+        ssize_t ret = read(fd, buf, len);
+        if (ret < 0 && errno == EINTR) {
+            continue;
+        }
+        return ret;
+    }
+}
+
+static ssize_t write_retry(int fd, const void *buf, size_t len) {
+    for (;;) {
+        ssize_t ret = write(fd, buf, len);
+        if (ret < 0 && errno == EINTR) {
+            continue;
+        }
+        return ret;
+    }
+}
+
+static int accept_retry(int fd) {
+    for (;;) {
+        int ret = accept(fd, NULL, NULL);
+        if (ret < 0 && errno == EINTR) {
+            continue;
+        }
+        return ret;
+    }
+}
+
+static pid_t waitpid_retry(pid_t pid, int *status, int options) {
+    for (;;) {
+        pid_t ret = waitpid(pid, status, options);
+        if (ret < 0 && errno == EINTR) {
+            continue;
+        }
+        return ret;
+    }
+}
+
 static int make_listener(void) {
     int fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0) return -1;
@@ -54,16 +104,16 @@ static int make_listener(void) {
 static void server_process(int ready_fd) {
     int listener = make_listener();
     if (listener < 0) _exit(10);
-    if (write(ready_fd, "R", 1) != 1) _exit(15);
+    if (write_retry(ready_fd, "R", 1) != 1) _exit(15);
     close(ready_fd);
 
-    int fd = accept(listener, NULL, NULL);
+    int fd = accept_retry(listener);
     if (fd < 0) _exit(11);
 
     char byte = 0;
-    if (read(fd, &byte, 1) != 1) _exit(12);
+    if (read_retry(fd, &byte, 1) != 1) _exit(12);
     if (byte != 'x') _exit(13);
-    if (write(fd, "y", 1) != 1) _exit(14);
+    if (write_retry(fd, "y", 1) != 1) _exit(14);
 
     close(fd);
     close(listener);
@@ -89,12 +139,12 @@ int main(void) {
     memset(&ready_pfd, 0, sizeof(ready_pfd));
     ready_pfd.fd = ready_pipe[0];
     ready_pfd.events = POLLIN;
-    int ret = poll(&ready_pfd, 1, 3000);
+    int ret = poll_retry(&ready_pfd, 1, 3000);
     CHECK(ret == 1 && (ready_pfd.revents & POLLIN) != 0,
           "server reports listener ready");
 
     char ready = 0;
-    CHECK(read(ready_pipe[0], &ready, 1) == 1 && ready == 'R',
+    CHECK(read_retry(ready_pipe[0], &ready, 1) == 1 && ready == 'R',
           "read server ready signal");
     close(ready_pipe[0]);
 
@@ -113,7 +163,7 @@ int main(void) {
     memset(&pfd, 0, sizeof(pfd));
     pfd.fd = fd;
     pfd.events = POLLOUT;
-    ret = poll(&pfd, 1, 3000);
+    ret = poll_retry(&pfd, 1, 3000);
     CHECK(ret == 1, "poll reports connect completion");
     CHECK((pfd.revents & (POLLOUT | POLLERR | POLLHUP)) != 0,
           "poll returns output or error event");
@@ -128,21 +178,21 @@ int main(void) {
     ret = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
     CHECK(ret == -1 && errno == EISCONN, "second connect reports EISCONN");
 
-    CHECK(write(fd, "x", 1) == 1, "write after nonblocking connect");
+    CHECK(write_retry(fd, "x", 1) == 1, "write after nonblocking connect");
     memset(&pfd, 0, sizeof(pfd));
     pfd.fd = fd;
     pfd.events = POLLIN;
-    ret = poll(&pfd, 1, 3000);
+    ret = poll_retry(&pfd, 1, 3000);
     CHECK(ret == 1, "poll reports server reply");
     CHECK((pfd.revents & (POLLIN | POLLERR | POLLHUP)) != 0,
           "poll returns input or close event");
 
     char reply = 0;
-    CHECK(read(fd, &reply, 1) == 1 && reply == 'y', "read server reply");
+    CHECK(read_retry(fd, &reply, 1) == 1 && reply == 'y', "read server reply");
     close(fd);
 
     int status = 0;
-    CHECK(waitpid(server, &status, 0) == server, "wait server");
+    CHECK(waitpid_retry(server, &status, 0) == server, "wait server");
     CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0, "server exits cleanly");
 
     printf("bug-tcp-nonblocking-connect-so-error: OK\n");


### PR DESCRIPTION
## 问题

#1384 中 LoongArch64 QEMU 在 virtio-net 路径触发 `wrong value for queue_enable 0`，根因是 `VirtIONetRaw` 通过 `queue_select` 访问多 virtqueue 时缺少互斥保护。任务上下文中的收发路径和中断上下文中的 ack/poll 路径可能交错选择不同队列，导致后续寄存器访问落到错误队列上。

第一次修复后，PR CI 在 `Test starry riscv64 qemu` 的 `qemu-smp4/system` 中卡在调度相关用例。继续看日志后确认，中断侧如果在任务侧持有 virtio-net 访问保护时直接跳过 `ack_interrupt/poll_transmit`，可能让 virtio 中断保持 pending，进而造成中断风暴或调度饥饿。第二步修复把中断侧也纳入同一段短临界区等待，不丢掉 ack/poll。

后续 CI `28225148758` 又在 LoongArch64 `qemu-smp1/system` 的 `bug-tcp-nonblocking-connect-so-error` 中失败，日志显示 ready pipe 的 `poll()` 返回 `-1/EINTR`。这是 POSIX 允许的结果，而该用例真正验证的是 nonblocking connect 和 `SO_ERROR` 语义，不应把无关的 `EINTR` 当成失败。

## 修改

- 为 virtio-net raw transport 访问增加 `VirtioNetInnerCell` 保护，串行化所有会触碰 `queue_select` 的队列操作。
- 任务侧访问在关闭本地中断和抢占后进入保护，避免同 CPU 中断重入同一段 raw transport 访问。
- 中断侧同样等待这段短临界区结束后再执行 `ack_interrupt` 和 `poll_transmit`，保持队列访问互斥，同时不丢中断处理。
- 增加 `ax-driver` 单测，覆盖任务侧保护未释放时中断侧必须等待、释放后才能进入的行为。
- 更新 Starry `bug-tcp-nonblocking-connect-so-error` 用例，对 `poll/read/write/accept/waitpid` 的 `EINTR` 做重试，让测试聚焦于 connect/SO_ERROR 语义。

## 方案逻辑

- virtio legacy/pci common config 的 `queue_select` 是设备级选择寄存器，不是每个队列独立的访问入口；因此所有 raw transport 队列操作必须在驱动内串行化。
- 仅在任务上下文加锁不够，因为 virtio-net 的中断处理也会访问同一 raw transport 状态。
- 中断上下文不能因为竞争而跳过 ack/poll，否则 pending interrupt 可能反复触发；等待短临界区完成后处理，可以同时保证 queue_select 一致性和中断语义完整性。
- `EINTR` 是等待型 syscall 的正常可见结果，Starry 用例应该重试这些辅助等待操作，避免 CI 因调度/信号时序误判。

## 验证

- `cargo test -p ax-driver --features virtio-net irq_access_waits_for_task_access_to_finish --lib`
- `cargo fmt`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ax-driver --features virtio-net --lib`
- `cargo xtask clippy --package ax-driver`
- `timeout 600 cargo xtask starry test qemu --arch riscv64 -c qemu-smp4/system`
- `timeout 600 cargo xtask starry test qemu --arch loongarch64 -c qemu-smp4/system`
- `timeout 600 cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/bug-tcp-nonblocking-connect-so-error`
- `timeout 900 cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system`

Fixes #1384