### PR TITLE
fix(starry): tighten LTP-derived syscall compatibility guards

### DIFF
--- a/memory/memory_set/src/area.rs
+++ b/memory/memory_set/src/area.rs
@@ -12,6 +12,7 @@ use crate::{MappingBackend, MappingError, MappingResult};
 pub struct MemoryArea<B: MappingBackend> {
     va_range: AddrRange<B::Addr>,
     flags: B::Flags,
+    reported_flags: B::Flags,
     backend: B,
 }
 
@@ -22,9 +23,28 @@ impl<B: MappingBackend> MemoryArea<B> {
     ///
     /// Panics if `start + size` overflows.
     pub fn new(start: B::Addr, size: usize, flags: B::Flags, backend: B) -> Self {
+        Self::new_with_reported_flags(start, size, flags, flags, backend)
+    }
+
+    /// Creates a new memory area with separate backend and reported flags.
+    ///
+    /// `flags` are used for page-table/backend operations. `reported_flags`
+    /// are metadata exposed through introspection interfaces such as procfs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `start + size` overflows.
+    pub fn new_with_reported_flags(
+        start: B::Addr,
+        size: usize,
+        flags: B::Flags,
+        reported_flags: B::Flags,
+        backend: B,
+    ) -> Self {
         Self {
             va_range: AddrRange::from_start_size(start, size),
             flags,
+            reported_flags,
             backend,
         }
     }
@@ -37,6 +57,11 @@ impl<B: MappingBackend> MemoryArea<B> {
     /// Returns the memory flags, e.g., the permission bits.
     pub const fn flags(&self) -> B::Flags {
         self.flags
+    }
+
+    /// Returns the permission flags reported to user-visible introspection.
+    pub const fn reported_flags(&self) -> B::Flags {
+        self.reported_flags
     }
 
     /// Returns the start address of the memory area.
@@ -61,9 +86,14 @@ impl<B: MappingBackend> MemoryArea<B> {
 }
 
 impl<B: MappingBackend> MemoryArea<B> {
-    /// Changes the flags.
-    pub(crate) fn set_flags(&mut self, new_flags: B::Flags) {
+    /// Changes backend/page-table flags and reported flags together.
+    pub(crate) fn set_flags_with_reported_flags(
+        &mut self,
+        new_flags: B::Flags,
+        new_reported_flags: B::Flags,
+    ) {
         self.flags = new_flags;
+        self.reported_flags = new_reported_flags;
     }
 
     /// Maps the whole memory area in the page table.
@@ -220,12 +250,13 @@ impl<B: MappingBackend> MemoryArea<B> {
                 .split(align_diff)
                 .expect("backend should be splittable");
 
-            let new_area = Self::new(
+            let new_area = Self::new_with_reported_flags(
                 pos,
                 // Use wrapping_sub_addr to avoid overflow check. It is safe because
                 // `pos` is within the memory area.
                 self.end().wrapping_sub_addr(pos),
                 self.flags,
+                self.reported_flags,
                 right,
             );
             self.va_range.end = pos;
@@ -245,6 +276,7 @@ where
         f.debug_struct("MemoryArea")
             .field("va_range", &self.va_range)
             .field("flags", &self.flags)
+            .field("reported_flags", &self.reported_flags)
             .finish()
     }
 }

--- a/memory/memory_set/src/set.rs
+++ b/memory/memory_set/src/set.rs
@@ -332,12 +332,30 @@ impl<B: MappingBackend> MemorySet<B> {
         update_flags: impl Fn(B::Flags) -> Option<B::Flags>,
         page_table: &mut B::PageTable,
     ) -> MappingResult {
+        self.protect_with_reported_flags(
+            start,
+            size,
+            |flags, _reported_flags| update_flags(flags).map(|new_flags| (new_flags, new_flags)),
+            page_table,
+        )
+    }
+
+    /// Change backend/page-table flags and reported flags within the given range.
+    pub fn protect_with_reported_flags(
+        &mut self,
+        start: B::Addr,
+        size: usize,
+        update_flags: impl Fn(B::Flags, B::Flags) -> Option<(B::Flags, B::Flags)>,
+        page_table: &mut B::PageTable,
+    ) -> MappingResult {
         let end = start.checked_add(size).ok_or(MappingError::InvalidParam)?;
         let mut to_insert = Vec::new();
         for (&area_start, area) in self.areas.iter_mut() {
             let area_end = area.end();
 
-            if let Some(new_flags) = update_flags(area.flags()) {
+            if let Some((new_flags, new_reported_flags)) =
+                update_flags(area.flags(), area.reported_flags())
+            {
                 if area_start >= end {
                     // [ prot ]
                     //          [ area ]
@@ -350,7 +368,7 @@ impl<B: MappingBackend> MemorySet<B> {
                     // [   prot   ]
                     //   [ area ]
                     area.protect_area(new_flags, page_table)?;
-                    area.set_flags(new_flags);
+                    area.set_flags_with_reported_flags(new_flags, new_reported_flags);
                 } else if area_start < start && area_end > end {
                     //        [ prot ]
                     // [ left | area | right ]
@@ -358,7 +376,7 @@ impl<B: MappingBackend> MemorySet<B> {
                     let right_part = middle_part.split(end).unwrap();
 
                     middle_part.protect_area(new_flags, page_table)?;
-                    middle_part.set_flags(new_flags);
+                    middle_part.set_flags_with_reported_flags(new_flags, new_reported_flags);
 
                     to_insert.push((right_part.start(), right_part));
                     to_insert.push((middle_part.start(), middle_part));
@@ -367,7 +385,7 @@ impl<B: MappingBackend> MemorySet<B> {
                     //   [  area | right ]
                     let right_part = area.split(end).unwrap();
                     area.protect_area(new_flags, page_table)?;
-                    area.set_flags(new_flags);
+                    area.set_flags_with_reported_flags(new_flags, new_reported_flags);
 
                     to_insert.push((right_part.start(), right_part));
                 } else {
@@ -375,7 +393,7 @@ impl<B: MappingBackend> MemorySet<B> {
                     // [ left |  area ]
                     let mut right_part = area.split(start).unwrap();
                     right_part.protect_area(new_flags, page_table)?;
-                    right_part.set_flags(new_flags);
+                    right_part.set_flags_with_reported_flags(new_flags, new_reported_flags);
 
                     to_insert.push((right_part.start(), right_part));
                 }

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -4,13 +4,13 @@ use core::{
     ffi::c_char,
     hint::{spin_loop, unlikely},
     mem::{MaybeUninit, transmute},
-    ptr, slice, str,
+    ptr, slice,
     sync::atomic::{AtomicU32, Ordering},
 };
 
 use ax_errno::{AxError, AxResult};
 use ax_io::prelude::*;
-use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
+use ax_memory_addr::{MemoryAddr, VirtAddr};
 use ax_runtime::hal::{
     cpu::{asm::user_copy, trap::page_fault_handler},
     paging::MappingFlags,
@@ -76,70 +76,6 @@ fn check_region(start: VirtAddr, layout: Layout, access_flags: MappingFlags) -> 
     aspace.populate_area(page_start, page_end - page_start, access_flags)?;
 
     Ok(())
-}
-
-fn check_null_terminated<T: PartialEq + Default>(
-    start: VirtAddr,
-    access_flags: MappingFlags,
-) -> AxResult<usize> {
-    let align = Layout::new::<T>().align();
-    if start.as_usize() & (align - 1) != 0 {
-        return Err(AxError::BadAddress);
-    }
-
-    let zero = T::default();
-
-    let mut page = start.align_down_4k();
-
-    let start = start.as_ptr_of::<T>();
-    let mut len = 0;
-
-    access_user_memory(|| {
-        loop {
-            // SAFETY: This won't overflow the address space since we'll check
-            // it below.
-            let ptr = unsafe { start.add(len) };
-            while ptr as usize >= page.as_ptr() as usize {
-                // Prepare only the page containing the next byte so the
-                // volatile read below does not fault while the aspace lock is
-                // not held.
-
-                // TODO: this is inefficient, but we have to do this instead of
-                // querying the page table since the page might has not been
-                // allocated yet.
-                let curr = current();
-                let Some(thr) = curr.try_as_thread() else {
-                    warn!(
-                        "reject nul-terminated user check outside thread context: task={}, \
-                         start={:#x}",
-                        curr.id_name(),
-                        start as usize
-                    );
-                    return Err(AxError::BadAddress);
-                };
-                let aspace_arc = thr.proc_data.aspace();
-                if unsafe { aspace_arc.raw() }.is_owned_by_current() {
-                    return Err(AxError::BadAddress);
-                }
-                let mut aspace = aspace_arc.lock();
-                if !aspace.can_access_range(page, PAGE_SIZE_4K, access_flags) {
-                    return Err(AxError::BadAddress);
-                }
-                aspace.populate_area(page, PAGE_SIZE_4K, access_flags)?;
-
-                page += PAGE_SIZE_4K;
-            }
-
-            // SAFETY: The pointer is valid and points to a valid memory region.
-            if unsafe { ptr.read_volatile() } == zero {
-                break;
-            }
-            len += 1;
-        }
-        Ok(())
-    })?;
-
-    Ok(len)
 }
 
 /// A pointer to user space memory.
@@ -285,25 +221,6 @@ impl<T> UserConstPtr<T> {
             Self::ACCESS_FLAGS,
         )?;
         Ok(unsafe { slice::from_raw_parts(self.0, len) })
-    }
-
-    pub fn get_as_null_terminated(self) -> AxResult<&'static [T]>
-    where
-        T: PartialEq + Default,
-    {
-        let len = check_null_terminated::<T>(self.address(), Self::ACCESS_FLAGS)?;
-        Ok(unsafe { slice::from_raw_parts(self.0, len) })
-    }
-}
-
-impl UserConstPtr<c_char> {
-    /// Get the pointer as `&str`, validating the memory region.
-    pub fn get_as_str(self) -> AxResult<&'static str> {
-        let slice = self.get_as_null_terminated()?;
-        // SAFETY: c_char is u8
-        let slice = unsafe { transmute::<&[c_char], &[u8]>(slice) };
-
-        str::from_utf8(slice).map_err(|_| AxError::IllegalBytes)
     }
 }
 

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -185,11 +185,24 @@ impl AddrSpace {
         populate: bool,
         backend: Backend,
     ) -> AxResult {
+        self.map_with_reported_flags(start, size, flags, flags, populate, backend)
+    }
+
+    pub fn map_with_reported_flags(
+        &mut self,
+        start: VirtAddr,
+        size: usize,
+        flags: MappingFlags,
+        reported_flags: MappingFlags,
+        populate: bool,
+        backend: Backend,
+    ) -> AxResult {
         self.validate_region(start, size)?;
 
         {
             let _rss = RssAccountingGuard::enter(&self.rss);
-            let area = MemoryArea::new(start, size, flags, backend);
+            let area =
+                MemoryArea::new_with_reported_flags(start, size, flags, reported_flags, backend);
             self.areas.map(area, &mut self.pt, false)?;
         }
         self.vm_stat.on_map((size / PAGE_SIZE_4K) as u64);
@@ -342,10 +355,21 @@ impl AddrSpace {
         flags: MappingFlags,
         backend: Backend,
     ) -> AxResult {
+        self.replace_area_metadata_with_reported_flags(start, size, flags, flags, backend)
+    }
+
+    pub fn replace_area_metadata_with_reported_flags(
+        &mut self,
+        start: VirtAddr,
+        size: usize,
+        flags: MappingFlags,
+        reported_flags: MappingFlags,
+        backend: Backend,
+    ) -> AxResult {
         self.validate_region(start, size)?;
 
         crate::syscall::memfd_on_aspace_replace_metadata(self, start, size, flags, &backend);
-        let area = MemoryArea::new(start, size, flags, backend);
+        let area = MemoryArea::new_with_reported_flags(start, size, flags, reported_flags, backend);
         self.areas.replace_area_metadata(area)?;
         Ok(())
     }
@@ -485,13 +509,27 @@ impl AddrSpace {
     /// Returns an error if the address range is out of the address space or not
     /// aligned.
     pub fn protect(&mut self, start: VirtAddr, size: usize, flags: MappingFlags) -> AxResult {
+        self.protect_with_reported_flags(start, size, flags, flags)
+    }
+
+    pub fn protect_with_reported_flags(
+        &mut self,
+        start: VirtAddr,
+        size: usize,
+        flags: MappingFlags,
+        reported_flags: MappingFlags,
+    ) -> AxResult {
         self.validate_region(start, size)?;
 
         let touched_memfds =
             crate::syscall::memfd_collect_metas_touching_mprotect_range(self, start, size);
         let _rss = RssAccountingGuard::enter(&self.rss);
-        self.areas
-            .protect(start, size, |_| Some(flags), &mut self.pt)?;
+        self.areas.protect_with_reported_flags(
+            start,
+            size,
+            |_, _| Some((flags, reported_flags)),
+            &mut self.pt,
+        )?;
         crate::syscall::memfd_resync_shared_writable_counts_after_mprotect(self, &touched_memfds);
 
         Ok(())
@@ -618,7 +656,13 @@ impl AddrSpace {
                 },
             )?;
 
-            let new_area = MemoryArea::new(area.start(), area.size(), area.flags(), new_backend);
+            let new_area = MemoryArea::new_with_reported_flags(
+                area.start(),
+                area.size(),
+                area.flags(),
+                area.reported_flags(),
+                new_backend,
+            );
             let start = new_area.start();
             {
                 let aspace = guard.deref_mut();

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -783,7 +783,7 @@ fn render_thread_maps(task: &WeakAxTaskRef) -> VfsResult<String> {
         } = bi;
 
         let flag_end = if is_shared { 's' } else { 'p' };
-        let flags = area.flags();
+        let flags = area.reported_flags();
         let perms = {
             let r = if flags.contains(MappingFlags::READ) {
                 'r'

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -193,7 +193,7 @@ pub fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> AxResult<isize
 pub fn sys_mknodat(dirfd: i32, path: *const c_char, mode: u32, dev: u64) -> Result<isize, AxError> {
     let curr = current();
     let thread = curr.as_thread();
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
     debug!(
         "sys_mknodat <= dirfd: {}, path: {:?}, mode: {}, dev: {}",
         dirfd, path, mode, dev

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -112,7 +112,7 @@ pub fn sys_mknod(path: *const c_char, mode: u32, dev: u64) -> AxResult<isize> {
 }
 
 pub fn sys_chroot(path: *const c_char) -> AxResult<isize> {
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
     debug!("sys_chroot <= path: {path}");
 
     let mut fs = FS_CONTEXT.lock();

--- a/os/StarryOS/kernel/src/syscall/fs/event.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/event.rs
@@ -17,6 +17,11 @@ bitflags! {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
+pub fn sys_eventfd(initval: u32) -> AxResult<isize> {
+    sys_eventfd2(initval, 0)
+}
+
 // Create an eventfd and install it into the current file descriptor table.
 pub fn sys_eventfd2(initval: u32, flags: u32) -> AxResult<isize> {
     debug!(

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -438,6 +438,16 @@ pub fn sys_open(path: *const c_char, flags: i32, mode: __kernel_mode_t) -> AxRes
     sys_openat(AT_FDCWD as _, path, flags, mode)
 }
 
+#[cfg(target_arch = "x86_64")]
+pub fn sys_creat(path: *const c_char, mode: __kernel_mode_t) -> AxResult<isize> {
+    sys_openat(
+        AT_FDCWD as _,
+        path,
+        (O_CREAT | O_WRONLY | O_TRUNC) as _,
+        mode,
+    )
+}
+
 pub fn sys_close(fd: c_int) -> AxResult<isize> {
     debug!("sys_close <= {fd}");
     close_file_like(fd)?;

--- a/os/StarryOS/kernel/src/syscall/fs/inotify.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/inotify.rs
@@ -6,7 +6,7 @@ use linux_raw_sys::general::{AT_FDCWD, IN_CLOEXEC, IN_NONBLOCK};
 
 use crate::{
     file::{FileLike, add_file_like, get_file_like, inotify::Inotify, resolve_at},
-    mm::vm_load_string,
+    mm::vm_load_path_string,
 };
 
 pub fn sys_inotify_init1(flags: u32) -> AxResult<isize> {
@@ -23,7 +23,7 @@ pub fn sys_inotify_init1(flags: u32) -> AxResult<isize> {
 }
 
 pub fn sys_inotify_add_watch(fd: c_int, path: *const c_char, mask: u32) -> AxResult<isize> {
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
     debug!("sys_inotify_add_watch <= fd: {fd}, path: {path}, mask: {mask}");
 
     let resolved_path = resolve_at(AT_FDCWD, Some(&path), 0)?

--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -25,7 +25,7 @@ use crate::{
         Directory, File, FileLike, Pipe, get_file_like,
         memfd::{F_SEAL_GROW, F_SEAL_WRITE, Memfd},
     },
-    mm::{IoVec, IoVectorBuf, UserConstPtr, VmBytesMut},
+    mm::{IoVec, IoVectorBuf, UserConstPtr, VmBytesMut, vm_load_path_string},
     task::AsThread,
 };
 
@@ -197,8 +197,8 @@ pub fn sys_lseek(fd: c_int, offset: __kernel_off_t, whence: c_int) -> AxResult<i
     Err(AxError::from(LinuxError::ESPIPE))
 }
 
-pub fn sys_truncate(path: UserConstPtr<c_char>, length: __kernel_off_t) -> AxResult<isize> {
-    let path = path.get_as_str()?;
+pub fn sys_truncate(path: *const c_char, length: __kernel_off_t) -> AxResult<isize> {
+    let path = vm_load_path_string(path)?;
     debug!("sys_truncate <= {path:?} {length}");
     if path.is_empty() {
         return Err(AxError::from(LinuxError::ENOENT));
@@ -208,7 +208,7 @@ pub fn sys_truncate(path: UserConstPtr<c_char>, length: __kernel_off_t) -> AxRes
     }
     let file = OpenOptions::new()
         .write(true)
-        .open(&FS_CONTEXT.lock(), path)?
+        .open(&FS_CONTEXT.lock(), &path)?
         .into_file()?;
     if (length as u64) > u32::MAX as u64 * 4096 {
         return Err(AxError::from(LinuxError::EFBIG));

--- a/os/StarryOS/kernel/src/syscall/fs/pipe.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/pipe.rs
@@ -35,7 +35,11 @@ pub fn sys_pipe2(fds: *mut [c_int; 2], flags: u32) -> AxResult<isize> {
         .add_to_fd_table(cloexec)
         .inspect_err(|_| close_file_like(read_fd).unwrap())?;
 
-    fds.vm_write([read_fd, write_fd])?;
+    if let Err(err) = fds.vm_write([read_fd, write_fd]) {
+        close_file_like(read_fd).ok();
+        close_file_like(write_fd).ok();
+        return Err(err.into());
+    }
 
     debug!(
         "sys_pipe2 <= fds: {:?}, flags: {:?}",

--- a/os/StarryOS/kernel/src/syscall/fs/stat.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/stat.rs
@@ -15,7 +15,7 @@ use starry_vm::{VmMutPtr, VmPtr};
 
 use crate::{
     file::{File, FileLike, resolve_at},
-    mm::{UserPtr, vm_load_path_string, vm_load_string},
+    mm::{UserPtr, vm_load_path_string},
     task::AsThread,
 };
 
@@ -229,7 +229,7 @@ fn statfs(loc: &Location) -> AxResult<statfs> {
 }
 
 pub fn sys_statfs(path: *const c_char, buf: *mut statfs) -> AxResult<isize> {
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
     debug!("sys_statfs <= path: {path:?}");
 
     buf.vm_write(statfs(
@@ -261,7 +261,7 @@ pub fn sys_name_to_handle_at(
         return Err(AxError::InvalidInput);
     }
 
-    let path = path.nullable().map(vm_load_string).transpose()?;
+    let path = path.nullable().map(vm_load_path_string).transpose()?;
     debug!("sys_name_to_handle_at <= dirfd: {dirfd}, path: {path:?}, flags: {flags}");
 
     let resolve_flags = if flags & AT_SYMLINK_FOLLOW != 0 {

--- a/os/StarryOS/kernel/src/syscall/fs/xattr.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/xattr.rs
@@ -25,7 +25,7 @@ use starry_vm::{vm_read_slice, vm_write_slice};
 
 use crate::{
     file::{fd_is_path, resolve_at},
-    mm::vm_load_string,
+    mm::{vm_load_path_string, vm_load_string},
     pseudofs::overlay,
 };
 
@@ -88,7 +88,7 @@ fn read_value(value: *const u8, size: usize) -> AxResult<Vec<u8>> {
 
 /// Resolve a path argument used by path-based xattr syscalls.
 fn resolve_path(path: *const c_char, nofollow: bool) -> AxResult<Location> {
-    let path = vm_load_string(path)?;
+    let path = vm_load_path_string(path)?;
     let flags = if nofollow { AT_SYMLINK_NOFOLLOW } else { 0 };
     resolve_at(AT_FDCWD, Some(&path), flags)?
         .into_file()

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -65,6 +65,23 @@ impl From<MmapProt> for MappingFlags {
     }
 }
 
+fn reported_mapping_flags_from_prot(value: MmapProt) -> MappingFlags {
+    let mut flags = MappingFlags::empty();
+    if value.contains(MmapProt::READ) {
+        flags |= MappingFlags::READ;
+    }
+    if value.contains(MmapProt::WRITE) {
+        flags |= MappingFlags::WRITE;
+    }
+    if value.contains(MmapProt::EXEC) {
+        flags |= MappingFlags::EXECUTE;
+    }
+    if !flags.is_empty() {
+        flags |= MappingFlags::USER;
+    }
+    flags
+}
+
 fn capped_device_map_len(request_len: usize, available_len: usize, page_size: PageSize) -> usize {
     request_len.min(available_len.align_up(page_size))
 }
@@ -275,6 +292,7 @@ pub fn sys_mmap(
             let range = ion_file.phys_range();
             let buffer_len = range.size().align_up(page_size);
             let map_length = length.align_up(page_size);
+            let reported_mapping_flags = reported_mapping_flags_from_prot(permission_flags);
             info!(
                 "Ion buffer mmap: phys_addr=0x{:x}, buffer_size={}, requested_length={}, \
                  map_length={}",
@@ -305,7 +323,14 @@ pub fn sys_mmap(
                 ion_file.buffer().clone(),
             );
             let populate = map_flags.contains(MmapFlags::POPULATE);
-            aspace.map(start, map_length, ion_mapping_flags, populate, backend)?;
+            aspace.map_with_reported_flags(
+                start,
+                map_length,
+                ion_mapping_flags,
+                reported_mapping_flags,
+                populate,
+                backend,
+            )?;
             drop(aspace);
             info!(
                 "Ion buffer mmap success: vaddr=0x{:x}, length={}",
@@ -317,6 +342,7 @@ pub fn sys_mmap(
     }
 
     let mut mapping_flags: MappingFlags = permission_flags.into();
+    let reported_mapping_flags = reported_mapping_flags_from_prot(permission_flags);
 
     let backend = match map_type {
         MmapFlags::SHARED => {
@@ -521,7 +547,14 @@ pub fn sys_mmap(
     };
 
     let populate = map_flags.contains(MmapFlags::POPULATE);
-    aspace.map(start, length, mapping_flags, populate, backend)?;
+    aspace.map_with_reported_flags(
+        start,
+        length,
+        mapping_flags,
+        reported_mapping_flags,
+        populate,
+        backend,
+    )?;
     drop(aspace);
 
     // perf side-band: an executable, file-backed mapping is (almost always) a
@@ -615,7 +648,12 @@ pub fn sys_mprotect(addr: usize, length: usize, prot: u32) -> AxResult<isize> {
             memfd_check_write_seal_for_shared_file_backend(&backend)?;
         }
     }
-    aspace.protect(start_addr, length, permission_flags.into())?;
+    aspace.protect_with_reported_flags(
+        start_addr,
+        length,
+        permission_flags.into(),
+        reported_mapping_flags_from_prot(permission_flags),
+    )?;
 
     Ok(0)
 }
@@ -642,6 +680,7 @@ struct MremapMove<'a> {
     target_size: usize,
     src_backend: &'a Backend,
     flags: MappingFlags,
+    reported_flags: MappingFlags,
     dontunmap: bool,
     src_offset: usize,
 }
@@ -658,17 +697,24 @@ fn mremap_move(
         target_size,
         src_backend,
         flags,
+        reported_flags,
         dontunmap,
         src_offset,
     } = move_args;
     let move_size = src_size.min(target_size);
     let backend = src_backend.relocated(target, src_offset, aspace_ref)?;
 
-    aspace.map(target, target_size, flags, false, backend)?;
+    aspace.map_with_reported_flags(target, target_size, flags, reported_flags, false, backend)?;
 
     if dontunmap {
         let empty = Backend::new_alloc(src, src_backend.page_size(), "");
-        if let Err(e) = aspace.replace_area_metadata(src, move_size, flags, empty) {
+        if let Err(e) = aspace.replace_area_metadata_with_reported_flags(
+            src,
+            move_size,
+            flags,
+            reported_flags,
+            empty,
+        ) {
             let _ = aspace.unmap(target, target_size);
             return Err(e);
         }
@@ -677,7 +723,13 @@ fn mremap_move(
     if let Err(e) = aspace.move_pages(src, target, move_size) {
         if dontunmap {
             aspace
-                .replace_area_metadata(src, move_size, flags, src_backend.clone())
+                .replace_area_metadata_with_reported_flags(
+                    src,
+                    move_size,
+                    flags,
+                    reported_flags,
+                    src_backend.clone(),
+                )
                 .expect("restore source VMA metadata after failed mremap move");
         }
         let _ = aspace.unmap(target, target_size);
@@ -753,7 +805,7 @@ pub fn sys_mremap(
     let aspace_ref = &curr.as_thread().proc_data.aspace();
     let mut aspace = aspace_ref.lock();
 
-    let (vma_start, vma_end, vma_flags, src_backend, shared_pages, page_size) = {
+    let (vma_start, vma_end, vma_flags, vma_reported_flags, src_backend, shared_pages, page_size) = {
         let area = aspace.find_area(addr).ok_or(AxError::BadAddress)?;
         let shared_pages = match area.backend() {
             Backend::Shared(sb) => Some(sb.pages().clone()),
@@ -763,6 +815,7 @@ pub fn sys_mremap(
             area.start(),
             area.end(),
             area.flags(),
+            area.reported_flags(),
             area.backend().clone(),
             shared_pages,
             area.backend().page_size(),
@@ -805,7 +858,14 @@ pub fn sys_mremap(
             .map(VirtAddr::from)
             .ok_or(AxError::InvalidInput)?;
         let backend = Backend::new_shared(backend_start, pages);
-        aspace.map(target, new_size, vma_flags, false, backend)?;
+        aspace.map_with_reported_flags(
+            target,
+            new_size,
+            vma_flags,
+            vma_reported_flags,
+            false,
+            backend,
+        )?;
         return Ok(target.as_usize() as isize);
     }
 
@@ -835,6 +895,7 @@ pub fn sys_mremap(
                 target_size: new_size,
                 src_backend: &src_backend,
                 flags: vma_flags,
+                reported_flags: vma_reported_flags,
                 dontunmap,
                 src_offset,
             },
@@ -863,6 +924,7 @@ pub fn sys_mremap(
                 target_size: new_size,
                 src_backend: &src_backend,
                 flags: vma_flags,
+                reported_flags: vma_reported_flags,
                 dontunmap: true,
                 src_offset,
             },
@@ -895,6 +957,7 @@ pub fn sys_mremap(
             target_size: new_size,
             src_backend: &src_backend,
             flags: vma_flags,
+            reported_flags: vma_reported_flags,
             dontunmap: false,
             src_offset,
         },

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -253,7 +253,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::write => sys_write(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         Sysno::writev => sys_writev(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
         Sysno::lseek => sys_lseek(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
-        Sysno::truncate => sys_truncate(uctx.arg0().into(), uctx.arg1() as _),
+        Sysno::truncate => sys_truncate(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::ftruncate => sys_ftruncate(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::fallocate => sys_fallocate(
             uctx.arg0() as _,

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -226,6 +226,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         // fd ops
         #[cfg(target_arch = "x86_64")]
         Sysno::open => sys_open(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::creat => sys_creat(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::openat => sys_openat(
             uctx.arg0() as _,
             uctx.arg1() as _,
@@ -471,6 +473,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
 
         // event
         Sysno::eventfd2 => sys_eventfd2(uctx.arg0() as _, uctx.arg1() as _),
+        #[cfg(target_arch = "x86_64")]
+        Sysno::eventfd => sys_eventfd(uctx.arg0() as _),
         #[cfg(target_arch = "x86_64")]
         Sysno::inotify_init => sys_inotify_init1(0),
         Sysno::inotify_init1 => sys_inotify_init1(uctx.arg0() as _),

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
@@ -212,6 +212,108 @@ static void test_mmap_min(void)
     expect_mmap_einval("mmap length zero -> EINVAL", 0, PROT_READ);
 }
 
+struct mmap_maps_case {
+    int prot;
+    int flags;
+    const char *expected;
+};
+
+static int read_maps_perms(void *addr, char perms[5])
+{
+    FILE *maps = fopen("/proc/self/maps", "r");
+    unsigned long target = (unsigned long)addr;
+    char line[256];
+
+    if (!maps) {
+        return -1;
+    }
+
+    while (fgets(line, sizeof(line), maps)) {
+        unsigned long start = 0;
+        unsigned long end = 0;
+        char found[5] = {0};
+
+        if (sscanf(line, "%lx-%lx %4s", &start, &end, found) == 3 &&
+            start == target && target < end) {
+            memcpy(perms, found, sizeof(found));
+            fclose(maps);
+            return 0;
+        }
+    }
+
+    fclose(maps);
+    errno = ENOENT;
+    return -1;
+}
+
+static void expect_mmap_maps_perms(const struct mmap_maps_case *tc)
+{
+    long pagesize = sysconf(_SC_PAGESIZE);
+    int guard_flags = (tc->flags & MAP_PRIVATE) ? MAP_SHARED : MAP_PRIVATE;
+    void *addr1;
+    void *addr2;
+    char perms[5] = {0};
+    char name[96];
+
+    if (pagesize <= 0) {
+        CHECK(0, "mmap maps perms setup pagesize");
+        return;
+    }
+
+    addr1 = mmap(NULL, (size_t)pagesize * 2, PROT_NONE,
+                 MAP_ANONYMOUS | guard_flags, -1, 0);
+    if (addr1 == MAP_FAILED) {
+        CHECK(0, "mmap maps perms setup guard mapping");
+        return;
+    }
+
+    addr2 = mmap((char *)addr1 + pagesize, (size_t)pagesize, tc->prot,
+                 tc->flags | MAP_FIXED, -1, 0);
+    if (addr2 == MAP_FAILED) {
+        munmap(addr1, (size_t)pagesize * 2);
+        CHECK(0, "mmap maps perms setup fixed mapping");
+        return;
+    }
+
+    snprintf(name, sizeof(name), "mmap /proc/self/maps perms %s", tc->expected);
+    if (read_maps_perms(addr2, perms) != 0) {
+        CHECK(0, name);
+    } else {
+        CHECK(strcmp(perms, tc->expected) == 0, name);
+        if (strcmp(perms, tc->expected) != 0) {
+            printf("    expected=%s found=%s\n", tc->expected, perms);
+        }
+    }
+
+    munmap(addr1, (size_t)pagesize * 2);
+}
+
+static void test_mmap_maps_min(void)
+{
+    static const struct mmap_maps_case tcases[] = {
+        {PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, "---p"},
+        {PROT_NONE, MAP_ANONYMOUS | MAP_SHARED, "---s"},
+        {PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, "r--p"},
+        {PROT_READ, MAP_ANONYMOUS | MAP_SHARED, "r--s"},
+        {PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, "-w-p"},
+        {PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, "-w-s"},
+        {PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, "rw-p"},
+        {PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, "rw-s"},
+        {PROT_READ | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, "r-xp"},
+        {PROT_READ | PROT_EXEC, MAP_ANONYMOUS | MAP_SHARED, "r-xs"},
+        {PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, "-wxp"},
+        {PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_SHARED, "-wxs"},
+        {PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, "rwxp"},
+        {PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_SHARED, "rwxs"},
+    };
+    size_t i;
+
+    printf("[TEST] mmap /proc/self/maps permissions\n");
+    for (i = 0; i < sizeof(tcases) / sizeof(tcases[0]); i++) {
+        expect_mmap_maps_perms(&tcases[i]);
+    }
+}
+
 static char *make_long_path(void)
 {
     char *path = malloc(PATH_MAX + 1);
@@ -281,6 +383,7 @@ int main(void)
 
     test_openat2_min();
     test_mmap_min();
+    test_mmap_maps_min();
     test_pathmax_min();
 
     printf("------------------------------------------------\n");

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
@@ -468,6 +468,10 @@ static void test_pathmax_min(void)
     expect_ret_errno("getxattr long path -> ENAMETOOLONG",
                      getxattr(path, "user.test", NULL, 0), ENAMETOOLONG);
 
+    errno = 0;
+    expect_ret_errno("truncate long path -> ENAMETOOLONG", truncate(path, 0),
+                     ENAMETOOLONG);
+
     free(path);
 }
 

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/inotify.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
@@ -334,6 +335,48 @@ static char *make_long_path(void)
     return path;
 }
 
+static void test_pipe_efault_min(void)
+{
+    int marker;
+    int fds[2] = {-1, -1};
+    long ret;
+
+    printf("[TEST] pipe bad user pointer rollback\n");
+
+    marker = open("/dev/null", O_RDONLY);
+    if (marker < 0) {
+        marker = open(".", O_RDONLY | O_DIRECTORY);
+    }
+    CHECK(marker >= 0, "pipe rollback setup marker fd");
+    if (marker < 0) {
+        return;
+    }
+
+#ifdef SYS_pipe2
+    errno = 0;
+    ret = syscall(SYS_pipe2, (int *)-1, 0);
+    CHECK(ret == -1 && errno == EFAULT, "pipe2 bad user fd array -> EFAULT");
+#else
+    errno = ENOSYS;
+    ret = -1;
+    CHECK(0, "pipe2 syscall number available");
+#endif
+
+    if (ret == -1 && errno == EFAULT) {
+        CHECK(pipe(fds) == 0, "pipe succeeds after pipe2 EFAULT");
+        if (fds[0] >= 0 && fds[1] >= 0) {
+            CHECK(fds[0] == marker + 1 && fds[1] == marker + 2,
+                  "pipe2 EFAULT does not leak allocated fds");
+        }
+    }
+
+    if (fds[0] >= 0)
+        close(fds[0]);
+    if (fds[1] >= 0)
+        close(fds[1]);
+    close(marker);
+}
+
 static void expect_path_errno(const char *name, int ret, int expected)
 {
     if (ret >= 0) {
@@ -346,6 +389,7 @@ static void test_pathmax_min(void)
 {
     char *path = make_long_path();
     struct stat st;
+    int ifd;
 #ifdef SYS_statx
     long statx_buf[64];
 #endif
@@ -371,6 +415,17 @@ static void test_pathmax_min(void)
     errno = 0;
     expect_path_errno("openat long path -> ENAMETOOLONG", openat(AT_FDCWD, path, O_RDONLY),
                       ENAMETOOLONG);
+    errno = 0;
+    expect_path_errno("chroot long path -> ENAMETOOLONG", chroot(path), ENAMETOOLONG);
+
+    ifd = inotify_init1(IN_CLOEXEC);
+    CHECK(ifd >= 0, "inotify setup fd");
+    if (ifd >= 0) {
+        errno = 0;
+        CHECK(inotify_add_watch(ifd, path, IN_MODIFY) == -1 && errno == ENAMETOOLONG,
+              "inotify_add_watch long path -> ENAMETOOLONG");
+        close(ifd);
+    }
 
     free(path);
 }
@@ -385,6 +440,7 @@ int main(void)
     test_mmap_min();
     test_mmap_maps_min();
     test_pathmax_min();
+    test_pipe_efault_min();
 
     printf("------------------------------------------------\n");
     printf("  DONE: %d pass, %d fail\n", pass_count, fail_count);

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
@@ -475,6 +475,59 @@ static void test_pathmax_min(void)
     free(path);
 }
 
+static void test_raw_alias_min(void)
+{
+    printf("[TEST] raw syscall alias minimal conformance\n");
+
+#ifdef SYS_creat
+    {
+        const char *path = "ltp-pilot-raw-creat";
+        struct stat st;
+        long fd;
+
+        unlink(path);
+        errno = 0;
+        fd = syscall(SYS_creat, path, 0600);
+        CHECK(fd >= 0, "raw SYS_creat creates a file");
+        if (fd >= 0) {
+            CHECK(close((int)fd) == 0, "raw SYS_creat close fd");
+            CHECK(stat(path, &st) == 0 && S_ISREG(st.st_mode),
+                  "raw SYS_creat result is a regular file");
+            unlink(path);
+        }
+    }
+#else
+    CHECK(1, "raw SYS_creat not available on this arch");
+#endif
+
+#ifdef SYS_eventfd
+    {
+        uint64_t value = 0;
+        long fd;
+
+        errno = 0;
+        fd = syscall(SYS_eventfd, 7);
+        CHECK(fd >= 0, "raw SYS_eventfd creates an eventfd");
+        if (fd >= 0) {
+            CHECK(read((int)fd, &value, sizeof(value)) == (ssize_t)sizeof(value) &&
+                      value == 7,
+                  "raw SYS_eventfd preserves initval");
+            close((int)fd);
+        }
+    }
+#else
+    CHECK(1, "raw SYS_eventfd not available on this arch");
+#endif
+
+#ifdef SYS_eventfd2
+    errno = 0;
+    expect_ret_errno("raw SYS_eventfd2 unknown flag -> EINVAL",
+                     syscall(SYS_eventfd2, 0, 0x80000000U), EINVAL);
+#else
+    CHECK(1, "raw SYS_eventfd2 not available on this arch");
+#endif
+}
+
 int main(void)
 {
     printf("================================================\n");
@@ -486,6 +539,7 @@ int main(void)
     test_mmap_maps_min();
     test_pathmax_min();
     test_pipe_efault_min();
+    test_raw_alias_min();
 
     printf("------------------------------------------------\n");
     printf("  DONE: %d pass, %d fail\n", pass_count, fail_count);

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-ltp-pilot-min/src/main.c
@@ -17,7 +17,9 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/statfs.h>
 #include <sys/inotify.h>
+#include <sys/xattr.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
@@ -385,10 +387,22 @@ static void expect_path_errno(const char *name, int ret, int expected)
     CHECK(ret == -1 && errno == expected, name);
 }
 
+static void expect_ret_errno(const char *name, long ret, int expected)
+{
+    CHECK(ret == -1 && errno == expected, name);
+}
+
+struct test_file_handle {
+    unsigned int handle_bytes;
+    int handle_type;
+    unsigned char f_handle[8];
+};
+
 static void test_pathmax_min(void)
 {
     char *path = make_long_path();
     struct stat st;
+    struct statfs sfs;
     int ifd;
 #ifdef SYS_statx
     long statx_buf[64];
@@ -426,6 +440,33 @@ static void test_pathmax_min(void)
               "inotify_add_watch long path -> ENAMETOOLONG");
         close(ifd);
     }
+
+    errno = 0;
+    expect_ret_errno("mknod long path -> ENAMETOOLONG",
+                     mknod(path, S_IFIFO | 0600, 0), ENAMETOOLONG);
+
+    errno = 0;
+    expect_ret_errno("statfs long path -> ENAMETOOLONG", statfs(path, &sfs),
+                     ENAMETOOLONG);
+
+#ifdef SYS_name_to_handle_at
+    {
+        struct test_file_handle handle = {
+            .handle_bytes = sizeof(handle.f_handle),
+        };
+        int mount_id = -1;
+
+        errno = 0;
+        expect_ret_errno("name_to_handle_at long path -> ENAMETOOLONG",
+                         syscall(SYS_name_to_handle_at, AT_FDCWD, path, &handle,
+                                 &mount_id, 0),
+                         ENAMETOOLONG);
+    }
+#endif
+
+    errno = 0;
+    expect_ret_errno("getxattr long path -> ENAMETOOLONG",
+                     getxattr(path, "user.test", NULL, 0), ENAMETOOLONG);
 
     free(path);
 }


### PR DESCRIPTION
  ## Summary

  This PR applies a set of LTP-derived syscall compatibility fixes for StarryOS.

  It focuses on statically identified syscall guard and alias gaps:

  - enforce `PATH_MAX` handling for additional pathname syscalls
  - roll back partially installed pipe file descriptors on `EFAULT`
  - enforce `PATH_MAX` for `truncate`
  - add x86_64 raw syscall aliases for `creat` and legacy `eventfd`
  - extend `syscall-test-ltp-pilot-min` with regression probes for the fixed cases

  ## Changes

  - Add `PATH_MAX` checked pathname loading for:
    - `chroot`
    - `inotify_add_watch`
    - `mknodat`
    - `statfs`
    - `name_to_handle_at`
    - path-based xattr syscalls
    - `truncate`

  - Fix `pipe` / `pipe2` side effects:
    - if copying the fd array back to userspace fails, already allocated fds are closed before returning the error

  - Add x86_64 raw syscall compatibility aliases:
    - `SYS_creat` -> `openat(AT_FDCWD, path, O_CREAT | O_WRONLY | O_TRUNC, mode)`
    - `SYS_eventfd` -> `eventfd2(initval, 0)`

  - Extend the minimal LTP pilot system test with regression coverage for these cases.
