### PR TITLE
fix(ax-net): preserve network poll wakeups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
               - "bootloader/axloader/**"
               - "components/**"
               - "drivers/**"
+              - "net/**"
               - "os/**"
               - "platforms/**"
               - "virtualization/**"

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -471,8 +471,14 @@ fn poll_until_idle() {
 ///
 /// This is the lightweight entry used by socket and device paths.
 pub fn request_poll() {
-    if !NET_POLL_REQUESTED.swap(true, Ordering::AcqRel) {
+    publish_poll_request(&NET_POLL_REQUESTED, || {
         NET_POLL_WAKE.notify_one(true);
+    });
+}
+
+fn publish_poll_request(requested: &AtomicBool, wake: impl FnOnce()) {
+    if !requested.swap(true, Ordering::AcqRel) {
+        wake();
     }
 }
 
@@ -722,8 +728,8 @@ fn net_poll_worker() {
                 || NET_IRQ_NOTIFY.is_pending()
                 || DEFERRED_POLL_WAKE_PENDING.load(Ordering::Acquire)
         });
-        if !timed_out && NET_POLL_REQUESTED.load(Ordering::Acquire) {
-            NET_POLL_REQUESTED.store(false, Ordering::Release);
+        if !timed_out {
+            take_poll_request(&NET_POLL_REQUESTED, || {});
         }
         if NET_IRQ_NOTIFY.drain() {
             get_service().wake_all_devices();
@@ -731,6 +737,35 @@ fn net_poll_worker() {
         drain_deferred_poll_wakes();
         poll_until_idle();
         drain_deferred_poll_wakes();
+    }
+}
+
+fn take_poll_request(requested: &AtomicBool, after_observe: impl FnOnce()) -> bool {
+    if requested.swap(false, Ordering::AcqRel) {
+        after_observe();
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use super::{publish_poll_request, take_poll_request};
+
+    #[test]
+    fn poll_request_after_worker_drain_stays_pending() {
+        let requested = AtomicBool::new(true);
+        let mut wakes = 0;
+
+        assert!(take_poll_request(&requested, || {
+            publish_poll_request(&requested, || wakes += 1);
+        }));
+
+        assert!(requested.load(Ordering::Acquire));
+        assert_eq!(wakes, 1);
     }
 }
 

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -731,13 +731,18 @@ fn net_poll_worker() {
         if !timed_out {
             take_poll_request(&NET_POLL_REQUESTED, || {});
         }
-        if NET_IRQ_NOTIFY.drain() {
+        let irq_pending = NET_IRQ_NOTIFY.drain();
+        if device_poll_fallback_due(timed_out, irq_pending, delay) {
             get_service().wake_all_devices();
         }
         drain_deferred_poll_wakes();
         poll_until_idle();
         drain_deferred_poll_wakes();
     }
+}
+
+fn device_poll_fallback_due(timed_out: bool, irq_pending: bool, delay: Duration) -> bool {
+    irq_pending || (timed_out && delay > Duration::ZERO)
 }
 
 fn take_poll_request(requested: &AtomicBool, after_observe: impl FnOnce()) -> bool {
@@ -751,9 +756,12 @@ fn take_poll_request(requested: &AtomicBool, after_observe: impl FnOnce()) -> bo
 
 #[cfg(test)]
 mod tests {
-    use core::sync::atomic::{AtomicBool, Ordering};
+    use core::{
+        sync::atomic::{AtomicBool, Ordering},
+        time::Duration,
+    };
 
-    use super::{publish_poll_request, take_poll_request};
+    use super::{device_poll_fallback_due, publish_poll_request, take_poll_request};
 
     #[test]
     fn poll_request_after_worker_drain_stays_pending() {
@@ -766,6 +774,21 @@ mod tests {
 
         assert!(requested.load(Ordering::Acquire));
         assert_eq!(wakes, 1);
+    }
+
+    #[test]
+    fn poll_timeout_wakes_devices_as_polling_fallback() {
+        assert!(device_poll_fallback_due(
+            true,
+            false,
+            Duration::from_millis(100)
+        ));
+    }
+
+    #[test]
+    fn immediate_socket_poll_does_not_force_device_fallback() {
+        assert!(!device_poll_fallback_due(true, false, Duration::ZERO));
+        assert!(device_poll_fallback_due(false, true, Duration::ZERO));
     }
 }
 

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -45,6 +45,7 @@ use alloc::{
 use core::{
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     task::Waker,
+    time::Duration,
 };
 
 use ax_hal::time::{NANOS_PER_MICROS, monotonic_time_nanos};
@@ -73,6 +74,7 @@ use crate::{
 };
 
 const DEVICE_RX_WORKER_BATCH: usize = 16;
+const DEVICE_RX_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug)]
 pub struct Rule {
@@ -922,7 +924,9 @@ fn device_rx_worker(device: Arc<DeviceHandle>) {
 
         if !received {
             register_device_poll(&device, &device.rx_waker);
-            device.rx_wake.wait_until(|| device.take_rx_ready());
+            device
+                .rx_wake
+                .wait_timeout_until(DEVICE_RX_IDLE_POLL_INTERVAL, || device.take_rx_ready());
         }
     }
 }
@@ -1091,6 +1095,12 @@ mod tests {
         device.rx_waker.wake_by_ref();
         assert!(device.take_rx_ready());
         assert!(!device.take_rx_ready());
+    }
+
+    #[test]
+    fn rx_worker_idle_poll_interval_keeps_polling_devices_active() {
+        assert!(DEVICE_RX_IDLE_POLL_INTERVAL > core::time::Duration::ZERO);
+        assert!(DEVICE_RX_IDLE_POLL_INTERVAL <= core::time::Duration::from_millis(10));
     }
 
     #[test]

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -43,7 +43,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     task::Waker,
 };
 
@@ -253,6 +253,10 @@ struct DeviceHandle {
     tx_wake: Arc<WaitQueue>,
     /// Waker registered into the concrete device.
     rx_waker: Waker,
+    /// Sticky readiness bit for RX wakeups. `WaitQueue` notifications are not
+    /// sticky, so a device wake that races with the worker entering `wait()`
+    /// must be preserved here until the worker observes it.
+    rx_ready: AtomicBool,
 }
 
 impl DeviceHandle {
@@ -273,7 +277,17 @@ impl DeviceHandle {
             rx_waker: Waker::from(Arc::new(DeviceRxWake {
                 device: weak.clone(),
             })),
+            rx_ready: AtomicBool::new(false),
         })
+    }
+
+    fn wake_rx(&self) {
+        self.rx_ready.store(true, Ordering::Release);
+        self.rx_wake.notify_one(true);
+    }
+
+    fn take_rx_ready(&self) -> bool {
+        self.rx_ready.swap(false, Ordering::AcqRel)
     }
 
     fn enqueue_tx(&self, next_hop: IpAddress, packet: &[u8]) -> bool {
@@ -328,7 +342,7 @@ impl Wake for DeviceRxWake {
 
     fn wake_by_ref(self: &Arc<Self>) {
         if let Some(device) = self.device.upgrade() {
-            device.rx_wake.notify_one(true);
+            device.wake_rx();
         }
     }
 }
@@ -684,7 +698,7 @@ impl Router {
     pub fn wake_all_devices(&self) {
         for device in &self.devices {
             wake_device_poll(device);
-            device.rx_wake.notify_one(true);
+            device.wake_rx();
         }
     }
 
@@ -908,7 +922,7 @@ fn device_rx_worker(device: Arc<DeviceHandle>) {
 
         if !received {
             register_device_poll(&device, &device.rx_waker);
-            device.rx_wake.wait();
+            device.rx_wake.wait_until(|| device.take_rx_ready());
         }
     }
 }
@@ -1027,6 +1041,8 @@ impl smoltcp::phy::Device for Router {
 
 #[cfg(test)]
 mod tests {
+    use smoltcp::storage::PacketBuffer;
+
     use super::*;
 
     const IF0: InterfaceId = InterfaceId::new(2);
@@ -1034,8 +1050,47 @@ mod tests {
     const SRC0: IpAddress = IpAddress::Ipv4(Ipv4Address::new(10, 0, 0, 2));
     const SRC1: IpAddress = IpAddress::Ipv4(Ipv4Address::new(10, 0, 1, 2));
 
+    struct EmptyDevice;
+
+    impl Device for EmptyDevice {
+        fn name(&self) -> &str {
+            "empty"
+        }
+
+        fn recv(
+            &mut self,
+            _interface_id: InterfaceId,
+            _buffer: &mut PacketBuffer<InterfaceId>,
+            _timestamp: Instant,
+            _snoop: &mut dyn FnMut(&[u8]),
+        ) -> bool {
+            false
+        }
+
+        fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> bool {
+            false
+        }
+    }
+
+    fn test_device_handle(device: Box<dyn Device>) -> Arc<DeviceHandle> {
+        let queues = Arc::new(RouterQueues {
+            rx: Arc::new(BoundedPacketQueue::new(1)),
+        });
+        DeviceHandle::new(IF0, device, &queues)
+    }
+
     fn ipv4_cidr(addr: Ipv4Address, prefix_len: u8) -> IpCidr {
         Ipv4Cidr::new(addr, prefix_len).into()
+    }
+
+    #[test]
+    fn rx_worker_wake_is_sticky_until_observed() {
+        let device = test_device_handle(Box::new(EmptyDevice));
+
+        assert!(!device.take_rx_ready());
+        device.rx_waker.wake_by_ref();
+        assert!(device.take_rx_ready());
+        assert!(!device.take_rx_ready());
     }
 
     #[test]


### PR DESCRIPTION
## 问题

`net/ax-net` 的 RX/轮询唤醒路径存在几个竞态和进度问题，导致 LoongArch Starry `apk-curl-equivalence` 在大量下载时可能长期停滞，最终触发 curl 180s timeout。之前 CI path filter 也没有把 `net/**` 变更纳入 `ci_checks`，会让网络栈改动误跳过真实矩阵。

## 修复

- 为设备 RX worker 增加 sticky `rx_ready` 位，避免设备 waker 在 worker 进入 `WaitQueue::wait_until` 前触发时丢失唤醒。
- 将全局 `request_poll` 发布改为原子 `swap`，避免 worker 清除 poll 请求时覆盖并发提交的新请求。
- 在 smoltcp poll timeout 或 IRQ pending 时唤醒设备 RX worker，让纯轮询或漏中断场景仍能推进设备 ring。
- 给每个设备 RX worker 增加 10ms idle poll fallback：保留 readiness waker 作为快路径，但即使中断/唤醒缺失，也会周期性重新轮询设备，避免大流量下载只依赖 100ms 全局兜底而吞吐不足。
- CI path filter 只补上 `net/**`，没有加入 `apps/**` 或 `tools/**`。

## 验证

- `cargo test -p ax-net -- --nocapture`
- `cargo xtask clippy --package ax-net`
- `cargo fmt`
- `git diff --check`
- `python3` 检查 CI path filter：`net/**` 存在，`apps/**` 和 `tools/**` 不存在
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/apk-curl-equivalence`，本地从 CI 中的 180s timeout 复现用例恢复为 `STARRY_SYSTEM_TEST_PASSED ... elapsed_s=4`
