### PR TITLE
test(starry): fix perf-hw busy loop warnings

### DIFF
--- a/test-suit/starryos/qemu-smp1/system/perf-hw-cycles/src/perf_hw_cycles.c
+++ b/test-suit/starryos/qemu-smp1/system/perf-hw-cycles/src/perf_hw_cycles.c
@@ -150,6 +150,7 @@ int main(void) {
     for (uint64_t i = 0; i < 20000000ull; i++) {
         spin += i;
     }
+    (void)spin;
 
     (void)ioctl(efd, PERF_EVENT_IOC_DISABLE, 0);
 

--- a/test-suit/starryos/qemu-smp1/system/perf-hw-freq/src/perf_hw_freq.c
+++ b/test-suit/starryos/qemu-smp1/system/perf-hw-freq/src/perf_hw_freq.c
@@ -179,6 +179,7 @@ int main(void) {
     for (uint64_t i = 0; i < 80000000ull; i++) {
         spin += i;
     }
+    (void)spin;
     (void)ioctl(efd, PERF_EVENT_IOC_DISABLE, 0);
 
     uint64_t data_head = meta->data_head;

--- a/test-suit/starryos/qemu-smp1/system/perf-hw-pmu-sysfs/src/perf_hw_pmu_sysfs.c
+++ b/test-suit/starryos/qemu-smp1/system/perf-hw-pmu-sysfs/src/perf_hw_pmu_sysfs.c
@@ -410,6 +410,7 @@ int main(void) {
     for (uint64_t i = 0; i < 20000000ull; i++) {
         spin += i;
     }
+    (void)spin;
 
     (void)ioctl(efd, PERF_EVENT_IOC_DISABLE, 0);
 

--- a/test-suit/starryos/qemu-smp1/system/perf-hw-rdpmc/src/perf_hw_rdpmc.c
+++ b/test-suit/starryos/qemu-smp1/system/perf-hw-rdpmc/src/perf_hw_rdpmc.c
@@ -185,6 +185,7 @@ int main(void) {
     for (uint64_t i = 0; i < 20000000ull; i++) {
         spin += i;
     }
+    (void)spin;
 
     /* EL0 read via mrs (the rdpmc path) and the syscall read, back to back. */
     uint64_t rd = read_pmccntr_el0();

--- a/test-suit/starryos/qemu-smp1/system/perf-hw-ring-merge/src/perf_hw_ring_merge.c
+++ b/test-suit/starryos/qemu-smp1/system/perf-hw-ring-merge/src/perf_hw_ring_merge.c
@@ -209,6 +209,7 @@ int main(void) {
     for (uint64_t i = 0; i < 60000000ull; i++) {
         spin += i;
     }
+    (void)spin;
     (void)ioctl(afd, PERF_EVENT_IOC_DISABLE, 0);
     (void)ioctl(bfd, PERF_EVENT_IOC_DISABLE, 0);
 

--- a/test-suit/starryos/qemu-smp1/system/perf-hw-sample/src/perf_hw_sample.c
+++ b/test-suit/starryos/qemu-smp1/system/perf-hw-sample/src/perf_hw_sample.c
@@ -294,6 +294,7 @@ int main(void) {
     for (uint64_t i = 0; i < 200000000ull; i++) {
         spin += i;
     }
+    (void)spin;
 
     (void)ioctl(efd, PERF_EVENT_IOC_DISABLE, 0);
 

--- a/test-suit/starryos/qemu-smp1/system/perf-hw-stat/src/perf_hw_stat.c
+++ b/test-suit/starryos/qemu-smp1/system/perf-hw-stat/src/perf_hw_stat.c
@@ -220,6 +220,7 @@ int main(void) {
     for (uint64_t i = 0; i < 30000000ull; i++) {
         spin += i;
     }
+    (void)spin;
 
     (void)ioctl(efd_a, PERF_EVENT_IOC_DISABLE, 0);
     (void)ioctl(efd_b, PERF_EVENT_IOC_DISABLE, 0);


### PR DESCRIPTION
  ## Summary

  Fix compiler warnings in Starry perf-hw system tests by explicitly marking the busy-loop accumulator as used.

  Changes:
  - add `(void)spin;` after intentional workload loops in 7 perf-hw tests
  - preserve the busy loops used to generate perf events
  - no behavior change to the perf test logic

  Affected tests:
  - `perf-hw-cycles`
  - `perf-hw-freq`
  - `perf-hw-pmu-sysfs`
  - `perf-hw-rdpmc`
  - `perf-hw-ring-merge`
  - `perf-hw-sample`
  - `perf-hw-stat`
