### PR TITLE
fix(ax-fs-ng): keep early IRQ block events

### DIFF
--- a/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
@@ -343,7 +343,7 @@ impl BlockIrqAction {
 
     pub fn run(&self) -> BlockIrqOutcome {
         let event = self.handler.handle_irq();
-        if self.device.record_driver_event_for_pending(event) {
+        if self.device.record_driver_event(event) {
             self.device.drain_wake.wake_drain_from_irq();
             BlockIrqOutcome::Handled
         } else {
@@ -503,10 +503,6 @@ impl BlockDeviceHandle {
 
     pub fn record_driver_event(&self, event: rdif_block::Event) -> bool {
         self.record_translated_event(event, false)
-    }
-
-    pub fn record_driver_event_for_pending(&self, event: rdif_block::Event) -> bool {
-        self.record_translated_event(event, true)
     }
 
     #[cfg(test)]

--- a/os/arceos/modules/axfs-ng/src/block_runtime/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/mod.rs
@@ -1589,6 +1589,32 @@ mod tests {
     }
 
     #[test]
+    fn irq_event_before_pending_insert_is_not_dropped() {
+        let _guard = test_task_guard();
+        let bridge = Arc::new(BlockIrqBridge::new());
+        let device = BlockDeviceHandle::new(
+            "mock",
+            [Box::new(MockQueue::with_id(0)) as Box<dyn IQueue>],
+            bridge,
+            irq_driven_config(),
+        )
+        .unwrap();
+
+        let action = BlockIrqAction::new(Box::new(QueueEventIrqHandler), device.clone(), 0);
+        assert_eq!(action.run(), crate::os::BlockIrqOutcome::Handled);
+        let events = device.bridge().take_events();
+        assert_eq!(events.queue_bits, 1);
+    }
+
+    struct QueueEventIrqHandler;
+
+    impl rdif_block::IrqHandler for QueueEventIrqHandler {
+        fn handle_irq(&self) -> rdif_block::Event {
+            rdif_block::Event::from_queue_bits(1)
+        }
+    }
+
+    #[test]
     fn irq_bridge_hint_overflow_falls_back_to_queue_ready_bit() {
         let bridge = BlockIrqBridge::new();
         for id in 0..rdif_block::MAX_COMPLETION_HINTS {


### PR DESCRIPTION
## 问题

最新 dev CI 的 `Test starry loongarch64 qemu / run_container` 在 `bug-dir-cookie-unlink-rmdir` 打出 `STARRY_SYSTEM_TEST_BEGIN` 后长时间无后续输出，最终被手动取消。日志显示该 LoongArch Starry 配置中 NVMe 文件系统块设备使用 `IRQ-driven completion`。

根因是 `ax-fs-ng` 的块设备 IRQ 路径存在一个丢事件窗口：submit 路径先调用 driver 提交请求，成功返回后才把请求写入 pending 表；如果设备 IRQ 在这两步之间到达，原先的 `BlockIrqAction` 会按当前 pending 表过滤 driver event，看到还没有 pending request 就把 IRQ event 丢掉。IRQ-driven 模式没有 polling 兜底，因此 drain 可能永远不被唤醒，表现为文件系统 I/O 卡死。

## 修改

- 在 IRQ handler 路径中保留 driver 上报的 block event，并唤醒 drain，不再在 IRQ 上下文按 pending 表提前丢弃事件。
- 移除只在 IRQ 路径使用的 `record_driver_event_for_pending`。
- 增加回归测试，覆盖“IRQ event 早于 pending insert 到达时不能被丢弃”的情况。

这样 pending 过滤仍留在 drain/poll 阶段，只避免 IRQ 到达时机过早造成 lost wake。

## 验证

- `cargo fmt --check`
- `cargo test -p ax-fs-ng irq_event_before_pending_insert_is_not_dropped --lib`
- `cargo xtask clippy --package ax-fs-ng`
- CI 同容器/QEMU 10.2.1 下运行：
  - `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system`
  - 结果：`result: 1/1 case(s) passed`，原卡住用例 `bug-dir-cookie-unlink-rmdir` 通过。