### PR TITLE
feat(rdif-pinctrl): add FDT pinctrl apply support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "rdif-input",
  "rdif-intc",
  "rdif-pcie",
+ "rdif-pinctrl",
  "rdif-serial",
  "rdif-vsock",
  "rdrive",
@@ -6359,6 +6360,15 @@ dependencies = [
  "pci_types",
  "rdif-base",
  "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rdif-pinctrl"
+version = "0.1.0"
+dependencies = [
+ "fdt-edit",
+ "rdif-base",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ rdif-eth = { version = "0.3.5", path = "drivers/interface/rdif-eth" }
 rdif-input = { version = "0.2.0", path = "drivers/interface/rdif-input" }
 rdif-intc = { version = "0.14.3", path = "drivers/interface/rdif-intc" }
 rdif-pcie = { version = "0.2.5", path = "drivers/interface/rdif-pcie" }
+rdif-pinctrl = { version = "0.1.0", path = "drivers/interface/rdif-pinctrl" }
 rdif-power = { version = "0.7.3", path = "drivers/interface/rdif-power" }
 rdif-serial = { version = "0.9.0", path = "drivers/interface/rdif-serial" }
 rdif-systick = { version = "0.6.3", path = "drivers/interface/rdif-systick" }

--- a/docs/docs/architecture/rdrive-rdif.md
+++ b/docs/docs/architecture/rdrive-rdif.md
@@ -11,7 +11,7 @@ sidebar_label: "rdrive + rdif 驱动框架"
 
 ## 非目标与硬约束
 
-本轮只处理宿主侧物理设备，包括 ArceOS、StarryOS、Axvisor 在真实平台或 QEMU 平台上使用的块设备、网卡、中断控制器、时钟、显示、输入、vsock、PCIe、USB host 等设备。
+本轮只处理宿主侧物理设备，包括 ArceOS、StarryOS、Axvisor 在真实平台或 QEMU 平台上使用的块设备、网卡、中断控制器、pinctrl/GPIO、时钟、显示、输入、vsock、PCIe、USB host 等设备。
 
 架构硬约束如下：
 
@@ -56,7 +56,7 @@ flowchart TB
         RdifDisplay["rdif-display"]
         RdifInput["rdif-input"]
         RdifVsock["rdif-vsock"]
-        RdifPlatform["rdif-intc / pcie / clk / timer / serial"]
+        RdifPlatform["rdif-intc / pinctrl / pcie / clk / timer / serial"]
     end
 
     subgraph Services["领域 service"]
@@ -224,7 +224,13 @@ sequenceDiagram
 | 显示 | `rdif-display` | `rd-display` | display service、Starry fb |
 | 输入 | `rdif-input` | `rd-input` | input service、Starry input |
 | vsock | `rdif-vsock` | `rd-vsock` | vsock service |
-| 平台设备 | `rdif-intc`、`rdif-pcie`、`rdif-clk`、`rdif-timer`、`rdif-systick`、`rdif-serial` | 按需 | HAL、Axvisor backend、平台 glue |
+| 平台设备 | `rdif-intc`、`rdif-pinctrl`、`rdif-pcie`、`rdif-clk`、`rdif-timer`、`rdif-systick`、`rdif-serial` | 按需 | HAL、Axvisor backend、平台 glue |
+
+`rdif-pinctrl` 是 pinctrl、GPIO、GPIO IRQ 的能力边界，分成三个独立 endpoint：`Interface`、`GpioBank`、`GpioIrqHandler`。`Interface` 只描述 pins/groups/functions/configs/states 这些 Linux pinctrl 模型中的稳定语义，但用 `PinId`、`GroupId`、`FunctionId`、`GpioLineId`、`MuxValue` 和 typed `PinConfig` 表达，不引入全局字符串 registry、packed `unsigned long` config、devm/module/debugfs 语义。`PinState` 应用顺序固定为先 mux 再 pin config。
+
+GPIO line 所有权通过 `GpioLineHandle` 表达。consumer 先向 `GpioBank` request line，后续 direction/read/write 必须带 handle，避免裸 `PinId` 被多个调用方重复配置。GPIO IRQ 与 GPIO control path 分离：`Interface::take_irq_handler(source_id)` 把 `Box<dyn GpioIrqHandler>` 所有权移交给 OS runtime，runtime 再把 handler move 进 IRQ registration closure；task/control path 不共享 handler。`GpioIrqHandler::handle_irq()` 只返回 pending line mask、edge/level/error/overflow 事件，不做 OS wakeup、任务调度、IRQ 注册或 GPIO consumer 回调。
+
+FDT/ACPI 解析不进入 `rdif-pinctrl` portable core。`rdrive` / `ax-driver` probe glue 负责把 FDT consumer node 的 `pinctrl-names` + `pinctrl-N`、SoC-specific `rockchip,pins`、`gpio-ranges`、`gpios` / `gpio` 等解析成 `PinState`、`MuxSetting`、`PinConfig` 或 `GpioLineId`。ACPI 第一版只暴露 `AcpiPinStateSpec` / `AcpiGpioLineSpec` 这类 typed metadata；仓库尚无 Linux-style ACPI pinctrl state parser 时，probe glue 必须返回明确的 `PinctrlError::UnsupportedFirmware(FirmwareKind::Acpi)`，不能静默 fallback。
 
 `rdif-block` 的块请求不暴露 Linux block layer 的 512B sector 公共单位，而使用真实设备的 `lba` / `block_count` / `logical_block_size`。OS glue 负责把上层 byte offset、FS block、Linux-like sector 或分区 region 转换成设备 LBA。接口保留 blk-mq 风格的结构能力：设备可报告 `QueueTopology`，OS 可创建一个或多个 queue，每个 queue 使用 queue-local `RequestId`/tag，经 `submit_request()` 提交、经 `poll_request()` 回收完成。
 

--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -24,6 +24,7 @@ display = ["dep:ax-errno", "dep:rdif-display"]
 input = ["dep:ax-errno", "dep:rdif-input"]
 vsock = ["dep:ax-errno", "dep:rdif-vsock"]
 rtc = ["plat-dyn"]
+pinctrl = ["dep:rdif-pinctrl", "rdif-pinctrl/fdt"]
 
 virtio-core = ["dep:ax-alloc", "dep:virtio-drivers", "virtio-drivers/alloc"]
 virtio = ["virtio-core"]
@@ -116,7 +117,7 @@ rk3588-pcie = [
     "rockchip-pm",
     "dep:rk3588-pci",
 ]
-rockchip-soc = ["plat-dyn", "dep:rdif-clk", "dep:rockchip-soc"]
+rockchip-soc = ["plat-dyn", "pinctrl", "dep:rdif-clk", "dep:rockchip-soc"]
 rockchip-pm = ["rockchip-soc", "dep:rockchip-pm"]
 list-pci-devices = ["pci"]
 pci-list-devices = ["list-pci-devices"]
@@ -153,6 +154,7 @@ rdif-input = { workspace = true, optional = true }
 rdif-serial = { workspace = true, optional = true }
 rdif-intc.workspace = true
 rdif-pcie = { workspace = true, optional = true }
+rdif-pinctrl = { workspace = true, optional = true }
 rdif-vsock = { workspace = true, optional = true }
 realtek-rtl8125 = { workspace = true, optional = true }
 rdrive.workspace = true

--- a/drivers/ax-driver/src/block/rockchip/sd/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sd/mod.rs
@@ -18,6 +18,7 @@ use core::time::Duration;
 use dwmmc_host::{CardDetect, DwMmc, HostClock, rdif as dwmmc_rdif};
 use fdt_edit::{Node, Phandle};
 use log::{info, warn};
+use rdif_pinctrl::PinctrlDevice;
 use rdrive::{
     probe::OnProbeError,
     register::{FdtInfo, ProbeFdt},
@@ -202,16 +203,19 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
 fn apply_rockchip_sd_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
     apply_assigned_clocks(info, "SDMMC")?;
-    let Some(pinctrl) = rdrive::get_one::<RockchipPinCtrl>() else {
+    let Some(pinctrl) = rdrive::get_one::<PinctrlDevice>() else {
         warn!(
-            "[{}] RockchipPinCtrl not found; skip SDMMC pinctrl and fixed regulators",
+            "[{}] PinctrlDevice not found; skip SDMMC pinctrl and fixed regulators",
             info.node.name()
         );
         return Ok(());
     };
     let mut pinctrl = pinctrl
         .lock()
-        .map_err(|err| OnProbeError::other(format!("failed to lock RockchipPinCtrl: {err}")))?;
+        .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
+    let pinctrl = pinctrl
+        .typed_mut::<RockchipPinCtrl>()
+        .ok_or_else(|| OnProbeError::other("PinctrlDevice is not backed by RockchipPinCtrl"))?;
     pinctrl.apply_default_pinctrl(info.node)?;
     for (name, supply) in sd_supply_phandles(info.node.as_node()) {
         if supply_has_fixed_gpio_enable(info, supply)? {

--- a/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
@@ -21,6 +21,7 @@ use core::{ptr::NonNull, time::Duration};
 
 use fdt_edit::Node;
 use log::{info, warn};
+use rdif_pinctrl::PinctrlDevice;
 use rdrive::{
     probe::OnProbeError,
     register::{FdtInfo, ProbeFdt},
@@ -233,10 +234,13 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
 fn apply_rockchip_sdhci_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
     apply_assigned_clocks(info, "SDHCI")?;
-    if let Some(pinctrl) = rdrive::get_one::<RockchipPinCtrl>() {
+    if let Some(pinctrl) = rdrive::get_one::<PinctrlDevice>() {
         let mut pinctrl = pinctrl
             .lock()
-            .map_err(|err| OnProbeError::other(format!("failed to lock RockchipPinCtrl: {err}")))?;
+            .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
+        let pinctrl = pinctrl
+            .typed_mut::<RockchipPinCtrl>()
+            .ok_or_else(|| OnProbeError::other("PinctrlDevice is not backed by RockchipPinCtrl"))?;
         let configured = pinctrl.apply_default_pinctrl(info.node)?;
         if configured.is_empty() {
             let fallback = rk3588_emmc_pinctrl_symbol_paths();

--- a/drivers/ax-driver/src/pci/fdt/rk3588/resources.rs
+++ b/drivers/ax-driver/src/pci/fdt/rk3588/resources.rs
@@ -14,6 +14,7 @@ use fdt_edit::{Node, PciRange, Phandle, RegFixed};
 use log::{info, warn};
 use mmio_api::{MmioAddr, MmioRaw};
 use rdif_pcie::PcieController;
+use rdif_pinctrl::{FdtPinctrl, PinctrlDevice};
 use rdrive::{
     probe::{OnProbeError, fdt::NodeType},
     register::{FdtInfo, ProbeFdt},
@@ -31,7 +32,7 @@ use super::{
         log_resource_summary, program_memory_windows, prop_phandle, set_rk3588_bar_range,
     },
 };
-use crate::soc::{RockchipPinCtrl, rk3588_enable_power_domain};
+use crate::soc::{RockchipFdtPinctrlParser, rk3588_enable_power_domain};
 
 pub(super) const RK3588_GPIO_BASES: [u64; 5] = [
     0xfd8a_0000,
@@ -395,12 +396,27 @@ fn enable_vpcie3v3_supply(supply: Option<Phandle>) -> Result<(), OnProbeError> {
     let Some(supply) = supply else {
         return Ok(());
     };
-    let pinctrl = rdrive::get_one::<RockchipPinCtrl>()
-        .ok_or_else(|| OnProbeError::other("RockchipPinCtrl not found for PCIe regulator"))?;
+    let fdt = live_fdt()?;
+    let regulator = fdt.get_by_phandle(supply).ok_or_else(|| {
+        OnProbeError::other(format!("PCIe regulator phandle {supply:?} not found"))
+    })?;
+    let pinctrl = rdrive::get_one::<PinctrlDevice>()
+        .ok_or_else(|| OnProbeError::other("PinctrlDevice not found for PCIe regulator"))?;
     let mut pinctrl = pinctrl
         .lock()
-        .map_err(|err| OnProbeError::other(format!("failed to lock RockchipPinCtrl: {err}")))?;
-    pinctrl.enable_fixed_regulator(supply)
+        .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
+    FdtPinctrl::apply_fixed_regulator(
+        &mut *pinctrl,
+        &fdt,
+        regulator.as_node(),
+        &RockchipFdtPinctrlParser,
+        "rk3588-pcie-regulator",
+    )
+    .map_err(|err| {
+        OnProbeError::other(format!(
+            "failed to enable PCIe regulator via pinctrl: {err}"
+        ))
+    })
 }
 
 fn parse_host_resources<'a>(

--- a/drivers/ax-driver/src/soc/mod.rs
+++ b/drivers/ax-driver/src/soc/mod.rs
@@ -21,8 +21,8 @@ mod sg2002;
 
 #[cfg(feature = "rockchip-soc")]
 pub use rockchip::{
-    RockchipPinCtrl, rk3588_enable_clock, rk3588_enable_power_domain, rk3588_reset_assert,
-    rk3588_reset_deassert, rk3588_set_clock_rate,
+    RockchipFdtPinctrlParser, RockchipPinCtrl, rk3588_enable_clock, rk3588_enable_power_domain,
+    rk3588_reset_assert, rk3588_reset_deassert, rk3588_set_clock_rate,
 };
 
 #[cfg(not(feature = "rockchip-soc"))]
@@ -48,6 +48,9 @@ pub fn rk3588_enable_power_domain(domain: usize) -> Result<(), alloc::string::St
 
 #[cfg(not(feature = "rockchip-soc"))]
 pub struct RockchipPinCtrl;
+
+#[cfg(not(feature = "rockchip-soc"))]
+pub struct RockchipFdtPinctrlParser;
 
 #[cfg(not(feature = "rockchip-soc"))]
 impl rdrive::DriverGeneric for RockchipPinCtrl {

--- a/drivers/ax-driver/src/soc/rockchip/mod.rs
+++ b/drivers/ax-driver/src/soc/rockchip/mod.rs
@@ -26,7 +26,7 @@ pub use clk::{
     rk3588_enable_clock, rk3588_reset_assert, rk3588_reset_deassert, rk3588_set_clock_rate,
 };
 #[cfg(feature = "rockchip-soc")]
-pub use pinctrl::RockchipPinCtrl;
+pub use pinctrl::{RockchipFdtPinctrlParser, RockchipPinCtrl};
 #[cfg(all(feature = "rockchip-soc", feature = "rockchip-pm"))]
 pub use pm::rk3588_enable_power_domain;
 

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
@@ -20,6 +20,7 @@ use crate::mmio::iomap;
 
 mod rdif_glue;
 
+use rdif_glue::ROCKCHIP_PIN_CONFIG_DRIVE_RAW;
 pub use rdif_glue::RockchipFdtPinctrlParser;
 
 const DRIVER_NAME: &str = "rk3588-pinctrl";
@@ -235,7 +236,9 @@ impl RdifPinctrl for RockchipPinCtrl {
                     .set_config(config)
                     .map_err(|_| RdifPinctrlError::InvalidConfig)
             }
-            rdif_pinctrl::PinConfig::DriveStrengthUa(value) => {
+            rdif_pinctrl::PinConfig::Vendor { param, value }
+                if param == ROCKCHIP_PIN_CONFIG_DRIVE_RAW =>
+            {
                 let mut config = self.current_or_default_config(pin);
                 config.drive = Some(value);
                 self.inner
@@ -257,6 +260,7 @@ impl RdifPinctrl for RockchipPinCtrl {
                 .write_gpio(pin, value)
                 .map_err(|_| RdifPinctrlError::InvalidConfig),
             rdif_pinctrl::PinConfig::InputEnable(false)
+            | rdif_pinctrl::PinConfig::DriveStrengthUa(_)
             | rdif_pinctrl::PinConfig::OutputEnable(false)
             | rdif_pinctrl::PinConfig::SlewRate(_)
             | rdif_pinctrl::PinConfig::DebounceUs(_)

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
@@ -1,19 +1,37 @@
 extern crate alloc;
 
-use alloc::{format, string::ToString, vec, vec::Vec};
+use alloc::{format, string::ToString, vec::Vec};
 use core::ptr::NonNull;
 
-use fdt_edit::{Fdt, Node, NodeType, Phandle, RegFixed};
-use log::{info, warn};
+use fdt_edit::{Fdt, NodeType, Phandle, RegFixed};
+use log::info;
+use rdif_pinctrl::{
+    Bias, ConfigSetting, ConfigTarget, FdtPinctrl, FdtPinctrlParser, FunctionId, GpioBankId,
+    GpioRange, GroupId, Interface as RdifPinctrl, MuxSetting, PinId as RdifPinId, PinState,
+    PinctrlDevice, PinctrlError as RdifPinctrlError, StateName,
+};
 use rdrive::{DriverGeneric, probe::OnProbeError, register::ProbeFdt};
 use rockchip_soc::{
-    BankId, GpioDirection, Iomux, PinConfig, PinCtrl, PinCtrlOp, PinId, Pull, SocType,
+    GpioDirection, Iomux, PinConfig as RockchipPinConfig, PinCtrl, PinCtrlOp,
+    PinId as RockchipPinId, Pull, SocType,
 };
 
 use crate::mmio::iomap;
 
+mod rdif_glue;
+
+pub use rdif_glue::RockchipFdtPinctrlParser;
+
 const DRIVER_NAME: &str = "rk3588-pinctrl";
 const GPIO_BANK_COUNT: usize = 5;
+const GPIO_LINES_PER_BANK: u32 = 32;
+const ROCKCHIP_GPIO_RANGES: [GpioRange; GPIO_BANK_COUNT] = [
+    GpioRange::new(GpioBankId::new(0), 0, 0, GPIO_LINES_PER_BANK),
+    GpioRange::new(GpioBankId::new(1), 32, 0, GPIO_LINES_PER_BANK),
+    GpioRange::new(GpioBankId::new(2), 64, 0, GPIO_LINES_PER_BANK),
+    GpioRange::new(GpioBankId::new(3), 96, 0, GPIO_LINES_PER_BANK),
+    GpioRange::new(GpioBankId::new(4), 128, 0, GPIO_LINES_PER_BANK),
+];
 
 crate::model_register!(
     name: "Rockchip PinCtrl",
@@ -41,7 +59,7 @@ impl RockchipPinCtrl {
     pub fn apply_default_pinctrl(
         &mut self,
         node: NodeType<'_>,
-    ) -> Result<Vec<PinId>, OnProbeError> {
+    ) -> Result<Vec<RockchipPinId>, OnProbeError> {
         let node_name = node.name().to_string();
         let Some(prop) = node.as_node().get_property("pinctrl-0") else {
             info!("Rockchip node {node_name} has no default pinctrl");
@@ -65,50 +83,18 @@ impl RockchipPinCtrl {
             OnProbeError::other(format!("regulator phandle {phandle:?} not found"))
         })?;
         let node_name = node.name().to_string();
-        let active_value = fixed_regulator_active_value(node.as_node());
-        let gpio_active_low = gpio_active_low(node.as_node());
-        let drive_value = if gpio_active_low {
-            !active_value
-        } else {
-            active_value
-        };
-        let pins = if let Some(gpio) = parse_gpio_pin(&fdt, node.as_node(), "gpios")
-            .or_else(|| parse_gpio_pin(&fdt, node.as_node(), "gpio"))
-        {
-            vec![gpio?]
-        } else {
-            let pinctrls = node
-                .as_node()
-                .get_property("pinctrl-0")
-                .ok_or_else(|| OnProbeError::other(format!("[{node_name}] has no enable GPIO")))?
-                .get_u32_iter()
-                .map(Phandle::from)
-                .collect::<Vec<_>>();
-
-            let mut pins = Vec::new();
-            for pinctrl in pinctrls {
-                pins.extend(self.apply_pinctrl_phandle(pinctrl)?);
-            }
-            if pins.is_empty() {
-                return Err(OnProbeError::other(format!(
-                    "[{node_name}] pinctrl-0 did not configure any GPIO"
-                )));
-            }
-            pins
-        };
-
-        for pin in pins {
-            self.inner
-                .set_gpio_direction(pin, GpioDirection::Output(drive_value))
-                .map_err(|err| {
-                    OnProbeError::other(format!(
-                        "failed to set [{node_name}] GPIO {pin:?} direction: {err}"
-                    ))
-                })?;
-            self.inner.write_gpio(pin, drive_value).map_err(|err| {
-                OnProbeError::other(format!("failed to drive [{node_name}] GPIO {pin:?}: {err}"))
-            })?;
-        }
+        FdtPinctrl::apply_fixed_regulator(
+            self,
+            &fdt,
+            node.as_node(),
+            &RockchipFdtPinctrlParser,
+            "rockchip-fixed-regulator",
+        )
+        .map_err(|err| {
+            OnProbeError::other(format!(
+                "failed to apply fixed regulator [{node_name}] via RDIF pinctrl: {err}"
+            ))
+        })?;
 
         let startup_delay_us = node
             .as_node()
@@ -125,7 +111,7 @@ impl RockchipPinCtrl {
         Ok(())
     }
 
-    pub fn apply_pinctrl_path(&mut self, path: &str) -> Result<Vec<PinId>, OnProbeError> {
+    pub fn apply_pinctrl_path(&mut self, path: &str) -> Result<Vec<RockchipPinId>, OnProbeError> {
         let fdt = live_fdt()?;
         let node = fdt
             .get_by_path(path)
@@ -133,7 +119,10 @@ impl RockchipPinCtrl {
         self.apply_pinctrl_node(node)
     }
 
-    fn apply_pinctrl_phandle(&mut self, phandle: Phandle) -> Result<Vec<PinId>, OnProbeError> {
+    fn apply_pinctrl_phandle(
+        &mut self,
+        phandle: Phandle,
+    ) -> Result<Vec<RockchipPinId>, OnProbeError> {
         let fdt = live_fdt()?;
         let node = fdt
             .get_by_phandle(phandle)
@@ -141,34 +130,26 @@ impl RockchipPinCtrl {
         self.apply_pinctrl_node(node)
     }
 
-    fn apply_pinctrl_node(&mut self, node: NodeType<'_>) -> Result<Vec<PinId>, OnProbeError> {
-        let pins = node
-            .as_node()
-            .get_property("rockchip,pins")
-            .ok_or_else(|| OnProbeError::other(format!("[{}] has no rockchip,pins", node.name())))?
-            .get_u32_iter()
-            .collect::<Vec<_>>();
-        if pins.len() % 4 != 0 {
-            return Err(OnProbeError::other(format!(
-                "[{}] has malformed rockchip,pins with {} cells",
-                node.name(),
-                pins.len()
-            )));
-        }
-
-        let mut configured = Vec::new();
-        for cells in pins.chunks(4) {
-            let config = pin_config_from_cells(cells)?;
-            let pin = config.id;
-            self.inner.set_config(config).map_err(|err| {
+    fn apply_pinctrl_node(
+        &mut self,
+        node: NodeType<'_>,
+    ) -> Result<Vec<RockchipPinId>, OnProbeError> {
+        let node_name = node.name().to_string();
+        let fdt = live_fdt()?;
+        let mut state = PinState::named(StateName::Named(node_name.clone()));
+        RockchipFdtPinctrlParser
+            .parse_pinctrl_node(&fdt, node, &mut state)
+            .map_err(|err| {
                 OnProbeError::other(format!(
-                    "failed to apply pinctrl [{}] pin {pin:?}: {err}",
-                    node.name()
+                    "failed to parse Rockchip pinctrl [{node_name}]: {err}"
                 ))
             })?;
-            configured.push(pin);
-        }
-
+        let configured = rockchip_pins_from_state(&state)?;
+        self.apply_state(&state).map_err(|err| {
+            OnProbeError::other(format!(
+                "failed to apply Rockchip pinctrl [{node_name}]: {err}"
+            ))
+        })?;
         Ok(configured)
     }
 }
@@ -176,6 +157,123 @@ impl RockchipPinCtrl {
 impl DriverGeneric for RockchipPinCtrl {
     fn name(&self) -> &str {
         DRIVER_NAME
+    }
+
+    fn raw_any(&self) -> Option<&dyn core::any::Any> {
+        Some(self)
+    }
+
+    fn raw_any_mut(&mut self) -> Option<&mut dyn core::any::Any> {
+        Some(self)
+    }
+}
+
+impl RdifPinctrl for RockchipPinCtrl {
+    fn gpio_ranges(&self) -> &[GpioRange] {
+        &ROCKCHIP_GPIO_RANGES
+    }
+
+    fn can_mux(&self, group: GroupId, function: FunctionId) -> bool {
+        rockchip_pin_id(group.raw()).is_ok() && function.raw() <= 0xff
+    }
+
+    fn validate_state(&self, state: &PinState) -> Result<(), RdifPinctrlError> {
+        for mux in state.muxes() {
+            if rockchip_pin_id(mux.group.raw()).is_err() {
+                return Err(RdifPinctrlError::InvalidGroup(mux.group));
+            }
+            if !self.can_mux(mux.group, mux.function) {
+                return Err(RdifPinctrlError::InvalidMux {
+                    group: mux.group,
+                    function: mux.function,
+                });
+            }
+        }
+
+        for config in state.configs() {
+            match config.target {
+                ConfigTarget::Pin(pin) => {
+                    if rockchip_pin_id(pin.raw()).is_err() {
+                        return Err(RdifPinctrlError::InvalidPin(pin));
+                    }
+                }
+                ConfigTarget::Group(group) => {
+                    if rockchip_pin_id(group.raw()).is_err() {
+                        return Err(RdifPinctrlError::InvalidGroup(group));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_mux(&mut self, setting: &MuxSetting) -> Result<(), RdifPinctrlError> {
+        let pin = rockchip_pin_id(setting.group.raw())?;
+        let mut config = self.inner.get_config(pin).unwrap_or(RockchipPinConfig {
+            id: pin,
+            mux: Iomux::from_bits_truncate(0),
+            pull: Pull::Disabled,
+            drive: None,
+        });
+        config.mux = Iomux::from_bits_truncate(setting.value.raw() as u8);
+        self.inner
+            .set_config(config)
+            .map_err(|_| RdifPinctrlError::InvalidConfig)
+    }
+
+    fn apply_config(&mut self, setting: &ConfigSetting) -> Result<(), RdifPinctrlError> {
+        let pin = match setting.target {
+            ConfigTarget::Pin(pin) => rockchip_pin_id(pin.raw())?,
+            ConfigTarget::Group(group) => rockchip_pin_id(group.raw())?,
+        };
+
+        match setting.config {
+            rdif_pinctrl::PinConfig::Bias(bias) => {
+                let mut config = self.current_or_default_config(pin);
+                config.pull = rockchip_pull_from_rdif_bias(bias);
+                self.inner
+                    .set_config(config)
+                    .map_err(|_| RdifPinctrlError::InvalidConfig)
+            }
+            rdif_pinctrl::PinConfig::DriveStrengthUa(value) => {
+                let mut config = self.current_or_default_config(pin);
+                config.drive = Some(value);
+                self.inner
+                    .set_config(config)
+                    .map_err(|_| RdifPinctrlError::InvalidConfig)
+            }
+            rdif_pinctrl::PinConfig::InputEnable(true) => self
+                .inner
+                .set_gpio_direction(pin, GpioDirection::Input)
+                .map_err(|_| RdifPinctrlError::InvalidConfig),
+            rdif_pinctrl::PinConfig::OutputEnable(true) => {
+                let value = self.inner.read_gpio(pin).unwrap_or(false);
+                self.inner
+                    .set_gpio_direction(pin, GpioDirection::Output(value))
+                    .map_err(|_| RdifPinctrlError::InvalidConfig)
+            }
+            rdif_pinctrl::PinConfig::OutputValue(value) => self
+                .inner
+                .write_gpio(pin, value)
+                .map_err(|_| RdifPinctrlError::InvalidConfig),
+            rdif_pinctrl::PinConfig::InputEnable(false)
+            | rdif_pinctrl::PinConfig::OutputEnable(false)
+            | rdif_pinctrl::PinConfig::SlewRate(_)
+            | rdif_pinctrl::PinConfig::DebounceUs(_)
+            | rdif_pinctrl::PinConfig::LowPowerMode(_)
+            | rdif_pinctrl::PinConfig::Vendor { .. } => Err(RdifPinctrlError::NotSupported),
+        }
+    }
+}
+
+impl RockchipPinCtrl {
+    fn current_or_default_config(&self, pin: RockchipPinId) -> RockchipPinConfig {
+        self.inner.get_config(pin).unwrap_or(RockchipPinConfig {
+            id: pin,
+            mux: Iomux::from_bits_truncate(0),
+            pull: Pull::Disabled,
+            drive: None,
+        })
     }
 }
 
@@ -209,7 +307,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     }
 
     let pinctrl = PinCtrl::new(SocType::Rk3588, ioc, &gpio_banks);
-    plat_dev.register(RockchipPinCtrl::new(pinctrl));
+    plat_dev.register(PinctrlDevice::new(RockchipPinCtrl::new(pinctrl)));
     info!("Rockchip RK3588 pinctrl registered successfully");
     Ok(())
 }
@@ -241,123 +339,32 @@ fn map_reg(reg: RegFixed) -> Result<NonNull<u8>, OnProbeError> {
     iomap(reg.address as usize, size)
 }
 
-fn fixed_regulator_active_value(node: &Node) -> bool {
-    node.get_property("enable-active-low").is_none()
+fn rockchip_pin_id(raw_pin: u32) -> Result<RockchipPinId, RdifPinctrlError> {
+    RockchipPinId::new(raw_pin).ok_or_else(|| RdifPinctrlError::InvalidPin(RdifPinId::new(raw_pin)))
 }
 
-fn gpio_active_low(node: &Node) -> bool {
-    node.get_property("gpios")
-        .or_else(|| node.get_property("gpio"))
-        .and_then(|prop| prop.get_u32_iter().nth(2))
-        .is_some_and(|flags| flags & 1 != 0)
-}
-
-fn parse_gpio_pin(fdt: &Fdt, node: &Node, prop_name: &str) -> Option<Result<PinId, OnProbeError>> {
-    let prop = node.get_property(prop_name)?;
-    Some((|| {
-        let mut cells = prop.get_u32_iter();
-        let phandle = Phandle::from(cells.next().ok_or_else(|| {
-            OnProbeError::other(format!("[{}] has malformed {prop_name}", node.name()))
-        })?);
-        let pin = cells.next().ok_or_else(|| {
-            OnProbeError::other(format!("[{}] has malformed {prop_name}", node.name()))
-        })?;
-        let gpio = fdt.get_by_phandle(phandle).ok_or_else(|| {
-            OnProbeError::other(format!(
-                "[{}] {prop_name} GPIO phandle {phandle:?} not found",
-                node.name()
-            ))
-        })?;
-        let bank = gpio_bank_index(gpio.as_node()).ok_or_else(|| {
-            OnProbeError::other(format!(
-                "[{}] cannot resolve GPIO bank for {prop_name} phandle {phandle:?}",
-                node.name()
-            ))
-        })?;
-        PinId::from_bank_pin(BankId::new(bank).unwrap_or(BankId::from(bank)), pin).ok_or_else(
-            || {
+fn rockchip_pins_from_state(state: &PinState) -> Result<Vec<RockchipPinId>, OnProbeError> {
+    state
+        .muxes()
+        .iter()
+        .map(|mux| {
+            rockchip_pin_id(mux.group.raw()).map_err(|err| {
                 OnProbeError::other(format!(
-                    "[{}] invalid GPIO bank {bank} pin {pin}",
-                    node.name()
+                    "Rockchip pinctrl state contains invalid pin {:?}: {err}",
+                    mux.group
                 ))
-            },
-        )
-    })())
+            })
+        })
+        .collect()
 }
 
-fn pin_config_from_cells(cells: &[u32]) -> Result<PinConfig, OnProbeError> {
-    let [bank, pin, mux, conf_phandle] = cells else {
-        return Err(OnProbeError::other("malformed rockchip,pins cells"));
-    };
-    let id = PinId::from_bank_pin(BankId::new(*bank).unwrap_or(BankId::from(*bank)), *pin)
-        .ok_or_else(|| OnProbeError::other(format!("invalid Rockchip pin {bank}:{pin}")))?;
-    let fdt = live_fdt()?;
-    let conf = fdt
-        .get_by_phandle(Phandle::from(*conf_phandle))
-        .ok_or_else(|| {
-            OnProbeError::other(format!("pinconf phandle {conf_phandle:?} not found"))
-        })?;
-    let mut pull = Pull::Disabled;
-    let mut drive = None;
-    for prop in conf.as_node().properties() {
-        match prop.name() {
-            "bias-disable" => pull = Pull::Disabled,
-            "bias-bus-hold" => pull = Pull::BusHold,
-            "bias-pull-up" => pull = Pull::PullUp,
-            "bias-pull-down" => pull = Pull::PullDown,
-            "bias-pull-pin-default" => pull = Pull::PullPinDefault,
-            "drive-strength" => drive = prop.get_u32(),
-            "phandle" => {}
-            name => warn!("Unknown pinconf property: {}", name),
-        }
-    }
-    Ok(PinConfig {
-        id,
-        mux: Iomux::from_bits_truncate(*mux as u8),
-        pull,
-        drive,
-    })
-}
-
-fn gpio_bank_index(node: &Node) -> Option<u32> {
-    let name = node.name();
-    if let Some(name) = name
-        .strip_prefix("gpio")
-        .filter(|name| !name.starts_with('@'))
-        && let Some(bank) = name
-            .chars()
-            .next()
-            .and_then(|ch| ch.to_digit(10))
-            .filter(|bank| *bank < GPIO_BANK_COUNT as u32)
-    {
-        return Some(bank);
-    }
-
-    let address = gpio_bank_address(node)?;
-    match address {
-        0xfd8a_0000 => Some(0),
-        0xfec2_0000 => Some(1),
-        0xfec3_0000 => Some(2),
-        0xfec4_0000 => Some(3),
-        0xfec5_0000 => Some(4),
-        _ => None,
-    }
-}
-
-fn gpio_bank_address(node: &Node) -> Option<u64> {
-    if let Some(address) = node
-        .name()
-        .split_once('@')
-        .and_then(|(_, unit)| u64::from_str_radix(unit, 16).ok())
-    {
-        return Some(address);
-    }
-
-    let reg = node.get_property("reg")?.get_u32_iter().collect::<Vec<_>>();
-    match reg.as_slice() {
-        [addr] => Some(u64::from(*addr)),
-        cells if cells.len() >= 2 => Some((u64::from(cells[0]) << 32) | u64::from(cells[1])),
-        _ => None,
+fn rockchip_pull_from_rdif_bias(bias: Bias) -> Pull {
+    match bias {
+        Bias::Disabled => Pull::Disabled,
+        Bias::BusHold => Pull::BusHold,
+        Bias::PullUp => Pull::PullUp,
+        Bias::PullDown => Pull::PullDown,
+        Bias::PullPinDefault => Pull::PullPinDefault,
     }
 }
 

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl/rdif_glue.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl/rdif_glue.rs
@@ -14,6 +14,8 @@ use super::{GPIO_BANK_COUNT, GPIO_LINES_PER_BANK};
 
 pub struct RockchipFdtPinctrlParser;
 
+pub(super) const ROCKCHIP_PIN_CONFIG_DRIVE_RAW: u32 = 1;
+
 impl FdtPinctrlParser for RockchipFdtPinctrlParser {
     fn parse_pinctrl_node(
         &self,
@@ -152,7 +154,10 @@ fn append_rockchip_node_to_state(
         if let Some(drive) = config.drive {
             state.push_config(ConfigSetting::pin(
                 RdifPinId::new(raw_pin),
-                RdifPinConfig::DriveStrengthUa(drive),
+                RdifPinConfig::Vendor {
+                    param: ROCKCHIP_PIN_CONFIG_DRIVE_RAW,
+                    value: drive,
+                },
             ));
         }
     }
@@ -368,7 +373,10 @@ mod tests {
         )));
         assert!(state.configs().contains(&ConfigSetting::pin(
             RdifPinId::new(34),
-            RdifPinConfig::DriveStrengthUa(8000)
+            RdifPinConfig::Vendor {
+                param: ROCKCHIP_PIN_CONFIG_DRIVE_RAW,
+                value: 8000,
+            }
         )));
     }
 

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl/rdif_glue.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl/rdif_glue.rs
@@ -1,0 +1,532 @@
+extern crate alloc;
+
+use alloc::{format, vec::Vec};
+
+use fdt_edit::{Fdt, Node, NodeType, Phandle};
+use log::warn;
+use rdif_pinctrl::{
+    Bias, ConfigSetting, FdtPinctrlParser, FunctionId, GpioBankId, GpioLineId, GroupId, MuxSetting,
+    MuxValue, PinConfig as RdifPinConfig, PinId as RdifPinId, PinState, PinctrlError,
+};
+use rockchip_soc::{BankId, Iomux, PinConfig as RockchipPinConfig, PinId as RockchipPinId, Pull};
+
+use super::{GPIO_BANK_COUNT, GPIO_LINES_PER_BANK};
+
+pub struct RockchipFdtPinctrlParser;
+
+impl FdtPinctrlParser for RockchipFdtPinctrlParser {
+    fn parse_pinctrl_node(
+        &self,
+        fdt: &Fdt,
+        node: NodeType<'_>,
+        state: &mut PinState,
+    ) -> Result<(), PinctrlError> {
+        append_rockchip_node_to_state(fdt, node, state)
+    }
+
+    fn parse_gpio_line(
+        &self,
+        fdt: &Fdt,
+        node: &Node,
+        prop_name: &str,
+    ) -> Option<Result<GpioLineId, PinctrlError>> {
+        parse_gpio_line(fdt, node, prop_name)
+    }
+
+    fn gpio_lines_from_state(&self, state: &PinState) -> Result<Vec<GpioLineId>, PinctrlError> {
+        state
+            .muxes()
+            .iter()
+            .map(|mux| rdif_gpio_line_from_raw_pin(mux.group.raw()))
+            .collect()
+    }
+}
+
+fn parse_gpio_line(
+    fdt: &Fdt,
+    node: &Node,
+    prop_name: &str,
+) -> Option<Result<GpioLineId, PinctrlError>> {
+    let prop = node.get_property(prop_name)?;
+    Some((|| {
+        let mut cells = prop.get_u32_iter();
+        let phandle = Phandle::from(cells.next().ok_or_else(|| {
+            PinctrlError::other(format!("[{}] has malformed {prop_name}", node.name()))
+        })?);
+        let pin = cells.next().ok_or_else(|| {
+            PinctrlError::other(format!("[{}] has malformed {prop_name}", node.name()))
+        })?;
+        let gpio = fdt.get_by_phandle(phandle).ok_or_else(|| {
+            PinctrlError::other(format!(
+                "[{}] {prop_name} GPIO phandle {phandle:?} not found",
+                node.name()
+            ))
+        })?;
+        let bank = gpio_bank_index(gpio.as_node()).ok_or_else(|| {
+            PinctrlError::other(format!(
+                "[{}] cannot resolve GPIO bank for {prop_name} phandle {phandle:?}",
+                node.name()
+            ))
+        })?;
+        if bank >= GPIO_BANK_COUNT as u32 || pin >= GPIO_LINES_PER_BANK {
+            return Err(PinctrlError::other(format!(
+                "[{}] invalid GPIO bank {bank} pin {pin}",
+                node.name()
+            )));
+        }
+        Ok(GpioLineId::new(GpioBankId::new(bank), pin))
+    })())
+}
+
+fn pin_config_from_cells_with_fdt(
+    fdt: &Fdt,
+    cells: &[u32],
+) -> Result<RockchipPinConfig, PinctrlError> {
+    let [bank, pin, mux, conf_phandle] = cells else {
+        return Err(PinctrlError::other("malformed rockchip,pins cells"));
+    };
+    let id = RockchipPinId::from_bank_pin(BankId::new(*bank).unwrap_or(BankId::from(*bank)), *pin)
+        .ok_or_else(|| PinctrlError::other(format!("invalid Rockchip pin {bank}:{pin}")))?;
+    let conf = fdt
+        .get_by_phandle(Phandle::from(*conf_phandle))
+        .ok_or_else(|| {
+            PinctrlError::other(format!("pinconf phandle {conf_phandle:?} not found"))
+        })?;
+    let mut pull = Pull::Disabled;
+    let mut drive = None;
+    for prop in conf.as_node().properties() {
+        match prop.name() {
+            "bias-disable" => pull = Pull::Disabled,
+            "bias-bus-hold" => pull = Pull::BusHold,
+            "bias-pull-up" => pull = Pull::PullUp,
+            "bias-pull-down" => pull = Pull::PullDown,
+            "bias-pull-pin-default" => pull = Pull::PullPinDefault,
+            "drive-strength" => drive = prop.get_u32(),
+            "phandle" => {}
+            name => warn!("Unknown pinconf property: {}", name),
+        }
+    }
+    Ok(RockchipPinConfig {
+        id,
+        mux: Iomux::from_bits_truncate(*mux as u8),
+        pull,
+        drive,
+    })
+}
+
+fn append_rockchip_node_to_state(
+    fdt: &Fdt,
+    node: NodeType<'_>,
+    state: &mut PinState,
+) -> Result<(), PinctrlError> {
+    let pins = node
+        .as_node()
+        .get_property("rockchip,pins")
+        .ok_or_else(|| PinctrlError::other(format!("[{}] has no rockchip,pins", node.name())))?
+        .get_u32_iter()
+        .collect::<Vec<_>>();
+    if pins.len() % 4 != 0 {
+        return Err(PinctrlError::other(format!(
+            "[{}] has malformed rockchip,pins with {} cells",
+            node.name(),
+            pins.len()
+        )));
+    }
+
+    for cells in pins.chunks(4) {
+        let [bank, pin, mux, _conf_phandle] = cells else {
+            unreachable!("chunks were prevalidated");
+        };
+        let raw_pin = rockchip_raw_pin(*bank, *pin)?;
+        let config = pin_config_from_cells_with_fdt(fdt, cells)?;
+        let group = GroupId::new(raw_pin);
+        state.push_mux(MuxSetting::new(
+            group,
+            FunctionId::new(*mux),
+            MuxValue::new(*mux),
+        ));
+        state.push_config(ConfigSetting::pin(
+            RdifPinId::new(raw_pin),
+            RdifPinConfig::Bias(rdif_bias_from_rockchip_pull(config.pull)),
+        ));
+        if let Some(drive) = config.drive {
+            state.push_config(ConfigSetting::pin(
+                RdifPinId::new(raw_pin),
+                RdifPinConfig::DriveStrengthUa(drive),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn rockchip_raw_pin(bank: u32, pin: u32) -> Result<u32, PinctrlError> {
+    if bank >= GPIO_BANK_COUNT as u32 || pin >= GPIO_LINES_PER_BANK {
+        return Err(PinctrlError::other(format!(
+            "invalid Rockchip pin {bank}:{pin}"
+        )));
+    }
+    Ok(bank * GPIO_LINES_PER_BANK + pin)
+}
+
+fn rdif_gpio_line_from_raw_pin(raw_pin: u32) -> Result<GpioLineId, PinctrlError> {
+    let bank = raw_pin / GPIO_LINES_PER_BANK;
+    let offset = raw_pin % GPIO_LINES_PER_BANK;
+    if bank >= GPIO_BANK_COUNT as u32 {
+        return Err(PinctrlError::other(format!(
+            "invalid Rockchip raw GPIO pin {raw_pin}"
+        )));
+    }
+    Ok(GpioLineId::new(GpioBankId::new(bank), offset))
+}
+
+fn rdif_bias_from_rockchip_pull(pull: Pull) -> Bias {
+    match pull {
+        Pull::Disabled => Bias::Disabled,
+        Pull::BusHold => Bias::BusHold,
+        Pull::PullUp => Bias::PullUp,
+        Pull::PullDown => Bias::PullDown,
+        Pull::PullPinDefault => Bias::PullPinDefault,
+    }
+}
+
+fn gpio_bank_index(node: &Node) -> Option<u32> {
+    let name = node.name();
+    if let Some(name) = name
+        .strip_prefix("gpio")
+        .filter(|name| !name.starts_with('@'))
+        && let Some(bank) = name
+            .chars()
+            .next()
+            .and_then(|ch| ch.to_digit(10))
+            .filter(|bank| *bank < GPIO_BANK_COUNT as u32)
+    {
+        return Some(bank);
+    }
+
+    let address = gpio_bank_address(node)?;
+    match address {
+        0xfd8a_0000 => Some(0),
+        0xfec2_0000 => Some(1),
+        0xfec3_0000 => Some(2),
+        0xfec4_0000 => Some(3),
+        0xfec5_0000 => Some(4),
+        _ => None,
+    }
+}
+
+fn gpio_bank_address(node: &Node) -> Option<u64> {
+    if let Some(address) = node
+        .name()
+        .split_once('@')
+        .and_then(|(_, unit)| u64::from_str_radix(unit, 16).ok())
+    {
+        return Some(address);
+    }
+
+    let reg = node.get_property("reg")?.get_u32_iter().collect::<Vec<_>>();
+    match reg.as_slice() {
+        [addr] => Some(u64::from(*addr)),
+        cells if cells.len() >= 2 => Some((u64::from(cells[0]) << 32) | u64::from(cells[1])),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    #[cfg(not(feature = "pci"))]
+    use axklib::{
+        AxError, AxResult, IrqCpuMask, IrqHandle, IrqId, Klib, PhysAddr, RawIrqHandler, VirtAddr,
+        impl_trait,
+    };
+    use fdt_edit::{Node, Property};
+    use rdif_pinctrl::{FdtPinctrl, StateName};
+
+    use super::*;
+
+    #[cfg(not(feature = "pci"))]
+    struct KlibImpl;
+
+    #[cfg(not(feature = "pci"))]
+    impl_trait! {
+        impl Klib for KlibImpl {
+            fn mem_iomap(_addr: PhysAddr, _size: usize) -> AxResult<VirtAddr> {
+                Err(AxError::Unsupported)
+            }
+
+            fn mem_virt_to_phys(addr: VirtAddr) -> PhysAddr {
+                PhysAddr::from_usize(addr.as_usize())
+            }
+
+            fn mem_make_dma_coherent_uncached(_addr: VirtAddr, _size: usize) -> AxResult {
+                Err(AxError::Unsupported)
+            }
+
+            fn mem_restore_dma_cached(_addr: VirtAddr, _size: usize) -> AxResult {
+                Err(AxError::Unsupported)
+            }
+
+            fn dma_alloc_pages(
+                _dma_mask: u64,
+                _num_pages: usize,
+                _align: usize,
+            ) -> AxResult<VirtAddr> {
+                Err(AxError::Unsupported)
+            }
+
+            fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+
+            fn time_busy_wait(_dur: core::time::Duration) {}
+
+            fn time_monotonic_nanos() -> u64 {
+                0
+            }
+
+            fn time_try_init_epoch_offset(_epoch_time_nanos: u64) -> bool {
+                false
+            }
+
+            fn irq_set_enable(_irq: IrqId, _enabled: bool) -> axklib::AxResult {
+                Ok(())
+            }
+
+            fn irq_request_shared(
+                _irq: IrqId,
+                _handler: RawIrqHandler,
+                _data: core::ptr::NonNull<()>,
+            ) -> AxResult<IrqHandle> {
+                Err(AxError::Unsupported)
+            }
+
+            fn irq_request_shared_disabled(
+                _irq: IrqId,
+                _handler: RawIrqHandler,
+                _data: core::ptr::NonNull<()>,
+            ) -> AxResult<IrqHandle> {
+                Err(AxError::Unsupported)
+            }
+
+            fn irq_request_percpu(
+                _irq: IrqId,
+                _cpus: IrqCpuMask,
+                _handler: RawIrqHandler,
+                _data: core::ptr::NonNull<()>,
+            ) -> AxResult<IrqHandle> {
+                Err(AxError::Unsupported)
+            }
+
+            fn irq_free(_handle: IrqHandle) -> axklib::AxResult {
+                Ok(())
+            }
+
+            fn irq_enable(_handle: IrqHandle) -> axklib::AxResult {
+                Ok(())
+            }
+
+            fn irq_disable(_handle: IrqHandle) -> axklib::AxResult {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn rockchip_pins_state_preserves_raw_mux_value() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            conf_node("pcfg-pull-up", 10, &["bias-pull-up"], Some(8000)),
+        );
+        fdt.add_node(
+            root,
+            node_with_props(
+                "uart0-pins",
+                &[
+                    prop_u32s("phandle", &[20]),
+                    prop_u32s("rockchip,pins", &[1, 2, 5, 10]),
+                ],
+            ),
+        );
+
+        let mut state = PinState::named(StateName::Default);
+        RockchipFdtPinctrlParser
+            .parse_pinctrl_node(
+                &fdt,
+                fdt.get_by_phandle(Phandle::from(20)).unwrap(),
+                &mut state,
+            )
+            .unwrap();
+
+        assert_eq!(state.muxes().len(), 1);
+        assert_eq!(state.muxes()[0].group, GroupId::new(34));
+        assert_eq!(state.muxes()[0].function, FunctionId::new(5));
+        assert_eq!(state.muxes()[0].value.raw(), 5);
+        assert!(state.configs().contains(&ConfigSetting::pin(
+            RdifPinId::new(34),
+            RdifPinConfig::Bias(Bias::PullUp)
+        )));
+        assert!(state.configs().contains(&ConfigSetting::pin(
+            RdifPinId::new(34),
+            RdifPinConfig::DriveStrengthUa(8000)
+        )));
+    }
+
+    #[test]
+    fn pinctrl_0_multiple_phandles_merge_into_one_state() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            conf_node("pcfg-disabled", 10, &["bias-disable"], None),
+        );
+        fdt.add_node(
+            root,
+            node_with_props(
+                "uart0-tx",
+                &[
+                    prop_u32s("phandle", &[21]),
+                    prop_u32s("rockchip,pins", &[1, 3, 10, 10]),
+                ],
+            ),
+        );
+        fdt.add_node(
+            root,
+            node_with_props(
+                "uart0-rx",
+                &[
+                    prop_u32s("phandle", &[22]),
+                    prop_u32s("rockchip,pins", &[1, 4, 11, 10]),
+                ],
+            ),
+        );
+        let consumer = fdt.add_node(
+            root,
+            node_with_props(
+                "serial@feb50000",
+                &[
+                    prop_strs("pinctrl-names", &["default"]),
+                    prop_u32s("pinctrl-0", &[21, 22]),
+                ],
+            ),
+        );
+
+        let state = FdtPinctrl::state_from_consumer(
+            &fdt,
+            fdt.node(consumer).unwrap(),
+            0,
+            &RockchipFdtPinctrlParser,
+        )
+        .unwrap();
+
+        assert_eq!(state.name(), &StateName::Default);
+        assert_eq!(state.muxes().len(), 2);
+        assert_eq!(state.muxes()[0].group, GroupId::new(35));
+        assert_eq!(state.muxes()[0].value.raw(), 10);
+        assert_eq!(state.muxes()[1].group, GroupId::new(36));
+        assert_eq!(state.muxes()[1].value.raw(), 11);
+    }
+
+    #[test]
+    fn fixed_regulator_gpio_and_pinctrl_paths_map_to_gpio_lines() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props(
+                "gpio2@fec30000",
+                &[
+                    prop_u32s("phandle", &[30]),
+                    prop_strs("compatible", &["rockchip,gpio-bank"]),
+                ],
+            ),
+        );
+        fdt.add_node(root, conf_node("pcfg-gpio", 10, &["bias-disable"], None));
+        fdt.add_node(
+            root,
+            node_with_props(
+                "vcc3v3-pinctrl",
+                &[
+                    prop_u32s("phandle", &[31]),
+                    prop_u32s("rockchip,pins", &[3, 4, 0, 10]),
+                ],
+            ),
+        );
+        let direct = fdt.add_node(
+            root,
+            node_with_props("regulator-direct", &[prop_u32s("gpios", &[30, 7, 0])]),
+        );
+        let legacy = fdt.add_node(
+            root,
+            node_with_props("regulator-legacy", &[prop_u32s("gpio", &[30, 8, 0])]),
+        );
+        let pinctrl = fdt.add_node(
+            root,
+            node_with_props("regulator-pinctrl", &[prop_u32s("pinctrl-0", &[31])]),
+        );
+
+        assert_eq!(
+            FdtPinctrl::gpio_lines_from_node(
+                &fdt,
+                fdt.node(direct).unwrap(),
+                &RockchipFdtPinctrlParser,
+            )
+            .unwrap(),
+            vec![GpioLineId::new(GpioBankId::new(2), 7)]
+        );
+        assert_eq!(
+            FdtPinctrl::gpio_lines_from_node(
+                &fdt,
+                fdt.node(legacy).unwrap(),
+                &RockchipFdtPinctrlParser,
+            )
+            .unwrap(),
+            vec![GpioLineId::new(GpioBankId::new(2), 8)]
+        );
+        assert_eq!(
+            FdtPinctrl::gpio_lines_from_node(
+                &fdt,
+                fdt.node(pinctrl).unwrap(),
+                &RockchipFdtPinctrlParser,
+            )
+            .unwrap(),
+            vec![GpioLineId::new(GpioBankId::new(3), 4)]
+        );
+    }
+
+    fn conf_node(name: &str, phandle: u32, biases: &[&str], drive: Option<u32>) -> Node {
+        let mut node = node_with_props(name, &[prop_u32s("phandle", &[phandle])]);
+        for bias in biases {
+            node.set_property(Property::new(bias, Vec::new()));
+        }
+        if let Some(drive) = drive {
+            node.set_property(prop_u32s("drive-strength", &[drive]));
+        }
+        node
+    }
+
+    fn node_with_props(name: &str, props: &[Property]) -> Node {
+        let mut node = Node::new(name);
+        for prop in props {
+            node.set_property(prop.clone());
+        }
+        node
+    }
+
+    fn prop_u32s(name: &str, values: &[u32]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        Property::new(name, data)
+    }
+
+    fn prop_strs(name: &str, values: &[&str]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(value.as_bytes());
+            data.push(0);
+        }
+        Property::new(name, data)
+    }
+}

--- a/drivers/ax-driver/src/usb/dwc.rs
+++ b/drivers/ax-driver/src/usb/dwc.rs
@@ -13,6 +13,7 @@ use crab_usb::{
 };
 use fdt_edit::{ClockRef, Fdt, Node, NodeType, Phandle, RegFixed};
 use log::{debug, info, warn};
+use rdif_pinctrl::{FdtPinctrl, PinctrlDevice};
 use rdrive::{
     probe::OnProbeError,
     register::{FdtInfo, ProbeFdt},
@@ -22,7 +23,9 @@ use rockchip_pm::{PowerDomain, RockchipPM};
 use super::{ProbeFdtUsbHost, usb_kernel};
 use crate::{
     mmio::iomap,
-    soc::{RockchipPinCtrl, rk3588_enable_clock, rk3588_reset_assert, rk3588_reset_deassert},
+    soc::{
+        RockchipFdtPinctrlParser, rk3588_enable_clock, rk3588_reset_assert, rk3588_reset_deassert,
+    },
 };
 
 const DRIVER_NAME: &str = "usb-dwc-xhci";
@@ -120,7 +123,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
     enable_power_domains(&resources.power_domains)?;
     enable_clocks(&resources.clocks);
-    enable_vbus(resources.usb2.supply)?;
+    enable_vbus(&fdt, resources.usb2.supply)?;
 
     let ctrl = map_reg(resources.ctrl)?;
     let phy = map_reg(resources.usbdp.reg)?;
@@ -452,18 +455,32 @@ fn enable_clocks(clocks: &[ClockSpec]) {
     }
 }
 
-fn enable_vbus(supply: Option<Phandle>) -> Result<(), OnProbeError> {
+fn enable_vbus(fdt: &Fdt, supply: Option<Phandle>) -> Result<(), OnProbeError> {
     let Some(supply) = supply else {
         debug!("DWC xHCI USB2 PHY has no phy-supply; skip VBUS pinctrl");
         return Ok(());
     };
 
-    let pinctrl = rdrive::get_one::<RockchipPinCtrl>()
-        .ok_or_else(|| OnProbeError::other("RockchipPinCtrl not found for DWC xHCI VBUS"))?;
+    let regulator = fdt.get_by_phandle(supply).ok_or_else(|| {
+        OnProbeError::other(format!(
+            "DWC xHCI VBUS regulator phandle {supply:?} not found"
+        ))
+    })?;
+    let pinctrl = rdrive::get_one::<PinctrlDevice>()
+        .ok_or_else(|| OnProbeError::other("PinctrlDevice not found for DWC xHCI VBUS"))?;
     let mut pinctrl = pinctrl
         .lock()
-        .map_err(|err| OnProbeError::other(format!("failed to lock RockchipPinCtrl: {err}")))?;
-    pinctrl.enable_fixed_regulator(supply)
+        .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
+    FdtPinctrl::apply_fixed_regulator(
+        &mut *pinctrl,
+        fdt,
+        regulator.as_node(),
+        &RockchipFdtPinctrlParser,
+        "dwc-xhci-vbus",
+    )
+    .map_err(|err| {
+        OnProbeError::other(format!("failed to enable DWC xHCI VBUS via pinctrl: {err}"))
+    })
 }
 
 fn clock_specs(clocks: Vec<ClockRef>) -> Vec<ClockSpec> {

--- a/drivers/ax-driver/tests/binding_info.rs
+++ b/drivers/ax-driver/tests/binding_info.rs
@@ -17,7 +17,7 @@ use {
         impl_trait,
     },
     core::time::Duration,
-    fdt_edit::{Fdt, Node, Property},
+    fdt_edit::{Fdt, Node, Phandle, Property},
     rdrive::{
         DriverGeneric, Platform, PlatformDevice,
         probe::{
@@ -201,7 +201,8 @@ fn fdt_binding_info_carries_first_irq_specifier_without_setup() {
         panic!("expected captured FDT interrupt binding");
     };
     assert_eq!(spec.cells, vec![0, 42, 4]);
-    assert_ne!(u64::from(spec.controller), 0);
+    let controller = rdrive::fdt_phandle_to_device_id(Phandle::from(1)).unwrap();
+    assert_eq!(spec.controller, controller);
     assert_eq!(*SETUP_SPECIFIER.lock().unwrap(), None);
 }
 

--- a/drivers/interface/rdif-pinctrl/Cargo.toml
+++ b/drivers/interface/rdif-pinctrl/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+authors = ["周睿 <zrufo747@outlook.com>"]
+categories = ["embedded", "no-std"]
+description = "Driver Interface pin control definition."
+edition.workspace = true
+keywords = ["os", "driver", "pinctrl", "gpio"]
+license = "MIT"
+name = "rdif-pinctrl"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+fdt-edit = { workspace = true, optional = true }
+rdif-base = { workspace = true }
+thiserror = { version = "2", default-features = false }
+
+[features]
+default = []
+fdt = ["dep:fdt-edit"]

--- a/drivers/interface/rdif-pinctrl/src/error.rs
+++ b/drivers/interface/rdif-pinctrl/src/error.rs
@@ -1,0 +1,108 @@
+use alloc::{boxed::Box, string::String};
+use core::fmt;
+
+use crate::{FirmwareKind, FunctionId, GpioLineId, GroupId, PinId, io};
+
+#[derive(thiserror::Error, Debug)]
+pub enum PinctrlError {
+    #[error("operation not supported")]
+    NotSupported,
+    #[error("firmware source is not supported: {0:?}")]
+    UnsupportedFirmware(FirmwareKind),
+    #[error("device is not available")]
+    NotAvailable,
+    #[error("invalid pin: {0:?}")]
+    InvalidPin(PinId),
+    #[error("invalid group: {0:?}")]
+    InvalidGroup(GroupId),
+    #[error("invalid function: {0:?}")]
+    InvalidFunction(FunctionId),
+    #[error("function {function:?} cannot mux group {group:?}")]
+    InvalidMux {
+        group: GroupId,
+        function: FunctionId,
+    },
+    #[error("invalid GPIO line: {0:?}")]
+    InvalidLine(GpioLineId),
+    #[error("GPIO line is already requested: {0:?}")]
+    LineBusy(GpioLineId),
+    #[error("GPIO line is not requested: {0:?}")]
+    LineNotRequested(GpioLineId),
+    #[error("invalid pin configuration")]
+    InvalidConfig,
+    #[error("IRQ event overflow")]
+    IrqEventOverflow,
+    #[error("other error: {0}")]
+    Other(Box<dyn core::error::Error>),
+}
+
+impl PartialEq for PinctrlError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::NotSupported, Self::NotSupported)
+            | (Self::NotAvailable, Self::NotAvailable)
+            | (Self::InvalidConfig, Self::InvalidConfig)
+            | (Self::IrqEventOverflow, Self::IrqEventOverflow) => true,
+            (Self::UnsupportedFirmware(a), Self::UnsupportedFirmware(b)) => a == b,
+            (Self::InvalidPin(a), Self::InvalidPin(b)) => a == b,
+            (Self::InvalidGroup(a), Self::InvalidGroup(b)) => a == b,
+            (Self::InvalidFunction(a), Self::InvalidFunction(b)) => a == b,
+            (
+                Self::InvalidMux {
+                    group: a_group,
+                    function: a_function,
+                },
+                Self::InvalidMux {
+                    group: b_group,
+                    function: b_function,
+                },
+            ) => a_group == b_group && a_function == b_function,
+            (Self::InvalidLine(a), Self::InvalidLine(b))
+            | (Self::LineBusy(a), Self::LineBusy(b))
+            | (Self::LineNotRequested(a), Self::LineNotRequested(b)) => a == b,
+            (Self::Other(_), Self::Other(_)) => false,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for PinctrlError {}
+
+#[derive(Debug)]
+struct PinctrlMessageError(String);
+
+impl fmt::Display for PinctrlMessageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl core::error::Error for PinctrlMessageError {}
+
+impl PinctrlError {
+    pub fn other(message: impl Into<String>) -> Self {
+        Self::Other(Box::new(PinctrlMessageError(message.into())))
+    }
+}
+
+impl From<PinctrlError> for io::ErrorKind {
+    fn from(value: PinctrlError) -> Self {
+        match value {
+            PinctrlError::NotSupported | PinctrlError::UnsupportedFirmware(_) => {
+                io::ErrorKind::Unsupported
+            }
+            PinctrlError::NotAvailable => io::ErrorKind::NotAvailable,
+            PinctrlError::InvalidPin(_)
+            | PinctrlError::InvalidGroup(_)
+            | PinctrlError::InvalidFunction(_)
+            | PinctrlError::InvalidMux { .. }
+            | PinctrlError::InvalidLine(_)
+            | PinctrlError::InvalidConfig => io::ErrorKind::InvalidData,
+            PinctrlError::LineBusy(_) => io::ErrorKind::Interrupted,
+            PinctrlError::LineNotRequested(_) | PinctrlError::IrqEventOverflow => {
+                io::ErrorKind::Other(Box::new(value))
+            }
+            PinctrlError::Other(error) => io::ErrorKind::Other(error),
+        }
+    }
+}

--- a/drivers/interface/rdif-pinctrl/src/fdt.rs
+++ b/drivers/interface/rdif-pinctrl/src/fdt.rs
@@ -1,0 +1,649 @@
+use alloc::{format, string::String, vec, vec::Vec};
+
+use fdt_edit::{Fdt, Node, NodeType, Phandle};
+
+use crate::{
+    ConfigSetting, Direction, FirmwareKind, GpioLineId, Interface, PinConfig, PinId, PinState,
+    PinctrlError, StateName,
+};
+
+pub trait FdtPinctrlParser {
+    fn parse_pinctrl_node(
+        &self,
+        fdt: &Fdt,
+        node: NodeType<'_>,
+        state: &mut PinState,
+    ) -> Result<(), PinctrlError>;
+
+    fn parse_gpio_line(
+        &self,
+        _fdt: &Fdt,
+        _consumer: &Node,
+        _prop_name: &str,
+    ) -> Option<Result<GpioLineId, PinctrlError>> {
+        None
+    }
+
+    fn gpio_lines_from_state(&self, _state: &PinState) -> Result<Vec<GpioLineId>, PinctrlError> {
+        Ok(Vec::new())
+    }
+}
+
+pub struct FdtPinctrl;
+
+impl FdtPinctrl {
+    pub const fn unsupported_firmware(kind: FirmwareKind) -> PinctrlError {
+        PinctrlError::UnsupportedFirmware(kind)
+    }
+
+    pub fn state_from_consumer(
+        fdt: &Fdt,
+        node: &Node,
+        index: u32,
+        parser: &(impl FdtPinctrlParser + ?Sized),
+    ) -> Result<PinState, PinctrlError> {
+        let prop_name = format!("pinctrl-{index}");
+        let prop = node
+            .get_property(&prop_name)
+            .ok_or_else(|| PinctrlError::other(format!("[{}] has no {prop_name}", node.name())))?;
+        let mut state = PinState::named(Self::state_name_from_pinctrl_names(node, index));
+
+        for phandle in prop.get_u32_iter().map(Phandle::from) {
+            let pinctrl = fdt.get_by_phandle(phandle).ok_or_else(|| {
+                PinctrlError::other(format!(
+                    "[{}] {prop_name} phandle {phandle:?} not found",
+                    node.name()
+                ))
+            })?;
+            parser.parse_pinctrl_node(fdt, pinctrl, &mut state)?;
+        }
+
+        Ok(state)
+    }
+
+    pub fn apply_state_from_consumer(
+        interface: &mut (impl Interface + ?Sized),
+        fdt: &Fdt,
+        node: &Node,
+        index: u32,
+        parser: &(impl FdtPinctrlParser + ?Sized),
+    ) -> Result<(), PinctrlError> {
+        let state = Self::state_from_consumer(fdt, node, index, parser)?;
+        interface.apply_state(&state)
+    }
+
+    pub fn gpio_lines_from_node(
+        fdt: &Fdt,
+        node: &Node,
+        parser: &(impl FdtPinctrlParser + ?Sized),
+    ) -> Result<Vec<GpioLineId>, PinctrlError> {
+        if let Some(line) = parser
+            .parse_gpio_line(fdt, node, "gpios")
+            .or_else(|| parser.parse_gpio_line(fdt, node, "gpio"))
+        {
+            return line.map(|line| vec![line]);
+        }
+
+        if node.get_property("pinctrl-0").is_none() {
+            return Ok(Vec::new());
+        }
+
+        let state = Self::state_from_consumer(fdt, node, 0, parser)?;
+        parser.gpio_lines_from_state(&state)
+    }
+
+    pub fn apply_fixed_regulator(
+        interface: &mut (impl Interface + ?Sized),
+        fdt: &Fdt,
+        regulator_node: &Node,
+        parser: &(impl FdtPinctrlParser + ?Sized),
+        owner: &str,
+    ) -> Result<(), PinctrlError> {
+        let state = if regulator_node.get_property("pinctrl-0").is_some() {
+            let state = Self::state_from_consumer(fdt, regulator_node, 0, parser)?;
+            interface.apply_state(&state)?;
+            Some(state)
+        } else {
+            None
+        };
+
+        let lines = if let Some(line) = parser
+            .parse_gpio_line(fdt, regulator_node, "gpios")
+            .or_else(|| parser.parse_gpio_line(fdt, regulator_node, "gpio"))
+        {
+            vec![line?]
+        } else if let Some(state) = &state {
+            parser.gpio_lines_from_state(state)?
+        } else {
+            Vec::new()
+        };
+
+        if lines.is_empty() {
+            return Err(PinctrlError::NotAvailable);
+        }
+
+        let active_value = regulator_node.get_property("enable-active-low").is_none();
+        let gpio_active_low = Self::gpio_flags_active_low(regulator_node);
+        let output_value = if gpio_active_low {
+            !active_value
+        } else {
+            active_value
+        };
+
+        for line in lines {
+            Self::drive_gpio_line(interface, line, output_value, owner)?;
+        }
+
+        Ok(())
+    }
+
+    fn state_name_from_pinctrl_names(node: &Node, index: u32) -> StateName {
+        let Some(name) = node
+            .get_property("pinctrl-names")
+            .and_then(|prop| prop.as_str_iter().nth(index as usize))
+        else {
+            return if index == 0 {
+                StateName::Default
+            } else {
+                StateName::Index(index)
+            };
+        };
+
+        match name {
+            "default" => StateName::Default,
+            "init" => StateName::Init,
+            "idle" => StateName::Idle,
+            "sleep" => StateName::Sleep,
+            other => StateName::Named(String::from(other)),
+        }
+    }
+
+    fn gpio_flags_active_low(node: &Node) -> bool {
+        node.get_property("gpios")
+            .or_else(|| node.get_property("gpio"))
+            .and_then(|prop| prop.get_u32_iter().nth(2))
+            .is_some_and(|flags| flags & 1 != 0)
+    }
+
+    fn drive_gpio_line(
+        interface: &mut (impl Interface + ?Sized),
+        line: GpioLineId,
+        value: bool,
+        owner: &str,
+    ) -> Result<(), PinctrlError> {
+        if let Some(mut bank) = interface.create_gpio_bank(line.bank) {
+            if line.offset >= bank.line_count() {
+                return Err(PinctrlError::InvalidLine(line));
+            }
+            let handle = bank.request_line(line, owner)?;
+            bank.set_direction(&handle, Direction::Output { initial: value })?;
+            bank.write(&handle, value)?;
+            bank.release_line(handle)?;
+            return Ok(());
+        }
+
+        let pin = Self::pin_from_gpio_ranges(interface, line)?;
+        interface.apply_config(&ConfigSetting::pin(pin, PinConfig::OutputEnable(true)))?;
+        interface.apply_config(&ConfigSetting::pin(pin, PinConfig::OutputValue(value)))
+    }
+
+    fn pin_from_gpio_ranges(
+        interface: &(impl Interface + ?Sized),
+        line: GpioLineId,
+    ) -> Result<PinId, PinctrlError> {
+        for range in interface.gpio_ranges() {
+            let end = range.line_base.saturating_add(range.count);
+            if range.bank == line.bank && (range.line_base..end).contains(&line.offset) {
+                return Ok(PinId::new(range.pin_base + line.offset - range.line_base));
+            }
+        }
+        Err(PinctrlError::InvalidLine(line))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, vec, vec::Vec};
+
+    use fdt_edit::{Fdt, Node, NodeType, Phandle, Property};
+
+    use crate::{
+        ConfigSetting, Direction, DriverGeneric, FdtPinctrl, FdtPinctrlParser, FunctionId,
+        GpioBank, GpioBankId, GpioLineHandle, GpioLineId, GpioRange, GroupId, Interface,
+        MuxSetting, MuxValue, PinConfig, PinDesc, PinFunction, PinGroup, PinId, PinState,
+        PinctrlError, StateName,
+    };
+
+    struct TestParser;
+
+    impl FdtPinctrlParser for TestParser {
+        fn parse_pinctrl_node(
+            &self,
+            _fdt: &Fdt,
+            node: NodeType<'_>,
+            state: &mut PinState,
+        ) -> Result<(), PinctrlError> {
+            let cells = node
+                .as_node()
+                .get_property("test,pins")
+                .ok_or(PinctrlError::InvalidConfig)?
+                .get_u32_iter()
+                .collect::<Vec<_>>();
+            for pin in cells.chunks_exact(3) {
+                let raw_pin = pin[0];
+                let function = pin[1];
+                let mux = pin[2];
+                state.push_mux(MuxSetting::new(
+                    GroupId::new(raw_pin),
+                    FunctionId::new(function),
+                    MuxValue::new(mux),
+                ));
+                state.push_config(ConfigSetting::pin(
+                    PinId::new(raw_pin),
+                    PinConfig::DriveStrengthUa(8000),
+                ));
+            }
+            Ok(())
+        }
+
+        fn parse_gpio_line(
+            &self,
+            fdt: &Fdt,
+            consumer: &Node,
+            prop_name: &str,
+        ) -> Option<Result<GpioLineId, PinctrlError>> {
+            let mut cells = consumer.get_property(prop_name)?.get_u32_iter();
+            let phandle = Phandle::from(cells.next()?);
+            let offset = cells.next()?;
+            let gpio = fdt.get_by_phandle(phandle)?;
+            let bank = gpio
+                .as_node()
+                .name()
+                .strip_prefix("gpio")
+                .and_then(|name| name.chars().next())
+                .and_then(|ch| ch.to_digit(10))?;
+            Some(Ok(GpioLineId::new(GpioBankId::new(bank), offset)))
+        }
+
+        fn gpio_lines_from_state(&self, state: &PinState) -> Result<Vec<GpioLineId>, PinctrlError> {
+            Ok(state
+                .muxes()
+                .iter()
+                .map(|mux| {
+                    GpioLineId::new(GpioBankId::new(mux.group.raw() / 32), mux.group.raw() % 32)
+                })
+                .collect())
+        }
+    }
+
+    struct Recorder {
+        calls: Vec<&'static str>,
+        configs: Vec<ConfigSetting>,
+        pins: Vec<PinDesc>,
+        groups: Vec<PinGroup>,
+        functions: Vec<PinFunction>,
+        gpio_ranges: Vec<GpioRange>,
+        use_gpio_bank: bool,
+    }
+
+    impl Recorder {
+        fn new() -> Self {
+            let pins = (0..96)
+                .map(|pin| PinDesc::new(PinId::new(pin), None))
+                .collect();
+            let groups = (0..96)
+                .map(|pin| PinGroup::new(GroupId::new(pin), None, vec![PinId::new(pin)]))
+                .collect();
+            let functions = (0..16)
+                .map(|function| {
+                    PinFunction::new(
+                        FunctionId::new(function),
+                        None,
+                        (0..96).map(GroupId::new).collect(),
+                    )
+                })
+                .collect();
+            Self {
+                calls: Vec::new(),
+                configs: Vec::new(),
+                pins,
+                groups,
+                functions,
+                gpio_ranges: vec![
+                    GpioRange::new(GpioBankId::new(0), 0, 0, 32),
+                    GpioRange::new(GpioBankId::new(1), 32, 0, 32),
+                    GpioRange::new(GpioBankId::new(2), 64, 0, 32),
+                ],
+                use_gpio_bank: false,
+            }
+        }
+
+        fn with_gpio_bank(mut self) -> Self {
+            self.use_gpio_bank = true;
+            self
+        }
+    }
+
+    impl DriverGeneric for Recorder {
+        fn name(&self) -> &str {
+            "recorder"
+        }
+    }
+
+    impl Interface for Recorder {
+        fn pins(&self) -> &[PinDesc] {
+            &self.pins
+        }
+
+        fn groups(&self) -> &[PinGroup] {
+            &self.groups
+        }
+
+        fn functions(&self) -> &[PinFunction] {
+            &self.functions
+        }
+
+        fn gpio_ranges(&self) -> &[GpioRange] {
+            &self.gpio_ranges
+        }
+
+        fn apply_mux(&mut self, _setting: &MuxSetting) -> Result<(), PinctrlError> {
+            self.calls.push("mux");
+            Ok(())
+        }
+
+        fn apply_config(&mut self, setting: &ConfigSetting) -> Result<(), PinctrlError> {
+            self.calls.push("config");
+            self.configs.push(*setting);
+            Ok(())
+        }
+
+        fn create_gpio_bank(&mut self, bank_id: GpioBankId) -> Option<Box<dyn GpioBank>> {
+            self.use_gpio_bank
+                .then(|| Box::new(RecordingBank::new(bank_id)) as Box<dyn GpioBank>)
+        }
+    }
+
+    struct RecordingBank {
+        bank_id: GpioBankId,
+        requested: Option<GpioLineHandle>,
+        value: bool,
+    }
+
+    impl RecordingBank {
+        fn new(bank_id: GpioBankId) -> Self {
+            Self {
+                bank_id,
+                requested: None,
+                value: false,
+            }
+        }
+
+        fn ensure_requested(&self, handle: &GpioLineHandle) -> Result<(), PinctrlError> {
+            if self.requested.as_ref() == Some(handle) {
+                Ok(())
+            } else {
+                Err(PinctrlError::LineNotRequested(handle.line()))
+            }
+        }
+    }
+
+    impl GpioBank for RecordingBank {
+        fn bank_id(&self) -> GpioBankId {
+            self.bank_id
+        }
+
+        fn line_count(&self) -> u32 {
+            32
+        }
+
+        fn request_line(
+            &mut self,
+            line: GpioLineId,
+            _owner: &str,
+        ) -> Result<GpioLineHandle, PinctrlError> {
+            let handle = GpioLineHandle::new(line, crate::OwnerId::new(1));
+            self.requested = Some(handle);
+            Ok(handle)
+        }
+
+        fn release_line(&mut self, handle: GpioLineHandle) -> Result<(), PinctrlError> {
+            self.ensure_requested(&handle)?;
+            self.requested = None;
+            Ok(())
+        }
+
+        fn set_direction(
+            &mut self,
+            handle: &GpioLineHandle,
+            direction: Direction,
+        ) -> Result<(), PinctrlError> {
+            self.ensure_requested(handle)?;
+            match direction {
+                Direction::Input => {}
+                Direction::Output { initial } => self.value = initial,
+            }
+            Ok(())
+        }
+
+        fn read(&self, handle: &GpioLineHandle) -> Result<bool, PinctrlError> {
+            self.ensure_requested(handle)?;
+            Ok(self.value)
+        }
+
+        fn write(&mut self, handle: &GpioLineHandle, value: bool) -> Result<(), PinctrlError> {
+            self.ensure_requested(handle)?;
+            self.value = value;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn pinctrl_names_and_pinctrl_0_create_default_state() {
+        let (fdt, consumer) = fdt_with_consumer(&["default"], &[10]);
+
+        let state =
+            FdtPinctrl::state_from_consumer(&fdt, fdt.node(consumer).unwrap(), 0, &TestParser)
+                .unwrap();
+
+        assert_eq!(state.name(), &StateName::Default);
+        assert_eq!(state.muxes()[0].group, GroupId::new(34));
+        assert_eq!(state.muxes()[0].value.raw(), 7);
+    }
+
+    #[test]
+    fn multiple_pinctrl_phandles_merge_into_one_state() {
+        let (fdt, consumer) = fdt_with_consumer(&["default"], &[10, 11]);
+
+        let state =
+            FdtPinctrl::state_from_consumer(&fdt, fdt.node(consumer).unwrap(), 0, &TestParser)
+                .unwrap();
+
+        assert_eq!(state.muxes().len(), 2);
+        assert_eq!(state.muxes()[0].group, GroupId::new(34));
+        assert_eq!(state.muxes()[1].group, GroupId::new(65));
+    }
+
+    #[test]
+    fn apply_state_from_consumer_keeps_mux_before_config() {
+        let (fdt, consumer) = fdt_with_consumer(&["default"], &[10]);
+        let mut recorder = Recorder::new();
+
+        FdtPinctrl::apply_state_from_consumer(
+            &mut recorder,
+            &fdt,
+            fdt.node(consumer).unwrap(),
+            0,
+            &TestParser,
+        )
+        .unwrap();
+
+        assert_eq!(recorder.calls, vec!["mux", "config"]);
+    }
+
+    #[test]
+    fn fixed_regulator_uses_gpio_flags_and_enable_active_low_for_output_value() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props("gpio1@0", &[prop_u32s("phandle", &[20])]),
+        );
+        let regulator = fdt.add_node(
+            root,
+            node_with_props(
+                "vbus-regulator",
+                &[
+                    prop_u32s("gpios", &[20, 5, 1]),
+                    Property::new("enable-active-low", Vec::new()),
+                ],
+            ),
+        );
+        let mut recorder = Recorder::new();
+
+        FdtPinctrl::apply_fixed_regulator(
+            &mut recorder,
+            &fdt,
+            fdt.node(regulator).unwrap(),
+            &TestParser,
+            "dwc-xhci-vbus",
+        )
+        .unwrap();
+
+        assert!(recorder.configs.contains(&ConfigSetting::pin(
+            PinId::new(37),
+            PinConfig::OutputEnable(true)
+        )));
+        assert!(recorder.configs.contains(&ConfigSetting::pin(
+            PinId::new(37),
+            PinConfig::OutputValue(true)
+        )));
+    }
+
+    #[test]
+    fn fixed_regulator_applies_pinctrl_0_before_driving_gpio() {
+        let (mut fdt, _consumer) = fdt_with_consumer(&["default"], &[10]);
+        let root = fdt.root_id();
+        let regulator = fdt.add_node(
+            root,
+            node_with_props(
+                "vbus-regulator",
+                &[
+                    prop_strs("pinctrl-names", &["default"]),
+                    prop_u32s("pinctrl-0", &[10]),
+                ],
+            ),
+        );
+        let mut recorder = Recorder::new();
+
+        FdtPinctrl::apply_fixed_regulator(
+            &mut recorder,
+            &fdt,
+            fdt.node(regulator).unwrap(),
+            &TestParser,
+            "dwc-xhci-vbus",
+        )
+        .unwrap();
+
+        assert_eq!(recorder.calls, vec!["mux", "config", "config", "config"]);
+        assert!(recorder.configs.contains(&ConfigSetting::pin(
+            PinId::new(34),
+            PinConfig::OutputValue(true)
+        )));
+    }
+
+    #[test]
+    fn unsupported_firmware_reports_explicit_error() {
+        assert_eq!(
+            FdtPinctrl::unsupported_firmware(crate::FirmwareKind::Acpi),
+            PinctrlError::UnsupportedFirmware(crate::FirmwareKind::Acpi)
+        );
+    }
+
+    #[test]
+    fn fixed_regulator_can_use_gpio_bank_endpoint() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props("gpio1@0", &[prop_u32s("phandle", &[20])]),
+        );
+        let regulator = fdt.add_node(
+            root,
+            node_with_props("vbus-regulator", &[prop_u32s("gpios", &[20, 5, 0])]),
+        );
+        let mut recorder = Recorder::new().with_gpio_bank();
+
+        FdtPinctrl::apply_fixed_regulator(
+            &mut recorder,
+            &fdt,
+            fdt.node(regulator).unwrap(),
+            &TestParser,
+            "dwc-xhci-vbus",
+        )
+        .unwrap();
+
+        assert!(recorder.configs.is_empty());
+    }
+
+    fn fdt_with_consumer(names: &[&str], phandles: &[u32]) -> (Fdt, fdt_edit::NodeId) {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props(
+                "pin-state-a",
+                &[
+                    prop_u32s("phandle", &[10]),
+                    prop_u32s("test,pins", &[34, 2, 7]),
+                ],
+            ),
+        );
+        fdt.add_node(
+            root,
+            node_with_props(
+                "pin-state-b",
+                &[
+                    prop_u32s("phandle", &[11]),
+                    prop_u32s("test,pins", &[65, 3, 8]),
+                ],
+            ),
+        );
+        let consumer = fdt.add_node(
+            root,
+            node_with_props(
+                "consumer",
+                &[
+                    prop_strs("pinctrl-names", names),
+                    prop_u32s("pinctrl-0", phandles),
+                ],
+            ),
+        );
+        (fdt, consumer)
+    }
+
+    fn node_with_props(name: &str, props: &[Property]) -> Node {
+        let mut node = Node::new(name);
+        for prop in props {
+            node.set_property(prop.clone());
+        }
+        node
+    }
+
+    fn prop_u32s(name: &str, values: &[u32]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        Property::new(name, data)
+    }
+
+    fn prop_strs(name: &str, values: &[&str]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(value.as_bytes());
+            data.push(0);
+        }
+        Property::new(name, data)
+    }
+}

--- a/drivers/interface/rdif-pinctrl/src/fdt.rs
+++ b/drivers/interface/rdif-pinctrl/src/fdt.rs
@@ -183,8 +183,8 @@ impl FdtPinctrl {
         }
 
         let pin = Self::pin_from_gpio_ranges(interface, line)?;
-        interface.apply_config(&ConfigSetting::pin(pin, PinConfig::OutputEnable(true)))?;
-        interface.apply_config(&ConfigSetting::pin(pin, PinConfig::OutputValue(value)))
+        interface.apply_config(&ConfigSetting::pin(pin, PinConfig::OutputValue(value)))?;
+        interface.apply_config(&ConfigSetting::pin(pin, PinConfig::OutputEnable(true)))
     }
 
     fn pin_from_gpio_ranges(
@@ -518,6 +518,43 @@ mod tests {
             PinId::new(37),
             PinConfig::OutputValue(true)
         )));
+    }
+
+    #[test]
+    fn fixed_regulator_sets_output_latch_before_enabling_output() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props("gpio1@0", &[prop_u32s("phandle", &[20])]),
+        );
+        let regulator = fdt.add_node(
+            root,
+            node_with_props("vbus-regulator", &[prop_u32s("gpios", &[20, 5, 0])]),
+        );
+        let mut recorder = Recorder::new();
+
+        FdtPinctrl::apply_fixed_regulator(
+            &mut recorder,
+            &fdt,
+            fdt.node(regulator).unwrap(),
+            &TestParser,
+            "dwc-xhci-vbus",
+        )
+        .unwrap();
+
+        let pin = PinId::new(37);
+        let configs = recorder
+            .configs
+            .iter()
+            .filter(|setting| setting.target == crate::ConfigTarget::Pin(pin))
+            .map(|setting| setting.config)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            configs,
+            vec![PinConfig::OutputValue(true), PinConfig::OutputEnable(true)]
+        );
     }
 
     #[test]

--- a/drivers/interface/rdif-pinctrl/src/gpio.rs
+++ b/drivers/interface/rdif-pinctrl/src/gpio.rs
@@ -1,0 +1,70 @@
+use crate::{GpioBankId, GpioLineId, OwnerId, PinctrlError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Input,
+    Output { initial: bool },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpioRange {
+    pub bank: GpioBankId,
+    pub pin_base: u32,
+    pub line_base: u32,
+    pub count: u32,
+}
+
+impl GpioRange {
+    pub const fn new(bank: GpioBankId, pin_base: u32, line_base: u32, count: u32) -> Self {
+        Self {
+            bank,
+            pin_base,
+            line_base,
+            count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpioLineHandle {
+    line: GpioLineId,
+    owner: OwnerId,
+}
+
+impl GpioLineHandle {
+    pub const fn new(line: GpioLineId, owner: OwnerId) -> Self {
+        Self { line, owner }
+    }
+
+    pub const fn line(&self) -> GpioLineId {
+        self.line
+    }
+
+    pub const fn owner(&self) -> OwnerId {
+        self.owner
+    }
+}
+
+pub trait GpioBank: Send + 'static {
+    fn bank_id(&self) -> GpioBankId;
+
+    fn line_count(&self) -> u32;
+
+    fn request_line(
+        &mut self,
+        line: GpioLineId,
+        owner: &str,
+    ) -> Result<GpioLineHandle, PinctrlError>;
+
+    fn release_line(&mut self, handle: GpioLineHandle) -> Result<(), PinctrlError>;
+
+    fn set_direction(
+        &mut self,
+        handle: &GpioLineHandle,
+        direction: Direction,
+    ) -> Result<(), PinctrlError>;
+
+    fn read(&self, handle: &GpioLineHandle) -> Result<bool, PinctrlError>;
+
+    fn write(&mut self, handle: &GpioLineHandle, value: bool) -> Result<(), PinctrlError>;
+}

--- a/drivers/interface/rdif-pinctrl/src/id.rs
+++ b/drivers/interface/rdif-pinctrl/src/id.rs
@@ -1,0 +1,89 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PinId(u32);
+
+impl PinId {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GroupId(u32);
+
+impl GroupId {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FunctionId(u32);
+
+impl FunctionId {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GpioBankId(u32);
+
+impl GpioBankId {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GpioLineId {
+    pub bank: GpioBankId,
+    pub offset: u32,
+}
+
+impl GpioLineId {
+    pub const fn new(bank: GpioBankId, offset: u32) -> Self {
+        Self { bank, offset }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GpioIrqSourceId(u32);
+
+impl GpioIrqSourceId {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OwnerId(u64);
+
+impl OwnerId {
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(self) -> u64 {
+        self.0
+    }
+}

--- a/drivers/interface/rdif-pinctrl/src/interface.rs
+++ b/drivers/interface/rdif-pinctrl/src/interface.rs
@@ -1,0 +1,199 @@
+use alloc::{boxed::Box, vec::Vec};
+use core::any::Any;
+
+use rdif_base::DriverGeneric;
+
+use crate::{
+    ConfigSetting, ConfigTarget, FunctionId, GpioBank, GpioBankId, GpioIrqHandler, GpioIrqSourceId,
+    GpioIrqSourceInfo, GpioRange, GroupId, PinDesc, PinFunction, PinGroup, PinState, PinctrlError,
+};
+
+pub type BPinctrl = Box<dyn Interface>;
+pub type BGpioBank = Box<dyn GpioBank>;
+pub type BGpioIrqHandler = Box<dyn GpioIrqHandler>;
+
+pub struct PinctrlDevice(BPinctrl);
+
+impl PinctrlDevice {
+    pub fn new(interface: impl Interface + 'static) -> Self {
+        Self(Box::new(interface))
+    }
+
+    pub fn boxed(interface: BPinctrl) -> Self {
+        Self(interface)
+    }
+
+    pub fn interface(&self) -> &dyn Interface {
+        self.0.as_ref()
+    }
+
+    pub fn interface_mut(&mut self) -> &mut dyn Interface {
+        self.0.as_mut()
+    }
+
+    pub fn typed_ref<T: Interface>(&self) -> Option<&T> {
+        self.raw_any()?.downcast_ref()
+    }
+
+    pub fn typed_mut<T: Interface>(&mut self) -> Option<&mut T> {
+        self.raw_any_mut()?.downcast_mut()
+    }
+}
+
+impl DriverGeneric for PinctrlDevice {
+    fn name(&self) -> &str {
+        self.0.name()
+    }
+
+    fn raw_any(&self) -> Option<&dyn Any> {
+        Some(self.0.as_ref() as &dyn Any)
+    }
+
+    fn raw_any_mut(&mut self) -> Option<&mut dyn Any> {
+        Some(self.0.as_mut() as &mut dyn Any)
+    }
+}
+
+impl Interface for PinctrlDevice {
+    fn pins(&self) -> &[PinDesc] {
+        self.0.pins()
+    }
+
+    fn groups(&self) -> &[PinGroup] {
+        self.0.groups()
+    }
+
+    fn functions(&self) -> &[PinFunction] {
+        self.0.functions()
+    }
+
+    fn gpio_ranges(&self) -> &[GpioRange] {
+        self.0.gpio_ranges()
+    }
+
+    fn can_mux(&self, group: GroupId, function: FunctionId) -> bool {
+        self.0.can_mux(group, function)
+    }
+
+    fn validate_state(&self, state: &PinState) -> Result<(), PinctrlError> {
+        self.0.validate_state(state)
+    }
+
+    fn apply_state(&mut self, state: &PinState) -> Result<(), PinctrlError> {
+        self.0.apply_state(state)
+    }
+
+    fn apply_mux(&mut self, setting: &crate::MuxSetting) -> Result<(), PinctrlError> {
+        self.0.apply_mux(setting)
+    }
+
+    fn apply_config(&mut self, setting: &ConfigSetting) -> Result<(), PinctrlError> {
+        self.0.apply_config(setting)
+    }
+
+    fn create_gpio_bank(&mut self, bank_id: GpioBankId) -> Option<BGpioBank> {
+        self.0.create_gpio_bank(bank_id)
+    }
+
+    fn irq_sources(&self) -> Vec<GpioIrqSourceInfo> {
+        self.0.irq_sources()
+    }
+
+    fn take_irq_handler(&mut self, source_id: GpioIrqSourceId) -> Option<BGpioIrqHandler> {
+        self.0.take_irq_handler(source_id)
+    }
+}
+
+pub trait Interface: DriverGeneric {
+    fn pins(&self) -> &[PinDesc] {
+        &[]
+    }
+
+    fn groups(&self) -> &[PinGroup] {
+        &[]
+    }
+
+    fn functions(&self) -> &[PinFunction] {
+        &[]
+    }
+
+    fn gpio_ranges(&self) -> &[GpioRange] {
+        &[]
+    }
+
+    fn can_mux(&self, group: GroupId, function: FunctionId) -> bool {
+        self.functions()
+            .iter()
+            .find(|candidate| candidate.id == function)
+            .is_some_and(|candidate| candidate.groups.contains(&group))
+    }
+
+    fn validate_state(&self, state: &PinState) -> Result<(), PinctrlError> {
+        for mux in state.muxes() {
+            if !self.groups().iter().any(|group| group.id == mux.group) {
+                return Err(PinctrlError::InvalidGroup(mux.group));
+            }
+            if !self
+                .functions()
+                .iter()
+                .any(|function| function.id == mux.function)
+            {
+                return Err(PinctrlError::InvalidFunction(mux.function));
+            }
+            if !self.can_mux(mux.group, mux.function) {
+                return Err(PinctrlError::InvalidMux {
+                    group: mux.group,
+                    function: mux.function,
+                });
+            }
+        }
+
+        for config in state.configs() {
+            match config.target {
+                ConfigTarget::Pin(pin) => {
+                    if !self.pins().iter().any(|desc| desc.id == pin) {
+                        return Err(PinctrlError::InvalidPin(pin));
+                    }
+                }
+                ConfigTarget::Group(group) => {
+                    if !self.groups().iter().any(|desc| desc.id == group) {
+                        return Err(PinctrlError::InvalidGroup(group));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply_state(&mut self, state: &PinState) -> Result<(), PinctrlError> {
+        self.validate_state(state)?;
+        for mux in state.muxes() {
+            self.apply_mux(mux)?;
+        }
+        for config in state.configs() {
+            self.apply_config(config)?;
+        }
+        Ok(())
+    }
+
+    fn apply_mux(&mut self, _setting: &crate::MuxSetting) -> Result<(), PinctrlError> {
+        Err(PinctrlError::NotSupported)
+    }
+
+    fn apply_config(&mut self, _setting: &ConfigSetting) -> Result<(), PinctrlError> {
+        Err(PinctrlError::NotSupported)
+    }
+
+    fn create_gpio_bank(&mut self, _bank_id: GpioBankId) -> Option<BGpioBank> {
+        None
+    }
+
+    fn irq_sources(&self) -> Vec<GpioIrqSourceInfo> {
+        Vec::new()
+    }
+
+    fn take_irq_handler(&mut self, _source_id: GpioIrqSourceId) -> Option<BGpioIrqHandler> {
+        None
+    }
+}

--- a/drivers/interface/rdif-pinctrl/src/irq.rs
+++ b/drivers/interface/rdif-pinctrl/src/irq.rs
@@ -1,0 +1,119 @@
+use crate::{GpioBankId, GpioIrqSourceId, GpioLineId};
+
+pub const MAX_GPIO_IRQ_EVENTS: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpioIrqTrigger {
+    EdgeRising,
+    EdgeFalling,
+    EdgeBoth,
+    LevelHigh,
+    LevelLow,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpioIrqError {
+    Overflow,
+    Spurious,
+    Controller,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpioLineEvent {
+    pub line: GpioLineId,
+    pub trigger: GpioIrqTrigger,
+}
+
+impl GpioLineEvent {
+    pub const fn new(line: GpioLineId, trigger: GpioIrqTrigger) -> Self {
+        Self { line, trigger }
+    }
+
+    const fn empty() -> Self {
+        Self {
+            line: GpioLineId::new(GpioBankId::new(0), 0),
+            trigger: GpioIrqTrigger::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpioIrqEvent {
+    source: Option<GpioIrqSourceId>,
+    lines: [GpioLineEvent; MAX_GPIO_IRQ_EVENTS],
+    len: usize,
+    error: Option<GpioIrqError>,
+}
+
+impl GpioIrqEvent {
+    pub const fn none() -> Self {
+        Self {
+            source: None,
+            lines: [GpioLineEvent::empty(); MAX_GPIO_IRQ_EVENTS],
+            len: 0,
+            error: None,
+        }
+    }
+
+    pub fn from_line(line: GpioLineEvent) -> Self {
+        let mut event = Self::none();
+        let _ = event.push_line(line);
+        event
+    }
+
+    pub const fn with_error(error: GpioIrqError) -> Self {
+        Self {
+            source: None,
+            lines: [GpioLineEvent::empty(); MAX_GPIO_IRQ_EVENTS],
+            len: 0,
+            error: Some(error),
+        }
+    }
+
+    pub const fn source(&self) -> Option<GpioIrqSourceId> {
+        self.source
+    }
+
+    pub fn set_source(&mut self, source: GpioIrqSourceId) {
+        self.source = Some(source);
+    }
+
+    pub fn push_line(&mut self, line: GpioLineEvent) -> bool {
+        if self.len == self.lines.len() {
+            self.error = Some(GpioIrqError::Overflow);
+            return false;
+        }
+        self.lines[self.len] = line;
+        self.len += 1;
+        true
+    }
+
+    pub fn lines(&self) -> &[GpioLineEvent] {
+        &self.lines[..self.len]
+    }
+
+    pub const fn error(&self) -> Option<GpioIrqError> {
+        self.error
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0 && self.error.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpioIrqSourceInfo {
+    pub id: GpioIrqSourceId,
+    pub lines: alloc::vec::Vec<GpioLineId>,
+}
+
+impl GpioIrqSourceInfo {
+    pub fn new(id: GpioIrqSourceId, lines: alloc::vec::Vec<GpioLineId>) -> Self {
+        Self { id, lines }
+    }
+}
+
+pub trait GpioIrqHandler: Send + 'static {
+    fn handle_irq(&mut self) -> GpioIrqEvent;
+}

--- a/drivers/interface/rdif-pinctrl/src/lib.rs
+++ b/drivers/interface/rdif-pinctrl/src/lib.rs
@@ -1,0 +1,294 @@
+#![no_std]
+
+extern crate alloc;
+
+mod error;
+#[cfg(feature = "fdt")]
+mod fdt;
+mod gpio;
+mod id;
+mod interface;
+mod irq;
+mod types;
+
+pub use error::*;
+#[cfg(feature = "fdt")]
+pub use fdt::*;
+pub use gpio::*;
+pub use id::*;
+pub use interface::*;
+pub use irq::*;
+pub use rdif_base::{DriverGeneric, KError, io};
+pub use types::*;
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, string::String, vec, vec::Vec};
+
+    use super::*;
+
+    struct Recorder {
+        calls: Vec<&'static str>,
+        pins: Vec<PinDesc>,
+        groups: Vec<PinGroup>,
+        functions: Vec<PinFunction>,
+    }
+
+    impl Recorder {
+        fn new() -> Self {
+            Self {
+                calls: Vec::new(),
+                pins: vec![PinDesc::new(PinId::new(1), Some("gpio1"))],
+                groups: vec![PinGroup::new(
+                    GroupId::new(1),
+                    Some("uart0"),
+                    vec![PinId::new(1)],
+                )],
+                functions: vec![PinFunction::new(
+                    FunctionId::new(1),
+                    Some("uart"),
+                    vec![GroupId::new(1)],
+                )],
+            }
+        }
+    }
+
+    impl DriverGeneric for Recorder {
+        fn name(&self) -> &str {
+            "recorder"
+        }
+    }
+
+    impl Interface for Recorder {
+        fn pins(&self) -> &[PinDesc] {
+            &self.pins
+        }
+
+        fn groups(&self) -> &[PinGroup] {
+            &self.groups
+        }
+
+        fn functions(&self) -> &[PinFunction] {
+            &self.functions
+        }
+
+        fn apply_mux(&mut self, _setting: &MuxSetting) -> Result<(), PinctrlError> {
+            self.calls.push("mux");
+            Ok(())
+        }
+
+        fn apply_config(&mut self, _setting: &ConfigSetting) -> Result<(), PinctrlError> {
+            self.calls.push("config");
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn apply_state_programs_mux_before_config() {
+        let mut recorder = Recorder::new();
+        let state = PinState::named(StateName::Default)
+            .with_mux(MuxSetting::new(
+                GroupId::new(1),
+                FunctionId::new(1),
+                MuxValue::new(8),
+            ))
+            .with_config(ConfigSetting::pin(
+                PinId::new(1),
+                PinConfig::DriveStrengthUa(8000),
+            ));
+
+        recorder.apply_state(&state).unwrap();
+
+        assert_eq!(recorder.calls, vec!["mux", "config"]);
+    }
+
+    #[test]
+    fn validate_state_rejects_invalid_group_function_pair() {
+        let recorder = Recorder::new();
+        let state = PinState::named(StateName::Default).with_mux(MuxSetting::new(
+            GroupId::new(1),
+            FunctionId::new(99),
+            MuxValue::new(2),
+        ));
+
+        assert_eq!(
+            recorder.validate_state(&state),
+            Err(PinctrlError::InvalidFunction(FunctionId::new(99)))
+        );
+    }
+
+    struct MockBank {
+        requested: Option<GpioLineHandle>,
+        value: bool,
+    }
+
+    impl MockBank {
+        fn new() -> Self {
+            Self {
+                requested: None,
+                value: false,
+            }
+        }
+
+        fn ensure_requested(&self, handle: &GpioLineHandle) -> Result<(), PinctrlError> {
+            if self.requested.as_ref() == Some(handle) {
+                Ok(())
+            } else {
+                Err(PinctrlError::LineNotRequested(handle.line()))
+            }
+        }
+    }
+
+    impl GpioBank for MockBank {
+        fn bank_id(&self) -> GpioBankId {
+            GpioBankId::new(0)
+        }
+
+        fn line_count(&self) -> u32 {
+            8
+        }
+
+        fn request_line(
+            &mut self,
+            line: GpioLineId,
+            owner: &str,
+        ) -> Result<GpioLineHandle, PinctrlError> {
+            assert_eq!(owner, "uart");
+            let handle = GpioLineHandle::new(line, OwnerId::new(7));
+            self.requested = Some(handle);
+            Ok(handle)
+        }
+
+        fn release_line(&mut self, handle: GpioLineHandle) -> Result<(), PinctrlError> {
+            self.ensure_requested(&handle)?;
+            self.requested = None;
+            Ok(())
+        }
+
+        fn set_direction(
+            &mut self,
+            handle: &GpioLineHandle,
+            _direction: Direction,
+        ) -> Result<(), PinctrlError> {
+            self.ensure_requested(handle)
+        }
+
+        fn read(&self, handle: &GpioLineHandle) -> Result<bool, PinctrlError> {
+            self.ensure_requested(handle)?;
+            Ok(self.value)
+        }
+
+        fn write(&mut self, handle: &GpioLineHandle, value: bool) -> Result<(), PinctrlError> {
+            self.ensure_requested(handle)?;
+            self.value = value;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn gpio_line_handle_is_required_for_line_io() {
+        let mut bank = MockBank::new();
+        let line = GpioLineId::new(GpioBankId::new(0), 3);
+        let forged = GpioLineHandle::new(line, OwnerId::new(9));
+
+        assert_eq!(
+            bank.write(&forged, true),
+            Err(PinctrlError::LineNotRequested(line))
+        );
+
+        let handle = bank.request_line(line, "uart").unwrap();
+        bank.set_direction(&handle, Direction::Output { initial: false })
+            .unwrap();
+        bank.write(&handle, true).unwrap();
+        assert!(bank.read(&handle).unwrap());
+        bank.release_line(handle).unwrap();
+    }
+
+    struct MockIrq {
+        line: GpioLineId,
+    }
+
+    impl GpioIrqHandler for MockIrq {
+        fn handle_irq(&mut self) -> GpioIrqEvent {
+            GpioIrqEvent::from_line(GpioLineEvent::new(self.line, GpioIrqTrigger::EdgeRising))
+        }
+    }
+
+    #[test]
+    fn gpio_irq_handler_reports_stable_event_without_os_types() {
+        let mut irq = MockIrq {
+            line: GpioLineId::new(GpioBankId::new(2), 5),
+        };
+
+        let event = irq.handle_irq();
+
+        assert_eq!(event.lines().len(), 1);
+        assert_eq!(
+            event.lines()[0].line,
+            GpioLineId::new(GpioBankId::new(2), 5)
+        );
+        assert_eq!(event.lines()[0].trigger, GpioIrqTrigger::EdgeRising);
+    }
+
+    #[test]
+    fn acpi_firmware_specs_can_represent_explicit_unsupported_mapping() {
+        let spec = AcpiPinStateSpec::new(String::from("\\_SB.GPIO"), StateName::Default);
+
+        assert_eq!(spec.state_name(), &StateName::Default);
+        assert_eq!(
+            PinctrlError::UnsupportedFirmware(FirmwareKind::Acpi),
+            PinctrlError::UnsupportedFirmware(FirmwareKind::Acpi)
+        );
+    }
+
+    #[test]
+    fn interface_can_transfer_gpio_irq_handler_ownership() {
+        struct Device {
+            handler: Option<Box<dyn GpioIrqHandler>>,
+        }
+
+        impl DriverGeneric for Device {
+            fn name(&self) -> &str {
+                "dev"
+            }
+        }
+
+        impl Interface for Device {
+            fn take_irq_handler(
+                &mut self,
+                source_id: GpioIrqSourceId,
+            ) -> Option<Box<dyn GpioIrqHandler>> {
+                if source_id == GpioIrqSourceId::new(0) {
+                    self.handler.take()
+                } else {
+                    None
+                }
+            }
+        }
+
+        let mut device = Device {
+            handler: Some(Box::new(MockIrq {
+                line: GpioLineId::new(GpioBankId::new(0), 1),
+            })),
+        };
+
+        assert!(device.take_irq_handler(GpioIrqSourceId::new(0)).is_some());
+        assert!(device.take_irq_handler(GpioIrqSourceId::new(0)).is_none());
+    }
+
+    #[test]
+    fn pinctrl_device_wraps_interface_as_queryable_capability() {
+        let mut device = PinctrlDevice::new(Recorder::new());
+        let state = PinState::named(StateName::Default).with_mux(MuxSetting::new(
+            GroupId::new(1),
+            FunctionId::new(1),
+            MuxValue::new(8),
+        ));
+
+        device.apply_state(&state).unwrap();
+
+        assert_eq!(device.name(), "recorder");
+        assert!(device.typed_ref::<Recorder>().is_some());
+        assert_eq!(device.typed_mut::<Recorder>().unwrap().calls, vec!["mux"]);
+    }
+}

--- a/drivers/interface/rdif-pinctrl/src/types.rs
+++ b/drivers/interface/rdif-pinctrl/src/types.rs
@@ -1,0 +1,255 @@
+use alloc::{string::String, vec::Vec};
+
+use crate::{FunctionId, GpioLineId, GroupId, PinId};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinDesc {
+    pub id: PinId,
+    pub name: Option<&'static str>,
+}
+
+impl PinDesc {
+    pub const fn new(id: PinId, name: Option<&'static str>) -> Self {
+        Self { id, name }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinGroup {
+    pub id: GroupId,
+    pub name: Option<&'static str>,
+    pub pins: Vec<PinId>,
+}
+
+impl PinGroup {
+    pub fn new(id: GroupId, name: Option<&'static str>, pins: Vec<PinId>) -> Self {
+        Self { id, name, pins }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinFunction {
+    pub id: FunctionId,
+    pub name: Option<&'static str>,
+    pub groups: Vec<GroupId>,
+}
+
+impl PinFunction {
+    pub fn new(id: FunctionId, name: Option<&'static str>, groups: Vec<GroupId>) -> Self {
+        Self { id, name, groups }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MuxValue(u32);
+
+impl MuxValue {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MuxSetting {
+    pub group: GroupId,
+    pub function: FunctionId,
+    pub value: MuxValue,
+}
+
+impl MuxSetting {
+    pub const fn new(group: GroupId, function: FunctionId, value: MuxValue) -> Self {
+        Self {
+            group,
+            function,
+            value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Bias {
+    Disabled,
+    BusHold,
+    PullUp,
+    PullDown,
+    PullPinDefault,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlewRate {
+    Slow,
+    Fast,
+    Raw(u32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowPowerMode {
+    Default,
+    Sleep,
+    Retention,
+    HiZ,
+    Raw(u32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinConfig {
+    Bias(Bias),
+    DriveStrengthUa(u32),
+    SlewRate(SlewRate),
+    InputEnable(bool),
+    OutputEnable(bool),
+    OutputValue(bool),
+    DebounceUs(u32),
+    LowPowerMode(LowPowerMode),
+    Vendor { param: u32, value: u32 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigTarget {
+    Pin(PinId),
+    Group(GroupId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConfigSetting {
+    pub target: ConfigTarget,
+    pub config: PinConfig,
+}
+
+impl ConfigSetting {
+    pub const fn pin(pin: PinId, config: PinConfig) -> Self {
+        Self {
+            target: ConfigTarget::Pin(pin),
+            config,
+        }
+    }
+
+    pub const fn group(group: GroupId, config: PinConfig) -> Self {
+        Self {
+            target: ConfigTarget::Group(group),
+            config,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateName {
+    Default,
+    Init,
+    Idle,
+    Sleep,
+    Named(String),
+    Index(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinState {
+    name: StateName,
+    muxes: Vec<MuxSetting>,
+    configs: Vec<ConfigSetting>,
+}
+
+impl PinState {
+    pub fn named(name: StateName) -> Self {
+        Self {
+            name,
+            muxes: Vec::new(),
+            configs: Vec::new(),
+        }
+    }
+
+    pub fn with_mux(mut self, setting: MuxSetting) -> Self {
+        self.muxes.push(setting);
+        self
+    }
+
+    pub fn with_config(mut self, setting: ConfigSetting) -> Self {
+        self.configs.push(setting);
+        self
+    }
+
+    pub fn push_mux(&mut self, setting: MuxSetting) {
+        self.muxes.push(setting);
+    }
+
+    pub fn push_config(&mut self, setting: ConfigSetting) {
+        self.configs.push(setting);
+    }
+
+    pub fn extend(&mut self, other: PinState) {
+        self.muxes.extend(other.muxes);
+        self.configs.extend(other.configs);
+    }
+
+    pub fn name(&self) -> &StateName {
+        &self.name
+    }
+
+    pub fn muxes(&self) -> &[MuxSetting] {
+        &self.muxes
+    }
+
+    pub fn configs(&self) -> &[ConfigSetting] {
+        &self.configs
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FirmwareKind {
+    Static,
+    Fdt,
+    Acpi,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpiPinStateSpec {
+    path: String,
+    state_name: StateName,
+}
+
+impl AcpiPinStateSpec {
+    pub fn new(path: String, state_name: StateName) -> Self {
+        Self { path, state_name }
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn state_name(&self) -> &StateName {
+        &self.state_name
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpiGpioLineSpec {
+    path: String,
+    line: GpioLineId,
+    resource_index: u32,
+}
+
+impl AcpiGpioLineSpec {
+    pub fn new(path: String, line: GpioLineId, resource_index: u32) -> Self {
+        Self {
+            path,
+            line,
+            resource_index,
+        }
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn line(&self) -> GpioLineId {
+        self.line
+    }
+
+    pub fn resource_index(&self) -> u32 {
+        self.resource_index
+    }
+}


### PR DESCRIPTION
## 问题

当前 Rockchip DWC3/xHCI VBUS 和 RK3588 PCIe regulator 仍直接查询 `RockchipPinCtrl` 并调用 SoC 私有 helper。这样 pinctrl、GPIO、GPIO IRQ 的能力边界无法通过 RDIF 统一表达，也让后续从 FDT consumer node 应用 `pinctrl-0` / `gpios` / `gpio` 的逻辑继续耦合在 Rockchip 私有代码里。

## 改动

- 新增 `rdif-pinctrl` crate，定义 typed pin/group/function/GPIO/IRQ ID、`PinState`、typed `PinConfig`、`Interface`、`GpioBank`、`GpioIrqHandler` 和 `PinctrlDevice` capability wrapper。
- 为 `rdif-pinctrl` 增加可选 `fdt` feature，提供 `FdtPinctrlParser` 和 `FdtPinctrl` helper，用于解析 consumer node 的 `pinctrl-names` / `pinctrl-N`、应用 state，以及 fixed regulator 的 pinctrl + GPIO 输出流程。
- fixed regulator 的 RDIF GPIO fallback 现在先写目标输出 latch，再 enable output，避免 Rockchip 适配层在切 output 时短暂驱动旧电平。
- 将 Rockchip `rockchip,pins` / `gpios` / `gpio` 解析移动到 ax-driver 的 `RockchipFdtPinctrlParser`，RDIF core 不内置 SoC 私有 binding；Rockchip FDT `drive-strength` 保留为 vendor raw config，不再伪装成 portable `DriveStrengthUa`。
- Rockchip pinctrl probe 现在注册 `PinctrlDevice`，`RockchipPinCtrl::enable_fixed_regulator()` 保留为兼容薄层并转调 RDIF FDT helper。
- DWC3/xHCI VBUS 和 RK3588 PCIe regulator 改为查询 `PinctrlDevice` 并通过 `FdtPinctrl::apply_fixed_regulator()` 应用，不再直接依赖 `RockchipPinCtrl`。
- 更新 rdrive/RDIF 架构文档，补充 `rdif-pinctrl` 能力边界、endpoint 分离和所有权语义。
- 稳定化 ax-driver FDT binding info 测试，改为比对 phandle 映射出的 controller `DeviceId`，避免依赖全局 `DeviceId` 是否从 0 开始。

## 方案逻辑

`rdif-pinctrl` 只承载跨 OS/跨 SoC 的能力边界：typed state、mux/config 应用顺序、GPIO line ownership 和 GPIO IRQ handler ownership。FDT 中的 SoC 私有 binding 由平台 glue 实现 parser trait，通用 helper 只负责 Linux-style consumer phandle 展开和 fixed regulator 的通用 apply 流程。fixed regulator 的 GPIO 输出路径保持旧 Rockchip helper 的初始电平语义，避免先切 output 后写值造成电源脚瞬态抖动。Rockchip 的 raw drive code 继续留在 SoC glue/vendor config 中，避免污染 `DriveStrengthUa` 的 portable 单位语义。这样 DWC3/xHCI probe 可以通过 RDIF capability 配置 VBUS，同时保留 Rockchip raw mux value 和现有 probe-time regulator 行为。

## 验证

- `cargo fmt`
- `cargo test -p rdif-pinctrl`
- `cargo test -p rdif-pinctrl --features fdt`
- `cargo test -p ax-driver --features rockchip-soc -- --nocapture`
- `cargo test -p ax-driver --features rockchip-dwc-xhci -- --nocapture`
- `cargo test -p ax-driver --features rk3588-pcie -- --nocapture`
- `cargo xtask clippy --package rdif-pinctrl`
- `cargo xtask clippy --package ax-driver`
