### PR TITLE
fix(axtask): defer cross-core wake instead of spinning on remote on_cpu

### DIFF
--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -895,31 +895,40 @@ impl AxRunQueue {
             let waking_current_task = current_state == TaskState::Blocked
                 && self.cpu_id == this_cpu_id()
                 && crate::current().ptr_eq(&task);
-            // If the task is blocked, wait for the task to finish its scheduling process.
-            // See `unblock_task()` for details.
-            if current_state == TaskState::Blocked {
-                // Wait for next task's scheduling process to complete.
-                // If the owning (remote) CPU is still in the middle of schedule() with
-                // this task (next task) as prev, wait until it's done referencing the task.
-                //
-                // Pairs with the `clear_prev_task_on_cpu()`.
-                //
-                // Note:
-                // 1. This should be placed after the judgement of `TaskState::Blocked,`,
-                //    because the task may have been woken up by other cores.
-                // 2. This can be placed in the front of `switch_to()`
-                #[cfg(feature = "smp")]
-                {
-                    // A scheduler tracepoint or other IRQ-safe notification can wake the
-                    // task that is currently being switched out on this CPU. Waiting for
-                    // `on_cpu` there would wait for the very switch we are still inside.
-                    if !waking_current_task {
-                        while task.on_cpu() {
-                            // Wait for the task to finish its scheduling process.
-                            core::hint::spin_loop();
-                        }
-                    }
+            // A blocked task woken here may still be finishing its context
+            // switch-out on its owning CPU: `on_cpu == true` means its registers
+            // are not yet fully saved. It must NOT be made runnable (enqueued)
+            // until `on_cpu` is false, or another CPU could resume it with stale
+            // registers. Pairs with `clear_prev_task_on_cpu()`.
+            //
+            // We must NOT busy-spin on `on_cpu` for a task owned by a *remote*
+            // CPU (as the old code did): two CPUs each spinning with IRQs off,
+            // each waiting for the other to reach `clear_prev_task_on_cpu()`, is
+            // a mutual deadlock (whole-board freeze). Instead, hand the enqueue
+            // to the owning CPU via a lock-free stash it drains once its context
+            // is saved. `waking_current_task` (self-wake on this CPU, mid-switch)
+            // keeps the old inline behavior: this CPU finishes the switch in
+            // program order when it returns.
+            #[cfg(feature = "smp")]
+            if current_state == TaskState::Blocked && !waking_current_task && task.on_cpu() {
+                // Record where the task must land, then stash a reference for the
+                // owning CPU to enqueue from `clear_prev_task_on_cpu()`.
+                task.set_cpu_id(self.cpu_id as _);
+                task.stash_wake(task.clone());
+                // Re-check under the SeqCst handshake. If still on its owning CPU,
+                // that CPU drains the stash after its switch completes — done.
+                if task.on_cpu() {
+                    return false;
                 }
+                // `on_cpu` cleared meanwhile: the owning CPU may already have
+                // passed its drain point. Whichever side wins `take_wake` does
+                // the enqueue exactly once.
+                if task.take_wake().is_none() {
+                    // Owner won the swap; it enqueues + kicks the target.
+                    return false;
+                }
+                // We won: the reclaimed reference is dropped here; fall through
+                // and enqueue our own `task` (its context is now saved).
             }
             // TODO: priority
             #[cfg(feature = "smp")]
@@ -1088,7 +1097,8 @@ pub(crate) fn migrate_entry(migrated_task: AxTaskRef) {
     force_kick_remote_cpu(cpu_id);
 }
 
-/// Clear the `on_cpu` field of previous task running on this CPU.
+/// Clear the `on_cpu` field of the previous task running on this CPU, then
+/// complete any cross-core wake that was deferred while it was still `on_cpu`.
 #[cfg(feature = "smp")]
 pub(crate) unsafe fn clear_prev_task_on_cpu() {
     let prev = unsafe { PREV_TASK.current_ref_mut_raw() }
@@ -1096,7 +1106,24 @@ pub(crate) unsafe fn clear_prev_task_on_cpu() {
         .expect("PREV_TASK should have been set by switch_to");
     // Safety: prev_task's Arc is still alive on the caller's stack at this point
     // (switch_to has not yet returned), so the pointer is valid.
-    unsafe { prev.as_ref() }.set_on_cpu(false);
+    let prev = unsafe { prev.as_ref() };
+    // Publish that the context is fully saved. The SeqCst store pairs with the
+    // waker's `on_cpu()`/`take_wake()` handshake in `put_task_with_state`.
+    prev.set_on_cpu(false);
+    // Drain a wake that raced our switch-out. `take_wake` is the single arbiter:
+    // if the waker did not reclaim it (it saw `on_cpu` still true), we get the
+    // owned reference and enqueue it now that the context is saved.
+    if let Some(task) = prev.take_wake() {
+        let target = task.cpu_id() as usize;
+        // Leaf lock: `resched()` already dropped this CPU's scheduler lock before
+        // `switch_to`, so this takes only the target run queue's lock.
+        get_run_queue(target)
+            .scheduler
+            .lock()
+            .put_prev_task(task, false);
+        #[cfg(feature = "ipi")]
+        kick_remote_cpu(target);
+    }
 }
 pub(crate) fn init() {
     let cpu_id = this_cpu_id();

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -1121,8 +1121,26 @@ pub(crate) unsafe fn clear_prev_task_on_cpu() {
             .scheduler
             .lock()
             .put_prev_task(task, false);
-        #[cfg(feature = "ipi")]
-        kick_remote_cpu(target);
+        if target != this_cpu_id() {
+            // Remote target: ask that CPU to reschedule so it picks the task up
+            // (and wakes if it is idle in `wait_for_irqs`).
+            #[cfg(feature = "ipi")]
+            kick_remote_cpu(target);
+        } else {
+            // Local target: `kick_remote_cpu(self)` is a no-op, so the reschedule
+            // the remote waker's IPI used to deliver here would be lost — the
+            // task could sit un-run until the next tick, or indefinitely if this
+            // CPU just switched to `idle` and is about to `wait_for_irqs()`.
+            // `target == this_cpu_id()` arises when `select_wake_run_queue()`
+            // falls back to the task's `last_cpu`, which is this owning CPU.
+            // Request a reschedule on THIS CPU instead: the current task
+            // (`next_task`, possibly `idle`) is forced to reschedule when the
+            // switch chain unwinds and its preempt guard is released
+            // (`current_check_preempt_pending` consumes the flag), mirroring the
+            // reschedule the IPI path (`request_current_reschedule`) performed.
+            #[cfg(feature = "preempt")]
+            crate::current().set_force_resched_pending(true);
+        }
     }
 }
 pub(crate) fn init() {

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -1,6 +1,8 @@
 use alloc::{boxed::Box, string::String, sync::Arc};
 #[cfg(not(feature = "stack-guard-page"))]
 use core::alloc::Layout;
+#[cfg(feature = "smp")]
+use core::sync::atomic::AtomicPtr;
 #[cfg(any(
     feature = "preempt",
     all(feature = "stack-guard-page", feature = "smp", feature = "ipi")
@@ -96,6 +98,18 @@ pub struct TaskInner {
     /// Used to indicate whether the task is running on a CPU.
     #[cfg(feature = "smp")]
     on_cpu: AtomicBool,
+    /// One-shot cross-core wake handoff.
+    ///
+    /// When a remote CPU wins the `Blocked -> Ready` transition for this task
+    /// while it is still `on_cpu` (its context not yet fully saved on its owning
+    /// CPU), the waker must NOT enqueue it — and must not spin on `on_cpu`
+    /// either (that is the cross-core mutual-wake deadlock). Instead it records
+    /// the target run-queue in `cpu_id` and stashes an owned reference here; the
+    /// owning CPU drains it in `clear_prev_task_on_cpu()` once `on_cpu` is false,
+    /// then enqueues + kicks the target. Holds a `*const AxTask` produced by
+    /// `Arc::into_raw` (null = empty). See `run_queue::put_task_with_state`.
+    #[cfg(feature = "smp")]
+    wake_handoff: AtomicPtr<AxTask>,
 
     /// A ticket ID used to identify the timer event.
     /// Set by `set_timer_ticket()` when creating a timer event in `set_alarm_wakeup()`,
@@ -361,6 +375,8 @@ impl TaskInner {
             cpu_id: AtomicU32::new(0),
             #[cfg(feature = "smp")]
             on_cpu: AtomicBool::new(false),
+            #[cfg(feature = "smp")]
+            wake_handoff: AtomicPtr::new(core::ptr::null_mut()),
             #[cfg(feature = "preempt")]
             need_resched: AtomicBool::new(false),
             #[cfg(feature = "preempt")]
@@ -611,17 +627,52 @@ impl TaskInner {
     /// while it has not finished its scheduling process.
     /// The `on_cpu field is set to `true` when the task is preparing to run on a CPU,
     /// and it is set to `false` when the task has finished its scheduling process in `clear_prev_task_on_cpu()`.
+    ///
+    /// `SeqCst` because it participates in a store-before-load (Dekker) handshake
+    /// with [`Self::stash_wake`]/[`Self::take_wake`] across two distinct atomics
+    /// (`on_cpu` and `wake_handoff`); Acquire/Release would permit the
+    /// "both sides observe the other's stale value" lost-wakeup execution.
     #[cfg(feature = "smp")]
     #[inline]
     pub(crate) fn on_cpu(&self) -> bool {
-        self.on_cpu.load(Ordering::Acquire)
+        self.on_cpu.load(Ordering::SeqCst)
     }
 
-    /// Sets whether the task is running on a CPU.
+    /// Sets whether the task is running on a CPU. `SeqCst`, see [`Self::on_cpu`].
     #[cfg(feature = "smp")]
     #[inline]
     pub(crate) fn set_on_cpu(&self, on_cpu: bool) {
-        self.on_cpu.store(on_cpu, Ordering::Release)
+        self.on_cpu.store(on_cpu, Ordering::SeqCst)
+    }
+
+    /// Stash an owned reference for a deferred cross-core wake (see the
+    /// `wake_handoff` field). Transfers ownership of `task` into the slot via
+    /// `Arc::into_raw`. Must be paired with exactly one [`Self::take_wake`].
+    #[cfg(feature = "smp")]
+    #[inline]
+    pub(crate) fn stash_wake(&self, task: AxTaskRef) {
+        let ptr = Arc::into_raw(task) as *mut AxTask;
+        // SeqCst: ordered with the `on_cpu` handshake (see `on_cpu`).
+        self.wake_handoff.store(ptr, Ordering::SeqCst);
+    }
+
+    /// Atomically consume a stashed deferred-wake reference, if any. Returns the
+    /// owned `AxTaskRef` to exactly one caller (the swap is the single arbiter);
+    /// all other callers get `None`.
+    #[cfg(feature = "smp")]
+    #[inline]
+    pub(crate) fn take_wake(&self) -> Option<AxTaskRef> {
+        let ptr = self
+            .wake_handoff
+            .swap(core::ptr::null_mut(), Ordering::SeqCst);
+        if ptr.is_null() {
+            None
+        } else {
+            // Safety: `ptr` came from `Arc::into_raw` in `stash_wake`, and the
+            // swap guarantees a single consumer, so this reconstructs the unique
+            // owning `Arc` exactly once.
+            Some(unsafe { Arc::from_raw(ptr as *const AxTask) })
+        }
     }
 }
 


### PR DESCRIPTION
## 问题

`axtask` 的 SMP 调度器存在一个跨核互相唤醒的死锁：在特定的并发唤醒时序下，两个核会各自以关中断的方式在对方的 `on_cpu` 标志上忙等，谁都无法前进，导致整板冻结（串口彻底静默，无任何输出）。

## 根因

`put_task_with_state` 在唤醒一个 `Blocked` 任务时，为了保证该任务不会在其上下文尚未保存完毕时就被另一个核恢复执行，会忙等其所属核完成切出：

```rust
while task.on_cpu() { spin_loop() }
```

这段自旋是在**关中断**下进行的。单次跨核唤醒是有界的（所属核最终会到达 `clear_prev_task_on_cpu` 清掉 `on_cpu`）。但如果**两个核同时**各自去唤醒一个「正被对方切出、`on_cpu` 仍为真」的任务，就会形成环形等待：

- 核 A 关中断自旋等核 B 清 `on_cpu`；
- 核 B 关中断自旋等核 A 清 `on_cpu`；
- 两者都无法到达各自的 `clear_prev_task_on_cpu` → 谁都清不掉 → 整板死锁。

触发条件是「来自两个核的并发跨核唤醒」，例如跨核的设备完成中断唤醒，或负载均衡器把唤醒路由到别的核。这也解释了为什么它在 `max_cpu_num=1` 下永远无法复现。

## 修复

核心思路：**绝不在远端的 `on_cpu` 上自旋**，改为把入队操作交回给任务所属的核来完成。

当被唤醒的任务仍处于 `on_cpu` 时：
1. 记录目标运行队列，并通过一个无锁的、`SeqCst` 的一次性槽 `wake_handoff`（`AtomicPtr`，`Arc::into_raw`/`from_raw` 转移所有权）暂存一份任务引用；
2. 重新检查 `on_cpu`：若已清零，说明所属核已过了排空点，由唤醒方自己入队；若仍为真，则由所属核在 `clear_prev_task_on_cpu()` 里（此时上下文已保存、`on_cpu` 已置假）排空该槽，完成入队并 `kick_remote_cpu` 唤醒目标核。

延迟分支里唤醒方**不持有任何锁**（只用原子操作），因此不会再出现跨核自旋，也不会形成 IPI 队列环。`on_cpu` 与 `wake_handoff` 之间通过 `SeqCst` 的 store-before-load（Dekker）握手，保证有且仅有一方执行入队：**不丢唤醒、不重复入队**，且入队总是发生在 `on_cpu` 置假之后——原自旋所保护的「上下文保存完毕才可被恢复」的不变量依旧成立。

## 验证

**静态检查 / QEMU**
- aarch64（smp + ipi）编译通过；`clippy` 干净（18/18）；`fmt` 干净。
- QEMU smp4 并发回归全部通过：`test-futex-race`、`test-fcntl-deadlock-smp`、`test-sched-family`、`test-shm-deadlock`、`test-rawmutex-handoff` 等（`PASS system`）。
- 该死锁**无法在 QEMU 复现**：QEMU MTTCG 每个 vCPU 一次执行一大段翻译块才让出，远端唤醒几乎不可能落进「`Blocked` 但 `on_cpu` 仍为真」这个约百周期的窗口（已用计数器插桩确认：多种高压跨核唤醒工作负载下，延迟分支命中次数为 0）。因此本 bug 是**板级专属**的硬件时序竞态。

**板级前后对比（可复现的回归验证，OrangePi 5 Plus / RK3588，4×A55 + 4×A76，smp8）**

同一份内核，唯一差异是是否包含本修复（对本修复 `git revert`），跑相同的全功能配置（USB xHCI + NPU + PCIe + 网卡 + SD/block + 负载均衡器，`max_cpu_num=8`）：

| 配置 | 结果 |
| --- | --- |
| **修复前**（`while on_cpu` 自旋 + 负载均衡器 + smp8） | 启动过程中**整板冻结**（在 `dma_heap` 一行后串口彻底静默，从未进入 shell） |
| **修复后**（同一配置） | 正常启动到 shell：`nproc=8`、8 核全部在线、NPU 注册成功、JPU/RGA 自检通过 |

进一步用负载均衡器 + 无亲和性多进程工作负载做压力：修复后跑完 2000 万次跨核 ping-pong（`online=8`）无冻结；并且真实的 tennis 感知流水线（USB 摄像头 → JPU 硬解 → RGA → NPU 推理，无亲和性由负载均衡器跨 8 核调度）在 smp8 上端到端运行，`decode_errors=0 / inference_errors=0`。

> 关于回归测试：该死锁是一个**内存序 / store-buffer 层面的双核硬件竞态**，在 QEMU、以及宿主机线程测试（尤其是 x86-on-ARM 模拟环境）中都**无法可靠复现**——普通单元测试对正确与被破坏的代码都会通过，因此不构成有效的回归判据。**上述板级前后对比本身就是可复现的回归验证**：它既能复现（修复前冻结），又能区分（修复后启动）。若需在 CI 中做穷尽式内存序验证，可后续单独引入 `loom` 模型测试（`--cfg loom`）。
