### PR TITLE
feat(starry-perf): add blocking poll support for perf event fd read

### DIFF
--- a/os/StarryOS/kernel/src/perf/bpf.rs
+++ b/os/StarryOS/kernel/src/perf/bpf.rs
@@ -23,7 +23,7 @@ use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr};
 use ax_task::IrqNotify;
 use axpoll::{IoEvents, PollSet, Pollable};
 use kbpf_basic::{
-    linux_bpf::perf_event_sample_format,
+    linux_bpf::{perf_event_header, perf_event_mmap_page, perf_event_sample_format},
     perf::{PerfProbeArgs, bpf::BpfPerfEvent},
 };
 use kprobe::PtRegs;
@@ -72,6 +72,9 @@ pub struct BpfPerfEventWrapper {
     /// mapping still exists. See the type-level docs for the ownership
     /// rationale.
     pages: Option<Weak<GlobalPage>>,
+    /// Kernel virtual address of the ringbuf start, saved during
+    /// `device_mmap` for `read(2)` access.
+    mmap_kvirt: Option<usize>,
 }
 
 impl BpfPerfEventWrapper {
@@ -87,6 +90,7 @@ impl BpfPerfEventWrapper {
             poll_notify,
             poll_alive,
             pages: None,
+            mmap_kvirt: None,
         }
     }
 
@@ -112,6 +116,77 @@ impl BpfPerfEventWrapper {
             self.poll_notify.notify_irq();
         }
         Ok(())
+    }
+
+    /// Read one ringbuf record into `dst`, returning the number of bytes
+    /// copied (including the `perf_event_header`). Returns `Ok(0)` when no
+    /// data is available. Safety: the ringbuf pages are valid as long as
+    /// the kernel virtual address was saved during `device_mmap` and the
+    /// strong page ref still exists (checked via `is_mapped`).
+    pub(crate) fn try_read_record(&self, dst: &mut [u8]) -> AxResult<usize> {
+        let kvirt = self.mmap_kvirt.ok_or(AxError::NotConnected)?;
+        if !self.is_mapped() {
+            return Ok(0);
+        }
+
+        // SAFETY: the ringbuf pages are pinned by the VMA and zero-
+        // initialised; the `perf_event_mmap_page` at offset 0 was
+        // initialised by `BpfPerfEvent::do_mmap` during `device_mmap`.
+        let mmap = unsafe { &*(kvirt as *const perf_event_mmap_page) };
+        if mmap.data_tail == mmap.data_head {
+            return Ok(0);
+        }
+
+        let data_region_size = mmap.data_size as usize;
+        let tail = (mmap.data_tail as usize) % data_region_size;
+
+        // SAFETY: the data region starts at PAGE_SIZE offset into the
+        // ringbuf allocation; `data_size` was set by kbpf-basic during
+        // `do_mmap` and bounds the accessible region.
+        let data_region = unsafe {
+            core::slice::from_raw_parts((kvirt + PAGE_SIZE_4K) as *const u8, data_region_size)
+        };
+
+        let hdr_size = core::mem::size_of::<perf_event_header>();
+        if hdr_size > dst.len() {
+            return Err(AxError::InvalidInput);
+        }
+
+        // Read the perf_event_header (handling ring-wrap).
+        let hdr_end = wrapping_add(tail, hdr_size, data_region_size);
+        copy_ring(data_region, tail, hdr_end, &mut dst[..hdr_size]);
+
+        // SAFETY: the header bytes are a valid `perf_event_header` written
+        // by kbpf-basic's `RingPage::write_sample`.
+        let header = unsafe { &*(dst.as_ptr() as *const perf_event_header) };
+        let record_size = header.size as usize;
+
+        if record_size < hdr_size || record_size > dst.len() {
+            warn!(
+                "eBPF perf: bad record size {record_size} (hdr_size={hdr_size}, buf_len={})",
+                dst.len()
+            );
+            return Err(AxError::InvalidInput);
+        }
+
+        // Copy the full record (header already copied at offset 0).
+        if record_size > hdr_size {
+            let payload_start = wrapping_add(tail, hdr_size, data_region_size);
+            let payload_end = wrapping_add(tail, record_size, data_region_size);
+            copy_ring(
+                data_region,
+                payload_start,
+                payload_end,
+                &mut dst[hdr_size..record_size],
+            );
+        }
+
+        // Advance data_tail past this record.
+        // SAFETY: the mmap page is writable by the kernel.
+        let mmap_mut = unsafe { &mut *(kvirt as *mut perf_event_mmap_page) };
+        mmap_mut.data_tail += record_size as u64;
+
+        Ok(record_size)
     }
 }
 
@@ -143,6 +218,35 @@ fn start_bpf_perf_notify_worker(
 impl Debug for BpfPerfEventWrapper {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "BpfPerfEventWrapper")
+    }
+}
+
+/// Compute `(base + offset) % modulus`. The modulus is always the ring
+/// data-region size so the result fits in a single wrapping-modulo round.
+#[inline]
+fn wrapping_add(base: usize, offset: usize, modulus: usize) -> usize {
+    debug_assert!(modulus > 0);
+    let sum = base + offset;
+    if sum < modulus { sum } else { sum % modulus }
+}
+
+/// Copy bytes from a ring buffer (`src`) into a linear buffer (`dst`).
+/// The ring extent is `[from, to)` with `from` and `to` modulo-wrapped into
+/// the ring size. Handles the zero or one wrap case.
+fn copy_ring(src: &[u8], from: usize, to: usize, dst: &mut [u8]) {
+    let ring_size = src.len();
+    let len = to.wrapping_sub(from) % ring_size;
+    if len == 0 {
+        return;
+    }
+    debug_assert!(len <= dst.len(), "copy_ring: dst too small");
+    let end = from + len;
+    if end <= ring_size {
+        dst[..len].copy_from_slice(&src[from..end]);
+    } else {
+        let first = ring_size - from;
+        dst[..first].copy_from_slice(&src[from..]);
+        dst[first..len].copy_from_slice(&src[..(end % ring_size)]);
     }
 }
 
@@ -196,6 +300,7 @@ impl PerfEventOps for BpfPerfEventWrapper {
         // (see the type-level docs). Without the anchor the pages would free
         // under a live mapping.
         self.pages = Some(Arc::downgrade(&pages));
+        self.mmap_kvirt = Some(kvirt.as_usize());
         let anchor: Arc<dyn Any + Send + Sync> = pages;
         Ok((paddr, anchor))
     }

--- a/os/StarryOS/kernel/src/perf/kprobe.rs
+++ b/os/StarryOS/kernel/src/perf/kprobe.rs
@@ -16,6 +16,11 @@ use axpoll::Pollable;
 use kbpf_basic::perf::{PerfProbeArgs, PerfProbeConfig};
 use kprobe::{CallBackFunc, KretprobeBuilder, ProbeBuilder, PtRegs};
 
+/// Config value for entry probes (kprobe/uprobe), per Linux PERF_TYPE_PROBE ABI.
+pub const PROBE_CONFIG_ENTRY: u64 = 0;
+/// Config value for return probes (kretprobe/uretprobe), per Linux PERF_TYPE_PROBE ABI.
+pub const PROBE_CONFIG_RETURN: u64 = 1;
+
 use crate::{
     file::FileLike,
     kprobe::{
@@ -188,19 +193,16 @@ fn perf_probe_arg_to_kretprobe_builder(
 }
 
 /// Build a `ProbePerfEvent` for a `PERF_TYPE_KPROBE` perf_event_open call.
-/// Config 0 = kprobe; config 1 = kretprobe (per kbpf-basic convention).
+/// Config `PROBE_CONFIG_ENTRY` (0) = kprobe; `PROBE_CONFIG_RETURN` (1) = kretprobe.
 pub fn perf_event_open_kprobe(args: PerfProbeArgs) -> AxResult<ProbePerfEvent> {
     let probe = match args.config {
-        PerfProbeConfig::Raw(val) => {
-            if val == 0 {
-                let builder = perf_probe_arg_to_kprobe_builder(&args)?;
-                ProbeTy::Kprobe(register_kprobe(builder))
-            } else if val == 1 {
-                let builder = perf_probe_arg_to_kretprobe_builder(&args)?;
-                ProbeTy::Kretprobe(register_kretprobe(builder))
-            } else {
-                return Err(AxError::InvalidInput);
-            }
+        PerfProbeConfig::Raw(PROBE_CONFIG_ENTRY) => {
+            let builder = perf_probe_arg_to_kprobe_builder(&args)?;
+            ProbeTy::Kprobe(register_kprobe(builder))
+        }
+        PerfProbeConfig::Raw(PROBE_CONFIG_RETURN) => {
+            let builder = perf_probe_arg_to_kretprobe_builder(&args)?;
+            ProbeTy::Kretprobe(register_kretprobe(builder))
         }
         _ => return Err(AxError::InvalidInput),
     };

--- a/os/StarryOS/kernel/src/perf/mod.rs
+++ b/os/StarryOS/kernel/src/perf/mod.rs
@@ -105,9 +105,24 @@ impl Pollable for PerfEvent {
     }
 }
 
+/// Stack buffer size for reading a single perf ringbuf record. The
+/// ringbuf data region minimum is one page, and a single perf record
+/// always fits within one data-region page.
+const PERF_READ_BUF_SIZE: usize = PAGE_SIZE_4K;
+
 impl FileLike for PerfEvent {
-    fn read(&self, _dst: &mut crate::file::IoDst) -> AxResult<usize> {
-        Err(AxError::Unsupported)
+    fn read(&self, dst: &mut crate::file::IoDst) -> AxResult<usize> {
+        let mut event = self.event.lock();
+        let bpf_event = event
+            .as_any_mut()
+            .downcast_mut::<BpfPerfEventWrapper>()
+            .ok_or(AxError::Unsupported)?;
+        let mut buf = [0u8; PERF_READ_BUF_SIZE];
+        let n = bpf_event.try_read_record(&mut buf)?;
+        if n == 0 {
+            return Ok(0);
+        }
+        dst.write(&buf[..n]).map_err(|_| AxError::Io)
     }
 
     fn write(&self, _src: &mut crate::file::IoSrc) -> AxResult<usize> {

--- a/os/StarryOS/kernel/src/perf/mod.rs
+++ b/os/StarryOS/kernel/src/perf/mod.rs
@@ -21,7 +21,8 @@ use ax_kspin::{SpinNoPreempt, SpinNoPreemptGuard};
 use ax_lazyinit::LazyInit;
 use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, PhysAddrRange, VirtAddr, VirtAddrRange};
 use ax_runtime::hal::paging::MappingFlags;
-use axpoll::Pollable;
+use ax_task::future::{block_on, poll_io};
+use axpoll::{IoEvents, Pollable};
 pub use bpf::BpfPerfEventWrapper;
 use hashbrown::HashMap;
 use kbpf_basic::{
@@ -112,17 +113,23 @@ const PERF_READ_BUF_SIZE: usize = PAGE_SIZE_4K;
 
 impl FileLike for PerfEvent {
     fn read(&self, dst: &mut crate::file::IoDst) -> AxResult<usize> {
-        let mut event = self.event.lock();
-        let bpf_event = event
-            .as_any_mut()
-            .downcast_mut::<BpfPerfEventWrapper>()
-            .ok_or(AxError::Unsupported)?;
-        let mut buf = [0u8; PERF_READ_BUF_SIZE];
-        let n = bpf_event.try_read_record(&mut buf)?;
-        if n == 0 {
-            return Ok(0);
-        }
-        dst.write(&buf[..n]).map_err(|_| AxError::Io)
+        block_on(poll_io(self, IoEvents::IN, self.nonblocking(), || {
+            let mut event = self.event.lock();
+            let bpf_event = event
+                .as_any_mut()
+                .downcast_mut::<BpfPerfEventWrapper>()
+                .ok_or(AxError::Unsupported)?;
+            let mut buf = [0u8; PERF_READ_BUF_SIZE];
+            let n = bpf_event.try_read_record(&mut buf)?;
+            // Release the lock before writing to dst (I/O outside the spin
+            // lock) and before returning WouldBlock (the lock must not be
+            // held across the poll_io reschedule).
+            drop(event);
+            if n == 0 {
+                return Err(AxError::WouldBlock);
+            }
+            dst.write(&buf[..n]).map_err(|_| AxError::Io)
+        }))
     }
 
     fn write(&self, _src: &mut crate::file::IoSrc) -> AxResult<usize> {

--- a/os/StarryOS/kernel/src/perf/uprobe.rs
+++ b/os/StarryOS/kernel/src/perf/uprobe.rs
@@ -15,7 +15,7 @@ use ax_errno::{AxError, AxResult};
 use kbpf_basic::perf::{PerfProbeArgs, PerfProbeConfig};
 use kprobe::ProbeBuilder;
 
-use super::kprobe::{ProbePerfEvent, ProbeTy};
+use super::kprobe::{PROBE_CONFIG_ENTRY, PROBE_CONFIG_RETURN, ProbePerfEvent, ProbeTy};
 use crate::{
     kprobe::KprobeAuxiliary,
     task::{AsThread, get_task},
@@ -74,13 +74,13 @@ fn perf_probe_arg_to_uprobe_builder(
 /// Build a uprobe perf event from `perf_event_open` args.
 pub fn perf_event_open_uprobe(args: PerfProbeArgs) -> AxResult<ProbePerfEvent> {
     let probe = match args.config {
-        PerfProbeConfig::Raw(0) => {
+        PerfProbeConfig::Raw(PROBE_CONFIG_ENTRY) => {
             let builder = perf_probe_arg_to_uprobe_builder(&args)?;
             ProbeTy::Uprobe(crate::uprobe::register_uprobe(builder))
         }
-        PerfProbeConfig::Raw(1) => {
+        PerfProbeConfig::Raw(PROBE_CONFIG_RETURN) => {
             // uretprobe — not implemented for user space yet.
-            warn!("uprobe: uretprobe (config=1) is not yet supported");
+            warn!("uprobe: uretprobe is not yet supported");
             return Err(AxError::Unsupported);
         }
         other => {


### PR DESCRIPTION
## 问题

已有的 read 是非阻塞轮询模式：ringbuf 为空时直接返回 0，不符合 Linux read(perf_fd) 的阻塞等待语义。用户态程序期望 read 在无数据时 block，直到 eBPF program 写入新记录。

## 变更

PerfEvent::read 重构为 block_on(poll_io(...)) 阻塞读模式：
- ringbuf 无数据时返回 WouldBlock，由 poll_io 注册 waker 并挂起任务
- 数据到达后，已有的 BpfPerfEventWrapper poll 基础设施唤醒任务继续读取
- read 闭包在返回 WouldBlock 前显式释放 SpinNoPreempt 锁

## 逻辑

复用 BpfPerfEventWrapper 已有的完整 poll 基础设施（Pollable trait、poll_ready PollSet、poll_notify IrqNotify、notify worker），仅需在 FileLike::read 层面集成 poll_io 等待循环。遵循 StarryOS 其他文件类型（signalfd/eventfd/pipe）的 block_on(poll_io(...)) 模式。