### PR TITLE
feat(axbuild): add ArceOS dynamic board flow

### DIFF
--- a/os/arceos/configs/board/orangepi-5-plus.toml
+++ b/os/arceos/configs/board/orangepi-5-plus.toml
@@ -1,0 +1,6 @@
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = true
+features = []
+log = "Info"
+max_cpu_num = 1

--- a/scripts/axbuild/src/arceos/board.rs
+++ b/scripts/axbuild/src/arceos/board.rs
@@ -1,0 +1,208 @@
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, anyhow, bail};
+use serde::Deserialize;
+
+use super::{
+    ArgsBoard,
+    build::{ArceosBuildConfig, ArceosBuildFile},
+};
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct ArceosBoardFile {
+    pub(crate) package: String,
+    pub(crate) target: String,
+    #[serde(flatten)]
+    pub(crate) build_config: ArceosBuildConfig,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Board {
+    pub(crate) name: String,
+    pub(crate) path: PathBuf,
+    pub(crate) package: String,
+    pub(crate) target: String,
+    pub(crate) build_config: ArceosBuildConfig,
+}
+
+pub(crate) fn arceos_dir(workspace_root: &Path) -> anyhow::Result<PathBuf> {
+    let path = workspace_root.join("os/arceos");
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(anyhow!(
+            "failed to locate ArceOS directory under {}",
+            workspace_root.display()
+        ))
+    }
+}
+
+pub(crate) fn board_dir(workspace_root: &Path) -> anyhow::Result<PathBuf> {
+    Ok(arceos_dir(workspace_root)?.join("configs/board"))
+}
+
+pub(crate) fn load_build_file(path: &Path) -> anyhow::Result<ArceosBuildFile> {
+    let file = super::build::load_arceos_build_file(path)?;
+    reject_static_build_config(path, &file.config)?;
+    Ok(file)
+}
+
+pub(crate) fn load_board_file(path: &Path) -> anyhow::Result<ArceosBoardFile> {
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("failed to read ArceOS board config {}", path.display()))?;
+    crate::build::reject_removed_std_field(path, &contents)?;
+    let board_file: ArceosBoardFile = toml::from_str(&contents)
+        .with_context(|| format!("failed to parse ArceOS board config {}", path.display()))?;
+    reject_static_build_config(path, &board_file.build_config)?;
+    Ok(board_file)
+}
+
+fn reject_static_build_config(path: &Path, config: &ArceosBuildConfig) -> anyhow::Result<()> {
+    if !config.build_info.plat_dyn {
+        bail!(
+            "ArceOS board config {} must use dynamic platform (`plat_dyn = true`); static \
+             platform board configs are not supported by `arceos board/config`",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_static_board_args(args: &ArgsBoard) -> anyhow::Result<()> {
+    if args.build.plat_dyn == Some(false) {
+        bail!(
+            "`arceos board` only supports dynamic platform builds; remove `--plat-dyn false` or \
+             pass `--plat-dyn true`"
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn board_default_list(workspace_root: &Path) -> anyhow::Result<Vec<Board>> {
+    let board_dir = board_dir(workspace_root)?;
+    let mut boards = Vec::new();
+    for entry in fs::read_dir(&board_dir).map_err(|e| {
+        anyhow!(
+            "failed to read ArceOS board config directory {}: {e}",
+            board_dir.display()
+        )
+    })? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension() != Some(OsStr::new("toml")) {
+            continue;
+        }
+
+        let name = path
+            .file_stem()
+            .and_then(OsStr::to_str)
+            .ok_or_else(|| anyhow!("invalid ArceOS board filename {}", path.display()))?
+            .to_string();
+        let board_file = load_board_file(&path)?;
+        boards.push(Board {
+            name,
+            path,
+            package: board_file.package,
+            target: board_file.target,
+            build_config: board_file.build_config,
+        });
+    }
+    boards.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(boards)
+}
+
+pub(crate) fn find_board(workspace_root: &Path, name: &str) -> anyhow::Result<Option<Board>> {
+    Ok(board_default_list(workspace_root)?
+        .into_iter()
+        .find(|board| board.name == name))
+}
+
+pub(crate) fn board_names(workspace_root: &Path) -> anyhow::Result<Vec<String>> {
+    Ok(board_default_list(workspace_root)?
+        .into_iter()
+        .map(|board| board.name)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn write_workspace(root: &Path) {
+        fs::create_dir_all(root.join("os/arceos")).unwrap();
+        fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"apps/arceos/helloworld\"]\n",
+        )
+        .unwrap();
+    }
+
+    fn write_board(root: &Path, name: &str, body: &str) {
+        let path = board_dir(root).unwrap().join(format!("{name}.toml"));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn loads_dynamic_board_names_in_filename_order() {
+        let root = tempdir().unwrap();
+        write_workspace(root.path());
+        write_board(
+            root.path(),
+            "z-board",
+            r#"
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = true
+features = []
+log = "Info"
+"#,
+        );
+        write_board(
+            root.path(),
+            "a-board",
+            r#"
+package = "arceos-helloworld"
+target = "x86_64-unknown-none"
+plat_dyn = true
+features = []
+log = "Info"
+"#,
+        );
+
+        assert_eq!(
+            board_names(root.path()).unwrap(),
+            vec!["a-board".to_string(), "z-board".to_string()]
+        );
+    }
+
+    #[test]
+    fn load_board_rejects_static_platform_template() {
+        let root = tempdir().unwrap();
+        write_workspace(root.path());
+        let path = board_dir(root.path()).unwrap().join("static.toml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = false
+features = []
+log = "Info"
+"#,
+        )
+        .unwrap();
+
+        let err = load_board_file(&path).unwrap_err().to_string();
+        assert!(err.contains("dynamic platform"));
+    }
+}

--- a/scripts/axbuild/src/arceos/build/c_app.rs
+++ b/scripts/axbuild/src/arceos/build/c_app.rs
@@ -5,15 +5,19 @@ use std::{
 
 use anyhow::{Context, bail};
 
-use super::{ArceosBuildConfig, ArceosBuildMode};
+use super::{ArceosBuildConfig, ArceosBuildFile, ArceosBuildMode};
 use crate::build;
 
-pub(crate) fn load_arceos_build_config(path: &Path) -> anyhow::Result<ArceosBuildConfig> {
+pub(crate) fn load_arceos_build_file(path: &Path) -> anyhow::Result<ArceosBuildFile> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("failed to read ArceOS build config {}", path.display()))?;
     build::reject_removed_std_field(path, &content)?;
     toml::from_str(&content)
         .with_context(|| format!("failed to parse ArceOS build config {}", path.display()))
+}
+
+pub(crate) fn load_arceos_build_config(path: &Path) -> anyhow::Result<ArceosBuildConfig> {
+    Ok(load_arceos_build_file(path)?.config)
 }
 
 pub(crate) fn load_arceos_build_mode(path: &Path) -> anyhow::Result<ArceosBuildMode> {

--- a/scripts/axbuild/src/arceos/build/mod.rs
+++ b/scripts/axbuild/src/arceos/build/mod.rs
@@ -7,11 +7,11 @@ mod types;
 
 use std::path::{Path, PathBuf};
 
-pub(crate) use c_app::{load_arceos_build_config, load_arceos_build_mode};
+pub(crate) use c_app::{load_arceos_build_config, load_arceos_build_file, load_arceos_build_mode};
 pub(crate) use cargo_config::{load_c_app_cargo_config, load_cargo_config};
 pub(crate) use info::resolve_build_info_path;
 pub use ostool::build::config::LogLevel;
-pub(crate) use types::{ArceosBuildConfig, ArceosBuildInfo, ArceosBuildMode};
+pub(crate) use types::{ArceosBuildConfig, ArceosBuildFile, ArceosBuildInfo, ArceosBuildMode};
 
 pub(crate) fn resolve_app_c_dir(config_path: &Path, app_c: &Path) -> anyhow::Result<PathBuf> {
     c_app::resolve_app_c_dir(config_path, app_c)

--- a/scripts/axbuild/src/arceos/build/types.rs
+++ b/scripts/axbuild/src/arceos/build/types.rs
@@ -24,6 +24,17 @@ impl ArceosBuildConfig {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub(crate) struct ArceosBuildFile {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) package: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) target: Option<String>,
+    #[serde(flatten)]
+    pub(crate) config: ArceosBuildConfig,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ArceosBuildMode {
     RustStd,

--- a/scripts/axbuild/src/arceos/config.rs
+++ b/scripts/axbuild/src/arceos/config.rs
@@ -1,0 +1,193 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::anyhow;
+
+use super::board::{self, Board};
+use crate::context::{
+    ArceosCommandSnapshot, ArceosQemuSnapshot, ArceosUbootSnapshot, arch_for_target_checked,
+    snapshot_path_value,
+};
+
+pub(crate) fn available_board_names(workspace_root: &Path) -> anyhow::Result<Vec<String>> {
+    board::board_names(workspace_root)
+}
+
+fn resolve_board(workspace_root: &Path, name: &str) -> anyhow::Result<Board> {
+    board::find_board(workspace_root, name)?.ok_or_else(|| {
+        let available = available_board_names(workspace_root).unwrap_or_default();
+        anyhow!(
+            "unknown ArceOS board `{name}` in {}; available boards: {}",
+            board::board_dir(workspace_root)
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|_| "os/arceos/configs/board".to_string()),
+            available.join(", ")
+        )
+    })
+}
+
+fn write_board_to_default_build_config(
+    workspace_root: &Path,
+    board: &Board,
+) -> anyhow::Result<PathBuf> {
+    let build_config_path = crate::build::default_build_info_path_in_workspace(
+        workspace_root,
+        &board.package,
+        &board.target,
+    );
+    if let Some(parent) = build_config_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(&board.path, &build_config_path).map_err(|e| {
+        anyhow!(
+            "failed to copy ArceOS board config {} to {}: {e}",
+            board.path.display(),
+            build_config_path.display()
+        )
+    })?;
+    Ok(build_config_path)
+}
+
+fn update_snapshot_for_board(
+    workspace_root: &Path,
+    board: &Board,
+    build_config_path: &Path,
+) -> anyhow::Result<()> {
+    let snapshot = ArceosCommandSnapshot {
+        package: Some(board.package.clone()),
+        arch: Some(arch_for_target_checked(&board.target)?.to_string()),
+        target: Some(board.target.clone()),
+        plat_dyn: Some(true),
+        smp: board.build_config.build_info.max_cpu_num,
+        config: Some(snapshot_path_value(workspace_root, build_config_path)),
+        qemu: ArceosQemuSnapshot::default(),
+        uboot: ArceosUbootSnapshot::default(),
+    };
+    snapshot.store(workspace_root)?;
+    Ok(())
+}
+
+pub(crate) fn write_defconfig(workspace_root: &Path, board_name: &str) -> anyhow::Result<PathBuf> {
+    let board = resolve_board(workspace_root, board_name)?;
+    let build_config_path = write_board_to_default_build_config(workspace_root, &board)?;
+    update_snapshot_for_board(workspace_root, &board, &build_config_path)?;
+    Ok(build_config_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::context::{ArceosCommandSnapshot, ArceosQemuSnapshot, ArceosUbootSnapshot};
+
+    fn write_workspace(root: &Path) {
+        fs::create_dir_all(root.join("os/arceos")).unwrap();
+        fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"apps/arceos/helloworld\"]\n",
+        )
+        .unwrap();
+    }
+
+    fn write_board(root: &Path, name: &str, body: &str) {
+        let path = crate::arceos::board::board_dir(root)
+            .unwrap()
+            .join(format!("{name}.toml"));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn write_defconfig_generates_dynamic_build_toml_and_updates_snapshot() {
+        let root = tempdir().unwrap();
+        write_workspace(root.path());
+        write_board(
+            root.path(),
+            "orangepi-5-plus",
+            r#"
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = true
+features = []
+log = "Info"
+max_cpu_num = 1
+"#,
+        );
+        let existing_snapshot = ArceosCommandSnapshot {
+            package: Some("old-package".to_string()),
+            arch: Some("riscv64".to_string()),
+            target: Some("riscv64gc-unknown-none-elf".to_string()),
+            plat_dyn: Some(false),
+            smp: Some(4),
+            config: None,
+            qemu: ArceosQemuSnapshot {
+                qemu_config: Some("configs/qemu.toml".into()),
+            },
+            uboot: ArceosUbootSnapshot {
+                uboot_config: Some("configs/uboot.toml".into()),
+            },
+        };
+        existing_snapshot.store(root.path()).unwrap();
+
+        let path = write_defconfig(root.path(), "orangepi-5-plus").unwrap();
+
+        assert_eq!(
+            path,
+            root.path().join(
+                "tmp/axbuild/config/arceos-helloworld/build-aarch64-unknown-none-softfloat.toml"
+            )
+        );
+        let written = fs::read_to_string(&path).unwrap();
+        assert!(written.contains("package = \"arceos-helloworld\""));
+        assert!(written.contains("target = \"aarch64-unknown-none-softfloat\""));
+        assert!(written.contains("plat_dyn = true"));
+        assert!(!written.contains("axconfig"));
+
+        let snapshot = ArceosCommandSnapshot::load(root.path()).unwrap();
+        assert_eq!(snapshot.package.as_deref(), Some("arceos-helloworld"));
+        assert_eq!(snapshot.arch.as_deref(), Some("aarch64"));
+        assert_eq!(
+            snapshot.target.as_deref(),
+            Some("aarch64-unknown-none-softfloat")
+        );
+        assert_eq!(snapshot.plat_dyn, Some(true));
+        assert_eq!(snapshot.smp, Some(1));
+        assert_eq!(
+            snapshot.config,
+            Some(
+                "tmp/axbuild/config/arceos-helloworld/build-aarch64-unknown-none-softfloat.toml"
+                    .into()
+            )
+        );
+        assert_eq!(snapshot.qemu.qemu_config, None);
+        assert_eq!(snapshot.uboot.uboot_config, None);
+    }
+
+    #[test]
+    fn write_defconfig_reports_board_directory_for_unknown_name() {
+        let root = tempdir().unwrap();
+        write_workspace(root.path());
+        write_board(
+            root.path(),
+            "orangepi-5-plus",
+            r#"
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = true
+features = []
+log = "Info"
+"#,
+        );
+
+        let err = write_defconfig(root.path(), "missing")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown ArceOS board `missing`"));
+        assert!(err.contains("orangepi-5-plus"));
+    }
+}

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -7,7 +7,11 @@ use std::{
 use anyhow::Context;
 use clap::{Args, Subcommand};
 use log::warn;
-use ostool::{build::config::Cargo, run::qemu::QemuConfig};
+use ostool::{
+    board::{RunBoardOptions, config::BoardRunConfig},
+    build::config::Cargo,
+    run::qemu::QemuConfig,
+};
 
 use crate::{
     context::{AppContext, BuildCliArgs, ResolvedBuildRequest, SnapshotPersistence},
@@ -77,8 +81,10 @@ fn should_recreate_runtime_image(workspace_root: &Path, image: &Path) -> bool {
     image.starts_with(crate::context::axbuild_tmp_dir(workspace_root).join("runtime-assets"))
 }
 
+mod board;
 pub mod build;
 pub mod cbuild;
+pub mod config;
 pub mod rootfs;
 pub mod test;
 
@@ -106,10 +112,16 @@ pub enum Command {
     Build(ArgsBuild),
     /// Build and run ArceOS application in QEMU
     Qemu(ArgsQemu),
+    /// Generate a default ArceOS dynamic board config
+    Defconfig(ArgsDefconfig),
+    /// ArceOS board config helpers
+    Config(ArgsConfig),
     /// Run ArceOS test suites
     Test(test::ArgsTest),
     /// Build and run ArceOS application with U-Boot
     Uboot(ArgsUboot),
+    /// Build and run ArceOS application on a remote board
+    Board(ArgsBoard),
 }
 
 #[derive(Args)]
@@ -154,6 +166,41 @@ pub struct ArgsUboot {
     pub uboot_config: Option<PathBuf>,
 }
 
+#[derive(Args)]
+pub struct ArgsBoard {
+    #[command(flatten)]
+    pub build: ArgsBuild,
+
+    #[arg(long = "board-config")]
+    pub board_config: Option<PathBuf>,
+
+    #[arg(short = 'b', long = "board-type")]
+    pub board_type: Option<String>,
+
+    #[arg(long)]
+    pub server: Option<String>,
+
+    #[arg(long)]
+    pub port: Option<u16>,
+}
+
+#[derive(Args)]
+pub struct ArgsDefconfig {
+    pub board: String,
+}
+
+#[derive(Args)]
+pub struct ArgsConfig {
+    #[command(subcommand)]
+    pub command: ConfigCommand,
+}
+
+#[derive(Subcommand)]
+pub enum ConfigCommand {
+    /// List available board names
+    Ls,
+}
+
 // ---------------------------------------------------------------------------
 // ArceOS executor
 // ---------------------------------------------------------------------------
@@ -186,7 +233,10 @@ impl ArceOS {
         match command {
             Command::Build(args) => self.build(args).await,
             Command::Qemu(args) => self.qemu(args).await,
+            Command::Defconfig(args) => self.defconfig(args),
+            Command::Config(args) => self.config(args),
             Command::Uboot(args) => self.uboot(args).await,
+            Command::Board(args) => self.board(args).await,
             Command::Test(args) => self.test(args).await,
         }
     }
@@ -219,6 +269,39 @@ impl ArceOS {
             SnapshotPersistence::Store,
         )?;
         self.run_uboot_request(request).await
+    }
+
+    fn defconfig(&mut self, args: ArgsDefconfig) -> anyhow::Result<()> {
+        let path = config::write_defconfig(self.app.workspace_root(), &args.board)?;
+        println!("Generated {} for board {}", path.display(), args.board);
+        Ok(())
+    }
+
+    fn config(&mut self, args: ArgsConfig) -> anyhow::Result<()> {
+        match args.command {
+            ConfigCommand::Ls => {
+                for board in config::available_board_names(self.app.workspace_root())? {
+                    println!("{board}");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn board(&mut self, args: ArgsBoard) -> anyhow::Result<()> {
+        board::reject_static_board_args(&args)?;
+        let request =
+            self.prepare_request((&args.build).into(), None, None, SnapshotPersistence::Store)?;
+        self.run_board_request(
+            request,
+            args.board_config,
+            RunBoardOptions {
+                board_type: args.board_type,
+                server: args.server,
+                port: args.port,
+            },
+        )
+        .await
     }
 
     // ---- test dispatch ----
@@ -282,6 +365,39 @@ impl ArceOS {
         }
     }
 
+    async fn load_board_config(
+        &mut self,
+        cargo: &Cargo,
+        board_config_path: Option<&Path>,
+    ) -> anyhow::Result<BoardRunConfig> {
+        match board_config_path {
+            Some(path) => {
+                self.app
+                    .read_board_run_config_from_path_for_cargo(cargo, path)
+                    .await
+            }
+            None => {
+                let workspace_root = self.app.workspace_root().to_path_buf();
+                self.app
+                    .ensure_board_run_config_in_dir_for_cargo(cargo, &workspace_root)
+                    .await
+            }
+        }
+    }
+
+    fn reject_static_board_request(request: &ResolvedBuildRequest) -> anyhow::Result<()> {
+        if request.plat_dyn == Some(false) {
+            anyhow::bail!(
+                "`arceos board` only supports dynamic platform builds; snapshot or CLI selected \
+                 `plat_dyn = false`"
+            );
+        }
+        if request.build_info_path.exists() {
+            board::load_build_file(&request.build_info_path)?;
+        }
+        Ok(())
+    }
+
     async fn run_qemu_request(&mut self, request: ResolvedBuildRequest) -> anyhow::Result<()> {
         match build::load_arceos_build_mode(&request.build_info_path)? {
             build::ArceosBuildMode::RustStd => {
@@ -290,6 +406,44 @@ impl ArceOS {
             }
             build::ArceosBuildMode::AppC { app_dir, app_name } => {
                 self.run_c_app_qemu_request(request, app_dir, app_name)
+                    .await
+            }
+        }
+    }
+
+    async fn run_board_request(
+        &mut self,
+        request: ResolvedBuildRequest,
+        board_config_path: Option<PathBuf>,
+        options: RunBoardOptions,
+    ) -> anyhow::Result<()> {
+        Self::reject_static_board_request(&request)?;
+        self.app.set_debug_mode(request.debug)?;
+        match build::load_arceos_build_mode(&request.build_info_path)? {
+            build::ArceosBuildMode::RustStd => {
+                let cargo = build::load_cargo_config(&request)?;
+                let board_config = self
+                    .load_board_config(&cargo, board_config_path.as_deref())
+                    .await?;
+                self.app
+                    .board(cargo, request.build_info_path, board_config, options)
+                    .await
+            }
+            build::ArceosBuildMode::AppC { app_dir, app_name } => {
+                let request = c_app_internal_request(&request);
+                let cargo = build::load_c_app_cargo_config(&request)?;
+                let board_config = self
+                    .load_board_config(&cargo, board_config_path.as_deref())
+                    .await?;
+                let output = self.build_c_app_request(&request, app_dir, app_name)?;
+                self.app
+                    .board_prepared_elf(
+                        output.elf_path,
+                        cargo.to_bin,
+                        request.build_info_path,
+                        board_config,
+                        options,
+                    )
                     .await
             }
         }
@@ -433,9 +587,89 @@ fn c_app_internal_request(request: &ResolvedBuildRequest) -> ResolvedBuildReques
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
     use tempfile::tempdir;
 
     use super::*;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(subcommand)]
+        command: Command,
+    }
+
+    fn parse(args: impl IntoIterator<Item = &'static str>) -> Command {
+        Cli::try_parse_from(args).unwrap().command
+    }
+
+    #[test]
+    fn command_parses_defconfig() {
+        match parse(["arceos", "defconfig", "orangepi-5-plus"]) {
+            Command::Defconfig(args) => assert_eq!(args.board, "orangepi-5-plus"),
+            _ => panic!("expected defconfig command"),
+        }
+    }
+
+    #[test]
+    fn command_parses_config_ls() {
+        match parse(["arceos", "config", "ls"]) {
+            Command::Config(args) => match args.command {
+                ConfigCommand::Ls => {}
+            },
+            _ => panic!("expected config ls command"),
+        }
+    }
+
+    #[test]
+    fn command_parses_board() {
+        match parse([
+            "arceos",
+            "board",
+            "--config",
+            "build.toml",
+            "--board-config",
+            "board.toml",
+            "-b",
+            "OrangePi-5-Plus",
+            "--server",
+            "10.0.0.2",
+            "--port",
+            "9000",
+        ]) {
+            Command::Board(args) => {
+                assert_eq!(args.build.config, Some(PathBuf::from("build.toml")));
+                assert_eq!(args.board_config, Some(PathBuf::from("board.toml")));
+                assert_eq!(args.board_type.as_deref(), Some("OrangePi-5-Plus"));
+                assert_eq!(args.server.as_deref(), Some("10.0.0.2"));
+                assert_eq!(args.port, Some(9000));
+            }
+            _ => panic!("expected board command"),
+        }
+    }
+
+    #[test]
+    fn board_rejects_static_platform_override() {
+        let args = ArgsBoard {
+            build: ArgsBuild {
+                config: Some(PathBuf::from("build.toml")),
+                package: None,
+                arch: None,
+                target: None,
+                plat_dyn: Some(false),
+                smp: None,
+                debug: false,
+            },
+            board_config: None,
+            board_type: None,
+            server: None,
+            port: None,
+        };
+
+        let err = board::reject_static_board_args(&args)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("dynamic platform"));
+    }
 
     #[test]
     fn qemu_runtime_disk_images_finds_disk_img_drive_paths() {

--- a/scripts/axbuild/src/arceos/test/args.rs
+++ b/scripts/axbuild/src/arceos/test/args.rs
@@ -11,6 +11,8 @@ pub struct ArgsTest {
 pub enum TestCommand {
     /// Run ArceOS QEMU test suites (Rust + C by default)
     Qemu(ArgsTestQemu),
+    /// Run ArceOS remote board test suite
+    Board(ArgsTestBoard),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -69,6 +71,36 @@ pub struct ArgsTestQemu {
     pub keep_qemu_log: bool,
 }
 
+#[derive(Args, Debug, Clone, Default)]
+pub struct ArgsTestBoard {
+    #[arg(
+        short = 'c',
+        long = "test-case",
+        value_name = "CASE",
+        help = "Run only one ArceOS board test case"
+    )]
+    pub test_case: Option<String>,
+
+    #[arg(
+        long,
+        value_name = "BOARD",
+        help = "Run all ArceOS board test cases for one board"
+    )]
+    pub board: Option<String>,
+
+    #[arg(short = 'b', long = "board-type", value_name = "BOARD_TYPE")]
+    pub board_type: Option<String>,
+
+    #[arg(long)]
+    pub server: Option<String>,
+
+    #[arg(long)]
+    pub port: Option<u16>,
+
+    #[arg(short = 'l', long, help = "List discovered ArceOS board test cases")]
+    pub list: bool,
+}
+
 pub(super) fn reject_removed_rust_package_filter(args: &ArgsTestQemu) -> anyhow::Result<()> {
     if args.package.is_empty() {
         return Ok(());
@@ -107,6 +139,7 @@ mod tests {
                     assert!(!args.only_rust);
                     assert!(!args.only_c);
                 }
+                _ => panic!("expected qemu test command"),
             },
             _ => panic!("expected test command"),
         }
@@ -139,6 +172,7 @@ mod tests {
                     assert!(args.only_rust);
                     assert!(!args.only_c);
                 }
+                _ => panic!("expected qemu test command"),
             },
             _ => panic!("expected test command"),
         }
@@ -171,6 +205,7 @@ mod tests {
                     assert!(!args.only_rust);
                     assert!(args.only_c);
                 }
+                _ => panic!("expected qemu test command"),
             },
             _ => panic!("expected test command"),
         }
@@ -226,6 +261,47 @@ mod tests {
                     assert!(!args.only_rust);
                     assert!(!args.only_c);
                 }
+                _ => panic!("expected qemu test command"),
+            },
+            _ => panic!("expected test command"),
+        }
+    }
+
+    #[test]
+    fn command_parses_test_board() {
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: Command,
+        }
+
+        let cli = Cli::try_parse_from([
+            "arceos",
+            "test",
+            "board",
+            "-c",
+            "boot",
+            "--board",
+            "orangepi-5-plus",
+            "-b",
+            "OrangePi-5-Plus",
+            "--server",
+            "10.0.0.2",
+            "--port",
+            "9000",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Test(args) => match args.command {
+                TestCommand::Board(args) => {
+                    assert_eq!(args.test_case.as_deref(), Some("boot"));
+                    assert_eq!(args.board.as_deref(), Some("orangepi-5-plus"));
+                    assert_eq!(args.board_type.as_deref(), Some("OrangePi-5-Plus"));
+                    assert_eq!(args.server.as_deref(), Some("10.0.0.2"));
+                    assert_eq!(args.port, Some(9000));
+                }
+                _ => panic!("expected board test command"),
             },
             _ => panic!("expected test command"),
         }

--- a/scripts/axbuild/src/arceos/test/board.rs
+++ b/scripts/axbuild/src/arceos/test/board.rs
@@ -1,0 +1,224 @@
+use std::path::Path;
+
+use anyhow::Context;
+use ostool::board::RunBoardOptions;
+
+use super::{ARCEOS_TEST_SUITE_OS, ArgsTestBoard, types::ArceosBoardTestGroup};
+use crate::{
+    arceos::ArceOS,
+    context::{BuildCliArgs, SnapshotPersistence, arch_for_target_checked},
+    test::{board as board_test, qemu as qemu_test, suite as test_suite},
+};
+
+pub(crate) fn collect_board_test_groups(
+    _workspace_root: &Path,
+    test_suite_dir: &Path,
+) -> anyhow::Result<Vec<ArceosBoardTestGroup>> {
+    let mut groups = Vec::new();
+    for info in board_test::discover_board_case_build_infos(test_suite_dir, "ArceOS")? {
+        let build_file = crate::arceos::board::load_build_file(&info.build_config_path)
+            .with_context(|| {
+                format!(
+                    "failed to load ArceOS board build config `{}`",
+                    info.build_config_path.display()
+                )
+            })?;
+        let package = build_file.package.with_context(|| {
+            format!(
+                "ArceOS board build config `{}` must set `package`",
+                info.build_config_path.display()
+            )
+        })?;
+        let target = build_file.target.with_context(|| {
+            format!(
+                "ArceOS board build config `{}` must set `target`",
+                info.build_config_path.display()
+            )
+        })?;
+        let arch = arch_for_target_checked(&target)?.to_string();
+        groups.push(ArceosBoardTestGroup {
+            name: info.name,
+            board_name: info.board_name,
+            package,
+            arch,
+            target,
+            build_config_path: info.build_config_path,
+            board_test_config_path: info.board_test_config_path,
+        });
+    }
+
+    Ok(groups)
+}
+
+pub(crate) fn discover_board_test_groups(
+    workspace_root: &Path,
+    selected_case: Option<&str>,
+    selected_board: Option<&str>,
+) -> anyhow::Result<Vec<ArceosBoardTestGroup>> {
+    let suite_root = test_suite::suite_root(workspace_root, ARCEOS_TEST_SUITE_OS);
+    let mut groups = Vec::new();
+    for group in test_suite::discover_group_names(workspace_root, ARCEOS_TEST_SUITE_OS)? {
+        let group_dir = test_suite::group_dir(workspace_root, ARCEOS_TEST_SUITE_OS, &group);
+        groups.extend(collect_board_test_groups(workspace_root, &group_dir)?);
+    }
+
+    board_test::filter_board_test_groups(groups, selected_case, selected_board, "ArceOS", || {
+        format!(
+            "no ArceOS board test groups found under {}",
+            suite_root.display()
+        )
+    })
+}
+
+impl ArceOS {
+    pub(super) async fn test_board(&mut self, args: ArgsTestBoard) -> anyhow::Result<()> {
+        let groups = discover_board_test_groups(
+            self.app.workspace_root(),
+            args.test_case.as_deref(),
+            args.board.as_deref(),
+        )?;
+        if args.list {
+            let case_names = board_test::labeled_board_cases(groups);
+            println!(
+                "{}",
+                qemu_test::render_labeled_case_forest("arceos", [("board", case_names)])
+            );
+            return Ok(());
+        }
+
+        let mut run_state = board_test::BoardTestRunState::new("arceos", groups.len());
+        for (index, group) in groups.into_iter().enumerate() {
+            let group_label = run_state.start_group(index, &group);
+            let board_test_config = group.board_test_config_path.clone();
+            let board_test_config_summary = board_test_config.display().to_string();
+            if !board_test_config.exists() {
+                run_state.fail_group(
+                    group_label,
+                    anyhow::anyhow!("missing board test config `{board_test_config_summary}`"),
+                );
+                continue;
+            }
+
+            let result = async {
+                let request = self.prepare_request(
+                    test_board_build_args(&group),
+                    None,
+                    None,
+                    SnapshotPersistence::Discard,
+                )?;
+                self.run_board_request(
+                    request,
+                    Some(board_test_config.clone()),
+                    RunBoardOptions {
+                        board_type: args.board_type.clone(),
+                        server: args.server.clone(),
+                        port: args.port,
+                    },
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "arceos board test failed for group `{}` (build_config={}, \
+                         board_test_config={})",
+                        group_label,
+                        group.build_config_path.display(),
+                        board_test_config_summary
+                    )
+                })
+            }
+            .await;
+
+            match result {
+                Ok(()) => run_state.pass_group(&group_label),
+                Err(err) => run_state.fail_group(group_label, err),
+            }
+        }
+        run_state.finish()
+    }
+}
+
+fn test_board_build_args(group: &ArceosBoardTestGroup) -> BuildCliArgs {
+    BuildCliArgs {
+        config: Some(group.build_config_path.clone()),
+        package: Some(group.package.clone()),
+        arch: None,
+        target: Some(group.target.clone()),
+        plat_dyn: Some(true),
+        smp: None,
+        debug: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn write_board_group(root: &Path) {
+        let group = root.join("test-suit/arceos/board-orangepi-5-plus");
+        let boot = group.join("boot");
+        fs::create_dir_all(&boot).unwrap();
+        fs::write(
+            group.join("build-aarch64-unknown-none-softfloat.toml"),
+            r#"
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = true
+features = []
+log = "Info"
+max_cpu_num = 1
+"#,
+        )
+        .unwrap();
+        fs::write(
+            boot.join("board-orangepi-5-plus.toml"),
+            r#"
+board_type = "OrangePi-5-Plus"
+success_regex = ["Hello, world!"]
+fail_regex = ["(?i)panic"]
+"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn collect_board_test_groups_reads_package_and_target_from_build_config() {
+        let root = tempdir().unwrap();
+        write_board_group(root.path());
+        let group_dir = root.path().join("test-suit/arceos/board-orangepi-5-plus");
+
+        let groups = collect_board_test_groups(root.path(), &group_dir).unwrap();
+
+        assert_eq!(groups.len(), 1);
+        let group = &groups[0];
+        assert_eq!(group.name, "boot");
+        assert_eq!(group.board_name, "orangepi-5-plus");
+        assert_eq!(group.package, "arceos-helloworld");
+        assert_eq!(group.arch, "aarch64");
+        assert_eq!(group.target, "aarch64-unknown-none-softfloat");
+        assert_eq!(
+            group.build_config_path,
+            group_dir.join("build-aarch64-unknown-none-softfloat.toml")
+        );
+        assert_eq!(
+            group.board_test_config_path,
+            group_dir.join("boot/board-orangepi-5-plus.toml")
+        );
+    }
+
+    #[test]
+    fn discover_board_test_groups_filters_by_case_and_board() {
+        let root = tempdir().unwrap();
+        write_board_group(root.path());
+
+        let groups =
+            discover_board_test_groups(root.path(), Some("boot"), Some("orangepi-5-plus")).unwrap();
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].name, "boot");
+        assert_eq!(groups[0].board_name, "orangepi-5-plus");
+    }
+}

--- a/scripts/axbuild/src/arceos/test/mod.rs
+++ b/scripts/axbuild/src/arceos/test/mod.rs
@@ -1,6 +1,7 @@
 mod args;
 mod assets;
 mod axtest_qemu;
+mod board;
 mod c_qemu;
 mod discovery;
 mod generic_qemu;
@@ -9,7 +10,7 @@ mod runner;
 mod rust_qemu;
 mod types;
 
-pub use args::{ArgsTest, ArgsTestQemu, TestCommand};
+pub use args::{ArgsTest, ArgsTestBoard, ArgsTestQemu, TestCommand};
 
 use crate::arceos::ArceOS;
 
@@ -80,5 +81,6 @@ const ARCEOS_C_QEMU_LISTED_CASES: &[&str] = &[
 pub(super) async fn test(arceos: &mut ArceOS, args: ArgsTest) -> anyhow::Result<()> {
     match args.command {
         TestCommand::Qemu(args) => runner::test_qemu(arceos, args).await,
+        TestCommand::Board(args) => arceos.test_board(args).await,
     }
 }

--- a/scripts/axbuild/src/arceos/test/types.rs
+++ b/scripts/axbuild/src/arceos/test/types.rs
@@ -4,7 +4,7 @@ use ostool::{build::config::Cargo, run::qemu::QemuConfig};
 
 use crate::{
     context::ResolvedBuildRequest,
-    test::{case::TestQemuCase, qemu as qemu_test},
+    test::{board as board_test, case::TestQemuCase, qemu as qemu_test},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,6 +31,27 @@ pub(super) struct PreparedArceosRustQemuCase {
     pub(super) cargo: Cargo,
     pub(super) qemu: QemuConfig,
     pub(super) host_symbolize_success_regex: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ArceosBoardTestGroup {
+    pub(crate) name: String,
+    pub(crate) board_name: String,
+    pub(crate) package: String,
+    pub(crate) arch: String,
+    pub(crate) target: String,
+    pub(crate) build_config_path: PathBuf,
+    pub(crate) board_test_config_path: PathBuf,
+}
+
+impl board_test::BoardTestGroupInfo for ArceosBoardTestGroup {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn board_name(&self) -> &str {
+        &self.board_name
+    }
 }
 
 impl qemu_test::BuildConfigRef for PreparedArceosRustQemuCase {

--- a/scripts/axbuild/src/context/resolve.rs
+++ b/scripts/axbuild/src/context/resolve.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context as _, anyhow};
+use anyhow::anyhow;
 
 use super::{
     ARCEOS_SNAPSHOT_FILE, AppContext, ArceosCommandSnapshot, ArceosQemuSnapshot,
@@ -15,6 +15,13 @@ use super::{
 struct ResolvedCommandPaths {
     qemu_config: Option<PathBuf>,
     uboot_config: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ArceosConfigSelectors {
+    package: Option<String>,
+    target: Option<String>,
+    uses_app_c: bool,
 }
 
 pub(crate) struct AxvisorRequestPaths<L, R> {
@@ -33,19 +40,34 @@ impl AppContext {
         resolve_build_info_path: impl FnOnce(&str, &str, Option<PathBuf>) -> anyhow::Result<PathBuf>,
     ) -> anyhow::Result<(ResolvedBuildRequest, ArceosCommandSnapshot)> {
         let snapshot = ArceosCommandSnapshot::load(&self.root)?;
-        let explicit_config_path = cli.config.clone();
-        let config_uses_app_c = explicit_config_path
+        let inherit_snapshot_config = cli.package.is_none()
+            && cli.arch.is_none()
+            && cli.target.is_none()
+            && cli.config.is_none();
+        let resolved_config = self.resolve_command_path(
+            cli.config.clone(),
+            inherit_snapshot_config
+                .then_some(snapshot.config.as_ref())
+                .flatten(),
+        );
+        let config_selectors = resolved_config
             .as_deref()
             .filter(|path| path.exists())
-            .map(arceos_config_uses_app_c)
+            .map(arceos_config_selectors)
             .transpose()?
-            .unwrap_or(false);
+            .unwrap_or_default();
+        let explicit_config_path = if cli.config.is_some() {
+            resolved_config
+        } else {
+            resolved_config.filter(|path| path.exists())
+        };
 
         let package = cli
             .package
             .clone()
+            .or(config_selectors.package)
             .or_else(|| {
-                if config_uses_app_c {
+                if config_selectors.uses_app_c {
                     Some("ax-libc".to_string())
                 } else {
                     snapshot.package.clone()
@@ -57,14 +79,15 @@ impl AppContext {
                     ARCEOS_SNAPSHOT_FILE
                 )
             })?;
+        let config_target = config_selectors.target;
         let effective_arch = cli.arch.clone().or_else(|| {
-            if cli.target.is_some() {
+            if cli.target.is_some() || config_target.is_some() {
                 None
             } else {
                 snapshot.arch.clone()
             }
         });
-        let effective_target = cli.target.clone().or_else(|| {
+        let effective_target = cli.target.clone().or(config_target).or_else(|| {
             if cli.arch.is_some() {
                 None
             } else {
@@ -107,7 +130,7 @@ impl AppContext {
             plat_dyn,
             smp,
             debug: cli.debug,
-            build_info_path,
+            build_info_path: build_info_path.clone(),
             qemu_config: runtime_paths.qemu_config.clone(),
             uboot_config: runtime_paths.uboot_config.clone(),
         };
@@ -118,6 +141,7 @@ impl AppContext {
             target: Some(target),
             plat_dyn,
             smp,
+            config: Some(snapshot_path_value(&self.root, &build_info_path)),
             qemu: ArceosQemuSnapshot {
                 qemu_config: runtime_paths
                     .qemu_config
@@ -407,13 +431,13 @@ impl AppContext {
     }
 }
 
-fn arceos_config_uses_app_c(path: &Path) -> anyhow::Result<bool> {
-    let contents = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read ArceOS build config {}", path.display()))?;
-    crate::build::reject_removed_std_field(path, &contents)?;
-    Ok(toml::from_str::<toml::Table>(&contents)
-        .map(|table| table.contains_key("app-c"))
-        .unwrap_or(false))
+fn arceos_config_selectors(path: &Path) -> anyhow::Result<ArceosConfigSelectors> {
+    let file = crate::arceos::build::load_arceos_build_file(path)?;
+    Ok(ArceosConfigSelectors {
+        package: file.package,
+        target: file.target,
+        uses_app_c: file.config.app_c.is_some(),
+    })
 }
 
 pub(crate) fn resolve_snapshot_path(root: &Path, path: Option<&PathBuf>) -> Option<PathBuf> {

--- a/scripts/axbuild/src/context/tests/arceos.rs
+++ b/scripts/axbuild/src/context/tests/arceos.rs
@@ -95,6 +95,163 @@ qemu_config = "configs/qemu.toml"
 }
 
 #[test]
+fn prepare_request_inherits_snapshot_config_when_no_explicit_selectors() {
+    let root = tempdir().unwrap();
+    let config_path = root.path().join("configs/board.toml");
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(
+        &config_path,
+        r#"
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = true
+features = []
+log = "Info"
+max_cpu_num = 1
+"#,
+    )
+    .unwrap();
+    write_snapshot_text(
+        root.path(),
+        ARCEOS_SNAPSHOT_FILE,
+        r#"
+config = "configs/board.toml"
+
+[qemu]
+qemu_config = "configs/qemu.toml"
+"#,
+    )
+    .unwrap();
+
+    let app = test_app_context(root.path());
+
+    let (request, snapshot) =
+        prepare_arceos_request(&app, BuildCliArgs::default(), None, None).unwrap();
+
+    assert_eq!(request.package, "arceos-helloworld");
+    assert_eq!(request.arch, "aarch64");
+    assert_eq!(request.target, "aarch64-unknown-none-softfloat");
+    assert_eq!(request.build_info_path, config_path);
+    assert_eq!(
+        request.qemu_config,
+        Some(root.path().join("configs/qemu.toml"))
+    );
+    assert_eq!(snapshot.config, Some(PathBuf::from("configs/board.toml")));
+}
+
+#[test]
+fn prepare_request_explicit_config_uses_package_and_target_selectors() {
+    let root = tempdir().unwrap();
+    let config_path = root.path().join("configs/orangepi.toml");
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(
+        &config_path,
+        r#"
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = true
+features = []
+log = "Info"
+"#,
+    )
+    .unwrap();
+    write_snapshot_text(
+        root.path(),
+        ARCEOS_SNAPSHOT_FILE,
+        r#"
+package = "from-snapshot"
+arch = "riscv64"
+target = "riscv64gc-unknown-none-elf"
+
+[qemu]
+qemu_config = "configs/qemu.toml"
+"#,
+    )
+    .unwrap();
+
+    let app = test_app_context(root.path());
+
+    let (request, snapshot) = prepare_arceos_request(
+        &app,
+        BuildCliArgs {
+            config: Some(config_path.clone()),
+            package: None,
+            arch: None,
+            target: None,
+            plat_dyn: None,
+            smp: None,
+            debug: false,
+        },
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(request.package, "arceos-helloworld");
+    assert_eq!(request.arch, "aarch64");
+    assert_eq!(request.target, "aarch64-unknown-none-softfloat");
+    assert_eq!(request.build_info_path, config_path);
+    assert_eq!(request.qemu_config, None);
+    assert_eq!(
+        snapshot.config,
+        Some(PathBuf::from("configs/orangepi.toml"))
+    );
+}
+
+#[test]
+fn prepare_request_explicit_package_does_not_inherit_snapshot_config() {
+    let root = tempdir().unwrap();
+    fs::create_dir_all(root.path().join("configs")).unwrap();
+    fs::write(
+        root.path().join("configs/orangepi.toml"),
+        r#"
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+plat_dyn = true
+"#,
+    )
+    .unwrap();
+    write_snapshot_text(
+        root.path(),
+        ARCEOS_SNAPSHOT_FILE,
+        r#"
+package = "from-snapshot"
+arch = "aarch64"
+target = "aarch64-unknown-none-softfloat"
+config = "configs/orangepi.toml"
+"#,
+    )
+    .unwrap();
+
+    let app = test_app_context(root.path());
+
+    let (request, snapshot) = prepare_arceos_request(
+        &app,
+        BuildCliArgs {
+            package: Some("arceos-helloworld".to_string()),
+            ..Default::default()
+        },
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(request.package, "arceos-helloworld");
+    assert_eq!(
+        request.build_info_path,
+        crate::arceos::build::default_build_info_path(
+            "arceos-helloworld",
+            "aarch64-unknown-none-softfloat",
+        )
+        .unwrap()
+    );
+    assert_ne!(
+        snapshot.config,
+        Some(PathBuf::from("configs/orangepi.toml"))
+    );
+}
+
+#[test]
 fn prepare_request_explicit_config_drops_snapshot_plat_dyn() {
     let root = tempdir().unwrap();
     write_snapshot_text(

--- a/scripts/axbuild/src/context/tests/snapshot.rs
+++ b/scripts/axbuild/src/context/tests/snapshot.rs
@@ -41,6 +41,7 @@ fn snapshot_store_round_trips() {
         target: Some("target".into()),
         plat_dyn: Some(true),
         smp: None,
+        config: Some(PathBuf::from("configs/build.toml")),
         qemu: ArceosQemuSnapshot {
             qemu_config: Some(PathBuf::from("configs/qemu.toml")),
         },

--- a/scripts/axbuild/src/context/types.rs
+++ b/scripts/axbuild/src/context/types.rs
@@ -71,6 +71,8 @@ pub struct ArceosCommandSnapshot {
     pub plat_dyn: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smp: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "ArceosQemuSnapshot::is_empty")]
     pub qemu: ArceosQemuSnapshot,
     #[serde(default, skip_serializing_if = "ArceosUbootSnapshot::is_empty")]

--- a/test-suit/arceos/board-orangepi-5-plus/boot/board-orangepi-5-plus.toml
+++ b/test-suit/arceos/board-orangepi-5-plus/boot/board-orangepi-5-plus.toml
@@ -1,0 +1,9 @@
+board_type = "OrangePi-5-Plus"
+success_regex = ["(?m)^Hello, world!\\s*$"]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)segmentation fault",
+    "(?i)SIGSEGV",
+    "exit with code: 139",
+]
+timeout = 300

--- a/test-suit/arceos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/arceos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,5 @@
+package = "arceos-helloworld"
+target = "aarch64-unknown-none-softfloat"
+features = []
+log = "Info"
+max_cpu_num = 1


### PR DESCRIPTION
## 问题

ArceOS 目前缺少和 Starry/Axvisor 类似的动态平台 board config/defconfig/test board 入口，OrangePi 5 Plus 真机冒烟测试也没有纳入 test-suit。这个变更只覆盖动态平台路径，不引入静态平台模板，也不生成或校验 `.axconfig`。

## 变更

- 为 `cargo xtask arceos` 增加 `config ls`、`defconfig <board>` 和 `board` 子命令。
- 为 ArceOS build config 增加可选 `package` / `target` selector，并让 `.arceos.toml` 记录和继承 `config`。
- 新增 ArceOS 动态 board 模板 `os/arceos/configs/board/orangepi-5-plus.toml`，默认选择 `arceos-helloworld`、`aarch64-unknown-none-softfloat` 和 `plat_dyn = true`。
- 新增 `arceos test board`，复用共享 board discovery/filter/summary helper。
- 在 `test-suit/arceos/board-orangepi-5-plus` 增加 OrangePi 5 Plus `boot` 冒烟用例，成功匹配 `Hello, world!`，失败匹配 panic/segfault/异常退出标记。

## 实现逻辑

- `defconfig` 只复制动态 build toml 到 `tmp/axbuild/config/<package>/build-<target>.toml`，并刷新 `.arceos.toml` 的 `package`、`arch`、`target`、`config`，同时清空旧 qemu/uboot runtime 路径。
- `arceos board` 和 board-test 路径会拒绝 `--plat-dyn false` 或静态 board build config，避免误进入静态平台/axconfig 流程。
- request resolution 仅在没有显式 package/arch/target/config 时继承 snapshot config；显式 config 可以从文件中的 selector 推导 package/target，旧配置保持兼容。

## 验证

- `cargo test -p axbuild --lib`
- `cargo xtask arceos config ls`
- `cargo xtask arceos defconfig orangepi-5-plus`
- `cargo xtask arceos build`
- `cargo xtask arceos test board --list`
- `cargo fmt --check`
- `cargo xtask clippy --package axbuild`

未在本地运行 OrangePi 5 Plus 真机测试；需要有可用板卡后执行 `cargo xtask arceos test board --board orangepi-5-plus --test-case boot -b OrangePi-5-Plus`。