### PR TITLE
fix(starry-kernel): make evdev polling demand driven

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 - After modifying a crate, ensure that crate passes clippy. Prefer `cargo xtask clippy --package <crate>` for targeted verification.
 - Do not silence clippy warnings with `allow` as a shortcut; prefer fixing the root cause unless the user explicitly asks otherwise.
 - Run `cargo fmt` after code edits.
+- When fixing a bug, first add a deterministic regression test that necessarily fails on the buggy implementation, verify the failure, then implement or restore the fix and verify the same test passes. Do not rely only on post-fix validation, probabilistic reproducers, or relaxed tests.
 - For ArceOS, StarryOS, and Axvisor builds/tests/runs, prefer the `cargo xtask` command family instead of raw `cargo build`, `cargo test`, or `cargo run`.
 - If `cargo xtask` cannot satisfy a special configuration, inspect the `xtask` flow first and only then fall back to native Cargo commands with manually matched arguments.
 - When resolving rebase or merge conflicts, do not manually merge conflicted `Cargo.lock` contents. Resolve all other conflicts first, then regenerate `Cargo.lock` with Cargo and verify the generated lockfile.

--- a/os/StarryOS/kernel/src/pseudofs/dev/event.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/event.rs
@@ -18,7 +18,10 @@ pub fn input_device_count() -> u32 {
 }
 
 use ax_errno::{AxError, AxResult};
-use ax_input::{ErasedInputDevice, Event, EventType, InputDevice, InputDeviceId, InputError};
+use ax_input::{
+    ErasedInputDevice, Event, EventType, InputDevice, InputDeviceId, InputError,
+    input_polling_fallback_should_drain,
+};
 use ax_runtime::hal::{
     irq::IrqId,
     time::{monotonic_time_nanos, wall_time},
@@ -286,17 +289,16 @@ impl EventDev {
             move || {
                 let mut empty_count = 0u32;
                 loop {
-                    if !dev.polling_requested.load(Ordering::Acquire) {
-                        empty_count = 0;
-                        ax_task::sleep(Duration::from_millis(200));
-                        continue;
-                    }
-
+                    let polling_requested = dev.polling_requested.load(Ordering::Acquire);
                     let now = monotonic_time_nanos();
                     let irq = dev.last_irq_event.load(Ordering::Acquire);
-                    let irq_alive = now.wrapping_sub(irq) <= IRQ_ALIVE_NS;
 
-                    if irq_alive {
+                    if !input_polling_fallback_should_drain(
+                        polling_requested,
+                        now,
+                        irq,
+                        IRQ_ALIVE_NS,
+                    ) {
                         empty_count = 0;
                         ax_task::sleep(Duration::from_millis(200));
                         continue;

--- a/os/StarryOS/kernel/src/pseudofs/dev/event.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/event.rs
@@ -2,7 +2,7 @@ use alloc::{collections::VecDeque, format, string::ToString, sync::Arc, vec, vec
 use core::{
     any::Any,
     ptr::NonNull,
-    sync::atomic::{AtomicU32, AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
     task::Context,
     time::Duration,
 };
@@ -132,6 +132,10 @@ pub struct EventDev {
     /// When this is recent, IRQ delivery is considered healthy and the
     /// polling fallback stays at low frequency even with active waiters.
     last_irq_event: AtomicU64,
+    /// Set when userspace is actively waiting for events. The polling fallback
+    /// only drains the hardware queue while this is set, then idles again after
+    /// a short empty window.
+    polling_requested: AtomicBool,
     ev_bits: Bitmap<{ EventType::COUNT as usize }>,
     /// Cached `EVIOCGPROP` bitmap. Computed once at probe from the driver's
     /// raw bits with a synthesized `INPUT_PROP_POINTER` for absolute or
@@ -194,6 +198,7 @@ impl EventDev {
             irq,
             irq_handle: spin::Once::new(),
             last_irq_event: AtomicU64::new(0),
+            polling_requested: AtomicBool::new(false),
             ev_bits,
             prop_bits,
             abs_bits,
@@ -235,10 +240,6 @@ impl EventDev {
     }
 
     fn register_irq(self: &Arc<Self>) {
-        // Always start a polling fallback.  IRQ handlers may fail to fire
-        // (e.g. INTx routed but not delivered, MSI-X not negotiated, etc.)
-        // and libinput blocks on epoll_wait forever.  The polling task
-        // ensures events always reach userspace.
         self.start_polling();
 
         let Some(irq) = self.irq else {
@@ -267,19 +268,30 @@ impl EventDev {
         }
     }
 
+    fn request_polling(&self) {
+        self.polling_requested.store(true, Ordering::Release);
+    }
+
     /// Spawn a background polling task that periodically drains input events
     /// from the device.  Used as a fallback when IRQ delivery is unreliable
     /// (e.g. MSI-X enabled but only INTx is resolved, or INTx routing fails).
     ///
-    /// - IRQ alive → 200 ms idle (IRQ is the primary path).
-    /// - IRQ stale, events found → 10 ms active (polling takes over).
-    /// - IRQ stale, 20 consecutive empty drains → backoff to 200 ms.
+    /// The task is demand-driven: it only actively polls after userspace has
+    /// attempted to read or wait for evdev input.  This keeps non-input system
+    /// tests from continuously touching virtio-input queues while preserving a
+    /// wakeup path for libinput when the platform IRQ path is broken.
     fn start_polling(self: &Arc<Self>) {
         let dev = self.clone();
         ax_task::spawn_with_name(
             move || {
                 let mut empty_count = 0u32;
                 loop {
+                    if !dev.polling_requested.load(Ordering::Acquire) {
+                        empty_count = 0;
+                        ax_task::sleep(Duration::from_millis(200));
+                        continue;
+                    }
+
                     let now = monotonic_time_nanos();
                     let irq = dev.last_irq_event.load(Ordering::Acquire);
                     let irq_alive = now.wrapping_sub(irq) <= IRQ_ALIVE_NS;
@@ -299,8 +311,12 @@ impl EventDev {
                         ax_task::sleep(Duration::from_millis(10));
                     } else {
                         empty_count = empty_count.saturating_add(1);
-                        let delay = if empty_count > 20 { 200 } else { 10 };
-                        ax_task::sleep(Duration::from_millis(delay));
+                        if empty_count > 20 {
+                            dev.polling_requested.store(false, Ordering::Release);
+                            ax_task::sleep(Duration::from_millis(200));
+                        } else {
+                            ax_task::sleep(Duration::from_millis(10));
+                        }
                     }
                 }
             },
@@ -396,6 +412,7 @@ impl DeviceOps for EventDev {
         if buf.len() < size_of::<InputEvent>() {
             return Err(AxError::InvalidInput);
         }
+        self.request_polling();
         let mut read = 0;
         let mut inner = self.inner.lock();
         // Drain the driver queue once up front so a single read() syscall
@@ -578,6 +595,7 @@ impl DeviceOps for EventDev {
 
 impl Pollable for EventDev {
     fn poll(&self) -> IoEvents {
+        self.request_polling();
         let mut events = IoEvents::empty();
         events.set(IoEvents::IN, self.inner.lock().has_event());
         events
@@ -587,6 +605,7 @@ impl Pollable for EventDev {
         if !events.contains(IoEvents::IN) {
             return;
         }
+        self.request_polling();
         unsafe { self.waiters.register(context.waker(), IoEvents::IN) };
         if self.inner.lock().has_event() {
             context.waker().wake_by_ref();

--- a/os/arceos/modules/axinput/src/lib.rs
+++ b/os/arceos/modules/axinput/src/lib.rs
@@ -36,3 +36,51 @@ pub fn init_input(input_devs: impl IntoIterator<Item = ErasedInputDevice>) {
 pub fn take_inputs() -> Vec<ErasedInputDevice> {
     mem::take(&mut DEVICES.lock())
 }
+
+/// Returns whether an evdev polling fallback should actively drain the device
+/// queue.
+pub fn input_polling_fallback_should_drain(
+    polling_requested: bool,
+    now_ns: u64,
+    last_irq_event_ns: u64,
+    irq_alive_ns: u64,
+) -> bool {
+    polling_requested && now_ns.wrapping_sub(last_irq_event_ns) > irq_alive_ns
+}
+
+#[cfg(test)]
+mod tests {
+    use super::input_polling_fallback_should_drain;
+
+    const IRQ_ALIVE_NS: u64 = 1_000_000_000;
+
+    #[test]
+    fn polling_fallback_stays_idle_without_user_interest_even_when_irq_is_stale() {
+        assert!(!input_polling_fallback_should_drain(
+            false,
+            IRQ_ALIVE_NS + 1,
+            0,
+            IRQ_ALIVE_NS
+        ));
+    }
+
+    #[test]
+    fn polling_fallback_drains_after_user_interest_when_irq_is_stale() {
+        assert!(input_polling_fallback_should_drain(
+            true,
+            IRQ_ALIVE_NS + 1,
+            0,
+            IRQ_ALIVE_NS
+        ));
+    }
+
+    #[test]
+    fn polling_fallback_stays_idle_while_irq_is_recent() {
+        assert!(!input_polling_fallback_should_drain(
+            true,
+            IRQ_ALIVE_NS,
+            0,
+            IRQ_ALIVE_NS
+        ));
+    }
+}


### PR DESCRIPTION
## 问题

最新 `dev` 的 Starry x86_64 system CI 在运行目录压力用例时发生 guest reset。reset 后同一个 grouped runner 会重新进入测试流程，前一次未正常结束的 `/root/bug-ext4-dir-ops-test` 残留在 rootfs 快照里，导致后续 `bug-ext4-dir-ops` 在 `mkdir base` / `mkdir rmrf` 等步骤遇到 `EEXIST`，最终被 system runner 标记失败。

原始链接中的 riscv64 `test-ptrace-gdb` 问题在最新 `dev` 上已经通过；当前仍会影响最新 dev CI 的是 x86_64 system 测试中途 reset，而不是 ext4 目录断言本身。

## 根因

`EventDev::register_irq` 在设备初始化时无条件启动 evdev polling fallback。即使没有用户态正在读取或等待输入事件，后台任务也会在 IRQ 被判定 stale 后持续触碰 virtio-input 队列。

在 CI 日志中，x86_64 system 测试每次 boot 都能看到同一个 evdev IRQ `Busy` 警告，之后在非输入类目录压力用例运行期间发生 reset。这里不应该通过清理测试目录、忽略 `EEXIST` 或放宽 system runner 来掩盖问题；更合理的是让 evdev fallback 只在确实有用户态输入消费者时工作。

## 修改

- 为 `EventDev` 增加 `polling_requested` 状态。
- 在 `ax-input` 增加 `input_polling_fallback_should_drain` 策略函数和 deterministic regression tests。
- `EventDev` 的 polling task 调用同一份策略：只有用户态读/等待输入且 IRQ stale 时才主动 drain 设备队列。
- `read_at`、`poll`、`register` 在用户态读或等待输入时请求 polling。
- 当请求后连续一小段时间没有事件，polling 自动回到 idle 状态。
- 在仓库级 `AGENTS.md` 记录 bugfix 必须先加必现失败回归测例、确认红灯、再修到同一测例通过的要求。

这样保留 Qt/libinput 在 IRQ 不可靠时需要的 fallback 唤醒路径，同时避免普通 system 测试期间后台 evdev 任务长期主动访问输入设备。

## 红绿验证

先加入回归测例并临时保持旧策略后，`cargo test -p ax-input polling_fallback -- --nocapture` 必然失败：

- `polling_fallback_stays_idle_without_user_interest_even_when_irq_is_stale` 断言失败，因为旧策略只看 IRQ 是否 stale，忽略 `polling_requested=false`。

恢复修复后，同一命令通过：

- `cargo test -p ax-input polling_fallback -- --nocapture`：3 passed。

## 其他验证

- `git diff --check`
- `cargo fmt`
- `cargo xtask clippy --package ax-input`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp1/system/test-ptrace-gdb`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/bug-dir-cookie-unlink-rmdir`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/bug-ext4-dir-ops`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system`