### PR TITLE
fix(starry): stabilize select null timeout test

### DIFF
--- a/test-suit/starryos/qemu-smp1/system/syscall-test-select-poll-family/src/select_null_timeout.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-select-poll-family/src/select_null_timeout.c
@@ -13,31 +13,57 @@ int run_select_null_timeout(void) {
 
     int fds[2];
     CHECK_RET(create_pipe(fds), 0, "pipe created");
+    int sync_fds[2];
+    CHECK_RET(create_pipe(sync_fds), 0, "sync pipe created");
 
     pid_t pid = fork();
     CHECK(pid >= 0, "fork succeeded");
 
     if (pid == 0) {
+        close(fds[0]);
+        close(sync_fds[1]);
+
         usleep(50000);
         char c = 'X';
-        write_exact(fds[1], &c, 1);
-        close(fds[0]);
+        if (write_exact(fds[1], &c, 1) != 0) {
+            _exit(1);
+        }
+
+        char release;
+        if (read_exact(sync_fds[0], &release, 1) != 0) {
+            _exit(2);
+        }
+
         close(fds[1]);
+        close(sync_fds[0]);
         _exit(0);
     }
 
+    close(sync_fds[0]);
+
     fd_set rfds;
-    FD_ZERO(&rfds);
-    FD_SET(fds[0], &rfds);
-    int ret = raw_select(fds[0] + 1, &rfds, NULL, NULL, NULL);
+    int ret;
+    do {
+        FD_ZERO(&rfds);
+        FD_SET(fds[0], &rfds);
+        errno = 0;
+        ret = raw_select(fds[0] + 1, &rfds, NULL, NULL, NULL);
+    } while (ret == -1 && errno == EINTR);
+
     CHECK(ret == 1, "select(timeout=NULL) returns 1 after child writes");
     CHECK(FD_ISSET(fds[0], &rfds), "FD_ISSET true for read fd after child writes");
 
+    char release = 'R';
+    CHECK_RET(write_exact(sync_fds[1], &release, 1), 0,
+              "release child after select observes pipe");
+
     int status;
     waitpid(pid, &status, 0);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0, "child exits cleanly");
 
     close(fds[0]);
     close(fds[1]);
+    close(sync_fds[1]);
 
     MODULE_SUMMARY("select_null_timeout");
     MODULE_RETURN();


### PR DESCRIPTION
## 问题

`test-select-poll-family` 中的 `select_null_timeout` 用例让子进程写入 pipe 后立即退出。这个测试把 `select(timeout=NULL)` 的 pipe 可读断言和子进程退出/信号生命周期耦合在一起，在 CI 调度下可能先观察到 `EINTR`，从而把时序竞态误报为 select 语义失败。

## 修改

- 为 `select_null_timeout` 增加一条同步 pipe。
- 子进程写入测试 pipe 后等待父进程释放，再退出。
- 父进程在每次 `select` 调用前重新初始化 `fd_set`，窄范围重试 `EINTR`，确认 pipe 可读后再释放并回收子进程。
- 子进程写入或等待释放失败时使用非零退出码，让父进程的退出状态检查能覆盖同步流程。

这样用例只验证 `select(timeout=NULL)` 在 pipe 变为可读后的阻塞返回行为，不再受子进程退出时序影响。

## 验证

- `cargo fmt`
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/syscall-test-select-poll-family`
  - `select_null_timeout: 7 pass, 0 fail`
  - `SUMMARY: 43 modules passed, 0 modules failed`
  - `all starry qemu tests passed`
- `cargo xtask clippy --package starryos`
  - 10 checks passed, 0 failed

Fixes #1418
