### PR TITLE
fix(ax-net): avoid panic on malformed inbound packet in snoop_tcp_packet

### DIFF
--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -950,9 +950,23 @@ impl smoltcp::phy::TxToken for TxToken<'_> {
 
 /// Detects passive TCP opens before smoltcp consumes the incoming packet.
 fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
-    let (src_addr, dst_addr, payload) = match IpVersion::of_packet(buf).unwrap() {
+    // This runs on every received packet *before* smoltcp validates it, on bytes
+    // that are attacker-controlled: the Ethernet layer only checks the L2 header
+    // and forwards any `0x0800`/`0x86DD` frame's payload verbatim. Parse with
+    // checked constructors (as `rx_meta`/`raw`/`dhcp_server` already do) so a
+    // malformed or truncated frame is dropped here instead of panicking the
+    // kernel. `of_packet` indexes `buf[0]`, so guard the empty case first.
+    if buf.is_empty() {
+        return;
+    }
+    let Ok(version) = IpVersion::of_packet(buf) else {
+        return;
+    };
+    let (src_addr, dst_addr, payload) = match version {
         IpVersion::Ipv4 => {
-            let packet = Ipv4Packet::new_unchecked(buf);
+            let Ok(packet) = Ipv4Packet::new_checked(buf) else {
+                return;
+            };
             if packet.next_header() != IpProtocol::Tcp {
                 return;
             }
@@ -963,7 +977,9 @@ fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
             )
         }
         IpVersion::Ipv6 => {
-            let packet = Ipv6Packet::new_unchecked(buf);
+            let Ok(packet) = Ipv6Packet::new_checked(buf) else {
+                return;
+            };
             if packet.next_header() != IpProtocol::Tcp {
                 return;
             }
@@ -974,7 +990,9 @@ fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
             )
         }
     };
-    let tcp_packet = TcpPacket::new_unchecked(payload);
+    let Ok(tcp_packet) = TcpPacket::new_checked(payload) else {
+        return;
+    };
     let src_addr = (src_addr, tcp_packet.src_port()).into();
     let dst_addr = (dst_addr, tcp_packet.dst_port()).into();
     let is_first = tcp_packet.syn() && !tcp_packet.ack();
@@ -1258,5 +1276,39 @@ mod tests {
         assert_eq!(queue.pop(), Some(2));
         assert_eq!(queue.pop(), None);
         assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn snoop_tcp_packet_tolerates_malformed_frames() {
+        // The Ethernet layer forwards any IPv4/IPv6 frame's payload verbatim, so
+        // `snoop_tcp_packet` must not panic on attacker-controlled garbage. Each
+        // input below reaches a parse step that previously used
+        // `unwrap`/`new_unchecked` and would panic; now it is dropped silently.
+        let mut sockets = SocketSet::new(vec![]);
+
+        // Well-formed IPv4 header (IHL=5, proto=TCP, total_len=22) whose TCP
+        // payload is far too short for a 20-byte TCP header.
+        let ipv4_tcp_short: &[u8] = &[
+            0x45, 0x00, 0x00, 0x16, // ver/ihl, tos, total_len = 22
+            0x00, 0x00, 0x00, 0x00, // id, flags/frag
+            0x40, 0x06, 0x00, 0x00, // ttl, proto = TCP(6), checksum
+            10, 0, 0, 1, // src addr
+            10, 0, 0, 2, // dst addr
+            0x00, 0x00, // 2 bytes, not a TCP header
+        ];
+
+        let cases: &[&[u8]] = &[
+            &[],              // empty: `of_packet` would index buf[0]
+            &[0x00],          // version nibble 0 -> `of_packet` Err
+            &[0xf0],          // version nibble 15
+            &[0x45],          // IPv4 claimed, truncated below header
+            &[0x4f, 0, 0, 0], // IPv4 IHL=15 (60 bytes) but 4-byte buffer
+            &[0x60],          // IPv6 claimed, truncated
+            ipv4_tcp_short,   // valid IPv4 + TCP header too short
+        ];
+        for buf in cases {
+            // The assertion is simply that this returns without panicking.
+            snoop_tcp_packet(buf, &mut sockets);
+        }
     }
 }


### PR DESCRIPTION
## 问题

`snoop_tcp_packet`（`net/ax-net/src/router.rs`）在 smoltcp 校验之前、对**每个**收到的报文运行（用于探测被动 TCP 打开）。它解析的是攻击者可控的字节：`EthernetDevice::handle_frame` 只校验以太网 L2 头，对任意 ethertype 为 `0x0800`/`0x86DD` 的帧都把其载荷原样入队、一路传到这里。该函数却用 `unwrap` / `new_unchecked` 解析这些不可信字节，于是单个畸形或截断的帧即可让内核 panic：

- `IpVersion::of_packet(buf).unwrap()`：首字节高 4 位非 4/6 时返回 `Err`，引发 unwrap panic，且 `buf` 为空时 `buf[0]` 越界。
- `Ipv4Packet::new_unchecked(buf).payload()`：按未经校验的 IHL 切片，IHL 过大即会越界引发 panic。
- `TcpPacket::new_unchecked(payload)` 的 `src_port()`/`dst_port()`/`syn()` 等：对过短的 TCP 载荷引发越界产生 panic。

构造一个 ethertype 为 IPv4、IP 内容为垃圾/过短的以太网帧即可触发，属于远程可达的内核 DoS。

## 修复

改为防御式解析：先处理 `buf` 为空的情况，再用 `IpVersion::of_packet().ok()` 和 `*::new_checked()`，任何畸形和截断帧在此处**安全丢弃**而非 panic。这与本仓库 `rx_meta.rs` / `raw.rs` / `dhcp_server.rs` 已有的解析写法一致。除此以外，合法报文的探测行为不变。

## 测试

- 新增单元测试 `snoop_tcp_packet_tolerates_malformed_frames`，覆盖空 buf、非法版本位、截断 IPv4/IPv6 头、IPv4 合法但 TCP 过短等用例。修复前每个用例都会 panic（实测空 buf 命中 `smoltcp .../wire/ip.rs:27` 的 `index out of bounds: the len is 0 but the index is 0`），修复后全部安全返回。
- `cargo test -p ax-net`：34 passed。
- `cargo xtask starry test qemu -c system`（aarch64，smp1 + smp4）：2/2 passed。
