### PR TITLE
feat(crab-usb): add RK3588 EHCI USB2 host

### DIFF
--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -49,6 +49,7 @@ aic8800-wifi = [
 
 usb = ["dep:crab-usb"]
 rockchip-dwc-xhci = ["usb", "rockchip-soc", "rockchip-pm"]
+rockchip-ehci = ["usb", "rockchip-soc", "rockchip-pm"]
 xhci-mmio = ["usb"]
 xhci-pci = ["usb", "pci"]
 serial = [

--- a/drivers/ax-driver/src/usb/ehci.rs
+++ b/drivers/ax-driver/src/usb/ehci.rs
@@ -1,0 +1,250 @@
+extern crate alloc;
+
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::ptr::NonNull;
+
+use crab_usb::{EhciNewParams, usb_if::Speed};
+use fdt_edit::{ClockRef, Fdt, Node, NodeType, Phandle, RegFixed};
+use log::{debug, info, warn};
+use rdrive::{
+    probe::OnProbeError,
+    register::{FdtInfo, ProbeFdt},
+};
+
+use super::{ProbeFdtUsbHost, usb_kernel};
+use crate::{
+    mmio::iomap,
+    soc::{rk3588_enable_clock, rk3588_enable_power_domain, rk3588_reset_deassert},
+};
+
+const DRIVER_NAME: &str = "usb-rockchip-ehci";
+
+crate::model_register!(
+    name: "USB Rockchip EHCI",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["rockchip,rk3588-ehci", "generic-ehci"],
+            on_probe: probe
+        }
+    ],
+);
+
+#[derive(Clone)]
+struct ClockSpec {
+    name: Option<String>,
+    id: u32,
+}
+
+#[derive(Clone)]
+struct ResetSpec {
+    name: String,
+    id: u64,
+}
+
+struct EhciResources {
+    ctrl: RegFixed,
+    power_domains: Vec<usize>,
+    clocks: Vec<ClockSpec>,
+    resets: Vec<ResetSpec>,
+}
+
+fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let info = probe.info();
+    let fdt = live_fdt()?;
+    let resources = collect_resources(info, &fdt)?;
+
+    enable_power_domains(&resources.power_domains)?;
+    enable_clocks(&resources.clocks);
+    deassert_resets(&resources.resets);
+
+    let mmio = map_reg(resources.ctrl)?;
+    let host = crab_usb::USBHost::new_ehci(EhciNewParams {
+        mmio,
+        kernel: usb_kernel(),
+    })
+    .map_err(|err| {
+        OnProbeError::other(format!(
+            "failed to create EHCI host for [{}]: {err}",
+            info.node.name()
+        ))
+    })?;
+
+    let node_name = info.node.name().to_string();
+    let irq = probe.register_usb_host_with_root_hub_speed(DRIVER_NAME, host, Speed::High)?;
+    info!(
+        "Rockchip EHCI driver initialized successfully for {} with irq {:?}",
+        node_name, irq
+    );
+    Ok(())
+}
+
+fn collect_resources(info: &FdtInfo<'_>, fdt: &Fdt) -> Result<EhciResources, OnProbeError> {
+    let ctrl = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or_else(|| OnProbeError::other(format!("[{}] has no reg", info.node.name())))?;
+
+    let mut clocks = clock_specs(info.node.clocks());
+    let mut resets = parse_resets(info.node)?;
+
+    for phy in collect_usb2_phys(info.node.as_node(), fdt) {
+        clocks.extend(clock_specs(phy.port.clocks()));
+        clocks.extend(clock_specs(phy.parent.clocks()));
+        resets.extend(parse_resets(phy.parent)?);
+    }
+
+    Ok(EhciResources {
+        ctrl,
+        power_domains: parse_power_domains(info.node.as_node())?,
+        clocks,
+        resets,
+    })
+}
+
+struct Usb2PhyNode<'a> {
+    port: NodeType<'a>,
+    parent: NodeType<'a>,
+}
+
+fn collect_usb2_phys<'a>(node: &Node, fdt: &'a Fdt) -> Vec<Usb2PhyNode<'a>> {
+    let Some(phys) = node.get_property("phys") else {
+        return Vec::new();
+    };
+
+    phys.get_u32_iter()
+        .filter_map(|cell| {
+            let port = fdt.get_by_phandle(Phandle::from(cell))?;
+            let parent = port.parent()?;
+            Some(Usb2PhyNode { port, parent })
+        })
+        .collect()
+}
+
+fn parse_power_domains(node: &Node) -> Result<Vec<usize>, OnProbeError> {
+    let Some(prop) = node.get_property("power-domains") else {
+        return Ok(Vec::new());
+    };
+    let cells = prop.get_u32_iter().collect::<Vec<_>>();
+    if cells.len() % 2 != 0 {
+        return Err(OnProbeError::other(format!(
+            "[{}] has malformed power-domains",
+            node.name()
+        )));
+    }
+
+    Ok(cells.chunks(2).map(|chunk| chunk[1] as usize).collect())
+}
+
+fn parse_resets(node: NodeType<'_>) -> Result<Vec<ResetSpec>, OnProbeError> {
+    let Some(resets_prop) = node.as_node().get_property("resets") else {
+        return Ok(Vec::new());
+    };
+    let reset_cells = resets_prop.get_u32_iter().collect::<Vec<_>>();
+    if reset_cells.len() % 2 != 0 {
+        return Err(OnProbeError::other(format!(
+            "[{}] has malformed resets",
+            node.name()
+        )));
+    }
+
+    let reset_names = node
+        .as_node()
+        .get_property("reset-names")
+        .ok_or_else(|| {
+            OnProbeError::other(format!("[{}] has resets but no reset-names", node.name()))
+        })?
+        .as_str_iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let reset_count = reset_cells.len() / 2;
+    if reset_names.len() < reset_count {
+        return Err(OnProbeError::other(format!(
+            "[{}] has fewer reset-names than resets",
+            node.name()
+        )));
+    }
+
+    Ok(reset_cells
+        .chunks(2)
+        .zip(reset_names.iter())
+        .map(|(cells, name)| ResetSpec {
+            name: name.clone(),
+            id: cells[1] as u64,
+        })
+        .collect())
+}
+
+fn enable_power_domains(domains: &[usize]) -> Result<(), OnProbeError> {
+    for &domain in domains {
+        rk3588_enable_power_domain(domain).map_err(|err| {
+            OnProbeError::other(format!(
+                "failed to enable EHCI power domain {domain}: {err}"
+            ))
+        })?;
+        info!("EHCI power domain {domain} enabled");
+    }
+    Ok(())
+}
+
+fn enable_clocks(clocks: &[ClockSpec]) {
+    for clock in clocks {
+        if clock.id == 0 {
+            continue;
+        }
+
+        match rk3588_enable_clock(clock.id) {
+            Ok(()) => debug!("EHCI clock {:?} ({:#x}) enabled", clock.name, clock.id),
+            Err(err) => warn!(
+                "EHCI clock {:?} ({:#x}) enable skipped: {err}",
+                clock.name, clock.id
+            ),
+        }
+    }
+}
+
+fn deassert_resets(resets: &[ResetSpec]) {
+    for reset in resets {
+        match rk3588_reset_deassert(reset.id) {
+            Ok(()) => debug!("EHCI reset {} ({:#x}) deasserted", reset.name, reset.id),
+            Err(err) => warn!(
+                "EHCI reset {} ({:#x}) deassert skipped: {err}",
+                reset.name, reset.id
+            ),
+        }
+    }
+}
+
+fn clock_specs(clocks: Vec<ClockRef>) -> Vec<ClockSpec> {
+    clocks
+        .into_iter()
+        .filter_map(|clock| {
+            let id = *clock.specifier.first()?;
+            Some(ClockSpec {
+                name: clock.name,
+                id,
+            })
+        })
+        .collect()
+}
+
+fn live_fdt() -> Result<Fdt, OnProbeError> {
+    rdrive::with_fdt(Clone::clone).ok_or_else(|| OnProbeError::other("live FDT not found"))
+}
+
+fn map_reg(reg: RegFixed) -> Result<NonNull<u8>, OnProbeError> {
+    let size = align_up_4k((reg.size.unwrap_or(0x1000) as usize).max(1));
+    iomap(reg.address as usize, size)
+}
+
+fn align_up_4k(size: usize) -> usize {
+    const MASK: usize = 0xfff;
+    (size + MASK) & !MASK
+}

--- a/drivers/ax-driver/src/usb/mod.rs
+++ b/drivers/ax-driver/src/usb/mod.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use core::time::Duration;
 
-use crab_usb::{EventHandler, USBHost};
+use crab_usb::{EventHandler, USBHost, usb_if::Speed};
 use dma_api::{DmaAllocHandle, DmaConstraints, DmaDirection, DmaError, DmaMapHandle, DmaOp};
 use rdrive::{DriverGeneric, probe::OnProbeError};
 
@@ -15,6 +15,8 @@ use crate::{PciIrqRequirement, binding_info_from_pci};
 
 #[cfg(feature = "rockchip-dwc-xhci")]
 mod dwc;
+#[cfg(feature = "rockchip-ehci")]
+mod ehci;
 #[cfg(feature = "xhci-mmio")]
 mod xhci_mmio;
 #[cfg(feature = "xhci-pci")]
@@ -137,15 +139,26 @@ pub struct PlatformUsbHost {
     name: &'static str,
     info: BindingInfo,
     host: USBHost,
+    root_hub_speed: Speed,
     irq_handler_taken: bool,
 }
 
 impl PlatformUsbHost {
     fn new(name: &'static str, host: USBHost, info: BindingInfo) -> Self {
+        Self::new_with_root_hub_speed(name, host, info, Speed::SuperSpeedPlus)
+    }
+
+    fn new_with_root_hub_speed(
+        name: &'static str,
+        host: USBHost,
+        info: BindingInfo,
+        root_hub_speed: Speed,
+    ) -> Self {
         Self {
             name,
             info,
             host,
+            root_hub_speed,
             irq_handler_taken: false,
         }
     }
@@ -172,6 +185,10 @@ impl PlatformUsbHost {
 
     pub fn binding_info(&self) -> &BindingInfo {
         &self.info
+    }
+
+    pub fn root_hub_speed(&self) -> Speed {
+        self.root_hub_speed
     }
 
     pub fn enable_irq(&mut self) -> crab_usb::err::Result {
@@ -257,6 +274,13 @@ pub trait ProbeFdtUsbHost {
         name: &'static str,
         host: USBHost,
     ) -> Result<Option<usize>, OnProbeError>;
+
+    fn register_usb_host_with_root_hub_speed(
+        self,
+        name: &'static str,
+        host: USBHost,
+        root_hub_speed: Speed,
+    ) -> Result<Option<usize>, OnProbeError>;
 }
 
 impl ProbeFdtUsbHost for rdrive::probe::fdt::ProbeFdt<'_> {
@@ -271,6 +295,22 @@ impl ProbeFdtUsbHost for rdrive::probe::fdt::ProbeFdt<'_> {
             name,
             host,
             info,
+        ))
+    }
+
+    fn register_usb_host_with_root_hub_speed(
+        self,
+        name: &'static str,
+        host: USBHost,
+        root_hub_speed: Speed,
+    ) -> Result<Option<usize>, OnProbeError> {
+        let info = binding_info_from_fdt(self.info())?;
+        Ok(register_usb_host_with_info_and_root_hub_speed(
+            self.into_platform_device(),
+            name,
+            host,
+            info,
+            root_hub_speed,
         ))
     }
 }
@@ -334,6 +374,19 @@ fn register_usb_host_with_info(
     info: BindingInfo,
 ) -> Option<usize> {
     register_bound_device(plat_dev, PlatformUsbHost::new(name, host, info))
+}
+
+fn register_usb_host_with_info_and_root_hub_speed(
+    plat_dev: rdrive::PlatformDevice,
+    name: &'static str,
+    host: USBHost,
+    info: BindingInfo,
+    root_hub_speed: Speed,
+) -> Option<usize> {
+    register_bound_device(
+        plat_dev,
+        PlatformUsbHost::new_with_root_hub_speed(name, host, info, root_hub_speed),
+    )
 }
 
 #[cfg(feature = "xhci-pci")]

--- a/drivers/usb/usb-host/src/backend/kmod/ehci/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/ehci/mod.rs
@@ -1,0 +1,1471 @@
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use core::{
+    ptr::NonNull,
+    sync::atomic::{AtomicUsize, Ordering},
+    task::Context,
+    time::Duration,
+};
+
+use ax_kspin::SpinRaw as Mutex;
+use dma_api::CoherentBox;
+use futures::{FutureExt, future::BoxFuture, task::AtomicWaker};
+use mbarrier::{mb, wmb};
+use usb_if::{
+    descriptor::{
+        ConfigurationDescriptor, DescriptorType, DeviceDescriptor, DeviceDescriptorBase,
+        EndpointDescriptor, EndpointType,
+    },
+    endpoint::{EndpointInfo, RequestId, TransferCompletion, TransferRequest, TransferStatus},
+    err::{TransferError, USBError},
+    host::{ControlSetup, hub::Speed},
+    transfer::{BmRequestType, Direction, Recipient, Request, RequestType},
+};
+
+use super::{
+    hub::{HubInfo, HubOp, PortChangeInfo, PortState},
+    kcore::CoreOp,
+    osal::{Kernel, KernelOp},
+};
+use crate::{
+    DeviceAddressInfo, Mmio,
+    backend::ty::{DeviceOp, Event, EventHandlerOp, HubParams, ep::Endpoint, transfer::Transfer},
+    err::{HostError, Result},
+};
+
+const QTD_MAX_TOTAL_BYTES: usize = 20 * 1024;
+const EHCI_DMA_MASK: u64 = u32::MAX as u64;
+const EHCI_QH_LINK_TYPE_QH: u32 = 0b01 << 1;
+const EHCI_LINK_TERMINATE: u32 = 1;
+
+const USBCMD: usize = 0x00;
+const USBSTS: usize = 0x04;
+const USBINTR: usize = 0x08;
+const CTRLDSSEGMENT: usize = 0x10;
+const PERIODICLISTBASE: usize = 0x14;
+const ASYNCLISTADDR: usize = 0x18;
+const CONFIGFLAG: usize = 0x40;
+const PORTSC_BASE: usize = 0x44;
+
+const USBCMD_RUN_STOP: u32 = 1 << 0;
+const USBCMD_HCRESET: u32 = 1 << 1;
+const USBCMD_PERIODIC_ENABLE: u32 = 1 << 4;
+const USBCMD_ASYNC_ENABLE: u32 = 1 << 5;
+const USBCMD_INT_ASYNC_ADVANCE_DOORBELL: u32 = 1 << 6;
+
+const USBSTS_USBINT: u32 = 1 << 0;
+const USBSTS_USBERRINT: u32 = 1 << 1;
+const USBSTS_PORT_CHANGE: u32 = 1 << 2;
+const USBSTS_FRAME_LIST_ROLLOVER: u32 = 1 << 3;
+const USBSTS_HOST_SYSTEM_ERROR: u32 = 1 << 4;
+const USBSTS_INTERRUPT_ASYNC_ADVANCE: u32 = 1 << 5;
+const USBSTS_HALTED: u32 = 1 << 12;
+
+const USBINTR_USBINT: u32 = 1 << 0;
+const USBINTR_USBERRINT: u32 = 1 << 1;
+const USBINTR_PORT_CHANGE: u32 = 1 << 2;
+const USBINTR_ASYNC_ADVANCE: u32 = 1 << 5;
+
+const PORT_CONNECT_CHANGE: u32 = 1 << 1;
+const PORT_ENABLE_CHANGE: u32 = 1 << 3;
+const PORT_OVER_CURRENT_CHANGE: u32 = 1 << 5;
+const PORT_RESET: u32 = 1 << 8;
+const PORT_POWER: u32 = 1 << 12;
+const PORT_OWNER: u32 = 1 << 13;
+
+const EHCI_WAIT_ITERS: usize = 1_000_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QtdPid {
+    Out,
+    In,
+    Setup,
+}
+
+impl QtdPid {
+    const fn token_bits(self) -> u32 {
+        match self {
+            Self::Out => 0,
+            Self::In => 1,
+            Self::Setup => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct QtdToken(u32);
+
+impl QtdToken {
+    #[cfg(test)]
+    pub(crate) const PID_MASK: u32 = 0b11 << 8;
+    #[cfg(test)]
+    pub(crate) const PID_IN: u32 = 1 << 8;
+
+    const ACTIVE: u32 = 1 << 7;
+    const ERROR_COUNTER_SHIFT: u32 = 10;
+    const ERROR_COUNTER_MASK: u32 = 0b11 << Self::ERROR_COUNTER_SHIFT;
+    const INTERRUPT_ON_COMPLETE: u32 = 1 << 15;
+    const TOTAL_BYTES_SHIFT: u32 = 16;
+    const TOTAL_BYTES_MASK: u32 = 0x7fff << Self::TOTAL_BYTES_SHIFT;
+    const DATA_TOGGLE: u32 = 1 << 31;
+    const ERROR_MASK: u32 = (1 << 6) | (1 << 5) | (1 << 4) | (1 << 3);
+
+    pub(crate) fn new(pid: QtdPid, total_bytes: usize) -> Self {
+        let total_bytes = total_bytes.min(0x7fff) as u32;
+        Self((pid.token_bits() << 8) | (total_bytes << Self::TOTAL_BYTES_SHIFT))
+    }
+
+    pub(crate) const fn raw(self) -> u32 {
+        self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pid(self) -> QtdPid {
+        match (self.0 & Self::PID_MASK) >> 8 {
+            0 => QtdPid::Out,
+            1 => QtdPid::In,
+            2 => QtdPid::Setup,
+            _ => QtdPid::Out,
+        }
+    }
+
+    pub(crate) fn total_bytes(self) -> usize {
+        ((self.0 & Self::TOTAL_BYTES_MASK) >> Self::TOTAL_BYTES_SHIFT) as usize
+    }
+
+    pub(crate) fn with_interrupt_on_complete(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.0 |= Self::INTERRUPT_ON_COMPLETE;
+        } else {
+            self.0 &= !Self::INTERRUPT_ON_COMPLETE;
+        }
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn interrupt_on_complete(self) -> bool {
+        (self.0 & Self::INTERRUPT_ON_COMPLETE) != 0
+    }
+
+    pub(crate) fn with_error_counter(mut self, count: u8) -> Self {
+        self.0 &= !Self::ERROR_COUNTER_MASK;
+        self.0 |= ((count.min(3) as u32) << Self::ERROR_COUNTER_SHIFT) & Self::ERROR_COUNTER_MASK;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn error_counter(self) -> u8 {
+        ((self.0 & Self::ERROR_COUNTER_MASK) >> Self::ERROR_COUNTER_SHIFT) as u8
+    }
+
+    pub(crate) fn with_active(mut self, active: bool) -> Self {
+        if active {
+            self.0 |= Self::ACTIVE;
+        } else {
+            self.0 &= !Self::ACTIVE;
+        }
+        self
+    }
+
+    pub(crate) const fn active(self) -> bool {
+        (self.0 & Self::ACTIVE) != 0
+    }
+
+    fn with_data_toggle(mut self, toggle: bool) -> Self {
+        if toggle {
+            self.0 |= Self::DATA_TOGGLE;
+        } else {
+            self.0 &= !Self::DATA_TOGGLE;
+        }
+        self
+    }
+
+    fn has_error(self) -> bool {
+        (self.0 & Self::ERROR_MASK) != 0
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EhciPortStatus(u32);
+
+impl EhciPortStatus {
+    pub(crate) const CURRENT_CONNECT: u32 = 1 << 0;
+    pub(crate) const PORT_ENABLED: u32 = 1 << 2;
+    pub(crate) const LINE_STATUS_K_STATE: u32 = 1 << 10;
+    const LINE_STATUS_MASK: u32 = 0b11 << 10;
+
+    pub(crate) const fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub(crate) const fn connected(self) -> bool {
+        (self.0 & Self::CURRENT_CONNECT) != 0
+    }
+
+    pub(crate) const fn enabled(self) -> bool {
+        (self.0 & Self::PORT_ENABLED) != 0
+    }
+
+    pub(crate) fn speed(self) -> Speed {
+        if self.connected() && self.enabled() {
+            return Speed::High;
+        }
+
+        match self.0 & Self::LINE_STATUS_MASK {
+            Self::LINE_STATUS_K_STATE => Speed::Low,
+            _ => Speed::Full,
+        }
+    }
+
+    pub(crate) fn is_high_speed_device_ready(self) -> bool {
+        self.connected() && self.enabled() && matches!(self.speed(), Speed::High)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ControlTdPlan {
+    pub(crate) setup: QtdToken,
+    pub(crate) data: Option<QtdToken>,
+    pub(crate) status: QtdToken,
+}
+
+pub(crate) fn build_control_td_plan(
+    request: &TransferRequest,
+) -> core::result::Result<ControlTdPlan, TransferError> {
+    let TransferRequest::Control {
+        setup: _,
+        direction,
+        buffer,
+    } = request
+    else {
+        return Err(TransferError::InvalidEndpoint);
+    };
+
+    let data_len = buffer.map(|buffer| buffer.len).unwrap_or(0);
+    let setup = QtdToken::new(QtdPid::Setup, 8)
+        .with_error_counter(3)
+        .with_active(true)
+        .with_data_toggle(false);
+    let data = (data_len > 0).then(|| {
+        let pid = match direction {
+            Direction::In => QtdPid::In,
+            Direction::Out => QtdPid::Out,
+        };
+        QtdToken::new(pid, data_len)
+            .with_error_counter(3)
+            .with_active(true)
+            .with_data_toggle(true)
+    });
+    let status_pid = match (direction, data_len > 0) {
+        (Direction::In, true) => QtdPid::Out,
+        (Direction::Out, true) => QtdPid::In,
+        (_, false) => QtdPid::In,
+    };
+    let status = QtdToken::new(status_pid, 0)
+        .with_error_counter(3)
+        .with_interrupt_on_complete(true)
+        .with_active(true)
+        .with_data_toggle(true);
+
+    Ok(ControlTdPlan {
+        setup,
+        data,
+        status,
+    })
+}
+
+pub(crate) fn split_bulk_lengths(len: usize, _direction: Direction) -> Vec<usize> {
+    let mut left = len;
+    let mut out = Vec::new();
+
+    while left > 0 {
+        let chunk = left.min(QTD_MAX_TOTAL_BYTES);
+        out.push(chunk);
+        left -= chunk;
+    }
+
+    if out.is_empty() {
+        out.push(0);
+    }
+
+    out
+}
+
+#[derive(Clone, Copy)]
+struct EhciRegisters {
+    op: NonNull<u8>,
+    ports: u8,
+}
+
+unsafe impl Send for EhciRegisters {}
+unsafe impl Sync for EhciRegisters {}
+
+impl EhciRegisters {
+    fn new(base: Mmio) -> Self {
+        let cap_len = unsafe { base.as_ptr().read_volatile() as usize };
+        let hcsparams = unsafe { (base.as_ptr().add(0x04) as *const u32).read_volatile() };
+        let ports = (hcsparams & 0x0f).max(1) as u8;
+        let op = unsafe { NonNull::new_unchecked(base.as_ptr().add(cap_len)) };
+
+        Self { op, ports }
+    }
+
+    fn ports(self) -> u8 {
+        self.ports
+    }
+
+    fn op_read32(self, offset: usize) -> u32 {
+        unsafe { (self.op.as_ptr().add(offset) as *const u32).read_volatile() }
+    }
+
+    fn op_write32(self, offset: usize, value: u32) {
+        unsafe { (self.op.as_ptr().add(offset) as *mut u32).write_volatile(value) }
+    }
+
+    fn op_update32(self, offset: usize, f: impl FnOnce(u32) -> u32) {
+        let value = self.op_read32(offset);
+        self.op_write32(offset, f(value));
+    }
+
+    fn port_offset(port_id: u8) -> usize {
+        PORTSC_BASE + ((port_id as usize - 1) * 4)
+    }
+
+    fn port_read(self, port_id: u8) -> EhciPortStatus {
+        EhciPortStatus::from_raw(self.op_read32(Self::port_offset(port_id)))
+    }
+
+    fn port_update(self, port_id: u8, f: impl FnOnce(u32) -> u32) {
+        self.op_update32(Self::port_offset(port_id), f);
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct EhciNewParams {
+    pub mmio: Mmio,
+    pub kernel: &'static dyn KernelOp,
+}
+
+#[derive(Clone)]
+struct AsyncSchedule(Arc<Mutex<AsyncScheduleInner>>);
+
+struct AsyncScheduleInner {
+    head: CoherentBox<QueueHead>,
+    active_qh: Option<u32>,
+}
+
+impl AsyncSchedule {
+    fn new(kernel: &Kernel) -> Result<Self> {
+        let mut head = kernel
+            .coherent_box_zero_with_align::<QueueHead>(32)
+            .map_err(HostError::from)?;
+        let addr = head.dma_addr().as_u64() as u32;
+        head.write_cpu(QueueHead::async_head(addr));
+        Ok(Self(Arc::new(Mutex::new(AsyncScheduleInner {
+            head,
+            active_qh: None,
+        }))))
+    }
+
+    fn head_addr(&self) -> u32 {
+        self.0.lock().head.dma_addr().as_u64() as u32
+    }
+
+    fn attach(&self, qh: &mut CoherentBox<QueueHead>) -> Result<()> {
+        let mut inner = self.0.lock();
+        let qh_addr = qh.dma_addr().as_u64() as u32;
+        if inner.active_qh.is_some_and(|active| active != qh_addr) {
+            return Err(USBError::TransferError(TransferError::QueueFull));
+        }
+
+        let head_addr = inner.head.dma_addr().as_u64() as u32;
+        qh.modify_cpu(|qh| {
+            qh.horizontal_link = ehci_qh_link(head_addr);
+        });
+        inner.head.modify_cpu(|head| {
+            head.horizontal_link = ehci_qh_link(qh_addr);
+        });
+        inner.active_qh = Some(qh_addr);
+        wmb();
+        Ok(())
+    }
+
+    fn detach(&self, qh_addr: u32) {
+        let mut inner = self.0.lock();
+        if inner.active_qh != Some(qh_addr) {
+            return;
+        }
+        let head_addr = inner.head.dma_addr().as_u64() as u32;
+        inner.head.modify_cpu(|head| {
+            head.horizontal_link = ehci_qh_link(head_addr);
+        });
+        inner.active_qh = None;
+        wmb();
+    }
+}
+
+fn ehci_qh_link(addr: u32) -> u32 {
+    (addr & !0x1f) | EHCI_QH_LINK_TYPE_QH
+}
+
+#[derive(Clone, Copy)]
+#[repr(C, align(32))]
+struct QueueHead {
+    horizontal_link: u32,
+    endpoint_chars: u32,
+    endpoint_caps: u32,
+    current_qtd: u32,
+    overlay: QueueTransferDescriptor,
+}
+
+impl QueueHead {
+    fn async_head(addr: u32) -> Self {
+        Self {
+            horizontal_link: ehci_qh_link(addr),
+            endpoint_chars: (1 << 15) | (64 << 16),
+            endpoint_caps: 1 << 30,
+            current_qtd: 0,
+            overlay: QueueTransferDescriptor::terminated(),
+        }
+    }
+
+    fn endpoint(addr: u8, ep_num: u8, ep_type: EndpointType, max_packet_size: u16) -> Self {
+        let mut endpoint_chars = (addr as u32 & 0x7f)
+            | ((ep_num as u32 & 0x0f) << 8)
+            | (0b10 << 12)
+            | ((max_packet_size as u32) << 16)
+            | (0x0f << 28);
+
+        if matches!(ep_type, EndpointType::Control) {
+            endpoint_chars |= 1 << 14;
+        }
+
+        Self {
+            horizontal_link: EHCI_LINK_TERMINATE,
+            endpoint_chars,
+            endpoint_caps: 1 << 30,
+            current_qtd: 0,
+            overlay: QueueTransferDescriptor::terminated(),
+        }
+    }
+
+    fn set_next_qtd(&mut self, qtd_addr: u32) {
+        self.overlay.next_qtd = qtd_addr & !0x1f;
+        self.overlay.alt_next_qtd = EHCI_LINK_TERMINATE;
+        self.overlay.token = 0;
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C, align(32))]
+struct QueueTransferDescriptor {
+    next_qtd: u32,
+    alt_next_qtd: u32,
+    token: u32,
+    buffer: [u32; 5],
+    ext_buffer: [u32; 5],
+}
+
+impl QueueTransferDescriptor {
+    const fn terminated() -> Self {
+        Self {
+            next_qtd: EHCI_LINK_TERMINATE,
+            alt_next_qtd: EHCI_LINK_TERMINATE,
+            token: 0,
+            buffer: [0; 5],
+            ext_buffer: [0; 5],
+        }
+    }
+
+    fn new(token: QtdToken, dma_addr: u64, len: usize) -> Self {
+        let mut qtd = Self::terminated();
+        qtd.token = token.raw();
+        qtd.set_buffer(dma_addr, len);
+        qtd
+    }
+
+    fn set_buffer(&mut self, dma_addr: u64, len: usize) {
+        if len == 0 {
+            return;
+        }
+
+        let first_page = dma_addr & !0xfff;
+        for index in 0..5 {
+            let page = first_page + (index as u64 * 4096);
+            if page >= dma_addr + len as u64 {
+                break;
+            }
+            self.buffer[index] = if index == 0 {
+                dma_addr as u32
+            } else {
+                page as u32
+            };
+        }
+    }
+
+    fn token(&self) -> QtdToken {
+        QtdToken(self.token)
+    }
+
+    fn set_next(&mut self, next: Option<u32>) {
+        self.next_qtd = next.map(|addr| addr & !0x1f).unwrap_or(EHCI_LINK_TERMINATE);
+    }
+}
+
+#[derive(Clone)]
+struct TransferWakeups {
+    count: Arc<AtomicUsize>,
+}
+
+impl TransferWakeups {
+    fn new() -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn notify(&self) {
+        self.count.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn take(&self) -> usize {
+        self.count.swap(0, Ordering::AcqRel)
+    }
+}
+
+pub struct Ehci {
+    regs: EhciRegisters,
+    kernel: Kernel,
+    schedule: AsyncSchedule,
+    root_hub: Option<EhciRootHub>,
+    event_handler: Option<EhciEventHandler>,
+    next_addr: u8,
+}
+
+unsafe impl Send for Ehci {}
+unsafe impl Sync for Ehci {}
+
+impl Ehci {
+    pub fn new(params: EhciNewParams) -> Result<Self> {
+        let regs = EhciRegisters::new(params.mmio);
+        let kernel = Kernel::new(EHCI_DMA_MASK, params.kernel);
+        let schedule = AsyncSchedule::new(&kernel)?;
+        let wakeups = TransferWakeups::new();
+        let root_hub = EhciRootHub::new(regs, kernel.clone());
+        let event_handler = EhciEventHandler::new(regs, wakeups.clone());
+
+        Ok(Self {
+            regs,
+            kernel,
+            schedule,
+            root_hub: Some(root_hub),
+            event_handler: Some(event_handler),
+            next_addr: 1,
+        })
+    }
+
+    async fn init_controller(&mut self) -> Result<()> {
+        self.disable_irq()?;
+        self.regs.op_update32(USBCMD, |cmd| {
+            cmd & !(USBCMD_RUN_STOP | USBCMD_ASYNC_ENABLE | USBCMD_PERIODIC_ENABLE)
+        });
+        self.wait_until(|| self.regs.op_read32(USBSTS) & USBSTS_HALTED != 0)?;
+
+        self.regs.op_update32(USBCMD, |cmd| cmd | USBCMD_HCRESET);
+        self.wait_until(|| self.regs.op_read32(USBCMD) & USBCMD_HCRESET == 0)?;
+
+        self.regs.op_write32(CTRLDSSEGMENT, 0);
+        self.regs.op_write32(PERIODICLISTBASE, 0);
+        self.regs
+            .op_write32(ASYNCLISTADDR, self.schedule.head_addr());
+        self.regs.op_write32(CONFIGFLAG, 1);
+        self.regs.op_write32(
+            USBSTS,
+            USBSTS_USBINT
+                | USBSTS_USBERRINT
+                | USBSTS_PORT_CHANGE
+                | USBSTS_FRAME_LIST_ROLLOVER
+                | USBSTS_HOST_SYSTEM_ERROR
+                | USBSTS_INTERRUPT_ASYNC_ADVANCE,
+        );
+
+        self.regs.op_update32(USBCMD, |cmd| {
+            (cmd | USBCMD_RUN_STOP | USBCMD_ASYNC_ENABLE) & !USBCMD_PERIODIC_ENABLE
+        });
+        self.wait_until(|| self.regs.op_read32(USBSTS) & USBSTS_HALTED == 0)?;
+        self.kernel.delay(Duration::from_millis(100));
+        Ok(())
+    }
+
+    fn wait_until(&self, ready: impl Fn() -> bool) -> Result<()> {
+        for _ in 0..EHCI_WAIT_ITERS {
+            if ready() {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(USBError::Timeout)
+    }
+
+    fn allocate_address(&mut self) -> Result<u8> {
+        if self.next_addr >= 128 {
+            return Err(USBError::SlotLimitReached);
+        }
+        let addr = self.next_addr;
+        self.next_addr += 1;
+        Ok(addr)
+    }
+
+    async fn new_device(&mut self, info: DeviceAddressInfo) -> Result<Box<dyn DeviceOp>> {
+        if !matches!(info.port_speed, Speed::High) {
+            return Err(USBError::NotSupported);
+        }
+
+        let addr = self.allocate_address()?;
+        let mut device = EhciDevice::new(
+            addr,
+            self.regs,
+            self.schedule.clone(),
+            self.kernel.clone(),
+            info.port_speed,
+        )?;
+        device.init().await?;
+        Ok(Box::new(device))
+    }
+}
+
+impl CoreOp for Ehci {
+    fn init<'a>(&'a mut self) -> BoxFuture<'a, Result<()>> {
+        self.init_controller().boxed()
+    }
+
+    fn root_hub(&mut self) -> Box<dyn HubOp> {
+        Box::new(
+            self.root_hub
+                .take()
+                .expect("EHCI root hub can only be taken once"),
+        )
+    }
+
+    fn new_addressed_device<'a>(
+        &'a mut self,
+        addr: DeviceAddressInfo,
+    ) -> BoxFuture<'a, Result<Box<dyn DeviceOp>>> {
+        self.new_device(addr).boxed()
+    }
+
+    fn create_event_handler(&mut self) -> Box<dyn EventHandlerOp> {
+        Box::new(
+            self.event_handler
+                .take()
+                .expect("EHCI event handler can only be created once"),
+        )
+    }
+
+    fn enable_irq(&mut self) -> Result<()> {
+        self.regs.op_write32(
+            USBINTR,
+            USBINTR_USBINT | USBINTR_USBERRINT | USBINTR_PORT_CHANGE | USBINTR_ASYNC_ADVANCE,
+        );
+        Ok(())
+    }
+
+    fn disable_irq(&mut self) -> Result<()> {
+        self.regs.op_write32(USBINTR, 0);
+        Ok(())
+    }
+
+    fn kernel(&self) -> &Kernel {
+        &self.kernel
+    }
+}
+
+struct EhciRootHub {
+    regs: EhciRegisters,
+    kernel: Kernel,
+    ports: Vec<PortState>,
+}
+
+unsafe impl Send for EhciRootHub {}
+
+impl EhciRootHub {
+    fn new(regs: EhciRegisters, kernel: Kernel) -> Self {
+        Self {
+            regs,
+            kernel,
+            ports: vec![PortState::Uninit; regs.ports() as usize],
+        }
+    }
+
+    async fn init_ports(&mut self, mut info: HubInfo) -> Result<HubInfo> {
+        info.speed = Speed::High;
+        for port_id in 1..=self.regs.ports() {
+            self.regs.port_update(port_id, |value| {
+                (value | PORT_POWER)
+                    & !(PORT_CONNECT_CHANGE | PORT_ENABLE_CHANGE | PORT_OVER_CURRENT_CHANGE)
+            });
+        }
+        self.kernel.delay(Duration::from_millis(20));
+        Ok(info)
+    }
+
+    async fn changed_ports_inner(&mut self) -> Result<Vec<PortChangeInfo>> {
+        let mut out = Vec::new();
+
+        for port_id in 1..=self.regs.ports() {
+            let idx = port_id as usize - 1;
+            if matches!(self.ports[idx], PortState::Probed) {
+                continue;
+            }
+
+            let status = self.regs.port_read(port_id);
+            if !status.connected() {
+                continue;
+            }
+
+            if matches!(self.ports[idx], PortState::Uninit) {
+                self.reset_port(port_id);
+                self.ports[idx] = PortState::Reseted;
+            }
+
+            let status = self.regs.port_read(port_id);
+            if status.is_high_speed_device_ready() {
+                self.ports[idx] = PortState::Probed;
+                out.push(PortChangeInfo {
+                    root_port_id: port_id,
+                    port_id,
+                    port_speed: Speed::High,
+                    tt_port_on_hub: None,
+                });
+            } else if status.connected() && !status.enabled() {
+                warn!(
+                    "ehci: port {} has non-high-speed device ({:?}); handing to companion is not \
+                     supported in v1",
+                    port_id,
+                    status.speed()
+                );
+                self.regs.port_update(port_id, |value| value | PORT_OWNER);
+            }
+        }
+
+        Ok(out)
+    }
+
+    fn reset_port(&self, port_id: u8) {
+        self.regs.port_update(port_id, |value| {
+            (value | PORT_POWER | PORT_RESET)
+                & !(PORT_CONNECT_CHANGE | PORT_ENABLE_CHANGE | PORT_OVER_CURRENT_CHANGE)
+        });
+        self.kernel.delay(Duration::from_millis(50));
+        self.regs.port_update(port_id, |value| value & !PORT_RESET);
+        self.kernel.delay(Duration::from_millis(20));
+    }
+}
+
+impl HubOp for EhciRootHub {
+    fn init<'a>(&'a mut self, info: HubInfo) -> BoxFuture<'a, Result<HubInfo>> {
+        self.init_ports(info).boxed()
+    }
+
+    fn changed_ports<'a>(&'a mut self) -> BoxFuture<'a, Result<Vec<PortChangeInfo>>> {
+        self.changed_ports_inner().boxed()
+    }
+
+    fn slot_id(&self) -> u8 {
+        0
+    }
+}
+
+struct EhciEventHandler {
+    regs: EhciRegisters,
+    wakeups: TransferWakeups,
+}
+
+unsafe impl Send for EhciEventHandler {}
+unsafe impl Sync for EhciEventHandler {}
+
+impl EhciEventHandler {
+    fn new(regs: EhciRegisters, wakeups: TransferWakeups) -> Self {
+        Self { regs, wakeups }
+    }
+}
+
+impl EventHandlerOp for EhciEventHandler {
+    fn handle_event(&self) -> Event {
+        let sts = self.regs.op_read32(USBSTS);
+        let pending = sts
+            & (USBSTS_USBINT
+                | USBSTS_USBERRINT
+                | USBSTS_PORT_CHANGE
+                | USBSTS_HOST_SYSTEM_ERROR
+                | USBSTS_INTERRUPT_ASYNC_ADVANCE);
+        if pending == 0 {
+            return Event::Nothing;
+        }
+
+        self.regs.op_write32(USBSTS, pending);
+        if pending & USBSTS_PORT_CHANGE != 0 {
+            return Event::PortChange { port: 0 };
+        }
+        if pending & (USBSTS_USBINT | USBSTS_USBERRINT | USBSTS_INTERRUPT_ASYNC_ADVANCE) != 0 {
+            self.wakeups.notify();
+            return Event::TransferActivity {
+                count: self.wakeups.take().max(1),
+            };
+        }
+        Event::Stopped
+    }
+}
+
+struct EhciDevice {
+    address: u8,
+    regs: EhciRegisters,
+    schedule: AsyncSchedule,
+    kernel: Kernel,
+    _port_speed: Speed,
+    desc: DeviceDescriptor,
+    ctrl_ep: Endpoint,
+    config_desc: Vec<ConfigurationDescriptor>,
+    current_config_value: Option<u8>,
+    eps: BTreeMap<u8, Endpoint>,
+    ep_interfaces: BTreeMap<u8, u8>,
+}
+
+unsafe impl Send for EhciDevice {}
+
+impl EhciDevice {
+    fn new(
+        address: u8,
+        regs: EhciRegisters,
+        schedule: AsyncSchedule,
+        kernel: Kernel,
+        port_speed: Speed,
+    ) -> Result<Self> {
+        let raw = EhciEndpoint::new(
+            regs,
+            schedule.clone(),
+            kernel.clone(),
+            0,
+            EndpointInfo::control(),
+        )?;
+        Ok(Self {
+            address,
+            regs,
+            schedule,
+            kernel,
+            _port_speed: port_speed,
+            desc: unsafe { core::mem::zeroed() },
+            ctrl_ep: Endpoint::new(EndpointInfo::control(), raw),
+            config_desc: Vec::new(),
+            current_config_value: None,
+            eps: BTreeMap::new(),
+            ep_interfaces: BTreeMap::new(),
+        })
+    }
+
+    async fn init(&mut self) -> Result<()> {
+        let base = self.get_device_descriptor_base().await?;
+        self.set_address().await?;
+        self.ctrl_ep
+            .with_raw_mut::<EhciEndpoint, _>(|ep| ep.set_device_address(self.address));
+        self.ctrl_ep
+            .with_raw_mut::<EhciEndpoint, _>(|ep| ep.set_max_packet_size(base.max_packet_size_0));
+        self.kernel.delay(Duration::from_millis(10));
+
+        self.desc = self.ctrl_ep.get_device_descriptor().await?;
+        self.current_config_value = Some(self.ctrl_ep.get_configuration().await?);
+        for index in 0..self.desc.num_configurations {
+            let config = self.ctrl_ep.get_configuration_descriptor(index).await?;
+            self.config_desc.push(config);
+        }
+        if let Some(config) = self.config_desc.first() {
+            self.set_configuration_inner(config.configuration_value)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn get_device_descriptor_base(&mut self) -> Result<DeviceDescriptorBase> {
+        let mut data = [0u8; 8];
+        self.ctrl_ep
+            .get_descriptor(DescriptorType::DEVICE, 0, 0, &mut data)
+            .await?;
+        Ok(unsafe { (data.as_ptr() as *const DeviceDescriptorBase).read_unaligned() })
+    }
+
+    async fn set_address(&mut self) -> Result<()> {
+        self.ctrl_ep
+            .control_out(
+                ControlSetup {
+                    request_type: RequestType::Standard,
+                    recipient: Recipient::Device,
+                    request: Request::SetAddress,
+                    value: self.address as u16,
+                    index: 0,
+                },
+                &[],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn set_configuration_inner(&mut self, configuration_value: u8) -> Result<()> {
+        self.ctrl_ep.set_configuration(configuration_value).await?;
+        self.current_config_value = Some(configuration_value);
+        self.eps.clear();
+        self.ep_interfaces.clear();
+        Ok(())
+    }
+
+    async fn claim_interface_inner(&mut self, interface: u8, alternate: u8) -> Result<()> {
+        self.ctrl_ep
+            .control_out(
+                ControlSetup {
+                    request_type: RequestType::Standard,
+                    recipient: Recipient::Interface,
+                    request: Request::SetInterface,
+                    value: alternate as u16,
+                    index: interface as u16,
+                },
+                &[],
+            )
+            .await?;
+        self.setup_interface_endpoints(interface, alternate)?;
+        Ok(())
+    }
+
+    fn setup_interface_endpoints(&mut self, interface: u8, alternate: u8) -> Result<()> {
+        let endpoints = self
+            .find_interface_endpoints(interface, alternate)?
+            .to_vec();
+        for desc in endpoints {
+            if matches!(desc.transfer_type, EndpointType::Isochronous) {
+                warn!(
+                    "ehci: isochronous endpoint {:#x} is not supported in v1",
+                    desc.address
+                );
+                continue;
+            }
+            let info = EndpointInfo::from(&desc);
+            let raw = EhciEndpoint::new(
+                self.regs,
+                self.schedule.clone(),
+                self.kernel.clone(),
+                self.address,
+                info,
+            )?;
+            self.eps.insert(desc.address, Endpoint::new(info, raw));
+            self.ep_interfaces.insert(desc.address, interface);
+        }
+        Ok(())
+    }
+
+    fn find_interface_endpoints(
+        &self,
+        interface: u8,
+        alternate: u8,
+    ) -> Result<&[EndpointDescriptor]> {
+        for config in &self.config_desc {
+            for iface in &config.interfaces {
+                if iface.interface_number != interface {
+                    continue;
+                }
+                for alt in &iface.alt_settings {
+                    if alt.alternate_setting == alternate {
+                        return Ok(&alt.endpoints);
+                    }
+                }
+            }
+        }
+        Err(USBError::NotFound)
+    }
+}
+
+impl DeviceOp for EhciDevice {
+    fn id(&self) -> usize {
+        self.address as usize
+    }
+
+    fn backend_name(&self) -> &str {
+        "ehci"
+    }
+
+    fn descriptor(&self) -> &DeviceDescriptor {
+        &self.desc
+    }
+
+    fn configuration_descriptors(&self) -> &[ConfigurationDescriptor] {
+        &self.config_desc
+    }
+
+    fn ctrl_ep_ref(&self) -> &Endpoint {
+        &self.ctrl_ep
+    }
+
+    fn ctrl_ep_mut(&mut self) -> &mut Endpoint {
+        &mut self.ctrl_ep
+    }
+
+    fn claim_interface<'a>(
+        &'a mut self,
+        interface: u8,
+        alternate: u8,
+    ) -> BoxFuture<'a, Result<()>> {
+        self.claim_interface_inner(interface, alternate).boxed()
+    }
+
+    fn set_configuration<'a>(&'a mut self, configuration_value: u8) -> BoxFuture<'a, Result<()>> {
+        self.set_configuration_inner(configuration_value).boxed()
+    }
+
+    fn endpoint(&mut self, desc: &EndpointDescriptor) -> Result<Endpoint> {
+        self.eps.remove(&desc.address).ok_or(USBError::NotFound)
+    }
+
+    fn update_hub(&mut self, _params: HubParams) -> BoxFuture<'_, Result<()>> {
+        async { Ok(()) }.boxed()
+    }
+}
+
+struct EhciEndpoint {
+    regs: EhciRegisters,
+    schedule: AsyncSchedule,
+    kernel: Kernel,
+    qh: CoherentBox<QueueHead>,
+    next_request_id: u64,
+    inflight: Option<SubmittedTransfer>,
+    waker: AtomicWaker,
+}
+
+unsafe impl Send for EhciEndpoint {}
+
+impl EhciEndpoint {
+    fn new(
+        regs: EhciRegisters,
+        schedule: AsyncSchedule,
+        kernel: Kernel,
+        device_address: u8,
+        info: EndpointInfo,
+    ) -> Result<Self> {
+        let mut qh = kernel
+            .coherent_box_zero_with_align::<QueueHead>(32)
+            .map_err(HostError::from)?;
+        qh.write_cpu(QueueHead::endpoint(
+            device_address,
+            endpoint_number(info.address.raw()),
+            info.transfer_type,
+            info.max_packet_size.max(8),
+        ));
+
+        Ok(Self {
+            regs,
+            schedule,
+            kernel,
+            qh,
+            next_request_id: 1,
+            inflight: None,
+            waker: AtomicWaker::new(),
+        })
+    }
+
+    fn set_device_address(&mut self, address: u8) {
+        self.qh.modify_cpu(|qh| {
+            qh.endpoint_chars = (qh.endpoint_chars & !0x7f) | (address as u32 & 0x7f);
+        });
+    }
+
+    fn set_max_packet_size(&mut self, max_packet_size: u8) {
+        let max_packet_size = max_packet_size.max(8) as u32;
+        self.qh.modify_cpu(|qh| {
+            qh.endpoint_chars = (qh.endpoint_chars & !(0x7ff << 16)) | (max_packet_size << 16);
+        });
+    }
+
+    fn allocate_request_id(&mut self) -> RequestId {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
+        RequestId::new(id)
+    }
+
+    fn build_qtds(
+        &self,
+        transfer: &Transfer,
+        request: &TransferRequest,
+    ) -> Result<SubmittedTransfer> {
+        let mut qtds = Vec::new();
+        let mut chunk_lengths = Vec::new();
+        let mut setup_packet = None;
+
+        match request {
+            TransferRequest::Control {
+                setup, direction, ..
+            } => {
+                let setup_bytes = setup_packet_bytes(setup, *direction, transfer.buffer_len());
+                let mut setup_dma = self
+                    .kernel
+                    .coherent_box_zero_with_align::<[u8; 8]>(8)
+                    .map_err(HostError::from)?;
+                setup_dma.write_cpu(setup_bytes);
+                let plan = build_control_td_plan(request)?;
+                qtds.push(new_qtd(
+                    &self.kernel,
+                    plan.setup,
+                    setup_dma.dma_addr().as_u64(),
+                    8,
+                )?);
+                chunk_lengths.push(0);
+                if let Some(data_token) = plan.data {
+                    qtds.push(new_qtd(
+                        &self.kernel,
+                        data_token,
+                        transfer.dma_addr(),
+                        transfer.buffer_len(),
+                    )?);
+                    chunk_lengths.push(transfer.buffer_len());
+                }
+                qtds.push(new_qtd(&self.kernel, plan.status, 0, 0)?);
+                chunk_lengths.push(0);
+                setup_packet = Some(setup_dma);
+            }
+            TransferRequest::Bulk { direction, .. }
+            | TransferRequest::Interrupt { direction, .. } => {
+                let chunks = split_bulk_lengths(transfer.buffer_len(), *direction);
+                let mut offset = 0u64;
+                for (idx, len) in chunks.iter().copied().enumerate() {
+                    let pid = match direction {
+                        Direction::In => QtdPid::In,
+                        Direction::Out => QtdPid::Out,
+                    };
+                    let token = QtdToken::new(pid, len)
+                        .with_error_counter(3)
+                        .with_interrupt_on_complete(idx + 1 == chunks.len())
+                        .with_active(true);
+                    qtds.push(new_qtd(
+                        &self.kernel,
+                        token,
+                        transfer.dma_addr() + offset,
+                        len,
+                    )?);
+                    chunk_lengths.push(len);
+                    offset += len as u64;
+                }
+            }
+            TransferRequest::Isochronous { .. } => return Err(USBError::NotSupported),
+        }
+
+        link_qtds(&mut qtds);
+
+        Ok(SubmittedTransfer {
+            request_id: RequestId::new(0),
+            transfer: None,
+            qtds,
+            chunk_lengths,
+            _setup_packet: setup_packet,
+            cancelled: false,
+        })
+    }
+
+    fn start_transfer(&mut self, submitted: &SubmittedTransfer) -> Result<()> {
+        let first_qtd = submitted
+            .qtds
+            .first()
+            .ok_or(USBError::InvalidParameter)?
+            .dma_addr()
+            .as_u64() as u32;
+        self.qh.modify_cpu(|qh| qh.set_next_qtd(first_qtd));
+        self.schedule.attach(&mut self.qh)?;
+        mb();
+        self.regs
+            .op_update32(USBCMD, |cmd| cmd | USBCMD_ASYNC_ENABLE | USBCMD_RUN_STOP);
+        Ok(())
+    }
+
+    fn finish_if_ready(
+        &mut self,
+        id: RequestId,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        let submitted = self.inflight.as_mut()?;
+        if submitted.request_id != id {
+            return Some(Err(TransferError::InvalidEndpoint));
+        }
+
+        let mut actual_length = 0usize;
+        let mut all_done = true;
+        let mut error = None;
+        for (qtd, requested) in submitted
+            .qtds
+            .iter()
+            .zip(submitted.chunk_lengths.iter().copied())
+        {
+            let token = qtd.read_cpu().token();
+            if token.active() {
+                all_done = false;
+                break;
+            }
+            if token.has_error() {
+                error = Some(TransferError::Other(anyhow!(
+                    "EHCI qTD failed token={:#x}",
+                    token.raw()
+                )));
+                break;
+            }
+            actual_length += requested.saturating_sub(token.total_bytes());
+        }
+
+        if !all_done {
+            return None;
+        }
+
+        let mut submitted = self.inflight.take()?;
+        let qh_addr = self.qh.dma_addr().as_u64() as u32;
+        self.schedule.detach(qh_addr);
+        self.regs
+            .op_update32(USBCMD, |cmd| cmd | USBCMD_INT_ASYNC_ADVANCE_DOORBELL);
+
+        if submitted.cancelled {
+            return Some(Err(TransferError::Cancelled));
+        }
+        if let Some(err) = error {
+            return Some(Err(err));
+        }
+
+        let Some(transfer) = submitted.transfer.take() else {
+            return Some(Err(TransferError::Other(anyhow!(
+                "EHCI transfer missing state"
+            ))));
+        };
+        if actual_length > 0 && matches!(transfer.direction, Direction::In) {
+            transfer.complete_for_cpu_all();
+        }
+
+        Some(Ok(TransferCompletion {
+            request_id: id,
+            status: TransferStatus::Completed,
+            actual_length,
+            iso_packets: Vec::new(),
+        }))
+    }
+}
+
+impl crate::backend::ty::ep::EndpointOp for EhciEndpoint {
+    fn submit_request(
+        &mut self,
+        request: TransferRequest,
+    ) -> core::result::Result<RequestId, TransferError> {
+        if self.inflight.is_some() {
+            return Err(TransferError::QueueFull);
+        }
+        if matches!(request, TransferRequest::Isochronous { .. }) {
+            return Err(TransferError::NotSupported);
+        }
+
+        let transfer = Transfer::from_request(&self.kernel, request.clone())?;
+        if transfer.buffer_len() > 0 && matches!(transfer.direction, Direction::Out) {
+            transfer.prepare_for_device_all();
+        }
+        let mut submitted = self
+            .build_qtds(&transfer, &request)
+            .map_err(usb_to_transfer_error)?;
+        let id = self.allocate_request_id();
+        submitted.request_id = id;
+        submitted.transfer = Some(transfer);
+        self.start_transfer(&submitted)
+            .map_err(usb_to_transfer_error)?;
+        self.inflight = Some(submitted);
+        Ok(id)
+    }
+
+    fn reclaim_request(
+        &mut self,
+        id: RequestId,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        self.finish_if_ready(id)
+    }
+
+    fn register_waker(&self, _id: RequestId, cx: &mut Context<'_>) {
+        self.waker.register(cx.waker());
+        cx.waker().wake_by_ref();
+    }
+
+    fn cancel_request(&mut self, id: RequestId) -> core::result::Result<(), TransferError> {
+        let submitted = self
+            .inflight
+            .as_mut()
+            .ok_or(TransferError::InvalidEndpoint)?;
+        if submitted.request_id != id {
+            return Err(TransferError::InvalidEndpoint);
+        }
+        submitted.cancelled = true;
+        Ok(())
+    }
+}
+
+struct SubmittedTransfer {
+    request_id: RequestId,
+    transfer: Option<Transfer>,
+    qtds: Vec<CoherentBox<QueueTransferDescriptor>>,
+    chunk_lengths: Vec<usize>,
+    _setup_packet: Option<CoherentBox<[u8; 8]>>,
+    cancelled: bool,
+}
+
+fn new_qtd(
+    kernel: &Kernel,
+    token: QtdToken,
+    dma_addr: u64,
+    len: usize,
+) -> Result<CoherentBox<QueueTransferDescriptor>> {
+    let mut qtd = kernel
+        .coherent_box_zero_with_align::<QueueTransferDescriptor>(32)
+        .map_err(HostError::from)?;
+    qtd.write_cpu(QueueTransferDescriptor::new(token, dma_addr, len));
+    Ok(qtd)
+}
+
+fn link_qtds(qtds: &mut [CoherentBox<QueueTransferDescriptor>]) {
+    let mut next_addrs = Vec::with_capacity(qtds.len());
+    for qtd in qtds.iter() {
+        next_addrs.push(qtd.dma_addr().as_u64() as u32);
+    }
+    for (idx, qtd) in qtds.iter_mut().enumerate() {
+        let next = next_addrs.get(idx + 1).copied();
+        qtd.modify_cpu(|qtd| qtd.set_next(next));
+    }
+}
+
+fn endpoint_number(address: u8) -> u8 {
+    address & 0x0f
+}
+
+fn setup_packet_bytes(setup: &ControlSetup, direction: Direction, len: usize) -> [u8; 8] {
+    let request_type = BmRequestType::new(direction, setup.request_type, setup.recipient);
+    let value = setup.value.to_le_bytes();
+    let index = setup.index.to_le_bytes();
+    let len = (len as u16).to_le_bytes();
+    [
+        request_type.into(),
+        setup.request.into(),
+        value[0],
+        value[1],
+        index[0],
+        index[1],
+        len[0],
+        len[1],
+    ]
+}
+
+fn usb_to_transfer_error(err: USBError) -> TransferError {
+    match err {
+        USBError::TransferError(err) => err,
+        USBError::NoMemory => TransferError::Other(anyhow!("EHCI DMA allocation failed")),
+        USBError::Timeout => TransferError::Timeout,
+        USBError::NotSupported => TransferError::NotSupported,
+        USBError::NotFound | USBError::InvalidParameter => TransferError::InvalidEndpoint,
+        err => TransferError::Other(anyhow!("EHCI transfer setup failed: {err}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use usb_if::{
+        endpoint::TransferRequest,
+        host::{ControlSetup, hub::Speed},
+        transfer::{Direction, Recipient, Request, RequestType},
+    };
+
+    use super::{
+        ControlTdPlan, EhciPortStatus, QtdPid, QtdToken, build_control_td_plan, split_bulk_lengths,
+    };
+
+    #[test]
+    fn port_status_reports_high_speed_only_when_enabled_and_line_status_is_k_state() {
+        let status = EhciPortStatus::from_raw(
+            EhciPortStatus::CURRENT_CONNECT
+                | EhciPortStatus::PORT_ENABLED
+                | EhciPortStatus::LINE_STATUS_K_STATE,
+        );
+
+        assert_eq!(status.speed(), Speed::High);
+        assert!(status.is_high_speed_device_ready());
+    }
+
+    #[test]
+    fn port_status_rejects_low_or_full_speed_for_ehci_v1() {
+        let low_speed = EhciPortStatus::from_raw(
+            EhciPortStatus::CURRENT_CONNECT | EhciPortStatus::LINE_STATUS_K_STATE,
+        );
+        let full_speed = EhciPortStatus::from_raw(EhciPortStatus::CURRENT_CONNECT);
+
+        assert_eq!(low_speed.speed(), Speed::Low);
+        assert_eq!(full_speed.speed(), Speed::Full);
+        assert!(!low_speed.is_high_speed_device_ready());
+        assert!(!full_speed.is_high_speed_device_ready());
+    }
+
+    #[test]
+    fn qtd_token_encodes_pid_length_ioc_active_and_error_counter() {
+        let token = QtdToken::new(QtdPid::In, 512)
+            .with_interrupt_on_complete(true)
+            .with_error_counter(3)
+            .with_active(true);
+
+        assert_eq!(token.raw() & QtdToken::PID_MASK, QtdToken::PID_IN);
+        assert_eq!(token.total_bytes(), 512);
+        assert!(token.interrupt_on_complete());
+        assert_eq!(token.error_counter(), 3);
+        assert!(token.active());
+    }
+
+    #[test]
+    fn control_td_plan_uses_setup_data_and_opposite_direction_status_stage() {
+        let mut data = [0u8; 18];
+        let request = TransferRequest::control_in(
+            ControlSetup {
+                request_type: RequestType::Standard,
+                recipient: Recipient::Device,
+                request: Request::GetDescriptor,
+                value: 0x0100,
+                index: 0,
+            },
+            &mut data,
+        );
+
+        let ControlTdPlan {
+            setup,
+            data,
+            status,
+        } = build_control_td_plan(&request).expect("control IN request should be supported");
+
+        assert_eq!(setup.pid(), QtdPid::Setup);
+        assert_eq!(setup.total_bytes(), 8);
+        assert_eq!(data.expect("data stage").pid(), QtdPid::In);
+        assert_eq!(status.pid(), QtdPid::Out);
+        assert!(status.interrupt_on_complete());
+    }
+
+    #[test]
+    fn control_td_plan_has_no_data_stage_for_zero_length_control_out() {
+        let request = TransferRequest::control_out(
+            ControlSetup {
+                request_type: RequestType::Standard,
+                recipient: Recipient::Device,
+                request: Request::SetAddress,
+                value: 7,
+                index: 0,
+            },
+            &[],
+        );
+
+        let plan = build_control_td_plan(&request).expect("zero-length control OUT is supported");
+
+        assert_eq!(plan.setup.pid(), QtdPid::Setup);
+        assert!(plan.data.is_none());
+        assert_eq!(plan.status.pid(), QtdPid::In);
+    }
+
+    #[test]
+    fn bulk_transfers_are_split_to_qtd_max_total_bytes() {
+        let lengths = split_bulk_lengths(48 * 1024, Direction::Out);
+
+        assert_eq!(lengths, [20 * 1024, 20 * 1024, 8 * 1024]);
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/mod.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 mod dwc;
+mod ehci;
 mod hub;
 mod kcore;
 pub mod osal;
@@ -18,6 +19,8 @@ pub use dwc::{
     CruOp, DwcNewParams, DwcParams, UdphyParam, Usb2PhyParam, UsbPhyInterfaceMode,
     usb2phy::Usb2PhyPortId,
 };
+use ehci::Ehci;
+pub use ehci::EhciNewParams;
 use id_arena::Id;
 use kcore::*;
 pub use osal::*;
@@ -33,6 +36,10 @@ impl USBHost {
 
     pub fn new_dwc(params: DwcNewParams<'_, impl CruOp>) -> Result<USBHost> {
         Ok(USBHost::new(Dwc::new(params)?))
+    }
+
+    pub fn new_ehci(params: EhciNewParams) -> Result<USBHost> {
+        Ok(USBHost::new(Ehci::new(params)?))
     }
 
     pub(crate) fn new(backend: impl CoreOp) -> Self {

--- a/os/StarryOS/configs/board/orangepi-5-plus.toml
+++ b/os/StarryOS/configs/board/orangepi-5-plus.toml
@@ -7,6 +7,7 @@ features = [
   "ax-driver/realtek-rtl8125",
   "ax-driver/rockchip-soc",
   "ax-driver/rockchip-dwc-xhci",
+  "ax-driver/rockchip-ehci",
   "ax-driver/rockchip-sdhci",
   "ax-driver/rockchip-dwmmc",
   "rknpu",

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/descriptor.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/descriptor.rs
@@ -8,6 +8,7 @@ use crab_usb::{
     usb_if::{
         self,
         descriptor::{ConfigurationDescriptor, DeviceDescriptor},
+        host::hub::Speed,
     },
 };
 use linux_raw_sys::general::{
@@ -155,11 +156,11 @@ pub(super) struct UsbDeviceSnapshot {
     pub(super) descriptor_blob: Vec<u8>,
 }
 
-pub(super) fn root_hub_snapshot(bus_num: u8) -> UsbDeviceSnapshot {
+pub(super) fn root_hub_snapshot(bus_num: u8, speed: Speed) -> UsbDeviceSnapshot {
     UsbDeviceSnapshot {
         bus_num,
         device_num: 1,
-        descriptor_blob: root_hub_descriptor_blob(),
+        descriptor_blob: root_hub_descriptor_blob(speed),
     }
 }
 
@@ -296,15 +297,48 @@ fn serialize_descriptor_blob(
     out
 }
 
-fn root_hub_descriptor_blob() -> Vec<u8> {
+fn root_hub_descriptor_blob(speed: Speed) -> Vec<u8> {
+    let (usb_version, product_id, protocol, max_packet_size_0) = match speed {
+        Speed::SuperSpeed | Speed::SuperSpeedPlus => (0x0300u16, 0x0003u16, 0x03u8, 9u8),
+        Speed::High | Speed::Wireless => (0x0200u16, 0x0002u16, 0x01u8, 64u8),
+        Speed::Full | Speed::Low => (0x0110u16, 0x0001u16, 0x00u8, 8u8),
+    };
+
     let mut out = Vec::new();
-    out.extend_from_slice(&[
-        18, 0x01, 0x00, 0x03, 0x09, 0x00, 0x03, 9, 0x6b, 0x1d, 0x03, 0x00, 0x00, 0x06, 0, 0, 0, 1,
-    ]);
+    out.extend_from_slice(&[18, 0x01]);
+    out.extend_from_slice(&usb_version.to_le_bytes());
+    out.extend_from_slice(&[0x09, 0x00, protocol, max_packet_size_0]);
+    out.extend_from_slice(&0x1d6bu16.to_le_bytes());
+    out.extend_from_slice(&product_id.to_le_bytes());
+    out.extend_from_slice(&0x0600u16.to_le_bytes());
+    out.extend_from_slice(&[0, 0, 0, 1]);
     out.extend_from_slice(&[9, 0x02, 25, 0, 1, 1, 0, 0xe0, 0]);
     out.extend_from_slice(&[9, 0x04, 0, 0, 1, 0x09, 0, 0, 0]);
     out.extend_from_slice(&[7, 0x05, 0x81, 0x03, 4, 0, 12]);
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn high_speed_root_hub_uses_usb2_linux_foundation_id() {
+        let snapshot = root_hub_snapshot(1, Speed::High);
+
+        assert_eq!(&snapshot.descriptor_blob[2..4], &0x0200u16.to_le_bytes());
+        assert_eq!(&snapshot.descriptor_blob[8..10], &0x1d6bu16.to_le_bytes());
+        assert_eq!(&snapshot.descriptor_blob[10..12], &0x0002u16.to_le_bytes());
+    }
+
+    #[test]
+    fn superspeed_root_hub_keeps_usb3_linux_foundation_id() {
+        let snapshot = root_hub_snapshot(1, Speed::SuperSpeedPlus);
+
+        assert_eq!(&snapshot.descriptor_blob[2..4], &0x0300u16.to_le_bytes());
+        assert_eq!(&snapshot.descriptor_blob[8..10], &0x1d6bu16.to_le_bytes());
+        assert_eq!(&snapshot.descriptor_blob[10..12], &0x0003u16.to_le_bytes());
+    }
 }
 
 fn endpoint_attributes(transfer_type: usb_if::descriptor::EndpointType) -> u8 {

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
@@ -15,7 +15,7 @@ use crab_usb::{
     usb_if::{
         endpoint::{RequestId, TransferCompletion, TransferRequest},
         err::{TransferError, USBError},
-        host::ControlSetup,
+        host::{ControlSetup, hub::Speed},
         transfer::{Direction, Recipient, Request, RequestType},
     },
 };
@@ -45,6 +45,7 @@ pub(super) struct UsbHostState {
     pub(super) device_id: RDriveDeviceId,
     pub(super) bus_num: u8,
     pub(super) irq: Option<IrqId>,
+    pub(super) root_hub_speed: Speed,
     pub(super) needs_probe: bool,
     pub(super) next_device_num: u8,
     pub(super) stable_id_to_device_num: BTreeMap<usize, u8>,
@@ -373,7 +374,7 @@ impl UsbFsManager {
                 },
                 UsbDeviceRecord {
                     host_device_id: host.device_id,
-                    snapshot: root_hub_snapshot(host.bus_num),
+                    snapshot: root_hub_snapshot(host.bus_num, host.root_hub_speed),
                     present: true,
                     unopened_info: None,
                     live_device: None,
@@ -1359,6 +1360,7 @@ pub(super) fn discover_hosts() -> (Vec<UsbHostState>, Vec<PendingUsbIrqSlot>) {
                     }
                 }
             });
+        let root_hub_speed = guard.root_hub_speed();
         let irq_handler = guard
             .take_event_handler()
             .map(|handler| (host_irq, handler));
@@ -1377,6 +1379,7 @@ pub(super) fn discover_hosts() -> (Vec<UsbHostState>, Vec<PendingUsbIrqSlot>) {
             device_id,
             bus_num,
             irq: host_irq,
+            root_hub_speed,
             needs_probe: true,
             next_device_num: 1,
             stable_id_to_device_num: BTreeMap::new(),

--- a/test-suit/starryos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -7,6 +7,7 @@ features = [
   "ax-driver/realtek-rtl8125",
   "ax-driver/rockchip-soc",
   "ax-driver/rockchip-dwc-xhci",
+  "ax-driver/rockchip-ehci",
   "ax-driver/rockchip-sdhci",
   "ax-driver/rockchip-dwmmc",
   "rknpu",

--- a/test-suit/starryos/board-orangepi-5-plus/usb2-lsusb/board-orangepi-5-plus.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/usb2-lsusb/board-orangepi-5-plus.toml
@@ -1,0 +1,16 @@
+board_type = "OrangePi-5-Plus"
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sleep 5; echo STARRY_USB2_LSUSB_BEGIN; lsusb > /tmp/starry-usb2-lsusb.out; cat /tmp/starry-usb2-lsusb.out; if ! grep -Eq 'ID 1d6b:0002' /tmp/starry-usb2-lsusb.out; then echo STARRY_USB2_ROOT_HUB_MISSING; elif ! grep -Eq 'ID 05e3:06(10|20)' /tmp/starry-usb2-lsusb.out; then echo STARRY_USB2_DEVICE_MISSING; else echo STARRY_USB2_LSUSB_OK; fi"
+success_regex = ["(?m)^STARRY_USB2_LSUSB_OK\\s*$"]
+fail_regex = [
+  '(?i)\bpanic(?:ked)?\b',
+  '(?i)segmentation fault',
+  '(?i)SIGSEGV',
+  'exit with code: 139',
+  "(?m)^unable to initialize libusb: .*$",
+  "(?i)(lsusb|tee|grep|sh): .*not found",
+  "(?m)^lsusb: .*",
+  "(?m)^STARRY_USB2_ROOT_HUB_MISSING\\s*$",
+  "(?m)^STARRY_USB2_DEVICE_MISSING\\s*$",
+]
+timeout = 300


### PR DESCRIPTION
## 问题

OrangePi 5 Plus 的 RK3588 Linux DTS 中，板载 USB2 host 实际走 EHCI/OHCI 控制器，而不是 DWC2。原计划如果继续在这块板上接 DWC2 host，会落到不存在的控制器路径，无法让 USB2-A host 口在 StarryOS 下枚举设备。

## 改动

- 在 `crab-usb` 增加 EHCI kmod host 后端，并提供 `USBHost::new_ehci` / `EhciNewParams`。
- 在 `ax-driver` 增加 `rockchip-ehci` feature 和 RK3588 FDT probe，初始化 EHCI 所需的 power domain、clock、reset、USB2 PHY、regulator，并注册为 USB host。
- 为 `PlatformUsbHost` 增加 root hub speed 元数据，让 Starry usbfs 能区分 xHCI SuperSpeed root hub 和 EHCI HighSpeed root hub。
- 更新 OrangePi 5 Plus Starry board 配置，保留 `rockchip-dwc-xhci`，同时启用 `rockchip-ehci`。
- 新增 `board-orangepi-5-plus/usb2-lsusb` board case，要求看到 USB2 root hub `1d6b:0002` 和已知 USB2 设备 `05e3:0610` / `05e3:0620`。

## 方案逻辑

OrangePi 5 Plus 上 Type-C/DWC3/xHCI 路径和板载 USB2-A host 路径是两套控制器。本 PR 不把 USB2-A host 强行挂到 DWC2，而是按 RK3588 DTS 暴露的 EHCI host 节点接入。EHCI 后端负责 host controller 初始化、root hub 端口状态/复位、EP0 控制传输以及 bulk/interrupt transfer 的 qTD 完成处理；Starry usbfs 则根据 driver 注册的 root hub speed 生成正确的 Linux Foundation root hub descriptor。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo xtask clippy --package crab-usb`
- `cargo xtask clippy --package ax-driver`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test board -l`
- `cargo xtask board ls`
- `cargo xtask starry test board -c usb2-lsusb --board orangepi-5-plus -b OrangePi-5-Plus`

实机 `usb2-lsusb` 输出确认：

```text
Bus 002 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 003 Device 002: ID 05e3:0610 Genesys Logic, Inc. Hub
STARRY_USB2_LSUSB_OK
```
