### PR TITLE
fix(ci): disable self-hosted rust cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
             command: cargo xtask clippy --since "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}"
-            cache_key: clippy
+            cache_key: ""
             container_image: base
             fetch_depth: full
             download_xtask_bin_artifact: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 - Do not silence clippy warnings with `allow` as a shortcut; prefer fixing the root cause unless the user explicitly asks otherwise.
 - Run `cargo fmt` after code edits.
 - When fixing a bug, first add a deterministic regression test that necessarily fails on the buggy implementation, verify the failure, then implement or restore the fix and verify the same test passes. Do not rely only on post-fix validation, probabilistic reproducers, or relaxed tests.
+- For self-hosted CI matrix entries in `.github/workflows/ci.yml`, keep `cache_key` as an empty string (`cache_key: ""`). Non-empty values enable the rust-cache step on self-hosted runners, which can remove Rust/Cargo state and break later jobs.
 - For ArceOS, StarryOS, and Axvisor builds/tests/runs, prefer the `cargo xtask` command family instead of raw `cargo build`, `cargo test`, or `cargo run`.
 - If `cargo xtask` cannot satisfy a special configuration, inspect the `xtask` flow first and only then fall back to native Cargo commands with manually matched arguments.
 - When resolving rebase or merge conflicts, do not manually merge conflicted `Cargo.lock` contents. Resolve all other conflicts first, then regenerate `Cargo.lock` with Cargo and verify the generated lockfile.


### PR DESCRIPTION
## 问题

self-hosted CI job 如果设置非空 `cache_key`，会触发 `reusable-command.yml` 里的 `Swatinem/rust-cache` 步骤；在 self-hosted runner 上这可能清理 Rust/Cargo 状态，影响后续任务。

## 修改

- 将 self-hosted clippy job 的 `cache_key` 从 `clippy` 改为空字符串，避免在 self-hosted runner 上启用 rust-cache。
- 在 `AGENTS.md` 中记录 self-hosted CI matrix entry 的 `cache_key` 必须保持为空字符串，避免后续误改。

## 验证

- `python3` 临时检查确认 `.github/workflows/ci.yml` 中 19 个 self-hosted matrix entry 的 `cache_key` 都是空字符串。
- `python3` + PyYAML 成功解析 `.github/workflows/ci.yml`。
- `git diff --check` 通过。