### PR TITLE
fix(starry-perf): eliminate hardcoded probe config constants

### DIFF
--- a/os/StarryOS/kernel/src/perf/kprobe.rs
+++ b/os/StarryOS/kernel/src/perf/kprobe.rs
@@ -16,6 +16,11 @@ use axpoll::Pollable;
 use kbpf_basic::perf::{PerfProbeArgs, PerfProbeConfig};
 use kprobe::{CallBackFunc, KretprobeBuilder, ProbeBuilder, PtRegs};
 
+/// Config value for entry probes (kprobe/uprobe), per Linux PERF_TYPE_PROBE ABI.
+pub const PROBE_CONFIG_ENTRY: u64 = 0;
+/// Config value for return probes (kretprobe/uretprobe), per Linux PERF_TYPE_PROBE ABI.
+pub const PROBE_CONFIG_RETURN: u64 = 1;
+
 use crate::{
     file::FileLike,
     kprobe::{
@@ -188,19 +193,16 @@ fn perf_probe_arg_to_kretprobe_builder(
 }
 
 /// Build a `ProbePerfEvent` for a `PERF_TYPE_KPROBE` perf_event_open call.
-/// Config 0 = kprobe; config 1 = kretprobe (per kbpf-basic convention).
+/// Config `PROBE_CONFIG_ENTRY` (0) = kprobe; `PROBE_CONFIG_RETURN` (1) = kretprobe.
 pub fn perf_event_open_kprobe(args: PerfProbeArgs) -> AxResult<ProbePerfEvent> {
     let probe = match args.config {
-        PerfProbeConfig::Raw(val) => {
-            if val == 0 {
-                let builder = perf_probe_arg_to_kprobe_builder(&args)?;
-                ProbeTy::Kprobe(register_kprobe(builder))
-            } else if val == 1 {
-                let builder = perf_probe_arg_to_kretprobe_builder(&args)?;
-                ProbeTy::Kretprobe(register_kretprobe(builder))
-            } else {
-                return Err(AxError::InvalidInput);
-            }
+        PerfProbeConfig::Raw(PROBE_CONFIG_ENTRY) => {
+            let builder = perf_probe_arg_to_kprobe_builder(&args)?;
+            ProbeTy::Kprobe(register_kprobe(builder))
+        }
+        PerfProbeConfig::Raw(PROBE_CONFIG_RETURN) => {
+            let builder = perf_probe_arg_to_kretprobe_builder(&args)?;
+            ProbeTy::Kretprobe(register_kretprobe(builder))
         }
         _ => return Err(AxError::InvalidInput),
     };

--- a/os/StarryOS/kernel/src/perf/uprobe.rs
+++ b/os/StarryOS/kernel/src/perf/uprobe.rs
@@ -15,7 +15,7 @@ use ax_errno::{AxError, AxResult};
 use kbpf_basic::perf::{PerfProbeArgs, PerfProbeConfig};
 use kprobe::ProbeBuilder;
 
-use super::kprobe::{ProbePerfEvent, ProbeTy};
+use super::kprobe::{PROBE_CONFIG_ENTRY, PROBE_CONFIG_RETURN, ProbePerfEvent, ProbeTy};
 use crate::{
     kprobe::KprobeAuxiliary,
     task::{AsThread, get_task},
@@ -74,13 +74,13 @@ fn perf_probe_arg_to_uprobe_builder(
 /// Build a uprobe perf event from `perf_event_open` args.
 pub fn perf_event_open_uprobe(args: PerfProbeArgs) -> AxResult<ProbePerfEvent> {
     let probe = match args.config {
-        PerfProbeConfig::Raw(0) => {
+        PerfProbeConfig::Raw(PROBE_CONFIG_ENTRY) => {
             let builder = perf_probe_arg_to_uprobe_builder(&args)?;
             ProbeTy::Uprobe(crate::uprobe::register_uprobe(builder))
         }
-        PerfProbeConfig::Raw(1) => {
+        PerfProbeConfig::Raw(PROBE_CONFIG_RETURN) => {
             // uretprobe — not implemented for user space yet.
-            warn!("uprobe: uretprobe (config=1) is not yet supported");
+            warn!("uprobe: uretprobe is not yet supported");
             return Err(AxError::Unsupported);
         }
         other => {


### PR DESCRIPTION
## 问题

`perf_event_open_kprobe` 和 `perf_event_open_uprobe` 使用硬编码的 `0`/`1` 字面量区分 kprobe/kretprobe 和 uprobe/uretprobe 配置，代码意图不明显。

## 变更

1. 在 `kprobe.rs` 定义命名常量 `PROBE_CONFIG_ENTRY = 0`、`PROBE_CONFIG_RETURN = 1`，与 Linux `PERF_TYPE_PROBE` ABI 一致
2. 重构 `perf_event_open_kprobe` 的 dispatch：从嵌套 `if val == 0/1` → 扁平 `match args.config` const-pattern match
3. `uprobe.rs` 导入常量，替换硬编码的 `Raw(0)`/`Raw(1)` 为 `Raw(PROBE_CONFIG_ENTRY)`/`Raw(PROBE_CONFIG_RETURN)`

## 逻辑

- 命名常量明确表达语义，消除"魔术数字"
- match const-pattern 在编译期保证完整性
- 为后续 uretprobe 支持奠定基础