### PR TITLE
refactor(starry-kernel): move arch runtime helpers into HAL

### DIFF
--- a/components/axcpu/src/aarch64/uspace.rs
+++ b/components/axcpu/src/aarch64/uspace.rs
@@ -7,7 +7,7 @@ use ax_memory_addr::VirtAddr;
 use tock_registers::LocalRegisterCopy;
 
 use super::trap::{TrapKind, is_valid_page_fault};
-pub use crate::uspace_common::{ExceptionKind, ReturnReason};
+pub use crate::uspace_common::{ExceptionKind, ExceptionSyndrome, ReturnReason};
 use crate::{TrapFrame, trap::PageFaultFlags};
 
 /// Context to enter user space.
@@ -134,6 +134,19 @@ impl UserContext {
                 .value;
     }
 
+    /// Clears any architecture single-step state after a debug exception.
+    ///
+    /// AArch64 user single-step is currently emulated by the Starry ptrace layer,
+    /// so there is no saved CPU flag to clear here.
+    pub const fn clear_single_step_after_debug(&mut self) -> bool {
+        false
+    }
+
+    /// Returns the syscall instruction length in bytes.
+    pub const fn syscall_insn_len(&self) -> usize {
+        4
+    }
+
     /// Gets the stack pointer.
     pub const fn sp(&self) -> usize {
         self.sp as _
@@ -234,6 +247,20 @@ pub struct ExceptionInfo {
 }
 
 impl ExceptionInfo {
+    /// Returns the faulting virtual address when the CPU records one.
+    pub const fn fault_addr(&self) -> Option<usize> {
+        Some(self.far)
+    }
+
+    /// Returns architecture-neutral syndrome information for this exception.
+    pub fn syndrome(&self) -> ExceptionSyndrome {
+        ExceptionSyndrome {
+            raw: self.esr_value(),
+            class: self.ec_value(),
+            iss: self.iss_value(),
+        }
+    }
+
     /// Returns the raw Exception Syndrome Register value.
     pub fn esr_value(&self) -> u64 {
         self.esr.get()

--- a/components/axcpu/src/cap.rs
+++ b/components/axcpu/src/cap.rs
@@ -1,0 +1,66 @@
+//! CPU capability helpers.
+
+/// Returns the Linux-style `AT_HWCAP` value for the current architecture.
+///
+/// This reports only capabilities that the CPU/runtime layer can actually make
+/// available to user space. Architecture-specific auxiliary-vector layout is
+/// still owned by the OS layer.
+pub const fn elf_hwcap() -> usize {
+    #[cfg(target_arch = "loongarch64")]
+    {
+        // Linux loongarch HWCAP bits (uapi/asm/hwcap.h).
+        const HWCAP_LOONGARCH_CPUCFG: usize = 1 << 0;
+        const HWCAP_LOONGARCH_LAM: usize = 1 << 1;
+        const HWCAP_LOONGARCH_UAL: usize = 1 << 2;
+        const HWCAP_LOONGARCH_FPU: usize = 1 << 3;
+        const HWCAP_LOONGARCH_LSX: usize = 1 << 4;
+        const HWCAP_LOONGARCH_LASX: usize = 1 << 5;
+
+        HWCAP_LOONGARCH_CPUCFG
+            | HWCAP_LOONGARCH_LAM
+            | HWCAP_LOONGARCH_UAL
+            | HWCAP_LOONGARCH_FPU
+            | HWCAP_LOONGARCH_LSX
+            | HWCAP_LOONGARCH_LASX
+    }
+    #[cfg(target_arch = "riscv64")]
+    {
+        const RISCV_COMPAT_HWCAP_IMAFDC: usize = (1 << (b'I' - b'A'))
+            | (1 << (b'M' - b'A'))
+            | (1 << 0)
+            | (1 << (b'F' - b'A'))
+            | (1 << (b'D' - b'A'))
+            | (1 << (b'C' - b'A'));
+
+        RISCV_COMPAT_HWCAP_IMAFDC
+    }
+    #[cfg(not(any(target_arch = "loongarch64", target_arch = "riscv64")))]
+    {
+        0
+    }
+}
+
+/// Returns a conservative RISC-V Linux `hwprobe` value for a known key.
+///
+/// `None` means the key is unknown and the OS should report it as unsupported
+/// according to its ABI policy.
+#[cfg(target_arch = "riscv64")]
+pub const fn riscv_hwprobe(key: i64) -> Option<u64> {
+    const RISCV_HWPROBE_KEY_BASE_BEHAVIOR: i64 = 3;
+    const RISCV_HWPROBE_BASE_BEHAVIOR_IMA: u64 = 1 << 0;
+    const RISCV_HWPROBE_KEY_IMA_EXT_0: i64 = 4;
+    const RISCV_HWPROBE_IMA_FD: u64 = 1 << 0;
+    const RISCV_HWPROBE_IMA_C: u64 = 1 << 1;
+    const RISCV_HWPROBE_KEY_CPUPERF_0: i64 = 5;
+    const RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF: i64 = 9;
+    const RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF: i64 = 10;
+
+    match key {
+        RISCV_HWPROBE_KEY_BASE_BEHAVIOR => Some(RISCV_HWPROBE_BASE_BEHAVIOR_IMA),
+        RISCV_HWPROBE_KEY_IMA_EXT_0 => Some(RISCV_HWPROBE_IMA_FD | RISCV_HWPROBE_IMA_C),
+        RISCV_HWPROBE_KEY_CPUPERF_0
+        | RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF
+        | RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF => Some(0),
+        _ => None,
+    }
+}

--- a/components/axcpu/src/lib.rs
+++ b/components/axcpu/src/lib.rs
@@ -13,6 +13,8 @@ extern crate ax_memory_addr;
 #[macro_use]
 pub mod trap;
 
+pub mod cap;
+
 #[cfg(feature = "exception-table")]
 mod exception_table;
 #[cfg(feature = "uspace")]

--- a/components/axcpu/src/loongarch64/uspace.rs
+++ b/components/axcpu/src/loongarch64/uspace.rs
@@ -8,7 +8,7 @@ use loongArch64::register::{
     estat::{self, Exception, Trap},
 };
 
-pub use crate::uspace_common::{ExceptionKind, ReturnReason};
+pub use crate::uspace_common::{ExceptionKind, ExceptionSyndrome, ReturnReason};
 use crate::{TrapFrame, trap::PageFaultFlags};
 
 const ECODE_LSX_DISABLED: usize = 0x10;
@@ -39,6 +39,19 @@ impl UserContext {
         const PPLV_MASK: usize = 0b11;
         const PIE: usize = 1 << 2;
         self.0.prmd = (self.0.prmd & !PPLV_MASK) | PPLV_MASK | PIE;
+    }
+
+    /// Clears any architecture single-step state after a debug exception.
+    ///
+    /// LoongArch single-step is currently emulated by temporarily patching a
+    /// `break`, so there is no saved CPU flag to clear here.
+    pub const fn clear_single_step_after_debug(&mut self) -> bool {
+        false
+    }
+
+    /// Returns the syscall instruction length in bytes.
+    pub const fn syscall_insn_len(&self) -> usize {
+        4
     }
 
     /// Enter user space.
@@ -142,6 +155,20 @@ pub struct ExceptionInfo {
 }
 
 impl ExceptionInfo {
+    /// Returns the faulting virtual address when the CPU records one.
+    pub const fn fault_addr(&self) -> Option<usize> {
+        Some(self.badv)
+    }
+
+    /// Returns architecture-neutral syndrome information for this exception.
+    pub const fn syndrome(&self) -> ExceptionSyndrome {
+        ExceptionSyndrome {
+            raw: self.ecode as u64,
+            class: self.ecode as u64,
+            iss: self.esubcode as u64,
+        }
+    }
+
     /// Returns a generalized kind of this exception.
     pub fn kind(&self) -> ExceptionKind {
         if matches!(

--- a/components/axcpu/src/riscv/uspace.rs
+++ b/components/axcpu/src/riscv/uspace.rs
@@ -13,7 +13,7 @@ use riscv::{
     register::{scause, sstatus::Sstatus, stval},
 };
 
-pub use crate::uspace_common::{ExceptionKind, ReturnReason};
+pub use crate::uspace_common::{ExceptionKind, ExceptionSyndrome, ReturnReason};
 use crate::{GeneralRegisters, TrapFrame, trap::PageFaultFlags};
 
 /// Context to enter user space.
@@ -63,6 +63,19 @@ impl UserContext {
         if matches!(self.0.sstatus.fs(), FS::Off) {
             self.0.sstatus.set_fs(FS::Initial);
         }
+    }
+
+    /// Clears any architecture single-step state after a debug exception.
+    ///
+    /// RISC-V single-step is currently emulated by temporarily patching an
+    /// `ebreak`, so there is no saved CPU flag to clear here.
+    pub const fn clear_single_step_after_debug(&mut self) -> bool {
+        false
+    }
+
+    /// Returns the syscall instruction length in bytes.
+    pub const fn syscall_insn_len(&self) -> usize {
+        4
     }
 
     /// Enter user space.
@@ -158,6 +171,20 @@ pub struct ExceptionInfo {
 }
 
 impl ExceptionInfo {
+    /// Returns the faulting virtual address when the CPU records one.
+    pub const fn fault_addr(&self) -> Option<usize> {
+        Some(self.stval)
+    }
+
+    /// Returns architecture-neutral syndrome information for this exception.
+    pub const fn syndrome(&self) -> ExceptionSyndrome {
+        ExceptionSyndrome {
+            raw: 0,
+            class: self.e as u64,
+            iss: 0,
+        }
+    }
+
     /// Returns a generalized kind of this exception.
     pub fn kind(&self) -> ExceptionKind {
         match self.e {

--- a/components/axcpu/src/uspace_common.rs
+++ b/components/axcpu/src/uspace_common.rs
@@ -38,3 +38,18 @@ pub enum ExceptionKind {
     /// Other kinds of exceptions.
     Other,
 }
+
+/// Architecture-neutral syndrome fields for user-space exceptions.
+///
+/// The meaning of each field remains architecture-specific, but this shape
+/// gives OS code a single way to log or forward the raw trap details without
+/// reaching into every architecture's private register type.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ExceptionSyndrome {
+    /// Raw syndrome/status register value when the architecture exposes one.
+    pub raw: u64,
+    /// Primary exception class or code.
+    pub class: u64,
+    /// Architecture-specific instruction syndrome or subcode.
+    pub iss: u64,
+}

--- a/components/axcpu/src/x86_64/uspace.rs
+++ b/components/axcpu/src/x86_64/uspace.rs
@@ -18,7 +18,7 @@ use super::{
     gdt,
     trap::{IRQ_VECTOR_END, IRQ_VECTOR_START, LEGACY_SYSCALL_VECTOR, err_code_to_flags},
 };
-pub use crate::uspace_common::{ExceptionKind, ReturnReason};
+pub use crate::uspace_common::{ExceptionKind, ExceptionSyndrome, ReturnReason};
 
 /// Context to enter user space.
 #[derive(Debug, Clone, Copy)]
@@ -57,6 +57,22 @@ impl UserContext {
         flags.insert(RFlags::INTERRUPT_FLAG);
         flags.remove(RFlags::TRAP_FLAG | RFlags::NESTED_TASK | RFlags::RESUME_FLAG);
         self.tf.rflags = flags.bits();
+    }
+
+    /// Clears the single-step trap flag after a debug exception.
+    ///
+    /// Returns whether the flag had been set in the saved user context.
+    pub fn clear_single_step_after_debug(&mut self) -> bool {
+        let mut flags = RFlags::from_bits_truncate(self.tf.rflags);
+        let was_set = flags.contains(RFlags::TRAP_FLAG);
+        flags.remove(RFlags::TRAP_FLAG);
+        self.tf.rflags = flags.bits();
+        was_set
+    }
+
+    /// Returns the syscall instruction length in bytes.
+    pub const fn syscall_insn_len(&self) -> usize {
+        2
     }
 
     /// Gets the TLS area.
@@ -146,6 +162,20 @@ pub struct ExceptionInfo {
 }
 
 impl ExceptionInfo {
+    /// Returns the faulting virtual address when the CPU records one.
+    pub const fn fault_addr(&self) -> Option<usize> {
+        Some(self.cr2)
+    }
+
+    /// Returns architecture-neutral syndrome information for this exception.
+    pub const fn syndrome(&self) -> ExceptionSyndrome {
+        ExceptionSyndrome {
+            raw: self.error_code,
+            class: self.vector as u64,
+            iss: 0,
+        }
+    }
+
     /// Returns a generalized kind of this exception.
     pub fn kind(&self) -> ExceptionKind {
         match ExceptionVector::try_from(self.vector) {

--- a/os/StarryOS/kernel/src/kmod/mod.rs
+++ b/os/StarryOS/kernel/src/kmod/mod.rs
@@ -32,7 +32,6 @@ use ax_kspin::SpinNoPreempt;
 #[cfg(not(target_arch = "loongarch64"))]
 use ax_memory_addr::{MemoryAddr, VirtAddrRange};
 use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr};
-use ax_runtime::hal::cpu::asm::{flush_icache_all, flush_tlb};
 #[cfg(not(target_arch = "loongarch64"))]
 use ax_runtime::hal::paging::MappingFlags;
 use kmod_loader::{KernelModuleHelper, ModuleLoader, ModuleOwner, SectionMemOps};
@@ -99,7 +98,7 @@ impl SectionMemOps for KmodMemSection {
                 // symbols. DMW translations do not consult the page table, so
                 // there are no PTE permissions to update here.
                 if perms.contains(kmod_loader::SectionPerm::EXECUTE) {
-                    flush_icache_all();
+                    ax_runtime::hal::cache::flush_icache_all();
                 }
                 true
             }
@@ -132,7 +131,7 @@ impl Drop for KmodMemSection {
                     self.num_pages,
                     UsageKind::VirtMem,
                 );
-                flush_icache_all();
+                ax_runtime::hal::cache::flush_icache_all();
             }
         }
     }
@@ -243,8 +242,7 @@ impl KernelModuleHelper for KmodHelper {
         // otherwise fetch stale instructions — or fault — from the new code
         // pages, so the instruction cache must be invalidated in addition to
         // the TLB. Mirrors `mm::access::sync_modified_kernel_text`.
-        flush_tlb(None);
-        flush_icache_all();
+        ax_runtime::hal::cache::sync_kernel_text(VirtAddr::from_usize(_addr), _size);
     }
 }
 

--- a/os/StarryOS/kernel/src/kprobe.rs
+++ b/os/StarryOS/kernel/src/kprobe.rs
@@ -113,8 +113,7 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
                 .expect("uprobe: target address not mapped");
             let kvaddr = ax_runtime::hal::mem::phys_to_virt(paddr);
             action(kvaddr.as_mut_ptr());
-            crate::mm::flush_tlb_range(vaddr.align_down_4k(), PAGE_SIZE_4K);
-            ax_runtime::hal::cpu::asm::flush_icache_all();
+            ax_runtime::hal::cache::sync_kernel_text(vaddr.align_down_4k(), PAGE_SIZE_4K);
             return;
         }
         let addr = VirtAddr::from(address);
@@ -175,8 +174,7 @@ impl KprobeAuxiliaryOps for KernelKprobeOps {
             .expect("uprobe: exec page not mapped after populate");
         let kvaddr = ax_runtime::hal::mem::phys_to_virt(paddr);
         action(kvaddr.as_mut_ptr());
-        crate::mm::flush_tlb_range(vaddr, PAGE_SIZE_4K);
-        ax_runtime::hal::cpu::asm::flush_icache_all();
+        ax_runtime::hal::cache::sync_kernel_text(vaddr, PAGE_SIZE_4K);
         vaddr.as_mut_ptr()
     }
 

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -581,8 +581,7 @@ where
                 flush_tlb_range(aligned_addr, aligned_length);
                 action(addr.as_mut_ptr());
 
-                #[cfg(target_arch = "aarch64")]
-                ax_runtime::hal::cpu::asm::clean_dcache_range_to_pou(addr, len);
+                ax_runtime::hal::cache::clean_dcache_to_pou(addr, len);
 
                 guard.protect(aligned_addr, aligned_length, original_flags)?;
                 return Ok(());
@@ -616,53 +615,13 @@ pub fn write_kernel_text(addr: VirtAddr, data: &[u8]) -> AxResult<()> {
 }
 
 pub fn flush_tlb_range(start: VirtAddr, size: usize) {
-    for offset in (0..size).step_by(PAGE_SIZE_4K) {
-        ax_runtime::hal::cpu::asm::flush_tlb(Some(start + offset));
-    }
+    ax_runtime::hal::cache::flush_tlb_range(start, size);
 }
 
 pub fn flush_tlb_range_sync(start: VirtAddr, size: usize) {
-    #[cfg(feature = "ipi")]
-    {
-        flush_tlb_range_remote(start, size);
-    }
-    #[cfg(not(feature = "ipi"))]
-    {
-        flush_tlb_range(start, size);
-    }
-}
-
-#[cfg(feature = "ipi")]
-fn flush_tlb_range_remote(start: VirtAddr, size: usize) {
-    let _guard = ax_kernel_guard::NoPreempt::new();
-    let current_cpu = ax_runtime::hal::percpu::this_cpu_id();
-    let start = start.as_usize();
-    let arg = FlushRangeArg { start, size };
-    let arg_ptr = &arg as *const FlushRangeArg as *mut ();
-
-    for cpu_id in 0..ax_runtime::hal::cpu_num() {
-        if cpu_id == current_cpu || !ax_ipi::wait_until_cpu_ready(cpu_id) {
-            continue;
-        }
-        let _ = unsafe { ax_ipi::run_on_cpu_sync_raw(cpu_id, flush_tlb_range_thunk, arg_ptr) };
-    }
-    flush_tlb_range(VirtAddr::from(start), size);
-}
-
-#[cfg(feature = "ipi")]
-struct FlushRangeArg {
-    start: usize,
-    size: usize,
-}
-
-#[cfg(feature = "ipi")]
-unsafe fn flush_tlb_range_thunk(arg: *mut ()) {
-    let arg = unsafe { &*(arg as *const FlushRangeArg) };
-    flush_tlb_range(VirtAddr::from(arg.start), arg.size);
+    ax_runtime::hal::cache::flush_tlb_range_all_cpus(start, size);
 }
 
 fn sync_modified_kernel_text(start: VirtAddr, size: usize) {
-    flush_tlb_range(start, size);
-
-    ax_runtime::hal::cpu::asm::flush_icache_all();
+    ax_runtime::hal::cache::sync_kernel_text(start, size);
 }

--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -22,14 +22,6 @@ use crate::{
     mm::aspace::{AddrSpace, Backend},
 };
 
-#[cfg(target_arch = "riscv64")]
-const RISCV_COMPAT_HWCAP_IMAFDC: usize = (1 << (b'I' - b'A'))
-    | (1 << (b'M' - b'A'))
-    | (1 << 0)
-    | (1 << (b'F' - b'A'))
-    | (1 << (b'D' - b'A'))
-    | (1 << (b'C' - b'A'));
-
 // RISC-V relocation types
 #[cfg(target_arch = "riscv64")]
 const R_RISCV_RELATIVE: u32 = 3;
@@ -541,48 +533,6 @@ impl ElfCacheEntry {
     }
 }
 
-/// The value reported in the `AT_HWCAP` auxiliary vector entry.
-///
-/// `AT_HWCAP` (auxv type 16) advertises architecture-dependent CPU capability
-/// bits to userspace. `getauxval(AT_HWCAP)` reads it, and feature-dispatching
-/// runtimes gate optional instruction sets on it.
-///
-/// Per-arch policy:
-/// - **loongarch64**: report the baseline the kernel actually provides. The
-///   platform enables LSX (128-bit vectors) and LASX (256-bit vectors) at boot
-///   via `EUEN.SXE`/`EUEN.ASXE`, and the task/signal save paths preserve all 256
-///   vector bits. Therefore we set `CPUCFG | LAM | UAL | FPU | LSX | LASX`.
-///   This matters for feature-dispatching libraries such as OpenSSL and numpy.
-/// - **riscv64**: report the baseline ISA bits expected by Linux-compatible
-///   user space (`IMAFDC`).
-/// - **x86_64 / aarch64**: 0. x86 uses CPUID; aarch64 ASIMD/NEON is mandatory.
-const fn hwcap_value() -> usize {
-    #[cfg(target_arch = "loongarch64")]
-    {
-        // Linux loongarch HWCAP bits (uapi/asm/hwcap.h):
-        const HWCAP_LOONGARCH_CPUCFG: usize = 1 << 0;
-        const HWCAP_LOONGARCH_LAM: usize = 1 << 1;
-        const HWCAP_LOONGARCH_UAL: usize = 1 << 2;
-        const HWCAP_LOONGARCH_FPU: usize = 1 << 3;
-        const HWCAP_LOONGARCH_LSX: usize = 1 << 4;
-        const HWCAP_LOONGARCH_LASX: usize = 1 << 5;
-        HWCAP_LOONGARCH_CPUCFG
-            | HWCAP_LOONGARCH_LAM
-            | HWCAP_LOONGARCH_UAL
-            | HWCAP_LOONGARCH_FPU
-            | HWCAP_LOONGARCH_LSX
-            | HWCAP_LOONGARCH_LASX
-    }
-    #[cfg(target_arch = "riscv64")]
-    {
-        RISCV_COMPAT_HWCAP_IMAFDC
-    }
-    #[cfg(not(any(target_arch = "loongarch64", target_arch = "riscv64")))]
-    {
-        0
-    }
-}
-
 struct ElfLoader(LRUCache<ElfCacheEntry, 32>);
 
 type LoadResult = Result<(VirtAddr, Vec<AuxEntry>), Vec<u8>>;
@@ -666,7 +616,10 @@ impl ElfLoader {
         let mut auxv = elf
             .aux_vector(PAGE_SIZE_4K, ldso.map(|elf| elf.base()))
             .collect::<Vec<_>>();
-        auxv.push(AuxEntry::new(AuxType::HWCAP, hwcap_value()));
+        auxv.push(AuxEntry::new(
+            AuxType::HWCAP,
+            ax_runtime::hal::cpu::cap::elf_hwcap(),
+        ));
         auxv.push(AuxEntry::new(AuxType::UID, 0));
         auxv.push(AuxEntry::new(AuxType::EUID, 0));
         auxv.push(AuxEntry::new(AuxType::GID, 0));

--- a/os/StarryOS/kernel/src/perf/hw.rs
+++ b/os/StarryOS/kernel/src/perf/hw.rs
@@ -4,8 +4,9 @@
 //! Counting events are one or more concurrent `PERF_TYPE_HARDWARE` /
 //! `PERF_TYPE_RAW` events, each backed by either the dedicated 64-bit cycle
 //! counter (`PMCCNTR_EL0`) or one of the programmable 32-bit event counters
-//! (`PMEVCNTRn_EL0`). The per-CPU sysreg layer lives in [`ax_cpu::pmu`]; this
-//! module allocates counters, configures the requested event, drives
+//! (`PMEVCNTRn_EL0`). PMU capability probing is exposed through `ax_hal::pmu`;
+//! the per-CPU sysreg operations remain in `ax_cpu::pmu`. This module allocates
+//! counters, configures the requested event, drives
 //! `ioctl(ENABLE/DISABLE/RESET)`, and serves `read(perf_fd)` with the timing
 //! fields `perf stat` expects.
 //!
@@ -95,7 +96,7 @@ enum Counter {
 /// indices `0..num_counters`; `cycle_used` guards the dedicated cycle counter.
 #[cfg(target_arch = "aarch64")]
 struct HwAlloc {
-    /// Number of programmable counters (`PMCR_EL0.N`), from [`ax_cpu::pmu::probe`].
+    /// Number of programmable counters (`PMCR_EL0.N`), from `ax_hal::pmu::info`.
     num_counters: usize,
     /// Bitmask of allocated programmable counters (bit `n` ⇒ index `n` in use).
     used: u32,
@@ -852,7 +853,7 @@ fn resolve_sampling(raw: u64, is_freq: bool) -> (u32, u32) {
 #[cfg(target_arch = "aarch64")]
 pub fn perf_event_open_hw(attr: &perf_event_attr, pid: i32) -> AxResult<HwPerfEvent> {
     // No PMUv3 → no hardware events.
-    let Some(info) = ax_cpu::pmu::probe() else {
+    let Some(info) = ax_hal::pmu::info() else {
         return Err(AxError::Unsupported);
     };
 

--- a/os/StarryOS/kernel/src/perf/mod.rs
+++ b/os/StarryOS/kernel/src/perf/mod.rs
@@ -11,7 +11,7 @@ pub mod hw;
 pub mod kprobe;
 pub mod raw_tracepoint;
 /// PMU overflow-IRQ sampling backend (M2). ARM PMUv3 only; the counting and
-/// tracing paths are arch-agnostic, but sampling depends on `ax_cpu::pmu`.
+/// tracing paths are arch-agnostic, but sampling depends on CPU PMU registers.
 #[cfg(target_arch = "aarch64")]
 pub mod sampling;
 /// Side-band records (`PERF_RECORD_COMM`/`MMAP2`/`FORK`/`EXIT`) for `perf report`
@@ -20,7 +20,8 @@ pub mod sampling;
 #[cfg(target_arch = "aarch64")]
 pub mod sideband;
 /// Per-task hardware-PMU counting (`perf stat -- cmd`, M3). ARM PMUv3 only; the
-/// scheduler hooks call into `ax_cpu::pmu`, so it is gated like `sampling`.
+/// scheduler hooks call into CPU PMU register helpers, so it is gated like
+/// `sampling`.
 #[cfg(target_arch = "aarch64")]
 pub mod task;
 pub mod tracepoint;
@@ -39,7 +40,7 @@ use ax_io::{Read, Write};
 use ax_kspin::{SpinNoPreempt, SpinNoPreemptGuard};
 use ax_lazyinit::LazyInit;
 use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, PhysAddrRange, VirtAddr, VirtAddrRange};
-use ax_runtime::hal::paging::MappingFlags;
+use ax_runtime::hal::{paging::MappingFlags, pmu};
 use axpoll::Pollable;
 pub use bpf::BpfPerfEventWrapper;
 use hashbrown::HashMap;
@@ -71,14 +72,7 @@ static NEXT_PERF_EVENT_ID: AtomicU64 = AtomicU64::new(1);
 /// `#[cfg(target_arch = "aarch64")]` gate so the pseudo-fs call sites stay arch
 /// agnostic (and compile under multi-target clippy).
 pub fn read_midr_el1() -> u64 {
-    #[cfg(target_arch = "aarch64")]
-    {
-        ax_cpu::pmu::read_midr_el1()
-    }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        0
-    }
+    pmu::cpu_id_raw().unwrap_or(0)
 }
 
 /// `ioctl` type byte for the perf-event ioctls (`'$'`).

--- a/os/StarryOS/kernel/src/perf/sampling.rs
+++ b/os/StarryOS/kernel/src/perf/sampling.rs
@@ -43,22 +43,13 @@
 
 use core::{ptr::NonNull, sync::atomic::Ordering};
 
-use ax_hal::irq::{HwIrq, IrqContext, IrqId, IrqReturn};
+use ax_hal::irq::{IrqContext, IrqId, IrqReturn};
 use ax_kernel_guard::NoPreemptIrqSave;
 use ax_task::IrqNotify;
 use kbpf_basic::linux_bpf::perf_event_mmap_page;
 
-/// Architecturally fixed PMUv3 overflow interrupt INTID.
-///
-/// On ARMv8 the PMU overflow interrupt is wired as PPI 7, i.e. GIC INTID 23
-/// (`16 + 7`). This is hardcoded for M2: the proper path is to read the
-/// `interrupts` property of the FDT `arm,armv8-pmuv3` node, which is a deferred
-/// follow-up. On the RK3588 (and the QEMU `virt` machine) the PMU PPI is INTID
-/// 23, matching this constant.
-const PMU_IRQ: HwIrq = HwIrq(23);
-
 fn pmu_irq() -> Result<IrqId, ax_hal::irq::IrqError> {
-    ax_hal::irq::resolve_percpu_irq(PMU_IRQ)
+    ax_hal::pmu::irq()
 }
 
 /// Maximum programmable counter index (matches [`ax_cpu::pmu::counter`] /
@@ -254,7 +245,7 @@ pub fn unregister(n: usize) {
 /// Ensures [`pmu_overflow_handler`] is registered with the IRQ framework and the
 /// PMU overflow line is enabled on the current core.
 ///
-/// Idempotent: the first caller installs the per-CPU action for [`PMU_IRQ`]
+/// Idempotent: the first caller installs the per-CPU action for the PMU IRQ
 /// across all online CPUs. Every caller (re-)enables INTID 23 on the *current*
 /// core. The explicit `set_enable` is required: the framework's per-core line
 /// enable runs at `cpu_online`/boot, before this handler is ever registered, so

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -17,6 +17,8 @@ use core::{
 
 use ax_lazyinit::LazyInit;
 use ax_memory_addr::{MemoryAddr, VirtAddr};
+#[cfg(target_arch = "aarch64")]
+use ax_runtime::hal::pmu;
 use ax_runtime::hal::{
     paging::MappingFlags,
     time::{monotonic_time, wall_time},
@@ -175,7 +177,7 @@ fn render_cpu_entry(buf: &mut String, idx: usize) {
     // tools key off implementer/part to identify the microarchitecture). On
     // RK3588 this yields A76 (0x41/0xd0b) and A55 (0x41/0xd05); under QEMU
     // cortex-a53 it reads 0x41/0xd03.
-    let midr = ax_cpu::pmu::read_midr_el1();
+    let midr = pmu::cpu_id_raw().unwrap_or(0);
     let implementer = (midr >> 24) & 0xff;
     let variant = (midr >> 20) & 0xf;
     let part = (midr >> 4) & 0xfff;
@@ -924,7 +926,7 @@ impl DirectRwFsFileOps for ProcMemFile {
         let aspace = self.proc_data.aspace();
         let aspace = aspace.lock();
         aspace.write(VirtAddr::from_usize(addr), buf)?;
-        ax_runtime::hal::cpu::asm::flush_icache_all();
+        ax_runtime::hal::cache::flush_icache_all();
         Ok(buf.len())
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/sysfs.rs
+++ b/os/StarryOS/kernel/src/pseudofs/sysfs.rs
@@ -423,7 +423,7 @@ impl SimpleDirOps for EventSourceDevicesDir {
         // The ARM PMUv3 CPU PMU is a hardware (counting/sampling) event source,
         // distinct from the tracing sources above. It is always listed on
         // aarch64 — the device is a static description of the architectural PMU,
-        // so it is advertised regardless of `ax_cpu::pmu::probe()` (which a
+        // so it is advertised regardless of `ax_hal::pmu::info()` (which a
         // `perf_event_open` against the type still consults and may reject).
         #[cfg(target_arch = "aarch64")]
         let pmu = core::iter::once(Cow::Borrowed(ARMV8_PMUV3_DEVICE));

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -780,7 +780,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::getrandom => sys_getrandom(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         Sysno::seccomp => sys_seccomp(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         #[cfg(target_arch = "riscv64")]
-        Sysno::riscv_flush_icache => sys_riscv_flush_icache(),
+        Sysno::riscv_flush_icache => sys_riscv_flush_icache(uctx.arg0(), uctx.arg1(), uctx.arg2()),
         #[cfg(target_arch = "riscv64")]
         Sysno::riscv_hwprobe => sys_riscv_hwprobe(
             uctx.arg0() as _,

--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -950,8 +950,22 @@ pub fn sys_seccomp(op: u32, flags: u32, args: *const ()) -> AxResult<isize> {
 }
 
 #[cfg(target_arch = "riscv64")]
-pub fn sys_riscv_flush_icache() -> AxResult<isize> {
-    riscv::asm::fence_i();
+const SYS_RISCV_FLUSH_ICACHE_LOCAL: usize = 1;
+
+#[cfg(target_arch = "riscv64")]
+pub fn sys_riscv_flush_icache(start: usize, end: usize, flags: usize) -> AxResult<isize> {
+    if flags & !SYS_RISCV_FLUSH_ICACHE_LOCAL != 0 {
+        return Err(AxError::InvalidInput);
+    }
+    if end < start {
+        return Err(AxError::InvalidInput);
+    }
+
+    if flags & SYS_RISCV_FLUSH_ICACHE_LOCAL != 0 {
+        ax_runtime::hal::cache::flush_icache_all();
+    } else {
+        ax_runtime::hal::cache::flush_icache_all_cpus();
+    }
     Ok(0)
 }
 
@@ -962,23 +976,6 @@ struct RiscvHwprobe {
     key: i64,
     value: u64,
 }
-
-#[cfg(target_arch = "riscv64")]
-const RISCV_HWPROBE_KEY_BASE_BEHAVIOR: i64 = 3;
-#[cfg(target_arch = "riscv64")]
-const RISCV_HWPROBE_BASE_BEHAVIOR_IMA: u64 = 1 << 0;
-#[cfg(target_arch = "riscv64")]
-const RISCV_HWPROBE_KEY_IMA_EXT_0: i64 = 4;
-#[cfg(target_arch = "riscv64")]
-const RISCV_HWPROBE_IMA_FD: u64 = 1 << 0;
-#[cfg(target_arch = "riscv64")]
-const RISCV_HWPROBE_IMA_C: u64 = 1 << 1;
-#[cfg(target_arch = "riscv64")]
-const RISCV_HWPROBE_KEY_CPUPERF_0: i64 = 5;
-#[cfg(target_arch = "riscv64")]
-const RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF: i64 = 9;
-#[cfg(target_arch = "riscv64")]
-const RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF: i64 = 10;
 
 #[cfg(target_arch = "riscv64")]
 pub fn sys_riscv_hwprobe(
@@ -1000,20 +997,11 @@ pub fn sys_riscv_hwprobe(
 
     let pairs = UserPtr::<RiscvHwprobe>::from(pairs.cast()).get_as_mut_slice(pair_count)?;
     for pair in pairs {
-        match pair.key {
-            RISCV_HWPROBE_KEY_BASE_BEHAVIOR => pair.value = RISCV_HWPROBE_BASE_BEHAVIOR_IMA,
-            RISCV_HWPROBE_KEY_IMA_EXT_0 => {
-                pair.value = RISCV_HWPROBE_IMA_FD | RISCV_HWPROBE_IMA_C;
-            }
-            RISCV_HWPROBE_KEY_CPUPERF_0
-            | RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF
-            | RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF => {
-                pair.value = 0;
-            }
-            _ => {
-                pair.key = -1;
-                pair.value = 0;
-            }
+        if let Some(value) = ax_runtime::hal::cpu::cap::riscv_hwprobe(pair.key) {
+            pair.value = value;
+        } else {
+            pair.key = -1;
+            pair.value = 0;
         }
     }
 

--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -948,7 +948,7 @@ fn ptrace_write_word(tracee: &ProcessData, addr: usize, data: usize) -> AxResult
     let mut aspace = aspace.lock();
     ptrace_populate_remote_range(&mut aspace, addr, size_of::<usize>(), MappingFlags::WRITE)?;
     aspace.write(VirtAddr::from_usize(addr), &data.to_ne_bytes())?;
-    ax_runtime::hal::cpu::asm::flush_icache_all();
+    ax_runtime::hal::cache::flush_icache_all();
     Ok(())
 }
 
@@ -1121,7 +1121,7 @@ fn remote_write(tracee: &ProcessData, addr: usize, data: &[u8]) -> AxResult {
     let mut aspace = aspace.lock();
     ptrace_populate_remote_range(&mut aspace, addr, data.len(), MappingFlags::WRITE)?;
     aspace.write(VirtAddr::from_usize(addr), data)?;
-    ax_runtime::hal::cpu::asm::flush_icache_all();
+    ax_runtime::hal::cache::flush_icache_all();
     Ok(())
 }
 
@@ -1217,7 +1217,7 @@ pub fn ptrace_setup_singlestep(
     };
     if orig_insn == EBREAK_INSN {
         tracee.set_ptrace_ss_saved_insn_for(tid, None);
-        ax_runtime::hal::cpu::asm::flush_icache_all();
+        ax_runtime::hal::cache::flush_icache_all();
         return;
     }
 
@@ -1226,7 +1226,7 @@ pub fn ptrace_setup_singlestep(
         return;
     }
     tracee.set_ptrace_ss_saved_insn_for(tid, Some((next_insn_addr, orig_insn as usize)));
-    ax_runtime::hal::cpu::asm::flush_icache_all();
+    ax_runtime::hal::cache::flush_icache_all();
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -1261,7 +1261,7 @@ pub fn ptrace_setup_singlestep(
     };
     if orig_insn == AARCH64_BRK_INSN {
         tracee.set_ptrace_ss_saved_insn_for(tid, None);
-        ax_runtime::hal::cpu::asm::flush_icache_all();
+        ax_runtime::hal::cache::flush_icache_all();
         return;
     }
 
@@ -1270,7 +1270,7 @@ pub fn ptrace_setup_singlestep(
         return;
     }
     tracee.set_ptrace_ss_saved_insn_for(tid, Some((next_insn_addr, orig_insn as usize)));
-    ax_runtime::hal::cpu::asm::flush_icache_all();
+    ax_runtime::hal::cache::flush_icache_all();
 }
 
 #[cfg(target_arch = "loongarch64")]
@@ -1305,7 +1305,7 @@ pub fn ptrace_setup_singlestep(
     };
     if orig_insn == LOONGARCH_BREAK_INSN {
         tracee.set_ptrace_ss_saved_insn_for(tid, None);
-        ax_runtime::hal::cpu::asm::flush_icache_all();
+        ax_runtime::hal::cache::flush_icache_all();
         return;
     }
 
@@ -1314,7 +1314,7 @@ pub fn ptrace_setup_singlestep(
         return;
     }
     tracee.set_ptrace_ss_saved_insn_for(tid, Some((next_insn_addr, orig_insn as usize)));
-    ax_runtime::hal::cpu::asm::flush_icache_all();
+    ax_runtime::hal::cache::flush_icache_all();
 }
 
 #[cfg(target_arch = "riscv64")]
@@ -1327,7 +1327,7 @@ pub fn ptrace_restore_singlestep_insn(
     let aspace = tracee.aspace();
     let mut aspace = aspace.lock();
     let restored = ptrace_write_u16_unlocked(&mut aspace, addr, insn as u16).is_ok();
-    ax_runtime::hal::cpu::asm::flush_icache_all();
+    ax_runtime::hal::cache::flush_icache_all();
     if !restored {
         tracee.set_ptrace_ss_saved_insn_for(tid, Some((addr, insn)));
     }
@@ -1344,7 +1344,7 @@ pub fn ptrace_restore_singlestep_insn(
     let aspace = tracee.aspace();
     let mut aspace = aspace.lock();
     let restored = ptrace_write_u32_unlocked(&mut aspace, addr, insn as u32).is_ok();
-    ax_runtime::hal::cpu::asm::flush_icache_all();
+    ax_runtime::hal::cache::flush_icache_all();
     if !restored {
         tracee.set_ptrace_ss_saved_insn_for(tid, Some((addr, insn)));
     }

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -62,15 +62,6 @@ struct PtracePendingEvent {
 }
 use crate::mm::AddrSpace;
 
-/// Size of the syscall instruction for the current architecture.
-/// Used by SA_RESTART to back up the program counter.
-#[cfg(target_arch = "x86_64")]
-pub const SYSCALL_INSN_LEN: usize = 2;
-/// Size of the syscall instruction for the current architecture.
-/// Used by SA_RESTART to back up the program counter.
-#[cfg(not(target_arch = "x86_64"))]
-pub const SYSCALL_INSN_LEN: usize = 4;
-
 ///  A wrapper type that assumes the inner type is `Sync`.
 #[repr(transparent)]
 pub struct AssumeSync<T>(pub T);

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -15,8 +15,8 @@ use starry_signal::{SignalInfo, SignalOSAction, SignalSet, Signo};
 use starry_vm::vm_read_slice;
 
 use super::{
-    AsThread, ProcessData, SYSCALL_INSN_LEN, Thread, do_exit, get_process_data, get_process_group,
-    get_task, is_zombie_pid,
+    AsThread, ProcessData, Thread, do_exit, get_process_data, get_process_group, get_task,
+    is_zombie_pid,
 };
 
 /// Information needed to restart a syscall if SA_RESTART applies.
@@ -324,7 +324,7 @@ pub fn check_signals(
                     && (uctx.retval() as isize) == -(ax_errno::LinuxError::EINTR.code() as isize)
                     && restartable
                 {
-                    let new_ip = uctx.ip() - SYSCALL_INSN_LEN;
+                    let new_ip = uctx.ip() - uctx.syscall_insn_len();
                     uctx.set_ip(new_ip);
                     uctx.set_arg0(info.saved_a0);
                     // On x86_64, rax holds both the syscall number and the return

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -1,4 +1,4 @@
-use ax_runtime::hal::cpu::uspace::{ExceptionInfo, ExceptionKind, ReturnReason, UserContext};
+use ax_runtime::hal::cpu::uspace::{ExceptionKind, ReturnReason, UserContext};
 use ax_task::TaskInner;
 use starry_process::Pid;
 use starry_signal::{FPE_INTDIV, SEGV_ACCERR, SEGV_MAPERR, SignalInfo, Signo};
@@ -220,7 +220,7 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                             // when delivering a TF-induced #DB, but QEMU may
                             // not always honour this.  Clearing explicitly
                             // prevents an unwanted extra single-step on resume.
-                            uctx.rflags &= !(1u64 << 8);
+                            let _ = uctx.clear_single_step_after_debug();
                             thr.proc_data.set_ptrace_singlestep_for(thr.tid(), false);
                             if let Some(_resume_sig) =
                                 ptrace_stop_current(thr, Signo::SIGTRAP, &mut uctx)
@@ -228,15 +228,16 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                                 break 'exc;
                             }
                         }
+                        let syndrome = exc_info.syndrome();
                         warn!(
                             "user exception: ip={:#x}, fault_addr={:#x}, kind={:?}, esr={:#x}, \
                              ec={:#x}, iss={:#x}, info={:?}",
                             uctx.ip(),
-                            exception_fault_addr(&exc_info),
+                            exc_info.fault_addr().unwrap_or(0),
                             kind,
-                            exception_esr_value(&exc_info),
-                            exception_ec_value(&exc_info),
-                            exception_iss_value(&exc_info),
+                            syndrome.raw,
+                            syndrome.class,
+                            syndrome.iss,
                             exc_info
                         );
                         let sig_info = match kind {
@@ -324,84 +325,4 @@ fn ptrace_exit_event_code(sysno: usize, arg0: usize) -> Option<i32> {
         Some(Sysno::exit | Sysno::exit_group) => Some((arg0 as i32) << 8),
         _ => None,
     }
-}
-
-#[cfg(target_arch = "aarch64")]
-fn exception_fault_addr(exc_info: &ExceptionInfo) -> usize {
-    exc_info.far
-}
-
-#[cfg(target_arch = "aarch64")]
-fn exception_esr_value(exc_info: &ExceptionInfo) -> u64 {
-    exc_info.esr_value()
-}
-
-#[cfg(target_arch = "aarch64")]
-fn exception_ec_value(exc_info: &ExceptionInfo) -> u64 {
-    exc_info.ec_value()
-}
-
-#[cfg(target_arch = "aarch64")]
-fn exception_iss_value(exc_info: &ExceptionInfo) -> u64 {
-    exc_info.iss_value()
-}
-
-#[cfg(target_arch = "riscv64")]
-fn exception_fault_addr(exc_info: &ExceptionInfo) -> usize {
-    exc_info.stval
-}
-
-#[cfg(target_arch = "riscv64")]
-fn exception_esr_value(_exc_info: &ExceptionInfo) -> u64 {
-    0
-}
-
-#[cfg(target_arch = "riscv64")]
-fn exception_ec_value(_exc_info: &ExceptionInfo) -> u64 {
-    0
-}
-
-#[cfg(target_arch = "riscv64")]
-fn exception_iss_value(_exc_info: &ExceptionInfo) -> u64 {
-    0
-}
-
-#[cfg(target_arch = "loongarch64")]
-fn exception_fault_addr(exc_info: &ExceptionInfo) -> usize {
-    exc_info.badv
-}
-
-#[cfg(target_arch = "loongarch64")]
-fn exception_esr_value(_exc_info: &ExceptionInfo) -> u64 {
-    0
-}
-
-#[cfg(target_arch = "loongarch64")]
-fn exception_ec_value(_exc_info: &ExceptionInfo) -> u64 {
-    _exc_info.ecode as u64
-}
-
-#[cfg(target_arch = "loongarch64")]
-fn exception_iss_value(_exc_info: &ExceptionInfo) -> u64 {
-    _exc_info.esubcode as u64
-}
-
-#[cfg(target_arch = "x86_64")]
-fn exception_fault_addr(exc_info: &ExceptionInfo) -> usize {
-    exc_info.cr2
-}
-
-#[cfg(target_arch = "x86_64")]
-fn exception_esr_value(_exc_info: &ExceptionInfo) -> u64 {
-    0
-}
-
-#[cfg(target_arch = "x86_64")]
-fn exception_ec_value(_exc_info: &ExceptionInfo) -> u64 {
-    0
-}
-
-#[cfg(target_arch = "x86_64")]
-fn exception_iss_value(_exc_info: &ExceptionInfo) -> u64 {
-    0
 }

--- a/os/arceos/modules/axhal/src/cache.rs
+++ b/os/arceos/modules/axhal/src/cache.rs
@@ -1,0 +1,109 @@
+//! Cache, TLB, and modified-text synchronization helpers.
+
+use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr};
+
+/// Flushes the TLB entries covering a virtual-address range on the current CPU.
+pub fn flush_tlb_range(start: VirtAddr, size: usize) {
+    for offset in (0..size).step_by(PAGE_SIZE_4K) {
+        ax_cpu::asm::flush_tlb(Some(start + offset));
+    }
+}
+
+/// Flushes the TLB entries covering a virtual-address range on all available CPUs.
+pub fn flush_tlb_range_all_cpus(start: VirtAddr, size: usize) {
+    #[cfg(feature = "ipi")]
+    {
+        let _guard = ax_kernel_guard::NoPreempt::new();
+        let current_cpu = crate::percpu::this_cpu_id();
+        let arg = FlushRangeArg {
+            start: start.as_usize(),
+            size,
+        };
+        let arg_ptr = &arg as *const FlushRangeArg as *mut ();
+
+        for cpu_id in 0..crate::cpu_num() {
+            if cpu_id == current_cpu {
+                continue;
+            }
+            let _ = unsafe {
+                crate::irq::run_on_cpu_sync(
+                    crate::irq::CpuId(cpu_id),
+                    flush_tlb_range_thunk,
+                    arg_ptr,
+                )
+            };
+        }
+        flush_tlb_range(start, size);
+    }
+    #[cfg(not(feature = "ipi"))]
+    {
+        flush_tlb_range(start, size);
+    }
+}
+
+#[cfg(feature = "ipi")]
+struct FlushRangeArg {
+    start: usize,
+    size: usize,
+}
+
+#[cfg(feature = "ipi")]
+unsafe fn flush_tlb_range_thunk(arg: *mut ()) {
+    let arg = unsafe { &*(arg as *const FlushRangeArg) };
+    flush_tlb_range(VirtAddr::from(arg.start), arg.size);
+}
+
+/// Flushes the entire instruction cache on the current CPU.
+pub fn flush_icache_all() {
+    ax_cpu::asm::flush_icache_all();
+}
+
+/// Flushes the entire instruction cache on all available CPUs.
+pub fn flush_icache_all_cpus() {
+    #[cfg(feature = "ipi")]
+    {
+        let _guard = ax_kernel_guard::NoPreempt::new();
+        let current_cpu = crate::percpu::this_cpu_id();
+
+        for cpu_id in 0..crate::cpu_num() {
+            if cpu_id == current_cpu {
+                continue;
+            }
+            let _ = unsafe {
+                crate::irq::run_on_cpu_sync(
+                    crate::irq::CpuId(cpu_id),
+                    flush_icache_all_thunk,
+                    core::ptr::null_mut(),
+                )
+            };
+        }
+        flush_icache_all();
+    }
+    #[cfg(not(feature = "ipi"))]
+    {
+        flush_icache_all();
+    }
+}
+
+#[cfg(feature = "ipi")]
+unsafe fn flush_icache_all_thunk(_arg: *mut ()) {
+    flush_icache_all();
+}
+
+/// Cleans a data-cache range to the point of unification when needed.
+pub fn clean_dcache_to_pou(vaddr: VirtAddr, size: usize) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        ax_cpu::asm::clean_dcache_range_to_pou(vaddr, size);
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let _ = (vaddr, size);
+    }
+}
+
+/// Synchronizes modified kernel text with the local execution pipeline.
+pub fn sync_kernel_text(start: VirtAddr, size: usize) {
+    flush_tlb_range(start, size);
+    flush_icache_all();
+}

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -43,9 +43,11 @@ mod build_info {
 }
 
 pub mod boot;
+pub mod cache;
 pub mod dtb;
 pub mod mem;
 pub mod percpu;
+pub mod pmu;
 pub mod time;
 
 #[cfg(feature = "tls")]

--- a/os/arceos/modules/axhal/src/pmu.rs
+++ b/os/arceos/modules/axhal/src/pmu.rs
@@ -1,0 +1,50 @@
+//! Performance-monitoring capability helpers.
+
+#[cfg(target_arch = "aarch64")]
+pub use ax_cpu::pmu::PmuInfo;
+
+#[cfg(not(target_arch = "aarch64"))]
+/// Information probed from a CPU PMU.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PmuInfo {
+    /// Number of programmable event counters.
+    pub num_counters: usize,
+}
+
+/// Returns PMU information when the current architecture/runtime supports it.
+pub fn info() -> Option<PmuInfo> {
+    #[cfg(target_arch = "aarch64")]
+    {
+        ax_cpu::pmu::probe()
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        None
+    }
+}
+
+/// Returns the raw CPU identification register used by PMU tooling.
+pub fn cpu_id_raw() -> Option<u64> {
+    #[cfg(target_arch = "aarch64")]
+    {
+        Some(ax_cpu::pmu::read_midr_el1())
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        None
+    }
+}
+
+/// Returns the platform IRQ id used for PMU overflows.
+#[cfg(feature = "irq")]
+pub fn irq() -> Result<crate::irq::IrqId, crate::irq::IrqError> {
+    #[cfg(target_arch = "aarch64")]
+    {
+        const PMU_IRQ: crate::irq::HwIrq = crate::irq::HwIrq(23);
+        crate::irq::resolve_percpu_irq(PMU_IRQ)
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        Err(crate::irq::IrqError::Unsupported)
+    }
+}


### PR DESCRIPTION
## 问题

Starry 里有一批架构条件编译逻辑属于 Linux 用户态 ABI，应该继续留在 Starry；但另一些逻辑其实是可复用的 CPU/runtime 机制，例如异常信息读取、用户上下文辅助、cache/TLB/text 同步、HWCAP/hwprobe 和 PMU 查询。它们混在 Starry 内部会让后续架构维护和 ArceOS/Axvisor 复用都更难。

## 改动

- 在 `ax-cpu` 增加通用能力接口：
  - `ax_cpu::cap::elf_hwcap()`
  - RISC-V `ax_cpu::cap::riscv_hwprobe()`
  - `ExceptionInfo::{fault_addr, syndrome}`
  - `UserContext::{clear_single_step_after_debug, syscall_insn_len}`
- 在 `ax-hal` 增加 runtime 维护接口：
  - `ax_hal::cache::{flush_tlb_range, flush_tlb_range_all_cpus, sync_kernel_text, clean_dcache_to_pou}`
  - `ax_hal::pmu::{info, cpu_id_raw, irq}`
- 调整 Starry 调用点，让异常处理、signal syscall PC 回退、kmod/kprobe/ptrace text sync、loader HWCAP、perf PMU 查询改走 `ax-cpu -> ax-hal` 路径。
- 保留 Starry 内部的 Linux ABI 边界：syscall 表差异、ptrace Linux regset/wire format、proc 文本格式等没有下沉。
- 对照本地 Linux v6.16 的 RISC-V `flush_icache` 语义，`sys_riscv_flush_icache(start, end, flags)` 现在会读取并校验参数，合法时调用新的 cache API。

## 方案逻辑

这次改动只做 additive API，不删除现有导出，避免影响其他 OS/平台。Starry 仍负责 Linux 用户态 ABI，`ax-cpu` 负责架构 CPU 语义，`ax-hal` 负责 OS 可调用的 runtime 维护入口。RISC-V/LoongArch 的 HWCAP/hwprobe 仍保持现有保守兼容值，只是集中到 CPU capability helper，方便后续接真实平台探测。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package ax-cpu`
- `cargo xtask clippy --package ax-hal`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --arch x86_64 --test-case qemu-smp1/system`
- `cargo xtask starry test qemu --arch riscv64 --test-case qemu-smp1/system`
- `cargo xtask starry test qemu --arch aarch64 --test-case qemu-smp1/system`
- `cargo xtask starry test qemu --arch loongarch64 --test-case qemu-smp1/system`
- `git diff --check HEAD~1 HEAD`

说明：当前 `xtask starry test qemu` CLI 已没有 `--test-group`，也没有名为 `smoke` 的 case，所以这里使用当前可用的四架构 `qemu-smp1/system` 作为替代覆盖；四个架构均为 `1/1 case(s) passed`。