### PR TITLE
fix(ci): update ostool to 0.23.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5456,9 +5456,9 @@ dependencies = [
 
 [[package]]
 name = "ostool"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1b6c39b541fdb2c9222bd1a66fdaad0c46657866470101a87e0763c7a7893d"
+checksum = "14149ab21b57e002a6463c775d0f459f232bab08e378ae46ba618a01aec45d5e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,7 +303,7 @@ lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = "0.12"
 atomic-waker = { version = "1.1", default-features = false }
-ostool = { version = "0.23.4" }
+ostool = { version = "0.23.5" }
 riscv = { version = "0.16.1", default-features = false }
 sbi-rt = { version = "0.0.4", default-features = false }
 uefi = "0.37.0"


### PR DESCRIPTION
## 问题

#1391 中的 `qemu-smp1/tty-console-input-burst` 超时，根因不在 Starry 测试本身，而在 ostool 自动注入 `shell_init_cmd` 时会将长 heredoc 一次性写入 QEMU/serial stdin，容易形成输入 burst，使 guest shell 初始化命令卡在半途。

ostool 上游 PR drivercraft/ostool#148 已经修复该问题：自动 shell init 输入改为分块发送，并已发布到 crates.io 的 `ostool 0.23.5`。

## 修改

- 将 workspace 中 `ostool` 依赖从 `0.23.4` 升级到 `0.23.5`。
- 更新 `Cargo.lock` 中对应的版本和 checksum。
- 不修改 Starry 用例、timeout 或 success/fail regex，保留原测试强度。

## 验证

- `cargo search ostool --limit 5`：确认 crates.io 最新版本为 `0.23.5`。
- `cargo info ostool@0.23.5`：确认 `0.23.5` 可从 crates.io 获取。
- `cargo xtask clippy --package axbuild`：通过，日志中使用 `ostool v0.23.5`。
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/tty-console-input-burst`：通过，日志中编译 `ostool v0.23.5`，结果 `PASS tty-console-input-burst` / `all starry qemu tests passed`。

Fixes #1391
