### PR TITLE
fix(ax-task): harden SMP wake and migration rescheduling

### DIFF
--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -183,15 +183,45 @@ pub(crate) fn clear_remote_reschedule_pending_for_current_cpu() {
     REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
 }
 
+#[cfg(all(feature = "smp", feature = "ipi"))]
+fn request_remote_reschedule_if_not_pending<F>(pending: &AtomicBool, request: F)
+where
+    F: FnOnce(),
+{
+    if !pending.swap(true, Ordering::AcqRel) {
+        request();
+    }
+}
+
+#[cfg(all(feature = "smp", feature = "ipi"))]
+fn force_remote_reschedule_request<F>(pending: &AtomicBool, request: F)
+where
+    F: FnOnce(),
+{
+    pending.store(true, Ordering::Release);
+    request();
+}
+
 #[cfg(all(
     feature = "smp",
     feature = "ipi",
     not(all(test, feature = "host-test"))
 ))]
 fn request_remote_reschedule(cpu_id: usize) {
-    if !REMOTE_RESCHEDULE_PENDING[cpu_id].swap(true, Ordering::AcqRel) {
+    request_remote_reschedule_if_not_pending(&REMOTE_RESCHEDULE_PENDING[cpu_id], || {
         ax_ipi::run_on_cpu(cpu_id, request_current_reschedule);
-    }
+    });
+}
+
+#[cfg(all(
+    feature = "smp",
+    feature = "ipi",
+    not(all(test, feature = "host-test"))
+))]
+fn force_remote_reschedule(cpu_id: usize) {
+    force_remote_reschedule_request(&REMOTE_RESCHEDULE_PENDING[cpu_id], || {
+        ax_ipi::run_on_cpu(cpu_id, request_current_reschedule);
+    });
 }
 
 #[cfg(all(test, feature = "smp", feature = "ipi", feature = "host-test"))]
@@ -199,9 +229,17 @@ fn request_remote_reschedule(cpu_id: usize) {
     let _ = cpu_id;
     // Host tests run with one dummy CPU and a no-op send_ipi(), so record the
     // scheduler-visible request that a real ax-ipi callback would carry.
-    if !REMOTE_RESCHEDULE_PENDING.swap(true, Ordering::AcqRel) {
+    request_remote_reschedule_if_not_pending(&REMOTE_RESCHEDULE_PENDING, || {
         REMOTE_RESCHEDULE_REQUESTS.fetch_add(1, Ordering::Release);
-    }
+    });
+}
+
+#[cfg(all(test, feature = "smp", feature = "ipi", feature = "host-test"))]
+fn force_remote_reschedule(cpu_id: usize) {
+    let _ = cpu_id;
+    force_remote_reschedule_request(&REMOTE_RESCHEDULE_PENDING, || {
+        REMOTE_RESCHEDULE_REQUESTS.fetch_add(1, Ordering::Release);
+    });
 }
 
 #[cfg(all(feature = "smp", feature = "ipi"))]
@@ -214,9 +252,16 @@ fn kick_remote_cpu(cpu_id: usize) {
     }
 }
 
+#[cfg(all(feature = "smp", feature = "ipi"))]
+fn force_kick_remote_cpu(cpu_id: usize) {
+    if cpu_id != this_cpu_id() {
+        force_remote_reschedule(cpu_id);
+    }
+}
+
 #[cfg(all(test, feature = "smp", feature = "ipi", feature = "host-test"))]
 mod tests {
-    use core::sync::atomic::Ordering;
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     // Host-test mode collapses per-CPU state into process-global statics, so
     // keep the shared pending/count assertions in one test.
@@ -290,6 +335,42 @@ mod tests {
 
         super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
         super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);
+    }
+
+    #[test]
+    fn forced_remote_reschedule_bypasses_stale_pending() {
+        let pending = AtomicBool::new(true);
+        let requests = AtomicUsize::new(0);
+
+        super::force_remote_reschedule_request(&pending, || {
+            requests.fetch_add(1, Ordering::Release);
+        });
+
+        assert_eq!(
+            requests.load(Ordering::Acquire),
+            1,
+            "forced remote kicks must bypass stale pending coalescing",
+        );
+
+        super::request_remote_reschedule_if_not_pending(&pending, || {
+            requests.fetch_add(1, Ordering::Release);
+        });
+
+        assert_eq!(
+            requests.load(Ordering::Acquire),
+            1,
+            "ordinary remote kicks should still coalesce stale pending requests",
+        );
+
+        super::force_remote_reschedule_request(&pending, || {
+            requests.fetch_add(1, Ordering::Release);
+        });
+
+        assert_eq!(
+            requests.load(Ordering::Acquire),
+            2,
+            "forced remote kicks must not coalesce required migration reschedules",
+        );
     }
 }
 
@@ -959,7 +1040,9 @@ pub(crate) fn migrate_entry(migrated_task: AxTaskRef) {
         .lock()
         .put_prev_task(migrated_task, false);
     #[cfg(all(feature = "smp", feature = "ipi"))]
-    kick_remote_cpu(cpu_id);
+    // Current-task migration cannot make progress until the target CPU runs
+    // the migrated task, so do not let a stale coalescing bit suppress this IPI.
+    force_kick_remote_cpu(cpu_id);
 }
 
 /// Clear the `on_cpu` field of previous task running on this CPU.

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -528,7 +528,11 @@ impl<G: BaseGuard> AxRunQueueRef<'_, G> {
     /// This function does nothing if the task is not in [`TaskState::Blocked`],
     /// which means the task is already unblocked by other cores.
     pub fn unblock_task(&mut self, task: AxTaskRef, resched: bool) {
-        let task_id_name = task.id_name();
+        let task_id_name = if log::log_enabled!(log::Level::Debug) {
+            Some(task.id_name())
+        } else {
+            None
+        };
         // Try to change the state of the task from `Blocked` to `Ready`,
         // if successful, the task will be put into this run queue,
         // otherwise, the task is already unblocked by other cores.
@@ -540,7 +544,9 @@ impl<G: BaseGuard> AxRunQueueRef<'_, G> {
         {
             // Since now, the task to be unblocked is in the `Ready` state.
             let cpu_id = self.inner.cpu_id;
-            debug!("task unblock: {task_id_name} on run_queue {cpu_id}");
+            if let Some(task_id_name) = task_id_name {
+                debug!("task unblock: {task_id_name} on run_queue {cpu_id}");
+            }
             // Note: when the task is unblocked on another CPU's run queue,
             // we just ignore the `resched` flag.
             if resched && cpu_id == this_cpu_id() {
@@ -560,13 +566,19 @@ impl<G: BaseGuard> CurrentRunQueueRef<'_, G> {
     /// See [`AxRunQueueRef::unblock_task`] for the state-transition details.
     #[cfg(feature = "irq")]
     pub(crate) fn unblock_task(&mut self, task: AxTaskRef, resched: bool) {
-        let task_id_name = task.id_name();
+        let task_id_name = if log::log_enabled!(log::Level::Debug) {
+            Some(task.id_name())
+        } else {
+            None
+        };
         if self
             .inner
             .put_task_with_state(task, TaskState::Blocked, resched)
         {
             let cpu_id = self.inner.cpu_id;
-            debug!("task unblock: {task_id_name} on run_queue {cpu_id}");
+            if let Some(task_id_name) = task_id_name {
+                debug!("task unblock: {task_id_name} on run_queue {cpu_id}");
+            }
             if resched {
                 #[cfg(feature = "preempt")]
                 crate::current().set_preempt_pending(true);

--- a/os/arceos/modules/axtask/src/wait_queue.rs
+++ b/os/arceos/modules/axtask/src/wait_queue.rs
@@ -1,6 +1,6 @@
 use alloc::collections::VecDeque;
 
-use ax_kernel_guard::{NoOp, NoPreemptIrqSave};
+use ax_kernel_guard::NoPreemptIrqSave;
 use ax_kspin::{SpinNoIrq, SpinNoIrqGuard};
 
 use crate::{AxTaskRef, CurrentTask, current_run_queue, select_wake_run_queue};
@@ -182,13 +182,12 @@ impl WaitQueue {
     /// If `resched` is true, the current task will be preempted when the
     /// preemption is enabled.
     pub fn notify_one(&self, resched: bool) -> bool {
-        let mut wq = self.queue.lock();
-        if let Some(task) = wq.pop_front() {
+        let task = self.pop_front();
+        if let Some(task) = task {
             unblock_one_task(task, resched);
-            true
-        } else {
-            false
+            return true;
         }
+        false
     }
 
     /// Wakes up one task from IRQ context.
@@ -215,15 +214,26 @@ impl WaitQueue {
     where
         F: Fn(u64),
     {
-        let mut wq = self.queue.lock();
-        if let Some(task) = wq.pop_front() {
-            func(task.id().as_u64());
+        let task = {
+            let mut wq = self.queue.lock();
+            match wq.pop_front() {
+                Some(task) => {
+                    func(task.id().as_u64());
+                    task.set_in_wait_queue(false);
+                    Some(task)
+                }
+                None => {
+                    func(0);
+                    None
+                }
+            }
+        };
+
+        if let Some(task) = task {
             unblock_one_task(task, resched);
-            true
-        } else {
-            func(0);
-            false
+            return true;
         }
+        false
     }
 
     /// Wakes all tasks in the wait queue.
@@ -246,13 +256,16 @@ impl WaitQueue {
             // loop until the wait queue is empty
         }
     }
+
+    fn pop_front(&self) -> Option<AxTaskRef> {
+        let mut wq = self.queue.lock();
+        let task = wq.pop_front()?;
+        task.set_in_wait_queue(false);
+        Some(task)
+    }
 }
 
 fn unblock_one_task(task: AxTaskRef, resched: bool) {
-    // Mark task as not in wait queue.
-    task.set_in_wait_queue(false);
     // Select run queue by the CPU set of the task.
-    // Use `NoOp` kernel guard here because the function is called with holding the
-    // lock of wait queue, where the irq and preemption are disabled.
-    select_wake_run_queue::<NoOp>(&task).unblock_task(task, resched)
+    select_wake_run_queue::<NoPreemptIrqSave>(&task).unblock_task(task, resched)
 }


### PR DESCRIPTION
  ## Problem

  Starry SMP affinity tests can expose scheduler stalls when a required remote reschedule is suppressed by the remote-
  reschedule coalescing bit. Wait queue wakeups also held the wait-queue lock while selecting and updating a run queue, which  can invert the lock order used by the blocking path.

  ## Changes

  - Add a forced remote-reschedule path for current-task migration.
  - Keep ordinary remote kicks coalesced, but bypass coalescing for migration kicks that must make progress.
  - Add a deterministic host test for stale-pending forced reschedule behavior.
  - Pop waiters and clear `in_wait_queue` while holding the wait-queue lock, then drop that lock before unblocking the task.
  - Avoid formatting task names for unblock debug logs unless debug logging is enabled.
