### PR TITLE
refactor(axvm): move VM boot and memory preparation into axvm

### DIFF
--- a/os/axvisor/src/config.rs
+++ b/os/axvisor/src/config.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use alloc::format;
-use core::alloc::Layout;
 #[cfg(all(
     feature = "fs",
     any(target_arch = "x86_64", target_arch = "loongarch64")
@@ -24,13 +23,13 @@ use ax_errno::{AxResult, ax_err_type};
 #[cfg(all(feature = "fs", target_arch = "x86_64"))]
 use axvm::InterruptTriggerMode;
 use axvm::{
-    AxVM, AxVMRef, GuestPhysAddr, VMMemoryRegion,
+    AxVM, GuestPhysAddr,
     config::{
-        AxVCpuConfig, AxVMConfig, AxVMConfigParams, PhysCpuList, RamdiskInfo, VMBootProtocol,
-        VMImageConfig, adjusted_kernel_load_gpa,
+        AxVCpuConfig, AxVMConfig, AxVMConfigParams, GuestBootPolicy, PhysCpuList, RamdiskInfo,
+        VMBootProtocol, VMImageConfig,
     },
 };
-use axvmconfig::{AxVMCrateConfig, VMType, VmMemConfig, VmMemMappingType};
+use axvmconfig::{AxVMCrateConfig, VMType};
 
 #[cfg(any(
     target_arch = "aarch64",
@@ -148,6 +147,10 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
     let skip_guest_address_adjustment = x86_linux_direct_boot_config(&vm_create_config);
     #[cfg(not(target_arch = "x86_64"))]
     let skip_guest_address_adjustment = false;
+    vm_config.set_boot_policy(guest_boot_policy(
+        &vm_create_config,
+        skip_guest_address_adjustment,
+    ));
 
     // info!("after parse_vm_interrupt, crate VM[{}] with config: {:#?}", vm_config.id(), vm_config);
     info!("Creating VM[{}] {:?}", vm_config.id(), vm_config.name());
@@ -157,21 +160,8 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
         .map_err(|e| ax_err_type!(InvalidData, format!("Failed to create VM: {e:?}")))?;
     let vm_id = vm.id();
 
-    vm_alloc_memory_regions(&vm_create_config, &vm)?;
-
-    let main_mem = vm
-        .memory_regions()
-        .first()
-        .cloned()
-        .ok_or_else(|| ax_err_type!(InvalidData, "VM must have at least one memory region"))?;
-
-    if !skip_guest_address_adjustment {
-        config_guest_address(
-            &vm,
-            &main_mem,
-            vm_create_config.kernel.effective_boot_protocol(),
-        );
-    }
+    let memory_layout = vm.prepare_memory_layout()?;
+    let main_mem = memory_layout.main_memory().clone();
 
     // Load corresponding images for VM.
     info!("VM[{}] created success, loading images...", vm.id());
@@ -244,8 +234,23 @@ pub(crate) fn build_axvm_config(cfg: &AxVMCrateConfig) -> AxVMConfig {
         reserved_address_ranges: Vec::new(),
         pass_through_ports: cfg.devices.passthrough_ports.clone(),
         address_space_policy: cfg.devices.address_space_policy,
+        memory_regions: cfg.kernel.memory_regions.clone(),
+        boot_policy: GuestBootPolicy::KeepConfigured,
         interrupt_mode: cfg.devices.interrupt_mode,
     })
+}
+
+fn guest_boot_policy(
+    cfg: &AxVMCrateConfig,
+    skip_guest_address_adjustment: bool,
+) -> GuestBootPolicy {
+    if skip_guest_address_adjustment {
+        GuestBootPolicy::KeepConfigured
+    } else {
+        GuestBootPolicy::AdjustKernelForBootProtocol {
+            protocol: cfg.kernel.effective_boot_protocol(),
+        }
+    }
 }
 
 fn configured_bios_load_gpa(cfg: &AxVMCrateConfig) -> Option<GuestPhysAddr> {
@@ -405,74 +410,7 @@ fn x86_intx_forwarding_trigger(binding: &ax_driver::BindingIrq) -> InterruptTrig
     }
 }
 
-fn config_guest_address(vm: &AxVMRef, main_memory: &VMMemoryRegion, boot_protocol: VMBootProtocol) {
-    vm.with_config(|config| {
-        if let Some(kernel_addr) = adjusted_kernel_load_gpa(
-            main_memory,
-            boot_protocol,
-            config.image_config.bios_load_gpa,
-        ) {
-            debug!(
-                "Adjusting kernel load address from {:#x} to {:#x}",
-                config.image_config.kernel_load_gpa, kernel_addr
-            );
-            config.relocate_kernel_image(kernel_addr);
-        }
-    });
-}
-
 #[cfg(target_arch = "x86_64")]
 fn x86_linux_direct_boot_config(config: &AxVMCrateConfig) -> bool {
     crate::images::is_x86_linux_image_config(config)
-}
-
-fn vm_alloc_memory_regions(vm_create_config: &AxVMCrateConfig, vm: &AxVMRef) -> AxResult {
-    const MB: usize = 1024 * 1024;
-    const ALIGN: usize = 2 * MB;
-
-    let make_layout = |memory: &VmMemConfig| {
-        Layout::from_size_align(memory.size, ALIGN).map_err(|e| {
-            ax_err_type!(
-                InvalidInput,
-                format!("Invalid VM memory layout {:?}: {e:?}", memory)
-            )
-        })
-    };
-
-    for memory in &vm_create_config.kernel.memory_regions {
-        match memory.map_type {
-            VmMemMappingType::MapAlloc => {
-                vm.alloc_memory_region(make_layout(memory)?, Some(GuestPhysAddr::from(memory.gpa)))
-                    .map_err(|e| {
-                        ax_err_type!(
-                            NoMemory,
-                            format!("Failed to allocate memory region for VM: {e:?}")
-                        )
-                    })?;
-            }
-            VmMemMappingType::MapIdentical => {
-                vm.alloc_memory_region(make_layout(memory)?, None)
-                    .map_err(|e| {
-                        ax_err_type!(
-                            NoMemory,
-                            format!("Failed to allocate memory region for VM: {e:?}")
-                        )
-                    })?;
-            }
-            VmMemMappingType::MapReserved => {
-                debug!("VM[{}] map same region: {:#x?}", vm.id(), memory);
-                vm.map_reserved_memory_region(
-                    make_layout(memory)?,
-                    Some(GuestPhysAddr::from(memory.gpa)),
-                )
-                .map_err(|e| {
-                    ax_err_type!(
-                        NoMemory,
-                        format!("Failed to map memory region for VM: {e:?}")
-                    )
-                })?;
-            }
-        }
-    }
-    Ok(())
 }

--- a/os/axvisor/src/config.rs
+++ b/os/axvisor/src/config.rs
@@ -22,11 +22,13 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use ax_errno::{AxResult, ax_err_type};
 #[cfg(all(feature = "fs", target_arch = "x86_64"))]
 use axvm::InterruptTriggerMode;
+#[cfg(any(target_arch = "x86_64", target_arch = "loongarch64"))]
+use axvm::config::VMBootProtocol;
 use axvm::{
     AxVM, GuestPhysAddr,
     config::{
         AxVCpuConfig, AxVMConfig, AxVMConfigParams, GuestBootPolicy, PhysCpuList, RamdiskInfo,
-        VMBootProtocol, VMImageConfig,
+        VMImageConfig,
     },
 };
 use axvmconfig::{AxVMCrateConfig, VMType};
@@ -143,6 +145,8 @@ pub fn init_guest_vm(raw_cfg: &str) -> AxResult<usize> {
     #[cfg(target_arch = "loongarch64")]
     handle_fdt_operations(&mut vm_config, &mut vm_create_config)?;
 
+    sync_axvm_config_from_crate_config(&mut vm_config, &vm_create_config);
+
     #[cfg(target_arch = "x86_64")]
     let skip_guest_address_adjustment = x86_linux_direct_boot_config(&vm_create_config);
     #[cfg(not(target_arch = "x86_64"))]
@@ -238,6 +242,10 @@ pub(crate) fn build_axvm_config(cfg: &AxVMCrateConfig) -> AxVMConfig {
         boot_policy: GuestBootPolicy::KeepConfigured,
         interrupt_mode: cfg.devices.interrupt_mode,
     })
+}
+
+fn sync_axvm_config_from_crate_config(vm_config: &mut AxVMConfig, cfg: &AxVMCrateConfig) {
+    vm_config.set_memory_regions(cfg.kernel.memory_regions.clone());
 }
 
 fn guest_boot_policy(
@@ -413,4 +421,45 @@ fn x86_intx_forwarding_trigger(binding: &ax_driver::BindingIrq) -> InterruptTrig
 #[cfg(target_arch = "x86_64")]
 fn x86_linux_direct_boot_config(config: &AxVMCrateConfig) -> bool {
     crate::images::is_x86_linux_image_config(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axvmconfig::{VmMemConfig, VmMemMappingType};
+
+    fn memory_region(gpa: usize, size: usize, map_type: VmMemMappingType) -> VmMemConfig {
+        VmMemConfig {
+            gpa,
+            size,
+            flags: 0x7,
+            map_type,
+        }
+    }
+
+    #[test]
+    fn sync_axvm_config_keeps_fdt_reserved_memory_regions() {
+        let mut crate_config = AxVMCrateConfig::default();
+        crate_config.kernel.memory_regions.push(memory_region(
+            0x8000_0000,
+            0x200000,
+            VmMemMappingType::MapIdentical,
+        ));
+        let mut vm_config = build_axvm_config(&crate_config);
+
+        crate_config.kernel.memory_regions.push(memory_region(
+            0x110000,
+            0x10000,
+            VmMemMappingType::MapReserved,
+        ));
+        assert_eq!(vm_config.memory_regions().len(), 1);
+
+        sync_axvm_config_from_crate_config(&mut vm_config, &crate_config);
+
+        let regions = vm_config.memory_regions();
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[1].gpa, 0x110000);
+        assert_eq!(regions[1].size, 0x10000);
+        assert_eq!(regions[1].map_type, VmMemMappingType::MapReserved);
+    }
 }

--- a/virtualization/axvm/src/config.rs
+++ b/virtualization/axvm/src/config.rs
@@ -22,9 +22,16 @@ pub use axvm_types::{
     VMInterruptMode, VMType, VmMemConfig, VmMemMappingType,
 };
 
-use crate::VMMemoryRegion;
-
-const BIOS_RESERVED_SIZE: usize = 2 * 1024 * 1024;
+/// Policy used by AxVM when deriving runtime guest boot image addresses.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GuestBootPolicy {
+    /// Keep the load addresses exactly as provided by the VM config.
+    #[default]
+    KeepConfigured,
+    /// Adjust the kernel load address for boot protocols that require a
+    /// reserved area inside the primary guest memory region.
+    AdjustKernelForBootProtocol { protocol: VMBootProtocol },
+}
 
 /// A part of `AxVMConfig`, which represents a `VCpu`.
 #[derive(Clone, Copy, Debug, Default)]
@@ -87,6 +94,8 @@ pub struct AxVMConfig {
     reserved_address_ranges: Vec<ReservedAddressConfig>,
     pass_through_ports: Vec<PassThroughPortConfig>,
     address_space_policy: AddressSpacePolicy,
+    memory_regions: Vec<VmMemConfig>,
+    boot_policy: GuestBootPolicy,
     // TODO: improve interrupt passthrough
     spi_list: Vec<u32>,
     interrupt_mode: VMInterruptMode,
@@ -108,27 +117,9 @@ pub struct AxVMConfigParams {
     pub reserved_address_ranges: Vec<ReservedAddressConfig>,
     pub pass_through_ports: Vec<PassThroughPortConfig>,
     pub address_space_policy: AddressSpacePolicy,
+    pub memory_regions: Vec<VmMemConfig>,
+    pub boot_policy: GuestBootPolicy,
     pub interrupt_mode: VMInterruptMode,
-}
-
-pub fn adjusted_kernel_load_gpa(
-    main_memory: &VMMemoryRegion,
-    boot_protocol: VMBootProtocol,
-    bios_load_gpa: Option<GuestPhysAddr>,
-) -> Option<GuestPhysAddr> {
-    if boot_protocol == VMBootProtocol::Uefi {
-        return None;
-    }
-
-    if !main_memory.is_identical() {
-        return None;
-    }
-
-    let mut kernel_addr = main_memory.gpa;
-    if boot_protocol == VMBootProtocol::Multiboot && bios_load_gpa.is_some() {
-        kernel_addr += BIOS_RESERVED_SIZE;
-    }
-    Some(kernel_addr)
 }
 
 impl AxVMConfig {
@@ -147,6 +138,8 @@ impl AxVMConfig {
             reserved_address_ranges: params.reserved_address_ranges,
             pass_through_ports: params.pass_through_ports,
             address_space_policy: params.address_space_policy,
+            memory_regions: params.memory_regions,
+            boot_policy: params.boot_policy,
             spi_list: Vec::new(),
             interrupt_mode: params.interrupt_mode,
         }
@@ -238,22 +231,21 @@ impl AxVMConfig {
     pub fn address_space_policy(&self) -> AddressSpacePolicy {
         self.address_space_policy
     }
-    // /// Returns configurations related to VM memory regions.
-    // pub fn memory_regions(&self) -> Vec<VmMemConfig> {
-    //     &self.memory_regions
-    // }
 
-    // /// Adds a new memory region to the VM configuration.
-    // pub fn add_memory_region(&mut self, region: VmMemConfig) {
-    //     self.memory_regions.push(region);
-    // }
+    /// Returns configurations related to VM memory regions.
+    pub fn memory_regions(&self) -> &[VmMemConfig] {
+        &self.memory_regions
+    }
 
-    // /// Checks if the VM memory regions contain a specific range.
-    // pub fn contains_memory_range(&self, range: &Range<usize>) -> bool {
-    //     self.memory_regions
-    //         .iter()
-    //         .any(|region| region.gpa <= range.start && region.gpa + region.size >= range.end)
-    // }
+    /// Returns the policy used to adjust runtime boot image addresses.
+    pub fn boot_policy(&self) -> GuestBootPolicy {
+        self.boot_policy
+    }
+
+    /// Sets the policy used to adjust runtime boot image addresses.
+    pub fn set_boot_policy(&mut self, boot_policy: GuestBootPolicy) {
+        self.boot_policy = boot_policy;
+    }
 
     /// Returns configurations related to VM emulated devices.
     pub fn emu_devices(&self) -> &Vec<EmulatedDeviceConfig> {

--- a/virtualization/axvm/src/config.rs
+++ b/virtualization/axvm/src/config.rs
@@ -237,6 +237,11 @@ impl AxVMConfig {
         &self.memory_regions
     }
 
+    /// Replaces configurations related to VM memory regions.
+    pub fn set_memory_regions(&mut self, memory_regions: Vec<VmMemConfig>) {
+        self.memory_regions = memory_regions;
+    }
+
     /// Returns the policy used to adjust runtime boot image addresses.
     pub fn boot_policy(&self) -> GuestBootPolicy {
         self.boot_policy
@@ -413,5 +418,39 @@ impl PhysCpuList {
     /// Sets the CPU IDs exposed to the guest.
     pub fn set_guest_phys_cpu_ids(&mut self, phys_cpu_ids: Vec<usize>) {
         self.phys_cpu_ids = Some(phys_cpu_ids);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    fn memory_region(gpa: usize, size: usize, map_type: VmMemMappingType) -> VmMemConfig {
+        VmMemConfig {
+            gpa,
+            size,
+            flags: 0x7,
+            map_type,
+        }
+    }
+
+    #[test]
+    fn set_memory_regions_replaces_stale_snapshot_after_config_enrichment() {
+        let main_memory = memory_region(0x8000_0000, 0x200000, VmMemMappingType::MapIdentical);
+        let reserved_memory = memory_region(0x110000, 0x10000, VmMemMappingType::MapReserved);
+        let mut config = AxVMConfig::default_for_test(1, "linux");
+
+        config.set_memory_regions(vec![main_memory.clone()]);
+        assert_eq!(config.memory_regions().len(), 1);
+
+        config.set_memory_regions(vec![main_memory, reserved_memory]);
+
+        let regions = config.memory_regions();
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[1].gpa, 0x110000);
+        assert_eq!(regions[1].size, 0x10000);
+        assert_eq!(regions[1].map_type, VmMemMappingType::MapReserved);
     }
 }

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -61,7 +61,7 @@ pub use runtime::loongarch_irq::{
     unregister_guest_irq_routes as unregister_loongarch_guest_irq_routes,
 };
 pub use task::{AsVCpuTask, VCpuTask};
-pub use vm::{AxVCpuRef, AxVM, AxVMRef, FwCfgDeviceConfig, VMMemoryRegion};
+pub use vm::{AxVCpuRef, AxVM, AxVMRef, FwCfgDeviceConfig, PreparedMemoryLayout, VMMemoryRegion};
 
 /// The architecture-independent per-CPU type.
 pub type AxVMPerCpu = axvcpu::AxPerCpu<vcpu::AxVMArchPerCpuImpl>;

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -23,35 +23,25 @@ use ax_errno::{AxError, AxResult, ax_err, ax_err_type};
 use ax_kspin::SpinNoIrq as Mutex;
 use ax_memory_addr::align_up_4k;
 use axaddrspace::{AddrSpace, MappingFlags};
-use axdevice::{
-    AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceFactoryRegistry, FwCfg,
-    FwCfgPlatformConfig, register_builtin_factories,
-};
-#[cfg(target_arch = "aarch64")]
-use axdevice_base::DeviceRegistry as _;
-#[cfg(target_arch = "x86_64")]
-use axdevice_base::DeviceRegistry as _;
-use axdevice_base::{AccessWidth, Resource};
-#[cfg(target_arch = "x86_64")]
-use axdevice_base::{BaseDeviceOps, PortDeviceAdapter};
+use axdevice::{AxVmDevices, FwCfg, FwCfgPlatformConfig};
+use axdevice_base::AccessWidth;
 use axvcpu::{AxArchVCpu, AxVCpu, AxVCpuExitReason, VCpuState};
-#[cfg(target_arch = "x86_64")]
-use axvm_types::EmulatedDeviceType;
 use axvm_types::{GuestPhysAddr, HostPhysAddr, HostVirtAddr};
-#[cfg(all(target_arch = "x86_64", feature = "vmx"))]
-use x86_vcpu::{X86_APIC_ACCESS_GPA, x86_apic_access_page_addr};
 
-#[cfg(not(target_arch = "x86_64"))]
-use crate::vcpu::AxVCpuCreateConfig;
 use crate::{
     boot::{GuestBootDescription, GuestFdtBuilder},
     config::{AxVMConfig, PhysCpuList, VMInterruptMode},
     host::paging::{HostPagingHandler, virt_to_phys},
     irq::InterruptFabric,
-    layout::{GuestOwnedRegion, VmAddressLayout, VmRegionKind, build_address_layout},
+    layout::VmAddressLayout,
     lifecycle::{Machine, StopReason, VmLifecycleError, VmStatus},
     vcpu::AxArchVCpuImpl,
 };
+
+pub(crate) mod boot;
+pub(crate) mod memory;
+mod prepare;
+pub use memory::PreparedMemoryLayout;
 
 const VM_ASPACE_BASE: usize = 0x0;
 const VM_ASPACE_SIZE: usize = 0x7fff_ffff_f000;
@@ -415,344 +405,6 @@ impl AxVM {
         let _ = self.ensure_resources_ready();
         self.with_resources(|resources| Ok(resources.config.interrupt_mode()))
             .unwrap_or(VMInterruptMode::NoIrq)
-    }
-
-    /// Sets up the VM before booting.
-    pub fn prepare(&self) -> AxResult {
-        self.ensure_resources_ready()?;
-        let mut factories = DeviceFactoryRegistry::new();
-        register_builtin_factories(&mut factories)?;
-        let interrupt_mode = self.interrupt_mode();
-        #[cfg(target_arch = "riscv64")]
-        let interrupt_fabric = {
-            let machine = self.machine.lock();
-            let resources = machine.resources().ok_or_else(|| {
-                ax_err_type!(
-                    BadState,
-                    "VM resources are not available for RISC-V IRQ setup"
-                )
-            })?;
-            crate::irq::riscv::configure(
-                &mut factories,
-                interrupt_mode,
-                resources.config.emu_devices(),
-            )?
-        };
-        #[cfg(not(target_arch = "riscv64"))]
-        let interrupt_fabric = InterruptFabric::new(interrupt_mode);
-
-        self.prepare_with_factories(&factories, interrupt_fabric)
-    }
-
-    /// Sets up the VM with explicit device factories and an interrupt fabric.
-    pub fn prepare_with_factories(
-        &self,
-        factories: &DeviceFactoryRegistry,
-        interrupt_fabric: InterruptFabric,
-    ) -> AxResult {
-        self.ensure_resources_ready()?;
-        let mut machine = self.machine.lock();
-        if !matches!(machine.status(), VmStatus::Ready | VmStatus::Stopped) {
-            return ax_err!(
-                BadState,
-                format!(
-                    "VM[{}] cannot prepare from {:?}",
-                    self.id(),
-                    machine.status()
-                )
-            );
-        }
-        let resources = machine
-            .resources_mut()
-            .ok_or_else(|| ax_err_type!(BadState, "VM resources are not available for prepare"))?;
-        if resources.vcpu_list.is_some()
-            || resources.devices.is_some()
-            || resources.interrupt_fabric.is_some()
-        {
-            resources.reset_transient_resources()?;
-        }
-        interrupt_fabric.validate_mode(resources.config.interrupt_mode())?;
-
-        let dtb_addr = resources.config.image_config().dtb_load_gpa;
-        let vcpu_id_pcpu_sets = resources.config.phys_cpu_ls.get_vcpu_affinities_pcpu_ids();
-        #[cfg(target_arch = "loongarch64")]
-        let loongarch_iocsr_state = {
-            let vcpu_state_count = vcpu_id_pcpu_sets
-                .iter()
-                .map(|(vcpu_id, ..)| *vcpu_id)
-                .max()
-                .map_or(0, |vcpu_id| vcpu_id + 1);
-            loongarch_vcpu::LoongArchIocsrState::new(vcpu_state_count)?
-        };
-
-        debug!("dtb_load_gpa: {dtb_addr:?}");
-        debug!("id: {}, VCpuIdPCpuSets: {vcpu_id_pcpu_sets:#x?}", self.id());
-
-        let mut vcpu_list = Vec::with_capacity(vcpu_id_pcpu_sets.len());
-        for (vcpu_id, phys_cpu_set, _pcpu_id) in vcpu_id_pcpu_sets {
-            #[cfg(target_arch = "aarch64")]
-            let arch_config = AxVCpuCreateConfig {
-                mpidr_el1: _pcpu_id as _,
-                dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
-            };
-            #[cfg(target_arch = "riscv64")]
-            let arch_config = AxVCpuCreateConfig {
-                hart_id: vcpu_id as _,
-                dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
-            };
-            #[cfg(target_arch = "loongarch64")]
-            let arch_config = AxVCpuCreateConfig {
-                cpu_id: vcpu_id,
-                dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
-                boot_args: resources.config.cpu_config.boot_args,
-                boot_stack_top: resources.config.cpu_config.boot_stack_top,
-                firmware_boot: resources.config.cpu_config.firmware_boot,
-                iocsr_state: loongarch_iocsr_state.clone(),
-            };
-
-            // FIXME: VCpu is neither `Send` nor `Sync` by design, check whether
-            // 1. we should make it `Send` and `Sync`, or
-            // 2. we can guarantee that no cross-thread access is performed
-            #[allow(clippy::arc_with_non_send_sync)]
-            vcpu_list.push(Arc::new(VCpu::new(
-                self.id(),
-                vcpu_id,
-                0, // Currently not used.
-                phys_cpu_set,
-                #[cfg(target_arch = "aarch64")]
-                arch_config,
-                #[cfg(target_arch = "loongarch64")]
-                arch_config,
-                #[cfg(target_arch = "riscv64")]
-                arch_config,
-                #[cfg(target_arch = "x86_64")]
-                (),
-            )?));
-        }
-
-        let mut devices = {
-            let build_context = DeviceBuildContext::new(&interrupt_fabric);
-            axdevice::AxVmDevices::build_with_factories(
-                AxVmDeviceConfig {
-                    emu_configs: resources.config.emu_devices().to_vec(),
-                },
-                factories,
-                &build_context,
-            )?
-        };
-
-        #[cfg(target_arch = "x86_64")]
-        for port in resources.config.pass_through_ports() {
-            let passthrough = Arc::new(crate::host::x86_port::HostPortPassthrough::new(
-                port.base,
-                port.length,
-            )?);
-            let range = passthrough.address_range();
-            debug!(
-                "PT port region: [{:#x}~{:#x}]",
-                range.start.number(),
-                range.end.number(),
-            );
-            devices
-                .register(PortDeviceAdapter::from_arc(passthrough))
-                .map_err(|err| ax_err_type!(InvalidInput, format!("register PT port: {err:?}")))?;
-        }
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
-            if passthrough {
-                let spis = resources.config.pass_through_spis();
-                let cpu_id = self.id() - 1; // FIXME: get the real CPU id.
-                let mut gicd_found = false;
-
-                for device in devices.devices() {
-                    if let Some(gicd) = device.as_any().downcast_ref::<arm_vgic::v3::vgicd::VGicD>()
-                    {
-                        debug!("VGicD found, assigning SPIs...");
-
-                        for spi in spis {
-                            gicd.assign_irq(*spi + 32, cpu_id, (0, 0, 0, cpu_id as _))
-                        }
-
-                        gicd_found = true;
-                        break;
-                    }
-                }
-
-                if !gicd_found {
-                    warn!("Failed to assign SPIs: No VGicD found in device list");
-                }
-            } else {
-                // non-passthrough mode, we need to set up the virtual timer.
-                #[cfg(target_arch = "aarch64")]
-                for dev in axdevice::create_vtimer_devices() {
-                    devices
-                        .register(Arc::from(dev) as Arc<dyn axdevice_base::Device>)
-                        .map_err(|e| {
-                            ax_err_type!(InvalidInput, format!("register vtimer: {e:?}"))
-                        })?;
-                }
-                #[cfg(not(target_arch = "aarch64"))]
-                let _ = (); // silence unused warning on non-aarch64
-            }
-        }
-
-        self.add_special_emulated_devices(&mut devices)?;
-
-        if dtb_addr.is_some() && resources.boot_description.device_tree().is_none() {
-            return ax_err!(
-                InvalidInput,
-                "DTB load GPA is configured but no guest device tree bytes are registered"
-            );
-        }
-
-        let owned_regions = Self::guest_owned_regions(resources);
-        let emulated_resources = devices
-            .devices()
-            .flat_map(|device| device.resources().iter().cloned())
-            .collect::<Vec<Resource>>();
-        let address_layout = build_address_layout(
-            resources.config.address_space_policy(),
-            VM_ASPACE_BASE,
-            VM_ASPACE_SIZE,
-            resources.config.pass_through_devices(),
-            resources.config.pass_through_addresses(),
-            &owned_regions,
-            &emulated_resources,
-        )?;
-
-        for mapping in address_layout.mappings() {
-            debug!(
-                "VM[{}] stage2 {:?}: [{:#x}, {:#x}) -> [{:#x}, {:#x}) {:?}",
-                self.id(),
-                mapping.kind,
-                mapping.gpa.as_usize(),
-                mapping.gpa.as_usize() + mapping.size,
-                mapping.hpa.as_usize(),
-                mapping.hpa.as_usize() + mapping.size,
-                mapping.flags
-            );
-            resources.address_space.map_linear(
-                mapping.gpa,
-                mapping.hpa,
-                mapping.size,
-                mapping.flags,
-            )?;
-        }
-        resources.address_layout = Some(address_layout);
-
-        #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
-        resources.address_space.map_linear(
-            GuestPhysAddr::from(X86_APIC_ACCESS_GPA),
-            x86_apic_access_page_addr(),
-            ax_memory_addr::PAGE_SIZE_4K,
-            MappingFlags::DEVICE | MappingFlags::READ | MappingFlags::WRITE,
-        )?;
-
-        // Setup VCpus.
-        for vcpu in &vcpu_list {
-            #[cfg(target_arch = "aarch64")]
-            let setup_config = {
-                let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
-                crate::vcpu::AxVCpuSetupConfig {
-                    passthrough_interrupt: passthrough,
-                    passthrough_timer: passthrough,
-                }
-            };
-            #[cfg(target_arch = "loongarch64")]
-            let setup_config = {
-                let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
-                crate::vcpu::AxVCpuSetupConfig {
-                    passthrough_interrupt: passthrough,
-                    passthrough_timer: passthrough,
-                    boot_args: resources.config.cpu_config.boot_args,
-                    boot_stack_top: resources.config.cpu_config.boot_stack_top,
-                    firmware_boot: resources.config.cpu_config.firmware_boot,
-                }
-            };
-            #[cfg(not(any(
-                target_arch = "aarch64",
-                target_arch = "loongarch64",
-                target_arch = "x86_64"
-            )))]
-            #[allow(clippy::let_unit_value)]
-            let setup_config = <AxArchVCpuImpl as axvcpu::AxArchVCpu>::SetupConfig::default();
-            #[cfg(target_arch = "x86_64")]
-            let setup_config = {
-                let mut config = crate::vcpu::AxVCpuSetupConfig {
-                    emulate_com1: resources
-                        .config
-                        .emu_devices()
-                        .iter()
-                        .any(|dev| dev.emu_type == EmulatedDeviceType::Console),
-                    ..Default::default()
-                };
-                for port in resources.config.pass_through_ports() {
-                    config.add_passthrough_port_range(port.base, port.length)?;
-                }
-                config
-            };
-
-            let entry = if vcpu.id() == 0 {
-                resources.config.bsp_entry()
-            } else {
-                resources.config.ap_entry()
-            };
-
-            debug!("Setting up vCPU[{}] entry at {:#x}", vcpu.id(), entry);
-
-            vcpu.setup(
-                entry,
-                resources.address_space.page_table_root(),
-                setup_config,
-            )?;
-        }
-
-        resources.phys_cpu_ls = resources.config.phys_cpu_ls.clone();
-        resources.vcpu_list = Some(vcpu_list.into_boxed_slice());
-        resources.devices = Some(Arc::new(devices));
-        resources.interrupt_fabric = Some(interrupt_fabric);
-
-        info!("VM setup: id={}", self.id());
-        Ok(())
-    }
-
-    fn guest_owned_regions(resources: &AxVMResources) -> Vec<GuestOwnedRegion> {
-        let mut regions = resources
-            .memory_regions
-            .iter()
-            .map(|region| {
-                GuestOwnedRegion::new(region.gpa.as_usize(), region.size(), VmRegionKind::Memory)
-            })
-            .collect::<Vec<_>>();
-
-        regions.extend(
-            resources
-                .boot_description
-                .occupied_ranges()
-                .map(|(base, length)| {
-                    GuestOwnedRegion::new(base, length, VmRegionKind::BootDescription)
-                }),
-        );
-        regions.extend(
-            resources
-                .config
-                .reserved_address_ranges()
-                .iter()
-                .map(|range| {
-                    GuestOwnedRegion::new(range.base_gpa, range.length, VmRegionKind::Reserved)
-                }),
-        );
-
-        #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
-        regions.push(GuestOwnedRegion::new(
-            X86_APIC_ACCESS_GPA,
-            ax_memory_addr::PAGE_SIZE_4K,
-            VmRegionKind::Reserved,
-        ));
-
-        regions
     }
 
     fn ensure_resources_ready(&self) -> AxResult {
@@ -1669,6 +1321,17 @@ impl AxVM {
     pub fn memory_regions(&self) -> Vec<VMMemoryRegion> {
         self.with_resources(|resources| Ok(resources.memory_regions.clone()))
             .unwrap_or_default()
+    }
+
+    /// Prepares all memory regions configured for this VM.
+    pub fn prepare_memory_layout(&self) -> AxResult<PreparedMemoryLayout> {
+        let memory_regions =
+            self.with_resources(|resources| Ok(resources.config.memory_regions().to_vec()))?;
+        let layout = memory::MemoryLayoutBuilder::new(self, &memory_regions).prepare()?;
+        let main_memory = layout.main_memory();
+        let boot_plan = boot::BootImagePlan::new(main_memory.gpa, main_memory.is_identical());
+        self.with_config(|config| boot_plan.apply_to_config(config));
+        Ok(layout)
     }
 
     /// Maps a reserved memory region for the VM.

--- a/virtualization/axvm/src/vm/boot.rs
+++ b/virtualization/axvm/src/vm/boot.rs
@@ -1,0 +1,117 @@
+//! Guest boot image address planning.
+
+pub(crate) use crate::config::GuestBootPolicy;
+use crate::{
+    GuestPhysAddr,
+    config::{AxVMConfig, VMBootProtocol},
+};
+
+const BIOS_RESERVED_SIZE: usize = 2 * 1024 * 1024;
+
+/// Boot image placement facts derived from prepared VM memory.
+pub(crate) struct BootImagePlan {
+    main_memory_gpa: GuestPhysAddr,
+    main_memory_identical: bool,
+}
+
+impl BootImagePlan {
+    pub(crate) const fn new(main_memory_gpa: GuestPhysAddr, main_memory_identical: bool) -> Self {
+        Self {
+            main_memory_gpa,
+            main_memory_identical,
+        }
+    }
+
+    pub(crate) fn apply_to_config(&self, config: &mut AxVMConfig) {
+        let Some(kernel_load_gpa) = self.adjusted_kernel_load_gpa(config) else {
+            return;
+        };
+        config.relocate_kernel_image(kernel_load_gpa);
+    }
+
+    fn adjusted_kernel_load_gpa(&self, config: &AxVMConfig) -> Option<GuestPhysAddr> {
+        let GuestBootPolicy::AdjustKernelForBootProtocol { protocol } = config.boot_policy() else {
+            return None;
+        };
+        if protocol == VMBootProtocol::Uefi || !self.main_memory_identical {
+            return None;
+        }
+
+        let mut kernel_addr = self.main_memory_gpa;
+        if protocol == VMBootProtocol::Multiboot && config.image_config().bios_load_gpa.is_some() {
+            kernel_addr += BIOS_RESERVED_SIZE;
+        }
+        Some(kernel_addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+
+    use super::*;
+    use crate::config::{AxVCpuConfig, AxVMConfig, AxVMConfigParams, PhysCpuList, VMImageConfig};
+
+    fn config_for_boot_policy(
+        protocol: VMBootProtocol,
+        bios_load_gpa: Option<usize>,
+    ) -> AxVMConfig {
+        AxVMConfig::new(AxVMConfigParams {
+            id: 1,
+            name: String::from("boot-policy-test"),
+            phys_cpu_ls: PhysCpuList::new(1, None, None),
+            cpu_config: AxVCpuConfig {
+                bsp_entry: GuestPhysAddr::from(0x101000),
+                ap_entry: GuestPhysAddr::from(0x102000),
+                ..Default::default()
+            },
+            image_config: VMImageConfig {
+                kernel_load_gpa: GuestPhysAddr::from(0x100000),
+                bios_load_gpa: bios_load_gpa.map(GuestPhysAddr::from),
+                ..Default::default()
+            },
+            boot_policy: GuestBootPolicy::AdjustKernelForBootProtocol { protocol },
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn boot_policy_moves_multiboot_kernel_after_reserved_bios_space() {
+        let mut config = config_for_boot_policy(VMBootProtocol::Multiboot, Some(0x8000));
+        let plan = BootImagePlan::new(GuestPhysAddr::from(0x4000_0000), true);
+
+        plan.apply_to_config(&mut config);
+
+        assert_eq!(
+            config.image_config().kernel_load_gpa.as_usize(),
+            0x4020_0000
+        );
+        assert_eq!(config.bsp_entry().as_usize(), 0x4020_1000);
+        assert_eq!(config.ap_entry().as_usize(), 0x4020_2000);
+    }
+
+    #[test]
+    fn boot_policy_keeps_uefi_kernel_load_address() {
+        let mut config = config_for_boot_policy(VMBootProtocol::Uefi, Some(0x2000_0000));
+        let plan = BootImagePlan::new(GuestPhysAddr::from(0x4000_0000), true);
+
+        plan.apply_to_config(&mut config);
+
+        assert_eq!(config.image_config().kernel_load_gpa.as_usize(), 0x100000);
+        assert_eq!(config.bsp_entry().as_usize(), 0x101000);
+        assert_eq!(config.ap_entry().as_usize(), 0x102000);
+    }
+
+    #[test]
+    fn keep_configured_boot_policy_does_not_relocate_identical_memory() {
+        let mut config = config_for_boot_policy(VMBootProtocol::Multiboot, Some(0x8000));
+        config.set_boot_policy(GuestBootPolicy::KeepConfigured);
+        let plan = BootImagePlan::new(GuestPhysAddr::from(0x4000_0000), true);
+
+        plan.apply_to_config(&mut config);
+
+        assert_eq!(config.image_config().kernel_load_gpa.as_usize(), 0x100000);
+        assert_eq!(config.bsp_entry().as_usize(), 0x101000);
+        assert_eq!(config.ap_entry().as_usize(), 0x102000);
+    }
+}

--- a/virtualization/axvm/src/vm/memory.rs
+++ b/virtualization/axvm/src/vm/memory.rs
@@ -1,0 +1,251 @@
+//! VM memory region planning.
+
+use alloc::vec::Vec;
+use core::alloc::Layout;
+
+use ax_errno::{AxResult, ax_err_type};
+use axvm_types::{GuestPhysAddr, VmMemConfig, VmMemMappingType};
+
+use super::{AxVM, VMMemoryRegion};
+
+const VM_MEMORY_ALIGN: usize = 2 * 1024 * 1024;
+
+/// Prepared memory regions for one VM.
+#[derive(Debug, Clone)]
+pub struct PreparedMemoryLayout {
+    main_memory: VMMemoryRegion,
+    regions: Vec<VMMemoryRegion>,
+}
+
+impl PreparedMemoryLayout {
+    fn new(regions: Vec<VMMemoryRegion>) -> AxResult<Self> {
+        let main_memory = regions
+            .first()
+            .cloned()
+            .ok_or_else(|| ax_err_type!(InvalidData, "VM must have at least one memory region"))?;
+        Ok(Self {
+            main_memory,
+            regions,
+        })
+    }
+
+    /// Returns the primary memory region used by image and boot planning.
+    pub fn main_memory(&self) -> &VMMemoryRegion {
+        &self.main_memory
+    }
+
+    /// Returns all prepared VM memory regions.
+    pub fn regions(&self) -> &[VMMemoryRegion] {
+        &self.regions
+    }
+}
+
+pub(crate) trait MemoryRegionMapper {
+    fn prepared_memory_regions(&self) -> Vec<VMMemoryRegion>;
+    fn allocate_memory_region(&self, layout: Layout, gpa: Option<GuestPhysAddr>) -> AxResult<()>;
+    fn map_reserved_memory_region(&self, layout: Layout, gpa: Option<GuestPhysAddr>) -> AxResult;
+}
+
+impl MemoryRegionMapper for AxVM {
+    fn prepared_memory_regions(&self) -> Vec<VMMemoryRegion> {
+        self.memory_regions()
+    }
+
+    fn allocate_memory_region(&self, layout: Layout, gpa: Option<GuestPhysAddr>) -> AxResult<()> {
+        self.alloc_memory_region(layout, gpa).map(|_| ())
+    }
+
+    fn map_reserved_memory_region(&self, layout: Layout, gpa: Option<GuestPhysAddr>) -> AxResult {
+        self.map_reserved_memory_region(layout, gpa)
+    }
+}
+
+pub(crate) struct MemoryLayoutBuilder<'a, M: MemoryRegionMapper + ?Sized> {
+    mapper: &'a M,
+    configs: &'a [VmMemConfig],
+}
+
+impl<'a, M: MemoryRegionMapper + ?Sized> MemoryLayoutBuilder<'a, M> {
+    pub(crate) const fn new(mapper: &'a M, configs: &'a [VmMemConfig]) -> Self {
+        Self { mapper, configs }
+    }
+
+    pub(crate) fn prepare(&self) -> AxResult<PreparedMemoryLayout> {
+        let existing = self.mapper.prepared_memory_regions();
+        if !existing.is_empty() {
+            return PreparedMemoryLayout::new(existing);
+        }
+
+        for config in self.configs {
+            let plan = MemoryRegionPlan::from_config(config)?;
+            if plan.maps_reserved_memory() {
+                self.mapper
+                    .map_reserved_memory_region(plan.layout(), plan.configured_gpa())?;
+            } else {
+                self.mapper
+                    .allocate_memory_region(plan.layout(), plan.configured_gpa())?;
+            }
+        }
+
+        PreparedMemoryLayout::new(self.mapper.prepared_memory_regions())
+    }
+}
+
+/// One planned guest memory mapping operation.
+#[derive(Debug, Clone)]
+pub(crate) struct MemoryRegionPlan {
+    configured_gpa: Option<GuestPhysAddr>,
+    layout: Layout,
+    map_type: VmMemMappingType,
+}
+
+impl MemoryRegionPlan {
+    pub(crate) fn from_config(config: &VmMemConfig) -> AxResult<Self> {
+        let layout = Layout::from_size_align(config.size, VM_MEMORY_ALIGN).map_err(|err| {
+            ax_err_type!(
+                InvalidInput,
+                alloc::format!("invalid VM memory region {config:?}: {err:?}")
+            )
+        })?;
+        let configured_gpa = match config.map_type {
+            VmMemMappingType::MapIdentical => None,
+            VmMemMappingType::MapAlloc | VmMemMappingType::MapReserved => {
+                Some(GuestPhysAddr::from(config.gpa))
+            }
+        };
+        Ok(Self {
+            configured_gpa,
+            layout,
+            map_type: config.map_type.clone(),
+        })
+    }
+
+    pub(crate) fn configured_gpa(&self) -> Option<GuestPhysAddr> {
+        self.configured_gpa
+    }
+
+    pub(crate) const fn layout(&self) -> Layout {
+        self.layout
+    }
+
+    pub(crate) const fn maps_reserved_memory(&self) -> bool {
+        matches!(self.map_type, VmMemMappingType::MapReserved)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use core::cell::{Cell, RefCell};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeMemoryMapper {
+        regions: RefCell<Vec<VMMemoryRegion>>,
+        map_reserved_calls: Cell<usize>,
+    }
+
+    impl MemoryRegionMapper for FakeMemoryMapper {
+        fn prepared_memory_regions(&self) -> Vec<VMMemoryRegion> {
+            self.regions.borrow().clone()
+        }
+
+        fn allocate_memory_region(
+            &self,
+            layout: Layout,
+            gpa: Option<GuestPhysAddr>,
+        ) -> AxResult<()> {
+            let gpa = gpa.unwrap_or_else(|| GuestPhysAddr::from(0x5000_0000));
+            self.regions.borrow_mut().push(VMMemoryRegion {
+                gpa,
+                hva: gpa.as_usize().into(),
+                layout,
+                needs_dealloc: true,
+            });
+            Ok(())
+        }
+
+        fn map_reserved_memory_region(
+            &self,
+            layout: Layout,
+            gpa: Option<GuestPhysAddr>,
+        ) -> AxResult {
+            let gpa = gpa.ok_or_else(|| ax_err_type!(InvalidInput, "reserved GPA is required"))?;
+            self.map_reserved_calls
+                .set(self.map_reserved_calls.get() + 1);
+            self.regions.borrow_mut().push(VMMemoryRegion {
+                gpa,
+                hva: gpa.as_usize().into(),
+                layout,
+                needs_dealloc: false,
+            });
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn memory_region_plan_preserves_mapping_intent_from_vm_config() {
+        let alloc = VmMemConfig {
+            gpa: 0x8000_0000,
+            size: 0x20_0000,
+            flags: 0,
+            map_type: VmMemMappingType::MapAlloc,
+        };
+        let reserved = VmMemConfig {
+            gpa: 0x9000_0000,
+            size: 0x10_0000,
+            flags: 0,
+            map_type: VmMemMappingType::MapReserved,
+        };
+        let identical = VmMemConfig {
+            gpa: 0,
+            size: 0x10_0000,
+            flags: 0,
+            map_type: VmMemMappingType::MapIdentical,
+        };
+
+        assert_eq!(
+            MemoryRegionPlan::from_config(&alloc)
+                .unwrap()
+                .configured_gpa(),
+            Some(GuestPhysAddr::from(0x8000_0000))
+        );
+        assert!(
+            !MemoryRegionPlan::from_config(&alloc)
+                .unwrap()
+                .maps_reserved_memory()
+        );
+        assert!(
+            MemoryRegionPlan::from_config(&reserved)
+                .unwrap()
+                .maps_reserved_memory()
+        );
+        assert!(
+            MemoryRegionPlan::from_config(&identical)
+                .unwrap()
+                .configured_gpa()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn prepare_memory_layout_maps_configured_reserved_region_once() {
+        let mapper = FakeMemoryMapper::default();
+        let configs = vec![VmMemConfig {
+            gpa: 0x4000_0000,
+            size: 0x20_0000,
+            flags: 0,
+            map_type: VmMemMappingType::MapReserved,
+        }];
+        let builder = MemoryLayoutBuilder::new(&mapper, &configs);
+
+        let layout = builder.prepare().unwrap();
+        let again = builder.prepare().unwrap();
+
+        assert_eq!(layout.main_memory().gpa, GuestPhysAddr::from(0x4000_0000));
+        assert_eq!(layout.regions().len(), 1);
+        assert_eq!(again.regions().len(), 1);
+        assert_eq!(mapper.map_reserved_calls.get(), 1);
+    }
+}

--- a/virtualization/axvm/src/vm/prepare.rs
+++ b/virtualization/axvm/src/vm/prepare.rs
@@ -1,0 +1,98 @@
+//! VM preparation orchestration.
+
+mod address_space;
+mod devices;
+mod vcpus;
+
+use alloc::{format, sync::Arc};
+
+use ax_errno::{AxResult, ax_err, ax_err_type};
+use axdevice::{DeviceFactoryRegistry, register_builtin_factories};
+
+use self::{devices::PreparedDevices, vcpus::PreparedVcpus};
+use super::AxVM;
+use crate::irq::InterruptFabric;
+
+impl AxVM {
+    /// Sets up the VM before booting.
+    pub fn prepare(&self) -> AxResult {
+        self.ensure_resources_ready()?;
+        let mut factories = DeviceFactoryRegistry::new();
+        register_builtin_factories(&mut factories)?;
+        let interrupt_mode = self.interrupt_mode();
+        #[cfg(target_arch = "riscv64")]
+        let interrupt_fabric = {
+            let machine = self.machine.lock();
+            let resources = machine.resources().ok_or_else(|| {
+                ax_err_type!(
+                    BadState,
+                    "VM resources are not available for RISC-V IRQ setup"
+                )
+            })?;
+            crate::irq::riscv::configure(
+                &mut factories,
+                interrupt_mode,
+                resources.config.emu_devices(),
+            )?
+        };
+        #[cfg(not(target_arch = "riscv64"))]
+        let interrupt_fabric = InterruptFabric::new(interrupt_mode);
+
+        self.prepare_with_factories(&factories, interrupt_fabric)
+    }
+
+    /// Sets up the VM with explicit device factories and an interrupt fabric.
+    pub fn prepare_with_factories(
+        &self,
+        factories: &DeviceFactoryRegistry,
+        interrupt_fabric: InterruptFabric,
+    ) -> AxResult {
+        self.ensure_resources_ready()?;
+        let mut machine = self.machine.lock();
+        if !matches!(
+            machine.status(),
+            crate::lifecycle::VmStatus::Ready | crate::lifecycle::VmStatus::Stopped
+        ) {
+            return ax_err!(
+                BadState,
+                format!(
+                    "VM[{}] cannot prepare from {:?}",
+                    self.id(),
+                    machine.status()
+                )
+            );
+        }
+        let resources = machine
+            .resources_mut()
+            .ok_or_else(|| ax_err_type!(BadState, "VM resources are not available for prepare"))?;
+        if resources.vcpu_list.is_some()
+            || resources.devices.is_some()
+            || resources.interrupt_fabric.is_some()
+        {
+            resources.reset_transient_resources()?;
+        }
+        interrupt_fabric.validate_mode(resources.config.interrupt_mode())?;
+
+        let dtb_addr = resources.config.image_config().dtb_load_gpa;
+        let vcpus = PreparedVcpus::create(self.id(), resources, dtb_addr)?;
+        let devices = PreparedDevices::build(self, resources, factories, &interrupt_fabric)?;
+
+        if dtb_addr.is_some() && resources.boot_description.device_tree().is_none() {
+            return ax_err!(
+                InvalidInput,
+                "DTB load GPA is configured but no guest device tree bytes are registered"
+            );
+        }
+
+        address_space::map_guest_address_space(self, resources, devices.devices())?;
+        vcpus.setup(resources)?;
+
+        resources.phys_cpu_ls = resources.config.phys_cpu_ls.clone();
+        resources.vcpu_list = Some(vcpus.into_boxed_slice());
+        resources.devices = Some(Arc::new(devices.into_inner()));
+        resources.interrupt_fabric = Some(interrupt_fabric);
+
+        info!("VM setup: id={}", self.id());
+        Ok(())
+    }
+}

--- a/virtualization/axvm/src/vm/prepare/address_space.rs
+++ b/virtualization/axvm/src/vm/prepare/address_space.rs
@@ -1,0 +1,104 @@
+//! Guest address-space construction for VM preparation.
+
+use alloc::vec::Vec;
+
+use ax_errno::AxResult;
+use axdevice::AxVmDevices;
+use axdevice_base::Resource;
+#[cfg(all(target_arch = "x86_64", feature = "vmx"))]
+use axvm_types::GuestPhysAddr;
+#[cfg(all(target_arch = "x86_64", feature = "vmx"))]
+use x86_vcpu::{X86_APIC_ACCESS_GPA, x86_apic_access_page_addr};
+
+use super::super::{AxVM, AxVMResources, VM_ASPACE_BASE, VM_ASPACE_SIZE};
+use crate::layout::{GuestOwnedRegion, VmRegionKind, build_address_layout};
+
+pub(super) fn map_guest_address_space(
+    vm: &AxVM,
+    resources: &mut AxVMResources,
+    devices: &AxVmDevices,
+) -> AxResult {
+    let owned_regions = guest_owned_regions(resources);
+    let emulated_resources = devices
+        .devices()
+        .flat_map(|device| device.resources().iter().cloned())
+        .collect::<Vec<Resource>>();
+    let address_layout = build_address_layout(
+        resources.config.address_space_policy(),
+        VM_ASPACE_BASE,
+        VM_ASPACE_SIZE,
+        resources.config.pass_through_devices(),
+        resources.config.pass_through_addresses(),
+        &owned_regions,
+        &emulated_resources,
+    )?;
+
+    for mapping in address_layout.mappings() {
+        debug!(
+            "VM[{}] stage2 {:?}: [{:#x}, {:#x}) -> [{:#x}, {:#x}) {:?}",
+            vm.id(),
+            mapping.kind,
+            mapping.gpa.as_usize(),
+            mapping.gpa.as_usize() + mapping.size,
+            mapping.hpa.as_usize(),
+            mapping.hpa.as_usize() + mapping.size,
+            mapping.flags
+        );
+        resources.address_space.map_linear(
+            mapping.gpa,
+            mapping.hpa,
+            mapping.size,
+            mapping.flags,
+        )?;
+    }
+    resources.address_layout = Some(address_layout);
+
+    #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
+    resources.address_space.map_linear(
+        GuestPhysAddr::from(X86_APIC_ACCESS_GPA),
+        x86_apic_access_page_addr(),
+        ax_memory_addr::PAGE_SIZE_4K,
+        axaddrspace::MappingFlags::DEVICE
+            | axaddrspace::MappingFlags::READ
+            | axaddrspace::MappingFlags::WRITE,
+    )?;
+
+    Ok(())
+}
+
+fn guest_owned_regions(resources: &AxVMResources) -> Vec<GuestOwnedRegion> {
+    let mut regions = resources
+        .memory_regions
+        .iter()
+        .map(|region| {
+            GuestOwnedRegion::new(region.gpa.as_usize(), region.size(), VmRegionKind::Memory)
+        })
+        .collect::<Vec<_>>();
+
+    regions.extend(
+        resources
+            .boot_description
+            .occupied_ranges()
+            .map(|(base, length)| {
+                GuestOwnedRegion::new(base, length, VmRegionKind::BootDescription)
+            }),
+    );
+    regions.extend(
+        resources
+            .config
+            .reserved_address_ranges()
+            .iter()
+            .map(|range| {
+                GuestOwnedRegion::new(range.base_gpa, range.length, VmRegionKind::Reserved)
+            }),
+    );
+
+    #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
+    regions.push(GuestOwnedRegion::new(
+        X86_APIC_ACCESS_GPA,
+        ax_memory_addr::PAGE_SIZE_4K,
+        VmRegionKind::Reserved,
+    ));
+
+    regions
+}

--- a/virtualization/axvm/src/vm/prepare/devices.rs
+++ b/virtualization/axvm/src/vm/prepare/devices.rs
@@ -1,0 +1,113 @@
+//! Device construction for VM preparation.
+
+use alloc::{format, sync::Arc};
+
+use ax_errno::{AxResult, ax_err_type};
+use axdevice::{AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceFactoryRegistry};
+#[cfg(target_arch = "aarch64")]
+use axdevice_base::DeviceRegistry as _;
+#[cfg(target_arch = "x86_64")]
+use axdevice_base::{BaseDeviceOps, DeviceRegistry as _, PortDeviceAdapter};
+
+use super::super::{AxVM, AxVMResources};
+#[cfg(target_arch = "aarch64")]
+use crate::config::VMInterruptMode;
+use crate::irq::InterruptFabric;
+
+pub(super) struct PreparedDevices {
+    devices: AxVmDevices,
+}
+
+impl PreparedDevices {
+    pub(super) fn build(
+        vm: &AxVM,
+        resources: &AxVMResources,
+        factories: &DeviceFactoryRegistry,
+        interrupt_fabric: &InterruptFabric,
+    ) -> AxResult<Self> {
+        let build_context = DeviceBuildContext::new(interrupt_fabric);
+        let mut devices = AxVmDevices::build_with_factories(
+            AxVmDeviceConfig {
+                emu_configs: resources.config.emu_devices().to_vec(),
+            },
+            factories,
+            &build_context,
+        )?;
+
+        #[cfg(target_arch = "x86_64")]
+        for port in resources.config.pass_through_ports() {
+            let passthrough = Arc::new(crate::host::x86_port::HostPortPassthrough::new(
+                port.base,
+                port.length,
+            )?);
+            let range = passthrough.address_range();
+            debug!(
+                "PT port region: [{:#x}~{:#x}]",
+                range.start.number(),
+                range.end.number(),
+            );
+            devices
+                .register(PortDeviceAdapter::from_arc(passthrough))
+                .map_err(|err| ax_err_type!(InvalidInput, format!("register PT port: {err:?}")))?;
+        }
+
+        Self::register_arch_devices(vm, resources, &mut devices)?;
+        vm.add_special_emulated_devices(&mut devices)?;
+        Ok(Self { devices })
+    }
+
+    pub(super) const fn devices(&self) -> &AxVmDevices {
+        &self.devices
+    }
+
+    pub(super) fn into_inner(self) -> AxVmDevices {
+        self.devices
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn register_arch_devices(
+        vm: &AxVM,
+        resources: &AxVMResources,
+        devices: &mut AxVmDevices,
+    ) -> AxResult {
+        let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
+        if passthrough {
+            let spis = resources.config.pass_through_spis();
+            let cpu_id = vm.id() - 1; // FIXME: get the real CPU id.
+            let mut gicd_found = false;
+
+            for device in devices.devices() {
+                if let Some(gicd) = device.as_any().downcast_ref::<arm_vgic::v3::vgicd::VGicD>() {
+                    debug!("VGicD found, assigning SPIs...");
+
+                    for spi in spis {
+                        gicd.assign_irq(*spi + 32, cpu_id, (0, 0, 0, cpu_id as _))
+                    }
+
+                    gicd_found = true;
+                    break;
+                }
+            }
+
+            if !gicd_found {
+                warn!("Failed to assign SPIs: No VGicD found in device list");
+            }
+        } else {
+            for dev in axdevice::create_vtimer_devices() {
+                devices
+                    .register(Arc::from(dev) as Arc<dyn axdevice_base::Device>)
+                    .map_err(|e| ax_err_type!(InvalidInput, format!("register vtimer: {e:?}")))?;
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    fn register_arch_devices(
+        _vm: &AxVM,
+        _resources: &AxVMResources,
+        _devices: &mut AxVmDevices,
+    ) -> AxResult {
+        Ok(())
+    }
+}

--- a/virtualization/axvm/src/vm/prepare/vcpus.rs
+++ b/virtualization/axvm/src/vm/prepare/vcpus.rs
@@ -1,0 +1,155 @@
+//! vCPU construction and setup for VM preparation.
+
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+
+use ax_errno::AxResult;
+#[cfg(target_arch = "x86_64")]
+use axvm_types::EmulatedDeviceType;
+use axvm_types::GuestPhysAddr;
+
+use super::super::{AxVCpuRef, AxVMResources, VCpu};
+#[cfg(any(target_arch = "aarch64", target_arch = "loongarch64"))]
+use crate::config::VMInterruptMode;
+#[cfg(not(any(
+    target_arch = "aarch64",
+    target_arch = "loongarch64",
+    target_arch = "x86_64"
+)))]
+use crate::vcpu::AxArchVCpuImpl;
+#[cfg(not(target_arch = "x86_64"))]
+use crate::vcpu::AxVCpuCreateConfig;
+
+pub(super) struct PreparedVcpus {
+    vcpus: Vec<AxVCpuRef>,
+}
+
+impl PreparedVcpus {
+    pub(super) fn create(
+        vm_id: usize,
+        resources: &AxVMResources,
+        dtb_addr: Option<GuestPhysAddr>,
+    ) -> AxResult<Self> {
+        let vcpu_id_pcpu_sets = resources.config.phys_cpu_ls.get_vcpu_affinities_pcpu_ids();
+        #[cfg(target_arch = "loongarch64")]
+        let loongarch_iocsr_state = {
+            let vcpu_state_count = vcpu_id_pcpu_sets
+                .iter()
+                .map(|(vcpu_id, ..)| *vcpu_id)
+                .max()
+                .map_or(0, |vcpu_id| vcpu_id + 1);
+            loongarch_vcpu::LoongArchIocsrState::new(vcpu_state_count)?
+        };
+
+        debug!("dtb_load_gpa: {dtb_addr:?}");
+        debug!("id: {vm_id}, VCpuIdPCpuSets: {vcpu_id_pcpu_sets:#x?}");
+
+        let mut vcpus = Vec::with_capacity(vcpu_id_pcpu_sets.len());
+        for (vcpu_id, phys_cpu_set, _pcpu_id) in vcpu_id_pcpu_sets {
+            #[cfg(target_arch = "aarch64")]
+            let arch_config = AxVCpuCreateConfig {
+                mpidr_el1: _pcpu_id as _,
+                dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
+            };
+            #[cfg(target_arch = "riscv64")]
+            let arch_config = AxVCpuCreateConfig {
+                hart_id: vcpu_id as _,
+                dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
+            };
+            #[cfg(target_arch = "loongarch64")]
+            let arch_config = AxVCpuCreateConfig {
+                cpu_id: vcpu_id,
+                dtb_addr: dtb_addr.unwrap_or_default().as_usize(),
+                boot_args: resources.config.cpu_config.boot_args,
+                boot_stack_top: resources.config.cpu_config.boot_stack_top,
+                firmware_boot: resources.config.cpu_config.firmware_boot,
+                iocsr_state: loongarch_iocsr_state.clone(),
+            };
+
+            // FIXME: VCpu is neither `Send` nor `Sync` by design, check whether
+            // 1. we should make it `Send` and `Sync`, or
+            // 2. we can guarantee that no cross-thread access is performed
+            #[allow(clippy::arc_with_non_send_sync)]
+            vcpus.push(Arc::new(VCpu::new(
+                vm_id,
+                vcpu_id,
+                0, // Currently not used.
+                phys_cpu_set,
+                #[cfg(target_arch = "aarch64")]
+                arch_config,
+                #[cfg(target_arch = "loongarch64")]
+                arch_config,
+                #[cfg(target_arch = "riscv64")]
+                arch_config,
+                #[cfg(target_arch = "x86_64")]
+                (),
+            )?));
+        }
+
+        Ok(Self { vcpus })
+    }
+
+    pub(super) fn setup(&self, resources: &AxVMResources) -> AxResult {
+        for vcpu in &self.vcpus {
+            #[cfg(target_arch = "aarch64")]
+            let setup_config = {
+                let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
+                crate::vcpu::AxVCpuSetupConfig {
+                    passthrough_interrupt: passthrough,
+                    passthrough_timer: passthrough,
+                }
+            };
+            #[cfg(target_arch = "loongarch64")]
+            let setup_config = {
+                let passthrough = resources.config.interrupt_mode() == VMInterruptMode::Passthrough;
+                crate::vcpu::AxVCpuSetupConfig {
+                    passthrough_interrupt: passthrough,
+                    passthrough_timer: passthrough,
+                    boot_args: resources.config.cpu_config.boot_args,
+                    boot_stack_top: resources.config.cpu_config.boot_stack_top,
+                    firmware_boot: resources.config.cpu_config.firmware_boot,
+                }
+            };
+            #[cfg(not(any(
+                target_arch = "aarch64",
+                target_arch = "loongarch64",
+                target_arch = "x86_64"
+            )))]
+            #[allow(clippy::let_unit_value)]
+            let setup_config = <AxArchVCpuImpl as axvcpu::AxArchVCpu>::SetupConfig::default();
+            #[cfg(target_arch = "x86_64")]
+            let setup_config = {
+                let mut config = crate::vcpu::AxVCpuSetupConfig {
+                    emulate_com1: resources
+                        .config
+                        .emu_devices()
+                        .iter()
+                        .any(|dev| dev.emu_type == EmulatedDeviceType::Console),
+                    ..Default::default()
+                };
+                for port in resources.config.pass_through_ports() {
+                    config.add_passthrough_port_range(port.base, port.length)?;
+                }
+                config
+            };
+
+            let entry = if vcpu.id() == 0 {
+                resources.config.bsp_entry()
+            } else {
+                resources.config.ap_entry()
+            };
+
+            debug!("Setting up vCPU[{}] entry at {:#x}", vcpu.id(), entry);
+
+            vcpu.setup(
+                entry,
+                resources.address_space.page_table_root(),
+                setup_config,
+            )?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn into_boxed_slice(self) -> Box<[AxVCpuRef]> {
+        self.vcpus.into_boxed_slice()
+    }
+}


### PR DESCRIPTION
## 背景

`axvisor` 目前还直接负责 VM memory region 的映射分发和部分 guest boot 地址修正，这会让配置管理层携带过多 arch/boot/runtime 细节。为了向 `axvisor next` 的分层靠拢，本 PR 将 VM 内存准备和启动地址规划下沉到 `axvm`，让 `axvisor` 更专注于配置解析、VM 管理和 host 资源申请。

## 改动

- 在 `AxVMConfig` 中保存 VM memory region 配置，并引入 `GuestBootPolicy` 表达启动地址策略。
- 新增 `vm::memory`，由 `MemoryLayoutBuilder` 和 `MemoryRegionPlan` 负责将 `VmMemConfig` 转换为实际 VM memory layout。
- 新增 `vm::boot`，由 `BootImagePlan` 基于主内存布局和 boot protocol 统一调整 kernel/BSP/AP 加载地址。
- 将 `AxVM::prepare_memory_layout()` 作为组合入口，完成内存准备并应用 boot image plan。
- 精简 `os/axvisor/src/config.rs`：axvisor 只选择 boot policy 并调用 axvm API，不再直接处理 `VmMemMappingType` 或 kernel 地址修正。
- 拆分原本较大的 VM prepare 流程为 `prepare.rs`、`prepare/devices.rs`、`prepare/vcpus.rs`、`prepare/address_space.rs`，通过组合件完成设备、vCPU 和地址空间准备。
- 修复 board CI 中 FDT reserved-memory 解析后没有同步到 `AxVMConfig` 的问题，避免 axvm 使用过期 memory region 列表准备 VM 内存。

## 方案逻辑

- x86 Linux direct boot 保持原配置地址，避免破坏现有直接启动路径。
- 其它启动协议通过 `GuestBootPolicy::AdjustKernelForBootProtocol` 交给 axvm，根据主内存是否同址映射、是否 Multiboot BIOS 等事实统一决定是否调整 kernel load GPA。
- 内存 region 映射逻辑由 axvm 的 mapper 抽象承载，axvisor 不再需要理解每种 memory mapping 类型的具体执行方式。
- FDT 处理仍属于 axvisor 的配置管理职责；当 FDT 解析追加 DTB reserved-memory 后，axvisor 在创建 `AxVM` 前把更新后的配置同步回 `AxVMConfig`，让 axvm 的内存准备入口看到完整 region 列表。
- prepare 流程按职责拆分，主流程只做编排，减少单个源码文件和函数的职责膨胀。

## CI 修复说明

CI 的 `Test axvisor self-hosted board orangepi-5-plus-linux / run_host` 日志显示 `VM memory region count 3 does not match config region count 7`，随后 guest 访问 `GPA 0x110000` 时触发 `mmio read: NotFound`。原因是本 PR 将 memory preparation 下沉到 axvm 后，`AxVMConfig` 过早 clone 了原始 `memory_regions`；而 board FDT 后续解析出的 reserved-memory 只追加到了 `AxVMCrateConfig`，没有进入 axvm 的运行时配置。

本次修复新增 `AxVMConfig::set_memory_regions`，并在 `handle_fdt_operations` 之后、`AxVM::new` 之前同步完整 memory region 列表，同时补充测试覆盖“配置先被 clone，之后被 FDT 扩展”的顺序。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p axvm --lib set_memory_regions_replaces_stale_snapshot_after_config_enrichment -- --nocapture`
- `cargo test -p axvm --lib`
- `cargo xtask clippy --package axvm`
- `cargo xtask clippy --package axvisor`（xtask 提示 axvisor 需要 target/build config，未选择 package；改用 axvisor build flow 验证）
- `cargo xtask axvisor build --config os/axvisor/configs/board/qemu-aarch64.toml`
- `cargo xtask axvisor build --config os/axvisor/configs/board/orangepi-5-plus.toml`
- `cargo xtask axvisor build --config os/axvisor/configs/board/roc-rk3568-pc.toml`
- `cargo xtask axvisor build --config os/axvisor/configs/board/qemu-x86_64.toml`