### PR TITLE
chore(axvisor): clean std dynamic platform surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,17 +744,18 @@ dependencies = [
 
 [[package]]
 name = "ax-errno"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984a5bfdec820bd61a2cec72b0e3cf6359bc9d4aa1fdc7a4b13fc5d5a14cfa81"
+version = "0.6.1"
 dependencies = [
  "log",
+ "quote",
  "strum 0.27.2",
 ]
 
 [[package]]
 name = "ax-errno"
 version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c022cf0479c114aaf55acd23dedad5f0c7e4011142231e60e7a91f47cc070e6"
 dependencies = [
  "log",
  "quote",
@@ -1504,20 +1505,12 @@ dependencies = [
  "ax-driver",
  "ax-errno 0.6.1",
  "ax-hal",
- "ax-kspin",
- "ax-lazyinit",
- "ax-memory-addr",
  "ax-std",
  "axbuild",
- "axdevice",
- "axplat-dyn",
  "axtest",
  "axvm",
  "axvmconfig",
- "byte-unit",
  "clap",
- "fdt-parser",
- "hashbrown 0.14.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4537,7 +4530,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "939c71c68bfebd52de856c50f7650713e449fe8a83255e8cee53d8519500b5e0"
 dependencies = [
- "ax-errno 0.6.0",
+ "ax-errno 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 2.13.0",
  "int-enum",
  "lock_api",
@@ -4592,7 +4585,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71b521b03673eb47aa8b7d70ff6709fabdc9243ee9e713cacc08f5b0ffae2c2"
 dependencies = [
- "ax-errno 0.6.0",
+ "ax-errno 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield-struct 0.13.0",
  "bitflags 2.13.0",
  "cfg-if",

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -57,34 +57,24 @@ sdmmc = [
     "ax-driver/phytium-mci",
 ]
 rockchip-pm = ["ax-driver/rockchip-pm"]
-serial = []
 stack-protector = ["ax-std/stack-protector"]
-plat-dyn = ["dep:axplat-dyn"]
 
 [dependencies]
 spin = { workspace = true }
 
 [target.'cfg(any(not(any(windows, unix)), target_env = "musl"))'.dependencies]
-ax-kspin = { workspace = true }
-ax-lazyinit = { workspace = true }
 log = "0.4"
-byte-unit = { version = "5", default-features = false, features = ["byte"] }
-fdt-parser = "0.4"
-hashbrown = "0.14"
 
 # System dependent modules provided by ArceOS.
-ax-std = { workspace = true, features = ["ext-ld", "paging", "irq", "multitask", "task-ext", "smp", "hv"] }
+ax-std = { workspace = true, features = ["ext-ld", "paging", "irq", "multitask", "task-ext", "smp", "hv", "plat-dyn"] }
 ax-hal = { workspace = true, features = ["paging", "irq", "smp", "hv", "axvisor-linker"] }
 # System dependent modules provided by ArceOS-Hypervisor (bare-metal only)
 # ax-runtime = { version = "=0.3.0-preview.1", features = ["alloc", "irq", "paging", "smp", "multitask"] }
-axvm = { workspace = true, default-features = false }
+axvm = { workspace = true, default-features = false, features = ["plat-dyn"] }
 axvmconfig = { workspace = true, default-features = false }
-axdevice = { workspace = true }
 # System independent crates provided by ArceOS
 ax-errno = { workspace = true }
-ax-memory-addr = { workspace = true }
 ax-driver.workspace = true
-axplat-dyn = { workspace = true, optional = true }
 
 [dev-dependencies]
 axtest.workspace = true

--- a/os/axvisor/configs/board/qemu-loongarch64.toml
+++ b/os/axvisor/configs/board/qemu-loongarch64.toml
@@ -1,6 +1,5 @@
 features = [
   "ax-driver/virtio-blk",
-  "axplat-dyn/efi",
   "ept-level-4",
   "fs",
 ]

--- a/os/axvisor/src/banner.rs
+++ b/os/axvisor/src/banner.rs
@@ -1,0 +1,36 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::println;
+
+/// Startup banner printed before the hypervisor begins initialization.
+const LOGO: &str = r#"
+       d8888            888     888  d8b
+      d88888            888     888  Y8P
+     d88P888            888     888
+    d88P 888  888  888  Y88b   d88P  888  .d8888b    .d88b.   888d888
+   d88P  888  `Y8bd8P'   Y88b d88P   888  88K       d88""88b  888P"
+  d88P   888    X88K      Y88o88P    888  "Y8888b.  888  888  888
+ d8888888888  .d8""8b.     Y888P     888       X88  Y88..88P  888
+d88P     888  888  888      Y8P      888   88888P'   "Y88P"   888
+"#;
+
+/// Prints the startup banner to the console.
+pub(crate) fn print_logo() {
+    println!();
+    println!("{}", LOGO);
+    println!();
+    println!("by AxVisor Team");
+    println!();
+}

--- a/os/axvisor/src/main.rs
+++ b/os/axvisor/src/main.rs
@@ -21,9 +21,6 @@
 //! The implementation is intentionally small so that the boot order is visible
 //! from a single file.
 
-#![cfg_attr(target_os = "none", no_std)]
-#![cfg_attr(target_os = "none", no_main)]
-
 #[macro_use]
 extern crate log;
 
@@ -31,44 +28,11 @@ extern crate log;
 extern crate alloc;
 
 use ax_std as _;
-#[cfg(target_os = "none")]
-extern crate ax_std as std;
 
+mod banner;
 mod config;
 mod manager;
 mod shell;
-
-use std::println;
-
-/// Startup banners printed before the hypervisor begins initialization.
-const LOGO: [&str; 2] = [
-    r#"
-       d8888            888     888  d8b
-      d88888            888     888  Y8P
-     d88P888            888     888
-    d88P 888  888  888  Y88b   d88P  888  .d8888b    .d88b.   888d888
-   d88P  888  `Y8bd8P'   Y88b d88P   888  88K       d88""88b  888P"
-  d88P   888    X88K      Y88o88P    888  "Y8888b.  888  888  888
- d8888888888  .d8""8b.     Y888P     888       X88  Y88..88P  888
-d88P     888  888  888      Y8P      888   88888P'   "Y88P"   888
-"#,
-    r#"
-    _         __     ___
-   / \   __  _\ \   / (_)___  ___  _ __
-  / _ \  \ \/ /\ \ / /| / __|/ _ \| '__|
- / ___ \  >  <  \ V / | \__ \ (_) | |
-/_/   \_\/_/\_\  \_/  |_|___/\___/|_|
-"#,
-];
-
-/// Prints the startup banner to the console.
-fn print_logo() {
-    println!();
-    println!("{}", LOGO[0]);
-    println!();
-    println!("by AxVisor Team");
-    println!();
-}
 
 /// Axvisor kernel entry point.
 ///
@@ -78,9 +42,8 @@ fn print_logo() {
 /// 2. Check and enable hardware virtualization on every CPU.
 /// 3. Build and start configured guest VMs.
 /// 4. Enter the management shell after the default guests have exited.
-#[cfg_attr(target_os = "none", unsafe(no_mangle))]
 fn main() {
-    print_logo();
+    banner::print_logo();
 
     info!("Starting virtualization...");
     let manager = manager::AxvmManager::new().expect("failed to initialize AxVM manager");

--- a/scripts/axbuild/src/axvisor/build/features.rs
+++ b/scripts/axbuild/src/axvisor/build/features.rs
@@ -3,12 +3,6 @@ use anyhow::anyhow;
 use super::metadata::{platform_feature_names, platform_metadata_entries};
 use crate::context::arch_for_target_checked;
 
-const AXVISOR_PLAT_DYN_FEATURES: &[&str] = &[
-    "plat-dyn",
-    "axvm/plat-dyn",
-    "ax-std/plat-dyn",
-    "ax-driver/plat-dyn",
-];
 const REMOVED_AXVISOR_PLATFORM_FEATURES: &[&str] = &["x86-qemu-q35", concat!("riscv64", "-sg2002")];
 
 pub(super) fn normalize_axvisor_feature_surface(
@@ -78,8 +72,8 @@ pub(super) fn reject_unsupported_nested_platform_features(
         .find(|feature| is_axvisor_plat_dyn_feature(feature))
     {
         return Err(anyhow!(
-            "Axvisor build configs enable dynamic platforms by default; remove dynamic platform \
-             features from `features`; found `{feature}`"
+            "Axvisor depends on an ax-std surface with dynamic platform support enabled; remove \
+             dynamic platform features from `features`; found `{feature}`"
         ));
     }
 
@@ -96,11 +90,6 @@ pub(super) fn reject_unsupported_nested_platform_features(
 
 pub(super) fn normalize_axvisor_plat_dyn_features(features: &mut Vec<String>) {
     features.retain(|feature| !is_axvisor_plat_dyn_feature(feature));
-    features.extend(
-        AXVISOR_PLAT_DYN_FEATURES
-            .iter()
-            .map(|feature| (*feature).to_string()),
-    );
 }
 
 pub(super) fn is_axvisor_plat_dyn_feature(feature: &str) -> bool {
@@ -108,12 +97,13 @@ pub(super) fn is_axvisor_plat_dyn_feature(feature: &str) -> bool {
         feature,
         "dyn-plat"
             | "plat-dyn"
+            | "axplat-dyn"
             | "ax-feat/plat-dyn"
             | "ax-hal/plat-dyn"
             | "ax-std/plat-dyn"
             | "axvm/plat-dyn"
             | "ax-driver/plat-dyn"
-    )
+    ) || feature.starts_with("axplat-dyn/")
 }
 
 fn removed_axvisor_platform_feature_name(feature: &str) -> Option<&str> {

--- a/scripts/axbuild/src/axvisor/build/tests.rs
+++ b/scripts/axbuild/src/axvisor/build/tests.rs
@@ -145,21 +145,10 @@ vm_configs = []
     .unwrap();
 
     assert!(cargo.features.contains(&"ept-level-4".to_string()));
-    assert!(
-        cargo
-            .features
-            .contains(&concat!("ax-driver/", "plat-dyn").to_string())
-    );
-    assert!(
-        cargo
-            .features
-            .contains(&concat!("ax-std/", "plat-dyn").to_string())
-    );
-    assert!(
-        cargo
-            .features
-            .contains(&concat!("axvm/", "plat-dyn").to_string())
-    );
+    assert!(!cargo.features.contains(&"plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"axvm/plat-dyn".to_string()));
     assert!(!cargo.features.contains(&"dyn-plat".to_string()));
     assert!(path.exists());
 }
@@ -349,10 +338,10 @@ vm_configs = []
     assert!(cargo.features.contains(&"ept-level-4".to_string()));
     assert!(cargo.features.contains(&"fs".to_string()));
     assert!(cargo.features.contains(&"vmx".to_string()));
-    assert!(cargo.features.contains(&"plat-dyn".to_string()));
-    assert!(cargo.features.contains(&"ax-std/plat-dyn".to_string()));
-    assert!(cargo.features.contains(&"axvm/plat-dyn".to_string()));
-    assert!(cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"axvm/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
     assert!(!cargo.features.contains(&"ax-std/defplat".to_string()));
     assert!(!cargo.features.contains(&"ax-std/x86-pc".to_string()));
     assert!(!cargo.features.contains(&"ax-hal/x86-pc".to_string()));
@@ -492,6 +481,38 @@ fn load_cargo_config_rejects_removed_sg2002_platform_feature() {
 }
 
 #[test]
+fn load_cargo_config_rejects_direct_axplat_dyn_feature() {
+    let root = tempdir().unwrap();
+    let config_path = root.path().join(".build.toml");
+    fs::write(
+        &config_path,
+        r#"
+features = ["axplat-dyn/efi", "ept-level-4"]
+log = "Info"
+"#,
+    )
+    .unwrap();
+
+    let err = load_cargo_config(&ResolvedAxvisorRequest {
+        package: AXVISOR_PACKAGE.to_string(),
+        axvisor_dir: root.path().join("os/axvisor"),
+        arch: "loongarch64".to_string(),
+        target: "loongarch64-unknown-none-softfloat".to_string(),
+        plat_dyn: Some(true),
+        smp: None,
+        debug: false,
+        build_info_path: config_path,
+        qemu_config: None,
+        uboot_config: None,
+        vmconfigs: vec![],
+    })
+    .unwrap_err();
+
+    assert!(err.to_string().contains("dynamic platform features"));
+    assert!(err.to_string().contains("axplat-dyn/efi"));
+}
+
+#[test]
 fn load_cargo_config_uses_dynamic_x86_platform_from_board_config() {
     let root = tempdir().unwrap();
     let config_path = root.path().join(".build.toml");
@@ -519,9 +540,10 @@ log = "Info"
     })
     .unwrap();
 
-    assert!(cargo.features.contains(&"ax-std/plat-dyn".to_string()));
-    assert!(cargo.features.contains(&"axvm/plat-dyn".to_string()));
-    assert!(cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"axvm/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
     assert!(!cargo.features.contains(&"dyn-plat".to_string()));
     assert!(!cargo.features.contains(&"ax-hal/x86-pc".to_string()));
     assert!(!cargo.features.contains(&"ax-hal/x86-qemu-q35".to_string()));
@@ -561,9 +583,10 @@ log = "Info"
     })
     .unwrap();
 
-    assert!(cargo.features.contains(&"ax-std/plat-dyn".to_string()));
-    assert!(cargo.features.contains(&"axvm/plat-dyn".to_string()));
-    assert!(cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"axvm/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
     assert!(!cargo.features.contains(&"ax-hal/x86-qemu-q35".to_string()));
     assert!(!cargo.features.contains(&"ax-hal/x86-pc".to_string()));
 }
@@ -614,7 +637,7 @@ fn load_cargo_config_keeps_loongarch_dynamic_axvisor_as_elf() {
     fs::write(
         &config_path,
         r#"
-features = ["axplat-dyn/efi", "ept-level-4"]
+features = ["ept-level-4"]
 log = "Info"
 "#,
     )
@@ -636,8 +659,11 @@ log = "Info"
     .unwrap();
 
     assert!(!cargo.to_bin);
-    assert!(cargo.features.contains(&"ax-std/plat-dyn".to_string()));
-    assert!(cargo.features.contains(&"axplat-dyn/efi".to_string()));
+    assert!(!cargo.features.contains(&"plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-std/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"axvm/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"ax-driver/plat-dyn".to_string()));
+    assert!(!cargo.features.contains(&"axplat-dyn/efi".to_string()));
     assert!(
         cargo
             .target

--- a/scripts/axbuild/src/test/qemu/boot.rs
+++ b/scripts/axbuild/src/test/qemu/boot.rs
@@ -297,7 +297,7 @@ pub(super) fn ensure_drive_snapshot_on(drive: &mut String) {
 }
 
 pub(super) fn cargo_dynamic_platform_boot_arch(cargo: &Cargo) -> Option<DynamicPlatformBootArch> {
-    if !cargo_dynamic_platform_features(cargo).any(dynamic_platform_feature) {
+    if !cargo_uses_dynamic_platform_boot(cargo) {
         return None;
     }
 
@@ -308,6 +308,11 @@ pub(super) fn cargo_dynamic_platform_boot_arch(cargo: &Cargo) -> Option<DynamicP
     } else {
         None
     }
+}
+
+fn cargo_uses_dynamic_platform_boot(cargo: &Cargo) -> bool {
+    cargo_dynamic_platform_features(cargo).any(dynamic_platform_feature)
+        || cargo.package == "axvisor"
 }
 
 pub(super) fn cargo_target_is_dynamic_x86_64(target: &str) -> bool {

--- a/scripts/axbuild/src/test/qemu/tests/boot.rs
+++ b/scripts/axbuild/src/test/qemu/tests/boot.rs
@@ -48,6 +48,52 @@ fn dynamic_x86_64_std_cargo_uses_uefi_bin_qemu_boot() {
 }
 
 #[test]
+fn axvisor_x86_64_uses_dependency_dynamic_platform_boot_without_feature() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let _debug = TempEnvVar::unset(DYNAMIC_X86_64_QEMU_DEBUG_ENV);
+    let cargo = Cargo {
+        package: "axvisor".to_string(),
+        target: "scripts/targets/std/pie/x86_64-unknown-linux-musl.json".to_string(),
+        features: vec![],
+        to_bin: false,
+        ..Default::default()
+    };
+    let mut qemu = QemuConfig {
+        uefi: false,
+        to_bin: false,
+        ..Default::default()
+    };
+
+    apply_dynamic_platform_qemu_boot_with_kvm_probe(&mut qemu, &cargo, || false);
+
+    assert!(qemu.uefi);
+    assert!(qemu.to_bin);
+}
+
+#[test]
+fn axvisor_loongarch64_uses_dependency_dynamic_platform_boot_without_feature() {
+    let cargo = Cargo {
+        package: "axvisor".to_string(),
+        target: "scripts/targets/std/pie/loongarch64-unknown-linux-musl.json".to_string(),
+        features: vec![],
+        to_bin: false,
+        ..Default::default()
+    };
+    let mut qemu = QemuConfig {
+        uefi: false,
+        to_bin: false,
+        args: vec!["-snapshot".to_string()],
+        ..Default::default()
+    };
+
+    apply_dynamic_platform_qemu_boot_with_kvm_probe(&mut qemu, &cargo, || false);
+
+    assert!(qemu.uefi);
+    assert!(qemu.to_bin);
+    assert!(qemu.args.is_empty());
+}
+
+#[test]
 fn dynamic_x86_64_qemu_boot_converts_global_snapshot_to_drive_snapshots() {
     let _guard = ENV_LOCK.lock().unwrap();
     let _debug = TempEnvVar::unset(DYNAMIC_X86_64_QEMU_DEBUG_ENV);

--- a/test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml
@@ -1,6 +1,5 @@
 features = [
   "ax-driver/virtio-blk",
-  "axplat-dyn/efi",
   "ept-level-4",
   "fs",
 ]


### PR DESCRIPTION
## 背景

Axvisor 现在走 std/pie 动态平台构建路径，但 crate 自身仍保留了 `plat-dyn` feature 转发、若干未直接使用的依赖，以及入口里的 `target_os = "none"` 兼容分支。这会让 Axvisor 的动态平台能力同时出现在应用 feature 和依赖层，增加 build config 和 axbuild 归一化逻辑的理解成本。

## 改动

- 清理 `os/axvisor` 的无用直接依赖和空 feature，删除 Axvisor 自己暴露的 `plat-dyn`。
- 将 `ax-std` 直接依赖固定开启 `plat-dyn`，让动态平台能力收敛在 std surface 依赖层。
- 将 `axvm` 直接依赖固定开启自身 `plat-dyn`，满足 riscv64 虚拟中断注入依赖，同时不恢复 axbuild 的 `axvm/plat-dyn` CLI feature 注入。
- 调整 axbuild 的 Axvisor feature 归一化：继续接受动态平台选择语义，但不再向 Cargo feature 注入 `plat-dyn`、`ax-std/plat-dyn`、`axvm/plat-dyn` 或 `ax-driver/plat-dyn`。
- 将 `axplat-dyn/*` 也纳入 Axvisor 显式动态平台 feature 拒绝范围，并移除 LoongArch Axvisor 配置里的旧 `axplat-dyn/efi`，避免 Cargo 收到已不存在的直接依赖 feature。
- 将 Axvisor banner 拆到 `banner.rs`，`main.rs` 只保留启动编排，并按 std 目标入口写法去掉 `target_os = "none"` 的 no_std/no_main 兼容层。
- 修复 Axvisor 不再显式携带 `plat-dyn` feature 后的 QEMU 动态平台启动判定，确保 x86_64 仍走 UEFI/to-bin 路径。
- 同步 `Cargo.lock` 中 registry 侧 `ax-errno` 到 `0.6.1`，修复 release 后 `cargo publish --workspace --dry-run --no-verify` 打包 `starry-kernel` 时 `kbpf-basic` 锁定旧版 `ax-errno` 导致的解析冲突。

## 验证

- `cargo fmt --check`
- `cargo test -p axbuild axvisor`
- `cargo xtask clippy --package axbuild`
- `cargo xtask clippy --package axvisor`（当前工具提示 Axvisor 需使用 axvisor xtask flow，因此跳过）
- `cargo xtask axvisor build --arch x86_64`
- `cargo xtask axvisor build --arch loongarch64`
- `cargo xtask axvisor build --arch riscv64`
- `cargo xtask ktest qemu -p axvisor --test axtest --arch x86_64`，通过并匹配 `AXTEST_SUITE_OK`
- `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx`，通过 `smoke-vmx`
- `cargo publish --workspace --dry-run --no-verify`

补充：本机 `cargo xtask axvisor test qemu --arch loongarch64` 已越过 Cargo feature/build 阶段并启动到 Axvisor，但本机普通 LoongArch QEMU 缺少 LVZ 虚拟化扩展，运行期停在 `hardware virtualization is not supported`；CI 的 LoongArch Axvisor job 使用 `axvisor-lvz` 容器继续覆盖该路径。
