### PR TITLE
fix(starry): apply termios serial format and handle tty drain ioctls

### DIFF
--- a/drivers/ax-driver/src/serial/mod.rs
+++ b/drivers/ax-driver/src/serial/mod.rs
@@ -7,8 +7,9 @@ use axklib::irq::{CpuId, IrqError, run_on_cpu_sync};
 use fdt_edit::{Fdt, RegFixed};
 use log::warn;
 pub use rdif_serial::{
-    Config, ConfigError, OwnerId, OwnerLease, RawUart, RxFlag, RxItem, RxQueue, SerialCounters,
-    SerialIrqHandler, SerialIrqOutcome, SerialParts, SerialPort, SerialSoftWork, TxQueue,
+    Config, ConfigError, DataBits, OwnerId, OwnerLease, Parity, RawUart, RxFlag, RxItem, RxQueue,
+    SerialCounters, SerialIrqHandler, SerialIrqOutcome, SerialParts, SerialPort, SerialSoftWork,
+    StopBits, TxQueue,
 };
 use rdrive::{Device, DeviceId, DriverGeneric, probe::acpi::AcpiInfo, register::FdtInfo};
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -209,6 +209,11 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                     );
                 }
             }
+            TCSBRK | TCSBRKP => {
+                // tcdrain()/tcsendbreak() compatibility. Serial writes are
+                // submitted synchronously to the driver path today, so treat
+                // drain/break requests as completed instead of returning ENOTTY.
+            }
             TIOCSPTLCK => {}
             TIOCGPTN => {
                 (arg as *mut u32).vm_write(self.pty_number())?;

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -143,11 +143,13 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 (arg as *mut Termios2).vm_write(termios)?;
             }
             TCSETS | TCSETSF | TCSETSW => {
-                // TODO: drain output?
                 // Note: vm_read() must complete before acquiring the terminal lock.
                 // Faultable user memory access inside an atomic context (preemption
                 // disabled) will call might_sleep() in handle_page_fault and panic.
                 let termios = Arc::new(Termios2::new((arg as *const Termios).vm_read()?));
+                if matches!(cmd, TCSETSF | TCSETSW) {
+                    self.writer.drain()?;
+                }
                 let old = {
                     let mut guard = self.terminal.termios.lock();
                     let old = guard.clone();
@@ -160,8 +162,10 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 }
             }
             TCSETS2 | TCSETSF2 | TCSETSW2 => {
-                // TODO: drain output?
                 let termios = Arc::new((arg as *const Termios2).vm_read()?);
+                if matches!(cmd, TCSETSF2 | TCSETSW2) {
+                    self.writer.drain()?;
+                }
                 let old = {
                     let mut guard = self.terminal.termios.lock();
                     let old = guard.clone();

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -209,10 +209,15 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                     );
                 }
             }
-            TCSBRK | TCSBRKP => {
-                // tcdrain()/tcsendbreak() compatibility. Serial writes are
-                // submitted synchronously to the driver path today, so treat
-                // drain/break requests as completed instead of returning ENOTTY.
+            TCSBRK => {
+                self.writer.drain()?;
+                if arg == 0 {
+                    return Err(AxError::Unsupported);
+                }
+            }
+            TCSBRKP => {
+                self.writer.drain()?;
+                return Err(AxError::Unsupported);
             }
             TIOCSPTLCK => {}
             TIOCGPTN => {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
@@ -1,5 +1,8 @@
 use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::{
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+    time::Duration,
+};
 
 use ax_driver::serial::{
     self as ax_serial, Config, ConfigError, DataBits, OwnerId, Parity, RxFlag, RxItem, RxQueue,
@@ -471,6 +474,23 @@ impl SerialBackend {
         (submit.accepted, outcome)
     }
 
+    fn tx_idle(&self) -> bool {
+        ax_serial::run_on_owner(self.owner, |lease| self.port.tx_idle(lease)).unwrap_or(false)
+    }
+
+    fn drain_tx(&self) -> AxResult<()> {
+        self.ensure_started()?;
+        let _guard = self.output_lock.lock();
+        loop {
+            let outcome = self.service_on_owner(SerialSoftWork::TX_KICK);
+            publish_serial_outcome(self, outcome, false);
+            if self.tx_idle() {
+                return Ok(());
+            }
+            ax_task::sleep(Duration::from_millis(1));
+        }
+    }
+
     fn drain_rx(&self, out: &mut [RxItem]) -> usize {
         self.rx.lock().drain(out)
     }
@@ -645,6 +665,10 @@ impl TtyWrite for SerialWriter {
 
     fn max_sync_echo_bytes(&self) -> usize {
         SERIAL_SYNC_ECHO_LIMIT
+    }
+
+    fn drain(&self) -> AxResult<()> {
+        self.backend.drain_tx()
     }
 
     fn termios_changed(&self, old: &Termios2, new: &Termios2) {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
@@ -2,8 +2,9 @@ use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use ax_driver::serial::{
-    self as ax_serial, Config, ConfigError, OwnerId, RxFlag, RxItem, RxQueue, SerialDevice,
-    SerialIrqHandler, SerialIrqOutcome, SerialPort, SerialSoftWork, TxQueue,
+    self as ax_serial, Config, ConfigError, DataBits, OwnerId, Parity, RxFlag, RxItem, RxQueue,
+    SerialDevice, SerialIrqHandler, SerialIrqOutcome, SerialPort, SerialSoftWork, StopBits,
+    TxQueue,
 };
 use ax_errno::{AxError, AxResult};
 use ax_kspin::SpinNoIrq;
@@ -24,7 +25,7 @@ use super::{
     terminal::{
         Terminal,
         ldisc::{ProcessMode, TtyConfig, TtyRead, TtyWrite},
-        termios::Termios2,
+        termios::{Termios2, TermiosParity},
     },
 };
 use crate::pseudofs::DeviceOps;
@@ -483,6 +484,32 @@ fn startup_baudrate(current: u32) -> u32 {
     }
 }
 
+fn serial_config_from_termios(termios: &Termios2) -> Config {
+    let mut config = Config::new()
+        .data_bits(match termios.data_bits() {
+            5 => DataBits::Five,
+            6 => DataBits::Six,
+            7 => DataBits::Seven,
+            _ => DataBits::Eight,
+        })
+        .stop_bits(if termios.stop_bits() == 2 {
+            StopBits::Two
+        } else {
+            StopBits::One
+        })
+        .parity(match termios.parity() {
+            TermiosParity::None => Parity::None,
+            TermiosParity::Odd => Parity::Odd,
+            TermiosParity::Even => Parity::Even,
+            TermiosParity::Mark => Parity::Mark,
+            TermiosParity::Space => Parity::Space,
+        });
+    if let Some(baudrate) = termios.baudrate() {
+        config = config.baudrate(baudrate);
+    }
+    config
+}
+
 fn spawn_serial_event_worker(backend: Arc<SerialBackend>) {
     let task_name = format!("{}-event", backend.tty_name);
     ax_task::spawn_with_name(
@@ -621,10 +648,11 @@ impl TtyWrite for SerialWriter {
     }
 
     fn termios_changed(&self, old: &Termios2, new: &Termios2) {
-        let Some(new_baud) = new.baudrate() else {
-            return;
-        };
-        if old.baudrate() == Some(new_baud) {
+        if old.baudrate() == new.baudrate()
+            && old.data_bits() == new.data_bits()
+            && old.stop_bits() == new.stop_bits()
+            && old.parity() == new.parity()
+        {
             return;
         }
         if self.backend.ensure_started().is_err() {
@@ -632,10 +660,10 @@ impl TtyWrite for SerialWriter {
         }
         if let Err(err) = self
             .backend
-            .set_port_config(&Config::new().baudrate(new_baud))
+            .set_port_config(&serial_config_from_termios(new))
         {
             warn!(
-                "{} failed to set baudrate {new_baud} on {}: {:?}",
+                "{} failed to apply termios on {}: {:?}",
                 self.backend.tty_name, self.backend.name, err
             );
         }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -77,6 +77,10 @@ pub trait TtyWrite: Send + Sync + 'static {
         }
     }
 
+    fn drain(&self) -> AxResult<()> {
+        Ok(())
+    }
+
     fn termios_changed(&self, _old: &Termios2, _new: &Termios2) {}
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/termios.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/termios.rs
@@ -6,11 +6,21 @@ use bytemuck::AnyBitPattern;
 use linux_raw_sys::general::{
     B50, B75, B110, B134, B150, B200, B300, B600, B1200, B1800, B2400, B4800, B9600, B19200,
     B38400, B57600, B115200, B230400, B460800, B500000, B576000, B921600, B1000000, B1152000,
-    B1500000, B2000000, B2500000, B3000000, B3500000, B4000000, BOTHER, CBAUD, CREAD, CS8, ECHO,
-    ECHOCTL, ECHOE, ECHOK, ECHOKE, ICANON, ICRNL, IEXTEN, ISIG, IXON, ONLCR, OPOST, VDISCARD, VEOF,
-    VEOL, VEOL2, VERASE, VINTR, VKILL, VLNEXT, VQUIT, VREPRINT, VSUSP, VWERASE, speed_t, tcflag_t,
+    B1500000, B2000000, B2500000, B3000000, B3500000, B4000000, BOTHER, CBAUD, CMSPAR, CREAD, CS5,
+    CS6, CS7, CS8, CSIZE, CSTOPB, ECHO, ECHOCTL, ECHOE, ECHOK, ECHOKE, ICANON, ICRNL, IEXTEN, ISIG,
+    IXON, ONLCR, OPOST, PARENB, PARODD, VDISCARD, VEOF, VEOL, VEOL2, VERASE, VINTR, VKILL, VLNEXT,
+    VQUIT, VREPRINT, VSUSP, VWERASE, speed_t, tcflag_t,
 };
 use starry_signal::Signo;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TermiosParity {
+    None,
+    Odd,
+    Even,
+    Mark,
+    Space,
+}
 
 #[repr(C)]
 #[derive(Clone, Copy, AnyBitPattern)]
@@ -77,6 +87,37 @@ impl Termios {
 
     pub fn cflag(&self) -> tcflag_t {
         self.c_cflag
+    }
+
+    pub fn data_bits(&self) -> u8 {
+        match self.c_cflag & CSIZE {
+            CS5 => 5,
+            CS6 => 6,
+            CS7 => 7,
+            CS8 => 8,
+            _ => 8,
+        }
+    }
+
+    pub fn stop_bits(&self) -> u8 {
+        if self.has_cflag(CSTOPB) { 2 } else { 1 }
+    }
+
+    pub fn parity(&self) -> TermiosParity {
+        if !self.has_cflag(PARENB) {
+            return TermiosParity::None;
+        }
+        if self.has_cflag(CMSPAR) {
+            if self.has_cflag(PARODD) {
+                TermiosParity::Mark
+            } else {
+                TermiosParity::Space
+            }
+        } else if self.has_cflag(PARODD) {
+            TermiosParity::Odd
+        } else {
+            TermiosParity::Even
+        }
     }
 
     pub fn has_lflag(&self, flag: u32) -> bool {


### PR DESCRIPTION
## Summary

修复 StarryOS 上用户态串口程序控制 SG2002 外设时的兼容性问题。

主要改动：

- 支持 `TCSBRK` / `TCSBRKP`，避免用户态串口库调用 `tcdrain()` / `tcsendbreak()` 时返回 `ENOTTY`，表现为 `Not a tty (os error 25)`。
- 为 termios 增加串口格式解析：
  - `CS5` / `CS6` / `CS7` / `CS8`
  - `CSTOPB`
  - `PARENB` / `PARODD` / `CMSPAR`
- 在用户态调用 `tcsetattr()` 后，将 termios 中的 baudrate、data bits、stop bits、parity 应用到硬件 UART。
- 串口启动路径保持原行为，只设置 baudrate；只有用户态明确配置 termios 时才修改完整串口格式。
- 调整 SG2002 远程 board 配置，避免启动成功后自动退出调试会话。

## Background

`akars` 在 StarryOS 上访问 `/dev/ttyS1` 时曾出现两类问题：

1. 写串口时报：

```text
write failed: Not a tty (os error 25)
```
原因是 StarryOS tty ioctl 未兼容 TCSBRK / TCSBRKP。

2. 修复写入错误后，串口写入成功但电机控制板无 ACK：
```
CMD_INIT timeout
CMD_SET_SPEED timeout
```
原因是用户态设置的 termios 串口格式没有真正应用到硬件 UART。