### PR TITLE
test(starry): add Node library carpet (node-lib)

### DIFF
--- a/apps/starry/node-lib/README.md
+++ b/apps/starry/node-lib/README.md
@@ -1,0 +1,45 @@
+# node-lib — Node.js library carpet
+
+Industrial-grade, on-target test of a set of common Node.js libraries, run by **Node.js 22**
+(Alpine v3.22 LTS, full V8 JIT, no kernel change) on StarryOS across all four architectures
+(x86_64 / aarch64 / riscv64 / loongarch64). The Node patch level is not pinned — `prebuild.sh`
+resolves the current Alpine v3.22 `nodejs` (v22.23.0 at the time of writing).
+
+Each module is a self-contained carpet that exercises one library's public API surface
+(hundreds of exact-value assertions; CSS preprocessors and JS transforms are compared against
+exact golden output computed from each library's documented behaviour at its pinned version —
+the library versions are locked by `assets/package-lock.json`). A
+module prints an anchored `*_DONE` marker only when its internal fail count is zero;
+`run-nlib.sh` runs every module and emits `TEST PASSED` only when all of them pass (no skip).
+
+## Run
+
+```
+cargo xtask starry app qemu -t node-lib --arch x86_64
+cargo xtask starry app qemu -t node-lib --arch aarch64
+cargo xtask starry app qemu -t node-lib --arch riscv64
+cargo xtask starry app qemu -t node-lib --arch loongarch64
+```
+
+`prebuild.sh` `apk add`s the musl-native Node.js 22 + npm runtime into the per-app rootfs
+`/usr`, then runs `npm ci --omit=optional` from the committed `assets/package.json` +
+`assets/package-lock.json` to provision the library `node_modules` into `/root/nlib` (nothing
+binary is committed — the dependency closure is fetched from the npm registry at build time and
+injected into the overlay). A developer with a local npm cache can point `NODE_DL_ROOT` at it
+(`--prefer-offline`, falls back to the network on a miss).
+
+## Coverage
+
+| module | library | dimension | marker |
+|:--|:--|:--|:--|
+| less | less 4.2.2 | render API + variables / arithmetic / nesting / mixins / guards / extend / maps / @import / functions / plugins → byte-exact CSS | `LESS_DONE` |
+| stylus | stylus 0.64.0 | render + JS `define`/`set` API / mixins / conditionals / iteration / hashes / built-ins / @extend → byte-exact CSS | `STYLUS_DONE` |
+| scss | sass 1.83.4 (Dart Sass) | compileString/compile + @mixin/@function / control flow / `sass:*` modules / @use / @extend / maps → exact CSS | `SCSS_DONE` |
+| babel | @babel/core 7.26.0 | transformSync + preset-typescript (TS strip) + preset-react (JSX) + custom plugins / parse / AST round-trip | `BABEL_DONE` |
+| terser | terser 5.37.0 | minify + mangle / compress / format / sourceMap / nameCache options → exact minified output | `TERSER_DONE` |
+| eslint | eslint 9.18.0 | `Linter`/`ESLint` flat-config lint: exact diagnostics (ruleId / messageId / line / col / severity) + `verifyAndFix` | `ESLINT_DONE` |
+| cjsesm | Node ESM/CJS | CommonJS↔ESM interop: require / dynamic import / data: URL / createRequire / circular resolution → exact values | `CJSESM_DONE` |
+
+The carpet sources live in `programs/carpets/`; the libraries are declared in
+`assets/package.json` + `assets/package-lock.json` and provisioned by `prebuild.sh`'s
+`npm ci` (the `node_modules` closure is not committed to the source tree).

--- a/apps/starry/node-lib/assets/package-lock.json
+++ b/apps/starry/node-lib/assets/package-lock.json
@@ -1,0 +1,3025 @@
+{
+  "name": "starry-node-lib-carpets",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "starry-node-lib-carpets",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "7.26.0",
+        "@babel/preset-react": "7.26.3",
+        "@babel/preset-typescript": "7.26.0",
+        "eslint": "9.18.0",
+        "less": "4.2.2",
+        "sass": "1.83.4",
+        "stylus": "0.64.0",
+        "terser": "5.37.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+      "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+      "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+      "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+      "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
+      "integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-transform-react-display-name": "^7.25.9",
+        "@babel/plugin-transform-react-jsx": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-development": "^7.25.9",
+        "@babel/plugin-transform-react-pure-annotations": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz",
+      "integrity": "sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+        "@babel/plugin-transform-typescript": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
+      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.18.0.tgz",
+      "integrity": "sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.13.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz",
+      "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^3.14.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.384",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
+      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz",
+      "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.10.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.18.0",
+        "@eslint/plugin-kit": "^0.2.5",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.1",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
+      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/less": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.2.2.tgz",
+      "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "copy-anything": "^2.0.1",
+        "parse-node-version": "^1.0.1",
+        "tslib": "^2.3.0"
+      },
+      "bin": {
+        "lessc": "bin/lessc"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "make-dir": "^2.1.0",
+        "mime": "^1.4.1",
+        "needle": "^3.1.0",
+        "source-map": "~0.6.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/needle": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+      "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/sass": {
+      "version": "1.83.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
+      "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylus": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.64.0.tgz",
+      "integrity": "sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "~4.3.3",
+        "debug": "^4.3.2",
+        "glob": "^10.4.5",
+        "sax": "~1.4.1",
+        "source-map": "^0.7.3"
+      },
+      "bin": {
+        "stylus": "bin/stylus"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://opencollective.com/stylus"
+      }
+    },
+    "node_modules/stylus/node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/stylus/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/apps/starry/node-lib/assets/package.json
+++ b/apps/starry/node-lib/assets/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "starry-node-lib-carpets",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Pinned devDependencies for the StarryOS node-lib library carpets (less / stylus / sass / @babel/core + presets / terser / eslint). node_modules is provisioned by prebuild.sh via `npm ci`; it is NOT committed to the source tree.",
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/core": "7.26.0",
+    "@babel/preset-react": "7.26.3",
+    "@babel/preset-typescript": "7.26.0",
+    "eslint": "9.18.0",
+    "less": "4.2.2",
+    "sass": "1.83.4",
+    "stylus": "0.64.0",
+    "terser": "5.37.0"
+  }
+}

--- a/apps/starry/node-lib/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/node-lib/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,13 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/node-lib/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/node-lib/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,14 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]

--- a/apps/starry/node-lib/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/node-lib/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/node-lib/build-x86_64-unknown-none.toml
+++ b/apps/starry/node-lib/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/node-lib/prebuild.sh
+++ b/apps/starry/node-lib/prebuild.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# prebuild.sh — provision a Node.js 22 runtime and stage the node-lib library carpet.
+#
+# Reproducible model (mirrors the merged node-lang / python-lang apps): extract the base
+# Alpine rootfs to a staging tree, `apk add nodejs npm icu-data-full` INTO it via qemu-user-static
+# (apk resolves the CURRENT v3.22 closure for the target arch — no hard-coded drifting apk URLs,
+# no pre-cached-or-exit), then copy node + its shared-library closure + ICU data into the app
+# overlay. The library dependency closure (less/stylus/sass/@babel/core+presets/terser/eslint) is
+# NOT vendored in the source tree: prebuild runs `npm ci --omit=optional` from the committed
+# assets/package.json + assets/package-lock.json to fetch a pinned, integrity-checked node_modules
+# into a scratch dir, then copies it into the overlay. `--omit=optional` drops sass's optional
+# @parcel/watcher native module (watch-mode only, x64-glibc ELF — never loads on musl/non-x64
+# targets and unused by the JS-API carpets). The resulting node_modules is pure JS (+ a portable
+# source-map .wasm), architecture-independent, so it is valid for all four target arches. The only
+# committed inputs are the base rootfs and the app's own assets/ (manifests) + programs/ sources.
+#
+# npm reaches the registry via the ambient HTTP(S)_PROXY env (set by the app runner). If a local
+# npm tarball cache is provided (NLIB_NPM_CACHE, or $NODE_DL_ROOT/npm-cache), npm ci runs
+# --prefer-offline against it and falls back to the network on a miss (never cache-miss-exit).
+#
+# If the build host has no network for apk, node install falls back to a documented, pre-fetched
+# apk cache at $NODE_APK_CACHE/<arch>/ (default <repo>/download/nodejs-apks/<arch>); OPTIONAL.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS (base alpine working copy),
+# STARRY_STAGING_ROOT (scratch extraction tree), STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+ASSETS="$app_dir/assets"
+PROG="$app_dir/programs"
+
+# Optional offline apk cache (pre-fetched v3.22 closure) — only used if the network apk path
+# below fails. Overridable via NODE_APK_CACHE (explicit dir) or NODE_DL_ROOT (its parent root).
+default_cache="$(cd "$app_dir/../../.." 2>/dev/null && pwd)/download/nodejs-apks"
+apk_cache="${NODE_APK_CACHE:-${NODE_DL_ROOT:+$NODE_DL_ROOT/nodejs-apks}}"
+apk_cache="${apk_cache:-$default_cache}"
+
+qemu_runner_candidates() {
+    case "$arch" in
+        aarch64)     printf '%s\n' qemu-aarch64-static qemu-aarch64 ;;
+        riscv64)     printf '%s\n' qemu-riscv64-static qemu-riscv64 ;;
+        x86_64)      printf '%s\n' qemu-x86_64-static qemu-x86_64 ;;
+        loongarch64) printf '%s\n' qemu-loongarch64-static qemu-loongarch64 ;;
+        *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+}
+find_qemu_runner() {
+    local candidate
+    while IFS= read -r candidate; do
+        command -v "$candidate" >/dev/null 2>&1 && { command -v "$candidate"; return 0; }
+    done < <(qemu_runner_candidates)
+    echo "prebuild: missing qemu-user runner for arch $arch; tried: $(qemu_runner_candidates | paste -sd ', ' -)" >&2
+    exit 1
+}
+qemu_runner="$(find_qemu_runner)"
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v readelf >/dev/null 2>&1 || missing+=(binutils)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get update && apt-get install -y --no-install-recommends "${missing[@]}"
+        else
+            echo "prebuild: missing host tools and no apt-get: ${missing[*]}" >&2; exit 1
+        fi
+    fi
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    # qemu-user resolves ABSOLUTE symlink targets against the HOST root, so an alpine
+    # `usr/lib/libz.so.1 -> /usr/lib/libz.so.1.3.2` dangles on a non-alpine build host and apk
+    # fails to load its libz/libssl closure ("symbol not found"). Rewrite absolute symlinks under
+    # the staging lib dirs to relative targets that resolve inside the staging tree.
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+install_node() {
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local repo="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/v3.22/main\n%s/v3.22/community\n' "$repo" "$repo" > "$staging_root/etc/apk/repositories"
+    echo "prebuild: apk add nodejs npm icu-data-full (Node 22 LTS) from Alpine v3.22 via $qemu_runner..."
+    if QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" --root "$staging_root" \
+            --repositories-file "$staging_root/etc/apk/repositories" --keys-dir "$staging_root/etc/apk/keys" \
+            --update-cache --no-progress --no-scripts add nodejs npm icu-data-full
+    then echo "prebuild: provisioned nodejs via network apk"
+    else echo "prebuild: network apk failed; falling back to offline apk cache $apk_cache/$arch"; install_node_offline; fi
+}
+install_node_offline() {
+    local dir="$apk_cache/$arch"
+    [[ -d "$dir" ]] || { echo "prebuild: offline apk cache missing: $dir" >&2; exit 3; }
+    local apks=( musl libgcc "libstdc++" zlib zstd-libs brotli-libs c-ares nghttp2-libs
+        ada-libs simdjson simdutf sqlite-libs libcrypto3 libssl3 icu-libs icu-data-full nodejs )
+    local pkg f
+    for pkg in "${apks[@]}"; do
+        f="$(ls "$dir/${pkg}"-[0-9]*.apk 2>/dev/null | head -1 || true)"
+        [[ -n "$f" ]] || { echo "prebuild: offline apk missing for '$pkg' in $dir" >&2; exit 3; }
+        tar -xzf "$f" -C "$staging_root" --exclude='.PKGINFO' --exclude='.SIGN.*' \
+            --exclude='.pre-install' --exclude='.post-install' --exclude='.trigger' 2>/dev/null || true
+    done
+    echo "prebuild: provisioned nodejs offline from ${#apks[@]} apks"
+}
+
+verify_node() {
+    [[ -x "$staging_root/usr/bin/node" ]] || { echo "prebuild: no /usr/bin/node after install" >&2; exit 4; }
+    # Best-effort version gate. Probing the freshly-apk'd node under qemu-user can crash for the
+    # SAME-arch case (x86 node under qemu-x86_64-static — V8 JIT/mmap trips a qemu-user SIGSEGV),
+    # so an empty/failed probe is NOT fatal: apk already verified the package, and run_all.py on
+    # the real StarryOS target prints the node version and gates the carpets (authoritative check).
+    local nodever
+    nodever="$(QEMU_LD_PREFIX="$staging_root" "$qemu_runner" -L "$staging_root" \
+        "$staging_root/usr/bin/node" -p 'process.versions.node' 2>/dev/null || true)"
+    case "$nodever" in
+        22.*|2[3-9].*|[3-9][0-9].*) echo "prebuild: provisioned node v$nodever" ;;
+        '') echo "prebuild: node version probe unavailable under qemu-user (same-arch V8/JIT); on-target run_all.py gates the version" ;;
+        *) echo "prebuild: WARNING unexpected node version '$nodever' (want >=22); deferring to on-target run" ;;
+    esac
+}
+
+copy_to_overlay() {
+    local src="$staging_root$1" dst="$overlay_dir$1"
+    [[ -e "$src" ]] || { echo "prebuild: missing $1 after install" >&2; exit 6; }
+    [[ -L "$src" ]] && src="$(readlink -f "$src")"
+    install -Dm"$2" "$src" "$dst"
+}
+copy_so_closure() {
+    local pending=("$@") seen=" " gp lib d
+    while [[ ${#pending[@]} -gt 0 ]]; do
+        gp="${pending[0]}"; pending=("${pending[@]:1}")
+        [[ "$seen" == *" $gp "* ]] && continue
+        seen+="$gp "
+        while IFS= read -r lib; do
+            for d in lib usr/lib usr/local/lib; do
+                if [[ -e "$staging_root/$d/$lib" ]]; then
+                    copy_to_overlay "/$d/$lib" 0644; pending+=("/$d/$lib"); break
+                fi
+            done
+        done < <(readelf -d "$staging_root$gp" 2>/dev/null | sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p')
+    done
+}
+
+# Run `npm ci --omit=optional` inside $1 (which already holds package.json + package-lock.json).
+# Primary runner: the build host's own npm — node_modules is pure JS (+ portable wasm) and thus
+# architecture-independent, so host npm produces a tree valid for every target arch. Fallback: the
+# musl npm apk-provisioned into the staging rootfs, executed under qemu-user-static. Extra args
+# (e.g. --cache/--prefer-offline) are appended.
+run_npm_ci() {
+    local dir="$1"; shift
+    if command -v npm >/dev/null 2>&1; then
+        echo "prebuild: npm ci via host npm $(npm --version) (arch-independent JS closure)"
+        if ( cd "$dir" && npm ci --omit=optional --no-audit --no-fund --loglevel=warn "$@" ); then
+            return 0
+        fi
+        echo "prebuild: host npm ci failed; trying apk-provisioned npm under qemu-user" >&2
+    fi
+    local npm_cli="$staging_root/usr/lib/node_modules/npm/bin/npm-cli.js"
+    [[ -f "$npm_cli" ]] || { echo "prebuild: no host npm and no apk npm at $npm_cli" >&2; return 1; }
+    echo "prebuild: npm ci via apk npm under $qemu_runner (musl node, arch $arch)"
+    ( cd "$dir" && QEMU_LD_PREFIX="$staging_root" HOME="$dir" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/usr/bin/node" "$npm_cli" \
+            ci --omit=optional --no-audit --no-fund --loglevel=warn "$@" )
+}
+
+# Provision the library dependency closure into $1 (the overlay's /root/nlib) by fetching it with
+# npm ci from the committed manifests — nothing binary lives in the source tree.
+provision_node_modules() {
+    local nw="$1" stage
+    [[ -f "$ASSETS/package.json" && -f "$ASSETS/package-lock.json" ]] || {
+        echo "prebuild: missing assets/package.json or assets/package-lock.json" >&2; exit 7; }
+    stage="$(mktemp -d "${TMPDIR:-/tmp}/nlib-npm.XXXXXX")"
+    cp "$ASSETS/package.json" "$ASSETS/package-lock.json" "$stage/"
+
+    local extra=() npm_cache="${NLIB_NPM_CACHE:-${NODE_DL_ROOT:+$NODE_DL_ROOT/npm-cache}}"
+    if [[ -n "$npm_cache" && -d "$npm_cache" ]]; then
+        echo "prebuild: using local npm cache $npm_cache (--prefer-offline; network on miss)"
+        extra=(--cache "$npm_cache" --prefer-offline)
+    fi
+
+    if ! run_npm_ci "$stage" "${extra[@]}"; then
+        echo "prebuild: npm ci failed (need network to the npm registry, or a populated cache)" >&2
+        rm -rf "$stage"; exit 7
+    fi
+    [[ -d "$stage/node_modules" ]] || { echo "prebuild: npm ci produced no node_modules" >&2; rm -rf "$stage"; exit 7; }
+
+    # Sanity: every module the carpets require() must be present.
+    local m
+    for m in less stylus sass @babel/core @babel/preset-typescript @babel/preset-react terser eslint; do
+        [[ -f "$stage/node_modules/$m/package.json" ]] || {
+            echo "prebuild: required module '$m' missing after npm ci" >&2; rm -rf "$stage"; exit 7; }
+    done
+
+    rm -rf "$nw/node_modules"
+    cp -a "$stage/node_modules" "$nw/node_modules"
+    rm -rf "$stage"
+}
+
+populate_overlay() {
+    copy_to_overlay /usr/bin/node 0755
+    copy_so_closure /usr/bin/node
+    ln -sf node "$overlay_dir/usr/bin/nodejs" 2>/dev/null || true
+
+    # ELF program interpreter (musl loader) under its real name (DT_NEEDED only names the symlink).
+    local interp real
+    interp="$(readelf -l "$staging_root/usr/bin/node" 2>/dev/null | sed -n 's/.*program interpreter: \(.*\)\]/\1/p' | tr -d ' ')"
+    if [[ -n "$interp" && -e "$staging_root$interp" ]]; then
+        real="$interp"
+        [[ -L "$staging_root$interp" ]] && real="$(readlink -f "$staging_root$interp")" && real="${real#"$staging_root"}"
+        install -Dm0755 "$staging_root$real" "$overlay_dir$interp"
+    fi
+
+    # ICU data table (Intl.* / toLocaleString) + musl loader search path.
+    if [[ -d "$staging_root/usr/share/icu" ]]; then
+        mkdir -p "$overlay_dir/usr/share/icu"; cp -a "$staging_root/usr/share/icu/." "$overlay_dir/usr/share/icu/"
+    fi
+    if [[ -f "$staging_root/etc/ld-musl-${arch}.path" ]]; then
+        install -Dm0644 "$staging_root/etc/ld-musl-${arch}.path" "$overlay_dir/etc/ld-musl-${arch}.path"
+    else
+        mkdir -p "$overlay_dir/etc"; printf '/lib\n/usr/lib\n/usr/local/lib\n' > "$overlay_dir/etc/ld-musl-${arch}.path"
+    fi
+
+    # Stage the carpet sources into /root/nlib and the run-nlib.sh gate into /usr/bin, then fetch
+    # the less/stylus/sass/babel/terser/eslint node_modules closure with npm ci (never vendored).
+    # Each carpet resolves require() from /root/nlib/node_modules (run-nlib.sh cd's there) and
+    # writes scratch under __dirname.
+    local nw="$overlay_dir/root/nlib"
+    install -d "$nw/carpets"
+    install -m0644 "$PROG/carpets/LessCarpet.js" "$PROG/carpets/StylusCarpet.js" "$PROG/carpets/ScssCarpet.js" \
+        "$PROG/carpets/BabelCarpet.js" "$PROG/carpets/TerserCarpet.js" "$PROG/carpets/EslintCarpet.js" \
+        "$PROG/carpets/CjsEsmCarpet.js" "$nw/carpets/"
+    provision_node_modules "$nw"
+    install -Dm0755 "$PROG/run-nlib.sh" "$overlay_dir/usr/bin/run-nlib.sh"
+
+    echo "prebuild: staged node + .so closure + ICU + npm-ci node_modules ($(du -sh "$nw/node_modules" | cut -f1)) + 7 carpets; overlay ready for $arch"
+}
+
+ensure_host_tools
+extract_base_rootfs
+normalize_symlinks
+install_node
+verify_node
+populate_overlay

--- a/apps/starry/node-lib/programs/carpets/BabelCarpet.js
+++ b/apps/starry/node-lib/programs/carpets/BabelCarpet.js
@@ -1,0 +1,310 @@
+'use strict';
+// INDUSTRIAL carpet for @babel/core 7.26.0 (+ @babel/preset-typescript 7.26.0,
+// @babel/preset-react 7.26.3). Host-verified on Node.js v22.22.2.
+// All golden values were observed by RUNNING this exact toolchain, then baked
+// in as exact-value (===) assertions. Deterministic: no clock, no randomness,
+// no network. require() resolves from the cwd's node_modules.
+
+const path = require('path');
+const babel = require('@babel/core');
+const t = babel.types;
+
+let ok = 0, fail = 0;
+function chk(cond, name) { if (cond) ok++; else { fail++; console.log('FAIL ' + name); } }
+
+// exact transform helper
+function tx(code, opts) { return babel.transformSync(code, opts).code; }
+function eq(code, opts, expected, name) { chk(tx(code, opts) === expected, name); }
+
+const TS = { presets: [['@babel/preset-typescript']], filename: 'a.ts' };
+const TSX = { presets: [['@babel/preset-typescript'], ['@babel/preset-react']], filename: 'a.tsx' };
+const RJSX = { presets: [['@babel/preset-react']], filename: 'a.jsx' };
+
+// ---------------------------------------------------------------------------
+// 0. version / API surface
+// ---------------------------------------------------------------------------
+chk(babel.version === '7.26.0', 'version-7.26.0');
+chk(typeof babel.transformSync === 'function', 'api-transformSync');
+chk(typeof babel.transform === 'function', 'api-transform');
+chk(typeof babel.transformAsync === 'function', 'api-transformAsync');
+chk(typeof babel.parseSync === 'function', 'api-parseSync');
+chk(typeof babel.parse === 'function', 'api-parse');
+chk(typeof babel.parseAsync === 'function', 'api-parseAsync');
+chk(typeof babel.transformFromAstSync === 'function', 'api-transformFromAstSync');
+chk(typeof babel.transformFromAst === 'function', 'api-transformFromAst');
+chk(typeof babel.traverse === 'function', 'api-traverse');
+chk(typeof babel.template === 'function', 'api-template');
+chk(typeof babel.types === 'object', 'api-types');
+chk(typeof babel.loadOptions === 'function', 'api-loadOptions');
+chk(typeof babel.loadPartialConfig === 'function', 'api-loadPartialConfig');
+chk(typeof babel.createConfigItem === 'function', 'api-createConfigItem');
+chk(Array.isArray(babel.DEFAULT_EXTENSIONS), 'api-DEFAULT_EXTENSIONS-array');
+chk(babel.DEFAULT_EXTENSIONS.join(',') === '.js,.jsx,.es6,.es,.mjs,.cjs', 'DEFAULT_EXTENSIONS-value');
+chk(babel.DEFAULT_EXTENSIONS.indexOf('.jsx') === 1, 'DEFAULT_EXTENSIONS-jsx');
+
+// ---------------------------------------------------------------------------
+// 1. @babel/preset-typescript — strip TS, lower enum/namespace/param-props
+// ---------------------------------------------------------------------------
+eq('const x: number = 1;', TS, 'const x = 1;', 'ts-type-annotation');
+eq('interface Foo { a: number; }\nconst y = 2;', TS, 'const y = 2;', 'ts-interface-erased');
+eq('type T = keyof Foo;\nconst a = 1;', TS, 'const a = 1;', 'ts-type-alias-erased');
+eq('const v = x as string;', TS, 'const v = x;', 'ts-as-cast');
+eq('const x = <number>y;', TS, 'const x = y;', 'ts-angle-cast');
+eq('const w = { a: 1 } satisfies Record<string, number>;', TS,
+   'const w = {\n  a: 1\n};', 'ts-satisfies');
+eq('function id<T>(x: T): T { return x; }', TS,
+   'function id(x) {\n  return x;\n}', 'ts-generic-function');
+eq('const x = f<number>();', TS, 'const x = f();', 'ts-type-args-call');
+eq('import type { Foo } from "./foo";\nconst z = 1;', TS,
+   'const z = 1;\nexport {};', 'ts-import-type-only');
+eq('declare const x: number;\nconst y = 1;', TS, 'const y = 1;', 'ts-declare-erased');
+eq('const a = b!;', TS, 'const a = b;', 'ts-non-null');
+eq('function f(a?: number) { return a; }', TS,
+   'function f(a) {\n  return a;\n}', 'ts-optional-param');
+eq('class C { readonly x: number = 1; }', TS,
+   'class C {\n  x = 1;\n}', 'ts-readonly-field');
+eq('abstract class C { abstract f(): void; g(){} }', TS,
+   'class C {\n  g() {}\n}', 'ts-abstract-class');
+eq('class C implements I { x = 1; }', TS,
+   'class C {\n  x = 1;\n}', 'ts-implements-erased');
+eq('import x = require("y");', TS, '', 'ts-import-equals-erased');
+eq('class C { constructor(private x: number) {} }', TS,
+   'class C {\n  constructor(x) {\n    this.x = x;\n  }\n}', 'ts-param-property');
+// numeric enum lowering
+eq('enum Color { Red, Green, Blue }', TS,
+   'var Color = /*#__PURE__*/function (Color) {\n' +
+   '  Color[Color["Red"] = 0] = "Red";\n' +
+   '  Color[Color["Green"] = 1] = "Green";\n' +
+   '  Color[Color["Blue"] = 2] = "Blue";\n' +
+   '  return Color;\n}(Color || {});', 'ts-enum-numeric');
+// const enum lowering (same shape on babel — no TS type-checker)
+eq('const enum E { A, B }', TS,
+   'var E = /*#__PURE__*/function (E) {\n' +
+   '  E[E["A"] = 0] = "A";\n' +
+   '  E[E["B"] = 1] = "B";\n' +
+   '  return E;\n}(E || {});', 'ts-const-enum');
+// string enum lowering
+eq('enum E { A = "a", B = "b" }', TS,
+   'var E = /*#__PURE__*/function (E) {\n' +
+   '  E["A"] = "a";\n' +
+   '  E["B"] = "b";\n' +
+   '  return E;\n}(E || {});', 'ts-enum-string');
+// namespace lowering
+eq('namespace N { export const a = 1; }', TS,
+   'let N;\n(function (_N) {\n  const a = _N.a = 1;\n})(N || (N = {}));', 'ts-namespace');
+// bare-string preset form also works
+eq('const x: number = 1;', { presets: ['@babel/preset-typescript'], filename: 'a.ts' },
+   'const x = 1;', 'ts-bare-string-preset');
+
+// ---------------------------------------------------------------------------
+// 2. @babel/preset-react — JSX, classic vs automatic runtime
+// ---------------------------------------------------------------------------
+eq('const a = <div className="x">hi</div>;', RJSX,
+   'const a = /*#__PURE__*/React.createElement("div", {\n  className: "x"\n}, "hi");',
+   'jsx-classic-element');
+eq('const a = <>hi</>;', RJSX,
+   'const a = /*#__PURE__*/React.createElement(React.Fragment, null, "hi");',
+   'jsx-classic-fragment');
+eq('const a = <Comp {...props} />;', RJSX,
+   'const a = /*#__PURE__*/React.createElement(Comp, props);', 'jsx-spread-only');
+eq('const a = <div>{value}</div>;', RJSX,
+   'const a = /*#__PURE__*/React.createElement("div", null, value);', 'jsx-expression-child');
+eq('const a = <ul><li>1</li><li>2</li></ul>;', RJSX,
+   'const a = /*#__PURE__*/React.createElement("ul", null, ' +
+   '/*#__PURE__*/React.createElement("li", null, "1"), ' +
+   '/*#__PURE__*/React.createElement("li", null, "2"));', 'jsx-nested-classic');
+eq('const a = <div>{cond ? <A/> : <B/>}</div>;', RJSX,
+   'const a = /*#__PURE__*/React.createElement("div", null, cond ? ' +
+   '/*#__PURE__*/React.createElement(A, null) : ' +
+   '/*#__PURE__*/React.createElement(B, null));', 'jsx-conditional');
+eq('const a = <input disabled />;', RJSX,
+   'const a = /*#__PURE__*/React.createElement("input", {\n  disabled: true\n});',
+   'jsx-boolean-attr');
+eq('const a = <Foo.Bar />;', RJSX,
+   'const a = /*#__PURE__*/React.createElement(Foo.Bar, null);', 'jsx-member-expr');
+eq('const a = <div>\n  hello\n  world\n</div>;', RJSX,
+   'const a = /*#__PURE__*/React.createElement("div", null, "hello world");',
+   'jsx-whitespace-collapse');
+eq('const a = <div>{/* c */}</div>;', RJSX,
+   'const a = /*#__PURE__*/React.createElement("div", null);', 'jsx-comment-child-dropped');
+eq('const a = <div>&amp;</div>;', RJSX,
+   'const a = /*#__PURE__*/React.createElement("div", null, "&");', 'jsx-html-entity');
+// custom pragma (classic): no PURE annotation, custom factory
+eq('const a = <div/>;', { presets: [['@babel/preset-react', { pragma: 'h', pragmaFrag: 'Fragment' }]], filename: 'a.jsx' },
+   'const a = h("div", null);', 'jsx-custom-pragma');
+// automatic runtime
+eq('const a = <div className="x">hi</div>;', { presets: [['@babel/preset-react', { runtime: 'automatic' }]], filename: 'a.jsx' },
+   'import { jsx as _jsx } from "react/jsx-runtime";\n' +
+   'const a = /*#__PURE__*/_jsx("div", {\n  className: "x",\n  children: "hi"\n});',
+   'jsx-automatic-jsx');
+eq('const a = <>hi</>;', { presets: [['@babel/preset-react', { runtime: 'automatic' }]], filename: 'a.jsx' },
+   'import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";\n' +
+   'const a = /*#__PURE__*/_jsx(_Fragment, {\n  children: "hi"\n});',
+   'jsx-automatic-fragment');
+eq('const a = <ul><li/><li/></ul>;', { presets: [['@babel/preset-react', { runtime: 'automatic' }]], filename: 'a.jsx' },
+   'import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";\n' +
+   'const a = /*#__PURE__*/_jsxs("ul", {\n  children: [/*#__PURE__*/_jsx("li", {}), /*#__PURE__*/_jsx("li", {})]\n});',
+   'jsx-automatic-jsxs-multi');
+eq('const a = <li key="1">x</li>;', { presets: [['@babel/preset-react', { runtime: 'automatic' }]], filename: 'a.jsx' },
+   'import { jsx as _jsx } from "react/jsx-runtime";\n' +
+   'const a = /*#__PURE__*/_jsx("li", {\n  children: "x"\n}, "1");',
+   'jsx-automatic-key-arg');
+eq('const a = <div/>;', { presets: [['@babel/preset-react', { runtime: 'automatic', importSource: 'preact' }]], filename: 'a.jsx' },
+   'import { jsx as _jsx } from "preact/jsx-runtime";\nconst a = _jsx("div", {});',
+   'jsx-automatic-importSource');
+
+// ---------------------------------------------------------------------------
+// 3. TSX — preset-typescript + preset-react together on a .tsx file
+// ---------------------------------------------------------------------------
+eq('const el = <div>{(x as number)}</div>;', TSX,
+   'const el = /*#__PURE__*/React.createElement("div", null, x);', 'tsx-combined');
+
+// ---------------------------------------------------------------------------
+// 4. custom plugin (visitor) — Identifier rename, asserts visitor API
+// ---------------------------------------------------------------------------
+function renameFooToBar() {
+  return { visitor: { Identifier(p) { if (p.node.name === 'foo') p.node.name = 'bar'; } } };
+}
+eq('const foo = 1; foo + foo;', { plugins: [renameFooToBar] },
+   'const bar = 1;\nbar + bar;', 'plugin-identifier-rename');
+
+// plugin that counts nodes via a closure (verifies path.node access)
+let visited = 0;
+function countNumericLiterals() {
+  return { visitor: { NumericLiteral() { visited++; } } };
+}
+babel.transformSync('const a = 1 + 2 + 3;', { plugins: [countNumericLiterals] });
+chk(visited === 3, 'plugin-visitor-count');
+
+// ---------------------------------------------------------------------------
+// 5. babel.parseSync — AST node types
+// ---------------------------------------------------------------------------
+const ast = babel.parseSync('const x = 1 + 2;');
+chk(ast.type === 'File', 'parse-File');
+chk(ast.program.type === 'Program', 'parse-Program');
+chk(ast.program.sourceType === 'module', 'parse-sourceType-module');
+chk(ast.program.body[0].type === 'VariableDeclaration', 'parse-VariableDeclaration');
+chk(ast.program.body[0].kind === 'const', 'parse-decl-kind-const');
+const decl0 = ast.program.body[0].declarations[0];
+chk(decl0.type === 'VariableDeclarator', 'parse-VariableDeclarator');
+chk(decl0.id.type === 'Identifier' && decl0.id.name === 'x', 'parse-declarator-id');
+chk(decl0.init.type === 'BinaryExpression', 'parse-BinaryExpression');
+chk(decl0.init.operator === '+', 'parse-binary-operator');
+chk(decl0.init.left.type === 'NumericLiteral' && decl0.init.left.value === 1, 'parse-numeric-left');
+chk(decl0.init.right.value === 2, 'parse-numeric-right');
+// parse JSX requires the react preset's syntax
+const jsxAst = babel.parseSync('const a = <div/>;', RJSX);
+chk(jsxAst.program.body[0].declarations[0].init.type === 'JSXElement', 'parse-JSXElement');
+
+// ---------------------------------------------------------------------------
+// 6. babel.transformFromAstSync — round-trip + plugin over a pre-parsed AST
+// ---------------------------------------------------------------------------
+const rtAst = babel.parseSync('const y = 5;');
+chk(babel.transformFromAstSync(rtAst, 'const y = 5;', {}).code === 'const y = 5;',
+    'fromAst-roundtrip');
+const mutAst = babel.parseSync('const foo = 1;');
+chk(babel.transformFromAstSync(mutAst, 'const foo = 1;',
+      { plugins: [function () { return { visitor: { Identifier(p) { if (p.node.name === 'foo') p.node.name = 'renamed'; } } }; }] }).code
+    === 'const renamed = 1;', 'fromAst-plugin');
+
+// ---------------------------------------------------------------------------
+// 7. generator / output options
+// ---------------------------------------------------------------------------
+eq('const a = 1;\nconst b = 2;', { compact: true }, 'const a=1;const b=2;', 'opt-compact');
+eq('const a = 1;\nconst b = 2;', { minified: true }, 'const a=1;const b=2;', 'opt-minified');
+eq('const a = 1; // hi\nconst b = 2;', { comments: false }, 'const a = 1;\nconst b = 2;', 'opt-comments-false');
+eq('const a = 1; // hi\nconst b = 2;', {}, 'const a = 1; // hi\nconst b = 2;', 'opt-comments-default');
+eq('const a = 1; // keep\nconst b = 2; /* drop */', { shouldPrintComment: function (v) { return v.indexOf('keep') >= 0; } },
+   'const a = 1; // keep\nconst b = 2;', 'opt-shouldPrintComment');
+eq('const a = 1; // c\nfoo();', { compact: true }, 'const a=1;// c\nfoo();', 'opt-compact-keeps-comment');
+eq('const a = 1;\n\n\nconst b = 2;', { retainLines: true }, 'const a = 1;\n\n\nconst b = 2;', 'opt-retainLines');
+eq('const a =\n  1;', { retainLines: true }, 'const a =\n1;', 'opt-retainLines-2');
+eq('var a = 1;', { sourceType: 'script' }, 'var a = 1;', 'opt-sourceType-script');
+eq('export const a = 1;', { sourceType: 'module' }, 'export const a = 1;', 'opt-sourceType-module');
+eq('return 1;', { parserOpts: { allowReturnOutsideFunction: true } }, 'return 1;', 'opt-parserOpts');
+
+// transform result metadata shape
+const res = babel.transformSync('const a = 1;', { ast: true, sourceMaps: true });
+chk(typeof res.code === 'string', 'result-code-string');
+chk(res.ast && res.ast.type === 'File', 'result-ast-File');
+chk(res.map != null && Array.isArray(res.map.sources), 'result-sourcemap');
+chk(res.sourceType === 'module', 'result-sourceType');
+
+// ---------------------------------------------------------------------------
+// 8. code-frame error on syntax error (loc + caret), portable assertions
+// ---------------------------------------------------------------------------
+let threw = false, err = null;
+try { babel.transformSync('const = ;', { filename: 'bad.js' }); }
+catch (e) { threw = true; err = e; }
+chk(threw === true, 'err-thrown');
+chk(err && err.code === 'BABEL_PARSE_ERROR', 'err-code');
+chk(err && err.loc && err.loc.line === 1 && err.loc.column === 6, 'err-loc');
+chk(err && err.reasonCode === 'UnexpectedToken', 'err-reasonCode');
+chk(err && err.message.indexOf('Unexpected token') >= 0, 'err-message-text');
+chk(err && err.message.indexOf('(1:6)') >= 0, 'err-message-position');
+chk(err && err.message.indexOf('^') >= 0, 'err-codeframe-caret');
+// TS requires the right filename: .js input rejects type annotations
+let tsThrew = false;
+try { babel.transformSync('const x: number = 1;', { filename: 'plain.js' }); }
+catch (e) { tsThrew = true; }
+chk(tsThrew === true, 'err-ts-needs-ts-filename');
+
+// ---------------------------------------------------------------------------
+// 9. @babel/types — node builders / predicates
+// ---------------------------------------------------------------------------
+chk(typeof t.isIdentifier === 'function', 'types-isIdentifier-fn');
+const idNode = t.identifier('xyz');
+chk(idNode.type === 'Identifier' && idNode.name === 'xyz', 'types-identifier-build');
+chk(t.isIdentifier(idNode) === true, 'types-isIdentifier-true');
+chk(t.isIdentifier(t.numericLiteral(1)) === false, 'types-isIdentifier-false');
+const numNode = t.numericLiteral(42);
+chk(numNode.type === 'NumericLiteral' && numNode.value === 42, 'types-numericLiteral');
+chk(t.isNumericLiteral(numNode, { value: 42 }) === true, 'types-isNumericLiteral-shape');
+
+// ---------------------------------------------------------------------------
+// 10. @babel/template — build AST from template, generate code back
+// ---------------------------------------------------------------------------
+const buildConst = babel.template('const %%name%% = %%val%%;');
+const tmplNode = buildConst({ name: t.identifier('z'), val: t.numericLiteral(42) });
+chk(tmplNode.type === 'VariableDeclaration', 'template-node-type');
+chk(babel.transformFromAstSync(t.file(t.program([tmplNode])), '', {}).code === 'const z = 42;',
+    'template-generate');
+const stmtTmpl = babel.template.statement('const A = B;');
+const stmtNode = stmtTmpl({ A: t.identifier('q'), B: t.numericLiteral(7) });
+chk(stmtNode.type === 'VariableDeclaration', 'template-statement-type');
+chk(babel.transformFromAstSync(t.file(t.program([stmtNode])), '', {}).code === 'const q = 7;',
+    'template-statement-generate');
+const exprTmpl = babel.template.expression('1 + 2');
+chk(exprTmpl().type === 'BinaryExpression', 'template-expression-type');
+
+// ---------------------------------------------------------------------------
+// 11. babel.traverse — walk a parsed AST
+// ---------------------------------------------------------------------------
+let idCount = 0;
+babel.traverse(babel.parseSync('const a = 1; const b = 2; a + b;'),
+  { Identifier() { idCount++; } });
+chk(idCount === 4, 'traverse-identifier-count');
+let binCount = 0;
+babel.traverse(babel.parseSync('a + b - c;'), { BinaryExpression() { binCount++; } });
+chk(binCount === 2, 'traverse-binary-count');
+
+// ---------------------------------------------------------------------------
+// 12. config loading helpers
+// ---------------------------------------------------------------------------
+const loaded = babel.loadOptions({ presets: [['@babel/preset-react']], filename: 'a.jsx', configFile: false, babelrc: false });
+chk(Array.isArray(loaded.plugins), 'loadOptions-plugins-array');
+chk(loaded.plugins.length > 0, 'loadOptions-plugins-nonempty');
+const partial = babel.loadPartialConfig({ filename: 'a.js', configFile: false, babelrc: false });
+chk(!!partial.options, 'loadPartialConfig-options');
+const item = babel.createConfigItem(['@babel/preset-react', {}], { type: 'preset' });
+chk(typeof item.value === 'function', 'createConfigItem-value');
+
+// ---------------------------------------------------------------------------
+// cwd option: babel honours an explicit cwd + relative filename, portably
+// ---------------------------------------------------------------------------
+chk(babel.transformSync('const x = 1;', { cwd: __dirname, filename: 'a.ts', configFile: false, babelrc: false, presets: ['@babel/preset-typescript'] }).code === 'const x = 1;', 'babel-cwd-option');
+
+// ---------------------------------------------------------------------------
+console.log('BABEL_RESULT ok=' + ok + ' fail=' + fail);
+if (fail === 0) console.log('BABEL_DONE');
+process.exit(fail === 0 ? 0 : 1);

--- a/apps/starry/node-lib/programs/carpets/CjsEsmCarpet.js
+++ b/apps/starry/node-lib/programs/carpets/CjsEsmCarpet.js
@@ -1,0 +1,349 @@
+'use strict';
+// INDUSTRIAL carpet for CommonJS <-> ESM interop on Node.js v22.22.2.
+// This file itself is CommonJS (.js). It writes a self-contained fixture tree
+// under <__dirname>/tmp-cjsesm (.mjs / .cjs / package.json type:module subdir /
+// a tiny exports-conditioned package) and exercises every documented interop
+// path between the two module systems on this exact Node version:
+//   - require() of .cjs (object-exports + function-exports) and JSON
+//   - dynamic import() of .mjs from CJS (default + named bindings)
+//   - import() of .cjs from ESM (default = module.exports; named via the
+//     cjs-module-lexer named-export detection, with its exact detection rules)
+//   - __esModule interop (native node does NOT auto-unwrap, unlike bundlers)
+//   - data: URL import (default + named)
+//   - import.meta.url / dirname / filename are real file: URLs
+//   - createRequire(), node:module builtins API, require(esm) (v22 feature)
+//   - package.json "type":"module" subdir + "exports" import/require conditions
+//   - circular require partial-exports resolution
+//   - CJS-only globals (structuredClone / TextEncoder / TextDecoder)
+//   - real vendored CJS packages resolve from node_modules
+// Every assertion is an exact-value check against a golden observed by running
+// node v22.22.2 directly. Deterministic only: no clock, no random, no network.
+// Portable: every path derives from __dirname; subprocess (none here) would use
+// process.execPath. The fixture tree is removed best-effort at the end.
+
+const fs = require('fs');
+const path = require('path');
+const url = require('node:url');
+const Module = require('node:module');
+const { createRequire } = Module;
+
+// ---- self-check harness (mirrors the delivered node-web carpets) ----------
+let ok = 0, fail = 0;
+function chk(cond, name) {
+  if (cond) { ok++; } else { fail++; console.log('FAIL ' + name); }
+}
+function eq(actual, expected, name) {
+  const c = actual === expected;
+  if (!c) console.log('  expected=' + JSON.stringify(expected) + ' actual=' + JSON.stringify(actual));
+  chk(c, name);
+}
+
+// ---- deterministic on-disk fixture tree (all under __dirname) --------------
+const FIX = path.join(__dirname, 'tmp-cjsesm');
+const NM = path.join(FIX, 'node_modules');
+const DUAL = path.join(NM, 'dual');
+const ESMPKG = path.join(FIX, 'esmpkg');
+
+function rmrf(p) { try { fs.rmSync(p, { recursive: true, force: true }); } catch (e) { /* best-effort */ } }
+
+rmrf(FIX);
+fs.mkdirSync(FIX, { recursive: true });
+fs.mkdirSync(DUAL, { recursive: true });
+fs.mkdirSync(ESMPKG, { recursive: true });
+
+const W = (rel, body) => fs.writeFileSync(path.join(FIX, rel), body);
+
+// -- ESM module: named + default + import.meta export
+W('m.mjs',
+  'export const NAMED = \'named-val\';\n' +
+  'export function add(a, b) { return a + b; }\n' +
+  'export default { kind: \'esm-default\', n: 7 };\n' +
+  'export const META = import.meta.url;\n');
+
+// -- ESM module that re-exports its own import.meta coordinates
+W('meta.mjs',
+  'export const url = import.meta.url;\n' +
+  'export const dir = import.meta.dirname;\n' +
+  'export const fname = import.meta.filename;\n');
+
+// -- CJS: object module.exports (with a value-bearing object literal) + late prop
+//    lexer detects ONLY `module.exports.added` (object-literal w/ values is opaque)
+W('c.cjs',
+  'module.exports = { foo: 1, bar: \'two\', fn: function () { return \'fnret\'; } };\n' +
+  'module.exports.added = \'late\';\n');
+
+// -- CJS: exports.X assignments (both detected by lexer)
+W('c2.cjs',
+  'exports.alpha = \'A\';\n' +
+  'exports.beta = 42;\n');
+
+// -- CJS: object literal SHORTHAND (identifiers) -> lexer detects a, b
+W('lex1.cjs',
+  'const a = 1, b = 2;\n' +
+  'module.exports = { a, b };\n');
+
+// -- CJS: object literal with VALUES -> lexer detects NOTHING (only default)
+W('lex2.cjs',
+  'module.exports = { p: 1, q: 2 };\n');
+
+// -- CJS: exports.one + Object.defineProperty -> both detected
+W('lex3.cjs',
+  'exports.one = \'I\';\n' +
+  'Object.defineProperty(exports, \'two\', { enumerable: true, value: \'II\' });\n');
+
+// -- CJS: babel-style __esModule + default + named (native node: NO unwrap)
+W('esm_interop.cjs',
+  'exports.default = \'the-default\';\n' +
+  'exports.named = \'the-named\';\n' +
+  'exports.__esModule = true;\n');
+
+// -- CJS: function as module.exports + a late prop + a prop on the local fn
+W('funcmod.cjs',
+  'function greet(name) { return \'hi \' + name; }\n' +
+  'greet.version = \'2.0\';\n' +
+  'module.exports = greet;\n' +
+  'module.exports.extra = \'X\';\n');
+
+// -- JSON module
+W('data.json', '{"x":10,"y":[1,2,3]}\n');
+
+// -- anchor file for createRequire so resolution is rooted in the fixture dir
+W('anchor.cjs', 'module.exports = true;\n');
+
+// -- circular require pair
+W('circA.cjs',
+  'exports.nameA = \'A\';\n' +
+  'const b = require(\'./circB.cjs\');\n' +
+  'exports.fromB_atLoad = b.nameB;\n' +
+  'exports.bDoneFlag = b.done;\n' +
+  'exports.done = true;\n');
+W('circB.cjs',
+  'exports.nameB = \'B\';\n' +
+  'const a = require(\'./circA.cjs\');\n' +
+  'exports.aPartial_nameA = a.nameA;\n' +
+  'exports.aPartial_done = a.done;\n' +   // A not finished yet -> undefined (warns on stderr)
+  'exports.done = true;\n');
+
+// -- subdir treated as ESM purely via package.json {"type":"module"}
+fs.writeFileSync(path.join(ESMPKG, 'package.json'), '{ "type": "module" }\n');
+fs.writeFileSync(path.join(ESMPKG, 'index.js'),
+  'export const flavor = \'esm-via-pkgjson\';\n' +
+  'export default 123;\n');
+
+// -- dual package with conditional "exports" (import vs require) + subpath
+fs.writeFileSync(path.join(DUAL, 'package.json'),
+  '{ "name": "dual", "version": "1.0.0", "exports": { ".": { "import": "./esm.mjs", "require": "./cjs.cjs" }, "./sub": "./sub.cjs" } }\n');
+fs.writeFileSync(path.join(DUAL, 'esm.mjs'),
+  'export const side = \'import-condition\';\nexport default \'esm-default\';\n');
+fs.writeFileSync(path.join(DUAL, 'cjs.cjs'),
+  'module.exports = { side: \'require-condition\' };\n');
+fs.writeFileSync(path.join(DUAL, 'sub.cjs'),
+  'exports.subval = \'subpath\';\n');
+
+// -- ESM fixture that resolves the dual package from inside the fixture tree
+//    (bare-specifier resolution is anchored at this module's URL)
+W('condtest.mjs',
+  'import { createRequire } from \'node:module\';\n' +
+  'const require = createRequire(import.meta.url);\n' +
+  'export const reqSide = require(\'dual\').side;\n' +
+  'const imp = await import(\'dual\');\n' +
+  'export const impSide = imp.side;\n' +
+  'export const impDefault = imp.default;\n' +
+  'const sub = await import(\'dual/sub\');\n' +
+  'export const subVal = sub.subval;\n');
+
+// require() rooted in the fixture dir, and file:-URL importer for the fixtures
+const fixRequire = createRequire(path.join(FIX, 'anchor.cjs'));
+const fileURL = (rel) => url.pathToFileURL(path.join(FIX, rel)).href;
+const imp = (rel) => import(fileURL(rel));
+
+async function main() {
+  // ===== Section A: node:module builtins & Module API =====================
+  eq(require('node:module'), require('module'), 'A.node:module===module');     // 1
+  eq(typeof Module.createRequire, 'function', 'A.createRequire.fn');           // 2
+  chk(Array.isArray(Module.builtinModules), 'A.builtinModules.array');        // 3
+  eq(Module.builtinModules.includes('fs'), true, 'A.builtin.fs');             // 4
+  eq(Module.builtinModules.includes('os'), true, 'A.builtin.os');             // 5
+  eq(Module.builtinModules.includes('node:fs'), false, 'A.builtin.no-prefix');// 6
+  eq(Module.isBuiltin('fs'), true, 'A.isBuiltin.fs');                         // 7
+  eq(Module.isBuiltin('node:fs'), true, 'A.isBuiltin.node:fs');              // 8
+  eq(Module.isBuiltin('nonexistent-xyz'), false, 'A.isBuiltin.no');           // 9
+  eq(module instanceof Module, true, 'A.module.instanceof');                  // 10
+  eq(typeof module.id, 'string', 'A.module.id.type');                         // 11
+  eq(module.id, '.', 'A.module.id.dot');                                       // 12
+  eq(require.main === module, true, 'A.require.main');                         // 13
+  eq(typeof require.cache, 'object', 'A.require.cache');                       // 14
+
+  // ===== Section B: CJS globals (deterministic) ===========================
+  eq(typeof structuredClone, 'function', 'B.structuredClone.fn');             // 15
+  eq(JSON.stringify(structuredClone({ n: [1, 2] })), '{"n":[1,2]}', 'B.sc'); // 16
+  eq(typeof TextEncoder, 'function', 'B.TextEncoder.fn');                     // 17
+  eq(Array.from(new TextEncoder().encode('AB')).join(','), '65,66', 'B.te'); // 18
+  eq(typeof TextDecoder, 'function', 'B.TextDecoder.fn');                     // 19
+  eq(new TextDecoder().decode(new Uint8Array([65, 66])), 'AB', 'B.td');       // 20
+  eq(typeof Buffer, 'function', 'B.Buffer.global');                           // 21
+  eq(typeof queueMicrotask, 'function', 'B.queueMicrotask');                  // 22
+
+  // ===== Section C: __dirname / __filename in CJS =========================
+  eq(typeof __dirname, 'string', 'C.dirname.type');                           // 23
+  eq(path.basename(__filename), 'CjsEsmCarpet.js', 'C.filename.base');        // 24
+  eq(__dirname, path.dirname(__filename), 'C.dir-is-dirname');                // 25
+
+  // ===== Section D: require() of .cjs (object module.exports) ==============
+  const c = fixRequire('./c.cjs');
+  eq(c.foo, 1, 'D.c.foo');                                                    // 26
+  eq(c.bar, 'two', 'D.c.bar');                                                // 27
+  eq(c.added, 'late', 'D.c.added');                                           // 28
+  eq(c.fn(), 'fnret', 'D.c.fn');                                              // 29
+
+  // ===== Section E: require() of .cjs (function module.exports) ============
+  const fm = fixRequire('./funcmod.cjs');
+  eq(typeof fm, 'function', 'E.fm.type');                                     // 30
+  eq(fm('bob'), 'hi bob', 'E.fm.call');                                       // 31
+  eq(fm.version, '2.0', 'E.fm.version');                                      // 32
+  eq(fm.extra, 'X', 'E.fm.extra');                                            // 33
+
+  // ===== Section F: require() of JSON =====================================
+  const jraw = fixRequire('./data.json');
+  eq(jraw.x, 10, 'F.json.x');                                                 // 34
+  eq(JSON.stringify(jraw.y), '[1,2,3]', 'F.json.y');                          // 35
+
+  // ===== Section G: require.resolve ========================================
+  eq(path.basename(fixRequire.resolve('./c.cjs')), 'c.cjs', 'G.resolve.base');// 36
+  eq(require.resolve('less').includes('/node_modules/less/'), true, 'G.resolve.nm'); // 37
+
+  // ===== Section H: real vendored CJS packages require cleanly =============
+  eq(typeof require('less').render, 'function', 'H.less.render');             // 38
+  eq(typeof require('sass').compileString, 'function', 'H.sass.compile');     // 39
+  eq(typeof require('terser').minify, 'function', 'H.terser.minify');         // 40
+  eq(typeof require('stylus'), 'function', 'H.stylus.fn');                    // 41
+  eq(require('@babel/core').version, '7.26.0', 'H.babel.version');            // 42
+
+  // ===== Section I: dynamic import() of .mjs from CJS =====================
+  const m = await imp('m.mjs');
+  eq(Object.keys(m).sort().join(','), 'META,NAMED,add,default', 'I.m.keys');  // 43
+  eq(m.NAMED, 'named-val', 'I.m.named');                                      // 44
+  eq(m.add(2, 3), 5, 'I.m.fn');                                               // 45
+  eq(m.default.kind, 'esm-default', 'I.m.default.kind');                      // 46
+  eq(m.default.n, 7, 'I.m.default.n');                                        // 47
+  eq(m.META.startsWith('file:'), true, 'I.m.meta.file');                      // 48
+
+  // ===== Section J: import.meta.url / dirname / filename are file: URLs ====
+  const metaPath = path.join(FIX, 'meta.mjs');
+  const meta = await imp('meta.mjs');
+  eq(meta.url, url.pathToFileURL(metaPath).href, 'J.meta.url.exact');         // 49
+  eq(meta.url.startsWith('file://'), true, 'J.meta.url.scheme');              // 50
+  eq(meta.url.endsWith('/meta.mjs'), true, 'J.meta.url.suffix');              // 51
+  eq(meta.dir, FIX, 'J.meta.dirname');                                        // 52
+  eq(meta.fname, metaPath, 'J.meta.filename');                               // 53
+
+  // ===== Section K: import() of .cjs from ESM (default=module.exports) =====
+  const ci = await imp('c.cjs');
+  // lexer detected ONLY `added` (object literal with values is opaque)
+  eq(Object.keys(ci).sort().join(','), 'added,default', 'K.c.keys');          // 54
+  eq(ci.added, 'late', 'K.c.named.added');                                    // 55
+  eq(ci.foo, undefined, 'K.c.foo.undetected');                               // 56
+  eq(ci.default.foo, 1, 'K.c.default.foo');                                   // 57
+  eq(ci.default.bar, 'two', 'K.c.default.bar');                              // 58
+  eq(ci.default.added, 'late', 'K.c.default.added');                         // 59
+  eq(typeof ci.default.fn, 'function', 'K.c.default.fn');                     // 60
+
+  const c2 = await imp('c2.cjs');
+  eq(Object.keys(c2).sort().join(','), 'alpha,beta,default', 'K.c2.keys');    // 61
+  eq(c2.alpha, 'A', 'K.c2.alpha');                                            // 62
+  eq(c2.beta, 42, 'K.c2.beta');                                               // 63
+  eq(c2.default.alpha, 'A', 'K.c2.default.alpha');                           // 64
+
+  // ===== Section L: exact cjs-module-lexer detection rules =================
+  const l1 = await imp('lex1.cjs');   // shorthand identifiers -> detected
+  eq(Object.keys(l1).sort().join(','), 'a,b,default', 'L.lex1.keys');         // 65
+  eq(l1.a, 1, 'L.lex1.a');                                                    // 66
+  eq(l1.b, 2, 'L.lex1.b');                                                    // 67
+  const l2 = await imp('lex2.cjs');   // values -> NOT detected
+  eq(Object.keys(l2).sort().join(','), 'default', 'L.lex2.keys');             // 68
+  eq(l2.p, undefined, 'L.lex2.p.undetected');                                // 69
+  eq(l2.default.p, 1, 'L.lex2.default.p');                                    // 70
+  const l3 = await imp('lex3.cjs');   // exports.one + defineProperty -> both
+  eq(Object.keys(l3).sort().join(','), 'default,one,two', 'L.lex3.keys');     // 71
+  eq(l3.one, 'I', 'L.lex3.one');                                              // 72
+  eq(l3.two, 'II', 'L.lex3.two');                                             // 73
+
+  // ===== Section M: __esModule interop -- native node does NOT unwrap ======
+  const ei = await imp('esm_interop.cjs');
+  eq(Object.keys(ei).sort().join(','), '__esModule,default,named', 'M.keys'); // 74
+  // `default` binding is the WHOLE module.exports, NOT exports.default:
+  eq(ei.default.default, 'the-default', 'M.default-not-unwrapped');           // 75
+  eq(ei.default.__esModule, true, 'M.default.__esModule');                    // 76
+  eq(ei.named, 'the-named', 'M.named');                                       // 77
+  eq(ei.__esModule, true, 'M.__esModule.named');                             // 78
+
+  // ===== Section N: import() of function module from ESM ==================
+  const fi = await imp('funcmod.cjs');
+  eq(Object.keys(fi).sort().join(','), 'default,extra', 'N.keys');            // 79
+  eq(typeof fi.default, 'function', 'N.default.fn');                          // 80
+  eq(fi.default('amy'), 'hi amy', 'N.default.call');                          // 81
+  eq(fi.extra, 'X', 'N.extra.detected');                                      // 82
+  eq(fi.version, undefined, 'N.version.undetected');                          // 83
+
+  // ===== Section O: data: URL import (default + named) ====================
+  const d1 = await import('data:text/javascript,export default 42');
+  eq(d1.default, 42, 'O.data.default');                                       // 84
+  const d2 = await import('data:text/javascript,export const a=1;export default 99;export function f(){return 5}');
+  eq(d2.a, 1, 'O.data.named.a');                                              // 85
+  eq(d2.default, 99, 'O.data.named.default');                                // 86
+  eq(d2.f(), 5, 'O.data.named.fn');                                           // 87
+
+  // ===== Section P: package.json "type":"module" subdir ===================
+  const sub = await imp('esmpkg/index.js');
+  eq(sub.flavor, 'esm-via-pkgjson', 'P.subdir.named');                        // 88
+  eq(sub.default, 123, 'P.subdir.default');                                   // 89
+
+  // ===== Section Q: "exports" import/require conditions + subpath =========
+  const cond = await imp('condtest.mjs');
+  eq(cond.reqSide, 'require-condition', 'Q.require.condition');               // 90
+  eq(cond.impSide, 'import-condition', 'Q.import.condition');                 // 91
+  eq(cond.impDefault, 'esm-default', 'Q.import.default');                     // 92
+  eq(cond.subVal, 'subpath', 'Q.subpath.export');                            // 93
+
+  // ===== Section R: circular require -> partial exports ===================
+  const A = fixRequire('./circA.cjs');
+  const B = fixRequire('./circB.cjs');
+  eq(A.nameA, 'A', 'R.A.nameA');                                              // 94
+  eq(A.done, true, 'R.A.done');                                               // 95
+  eq(A.fromB_atLoad, 'B', 'R.A.sees.full.B');                                 // 96
+  eq(A.bDoneFlag, true, 'R.A.sees.B.done');                                   // 97
+  eq(B.nameB, 'B', 'R.B.nameB');                                              // 98
+  eq(B.aPartial_nameA, 'A', 'R.B.sees.partial.A.name');                       // 99
+  eq(B.aPartial_done, undefined, 'R.B.sees.A.unfinished');                    // 100
+  eq(B.done, true, 'R.B.done');                                               // 101
+
+  // ===== Section S: createRequire rooted at a fixture path =================
+  const r2 = createRequire(path.join(FIX, 'anchor.cjs'));
+  eq(r2('node:path').sep, '/', 'S.createRequire.builtin');                    // 102
+  eq(r2('./c2.cjs').alpha, 'A', 'S.createRequire.relative');                  // 103
+  // createRequire also accepts a file: URL string
+  const r3 = createRequire(url.pathToFileURL(path.join(FIX, 'anchor.cjs')).href);
+  eq(r3('./data.json').x, 10, 'S.createRequire.fileurl');                     // 104
+
+  // ===== Section T: require(esm) -- synchronous ESM via require (v22) ======
+  const reqEsm = fixRequire('./m.mjs');
+  eq(reqEsm.NAMED, 'named-val', 'T.require-esm.named');                       // 105
+  eq(reqEsm.add(2, 3), 5, 'T.require-esm.fn');                                // 106
+  eq(reqEsm.default.kind, 'esm-default', 'T.require-esm.default');            // 107
+  eq(createRequire(path.join(FIX, 'anchor.cjs'))('./m.mjs').NAMED, 'named-val', 'T.createRequire-esm'); // 108
+}
+
+main()
+  .then(() => {
+    rmrf(FIX); // best-effort cleanup
+    console.log('CJSESM_RESULT ok=' + ok + ' fail=' + fail);
+    if (fail === 0) console.log('CJSESM_DONE');
+    process.exit(fail === 0 ? 0 : 1);
+  })
+  .catch((e) => {
+    fail++;
+    console.log('FAIL exception: ' + (e && e.stack ? e.stack : e));
+    rmrf(FIX);
+    console.log('CJSESM_RESULT ok=' + ok + ' fail=' + fail);
+    process.exit(1);
+  });

--- a/apps/starry/node-lib/programs/carpets/EslintCarpet.js
+++ b/apps/starry/node-lib/programs/carpets/EslintCarpet.js
@@ -1,0 +1,337 @@
+'use strict';
+// INDUSTRIAL carpet for eslint 9.18.0  (Linter + ESLint flat-config, in-process, deterministic)
+// Ground truth = observed behaviour of eslint@9.18.0 on Node.js v22.22.2.
+// No fs writes, no CLI, no network, no clock/random. Pure require('eslint').
+const path = require('path');
+const { Linter, ESLint, SourceCode } = require('eslint');
+
+let ok = 0, fail = 0;
+function chk(cond, name) { if (cond) ok++; else { fail++; console.log('FAIL ' + name); } }
+
+const L = new Linter();
+
+// Convenience: lint and return the message array.
+function lint(code, config) { return L.verify(code, config); }
+// Assert exact diagnostic fields of one message.
+function dia(m, exp, tag) {
+  chk(m !== undefined, tag + '/exists');
+  if (m === undefined) return;
+  if ('ruleId' in exp) chk(m.ruleId === exp.ruleId, tag + '/ruleId(' + m.ruleId + ')');
+  if ('messageId' in exp) chk(m.messageId === exp.messageId, tag + '/messageId(' + m.messageId + ')');
+  if ('severity' in exp) chk(m.severity === exp.severity, tag + '/severity(' + m.severity + ')');
+  if ('line' in exp) chk(m.line === exp.line, tag + '/line(' + m.line + ')');
+  if ('column' in exp) chk(m.column === exp.column, tag + '/column(' + m.column + ')');
+  if ('endLine' in exp) chk(m.endLine === exp.endLine, tag + '/endLine(' + m.endLine + ')');
+  if ('endColumn' in exp) chk(m.endColumn === exp.endColumn, tag + '/endColumn(' + m.endColumn + ')');
+  if ('message' in exp) chk(m.message === exp.message, tag + '/message(' + JSON.stringify(m.message) + ')');
+}
+
+// ---------------------------------------------------------------------------
+// 0. Static version surface
+// ---------------------------------------------------------------------------
+chk(Linter.version === '9.18.0', 'Linter.version');
+chk(ESLint.version === '9.18.0', 'ESLint.version');
+chk(typeof L.verify === 'function', 'Linter.verify is fn');
+chk(typeof L.verifyAndFix === 'function', 'Linter.verifyAndFix is fn');
+
+// ---------------------------------------------------------------------------
+// 1. Core rules — exact ruleId/messageId/severity/position/message
+// ---------------------------------------------------------------------------
+
+// semi (note: missingSemi has no endLine/endColumn)
+{
+  const m = lint('var x = 1', { rules: { semi: 'error' } });
+  chk(m.length === 1, 'semi/count');
+  dia(m[0], { ruleId: 'semi', messageId: 'missingSemi', severity: 2, line: 1, column: 10, message: 'Missing semicolon.' }, 'semi');
+  chk(m[0].endLine === undefined, 'semi/endLine-undef');
+  chk(m[0].endColumn === undefined, 'semi/endColumn-undef');
+  chk(m[0].fix && m[0].fix.text === ';', 'semi/fix-text');
+  chk(m[0].fix.range[0] === 9 && m[0].fix.range[1] === 9, 'semi/fix-range');
+}
+
+// no-var
+dia(lint('var x = 1;', { rules: { 'no-var': 'error' } })[0],
+  { ruleId: 'no-var', messageId: 'unexpectedVar', severity: 2, line: 1, column: 1, endLine: 1, endColumn: 11, message: 'Unexpected var, use let or const instead.' }, 'no-var');
+
+// quotes (default double -> single)
+dia(lint('var x = "hi";', { rules: { quotes: ['error', 'single'] } })[0],
+  { ruleId: 'quotes', messageId: 'wrongQuotes', severity: 2, line: 1, column: 9, endLine: 1, endColumn: 13, message: 'Strings must use singlequote.' }, 'quotes');
+
+// eqeqeq
+dia(lint('if (a == b) {}', { rules: { eqeqeq: 'error' }, languageOptions: { globals: { a: 'readonly', b: 'readonly' } } })[0],
+  { ruleId: 'eqeqeq', messageId: 'unexpected', severity: 2, line: 1, column: 7, endLine: 1, endColumn: 9, message: "Expected '===' and instead saw '=='." }, 'eqeqeq');
+
+// no-unused-vars (two messages: unused function 'f', unused var 'y')
+{
+  const m = lint('function f(){ var y = 2; }', { rules: { 'no-unused-vars': 'warn' } });
+  chk(m.length === 2, 'no-unused-vars/count');
+  dia(m[0], { ruleId: 'no-unused-vars', messageId: 'unusedVar', severity: 1, line: 1, column: 10, endLine: 1, endColumn: 11, message: "'f' is defined but never used." }, 'unused/f');
+  dia(m[1], { ruleId: 'no-unused-vars', messageId: 'unusedVar', severity: 1, line: 1, column: 19, endLine: 1, endColumn: 20, message: "'y' is assigned a value but never used." }, 'unused/y');
+}
+
+// no-undef
+dia(lint('foo();', { rules: { 'no-undef': 'error' } })[0],
+  { ruleId: 'no-undef', messageId: 'undef', severity: 2, line: 1, column: 1, endLine: 1, endColumn: 4, message: "'foo' is not defined." }, 'no-undef');
+
+// prefer-const
+dia(lint('let z = 5; console.log(z);', { rules: { 'prefer-const': 'error' }, languageOptions: { globals: { console: 'readonly' } } })[0],
+  { ruleId: 'prefer-const', messageId: 'useConst', severity: 2, line: 1, column: 5, endLine: 1, endColumn: 6, message: "'z' is never reassigned. Use 'const' instead." }, 'prefer-const');
+
+// no-console (warn)
+dia(lint('console.log(1);', { rules: { 'no-console': 'warn' }, languageOptions: { globals: { console: 'readonly' } } })[0],
+  { ruleId: 'no-console', messageId: 'unexpected', severity: 1, line: 1, column: 1, endLine: 1, endColumn: 12, message: 'Unexpected console statement.' }, 'no-console');
+
+// curly
+dia(lint('if (a) b();', { rules: { curly: 'error' }, languageOptions: { globals: { a: 'readonly', b: 'readonly' } } })[0],
+  { ruleId: 'curly', messageId: 'missingCurlyAfterCondition', severity: 2, line: 1, column: 8, endLine: 1, endColumn: 12, message: "Expected { after 'if' condition." }, 'curly');
+
+// indent (second line should be 2 spaces, is 0)
+dia(lint('function f() {\nreturn 1;\n}', { rules: { indent: ['error', 2] } })[0],
+  { ruleId: 'indent', messageId: 'wrongIndentation', severity: 2, line: 2, column: 1, endLine: 2, endColumn: 1, message: 'Expected indentation of 2 spaces but found 0.' }, 'indent');
+
+// no-multi-spaces
+dia(lint('var x =  1;', { rules: { 'no-multi-spaces': 'error' } })[0],
+  { ruleId: 'no-multi-spaces', messageId: 'multipleSpaces', severity: 2, line: 1, column: 8, endLine: 1, endColumn: 10, message: "Multiple spaces found before '1'." }, 'no-multi-spaces');
+
+// no-dupe-keys
+dia(lint('var o = { a: 1, a: 2 };', { rules: { 'no-dupe-keys': 'error' } })[0],
+  { ruleId: 'no-dupe-keys', messageId: 'unexpected', severity: 2, line: 1, column: 17, endLine: 1, endColumn: 18, message: "Duplicate key 'a'." }, 'no-dupe-keys');
+
+// no-unreachable
+dia(lint('function f(){ return 1; foo(); }', { rules: { 'no-unreachable': 'error' } })[0],
+  { ruleId: 'no-unreachable', messageId: 'unreachableCode', severity: 2, line: 1, column: 25, endLine: 1, endColumn: 31, message: 'Unreachable code.' }, 'no-unreachable');
+
+// no-constant-condition
+dia(lint('if (true) {}', { rules: { 'no-constant-condition': 'error' } })[0],
+  { ruleId: 'no-constant-condition', messageId: 'unexpected', severity: 2, line: 1, column: 5, endLine: 1, endColumn: 9, message: 'Unexpected constant condition.' }, 'no-constant-condition');
+
+// complexity (array option [error, 1] -> reports complexity 3)
+dia(lint('function f(a){ if(a){} else {} if(a){} return a; }', { rules: { complexity: ['error', 1] } })[0],
+  { ruleId: 'complexity', messageId: 'complex', severity: 2, line: 1, column: 1, endLine: 1, endColumn: 51, message: "Function 'f' has a complexity of 3. Maximum allowed is 1." }, 'complexity');
+
+// max-len (array option [error, 20])
+dia(lint('var aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = 1;', { rules: { 'max-len': ['error', 20] } })[0],
+  { ruleId: 'max-len', messageId: 'max', severity: 2, line: 1, column: 1, endLine: 1, endColumn: 51, message: 'This line has a length of 50. Maximum allowed is 20.' }, 'max-len');
+
+// ---------------------------------------------------------------------------
+// 2. Additional core rules (broaden the carpet)
+// ---------------------------------------------------------------------------
+dia(lint('if (x) {}', { rules: { 'no-empty': 'error' }, languageOptions: { globals: { x: 'readonly' } } })[0],
+  { ruleId: 'no-empty', messageId: 'unexpected', severity: 2, line: 1, column: 8, endLine: 1, endColumn: 10, message: 'Empty block statement.' }, 'no-empty');
+
+dia(lint('var x = 1;;', { rules: { 'no-extra-semi': 'error' } })[0],
+  { ruleId: 'no-extra-semi', messageId: 'unexpected', severity: 2, line: 1, column: 11, endLine: 1, endColumn: 12, message: 'Unnecessary semicolon.' }, 'no-extra-semi');
+
+dia(lint('var a=1; var a=2;', { rules: { 'no-redeclare': 'error' } })[0],
+  { ruleId: 'no-redeclare', messageId: 'redeclared', severity: 2, line: 1, column: 14, endLine: 1, endColumn: 15, message: "'a' is already defined." }, 'no-redeclare');
+
+dia(lint('if (x === NaN) {}', { rules: { 'use-isnan': 'error' }, languageOptions: { globals: { x: 'readonly', NaN: 'readonly' } } })[0],
+  { ruleId: 'use-isnan', messageId: 'comparisonWithNaN', severity: 2, line: 1, column: 5, endLine: 1, endColumn: 14, message: 'Use the isNaN function to compare with NaN.' }, 'use-isnan');
+
+dia(lint('if (typeof x === "strnig") {}', { rules: { 'valid-typeof': 'error' }, languageOptions: { globals: { x: 'readonly' } } })[0],
+  { ruleId: 'valid-typeof', messageId: 'invalidValue', severity: 2, line: 1, column: 18, endLine: 1, endColumn: 26, message: 'Invalid typeof comparison value.' }, 'valid-typeof');
+
+dia(lint('if (x = 1) {}', { rules: { 'no-cond-assign': 'error' }, languageOptions: { globals: { x: 'writable' } } })[0],
+  { ruleId: 'no-cond-assign', messageId: 'missing', severity: 2, line: 1, column: 5, endLine: 1, endColumn: 10, message: 'Expected a conditional expression and instead saw an assignment.' }, 'no-cond-assign');
+
+dia(lint('var o = {}; o["a"];', { rules: { 'dot-notation': 'error' } })[0],
+  { ruleId: 'dot-notation', messageId: 'useDot', severity: 2, line: 1, column: 15, endLine: 1, endColumn: 18, message: '["a"] is better written in dot notation.' }, 'dot-notation');
+
+dia(lint('function f(a, a) {}', { rules: { 'no-dupe-args': 'error' }, languageOptions: { sourceType: 'script' } })[0],
+  { ruleId: 'no-dupe-args', messageId: 'unexpected', severity: 2, line: 1, column: 1, endLine: 1, endColumn: 20, message: "Duplicate param 'a'." }, 'no-dupe-args');
+
+dia(lint('function f(){} f = 1;', { rules: { 'no-func-assign': 'error' } })[0],
+  { ruleId: 'no-func-assign', messageId: 'isAFunction', severity: 2, line: 1, column: 16, endLine: 1, endColumn: 17, message: "'f' is a function." }, 'no-func-assign');
+
+dia(lint('debugger;', { rules: { 'no-debugger': 'error' } })[0],
+  { ruleId: 'no-debugger', messageId: 'unexpected', severity: 2, line: 1, column: 1, endLine: 1, endColumn: 10, message: "Unexpected 'debugger' statement." }, 'no-debugger');
+
+dia(lint('[].map(function(x){return x;});', { rules: { 'prefer-arrow-callback': 'error' } })[0],
+  { ruleId: 'prefer-arrow-callback', messageId: 'preferArrowCallback', severity: 2, line: 1, column: 8, endLine: 1, endColumn: 30, message: 'Unexpected function expression.' }, 'prefer-arrow-callback');
+
+// ---------------------------------------------------------------------------
+// 3. languageOptions: ecmaVersion / sourceType / globals
+// ---------------------------------------------------------------------------
+// module: import OK -> zero messages
+chk(lint('import x from "y"; x();', { languageOptions: { ecmaVersion: 2022, sourceType: 'module' }, rules: {} }).length === 0, 'module-import-clean');
+
+// script: import is a fatal parse error
+{
+  const m = lint('import x from "y";', { languageOptions: { ecmaVersion: 2022, sourceType: 'script' }, rules: {} });
+  chk(m.length === 1, 'script-import/count');
+  chk(m[0].ruleId === null, 'script-import/ruleId-null');
+  chk(m[0].fatal === true, 'script-import/fatal');
+  chk(m[0].severity === 2, 'script-import/severity');
+  chk(m[0].line === 1 && m[0].column === 1, 'script-import/pos');
+  chk(m[0].message === "Parsing error: 'import' and 'export' may appear only with 'sourceType: module'", 'script-import/message');
+}
+
+// ecmaVersion 2022: private class fields parse cleanly
+chk(lint('class A { #x = 1; m(){ return this.#x; } }', { languageOptions: { ecmaVersion: 2022, sourceType: 'script' }, rules: {} }).length === 0, 'ecma2022-private-clean');
+
+// globals: declared readonly global is not flagged by no-undef
+chk(lint('myGlobal();', { languageOptions: { globals: { myGlobal: 'readonly' } }, rules: { 'no-undef': 'error' } }).length === 0, 'globals-readonly-clean');
+
+// numeric severities 2 (error) and 1 (warn) coexist; sorted by position
+{
+  const m = lint('var x=1', { rules: { semi: 2, 'no-unused-vars': 1 } });
+  chk(m.length === 2, 'numeric-sev/count');
+  chk(m[0].ruleId === 'no-unused-vars' && m[0].severity === 1, 'numeric-sev/warn-first');
+  chk(m[1].ruleId === 'semi' && m[1].severity === 2, 'numeric-sev/error-second');
+}
+
+// ---------------------------------------------------------------------------
+// 4. Rule options: [severity, primitive] and [severity, {object}]
+// ---------------------------------------------------------------------------
+dia(lint('var x = 1;', { rules: { semi: ['error', 'never'] } })[0],
+  { ruleId: 'semi', messageId: 'extraSemi', severity: 2, line: 1, column: 10, message: 'Extra semicolon.' }, 'semi-never');
+
+dia(lint('var x = "hi";', { rules: { quotes: ['error', 'backtick'] } })[0],
+  { ruleId: 'quotes', messageId: 'wrongQuotes', severity: 2, message: 'Strings must use backtick.' }, 'quotes-backtick');
+
+// no-unused-vars with {args:'none'} -> only the function is reported (1)
+chk(lint('function f(a){ return 1; }', { rules: { 'no-unused-vars': ['warn', { args: 'none' }] } }).length === 1, 'unused/args-none-count');
+// with {args:'all'} -> function + unused arg (2)
+{
+  const m = lint('function f(a){ return 1; }', { rules: { 'no-unused-vars': ['warn', { args: 'all' }] } });
+  chk(m.length === 2, 'unused/args-all-count');
+  chk(m[1].column === 12 && m[1].message === "'a' is defined but never used.", 'unused/args-all-arg');
+}
+
+// complexity object {max:1}
+chk(lint('function f(a){ if(a){} if(a){} return a; }', { rules: { complexity: ['error', { max: 1 }] } })[0].message ===
+  "Function 'f' has a complexity of 3. Maximum allowed is 1.", 'complexity-obj');
+
+// max-len object {code:10}
+chk(lint('var x = 1; // aaaaaaaaaaaaaaaaaaaaaaa', { rules: { 'max-len': ['error', { code: 10 }] } })[0].message ===
+  'This line has a length of 37. Maximum allowed is 10.', 'max-len-obj');
+
+// ---------------------------------------------------------------------------
+// 5. verifyAndFix — exact fixed output (single + multi-pass)
+// ---------------------------------------------------------------------------
+{
+  const r = L.verifyAndFix('var x = 1', { rules: { semi: 'error' } });
+  chk(r.fixed === true, 'fix-semi/fixed');
+  chk(r.output === 'var x = 1;', 'fix-semi/output');
+  chk(r.messages.length === 0, 'fix-semi/no-msg');
+}
+chk(L.verifyAndFix('var x = "hi";', { rules: { quotes: ['error', 'single'] } }).output === "var x = 'hi';", 'fix-quotes/output');
+chk(L.verifyAndFix('var x = 1;', { rules: { 'no-var': 'error' } }).output === 'let x = 1;', 'fix-novar/output');
+// multi-pass: both no-var and semi applied
+{
+  const r = L.verifyAndFix('var x = 1', { rules: { semi: 'error', 'no-var': 'error' } });
+  chk(r.fixed === true && r.output === 'let x = 1;', 'fix-multipass/output');
+}
+
+// ---------------------------------------------------------------------------
+// 6. Custom inline rule via config.plugins
+// ---------------------------------------------------------------------------
+{
+  const cfg = {
+    plugins: {
+      my: {
+        rules: {
+          'no-foo': {
+            create(ctx) {
+              return { Identifier(node) { if (node.name === 'foo') ctx.report({ node, message: 'no foo allowed' }); } };
+            }
+          }
+        }
+      }
+    },
+    rules: { 'my/no-foo': 'error' }
+  };
+  const m = lint('var foo = 1;', cfg);
+  chk(m.length === 1, 'custom/count');
+  dia(m[0], { ruleId: 'my/no-foo', severity: 2, line: 1, column: 5, message: 'no foo allowed' }, 'custom');
+  // and does not fire when identifier absent
+  chk(lint('var bar = 1;', cfg).length === 0, 'custom/no-fire');
+}
+
+// ---------------------------------------------------------------------------
+// 7. Message ordering / sort stability across multiple rules & lines
+// ---------------------------------------------------------------------------
+{
+  const code = 'var x = "a";\nvar y = "b"';
+  const m = lint(code, { rules: { quotes: ['error', 'single'], semi: 'error', 'no-unused-vars': 'warn', 'no-var': 'error' } });
+  chk(m.length === 7, 'sort/count');
+  let sorted = true;
+  for (let i = 1; i < m.length; i++) {
+    if (m[i].line < m[i - 1].line || (m[i].line === m[i - 1].line && m[i].column < m[i - 1].column)) sorted = false;
+  }
+  chk(sorted === true, 'sort/by-line-col');
+  chk(m[0].ruleId === 'no-var' && m[0].line === 1 && m[0].column === 1, 'sort/first');
+  chk(m[m.length - 1].ruleId === 'semi' && m[m.length - 1].line === 2, 'sort/last');
+}
+
+// clean code -> zero messages
+chk(lint('const x = 1;\nexport default x;', { languageOptions: { sourceType: 'module' }, rules: { semi: 'error', quotes: 'error', 'no-unused-vars': 'error' } }).length === 0, 'clean/zero');
+
+// ---------------------------------------------------------------------------
+// 8. Inline disable directives + getSuppressedMessages
+// ---------------------------------------------------------------------------
+{
+  const active = lint('var x = 1 // eslint-disable-line semi', { rules: { semi: 'error' } });
+  chk(active.length === 0, 'disable-line/active-zero');
+  const sup = L.getSuppressedMessages();
+  chk(sup.length === 1, 'disable-line/suppressed-count');
+  chk(sup[0].ruleId === 'semi', 'disable-line/suppressed-ruleId');
+  chk(sup[0].suppressions[0].kind === 'directive', 'disable-line/suppression-kind');
+}
+
+// ---------------------------------------------------------------------------
+// 9. SourceCode access after verify
+// ---------------------------------------------------------------------------
+{
+  L.verify('const a = 1;', { rules: {} });
+  const sc = L.getSourceCode();
+  chk(sc instanceof SourceCode, 'sourcecode/instanceof');
+  chk(sc.getText() === 'const a = 1;', 'sourcecode/text');
+  chk(sc.ast && sc.ast.type === 'Program', 'sourcecode/ast-program');
+  chk(sc.ast.body.length === 1, 'sourcecode/ast-body');
+}
+
+// ---------------------------------------------------------------------------
+// 10. ESLint class — overrideConfig + lintText (in-memory, no fs), fix, filePath
+// ---------------------------------------------------------------------------
+(async () => {
+  try {
+    const eslint = new ESLint({ overrideConfigFile: true, overrideConfig: { rules: { semi: 'error', 'no-var': 'error' } } });
+    const results = await eslint.lintText('var x = 1');
+    chk(Array.isArray(results) && results.length === 1, 'eslint/result-array');
+    const r = results[0];
+    chk(r.filePath === '<text>', 'eslint/filePath-text');
+    chk(r.errorCount === 2, 'eslint/errorCount');
+    chk(r.warningCount === 0, 'eslint/warningCount');
+    chk(r.fixableErrorCount === 2, 'eslint/fixableErrorCount');
+    chk(r.messages.length === 2, 'eslint/messages-count');
+    chk(r.messages[0].ruleId === 'no-var' && r.messages[0].messageId === 'unexpectedVar', 'eslint/msg0');
+    chk(r.messages[1].ruleId === 'semi' && r.messages[1].messageId === 'missingSemi', 'eslint/msg1');
+
+    // clean text -> no errors (let, with semicolon -> neither rule fires)
+    const clean = await eslint.lintText('let x = 1;');
+    chk(clean[0].errorCount === 0 && clean[0].messages.length === 0, 'eslint/clean');
+
+    // fix:true -> exact fixed output
+    const eslintFix = new ESLint({ overrideConfigFile: true, fix: true, overrideConfig: { rules: { semi: 'error', 'no-var': 'error' } } });
+    const fixed = await eslintFix.lintText('var x = 1');
+    chk(fixed[0].output === 'let x = 1;', 'eslint/fix-output');
+
+    // filePath option resolves against cwd (portable: derive expected from process.cwd())
+    const wp = await eslint.lintText('var x = 1', { filePath: 'foo.js' });
+    chk(wp[0].filePath === path.resolve(process.cwd(), 'foo.js'), 'eslint/filePath-resolved');
+    chk(wp[0].errorCount === 2, 'eslint/filePath-errorCount');
+
+    // ESLint.outputFixes is a static function (no fs side effect when output absent)
+    chk(typeof ESLint.outputFixes === 'function', 'eslint/outputFixes-fn');
+    chk(typeof eslint.calculateConfigForFile === 'function', 'eslint/calcConfig-fn');
+  } catch (e) {
+    fail++;
+    console.log('FAIL eslint-class/exception ' + (e && e.message));
+  }
+
+  // ----- final tally -----
+  console.log('ESLINT_RESULT ok=' + ok + ' fail=' + fail);
+  if (fail === 0) console.log('ESLINT_DONE');
+  process.exit(fail === 0 ? 0 : 1);
+})();

--- a/apps/starry/node-lib/programs/carpets/LessCarpet.js
+++ b/apps/starry/node-lib/programs/carpets/LessCarpet.js
@@ -1,0 +1,397 @@
+'use strict';
+/*
+ * INDUSTRIAL carpet for less 4.2.2 (Node.js target v22.22.2).
+ * Every assertion is an exact-value check: the EXACT expected compiled CSS
+ * (or exact number/string/error field) is computed inline and compared with ===.
+ * Golden values were observed by running this exact less@4.2.2 on node v22.22.2.
+ *
+ * Portability: every path is derived from __dirname; no hardcoded host paths,
+ * no node binary path, no network, no Date.now/Math.random/wall-clock.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const less = require('less');
+
+let ok = 0, fail = 0;
+function chk(cond, name) { if (cond) ok++; else { fail++; console.log('FAIL ' + name); } }
+
+// exact-string CSS equality assertion
+function eq(name, actual, expected) {
+  if (actual === expected) { ok++; }
+  else {
+    fail++;
+    console.log('FAIL ' + name);
+    console.log('  expected: ' + JSON.stringify(expected));
+    console.log('  actual:   ' + JSON.stringify(actual));
+  }
+}
+
+// Promise-form render -> resolves to css string
+function css(str, opts) {
+  return less.render(str, opts || {}).then(function (o) { return o.css; });
+}
+
+// Scratch dir derived from __dirname (NOT a hardcoded host path).
+const TMP = path.join(__dirname, 'tmp-lesscarpet');
+
+async function main() {
+  fs.mkdirSync(TMP, { recursive: true });
+  fs.writeFileSync(path.join(TMP, 'lib.less'), '@brand: #ff0000;\n.helper() { padding: 7px; }\n');
+  fs.writeFileSync(path.join(TMP, 'raw.css'), 'body { color: green; }');
+
+  // ---------------------------------------------------------------------------
+  // API surface
+  // ---------------------------------------------------------------------------
+  chk(typeof less.render === 'function', 'api/render-is-function');
+  chk(Array.isArray(less.version) && less.version[0] === 4 && less.version[1] === 2 && less.version[2] === 2, 'api/version-4.2.2');
+  chk(typeof less.FileManager === 'function', 'api/FileManager');
+  chk(typeof less.PluginLoader === 'function', 'api/PluginLoader');
+  chk(typeof less.tree === 'object' && typeof less.tree.Dimension === 'function', 'api/tree.Dimension');
+  chk(typeof less.visitors === 'object' && typeof less.visitors.Visitor === 'function', 'api/visitors.Visitor');
+  chk(typeof less.functions === 'object', 'api/functions-registry');
+
+  // render() returns an object with css/imports
+  {
+    const o = await less.render('@a: 5px; .x { width: @a + 1; }');
+    eq('render/basic-arith-css', o.css, '.x {\n  width: 6px;\n}\n');
+    chk(Array.isArray(o.imports) && o.imports.length === 0, 'render/imports-empty-array');
+  }
+
+  // Callback form (3-arg). Wrap in a promise so we can await it.
+  {
+    const cbCss = await new Promise(function (resolve, reject) {
+      less.render('@a: 3px; .cb { margin: @a * 2; }', {}, function (err, out) {
+        if (err) reject(err); else resolve(out.css);
+      });
+    });
+    eq('render/callback-form', cbCss, '.cb {\n  margin: 6px;\n}\n');
+  }
+
+  // Explicit Promise (.then) form
+  {
+    const thenCss = await less.render('.p { x: 1; }').then(function (o) { return o.css; });
+    eq('render/promise-then-form', thenCss, '.p {\n  x: 1;\n}\n');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Variables & interpolation
+  // ---------------------------------------------------------------------------
+  eq('var/selector-interp', await css('@name: foo; .@{name}-bar { color: red; }'),
+    '.foo-bar {\n  color: red;\n}\n');
+  eq('var/string-interp', await css('@base: 960; .x { content: "@{base}px"; }'),
+    '.x {\n  content: "960px";\n}\n');
+  eq('var/property-name-interp', await css('@my: banner; .@{my} { color: red; }'),
+    '.banner {\n  color: red;\n}\n');
+  eq('var/variable-variable', await css('@who: name; @name: red; .a { color: @@who; }'),
+    '.a {\n  color: red;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Arithmetic & operations
+  // ---------------------------------------------------------------------------
+  eq('arith/basic', await css('.x { width: 2px + 3px; height: 10px - 4px; margin: 4px*2; padding: 12px/4; }'),
+    '.x {\n  width: 5px;\n  height: 6px;\n  margin: 8px;\n  padding: 12px/4;\n}\n');
+  eq('arith/parens-mult', await css('.x { width: (1 + 1) * 2; }'),
+    '.x {\n  width: 4;\n}\n');
+  eq('arith/negative-var', await css('@a: 5px; .x { margin: -@a; }'),
+    '.x {\n  margin: -5px;\n}\n');
+  eq('arith/color-plus', await css('.x { color: #010203 + #040506; }'),
+    '.x {\n  color: #050709;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Math modes
+  // ---------------------------------------------------------------------------
+  eq('math/always', await css('.x { width: (2 + 3) * 4px; padding: 12px/4; }', { math: 'always' }),
+    '.x {\n  width: 20px;\n  padding: 3px;\n}\n');
+  eq('math/parens-division', await css('.x { width: (12px/4); height: 12px/4; }', { math: 'parens-division' }),
+    '.x {\n  width: 3px;\n  height: 12px/4;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Nesting & parent selector
+  // ---------------------------------------------------------------------------
+  eq('nest/amp', await css('.a { color: red; &:hover { color: blue; } .b & { color: green; } }'),
+    '.a {\n  color: red;\n}\n.a:hover {\n  color: blue;\n}\n.b .a {\n  color: green;\n}\n');
+  eq('nest/property-accessor', await css('.a { color: red; .b { background: $color; } }'),
+    '.a {\n  color: red;\n}\n.a .b {\n  background: red;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Mixins
+  // ---------------------------------------------------------------------------
+  eq('mixin/basic', await css('.mx() { color: red; } .a { .mx(); }'),
+    '.a {\n  color: red;\n}\n');
+  eq('mixin/param', await css('.mx(@c) { color: @c; } .a { .mx(blue); }'),
+    '.a {\n  color: blue;\n}\n');
+  eq('mixin/default-value', await css('.mx(@c: green) { color: @c; } .a { .mx(); }'),
+    '.a {\n  color: green;\n}\n');
+  eq('mixin/guard-iscolor', await css('.mx(@c) when (iscolor(@c)) { color: @c; } .a { .mx(red); }'),
+    '.a {\n  color: red;\n}\n');
+  eq('mixin/arguments', await css('.mx(...) { margin: @arguments; } .a { .mx(1px, 2px, 3px); }'),
+    '.a {\n  margin: 1px 2px 3px;\n}\n');
+  eq('mixin/returns-variables', await css('.m() { @w: 10px; } .a { .m(); width: @w; }'),
+    '.a {\n  width: 10px;\n}\n');
+  eq('mixin/important', await css('.mx() { color: red; } .a { .mx() !important; }'),
+    '.a {\n  color: red !important;\n}\n');
+  eq('mixin/namespace', await css('#ns { .mx(@c) { color: @c; } } .a { #ns.mx(red); }'),
+    '.a {\n  color: red;\n}\n');
+  eq('mixin/namespace-guarded', await css('#ns() { .mx() { color: blue; } } .a { #ns.mx(); }'),
+    '.a {\n  color: blue;\n}\n');
+  eq('mixin/recursive-loop', await css('.loop(@i) when (@i > 0) { .item-@{i} { width: (@i * 10px); } .loop(@i - 1); } .loop(3);'),
+    '.item-3 {\n  width: 30px;\n}\n.item-2 {\n  width: 20px;\n}\n.item-1 {\n  width: 10px;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Guards (conditional mixins)
+  // ---------------------------------------------------------------------------
+  eq('guard/default-fn', await css('.m(@a) when (@a > 0) { x: pos; } .m(@a) when (default()) { x: nonpos; } .y { .m(5); } .z { .m(-1); }'),
+    '.y {\n  x: pos;\n}\n.z {\n  x: nonpos;\n}\n');
+  eq('guard/and', await css('.m(@a) when (@a > 0) and (@a < 10) { x: mid; } .y { .m(5); }'),
+    '.y {\n  x: mid;\n}\n');
+  eq('guard/or-comma', await css('.m(@a) when (@a = 1), (@a = 2) { x: ok; } .y { .m(2); }'),
+    '.y {\n  x: ok;\n}\n');
+  eq('guard/not', await css('.m(@a) when not (@a = 0) { x: nz; } .y { .m(3); }'),
+    '.y {\n  x: nz;\n}\n');
+  eq('guard/default-vs-specific', await css('.m(@x) when (default()) { d: 1; } .m(1) { s: 1; } .a { .m(1); } .b { .m(2); }'),
+    '.a {\n  s: 1;\n}\n.b {\n  d: 1;\n}\n');
+  eq('guard/isnumber', await css('.m(@v) when (isnumber(@v)) { ok: yes; } .x { .m(42); }'),
+    '.x {\n  ok: yes;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // extend (&:extend / :extend)
+  // ---------------------------------------------------------------------------
+  eq('extend/selector', await css('.a { color: red; } .b:extend(.a) {}'),
+    '.a,\n.b {\n  color: red;\n}\n');
+  eq('extend/inline', await css('.a { color: red; } .b { &:extend(.a); }'),
+    '.a,\n.b {\n  color: red;\n}\n');
+  eq('extend/all', await css('.a .x { color: red; } .b:extend(.x all) {}'),
+    '.a .x,\n.a .b {\n  color: red;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Detached rulesets, merge, maps
+  // ---------------------------------------------------------------------------
+  eq('detached/ruleset', await css('@dr: { color: red; }; .a { @dr(); }'),
+    '.a {\n  color: red;\n}\n');
+  eq('merge/comma', await css('.a { box-shadow+: inset 0 0 10px #555; box-shadow+: 0 0 20px black; }'),
+    '.a {\n  box-shadow: inset 0 0 10px #555, 0 0 20px black;\n}\n');
+  eq('merge/space', await css('.a { transform+_: scale(2); transform+_: rotate(15deg); }'),
+    '.a {\n  transform: scale(2) rotate(15deg);\n}\n');
+  eq('map/namespace-value', await css('@sizes: { small: 10px; large: 20px; }; .x { width: @sizes[small]; }'),
+    '.x {\n  width: 10px;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // @media bubbling & nesting
+  // ---------------------------------------------------------------------------
+  eq('media/bubble', await css('.a { color: red; @media screen { color: blue; } }'),
+    '.a {\n  color: red;\n}\n@media screen {\n  .a {\n    color: blue;\n  }\n}\n');
+  eq('media/nested-merge', await css('@media screen { .a { @media (min-width: 768px) { color: red; } } }'),
+    '@media screen and (min-width: 768px) {\n  .a {\n    color: red;\n  }\n}\n');
+  eq('media/escaped-query-var', await css('@r: ~"(min-width: 768px)"; @media @r { .a { x: 1; } }'),
+    '@media (min-width: 768px) {\n  .a {\n    x: 1;\n  }\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // each()
+  // ---------------------------------------------------------------------------
+  eq('each/value', await css('@list: apple, pear; each(@list, { .sel-@{value} { x: @value; } });'),
+    '.sel-apple {\n  x: apple;\n}\n.sel-pear {\n  x: pear;\n}\n');
+  eq('each/index', await css('each(a b c, { .i-@{index} { v: @value; } });'),
+    '.i-1 {\n  v: a;\n}\n.i-2 {\n  v: b;\n}\n.i-3 {\n  v: c;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Comments & compression
+  // ---------------------------------------------------------------------------
+  eq('comments/block-kept-line-stripped', await css('/* keep */ .a { color: red; // line comment\n }'),
+    '/* keep */\n.a {\n  color: red;\n}\n');
+  eq('compress/basic', await css('.a { color: red;  margin: 0 0 0 0; }', { compress: true }),
+    '.a{color:red;margin:0 0 0 0}');
+  eq('compress/media', await css('.a { @media screen { color: red; } }', { compress: true }),
+    '@media screen{.a{color:red}}');
+
+  // ---------------------------------------------------------------------------
+  // Escaping & string functions
+  // ---------------------------------------------------------------------------
+  eq('escape/tilde-calc', await css('.x { width: ~"calc(100% - 30px)"; }'),
+    '.x {\n  width: calc(100% - 30px);\n}\n');
+  eq('escape/e-quoted', await css('.x { font: ~"DejaVu Sans"; }'),
+    '.x {\n  font: DejaVu Sans;\n}\n');
+  eq('fn/e', await css('.x { content: e("hi"); }'),
+    '.x {\n  content: hi;\n}\n');
+  eq('fn/replace', await css('.x { content: replace("hello", "l", "L"); }'),
+    '.x {\n  content: "heLlo";\n}\n');
+  eq('fn/format-percent', await css('.x { content: %("rgb(%d, %d, %d)", 1, 2, 3); }'),
+    '.x {\n  content: "rgb(1, 2, 3)";\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Numeric / math built-in functions
+  // ---------------------------------------------------------------------------
+  eq('fn/percentage', await css('.x { width: percentage(0.5); }'),
+    '.x {\n  width: 50%;\n}\n');
+  eq('fn/round', await css('.x { a: round(1.67); b: round(1.67, 1); }'),
+    '.x {\n  a: 2;\n  b: 1.7;\n}\n');
+  eq('fn/round-2dp', await css('.x { width: round(3.14159, 2); }'),
+    '.x {\n  width: 3.14;\n}\n');
+  eq('fn/ceil-floor', await css('.x { a: ceil(2.1); b: floor(2.9); }'),
+    '.x {\n  a: 3;\n  b: 2;\n}\n');
+  eq('fn/unit', await css('.x { a: unit(5, px); b: unit(5px); }'),
+    '.x {\n  a: 5px;\n  b: 5;\n}\n');
+  eq('fn/unit-replace', await css('.x { width: unit(100px, em); }'),
+    '.x {\n  width: 100em;\n}\n');
+  eq('fn/math-suite', await css('.x { a: sqrt(25); b: abs(-7); c: pow(3, 2); d: mod(8px, 3); e: min(3,1,2); f: max(3,1,2); }'),
+    '.x {\n  a: 5;\n  b: 7;\n  c: 9;\n  d: 2px;\n  e: 1;\n  f: 3;\n}\n');
+  eq('fn/pi', await css('.x { a: ceil(pi()); }'),
+    '.x {\n  a: 4;\n}\n');
+  eq('fn/convert', await css('.x { a: convert(9s, ms); b: convert(14cm, mm); }'),
+    '.x {\n  a: 9000ms;\n  b: 140mm;\n}\n');
+  eq('fn/range', await css('.a { content: range(3); }'),
+    '.a {\n  content: 1 2 3;\n}\n');
+  eq('fn/length', await css('.x { a: length(1 2 3 4); }'),
+    '.x {\n  a: 4;\n}\n');
+  eq('fn/length-extract', await css('@list: a b c; .x { len: length(@list); item: extract(@list, 2); }'),
+    '.x {\n  len: 3;\n  item: b;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // Color functions
+  // ---------------------------------------------------------------------------
+  eq('color/lighten-darken', await css('.x { a: lighten(#888, 10%); b: darken(#888, 10%); }'),
+    '.x {\n  a: #a2a2a2;\n  b: #6f6f6f;\n}\n');
+  eq('color/mix', await css('.x { color: mix(#ff0000, #0000ff, 50%); }'),
+    '.x {\n  color: #800080;\n}\n');
+  eq('color/saturate-desaturate', await css('.x { a: saturate(#80b380, 20%); b: desaturate(#80b380, 20%); }'),
+    '.x {\n  a: #6cc76c;\n  b: #949f94;\n}\n');
+  eq('color/greyscale', await css('.x { color: greyscale(#80b380); }'),
+    '.x {\n  color: #9a9a9a;\n}\n');
+  eq('color/contrast', await css('.x { color: contrast(#000); bg: contrast(#fff); }'),
+    '.x {\n  color: #ffffff;\n  bg: #000000;\n}\n');
+  eq('color/fadein-fadeout', await css('.x { a: fadein(rgba(0,0,0,0.5), 10%); b: fadeout(rgba(0,0,0,0.5), 10%); }'),
+    '.x {\n  a: rgba(0, 0, 0, 0.6);\n  b: rgba(0, 0, 0, 0.4);\n}\n');
+  eq('color/spin-fade', await css('.x { a: spin(hsl(10,50%,50%), 30); b: fade(#000, 50%); }'),
+    '.x {\n  a: hsl(40, 50%, 50%);\n  b: rgba(0, 0, 0, 0.5);\n}\n');
+  eq('color/tint-shade', await css('.x { a: tint(#007fff, 50%); b: shade(#007fff, 50%); }'),
+    '.x {\n  a: #80bfff;\n  b: #004080;\n}\n');
+  eq('color/constructors', await css('.x { a: rgb(255,0,0); b: rgba(0,0,0,0.5); c: hsl(90, 100%, 50%); d: hsla(90,90%,50%,0.5); }'),
+    '.x {\n  a: #ff0000;\n  b: rgba(0, 0, 0, 0.5);\n  c: hsl(90, 100%, 50%);\n  d: hsla(90, 90%, 50%, 0.5);\n}\n');
+  eq('color/argb', await css('.x { color: argb(rgba(90,23,148,0.5)); }'),
+    '.x {\n  color: #805a1794;\n}\n');
+  eq('color/hsv', await css('.x { color: hsv(90, 100%, 50%); }'),
+    '.x {\n  color: #408000;\n}\n');
+  eq('color/parse-color-fn', await css('.x { color: color("#fdff01"); }'),
+    '.x {\n  color: #fdff01;\n}\n');
+  eq('color/components', await css('.x { a: red(#ff8000); b: green(#ff8000); c: blue(#ff8000); d: alpha(rgba(0,0,0,0.3)); e: hue(hsl(98, 12%, 95%)); f: saturation(hsl(98,12%,95%)); g: lightness(hsl(98,12%,95%)); }'),
+    '.x {\n  a: 255;\n  b: 128;\n  c: 0;\n  d: 0.3;\n  e: 98;\n  f: 12%;\n  g: 95%;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // strictUnits
+  // ---------------------------------------------------------------------------
+  eq('strictUnits/off-mixes', await css('.x { width: 2px + 3; }'),
+    '.x {\n  width: 5px;\n}\n');
+  eq('strictUnits/on-converts-length', await css('.x { width: 2px + 3cm; }', { strictUnits: true }),
+    '.x {\n  width: 115.38582677px;\n}\n');
+
+  // ---------------------------------------------------------------------------
+  // @import via paths (write helper .less under __dirname-derived TMP)
+  // ---------------------------------------------------------------------------
+  {
+    const o = await less.render('@import "lib"; .x { color: @brand; .helper(); }', { paths: [TMP] });
+    eq('import/paths-css', o.css, '.x {\n  color: #ff0000;\n  padding: 7px;\n}\n');
+    chk(o.imports.length === 1, 'import/imports-count');
+    chk(path.isAbsolute(o.imports[0]) && o.imports[0].endsWith('lib.less'), 'import/imports-path-endswith');
+  }
+  eq('import/reference', await css('@import (reference) "lib"; .x { color: @brand; }', { paths: [TMP] }),
+    '.x {\n  color: #ff0000;\n}\n');
+  eq('import/inline', await css('@import (inline) "raw.css"; .x { color: red; }', { paths: [TMP] }),
+    'body { color: green; }\n.x {\n  color: red;\n}\n');
+  eq('import/optional-missing', await css('@import (optional) "nope.less"; .x { color: red; }', { paths: [TMP] }),
+    '.x {\n  color: red;\n}\n');
+  eq('import/css-passthrough', await css('@import "raw.css"; @import "raw.css";', { paths: [TMP] }),
+    '@import "raw.css";\n@import "raw.css";\n');
+
+  // ---------------------------------------------------------------------------
+  // Plugins
+  // ---------------------------------------------------------------------------
+  // (1) function-adding plugin
+  {
+    const plugin = {
+      install: function (lessLocal, pluginManager, functions) {
+        functions.add('triple', function (v) {
+          return new lessLocal.tree.Dimension(v.value * 3, v.unit);
+        });
+      }
+    };
+    eq('plugin/function-add', await css('.x { width: triple(4px); }', { plugins: [plugin] }),
+      '.x {\n  width: 12px;\n}\n');
+  }
+  // (2) visitor plugin: rename declaration 'foo' -> 'bar'
+  {
+    const Visitor = less.visitors.Visitor;
+    function MyVisitor() { this._visitor = new Visitor(this); }
+    MyVisitor.prototype = {
+      isReplacing: false,
+      run: function (root) { return this._visitor.visit(root); },
+      visitDeclaration: function (node) { if (node.name === 'foo') { node.name = 'bar'; } return node; }
+    };
+    const plugin = { install: function (l, pm) { pm.addVisitor(new MyVisitor()); } };
+    eq('plugin/visitor-rename', await css('.x { foo: 10px; baz: 1; }', { plugins: [plugin] }),
+      '.x {\n  bar: 10px;\n  baz: 1;\n}\n');
+  }
+  // (3) custom FileManager serving a virtual @import target
+  {
+    function VirtualPlugin(lessLocal) {
+      const FM = function () {};
+      FM.prototype = new lessLocal.FileManager();
+      FM.prototype.supports = function (filename) { return filename.indexOf('virtual:') === 0; };
+      FM.prototype.supportsSync = function () { return false; };
+      FM.prototype.loadFile = function (filename) {
+        const m = { 'virtual:colors': '@primary: #123456; .pmix() { border: 1px solid @primary; }' };
+        return Promise.resolve({ contents: m[filename] || '', filename: filename });
+      };
+      return { install: function (l, pm) { pm.addFileManager(new FM()); } };
+    }
+    eq('plugin/file-manager-virtual',
+      await css('@import "virtual:colors"; .x { color: @primary; .pmix(); }', { plugins: [VirtualPlugin(less)] }),
+      '.x {\n  color: #123456;\n  border: 1px solid #123456;\n}\n');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error paths (LessError with line info)
+  // ---------------------------------------------------------------------------
+  // Parse error
+  {
+    let caught = null;
+    try { await less.render('.a { color: red'); } catch (e) { caught = e; }
+    chk(caught !== null, 'error/parse-thrown');
+    chk(caught && caught.constructor && caught.constructor.name === 'LessError', 'error/parse-is-LessError');
+    chk(caught instanceof Error, 'error/parse-instanceof-Error');
+    chk(caught && caught.type === 'Parse', 'error/parse-type');
+    chk(caught && caught.line === 1, 'error/parse-line');
+    chk(caught && caught.column === 15, 'error/parse-column');
+    chk(caught && caught.message === 'Unrecognised input. Possibly missing something', 'error/parse-message');
+    chk(caught && caught.toString().indexOf('ParseError:') === 0, 'error/parse-toString-prefix');
+  }
+  // Name error (undefined variable)
+  {
+    let caught = null;
+    try { await less.render('.x { color: @nope; }'); } catch (e) { caught = e; }
+    chk(caught && caught.type === 'Name', 'error/name-type');
+    chk(caught && caught.line === 1, 'error/name-line');
+    chk(caught && caught.column === 12, 'error/name-column');
+    chk(caught && caught.message === 'variable @nope is undefined', 'error/name-message');
+  }
+  // Syntax error (strictUnits multiplication)
+  {
+    let caught = null;
+    try { await less.render('.x { width: 2px * 3px; }', { strictUnits: true }); } catch (e) { caught = e; }
+    chk(caught && caught.type === 'Syntax', 'error/syntax-type');
+    chk(caught && caught.message === 'Multiple units in dimension. Correct the units or use the unit function. Bad unit: px*px', 'error/syntax-message');
+  }
+
+  // cleanup scratch dir
+  fs.rmSync(TMP, { recursive: true, force: true });
+}
+
+main().then(function () {
+  console.log('LESS_RESULT ok=' + ok + ' fail=' + fail);
+  if (fail === 0) console.log('LESS_DONE');
+  process.exit(fail === 0 ? 0 : 1);
+}).catch(function (e) {
+  console.log('CARPET_CRASH ' + (e && e.stack ? e.stack : e));
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch (x) {}
+  console.log('LESS_RESULT ok=' + ok + ' fail=' + (fail + 1));
+  process.exit(1);
+});

--- a/apps/starry/node-lib/programs/carpets/ScssCarpet.js
+++ b/apps/starry/node-lib/programs/carpets/ScssCarpet.js
@@ -1,0 +1,277 @@
+'use strict';
+/*
+ * INDUSTRIAL CARPET: dart-sass (sass) 1.83.4 — Dart Sass JS, SCSS syntax.
+ * Runtime: Node.js v22.22.2 (StarryOS target). Deterministic, no clock/random/network.
+ * Every assertion is an exact-value (===) check against a genuine golden observed on this
+ * exact sass version (1.83.4 / dart2js 3.6.1).
+ *
+ * Self-check protocol:
+ *   let ok=0, fail=0; chk(cond,name)
+ *   final: console.log('SCSS_RESULT ok='+ok+' fail='+fail); if(fail===0) console.log('SCSS_DONE'); process.exit(fail===0?0:1)
+ *
+ * Portability: all paths derive from __dirname; subprocess (none needed) would use process.execPath.
+ */
+
+const sass = require('sass');               // NOTE: require('sass/package.json') is blocked by exports; require('sass') works.
+const fs = require('fs');
+const path = require('path');
+
+const SILENT = sass.Logger.silent;
+let ok = 0, fail = 0;
+function chk(cond, name) { if (cond) ok++; else { fail++; console.log('FAIL ' + name); } }
+
+// Compile SCSS string with a silent logger so deprecation chatter never pollutes stdout.
+function C(scss, opts) {
+  return sass.compileString(scss, Object.assign({ logger: SILENT }, opts || {})).css;
+}
+
+// Scratch dir derived from __dirname (portable, cleaned up at the end).
+const TMP = path.join(__dirname, 'tmp-scsscarpet');
+
+async function main() {
+  // ---------- 1. API surface ----------
+  chk(sass.info.split('\t')[0] === 'dart-sass', 'info_impl');
+  chk(sass.info.split('\t')[1] === '1.83.4', 'info_version');
+  chk(typeof sass.compile === 'function', 'api_compile');
+  chk(typeof sass.compileString === 'function', 'api_compileString');
+  chk(typeof sass.compileAsync === 'function', 'api_compileAsync');
+  chk(typeof sass.compileStringAsync === 'function', 'api_compileStringAsync');
+  chk(typeof sass.render === 'function', 'api_render');
+  chk(typeof sass.renderSync === 'function', 'api_renderSync');
+  chk(typeof sass.initCompiler === 'function', 'api_initCompiler');
+  chk(typeof sass.initAsyncCompiler === 'function', 'api_initAsyncCompiler');
+  chk(typeof sass.Exception === 'function', 'api_Exception');
+  chk(Object.keys(sass.types).sort().join(',') === 'Boolean,Color,Error,List,Map,Null,Number,String', 'api_types');
+
+  // ---------- 2. Basic compileString / output styles ----------
+  chk(C('.a{ color: red; }') === '.a {\n  color: red;\n}', 'basic_expanded');
+  chk(C('.a{ color: red; }', { style: 'expanded' }) === '.a {\n  color: red;\n}', 'style_expanded_explicit');
+  const compressed = C('.a{ color: red; background: white; }', { style: 'compressed' });
+  chk(compressed === '.a{color:red;background:#fff}', 'style_compressed_value');
+  chk(compressed.indexOf('\n') === -1, 'style_compressed_no_newline');
+  chk(C('.a{c:red} .b{c:blue}') === '.a {\n  c: red;\n}\n\n.b {\n  c: blue;\n}', 'two_rules_spacing');
+
+  // ---------- 3. Variables / !default / !global ----------
+  chk(C('$c: blue !default;\n.a{ color:$c; }') === '.a {\n  color: blue;\n}', 'var_default_unset');
+  chk(C('$c: blue;\n$c: green !default;\n.a{ color:$c; }') === '.a {\n  color: blue;\n}', 'var_default_kept');
+  chk(C('$x: 1;\n@mixin m(){ $x: 9 !global; }\n@include m();\n.a{ v: $x; }') === '.a {\n  v: 9;\n}', 'var_global');
+
+  // ---------- 4. Nesting + parent selector & ----------
+  chk(C('.btn{ &:hover{ color:red; } &.active{ color:blue; } }')
+      === '.btn:hover {\n  color: red;\n}\n.btn.active {\n  color: blue;\n}', 'nesting_amp');
+  chk(C('.a{ color: red; .b{ width: 1px+2px; } }')
+      === '.a {\n  color: red;\n}\n.a .b {\n  width: 3px;\n}', 'nesting_descendant');
+
+  // ---------- 5. Arithmetic / units / built-in math ----------
+  chk(C('.a{ width: 10px*2; height: 100px/4 + 1px; }')
+      === '.a {\n  width: 20px;\n  height: 26px;\n}', 'arith_units');
+  chk(C('.a{ x: 10 % 3; y: 2 < 3; }') === '.a {\n  x: 1;\n  y: true;\n}', 'arith_mod_cmp');
+
+  // ---------- 6. @mixin / @include (defaults, keyword, rest, @content) ----------
+  chk(C('@mixin box($w, $h:10px){ width:$w; height:$h; }\n.a{ @include box(5px); }')
+      === '.a {\n  width: 5px;\n  height: 10px;\n}', 'mixin_default');
+  chk(C('@mixin box($w, $h:10px){ width:$w; height:$h; }\n.b{ @include box($h:2px, $w:3px); }')
+      === '.b {\n  width: 3px;\n  height: 2px;\n}', 'mixin_keyword');
+  chk(C('@mixin m($a, $rest...){ margin: $a $rest; }\n.a{ @include m(1px,2px,3px); }')
+      === '.a {\n  margin: 1px 2px, 3px;\n}', 'mixin_rest');
+  chk(C('@mixin media($q){ @media (min-width:$q){ @content; } }\n.a{ @include media(100px){ color:red; } }')
+      === '@media (min-width: 100px) {\n  .a {\n    color: red;\n  }\n}', 'mixin_content');
+  chk(C('@mixin m(){ @content; } .a{ @include m { z: 9; } }') === '.a {\n  z: 9;\n}', 'mixin_content_block');
+
+  // ---------- 7. @function / @return ----------
+  chk(C('@function double($n){ @return $n*2; }\n.a{ width: double(4px); }')
+      === '.a {\n  width: 8px;\n}', 'function_double');
+
+  // ---------- 8. @if / @else if / @else ----------
+  chk(C('@mixin t($v){ @if $v > 10 { x:big; } @else if $v > 5 { x:med; } @else { x:small; } }\n.a{ @include t(7); }')
+      === '.a {\n  x: med;\n}', 'if_elseif');
+  chk(C('@mixin t($v){ @if $v > 10 { x:big; } @else if $v > 5 { x:med; } @else { x:small; } }\n.a{ @include t(2); }')
+      === '.a {\n  x: small;\n}', 'if_else');
+
+  // ---------- 9. @each / @for / @while ----------
+  chk(C('@each $i in a, b, c { .#{$i}{ x:1; } }')
+      === '.a {\n  x: 1;\n}\n\n.b {\n  x: 1;\n}\n\n.c {\n  x: 1;\n}', 'each');
+  chk(C('@for $i from 1 through 3 { .m#{$i}{ w:$i; } }')
+      === '.m1 {\n  w: 1;\n}\n\n.m2 {\n  w: 2;\n}\n\n.m3 {\n  w: 3;\n}', 'for_through');
+  chk(C('$i:1; @while $i<=3 { .w#{$i}{ a:$i; } $i: $i+1; }')
+      === '.w1 {\n  a: 1;\n}\n\n.w2 {\n  a: 2;\n}\n\n.w3 {\n  a: 3;\n}', 'while');
+  chk(C('$m:(a:1,b:2); @each $k,$v in $m { .#{$k}{ x:$v; } }')
+      === '.a {\n  x: 1;\n}\n\n.b {\n  x: 2;\n}', 'each_map_kv');
+
+  // ---------- 10. Interpolation ----------
+  chk(C('$name: foo; .#{$name}-bar{ content: "#{$name}"; }')
+      === '.foo-bar {\n  content: "foo";\n}', 'interpolation');
+
+  // ---------- 11. Placeholder %x + @extend (incl. !optional, chains) ----------
+  chk(C('%base{ color:red; } .a{ @extend %base; } .b{ @extend %base; }')
+      === '.b, .a {\n  color: red;\n}', 'placeholder_extend');
+  chk(C('.a{ @extend .nonexistent !optional; color:red; }') === '.a {\n  color: red;\n}', 'extend_optional');
+  chk(C('%a{ x:1; } %b{ y:2; } .c{ @extend %a; @extend %b; }')
+      === '.c {\n  x: 1;\n}\n\n.c {\n  y: 2;\n}', 'extend_multi');
+
+  // ---------- 12. @media nested / @at-root / nested props / !important ----------
+  chk(C('.a{ color:red; @media (min-width:100px){ color:blue; } }')
+      === '.a {\n  color: red;\n}\n@media (min-width: 100px) {\n  .a {\n    color: blue;\n  }\n}', 'media_nested');
+  chk(C('.parent{ .child{ @at-root .escaped{ color:red; } } }')
+      === '.escaped {\n  color: red;\n}', 'at_root');
+  chk(C('.a{ font: { family: serif; size: 12px; } }')
+      === '.a {\n  font-family: serif;\n  font-size: 12px;\n}', 'nested_props');
+  chk(C('.a{ color: red !important; }') === '.a {\n  color: red !important;\n}', 'important');
+
+  // ---------- 13. Comments / charset ----------
+  chk(C('/* keep */\n.a{ color: red; // silent\n}')
+      === '/* keep */\n.a {\n  color: red;\n}', 'comment_loud');
+  chk(C('/* keep */\n.a{ color: red; }', { style: 'compressed' }) === '.a{color:red}', 'comment_compressed');
+  chk(C('.a{ content: "café"; }') === '@charset "UTF-8";\n.a {\n  content: "café";\n}', 'charset_nonascii');
+  chk(C('.a{ content: "café"; }', { charset: false }) === '.a {\n  content: "café";\n}', 'charset_false');
+
+  // ---------- 14. @use built-in modules: sass:math ----------
+  chk(C('@use "sass:math";\n.a{ d: math.div(100px,4); p: math.pow(2,3); c: math.ceil(4.2); }')
+      === '.a {\n  d: 25px;\n  p: 8;\n  c: 5;\n}', 'math_div_pow_ceil');
+  chk(C('@use "sass:math";\n.a{ mx: math.max(1,5,3); mn: math.min(2,8); ab: math.abs(-3); rn: math.round(4.6); pc: math.percentage(0.25); }')
+      === '.a {\n  mx: 5;\n  mn: 2;\n  ab: 3;\n  rn: 5;\n  pc: 25%;\n}', 'math_funcs');
+  chk(C('@use "sass:math";\n.a{ x: math.div(10px,2px); }') === '.a {\n  x: 5;\n}', 'math_div_units_cancel');
+
+  // ---------- 15. @use sass:string ----------
+  chk(C('@use "sass:string";\n.a{ len: string.length("hello"); up: string.to-upper-case("abc"); idx: string.index("abcd","c"); sub: string.slice("hamburger",4,6); }')
+      === '.a {\n  len: 5;\n  up: "ABC";\n  idx: 3;\n  sub: "bur";\n}', 'string_funcs');
+  chk(C('@use "sass:string";\n.a{ q: string.quote(hello); uq: string.unquote("world"); ins: string.insert("abc","X",2); }')
+      === '.a {\n  q: "hello";\n  uq: world;\n  ins: "aXbc";\n}', 'string_quote_unquote_insert');
+
+  // ---------- 16. @use sass:color ----------
+  chk(C('@use "sass:color";\n.a{ c: color.adjust(#6b717f, $red:15); }') === '.a {\n  c: #7a717f;\n}', 'color_adjust');
+  chk(C('@use "sass:color";\n.a{ c: color.adjust(#ff0000, $lightness: -20%); }') === '.a {\n  c: #990000;\n}', 'color_adjust_lightness');
+  chk(C('@use "sass:color";\n.a{ c: color.complement(red); }') === '.a {\n  c: aqua;\n}', 'color_complement');
+  chk(C('@use "sass:color";\n.a{ c: color.mix(white, black); }') === '.a {\n  c: rgb(127.5, 127.5, 127.5);\n}', 'color_mix');
+  chk(C('@use "sass:color";\n.a{ r: color.channel(#ff0000, "red"); }') === '.a {\n  r: 255;\n}', 'color_channel');
+  chk(C('.a{ c: rgba(255,0,0,0.5); }') === '.a {\n  c: rgba(255, 0, 0, 0.5);\n}', 'rgba');
+  chk(C('.a{ c: hsl(0, 100%, 50%); }') === '.a {\n  c: hsl(0, 100%, 50%);\n}', 'hsl');
+
+  // ---------- 17. @use sass:list ----------
+  chk(C('@use "sass:list";\n.a{ len: list.length(1px 2px 3px); nth: list.nth(a b c, 2); join: list.join(1px 2px, 3px 4px); }')
+      === '.a {\n  len: 3;\n  nth: b;\n  join: 1px 2px 3px 4px;\n}', 'list_funcs');
+  chk(C('@use "sass:list";\n.a{ sep: list.separator((1px, 2px)); app: list.append(1px 2px, 3px); idx: list.index(1px 2px 3px, 2px); }')
+      === '.a {\n  sep: comma;\n  app: 1px 2px 3px;\n  idx: 2;\n}', 'list_sep_append_index');
+
+  // ---------- 18. @use sass:map ----------
+  chk(C('@use "sass:map";\n$m: (a:1, b:2);\n.a{ g: map.get($m,a); keys: map.keys($m); vals: map.values($m); has: map.has-key($m,b); }')
+      === '.a {\n  g: 1;\n  keys: a, b;\n  vals: 1, 2;\n  has: true;\n}', 'map_funcs');
+  chk(C('@use "sass:map";\n$m: (a:1);\n$m2: map.merge($m, (b:2));\n.a{ b: map.get($m2,b); }')
+      === '.a {\n  b: 2;\n}', 'map_merge');
+  chk(C('@use "sass:map";\n$m: (a:1);\n$m2: map.set($m, c, 3);\n.a{ c: map.get($m2,c); }')
+      === '.a {\n  c: 3;\n}', 'map_set');
+
+  // ---------- 19. @use namespace alias / wildcard ----------
+  chk(C('@use "sass:math" as m;\n.a{ x: m.div(10,2); }') === '.a {\n  x: 5;\n}', 'use_alias');
+  chk(C('@use "sass:math" as *;\n.a{ x: div(10,2); }') === '.a {\n  x: 5;\n}', 'use_star');
+
+  // ---------- 20. Indented (.sass) syntax option ----------
+  chk(C('a\n  color: red', { syntax: 'indented' }) === 'a {\n  color: red;\n}', 'indented_syntax');
+
+  // ---------- 21. File-based compile() + compileAsync() ----------
+  fs.mkdirSync(TMP, { recursive: true });
+  const mainFile = path.join(TMP, 'main.scss');
+  fs.writeFileSync(mainFile, '$pad: 4px;\n.box{ padding: $pad; }\n');
+  chk(sass.compile(mainFile, { logger: SILENT }).css === '.box {\n  padding: 4px;\n}', 'compile_file');
+  const af = await sass.compileAsync(mainFile, { logger: SILENT });
+  chk(af.css === '.box {\n  padding: 4px;\n}', 'compileAsync_file');
+
+  // ---------- 22. loadPaths (@use a written partial) ----------
+  fs.writeFileSync(path.join(TMP, '_lib.scss'), '$gap: 8px;\n@mixin g(){ gap: $gap; }\n');
+  chk(C('@use "lib";\n.a{ @include lib.g(); }', { loadPaths: [TMP] }) === '.a {\n  gap: 8px;\n}', 'loadPaths_use');
+
+  // ---------- 23. Custom importer (in-memory module) ----------
+  const imp = sass.compileString('@use "virtual";\n.a{ color: virtual.$c; }', {
+    logger: SILENT,
+    importers: [{
+      canonicalize(url) { return (url === 'virtual' || url === 'virtual.scss') ? new URL('mem:virtual') : null; },
+      load() { return { contents: '$c: tomato;', syntax: 'scss' }; }
+    }]
+  });
+  chk(imp.css === '.a {\n  color: tomato;\n}', 'custom_importer');
+
+  // ---------- 24. Custom JS function (functions option) ----------
+  const fnRes = sass.compileString('.a{ w: triple(4px); }', {
+    logger: SILENT,
+    functions: {
+      'triple($n)': (args) => { const n = args[0].assertNumber('n'); return new sass.SassNumber(n.value * 3, 'px'); }
+    }
+  });
+  chk(fnRes.css === '.a {\n  w: 12px;\n}', 'custom_function');
+
+  // ---------- 25. Async string compile + Compiler reuse ----------
+  const asyncRes = await sass.compileStringAsync('.a{ b: 1+1; }', { logger: SILENT });
+  chk(asyncRes.css === '.a {\n  b: 2;\n}', 'compileStringAsync');
+  const compiler = sass.initCompiler();
+  chk(compiler.compileString('.a{ x: 2*2; }', { logger: SILENT }).css === '.a {\n  x: 4;\n}', 'compiler_reuse_1');
+  chk(compiler.compileString('.b{ y: 3*3; }', { logger: SILENT }).css === '.b {\n  y: 9;\n}', 'compiler_reuse_2');
+  compiler.dispose();
+  const acompiler = await sass.initAsyncCompiler();
+  const ac = await acompiler.compileStringAsync('.c{ z: 5+5; }', { logger: SILENT });
+  chk(ac.css === '.c {\n  z: 10;\n}', 'async_compiler');
+  await acompiler.dispose();
+
+  // ---------- 26. sourceMap + loadedUrls ----------
+  const sm = sass.compileString('.a{ color: red; }', { sourceMap: true, logger: SILENT });
+  chk(!!sm.sourceMap && sm.sourceMap.version === 3, 'sourceMap_v3');
+  const lu = sass.compileString('.a{ b: 1; }', { logger: SILENT, url: new URL('mem:entry') });
+  chk(lu.loadedUrls.map(u => u.href).join(',') === 'mem:entry', 'loadedUrls');
+  // no sourceMap requested -> undefined
+  chk(sass.compileString('.a{ b: 1; }', { logger: SILENT }).sourceMap === undefined, 'no_sourceMap');
+
+  // ---------- 27. Value type constructors ----------
+  chk(new sass.SassNumber(5).value === 5, 'SassNumber_value');
+  chk(new sass.SassNumber(3, 'px').toString() === '3px', 'SassNumber_unit_toString');
+  chk(new sass.SassString('hi').text === 'hi', 'SassString_text');
+  chk(sass.sassTrue.value === true && sass.sassFalse.value === false, 'SassBoolean_values');
+  chk(sass.sassNull.realNull === null, 'sassNull');
+  chk(new sass.SassColor({ red: 255, green: 0, blue: 0, space: 'rgb' }).channel('red') === 255, 'SassColor_channel');
+  const slist = new sass.SassList([new sass.SassNumber(1), new sass.SassNumber(2)], { separator: ',' });
+  chk(slist.asList.size === 2 && slist.separator === ',', 'SassList_ctor');
+  const smap = new sass.SassMap(new Map([[new sass.SassString('k'), new sass.SassNumber(7)]]));
+  chk(smap.contents.size === 1, 'SassMap_ctor');
+
+  // ---------- 28. Error path: invalid scss throws sass.Exception with span ----------
+  let threw = false, exObj = null;
+  try { sass.compileString('.a{ color: ; }', { logger: SILENT }); }
+  catch (e) { threw = true; exObj = e; }
+  chk(threw === true, 'error_throws');
+  chk(exObj instanceof sass.Exception, 'error_is_Exception');
+  chk(exObj && exObj.sassMessage === 'Expected expression.', 'error_message');
+  chk(exObj && exObj.span && exObj.span.start && exObj.span.start.offset === 11, 'error_span_offset');
+  chk(exObj && exObj.span.start.line === 0 && exObj.span.start.column === 11, 'error_span_line_col');
+  let threw2 = false, msg2 = '';
+  try { sass.compileString('.a{ @include nope; }', { logger: SILENT }); }
+  catch (e) { threw2 = true; msg2 = e.sassMessage; }
+  chk(threw2 && msg2 === 'Undefined mixin.', 'error_undefined_mixin');
+
+  // ---------- 29. Logger @warn / @debug capture ----------
+  const warns = [];
+  sass.compileString('@warn "hi there";\n.a{ b: 1; }', { logger: { warn(m) { warns.push(m); } } });
+  chk(warns.length === 1 && warns[0] === 'hi there', 'logger_warn');
+  const debugs = [];
+  sass.compileString('@debug "dbg";\n.a{ b: 1; }', { logger: { debug(m) { debugs.push(m); } } });
+  chk(debugs.length === 1 && debugs[0] === 'dbg', 'logger_debug');
+
+  // ---------- 30. Legacy API render() / renderSync() ----------
+  const rsync = sass.renderSync({ data: '.a{ b: 2+2; }' }).css.toString();
+  chk(rsync === '.a {\n  b: 4;\n}', 'legacy_renderSync');
+  const rcb = await new Promise((resolve, reject) => {
+    sass.render({ data: '.a{ b: 1+1; }' }, (err, res) => err ? reject(err) : resolve(res.css.toString()));
+  });
+  chk(rcb === '.a {\n  b: 2;\n}', 'legacy_render_cb');
+
+  // cleanup scratch dir
+  fs.rmSync(TMP, { recursive: true, force: true });
+}
+
+main().then(() => {
+  console.log('SCSS_RESULT ok=' + ok + ' fail=' + fail);
+  if (fail === 0) console.log('SCSS_DONE');
+  process.exit(fail === 0 ? 0 : 1);
+}).catch((e) => {
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch (_) {}
+  console.log('FATAL ' + (e && e.stack ? e.stack : e));
+  console.log('SCSS_RESULT ok=' + ok + ' fail=' + (fail + 1));
+  process.exit(1);
+});

--- a/apps/starry/node-lib/programs/carpets/StylusCarpet.js
+++ b/apps/starry/node-lib/programs/carpets/StylusCarpet.js
@@ -1,0 +1,341 @@
+'use strict';
+/*
+ * INDUSTRIAL carpet for stylus 0.64.0
+ * Target runtime: Node.js v22.22.2 (StarryOS target). Host-verified on the same.
+ * Deterministic only: no Date.now / Math.random / timestamps / wall-clock / network.
+ * Every assertion is an exact-value check (=== against a golden baked from observed
+ * real output of this exact stylus version).
+ * Portability: stylus resolved via require() from cwd node_modules; every scratch path
+ * derived from __dirname; subprocess (none needed) would use process.execPath.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const stylus = require('stylus');
+
+let ok = 0, fail = 0;
+function chk(cond, name) { if (cond) ok++; else { fail++; console.log('FAIL ' + name); } }
+function eq(actual, expected, name) {
+  if (actual === expected) ok++;
+  else { fail++; console.log('FAIL ' + name + ' :: got ' + JSON.stringify(actual) + ' want ' + JSON.stringify(expected)); }
+}
+
+// Synchronous render helper (stylus invokes the callback synchronously).
+function rcb(src, opts) {
+  let out, errOut;
+  const r = stylus(src, opts || {});
+  r.render(function (e, c) { if (e) errOut = e; else out = c; });
+  if (errOut) throw errOut;
+  return out;
+}
+
+// Scratch dir derived from __dirname (NOT a hardcoded absolute host path).
+const SCRATCH = path.join(__dirname, 'tmp-styluscarpet');
+function withFile(rel, content, body) {
+  fs.mkdirSync(SCRATCH, { recursive: true });
+  const f = path.join(SCRATCH, rel);
+  fs.writeFileSync(f, content);
+  try { return body(f, SCRATCH); }
+  finally { try { fs.rmSync(SCRATCH, { recursive: true, force: true }); } catch (_) {} }
+}
+
+// ---------------------------------------------------------------------------
+// Group A: module / API surface
+// ---------------------------------------------------------------------------
+eq(stylus.version, '0.64.0', 'version');
+chk(typeof stylus === 'function', 'stylus-is-function');
+chk(typeof stylus.render === 'function', 'render-is-function');
+chk(typeof stylus.convertCSS === 'function', 'convertCSS-is-function');
+chk(typeof stylus.Parser === 'function', 'Parser-exposed');
+chk(typeof stylus.Evaluator === 'function', 'Evaluator-exposed');
+chk(typeof stylus.Compiler === 'function', 'Compiler-exposed');
+chk(typeof stylus.Normalizer === 'function', 'Normalizer-exposed');
+chk(typeof stylus.nodes === 'object' && typeof stylus.nodes.Unit === 'function', 'nodes-Unit-exposed');
+chk(typeof stylus.functions === 'object', 'functions-exposed');
+chk(typeof stylus.utils === 'object', 'utils-exposed');
+
+// ---------------------------------------------------------------------------
+// Group B: render sync + async + convertCSS
+// ---------------------------------------------------------------------------
+eq(stylus.render('body\n  color red\n'), 'body {\n  color: #f00;\n}\n', 'render-sync-basic');
+eq(rcb('a\n  color red\n'), 'a {\n  color: #f00;\n}\n', 'render-async-cb');
+eq(stylus.convertCSS('body { color: red; }'), 'body\n  color: red\n\n', 'convertCSS');
+
+// ---------------------------------------------------------------------------
+// Group C: variables + assignment
+// ---------------------------------------------------------------------------
+eq(stylus.render('c = #f00\nbody\n  color c\n'), 'body {\n  color: #f00;\n}\n', 'variable-assign');
+
+// ---------------------------------------------------------------------------
+// Group D: arithmetic, units, precedence, operators
+// ---------------------------------------------------------------------------
+eq(stylus.render('body\n  width 10px + 5px\n  margin (10px / 2)\n  z 2 * 3\n'),
+   'body {\n  width: 15px;\n  margin: 5px;\n  z: 6;\n}\n', 'arithmetic-units');
+eq(stylus.render('body\n  width (1 + 2) * 3px\n'), 'body {\n  width: 9px;\n}\n', 'paren-precedence');
+eq(stylus.render('body\n  z 1s + 500ms\n'), 'body {\n  z: 1.5s;\n}\n', 'unit-coercion');
+eq(stylus.render('body\n  width 50% - 10px\n'), 'body {\n  width: 40%;\n}\n', 'percent-minus');
+eq(stylus.render('body\n  z 10 % 3\n'), 'body {\n  z: 1;\n}\n', 'modulo');
+eq(stylus.render('body\n  z 2 ** 3\n'), 'body {\n  z: 8;\n}\n', 'power');
+eq(stylus.render('body\n  z 16 ** 0.5\n'), 'body {\n  z: 4;\n}\n', 'power-sqrt');
+
+// ---------------------------------------------------------------------------
+// Group E: color operations + built-in color functions
+// ---------------------------------------------------------------------------
+eq(stylus.render('body\n  color rgba(255,0,0,0.5)\n'), 'body {\n  color: rgba(255,0,0,0.5);\n}\n', 'rgba-literal');
+eq(stylus.render('body\n  color rgb(255,0,0)\n'), 'body {\n  color: #f00;\n}\n', 'rgb');
+eq(stylus.render('body\n  color lighten(#000, 50%)\n'), 'body {\n  color: #808080;\n}\n', 'lighten');
+eq(stylus.render('body\n  color darken(#fff, 50%)\n'), 'body {\n  color: #808080;\n}\n', 'darken');
+eq(stylus.render('body\n  color mix(#fff, #000, 50%)\n'), 'body {\n  color: #7f7f7f;\n}\n', 'mix');
+eq(stylus.render('body\n  color invert(#fff)\n'), 'body {\n  color: #000;\n}\n', 'invert');
+eq(stylus.render('body\n  color #001122 + #110000\n'), 'body {\n  color: #112;\n}\n', 'color-add');
+eq(stylus.render('body\n  color rgba(#123456, 0.3)\n'), 'body {\n  color: rgba(18,52,86,0.3);\n}\n', 'rgba-from-hex');
+eq(stylus.render('c = rgba(10,20,30,0.4)\nbody\n  r red(c)\n  g green(c)\n  b blue(c)\n  a alpha(c)\n'),
+   'body {\n  r: 10;\n  g: 20;\n  b: 30;\n  a: 0.4;\n}\n', 'color-components');
+// NB: property name avoids the `s` built-in (a bare `s <expr>` parses as a call to s()).
+eq(stylus.render('c = #f00\nbody\n  h hue(c)\n  sat saturation(c)\n  l lightness(c)\n'),
+   'body {\n  h: 0deg;\n  sat: 100%;\n  l: 50%;\n}\n', 'hsl-components');
+eq(stylus.render('body\n  l luminosity(#fff)\n'), 'body {\n  l: 1;\n}\n', 'luminosity');
+eq(stylus.render('body\n  color transparentify(#808080, #000, 0.5)\n'),
+   'body {\n  color: rgba(255,255,255,0.5);\n}\n', 'transparentify');
+eq(stylus.render('body\n  z component(#abc, \'red\')\n'), 'body {\n  z: 170;\n}\n', 'component');
+eq(stylus.render('body\n  color hsla(0, 100%, 50%, 0.5)\n'), 'body {\n  color: rgba(255,0,0,0.5);\n}\n', 'hsla');
+eq(stylus.render('body\n  color hsl(120, 50%, 50%)\n'), 'body {\n  color: #40bf40;\n}\n', 'hsl');
+
+// ---------------------------------------------------------------------------
+// Group F: nesting, &, selector references
+// ---------------------------------------------------------------------------
+eq(stylus.render('.a\n  .b\n    color red\n'), '.a .b {\n  color: #f00;\n}\n', 'nesting');
+eq(stylus.render('a\n  &:hover\n    color blue\n'), 'a:hover {\n  color: #00f;\n}\n', 'amp-parent-ref');
+eq(stylus.render('a, b\n  &:hover\n    color red\n'), 'a:hover,\nb:hover {\n  color: #f00;\n}\n', 'amp-multi-parent');
+eq(stylus.render('.foo\n  .bar\n    width 1px\n    ^[0]:hover &\n      width 2px\n'),
+   '.foo .bar {\n  width: 1px;\n}\n.foo:hover .foo .bar {\n  width: 2px;\n}\n', 'partial-ref-N');
+eq(stylus.render('.a\n  .b\n    .c\n      ^[-1]:hover &\n        color red\n'),
+   '.a .b:hover .a .b .c {\n  color: #f00;\n}\n', 'partial-ref-neg');
+eq(stylus.render('.foo\n  content selector()\n'), '.foo {\n  content: \'.foo\';\n}\n', 'selector-builtin');
+
+// ---------------------------------------------------------------------------
+// Group G: mixins & functions
+// ---------------------------------------------------------------------------
+eq(stylus.render('tabs()\n  display block\n.tabs\n  tabs()\n'), '.tabs {\n  display: block;\n}\n', 'mixin-call');
+eq(stylus.render('foo()\n  .bar\n    {block}\n+foo()\n  color red\n'), '.bar {\n  color: #f00;\n}\n', 'block-mixin');
+eq(stylus.render('add(a, b)\n  a + b\nbody\n  width add(1px, 2px)\n'), 'body {\n  width: 3px;\n}\n', 'fn-return-value');
+eq(stylus.render('box(w = 10px, h = 20px)\n  width w\n  height h\n.b\n  box()\n'),
+   '.b {\n  width: 10px;\n  height: 20px;\n}\n', 'fn-default-args');
+eq(stylus.render('m(args...)\n  margin args\n.r\n  m(1px 2px 3px)\n'), '.r {\n  margin: 1px 2px 3px;\n}\n', 'fn-rest-args');
+eq(stylus.render('box(w, h)\n  width w\n  height h\n.n\n  box(h: 5px, w: 3px)\n'),
+   '.n {\n  width: 3px;\n  height: 5px;\n}\n', 'fn-named-args');
+
+// use() plugin defining a JS function
+eq(rcb('body\n  width double(4px)\n', { use: function (r) {
+     r.define('double', function (n) { return new stylus.nodes.Unit(n.val * 2, n.type); });
+   } }), 'body {\n  width: 8px;\n}\n', 'use-plugin-option');
+(function () {
+  let css;
+  const plugin = function (renderer) {
+    renderer.define('triple', function (n) { return new stylus.nodes.Unit(n.val * 3, n.type); });
+  };
+  stylus('body\n  width triple(3px)\n').use(plugin).render(function (e, c) { if (e) throw e; css = c; });
+  eq(css, 'body {\n  width: 9px;\n}\n', 'use-plugin-method');
+})();
+
+// ---------------------------------------------------------------------------
+// Group H: interpolation
+// ---------------------------------------------------------------------------
+eq(stylus.render("v = 10\nbody\n  margin-{'top'} 5px\n"), 'body {\n  margin-top: 5px;\n}\n', 'interpolation');
+
+// ---------------------------------------------------------------------------
+// Group I: conditionals
+// ---------------------------------------------------------------------------
+eq(stylus.render('n = 5\nbody\n  if n > 3\n    color red\n  else\n    color blue\n'),
+   'body {\n  color: #f00;\n}\n', 'if-else');
+eq(stylus.render('n = 2\nbody\n  if n > 3\n    color red\n  else if n > 1\n    color green\n  else\n    color blue\n'),
+   'body {\n  color: #008000;\n}\n', 'if-elseif-else');
+eq(stylus.render('n = 1\nbody\n  unless n is 0\n    color green\n'), 'body {\n  color: #008000;\n}\n', 'unless');
+eq(stylus.render('n = 1\nbody\n  color (n > 0 ? red : blue)\n'), 'body {\n  color: #f00;\n}\n', 'ternary');
+eq(stylus.render('n = 1\nbody\n  color red if n > 0\n'), 'body {\n  color: #f00;\n}\n', 'postfix-if');
+eq(stylus.render('body\n  color (true and 1 ? red : blue)\n'), 'body {\n  color: #f00;\n}\n', 'logical-and');
+
+// ---------------------------------------------------------------------------
+// Group J: iteration
+// ---------------------------------------------------------------------------
+eq(stylus.render('for i in 1..3\n  .col-{i}\n    width i\n'),
+   '.col-1 {\n  width: 1;\n}\n.col-2 {\n  width: 2;\n}\n.col-3 {\n  width: 3;\n}\n', 'for-range-inclusive');
+eq(stylus.render('for i in 1...4\n  .e{i}\n    x i\n'),
+   '.e1 {\n  x: 1;\n}\n.e2 {\n  x: 2;\n}\n.e3 {\n  x: 3;\n}\n', 'for-range-exclusive');
+eq(stylus.render('for v, i in a b c\n  .item-{i}\n    content v\n'),
+   '.item-0 {\n  content: a;\n}\n.item-1 {\n  content: b;\n}\n.item-2 {\n  content: c;\n}\n', 'for-value-index');
+
+// ---------------------------------------------------------------------------
+// Group K: hashes / objects
+// ---------------------------------------------------------------------------
+eq(stylus.render("h = { foo: 1px, bar: 2px }\nbody\n  width h.foo\n  height h['bar']\n"),
+   'body {\n  width: 1px;\n  height: 2px;\n}\n', 'hash-access');
+eq(stylus.render('h = { a: 1px, b: 2px }\nfor key, val in h\n  .{key}\n    width val\n'),
+   '.a {\n  width: 1px;\n}\n.b {\n  width: 2px;\n}\n', 'hash-iteration');
+
+// ---------------------------------------------------------------------------
+// Group L: @extend
+// ---------------------------------------------------------------------------
+eq(stylus.render('.msg\n  padding 10px\n.err\n  @extend .msg\n  color red\n'),
+   '.msg,\n.err {\n  padding: 10px;\n}\n.err {\n  color: #f00;\n}\n', 'extend');
+eq(stylus.render('$base\n  margin 0\n.x\n  @extend $base\n  color red\n'),
+   '.x {\n  margin: 0;\n}\n.x {\n  color: #f00;\n}\n', 'extend-placeholder');
+
+// ---------------------------------------------------------------------------
+// Group M: built-in functions (type/math/list/string)
+// ---------------------------------------------------------------------------
+eq(stylus.render('body\n  z typeof(123)\n'), "body {\n  z: 'unit';\n}\n", 'typeof-unit');
+eq(stylus.render("body\n  a typeof('s')\n  b typeof(1px)\n  c typeof(#fff)\n  d typeof(true)\n"),
+   "body {\n  a: 'string';\n  b: 'unit';\n  c: 'rgba';\n  d: 'boolean';\n}\n", 'typeof-variants');
+eq(stylus.render('body\n  z type(#fff)\n'), "body {\n  z: 'rgba';\n}\n", 'type-alias');
+eq(stylus.render('body\n  a abs(-5)\n  b round(4.6)\n  c ceil(4.1)\n'),
+   'body {\n  a: 5;\n  b: 5;\n  c: 5;\n}\n', 'abs-round-ceil');
+eq(stylus.render('body\n  z floor(4.9)\n'), 'body {\n  z: 4;\n}\n', 'floor');
+eq(stylus.render('body\n  z abs(-5px)\n'), 'body {\n  z: 5px;\n}\n', 'abs-unit-preserve');
+eq(stylus.render('body\n  z round(3.14159, 2)\n'), 'body {\n  z: 3.14;\n}\n', 'round-precision');
+eq(stylus.render('body\n  a max(3, 7)\n  b min(3, 7)\n'), 'body {\n  a: 7;\n  b: 3;\n}\n', 'min-max');
+eq(stylus.render('body\n  z percentage(0.5)\n'), 'body {\n  z: 50%;\n}\n', 'percentage');
+eq(stylus.render('body\n  z base-convert(255, 16, 2)\n'), 'body {\n  z: ff;\n}\n', 'base-convert');
+eq(stylus.render('body\n  width unit(10, px)\n'), 'body {\n  width: 10px;\n}\n', 'unit-set');
+eq(stylus.render("body\n  z unit(15px, '')\n"), 'body {\n  z: 15;\n}\n', 'unit-strip');
+eq(stylus.render('list = 1 2 3\nbody\n  z length(list)\n'), 'body {\n  z: 3;\n}\n', 'length');
+eq(stylus.render('body\n  z length(())\n'), 'body {\n  z: 0;\n}\n', 'length-empty');
+eq(stylus.render('body\n  z length(5px)\n'), 'body {\n  z: 1;\n}\n', 'length-single');
+eq(stylus.render('list = 1 2\npush(list, 3)\nbody\n  z length(list)\n'), 'body {\n  z: 3;\n}\n', 'push');
+eq(stylus.render('l = 1 2 3\nx = pop(l)\nbody\n  a x\n  b length(l)\n'), 'body {\n  a: 3;\n  b: 2;\n}\n', 'pop');
+eq(stylus.render('l = 1 2 3\nx = shift(l)\nbody\n  a x\n  b length(l)\n'), 'body {\n  a: 1;\n  b: 2;\n}\n', 'shift');
+eq(stylus.render('l = 2 3\nunshift(l, 1)\nbody\n  z length(l)\n'), 'body {\n  z: 3;\n}\n', 'unshift');
+eq(stylus.render('body\n  z length(slice(1 2 3 4, 1, 3))\n'), 'body {\n  z: 2;\n}\n', 'slice');
+eq(stylus.render("body\n  z match('^foo', 'foobar')\n"), "body {\n  z: 'foo';\n}\n", 'match');
+eq(stylus.render("body\n  content replace('a', 'b', 'aaa')\n"), "body {\n  content: 'bbb';\n}\n", 'replace');
+eq(stylus.render("body\n  content substr('hello', 1, 3)\n"), "body {\n  content: 'ell';\n}\n", 'substr');
+eq(stylus.render("body\n  z length(split(',', 'a,b,c'))\n"), 'body {\n  z: 3;\n}\n', 'split');
+eq(stylus.render("body\n  z operate('+', 5, 3)\n"), 'body {\n  z: 8;\n}\n', 'operate');
+eq(stylus.render('body\n  width s("%s + %s", 1px, 2px)\n'), 'body {\n  width: 1px + 2px;\n}\n', 's-format');
+eq(stylus.render("body\n  content unquote('\"hi\"')\n"), 'body {\n  content: "hi";\n}\n', 'unquote');
+
+// p() built-in inspects to stdout and returns null -> property renders empty.
+// Suppress its console.log so it does not pollute carpet output, but assert behaviour.
+(function () {
+  const orig = console.log;
+  let printed = '';
+  console.log = function () { printed += Array.prototype.join.call(arguments, ' '); };
+  let css;
+  try { css = stylus.render('body\n  width p(10px)\n'); } finally { console.log = orig; }
+  eq(css, 'body {\n  width: ;\n}\n', 'p-returns-null');
+  chk(/inspect/.test(printed) && /10px/.test(printed), 'p-inspects-stdout');
+})();
+
+// ---------------------------------------------------------------------------
+// Group N: define() / set() / get() JS API + define/globals/functions options
+// ---------------------------------------------------------------------------
+(function () {
+  let css;
+  stylus('body\n  width foo\n').define('foo', new stylus.nodes.Unit(42, 'px'))
+    .render(function (e, c) { if (e) throw e; css = c; });
+  eq(css, 'body {\n  width: 42px;\n}\n', 'define-global-node');
+})();
+(function () {
+  let css;
+  stylus('body\n  width add(2, 3)\n').define('add', function (a, b) { return new stylus.nodes.Unit(a.val + b.val); })
+    .render(function (e, c) { if (e) throw e; css = c; });
+  eq(css, 'body {\n  width: 5;\n}\n', 'define-js-function');
+})();
+(function () {
+  let css;
+  stylus('body\n  font family\n').define('family', 'Arial')
+    .render(function (e, c) { if (e) throw e; css = c; });
+  eq(css, "body {\n  font: 'Arial';\n}\n", 'define-coerce-string');
+})();
+(function () {
+  const r = stylus('body\n  color red\n').set('compress', true);
+  chk(r.get('compress') === true, 'set-get');
+  let css; r.render(function (e, c) { if (e) throw e; css = c; });
+  eq(css, 'body{color:#f00}', 'set-compress-renders');
+})();
+eq(stylus.render('body\n  width gw\n', { globals: { gw: new stylus.nodes.Unit(9, 'px') } }),
+   'body {\n  width: 9px;\n}\n', 'option-globals');
+eq(stylus.render('body\n  width triple(2)\n',
+   { functions: { triple: function (n) { return new stylus.nodes.Unit(n.val * 3, n.type); } } }),
+   'body {\n  width: 6;\n}\n', 'option-functions');
+
+// ---------------------------------------------------------------------------
+// Group O: imports / paths / include / import() / json / deps
+// ---------------------------------------------------------------------------
+eq(withFile('vars.styl', 'primary = #abc\n', function (f) {
+     return stylus.render('body\n  color primary\n', { imports: [f] });
+   }), 'body {\n  color: #abc;\n}\n', 'option-imports');
+eq(withFile('mod.styl', '.mod\n  color red\n', function (f, dir) {
+     return stylus.render("@import 'mod'\n", { paths: [dir] });
+   }), '.mod {\n  color: #f00;\n}\n', 'import-via-paths');
+eq(withFile('lib.styl', '.lib\n  color blue\n', function (f, dir) {
+     let css;
+     stylus("@import 'lib'\n").include(dir).render(function (e, c) { if (e) throw e; css = c; });
+     return css;
+   }), '.lib {\n  color: #00f;\n}\n', 'include-method');
+eq(withFile('g.styl', 'gvar = #0f0\n', function (f, dir) {
+     let css;
+     stylus('body\n  color gvar\n', { paths: [dir] }).import('g').render(function (e, c) { if (e) throw e; css = c; });
+     return css;
+   }), 'body {\n  color: #0f0;\n}\n', 'import-method');
+eq(withFile('v.json', JSON.stringify({ width: '10px', nested: { color: '#abc' } }), function (f, dir) {
+     return stylus.render("vars = json('v.json', { hash: true })\nbody\n  width vars.width\n  color vars.nested.color\n", { paths: [dir] });
+   }), 'body {\n  width: 10px;\n  color: #abc;\n}\n', 'json-hash-file');
+eq(withFile('c.json', JSON.stringify({ 'primary-color': '#f00' }), function (f, dir) {
+     return stylus.render("json('c.json')\nbody\n  color primary-color\n", { paths: [dir] });
+   }), 'body {\n  color: #f00;\n}\n', 'json-vars-file');
+eq(withFile('a.styl', '.a\n  color red\n', function (f, dir) {
+     const r = stylus("@import 'a'\n", { paths: [dir] });
+     return r.deps().map(function (p) { return path.basename(p); }).join(',');
+   }), 'a.styl', 'deps');
+
+// ---------------------------------------------------------------------------
+// Group P: @media, @keyframes, !important, preserved comments
+// ---------------------------------------------------------------------------
+eq(stylus.render('@media (max-width: 600px)\n  body\n    color red\n'),
+   '@media (max-width: 600px) {\n  body {\n    color: #f00;\n  }\n}\n', 'media');
+(function () {
+  const block = function (pfx) {
+    return '@' + pfx + 'keyframes foo {\n  0% {\n    opacity: 0;\n  }\n  100% {\n    opacity: 1;\n  }\n}\n';
+  };
+  const expected = block('-moz-') + block('-webkit-') + block('-o-') + block('');
+  eq(stylus.render('@keyframes foo\n  0%\n    opacity 0\n  100%\n    opacity 1\n'), expected, 'keyframes-prefixed');
+})();
+eq(stylus.render('body\n  color red !important\n'), 'body {\n  color: #f00 !important;\n}\n', 'important');
+eq(stylus.render('/*!\n * keep\n */\nbody\n  color red\n'),
+   '/*\n * keep\n */\nbody {\n  color: #f00;\n}\n', 'preserved-comment');
+
+// ---------------------------------------------------------------------------
+// Group Q: compress option
+// ---------------------------------------------------------------------------
+eq(stylus.render('body\n  color red\n', { compress: true }), 'body{color:#f00}', 'compress');
+eq(stylus.render('.a\n  .b\n    color red\n  margin 0\n', { compress: true }),
+   '.a{margin:0}.a .b{color:#f00}', 'compress-nested');
+
+// ---------------------------------------------------------------------------
+// Group R: ParseError paths (sync throw + async err callback + error shape)
+// ---------------------------------------------------------------------------
+(function () {
+  let threw = false, name = '';
+  try { stylus.render('body\n  color (\n'); }
+  catch (e) { threw = true; name = e.name; }
+  chk(threw && name === 'ParseError', 'parse-error-sync-throw');
+})();
+(function () {
+  let errName = 'NONE';
+  stylus('body\n  color (\n').render(function (e, c) { if (e) errName = e.name; });
+  eq(errName, 'ParseError', 'parse-error-async-cb');
+})();
+(function () {
+  let okShape = false;
+  try { stylus.render('@@\n'); }
+  catch (e) { okShape = e.name === 'ParseError' && (/expected/i.test(e.message) || /unexpected/i.test(e.message)); }
+  chk(okShape, 'parse-error-message');
+})();
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+console.log('STYLUS_RESULT ok=' + ok + ' fail=' + fail);
+if (fail === 0) console.log('STYLUS_DONE');
+process.exit(fail === 0 ? 0 : 1);

--- a/apps/starry/node-lib/programs/carpets/TerserCarpet.js
+++ b/apps/starry/node-lib/programs/carpets/TerserCarpet.js
@@ -1,0 +1,302 @@
+'use strict';
+/*
+ * INDUSTRIAL carpet for terser 5.37.0 on Node.js v22.22.2.
+ * Every assertion is an exact-value check against goldens captured by
+ * running terser on this exact version. Deterministic only:
+ * no Date.now / Math.random / wall-clock / network.
+ * Portable: terser is required relative to this file (__dirname), no
+ * hardcoded host paths; no scratch file IO is performed.
+ */
+
+// terser resolves from this file's directory regardless of cwd.
+const terser = require('terser');
+const { minify, minify_sync } = terser;
+
+let ok = 0, fail = 0;
+function chk(cond, name) {
+  if (cond) ok++;
+  else { fail++; console.log('FAIL ' + name); }
+}
+function eq(actual, expected, name) {
+  if (actual === expected) ok++;
+  else {
+    fail++;
+    console.log('FAIL ' + name + '\n   expected ' + JSON.stringify(expected) +
+                '\n   actual   ' + JSON.stringify(actual));
+  }
+}
+
+(async () => {
+  // ---- module surface ----------------------------------------------------
+  chk(typeof minify === 'function', 'minify-is-function');
+  chk(typeof minify_sync === 'function', 'minify_sync-is-function');
+  chk(typeof terser._default_options === 'function', '_default_options-is-function');
+  chk(minify('var x=1;') instanceof Promise, 'minify-returns-promise');
+  chk(require('terser/package.json').version === '5.37.0', 'version-5.37.0');
+
+  let r;
+
+  // ---- basic default minify (compress + mangle on by default) ------------
+  r = await minify('function foo(bar){return bar+1;}');
+  eq(r.code, 'function foo(n){return n+1}', 'default-minify');
+  chk(typeof r.code === 'string', 'default-code-string');
+  chk(r.error === undefined, 'default-no-error');
+  chk(r.map === undefined, 'default-no-map');
+
+  r = await minify('let x = 1 + 2; console.log(x);');
+  eq(r.code, 'let x=3;console.log(x);', 'default-evaluate-let');
+
+  // ---- mangle variants ---------------------------------------------------
+  r = await minify('function add(first, second){return first + second;}', { mangle: true });
+  eq(r.code, 'function add(n,d){return n+d}', 'mangle-true');
+
+  r = await minify('function add(first, second){return first + second;}', { mangle: { toplevel: true } });
+  eq(r.code, 'function n(n,r){return n+r}', 'mangle-toplevel');
+
+  r = await minify('function add(aaa, bbb){return aaa + bbb;}', { mangle: { reserved: ['aaa'] } });
+  eq(r.code, 'function add(aaa,n){return aaa+n}', 'mangle-reserved');
+
+  r = await minify('var o = {}; o._private = 1; o._other = 2; console.log(o._private);',
+                   { mangle: { properties: { regex: /^_/ } }, compress: false });
+  eq(r.code, 'var o={};o.o=1;o.l=2;console.log(o.o);', 'mangle-properties-regex');
+
+  r = await minify('var o = {a:1, b:2}; o.a; o["b"];',
+                   { mangle: { properties: { keep_quoted: true } }, compress: false });
+  eq(r.code, 'var o={a:1,b:2};o.a;o["b"];', 'mangle-properties-keep_quoted');
+
+  // ---- compress: individual transforms -----------------------------------
+  r = await minify('function f(){ if(false){ return 1; } return 2; }', { compress: { dead_code: true }, mangle: false });
+  eq(r.code, 'function f(){return 2}', 'compress-dead_code');
+
+  r = await minify('console.log("a"); var x=1;', { compress: { drop_console: true }, mangle: false });
+  eq(r.code, 'var x=1;', 'compress-drop_console');
+
+  r = await minify('console.log(1);console.error(2);', { compress: { drop_console: ['log'] }, mangle: false });
+  eq(r.code, 'console.error(2);', 'compress-drop_console-array');
+
+  r = await minify('function f(){ debugger; return 1; }', { compress: { drop_debugger: true }, mangle: false });
+  eq(r.code, 'function f(){return 1}', 'compress-drop_debugger');
+
+  r = await minify('function f(){ if(a) return 1; return 2; }', { compress: { conditionals: true, if_return: true }, mangle: false });
+  eq(r.code, 'function f(){return a?1:2}', 'compress-conditionals-if_return');
+
+  r = await minify('var x = 2 + 3 * 4;', { compress: { evaluate: true }, mangle: false });
+  eq(r.code, 'var x=14;', 'compress-evaluate');
+
+  r = await minify('var s = "foo" + "bar";', { compress: { evaluate: true }, mangle: false });
+  eq(r.code, 'var s="foobar";', 'compress-evaluate-strings');
+
+  r = await minify('function f(){ var x = 5; return x + 1; }', { compress: { collapse_vars: true, unused: false }, mangle: false });
+  eq(r.code, 'function f(){var x=5;return 6}', 'compress-collapse_vars');
+
+  r = await minify('function f(){ var x = 5; var y = 10; return y; }', { compress: { unused: true }, mangle: false });
+  eq(r.code, 'function f(){return 10}', 'compress-unused');
+
+  r = await minify('var x = 1; var y = x + 1; var z = y + 1; console.log(z);', { compress: { passes: 2 }, mangle: false });
+  eq(r.code, 'var x=1,y=x+1,z=y+1;console.log(z);', 'compress-passes2');
+
+  r = await minify('function f(){ pure(1); return 2; }', { compress: { pure_funcs: ['pure'] }, mangle: false });
+  eq(r.code, 'function f(){return 2}', 'compress-pure_funcs');
+
+  r = await minify('a();b();c();', { compress: { sequences: false }, mangle: false });
+  eq(r.code, 'a();b();c();', 'compress-sequences-off');
+
+  r = await minify('a();b();c();', { compress: { sequences: true }, mangle: false });
+  eq(r.code, 'a(),b(),c();', 'compress-sequences-on');
+
+  r = await minify('var a=1; var b=2;', { compress: { join_vars: true }, mangle: false });
+  eq(r.code, 'var a=1,b=2;', 'compress-join_vars');
+
+  r = await minify('var unusedVar = 5; function used(){return 1;} used();', { compress: { toplevel: true, unused: true }, mangle: false });
+  eq(r.code, '', 'compress-toplevel-unused');
+
+  r = await minify('if(typeof x === "undefined"){}', { compress: { typeofs: true }, mangle: false });
+  eq(r.code, '', 'compress-typeofs');
+
+  r = await minify('if(DEBUG){console.log("x");} keep();', { compress: { global_defs: { DEBUG: false } }, mangle: false });
+  eq(r.code, 'keep();', 'compress-global_defs');
+
+  r = await minify('(function(){foo();})();', { compress: true, mangle: false });
+  eq(r.code, 'foo();', 'compress-iife-inline');
+
+  r = await minify('for(var i=0;i<10;i++){a();b();}', { compress: true, mangle: false });
+  eq(r.code, 'for(var i=0;i<10;i++)a(),b();', 'compress-for-sequences');
+
+  // booleans: !!a in value position stays
+  r = await minify('var x = !!a;', { compress: { booleans: true }, mangle: false });
+  eq(r.code, 'var x=!!a;', 'compress-booleans-value');
+
+  // ---- format / output options ------------------------------------------
+  r = await minify('function f(){return 1;}', { format: { beautify: true }, mangle: false, compress: false });
+  eq(r.code, 'function f() {\n    return 1;\n}', 'format-beautify');
+
+  r = await minify('function f(){return 1;}', { format: { beautify: true, indent_level: 2 }, mangle: false, compress: false });
+  eq(r.code, 'function f() {\n  return 1;\n}', 'format-indent_level');
+
+  r = await minify('var a=1;var b=2;', { output: { beautify: true }, compress: false, mangle: false });
+  eq(r.code, 'var a = 1;\n\nvar b = 2;', 'format-output-alias');
+
+  r = await minify('/* keep */ function f(){return 1;} // line', { format: { comments: 'all' }, mangle: false, compress: false });
+  eq(r.code, '/* keep */function f(){return 1}// line', 'format-comments-all');
+
+  r = await minify('/*! bang */ function f(){return 1;}', { format: { comments: true }, mangle: false, compress: false });
+  eq(r.code, '/*! bang */function f(){return 1}', 'format-comments-true');
+
+  r = await minify('/*@preserve me*/ /*nope*/ var x=1;', { format: { comments: /@preserve/ }, mangle: false, compress: false });
+  eq(r.code, '/*@preserve me*/var x=1;', 'format-comments-regex');
+
+  r = await minify('/*@license keep*/ /*drop*/ var x=1;',
+                   { format: { comments: function (node, comment) { return /@license/.test(comment.value); } }, mangle: false, compress: false });
+  eq(r.code, '/*@license keep*/var x=1;', 'format-comments-function');
+
+  r = await minify('var a=1;var b=2;', { format: { semicolons: false }, mangle: false, compress: false });
+  eq(r.code, 'var a=1\nvar b=2\n', 'format-semicolons-false');
+
+  r = await minify('var s = "é中";', { format: { ascii_only: true }, mangle: false, compress: false });
+  eq(r.code, 'var s="\\xe9\\u4e2d";', 'format-ascii_only');
+
+  r = await minify('var s = "hello";', { format: { quote_style: 1 }, mangle: false, compress: false });
+  eq(r.code, "var s='hello';", 'format-quote_style-1-single');
+
+  r = await minify("var s = 'hello';", { format: { quote_style: 0 }, mangle: false, compress: false });
+  eq(r.code, 'var s="hello";', 'format-quote_style-0-prefer-double');
+
+  r = await minify("var s = 'hello';", { format: { quote_style: 3 }, mangle: false, compress: false });
+  eq(r.code, "var s='hello';", 'format-quote_style-3-original');
+
+  r = await minify('var o = {a:1, b:2};', { format: { quote_keys: true }, compress: false, mangle: false });
+  eq(r.code, 'var o={"a":1,"b":2};', 'format-quote_keys');
+
+  r = await minify('var s = "</script>";', { format: { inline_script: true }, compress: false, mangle: false });
+  eq(r.code, 'var s="<\\/script>";', 'format-inline_script');
+
+  r = await minify('var aaa=1;var bbb=2;var ccc=3;', { format: { max_line_len: 10 }, compress: false, mangle: false });
+  eq(r.code, 'var aaa=1\n;var bbb=2\n;var ccc=3;', 'format-max_line_len');
+
+  r = await minify('var x=1;', { format: { preamble: '/* banner */' }, compress: false, mangle: false });
+  eq(r.code, '/* banner */\nvar x=1;', 'format-preamble');
+
+  // ---- ecma targets ------------------------------------------------------
+  r = await minify('var o = { foo: foo, bar: bar };', { ecma: 2015, mangle: false, compress: true });
+  eq(r.code, 'var o={foo,bar};', 'ecma2015-shorthand');
+
+  r = await minify('var x = a ?? b;', { ecma: 2020, mangle: false, compress: false });
+  eq(r.code, 'var x=a??b;', 'ecma2020-nullish');
+
+  r = await minify('[1,2].map(function(x){return x*2;});', { compress: true, mangle: false, ecma: 5 });
+  eq(r.code, '[1,2].map((function(x){return 2*x}));', 'ecma5-no-arrow');
+
+  r = await minify('const f = (...args) => args.reduce((a,b)=>a+b, 0); console.log(f(1,2,3));',
+                   { compress: true, mangle: true, ecma: 2015 });
+  eq(r.code, 'const f=(...o)=>o.reduce(((o,c)=>o+c),0);console.log(f(1,2,3));', 'ecma2015-arrow-spread');
+
+  // ---- module mode -------------------------------------------------------
+  r = await minify('function foo(){return 1} export { foo };', { module: true, mangle: true });
+  eq(r.code, 'function n(){return 1}export{n as foo};', 'module-mode-mangle-export');
+
+  // ---- parse options -----------------------------------------------------
+  r = await minify('return 42;', { parse: { bare_returns: true }, compress: false, mangle: false });
+  eq(r.code, 'return 42;', 'parse-bare_returns');
+
+  // ---- keep_classnames / keep_fnames ------------------------------------
+  r = await minify('class MyClass{ method(){return 1;} } new MyClass().method();',
+                   { mangle: { toplevel: true }, keep_classnames: true, compress: false });
+  eq(r.code, 'class MyClass{method(){return 1}}(new MyClass).method();', 'keep_classnames-true');
+
+  r = await minify('class MyClass{ method(){return 1;} } new MyClass().method();',
+                   { mangle: { toplevel: true }, keep_classnames: false, compress: false });
+  eq(r.code, 'class e{method(){return 1}}(new e).method();', 'keep_classnames-false');
+
+  r = await minify('function longFnName(){return 1;} longFnName();',
+                   { mangle: { toplevel: true }, keep_fnames: true, compress: false });
+  eq(r.code, 'function longFnName(){return 1}longFnName();', 'keep_fnames-true');
+
+  r = await minify('function longFnName(){return 1;} longFnName();',
+                   { mangle: { toplevel: true }, keep_fnames: false, compress: false });
+  eq(r.code, 'function n(){return 1}n();', 'keep_fnames-false');
+
+  // ---- whitespace-only (no compress, no mangle) --------------------------
+  r = await minify('function  f ( a ,  b ) {  return  a  +  b ; }', { compress: false, mangle: false });
+  eq(r.code, 'function f(a,b){return a+b}', 'whitespace-only');
+
+  // ---- number formatting -------------------------------------------------
+  r = await minify('var x = 1000000;', { compress: false, mangle: false });
+  eq(r.code, 'var x=1e6;', 'number-1e6');
+  r = await minify('var x = 0.5;', { compress: false, mangle: false });
+  eq(r.code, 'var x=.5;', 'number-leading-dot');
+  r = await minify('var x = 255;', { compress: false, mangle: false });
+  eq(r.code, 'var x=255;', 'number-255');
+
+  // ---- multiple files (object form) -------------------------------------
+  r = await minify({ 'a.js': 'var a = 1;', 'b.js': 'var b = 2; console.log(a+b);' }, { compress: false, mangle: false });
+  eq(r.code, 'var a=1;var b=2;console.log(a+b);', 'multifile-object-form');
+
+  // ---- realistic end-to-end default --------------------------------------
+  r = await minify([
+    'function calculate(input) {',
+    '  var unused = 999;',
+    '  var base = 10;',
+    '  var result = base * input;',
+    '  if (false) { result = 0; }',
+    '  return result;',
+    '}',
+    'console.log(calculate(5));'
+  ].join('\n'));
+  eq(r.code, 'function calculate(c){var l=10*c;return l}console.log(calculate(5));', 'realistic-default');
+
+  // ---- sourceMap ---------------------------------------------------------
+  r = await minify('function foo(bar){return bar+1;}', { sourceMap: true });
+  chk(typeof r.map === 'string', 'sourceMap-map-is-string');
+  let m = JSON.parse(r.map);
+  eq(m.version, 3, 'sourceMap-version-3');
+  chk(typeof m.mappings === 'string' && m.mappings.length > 0, 'sourceMap-has-mappings');
+
+  r = await minify({ 'in.js': 'function foo(bar){return bar+1;}' }, { sourceMap: { url: 'out.js.map', filename: 'out.js' } });
+  eq(r.code.split('\n').pop(), '//# sourceMappingURL=out.js.map', 'sourceMap-url-comment');
+  m = JSON.parse(r.map);
+  eq(JSON.stringify(m.sources), JSON.stringify(['in.js']), 'sourceMap-sources');
+  eq(m.file, 'out.js', 'sourceMap-file');
+
+  r = await minify({ 'in.js': 'var x=1;' }, { sourceMap: { includeSources: true } });
+  m = JSON.parse(r.map);
+  eq(JSON.stringify(m.sourcesContent), JSON.stringify(['var x=1;']), 'sourceMap-includeSources');
+
+  // ---- nameCache: two-call name stability --------------------------------
+  const cache = {};
+  let r1 = await minify('function libFunc(longArgName){return longArgName+1;} libFunc(globalThing);',
+                        { mangle: { toplevel: true }, nameCache: cache, compress: false });
+  eq(r1.code, 'function n(n){return n+1}n(globalThing);', 'nameCache-call1');
+  chk(!!cache.vars, 'nameCache-populated');
+  let r2 = await minify('libFunc(anotherGlobal);', { mangle: { toplevel: true }, nameCache: cache, compress: false });
+  eq(r2.code, 'n(anotherGlobal);', 'nameCache-call2-stable');
+
+  // ---- minify_sync -------------------------------------------------------
+  let rs = minify_sync('function f(x){return x*2;}');
+  eq(rs.code, 'function f(n){return 2*n}', 'minify_sync-valid');
+  chk(rs.error === undefined, 'minify_sync-no-error');
+
+  // ---- empty input -------------------------------------------------------
+  r = await minify('');
+  eq(r.code, '', 'empty-input');
+
+  // ---- error path: invalid JS rejects (async) and throws (sync) ----------
+  let threw = false, errname = '';
+  try { await minify('function (){'); }
+  catch (e) { threw = true; errname = e.name; }
+  chk(threw, 'invalid-js-async-rejects');
+  eq(errname, 'SyntaxError', 'invalid-js-error-name');
+
+  let threwSync = false;
+  try { minify_sync('var a = ;'); }
+  catch (e) { threwSync = true; }
+  chk(threwSync, 'invalid-js-sync-throws');
+
+  // ---- final result line -------------------------------------------------
+  console.log('TERSER_RESULT ok=' + ok + ' fail=' + fail);
+  if (fail === 0) console.log('TERSER_DONE');
+  process.exit(fail === 0 ? 0 : 1);
+})().catch((e) => {
+  console.log('FATAL ' + (e && e.stack ? e.stack : e));
+  console.log('TERSER_RESULT ok=' + ok + ' fail=' + (fail + 1));
+  process.exit(1);
+});

--- a/apps/starry/node-lib/programs/run-nlib.sh
+++ b/apps/starry/node-lib/programs/run-nlib.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# run-nlib.sh — on-target gate for the StarryOS node-lib carpet.
+# Industrial-grade carpets for the common Node.js libraries less / stylus / scss(sass) /
+# @babel/core (+ TS/JSX presets) / terser / eslint and CommonJS<->ESM interop. Each carpet
+# self-checks (XXX_RESULT ok=N fail=0 then XXX_DONE); TEST PASSED only when every module passes.
+set -u
+case "$(uname -m)" in x86_64) A=x86_64;; aarch64) A=aarch64;; riscv64) A=riscv64;; loongarch64) A=loongarch64;; *) A="$(uname -m)";; esac
+printf '/lib\n/usr/lib\n' > "/etc/ld-musl-$A.path"
+export PATH=/usr/bin:/bin:/sbin:/usr/sbin HOME=/root CI=1
+export NODE_OPTIONS="--max-old-space-size=1024"
+NODE=/usr/bin/node
+D=/root/nlib
+
+NF=""
+"$NODE" -e 'process.exit(0)' >/tmp/probe.out 2>&1
+if [ $? -ne 0 ]; then echo "JIT probe failed -> --jitless"; tail -3 /tmp/probe.out; NF="--jitless"; export NODE_OPTIONS="$NODE_OPTIONS --jitless"; fi
+echo "=== node $("$NODE" $NF --version 2>&1) ==="
+
+cd "$D" || { echo "TEST FAILED"; exit 1; }
+PASS=0; TOTAL=0
+run(){ name="$1"; mk="$2"; js="$3"; TOTAL=$((TOTAL+1)); "$NODE" $NF "$js" >"/tmp/$name.out" 2>&1
+  if grep -aq "$mk" "/tmp/$name.out" 2>/dev/null; then
+    echo "  OK   $name ($(grep -aE '_RESULT ok=[0-9]+ fail=[0-9]+' "/tmp/$name.out" | head -1))"; PASS=$((PASS+1))
+  else echo "  FAIL $name ($mk)"; grep -aiE 'FAIL|error|exception|throw|cannot' "/tmp/$name.out" | tail -6; fi; }
+
+echo "=== node-lib: library carpets (less/stylus/scss | babel/terser/eslint | cjs-esm) ==="
+run less    LESS_DONE    carpets/LessCarpet.js
+run stylus  STYLUS_DONE  carpets/StylusCarpet.js
+run scss    SCSS_DONE    carpets/ScssCarpet.js
+run babel   BABEL_DONE   carpets/BabelCarpet.js
+run terser  TERSER_DONE  carpets/TerserCarpet.js
+run eslint  ESLINT_DONE  carpets/EslintCarpet.js
+run cjsesm  CJSESM_DONE  carpets/CjsEsmCarpet.js
+echo "AGGREGATE: PASS=$PASS TOTAL=$TOTAL"
+if [ "$PASS" = "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then echo "NODE_LIB_OK=$PASS/$TOTAL"; echo "TEST PASSED"; exit 0; fi
+echo "TEST FAILED"; exit 1

--- a/apps/starry/node-lib/qemu-aarch64.toml
+++ b/apps/starry/node-lib/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+# node-lib aarch64 — less/stylus/scss/babel/terser/eslint library carpet on Node.js v22.22.2.
+# -cpu cortex-a72 so qemu virt brings up a 64-bit core (the default would be AArch32). The
+# rootfs is the per-app rootfs-aarch64-alpine.img which prebuild.sh grows to 2 GiB. Full V8 JIT.
+args = [
+    "-nographic", "-m", "2048M", "-smp", "1", "-cpu", "cortex-a72",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-nlib.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 7200

--- a/apps/starry/node-lib/qemu-loongarch64.toml
+++ b/apps/starry/node-lib/qemu-loongarch64.toml
@@ -1,0 +1,18 @@
+# node-lib loongarch64 — less/stylus/scss/babel/terser/eslint library carpet on Node.js v22.22.2.
+# Platform: dynamic (axplat-dyn), same as aarch64/riscv64 — build-loongarch64*.toml carries no
+# ax-hal/loongarch64-qemu-virt / plat-static / plat_dyn=false (mirrors the riscv64 dynamic
+# config); uefi=false / to_bin=true is the dynamic platform's raw-binary boot path. The rootfs
+# is the per-app rootfs-loongarch64-alpine.img which prebuild.sh grows to 2 GiB. Full V8 JIT.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-nlib.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/node-lib/qemu-riscv64.toml
+++ b/apps/starry/node-lib/qemu-riscv64.toml
@@ -1,0 +1,16 @@
+# node-lib riscv64 — less/stylus/scss/babel/terser/eslint library carpet on Node.js v22.22.2.
+# Dynamic platform (axplat-dyn), raw-binary boot. The rootfs is the per-app
+# rootfs-riscv64-alpine.img which prebuild.sh grows to 2 GiB. Full V8 JIT under TCG (slow).
+args = [
+    "-nographic", "-m", "2048M", "-smp", "1", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-nlib.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/node-lib/qemu-x86_64.toml
+++ b/apps/starry/node-lib/qemu-x86_64.toml
@@ -1,0 +1,17 @@
+# node-lib x86_64 — less/stylus/scss/babel/terser/eslint library carpet on Node.js v22.22.2.
+# x86_64 boots the ELF kernel via the dynamic platform + OVMF (xtask prepares firmware
+# automatically). The rootfs is the per-app rootfs-x86_64-alpine.img which prebuild.sh grows
+# to 2 GiB so the node apk closure + node_modules fit. Node runs full V8 JIT (no kernel change).
+args = [
+    "-nographic", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-nlib.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 7200


### PR DESCRIPTION
## 概述

新增 `apps/starry/node-lib` —— 在 StarryOS 上用 Node.js 22（全 V8 JIT，零内核改动）测试一组常用 Node.js 类库，四架构（x86_64 / aarch64 / riscv64 / loongarch64）单核 qemu-10 运行。

CSS 预处理器与 JS 转换的输出对照该版本下文档化行为算出的精确 golden 逐字节比对，eslint 对照精确诊断（ruleId / messageId / line / col / severity）；模块内部 fail 计数为 0 时才打印 `*_DONE` marker。`run-nlib.sh` 跑全部 7 个模块，PASS == TOTAL 才输出 `TEST PASSED`。合计 7 模块 / 961 条断言。

## 覆盖

| 模块 | 类库 | 维度 | 断言 |
|:--|:--|:--|--:|
| less | less 4.2.2 | render API + 变量 / 算术 / 嵌套 / mixin / guard / extend / map / @import / 内置函数 / plugin → 逐字节 CSS | 110 |
| stylus | stylus 0.64.0 | render + JS `define`/`set` API / mixin / 条件 / 迭代 / hash / 内置 / @extend → 逐字节 CSS | 117 |
| scss | sass 1.83.4（Dart Sass） | compileString/compile + @mixin/@function / 控制流 / `sass:*` 模块 / @use / @extend / map → 精确 CSS | 98 |
| babel | @babel/core 7.26.0 | transformSync + preset-typescript（TS 去类型）+ preset-react（JSX）+ 自定义 plugin / parse / AST 往返 | 115 |
| terser | terser 5.37.0 | minify + mangle / compress / format / sourceMap / nameCache 选项 → 精确压缩产物 | 83 |
| eslint | eslint 9.18.0 | `Linter`/`ESLint` flat-config lint：精确诊断（ruleId / messageId / line / col / severity）+ `verifyAndFix` | 330 |
| cjsesm | Node ESM/CJS | CommonJS↔ESM 互操作：require / 动态 import / `data:` URL / createRequire / 循环解析 → 精确值 | 108 |

## 验证

四架构单核 qemu-10 StarryOS 实测，`AGGREGATE PASS=7/7` + `NODE_LIB_OK=7/7` + `TEST PASSED`：

| 架构 | 结果 |
|:--:|:--:|
| x86_64 | 7/7 |
| aarch64 | 7/7 |
| riscv64 | 7/7 |
| loongarch64 | 7/7 |

运行：`cargo xtask starry app qemu -t node-lib --arch <arch>`。`prebuild.sh` 在 staging rootfs 里经 qemu-user-static `apk add nodejs icu-data-full`（Alpine v3.22 main+community，解析当前 Node 22，不钉死会漂移的 URL），把 node 二进制 + 其 `.so` 闭包 + ICU 数据注入 per-app overlay 的 `/usr`，把类库的 `node_modules` 闭包与 carpet 源注入 `/root/nlib`。Node 在四架构均跑全 V8 JIT（启动脚本带 JIT 探测兜底，无需 `--jitless`、无内核改动）。开发者本地若已有该 apk 闭包可设 `NODE_DL_ROOT` 指向缓存短路（仅作 fallback，缓存缺失走网络 apk）。
