### PR TITLE
ci(starry): remove LicheeRV Nano SG2002 board job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,14 +706,6 @@ jobs:
             container_image: ""
             limit_to_owner: rcore-os
             main_pr_only: false
-          - name: Test starry self-hosted board licheerv-nano-sg2002
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask starry test board --board licheerv-nano-sg2002
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
           - name: Test starry self-hosted board aka-00-sg2002
             use_container: false
             runs_on: '["self-hosted","linux","board"]'

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -108,7 +108,6 @@ push 到 `main` / `dev` 时强制运行 CI 检查。若非 `main` / `dev` 分支
 | Test axvisor x86_64 svm hosted | `ubuntu-latest` | 否 | 无 | AMD SVM 虚拟化冒烟测试；Intel CPU 时自动跳过 |
 | Test axvisor self-hosted board orangepi-5-plus-linux | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board orangepi-5-plus-linux`；物理板卡；仅 `rcore-os` 仓库触发 |
 | Test starry self-hosted board orangepi-5-plus | `self-hosted linux board` | 否 | 无 | `cargo xtask starry test board --board orangepi-5-plus`；物理板卡；仅 `rcore-os` 仓库触发 |
-| Test starry self-hosted board licheerv-nano-sg2002 | `self-hosted linux board` | 否 | 无 | `cargo xtask starry test board --board licheerv-nano-sg2002`；LicheeRV-Nano-SG2002 物理板卡；仅 `rcore-os` 仓库触发 |
 
 StarryOS stress 测试条目保留在 workflow 中，但当前处于注释状态。启用后仅用于 target 为 `main` 的 PR。
 


### PR DESCRIPTION
## 问题

CI 目前仍会调度 LicheeRV-Nano-SG2002 的 StarryOS self-hosted board 测试。该板卡测试需要从当前 CI 矩阵中移除，避免继续占用对应物理板 runner。

## 变更

- 从 `.github/workflows/ci.yml` 的 CI matrix 中删除 `Test starry self-hosted board licheerv-nano-sg2002` 任务。
- 同步更新 `docs/docs/build/ci.md`，移除该 CI 任务的说明行。

## 实现逻辑

这次只移除 CI 调度入口和公开 CI 文档记录，不删除 StarryOS/SG2002 平台支持、quick-start 命令或测试套件目录。这样可以停止 GitHub Actions 中的 LicheeRV-Nano-SG2002 物理板测试，同时保留后续手动验证或重新接入 CI 所需的板卡配置。

## 验证

- `rg -n "Test starry self-hosted board licheerv-nano-sg2002|cargo xtask starry test board --board licheerv-nano-sg2002|licheerv-nano-sg2002" .github docs/docs/build/ci.md` 无匹配。
- `python3` + PyYAML 解析 `.github/workflows/ci.yml` 通过。
- `git diff --check origin/dev...HEAD` 通过。

未运行 `cargo clippy`：本次仅修改 GitHub Actions 配置和 CI 文档，没有修改 Rust crate 逻辑。
