### PR TITLE
starry: fix LTP-derived syscall conformance gaps

### DIFF
--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -368,10 +368,20 @@ fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
     aspace_arc.lock().handle_page_fault(vaddr, access_flags)
 }
 
+pub const PATH_MAX: usize = 4096;
+
 pub fn vm_load_string(ptr: *const c_char) -> AxResult<String> {
     #[allow(clippy::unnecessary_cast)]
     let bytes = vm_load_until_nul(ptr as *const u8)?;
     String::from_utf8(bytes).map_err(|_| AxError::IllegalBytes)
+}
+
+pub fn vm_load_path_string(ptr: *const c_char) -> AxResult<String> {
+    let path = vm_load_string(ptr)?;
+    if path.len() >= PATH_MAX {
+        return Err(AxError::NameTooLong);
+    }
+    Ok(path)
 }
 
 struct Vm;

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -23,7 +23,7 @@ use starry_vm::{VmPtr, vm_write_slice};
 
 use crate::{
     file::{Directory, FD_TABLE, FileLike, fd_is_path, get_file_like, resolve_at, with_fs},
-    mm::vm_load_string,
+    mm::{vm_load_path_string, vm_load_string},
     task::AsThread,
     time::TimeValueLike,
 };
@@ -84,7 +84,7 @@ pub fn sys_ioctl(fd: i32, cmd: u32, arg: usize) -> AxResult<isize> {
 
 #[ddebug::named]
 pub fn sys_chdir(path: *const c_char) -> AxResult<isize> {
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
     debug_fn!("sys_chdir <= path: {path}");
 
     let mut fs = FS_CONTEXT.lock();
@@ -160,7 +160,7 @@ ktracepoint::define_event_trace!(
 pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize> {
     let curr = current();
     let thread = curr.as_thread();
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
     debug!("sys_mkdirat <= dirfd: {dirfd}, path: {path}, mode: {mode}");
 
     let mode = mode & !thread.proc_data.umask();
@@ -337,8 +337,8 @@ pub fn sys_linkat(
         return Err(AxError::InvalidInput);
     }
 
-    let old_path = old_path.nullable().map(vm_load_string).transpose()?;
-    let new_path = vm_load_string(new_path)?;
+    let old_path = old_path.nullable().map(vm_load_path_string).transpose()?;
+    let new_path = vm_load_path_string(new_path)?;
     debug!(
         "sys_linkat <= old_dirfd: {old_dirfd}, old_path: {old_path:?}, new_dirfd: {new_dirfd}, \
          new_path: {new_path}, flags: {flags}"
@@ -376,7 +376,7 @@ pub fn sys_link(old_path: *const c_char, new_path: *const c_char) -> AxResult<is
 /// flags: can be 0 or AT_REMOVEDIR
 /// return 0 when success, else return -1
 pub fn sys_unlinkat(dirfd: i32, path: *const c_char, flags: usize) -> AxResult<isize> {
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
 
     debug!("sys_unlinkat <= dirfd: {dirfd}, path: {path:?}, flags: {flags}");
 
@@ -443,7 +443,7 @@ pub fn sys_symlinkat(
     linkpath: *const c_char,
 ) -> AxResult<isize> {
     let target = vm_load_string(target)?;
-    let linkpath = vm_load_string(linkpath)?;
+    let linkpath = vm_load_path_string(linkpath)?;
     debug!("sys_symlinkat <= target: {target:?}, new_dirfd: {new_dirfd}, linkpath: {linkpath:?}");
 
     let cred = current().as_thread().cred();
@@ -470,7 +470,7 @@ pub fn sys_readlinkat(
         return Err(AxError::InvalidInput);
     }
 
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
 
     debug!("sys_readlinkat <= dirfd: {dirfd}, path: {path:?}");
 
@@ -510,7 +510,7 @@ pub fn sys_fchownat(
         return Err(AxError::InvalidInput);
     }
 
-    let path = path.nullable().map(vm_load_string).transpose()?;
+    let path = path.nullable().map(vm_load_path_string).transpose()?;
     let loc = resolve_at(dirfd, path.as_deref(), flags)?
         .into_file()
         .ok_or(AxError::BadFileDescriptor)?;
@@ -584,7 +584,7 @@ pub fn sys_fchmodat(dirfd: i32, path: *const c_char, mode: u32, flags: u32) -> A
         return Err(AxError::InvalidInput);
     }
 
-    let path = path.nullable().map(vm_load_string).transpose()?;
+    let path = path.nullable().map(vm_load_path_string).transpose()?;
 
     // man 2 open §"O_PATH": "other file operations (e.g., read(2), write(2),
     // fchmod(2), fchown(2), fgetxattr(2), ioctl(2), mmap(2)) fail with the
@@ -733,7 +733,7 @@ pub fn sys_utimensat(
     }
 
     // Resolve file and check permissions.
-    let path = path.nullable().map(vm_load_string).transpose()?;
+    let path = path.nullable().map(vm_load_path_string).transpose()?;
     let loc = resolve_at(dirfd, path.as_deref(), flags)?
         .into_file()
         .ok_or(AxError::BadFileDescriptor)?;
@@ -782,8 +782,8 @@ pub fn sys_renameat2(
         return Err(AxError::InvalidInput);
     }
 
-    let old_path = vm_load_string(old_path)?;
-    let new_path = vm_load_string(new_path)?;
+    let old_path = vm_load_path_string(old_path)?;
+    let new_path = vm_load_path_string(new_path)?;
     debug!(
         "sys_renameat2 <= old_dirfd: {old_dirfd}, old_path: {old_path:?}, new_dirfd: {new_dirfd}, \
          new_path: {new_path}, flags: {flags}"

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -210,7 +210,10 @@ fn openat2_check_extra_bytes(how: *const OpenHow, size: usize) -> AxResult<()> {
         return Ok(());
     }
 
-    let extra = vm_load(unsafe { (how as *const u8).add(base_size) }, size - base_size)?;
+    let extra = vm_load(
+        unsafe { (how as *const u8).add(base_size) },
+        size - base_size,
+    )?;
     if extra.iter().any(|byte| *byte != 0) {
         return Err(AxError::ArgumentListTooLong);
     }

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -1,6 +1,7 @@
 use alloc::{format, string::ToString, sync::Arc};
 use core::{
     ffi::{c_char, c_int},
+    mem::size_of,
     ops::DerefMut,
 };
 
@@ -10,14 +11,14 @@ use ax_task::current;
 use axfs_ng_vfs::{DirEntry, FileNode, Location, NodeOps, NodeType, Reference};
 use bitflags::bitflags;
 use linux_raw_sys::general::*;
-use starry_vm::{VmMutPtr, VmPtr};
+use starry_vm::{VmMutPtr, VmPtr, vm_load};
 
 use crate::{
     file::{
         Directory, FD_TABLE, File, FileDescriptor, FileLike, NsFd, Pipe, add_file_like,
         close_file_like, get_file_like, memfd::Memfd, with_fs,
     },
-    mm::vm_load_string,
+    mm::vm_load_path_string,
     pseudofs::{Device, dev::tty},
     task::AsThread,
 };
@@ -170,6 +171,52 @@ fn add_to_fd(result: OpenResult, flags: u32) -> AxResult<i32> {
     add_file_like(f, flags & O_CLOEXEC != 0)
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::AnyBitPattern)]
+pub struct OpenHow {
+    flags: u64,
+    mode: u64,
+    resolve: u64,
+}
+
+const OPENAT2_VALID_RESOLVE: u64 = (RESOLVE_NO_XDEV
+    | RESOLVE_NO_MAGICLINKS
+    | RESOLVE_NO_SYMLINKS
+    | RESOLVE_BENEATH
+    | RESOLVE_IN_ROOT
+    | RESOLVE_CACHED) as u64;
+
+const OPENAT2_VALID_FLAGS: u64 = (O_ACCMODE
+    | O_CREAT
+    | O_EXCL
+    | O_NOCTTY
+    | O_TRUNC
+    | O_APPEND
+    | O_NONBLOCK
+    | O_DSYNC
+    | O_DIRECT
+    | O_LARGEFILE
+    | O_DIRECTORY
+    | O_NOFOLLOW
+    | O_NOATIME
+    | O_CLOEXEC
+    | O_SYNC
+    | O_PATH
+    | O_TMPFILE) as u64;
+
+fn openat2_check_extra_bytes(how: *const OpenHow, size: usize) -> AxResult<()> {
+    let base_size = size_of::<OpenHow>();
+    if size <= base_size {
+        return Ok(());
+    }
+
+    let extra = vm_load(unsafe { (how as *const u8).add(base_size) }, size - base_size)?;
+    if extra.iter().any(|byte| *byte != 0) {
+        return Err(AxError::ArgumentListTooLong);
+    }
+    Ok(())
+}
+
 /// Check whether `path` refers to a `/proc/<pid>/ns/<type>` entry.
 /// If so, create an [`NsFd`] and add it to the fd table instead of
 /// opening a regular file.
@@ -266,17 +313,10 @@ pub fn sys_openat(
 
     let curr = current();
     let thread = curr.as_thread();
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
     debug!("sys_openat <= {dirfd} {path:?} {flags:#o} {mode:#o}");
 
     let uflags = flags as u32;
-
-    // Pathname length check — man "ENAMETOOLONG — pathname was too long".
-    // starry path layer only checks per-component (255); add whole-path
-    // check (PATH_MAX = 4096). Fixes bug-open-pathmax-no-enametoolong.
-    if path.len() >= 4096 {
-        return Err(AxError::NameTooLong);
-    }
 
     // Empty pathname → ENOENT. openat() does not accept AT_EMPTY_PATH.
     // Fixes bug-openat-empty-path-no-enoent.
@@ -340,6 +380,45 @@ pub fn sys_openat(
         crate::file::inotify::notify_create_path(file.path().as_ref(), false);
     }
     Ok(fd as isize)
+}
+
+pub fn sys_openat2(
+    dirfd: c_int,
+    path: *const c_char,
+    how: *const OpenHow,
+    size: usize,
+) -> AxResult<isize> {
+    let base_size = size_of::<OpenHow>();
+    if size < base_size {
+        return Err(AxError::InvalidInput);
+    }
+
+    let how_value = how.vm_read()?;
+    openat2_check_extra_bytes(how, size)?;
+
+    if how_value.flags & !OPENAT2_VALID_FLAGS != 0 {
+        return Err(AxError::InvalidInput);
+    }
+    if how_value.mode & !0o7777 != 0 {
+        return Err(AxError::InvalidInput);
+    }
+    if how_value.mode != 0 && how_value.flags & ((O_CREAT | O_TMPFILE) as u64) == 0 {
+        return Err(AxError::InvalidInput);
+    }
+    if how_value.resolve & !OPENAT2_VALID_RESOLVE != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
+    let flags: i32 = how_value
+        .flags
+        .try_into()
+        .map_err(|_| AxError::InvalidInput)?;
+    let mode: __kernel_mode_t = how_value
+        .mode
+        .try_into()
+        .map_err(|_| AxError::InvalidInput)?;
+
+    sys_openat(dirfd, path, flags, mode)
 }
 
 /// Open a file by `filename` and insert it into the file descriptor table.

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -411,6 +411,11 @@ pub fn sys_openat2(
     if how_value.resolve & !OPENAT2_VALID_RESOLVE != 0 {
         return Err(AxError::InvalidInput);
     }
+    // This minimal openat2 implementation does not enforce Linux RESOLVE_*
+    // path-walk constraints yet, so reject known resolve bits explicitly.
+    if how_value.resolve != 0 {
+        return Err(AxError::OperationNotSupported);
+    }
 
     let flags: i32 = how_value
         .flags

--- a/os/StarryOS/kernel/src/syscall/fs/stat.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/stat.rs
@@ -15,7 +15,7 @@ use starry_vm::{VmMutPtr, VmPtr};
 
 use crate::{
     file::{File, FileLike, resolve_at},
-    mm::{UserPtr, vm_load_string},
+    mm::{UserPtr, vm_load_path_string, vm_load_string},
     task::AsThread,
 };
 
@@ -68,7 +68,7 @@ pub fn sys_fstatat(
         return Err(AxError::InvalidInput);
     }
 
-    let path = path.nullable().map(vm_load_string).transpose()?;
+    let path = path.nullable().map(vm_load_path_string).transpose()?;
 
     debug!("sys_fstatat <= dirfd: {dirfd}, path: {path:?}, flags: {flags}");
 
@@ -154,7 +154,7 @@ pub fn sys_faccessat2(dirfd: c_int, path: *const c_char, mode: u32, flags: u32) 
         return Err(AxError::InvalidInput);
     }
 
-    let path = path.nullable().map(vm_load_string).transpose()?;
+    let path = path.nullable().map(vm_load_path_string).transpose()?;
     debug!("sys_faccessat2 <= dirfd: {dirfd}, path: {path:?}, mode: {mode}, flags: {flags}");
 
     let file = resolve_at(dirfd, path.as_deref(), flags)?;

--- a/os/StarryOS/kernel/src/syscall/fs/stat.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/stat.rs
@@ -126,7 +126,7 @@ pub fn sys_statx(
     //        below), then the target file is the one referred to by the
     //        file descriptor dirfd.
 
-    let path = path.nullable().map(vm_load_string).transpose()?;
+    let path = path.nullable().map(vm_load_path_string).transpose()?;
     debug!("sys_statx <= dirfd: {dirfd}, path: {path:?}, flags: {flags}");
 
     statxbuf.vm_write(resolve_at(dirfd, path.as_deref(), flags)?.stat()?.into())?;

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -123,8 +123,9 @@ pub fn sys_mmap(
     let curr = current();
     let curr_aspace = curr.as_thread().proc_data.aspace();
     let mut aspace = curr_aspace.lock();
-    let permission_flags = MmapProt::from_bits_truncate(prot);
-    // TODO: check illegal flags for mmap
+    let Some(permission_flags) = MmapProt::from_bits(prot) else {
+        return Err(AxError::InvalidInput);
+    };
     let map_flags = match MmapFlags::from_bits(flags) {
         Some(flags) => flags,
         None => {

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -232,6 +232,12 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg2() as _,
             uctx.arg3() as _,
         ),
+        Sysno::openat2 => sys_openat2(
+            uctx.arg0() as _,
+            uctx.arg1() as _,
+            uctx.arg2() as _,
+            uctx.arg3() as _,
+        ),
         Sysno::close => sys_close(uctx.arg0() as _),
         Sysno::close_range => sys_close_range(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         Sysno::dup => sys_dup(uctx.arg0() as _),

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/CMakeLists.txt
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(syscall-test-ltp-pilot-min C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+add_executable(syscall-test-ltp-pilot-min src/main.c)
+target_compile_options(syscall-test-ltp-pilot-min PRIVATE -Wall -Wextra -Werror)
+install(TARGETS syscall-test-ltp-pilot-min RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
@@ -1,0 +1,259 @@
+/*
+ * Minimal dynamic confirmation for LTP-derived syscall conformance fixes.
+ *
+ * Scope is intentionally narrow:
+ * - openat2 open_how validation and ordinary-path fallback through openat
+ * - mmap invalid PROT bit validation
+ * - multi-component PATH_MAX handling for representative path syscalls
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_openat2
+#define SYS_openat2 437
+#endif
+
+#ifndef RESOLVE_NO_XDEV
+#define RESOLVE_NO_XDEV        0x01
+#define RESOLVE_NO_MAGICLINKS  0x02
+#define RESOLVE_NO_SYMLINKS    0x04
+#define RESOLVE_BENEATH        0x08
+#define RESOLVE_IN_ROOT        0x10
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+struct open_how {
+    uint64_t flags;
+    uint64_t mode;
+    uint64_t resolve;
+};
+
+struct open_how_pad {
+    struct open_how how;
+    uint64_t pad;
+};
+
+static int pass_count;
+static int fail_count;
+
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        pass_count++;                                                   \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        fail_count++;                                                   \
+    }                                                                   \
+} while (0)
+
+static long do_openat2(int dirfd, const char *path, const struct open_how *how,
+                       size_t size)
+{
+    return syscall(SYS_openat2, dirfd, path, how, size);
+}
+
+static void expect_openat2_errno(const char *name, int dirfd, const char *path,
+                                 struct open_how how, size_t size, int expected)
+{
+    errno = 0;
+    long ret = do_openat2(dirfd, path, &how, size);
+    if (ret >= 0) {
+        close((int)ret);
+    }
+    CHECK(ret == -1 && errno == expected, name);
+}
+
+static void expect_openat2_padded_e2big(void)
+{
+    struct open_how_pad padded = {
+        .how = {
+            .flags = O_RDWR | O_CREAT,
+            .mode = 0700,
+            .resolve = 0,
+        },
+        .pad = 0xdead,
+    };
+
+    errno = 0;
+    long ret = do_openat2(AT_FDCWD, "openat2-e2big", &padded.how, sizeof(padded));
+    if (ret >= 0) {
+        close((int)ret);
+    }
+    CHECK(ret == -1 && errno == E2BIG, "openat2 nonzero extension bytes -> E2BIG");
+}
+
+static void expect_openat2_success(const char *name, int dirfd, const char *path,
+                                   uint64_t flags, uint64_t resolve)
+{
+    struct open_how how = {
+        .flags = flags | O_CREAT,
+        .mode = 0600,
+        .resolve = resolve,
+    };
+    struct stat st;
+
+    errno = 0;
+    long ret = do_openat2(dirfd, path, &how, sizeof(how));
+    if (ret < 0) {
+        CHECK(0, name);
+        return;
+    }
+
+    CHECK(fstat((int)ret, &st) == 0 && st.st_size == 0, name);
+    close((int)ret);
+    unlinkat(dirfd, path, 0);
+}
+
+static void test_openat2_min(void)
+{
+    const char *dir = "openat2-min-dir";
+    int dirfd;
+
+    printf("[TEST] openat2 minimal conformance\n");
+    unlink("openat2-e2big");
+    rmdir(dir);
+    CHECK(mkdir(dir, 0700) == 0 || errno == EEXIST, "openat2 setup mkdir");
+    dirfd = open(dir, O_RDONLY | O_DIRECTORY);
+    CHECK(dirfd >= 0, "openat2 setup open dir");
+    if (dirfd < 0) {
+        return;
+    }
+
+    expect_openat2_errno("openat2 invalid dirfd -> EBADF", -1, "file",
+                         (struct open_how){ O_RDWR | O_CREAT, 0700, 0 },
+                         sizeof(struct open_how), EBADF);
+    expect_openat2_errno("openat2 NULL pathname -> EFAULT", AT_FDCWD, NULL,
+                         (struct open_how){ O_RDONLY | O_CREAT, 0400, 0 },
+                         sizeof(struct open_how), EFAULT);
+    expect_openat2_errno("openat2 mode without create -> EINVAL", AT_FDCWD, "file",
+                         (struct open_how){ O_RDONLY, 0200, 0 },
+                         sizeof(struct open_how), EINVAL);
+    expect_openat2_errno("openat2 invalid mode -> EINVAL", AT_FDCWD, "file",
+                         (struct open_how){ O_RDWR | O_CREAT, UINT64_MAX, 0 },
+                         sizeof(struct open_how), EINVAL);
+    expect_openat2_errno("openat2 invalid resolve -> EINVAL", AT_FDCWD, "file",
+                         (struct open_how){ O_RDWR | O_CREAT, 0700, UINT64_MAX },
+                         sizeof(struct open_how), EINVAL);
+    expect_openat2_errno("openat2 size zero -> EINVAL", AT_FDCWD, "file",
+                         (struct open_how){ O_RDWR | O_CREAT, 0700, 0 },
+                         0, EINVAL);
+    expect_openat2_errno("openat2 size small -> EINVAL", AT_FDCWD, "file",
+                         (struct open_how){ O_RDWR | O_CREAT, 0700, 0 },
+                         sizeof(struct open_how) - 1, EINVAL);
+    expect_openat2_padded_e2big();
+
+    expect_openat2_success("openat2 ordinary path succeeds", dirfd, "basic", O_RDWR, 0);
+    expect_openat2_success("openat2 RESOLVE_NO_XDEV ordinary path succeeds",
+                           dirfd, "resolve-xdev", O_RDWR, RESOLVE_NO_XDEV);
+    expect_openat2_success("openat2 RESOLVE_NO_MAGICLINKS ordinary path succeeds",
+                           dirfd, "resolve-magic", O_RDWR, RESOLVE_NO_MAGICLINKS);
+    expect_openat2_success("openat2 RESOLVE_NO_SYMLINKS ordinary path succeeds",
+                           dirfd, "resolve-symlink", O_RDWR, RESOLVE_NO_SYMLINKS);
+    expect_openat2_success("openat2 RESOLVE_BENEATH ordinary path succeeds",
+                           dirfd, "resolve-beneath", O_RDWR, RESOLVE_BENEATH);
+    expect_openat2_success("openat2 RESOLVE_IN_ROOT ordinary path succeeds",
+                           dirfd, "resolve-in-root", O_RDWR, RESOLVE_IN_ROOT);
+
+    close(dirfd);
+    rmdir(dir);
+}
+
+static void expect_mmap_einval(const char *name, size_t length, int prot)
+{
+    errno = 0;
+    void *addr = mmap(NULL, length, prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (addr != MAP_FAILED) {
+        munmap(addr, length);
+    }
+    CHECK(addr == MAP_FAILED && errno == EINVAL, name);
+}
+
+static void test_mmap_min(void)
+{
+    printf("[TEST] mmap minimal conformance\n");
+    expect_mmap_einval("mmap unknown PROT bit -> EINVAL", 4096, PROT_READ | 0x40000000);
+    expect_mmap_einval("mmap length zero -> EINVAL", 0, PROT_READ);
+}
+
+static char *make_long_path(void)
+{
+    char *path = malloc(PATH_MAX + 1);
+    size_t pos = 0;
+
+    if (!path) {
+        return NULL;
+    }
+
+    while (pos + 2 < PATH_MAX) {
+        path[pos++] = 'a';
+        path[pos++] = '/';
+    }
+    while (pos < PATH_MAX) {
+        path[pos++] = 'b';
+    }
+    path[pos] = '\0';
+    return path;
+}
+
+static void expect_path_errno(const char *name, int ret, int expected)
+{
+    if (ret >= 0) {
+        close(ret);
+    }
+    CHECK(ret == -1 && errno == expected, name);
+}
+
+static void test_pathmax_min(void)
+{
+    char *path = make_long_path();
+    struct stat st;
+
+    printf("[TEST] PATH_MAX minimal conformance\n");
+    CHECK(path != NULL, "allocate PATH_MAX test path");
+    if (!path) {
+        return;
+    }
+
+    errno = 0;
+    expect_path_errno("stat long path -> ENAMETOOLONG", stat(path, &st), ENAMETOOLONG);
+    errno = 0;
+    expect_path_errno("access long path -> ENAMETOOLONG", access(path, F_OK), ENAMETOOLONG);
+    errno = 0;
+    expect_path_errno("chdir long path -> ENAMETOOLONG", chdir(path), ENAMETOOLONG);
+    errno = 0;
+    expect_path_errno("openat long path -> ENAMETOOLONG", openat(AT_FDCWD, path, O_RDONLY),
+                      ENAMETOOLONG);
+
+    free(path);
+}
+
+int main(void)
+{
+    printf("================================================\n");
+    printf("  TEST: LTP-derived syscall pilot minimal checks\n");
+    printf("================================================\n");
+
+    test_openat2_min();
+    test_mmap_min();
+    test_pathmax_min();
+
+    printf("------------------------------------------------\n");
+    printf("  DONE: %d pass, %d fail\n", pass_count, fail_count);
+    printf("================================================\n");
+    return fail_count == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
@@ -24,6 +24,10 @@
 #define SYS_openat2 437
 #endif
 
+#ifndef STATX_BASIC_STATS
+#define STATX_BASIC_STATS 0x000007ffU
+#endif
+
 #ifndef RESOLVE_NO_XDEV
 #define RESOLVE_NO_XDEV        0x01
 #define RESOLVE_NO_MAGICLINKS  0x02
@@ -222,6 +226,9 @@ static void test_pathmax_min(void)
 {
     char *path = make_long_path();
     struct stat st;
+#ifdef SYS_statx
+    long statx_buf[64];
+#endif
 
     printf("[TEST] PATH_MAX minimal conformance\n");
     CHECK(path != NULL, "allocate PATH_MAX test path");
@@ -231,6 +238,12 @@ static void test_pathmax_min(void)
 
     errno = 0;
     expect_path_errno("stat long path -> ENAMETOOLONG", stat(path, &st), ENAMETOOLONG);
+#ifdef SYS_statx
+    errno = 0;
+    expect_path_errno("statx long path -> ENAMETOOLONG",
+                      syscall(SYS_statx, AT_FDCWD, path, 0, STATX_BASIC_STATS, statx_buf),
+                      ENAMETOOLONG);
+#endif
     errno = 0;
     expect_path_errno("access long path -> ENAMETOOLONG", access(path, F_OK), ENAMETOOLONG);
     errno = 0;

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
@@ -36,6 +36,10 @@
 #define RESOLVE_IN_ROOT        0x10
 #endif
 
+#ifndef RESOLVE_CACHED
+#define RESOLVE_CACHED         0x20
+#endif
+
 #ifndef PATH_MAX
 #define PATH_MAX 4096
 #endif
@@ -162,16 +166,30 @@ static void test_openat2_min(void)
     expect_openat2_padded_e2big();
 
     expect_openat2_success("openat2 ordinary path succeeds", dirfd, "basic", O_RDWR, 0);
-    expect_openat2_success("openat2 RESOLVE_NO_XDEV ordinary path succeeds",
-                           dirfd, "resolve-xdev", O_RDWR, RESOLVE_NO_XDEV);
-    expect_openat2_success("openat2 RESOLVE_NO_MAGICLINKS ordinary path succeeds",
-                           dirfd, "resolve-magic", O_RDWR, RESOLVE_NO_MAGICLINKS);
-    expect_openat2_success("openat2 RESOLVE_NO_SYMLINKS ordinary path succeeds",
-                           dirfd, "resolve-symlink", O_RDWR, RESOLVE_NO_SYMLINKS);
-    expect_openat2_success("openat2 RESOLVE_BENEATH ordinary path succeeds",
-                           dirfd, "resolve-beneath", O_RDWR, RESOLVE_BENEATH);
-    expect_openat2_success("openat2 RESOLVE_IN_ROOT ordinary path succeeds",
-                           dirfd, "resolve-in-root", O_RDWR, RESOLVE_IN_ROOT);
+    expect_openat2_errno("openat2 unsupported RESOLVE_NO_XDEV -> EOPNOTSUPP",
+                         dirfd, "resolve-xdev",
+                         (struct open_how){ O_RDWR | O_CREAT, 0600, RESOLVE_NO_XDEV },
+                         sizeof(struct open_how), EOPNOTSUPP);
+    expect_openat2_errno("openat2 unsupported RESOLVE_NO_MAGICLINKS -> EOPNOTSUPP",
+                         dirfd, "resolve-magic",
+                         (struct open_how){ O_RDWR | O_CREAT, 0600, RESOLVE_NO_MAGICLINKS },
+                         sizeof(struct open_how), EOPNOTSUPP);
+    expect_openat2_errno("openat2 unsupported RESOLVE_NO_SYMLINKS -> EOPNOTSUPP",
+                         dirfd, "resolve-symlink",
+                         (struct open_how){ O_RDWR | O_CREAT, 0600, RESOLVE_NO_SYMLINKS },
+                         sizeof(struct open_how), EOPNOTSUPP);
+    expect_openat2_errno("openat2 unsupported RESOLVE_BENEATH -> EOPNOTSUPP",
+                         dirfd, "resolve-beneath",
+                         (struct open_how){ O_RDWR | O_CREAT, 0600, RESOLVE_BENEATH },
+                         sizeof(struct open_how), EOPNOTSUPP);
+    expect_openat2_errno("openat2 unsupported RESOLVE_IN_ROOT -> EOPNOTSUPP",
+                         dirfd, "resolve-in-root",
+                         (struct open_how){ O_RDWR | O_CREAT, 0600, RESOLVE_IN_ROOT },
+                         sizeof(struct open_how), EOPNOTSUPP);
+    expect_openat2_errno("openat2 unsupported RESOLVE_CACHED -> EOPNOTSUPP",
+                         dirfd, "resolve-cached",
+                         (struct open_how){ O_RDWR | O_CREAT, 0600, RESOLVE_CACHED },
+                         sizeof(struct open_how), EOPNOTSUPP);
 
     close(dirfd);
     rmdir(dir);


### PR DESCRIPTION
  ## Summary

  This PR fixes several syscall conformance gaps found by the LTP-derived syscall pilot spec.

  Changes:
  - add minimal `openat2` support with validation for `open_how` fields, size, extension bytes, and unsupported flag combinations
  - return `ENAMETOOLONG` consistently for representative PATH_MAX path handling cases
  - reject unknown `mmap` PROT bits with `EINVAL`
  - add a focused Starry system test for the pilot checks covering `openat2`, `mmap`, and PATH_MAX behavior

  The implementation is intentionally minimal: it fixes the checked compatibility gaps without expanding `openat2` into a full
  path-resolution feature implementation.
