### PR TITLE
refactor(rdrive): apply default FDT pinctrl before probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6426,6 +6426,7 @@ dependencies = [
  "pcie",
  "rdif-base",
  "rdif-pcie",
+ "rdif-pinctrl",
  "rdrive-macros",
  "spin",
  "thiserror 2.0.18",

--- a/drivers/ax-driver/src/block/rockchip/sd/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sd/mod.rs
@@ -18,7 +18,7 @@ use core::time::Duration;
 use dwmmc_host::{CardDetect, DwMmc, HostClock, rdif as dwmmc_rdif};
 use fdt_edit::{Node, Phandle};
 use log::{info, warn};
-use rdif_pinctrl::PinctrlDevice;
+use rdif_pinctrl::{FdtPinctrl, PinctrlDevice};
 use rdrive::{
     probe::OnProbeError,
     register::{FdtInfo, ProbeFdt},
@@ -35,7 +35,7 @@ use super::clock::{
 use crate::{
     block::ProbeFdtBlock,
     mmio::iomap,
-    soc::{RockchipPinCtrl, rk3588_enable_power_domain},
+    soc::{RockchipFdtPinctrlParser, rk3588_enable_power_domain},
 };
 
 const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
@@ -213,13 +213,9 @@ fn apply_rockchip_sd_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
     let mut pinctrl = pinctrl
         .lock()
         .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
-    let pinctrl = pinctrl
-        .typed_mut::<RockchipPinCtrl>()
-        .ok_or_else(|| OnProbeError::other("PinctrlDevice is not backed by RockchipPinCtrl"))?;
-    pinctrl.apply_default_pinctrl(info.node)?;
     for (name, supply) in sd_supply_phandles(info.node.as_node()) {
         if supply_has_fixed_gpio_enable(info, supply)? {
-            pinctrl.enable_fixed_regulator(supply)?;
+            enable_fixed_regulator_with_pinctrl(&mut pinctrl, info, supply)?;
         } else {
             info!(
                 "[{}] {name} phandle {:?} is not a fixed GPIO regulator; skip pinctrl enable",
@@ -230,6 +226,42 @@ fn apply_rockchip_sd_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
     }
     enable_power_domains(parse_power_domains(info.node.as_node())?)?;
     enable_node_clocks(info, "SDMMC");
+    Ok(())
+}
+
+fn enable_fixed_regulator_with_pinctrl(
+    pinctrl: &mut PinctrlDevice,
+    info: &FdtInfo<'_>,
+    supply: Phandle,
+) -> Result<(), OnProbeError> {
+    let regulator = info.get_by_phandle(supply).ok_or_else(|| {
+        OnProbeError::other(format!("SDMMC regulator phandle {supply:?} not found"))
+    })?;
+    let fdt = rdrive::with_fdt(Clone::clone)
+        .ok_or_else(|| OnProbeError::other("live FDT not found for SDMMC regulator"))?;
+    FdtPinctrl::apply_fixed_regulator(
+        pinctrl,
+        &fdt,
+        regulator.as_node(),
+        &RockchipFdtPinctrlParser,
+        "rockchip-sd-regulator",
+    )
+    .map_err(|err| {
+        OnProbeError::other(format!(
+            "failed to enable SDMMC regulator {supply:?} via pinctrl: {err}"
+        ))
+    })?;
+
+    let startup_delay_us = regulator
+        .as_node()
+        .get_property("startup-delay-us")
+        .and_then(|prop| prop.get_u32())
+        .unwrap_or(0);
+    if startup_delay_us != 0 {
+        axklib::time::busy_wait(core::time::Duration::from_micros(u64::from(
+            startup_delay_us,
+        )));
+    }
     Ok(())
 }
 

--- a/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
@@ -21,7 +21,6 @@ use core::{ptr::NonNull, time::Duration};
 
 use fdt_edit::Node;
 use log::{info, warn};
-use rdif_pinctrl::PinctrlDevice;
 use rdrive::{
     probe::OnProbeError,
     register::{FdtInfo, ProbeFdt},
@@ -38,9 +37,7 @@ use super::clock::{RockchipClockOps, apply_assigned_clocks, enable_node_clocks};
 use crate::{
     block::ProbeFdtBlock,
     mmio::iomap,
-    soc::{
-        RockchipPinCtrl, rk3588_enable_power_domain, rk3588_reset_assert, rk3588_reset_deassert,
-    },
+    soc::{rk3588_enable_power_domain, rk3588_reset_assert, rk3588_reset_deassert},
 };
 
 // RK3588 DWCMSHC follows Linux's normal SDHCI completion path: command/data
@@ -49,13 +46,6 @@ use crate::{
 const ROCKCHIP_SDHCI_IRQ_DRIVEN: bool = true;
 const SDMMC_INIT_POLL_DELAY: Duration = Duration::from_micros(1);
 const SDMMC_INIT_RETRY_DELAY: Duration = Duration::from_millis(10);
-const RK3588_EMMC_PINCTRL_SYMBOLS: [&str; 5] = [
-    "emmc_rstnout",
-    "emmc_bus8",
-    "emmc_clk",
-    "emmc_cmd",
-    "emmc_data_strobe",
-];
 const DWCMSHC_P_VENDOR_AREA1: usize = 0xe8;
 const DWCMSHC_AREA1_MASK: u16 = 0x0fff;
 const DWCMSHC_HOST_CTRL3: usize = 0x08;
@@ -234,29 +224,6 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
 fn apply_rockchip_sdhci_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
     apply_assigned_clocks(info, "SDHCI")?;
-    if let Some(pinctrl) = rdrive::get_one::<PinctrlDevice>() {
-        let mut pinctrl = pinctrl
-            .lock()
-            .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
-        let pinctrl = pinctrl
-            .typed_mut::<RockchipPinCtrl>()
-            .ok_or_else(|| OnProbeError::other("PinctrlDevice is not backed by RockchipPinCtrl"))?;
-        let configured = pinctrl.apply_default_pinctrl(info.node)?;
-        if configured.is_empty() {
-            let fallback = rk3588_emmc_pinctrl_symbol_paths();
-            if !fallback.is_empty() {
-                let mut total = 0;
-                for path in &fallback {
-                    total += pinctrl.apply_pinctrl_path(path.as_str())?.len();
-                }
-                info!(
-                    "[{}] applied {} RK3588 eMMC symbol fallback pinctrl pins",
-                    info.node.name(),
-                    total
-                );
-            }
-        }
-    }
     enable_power_domains(parse_power_domains(info.node.as_node())?)?;
     let resets = parse_resets(info.node.as_node())?;
     if !resets.is_empty() {
@@ -264,27 +231,6 @@ fn apply_rockchip_sdhci_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError
     }
     enable_node_clocks(info, "SDHCI");
     Ok(())
-}
-
-fn rk3588_emmc_pinctrl_symbol_paths() -> Vec<String> {
-    rdrive::with_fdt(|fdt| {
-        fdt.get_by_path("/__symbols__")
-            .map(|symbols| rk3588_emmc_pinctrl_paths_from_symbols(symbols.as_node()))
-            .unwrap_or_default()
-    })
-    .unwrap_or_default()
-}
-
-fn rk3588_emmc_pinctrl_paths_from_symbols(symbols: &Node) -> Vec<String> {
-    RK3588_EMMC_PINCTRL_SYMBOLS
-        .into_iter()
-        .filter_map(|symbol| {
-            symbols
-                .get_property(symbol)?
-                .as_str()
-                .map(ToString::to_string)
-        })
-        .collect()
 }
 
 fn parse_power_domains(node: &Node) -> Result<Vec<usize>, OnProbeError> {
@@ -623,42 +569,6 @@ mod tests {
         let node = Node::new("mmc@fe2e0000");
 
         assert_eq!(parse_power_domains(&node).unwrap(), Vec::<usize>::new());
-    }
-
-    #[test]
-    fn emmc_symbol_fallback_reads_linux_pinctrl_paths_in_order() {
-        let mut symbols = Node::new("__symbols__");
-        symbols.add_property(fdt_edit::Property::new(
-            "emmc_cmd",
-            b"/pinctrl/emmc/emmc-cmd\0".to_vec(),
-        ));
-        symbols.add_property(fdt_edit::Property::new(
-            "emmc_rstnout",
-            b"/pinctrl/emmc/emmc-rstnout\0".to_vec(),
-        ));
-        symbols.add_property(fdt_edit::Property::new(
-            "emmc_clk",
-            b"/pinctrl/emmc/emmc-clk\0".to_vec(),
-        ));
-        symbols.add_property(fdt_edit::Property::new(
-            "emmc_bus8",
-            b"/pinctrl/emmc/emmc-bus8\0".to_vec(),
-        ));
-        symbols.add_property(fdt_edit::Property::new(
-            "emmc_data_strobe",
-            b"/pinctrl/emmc/emmc-data-strobe\0".to_vec(),
-        ));
-
-        assert_eq!(
-            rk3588_emmc_pinctrl_paths_from_symbols(&symbols),
-            vec![
-                String::from("/pinctrl/emmc/emmc-rstnout"),
-                String::from("/pinctrl/emmc/emmc-bus8"),
-                String::from("/pinctrl/emmc/emmc-clk"),
-                String::from("/pinctrl/emmc/emmc-cmd"),
-                String::from("/pinctrl/emmc/emmc-data-strobe"),
-            ]
-        );
     }
 
     #[test]

--- a/drivers/ax-driver/src/soc/fixed_regulator.rs
+++ b/drivers/ax-driver/src/soc/fixed_regulator.rs
@@ -1,0 +1,102 @@
+extern crate alloc;
+
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+use core::time::Duration;
+
+use fdt_edit::Node;
+use log::{debug, info};
+use rdif_pinctrl::{PinctrlDevice, PinctrlError};
+use rdrive::{DriverGeneric, probe::OnProbeError, register::ProbeFdt};
+
+const DRIVER_NAME: &str = "fixed-regulator";
+const PINCTRL_OWNER: &str = "fixed-regulator";
+
+crate::model_register!(
+    name: DRIVER_NAME,
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority(64),
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["regulator-fixed"],
+            on_probe: probe
+        }
+    ],
+);
+
+struct FixedRegulator {
+    name: String,
+}
+
+impl DriverGeneric for FixedRegulator {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let (info, platform) = probe.into_parts();
+    let node = info.node.as_node();
+    if !is_boot_enabled(node) {
+        return Err(OnProbeError::NotMatch);
+    }
+
+    let name = regulator_name(node).unwrap_or_else(|| info.node.name().to_string());
+    apply_fixed_regulator_pinctrl(node, &name)?;
+    platform.register(FixedRegulator { name });
+    Ok(())
+}
+
+fn apply_fixed_regulator_pinctrl(node: &Node, name: &str) -> Result<(), OnProbeError> {
+    let Some(pinctrl) = rdrive::get_one::<PinctrlDevice>() else {
+        debug!("Fixed regulator {name} has no PinctrlDevice; skip pinctrl enable");
+        return Ok(());
+    };
+    let mut pinctrl = pinctrl
+        .lock()
+        .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
+    if pinctrl.fdt_parser().is_none() {
+        debug!("Fixed regulator {name} has no FDT pinctrl parser; skip pinctrl enable");
+        return Ok(());
+    }
+
+    let fdt = rdrive::with_fdt(Clone::clone)
+        .ok_or_else(|| OnProbeError::other("live FDT not found for fixed regulator"))?;
+    match pinctrl.apply_fdt_fixed_regulator(&fdt, node, PINCTRL_OWNER) {
+        Ok(()) => {
+            apply_startup_delay(node);
+            info!("Fixed regulator {name} enabled via pinctrl");
+            Ok(())
+        }
+        Err(PinctrlError::NotAvailable) => {
+            debug!("Fixed regulator {name} has no pinctrl GPIO line; skip pinctrl enable");
+            Ok(())
+        }
+        Err(err) => Err(OnProbeError::other(format!(
+            "failed to enable fixed regulator {name} via pinctrl: {err}"
+        ))),
+    }
+}
+
+fn is_boot_enabled(node: &Node) -> bool {
+    node.get_property("regulator-boot-on").is_some()
+        || node.get_property("regulator-always-on").is_some()
+}
+
+fn regulator_name(node: &Node) -> Option<String> {
+    node.get_property("regulator-name")
+        .and_then(|prop| prop.as_str_iter().next())
+        .map(ToString::to_string)
+}
+
+fn apply_startup_delay(node: &Node) {
+    let startup_delay_us = node
+        .get_property("startup-delay-us")
+        .and_then(|prop| prop.get_u32())
+        .unwrap_or(0);
+    if startup_delay_us != 0 {
+        axklib::time::busy_wait(Duration::from_micros(u64::from(startup_delay_us)));
+    }
+}

--- a/drivers/ax-driver/src/soc/mod.rs
+++ b/drivers/ax-driver/src/soc/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(all(feature = "pinctrl", feature = "plat-dyn"))]
+mod fixed_regulator;
 #[cfg(feature = "rockchip-soc")]
 mod rockchip;
 #[cfg(feature = "rockchip-dwmmc")]

--- a/drivers/ax-driver/src/soc/mod.rs
+++ b/drivers/ax-driver/src/soc/mod.rs
@@ -61,16 +61,6 @@ impl rdrive::DriverGeneric for RockchipPinCtrl {
 
 #[cfg(not(feature = "rockchip-soc"))]
 impl RockchipPinCtrl {
-    pub fn apply_default_pinctrl(
-        &mut self,
-        node: fdt_edit::NodeType<'_>,
-    ) -> Result<alloc::vec::Vec<()>, rdrive::probe::OnProbeError> {
-        Err(rdrive::probe::OnProbeError::other(alloc::format!(
-            "RK3588 pinctrl support is not enabled for node {}",
-            node.name()
-        )))
-    }
-
     pub fn enable_fixed_regulator(
         &mut self,
         phandle: fdt_edit::Phandle,

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
@@ -6,9 +6,9 @@ use core::ptr::NonNull;
 use fdt_edit::{Fdt, NodeType, Phandle, RegFixed};
 use log::info;
 use rdif_pinctrl::{
-    Bias, ConfigSetting, ConfigTarget, FdtPinctrl, FdtPinctrlParser, FunctionId, GpioBankId,
-    GpioRange, GroupId, Interface as RdifPinctrl, MuxSetting, PinId as RdifPinId, PinState,
-    PinctrlDevice, PinctrlError as RdifPinctrlError, StateName,
+    Bias, ConfigSetting, ConfigTarget, FdtPinctrl, FunctionId, GpioBankId, GpioRange, GroupId,
+    Interface as RdifPinctrl, MuxSetting, PinId as RdifPinId, PinState, PinctrlDevice,
+    PinctrlError as RdifPinctrlError,
 };
 use rdrive::{DriverGeneric, probe::OnProbeError, register::ProbeFdt};
 use rockchip_soc::{
@@ -57,27 +57,6 @@ impl RockchipPinCtrl {
         Self { inner }
     }
 
-    pub fn apply_default_pinctrl(
-        &mut self,
-        node: NodeType<'_>,
-    ) -> Result<Vec<RockchipPinId>, OnProbeError> {
-        let node_name = node.name().to_string();
-        let Some(prop) = node.as_node().get_property("pinctrl-0") else {
-            info!("Rockchip node {node_name} has no default pinctrl");
-            return Ok(Vec::new());
-        };
-
-        let mut configured = Vec::new();
-        for phandle in prop.get_u32_iter().map(Phandle::from) {
-            configured.extend(self.apply_pinctrl_phandle(phandle)?);
-        }
-        info!(
-            "Rockchip node {node_name} applied {} default pinctrl pins",
-            configured.len()
-        );
-        Ok(configured)
-    }
-
     pub fn enable_fixed_regulator(&mut self, phandle: Phandle) -> Result<(), OnProbeError> {
         let fdt = live_fdt()?;
         let node = fdt.get_by_phandle(phandle).ok_or_else(|| {
@@ -110,48 +89,6 @@ impl RockchipPinCtrl {
 
         info!("Rockchip fixed regulator {node_name} enabled via pinctrl");
         Ok(())
-    }
-
-    pub fn apply_pinctrl_path(&mut self, path: &str) -> Result<Vec<RockchipPinId>, OnProbeError> {
-        let fdt = live_fdt()?;
-        let node = fdt
-            .get_by_path(path)
-            .ok_or_else(|| OnProbeError::other(format!("pinctrl path {path} not found")))?;
-        self.apply_pinctrl_node(node)
-    }
-
-    fn apply_pinctrl_phandle(
-        &mut self,
-        phandle: Phandle,
-    ) -> Result<Vec<RockchipPinId>, OnProbeError> {
-        let fdt = live_fdt()?;
-        let node = fdt
-            .get_by_phandle(phandle)
-            .ok_or_else(|| OnProbeError::other(format!("pinctrl phandle {phandle:?} not found")))?;
-        self.apply_pinctrl_node(node)
-    }
-
-    fn apply_pinctrl_node(
-        &mut self,
-        node: NodeType<'_>,
-    ) -> Result<Vec<RockchipPinId>, OnProbeError> {
-        let node_name = node.name().to_string();
-        let fdt = live_fdt()?;
-        let mut state = PinState::named(StateName::Named(node_name.clone()));
-        RockchipFdtPinctrlParser
-            .parse_pinctrl_node(&fdt, node, &mut state)
-            .map_err(|err| {
-                OnProbeError::other(format!(
-                    "failed to parse Rockchip pinctrl [{node_name}]: {err}"
-                ))
-            })?;
-        let configured = rockchip_pins_from_state(&state)?;
-        self.apply_state(&state).map_err(|err| {
-            OnProbeError::other(format!(
-                "failed to apply Rockchip pinctrl [{node_name}]: {err}"
-            ))
-        })?;
-        Ok(configured)
     }
 }
 
@@ -311,7 +248,10 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     }
 
     let pinctrl = PinCtrl::new(SocType::Rk3588, ioc, &gpio_banks);
-    plat_dev.register(PinctrlDevice::new(RockchipPinCtrl::new(pinctrl)));
+    plat_dev.register(PinctrlDevice::with_fdt_parser(
+        RockchipPinCtrl::new(pinctrl),
+        RockchipFdtPinctrlParser,
+    ));
     info!("Rockchip RK3588 pinctrl registered successfully");
     Ok(())
 }
@@ -345,21 +285,6 @@ fn map_reg(reg: RegFixed) -> Result<NonNull<u8>, OnProbeError> {
 
 fn rockchip_pin_id(raw_pin: u32) -> Result<RockchipPinId, RdifPinctrlError> {
     RockchipPinId::new(raw_pin).ok_or_else(|| RdifPinctrlError::InvalidPin(RdifPinId::new(raw_pin)))
-}
-
-fn rockchip_pins_from_state(state: &PinState) -> Result<Vec<RockchipPinId>, OnProbeError> {
-    state
-        .muxes()
-        .iter()
-        .map(|mux| {
-            rockchip_pin_id(mux.group.raw()).map_err(|err| {
-                OnProbeError::other(format!(
-                    "Rockchip pinctrl state contains invalid pin {:?}: {err}",
-                    mux.group
-                ))
-            })
-        })
-        .collect()
 }
 
 fn rockchip_pull_from_rdif_bias(bias: Bias) -> Pull {

--- a/drivers/ax-driver/src/usb/dwc.rs
+++ b/drivers/ax-driver/src/usb/dwc.rs
@@ -13,7 +13,6 @@ use crab_usb::{
 };
 use fdt_edit::{ClockRef, Fdt, Node, NodeType, Phandle, RegFixed};
 use log::{debug, info, warn};
-use rdif_pinctrl::{FdtPinctrl, PinctrlDevice};
 use rdrive::{
     probe::OnProbeError,
     register::{FdtInfo, ProbeFdt},
@@ -23,9 +22,7 @@ use rockchip_pm::{PowerDomain, RockchipPM};
 use super::{ProbeFdtUsbHost, usb_kernel};
 use crate::{
     mmio::iomap,
-    soc::{
-        RockchipFdtPinctrlParser, rk3588_enable_clock, rk3588_reset_assert, rk3588_reset_deassert,
-    },
+    soc::{rk3588_enable_clock, rk3588_reset_assert, rk3588_reset_deassert},
 };
 
 const DRIVER_NAME: &str = "usb-dwc-xhci";
@@ -74,7 +71,6 @@ struct Usb2PhyResources {
     port_name: String,
     reg: usize,
     grf: Phandle,
-    supply: Option<Phandle>,
     resets: Vec<ResetSpec>,
     clocks: Vec<ClockSpec>,
 }
@@ -123,7 +119,6 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
     enable_power_domains(&resources.power_domains)?;
     enable_clocks(&resources.clocks);
-    enable_vbus(&fdt, resources.usb2.supply)?;
 
     let ctrl = map_reg(resources.ctrl)?;
     let phy = map_reg(resources.usbdp.reg)?;
@@ -237,7 +232,6 @@ fn collect_usb2_phy(fdt: &Fdt, port_phandle: Phandle) -> Result<Usb2PhyResources
         port_name: port.name().to_string(),
         reg,
         grf,
-        supply: get_phandle_prop(port.as_node(), "phy-supply"),
         resets: parse_resets(phy)?,
         clocks: clock_specs(phy.clocks()),
     })
@@ -453,34 +447,6 @@ fn enable_clocks(clocks: &[ClockSpec]) {
             ),
         }
     }
-}
-
-fn enable_vbus(fdt: &Fdt, supply: Option<Phandle>) -> Result<(), OnProbeError> {
-    let Some(supply) = supply else {
-        debug!("DWC xHCI USB2 PHY has no phy-supply; skip VBUS pinctrl");
-        return Ok(());
-    };
-
-    let regulator = fdt.get_by_phandle(supply).ok_or_else(|| {
-        OnProbeError::other(format!(
-            "DWC xHCI VBUS regulator phandle {supply:?} not found"
-        ))
-    })?;
-    let pinctrl = rdrive::get_one::<PinctrlDevice>()
-        .ok_or_else(|| OnProbeError::other("PinctrlDevice not found for DWC xHCI VBUS"))?;
-    let mut pinctrl = pinctrl
-        .lock()
-        .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
-    FdtPinctrl::apply_fixed_regulator(
-        &mut *pinctrl,
-        fdt,
-        regulator.as_node(),
-        &RockchipFdtPinctrlParser,
-        "dwc-xhci-vbus",
-    )
-    .map_err(|err| {
-        OnProbeError::other(format!("failed to enable DWC xHCI VBUS via pinctrl: {err}"))
-    })
 }
 
 fn clock_specs(clocks: Vec<ClockRef>) -> Vec<ClockSpec> {

--- a/drivers/interface/rdif-pinctrl/src/fdt.rs
+++ b/drivers/interface/rdif-pinctrl/src/fdt.rs
@@ -639,6 +639,57 @@ mod tests {
     }
 
     #[test]
+    fn pinctrl_device_applies_fdt_fixed_regulator_with_registered_parser() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props("gpio1@0", &[prop_u32s("phandle", &[20])]),
+        );
+        let regulator = fdt.add_node(
+            root,
+            node_with_props("vbus-regulator", &[prop_u32s("gpios", &[20, 5, 0])]),
+        );
+        let mut device = PinctrlDevice::with_fdt_parser(Recorder::new(), TestParser);
+
+        device
+            .apply_fdt_fixed_regulator(&fdt, fdt.node(regulator).unwrap(), "fixed-regulator")
+            .unwrap();
+
+        assert!(
+            device
+                .typed_ref::<Recorder>()
+                .unwrap()
+                .configs
+                .contains(&ConfigSetting::pin(
+                    PinId::new(37),
+                    PinConfig::OutputValue(true)
+                ))
+        );
+    }
+
+    #[test]
+    fn pinctrl_device_skips_fdt_fixed_regulator_without_parser() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props("gpio1@0", &[prop_u32s("phandle", &[20])]),
+        );
+        let regulator = fdt.add_node(
+            root,
+            node_with_props("vbus-regulator", &[prop_u32s("gpios", &[20, 5, 0])]),
+        );
+        let mut device = PinctrlDevice::new(Recorder::new());
+
+        device
+            .apply_fdt_fixed_regulator(&fdt, fdt.node(regulator).unwrap(), "fixed-regulator")
+            .unwrap();
+
+        assert!(device.typed_ref::<Recorder>().unwrap().configs.is_empty());
+    }
+
+    #[test]
     fn unsupported_firmware_reports_explicit_error() {
         assert_eq!(
             FdtPinctrl::unsupported_firmware(crate::FirmwareKind::Acpi),

--- a/drivers/interface/rdif-pinctrl/src/fdt.rs
+++ b/drivers/interface/rdif-pinctrl/src/fdt.rs
@@ -211,7 +211,7 @@ mod tests {
         ConfigSetting, Direction, DriverGeneric, FdtPinctrl, FdtPinctrlParser, FunctionId,
         GpioBank, GpioBankId, GpioLineHandle, GpioLineId, GpioRange, GroupId, Interface,
         MuxSetting, MuxValue, PinConfig, PinDesc, PinFunction, PinGroup, PinId, PinState,
-        PinctrlError, StateName,
+        PinctrlDevice, PinctrlError, StateName,
     };
 
     struct TestParser;
@@ -479,6 +479,55 @@ mod tests {
         .unwrap();
 
         assert_eq!(recorder.calls, vec!["mux", "config"]);
+    }
+
+    #[test]
+    fn pinctrl_device_applies_fdt_default_state_with_registered_parser() {
+        let (fdt, consumer) = fdt_with_consumer(&["default"], &[10]);
+        let mut device = PinctrlDevice::with_fdt_parser(Recorder::new(), TestParser);
+
+        device
+            .apply_fdt_default_state(&fdt, fdt.node(consumer).unwrap())
+            .unwrap();
+
+        assert_eq!(
+            device.typed_ref::<Recorder>().unwrap().calls,
+            vec!["mux", "config"]
+        );
+    }
+
+    #[test]
+    fn pinctrl_device_skips_fdt_default_state_without_property_or_parser() {
+        let (fdt, consumer) = fdt_with_consumer(&["default"], &[10]);
+        let mut without_parser = PinctrlDevice::new(Recorder::new());
+        without_parser
+            .apply_fdt_default_state(&fdt, fdt.node(consumer).unwrap())
+            .unwrap();
+        assert!(
+            without_parser
+                .typed_ref::<Recorder>()
+                .unwrap()
+                .calls
+                .is_empty()
+        );
+
+        let mut fdt_without_pinctrl = Fdt::new();
+        let root = fdt_without_pinctrl.root_id();
+        let consumer_without_pinctrl = fdt_without_pinctrl.add_node(root, Node::new("consumer"));
+        let mut with_parser = PinctrlDevice::with_fdt_parser(Recorder::new(), TestParser);
+        with_parser
+            .apply_fdt_default_state(
+                &fdt_without_pinctrl,
+                fdt_without_pinctrl.node(consumer_without_pinctrl).unwrap(),
+            )
+            .unwrap();
+        assert!(
+            with_parser
+                .typed_ref::<Recorder>()
+                .unwrap()
+                .calls
+                .is_empty()
+        );
     }
 
     #[test]

--- a/drivers/interface/rdif-pinctrl/src/interface.rs
+++ b/drivers/interface/rdif-pinctrl/src/interface.rs
@@ -100,6 +100,23 @@ impl PinctrlDevice {
         };
         FdtPinctrl::apply_state_from_consumer(interface.as_mut(), fdt, node, 0, parser)
     }
+
+    #[cfg(feature = "fdt")]
+    pub fn apply_fdt_fixed_regulator(
+        &mut self,
+        fdt: &fdt_edit::Fdt,
+        regulator_node: &fdt_edit::Node,
+        owner: &str,
+    ) -> Result<(), PinctrlError> {
+        let Self {
+            interface,
+            fdt_parser,
+        } = self;
+        let Some(parser) = fdt_parser.as_deref() else {
+            return Ok(());
+        };
+        FdtPinctrl::apply_fixed_regulator(interface.as_mut(), fdt, regulator_node, parser, owner)
+    }
 }
 
 impl DriverGeneric for PinctrlDevice {

--- a/drivers/interface/rdif-pinctrl/src/interface.rs
+++ b/drivers/interface/rdif-pinctrl/src/interface.rs
@@ -7,28 +7,64 @@ use crate::{
     ConfigSetting, ConfigTarget, FunctionId, GpioBank, GpioBankId, GpioIrqHandler, GpioIrqSourceId,
     GpioIrqSourceInfo, GpioRange, GroupId, PinDesc, PinFunction, PinGroup, PinState, PinctrlError,
 };
+#[cfg(feature = "fdt")]
+use crate::{FdtPinctrl, FdtPinctrlParser};
+
+#[cfg(feature = "fdt")]
+pub type BFdtPinctrlParser = Box<dyn FdtPinctrlParser + Send>;
 
 pub type BPinctrl = Box<dyn Interface>;
 pub type BGpioBank = Box<dyn GpioBank>;
 pub type BGpioIrqHandler = Box<dyn GpioIrqHandler>;
 
-pub struct PinctrlDevice(BPinctrl);
+pub struct PinctrlDevice {
+    interface: BPinctrl,
+    #[cfg(feature = "fdt")]
+    fdt_parser: Option<BFdtPinctrlParser>,
+}
 
 impl PinctrlDevice {
     pub fn new(interface: impl Interface + 'static) -> Self {
-        Self(Box::new(interface))
+        Self {
+            interface: Box::new(interface),
+            #[cfg(feature = "fdt")]
+            fdt_parser: None,
+        }
+    }
+
+    #[cfg(feature = "fdt")]
+    pub fn with_fdt_parser(
+        interface: impl Interface + 'static,
+        parser: impl FdtPinctrlParser + Send + 'static,
+    ) -> Self {
+        Self {
+            interface: Box::new(interface),
+            fdt_parser: Some(Box::new(parser)),
+        }
     }
 
     pub fn boxed(interface: BPinctrl) -> Self {
-        Self(interface)
+        Self {
+            interface,
+            #[cfg(feature = "fdt")]
+            fdt_parser: None,
+        }
+    }
+
+    #[cfg(feature = "fdt")]
+    pub fn boxed_with_fdt_parser(interface: BPinctrl, parser: BFdtPinctrlParser) -> Self {
+        Self {
+            interface,
+            fdt_parser: Some(parser),
+        }
     }
 
     pub fn interface(&self) -> &dyn Interface {
-        self.0.as_ref()
+        self.interface.as_ref()
     }
 
     pub fn interface_mut(&mut self) -> &mut dyn Interface {
-        self.0.as_mut()
+        self.interface.as_mut()
     }
 
     pub fn typed_ref<T: Interface>(&self) -> Option<&T> {
@@ -38,69 +74,95 @@ impl PinctrlDevice {
     pub fn typed_mut<T: Interface>(&mut self) -> Option<&mut T> {
         self.raw_any_mut()?.downcast_mut()
     }
+
+    #[cfg(feature = "fdt")]
+    pub fn fdt_parser(&self) -> Option<&dyn FdtPinctrlParser> {
+        self.fdt_parser
+            .as_deref()
+            .map(|parser| parser as &dyn FdtPinctrlParser)
+    }
+
+    #[cfg(feature = "fdt")]
+    pub fn apply_fdt_default_state(
+        &mut self,
+        fdt: &fdt_edit::Fdt,
+        node: &fdt_edit::Node,
+    ) -> Result<(), PinctrlError> {
+        if node.get_property("pinctrl-0").is_none() {
+            return Ok(());
+        }
+        let Self {
+            interface,
+            fdt_parser,
+        } = self;
+        let Some(parser) = fdt_parser.as_deref() else {
+            return Ok(());
+        };
+        FdtPinctrl::apply_state_from_consumer(interface.as_mut(), fdt, node, 0, parser)
+    }
 }
 
 impl DriverGeneric for PinctrlDevice {
     fn name(&self) -> &str {
-        self.0.name()
+        self.interface.name()
     }
 
     fn raw_any(&self) -> Option<&dyn Any> {
-        Some(self.0.as_ref() as &dyn Any)
+        Some(self.interface.as_ref() as &dyn Any)
     }
 
     fn raw_any_mut(&mut self) -> Option<&mut dyn Any> {
-        Some(self.0.as_mut() as &mut dyn Any)
+        Some(self.interface.as_mut() as &mut dyn Any)
     }
 }
 
 impl Interface for PinctrlDevice {
     fn pins(&self) -> &[PinDesc] {
-        self.0.pins()
+        self.interface.pins()
     }
 
     fn groups(&self) -> &[PinGroup] {
-        self.0.groups()
+        self.interface.groups()
     }
 
     fn functions(&self) -> &[PinFunction] {
-        self.0.functions()
+        self.interface.functions()
     }
 
     fn gpio_ranges(&self) -> &[GpioRange] {
-        self.0.gpio_ranges()
+        self.interface.gpio_ranges()
     }
 
     fn can_mux(&self, group: GroupId, function: FunctionId) -> bool {
-        self.0.can_mux(group, function)
+        self.interface.can_mux(group, function)
     }
 
     fn validate_state(&self, state: &PinState) -> Result<(), PinctrlError> {
-        self.0.validate_state(state)
+        self.interface.validate_state(state)
     }
 
     fn apply_state(&mut self, state: &PinState) -> Result<(), PinctrlError> {
-        self.0.apply_state(state)
+        self.interface.apply_state(state)
     }
 
     fn apply_mux(&mut self, setting: &crate::MuxSetting) -> Result<(), PinctrlError> {
-        self.0.apply_mux(setting)
+        self.interface.apply_mux(setting)
     }
 
     fn apply_config(&mut self, setting: &ConfigSetting) -> Result<(), PinctrlError> {
-        self.0.apply_config(setting)
+        self.interface.apply_config(setting)
     }
 
     fn create_gpio_bank(&mut self, bank_id: GpioBankId) -> Option<BGpioBank> {
-        self.0.create_gpio_bank(bank_id)
+        self.interface.create_gpio_bank(bank_id)
     }
 
     fn irq_sources(&self) -> Vec<GpioIrqSourceInfo> {
-        self.0.irq_sources()
+        self.interface.irq_sources()
     }
 
     fn take_irq_handler(&mut self, source_id: GpioIrqSourceId) -> Option<BGpioIrqHandler> {
-        self.0.take_irq_handler(source_id)
+        self.interface.take_irq_handler(source_id)
     }
 }
 

--- a/drivers/rdrive/Cargo.toml
+++ b/drivers/rdrive/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { version = "2", default-features = false }
 pcie.workspace = true
 
 rdif-base = { workspace = true }
+rdif-pinctrl = { workspace = true, features = ["fdt"] }
 rdrive-macros.workspace = true
 rdif-pcie = { workspace = true }
 

--- a/drivers/rdrive/src/probe/fdt/mod.rs
+++ b/drivers/rdrive/src/probe/fdt/mod.rs
@@ -7,6 +7,7 @@ use core::ptr::NonNull;
 
 use ax_kspin::SpinRaw as Mutex;
 pub use fdt_edit::{ClockRef, Fdt, InterruptRef, NodeId, NodeType, Phandle, RegInfo, Status};
+use rdif_pinctrl::PinctrlDevice;
 use spin::Once;
 
 use super::ProbeError;
@@ -80,6 +81,23 @@ impl<'a> FdtInfo<'a> {
     pub fn interrupts(&self) -> Vec<InterruptRef> {
         self.node.interrupts()
     }
+}
+
+fn apply_default_pinctrl(node: NodeType<'_>) -> Result<(), OnProbeError> {
+    let Some(pinctrl) = crate::get_one::<PinctrlDevice>() else {
+        return Ok(());
+    };
+    let mut pinctrl = pinctrl
+        .lock()
+        .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
+    pinctrl
+        .apply_fdt_default_state(system().fdt(), node.as_node())
+        .map_err(|err| {
+            OnProbeError::other(format!(
+                "failed to apply default pinctrl for [{}]: {err}",
+                node.name()
+            ))
+        })
 }
 
 pub struct ProbeFdt<'a> {
@@ -231,20 +249,21 @@ impl System {
             let phandle_map = self.phandle_2_device_id.clone();
 
             debug!("Probe [{}]->[{}]", node.name(), node_info.name);
+            let res = apply_default_pinctrl(node).and_then(|()| {
+                let descriptor = Descriptor {
+                    name: node_info.name,
+                    device_id: id,
+                    irq_parent,
+                };
 
-            let descriptor = Descriptor {
-                name: node_info.name,
-                device_id: id,
-                irq_parent,
-            };
-
-            let res = (node_info.on_probe)(ProbeFdt::new(
-                FdtInfo {
-                    node,
-                    phandle_2_device_id: phandle_map,
-                },
-                PlatformDevice::new(descriptor),
-            ));
+                (node_info.on_probe)(ProbeFdt::new(
+                    FdtInfo {
+                        node,
+                        phandle_2_device_id: phandle_map,
+                    },
+                    PlatformDevice::new(descriptor),
+                ))
+            });
 
             if res.is_ok() {
                 self.populated_paths.lock().insert(node.path(), id);

--- a/drivers/rdrive/tests/fdt_pinctrl.rs
+++ b/drivers/rdrive/tests/fdt_pinctrl.rs
@@ -1,0 +1,231 @@
+use core::{
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, Ordering},
+};
+use std::{vec, vec::Vec};
+
+use fdt_edit::{Fdt, Node, NodeType, Property};
+use rdif_pinctrl::{
+    ConfigSetting, DriverGeneric, FdtPinctrlParser, FunctionId, GroupId,
+    Interface as PinctrlInterface, MuxSetting, MuxValue, PinConfig, PinDesc, PinFunction, PinGroup,
+    PinId, PinState, PinctrlDevice, PinctrlError,
+};
+use rdrive::{
+    Platform, PlatformDevice, get_one,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+static PINCTRL_APPLIED_BEFORE_PROBE: AtomicBool = AtomicBool::new(false);
+
+struct TestPinctrl {
+    calls: Vec<&'static str>,
+    pins: Vec<PinDesc>,
+    groups: Vec<PinGroup>,
+    functions: Vec<PinFunction>,
+}
+
+impl TestPinctrl {
+    fn new() -> Self {
+        Self {
+            calls: Vec::new(),
+            pins: vec![PinDesc::new(PinId::new(1), None)],
+            groups: vec![PinGroup::new(GroupId::new(1), None, vec![PinId::new(1)])],
+            functions: vec![PinFunction::new(
+                FunctionId::new(1),
+                None,
+                vec![GroupId::new(1)],
+            )],
+        }
+    }
+}
+
+impl DriverGeneric for TestPinctrl {
+    fn name(&self) -> &str {
+        "test-pinctrl"
+    }
+}
+
+impl PinctrlInterface for TestPinctrl {
+    fn pins(&self) -> &[PinDesc] {
+        &self.pins
+    }
+
+    fn groups(&self) -> &[PinGroup] {
+        &self.groups
+    }
+
+    fn functions(&self) -> &[PinFunction] {
+        &self.functions
+    }
+
+    fn apply_mux(&mut self, _setting: &MuxSetting) -> Result<(), PinctrlError> {
+        self.calls.push("mux");
+        Ok(())
+    }
+
+    fn apply_config(&mut self, _setting: &ConfigSetting) -> Result<(), PinctrlError> {
+        self.calls.push("config");
+        Ok(())
+    }
+}
+
+struct TestParser;
+
+impl FdtPinctrlParser for TestParser {
+    fn parse_pinctrl_node(
+        &self,
+        _fdt: &Fdt,
+        node: NodeType<'_>,
+        state: &mut PinState,
+    ) -> Result<(), PinctrlError> {
+        let mut cells = node
+            .as_node()
+            .get_property("test,pins")
+            .ok_or(PinctrlError::InvalidConfig)?
+            .get_u32_iter();
+        state.push_mux(MuxSetting::new(
+            GroupId::new(cells.next().ok_or(PinctrlError::InvalidConfig)?),
+            FunctionId::new(cells.next().ok_or(PinctrlError::InvalidConfig)?),
+            MuxValue::new(cells.next().ok_or(PinctrlError::InvalidConfig)?),
+        ));
+        state.push_config(ConfigSetting::pin(
+            PinId::new(1),
+            PinConfig::DriveStrengthUa(4000),
+        ));
+        Ok(())
+    }
+}
+
+struct FdtConsumerDevice;
+
+impl DriverGeneric for FdtConsumerDevice {
+    fn name(&self) -> &str {
+        "fdt-consumer"
+    }
+}
+
+fn register_test_pinctrl(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(PinctrlDevice::with_fdt_parser(
+            TestPinctrl::new(),
+            TestParser,
+        ));
+    Ok(())
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let pinctrl = get_one::<PinctrlDevice>()
+        .ok_or_else(|| OnProbeError::other("pinctrl should be registered"))?;
+    let pinctrl = pinctrl
+        .lock()
+        .map_err(|err| OnProbeError::other(format!("failed to lock pinctrl: {err}")))?;
+    PINCTRL_APPLIED_BEFORE_PROBE.store(
+        pinctrl
+            .typed_ref::<TestPinctrl>()
+            .is_some_and(|pinctrl| pinctrl.calls == vec!["mux", "config"]),
+        Ordering::SeqCst,
+    );
+
+    let dev: PlatformDevice = probe.into_platform_device();
+    dev.register(FdtConsumerDevice);
+    Ok(())
+}
+
+static PINCTRL_REGISTER: DriverRegister = DriverRegister {
+    name: "test pinctrl provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,pinctrl"],
+        on_probe: register_test_pinctrl,
+    }],
+};
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test pinctrl consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn fdt_probe_applies_default_pinctrl_before_consumer_probe() {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "pinctrl",
+            &[
+                prop_strs("compatible", &["test,pinctrl"]),
+                prop_u32s("phandle", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "uart0-pins",
+            &[
+                prop_u32s("phandle", &[2]),
+                prop_u32s("test,pins", &[1, 1, 7]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "consumer",
+            &[
+                prop_strs("compatible", &["test,consumer"]),
+                prop_strs("pinctrl-names", &["default"]),
+                prop_u32s("pinctrl-0", &[2]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(PINCTRL_REGISTER.clone());
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    probe_all(true).expect("FDT probe should succeed");
+
+    assert!(PINCTRL_APPLIED_BEFORE_PROBE.load(Ordering::SeqCst));
+    assert!(get_one::<FdtConsumerDevice>().is_some());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/rdrive/tests/fdt_pinctrl_error.rs
+++ b/drivers/rdrive/tests/fdt_pinctrl_error.rs
@@ -1,0 +1,144 @@
+use core::ptr::NonNull;
+use std::vec::Vec;
+
+use fdt_edit::{Fdt, Node, NodeType, Property};
+use rdif_pinctrl::{
+    DriverGeneric, FdtPinctrlParser, Interface as PinctrlInterface, PinState, PinctrlDevice,
+    PinctrlError,
+};
+use rdrive::{
+    Platform, PlatformDevice,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+struct TestPinctrl;
+
+impl DriverGeneric for TestPinctrl {
+    fn name(&self) -> &str {
+        "test-pinctrl"
+    }
+}
+
+impl PinctrlInterface for TestPinctrl {}
+
+struct TestParser;
+
+impl FdtPinctrlParser for TestParser {
+    fn parse_pinctrl_node(
+        &self,
+        _fdt: &Fdt,
+        _node: NodeType<'_>,
+        _state: &mut PinState,
+    ) -> Result<(), PinctrlError> {
+        Err(PinctrlError::InvalidConfig)
+    }
+}
+
+struct ShouldNotProbe;
+
+impl DriverGeneric for ShouldNotProbe {
+    fn name(&self) -> &str {
+        "should-not-probe"
+    }
+}
+
+fn register_test_pinctrl(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(PinctrlDevice::with_fdt_parser(TestPinctrl, TestParser));
+    Ok(())
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let dev: PlatformDevice = probe.into_platform_device();
+    dev.register(ShouldNotProbe);
+    Ok(())
+}
+
+static PINCTRL_REGISTER: DriverRegister = DriverRegister {
+    name: "test pinctrl provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,pinctrl"],
+        on_probe: register_test_pinctrl,
+    }],
+};
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "bad pinctrl consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn fdt_probe_reports_bad_default_pinctrl_before_consumer_probe() {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "pinctrl",
+            &[
+                prop_strs("compatible", &["test,pinctrl"]),
+                prop_u32s("phandle", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "consumer",
+            &[
+                prop_strs("compatible", &["test,consumer"]),
+                prop_strs("pinctrl-names", &["default"]),
+                prop_u32s("pinctrl-0", &[99]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(PINCTRL_REGISTER.clone());
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    let err = probe_all(true).expect_err("bad pinctrl phandle should abort consumer probe");
+
+    assert!(format!("{err}").contains("failed to apply default pinctrl"));
+    assert!(rdrive::get_one::<ShouldNotProbe>().is_none());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/soc/rockchip/rockchip-soc/src/variants/rk3588/pinctrl/reg.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/variants/rk3588/pinctrl/reg.rs
@@ -13,6 +13,24 @@ pub(crate) struct PinctrlReg {
 
 unsafe impl Send for PinctrlReg {}
 
+fn rk3588_pull_to_reg_value(pull: Pull) -> Option<u32> {
+    match pull {
+        Pull::Disabled => Some(0),
+        Pull::PullDown => Some(1),
+        Pull::PullUp => Some(3),
+        Pull::BusHold | Pull::PullPinDefault => None,
+    }
+}
+
+fn rk3588_reg_value_to_pull(value: u32) -> Option<Pull> {
+    match value {
+        0 | 2 => Some(Pull::Disabled),
+        1 => Some(Pull::PullDown),
+        3 => Some(Pull::PullUp),
+        _ => None,
+    }
+}
+
 impl PinctrlReg {
     /// 创建新的 pinctrl 实例
     ///
@@ -137,7 +155,8 @@ impl PinctrlReg {
         // Rockchip 写掩码机制
         // 每个 pull 配置占 2 位，掩码为 0x3
         let mask = 0x3u32 << bit_offset;
-        let value = (pull as u32) << bit_offset;
+        let value =
+            rk3588_pull_to_reg_value(pull).ok_or(PinctrlError::InvalidConfig)? << bit_offset;
 
         unsafe {
             let reg_ptr = self.ioc_base.as_ptr().add(reg_offset) as *mut u32;
@@ -272,15 +291,11 @@ impl PinctrlReg {
 
         debug!("get_pull: pull_value={}, mask={:#x}", pull_value, mask);
 
-        // 转换为 Pull 枚举
-        match pull_value {
-            0 => Ok(Pull::Disabled),
-            1 => Ok(Pull::PullUp),
-            2 => Ok(Pull::PullDown),
-            _ => {
-                log::warn!("Invalid pull value {} for pin {}", pull_value, pin.raw());
-                Err(PinctrlError::InvalidConfig)
-            }
+        if let Some(pull) = rk3588_reg_value_to_pull(pull_value) {
+            Ok(pull)
+        } else {
+            log::warn!("Invalid pull value {} for pin {}", pull_value, pin.raw());
+            Err(PinctrlError::InvalidConfig)
         }
     }
 
@@ -319,5 +334,24 @@ impl PinctrlReg {
         debug!("get_drive: drive_value={}, mask={:#x}", drive_value, mask);
 
         Ok(drive_value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rk3588_pull_encoding_matches_linux_1v8_only_table() {
+        assert_eq!(rk3588_pull_to_reg_value(Pull::Disabled), Some(0));
+        assert_eq!(rk3588_pull_to_reg_value(Pull::PullDown), Some(1));
+        assert_eq!(rk3588_pull_to_reg_value(Pull::PullUp), Some(3));
+        assert_eq!(rk3588_pull_to_reg_value(Pull::BusHold), None);
+        assert_eq!(rk3588_pull_to_reg_value(Pull::PullPinDefault), None);
+
+        assert_eq!(rk3588_reg_value_to_pull(0), Some(Pull::Disabled));
+        assert_eq!(rk3588_reg_value_to_pull(1), Some(Pull::PullDown));
+        assert_eq!(rk3588_reg_value_to_pull(2), Some(Pull::Disabled));
+        assert_eq!(rk3588_reg_value_to_pull(3), Some(Pull::PullUp));
     }
 }


### PR DESCRIPTION
## 背景

RK3588 SD/MMC 和 USB DWC consumer driver 里还残留手写 pinctrl 路径：普通设备需要知道 `RockchipPinCtrl`/`RockchipFdtPinctrlParser`，SDHCI/eMMC 里还保留过时的 `/__symbols__` fallback。Linux 的对应行为是由 pinctrl/regulator core 在 provider 注册后统一处理 default state 和 boot/always-on fixed regulator，consumer driver 不应直接拼 SoC-specific pinctrl 细节。

## 改动

- 在 `rdif-pinctrl` 中扩展 `PinctrlDevice`，保存可选 FDT parser，并提供 `apply_fdt_default_state()` 与 `apply_fdt_fixed_regulator()` 高级接口。
- 在 `rdrive` FDT probe 流程中，在 `on_probe` 前统一尝试应用 consumer node 的 `pinctrl-0`；无 pinctrl provider、无 parser、无 `pinctrl-0` 均按正常跳过处理，解析或 apply 失败按 probe error 传播。
- Rockchip pinctrl provider 注册时绑定 `RockchipFdtPinctrlParser`，普通 consumer driver 不再 downcast 到 `RockchipPinCtrl`。
- 清理 RK3588 SDHCI/DWMMC consumer 侧手写 default pinctrl 和过时 `/__symbols__` fallback；保留 controller PHY/DLL/phase tuning 等内部初始化语义。
- 新增通用 `regulator-fixed` FDT probe：只对 `regulator-boot-on` 或 `regulator-always-on` 的 fixed regulator，通过 `PinctrlDevice::apply_fdt_fixed_regulator()` 自动启用 GPIO/pinctrl；非 boot/always-on regulator 不会被无条件拉高。
- 清理 USB DWC driver 中的 VBUS 手写 pinctrl 代码，删除 `phy-supply` 保存、`enable_vbus()` 以及对 `PinctrlDevice`/`FdtPinctrl`/`RockchipFdtPinctrlParser` 的直接依赖，改由 fixed regulator 自动 probe 处理 `vcc5v0-host`。
- 按 Linux `PULL_TYPE_IO_1V8_ONLY` 逻辑修正 RK3588 pull 寄存器编码，避免把 generic pinconf 值直接当硬件字段写入。
- 增加 `rdif-pinctrl`、`rdrive` 和 Rockchip pinctrl 的 default/fixed-regulator/错误路径回归测试。

## 验证

- `cargo fmt --check`
- `git diff --check origin/dev...HEAD`
- `cargo xtask clippy --package rdif-pinctrl`：2/2 passed
- `cargo xtask clippy --package rdrive`：1/1 passed
- `cargo xtask clippy --package rockchip-soc`：1/1 passed
- `cargo xtask clippy --package ax-driver`：46/46 passed
- `cargo test -p rdif-pinctrl --features fdt`：19 passed
- `cargo xtask board ls`：OrangePi-5-Plus 1/1 available
- `cargo xtask starry app board -t block-rw-bench --board-config board-orangepi-5-plus.toml -b OrangePi-5-Plus`：三组 `verify=ok`，最终 `block-rw-bench: done cases=3 status=ok`
- `cargo xtask starry app board -t orangepi-5-plus-uvc-rknn -b OrangePi-5-Plus`：`stream-rknn: streaming started`，3 次 YOLO 推理，`decode_errors=0 inference_errors=0`，最终 `UVC_RKNN_STREAM_DONE`
- `cargo xtask starry app board -t orangepi-5-plus-uvc-rknn --board-config /tmp/uvc-rknn-bench-done.toml -b OrangePi-5-Plus`：使用与仓库 bench config 相同命令，仅将 success regex 收敛到最终 marker；结果为 `UVC_RKNN_VALIDATE_PASS images=3`，`UVC_RKNN_BENCH_RESULT duration_sec=60.3 captured=761 inferences=385 decode_errors=0 inference_errors=0`，最终 `UVC_RKNN_BENCH_DONE`

板端日志中仍可看到未使用的 PCIe 链路 down 和一个 SDHCI/eMMC timeout warning，但 `rockchip-sd`、USB UVC、RKNN 推理均完成上述正确性验证。
