### PR TITLE
fix(starry-kernel): sync riscv ptrace single-step text

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -1182,6 +1182,7 @@ pub fn ptrace_setup_singlestep(
     let saved = tracee.take_ptrace_ss_saved_insn_for(tid);
     if let Some((saved_addr, saved_insn)) = saved {
         let _ = ptrace_write_u16_unlocked(&mut aspace, saved_addr, saved_insn as u16);
+        let _ = aspace.sync_modified_text(VirtAddr::from_usize(saved_addr), size_of::<u16>());
     }
 
     let first_half = match ptrace_read_u16_unlocked(&mut aspace, pc) {
@@ -1217,7 +1218,7 @@ pub fn ptrace_setup_singlestep(
     };
     if orig_insn == EBREAK_INSN {
         tracee.set_ptrace_ss_saved_insn_for(tid, None);
-        ax_runtime::hal::cache::flush_icache_all();
+        let _ = aspace.sync_modified_text(VirtAddr::from_usize(next_insn_addr), size_of::<u16>());
         return;
     }
 
@@ -1226,7 +1227,7 @@ pub fn ptrace_setup_singlestep(
         return;
     }
     tracee.set_ptrace_ss_saved_insn_for(tid, Some((next_insn_addr, orig_insn as usize)));
-    ax_runtime::hal::cache::flush_icache_all();
+    let _ = aspace.sync_modified_text(VirtAddr::from_usize(next_insn_addr), size_of::<u16>());
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -1328,11 +1329,13 @@ pub fn ptrace_restore_singlestep_insn(
     let aspace = tracee.aspace();
     let mut aspace = aspace.lock();
     let restored = ptrace_write_u16_unlocked(&mut aspace, addr, insn as u16).is_ok();
-    ax_runtime::hal::cache::flush_icache_all();
-    if !restored {
+    let synced = aspace
+        .sync_modified_text(VirtAddr::from_usize(addr), size_of::<u16>())
+        .is_ok();
+    if !(restored && synced) {
         tracee.set_ptrace_ss_saved_insn_for(tid, Some((addr, insn)));
     }
-    restored
+    restored && synced
 }
 
 #[cfg(any(target_arch = "aarch64", target_arch = "loongarch64"))]


### PR DESCRIPTION
## 问题

CI 的 `Test starry riscv64 qemu / run_container` job 在 `test-ptrace-gdb` 中失败：`PTRACE_SINGLESTEP` 跑到控制流目标后，目标侧副作用已经提前发生，说明临时单步断点没有被执行端稳定看见。

根因是 RISC-V ptrace 单步通过改写用户态指令为临时 `ebreak` 来模拟 single-step，但写入/恢复指令后只做了全局 icache flush，没有走用户地址空间的 modified text 同步路径。这样在 CI 的 QEMU/缓存模型下，刚写入的临时断点或恢复后的原指令可能没有按对应物理页完成 text 同步，导致执行 stale instruction。

## 修改

- RISC-V `ptrace_setup_singlestep` 在恢复上一次保存的指令后，对对应用户 text 地址调用 `AddrSpace::sync_modified_text`。
- 写入临时 `ebreak` 后，按被修改地址和 `u16` 指令宽度同步 modified text。
- RISC-V `ptrace_restore_singlestep_insn` 恢复原指令后同步 modified text；如果写回或同步失败，保留 saved instruction，后续仍可重试恢复。

## 验证

- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp1/system/test-ptrace-gdb`
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp1/system`
- `cargo fmt --check`
- `git diff --check HEAD^ HEAD`