### PR TITLE
refactor(axvm): redesign guest address layout planning

### DIFF
--- a/os/axvisor/src/config.rs
+++ b/os/axvisor/src/config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{format, sync::Arc};
+use alloc::format;
 use core::alloc::Layout;
 #[cfg(all(
     feature = "fs",
@@ -86,26 +86,11 @@ pub mod vmcfg {
     include!(concat!(env!("OUT_DIR"), "/vm_configs.rs"));
 }
 
-pub fn get_vm_dtb_arc(_vm_cfg: &AxVMConfig) -> Option<Arc<[u8]>> {
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-    {
-        let cache_lock = dtb_cache().lock();
-        if let Some(dtb) = cache_lock.get(&_vm_cfg.id()) {
-            return Some(Arc::from(dtb.as_slice()));
-        }
-    }
-    None
-}
-
 pub fn init_guest_vms() {
-    // Initialize the DTB cache in the fdt module
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "loongarch64",
-        target_arch = "riscv64"
-    ))]
+    // Initialize LoongArch firmware resources before guest configs are materialized.
+    #[cfg(target_arch = "loongarch64")]
     {
-        init_dtb_cache();
+        init_guest_boot_resources();
     }
 
     // First try to get configs from filesystem if fs feature is enabled
@@ -154,11 +139,9 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
     let mut vm_config = build_axvm_config(&vm_create_config);
 
     // Handle FDT-related operations for architectures that boot guests with DTB.
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "loongarch64",
-        target_arch = "riscv64"
-    ))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    let guest_dtb = handle_fdt_operations(&mut vm_config, &mut vm_create_config)?;
+    #[cfg(target_arch = "loongarch64")]
     handle_fdt_operations(&mut vm_config, &mut vm_create_config)?;
 
     #[cfg(target_arch = "x86_64")]
@@ -193,6 +176,9 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
     // Load corresponding images for VM.
     info!("VM[{}] created success, loading images...", vm.id());
 
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    let mut loader = ImageLoader::new(main_mem, vm_create_config, vm.clone(), guest_dtb);
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     let mut loader = ImageLoader::new(main_mem, vm_create_config, vm.clone());
     loader.load()?;
 
@@ -255,7 +241,9 @@ pub(crate) fn build_axvm_config(cfg: &AxVMCrateConfig) -> AxVMConfig {
         pass_through_devices: cfg.devices.passthrough_devices.clone(),
         excluded_devices: cfg.devices.excluded_devices.clone(),
         pass_through_addresses: cfg.devices.passthrough_addresses.clone(),
+        reserved_address_ranges: Vec::new(),
         pass_through_ports: cfg.devices.passthrough_ports.clone(),
+        address_space_policy: cfg.devices.address_space_policy,
         interrupt_mode: cfg.devices.interrupt_mode,
     })
 }
@@ -415,12 +403,6 @@ fn x86_intx_forwarding_trigger(binding: &ax_driver::BindingIrq) -> InterruptTrig
         }
         _ => InterruptTriggerMode::LevelTriggered,
     }
-}
-
-#[cfg(all(feature = "fs", target_arch = "x86_64"))]
-fn resolve_device_irq(raw_irq: usize) -> ax_hal::irq::IrqId {
-    ax_hal::irq::try_legacy_irq(raw_irq)
-        .unwrap_or_else(|_| panic!("legacy device IRQ {raw_irq} exceeds platform IRQ id width"))
 }
 
 fn config_guest_address(vm: &AxVMRef, main_memory: &VMMemoryRegion, boot_protocol: VMBootProtocol) {

--- a/os/axvisor/src/fdt/create.rs
+++ b/os/axvisor/src/fdt/create.rs
@@ -58,7 +58,7 @@ fn should_skip_guest_cpu_prop(prop_name: &str) -> bool {
 ///
 /// # Return Value
 /// Returns the generated DTB data
-pub fn crate_guest_fdt(
+pub fn create_guest_fdt(
     fdt: &Fdt,
     passthrough_device_names: &[String],
     crate_config: &AxVMCrateConfig,
@@ -525,7 +525,8 @@ pub fn update_fdt(
         new_fdt_bytes.len()
     );
     // Load the updated FDT into VM
-    load_vm_image_from_memory(&new_fdt_bytes, dest_addr, vm_clone)?;
+    load_vm_image_from_memory(&new_fdt_bytes, dest_addr, vm_clone.clone())?;
+    vm_clone.set_guest_device_tree(dest_addr, new_fdt_bytes)?;
     Ok(())
 }
 
@@ -536,14 +537,10 @@ pub fn update_fdt(
     vm: AxVMRef,
     crate_config: &AxVMCrateConfig,
 ) -> AxResult {
-    // Fix up the cached DTB against the runtime layout before boot.
+    // Fix up the guest DTB against the runtime layout before boot.
     let fdt_bytes = unsafe { core::slice::from_raw_parts(fdt_src.as_ptr(), dtb_size) };
-    let fdt = Fdt::from_bytes(fdt_bytes).map_err(|e| {
-        ax_err_type!(
-            InvalidData,
-            format!("Failed to parse cached guest FDT: {e:#?}")
-        )
-    })?;
+    let fdt = Fdt::from_bytes(fdt_bytes)
+        .map_err(|e| ax_err_type!(InvalidData, format!("Failed to parse guest FDT: {e:#?}")))?;
     // Keep boot metadata such as /chosen from the host FDT when it is available.
     let host_fdt_bytes = super::try_get_host_fdt();
     let host_fdt = host_fdt_bytes
@@ -561,7 +558,8 @@ pub fn update_fdt(
     // Recompute the DTB load address from the runtime memory layout.
     let dest_addr = calculate_dtb_load_addr(vm.clone(), new_fdt_bytes.len())?;
 
-    load_vm_image_from_memory(&new_fdt_bytes, dest_addr, vm)
+    load_vm_image_from_memory(&new_fdt_bytes, dest_addr, vm.clone())?;
+    vm.set_guest_device_tree(dest_addr, new_fdt_bytes)
 }
 
 #[cfg(test)]

--- a/os/axvisor/src/fdt/mod.rs
+++ b/os/axvisor/src/fdt/mod.rs
@@ -31,15 +31,11 @@ pub(crate) mod vm_fdt;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use alloc::format;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::vec::Vec;
 
 use ax_errno::AxResult;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use ax_errno::ax_err_type;
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-use ax_kspin::SpinNoIrq as Mutex;
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-use ax_lazyinit::LazyInit;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use fdt_parser::Fdt;
 // pub use print::print_fdt;
@@ -54,38 +50,30 @@ use axvm::config::AxVMConfig;
 use axvmconfig::{AxVMCrateConfig, VMBootProtocol};
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-use crate::config::{get_vm_dtb_arc, vmcfg};
+use crate::config::vmcfg;
 
-// DTB cache for generated device trees
+/// Guest DTB artifact produced or patched by the monitor before AxVM owns it.
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-static GENERATED_DTB_CACHE: LazyInit<Mutex<BTreeMap<usize, Vec<u8>>>> = LazyInit::new();
+#[derive(Debug, Clone)]
+pub(crate) struct GuestDtbImage {
+    bytes: Vec<u8>,
+}
 
-/// Initialize the DTB cache
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-pub fn init_dtb_cache() {
-    GENERATED_DTB_CACHE.init_once(Mutex::new(BTreeMap::new()));
+impl GuestDtbImage {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
 }
 
 /// Initialize LoongArch guest firmware resource handling.
 #[cfg(target_arch = "loongarch64")]
-pub fn init_dtb_cache() {
+pub(crate) fn init_guest_boot_resources() {
     crate::guest_platform::loongarch64::init();
-}
-
-/// Get reference to the DTB cache
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-pub fn dtb_cache() -> &'static Mutex<BTreeMap<usize, Vec<u8>>> {
-    GENERATED_DTB_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()))
-}
-
-/// Generate guest FDT cache the result
-/// # Return Value
-/// Returns the generated DTB data and stores it in the global cache
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-pub fn crate_guest_fdt_with_cache(dtb_data: Vec<u8>, crate_config: &AxVMCrateConfig) {
-    // Store data in global cache
-    let mut cache_lock = dtb_cache().lock();
-    cache_lock.insert(crate_config.base.id, dtb_data);
 }
 
 #[cfg(target_arch = "loongarch64")]
@@ -110,14 +98,15 @@ fn handle_uefi_fdt_operations(
     Ok(())
 }
 
-/// Handle all FDT-related operations for guest architectures that boot with DTB.
+/// Prepare LoongArch guest firmware FDT facts for UEFI boot.
 #[cfg(target_arch = "loongarch64")]
-pub fn handle_fdt_operations(
+pub(crate) fn handle_fdt_operations(
     vm_config: &mut AxVMConfig,
     vm_create_config: &mut AxVMCrateConfig,
 ) -> AxResult {
     if vm_create_config.kernel.effective_boot_protocol() == VMBootProtocol::Uefi {
-        return handle_uefi_fdt_operations(vm_config, vm_create_config);
+        handle_uefi_fdt_operations(vm_config, vm_create_config)?;
+        return Ok(());
     }
 
     ax_errno::ax_err!(
@@ -128,15 +117,17 @@ pub fn handle_fdt_operations(
 
 /// Handle all FDT-related operations for guest architectures that boot with DTB.
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-pub fn handle_fdt_operations(
+pub(crate) fn handle_fdt_operations(
     vm_config: &mut AxVMConfig,
     vm_create_config: &mut AxVMCrateConfig,
-) -> AxResult {
+) -> AxResult<Option<GuestDtbImage>> {
     if vm_create_config.kernel.effective_boot_protocol() == VMBootProtocol::Uefi {
-        return handle_uefi_fdt_operations(vm_config, vm_create_config);
+        handle_uefi_fdt_operations(vm_config, vm_create_config)?;
+        return Ok(None);
     }
 
     let host_fdt_bytes = try_get_host_fdt();
+    let mut guest_dtb = None;
 
     if let Some(host_fdt_bytes) = host_fdt_bytes {
         let host_fdt = Fdt::from_bytes(host_fdt_bytes)
@@ -145,17 +136,31 @@ pub fn handle_fdt_operations(
 
         if let Some(provided_dtb) = get_developer_provided_dtb(vm_config, vm_create_config)? {
             info!("VM[{}] found DTB , parsing...", vm_config.id());
-            update_provided_fdt(&provided_dtb, host_fdt_bytes, vm_create_config)?;
+            reserve_excluded_device_ranges(vm_config, vm_create_config, &provided_dtb)?;
+            guest_dtb = Some(GuestDtbImage::new(update_provided_fdt(
+                &provided_dtb,
+                host_fdt_bytes,
+                vm_create_config,
+            )?));
         } else {
             info!(
                 "VM[{}] DTB not found, generating based on the configuration file.",
                 vm_config.id()
             );
-            setup_guest_fdt_from_vmm(host_fdt_bytes, vm_config, vm_create_config)?;
+            guest_dtb = Some(GuestDtbImage::new(setup_guest_fdt_from_vmm(
+                host_fdt_bytes,
+                vm_config,
+                vm_create_config,
+            )?));
         }
     } else if let Some(provided_dtb) = get_developer_provided_dtb(vm_config, vm_create_config)? {
         info!("VM[{}] found DTB , parsing...", vm_config.id());
-        update_provided_fdt(&provided_dtb, &[], vm_create_config)?;
+        reserve_excluded_device_ranges(vm_config, vm_create_config, &provided_dtb)?;
+        guest_dtb = Some(GuestDtbImage::new(update_provided_fdt(
+            &provided_dtb,
+            &[],
+            vm_create_config,
+        )?));
     } else {
         warn!(
             "VM[{}] no guest DTB provided; continuing without generated DTB",
@@ -164,8 +169,7 @@ pub fn handle_fdt_operations(
     }
 
     // Overlay VM config with the given DTB.
-    if let Some(dtb_arc) = get_vm_dtb_arc(vm_config) {
-        let dtb = dtb_arc.as_ref();
+    if let Some(dtb) = guest_dtb.as_ref().map(GuestDtbImage::as_bytes) {
         parse_reserved_memory_regions(vm_create_config, dtb)?;
         parse_passthrough_devices_address(vm_config, vm_create_config, dtb)?;
         #[cfg(target_arch = "aarch64")]
@@ -194,21 +198,21 @@ pub fn handle_fdt_operations(
         vm_config.clear_dtb_load_gpa();
         vm_create_config.kernel.dtb_load_addr = None;
     }
-    Ok(())
+    Ok(guest_dtb)
 }
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-pub fn get_developer_provided_dtb(
+fn get_developer_provided_dtb(
     vm_cfg: &AxVMConfig,
     crate_config: &AxVMCrateConfig,
 ) -> AxResult<Option<Vec<u8>>> {
     match crate_config.kernel.image_location.as_deref() {
         Some("memory") => {
-            let vm_imags = vmcfg::get_memory_images()
+            let vm_images = vmcfg::get_memory_images()
                 .iter()
                 .find(|&v| v.id == vm_cfg.id());
 
-            if let Some(dtb) = vm_imags.and_then(|images| images.dtb) {
+            if let Some(dtb) = vm_images.and_then(|images| images.dtb) {
                 info!("DTB file in memory, size: 0x{:x}", dtb.len());
                 return Ok(Some(dtb.to_vec()));
             }

--- a/os/axvisor/src/fdt/parser.rs
+++ b/os/axvisor/src/fdt/parser.rs
@@ -22,9 +22,9 @@ use fdt_parser::{Fdt, FdtHeader, PciRange, PciSpace};
 #[cfg(target_arch = "aarch64")]
 use crate::fdt::create::update_cpu_node;
 use axvm::{MappingFlags, config::AxVMConfig};
-use axvmconfig::{AxVMCrateConfig, PassThroughDeviceConfig, VmMemConfig, VmMemMappingType};
-
-use crate::fdt::crate_guest_fdt_with_cache;
+use axvmconfig::{
+    AxVMCrateConfig, PassThroughDeviceConfig, ReservedAddressConfig, VmMemConfig, VmMemMappingType,
+};
 
 const PAGE_SIZE_4K: usize = 0x1000;
 
@@ -64,16 +64,17 @@ pub fn setup_guest_fdt_from_vmm(
     fdt_bytes: &[u8],
     vm_cfg: &mut AxVMConfig,
     crate_config: &AxVMCrateConfig,
-) -> AxResult {
+) -> AxResult<Vec<u8>> {
     let fdt = Fdt::from_bytes(fdt_bytes)
         .map_err(|e| ax_err_type!(InvalidData, format!("Failed to parse host FDT: {e:#?}")))?;
+
+    reserve_excluded_device_ranges(vm_cfg, crate_config, fdt_bytes)?;
 
     // Call the modified function and get the returned device name list
     let passthrough_device_names = super::device::find_all_passthrough_devices(vm_cfg, &fdt);
 
-    let dtb_data = super::create::crate_guest_fdt(&fdt, &passthrough_device_names, crate_config)?;
-    crate_guest_fdt_with_cache(dtb_data, crate_config);
-    Ok(())
+    let dtb_data = super::create::create_guest_fdt(&fdt, &passthrough_device_names, crate_config)?;
+    Ok(dtb_data)
 }
 
 fn is_reserved_memory_path(node_path: &str) -> bool {
@@ -160,6 +161,123 @@ fn reserved_memory_regions(crate_cfg: &AxVMCrateConfig) -> impl Iterator<Item = 
         .memory_regions
         .iter()
         .filter(|region| region.map_type == VmMemMappingType::MapReserved)
+}
+
+fn excluded_device_paths(crate_cfg: &AxVMCrateConfig) -> Vec<String> {
+    crate_cfg
+        .devices
+        .excluded_devices
+        .iter()
+        .flatten()
+        .cloned()
+        .collect()
+}
+
+fn is_excluded_node_path(node_path: &str, excluded_paths: &[String]) -> bool {
+    excluded_paths.iter().any(|excluded| {
+        node_path == excluded
+            || node_path
+                .strip_prefix(excluded)
+                .is_some_and(|suffix| suffix.starts_with('/'))
+    })
+}
+
+fn push_reserved_address_range(
+    ranges: &mut Vec<ReservedAddressConfig>,
+    node_path: &str,
+    base: usize,
+    size: usize,
+) {
+    let Some((base_gpa, length)) = align_reserved_region_4k(base, size) else {
+        return;
+    };
+
+    let mut merged = ReservedAddressConfig { base_gpa, length };
+    let mut index = 0;
+    while index < ranges.len() {
+        let existing = &ranges[index];
+        let merged_end = merged.base_gpa.saturating_add(merged.length);
+        let existing_end = existing.base_gpa.saturating_add(existing.length);
+        let overlaps_or_touches =
+            merged.base_gpa <= existing_end && existing.base_gpa <= merged_end;
+        if overlaps_or_touches {
+            let merged_base = merged.base_gpa.min(existing.base_gpa);
+            let merged_end = merged_end.max(existing_end);
+            merged = ReservedAddressConfig {
+                base_gpa: merged_base,
+                length: merged_end.saturating_sub(merged_base),
+            };
+            ranges.remove(index);
+        } else {
+            index += 1;
+        }
+    }
+
+    debug!(
+        "Reserving excluded device {} range [{:#x}~{:#x}] from passthrough mapping",
+        node_path,
+        merged.base_gpa,
+        merged.base_gpa.saturating_add(merged.length)
+    );
+    ranges.push(merged);
+}
+
+pub fn reserve_excluded_device_ranges(
+    vm_cfg: &mut AxVMConfig,
+    crate_cfg: &AxVMCrateConfig,
+    dtb: &[u8],
+) -> AxResult {
+    let excluded_paths = excluded_device_paths(crate_cfg);
+    if excluded_paths.is_empty() {
+        return Ok(());
+    }
+
+    let fdt = Fdt::from_bytes(dtb).map_err(|e| {
+        ax_err_type!(
+            InvalidData,
+            format!("Failed to parse DTB image while reading excluded devices: {e:#?}")
+        )
+    })?;
+    let all_nodes: Vec<_> = fdt.all_nodes().collect();
+    let all_paths = super::build_all_node_paths(&all_nodes);
+    let mut reserved_ranges = Vec::new();
+
+    for (node, node_path) in all_nodes.iter().zip(all_paths.iter()) {
+        if !is_excluded_node_path(node_path, &excluded_paths) {
+            continue;
+        }
+
+        if let Some(reg_iter) = node.reg() {
+            for reg in reg_iter {
+                push_reserved_address_range(
+                    &mut reserved_ranges,
+                    node_path,
+                    reg.address as usize,
+                    reg.size.unwrap_or(0),
+                );
+            }
+        }
+
+        if let Some(pci) = node.clone().into_pci()
+            && let Ok(pci_ranges) = pci.ranges()
+        {
+            for range in pci_ranges {
+                push_reserved_address_range(
+                    &mut reserved_ranges,
+                    node_path,
+                    range.cpu_address as usize,
+                    range.size as usize,
+                );
+            }
+        }
+    }
+
+    reserved_ranges.sort_by_key(|range| range.base_gpa);
+    for range in reserved_ranges {
+        vm_cfg.add_reserved_address_range(range);
+    }
+
+    Ok(())
 }
 
 fn is_memory_like_compatible(node: &fdt_parser::Node<'_>) -> bool {
@@ -308,7 +426,33 @@ pub fn parse_reserved_memory_regions(crate_cfg: &mut AxVMCrateConfig, dtb: &[u8]
 
 #[cfg(test)]
 mod tests {
-    use super::align_reserved_region_4k;
+    use super::{align_reserved_region_4k, reserve_excluded_device_ranges};
+    use crate::fdt::vm_fdt::FdtWriter;
+    use axvm::config::{AxVMConfig, AxVMConfigParams, PhysCpuList};
+    use axvm_types::AddressSpacePolicy;
+    use axvmconfig::{AxVMCrateConfig, VMDevicesConfig};
+
+    fn fdt_with_excluded_devices() -> Vec<u8> {
+        let mut writer = FdtWriter::new().unwrap();
+        let root = writer.begin_node("").unwrap();
+        writer.property_u32("#address-cells", 2).unwrap();
+        writer.property_u32("#size-cells", 2).unwrap();
+
+        let serial = writer.begin_node("serial@10001234").unwrap();
+        writer
+            .property_array_u32("reg", &[0, 0x1000_1234, 0, 0x100])
+            .unwrap();
+        writer.end_node(serial).unwrap();
+
+        let gpio = writer.begin_node("gpio@10002000").unwrap();
+        writer
+            .property_array_u32("reg", &[0, 0x1000_2000, 0, 0x1000])
+            .unwrap();
+        writer.end_node(gpio).unwrap();
+
+        writer.end_node(root).unwrap();
+        writer.finish().unwrap()
+    }
 
     #[test]
     fn align_reserved_region_keeps_aligned_range() {
@@ -371,6 +515,32 @@ mod tests {
         }];
 
         assert!(subtract_memory_region_overlap(0x2000, 0x1000, &existing).is_empty());
+    }
+
+    #[test]
+    fn excluded_device_ranges_become_reserved_vm_ranges() {
+        let dtb = fdt_with_excluded_devices();
+        let mut vm_cfg = AxVMConfig::new(AxVMConfigParams {
+            id: 0,
+            name: "test".to_string(),
+            phys_cpu_ls: PhysCpuList::new(1, None, None),
+            ..Default::default()
+        });
+        let crate_cfg = AxVMCrateConfig {
+            devices: VMDevicesConfig {
+                address_space_policy: AddressSpacePolicy::Passthrough,
+                excluded_devices: vec![vec!["/serial@10001234".to_string()]],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        reserve_excluded_device_ranges(&mut vm_cfg, &crate_cfg, &dtb).unwrap();
+
+        let ranges = vm_cfg.reserved_address_ranges();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].base_gpa, 0x1000_1000);
+        assert_eq!(ranges[0].length, 0x1000);
     }
 }
 
@@ -764,11 +934,12 @@ pub fn update_provided_fdt(
     provided_dtb: &[u8],
     host_dtb: &[u8],
     crate_config: &AxVMCrateConfig,
-) -> AxResult {
+) -> AxResult<Vec<u8>> {
     #[cfg(any(target_arch = "loongarch64", target_arch = "riscv64"))]
     {
         let _ = host_dtb;
-        crate_guest_fdt_with_cache(provided_dtb.to_vec(), crate_config);
+        let _ = crate_config;
+        Ok(provided_dtb.to_vec())
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -786,7 +957,6 @@ pub fn update_provided_fdt(
             )
         })?;
         let provided_dtb_data = update_cpu_node(&provided_fdt, &host_fdt, crate_config)?;
-        crate_guest_fdt_with_cache(provided_dtb_data, crate_config);
+        Ok(provided_dtb_data)
     }
-    Ok(())
 }

--- a/os/axvisor/src/guest_platform/loongarch64/mod.rs
+++ b/os/axvisor/src/guest_platform/loongarch64/mod.rs
@@ -161,7 +161,8 @@ pub fn load_firmware_fdt(vm: &AxVMRef, config: &AxVMCrateConfig) -> AxResult {
         &fdt,
         GuestPhysAddr::from(UEFI_FIRMWARE_FDT_BASE),
         vm.clone(),
-    )
+    )?;
+    vm.set_guest_device_tree(GuestPhysAddr::from(UEFI_FIRMWARE_FDT_BASE), fdt)
 }
 
 pub fn fw_cfg_platform_config(vm: &AxVMRef, config: &AxVMCrateConfig) -> FwCfgPlatformConfig {

--- a/os/axvisor/src/images/mod.rs
+++ b/os/axvisor/src/images/mod.rs
@@ -26,7 +26,9 @@ use byte_unit::Byte;
 
 use axvm::{AxVMRef, GuestPhysAddr, VMMemoryRegion};
 
-use crate::config::{get_vm_dtb_arc, vmcfg};
+use crate::config::vmcfg;
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+use crate::fdt::GuestDtbImage;
 
 mod linux;
 #[cfg(target_arch = "x86_64")]
@@ -86,11 +88,11 @@ fn with_memory_image<F, R>(config: &AxVMCrateConfig, func: F) -> Option<R>
 where
     F: FnOnce(&[u8]) -> R,
 {
-    let vm_imags = vmcfg::get_memory_images()
+    let vm_images = vmcfg::get_memory_images()
         .iter()
         .find(|&v| v.id == config.base.id)?;
 
-    Some(func(vm_imags.kernel))
+    Some(func(vm_images.kernel))
 }
 
 fn memory_images_for_vm(config: &AxVMCrateConfig) -> AxResult<&'static vmcfg::MemoryImage> {
@@ -117,23 +119,40 @@ pub struct ImageLoader {
     main_memory: VMMemoryRegion,
     vm: AxVMRef,
     config: AxVMCrateConfig,
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    guest_dtb: Option<GuestDtbImage>,
     kernel_load_gpa: GuestPhysAddr,
     bios_load_gpa: Option<GuestPhysAddr>,
-    dtb_load_gpa: Option<GuestPhysAddr>,
     ramdisk_load_gpa: Option<GuestPhysAddr>,
 }
 
 impl ImageLoader {
-    pub fn new(main_memory: VMMemoryRegion, config: AxVMCrateConfig, vm: AxVMRef) -> Self {
+    pub fn new(
+        main_memory: VMMemoryRegion,
+        config: AxVMCrateConfig,
+        vm: AxVMRef,
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))] guest_dtb: Option<
+            GuestDtbImage,
+        >,
+    ) -> Self {
         Self {
             main_memory,
             vm,
             config,
+            #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+            guest_dtb,
             kernel_load_gpa: GuestPhysAddr::default(),
             bios_load_gpa: None,
-            dtb_load_gpa: None,
             ramdisk_load_gpa: None,
         }
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    fn load_guest_dtb(&self, dtb: &GuestDtbImage) -> AxResult {
+        let bytes = dtb.as_bytes();
+        let dtb_src = core::ptr::NonNull::new(bytes.as_ptr() as *mut u8)
+            .ok_or_else(|| ax_err_type!(InvalidData, "Guest DTB pointer is null"))?;
+        crate::fdt::update_fdt(dtb_src, bytes.len(), self.vm.clone(), &self.config)
     }
 
     pub fn load(&mut self) -> AxResult {
@@ -148,7 +167,6 @@ impl ImageLoader {
 
         self.vm.with_config(|config| {
             self.kernel_load_gpa = config.image_config.kernel_load_gpa;
-            self.dtb_load_gpa = config.image_config.dtb_load_gpa;
             self.bios_load_gpa = config.image_config.bios_load_gpa;
             self.ramdisk_load_gpa = config.image_config.ramdisk.as_ref().map(|r| r.load_gpa);
         });
@@ -169,69 +187,44 @@ impl ImageLoader {
     fn load_vm_images_from_memory(&mut self) -> AxResult {
         debug!("Loading VM[{}] images from memory", self.config.base.id);
 
-        let vm_imags = memory_images_for_vm(&self.config)?;
+        let vm_images = memory_images_for_vm(&self.config)?;
 
         #[cfg(target_arch = "x86_64")]
         if should_direct_boot_x86_linux(&self.config)
-            && let Some(header) = detect_x86_linux_image(vm_imags.kernel)
+            && let Some(header) = detect_x86_linux_image(vm_images.kernel)
         {
             return self.load_x86_linux_images_from_memory(
                 header,
-                vm_imags.kernel,
-                vm_imags.ramdisk,
+                vm_images.kernel,
+                vm_images.ramdisk,
             );
         }
 
         #[cfg(target_arch = "loongarch64")]
         if self.loongarch_uefi_boot() {
             self.load_loongarch_uefi_firmware_dtb()?;
-            self.add_loongarch_uefi_fw_cfg_from_memory(vm_imags.kernel, vm_imags.ramdisk)?;
-            self.load_loongarch_uefi_firmware_from_memory(vm_imags.bios)?;
+            self.add_loongarch_uefi_fw_cfg_from_memory(vm_images.kernel, vm_images.ramdisk)?;
+            self.load_loongarch_uefi_firmware_from_memory(vm_images.bios)?;
             return Ok(());
         }
 
-        load_vm_image_from_memory(vm_imags.kernel, self.kernel_load_gpa, self.vm.clone())?;
+        load_vm_image_from_memory(vm_images.kernel, self.kernel_load_gpa, self.vm.clone())?;
 
         // Load Ramdisk image and record its size before regenerating the DTB.
-        if let Some(buffer) = vm_imags.ramdisk {
+        if let Some(buffer) = vm_images.ramdisk {
             self.load_ramdisk_from_memory(buffer)?;
         }
-        // Load DTB image
-        let vm_config = crate::config::build_axvm_config(&self.config);
-
-        if let Some(dtb_arc) = get_vm_dtb_arc(&vm_config) {
-            let _dtb_slice: &[u8] = &dtb_arc;
-            #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-            {
-                if let Some(dtb_src) = core::ptr::NonNull::new(_dtb_slice.as_ptr() as *mut u8) {
-                    crate::fdt::update_fdt(
-                        dtb_src,
-                        _dtb_slice.len(),
-                        self.vm.clone(),
-                        &self.config,
-                    )?;
-                } else {
-                    return ax_err!(InvalidData, "Guest DTB pointer is null");
-                }
-            }
-        } else {
-            #[cfg(target_arch = "riscv64")]
-            if let Some(buffer) = vm_imags.dtb {
-                let dtb_load_gpa = self
-                    .dtb_load_gpa
-                    .ok_or_else(|| ax_err_type!(NotFound, "DTB load address is missing"))?;
-                load_vm_image_from_memory(buffer, dtb_load_gpa, self.vm.clone())?;
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+        {
+            // Load DTB image
+            if let Some(dtb) = &self.guest_dtb {
+                self.load_guest_dtb(dtb)?;
             } else {
-                info!("dtb_load_gpa not provided");
-            }
-
-            #[cfg(not(target_arch = "riscv64"))]
-            {
-                info!("dtb_load_gpa not provided");
+                info!("VM[{}] has no guest DTB image to load", self.config.base.id);
             }
         }
 
-        self.load_boot_image_from_memory(vm_imags.bios)?;
+        self.load_boot_image_from_memory(vm_images.bios)?;
 
         Ok(())
     }
@@ -720,6 +713,7 @@ pub fn load_vm_image_from_memory(
     }
 }
 
+#[cfg(target_arch = "loongarch64")]
 fn fill_vm_region(load_addr: GuestPhysAddr, size: usize, byte: u8, vm: AxVMRef) -> AxResult {
     let image_load_regions = vm.get_image_load_region(load_addr, size)?;
     let mut filled_size = 0;
@@ -836,20 +830,11 @@ pub mod fs {
         if let Some(ramdisk_path) = &loader.config.kernel.ramdisk_path {
             loader.load_ramdisk_from_filesystem(ramdisk_path)?;
         };
-        // Load DTB image if needed.
-        let vm_config = crate::config::build_axvm_config(&loader.config);
-        if let Some(dtb_arc) = get_vm_dtb_arc(&vm_config) {
-            let _dtb_slice: &[u8] = &dtb_arc;
-            #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-            {
-                let dtb_src = core::ptr::NonNull::new(_dtb_slice.as_ptr() as *mut u8)
-                    .ok_or_else(|| ax_err_type!(InvalidData, "Guest DTB pointer is null"))?;
-                crate::fdt::update_fdt(
-                    dtb_src,
-                    _dtb_slice.len(),
-                    loader.vm.clone(),
-                    &loader.config,
-                )?;
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+        {
+            // Load DTB image if needed.
+            if let Some(dtb) = &loader.guest_dtb {
+                loader.load_guest_dtb(dtb)?;
             }
         }
 

--- a/virtualization/axaddrspace/src/address_space/backend/linear.rs
+++ b/virtualization/axaddrspace/src/address_space/backend/linear.rs
@@ -21,8 +21,13 @@ use crate::npt::NestedPageTable as PageTable;
 
 impl<H: PagingHandler> Backend<H> {
     /// Creates a new linear mapping backend.
-    pub const fn new_linear(pa_va_offset: usize) -> Self {
-        Self::Linear { pa_va_offset }
+    pub const fn new_linear(pa_to_va_delta: i128) -> Self {
+        Self::Linear { pa_to_va_delta }
+    }
+
+    fn linear_paddr(vaddr: GuestPhysAddr, pa_to_va_delta: i128) -> Option<PhysAddr> {
+        let paddr = (vaddr.as_usize() as i128).checked_sub(pa_to_va_delta)?;
+        usize::try_from(paddr).ok().map(PhysAddr::from)
     }
 
     pub(crate) fn map_linear(
@@ -31,9 +36,11 @@ impl<H: PagingHandler> Backend<H> {
         size: usize,
         flags: MappingFlags,
         pt: &mut PageTable<H>,
-        pa_va_offset: usize,
+        pa_to_va_delta: i128,
     ) -> bool {
-        let pa_start = PhysAddr::from(start.as_usize() - pa_va_offset);
+        let Some(pa_start) = Self::linear_paddr(start, pa_to_va_delta) else {
+            return false;
+        };
         debug!(
             "map_linear: [{:#x}, {:#x}) -> [{:#x}, {:#x}) {:?}",
             start,
@@ -45,7 +52,10 @@ impl<H: PagingHandler> Backend<H> {
         let allow_huge = true;
         pt.map_region(
             start,
-            |va| PhysAddr::from(va.as_usize() - pa_va_offset),
+            |va| {
+                Self::linear_paddr(va, pa_to_va_delta)
+                    .expect("linear mapping physical address underflow")
+            },
             size,
             flags,
             allow_huge,
@@ -58,7 +68,7 @@ impl<H: PagingHandler> Backend<H> {
         start: GuestPhysAddr,
         size: usize,
         pt: &mut PageTable<H>,
-        _pa_va_offset: usize,
+        _pa_to_va_delta: i128,
     ) -> bool {
         debug!("unmap_linear: [{:#x}, {:#x})", start, start + size);
         pt.unmap_region(start, size).is_ok()

--- a/virtualization/axaddrspace/src/address_space/backend/mod.rs
+++ b/virtualization/axaddrspace/src/address_space/backend/mod.rs
@@ -35,11 +35,12 @@ pub enum Backend<H: PagingHandler> {
     /// Linear mapping backend.
     ///
     /// The offset between the virtual address and the physical address is
-    /// constant, which is specified by `pa_va_offset`. For example, the virtual
-    /// address `vaddr` is mapped to the physical address `vaddr - pa_va_offset`.
+    /// constant, which is specified by `pa_to_va_delta`. For example, the
+    /// virtual address `vaddr` is mapped to the physical address
+    /// `(vaddr as i128 - pa_to_va_delta) as usize`.
     Linear {
         /// `vaddr - paddr`.
-        pa_va_offset: usize,
+        pa_to_va_delta: i128,
     },
     /// Allocation mapping backend.
     ///
@@ -58,7 +59,7 @@ pub enum Backend<H: PagingHandler> {
 impl<H: PagingHandler> Clone for Backend<H> {
     fn clone(&self) -> Self {
         match *self {
-            Self::Linear { pa_va_offset } => Self::Linear { pa_va_offset },
+            Self::Linear { pa_to_va_delta } => Self::Linear { pa_to_va_delta },
             Self::Alloc { populate, .. } => Self::Alloc {
                 populate,
                 _phantom: core::marker::PhantomData,
@@ -80,14 +81,16 @@ impl<H: PagingHandler> MappingBackend for Backend<H> {
         pt: &mut PageTable<H>,
     ) -> bool {
         match *self {
-            Self::Linear { pa_va_offset } => self.map_linear(start, size, flags, pt, pa_va_offset),
+            Self::Linear { pa_to_va_delta } => {
+                self.map_linear(start, size, flags, pt, pa_to_va_delta)
+            }
             Self::Alloc { populate, .. } => self.map_alloc(start, size, flags, pt, populate),
         }
     }
 
     fn unmap(&self, start: GuestPhysAddr, size: usize, pt: &mut PageTable<H>) -> bool {
         match *self {
-            Self::Linear { pa_va_offset } => self.unmap_linear(start, size, pt, pa_va_offset),
+            Self::Linear { pa_to_va_delta } => self.unmap_linear(start, size, pt, pa_to_va_delta),
             Self::Alloc { populate, .. } => self.unmap_alloc(start, size, pt, populate),
         }
     }

--- a/virtualization/axaddrspace/src/address_space/mod.rs
+++ b/virtualization/axaddrspace/src/address_space/mod.rs
@@ -94,8 +94,11 @@ impl<H: PagingHandler> AddrSpace<H> {
         if !start_vaddr.is_aligned_4k() || !start_paddr.is_aligned_4k() || !is_aligned_4k(size) {
             return ax_err!(InvalidInput, "address not aligned");
         }
+        if start_paddr.as_usize().checked_add(size).is_none() {
+            return ax_err!(InvalidInput, "physical address range overflow");
+        }
 
-        let offset = start_vaddr.as_usize() - start_paddr.as_usize();
+        let offset = start_vaddr.as_usize() as i128 - start_paddr.as_usize() as i128;
         let area = MemoryArea::new(start_vaddr, size, flags, Backend::new_linear(offset));
         self.areas
             .map(area, &mut self.pt, false)

--- a/virtualization/axaddrspace/tests/address_space.rs
+++ b/virtualization/axaddrspace/tests/address_space.rs
@@ -102,6 +102,37 @@ fn test_map_linear() {
 
 #[test]
 #[axin(decorator(mock_hal_test))]
+fn test_map_linear_allows_hpa_above_gpa() {
+    let (mut addr_space, _base, _size) = setup_test_addr_space();
+    let vaddr = GuestPhysAddr::from_usize(0x18000);
+    let paddr = PhysAddr::from_usize(0x1c000);
+    let map_linear_size = 0x4000;
+    let flags = MappingFlags::READ | MappingFlags::WRITE;
+
+    addr_space
+        .map_linear(vaddr, paddr, map_linear_size, flags)
+        .unwrap();
+
+    assert_eq!(addr_space.translate(vaddr).unwrap(), paddr);
+    assert_eq!(
+        addr_space.translate(vaddr + 0x3000).unwrap(),
+        paddr + 0x3000
+    );
+}
+
+#[test]
+#[axin(decorator(mock_hal_test))]
+fn test_map_linear_rejects_physical_range_overflow() {
+    let (mut addr_space, _base, _size) = setup_test_addr_space();
+    let vaddr = GuestPhysAddr::from_usize(0x18000);
+    let paddr = PhysAddr::from_usize(usize::MAX - 0xfff);
+    let flags = MappingFlags::READ | MappingFlags::WRITE;
+
+    assert!(addr_space.map_linear(vaddr, paddr, 0x2000, flags).is_err());
+}
+
+#[test]
+#[axin(decorator(mock_hal_test))]
 fn test_map_alloc_populate() {
     let (mut addr_space, _base, _size) = setup_test_addr_space();
     let vaddr = GuestPhysAddr::from_usize(0x10000);

--- a/virtualization/axvm-types/src/lib.rs
+++ b/virtualization/axvm-types/src/lib.rs
@@ -118,6 +118,20 @@ impl From<VMType> for usize {
     }
 }
 
+/// Guest physical address space population policy.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum AddressSpacePolicy {
+    /// Start from an empty guest physical address space and map only explicit
+    /// guest memory, boot-description regions, and explicitly configured
+    /// passthrough resources.
+    #[default]
+    Virtualized,
+    /// Start from a host-physical identity passthrough address space, then
+    /// punch holes for guest memory, boot-description regions, emulated
+    /// devices, and reserved ranges.
+    Passthrough,
+}
+
 /// The type of memory mapping used for VM memory regions.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[repr(u8)]
@@ -179,6 +193,15 @@ pub struct PassThroughDeviceConfig {
 /// A part of `AxVMConfig`, which represents the configuration of a pass-through address for a virtual machine.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct PassThroughAddressConfig {
+    /// The base GPA (Guest Physical Address).
+    pub base_gpa: usize,
+    /// The address length.
+    pub length: usize,
+}
+
+/// A guest physical address range reserved from default passthrough mapping.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ReservedAddressConfig {
     /// The base GPA (Guest Physical Address).
     pub base_gpa: usize,
     /// The address length.

--- a/virtualization/axvm/src/boot.rs
+++ b/virtualization/axvm/src/boot.rs
@@ -1,0 +1,142 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Guest boot-description ownership for AxVM.
+
+use alloc::vec::Vec;
+
+use axvm_types::GuestPhysAddr;
+
+/// Device-tree boot description owned by the VM lifecycle.
+#[derive(Debug, Clone)]
+pub struct GuestDeviceTree {
+    load_gpa: GuestPhysAddr,
+    bytes: Vec<u8>,
+}
+
+impl GuestDeviceTree {
+    /// Creates a DTB descriptor with owned bytes.
+    pub fn generated(load_gpa: GuestPhysAddr, bytes: Vec<u8>) -> Self {
+        Self { load_gpa, bytes }
+    }
+
+    /// Returns the guest physical load address of the DTB.
+    pub const fn load_gpa(&self) -> GuestPhysAddr {
+        self.load_gpa
+    }
+
+    /// Returns the owned DTB bytes.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub(crate) fn range(&self) -> (usize, usize) {
+        (self.load_gpa.as_usize(), self.bytes.len())
+    }
+}
+
+/// ACPI boot-description tables owned by the VM lifecycle.
+#[derive(Debug, Clone)]
+pub struct GuestAcpiTables {
+    rsdp_gpa: GuestPhysAddr,
+    bytes: Vec<u8>,
+}
+
+impl GuestAcpiTables {
+    /// Creates an ACPI table descriptor.
+    pub fn generated(rsdp_gpa: GuestPhysAddr, bytes: Vec<u8>) -> Self {
+        Self { rsdp_gpa, bytes }
+    }
+
+    /// Returns the guest physical address of the RSDP.
+    pub const fn rsdp_gpa(&self) -> GuestPhysAddr {
+        self.rsdp_gpa
+    }
+
+    /// Returns the owned ACPI table bytes.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub(crate) fn range(&self) -> (usize, usize) {
+        (self.rsdp_gpa.as_usize(), self.bytes.len())
+    }
+}
+
+/// Guest boot-description payload selected for this VM.
+#[derive(Debug, Default, Clone)]
+pub struct GuestBootDescription {
+    device_tree: Option<GuestDeviceTree>,
+    acpi_tables: Option<GuestAcpiTables>,
+}
+
+impl GuestBootDescription {
+    /// Creates an empty boot-description object.
+    pub const fn none() -> Self {
+        Self {
+            device_tree: None,
+            acpi_tables: None,
+        }
+    }
+
+    /// Replaces the device-tree description.
+    pub fn set_device_tree(&mut self, device_tree: GuestDeviceTree) {
+        self.device_tree = Some(device_tree);
+        self.acpi_tables = None;
+    }
+
+    /// Replaces the ACPI table description.
+    pub fn set_acpi_tables(&mut self, acpi_tables: GuestAcpiTables) {
+        self.acpi_tables = Some(acpi_tables);
+        self.device_tree = None;
+    }
+
+    /// Returns the device-tree descriptor, if this VM boots with DTB.
+    pub const fn device_tree(&self) -> Option<&GuestDeviceTree> {
+        self.device_tree.as_ref()
+    }
+
+    /// Returns the ACPI descriptor, if this VM boots with ACPI.
+    pub const fn acpi_tables(&self) -> Option<&GuestAcpiTables> {
+        self.acpi_tables.as_ref()
+    }
+
+    pub(crate) fn occupied_ranges(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+        self.device_tree
+            .iter()
+            .map(GuestDeviceTree::range)
+            .chain(self.acpi_tables.iter().map(GuestAcpiTables::range))
+    }
+}
+
+/// Device-tree builder abstraction owned by AxVM.
+///
+/// Platform-specific host FDT parsing still lives in the monitor today; this
+/// type establishes the AxVM-side lifecycle boundary for generated DTBs.
+#[derive(Debug, Default)]
+pub struct GuestFdtBuilder {
+    bytes: Vec<u8>,
+}
+
+impl GuestFdtBuilder {
+    /// Creates a builder from already generated DTB bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    /// Finishes the builder and returns a VM-owned DTB descriptor.
+    pub fn build(self, load_gpa: GuestPhysAddr) -> GuestDeviceTree {
+        GuestDeviceTree::generated(load_gpa, self.bytes)
+    }
+}

--- a/virtualization/axvm/src/config.rs
+++ b/virtualization/axvm/src/config.rs
@@ -17,8 +17,9 @@
 use alloc::{string::String, vec::Vec};
 
 pub use axvm_types::{
-    EmulatedDeviceConfig, GuestPhysAddr, PassThroughAddressConfig, PassThroughDeviceConfig,
-    PassThroughPortConfig, VMBootProtocol, VMInterruptMode, VMType, VmMemConfig, VmMemMappingType,
+    AddressSpacePolicy, EmulatedDeviceConfig, GuestPhysAddr, PassThroughAddressConfig,
+    PassThroughDeviceConfig, PassThroughPortConfig, ReservedAddressConfig, VMBootProtocol,
+    VMInterruptMode, VMType, VmMemConfig, VmMemMappingType,
 };
 
 use crate::VMMemoryRegion;
@@ -83,7 +84,9 @@ pub struct AxVMConfig {
     pass_through_devices: Vec<PassThroughDeviceConfig>,
     excluded_devices: Vec<Vec<String>>,
     pass_through_addresses: Vec<PassThroughAddressConfig>,
+    reserved_address_ranges: Vec<ReservedAddressConfig>,
     pass_through_ports: Vec<PassThroughPortConfig>,
+    address_space_policy: AddressSpacePolicy,
     // TODO: improve interrupt passthrough
     spi_list: Vec<u32>,
     interrupt_mode: VMInterruptMode,
@@ -102,7 +105,9 @@ pub struct AxVMConfigParams {
     pub pass_through_devices: Vec<PassThroughDeviceConfig>,
     pub excluded_devices: Vec<Vec<String>>,
     pub pass_through_addresses: Vec<PassThroughAddressConfig>,
+    pub reserved_address_ranges: Vec<ReservedAddressConfig>,
     pub pass_through_ports: Vec<PassThroughPortConfig>,
+    pub address_space_policy: AddressSpacePolicy,
     pub interrupt_mode: VMInterruptMode,
 }
 
@@ -139,7 +144,9 @@ impl AxVMConfig {
             pass_through_devices: params.pass_through_devices,
             excluded_devices: params.excluded_devices,
             pass_through_addresses: params.pass_through_addresses,
+            reserved_address_ranges: params.reserved_address_ranges,
             pass_through_ports: params.pass_through_ports,
+            address_space_policy: params.address_space_policy,
             spi_list: Vec::new(),
             interrupt_mode: params.interrupt_mode,
         }
@@ -212,9 +219,24 @@ impl AxVMConfig {
         &self.pass_through_addresses
     }
 
+    /// Returns guest address ranges reserved from default passthrough mapping.
+    pub fn reserved_address_ranges(&self) -> &Vec<ReservedAddressConfig> {
+        &self.reserved_address_ranges
+    }
+
+    /// Adds a guest address range reserved from default passthrough mapping.
+    pub fn add_reserved_address_range(&mut self, range: ReservedAddressConfig) {
+        self.reserved_address_ranges.push(range);
+    }
+
     /// Returns the list of passthrough host I/O port configurations.
     pub fn pass_through_ports(&self) -> &Vec<PassThroughPortConfig> {
         &self.pass_through_ports
+    }
+
+    /// Returns the guest physical address space population policy.
+    pub fn address_space_policy(&self) -> AddressSpacePolicy {
+        self.address_space_policy
     }
     // /// Returns configurations related to VM memory regions.
     // pub fn memory_regions(&self) -> Vec<VmMemConfig> {

--- a/virtualization/axvm/src/layout.rs
+++ b/virtualization/axvm/src/layout.rs
@@ -1,0 +1,907 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Guest physical address layout planning.
+
+use alloc::{format, vec::Vec};
+use core::cmp::{max, min};
+
+use ax_errno::{AxResult, ax_err_type};
+use ax_memory_addr::{PAGE_SIZE_4K, align_down_4k};
+use axaddrspace::MappingFlags;
+use axdevice_base::Resource;
+use axvm_types::{
+    AddressSpacePolicy, GuestPhysAddr, HostPhysAddr, PassThroughAddressConfig,
+    PassThroughDeviceConfig,
+};
+
+/// The ownership class of a guest physical range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmRegionKind {
+    /// The range is identity-passthrough to host physical memory.
+    Passthrough,
+    /// The range is backed by VM-owned guest memory.
+    Memory,
+    /// The range is occupied by the guest boot description.
+    BootDescription,
+    /// The range is owned by an emulated device and must fault into device
+    /// emulation instead of being stage-2 mapped as passthrough.
+    EmulatedDevice,
+    /// The range is reserved from passthrough mapping.
+    Reserved,
+}
+
+/// A final stage-2 linear mapping planned for the VM.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VmStage2Mapping {
+    /// Guest physical base address.
+    pub gpa: GuestPhysAddr,
+    /// Host physical base address.
+    pub hpa: HostPhysAddr,
+    /// Mapping length in bytes.
+    pub size: usize,
+    /// Stage-2 mapping flags.
+    pub flags: MappingFlags,
+    /// Ownership class of this mapping.
+    pub kind: VmRegionKind,
+}
+
+/// A VM-owned address range that reserves guest physical space.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VmAddressRegion {
+    /// Guest physical base address.
+    pub gpa: GuestPhysAddr,
+    /// Range length in bytes.
+    pub size: usize,
+    /// Ownership class of this range.
+    pub kind: VmRegionKind,
+}
+
+impl VmAddressRegion {
+    fn new(base: usize, size: usize, kind: VmRegionKind) -> Self {
+        Self {
+            gpa: GuestPhysAddr::from(base),
+            size,
+            kind,
+        }
+    }
+}
+
+impl VmStage2Mapping {
+    fn new(
+        base_gpa: usize,
+        base_hpa: usize,
+        size: usize,
+        flags: MappingFlags,
+        kind: VmRegionKind,
+    ) -> Self {
+        Self {
+            gpa: GuestPhysAddr::from(base_gpa),
+            hpa: HostPhysAddr::from(base_hpa),
+            size,
+            flags,
+            kind,
+        }
+    }
+
+    fn gpa_end(&self) -> usize {
+        self.gpa.as_usize() + self.size
+    }
+
+    fn hpa_end(&self) -> usize {
+        self.hpa.as_usize() + self.size
+    }
+
+    fn overlaps_gpa(&self, base: usize, size: usize) -> bool {
+        ranges_overlap(self.gpa.as_usize(), self.size, base, size)
+    }
+
+    fn can_merge(&self, next: &Self) -> bool {
+        self.kind == next.kind
+            && self.flags == next.flags
+            && self.gpa_end() == next.gpa.as_usize()
+            && self.hpa_end() == next.hpa.as_usize()
+    }
+}
+
+/// A VM-owned range that should reserve guest physical address space from
+/// passthrough mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GuestOwnedRegion {
+    pub(crate) base: usize,
+    pub(crate) length: usize,
+    pub(crate) kind: VmRegionKind,
+}
+
+impl GuestOwnedRegion {
+    pub(crate) const fn new(base: usize, length: usize, kind: VmRegionKind) -> Self {
+        Self { base, length, kind }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PlannedRegion {
+    base: usize,
+    size: usize,
+    kind: VmRegionKind,
+}
+
+impl PlannedRegion {
+    fn end(&self) -> usize {
+        self.base + self.size
+    }
+
+    fn contains(&self, other: &Self) -> bool {
+        self.base <= other.base && other.end() <= self.end()
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        ranges_overlap(self.base, self.size, other.base, other.size)
+    }
+
+    fn to_address_region(self) -> VmAddressRegion {
+        VmAddressRegion::new(self.base, self.size, self.kind)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PassthroughWindow {
+    base: usize,
+    size: usize,
+}
+
+impl PassthroughWindow {
+    fn end(&self) -> usize {
+        self.base + self.size
+    }
+
+    fn to_mapping(self) -> VmStage2Mapping {
+        VmStage2Mapping::new(
+            self.base,
+            self.base,
+            self.size,
+            device_mapping_flags(),
+            VmRegionKind::Passthrough,
+        )
+    }
+}
+
+/// Final guest physical address layout owned by [`crate::AxVMResources`].
+#[derive(Debug, Default, Clone)]
+pub struct VmAddressLayout {
+    mappings: Vec<VmStage2Mapping>,
+    owned_regions: Vec<PlannedRegion>,
+}
+
+impl VmAddressLayout {
+    fn new(mappings: Vec<VmStage2Mapping>, owned_regions: Vec<PlannedRegion>) -> Self {
+        Self {
+            mappings,
+            owned_regions,
+        }
+    }
+
+    /// Returns all final stage-2 passthrough mappings.
+    pub fn mappings(&self) -> &[VmStage2Mapping] {
+        &self.mappings
+    }
+
+    /// Returns all VM-owned regions that punched holes in passthrough space.
+    pub fn owned_regions(&self) -> impl Iterator<Item = VmAddressRegion> + '_ {
+        self.owned_regions
+            .iter()
+            .copied()
+            .map(PlannedRegion::to_address_region)
+    }
+}
+
+/// Planner for guest physical address mappings.
+pub struct GuestRegionPlanner {
+    policy: AddressSpacePolicy,
+    guest_base: usize,
+    guest_end: usize,
+    windows: Vec<PassthroughWindow>,
+    explicit_mappings: Vec<VmStage2Mapping>,
+    owned_regions: Vec<PlannedRegion>,
+}
+
+impl GuestRegionPlanner {
+    /// Creates a planner for a guest physical address space.
+    pub fn new(policy: AddressSpacePolicy, guest_base: usize, guest_size: usize) -> AxResult<Self> {
+        let guest_end = checked_end("guest address space", guest_base, guest_size)?;
+        let windows = match policy {
+            AddressSpacePolicy::Virtualized => Vec::new(),
+            AddressSpacePolicy::Passthrough => alloc::vec![PassthroughWindow {
+                base: guest_base,
+                size: guest_size,
+            }],
+        };
+        Ok(Self {
+            policy,
+            guest_base,
+            guest_end,
+            windows,
+            explicit_mappings: Vec::new(),
+            owned_regions: Vec::new(),
+        })
+    }
+
+    /// Reserves a VM-owned range and punches it out of passthrough windows.
+    pub fn reserve(&mut self, base: usize, length: usize, kind: VmRegionKind) -> AxResult {
+        let (base, size) = normalize_guest_range(kind.name(), base, length)?;
+        self.ensure_guest_range(kind.name(), base, size)?;
+        let region = PlannedRegion { base, size, kind };
+
+        for mapping in &self.explicit_mappings {
+            if mapping.overlaps_gpa(base, size) {
+                return Err(ax_err_type!(
+                    InvalidInput,
+                    format!(
+                        "{} range [{:#x}, {:#x}) conflicts with passthrough mapping [{:#x}, {:#x})",
+                        kind.name(),
+                        base,
+                        base + size,
+                        mapping.gpa.as_usize(),
+                        mapping.gpa_end()
+                    )
+                ));
+            }
+        }
+
+        for existing in &self.owned_regions {
+            if existing.overlaps(&region) && !owned_overlap_allowed(existing, &region) {
+                return Err(ax_err_type!(
+                    InvalidInput,
+                    format!(
+                        "{} range [{:#x}, {:#x}) conflicts with {} range [{:#x}, {:#x})",
+                        kind.name(),
+                        base,
+                        base + size,
+                        existing.kind.name(),
+                        existing.base,
+                        existing.end()
+                    )
+                ));
+            }
+        }
+
+        self.punch_hole(base, size);
+        self.owned_regions.push(region);
+        Ok(())
+    }
+
+    /// Adds an explicit passthrough mapping.
+    pub fn add_passthrough_mapping(
+        &mut self,
+        base_gpa: usize,
+        base_hpa: usize,
+        length: usize,
+    ) -> AxResult {
+        let (base_gpa, base_hpa, size) =
+            normalize_linear_range("passthrough", base_gpa, base_hpa, length)?;
+        self.ensure_guest_range("passthrough", base_gpa, size)?;
+
+        for region in &self.owned_regions {
+            if ranges_overlap(base_gpa, size, region.base, region.size) {
+                return Err(ax_err_type!(
+                    InvalidInput,
+                    format!(
+                        "passthrough range [{:#x}, {:#x}) conflicts with {} range [{:#x}, {:#x})",
+                        base_gpa,
+                        base_gpa + size,
+                        region.kind.name(),
+                        region.base,
+                        region.end()
+                    )
+                ));
+            }
+        }
+
+        let mut mapping = VmStage2Mapping::new(
+            base_gpa,
+            base_hpa,
+            size,
+            device_mapping_flags(),
+            VmRegionKind::Passthrough,
+        );
+        let mut index = 0;
+        while index < self.explicit_mappings.len() {
+            let existing = self.explicit_mappings[index];
+            if !existing.overlaps_gpa(mapping.gpa.as_usize(), mapping.size) {
+                index += 1;
+                continue;
+            }
+
+            if same_linear_mapping(&existing, &mapping) {
+                mapping = merge_linear_mappings(existing, mapping)?;
+                self.explicit_mappings.remove(index);
+            } else {
+                return Err(ax_err_type!(
+                    InvalidInput,
+                    format!(
+                        "passthrough range [{:#x}, {:#x}) conflicts with passthrough mapping \
+                         [{:#x}, {:#x})",
+                        mapping.gpa.as_usize(),
+                        mapping.gpa_end(),
+                        existing.gpa.as_usize(),
+                        existing.gpa_end()
+                    )
+                ));
+            }
+        }
+
+        if self.policy == AddressSpacePolicy::Passthrough {
+            self.punch_hole(base_gpa, size);
+        }
+        self.explicit_mappings.push(mapping);
+        Ok(())
+    }
+
+    /// Adds an explicit identity passthrough mapping.
+    pub fn add_identity_passthrough(&mut self, base_gpa: usize, length: usize) -> AxResult {
+        self.add_passthrough_mapping(base_gpa, base_gpa, length)
+    }
+
+    /// Finishes the layout and returns final stage-2 mappings.
+    pub fn finish(mut self) -> AxResult<VmAddressLayout> {
+        let mut mappings: Vec<_> = self
+            .windows
+            .drain(..)
+            .map(PassthroughWindow::to_mapping)
+            .chain(self.explicit_mappings)
+            .collect();
+        mappings.sort_by_key(|mapping| mapping.gpa.as_usize());
+
+        let mut merged = Vec::<VmStage2Mapping>::new();
+        for mapping in mappings {
+            if mapping.size == 0 {
+                continue;
+            }
+            if let Some(last) = merged.last_mut() {
+                if last.overlaps_gpa(mapping.gpa.as_usize(), mapping.size) {
+                    return Err(ax_err_type!(
+                        InvalidInput,
+                        format!(
+                            "stage-2 mapping [{:#x}, {:#x}) conflicts with [{:#x}, {:#x})",
+                            mapping.gpa.as_usize(),
+                            mapping.gpa_end(),
+                            last.gpa.as_usize(),
+                            last.gpa_end()
+                        )
+                    ));
+                }
+                if last.can_merge(&mapping) {
+                    last.size += mapping.size;
+                    continue;
+                }
+            }
+            merged.push(mapping);
+        }
+
+        Ok(VmAddressLayout::new(merged, self.owned_regions))
+    }
+
+    fn punch_hole(&mut self, base: usize, size: usize) {
+        if self.policy == AddressSpacePolicy::Virtualized {
+            return;
+        }
+
+        let end = base + size;
+        let mut next_windows = Vec::with_capacity(self.windows.len() + 1);
+        for window in self.windows.drain(..) {
+            if !ranges_overlap(window.base, window.size, base, size) {
+                next_windows.push(window);
+                continue;
+            }
+
+            if window.base < base {
+                next_windows.push(PassthroughWindow {
+                    base: window.base,
+                    size: base - window.base,
+                });
+            }
+            if end < window.end() {
+                next_windows.push(PassthroughWindow {
+                    base: end,
+                    size: window.end() - end,
+                });
+            }
+        }
+        self.windows = next_windows;
+    }
+
+    fn ensure_guest_range(&self, name: &str, base: usize, size: usize) -> AxResult {
+        let end = checked_end(name, base, size)?;
+        if base < self.guest_base || end > self.guest_end {
+            return Err(ax_err_type!(
+                InvalidInput,
+                format!(
+                    "{} range [{:#x}, {:#x}) is outside guest address space [{:#x}, {:#x})",
+                    name, base, end, self.guest_base, self.guest_end
+                )
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Plans all non-memory stage-2 mappings for a VM.
+pub(crate) fn build_address_layout(
+    policy: AddressSpacePolicy,
+    guest_base: usize,
+    guest_size: usize,
+    passthrough_devices: &[PassThroughDeviceConfig],
+    passthrough_addresses: &[PassThroughAddressConfig],
+    owned_regions: &[GuestOwnedRegion],
+    emulated_resources: &[Resource],
+) -> AxResult<VmAddressLayout> {
+    let mut planner = GuestRegionPlanner::new(policy, guest_base, guest_size)?;
+
+    for region in owned_regions {
+        planner.reserve(region.base, region.length, region.kind)?;
+    }
+
+    for resource in emulated_resources {
+        if let Resource::MmioRange { base, size } = *resource {
+            let base = usize::try_from(base).map_err(|_| {
+                ax_err_type!(
+                    InvalidInput,
+                    format!("emulated MMIO base exceeds usize: {base:#x}")
+                )
+            })?;
+            let size = usize::try_from(size).map_err(|_| {
+                ax_err_type!(
+                    InvalidInput,
+                    format!("emulated MMIO size exceeds usize: {size:#x}")
+                )
+            })?;
+            planner.reserve(base, size, VmRegionKind::EmulatedDevice)?;
+        }
+    }
+
+    for device in passthrough_devices {
+        planner.add_passthrough_mapping(device.base_gpa, device.base_hpa, device.length)?;
+    }
+
+    for address in passthrough_addresses {
+        planner.add_identity_passthrough(address.base_gpa, address.length)?;
+    }
+
+    planner.finish()
+}
+
+fn device_mapping_flags() -> MappingFlags {
+    MappingFlags::DEVICE | MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER
+}
+
+fn normalize_guest_range(name: &str, base: usize, length: usize) -> AxResult<(usize, usize)> {
+    let end = checked_end(name, base, length)?;
+    let aligned_base = align_down_4k(base);
+    let aligned_end = align_up_checked(end).ok_or_else(|| {
+        ax_err_type!(
+            InvalidInput,
+            format!("{name} range [{base:#x}, {end:#x}) overflows when aligned")
+        )
+    })?;
+    Ok((aligned_base, aligned_end - aligned_base))
+}
+
+fn normalize_linear_range(
+    name: &str,
+    base_gpa: usize,
+    base_hpa: usize,
+    length: usize,
+) -> AxResult<(usize, usize, usize)> {
+    let end_gpa = checked_end(name, base_gpa, length)?;
+    checked_end(name, base_hpa, length)?;
+
+    let gpa_offset = base_gpa - align_down_4k(base_gpa);
+    let hpa_offset = base_hpa - align_down_4k(base_hpa);
+    if gpa_offset != hpa_offset {
+        return Err(ax_err_type!(
+            InvalidInput,
+            format!(
+                "{name} range has different GPA/HPA page offsets: gpa={base_gpa:#x}, \
+                 hpa={base_hpa:#x}"
+            )
+        ));
+    }
+
+    let aligned_gpa = align_down_4k(base_gpa);
+    let aligned_hpa = align_down_4k(base_hpa);
+    let aligned_end = align_up_checked(end_gpa).ok_or_else(|| {
+        ax_err_type!(
+            InvalidInput,
+            format!("{name} range [{base_gpa:#x}, {end_gpa:#x}) overflows when aligned")
+        )
+    })?;
+    let aligned_size = aligned_end - aligned_gpa;
+    aligned_hpa.checked_add(aligned_size).ok_or_else(|| {
+        ax_err_type!(
+            InvalidInput,
+            format!(
+                "{name} host range overflows when aligned: hpa={base_hpa:#x}, length={length:#x}"
+            )
+        )
+    })?;
+    Ok((aligned_gpa, aligned_hpa, aligned_size))
+}
+
+fn checked_end(name: &str, base: usize, length: usize) -> AxResult<usize> {
+    if length == 0 {
+        return Err(ax_err_type!(
+            InvalidInput,
+            format!("{name} range has zero length")
+        ));
+    }
+    base.checked_add(length).ok_or_else(|| {
+        ax_err_type!(
+            InvalidInput,
+            format!("{name} range overflows: base={base:#x}, length={length:#x}")
+        )
+    })
+}
+
+fn align_up_checked(value: usize) -> Option<usize> {
+    value.checked_add(PAGE_SIZE_4K - 1).map(align_down_4k)
+}
+
+fn ranges_overlap(base_a: usize, size_a: usize, base_b: usize, size_b: usize) -> bool {
+    let end_a = base_a + size_a;
+    let end_b = base_b + size_b;
+    base_a < end_b && base_b < end_a
+}
+
+fn linear_delta(mapping: &VmStage2Mapping) -> i128 {
+    mapping.gpa.as_usize() as i128 - mapping.hpa.as_usize() as i128
+}
+
+fn same_linear_mapping(left: &VmStage2Mapping, right: &VmStage2Mapping) -> bool {
+    left.kind == right.kind
+        && left.flags == right.flags
+        && linear_delta(left) == linear_delta(right)
+}
+
+fn merge_linear_mappings(
+    left: VmStage2Mapping,
+    right: VmStage2Mapping,
+) -> AxResult<VmStage2Mapping> {
+    debug_assert!(same_linear_mapping(&left, &right));
+    let base_gpa = min(left.gpa.as_usize(), right.gpa.as_usize());
+    let end_gpa = max(left.gpa_end(), right.gpa_end());
+    let delta = linear_delta(&left);
+    let base_hpa = usize::try_from(base_gpa as i128 - delta).map_err(|_| {
+        ax_err_type!(
+            InvalidInput,
+            format!(
+                "merged passthrough mapping underflows host address: gpa={base_gpa:#x}, \
+                 delta={delta:#x}"
+            )
+        )
+    })?;
+    Ok(VmStage2Mapping::new(
+        base_gpa,
+        base_hpa,
+        end_gpa - base_gpa,
+        left.flags,
+        left.kind,
+    ))
+}
+
+fn owned_overlap_allowed(existing: &PlannedRegion, new: &PlannedRegion) -> bool {
+    matches!(
+        (existing.kind, new.kind),
+        (VmRegionKind::Memory, VmRegionKind::BootDescription)
+            | (VmRegionKind::BootDescription, VmRegionKind::Memory)
+    ) && (existing.contains(new) || new.contains(existing))
+}
+
+impl VmRegionKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Passthrough => "passthrough",
+            Self::Memory => "memory",
+            Self::BootDescription => "boot description",
+            Self::EmulatedDevice => "emulated device",
+            Self::Reserved => "reserved",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axvm_types::{PassThroughAddressConfig, PassThroughDeviceConfig};
+
+    use super::*;
+
+    const GUEST_BASE: usize = 0;
+    const GUEST_SIZE: usize = 0x1_0000;
+
+    #[test]
+    fn virtualized_policy_only_maps_explicit_passthrough() {
+        let layout = build_address_layout(
+            AddressSpacePolicy::Virtualized,
+            GUEST_BASE,
+            GUEST_SIZE,
+            &[],
+            &[],
+            &[],
+            &[],
+        )
+        .unwrap();
+        assert!(layout.mappings().is_empty());
+
+        let device = PassThroughDeviceConfig {
+            name: alloc::string::String::from("uart"),
+            base_gpa: 0x2000,
+            base_hpa: 0x9000,
+            length: 0x1000,
+            irq_id: 0,
+        };
+        let layout = build_address_layout(
+            AddressSpacePolicy::Virtualized,
+            GUEST_BASE,
+            GUEST_SIZE,
+            &[device],
+            &[],
+            &[],
+            &[],
+        )
+        .unwrap();
+        assert_eq!(layout.mappings().len(), 1);
+        assert_eq!(layout.mappings()[0].gpa.as_usize(), 0x2000);
+        assert_eq!(layout.mappings()[0].hpa.as_usize(), 0x9000);
+        assert_eq!(layout.mappings()[0].size, 0x1000);
+    }
+
+    #[test]
+    fn passthrough_policy_punches_memory_and_emulated_mmio_holes() {
+        let owned = [GuestOwnedRegion::new(0x2000, 0x2000, VmRegionKind::Memory)];
+        let emu = [Resource::MmioRange {
+            base: 0x8000,
+            size: 0x1000,
+        }];
+
+        let layout = build_address_layout(
+            AddressSpacePolicy::Passthrough,
+            GUEST_BASE,
+            GUEST_SIZE,
+            &[],
+            &[],
+            &owned,
+            &emu,
+        )
+        .unwrap();
+
+        let mappings = layout.mappings();
+        assert_eq!(mappings.len(), 3);
+        assert_eq!((mappings[0].gpa.as_usize(), mappings[0].size), (0, 0x2000));
+        assert_eq!(
+            (mappings[1].gpa.as_usize(), mappings[1].size),
+            (0x4000, 0x4000)
+        );
+        assert_eq!(
+            (mappings[2].gpa.as_usize(), mappings[2].size),
+            (0x9000, 0x7000)
+        );
+        let owned_regions = layout.owned_regions().collect::<Vec<_>>();
+        assert_eq!(owned_regions.len(), 2);
+        assert_eq!(
+            (owned_regions[0].gpa.as_usize(), owned_regions[0].size),
+            (0x2000, 0x2000)
+        );
+        assert_eq!(owned_regions[0].kind, VmRegionKind::Memory);
+        assert_eq!(
+            (owned_regions[1].gpa.as_usize(), owned_regions[1].size),
+            (0x8000, 0x1000)
+        );
+        assert_eq!(owned_regions[1].kind, VmRegionKind::EmulatedDevice);
+    }
+
+    #[test]
+    fn passthrough_policy_punches_reserved_regions() {
+        let owned = [GuestOwnedRegion::new(
+            0x3000,
+            0x2000,
+            VmRegionKind::Reserved,
+        )];
+
+        let layout = build_address_layout(
+            AddressSpacePolicy::Passthrough,
+            GUEST_BASE,
+            GUEST_SIZE,
+            &[],
+            &[],
+            &owned,
+            &[],
+        )
+        .unwrap();
+
+        let mappings = layout.mappings();
+        assert_eq!(mappings.len(), 2);
+        assert_eq!((mappings[0].gpa.as_usize(), mappings[0].size), (0, 0x3000));
+        assert_eq!(
+            (mappings[1].gpa.as_usize(), mappings[1].size),
+            (0x5000, 0xb000)
+        );
+        assert!(mappings.iter().all(|mapping| {
+            !ranges_overlap(mapping.gpa.as_usize(), mapping.size, 0x3000, 0x2000)
+        }));
+        let owned_regions = layout.owned_regions().collect::<Vec<_>>();
+        assert_eq!(owned_regions.len(), 1);
+        assert_eq!(owned_regions[0].kind, VmRegionKind::Reserved);
+    }
+
+    #[test]
+    fn passthrough_device_uses_base_hpa_and_keeps_non_contiguous_mappings_split() {
+        let devices = [
+            PassThroughDeviceConfig {
+                name: alloc::string::String::from("dev0"),
+                base_gpa: 0x1000,
+                base_hpa: 0x9000,
+                length: 0x1000,
+                irq_id: 0,
+            },
+            PassThroughDeviceConfig {
+                name: alloc::string::String::from("dev1"),
+                base_gpa: 0x2000,
+                base_hpa: 0xb000,
+                length: 0x1000,
+                irq_id: 0,
+            },
+        ];
+
+        let layout = build_address_layout(
+            AddressSpacePolicy::Virtualized,
+            GUEST_BASE,
+            GUEST_SIZE,
+            &devices,
+            &[],
+            &[],
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(layout.mappings().len(), 2);
+        assert_eq!(layout.mappings()[0].hpa.as_usize(), 0x9000);
+        assert_eq!(layout.mappings()[1].hpa.as_usize(), 0xb000);
+    }
+
+    #[test]
+    fn duplicate_explicit_passthrough_ranges_are_merged_when_linear_mapping_matches() {
+        let devices = [
+            PassThroughDeviceConfig {
+                name: alloc::string::String::from("dev0"),
+                base_gpa: 0x1000,
+                base_hpa: 0x9000,
+                length: 0x2000,
+                irq_id: 0,
+            },
+            PassThroughDeviceConfig {
+                name: alloc::string::String::from("dev1"),
+                base_gpa: 0x2000,
+                base_hpa: 0xa000,
+                length: 0x2000,
+                irq_id: 0,
+            },
+        ];
+
+        let layout = build_address_layout(
+            AddressSpacePolicy::Virtualized,
+            GUEST_BASE,
+            GUEST_SIZE,
+            &devices,
+            &[],
+            &[],
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(layout.mappings().len(), 1);
+        assert_eq!(layout.mappings()[0].gpa.as_usize(), 0x1000);
+        assert_eq!(layout.mappings()[0].hpa.as_usize(), 0x9000);
+        assert_eq!(layout.mappings()[0].size, 0x3000);
+    }
+
+    #[test]
+    fn passthrough_address_is_identity_and_unaligned_ranges_are_expanded() {
+        let addresses = [PassThroughAddressConfig {
+            base_gpa: 0x1803,
+            length: 0x20,
+        }];
+
+        let layout = build_address_layout(
+            AddressSpacePolicy::Virtualized,
+            GUEST_BASE,
+            GUEST_SIZE,
+            &[],
+            &addresses,
+            &[],
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(layout.mappings().len(), 1);
+        assert_eq!(layout.mappings()[0].gpa.as_usize(), 0x1000);
+        assert_eq!(layout.mappings()[0].hpa.as_usize(), 0x1000);
+        assert_eq!(layout.mappings()[0].size, 0x1000);
+    }
+
+    #[test]
+    fn invalid_and_conflicting_ranges_are_rejected() {
+        let zero = [PassThroughAddressConfig {
+            base_gpa: 0x1000,
+            length: 0,
+        }];
+        assert!(
+            build_address_layout(
+                AddressSpacePolicy::Virtualized,
+                GUEST_BASE,
+                GUEST_SIZE,
+                &[],
+                &zero,
+                &[],
+                &[],
+            )
+            .is_err()
+        );
+
+        let owned = [GuestOwnedRegion::new(0x2000, 0x1000, VmRegionKind::Memory)];
+        let conflict = [PassThroughAddressConfig {
+            base_gpa: 0x2000,
+            length: 0x1000,
+        }];
+        assert!(
+            build_address_layout(
+                AddressSpacePolicy::Virtualized,
+                GUEST_BASE,
+                GUEST_SIZE,
+                &[],
+                &conflict,
+                &owned,
+                &[],
+            )
+            .is_err()
+        );
+
+        let conflicting_hpa = [
+            PassThroughDeviceConfig {
+                name: alloc::string::String::from("dev0"),
+                base_gpa: 0x3000,
+                base_hpa: 0x9000,
+                length: 0x1000,
+                irq_id: 0,
+            },
+            PassThroughDeviceConfig {
+                name: alloc::string::String::from("dev1"),
+                base_gpa: 0x3000,
+                base_hpa: 0xa000,
+                length: 0x1000,
+                irq_id: 0,
+            },
+        ];
+        assert!(
+            build_address_layout(
+                AddressSpacePolicy::Virtualized,
+                GUEST_BASE,
+                GUEST_SIZE,
+                &conflicting_hpa,
+                &[],
+                &[],
+                &[],
+            )
+            .is_err()
+        );
+    }
+}

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -24,9 +24,11 @@ extern crate alloc;
 extern crate log;
 
 mod arch;
+pub mod boot;
 mod cache;
 mod host;
 pub mod irq;
+pub mod layout;
 pub mod lifecycle;
 mod manager;
 mod percpu;

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -21,17 +21,17 @@ use core::{
 use ax_cpumask::CpuMask;
 use ax_errno::{AxError, AxResult, ax_err, ax_err_type};
 use ax_kspin::SpinNoIrq as Mutex;
-use ax_memory_addr::{align_down_4k, align_up_4k};
+use ax_memory_addr::align_up_4k;
 use axaddrspace::{AddrSpace, MappingFlags};
 use axdevice::{
     AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceFactoryRegistry, FwCfg,
     FwCfgPlatformConfig, register_builtin_factories,
 };
-use axdevice_base::AccessWidth;
 #[cfg(target_arch = "aarch64")]
 use axdevice_base::DeviceRegistry as _;
 #[cfg(target_arch = "x86_64")]
 use axdevice_base::DeviceRegistry as _;
+use axdevice_base::{AccessWidth, Resource};
 #[cfg(target_arch = "x86_64")]
 use axdevice_base::{BaseDeviceOps, PortDeviceAdapter};
 use axvcpu::{AxArchVCpu, AxVCpu, AxVCpuExitReason, VCpuState};
@@ -44,9 +44,11 @@ use x86_vcpu::{X86_APIC_ACCESS_GPA, x86_apic_access_page_addr};
 #[cfg(not(target_arch = "x86_64"))]
 use crate::vcpu::AxVCpuCreateConfig;
 use crate::{
+    boot::{GuestBootDescription, GuestFdtBuilder},
     config::{AxVMConfig, PhysCpuList, VMInterruptMode},
     host::paging::{HostPagingHandler, virt_to_phys},
     irq::InterruptFabric,
+    layout::{GuestOwnedRegion, VmAddressLayout, VmRegionKind, build_address_layout},
     lifecycle::{Machine, StopReason, VmLifecycleError, VmStatus},
     vcpu::AxArchVCpuImpl,
 };
@@ -79,6 +81,31 @@ fn sign_extend_value(value: usize, width: AccessWidth) -> usize {
     }
 }
 
+fn write_guest_bytes_to_chunks(chunks: &mut [&mut [u8]], data: &[u8]) -> AxResult {
+    if data.is_empty() {
+        return Ok(());
+    }
+
+    let mut copied = 0;
+    for chunk in chunks {
+        let len = (data.len() - copied).min(chunk.len());
+        if len == 0 {
+            continue;
+        }
+        chunk[..len].copy_from_slice(&data[copied..copied + len]);
+        crate::clean_dcache_range((chunk.as_ptr() as usize).into(), len);
+        copied += len;
+        if copied == data.len() {
+            return Ok(());
+        }
+    }
+
+    ax_err!(
+        InvalidInput,
+        "Insufficient guest memory to write the requested buffer"
+    )
+}
+
 pub(crate) struct AxVMResources {
     // Todo: use more efficient lock.
     address_space: AddrSpace<HostPagingHandler>,
@@ -88,6 +115,8 @@ pub(crate) struct AxVMResources {
     vcpu_list: Option<Box<[AxVCpuRef]>>,
     devices: Option<Arc<AxVmDevices>>,
     interrupt_fabric: Option<InterruptFabric>,
+    address_layout: Option<VmAddressLayout>,
+    boot_description: GuestBootDescription,
 }
 
 unsafe impl Send for AxVMResources {}
@@ -241,6 +270,8 @@ impl AxVMResources {
             vcpu_list: None,
             devices: None,
             interrupt_fabric: None,
+            address_layout: None,
+            boot_description: GuestBootDescription::none(),
         })
     }
 
@@ -279,6 +310,7 @@ impl AxVMResources {
         self.vcpu_list = None;
         self.devices = None;
         self.interrupt_fabric = None;
+        self.address_layout = None;
         Ok(())
     }
 }
@@ -498,73 +530,6 @@ impl AxVM {
             )?));
         }
 
-        let mut pt_dev_region = Vec::new();
-        for pt_device in resources.config.pass_through_devices() {
-            trace!(
-                "PT dev {:?} region: [{:#x}~{:#x}] -> [{:#x}~{:#x}]",
-                pt_device.name,
-                pt_device.base_gpa,
-                pt_device.base_gpa + pt_device.length,
-                pt_device.base_hpa,
-                pt_device.base_hpa + pt_device.length
-            );
-            // Align the base address and length to 4K boundaries.
-            pt_dev_region.push((
-                align_down_4k(pt_device.base_gpa),
-                align_up_4k(pt_device.length),
-            ));
-        }
-
-        for pt_addr in resources.config.pass_through_addresses() {
-            debug!(
-                "PT addr region: [{:#x}~{:#x}]",
-                pt_addr.base_gpa,
-                pt_addr.base_gpa + pt_addr.length,
-            );
-            // Align the base address and length to 4K boundaries.
-            pt_dev_region.push((align_down_4k(pt_addr.base_gpa), align_up_4k(pt_addr.length)));
-        }
-
-        pt_dev_region.sort_by_key(|(gpa, _)| *gpa);
-
-        // Merge overlapping regions.
-        let pt_dev_region =
-            pt_dev_region
-                .into_iter()
-                .fold(Vec::<(usize, usize)>::new(), |mut acc, (gpa, len)| {
-                    if let Some(last) = acc.last_mut() {
-                        if last.0 + last.1 >= gpa {
-                            // Merge with the last region.
-                            last.1 = (last.0 + last.1).max(gpa + len) - last.0;
-                        } else {
-                            acc.push((gpa, len));
-                        }
-                    } else {
-                        acc.push((gpa, len));
-                    }
-                    acc
-                });
-
-        for (gpa, len) in &pt_dev_region {
-            resources.address_space.map_linear(
-                GuestPhysAddr::from(*gpa),
-                HostPhysAddr::from(*gpa),
-                *len,
-                MappingFlags::DEVICE
-                    | MappingFlags::READ
-                    | MappingFlags::WRITE
-                    | MappingFlags::USER,
-            )?;
-        }
-
-        #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
-        resources.address_space.map_linear(
-            GuestPhysAddr::from(X86_APIC_ACCESS_GPA),
-            x86_apic_access_page_addr(),
-            ax_memory_addr::PAGE_SIZE_4K,
-            MappingFlags::DEVICE | MappingFlags::READ | MappingFlags::WRITE,
-        )?;
-
         let mut devices = {
             let build_context = DeviceBuildContext::new(&interrupt_fabric);
             axdevice::AxVmDevices::build_with_factories(
@@ -635,6 +600,56 @@ impl AxVM {
 
         self.add_special_emulated_devices(&mut devices)?;
 
+        if dtb_addr.is_some() && resources.boot_description.device_tree().is_none() {
+            return ax_err!(
+                InvalidInput,
+                "DTB load GPA is configured but no guest device tree bytes are registered"
+            );
+        }
+
+        let owned_regions = Self::guest_owned_regions(resources);
+        let emulated_resources = devices
+            .devices()
+            .flat_map(|device| device.resources().iter().cloned())
+            .collect::<Vec<Resource>>();
+        let address_layout = build_address_layout(
+            resources.config.address_space_policy(),
+            VM_ASPACE_BASE,
+            VM_ASPACE_SIZE,
+            resources.config.pass_through_devices(),
+            resources.config.pass_through_addresses(),
+            &owned_regions,
+            &emulated_resources,
+        )?;
+
+        for mapping in address_layout.mappings() {
+            debug!(
+                "VM[{}] stage2 {:?}: [{:#x}, {:#x}) -> [{:#x}, {:#x}) {:?}",
+                self.id(),
+                mapping.kind,
+                mapping.gpa.as_usize(),
+                mapping.gpa.as_usize() + mapping.size,
+                mapping.hpa.as_usize(),
+                mapping.hpa.as_usize() + mapping.size,
+                mapping.flags
+            );
+            resources.address_space.map_linear(
+                mapping.gpa,
+                mapping.hpa,
+                mapping.size,
+                mapping.flags,
+            )?;
+        }
+        resources.address_layout = Some(address_layout);
+
+        #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
+        resources.address_space.map_linear(
+            GuestPhysAddr::from(X86_APIC_ACCESS_GPA),
+            x86_apic_access_page_addr(),
+            ax_memory_addr::PAGE_SIZE_4K,
+            MappingFlags::DEVICE | MappingFlags::READ | MappingFlags::WRITE,
+        )?;
+
         // Setup VCpus.
         for vcpu in &vcpu_list {
             #[cfg(target_arch = "aarch64")]
@@ -701,6 +716,43 @@ impl AxVM {
 
         info!("VM setup: id={}", self.id());
         Ok(())
+    }
+
+    fn guest_owned_regions(resources: &AxVMResources) -> Vec<GuestOwnedRegion> {
+        let mut regions = resources
+            .memory_regions
+            .iter()
+            .map(|region| {
+                GuestOwnedRegion::new(region.gpa.as_usize(), region.size(), VmRegionKind::Memory)
+            })
+            .collect::<Vec<_>>();
+
+        regions.extend(
+            resources
+                .boot_description
+                .occupied_ranges()
+                .map(|(base, length)| {
+                    GuestOwnedRegion::new(base, length, VmRegionKind::BootDescription)
+                }),
+        );
+        regions.extend(
+            resources
+                .config
+                .reserved_address_ranges()
+                .iter()
+                .map(|range| {
+                    GuestOwnedRegion::new(range.base_gpa, range.length, VmRegionKind::Reserved)
+                }),
+        );
+
+        #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
+        regions.push(GuestOwnedRegion::new(
+            X86_APIC_ACCESS_GPA,
+            ax_memory_addr::PAGE_SIZE_4K,
+            VmRegionKind::Reserved,
+        ));
+
+        regions
     }
 
     fn ensure_resources_ready(&self) -> AxResult {
@@ -809,6 +861,17 @@ impl AxVM {
             .resources_mut()
             .expect("VM resources are not available for config access");
         f(&mut resources.config)
+    }
+
+    /// Stores a guest DTB as VM-owned boot-description state.
+    pub fn set_guest_device_tree(&self, load_gpa: GuestPhysAddr, bytes: Vec<u8>) -> AxResult {
+        self.with_resources_mut(|resources| {
+            resources.config.set_dtb_load_gpa(load_gpa);
+            resources
+                .boot_description
+                .set_device_tree(GuestFdtBuilder::from_bytes(bytes).build(load_gpa));
+            Ok(())
+        })
     }
 
     /// Returns guest VM image load region in `Vec<&'static mut [u8]>`,
@@ -1505,33 +1568,18 @@ impl AxVM {
 
     /// Writes an object of type `T` to the guest physical address.
     pub fn write_to_guest_of<T>(&self, gpa_ptr: GuestPhysAddr, data: &T) -> AxResult {
-        self.with_resources(|resources| {
-            match resources
-                .address_space
-                .translated_byte_buffer(gpa_ptr, core::mem::size_of::<T>())
-            {
-                Some(mut buffer) => {
-                    let bytes = unsafe {
-                        core::slice::from_raw_parts(
-                            data as *const T as *const u8,
-                            core::mem::size_of::<T>(),
-                        )
-                    };
-                    let mut copied_bytes = 0;
-                    for chunk in buffer.iter_mut() {
-                        let end = copied_bytes + chunk.len();
-                        chunk.copy_from_slice(&bytes[copied_bytes..end]);
-                        copied_bytes += chunk.len();
-                    }
-                    Ok(())
-                }
-                None => ax_err!(InvalidInput, "Failed to translate guest physical address"),
-            }
-        })
+        let bytes = unsafe {
+            core::slice::from_raw_parts(data as *const T as *const u8, core::mem::size_of::<T>())
+        };
+        self.write_to_guest(gpa_ptr, bytes)
     }
 
     /// Writes raw bytes into guest physical memory.
     pub fn write_to_guest(&self, gpa_ptr: GuestPhysAddr, data: &[u8]) -> AxResult {
+        if data.is_empty() {
+            return Ok(());
+        }
+
         self.with_resources(|resources| {
             let Some(mut chunks) = resources
                 .address_space
@@ -1540,21 +1588,7 @@ impl AxVM {
                 return ax_err!(InvalidInput, "Failed to translate guest physical address");
             };
 
-            let mut copied = 0;
-            for chunk in chunks.iter_mut() {
-                let len = (data.len() - copied).min(chunk.len());
-                chunk[..len].copy_from_slice(&data[copied..copied + len]);
-                crate::clean_dcache_range((chunk.as_ptr() as usize).into(), len);
-                copied += len;
-                if copied == data.len() {
-                    return Ok(());
-                }
-            }
-
-            ax_err!(
-                InvalidInput,
-                "Insufficient guest memory to write the requested buffer"
-            )
+            write_guest_bytes_to_chunks(chunks.as_mut_slice(), data)
         })
     }
 
@@ -1761,5 +1795,43 @@ impl Drop for AxVM {
         }
 
         info!("VM[{}] dropped", self.id());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_guest_bytes_to_chunks_writes_only_remaining_bytes() {
+        let mut first = [0u8; 2];
+        let mut second = [0u8; 4];
+        let mut chunks: [&mut [u8]; 2] = [&mut first, &mut second];
+
+        write_guest_bytes_to_chunks(&mut chunks, &[1, 2, 3]).unwrap();
+
+        assert_eq!(first, [1, 2]);
+        assert_eq!(second, [3, 0, 0, 0]);
+    }
+
+    #[test]
+    fn write_guest_bytes_to_chunks_rejects_insufficient_capacity() {
+        let mut only = [0u8; 2];
+        let mut chunks: [&mut [u8]; 1] = [&mut only];
+
+        let err = write_guest_bytes_to_chunks(&mut chunks, &[1, 2, 3]).unwrap_err();
+
+        assert_eq!(err, AxError::InvalidInput);
+        assert_eq!(only, [1, 2]);
+    }
+
+    #[test]
+    fn write_guest_bytes_to_chunks_accepts_empty_writes() {
+        let mut chunk = [7u8; 2];
+        let mut chunks: [&mut [u8]; 1] = [&mut chunk];
+
+        write_guest_bytes_to_chunks(&mut chunks, &[]).unwrap();
+
+        assert_eq!(chunk, [7, 7]);
     }
 }

--- a/virtualization/axvmconfig/src/lib.rs
+++ b/virtualization/axvmconfig/src/lib.rs
@@ -26,8 +26,9 @@ use alloc::{string::String, vec::Vec};
 
 use ax_errno::AxResult;
 pub use axvm_types::{
-    EmulatedDeviceConfig, EmulatedDeviceType, PassThroughAddressConfig, PassThroughDeviceConfig,
-    PassThroughPortConfig, VMBootProtocol, VMInterruptMode, VMType, VmMemConfig, VmMemMappingType,
+    AddressSpacePolicy, EmulatedDeviceConfig, EmulatedDeviceType, PassThroughAddressConfig,
+    PassThroughDeviceConfig, PassThroughPortConfig, ReservedAddressConfig, VMBootProtocol,
+    VMInterruptMode, VMType, VmMemConfig, VmMemMappingType,
 };
 
 mod emu_device_type_serde {
@@ -53,6 +54,54 @@ mod emu_device_type_serde {
                 "unknown emulated device type value: {value}"
             ))),
         }
+    }
+}
+
+#[cfg_attr(all(feature = "std", any(windows, unix)), derive(schemars::JsonSchema))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+enum AddressSpacePolicySerde {
+    #[serde(rename = "virtualized", alias = "virtual")]
+    #[default]
+    Virtualized,
+    #[serde(rename = "passthrough", alias = "pt")]
+    Passthrough,
+}
+
+impl From<AddressSpacePolicySerde> for AddressSpacePolicy {
+    fn from(value: AddressSpacePolicySerde) -> Self {
+        match value {
+            AddressSpacePolicySerde::Virtualized => Self::Virtualized,
+            AddressSpacePolicySerde::Passthrough => Self::Passthrough,
+        }
+    }
+}
+
+impl From<&AddressSpacePolicy> for AddressSpacePolicySerde {
+    fn from(value: &AddressSpacePolicy) -> Self {
+        match value {
+            AddressSpacePolicy::Virtualized => Self::Virtualized,
+            AddressSpacePolicy::Passthrough => Self::Passthrough,
+        }
+    }
+}
+
+mod address_space_policy_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::*;
+
+    pub fn serialize<S>(value: &AddressSpacePolicy, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        AddressSpacePolicySerde::from(value).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<AddressSpacePolicy, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(AddressSpacePolicySerde::deserialize(deserializer)?.into())
     }
 }
 
@@ -736,6 +785,14 @@ const BUILD_TARGET_ARCH: &str = "unknown";
 #[cfg_attr(all(feature = "std", any(windows, unix)), derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VMDevicesConfig {
+    /// Guest physical address space population policy.
+    #[serde(default)]
+    #[cfg_attr(
+        all(feature = "std", any(windows, unix)),
+        schemars(with = "AddressSpacePolicySerde")
+    )]
+    #[serde(with = "address_space_policy_serde")]
+    pub address_space_policy: AddressSpacePolicy,
     /// Emu device Information
     #[cfg_attr(
         all(feature = "std", any(windows, unix)),

--- a/virtualization/axvmconfig/src/templates.rs
+++ b/virtualization/axvmconfig/src/templates.rs
@@ -88,12 +88,13 @@ pub fn get_vm_config_template(params: VmTemplateParams) -> AxVMCrateConfig {
         },
         // Device configuration - starts empty, can be customized
         devices: VMDevicesConfig {
-            emu_devices: vec![],                // No emulated devices by default
-            passthrough_devices: vec![],        // No passthrough devices by default
-            interrupt_mode: Default::default(), // Use default interrupt mode
-            excluded_devices: vec![],           // No excluded devices by default
-            passthrough_addresses: vec![],      // No passthrough addresses by default
-            passthrough_ports: vec![],          // No passthrough ports by default
+            address_space_policy: Default::default(), // Virtualized address space by default
+            emu_devices: vec![],                      // No emulated devices by default
+            passthrough_devices: vec![],              // No passthrough devices by default
+            interrupt_mode: Default::default(),       // Use default interrupt mode
+            excluded_devices: vec![],                 // No excluded devices by default
+            passthrough_addresses: vec![],            // No passthrough addresses by default
+            passthrough_ports: vec![],                // No passthrough ports by default
         },
     }
 }

--- a/virtualization/axvmconfig/src/test.rs
+++ b/virtualization/axvmconfig/src/test.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::{
-    AxVMCrateConfig, EmulatedDeviceType, VMBootProtocol, VMDevicesConfig, VMInterruptMode,
-    VmMemMappingType,
+    AddressSpacePolicy, AxVMCrateConfig, EmulatedDeviceType, VMBootProtocol, VMDevicesConfig,
+    VMInterruptMode, VmMemMappingType,
 };
 
 #[test]
@@ -44,6 +44,8 @@ memory_regions = [
 ]
 
 [devices]
+address_space_policy = "passthrough"
+
 passthrough_devices = [
     ["dev0", 0x0, 0x0, 0x0800_0000, 0x1],
     ["dev1", 0x0900_0000, 0x0900_0000, 0x0a00_0000, 0x2],
@@ -127,6 +129,83 @@ interrupt_mode = "passthrough"
         EmulatedDeviceType::GPPTITS
     );
     assert_eq!(config.devices.interrupt_mode, VMInterruptMode::Passthrough);
+    assert_eq!(
+        config.devices.address_space_policy,
+        AddressSpacePolicy::Passthrough
+    );
+}
+
+#[test]
+fn test_address_space_policy_deser_and_defaults() {
+    const DEFAULT_POLICY_CONFIG: &str = r#"
+[base]
+id = 1
+name = "policy-default"
+vm_type = 1
+cpu_num = 1
+
+[kernel]
+entry_point = 0x8020_0000
+kernel_path = "guest.bin"
+kernel_load_addr = 0x8020_0000
+memory_regions = []
+
+[devices]
+emu_devices = []
+passthrough_devices = []
+    "#;
+
+    let config = AxVMCrateConfig::from_toml(DEFAULT_POLICY_CONFIG).unwrap();
+    assert_eq!(
+        config.devices.address_space_policy,
+        AddressSpacePolicy::Virtualized
+    );
+
+    const PASSTHROUGH_POLICY_CONFIG: &str = r#"
+[base]
+id = 1
+name = "policy-passthrough"
+vm_type = 1
+cpu_num = 1
+
+[kernel]
+entry_point = 0x8020_0000
+kernel_path = "guest.bin"
+kernel_load_addr = 0x8020_0000
+memory_regions = []
+
+[devices]
+address_space_policy = "passthrough"
+emu_devices = []
+passthrough_devices = []
+    "#;
+
+    let config = AxVMCrateConfig::from_toml(PASSTHROUGH_POLICY_CONFIG).unwrap();
+    assert_eq!(
+        config.devices.address_space_policy,
+        AddressSpacePolicy::Passthrough
+    );
+
+    const INVALID_POLICY_CONFIG: &str = r#"
+[base]
+id = 1
+name = "policy-invalid"
+vm_type = 1
+cpu_num = 1
+
+[kernel]
+entry_point = 0x8020_0000
+kernel_path = "guest.bin"
+kernel_load_addr = 0x8020_0000
+memory_regions = []
+
+[devices]
+address_space_policy = "everything"
+emu_devices = []
+passthrough_devices = []
+    "#;
+
+    assert!(AxVMCrateConfig::from_toml(INVALID_POLICY_CONFIG).is_err());
 }
 
 #[test]
@@ -502,6 +581,10 @@ fn test_default_implementations() {
     assert!(vm_kernel_config.memory_regions.is_empty());
 
     let vm_devices_config = VMDevicesConfig::default();
+    assert_eq!(
+        vm_devices_config.address_space_policy,
+        AddressSpacePolicy::Virtualized
+    );
     assert!(vm_devices_config.emu_devices.is_empty());
     assert!(vm_devices_config.passthrough_devices.is_empty());
     assert_eq!(vm_devices_config.interrupt_mode, VMInterruptMode::NoIrq);


### PR DESCRIPTION
## 背景

AxVM 之前的启动描述和 stage-2 passthrough 映射逻辑分散在 axvisor 与 axvm 之间，DTB 生成依赖全局 cache，隐式透传语义也不够清晰。这样会让 emulated device、guest memory、DTB/ACPI 等 guest-owned 区域和 passthrough hole 的关系难以统一管理。

## 修改

- 在 `axvmconfig`/`axvm-types` 中加入 `address_space_policy`，默认 `virtualized`，并支持显式 `passthrough`。
- 在 `axvm` 中加入 `GuestBootDescription`、`GuestFdtBuilder`、`VmAddressLayout` 和 `GuestRegionPlanner`，由 VM prepare/reset 生命周期统一生成启动描述占用区和最终 stage-2 passthrough mapping。
- 将 aarch64/riscv64 guest DTB 从 axvisor 全局 cache 改成按 VM 传递给 `AxVM`，LoongArch UEFI firmware FDT 继续由平台事实初始化。
- `passthrough` 策略下先建立 identity passthrough window，再由 VM memory、boot description、emulated device 和 reserved ranges 打洞；`virtualized` 策略下只映射显式 passthrough。
- `PassThroughDeviceConfig` 使用 `base_gpa -> base_hpa`，`PassThroughAddressConfig` 保持 identity passthrough 语义。
- `excluded_devices` 现在会从源 DTB/provided DTB 解析 MMIO ranges，写入 VM reserved address ranges，让 planner 在 passthrough 模式下打洞，避免节点从 guest DTB 删除后仍被默认透传。
- 修复 `AddrSpace::map_linear` 对完整 HPA 区间缺少溢出校验的问题，非法映射返回配置错误而不是 panic。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p axvmconfig --lib`
- `cargo test -p axvm --lib`
- `cargo test -p axaddrspace`
- `cargo xtask clippy --package axaddrspace`
- `cargo xtask clippy --package axvm`
- `cargo xtask clippy --package axvmconfig`
- `cargo xtask clippy --package axvm-types`
- `cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case smoke`
- `cargo xtask axvisor test qemu --arch riscv64 --test-group normal --test-case smoke`
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case smoke-vmx`

说明：`cargo xtask clippy --package axvisor` 会按工具提示跳过，因为 axvisor 需要具体 target/build config；上面的三架构 smoke 覆盖了实际 axvisor 目标构建和启动路径。
