### PR TITLE
refactor(axbuild): use typed config serialization

### DIFF
--- a/scripts/axbuild/src/axvisor/build/load.rs
+++ b/scripts/axbuild/src/axvisor/build/load.rs
@@ -12,19 +12,11 @@ use crate::{
 };
 
 pub(crate) fn load_board_file(path: &Path) -> anyhow::Result<AxvisorBoardFile> {
-    let content = fs::read_to_string(path).map_err(|e| {
-        anyhow!(
-            "failed to read Axvisor board config {}: {e}",
-            path.display()
-        )
-    })?;
-    reject_unsupported_axvisor_fields(path, &content)?;
-    toml::from_str(&content).map_err(|e| {
-        anyhow!(
-            "failed to parse Axvisor board config {}: {e}",
-            path.display()
-        )
-    })
+    crate::build::load_toml_with_rejector(
+        path,
+        "Axvisor board config",
+        reject_unsupported_axvisor_fields,
+    )
 }
 
 pub(crate) fn resolve_build_info_path(
@@ -57,13 +49,11 @@ pub(crate) fn default_build_info_path(axvisor_dir: &Path, target: &str) -> PathB
 }
 
 pub(crate) fn load_target_from_build_config(path: &Path) -> anyhow::Result<Option<String>> {
-    let content = fs::read_to_string(path).map_err(|e| {
-        anyhow!(
-            "failed to read Axvisor build config {}: {e}",
-            path.display()
-        )
-    })?;
-    reject_unsupported_axvisor_fields(path, &content)?;
+    let content = crate::build::read_toml_with_rejector(
+        path,
+        "Axvisor build config",
+        reject_unsupported_axvisor_fields,
+    )?;
 
     if let Ok(board_file) = toml::from_str::<AxvisorBoardFile>(&content) {
         return Ok(Some(board_file.target));
@@ -84,13 +74,11 @@ pub(super) fn load_build_config(
         return load_or_create_missing_build_config(request);
     }
 
-    let content = fs::read_to_string(&request.build_info_path).map_err(|e| {
-        anyhow!(
-            "failed to read Axvisor build config {}: {e}",
-            request.build_info_path.display()
-        )
-    })?;
-    reject_unsupported_axvisor_fields(&request.build_info_path, &content)?;
+    let content = crate::build::read_toml_with_rejector(
+        &request.build_info_path,
+        "Axvisor build config",
+        reject_unsupported_axvisor_fields,
+    )?;
 
     if let Ok(board_config) = toml::from_str::<AxvisorBoardFile>(&content) {
         let mut loaded = board_config.into_loaded();

--- a/scripts/axbuild/src/axvisor/build/tests.rs
+++ b/scripts/axbuild/src/axvisor/build/tests.rs
@@ -247,6 +247,22 @@ vm_configs = []
 }
 
 #[test]
+fn load_target_from_plain_build_config_returns_none() {
+    let root = tempdir().unwrap();
+    let path = root.path().join(".build.toml");
+    fs::write(
+        &path,
+        r#"
+features = ["fs"]
+log = "Info"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(load_target_from_build_config(&path).unwrap(), None);
+}
+
+#[test]
 fn load_target_from_build_config_rejects_removed_std_field() {
     let root = tempdir().unwrap();
     let path = root.path().join("qemu-aarch64.toml");

--- a/scripts/axbuild/src/axvisor/rootfs.rs
+++ b/scripts/axbuild/src/axvisor/rootfs.rs
@@ -13,9 +13,20 @@ use std::{
 
 use anyhow::{Context, anyhow};
 use ostool::{build::config::Cargo, run::qemu::QemuConfig};
+use serde::Deserialize;
 
 use super::{Axvisor, build};
 use crate::{context::ResolvedAxvisorRequest, rootfs, test::qemu as qemu_test};
+
+#[derive(Deserialize)]
+struct VmRootfsProbe {
+    kernel: Option<VmKernelRootfsProbe>,
+}
+
+#[derive(Deserialize)]
+struct VmKernelRootfsProbe {
+    kernel_path: Option<String>,
+}
 
 pub(super) async fn qemu(axvisor: &mut Axvisor, args: super::ArgsQemu) -> anyhow::Result<()> {
     let mut request = axvisor.prepare_request(
@@ -235,16 +246,12 @@ pub(crate) fn infer_rootfs_path(vmconfigs: &[PathBuf]) -> anyhow::Result<Option<
     for vmconfig in vmconfigs {
         let content = fs::read_to_string(vmconfig)
             .map_err(|e| anyhow!("failed to read vm config {}: {e}", vmconfig.display()))?;
-        let value: toml::Value = toml::from_str(&content)
+        let probe: VmRootfsProbe = toml::from_str(&content)
             .map_err(|e| anyhow!("failed to parse vm config {}: {e}", vmconfig.display()))?;
-        let Some(kernel_path) = value
-            .get("kernel")
-            .and_then(|kernel| kernel.get("kernel_path"))
-            .and_then(|path| path.as_str())
-        else {
+        let Some(kernel_path) = probe.kernel.and_then(|kernel| kernel.kernel_path) else {
             continue;
         };
-        let rootfs_path = Path::new(kernel_path)
+        let rootfs_path = Path::new(&kernel_path)
             .parent()
             .map(|dir| dir.join("rootfs.img"));
         if let Some(rootfs_path) = rootfs_path
@@ -315,6 +322,43 @@ kernel_path = "{}"
             infer_rootfs_path(&[vmconfig]).unwrap(),
             Some(image_dir.join("rootfs.img"))
         );
+    }
+
+    #[test]
+    fn infer_rootfs_path_skips_vmconfig_without_kernel_path() {
+        let root = tempdir().unwrap();
+        let vmconfig = root.path().join("vm.toml");
+        fs::write(
+            &vmconfig,
+            r#"
+[kernel]
+cmdline = "console=ttyS0"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(infer_rootfs_path(&[vmconfig]).unwrap(), None);
+    }
+
+    #[test]
+    fn infer_rootfs_path_skips_nonexistent_kernel_sibling_rootfs() {
+        let root = tempdir().unwrap();
+        let image_dir = root.path().join("image");
+        fs::create_dir_all(&image_dir).unwrap();
+        let vmconfig = root.path().join("vm.toml");
+        fs::write(
+            &vmconfig,
+            format!(
+                r#"
+[kernel]
+kernel_path = "{}"
+"#,
+                image_dir.join("qemu-aarch64").display()
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(infer_rootfs_path(&[vmconfig]).unwrap(), None);
     }
 
     #[test]

--- a/scripts/axbuild/src/build/config_file.rs
+++ b/scripts/axbuild/src/build/config_file.rs
@@ -27,10 +27,31 @@ pub(crate) fn load_build_info<T>(path: &Path) -> anyhow::Result<T>
 where
     T: DeserializeOwned,
 {
-    let contents = std::fs::read_to_string(path)?;
-    reject_removed_std_field(path, &contents)?;
+    load_toml_with_rejector(path, "build info", reject_removed_std_field)
+}
+
+pub(crate) fn load_toml_with_rejector<T>(
+    path: &Path,
+    description: &str,
+    rejector: impl FnOnce(&Path, &str) -> anyhow::Result<()>,
+) -> anyhow::Result<T>
+where
+    T: DeserializeOwned,
+{
+    let contents = read_toml_with_rejector(path, description, rejector)?;
     toml::from_str::<T>(&contents)
-        .with_context(|| format!("failed to parse build info {}", path.display()))
+        .with_context(|| format!("failed to parse {description} {}", path.display()))
+}
+
+pub(crate) fn read_toml_with_rejector(
+    path: &Path,
+    description: &str,
+    rejector: impl FnOnce(&Path, &str) -> anyhow::Result<()>,
+) -> anyhow::Result<String> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {description} {}", path.display()))?;
+    rejector(path, &contents)?;
+    Ok(contents)
 }
 
 pub(crate) fn reject_removed_std_field(path: &Path, contents: &str) -> anyhow::Result<()> {

--- a/scripts/axbuild/src/build/mod.rs
+++ b/scripts/axbuild/src/build/mod.rs
@@ -26,7 +26,8 @@ mod platform;
 mod std_build;
 
 pub(crate) use config_file::{
-    ensure_build_info, load_build_info, reject_arceos_app_c_field, reject_removed_std_field,
+    ensure_build_info, load_build_info, load_toml_with_rejector, read_toml_with_rejector,
+    reject_arceos_app_c_field, reject_removed_std_field,
 };
 pub(crate) use info::{
     ARCEOS_LINKER_SCRIPT, BuildInfo, build_info_enables_backtrace_path,

--- a/scripts/axbuild/src/build/std_build.rs
+++ b/scripts/axbuild/src/build/std_build.rs
@@ -7,6 +7,62 @@ pub(super) struct StdBuildTarget {
     pub(super) env: HashMap<String, String>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct StdCargoConfig {
+    unstable: StdCargoUnstableConfig,
+    profile: StdCargoProfileConfig,
+    target: HashMap<String, StdCargoTargetConfig>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct StdCargoUnstableConfig {
+    build_std: Vec<&'static str>,
+    build_std_features: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct StdCargoProfileConfig {
+    release: StdCargoReleaseProfile,
+}
+
+#[derive(Serialize)]
+struct StdCargoReleaseProfile {
+    lto: bool,
+    panic: &'static str,
+}
+
+#[derive(Serialize)]
+struct StdCargoTargetConfig {
+    linker: String,
+    rustflags: Vec<String>,
+}
+
+impl StdCargoConfig {
+    fn new(target: &str, linker: &Path, extra_rustflags: &[String]) -> Self {
+        Self {
+            unstable: StdCargoUnstableConfig {
+                build_std: vec!["std", "panic_abort"],
+                build_std_features: Vec::new(),
+            },
+            profile: StdCargoProfileConfig {
+                release: StdCargoReleaseProfile {
+                    lto: false,
+                    panic: "abort",
+                },
+            },
+            target: HashMap::from([(
+                target.to_string(),
+                StdCargoTargetConfig {
+                    linker: linker.display().to_string(),
+                    rustflags: extra_rustflags.to_vec(),
+                },
+            )]),
+        }
+    }
+}
+
 pub(super) fn std_build_target_for(target: &str, plat_dyn: bool) -> anyhow::Result<StdBuildTarget> {
     let (target_name, tool_prefix) = if target.starts_with("x86_64-") {
         ("x86_64-unknown-linux-musl", "x86_64-linux-musl")
@@ -317,41 +373,13 @@ pub(super) fn std_cargo_config_path(
 ) -> anyhow::Result<PathBuf> {
     let mode = std_link_mode_suffix(plat_dyn);
     let path = std_build_dir()?.join(format!("config-{target}-{mode}.toml"));
-    let rustflags = std_rustflags_toml(extra_rustflags);
-    write_if_changed(
-        &path,
-        &format!(
-            r#"[unstable]
-build-std = ["std", "panic_abort"]
-build-std-features = []
-
-[profile.release]
-lto = false
-panic = "abort"
-
-[target.{target}]
-linker = "{}"
-rustflags = [
-{}
-]
-"#,
-            toml_escape_string(&linker.display().to_string()),
-            rustflags,
-        ),
-    )?;
+    let config = toml::to_string_pretty(&StdCargoConfig::new(target, linker, extra_rustflags))?;
+    write_if_changed(&path, &config)?;
     Ok(path)
 }
 
 pub(super) fn std_link_mode_suffix(plat_dyn: bool) -> &'static str {
     if plat_dyn { "dynamic" } else { "static" }
-}
-
-pub(super) fn std_rustflags_toml(extra_rustflags: &[String]) -> String {
-    extra_rustflags
-        .iter()
-        .map(|flag| format!("    {},", toml::Value::String(flag.clone())))
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 pub(super) fn std_fake_lib_dir(target: &str) -> anyhow::Result<PathBuf> {
@@ -644,10 +672,6 @@ pub(super) fn lld_machine_for_std_target(target: &str) -> anyhow::Result<&'stati
     } else {
         bail!("unsupported ArceOS std linker target `{target}`")
     }
-}
-
-pub(super) fn toml_escape_string(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 pub(super) fn shell_single_quote(value: &str) -> String {

--- a/scripts/axbuild/src/build/tests/std_linker.rs
+++ b/scripts/axbuild/src/build/tests/std_linker.rs
@@ -1,18 +1,37 @@
 use super::*;
 
+fn load_std_cargo_config(path: &Path) -> toml::Table {
+    toml::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
 #[test]
 fn std_cargo_config_uses_linux_musl_wrapper_with_plain_std_build() {
     let fake_dir = std_fake_lib_dir("x86_64-unknown-linux-musl").unwrap();
     let wrapper = std_linker_wrapper_path("x86_64-unknown-linux-musl", &fake_dir, false).unwrap();
     let config = std_cargo_config_path("x86_64-unknown-linux-musl", &wrapper, false, &[]).unwrap();
     let config = fs::read_to_string(config).unwrap();
+    let parsed: toml::Table = toml::from_str(&config).unwrap();
 
-    assert!(config.contains("build-std = [\"std\", \"panic_abort\"]"));
-    assert!(config.contains("build-std-features = []"));
-    assert!(config.contains("[target.x86_64-unknown-linux-musl]"));
+    assert_eq!(
+        parsed["unstable"]["build-std"].as_array().unwrap(),
+        &vec![
+            toml::Value::String("std".to_string()),
+            toml::Value::String("panic_abort".to_string())
+        ]
+    );
+    assert_eq!(
+        parsed["unstable"]["build-std-features"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
+    assert_eq!(
+        parsed["target"]["x86_64-unknown-linux-musl"]["linker"].as_str(),
+        Some(wrapper.display().to_string().as_str())
+    );
     assert!(!config.contains("--cfg"));
     assert!(!config.contains("--check-cfg"));
-    assert!(config.contains(&wrapper.display().to_string()));
     assert!(!config.contains("relocation-model"));
     assert!(!config.contains("code-model"));
     assert!(!config.contains("--cfg"));
@@ -99,6 +118,91 @@ fn std_cargo_config_and_wrapper_paths_are_partitioned_by_link_mode() {
             .display()
             .to_string()
             .ends_with("config-aarch64-unknown-linux-musl-dynamic.toml")
+    );
+}
+
+#[test]
+fn std_cargo_config_serializes_structured_toml_fields() {
+    let fake_dir = std_fake_lib_dir("x86_64-unknown-linux-musl").unwrap();
+    let wrapper = std_linker_wrapper_path("x86_64-unknown-linux-musl", &fake_dir, false).unwrap();
+    let path = std_cargo_config_path(
+        "x86_64-unknown-linux-musl",
+        &wrapper,
+        false,
+        &["--cfg".to_string(), r#"feature="quote\slash""#.to_string()],
+    )
+    .unwrap();
+
+    let config = load_std_cargo_config(&path);
+    let unstable = config.get("unstable").unwrap().as_table().unwrap();
+    assert_eq!(
+        unstable.get("build-std").unwrap().as_array().unwrap(),
+        &vec![
+            toml::Value::String("std".to_string()),
+            toml::Value::String("panic_abort".to_string())
+        ]
+    );
+    assert_eq!(
+        unstable
+            .get("build-std-features")
+            .unwrap()
+            .as_array()
+            .unwrap(),
+        &Vec::<toml::Value>::new()
+    );
+
+    let profile = config
+        .get("profile")
+        .unwrap()
+        .get("release")
+        .unwrap()
+        .as_table()
+        .unwrap();
+    assert_eq!(profile.get("lto").unwrap().as_bool(), Some(false));
+    assert_eq!(profile.get("panic").unwrap().as_str(), Some("abort"));
+
+    let target = config
+        .get("target")
+        .unwrap()
+        .get("x86_64-unknown-linux-musl")
+        .unwrap()
+        .as_table()
+        .unwrap();
+    assert_eq!(
+        target.get("linker").unwrap().as_str(),
+        Some(wrapper.display().to_string().as_str())
+    );
+    assert_eq!(
+        target
+            .get("rustflags")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["--cfg", r#"feature="quote\slash""#]
+    );
+}
+
+#[test]
+fn std_cargo_config_serializes_empty_rustflags_as_empty_array() {
+    let fake_dir = std_fake_lib_dir("riscv64gc-unknown-linux-musl").unwrap();
+    let wrapper =
+        std_linker_wrapper_path("riscv64gc-unknown-linux-musl", &fake_dir, false).unwrap();
+    let path = std_cargo_config_path("riscv64gc-unknown-linux-musl", &wrapper, false, &[]).unwrap();
+
+    let config = load_std_cargo_config(&path);
+    let target = config
+        .get("target")
+        .unwrap()
+        .get("riscv64gc-unknown-linux-musl")
+        .unwrap()
+        .as_table()
+        .unwrap();
+    assert_eq!(
+        target.get("rustflags").unwrap().as_array().unwrap().len(),
+        0
     );
 }
 

--- a/scripts/axbuild/src/clippy/env.rs
+++ b/scripts/axbuild/src/clippy/env.rs
@@ -5,13 +5,25 @@ use std::{
 
 use anyhow::Context;
 use cargo_metadata::{Metadata, Package};
-use serde_json::Value;
+use serde::Deserialize;
 
 use super::{
-    AX_CONFIG_PATH_ENV, AXBUILD_METADATA, AXCONFIG_FILE, AXSTD_STD_CLIPPY_TARGET,
-    AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE, CLIPPY_FEATURE_AXCONFIG_OVERRIDES_METADATA,
-    check::ClippyAxconfigOverride,
+    AX_CONFIG_PATH_ENV, AXCONFIG_FILE, AXSTD_STD_CLIPPY_TARGET, AXSTD_STD_DEFAULT_FEATURE,
+    AXSTD_STD_PACKAGE, check::ClippyAxconfigOverride,
 };
+
+#[derive(Debug, Default, Deserialize)]
+struct PackageAxbuildMetadata {
+    #[serde(default)]
+    axbuild: AxbuildMetadata,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct AxbuildMetadata {
+    #[serde(default)]
+    clippy_feature_axconfig_overrides: HashMap<String, Vec<String>>,
+}
 
 pub(super) fn clippy_env(package: &Package) -> Vec<(String, String)> {
     let Some(manifest_dir) = package.manifest_path.parent() else {
@@ -32,29 +44,9 @@ fn package_axconfig_path(package: &Package) -> Option<PathBuf> {
 }
 
 pub(super) fn feature_axconfig_overrides(package: &Package) -> HashMap<String, Vec<String>> {
-    let Some(overrides) = package
-        .metadata
-        .get(AXBUILD_METADATA)
-        .and_then(Value::as_object)
-        .and_then(|metadata| metadata.get(CLIPPY_FEATURE_AXCONFIG_OVERRIDES_METADATA))
-        .and_then(Value::as_object)
-    else {
-        return HashMap::new();
-    };
-
-    overrides
-        .iter()
-        .filter_map(|(feature, values)| {
-            let values = values
-                .as_array()?
-                .iter()
-                .map(Value::as_str)
-                .map(Option::unwrap_or_default)
-                .map(ToString::to_string)
-                .collect::<Vec<_>>();
-            Some((feature.clone(), values))
-        })
-        .collect()
+    serde_json::from_value::<PackageAxbuildMetadata>(package.metadata.clone())
+        .map(|metadata| metadata.axbuild.clippy_feature_axconfig_overrides)
+        .unwrap_or_default()
 }
 
 pub(super) fn clippy_axconfig_override(

--- a/scripts/axbuild/src/clippy/mod.rs
+++ b/scripts/axbuild/src/clippy/mod.rs
@@ -31,13 +31,6 @@ pub(super) const AXSTD_STD_PACKAGE: &str = "ax-std";
 pub(super) const AXSTD_STD_DEFAULT_FEATURE: &str = "default";
 pub(super) const AXSTD_STD_CLIPPY_FEATURES: &str = "std-compat,plat-dyn,fs,multitask,irq,net";
 pub(super) const AXSTD_STD_CLIPPY_TARGET: &str = "x86_64-unknown-none";
-pub(super) const DOCS_RS_METADATA: &str = "docs.rs";
-pub(super) const DOCS_METADATA: &str = "docs";
-pub(super) const RS_METADATA: &str = "rs";
-pub(super) const TARGETS_METADATA: &str = "targets";
-pub(super) const AXBUILD_METADATA: &str = "axbuild";
-pub(super) const CLIPPY_FEATURE_AXCONFIG_OVERRIDES_METADATA: &str =
-    "clippy-feature-axconfig-overrides";
 pub(super) const AX_HAL_PACKAGE: &str = "ax-hal";
 
 pub(crate) fn run_workspace_clippy_command(args: &crate::ClippyArgs) -> anyhow::Result<()> {

--- a/scripts/axbuild/src/clippy/targets.rs
+++ b/scripts/axbuild/src/clippy/targets.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeSet;
 
 use cargo_metadata::Package;
-use serde_json::Value;
+use serde::Deserialize;
 
-use super::{AX_HAL_PACKAGE, DOCS_METADATA, DOCS_RS_METADATA, RS_METADATA, TARGETS_METADATA};
+use super::AX_HAL_PACKAGE;
 
 const CLIPPY_TARGET_ALIASES: &[(&str, &str)] = &[
     (
@@ -23,30 +23,40 @@ const AX_HAL_PLATFORM_FEATURE_TARGET_ARCHES: &[(&str, &[&str])] = &[
     ("riscv64-sg2002", &["riscv64"]),
 ];
 
+#[derive(Debug, Default, Deserialize)]
+struct PackageDocsMetadata {
+    #[serde(default, rename = "docs.rs")]
+    docs_rs: DocsRsMetadata,
+    #[serde(default)]
+    docs: NestedDocsMetadata,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NestedDocsMetadata {
+    #[serde(default)]
+    rs: DocsRsMetadata,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DocsRsMetadata {
+    #[serde(default)]
+    targets: Vec<String>,
+}
+
 pub(super) fn docs_rs_targets(package: &Package) -> Vec<String> {
-    let Some(docs_rs) = package
-        .metadata
-        .get(DOCS_RS_METADATA)
-        .and_then(Value::as_object)
-        .or_else(|| {
-            package
-                .metadata
-                .get(DOCS_METADATA)
-                .and_then(Value::as_object)
-                .and_then(|docs| docs.get(RS_METADATA))
-                .and_then(Value::as_object)
-        })
+    let Ok(metadata) = serde_json::from_value::<PackageDocsMetadata>(package.metadata.clone())
     else {
         return Vec::new();
     };
-
-    let Some(targets) = docs_rs.get(TARGETS_METADATA).and_then(Value::as_array) else {
-        return Vec::new();
+    let targets = if metadata.docs_rs.targets.is_empty() {
+        metadata.docs.rs.targets
+    } else {
+        metadata.docs_rs.targets
     };
 
     let mut unique_targets = BTreeSet::new();
-    for target in targets.iter().filter_map(Value::as_str) {
-        unique_targets.insert(normalize_clippy_target(target).to_string());
+    for target in targets {
+        unique_targets.insert(normalize_clippy_target(&target).to_string());
     }
 
     unique_targets.into_iter().collect()

--- a/scripts/axbuild/src/clippy/tests/env.rs
+++ b/scripts/axbuild/src/clippy/tests/env.rs
@@ -1,8 +1,11 @@
+use std::path::PathBuf;
+
 use super::common::{expand, pkg_with_manifest_path, pkg_with_manifest_path_and_metadata};
 use crate::clippy::{
     AX_CONFIG_PATH_ENV, AXSTD_STD_CLIPPY_FEATURES, AXSTD_STD_CLIPPY_TARGET,
     AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE,
     check::{ClippyCheckKind, ClippyDepsMode},
+    env::feature_axconfig_overrides,
     expand::expand_clippy_checks,
     selection::SelectedClippyPackage,
 };
@@ -88,6 +91,27 @@ fn feature_axconfig_overrides_apply_only_to_that_feature_check() {
             ),
         ]
     );
+}
+
+#[test]
+fn malformed_feature_axconfig_overrides_are_ignored() {
+    let package = pkg_with_manifest_path_and_metadata(
+        "alpha",
+        "alpha 0.1.0 (path+file:///tmp/alpha)",
+        &[("cntv-timer", &[])],
+        Some(&["aarch64-unknown-none"]),
+        PathBuf::from("/tmp/alpha/Cargo.toml"),
+        serde_json::json!({
+            "axbuild": {
+                "clippy-feature-axconfig-overrides": {
+                    "cntv-timer": "devices.timer-irq=27",
+                    "gic-v3": [27, true]
+                }
+            }
+        }),
+    );
+
+    assert!(feature_axconfig_overrides(&package).is_empty());
 }
 
 #[test]

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -47,10 +47,11 @@ pub(crate) fn resolve_build_info_path(
 }
 
 pub(crate) fn load_target_from_build_config(path: &Path) -> anyhow::Result<Option<String>> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| anyhow!("failed to read Starry build config {}: {e}", path.display()))?;
-    crate::build::reject_removed_std_field(path, &content)?;
-    crate::build::reject_arceos_app_c_field(path, &content)?;
+    let content = crate::build::read_toml_with_rejector(
+        path,
+        "Starry build config",
+        reject_unsupported_starry_fields,
+    )?;
 
     if let Ok(board_file) = toml::from_str::<board::StarryBoardFile>(&content) {
         return Ok(Some(board_file.target));
@@ -62,6 +63,12 @@ pub(crate) fn load_target_from_build_config(path: &Path) -> anyhow::Result<Optio
     Err(anyhow!("invalid Starry build config {}", path.display()))
 }
 
+fn reject_unsupported_starry_fields(path: &Path, content: &str) -> anyhow::Result<()> {
+    crate::build::reject_removed_std_field(path, content)?;
+    crate::build::reject_arceos_app_c_field(path, content)?;
+    Ok(())
+}
+
 #[cfg(test)]
 pub(crate) fn load_build_info(request: &ResolvedStarryRequest) -> anyhow::Result<StarryBuildInfo> {
     let makefile_features = crate::build::makefile_features_from_env();
@@ -71,15 +78,11 @@ pub(crate) fn load_build_info(request: &ResolvedStarryRequest) -> anyhow::Result
         crate::build::ensure_build_info(&request.build_info_path, || {
             default_starry_build_info_for_target(&request.target)
         })?;
-        let content = std::fs::read_to_string(&request.build_info_path)?;
-        crate::build::reject_arceos_app_c_field(&request.build_info_path, &content)?;
-        let build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
-            format!(
-                "failed to parse build info {}",
-                request.build_info_path.display()
-            )
-        })?;
-        build_info
+        crate::build::load_toml_with_rejector(
+            &request.build_info_path,
+            "build info",
+            crate::build::reject_arceos_app_c_field,
+        )?
     };
 
     crate::build::apply_makefile_features(&mut build_info, &request.package, &makefile_features);
@@ -101,15 +104,11 @@ pub(crate) fn load_cargo_config(request: &ResolvedStarryRequest) -> anyhow::Resu
         crate::build::ensure_build_info(&request.build_info_path, || {
             default_starry_build_info_for_target(&request.target)
         })?;
-        let content = std::fs::read_to_string(&request.build_info_path)?;
-        crate::build::reject_arceos_app_c_field(&request.build_info_path, &content)?;
-        let build_info: StarryBuildInfo = toml::from_str(&content).with_context(|| {
-            format!(
-                "failed to parse build info {}",
-                request.build_info_path.display()
-            )
-        })?;
-        build_info
+        crate::build::load_toml_with_rejector(
+            &request.build_info_path,
+            "build info",
+            crate::build::reject_arceos_app_c_field,
+        )?
     };
     crate::build::apply_makefile_features_with_metadata(
         &mut build_info,

--- a/scripts/axbuild/src/starry/build/tests.rs
+++ b/scripts/axbuild/src/starry/build/tests.rs
@@ -218,6 +218,22 @@ log = "Info"
 }
 
 #[test]
+fn load_target_from_plain_build_config_returns_none() {
+    let root = tempdir().unwrap();
+    let path = root.path().join(".build-target.toml");
+    fs::write(
+        &path,
+        r#"
+features = ["net"]
+log = "Info"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(load_target_from_build_config(&path).unwrap(), None);
+}
+
+#[test]
 fn load_build_info_prefers_request_override_without_writing_file() {
     let root = tempdir().unwrap();
     let path = root.path().join(".build-target.toml");


### PR DESCRIPTION
## 背景

`axbuild` 里有几处配置读写仍依赖手写 TOML/JSON 拼接或 `serde_json::Value` / `toml::Value` 手动取字段，代码重复且不容易覆盖转义、默认值和坏 metadata 的行为。本 PR 做一批保守重构，只整理低风险的结构化配置路径，不改变 CLI、配置格式或 QEMU/shell 字符串协议。

## 修改内容

- 将 std Cargo config 的生成改为私有 serde 结构体序列化，移除手写 TOML 拼接和手写转义逻辑。
- 将 clippy metadata 读取改为本地 `Deserialize` 结构体，覆盖 `docs.rs` / `docs.rs` nested metadata 和 axbuild feature override metadata，并保持坏 metadata 容错为空结果。
- 将 Axvisor VM config 的 `kernel.kernel_path` 探测改成小型 typed TOML 结构体。
- 在 `build/config_file.rs` 中补充共享的 TOML 读取、reject、parse helper，并迁移 Starry/Axvisor 中机械重复的配置读取路径。
- 增加回归测试，覆盖结构化 TOML 字段、空 rustflags、metadata 容错、VM rootfs 推断和 plain build config target probing。

## 验证

- `cargo test -p axbuild --lib build::tests::std_linker`
- `cargo test -p axbuild --lib clippy::tests`
- `cargo test -p axbuild --lib axvisor::rootfs::tests`
- `cargo test -p axbuild --lib axvisor::build::tests`
- `cargo test -p axbuild --lib starry::build::tests`
- `cargo test -p axbuild --lib`
- `cargo fmt --check`
- `cargo xtask clippy --package axbuild`
