### PR TITLE
refactor(irq-framework): require boxed IRQ callbacks

### DIFF
--- a/components/axklib/src/lib.rs
+++ b/components/axklib/src/lib.rs
@@ -35,20 +35,22 @@
 //!
 //! // request a shared IRQ action
 //! let irq = axklib::irq::try_legacy_irq(32)?;
-//! let handle = axklib::irq::request_shared(irq, my_irq_handler, data)?;
+//! let handle = axklib::irq::request_shared(irq, my_irq_handler)?;
 //! ```
 
 #![no_std]
 // #![allow(missing_docs)]
 
-use core::{ptr::NonNull, time::Duration};
+extern crate alloc;
+
+use core::time::Duration;
 
 pub use ax_errno::{AxError, AxResult};
 pub use ax_memory_addr::{PhysAddr, VirtAddr};
 pub use irq_framework::{
-    AutoEnable as IrqAutoEnable, BoxedIrqHandler, CpuId as IrqCpuId, CpuMask as IrqCpuMask,
-    IrqAffinity, IrqContext, IrqError, IrqExecution, IrqHandle, IrqId, IrqOutcome, IrqRequest,
-    IrqReturn, IrqScope, IrqStatus, RawIrqHandler, ShareMode as IrqShareMode,
+    AutoEnable as IrqAutoEnable, BoxedIrqHandler, ConcurrentBoxedIrqHandler, CpuId as IrqCpuId,
+    CpuMask as IrqCpuMask, IrqAffinity, IrqContext, IrqError, IrqExecution, IrqHandle, IrqId,
+    IrqOutcome, IrqRequest, IrqReturn, IrqScope, IrqStatus, ShareMode as IrqShareMode,
 };
 use trait_ffi::*;
 
@@ -156,25 +158,16 @@ pub trait Klib {
     fn irq_set_enable(irq: IrqId, enabled: bool) -> AxResult;
 
     /// Request a shared IRQ action and return its handle on success.
-    fn irq_request_shared(
-        irq: IrqId,
-        handler: RawIrqHandler,
-        data: NonNull<()>,
-    ) -> AxResult<IrqHandle>;
+    fn irq_request_shared(irq: IrqId, handler: BoxedIrqHandler) -> AxResult<IrqHandle>;
 
     /// Request a shared IRQ action without enabling it.
-    fn irq_request_shared_disabled(
-        irq: IrqId,
-        handler: RawIrqHandler,
-        data: NonNull<()>,
-    ) -> AxResult<IrqHandle>;
+    fn irq_request_shared_disabled(irq: IrqId, handler: BoxedIrqHandler) -> AxResult<IrqHandle>;
 
     /// Request a per-CPU IRQ action and return its handle on success.
     fn irq_request_percpu(
         irq: IrqId,
         cpus: IrqCpuMask,
-        handler: RawIrqHandler,
-        data: NonNull<()>,
+        handler: ConcurrentBoxedIrqHandler,
     ) -> AxResult<IrqHandle>;
 
     /// Free an IRQ action previously returned by a request function.
@@ -229,15 +222,39 @@ pub mod time {
 /// Convenience re-exports for IRQ operations.
 pub mod irq {
     pub use super::{
-        BoxedIrqHandler, IrqAffinity, IrqAutoEnable as AutoEnable, IrqContext, IrqCpuId as CpuId,
-        IrqCpuMask as CpuMask, IrqError, IrqExecution, IrqHandle, IrqId, IrqNumber, IrqOutcome,
-        IrqRequest, IrqReturn, IrqScope, IrqShareMode as ShareMode, IrqStatus, RawIrqHandler,
+        BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqAffinity, IrqAutoEnable as AutoEnable,
+        IrqContext, IrqCpuId as CpuId, IrqCpuMask as CpuMask, IrqError, IrqExecution, IrqHandle,
+        IrqId, IrqNumber, IrqOutcome, IrqRequest, IrqReturn, IrqScope, IrqShareMode as ShareMode,
+        IrqStatus,
         klib::{
             irq_disable as disable, irq_enable as enable, irq_free as free,
-            irq_request_percpu as request_percpu, irq_request_shared as request_shared,
-            irq_request_shared_disabled as request_shared_disabled,
             irq_run_on_cpu_sync as run_on_cpu_sync, irq_set_enable as set_enable,
         },
         legacy_irq, legacy_irq_raw, try_legacy_irq,
     };
+
+    /// Request a shared IRQ action and return its handle on success.
+    pub fn request_shared(
+        irq: IrqId,
+        handler: impl FnMut(IrqContext) -> IrqReturn + Send + 'static,
+    ) -> super::AxResult<IrqHandle> {
+        super::klib::irq_request_shared(irq, alloc::boxed::Box::new(handler))
+    }
+
+    /// Request a shared IRQ action without enabling it.
+    pub fn request_shared_disabled(
+        irq: IrqId,
+        handler: impl FnMut(IrqContext) -> IrqReturn + Send + 'static,
+    ) -> super::AxResult<IrqHandle> {
+        super::klib::irq_request_shared_disabled(irq, alloc::boxed::Box::new(handler))
+    }
+
+    /// Request a per-CPU IRQ action and return its handle on success.
+    pub fn request_percpu(
+        irq: IrqId,
+        cpus: CpuMask,
+        handler: impl Fn(IrqContext) -> IrqReturn + Send + Sync + 'static,
+    ) -> super::AxResult<IrqHandle> {
+        super::klib::irq_request_percpu(irq, cpus, alloc::boxed::Box::new(handler))
+    }
 }

--- a/components/irq-framework/src/action.rs
+++ b/components/irq-framework/src/action.rs
@@ -1,16 +1,13 @@
 use core::{cell::UnsafeCell, ptr, sync::atomic::AtomicBool};
 
 use crate::{
-    AutoEnable, BoxedIrqHandler, CpuId, CpuMask, IrqContext, IrqExecution, IrqRequest, IrqReturn,
-    IrqScope, types::IrqHandler,
+    AutoEnable, BoxedIrqHandler, ConcurrentBoxedIrqHandler, CpuId, CpuMask, IrqContext,
+    IrqExecution, IrqRequest, IrqReturn, IrqScope, types::IrqHandler,
 };
 
 pub(crate) enum ActionHandler {
-    Raw {
-        handler: unsafe fn(IrqContext, core::ptr::NonNull<()>) -> IrqReturn,
-        data: core::ptr::NonNull<()>,
-    },
-    Boxed(UnsafeCell<BoxedIrqHandler>),
+    NonReentrant(UnsafeCell<BoxedIrqHandler>),
+    Concurrent(ConcurrentBoxedIrqHandler),
 }
 
 unsafe impl Send for ActionHandler {}
@@ -28,9 +25,9 @@ pub(crate) struct Action {
     pub(crate) next: *mut Action,
 }
 
-// Raw handler context pointers and boxed callbacks are owned by the registered
-// action. Boxed callbacks are only called after the NonReentrant run guard
-// succeeds, so the UnsafeCell is not mutably aliased by framework dispatch.
+// Boxed callbacks are owned by the registered action and only called after the
+// NonReentrant run guard succeeds, so the UnsafeCell is not mutably aliased by
+// framework dispatch.
 unsafe impl Send for Action {}
 unsafe impl Sync for Action {}
 
@@ -41,8 +38,10 @@ impl Action {
             .take()
             .expect("IRQ handler was already consumed")
         {
-            IrqHandler::Raw { handler, data } => ActionHandler::Raw { handler, data },
-            IrqHandler::Boxed(handler) => ActionHandler::Boxed(UnsafeCell::new(handler)),
+            IrqHandler::NonReentrant(handler) => {
+                ActionHandler::NonReentrant(UnsafeCell::new(handler))
+            }
+            IrqHandler::Concurrent(handler) => ActionHandler::Concurrent(handler),
         };
         Self {
             id,
@@ -71,5 +70,15 @@ impl Action {
 
     pub(crate) fn clear_pending_enable_all(&self) {
         unsafe { *self.pending_enable.get() = CpuMask::empty() };
+    }
+
+    pub(crate) fn call(&self, ctx: IrqContext) -> IrqReturn {
+        match &self.handler {
+            ActionHandler::NonReentrant(handler) => {
+                let handler = unsafe { &mut *handler.get() };
+                handler(ctx)
+            }
+            ActionHandler::Concurrent(handler) => handler(ctx),
+        }
     }
 }

--- a/components/irq-framework/src/lib.rs
+++ b/components/irq-framework/src/lib.rs
@@ -11,7 +11,7 @@ mod types;
 pub use registry::Registry;
 pub use types::{
     AcpiGsiController, AcpiGsiRoute, AcpiIrqPolarity, AcpiIrqTrigger, AutoEnable, BoxedIrqHandler,
-    CpuId, CpuMask, CpuMaskIter, HwIrq, IrqAffinity, IrqContext, IrqDomainId, IrqError,
-    IrqExecution, IrqHandle, IrqId, IrqOps, IrqOutcome, IrqRequest, IrqReturn, IrqScope, IrqSource,
-    IrqStatus, RawIrqHandler, ShareMode, TrapVector,
+    ConcurrentBoxedIrqHandler, CpuId, CpuMask, CpuMaskIter, HwIrq, IrqAffinity, IrqContext,
+    IrqDomainId, IrqError, IrqExecution, IrqHandle, IrqId, IrqOps, IrqOutcome, IrqRequest,
+    IrqReturn, IrqScope, IrqSource, IrqStatus, ShareMode, TrapVector,
 };

--- a/components/irq-framework/src/registry.rs
+++ b/components/irq-framework/src/registry.rs
@@ -8,7 +8,7 @@ use core::{
 use crate::{
     CpuId, IrqAffinity, IrqContext, IrqError, IrqExecution, IrqHandle, IrqId, IrqOps, IrqOutcome,
     IrqRequest, IrqReturn, IrqScope, IrqStatus,
-    action::{Action, ActionHandler},
+    action::Action,
     descriptor::{Descriptor, action_matches_cpu, recompute_scope_line_desired},
     lock::MetadataLock,
 };
@@ -266,7 +266,7 @@ impl<O: IrqOps> Registry<O> {
     }
 
     fn validate_request(&self, request: &IrqRequest) -> Result<(), IrqError> {
-        if request.is_boxed() && request.execution == IrqExecution::Concurrent {
+        if request.execution == IrqExecution::Concurrent && !request.supports_concurrent() {
             return Err(IrqError::Busy);
         }
         if let IrqScope::PerCpu { cpus } = request.scope
@@ -736,18 +736,6 @@ impl<O: IrqOps> Registry<O> {
 
     fn state_ref(&self) -> &RegistryState {
         unsafe { &*self.state.get() }
-    }
-}
-
-impl Action {
-    fn call(&self, ctx: IrqContext) -> IrqReturn {
-        match &self.handler {
-            ActionHandler::Raw { handler, data } => unsafe { handler(ctx, *data) },
-            ActionHandler::Boxed(handler) => {
-                let handler = unsafe { &mut *handler.get() };
-                handler(ctx)
-            }
-        }
     }
 }
 

--- a/components/irq-framework/src/types.rs
+++ b/components/irq-framework/src/types.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-use core::ptr::NonNull;
 
 /// An IRQ controller domain id.
 #[repr(transparent)]
@@ -298,18 +297,15 @@ pub struct IrqContext {
     pub cpu: CpuId,
 }
 
-/// Raw IRQ handler ABI.
-pub type RawIrqHandler = unsafe fn(ctx: IrqContext, data: NonNull<()>) -> IrqReturn;
-
 /// Boxed IRQ handler ABI.
 pub type BoxedIrqHandler = Box<dyn FnMut(IrqContext) -> IrqReturn + Send + 'static>;
 
+/// Boxed IRQ handler ABI for callbacks that may run concurrently.
+pub type ConcurrentBoxedIrqHandler = Box<dyn Fn(IrqContext) -> IrqReturn + Send + Sync + 'static>;
+
 pub(crate) enum IrqHandler {
-    Raw {
-        handler: RawIrqHandler,
-        data: NonNull<()>,
-    },
-    Boxed(BoxedIrqHandler),
+    NonReentrant(BoxedIrqHandler),
+    Concurrent(ConcurrentBoxedIrqHandler),
 }
 
 /// External capabilities supplied by the OS/platform adapter.
@@ -373,21 +369,9 @@ pub struct IrqRequest {
 
 impl IrqRequest {
     /// Creates a new exclusive, global, auto-enabled IRQ request.
-    pub fn new(handler: RawIrqHandler, data: NonNull<()>) -> Self {
+    pub fn new(handler: impl FnMut(IrqContext) -> IrqReturn + Send + 'static) -> Self {
         Self {
-            handler: Some(IrqHandler::Raw { handler, data }),
-            scope: IrqScope::Global,
-            affinity: IrqAffinity::Any,
-            execution: IrqExecution::Concurrent,
-            share_mode: ShareMode::Exclusive,
-            auto_enable: AutoEnable::Yes,
-        }
-    }
-
-    /// Creates a new exclusive, global, auto-enabled boxed IRQ request.
-    pub fn new_boxed(handler: BoxedIrqHandler) -> Self {
-        Self {
-            handler: Some(IrqHandler::Boxed(handler)),
+            handler: Some(IrqHandler::NonReentrant(Box::new(handler))),
             scope: IrqScope::Global,
             affinity: IrqAffinity::Any,
             execution: IrqExecution::NonReentrant,
@@ -396,8 +380,22 @@ impl IrqRequest {
         }
     }
 
-    pub(crate) fn is_boxed(&self) -> bool {
-        matches!(self.handler.as_ref(), Some(IrqHandler::Boxed(_)))
+    /// Creates a new exclusive, global, auto-enabled concurrent IRQ request.
+    pub fn new_concurrent(
+        handler: impl Fn(IrqContext) -> IrqReturn + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            handler: Some(IrqHandler::Concurrent(Box::new(handler))),
+            scope: IrqScope::Global,
+            affinity: IrqAffinity::Any,
+            execution: IrqExecution::Concurrent,
+            share_mode: ShareMode::Exclusive,
+            auto_enable: AutoEnable::Yes,
+        }
+    }
+
+    pub(crate) fn supports_concurrent(&self) -> bool {
+        matches!(self.handler.as_ref(), Some(IrqHandler::Concurrent(_)))
     }
 
     /// Sets the IRQ scope.

--- a/components/irq-framework/tests/std_sim.rs
+++ b/components/irq-framework/tests/std_sim.rs
@@ -1,15 +1,15 @@
 use std::{
-    ptr::NonNull,
     sync::{
         Arc, Barrier, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     thread,
+    time::Duration,
 };
 
 use irq_framework::{
-    AutoEnable, CpuId, CpuMask, HwIrq, IrqAffinity, IrqContext, IrqDomainId, IrqError,
-    IrqExecution, IrqId, IrqOps, IrqRequest, IrqReturn, IrqScope, Registry, ShareMode,
+    AutoEnable, CpuId, CpuMask, HwIrq, IrqAffinity, IrqDomainId, IrqError, IrqExecution, IrqId,
+    IrqOps, IrqRequest, IrqReturn, IrqScope, Registry, ShareMode,
 };
 
 const TEST_DOMAIN: IrqDomainId = IrqDomainId(1);
@@ -27,6 +27,25 @@ fn raw_irq(irq: IrqId) -> usize {
 fn irq(raw: usize) -> IrqId {
     let hwirq = u32::try_from(raw).expect("test IRQ number exceeds hwirq width");
     domain_irq(TEST_DOMAIN, hwirq)
+}
+
+fn count_request(counter: &AtomicUsize) -> IrqRequest {
+    let counter = counter as *const AtomicUsize as usize;
+    IrqRequest::new(move |ctx| {
+        assert!(ctx.irq.hwirq.0 > 0);
+        let counter = unsafe { &*(counter as *const AtomicUsize) };
+        counter.fetch_add(1, Ordering::SeqCst);
+        IrqReturn::Handled
+    })
+}
+
+fn wake_request(counter: &AtomicUsize) -> IrqRequest {
+    let counter = counter as *const AtomicUsize as usize;
+    IrqRequest::new(move |_| {
+        let counter = unsafe { &*(counter as *const AtomicUsize) };
+        counter.fetch_add(1, Ordering::SeqCst);
+        IrqReturn::Wake
+    })
 }
 
 #[derive(Clone, Default)]
@@ -270,11 +289,8 @@ fn request_restores_enabled_line_without_hal_enable() {
     let ops = MockOps::with_cpus(1);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
-    let handle = registry
-        .request(irq(30), IrqRequest::new(count_handler, data))
-        .unwrap();
+    let handle = registry.request(irq(30), count_request(&counter)).unwrap();
 
     assert_eq!(
         ops.calls(),
@@ -305,11 +321,8 @@ fn request_restores_disabled_line_without_hal_enable() {
     ops.set_line_enabled(31, None, false);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
-    let handle = registry
-        .request(irq(31), IrqRequest::new(count_handler, data))
-        .unwrap();
+    let handle = registry.request(irq(31), count_request(&counter)).unwrap();
 
     assert!(!ops.calls().contains(&OpCall::SetEnabled {
         irq: 31,
@@ -328,13 +341,9 @@ fn request_auto_enable_no_restores_line_but_keeps_action_disabled() {
     let ops = MockOps::with_cpus(1);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let handle = registry
-        .request(
-            irq(32),
-            IrqRequest::new(count_handler, data).auto_enable(AutoEnable::No),
-        )
+        .request(irq(32), count_request(&counter).auto_enable(AutoEnable::No))
         .unwrap();
 
     assert_eq!(
@@ -363,20 +372,16 @@ fn request_auto_enable_no_restores_line_but_keeps_action_disabled() {
 #[test]
 fn irq_request_exposes_auto_enable_mode() {
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
+    assert_eq!(count_request(&counter).auto_enable_mode(), AutoEnable::Yes);
     assert_eq!(
-        IrqRequest::new(count_handler, data).auto_enable_mode(),
-        AutoEnable::Yes
-    );
-    assert_eq!(
-        IrqRequest::new(count_handler, data)
+        count_request(&counter)
             .auto_enable(AutoEnable::No)
             .auto_enable_mode(),
         AutoEnable::No
     );
     assert_eq!(
-        IrqRequest::new_boxed(Box::new(|_| IrqReturn::Handled)).auto_enable_mode(),
+        IrqRequest::new(|_| IrqReturn::Handled).auto_enable_mode(),
         AutoEnable::Yes
     );
 }
@@ -390,11 +395,11 @@ fn boxed_callback_persists_captured_state() {
     registry
         .request(
             irq(46),
-            IrqRequest::new_boxed(Box::new(move |ctx| {
+            IrqRequest::new(move |ctx| {
                 assert_eq!(ctx.irq, irq(46));
                 callback_calls.fetch_add(1, Ordering::SeqCst);
                 IrqReturn::Wake
-            })),
+            }),
         )
         .unwrap();
 
@@ -417,8 +422,7 @@ fn boxed_callback_rejects_concurrent_execution() {
     let err = registry
         .request(
             irq(47),
-            IrqRequest::new_boxed(Box::new(|_| IrqReturn::Handled))
-                .execution(IrqExecution::Concurrent),
+            IrqRequest::new(|_| IrqReturn::Handled).execution(IrqExecution::Concurrent),
         )
         .unwrap_err();
 
@@ -438,12 +442,12 @@ fn boxed_callback_is_non_reentrant() {
     registry
         .request(
             irq(48),
-            IrqRequest::new_boxed(Box::new(move |_| {
+            IrqRequest::new(move |_| {
                 callback_calls.fetch_add(1, Ordering::SeqCst);
                 callback_entered.wait();
                 callback_release.wait();
                 IrqReturn::Handled
-            })),
+            }),
         )
         .unwrap();
 
@@ -470,19 +474,14 @@ fn shared_request_temporarily_disables_existing_line_and_restores_it() {
     let second = AtomicUsize::new(0);
 
     registry
-        .request(
-            irq(33),
-            IrqRequest::new(count_handler, NonNull::from(&first).cast())
-                .share_mode(ShareMode::Shared),
-        )
+        .request(irq(33), count_request(&first).share_mode(ShareMode::Shared))
         .unwrap();
     ops.clear_calls();
 
     registry
         .request(
             irq(33),
-            IrqRequest::new(count_handler, NonNull::from(&second).cast())
-                .share_mode(ShareMode::Shared),
+            count_request(&second).share_mode(ShareMode::Shared),
         )
         .unwrap();
 
@@ -514,19 +513,13 @@ fn failed_request_restores_line_and_drops_new_action() {
     let first = AtomicUsize::new(0);
     let rejected = AtomicUsize::new(0);
 
-    registry
-        .request(
-            irq(34),
-            IrqRequest::new(count_handler, NonNull::from(&first).cast()),
-        )
-        .unwrap();
+    registry.request(irq(34), count_request(&first)).unwrap();
     ops.clear_calls();
 
     let err = registry
         .request(
             irq(34),
-            IrqRequest::new(count_handler, NonNull::from(&rejected).cast())
-                .share_mode(ShareMode::Shared),
+            count_request(&rejected).share_mode(ShareMode::Shared),
         )
         .unwrap_err();
 
@@ -558,10 +551,9 @@ fn failed_restore_after_request_drops_new_action() {
     ops.fail_set_enabled(36, None, true);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let err = registry
-        .request(irq(36), IrqRequest::new(count_handler, data))
+        .request(irq(36), count_request(&counter))
         .unwrap_err();
 
     assert_eq!(err, IrqError::Controller);
@@ -590,7 +582,6 @@ fn failed_percpu_snapshot_restores_already_disabled_cpu_lines() {
     ops.fail_set_enabled(37, Some(1), false);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
     let mut cpus = CpuMask::empty();
     cpus.insert(CpuId(0));
     cpus.insert(CpuId(1));
@@ -598,7 +589,7 @@ fn failed_percpu_snapshot_restores_already_disabled_cpu_lines() {
     let err = registry
         .request(
             irq(37),
-            IrqRequest::new(count_handler, data).scope(IrqScope::PerCpu { cpus }),
+            count_request(&counter).scope(IrqScope::PerCpu { cpus }),
         )
         .unwrap_err();
 
@@ -641,12 +632,11 @@ fn percpu_request_temporarily_disables_and_restores_online_target_cpu_line() {
     ops.set_current_cpu(0);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     registry
         .request(
             irq(35),
-            IrqRequest::new(count_handler, data)
+            count_request(&counter)
                 .scope(IrqScope::PerCpu {
                     cpus: CpuMask::from_cpu(CpuId(2)),
                 })
@@ -685,36 +675,13 @@ fn same_hwirq_in_different_domains_are_independent_descriptors() {
     let irq_a = domain_irq(TEST_DOMAIN_A, 5);
     let irq_b = domain_irq(TEST_DOMAIN_B, 5);
 
-    registry
-        .request(
-            irq_a,
-            IrqRequest::new(count_handler, NonNull::from(&first).cast()),
-        )
-        .unwrap();
-    registry
-        .request(
-            irq_b,
-            IrqRequest::new(count_handler, NonNull::from(&second).cast()),
-        )
-        .unwrap();
+    registry.request(irq_a, count_request(&first)).unwrap();
+    registry.request(irq_b, count_request(&second)).unwrap();
 
     assert_eq!(registry.dispatch(irq_a, CpuId(0)).called, 1);
     assert_eq!(registry.dispatch(irq_b, CpuId(0)).called, 1);
     assert_eq!(first.load(Ordering::SeqCst), 1);
     assert_eq!(second.load(Ordering::SeqCst), 1);
-}
-
-unsafe fn count_handler(ctx: IrqContext, data: NonNull<()>) -> IrqReturn {
-    assert!(ctx.irq.hwirq.0 > 0);
-    let counter = unsafe { data.cast::<AtomicUsize>().as_ref() };
-    counter.fetch_add(1, Ordering::SeqCst);
-    IrqReturn::Handled
-}
-
-unsafe fn wake_handler(_ctx: IrqContext, data: NonNull<()>) -> IrqReturn {
-    let counter = unsafe { data.cast::<AtomicUsize>().as_ref() };
-    counter.fetch_add(1, Ordering::SeqCst);
-    IrqReturn::Wake
 }
 
 #[test]
@@ -725,12 +692,9 @@ fn dynamic_shared_actions_all_dispatch() {
 
     for _ in 0..64 {
         counters.push(Box::new(AtomicUsize::new(0)));
-        let data = NonNull::from(counters.last().unwrap().as_ref()).cast();
+        let counter = counters.last().unwrap();
         registry
-            .request(
-                irq(7),
-                IrqRequest::new(count_handler, data).share_mode(ShareMode::Shared),
-            )
+            .request(irq(7), count_request(counter).share_mode(ShareMode::Shared))
             .unwrap();
     }
 
@@ -754,15 +718,13 @@ fn shared_dispatch_does_not_short_circuit_on_handled() {
     registry
         .request(
             irq(22),
-            IrqRequest::new(count_handler, NonNull::from(&handled_counter).cast())
-                .share_mode(ShareMode::Shared),
+            count_request(&handled_counter).share_mode(ShareMode::Shared),
         )
         .unwrap();
     registry
         .request(
             irq(22),
-            IrqRequest::new(wake_handler, NonNull::from(&wake_counter).cast())
-                .share_mode(ShareMode::Shared),
+            wake_request(&wake_counter).share_mode(ShareMode::Shared),
         )
         .unwrap();
 
@@ -783,16 +745,11 @@ fn disabled_or_freed_shared_action_is_skipped_but_peers_run() {
     let disabled_or_freed_handle = registry
         .request(
             irq(23),
-            IrqRequest::new(count_handler, NonNull::from(&disabled_or_freed).cast())
-                .share_mode(ShareMode::Shared),
+            count_request(&disabled_or_freed).share_mode(ShareMode::Shared),
         )
         .unwrap();
     registry
-        .request(
-            irq(23),
-            IrqRequest::new(count_handler, NonNull::from(&peer).cast())
-                .share_mode(ShareMode::Shared),
-        )
+        .request(irq(23), count_request(&peer).share_mode(ShareMode::Shared))
         .unwrap();
 
     registry.disable(disabled_or_freed_handle).unwrap();
@@ -816,19 +773,15 @@ fn disabled_or_freed_shared_action_is_skipped_but_peers_run() {
 fn exclusive_and_shared_conflict() {
     let registry = Registry::new(MockOps::with_cpus(1));
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     registry
-        .request(
-            irq(3),
-            IrqRequest::new(count_handler, data).auto_enable(AutoEnable::No),
-        )
+        .request(irq(3), count_request(&counter).auto_enable(AutoEnable::No))
         .unwrap();
 
     let err = registry
         .request(
             irq(3),
-            IrqRequest::new(count_handler, data)
+            count_request(&counter)
                 .share_mode(ShareMode::Shared)
                 .auto_enable(AutoEnable::No),
         )
@@ -842,12 +795,11 @@ fn fixed_affinity_is_set_before_restoring_enabled_line() {
     let ops = MockOps::with_cpus(2);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     registry
         .request(
             irq(41),
-            IrqRequest::new(count_handler, data).affinity(IrqAffinity::Fixed(CpuId(1))),
+            count_request(&counter).affinity(IrqAffinity::Fixed(CpuId(1))),
         )
         .unwrap();
 
@@ -878,13 +830,12 @@ fn fixed_affinity_rejects_offline_cpu_and_controller_failure() {
     let ops = MockOps::with_cpus(2);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     ops.set_online(1, false);
     assert_eq!(
         registry.request(
             irq(42),
-            IrqRequest::new(count_handler, data).affinity(IrqAffinity::Fixed(CpuId(1))),
+            count_request(&counter).affinity(IrqAffinity::Fixed(CpuId(1))),
         ),
         Err(IrqError::CpuOffline)
     );
@@ -894,14 +845,14 @@ fn fixed_affinity_rejects_offline_cpu_and_controller_failure() {
     assert_eq!(
         registry.request(
             irq(42),
-            IrqRequest::new(count_handler, data).affinity(IrqAffinity::Fixed(CpuId(1))),
+            count_request(&counter).affinity(IrqAffinity::Fixed(CpuId(1))),
         ),
         Err(IrqError::Controller)
     );
 }
 
 #[test]
-fn shared_actions_must_use_same_affinity_and_execution_contract() {
+fn shared_actions_must_use_same_affinity() {
     let registry = Registry::new(MockOps::with_cpus(2));
     let first = AtomicUsize::new(0);
     let second = AtomicUsize::new(0);
@@ -909,7 +860,7 @@ fn shared_actions_must_use_same_affinity_and_execution_contract() {
     registry
         .request(
             irq(43),
-            IrqRequest::new(count_handler, NonNull::from(&first).cast())
+            count_request(&first)
                 .share_mode(ShareMode::Shared)
                 .affinity(IrqAffinity::Fixed(CpuId(0)))
                 .execution(IrqExecution::NonReentrant),
@@ -919,19 +870,10 @@ fn shared_actions_must_use_same_affinity_and_execution_contract() {
     assert_eq!(
         registry.request(
             irq(43),
-            IrqRequest::new(count_handler, NonNull::from(&second).cast())
+            count_request(&second)
                 .share_mode(ShareMode::Shared)
                 .affinity(IrqAffinity::Fixed(CpuId(1)))
                 .execution(IrqExecution::NonReentrant),
-        ),
-        Err(IrqError::Busy)
-    );
-    assert_eq!(
-        registry.request(
-            irq(43),
-            IrqRequest::new(count_handler, NonNull::from(&second).cast())
-                .share_mode(ShareMode::Shared)
-                .affinity(IrqAffinity::Fixed(CpuId(0))),
         ),
         Err(IrqError::Busy)
     );
@@ -945,23 +887,23 @@ fn free_waits_for_inflight_dispatch_and_detaches_action() {
         calls: AtomicUsize,
     }
 
-    unsafe fn blocking_handler(_ctx: IrqContext, data: NonNull<()>) -> IrqReturn {
-        let blocker = unsafe { data.cast::<Blocker>().as_ref() };
-        blocker.calls.fetch_add(1, Ordering::SeqCst);
-        blocker.entered.wait();
-        blocker.release.wait();
-        IrqReturn::Handled
-    }
-
     let registry = Arc::new(Registry::new(MockOps::with_cpus(1)));
-    let blocker = Box::new(Blocker {
+    let blocker = Arc::new(Blocker {
         entered: Arc::new(Barrier::new(2)),
         release: Arc::new(Barrier::new(2)),
         calls: AtomicUsize::new(0),
     });
-    let data = NonNull::from(blocker.as_ref()).cast();
+    let handler_blocker = blocker.clone();
     let handle = registry
-        .request(irq(11), IrqRequest::new(blocking_handler, data))
+        .request(
+            irq(11),
+            IrqRequest::new(move |_| {
+                handler_blocker.calls.fetch_add(1, Ordering::SeqCst);
+                handler_blocker.entered.wait();
+                handler_blocker.release.wait();
+                IrqReturn::Handled
+            }),
+        )
         .unwrap();
 
     let dispatch_registry = registry.clone();
@@ -993,25 +935,23 @@ fn non_reentrant_action_skips_nested_dispatch() {
         calls: AtomicUsize,
     }
 
-    unsafe fn blocking_handler(_ctx: IrqContext, data: NonNull<()>) -> IrqReturn {
-        let blocker = unsafe { data.cast::<Blocker>().as_ref() };
-        blocker.calls.fetch_add(1, Ordering::SeqCst);
-        blocker.entered.wait();
-        blocker.release.wait();
-        IrqReturn::Handled
-    }
-
     let registry = Arc::new(Registry::new(MockOps::with_cpus(1)));
-    let blocker = Box::new(Blocker {
+    let blocker = Arc::new(Blocker {
         entered: Arc::new(Barrier::new(2)),
         release: Arc::new(Barrier::new(2)),
         calls: AtomicUsize::new(0),
     });
-    let data = NonNull::from(blocker.as_ref()).cast();
+    let handler_blocker = blocker.clone();
     registry
         .request(
             irq(44),
-            IrqRequest::new(blocking_handler, data).execution(IrqExecution::NonReentrant),
+            IrqRequest::new(move |_| {
+                handler_blocker.calls.fetch_add(1, Ordering::SeqCst);
+                handler_blocker.entered.wait();
+                handler_blocker.release.wait();
+                IrqReturn::Handled
+            })
+            .execution(IrqExecution::NonReentrant),
         )
         .unwrap();
 
@@ -1037,21 +977,21 @@ fn synchronize_waits_for_inflight_dispatch() {
         release: Arc<Barrier>,
     }
 
-    unsafe fn blocking_handler(_ctx: IrqContext, data: NonNull<()>) -> IrqReturn {
-        let blocker = unsafe { data.cast::<Blocker>().as_ref() };
-        blocker.entered.wait();
-        blocker.release.wait();
-        IrqReturn::Handled
-    }
-
     let registry = Arc::new(Registry::new(MockOps::with_cpus(1)));
-    let blocker = Box::new(Blocker {
+    let blocker = Arc::new(Blocker {
         entered: Arc::new(Barrier::new(2)),
         release: Arc::new(Barrier::new(2)),
     });
-    let data = NonNull::from(blocker.as_ref()).cast();
+    let handler_blocker = blocker.clone();
     let handle = registry
-        .request(irq(45), IrqRequest::new(blocking_handler, data))
+        .request(
+            irq(45),
+            IrqRequest::new(move |_| {
+                handler_blocker.entered.wait();
+                handler_blocker.release.wait();
+                IrqReturn::Handled
+            }),
+        )
         .unwrap();
 
     let dispatch_registry = registry.clone();
@@ -1072,13 +1012,12 @@ fn synchronize_waits_for_inflight_dispatch() {
 fn per_cpu_action_dispatches_only_on_matching_cpu() {
     let registry = Registry::new(MockOps::with_cpus(4));
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
     let cpus = CpuMask::from_cpu(CpuId(2));
 
     registry
         .request(
             irq(9),
-            IrqRequest::new(count_handler, data).scope(IrqScope::PerCpu { cpus }),
+            count_request(&counter).scope(IrqScope::PerCpu { cpus }),
         )
         .unwrap();
 
@@ -1088,18 +1027,69 @@ fn per_cpu_action_dispatches_only_on_matching_cpu() {
 }
 
 #[test]
+fn per_cpu_concurrent_action_allows_parallel_dispatch_on_different_cpus() {
+    struct Blocker {
+        entered: std::sync::mpsc::Sender<CpuId>,
+        release: Barrier,
+        calls: AtomicUsize,
+    }
+
+    let registry = Arc::new(Registry::new(MockOps::with_cpus(4)));
+    let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+    let blocker = Arc::new(Blocker {
+        entered: entered_tx,
+        release: Barrier::new(3),
+        calls: AtomicUsize::new(0),
+    });
+    let mut cpus = CpuMask::empty();
+    cpus.insert(CpuId(1));
+    cpus.insert(CpuId(2));
+    let handler_blocker = blocker.clone();
+
+    registry
+        .request(
+            irq(49),
+            IrqRequest::new_concurrent(move |ctx| {
+                handler_blocker.calls.fetch_add(1, Ordering::SeqCst);
+                handler_blocker.entered.send(ctx.cpu).unwrap();
+                handler_blocker.release.wait();
+                IrqReturn::Handled
+            })
+            .scope(IrqScope::PerCpu { cpus }),
+        )
+        .unwrap();
+
+    let dispatch_registry = registry.clone();
+    let first = thread::spawn(move || dispatch_registry.dispatch(irq(49), CpuId(1)));
+    assert_eq!(entered_rx.recv().unwrap(), CpuId(1));
+
+    let dispatch_registry = registry.clone();
+    let second = thread::spawn(move || dispatch_registry.dispatch(irq(49), CpuId(2)));
+    assert_eq!(
+        entered_rx.recv_timeout(Duration::from_millis(100)).unwrap(),
+        CpuId(2)
+    );
+    blocker.release.wait();
+    let first = first.join().unwrap();
+    let second = second.join().unwrap();
+
+    assert_eq!(first.called, 1);
+    assert_eq!(second.called, 1);
+    assert_eq!(blocker.calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
 fn remote_per_cpu_enable_uses_run_on_cpu_sync() {
     let ops = MockOps::with_cpus(4);
     ops.set_current_cpu(0);
     ops.set_line_enabled(12, Some(2), false);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let handle = registry
         .request(
             irq(12),
-            IrqRequest::new(count_handler, data)
+            count_request(&counter)
                 .scope(IrqScope::PerCpu {
                     cpus: CpuMask::from_cpu(CpuId(2)),
                 })
@@ -1126,12 +1116,11 @@ fn remote_per_cpu_enable_from_irq_context_is_rejected_without_ipi() {
     ops.set_line_enabled(13, Some(2), false);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let handle = registry
         .request(
             irq(13),
-            IrqRequest::new(count_handler, data)
+            count_request(&counter)
                 .scope(IrqScope::PerCpu {
                     cpus: CpuMask::from_cpu(CpuId(2)),
                 })
@@ -1161,12 +1150,11 @@ fn failed_per_cpu_enable_rolls_back_action_state() {
     ops.fail_set_enabled(18, Some(2), true);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let handle = registry
         .request(
             irq(18),
-            IrqRequest::new(count_handler, data)
+            count_request(&counter)
                 .scope(IrqScope::PerCpu {
                     cpus: CpuMask::from_cpu(CpuId(2)),
                 })
@@ -1189,12 +1177,11 @@ fn offline_cpu_enable_is_applied_when_cpu_comes_online() {
     ops.set_online(3, false);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let handle = registry
         .request(
             irq(13),
-            IrqRequest::new(count_handler, data)
+            count_request(&counter)
                 .scope(IrqScope::PerCpu {
                     cpus: CpuMask::from_cpu(CpuId(3)),
                 })
@@ -1227,7 +1214,6 @@ fn pending_enable_is_tracked_per_cpu() {
     ops.set_online(3, false);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
     let mut cpus = CpuMask::empty();
     cpus.insert(CpuId(2));
     cpus.insert(CpuId(3));
@@ -1235,7 +1221,7 @@ fn pending_enable_is_tracked_per_cpu() {
     let handle = registry
         .request(
             irq(19),
-            IrqRequest::new(count_handler, data)
+            count_request(&counter)
                 .scope(IrqScope::PerCpu { cpus })
                 .auto_enable(AutoEnable::No),
         )
@@ -1281,12 +1267,11 @@ fn freeing_per_cpu_action_disables_target_cpu_line() {
     ops.set_current_cpu(0);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let handle = registry
         .request(
             irq(17),
-            IrqRequest::new(count_handler, data)
+            count_request(&counter)
                 .scope(IrqScope::PerCpu {
                     cpus: CpuMask::from_cpu(CpuId(0)),
                 })
@@ -1309,13 +1294,9 @@ fn status_queries_controller_state() {
     let ops = MockOps::with_cpus(1);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let handle = registry
-        .request(
-            irq(14),
-            IrqRequest::new(count_handler, data).auto_enable(AutoEnable::No),
-        )
+        .request(irq(14), count_request(&counter).auto_enable(AutoEnable::No))
         .unwrap();
 
     let status = registry.status(handle).unwrap();
@@ -1344,13 +1325,9 @@ fn status_uses_framework_line_state_when_controller_status_is_unsupported() {
     ops.set_unsupported_status(true);
     let registry = Registry::new(ops);
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     let handle = registry
-        .request(
-            irq(20),
-            IrqRequest::new(count_handler, data).auto_enable(AutoEnable::No),
-        )
+        .request(irq(20), count_request(&counter).auto_enable(AutoEnable::No))
         .unwrap();
 
     let status = registry.status(handle).unwrap();
@@ -1475,17 +1452,13 @@ fn stale_disable_does_not_override_concurrent_enable() {
     let second = AtomicUsize::new(0);
 
     let first = registry
-        .request(
-            irq(21),
-            IrqRequest::new(count_handler, NonNull::from(&first).cast())
-                .share_mode(ShareMode::Shared),
-        )
+        .request(irq(21), count_request(&first).share_mode(ShareMode::Shared))
         .unwrap();
     registry.enable(first).unwrap();
     let second = registry
         .request(
             irq(21),
-            IrqRequest::new(count_handler, NonNull::from(&second).cast())
+            count_request(&second)
                 .share_mode(ShareMode::Shared)
                 .auto_enable(AutoEnable::No),
         )
@@ -1511,17 +1484,12 @@ fn disabling_one_shared_action_keeps_line_enabled_until_last_action() {
     let second = AtomicUsize::new(0);
 
     let first = registry
-        .request(
-            irq(16),
-            IrqRequest::new(count_handler, NonNull::from(&first).cast())
-                .share_mode(ShareMode::Shared),
-        )
+        .request(irq(16), count_request(&first).share_mode(ShareMode::Shared))
         .unwrap();
     let second = registry
         .request(
             irq(16),
-            IrqRequest::new(count_handler, NonNull::from(&second).cast())
-                .share_mode(ShareMode::Shared),
+            count_request(&second).share_mode(ShareMode::Shared),
         )
         .unwrap();
     ops.clear_calls();
@@ -1545,12 +1513,11 @@ fn disabling_one_shared_action_keeps_line_enabled_until_last_action() {
 fn handler_can_report_wake_outcome() {
     let registry = Registry::new(MockOps::with_cpus(1));
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
 
     registry
         .request(
             irq(15),
-            IrqRequest::new(wake_handler, data).share_mode(ShareMode::Shared),
+            wake_request(&counter).share_mode(ShareMode::Shared),
         )
         .unwrap();
 
@@ -1565,12 +1532,8 @@ fn free_from_irq_context_is_rejected() {
     let ops = MockOps::with_cpus(1);
     let registry = Registry::new(ops.clone());
     let counter = AtomicUsize::new(0);
-    let data = NonNull::from(&counter).cast();
     let handle = registry
-        .request(
-            irq(16),
-            IrqRequest::new(count_handler, data).auto_enable(AutoEnable::No),
-        )
+        .request(irq(16), count_request(&counter).auto_enable(AutoEnable::No))
         .unwrap();
 
     ops.set_in_irq(true);

--- a/docs/docs/architecture/rdrive-rdif.md
+++ b/docs/docs/architecture/rdrive-rdif.md
@@ -211,7 +211,7 @@ sequenceDiagram
 - 无中断的设备注册为 `None`；PCI required IRQ 最终无结果时返回 probe error，optional IRQ 允许注册为 `None`。
 - `ax-runtime`、`ax-hal`、`ax-net-ng`、StarryOS usbfs 等上层以 `IrqId` 注册 handler。需要处理 firmware source 的地方应先经 `resolve_irq_source(...)`，不应自行做 `usize` 算术换算。
 
-网络 IRQ 的 runtime 适配也遵循同一方向。`ax-net-ng` 只暴露网络领域自己的 `EthernetIrqAction`、`EthernetIrqOutcome` 和注册错误类型，不再在公开 registrar trait 中泄漏 `ax-hal::irq::{RawIrqHandler, IrqContext, IrqReturn, IrqError}`。`ax-runtime` 持有 HAL IRQ registration，并把 HAL raw handler trampoline 适配到 `EthernetIrqAction`；因此网络 runtime 只描述“是否需要唤醒 poll 方”，HAL ABI 留在 ArceOS runtime 边界内。
+网络 IRQ 的 runtime 适配也遵循同一方向。`ax-net-ng` 只暴露网络领域自己的 `EthernetIrqAction`、`EthernetIrqOutcome` 和注册错误类型，不再在公开 registrar trait 中泄漏 HAL IRQ 细节。`ax-runtime` 持有 HAL IRQ registration，并把 `EthernetIrqAction` 放入 boxed HAL callback；因此网络 runtime 只描述“是否需要唤醒 poll 方”，HAL 注册形态留在 ArceOS runtime 边界内。
 
 ## Capability Boundary
 

--- a/drivers/ax-driver/src/net/aic8800.rs
+++ b/drivers/ax-driver/src/net/aic8800.rs
@@ -27,8 +27,6 @@
 //! attached to the device via `WifiLinkPolicy`, which the runtime reads back
 //! generically through `wifi_control()` once the network service is up.
 
-use core::ptr::NonNull;
-
 use log::{error, info};
 use rd_net::WifiLinkPolicy;
 use rdrive::{probe::OnProbeError, register::ProbeFdt};
@@ -106,14 +104,11 @@ fn resolve_fdt_irq(
     Ok(translation.id)
 }
 
-/// Raw IRQ trampoline: the SDIO1 controller interrupt is forwarded to the SDHCI
+/// IRQ trampoline: the SDIO1 controller interrupt is forwarded to the SDHCI
 /// handler (CARD_INT detection). This is a *controller-level* IRQ, distinct from
 /// a NIC's rx/tx-queue IRQ, so the net device itself registers with `irq=None`
 /// and RX is driven out-of-band via the chip's RX-data callback.
-unsafe fn sdio1_raw_irq_handler(
-    _ctx: axklib::irq::IrqContext,
-    _data: NonNull<()>,
-) -> axklib::irq::IrqReturn {
+fn sdio1_irq_handler(_ctx: axklib::irq::IrqContext) -> axklib::irq::IrqReturn {
     sdhci_cv1800::irq::sdhci_irq_handler(0);
     axklib::irq::IrqReturn::Handled
 }
@@ -152,13 +147,11 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     // Register the SDIO1 controller IRQ (shared). Resolved from the FDT node.
     let irq = resolve_fdt_irq(&info)?;
     info!("[wifi] SDIO1 IRQ resolved to {irq:?}");
-    let irq_handle =
-        axklib::irq::request_shared_disabled(irq, sdio1_raw_irq_handler, NonNull::dangling())
-            .map_err(|e| {
-                OnProbeError::other(alloc::format!(
-                    "[wifi] failed to register SDIO1 IRQ {irq:?}: {e:?}"
-                ))
-            })?;
+    let irq_handle = axklib::irq::request_shared_disabled(irq, sdio1_irq_handler).map_err(|e| {
+        OnProbeError::other(alloc::format!(
+            "[wifi] failed to register SDIO1 IRQ {irq:?}: {e:?}"
+        ))
+    })?;
 
     // SDHCI init.
     let mut sdio = CviSdhci::new(cfg.sdio1_base_va);

--- a/drivers/ax-driver/src/pci/mod.rs
+++ b/drivers/ax-driver/src/pci/mod.rs
@@ -567,8 +567,8 @@ mod tests {
 
     #[cfg(plat_dyn)]
     use axklib::{
-        AxError, AxResult, IrqCpuMask, IrqHandle, IrqId, Klib, PhysAddr, RawIrqHandler, VirtAddr,
-        impl_trait,
+        AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuMask, IrqHandle,
+        IrqId, Klib, PhysAddr, VirtAddr, impl_trait,
     };
     use rdrive::probe::{
         OnProbeError,
@@ -630,26 +630,23 @@ mod tests {
             }
 
             fn irq_request_shared(
-            _irq: IrqId,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _irq: IrqId,
+                _handler: BoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }
 
             fn irq_request_shared_disabled(
                 _irq: IrqId,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _handler: BoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }
 
             fn irq_request_percpu(
-            _irq: IrqId,
+                _irq: IrqId,
                 _cpus: IrqCpuMask,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _handler: ConcurrentBoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }

--- a/drivers/ax-driver/src/time/mod.rs
+++ b/drivers/ax-driver/src/time/mod.rs
@@ -51,8 +51,8 @@ fn init_epoch_offset(node_name: &str, unix_timestamp: u64) -> Result<(), OnProbe
 #[cfg(test)]
 mod tests {
     use axklib::{
-        AxError, AxResult, IrqCpuMask, IrqHandle, IrqId, Klib, PhysAddr, RawIrqHandler, VirtAddr,
-        impl_trait,
+        AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuMask, IrqHandle,
+        IrqId, Klib, PhysAddr, VirtAddr, impl_trait,
     };
 
     struct KlibImpl;
@@ -100,26 +100,23 @@ mod tests {
             }
 
             fn irq_request_shared(
-            _irq: IrqId,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _irq: IrqId,
+                _handler: BoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }
 
             fn irq_request_shared_disabled(
                 _irq: IrqId,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _handler: BoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }
 
             fn irq_request_percpu(
-            _irq: IrqId,
+                _irq: IrqId,
                 _cpus: IrqCpuMask,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _handler: ConcurrentBoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }

--- a/drivers/ax-driver/tests/binding_info.rs
+++ b/drivers/ax-driver/tests/binding_info.rs
@@ -13,8 +13,8 @@ use rdrive::probe::pci::{PciAddress, PciInfo};
 #[cfg(feature = "plat-dyn")]
 use {
     axklib::{
-        AxError, AxResult, IrqCpuMask, IrqHandle, IrqId, Klib, PhysAddr, RawIrqHandler, VirtAddr,
-        impl_trait,
+        AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuMask, IrqHandle,
+        IrqId, Klib, PhysAddr, VirtAddr, impl_trait,
     },
     core::time::Duration,
     fdt_edit::{Fdt, Node, Property},
@@ -101,16 +101,14 @@ impl_trait! {
 
         fn irq_request_shared(
             _irq: IrqId,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: BoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             Err(AxError::Unsupported)
         }
 
         fn irq_request_shared_disabled(
             _irq: IrqId,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: BoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             Err(AxError::Unsupported)
         }
@@ -118,8 +116,7 @@ impl_trait! {
         fn irq_request_percpu(
             _irq: IrqId,
             _cpus: IrqCpuMask,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: ConcurrentBoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             Err(AxError::Unsupported)
         }

--- a/drivers/ax-driver/tests/model_register.rs
+++ b/drivers/ax-driver/tests/model_register.rs
@@ -3,8 +3,8 @@
 use ax_driver::{PlatformDevice, probe::OnProbeError};
 #[cfg(feature = "plat-dyn")]
 use axklib::{
-    AxError, AxResult, IrqCpuMask, IrqHandle, IrqId, Klib, PhysAddr, RawIrqHandler, VirtAddr,
-    impl_trait,
+    AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuMask, IrqHandle, IrqId,
+    Klib, PhysAddr, VirtAddr, impl_trait,
 };
 
 #[cfg(feature = "plat-dyn")]
@@ -55,16 +55,14 @@ impl_trait! {
 
         fn irq_request_shared(
             _irq: IrqId,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: BoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             Err(AxError::Unsupported)
         }
 
         fn irq_request_shared_disabled(
             _irq: IrqId,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: BoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             Err(AxError::Unsupported)
         }
@@ -72,8 +70,7 @@ impl_trait! {
         fn irq_request_percpu(
             _irq: IrqId,
             _cpus: IrqCpuMask,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: ConcurrentBoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             Err(AxError::Unsupported)
         }

--- a/drivers/interface/rdif-eth/src/lib.rs
+++ b/drivers/interface/rdif-eth/src/lib.rs
@@ -117,7 +117,7 @@ impl IdList {
     }
 }
 
-/// Event returned by [`Interface::handle_irq`] indicating which queues have
+/// Event returned by [`IrqHandler::handle_irq`] indicating which queues have
 /// completed operations.
 #[derive(Debug, Clone, Copy)]
 pub struct Event {
@@ -179,14 +179,18 @@ pub trait Interface: DriverGeneric {
     fn is_irq_enabled(&self) -> bool;
 
     /// Handle a device interrupt, returning which queues have events.
+    ///
+    /// This method is kept for non-OS test code and direct polling adapters.
+    /// Runtime IRQ registration must use [`Interface::take_irq_handler`] so the
+    /// hard IRQ callback owns a narrow endpoint instead of borrowing the full
+    /// interface object.
     fn handle_irq(&mut self) -> Event;
 
     /// Detach an owned IRQ endpoint from the interface.
     ///
-    /// The default returns `None` to keep older drivers on the compatibility
-    /// path, where [`Interface::handle_irq`] is still called through the shared
-    /// interface object. New or migrated drivers should return `Some` so hard
-    /// IRQ callbacks do not need to lock the whole device.
+    /// Returns `None` for devices without an OS-registered NIC IRQ. Drivers
+    /// with an IRQ line must return `Some` so hard IRQ callbacks do not need to
+    /// lock the whole device.
     fn take_irq_handler(&mut self) -> Option<BIrqHandler> {
         None
     }

--- a/drivers/net/rd-net/src/lib.rs
+++ b/drivers/net/rd-net/src/lib.rs
@@ -171,19 +171,15 @@ impl Net {
         Ok(rx)
     }
 
-    pub fn irq_handler(&mut self) -> IrqHandler {
+    pub fn take_irq_handler(&mut self) -> Option<IrqHandler> {
         let irq_guard = self.irq_guard();
-        let source = self
-            .interface()
-            .take_irq_handler()
-            .map(IrqHandlerSource::Owned)
-            .unwrap_or(IrqHandlerSource::Compat);
+        let handler = self.interface().take_irq_handler();
         drop(irq_guard);
 
-        IrqHandler {
+        handler.map(|handler| IrqHandler {
             inner: self.inner.clone(),
-            source,
-        }
+            handler,
+        })
     }
 
     /// Detaches a standalone control-plane handle for this device.
@@ -257,16 +253,7 @@ fn make_pool(
 
 pub struct IrqHandler {
     inner: Arc<NetInner>,
-    source: IrqHandlerSource,
-}
-
-enum IrqHandlerSource {
-    /// Migrated driver path: hard IRQ owns this endpoint and never locks the
-    /// full `Interface` object.
-    Owned(rdif_eth::BIrqHandler),
-    /// Compatibility path for drivers that have not yet split their IRQ
-    /// endpoint out of the main interface object.
-    Compat,
+    handler: rdif_eth::BIrqHandler,
 }
 
 unsafe impl Send for IrqHandler {}
@@ -291,13 +278,7 @@ impl IrqHandler {
     /// Runtime queue wakers must be invoked later from task/deferred context
     /// through [`handle`](Self::handle).
     pub fn handle_irq(&mut self) -> rdif_eth::Event {
-        match &mut self.source {
-            IrqHandlerSource::Owned(handler) => handler.handle_irq(),
-            IrqHandlerSource::Compat => {
-                let iface = unsafe { &mut **self.inner.interface.get() };
-                iface.handle_irq()
-            }
-        }
+        self.handler.handle_irq()
     }
 
     /// Handles a device interrupt and wakes registered queue waiters.
@@ -702,15 +683,19 @@ mod tests {
         rx.insert(3);
         let mut tx = IdList::none();
         tx.insert(5);
-        let handle_calls = Arc::new(AtomicUsize::new(0));
+        let interface_calls = Arc::new(AtomicUsize::new(0));
+        let irq_calls = Arc::new(AtomicUsize::new(0));
         let mut net = Net::new(
             TestInterface {
-                irq_events: Event {
-                    tx_queue: tx,
-                    rx_queue: rx,
-                },
-                handle_calls: Arc::clone(&handle_calls),
-                owned_irq_handler: None,
+                irq_events: Event::none(),
+                handle_calls: Arc::clone(&interface_calls),
+                owned_irq_handler: Some(Box::new(OwnedTestIrqHandler {
+                    irq_events: Event {
+                        tx_queue: tx,
+                        rx_queue: rx,
+                    },
+                    handle_calls: Arc::clone(&irq_calls),
+                })),
             },
             &DMA,
         );
@@ -725,18 +710,35 @@ mod tests {
             .register(5)
             .register(&count_waker(Arc::clone(&tx_wake_count)));
 
-        let mut irq = net.irq_handler();
+        let mut irq = net.take_irq_handler().unwrap();
         let events = irq.handle_irq();
 
         assert!(events.rx_queue.contains(3));
         assert!(events.tx_queue.contains(5));
-        assert_eq!(handle_calls.load(Ordering::Acquire), 1);
+        assert_eq!(irq_calls.load(Ordering::Acquire), 1);
+        assert_eq!(interface_calls.load(Ordering::Acquire), 0);
         assert_eq!(rx_wake_count.load(Ordering::Acquire), 0);
         assert_eq!(tx_wake_count.load(Ordering::Acquire), 0);
     }
 
     #[test]
-    fn irq_handler_prefers_owned_endpoint_over_interface_fallback() {
+    fn irq_handler_requires_owned_endpoint() {
+        static DMA: TestDma = TestDma;
+        let handle_calls = Arc::new(AtomicUsize::new(0));
+        let mut net = Net::new(
+            TestInterface {
+                irq_events: Event::none(),
+                handle_calls,
+                owned_irq_handler: None,
+            },
+            &DMA,
+        );
+
+        assert!(net.take_irq_handler().is_none());
+    }
+
+    #[test]
+    fn irq_handler_uses_owned_endpoint() {
         static DMA: TestDma = TestDma;
         let mut rx = IdList::none();
         rx.insert(1);
@@ -759,7 +761,7 @@ mod tests {
             &DMA,
         );
 
-        let mut irq = net.irq_handler();
+        let mut irq = net.take_irq_handler().unwrap();
         let events = irq.handle_irq();
 
         assert!(events.rx_queue.contains(1));

--- a/net/ax-net/src/device/driver.rs
+++ b/net/ax-net/src/device/driver.rs
@@ -140,7 +140,8 @@ pub trait EthernetDriver: Send + Sync {
     /// Handles a device interrupt and reports wake-relevant events.
     fn handle_irq(&mut self) -> NetIrqEvents;
     /// Detaches an owned IRQ endpoint for registration into the platform IRQ
-    /// callback. Drivers that return `None` stay on the compatibility path.
+    /// callback. Drivers with a registered IRQ should return `Some`; `None` is
+    /// only for devices that do not use the shared Ethernet IRQ path.
     fn take_irq_handler(&mut self) -> Option<Box<dyn EthernetIrqHandler>> {
         None
     }
@@ -206,7 +207,7 @@ impl RdNetDriver {
         let mac = net.mac_address();
         let tx_queue = net.create_tx_queue().map_err(map_net_error)?;
         let rx_queue = net.create_rx_queue().map_err(map_net_error)?;
-        let irq_handler = irq.as_ref().map(|_| net.irq_handler());
+        let irq_handler = irq.as_ref().and_then(|_| net.take_irq_handler());
 
         Ok(Self {
             name: name.into(),

--- a/net/ax-net/src/device/ethernet.rs
+++ b/net/ax-net/src/device/ethernet.rs
@@ -21,7 +21,6 @@
 //! the router before Ethernet sees the packet.
 
 use alloc::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
-use core::ptr::NonNull;
 
 use ax_sync::spin::SpinNoIrq;
 use axpoll::PollSet;
@@ -52,17 +51,10 @@ pub struct EthernetIrqAction {
 }
 
 impl EthernetIrqAction {
-    pub fn new(data: NonNull<()>, handler: unsafe fn(NonNull<()>) -> EthernetIrqOutcome) -> Self {
-        let data = data.as_ptr() as usize;
-        Self::new_boxed(Box::new(move || {
-            let data = NonNull::new(data as *mut ())
-                .expect("ethernet irq action data pointer must be non-null");
-            unsafe { handler(data) }
-        }))
-    }
-
-    pub fn new_boxed(handler: Box<dyn FnMut() -> EthernetIrqOutcome + Send>) -> Self {
-        Self { handler }
+    pub fn new(handler: impl FnMut() -> EthernetIrqOutcome + Send + 'static) -> Self {
+        Self {
+            handler: Box::new(handler),
+        }
     }
 
     /// Runs the IRQ action.
@@ -128,12 +120,6 @@ struct EthernetIrqState {
     poll_ready: Arc<PollSet>,
 }
 
-impl EthernetIrqState {
-    fn handle_irq(&self) -> NetIrqEvents {
-        self.driver.lock().handle_irq()
-    }
-}
-
 pub struct EthernetDevice {
     name: String,
     inner: Arc<EthernetIrqState>,
@@ -142,11 +128,6 @@ pub struct EthernetDevice {
     ip: Option<Ipv4Cidr>,
 
     pending_packets: PacketBuffer<'static, IpAddress>,
-}
-
-unsafe fn handle_ethernet_irq(data: NonNull<()>) -> EthernetIrqOutcome {
-    let state = unsafe { data.cast::<EthernetIrqState>().as_ref() };
-    ethernet_irq_outcome(state.handle_irq())
 }
 
 fn handle_owned_ethernet_irq(handler: &mut dyn EthernetIrqHandler) -> EthernetIrqOutcome {
@@ -193,7 +174,7 @@ impl EthernetDevice {
         let irq = inner.irq_id();
         let registrar = irq.and_then(|_| ETHERNET_IRQ_REGISTRAR.get().copied());
         let irq_handler = registrar.and_then(|_| inner.take_irq_handler());
-        let mut inner = Arc::new(EthernetIrqState {
+        let inner = Arc::new(EthernetIrqState {
             irq,
             irq_registration: spin::Once::new(),
             oob_rx,
@@ -210,26 +191,27 @@ impl EthernetDevice {
         );
         if let Some(irq) = inner.irq {
             if let Some(registrar) = registrar {
-                let action = if let Some(mut irq_handler) = irq_handler {
-                    EthernetIrqAction::new_boxed(Box::new(move || {
+                if let Some(mut irq_handler) = irq_handler {
+                    let action = EthernetIrqAction::new(move || {
                         handle_owned_ethernet_irq(&mut *irq_handler)
-                    }))
+                    });
+                    match registrar.register_shared(&name, irq, action) {
+                        Ok(registration) => {
+                            inner.irq_registration.call_once(|| registration);
+                            inner.driver.lock().enable_irq();
+                        }
+                        Err(err) => {
+                            warn!(
+                                "failed to register ethernet irq handler for {name} irq {irq:?}: \
+                                 {err:?}"
+                            );
+                        }
+                    }
                 } else {
-                    let data =
-                        NonNull::from(Arc::get_mut(&mut inner).expect("new Arc is unique")).cast();
-                    EthernetIrqAction::new(data, handle_ethernet_irq)
-                };
-                match registrar.register_shared(&name, irq, action) {
-                    Ok(registration) => {
-                        inner.irq_registration.call_once(|| registration);
-                        inner.driver.lock().enable_irq();
-                    }
-                    Err(err) => {
-                        warn!(
-                            "failed to register ethernet irq handler for {name} irq {irq:?}: \
-                             {err:?}"
-                        );
-                    }
+                    warn!(
+                        "skip ethernet irq registration for {name} irq {irq:?}: driver did not \
+                         provide an owned IRQ handler"
+                    );
                 }
             } else {
                 warn!(

--- a/os/StarryOS/kernel/src/perf/sampling.rs
+++ b/os/StarryOS/kernel/src/perf/sampling.rs
@@ -41,7 +41,7 @@
 //! the slot — *before* dropping that `Arc`. The handler therefore only ever
 //! dereferences a pointer whose target is still alive.
 
-use core::{ptr::NonNull, sync::atomic::Ordering};
+use core::sync::atomic::Ordering;
 
 use ax_hal::irq::{IrqContext, IrqId, IrqReturn};
 use ax_kernel_guard::NoPreemptIrqSave;
@@ -266,12 +266,7 @@ pub fn ensure_pmu_irq_registered() {
     {
         let cpus = ax_hal::irq::CpuMask::first_n(ax_hal::cpu_num());
         // Mirror the timer's unit-data pattern: the handler does not use `data`.
-        if let Err(err) = ax_hal::irq::request_percpu_irq(
-            pmu_irq,
-            cpus,
-            pmu_overflow_handler,
-            NonNull::dangling(),
-        ) {
+        if let Err(err) = ax_hal::irq::request_percpu_irq(pmu_irq, cpus, pmu_overflow_handler) {
             // Roll back so a later open can retry registration.
             REGISTERED.store(false, Ordering::Release);
             warn!("perf sampling: failed to register PMU overflow IRQ: {err:?}");
@@ -301,7 +296,7 @@ pub fn ensure_pmu_irq_registered() {
 ///
 /// Must only be invoked by the IRQ framework in hard-IRQ context on the core the
 /// overflow fired on. Performs no allocation and takes no sleeping locks.
-pub unsafe fn pmu_overflow_handler(_ctx: IrqContext, _data: NonNull<()>) -> IrqReturn {
+pub fn pmu_overflow_handler(_ctx: IrqContext) -> IrqReturn {
     // Capture the interrupted context before doing anything that could fault or
     // overwrite ELR_EL1 / SPSR_EL1.
     let ip = ax_cpu::pmu::interrupted_pc();

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -37,7 +37,6 @@ use alloc::{
 };
 use core::{
     any::Any,
-    ptr::NonNull,
     sync::atomic::{AtomicU32, AtomicU64, Ordering},
     task::Context,
 };
@@ -408,10 +407,15 @@ impl Card0 {
             return;
         };
 
-        let data = NonNull::from(self.as_ref()).cast();
-        let request = ax_runtime::hal::irq::IrqRequest::new(card0_irq_handler, data)
-            .share_mode(ax_runtime::hal::irq::ShareMode::Shared)
-            .auto_enable(ax_runtime::hal::irq::AutoEnable::No);
+        let request = ax_runtime::hal::irq::IrqRequest::new(|_| {
+            if ax_display::framebuffer_handle_irq() {
+                ax_runtime::hal::irq::IrqReturn::Handled
+            } else {
+                ax_runtime::hal::irq::IrqReturn::Unhandled
+            }
+        })
+        .share_mode(ax_runtime::hal::irq::ShareMode::Shared)
+        .auto_enable(ax_runtime::hal::irq::AutoEnable::No);
         match ax_runtime::hal::irq::request_irq(irq, request) {
             Ok(handle) => {
                 self.irq_handle.call_once(|| handle);
@@ -640,17 +644,6 @@ impl DeviceOps for Card0 {
 
     fn flags(&self) -> NodeFlags {
         NodeFlags::NON_CACHEABLE | NodeFlags::STREAM
-    }
-}
-
-unsafe fn card0_irq_handler(
-    _ctx: ax_runtime::hal::irq::IrqContext,
-    _data: NonNull<()>,
-) -> ax_runtime::hal::irq::IrqReturn {
-    if ax_display::framebuffer_handle_irq() {
-        ax_runtime::hal::irq::IrqReturn::Handled
-    } else {
-        ax_runtime::hal::irq::IrqReturn::Unhandled
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/cvi_camera.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/cvi_camera.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use alloc::vec::Vec;
-use core::{any::Any, ptr::NonNull, time::Duration};
+use core::{any::Any, time::Duration};
 
 use ax_errno::{AxError, LinuxError};
 use ax_kspin::SpinNoIrq as Mutex;
@@ -37,9 +37,8 @@ const SLIP_ESC: u8 = 0xDB;
 const SLIP_ESC_END: u8 = 0xDC;
 const SLIP_ESC_ESC: u8 = 0xDD;
 
-unsafe fn cvi_camera_raw_irq_handler(
+fn cvi_camera_irq_handler(
     _ctx: ax_runtime::hal::irq::IrqContext,
-    _data: NonNull<()>,
 ) -> ax_runtime::hal::irq::IrqReturn {
     let mut uart3 = some_serial::ns16550::dw_apb::DwApbUart::new(
         phys_to_virt(PhysAddr::from(UART3_ADDR)).as_usize(),
@@ -421,21 +420,18 @@ impl CviCamera {
         uart3.set_irq_mask(InterruptMask::empty());
         let mut irq_registration = None;
         match camera_uart_irq() {
-            Ok(irq) => {
-                match request_shared_disabled(irq, cvi_camera_raw_irq_handler, NonNull::dangling())
-                {
-                    Ok(registration) => {
-                        uart3.set_irq_mask(InterruptMask::RX_AVAILABLE);
-                        if let Err(err) = registration.enable() {
-                            warn!("failed to enable cvi camera IRQ: {err:?}");
-                            uart3.set_irq_mask(InterruptMask::empty());
-                        } else {
-                            irq_registration = Some(registration);
-                        }
+            Ok(irq) => match request_shared_disabled(irq, cvi_camera_irq_handler) {
+                Ok(registration) => {
+                    uart3.set_irq_mask(InterruptMask::RX_AVAILABLE);
+                    if let Err(err) = registration.enable() {
+                        warn!("failed to enable cvi camera IRQ: {err:?}");
+                        uart3.set_irq_mask(InterruptMask::empty());
+                    } else {
+                        irq_registration = Some(registration);
                     }
-                    Err(err) => warn!("failed to request cvi camera IRQ: {err:?}"),
                 }
-            }
+                Err(err) => warn!("failed to request cvi camera IRQ: {err:?}"),
+            },
             Err(err) => warn!("failed to resolve cvi camera IRQ: {err:?}"),
         }
         Self {

--- a/os/StarryOS/kernel/src/pseudofs/dev/event.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/event.rs
@@ -1,7 +1,6 @@
 use alloc::{collections::VecDeque, format, string::ToString, sync::Arc, vec, vec::Vec};
 use core::{
     any::Any,
-    ptr::NonNull,
     sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
     task::Context,
     time::Duration,
@@ -249,8 +248,8 @@ impl EventDev {
             return;
         };
 
-        let data = NonNull::from(self.as_ref()).cast();
-        let request = ax_runtime::hal::irq::IrqRequest::new(event_dev_irq_handler, data)
+        let event_dev = Arc::clone(self);
+        let request = ax_runtime::hal::irq::IrqRequest::new(move |_| event_dev.handle_irq())
             .share_mode(ax_runtime::hal::irq::ShareMode::Shared)
             .auto_enable(ax_runtime::hal::irq::AutoEnable::No);
         match ax_runtime::hal::irq::request_irq(irq, request) {
@@ -325,32 +324,27 @@ impl EventDev {
             "evdev-poll".into(),
         );
     }
-}
 
-unsafe fn event_dev_irq_handler(
-    _ctx: ax_runtime::hal::irq::IrqContext,
-    data: NonNull<()>,
-) -> ax_runtime::hal::irq::IrqReturn {
-    let event_dev = unsafe { data.cast::<EventDev>().as_ref() };
-    // Use `lock()` rather than `try_lock()` so the virtio ISR is always
-    // acknowledged. `SpinNoIrq` guarantees the holder has local IRQs
-    // disabled, so this IRQ can only fire on a different CPU. Without the
-    // ack, a level-triggered shared IRQ line stays asserted and can starve
-    // other devices on the same line.
-    let mut inner = event_dev.inner.lock();
-    let event = inner.device.handle_irq();
-    if event.input_ready && inner.drain_into_queue() {
-        event_dev
-            .last_irq_event
-            .store(monotonic_time_nanos(), Ordering::Release);
-        drop(inner);
-        event_dev.waiters.wake_from_irq(IoEvents::IN);
-        return ax_runtime::hal::irq::IrqReturn::Wake;
-    }
-    if event.handled {
-        ax_runtime::hal::irq::IrqReturn::Handled
-    } else {
-        ax_runtime::hal::irq::IrqReturn::Unhandled
+    fn handle_irq(&self) -> ax_runtime::hal::irq::IrqReturn {
+        // Use `lock()` rather than `try_lock()` so the virtio ISR is always
+        // acknowledged. `SpinNoIrq` guarantees the holder has local IRQs
+        // disabled, so this IRQ can only fire on a different CPU. Without the
+        // ack, a level-triggered shared IRQ line stays asserted and can starve
+        // other devices on the same line.
+        let mut inner = self.inner.lock();
+        let event = inner.device.handle_irq();
+        if event.input_ready && inner.drain_into_queue() {
+            self.last_irq_event
+                .store(monotonic_time_nanos(), Ordering::Release);
+            drop(inner);
+            self.waiters.wake_from_irq(IoEvents::IN);
+            return ax_runtime::hal::irq::IrqReturn::Wake;
+        }
+        if event.handled {
+            ax_runtime::hal::irq::IrqReturn::Handled
+        } else {
+            ax_runtime::hal::irq::IrqReturn::Unhandled
+        }
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/kpu.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/kpu.rs
@@ -1,7 +1,6 @@
 use core::{
     any::Any,
     mem::{MaybeUninit, size_of},
-    ptr::NonNull,
     sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
@@ -441,7 +440,7 @@ impl KpuResource {
 }
 
 fn register_kpu_irq(irq: ax_runtime::hal::irq::IrqId) -> Option<IrqRegistration> {
-    let registration = match request_shared_disabled(irq, kpu_irq_handler, NonNull::dangling()) {
+    let registration = match request_shared_disabled(irq, kpu_irq_handler) {
         Ok(registration) => registration,
         Err(err) => {
             warn!("k230-kpu devfs: failed to register IRQ handler for irq {irq:?}: {err:?}");
@@ -455,10 +454,7 @@ fn register_kpu_irq(irq: ax_runtime::hal::irq::IrqId) -> Option<IrqRegistration>
     Some(registration)
 }
 
-unsafe fn kpu_irq_handler(
-    _ctx: ax_runtime::hal::irq::IrqContext,
-    _data: NonNull<()>,
-) -> ax_runtime::hal::irq::IrqReturn {
+fn kpu_irq_handler(_ctx: ax_runtime::hal::irq::IrqContext) -> ax_runtime::hal::irq::IrqReturn {
     KPU_IRQ_COUNT.fetch_add(1, Ordering::AcqRel);
     KPU_DONE_WQ.notify_all_from_irq();
     ax_runtime::hal::irq::IrqReturn::Handled

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -85,10 +85,11 @@ impl Drop for IrqRegistration {
 #[cfg(any(feature = "sg2002", feature = "k230-kpu"))]
 pub(super) fn request_shared_disabled(
     irq: ax_runtime::hal::irq::IrqId,
-    handler: ax_runtime::hal::irq::RawIrqHandler,
-    data: core::ptr::NonNull<()>,
+    handler: impl FnMut(ax_runtime::hal::irq::IrqContext) -> ax_runtime::hal::irq::IrqReturn
+    + Send
+    + 'static,
 ) -> Result<IrqRegistration, ax_runtime::hal::irq::IrqError> {
-    let request = ax_runtime::hal::irq::IrqRequest::new(handler, data)
+    let request = ax_runtime::hal::irq::IrqRequest::new(handler)
         .share_mode(ax_runtime::hal::irq::ShareMode::Shared)
         .auto_enable(ax_runtime::hal::irq::AutoEnable::No);
     ax_runtime::hal::irq::request_irq(irq, request).map(IrqRegistration::new)

--- a/os/StarryOS/kernel/src/pseudofs/dev/tpu/device.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tpu/device.rs
@@ -27,7 +27,6 @@
 
 use alloc::{collections::VecDeque, string::String, sync::Arc};
 use core::{
-    ptr::NonNull,
     sync::atomic::{AtomicBool, AtomicPtr, Ordering},
     time::Duration,
 };
@@ -114,7 +113,6 @@ const TPU_TDMA_IRQ: usize = 76;
 const TPU_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn register_tpu_irq(hw: &Arc<Sg2002Tpu>) -> Option<IrqRegistration> {
-    let data = unsafe { NonNull::new_unchecked(Arc::as_ptr(hw) as *mut ()) };
     let Ok(hwirq) = u32::try_from(TPU_TDMA_IRQ) else {
         warn!("[TPU] invalid tdma irq {}", TPU_TDMA_IRQ);
         return None;
@@ -123,7 +121,16 @@ fn register_tpu_irq(hw: &Arc<Sg2002Tpu>) -> Option<IrqRegistration> {
         ax_runtime::hal::irq::RISCV_PLIC_DOMAIN,
         ax_runtime::hal::irq::HwIrq(hwirq),
     );
-    let registration = match request_shared_disabled(irq, tpu_tdma_irq_handler, data) {
+    let hw = Arc::clone(hw);
+    let registration = match request_shared_disabled(irq, move |_| {
+        if hw.handle_irq() {
+            warn!("[TPU] tdma irq {} reports error status", TPU_TDMA_IRQ);
+        }
+        // 唤醒在 IRQ_WQ 上睡眠的 worker。中断上下文不重调度（resched=false），
+        // 对齐 kpu.rs 的做法；WaitQueue 由 SpinNoIrq 守护，IRQ 内 notify 安全。
+        IRQ_WQ.notify_all(false);
+        ax_runtime::hal::irq::IrqReturn::Handled
+    }) {
         Ok(registration) => registration,
         Err(err) => {
             warn!(
@@ -138,20 +145,6 @@ fn register_tpu_irq(hw: &Arc<Sg2002Tpu>) -> Option<IrqRegistration> {
         return None;
     }
     Some(registration)
-}
-
-unsafe fn tpu_tdma_irq_handler(
-    _ctx: ax_runtime::hal::irq::IrqContext,
-    data: NonNull<()>,
-) -> ax_runtime::hal::irq::IrqReturn {
-    let hw = unsafe { &*(data.as_ptr() as *const Sg2002Tpu) };
-    if hw.handle_irq() {
-        warn!("[TPU] tdma irq {} reports error status", TPU_TDMA_IRQ);
-    }
-    // 唤醒在 IRQ_WQ 上睡眠的 worker。中断上下文不重调度（resched=false），
-    // 对齐 kpu.rs 的做法；WaitQueue 由 SpinNoIrq 守护，IRQ 内 notify 安全。
-    IRQ_WQ.notify_all(false);
-    ax_runtime::hal::irq::IrqReturn::Handled
 }
 
 /// 注入给 driver core 的阻塞等待函数：在超时内睡眠等待 TDMA 中断到达。

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, format, string::String, sync::Arc, vec, vec::Vec};
+use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use ax_driver::serial::{
@@ -350,7 +350,7 @@ fn new_serial_tty(number: usize, serial: SerialDevice) -> AxResult<SerialTtyEntr
 impl SerialBackend {
     fn register_irq(self: &Arc<Self>, mut irq: SerialIrqHandler) -> AxResult<()> {
         let backend = self.clone();
-        let request = IrqRequest::new_boxed(Box::new(move |ctx| {
+        let request = IrqRequest::new(move |ctx| {
             let outcome = backend.handle_irq_on_owner(ctx.cpu, &mut irq);
             if !outcome.claimed {
                 return ax_runtime::hal::irq::IrqReturn::Unhandled;
@@ -361,7 +361,7 @@ impl SerialBackend {
             } else {
                 ax_runtime::hal::irq::IrqReturn::Wake
             }
-        }))
+        })
         .share_mode(ShareMode::Shared)
         .affinity(IrqAffinity::Fixed(CpuId(self.owner.0)))
         .auto_enable(AutoEnable::No);

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/irq.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/irq.rs
@@ -1,7 +1,6 @@
 use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec::Vec};
 use core::{
     cell::UnsafeCell,
-    ptr::NonNull,
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
@@ -94,9 +93,12 @@ pub(super) fn init_globals(manager: Arc<UsbFsManager>, pending_slots: Vec<Pendin
                     "usbfs: registering IRQ callback for IRQ {:?} (bus {}, host {:?})",
                     irq, slot.bus_num, slot.device_id
                 );
-                let request = IrqRequest::new(usbfs_raw_irq_handler, NonNull::dangling())
-                    .share_mode(ShareMode::Shared)
-                    .auto_enable(AutoEnable::No);
+                let request = IrqRequest::new(|ctx| {
+                    usbfs_irq_handler_by_irq(ctx.irq);
+                    ax_runtime::hal::irq::IrqReturn::Handled
+                })
+                .share_mode(ShareMode::Shared)
+                .auto_enable(AutoEnable::No);
                 match ax_runtime::hal::irq::request_irq(irq, request) {
                     Ok(handle) => {
                         *slot.handle.lock() = Some(handle);
@@ -280,12 +282,4 @@ fn usbfs_event_handler(slot_index: usize) {
             manager.notify_topology_from_irq();
         }
     }
-}
-
-unsafe fn usbfs_raw_irq_handler(
-    ctx: ax_runtime::hal::irq::IrqContext,
-    _data: NonNull<()>,
-) -> ax_runtime::hal::irq::IrqReturn {
-    usbfs_irq_handler_by_irq(ctx.irq);
-    ax_runtime::hal::irq::IrqReturn::Handled
 }

--- a/os/arceos/modules/axhal/src/irq.rs
+++ b/os/arceos/modules/axhal/src/irq.rs
@@ -6,10 +6,9 @@ pub use ax_plat::irq::{
     AutoEnable, BoxedIrqHandler, CPU_LOCAL_IRQ_DOMAIN, CpuId, CpuMask, HwIrq, IrqAffinity,
     IrqContext, IrqDomainId, IrqError, IrqExecution, IrqHandle, IrqId, IrqNumber, IrqOutcome,
     IrqRequest, IrqReturn, IrqScope, IrqSource, IrqStatus, LEGACY_IRQ_DOMAIN,
-    LOONGARCH_EIOINTC_DOMAIN, LOONGARCH_PCH_PIC_DOMAIN, RISCV_PLIC_DOMAIN, RawIrqHandler,
-    ShareMode, TrapVector, X86_IOAPIC_DOMAIN, X86_LAPIC_DOMAIN, cpu_online, disable_irq,
-    dispatch_irq, enable_irq, free_irq, handle, irq_status, legacy_irq, legacy_irq_raw,
-    request_boxed_irq, request_boxed_shared_irq, request_irq, request_percpu_irq,
+    LOONGARCH_EIOINTC_DOMAIN, LOONGARCH_PCH_PIC_DOMAIN, RISCV_PLIC_DOMAIN, ShareMode, TrapVector,
+    X86_IOAPIC_DOMAIN, X86_LAPIC_DOMAIN, cpu_online, disable_irq, dispatch_irq, enable_irq,
+    free_irq, handle, irq_status, legacy_irq, legacy_irq_raw, request_irq, request_percpu_irq,
     request_shared_irq, resolve_irq_source, resolve_percpu_irq, run_on_cpu_sync, set_enable,
     set_run_on_cpu_sync, synchronize_irq, try_legacy_irq,
 };

--- a/os/arceos/modules/axruntime/src/fs/block.rs
+++ b/os/arceos/modules/axruntime/src/fs/block.rs
@@ -134,14 +134,10 @@ impl BlockIrqRegistrar for RuntimeBlockIrqRegistrar {
         irq: irq_framework::IrqId,
         mut action: Box<dyn FnMut(ax_hal::irq::IrqContext) -> BlockIrqOutcome + Send + 'static>,
     ) -> ax_errno::AxResult<Box<dyn BlockIrqRegistration>> {
-        crate::irq::Registration::register_boxed_shared(
-            name,
-            irq,
-            Box::new(move |ctx| match action(ctx) {
-                BlockIrqOutcome::Handled => ax_hal::irq::IrqReturn::Handled,
-                BlockIrqOutcome::Wake => ax_hal::irq::IrqReturn::Wake,
-            }),
-        )
+        crate::irq::Registration::register_shared(name, irq, move |ctx| match action(ctx) {
+            BlockIrqOutcome::Handled => ax_hal::irq::IrqReturn::Handled,
+            BlockIrqOutcome::Wake => ax_hal::irq::IrqReturn::Wake,
+        })
         .map(|inner| Box::new(RuntimeBlockIrqRegistration { _inner: inner }) as _)
         .map_err(map_block_irq_error)
     }

--- a/os/arceos/modules/axruntime/src/irq.rs
+++ b/os/arceos/modules/axruntime/src/irq.rs
@@ -1,5 +1,4 @@
-use alloc::{boxed::Box, string::String};
-use core::ptr::NonNull;
+use alloc::string::String;
 
 #[cfg(all(
     any(
@@ -20,7 +19,7 @@ use ax_hal::irq::CPU_LOCAL_IRQ_DOMAIN;
     feature = "plat-dyn"
 ))]
 use ax_hal::irq::HwIrq;
-use ax_hal::irq::{BoxedIrqHandler, IrqError, IrqHandle, IrqId, IrqSource, RawIrqHandler};
+use ax_hal::irq::{IrqContext, IrqError, IrqHandle, IrqId, IrqReturn, IrqSource};
 
 /// Resolves an explicitly legacy numeric IRQ without truncating it.
 pub fn resolve_legacy_irq(irq: usize) -> Result<IrqId, IrqError> {
@@ -131,32 +130,10 @@ impl Registration {
     pub fn register_shared(
         name: impl Into<String>,
         irq: IrqId,
-        handler: RawIrqHandler,
-        data: NonNull<()>,
+        handler: impl FnMut(IrqContext) -> IrqReturn + Send + 'static,
     ) -> Result<Self, IrqError> {
         let name = name.into();
-        match ax_hal::irq::request_shared_irq(irq, handler, data) {
-            Ok(handle) => {
-                info!("registered {name} irq {:?}", handle.irq());
-                Ok(Self {
-                    name,
-                    handle: Some(handle),
-                })
-            }
-            Err(err) => {
-                warn!("failed to register {name} irq handler for irq {irq:?}: {err:?}");
-                Err(err)
-            }
-        }
-    }
-
-    pub fn register_boxed_shared(
-        name: impl Into<String>,
-        irq: IrqId,
-        handler: BoxedIrqHandler,
-    ) -> Result<Self, IrqError> {
-        let name = name.into();
-        match ax_hal::irq::request_boxed_shared_irq(irq, handler) {
+        match ax_hal::irq::request_shared_irq(irq, handler) {
             Ok(handle) => {
                 info!("registered {name} irq {:?}", handle.irq());
                 Ok(Self {
@@ -184,36 +161,6 @@ impl Drop for Registration {
         if let Err(err) = ax_hal::irq::free_irq(handle) {
             warn!("failed to free {} irq handler: {err:?}", self.name);
         }
-    }
-}
-
-pub struct HandlerRegistration<T> {
-    _registration: Registration,
-    state: Box<T>,
-}
-
-impl<T> HandlerRegistration<T> {
-    pub fn register_shared(
-        name: impl Into<String>,
-        irq: IrqId,
-        state: T,
-        handler: RawIrqHandler,
-    ) -> Result<Self, IrqError> {
-        let mut state = Box::new(state);
-        let data = NonNull::from(state.as_mut()).cast();
-        let registration = Registration::register_shared(name, irq, handler, data)?;
-        Ok(Self {
-            _registration: registration,
-            state,
-        })
-    }
-
-    pub fn state(&self) -> &T {
-        &self.state
-    }
-
-    pub fn handle(&self) -> Option<IrqHandle> {
-        self._registration.handle()
     }
 }
 
@@ -249,15 +196,20 @@ impl ax_net::EthernetIrqRegistrar for RuntimeNetIrqRegistrar {
         name: &str,
         irq: IrqId,
         action: ax_net::EthernetIrqAction,
-    ) -> Result<Box<dyn ax_net::EthernetIrqRegistration>, ax_net::EthernetIrqRegistrationError>
-    {
+    ) -> Result<
+        alloc::boxed::Box<dyn ax_net::EthernetIrqRegistration>,
+        ax_net::EthernetIrqRegistrationError,
+    > {
         let mut action = action;
-        let handler = Box::new(move |_ctx| match action.run() {
+        let handler = move |_ctx| match action.run() {
             ax_net::EthernetIrqOutcome::Handled => ax_hal::irq::IrqReturn::Handled,
             ax_net::EthernetIrqOutcome::Wake => ax_hal::irq::IrqReturn::Wake,
-        });
-        Registration::register_boxed_shared(name, irq, handler)
-            .map(|registration| Box::new(registration) as Box<dyn ax_net::EthernetIrqRegistration>)
+        };
+        Registration::register_shared(name, irq, handler)
+            .map(|registration| {
+                alloc::boxed::Box::new(registration)
+                    as alloc::boxed::Box<dyn ax_net::EthernetIrqRegistration>
+            })
             .map_err(map_net_irq_error)
     }
 }

--- a/os/arceos/modules/axruntime/src/klib.rs
+++ b/os/arceos/modules/axruntime/src/klib.rs
@@ -15,8 +15,8 @@ use core::time::Duration;
 #[cfg(feature = "paging")]
 use ax_memory_addr::MemoryAddr;
 use axklib::{
-    AxError, AxResult, IrqCpuId, IrqCpuMask, IrqError, IrqHandle, IrqId, Klib, PhysAddr,
-    RawIrqHandler, VirtAddr, impl_trait,
+    AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuId, IrqCpuMask, IrqError,
+    IrqHandle, IrqId, Klib, PhysAddr, VirtAddr, impl_trait,
 };
 
 struct KlibImpl;
@@ -221,12 +221,11 @@ impl_trait! {
 
         fn irq_request_shared(
             _irq: IrqId,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: BoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             #[cfg(feature = "irq")]
             {
-                ax_hal::irq::request_shared_irq(_irq, _handler, _data).map_err(map_irq_error)
+                ax_hal::irq::request_shared_irq(_irq, _handler).map_err(map_irq_error)
             }
             #[cfg(not(feature = "irq"))]
             {
@@ -236,14 +235,13 @@ impl_trait! {
 
         fn irq_request_shared_disabled(
             _irq: IrqId,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: BoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             #[cfg(feature = "irq")]
             {
                 ax_hal::irq::request_irq(
                     _irq,
-                    ax_hal::irq::IrqRequest::new(_handler, _data)
+                    ax_hal::irq::IrqRequest::new(_handler)
                         .share_mode(ax_hal::irq::ShareMode::Shared)
                         .auto_enable(ax_hal::irq::AutoEnable::No),
                 )
@@ -258,12 +256,11 @@ impl_trait! {
         fn irq_request_percpu(
             _irq: IrqId,
             _cpus: IrqCpuMask,
-            _handler: RawIrqHandler,
-            _data: core::ptr::NonNull<()>,
+            _handler: ConcurrentBoxedIrqHandler,
         ) -> AxResult<IrqHandle> {
             #[cfg(feature = "irq")]
             {
-                ax_hal::irq::request_percpu_irq(_irq, _cpus, _handler, _data)
+                ax_hal::irq::request_percpu_irq(_irq, _cpus, _handler)
                     .map_err(map_irq_error)
             }
             #[cfg(not(feature = "irq"))]

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -431,27 +431,16 @@ fn init_interrupt() {
 
 #[cfg(feature = "irq")]
 pub(crate) fn init_percpu_irq(cpu_id: usize) {
-    use core::ptr::NonNull;
-
-    fn unit_data() -> NonNull<()> {
-        NonNull::dangling()
-    }
-
     ax_hal::irq::cpu_online(cpu_id).expect("failed to mark CPU online for IRQ framework");
     ax_hal::irq::init_common_irq_handler();
 
     if ax_hal::percpu::this_cpu_is_bsp() {
         let cpus = ax_hal::irq::CpuMask::first_n(ax_hal::cpu_num());
-        ax_hal::irq::request_percpu_irq(
-            ax_hal::time::irq_num(),
-            cpus,
-            timer_irq_handler,
-            unit_data(),
-        )
-        .expect("failed to register timer IRQ handler");
+        ax_hal::irq::request_percpu_irq(ax_hal::time::irq_num(), cpus, timer_irq_handler)
+            .expect("failed to register timer IRQ handler");
 
         #[cfg(any(feature = "ipi", feature = "wake-ipi"))]
-        ax_hal::irq::request_percpu_irq(ax_hal::irq::ipi_irq(), cpus, ipi_irq_handler, unit_data())
+        ax_hal::irq::request_percpu_irq(ax_hal::irq::ipi_irq(), cpus, ipi_irq_handler)
             .expect("failed to register IPI IRQ handler");
     }
 
@@ -530,10 +519,7 @@ fn program_next_timer() {
 }
 
 #[cfg(feature = "irq")]
-unsafe fn timer_irq_handler(
-    ctx: ax_hal::irq::IrqContext,
-    _data: core::ptr::NonNull<()>,
-) -> ax_hal::irq::IrqReturn {
+fn timer_irq_handler(ctx: ax_hal::irq::IrqContext) -> ax_hal::irq::IrqReturn {
     let _ = ctx;
     #[cfg(feature = "multitask")]
     let scheduler_tick = advance_periodic_timer(ax_hal::time::monotonic_time_nanos());
@@ -546,19 +532,13 @@ unsafe fn timer_irq_handler(
 }
 
 #[cfg(all(feature = "irq", feature = "ipi"))]
-unsafe fn ipi_irq_handler(
-    _ctx: ax_hal::irq::IrqContext,
-    _data: core::ptr::NonNull<()>,
-) -> ax_hal::irq::IrqReturn {
+fn ipi_irq_handler(_ctx: ax_hal::irq::IrqContext) -> ax_hal::irq::IrqReturn {
     ax_ipi::ipi_handler();
     ax_hal::irq::IrqReturn::Handled
 }
 
 #[cfg(all(feature = "irq", feature = "wake-ipi", not(feature = "ipi")))]
-unsafe fn ipi_irq_handler(
-    _ctx: ax_hal::irq::IrqContext,
-    _data: core::ptr::NonNull<()>,
-) -> ax_hal::irq::IrqReturn {
+fn ipi_irq_handler(_ctx: ax_hal::irq::IrqContext) -> ax_hal::irq::IrqReturn {
     ax_hal::irq::IrqReturn::Handled
 }
 

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -70,10 +70,7 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
 #[cfg(feature = "irq")]
 pub fn register_irq_waker(irq: ax_hal::irq::IrqId, waker: &core::task::Waker) -> AxResult<()> {
     use alloc::{collections::BTreeMap, sync::Arc};
-    use core::{
-        ptr::NonNull,
-        sync::atomic::{AtomicBool, Ordering},
-    };
+    use core::sync::atomic::{AtomicBool, Ordering};
 
     use ax_kspin::SpinNoIrq;
     use axpoll::PollSet;
@@ -91,10 +88,7 @@ pub fn register_irq_waker(irq: ax_hal::irq::IrqId, waker: &core::task::Waker) ->
         poll: Arc<PollSet>,
     }
 
-    unsafe fn irq_waker_handler(
-        ctx: ax_hal::irq::IrqContext,
-        _data: NonNull<()>,
-    ) -> ax_hal::irq::IrqReturn {
+    fn irq_waker_handler(ctx: ax_hal::irq::IrqContext) -> ax_hal::irq::IrqReturn {
         // Runs in IRQ context with interrupts off. Only mark an already
         // registered slot and notify the drain task. The map entry is created
         // during task-context registration, so this path does not allocate.
@@ -162,7 +156,7 @@ pub fn register_irq_waker(irq: ax_hal::irq::IrqId, waker: &core::task::Waker) ->
     unsafe { poll.register(waker, axpoll::IoEvents::all()) };
 
     if should_install {
-        ax_hal::irq::request_shared_irq(irq, irq_waker_handler, NonNull::dangling())
+        ax_hal::irq::request_shared_irq(irq, irq_waker_handler)
             .map_err(|_| AxError::Unsupported)?;
     }
 

--- a/platforms/ax-plat/src/irq.rs
+++ b/platforms/ax-plat/src/irq.rs
@@ -6,8 +6,8 @@ use ax_kernel_guard::BaseGuard;
 pub use irq_framework::{
     AcpiGsiController, AcpiGsiRoute, AcpiIrqPolarity, AcpiIrqTrigger, AutoEnable, BoxedIrqHandler,
     CpuId, CpuMask, HwIrq, IrqAffinity, IrqContext, IrqDomainId, IrqError, IrqExecution, IrqHandle,
-    IrqId, IrqOps, IrqOutcome, IrqRequest, IrqReturn, IrqScope, IrqSource, IrqStatus,
-    RawIrqHandler, Registry, ShareMode, TrapVector,
+    IrqId, IrqOps, IrqOutcome, IrqRequest, IrqReturn, IrqScope, IrqSource, IrqStatus, Registry,
+    ShareMode, TrapVector,
 };
 use spin::Once;
 
@@ -190,41 +190,20 @@ pub fn request_irq(irq: IrqId, request: IrqRequest) -> Result<IrqHandle, IrqErro
 /// Requests a shared IRQ action.
 pub fn request_shared_irq(
     irq: IrqId,
-    handler: RawIrqHandler,
-    data: core::ptr::NonNull<()>,
+    handler: impl FnMut(IrqContext) -> IrqReturn + Send + 'static,
 ) -> Result<IrqHandle, IrqError> {
-    request_irq(
-        irq,
-        IrqRequest::new(handler, data).share_mode(ShareMode::Shared),
-    )
-}
-
-/// Requests a boxed IRQ action.
-pub fn request_boxed_irq(irq: IrqId, request: IrqRequest) -> Result<IrqHandle, IrqError> {
-    request_irq(irq, request)
-}
-
-/// Requests a boxed shared IRQ action.
-pub fn request_boxed_shared_irq(
-    irq: IrqId,
-    handler: BoxedIrqHandler,
-) -> Result<IrqHandle, IrqError> {
-    request_irq(
-        irq,
-        IrqRequest::new_boxed(handler).share_mode(ShareMode::Shared),
-    )
+    request_irq(irq, IrqRequest::new(handler).share_mode(ShareMode::Shared))
 }
 
 /// Requests a per-CPU IRQ action.
 pub fn request_percpu_irq(
     irq: IrqId,
     cpus: CpuMask,
-    handler: RawIrqHandler,
-    data: core::ptr::NonNull<()>,
+    handler: impl Fn(IrqContext) -> IrqReturn + Send + Sync + 'static,
 ) -> Result<IrqHandle, IrqError> {
     request_irq(
         irq,
-        IrqRequest::new(handler, data).scope(IrqScope::PerCpu { cpus }),
+        IrqRequest::new_concurrent(handler).scope(IrqScope::PerCpu { cpus }),
     )
 }
 
@@ -342,10 +321,7 @@ pub trait IrqIf {
 
 #[cfg(test)]
 mod tests {
-    use core::{
-        ptr::NonNull,
-        sync::atomic::{AtomicUsize, Ordering},
-    };
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
     use crate::impl_plat_interface;
@@ -388,15 +364,10 @@ mod tests {
         }
     }
 
-    unsafe fn test_irq_handler(_ctx: IrqContext, _data: NonNull<()>) -> IrqReturn {
-        IrqReturn::Handled
-    }
-
     #[test]
     fn request_irq_auto_enable_no_does_not_enable_line() {
         let irq = IrqId::new(IrqDomainId(0xff), HwIrq(1));
-        let request =
-            IrqRequest::new(test_irq_handler, NonNull::dangling()).auto_enable(AutoEnable::No);
+        let request = IrqRequest::new(|_| IrqReturn::Handled).auto_enable(AutoEnable::No);
 
         ENABLE_CALLS.store(0, Ordering::Relaxed);
         let handle = request_irq(irq, request).unwrap();
@@ -410,7 +381,7 @@ mod tests {
     #[test]
     fn request_irq_rolls_back_action_when_auto_enable_fails() {
         let irq = IrqId::new(IrqDomainId(0xff), HwIrq(2));
-        let request = || IrqRequest::new(test_irq_handler, NonNull::dangling());
+        let request = || IrqRequest::new(|_| IrqReturn::Handled);
 
         ENABLE_CALLS.store(0, Ordering::Relaxed);
         FAIL_ENABLE.store(1, Ordering::Relaxed);

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -237,15 +237,11 @@ pub(crate) type ArceOsIrqReturn = modules::ax_hal::irq::IrqReturn;
 #[cfg(target_arch = "x86_64")]
 pub(crate) type ArceOsIrqSource = modules::ax_hal::irq::IrqSource;
 #[cfg(target_arch = "x86_64")]
-pub(crate) type ArceOsRawIrqHandler = modules::ax_hal::irq::RawIrqHandler;
-
-#[cfg(target_arch = "x86_64")]
 pub(crate) fn request_shared_irq(
     irq: ArceOsIrqId,
-    handler: ArceOsRawIrqHandler,
-    data: core::ptr::NonNull<()>,
+    handler: impl FnMut(ArceOsIrqContext) -> ArceOsIrqReturn + Send + 'static,
 ) -> Result<ArceOsIrqHandle, ArceOsIrqError> {
-    modules::ax_hal::irq::request_shared_irq(irq, handler, data)
+    modules::ax_hal::irq::request_shared_irq(irq, handler)
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/virtualization/axvm/src/host/irq.rs
+++ b/virtualization/axvm/src/host/irq.rs
@@ -1,6 +1,5 @@
 //! Host IRQ facade for AxVM runtime glue.
 
-use core::ptr::NonNull;
 #[cfg(test)]
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -18,10 +17,9 @@ pub(crate) fn make_irq_id(domain: u16, hwirq: u32) -> IrqId {
 
 pub(crate) fn request_shared_irq(
     irq: IrqId,
-    handler: arceos::ArceOsRawIrqHandler,
-    data: NonNull<()>,
+    handler: impl FnMut(IrqContext) -> IrqReturn + Send + 'static,
 ) -> Result<arceos::ArceOsIrqHandle, arceos::ArceOsIrqError> {
-    arceos::request_shared_irq(irq, handler, data)
+    arceos::request_shared_irq(irq, handler)
 }
 
 #[cfg(test)]

--- a/virtualization/axvm/src/runtime/x86_irq.rs
+++ b/virtualization/axvm/src/runtime/x86_irq.rs
@@ -1,7 +1,4 @@
-use core::{
-    ptr::NonNull,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-};
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use ax_kspin::SpinRaw as Mutex;
 
@@ -259,11 +256,7 @@ pub fn enable_ioapic_irq_forwarding(vm: &VMRef, vcpu: &VCpuRef) {
                     continue;
                 }
 
-                match irq::request_shared_irq(
-                    host_irq,
-                    ioapic_irq_forwarding_handler,
-                    NonNull::dangling(),
-                ) {
+                match irq::request_shared_irq(host_irq, ioapic_irq_forwarding_handler) {
                     Ok(handle) => {
                         IOAPIC_IRQ_HANDLES[gsi].store(handle.id() as usize, Ordering::Release);
                         registered += 1;
@@ -552,10 +545,7 @@ fn unmask_forwarded_host_gsi(gsi: usize) {
     IOAPIC_IRQ_MASKED.fetch_and(!bit, Ordering::AcqRel);
 }
 
-unsafe fn ioapic_irq_forwarding_handler(
-    ctx: irq::IrqContext,
-    _data: NonNull<()>,
-) -> irq::IrqReturn {
+fn ioapic_irq_forwarding_handler(ctx: irq::IrqContext) -> irq::IrqReturn {
     let Some(gsi) = guest_gsi_for_host_irq(ctx.irq) else {
         return irq::IrqReturn::Unhandled;
     };


### PR DESCRIPTION
## 背景

`irq-framework` 之前同时保留 raw handler + data 指针和 boxed 回调两套注册方式，上层还有 `request_boxed_*`、`register_boxed_shared`、`HandlerRegistration` 等迁移期兼容 API。这会让新的中断注册路径继续暴露旧 ABI，也让网络 IRQ 仍可能退回共享 interface/raw 指针回调。

review 还指出 per-CPU action 不能简单复用 `FnMut` 的单实例 non-reentrant guard，否则同一个 per-CPU action 在不同 CPU 上并发 dispatch 时会被 `running` guard 跳过。

## 修改

- 将 `irq-framework` 收敛为 boxed callback 路径，删除 `RawIrqHandler`、`IrqRequest::new_boxed`、内部 raw action 分支和 boxed 兼容包装入口。
- 将普通 IRQ callback 明确为 `FnMut + Send` / `NonReentrant`，新增 `ConcurrentBoxedIrqHandler` 与 `IrqRequest::new_concurrent`，仅 `Fn + Send + Sync` handler 可以声明 `IrqExecution::Concurrent`。
- 让 per-CPU IRQ 注册走 concurrent handler，避免跨 CPU 并发 dispatch 被单一 action `running` guard 丢掉；保留 `FnMut` handler 的 non-reentrant 保护。
- 优化 `IrqRequest::new`、`request_shared_irq`、`request_percpu_irq`、`axruntime`/`axklib`/Starry helper、`EthernetIrqAction::new` 等接口为泛型 callback 入参，在接口内部 `Box::new`，调用点不再重复写 boxing。
- 同步清理 `ax-plat`、`axhal`、`axruntime`、`axklib`、`axtask`、AxVM、Starry 设备节点等调用点，统一使用新的 callback 注册接口。
- 清理 `rd-net` / `ax-net` 的旧兼容 fallback：有 IRQ 的网络设备需要提供 owned IRQ handler；没有 handler 时跳过 IRQ 注册并告警，不再通过共享 interface 对象回调。
- 更新 `rdif-eth` 文档和 rdrive/RDIF 架构文档，说明设备 IRQ 应通过 owned boxed handler 暴露。

## 验证

- `cargo fmt`
- `cargo fmt --check`
- `git diff --check 0e638e620f8f898c2b6453beadd9d007d137dc12`
- `cargo test -p irq-framework`
- `cargo xtask clippy --package irq-framework`
- `cargo xtask clippy --package axklib`
- `cargo xtask clippy --package ax-plat`
- `cargo xtask clippy --package rdif-eth`
- `cargo xtask clippy --package rd-net`
- `cargo xtask clippy --package ax-driver`
- `cargo xtask clippy --package ax-net`
- `cargo xtask clippy --package ax-hal`
- `cargo xtask clippy --package ax-task`
- `cargo xtask clippy --package ax-runtime`
- `cargo xtask clippy --package axvm`
- `cargo xtask clippy --package starry-kernel`
- 搜索旧接口名 `RawIrqHandler`、`request_boxed_irq`、`request_boxed_shared_irq`、`IrqRequest::new_boxed`、`ActionHandler::Raw`、`IrqHandler::Raw` 等无命中。
- 搜索调用侧 `IrqRequest::new(Box::new`、`request_shared_irq(...Box::new`、`request_percpu_irq(...Box::new`、`request_shared_disabled(...Box::new`、`EthernetIrqAction::new(Box::new`、`Registration::register_shared(...Box::new`，仅剩 `axklib` wrapper 内部 boxing。