### PR TITLE
test(starry): add Python scientific-computing carpet (py-sci)

### DIFF
--- a/apps/starry/py-sci/README.md
+++ b/apps/starry/py-sci/README.md
@@ -1,0 +1,57 @@
+# py-sci — Python 科学计算地毯式测试
+
+工业级、精确断言（exact-assertion）的科学计算库正确性测试：由 **musl 原生 CPython3** 在 StarryOS
+四个架构（x86_64 / aarch64 / riscv64 / loongarch64）上运行，覆盖五个科学计算库：
+
+| 模块 | 库 | 维度 | 标记 |
+|:--|:--|:--|:--|
+| numpy | NumPy | 数组运算 / 广播 / 视图与跨步 / dtype 转换 / 布尔与花式索引 / 轴向归约 / 线性代数（det·solve·inv·eigvalsh·norm·matmul）/ FFT / PCG64 原始随机流 / 排序与拼接 | `NUMPY_DONE` |
+| opencv | OpenCV (cv2) | 色彩空间转换 / 最近邻缩放 / 阈值 / PNG·BMP 往返 / 仿射平移与旋转矩阵 / 边框 / 翻转与转置 / 形态学腐蚀膨胀 / filter2D 单位核 / 积分图 / minMaxLoc / 轮廓计数 | `OPENCV_DONE` |
+| pyarrow | Apache Arrow / Parquet | Parquet 写入→读回的精确往返（schema 字段名与类型 + 全部取值）/ compute 计算核 / bool·list 类型 / RecordBatch / ChunkedArray / 内存 IPC 流往返 | `PYARROW_DONE` |
+| scipy | SciPy | LU / Cholesky / solve / det / inv / 稀疏 CSR 矩阵 / 凸二次极小化与多项式求根 / 卷积与相关 / 高斯 cdf·pdf / 皮尔逊相关 | `SCIPY_DONE` |
+| sympy | SymPy | 符号化简与三角恒等式 / 展开与因式分解 / 方程求解 / 微分·积分·极限 / 精确有理数 / 矩阵行列式与逆 / 求和闭式 / 高精度数值（π、√2 固定前缀） | `SYMPY_DONE` |
+
+每个模块都是自包含地毯（独立 ok/fail 计数器），断言全部采用与库版本无关的**精确整数 /
+闭式代数 / 定点整数运算的 sha256 / 标签无关聚类 / 固定位数高精度前缀**等稳定不变量——因此宿主参照库与
+（更新的）目标端库会给出逐字相同的结果，不依赖浮点 repr、默认 dtype 宽度或打印格式。模块仅在内部 fail
+计数为 0 时打印其 `*_DONE` 标记；`run_pysci.py` 运行全部五个模块，且仅当五个全部通过时才打印
+`PY_SCI_OK=5/5` 与 `TEST PASSED`（不允许跳过）。
+
+## numba（暂缓项 🕊）
+
+`numba` 未纳入本测试：Alpine 没有 `py3-numba` 的 musl apk，且其依赖的 `llvmlite` / LLVM JIT
+没有 musl 发行版（无法在 musl 原生 CPython 上即时编译）。`run_pysci.py` 会就此打印一条信息性
+SKIP 行，**不计入** 通过/总数。这是发行版与工具链的客观边界，并非 StarryOS 的缺陷。
+
+## 运行
+
+```
+cargo xtask starry app qemu -t py-sci --arch x86_64
+cargo xtask starry app qemu -t py-sci --arch aarch64
+cargo xtask starry app qemu -t py-sci --arch riscv64
+cargo xtask starry app qemu -t py-sci --arch loongarch64
+```
+
+`prebuild.sh` 通过 qemu-user-static 把 base Alpine rootfs 解到 staging 树后，将其 apk
+仓库指向 Alpine **v3.23** 分支（main + community），`apk add`
+`python3 py3-numpy py3-opencv py3-pyarrow py3-scipy py3-sympy`——由 apk 为目标架构解析**当前版本**
+及其完整的 musl 原生 `.so` 闭包（无任何写死的、会漂移的 apk URL，无缓存缺失即退出）。v3.23 为
+python 3.12 系列，与 base 镜像同系，无 musl/ABI 漂移；四个架构在 v3.23 上均有这五个包的 musl 原生构建
+（`py3-sympy` 为 noarch 纯 python）。脚本随后把解释器、其共享库闭包、标准库 + site-packages
+（numpy/cv2/pyarrow/scipy/sympy 及其扩展 `.so`）以及扩展所需的每个 `/usr/lib/*.so*`
+（OpenBLAS / libgfortran / OpenCV 库 / Arrow C++ 与 Parquet 库等）复制进 per-app overlay。
+
+科学计算闭包体积很大，prebuild 在 harness 注入 overlay 之前先把 per-app rootfs 镜像扩容
+（truncate + e2fsck + resize2fs），以免 debugfs 注入时静默截断大型 `.so` 文件。
+
+地毯源码位于 `python/`；on-target 启动器 `programs/run-pysci.sh` 设置 musl 加载器搜索路径并把
+BLAS/OpenMP 线程数固定为 1，然后执行 `python3 /root/pysci/run_pysci.py`。
+
+## 架构说明
+
+- x86_64：`-cpu Haswell` 向用户态暴露 AVX2/AES-NI/XSAVE（NumPy/OpenCV/pyarrow 的 SIMD 与
+  Arrow/abseil 的 RANDEN 会探测并使用 AVX）；内核侧 CR4.OSXSAVE 与 XCR0 的开启在 dev 分支中。
+- aarch64：`-cpu cortex-a72`（NEON 与 64 位特性集）。
+- riscv64：`-cpu rv64`。
+- loongarch64：`-machine virt -cpu la464`，动态平台（`build-loongarch64*.toml` 带
+  `ax-driver/serial`，不含 `ax-hal/loongarch64-qemu-virt` / `plat-static` / `plat_dyn=false`）。

--- a/apps/starry/py-sci/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/py-sci/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,13 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/py-sci/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/py-sci/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,14 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]

--- a/apps/starry/py-sci/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/py-sci/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/py-sci/build-x86_64-unknown-none.toml
+++ b/apps/starry/py-sci/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/py-sci/prebuild.sh
+++ b/apps/starry/py-sci/prebuild.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# prebuild.sh — provision a CPython 3 scientific-computing environment (NumPy / OpenCV /
+# pyarrow / SciPy / SymPy) and stage the exact-assertion carpet suite for StarryOS.
+#
+# Portable, reproducible model (mirrors the merged python-lang / python-net apps): extract the
+# base Alpine rootfs to a staging tree, point its apk repositories at the Alpine v3.23 branch,
+# `apk add` the scientific package set INTO the staging tree via qemu-user-static (so apk
+# RESOLVES THE CURRENT VERSION + the full musl-native .so closure for the TARGET arch — no
+# hardcoded drifting apk URLs, no cache-miss-exit), then copy the python3 binary, its shared-
+# library closure, the stdlib + site-packages (numpy / cv2 / pyarrow / scipy / sympy and their
+# C/C++/Fortran extension .so) and every staged /usr/lib/*.so* the extensions need into the app
+# overlay. The only inputs are the registered base rootfs and the Alpine apk repos.
+#
+# Branch choice: Alpine v3.23 community ships musl-native binaries of all five packages for all
+# four target arches (x86_64 / aarch64 / riscv64 / loongarch64) at the proven versions
+# (py3-numpy 2.3.5 / py3-opencv 4.12.0 / py3-pyarrow 21.0.0 / py3-scipy 1.16.x; py3-sympy is
+# noarch pure-python). v3.23 is python 3.12.x — the same 3.12 series as the base image, so there
+# is no musl/ABI drift. Because the WHOLE closure (including musl) is taken from the v3.23
+# staging tree, the overlay is self-consistent regardless of the base image's exact branch. If a
+# package/arch were ever missing from v3.23 one would fall through to edge (PYSCI_APK_BRANCH=edge),
+# but all five are present in v3.23 for all four arches.
+#
+# numba is intentionally NOT provisioned: Alpine has no py3-numba musl apk and llvmlite / the LLVM
+# JIT it needs has no musl distribution. The carpet reports numba as a documented SKIP.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS (per-app rootfs image, injected after this
+# script), STARRY_STAGING_ROOT (scratch extraction tree), STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+PROG="$app_dir/programs"
+
+# Alpine branch holding the scientific package set (v3.23 = proven versions, python 3.12).
+APK_BRANCH="${PYSCI_APK_BRANCH:-v3.23}"
+ALPINE_CDN="${ALPINE_CDN:-https://dl-cdn.alpinelinux.org/alpine}"
+# Target rootfs size: the scientific closure (numpy + opencv + pyarrow + scipy + their C++/
+# Fortran .so, incl. OpenBLAS / Arrow C++ / OpenCV libs) is large (hundreds of MB). The harness
+# injects the overlay via debugfs WITHOUT resizing, so an undersized fs SILENTLY TRUNCATES the
+# big .so files. Grow first (mirrors the java-lang recipe). Disk is cheap; QEMU maps only what it uses.
+ROOTFS_SIZE="${PYSCI_ROOTFS_SIZE:-6G}"
+# Optional offline apk cache (speed-up only). Network apk add stays the primary, source-of-truth
+# path; a missing cache entry is filled from the network, NEVER an exit.
+APK_CACHE="${PYSCI_APK_CACHE:-}"
+
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs    >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v resize2fs  >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v e2fsck     >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v truncate   >/dev/null 2>&1 || missing+=(coreutils)
+    command -v readelf    >/dev/null 2>&1 || missing+=(binutils)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        if command -v apt-get >/dev/null 2>&1; then
+            echo "prebuild: installing host tools: ${missing[*]}"
+            apt-get update && apt-get install -y --no-install-recommends "${missing[@]}"
+        else
+            echo "prebuild: missing host tools and no apt-get: ${missing[*]}" >&2
+            exit 1
+        fi
+    fi
+}
+
+# Grow the per-app rootfs image so the injected scientific closure fits without truncation.
+# Idempotent: truncate only grows, e2fsck/resize2fs are safe to re-run.
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    local before after
+    before=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs $base_rootfs is $((before / 1024 / 1024)) MiB; growing to $ROOTFS_SIZE"
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown to $((after / 1024 / 1024)) MiB (fs resized)"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    # qemu-user resolves ABSOLUTE symlink targets against the HOST root, so an alpine
+    # `usr/lib/libz.so.1 -> /usr/lib/libz.so.1.3.2` dangles on a non-alpine build host and apk
+    # fails to load its libz/libssl/libcrypto closure ("symbol not found"). Rewrite every absolute
+    # symlink under the staging lib dirs to a relative target that resolves inside the staging tree.
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"
+        [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+install_python() {
+    normalize_symlinks
+    # apk can resolve hostnames inside qemu-user with the host's DNS config.
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    # Point apk at the chosen Alpine branch (v3.23 main+community) so `apk add` resolves the
+    # CURRENT version of each package + its full musl/openblas/Arrow/opencv closure for the
+    # target arch (copied into the overlay below). No hardcoded per-file apk URLs.
+    printf '%s/%s/main\n%s/%s/community\n' \
+        "$ALPINE_CDN" "$APK_BRANCH" "$ALPINE_CDN" "$APK_BRANCH" \
+        > "$staging_root/etc/apk/repositories"
+    local cache_args=()
+    if [[ -n "$APK_CACHE" ]]; then
+        mkdir -p "$APK_CACHE"
+        cache_args=(--cache-dir "$APK_CACHE")
+        echo "prebuild: using offline apk cache $APK_CACHE (network fills any miss)"
+    fi
+    echo "prebuild: apk add python3 + scientific set ($APK_BRANCH) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" \
+    LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" \
+            "$staging_root/sbin/apk" \
+            --root "$staging_root" \
+            --repositories-file "$staging_root/etc/apk/repositories" \
+            --keys-dir "$staging_root/etc/apk/keys" \
+            "${cache_args[@]}" \
+            --update-cache --no-progress --no-scripts \
+            add python3 py3-numpy py3-opencv py3-pyarrow py3-scipy py3-sympy
+    # Lenient version gate: the carpet asserts version-stable invariants, so any CPython >= 3.12
+    # is acceptable (never an exact patch string).
+    local pyver
+    pyver="$(ls -d "$staging_root"/usr/lib/python3.* 2>/dev/null | grep -oE 'python3\.[0-9]+' | head -1)"
+    case "$pyver" in
+        python3.1[2-9]|python3.2[0-9]) echo "prebuild: provisioned $pyver" ;;
+        *) echo "prebuild: need CPython >= 3.12 but got '$pyver'" >&2; exit 3 ;;
+    esac
+}
+
+copy_to_overlay() {  # guest-path mode
+    local src="$staging_root$1" dst="$overlay_dir$1"
+    [[ -e "$src" ]] || { echo "prebuild: missing $1 after install" >&2; exit 4; }
+    [[ -L "$src" ]] && src="$(readlink -f "$src")"
+    install -Dm"$2" "$src" "$dst"
+}
+
+# recursively copy the shared-library closure of an ELF into the overlay
+copy_so_closure() {
+    local pending=("$@") seen=" " gp lib d
+    while [[ ${#pending[@]} -gt 0 ]]; do
+        gp="${pending[0]}"; pending=("${pending[@]:1}")
+        [[ "$seen" == *" $gp "* ]] && continue
+        seen+="$gp "
+        while IFS= read -r lib; do
+            for d in lib usr/lib usr/local/lib; do
+                if [[ -e "$staging_root/$d/$lib" ]]; then
+                    copy_to_overlay "/$d/$lib" 0644
+                    pending+=("/$d/$lib")
+                    break
+                fi
+            done
+        done < <(readelf -d "$staging_root$gp" 2>/dev/null | sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p')
+    done
+}
+
+populate_overlay() {
+    local pyver
+    pyver="$(ls -d "$staging_root"/usr/lib/python3.* 2>/dev/null | grep -oE 'python3\.[0-9]+' | head -1)"
+    copy_to_overlay /usr/bin/python3 0755
+    copy_so_closure /usr/bin/python3
+    # lib-dynload C-extension modules carry their own .so deps
+    if [[ -d "$staging_root/usr/lib/$pyver/lib-dynload" ]]; then
+        for so in "$staging_root/usr/lib/$pyver/lib-dynload"/*.so; do
+            [[ -e "$so" ]] && copy_so_closure "/usr/lib/$pyver/lib-dynload/$(basename "$so")"
+        done
+    fi
+    # The scientific apks landed in site-packages of the staging tree; the cp -a below carries
+    # numpy / cv2 / pyarrow / scipy / sympy and their bundled .so into the overlay.
+    local sp="$staging_root/usr/lib/$pyver/site-packages"
+    mkdir -p "$overlay_dir/usr/lib/$pyver"
+    cp -a "$staging_root/usr/lib/$pyver/." "$overlay_dir/usr/lib/$pyver/"
+    ln -sf python3 "$overlay_dir/usr/bin/python" 2>/dev/null || true
+
+    # site-packages C-extensions (numpy / cv2 / pyarrow / scipy native .so) carry their own .so
+    # deps (libopenblas, libgfortran, libopencv_*, libarrow / libparquet / libthrift, liblapack,
+    # libstdc++, ...). Pull the full transitive closure so the runtime loader finds every one of
+    # them in the overlay /usr/lib.
+    if [[ -d "$sp" ]]; then
+        while IFS= read -r so; do
+            copy_so_closure "/usr/lib/$pyver/site-packages/${so#"$sp"/}"
+        done < <(find "$sp" -name '*.so' 2>/dev/null)
+    fi
+
+    # Stage the carpet suite + on-target gate harness under /root/pysci (run by run_pysci.py).
+    mkdir -p "$overlay_dir/root/pysci"
+    local n=0
+    for f in "$app_dir"/python/*.py; do
+        [[ -f "$f" ]] || continue
+        install -Dm0644 "$f" "$overlay_dir/root/pysci/$(basename "$f")"
+        n=$((n + 1))
+    done
+    # Stage the run wrapper (sets musl loader path + thread caps, then execs python3 run_pysci.py).
+    install -Dm0755 "$PROG/run-pysci.sh" "$overlay_dir/usr/bin/run-pysci.sh"
+    echo "prebuild: staged $n python module(s); $pyver scientific overlay ready for $arch"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+install_python
+populate_overlay

--- a/apps/starry/py-sci/programs/run-pysci.sh
+++ b/apps/starry/py-sci/programs/run-pysci.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# run-pysci.sh — on-target launcher for the python scientific-computing carpet.
+#
+# Sets the musl dynamic-loader search path (so the loader finds the OpenBLAS / Arrow C++ /
+# OpenCV / Fortran .so injected under /lib + /usr/lib), pins BLAS/OpenMP to a single thread for
+# determinism, then hands off to python3 run_pysci.py. The PASS/FAIL gate (the TEST PASSED /
+# TEST FAILED anchor) lives entirely in run_pysci.py — this wrapper never prints it, so the
+# success regex cannot self-match on the launch command.
+#
+# The musl loader reads only /etc/ld-musl-<this-arch>.path; writing all four names is harmless
+# and keeps the launcher arch-agnostic.
+for a in x86_64 aarch64 riscv64 loongarch64; do
+    printf '/lib\n/usr/lib\n' > "/etc/ld-musl-$a.path"
+done
+
+export PATH=/usr/bin:/bin:/sbin:/usr/sbin
+export HOME=/root
+export PYTHONDONTWRITEBYTECODE=1
+export PYTHONUNBUFFERED=1
+export OPENBLAS_NUM_THREADS=1
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+export OPENCV_NUM_THREADS=1
+
+cd /root/pysci || exit 1
+exec python3 run_pysci.py

--- a/apps/starry/py-sci/python/NumpyCarpet.py
+++ b/apps/starry/py-sci/python/NumpyCarpet.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# NumpyCarpet.py — exact-assertion carpet for NumPy on musl-native CPython.
+#
+# Every assertion is an EXACT integer, a closed-form linear-algebra identity, or a
+# version-stable structural invariant — chosen so it holds identically on the host
+# reference NumPy and on the (newer) on-target NumPy. Nothing depends on float repr,
+# default-dtype width, or print formatting. Self-contained ok/fail counters; prints
+# NUMPY_RESULT then NUMPY_DONE only when fail == 0.
+import sys
+
+ok = 0
+fail = 0
+
+
+def chk(name, cond, info=""):
+    global ok, fail
+    if cond:
+        ok += 1
+        print("  ok %s%s" % (name, (" " + info) if info else ""))
+    else:
+        fail += 1
+        print("  FAIL %s%s" % (name, (" " + info) if info else ""))
+
+
+import numpy as np
+
+# Lenient version floor (major), never an exact patch string.
+chk("version", int(np.__version__.split(".")[0]) >= 1, "numpy=%s" % np.__version__)
+
+# ---- PROVEN core (4-arch green): EXACT integer + closed-form linear algebra ----
+A = np.arange(1, 10, dtype=np.int64).reshape(3, 3)
+C = A.dot(np.eye(3, dtype=np.int64) * 2)  # matmul with 2*I
+chk("matmul_sum", int(C.sum()) == 90)
+chk("matmul_trace", int(np.trace(C)) == 30)
+v = np.array([3, 1, 2, 5, 4], dtype=np.int64)
+chk("sort", np.sort(v).tolist() == [1, 2, 3, 4, 5])
+chk("cumsum", np.cumsum(v).tolist() == [3, 4, 6, 11, 15])
+chk("dot", int(np.array([1, 2, 3]).dot(np.array([4, 5, 6]))) == 32)
+chk("det_diag", round(float(np.linalg.det(np.diag([2.0, 3.0, 4.0])))) == 24)
+xs = np.linalg.solve(np.array([[3.0, 0.0], [0.0, 5.0]]), np.array([9.0, 20.0]))
+chk("solve", [round(float(z)) for z in xs] == [3, 4])
+chk("fsum", float(np.array([0.5, 0.25, 0.125]).sum()) == 0.875)  # exact in binary
+
+# ---- Broadcasting (row + column vector -> outer-sum matrix) ----
+B = np.arange(3).reshape(3, 1) + np.arange(3).reshape(1, 3)
+chk("broadcast", B.tolist() == [[0, 1, 2], [1, 2, 3], [2, 3, 4]])
+
+# ---- Views / strides / reshape / transpose ----
+a = np.arange(12, dtype=np.int64)
+m = a.reshape(3, 4)
+chk("reshape_index", int(m[1, 2]) == 6)
+chk("transpose", m.T.tolist() == [[0, 4, 8], [1, 5, 9], [2, 6, 10], [3, 7, 11]])
+chk("strided_view", a[::2].tolist() == [0, 2, 4, 6, 8, 10])
+chk("ravel", m[:2, :2].ravel().tolist() == [0, 1, 4, 5])
+# A slice is a view that shares memory with its base; mutate a fresh array to prove it.
+fresh = np.arange(6, dtype=np.int64)
+fview = fresh[::2]
+fview[0] = 99
+chk("view_aliases_base", int(fresh[0]) == 99)
+
+# ---- dtype casting (truncation, bool, modular integer wrap) ----
+# Array arithmetic wraps modularly in every NumPy version (defined C behaviour); avoid the
+# scalar / out-of-bound-Python-int casts that NumPy 2.x turns into errors.
+chk("cast_float_to_int", np.array([1.9, 2.1, -1.7]).astype(np.int64).tolist() == [1, 2, -1])
+chk("cast_to_bool", np.array([0, 1, 2, 0]).astype(bool).tolist() == [False, True, True, False])
+chk("uint8_wrap", (np.array([250, 200], dtype=np.uint8) + np.array([50, 100], dtype=np.uint8)).tolist() == [44, 44])
+chk("int8_wrap", (np.array([127], dtype=np.int8) + np.array([1], dtype=np.int8)).tolist() == [-128])
+
+# ---- Boolean masking / fancy indexing / where ----
+g = np.arange(10)
+chk("bool_mask", g[g % 2 == 0].tolist() == [0, 2, 4, 6, 8])
+chk("fancy_index", g[[1, 3, 5, 7]].tolist() == [1, 3, 5, 7])
+chk("where", np.where(np.array([True, False, True]), np.array([1, 2, 3]), np.array([4, 5, 6])).tolist() == [1, 5, 3])
+
+# ---- Reductions over axes ----
+M = np.arange(6, dtype=np.int64).reshape(2, 3)  # [[0,1,2],[3,4,5]]
+chk("sum_axis0", M.sum(axis=0).tolist() == [3, 5, 7])
+chk("sum_axis1", M.sum(axis=1).tolist() == [3, 12])
+chk("prod_all", int(np.arange(1, 5).prod()) == 24)
+chk("min_max", int(M.min()) == 0 and int(M.max()) == 5)
+chk("argmin_argmax", int(M.argmin()) == 0 and int(M.argmax()) == 5)
+chk("max_axis1", M.max(axis=1).tolist() == [2, 5])
+chk("mean_axis0", M.mean(axis=0).tolist() == [1.5, 2.5, 3.5])  # exact in binary
+
+# ---- Linear algebra (det / inv / eigvalsh / norm / matmul-operator) ----
+chk("det_2x2", round(float(np.linalg.det(np.array([[1.0, 2.0], [3.0, 4.0]])))) == -2)
+inv = np.linalg.inv(np.array([[2.0, 0.0], [0.0, 4.0]]))
+chk("inv_diag", inv.tolist() == [[0.5, 0.0], [0.0, 0.25]])
+ev = np.linalg.eigvalsh(np.diag([3.0, 1.0, 2.0]))  # symmetric -> sorted ascending
+chk("eigvalsh", [round(float(z)) for z in ev] == [1, 2, 3])
+chk("norm", float(np.linalg.norm(np.array([3.0, 4.0]))) == 5.0)
+P = np.array([[1, 2], [3, 4]], dtype=np.int64)
+Q = np.array([[5, 6], [7, 8]], dtype=np.int64)
+chk("matmul_op", (P @ Q).tolist() == [[19, 22], [43, 50]])
+
+# ---- FFT: DFT of [1,2,3,4] has exact integer bins (rfft -> [10, -2+2j, -2]) ----
+sp = np.fft.rfft(np.array([1.0, 2.0, 3.0, 4.0]))
+re = [round(float(z.real)) for z in sp]
+im = [round(float(z.imag)) for z in sp]
+chk("rfft_real", re == [10, -2, -2])
+chk("rfft_imag", im == [0, 2, 0])
+
+# ---- Random ----
+# The PCG64 *bit-generator raw stream* is the algorithm's defining output and is frozen
+# across versions (NEP 19 + frozen SeedSequence) -> exact uint64 golden is version-stable.
+# (Generator.integers() is NOT stream-guaranteed across versions, so we assert only its
+# reproducibility + range, not exact values.)
+raw = np.random.PCG64(12345).random_raw(4).tolist()
+chk("rng_raw_stream", raw == [4193609425186963869, 5843160025838961886,
+                              14708796524633321433, 12474696839993944336], "raw=%s" % raw)
+seq = np.random.Generator(np.random.PCG64(7)).integers(0, 1000, size=8)
+seq2 = np.random.Generator(np.random.PCG64(7)).integers(0, 1000, size=8)
+chk("rng_reproducible", seq.tolist() == seq2.tolist())
+chk("rng_bounded", bool(((seq >= 0) & (seq < 1000)).all()) and len(seq) == 8)
+
+# ---- Sorting helpers / searchsorted / concatenate / stack ----
+chk("argsort", np.argsort(np.array([3, 1, 2])).tolist() == [1, 2, 0])
+chk("searchsorted", int(np.searchsorted(np.array([1, 3, 5, 7]), 4)) == 2)
+chk("concatenate", np.concatenate([np.array([1, 2]), np.array([3, 4])]).tolist() == [1, 2, 3, 4])
+chk("stack", np.stack([np.array([1, 2]), np.array([3, 4])]).tolist() == [[1, 2], [3, 4]])
+chk("unique", np.unique(np.array([3, 1, 2, 3, 1])).tolist() == [1, 2, 3])
+chk("clip", np.clip(np.array([-5, 0, 5, 10]), 0, 7).tolist() == [0, 0, 5, 7])
+
+print("NUMPY_RESULT ok=%d fail=%d" % (ok, fail))
+if fail == 0:
+    print("NUMPY_DONE")
+    sys.exit(0)
+sys.exit(1)

--- a/apps/starry/py-sci/python/OpencvCarpet.py
+++ b/apps/starry/py-sci/python/OpencvCarpet.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# OpencvCarpet.py — exact-assertion carpet for OpenCV (cv2) on musl-native CPython.
+#
+# Image ops are checked by EXACT pixel values, raw-buffer sha256 of fixed-point integer
+# operations, or exact integer arrays — all version-stable (fixed-point BGR2GRAY weights,
+# nearest-neighbour replication, morphology min/max, etc. are identical across OpenCV 4.x).
+# The cv2 version gate is lenient (major >= 4). Self-contained ok/fail counters; prints
+# OPENCV_RESULT then OPENCV_DONE only when fail == 0.
+import hashlib
+import sys
+
+ok = 0
+fail = 0
+
+
+def chk(name, cond, info=""):
+    global ok, fail
+    if cond:
+        ok += 1
+        print("  ok %s%s" % (name, (" " + info) if info else ""))
+    else:
+        fail += 1
+        print("  FAIL %s%s" % (name, (" " + info) if info else ""))
+
+
+import numpy as np
+import cv2
+
+# Lenient version floor (major), never an exact patch string.
+chk("version", int(cv2.__version__.split(".")[0]) >= 4, "cv2=%s" % cv2.__version__)
+
+# ---- PROVEN core (4-arch green): EXACT pixels + raw-buffer sha256 ----
+# BGR2GRAY uses fixed-point integer weights -> identical across OpenCV versions.
+img = np.zeros((4, 4, 3), dtype=np.uint8)
+img[:2] = [10, 20, 30]
+img[2:] = [200, 100, 50]
+gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+chk("gray_pixels", gray.flatten().tolist() == [22] * 8 + [96] * 8)
+chk("gray_sha256",
+    hashlib.sha256(gray.tobytes()).hexdigest()
+    == "1089201e8d888b0f9ef27f7cac6a0a8278979425c58dcd7da0004e71a0bae46d")
+# nearest-neighbour resize = exact pixel replication.
+small = np.array([[0, 255], [128, 64]], dtype=np.uint8)
+big = cv2.resize(small, (4, 4), interpolation=cv2.INTER_NEAREST)
+chk("resize_sha256",
+    hashlib.sha256(big.tobytes()).hexdigest()
+    == "0c45115614dc9b395f95c1f6f28dbc0aeb8d3fbc16910a49f0fe2c515a59bc1a")
+# binary threshold = exact.
+_, th = cv2.threshold(np.array([[0, 100, 150, 200]], dtype=np.uint8), 127, 255, cv2.THRESH_BINARY)
+chk("threshold", th.flatten().tolist() == [0, 0, 255, 255])
+_, thi = cv2.threshold(np.array([[0, 100, 150, 200]], dtype=np.uint8), 127, 255, cv2.THRESH_BINARY_INV)
+chk("threshold_inv", thi.flatten().tolist() == [255, 255, 0, 0])
+# PNG round-trip: encode then decode reproduces the SAME pixels (lossless), even though the
+# encoded byte stream may differ by libpng version.
+buf = cv2.imencode(".png", gray)[1]
+dec = cv2.imdecode(buf, cv2.IMREAD_GRAYSCALE)
+chk("png_roundtrip", np.array_equal(dec, gray))
+# BMP round-trip (uncompressed) — second codec path.
+buf2 = cv2.imencode(".bmp", img)[1]
+dec2 = cv2.imdecode(buf2, cv2.IMREAD_COLOR)
+chk("bmp_roundtrip", np.array_equal(dec2, img))
+
+# ---- More cvtColor codes (channel algebra, exact) ----
+px = np.array([[[1, 2, 3]]], dtype=np.uint8)  # one BGR pixel
+chk("bgr2rgb", cv2.cvtColor(px, cv2.COLOR_BGR2RGB)[0, 0].tolist() == [3, 2, 1])
+g1 = np.array([[7]], dtype=np.uint8)
+chk("gray2bgr", cv2.cvtColor(g1, cv2.COLOR_GRAY2BGR)[0, 0].tolist() == [7, 7, 7])
+
+# ---- Geometric: warpAffine integer translate + getRotationMatrix2D identity ----
+base = np.array([[10, 20, 30], [40, 50, 60], [70, 80, 90]], dtype=np.uint8)
+M = np.float32([[1, 0, 1], [0, 1, 0]])  # shift right by 1 column
+w = cv2.warpAffine(base, M, (3, 3), flags=cv2.INTER_NEAREST,
+                   borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+chk("warp_translate", w.tolist() == [[0, 10, 20], [0, 40, 50], [0, 70, 80]])
+R = cv2.getRotationMatrix2D((1.0, 1.0), 0.0, 1.0)  # 0 deg, scale 1 -> identity
+chk("rotmat_identity", np.allclose(R, np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])))
+wr = cv2.warpAffine(base, R, (3, 3), flags=cv2.INTER_NEAREST)
+chk("warp_identity_noop", np.array_equal(wr, base))
+
+# ---- Borders / flips / transpose (exact integer reshaping) ----
+a = np.array([[1, 2], [3, 4]], dtype=np.uint8)
+chk("copyMakeBorder",
+    cv2.copyMakeBorder(a, 1, 1, 1, 1, cv2.BORDER_CONSTANT, value=0).tolist()
+    == [[0, 0, 0, 0], [0, 1, 2, 0], [0, 3, 4, 0], [0, 0, 0, 0]])
+chk("flip_vertical", cv2.flip(a, 0).tolist() == [[3, 4], [1, 2]])
+chk("flip_horizontal", cv2.flip(a, 1).tolist() == [[2, 1], [4, 3]])
+chk("flip_both", cv2.flip(a, -1).tolist() == [[4, 3], [2, 1]])
+chk("transpose", cv2.transpose(a).tolist() == [[1, 3], [2, 4]])
+
+# ---- Morphology with a known 3x3 rectangular kernel (min/max, exact) ----
+spot = np.zeros((5, 5), dtype=np.uint8)
+spot[2, 2] = 255
+k3 = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3))
+chk("erode_isolated", int(cv2.erode(spot, k3).sum()) == 0)  # lone pixel eroded away
+chk("dilate_isolated",
+    cv2.dilate(spot, k3).tolist()
+    == [[0, 0, 0, 0, 0], [0, 255, 255, 255, 0], [0, 255, 255, 255, 0],
+        [0, 255, 255, 255, 0], [0, 0, 0, 0, 0]])
+
+# ---- filter2D identity kernel == input; integral image; minMaxLoc ----
+src = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.uint8)
+ident = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]], dtype=np.float32)
+chk("filter2d_identity", np.array_equal(cv2.filter2D(src, -1, ident), src))
+chk("integral",
+    cv2.integral(np.ones((2, 2), dtype=np.uint8)).tolist() == [[0, 0, 0], [0, 1, 2], [0, 2, 4]])
+mn, mx, mnloc, mxloc = cv2.minMaxLoc(np.array([[1, 5, 3], [9, 2, 7]], dtype=np.uint8))
+chk("minmaxloc", mn == 1.0 and mx == 9.0 and mnloc == (0, 0) and mxloc == (0, 1),
+    "min=%s max=%s minloc=%s maxloc=%s" % (mn, mx, mnloc, mxloc))
+
+# ---- findContours: exactly one external contour for a single solid square (OpenCV 4.x) ----
+canvas = np.zeros((10, 10), dtype=np.uint8)
+canvas[3:7, 3:7] = 255
+contours, _ = cv2.findContours(canvas, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+chk("contour_count", len(contours) == 1)
+chk("contour_area", int(cv2.contourArea(contours[0])) == 9)  # 3x3 inner polygon area
+
+print("OPENCV_RESULT ok=%d fail=%d" % (ok, fail))
+if fail == 0:
+    print("OPENCV_DONE")
+    sys.exit(0)
+sys.exit(1)

--- a/apps/starry/py-sci/python/PyarrowCarpet.py
+++ b/apps/starry/py-sci/python/PyarrowCarpet.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# PyarrowCarpet.py — Apache Arrow / Parquet I/O correctness carpet on musl-native CPython.
+#
+# The core is the PROVEN (4-arch green) Parquet write -> read -> exact round-trip equality
+# assertion (schema field names/types AND every value), ported verbatim. It exercises the
+# heavy Arrow C++ stack on musl (libarrow / libparquet / libthrift / libprotobuf + Snappy/Zstd
+# codecs + mmap/threads/file I/O of the columnar Parquet format). A few conservative, API-stable
+# additions (compute kernels, more Arrow types, RecordBatch, ChunkedArray, in-memory IPC stream
+# round-trip) widen the surface using only long-stable pyarrow APIs. Version gate lenient
+# (major >= 4). Self-contained ok/fail counters; prints PYARROW_RESULT then PYARROW_DONE only
+# when fail == 0.
+import os
+import sys
+
+ok = 0
+fail = 0
+
+
+def chk(name, cond, info=""):
+    global ok, fail
+    if cond:
+        ok += 1
+        print("  ok %s%s" % (name, (" " + info) if info else ""))
+    else:
+        fail += 1
+        print("  FAIL %s%s" % (name, (" " + info) if info else ""))
+
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+chk("version", int(pa.__version__.split(".")[0]) >= 4, "pyarrow=%s" % pa.__version__)
+
+# ---- PROVEN core (4-arch green): Parquet write -> read -> EXACT round-trip equality ----
+ids = pa.array([1, 2, 3, 4, 5], type=pa.int32())
+bigs = pa.array([100, 200, 300, 400, 500], type=pa.int64())
+names = pa.array(["alice", "bob", "carol", "dave", "erin"], type=pa.string())
+scores = pa.array([1.5, 2.5, 3.5, 4.5, 5.5], type=pa.float64())
+tags = pa.array(["x", "yy", "zzz", "", "w"], type=pa.string())
+table = pa.table({"id": ids, "big": bigs, "name": names, "score": scores, "tag": tags})
+chk("table_build", table.num_rows == 5 and table.num_columns == 5)
+
+path = "/tmp/t.parquet"
+pq.write_table(table, path)
+sz = os.path.getsize(path)
+back = pq.read_table(path)
+chk("parquet_file_nonempty", sz > 0, "%d bytes" % sz)
+chk("parquet_schema_equal", table.schema.equals(back.schema))
+chk("parquet_values_equal", table.equals(back))
+# Spot-check actual cell values (defense in depth, independent of .equals()).
+chk("parquet_cells_id", back.column("id").to_pylist() == [1, 2, 3, 4, 5])
+chk("parquet_cells_big", back.column("big").to_pylist() == [100, 200, 300, 400, 500])
+chk("parquet_cells_name", back.column("name").to_pylist() == ["alice", "bob", "carol", "dave", "erin"])
+chk("parquet_cells_score", back.column("score").to_pylist() == [1.5, 2.5, 3.5, 4.5, 5.5])
+chk("parquet_cells_tag", back.column("tag").to_pylist() == ["x", "yy", "zzz", "", "w"])
+# Schema field types are exactly what we declared (string of the type is stable).
+ftypes = [str(f.type) for f in back.schema]
+chk("parquet_field_types", ftypes == ["int32", "int64", "string", "double", "string"], "%s" % ftypes)
+
+# ---- compute kernels (long-stable pyarrow.compute API) ----
+import pyarrow.compute as pc
+
+chk("compute_sum", pc.sum(ids).as_py() == 15)
+chk("compute_add", pc.add(pa.array([1, 2, 3]), pa.array([10, 20, 30])).to_pylist() == [11, 22, 33])
+chk("compute_equal", pc.equal(pa.array([1, 2, 3]), pa.array([1, 9, 3])).to_pylist() == [True, False, True])
+chk("compute_min_max",
+    pc.min(scores).as_py() == 1.5 and pc.max(scores).as_py() == 5.5)
+
+# ---- more Arrow types: bool / list ----
+b = pa.array([True, False, True, None], type=pa.bool_())
+chk("bool_array", b.to_pylist() == [True, False, True, None] and b.null_count == 1)
+li = pa.array([[1, 2], [3], []], type=pa.list_(pa.int64()))
+chk("list_array", li.to_pylist() == [[1, 2], [3], []])
+
+# ---- RecordBatch from arrays ----
+rb = pa.RecordBatch.from_arrays([pa.array([1, 2, 3]), pa.array(["a", "b", "c"])], names=["n", "s"])
+chk("recordbatch", rb.num_rows == 3 and rb.num_columns == 2
+    and rb.column(0).to_pylist() == [1, 2, 3] and rb.column(1).to_pylist() == ["a", "b", "c"])
+
+# ---- ChunkedArray ----
+ca = pa.chunked_array([[1, 2], [3, 4, 5]])
+chk("chunked_array", ca.length() == 5 and ca.num_chunks == 2 and ca.to_pylist() == [1, 2, 3, 4, 5])
+
+# ---- in-memory Arrow IPC stream round-trip (pure pyarrow, no pandas) ----
+sink = pa.BufferOutputStream()
+with pa.ipc.new_stream(sink, table.schema) as writer:
+    writer.write_table(table)
+buf = sink.getvalue()
+ipc_back = pa.ipc.open_stream(buf).read_all()
+chk("ipc_roundtrip", ipc_back.equals(table))
+
+print("PYARROW_RESULT ok=%d fail=%d" % (ok, fail))
+if fail == 0:
+    print("PYARROW_DONE")
+    sys.exit(0)
+sys.exit(1)

--- a/apps/starry/py-sci/python/ScipyCarpet.py
+++ b/apps/starry/py-sci/python/ScipyCarpet.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# ScipyCarpet.py — exact/closed-form-assertion carpet for SciPy on musl-native CPython.
+#
+# Floating-point results are checked within a tolerance against closed-form analytic values
+# (det, Cholesky/LU reconstruction, convex-quadratic argmin, polynomial roots, Gaussian
+# cdf/pdf, perfect correlation); integer/structural results are checked exactly. Nothing
+# depends on print formatting. Self-contained ok/fail counters; prints SCIPY_RESULT then
+# SCIPY_DONE only when fail == 0.
+import math
+import sys
+
+ok = 0
+fail = 0
+
+
+def chk(name, cond, info=""):
+    global ok, fail
+    if cond:
+        ok += 1
+        print("  ok %s%s" % (name, (" " + info) if info else ""))
+    else:
+        fail += 1
+        print("  FAIL %s%s" % (name, (" " + info) if info else ""))
+
+
+import numpy as np
+import scipy
+
+chk("version", int(scipy.__version__.split(".")[0]) >= 1, "scipy=%s" % scipy.__version__)
+
+# ---- scipy.linalg: LU / Cholesky / solve / det (closed-form reconstructions) ----
+from scipy import linalg
+
+A = np.array([[4.0, 3.0], [6.0, 3.0]])
+P, L, U = linalg.lu(A)
+chk("lu_reconstruct", np.allclose(P @ L @ U, A))
+chk("lu_L_unit_lower", np.allclose(np.tril(L), L) and np.allclose(np.diag(L), [1.0, 1.0]))
+chk("lu_U_upper", np.allclose(np.triu(U), U))
+
+S = np.array([[4.0, 2.0], [2.0, 3.0]])  # symmetric positive-definite
+Lc = linalg.cholesky(S, lower=True)
+chk("cholesky_reconstruct", np.allclose(Lc @ Lc.T, S))
+chk("cholesky_lower", np.allclose(np.tril(Lc), Lc))
+
+x = linalg.solve(np.array([[3.0, 0.0], [0.0, 5.0]]), np.array([9.0, 20.0]))
+chk("solve", np.allclose(x, [3.0, 4.0]))
+chk("det", abs(linalg.det(np.array([[1.0, 2.0], [3.0, 4.0]])) - (-2.0)) < 1e-9)
+chk("inv", np.allclose(linalg.inv(np.array([[2.0, 0.0], [0.0, 4.0]])), [[0.5, 0.0], [0.0, 0.25]]))
+
+# ---- scipy.sparse: build a CSR matrix and check exact matrix-vector product ----
+from scipy.sparse import csr_matrix
+
+data = np.array([1.0, 2.0, 3.0])
+rows = np.array([0, 1, 2])
+cols = np.array([0, 1, 2])
+sp = csr_matrix((data, (rows, cols)), shape=(3, 3))  # diag(1,2,3)
+chk("sparse_nnz", int(sp.nnz) == 3)
+chk("sparse_matvec", sp.dot(np.array([1.0, 1.0, 1.0])).tolist() == [1.0, 2.0, 3.0])
+dense = sp.toarray()
+chk("sparse_toarray", dense.tolist() == [[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]])
+# CSR @ CSR product is still diagonal: diag(1,2,3)^2 = diag(1,4,9).
+chk("sparse_matmul", (sp @ sp).toarray().tolist() == [[1.0, 0.0, 0.0], [0.0, 4.0, 0.0], [0.0, 0.0, 9.0]])
+
+# ---- scipy.optimize: minimize a convex quadratic + bracketed polynomial root ----
+from scipy import optimize
+
+
+def quad(p):
+    return (p[0] - 3.0) ** 2 + (p[1] + 1.0) ** 2  # unique min at (3, -1)
+
+
+res = optimize.minimize(quad, np.array([0.0, 0.0]), method="BFGS")
+chk("minimize_argmin", np.allclose(res.x, [3.0, -1.0], atol=1e-4), "x=%s" % res.x.tolist())
+chk("minimize_fmin", abs(float(res.fun)) < 1e-8)
+root = optimize.brentq(lambda t: t * t - 2.0, 0.0, 2.0)  # sqrt(2)
+chk("brentq_sqrt2", abs(root - math.sqrt(2.0)) < 1e-10, "root=%.12f" % root)
+root2 = optimize.brentq(lambda t: t ** 3 - t - 2.0, 1.0, 2.0)
+chk("brentq_cubic", abs(root2 ** 3 - root2 - 2.0) < 1e-10)
+
+# ---- scipy.signal: discrete convolution of known integer sequences (exact) ----
+from scipy import signal
+
+chk("convolve_full", signal.convolve(np.array([1, 2, 3]), np.array([1, 1])).tolist() == [1, 3, 5, 3])
+chk("convolve_kernel",
+    signal.convolve(np.array([0, 1, 0, 0]), np.array([1, 2, 3])).tolist() == [0, 1, 2, 3, 0, 0])
+chk("correlate",
+    signal.correlate(np.array([1, 2, 3]), np.array([1, 1]), mode="valid").tolist() == [3, 5])
+
+# ---- scipy.stats: Gaussian cdf/pdf (closed-form) + perfect-correlation pearsonr ----
+from scipy import stats
+
+chk("norm_cdf_0", abs(stats.norm.cdf(0.0) - 0.5) < 1e-12)
+chk("norm_pdf_0", abs(stats.norm.pdf(0.0) - (1.0 / math.sqrt(2.0 * math.pi))) < 1e-12)
+chk("norm_cdf_196", abs(stats.norm.cdf(1.959963984540054) - 0.975) < 1e-9)
+chk("norm_symmetry", abs((stats.norm.cdf(1.0) + stats.norm.cdf(-1.0)) - 1.0) < 1e-12)
+r = stats.pearsonr(np.array([1.0, 2.0, 3.0, 4.0, 5.0]), np.array([2.0, 4.0, 6.0, 8.0, 10.0]))[0]
+chk("pearsonr_perfect", abs(r - 1.0) < 1e-12, "r=%.12f" % r)
+ra = stats.pearsonr(np.array([1.0, 2.0, 3.0]), np.array([3.0, 2.0, 1.0]))[0]
+chk("pearsonr_anti", abs(ra - (-1.0)) < 1e-12)
+
+print("SCIPY_RESULT ok=%d fail=%d" % (ok, fail))
+if fail == 0:
+    print("SCIPY_DONE")
+    sys.exit(0)
+sys.exit(1)

--- a/apps/starry/py-sci/python/SympyCarpet.py
+++ b/apps/starry/py-sci/python/SympyCarpet.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SympyCarpet.py — exact symbolic-algebra carpet for SymPy on musl-native CPython.
+#
+# Every assertion is an EXACT symbolic identity, exact rational arithmetic, or a fixed-prefix
+# high-precision evaluation — all independent of library version and of float formatting.
+# Self-contained ok/fail counters; prints SYMPY_RESULT then SYMPY_DONE only when fail == 0.
+import sys
+
+ok = 0
+fail = 0
+
+
+def chk(name, cond, info=""):
+    global ok, fail
+    if cond:
+        ok += 1
+        print("  ok %s%s" % (name, (" " + info) if info else ""))
+    else:
+        fail += 1
+        print("  FAIL %s%s" % (name, (" " + info) if info else ""))
+
+
+import sympy
+from sympy import (Rational, Matrix, symbols, simplify, expand, factor, solve, diff,
+                   integrate, limit, sin, cos, exp, sqrt, pi, oo, summation, Symbol)
+
+chk("version", int(sympy.__version__.split(".")[0]) >= 1, "sympy=%s" % sympy.__version__)
+
+x, y = symbols("x y")
+
+# ---- simplify / trig identity ----
+chk("pythagorean", simplify(sin(x) ** 2 + cos(x) ** 2) == 1)
+chk("double_angle", simplify(sin(2 * x) - 2 * sin(x) * cos(x)) == 0)
+
+# ---- expand / factor (exact polynomials) ----
+chk("expand_square", expand((x + 1) ** 2) == x ** 2 + 2 * x + 1)
+chk("expand_binomial", expand((x + y) ** 3) == x ** 3 + 3 * x ** 2 * y + 3 * x * y ** 2 + y ** 3)
+chk("factor_diff_squares", factor(x ** 2 - 1) == (x - 1) * (x + 1))
+chk("factor_quadratic", factor(x ** 2 - 5 * x + 6) == (x - 2) * (x - 3))
+
+# ---- solve (exact roots) ----
+chk("solve_quadratic", set(solve(x ** 2 - 5 * x + 6, x)) == {2, 3})
+chk("solve_linear_system",
+    solve([x + y - 3, x - y - 1], [x, y]) == {x: 2, y: 1})
+roots = solve(x ** 2 + 1, x)
+chk("solve_complex", set(roots) == {sympy.I, -sympy.I})
+
+# ---- calculus: diff / integrate / limit (exact closed form) ----
+chk("diff_power", diff(x ** 3, x) == 3 * x ** 2)
+chk("diff_product", diff(x * sin(x), x) == sin(x) + x * cos(x))
+chk("integrate_power", integrate(2 * x, x) == x ** 2)
+chk("integrate_definite", integrate(x ** 2, (x, 0, 3)) == 9)
+chk("integrate_gaussian", integrate(exp(-x ** 2), (x, -oo, oo)) == sqrt(pi))
+chk("limit_sinc", limit(sin(x) / x, x, 0) == 1)
+chk("limit_inf", limit((1 + 1 / x) ** x, x, oo) == sympy.E)
+
+# ---- exact rational arithmetic ----
+chk("rational_add", Rational(1, 3) + Rational(1, 6) == Rational(1, 2))
+chk("rational_mul", Rational(2, 3) * Rational(3, 4) == Rational(1, 2))
+chk("rational_no_float", Rational(1, 7) * 7 == 1)
+
+# ---- Matrix: exact determinant / inverse (rationals) / eigenvalues ----
+Mx = Matrix([[1, 2], [3, 4]])
+chk("matrix_det", Mx.det() == -2)
+chk("matrix_inv", Mx.inv() == Matrix([[Rational(-2), Rational(1)], [Rational(3, 2), Rational(-1, 2)]]))
+chk("matrix_mul", (Mx * Mx) == Matrix([[7, 10], [15, 22]]))
+chk("matrix_eigen", set(Matrix([[2, 0], [0, 3]]).eigenvals().keys()) == {2, 3})
+
+# ---- summation (exact closed form) ----
+k = Symbol("k")
+chk("sum_arith", summation(k, (k, 1, 100)) == 5050)
+chk("sum_squares", summation(k ** 2, (k, 1, 10)) == 385)
+
+# ---- high-precision evaluation: pi to a fixed digit prefix (version-stable) ----
+chk("pi_digits", str(pi.evalf(40)).startswith("3.141592653589793238462643383279502884"),
+    "pi40=%s" % str(pi.evalf(40)))
+chk("sqrt2_digits", str(sqrt(2).evalf(20)).startswith("1.4142135623730950488"))
+
+print("SYMPY_RESULT ok=%d fail=%d" % (ok, fail))
+if fail == 0:
+    print("SYMPY_DONE")
+    sys.exit(0)
+sys.exit(1)

--- a/apps/starry/py-sci/python/run_pysci.py
+++ b/apps/starry/py-sci/python/run_pysci.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# run_pysci.py — on-target gate for the StarryOS python scientific-computing carpet.
+#
+# Runs each library carpet (NumPy / OpenCV / pyarrow / SciPy / SymPy) as a subprocess; each
+# carpet self-checks (XXX_RESULT ok=N fail=0 then XXX_DONE only when its fail count is zero).
+# A carpet is OK only when its DONE marker is present, it exited 0, and no FAIL line appears.
+# Prints PY_SCI_OK=<P>/<T> and TEST PASSED only when ALL five carpets pass, else TEST FAILED.
+#
+# numba is a documented deferred wall: Alpine ships no py3-numba musl apk and llvmlite / the
+# LLVM JIT it needs has no musl distribution. It is reported as an informational SKIP and is
+# NOT counted toward PASS / TOTAL.
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+os.chdir(HERE)  # so each carpet's imports resolve from the staged carpet dir
+
+# Deterministic, single-threaded BLAS / OpenMP: reproducible results and we do not stress the
+# kernel's threading before correctness is established. Inherited by the carpet subprocesses.
+for _k in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS",
+           "NUMEXPR_NUM_THREADS", "OPENCV_NUM_THREADS"):
+    os.environ[_k] = "1"
+os.environ.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+PY = sys.executable
+MODULES = [
+    ("numpy", "NumpyCarpet.py", "NUMPY_DONE"),
+    ("opencv", "OpencvCarpet.py", "OPENCV_DONE"),
+    ("pyarrow", "PyarrowCarpet.py", "PYARROW_DONE"),
+    ("scipy", "ScipyCarpet.py", "SCIPY_DONE"),
+    ("sympy", "SympyCarpet.py", "SYMPY_DONE"),
+]
+
+print("=== python3 %s ===" % sys.version.split()[0])
+print("=== py-sci: scientific-computing carpets (numpy | opencv | pyarrow | scipy | sympy) ===")
+print("  SKIP numba (no musl py3-numba apk / no musl LLVM JIT for llvmlite; documented defer)")
+
+passed = 0
+for name, fn, marker in MODULES:
+    r = subprocess.run([PY, os.path.join(HERE, fn)], capture_output=True, text=True)
+    out = (r.stdout or "") + (r.stderr or "")
+    res = [ln for ln in out.splitlines() if "_RESULT ok=" in ln]
+    if marker in out and r.returncode == 0 and "  FAIL " not in out:
+        print("  OK   %s (%s)" % (name, res[0].strip() if res else ""))
+        passed += 1
+    else:
+        print("  FAIL %s (%s) rc=%s" % (name, marker, r.returncode))
+        bad = [ln for ln in out.splitlines()
+               if any(t in ln for t in ("FAIL", "Error", "Traceback", "Exception"))]
+        print("\n".join(bad[-12:]))
+
+total = len(MODULES)
+print("PY_SCI_RESULT PASS=%d TOTAL=%d" % (passed, total))
+print("PY_SCI_OK=%d/%d" % (passed, total))
+if passed == total and total > 0:
+    print("TEST PASSED")
+    sys.exit(0)
+print("TEST FAILED")
+sys.exit(1)

--- a/apps/starry/py-sci/qemu-aarch64.toml
+++ b/apps/starry/py-sci/qemu-aarch64.toml
@@ -1,0 +1,17 @@
+# py-sci aarch64 — Python scientific-computing carpet on musl-native CPython3.
+# -cpu max exposes the full AArch64 feature set (LSE atomics, dotprod, the ARMv8.2+ NEON
+# extensions) that the apk pyarrow/Arrow C++ compute kernels dispatch to at runtime;
+# cortex-a72 (ARMv8.0-A) lacks them and pyarrow's compute path SIGILLs there.
+args = [
+    "-nographic", "-cpu", "max", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-pysci.sh"
+success_regex = ['(?m)^PY_SCI_OK=5/5', '(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 12000

--- a/apps/starry/py-sci/qemu-loongarch64.toml
+++ b/apps/starry/py-sci/qemu-loongarch64.toml
@@ -1,0 +1,18 @@
+# py-sci loongarch64 — Python scientific-computing carpet on musl-native CPython3.
+# Platform: dynamic (axplat-dyn) — build-loongarch64*.toml carries ax-driver/serial and no
+# ax-hal/loongarch64-qemu-virt / plat-static / plat_dyn=false (mirrors aarch64/riscv64); the
+# static platform lacks the serial console binding ("/dev/console has no serial TTY binding"
+# -> 7.88s early exit). uefi=false / to_bin=true is the dynamic platform's raw-binary boot path.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-pysci.sh"
+success_regex = ['(?m)^PY_SCI_OK=5/5', '(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/py-sci/qemu-riscv64.toml
+++ b/apps/starry/py-sci/qemu-riscv64.toml
@@ -1,0 +1,14 @@
+# py-sci riscv64 — Python scientific-computing carpet on musl-native CPython3.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-pysci.sh"
+success_regex = ['(?m)^PY_SCI_OK=5/5', '(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/py-sci/qemu-x86_64.toml
+++ b/apps/starry/py-sci/qemu-x86_64.toml
@@ -1,0 +1,16 @@
+# py-sci x86_64 — Python scientific-computing carpet on musl-native CPython3.
+# -cpu Haswell exposes AVX2 + AES-NI + XSAVE to userspace (NumPy / OpenCV / pyarrow SIMD and
+# Arrow/abseil RANDEN probe AVX); the kernel CR4.OSXSAVE + XCR0 enable lives in dev.
+args = [
+    "-nographic", "-cpu", "Haswell", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-pysci.sh"
+success_regex = ['(?m)^PY_SCI_OK=5/5', '(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 9000


### PR DESCRIPTION
## 概述

新增 `apps/starry/py-sci` —— 在 StarryOS 上用 musl-native CPython 3.12 测试一组科学计算库，四架构（x86_64 / aarch64 / riscv64 / loongarch64）单核 qemu-10 运行。

每个库按其公开 API 做确定性断言（精确整数 / 闭式解 / 原始缓冲 sha256 / Parquet 字节级 round-trip），内部 fail 计数为 0 时才打印 `*_DONE` marker。`run-pysci.sh` 跑全部 5 个库，PASS == TOTAL 才输出 `PY_SCI_OK=5/5` 与 `TEST PASSED`。

## 覆盖

| 库 | 维度 | 断言 |
|:--|:--|--:|
| numpy | ndarray / 广播 / 视图 / dtype / 掩码 / 归约 / 线代（det·solve·inv·eig·matmul）/ fft / 定种随机 / 排序 / 拼接 | 45 |
| opencv | cvtColor / resize / threshold / warpAffine / copyMakeBorder / flip / 形态学 / filter2D / 积分图 / minMaxLoc / 轮廓 / PNG round-trip | 25 |
| pyarrow | Parquet write→read 精确 round-trip（schema + 值 + 单元）/ compute / 多类型 / RecordBatch / ChunkedArray / IPC 流 | 20 |
| scipy | linalg（lu·cholesky·solve·det）/ sparse / optimize（minimize·brentq）/ signal / stats | 26 |
| sympy | 符号化简 / expand·factor / solve / diff·integrate / limit / Matrix / Rational / evalf | 28 |

numba 暂未纳入：Alpine 无 `py3-numba` musl apk，其 LLVM JIT 后端（llvmlite / libLLVM）无 musl 分发，留待后续。

## 验证

四架构单核 qemu-10 StarryOS 实测，`PY_SCI_OK=5/5` + `TEST PASSED`：

| 架构 | 结果 |
|:--:|:--:|
| x86_64 | 5/5 |
| aarch64 | 5/5 |
| riscv64 | 5/5 |
| loongarch64 | 5/5 |

运行：`cargo xtask starry app qemu -t py-sci --arch <arch>`。`prebuild.sh` 在 staging rootfs 里经 qemu-user-static `apk add python3 py3-numpy py3-opencv py3-pyarrow py3-scipy py3-sympy`（Alpine v3.23，解析当前版本，不钉死会漂移的 URL），把 python3 + site-packages + `.so` 闭包注入 per-app rootfs（含 openblas / libgfortran / libopencv_* / libarrow·libparquet 等），rootfs 扩到 6 GiB 容下科学闭包。x86_64 用 `-cpu Haswell`、aarch64 用 `-cpu max`（pyarrow 的 Arrow C++ compute 内核运行时派发到 ARMv8.2+ 指令，cortex-a72 缺这些会 SIGILL）。
