### PR TITLE
fix(ci): prevent Starry qemu hangs in IRQ paths

### DIFF
--- a/.claude/skills/cross-kernel-driver/SKILL.md
+++ b/.claude/skills/cross-kernel-driver/SKILL.md
@@ -53,7 +53,7 @@ For nontrivial driver design or refactoring, read `references/architecture.md` b
 
 Use `&mut self` APIs where exclusive access is the natural contract. Do not require callers to provide an OS lock as part of the portable abstraction. If only the IRQ callback should call a handler, make that visible in the type shape: move the handler into the callback and expose `handle(&mut self, ...)` instead of making the handler a clonable shared object.
 
-For block-device integration in ArceOS, expose portable block drivers through `rdif_block::Interface` and `rdif_block::IQueue`. Keep queue creation, DMA/wait policy, and IRQ registration in OS glue/runtime layers; the portable boundary should be submit/poll requests plus `handle_irq() -> Event`.
+For block-device integration in ArceOS, expose portable block drivers through `rdif_block::Interface` and `rdif_block::IQueue`. Keep queue creation, DMA/wait policy, and IRQ registration in OS glue/runtime layers; the portable boundary should be submit/poll requests plus an owned IRQ endpoint with `handle_irq(&mut self) -> Event`.
 
 Prefer small interfaces:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,7 @@ dependencies = [
  "ax-hal",
  "ax-input",
  "ax-ipi",
+ "ax-kspin",
  "ax-lazyinit",
  "ax-log",
  "ax-memory-addr",

--- a/drivers/ax-driver/src/block/binding.rs
+++ b/drivers/ax-driver/src/block/binding.rs
@@ -118,7 +118,7 @@ impl BlockIrqHandler {
         }
     }
 
-    pub fn handle(&self) -> rdif_block::Event {
+    pub fn handle(&mut self) -> rdif_block::Event {
         let event = self.handler.handle_irq();
         if let Some(events) = &self.events {
             events.record(event);

--- a/drivers/blk/nvme-driver/src/block.rs
+++ b/drivers/blk/nvme-driver/src/block.rs
@@ -257,7 +257,7 @@ struct NvmeBlockIrqHandler {
 }
 
 impl IrqHandler for NvmeBlockIrqHandler {
-    fn handle_irq(&self) -> Event {
+    fn handle_irq(&mut self) -> Event {
         if !self.owner.irq_enabled.load(Ordering::Acquire) {
             return Event::none();
         }

--- a/drivers/blk/ramdisk/src/lib.rs
+++ b/drivers/blk/ramdisk/src/lib.rs
@@ -182,7 +182,7 @@ struct RamIrqHandler {
 }
 
 impl IrqHandler for RamIrqHandler {
-    fn handle_irq(&self) -> Event {
+    fn handle_irq(&mut self) -> Event {
         if !self.irq.enabled.load(Ordering::Acquire) {
             return Event::none();
         }

--- a/drivers/blk/sdmmc-protocol/src/rdif.rs
+++ b/drivers/blk/sdmmc-protocol/src/rdif.rs
@@ -1161,7 +1161,7 @@ impl<H> rdif_block::IrqHandler for BlockIrqHandler<H>
 where
     H: BlockHost,
 {
-    fn handle_irq(&self) -> rdif_block::Event {
+    fn handle_irq(&mut self) -> rdif_block::Event {
         let host_event = self.handle.handle_irq();
         let mut event = rdif_block::Event::none();
         if let Some(queue_id) = block_queue_ready_from_host_event(&host_event) {

--- a/drivers/interface/rdif-block/src/interface.rs
+++ b/drivers/interface/rdif-block/src/interface.rs
@@ -145,9 +145,9 @@ pub struct IrqHandlerHandle {
 }
 
 impl IrqHandler for IrqHandlerHandle {
-    fn handle_irq(&self) -> crate::Event {
+    fn handle_irq(&mut self) -> crate::Event {
         self.handler
-            .as_ref()
+            .as_mut()
             .expect("IRQ handler handle must contain handler")
             .handle_irq()
     }
@@ -215,10 +215,13 @@ mod tests {
     use super::*;
     use crate::{DeviceInfo, Event, QueueLimits, RequestOp};
 
-    struct NoopIrq;
+    struct NoopIrq {
+        calls: usize,
+    }
 
     impl IrqHandler for NoopIrq {
-        fn handle_irq(&self) -> Event {
+        fn handle_irq(&mut self) -> Event {
+            self.calls += 1;
             let mut event = Event::none();
             event.queues.insert(1);
             event
@@ -260,8 +263,10 @@ mod tests {
         assert_queue::<Queue>();
         assert_irq_handler::<NoopIrq>();
 
-        let event = NoopIrq.handle_irq();
+        let mut irq = NoopIrq { calls: 0 };
+        let event = irq.handle_irq();
         assert!(event.queues.contains(1));
+        assert_eq!(irq.calls, 1);
     }
 
     #[derive(Default)]
@@ -332,8 +337,8 @@ mod tests {
 
     #[test]
     fn irq_handler_slot_returns_handler_on_drop() {
-        let slot = IrqHandlerSlot::new(Box::new(NoopIrq));
-        let handler = slot.take().unwrap();
+        let slot = IrqHandlerSlot::new(Box::new(NoopIrq { calls: 0 }));
+        let mut handler = slot.take().unwrap();
 
         assert!(slot.take().is_none());
         assert!(handler.handle_irq().queues.contains(1));

--- a/drivers/interface/rdif-block/src/irq.rs
+++ b/drivers/interface/rdif-block/src/irq.rs
@@ -33,7 +33,7 @@ pub trait IrqHandler: Send + Sync + 'static {
     /// block runtime pending table. Drivers that need to consume device queue
     /// state to clear the interrupt should cache those completions internally
     /// and return a queue-level event.
-    fn handle_irq(&self) -> Event;
+    fn handle_irq(&mut self) -> Event;
 }
 
 #[repr(transparent)]

--- a/os/arceos/modules/axfs-ng/src/block/runtime/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/block/runtime/mod.rs
@@ -7,8 +7,7 @@ pub mod irq;
 #[path = "../../block_runtime/request.rs"]
 pub mod pending;
 #[path = "../../block_runtime/queue.rs"]
-#[cfg(test)]
-mod queue;
+pub mod queue;
 
 #[cfg(test)]
 pub use device::NoopDrainWake;
@@ -19,13 +18,12 @@ pub use device::{
 #[cfg(test)]
 pub use dma::VEC_DMA_OP;
 pub use dma::{DmaBufferGuard, RuntimeDmaBuffer, new_owned_dma_buffer};
-pub use irq::{BlockIrqBridge, DrainEvents};
+pub use irq::{BlockIrqBridge, DrainEvents, RuntimeEventLatch};
 pub use pending::{
     PendingRequest, PendingTable, PollClaim, PollProgress, RequestKey, RequestState,
     RuntimeRequestId,
 };
-#[cfg(test)]
-pub use queue::{CompletionDrain, CompletionSink, RequestPoller};
+pub use queue::{CompletionDrain, CompletionSink, PollOutcome, RequestPoller};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BlockIoFutureState {

--- a/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
@@ -12,8 +12,9 @@ use rdif_block::{
 };
 
 use super::{
-    BlockIrqBridge, DmaBufferGuard, DrainEvents, PendingTable, PollClaim, PollProgress, RequestKey,
-    RuntimeDmaBuffer, new_owned_dma_buffer,
+    BlockIrqBridge, CompletionDrain, CompletionSink, DmaBufferGuard, DrainEvents, PendingTable,
+    PollOutcome, RequestKey, RequestPoller, RuntimeDmaBuffer, RuntimeEventLatch,
+    new_owned_dma_buffer,
 };
 use crate::os::{
     BlockIrqOutcome, BlockIrqRegistration, current_task_id, dma_op, notify_drain,
@@ -30,7 +31,7 @@ fn runtime_device_dma(domain: DmaDomainId, dma_mask: u64) -> Result<DeviceDma, B
     Ok(DeviceDma::new(domain, dma_mask, dma_op))
 }
 
-type CompletionRecord = (RequestId, Result<(), BlkError>);
+type CompletionRecord = (RequestId, Result<(), BlkError>, Option<RuntimeDmaBuffer>);
 
 static BLOCK_DRAIN_DEVICE_BITS: AtomicU64 = AtomicU64::new(0);
 static BLOCK_DRAIN_FULL_SCAN: AtomicBool = AtomicBool::new(false);
@@ -50,12 +51,6 @@ struct ActiveQueue {
     index: usize,
     queue_id: usize,
     window: usize,
-}
-
-struct ClaimedQueueBatch {
-    queue_id: usize,
-    claimed: Vec<RequestKey>,
-    driver_ids: Vec<RequestId>,
 }
 
 struct QueueProgressWaiter {
@@ -171,11 +166,10 @@ impl BlockRuntimeConfig {
 pub struct BlockDeviceHandle {
     name: String,
     queues: Box<[SpinNoIrq<QueueRuntime>]>,
-    driver_queue_map: [Option<usize>; u64::BITS as usize],
+    event_latch: RuntimeEventLatch,
     pending: SpinNoIrq<PendingTable>,
     queue_progress_waiters: SpinNoIrq<Vec<QueueProgressWaiter>>,
     barrier_waiters: SpinNoIrq<Vec<BarrierWaiter>>,
-    bridge: Arc<BlockIrqBridge>,
     drain_wake: Arc<dyn BlockDrainWake>,
     submit_window: usize,
     completion_mode: AtomicUsize,
@@ -341,7 +335,7 @@ impl BlockIrqAction {
         }
     }
 
-    pub fn run(&self) -> BlockIrqOutcome {
+    pub fn run(&mut self) -> BlockIrqOutcome {
         let event = self.handler.handle_irq();
         if self.device.record_driver_event(event) {
             self.device.drain_wake.wake_drain_from_irq();
@@ -439,11 +433,10 @@ impl BlockDeviceHandle {
         Ok(Arc::new(Self {
             name: name.into(),
             queues: queues.into_boxed_slice(),
-            driver_queue_map,
+            event_latch: RuntimeEventLatch::new(bridge, driver_queue_map),
             pending: SpinNoIrq::new(PendingTable::new()),
             queue_progress_waiters: SpinNoIrq::new(Vec::new()),
             barrier_waiters: SpinNoIrq::new(Vec::new()),
-            bridge,
             drain_wake: config.drain_wake,
             submit_window: config.submit_window.max(1),
             completion_mode: AtomicUsize::new(config.completion_mode.as_usize()),
@@ -455,7 +448,7 @@ impl BlockDeviceHandle {
     }
 
     pub fn bridge(&self) -> Arc<BlockIrqBridge> {
-        self.bridge.clone()
+        self.event_latch.bridge()
     }
 
     pub fn name(&self) -> &str {
@@ -492,17 +485,20 @@ impl BlockDeviceHandle {
 
     pub fn drain_events(&self) -> usize {
         self.with_drain(|| {
-            let events = self.bridge.take_events();
+            let events = self.event_latch.bridge().take_events();
             self.drain_given_events(events)
         })
     }
 
     pub fn drain_hint(&self, hint: CompletionHint) -> usize {
-        self.with_drain(|| self.drain_one_hint(hint))
+        self.with_drain(|| {
+            let mut poller = DeviceRequestPoller { device: self };
+            CompletionDrain::new(&self.pending, &mut poller).drain_hint(hint)
+        })
     }
 
     pub fn record_driver_event(&self, event: rdif_block::Event) -> bool {
-        self.record_translated_event(event, false)
+        self.event_latch.record_driver_event(event)
     }
 
     #[cfg(test)]
@@ -512,7 +508,7 @@ impl BlockDeviceHandle {
 
     #[cfg(test)]
     pub(crate) fn pending_queue_ready_events(&self) -> u64 {
-        self.bridge.take_events().queue_bits
+        self.event_latch.bridge().take_events().queue_bits
     }
 
     fn with_drain(&self, f: impl FnOnce() -> usize) -> usize {
@@ -529,242 +525,14 @@ impl BlockDeviceHandle {
     }
 
     fn drain_given_events(&self, events: DrainEvents) -> usize {
-        let mut completed = 0;
-        for hint in events.hints.iter() {
-            completed += self.drain_one_hint(hint);
-        }
-        for queue_id in queue_ids_from_bits(events.queue_bits) {
-            completed += self.drain_queue(queue_id);
-        }
-        completed
-    }
-
-    fn runtime_queue_id(&self, driver_queue_id: usize) -> Option<usize> {
-        self.driver_queue_map
-            .get(driver_queue_id)
-            .copied()
-            .flatten()
-    }
-
-    fn record_translated_event(&self, event: rdif_block::Event, pending_only: bool) -> bool {
-        let pending_queue_bits = pending_only.then(|| self.pending.lock().pending_queue_bits());
-        let mut translated = rdif_block::Event::none();
-        for driver_queue_id in event.queues.iter() {
-            if let Some(runtime_queue_id) = self.runtime_queue_id(driver_queue_id)
-                && pending_queue_bits.is_none_or(|bits| bits & (1 << runtime_queue_id) != 0)
-            {
-                translated.queues.insert(runtime_queue_id);
-            }
-        }
-        for hint in event.completions.iter() {
-            if let Some(hint) = self.translate_driver_hint(hint)
-                && pending_queue_bits.is_none_or(|bits| bits & (1 << hint.queue_id()) != 0)
-            {
-                translated.push_hint(hint);
-            }
-        }
-        if translated.is_empty() {
-            return false;
-        }
-        self.bridge.record_event(translated);
-        true
-    }
-
-    fn translate_driver_hint(&self, hint: CompletionHint) -> Option<CompletionHint> {
-        let queue_id = self.runtime_queue_id(hint.queue_id())?;
-        Some(match hint {
-            CompletionHint::Queue { .. } => CompletionHint::Queue { queue_id },
-            CompletionHint::Request { request_id, .. } => CompletionHint::Request {
-                queue_id,
-                request_id,
-            },
-            CompletionHint::Batch { ids, .. } => CompletionHint::Batch { queue_id, ids },
-        })
-    }
-
-    fn drain_one_hint(&self, hint: CompletionHint) -> usize {
-        match hint {
-            CompletionHint::Queue { queue_id } => self.drain_queue(queue_id),
-            CompletionHint::Request {
-                queue_id,
-                request_id,
-            } => {
-                let keys = self.matching_driver_keys(queue_id, &[request_id]);
-                self.poll_batch(&keys)
-            }
-            CompletionHint::Batch { queue_id, ids } => {
-                let ids = ids.iter().collect::<Vec<_>>();
-                let keys = self.matching_driver_keys(queue_id, &ids);
-                self.poll_batch(&keys)
-            }
-        }
-    }
-
-    fn drain_queue(&self, queue_id: usize) -> usize {
-        let keys = self.pending.lock().keys_for_queue(queue_id);
-        self.poll_batch(&keys)
-    }
-
-    fn matching_driver_keys(&self, queue_id: usize, ids: &[RequestId]) -> Vec<RequestKey> {
-        self.pending.lock().matching_driver_keys(queue_id, ids)
-    }
-
-    fn poll_batch(&self, keys: &[RequestKey]) -> usize {
-        let batches = self.claim_poll_batches(keys);
-        if batches.is_empty() {
-            return 0;
-        }
-
-        let mut completed = 0;
-        for batch in batches {
-            let result = self.poll_queue_completions(batch.queue_id, &batch.driver_ids);
-            let query_failed = result.is_err();
-            let mut sink = DeviceCompletionSink {
-                device: self,
-                completed: 0,
-                terminal: Vec::new(),
-                claimed: batch
-                    .claimed
-                    .iter()
-                    .copied()
-                    .zip(batch.driver_ids.iter().copied())
-                    .map(|(key, request_id)| (request_id, key))
-                    .collect(),
-            };
-            if let Ok(completions) = result {
-                for (request_id, result) in completions {
-                    sink.complete(request_id, result);
-                }
-            }
-            if query_failed {
-                self.bridge.record_queue_ready(batch.queue_id);
-                self.drain_wake.wake_drain();
-            }
-            let terminal = sink.terminal.clone();
-            completed += sink.completed;
-            for key in batch.claimed {
-                if terminal.contains(&key) {
-                    continue;
-                }
-                if query_failed {
-                    self.release_claimed_poll(key);
-                } else {
-                    let progress = self.pending.lock().finish_pending_poll(key);
-                    match progress {
-                        PollProgress::Pending | PollProgress::Complete => {}
-                        PollProgress::Repoll => {
-                            let submitted = self
-                                .pending
-                                .lock()
-                                .request(key)
-                                .map(|request| request.submitted_request());
-                            let completed_key = match submitted {
-                                Some(request) => {
-                                    let result =
-                                        self.poll_request(request.queue_id, request.request_id);
-                                    self.finish_poll(key, result).unwrap_or(false)
-                                }
-                                None => false,
-                            };
-                            completed += usize::from(completed_key);
-                        }
-                    }
-                }
-            }
-        }
-        completed
-    }
-
-    fn release_claimed_poll(&self, key: RequestKey) {
-        while let PollProgress::Repoll = self.pending.lock().finish_pending_poll(key) {}
-    }
-
-    fn claim_poll_batches(&self, keys: &[RequestKey]) -> Vec<ClaimedQueueBatch> {
-        let mut batches: Vec<ClaimedQueueBatch> = Vec::new();
-        let mut pending = self.pending.lock();
-        for &key in keys {
-            if pending.begin_poll(key) != PollClaim::Claimed {
-                continue;
-            }
-            let submitted = pending
-                .request(key)
-                .expect("claimed request must remain present")
-                .submitted_request();
-            if let Some(batch) = batches
-                .iter_mut()
-                .find(|batch| batch.queue_id == submitted.queue_id)
-            {
-                batch.claimed.push(key);
-                batch.driver_ids.push(submitted.request_id);
-            } else {
-                let mut batch = ClaimedQueueBatch {
-                    queue_id: submitted.queue_id,
-                    claimed: Vec::new(),
-                    driver_ids: Vec::new(),
-                };
-                batch.claimed.push(key);
-                batch.driver_ids.push(submitted.request_id);
-                batches.push(batch);
-            }
-        }
-        batches
+        let mut poller = DeviceRequestPoller { device: self };
+        CompletionDrain::new(&self.pending, &mut poller).drain_events(events)
     }
 
     #[cfg(feature = "ext4")]
     fn poll_one(&self, key: RequestKey) -> bool {
-        if self.pending.lock().begin_poll(key) != PollClaim::Claimed {
-            return false;
-        }
-        self.poll_claimed_one(key)
-    }
-
-    #[cfg(feature = "ext4")]
-    fn poll_claimed_one(&self, key: RequestKey) -> bool {
-        loop {
-            let submitted = match self.pending.lock().request(key) {
-                Some(request) => request.submitted_request(),
-                None => return false,
-            };
-            let result = self.poll_request(submitted.queue_id, submitted.request_id);
-            if let Some(completed) = self.finish_poll(key, result) {
-                return completed;
-            }
-        }
-    }
-
-    fn finish_poll(
-        &self,
-        key: RequestKey,
-        mut result: Result<RequestStatus, BlkError>,
-    ) -> Option<bool> {
-        loop {
-            match result {
-                Ok(RequestStatus::Pending) => {
-                    let progress = self.pending.lock().finish_pending_poll(key);
-                    match progress {
-                        PollProgress::Pending | PollProgress::Complete => return Some(false),
-                        PollProgress::Repoll => {
-                            let submitted = self
-                                .pending
-                                .lock()
-                                .request(key)
-                                .map(|request| request.submitted_request())?;
-                            result = self.poll_request(submitted.queue_id, submitted.request_id);
-                        }
-                    }
-                }
-                Ok(RequestStatus::Complete) => {
-                    let task_id = self.pending.lock().complete(key, Ok(()));
-                    self.wake_completed_request(key, task_id);
-                    return Some(true);
-                }
-                Err(err) => {
-                    let task_id = self.pending.lock().complete(key, Err(err));
-                    self.wake_completed_request(key, task_id);
-                    return Some(true);
-                }
-            }
-        }
+        let mut poller = DeviceRequestPoller { device: self };
+        CompletionDrain::new(&self.pending, &mut poller).poll_one(key)
     }
 
     fn wake_completed_request(&self, key: RequestKey, task_id: Option<u64>) {
@@ -1186,6 +954,11 @@ impl BlockDeviceHandle {
         self.poll_batch(&keys)
     }
 
+    fn poll_batch(&self, keys: &[RequestKey]) -> usize {
+        let mut poller = DeviceRequestPoller { device: self };
+        CompletionDrain::new(&self.pending, &mut poller).poll_keys(keys)
+    }
+
     fn harvest_active(
         &self,
         active: &mut Vec<WindowEntry>,
@@ -1572,17 +1345,17 @@ impl BlockDeviceHandle {
         &self,
         queue_id: usize,
         request_id: RequestId,
-    ) -> Result<RequestStatus, BlkError> {
+    ) -> Result<PollOutcome, BlkError> {
         let queue = self.queue_by_runtime_id(queue_id)?;
         let mut queue = queue.lock();
         match &mut queue.queue {
-            RuntimeQueue::Legacy(legacy) => legacy.poll_request(request_id),
+            RuntimeQueue::Legacy(legacy) => Ok(match legacy.poll_request(request_id)? {
+                RequestStatus::Pending => PollOutcome::Pending,
+                RequestStatus::Complete => PollOutcome::complete(Ok(())),
+            }),
             RuntimeQueue::Owned(owned) => match owned.poll_request(request_id)? {
-                OwnedRequestPoll::Pending => Ok(RequestStatus::Pending),
-                OwnedRequestPoll::Ready(completed) => {
-                    self.finish_owned_completion(queue_id, completed);
-                    Ok(RequestStatus::Complete)
-                }
+                OwnedRequestPoll::Pending => Ok(PollOutcome::Pending),
+                OwnedRequestPoll::Ready(completed) => Ok(poll_outcome_from_owned(completed)),
             },
         }
     }
@@ -1606,10 +1379,8 @@ impl BlockDeviceHandle {
                     match owned.poll_request(request_id)? {
                         OwnedRequestPoll::Pending => {}
                         OwnedRequestPoll::Ready(completed) => {
-                            let result = completed.result;
-                            let id = completed.id;
-                            self.finish_owned_completion(queue_id, completed);
-                            completions.push((id, result));
+                            let rdif_block::CompletedRequest { id, result, data } = completed;
+                            completions.push((id, result, data.map(RuntimeDmaBuffer::Owned)));
                         }
                     }
                 }
@@ -1621,23 +1392,49 @@ impl BlockDeviceHandle {
     fn queue_by_runtime_id(&self, queue_id: usize) -> Result<&SpinNoIrq<QueueRuntime>, BlkError> {
         self.queues.get(queue_id).ok_or(BlkError::InvalidRequest)
     }
+}
 
-    fn finish_owned_completion(&self, queue_id: usize, completed: rdif_block::CompletedRequest) {
-        let key = self
-            .pending
-            .lock()
-            .matching_driver_keys(queue_id, &[completed.id])
-            .into_iter()
-            .next();
-        let Some(key) = key else {
-            return;
-        };
-        let buffer = completed.data.map(RuntimeDmaBuffer::Owned);
-        let task_id = self
-            .pending
-            .lock()
-            .complete_with_buffer(key, completed.result, buffer);
-        self.wake_completed_request(key, task_id);
+struct DeviceRequestPoller<'a> {
+    device: &'a BlockDeviceHandle,
+}
+
+impl RequestPoller for DeviceRequestPoller<'_> {
+    fn poll_request(
+        &mut self,
+        queue_id: usize,
+        request_id: RequestId,
+    ) -> Result<PollOutcome, BlkError> {
+        self.device.poll_request(queue_id, request_id)
+    }
+
+    fn poll_completions(
+        &mut self,
+        queue_id: usize,
+        request_ids: &[RequestId],
+        sink: &mut dyn CompletionSink,
+    ) -> Result<(), BlkError> {
+        for (request_id, result, buffer) in
+            self.device.poll_queue_completions(queue_id, request_ids)?
+        {
+            sink.complete_with_buffer(request_id, result, buffer);
+        }
+        Ok(())
+    }
+
+    fn poll_batch_query_failed(&mut self, queue_id: usize) {
+        self.device
+            .event_latch
+            .bridge()
+            .record_queue_ready(queue_id);
+        self.device.drain_wake.wake_drain();
+    }
+
+    fn completed_request(&mut self, queue_id: usize, task_id: Option<u64>) {
+        self.device.wake_queue_progress(queue_id);
+        if let Some(task_id) = task_id {
+            wake_task(task_id);
+        }
+        notify_waiters();
     }
 }
 
@@ -1675,34 +1472,15 @@ struct CollectCompletionSink {
 
 impl RdifCompletionSink for CollectCompletionSink {
     fn complete(&mut self, request: RequestId, result: Result<(), BlkError>) {
-        self.completions.push((request, result));
+        self.completions.push((request, result, None));
     }
 }
 
-struct DeviceCompletionSink<'a> {
-    device: &'a BlockDeviceHandle,
-    completed: usize,
-    terminal: Vec<RequestKey>,
-    claimed: Vec<(RequestId, RequestKey)>,
-}
-
-impl DeviceCompletionSink<'_> {
-    fn complete(&mut self, request_id: RequestId, result: Result<(), BlkError>) {
-        if let Some((_, key)) = self
-            .claimed
-            .iter()
-            .copied()
-            .find(|(candidate, _)| *candidate == request_id)
-        {
-            self.complete_runtime(key, result);
-        }
-    }
-
-    fn complete_runtime(&mut self, key: RequestKey, result: Result<(), BlkError>) {
-        let task_id = self.device.pending.lock().complete(key, result);
-        self.device.wake_completed_request(key, task_id);
-        self.terminal.push(key);
-        self.completed += 1;
+fn poll_outcome_from_owned(completed: rdif_block::CompletedRequest) -> PollOutcome {
+    let rdif_block::CompletedRequest { result, data, .. } = completed;
+    PollOutcome::Complete {
+        result,
+        buffer: data.map(RuntimeDmaBuffer::Owned),
     }
 }
 
@@ -1764,6 +1542,7 @@ pub fn map_blk_err_to_ax_err(err: BlkError) -> AxError {
     }
 }
 
+#[cfg(feature = "ext4")]
 fn queue_ids_from_bits(bits: u64) -> impl Iterator<Item = usize> {
     (0..u64::BITS as usize).filter(move |queue_id| bits & (1 << queue_id) != 0)
 }

--- a/os/arceos/modules/axfs-ng/src/block_runtime/irq.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/irq.rs
@@ -1,3 +1,4 @@
+use alloc::{sync::Arc, vec::Vec};
 use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 
 use rdif_block::{CompletionHint, CompletionList, Event};
@@ -10,10 +11,69 @@ pub struct BlockIrqBridge {
     drain_ready: AtomicBool,
 }
 
+pub struct RuntimeEventLatch {
+    bridge: Arc<BlockIrqBridge>,
+    driver_queue_map: Vec<Option<usize>>,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct DrainEvents {
     pub queue_bits: u64,
     pub hints: CompletionList,
+}
+
+impl RuntimeEventLatch {
+    pub fn new(
+        bridge: Arc<BlockIrqBridge>,
+        driver_queue_map: impl IntoIterator<Item = Option<usize>>,
+    ) -> Self {
+        Self {
+            bridge,
+            driver_queue_map: driver_queue_map.into_iter().collect(),
+        }
+    }
+
+    pub fn bridge(&self) -> Arc<BlockIrqBridge> {
+        self.bridge.clone()
+    }
+
+    pub fn record_driver_event(&self, event: Event) -> bool {
+        let mut translated = Event::none();
+        for driver_queue_id in event.queues.iter() {
+            if let Some(runtime_queue_id) = self.runtime_queue_id(driver_queue_id) {
+                translated.queues.insert(runtime_queue_id);
+            }
+        }
+        for hint in event.completions.iter() {
+            if let Some(hint) = self.translate_driver_hint(hint) {
+                translated.push_hint(hint);
+            }
+        }
+        if translated.is_empty() {
+            return false;
+        }
+        self.bridge.record_event(translated);
+        true
+    }
+
+    fn runtime_queue_id(&self, driver_queue_id: usize) -> Option<usize> {
+        self.driver_queue_map
+            .get(driver_queue_id)
+            .copied()
+            .flatten()
+    }
+
+    fn translate_driver_hint(&self, hint: CompletionHint) -> Option<CompletionHint> {
+        let queue_id = self.runtime_queue_id(hint.queue_id())?;
+        Some(match hint {
+            CompletionHint::Queue { .. } => CompletionHint::Queue { queue_id },
+            CompletionHint::Request { request_id, .. } => CompletionHint::Request {
+                queue_id,
+                request_id,
+            },
+            CompletionHint::Batch { ids, .. } => CompletionHint::Batch { queue_id, ids },
+        })
+    }
 }
 
 impl BlockIrqBridge {
@@ -196,5 +256,43 @@ impl AtomicHintSlot {
 
     fn is_occupied(&self) -> bool {
         self.state.load(Ordering::Acquire) != Self::EMPTY
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn runtime_event_latch_translates_driver_queue_ids() {
+        let bridge = Arc::new(BlockIrqBridge::new());
+        let latch = RuntimeEventLatch::new(bridge.clone(), [None, Some(0), None, Some(1)]);
+
+        assert!(latch.record_driver_event(Event::from_queue_bits(1 << 3)));
+
+        let events = bridge.take_events();
+        assert_eq!(events.queue_bits, 1 << 1);
+    }
+
+    #[test]
+    fn runtime_event_latch_ignores_unknown_driver_queue_ids() {
+        let bridge = Arc::new(BlockIrqBridge::new());
+        let latch = RuntimeEventLatch::new(bridge.clone(), [Some(0)]);
+
+        assert!(!latch.record_driver_event(Event::from_queue_bits(1 << 4)));
+        assert!(!bridge.drain_ready());
+    }
+
+    #[test]
+    fn runtime_event_latch_keeps_event_without_pending_table() {
+        let bridge = Arc::new(BlockIrqBridge::new());
+        let latch = RuntimeEventLatch::new(bridge.clone(), [Some(0)]);
+
+        assert!(latch.record_driver_event(Event::from_queue_bits(1)));
+
+        let events = bridge.take_events();
+        assert_eq!(events.queue_bits, 1);
     }
 }

--- a/os/arceos/modules/axfs-ng/src/block_runtime/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/mod.rs
@@ -14,7 +14,6 @@ mod tests {
     };
 
     use ax_errno::AxError;
-    use ax_kspin::SpinRaw as SpinNoIrq;
     use dma_api::{DeviceDma, DmaDomainId};
     use rdif_block::{
         BlkError, CompletionHint, DeviceInfo, DriverGeneric, IQueue, IQueueOwned, Interface,
@@ -23,7 +22,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::os::{BlockTaskOps, install_dma_op, set_task_ops};
+    use crate::os::{BlockTaskOps, install_dma_op, set_task_ops, sync::IrqMutex as SpinNoIrq};
 
     static TEST_TASK_OPS: TestTaskOps = TestTaskOps;
     static NEXT_TEST_TASK_ID: AtomicU64 = AtomicU64::new(1_000_000);
@@ -134,7 +133,9 @@ mod tests {
     }
 
     fn test_task_guard() -> std::sync::MutexGuard<'static, ()> {
-        TEST_TASK_LOCK.lock().unwrap()
+        let guard = TEST_TASK_LOCK.lock().unwrap();
+        clear_test_tasks();
+        guard
     }
 
     struct TestTaskGuard {
@@ -181,6 +182,12 @@ mod tests {
 
     fn test_tasks() -> &'static StdMutex<HashMap<u64, StdArc<TestTaskState>>> {
         TEST_TASKS.get_or_init(|| StdMutex::new(HashMap::new()))
+    }
+
+    fn clear_test_tasks() {
+        if let Some(tasks) = TEST_TASKS.get() {
+            tasks.lock().unwrap().clear();
+        }
     }
 
     struct ChannelDrainWake {
@@ -265,12 +272,13 @@ mod tests {
             &mut self,
             queue_id: usize,
             request_id: RequestId,
-        ) -> Result<RequestStatus, BlkError> {
+        ) -> Result<PollOutcome, BlkError> {
             let key = (queue_id, request_id);
             self.polled.push(key);
             self.completions
                 .remove(&key)
                 .unwrap_or(Ok(RequestStatus::Pending))
+                .map(poll_outcome_from_status)
         }
     }
 
@@ -304,9 +312,9 @@ mod tests {
             &mut self,
             _queue_id: usize,
             _request_id: RequestId,
-        ) -> Result<RequestStatus, BlkError> {
+        ) -> Result<PollOutcome, BlkError> {
             self.single_polls += 1;
-            Ok(RequestStatus::Pending)
+            Ok(PollOutcome::Pending)
         }
 
         fn poll_completions(
@@ -661,17 +669,24 @@ mod tests {
             &mut self,
             _queue_id: usize,
             _request_id: RequestId,
-        ) -> Result<RequestStatus, BlkError> {
+        ) -> Result<PollOutcome, BlkError> {
             self.polls += 1;
             if self.polls == 1 {
                 assert_eq!(
                     self.pending.lock().begin_poll(self.key),
                     PollClaim::AlreadyPolling
                 );
-                Ok(RequestStatus::Pending)
+                Ok(PollOutcome::Pending)
             } else {
-                Ok(RequestStatus::Complete)
+                Ok(PollOutcome::complete(Ok(())))
             }
+        }
+    }
+
+    fn poll_outcome_from_status(status: RequestStatus) -> PollOutcome {
+        match status {
+            RequestStatus::Pending => PollOutcome::Pending,
+            RequestStatus::Complete => PollOutcome::complete(Ok(())),
         }
     }
 
@@ -1600,7 +1615,7 @@ mod tests {
         )
         .unwrap();
 
-        let action = BlockIrqAction::new(Box::new(QueueEventIrqHandler), device.clone(), 0);
+        let mut action = BlockIrqAction::new(Box::new(QueueEventIrqHandler), device.clone(), 0);
         assert_eq!(action.run(), crate::os::BlockIrqOutcome::Handled);
         let events = device.bridge().take_events();
         assert_eq!(events.queue_bits, 1);
@@ -1609,7 +1624,7 @@ mod tests {
     struct QueueEventIrqHandler;
 
     impl rdif_block::IrqHandler for QueueEventIrqHandler {
-        fn handle_irq(&self) -> rdif_block::Event {
+        fn handle_irq(&mut self) -> rdif_block::Event {
             rdif_block::Event::from_queue_bits(1)
         }
     }

--- a/os/arceos/modules/axfs-ng/src/block_runtime/queue.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/queue.rs
@@ -1,6 +1,6 @@
-use rdif_block::{BlkError, CompletionHint, RequestId, RequestStatus};
+use rdif_block::{BlkError, CompletionHint, RequestId};
 
-use super::{DrainEvents, PendingTable, PollClaim, PollProgress, RequestKey};
+use super::{DrainEvents, PendingTable, PollClaim, PollProgress, RequestKey, RuntimeDmaBuffer};
 use crate::os::{sync::IrqMutex as SpinNoIrq, wake_task};
 
 struct ClaimedQueueBatch {
@@ -14,7 +14,7 @@ pub trait RequestPoller {
         &mut self,
         queue_id: usize,
         request_id: RequestId,
-    ) -> Result<RequestStatus, BlkError>;
+    ) -> Result<PollOutcome, BlkError>;
 
     fn poll_completions(
         &mut self,
@@ -24,17 +24,67 @@ pub trait RequestPoller {
     ) -> Result<(), BlkError> {
         for &request_id in request_ids {
             match self.poll_request(queue_id, request_id) {
-                Ok(RequestStatus::Pending) => {}
-                Ok(RequestStatus::Complete) => sink.complete(request_id, Ok(())),
+                Ok(PollOutcome::Pending) => {}
+                Ok(PollOutcome::Complete { result, buffer }) => {
+                    sink.complete_with_buffer(request_id, result, buffer);
+                }
                 Err(err) => sink.complete(request_id, Err(err)),
             }
         }
         Ok(())
     }
+
+    fn poll_batch_query_failed(&mut self, queue_id: usize) {
+        let _ = queue_id;
+    }
+
+    fn completed_request(&mut self, queue_id: usize, task_id: Option<u64>) {
+        let _ = queue_id;
+        if let Some(task_id) = task_id {
+            wake_task(task_id);
+        }
+    }
+}
+
+pub enum PollOutcome {
+    Pending,
+    Complete {
+        result: Result<(), BlkError>,
+        buffer: Option<RuntimeDmaBuffer>,
+    },
+}
+
+impl PollOutcome {
+    pub const fn complete(result: Result<(), BlkError>) -> Self {
+        Self::Complete {
+            result,
+            buffer: None,
+        }
+    }
+
+    pub const fn complete_with_buffer(
+        result: Result<(), BlkError>,
+        buffer: RuntimeDmaBuffer,
+    ) -> Self {
+        Self::Complete {
+            result,
+            buffer: Some(buffer),
+        }
+    }
 }
 
 pub trait CompletionSink {
     fn complete(&mut self, request_id: RequestId, result: Result<(), BlkError>);
+
+    fn complete_with_buffer(
+        &mut self,
+        request_id: RequestId,
+        result: Result<(), BlkError>,
+        buffer: Option<RuntimeDmaBuffer>,
+    ) {
+        let _ = buffer;
+        self.complete(request_id, result);
+    }
 }
 
 pub struct CompletionDrain<'a, P> {
@@ -77,6 +127,17 @@ impl<'a, P: RequestPoller> CompletionDrain<'a, P> {
         self.poll_batch(&keys)
     }
 
+    pub fn poll_keys(&mut self, keys: &[RequestKey]) -> usize {
+        self.poll_batch(keys)
+    }
+
+    pub fn poll_one(&mut self, key: RequestKey) -> bool {
+        if self.pending.lock().begin_poll(key) != PollClaim::Claimed {
+            return false;
+        }
+        self.poll_claimed_one(key)
+    }
+
     fn poll_matching_driver_requests(&mut self, queue_id: usize, ids: &[RequestId]) -> usize {
         let keys = self.matching_driver_keys(queue_id, ids);
         self.poll_batch(&keys)
@@ -99,8 +160,6 @@ impl<'a, P: RequestPoller> CompletionDrain<'a, P> {
         let mut completed = 0;
         for batch in batches {
             let mut sink = DrainCompletionSink {
-                pending: self.pending,
-                completed: 0,
                 terminal: alloc::vec::Vec::new(),
                 claimed: batch
                     .claimed
@@ -114,10 +173,28 @@ impl<'a, P: RequestPoller> CompletionDrain<'a, P> {
                 .poller
                 .poll_completions(batch.queue_id, &batch.driver_ids, &mut sink)
                 .is_err();
-            let terminal = sink.terminal.clone();
-            completed += sink.completed;
+            let terminal = sink.terminal;
+            let terminal_keys = terminal
+                .iter()
+                .map(|(key, ..)| *key)
+                .collect::<alloc::vec::Vec<_>>();
+            for (key, result, buffer) in terminal {
+                let queue_id = self
+                    .pending
+                    .lock()
+                    .request(key)
+                    .map(|request| request.submitted_request().queue_id);
+                let task_id = self
+                    .pending
+                    .lock()
+                    .complete_with_buffer(key, result, buffer);
+                if let Some(queue_id) = queue_id {
+                    self.poller.completed_request(queue_id, task_id);
+                }
+                completed += 1;
+            }
             for key in batch.claimed {
-                if terminal.contains(&key) {
+                if terminal_keys.contains(&key) {
                     continue;
                 }
                 if query_failed {
@@ -131,6 +208,9 @@ impl<'a, P: RequestPoller> CompletionDrain<'a, P> {
                         }
                     }
                 }
+            }
+            if query_failed {
+                self.poller.poll_batch_query_failed(batch.queue_id);
             }
         }
         completed
@@ -180,51 +260,53 @@ impl<'a, P: RequestPoller> CompletionDrain<'a, P> {
             let result = self
                 .poller
                 .poll_request(submitted.queue_id, submitted.request_id);
-            let wake = match result {
-                Ok(RequestStatus::Pending) => match self.pending.lock().finish_pending_poll(key) {
-                    PollProgress::Pending => None,
+            match result {
+                Ok(PollOutcome::Pending) => match self.pending.lock().finish_pending_poll(key) {
+                    PollProgress::Pending | PollProgress::Complete => return false,
                     PollProgress::Repoll => continue,
-                    PollProgress::Complete => None,
                 },
-                Ok(RequestStatus::Complete) => self.pending.lock().complete(key, Ok(())),
-                Err(err) => self.pending.lock().complete(key, Err(err)),
+                Ok(PollOutcome::Complete { result, buffer }) => {
+                    let wake = self
+                        .pending
+                        .lock()
+                        .complete_with_buffer(key, result, buffer);
+                    self.poller.completed_request(submitted.queue_id, wake);
+                    return true;
+                }
+                Err(err) => {
+                    let wake = self.pending.lock().complete(key, Err(err));
+                    self.poller.completed_request(submitted.queue_id, wake);
+                    return true;
+                }
             };
-            if let Some(task_id) = wake {
-                wake_task(task_id);
-            }
-            return !matches!(result, Ok(RequestStatus::Pending));
         }
     }
 }
 
-struct DrainCompletionSink<'a> {
-    pending: &'a SpinNoIrq<PendingTable>,
-    completed: usize,
-    terminal: alloc::vec::Vec<RequestKey>,
+struct DrainCompletionSink {
+    terminal: alloc::vec::Vec<(RequestKey, Result<(), BlkError>, Option<RuntimeDmaBuffer>)>,
     claimed: alloc::vec::Vec<(RequestId, RequestKey)>,
 }
 
-impl CompletionSink for DrainCompletionSink<'_> {
+impl CompletionSink for DrainCompletionSink {
     fn complete(&mut self, request_id: RequestId, result: Result<(), BlkError>) {
+        self.complete_with_buffer(request_id, result, None);
+    }
+
+    fn complete_with_buffer(
+        &mut self,
+        request_id: RequestId,
+        result: Result<(), BlkError>,
+        buffer: Option<RuntimeDmaBuffer>,
+    ) {
         if let Some((_, runtime_key)) = self
             .claimed
             .iter()
             .copied()
             .find(|(candidate, _)| *candidate == request_id)
         {
-            self.complete_runtime(runtime_key, result);
+            self.terminal.push((runtime_key, result, buffer));
         }
-    }
-}
-
-impl DrainCompletionSink<'_> {
-    fn complete_runtime(&mut self, runtime_key: RequestKey, result: Result<(), BlkError>) {
-        let token = self.pending.lock().complete(runtime_key, result);
-        if let Some(task_id) = token {
-            wake_task(task_id);
-        }
-        self.terminal.push(runtime_key);
-        self.completed += 1;
     }
 }
 

--- a/os/arceos/modules/axfs-ng/src/os/irq.rs
+++ b/os/arceos/modules/axfs-ng/src/os/irq.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use ax_errno::AxResult;
 use ax_kspin::SpinRwLock as RwLock;
-use irq_framework::IrqId;
+use irq_framework::{IrqContext, IrqId};
 
 use crate::block::runtime::BlockIrqAction;
 
@@ -19,7 +19,7 @@ pub trait BlockIrqRegistrar: Send + Sync {
         &self,
         name: String,
         irq: IrqId,
-        action: BlockIrqAction,
+        action: Box<dyn FnMut(IrqContext) -> BlockIrqOutcome + Send + 'static>,
     ) -> AxResult<Box<dyn BlockIrqRegistration>>;
 }
 
@@ -41,7 +41,8 @@ pub fn register_shared_block_irq(
         .as_ref()
         .copied()
         .ok_or(ax_errno::AxError::BadState)?;
-    registrar.register_shared(name, irq, action)
+    let mut action = action;
+    registrar.register_shared(name, irq, Box::new(move |_ctx| action.run()))
 }
 
 pub fn has_irq_registrar() -> bool {

--- a/os/arceos/modules/axfs-ng/src/os/sync.rs
+++ b/os/arceos/modules/axfs-ng/src/os/sync.rs
@@ -1,8 +1,40 @@
 #[cfg(not(test))]
 pub use ax_kspin::{SpinNoIrq as IrqMutex, SpinNoIrqGuard as IrqMutexGuard};
-#[cfg(test)]
-pub use ax_kspin::{SpinRaw as IrqMutex, SpinRaw as SleepMutex};
-#[cfg(test)]
-pub use ax_kspin::{SpinRawGuard as IrqMutexGuard, SpinRawGuard as SleepMutexGuard};
 #[cfg(not(test))]
 pub use ax_sync::{Mutex as SleepMutex, MutexGuard as SleepMutexGuard};
+#[cfg(test)]
+pub use test_sync::{
+    TestMutex as IrqMutex, TestMutex as SleepMutex, TestMutexGuard as IrqMutexGuard,
+    TestMutexGuard as SleepMutexGuard,
+};
+
+#[cfg(test)]
+mod test_sync {
+    use std::sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard, TryLockError};
+
+    pub struct TestMutex<T> {
+        inner: StdMutex<T>,
+    }
+
+    pub type TestMutexGuard<'a, T> = StdMutexGuard<'a, T>;
+
+    impl<T> TestMutex<T> {
+        pub const fn new(value: T) -> Self {
+            Self {
+                inner: StdMutex::new(value),
+            }
+        }
+
+        pub fn lock(&self) -> TestMutexGuard<'_, T> {
+            self.inner.lock().unwrap_or_else(|err| err.into_inner())
+        }
+
+        pub fn try_lock(&self) -> Option<TestMutexGuard<'_, T>> {
+            match self.inner.try_lock() {
+                Ok(guard) => Some(guard),
+                Err(TryLockError::Poisoned(err)) => Some(err.into_inner()),
+                Err(TryLockError::WouldBlock) => None,
+            }
+        }
+    }
+}

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -21,6 +21,7 @@ wake-ipi = ["irq", "ax-hal/ipi"]
 irq = [
   "ax-hal/irq",
   "ax-task?/irq",
+  "dep:ax-kspin",
   "dep:ax-percpu",
   "dep:axklib",
   "ax-driver/irq",
@@ -90,6 +91,7 @@ axfs-ng-vfs = {workspace = true, optional = true}
 ax-hal = {workspace = true}
 ax-input = {workspace = true, optional = true}
 ax-ipi = {workspace = true, optional = true}
+ax-kspin = {workspace = true, optional = true}
 ax-lazyinit = {workspace = true}
 ax-log = {workspace = true}
 ax-memory-addr = {workspace = true}

--- a/os/arceos/modules/axruntime/src/fs/block.rs
+++ b/os/arceos/modules/axruntime/src/fs/block.rs
@@ -1,4 +1,6 @@
 use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(feature = "irq")]
+use core::ptr::NonNull;
 
 use ax_alloc::UsageKind;
 use ax_fs_ng::{
@@ -93,11 +95,29 @@ struct RuntimeBlockIrqRegistrar;
 
 #[cfg(feature = "irq")]
 struct RuntimeBlockIrqRegistration {
-    _inner: crate::irq::Registration,
+    _inner: crate::irq::HandlerRegistration<RuntimeBlockIrqState>,
 }
 
 #[cfg(feature = "irq")]
 impl BlockIrqRegistration for RuntimeBlockIrqRegistration {}
+
+#[cfg(feature = "irq")]
+struct RuntimeBlockIrqState {
+    action: ax_kspin::SpinNoIrq<
+        Box<dyn FnMut(ax_hal::irq::IrqContext) -> BlockIrqOutcome + Send + 'static>,
+    >,
+}
+
+#[cfg(feature = "irq")]
+unsafe fn handle_block_irq(
+    ctx: ax_hal::irq::IrqContext,
+    data: NonNull<()>,
+) -> ax_hal::irq::IrqReturn {
+    let state = unsafe { data.cast::<RuntimeBlockIrqState>().as_ref() };
+    match state.action.lock()(ctx) {
+        BlockIrqOutcome::Handled => ax_hal::irq::IrqReturn::Handled,
+    }
+}
 
 #[cfg(feature = "irq")]
 fn map_block_irq_error(err: ax_hal::irq::IrqError) -> ax_errno::AxError {
@@ -124,17 +144,14 @@ impl BlockIrqRegistrar for RuntimeBlockIrqRegistrar {
         &self,
         name: String,
         irq: irq_framework::IrqId,
-        mut action: Box<dyn FnMut(ax_hal::irq::IrqContext) -> BlockIrqOutcome + Send + 'static>,
+        action: Box<dyn FnMut(ax_hal::irq::IrqContext) -> BlockIrqOutcome + Send + 'static>,
     ) -> ax_errno::AxResult<Box<dyn BlockIrqRegistration>> {
-        crate::irq::Registration::register_boxed_shared(
-            name,
-            irq,
-            Box::new(move |ctx| match action(ctx) {
-                BlockIrqOutcome::Handled => ax_hal::irq::IrqReturn::Handled,
-            }),
-        )
-        .map(|inner| Box::new(RuntimeBlockIrqRegistration { _inner: inner }) as _)
-        .map_err(map_block_irq_error)
+        let state = RuntimeBlockIrqState {
+            action: ax_kspin::SpinNoIrq::new(action),
+        };
+        crate::irq::HandlerRegistration::register_shared(name, irq, state, handle_block_irq)
+            .map(|inner| Box::new(RuntimeBlockIrqRegistration { _inner: inner }) as _)
+            .map_err(map_block_irq_error)
     }
 }
 

--- a/os/arceos/modules/axruntime/src/fs/block.rs
+++ b/os/arceos/modules/axruntime/src/fs/block.rs
@@ -1,10 +1,8 @@
 use alloc::{boxed::Box, string::String, vec::Vec};
-#[cfg(feature = "irq")]
-use core::ptr::NonNull;
 
 use ax_alloc::UsageKind;
 use ax_fs_ng::{
-    block::runtime::{BlockIrqAction, RdifBlockDevice},
+    block::runtime::RdifBlockDevice,
     os::{
         BlockIrqOutcome, BlockIrqRegistrar, BlockIrqRegistration, BlockTaskOps, BlockTimeProvider,
         FsPage, FsPageProvider,
@@ -95,27 +93,11 @@ struct RuntimeBlockIrqRegistrar;
 
 #[cfg(feature = "irq")]
 struct RuntimeBlockIrqRegistration {
-    _inner: crate::irq::HandlerRegistration<RuntimeBlockIrqState>,
+    _inner: crate::irq::Registration,
 }
 
 #[cfg(feature = "irq")]
 impl BlockIrqRegistration for RuntimeBlockIrqRegistration {}
-
-#[cfg(feature = "irq")]
-struct RuntimeBlockIrqState {
-    action: BlockIrqAction,
-}
-
-#[cfg(feature = "irq")]
-unsafe fn handle_block_irq(
-    _ctx: ax_hal::irq::IrqContext,
-    data: NonNull<()>,
-) -> ax_hal::irq::IrqReturn {
-    let state = unsafe { data.cast::<RuntimeBlockIrqState>().as_ref() };
-    match state.action.run() {
-        BlockIrqOutcome::Handled => ax_hal::irq::IrqReturn::Handled,
-    }
-}
 
 #[cfg(feature = "irq")]
 fn map_block_irq_error(err: ax_hal::irq::IrqError) -> ax_errno::AxError {
@@ -142,12 +124,17 @@ impl BlockIrqRegistrar for RuntimeBlockIrqRegistrar {
         &self,
         name: String,
         irq: irq_framework::IrqId,
-        action: BlockIrqAction,
+        mut action: Box<dyn FnMut(ax_hal::irq::IrqContext) -> BlockIrqOutcome + Send + 'static>,
     ) -> ax_errno::AxResult<Box<dyn BlockIrqRegistration>> {
-        let state = RuntimeBlockIrqState { action };
-        crate::irq::HandlerRegistration::register_shared(name, irq, state, handle_block_irq)
-            .map(|inner| Box::new(RuntimeBlockIrqRegistration { _inner: inner }) as _)
-            .map_err(map_block_irq_error)
+        crate::irq::Registration::register_boxed_shared(
+            name,
+            irq,
+            Box::new(move |ctx| match action(ctx) {
+                BlockIrqOutcome::Handled => ax_hal::irq::IrqReturn::Handled,
+            }),
+        )
+        .map(|inner| Box::new(RuntimeBlockIrqRegistration { _inner: inner }) as _)
+        .map_err(map_block_irq_error)
     }
 }
 

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -154,9 +154,13 @@ fn get_run_queue(index: usize) -> &'static mut AxRunQueue {
 #[cfg_attr(all(test, feature = "host-test"), allow(dead_code))]
 fn request_current_reschedule() {
     clear_remote_reschedule_pending_for_current_cpu();
-    #[cfg(feature = "preempt")]
+    #[cfg(all(feature = "preempt", feature = "host-test"))]
     if let Some(curr) = crate::current_may_uninit() {
         curr.set_force_resched_pending(true);
+    }
+    #[cfg(all(feature = "preempt", not(feature = "host-test")))]
+    if crate::current_may_uninit().is_some() {
+        CurrentRunQueueRef::<ax_kernel_guard::NoOp>::force_resched_from_irq();
     }
 }
 
@@ -680,10 +684,15 @@ impl<G: BaseGuard> CurrentRunQueueRef<'_, G> {
 
     #[cfg(feature = "preempt")]
     pub fn force_resched(&mut self) {
+        self.force_resched_with_preempt_count(1);
+    }
+
+    #[cfg(feature = "preempt")]
+    fn force_resched_with_preempt_count(&mut self, current_disable_count: usize) {
         let curr = &self.current_task;
         assert!(curr.is_running());
 
-        let can_preempt = curr.can_preempt(1);
+        let can_preempt = curr.can_preempt(current_disable_count);
         trace!(
             "current task is forced to reschedule: {}, allow={}",
             curr.id_name(),
@@ -702,6 +711,17 @@ impl<G: BaseGuard> CurrentRunQueueRef<'_, G> {
         } else {
             curr.set_force_resched_pending(true);
         }
+    }
+
+    #[cfg(all(
+        feature = "smp",
+        feature = "ipi",
+        feature = "preempt",
+        not(feature = "host-test")
+    ))]
+    fn force_resched_from_irq() {
+        let mut rq = current_run_queue::<ax_kernel_guard::NoOp>();
+        rq.force_resched_with_preempt_count(0);
     }
 
     /// Exit the current task with the specified exit code.


### PR DESCRIPTION
## 问题

PR 的 Starry QEMU CI 在 loongarch64 和 riscv64 上都出现过长时间无进展：

- loongarch64 `qemu-smp1/system` 卡在 `bug-dir-cookie-unlink-rmdir`，日志显示 NVMe 已注册 IRQ-driven completion。
- riscv64 `qemu-smp4/system` 卡在 `bug-sched-affinity-pid` 的 parent `sched_setaffinity` 迁移路径。

## 修改

1. 拆分 `ax-fs-ng` block runtime 中的 completion/IRQ ownership，让队列、设备和 IRQ 处理边界更明确。
2. 在 `ax-runtime` 中改用可重入的运行时 block IRQ handler，避免共享 boxed IRQ callback 的 non-reentrant 保护丢掉并发 completion。
3. 在 `ax-task` 的远程 reschedule IPI 回调中直接尝试驱动当前 CPU 调度；如果当前任务暂时不能抢占，仍然只设置 `force_resched_pending`，保持原有延迟重调度语义。

## 设计理由

- block I/O 的 IRQ completion 必须允许同一 IRQ source 上的连续 completion 被可靠消费，否则 loongarch64 上的目录/文件系统压力用例可能等待永远不会被推进的 I/O。
- `sched_setaffinity(0, ...)` 触发 current-task migration 时，目标 CPU 上的 migration task 不能只依赖之后某个自然 preempt 检查；远程 IPI 已经到达目标 CPU 时，应当在 IRQ-disabled 上下文中立即尝试 forced reschedule，从根上消除 SMP affinity 迁移卡死。
- 未放宽 Starry 测试和超时；修复的是调度/IRQ 推进路径。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo xtask clippy --package ax-task`
- `cargo xtask clippy --package ax-runtime`
- `timeout 1200s cargo xtask starry test qemu --arch riscv64 -c qemu-smp4/system`
- `timeout 1200s cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system`
- rebase 最新 `origin/dev` 后：`timeout 1200s cargo xtask starry test qemu --arch riscv64 -c qemu-smp4/system/bug-sched-affinity-pid`
- rebase 最新 `origin/dev` 后：`timeout 1200s cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/bug-dir-cookie-unlink-rmdir`