### PR TITLE
refactor(somehal): cache IRQ routes in CPU interfaces

### DIFF
--- a/platforms/somehal/src/arch/loongarch64/mod.rs
+++ b/platforms/somehal/src/arch/loongarch64/mod.rs
@@ -10,10 +10,7 @@ mod eiointc;
 mod irq_common;
 mod pch_pic;
 
-use crate::irq_routing::{
-    ExternalVectorResolveFailure, RawIrq, classify_cpu_irq, cpu_local_hwirq_is_runtime_irq,
-    external_vector_failure_policy,
-};
+use crate::irq_routing::{RawIrq, classify_cpu_irq, cpu_local_hwirq_is_runtime_irq};
 
 pub struct Plat;
 
@@ -197,19 +194,8 @@ impl PlatOp for Plat {
                     debug!("Spurious LoongArch EIOINTC interrupt");
                     return None;
                 };
-                let irq = match pch_pic::irq_for_external_vector(external) {
-                    Ok(Some(irq)) => irq,
-                    Ok(None) => eiointc_irq(external),
-                    Err(err) => {
-                        warn!("failed to resolve LoongArch external vector {external}: {err:?}");
-                        if external_vector_failure_policy(err)
-                            == ExternalVectorResolveFailure::Complete
-                        {
-                            eiointc::complete_irq(external);
-                        }
-                        return None;
-                    }
-                };
+                let irq = pch_pic::irq_for_external_vector(external)
+                    .unwrap_or_else(|| eiointc_irq(external));
                 Some(ActiveIrq::new(irq, Completion::EioIntc { irq: external }))
             }
             RawIrq::Unknown => {

--- a/platforms/somehal/src/arch/loongarch64/pch_pic.rs
+++ b/platforms/somehal/src/arch/loongarch64/pch_pic.rs
@@ -1,3 +1,4 @@
+use kernutil::StaticCell;
 use rdif_intc::{AcpiGsiController, AcpiIrqPolarity, AcpiIrqTrigger, Interface};
 use rdrive::{
     DriverGeneric, PlatformDevice, module_driver,
@@ -6,7 +7,11 @@ use rdrive::{
 };
 
 use super::irq_common::{PCH_PIC_VECTOR_COUNT, fdt_first_cell_vector, pch_pic_reg_bit};
-use crate::{common::ioremap, irq_routing::AcpiControllerRoutes, setup::MmioRaw};
+use crate::{
+    common::ioremap,
+    irq_routing::{AcpiControllerRoutes, PchPicCpuInterface},
+    setup::MmioRaw,
+};
 
 const DEFAULT_PCH_PIC_SIZE: usize = 0x400;
 
@@ -15,6 +20,8 @@ const PCH_PIC_MASK: usize = 0x20;
 const PCH_PIC_EDGE: usize = 0x60;
 const PCH_PIC_POL: usize = 0x3e0;
 const PCH_INT_HTVEC: usize = 0x200;
+
+static CPU_IF: StaticCell<PchPicCpuInterface> = StaticCell::uninit();
 
 module_driver!(
     name: "Loongson PCH-PIC",
@@ -36,36 +43,12 @@ module_driver!(
     ],
 );
 
-pub fn irq_for_external_vector(
-    vector: usize,
-) -> Result<Option<rdif_intc::IrqId>, rdif_intc::IrqError> {
-    if !rdrive::is_initialized() {
-        return Ok(None);
-    }
+pub fn irq_for_external_vector(vector: usize) -> Option<rdif_intc::IrqId> {
+    cpu_interface().and_then(|cpu_if| cpu_if.irq_for_external_vector(vector))
+}
 
-    for intc in rdrive::get_list::<rdif_intc::Intc>() {
-        let Ok(pic) = intc.downcast::<PchPic>() else {
-            continue;
-        };
-        let domain = crate::irq::domain_by_owner(intc.descriptor().device_id())
-            .map(|domain| domain.id)
-            .ok_or(rdif_intc::IrqError::Unsupported)?;
-        let Ok(pic) = pic.try_lock() else {
-            warn!("failed to lock Loongson PCH-PIC when resolving vector {vector}");
-            return Err(rdif_intc::IrqError::Busy);
-        };
-        if let Some(irq) = pic.irq_for_external_vector(vector) {
-            return Ok(Some(irq));
-        }
-        if let Some(input) = pic.input_for_external_vector(vector) {
-            return Ok(Some(rdif_intc::IrqId::new(
-                domain,
-                rdif_intc::HwIrq(input as u32),
-            )));
-        }
-    }
-
-    Ok(None)
+fn cpu_interface() -> Option<&'static PchPicCpuInterface> {
+    CPU_IF.is_init().then(|| &*CPU_IF)
 }
 
 pub fn resolve_acpi_route(
@@ -154,11 +137,21 @@ fn register_pch_pic(
         crate::irq::IrqDomainKind::LoongArchPchPic,
     )
     .map_err(|err| OnProbeError::other(format!("failed to register PCH-PIC domain: {err:?}")))?;
-    let pic = PchPic::new(
-        mmio,
-        base_vector,
-        vector_count.unwrap_or(detected_vector_count),
-    );
+    let vector_count = vector_count.unwrap_or(detected_vector_count);
+    let controller_address = mmio.phys_addr().as_usize() as u64;
+    if !CPU_IF.is_init() {
+        CPU_IF.init(PchPicCpuInterface::new(
+            domain,
+            AcpiGsiController::PchPic,
+            controller_address,
+            base_vector,
+            vector_count,
+        ));
+    } else {
+        warn!("Loongson PCH-PIC CPU interface is already initialized");
+    }
+
+    let pic = PchPic::new(mmio, base_vector, vector_count);
     pic.init();
     dev.register(rdif_intc::Intc::new(domain, pic));
     Ok(())
@@ -279,14 +272,6 @@ impl PchPic {
         self.write_w(pol_addr, pol);
     }
 
-    fn irq_for_external_vector(&self, vector: usize) -> Option<rdif_intc::IrqId> {
-        self.routes.irq_for_external_vector(vector)
-    }
-
-    fn input_for_external_vector(&self, vector: usize) -> Option<usize> {
-        self.routes.input_for_vector(vector)
-    }
-
     fn read_w(&self, offset: usize) -> u32 {
         self.mmio.read(offset)
     }
@@ -339,6 +324,10 @@ impl Interface for PchPic {
             return Err(rdif_intc::IrqError::InvalidIrq);
         }
         self.routes.remember_route(route, translation.id)?;
+        let Some(cpu_if) = cpu_interface() else {
+            return Err(rdif_intc::IrqError::Controller);
+        };
+        cpu_if.remember_route(route, translation.id)?;
         self.configure_input(usize::from(route.controller_input), route);
         Ok(())
     }

--- a/platforms/somehal/src/arch/x86_64/mod.rs
+++ b/platforms/somehal/src/arch/x86_64/mod.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use rdif_intc::{AcpiGsiRoute, AcpiIrqPolarity, AcpiIrqTrigger};
 use rdrive::{
@@ -12,7 +13,7 @@ use x2apic::ioapic::{IoApic, IrqFlags, IrqMode};
 
 use crate::{
     common::PlatOp,
-    irq::{CPU_LOCAL_IRQ_DOMAIN, HwIrq, IrqError, IrqId, IrqSource, X86_LAPIC_DOMAIN},
+    irq::{CPU_LOCAL_IRQ_DOMAIN, HwIrq, IrqDomainId, IrqError, IrqId, IrqSource, X86_LAPIC_DOMAIN},
 };
 
 mod lapic;
@@ -26,6 +27,9 @@ use vector::{
 };
 
 const MASKED_IOAPIC_PLACEHOLDER_VECTOR: u8 = 0x21;
+const IRQ_ROUTE_VALID: u64 = 1 << 63;
+
+static IOAPIC_CPU_IF: X86IoApicCpuInterface = X86IoApicCpuInterface::new();
 
 pub struct Plat;
 
@@ -41,6 +45,49 @@ module_driver!(
         on_probe: probe_ioapic
     }],
 );
+
+struct X86IoApicCpuInterface {
+    vector_routes: [AtomicU64; 256],
+}
+
+impl X86IoApicCpuInterface {
+    const fn new() -> Self {
+        Self {
+            vector_routes: [const { AtomicU64::new(0) }; 256],
+        }
+    }
+
+    fn remember_vector_route(&self, vector: usize, irq: IrqId) -> Result<u8, IrqError> {
+        let vector_u8 = validate_external_vector(vector)?;
+        let encoded = encode_irq_id(irq);
+        let slot = &self.vector_routes[usize::from(vector_u8)];
+
+        match slot.compare_exchange(0, encoded, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => Ok(vector_u8),
+            Err(existing) if existing == encoded => Ok(vector_u8),
+            Err(_) => Err(IrqError::Busy),
+        }
+    }
+
+    fn irq_for_vector(&self, vector: usize) -> Option<IrqId> {
+        let vector = u8::try_from(vector).ok()?;
+        decode_irq_id(self.vector_routes[usize::from(vector)].load(Ordering::Acquire))
+    }
+}
+
+fn encode_irq_id(irq: IrqId) -> u64 {
+    IRQ_ROUTE_VALID | ((u64::from(irq.domain.0)) << 32) | u64::from(irq.hwirq.0)
+}
+
+fn decode_irq_id(encoded: u64) -> Option<IrqId> {
+    if encoded & IRQ_ROUTE_VALID == 0 {
+        return None;
+    }
+
+    let domain = IrqDomainId(((encoded >> 32) & u64::from(u16::MAX)) as u16);
+    let hwirq = HwIrq((encoded & u64::from(u32::MAX)) as u32);
+    Some(IrqId::new(domain, hwirq))
+}
 
 struct X86IoApicIntc {
     ioapics: Vec<X86IoApic>,
@@ -72,10 +119,12 @@ impl X86IoApicIntc {
             return Err(IrqError::Busy);
         }
 
+        IOAPIC_CPU_IF.remember_vector_route(vector, irq)?;
         self.vector_routes.push((vector, irq));
         Ok(vector_u8)
     }
 
+    #[cfg(test)]
     fn irq_for_vector(&self, vector: usize) -> Option<IrqId> {
         self.vector_routes
             .iter()
@@ -428,14 +477,9 @@ impl PlatOp for Plat {
         }
 
         match ioapic_irq_for_vector(raw) {
-            Ok(Some(irq)) => Some(ActiveIrq::new(irq)),
-            Ok(None) => {
+            Some(irq) => Some(ActiveIrq::new(irq)),
+            None => {
                 warn!("unrouted x86 interrupt vector {raw:#x}");
-                lapic::eoi();
-                None
-            }
-            Err(err) => {
-                warn!("failed to resolve x86 interrupt vector {raw:#x}: {err:?}");
                 lapic::eoi();
                 None
             }
@@ -578,16 +622,8 @@ fn set_ioapic_gsi_destination(
     Ok(ioapic.set_gsi_destination(gsi, dest))
 }
 
-fn ioapic_irq_for_vector(vector: usize) -> Result<Option<IrqId>, IrqError> {
-    let Some(domain) = crate::irq::domain_by_kind_fast(crate::irq::IrqDomainKind::X86IoApic) else {
-        return Ok(None);
-    };
-    let intc = crate::irq::intc_by_domain(domain)?;
-    let mut intc = intc.try_lock().map_err(|_| IrqError::Busy)?;
-    let ioapic = intc
-        .typed_mut::<X86IoApicIntc>()
-        .ok_or(IrqError::Unsupported)?;
-    Ok(ioapic.irq_for_vector(vector))
+fn ioapic_irq_for_vector(vector: usize) -> Option<IrqId> {
+    IOAPIC_CPU_IF.irq_for_vector(vector)
 }
 
 fn intx_flags(trigger: AcpiIrqTrigger, polarity: AcpiIrqPolarity) -> IrqFlags {
@@ -646,6 +682,34 @@ mod tests {
 
         assert_eq!(intc.irq_for_vector(vector), Some(irq));
         assert_ne!(intc.irq_for_vector(vector), Some(ioapic_gsi_irq_id(3)));
+    }
+
+    #[test]
+    fn ioapic_cpu_interface_resolves_vector_without_controller_device() {
+        let vector = rdrive::probe::acpi::PCI_INTX_VECTOR_BASE + 5;
+        let irq = ioapic_gsi_irq_id(21);
+        let cpu_if = X86IoApicCpuInterface::new();
+
+        cpu_if.remember_vector_route(vector, irq).unwrap();
+
+        assert_eq!(cpu_if.irq_for_vector(vector), Some(irq));
+        assert_eq!(cpu_if.irq_for_vector(vector + 1), None);
+    }
+
+    #[test]
+    fn ioapic_cpu_interface_rejects_vector_conflicts() {
+        let vector = rdrive::probe::acpi::PCI_INTX_VECTOR_BASE + 6;
+        let irq = ioapic_gsi_irq_id(22);
+        let conflicting = ioapic_gsi_irq_id(23);
+        let cpu_if = X86IoApicCpuInterface::new();
+
+        assert_eq!(cpu_if.remember_vector_route(vector, irq), Ok(vector as u8));
+        assert_eq!(cpu_if.remember_vector_route(vector, irq), Ok(vector as u8));
+        assert_eq!(
+            cpu_if.remember_vector_route(vector, conflicting),
+            Err(IrqError::Busy)
+        );
+        assert_eq!(cpu_if.irq_for_vector(vector), Some(irq));
     }
 
     #[test]

--- a/platforms/somehal/src/irq_routing.rs
+++ b/platforms/somehal/src/irq_routing.rs
@@ -2,10 +2,14 @@
 
 #[cfg(any(test, target_arch = "loongarch64"))]
 use alloc::vec::Vec;
+#[cfg(any(test, target_arch = "loongarch64"))]
+use core::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(any(test, target_arch = "loongarch64"))]
 use rdif_intc::{AcpiGsiController, AcpiGsiRoute};
 
+#[cfg(any(test, target_arch = "loongarch64"))]
+use crate::irq::IrqDomainId;
 #[cfg(any(test, target_arch = "riscv64"))]
 use crate::irq::{CPU_LOCAL_IRQ_DOMAIN, IrqSource};
 use crate::irq::{HwIrq, IrqError, IrqId};
@@ -50,14 +54,14 @@ pub(super) const fn cpu_local_hwirq_is_runtime_irq(
     )
 }
 
-#[cfg(any(test, target_arch = "loongarch64"))]
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ExternalVectorResolveFailure {
     KeepPending,
     Complete,
 }
 
-#[cfg(any(test, target_arch = "loongarch64"))]
+#[cfg(test)]
 pub(super) const fn external_vector_failure_policy(err: IrqError) -> ExternalVectorResolveFailure {
     if matches!(err, IrqError::Busy) {
         ExternalVectorResolveFailure::KeepPending
@@ -65,6 +69,11 @@ pub(super) const fn external_vector_failure_policy(err: IrqError) -> ExternalVec
         ExternalVectorResolveFailure::Complete
     }
 }
+
+#[cfg(any(test, target_arch = "loongarch64"))]
+const IRQ_ROUTE_VALID: u64 = 1 << 63;
+#[cfg(any(test, target_arch = "loongarch64"))]
+const PCH_PIC_CPU_ROUTE_SLOTS: usize = 256;
 
 #[cfg(any(test, target_arch = "riscv64"))]
 pub(crate) const RISCV_INTERRUPT_BIT: usize = 1usize << (usize::BITS as usize - 1);
@@ -179,6 +188,91 @@ struct RouteEntry {
 }
 
 #[cfg(any(test, target_arch = "loongarch64"))]
+pub(super) struct PchPicCpuInterface {
+    domain: IrqDomainId,
+    controller: AcpiGsiController,
+    controller_address: u64,
+    base_vector: usize,
+    vector_count: usize,
+    routes: [AtomicU64; PCH_PIC_CPU_ROUTE_SLOTS],
+}
+
+#[cfg(any(test, target_arch = "loongarch64"))]
+impl PchPicCpuInterface {
+    pub(super) const fn new(
+        domain: IrqDomainId,
+        controller: AcpiGsiController,
+        controller_address: u64,
+        base_vector: usize,
+        vector_count: usize,
+    ) -> Self {
+        Self {
+            domain,
+            controller,
+            controller_address,
+            base_vector,
+            vector_count,
+            routes: [const { AtomicU64::new(0) }; PCH_PIC_CPU_ROUTE_SLOTS],
+        }
+    }
+
+    pub(super) fn remember_route(&self, route: &AcpiGsiRoute, irq: IrqId) -> Result<(), IrqError> {
+        if !self.supports_acpi_gsi(route) {
+            return Err(IrqError::Unsupported);
+        }
+        if irq.hwirq != HwIrq(u32::from(route.controller_input)) {
+            return Err(IrqError::InvalidIrq);
+        }
+
+        let input = usize::from(route.controller_input);
+        let encoded = encode_irq_id(irq);
+        let slot = &self.routes[input];
+        match slot.compare_exchange(0, encoded, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => Ok(()),
+            Err(existing) if existing == encoded => Ok(()),
+            Err(_) => Err(IrqError::Busy),
+        }
+    }
+
+    pub(super) fn irq_for_external_vector(&self, vector: usize) -> Option<IrqId> {
+        let input = self.input_for_vector(vector)?;
+        decode_irq_id(self.routes[input].load(Ordering::Acquire))
+            .or_else(|| Some(IrqId::new(self.domain, HwIrq(input as u32))))
+    }
+
+    fn supports_acpi_gsi(&self, route: &AcpiGsiRoute) -> bool {
+        route.controller == self.controller
+            && route.controller_address == self.controller_address
+            && self.valid_input(usize::from(route.controller_input))
+    }
+
+    fn input_for_vector(&self, vector: usize) -> Option<usize> {
+        let input = vector.checked_sub(self.base_vector)?;
+        self.valid_input(input).then_some(input)
+    }
+
+    fn valid_input(&self, input: usize) -> bool {
+        input < self.vector_count && input < self.routes.len()
+    }
+}
+
+#[cfg(any(test, target_arch = "loongarch64"))]
+fn encode_irq_id(irq: IrqId) -> u64 {
+    IRQ_ROUTE_VALID | ((u64::from(irq.domain.0)) << 32) | u64::from(irq.hwirq.0)
+}
+
+#[cfg(any(test, target_arch = "loongarch64"))]
+fn decode_irq_id(encoded: u64) -> Option<IrqId> {
+    if encoded & IRQ_ROUTE_VALID == 0 {
+        return None;
+    }
+
+    let domain = IrqDomainId(((encoded >> 32) & u64::from(u16::MAX)) as u16);
+    let hwirq = HwIrq((encoded & u64::from(u32::MAX)) as u32);
+    Some(IrqId::new(domain, hwirq))
+}
+
+#[cfg(any(test, target_arch = "loongarch64"))]
 pub(super) struct AcpiControllerRoutes {
     controller: AcpiGsiController,
     controller_address: u64,
@@ -252,6 +346,7 @@ impl AcpiControllerRoutes {
         Ok(())
     }
 
+    #[cfg(test)]
     pub(super) fn irq_for_external_vector(&self, vector: usize) -> Option<IrqId> {
         let input = self.input_for_vector(vector)?;
         self.routes
@@ -294,6 +389,68 @@ mod tests {
             routes.irq_for_external_vector(18),
             Some(IrqId::new(IrqDomainId(42), HwIrq(82)))
         );
+    }
+
+    #[test]
+    fn pch_pic_cpu_interface_resolves_external_vector_without_controller_device() {
+        let cpu_if = PchPicCpuInterface::new(
+            IrqId::new(IrqDomainId(42), HwIrq(0)).domain,
+            AcpiGsiController::PchPic,
+            0x1000_0000,
+            0,
+            64,
+        );
+        let route = acpi_route(82, 18);
+        let irq = IrqId::new(IrqDomainId(42), HwIrq(18));
+
+        cpu_if.remember_route(&route, irq).unwrap();
+
+        assert_eq!(cpu_if.irq_for_external_vector(18), Some(irq));
+        assert_eq!(
+            cpu_if.irq_for_external_vector(19),
+            Some(IrqId::new(IrqDomainId(42), HwIrq(19)))
+        );
+        assert_eq!(cpu_if.irq_for_external_vector(route.vector), None);
+    }
+
+    #[test]
+    fn pch_pic_cpu_interface_rejects_out_of_range_input() {
+        let cpu_if = PchPicCpuInterface::new(
+            IrqId::new(IrqDomainId(42), HwIrq(0)).domain,
+            AcpiGsiController::PchPic,
+            0x1000_0000,
+            0,
+            64,
+        );
+        let route = AcpiGsiRoute {
+            controller_input: 64,
+            ..acpi_route(82, 18)
+        };
+        let irq = IrqId::new(IrqDomainId(42), HwIrq(64));
+
+        assert_eq!(
+            cpu_if.remember_route(&route, irq),
+            Err(IrqError::Unsupported)
+        );
+        assert_eq!(cpu_if.irq_for_external_vector(64), None);
+    }
+
+    #[test]
+    fn pch_pic_cpu_interface_does_not_store_acpi_vector_as_external_vector() {
+        let domain = IrqId::new(IrqDomainId(42), HwIrq(0)).domain;
+        let cpu_if =
+            PchPicCpuInterface::new(domain, AcpiGsiController::PchPic, 0x1000_0000, 16, 64);
+        let route = acpi_route(8, 18);
+        let irq = IrqId::new(domain, HwIrq(18));
+
+        cpu_if.remember_route(&route, irq).unwrap();
+
+        assert_eq!(cpu_if.irq_for_external_vector(16 + 18), Some(irq));
+        assert_eq!(
+            cpu_if.irq_for_external_vector(route.vector),
+            Some(IrqId::new(domain, HwIrq((route.vector - 16) as u32)))
+        );
+        assert_ne!(cpu_if.irq_for_external_vector(route.vector), Some(irq));
     }
 
     #[test]


### PR DESCRIPTION
## 问题

x86 IOAPIC 和 LoongArch PCH-PIC 的硬中断解析路径仍会回到 `rdrive` 查找 controller 设备并尝试获取 controller lock。这样会让 hard IRQ top-half 依赖设备生命周期和 OS/driver lock 状态，和 aarch64 GIC 已有的 CPU interface 分层不一致，也容易在中断上下文里引入不必要的锁失败或重入风险。

## 修改

- 为 x86 IOAPIC 增加独立的 CPU-side vector route cache，在 ACPI route 配置阶段发布 vector -> `IrqId` 映射，`begin_irq()` 只读取该 cache。
- 为 LoongArch PCH-PIC 增加独立的 CPU-side external route cache，在 PCH-PIC probe/config 阶段初始化并发布 ACPI route，EIOINTC claim 后只读取该 cache；未显式配置的合法 PCH input 仍按 PCH-PIC domain-local IRQ 处理。
- route cache 使用固定大小 `AtomicU64` slot 编码 `IrqId`，空 slot 为 0，配置期用 AcqRel 发布，中断期用 Acquire 读取，避免在 hard IRQ 路径中扫 `rdrive` 或拿 controller device lock。
- 保留原 controller route state 负责硬件配置、enable/disable 和测试；`rdrive` 仍只用于 probe/config/控制面路径。

## 验证

- `cargo test -p somehal --lib`
- `cargo xtask clippy --package somehal`
