### PR TITLE
fix(ci): skip duplicate branch push checks

### DIFF
--- a/.github/workflows/ci-branch-push.yml
+++ b/.github/workflows/ci-branch-push.yml
@@ -1,0 +1,79 @@
+name: CI Branch Push Router
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - dev
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.rst"
+      - "**/*.adoc"
+      - "docs/**"
+      - "**/docs/**"
+      - "**/doc/**"
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  route:
+    name: Route branch push CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Route branch push
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE_SHA: ${{ github.event.before }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          open_pr_count=0
+          if [ "$GITHUB_REPOSITORY" = "rcore-os/tgoskits" ]; then
+            open_pr_count="$(
+              gh pr list \
+                --repo "$GITHUB_REPOSITORY" \
+                --head "$REF_NAME" \
+                --state open \
+                --json number,headRefName,headRepositoryOwner \
+                --jq '[.[] | select(.headRepositoryOwner.login == env.REPOSITORY_OWNER and .headRefName == env.REF_NAME)] | length'
+            )"
+          fi
+
+          if [ "$open_pr_count" != "0" ]; then
+            open_prs="$(
+              gh pr list \
+                --repo "$GITHUB_REPOSITORY" \
+                --head "$REF_NAME" \
+                --state open \
+                --json number,url,headRefName,headRepositoryOwner \
+                --jq '.[] | select(.headRepositoryOwner.login == env.REPOSITORY_OWNER and .headRefName == env.REF_NAME) | "- #\(.number): \(.url)"'
+            )"
+            {
+              echo "## Duplicate push CI skipped"
+              echo ""
+              echo "This branch already has an open pull request, so the duplicate push CI was not dispatched."
+              echo "The pull_request CI run validates the same commit."
+              echo ""
+              echo "$open_prs"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          gh workflow run ci.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$REF_NAME" \
+            -f run_target=ci \
+            -f container_target=both \
+            -f since_sha="$BEFORE_SHA"
+
+          {
+            echo "## Branch CI dispatched"
+            echo ""
+            echo "No open pull request was found for this branch, so the full CI workflow was dispatched for \`${REF_NAME}\`."
+            echo "Diff-based checks will use \`${BEFORE_SHA}\` as their base commit."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,14 +705,6 @@ jobs:
             container_image: ""
             limit_to_owner: rcore-os
             main_pr_only: false
-          - name: Test starry self-hosted board licheerv-nano-sg2002
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask starry test board --board licheerv-nano-sg2002
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
           - name: Test starry self-hosted board aka-00-sg2002
             use_container: false
             runs_on: '["self-hosted","linux","board"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - dev
     paths-ignore:
       - "**/*.md"
       - "**/*.rst"
@@ -19,15 +22,28 @@ on:
       - "**/doc/**"
   workflow_dispatch:
     inputs:
+      run_target:
+        description: Run CI checks or publish container images.
+        required: false
+        default: container
+        type: choice
+        options:
+          - container
+          - ci
       container_target:
         description: Container image(s) to publish manually.
-        required: true
+        required: false
         default: both
         type: choice
         options:
           - base
           - axvisor-lvz
           - both
+      since_sha:
+        description: Base commit for CI diff checks when run_target is ci.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -128,7 +144,7 @@ jobs:
       pull-requests: read
     outputs:
       ci_checks: ${{ steps.outputs.outputs.ci_checks }}
-      skip_duplicate_push_ci: ${{ steps.outputs.outputs.skip_duplicate_push_ci }}
+      since_ref: ${{ steps.outputs.outputs.since_ref }}
       base_container_publish: ${{ steps.outputs.outputs.base_container_publish }}
       axvisor_lvz_container_publish: ${{ steps.outputs.outputs.axvisor_lvz_container_publish }}
       base_container_image: ${{ steps.outputs.outputs.base_container_image }}
@@ -149,6 +165,7 @@ jobs:
           filters: |
             ci_checks:
               - ".cargo/**"
+              - ".github/workflows/ci-branch-push.yml"
               - ".github/workflows/container-publish.yml"
               - ".github/workflows/ci.yml"
               - ".github/workflows/reusable-command.yml"
@@ -178,58 +195,91 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
+          RUN_TARGET: ${{ github.event.inputs.run_target || 'container' }}
           MANUAL_TARGET: ${{ github.event.inputs.container_target }}
+          SINCE_SHA: ${{ github.event.inputs.since_sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           FILTER_CI_CHECKS: ${{ steps.filter.outputs.ci_checks }}
           FILTER_BASE_CONTAINER_PUBLISH: ${{ steps.filter.outputs.base_container_publish }}
           FILTER_AXVISOR_LVZ_CONTAINER_PUBLISH: ${{ steps.filter.outputs.axvisor_lvz_container_publish }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           repository="$(printf '%s' "$GITHUB_REPOSITORY" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
           base_container_image="ghcr.io/${repository}-container"
           axvisor_lvz_container_image="ghcr.io/${repository}-container-axvisor-lvz"
-          skip_duplicate_push_ci=false
 
-          if [ "$EVENT_NAME" = "push" ] \
-            && [ "$REF_NAME" != "main" ] \
-            && [ "$REF_NAME" != "dev" ]; then
-            open_pr_count="$(
-              gh pr list \
-                --repo "$GITHUB_REPOSITORY" \
-                --head "$REF_NAME" \
-                --state open \
-                --json number \
-                --jq 'length'
-            )"
+          is_empty_or_zero_sha() {
+            local value="$1"
+            [ -z "$value" ] || [ "$value" = "0000000000000000000000000000000000000000" ]
+          }
 
-            if [ "$open_pr_count" != "0" ]; then
-              skip_duplicate_push_ci=true
+          resolve_since_ref() {
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              printf '%s\n' "$PR_BASE_SHA"
+              return
             fi
-          fi
 
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$EVENT_NAME" = "push" ]; then
+              if ! is_empty_or_zero_sha "$PUSH_BEFORE_SHA"; then
+                printf '%s\n' "$PUSH_BEFORE_SHA"
+                return
+              fi
+            elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$RUN_TARGET" = "ci" ]; then
+              if ! is_empty_or_zero_sha "$SINCE_SHA"; then
+                printf '%s\n' "$SINCE_SHA"
+                return
+              fi
+            fi
+
+            if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+              git rev-parse HEAD~1
+              return
+            fi
+
+            git fetch --no-tags --depth=1 origin dev:refs/remotes/origin/dev >/dev/null 2>&1 || true
+            merge_base="$(git merge-base HEAD origin/dev 2>/dev/null || true)"
+            if [ -n "$merge_base" ]; then
+              printf '%s\n' "$merge_base"
+              return
+            fi
+
+            git rev-parse HEAD
+          }
+
+          since_ref="$(resolve_since_ref)"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$RUN_TARGET" = "ci" ]; then
+            ci_checks=true
+            base_container_publish=false
+            axvisor_lvz_container_publish=false
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             ci_checks=false
-            case "$MANUAL_TARGET" in
-              base)
-                base_container_publish=true
-                axvisor_lvz_container_publish=false
-                ;;
-              axvisor-lvz)
-                base_container_publish=false
-                axvisor_lvz_container_publish=true
-                ;;
-              both)
-                base_container_publish=true
-                axvisor_lvz_container_publish=true
+            case "$RUN_TARGET" in
+              container)
+                case "$MANUAL_TARGET" in
+                  base)
+                    base_container_publish=true
+                    axvisor_lvz_container_publish=false
+                    ;;
+                  axvisor-lvz)
+                    base_container_publish=false
+                    axvisor_lvz_container_publish=true
+                    ;;
+                  both)
+                    base_container_publish=true
+                    axvisor_lvz_container_publish=true
+                    ;;
+                  *)
+                    echo "Unexpected container_target: $MANUAL_TARGET" >&2
+                    exit 1
+                    ;;
+                esac
                 ;;
               *)
-                echo "Unexpected container_target: $MANUAL_TARGET" >&2
+                echo "Unexpected run_target: $RUN_TARGET" >&2
                 exit 1
                 ;;
             esac
-          elif [ "$skip_duplicate_push_ci" = "true" ]; then
-            ci_checks=false
-            base_container_publish=false
-            axvisor_lvz_container_publish=false
           else
             if [ "$EVENT_NAME" = "push" ] && { [ "$REF_NAME" = "main" ] || [ "$REF_NAME" = "dev" ]; }; then
               ci_checks=true
@@ -242,7 +292,7 @@ jobs:
 
           {
             echo "ci_checks=${ci_checks}"
-            echo "skip_duplicate_push_ci=${skip_duplicate_push_ci}"
+            echo "since_ref=${since_ref}"
             echo "base_container_publish=${base_container_publish}"
             echo "axvisor_lvz_container_publish=${axvisor_lvz_container_publish}"
             echo "base_container_image=${base_container_image}"
@@ -253,15 +303,12 @@ jobs:
         if: steps.outputs.outputs.ci_checks != 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
-          SKIP_DUPLICATE_PUSH_CI: ${{ steps.outputs.outputs.skip_duplicate_push_ci }}
         run: |
           {
             echo "## CI checks skipped"
             echo ""
             if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
               echo "This manual run is scoped to container publishing, so static checks and follow-up CI checks were skipped."
-            elif [ "$SKIP_DUPLICATE_PUSH_CI" = "true" ]; then
-              echo "This branch already has an open pull request. The duplicate push CI was skipped; the pull_request CI run will validate the same commit."
             else
               echo "Changed files do not match the test-relevant path set, so static checks and follow-up CI checks were skipped."
             fi
@@ -271,6 +318,7 @@ jobs:
         if: >-
           ${{
             github.event_name == 'workflow_dispatch'
+            && (github.event.inputs.run_target || 'container') == 'container'
             && github.ref_name != 'main'
             && github.ref_name != 'dev'
           }}
@@ -302,7 +350,7 @@ jobs:
           - name: Run sync-lint
             use_container: true
             runs_on: '["ubuntu-latest"]'
-            command: cargo xtask sync-lint --since "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}"
+            command: cargo xtask sync-lint --since "${{ needs.detect_changes.outputs.since_ref }}"
             cache_key: ""
             container_image: base
             fetch_depth: full
@@ -367,7 +415,7 @@ jobs:
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
-            command: cargo xtask clippy --since "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}"
+            command: cargo xtask clippy --since "${{ needs.detect_changes.outputs.since_ref }}"
             cache_key: ""
             container_image: base
             fetch_depth: full

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -5,7 +5,7 @@ sidebar_label: "自动 CI 测试"
 
 # 自动 CI 测试
 
-本文档说明 `.github/workflows/ci.yml`、`.github/workflows/reusable-command.yml` 和容器镜像在 CI 中的职责，以及当前测试矩阵、缓存策略和 self-hosted runner 的使用方式。
+本文档说明 `.github/workflows/ci.yml`、`.github/workflows/ci-branch-push.yml`、`.github/workflows/reusable-command.yml` 和容器镜像在 CI 中的职责，以及当前测试矩阵、缓存策略和 self-hosted runner 的使用方式。
 
 TGOSKits 将大部分构建与运行依赖收敛到统一的 container 镜像，由 GitHub Actions 和本地开发流程共同消费。需要物理设备、虚拟化能力或专用机器环境的任务则运行在 self-hosted runner 上。
 
@@ -20,7 +20,7 @@ flowchart TB
         L2_D["reusable-command.yml"]
     end
     subgraph L3["CI 编排"]
-        L3_D["ci.yml · container-publish.yml"]
+        L3_D["ci-branch-push.yml · ci.yml · container-publish.yml"]
     end
     L1 --> L2 --> L3
 ```
@@ -29,17 +29,20 @@ flowchart TB
 |------|------|----------|
 | Container 镜像 | 固化工具链、QEMU、交叉编译器 | `container/Dockerfile`、`container/Dockerfile.axvisor-lvz` |
 | 可复用工作流 | 统一在 host 或 container 中执行命令 | `.github/workflows/reusable-command.yml` |
-| CI 编排 | 选择测试矩阵、决定何时发布镜像 | `.github/workflows/ci.yml`、`.github/workflows/container-publish.yml` |
+| CI 编排 | 选择测试矩阵、决定何时发布镜像，并路由非主线分支 push | `.github/workflows/ci.yml`、`.github/workflows/ci-branch-push.yml`、`.github/workflows/container-publish.yml` |
 
 ## 触发条件
 
 | 事件 | 说明 |
 |------|------|
-| `push` | 排除纯文档变更（`*.md`、`docs/**` 等），其余路径触发 CI |
+| `push` 到 `main` / `dev` | 排除纯文档变更（`*.md`、`docs/**` 等），其余路径直接触发完整 CI |
+| `push` 到其他分支 | 先进入 `ci-branch-push.yml`。若该分支已有 open PR，则只保留一个成功的 router 检查；否则由 router 触发完整 CI |
 | `pull_request` | 同上 |
-| `workflow_dispatch` | 手动触发，仅用于发布容器镜像（`base` / `axvisor-lvz` / `both`），不执行 CI 检查 |
+| `workflow_dispatch` | 默认用于发布容器镜像（`base` / `axvisor-lvz` / `both`）；router 也会用 `run_target=ci` 调度非 PR 分支的完整 CI |
 
 `dev` 分支的 `push` 和手动触发使用 `concurrency.queue: max` 串行排队运行，避免多个 dev CI 同时占用 runner。其他分支、`main` 分支、PR 以及非 `dev` 手动触发不会进入 dev 队列；新 run 会在最早的 `cancel_stale_runs` 阶段取消同一分支或同一 PR 上仍在 queued/running 的旧 CI run。
+
+非 `main` / `dev` 分支的 `push` 由轻量 router 先检查是否已有同名 open PR。已有 PR 时不会调度 `.github/workflows/ci.yml`，因此不会为重复 push 生成一组 skipped matrix check；PR 的 `pull_request` CI 负责验证同一提交。没有 open PR 时，router 使用 `workflow_dispatch` 调度完整 CI，并把 push 事件的 `before` SHA 传给后续差异检查。
 
 ## 执行流水线
 
@@ -57,6 +60,16 @@ cancel_stale_runs
         `-- publish_axvisor_lvz_container       依赖 base 成功后才运行
 ```
 
+非 `main` / `dev` 分支 push 会先经过 `ci-branch-push.yml`：
+
+```text
+branch push router
+  |
+  +-- [branch has open PR]  success summary only
+  |
+  `-- [no open PR]         workflow_dispatch(run_target=ci) -> ci.yml
+```
+
 `static_checks` 作为测试矩阵的前置门禁：格式检查或 sync-lint 不通过时，后续测试不会启动。`static_checks` 和 `test_checks` 都启用 `fail-fast: true`，任意矩阵项失败会取消同矩阵内其他任务，减少 runner 占用。
 
 ## 变更检测
@@ -65,11 +78,11 @@ cancel_stale_runs
 
 | 检测路径 | 触发任务 |
 |----------|----------|
-| `.cargo/`、`Cargo.toml`、`Cargo.lock`、`components/`、`drivers/`、`examples/`、`os/`、`platforms/`、`scripts/`、`test-suit/`、`xtask/` 等 | CI 检查 |
+| `.cargo/`、`.github/workflows/ci-branch-push.yml`、`.github/workflows/ci.yml`、`.github/workflows/reusable-command.yml`、`Cargo.toml`、`Cargo.lock`、`components/`、`drivers/`、`examples/`、`os/`、`platforms/`、`scripts/`、`test-suit/`、`xtask/` 等 | CI 检查 |
 | `container/Dockerfile`、`rust-toolchain.toml` | 发布基础容器镜像 |
 | `container/Dockerfile.axvisor-lvz`、`rust-toolchain.toml` | 发布 LVZ 扩展镜像 |
 
-push 到 `main` / `dev` 时强制运行 CI 检查。若非 `main` / `dev` 分支的 push 已存在 open PR，则跳过重复的 push CI，由 pull request CI 覆盖同一提交。
+push 到 `main` / `dev` 时强制运行 CI 检查。非 `main` / `dev` 分支没有 open PR 时由 router 调度完整 CI；已有 open PR 时只保留一个成功的 router 检查，由 pull request CI 覆盖同一提交。
 
 `detect_changes` 内部还负责输出跳过原因：
 

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -108,7 +108,6 @@ push 到 `main` / `dev` 时强制运行 CI 检查。若非 `main` / `dev` 分支
 | Test axvisor x86_64 svm hosted | `ubuntu-latest` | 否 | 无 | AMD SVM 虚拟化冒烟测试；Intel CPU 时自动跳过 |
 | Test axvisor self-hosted board orangepi-5-plus-linux | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board orangepi-5-plus-linux`；物理板卡；仅 `rcore-os` 仓库触发 |
 | Test starry self-hosted board orangepi-5-plus | `self-hosted linux board` | 否 | 无 | `cargo xtask starry test board --board orangepi-5-plus`；物理板卡；仅 `rcore-os` 仓库触发 |
-| Test starry self-hosted board licheerv-nano-sg2002 | `self-hosted linux board` | 否 | 无 | `cargo xtask starry test board --board licheerv-nano-sg2002`；LicheeRV-Nano-SG2002 物理板卡；仅 `rcore-os` 仓库触发 |
 
 StarryOS stress 测试条目保留在 workflow 中，但当前处于注释状态。启用后仅用于 target 为 `main` 的 PR。
 


### PR DESCRIPTION
## 背景

同仓库分支在已经打开 PR 后继续 push 时，会同时触发 `push` CI 和 `pull_request` CI。此前重复 push 虽然在 `detect_changes` 后跳过了重测试，但仍会在外部状态里留下 skipped matrix / publish check，容易被看成不干净的状态。

另外，LicheeRV-Nano-SG2002 物理板测试不再需要作为 CI 矩阵项运行，继续保留会占用 self-hosted board runner。

## 改动

- 将 `.github/workflows/ci.yml` 的直接 `push` 触发限制到 `main` / `dev`，保留 `pull_request` 和手动容器发布。
- 新增 `ci-branch-push.yml` 作为非 `main` / `dev` 分支 push router：同仓库分支已有 open PR 时只保留一个成功的 router 检查；没有 open PR 时用 `workflow_dispatch(run_target=ci)` 调度完整 CI。
- 给 `ci.yml` 增加 `run_target` / `since_sha` 输入，并输出 `since_ref` 供 `sync-lint` 和 `clippy` 使用，移除原来的 `skip_duplicate_push_ci` 执行层跳过逻辑。
- 移除 LicheeRV-Nano-SG2002 的 Starry board CI job，并同步更新 CI 文档。

## 验证

- `git diff --check HEAD~1..HEAD`
- `actionlint .github/workflows/ci-branch-push.yml`
- `actionlint -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/ci.yml .github/workflows/ci-branch-push.yml`
- `gh pr list --repo rcore-os/tgoskits --head codex/remove-licheerv-board-ci --state open --json number,url,headRepositoryOwner,headRefName --jq ...`，确认 router 的 same-repo open PR 查询命中 `#1455`。
- 推送 head `a64173b0d` 后，`gh run list --branch codex/remove-licheerv-board-ci` 显示 `push` 事件只产生 `CI Branch Push Router` 成功 run，完整 `CI` 只在 `pull_request` 事件运行。