### PR TITLE
fix(ci): update locked ax-errno for publish dry-run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,17 +744,18 @@ dependencies = [
 
 [[package]]
 name = "ax-errno"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984a5bfdec820bd61a2cec72b0e3cf6359bc9d4aa1fdc7a4b13fc5d5a14cfa81"
+version = "0.6.1"
 dependencies = [
  "log",
+ "quote",
  "strum 0.27.2",
 ]
 
 [[package]]
 name = "ax-errno"
 version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c022cf0479c114aaf55acd23dedad5f0c7e4011142231e60e7a91f47cc070e6"
 dependencies = [
  "log",
  "quote",
@@ -4537,7 +4538,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "939c71c68bfebd52de856c50f7650713e449fe8a83255e8cee53d8519500b5e0"
 dependencies = [
- "ax-errno 0.6.0",
+ "ax-errno 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 2.13.0",
  "int-enum",
  "lock_api",
@@ -4592,7 +4593,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71b521b03673eb47aa8b7d70ff6709fabdc9243ee9e713cacc08f5b0ffae2c2"
 dependencies = [
- "ax-errno 0.6.0",
+ "ax-errno 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield-struct 0.13.0",
  "bitflags 2.13.0",
  "cfg-if",


### PR DESCRIPTION
## 问题

`Check formatting / run_host` 在执行 `cargo publish --workspace --dry-run --no-verify` 时，打包 `starry-kernel` 失败。失败原因是 `Cargo.lock` 中 registry 来源的 `ax-errno` 仍锁定在 `0.6.0`，而当前 `starry-kernel` 以及工作区发布版本需要 `ax-errno 0.6.1`。

## 修改

- 使用 Cargo 重新解析并更新 registry 来源的 `ax-errno` 锁定版本：`0.6.0 -> 0.6.1`。
- 让外部依赖 `kbpf-basic v0.6.0` 和 `kmod-loader v0.3.1` 在 lockfile 中指向 registry `ax-errno 0.6.1`，与当前发布 dry-run 的解析保持一致。

## 逻辑

`starry-kernel` 同时依赖工作区内的 `ax-errno 0.6.1` 和外部 crate `kbpf-basic` / `kmod-loader`。这些外部 crate 的 `ax-errno` 版本约束允许 `0.6.1`，但 lockfile 仍保留旧的 registry `0.6.0`，导致发布 dry-run 在准备 `starry-kernel` 包时无法选择一个兼容版本。更新 lockfile 后，工作区 path `ax-errno 0.6.1` 与 registry `ax-errno 0.6.1` 分别服务对应来源，解析冲突消失。

## 验证

- `cargo publish --workspace --dry-run --no-verify`
- `cargo fmt --all -- --check`
- `cargo xtask clippy --package starry-kernel`
- `git diff --check`
