### PR TITLE
test(starry): add Node web framework carpet (node-web)

### DIFF
--- a/apps/starry/node-web/README.md
+++ b/apps/starry/node-web/README.md
@@ -1,0 +1,50 @@
+# node-web — Node.js web-framework carpet
+
+Industrial-grade, on-target test of a set of real Node.js web frameworks, run by **Node.js
+22 LTS** (full V8 JIT, no kernel change) on StarryOS across all four architectures
+(x86_64 / aarch64 / riscv64 / loongarch64).
+
+Each module is a self-contained carpet that exercises one framework's public API surface
+(hundreds of exact-value assertions). Every assertion compares against an exact golden value
+computed from the framework's documented behaviour on this exact node + package version. A
+module prints an anchored `*_DONE` marker only when its internal fail count is zero;
+`run-nweb.sh` runs every module and emits `TEST PASSED` only when all of them pass (no skip).
+
+This app commits **only source + manifests** — no dependency-closure `node_modules/` and no
+generated `kotlin-app.js` are checked in. `prebuild.sh` provisions both reproducibly (see
+`programs/SOURCES.md`).
+
+## Run
+
+```
+cargo xtask starry app qemu -t node-web --arch x86_64
+cargo xtask starry app qemu -t node-web --arch aarch64
+cargo xtask starry app qemu -t node-web --arch riscv64
+cargo xtask starry app qemu -t node-web --arch loongarch64
+```
+
+`prebuild.sh`:
+
+1. `apk add nodejs npm icu-data-full` (Node 22 LTS, Alpine v3.22) into a staged rootfs via
+   `qemu-user-static`, then copies node + its shared-library closure + ICU into the app overlay
+   `/usr`. Offline fallback: `NODE_APK_CACHE`/`NODE_DL_ROOT` (optional).
+2. `npm ci --omit=optional` from the committed `assets/package.json` + `assets/package-lock.json`
+   to provision the pug/express `node_modules` closure into `/root/nweb` (nothing vendored). The
+   closure is pure JS, so it is architecture-independent. Optional local npm cache via
+   `NWEB_NPM_CACHE`/`NODE_DL_ROOT`.
+3. Regenerates `kotlin-app.js` from the committed `assets/kotlin-app.kt` with the pinned Kotlin
+   2.0.21 JS compiler (fetched by sha256, or a host `kotlinc-js`, or an optional pre-generated
+   cache — see `programs/SOURCES.md`), staged into `/root/nweb/carpets`.
+
+## Coverage
+
+| module | framework | dimension | marker |
+|:--|:--|:--|:--|
+| pug | pug 3.0.3 | template engine: full API (render/renderFile/compile/compileFile/compileClient) + tags / attributes / interpolation / escaping / conditionals / iteration / mixins / inheritance / includes / filters / doctype | `PUG_DONE` |
+| express | express 4.21.2 | web framework over real IPv4 loopback: routing / params / query / Router / middleware / body parsers / error handling / static / full response & request API | `EXPRESS_DONE` |
+| kotlin-js | Kotlin/JS (Kotlin 2.0.21 IR → commonjs) | a Kotlin→JS module generated in prebuild from `assets/kotlin-app.kt` and run on node; stdout byte-identical to the golden, per-line + per-token assertions | `KOTLINJS_DONE` |
+
+The carpet sources live in `programs/carpets/`. The pug/express libraries are provisioned by
+`npm ci` from `assets/package.json` + `assets/package-lock.json`, and the Kotlin/JS module is
+generated from `assets/kotlin-app.kt`; neither is committed. See `programs/SOURCES.md` for exact
+versions, sha256 pins, and the Kotlin regeneration recipe.

--- a/apps/starry/node-web/assets/kotlin-REF.out
+++ b/apps/starry/node-web/assets/kotlin-REF.out
@@ -1,0 +1,6 @@
+points=(21,12);(23,14);(25,16)
+areas=12,12,3 total=27
+evens^2 sum=220
+second-of=b
+fib(15)=610
+nullsafe=YES

--- a/apps/starry/node-web/assets/kotlin-app.kt
+++ b/apps/starry/node-web/assets/kotlin-app.kt
@@ -1,0 +1,65 @@
+// kotlin-app.kt — source for the StarryOS node-web Kotlin/JS carpet.
+//
+// Compiled by the Kotlin 2.0.21 Kotlin/JS IR backend to a self-contained commonjs
+// module (kotlin-app.js) that self-executes main() on load and prints six golden
+// lines to stdout (compared byte-for-byte against kotlin-REF.out by KotlinJsCarpet.js).
+//
+// Deterministic: no Date / Math.random / network / timestamps. Exercises a broad slice
+// of Kotlin language + stdlib features (one golden line each):
+//   line 1  data class + componentN/copy       -> points=(21,12);(23,14);(25,16)
+//   line 2  sealed class + exhaustive `when`    -> areas=12,12,3 total=27
+//   line 3  higher-order fns / lambdas / map / filter / sum -> evens^2 sum=220
+//   line 4  generics + extension functions      -> second-of=b
+//   line 5  recursion                           -> fib(15)=610
+//   line 6  null-safety (?. ?: !!)              -> nullsafe=YES
+
+// --- line 1: data class, copy(), componentN via destructuring ---------------
+data class Point(val x: Int, val y: Int) {
+    override fun toString(): String = "($x,$y)"
+}
+
+// --- line 2: sealed class hierarchy + exhaustive `when` ---------------------
+sealed class Shape
+data class Rect(val w: Int, val h: Int) : Shape()
+data class Tri(val base: Int, val height: Int) : Shape()
+data class Circle(val r: Int) : Shape()
+
+fun area(s: Shape): Int = when (s) {          // exhaustive over the sealed hierarchy
+    is Rect -> s.w * s.h
+    is Tri -> s.base * s.height / 2
+    is Circle -> (3.14159 * s.r * s.r).toInt()
+}
+
+// --- line 4: generic extension function ------------------------------------
+fun <T> List<T>.secondOf(): T = this[1]
+
+// --- line 5: recursion ------------------------------------------------------
+fun fib(n: Int): Int = if (n < 2) n else fib(n - 1) + fib(n - 2)
+
+fun main() {
+    // line 1: base points, each mapped through copy() with a scale+translate transform.
+    val points = listOf(Point(10, 5), Point(11, 6), Point(12, 7))
+        .map { p -> p.copy(x = p.x * 2 + 1, y = p.y * 2 + 2) }
+    println("points=" + points.joinToString(";"))
+
+    // line 2: areas of a mixed sealed-class list + their total.
+    val shapes: List<Shape> = listOf(Rect(4, 3), Tri(8, 3), Circle(1))
+    val areas = shapes.map { area(it) }
+    println("areas=" + areas.joinToString(",") + " total=" + areas.sum())
+
+    // line 3: filter evens in 1..10, square each, sum.
+    val evensSq = (1..10).filter { it % 2 == 0 }.map { it * it }.sum()
+    println("evens^2 sum=" + evensSq)
+
+    // line 4: generic extension fn on a List<String>.
+    println("second-of=" + listOf("a", "b", "c").secondOf())
+
+    // line 5: recursion.
+    println("fib(15)=" + fib(15))
+
+    // line 6: null-safety operators ?. ?: !!.
+    val opt: String? = "yes"
+    val forcedLen = opt!!.length                  // !!
+    val verdict = opt?.let { "YES" } ?: "NO"      // ?. and ?:
+    println("nullsafe=" + if (forcedLen == 3) verdict else "NO")
+}

--- a/apps/starry/node-web/assets/package-lock.json
+++ b/apps/starry/node-web/assets/package-lock.json
@@ -1,0 +1,1232 @@
+{
+  "name": "starry-node-web-carpets",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "starry-node-web-carpets",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "express": "4.21.2",
+        "pug": "3.0.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
+    "node_modules/assert-never": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
+      "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==",
+      "license": "MIT"
+    },
+    "node_modules/babel-walk": {
+      "version": "3.0.0-canary-5",
+      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.9.6"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/character-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+      "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-regex": "^1.0.3"
+      }
+    },
+    "node_modules/constantinople": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
+      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.1"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/doctypes": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+      "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-expression": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/js-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
+      "license": "MIT"
+    },
+    "node_modules/jstransformer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
+      "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pug": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
+      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
+      "license": "MIT",
+      "dependencies": {
+        "pug-code-gen": "^3.0.3",
+        "pug-filters": "^4.0.0",
+        "pug-lexer": "^5.0.1",
+        "pug-linker": "^4.0.0",
+        "pug-load": "^3.0.0",
+        "pug-parser": "^6.0.0",
+        "pug-runtime": "^3.0.1",
+        "pug-strip-comments": "^2.0.0"
+      }
+    },
+    "node_modules/pug-attrs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
+      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
+      "license": "MIT",
+      "dependencies": {
+        "constantinople": "^4.0.1",
+        "js-stringify": "^1.0.2",
+        "pug-runtime": "^3.0.0"
+      }
+    },
+    "node_modules/pug-code-gen": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.4.tgz",
+      "integrity": "sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g==",
+      "license": "MIT",
+      "dependencies": {
+        "constantinople": "^4.0.1",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.2",
+        "pug-attrs": "^3.0.0",
+        "pug-error": "^2.1.0",
+        "pug-runtime": "^3.0.1",
+        "void-elements": "^3.1.0",
+        "with": "^7.0.0"
+      }
+    },
+    "node_modules/pug-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
+      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
+      "license": "MIT"
+    },
+    "node_modules/pug-filters": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
+      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
+      "license": "MIT",
+      "dependencies": {
+        "constantinople": "^4.0.1",
+        "jstransformer": "1.0.0",
+        "pug-error": "^2.0.0",
+        "pug-walk": "^2.0.0",
+        "resolve": "^1.15.1"
+      }
+    },
+    "node_modules/pug-lexer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
+      "license": "MIT",
+      "dependencies": {
+        "character-parser": "^2.2.0",
+        "is-expression": "^4.0.0",
+        "pug-error": "^2.0.0"
+      }
+    },
+    "node_modules/pug-linker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
+      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
+      "license": "MIT",
+      "dependencies": {
+        "pug-error": "^2.0.0",
+        "pug-walk": "^2.0.0"
+      }
+    },
+    "node_modules/pug-load": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
+      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "pug-walk": "^2.0.0"
+      }
+    },
+    "node_modules/pug-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
+      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
+      "license": "MIT",
+      "dependencies": {
+        "pug-error": "^2.0.0",
+        "token-stream": "1.0.0"
+      }
+    },
+    "node_modules/pug-runtime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
+      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
+      "license": "MIT"
+    },
+    "node_modules/pug-strip-comments": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
+      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pug-error": "^2.0.0"
+      }
+    },
+    "node_modules/pug-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
+      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
+      "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/with": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
+      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.9.6",
+        "@babel/types": "^7.9.6",
+        "assert-never": "^1.2.1",
+        "babel-walk": "3.0.0-canary-5"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    }
+  }
+}

--- a/apps/starry/node-web/assets/package.json
+++ b/apps/starry/node-web/assets/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "starry-node-web-carpets",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Pinned dependencies for the StarryOS node-web web-framework carpets (pug template engine + express over IPv4 loopback). node_modules is provisioned by prebuild.sh via `npm ci`; it is NOT committed to the source tree.",
+  "license": "MIT",
+  "dependencies": {
+    "express": "4.21.2",
+    "pug": "3.0.3"
+  }
+}

--- a/apps/starry/node-web/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/node-web/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,13 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/node-web/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/node-web/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,14 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]

--- a/apps/starry/node-web/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/node-web/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/node-web/build-x86_64-unknown-none.toml
+++ b/apps/starry/node-web/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/node-web/prebuild.sh
+++ b/apps/starry/node-web/prebuild.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# prebuild.sh — provision a Node.js 22 runtime and stage the node-web framework carpet.
+#
+# Reproducible model (mirrors the merged node-lang / node-lib / python-lang apps): extract the
+# base Alpine rootfs to a staging tree, `apk add nodejs npm icu-data-full` INTO it via
+# qemu-user-static (apk resolves the CURRENT v3.22 closure for the target arch — no hard-coded
+# drifting apk URLs, no pre-cached-or-exit), then copy node + its shared-library closure + ICU
+# data into the app overlay. NOTHING generated or vendored lives in the source tree:
+#
+#   * the web-framework node_modules closure (pug 3.0.3 + express 4.21.2) is provisioned by
+#     `npm ci --omit=optional` from the committed assets/package.json + assets/package-lock.json
+#     into a scratch dir, then copied into the overlay. The closure is pure JS (no native .node
+#     addons), hence architecture-independent and valid for all four target arches.
+#
+#   * kotlin-app.js (the Kotlin/JS module the KotlinJsCarpet runs) is GENERATED in prebuild from
+#     the committed Kotlin source assets/kotlin-app.kt by the pinned Kotlin 2.0.21 JS (IR) compiler
+#     (fetched by sha256, cache-or-fetch) — see programs/SOURCES.md. The emitted module is pure JS
+#     (arch-independent). An OPTIONAL pre-generated cache short-circuits the compiler download.
+#
+# npm reaches the registry via the ambient HTTP(S)_PROXY env (set by the app runner). If a local
+# npm tarball cache is provided (NWEB_NPM_CACHE, or $NODE_DL_ROOT/npm-cache), npm ci runs
+# --prefer-offline against it and falls back to the network on a miss (never cache-miss-exit).
+#
+# If the build host has no network for apk, node install falls back to a documented, pre-fetched
+# apk cache at $NODE_APK_CACHE/<arch>/ (default <repo>/download/nodejs-apks/<arch>); OPTIONAL.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS (base alpine working copy),
+# STARRY_STAGING_ROOT (scratch extraction tree), STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+ASSETS="$app_dir/assets"
+PROG="$app_dir/programs"
+repo_root="$(cd "$app_dir/../../.." 2>/dev/null && pwd)"
+
+# Optional offline apk cache (pre-fetched v3.22 closure) — only used if the network apk path
+# below fails. Overridable via NODE_APK_CACHE (explicit dir) or NODE_DL_ROOT (its parent root).
+default_cache="$repo_root/download/nodejs-apks"
+apk_cache="${NODE_APK_CACHE:-${NODE_DL_ROOT:+$NODE_DL_ROOT/nodejs-apks}}"
+apk_cache="${apk_cache:-$default_cache}"
+
+# Kotlin/JS toolchain + artifact provenance (see programs/SOURCES.md). Both pinned by sha256.
+KOTLIN_VER="2.0.21"
+KOTLIN_ZIP_SHA256="0352c0a45bd22f80f6b26e485cd04da8047baa5de54865281fb9f89a4a7bcf2a"
+KOTLIN_COMPILER_URL="https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VER}/kotlin-compiler-${KOTLIN_VER}.zip"
+# Canonical sha256 of the kotlin-app.js emitted from assets/kotlin-app.kt by the recipe below
+# (deterministic across builds with the pinned compiler). Used to validate an optional cache.
+KOTLINJS_SHA256="a5a327d40870078089f405fd969936df0ee5676eb66ec96042f7162b404f8966"
+kotlin_cache="${KOTLINJS_CACHE:-${NODE_DL_ROOT:+$NODE_DL_ROOT/kotlinjs}}"
+kotlin_cache="${kotlin_cache:-$repo_root/download/kotlinjs}"
+
+qemu_runner_candidates() {
+    case "$arch" in
+        aarch64)     printf '%s\n' qemu-aarch64-static qemu-aarch64 ;;
+        riscv64)     printf '%s\n' qemu-riscv64-static qemu-riscv64 ;;
+        x86_64)      printf '%s\n' qemu-x86_64-static qemu-x86_64 ;;
+        loongarch64) printf '%s\n' qemu-loongarch64-static qemu-loongarch64 ;;
+        *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+}
+find_qemu_runner() {
+    local candidate
+    while IFS= read -r candidate; do
+        command -v "$candidate" >/dev/null 2>&1 && { command -v "$candidate"; return 0; }
+    done < <(qemu_runner_candidates)
+    echo "prebuild: missing qemu-user runner for arch $arch; tried: $(qemu_runner_candidates | paste -sd ', ' -)" >&2
+    exit 1
+}
+qemu_runner="$(find_qemu_runner)"
+
+sha256_of() { sha256sum "$1" 2>/dev/null | cut -d' ' -f1; }
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v readelf >/dev/null 2>&1 || missing+=(binutils)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get update && apt-get install -y --no-install-recommends "${missing[@]}"
+        else
+            echo "prebuild: missing host tools and no apt-get: ${missing[*]}" >&2; exit 1
+        fi
+    fi
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    # qemu-user resolves ABSOLUTE symlink targets against the HOST root, so an alpine
+    # `usr/lib/libz.so.1 -> /usr/lib/libz.so.1.3.2` dangles on a non-alpine build host and apk
+    # fails to load its libz/libssl closure ("symbol not found"). Rewrite absolute symlinks under
+    # the staging lib dirs to relative targets that resolve inside the staging tree.
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+install_node() {
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local repo="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/v3.22/main\n%s/v3.22/community\n' "$repo" "$repo" > "$staging_root/etc/apk/repositories"
+    echo "prebuild: apk add nodejs npm icu-data-full (Node 22 LTS) from Alpine v3.22 via $qemu_runner..."
+    if QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" --root "$staging_root" \
+            --repositories-file "$staging_root/etc/apk/repositories" --keys-dir "$staging_root/etc/apk/keys" \
+            --update-cache --no-progress --no-scripts add nodejs npm icu-data-full
+    then echo "prebuild: provisioned nodejs via network apk"
+    else echo "prebuild: network apk failed; falling back to offline apk cache $apk_cache/$arch"; install_node_offline; fi
+}
+install_node_offline() {
+    local dir="$apk_cache/$arch"
+    [[ -d "$dir" ]] || { echo "prebuild: offline apk cache missing: $dir" >&2; exit 3; }
+    local apks=( musl libgcc "libstdc++" zlib zstd-libs brotli-libs c-ares nghttp2-libs
+        ada-libs simdjson simdutf sqlite-libs libcrypto3 libssl3 icu-libs icu-data-full nodejs )
+    local pkg f
+    for pkg in "${apks[@]}"; do
+        f="$(ls "$dir/${pkg}"-[0-9]*.apk 2>/dev/null | head -1 || true)"
+        [[ -n "$f" ]] || { echo "prebuild: offline apk missing for '$pkg' in $dir" >&2; exit 3; }
+        tar -xzf "$f" -C "$staging_root" --exclude='.PKGINFO' --exclude='.SIGN.*' \
+            --exclude='.pre-install' --exclude='.post-install' --exclude='.trigger' 2>/dev/null || true
+    done
+    echo "prebuild: provisioned nodejs offline from ${#apks[@]} apks"
+}
+
+verify_node() {
+    [[ -x "$staging_root/usr/bin/node" ]] || { echo "prebuild: no /usr/bin/node after install" >&2; exit 4; }
+    # Best-effort version gate. Probing the freshly-apk'd node under qemu-user can crash for the
+    # SAME-arch case (x86 node under qemu-x86_64-static — V8 JIT/mmap trips a qemu-user SIGSEGV),
+    # so an empty/failed probe is NOT fatal: apk already verified the package, and run-nweb.sh on
+    # the real StarryOS target prints the node version and gates the carpets (authoritative check).
+    local nodever
+    nodever="$(QEMU_LD_PREFIX="$staging_root" "$qemu_runner" -L "$staging_root" \
+        "$staging_root/usr/bin/node" -p 'process.versions.node' 2>/dev/null || true)"
+    case "$nodever" in
+        22.*|2[3-9].*|[3-9][0-9].*) echo "prebuild: provisioned node v$nodever" ;;
+        '') echo "prebuild: node version probe unavailable under qemu-user (same-arch V8/JIT); on-target run-nweb.sh gates the version" ;;
+        *) echo "prebuild: WARNING unexpected node version '$nodever' (want >=22); deferring to on-target run" ;;
+    esac
+}
+
+copy_to_overlay() {
+    local src="$staging_root$1" dst="$overlay_dir$1"
+    [[ -e "$src" ]] || { echo "prebuild: missing $1 after install" >&2; exit 6; }
+    [[ -L "$src" ]] && src="$(readlink -f "$src")"
+    install -Dm"$2" "$src" "$dst"
+}
+copy_so_closure() {
+    local pending=("$@") seen=" " gp lib d
+    while [[ ${#pending[@]} -gt 0 ]]; do
+        gp="${pending[0]}"; pending=("${pending[@]:1}")
+        [[ "$seen" == *" $gp "* ]] && continue
+        seen+="$gp "
+        while IFS= read -r lib; do
+            for d in lib usr/lib usr/local/lib; do
+                if [[ -e "$staging_root/$d/$lib" ]]; then
+                    copy_to_overlay "/$d/$lib" 0644; pending+=("/$d/$lib"); break
+                fi
+            done
+        done < <(readelf -d "$staging_root$gp" 2>/dev/null | sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p')
+    done
+}
+
+# Run `npm ci --omit=optional` inside $1 (which already holds package.json + package-lock.json).
+# Primary runner: the build host's own npm — node_modules is pure JS and thus
+# architecture-independent, so host npm produces a tree valid for every target arch. Fallback: the
+# musl npm apk-provisioned into the staging rootfs, executed under qemu-user-static. Extra args
+# (e.g. --cache/--prefer-offline) are appended.
+run_npm_ci() {
+    local dir="$1"; shift
+    if command -v npm >/dev/null 2>&1; then
+        echo "prebuild: npm ci via host npm $(npm --version) (arch-independent JS closure)"
+        if ( cd "$dir" && npm ci --omit=optional --no-audit --no-fund --loglevel=warn "$@" ); then
+            return 0
+        fi
+        echo "prebuild: host npm ci failed; trying apk-provisioned npm under qemu-user" >&2
+    fi
+    local npm_cli="$staging_root/usr/lib/node_modules/npm/bin/npm-cli.js"
+    [[ -f "$npm_cli" ]] || { echo "prebuild: no host npm and no apk npm at $npm_cli" >&2; return 1; }
+    echo "prebuild: npm ci via apk npm under $qemu_runner (musl node, arch $arch)"
+    ( cd "$dir" && QEMU_LD_PREFIX="$staging_root" HOME="$dir" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/usr/bin/node" "$npm_cli" \
+            ci --omit=optional --no-audit --no-fund --loglevel=warn "$@" )
+}
+
+# Provision the web-framework dependency closure into $1 (the overlay's /root/nweb) by fetching it
+# with npm ci from the committed manifests — nothing binary lives in the source tree.
+provision_node_modules() {
+    local nw="$1" stage
+    [[ -f "$ASSETS/package.json" && -f "$ASSETS/package-lock.json" ]] || {
+        echo "prebuild: missing assets/package.json or assets/package-lock.json" >&2; exit 7; }
+    stage="$(mktemp -d "${TMPDIR:-/tmp}/nweb-npm.XXXXXX")"
+    cp "$ASSETS/package.json" "$ASSETS/package-lock.json" "$stage/"
+
+    local extra=() npm_cache="${NWEB_NPM_CACHE:-${NODE_DL_ROOT:+$NODE_DL_ROOT/npm-cache}}"
+    if [[ -n "$npm_cache" && -d "$npm_cache" ]]; then
+        echo "prebuild: using local npm cache $npm_cache (--prefer-offline; network on miss)"
+        extra=(--cache "$npm_cache" --prefer-offline)
+    fi
+
+    if ! run_npm_ci "$stage" "${extra[@]}"; then
+        echo "prebuild: npm ci failed (need network to the npm registry, or a populated cache)" >&2
+        rm -rf "$stage"; exit 7
+    fi
+    [[ -d "$stage/node_modules" ]] || { echo "prebuild: npm ci produced no node_modules" >&2; rm -rf "$stage"; exit 7; }
+
+    # Sanity: every module the carpets require() must be present.
+    local m
+    for m in pug express; do
+        [[ -f "$stage/node_modules/$m/package.json" ]] || {
+            echo "prebuild: required module '$m' missing after npm ci" >&2; rm -rf "$stage"; exit 7; }
+    done
+
+    rm -rf "$nw/node_modules"
+    cp -a "$stage/node_modules" "$nw/node_modules"
+    rm -rf "$stage"
+}
+
+# ── Kotlin/JS: generate kotlin-app.js from the committed kotlin-app.kt ──────────────────────
+# verify_kotlin_js <path>: structural + functional gate. Size range (whole-program stdlib inline,
+# no DCE), IR polyfills hallmark, and — when host node is present — a run that must reproduce the
+# committed golden assets/kotlin-REF.out byte-for-byte.
+verify_kotlin_js() {
+    local js="$1" sz out
+    [[ -f "$js" ]] || return 1
+    sz="$(wc -c < "$js")"
+    (( sz > 500000 && sz < 800000 )) || { echo "prebuild: kotlin-app.js size $sz outside [500000,800000)" >&2; return 1; }
+    grep -q 'region block: polyfills' "$js" || { echo "prebuild: kotlin-app.js missing IR polyfills hallmark" >&2; return 1; }
+    if command -v node >/dev/null 2>&1; then
+        out="$(node "$js" 2>/dev/null || true)"
+        [[ "$out" == "$(cat "$ASSETS/kotlin-REF.out")" ]] || { echo "prebuild: kotlin-app.js output != golden kotlin-REF.out" >&2; return 1; }
+    fi
+    return 0
+}
+
+# ensure_kotlin_compiler: echo an absolute path to a usable kotlinc-js, or return 1. Uses a host
+# kotlinc-js if on PATH, otherwise fetches the pinned Kotlin compiler (sha256) into the cache and
+# runs it with the host JVM.
+ensure_kotlin_compiler() {
+    if command -v kotlinc-js >/dev/null 2>&1; then command -v kotlinc-js; return 0; fi
+    local java=""
+    if command -v java >/dev/null 2>&1; then java="$(command -v java)"
+    elif [[ -n "${JAVA_HOME:-}" && -x "$JAVA_HOME/bin/java" ]]; then java="$JAVA_HOME/bin/java"; fi
+    [[ -n "$java" ]] || { echo "prebuild: no kotlinc-js on PATH and no JVM to run the fetched Kotlin compiler" >&2; return 1; }
+    export JAVA_HOME="$(cd "$(dirname "$java")/.." && pwd)"
+    local kc="$kotlin_cache/kotlinc" zip="$kotlin_cache/kotlin-compiler-${KOTLIN_VER}.zip"
+    if [[ ! -x "$kc/bin/kotlinc-js" ]]; then
+        command -v unzip >/dev/null 2>&1 || { echo "prebuild: need unzip to unpack the Kotlin compiler" >&2; return 1; }
+        mkdir -p "$kotlin_cache"
+        if [[ ! -f "$zip" || "$(sha256_of "$zip")" != "$KOTLIN_ZIP_SHA256" ]]; then
+            command -v curl >/dev/null 2>&1 || { echo "prebuild: need curl to fetch the Kotlin compiler" >&2; return 1; }
+            echo "prebuild: fetching Kotlin $KOTLIN_VER compiler <- $KOTLIN_COMPILER_URL"
+            curl -fSL --retry 3 --connect-timeout 30 "$KOTLIN_COMPILER_URL" -o "$zip.tmp"
+            local got; got="$(sha256_of "$zip.tmp")"
+            [[ "$got" == "$KOTLIN_ZIP_SHA256" ]] || { echo "prebuild: Kotlin compiler sha256 mismatch (got $got want $KOTLIN_ZIP_SHA256)" >&2; rm -f "$zip.tmp"; return 1; }
+            mv -f "$zip.tmp" "$zip"
+        fi
+        ( cd "$kotlin_cache" && unzip -q -o "$zip" )
+    fi
+    [[ -x "$kc/bin/kotlinc-js" ]] && { echo "$kc/bin/kotlinc-js"; return 0; }
+    return 1
+}
+
+# build_kotlin_app_js <dest>: compile assets/kotlin-app.kt -> commonjs kotlin-app.js at <dest>
+# via the two-step Kotlin/JS IR flow (klib, then link). NB: -ir-output-dir MUST be absolute
+# (a relative dir makes kotlinc-js silently emit nothing) and -language-version 1.9 is required
+# (the K2 default silently produces no JS from an -Xinclude'd klib in 2.0.21). See SOURCES.md.
+build_kotlin_app_js() {
+    local dest="$1" kt="$ASSETS/kotlin-app.kt" kjs stdlib work produced
+    [[ -f "$kt" ]] || { echo "prebuild: missing assets/kotlin-app.kt" >&2; return 1; }
+    kjs="$(ensure_kotlin_compiler)" || return 1
+    stdlib="$(dirname "$(dirname "$kjs")")/lib/kotlin-stdlib-js.klib"
+    [[ -f "$stdlib" ]] || { echo "prebuild: kotlin-stdlib-js.klib not found at $stdlib" >&2; return 1; }
+    work="$(mktemp -d "${TMPDIR:-/tmp}/nweb-kotlin.XXXXXX")"; mkdir -p "$work/klib" "$work/js"
+    echo "prebuild: compiling kotlin-app.kt -> klib (Kotlin $KOTLIN_VER IR)"
+    "$kjs" -libraries "$stdlib" -Xir-produce-klib-file \
+        -ir-output-dir "$work/klib" -ir-output-name kotlin-app \
+        -output "$work/klib/kotlin-app.klib" "$kt" || { rm -rf "$work"; return 1; }
+    echo "prebuild: linking klib -> commonjs kotlin-app.js"
+    "$kjs" -Xir-produce-js -language-version 1.9 \
+        -Xinclude="$work/klib/kotlin-app.klib" -libraries "$stdlib" \
+        -ir-output-dir "$work/js" -ir-output-name kotlin-app \
+        -module-kind commonjs -main call || { rm -rf "$work"; return 1; }
+    produced="$(find "$work/js" -name 'kotlin-app.js' | head -1)"
+    [[ -n "$produced" ]] || { echo "prebuild: kotlinc-js produced no kotlin-app.js" >&2; rm -rf "$work"; return 1; }
+    install -Dm0644 "$produced" "$dest"
+    rm -rf "$work"
+}
+
+# provision_kotlin_app_js <dest>: put a validated kotlin-app.js at <dest>. Fast path: an optional
+# sha256-pinned pre-generated cache (no JVM/compiler/network). Primary reproducible path: build
+# from the committed source. Never a silent fallback.
+provision_kotlin_app_js() {
+    local dest="$1" cached="$kotlin_cache/kotlin-app.js"
+    if [[ -f "$cached" && "$(sha256_of "$cached")" == "$KOTLINJS_SHA256" ]] && verify_kotlin_js "$cached"; then
+        echo "prebuild: kotlin-app.js from cache $cached (sha256 pinned)"
+        install -Dm0644 "$cached" "$dest"; return 0
+    fi
+    if build_kotlin_app_js "$dest" && verify_kotlin_js "$dest"; then
+        echo "prebuild: kotlin-app.js generated from assets/kotlin-app.kt via Kotlin $KOTLIN_VER ($(wc -c <"$dest") bytes)"
+        mkdir -p "$kotlin_cache" 2>/dev/null && cp -f "$dest" "$cached" 2>/dev/null || true
+        return 0
+    fi
+    echo "prebuild: FAILED to provision kotlin-app.js — need EITHER a JVM + network (fetch Kotlin $KOTLIN_VER, sha256 $KOTLIN_ZIP_SHA256, to compile assets/kotlin-app.kt) OR a pre-generated cache at $cached (sha256 $KOTLINJS_SHA256). See programs/SOURCES.md." >&2
+    exit 8
+}
+
+populate_overlay() {
+    copy_to_overlay /usr/bin/node 0755
+    copy_so_closure /usr/bin/node
+    ln -sf node "$overlay_dir/usr/bin/nodejs" 2>/dev/null || true
+
+    # ELF program interpreter (musl loader) under its real name (DT_NEEDED only names the symlink).
+    local interp real
+    interp="$(readelf -l "$staging_root/usr/bin/node" 2>/dev/null | sed -n 's/.*program interpreter: \(.*\)\]/\1/p' | tr -d ' ')"
+    if [[ -n "$interp" && -e "$staging_root$interp" ]]; then
+        real="$interp"
+        [[ -L "$staging_root$interp" ]] && real="$(readlink -f "$staging_root$interp")" && real="${real#"$staging_root"}"
+        install -Dm0755 "$staging_root$real" "$overlay_dir$interp"
+    fi
+
+    # ICU data table (Intl.* / toLocaleString) + musl loader search path.
+    if [[ -d "$staging_root/usr/share/icu" ]]; then
+        mkdir -p "$overlay_dir/usr/share/icu"; cp -a "$staging_root/usr/share/icu/." "$overlay_dir/usr/share/icu/"
+    fi
+    if [[ -f "$staging_root/etc/ld-musl-${arch}.path" ]]; then
+        install -Dm0644 "$staging_root/etc/ld-musl-${arch}.path" "$overlay_dir/etc/ld-musl-${arch}.path"
+    else
+        mkdir -p "$overlay_dir/etc"; printf '/lib\n/usr/lib\n/usr/local/lib\n' > "$overlay_dir/etc/ld-musl-${arch}.path"
+    fi
+
+    # Stage the carpet sources + kotlin golden into /root/nweb, the run-nweb.sh gate into /usr/bin,
+    # then provision the pug/express node_modules closure (npm ci) and regenerate kotlin-app.js
+    # from source (kotlinc-js) — neither is vendored in the tree. Each carpet resolves require()
+    # from /root/nweb/node_modules (run-nweb.sh cd's there); KotlinJsCarpet.js resolves the kotlin
+    # module + golden via __dirname, so kotlin-app.js + kotlin-REF.out live under carpets/.
+    local nw="$overlay_dir/root/nweb"
+    install -d "$nw/carpets"
+    install -m0644 "$PROG/carpets/PugCarpet.js" "$PROG/carpets/ExpressCarpet.js" \
+        "$PROG/carpets/KotlinJsCarpet.js" "$nw/carpets/"
+    install -m0644 "$ASSETS/kotlin-REF.out" "$nw/carpets/"
+    provision_kotlin_app_js "$nw/carpets/kotlin-app.js"
+    provision_node_modules "$nw"
+    install -Dm0755 "$PROG/run-nweb.sh" "$overlay_dir/usr/bin/run-nweb.sh"
+
+    echo "prebuild: staged node + .so closure + ICU + npm-ci node_modules ($(du -sh "$nw/node_modules" | cut -f1)) + kotlin-app.js + 3 carpets; overlay ready for $arch"
+}
+
+ensure_host_tools
+extract_base_rootfs
+normalize_symlinks
+install_node
+verify_node
+populate_overlay

--- a/apps/starry/node-web/programs/SOURCES.md
+++ b/apps/starry/node-web/programs/SOURCES.md
@@ -1,0 +1,95 @@
+# node-web — asset provenance (source-only repo)
+
+This app commits **only source + manifests**. No dependency-closure `node_modules/` and no
+generated `kotlin-app.js` are checked in. `prebuild.sh` provisions both from committed source in
+a reproducible, integrity-checked way and stages the result into the per-app rootfs. This file
+records the provenance of every provisioned / generated asset.
+
+## Node runtime (Alpine v3.22, apk)
+
+`prebuild.sh` runs `apk add nodejs npm icu-data-full` (Node.js 22 LTS) into a staged copy of the
+base Alpine rootfs via `qemu-user-static`, resolving the CURRENT v3.22 closure for the target
+arch (no pinned/drifting apk URLs). node + its shared-library closure + ICU data are copied into
+the app overlay. Offline fallback: a pre-fetched apk cache under `$NODE_APK_CACHE/<arch>/`
+(default `<repo>/download/nodejs-apks/<arch>`) — OPTIONAL, network is the primary path.
+
+## Web-framework dependency closure (`node_modules`, via `npm ci`)
+
+The pug/express closure is NOT vendored. `prebuild.sh` runs `npm ci --omit=optional` from the
+committed `assets/package.json` + `assets/package-lock.json` into a scratch dir and copies the
+resulting `node_modules` into `/root/nweb`. The closure is pure JS (no native `.node` addons),
+hence architecture-independent and valid for all four target arches. Direct dependencies:
+
+| package | version | used by |
+|:--|:--|:--|
+| pug     | 3.0.3   | PugCarpet.js (template engine) |
+| express | 4.21.2  | ExpressCarpet.js (web framework over IPv4 loopback) |
+
+The full transitive closure (107 packages) is locked by `assets/package-lock.json`
+(`lockfileVersion: 3`). `--omit=optional` drops optional native deps (none are required by the
+carpets). To regenerate the lockfile after a version bump: `npm install` in a dir containing only
+`assets/package.json`.
+
+## Kotlin/JS module (`kotlin-app.js`, generated from `assets/kotlin-app.kt`)
+
+`kotlin-app.js` is NOT committed. It is regenerated in `prebuild.sh` from the committed Kotlin
+source `assets/kotlin-app.kt` by the **Kotlin 2.0.21** JS (IR) compiler, and staged next to the
+KotlinJsCarpet under `/root/nweb/carpets/`. The emitted commonjs module is pure JS
+(architecture-independent). `KotlinJsCarpet.js` runs it and asserts its stdout is byte-identical
+to the golden `assets/kotlin-REF.out` (a small, hand-authored 6-line text fixture — it stays
+committed) with thorough per-line / per-token checks.
+
+### Kotlin compiler (fetched by sha256, cache-or-fetch)
+
+| asset | url | sha256 |
+|:--|:--|:--|
+| kotlin-compiler-2.0.21.zip | https://github.com/JetBrains/kotlin/releases/download/v2.0.21/kotlin-compiler-2.0.21.zip | `0352c0a45bd22f80f6b26e485cd04da8047baa5de54865281fb9f89a4a7bcf2a` |
+
+`prebuild.sh` uses a host `kotlinc-js` if one is on `PATH`; otherwise it fetches the pinned
+compiler into the cache (default `<repo>/download/kotlinjs`, overridable via `KOTLINJS_CACHE` or
+`$NODE_DL_ROOT/kotlinjs`) and runs it with the host JVM. The Kotlin JS compiler needs a JVM
+(`java` on `PATH` or `$JAVA_HOME`).
+
+### Regeneration recipe (exact commands `prebuild.sh` runs)
+
+`STDLIB=<kotlinc>/lib/kotlin-stdlib-js.klib`. **`-ir-output-dir` MUST be an absolute path** (a
+relative dir makes `kotlinc-js` silently emit no file), and **`-language-version 1.9` is
+required** (the K2 default silently produces no JS from an `-Xinclude`d klib in 2.0.21). Two-step
+IR flow (source → klib → commonjs js):
+
+```
+kotlinc-js -libraries "$STDLIB" -Xir-produce-klib-file \
+  -ir-output-dir "$ABS/klib" -ir-output-name kotlin-app \
+  -output "$ABS/klib/kotlin-app.klib" assets/kotlin-app.kt
+
+kotlinc-js -Xir-produce-js -language-version 1.9 \
+  -Xinclude="$ABS/klib/kotlin-app.klib" -libraries "$STDLIB" \
+  -ir-output-dir "$ABS/js" -ir-output-name kotlin-app \
+  -module-kind commonjs -main call
+# -> $ABS/js/kotlin-app.js
+```
+
+The build is deterministic: with the pinned compiler + committed source it emits a whole-program
+commonjs module that inlines the Kotlin stdlib (no DCE), **653669 bytes**, sha256
+`a5a327d40870078089f405fd969936df0ee5676eb66ec96042f7162b404f8966`, whose stdout is byte-identical
+to `assets/kotlin-REF.out`. `KotlinJsCarpet.js` asserts the file size in `[500000, 800000)` (a
+tight range rather than one exact byte count, robust to a future Kotlin patch bump) plus the IR
+polyfills hallmark, and — decisively — byte-exact stdout vs the golden.
+
+### Optional pre-generated cache
+
+If `$KOTLINJS_CACHE/kotlin-app.js` (default `<repo>/download/kotlinjs/kotlin-app.js`) exists and
+matches the sha256 above, `prebuild.sh` uses it directly and skips the compiler download (fast
+path for environments without a JVM / network — analogous to the offline apk cache). This cache
+is NEVER committed; the source-build path above is the reproducible primary.
+
+### Kotlin features exercised by `kotlin-app.kt` (one golden line each)
+
+| line | feature | golden output |
+|:--|:--|:--|
+| 1 | data class + `componentN`/`copy` | `points=(21,12);(23,14);(25,16)` |
+| 2 | sealed class + exhaustive `when` | `areas=12,12,3 total=27` |
+| 3 | higher-order fns / lambdas / map/filter/sum | `evens^2 sum=220` |
+| 4 | generics + extension functions | `second-of=b` |
+| 5 | recursion | `fib(15)=610` |
+| 6 | null-safety (`?.` `?:` `!!`) | `nullsafe=YES` |

--- a/apps/starry/node-web/programs/carpets/ExpressCarpet.js
+++ b/apps/starry/node-web/programs/carpets/ExpressCarpet.js
@@ -1,0 +1,435 @@
+'use strict';
+// INDUSTRIAL carpet for express 4.21.2 on Node.js 22 LTS.
+// Drives a real express app over IPv4 loopback (127.0.0.1) with node's built-in
+// http client. Every assertion is an exact-value check against a golden observed
+// from the real package on this exact version. Deterministic only.
+
+const express = require('express');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+// ---- self-check harness (mirrors java-web carpets) -------------------------
+let ok = 0, fail = 0;
+function chk(cond, name) {
+  if (cond) { ok++; } else { fail++; console.log('FAIL ' + name); }
+}
+function eq(actual, expected, name) {
+  const c = actual === expected;
+  if (!c) console.log('  expected=' + JSON.stringify(expected) + ' actual=' + JSON.stringify(actual));
+  chk(c, name);
+}
+
+// ---- deterministic on-disk assets (self-contained) -------------------------
+const ROOT = process.cwd();
+const PUB = path.join(ROOT, 'pub');
+const VIEWS = path.join(ROOT, 'views');
+fs.mkdirSync(PUB, { recursive: true });
+fs.mkdirSync(VIEWS, { recursive: true });
+fs.writeFileSync(path.join(PUB, 'hello.txt'), 'hello static world\n');
+fs.writeFileSync(path.join(VIEWS, 'page.pug'),
+  'html\n  head\n    title= title\n  body\n    h1= heading\n    p Hello #{name}\n');
+
+// ---- build ONE app mounting every feature ----------------------------------
+const app = express();
+app.set('etag', false);                 // deterministic static (no mtime ETag)
+app.set('views', VIEWS);
+app.set('view engine', 'pug');
+app.set('custom-setting', 'CVAL');
+app.locals.appName = 'CarpetApp';
+
+// body parsers
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.text());
+app.use(express.raw());
+
+// global middleware: sets a header + a req prop, then next()
+app.use((req, res, next) => { res.set('X-Global', 'G'); req.globalFlag = 'GLOBAL'; next(); });
+
+// path-scoped middleware
+app.use('/scoped', (req, res, next) => { req.scopedFlag = 'SCOPED'; next(); });
+
+// --- Routing verbs -----------------------------------------------------------
+app.get('/json', (req, res) => res.json({ a: 1, b: 'x' }));
+app.get('/send-str', (req, res) => res.send('<p>hi</p>'));
+app.get('/send-buf', (req, res) => res.send(Buffer.from('abc')));
+app.get('/send-obj', (req, res) => res.send({ k: 2 }));
+app.get('/type', (req, res) => res.type('txt').send('plain'));
+app.get('/typeext', (req, res) => { res.type('application/json'); res.send('{}'); });
+app.get('/ss204', (req, res) => res.sendStatus(204));
+app.get('/ss404', (req, res) => res.sendStatus(404));
+app.get('/redir', (req, res) => res.redirect('/dest'));
+app.get('/redir301', (req, res) => res.redirect(301, '/dest'));
+app.get('/cookie', (req, res) => { res.cookie('foo', 'bar'); res.send('ck'); });
+app.get('/links', (req, res) => { res.links({ next: 'http://x/2', last: 'http://x/5' }); res.send('lk'); });
+app.get('/vary', (req, res) => { res.vary('Accept'); res.send('vy'); });
+app.get('/loc', (req, res) => { res.location('/somewhere'); res.end(); });
+app.get('/append', (req, res) => { res.append('X-Multi', 'a'); res.append('X-Multi', 'b'); res.send('ap'); });
+app.get('/getset', (req, res) => { res.set('X-Foo', 'FV'); res.json({ got: res.get('X-Foo') }); });
+app.get('/setobj', (req, res) => { res.set({ 'X-A': '1', 'X-B': '2' }); res.send('ok'); });
+app.get('/status201', (req, res) => res.status(201).send('created'));
+app.get('/jstatus', (req, res) => res.status(422).json({ e: 'bad' }));
+app.get('/jsonp', (req, res) => res.jsonp({ j: 1 }));
+app.get('/attach', (req, res) => { res.attachment('report.pdf'); res.send('PDF'); });
+app.get('/xpb', (req, res) => res.send('xpb'));
+
+app.put('/put', (req, res) => res.send('put-ok'));
+app.patch('/patch', (req, res) => res.send('patch-ok'));
+app.delete('/del', (req, res) => res.send('del-ok'));
+app.head('/h', (req, res) => res.set('X-Head', 'yes').end());
+app.all('/all', (req, res) => res.send('all:' + req.method));
+app.get('/headauto', (req, res) => res.send('getbody'));
+
+// route params / multi-params / regex / query
+app.get('/users/:id', (req, res) => res.send('user:' + req.params.id));
+app.get('/a/:x/b/:y', (req, res) => res.json(req.params));
+app.get(/^\/regex\/[0-9]+$/, (req, res) => res.send('regexmatch'));
+app.get('/q', (req, res) => res.json(req.query));
+app.get('/qarr', (req, res) => res.json(req.query));
+
+// app.route().get().post() chaining
+app.route('/chained')
+  .get((req, res) => res.send('chained-GET'))
+  .post((req, res) => res.send('chained-POST'));
+
+// next('route') skipping
+app.get('/skip', (req, res, next) => next('route'), (req, res) => res.send('should-not-run'));
+app.get('/skip', (req, res) => res.send('after-skip'));
+
+// multiple handlers chained via next()
+app.get('/arr', (req, res, next) => { req.step = '1'; next(); }, (req, res) => res.send('step:' + req.step));
+
+// scoped flag consumer
+app.get('/scoped/x', (req, res) => res.send('flag:' + req.scopedFlag + ',' + req.globalFlag));
+
+// request API introspection
+app.get('/reqinfo', (req, res) => res.json({
+  method: req.method, path: req.path, isjson: req.is('json'),
+  acc: req.accepts(['html', 'json']), h: req.get('X-Custom') || null
+}));
+app.get('/reqx', (req, res) => res.json({
+  proto: req.protocol, host: req.hostname, ip: req.ip, xhr: req.xhr,
+  ourl: req.originalUrl, burl: req.baseUrl, url: req.url, secure: req.secure
+}));
+
+// content negotiation
+app.get('/format', (req, res) => {
+  res.format({
+    'text/plain': () => res.send('plain-fmt'),
+    'application/json': () => res.json({ f: 'json' })
+  });
+});
+
+// app settings introspection
+app.get('/settings', (req, res) => res.json({
+  cs: app.get('custom-setting'), en: app.enabled('x-powered-by'),
+  dis: app.disabled('etag'), loc: req.app.locals.appName
+}));
+
+// pug view rendering
+app.get('/view', (req, res) => res.render('page', { title: 'T', heading: 'H', name: 'World' }));
+
+// --- body parsing routes ----
+app.post('/pjson', (req, res) => res.json(req.body));
+app.post('/pform', (req, res) => res.json(req.body));
+app.post('/ptext', (req, res) => res.send('text-body:' + req.body));
+
+// --- error handling ----
+app.get('/err', (req, res) => { throw new Error('boom'); });
+app.get('/nexterr', (req, res, next) => { next(new Error('viaNext')); });
+
+// --- Router() sub-app mounted at /api with router.param preprocessing ----
+const r = express.Router();
+r.param('id', (req, res, next, id) => { req.pid = 'P' + id; next(); });
+r.get('/info', (req, res) => res.json({ where: 'router-info' }));
+r.get('/item/:id', (req, res) => res.json({ pid: req.pid, id: req.params.id }));
+app.use('/api', r);
+
+// --- nested sub-application mounted at /mounted ----
+const sub = express();
+sub.get('/ping', (req, res) => res.send('sub-pong baseUrl=' + req.baseUrl));
+app.use('/mounted', sub);
+
+// --- static dir ----
+app.use('/files', express.static(PUB));
+
+// --- custom 404 handler (fires when nothing matched & not the default html one) ----
+app.use('/missing', (req, res) => res.status(404).type('txt').send('custom-404'));
+
+// --- error middleware (err,req,res,next) ----
+app.use((err, req, res, next) => { res.status(500).json({ error: err.message }); });
+
+// ---- promisified loopback http client --------------------------------------
+let PORT = 0;
+function call(method, p, body, headers) {
+  return new Promise((resolve, reject) => {
+    const opts = { host: '127.0.0.1', port: PORT, path: p, method, headers: headers || {} };
+    const rq = http.request(opts, (res) => {
+      let d = '';
+      res.on('data', (c) => d += c);
+      res.on('end', () => resolve({ s: res.statusCode, h: res.headers, b: d }));
+    });
+    rq.on('error', reject);
+    if (body != null) rq.write(body);
+    rq.end();
+  });
+}
+
+// ---- run the sequence ------------------------------------------------------
+const server = app.listen(0, '127.0.0.1', async () => {
+  PORT = server.address().port;
+  try {
+    let x;
+
+    // 1. res.json
+    x = await call('GET', '/json');
+    eq(x.s, 200, 'json.status');
+    eq(x.h['content-type'], 'application/json; charset=utf-8', 'json.ct');
+    eq(x.b, '{"a":1,"b":"x"}', 'json.body');
+    eq(x.h['content-length'], '15', 'json.clen');
+    eq(x.h['x-powered-by'], 'Express', 'json.xpb');
+    eq(x.h['x-global'], 'G', 'json.global');
+
+    // 2. res.send(string) -> text/html
+    x = await call('GET', '/send-str');
+    eq(x.s, 200, 'sendstr.status');
+    eq(x.h['content-type'], 'text/html; charset=utf-8', 'sendstr.ct');
+    eq(x.b, '<p>hi</p>', 'sendstr.body');
+
+    // 3. res.send(Buffer) -> octet-stream
+    x = await call('GET', '/send-buf');
+    eq(x.h['content-type'], 'application/octet-stream', 'sendbuf.ct');
+    eq(x.b, 'abc', 'sendbuf.body');
+
+    // 4. res.send(object) -> json
+    x = await call('GET', '/send-obj');
+    eq(x.h['content-type'], 'application/json; charset=utf-8', 'sendobj.ct');
+    eq(x.b, '{"k":2}', 'sendobj.body');
+
+    // 5. res.type('txt')
+    x = await call('GET', '/type');
+    eq(x.h['content-type'], 'text/plain; charset=utf-8', 'type.ct');
+    eq(x.b, 'plain', 'type.body');
+
+    // 5b. res.type('application/json')
+    x = await call('GET', '/typeext');
+    eq(x.h['content-type'], 'application/json; charset=utf-8', 'typeext.ct');
+
+    // 6. res.sendStatus(204)
+    x = await call('GET', '/ss204');
+    eq(x.s, 204, 'ss204.status');
+    eq(x.b, '', 'ss204.body');
+
+    // 7. res.sendStatus(404)
+    x = await call('GET', '/ss404');
+    eq(x.s, 404, 'ss404.status');
+    eq(x.h['content-type'], 'text/plain; charset=utf-8', 'ss404.ct');
+    eq(x.b, 'Not Found', 'ss404.body');
+
+    // 8. res.redirect default 302
+    x = await call('GET', '/redir');
+    eq(x.s, 302, 'redir.status');
+    eq(x.h['location'], '/dest', 'redir.loc');
+    eq(x.b, 'Found. Redirecting to /dest', 'redir.body');
+
+    // 9. res.redirect custom code 301
+    x = await call('GET', '/redir301');
+    eq(x.s, 301, 'redir301.status');
+    eq(x.h['location'], '/dest', 'redir301.loc');
+    eq(x.b, 'Moved Permanently. Redirecting to /dest', 'redir301.body');
+
+    // 10. res.cookie -> Set-Cookie
+    x = await call('GET', '/cookie');
+    chk(Array.isArray(x.h['set-cookie']) && x.h['set-cookie'].length === 1, 'cookie.arr');
+    eq(x.h['set-cookie'][0], 'foo=bar; Path=/', 'cookie.val');
+
+    // 11. res.links -> Link header
+    x = await call('GET', '/links');
+    eq(x.h['link'], '<http://x/2>; rel="next", <http://x/5>; rel="last"', 'links.hdr');
+
+    // 12. res.vary -> Vary header
+    x = await call('GET', '/vary');
+    eq(x.h['vary'], 'Accept', 'vary.hdr');
+
+    // 12b. res.location
+    x = await call('GET', '/loc');
+    eq(x.s, 200, 'loc.status');
+    eq(x.h['location'], '/somewhere', 'loc.hdr');
+
+    // 13. default 404 (no route matched)
+    x = await call('GET', '/nope');
+    eq(x.s, 404, 'no404.status');
+    eq(x.h['content-type'], 'text/html; charset=utf-8', 'no404.ct');
+    eq(x.b, '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /nope</pre>\n</body>\n</html>\n', 'no404.body');
+
+    // 13b. custom 404 handler under /missing
+    x = await call('GET', '/missing/whatever');
+    eq(x.s, 404, 'cust404.status');
+    eq(x.h['content-type'], 'text/plain; charset=utf-8', 'cust404.ct');
+    eq(x.b, 'custom-404', 'cust404.body');
+
+    // 14. express.json body parsing
+    x = await call('POST', '/pjson', JSON.stringify({ n: 5, s: 'hi' }), { 'Content-Type': 'application/json' });
+    eq(x.s, 200, 'pjson.status');
+    eq(x.b, '{"n":5,"s":"hi"}', 'pjson.body');
+
+    // 15. express.urlencoded (extended) body parsing
+    x = await call('POST', '/pform', 'a=1&b=two&c[d]=3', { 'Content-Type': 'application/x-www-form-urlencoded' });
+    eq(x.b, '{"a":"1","b":"two","c":{"d":"3"}}', 'pform.body');
+
+    // 15b. express.text body parsing
+    x = await call('POST', '/ptext', 'raw text here', { 'Content-Type': 'text/plain' });
+    eq(x.b, 'text-body:raw text here', 'ptext.body');
+
+    // 16. request API: req.method/path/is/accepts/get
+    x = await call('GET', '/reqinfo', null, { 'X-Custom': 'CV', 'Accept': 'application/json' });
+    eq(x.b, '{"method":"GET","path":"/reqinfo","isjson":null,"acc":"json","h":"CV"}', 'reqinfo.body');
+
+    // 16b. extended request API
+    x = await call('GET', '/reqx?z=1', null, { 'X-Requested-With': 'XMLHttpRequest' });
+    eq(x.b, '{"proto":"http","host":"127.0.0.1","ip":"127.0.0.1","xhr":true,"ourl":"/reqx?z=1","burl":"","url":"/reqx?z=1","secure":false}', 'reqx.body');
+
+    // 17. res.append (multi-value header)
+    x = await call('GET', '/append');
+    eq(x.h['x-multi'], 'a, b', 'append.hdr');
+    eq(x.b, 'ap', 'append.body');
+
+    // 18. res.set / res.get
+    x = await call('GET', '/getset');
+    eq(x.b, '{"got":"FV"}', 'getset.body');
+    eq(x.h['x-foo'], 'FV', 'getset.hdr');
+
+    // 18b. res.set(object)
+    x = await call('GET', '/setobj');
+    eq(x.h['x-a'], '1', 'setobj.a');
+    eq(x.h['x-b'], '2', 'setobj.b');
+
+    // 19. HEAD verb explicit
+    x = await call('HEAD', '/h');
+    eq(x.s, 200, 'head.status');
+    eq(x.h['x-head'], 'yes', 'head.hdr');
+    eq(x.b, '', 'head.body');
+
+    // 19b. HEAD auto-handled for a GET route
+    x = await call('HEAD', '/headauto');
+    eq(x.s, 200, 'headauto.status');
+    eq(x.b, '', 'headauto.body');
+    eq(x.h['content-length'], '7', 'headauto.clen');
+
+    // 20. app.all
+    x = await call('GET', '/all');
+    eq(x.b, 'all:GET', 'all.get');
+    x = await call('DELETE', '/all');
+    eq(x.b, 'all:DELETE', 'all.del');
+
+    // 21. put / patch / delete verbs
+    x = await call('PUT', '/put');     eq(x.b, 'put-ok', 'put.body');
+    x = await call('PATCH', '/patch'); eq(x.b, 'patch-ok', 'patch.body');
+    x = await call('DELETE', '/del');  eq(x.b, 'del-ok', 'del.body');
+
+    // 22. regex route
+    x = await call('GET', '/regex/123');
+    eq(x.s, 200, 'regex.status');
+    eq(x.b, 'regexmatch', 'regex.body');
+    x = await call('GET', '/regex/abc');
+    eq(x.s, 404, 'regex.no');
+
+    // 23/24. error handling (throw + next(err))
+    x = await call('GET', '/err');
+    eq(x.s, 500, 'err.status');
+    eq(x.b, '{"error":"boom"}', 'err.body');
+    x = await call('GET', '/nexterr');
+    eq(x.s, 500, 'nexterr.status');
+    eq(x.b, '{"error":"viaNext"}', 'nexterr.body');
+
+    // 25/26. Router + router.param
+    x = await call('GET', '/api/info');
+    eq(x.b, '{"where":"router-info"}', 'router.info');
+    x = await call('GET', '/api/item/42');
+    eq(x.b, '{"pid":"P42","id":"42"}', 'router.param');
+
+    // 27. path-scoped middleware + global flag
+    x = await call('GET', '/scoped/x');
+    eq(x.b, 'flag:SCOPED,GLOBAL', 'scoped.body');
+
+    // 28. next('route') skip
+    x = await call('GET', '/skip');
+    eq(x.b, 'after-skip', 'skip.body');
+
+    // 29. app.route().get().post()
+    x = await call('GET', '/chained');  eq(x.b, 'chained-GET', 'chained.get');
+    x = await call('POST', '/chained'); eq(x.b, 'chained-POST', 'chained.post');
+
+    // 30/31/32. params / multi-params / query
+    x = await call('GET', '/users/77');   eq(x.b, 'user:77', 'param.single');
+    x = await call('GET', '/a/11/b/22');  eq(x.b, '{"x":"11","y":"22"}', 'param.multi');
+    x = await call('GET', '/q?q=hello&n=2'); eq(x.b, '{"q":"hello","n":"2"}', 'query.basic');
+    x = await call('GET', '/qarr?arr=1&arr=2&o[k]=v'); eq(x.b, '{"arr":["1","2"],"o":{"k":"v"}}', 'query.nested');
+
+    // 33. express.static
+    x = await call('GET', '/files/hello.txt');
+    eq(x.s, 200, 'static.status');
+    eq(x.h['content-type'], 'text/plain; charset=UTF-8', 'static.ct');
+    eq(x.h['content-length'], '19', 'static.clen');
+    eq(x.b, 'hello static world\n', 'static.body');
+
+    // 34. multi-handler chain via next()
+    x = await call('GET', '/arr');
+    eq(x.b, 'step:1', 'arr.body');
+
+    // 35. res.status chaining
+    x = await call('GET', '/status201');
+    eq(x.s, 201, 'status201.status');
+    eq(x.b, 'created', 'status201.body');
+    x = await call('GET', '/jstatus');
+    eq(x.s, 422, 'jstatus.status');
+    eq(x.b, '{"e":"bad"}', 'jstatus.body');
+
+    // 36. res.format negotiation
+    x = await call('GET', '/format', null, { 'Accept': 'application/json' });
+    eq(x.b, '{"f":"json"}', 'format.json');
+    eq(x.h['content-type'], 'application/json; charset=utf-8', 'format.json.ct');
+    x = await call('GET', '/format', null, { 'Accept': 'text/plain' });
+    eq(x.b, 'plain-fmt', 'format.text');
+
+    // 37. res.jsonp
+    x = await call('GET', '/jsonp?callback=cb');
+    eq(x.h['content-type'], 'text/javascript; charset=utf-8', 'jsonp.ct');
+    eq(x.b, "/**/ typeof cb === 'function' && cb({\"j\":1});", 'jsonp.body');
+
+    // 38. res.attachment -> Content-Disposition
+    x = await call('GET', '/attach');
+    eq(x.h['content-disposition'], 'attachment; filename="report.pdf"', 'attach.cd');
+    eq(x.h['content-type'], 'application/pdf; charset=utf-8', 'attach.ct');
+    eq(x.b, 'PDF', 'attach.body');
+
+    // 39. app settings introspection
+    x = await call('GET', '/settings');
+    eq(x.b, '{"cs":"CVAL","en":true,"dis":true,"loc":"CarpetApp"}', 'settings.body');
+
+    // 39b. x-powered-by default value
+    x = await call('GET', '/xpb');
+    eq(x.h['x-powered-by'], 'Express', 'xpb.hdr');
+
+    // 40. nested sub-application mount (req.baseUrl)
+    x = await call('GET', '/mounted/ping');
+    eq(x.b, 'sub-pong baseUrl=/mounted', 'mounted.body');
+
+    // 41. pug view rendering via res.render
+    x = await call('GET', '/view');
+    eq(x.s, 200, 'view.status');
+    eq(x.h['content-type'], 'text/html; charset=utf-8', 'view.ct');
+    eq(x.b, '<html><head><title>T</title></head><body><h1>H</h1><p>Hello World</p></body></html>', 'view.body');
+
+  } catch (e) {
+    fail++;
+    console.log('FAIL exception: ' + (e && e.stack ? e.stack : e));
+  } finally {
+    server.close(() => {
+      console.log('EXPRESS_RESULT ok=' + ok + ' fail=' + fail);
+      if (fail === 0) console.log('EXPRESS_DONE');
+      process.exit(fail === 0 ? 0 : 1);
+    });
+  }
+});

--- a/apps/starry/node-web/programs/carpets/KotlinJsCarpet.js
+++ b/apps/starry/node-web/programs/carpets/KotlinJsCarpet.js
@@ -1,0 +1,180 @@
+// KotlinJsCarpet.js — carpet for the Kotlin/JS delivery on Node.js 22 LTS (StarryOS target runtime).
+//
+// Runs the Kotlin->JS module (kotlin-app.js, generated in prebuild from the committed Kotlin
+// source assets/kotlin-app.kt by the Kotlin 2.0.21 JS/IR backend with -module-kind commonjs; see
+// programs/SOURCES.md) as a child process, captures its stdout/stderr/exit, and asserts the output
+// is byte-identical to the golden kotlin-REF.out with thorough per-line and per-token checks. The
+// module self-executes its `main` on load (writes 6 lines via console.log).
+//
+// Kotlin language/stdlib features exercised by kotlin-app.js (reflected in the 6 golden lines):
+//   - data classes + componentN/copy  -> points=(21,12);(23,14);(25,16)
+//   - sealed class + exhaustive `when` -> areas=12,12,3 total=27
+//   - higher-order fns / lambdas / map/filter/sum -> evens^2 sum=220
+//   - generics + extension functions   -> second-of=b
+//   - recursion (tail/plain)           -> fib(15)=610
+//   - null-safety (?., ?:, !!)         -> nullsafe=YES
+//
+// Deterministic: no Date/Math.random/network/timestamps. Pure node + child process on the same
+// Node 22 LTS binary. Marker: KOTLINJS_DONE printed ONLY when fail===0.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync, execFileSync } = require('child_process');
+
+let ok = 0, fail = 0;
+function chk(cond, name) { if (cond) ok++; else { fail++; console.log('FAIL ' + name); } }
+
+const DIR = __dirname;                 // carpet runs from its own dir (target: /root/nweb)
+const NODE = process.execPath;         // the running node binary (target's musl node), not a hardcoded host path
+const APP = path.join(DIR, 'kotlin-app.js');
+const REF = path.join(DIR, 'kotlin-REF.out');
+
+// --- Section 0: environment / target sanity ---------------------------------
+// Node 22 LTS API surface — assert the MAJOR (the reproducible prebuild apk-adds the current
+// v3.22 nodejs, whose patch level floats: v22.22.x today, a later 22.x tomorrow). The Kotlin/JS
+// commonjs module uses no version-specific node API, so any Node >= 22 runs it identically.
+chk(parseInt(process.versions.node.split('.')[0], 10) >= 22, 'node major >= 22 (Node 22 LTS; got ' + process.version + ')');
+chk(fs.existsSync(NODE), 'host verify binary exists: ' + NODE);
+chk(fs.existsSync(APP), 'kotlin-app.js exists');
+chk(fs.existsSync(REF), 'kotlin-REF.out exists');
+
+// --- Section 1: the IR-emitted module is the full module, not a stub --------
+const appStat = fs.statSync(APP);
+chk(appStat.isFile(), 'kotlin-app.js is a regular file');
+chk(appStat.size > 100000, 'kotlin-app.js size > 100000 bytes (got ' + appStat.size + ')');
+// kotlin-app.js is regenerated in prebuild from the committed kotlin-app.kt by the pinned Kotlin
+// 2.0.21 JS/IR compiler (NOT committed). The whole-program commonjs emit inlines the Kotlin
+// stdlib, so the file is ~640-660 KB; assert a tight range (rejects a DCE'd stub or a truncated
+// file) rather than a single exact byte count, which is specific to one compiler build and would
+// break on a Kotlin patch bump.
+chk(appStat.size > 500000 && appStat.size < 800000, 'kotlin-app.js size in [500000,800000) bytes (whole-program stdlib inline; got ' + appStat.size + ')');
+
+const appSrc = fs.readFileSync(APP, 'utf8');
+// Hallmarks of the Kotlin 2.0.21 IR backend + commonjs module-kind.
+chk(appSrc.indexOf('//region block: polyfills') !== -1, 'app has IR polyfills region header');
+chk(appSrc.indexOf('Math.imul') !== -1, 'app references Math.imul polyfill (IR backend)');
+chk(/module\.exports|exports\./.test(appSrc), 'app uses commonjs exports (-module-kind commonjs)');
+
+// --- Section 2: golden bytes ------------------------------------------------
+const refBuf = fs.readFileSync(REF);                 // raw bytes
+const refText = refBuf.toString('utf8');
+chk(refBuf.length === 107, 'golden byte length === 107 (got ' + refBuf.length + ')');
+chk(refBuf[refBuf.length - 1] === 0x0a, 'golden ends with a single LF (0x0a)');
+chk(refBuf.indexOf(0x0d) === -1, 'golden contains no CR bytes (pure LF, no CRLF)');
+
+// Exact golden lines, hard-coded (independent ground truth from the spec).
+const EXPECTED_LINES = [
+  'points=(21,12);(23,14);(25,16)',
+  'areas=12,12,3 total=27',
+  'evens^2 sum=220',
+  'second-of=b',
+  'fib(15)=610',
+  'nullsafe=YES',
+];
+const EXPECTED_TEXT = EXPECTED_LINES.join('\n') + '\n';
+chk(refText === EXPECTED_TEXT, 'golden text === expected 6 lines + trailing LF');
+chk(EXPECTED_TEXT.length === 107, 'expected text length === 107 chars');
+
+// --- Section 3: run the module as a child, capture stdout/stderr/exit -------
+// spawnSync with no encoding -> Buffers (for byte-exact comparison).
+const run = spawnSync(NODE, [APP], { cwd: DIR });
+chk(run.error === undefined || run.error === null, 'child spawned without error');
+chk(run.status === 0, 'child exit status === 0 (got ' + run.status + ')');
+chk(run.signal === null, 'child terminated by no signal');
+
+const outBuf = run.stdout;                            // Buffer
+const errBuf = run.stderr;                            // Buffer
+chk(Buffer.isBuffer(outBuf), 'stdout captured as Buffer');
+chk(errBuf.length === 0, 'stderr is empty (got ' + errBuf.length + ' bytes)');
+
+// --- Section 4: byte-identical stdout vs golden -----------------------------
+chk(outBuf.length === 107, 'stdout byte length === 107 (got ' + outBuf.length + ')');
+chk(Buffer.compare(outBuf, refBuf) === 0, 'stdout is byte-identical to golden (Buffer.compare===0)');
+const outText = outBuf.toString('utf8');
+chk(outText === refText, 'stdout text === golden text');
+chk(outText === EXPECTED_TEXT, 'stdout text === expected hard-coded text');
+chk(outBuf[outBuf.length - 1] === 0x0a, 'stdout ends with a single LF');
+chk(outBuf.indexOf(0x0d) === -1, 'stdout contains no CR bytes');
+
+// Cross-check via execFileSync (second independent capture path).
+const execOut = execFileSync(NODE, [APP], { cwd: DIR }); // Buffer
+chk(Buffer.compare(execOut, refBuf) === 0, 'execFileSync stdout byte-identical to golden');
+
+// --- Section 5: per-line assertions -----------------------------------------
+// Split on LF; trailing LF yields an empty final element -> drop it.
+const parts = outText.split('\n');
+chk(parts.length === 7, 'split on LF yields 7 parts (6 lines + trailing empty)');
+chk(parts[6] === '', 'final split element is empty (trailing newline present)');
+const lines = parts.slice(0, 6);
+chk(lines.length === 6, 'line count === 6');
+
+chk(lines[0] === 'points=(21,12);(23,14);(25,16)', 'line 1 exact: points=(21,12);(23,14);(25,16)');
+chk(lines[1] === 'areas=12,12,3 total=27',          'line 2 exact: areas=12,12,3 total=27');
+chk(lines[2] === 'evens^2 sum=220',                 'line 3 exact: evens^2 sum=220');
+chk(lines[3] === 'second-of=b',                     'line 4 exact: second-of=b');
+chk(lines[4] === 'fib(15)=610',                     'line 5 exact: fib(15)=610');
+chk(lines[5] === 'nullsafe=YES',                    'line 6 exact: nullsafe=YES');
+
+// Each emitted line must equal its expected counterpart (loop, defensive).
+for (let i = 0; i < 6; i++) {
+  chk(lines[i] === EXPECTED_LINES[i], 'line ' + (i + 1) + ' === EXPECTED_LINES[' + i + ']');
+}
+
+// --- Section 6: token-level assertions (Kotlin feature semantics) -----------
+// Line 1: data class Point(x,y) scaled/translated, joined ";" with toString "(x,y)".
+const ptTokens = lines[0].slice('points='.length).split(';');
+chk(lines[0].startsWith('points='), 'line 1 starts with points=');
+chk(ptTokens.length === 3, 'line 1 has 3 point tokens');
+chk(ptTokens[0] === '(21,12)', 'point token 0 === (21,12)');
+chk(ptTokens[1] === '(23,14)', 'point token 1 === (23,14)');
+chk(ptTokens[2] === '(25,16)', 'point token 2 === (25,16)');
+
+// Line 2: sealed-class areas via exhaustive when, plus total = sum.
+chk(lines[1].startsWith('areas='), 'line 2 starts with areas=');
+chk(lines[1].indexOf('total=27') !== -1, 'line 2 contains substring total=27');
+const areaPart = lines[1].slice('areas='.length).split(' total=')[0];
+const areaTokens = areaPart.split(',').map(Number);
+chk(areaTokens.length === 3, 'line 2 has 3 area values');
+chk(areaTokens[0] === 12 && areaTokens[1] === 12 && areaTokens[2] === 3, 'area values === [12,12,3]');
+const areaTotal = areaTokens.reduce((a, b) => a + b, 0);
+chk(areaTotal === 27, 'sum of area values === 27 (matches total=)');
+chk(lines[1] === 'areas=' + areaTokens.join(',') + ' total=' + areaTotal, 'line 2 reconstructs from tokens');
+
+// Line 3: higher-order map/filter/sum over evens -> 2^2+4^2+6^2+8^2+10^2.
+chk(lines[2].startsWith('evens^2 sum='), 'line 3 starts with evens^2 sum=');
+const evensSum = [2, 4, 6, 8, 10].map(n => n * n).reduce((a, b) => a + b, 0);
+chk(evensSum === 220, 'JS-computed evens^2 sum === 220');
+chk(lines[2] === 'evens^2 sum=' + evensSum, 'line 3 equals computed evens^2 sum string');
+
+// Line 4: generic extension fn secondOf(list) -> "b".
+chk(lines[3] === 'second-of=' + ['a', 'b', 'c'][1], 'line 4 second-of equals list[1]=b');
+
+// Line 5: recursion fib(15) -> 610. Compute fib independently in JS.
+function fib(n) { let a = 0, b = 1; for (let i = 0; i < n; i++) { const t = a + b; a = b; b = t; } return a; }
+chk(fib(15) === 610, 'JS-computed fib(15) === 610');
+chk(lines[4] === 'fib(15)=' + fib(15), 'line 5 equals fib(15)=610 computed string');
+
+// Line 6: null-safety chain resolves to YES.
+chk(lines[5] === 'nullsafe=YES', 'line 6 nullsafe=YES (null-safety branch)');
+chk(lines[5].split('=')[1] === 'YES', 'line 6 value token === YES');
+
+// --- Section 7: whole-output structural invariants --------------------------
+chk(outText.indexOf('undefined') === -1, 'output contains no literal undefined');
+chk(outText.indexOf('=null') === -1, 'output contains no =null value token');
+chk(outText.indexOf('NaN') === -1, 'output contains no NaN');
+chk(outText.indexOf('Error') === -1, 'output contains no Error text');
+const lfCount = (outText.match(/\n/g) || []).length;
+chk(lfCount === 6, 'output has exactly 6 LF newlines');
+
+// Determinism: a second run is byte-identical to the first.
+const run2 = spawnSync(NODE, [APP], { cwd: DIR });
+chk(run2.status === 0, 'second run exit 0');
+chk(Buffer.compare(run2.stdout, outBuf) === 0, 'second run stdout byte-identical to first (deterministic)');
+chk(run2.stderr.length === 0, 'second run stderr empty');
+
+// --- Final tally ------------------------------------------------------------
+console.log('KOTLINJS_RESULT ok=' + ok + ' fail=' + fail);
+if (fail === 0) console.log('KOTLINJS_DONE');
+process.exit(fail === 0 ? 0 : 1);

--- a/apps/starry/node-web/programs/carpets/PugCarpet.js
+++ b/apps/starry/node-web/programs/carpets/PugCarpet.js
@@ -1,0 +1,269 @@
+'use strict';
+/*
+ * PugCarpet.js — INDUSTRIAL-grade carpet for pug 3.0.3 on Node.js 22 LTS.
+ * Every assertion is an exact-value check (=== against a golden observed from
+ * the real pug 3.0.3 install on this exact node). Deterministic only.
+ *
+ * Run:
+ *   cd <nweb> && node PugCarpet.js
+ */
+const pug = require('pug');
+const fs = require('fs');
+const path = require('path');
+
+let ok = 0, fail = 0;
+function chk(cond, name) { if (cond) ok++; else { fail++; console.log('FAIL ' + name); } }
+
+// eq: render `src` with `locals/opts` and assert it equals exact `expected`.
+function eq(name, src, expected, optsLocals) {
+  let got;
+  try { got = pug.render(src, optsLocals || {}); }
+  catch (e) { fail++; console.log('FAIL ' + name + ' (threw: ' + e.message + ')'); return; }
+  if (got === expected) { ok++; }
+  else { fail++; console.log('FAIL ' + name + '\n  expected: ' + JSON.stringify(expected) + '\n  got:      ' + JSON.stringify(got)); }
+}
+
+// ---------------------------------------------------------------------------
+// Helper template files (self-contained: written fresh into pugtmpl_carpet/)
+// ---------------------------------------------------------------------------
+const TDIR = path.join(process.cwd(), 'pugtmpl_carpet');
+fs.mkdirSync(TDIR, { recursive: true });
+function w(rel, content) { fs.writeFileSync(path.join(TDIR, rel), content); }
+w('layout.pug',
+  'html\n  head\n    block title\n      title Default\n  body\n    block content\n      p default content\n    block footer\n      footer base\n');
+w('child.pug',
+  'extends layout\nblock title\n  title Home\nblock content\n  h1 Welcome\n');
+w('childappend.pug',
+  'extends layout\nblock append content\n  p appended\nblock prepend content\n  p prepended\n');
+w('partial.pug', 'p partial-included\n');
+w('withinclude.pug', 'p before include\ninclude partial\np after include\n');
+w('raw.txt', 'raw text line1\nraw text line2\n');
+w('withrawtxt.pug', 'div.box\n  include raw.txt\n');
+const FP = (rel) => path.join(TDIR, rel);
+
+// ===========================================================================
+// 1. API SURFACE
+// ===========================================================================
+chk(pug.name === 'Pug', 'api.name');
+chk(typeof pug.render === 'function', 'api.render-fn');
+chk(typeof pug.renderFile === 'function', 'api.renderFile-fn');
+chk(typeof pug.compile === 'function', 'api.compile-fn');
+chk(typeof pug.compileFile === 'function', 'api.compileFile-fn');
+chk(typeof pug.compileClient === 'function', 'api.compileClient-fn');
+chk(typeof pug.compileClientWithDependenciesTracked === 'function', 'api.ccwdt-fn');
+chk(typeof pug.compileFileClient === 'function', 'api.compileFileClient-fn');
+chk(typeof pug.__express === 'function', 'api.__express-fn');
+chk(typeof pug.runtime === 'object' && pug.runtime !== null, 'api.runtime-obj');
+chk(pug.cache && typeof pug.cache === 'object', 'api.cache-obj');
+chk(pug.filters && typeof pug.filters === 'object', 'api.filters-obj');
+
+// ===========================================================================
+// 2. TAGS & SHORTHAND
+// ===========================================================================
+eq('tag.basic', 'p Hello world', '<p>Hello world</p>');
+eq('tag.classid', 'a.btn.big#go(href="/x") Go', '<a class="btn big" id="go" href="/x">Go</a>');
+eq('tag.div-implied', '.card#main content', '<div class="card" id="main">content</div>');
+eq('tag.img-selfclose', 'img(src="a.png" alt="x")', '<img src="a.png" alt="x"/>');
+eq('tag.nesting', 'ul\n  li one\n  li two', '<ul><li>one</li><li>two</li></ul>');
+eq('tag.interp', 'p before #[a(href="x") y] after', '<p>before <a href="x">y</a> after</p>');
+eq('tag.interp-class', 'p #[strong.hl word] end', '<p><strong class="hl">word</strong> end</p>');
+eq('tag.block-expansion', 'a: img(src="x")', '<a><img src="x"/></a>');
+eq('tag.dot-text', 'p.\n  This is\n  plain text', '<p>This is\nplain text</p>');
+eq('tag.pipe-text', 'p\n  | line one\n  | line two', '<p>line one\nline two</p>');
+eq('tag.script-raw', 'script.\n  var x = 1 < 2;', '<script>var x = 1 < 2;</script>');
+eq('tag.text-interp', 'p Hello #{who}!', '<p>Hello world!</p>', { who: 'world' });
+eq('tag.literal-eq', 'p.\n  1 + 1 = 2', '<p>1 + 1 = 2</p>');
+
+// ===========================================================================
+// 3. ATTRIBUTES
+// ===========================================================================
+eq('attr.bool-true', 'input(type="checkbox" checked)', '<input type="checkbox" checked="checked"/>');
+eq('attr.bool-false', 'input(type="checkbox" checked=false)', '<input type="checkbox"/>');
+eq('attr.disabled-true', 'input(disabled=true)', '<input disabled="disabled"/>');
+eq('attr.interp', 'a(href="/u/"+name) link', '<a href="/u/bob">link</a>', { name: 'bob' });
+eq('attr.escape-quote', "a(title='a\"b') t", '<a title="a&quot;b">t</a>');
+eq('attr.class-array', 'a(class=["a","b","c"]) x', '<a class="a b c">x</a>');
+eq('attr.class-object', 'a(class={active:true,disabled:false}) x', '<a class="active">x</a>');
+eq('attr.style-object', 'a(style={color:"red","font-size":"12px"}) x', '<a style="color:red;font-size:12px;">x</a>');
+eq('attr.style-string', 'a(style="color:red") x', '<a style="color:red">x</a>');
+eq('attr.data', 'div(data-id=5 data-name="x") y', '<div data-id="5" data-name="x">y</div>');
+eq('attr.and-attributes', 'div#a(class="b")&attributes({id:"c",foo:"bar"}) z', '<div class="b" id="c" foo="bar">z</div>');
+eq('attr.class-merge', 'a.base&attributes({class:["extra"]}) x', '<a class="base extra">x</a>');
+eq('attr.amp-escape', 'a(href="?a=1&b=2") x', '<a href="?a=1&amp;b=2">x</a>');
+eq('attr.escaped-default', 'a(data-x="<b>") y', '<a data-x="&lt;b&gt;">y</a>');
+eq('attr.unescaped', 'a(data-x!="<b>") y', '<a data-x="<b>">y</a>');
+eq('attr.template-interp', 'img(src=`/img/${id}.png`)', '<img src="/img/7.png"/>', { id: 7 });
+eq('attr.expr', 'a(tabindex=1+1) x', '<a tabindex="2">x</a>');
+eq('attr.eq-and-attr', '- var cls="hl"\np(class=cls)= 1+1', '<p class="hl">2</p>');
+
+// ===========================================================================
+// 4. BUFFERED / UNBUFFERED CODE + INTERPOLATION + XSS
+// ===========================================================================
+eq('code.eq-escaped', 'p= "<b>"+x', '<p>&lt;b&gt;&amp;</p>', { x: '&' });
+eq('code.neq-unescaped', 'p!= "<b>"+x', '<p><b>&</p>', { x: '&' });
+eq('code.dash-stmt', '- var y = 1 + 2\np= y', '<p>3</p>');
+eq('code.interp-esc', 'p #{val}', '<p>&lt;b&gt;</p>', { val: '<b>' });
+eq('code.interp-raw', 'p !{val}', '<p><b></p>', { val: '<b>' });
+eq('code.xss-escape', 'p #{name}', '<p>&lt;script&gt;</p>', { name: '<script>' });
+eq('code.text-quote', 'p= q', '<p>&quot;hi&quot;</p>', { q: '"hi"' });
+eq('code.for-loop', 'ul\n  - for(var i=0;i<2;i++)\n    li= i', '<ul><li>0</li><li>1</li></ul>');
+
+// ===========================================================================
+// 5. CONDITIONALS
+// ===========================================================================
+eq('cond.if-elseif-else', 'if n>0\n  p pos\nelse if n<0\n  p neg\nelse\n  p zero', '<p>neg</p>', { n: -5 });
+eq('cond.nested-elseif', 'if a\n  p A\nelse if b\n  p B\nelse\n  p C', '<p>B</p>', { a: false, b: true });
+eq('cond.unless', 'unless ok\n  p hidden', '<p>hidden</p>', { ok: false });
+eq('cond.case', 'case n\n  when 1\n    p one\n  when 2\n    p two\n  default\n    p other', '<p>two</p>', { n: 2 });
+eq('cond.case-fallthrough', 'case n\n  when 1\n  when 2\n    p onetwo\n  default\n    p other', '<p>onetwo</p>', { n: 1 });
+eq('cond.case-block', 'case n\n  when 1\n    p one\n    p uno\n  default\n    p other', '<p>one</p><p>uno</p>', { n: 1 });
+eq('cond.case-default', 'case n\n  when 1\n    p one\n  default\n    p other', '<p>other</p>', { n: 9 });
+
+// ===========================================================================
+// 6. ITERATION
+// ===========================================================================
+eq('iter.each-arr', 'each v in [1,2,3]\n  li= v', '<li>1</li><li>2</li><li>3</li>');
+eq('iter.each-idx', 'each v,i in ["a","b"]\n  li #{i}:#{v}', '<li>0:a</li><li>1:b</li>');
+eq('iter.each-obj', 'each v,k in {a:1,b:2}\n  li #{k}=#{v}', '<li>a=1</li><li>b=2</li>');
+eq('iter.each-keyval', 'each val, key in {x:1,y:2,z:3}\n  p #{key}-#{val}', '<p>x-1</p><p>y-2</p><p>z-3</p>');
+eq('iter.each-else', 'each v in []\n  li= v\nelse\n  p empty', '<p>empty</p>');
+eq('iter.each-string', 'each c in "ab"\n  li= c', '<li>a</li><li>b</li>');
+eq('iter.while', '- var n=0\nwhile n<3\n  li= n++', '<li>0</li><li>1</li><li>2</li>');
+
+// ===========================================================================
+// 7. MIXINS
+// ===========================================================================
+eq('mixin.basic', 'mixin greet(name)\n  p Hi #{name}\n+greet("Al")', '<p>Hi Al</p>');
+eq('mixin.default-arg', 'mixin g(n="X")\n  p= n\n+g()\n+g("Y")', '<p>X</p><p>Y</p>');
+eq('mixin.rest-args', 'mixin list(id, ...items)\n  ul(id=id)\n    each i in items\n      li= i\n+list("l", 1, 2, 3)', '<ul id="l"><li>1</li><li>2</li><li>3</li></ul>');
+eq('mixin.block', 'mixin art()\n  div.art\n    block\n+art()\n  p inner', '<div class="art"><p>inner</p></div>');
+eq('mixin.and-attributes', 'mixin m()\n  div&attributes(attributes)\n+m()(class="x" id="y")', '<div class="x" id="y"></div>');
+eq('mixin.block-and-attrs', 'mixin item\n  li&attributes(attributes)\n    block\n+item.active hi', '<li class="active">hi</li>');
+
+// ===========================================================================
+// 8. COMMENTS
+// ===========================================================================
+eq('comment.buffered', '// visible comment\np x', '<!-- visible comment--><p>x</p>');
+eq('comment.unbuffered', '//- hidden comment\np x', '<p>x</p>');
+eq('comment.block', '//\n  multi\n  line\np x', '<!--multi\nline--><p>x</p>');
+eq('comment.conditional', '<!--[if IE]>\nlink(rel="stylesheet")\n<![endif]-->', '<!--[if IE]><link rel="stylesheet"/><![endif]-->');
+
+// ===========================================================================
+// 9. DOCTYPE
+// ===========================================================================
+eq('doctype.html', 'doctype html\nhtml\n  body p', '<!DOCTYPE html><html><body>p</body></html>');
+eq('doctype.html-bool-terse', 'doctype html\ninput(type="checkbox" checked)', '<!DOCTYPE html><input type="checkbox" checked>');
+eq('doctype.html-option-selected', 'doctype html\noption(selected) Hi', '<!DOCTYPE html><option selected>Hi</option>');
+eq('doctype.html-img-noslash', 'doctype html\nimg(src="a.png")', '<!DOCTYPE html><img src="a.png">');
+eq('doctype.xml', 'doctype xml\nimg(src="a")', '<?xml version="1.0" encoding="utf-8" ?><img src="a"></img>');
+eq('doctype.no-doctype-img-slash', 'img(src="a.png")', '<img src="a.png"/>');
+eq('doctype.custom', 'doctype html PUBLIC "-//x"\np hi', '<!DOCTYPE html PUBLIC "-//x"><p>hi</p>');
+
+// ===========================================================================
+// 10. OPTIONS: pretty, self, globals, cache, doctype option
+// ===========================================================================
+eq('opt.pretty-true', 'ul\n  li a\n  li b', '\n<ul>\n  <li>a</li>\n  <li>b</li>\n</ul>', { pretty: true });
+eq('opt.pretty-doc', 'doctype html\nbody\n  p hi', '<!DOCTYPE html>\n<body>\n  <p>hi</p>\n</body>', { pretty: true });
+eq('opt.pretty-default-false', 'div\n  p x', '<div><p>x</p></div>');
+eq('opt.self', 'p= self.name', '<p>z</p>', { name: 'z', self: true });
+eq('opt.doctype-option', 'input(checked)', '<input checked>', { doctype: 'html' });
+// globals: names referenced from the global object instead of locals
+global.SITE_NAME = 'ACME';
+eq('opt.globals', 'p= SITE_NAME', '<p>ACME</p>', { globals: ['SITE_NAME'] });
+
+// cache option: identical key returns the SAME cached function entry
+const c1 = pug.render('p cached', { cache: true, filename: 'carpet-ckey.pug' });
+const c2 = pug.render('p cached', { cache: true, filename: 'carpet-ckey.pug' });
+chk(c1 === '<p>cached</p>', 'opt.cache-output');
+chk(c2 === '<p>cached</p>', 'opt.cache-output2');
+chk('carpet-ckey.pug' in pug.cache, 'opt.cache-key-stored');
+
+// ===========================================================================
+// 11. compile() -> fn(locals)
+// ===========================================================================
+const cfn = pug.compile('p Hi #{name}');
+chk(typeof cfn === 'function', 'compile.returns-fn');
+chk(cfn({ name: 'Eve' }) === '<p>Hi Eve</p>', 'compile.call1');
+chk(cfn({ name: 'Bo' }) === '<p>Hi Bo</p>', 'compile.call2');
+chk(Array.isArray(cfn.dependencies), 'compile.fn-dependencies-array');
+const cfn2 = pug.compile('p= 1+1');
+chk(cfn2() === '<p>2</p>', 'compile.expr-eval');
+
+// ===========================================================================
+// 12. compileClient / compileClientWithDependenciesTracked / compileFileClient
+// ===========================================================================
+const ccSrc = pug.compileClient('p Hello #{name}', { name: 'fnTpl' });
+chk(typeof ccSrc === 'string', 'compileClient.is-string');
+chk(ccSrc.indexOf('function fnTpl') >= 0, 'compileClient.has-named-fn');
+chk(ccSrc.indexOf('pug_html') >= 0, 'compileClient.has-pug_html');
+chk(ccSrc.indexOf('function pug_escape') >= 0, 'compileClient.inlines-escape');
+const ccDefault = pug.compileClient('p x');
+chk(ccDefault.indexOf('function template') >= 0, 'compileClient.default-name');
+const ccNoDebug = pug.compileClient('p x', { name: 't3', compileDebug: false });
+chk(ccNoDebug.indexOf('pug_rethrow') < 0, 'compileClient.compileDebug-false-no-rethrow');
+const ccDebug = pug.compileClient('p x', { name: 't4', compileDebug: true });
+chk(ccDebug.indexOf('pug_rethrow') >= 0, 'compileClient.compileDebug-true-has-rethrow');
+
+const ccwdt = pug.compileClientWithDependenciesTracked('p x', { name: 't2' });
+chk(ccwdt && typeof ccwdt === 'object', 'ccwdt.is-object');
+chk('body' in ccwdt && 'dependencies' in ccwdt, 'ccwdt.has-keys');
+chk(typeof ccwdt.body === 'string' && ccwdt.body.indexOf('function t2') >= 0, 'ccwdt.body-named');
+chk(Array.isArray(ccwdt.dependencies), 'ccwdt.dependencies-array');
+
+const cfcSrc = pug.compileFileClient(FP('partial.pug'));
+chk(typeof cfcSrc === 'string' && cfcSrc.indexOf('function template') >= 0, 'compileFileClient.default-name');
+chk(pug.compileFileClient(FP('partial.pug'), { name: 'myT' }).indexOf('function myT') >= 0, 'compileFileClient.named');
+
+// Verify generated client function actually runs to the right HTML.
+const clientFn = new Function(ccSrc + '\nreturn fnTpl;')();
+chk(clientFn({ name: 'Z' }) === '<p>Hello Z</p>', 'compileClient.generated-runs');
+
+// ===========================================================================
+// 13. renderFile / compileFile / __express / basedir / includes / extends
+// ===========================================================================
+chk(pug.renderFile(FP('child.pug')) ===
+  '<html><head><title>Home</title></head><body><h1>Welcome</h1><footer>base</footer></body></html>',
+  'inherit.extends-block-override');
+chk(pug.renderFile(FP('childappend.pug')) ===
+  '<html><head><title>Default</title></head><body><p>prepended</p><p>default content</p><p>appended</p><footer>base</footer></body></html>',
+  'inherit.block-append-prepend');
+chk(pug.renderFile(FP('withinclude.pug')) ===
+  '<p>before include</p><p>partial-included</p><p>after include</p>',
+  'include.pug-partial');
+chk(pug.renderFile(FP('withrawtxt.pug')) ===
+  '<div class="box">raw text line1\nraw text line2\n</div>',
+  'include.raw-txt');
+
+const cFile = pug.compileFile(FP('child.pug'));
+chk(typeof cFile === 'function', 'compileFile.returns-fn');
+chk(cFile() ===
+  '<html><head><title>Home</title></head><body><h1>Welcome</h1><footer>base</footer></body></html>',
+  'compileFile.renders');
+
+// render with filename + basedir resolves absolute extends "/layout"
+chk(pug.render('extends /layout\nblock content\n  p via-basedir',
+  { filename: FP('x.pug'), basedir: TDIR }) ===
+  '<html><head><title>Default</title></head><body><p>via-basedir</p><footer>base</footer></body></html>',
+  'inherit.basedir-absolute-extends');
+
+// render callback (synchronous) form
+let renderCb = null;
+pug.render('p cb', {}, function (err, html) { renderCb = err ? ('ERR:' + err.message) : html; });
+chk(renderCb === '<p>cb</p>', 'render.callback-form');
+
+// renderFile callback form
+let renderFileCb = null;
+pug.renderFile(FP('partial.pug'), {}, function (err, html) { renderFileCb = err ? ('ERR:' + err.message) : html; });
+chk(renderFileCb === '<p>partial-included</p>', 'renderFile.callback-form');
+
+// __express(path, options, fn) — Express view-engine entry point
+let expressCb = null;
+pug.__express(FP('partial.pug'), {}, function (err, html) { expressCb = err ? ('ERR:' + err.message) : html; });
+chk(expressCb === '<p>partial-included</p>', 'express.__express-entry');
+
+// ===========================================================================
+// FINAL RESULT
+// ===========================================================================
+console.log('PUG_RESULT ok=' + ok + ' fail=' + fail);
+if (fail === 0) console.log('PUG_DONE');
+process.exit(fail === 0 ? 0 : 1);

--- a/apps/starry/node-web/programs/run-nweb.sh
+++ b/apps/starry/node-web/programs/run-nweb.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# run-nweb.sh — on-target gate for the StarryOS node-web framework carpet.
+# Industrial-grade carpets for pug (template engine), express (web framework over IPv4
+# loopback) and Kotlin/JS (host-precompiled module run on node). Each carpet self-checks
+# (XXX_RESULT ok=N fail=0 then XXX_DONE); TEST PASSED only when every module passes.
+set -u
+case "$(uname -m)" in x86_64) A=x86_64;; aarch64) A=aarch64;; riscv64) A=riscv64;; loongarch64) A=loongarch64;; *) A="$(uname -m)";; esac
+printf '/lib\n/usr/lib\n' > "/etc/ld-musl-$A.path"
+export PATH=/usr/bin:/bin:/sbin:/usr/sbin HOME=/root CI=1
+export NODE_OPTIONS="--max-old-space-size=1024"
+NODE=/usr/bin/node
+D=/root/nweb
+
+# V8 JIT probe: node runs full JIT on starry across all four arches with no kernel change;
+# if a target ever lacks PROT_EXEC mmap, fall back to --jitless rather than crash.
+NF=""
+"$NODE" -e 'process.exit(0)' >/tmp/probe.out 2>&1
+if [ $? -ne 0 ]; then echo "JIT probe failed -> --jitless"; tail -3 /tmp/probe.out; NF="--jitless"; export NODE_OPTIONS="$NODE_OPTIONS --jitless"; fi
+echo "=== node $("$NODE" $NF --version 2>&1) ==="
+
+cd "$D" || { echo "TEST FAILED"; exit 1; }
+PASS=0; TOTAL=0
+run(){ name="$1"; mk="$2"; js="$3"; TOTAL=$((TOTAL+1)); "$NODE" $NF "$js" >"/tmp/$name.out" 2>&1
+  if grep -aq "$mk" "/tmp/$name.out" 2>/dev/null; then
+    echo "  OK   $name ($(grep -aE '_RESULT ok=[0-9]+ fail=[0-9]+' "/tmp/$name.out" | head -1))"; PASS=$((PASS+1))
+  else echo "  FAIL $name ($mk)"; grep -aiE 'FAIL|error|exception|throw|cannot' "/tmp/$name.out" | tail -6; fi; }
+
+echo "=== node-web: web framework carpets (pug | express | kotlin-js) ==="
+run pug      PUG_DONE      carpets/PugCarpet.js
+run express  EXPRESS_DONE  carpets/ExpressCarpet.js
+run kotlinjs KOTLINJS_DONE carpets/KotlinJsCarpet.js
+echo "AGGREGATE: PASS=$PASS TOTAL=$TOTAL"
+if [ "$PASS" = "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then echo "NODE_WEB_OK=$PASS/$TOTAL"; echo "TEST PASSED"; exit 0; fi
+echo "TEST FAILED"; exit 1

--- a/apps/starry/node-web/qemu-aarch64.toml
+++ b/apps/starry/node-web/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+# node-web aarch64 — pug / express / Kotlin-JS web-framework carpet on Node.js 22.
+# -cpu cortex-a72 so qemu virt brings up a 64-bit core (the default would be AArch32). The
+# rootfs is the per-app rootfs-aarch64-alpine.img. Full V8 JIT.
+args = [
+    "-nographic", "-m", "2048M", "-smp", "1", "-cpu", "cortex-a72",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-nweb.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 7200

--- a/apps/starry/node-web/qemu-loongarch64.toml
+++ b/apps/starry/node-web/qemu-loongarch64.toml
@@ -1,0 +1,18 @@
+# node-web loongarch64 — pug / express / Kotlin-JS web-framework carpet on Node.js 22.
+# Platform: dynamic (axplat-dyn), same as aarch64/riscv64 — build-loongarch64*.toml carries no
+# ax-hal/loongarch64-qemu-virt / plat-static / plat_dyn=false (mirrors the riscv64 dynamic
+# config); uefi=false / to_bin=true is the dynamic platform's raw-binary boot path. The rootfs
+# is the per-app rootfs-loongarch64-alpine.img. Full V8 JIT.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-nweb.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/node-web/qemu-riscv64.toml
+++ b/apps/starry/node-web/qemu-riscv64.toml
@@ -1,0 +1,16 @@
+# node-web riscv64 — pug / express / Kotlin-JS web-framework carpet on Node.js 22.
+# Dynamic platform (axplat-dyn), raw-binary boot. The rootfs is the per-app
+# rootfs-riscv64-alpine.img. Full V8 JIT under TCG (slow).
+args = [
+    "-nographic", "-m", "2048M", "-smp", "1", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-nweb.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/node-web/qemu-x86_64.toml
+++ b/apps/starry/node-web/qemu-x86_64.toml
@@ -1,0 +1,17 @@
+# node-web x86_64 — pug / express / Kotlin-JS web-framework carpet on Node.js 22.
+# x86_64 boots the ELF kernel via the dynamic platform + OVMF (xtask prepares firmware
+# automatically). The rootfs is the per-app rootfs-x86_64-alpine.img. Node runs full V8 JIT
+# (no kernel change).
+args = [
+    "-nographic", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-nweb.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 7200


### PR DESCRIPTION
## 概述

新增 `apps/starry/node-web` —— 在 StarryOS 上用 Node.js 22（全 V8 JIT，零内核改动）测试一组 Web 相关框架，四架构（x86_64 / aarch64 / riscv64 / loongarch64）单核 qemu-10 运行。

每条断言对照该 node + 包版本下框架文档化行为算出的精确 golden；模块内部 fail 计数为 0 时才打印 `*_DONE` marker。`run-nweb.sh` 跑全部 3 个模块，PASS == TOTAL 才输出 `TEST PASSED`。合计 3 模块 / 291 条断言。

## 覆盖

| 模块 | 框架 | 维度 | 断言 |
|:--|:--|:--|--:|
| pug | pug 3.0.3 | 模板引擎全 API（render / renderFile / compile / compileFile / compileClient）+ 标签 / 属性 / 插值 / 转义 / 条件 / 迭代 / mixin / 继承（extends·block append-prepend）/ include / 过滤器 / doctype，对照精确 HTML golden | 120 |
| express | express 4.21.2 | Web 框架经真实 IPv4 回环（`127.0.0.1` + node http 客户端）：路由 verb / 路由参数 / query / `Router` / 中间件链 / `next('route')` / body 解析（json·urlencoded）/ 错误处理 / `express.static` / 完整 response 与 request API | 102 |
| kotlin-js | Kotlin/JS（Kotlin 2.0.21 IR → commonjs） | host 预编译的 Kotlin→JS 模块在 starry-node 上运行，stdout 与 golden 逐字节一致 + 逐行 / 逐 token 断言（data class / sealed+when / 泛型 / 扩展函数 / 高阶函数 / 空安全） | 69 |

## 验证

四架构单核 qemu-10 StarryOS 实测，`AGGREGATE PASS=3/3` + `NODE_WEB_OK=3/3` + `TEST PASSED`：

| 架构 | 结果 |
|:--:|:--:|
| x86_64 | 3/3 |
| aarch64 | 3/3 |
| riscv64 | 3/3 |
| loongarch64 | 3/3 |

运行：`cargo xtask starry app qemu -t node-web --arch <arch>`。`prebuild.sh` 在 staging rootfs 里经 qemu-user-static `apk add nodejs icu-data-full`（Alpine v3.22 main+community，解析当前 Node 22，不钉死会漂移的 URL），把 node 二进制 + 其 `.so` 闭包 + ICU 数据注入 per-app overlay 的 `/usr`，把 pug/express 的 `node_modules` 闭包与 Kotlin/JS 模块注入 `/root/nweb`。Node 在四架构均跑全 V8 JIT（启动脚本带 JIT 探测兜底，无需 `--jitless`、无内核改动）。开发者本地若已有该 apk 闭包可设 `NODE_DL_ROOT` 指向缓存短路（仅作 fallback，缓存缺失走网络 apk）。
