### PR TITLE
refactor(axvm): redesign VM lifecycle state machine

### DIFF
--- a/os/axvisor/src/config.rs
+++ b/os/axvisor/src/config.rs
@@ -196,10 +196,9 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
     let mut loader = ImageLoader::new(main_mem, vm_create_config, vm.clone());
     loader.load()?;
 
-    vm.init()
+    vm.prepare()
         .map_err(|e| ax_err_type!(InvalidData, format!("VM[{}] setup failed: {e:?}", vm.id())))?;
 
-    vm.set_vm_status(axvm::VMStatus::Loaded);
     if !axvm::register_vm(vm) {
         return Err(ax_err_type!(
             AlreadyExists,

--- a/os/axvisor/src/manager.rs
+++ b/os/axvisor/src/manager.rs
@@ -59,6 +59,11 @@ impl AxvmManager {
         AxvmRuntime::resume_vm(vm_id)
     }
 
+    /// Reset a VM by ID.
+    pub fn reset_vm(vm_id: VMId) -> AxResult {
+        AxvmRuntime::reset_vm(vm_id)
+    }
+
     /// Remove a VM by ID.
     pub fn remove_vm(vm_id: VMId) -> Option<AxVMRef> {
         #[cfg(target_arch = "loongarch64")]

--- a/os/axvisor/src/shell/command/vm.rs
+++ b/os/axvisor/src/shell/command/vm.rs
@@ -20,7 +20,7 @@ use std::{
     vec::Vec,
 };
 
-use axvm::{VCpuState, VMStatus};
+use axvm::{StopReason, VCpuState, VmStatus};
 #[cfg(feature = "fs")]
 use std::fs::read_to_string;
 
@@ -28,54 +28,66 @@ use crate::shell::command::{CommandNode, FlagDef, OptionDef, ParsedCommand};
 
 /// Check if a VM can transition to Running state.
 /// Returns Ok(()) if the transition is valid, Err with a message otherwise.
-fn can_start_vm(status: VMStatus) -> Result<(), &'static str> {
+fn can_start_vm(status: VmStatus) -> Result<(), &'static str> {
     match status {
-        VMStatus::Loaded | VMStatus::Stopped => Ok(()),
-        VMStatus::Running => Err("VM is already running"),
-        VMStatus::Suspended => Err("VM is suspended, use 'vm resume' instead"),
-        VMStatus::Stopping => Err("VM is stopping, wait for it to fully stop"),
-        VMStatus::Loading => Err("VM is still loading"),
+        VmStatus::Ready | VmStatus::Stopped => Ok(()),
+        VmStatus::Running => Err("VM is already running"),
+        VmStatus::Paused => Err("VM is suspended, use 'vm resume' instead"),
+        VmStatus::Stopping => Err("VM is stopping, wait for it to fully stop"),
+        VmStatus::Uninit => Err("VM is still loading"),
+        VmStatus::Pausing => Err("VM is pausing"),
+        VmStatus::Destroying | VmStatus::Destroyed => Err("VM is being destroyed"),
+        VmStatus::Failed => Err("VM is failed"),
     }
 }
 
 /// Check if a VM can transition to Stopping state.
 /// Returns Ok(()) if the transition is valid, Err with a message otherwise.
-fn can_stop_vm(status: VMStatus, force: bool) -> Result<(), &'static str> {
+fn can_stop_vm(status: VmStatus, force: bool) -> Result<(), &'static str> {
     match status {
-        VMStatus::Running | VMStatus::Suspended => Ok(()),
-        VMStatus::Stopping => {
+        VmStatus::Running | VmStatus::Paused => Ok(()),
+        VmStatus::Stopping => {
             if force {
                 Ok(())
             } else {
                 Err("VM is already stopping")
             }
         }
-        VMStatus::Stopped => Err("VM is already stopped"),
-        VMStatus::Loading | VMStatus::Loaded => Ok(()), // Allow stopping VMs in these states
+        VmStatus::Stopped => Err("VM is already stopped"),
+        VmStatus::Uninit | VmStatus::Ready => Ok(()), // Allow stopping VMs in these states
+        VmStatus::Pausing => Err("VM is pausing"),
+        VmStatus::Destroying | VmStatus::Destroyed => Err("VM is being destroyed"),
+        VmStatus::Failed => Err("VM is failed"),
     }
 }
 
 /// Check if a VM can be suspended.
-fn can_suspend_vm(status: VMStatus) -> Result<(), &'static str> {
+fn can_suspend_vm(status: VmStatus) -> Result<(), &'static str> {
     match status {
-        VMStatus::Running => Ok(()),
-        VMStatus::Suspended => Err("VM is already suspended"),
-        VMStatus::Stopped => Err("VM is stopped, cannot suspend"),
-        VMStatus::Stopping => Err("VM is stopping, cannot suspend"),
-        VMStatus::Loading => Err("VM is loading, cannot suspend"),
-        VMStatus::Loaded => Err("VM is not running, cannot suspend"),
+        VmStatus::Running => Ok(()),
+        VmStatus::Paused => Err("VM is already suspended"),
+        VmStatus::Stopped => Err("VM is stopped, cannot suspend"),
+        VmStatus::Stopping => Err("VM is stopping, cannot suspend"),
+        VmStatus::Uninit => Err("VM is loading, cannot suspend"),
+        VmStatus::Ready => Err("VM is not running, cannot suspend"),
+        VmStatus::Pausing => Err("VM is already pausing"),
+        VmStatus::Destroying | VmStatus::Destroyed => Err("VM is being destroyed"),
+        VmStatus::Failed => Err("VM is failed"),
     }
 }
 
 /// Check if a VM can be resumed.
-fn can_resume_vm(status: VMStatus) -> Result<(), &'static str> {
+fn can_resume_vm(status: VmStatus) -> Result<(), &'static str> {
     match status {
-        VMStatus::Suspended => Ok(()),
-        VMStatus::Running => Err("VM is already running"),
-        VMStatus::Stopped => Err("VM is stopped, use 'vm start' instead"),
-        VMStatus::Stopping => Err("VM is stopping, cannot resume"),
-        VMStatus::Loading => Err("VM is loading, cannot resume"),
-        VMStatus::Loaded => Err("VM is not started yet, use 'vm start' instead"),
+        VmStatus::Paused => Ok(()),
+        VmStatus::Running => Err("VM is already running"),
+        VmStatus::Stopped => Err("VM is stopped, use 'vm start' instead"),
+        VmStatus::Stopping => Err("VM is stopping, cannot resume"),
+        VmStatus::Uninit => Err("VM is loading, cannot resume"),
+        VmStatus::Ready => Err("VM is not started yet, use 'vm start' instead"),
+        VmStatus::Pausing => Err("VM is pausing, wait before resuming"),
+        VmStatus::Destroying | VmStatus::Destroyed => Err("VM is being destroyed"),
+        VmStatus::Failed => Err("VM is failed"),
     }
 }
 
@@ -105,7 +117,7 @@ fn vm_help(_cmd: &ParsedCommand) {
     println!("  stop      Stop a virtual machine");
     println!("  suspend   Suspend (pause) a running virtual machine");
     println!("  resume    Resume a suspended virtual machine");
-    println!("  restart   Restart a virtual machine");
+    println!("  reset     Reset and restart a virtual machine");
     println!("  delete    Delete a virtual machine");
     println!();
     println!("Information commands:");
@@ -181,13 +193,13 @@ fn vm_start(cmd: &ParsedCommand) {
 
         for vm in crate::manager::AxvmManager::vm_list() {
             // Check current status before starting
-            let status: VMStatus = vm.vm_status();
-            if status == VMStatus::Running {
+            let status: VmStatus = vm.status();
+            if status == VmStatus::Running {
                 println!("⚠ VM[{}] is already running, skipping", vm.id());
                 continue;
             }
 
-            if status != VMStatus::Loaded && status != VMStatus::Stopped {
+            if status != VmStatus::Ready && status != VmStatus::Stopped {
                 println!("⚠ VM[{}] is in {:?} state, cannot start", vm.id(), status);
                 continue;
             }
@@ -223,7 +235,7 @@ fn vm_start(cmd: &ParsedCommand) {
 /// Returns Ok(()) if successful, Err otherwise.
 fn start_single_vm(vm: axvm::AxVMRef) -> Result<(), &'static str> {
     let vm_id = vm.id();
-    let status = vm.vm_status();
+    let status = vm.status();
 
     // Validate state transition using helper function
     can_start_vm(status)?;
@@ -273,7 +285,7 @@ fn vm_stop(cmd: &ParsedCommand) {
 
 fn stop_vm_by_id(vm_id: usize, force: bool) {
     match crate::manager::AxvmManager::with_vm(vm_id, |vm| {
-        let status = vm.vm_status();
+        let status = vm.status();
 
         // Validate state transition using helper function
         if let Err(err) = can_stop_vm(status, force) {
@@ -283,17 +295,17 @@ fn stop_vm_by_id(vm_id: usize, force: bool) {
 
         // Print appropriate message based on status
         match status {
-            VMStatus::Stopping if force => {
+            VmStatus::Stopping if force => {
                 println!("Force stopping VM[{}]...", vm_id);
             }
-            VMStatus::Running => {
+            VmStatus::Running => {
                 if force {
                     println!("Force stopping VM[{}]...", vm_id);
                 } else {
                     println!("Gracefully stopping VM[{}]...", vm_id);
                 }
             }
-            VMStatus::Loading | VMStatus::Loaded => {
+            VmStatus::Uninit | VmStatus::Ready => {
                 println!(
                     "⚠ VM[{}] is in {:?} state, stopping anyway...",
                     vm_id, status
@@ -326,108 +338,39 @@ fn stop_vm_by_id(vm_id: usize, force: bool) {
     }
 }
 
-/// Restart a VM by stopping it (if running) and then starting it again.(functionality incomplete)
-fn vm_restart(cmd: &ParsedCommand) {
+/// Reset a VM through the AxVM lifecycle state machine.
+fn vm_reset(cmd: &ParsedCommand) {
     let args = &cmd.positional_args;
-    let force = cmd.flags.contains("force");
 
     if args.is_empty() {
         println!("Error: No VM specified");
-        println!("Usage: vm restart [OPTIONS] <VM_ID>");
+        println!("Usage: vm reset <VM_ID>");
         return;
     }
 
     for vm_name in args {
         if let Ok(vm_id) = vm_name.parse::<usize>() {
-            restart_vm_by_id(vm_id, force);
+            reset_vm_by_id(vm_id);
         } else {
             println!("Error: Invalid VM ID: {}", vm_name);
         }
     }
 }
 
-fn restart_vm_by_id(vm_id: usize, force: bool) {
-    println!("Restarting VM[{}]...", vm_id);
-
-    // Check current status
-    let Some(status) = crate::manager::AxvmManager::with_vm(vm_id, |vm| vm.vm_status()) else {
-        println!("✗ VM[{}] not found", vm_id);
-        return;
-    };
-    match status {
-        VMStatus::Stopped | VMStatus::Loaded => {
-            // VM is already stopped, just start it
-            println!("VM[{}] is already stopped, starting...", vm_id);
-            start_vm_by_id(vm_id);
-        }
-        VMStatus::Suspended | VMStatus::Running => {
-            // Stop the VM (this will wake up suspended VCpus automatically)
-            println!("Stopping VM[{}]...", vm_id);
-            stop_vm_by_id(vm_id, force);
-
-            // Wait for VM to fully stop
-            println!("Waiting for VM[{}] to stop completely...", vm_id);
-            let max_wait_iterations = 50; // 5 seconds timeout (50 * 100ms)
-            let mut iterations = 0;
-
-            loop {
-                if let Some(vm_status) =
-                    crate::manager::AxvmManager::with_vm(vm_id, |vm| vm.vm_status())
-                {
-                    match vm_status {
-                        VMStatus::Stopped => {
-                            println!("✓ VM[{}] stopped successfully", vm_id);
-                            break;
-                        }
-                        VMStatus::Stopping => {
-                            // Still stopping, wait a bit
-                            iterations += 1;
-                            if iterations >= max_wait_iterations {
-                                println!(
-                                    "⚠ VM[{}] stop timeout, it may still be shutting down",
-                                    vm_id
-                                );
-                                println!("  Use 'vm status {}' to check status manually", vm_id);
-                                return;
-                            }
-                            // Sleep for 100ms
-                            thread::sleep(core::time::Duration::from_millis(100));
-                        }
-                        _ => {
-                            println!("⚠ VM[{}] in unexpected state: {:?}", vm_id, vm_status);
-                            return;
-                        }
-                    }
-                } else {
-                    println!("✗ VM[{}] no longer exists", vm_id);
-                    return;
-                }
-            }
-
-            // Now restart the VM
-            println!("Starting VM[{}]...", vm_id);
-            start_vm_by_id(vm_id);
-        }
-        VMStatus::Stopping => {
-            if force {
-                println!(
-                    "⚠ VM[{}] is currently stopping, waiting for shutdown to complete...",
-                    vm_id
-                );
-                // Could implement similar wait logic here if needed
-            } else {
-                println!("⚠ VM[{}] is currently stopping", vm_id);
-                println!(
-                    "  Wait for shutdown to complete, then use 'vm start {}'",
-                    vm_id
-                );
-                println!("  Or use --force to wait and then restart");
-            }
-        }
-        VMStatus::Loading => {
-            println!("✗ VM[{}] is still loading, cannot restart", vm_id);
-        }
+fn reset_vm_by_id(vm_id: usize) {
+    println!("Resetting VM[{}]...", vm_id);
+    match crate::manager::AxvmManager::reset_vm(vm_id) {
+        Ok(()) => println!("✓ VM[{}] reset and started successfully", vm_id),
+        Err(err) => println!("✗ VM[{}] reset failed: {:?}", vm_id, err),
     }
+}
+
+/// Compatibility alias for the old shell command name.
+fn vm_restart(cmd: &ParsedCommand) {
+    if cmd.flags.contains("force") {
+        println!("⚠ --force is ignored; reset always rebuilds runtime state");
+    }
+    vm_reset(cmd);
 }
 
 /// Suspend a running VM (functionality incomplete)
@@ -453,14 +396,13 @@ fn suspend_vm_by_id(vm_id: usize) {
     println!("Suspending VM[{}]...", vm_id);
 
     let result: Option<Result<(), &str>> = crate::manager::AxvmManager::with_vm(vm_id, |vm| {
-        let status = vm.vm_status();
+        let status = vm.status();
 
         // Check if VM can be suspended
         can_suspend_vm(status)?;
 
-        // Set VM status to Suspended
-        vm.set_vm_status(VMStatus::Suspended);
-        info!("VM[{}] status set to Suspended", vm_id);
+        vm.pause().map_err(|_| "Failed to suspend VM")?;
+        info!("VM[{}] status set to Paused", vm_id);
 
         Ok(())
     });
@@ -551,7 +493,7 @@ fn resume_vm_by_id(vm_id: usize) {
     println!("Resuming VM[{}]...", vm_id);
 
     let result: Option<Result<(), &str>> = crate::manager::AxvmManager::with_vm(vm_id, |vm| {
-        let status = vm.vm_status();
+        let status = vm.status();
 
         // Check if VM can be resumed
         can_resume_vm(status)?;
@@ -590,14 +532,14 @@ fn vm_delete(cmd: &ParsedCommand) {
 
     if let Ok(vm_id) = vm_name.parse::<usize>() {
         // Check if VM exists and get its status first
-        let Some(status) = crate::manager::AxvmManager::with_vm(vm_id, |vm| vm.vm_status()) else {
+        let Some(status) = crate::manager::AxvmManager::with_vm(vm_id, |vm| vm.status()) else {
             println!("✗ VM[{}] not found", vm_id);
             return;
         };
 
         // Check if VM is running
         match status {
-            VMStatus::Running => {
+            VmStatus::Running => {
                 if !force {
                     println!("✗ VM[{}] is currently running", vm_id);
                     println!(
@@ -608,7 +550,7 @@ fn vm_delete(cmd: &ParsedCommand) {
                 }
                 println!("⚠ Force deleting running VM[{}]...", vm_id);
             }
-            VMStatus::Stopping => {
+            VmStatus::Stopping => {
                 if !force {
                     println!("⚠ VM[{}] is currently stopping", vm_id);
                     println!("  Wait for it to stop completely, or use '--force' to force delete");
@@ -616,7 +558,7 @@ fn vm_delete(cmd: &ParsedCommand) {
                 }
                 println!("⚠ Force deleting stopping VM[{}]...", vm_id);
             }
-            VMStatus::Stopped => {
+            VmStatus::Stopped => {
                 println!("Deleting stopped VM[{}]...", vm_id);
             }
             _ => {
@@ -637,20 +579,19 @@ fn vm_delete(cmd: &ParsedCommand) {
 fn delete_vm_by_id(vm_id: usize, keep_data: bool) {
     // First check VM status and try to stop it if running
     let vm_status = crate::manager::AxvmManager::with_vm(vm_id, |vm| {
-        let status = vm.vm_status();
+        let status = vm.status();
 
         // If VM is running, suspended, or stopping, send shutdown signal
         match status {
-            VMStatus::Running | VMStatus::Suspended | VMStatus::Stopping => {
+            VmStatus::Running | VmStatus::Paused | VmStatus::Stopping => {
                 println!(
                     "  VM[{}] is {:?}, sending shutdown signal...",
                     vm_id, status
                 );
                 let _ = crate::manager::AxvmManager::stop_vm(vm_id);
             }
-            VMStatus::Loaded => {
-                // Transition from Loaded to Stopped
-                vm.set_vm_status(VMStatus::Stopped);
+            VmStatus::Ready => {
+                let _ = vm.stop(StopReason::Forced);
             }
             _ => {}
         }
@@ -667,7 +608,10 @@ fn delete_vm_by_id(vm_id: usize, keep_data: bool) {
     // Note: This drops the reference from the global list, but the VM object
     // will only be fully destroyed when all vCPU threads exit and drop their references
     match crate::manager::AxvmManager::remove_vm(vm_id) {
-        Some(_vm) => {
+        Some(vm) => {
+            if let Err(err) = vm.destroy() {
+                println!("⚠ VM[{}] destroy failed: {:?}", vm_id, err);
+            }
             println!("✓ VM[{}] removed from VM list", vm_id);
 
             if keep_data {
@@ -698,7 +642,7 @@ fn vm_list_simple() {
     println!("ID    NAME           STATE      VCPU   MEMORY");
     println!("----  -----------    -------    ----   ------");
     for vm in vms {
-        let status = vm.vm_status();
+        let status = vm.status();
 
         // Calculate total memory size
         let total_memory: usize = vm.memory_regions().iter().map(|region| region.size()).sum();
@@ -730,7 +674,7 @@ fn vm_list(cmd: &ParsedCommand) {
         println!("{{");
         println!("  \"vms\": [");
         for (i, vm) in display_vms.iter().enumerate() {
-            let status = vm.vm_status();
+            let status = vm.status();
             let total_memory: usize = vm.memory_regions().iter().map(|region| region.size()).sum();
 
             println!("    {{");
@@ -760,7 +704,7 @@ fn vm_list(cmd: &ParsedCommand) {
         );
 
         for vm in display_vms {
-            let status = vm.vm_status();
+            let status = vm.status();
             let total_memory: usize = vm.memory_regions().iter().map(|region| region.size()).sum();
 
             // Get VCpu ID list
@@ -840,7 +784,7 @@ fn vm_show(cmd: &ParsedCommand) {
 /// Show basic VM information (default view)
 fn show_vm_basic_details(vm_id: usize, show_config: bool, show_stats: bool) {
     match crate::manager::AxvmManager::with_vm(vm_id, |vm| {
-        let status = vm.vm_status();
+        let status = vm.status();
 
         println!("VM Details: {}", vm_id);
         println!();
@@ -857,15 +801,15 @@ fn show_vm_basic_details(vm_id: usize, show_config: bool, show_stats: bool) {
 
         // Add state-specific information
         match status {
-            VMStatus::Suspended => {
+            VmStatus::Paused => {
                 println!();
                 println!("  ℹ VM is paused. Use 'vm resume {}' to continue.", vm_id);
             }
-            VMStatus::Stopped => {
+            VmStatus::Stopped => {
                 println!();
                 println!("  ℹ VM is stopped. Use 'vm delete {}' to clean up.", vm_id);
             }
-            VMStatus::Loaded => {
+            VmStatus::Ready => {
                 println!();
                 println!("  ℹ VM is ready. Use 'vm start {}' to boot.", vm_id);
             }
@@ -916,10 +860,7 @@ fn show_vm_basic_details(vm_id: usize, show_config: bool, show_stats: bool) {
         if show_stats {
             println!();
             println!("Device Summary:");
-            println!(
-                "  Registered Devices: {}",
-                vm.get_devices().devices().count()
-            );
+            println!("  Registered Devices: {}", vm.device_count());
         }
 
         println!();
@@ -935,7 +876,7 @@ fn show_vm_basic_details(vm_id: usize, show_config: bool, show_stats: bool) {
 /// Show full detailed information about a specific VM (--full flag)
 fn show_vm_full_details(vm_id: usize) {
     match crate::manager::AxvmManager::with_vm(vm_id, |vm| {
-        let status = vm.vm_status();
+        let status = vm.status();
 
         println!("=== VM Details: {} ===", vm_id);
         println!();
@@ -950,26 +891,29 @@ fn show_vm_full_details(vm_id: usize) {
         // Calculate total memory
         let total_memory: usize = vm.memory_regions().iter().map(|region| region.size()).sum();
         println!("  Memory:    {}", format_memory_size(total_memory));
-        println!("  EPT Root:  {:#x}", vm.ept_root().as_usize());
+        match vm.ept_root() {
+            Ok(root) => println!("  EPT Root:  {:#x}", root.as_usize()),
+            Err(err) => println!("  EPT Root:  unavailable ({:?})", err),
+        }
 
         // Add state-specific information
         match status {
-            VMStatus::Suspended => {
+            VmStatus::Paused => {
                 println!(
                     "    ℹ VM is paused, VCpu tasks are waiting. Use 'vm resume {}' to continue.",
                     vm_id
                 );
             }
-            VMStatus::Stopping => {
+            VmStatus::Stopping => {
                 println!("    ℹ VM is shutting down, VCpu tasks are exiting.");
             }
-            VMStatus::Stopped => {
+            VmStatus::Stopped => {
                 println!(
                     "    ℹ VM is stopped, all VCpu tasks have exited. Use 'vm delete {}' to clean up.",
                     vm_id
                 );
             }
-            VMStatus::Loaded => {
+            VmStatus::Ready => {
                 println!(
                     "    ℹ VM is ready to start. Use 'vm start {}' to boot.",
                     vm_id
@@ -1027,7 +971,7 @@ fn show_vm_full_details(vm_id: usize) {
         }
 
         // Add note for Suspended VMs
-        if status == VMStatus::Suspended {
+        if status == VmStatus::Paused {
             println!();
             println!(
                 "  Note: VCpu tasks are blocked in wait queue and will resume when VM is unpaused."
@@ -1143,7 +1087,7 @@ fn show_vm_full_details(vm_id: usize) {
 
         // Devices
         println!();
-        let device_count = vm.get_devices().devices().count();
+        let device_count = vm.device_count();
         println!("Devices:");
         println!("  Devices:        {}", device_count);
 
@@ -1232,7 +1176,11 @@ pub fn build_vm_cmd(tree: &mut BTreeMap<String, CommandNode>) {
                 .with_long("graceful"),
         );
 
-    let restart_cmd = CommandNode::new("Restart a virtual machine")
+    let reset_cmd = CommandNode::new("Reset and restart a virtual machine")
+        .with_handler(vm_reset)
+        .with_usage("vm reset <VM_ID>...");
+
+    let restart_cmd = CommandNode::new("Restart a virtual machine (alias of reset)")
         .with_handler(vm_restart)
         .with_usage("vm restart [OPTIONS] <VM_ID>...")
         .with_flag(
@@ -1308,6 +1256,7 @@ pub fn build_vm_cmd(tree: &mut BTreeMap<String, CommandNode>) {
         .add_subcommand("stop", stop_cmd)
         .add_subcommand("suspend", suspend_cmd)
         .add_subcommand("resume", resume_cmd)
+        .add_subcommand("reset", reset_cmd)
         .add_subcommand("restart", restart_cmd)
         .add_subcommand("delete", delete_cmd)
         .add_subcommand("list", list_cmd)

--- a/os/axvisor/src/vmm/mod.rs
+++ b/os/axvisor/src/vmm/mod.rs
@@ -54,17 +54,12 @@ static RUNNING_VM_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Initialize the VMM.
 ///
-/// This function creates the VM structures and sets up the primary VCpu for each VM.
+/// This function creates the VM structures. Runtime vCPU tasks are now created
+/// by the VM lifecycle state machine when a VM starts.
 pub fn init() {
     info!("Initializing VMM...");
     // Initialize guest VM according to config file.
     config::init_guest_vms();
-
-    // Setup vCPUs, spawn an ax-task for the primary vCPU.
-    info!("Setting up vcpus...");
-    for vm in vm_list::get_vm_list() {
-        vcpus::setup_vm_primary_vcpu(vm);
-    }
 
     #[cfg(all(feature = "fs", target_arch = "x86_64"))]
     release_host_filesystem_for_guest_passthrough().expect(
@@ -93,7 +88,7 @@ fn release_host_filesystem_for_guest_passthrough() -> AxResult {
 pub fn start() {
     info!("VMM starting, booting VMs...");
     for vm in vm_list::get_vm_list() {
-        match vm.boot() {
+        match vm.start() {
             Ok(_) => {
                 vcpus::notify_primary_vcpu(vm.id());
                 RUNNING_VM_COUNT.fetch_add(1, Ordering::Release);

--- a/virtualization/axvm/src/arch.rs
+++ b/virtualization/axvm/src/arch.rs
@@ -165,7 +165,7 @@ mod riscv64 {
         };
 
         let Some(injected) = crate::manager::with_vm(vm_id, |vm| {
-            if let Err(err) = vm.interrupt_fabric().pulse(irq_id) {
+            if let Err(err) = vm.pulse_interrupt(irq_id) {
                 warn!("failed to inject RISC-V virtual IRQ {irq_id}: {err:?}");
                 return false;
             }

--- a/virtualization/axvm/src/config.rs
+++ b/virtualization/axvm/src/config.rs
@@ -145,6 +145,16 @@ impl AxVMConfig {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn default_for_test(id: usize, name: &str) -> Self {
+        Self::new(AxVMConfigParams {
+            id,
+            name: String::from(name),
+            phys_cpu_ls: PhysCpuList::new(1, None, None),
+            ..Default::default()
+        })
+    }
+
     /// Returns VM id.
     pub fn id(&self) -> usize {
         self.id

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -188,6 +188,10 @@ pub(crate) fn spawn_task(task: ArceOsTaskInner) -> ArceOsAxTaskRef {
     modules::ax_task::spawn_task(task)
 }
 
+pub(crate) fn yield_now() {
+    thread::yield_now();
+}
+
 pub(crate) fn wait_queue_wait_until(
     queue: &api::task::AxWaitQueueHandle,
     condition: impl Fn() -> bool,

--- a/virtualization/axvm/src/host/task.rs
+++ b/virtualization/axvm/src/host/task.rs
@@ -18,6 +18,10 @@ pub(crate) fn spawn_task(task: TaskInner) -> AxTaskRef {
     arceos::spawn_task(task)
 }
 
+pub(crate) fn yield_now() {
+    arceos::yield_now();
+}
+
 pub(crate) fn cpu_mask_from_raw_bits(bits: usize) -> arceos::ArceOsCpuMask {
     arceos::cpu_mask_from_raw_bits(bits)
 }

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -27,6 +27,7 @@ mod arch;
 mod cache;
 mod host;
 pub mod irq;
+pub mod lifecycle;
 mod manager;
 mod percpu;
 mod runtime;
@@ -47,6 +48,7 @@ pub(crate) use host::{
     task::{AxTaskExt, AxTaskRef, TaskInner, WaitQueue, WaitQueueHandle as HostWaitQueueHandle},
 };
 pub use irq::InterruptFabric;
+pub use lifecycle::{StopReason, VmLifecycleError, VmStatus};
 pub use manager::{
     AxvmRuntime, current_vcpu_id, current_vm_id, get_vm_by_id, get_vm_list,
     inject_current_vcpu_interrupt, register_vm,
@@ -57,7 +59,7 @@ pub use runtime::loongarch_irq::{
     unregister_guest_irq_routes as unregister_loongarch_guest_irq_routes,
 };
 pub use task::{AsVCpuTask, VCpuTask};
-pub use vm::{AxVCpuRef, AxVM, AxVMRef, FwCfgDeviceConfig, VMMemoryRegion, VMStatus};
+pub use vm::{AxVCpuRef, AxVM, AxVMRef, FwCfgDeviceConfig, VMMemoryRegion};
 
 /// The architecture-independent per-CPU type.
 pub type AxVMPerCpu = axvcpu::AxPerCpu<vcpu::AxVMArchPerCpuImpl>;

--- a/virtualization/axvm/src/lifecycle/error.rs
+++ b/virtualization/axvm/src/lifecycle/error.rs
@@ -1,0 +1,57 @@
+use alloc::string::{String, ToString};
+use core::fmt;
+
+use ax_errno::{AxError, ax_err_type};
+
+use super::{StopReason, VmStatus};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VmLifecycleError {
+    InvalidTransition {
+        from: VmStatus,
+        to: VmStatus,
+        op: &'static str,
+    },
+    MissingResource(&'static str),
+    VcpuExit(String),
+    Destroy(String),
+}
+
+pub type VmLifecycleResult<T = ()> = core::result::Result<T, VmLifecycleError>;
+
+impl VmLifecycleError {
+    pub fn invalid_transition(from: VmStatus, to: VmStatus, op: &'static str) -> Self {
+        Self::InvalidTransition { from, to, op }
+    }
+
+    pub fn into_ax_error(self) -> AxError {
+        ax_err_type!(BadState, self.to_string())
+    }
+}
+
+impl fmt::Display for VmLifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VmLifecycleError::InvalidTransition { from, to, op } => {
+                write!(
+                    f,
+                    "invalid VM lifecycle transition during {op}: {from:?} -> {to:?}"
+                )
+            }
+            VmLifecycleError::MissingResource(name) => write!(f, "missing VM resource: {name}"),
+            VmLifecycleError::VcpuExit(err) => write!(f, "vCPU exited with error: {err}"),
+            VmLifecycleError::Destroy(err) => write!(f, "VM destroy failed: {err}"),
+        }
+    }
+}
+
+impl From<StopReason> for VmLifecycleError {
+    fn from(reason: StopReason) -> Self {
+        match reason {
+            StopReason::Clean => VmLifecycleError::VcpuExit(String::from("clean stop")),
+            StopReason::SystemDown => VmLifecycleError::VcpuExit(String::from("guest system down")),
+            StopReason::Forced => VmLifecycleError::VcpuExit(String::from("forced stop")),
+            StopReason::Fault(message) => VmLifecycleError::VcpuExit(message),
+        }
+    }
+}

--- a/virtualization/axvm/src/lifecycle/machine.rs
+++ b/virtualization/axvm/src/lifecycle/machine.rs
@@ -1,0 +1,494 @@
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
+
+use super::{StopReason, VmLifecycleError, VmLifecycleResult, VmStatus};
+use crate::config::AxVMConfig;
+
+pub enum Machine<R, H = ()> {
+    Uninit(Box<AxVMConfig>),
+    Ready(R),
+    Running {
+        resources: R,
+        runtime: H,
+    },
+    Pausing {
+        resources: R,
+        runtime: H,
+    },
+    Paused {
+        resources: R,
+        runtime: H,
+    },
+    Stopping {
+        resources: Option<R>,
+        runtime: Option<H>,
+        reason: StopReason,
+    },
+    Stopped {
+        resources: Option<R>,
+        reason: StopReason,
+    },
+    Destroying,
+    Destroyed,
+    Failed(String),
+    Switching,
+}
+
+impl<R, H> Machine<R, H> {
+    pub fn status(&self) -> VmStatus {
+        match self {
+            Machine::Uninit(_) => VmStatus::Uninit,
+            Machine::Ready(_) => VmStatus::Ready,
+            Machine::Running { .. } => VmStatus::Running,
+            Machine::Pausing { .. } => VmStatus::Pausing,
+            Machine::Paused { .. } => VmStatus::Paused,
+            Machine::Stopping { .. } => VmStatus::Stopping,
+            Machine::Stopped { .. } => VmStatus::Stopped,
+            Machine::Destroying => VmStatus::Destroying,
+            Machine::Destroyed => VmStatus::Destroyed,
+            Machine::Failed(_) => VmStatus::Failed,
+            Machine::Switching => VmStatus::Failed,
+        }
+    }
+
+    pub fn resources(&self) -> Option<&R> {
+        match self {
+            Machine::Ready(resources)
+            | Machine::Running { resources, .. }
+            | Machine::Pausing { resources, .. }
+            | Machine::Paused { resources, .. } => Some(resources),
+            Machine::Stopping { resources, .. } | Machine::Stopped { resources, .. } => {
+                resources.as_ref()
+            }
+            _ => None,
+        }
+    }
+
+    pub fn resources_mut(&mut self) -> Option<&mut R> {
+        match self {
+            Machine::Ready(resources)
+            | Machine::Running { resources, .. }
+            | Machine::Pausing { resources, .. }
+            | Machine::Paused { resources, .. } => Some(resources),
+            Machine::Stopping { resources, .. } | Machine::Stopped { resources, .. } => {
+                resources.as_mut()
+            }
+            _ => None,
+        }
+    }
+
+    pub fn config_mut(&mut self) -> Option<&mut AxVMConfig> {
+        match self {
+            Machine::Uninit(config) => Some(config.as_mut()),
+            _ => None,
+        }
+    }
+
+    pub fn prepare_with<F>(&mut self, f: F) -> VmLifecycleResult
+    where
+        F: FnOnce(AxVMConfig) -> VmLifecycleResult<R>,
+    {
+        let old = core::mem::replace(self, Machine::Switching);
+        match old {
+            Machine::Uninit(config) => match f(*config) {
+                Ok(resources) => {
+                    *self = Machine::Ready(resources);
+                    Ok(())
+                }
+                Err(err) => {
+                    *self = Machine::Failed(err.to_string());
+                    Err(err)
+                }
+            },
+            other => {
+                let from = other.status();
+                *self = other;
+                Err(VmLifecycleError::invalid_transition(
+                    from,
+                    VmStatus::Ready,
+                    "prepare",
+                ))
+            }
+        }
+    }
+
+    pub fn runtime(&self) -> Option<&H> {
+        match self {
+            Machine::Running { runtime, .. }
+            | Machine::Pausing { runtime, .. }
+            | Machine::Paused { runtime, .. } => Some(runtime),
+            Machine::Stopping { runtime, .. } => runtime.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub fn runtime_mut(&mut self) -> Option<&mut H> {
+        match self {
+            Machine::Running { runtime, .. }
+            | Machine::Pausing { runtime, .. }
+            | Machine::Paused { runtime, .. } => Some(runtime),
+            Machine::Stopping { runtime, .. } => runtime.as_mut(),
+            _ => None,
+        }
+    }
+
+    pub fn start_with<F>(&mut self, f: F) -> VmLifecycleResult
+    where
+        F: FnOnce(&mut R) -> VmLifecycleResult<H>,
+    {
+        let old = core::mem::replace(self, Machine::Switching);
+        match old {
+            Machine::Ready(mut resources)
+            | Machine::Stopped {
+                resources: Some(mut resources),
+                ..
+            } => match f(&mut resources) {
+                Ok(runtime) => {
+                    *self = Machine::Running { resources, runtime };
+                    Ok(())
+                }
+                Err(err) => {
+                    *self = Machine::Failed(err.to_string());
+                    Err(err)
+                }
+            },
+            other => {
+                let from = other.status();
+                *self = other;
+                Err(VmLifecycleError::invalid_transition(
+                    from,
+                    VmStatus::Running,
+                    "start",
+                ))
+            }
+        }
+    }
+
+    pub fn pause(&mut self) -> VmLifecycleResult {
+        let old = core::mem::replace(self, Machine::Switching);
+        match old {
+            Machine::Running { resources, runtime } => {
+                *self = Machine::Paused { resources, runtime };
+                Ok(())
+            }
+            other => {
+                let from = other.status();
+                *self = other;
+                Err(VmLifecycleError::invalid_transition(
+                    from,
+                    VmStatus::Paused,
+                    "pause",
+                ))
+            }
+        }
+    }
+
+    pub fn resume(&mut self) -> VmLifecycleResult {
+        let old = core::mem::replace(self, Machine::Switching);
+        match old {
+            Machine::Paused { resources, runtime } => {
+                *self = Machine::Running { resources, runtime };
+                Ok(())
+            }
+            other => {
+                let from = other.status();
+                *self = other;
+                Err(VmLifecycleError::invalid_transition(
+                    from,
+                    VmStatus::Running,
+                    "resume",
+                ))
+            }
+        }
+    }
+
+    pub fn stop_with<F>(&mut self, reason: StopReason, f: F) -> VmLifecycleResult
+    where
+        F: FnOnce(Option<&mut R>, &StopReason) -> VmLifecycleResult,
+    {
+        let old = core::mem::replace(self, Machine::Switching);
+        match old {
+            Machine::Ready(resources) => {
+                let mut resources = Some(resources);
+                if let Err(err) = f(resources.as_mut(), &reason) {
+                    *self = Machine::Failed(err.to_string());
+                    return Err(err);
+                }
+                *self = Machine::Stopped { resources, reason };
+                Ok(())
+            }
+            Machine::Running { resources, .. } | Machine::Paused { resources, .. } => {
+                let mut resources = Some(resources);
+                if let Err(err) = f(resources.as_mut(), &reason) {
+                    *self = Machine::Failed(err.to_string());
+                    return Err(err);
+                }
+                *self = Machine::Stopped { resources, reason };
+                Ok(())
+            }
+            Machine::Stopped { resources, reason } => {
+                *self = Machine::Stopped { resources, reason };
+                Ok(())
+            }
+            other => {
+                let from = other.status();
+                *self = other;
+                Err(VmLifecycleError::invalid_transition(
+                    from,
+                    VmStatus::Stopped,
+                    "stop",
+                ))
+            }
+        }
+    }
+
+    pub fn request_stop_with<F>(&mut self, reason: StopReason, f: F) -> VmLifecycleResult
+    where
+        F: FnOnce(Option<&mut R>, &StopReason) -> VmLifecycleResult,
+    {
+        let old = core::mem::replace(self, Machine::Switching);
+        match old {
+            Machine::Ready(mut resources) => {
+                f(Some(&mut resources), &reason)?;
+                *self = Machine::Stopped {
+                    resources: Some(resources),
+                    reason,
+                };
+                Ok(())
+            }
+            Machine::Running {
+                mut resources,
+                runtime,
+            }
+            | Machine::Paused {
+                mut resources,
+                runtime,
+            } => {
+                f(Some(&mut resources), &reason)?;
+                *self = Machine::Stopping {
+                    resources: Some(resources),
+                    runtime: Some(runtime),
+                    reason,
+                };
+                Ok(())
+            }
+            Machine::Stopping {
+                resources,
+                runtime,
+                reason,
+            } => {
+                *self = Machine::Stopping {
+                    resources,
+                    runtime,
+                    reason,
+                };
+                Ok(())
+            }
+            Machine::Stopped { resources, reason } => {
+                *self = Machine::Stopped { resources, reason };
+                Ok(())
+            }
+            other => {
+                let from = other.status();
+                *self = other;
+                Err(VmLifecycleError::invalid_transition(
+                    from,
+                    VmStatus::Stopping,
+                    "request_stop",
+                ))
+            }
+        }
+    }
+
+    pub fn finish_stop(&mut self) -> VmLifecycleResult {
+        let old = core::mem::replace(self, Machine::Switching);
+        match old {
+            Machine::Stopping {
+                resources, reason, ..
+            } => {
+                *self = Machine::Stopped { resources, reason };
+                Ok(())
+            }
+            Machine::Stopped { resources, reason } => {
+                *self = Machine::Stopped { resources, reason };
+                Ok(())
+            }
+            other => {
+                let from = other.status();
+                *self = other;
+                Err(VmLifecycleError::invalid_transition(
+                    from,
+                    VmStatus::Stopped,
+                    "finish_stop",
+                ))
+            }
+        }
+    }
+
+    pub fn reset_with<F>(&mut self, f: F) -> VmLifecycleResult
+    where
+        F: FnOnce(&mut R) -> VmLifecycleResult,
+    {
+        let old = core::mem::replace(self, Machine::Switching);
+        match old {
+            Machine::Ready(mut resources)
+            | Machine::Running { mut resources, .. }
+            | Machine::Paused { mut resources, .. }
+            | Machine::Stopped {
+                resources: Some(mut resources),
+                ..
+            } => {
+                f(&mut resources)?;
+                *self = Machine::Ready(resources);
+                Ok(())
+            }
+            Machine::Stopping {
+                resources: Some(mut resources),
+                ..
+            } => {
+                f(&mut resources)?;
+                *self = Machine::Ready(resources);
+                Ok(())
+            }
+            other => {
+                let from = other.status();
+                *self = other;
+                Err(VmLifecycleError::invalid_transition(
+                    from,
+                    VmStatus::Ready,
+                    "reset",
+                ))
+            }
+        }
+    }
+
+    pub fn destroy_with<F>(&mut self, f: F) -> VmLifecycleResult
+    where
+        F: FnOnce(Option<R>) -> VmLifecycleResult,
+    {
+        let old = core::mem::replace(self, Machine::Destroying);
+        match old {
+            Machine::Destroyed => {
+                *self = Machine::Destroyed;
+                Ok(())
+            }
+            Machine::Ready(resources) => {
+                f(Some(resources))?;
+                *self = Machine::Destroyed;
+                Ok(())
+            }
+            Machine::Running { resources, .. }
+            | Machine::Pausing { resources, .. }
+            | Machine::Paused { resources, .. } => {
+                f(Some(resources))?;
+                *self = Machine::Destroyed;
+                Ok(())
+            }
+            Machine::Stopping { resources, .. } | Machine::Stopped { resources, .. } => {
+                f(resources)?;
+                *self = Machine::Destroyed;
+                Ok(())
+            }
+            Machine::Uninit(_) | Machine::Failed(_) | Machine::Switching | Machine::Destroying => {
+                f(None)?;
+                *self = Machine::Destroyed;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> AxVMConfig {
+        AxVMConfig::default_for_test(1, "lifecycle-test")
+    }
+
+    #[test]
+    fn lifecycle_allows_prepare_start_pause_resume_stop_destroy() {
+        let mut machine = Machine::Uninit(Box::new(config()));
+        assert_eq!(machine.status(), VmStatus::Uninit);
+
+        machine.prepare_with(|_| Ok(7usize)).unwrap();
+        assert_eq!(machine.status(), VmStatus::Ready);
+
+        machine
+            .start_with(|resources| {
+                *resources += 1;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(machine.status(), VmStatus::Running);
+
+        machine.pause().unwrap();
+        assert_eq!(machine.status(), VmStatus::Paused);
+
+        machine.resume().unwrap();
+        assert_eq!(machine.status(), VmStatus::Running);
+
+        machine
+            .stop_with(StopReason::Clean, |resources, _| {
+                *resources.unwrap() += 1;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(machine.status(), VmStatus::Stopped);
+
+        machine
+            .destroy_with(|resources| {
+                assert_eq!(resources, Some(9));
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(machine.status(), VmStatus::Destroyed);
+    }
+
+    #[test]
+    fn lifecycle_rejects_invalid_transitions_without_changing_state() {
+        let mut machine = Machine::<usize>::Uninit(Box::new(config()));
+        let err = machine.start_with(|_| Ok(())).unwrap_err();
+        assert!(matches!(
+            err,
+            VmLifecycleError::InvalidTransition {
+                from: VmStatus::Uninit,
+                to: VmStatus::Running,
+                op: "start"
+            }
+        ));
+        assert_eq!(machine.status(), VmStatus::Uninit);
+
+        machine.prepare_with(|_| Ok(1)).unwrap();
+        let err = machine.resume().unwrap_err();
+        assert!(matches!(
+            err,
+            VmLifecycleError::InvalidTransition {
+                from: VmStatus::Ready,
+                to: VmStatus::Running,
+                op: "resume"
+            }
+        ));
+        assert_eq!(machine.status(), VmStatus::Ready);
+    }
+
+    #[test]
+    fn lifecycle_reset_drops_runtime_and_returns_to_ready() {
+        let mut machine = Machine::Ready(7usize);
+        machine.start_with(|resources| Ok(*resources + 1)).unwrap();
+        assert_eq!(machine.status(), VmStatus::Running);
+
+        machine
+            .reset_with(|resources| {
+                *resources += 10;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(machine.status(), VmStatus::Ready);
+        assert_eq!(machine.resources(), Some(&17));
+        assert!(machine.runtime().is_none());
+    }
+}

--- a/virtualization/axvm/src/lifecycle/machine.rs
+++ b/virtualization/axvm/src/lifecycle/machine.rs
@@ -28,6 +28,7 @@ pub enum Machine<R, H = ()> {
     },
     Stopped {
         resources: Option<R>,
+        runtime: Option<H>,
         reason: StopReason,
     },
     Destroying,
@@ -140,11 +141,7 @@ impl<R, H> Machine<R, H> {
     {
         let old = core::mem::replace(self, Machine::Switching);
         match old {
-            Machine::Ready(mut resources)
-            | Machine::Stopped {
-                resources: Some(mut resources),
-                ..
-            } => match f(&mut resources) {
+            Machine::Ready(mut resources) => match f(&mut resources) {
                 Ok(runtime) => {
                     *self = Machine::Running { resources, runtime };
                     Ok(())
@@ -154,6 +151,40 @@ impl<R, H> Machine<R, H> {
                     Err(err)
                 }
             },
+            Machine::Stopped {
+                resources: Some(mut resources),
+                runtime: None,
+                reason,
+            } => match f(&mut resources) {
+                Ok(runtime) => {
+                    *self = Machine::Running { resources, runtime };
+                    Ok(())
+                }
+                Err(err) => {
+                    *self = Machine::Stopped {
+                        resources: Some(resources),
+                        runtime: None,
+                        reason,
+                    };
+                    Err(err)
+                }
+            },
+            Machine::Stopped {
+                resources,
+                runtime: Some(runtime),
+                reason,
+            } => {
+                *self = Machine::Stopped {
+                    resources,
+                    runtime: Some(runtime),
+                    reason,
+                };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Stopped,
+                    VmStatus::Running,
+                    "start",
+                ))
+            }
             other => {
                 let from = other.status();
                 *self = other;
@@ -216,20 +247,47 @@ impl<R, H> Machine<R, H> {
                     *self = Machine::Failed(err.to_string());
                     return Err(err);
                 }
-                *self = Machine::Stopped { resources, reason };
+                *self = Machine::Stopped {
+                    resources,
+                    runtime: None,
+                    reason,
+                };
                 Ok(())
             }
-            Machine::Running { resources, .. } | Machine::Paused { resources, .. } => {
-                let mut resources = Some(resources);
-                if let Err(err) = f(resources.as_mut(), &reason) {
-                    *self = Machine::Failed(err.to_string());
-                    return Err(err);
-                }
-                *self = Machine::Stopped { resources, reason };
-                Ok(())
+            Machine::Running { resources, runtime } => {
+                *self = Machine::Running { resources, runtime };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Running,
+                    VmStatus::Stopped,
+                    "stop",
+                ))
             }
-            Machine::Stopped { resources, reason } => {
-                *self = Machine::Stopped { resources, reason };
+            Machine::Pausing { resources, runtime } => {
+                *self = Machine::Pausing { resources, runtime };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Pausing,
+                    VmStatus::Stopped,
+                    "stop",
+                ))
+            }
+            Machine::Paused { resources, runtime } => {
+                *self = Machine::Paused { resources, runtime };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Paused,
+                    VmStatus::Stopped,
+                    "stop",
+                ))
+            }
+            Machine::Stopped {
+                resources,
+                runtime,
+                reason,
+            } => {
+                *self = Machine::Stopped {
+                    resources,
+                    runtime,
+                    reason,
+                };
                 Ok(())
             }
             other => {
@@ -254,11 +312,16 @@ impl<R, H> Machine<R, H> {
                 f(Some(&mut resources), &reason)?;
                 *self = Machine::Stopped {
                     resources: Some(resources),
+                    runtime: None,
                     reason,
                 };
                 Ok(())
             }
             Machine::Running {
+                mut resources,
+                runtime,
+            }
+            | Machine::Pausing {
                 mut resources,
                 runtime,
             }
@@ -286,8 +349,16 @@ impl<R, H> Machine<R, H> {
                 };
                 Ok(())
             }
-            Machine::Stopped { resources, reason } => {
-                *self = Machine::Stopped { resources, reason };
+            Machine::Stopped {
+                resources,
+                runtime,
+                reason,
+            } => {
+                *self = Machine::Stopped {
+                    resources,
+                    runtime,
+                    reason,
+                };
                 Ok(())
             }
             other => {
@@ -306,13 +377,27 @@ impl<R, H> Machine<R, H> {
         let old = core::mem::replace(self, Machine::Switching);
         match old {
             Machine::Stopping {
-                resources, reason, ..
+                resources,
+                runtime,
+                reason,
             } => {
-                *self = Machine::Stopped { resources, reason };
+                *self = Machine::Stopped {
+                    resources,
+                    runtime,
+                    reason,
+                };
                 Ok(())
             }
-            Machine::Stopped { resources, reason } => {
-                *self = Machine::Stopped { resources, reason };
+            Machine::Stopped {
+                resources,
+                runtime,
+                reason,
+            } => {
+                *self = Machine::Stopped {
+                    resources,
+                    runtime,
+                    reason,
+                };
                 Ok(())
             }
             other => {
@@ -327,17 +412,27 @@ impl<R, H> Machine<R, H> {
         }
     }
 
+    pub fn take_stopped_runtime(&mut self) -> Option<H> {
+        match self {
+            Machine::Stopped { runtime, .. } => runtime.take(),
+            _ => None,
+        }
+    }
+
     pub fn reset_with<F>(&mut self, f: F) -> VmLifecycleResult
     where
         F: FnOnce(&mut R) -> VmLifecycleResult,
     {
         let old = core::mem::replace(self, Machine::Switching);
         match old {
-            Machine::Ready(mut resources)
-            | Machine::Running { mut resources, .. }
-            | Machine::Paused { mut resources, .. }
-            | Machine::Stopped {
+            Machine::Ready(mut resources) => {
+                f(&mut resources)?;
+                *self = Machine::Ready(resources);
+                Ok(())
+            }
+            Machine::Stopped {
                 resources: Some(mut resources),
+                runtime: None,
                 ..
             } => {
                 f(&mut resources)?;
@@ -345,12 +440,52 @@ impl<R, H> Machine<R, H> {
                 Ok(())
             }
             Machine::Stopping {
-                resources: Some(mut resources),
-                ..
+                resources,
+                runtime,
+                reason,
             } => {
-                f(&mut resources)?;
-                *self = Machine::Ready(resources);
-                Ok(())
+                *self = Machine::Stopping {
+                    resources,
+                    runtime,
+                    reason,
+                };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Stopping,
+                    VmStatus::Ready,
+                    "reset",
+                ))
+            }
+            Machine::Running { resources, runtime } => {
+                *self = Machine::Running { resources, runtime };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Running,
+                    VmStatus::Ready,
+                    "reset",
+                ))
+            }
+            Machine::Paused { resources, runtime } => {
+                *self = Machine::Paused { resources, runtime };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Paused,
+                    VmStatus::Ready,
+                    "reset",
+                ))
+            }
+            Machine::Stopped {
+                resources,
+                runtime: Some(runtime),
+                reason,
+            } => {
+                *self = Machine::Stopped {
+                    resources,
+                    runtime: Some(runtime),
+                    reason,
+                };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Stopped,
+                    VmStatus::Ready,
+                    "reset",
+                ))
             }
             other => {
                 let from = other.status();
@@ -379,14 +514,67 @@ impl<R, H> Machine<R, H> {
                 *self = Machine::Destroyed;
                 Ok(())
             }
-            Machine::Running { resources, .. }
-            | Machine::Pausing { resources, .. }
-            | Machine::Paused { resources, .. } => {
-                f(Some(resources))?;
-                *self = Machine::Destroyed;
-                Ok(())
+            Machine::Running { resources, runtime } => {
+                *self = Machine::Running { resources, runtime };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Running,
+                    VmStatus::Destroyed,
+                    "destroy",
+                ))
             }
-            Machine::Stopping { resources, .. } | Machine::Stopped { resources, .. } => {
+            Machine::Pausing { resources, runtime } => {
+                *self = Machine::Pausing { resources, runtime };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Pausing,
+                    VmStatus::Destroyed,
+                    "destroy",
+                ))
+            }
+            Machine::Paused { resources, runtime } => {
+                *self = Machine::Paused { resources, runtime };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Paused,
+                    VmStatus::Destroyed,
+                    "destroy",
+                ))
+            }
+            Machine::Stopping {
+                resources,
+                runtime,
+                reason,
+            } => {
+                *self = Machine::Stopping {
+                    resources,
+                    runtime,
+                    reason,
+                };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Stopping,
+                    VmStatus::Destroyed,
+                    "destroy",
+                ))
+            }
+            Machine::Stopped {
+                resources,
+                runtime: Some(runtime),
+                reason,
+            } => {
+                *self = Machine::Stopped {
+                    resources,
+                    runtime: Some(runtime),
+                    reason,
+                };
+                Err(VmLifecycleError::invalid_transition(
+                    VmStatus::Stopped,
+                    VmStatus::Destroyed,
+                    "destroy",
+                ))
+            }
+            Machine::Stopped {
+                resources,
+                runtime: None,
+                ..
+            } => {
                 f(resources)?;
                 *self = Machine::Destroyed;
                 Ok(())
@@ -431,11 +619,13 @@ mod tests {
         assert_eq!(machine.status(), VmStatus::Running);
 
         machine
-            .stop_with(StopReason::Clean, |resources, _| {
+            .request_stop_with(StopReason::Clean, |resources, _| {
                 *resources.unwrap() += 1;
                 Ok(())
             })
             .unwrap();
+        machine.finish_stop().unwrap();
+        assert_eq!(machine.take_stopped_runtime(), Some(()));
         assert_eq!(machine.status(), VmStatus::Stopped);
 
         machine
@@ -479,6 +669,11 @@ mod tests {
         let mut machine = Machine::Ready(7usize);
         machine.start_with(|resources| Ok(*resources + 1)).unwrap();
         assert_eq!(machine.status(), VmStatus::Running);
+        machine
+            .request_stop_with(StopReason::Forced, |_, _| Ok(()))
+            .unwrap();
+        machine.finish_stop().unwrap();
+        assert_eq!(machine.take_stopped_runtime(), Some(8));
 
         machine
             .reset_with(|resources| {
@@ -490,5 +685,70 @@ mod tests {
         assert_eq!(machine.status(), VmStatus::Ready);
         assert_eq!(machine.resources(), Some(&17));
         assert!(machine.runtime().is_none());
+    }
+
+    #[test]
+    fn lifecycle_rejects_reset_while_runtime_is_live() {
+        let mut machine = Machine::Ready(7usize);
+        machine.start_with(|resources| Ok(*resources + 1)).unwrap();
+
+        let err = machine.reset_with(|_| Ok(())).unwrap_err();
+
+        assert!(matches!(
+            err,
+            VmLifecycleError::InvalidTransition {
+                from: VmStatus::Running,
+                to: VmStatus::Ready,
+                op: "reset"
+            }
+        ));
+        assert_eq!(machine.status(), VmStatus::Running);
+        assert_eq!(machine.resources(), Some(&7));
+        assert_eq!(machine.runtime(), Some(&8));
+    }
+
+    #[test]
+    fn lifecycle_rejects_destroy_while_runtime_is_live() {
+        let mut machine = Machine::Ready(7usize);
+        machine.start_with(|resources| Ok(*resources + 1)).unwrap();
+
+        let err = machine.destroy_with(|_| Ok(())).unwrap_err();
+
+        assert!(matches!(
+            err,
+            VmLifecycleError::InvalidTransition {
+                from: VmStatus::Running,
+                to: VmStatus::Destroyed,
+                op: "destroy"
+            }
+        ));
+        assert_eq!(machine.status(), VmStatus::Running);
+        assert_eq!(machine.resources(), Some(&7));
+        assert_eq!(machine.runtime(), Some(&8));
+    }
+
+    #[test]
+    fn lifecycle_requires_runtime_cleanup_before_restarting_stopped_vm() {
+        let mut machine = Machine::Ready(7usize);
+        machine.start_with(|resources| Ok(*resources + 1)).unwrap();
+        machine
+            .request_stop_with(StopReason::Forced, |_, _| Ok(()))
+            .unwrap();
+        machine.finish_stop().unwrap();
+
+        let err = machine.start_with(|_| Ok(9usize)).unwrap_err();
+
+        assert!(matches!(
+            err,
+            VmLifecycleError::InvalidTransition {
+                from: VmStatus::Stopped,
+                to: VmStatus::Running,
+                op: "start"
+            }
+        ));
+        assert_eq!(machine.status(), VmStatus::Stopped);
+        assert_eq!(machine.resources(), Some(&7));
+        assert!(machine.runtime().is_none());
+        assert_eq!(machine.take_stopped_runtime(), Some(8));
     }
 }

--- a/virtualization/axvm/src/lifecycle/mod.rs
+++ b/virtualization/axvm/src/lifecycle/mod.rs
@@ -1,0 +1,9 @@
+//! VM lifecycle state machine.
+
+pub mod error;
+pub mod machine;
+pub mod status;
+
+pub use error::{VmLifecycleError, VmLifecycleResult};
+pub(crate) use machine::Machine;
+pub use status::{StopReason, VmStatus};

--- a/virtualization/axvm/src/lifecycle/status.rs
+++ b/virtualization/axvm/src/lifecycle/status.rs
@@ -1,0 +1,66 @@
+use alloc::string::String;
+use core::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StopReason {
+    Clean,
+    SystemDown,
+    Forced,
+    Fault(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VmStatus {
+    Uninit,
+    Ready,
+    Running,
+    Pausing,
+    Paused,
+    Stopping,
+    Stopped,
+    Destroying,
+    Destroyed,
+    Failed,
+}
+
+impl VmStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            VmStatus::Uninit => "uninit",
+            VmStatus::Ready => "ready",
+            VmStatus::Running => "running",
+            VmStatus::Pausing => "pausing",
+            VmStatus::Paused => "paused",
+            VmStatus::Stopping => "stopping",
+            VmStatus::Stopped => "stopped",
+            VmStatus::Destroying => "destroying",
+            VmStatus::Destroyed => "destroyed",
+            VmStatus::Failed => "failed",
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, VmStatus::Destroyed | VmStatus::Failed)
+    }
+
+    pub const fn as_str_with_icon(self) -> &'static str {
+        match self {
+            VmStatus::Uninit => "[..] uninit",
+            VmStatus::Ready => "[OK] ready",
+            VmStatus::Running => "[RUN] running",
+            VmStatus::Pausing => "[..] pausing",
+            VmStatus::Paused => "[PAUSE] paused",
+            VmStatus::Stopping => "[..] stopping",
+            VmStatus::Stopped => "[STOP] stopped",
+            VmStatus::Destroying => "[..] destroying",
+            VmStatus::Destroyed => "[DEL] destroyed",
+            VmStatus::Failed => "[ERR] failed",
+        }
+    }
+}
+
+impl fmt::Display for VmStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/virtualization/axvm/src/manager.rs
+++ b/virtualization/axvm/src/manager.rs
@@ -39,9 +39,8 @@ pub(crate) fn push_existing_vm(vm: AxVMRef) -> bool {
 
 /// Remove a VM from the process-wide AxVM runtime registry.
 pub(crate) fn remove_existing_vm(vm_id: VMId) -> Option<AxVMRef> {
-    let vm = VM_REGISTRY.lock().remove(&vm_id)?;
     crate::runtime::vcpus::cleanup_vm_vcpus(vm_id);
-    Some(vm)
+    VM_REGISTRY.lock().remove(&vm_id)
 }
 
 /// Return a VM from the process-wide AxVM runtime registry.
@@ -155,6 +154,11 @@ impl AxvmRuntime {
     /// Resume a VM selected from the runtime registry.
     pub fn resume_vm(vm_id: VMId) -> AxResult {
         crate::runtime::resume_vm(vm_id)
+    }
+
+    /// Reset a VM selected from the runtime registry.
+    pub fn reset_vm(vm_id: VMId) -> AxResult {
+        crate::runtime::reset_vm(vm_id)
     }
 
     /// Remove a VM selected from the runtime registry.

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -27,6 +27,8 @@ use ax_errno::{AxResult, ax_err, ax_err_type};
 #[cfg(target_arch = "x86_64")]
 use axvcpu::InterruptTriggerMode;
 
+use crate::{StopReason, VmStatus};
+
 /// The instantiated VM ref type (by `Arc`).
 pub type VMRef = crate::AxVMRef;
 /// The instantiated VCpu ref type (by `Arc`).
@@ -40,17 +42,13 @@ static RUNNING_VM_COUNT: AtomicUsize = AtomicUsize::new(0);
 /// Initialize runtime state for already registered VMs.
 pub fn init() {
     info!("Initializing VMM...");
-    info!("Setting up vcpus...");
-    for vm in crate::get_vm_list() {
-        vcpus::setup_vm_primary_vcpu(vm);
-    }
 }
 
 /// Start the VMM.
 pub fn start() {
     info!("VMM starting, booting VMs...");
     for vm in crate::get_vm_list() {
-        match vm.boot() {
+        match vm.start() {
             Ok(_) => {
                 RUNNING_VM_COUNT.fetch_add(1, Ordering::Release);
                 vcpus::notify_primary_vcpu(vm.id());
@@ -78,13 +76,12 @@ pub fn sub_running_vm_count(count: usize) {
 
 pub fn start_vm(vm_id: usize) -> AxResult {
     let vm = crate::get_vm_by_id(vm_id).ok_or_else(|| ax_err_type!(NotFound, "VM not found"))?;
-    let status = vm.vm_status();
-    if !matches!(status, crate::VMStatus::Loaded | crate::VMStatus::Stopped) {
+    let status = vm.status();
+    if !matches!(status, VmStatus::Ready | VmStatus::Stopped) {
         return ax_err!(BadState, "VM cannot be started from its current state");
     }
 
-    vcpus::setup_vm_primary_vcpu(vm.clone());
-    vm.boot()?;
+    vm.start()?;
     add_running_vm_count(1);
     vcpus::notify_primary_vcpu(vm_id);
     Ok(())
@@ -92,15 +89,26 @@ pub fn start_vm(vm_id: usize) -> AxResult {
 
 pub fn stop_vm(vm_id: usize) -> AxResult {
     let vm = crate::get_vm_by_id(vm_id).ok_or_else(|| ax_err_type!(NotFound, "VM not found"))?;
-    vm.shutdown()?;
+    vm.stop(StopReason::Forced)?;
     vcpus::notify_all_vcpus(vm_id);
     Ok(())
 }
 
 pub fn resume_vm(vm_id: usize) -> AxResult {
     let vm = crate::get_vm_by_id(vm_id).ok_or_else(|| ax_err_type!(NotFound, "VM not found"))?;
-    vm.set_vm_status(crate::VMStatus::Running);
+    vm.resume()?;
     vcpus::notify_all_vcpus(vm_id);
+    Ok(())
+}
+
+pub fn reset_vm(vm_id: usize) -> AxResult {
+    let vm = crate::get_vm_by_id(vm_id).ok_or_else(|| ax_err_type!(NotFound, "VM not found"))?;
+    let was_running = vm.running();
+    vm.reset()?;
+    if !was_running {
+        add_running_vm_count(1);
+    }
+    vcpus::notify_primary_vcpu(vm_id);
     Ok(())
 }
 

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -74,6 +74,17 @@ pub fn sub_running_vm_count(count: usize) {
     RUNNING_VM_COUNT.fetch_sub(count, Ordering::Release);
 }
 
+fn reset_starts_counted_runtime(previous_status: VmStatus) -> bool {
+    matches!(
+        previous_status,
+        VmStatus::Ready
+            | VmStatus::Running
+            | VmStatus::Paused
+            | VmStatus::Stopping
+            | VmStatus::Stopped
+    )
+}
+
 pub fn start_vm(vm_id: usize) -> AxResult {
     let vm = crate::get_vm_by_id(vm_id).ok_or_else(|| ax_err_type!(NotFound, "VM not found"))?;
     let status = vm.status();
@@ -103,9 +114,9 @@ pub fn resume_vm(vm_id: usize) -> AxResult {
 
 pub fn reset_vm(vm_id: usize) -> AxResult {
     let vm = crate::get_vm_by_id(vm_id).ok_or_else(|| ax_err_type!(NotFound, "VM not found"))?;
-    let was_running = vm.running();
+    let previous_status = vm.status();
     vm.reset()?;
-    if !was_running {
+    if reset_starts_counted_runtime(previous_status) {
         add_running_vm_count(1);
     }
     vcpus::notify_primary_vcpu(vm_id);
@@ -139,6 +150,27 @@ pub(crate) fn register_x86_ioapic_irq_forwarding_route_with_trigger(
     trigger: InterruptTriggerMode,
 ) {
     x86_irq::register_ioapic_irq_forwarding_route_with_trigger(guest_gsi, host_irq, trigger);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_counts_replacement_runtime_for_every_restartable_state() {
+        for status in [
+            VmStatus::Ready,
+            VmStatus::Running,
+            VmStatus::Paused,
+            VmStatus::Stopping,
+            VmStatus::Stopped,
+        ] {
+            assert!(
+                reset_starts_counted_runtime(status),
+                "reset from {status:?} starts a fresh running runtime"
+            );
+        }
+    }
 }
 
 /// Register a callback to activate one x86 guest IOAPIC GSI after the guest has

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -12,180 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{collections::BTreeMap, format, sync::Arc, vec::Vec};
-use core::sync::atomic::{AtomicUsize, Ordering};
+use alloc::format;
 
 use ax_errno::{AxResult, ax_err_type};
-use ax_kspin::SpinNoIrq as Mutex;
 #[cfg(target_arch = "riscv64")]
 use riscv_vcpu::GprIndex as RiscvGprIndex;
 
 use crate::{
-    AsVCpuTask, AxVCpuExitReason, CpuMask, GuestPhysAddr, VCpuState, VCpuTask,
+    AsVCpuTask, AxVCpuExitReason, CpuMask, GuestPhysAddr, StopReason, VCpuState, VCpuTask,
+    VmStatus,
     runtime::{VCpuRef, VMRef, sub_running_vm_count},
+    vm::{PendingInterrupt, VmRuntimeHandle},
 };
 
 const KERNEL_STACK_SIZE: usize = 0x40000; // 256 KiB
-
-#[derive(Clone, Copy, Debug)]
-enum PendingInterrupt {
-    Normal(usize),
-    #[cfg(target_arch = "loongarch64")]
-    LoongArchExternal {
-        vector: usize,
-        physical_irq: usize,
-    },
-}
-
-/// A global map that holds the vCPU task state for each VM.
-static VM_VCPU_TASKS: Mutex<BTreeMap<usize, Arc<VMVCpus>>> = Mutex::new(BTreeMap::new());
-fn get_vm_vcpus(vm_id: usize) -> Option<Arc<VMVCpus>> {
-    VM_VCPU_TASKS.lock().get(&vm_id).cloned()
-}
-
-/// A structure representing the VCpus of a specific VM, including a wait queue
-/// and a list of tasks associated with the VCpus.
-pub struct VMVCpus {
-    // The ID of the VM to which these VCpus belong.
-    _vm_id: usize,
-    // A wait queue to manage task scheduling for the VCpus.
-    wait_queue: crate::WaitQueue,
-    // A map of tasks associated with the VCpus of this VM, keyed by vCPU ID.
-    vcpu_task_list: Mutex<BTreeMap<usize, crate::AxTaskRef>>,
-    // Pending virtual interrupts that must be injected by the owning vCPU task.
-    pending_interrupts: Mutex<BTreeMap<usize, Vec<PendingInterrupt>>>,
-    /// The number of currently running or halting VCpus. Used to track when the VM is fully
-    /// shutdown.
-    ///
-    /// This number is incremented when a VCpu starts running and decremented when it exits because
-    /// of the VM being shutdown.
-    running_halting_vcpu_count: AtomicUsize,
-}
-
-impl VMVCpus {
-    /// Creates a new `VMVCpus` instance for the given VM.
-    ///
-    /// # Arguments
-    ///
-    /// * `vm` - A reference to the VM for which the VCpus are being created.
-    ///
-    /// # Returns
-    ///
-    /// A new `VMVCpus` instance with an empty task list and a fresh wait queue.
-    fn new(vm: VMRef) -> Self {
-        Self {
-            _vm_id: vm.id(),
-            wait_queue: crate::WaitQueue::new(),
-            vcpu_task_list: Mutex::new(BTreeMap::new()),
-            pending_interrupts: Mutex::new(BTreeMap::new()),
-            running_halting_vcpu_count: AtomicUsize::new(0),
-        }
-    }
-
-    /// Adds a VCpu task to the list of VCpu tasks for this VM.
-    ///
-    /// # Arguments
-    ///
-    /// * `vcpu_task` - A reference to the task associated with a VCpu that is to be added.
-    fn add_vcpu_task(&self, vcpu_id: usize, vcpu_task: crate::AxTaskRef) {
-        self.vcpu_task_list.lock().insert(vcpu_id, vcpu_task);
-        self.pending_interrupts.lock().entry(vcpu_id).or_default();
-    }
-
-    fn queue_interrupt(&self, vcpu_id: usize, vector: usize) -> AxResult<usize> {
-        let task = self
-            .vcpu_task_list
-            .lock()
-            .get(&vcpu_id)
-            .cloned()
-            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
-        let mut pending = self.pending_interrupts.lock();
-        pending
-            .entry(vcpu_id)
-            .or_default()
-            .push(PendingInterrupt::Normal(vector));
-        Ok(task.cpu_id() as usize)
-    }
-
-    #[cfg(target_arch = "loongarch64")]
-    fn queue_external_interrupt(
-        &self,
-        vcpu_id: usize,
-        vector: usize,
-        physical_irq: usize,
-    ) -> AxResult<usize> {
-        let task = self
-            .vcpu_task_list
-            .lock()
-            .get(&vcpu_id)
-            .cloned()
-            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
-        let mut pending = self.pending_interrupts.lock();
-        pending
-            .entry(vcpu_id)
-            .or_default()
-            .push(PendingInterrupt::LoongArchExternal {
-                vector,
-                physical_irq,
-            });
-        Ok(task.cpu_id() as usize)
-    }
-
-    fn drain_pending_interrupts(&self, vcpu_id: usize) -> Vec<PendingInterrupt> {
-        let mut pending = self.pending_interrupts.lock();
-        pending
-            .get_mut(&vcpu_id)
-            .map(core::mem::take)
-            .unwrap_or_default()
-    }
-
-    /// Blocks the current thread on the wait queue associated with the VCpus of this VM.
-    fn wait(&self) {
-        self.wait_queue.wait()
-    }
-
-    /// Blocks the current thread on the wait queue associated with the VCpus of this VM
-    /// until the provided condition is met.
-    fn wait_until<F>(&self, condition: F)
-    where
-        F: Fn() -> bool,
-    {
-        self.wait_queue.wait_until(condition)
-    }
-
-    #[allow(dead_code)]
-    fn notify_one(&self) {
-        // FIXME: `WaitQueue::len` is removed
-        // info!("Current wait queue length: {}", self.wait_queue.len());
-        self.wait_queue.notify_one(false);
-    }
-
-    /// Notify all waiting vCPU threads to wake up.
-    /// This is useful when shutting down a VM to ensure all vCPUs can check the shutdown flag.
-    fn notify_all(&self) {
-        self.wait_queue.notify_all(false);
-    }
-
-    /// Increments the count of running or halting VCpus by one.
-    fn mark_vcpu_running(&self) {
-        self.running_halting_vcpu_count
-            .fetch_add(1, Ordering::Relaxed);
-        // Relaxed is enough here, as we only need to ensure that the count is incremented and
-        // decremented correctly, and there is no other data synchronization needed.
-    }
-
-    /// Decrements the count of running or halting VCpus by one. Returns true if this was the last
-    /// VCpu to exit.
-    fn mark_vcpu_exiting(&self) -> bool {
-        self.running_halting_vcpu_count.fetch_update(
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-            |count| count.checked_sub(1),
-        ) == Ok(1)
-        // Relaxed is enough here, as we only need to ensure that the count is incremented and
-        // decremented correctly, and there is no other data synchronization needed.
-    }
-}
 
 /// Blocks the current thread until it is explicitly woken up, using the wait queue
 /// associated with the VCpus of the specified VM.
@@ -193,7 +33,7 @@ impl VMVCpus {
 /// # Arguments
 ///
 /// * `vm_id` - The ID of the VM whose VCpu wait queue is used to block the current thread.
-fn wait(vm_vcpus: &VMVCpus) {
+fn wait(vm_vcpus: &VmRuntimeHandle) {
     vm_vcpus.wait();
 }
 
@@ -204,7 +44,7 @@ fn wait(vm_vcpus: &VMVCpus) {
 ///
 /// * `vm_id` - The ID of the VM whose VCpu wait queue is used to block the current thread.
 /// * `condition` - A closure that returns a boolean value indicating whether the condition is met.
-fn wait_for<F>(vm_vcpus: &VMVCpus, condition: F)
+fn wait_for<F>(vm_vcpus: &VmRuntimeHandle, condition: F)
 where
     F: Fn() -> bool,
 {
@@ -219,10 +59,15 @@ where
 /// * `vm_id` - The ID of the VM whose VCpus are to be notified.
 pub(crate) fn notify_primary_vcpu(vm_id: usize) {
     // Generally, the primary VCpu is the first and **only** VCpu in the list.
-    if let Some(vm_vcpus) = get_vm_vcpus(vm_id) {
-        vm_vcpus.notify_one();
-    } else {
-        warn!("VM[{vm_id}] vCPU resources not found");
+    let Some(vm) = crate::get_vm_by_id(vm_id) else {
+        warn!("VM[{vm_id}] not found while notifying primary vCPU");
+        return;
+    };
+    if let Err(err) = vm.with_runtime(|runtime| {
+        runtime.notify_one();
+        Ok(())
+    }) {
+        warn!("VM[{vm_id}] vCPU runtime not found: {err:?}");
     }
 }
 
@@ -233,28 +78,29 @@ pub(crate) fn notify_primary_vcpu(vm_id: usize) {
 ///
 /// * `vm_id` - The ID of the VM whose VCpus should be notified.
 pub(crate) fn notify_all_vcpus(vm_id: usize) {
-    if let Some(vm_vcpus) = get_vm_vcpus(vm_id) {
-        vm_vcpus.notify_all();
+    if let Some(vm) = crate::get_vm_by_id(vm_id) {
+        let _ = vm.with_runtime(|runtime| {
+            runtime.notify_all();
+            Ok(())
+        });
     }
 }
 
 pub(crate) fn queue_interrupt(vm_id: usize, vcpu_id: usize, vector: usize) -> AxResult {
     let vm = crate::get_vm_by_id(vm_id)
         .ok_or_else(|| ax_err_type!(NotFound, format!("VM[{vm_id}] not found")))?;
-    if matches!(
-        vm.vm_status(),
-        crate::VMStatus::Stopping | crate::VMStatus::Stopped
-    ) {
+    if !matches!(vm.status(), VmStatus::Running | VmStatus::Paused) {
         return Err(ax_err_type!(
             BadState,
             format!("VM[{vm_id}] is not accepting interrupts")
         ));
     }
 
-    let vm_vcpus = get_vm_vcpus(vm_id)
-        .ok_or_else(|| ax_err_type!(NotFound, format!("VM[{vm_id}] vCPU resources not found")))?;
-    let cpu_id = vm_vcpus.queue_interrupt(vcpu_id, vector)?;
-    vm_vcpus.notify_all();
+    let cpu_id = vm.with_runtime(|runtime| runtime.queue_interrupt(vcpu_id, vector))?;
+    vm.with_runtime(|runtime| {
+        runtime.notify_all();
+        Ok(())
+    })?;
     crate::host::task::send_ipi(cpu_id);
     Ok(())
 }
@@ -268,31 +114,35 @@ pub(crate) fn queue_external_interrupt(
 ) -> AxResult {
     let vm = crate::get_vm_by_id(vm_id)
         .ok_or_else(|| ax_err_type!(NotFound, format!("VM[{vm_id}] not found")))?;
-    if matches!(
-        vm.vm_status(),
-        crate::VMStatus::Stopping | crate::VMStatus::Stopped
-    ) {
+    if !matches!(vm.status(), VmStatus::Running | VmStatus::Paused) {
         return Err(ax_err_type!(
             BadState,
             format!("VM[{vm_id}] is not accepting interrupts")
         ));
     }
 
-    let vm_vcpus = get_vm_vcpus(vm_id)
-        .ok_or_else(|| ax_err_type!(NotFound, format!("VM[{vm_id}] vCPU resources not found")))?;
-    let cpu_id = vm_vcpus.queue_external_interrupt(vcpu_id, vector, physical_irq)?;
-    vm_vcpus.notify_all();
+    let cpu_id =
+        vm.with_runtime(|runtime| runtime.queue_external_interrupt(vcpu_id, vector, physical_irq))?;
+    vm.with_runtime(|runtime| {
+        runtime.notify_all();
+        Ok(())
+    })?;
     crate::host::task::send_ipi(cpu_id);
     Ok(())
 }
 
 pub(crate) fn inject_pending_interrupts(vm_id: usize, vcpu_id: usize, vcpu: &VCpuRef) {
-    let Some(vm_vcpus) = get_vm_vcpus(vm_id) else {
-        warn!("VM[{vm_id}] vCPU resources not found, cannot drain VCpu[{vcpu_id}] interrupts");
+    let Some(vm) = crate::get_vm_by_id(vm_id) else {
+        warn!("VM[{vm_id}] not found, cannot drain VCpu[{vcpu_id}] interrupts");
+        return;
+    };
+    let Ok(interrupts) = vm.with_runtime(|runtime| Ok(runtime.drain_pending_interrupts(vcpu_id)))
+    else {
+        warn!("VM[{vm_id}] vCPU runtime not found, cannot drain VCpu[{vcpu_id}] interrupts");
         return;
     };
 
-    for interrupt in vm_vcpus.drain_pending_interrupts(vcpu_id) {
+    for interrupt in interrupts {
         match interrupt {
             PendingInterrupt::Normal(vector) => {
                 trace!("Injecting queued interrupt {vector:#x} into VM[{vm_id}] VCpu[{vcpu_id}]");
@@ -390,43 +240,22 @@ fn ipi_targets(
 /// This should be called after all VCpu threads have exited to avoid resource leaks.
 /// It will join all VCpu tasks to ensure they are fully cleaned up.
 pub(crate) fn cleanup_vm_vcpus(vm_id: usize) {
-    if let Some(vm_vcpus) = VM_VCPU_TASKS.lock().remove(&vm_id) {
-        // Take task references out before joining so we never block while
-        // holding the per-VM task-list lock.
-        let tasks: Vec<_> = vm_vcpus.vcpu_task_list.lock().values().cloned().collect();
-        let task_count = tasks.len();
-
-        info!("VM[{}] Joining {} VCpu tasks...", vm_id, task_count);
-
-        // Join all VCpu tasks to ensure they have fully exited and cleaned up
-        for (idx, task) in tasks.iter().enumerate() {
-            debug!(
-                "VM[{}] Joining VCpu task[{}]: {}",
-                vm_id,
-                idx,
-                task.id_name()
-            );
-            let exit_code = task.join();
-            debug!(
-                "VM[{}] VCpu task[{}] exited with code: {}",
-                vm_id, idx, exit_code
-            );
-        }
-
-        info!(
-            "VM[{}] VCpu resources cleaned up, {} VCpu tasks joined successfully",
-            vm_id, task_count
-        );
-    } else {
-        warn!("VM[{}] VCpu resources not found in queue", vm_id);
+    if let Some(vm) = crate::get_vm_by_id(vm_id)
+        && let Err(err) = vm.with_runtime(|runtime| {
+            runtime.join_all_vcpu_tasks(vm_id);
+            Ok(())
+        })
+    {
+        warn!("VM[{vm_id}] vCPU runtime cleanup skipped: {err:?}");
     }
 }
 
 /// Marks the VCpu of the specified VM as running.
-fn mark_vcpu_running(vm_id: usize) {
-    if let Some(vm_vcpus) = get_vm_vcpus(vm_id) {
-        vm_vcpus.mark_vcpu_running();
-    }
+fn mark_vcpu_running(vm: &VMRef) {
+    let _ = vm.with_runtime(|runtime| {
+        runtime.mark_vcpu_running();
+        Ok(())
+    });
 }
 
 /// Boot target VCpu on the specified VM.
@@ -465,66 +294,19 @@ fn vcpu_on(vm: VMRef, vcpu_id: usize, entry_point: GuestPhysAddr, arg: usize) ->
         vcpu.set_gpr(RiscvGprIndex::A1 as usize, arg);
     }
 
-    let vm_vcpus = get_vm_vcpus(vm.id()).ok_or_else(|| {
-        ax_err_type!(
-            NotFound,
-            format!("VM[{}] vCPU resources not found", vm.id())
-        )
-    })?;
     let vcpu_task = alloc_vcpu_task(&vm, vcpu);
-    vm_vcpus.add_vcpu_task(vcpu_id, vcpu_task);
+    vm.with_runtime(|runtime| {
+        runtime.add_vcpu_task(vcpu_id, vcpu_task);
+        Ok(())
+    })?;
     Ok(())
 }
 
-/// Sets up the primary VCpu for the given VM,
-/// generally the first VCpu in the VCpu list,
-/// and initializing their respective wait queues and task lists.
-/// VM's secondary VCpus are not started at this point.
-///
-/// # Arguments
-///
-/// * `vm` - A reference to the VM for which the VCpus are being set up.
-pub fn setup_vm_primary_vcpu(vm: VMRef) {
-    info!("Initializing VM[{}]'s {} vcpus", vm.id(), vm.vcpu_num());
-    let vm_id = vm.id();
-    let primary_vcpu_id = 0;
-
-    let Some(primary_vcpu) = vm.vcpu_list().get(primary_vcpu_id).cloned() else {
-        warn!("VM[{vm_id}] has no primary vCPU");
-        return;
-    };
-    let vm_vcpus = Arc::new(VMVCpus::new(vm.clone()));
-    {
-        let mut vm_vcpu_tasks = VM_VCPU_TASKS.lock();
-        if vm_vcpu_tasks.contains_key(&vm_id) {
-            debug!("VM[{vm_id}] vCPU resources already exist");
-            return;
-        }
-        vm_vcpu_tasks.insert(vm_id, vm_vcpus.clone());
-    }
-
-    let primary_vcpu_task = alloc_vcpu_task(&vm, primary_vcpu);
-    vm_vcpus.add_vcpu_task(0, primary_vcpu_task);
+pub(crate) fn alloc_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::AxTaskRef {
+    crate::host::task::spawn_task(build_vcpu_task(vm, vcpu))
 }
 
-/// Allocates arceos task for vcpu, set the task's entry function to [`vcpu_run()`],
-/// also initializes the CPU mask if the VCpu has a dedicated physical CPU set.
-///
-/// # Arguments
-///
-/// * `vm` - A reference to the VM for which the VCpu task is being allocated.
-/// * `vcpu` - A reference to the VCpu for which the task is being allocated.
-///
-/// # Returns
-///
-/// A reference to the task that has been allocated for the VCpu.
-///
-/// # Note
-///
-/// * The task associated with the VCpu is created with a kernel stack size of 256 KiB.
-/// * The task is created in blocked state and added to the wait queue directly,
-///   instead of being added to the ready queue. It will be woken up by notify_primary_vcpu().
-fn alloc_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::AxTaskRef {
+pub(crate) fn build_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::TaskInner {
     info!("Spawning task for VM[{}] VCpu[{}]", vm.id(), vcpu.id());
     let mut vcpu_task = crate::TaskInner::new(
         vcpu_run,
@@ -547,7 +329,7 @@ fn alloc_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::AxTaskRef {
         vcpu_task.id_name(),
         vcpu_task.cpumask()
     );
-    crate::host::task::spawn_task(vcpu_task)
+    vcpu_task
 }
 
 fn vcpu_task_cpu_mask(vm_id: usize, vcpu_id: usize, requested_mask: usize) -> usize {
@@ -591,18 +373,18 @@ fn vcpu_run() {
     let vcpu = curr.as_vcpu_task().vcpu.clone();
     let vm_id = vm.id();
     let vcpu_id = vcpu.id();
-    let Some(vm_vcpus) = get_vm_vcpus(vm_id) else {
-        warn!("VM[{vm_id}] vCPU resources not found, VCpu[{vcpu_id}] exiting");
+    let Ok(runtime) = vm.with_runtime(|runtime| Ok(runtime.clone())) else {
+        warn!("VM[{vm_id}] vCPU runtime not found, VCpu[{vcpu_id}] exiting");
         return;
     };
 
     info!("VM[{}] VCpu[{}] waiting for running", vm.id(), vcpu.id());
-    wait_for(&vm_vcpus, || vm.running());
+    wait_for(&runtime, || vm.running());
 
     info!("VM[{}] VCpu[{}] running...", vm.id(), vcpu.id());
     #[cfg(target_arch = "x86_64")]
     super::x86_irq::enable_ioapic_irq_forwarding(&vm, &vcpu);
-    mark_vcpu_running(vm_id);
+    mark_vcpu_running(&vm);
 
     loop {
         inject_pending_interrupts(vm_id, vcpu_id, &vcpu);
@@ -679,7 +461,7 @@ fn vcpu_run() {
                     #[cfg(target_arch = "x86_64")]
                     continue;
                     #[cfg(not(target_arch = "x86_64"))]
-                    wait(&vm_vcpus)
+                    wait(&runtime)
                 }
                 AxVCpuExitReason::Idle => {
                     trace!("VM[{vm_id}] run VCpu[{vcpu_id}] Idle");
@@ -709,7 +491,7 @@ fn vcpu_run() {
                 AxVCpuExitReason::Nothing => {}
                 AxVCpuExitReason::CpuDown { _state } => {
                     warn!("VM[{vm_id}] run VCpu[{vcpu_id}] CpuDown state {_state:#x}");
-                    wait(&vm_vcpus)
+                    wait(&runtime)
                 }
                 AxVCpuExitReason::CpuUp {
                     target_cpu,
@@ -750,7 +532,7 @@ fn vcpu_run() {
                 }
                 AxVCpuExitReason::SystemDown => {
                     warn!("VM[{vm_id}] run VCpu[{vcpu_id}] SystemDown");
-                    if let Err(err) = vm.shutdown() {
+                    if let Err(err) = vm.stop(StopReason::SystemDown) {
                         warn!("VM[{vm_id}] shutdown failed: {err:?}");
                     }
                     // Notify all vCPUs to wake up to check the shutdown flag
@@ -804,7 +586,7 @@ fn vcpu_run() {
             },
             Err(err) => {
                 error!("VM[{vm_id}] run VCpu[{vcpu_id}] get error {err:?}");
-                if let Err(err) = vm.shutdown() {
+                if let Err(err) = vm.stop(StopReason::Fault(format!("{err:?}"))) {
                     warn!("VM[{vm_id}] shutdown failed after vCPU error: {err:?}");
                 }
                 // Notify all vCPUs to wake up to check the shutdown flag
@@ -818,7 +600,7 @@ fn vcpu_run() {
                 "VM[{}] VCpu[{}] is suspended, waiting for resume...",
                 vm_id, vcpu_id
             );
-            wait_for(&vm_vcpus, || !vm.suspending());
+            wait_for(&runtime, || !vm.suspending());
             info!("VM[{}] VCpu[{}] resumed from suspend", vm_id, vcpu_id);
             continue;
         }
@@ -830,11 +612,12 @@ fn vcpu_run() {
                 vm_id, vcpu_id
             );
 
-            if vm_vcpus.mark_vcpu_exiting() {
+            if runtime.mark_vcpu_exiting() {
                 info!("VM[{vm_id}] VCpu[{vcpu_id}] last VCpu exiting, decreasing running VM count");
 
-                // Transition from Stopping to Stopped
-                vm.set_vm_status(crate::VMStatus::Stopped);
+                if let Err(err) = vm.finish_stop() {
+                    warn!("VM[{vm_id}] finish stop failed: {err:?}");
+                }
                 info!("VM[{}] state changed to Stopped", vm_id);
 
                 #[cfg(target_arch = "x86_64")]

--- a/virtualization/axvm/src/runtime/x86_irq.rs
+++ b/virtualization/axvm/src/runtime/x86_irq.rs
@@ -97,11 +97,14 @@ pub fn inject_due_pit_irq0(vm: &VMRef, vcpu: &VCpuRef) {
     }
 
     let now_ns = crate::host::arceos::monotonic_time_nanos();
-    if !vm.get_devices().x86_pit_consume_irq0_if_due(now_ns) {
+    let Ok(devices) = vm.get_devices() else {
+        return;
+    };
+    if !devices.x86_pit_consume_irq0_if_due(now_ns) {
         return;
     }
 
-    let Some(irq) = vm.get_devices().x86_ioapic_assert_gsi(PIT_TIMER_GSI) else {
+    let Some(irq) = devices.x86_ioapic_assert_gsi(PIT_TIMER_GSI) else {
         trace!("x86 PIT IRQ0 due but vIOAPIC GSI0 is not ready");
         return;
     };
@@ -122,11 +125,14 @@ pub fn inject_pending_serial_irq(vm: &VMRef, vcpu: &VCpuRef) {
         return;
     }
 
-    if !vm.get_devices().x86_serial_poll_irq() {
+    let Ok(devices) = vm.get_devices() else {
+        return;
+    };
+    if !devices.x86_serial_poll_irq() {
         return;
     }
 
-    let Some(irq) = vm.get_devices().x86_ioapic_assert_gsi(COM1_GSI) else {
+    let Some(irq) = devices.x86_ioapic_assert_gsi(COM1_GSI) else {
         trace!("x86 COM1 RX pending but vIOAPIC GSI4 is not ready");
         return;
     };
@@ -148,7 +154,10 @@ pub fn inject_pending_ioapic_irq_after_eoi(vm: &VMRef, vcpu: &VCpuRef, vector: u
         return;
     }
 
-    let Some(eoi) = vm.get_devices().x86_ioapic_end_of_interrupt(vector) else {
+    let Ok(devices) = vm.get_devices() else {
+        return;
+    };
+    let Some(eoi) = devices.x86_ioapic_end_of_interrupt(vector) else {
         return;
     };
     let pending = eoi.pending;
@@ -300,7 +309,10 @@ pub fn activate_ready_ioapic_forwarding_routes(vm: &VMRef) {
             continue;
         }
 
-        if vm.get_devices().x86_ioapic_vector_for_gsi(gsi).is_none() {
+        let Ok(devices) = vm.get_devices() else {
+            return;
+        };
+        if devices.x86_ioapic_vector_for_gsi(gsi).is_none() {
             continue;
         }
 
@@ -413,12 +425,11 @@ fn forward_passthrough_gsi(
         return true;
     }
 
-    let Some(guest_irq) = vm.get_devices().x86_ioapic_assert_gsi(guest_gsi) else {
-        if vm
-            .get_devices()
-            .x86_ioapic_vector_for_gsi(guest_gsi)
-            .is_some()
-        {
+    let Ok(devices) = vm.get_devices() else {
+        return false;
+    };
+    let Some(guest_irq) = devices.x86_ioapic_assert_gsi(guest_gsi) else {
+        if devices.x86_ioapic_vector_for_gsi(guest_gsi).is_some() {
             trace!(
                 "x86 passthrough IRQ for guest GSI {guest_gsi} is deferred by guest vIOAPIC state"
             );

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
-use core::{alloc::Layout, fmt};
+use alloc::{boxed::Box, collections::BTreeMap, format, string::String, sync::Arc, vec::Vec};
+use core::{
+    alloc::Layout,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use ax_cpumask::CpuMask;
 use ax_errno::{AxError, AxResult, ax_err, ax_err_type};
@@ -35,7 +38,6 @@ use axvcpu::{AxArchVCpu, AxVCpu, AxVCpuExitReason, VCpuState};
 #[cfg(target_arch = "x86_64")]
 use axvm_types::EmulatedDeviceType;
 use axvm_types::{GuestPhysAddr, HostPhysAddr, HostVirtAddr};
-use spin::Once;
 #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
 use x86_vcpu::{X86_APIC_ACCESS_GPA, x86_apic_access_page_addr};
 
@@ -45,6 +47,7 @@ use crate::{
     config::{AxVMConfig, PhysCpuList, VMInterruptMode},
     host::paging::{HostPagingHandler, virt_to_phys},
     irq::InterruptFabric,
+    lifecycle::{Machine, StopReason, VmLifecycleError, VmStatus},
     vcpu::AxArchVCpuImpl,
 };
 
@@ -76,15 +79,202 @@ fn sign_extend_value(value: usize, width: AccessWidth) -> usize {
     }
 }
 
-struct AxVMInnerConst {
+pub(crate) struct AxVMResources {
+    // Todo: use more efficient lock.
+    address_space: AddrSpace<HostPagingHandler>,
+    memory_regions: Vec<VMMemoryRegion>,
+    config: AxVMConfig,
     phys_cpu_ls: PhysCpuList,
-    vcpu_list: Box<[AxVCpuRef]>,
-    devices: AxVmDevices,
-    interrupt_fabric: InterruptFabric,
+    vcpu_list: Option<Box<[AxVCpuRef]>>,
+    devices: Option<Arc<AxVmDevices>>,
+    interrupt_fabric: Option<InterruptFabric>,
 }
 
-unsafe impl Send for AxVMInnerConst {}
-unsafe impl Sync for AxVMInnerConst {}
+unsafe impl Send for AxVMResources {}
+unsafe impl Sync for AxVMResources {}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PendingInterrupt {
+    Normal(usize),
+    #[cfg(target_arch = "loongarch64")]
+    LoongArchExternal {
+        vector: usize,
+        physical_irq: usize,
+    },
+}
+
+/// Runtime-only resources owned by Running/Paused/Stopping lifecycle states.
+pub(crate) struct VmRuntimeHandle {
+    wait_queue: crate::WaitQueue,
+    vcpu_task_list: Mutex<BTreeMap<usize, crate::AxTaskRef>>,
+    pending_interrupts: Mutex<BTreeMap<usize, Vec<PendingInterrupt>>>,
+    running_halting_vcpu_count: AtomicUsize,
+}
+
+impl VmRuntimeHandle {
+    pub(crate) fn new() -> Self {
+        Self {
+            wait_queue: crate::WaitQueue::new(),
+            vcpu_task_list: Mutex::new(BTreeMap::new()),
+            pending_interrupts: Mutex::new(BTreeMap::new()),
+            running_halting_vcpu_count: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn add_vcpu_task(&self, vcpu_id: usize, vcpu_task: crate::AxTaskRef) {
+        self.vcpu_task_list.lock().insert(vcpu_id, vcpu_task);
+        self.pending_interrupts.lock().entry(vcpu_id).or_default();
+    }
+
+    pub(crate) fn queue_interrupt(&self, vcpu_id: usize, vector: usize) -> AxResult<usize> {
+        let task = self
+            .vcpu_task_list
+            .lock()
+            .get(&vcpu_id)
+            .cloned()
+            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
+        self.pending_interrupts
+            .lock()
+            .entry(vcpu_id)
+            .or_default()
+            .push(PendingInterrupt::Normal(vector));
+        Ok(task.cpu_id() as usize)
+    }
+
+    #[cfg(target_arch = "loongarch64")]
+    pub(crate) fn queue_external_interrupt(
+        &self,
+        vcpu_id: usize,
+        vector: usize,
+        physical_irq: usize,
+    ) -> AxResult<usize> {
+        let task = self
+            .vcpu_task_list
+            .lock()
+            .get(&vcpu_id)
+            .cloned()
+            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
+        self.pending_interrupts
+            .lock()
+            .entry(vcpu_id)
+            .or_default()
+            .push(PendingInterrupt::LoongArchExternal {
+                vector,
+                physical_irq,
+            });
+        Ok(task.cpu_id() as usize)
+    }
+
+    pub(crate) fn drain_pending_interrupts(&self, vcpu_id: usize) -> Vec<PendingInterrupt> {
+        self.pending_interrupts
+            .lock()
+            .get_mut(&vcpu_id)
+            .map(core::mem::take)
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn wait(&self) {
+        self.wait_queue.wait();
+    }
+
+    pub(crate) fn wait_until(&self, condition: impl Fn() -> bool) {
+        self.wait_queue.wait_until(condition);
+    }
+
+    pub(crate) fn notify_one(&self) {
+        self.wait_queue.notify_one(false);
+    }
+
+    pub(crate) fn notify_all(&self) {
+        self.wait_queue.notify_all(false);
+    }
+
+    pub(crate) fn mark_vcpu_running(&self) {
+        self.running_halting_vcpu_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn mark_vcpu_exiting(&self) -> bool {
+        self.running_halting_vcpu_count.fetch_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |count| count.checked_sub(1),
+        ) == Ok(1)
+    }
+
+    pub(crate) fn join_all_vcpu_tasks(&self, vm_id: usize) {
+        let tasks: Vec<_> = self.vcpu_task_list.lock().values().cloned().collect();
+        let task_count = tasks.len();
+        info!("VM[{vm_id}] Joining {task_count} VCpu tasks...");
+        for (idx, task) in tasks.iter().enumerate() {
+            debug!(
+                "VM[{}] Joining VCpu task[{}]: {}",
+                vm_id,
+                idx,
+                task.id_name()
+            );
+            let exit_code = task.join();
+            debug!("VM[{vm_id}] VCpu task[{idx}] exited with code: {exit_code}");
+        }
+        info!("VM[{vm_id}] VCpu resources cleaned up, {task_count} VCpu tasks joined");
+    }
+}
+
+impl AxVMResources {
+    fn new(config: AxVMConfig) -> AxResult<Self> {
+        Ok(Self {
+            address_space: AddrSpace::new_empty(
+                crate::vcpu::max_guest_page_table_levels(),
+                GuestPhysAddr::from(VM_ASPACE_BASE),
+                VM_ASPACE_SIZE,
+            )?,
+            memory_regions: Vec::new(),
+            config,
+            phys_cpu_ls: PhysCpuList::default(),
+            vcpu_list: None,
+            devices: None,
+            interrupt_fabric: None,
+        })
+    }
+
+    fn vcpu_list(&self) -> AxResult<&[AxVCpuRef]> {
+        self.vcpu_list
+            .as_deref()
+            .ok_or_else(|| ax_err_type!(BadState, "VM vCPU resources are not prepared"))
+    }
+
+    fn devices(&self) -> AxResult<Arc<AxVmDevices>> {
+        self.devices
+            .clone()
+            .ok_or_else(|| ax_err_type!(BadState, "VM devices are not prepared"))
+    }
+
+    fn interrupt_fabric(&self) -> AxResult<&InterruptFabric> {
+        self.interrupt_fabric
+            .as_ref()
+            .ok_or_else(|| ax_err_type!(BadState, "VM interrupt fabric is not prepared"))
+    }
+
+    fn reset_transient_resources(&mut self) -> AxResult {
+        let memory_regions = self.memory_regions.clone();
+        self.address_space.clear();
+        for region in &memory_regions {
+            self.address_space.map_linear(
+                region.gpa,
+                region.host_paddr(),
+                region.size(),
+                MappingFlags::READ
+                    | MappingFlags::WRITE
+                    | MappingFlags::EXECUTE
+                    | MappingFlags::USER,
+            )?;
+        }
+        self.vcpu_list = None;
+        self.devices = None;
+        self.interrupt_fabric = None;
+        Ok(())
+    }
+}
 
 struct PendingFwCfg {
     base: GuestPhysAddr,
@@ -136,93 +326,27 @@ impl VMMemoryRegion {
     }
 }
 
-struct AxVMInnerMut {
-    // Todo: use more efficient lock.
-    address_space: AddrSpace<HostPagingHandler>,
-    memory_regions: Vec<VMMemoryRegion>,
-    config: AxVMConfig,
-    vm_status: VMStatus,
-}
-
-/// VM status enumeration representing the lifecycle states of a virtual machine
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum VMStatus {
-    /// VM is being created/loaded
-    Loading,
-    /// VM is loaded but not yet started
-    Loaded,
-    /// VM is currently running
-    Running,
-    /// VM is suspended (paused but can be resumed)
-    Suspended,
-    /// VM is in the process of shutting down
-    Stopping,
-    /// VM is stopped
-    Stopped,
-}
-
-impl VMStatus {
-    /// Get status as a string (lowercase)
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            VMStatus::Loading => "loading",
-            VMStatus::Loaded => "loaded",
-            VMStatus::Running => "running",
-            VMStatus::Suspended => "suspended",
-            VMStatus::Stopping => "stopping",
-            VMStatus::Stopped => "stopped",
-        }
-    }
-
-    /// Get status with emoji icon
-    pub fn as_str_with_icon(&self) -> &'static str {
-        match self {
-            VMStatus::Loading => "🔄 loading",
-            VMStatus::Loaded => "📦 loaded",
-            VMStatus::Running => "🚀 running",
-            VMStatus::Suspended => "🛑 suspended",
-            VMStatus::Stopping => "⏹️ stopping",
-            VMStatus::Stopped => "💤 stopped",
-        }
-    }
-}
-
-impl fmt::Display for VMStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
 const TEMP_MAX_VCPU_NUM: usize = 64;
 
 /// A Virtual Machine.
 pub struct AxVM {
     id: usize,
-    inner_const: Once<AxVMInnerConst>,
-    inner_mut: Mutex<AxVMInnerMut>,
+    name: String,
+    machine: Mutex<Machine<AxVMResources, Arc<VmRuntimeHandle>>>,
     pending_fw_cfg: Mutex<Option<PendingFwCfg>>,
 }
 
 impl AxVM {
     /// Creates a new VM with the given configuration.
     /// Returns an error if the configuration is invalid.
-    /// The VM is not started until `boot` is called.
+    /// The VM is not started until `start` is called.
     pub fn new(config: AxVMConfig) -> AxResult<AxVMRef> {
-        let address_space = AddrSpace::new_empty(
-            crate::vcpu::max_guest_page_table_levels(),
-            GuestPhysAddr::from(VM_ASPACE_BASE),
-            VM_ASPACE_SIZE,
-        )?;
-
+        let id = config.id();
+        let name = config.name();
         let result = Arc::new(Self {
-            id: config.id(),
-            inner_const: Once::new(),
-            inner_mut: Mutex::new(AxVMInnerMut {
-                address_space,
-                config,
-                memory_regions: Vec::new(),
-                vm_status: VMStatus::Loading,
-            }),
+            id,
+            name,
+            machine: Mutex::new(Machine::Uninit(Box::new(config))),
             pending_fw_cfg: Mutex::new(None),
         });
 
@@ -237,42 +361,81 @@ impl AxVM {
         self.id
     }
 
+    /// Returns the configured VM name.
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// Returns the current lifecycle status.
+    pub fn status(&self) -> VmStatus {
+        self.machine.lock().status()
+    }
+
     /// Returns the configured VM interrupt mode.
     pub fn interrupt_mode(&self) -> VMInterruptMode {
-        self.inner_mut.lock().config.interrupt_mode()
+        let _ = self.ensure_resources_ready();
+        self.with_resources(|resources| Ok(resources.config.interrupt_mode()))
+            .unwrap_or(VMInterruptMode::NoIrq)
     }
 
     /// Sets up the VM before booting.
-    pub fn init(&self) -> AxResult {
+    pub fn prepare(&self) -> AxResult {
+        self.ensure_resources_ready()?;
         let mut factories = DeviceFactoryRegistry::new();
         register_builtin_factories(&mut factories)?;
         let interrupt_mode = self.interrupt_mode();
         #[cfg(target_arch = "riscv64")]
         let interrupt_fabric = {
-            let inner_mut = self.inner_mut.lock();
+            let machine = self.machine.lock();
+            let resources = machine.resources().ok_or_else(|| {
+                ax_err_type!(
+                    BadState,
+                    "VM resources are not available for RISC-V IRQ setup"
+                )
+            })?;
             crate::irq::riscv::configure(
                 &mut factories,
                 interrupt_mode,
-                inner_mut.config.emu_devices(),
+                resources.config.emu_devices(),
             )?
         };
         #[cfg(not(target_arch = "riscv64"))]
         let interrupt_fabric = InterruptFabric::new(interrupt_mode);
 
-        self.init_with_factories(&factories, interrupt_fabric)
+        self.prepare_with_factories(&factories, interrupt_fabric)
     }
 
     /// Sets up the VM with explicit device factories and an interrupt fabric.
-    pub fn init_with_factories(
+    pub fn prepare_with_factories(
         &self,
         factories: &DeviceFactoryRegistry,
         interrupt_fabric: InterruptFabric,
     ) -> AxResult {
-        let mut inner_mut = self.inner_mut.lock();
-        interrupt_fabric.validate_mode(inner_mut.config.interrupt_mode())?;
+        self.ensure_resources_ready()?;
+        let mut machine = self.machine.lock();
+        if !matches!(machine.status(), VmStatus::Ready | VmStatus::Stopped) {
+            return ax_err!(
+                BadState,
+                format!(
+                    "VM[{}] cannot prepare from {:?}",
+                    self.id(),
+                    machine.status()
+                )
+            );
+        }
+        let resources = machine
+            .resources_mut()
+            .ok_or_else(|| ax_err_type!(BadState, "VM resources are not available for prepare"))?;
+        if resources.vcpu_list.is_some()
+            || resources.devices.is_some()
+            || resources.interrupt_fabric.is_some()
+        {
+            resources.reset_transient_resources()?;
+        }
+        interrupt_fabric.validate_mode(resources.config.interrupt_mode())?;
 
-        let dtb_addr = inner_mut.config.image_config().dtb_load_gpa;
-        let vcpu_id_pcpu_sets = inner_mut.config.phys_cpu_ls.get_vcpu_affinities_pcpu_ids();
+        let dtb_addr = resources.config.image_config().dtb_load_gpa;
+        let vcpu_id_pcpu_sets = resources.config.phys_cpu_ls.get_vcpu_affinities_pcpu_ids();
         #[cfg(target_arch = "loongarch64")]
         let loongarch_iocsr_state = {
             let vcpu_state_count = vcpu_id_pcpu_sets
@@ -302,9 +465,9 @@ impl AxVM {
             let arch_config = AxVCpuCreateConfig {
                 cpu_id: vcpu_id,
                 dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
-                boot_args: inner_mut.config.cpu_config.boot_args,
-                boot_stack_top: inner_mut.config.cpu_config.boot_stack_top,
-                firmware_boot: inner_mut.config.cpu_config.firmware_boot,
+                boot_args: resources.config.cpu_config.boot_args,
+                boot_stack_top: resources.config.cpu_config.boot_stack_top,
+                firmware_boot: resources.config.cpu_config.firmware_boot,
                 iocsr_state: loongarch_iocsr_state.clone(),
             };
 
@@ -329,7 +492,7 @@ impl AxVM {
         }
 
         let mut pt_dev_region = Vec::new();
-        for pt_device in inner_mut.config.pass_through_devices() {
+        for pt_device in resources.config.pass_through_devices() {
             trace!(
                 "PT dev {:?} region: [{:#x}~{:#x}] -> [{:#x}~{:#x}]",
                 pt_device.name,
@@ -345,7 +508,7 @@ impl AxVM {
             ));
         }
 
-        for pt_addr in inner_mut.config.pass_through_addresses() {
+        for pt_addr in resources.config.pass_through_addresses() {
             debug!(
                 "PT addr region: [{:#x}~{:#x}]",
                 pt_addr.base_gpa,
@@ -376,7 +539,7 @@ impl AxVM {
                 });
 
         for (gpa, len) in &pt_dev_region {
-            inner_mut.address_space.map_linear(
+            resources.address_space.map_linear(
                 GuestPhysAddr::from(*gpa),
                 HostPhysAddr::from(*gpa),
                 *len,
@@ -388,7 +551,7 @@ impl AxVM {
         }
 
         #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
-        inner_mut.address_space.map_linear(
+        resources.address_space.map_linear(
             GuestPhysAddr::from(X86_APIC_ACCESS_GPA),
             x86_apic_access_page_addr(),
             ax_memory_addr::PAGE_SIZE_4K,
@@ -399,7 +562,7 @@ impl AxVM {
             let build_context = DeviceBuildContext::new(&interrupt_fabric);
             axdevice::AxVmDevices::build_with_factories(
                 AxVmDeviceConfig {
-                    emu_configs: inner_mut.config.emu_devices().to_vec(),
+                    emu_configs: resources.config.emu_devices().to_vec(),
                 },
                 factories,
                 &build_context,
@@ -407,7 +570,7 @@ impl AxVM {
         };
 
         #[cfg(target_arch = "x86_64")]
-        for port in inner_mut.config.pass_through_ports() {
+        for port in resources.config.pass_through_ports() {
             let passthrough = Arc::new(crate::host::x86_port::HostPortPassthrough::new(
                 port.base,
                 port.length,
@@ -425,9 +588,9 @@ impl AxVM {
 
         #[cfg(target_arch = "aarch64")]
         {
-            let passthrough = inner_mut.config.interrupt_mode() == VMInterruptMode::Passthrough;
+            let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
             if passthrough {
-                let spis = inner_mut.config.pass_through_spis();
+                let spis = resources.config.pass_through_spis();
                 let cpu_id = self.id() - 1; // FIXME: get the real CPU id.
                 let mut gicd_found = false;
 
@@ -469,7 +632,7 @@ impl AxVM {
         for vcpu in &vcpu_list {
             #[cfg(target_arch = "aarch64")]
             let setup_config = {
-                let passthrough = inner_mut.config.interrupt_mode() == VMInterruptMode::Passthrough;
+                let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
                 crate::vcpu::AxVCpuSetupConfig {
                     passthrough_interrupt: passthrough,
                     passthrough_timer: passthrough,
@@ -477,13 +640,13 @@ impl AxVM {
             };
             #[cfg(target_arch = "loongarch64")]
             let setup_config = {
-                let passthrough = inner_mut.config.interrupt_mode() == VMInterruptMode::Passthrough;
+                let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
                 crate::vcpu::AxVCpuSetupConfig {
                     passthrough_interrupt: passthrough,
                     passthrough_timer: passthrough,
-                    boot_args: inner_mut.config.cpu_config.boot_args,
-                    boot_stack_top: inner_mut.config.cpu_config.boot_stack_top,
-                    firmware_boot: inner_mut.config.cpu_config.firmware_boot,
+                    boot_args: resources.config.cpu_config.boot_args,
+                    boot_stack_top: resources.config.cpu_config.boot_stack_top,
+                    firmware_boot: resources.config.cpu_config.firmware_boot,
                 }
             };
             #[cfg(not(any(
@@ -496,55 +659,93 @@ impl AxVM {
             #[cfg(target_arch = "x86_64")]
             let setup_config = {
                 let mut config = crate::vcpu::AxVCpuSetupConfig {
-                    emulate_com1: inner_mut
+                    emulate_com1: resources
                         .config
                         .emu_devices()
                         .iter()
                         .any(|dev| dev.emu_type == EmulatedDeviceType::Console),
                     ..Default::default()
                 };
-                for port in inner_mut.config.pass_through_ports() {
+                for port in resources.config.pass_through_ports() {
                     config.add_passthrough_port_range(port.base, port.length)?;
                 }
                 config
             };
 
             let entry = if vcpu.id() == 0 {
-                inner_mut.config.bsp_entry()
+                resources.config.bsp_entry()
             } else {
-                inner_mut.config.ap_entry()
+                resources.config.ap_entry()
             };
 
             debug!("Setting up vCPU[{}] entry at {:#x}", vcpu.id(), entry);
 
             vcpu.setup(
                 entry,
-                inner_mut.address_space.page_table_root(),
+                resources.address_space.page_table_root(),
                 setup_config,
             )?;
         }
 
-        self.inner_const.call_once(|| AxVMInnerConst {
-            phys_cpu_ls: inner_mut.config.phys_cpu_ls.clone(),
-            vcpu_list: vcpu_list.into_boxed_slice(),
-            devices,
-            interrupt_fabric,
-        });
+        resources.phys_cpu_ls = resources.config.phys_cpu_ls.clone();
+        resources.vcpu_list = Some(vcpu_list.into_boxed_slice());
+        resources.devices = Some(Arc::new(devices));
+        resources.interrupt_fabric = Some(interrupt_fabric);
 
         info!("VM setup: id={}", self.id());
         Ok(())
     }
 
-    /// Sets the VM status.
-    pub fn set_vm_status(&self, status: VMStatus) {
-        let mut inner_mut = self.inner_mut.lock();
-        inner_mut.vm_status = status;
+    fn ensure_resources_ready(&self) -> AxResult {
+        let mut machine = self.machine.lock();
+        if !matches!(machine.status(), VmStatus::Uninit) {
+            return Ok(());
+        }
+        machine
+            .prepare_with(|config| {
+                AxVMResources::new(config).map_err(|err| {
+                    VmLifecycleError::MissingResource(match err {
+                        AxError::NoMemory => "VM address space memory",
+                        _ => "VM address space",
+                    })
+                })
+            })
+            .map_err(VmLifecycleError::into_ax_error)
     }
 
-    /// Returns the current VM status.
-    pub fn vm_status(&self) -> VMStatus {
-        let inner_mut = self.inner_mut.lock();
-        inner_mut.vm_status
+    fn with_resources<F, R>(&self, f: F) -> AxResult<R>
+    where
+        F: FnOnce(&AxVMResources) -> AxResult<R>,
+    {
+        self.ensure_resources_ready()?;
+        let machine = self.machine.lock();
+        let resources = machine
+            .resources()
+            .ok_or_else(|| ax_err_type!(BadState, "VM resources are not available"))?;
+        f(resources)
+    }
+
+    fn with_resources_mut<F, R>(&self, f: F) -> AxResult<R>
+    where
+        F: FnOnce(&mut AxVMResources) -> AxResult<R>,
+    {
+        self.ensure_resources_ready()?;
+        let mut machine = self.machine.lock();
+        let resources = machine
+            .resources_mut()
+            .ok_or_else(|| ax_err_type!(BadState, "VM resources are not available"))?;
+        f(resources)
+    }
+
+    pub(crate) fn with_runtime<F, R>(&self, f: F) -> AxResult<R>
+    where
+        F: FnOnce(&Arc<VmRuntimeHandle>) -> AxResult<R>,
+    {
+        let machine = self.machine.lock();
+        let runtime = machine
+            .runtime()
+            .ok_or_else(|| ax_err_type!(BadState, "VM runtime is not available"))?;
+        f(runtime)
     }
 
     /// Retrieves the vCPU corresponding to the given vcpu_id for the VM.
@@ -557,24 +758,20 @@ impl AxVM {
     /// Returns the number of vCPUs corresponding to the VM.
     #[inline]
     pub fn vcpu_num(&self) -> usize {
-        self.inner_const().vcpu_list.len()
+        self.with_resources(|resources| Ok(resources.vcpu_list().map_or(0, <[_]>::len)))
+            .unwrap_or(0)
     }
 
-    fn inner_const(&self) -> &AxVMInnerConst {
-        self.inner_const
-            .get()
-            .expect("VM inner_const not initialized")
-    }
-
-    /// Returns a reference to the list of vCPUs corresponding to the VM.
+    /// Returns a snapshot of the VM's vCPU references.
     #[inline]
-    pub fn vcpu_list(&self) -> &[AxVCpuRef] {
-        &self.inner_const().vcpu_list
+    pub fn vcpu_list(&self) -> Vec<AxVCpuRef> {
+        self.with_resources(|resources| Ok(resources.vcpu_list()?.to_vec()))
+            .unwrap_or_default()
     }
 
     /// Returns the base address of the two-stage address translation page table for the VM.
-    pub fn ept_root(&self) -> HostPhysAddr {
-        self.inner_mut.lock().address_space.page_table_root()
+    pub fn ept_root(&self) -> AxResult<HostPhysAddr> {
+        self.with_resources(|resources| Ok(resources.address_space.page_table_root()))
     }
 
     /// Returns to the VM's configuration.
@@ -582,8 +779,25 @@ impl AxVM {
     where
         F: FnOnce(&mut AxVMConfig) -> R,
     {
-        let mut g = self.inner_mut.lock();
-        f(&mut g.config)
+        let mut machine = self.machine.lock();
+        if matches!(machine.status(), VmStatus::Uninit) {
+            let old = core::mem::replace(&mut *machine, Machine::Switching);
+            if let Machine::Uninit(config) = old {
+                match AxVMResources::new(*config) {
+                    Ok(resources) => *machine = Machine::Ready(resources),
+                    Err(err) => {
+                        *machine = Machine::Failed(format!("prepare config resources: {err:?}"));
+                        panic!("VM resources are not available: {err:?}");
+                    }
+                }
+            } else {
+                *machine = old;
+            }
+        }
+        let resources = machine
+            .resources_mut()
+            .expect("VM resources are not available for config access");
+        f(&mut resources.config)
     }
 
     /// Returns guest VM image load region in `Vec<&'static mut [u8]>`,
@@ -599,73 +813,189 @@ impl AxVM {
         image_load_gpa: GuestPhysAddr,
         image_size: usize,
     ) -> AxResult<Vec<&'static mut [u8]>> {
-        let g = self.inner_mut.lock();
-        let image_load_hva = g
-            .address_space
-            .translated_byte_buffer(image_load_gpa, image_size)
-            .expect("Failed to translate kernel image load address");
+        let image_load_hva = self.with_resources(|resources| {
+            resources
+                .address_space
+                .translated_byte_buffer(image_load_gpa, image_size)
+                .ok_or_else(|| {
+                    ax_err_type!(BadState, "Failed to translate kernel image load address")
+                })
+        })?;
         Ok(image_load_hva)
     }
 
-    /// Boots the VM by transitioning to Running state.
-    pub fn boot(&self) -> AxResult {
-        if self.running() {
-            ax_err!(BadState, format!("VM[{}] is already running", self.id()))
-        } else {
-            info!("Booting VM[{}]", self.id());
-            self.set_vm_status(VMStatus::Running);
-            Ok(())
+    /// Starts the VM by transitioning to Running state.
+    pub fn start(self: &Arc<Self>) -> AxResult {
+        self.ensure_resources_ready()?;
+        if self.status() == VmStatus::Stopped {
+            self.prepare()?;
         }
+        info!("Starting VM[{}]", self.id());
+        let primary_vcpu = self
+            .vcpu(0)
+            .ok_or_else(|| ax_err_type!(BadState, "VM primary vCPU is not prepared"))?;
+        let primary_task = crate::runtime::vcpus::build_vcpu_task(self, primary_vcpu);
+        let runtime = Arc::new(VmRuntimeHandle::new());
+
+        self.machine
+            .lock()
+            .start_with(|resources| {
+                resources
+                    .vcpu_list()
+                    .map_err(|_| VmLifecycleError::MissingResource("vCPU list"))?;
+                resources
+                    .devices()
+                    .map_err(|_| VmLifecycleError::MissingResource("devices"))?;
+                resources
+                    .interrupt_fabric()
+                    .map_err(|_| VmLifecycleError::MissingResource("interrupt fabric"))?;
+                Ok(runtime.clone())
+            })
+            .map_err(VmLifecycleError::into_ax_error)?;
+
+        let task = crate::host::task::spawn_task(primary_task);
+        runtime.add_vcpu_task(0, task);
+        Ok(())
     }
 
     /// Returns if the VM is running.
     pub fn running(&self) -> bool {
-        self.vm_status() == VMStatus::Running
+        self.status() == VmStatus::Running
     }
 
     /// Returns if the VM is shutting down (in Stopping state).
     pub fn stopping(&self) -> bool {
-        self.vm_status() == VMStatus::Stopping
+        self.status() == VmStatus::Stopping
     }
 
     /// Returns if the VM is suspended.
     pub fn suspending(&self) -> bool {
-        self.vm_status() == VMStatus::Suspended
+        matches!(self.status(), VmStatus::Pausing | VmStatus::Paused)
     }
 
     /// Returns if the VM is stopped.
     pub fn stopped(&self) -> bool {
-        self.vm_status() == VMStatus::Stopped
+        self.status() == VmStatus::Stopped
     }
 
-    /// Shuts down the VM by transitioning to Stopping state.
-    ///
-    /// This method sets the VM status to Stopping, which signals all vCPUs to exit.
-    /// Currently, the "re-init" process of the VM is not implemented. Therefore, a VM can only be
-    /// booted once. And after the VM is shut down, it cannot be booted again.
-    pub fn shutdown(&self) -> AxResult {
-        if self.stopping() {
-            ax_err!(BadState, format!("VM[{}] is already stopping", self.id()))
-        } else if self.stopped() {
-            ax_err!(BadState, format!("VM[{}] is already stopped", self.id()))
-        } else {
-            info!("Shutting down VM[{}]", self.id());
-            self.set_vm_status(VMStatus::Stopping);
-            Ok(())
+    /// Pauses a running VM.
+    pub fn pause(&self) -> AxResult {
+        self.machine
+            .lock()
+            .pause()
+            .map_err(VmLifecycleError::into_ax_error)
+    }
+
+    /// Resumes a paused VM.
+    pub fn resume(&self) -> AxResult {
+        self.machine
+            .lock()
+            .resume()
+            .map_err(VmLifecycleError::into_ax_error)
+    }
+
+    /// Requests a stop. Running vCPUs observe the Stopping state and exit.
+    pub fn stop(&self, reason: StopReason) -> AxResult {
+        info!("Stopping VM[{}]: {reason:?}", self.id());
+        self.machine
+            .lock()
+            .request_stop_with(reason, |_, _| Ok(()))
+            .map_err(VmLifecycleError::into_ax_error)
+    }
+
+    pub(crate) fn finish_stop(&self) -> AxResult {
+        self.machine
+            .lock()
+            .finish_stop()
+            .map_err(VmLifecycleError::into_ax_error)
+    }
+
+    fn wait_until_stopped(&self) -> AxResult {
+        const MAX_YIELDS: usize = 10_000;
+        for _ in 0..MAX_YIELDS {
+            match self.status() {
+                VmStatus::Stopped | VmStatus::Ready => return Ok(()),
+                VmStatus::Stopping | VmStatus::Running | VmStatus::Paused | VmStatus::Pausing => {
+                    crate::host::task::yield_now();
+                }
+                status => {
+                    return ax_err!(
+                        BadState,
+                        format!("VM[{}] cannot wait for stop from {status:?}", self.id())
+                    );
+                }
+            }
+        }
+        ax_err!(
+            BadState,
+            format!("VM[{}] did not stop before reset timeout", self.id())
+        )
+    }
+
+    /// Resets the VM by discarding runtime-only state, rebuilding vCPUs/devices,
+    /// and starting from a fresh `Running` state.
+    pub fn reset(self: &Arc<Self>) -> AxResult {
+        info!("Resetting VM[{}]", self.id());
+        match self.status() {
+            VmStatus::Running | VmStatus::Paused => {
+                self.stop(StopReason::Forced)?;
+                if let Ok(()) = self.with_runtime(|runtime| {
+                    runtime.notify_all();
+                    Ok(())
+                }) {}
+                self.wait_until_stopped()?;
+            }
+            VmStatus::Stopping => {
+                if let Ok(()) = self.with_runtime(|runtime| {
+                    runtime.notify_all();
+                    Ok(())
+                }) {}
+                self.wait_until_stopped()?;
+            }
+            VmStatus::Stopped | VmStatus::Ready => {}
+            status => {
+                return ax_err!(
+                    BadState,
+                    format!("VM[{}] cannot reset from {status:?}", self.id())
+                );
+            }
+        }
+
+        self.machine
+            .lock()
+            .reset_with(|resources| {
+                resources
+                    .reset_transient_resources()
+                    .map_err(|_| VmLifecycleError::MissingResource("reset resources"))
+            })
+            .map_err(VmLifecycleError::into_ax_error)?;
+        self.prepare()?;
+        self.start()
+    }
+
+    /// Returns this VM's emulated devices.
+    pub fn get_devices(&self) -> AxResult<Arc<AxVmDevices>> {
+        self.with_resources(|resources| resources.devices())
+    }
+
+    /// Pulses a prepared VM interrupt fabric line without exposing the fabric.
+    pub fn pulse_interrupt(&self, irq_id: usize) -> AxResult {
+        match self.status() {
+            VmStatus::Running | VmStatus::Paused => {
+                self.with_resources(|resources| resources.interrupt_fabric()?.pulse(irq_id))
+            }
+            status => ax_err!(
+                BadState,
+                format!("VM[{}] cannot accept IRQ in {status:?}", self.id())
+            ),
         }
     }
 
-    // TODO: implement suspend/resume.
-    // TODO: implement re-init.
-
-    /// Returns this VM's emulated devices.
-    pub fn get_devices(&self) -> &AxVmDevices {
-        &self.inner_const().devices
-    }
-
-    /// Returns this VM's interrupt fabric.
-    pub fn interrupt_fabric(&self) -> &InterruptFabric {
-        &self.inner_const().interrupt_fabric
+    /// Returns the number of prepared emulated devices.
+    pub fn device_count(&self) -> usize {
+        self.get_devices()
+            .map(|devices| devices.devices().count())
+            .unwrap_or(0)
     }
 
     /// Assert a routed LoongArch platform IRQ in the guest interrupt model.
@@ -675,10 +1005,8 @@ impl AxVM {
         fallback_vector: usize,
         _physical_irq: usize,
     ) -> Option<usize> {
-        match self
-            .get_devices()
-            .loongarch_pch_pic_assert_irq(fallback_vector)
-        {
+        let devices = self.get_devices().ok()?;
+        match devices.loongarch_pch_pic_assert_irq(fallback_vector) {
             Some(Some(vector)) => Some(vector),
             Some(None) => None,
             None => Some(fallback_vector),
@@ -759,6 +1087,7 @@ impl AxVM {
             }
         }
 
+        let devices = self.get_devices()?;
         let run_result = vcpu.with_current_cpu_set(|| -> AxResult<AxVCpuExitReason> {
             loop {
                 crate::runtime::vcpus::inject_pending_interrupts(self.id(), vcpu_id, &vcpu);
@@ -773,7 +1102,7 @@ impl AxVM {
                         reg_width,
                         signed_ext,
                     } => {
-                        let raw = self.get_devices().handle_mmio_read(addr, width)?;
+                        let raw = devices.handle_mmio_read(addr, width)?;
                         let masked = raw & width_mask(width);
                         let val = if signed_ext {
                             sign_extend_value(masked, width)
@@ -786,7 +1115,7 @@ impl AxVM {
                         self.handle_mmio_write(addr, width, data as usize)?;
                     }
                     AxVCpuExitReason::IoRead { port, width } => {
-                        let val = self.get_devices().handle_port_read(port, width)?;
+                        let val = devices.handle_port_read(port, width)?;
                         #[cfg(not(target_arch = "riscv64"))]
                         vcpu.set_gpr(0, val); // The target is always eax/ax/al, todo: handle access_width correctly
 
@@ -794,11 +1123,10 @@ impl AxVM {
                         vcpu.set_gpr(riscv_vcpu::GprIndex::A0 as usize, val);
                     }
                     AxVCpuExitReason::IoWrite { port, width, data } => {
-                        self.get_devices()
-                            .handle_port_write(port, width, data as usize)?;
+                        devices.handle_port_write(port, width, data as usize)?;
                     }
                     AxVCpuExitReason::SysRegRead { addr, reg } => {
-                        let val = self.get_devices().handle_sys_reg_read(
+                        let val = devices.handle_sys_reg_read(
                             addr,
                             // Generally speaking, the width of system register is fixed and needless to be specified.
                             // AccessWidth::Qword here is just a placeholder, may be changed in the future.
@@ -807,14 +1135,10 @@ impl AxVM {
                         vcpu.set_gpr(reg, val);
                     }
                     AxVCpuExitReason::SysRegWrite { addr, value } => {
-                        self.get_devices().handle_sys_reg_write(
-                            addr,
-                            AccessWidth::Qword,
-                            value as usize,
-                        )?;
+                        devices.handle_sys_reg_write(addr, AccessWidth::Qword, value as usize)?;
                     }
                     AxVCpuExitReason::NestedPageFault { addr, access_flags } => {
-                        if self.get_devices().find_mmio_dev(addr).is_some() {
+                        if devices.find_mmio_dev(addr).is_some() {
                             if let Some(mmio_exit) =
                                 vcpu.get_arch_vcpu().decode_mmio_fault(addr, access_flags)
                             {
@@ -826,8 +1150,7 @@ impl AxVM {
                                         reg_width,
                                         signed_ext,
                                     } => {
-                                        let raw =
-                                            self.get_devices().handle_mmio_read(addr, width)?;
+                                        let raw = devices.handle_mmio_read(addr, width)?;
                                         let masked = raw & width_mask(width);
                                         let val = if signed_ext {
                                             sign_extend_value(masked, width)
@@ -871,7 +1194,8 @@ impl AxVM {
     }
 
     fn handle_mmio_write(&self, addr: GuestPhysAddr, width: AccessWidth, data: usize) -> AxResult {
-        if let Some(fw_cfg) = self.get_devices().fw_cfg_for_dma_addr(addr) {
+        let devices = self.get_devices()?;
+        if let Some(fw_cfg) = devices.fw_cfg_for_dma_addr(addr) {
             if let Some(desc_addr) = fw_cfg.write_dma_address(addr, width, data)? {
                 fw_cfg.process_dma(
                     desc_addr,
@@ -882,7 +1206,7 @@ impl AxVM {
             return Ok(());
         }
 
-        self.get_devices().handle_mmio_write(addr, width, data)?;
+        devices.handle_mmio_write(addr, width, data)?;
         #[cfg(target_arch = "loongarch64")]
         self.drain_loongarch_pch_pic_events();
         Ok(())
@@ -890,7 +1214,10 @@ impl AxVM {
 
     #[cfg(target_arch = "loongarch64")]
     fn drain_loongarch_pch_pic_events(&self) {
-        self.get_devices().drain_loongarch_pch_pic_events(|event| {
+        let Ok(devices) = self.get_devices() else {
+            return;
+        };
+        devices.drain_loongarch_pch_pic_events(|event| {
             if !event.asserted {
                 trace!(
                     "LoongArch VM[{}] PCH-PIC deassert event for EIOINTC vector {}",
@@ -910,21 +1237,25 @@ impl AxVM {
     }
 
     fn handle_nested_page_fault(&self, addr: GuestPhysAddr, access_flags: MappingFlags) -> bool {
-        let mut guard = self.inner_mut.lock();
-        let handled = guard.address_space.handle_page_fault(addr, access_flags);
-        Self::debug_nested_page_fault(self.id(), &guard, addr, access_flags, handled);
-        handled
+        self.with_resources_mut(|resources| {
+            let handled = resources
+                .address_space
+                .handle_page_fault(addr, access_flags);
+            Self::debug_nested_page_fault(self.id(), resources, addr, access_flags, handled);
+            Ok(handled)
+        })
+        .unwrap_or(false)
     }
 
     fn debug_nested_page_fault(
         vm_id: usize,
-        inner: &AxVMInnerMut,
+        resources: &AxVMResources,
         addr: GuestPhysAddr,
         access_flags: MappingFlags,
         handled: bool,
     ) {
-        let root = inner.address_space.page_table_root();
-        match inner.address_space.page_table().query(addr) {
+        let root = resources.address_space.page_table_root();
+        match resources.address_space.page_table().query(addr) {
             Ok((hpa, flags, size)) => {
                 if handled {
                     debug!(
@@ -975,7 +1306,7 @@ impl AxVM {
             }
         }
 
-        let translate = inner.address_space.translate(addr);
+        let translate = resources.address_space.translate(addr);
         if handled {
             debug!(
                 "VM[{}] stage2 translate: gpa={:#x} -> {:?}",
@@ -992,7 +1323,7 @@ impl AxVM {
             );
         }
 
-        for (idx, region) in inner.memory_regions.iter().enumerate() {
+        for (idx, region) in resources.memory_regions.iter().enumerate() {
             let start = region.gpa.as_usize();
             let end = start + region.size();
             if (start..end).contains(&addr.as_usize()) {
@@ -1050,15 +1381,9 @@ impl AxVM {
     /// - The pCpu affinity mask, `None` if not set.
     /// - The physical id of the vCpu, equal to vCpu id if not provided.
     pub fn get_vcpu_affinities_pcpu_ids(&self) -> Vec<(usize, Option<usize>, usize)> {
-        self.inner_const()
-            .phys_cpu_ls
-            .get_vcpu_affinities_pcpu_ids()
+        self.with_resources(|resources| Ok(resources.phys_cpu_ls.get_vcpu_affinities_pcpu_ids()))
+            .unwrap_or_default()
     }
-
-    // /// Returns a reference to the VM's configuration.
-    // pub fn config(&self) -> &AxVMConfig {
-    //     &self.inner_const.config
-    // }
 
     /// Maps a region of host physical memory to guest physical memory.
     pub fn map_region(
@@ -1068,17 +1393,18 @@ impl AxVM {
         size: usize,
         flags: MappingFlags,
     ) -> AxResult {
-        self.inner_mut
-            .lock()
-            .address_space
-            .map_linear(gpa, hpa, size, flags)?;
-        Ok(())
+        self.with_resources_mut(|resources| {
+            resources.address_space.map_linear(gpa, hpa, size, flags)?;
+            Ok(())
+        })
     }
 
     /// Unmaps a region of guest physical memory.
     pub fn unmap_region(&self, gpa: GuestPhysAddr, size: usize) -> AxResult {
-        self.inner_mut.lock().address_space.unmap(gpa, size)?;
-        Ok(())
+        self.with_resources_mut(|resources| {
+            resources.address_space.unmap(gpa, size)?;
+            Ok(())
+        })
     }
 
     /// Reads an object of type `T` from the guest physical address.
@@ -1093,112 +1419,120 @@ impl AxVM {
             return ax_err!(InvalidInput, "Unaligned guest physical address");
         }
 
-        let g = self.inner_mut.lock();
-        match g.address_space.translated_byte_buffer(gpa_ptr, size) {
-            Some(buffers) => {
-                let mut data_bytes = Vec::with_capacity(size);
-                for chunk in buffers {
-                    let remaining = size - data_bytes.len();
-                    let chunk_size = remaining.min(chunk.len());
-                    data_bytes.extend_from_slice(&chunk[..chunk_size]);
-                    if data_bytes.len() >= size {
-                        break;
-                    }
+        self.with_resources(|resources| {
+            let Some(buffers) = resources
+                .address_space
+                .translated_byte_buffer(gpa_ptr, size)
+            else {
+                return ax_err!(
+                    InvalidInput,
+                    "Failed to translate guest physical address or insufficient buffer size"
+                );
+            };
+
+            let mut data_bytes = Vec::with_capacity(size);
+            for chunk in buffers {
+                let remaining = size - data_bytes.len();
+                let chunk_size = remaining.min(chunk.len());
+                data_bytes.extend_from_slice(&chunk[..chunk_size]);
+                if data_bytes.len() >= size {
+                    break;
                 }
-                if data_bytes.len() < size {
-                    return ax_err!(
-                        InvalidInput,
-                        "Insufficient data in guest memory to read the requested object"
-                    );
-                }
-                let data: T = unsafe {
-                    // Use `ptr::read_unaligned` for safety in case of unaligned memory.
-                    core::ptr::read_unaligned(data_bytes.as_ptr() as *const T)
-                };
-                Ok(data)
             }
-            None => ax_err!(
-                InvalidInput,
-                "Failed to translate guest physical address or insufficient buffer size"
-            ),
-        }
+            if data_bytes.len() < size {
+                return ax_err!(
+                    InvalidInput,
+                    "Insufficient data in guest memory to read the requested object"
+                );
+            }
+            let data: T = unsafe {
+                // Use `ptr::read_unaligned` for safety in case of unaligned memory.
+                core::ptr::read_unaligned(data_bytes.as_ptr() as *const T)
+            };
+            Ok(data)
+        })
     }
 
     /// Reads raw bytes from guest physical memory.
     pub fn read_from_guest(&self, gpa_ptr: GuestPhysAddr, buffer: &mut [u8]) -> AxResult {
-        let g = self.inner_mut.lock();
-        let Some(chunks) = g
-            .address_space
-            .translated_byte_buffer(gpa_ptr, buffer.len())
-        else {
-            return ax_err!(InvalidInput, "Failed to translate guest physical address");
-        };
+        self.with_resources(|resources| {
+            let Some(chunks) = resources
+                .address_space
+                .translated_byte_buffer(gpa_ptr, buffer.len())
+            else {
+                return ax_err!(InvalidInput, "Failed to translate guest physical address");
+            };
 
-        let mut copied = 0;
-        for chunk in chunks {
-            let len = (buffer.len() - copied).min(chunk.len());
-            buffer[copied..copied + len].copy_from_slice(&chunk[..len]);
-            copied += len;
-            if copied == buffer.len() {
-                return Ok(());
+            let mut copied = 0;
+            for chunk in chunks {
+                let len = (buffer.len() - copied).min(chunk.len());
+                buffer[copied..copied + len].copy_from_slice(&chunk[..len]);
+                copied += len;
+                if copied == buffer.len() {
+                    return Ok(());
+                }
             }
-        }
 
-        ax_err!(
-            InvalidInput,
-            "Insufficient guest memory to read the requested buffer"
-        )
+            ax_err!(
+                InvalidInput,
+                "Insufficient guest memory to read the requested buffer"
+            )
+        })
     }
 
     /// Writes an object of type `T` to the guest physical address.
     pub fn write_to_guest_of<T>(&self, gpa_ptr: GuestPhysAddr, data: &T) -> AxResult {
-        match self
-            .inner_mut
-            .lock()
-            .address_space
-            .translated_byte_buffer(gpa_ptr, core::mem::size_of::<T>())
-        {
-            Some(mut buffer) => {
-                let bytes = unsafe {
-                    core::slice::from_raw_parts(
-                        data as *const T as *const u8,
-                        core::mem::size_of::<T>(),
-                    )
-                };
-                let mut copied_bytes = 0;
-                for chunk in buffer.iter_mut() {
-                    let end = copied_bytes + chunk.len();
-                    chunk.copy_from_slice(&bytes[copied_bytes..end]);
-                    copied_bytes += chunk.len();
+        self.with_resources(|resources| {
+            match resources
+                .address_space
+                .translated_byte_buffer(gpa_ptr, core::mem::size_of::<T>())
+            {
+                Some(mut buffer) => {
+                    let bytes = unsafe {
+                        core::slice::from_raw_parts(
+                            data as *const T as *const u8,
+                            core::mem::size_of::<T>(),
+                        )
+                    };
+                    let mut copied_bytes = 0;
+                    for chunk in buffer.iter_mut() {
+                        let end = copied_bytes + chunk.len();
+                        chunk.copy_from_slice(&bytes[copied_bytes..end]);
+                        copied_bytes += chunk.len();
+                    }
+                    Ok(())
                 }
-                Ok(())
+                None => ax_err!(InvalidInput, "Failed to translate guest physical address"),
             }
-            None => ax_err!(InvalidInput, "Failed to translate guest physical address"),
-        }
+        })
     }
 
     /// Writes raw bytes into guest physical memory.
     pub fn write_to_guest(&self, gpa_ptr: GuestPhysAddr, data: &[u8]) -> AxResult {
-        let g = self.inner_mut.lock();
-        let Some(mut chunks) = g.address_space.translated_byte_buffer(gpa_ptr, data.len()) else {
-            return ax_err!(InvalidInput, "Failed to translate guest physical address");
-        };
+        self.with_resources(|resources| {
+            let Some(mut chunks) = resources
+                .address_space
+                .translated_byte_buffer(gpa_ptr, data.len())
+            else {
+                return ax_err!(InvalidInput, "Failed to translate guest physical address");
+            };
 
-        let mut copied = 0;
-        for chunk in chunks.iter_mut() {
-            let len = (data.len() - copied).min(chunk.len());
-            chunk[..len].copy_from_slice(&data[copied..copied + len]);
-            crate::clean_dcache_range((chunk.as_ptr() as usize).into(), len);
-            copied += len;
-            if copied == data.len() {
-                return Ok(());
+            let mut copied = 0;
+            for chunk in chunks.iter_mut() {
+                let len = (data.len() - copied).min(chunk.len());
+                chunk[..len].copy_from_slice(&data[copied..copied + len]);
+                crate::clean_dcache_range((chunk.as_ptr() as usize).into(), len);
+                copied += len;
+                if copied == data.len() {
+                    return Ok(());
+                }
             }
-        }
 
-        ax_err!(
-            InvalidInput,
-            "Insufficient guest memory to write the requested buffer"
-        )
+            ax_err!(
+                InvalidInput,
+                "Insufficient guest memory to write the requested buffer"
+            )
+        })
     }
 
     /// Allocates an IVC channel for inter-VM communication region.
@@ -1210,7 +1544,7 @@ impl AxVM {
     pub fn alloc_ivc_channel(&self, expected_size: usize) -> AxResult<(GuestPhysAddr, usize)> {
         // Ensure the expected size is aligned to 4K.
         let size = align_up_4k(expected_size);
-        let gpa = self.inner_const().devices.alloc_ivc_channel(size)?;
+        let gpa = self.get_devices()?.alloc_ivc_channel(size)?;
         Ok((gpa, size))
     }
 
@@ -1221,7 +1555,7 @@ impl AxVM {
     /// ## Returns
     /// * `AxResult<()>` - An empty result indicating success or failure.
     pub fn release_ivc_channel(&self, gpa: GuestPhysAddr, size: usize) -> AxResult {
-        self.inner_const().devices.release_ivc_channel(gpa, size)?;
+        self.get_devices()?.release_ivc_channel(gpa, size)?;
         Ok(())
     }
 
@@ -1247,26 +1581,37 @@ impl AxVM {
 
         let gpa = gpa.unwrap_or_else(|| hpa.as_usize().into());
 
-        let mut g = self.inner_mut.lock();
-        g.address_space.map_linear(
-            gpa,
-            hpa,
-            layout.size(),
-            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE | MappingFlags::USER,
-        )?;
-        g.memory_regions.push(VMMemoryRegion {
-            gpa,
-            hva,
-            layout,
-            needs_dealloc: true, // This region was allocated and needs to be freed
-        });
+        if let Err(err) = self.with_resources_mut(|resources| {
+            resources.address_space.map_linear(
+                gpa,
+                hpa,
+                layout.size(),
+                MappingFlags::READ
+                    | MappingFlags::WRITE
+                    | MappingFlags::EXECUTE
+                    | MappingFlags::USER,
+            )?;
+            resources.memory_regions.push(VMMemoryRegion {
+                gpa,
+                hva,
+                layout,
+                needs_dealloc: true, // This region was allocated and needs to be freed
+            });
+            Ok(())
+        }) {
+            unsafe {
+                alloc::alloc::dealloc(hva.as_mut_ptr(), layout);
+            }
+            return Err(err);
+        }
 
         Ok(s)
     }
 
     /// Returns a list of all memory regions in the VM.
     pub fn memory_regions(&self) -> Vec<VMMemoryRegion> {
-        self.inner_mut.lock().memory_regions.clone()
+        self.with_resources(|resources| Ok(resources.memory_regions.clone()))
+            .unwrap_or_default()
     }
 
     /// Maps a reserved memory region for the VM.
@@ -1281,73 +1626,63 @@ impl AxVM {
         );
         let gpa =
             gpa.ok_or_else(|| ax_err_type!(InvalidInput, "Reserved memory GPA is required"))?;
-        let mut g = self.inner_mut.lock();
-        g.address_space.map_linear(
-            gpa,
-            gpa.as_usize().into(),
-            layout.size(),
-            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE | MappingFlags::USER,
-        )?;
-        let hva = gpa.as_usize().into();
-        g.memory_regions.push(VMMemoryRegion {
-            gpa,
-            hva,
-            layout,
-            needs_dealloc: false, // This is a reserved region, not allocated
-        });
-        Ok(())
+        self.with_resources_mut(|resources| {
+            resources.address_space.map_linear(
+                gpa,
+                gpa.as_usize().into(),
+                layout.size(),
+                MappingFlags::READ
+                    | MappingFlags::WRITE
+                    | MappingFlags::EXECUTE
+                    | MappingFlags::USER,
+            )?;
+            let hva = gpa.as_usize().into();
+            resources.memory_regions.push(VMMemoryRegion {
+                gpa,
+                hva,
+                layout,
+                needs_dealloc: false, // This is a reserved region, not allocated
+            });
+            Ok(())
+        })
     }
 
-    /// Cleanup resources for the VM before drop.
-    /// This is called internally by the Drop implementation.
-    fn cleanup_resources(&self) {
-        info!("Cleaning up VM[{}] resources...", self.id());
+    /// Destroys the VM and releases all lifecycle-owned resources.
+    pub fn destroy(&self) -> AxResult {
+        let vm_id = self.id();
+        self.machine
+            .lock()
+            .destroy_with(|resources| {
+                if let Some(mut resources) = resources {
+                    Self::cleanup_resource_set(vm_id, &mut resources);
+                }
+                Ok(())
+            })
+            .map_err(VmLifecycleError::into_ax_error)
+    }
 
-        // 1. Ensure the VM is in Stopping or Stopped state
-        let current_status = self.vm_status();
-        if !matches!(current_status, VMStatus::Stopping | VMStatus::Stopped) {
-            warn!(
-                "VM[{}] is being dropped without explicit shutdown (status: {:?}), marking as \
-                 stopping",
-                self.id(),
-                current_status
-            );
-            self.set_vm_status(VMStatus::Stopping);
-        }
+    fn cleanup_resource_set(vm_id: usize, resources: &mut AxVMResources) {
+        info!("Cleaning up VM[{vm_id}] resources...");
 
-        let mut inner_mut = self.inner_mut.lock();
-
-        // First, collect all memory regions to clean up
-        // We need to clone the regions to avoid borrowing issues
-        let regions_to_cleanup: Vec<VMMemoryRegion> = inner_mut.memory_regions.clone();
-
-        // Unmap all memory regions from the address space
-        // This must be done BEFORE deallocating memory to avoid use-after-free
+        let regions_to_cleanup = resources.memory_regions.clone();
         for region in &regions_to_cleanup {
             debug!(
-                "VM[{}] unmapping memory region: GPA={:#x}, size={:#x}",
-                self.id(),
+                "VM[{vm_id}] unmapping memory region: GPA={:#x}, size={:#x}",
                 region.gpa.as_usize(),
                 region.size()
             );
-            // Unmap the region from guest physical address space
-            if let Err(e) = inner_mut.address_space.unmap(region.gpa, region.size()) {
+            if let Err(err) = resources.address_space.unmap(region.gpa, region.size()) {
                 warn!(
-                    "VM[{}] failed to unmap region at GPA={:#x}: {:?}",
-                    self.id(),
-                    region.gpa.as_usize(),
-                    e
+                    "VM[{vm_id}] failed to unmap region at GPA={:#x}: {err:?}",
+                    region.gpa.as_usize()
                 );
             }
         }
 
-        // Now it's safe to deallocate the memory
         for region in &regions_to_cleanup {
-            // Only deallocate memory regions that were allocated by the allocator
             if region.needs_dealloc {
                 debug!(
-                    "VM[{}] deallocating memory region: HVA={:#x}, size={:#x}",
-                    self.id(),
+                    "VM[{vm_id}] deallocating memory region: HVA={:#x}, size={:#x}",
                     region.hva.as_usize(),
                     region.size()
                 );
@@ -1356,56 +1691,27 @@ impl AxVM {
                 }
             } else {
                 debug!(
-                    "VM[{}] skipping dealloc for reserved memory region: GPA={:#x}, HVA={:#x}, \
+                    "VM[{vm_id}] skipping reserved memory region dealloc: GPA={:#x}, HVA={:#x}, \
                      size={:#x}",
-                    self.id(),
                     region.gpa.as_usize(),
                     region.hva.as_usize(),
                     region.size()
                 );
             }
         }
-        inner_mut.memory_regions.clear();
+        resources.memory_regions.clear();
+        resources.address_space.clear();
 
-        // Clear remaining address space mappings
-        // This includes:
-        // - Passthrough device MMIO mappings
-        // - Emulated device MMIO mappings
-        // - Reserved memory mappings
-        // - All other page table entries
-        debug!(
-            "VM[{}] clearing remaining address space mappings",
-            self.id()
-        );
-        inner_mut.address_space.clear();
-
-        // Release the lock before accessing inner_const
-        drop(inner_mut);
-
-        // Device cleanup
-        // Although devices will be automatically dropped when inner_const is dropped,
-        // we should perform explicit cleanup if devices hold resources like:
-        // - Hardware interrupt registrations
-        // - DMA mappings
-        // - Background threads or timers
-        if let Some(inner_const) = self.inner_const.get() {
+        if let Some(devices) = resources.devices.take() {
             debug!(
-                "VM[{}] devices cleanup: {} device(s)",
-                self.id(),
-                inner_const.devices.devices().count()
+                "VM[{vm_id}] devices cleanup: {} device(s)",
+                devices.devices().count()
             );
-
-            // TODO: Add device-specific cleanup if needed
-            // For example:
-            // - Stop device background tasks
-            // - Unregister interrupts
-            // - Release device-specific resources
-
-            // Note: Device Arc references will be dropped automatically when
-            // inner_const is dropped at the end of AxVM's drop
         }
+        resources.vcpu_list = None;
+        resources.interrupt_fabric = None;
 
-        info!("VM[{}] resources cleanup completed", self.id());
+        info!("VM[{vm_id}] resources cleanup completed");
     }
 }
 
@@ -1413,8 +1719,9 @@ impl Drop for AxVM {
     fn drop(&mut self) {
         info!("Dropping VM[{}]", self.id());
 
-        // Clean up all allocated resources
-        self.cleanup_resources();
+        if let Err(err) = self.destroy() {
+            warn!("VM[{}] destroy during drop failed: {err:?}", self.id());
+        }
 
         info!("VM[{}] dropped", self.id());
     }

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -203,7 +203,14 @@ impl VmRuntimeHandle {
     }
 
     pub(crate) fn join_all_vcpu_tasks(&self, vm_id: usize) {
-        let tasks: Vec<_> = self.vcpu_task_list.lock().values().cloned().collect();
+        let current = crate::host::task::current_task();
+        let tasks: Vec<_> = self
+            .vcpu_task_list
+            .lock()
+            .values()
+            .filter(|task| !current.ptr_eq(task))
+            .cloned()
+            .collect();
         let task_count = tasks.len();
         info!("VM[{vm_id}] Joining {task_count} VCpu tasks...");
         for (idx, task) in tasks.iter().enumerate() {
@@ -748,6 +755,10 @@ impl AxVM {
         f(runtime)
     }
 
+    fn take_stopped_runtime(&self) -> Option<Arc<VmRuntimeHandle>> {
+        self.machine.lock().take_stopped_runtime()
+    }
+
     /// Retrieves the vCPU corresponding to the given vcpu_id for the VM.
     /// Returns None if the vCPU does not exist.
     #[inline]
@@ -828,6 +839,9 @@ impl AxVM {
     pub fn start(self: &Arc<Self>) -> AxResult {
         self.ensure_resources_ready()?;
         if self.status() == VmStatus::Stopped {
+            if let Some(runtime) = self.take_stopped_runtime() {
+                runtime.join_all_vcpu_tasks(self.id());
+            }
             self.prepare()?;
         }
         info!("Starting VM[{}]", self.id());
@@ -932,13 +946,10 @@ impl AxVM {
         )
     }
 
-    /// Resets the VM by discarding runtime-only state, rebuilding vCPUs/devices,
-    /// and starting from a fresh `Running` state.
-    pub fn reset(self: &Arc<Self>) -> AxResult {
-        info!("Resetting VM[{}]", self.id());
+    fn stop_and_join_runtime(&self, reason: StopReason) -> AxResult {
         match self.status() {
             VmStatus::Running | VmStatus::Paused => {
-                self.stop(StopReason::Forced)?;
+                self.stop(reason)?;
                 if let Ok(()) = self.with_runtime(|runtime| {
                     runtime.notify_all();
                     Ok(())
@@ -956,10 +967,22 @@ impl AxVM {
             status => {
                 return ax_err!(
                     BadState,
-                    format!("VM[{}] cannot reset from {status:?}", self.id())
+                    format!("VM[{}] cannot quiesce runtime from {status:?}", self.id())
                 );
             }
         }
+
+        if let Some(runtime) = self.take_stopped_runtime() {
+            runtime.join_all_vcpu_tasks(self.id());
+        }
+        Ok(())
+    }
+
+    /// Resets the VM by discarding runtime-only state, rebuilding vCPUs/devices,
+    /// and starting from a fresh `Running` state.
+    pub fn reset(self: &Arc<Self>) -> AxResult {
+        info!("Resetting VM[{}]", self.id());
+        self.stop_and_join_runtime(StopReason::Forced)?;
 
         self.machine
             .lock()
@@ -1650,6 +1673,20 @@ impl AxVM {
     /// Destroys the VM and releases all lifecycle-owned resources.
     pub fn destroy(&self) -> AxResult {
         let vm_id = self.id();
+        match self.status() {
+            VmStatus::Running | VmStatus::Paused | VmStatus::Stopping => {
+                self.stop_and_join_runtime(StopReason::Forced)?;
+            }
+            VmStatus::Ready | VmStatus::Stopped | VmStatus::Uninit | VmStatus::Failed => {
+                if let Some(runtime) = self.take_stopped_runtime() {
+                    runtime.join_all_vcpu_tasks(vm_id);
+                }
+            }
+            VmStatus::Destroyed | VmStatus::Destroying => {}
+            VmStatus::Pausing => {
+                self.stop_and_join_runtime(StopReason::Forced)?;
+            }
+        }
         self.machine
             .lock()
             .destroy_with(|resources| {


### PR DESCRIPTION
## 问题

`axvm` 原有 VM 生命周期由多个位置共同维护：VM 内部状态、runtime vCPU task 全局表、Axvisor shell/runtime 的手写状态判断各自推进，导致状态真相分散，vCPU task、设备、IRQ fabric、地址空间等资源生命周期不闭环，也不利于后续 stop/reset/destroy 语义收敛。

## 改动

- 新增 `axvm::lifecycle` 模块，提供公开 `VmStatus` / `StopReason` 和内部 `Machine` 状态机。
- 将 `AxVM` 重构为稳定元数据加 `Mutex<Machine<AxVMResources, VmRuntimeHandle>>`，由 `Machine` 持有不同阶段资源。
- 将 vCPU task、wait queue、pending interrupt、运行计数从全局表迁移到 VM-owned `VmRuntimeHandle`，随 `Running/Stopping/Stopped` 生命周期创建、停止确认和回收。
- 重写 VM 生命周期 API：`prepare/start/pause/resume/stop/reset/destroy/status`，移除旧状态写入口和启动 helper 依赖。
- `reset` 会等待旧运行态停止并 join 旧 vCPU task，清理 vCPU/device/interrupt fabric 派生状态，保留 VM 内存镜像并重建运行态后重新启动。
- `destroy` 会先 quiesce 运行态并回收旧 runtime，再释放地址空间、设备、IRQ fabric 和 vCPU 资源，避免运行中的 vCPU 访问已释放资源。
- 迁移 `os/axvisor` manager、config、shell、vmm 到新 API；新增 `vm reset`，保留 `vm restart` 作为 reset 别名。
- RISC-V 虚拟 IRQ 注入改为通过 VM 受控方法进入 interrupt fabric，避免外部直接拿内部资源。

## 设计逻辑

这次重构把 VM 生命周期收敛为单一状态机真相：状态转换通过消费旧 variant 构造新 variant 完成，外部只能通过公开生命周期 API 触发协议，不能直接写状态。运行期资源不再挂在 runtime 全局表上，而是跟随 VM 的生命周期 variant，避免 stop/destroy/reset 后继续复用脏 runtime。

停止协议被拆成两段：vCPU 观察到 `Stopping` 后退出并调用 `finish_stop`，状态进入 `Stopped` 但仍临时保留待回收 runtime；随后 VM API 取出 runtime 并 join vCPU task，只有回收完成后的 `Stopped` 才能进入 `start/reset/destroy`。这样 `reset` 不会在旧 vCPU 退出前启动新 runtime，全局 running VM 计数也按新 runtime 重新计入。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p axvm`
- `cargo xtask clippy --package axvm`
- `cargo xtask clippy --package axvisor`（当前 xtask 提示 axvisor 需要专用 target/build 配置并跳过包选择）
- `cargo xtask axvisor test qemu --list`
- `cargo xtask axvisor build --arch x86_64`（通过；保留既有 `resolve_device_irq` / `fill_vm_region` unused warning）

未运行完整 QEMU smoke 矩阵和 LoongArch LVZ container smoke。
