### PR TITLE
feat(crab-usb): add SG2002 DWC2 host axtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "arceos-axtest-sg2002-usb-msc"
+version = "0.1.0"
+dependencies = [
+ "ax-driver",
+ "ax-hal",
+ "ax-std",
+ "ax-task",
+ "axplat-dyn",
+ "axtest",
+ "crab-usb",
+ "rdrive",
+]
+
+[[package]]
 name = "arceos-axtest-suit"
 version = "0.1.0"
 dependencies = [
@@ -701,6 +715,7 @@ dependencies = [
  "sdhci-host",
  "sdio-host-cv1800",
  "sdmmc-protocol",
+ "sg200x-bsp",
  "simple-ahci",
  "some-serial",
  "spin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ version = "0.1.0"
 dependencies = [
  "ax-driver",
  "ax-hal",
+ "ax-runtime",
  "ax-std",
  "ax-task",
  "axplat-dyn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ members = [
     "os/axvisor",
     "scripts/axbuild",
     "test-suit/arceos/axtest/smoke",
+    "test-suit/arceos/axtest/sg2002-usb-msc",
     "test-suit/arceos/rust",
     "apps/arceos/*",
     "apps/starry/qemu/rust-hello/rust",

--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -57,6 +57,7 @@ aic8800-wifi = [
 usb = ["dep:crab-usb"]
 rockchip-dwc-xhci = ["usb", "rockchip-soc", "rockchip-pm"]
 rockchip-ehci = ["usb", "rockchip-soc", "rockchip-pm"]
+sg2002-dwc2 = ["usb", "dep:sg200x-bsp"]
 xhci-mmio = ["usb"]
 xhci-pci = ["usb", "pci"]
 serial = [
@@ -193,10 +194,11 @@ sdhci-host = { workspace = true, optional = true }
 sdhci-cv1800 = { workspace = true, optional = true }
 sdio-host = { workspace = true, optional = true }
 sdmmc-protocol = { workspace = true, default-features = false, optional = true }
-starfive-jh7110-dwmmc = { workspace = true, optional = true }
+sg200x-bsp = { workspace = true, optional = true }
 simple-ahci = { workspace = true, optional = true }
 some-serial = { workspace = true, optional = true }
 spin.workspace = true
+starfive-jh7110-dwmmc = { workspace = true, optional = true }
 tock-registers = { workspace = true, optional = true }
 virtio-drivers = { workspace = true, optional = true }
 

--- a/drivers/ax-driver/src/usb/mod.rs
+++ b/drivers/ax-driver/src/usb/mod.rs
@@ -17,6 +17,8 @@ use crate::{PciIrqRequirement, binding_info_from_pci};
 mod dwc;
 #[cfg(feature = "rockchip-ehci")]
 mod ehci;
+#[cfg(feature = "sg2002-dwc2")]
+mod sg2002_dwc2;
 #[cfg(feature = "xhci-mmio")]
 mod xhci_mmio;
 #[cfg(feature = "xhci-pci")]

--- a/drivers/ax-driver/src/usb/mod.rs
+++ b/drivers/ax-driver/src/usb/mod.rs
@@ -207,6 +207,12 @@ impl PlatformUsbHost {
         Some((irq, handler))
     }
 
+    pub fn take_binding_irq_handler(&mut self) -> Option<(BindingIrq, UsbHostIrqHandler)> {
+        let irq = self.info.irq_cloned()?;
+        let handler = self.take_event_handler()?;
+        Some((irq, handler))
+    }
+
     pub fn take_event_handler(&mut self) -> Option<UsbHostIrqHandler> {
         if self.irq_handler_taken {
             return None;
@@ -399,4 +405,92 @@ pub(crate) fn align_up_4k(size: usize) -> usize {
 
 pub fn usb_host_device() -> Option<UsbHostDevice> {
     rdrive::get_one()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, vec};
+    use core::{alloc::Layout, num::NonZeroUsize, ptr::NonNull};
+
+    use crab_usb::{Dwc2HostParams, Dwc2NewParams, USBHost, usb_if::Speed};
+    use dma_api::{DmaAllocHandle, DmaConstraints, DmaDirection, DmaError, DmaMapHandle, DmaOp};
+
+    use super::*;
+
+    struct TestUsbKernel;
+
+    impl DmaOp for TestUsbKernel {
+        fn page_size(&self) -> usize {
+            4096
+        }
+
+        unsafe fn alloc_contiguous(
+            &self,
+            _constraints: DmaConstraints,
+            _layout: Layout,
+        ) -> Option<DmaAllocHandle> {
+            None
+        }
+
+        unsafe fn dealloc_contiguous(&self, _handle: DmaAllocHandle) {}
+
+        unsafe fn alloc_coherent(
+            &self,
+            _constraints: DmaConstraints,
+            _layout: Layout,
+        ) -> Option<DmaAllocHandle> {
+            None
+        }
+
+        unsafe fn dealloc_coherent(&self, _handle: DmaAllocHandle) {}
+
+        unsafe fn map_streaming(
+            &self,
+            _constraints: DmaConstraints,
+            _addr: NonNull<u8>,
+            _size: NonZeroUsize,
+            _direction: DmaDirection,
+        ) -> Result<DmaMapHandle, DmaError> {
+            Err(DmaError::NoMemory)
+        }
+
+        unsafe fn unmap_streaming(&self, _handle: DmaMapHandle) {}
+    }
+
+    impl crab_usb::KernelOp for TestUsbKernel {
+        fn delay(&self, _duration: core::time::Duration) {}
+    }
+
+    static TEST_USB_KERNEL: TestUsbKernel = TestUsbKernel;
+
+    fn test_usb_host() -> USBHost {
+        let regs = Box::leak(vec![0u32; 1024].into_boxed_slice());
+        let mmio = NonNull::new(regs.as_mut_ptr().cast::<u8>()).unwrap();
+        USBHost::new_dwc2(Dwc2NewParams {
+            mmio,
+            kernel: &TEST_USB_KERNEL,
+            params: Dwc2HostParams::sg2002(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn binding_irq_handler_preserves_fdt_interrupt_binding() {
+        let binding =
+            BindingIrq::fdt_interrupt_with_controller(rdrive::DeviceId::new(), [0, 30, 4]);
+        let info = BindingInfo::with_binding_irq(Some(binding.clone()));
+        let mut host = PlatformUsbHost::new_with_root_hub_speed(
+            "test-usb",
+            test_usb_host(),
+            info,
+            Speed::High,
+        );
+
+        assert_eq!(host.irq_num(), None);
+        let (actual, _handler) = host
+            .take_binding_irq_handler()
+            .expect("binding IRQ handler should be available");
+        assert_eq!(actual, binding);
+        assert!(host.take_binding_irq_handler().is_none());
+    }
 }

--- a/drivers/ax-driver/src/usb/sg2002_dwc2.rs
+++ b/drivers/ax-driver/src/usb/sg2002_dwc2.rs
@@ -1,0 +1,320 @@
+extern crate alloc;
+
+use alloc::{format, string::ToString, vec::Vec};
+use core::{ptr::NonNull, time::Duration};
+
+use crab_usb::{
+    Dwc2FifoSizes, Dwc2HostParams, Dwc2NewParams, Dwc2Quirks, Dwc2UtmiWidth, USBHost, usb_if::Speed,
+};
+use fdt_edit::{Node, RegFixed};
+use log::{debug, info, warn};
+use rdrive::{
+    probe::OnProbeError,
+    register::{FdtInfo, ProbeFdt},
+};
+use sg200x_bsp::{
+    gpio::{Direction, GPIO},
+    soc::{
+        CLKGEN_BASE, CV182X_USB2_PHY_BASE, FMUX_BASE, GPIO1_BASE, IOBLK_BASE, IOBLK_GRTC_BASE,
+        TOP_BASE,
+    },
+};
+
+use super::{ProbeFdtUsbHost, usb_kernel};
+use crate::mmio::iomap;
+
+const DRIVER_NAME: &str = "usb-sg2002-dwc2";
+
+const REG_MMIO_SIZE: usize = 0x1000;
+const TOP_MMIO_SIZE: usize = 0x4000;
+const DWC2_MMIO_DEFAULT_SIZE: usize = 0x10000;
+
+const CLKGEN_CLK_EN_1: usize = 0x004;
+const CLKGEN_CLK_EN_2: usize = 0x008;
+const CLKGEN_CLK_BYP_0: usize = 0x030;
+const CLKGEN_USB_CLK_EN_1_BITS: u32 = 0x0f << 28;
+const CLKGEN_USB_CLK_EN_2_BITS: u32 = 1;
+const CLKGEN_USB_BYP0_CLEAR_BITS: u32 = (1 << 17) | (1 << 18);
+
+const TOP_USB_PHY_RESET: usize = 0x3000;
+const TOP_USB_IDPAD: usize = 0x048;
+const TOP_USB_ECO: usize = 0x0b4;
+const TOP_USB_PHY_RESET_N: u32 = 1 << 11;
+const TOP_USB_IDPAD_MODE_MASK: u32 = 0xc0;
+const TOP_USB_IDPAD_DEVICE_MODE: u32 = 0xc0 | 0x01;
+const TOP_USB_IDPAD_HOST_MODE: u32 = 0x40 | 0x01;
+const TOP_USB_ECO_HOST_BIT: u32 = 0x80;
+
+const FMUX_USB_VBUS_DET: usize = 0x0fc;
+const FMUX_USB_VBUS_DET_XGPIOB6: u32 = 3;
+const IOBLK_G1_USB_VBUS_DET: usize = 0x020;
+const IOBLK_USB_VBUS_DET_DRIVE_MASK: u32 = 7 << 5;
+
+const VBUS_GPIO_PIN: u8 = 6;
+const CV182X_USB2_PHY_REG014: usize = 0x014;
+const VBUS_SETTLE_DELAY: Duration = Duration::from_secs(2);
+
+crate::model_register!(
+    name: "SG2002 DWC2 USB2 Host",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["cvitek,cv182x-usb"],
+            on_probe: probe
+        }
+    ],
+);
+
+#[derive(Clone)]
+struct Sg2002Dwc2Resources {
+    ctrl: RegFixed,
+    phy: RegFixed,
+    params: Dwc2HostParams,
+    vbus_gpio: Option<VbusGpio>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct VbusGpio {
+    pin: u8,
+    active_low: bool,
+}
+
+fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let info = probe.info();
+    match prop_str(info.node.as_node(), "dr_mode") {
+        Some("host" | "otg") => {}
+        Some(mode) => {
+            debug!(
+                "skip CV182x DWC2 node {} because dr_mode={mode}",
+                info.node.name()
+            );
+            return Err(OnProbeError::NotMatch);
+        }
+        None => {
+            debug!(
+                "skip CV182x DWC2 node {} because dr_mode is missing",
+                info.node.name()
+            );
+            return Err(OnProbeError::NotMatch);
+        }
+    }
+
+    let resources = collect_resources(info)?;
+    sg2002_board_usb_host_init(&resources)?;
+
+    let ctrl = map_reg(resources.ctrl, DWC2_MMIO_DEFAULT_SIZE)?;
+    let host = USBHost::new_dwc2(Dwc2NewParams {
+        mmio: ctrl,
+        kernel: usb_kernel(),
+        params: resources.params,
+    })
+    .map_err(|err| {
+        OnProbeError::other(format!(
+            "failed to create SG2002 DWC2 host for [{}]: {err}",
+            info.node.name()
+        ))
+    })?;
+
+    let node_name = info.node.name().to_string();
+    let irq = probe.register_usb_host_with_root_hub_speed(DRIVER_NAME, host, Speed::High)?;
+    info!(
+        "SG2002 DWC2 USB2 host initialized for {} with irq {:?}",
+        node_name, irq
+    );
+    Ok(())
+}
+
+fn collect_resources(info: &FdtInfo<'_>) -> Result<Sg2002Dwc2Resources, OnProbeError> {
+    let regs = info.node.regs();
+    let ctrl = regs
+        .first()
+        .copied()
+        .ok_or_else(|| OnProbeError::other(format!("[{}] has no DWC2 reg", info.node.name())))?;
+    let phy = regs.get(1).copied().unwrap_or(RegFixed {
+        address: CV182X_USB2_PHY_BASE as u64,
+        size: Some(REG_MMIO_SIZE as u64),
+        child_bus_address: CV182X_USB2_PHY_BASE as u64,
+    });
+
+    Ok(Sg2002Dwc2Resources {
+        ctrl,
+        phy,
+        params: parse_dwc2_params(info.node.as_node()),
+        vbus_gpio: parse_vbus_gpio(info.node.as_node()),
+    })
+}
+
+fn parse_dwc2_params(node: &Node) -> Dwc2HostParams {
+    let mut params = Dwc2HostParams::sg2002();
+    params.fifo = Dwc2FifoSizes {
+        rx_depth: prop_u32(node, "g-rx-fifo-size")
+            .and_then(|value| u16::try_from(value).ok())
+            .unwrap_or(params.fifo.rx_depth),
+        non_periodic_tx_depth: prop_u32(node, "g-np-tx-fifo-size")
+            .and_then(|value| u16::try_from(value).ok())
+            .unwrap_or(params.fifo.non_periodic_tx_depth),
+        periodic_tx_depth: prop_u32_list(node, "g-tx-fifo-size")
+            .first()
+            .copied()
+            .and_then(|value| u16::try_from(value).ok())
+            .unwrap_or(params.fifo.periodic_tx_depth),
+    };
+    params.utmi = Dwc2UtmiWidth::Auto;
+    params.quirks = Dwc2Quirks {
+        otg_host_session_override: true,
+        clear_utmi_override: true,
+    };
+    params
+}
+
+fn parse_vbus_gpio(node: &Node) -> Option<VbusGpio> {
+    let cells = prop_u32_list(node, "vbus-gpio");
+    if cells.len() < 3 {
+        return None;
+    }
+    Some(VbusGpio {
+        pin: cells[1] as u8,
+        active_low: cells[2] & 1 != 0,
+    })
+}
+
+fn sg2002_board_usb_host_init(resources: &Sg2002Dwc2Resources) -> Result<(), OnProbeError> {
+    enable_usb_clocks()?;
+    usb_top_host_bringup()?;
+    prepare_vbus_pin(resources.vbus_gpio)?;
+    enable_vbus_gpio(resources.vbus_gpio)?;
+    clear_usb2_phy_utmi_override(resources.phy)?;
+    axklib::time::busy_wait(VBUS_SETTLE_DELAY);
+    Ok(())
+}
+
+fn enable_usb_clocks() -> Result<(), OnProbeError> {
+    let clkgen = map_fixed(CLKGEN_BASE, REG_MMIO_SIZE, "SG2002 CLKGEN")?;
+    update32(clkgen, CLKGEN_CLK_EN_1, |value| {
+        value | CLKGEN_USB_CLK_EN_1_BITS
+    });
+    update32(clkgen, CLKGEN_CLK_EN_2, |value| {
+        value | CLKGEN_USB_CLK_EN_2_BITS
+    });
+    update32(clkgen, CLKGEN_CLK_BYP_0, |value| {
+        value & !CLKGEN_USB_BYP0_CLEAR_BITS
+    });
+    Ok(())
+}
+
+fn usb_top_host_bringup() -> Result<(), OnProbeError> {
+    let top = map_fixed(TOP_BASE, TOP_MMIO_SIZE, "SG2002 TOP")?;
+    let reset_value = read32(top, TOP_USB_PHY_RESET);
+    write32(top, TOP_USB_PHY_RESET, reset_value & !TOP_USB_PHY_RESET_N);
+    axklib::time::busy_wait(Duration::from_micros(50));
+    write32(top, TOP_USB_PHY_RESET, reset_value | TOP_USB_PHY_RESET_N);
+    axklib::time::busy_wait(Duration::from_micros(50));
+
+    let idpad = read32(top, TOP_USB_IDPAD);
+    write32(
+        top,
+        TOP_USB_IDPAD,
+        (idpad & !TOP_USB_IDPAD_MODE_MASK) | TOP_USB_IDPAD_DEVICE_MODE,
+    );
+    axklib::time::busy_wait(Duration::from_millis(1));
+    write32(
+        top,
+        TOP_USB_IDPAD,
+        (idpad & !TOP_USB_IDPAD_MODE_MASK) | TOP_USB_IDPAD_HOST_MODE,
+    );
+    axklib::time::busy_wait(Duration::from_millis(1));
+
+    update32(top, TOP_USB_ECO, |value| value | TOP_USB_ECO_HOST_BIT);
+    Ok(())
+}
+
+fn prepare_vbus_pin(vbus: Option<VbusGpio>) -> Result<(), OnProbeError> {
+    if let Some(vbus) = vbus
+        && vbus.pin != VBUS_GPIO_PIN
+    {
+        warn!(
+            "SG2002 DWC2 vbus-gpio pin {} is not GPIOB{}, using fixed board pin",
+            vbus.pin, VBUS_GPIO_PIN
+        );
+    }
+
+    let fmux = map_fixed(FMUX_BASE, REG_MMIO_SIZE, "SG2002 FMUX")?;
+    let ioblk = map_fixed(IOBLK_BASE, REG_MMIO_SIZE, "SG2002 IOBLK")?;
+    let _ioblk_grtc = map_fixed(IOBLK_GRTC_BASE, REG_MMIO_SIZE, "SG2002 IOBLK GRTC")?;
+
+    write32(fmux, FMUX_USB_VBUS_DET, FMUX_USB_VBUS_DET_XGPIOB6);
+    update32(ioblk, IOBLK_G1_USB_VBUS_DET, |value| {
+        value | IOBLK_USB_VBUS_DET_DRIVE_MASK
+    });
+    Ok(())
+}
+
+fn enable_vbus_gpio(vbus: Option<VbusGpio>) -> Result<(), OnProbeError> {
+    let active_high = !vbus.is_some_and(|gpio| gpio.active_low);
+    let gpio1 = map_fixed(GPIO1_BASE, REG_MMIO_SIZE, "SG2002 GPIO1")?;
+    let gpio = unsafe {
+        // SAFETY: `gpio1` is an ioremapped GPIO1 register block owned by this
+        // board bring-up path during probe.
+        GPIO::new(gpio1.as_ptr() as usize)
+    };
+    let pin = gpio.pin(VBUS_GPIO_PIN);
+    pin.set_direction(Direction::Output);
+    pin.set(active_high);
+    Ok(())
+}
+
+fn clear_usb2_phy_utmi_override(phy: RegFixed) -> Result<(), OnProbeError> {
+    let phy = map_reg(phy, REG_MMIO_SIZE)?;
+    write32(phy, CV182X_USB2_PHY_REG014, 0);
+    Ok(())
+}
+
+fn map_reg(reg: RegFixed, default_size: usize) -> Result<NonNull<u8>, OnProbeError> {
+    let size = align_up_4k((reg.size.unwrap_or(default_size as u64) as usize).max(1));
+    iomap(reg.address as usize, size)
+}
+
+fn map_fixed(address: usize, size: usize, name: &str) -> Result<NonNull<u8>, OnProbeError> {
+    iomap(address, size).map_err(|err| OnProbeError::other(format!("failed to map {name}: {err}")))
+}
+
+fn read32(base: NonNull<u8>, offset: usize) -> u32 {
+    unsafe {
+        // SAFETY: callers pass an ioremapped MMIO base and a register offset
+        // within that mapping.
+        (base.as_ptr().add(offset) as *const u32).read_volatile()
+    }
+}
+
+fn write32(base: NonNull<u8>, offset: usize, value: u32) {
+    unsafe {
+        // SAFETY: callers pass an ioremapped MMIO base and a register offset
+        // within that mapping.
+        (base.as_ptr().add(offset) as *mut u32).write_volatile(value)
+    }
+}
+
+fn update32(base: NonNull<u8>, offset: usize, f: impl FnOnce(u32) -> u32) {
+    let value = read32(base, offset);
+    write32(base, offset, f(value));
+}
+
+fn prop_str<'a>(node: &'a Node, name: &str) -> Option<&'a str> {
+    node.get_property(name).and_then(|prop| prop.as_str())
+}
+
+fn prop_u32(node: &Node, name: &str) -> Option<u32> {
+    node.get_property(name).and_then(|prop| prop.get_u32())
+}
+
+fn prop_u32_list(node: &Node, name: &str) -> Vec<u32> {
+    node.get_property(name)
+        .map(|prop| prop.get_u32_iter().collect())
+        .unwrap_or_default()
+}
+
+fn align_up_4k(size: usize) -> usize {
+    const MASK: usize = 0xfff;
+    (size + MASK) & !MASK
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec, vec::Vec};
 use core::{
     ptr::NonNull,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
     task::Context,
     time::Duration,
 };
@@ -34,9 +34,10 @@ use crate::{
 
 const DWC2_DMA_MASK_32: u64 = u32::MAX as u64;
 const DWC2_WAIT_ITERS: usize = 3_000_000;
-const DWC2_CHANNEL_WAIT_ITERS: usize = 8_000_000;
 const DWC2_MAX_CHANNELS: u8 = 16;
 const DWC2_DMA_ALIGN: usize = 64;
+const DWC2_NAK_RETRIES: u32 = 64;
+const DWC2_XACT_RETRIES: u32 = 8;
 
 const GOTGCTL: usize = 0x000;
 const GAHBCFG: usize = 0x008;
@@ -51,6 +52,7 @@ const GHWCFG4: usize = 0x050;
 const HPTXFSIZ: usize = 0x100;
 const HCFG: usize = 0x400;
 const HFNUM: usize = 0x408;
+const HAINT: usize = 0x414;
 const HAINTMSK: usize = 0x418;
 const HPRT0: usize = 0x440;
 const HC_BASE: usize = 0x500;
@@ -81,6 +83,7 @@ const GINTSTS_CURMODE_HOST: u32 = 1 << 0;
 const GINTSTS_PRTINT: u32 = 1 << 24;
 const GINTSTS_HCHINT: u32 = 1 << 25;
 const GINTSTS_DISCONNINT: u32 = 1 << 29;
+const DWC2_RUNTIME_GINTMSK: u32 = GINTSTS_HCHINT;
 
 const GOTGCTL_VBVALOEN: u32 = 1 << 2;
 const GOTGCTL_VBVALOVAL: u32 = 1 << 3;
@@ -118,6 +121,13 @@ const HCINT_TRANSFER_MASK: u32 = HCINT_XFERCOMPL
     | HCINT_AHBERR
     | HCINT_STALL
     | HCINT_NAK
+    | HCINT_XACTERR
+    | HCINT_BBLERR
+    | HCINT_FRMOVRN
+    | HCINT_DATATGLERR;
+const HCINT_DMA_IRQ_MASK: u32 = HCINT_CHHLTD
+    | HCINT_AHBERR
+    | HCINT_STALL
     | HCINT_XACTERR
     | HCINT_BBLERR
     | HCINT_FRMOVRN
@@ -256,25 +266,275 @@ impl Dwc2Registers {
     }
 }
 
-#[derive(Clone)]
-struct TransferWakeups {
-    count: Arc<AtomicUsize>,
+struct Dwc2ChannelCompletionSlot {
+    hcint: AtomicU32,
+    deferred_hcint: AtomicU32,
+    busy: AtomicBool,
+    waker: AtomicWaker,
 }
 
-impl TransferWakeups {
+impl Dwc2ChannelCompletionSlot {
     fn new() -> Self {
         Self {
-            count: Arc::new(AtomicUsize::new(0)),
+            hcint: AtomicU32::new(0),
+            deferred_hcint: AtomicU32::new(0),
+            busy: AtomicBool::new(false),
+            waker: AtomicWaker::new(),
         }
     }
 
-    fn notify(&self) {
-        self.count.fetch_add(1, Ordering::AcqRel);
+    fn try_begin_request(&self) -> bool {
+        self.busy
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
     }
 
-    fn take(&self) -> usize {
-        self.count.swap(0, Ordering::AcqRel)
+    fn end_request(&self) {
+        self.busy.store(false, Ordering::Release);
+        self.clear();
     }
+
+    fn clear(&self) {
+        self.hcint.store(0, Ordering::Release);
+        self.deferred_hcint.store(0, Ordering::Release);
+    }
+
+    fn publish(&self, hcint: u32) {
+        let deferred = self.deferred_hcint.swap(0, Ordering::AcqRel);
+        self.hcint.fetch_or(hcint | deferred, Ordering::AcqRel);
+        self.waker.wake();
+    }
+
+    fn defer(&self, hcint: u32) {
+        self.deferred_hcint.fetch_or(hcint, Ordering::AcqRel);
+    }
+
+    fn take(&self) -> Option<u32> {
+        let hcint = self.hcint.swap(0, Ordering::AcqRel);
+        (hcint != 0).then_some(hcint)
+    }
+
+    fn register_waker(&self, cx: &mut Context<'_>) {
+        self.waker.register(cx.waker());
+    }
+}
+
+#[derive(Clone)]
+struct Dwc2ChannelCompletions {
+    slots: Arc<Vec<Dwc2ChannelCompletionSlot>>,
+}
+
+impl Dwc2ChannelCompletions {
+    fn new() -> Self {
+        Self {
+            slots: Arc::new(
+                (0..usize::from(DWC2_MAX_CHANNELS))
+                    .map(|_| Dwc2ChannelCompletionSlot::new())
+                    .collect(),
+            ),
+        }
+    }
+
+    fn slot(&self, channel: u8) -> &Dwc2ChannelCompletionSlot {
+        self.slots
+            .get(usize::from(channel))
+            .unwrap_or_else(|| &self.slots[0])
+    }
+
+    fn try_begin_request(&self, channel: u8) -> bool {
+        self.slot(channel).try_begin_request()
+    }
+
+    fn end_request(&self, channel: u8) {
+        self.slot(channel).end_request();
+    }
+
+    fn clear(&self, channel: u8) {
+        self.slot(channel).clear();
+    }
+
+    fn publish(&self, channel: u8, hcint: u32) {
+        self.slot(channel).publish(hcint);
+    }
+
+    fn defer(&self, channel: u8, hcint: u32) {
+        self.slot(channel).defer(hcint);
+    }
+
+    fn take(&self, channel: u8) -> Option<u32> {
+        self.slot(channel).take()
+    }
+
+    fn register_waker(&self, channel: u8, cx: &mut Context<'_>) {
+        self.slot(channel).register_waker(cx);
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Dwc2TransferStats {
+    pub transfers: usize,
+    pub stages: usize,
+    pub dma_allocs: usize,
+    pub bounce_to_device_bytes: usize,
+    pub bounce_from_device_bytes: usize,
+    pub naks: usize,
+    pub xact_errors: usize,
+    pub timeouts: usize,
+    pub wait_iters: usize,
+    pub init_wait_iters: usize,
+    pub transfer_busy_wait_iters: usize,
+    pub irq_events: usize,
+    pub channel_completions: usize,
+}
+
+#[derive(Default)]
+struct Dwc2StatsInner {
+    transfers: AtomicUsize,
+    stages: AtomicUsize,
+    dma_allocs: AtomicUsize,
+    bounce_to_device_bytes: AtomicUsize,
+    bounce_from_device_bytes: AtomicUsize,
+    naks: AtomicUsize,
+    xact_errors: AtomicUsize,
+    timeouts: AtomicUsize,
+    init_wait_iters: AtomicUsize,
+    transfer_busy_wait_iters: AtomicUsize,
+    irq_events: AtomicUsize,
+    channel_completions: AtomicUsize,
+}
+
+#[derive(Clone, Default)]
+struct Dwc2Stats {
+    inner: Arc<Dwc2StatsInner>,
+}
+
+impl Dwc2Stats {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn reset(&self) {
+        self.inner.transfers.store(0, Ordering::Relaxed);
+        self.inner.stages.store(0, Ordering::Relaxed);
+        self.inner.dma_allocs.store(0, Ordering::Relaxed);
+        self.inner
+            .bounce_to_device_bytes
+            .store(0, Ordering::Relaxed);
+        self.inner
+            .bounce_from_device_bytes
+            .store(0, Ordering::Relaxed);
+        self.inner.naks.store(0, Ordering::Relaxed);
+        self.inner.xact_errors.store(0, Ordering::Relaxed);
+        self.inner.timeouts.store(0, Ordering::Relaxed);
+        self.inner.init_wait_iters.store(0, Ordering::Relaxed);
+        self.inner
+            .transfer_busy_wait_iters
+            .store(0, Ordering::Relaxed);
+        self.inner.irq_events.store(0, Ordering::Relaxed);
+        self.inner.channel_completions.store(0, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> Dwc2TransferStats {
+        let init_wait_iters = self.inner.init_wait_iters.load(Ordering::Relaxed);
+        let transfer_busy_wait_iters = self.inner.transfer_busy_wait_iters.load(Ordering::Relaxed);
+        Dwc2TransferStats {
+            transfers: self.inner.transfers.load(Ordering::Relaxed),
+            stages: self.inner.stages.load(Ordering::Relaxed),
+            dma_allocs: self.inner.dma_allocs.load(Ordering::Relaxed),
+            bounce_to_device_bytes: self.inner.bounce_to_device_bytes.load(Ordering::Relaxed),
+            bounce_from_device_bytes: self.inner.bounce_from_device_bytes.load(Ordering::Relaxed),
+            naks: self.inner.naks.load(Ordering::Relaxed),
+            xact_errors: self.inner.xact_errors.load(Ordering::Relaxed),
+            timeouts: self.inner.timeouts.load(Ordering::Relaxed),
+            wait_iters: init_wait_iters + transfer_busy_wait_iters,
+            init_wait_iters,
+            transfer_busy_wait_iters,
+            irq_events: self.inner.irq_events.load(Ordering::Relaxed),
+            channel_completions: self.inner.channel_completions.load(Ordering::Relaxed),
+        }
+    }
+
+    fn record_transfer(&self) {
+        self.inner.transfers.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_stage(&self) {
+        self.inner.stages.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_dma_alloc(&self) {
+        self.inner.dma_allocs.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_bounce_to_device(&self, bytes: usize) {
+        self.inner
+            .bounce_to_device_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    fn record_bounce_from_device(&self, bytes: usize) {
+        self.inner
+            .bounce_from_device_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    fn record_fault(&self, fault: Dwc2TransferFault) {
+        match fault {
+            Dwc2TransferFault::Nak => {
+                self.inner.naks.fetch_add(1, Ordering::Relaxed);
+            }
+            Dwc2TransferFault::Xact => {
+                self.inner.xact_errors.fetch_add(1, Ordering::Relaxed);
+            }
+            Dwc2TransferFault::Stall
+            | Dwc2TransferFault::Ahb
+            | Dwc2TransferFault::Babble
+            | Dwc2TransferFault::FrameOverrun
+            | Dwc2TransferFault::DataToggle
+            | Dwc2TransferFault::HaltedWithoutComplete => {}
+        }
+    }
+
+    fn record_timeout(&self) {
+        self.inner.timeouts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_init_wait_iters(&self, iters: usize) {
+        self.inner
+            .init_wait_iters
+            .fetch_add(iters, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    fn record_transfer_busy_wait_iters(&self, iters: usize) {
+        self.inner
+            .transfer_busy_wait_iters
+            .fetch_add(iters, Ordering::Relaxed);
+    }
+
+    fn record_irq_event(&self) {
+        self.inner.irq_events.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_channel_completion(&self) {
+        self.inner
+            .channel_completions
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn build_channel_gates(channel_count: u8) -> Vec<Arc<Mutex<()>>> {
+    (0..usize::from(channel_count.max(1)))
+        .map(|_| Arc::new(Mutex::new(())))
+        .collect()
+}
+
+fn channel_gate(gates: &[Arc<Mutex<()>>], channel: u8) -> Arc<Mutex<()>> {
+    gates
+        .get(usize::from(channel))
+        .or_else(|| gates.first())
+        .expect("DWC2 channel gates must not be empty")
+        .clone()
 }
 
 pub struct Dwc2 {
@@ -285,7 +545,9 @@ pub struct Dwc2 {
     event_handler: Option<Dwc2EventHandler>,
     next_addr: u8,
     channel_count: u8,
-    transfer_gate: Arc<Mutex<()>>,
+    channel_gates: Vec<Arc<Mutex<()>>>,
+    channel_completions: Dwc2ChannelCompletions,
+    stats: Dwc2Stats,
 }
 
 unsafe impl Send for Dwc2 {}
@@ -299,9 +561,11 @@ impl Dwc2 {
 
         let regs = Dwc2Registers::new(params.mmio);
         let kernel = Kernel::new(params.params.dma_mask, params.kernel);
-        let wakeups = TransferWakeups::new();
         let root_hub = Dwc2RootHub::new(regs, kernel.clone());
-        let event_handler = Dwc2EventHandler::new(regs, wakeups);
+        let channel_completions = Dwc2ChannelCompletions::new();
+        let stats = Dwc2Stats::new();
+        let event_handler = Dwc2EventHandler::new(regs, channel_completions.clone(), stats.clone());
+        let channel_count = regs.host_channel_count();
 
         Ok(Self {
             regs,
@@ -310,8 +574,10 @@ impl Dwc2 {
             root_hub: Some(root_hub),
             event_handler: Some(event_handler),
             next_addr: 1,
-            channel_count: regs.host_channel_count(),
-            transfer_gate: Arc::new(Mutex::new(())),
+            channel_count,
+            channel_gates: build_channel_gates(channel_count),
+            channel_completions,
+            stats,
         })
     }
 
@@ -351,16 +617,16 @@ impl Dwc2 {
         self.flush_rx_fifo()?;
 
         self.channel_count = self.regs.host_channel_count();
+        if self.channel_gates.len() != usize::from(self.channel_count) {
+            self.channel_gates = build_channel_gates(self.channel_count);
+        }
         let channel_mask = if self.channel_count >= 16 {
             u16::MAX as u32
         } else {
             (1u32 << self.channel_count) - 1
         };
         self.regs.write32(HAINTMSK, channel_mask);
-        self.regs.write32(
-            GINTMSK,
-            GINTSTS_PRTINT | GINTSTS_HCHINT | GINTSTS_DISCONNINT,
-        );
+        self.regs.write32(GINTMSK, DWC2_RUNTIME_GINTMSK);
         self.regs.write32(GINTSTS, u32::MAX);
         self.port_power_on();
         self.kernel.delay(Duration::from_millis(20));
@@ -388,12 +654,15 @@ impl Dwc2 {
     }
 
     fn wait_until(&self, ready: impl Fn() -> bool) -> Result<()> {
-        for _ in 0..DWC2_WAIT_ITERS {
+        for iter in 0..DWC2_WAIT_ITERS {
             if ready() {
+                self.stats.record_init_wait_iters(iter + 1);
                 return Ok(());
             }
             core::hint::spin_loop();
         }
+        self.stats.record_init_wait_iters(DWC2_WAIT_ITERS);
+        self.stats.record_timeout();
         Err(USBError::Timeout)
     }
 
@@ -451,14 +720,16 @@ impl Dwc2 {
 
     async fn new_device(&mut self, info: DeviceAddressInfo) -> Result<Box<dyn DeviceOp>> {
         let addr = self.allocate_address()?;
-        let mut device = Dwc2Device::new(
-            addr,
-            self.regs,
-            self.kernel.clone(),
-            info.port_speed,
-            self.channel_count,
-            self.transfer_gate.clone(),
-        )?;
+        let mut device = Dwc2Device::new(Dwc2DeviceParams {
+            address: addr,
+            regs: self.regs,
+            kernel: self.kernel.clone(),
+            port_speed: info.port_speed,
+            channel_count: self.channel_count,
+            channel_gates: self.channel_gates.clone(),
+            channel_completions: self.channel_completions.clone(),
+            stats: self.stats.clone(),
+        })?;
         device.init().await?;
         Ok(Box::new(device))
     }
@@ -493,16 +764,21 @@ impl CoreOp for Dwc2 {
     }
 
     fn enable_irq(&mut self) -> Result<()> {
-        self.regs.write32(
-            GINTMSK,
-            GINTSTS_PRTINT | GINTSTS_HCHINT | GINTSTS_DISCONNINT,
-        );
+        self.regs.write32(GINTMSK, DWC2_RUNTIME_GINTMSK);
         Ok(())
     }
 
     fn disable_irq(&mut self) -> Result<()> {
         self.regs.write32(GINTMSK, 0);
         Ok(())
+    }
+
+    fn dwc2_transfer_stats(&self) -> Option<Dwc2TransferStats> {
+        Some(self.stats.snapshot())
+    }
+
+    fn reset_dwc2_transfer_stats(&self) {
+        self.stats.reset();
     }
 
     fn kernel(&self) -> &Kernel {
@@ -608,15 +884,24 @@ impl HubOp for Dwc2RootHub {
 
 struct Dwc2EventHandler {
     regs: Dwc2Registers,
-    wakeups: TransferWakeups,
+    channel_completions: Dwc2ChannelCompletions,
+    stats: Dwc2Stats,
 }
 
 unsafe impl Send for Dwc2EventHandler {}
 unsafe impl Sync for Dwc2EventHandler {}
 
 impl Dwc2EventHandler {
-    fn new(regs: Dwc2Registers, wakeups: TransferWakeups) -> Self {
-        Self { regs, wakeups }
+    fn new(
+        regs: Dwc2Registers,
+        channel_completions: Dwc2ChannelCompletions,
+        stats: Dwc2Stats,
+    ) -> Self {
+        Self {
+            regs,
+            channel_completions,
+            stats,
+        }
     }
 }
 
@@ -629,17 +914,59 @@ impl EventHandlerOp for Dwc2EventHandler {
             return Event::Nothing;
         }
 
-        self.regs.write32(GINTSTS, pending);
         if pending & GINTSTS_PRTINT != 0 {
+            self.regs.write32(GINTSTS, GINTSTS_PRTINT);
             return Event::PortChange { port: 1 };
         }
         if pending & GINTSTS_HCHINT != 0 {
-            self.wakeups.notify();
+            self.stats.record_irq_event();
+            let count = self.handle_channel_interrupts();
+            self.regs.write32(GINTSTS, GINTSTS_HCHINT);
             return Event::TransferActivity {
-                count: self.wakeups.take().max(1),
+                count: count.max(1),
             };
         }
+        self.regs.write32(GINTSTS, pending);
         Event::Stopped
+    }
+}
+
+impl Dwc2EventHandler {
+    fn handle_channel_interrupts(&self) -> usize {
+        let pending = self.regs.read32(HAINT) & self.regs.read32(HAINTMSK);
+        let mut count = 0usize;
+        for channel in 0..DWC2_MAX_CHANNELS {
+            if pending & (1u32 << channel) == 0 {
+                continue;
+            }
+            let hcint_raw = self.regs.channel_read32(channel, HCINT) & HCINT_TRANSFER_MASK;
+            let hcint_masked = hcint_raw & self.regs.channel_read32(channel, HCINTMSK);
+            if hcint_masked == 0 {
+                continue;
+            }
+            self.regs.channel_write32(channel, HCINT, hcint_raw);
+            let hcint = if hcint_masked & HCINT_CHHLTD != 0 {
+                hcint_raw
+            } else {
+                hcint_masked
+            };
+            if hcint & HCINT_CHHLTD == 0 {
+                let hcchar = self.regs.channel_read32(channel, HCCHAR);
+                if hcchar & HCCHAR_CHENA != 0 {
+                    self.channel_completions.defer(channel, hcint);
+                    self.regs.channel_write32(
+                        channel,
+                        HCCHAR,
+                        hcchar | HCCHAR_CHENA | HCCHAR_CHDIS,
+                    );
+                    continue;
+                }
+            }
+            self.channel_completions.publish(channel, hcint);
+            self.stats.record_channel_completion();
+            count += 1;
+        }
+        count
     }
 }
 
@@ -707,6 +1034,19 @@ impl Dwc2EpType {
             Self::Bulk => 2,
             Self::Interrupt => 3,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DataStageRetryPolicy {
+    nak_retries: u32,
+}
+
+fn data_stage_retry_policy(ep_type: Dwc2EpType) -> DataStageRetryPolicy {
+    match ep_type {
+        Dwc2EpType::Control | Dwc2EpType::Bulk | Dwc2EpType::Interrupt => DataStageRetryPolicy {
+            nak_retries: DWC2_NAK_RETRIES,
+        },
     }
 }
 
@@ -978,17 +1318,6 @@ fn fault_to_transfer_error(fault: Dwc2TransferFault, hcint: u32) -> TransferErro
     }
 }
 
-fn usb_to_transfer_error(err: USBError) -> TransferError {
-    match err {
-        USBError::Timeout => TransferError::Timeout,
-        USBError::TransferError(err) => err,
-        USBError::NotSupported => TransferError::NotSupported,
-        USBError::NoMemory => TransferError::Other(anyhow!("DWC2 DMA allocation failed")),
-        USBError::NotFound | USBError::InvalidParameter => TransferError::InvalidEndpoint,
-        err => TransferError::Other(anyhow!("DWC2 transfer failed: {err}")),
-    }
-}
-
 fn endpoint_number(address: u8) -> u8 {
     address & 0x0f
 }
@@ -1024,15 +1353,57 @@ fn setup_packet_bytes(setup: &ControlSetup, direction: Direction, len: usize) ->
     ]
 }
 
+#[derive(Default)]
+struct Dwc2DmaBufferPool {
+    cached: Option<CoherentArray<u8>>,
+}
+
+impl Dwc2DmaBufferPool {
+    fn take(
+        &mut self,
+        kernel: &Kernel,
+        len: usize,
+        stats: &Dwc2Stats,
+    ) -> core::result::Result<Option<CoherentArray<u8>>, TransferError> {
+        if len == 0 {
+            return Ok(None);
+        }
+        if self
+            .cached
+            .as_ref()
+            .is_some_and(|buffer| buffer.len() >= len)
+        {
+            return Ok(self.cached.take());
+        }
+
+        let buffer = kernel
+            .coherent_array_zero_with_align::<u8>(len, DWC2_DMA_ALIGN)
+            .map_err(|err| {
+                TransferError::Other(anyhow!("DWC2 coherent DMA allocation failed: {err}"))
+            })?;
+        stats.record_dma_alloc();
+        Ok(Some(buffer))
+    }
+
+    fn reclaim(&mut self, buffer: Dwc2DmaBuffer) {
+        if let Some(coherent) = buffer.coherent {
+            self.cached = Some(coherent);
+        }
+    }
+}
+
 struct Dwc2DmaBuffer {
     direction: Direction,
     request_buffer: Option<(NonNull<u8>, usize)>,
     coherent: Option<CoherentArray<u8>>,
+    len: usize,
 }
 
 impl Dwc2DmaBuffer {
     fn new(
         kernel: &Kernel,
+        pool: &mut Dwc2DmaBufferPool,
+        stats: &Dwc2Stats,
         request: &TransferRequest,
     ) -> core::result::Result<Self, TransferError> {
         let direction = request.direction();
@@ -1040,15 +1411,18 @@ impl Dwc2DmaBuffer {
             .buffer()
             .filter(|buffer| buffer.len > 0)
             .map(|buffer| (buffer.ptr, buffer.len));
+        let len = request_buffer.map_or(0, |(_, len)| len);
         let coherent = if let Some((ptr, len)) = request_buffer {
-            let mut coherent = kernel
-                .coherent_array_zero_with_align::<u8>(len, DWC2_DMA_ALIGN)
-                .map_err(|err| {
-                    TransferError::Other(anyhow!("DWC2 coherent DMA allocation failed: {err}"))
-                })?;
+            let mut coherent = pool.take(kernel, len, stats)?.ok_or_else(|| {
+                TransferError::Other(anyhow!("DWC2 DMA buffer pool returned no buffer"))
+            })?;
             if matches!(direction, Direction::Out) {
                 let data = unsafe { core::slice::from_raw_parts(ptr.as_ptr().cast_const(), len) };
-                coherent.copy_from_slice_cpu(data);
+                coherent.write_with_cpu(len, |dst| dst.copy_from_slice(data));
+                stats.record_bounce_to_device(len);
+            } else {
+                coherent.write_with_cpu(len, |dst| dst.fill(0));
+                stats.record_bounce_from_device(len);
             }
             Some(coherent)
         } else {
@@ -1059,11 +1433,12 @@ impl Dwc2DmaBuffer {
             direction,
             request_buffer,
             coherent,
+            len,
         })
     }
 
     fn buffer_len(&self) -> usize {
-        self.coherent.as_ref().map_or(0, CoherentArray::len)
+        self.len
     }
 
     fn dma_addr(&self) -> u64 {
@@ -1083,7 +1458,7 @@ impl Dwc2DmaBuffer {
         };
         let Some(coherent) = self.coherent.as_ref() else {
             return Err(TransferError::Other(anyhow!(
-                "DWC2 IN transfer completed without a coherent buffer"
+                "DWC2 IN transfer completed without a DMA buffer"
             )));
         };
         if actual > len || actual > coherent.len() {
@@ -1093,7 +1468,7 @@ impl Dwc2DmaBuffer {
         }
 
         let dst = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), actual) };
-        dst.copy_from_slice(&coherent.as_slice_cpu()[..actual]);
+        coherent.read_with_cpu(actual, |src| dst.copy_from_slice(src));
         Ok(())
     }
 }
@@ -1104,7 +1479,9 @@ struct Dwc2Device {
     kernel: Kernel,
     port_speed: Speed,
     channel_count: u8,
-    transfer_gate: Arc<Mutex<()>>,
+    channel_gates: Vec<Arc<Mutex<()>>>,
+    channel_completions: Dwc2ChannelCompletions,
+    stats: Dwc2Stats,
     desc: DeviceDescriptor,
     ctrl_ep: Endpoint,
     config_desc: Vec<ConfigurationDescriptor>,
@@ -1113,33 +1490,51 @@ struct Dwc2Device {
     ep_interfaces: BTreeMap<u8, u8>,
 }
 
+struct Dwc2DeviceParams {
+    address: u8,
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    port_speed: Speed,
+    channel_count: u8,
+    channel_gates: Vec<Arc<Mutex<()>>>,
+    channel_completions: Dwc2ChannelCompletions,
+    stats: Dwc2Stats,
+}
+
 unsafe impl Send for Dwc2Device {}
 
 impl Dwc2Device {
-    fn new(
-        address: u8,
-        regs: Dwc2Registers,
-        kernel: Kernel,
-        port_speed: Speed,
-        channel_count: u8,
-        transfer_gate: Arc<Mutex<()>>,
-    ) -> Result<Self> {
-        let raw = Dwc2Endpoint::new(
+    fn new(params: Dwc2DeviceParams) -> Result<Self> {
+        let Dwc2DeviceParams {
+            address,
             regs,
-            kernel.clone(),
-            0,
+            kernel,
             port_speed,
-            0,
-            EndpointInfo::control(),
-            transfer_gate.clone(),
-        )?;
+            channel_count,
+            channel_gates,
+            channel_completions,
+            stats,
+        } = params;
+        let raw = Dwc2Endpoint::new(Dwc2EndpointParams {
+            regs,
+            kernel: kernel.clone(),
+            device_address: 0,
+            port_speed,
+            channel: 0,
+            info: EndpointInfo::control(),
+            channel_gate: channel_gate(&channel_gates, 0),
+            channel_completions: channel_completions.clone(),
+            stats: stats.clone(),
+        })?;
         Ok(Self {
             address,
             regs,
             kernel,
             port_speed,
             channel_count,
-            transfer_gate,
+            channel_gates,
+            channel_completions,
+            stats,
             desc: unsafe { core::mem::zeroed() },
             ctrl_ep: Endpoint::new(EndpointInfo::control(), raw),
             config_desc: Vec::new(),
@@ -1234,15 +1629,17 @@ impl Dwc2Device {
             }
             let info = EndpointInfo::from(&desc);
             let channel = self.channel_for_endpoint(info);
-            let raw = Dwc2Endpoint::new(
-                self.regs,
-                self.kernel.clone(),
-                self.address,
-                self.port_speed,
+            let raw = Dwc2Endpoint::new(Dwc2EndpointParams {
+                regs: self.regs,
+                kernel: self.kernel.clone(),
+                device_address: self.address,
+                port_speed: self.port_speed,
                 channel,
                 info,
-                self.transfer_gate.clone(),
-            )?;
+                channel_gate: channel_gate(&self.channel_gates, channel),
+                channel_completions: self.channel_completions.clone(),
+                stats: self.stats.clone(),
+            })?;
             self.eps.insert(desc.address, Endpoint::new(info, raw));
             self.ep_interfaces.insert(desc.address, interface);
         }
@@ -1324,6 +1721,46 @@ impl DeviceOp for Dwc2Device {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+enum Dwc2StageRole {
+    ControlSetup,
+    ControlData,
+    ControlStatus,
+    Data {
+        direction: Direction,
+        max_packet_size: u16,
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Dwc2QueuedStage {
+    stage: Dwc2TransferStage,
+    role: Dwc2StageRole,
+    nak_retries: u32,
+}
+
+#[derive(Clone, Copy)]
+struct Dwc2InFlightStage {
+    queued: Dwc2QueuedStage,
+    nak_left: u32,
+    xact_left: u32,
+}
+
+struct Dwc2ActiveRequest {
+    id: RequestId,
+    transfer: Dwc2DmaBuffer,
+    _setup_dma: Option<CoherentArray<u8>>,
+    stages: Vec<Dwc2QueuedStage>,
+    next_stage: usize,
+    in_flight: Option<Dwc2InFlightStage>,
+    actual_length: usize,
+}
+
+struct Dwc2PreparedStages {
+    stages: Vec<Dwc2QueuedStage>,
+    setup_dma: Option<CoherentArray<u8>>,
+}
+
 struct Dwc2Endpoint {
     regs: Dwc2Registers,
     kernel: Kernel,
@@ -1331,28 +1768,46 @@ struct Dwc2Endpoint {
     port_speed: Speed,
     channel: u8,
     info: EndpointInfo,
-    transfer_gate: Arc<Mutex<()>>,
+    channel_gate: Arc<Mutex<()>>,
+    channel_completions: Dwc2ChannelCompletions,
+    stats: Dwc2Stats,
+    dma_pool: Dwc2DmaBufferPool,
     data_toggle: DataToggle,
     next_request_id: u64,
+    active: Option<Dwc2ActiveRequest>,
     completed: Option<(
         RequestId,
         core::result::Result<TransferCompletion, TransferError>,
     )>,
-    waker: AtomicWaker,
 }
 
 unsafe impl Send for Dwc2Endpoint {}
 
+struct Dwc2EndpointParams {
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    device_address: u8,
+    port_speed: Speed,
+    channel: u8,
+    info: EndpointInfo,
+    channel_gate: Arc<Mutex<()>>,
+    channel_completions: Dwc2ChannelCompletions,
+    stats: Dwc2Stats,
+}
+
 impl Dwc2Endpoint {
-    fn new(
-        regs: Dwc2Registers,
-        kernel: Kernel,
-        device_address: u8,
-        port_speed: Speed,
-        channel: u8,
-        info: EndpointInfo,
-        transfer_gate: Arc<Mutex<()>>,
-    ) -> Result<Self> {
+    fn new(params: Dwc2EndpointParams) -> Result<Self> {
+        let Dwc2EndpointParams {
+            regs,
+            kernel,
+            device_address,
+            port_speed,
+            channel,
+            info,
+            channel_gate,
+            channel_completions,
+            stats,
+        } = params;
         endpoint_type_to_dwc2(info.transfer_type)?;
         Ok(Self {
             regs,
@@ -1361,11 +1816,14 @@ impl Dwc2Endpoint {
             port_speed,
             channel,
             info,
-            transfer_gate,
+            channel_gate,
+            channel_completions,
+            stats,
+            dma_pool: Dwc2DmaBufferPool::default(),
             data_toggle: DataToggle::data0(),
             next_request_id: 1,
+            active: None,
             completed: None,
-            waker: AtomicWaker::new(),
         })
     }
 
@@ -1383,42 +1841,44 @@ impl Dwc2Endpoint {
         RequestId::new(id)
     }
 
-    fn execute_request(
+    fn prepare_request(
         &mut self,
         id: RequestId,
         request: TransferRequest,
-    ) -> core::result::Result<TransferCompletion, TransferError> {
+    ) -> core::result::Result<Dwc2ActiveRequest, TransferError> {
         if matches!(request, TransferRequest::Isochronous { .. }) {
             return Err(TransferError::NotSupported);
         }
 
-        let transfer = Dwc2DmaBuffer::new(&self.kernel, &request)?;
-
-        let transfer_gate = self.transfer_gate.clone();
-        let _guard = transfer_gate.lock();
-        let actual_length = match &request {
-            TransferRequest::Control { .. } => self.execute_control(&request, &transfer)?,
+        self.stats.record_transfer();
+        let transfer = Dwc2DmaBuffer::new(&self.kernel, &mut self.dma_pool, &self.stats, &request)?;
+        let prepared = match &request {
+            TransferRequest::Control { .. } => self.control_stages(&request, &transfer)?,
             TransferRequest::Bulk { .. } | TransferRequest::Interrupt { .. } => {
-                self.execute_data(&request, &transfer)?
+                Dwc2PreparedStages {
+                    stages: self.data_stages(&request, &transfer)?,
+                    setup_dma: None,
+                }
             }
             TransferRequest::Isochronous { .. } => return Err(TransferError::NotSupported),
         };
 
-        transfer.copy_in_to_request(actual_length)?;
-
-        Ok(TransferCompletion {
-            request_id: id,
-            status: TransferStatus::Completed,
-            actual_length,
-            iso_packets: Vec::new(),
+        Ok(Dwc2ActiveRequest {
+            id,
+            transfer,
+            _setup_dma: prepared.setup_dma,
+            stages: prepared.stages,
+            next_stage: 0,
+            in_flight: None,
+            actual_length: 0,
         })
     }
 
-    fn execute_control(
+    fn control_stages(
         &self,
         request: &TransferRequest,
         transfer: &Dwc2DmaBuffer,
-    ) -> core::result::Result<usize, TransferError> {
+    ) -> core::result::Result<Dwc2PreparedStages, TransferError> {
         let TransferRequest::Control {
             setup, direction, ..
         } = request
@@ -1428,11 +1888,13 @@ impl Dwc2Endpoint {
 
         let mut setup_dma = self
             .kernel
-            .coherent_box_zero_with_align::<[u8; 8]>(8)
+            .coherent_array_zero_with_align::<u8>(8, DWC2_DMA_ALIGN)
             .map_err(|err| {
                 TransferError::Other(anyhow!("DWC2 setup DMA allocation failed: {err}"))
             })?;
-        setup_dma.write_cpu(setup_packet_bytes(setup, *direction, transfer.buffer_len()));
+        self.stats.record_dma_alloc();
+        let setup_bytes = setup_packet_bytes(setup, *direction, transfer.buffer_len());
+        setup_dma.write_with_cpu(8, |dst| dst.copy_from_slice(&setup_bytes));
         let setup_addr = dma_addr32(setup_dma.dma_addr().as_u64())?;
         let data_addr = dma_addr32(transfer.dma_addr())?;
         let plan = build_control_plan(
@@ -1443,20 +1905,35 @@ impl Dwc2Endpoint {
             data_addr,
         )?;
 
-        self.execute_stage(self.channel, plan.setup, true)?;
-        let mut actual_length = 0usize;
+        let mut stages = Vec::with_capacity(plan.data.len() + 2);
+        stages.push(Dwc2QueuedStage {
+            stage: plan.setup,
+            role: Dwc2StageRole::ControlSetup,
+            nak_retries: DWC2_NAK_RETRIES,
+        });
         for stage in plan.data {
-            actual_length += self.execute_stage(self.channel, stage, true)?;
+            stages.push(Dwc2QueuedStage {
+                stage,
+                role: Dwc2StageRole::ControlData,
+                nak_retries: DWC2_NAK_RETRIES,
+            });
         }
-        self.execute_stage(self.channel, plan.status, true)?;
-        Ok(actual_length)
+        stages.push(Dwc2QueuedStage {
+            stage: plan.status,
+            role: Dwc2StageRole::ControlStatus,
+            nak_retries: DWC2_NAK_RETRIES,
+        });
+        Ok(Dwc2PreparedStages {
+            stages,
+            setup_dma: Some(setup_dma),
+        })
     }
 
-    fn execute_data(
-        &mut self,
+    fn data_stages(
+        &self,
         request: &TransferRequest,
         transfer: &Dwc2DmaBuffer,
-    ) -> core::result::Result<usize, TransferError> {
+    ) -> core::result::Result<Vec<Dwc2QueuedStage>, TransferError> {
         let (direction, ep_type) = match request {
             TransferRequest::Bulk { direction, .. } => (*direction, Dwc2EpType::Bulk),
             TransferRequest::Interrupt { direction, .. } => (*direction, Dwc2EpType::Interrupt),
@@ -1465,7 +1942,9 @@ impl Dwc2Endpoint {
 
         let mps = self.info.max_packet_size.max(1);
         let endpoint = endpoint_number(self.info.address.raw());
-        let mut actual_length = 0usize;
+        let retry_policy = data_stage_retry_policy(ep_type);
+        let mut stages = Vec::new();
+        let mut toggle = self.data_toggle;
         let mut offset = 0u64;
         for len in split_dma_lengths(transfer.buffer_len(), mps) {
             let packets = packet_count(len, mps);
@@ -1478,110 +1957,191 @@ impl Dwc2Endpoint {
                     mps,
                     matches!(self.port_speed, Speed::Low),
                 ),
-                hctsiz: hctsiz(self.data_toggle.pid(), packets, len as u32),
+                hctsiz: hctsiz(toggle.pid(), packets, len as u32),
                 dma_addr: dma_addr32(transfer.dma_addr() + offset)?,
                 len,
             };
             if matches!(ep_type, Dwc2EpType::Interrupt) {
                 stage.hcchar |= self.regs.periodic_odd_frame_bit();
             }
-            let actual = self.execute_stage(self.channel, stage, false)?;
-            actual_length += actual;
-            self.data_toggle
-                .advance(successful_packet_count(actual, len, mps));
+            stages.push(Dwc2QueuedStage {
+                stage,
+                role: Dwc2StageRole::Data {
+                    direction,
+                    max_packet_size: mps,
+                },
+                nak_retries: retry_policy.nak_retries,
+            });
+            toggle.advance(packets);
             offset += len as u64;
-            if matches!(direction, Direction::In) && actual < len {
-                break;
-            }
         }
-        Ok(actual_length)
+        Ok(stages)
     }
 
-    fn execute_stage(
+    fn start_active_request(
+        &mut self,
+        mut active: Dwc2ActiveRequest,
+    ) -> core::result::Result<Dwc2ActiveRequest, TransferError> {
+        self.start_next_stage(&mut active)?;
+        Ok(active)
+    }
+
+    fn start_next_stage(
         &self,
-        channel: u8,
-        stage: Dwc2TransferStage,
-        retry_nak: bool,
-    ) -> core::result::Result<usize, TransferError> {
-        const NAK_RETRIES: u32 = 64;
-        const XACT_RETRIES: u32 = 8;
+        active: &mut Dwc2ActiveRequest,
+    ) -> core::result::Result<bool, TransferError> {
+        let Some(queued) = active.stages.get(active.next_stage).copied() else {
+            return Ok(false);
+        };
+        active.next_stage += 1;
+        self.start_stage(queued.stage)?;
+        active.in_flight = Some(Dwc2InFlightStage {
+            queued,
+            nak_left: queued.nak_retries,
+            xact_left: DWC2_XACT_RETRIES,
+        });
+        Ok(true)
+    }
 
-        let mut nak_left = if retry_nak { NAK_RETRIES } else { 0 };
-        let mut xact_left = XACT_RETRIES;
-        loop {
-            self.wait_channel_disabled(channel)
-                .map_err(usb_to_transfer_error)?;
-            self.halt_channel(channel);
-            self.regs.channel_write32(channel, HCSPLT, 0);
-            self.regs.channel_write32(channel, HCINT, HCINT_ALL_W1C);
-            self.regs
-                .channel_write32(channel, HCINTMSK, HCINT_TRANSFER_MASK);
-            self.regs.channel_write32(channel, HCTSIZ, stage.hctsiz);
-            mb();
-            self.regs.channel_write32(channel, HCDMA, stage.dma_addr);
-            mb();
-            self.regs
-                .channel_write32(channel, HCCHAR, stage.hcchar | HCCHAR_CHENA);
+    fn restart_stage(
+        &self,
+        active: &mut Dwc2ActiveRequest,
+        in_flight: Dwc2InFlightStage,
+    ) -> core::result::Result<(), TransferError> {
+        self.start_stage(in_flight.queued.stage)?;
+        active.in_flight = Some(in_flight);
+        Ok(())
+    }
 
-            let hcint = self
-                .wait_channel_halted(channel)
-                .map_err(usb_to_transfer_error)?;
-            if let Some(fault) = hcint_fault(hcint) {
-                match fault {
-                    Dwc2TransferFault::Nak if nak_left > 0 => {
-                        nak_left -= 1;
-                        self.kernel.delay(Duration::from_millis(1));
-                        continue;
+    fn start_stage(&self, stage: Dwc2TransferStage) -> core::result::Result<(), TransferError> {
+        if self.regs.channel_read32(self.channel, HCCHAR) & HCCHAR_CHENA != 0 {
+            return Err(TransferError::QueueFull);
+        }
+
+        self.stats.record_stage();
+        self.channel_completions.clear(self.channel);
+        let _guard = self.channel_gate.lock();
+        self.regs.channel_write32(self.channel, HCSPLT, 0);
+        self.regs
+            .channel_write32(self.channel, HCINT, HCINT_ALL_W1C);
+        self.regs
+            .channel_write32(self.channel, HCINTMSK, HCINT_DMA_IRQ_MASK);
+        self.regs
+            .channel_write32(self.channel, HCTSIZ, stage.hctsiz);
+        mb();
+        self.regs
+            .channel_write32(self.channel, HCDMA, stage.dma_addr);
+        mb();
+        self.regs
+            .channel_write32(self.channel, HCCHAR, stage.hcchar | HCCHAR_CHENA);
+        Ok(())
+    }
+
+    fn poll_active_request(
+        &mut self,
+        mut active: Dwc2ActiveRequest,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        let Some(hcint) = self.channel_completions.take(self.channel) else {
+            self.active = Some(active);
+            return None;
+        };
+        let Some(mut in_flight) = active.in_flight.take() else {
+            return Some(self.complete_active_request(
+                active,
+                Err(TransferError::Other(anyhow!(
+                    "DWC2 completion arrived without an in-flight stage"
+                ))),
+            ));
+        };
+
+        if let Some(fault) = hcint_fault(hcint) {
+            self.stats.record_fault(fault);
+            match fault {
+                Dwc2TransferFault::Nak if in_flight.nak_left > 0 => {
+                    in_flight.nak_left -= 1;
+                    if let Err(err) = self.restart_stage(&mut active, in_flight) {
+                        return Some(self.complete_active_request(active, Err(err)));
                     }
-                    Dwc2TransferFault::Xact if xact_left > 0 => {
-                        xact_left -= 1;
-                        self.kernel.delay(Duration::from_millis(1));
-                        continue;
+                    self.active = Some(active);
+                    return None;
+                }
+                Dwc2TransferFault::Xact if in_flight.xact_left > 0 => {
+                    in_flight.xact_left -= 1;
+                    if let Err(err) = self.restart_stage(&mut active, in_flight) {
+                        return Some(self.complete_active_request(active, Err(err)));
                     }
-                    _ => return Err(fault_to_transfer_error(fault, hcint)),
+                    self.active = Some(active);
+                    return None;
+                }
+                _ => {
+                    warn!(
+                        "dwc2: transfer fault channel={} role={:?} hcint={:#x} nak_left={} \
+                         xact_left={}",
+                        self.channel,
+                        in_flight.queued.role,
+                        hcint,
+                        in_flight.nak_left,
+                        in_flight.xact_left
+                    );
+                    return Some(self.complete_active_request(
+                        active,
+                        Err(fault_to_transfer_error(fault, hcint)),
+                    ));
                 }
             }
+        }
 
-            let hctsiz_after = self.regs.channel_read32(channel, HCTSIZ);
-            return Ok(stage_actual_length(stage, hctsiz_after));
+        let hctsiz_after = self.regs.channel_read32(self.channel, HCTSIZ);
+        let actual = stage_actual_length(in_flight.queued.stage, hctsiz_after);
+        match in_flight.queued.role {
+            Dwc2StageRole::ControlSetup | Dwc2StageRole::ControlStatus => {}
+            Dwc2StageRole::ControlData => {
+                active.actual_length = active.actual_length.saturating_add(actual);
+            }
+            Dwc2StageRole::Data {
+                direction,
+                max_packet_size,
+            } => {
+                active.actual_length = active.actual_length.saturating_add(actual);
+                self.data_toggle.advance(successful_packet_count(
+                    actual,
+                    in_flight.queued.stage.len,
+                    max_packet_size,
+                ));
+                if matches!(direction, Direction::In) && actual < in_flight.queued.stage.len {
+                    return Some(self.complete_active_request(active, Ok(())));
+                }
+            }
+        }
+
+        match self.start_next_stage(&mut active) {
+            Ok(true) => {
+                self.active = Some(active);
+                None
+            }
+            Ok(false) => Some(self.complete_active_request(active, Ok(()))),
+            Err(err) => Some(self.complete_active_request(active, Err(err))),
         }
     }
 
-    fn wait_channel_disabled(&self, channel: u8) -> Result<()> {
-        for _ in 0..DWC2_CHANNEL_WAIT_ITERS {
-            if self.regs.channel_read32(channel, HCCHAR) & HCCHAR_CHENA == 0 {
-                return Ok(());
-            }
-            core::hint::spin_loop();
-        }
-        Err(USBError::Timeout)
-    }
-
-    fn halt_channel(&self, channel: u8) {
-        let value = self.regs.channel_read32(channel, HCCHAR);
-        if value & HCCHAR_CHENA == 0 {
-            return;
-        }
-        self.regs
-            .channel_write32(channel, HCCHAR, value | HCCHAR_CHENA | HCCHAR_CHDIS);
-        for _ in 0..DWC2_WAIT_ITERS {
-            if self.regs.channel_read32(channel, HCCHAR) & HCCHAR_CHENA == 0 {
-                return;
-            }
-            core::hint::spin_loop();
-        }
-    }
-
-    fn wait_channel_halted(&self, channel: u8) -> Result<u32> {
-        for _ in 0..DWC2_CHANNEL_WAIT_ITERS {
-            let hcint = self.regs.channel_read32(channel, HCINT);
-            if hcint & HCINT_CHHLTD != 0 {
-                self.regs.channel_write32(channel, HCINT, hcint);
-                return Ok(hcint);
-            }
-            core::hint::spin_loop();
-        }
-        Err(USBError::Timeout)
+    fn complete_active_request(
+        &mut self,
+        active: Dwc2ActiveRequest,
+        result: core::result::Result<(), TransferError>,
+    ) -> core::result::Result<TransferCompletion, TransferError> {
+        let id = active.id;
+        let completion = result.and_then(|()| {
+            active.transfer.copy_in_to_request(active.actual_length)?;
+            Ok(TransferCompletion {
+                request_id: id,
+                status: TransferStatus::Completed,
+                actual_length: active.actual_length,
+                iso_packets: Vec::new(),
+            })
+        });
+        self.dma_pool.reclaim(active.transfer);
+        self.channel_completions.end_request(self.channel);
+        completion
     }
 }
 
@@ -1590,13 +2150,29 @@ impl crate::backend::ty::ep::EndpointOp for Dwc2Endpoint {
         &mut self,
         request: TransferRequest,
     ) -> core::result::Result<RequestId, TransferError> {
-        if self.completed.is_some() {
+        if self.active.is_some() || self.completed.is_some() {
             return Err(TransferError::QueueFull);
         }
         let id = self.allocate_request_id();
-        let result = self.execute_request(id, request);
-        self.completed = Some((id, result));
-        self.waker.wake();
+        if !self.channel_completions.try_begin_request(self.channel) {
+            return Err(TransferError::QueueFull);
+        }
+        self.channel_completions.clear(self.channel);
+        let active = match self.prepare_request(id, request) {
+            Ok(active) => active,
+            Err(err) => {
+                self.channel_completions.end_request(self.channel);
+                return Err(err);
+            }
+        };
+        let active = match self.start_active_request(active) {
+            Ok(active) => active,
+            Err(err) => {
+                self.channel_completions.end_request(self.channel);
+                return Err(err);
+            }
+        };
+        self.active = Some(active);
         Ok(id)
     }
 
@@ -1604,27 +2180,52 @@ impl crate::backend::ty::ep::EndpointOp for Dwc2Endpoint {
         &mut self,
         id: RequestId,
     ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
-        let (completed_id, _) = self.completed.as_ref()?;
-        if *completed_id != id {
+        if let Some((completed_id, _)) = self.completed.as_ref() {
+            if *completed_id != id {
+                return Some(Err(TransferError::InvalidEndpoint));
+            }
+            return self.completed.take().map(|(_, result)| result);
+        }
+
+        let active = self.active.take()?;
+        if active.id != id {
+            self.active = Some(active);
             return Some(Err(TransferError::InvalidEndpoint));
         }
-        self.completed.take().map(|(_, result)| result)
+        self.poll_active_request(active)
     }
 
-    fn register_waker(&self, _id: RequestId, cx: &mut Context<'_>) {
-        self.waker.register(cx.waker());
-        cx.waker().wake_by_ref();
+    fn register_waker(&self, id: RequestId, cx: &mut Context<'_>) {
+        if self.active.as_ref().is_some_and(|active| active.id == id) {
+            self.channel_completions.register_waker(self.channel, cx);
+        }
     }
 
     fn cancel_request(&mut self, id: RequestId) -> core::result::Result<(), TransferError> {
-        let Some((completed_id, _)) = self.completed.as_ref() else {
+        if self
+            .completed
+            .as_ref()
+            .is_some_and(|(done_id, _)| *done_id == id)
+        {
+            self.completed = Some((id, Err(TransferError::Cancelled)));
+            return Ok(());
+        }
+        let Some(active) = self.active.take() else {
             return Err(TransferError::InvalidEndpoint);
         };
-        if *completed_id != id {
+        if active.id != id {
+            self.active = Some(active);
             return Err(TransferError::InvalidEndpoint);
         }
+        let value = self.regs.channel_read32(self.channel, HCCHAR);
+        if value & HCCHAR_CHENA != 0 {
+            self.regs
+                .channel_write32(self.channel, HCCHAR, value | HCCHAR_CHENA | HCCHAR_CHDIS);
+        }
+        self.dma_pool.reclaim(active.transfer);
+        self.channel_completions.end_request(self.channel);
         self.completed = Some((id, Err(TransferError::Cancelled)));
-        self.waker.wake();
+        self.channel_completions.publish(self.channel, HCINT_CHHLTD);
         Ok(())
     }
 }
@@ -1639,26 +2240,46 @@ fn successful_packet_count(actual: usize, requested: usize, max_packet_size: u16
 
 #[cfg(test)]
 mod tests {
-    use alloc::alloc::{alloc_zeroed, dealloc};
-    use core::{alloc::Layout, num::NonZeroUsize, ptr::NonNull};
+    use alloc::{
+        alloc::{alloc_zeroed, dealloc},
+        vec,
+        vec::Vec,
+    };
+    use core::{
+        alloc::Layout,
+        num::NonZeroUsize,
+        ptr::NonNull,
+        sync::atomic::{AtomicU64, Ordering as AtomicOrdering},
+    };
 
     use dma_api::{DmaAllocHandle, DmaConstraints, DmaDirection, DmaError, DmaMapHandle, DmaOp};
     use usb_if::{
-        endpoint::TransferRequest,
+        descriptor::EndpointType,
+        endpoint::{EndpointAddress, EndpointInfo, TransferRequest},
         host::{ControlSetup, hub::Speed},
         transfer::{Direction, Recipient, Request, RequestType},
     };
 
     use super::{
-        DataToggle, Dwc2DmaBuffer, Dwc2EpType, Dwc2FifoSizes, Dwc2Pid, Dwc2PortStatus,
-        Dwc2TransferFault, Dwc2TransferStage, HCINT_AHBERR, HCINT_BBLERR, HCINT_NAK, HCINT_STALL,
-        HCINT_XACTERR, HPRT_CONN_DET, HPRT_CONN_STS, HPRT_ENA, HPRT_ENA_CHG, HPRT_OVRCUR_CHG,
-        build_control_plan, build_gahbcfg_internal_dma, fifo_register_plan, hcchar, hcint_fault,
-        hctsiz, packet_count, split_dma_lengths, stage_actual_length, successful_packet_count,
+        DataStageRetryPolicy, DataToggle, Dwc2ChannelCompletions, Dwc2DmaBuffer, Dwc2DmaBufferPool,
+        Dwc2Endpoint, Dwc2EndpointParams, Dwc2EpType, Dwc2EventHandler, Dwc2FifoSizes,
+        Dwc2HostParams, Dwc2NewParams, Dwc2Pid, Dwc2PortStatus, Dwc2Stats, Dwc2TransferFault,
+        Dwc2TransferStage, GINTMSK, GINTSTS, GINTSTS_HCHINT, HAINT, HAINTMSK, HCCHAR, HCCHAR_CHDIS,
+        HCCHAR_CHENA, HCINT, HCINT_AHBERR, HCINT_BBLERR, HCINT_CHHLTD, HCINT_DMA_IRQ_MASK,
+        HCINT_NAK, HCINT_STALL, HCINT_XACTERR, HCINT_XFERCOMPL, HCINTMSK, HPRT_CONN_DET,
+        HPRT_CONN_STS, HPRT_ENA, HPRT_ENA_CHG, HPRT_OVRCUR_CHG, build_channel_gates,
+        build_control_plan, build_gahbcfg_internal_dma, data_stage_retry_policy,
+        fifo_register_plan, hcchar, hcint_fault, hctsiz, packet_count, split_dma_lengths,
+        stage_actual_length, successful_packet_count,
     };
-    use crate::backend::kmod::osal::Kernel;
+    use crate::backend::{
+        kmod::osal::Kernel,
+        ty::{Event, EventHandlerOp, ep::EndpointOp},
+    };
 
     struct TestKernel;
+
+    static TEST_DMA_ADDR: AtomicU64 = AtomicU64::new(0x1000);
 
     impl DmaOp for TestKernel {
         fn page_size(&self) -> usize {
@@ -1679,12 +2300,16 @@ mod tests {
 
         unsafe fn alloc_coherent(
             &self,
-            _constraints: DmaConstraints,
+            constraints: DmaConstraints,
             layout: Layout,
         ) -> Option<DmaAllocHandle> {
             let ptr = unsafe { alloc_zeroed(layout) };
             let ptr = NonNull::new(ptr)?;
-            Some(unsafe { DmaAllocHandle::new(ptr, (ptr.as_ptr() as u64).into(), layout) })
+            let align = constraints.align.max(layout.align()).max(1) as u64;
+            let size = layout.size().max(1) as u64;
+            let current = TEST_DMA_ADDR.fetch_add(size + align, AtomicOrdering::Relaxed);
+            let dma_addr = (current + align - 1) & !(align - 1);
+            Some(unsafe { DmaAllocHandle::new(ptr, dma_addr.into(), layout) })
         }
 
         unsafe fn dealloc_coherent(&self, handle: DmaAllocHandle) {
@@ -1715,6 +2340,12 @@ mod tests {
     const GAHBCFG_HBSTLEN_INCR16: u32 = 7 << 1;
     const GAHBCFG_DMA_EN: u32 = 1 << 5;
 
+    fn test_regs() -> (Vec<u32>, super::Dwc2Registers) {
+        let mut regs = vec![0u32; 1024];
+        let base = NonNull::new(regs.as_mut_ptr().cast::<u8>()).unwrap();
+        (regs, super::Dwc2Registers { base })
+    }
+
     #[test]
     fn gahbcfg_requires_internal_dma_and_enables_incr16() {
         let value = build_gahbcfg_internal_dma(2).expect("internal DMA architecture is supported");
@@ -1733,6 +2364,21 @@ mod tests {
         assert_eq!(plan.grxfsiz, 536);
         assert_eq!(plan.gnptxfsiz, (32 << 16) | 536);
         assert_eq!(plan.hptxfsiz, (768 << 16) | (536 + 32));
+    }
+
+    #[test]
+    fn runtime_irq_mask_only_enables_host_channel_completion() {
+        let (_backing, regs) = test_regs();
+        let mut host = super::Dwc2::new(Dwc2NewParams {
+            mmio: regs.base,
+            kernel: &TEST_KERNEL,
+            params: Dwc2HostParams::sg2002(),
+        })
+        .unwrap();
+
+        crate::backend::kmod::kcore::CoreOp::enable_irq(&mut host).unwrap();
+
+        assert_eq!(regs.read32(GINTMSK), GINTSTS_HCHINT);
     }
 
     #[test]
@@ -1792,21 +2438,225 @@ mod tests {
     }
 
     #[test]
-    fn dma_buffer_bounces_in_data_through_coherent_memory() {
+    fn dma_buffer_bounces_in_data_through_coherent_dma_memory() {
         let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
+        let mut pool = Dwc2DmaBufferPool::default();
+        let stats = Dwc2Stats::new();
         let mut data = [0u8; 4];
         let request = TransferRequest::bulk_in(&mut data);
-        let mut dma = Dwc2DmaBuffer::new(&kernel, &request).unwrap();
+        let mut dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, &request).unwrap();
 
         assert_eq!(dma.buffer_len(), 4);
         assert_ne!(dma.dma_addr(), data.as_ptr() as u64);
         dma.coherent
             .as_mut()
             .unwrap()
-            .copy_from_slice_cpu(&[1, 2, 3, 4]);
+            .write_with_cpu(4, |dst| dst.copy_from_slice(&[1, 2, 3, 4]));
         dma.copy_in_to_request(3).unwrap();
 
         assert_eq!(data, [1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn dma_buffer_pool_reuses_existing_dma_allocation() {
+        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
+        let stats = Dwc2Stats::new();
+        let mut pool = Dwc2DmaBufferPool::default();
+        let mut first = [0u8; 64];
+        let first_request = TransferRequest::bulk_in(&mut first);
+        let first_dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, &first_request).unwrap();
+        let first_addr = first_dma.dma_addr();
+        pool.reclaim(first_dma);
+
+        let mut smaller = [0u8; 32];
+        let smaller_request = TransferRequest::bulk_in(&mut smaller);
+        let smaller_dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, &smaller_request).unwrap();
+        assert_eq!(smaller_dma.dma_addr(), first_addr);
+        pool.reclaim(smaller_dma);
+
+        let mut larger = [0u8; 128];
+        let larger_request = TransferRequest::bulk_in(&mut larger);
+        let larger_dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, &larger_request).unwrap();
+        assert_eq!(larger_dma.buffer_len(), 128);
+        pool.reclaim(larger_dma);
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.dma_allocs, 2);
+        assert_eq!(snapshot.bounce_from_device_bytes, 64 + 32 + 128);
+    }
+
+    #[test]
+    fn stats_records_transfer_faults_and_wait_iterations() {
+        let stats = Dwc2Stats::new();
+
+        stats.record_transfer();
+        stats.record_stage();
+        stats.record_fault(Dwc2TransferFault::Nak);
+        stats.record_fault(Dwc2TransferFault::Xact);
+        stats.record_timeout();
+        stats.record_transfer_busy_wait_iters(17);
+        stats.record_init_wait_iters(3);
+        stats.record_irq_event();
+        stats.record_channel_completion();
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.transfers, 1);
+        assert_eq!(snapshot.stages, 1);
+        assert_eq!(snapshot.naks, 1);
+        assert_eq!(snapshot.xact_errors, 1);
+        assert_eq!(snapshot.timeouts, 1);
+        assert_eq!(snapshot.transfer_busy_wait_iters, 17);
+        assert_eq!(snapshot.init_wait_iters, 3);
+        assert_eq!(snapshot.wait_iters, 20);
+        assert_eq!(snapshot.irq_events, 1);
+        assert_eq!(snapshot.channel_completions, 1);
+    }
+
+    #[test]
+    fn hchint_event_publishes_channel_completion_without_endpoint_polling_hcint() {
+        let (_backing, regs) = test_regs();
+        let completions = Dwc2ChannelCompletions::new();
+        let stats = Dwc2Stats::new();
+        let handler = Dwc2EventHandler::new(regs, completions.clone(), stats.clone());
+        let hcint = HCINT_CHHLTD | HCINT_XFERCOMPL;
+
+        regs.write32(GINTMSK, GINTSTS_HCHINT);
+        regs.write32(GINTSTS, GINTSTS_HCHINT);
+        regs.write32(HAINTMSK, 1);
+        regs.write32(HAINT, 1);
+        regs.channel_write32(0, HCINTMSK, hcint);
+        regs.channel_write32(0, HCINT, hcint);
+
+        match handler.handle_event() {
+            Event::TransferActivity { count } => assert_eq!(count, 1),
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+        assert_eq!(completions.take(0), Some(hcint));
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.irq_events, 1);
+        assert_eq!(snapshot.channel_completions, 1);
+    }
+
+    #[test]
+    fn chhltd_completion_preserves_unmasked_raw_hcint_reason() {
+        let (_backing, regs) = test_regs();
+        let completions = Dwc2ChannelCompletions::new();
+        let stats = Dwc2Stats::new();
+        let handler = Dwc2EventHandler::new(regs, completions.clone(), stats.clone());
+
+        regs.write32(GINTMSK, GINTSTS_HCHINT);
+        regs.write32(GINTSTS, GINTSTS_HCHINT);
+        regs.write32(HAINTMSK, 1);
+        regs.write32(HAINT, 1);
+        regs.channel_write32(0, HCINTMSK, HCINT_CHHLTD);
+        regs.channel_write32(0, HCINT, HCINT_CHHLTD | HCINT_XFERCOMPL);
+
+        match handler.handle_event() {
+            Event::TransferActivity { count } => assert_eq!(count, 1),
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+        assert_eq!(completions.take(0), Some(HCINT_CHHLTD | HCINT_XFERCOMPL));
+    }
+
+    #[test]
+    fn xfercomplete_without_channel_halt_requests_halt_before_publish() {
+        let (_backing, regs) = test_regs();
+        let completions = Dwc2ChannelCompletions::new();
+        let stats = Dwc2Stats::new();
+        let handler = Dwc2EventHandler::new(regs, completions.clone(), stats.clone());
+
+        regs.write32(GINTMSK, GINTSTS_HCHINT);
+        regs.write32(GINTSTS, GINTSTS_HCHINT);
+        regs.write32(HAINTMSK, 1);
+        regs.write32(HAINT, 1);
+        regs.channel_write32(0, HCCHAR, HCCHAR_CHENA);
+        regs.channel_write32(0, HCINTMSK, HCINT_CHHLTD | HCINT_XFERCOMPL);
+        regs.channel_write32(0, HCINT, HCINT_XFERCOMPL);
+
+        match handler.handle_event() {
+            Event::TransferActivity { .. } => {}
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+
+        assert_eq!(completions.take(0), None);
+        assert_eq!(regs.channel_read32(0, HCCHAR) & HCCHAR_CHDIS, HCCHAR_CHDIS);
+        assert_eq!(stats.snapshot().channel_completions, 0);
+
+        regs.write32(GINTSTS, GINTSTS_HCHINT);
+        regs.write32(HAINT, 1);
+        regs.channel_write32(0, HCCHAR, 0);
+        regs.channel_write32(0, HCINT, HCINT_CHHLTD);
+
+        match handler.handle_event() {
+            Event::TransferActivity { count } => assert_eq!(count, 1),
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+
+        assert_eq!(completions.take(0), Some(HCINT_CHHLTD | HCINT_XFERCOMPL));
+        assert_eq!(stats.snapshot().channel_completions, 1);
+    }
+
+    #[test]
+    fn endpoint_submit_waits_for_irq_completion_before_reclaiming() {
+        let (_backing, regs) = test_regs();
+        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
+        let completions = Dwc2ChannelCompletions::new();
+        let stats = Dwc2Stats::new();
+        let mut endpoint = Dwc2Endpoint::new(Dwc2EndpointParams {
+            regs,
+            kernel,
+            device_address: 2,
+            port_speed: Speed::High,
+            channel: 1,
+            info: EndpointInfo {
+                address: EndpointAddress::new(0x81),
+                transfer_type: EndpointType::Bulk,
+                direction: Direction::In,
+                max_packet_size: 512,
+                packets_per_microframe: 1,
+                interval: 0,
+            },
+            channel_gate: build_channel_gates(2)[1].clone(),
+            channel_completions: completions.clone(),
+            stats: stats.clone(),
+        })
+        .unwrap();
+        let mut data = [0u8; 512];
+        let id = endpoint
+            .submit_request(TransferRequest::bulk_in(&mut data))
+            .unwrap();
+
+        let hcintmsk = regs.channel_read32(1, HCINTMSK);
+        assert_eq!(hcintmsk, HCINT_DMA_IRQ_MASK);
+        assert_eq!(hcintmsk & HCINT_NAK, 0);
+        assert_eq!(hcintmsk & HCINT_XFERCOMPL, 0);
+        assert!(endpoint.reclaim_request(id).is_none());
+
+        completions.publish(1, HCINT_CHHLTD | HCINT_XFERCOMPL);
+        assert!(endpoint.reclaim_request(id).is_some());
+        assert_eq!(stats.snapshot().transfer_busy_wait_iters, 0);
+    }
+
+    #[test]
+    fn bulk_and_interrupt_data_stages_retry_nak_like_linux_hcd_flow_control() {
+        assert_eq!(
+            data_stage_retry_policy(Dwc2EpType::Bulk),
+            DataStageRetryPolicy { nak_retries: 64 }
+        );
+        assert_eq!(
+            data_stage_retry_policy(Dwc2EpType::Interrupt),
+            DataStageRetryPolicy { nak_retries: 64 }
+        );
+    }
+
+    #[test]
+    fn channel_gates_are_per_channel_instead_of_one_global_gate() {
+        let gates = build_channel_gates(4);
+
+        assert_eq!(gates.len(), 4);
+        assert!(alloc::sync::Arc::ptr_eq(&gates[1], &gates[1]));
+        assert!(!alloc::sync::Arc::ptr_eq(&gates[1], &gates[2]));
     }
 
     #[test]

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
@@ -1,0 +1,1897 @@
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use core::{
+    ptr::NonNull,
+    sync::atomic::{AtomicUsize, Ordering},
+    task::Context,
+    time::Duration,
+};
+
+use ax_kspin::SpinRaw as Mutex;
+use dma_api::CoherentArray;
+use futures::{FutureExt, future::BoxFuture, task::AtomicWaker};
+use mbarrier::mb;
+use usb_if::{
+    descriptor::{
+        ConfigurationDescriptor, DescriptorType, DeviceDescriptor, DeviceDescriptorBase,
+        EndpointDescriptor, EndpointType,
+    },
+    endpoint::{EndpointInfo, RequestId, TransferCompletion, TransferRequest, TransferStatus},
+    err::{TransferError, USBError},
+    host::{ControlSetup, hub::Speed},
+    transfer::{BmRequestType, Direction, Recipient, Request, RequestType},
+};
+
+use super::{
+    hub::{HubInfo, HubOp, PortChangeInfo, PortState},
+    kcore::CoreOp,
+    osal::{Kernel, KernelOp},
+};
+use crate::{
+    DeviceAddressInfo, Mmio,
+    backend::ty::{DeviceOp, Event, EventHandlerOp, HubParams, ep::Endpoint},
+    err::Result,
+};
+
+const DWC2_DMA_MASK_32: u64 = u32::MAX as u64;
+const DWC2_WAIT_ITERS: usize = 3_000_000;
+const DWC2_CHANNEL_WAIT_ITERS: usize = 8_000_000;
+const DWC2_MAX_CHANNELS: u8 = 16;
+const DWC2_DMA_ALIGN: usize = 64;
+
+const GOTGCTL: usize = 0x000;
+const GAHBCFG: usize = 0x008;
+const GUSBCFG: usize = 0x00c;
+const GRSTCTL: usize = 0x010;
+const GINTSTS: usize = 0x014;
+const GINTMSK: usize = 0x018;
+const GRXFSIZ: usize = 0x024;
+const GNPTXFSIZ: usize = 0x028;
+const GHWCFG2: usize = 0x048;
+const GHWCFG4: usize = 0x050;
+const HPTXFSIZ: usize = 0x100;
+const HCFG: usize = 0x400;
+const HFNUM: usize = 0x408;
+const HAINTMSK: usize = 0x418;
+const HPRT0: usize = 0x440;
+const HC_BASE: usize = 0x500;
+const HC_STRIDE: usize = 0x20;
+const PCGCTL: usize = 0xe00;
+
+const HCCHAR: usize = 0x00;
+const HCSPLT: usize = 0x04;
+const HCINT: usize = 0x08;
+const HCINTMSK: usize = 0x0c;
+const HCTSIZ: usize = 0x10;
+const HCDMA: usize = 0x14;
+
+const GUSBCFG_TOUTCAL_MASK: u32 = 0x7;
+const GUSBCFG_PHYIF16: u32 = 1 << 3;
+const GUSBCFG_ULPI_UTMI_SEL: u32 = 1 << 4;
+const GUSBCFG_FORCEHOSTMODE: u32 = 1 << 29;
+const GUSBCFG_FORCEDEVMODE: u32 = 1 << 30;
+
+const GRSTCTL_CSFTRST: u32 = 1 << 0;
+const GRSTCTL_RXFFLSH: u32 = 1 << 4;
+const GRSTCTL_TXFFLSH: u32 = 1 << 5;
+const GRSTCTL_TXFNUM_ALL: u32 = 0x10 << 6;
+const GRSTCTL_CSFTRST_DONE: u32 = 1 << 29;
+const GRSTCTL_AHBIDLE: u32 = 1 << 31;
+
+const GINTSTS_CURMODE_HOST: u32 = 1 << 0;
+const GINTSTS_PRTINT: u32 = 1 << 24;
+const GINTSTS_HCHINT: u32 = 1 << 25;
+const GINTSTS_DISCONNINT: u32 = 1 << 29;
+
+const GOTGCTL_VBVALOEN: u32 = 1 << 2;
+const GOTGCTL_VBVALOVAL: u32 = 1 << 3;
+const GOTGCTL_AVALOEN: u32 = 1 << 4;
+const GOTGCTL_AVALOVAL: u32 = 1 << 5;
+const GOTGCTL_DBNCE_FLTR_BYPASS: u32 = 1 << 15;
+
+const HPRT_CONN_STS: u32 = 1 << 0;
+const HPRT_CONN_DET: u32 = 1 << 1;
+const HPRT_ENA: u32 = 1 << 2;
+const HPRT_ENA_CHG: u32 = 1 << 3;
+const HPRT_OVRCUR_CHG: u32 = 1 << 5;
+const HPRT_RST: u32 = 1 << 8;
+const HPRT_PWR: u32 = 1 << 12;
+const HPRT_SPD_SHIFT: u32 = 17;
+const HPRT_SPD_MASK: u32 = 0b11 << HPRT_SPD_SHIFT;
+const HPRT_W1C_MASK: u32 = HPRT_CONN_DET | HPRT_ENA | HPRT_ENA_CHG | HPRT_OVRCUR_CHG;
+
+const HCCHAR_CHENA: u32 = 1 << 31;
+const HCCHAR_CHDIS: u32 = 1 << 30;
+const HCCHAR_ODDFRM: u32 = 1 << 29;
+const HCCHAR_EPDIR: u32 = 1 << 15;
+const HCINT_XFERCOMPL: u32 = 1 << 0;
+const HCINT_CHHLTD: u32 = 1 << 1;
+const HCINT_AHBERR: u32 = 1 << 2;
+const HCINT_STALL: u32 = 1 << 3;
+const HCINT_NAK: u32 = 1 << 4;
+const HCINT_XACTERR: u32 = 1 << 7;
+const HCINT_BBLERR: u32 = 1 << 8;
+const HCINT_FRMOVRN: u32 = 1 << 9;
+const HCINT_DATATGLERR: u32 = 1 << 10;
+const HCINT_ALL_W1C: u32 = 0x7ff;
+const HCINT_TRANSFER_MASK: u32 = HCINT_XFERCOMPL
+    | HCINT_CHHLTD
+    | HCINT_AHBERR
+    | HCINT_STALL
+    | HCINT_NAK
+    | HCINT_XACTERR
+    | HCINT_BBLERR
+    | HCINT_FRMOVRN
+    | HCINT_DATATGLERR;
+
+const HCTSIZ_XFERSIZE_MASK: u32 = 0x7ffff;
+const HCTSIZ_MAX_PACKETS: u32 = 1023;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dwc2UtmiWidth {
+    Eight,
+    Sixteen,
+    Auto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Dwc2FifoSizes {
+    pub rx_depth: u16,
+    pub non_periodic_tx_depth: u16,
+    pub periodic_tx_depth: u16,
+}
+
+impl Dwc2FifoSizes {
+    pub const fn sg2002_default() -> Self {
+        Self {
+            rx_depth: 536,
+            non_periodic_tx_depth: 32,
+            periodic_tx_depth: 768,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Dwc2Quirks {
+    pub otg_host_session_override: bool,
+    pub clear_utmi_override: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Dwc2HostParams {
+    pub dma_mask: u64,
+    pub fifo: Dwc2FifoSizes,
+    pub utmi: Dwc2UtmiWidth,
+    pub quirks: Dwc2Quirks,
+}
+
+impl Dwc2HostParams {
+    pub const fn sg2002() -> Self {
+        Self {
+            dma_mask: DWC2_DMA_MASK_32,
+            fifo: Dwc2FifoSizes::sg2002_default(),
+            utmi: Dwc2UtmiWidth::Auto,
+            quirks: Dwc2Quirks {
+                otg_host_session_override: true,
+                clear_utmi_override: true,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Dwc2NewParams {
+    pub mmio: Mmio,
+    pub kernel: &'static dyn KernelOp,
+    pub params: Dwc2HostParams,
+}
+
+#[derive(Clone, Copy)]
+struct Dwc2Registers {
+    base: NonNull<u8>,
+}
+
+unsafe impl Send for Dwc2Registers {}
+unsafe impl Sync for Dwc2Registers {}
+
+impl Dwc2Registers {
+    fn new(base: Mmio) -> Self {
+        Self { base }
+    }
+
+    fn read32(self, offset: usize) -> u32 {
+        unsafe { (self.base.as_ptr().add(offset) as *const u32).read_volatile() }
+    }
+
+    fn write32(self, offset: usize, value: u32) {
+        unsafe { (self.base.as_ptr().add(offset) as *mut u32).write_volatile(value) }
+    }
+
+    fn update32(self, offset: usize, f: impl FnOnce(u32) -> u32) {
+        let value = self.read32(offset);
+        self.write32(offset, f(value));
+    }
+
+    fn channel_offset(channel: u8, reg: usize) -> usize {
+        HC_BASE + usize::from(channel) * HC_STRIDE + reg
+    }
+
+    fn channel_read32(self, channel: u8, reg: usize) -> u32 {
+        self.read32(Self::channel_offset(channel, reg))
+    }
+
+    fn channel_write32(self, channel: u8, reg: usize, value: u32) {
+        self.write32(Self::channel_offset(channel, reg), value);
+    }
+
+    fn host_channel_count(self) -> u8 {
+        ((((self.read32(GHWCFG2) >> 14) & 0x0f) + 1) as u8).clamp(2, DWC2_MAX_CHANNELS)
+    }
+
+    fn hprt_status(self) -> Dwc2PortStatus {
+        Dwc2PortStatus::from_raw(self.read32(HPRT0))
+    }
+
+    fn hprt_write_safe(self, value: u32) {
+        self.write32(HPRT0, Dwc2PortStatus::from_raw(value).rmw_preserving_w1c());
+    }
+
+    fn hprt_update_safe(self, f: impl FnOnce(u32) -> u32) {
+        let value = self.read32(HPRT0) & !HPRT_W1C_MASK;
+        self.write32(HPRT0, f(value) & !HPRT_W1C_MASK);
+    }
+
+    fn clear_hprt_connect_detect(self) {
+        let current = self.read32(HPRT0);
+        if current & HPRT_CONN_DET != 0 {
+            self.write32(HPRT0, (current & !HPRT_W1C_MASK) | HPRT_CONN_DET);
+        }
+    }
+
+    fn periodic_odd_frame_bit(self) -> u32 {
+        if self.read32(HFNUM) & 1 == 0 {
+            HCCHAR_ODDFRM
+        } else {
+            0
+        }
+    }
+}
+
+#[derive(Clone)]
+struct TransferWakeups {
+    count: Arc<AtomicUsize>,
+}
+
+impl TransferWakeups {
+    fn new() -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn notify(&self) {
+        self.count.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn take(&self) -> usize {
+        self.count.swap(0, Ordering::AcqRel)
+    }
+}
+
+pub struct Dwc2 {
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    params: Dwc2HostParams,
+    root_hub: Option<Dwc2RootHub>,
+    event_handler: Option<Dwc2EventHandler>,
+    next_addr: u8,
+    channel_count: u8,
+    transfer_gate: Arc<Mutex<()>>,
+}
+
+unsafe impl Send for Dwc2 {}
+unsafe impl Sync for Dwc2 {}
+
+impl Dwc2 {
+    pub fn new(params: Dwc2NewParams) -> Result<Self> {
+        if params.params.dma_mask != DWC2_DMA_MASK_32 {
+            return Err(USBError::NotSupported);
+        }
+
+        let regs = Dwc2Registers::new(params.mmio);
+        let kernel = Kernel::new(params.params.dma_mask, params.kernel);
+        let wakeups = TransferWakeups::new();
+        let root_hub = Dwc2RootHub::new(regs, kernel.clone());
+        let event_handler = Dwc2EventHandler::new(regs, wakeups);
+
+        Ok(Self {
+            regs,
+            kernel,
+            params: params.params,
+            root_hub: Some(root_hub),
+            event_handler: Some(event_handler),
+            next_addr: 1,
+            channel_count: regs.host_channel_count(),
+            transfer_gate: Arc::new(Mutex::new(())),
+        })
+    }
+
+    async fn init_controller(&mut self) -> Result<()> {
+        self.disable_irq()?;
+        self.regs.write32(GINTSTS, u32::MAX);
+        self.core_soft_reset()?;
+        self.force_host_mode()?;
+        self.core_soft_reset()?;
+
+        if self.params.quirks.otg_host_session_override {
+            self.regs.update32(GOTGCTL, |value| {
+                value
+                    | GOTGCTL_DBNCE_FLTR_BYPASS
+                    | GOTGCTL_AVALOEN
+                    | GOTGCTL_AVALOVAL
+                    | GOTGCTL_VBVALOEN
+                    | GOTGCTL_VBVALOVAL
+            });
+            self.kernel.delay(Duration::from_micros(200));
+        }
+
+        self.init_gusbcfg();
+        self.regs.write32(PCGCTL, 0);
+
+        let arch = (self.regs.read32(GHWCFG2) >> 3) & 0b11;
+        let gahbcfg = build_gahbcfg_internal_dma(arch)?;
+        self.regs.write32(GAHBCFG, gahbcfg);
+
+        self.regs.update32(HCFG, |value| value & !0x7);
+
+        let fifo = fifo_register_plan(self.params.fifo);
+        self.regs.write32(GRXFSIZ, fifo.grxfsiz);
+        self.regs.write32(GNPTXFSIZ, fifo.gnptxfsiz);
+        self.regs.write32(HPTXFSIZ, fifo.hptxfsiz);
+        self.flush_tx_fifo_all()?;
+        self.flush_rx_fifo()?;
+
+        self.channel_count = self.regs.host_channel_count();
+        let channel_mask = if self.channel_count >= 16 {
+            u16::MAX as u32
+        } else {
+            (1u32 << self.channel_count) - 1
+        };
+        self.regs.write32(HAINTMSK, channel_mask);
+        self.regs.write32(
+            GINTMSK,
+            GINTSTS_PRTINT | GINTSTS_HCHINT | GINTSTS_DISCONNINT,
+        );
+        self.regs.write32(GINTSTS, u32::MAX);
+        self.port_power_on();
+        self.kernel.delay(Duration::from_millis(20));
+        Ok(())
+    }
+
+    fn init_gusbcfg(&self) {
+        let want_16bit = match self.params.utmi {
+            Dwc2UtmiWidth::Eight => false,
+            Dwc2UtmiWidth::Sixteen => true,
+            Dwc2UtmiWidth::Auto => ((self.regs.read32(GHWCFG4) >> 14) & 0b11) == 1,
+        };
+
+        self.regs.update32(GUSBCFG, |mut value| {
+            value &= !(GUSBCFG_TOUTCAL_MASK
+                | GUSBCFG_PHYIF16
+                | GUSBCFG_ULPI_UTMI_SEL
+                | GUSBCFG_FORCEDEVMODE);
+            value |= GUSBCFG_FORCEHOSTMODE | 0x7;
+            if want_16bit {
+                value |= GUSBCFG_PHYIF16;
+            }
+            value
+        });
+    }
+
+    fn wait_until(&self, ready: impl Fn() -> bool) -> Result<()> {
+        for _ in 0..DWC2_WAIT_ITERS {
+            if ready() {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(USBError::Timeout)
+    }
+
+    fn wait_ahb_idle(&self) -> Result<()> {
+        self.wait_until(|| self.regs.read32(GRSTCTL) & GRSTCTL_AHBIDLE != 0)
+    }
+
+    fn core_soft_reset(&self) -> Result<()> {
+        self.wait_ahb_idle()?;
+        self.regs.update32(GRSTCTL, |value| value | GRSTCTL_CSFTRST);
+        self.wait_until(|| {
+            let value = self.regs.read32(GRSTCTL);
+            value & GRSTCTL_CSFTRST == 0 || value & GRSTCTL_CSFTRST_DONE != 0
+        })?;
+        if self.regs.read32(GRSTCTL) & GRSTCTL_CSFTRST_DONE != 0 {
+            self.regs.update32(GRSTCTL, |value| {
+                (value & !GRSTCTL_CSFTRST) | GRSTCTL_CSFTRST_DONE
+            });
+        }
+        self.kernel.delay(Duration::from_millis(1));
+        Ok(())
+    }
+
+    fn force_host_mode(&self) -> Result<()> {
+        self.regs.update32(GUSBCFG, |value| {
+            (value | GUSBCFG_FORCEHOSTMODE) & !GUSBCFG_FORCEDEVMODE
+        });
+        self.kernel.delay(Duration::from_millis(25));
+        self.wait_until(|| self.regs.read32(GINTSTS) & GINTSTS_CURMODE_HOST != 0)
+    }
+
+    fn flush_tx_fifo_all(&self) -> Result<()> {
+        self.regs
+            .write32(GRSTCTL, GRSTCTL_TXFFLSH | GRSTCTL_TXFNUM_ALL);
+        self.wait_until(|| self.regs.read32(GRSTCTL) & GRSTCTL_TXFFLSH == 0)
+    }
+
+    fn flush_rx_fifo(&self) -> Result<()> {
+        self.regs.write32(GRSTCTL, GRSTCTL_RXFFLSH);
+        self.wait_until(|| self.regs.read32(GRSTCTL) & GRSTCTL_RXFFLSH == 0)
+    }
+
+    fn port_power_on(&self) {
+        self.regs.hprt_update_safe(|value| value | HPRT_PWR);
+    }
+
+    fn allocate_address(&mut self) -> Result<u8> {
+        if self.next_addr >= 128 {
+            return Err(USBError::SlotLimitReached);
+        }
+        let addr = self.next_addr;
+        self.next_addr += 1;
+        Ok(addr)
+    }
+
+    async fn new_device(&mut self, info: DeviceAddressInfo) -> Result<Box<dyn DeviceOp>> {
+        let addr = self.allocate_address()?;
+        let mut device = Dwc2Device::new(
+            addr,
+            self.regs,
+            self.kernel.clone(),
+            info.port_speed,
+            self.channel_count,
+            self.transfer_gate.clone(),
+        )?;
+        device.init().await?;
+        Ok(Box::new(device))
+    }
+}
+
+impl CoreOp for Dwc2 {
+    fn init<'a>(&'a mut self) -> BoxFuture<'a, Result<()>> {
+        self.init_controller().boxed()
+    }
+
+    fn root_hub(&mut self) -> Box<dyn HubOp> {
+        Box::new(
+            self.root_hub
+                .take()
+                .expect("DWC2 root hub can only be taken once"),
+        )
+    }
+
+    fn new_addressed_device<'a>(
+        &'a mut self,
+        addr: DeviceAddressInfo,
+    ) -> BoxFuture<'a, Result<Box<dyn DeviceOp>>> {
+        self.new_device(addr).boxed()
+    }
+
+    fn create_event_handler(&mut self) -> Box<dyn EventHandlerOp> {
+        Box::new(
+            self.event_handler
+                .take()
+                .expect("DWC2 event handler can only be created once"),
+        )
+    }
+
+    fn enable_irq(&mut self) -> Result<()> {
+        self.regs.write32(
+            GINTMSK,
+            GINTSTS_PRTINT | GINTSTS_HCHINT | GINTSTS_DISCONNINT,
+        );
+        Ok(())
+    }
+
+    fn disable_irq(&mut self) -> Result<()> {
+        self.regs.write32(GINTMSK, 0);
+        Ok(())
+    }
+
+    fn kernel(&self) -> &Kernel {
+        &self.kernel
+    }
+}
+
+struct Dwc2RootHub {
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    port: PortState,
+    last_logged_hprt: Option<u32>,
+}
+
+unsafe impl Send for Dwc2RootHub {}
+
+impl Dwc2RootHub {
+    fn new(regs: Dwc2Registers, kernel: Kernel) -> Self {
+        Self {
+            regs,
+            kernel,
+            port: PortState::Uninit,
+            last_logged_hprt: None,
+        }
+    }
+
+    async fn init_port(&mut self, mut info: HubInfo) -> Result<HubInfo> {
+        info.speed = Speed::High;
+        self.regs.hprt_update_safe(|value| value | HPRT_PWR);
+        self.kernel.delay(Duration::from_millis(20));
+        Ok(info)
+    }
+
+    async fn changed_ports_inner(&mut self) -> Result<Vec<PortChangeInfo>> {
+        if matches!(self.port, PortState::Probed) {
+            return Ok(Vec::new());
+        }
+
+        let mut status = self.regs.hprt_status();
+        self.log_port_status("scan", status);
+        if !status.connected() {
+            return Ok(Vec::new());
+        }
+
+        if matches!(self.port, PortState::Uninit) {
+            self.reset_port();
+            self.port = PortState::Reseted;
+            status = self.regs.hprt_status();
+            self.log_port_status("reset", status);
+        }
+
+        if status.connected() && status.enabled() {
+            self.port = PortState::Probed;
+            Ok(vec![PortChangeInfo {
+                root_port_id: 1,
+                port_id: 1,
+                port_speed: status.speed(),
+                tt_port_on_hub: None,
+            }])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    fn reset_port(&self) {
+        self.regs.clear_hprt_connect_detect();
+        self.regs
+            .hprt_write_safe((self.regs.read32(HPRT0) & !HPRT_W1C_MASK) | HPRT_PWR | HPRT_RST);
+        self.kernel.delay(Duration::from_millis(60));
+        self.regs
+            .hprt_write_safe(((self.regs.read32(HPRT0) & !HPRT_W1C_MASK) | HPRT_PWR) & !HPRT_RST);
+        self.kernel.delay(Duration::from_millis(80));
+    }
+
+    fn log_port_status(&mut self, phase: &str, status: Dwc2PortStatus) {
+        if self.last_logged_hprt == Some(status.raw()) {
+            return;
+        }
+        self.last_logged_hprt = Some(status.raw());
+        log::info!(
+            "dwc2: root port {phase} hprt0={:#010x} connected={} enabled={} speed={:?}",
+            status.raw(),
+            status.connected(),
+            status.enabled(),
+            status.speed()
+        );
+    }
+}
+
+impl HubOp for Dwc2RootHub {
+    fn init<'a>(&'a mut self, info: HubInfo) -> BoxFuture<'a, Result<HubInfo>> {
+        self.init_port(info).boxed()
+    }
+
+    fn changed_ports<'a>(&'a mut self) -> BoxFuture<'a, Result<Vec<PortChangeInfo>>> {
+        self.changed_ports_inner().boxed()
+    }
+
+    fn slot_id(&self) -> u8 {
+        0
+    }
+}
+
+struct Dwc2EventHandler {
+    regs: Dwc2Registers,
+    wakeups: TransferWakeups,
+}
+
+unsafe impl Send for Dwc2EventHandler {}
+unsafe impl Sync for Dwc2EventHandler {}
+
+impl Dwc2EventHandler {
+    fn new(regs: Dwc2Registers, wakeups: TransferWakeups) -> Self {
+        Self { regs, wakeups }
+    }
+}
+
+impl EventHandlerOp for Dwc2EventHandler {
+    fn handle_event(&self) -> Event {
+        let pending = self.regs.read32(GINTSTS)
+            & self.regs.read32(GINTMSK)
+            & (GINTSTS_PRTINT | GINTSTS_HCHINT | GINTSTS_DISCONNINT);
+        if pending == 0 {
+            return Event::Nothing;
+        }
+
+        self.regs.write32(GINTSTS, pending);
+        if pending & GINTSTS_PRTINT != 0 {
+            return Event::PortChange { port: 1 };
+        }
+        if pending & GINTSTS_HCHINT != 0 {
+            self.wakeups.notify();
+            return Event::TransferActivity {
+                count: self.wakeups.take().max(1),
+            };
+        }
+        Event::Stopped
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Dwc2PortStatus(u32);
+
+impl Dwc2PortStatus {
+    const fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    const fn connected(self) -> bool {
+        self.0 & HPRT_CONN_STS != 0
+    }
+
+    const fn raw(self) -> u32 {
+        self.0
+    }
+
+    const fn enabled(self) -> bool {
+        self.0 & HPRT_ENA != 0
+    }
+
+    fn speed(self) -> Speed {
+        match (self.0 & HPRT_SPD_MASK) >> HPRT_SPD_SHIFT {
+            0 => Speed::High,
+            2 => Speed::Low,
+            _ => Speed::Full,
+        }
+    }
+
+    const fn rmw_preserving_w1c(self) -> u32 {
+        self.0 & !HPRT_W1C_MASK
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Dwc2Pid {
+    Data0,
+    Data1,
+    Setup,
+}
+
+impl Dwc2Pid {
+    const fn bits(self) -> u32 {
+        match self {
+            Self::Data0 => 0,
+            Self::Data1 => 2,
+            Self::Setup => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Dwc2EpType {
+    Control,
+    Bulk,
+    Interrupt,
+}
+
+impl Dwc2EpType {
+    const fn bits(self) -> u32 {
+        match self {
+            Self::Control => 0,
+            Self::Bulk => 2,
+            Self::Interrupt => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Dwc2TransferStage {
+    pub(crate) hcchar: u32,
+    pub(crate) hctsiz: u32,
+    pub(crate) dma_addr: u32,
+    pub(crate) len: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Dwc2ControlPlan {
+    pub(crate) setup: Dwc2TransferStage,
+    pub(crate) data: Vec<Dwc2TransferStage>,
+    pub(crate) status: Dwc2TransferStage,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FifoRegisterPlan {
+    pub(crate) grxfsiz: u32,
+    pub(crate) gnptxfsiz: u32,
+    pub(crate) hptxfsiz: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Dwc2TransferFault {
+    Nak,
+    Stall,
+    Ahb,
+    Xact,
+    Babble,
+    FrameOverrun,
+    DataToggle,
+    HaltedWithoutComplete,
+}
+
+pub(crate) fn build_gahbcfg_internal_dma(arch: u32) -> core::result::Result<u32, USBError> {
+    if arch != 2 {
+        return Err(USBError::NotSupported);
+    }
+    Ok((1 << 0) | (7 << 1) | (1 << 5))
+}
+
+pub(crate) fn fifo_register_plan(fifo: Dwc2FifoSizes) -> FifoRegisterPlan {
+    let rx = u32::from(fifo.rx_depth);
+    let nptx = u32::from(fifo.non_periodic_tx_depth);
+    let ptx = u32::from(fifo.periodic_tx_depth);
+    FifoRegisterPlan {
+        grxfsiz: rx,
+        gnptxfsiz: (nptx << 16) | rx,
+        hptxfsiz: (ptx << 16) | (rx + nptx),
+    }
+}
+
+fn hctsiz(pid: Dwc2Pid, packet_count: u32, len: u32) -> u32 {
+    ((pid.bits() & 0b11) << 29)
+        | ((packet_count.min(HCTSIZ_MAX_PACKETS) & 0x03ff) << 19)
+        | (len & HCTSIZ_XFERSIZE_MASK)
+}
+
+fn hcchar(
+    device: u8,
+    endpoint: u8,
+    direction: Direction,
+    ep_type: Dwc2EpType,
+    max_packet_size: u16,
+    low_speed: bool,
+) -> u32 {
+    let mut value = u32::from(max_packet_size.max(1)) & 0x7ff;
+    value |= (u32::from(endpoint) & 0x0f) << 11;
+    value |= (direction as u32) << 15;
+    if low_speed {
+        value |= 1 << 17;
+    }
+    value |= ep_type.bits() << 18;
+    value |= (u32::from(device) & 0x7f) << 22;
+    value
+}
+
+fn stage_actual_length(stage: Dwc2TransferStage, hctsiz_after: u32) -> usize {
+    if stage.len == 0 {
+        return 0;
+    }
+    if stage.hcchar & HCCHAR_EPDIR == 0 {
+        return stage.len;
+    }
+
+    let remaining = (hctsiz_after & HCTSIZ_XFERSIZE_MASK) as usize;
+    stage.len.saturating_sub(remaining)
+}
+
+pub(crate) fn build_control_plan(
+    request: &TransferRequest,
+    device: u8,
+    max_packet_size: u16,
+    setup_dma: u32,
+    data_dma: u32,
+) -> core::result::Result<Dwc2ControlPlan, TransferError> {
+    let TransferRequest::Control {
+        direction, buffer, ..
+    } = request
+    else {
+        return Err(TransferError::InvalidEndpoint);
+    };
+
+    let data_len = buffer.map(|buffer| buffer.len).unwrap_or(0);
+    let setup = Dwc2TransferStage {
+        hcchar: hcchar(
+            device,
+            0,
+            Direction::Out,
+            Dwc2EpType::Control,
+            max_packet_size,
+            false,
+        ),
+        hctsiz: hctsiz(Dwc2Pid::Setup, 1, 8),
+        dma_addr: setup_dma,
+        len: 8,
+    };
+
+    let mut data = Vec::new();
+    if data_len > 0 {
+        let mut offset = 0usize;
+        let mut toggle = DataToggle::data1();
+        for len in split_dma_lengths(data_len, max_packet_size) {
+            let packets = packet_count(len, max_packet_size);
+            data.push(Dwc2TransferStage {
+                hcchar: hcchar(
+                    device,
+                    0,
+                    *direction,
+                    Dwc2EpType::Control,
+                    max_packet_size,
+                    false,
+                ),
+                hctsiz: hctsiz(toggle.pid(), packets, len as u32),
+                dma_addr: data_dma.wrapping_add(offset as u32),
+                len,
+            });
+            toggle.advance(packets);
+            offset += len;
+        }
+    }
+
+    let status_direction = if data_len > 0 {
+        match direction {
+            Direction::In => Direction::Out,
+            Direction::Out => Direction::In,
+        }
+    } else {
+        Direction::In
+    };
+    let status = Dwc2TransferStage {
+        hcchar: hcchar(
+            device,
+            0,
+            status_direction,
+            Dwc2EpType::Control,
+            max_packet_size,
+            false,
+        ),
+        hctsiz: hctsiz(Dwc2Pid::Data1, 1, 0),
+        dma_addr: setup_dma,
+        len: 0,
+    };
+    Ok(Dwc2ControlPlan {
+        setup,
+        data,
+        status,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DataToggle(bool);
+
+impl DataToggle {
+    pub(crate) const fn data0() -> Self {
+        Self(false)
+    }
+
+    pub(crate) const fn data1() -> Self {
+        Self(true)
+    }
+
+    pub(crate) fn pid(self) -> Dwc2Pid {
+        if self.0 {
+            Dwc2Pid::Data1
+        } else {
+            Dwc2Pid::Data0
+        }
+    }
+
+    pub(crate) fn advance(&mut self, packet_count: u32) {
+        if packet_count % 2 == 1 {
+            self.0 = !self.0;
+        }
+    }
+}
+
+fn packet_count(len: usize, max_packet_size: u16) -> u32 {
+    if len == 0 {
+        return 1;
+    }
+    let max_packet_size = u32::from(max_packet_size.max(1));
+    (len as u32).div_ceil(max_packet_size)
+}
+
+fn split_dma_lengths(len: usize, max_packet_size: u16) -> Vec<usize> {
+    if len == 0 {
+        return vec![0];
+    }
+
+    let max_packet_size = usize::from(max_packet_size.max(1));
+    let max_by_packets = max_packet_size * HCTSIZ_MAX_PACKETS as usize;
+    let max_len = max_by_packets.min(HCTSIZ_XFERSIZE_MASK as usize).max(1);
+    let mut left = len;
+    let mut out = Vec::new();
+    while left > 0 {
+        let chunk = left.min(max_len);
+        out.push(chunk);
+        left -= chunk;
+    }
+    out
+}
+
+fn hcint_fault(bits: u32) -> Option<Dwc2TransferFault> {
+    if bits & HCINT_STALL != 0 {
+        Some(Dwc2TransferFault::Stall)
+    } else if bits & HCINT_NAK != 0 {
+        Some(Dwc2TransferFault::Nak)
+    } else if bits & HCINT_AHBERR != 0 {
+        Some(Dwc2TransferFault::Ahb)
+    } else if bits & HCINT_XACTERR != 0 {
+        Some(Dwc2TransferFault::Xact)
+    } else if bits & HCINT_BBLERR != 0 {
+        Some(Dwc2TransferFault::Babble)
+    } else if bits & HCINT_FRMOVRN != 0 {
+        Some(Dwc2TransferFault::FrameOverrun)
+    } else if bits & HCINT_DATATGLERR != 0 {
+        Some(Dwc2TransferFault::DataToggle)
+    } else if bits & HCINT_XFERCOMPL == 0 {
+        Some(Dwc2TransferFault::HaltedWithoutComplete)
+    } else {
+        None
+    }
+}
+
+fn fault_to_transfer_error(fault: Dwc2TransferFault, hcint: u32) -> TransferError {
+    match fault {
+        Dwc2TransferFault::Stall => TransferError::Stall,
+        Dwc2TransferFault::Nak => TransferError::Other(anyhow!("DWC2 transfer NAK")),
+        Dwc2TransferFault::Ahb => TransferError::Other(anyhow!("DWC2 AHB error hcint={hcint:#x}")),
+        Dwc2TransferFault::Xact => {
+            TransferError::Other(anyhow!("DWC2 transaction error hcint={hcint:#x}"))
+        }
+        Dwc2TransferFault::Babble => {
+            TransferError::Other(anyhow!("DWC2 babble error hcint={hcint:#x}"))
+        }
+        Dwc2TransferFault::FrameOverrun => {
+            TransferError::Other(anyhow!("DWC2 frame overrun hcint={hcint:#x}"))
+        }
+        Dwc2TransferFault::DataToggle => {
+            TransferError::Other(anyhow!("DWC2 data toggle error hcint={hcint:#x}"))
+        }
+        Dwc2TransferFault::HaltedWithoutComplete => {
+            TransferError::Other(anyhow!("DWC2 halted without completion hcint={hcint:#x}"))
+        }
+    }
+}
+
+fn usb_to_transfer_error(err: USBError) -> TransferError {
+    match err {
+        USBError::Timeout => TransferError::Timeout,
+        USBError::TransferError(err) => err,
+        USBError::NotSupported => TransferError::NotSupported,
+        USBError::NoMemory => TransferError::Other(anyhow!("DWC2 DMA allocation failed")),
+        USBError::NotFound | USBError::InvalidParameter => TransferError::InvalidEndpoint,
+        err => TransferError::Other(anyhow!("DWC2 transfer failed: {err}")),
+    }
+}
+
+fn endpoint_number(address: u8) -> u8 {
+    address & 0x0f
+}
+
+fn endpoint_type_to_dwc2(ty: EndpointType) -> Result<Dwc2EpType> {
+    match ty {
+        EndpointType::Control => Ok(Dwc2EpType::Control),
+        EndpointType::Bulk => Ok(Dwc2EpType::Bulk),
+        EndpointType::Interrupt => Ok(Dwc2EpType::Interrupt),
+        EndpointType::Isochronous => Err(USBError::NotSupported),
+    }
+}
+
+fn dma_addr32(addr: u64) -> core::result::Result<u32, TransferError> {
+    u32::try_from(addr)
+        .map_err(|_| TransferError::Other(anyhow!("DWC2 DMA address above 32-bit mask: {addr:#x}")))
+}
+
+fn setup_packet_bytes(setup: &ControlSetup, direction: Direction, len: usize) -> [u8; 8] {
+    let request_type = BmRequestType::new(direction, setup.request_type, setup.recipient);
+    let value = setup.value.to_le_bytes();
+    let index = setup.index.to_le_bytes();
+    let len = (len as u16).to_le_bytes();
+    [
+        request_type.into(),
+        setup.request.into(),
+        value[0],
+        value[1],
+        index[0],
+        index[1],
+        len[0],
+        len[1],
+    ]
+}
+
+struct Dwc2DmaBuffer {
+    direction: Direction,
+    request_buffer: Option<(NonNull<u8>, usize)>,
+    coherent: Option<CoherentArray<u8>>,
+}
+
+impl Dwc2DmaBuffer {
+    fn new(
+        kernel: &Kernel,
+        request: &TransferRequest,
+    ) -> core::result::Result<Self, TransferError> {
+        let direction = request.direction();
+        let request_buffer = request
+            .buffer()
+            .filter(|buffer| buffer.len > 0)
+            .map(|buffer| (buffer.ptr, buffer.len));
+        let coherent = if let Some((ptr, len)) = request_buffer {
+            let mut coherent = kernel
+                .coherent_array_zero_with_align::<u8>(len, DWC2_DMA_ALIGN)
+                .map_err(|err| {
+                    TransferError::Other(anyhow!("DWC2 coherent DMA allocation failed: {err}"))
+                })?;
+            if matches!(direction, Direction::Out) {
+                let data = unsafe { core::slice::from_raw_parts(ptr.as_ptr().cast_const(), len) };
+                coherent.copy_from_slice_cpu(data);
+            }
+            Some(coherent)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            direction,
+            request_buffer,
+            coherent,
+        })
+    }
+
+    fn buffer_len(&self) -> usize {
+        self.coherent.as_ref().map_or(0, CoherentArray::len)
+    }
+
+    fn dma_addr(&self) -> u64 {
+        self.coherent
+            .as_ref()
+            .map_or(0, |buffer| buffer.dma_addr().as_u64())
+    }
+
+    fn copy_in_to_request(&self, actual: usize) -> core::result::Result<(), TransferError> {
+        if !matches!(self.direction, Direction::In) || actual == 0 {
+            return Ok(());
+        }
+        let Some((ptr, len)) = self.request_buffer else {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 IN transfer completed without a request buffer"
+            )));
+        };
+        let Some(coherent) = self.coherent.as_ref() else {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 IN transfer completed without a coherent buffer"
+            )));
+        };
+        if actual > len || actual > coherent.len() {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 IN transfer actual length {actual} exceeds buffer len {len}"
+            )));
+        }
+
+        let dst = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), actual) };
+        dst.copy_from_slice(&coherent.as_slice_cpu()[..actual]);
+        Ok(())
+    }
+}
+
+struct Dwc2Device {
+    address: u8,
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    port_speed: Speed,
+    channel_count: u8,
+    transfer_gate: Arc<Mutex<()>>,
+    desc: DeviceDescriptor,
+    ctrl_ep: Endpoint,
+    config_desc: Vec<ConfigurationDescriptor>,
+    current_config_value: Option<u8>,
+    eps: BTreeMap<u8, Endpoint>,
+    ep_interfaces: BTreeMap<u8, u8>,
+}
+
+unsafe impl Send for Dwc2Device {}
+
+impl Dwc2Device {
+    fn new(
+        address: u8,
+        regs: Dwc2Registers,
+        kernel: Kernel,
+        port_speed: Speed,
+        channel_count: u8,
+        transfer_gate: Arc<Mutex<()>>,
+    ) -> Result<Self> {
+        let raw = Dwc2Endpoint::new(
+            regs,
+            kernel.clone(),
+            0,
+            port_speed,
+            0,
+            EndpointInfo::control(),
+            transfer_gate.clone(),
+        )?;
+        Ok(Self {
+            address,
+            regs,
+            kernel,
+            port_speed,
+            channel_count,
+            transfer_gate,
+            desc: unsafe { core::mem::zeroed() },
+            ctrl_ep: Endpoint::new(EndpointInfo::control(), raw),
+            config_desc: Vec::new(),
+            current_config_value: None,
+            eps: BTreeMap::new(),
+            ep_interfaces: BTreeMap::new(),
+        })
+    }
+
+    async fn init(&mut self) -> Result<()> {
+        let base = self.get_device_descriptor_base().await?;
+        self.set_address().await?;
+        self.ctrl_ep
+            .with_raw_mut::<Dwc2Endpoint, _>(|ep| ep.set_device_address(self.address));
+        self.ctrl_ep
+            .with_raw_mut::<Dwc2Endpoint, _>(|ep| ep.set_max_packet_size(base.max_packet_size_0));
+        self.kernel.delay(Duration::from_millis(10));
+
+        self.desc = self.ctrl_ep.get_device_descriptor().await?;
+        self.current_config_value = Some(self.ctrl_ep.get_configuration().await?);
+        for index in 0..self.desc.num_configurations {
+            let config = self.ctrl_ep.get_configuration_descriptor(index).await?;
+            self.config_desc.push(config);
+        }
+        if let Some(config) = self.config_desc.first() {
+            self.set_configuration_inner(config.configuration_value)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn get_device_descriptor_base(&mut self) -> Result<DeviceDescriptorBase> {
+        let mut data = [0u8; 8];
+        self.ctrl_ep
+            .get_descriptor(DescriptorType::DEVICE, 0, 0, &mut data)
+            .await?;
+        Ok(unsafe { (data.as_ptr() as *const DeviceDescriptorBase).read_unaligned() })
+    }
+
+    async fn set_address(&mut self) -> Result<()> {
+        self.ctrl_ep
+            .control_out(
+                ControlSetup {
+                    request_type: RequestType::Standard,
+                    recipient: Recipient::Device,
+                    request: Request::SetAddress,
+                    value: self.address as u16,
+                    index: 0,
+                },
+                &[],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn set_configuration_inner(&mut self, configuration_value: u8) -> Result<()> {
+        self.ctrl_ep.set_configuration(configuration_value).await?;
+        self.current_config_value = Some(configuration_value);
+        self.eps.clear();
+        self.ep_interfaces.clear();
+        Ok(())
+    }
+
+    async fn claim_interface_inner(&mut self, interface: u8, alternate: u8) -> Result<()> {
+        self.ctrl_ep
+            .control_out(
+                ControlSetup {
+                    request_type: RequestType::Standard,
+                    recipient: Recipient::Interface,
+                    request: Request::SetInterface,
+                    value: alternate as u16,
+                    index: interface as u16,
+                },
+                &[],
+            )
+            .await?;
+        self.setup_interface_endpoints(interface, alternate)?;
+        Ok(())
+    }
+
+    fn setup_interface_endpoints(&mut self, interface: u8, alternate: u8) -> Result<()> {
+        let endpoints = self
+            .find_interface_endpoints(interface, alternate)?
+            .to_vec();
+        for desc in endpoints {
+            if matches!(desc.transfer_type, EndpointType::Isochronous) {
+                warn!(
+                    "dwc2: isochronous endpoint {:#x} is not supported in v1",
+                    desc.address
+                );
+                continue;
+            }
+            let info = EndpointInfo::from(&desc);
+            let channel = self.channel_for_endpoint(info);
+            let raw = Dwc2Endpoint::new(
+                self.regs,
+                self.kernel.clone(),
+                self.address,
+                self.port_speed,
+                channel,
+                info,
+                self.transfer_gate.clone(),
+            )?;
+            self.eps.insert(desc.address, Endpoint::new(info, raw));
+            self.ep_interfaces.insert(desc.address, interface);
+        }
+        Ok(())
+    }
+
+    fn find_interface_endpoints(
+        &self,
+        interface: u8,
+        alternate: u8,
+    ) -> Result<&[EndpointDescriptor]> {
+        for config in &self.config_desc {
+            for iface in &config.interfaces {
+                if iface.interface_number != interface {
+                    continue;
+                }
+                for alt in &iface.alt_settings {
+                    if alt.alternate_setting == alternate {
+                        return Ok(&alt.endpoints);
+                    }
+                }
+            }
+        }
+        Err(USBError::NotFound)
+    }
+
+    fn channel_for_endpoint(&self, info: EndpointInfo) -> u8 {
+        if matches!(info.transfer_type, EndpointType::Control) {
+            return 0;
+        }
+        let available = self.channel_count.saturating_sub(1).max(1);
+        1 + ((endpoint_number(info.address.raw()).max(1) - 1) % available)
+    }
+}
+
+impl DeviceOp for Dwc2Device {
+    fn id(&self) -> usize {
+        self.address as usize
+    }
+
+    fn backend_name(&self) -> &str {
+        "dwc2"
+    }
+
+    fn descriptor(&self) -> &DeviceDescriptor {
+        &self.desc
+    }
+
+    fn configuration_descriptors(&self) -> &[ConfigurationDescriptor] {
+        &self.config_desc
+    }
+
+    fn ctrl_ep_ref(&self) -> &Endpoint {
+        &self.ctrl_ep
+    }
+
+    fn ctrl_ep_mut(&mut self) -> &mut Endpoint {
+        &mut self.ctrl_ep
+    }
+
+    fn claim_interface<'a>(
+        &'a mut self,
+        interface: u8,
+        alternate: u8,
+    ) -> BoxFuture<'a, Result<()>> {
+        self.claim_interface_inner(interface, alternate).boxed()
+    }
+
+    fn set_configuration<'a>(&'a mut self, configuration_value: u8) -> BoxFuture<'a, Result<()>> {
+        self.set_configuration_inner(configuration_value).boxed()
+    }
+
+    fn endpoint(&mut self, desc: &EndpointDescriptor) -> Result<Endpoint> {
+        self.eps.remove(&desc.address).ok_or(USBError::NotFound)
+    }
+
+    fn update_hub(&mut self, _params: HubParams) -> BoxFuture<'_, Result<()>> {
+        async { Ok(()) }.boxed()
+    }
+}
+
+struct Dwc2Endpoint {
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    device_address: u8,
+    port_speed: Speed,
+    channel: u8,
+    info: EndpointInfo,
+    transfer_gate: Arc<Mutex<()>>,
+    data_toggle: DataToggle,
+    next_request_id: u64,
+    completed: Option<(
+        RequestId,
+        core::result::Result<TransferCompletion, TransferError>,
+    )>,
+    waker: AtomicWaker,
+}
+
+unsafe impl Send for Dwc2Endpoint {}
+
+impl Dwc2Endpoint {
+    fn new(
+        regs: Dwc2Registers,
+        kernel: Kernel,
+        device_address: u8,
+        port_speed: Speed,
+        channel: u8,
+        info: EndpointInfo,
+        transfer_gate: Arc<Mutex<()>>,
+    ) -> Result<Self> {
+        endpoint_type_to_dwc2(info.transfer_type)?;
+        Ok(Self {
+            regs,
+            kernel,
+            device_address,
+            port_speed,
+            channel,
+            info,
+            transfer_gate,
+            data_toggle: DataToggle::data0(),
+            next_request_id: 1,
+            completed: None,
+            waker: AtomicWaker::new(),
+        })
+    }
+
+    fn set_device_address(&mut self, address: u8) {
+        self.device_address = address;
+    }
+
+    fn set_max_packet_size(&mut self, max_packet_size: u8) {
+        self.info.max_packet_size = u16::from(max_packet_size).max(8);
+    }
+
+    fn allocate_request_id(&mut self) -> RequestId {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
+        RequestId::new(id)
+    }
+
+    fn execute_request(
+        &mut self,
+        id: RequestId,
+        request: TransferRequest,
+    ) -> core::result::Result<TransferCompletion, TransferError> {
+        if matches!(request, TransferRequest::Isochronous { .. }) {
+            return Err(TransferError::NotSupported);
+        }
+
+        let transfer = Dwc2DmaBuffer::new(&self.kernel, &request)?;
+
+        let transfer_gate = self.transfer_gate.clone();
+        let _guard = transfer_gate.lock();
+        let actual_length = match &request {
+            TransferRequest::Control { .. } => self.execute_control(&request, &transfer)?,
+            TransferRequest::Bulk { .. } | TransferRequest::Interrupt { .. } => {
+                self.execute_data(&request, &transfer)?
+            }
+            TransferRequest::Isochronous { .. } => return Err(TransferError::NotSupported),
+        };
+
+        transfer.copy_in_to_request(actual_length)?;
+
+        Ok(TransferCompletion {
+            request_id: id,
+            status: TransferStatus::Completed,
+            actual_length,
+            iso_packets: Vec::new(),
+        })
+    }
+
+    fn execute_control(
+        &self,
+        request: &TransferRequest,
+        transfer: &Dwc2DmaBuffer,
+    ) -> core::result::Result<usize, TransferError> {
+        let TransferRequest::Control {
+            setup, direction, ..
+        } = request
+        else {
+            return Err(TransferError::InvalidEndpoint);
+        };
+
+        let mut setup_dma = self
+            .kernel
+            .coherent_box_zero_with_align::<[u8; 8]>(8)
+            .map_err(|err| {
+                TransferError::Other(anyhow!("DWC2 setup DMA allocation failed: {err}"))
+            })?;
+        setup_dma.write_cpu(setup_packet_bytes(setup, *direction, transfer.buffer_len()));
+        let setup_addr = dma_addr32(setup_dma.dma_addr().as_u64())?;
+        let data_addr = dma_addr32(transfer.dma_addr())?;
+        let plan = build_control_plan(
+            request,
+            self.device_address,
+            self.info.max_packet_size.max(8),
+            setup_addr,
+            data_addr,
+        )?;
+
+        self.execute_stage(self.channel, plan.setup, true)?;
+        let mut actual_length = 0usize;
+        for stage in plan.data {
+            actual_length += self.execute_stage(self.channel, stage, true)?;
+        }
+        self.execute_stage(self.channel, plan.status, true)?;
+        Ok(actual_length)
+    }
+
+    fn execute_data(
+        &mut self,
+        request: &TransferRequest,
+        transfer: &Dwc2DmaBuffer,
+    ) -> core::result::Result<usize, TransferError> {
+        let (direction, ep_type) = match request {
+            TransferRequest::Bulk { direction, .. } => (*direction, Dwc2EpType::Bulk),
+            TransferRequest::Interrupt { direction, .. } => (*direction, Dwc2EpType::Interrupt),
+            _ => return Err(TransferError::InvalidEndpoint),
+        };
+
+        let mps = self.info.max_packet_size.max(1);
+        let endpoint = endpoint_number(self.info.address.raw());
+        let mut actual_length = 0usize;
+        let mut offset = 0u64;
+        for len in split_dma_lengths(transfer.buffer_len(), mps) {
+            let packets = packet_count(len, mps);
+            let mut stage = Dwc2TransferStage {
+                hcchar: hcchar(
+                    self.device_address,
+                    endpoint,
+                    direction,
+                    ep_type,
+                    mps,
+                    matches!(self.port_speed, Speed::Low),
+                ),
+                hctsiz: hctsiz(self.data_toggle.pid(), packets, len as u32),
+                dma_addr: dma_addr32(transfer.dma_addr() + offset)?,
+                len,
+            };
+            if matches!(ep_type, Dwc2EpType::Interrupt) {
+                stage.hcchar |= self.regs.periodic_odd_frame_bit();
+            }
+            let actual = self.execute_stage(self.channel, stage, false)?;
+            actual_length += actual;
+            self.data_toggle
+                .advance(successful_packet_count(actual, len, mps));
+            offset += len as u64;
+            if matches!(direction, Direction::In) && actual < len {
+                break;
+            }
+        }
+        Ok(actual_length)
+    }
+
+    fn execute_stage(
+        &self,
+        channel: u8,
+        stage: Dwc2TransferStage,
+        retry_nak: bool,
+    ) -> core::result::Result<usize, TransferError> {
+        const NAK_RETRIES: u32 = 64;
+        const XACT_RETRIES: u32 = 8;
+
+        let mut nak_left = if retry_nak { NAK_RETRIES } else { 0 };
+        let mut xact_left = XACT_RETRIES;
+        loop {
+            self.wait_channel_disabled(channel)
+                .map_err(usb_to_transfer_error)?;
+            self.halt_channel(channel);
+            self.regs.channel_write32(channel, HCSPLT, 0);
+            self.regs.channel_write32(channel, HCINT, HCINT_ALL_W1C);
+            self.regs
+                .channel_write32(channel, HCINTMSK, HCINT_TRANSFER_MASK);
+            self.regs.channel_write32(channel, HCTSIZ, stage.hctsiz);
+            mb();
+            self.regs.channel_write32(channel, HCDMA, stage.dma_addr);
+            mb();
+            self.regs
+                .channel_write32(channel, HCCHAR, stage.hcchar | HCCHAR_CHENA);
+
+            let hcint = self
+                .wait_channel_halted(channel)
+                .map_err(usb_to_transfer_error)?;
+            if let Some(fault) = hcint_fault(hcint) {
+                match fault {
+                    Dwc2TransferFault::Nak if nak_left > 0 => {
+                        nak_left -= 1;
+                        self.kernel.delay(Duration::from_millis(1));
+                        continue;
+                    }
+                    Dwc2TransferFault::Xact if xact_left > 0 => {
+                        xact_left -= 1;
+                        self.kernel.delay(Duration::from_millis(1));
+                        continue;
+                    }
+                    _ => return Err(fault_to_transfer_error(fault, hcint)),
+                }
+            }
+
+            let hctsiz_after = self.regs.channel_read32(channel, HCTSIZ);
+            return Ok(stage_actual_length(stage, hctsiz_after));
+        }
+    }
+
+    fn wait_channel_disabled(&self, channel: u8) -> Result<()> {
+        for _ in 0..DWC2_CHANNEL_WAIT_ITERS {
+            if self.regs.channel_read32(channel, HCCHAR) & HCCHAR_CHENA == 0 {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(USBError::Timeout)
+    }
+
+    fn halt_channel(&self, channel: u8) {
+        let value = self.regs.channel_read32(channel, HCCHAR);
+        if value & HCCHAR_CHENA == 0 {
+            return;
+        }
+        self.regs
+            .channel_write32(channel, HCCHAR, value | HCCHAR_CHENA | HCCHAR_CHDIS);
+        for _ in 0..DWC2_WAIT_ITERS {
+            if self.regs.channel_read32(channel, HCCHAR) & HCCHAR_CHENA == 0 {
+                return;
+            }
+            core::hint::spin_loop();
+        }
+    }
+
+    fn wait_channel_halted(&self, channel: u8) -> Result<u32> {
+        for _ in 0..DWC2_CHANNEL_WAIT_ITERS {
+            let hcint = self.regs.channel_read32(channel, HCINT);
+            if hcint & HCINT_CHHLTD != 0 {
+                self.regs.channel_write32(channel, HCINT, hcint);
+                return Ok(hcint);
+            }
+            core::hint::spin_loop();
+        }
+        Err(USBError::Timeout)
+    }
+}
+
+impl crate::backend::ty::ep::EndpointOp for Dwc2Endpoint {
+    fn submit_request(
+        &mut self,
+        request: TransferRequest,
+    ) -> core::result::Result<RequestId, TransferError> {
+        if self.completed.is_some() {
+            return Err(TransferError::QueueFull);
+        }
+        let id = self.allocate_request_id();
+        let result = self.execute_request(id, request);
+        self.completed = Some((id, result));
+        self.waker.wake();
+        Ok(id)
+    }
+
+    fn reclaim_request(
+        &mut self,
+        id: RequestId,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        let (completed_id, _) = self.completed.as_ref()?;
+        if *completed_id != id {
+            return Some(Err(TransferError::InvalidEndpoint));
+        }
+        self.completed.take().map(|(_, result)| result)
+    }
+
+    fn register_waker(&self, _id: RequestId, cx: &mut Context<'_>) {
+        self.waker.register(cx.waker());
+        cx.waker().wake_by_ref();
+    }
+
+    fn cancel_request(&mut self, id: RequestId) -> core::result::Result<(), TransferError> {
+        let Some((completed_id, _)) = self.completed.as_ref() else {
+            return Err(TransferError::InvalidEndpoint);
+        };
+        if *completed_id != id {
+            return Err(TransferError::InvalidEndpoint);
+        }
+        self.completed = Some((id, Err(TransferError::Cancelled)));
+        self.waker.wake();
+        Ok(())
+    }
+}
+
+fn successful_packet_count(actual: usize, requested: usize, max_packet_size: u16) -> u32 {
+    if requested == 0 || actual == 0 {
+        1
+    } else {
+        packet_count(actual, max_packet_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::alloc::{alloc_zeroed, dealloc};
+    use core::{alloc::Layout, num::NonZeroUsize, ptr::NonNull};
+
+    use dma_api::{DmaAllocHandle, DmaConstraints, DmaDirection, DmaError, DmaMapHandle, DmaOp};
+    use usb_if::{
+        endpoint::TransferRequest,
+        host::{ControlSetup, hub::Speed},
+        transfer::{Direction, Recipient, Request, RequestType},
+    };
+
+    use super::{
+        DataToggle, Dwc2DmaBuffer, Dwc2EpType, Dwc2FifoSizes, Dwc2Pid, Dwc2PortStatus,
+        Dwc2TransferFault, Dwc2TransferStage, HCINT_AHBERR, HCINT_BBLERR, HCINT_NAK, HCINT_STALL,
+        HCINT_XACTERR, HPRT_CONN_DET, HPRT_CONN_STS, HPRT_ENA, HPRT_ENA_CHG, HPRT_OVRCUR_CHG,
+        build_control_plan, build_gahbcfg_internal_dma, fifo_register_plan, hcchar, hcint_fault,
+        hctsiz, packet_count, split_dma_lengths, stage_actual_length, successful_packet_count,
+    };
+    use crate::backend::kmod::osal::Kernel;
+
+    struct TestKernel;
+
+    impl DmaOp for TestKernel {
+        fn page_size(&self) -> usize {
+            4096
+        }
+
+        unsafe fn alloc_contiguous(
+            &self,
+            constraints: DmaConstraints,
+            layout: Layout,
+        ) -> Option<DmaAllocHandle> {
+            unsafe { self.alloc_coherent(constraints, layout) }
+        }
+
+        unsafe fn dealloc_contiguous(&self, handle: DmaAllocHandle) {
+            unsafe { self.dealloc_coherent(handle) }
+        }
+
+        unsafe fn alloc_coherent(
+            &self,
+            _constraints: DmaConstraints,
+            layout: Layout,
+        ) -> Option<DmaAllocHandle> {
+            let ptr = unsafe { alloc_zeroed(layout) };
+            let ptr = NonNull::new(ptr)?;
+            Some(unsafe { DmaAllocHandle::new(ptr, (ptr.as_ptr() as u64).into(), layout) })
+        }
+
+        unsafe fn dealloc_coherent(&self, handle: DmaAllocHandle) {
+            unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) }
+        }
+
+        unsafe fn map_streaming(
+            &self,
+            _constraints: DmaConstraints,
+            addr: NonNull<u8>,
+            size: NonZeroUsize,
+            _direction: DmaDirection,
+        ) -> core::result::Result<DmaMapHandle, DmaError> {
+            let layout = Layout::from_size_align(size.get(), 1)?;
+            Ok(unsafe { DmaMapHandle::new(addr, (addr.as_ptr() as u64).into(), layout, None) })
+        }
+
+        unsafe fn unmap_streaming(&self, _handle: DmaMapHandle) {}
+    }
+
+    impl super::KernelOp for TestKernel {
+        fn delay(&self, _duration: core::time::Duration) {}
+    }
+
+    static TEST_KERNEL: TestKernel = TestKernel;
+
+    const GAHBCFG_GLBL_INTR_EN: u32 = 1 << 0;
+    const GAHBCFG_HBSTLEN_INCR16: u32 = 7 << 1;
+    const GAHBCFG_DMA_EN: u32 = 1 << 5;
+
+    #[test]
+    fn gahbcfg_requires_internal_dma_and_enables_incr16() {
+        let value = build_gahbcfg_internal_dma(2).expect("internal DMA architecture is supported");
+
+        assert_eq!(
+            value & (GAHBCFG_GLBL_INTR_EN | GAHBCFG_HBSTLEN_INCR16 | GAHBCFG_DMA_EN),
+            GAHBCFG_GLBL_INTR_EN | GAHBCFG_HBSTLEN_INCR16 | GAHBCFG_DMA_EN
+        );
+        assert!(build_gahbcfg_internal_dma(1).is_err());
+    }
+
+    #[test]
+    fn fifo_register_plan_matches_sg2002_dtb_defaults() {
+        let plan = fifo_register_plan(Dwc2FifoSizes::sg2002_default());
+
+        assert_eq!(plan.grxfsiz, 536);
+        assert_eq!(plan.gnptxfsiz, (32 << 16) | 536);
+        assert_eq!(plan.hptxfsiz, (768 << 16) | (536 + 32));
+    }
+
+    #[test]
+    fn hctsiz_encodes_pid_packet_count_and_transfer_size() {
+        assert_eq!(hctsiz(Dwc2Pid::Setup, 1, 8), (3 << 29) | (1 << 19) | 8);
+        assert_eq!(
+            hctsiz(Dwc2Pid::Data1, 2, 1024),
+            (2 << 29) | (2 << 19) | 1024
+        );
+    }
+
+    #[test]
+    fn hcchar_encodes_control_bulk_and_interrupt_dma_channels() {
+        let control = hcchar(0, 0, Direction::Out, Dwc2EpType::Control, 64, false);
+        assert_eq!(control & 0x7ff, 64);
+        assert_eq!((control >> 18) & 0b11, 0);
+        assert_eq!((control >> 22) & 0x7f, 0);
+
+        let bulk_in = hcchar(5, 2, Direction::In, Dwc2EpType::Bulk, 512, false);
+        assert_eq!(bulk_in & 0x7ff, 512);
+        assert_eq!((bulk_in >> 11) & 0x0f, 2);
+        assert_eq!((bulk_in >> 15) & 1, 1);
+        assert_eq!((bulk_in >> 18) & 0b11, 2);
+        assert_eq!((bulk_in >> 22) & 0x7f, 5);
+
+        let interrupt_low = hcchar(3, 1, Direction::In, Dwc2EpType::Interrupt, 8, true);
+        assert_eq!((interrupt_low >> 17) & 1, 1);
+        assert_eq!((interrupt_low >> 18) & 0b11, 3);
+    }
+
+    #[test]
+    fn control_in_plan_uses_dma_for_setup_data_and_status() {
+        let mut data = [0u8; 18];
+        let request = TransferRequest::control_in(
+            ControlSetup {
+                request_type: RequestType::Standard,
+                recipient: Recipient::Device,
+                request: Request::GetDescriptor,
+                value: 0x0100,
+                index: 0,
+            },
+            &mut data,
+        );
+
+        let plan = build_control_plan(&request, 0, 64, 0x1000, 0x2000).unwrap();
+
+        assert_eq!(plan.setup.dma_addr, 0x1000);
+        assert_eq!(plan.setup.len, 8);
+        assert_eq!(plan.setup.hctsiz, hctsiz(Dwc2Pid::Setup, 1, 8));
+        let data = plan.data.first().expect("control IN has a data stage");
+        assert_eq!(data.dma_addr, 0x2000);
+        assert_eq!(data.hctsiz, hctsiz(Dwc2Pid::Data1, 1, 18));
+        assert_eq!((data.hcchar >> 15) & 1, 1);
+        assert_eq!(plan.status.dma_addr, 0x1000);
+        assert_eq!(plan.status.hctsiz, hctsiz(Dwc2Pid::Data1, 1, 0));
+        assert_eq!((plan.status.hcchar >> 15) & 1, 0);
+    }
+
+    #[test]
+    fn dma_buffer_bounces_in_data_through_coherent_memory() {
+        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
+        let mut data = [0u8; 4];
+        let request = TransferRequest::bulk_in(&mut data);
+        let mut dma = Dwc2DmaBuffer::new(&kernel, &request).unwrap();
+
+        assert_eq!(dma.buffer_len(), 4);
+        assert_ne!(dma.dma_addr(), data.as_ptr() as u64);
+        dma.coherent
+            .as_mut()
+            .unwrap()
+            .copy_from_slice_cpu(&[1, 2, 3, 4]);
+        dma.copy_in_to_request(3).unwrap();
+
+        assert_eq!(data, [1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn out_stage_completion_reports_requested_length() {
+        let stage = Dwc2TransferStage {
+            hcchar: hcchar(2, 2, Direction::Out, Dwc2EpType::Bulk, 512, false),
+            hctsiz: hctsiz(Dwc2Pid::Data0, 1, 31),
+            dma_addr: 0,
+            len: 31,
+        };
+
+        assert_eq!(
+            stage_actual_length(stage, hctsiz(Dwc2Pid::Data0, 1, 31)),
+            31
+        );
+
+        let in_stage = Dwc2TransferStage {
+            hcchar: hcchar(2, 1, Direction::In, Dwc2EpType::Bulk, 512, false),
+            hctsiz: hctsiz(Dwc2Pid::Data0, 1, 31),
+            dma_addr: 0,
+            len: 31,
+        };
+
+        assert_eq!(
+            stage_actual_length(in_stage, hctsiz(Dwc2Pid::Data0, 1, 13)),
+            18
+        );
+    }
+
+    #[test]
+    fn control_data_stage_splits_at_hctsiz_packet_limit_and_toggles_pid() {
+        let mut data = [0u8; 2048];
+        let request = TransferRequest::control_in(
+            ControlSetup {
+                request_type: RequestType::Standard,
+                recipient: Recipient::Device,
+                request: Request::GetDescriptor,
+                value: 0x0200,
+                index: 0,
+            },
+            &mut data,
+        );
+
+        let plan = build_control_plan(&request, 2, 8, 0x1000, 0x2000).unwrap();
+
+        assert_eq!(plan.data.len(), 1);
+        assert_eq!(plan.data[0].hctsiz >> 29, Dwc2Pid::Data1.bits());
+        assert_eq!(split_dma_lengths(8192, 8), [8184, 8]);
+    }
+
+    #[test]
+    fn data_toggle_advances_by_packet_count() {
+        let mut toggle = DataToggle::data0();
+
+        assert_eq!(toggle.pid(), Dwc2Pid::Data0);
+        toggle.advance(packet_count(512, 512));
+        assert_eq!(toggle.pid(), Dwc2Pid::Data1);
+        toggle.advance(packet_count(1024, 512));
+        assert_eq!(toggle.pid(), Dwc2Pid::Data1);
+        toggle.advance(packet_count(1, 512));
+        assert_eq!(toggle.pid(), Dwc2Pid::Data0);
+        assert_eq!(successful_packet_count(0, 64, 64), 1);
+    }
+
+    #[test]
+    fn hprt_status_decodes_speed_and_preserves_w1c_bits_for_rmw() {
+        let status = Dwc2PortStatus::from_raw(
+            HPRT_CONN_STS | HPRT_ENA | HPRT_CONN_DET | HPRT_ENA_CHG | HPRT_OVRCUR_CHG | (2 << 17),
+        );
+
+        assert!(status.connected());
+        assert!(status.enabled());
+        assert_eq!(status.speed(), Speed::Low);
+        assert_eq!(
+            status.rmw_preserving_w1c() & (HPRT_CONN_DET | HPRT_ENA | HPRT_ENA_CHG),
+            0
+        );
+    }
+
+    #[test]
+    fn hcint_fault_maps_nak_stall_xact_and_bus_errors() {
+        assert_eq!(hcint_fault(HCINT_NAK), Some(Dwc2TransferFault::Nak));
+        assert_eq!(hcint_fault(HCINT_STALL), Some(Dwc2TransferFault::Stall));
+        assert_eq!(hcint_fault(HCINT_XACTERR), Some(Dwc2TransferFault::Xact));
+        assert_eq!(hcint_fault(HCINT_AHBERR), Some(Dwc2TransferFault::Ahb));
+        assert_eq!(hcint_fault(HCINT_BBLERR), Some(Dwc2TransferFault::Babble));
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
@@ -200,7 +200,17 @@ struct Dwc2Registers {
     base: NonNull<u8>,
 }
 
+// SAFETY: `Dwc2Registers` is a copyable handle to a DWC2 MMIO mapping that is
+// owned by the platform USB host for the whole backend lifetime. The type does
+// not provide references into the mapping; all accesses are volatile 32-bit
+// loads/stores through private methods, and higher-level code serializes
+// channel programming with per-channel gates when concurrent task/IRQ paths can
+// touch the same channel registers.
 unsafe impl Send for Dwc2Registers {}
+// SAFETY: Shared references to this handle cannot create Rust aliasing to the
+// MMIO region because MMIO is only accessed by volatile operations. Register
+// ordering and channel-level races are handled by the DWC2 protocol code and
+// the per-channel gates/completion atomics rather than by Rust references.
 unsafe impl Sync for Dwc2Registers {}
 
 impl Dwc2Registers {
@@ -209,10 +219,18 @@ impl Dwc2Registers {
     }
 
     fn read32(self, offset: usize) -> u32 {
+        // SAFETY: `base` points at the live DWC2 register window supplied by the
+        // board glue. `Dwc2Registers` is private, and every caller passes either
+        // a constant register offset from this file or a channel offset computed
+        // from a bounded host-channel index. Volatile access is required for
+        // MMIO and does not create Rust references into the device memory.
         unsafe { (self.base.as_ptr().add(offset) as *const u32).read_volatile() }
     }
 
     fn write32(self, offset: usize, value: u32) {
+        // SAFETY: Same mapping and offset invariants as `read32`. The write is
+        // volatile because it programs hardware state; callers preserve W1C and
+        // read-modify-write semantics at the register-specific helper layer.
         unsafe { (self.base.as_ptr().add(offset) as *mut u32).write_volatile(value) }
     }
 
@@ -550,7 +568,15 @@ pub struct Dwc2 {
     stats: Dwc2Stats,
 }
 
+// SAFETY: `Dwc2` is moved into the kmod core as the unique owner of host state.
+// Public core operations require `&mut self`; the separately exposed IRQ handler
+// owns only cloned register/completion/stat handles. Shared state between the
+// task path and IRQ path is restricted to atomics, wakers, and per-channel gates.
 unsafe impl Send for Dwc2 {}
+// SAFETY: The only `&self` operations exposed by `Dwc2` read/reset atomic
+// statistics or return immutable kernel references. MMIO mutation remains behind
+// `&mut self` core methods or the IRQ handler, whose synchronization invariants
+// are documented on `Dwc2Registers` and `Dwc2EventHandler`.
 unsafe impl Sync for Dwc2 {}
 
 impl Dwc2 {
@@ -793,6 +819,9 @@ struct Dwc2RootHub {
     last_logged_hprt: Option<u32>,
 }
 
+// SAFETY: The root hub is driven by `HubOp` methods taking `&mut self`, so its
+// port state and cached log value are not concurrently mutated. MMIO access uses
+// the `Dwc2Registers` volatile-access invariants.
 unsafe impl Send for Dwc2RootHub {}
 
 impl Dwc2RootHub {
@@ -888,7 +917,15 @@ struct Dwc2EventHandler {
     stats: Dwc2Stats,
 }
 
+// SAFETY: The event handler may be registered on an IRQ path and moved between
+// runtimes. It contains no unsynchronized mutable Rust state: completions and
+// statistics are atomic, and register access is volatile through
+// `Dwc2Registers`.
 unsafe impl Send for Dwc2EventHandler {}
+// SAFETY: `handle_event` only uses `&self`. It acknowledges hardware IRQ bits
+// and publishes completions through atomics/wakers; channel programming races
+// with the task path are bounded by per-channel gates and DWC2 channel-halt
+// completion ordering.
 unsafe impl Sync for Dwc2EventHandler {}
 
 impl Dwc2EventHandler {
@@ -1353,6 +1390,18 @@ fn setup_packet_bytes(setup: &ControlSetup, direction: Direction, len: usize) ->
     ]
 }
 
+fn device_descriptor_base_from_bytes(data: [u8; 8]) -> DeviceDescriptorBase {
+    DeviceDescriptorBase {
+        length: data[0],
+        descriptor_type: data[1],
+        usb_version: u16::from_le_bytes([data[2], data[3]]),
+        class: data[4],
+        subclass: data[5],
+        protocol: data[6],
+        max_packet_size_0: data[7],
+    }
+}
+
 #[derive(Default)]
 struct Dwc2DmaBufferPool {
     cached: Option<CoherentArray<u8>>,
@@ -1417,6 +1466,10 @@ impl Dwc2DmaBuffer {
                 TransferError::Other(anyhow!("DWC2 DMA buffer pool returned no buffer"))
             })?;
             if matches!(direction, Direction::Out) {
+                // SAFETY: `TransferRequest::buffer` is the usb-host transfer
+                // contract for a live CPU buffer of `len` bytes until the
+                // request completes. We only create a temporary shared slice to
+                // copy OUT payload bytes into the owned coherent bounce buffer.
                 let data = unsafe { core::slice::from_raw_parts(ptr.as_ptr().cast_const(), len) };
                 coherent.write_with_cpu(len, |dst| dst.copy_from_slice(data));
                 stats.record_bounce_to_device(len);
@@ -1467,6 +1520,11 @@ impl Dwc2DmaBuffer {
             )));
         }
 
+        // SAFETY: The request buffer pointer comes from `TransferRequest` and
+        // remains owned by that request until this completion path finishes.
+        // `actual` has been checked against both the request length and the
+        // coherent bounce buffer length, so the mutable slice is in-bounds and
+        // used only for the final IN payload copy.
         let dst = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), actual) };
         coherent.read_with_cpu(actual, |src| dst.copy_from_slice(src));
         Ok(())
@@ -1482,7 +1540,7 @@ struct Dwc2Device {
     channel_gates: Vec<Arc<Mutex<()>>>,
     channel_completions: Dwc2ChannelCompletions,
     stats: Dwc2Stats,
-    desc: DeviceDescriptor,
+    desc: Option<DeviceDescriptor>,
     ctrl_ep: Endpoint,
     config_desc: Vec<ConfigurationDescriptor>,
     current_config_value: Option<u8>,
@@ -1501,6 +1559,10 @@ struct Dwc2DeviceParams {
     stats: Dwc2Stats,
 }
 
+// SAFETY: `Dwc2Device` is owned as a boxed `DeviceOp` and every mutating device
+// operation requires `&mut self`. Endpoint objects created from it get their own
+// owned DMA pools and share only atomic completions, per-channel gates, and the
+// volatile register handle.
 unsafe impl Send for Dwc2Device {}
 
 impl Dwc2Device {
@@ -1535,7 +1597,7 @@ impl Dwc2Device {
             channel_gates,
             channel_completions,
             stats,
-            desc: unsafe { core::mem::zeroed() },
+            desc: None,
             ctrl_ep: Endpoint::new(EndpointInfo::control(), raw),
             config_desc: Vec::new(),
             current_config_value: None,
@@ -1553,12 +1615,13 @@ impl Dwc2Device {
             .with_raw_mut::<Dwc2Endpoint, _>(|ep| ep.set_max_packet_size(base.max_packet_size_0));
         self.kernel.delay(Duration::from_millis(10));
 
-        self.desc = self.ctrl_ep.get_device_descriptor().await?;
+        let desc = self.ctrl_ep.get_device_descriptor().await?;
         self.current_config_value = Some(self.ctrl_ep.get_configuration().await?);
-        for index in 0..self.desc.num_configurations {
+        for index in 0..desc.num_configurations {
             let config = self.ctrl_ep.get_configuration_descriptor(index).await?;
             self.config_desc.push(config);
         }
+        self.desc = Some(desc);
         if let Some(config) = self.config_desc.first() {
             self.set_configuration_inner(config.configuration_value)
                 .await?;
@@ -1571,7 +1634,7 @@ impl Dwc2Device {
         self.ctrl_ep
             .get_descriptor(DescriptorType::DEVICE, 0, 0, &mut data)
             .await?;
-        Ok(unsafe { (data.as_ptr() as *const DeviceDescriptorBase).read_unaligned() })
+        Ok(device_descriptor_base_from_bytes(data))
     }
 
     async fn set_address(&mut self) -> Result<()> {
@@ -1685,7 +1748,9 @@ impl DeviceOp for Dwc2Device {
     }
 
     fn descriptor(&self) -> &DeviceDescriptor {
-        &self.desc
+        self.desc
+            .as_ref()
+            .expect("DWC2 device descriptor must be initialized before device publication")
     }
 
     fn configuration_descriptors(&self) -> &[ConfigurationDescriptor] {
@@ -1781,6 +1846,11 @@ struct Dwc2Endpoint {
     )>,
 }
 
+// SAFETY: `EndpointOp` methods that mutate transfer state require `&mut self`.
+// The endpoint owns its active DMA buffer and reusable bounce buffer pool; the
+// IRQ path never accesses those buffers directly and only publishes HCINT bits
+// through atomic completion slots. Register programming for the endpoint channel
+// is serialized by `channel_gate`.
 unsafe impl Send for Dwc2Endpoint {}
 
 struct Dwc2EndpointParams {
@@ -2291,10 +2361,15 @@ mod tests {
             constraints: DmaConstraints,
             layout: Layout,
         ) -> Option<DmaAllocHandle> {
+            // SAFETY: The test kernel models contiguous DMA with the same
+            // heap-backed allocation used for coherent DMA below.
             unsafe { self.alloc_coherent(constraints, layout) }
         }
 
         unsafe fn dealloc_contiguous(&self, handle: DmaAllocHandle) {
+            // SAFETY: Handles returned by `alloc_contiguous` are created by
+            // `alloc_coherent`, so they must be released through the same mock
+            // deallocation path.
             unsafe { self.dealloc_coherent(handle) }
         }
 
@@ -2303,16 +2378,25 @@ mod tests {
             constraints: DmaConstraints,
             layout: Layout,
         ) -> Option<DmaAllocHandle> {
+            // SAFETY: Unit tests request valid `Layout` values. The returned
+            // pointer is either null or points to a heap allocation owned by the
+            // DMA handle until `dealloc_coherent` consumes it.
             let ptr = unsafe { alloc_zeroed(layout) };
             let ptr = NonNull::new(ptr)?;
             let align = constraints.align.max(layout.align()).max(1) as u64;
             let size = layout.size().max(1) as u64;
             let current = TEST_DMA_ADDR.fetch_add(size + align, AtomicOrdering::Relaxed);
             let dma_addr = (current + align - 1) & !(align - 1);
+            // SAFETY: `ptr` and `layout` describe the allocation above, and
+            // `dma_addr` is a deterministic fake bus address used only by unit
+            // tests that never reaches real hardware.
             Some(unsafe { DmaAllocHandle::new(ptr, dma_addr.into(), layout) })
         }
 
         unsafe fn dealloc_coherent(&self, handle: DmaAllocHandle) {
+            // SAFETY: The mock only creates coherent handles from
+            // `alloc_zeroed` with the stored layout, so deallocating with the
+            // same layout releases exactly that allocation.
             unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) }
         }
 
@@ -2324,6 +2408,9 @@ mod tests {
             _direction: DmaDirection,
         ) -> core::result::Result<DmaMapHandle, DmaError> {
             let layout = Layout::from_size_align(size.get(), 1)?;
+            // SAFETY: This mock streaming map does not transfer ownership of
+            // `addr`; it records the caller-provided live buffer and a fake bus
+            // address for tests that only inspect programming values.
             Ok(unsafe { DmaMapHandle::new(addr, (addr.as_ptr() as u64).into(), layout, None) })
         }
 
@@ -2379,6 +2466,20 @@ mod tests {
         crate::backend::kmod::kcore::CoreOp::enable_irq(&mut host).unwrap();
 
         assert_eq!(regs.read32(GINTMSK), GINTSTS_HCHINT);
+    }
+
+    #[test]
+    fn device_descriptor_base_is_parsed_without_unaligned_struct_access() {
+        let desc =
+            super::device_descriptor_base_from_bytes([18, 1, 0x00, 0x02, 0x08, 0x06, 0x50, 64]);
+
+        assert_eq!(desc.length, 18);
+        assert_eq!(desc.descriptor_type, 1);
+        assert_eq!(desc.usb_version, 0x0200);
+        assert_eq!(desc.class, 0x08);
+        assert_eq!(desc.subclass, 0x06);
+        assert_eq!(desc.protocol, 0x50);
+        assert_eq!(desc.max_packet_size_0, 64);
     }
 
     #[test]

--- a/drivers/usb/usb-host/src/backend/kmod/kcore.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/kcore.rs
@@ -41,6 +41,12 @@ pub trait CoreOp: Send + 'static {
         Err(USBError::NotSupported)
     }
 
+    fn dwc2_transfer_stats(&self) -> Option<crate::Dwc2TransferStats> {
+        None
+    }
+
+    fn reset_dwc2_transfer_stats(&self) {}
+
     fn kernel(&self) -> &Kernel;
 }
 
@@ -206,6 +212,14 @@ impl BackendOp for Core {
 
     fn disable_irq(&mut self) -> Result<(), USBError> {
         self.backend.disable_irq()
+    }
+
+    fn dwc2_transfer_stats(&self) -> Option<crate::Dwc2TransferStats> {
+        self.backend.dwc2_transfer_stats()
+    }
+
+    fn reset_dwc2_transfer_stats(&self) {
+        self.backend.reset_dwc2_transfer_stats();
     }
 }
 

--- a/drivers/usb/usb-host/src/backend/kmod/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/mod.rs
@@ -21,7 +21,9 @@ pub use dwc::{
     UsbPhyInterfaceMode, usb2phy::Usb2PhyPortId,
 };
 use dwc2::Dwc2;
-pub use dwc2::{Dwc2FifoSizes, Dwc2HostParams, Dwc2NewParams, Dwc2Quirks, Dwc2UtmiWidth};
+pub use dwc2::{
+    Dwc2FifoSizes, Dwc2HostParams, Dwc2NewParams, Dwc2Quirks, Dwc2TransferStats, Dwc2UtmiWidth,
+};
 use ehci::Ehci;
 pub use ehci::EhciNewParams;
 use id_arena::Id;

--- a/drivers/usb/usb-host/src/backend/kmod/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/mod.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 mod dwc;
+mod dwc2;
 mod ehci;
 mod hub;
 mod kcore;
@@ -19,6 +20,8 @@ pub use dwc::{
     DwcNewParams, DwcParams, NamedResetLine, ResetLine, UdphyParam, Usb2PhyParam,
     UsbPhyInterfaceMode, usb2phy::Usb2PhyPortId,
 };
+use dwc2::Dwc2;
+pub use dwc2::{Dwc2FifoSizes, Dwc2HostParams, Dwc2NewParams, Dwc2Quirks, Dwc2UtmiWidth};
 use ehci::Ehci;
 pub use ehci::EhciNewParams;
 use id_arena::Id;
@@ -36,6 +39,10 @@ impl USBHost {
 
     pub fn new_dwc(params: DwcNewParams<'_>) -> Result<USBHost> {
         Ok(USBHost::new(Dwc::new(params)?))
+    }
+
+    pub fn new_dwc2(params: Dwc2NewParams) -> Result<USBHost> {
+        Ok(USBHost::new(Dwc2::new(params)?))
     }
 
     pub fn new_ehci(params: EhciNewParams) -> Result<USBHost> {

--- a/drivers/usb/usb-host/src/backend/mod.rs
+++ b/drivers/usb/usb-host/src/backend/mod.rs
@@ -57,4 +57,12 @@ pub(crate) trait BackendOp: Send + Any + 'static {
     fn disable_irq(&mut self) -> Result<(), USBError> {
         Err(USBError::NotSupported)
     }
+
+    #[cfg(kmod)]
+    fn dwc2_transfer_stats(&self) -> Option<crate::Dwc2TransferStats> {
+        None
+    }
+
+    #[cfg(kmod)]
+    fn reset_dwc2_transfer_stats(&self) {}
 }

--- a/drivers/usb/usb-host/src/host.rs
+++ b/drivers/usb/usb-host/src/host.rs
@@ -57,6 +57,16 @@ impl USBHost {
         self.backend.disable_irq()
     }
 
+    #[cfg(kmod)]
+    pub fn dwc2_transfer_stats(&self) -> Option<Dwc2TransferStats> {
+        self.backend.dwc2_transfer_stats()
+    }
+
+    #[cfg(kmod)]
+    pub fn reset_dwc2_transfer_stats(&self) {
+        self.backend.reset_dwc2_transfer_stats();
+    }
+
     pub async fn open_device(&mut self, dev: &DeviceInfo) -> Result<Device> {
         let device = self.backend.open_device(dev.inner.as_ref()).await?;
         let mut device: Device = device.into();

--- a/os/StarryOS/configs/board/aka-00-sg2002.toml
+++ b/os/StarryOS/configs/board/aka-00-sg2002.toml
@@ -3,6 +3,7 @@ features = [
   "axplat-dyn/thead-mae",
   "ax-driver/cvsd",
   "ax-driver/serial",
+  "ax-driver/sg2002-dwc2",
 ]
 log = "Info"
 target = "riscv64gc-unknown-none-elf"

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -41,6 +41,14 @@ sg2002 = [
     "dep:sg200x-bsp",
     "dep:tock-registers",
 ]
+# SG2002 AIC8800 SoftAP Wi-Fi. The whole bring-up (FDT probe + SoftAP + stack
+# registration) now lives in ax-driver / ax-runtime; the kernel just turns the
+# feature on. No direct chip-crate deps needed here anymore.
+sg2002-wifi = [
+    "sg2002",
+    "ax-runtime/aic8800-wifi",
+]
+sg2002-cvi-usb-camera = ["sg2002"]
 stack-guard-page = ["ax-runtime/stack-guard-page"]
 stack-protector = ["ax-runtime/stack-protector"]
 axtest = []

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -36,7 +36,7 @@ mod rtc;
 pub mod tpu;
 pub mod tty;
 
-#[cfg(feature = "sg2002")]
+#[cfg(feature = "sg2002-cvi-usb-camera")]
 mod cvi_usb_camera;
 
 use alloc::{format, sync::Arc};
@@ -698,6 +698,7 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
                 Arc::new(pinmux::PinmuxDev),
             ),
         );
+        #[cfg(feature = "sg2002-cvi-usb-camera")]
         root.add(
             "cvi-usb-camera0",
             Device::new(

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -453,6 +453,187 @@ fn render_mountinfo() -> String {
     buf
 }
 
+fn render_proc_bus_usb_devices() -> String {
+    let mut snapshots = crate::pseudofs::usbfs::usb_device_snapshots();
+    snapshots.sort_by_key(|snapshot| (snapshot.bus_num, snapshot.device_num));
+    render_proc_bus_usb_devices_from_snapshots(&snapshots)
+}
+
+fn render_proc_bus_usb_devices_from_snapshots(
+    snapshots: &[crate::pseudofs::usbfs::UsbDeviceSnapshotInfo],
+) -> String {
+    let mut out = String::new();
+    for snapshot in snapshots {
+        render_proc_bus_usb_device(snapshot, &mut out);
+    }
+    out
+}
+
+fn render_proc_bus_usb_device(
+    snapshot: &crate::pseudofs::usbfs::UsbDeviceSnapshotInfo,
+    out: &mut String,
+) {
+    let blob = &snapshot.descriptor_blob;
+    if blob.len() < 18 || descriptor_u8(blob, 0) < 18 || descriptor_u8(blob, 1) != 0x01 {
+        return;
+    }
+
+    let device_class = descriptor_u8(blob, 4);
+    let device_subclass = descriptor_u8(blob, 5);
+    let device_protocol = descriptor_u8(blob, 6);
+    let max_packet_size = descriptor_u8(blob, 7);
+    let vendor_id = descriptor_u16(blob, 8);
+    let product_id = descriptor_u16(blob, 10);
+    let device_version = descriptor_u16(blob, 12);
+    let config_count = descriptor_u8(blob, 17);
+    let max_child_count = if device_class == 0x09 { 1 } else { 0 };
+
+    let _ = writeln!(
+        out,
+        "T:  Bus={:02} Lev=00 Prnt=00 Port=00 Cnt=00 Dev#={:3} Spd=480  MxCh={:2}",
+        snapshot.bus_num, snapshot.device_num, max_child_count
+    );
+    let _ = writeln!(
+        out,
+        "D:  Ver={} Cls={:02x}({:<5}) Sub={:02x} Prot={:02x} MxPS={:2} #Cfgs={:3}",
+        usb_bcd(descriptor_u16(blob, 2)),
+        device_class,
+        usb_class_label(device_class),
+        device_subclass,
+        device_protocol,
+        max_packet_size,
+        config_count
+    );
+    let _ = writeln!(
+        out,
+        "P:  Vendor={:04x} ProdID={:04x} Rev={}",
+        vendor_id,
+        product_id,
+        usb_bcd(device_version)
+    );
+    let _ = writeln!(out);
+
+    let mut offset = 18usize;
+    while offset + 2 <= blob.len() {
+        let len = descriptor_u8(blob, offset) as usize;
+        let ty = descriptor_u8(blob, offset + 1);
+        if len == 0 {
+            break;
+        }
+        if ty != 0x02 || len < 9 || offset + len > blob.len() {
+            offset = offset.saturating_add(len);
+            continue;
+        }
+
+        let total = descriptor_u16(blob, offset + 2) as usize;
+        let config_end = offset.saturating_add(total).min(blob.len());
+        let active = descriptor_u8(blob, offset + 5);
+        let _ = writeln!(
+            out,
+            "C:* #Ifs={:2} Cfg#={:2} Atr={:02x} MxPwr={:3}mA",
+            descriptor_u8(blob, offset + 4),
+            active,
+            descriptor_u8(blob, offset + 7),
+            u16::from(descriptor_u8(blob, offset + 8)) * 2
+        );
+
+        let mut desc = offset + len;
+        while desc + 2 <= config_end {
+            let desc_len = descriptor_u8(blob, desc) as usize;
+            let desc_ty = descriptor_u8(blob, desc + 1);
+            if desc_len == 0 || desc + desc_len > config_end {
+                break;
+            }
+            match desc_ty {
+                0x04 if desc_len >= 9 => {
+                    render_proc_bus_usb_interface(&blob[desc..desc + desc_len], out);
+                }
+                0x05 if desc_len >= 7 => {
+                    render_proc_bus_usb_endpoint(&blob[desc..desc + desc_len], out);
+                }
+                _ => {}
+            }
+            desc += desc_len;
+        }
+
+        let _ = writeln!(out);
+        offset = config_end.max(offset + len);
+    }
+}
+
+fn render_proc_bus_usb_interface(desc: &[u8], out: &mut String) {
+    let class = descriptor_u8(desc, 5);
+    let _ = writeln!(
+        out,
+        "I:* If#={:2} Alt={:2} #EPs={:2} Cls={:02x}({:<5}) Sub={:02x} Prot={:02x} Driver={}",
+        descriptor_u8(desc, 2),
+        descriptor_u8(desc, 3),
+        descriptor_u8(desc, 4),
+        class,
+        usb_class_label(class),
+        descriptor_u8(desc, 6),
+        descriptor_u8(desc, 7),
+        if class == 0x09 { "hub" } else { "(none)" }
+    );
+}
+
+fn render_proc_bus_usb_endpoint(desc: &[u8], out: &mut String) {
+    let address = descriptor_u8(desc, 2);
+    let attributes = descriptor_u8(desc, 3);
+    let max_packet_size = descriptor_u16(desc, 4) & 0x07ff;
+    let _ = writeln!(
+        out,
+        "E:  Ad={:02x}({}) Atr={:02x}({:<5}) MxPS={:4} Ivl={}ms",
+        address,
+        if address & 0x80 != 0 { "I" } else { "O" },
+        attributes,
+        usb_endpoint_type_label(attributes & 0x03),
+        max_packet_size,
+        descriptor_u8(desc, 6)
+    );
+}
+
+fn descriptor_u8(blob: &[u8], offset: usize) -> u8 {
+    blob.get(offset).copied().unwrap_or_default()
+}
+
+fn descriptor_u16(blob: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes([descriptor_u8(blob, offset), descriptor_u8(blob, offset + 1)])
+}
+
+fn usb_bcd(value: u16) -> String {
+    format!(
+        "{:2x}.{:x}{:x}",
+        (value >> 8) & 0xff,
+        (value >> 4) & 0x0f,
+        value & 0x0f
+    )
+}
+
+fn usb_class_label(class: u8) -> &'static str {
+    match class {
+        0x00 => ">ifc",
+        0x03 => "HID",
+        0x08 => "stor.",
+        0x09 => "hub",
+        0x0e => "video",
+        0xe0 => "wlcon",
+        0xef => "misc",
+        0xff => "vend.",
+        _ => "unk.",
+    }
+}
+
+fn usb_endpoint_type_label(ty: u8) -> &'static str {
+    match ty {
+        0 => "Ctrl",
+        1 => "Isoc",
+        2 => "Bulk",
+        3 => "Int.",
+        _ => "Unk.",
+    }
+}
+
 pub fn new_procfs() -> Filesystem {
     SimpleFs::new_with("proc".into(), 0x9fa0, builder)
 }
@@ -1608,6 +1789,19 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         SimpleDir::new_maker(fs.clone(), Arc::new(net))
     });
 
+    root.add("bus", {
+        let mut bus = DirMapping::new();
+        bus.add("usb", {
+            let mut usb = DirMapping::new();
+            usb.add(
+                "devices",
+                SimpleFile::new_regular(fs.clone(), || Ok(render_proc_bus_usb_devices())),
+            );
+            SimpleDir::new_maker(fs.clone(), Arc::new(usb))
+        });
+        SimpleDir::new_maker(fs.clone(), Arc::new(bus))
+    });
+
     // /proc/device-tree/{compatible,model} — minimal Open Firmware view from the
     // live FDT, so SoC-detecting userspace (e.g. librockchip_mpp's read_soc_name)
     // can identify the chip. Built only for the JPU/MPP path (`jpeg` feature) and
@@ -1718,9 +1912,10 @@ mod tests {
 
     use super::{
         TaskStatusBase, TaskStatusFields, collect_cpu_presence, format_cpu_presence_hex,
-        format_cpu_presence_list, render_task_status_fields,
+        format_cpu_presence_list, render_proc_bus_usb_devices_from_snapshots,
+        render_task_status_fields,
     };
-    use crate::{mm::ProcessMemStats, task::Cred};
+    use crate::{mm::ProcessMemStats, pseudofs::usbfs::UsbDeviceSnapshotInfo, task::Cred};
 
     fn sample_mem_stats() -> ProcessMemStats {
         ProcessMemStats {
@@ -1758,6 +1953,30 @@ mod tests {
             cpus_allowed_list: &cpus_allowed_list,
             mem: &sample_mem_stats(),
         })
+    }
+
+    fn high_speed_root_hub_snapshot() -> UsbDeviceSnapshotInfo {
+        UsbDeviceSnapshotInfo {
+            bus_num: 1,
+            device_num: 1,
+            descriptor_blob: alloc::vec![
+                18, 0x01, 0x00, 0x02, 0x09, 0x00, 0x01, 64, 0x6b, 0x1d, 0x02, 0x00, 0x00, 0x06, 0,
+                0, 0, 1, 9, 0x02, 25, 0, 1, 1, 0, 0xe0, 0, 9, 0x04, 0, 0, 1, 0x09, 0, 0, 0, 7,
+                0x05, 0x81, 0x03, 4, 0, 12,
+            ],
+        }
+    }
+
+    #[test]
+    fn proc_bus_usb_devices_renders_busybox_lsusb_id_lines() {
+        let text = render_proc_bus_usb_devices_from_snapshots(&[high_speed_root_hub_snapshot()]);
+
+        assert!(text.contains("T:  Bus=01"));
+        assert!(text.contains("Dev#=  1"));
+        assert!(text.contains("P:  Vendor=1d6b ProdID=0002 Rev= 6.00"));
+        assert!(text.contains("I:* If#= 0"));
+        assert!(text.contains("Driver=hub"));
+        assert!(text.contains("E:  Ad=81(I)"));
     }
 
     #[test]

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
@@ -1212,16 +1212,11 @@ pub(super) fn initialize_hosts(manager: &UsbFsManager) -> usize {
             continue;
         }
 
-        let devices = match ax_task::future::block_on(guard.host_mut().probe_devices()) {
-            Ok(devices) => devices,
-            Err(err) => {
-                warn!("usbfs: initial probe failed on bus {bus_num}: {err:?}");
-                failed_device_ids.push((device_id, host_irq));
-                continue;
-            }
-        };
-
         if let Some(host_irq) = host_irq {
+            // DWC2 internal-DMA transfers complete through host-channel IRQs.
+            // Enable both the controller interrupt mask and the framework
+            // callback before the initial probe, because enumeration itself
+            // issues control transfers that wait for IRQ completions.
             if let Err(err) = guard.enable_irq() {
                 warn!("usbfs: failed to enable host IRQ on bus {bus_num}: {err:?}");
                 failed_device_ids.push((device_id, Some(host_irq)));
@@ -1237,6 +1232,23 @@ pub(super) fn initialize_hosts(manager: &UsbFsManager) -> usize {
             }
             irq::bootstrap_irq(host_irq);
         }
+
+        let devices = match ax_task::future::block_on(guard.host_mut().probe_devices()) {
+            Ok(devices) => devices,
+            Err(err) => {
+                warn!("usbfs: initial probe failed on bus {bus_num}: {err:?}");
+                if host_irq.is_some()
+                    && let Err(disable_err) = guard.disable_irq()
+                {
+                    warn!(
+                        "usbfs: failed to disable host IRQ after probe failure on bus {bus_num}: \
+                         {disable_err:?}"
+                    );
+                }
+                failed_device_ids.push((device_id, host_irq));
+                continue;
+            }
+        };
         info!("usbfs: host on bus {} initialized", bus_num);
         initialized += 1;
         manager.apply_probe_results(device_id, bus_num, devices);

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/sysfs.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/sysfs.rs
@@ -32,9 +32,10 @@ fn text_file(fs: Arc<SimpleFs>, text: impl Into<Vec<u8>>) -> NodeOpsMux {
     SimpleFile::new_regular(fs, move || -> VfsResult<Vec<u8>> { Ok(text.clone()) }).into()
 }
 
-fn symlink(fs: Arc<SimpleFs>, target: &'static str) -> NodeOpsMux {
+fn symlink(fs: Arc<SimpleFs>, target: impl Into<String>) -> NodeOpsMux {
+    let target = target.into().into_bytes();
     SimpleFile::new(fs, NodeType::Symlink, move || -> VfsResult<Vec<u8>> {
-        Ok(target.as_bytes().to_vec())
+        Ok(target.clone())
     })
     .into()
 }
@@ -46,7 +47,7 @@ struct SysUsbDir {
 
 impl SimpleDirOps for SysUsbDir {
     fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
-        Box::new(["devices"].into_iter().map(Cow::Borrowed))
+        Box::new(["devices", "device-nodes"].into_iter().map(Cow::Borrowed))
     }
 
     fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
@@ -54,6 +55,13 @@ impl SimpleDirOps for SysUsbDir {
             "devices" => Ok(dir(
                 self.fs.clone(),
                 SysUsbDevicesDir {
+                    fs: self.fs.clone(),
+                    manager: self.manager.clone(),
+                },
+            )),
+            "device-nodes" => Ok(dir(
+                self.fs.clone(),
+                SysUsbDeviceNodesDir {
                     fs: self.fs.clone(),
                     manager: self.manager.clone(),
                 },
@@ -87,6 +95,51 @@ impl SysUsbDevicesDir {
 }
 
 impl SimpleDirOps for SysUsbDevicesDir {
+    fn is_cacheable(&self) -> bool {
+        false
+    }
+
+    fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
+        Box::new(
+            self.snapshots()
+                .into_iter()
+                .map(|snapshot| Cow::Owned(sysfs_device_name(&snapshot))),
+        )
+    }
+
+    fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
+        self.snapshots()
+            .into_iter()
+            .find(|snapshot| sysfs_device_name(snapshot) == name)
+            .ok_or(ax_errno::AxError::NotFound)?;
+        Ok(symlink(self.fs.clone(), format!("../device-nodes/{name}")))
+    }
+}
+
+struct SysUsbDeviceNodesDir {
+    fs: Arc<SimpleFs>,
+    manager: Option<Arc<UsbFsManager>>,
+}
+
+impl SysUsbDeviceNodesDir {
+    fn snapshots(&self) -> Vec<UsbDeviceSnapshot> {
+        let Some(manager) = &self.manager else {
+            return Vec::new();
+        };
+        let mut snapshots = Vec::new();
+        for bus_num in manager.bus_numbers() {
+            for device_num in manager.device_numbers(bus_num) {
+                if let Some(snapshot) = manager.device_snapshot(bus_num, device_num) {
+                    snapshots.push(snapshot);
+                }
+            }
+        }
+        snapshots.sort_by_key(|snapshot| (snapshot.bus_num, snapshot.device_num));
+        snapshots
+    }
+}
+
+impl SimpleDirOps for SysUsbDeviceNodesDir {
     fn is_cacheable(&self) -> bool {
         false
     }
@@ -206,8 +259,17 @@ impl SysUsbDeviceDir {
 
     fn uevent(&self) -> Vec<u8> {
         format!(
-            "MAJOR=189\nMINOR={}\nDEVNAME=bus/usb/{}/{}\nDEVTYPE=usb_device\nDRIVER=usb\\
-             nPRODUCT={:x}/{:x}/{:x}\nTYPE={}/{}/{}\nBUSNUM={}\nDEVNUM={}\n",
+            concat!(
+                "MAJOR=189\n",
+                "MINOR={}\n",
+                "DEVNAME=bus/usb/{}/{}\n",
+                "DEVTYPE=usb_device\n",
+                "DRIVER=usb\n",
+                "PRODUCT={:x}/{:x}/{:x}\n",
+                "TYPE={}/{}/{}\n",
+                "BUSNUM={}\n",
+                "DEVNUM={}\n",
+            ),
             self.minor(),
             bus_name(self.snapshot.bus_num),
             device_name(self.snapshot.device_num),

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -4,7 +4,7 @@ use std::{
     process::Command as StdCommand,
 };
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use clap::{Args, Subcommand};
 use log::warn;
 use ostool::{
@@ -407,11 +407,25 @@ impl ArceOS {
         board_config_path: Option<PathBuf>,
         options: RunBoardOptions,
     ) -> anyhow::Result<()> {
+        self.run_board_request_with_extra_rustflags(request, board_config_path, options, &[])
+            .await
+    }
+
+    pub(super) async fn run_board_request_with_extra_rustflags(
+        &mut self,
+        request: ResolvedBuildRequest,
+        board_config_path: Option<PathBuf>,
+        options: RunBoardOptions,
+        extra_rustflags: &[&str],
+    ) -> anyhow::Result<()> {
         Self::validate_board_request(&request)?;
         self.app.set_debug_mode(request.debug)?;
         match build::load_arceos_build_mode(&request.build_info_path)? {
             build::ArceosBuildMode::RustStd => {
-                let cargo = build::load_cargo_config(&request)?;
+                let mut cargo = build::load_cargo_config(&request)?;
+                if !extra_rustflags.is_empty() {
+                    crate::build::append_encoded_rustflags(&mut cargo, extra_rustflags);
+                }
                 let board_config = self
                     .load_board_config(&cargo, board_config_path.as_deref())
                     .await?;
@@ -420,6 +434,9 @@ impl ArceOS {
                     .await
             }
             build::ArceosBuildMode::AppC { app_dir, app_name } => {
+                if !extra_rustflags.is_empty() {
+                    bail!("ArceOS board extra rustflags are only supported for RustStd packages");
+                }
                 let request = c_app_internal_request(&request);
                 let cargo = build::load_c_app_cargo_config(&request)?;
                 let board_config = self

--- a/scripts/axbuild/src/arceos/test/axtest_qemu.rs
+++ b/scripts/axbuild/src/arceos/test/axtest_qemu.rs
@@ -1,5 +1,5 @@
 use super::{
-    ARCEOS_AXTEST_GROUP,
+    ARCEOS_AXTEST_GROUP, ARCEOS_AXTEST_RUSTFLAGS,
     assets::arceos_test_group_dir,
     discovery::{discover_qemu_cases_in_dir, discover_qemu_cases_in_dir_allow_empty},
     runner::run_prepared_qemu_groups,
@@ -7,8 +7,6 @@ use super::{
     types::GenericQemuRunOptions,
 };
 use crate::{arceos::ArceOS, build::append_encoded_rustflags};
-
-const AXTEST_RUSTFLAGS: &[&str] = &["--cfg", "axtest", "--check-cfg", "cfg(axtest)"];
 
 pub(super) async fn test_axtest_qemu(
     arceos: &mut ArceOS,
@@ -45,7 +43,7 @@ pub(super) async fn test_axtest_qemu(
     );
     let mut prepared = prepare_rust_qemu_cases(arceos, target, cases).await?;
     for case in &mut prepared {
-        append_encoded_rustflags(&mut case.cargo, AXTEST_RUSTFLAGS);
+        append_encoded_rustflags(&mut case.cargo, ARCEOS_AXTEST_RUSTFLAGS);
         if crate::support::axtest_coverage::enabled(&case.cargo) {
             crate::support::axtest_coverage::prepare_cargo(&mut case.cargo);
         }

--- a/scripts/axbuild/src/arceos/test/axtest_qemu.rs
+++ b/scripts/axbuild/src/arceos/test/axtest_qemu.rs
@@ -84,4 +84,26 @@ mod tests {
             Some("-Cdebuginfo=2\u{1f}--cfg\u{1f}axtest")
         );
     }
+
+    #[test]
+    fn append_encoded_rustflags_skips_existing_sequence() {
+        let mut cargo = Cargo {
+            env: [(
+                "CARGO_ENCODED_RUSTFLAGS".to_string(),
+                "--cfg\u{1f}axtest\u{1f}--check-cfg\u{1f}cfg(axtest)".to_string(),
+            )]
+            .into(),
+            ..Cargo::default()
+        };
+
+        append_encoded_rustflags(
+            &mut cargo,
+            &["--cfg", "axtest", "--check-cfg", "cfg(axtest)"],
+        );
+
+        assert_eq!(
+            cargo.env.get("CARGO_ENCODED_RUSTFLAGS").map(String::as_str),
+            Some("--cfg\u{1f}axtest\u{1f}--check-cfg\u{1f}cfg(axtest)")
+        );
+    }
 }

--- a/scripts/axbuild/src/arceos/test/board.rs
+++ b/scripts/axbuild/src/arceos/test/board.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 use anyhow::Context;
 use ostool::board::RunBoardOptions;
 
-use super::{ARCEOS_TEST_SUITE_OS, ArgsTestBoard, types::ArceosBoardTestGroup};
+use super::{
+    ARCEOS_AXTEST_GROUP, ARCEOS_AXTEST_RUSTFLAGS, ARCEOS_TEST_SUITE_OS, ArgsTestBoard,
+    types::ArceosBoardTestGroup,
+};
 use crate::{
     arceos::ArceOS,
     context::{BuildCliArgs, SnapshotPersistence, arch_for_target_checked},
@@ -15,6 +18,8 @@ pub(crate) fn collect_board_test_groups(
     test_suite_dir: &Path,
 ) -> anyhow::Result<Vec<ArceosBoardTestGroup>> {
     let mut groups = Vec::new();
+    let is_axtest =
+        test_suite_dir.file_name().and_then(|name| name.to_str()) == Some(ARCEOS_AXTEST_GROUP);
     for info in board_test::discover_board_case_build_infos(test_suite_dir, "ArceOS")? {
         let build_file = crate::arceos::board::load_build_file(&info.build_config_path)
             .with_context(|| {
@@ -44,10 +49,19 @@ pub(crate) fn collect_board_test_groups(
             target,
             build_config_path: info.build_config_path,
             board_test_config_path: info.board_test_config_path,
+            is_axtest,
         });
     }
 
     Ok(groups)
+}
+
+fn board_extra_rustflags(group: &ArceosBoardTestGroup) -> &'static [&'static str] {
+    if group.is_axtest {
+        ARCEOS_AXTEST_RUSTFLAGS
+    } else {
+        &[]
+    }
 }
 
 pub(crate) fn discover_board_test_groups(
@@ -106,7 +120,7 @@ impl ArceOS {
                     None,
                     SnapshotPersistence::Discard,
                 )?;
-                self.run_board_request(
+                self.run_board_request_with_extra_rustflags(
                     request,
                     Some(board_test_config.clone()),
                     RunBoardOptions {
@@ -114,6 +128,7 @@ impl ArceOS {
                         server: args.server.clone(),
                         port: args.port,
                     },
+                    board_extra_rustflags(&group),
                 )
                 .await
                 .with_context(|| {
@@ -182,6 +197,32 @@ fail_regex = ["(?i)panic"]
         .unwrap();
     }
 
+    fn write_axtest_board_group(root: &Path) {
+        let group = root.join("test-suit/arceos/axtest");
+        let case = group.join("sg2002-usb-msc");
+        fs::create_dir_all(&case).unwrap();
+        fs::write(
+            group.join("build-riscv64gc-unknown-none-elf.toml"),
+            r#"
+package = "arceos-axtest-sg2002-usb-msc"
+target = "riscv64gc-unknown-none-elf"
+features = []
+log = "Info"
+max_cpu_num = 1
+"#,
+        )
+        .unwrap();
+        fs::write(
+            case.join("board-aka-00-sg2002.toml"),
+            r#"
+board_type = "AKA-00-SG2002"
+success_regex = ["AXTEST_SUITE_OK"]
+fail_regex = ["(?i)panic"]
+"#,
+        )
+        .unwrap();
+    }
+
     #[test]
     fn collect_board_test_groups_reads_package_and_target_from_build_config() {
         let root = tempdir().unwrap();
@@ -205,6 +246,7 @@ fail_regex = ["(?i)panic"]
             group.board_test_config_path,
             group_dir.join("boot/board-orangepi-5-plus.toml")
         );
+        assert!(!group.is_axtest);
     }
 
     #[test]
@@ -218,5 +260,24 @@ fail_regex = ["(?i)panic"]
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].name, "boot");
         assert_eq!(groups[0].board_name, "orangepi-5-plus");
+    }
+
+    #[test]
+    fn collect_board_test_groups_marks_axtest_groups() {
+        let root = tempdir().unwrap();
+        write_axtest_board_group(root.path());
+        let group_dir = root.path().join("test-suit/arceos/axtest");
+
+        let groups = collect_board_test_groups(root.path(), &group_dir).unwrap();
+
+        assert_eq!(groups.len(), 1);
+        let group = &groups[0];
+        assert_eq!(group.name, "sg2002-usb-msc");
+        assert_eq!(group.board_name, "aka-00-sg2002");
+        assert!(group.is_axtest);
+        assert_eq!(
+            board_extra_rustflags(group),
+            ["--cfg", "axtest", "--check-cfg", "cfg(axtest)"]
+        );
     }
 }

--- a/scripts/axbuild/src/arceos/test/mod.rs
+++ b/scripts/axbuild/src/arceos/test/mod.rs
@@ -21,6 +21,8 @@ const ARCEOS_TEST_SUITE_OS: &str = "arceos";
 const ARCEOS_RUST_TEST_PACKAGE: &str = "arceos-test-suit";
 const ARCEOS_RUST_TEST_BUILD_GROUP: &str = "arceos-test-suit";
 const ARCEOS_C_TEST_BUILD_GROUP: &str = "arceos-c-test-suit";
+pub(super) const ARCEOS_AXTEST_RUSTFLAGS: &[&str] =
+    &["--cfg", "axtest", "--check-cfg", "cfg(axtest)"];
 
 const ARCEOS_RUST_ALL_FEATURE: &str = "all";
 const ARCEOS_C_ALL_FEATURE: &str = "all";

--- a/scripts/axbuild/src/arceos/test/types.rs
+++ b/scripts/axbuild/src/arceos/test/types.rs
@@ -42,6 +42,7 @@ pub(crate) struct ArceosBoardTestGroup {
     pub(crate) target: String,
     pub(crate) build_config_path: PathBuf,
     pub(crate) board_test_config_path: PathBuf,
+    pub(crate) is_axtest: bool,
 }
 
 impl board_test::BoardTestGroupInfo for ArceosBoardTestGroup {

--- a/scripts/axbuild/src/build/info.rs
+++ b/scripts/axbuild/src/build/info.rs
@@ -48,11 +48,30 @@ pub(crate) fn toolchain_rustflags_for_features(
 
 pub(crate) fn append_encoded_rustflags(cargo: &mut Cargo, flags: &[&str]) {
     const KEY: &str = "CARGO_ENCODED_RUSTFLAGS";
+    let encoded = flags.join("\x1f");
+    if encoded.is_empty() {
+        return;
+    }
     let value = cargo.env.entry(KEY.to_string()).or_default();
+    if encoded_rustflags_contains_sequence(value, &encoded) {
+        return;
+    }
     if !value.is_empty() {
         value.push('\x1f');
     }
-    value.push_str(&flags.join("\x1f"));
+    value.push_str(&encoded);
+}
+
+fn encoded_rustflags_contains_sequence(value: &str, encoded: &str) -> bool {
+    let needle: Vec<_> = encoded.split('\x1f').collect();
+    if needle.is_empty() {
+        return true;
+    }
+    value
+        .split('\x1f')
+        .collect::<Vec<_>>()
+        .windows(needle.len())
+        .any(|window| window == needle.as_slice())
 }
 
 /// Whether the build config enables target backtrace support (frame pointers / unwind).

--- a/scripts/axbuild/src/support/git/manifest.rs
+++ b/scripts/axbuild/src/support/git/manifest.rs
@@ -1,4 +1,9 @@
-use std::{collections::BTreeSet, fs, path::Path, process::Command};
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use anyhow::{Context, bail};
 use toml::Value;
@@ -8,6 +13,7 @@ use super::refs::git_safe_directory_args;
 pub(super) const ROOT_MANIFEST: &str = "Cargo.toml";
 const WORKSPACE_TABLE: &str = "workspace";
 const WORKSPACE_DEPENDENCIES_TABLE: &str = "dependencies";
+const WORKSPACE_MEMBERS: &str = "members";
 const WORKSPACE_PACKAGE_TABLE: &str = "package";
 const WORKSPACE_METADATA_TABLE: &str = "metadata";
 const PROFILE_TABLE: &str = "profile";
@@ -15,7 +21,13 @@ const PROFILE_TABLE: &str = "profile";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum RootManifestChange {
     Hard,
-    LocalWorkspaceDependencies(BTreeSet<String>),
+    LocalWorkspace(LocalRootManifestChange),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(super) struct LocalRootManifestChange {
+    pub(super) dependencies: BTreeSet<String>,
+    pub(super) members: BTreeSet<PathBuf>,
 }
 
 pub(super) fn root_manifest_change_since(
@@ -70,6 +82,10 @@ pub(super) fn classify_root_manifest_change(
     let old: Value = toml::from_str(old_manifest).context("failed to parse old root Cargo.toml")?;
     let new: Value = toml::from_str(new_manifest).context("failed to parse new root Cargo.toml")?;
 
+    let Some(changed_members) = changed_literal_workspace_members(&old, &new) else {
+        return Ok(RootManifestChange::Hard);
+    };
+
     if dependency_resolution_surface(old.clone()) != dependency_resolution_surface(new.clone()) {
         return Ok(RootManifestChange::Hard);
     }
@@ -100,7 +116,12 @@ pub(super) fn classify_root_manifest_change(
         changed.extend(new_package);
     }
 
-    Ok(RootManifestChange::LocalWorkspaceDependencies(changed))
+    Ok(RootManifestChange::LocalWorkspace(
+        LocalRootManifestChange {
+            dependencies: changed,
+            members: changed_members,
+        },
+    ))
 }
 
 fn dependency_resolution_surface(mut manifest: Value) -> Value {
@@ -109,6 +130,7 @@ fn dependency_resolution_surface(mut manifest: Value) -> Value {
         .and_then(Value::as_table_mut)
     {
         workspace.remove(WORKSPACE_DEPENDENCIES_TABLE);
+        workspace.remove(WORKSPACE_MEMBERS);
         workspace.remove(WORKSPACE_PACKAGE_TABLE);
         workspace.remove(WORKSPACE_METADATA_TABLE);
     }
@@ -116,6 +138,66 @@ fn dependency_resolution_surface(mut manifest: Value) -> Value {
         .as_table_mut()
         .map(|table| table.remove(PROFILE_TABLE));
     manifest
+}
+
+fn changed_literal_workspace_members(old: &Value, new: &Value) -> Option<BTreeSet<PathBuf>> {
+    let old_members = workspace_members(old);
+    let new_members = workspace_members(new);
+    if old_members == new_members {
+        return Some(BTreeSet::new());
+    }
+
+    let old_members = workspace_member_strings(old)?;
+    let new_members = workspace_member_strings(new)?;
+
+    old_members
+        .symmetric_difference(&new_members)
+        .map(|member| normalize_literal_workspace_member(member))
+        .collect()
+}
+
+fn workspace_members(manifest: &Value) -> Option<&Value> {
+    manifest
+        .get(WORKSPACE_TABLE)
+        .and_then(|workspace| workspace.get(WORKSPACE_MEMBERS))
+}
+
+fn workspace_member_strings(manifest: &Value) -> Option<BTreeSet<String>> {
+    let Some(members) = workspace_members(manifest) else {
+        return Some(BTreeSet::new());
+    };
+    let members = members.as_array()?;
+
+    let mut member_strings = BTreeSet::new();
+    for member in members {
+        let member = member.as_str()?;
+        member_strings.insert(member.to_string());
+    }
+    Some(member_strings)
+}
+
+fn normalize_literal_workspace_member(member: &str) -> Option<PathBuf> {
+    if member
+        .bytes()
+        .any(|byte| matches!(byte, b'*' | b'?' | b'[' | b']'))
+    {
+        return None;
+    }
+
+    let path = Path::new(member);
+    if path.is_absolute() {
+        return None;
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => normalized.push(part),
+            std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    Some(normalized)
 }
 
 fn workspace_dependencies(manifest: &Value) -> toml::Table {

--- a/scripts/axbuild/src/support/git/selection.rs
+++ b/scripts/axbuild/src/support/git/selection.rs
@@ -175,8 +175,15 @@ impl PackagePathIndex {
                     .unwrap_or(RootManifestChange::Hard)
                 {
                     RootManifestChange::Hard => return Ok(ChangedPackages::Full { path }),
-                    RootManifestChange::LocalWorkspaceDependencies(dependencies) => {
-                        packages.extend(dependencies);
+                    RootManifestChange::LocalWorkspace(change) => {
+                        packages.extend(change.dependencies);
+                        packages.extend(
+                            change
+                                .members
+                                .into_iter()
+                                .filter_map(|member| self.package_for_path(&member))
+                                .map(ToString::to_string),
+                        );
                     }
                 }
                 continue;

--- a/scripts/axbuild/src/support/git/tests/manifest.rs
+++ b/scripts/axbuild/src/support/git/tests/manifest.rs
@@ -1,11 +1,21 @@
-use std::{collections::BTreeSet, path::PathBuf};
+use std::path::PathBuf;
 
 use super::common::test_workspace;
 use crate::support::git::{
     IncrementalPackageSelection,
-    manifest::{RootManifestChange, classify_root_manifest_change},
+    manifest::{LocalRootManifestChange, RootManifestChange, classify_root_manifest_change},
     selection::select_incremental_packages_for_paths_with_root_manifest_change,
 };
+
+fn local_root_change(dependencies: &[&str], members: &[&str]) -> RootManifestChange {
+    RootManifestChange::LocalWorkspace(LocalRootManifestChange {
+        dependencies: dependencies
+            .iter()
+            .map(|dependency| (*dependency).to_string())
+            .collect(),
+        members: members.iter().map(PathBuf::from).collect(),
+    })
+}
 
 #[test]
 fn root_cargo_toml_workspace_dependency_change_keeps_incremental_package_selection() {
@@ -18,9 +28,7 @@ fn root_cargo_toml_workspace_dependency_change_keeps_incremental_package_selecti
             PathBuf::from("Cargo.toml"),
             PathBuf::from("crates/beta/Cargo.toml"),
         ],
-        Some(RootManifestChange::LocalWorkspaceDependencies(
-            BTreeSet::from(["beta".to_string()]),
-        )),
+        Some(local_root_change(&["beta"], &[])),
     )
     .unwrap();
 
@@ -51,10 +59,7 @@ fn root_cargo_toml_semantic_noop_selects_no_packages() {
             alpha = { version = "0.1.0", path = "crates/alpha" }
         "#;
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
-    assert_eq!(
-        change,
-        RootManifestChange::LocalWorkspaceDependencies(BTreeSet::new())
-    );
+    assert_eq!(change, local_root_change(&[], &[]));
 
     let (root, metadata, workspace_packages) = test_workspace();
     let selected = select_incremental_packages_for_paths_with_root_manifest_change(
@@ -100,10 +105,7 @@ fn root_cargo_toml_workspace_package_metadata_change_selects_no_packages() {
             alpha = { version = "0.1.0", path = "crates/alpha" }
         "#;
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
-    assert_eq!(
-        change,
-        RootManifestChange::LocalWorkspaceDependencies(BTreeSet::new())
-    );
+    assert_eq!(change, local_root_change(&[], &[]));
 
     let (root, metadata, workspace_packages) = test_workspace();
     let selected = select_incremental_packages_for_paths_with_root_manifest_change(
@@ -135,9 +137,7 @@ fn root_cargo_toml_semantic_noop_keeps_incremental_package_selection() {
             PathBuf::from("Cargo.toml"),
             PathBuf::from("crates/beta/src/lib.rs"),
         ],
-        Some(RootManifestChange::LocalWorkspaceDependencies(
-            BTreeSet::new(),
-        )),
+        Some(local_root_change(&[], &[])),
     )
     .unwrap();
 
@@ -158,9 +158,7 @@ fn root_cargo_toml_workspace_dependency_change_skips_removed_packages() {
         &metadata,
         &workspace_packages,
         [PathBuf::from("Cargo.toml")],
-        Some(RootManifestChange::LocalWorkspaceDependencies(
-            BTreeSet::from(["beta".to_string(), "removed".to_string()]),
-        )),
+        Some(local_root_change(&["beta", "removed"], &[])),
     )
     .unwrap();
 
@@ -192,10 +190,7 @@ fn root_manifest_classifier_uses_package_name_for_local_dependency_alias() {
 
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
 
-    assert_eq!(
-        change,
-        RootManifestChange::LocalWorkspaceDependencies(BTreeSet::from(["alpha".to_string()]))
-    );
+    assert_eq!(change, local_root_change(&["alpha"], &[]));
 }
 
 #[test]
@@ -217,13 +212,7 @@ fn root_manifest_classifier_tracks_local_dependency_alias_package_change() {
 
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
 
-    assert_eq!(
-        change,
-        RootManifestChange::LocalWorkspaceDependencies(BTreeSet::from([
-            "alpha".to_string(),
-            "beta".to_string()
-        ]))
-    );
+    assert_eq!(change, local_root_change(&["alpha", "beta"], &[]));
 }
 
 #[test]
@@ -246,10 +235,7 @@ fn root_manifest_classifier_accepts_local_workspace_dependency_removal() {
 
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
 
-    assert_eq!(
-        change,
-        RootManifestChange::LocalWorkspaceDependencies(BTreeSet::from(["beta".to_string()]))
-    );
+    assert_eq!(change, local_root_change(&["beta"], &[]));
 }
 
 #[test]
@@ -275,7 +261,7 @@ fn root_manifest_classifier_keeps_external_dependency_changes_hard() {
 }
 
 #[test]
-fn root_manifest_classifier_keeps_workspace_members_changes_hard() {
+fn root_manifest_classifier_keeps_literal_workspace_member_changes_incremental() {
     let old_manifest = r#"
             [workspace]
             members = ["crates/alpha"]
@@ -286,6 +272,68 @@ fn root_manifest_classifier_keeps_workspace_members_changes_hard() {
     let new_manifest = r#"
             [workspace]
             members = ["crates/alpha", "crates/beta"]
+
+            [workspace.dependencies]
+            alpha = { version = "0.1.0", path = "crates/alpha" }
+        "#;
+
+    let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+
+    assert_eq!(change, local_root_change(&[], &["crates/beta"]));
+
+    let (root, metadata, workspace_packages) = test_workspace();
+    let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+        root.path(),
+        &metadata,
+        &workspace_packages,
+        [PathBuf::from("Cargo.toml")],
+        Some(change),
+    )
+    .unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: vec!["beta".into()],
+            affected: vec!["beta".into(), "gamma".into()],
+        }
+    );
+}
+
+#[test]
+fn root_manifest_classifier_ignores_unchanged_workspace_member_globs() {
+    let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "apps/arceos/*"]
+
+            [workspace.dependencies]
+            alpha = { version = "0.1.0", path = "crates/alpha" }
+        "#;
+    let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "apps/arceos/*"]
+
+            [workspace.dependencies]
+            alpha = { version = "0.1.0", path = "crates/alpha" }
+        "#;
+
+    let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+
+    assert_eq!(change, local_root_change(&[], &["crates/beta"]));
+}
+
+#[test]
+fn root_manifest_classifier_keeps_changed_workspace_member_globs_hard() {
+    let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "apps/arceos/*"]
+
+            [workspace.dependencies]
+            alpha = { version = "0.1.0", path = "crates/alpha" }
+        "#;
+    let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "apps/arceos/*", "apps/starry/*"]
 
             [workspace.dependencies]
             alpha = { version = "0.1.0", path = "crates/alpha" }

--- a/test-suit/arceos/axtest/sg2002-usb-msc/Cargo.toml
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/Cargo.toml
@@ -6,11 +6,12 @@ publish = false
 
 [features]
 default = []
-ax-std = ["dep:ax-hal", "dep:ax-std"]
+ax-std = ["dep:ax-hal", "dep:ax-runtime", "dep:ax-std", "ax-runtime/irq"]
 
 [dependencies]
 ax-driver.workspace = true
 ax-hal = { workspace = true, optional = true }
+ax-runtime = { workspace = true, optional = true }
 ax-std = { workspace = true, optional = true }
 ax-task.workspace = true
 axplat-dyn.workspace = true

--- a/test-suit/arceos/axtest/sg2002-usb-msc/Cargo.toml
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "arceos-axtest-sg2002-usb-msc"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[features]
+default = []
+ax-std = ["dep:ax-hal", "dep:ax-std"]
+
+[dependencies]
+ax-driver.workspace = true
+ax-hal = { workspace = true, optional = true }
+ax-std = { workspace = true, optional = true }
+ax-task.workspace = true
+axplat-dyn.workspace = true
+axtest.workspace = true
+crab-usb.workspace = true
+rdrive.workspace = true

--- a/test-suit/arceos/axtest/sg2002-usb-msc/board-aka-00-sg2002.toml
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/board-aka-00-sg2002.toml
@@ -1,0 +1,20 @@
+board_type = "AKA-00-SG2002"
+dtb_file = "os/StarryOS/configs/board/aka-00-sg2002.dtb"
+kernel_load_addr = "0x80200000"
+fit_load_addr = "0x82200000"
+bootm_addr = "0x82200000"
+success_regex = [
+  "(?m)^SG2002_DWC2_MSC_READ_OK .*$",
+  "(?m)^AXTEST_SUITE_OK\\s*$",
+]
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)segmentation fault",
+  "(?i)SIGSEGV",
+  "exit with code: 139",
+  "(?m)^SG2002_DWC2_MSC_FAIL .*$",
+  "AXTEST_SUITE_FAIL",
+  "AXTEST_CASE status=fail",
+]
+timeout = 600
+

--- a/test-suit/arceos/axtest/sg2002-usb-msc/board-aka-00-sg2002.toml
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/board-aka-00-sg2002.toml
@@ -4,8 +4,7 @@ kernel_load_addr = "0x80200000"
 fit_load_addr = "0x82200000"
 bootm_addr = "0x82200000"
 success_regex = [
-  "(?m)^SG2002_DWC2_MSC_READ_OK .*$",
-  "(?m)^AXTEST_SUITE_OK\\s*$",
+  "(?s)SG2002_DWC2_MSC_READ_PERF size=262144 .*SG2002_DWC2_BUSYWAIT_CHECK transfer_busy_wait_iters=0 .*SG2002_DWC2_MSC_BENCH_SUMMARY .*AXTEST_SUITE_OK",
 ]
 fail_regex = [
   "(?i)\\bpanic(?:ked)?\\b",
@@ -13,8 +12,8 @@ fail_regex = [
   "(?i)SIGSEGV",
   "exit with code: 139",
   "(?m)^SG2002_DWC2_MSC_FAIL .*$",
+  "(?m)^SG2002_DWC2_MSC_WRITE_PERF .*$",
   "AXTEST_SUITE_FAIL",
   "AXTEST_CASE status=fail",
 ]
 timeout = 600
-

--- a/test-suit/arceos/axtest/sg2002-usb-msc/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+package = "arceos-axtest-sg2002-usb-msc"
+target = "riscv64gc-unknown-none-elf"
+features = [
+  "ax-std",
+  "irq",
+  "multitask",
+  "dma",
+  "ax-task/multitask",
+  "axplat-dyn/thead-mae",
+  "ax-driver/serial",
+  "ax-driver/sg2002-dwc2",
+]
+log = "Info"
+max_cpu_num = 1

--- a/test-suit/arceos/axtest/sg2002-usb-msc/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/build-riscv64gc-unknown-none-elf.toml
@@ -12,3 +12,6 @@ features = [
 ]
 log = "Info"
 max_cpu_num = 1
+
+[env]
+CARGO_ENCODED_RUSTFLAGS = "--cfg\u001faxtest\u001f--check-cfg\u001fcfg(axtest)"

--- a/test-suit/arceos/axtest/sg2002-usb-msc/build.rs
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(axtest)");
+}

--- a/test-suit/arceos/axtest/sg2002-usb-msc/src/main.rs
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/src/main.rs
@@ -1,0 +1,556 @@
+#![cfg_attr(any(feature = "ax-std", target_os = "none"), no_std)]
+#![cfg_attr(any(feature = "ax-std", target_os = "none"), no_main)]
+
+extern crate alloc;
+
+#[cfg(feature = "ax-std")]
+extern crate ax_std as std;
+
+#[cfg(all(feature = "ax-std", axtest))]
+mod sg2002_usb_msc {
+    use alloc::{string::String, vec};
+    use core::{fmt, time::Duration};
+
+    use ax_driver::usb::PlatformUsbHost;
+    use crab_usb::{
+        DeviceInfo, Endpoint,
+        err::{TransferError, USBError},
+        usb_if::{descriptor::EndpointType, endpoint::TransferRequest, transfer::Direction},
+    };
+    use rdrive::{DeviceGuard, DriverGeneric, GetDeviceError};
+
+    const DRIVER_NAME: &str = "usb-sg2002-dwc2";
+    const MSC_CLASS: u8 = 0x08;
+    const MSC_SUBCLASS_SCSI: u8 = 0x06;
+    const MSC_PROTOCOL_BULK_ONLY: u8 = 0x50;
+    const CBW_SIGNATURE: u32 = 0x4342_5355;
+    const CSW_SIGNATURE: u32 = 0x5342_5355;
+    const CBW_LEN: usize = 31;
+    const CSW_LEN: usize = 13;
+    const MAX_BLOCK_SIZE: u32 = 4096;
+
+    #[derive(Debug)]
+    pub struct MscSmokeReport {
+        pub vendor_id: u16,
+        pub product_id: u16,
+        pub inquiry_vendor: String,
+        pub inquiry_product: String,
+        pub blocks: u64,
+        pub block_size: u32,
+        pub read_checksum: u32,
+    }
+
+    #[derive(Debug)]
+    pub enum SmokeError {
+        NoHost,
+        HostLock(GetDeviceError),
+        Usb(USBError),
+        Transfer(TransferError),
+        NoMassStorageDevice,
+        MissingBulkEndpoint,
+        ShortTransfer {
+            stage: &'static str,
+            expected: usize,
+            actual: usize,
+        },
+        InvalidCswSignature(u32),
+        CswTagMismatch {
+            expected: u32,
+            actual: u32,
+        },
+        BotCommandFailed {
+            opcode: u8,
+            status: u8,
+            residue: u32,
+        },
+        InvalidCapacity {
+            blocks: u64,
+            block_size: u32,
+        },
+    }
+
+    impl fmt::Display for SmokeError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::NoHost => write!(f, "SG2002 DWC2 host not found"),
+                Self::HostLock(err) => write!(f, "host lock failed: {err:?}"),
+                Self::Usb(err) => write!(f, "USB error: {err:?}"),
+                Self::Transfer(err) => write!(f, "transfer error: {err:?}"),
+                Self::NoMassStorageDevice => write!(f, "USB mass-storage device not found"),
+                Self::MissingBulkEndpoint => write!(f, "mass-storage bulk endpoint missing"),
+                Self::ShortTransfer {
+                    stage,
+                    expected,
+                    actual,
+                } => write!(
+                    f,
+                    "{stage} short transfer: expected {expected}, actual {actual}"
+                ),
+                Self::InvalidCswSignature(signature) => {
+                    write!(f, "invalid CSW signature {signature:#010x}")
+                }
+                Self::CswTagMismatch { expected, actual } => write!(
+                    f,
+                    "CSW tag mismatch: expected {expected:#010x}, actual {actual:#010x}"
+                ),
+                Self::BotCommandFailed {
+                    opcode,
+                    status,
+                    residue,
+                } => write!(
+                    f,
+                    "BOT command {opcode:#04x} failed: status={status} residue={residue}"
+                ),
+                Self::InvalidCapacity { blocks, block_size } => {
+                    write!(
+                        f,
+                        "invalid capacity: blocks={blocks} block_size={block_size}"
+                    )
+                }
+            }
+        }
+    }
+
+    impl From<USBError> for SmokeError {
+        fn from(value: USBError) -> Self {
+            Self::Usb(value)
+        }
+    }
+
+    impl From<TransferError> for SmokeError {
+        fn from(value: TransferError) -> Self {
+            Self::Transfer(value)
+        }
+    }
+
+    impl From<GetDeviceError> for SmokeError {
+        fn from(value: GetDeviceError) -> Self {
+            Self::HostLock(value)
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct MscInterface {
+        interface_number: u8,
+        alternate_setting: u8,
+        bulk_in: u8,
+        bulk_out: u8,
+    }
+
+    struct BotTag(u32);
+
+    impl BotTag {
+        fn next(&mut self) -> u32 {
+            let tag = self.0;
+            self.0 = self.0.wrapping_add(1).max(1);
+            tag
+        }
+    }
+
+    pub async fn run() -> Result<MscSmokeReport, SmokeError> {
+        let devices = rdrive::get_list::<PlatformUsbHost>();
+        for device in devices {
+            let mut host = device.lock()?;
+            if host.name() != DRIVER_NAME {
+                continue;
+            }
+            axtest::axtest_println!("SG2002_DWC2_HOST_FOUND name={}", host.name());
+            return run_on_host(&mut host).await;
+        }
+        Err(SmokeError::NoHost)
+    }
+
+    async fn run_on_host(
+        host: &mut DeviceGuard<PlatformUsbHost>,
+    ) -> Result<MscSmokeReport, SmokeError> {
+        host.host_mut().init().await?;
+        let devices = host.host_mut().probe_devices().await?;
+        for probed in devices {
+            let Some(info) = probed.as_device_info() else {
+                continue;
+            };
+            let Some(msc) = find_msc_interface(info) else {
+                continue;
+            };
+            let vendor_id = probed.vendor_id();
+            let product_id = probed.product_id();
+            axtest::axtest_println!(
+                "SG2002_DWC2_MSC_FOUND vid={vendor_id:04x} pid={product_id:04x} interface={} \
+                 alt={} bulk_in=0x{:02x} bulk_out=0x{:02x}",
+                msc.interface_number,
+                msc.alternate_setting,
+                msc.bulk_in,
+                msc.bulk_out
+            );
+
+            let Some(info) = probed.into_device_info() else {
+                continue;
+            };
+            return run_on_device(host, info, msc, vendor_id, product_id).await;
+        }
+        Err(SmokeError::NoMassStorageDevice)
+    }
+
+    async fn run_on_device(
+        host: &mut DeviceGuard<PlatformUsbHost>,
+        info: DeviceInfo,
+        msc: MscInterface,
+        vendor_id: u16,
+        product_id: u16,
+    ) -> Result<MscSmokeReport, SmokeError> {
+        let mut device = host.host_mut().open_device(&info).await?;
+        device
+            .claim_interface(msc.interface_number, msc.alternate_setting)
+            .await?;
+        let mut endpoints = device.take_endpoints_for_interface(msc.interface_number)?;
+        let mut bulk_in = endpoints
+            .remove(&msc.bulk_in)
+            .ok_or(SmokeError::MissingBulkEndpoint)?;
+        let mut bulk_out = endpoints
+            .remove(&msc.bulk_out)
+            .ok_or(SmokeError::MissingBulkEndpoint)?;
+        let mut tag = BotTag(1);
+
+        let mut inquiry = [0u8; 36];
+        bot_inquiry(&mut bulk_out, &mut bulk_in, &mut tag, &mut inquiry).await?;
+        let inquiry_vendor = ascii_field(&inquiry[8..16]);
+        let inquiry_product = ascii_field(&inquiry[16..32]);
+        axtest::axtest_println!(
+            "SG2002_DWC2_MSC_INQUIRY vendor=\"{}\" product=\"{}\"",
+            inquiry_vendor,
+            inquiry_product
+        );
+
+        wait_until_ready(&mut bulk_out, &mut bulk_in, &mut tag).await?;
+
+        let capacity = bot_read_capacity(&mut bulk_out, &mut bulk_in, &mut tag).await?;
+        axtest::axtest_println!(
+            "SG2002_DWC2_MSC_CAPACITY blocks={} block_size={}",
+            capacity.blocks,
+            capacity.block_size
+        );
+
+        if capacity.blocks == 0 || capacity.block_size == 0 || capacity.block_size > MAX_BLOCK_SIZE
+        {
+            return Err(SmokeError::InvalidCapacity {
+                blocks: capacity.blocks,
+                block_size: capacity.block_size,
+            });
+        }
+
+        let mut block = vec![0u8; capacity.block_size as usize];
+        bot_read10(&mut bulk_out, &mut bulk_in, &mut tag, 0, &mut block).await?;
+        let read_checksum = checksum32(&block);
+        axtest::axtest_println!(
+            "SG2002_DWC2_MSC_READ_OK lba=0 bytes={} checksum=0x{read_checksum:08x}",
+            block.len()
+        );
+
+        Ok(MscSmokeReport {
+            vendor_id,
+            product_id,
+            inquiry_vendor,
+            inquiry_product,
+            blocks: capacity.blocks,
+            block_size: capacity.block_size,
+            read_checksum,
+        })
+    }
+
+    fn find_msc_interface(info: &DeviceInfo) -> Option<MscInterface> {
+        for config in info.configurations() {
+            for interface in &config.interfaces {
+                for alt in &interface.alt_settings {
+                    if alt.class != MSC_CLASS
+                        || alt.subclass != MSC_SUBCLASS_SCSI
+                        || alt.protocol != MSC_PROTOCOL_BULK_ONLY
+                    {
+                        continue;
+                    }
+                    let mut bulk_in = None;
+                    let mut bulk_out = None;
+                    for endpoint in &alt.endpoints {
+                        if endpoint.transfer_type != EndpointType::Bulk {
+                            continue;
+                        }
+                        match endpoint.direction {
+                            Direction::In => bulk_in = Some(endpoint.address),
+                            Direction::Out => bulk_out = Some(endpoint.address),
+                        }
+                    }
+                    if let (Some(bulk_in), Some(bulk_out)) = (bulk_in, bulk_out) {
+                        return Some(MscInterface {
+                            interface_number: alt.interface_number,
+                            alternate_setting: alt.alternate_setting,
+                            bulk_in,
+                            bulk_out,
+                        });
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    #[derive(Clone, Copy)]
+    struct Capacity {
+        blocks: u64,
+        block_size: u32,
+    }
+
+    async fn bot_inquiry(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        data: &mut [u8; 36],
+    ) -> Result<(), SmokeError> {
+        let command = [0x12, 0, 0, 0, data.len() as u8, 0];
+        bot_command_in(bulk_out, bulk_in, tag, &command, data).await?;
+        Ok(())
+    }
+
+    async fn wait_until_ready(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+    ) -> Result<(), SmokeError> {
+        let command = [0x00, 0, 0, 0, 0, 0];
+        for _ in 0..10 {
+            match bot_command_no_data(bulk_out, bulk_in, tag, &command).await {
+                Ok(()) => return Ok(()),
+                Err(SmokeError::BotCommandFailed { .. }) => {
+                    let mut sense = [0u8; 18];
+                    let _ = bot_request_sense(bulk_out, bulk_in, tag, &mut sense).await;
+                    axtest::axtest_println!(
+                        "SG2002_DWC2_MSC_NOT_READY sense_key=0x{:02x} asc=0x{:02x} ascq=0x{:02x}",
+                        sense[2] & 0x0f,
+                        sense[12],
+                        sense[13]
+                    );
+                    ax_task::sleep(Duration::from_millis(100));
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        bot_command_no_data(bulk_out, bulk_in, tag, &command).await
+    }
+
+    async fn bot_request_sense(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        data: &mut [u8; 18],
+    ) -> Result<(), SmokeError> {
+        let command = [0x03, 0, 0, 0, data.len() as u8, 0];
+        bot_command_in(bulk_out, bulk_in, tag, &command, data).await?;
+        Ok(())
+    }
+
+    async fn bot_read_capacity(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+    ) -> Result<Capacity, SmokeError> {
+        let command = [0x25, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let mut data = [0u8; 8];
+        bot_command_in(bulk_out, bulk_in, tag, &command, &mut data).await?;
+        let last_lba = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+        let block_size = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+        Ok(Capacity {
+            blocks: u64::from(last_lba) + 1,
+            block_size,
+        })
+    }
+
+    async fn bot_read10(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        lba: u32,
+        data: &mut [u8],
+    ) -> Result<(), SmokeError> {
+        let lba = lba.to_be_bytes();
+        let command = [0x28, 0, lba[0], lba[1], lba[2], lba[3], 0, 0, 1, 0];
+        bot_command_in(bulk_out, bulk_in, tag, &command, data).await?;
+        Ok(())
+    }
+
+    async fn bot_command_no_data(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        command: &[u8],
+    ) -> Result<(), SmokeError> {
+        let opcode = command.first().copied().unwrap_or(0);
+        let tag = tag.next();
+        let cbw = build_cbw(tag, 0, Direction::Out, command);
+        transfer_exact_out(bulk_out, &cbw, "cbw").await?;
+        read_csw(bulk_in, tag, opcode).await?;
+        Ok(())
+    }
+
+    async fn bot_command_in(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        command: &[u8],
+        data: &mut [u8],
+    ) -> Result<(), SmokeError> {
+        let opcode = command.first().copied().unwrap_or(0);
+        let tag = tag.next();
+        let cbw = build_cbw(tag, data.len() as u32, Direction::In, command);
+        transfer_exact_out(bulk_out, &cbw, "cbw").await?;
+        transfer_exact_in(bulk_in, data, "data").await?;
+        read_csw(bulk_in, tag, opcode).await?;
+        Ok(())
+    }
+
+    async fn transfer_exact_out(
+        endpoint: &mut Endpoint,
+        data: &[u8],
+        stage: &'static str,
+    ) -> Result<(), SmokeError> {
+        let completion = endpoint.wait(TransferRequest::bulk_out(data)).await?;
+        if completion.actual_length != data.len() {
+            return Err(SmokeError::ShortTransfer {
+                stage,
+                expected: data.len(),
+                actual: completion.actual_length,
+            });
+        }
+        Ok(())
+    }
+
+    async fn transfer_exact_in(
+        endpoint: &mut Endpoint,
+        data: &mut [u8],
+        stage: &'static str,
+    ) -> Result<(), SmokeError> {
+        let completion = endpoint.wait(TransferRequest::bulk_in(data)).await?;
+        if completion.actual_length != data.len() {
+            return Err(SmokeError::ShortTransfer {
+                stage,
+                expected: data.len(),
+                actual: completion.actual_length,
+            });
+        }
+        Ok(())
+    }
+
+    async fn read_csw(
+        bulk_in: &mut Endpoint,
+        expected_tag: u32,
+        opcode: u8,
+    ) -> Result<(), SmokeError> {
+        let mut csw = [0u8; CSW_LEN];
+        transfer_exact_in(bulk_in, &mut csw, "csw").await?;
+        let signature = u32::from_le_bytes([csw[0], csw[1], csw[2], csw[3]]);
+        if signature != CSW_SIGNATURE {
+            return Err(SmokeError::InvalidCswSignature(signature));
+        }
+        let actual_tag = u32::from_le_bytes([csw[4], csw[5], csw[6], csw[7]]);
+        if actual_tag != expected_tag {
+            return Err(SmokeError::CswTagMismatch {
+                expected: expected_tag,
+                actual: actual_tag,
+            });
+        }
+        let residue = u32::from_le_bytes([csw[8], csw[9], csw[10], csw[11]]);
+        let status = csw[12];
+        if status != 0 {
+            return Err(SmokeError::BotCommandFailed {
+                opcode,
+                status,
+                residue,
+            });
+        }
+        Ok(())
+    }
+
+    fn build_cbw(tag: u32, data_len: u32, direction: Direction, command: &[u8]) -> [u8; CBW_LEN] {
+        let mut cbw = [0u8; CBW_LEN];
+        cbw[0..4].copy_from_slice(&CBW_SIGNATURE.to_le_bytes());
+        cbw[4..8].copy_from_slice(&tag.to_le_bytes());
+        cbw[8..12].copy_from_slice(&data_len.to_le_bytes());
+        cbw[12] = if matches!(direction, Direction::In) {
+            0x80
+        } else {
+            0
+        };
+        cbw[14] = command.len().min(16) as u8;
+        let command_len = command.len().min(16);
+        cbw[15..15 + command_len].copy_from_slice(&command[..command_len]);
+        cbw
+    }
+
+    fn ascii_field(bytes: &[u8]) -> String {
+        let mut start = 0usize;
+        let mut end = bytes.len();
+        while start < end && bytes[start] == b' ' {
+            start += 1;
+        }
+        while end > start && bytes[end - 1] == b' ' {
+            end -= 1;
+        }
+        bytes[start..end]
+            .iter()
+            .map(|byte| {
+                if byte.is_ascii_graphic() || *byte == b' ' {
+                    *byte as char
+                } else {
+                    '.'
+                }
+            })
+            .collect()
+    }
+
+    fn checksum32(data: &[u8]) -> u32 {
+        data.iter()
+            .fold(0u32, |acc, byte| acc.wrapping_add(u32::from(*byte)))
+    }
+}
+
+#[cfg(all(feature = "ax-std", axtest))]
+#[axtest::tests]
+mod tests {
+    use axtest::prelude::*;
+
+    #[test]
+    fn sg2002_dwc2_usb_msc_read_smoke() -> axtest::AxTestResult {
+        match ax_task::future::block_on(super::sg2002_usb_msc::run()) {
+            Ok(report) => {
+                axtest_println!(
+                    "SG2002_DWC2_MSC_REPORT vid={:04x} pid={:04x} vendor=\"{}\" product=\"{}\" \
+                     blocks={} block_size={} checksum=0x{:08x}",
+                    report.vendor_id,
+                    report.product_id,
+                    report.inquiry_vendor,
+                    report.inquiry_product,
+                    report.blocks,
+                    report.block_size,
+                    report.read_checksum
+                );
+                axtest::AxTestResult::Ok
+            }
+            Err(err) => {
+                axtest_println!("SG2002_DWC2_MSC_FAIL error={err}");
+                axtest::AxTestResult::Failed
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "ax-std"))]
+fn main() {
+    eprintln!("arceos-axtest-sg2002-usb-msc is only meaningful as an ArceOS axtest target");
+}
+
+#[cfg(all(target_os = "none", not(feature = "ax-std")))]
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() {}
+
+#[cfg(all(target_os = "none", not(feature = "ax-std")))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
+}

--- a/test-suit/arceos/axtest/sg2002-usb-msc/src/main.rs
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/src/main.rs
@@ -6,18 +6,136 @@ extern crate alloc;
 #[cfg(feature = "ax-std")]
 extern crate ax_std as std;
 
+const DEFAULT_READ_BENCH_SIZES: [usize; 5] = [512, 4096, 16 * 1024, 64 * 1024, 256 * 1024];
+const MIN_READ_BENCH_BYTES: usize = 4 * 1024 * 1024;
+const MIN_READ_BENCH_ITERS: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BenchConfig {
+    pub read_sizes: [usize; 5],
+}
+
+impl Default for BenchConfig {
+    fn default() -> Self {
+        Self {
+            read_sizes: DEFAULT_READ_BENCH_SIZES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriteBenchConfig {
+    pub start_lba: u32,
+    pub blocks: u16,
+}
+
+pub fn build_read10_command(lba: u32, blocks: u16) -> [u8; 10] {
+    build_rw10_command(0x28, lba, blocks)
+}
+
+pub fn build_write10_command(lba: u32, blocks: u16) -> [u8; 10] {
+    build_rw10_command(0x2a, lba, blocks)
+}
+
+fn build_rw10_command(opcode: u8, lba: u32, blocks: u16) -> [u8; 10] {
+    let lba = lba.to_be_bytes();
+    let blocks = blocks.to_be_bytes();
+    [
+        opcode, 0, lba[0], lba[1], lba[2], lba[3], 0, blocks[0], blocks[1], 0,
+    ]
+}
+
+pub fn blocks_per_transfer(bytes: usize, block_size: usize) -> u16 {
+    if bytes == 0 || block_size == 0 {
+        return 0;
+    }
+    let blocks = bytes.div_ceil(block_size);
+    blocks.min(u16::MAX as usize) as u16
+}
+
+pub fn bench_iterations(transfer_bytes: usize) -> usize {
+    if transfer_bytes == 0 {
+        return 0;
+    }
+    let min_bytes_iters = MIN_READ_BENCH_BYTES.div_ceil(transfer_bytes);
+    min_bytes_iters.max(MIN_READ_BENCH_ITERS)
+}
+
+pub fn parse_write_bench_config(
+    get: impl Fn(&str) -> Option<&'static str>,
+) -> Option<WriteBenchConfig> {
+    if get("SG2002_DWC2_WRITE_BENCH") != Some("1") {
+        return None;
+    }
+    let start_lba = parse_u32_env(get("SG2002_DWC2_WRITE_LBA")?)?;
+    let blocks = parse_u16_env(get("SG2002_DWC2_WRITE_BLOCKS")?)?;
+    if blocks == 0 {
+        return None;
+    }
+    Some(WriteBenchConfig { start_lba, blocks })
+}
+
+#[cfg(any(test, all(feature = "ax-std", axtest)))]
+fn compile_time_write_bench_config() -> Option<WriteBenchConfig> {
+    parse_write_bench_config(|name| match name {
+        "SG2002_DWC2_WRITE_BENCH" => option_env!("SG2002_DWC2_WRITE_BENCH"),
+        "SG2002_DWC2_WRITE_LBA" => option_env!("SG2002_DWC2_WRITE_LBA"),
+        "SG2002_DWC2_WRITE_BLOCKS" => option_env!("SG2002_DWC2_WRITE_BLOCKS"),
+        _ => None,
+    })
+}
+
+fn parse_u32_env(value: &str) -> Option<u32> {
+    parse_u64_env(value).and_then(|value| u32::try_from(value).ok())
+}
+
+fn parse_u16_env(value: &str) -> Option<u16> {
+    parse_u64_env(value).and_then(|value| u16::try_from(value).ok())
+}
+
+fn parse_u64_env(value: &str) -> Option<u64> {
+    let trimmed = value.trim();
+    if let Some(hex) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        u64::from_str_radix(hex, 16).ok()
+    } else {
+        trimmed.parse().ok()
+    }
+}
+
+#[cfg(any(test, all(feature = "ax-std", axtest)))]
+fn mib_per_sec_x100(bytes: usize, nanos: u64) -> u64 {
+    if nanos == 0 {
+        return 0;
+    }
+    let value = (bytes as u128) * 100 * 1_000_000_000u128 / (nanos as u128) / 1_048_576u128;
+    value.min(u64::MAX as u128) as u64
+}
+
 #[cfg(all(feature = "ax-std", axtest))]
 mod sg2002_usb_msc {
     use alloc::{string::String, vec};
     use core::{fmt, time::Duration};
 
     use ax_driver::usb::PlatformUsbHost;
+    use ax_hal::time::monotonic_time_nanos;
+    use ax_runtime::{
+        hal::irq::{IrqError, IrqId, IrqReturn},
+        irq::{Registration, resolve_binding_irq},
+    };
     use crab_usb::{
-        DeviceInfo, Endpoint,
+        DeviceInfo, Endpoint, Event,
         err::{TransferError, USBError},
         usb_if::{descriptor::EndpointType, endpoint::TransferRequest, transfer::Direction},
     };
     use rdrive::{DeviceGuard, DriverGeneric, GetDeviceError};
+
+    use super::{
+        BenchConfig, WriteBenchConfig, bench_iterations, blocks_per_transfer, build_read10_command,
+        build_write10_command, compile_time_write_bench_config, mib_per_sec_x100,
+    };
 
     const DRIVER_NAME: &str = "usb-sg2002-dwc2";
     const MSC_CLASS: u8 = 0x08;
@@ -46,6 +164,9 @@ mod sg2002_usb_msc {
         HostLock(GetDeviceError),
         Usb(USBError),
         Transfer(TransferError),
+        MissingIrqBinding,
+        IrqResolve(IrqError),
+        IrqRegister(IrqError),
         NoMassStorageDevice,
         MissingBulkEndpoint,
         ShortTransfer {
@@ -67,6 +188,18 @@ mod sg2002_usb_msc {
             blocks: u64,
             block_size: u32,
         },
+        InvalidWriteBench {
+            start_lba: u32,
+            blocks: u16,
+            capacity_blocks: u64,
+        },
+        WriteVerifyMismatch {
+            expected: u32,
+            actual: u32,
+        },
+        TransferBusyWait {
+            iters: usize,
+        },
     }
 
     impl fmt::Display for SmokeError {
@@ -76,6 +209,9 @@ mod sg2002_usb_msc {
                 Self::HostLock(err) => write!(f, "host lock failed: {err:?}"),
                 Self::Usb(err) => write!(f, "USB error: {err:?}"),
                 Self::Transfer(err) => write!(f, "transfer error: {err:?}"),
+                Self::MissingIrqBinding => write!(f, "SG2002 DWC2 host has no binding IRQ"),
+                Self::IrqResolve(err) => write!(f, "failed to resolve USB binding IRQ: {err:?}"),
+                Self::IrqRegister(err) => write!(f, "failed to register USB IRQ: {err:?}"),
                 Self::NoMassStorageDevice => write!(f, "USB mass-storage device not found"),
                 Self::MissingBulkEndpoint => write!(f, "mass-storage bulk endpoint missing"),
                 Self::ShortTransfer {
@@ -106,6 +242,23 @@ mod sg2002_usb_msc {
                         f,
                         "invalid capacity: blocks={blocks} block_size={block_size}"
                     )
+                }
+                Self::InvalidWriteBench {
+                    start_lba,
+                    blocks,
+                    capacity_blocks,
+                } => write!(
+                    f,
+                    "invalid write bench range: lba={start_lba} blocks={blocks} \
+                     capacity_blocks={capacity_blocks}"
+                ),
+                Self::WriteVerifyMismatch { expected, actual } => write!(
+                    f,
+                    "write bench readback checksum mismatch: expected=0x{expected:08x} \
+                     actual=0x{actual:08x}"
+                ),
+                Self::TransferBusyWait { iters } => {
+                    write!(f, "DWC2 transfer path still busy-waited: iters={iters}")
                 }
             }
         }
@@ -163,8 +316,14 @@ mod sg2002_usb_msc {
     async fn run_on_host(
         host: &mut DeviceGuard<PlatformUsbHost>,
     ) -> Result<MscSmokeReport, SmokeError> {
+        let _irq = install_usb_irq(host)?;
+        axtest::axtest_println!("SG2002_DWC2_INIT_START");
         host.host_mut().init().await?;
+        host.enable_irq()?;
+        axtest::axtest_println!("SG2002_DWC2_INIT_DONE");
+        axtest::axtest_println!("SG2002_DWC2_PROBE_START");
         let devices = host.host_mut().probe_devices().await?;
+        axtest::axtest_println!("SG2002_DWC2_PROBE_DONE devices={}", devices.len());
         for probed in devices {
             let Some(info) = probed.as_device_info() else {
                 continue;
@@ -239,11 +398,69 @@ mod sg2002_usb_msc {
         }
 
         let mut block = vec![0u8; capacity.block_size as usize];
-        bot_read10(&mut bulk_out, &mut bulk_in, &mut tag, 0, &mut block).await?;
+        bot_read10(&mut bulk_out, &mut bulk_in, &mut tag, 0, 1, &mut block).await?;
         let read_checksum = checksum32(&block);
         axtest::axtest_println!(
             "SG2002_DWC2_MSC_READ_OK lba=0 bytes={} checksum=0x{read_checksum:08x}",
             block.len()
+        );
+
+        host.host().reset_dwc2_transfer_stats();
+        let read_summary = run_read_bench(
+            &mut bulk_out,
+            &mut bulk_in,
+            &mut tag,
+            capacity,
+            BenchConfig::default(),
+        )
+        .await?;
+        let write_summary = if let Some(config) = compile_time_write_bench_config() {
+            Some(run_write_bench(&mut bulk_out, &mut bulk_in, &mut tag, capacity, config).await?)
+        } else {
+            None
+        };
+        if let Some(stats) = host.host().dwc2_transfer_stats() {
+            axtest::axtest_println!(
+                "SG2002_DWC2_STATS transfers={} stages={} dma_allocs={} bounce_to_device_bytes={} \
+                 bounce_from_device_bytes={} naks={} xact_errors={} timeouts={} wait_iters={} \
+                 init_wait_iters={} transfer_busy_wait_iters={} irq_events={} \
+                 channel_completions={}",
+                stats.transfers,
+                stats.stages,
+                stats.dma_allocs,
+                stats.bounce_to_device_bytes,
+                stats.bounce_from_device_bytes,
+                stats.naks,
+                stats.xact_errors,
+                stats.timeouts,
+                stats.wait_iters,
+                stats.init_wait_iters,
+                stats.transfer_busy_wait_iters,
+                stats.irq_events,
+                stats.channel_completions
+            );
+            if stats.transfer_busy_wait_iters != 0 {
+                return Err(SmokeError::TransferBusyWait {
+                    iters: stats.transfer_busy_wait_iters,
+                });
+            }
+            axtest::axtest_println!(
+                "SG2002_DWC2_BUSYWAIT_CHECK transfer_busy_wait_iters={} irq_events={} \
+                 channel_completions={}",
+                stats.transfer_busy_wait_iters,
+                stats.irq_events,
+                stats.channel_completions
+            );
+        }
+        axtest::axtest_println!(
+            "SG2002_DWC2_MSC_BENCH_SUMMARY read_bytes={} read_ns={} read_checksum=0x{:08x} \
+             write_bytes={} write_ns={} write_checksum=0x{:08x}",
+            read_summary.bytes,
+            read_summary.nanos,
+            read_summary.checksum,
+            write_summary.map_or(0, |summary| summary.bytes),
+            write_summary.map_or(0, |summary| summary.nanos),
+            write_summary.map_or(0, |summary| summary.checksum)
         );
 
         Ok(MscSmokeReport {
@@ -254,6 +471,174 @@ mod sg2002_usb_msc {
             blocks: capacity.blocks,
             block_size: capacity.block_size,
             read_checksum,
+        })
+    }
+
+    struct UsbIrqRegistration {
+        _irq: IrqId,
+        _registration: Registration,
+    }
+
+    fn install_usb_irq(
+        host: &mut DeviceGuard<PlatformUsbHost>,
+    ) -> Result<UsbIrqRegistration, SmokeError> {
+        let (binding, handler) = host
+            .take_binding_irq_handler()
+            .ok_or(SmokeError::MissingIrqBinding)?;
+        let irq = resolve_binding_irq(binding).map_err(SmokeError::IrqResolve)?;
+        let registration =
+            Registration::register_shared(DRIVER_NAME, irq, move |_ctx| match handler.handle() {
+                Event::Nothing => IrqReturn::Unhandled,
+                Event::TransferActivity { .. } | Event::PortChange { .. } => IrqReturn::Wake,
+                Event::Stopped => IrqReturn::Handled,
+            })
+            .map_err(SmokeError::IrqRegister)?;
+        axtest::axtest_println!("SG2002_DWC2_IRQ_MODE mode=irq irq={irq:?}");
+        Ok(UsbIrqRegistration {
+            _irq: irq,
+            _registration: registration,
+        })
+    }
+
+    #[derive(Clone, Copy)]
+    struct BenchSummary {
+        bytes: usize,
+        nanos: u64,
+        checksum: u32,
+    }
+
+    async fn run_read_bench(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        capacity: Capacity,
+        config: BenchConfig,
+    ) -> Result<BenchSummary, SmokeError> {
+        let mut total_bytes = 0usize;
+        let mut total_nanos = 0u64;
+        let mut total_checksum = 0u32;
+
+        for size in config.read_sizes {
+            let block_size = capacity.block_size as usize;
+            let transfer_blocks = blocks_per_transfer(size, block_size);
+            if transfer_blocks == 0 {
+                continue;
+            }
+            let transfer_blocks = u64::from(transfer_blocks).min(capacity.blocks);
+            if transfer_blocks == 0 {
+                continue;
+            }
+            let transfer_bytes = transfer_blocks as usize * block_size;
+            let max_iters = (capacity.blocks / transfer_blocks).max(1) as usize;
+            let iters = bench_iterations(transfer_bytes).min(max_iters);
+            let mut buffer = vec![0u8; transfer_bytes];
+            let mut lba = 0u32;
+            let start = monotonic_time_nanos();
+            let mut bytes = 0usize;
+            let mut checksum = 0u32;
+            for _ in 0..iters {
+                bot_read10(
+                    bulk_out,
+                    bulk_in,
+                    tag,
+                    lba,
+                    transfer_blocks as u16,
+                    &mut buffer,
+                )
+                .await?;
+                checksum = checksum.wrapping_add(checksum32(&buffer));
+                bytes = bytes.saturating_add(buffer.len());
+                lba = lba.saturating_add(transfer_blocks as u32);
+            }
+            let nanos = monotonic_time_nanos().saturating_sub(start).max(1);
+            total_bytes = total_bytes.saturating_add(bytes);
+            total_nanos = total_nanos.saturating_add(nanos);
+            total_checksum = total_checksum.wrapping_add(checksum);
+            axtest::axtest_println!(
+                "SG2002_DWC2_MSC_READ_PERF size={} blocks={} iters={} bytes={} ns={} \
+                 mib_s_x100={} checksum=0x{checksum:08x}",
+                transfer_bytes,
+                transfer_blocks,
+                iters,
+                bytes,
+                nanos,
+                mib_per_sec_x100(bytes, nanos)
+            );
+        }
+
+        Ok(BenchSummary {
+            bytes: total_bytes,
+            nanos: total_nanos,
+            checksum: total_checksum,
+        })
+    }
+
+    async fn run_write_bench(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        capacity: Capacity,
+        config: WriteBenchConfig,
+    ) -> Result<BenchSummary, SmokeError> {
+        let end_lba = u64::from(config.start_lba) + u64::from(config.blocks);
+        if end_lba > capacity.blocks {
+            return Err(SmokeError::InvalidWriteBench {
+                start_lba: config.start_lba,
+                blocks: config.blocks,
+                capacity_blocks: capacity.blocks,
+            });
+        }
+
+        let bytes = usize::from(config.blocks) * capacity.block_size as usize;
+        let mut pattern = vec![0u8; bytes];
+        fill_write_pattern(config.start_lba, &mut pattern);
+        let expected_checksum = checksum32(&pattern);
+
+        let start = monotonic_time_nanos();
+        bot_write10(
+            bulk_out,
+            bulk_in,
+            tag,
+            config.start_lba,
+            config.blocks,
+            &pattern,
+        )
+        .await?;
+        let nanos = monotonic_time_nanos().saturating_sub(start).max(1);
+
+        let mut readback = vec![0u8; bytes];
+        bot_read10(
+            bulk_out,
+            bulk_in,
+            tag,
+            config.start_lba,
+            config.blocks,
+            &mut readback,
+        )
+        .await?;
+        let actual_checksum = checksum32(&readback);
+        if actual_checksum != expected_checksum || readback != pattern {
+            return Err(SmokeError::WriteVerifyMismatch {
+                expected: expected_checksum,
+                actual: actual_checksum,
+            });
+        }
+
+        axtest::axtest_println!(
+            "SG2002_DWC2_MSC_WRITE_PERF lba={} blocks={} size={} bytes={} ns={} mib_s_x100={} \
+             checksum=0x{expected_checksum:08x}",
+            config.start_lba,
+            config.blocks,
+            bytes,
+            bytes,
+            nanos,
+            mib_per_sec_x100(bytes, nanos)
+        );
+
+        Ok(BenchSummary {
+            bytes,
+            nanos,
+            checksum: expected_checksum,
         })
     }
 
@@ -367,11 +752,24 @@ mod sg2002_usb_msc {
         bulk_in: &mut Endpoint,
         tag: &mut BotTag,
         lba: u32,
+        blocks: u16,
         data: &mut [u8],
     ) -> Result<(), SmokeError> {
-        let lba = lba.to_be_bytes();
-        let command = [0x28, 0, lba[0], lba[1], lba[2], lba[3], 0, 0, 1, 0];
+        let command = build_read10_command(lba, blocks);
         bot_command_in(bulk_out, bulk_in, tag, &command, data).await?;
+        Ok(())
+    }
+
+    async fn bot_write10(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        lba: u32,
+        blocks: u16,
+        data: &[u8],
+    ) -> Result<(), SmokeError> {
+        let command = build_write10_command(lba, blocks);
+        bot_command_out(bulk_out, bulk_in, tag, &command, data).await?;
         Ok(())
     }
 
@@ -401,6 +799,22 @@ mod sg2002_usb_msc {
         let cbw = build_cbw(tag, data.len() as u32, Direction::In, command);
         transfer_exact_out(bulk_out, &cbw, "cbw").await?;
         transfer_exact_in(bulk_in, data, "data").await?;
+        read_csw(bulk_in, tag, opcode).await?;
+        Ok(())
+    }
+
+    async fn bot_command_out(
+        bulk_out: &mut Endpoint,
+        bulk_in: &mut Endpoint,
+        tag: &mut BotTag,
+        command: &[u8],
+        data: &[u8],
+    ) -> Result<(), SmokeError> {
+        let opcode = command.first().copied().unwrap_or(0);
+        let tag = tag.next();
+        let cbw = build_cbw(tag, data.len() as u32, Direction::Out, command);
+        transfer_exact_out(bulk_out, &cbw, "cbw").await?;
+        transfer_exact_out(bulk_out, data, "data").await?;
         read_csw(bulk_in, tag, opcode).await?;
         Ok(())
     }
@@ -508,6 +922,15 @@ mod sg2002_usb_msc {
         data.iter()
             .fold(0u32, |acc, byte| acc.wrapping_add(u32::from(*byte)))
     }
+
+    fn fill_write_pattern(start_lba: u32, data: &mut [u8]) {
+        for (index, byte) in data.iter_mut().enumerate() {
+            *byte = (index as u8)
+                .wrapping_add((start_lba & 0xff) as u8)
+                .wrapping_mul(31)
+                ^ 0xa5;
+        }
+    }
 }
 
 #[cfg(all(feature = "ax-std", axtest))]
@@ -537,6 +960,66 @@ mod tests {
                 axtest::AxTestResult::Failed
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod host_unit_tests {
+    use super::{
+        BenchConfig, WriteBenchConfig, bench_iterations, blocks_per_transfer, build_read10_command,
+        build_write10_command, compile_time_write_bench_config, mib_per_sec_x100,
+        parse_write_bench_config,
+    };
+
+    #[test]
+    fn read_and_write10_commands_encode_lba_and_block_count() {
+        assert_eq!(
+            build_read10_command(0x0102_0304, 0x0020),
+            [0x28, 0, 0x01, 0x02, 0x03, 0x04, 0, 0x00, 0x20, 0]
+        );
+        assert_eq!(
+            build_write10_command(0x0a0b_0c0d, 0x0100),
+            [0x2a, 0, 0x0a, 0x0b, 0x0c, 0x0d, 0, 0x01, 0x00, 0]
+        );
+    }
+
+    #[test]
+    fn bench_sizes_map_to_whole_blocks_and_minimum_iterations() {
+        assert_eq!(
+            BenchConfig::default().read_sizes,
+            [512, 4096, 16 * 1024, 64 * 1024, 256 * 1024]
+        );
+        assert_eq!(blocks_per_transfer(4096, 512), 8);
+        assert_eq!(blocks_per_transfer(4097, 512), 9);
+        assert_eq!(bench_iterations(512), 8192);
+        assert_eq!(bench_iterations(1024 * 1024), 8);
+        assert_eq!(mib_per_sec_x100(1024 * 1024, 1_000_000_000), 100);
+    }
+
+    #[test]
+    fn write_bench_requires_opt_in_lba_and_block_count() {
+        assert_eq!(compile_time_write_bench_config(), None);
+        assert_eq!(parse_write_bench_config(|_| None), None);
+        assert_eq!(
+            parse_write_bench_config(|name| match name {
+                "SG2002_DWC2_WRITE_BENCH" => Some("1"),
+                "SG2002_DWC2_WRITE_LBA" => Some("4096"),
+                "SG2002_DWC2_WRITE_BLOCKS" => Some("128"),
+                _ => None,
+            }),
+            Some(WriteBenchConfig {
+                start_lba: 4096,
+                blocks: 128,
+            })
+        );
+        assert_eq!(
+            parse_write_bench_config(|name| match name {
+                "SG2002_DWC2_WRITE_BENCH" => Some("1"),
+                "SG2002_DWC2_WRITE_LBA" => Some("4096"),
+                _ => None,
+            }),
+            None
+        );
     }
 }
 

--- a/test-suit/starryos/board-aka-00-sg2002/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/starryos/board-aka-00-sg2002/build-riscv64gc-unknown-none-elf.toml
@@ -5,6 +5,7 @@ features = [
   "axplat-dyn/thead-mae",
   "ax-driver/cvsd",
   "ax-driver/serial",
+  "ax-driver/sg2002-dwc2",
 ]
 log = "Info"
 max_cpu_num = 1

--- a/test-suit/starryos/board-aka-00-sg2002/usb2-lsusb/board-aka-00-sg2002.toml
+++ b/test-suit/starryos/board-aka-00-sg2002/usb2-lsusb/board-aka-00-sg2002.toml
@@ -1,0 +1,20 @@
+board_type = "AKA-00-SG2002"
+kernel_load_addr = "0x80200000"
+fit_load_addr = "0x82200000"
+bootm_addr = "0x82200000"
+shell_prefix = "root@starry:"
+shell_init_cmd = "sleep 5; echo STARRY_AKA_USB2_LSUSB_BEGIN; lsusb > /tmp/starry-aka-usb2-lsusb.out; cat /tmp/starry-aka-usb2-lsusb.out; if ! grep -Eq 'ID 1d6b:0002' /tmp/starry-aka-usb2-lsusb.out; then echo STARRY_AKA_USB2_ROOT_HUB_MISSING; elif ! grep -Eq 'ID 05e3:06(10|20)' /tmp/starry-aka-usb2-lsusb.out; then echo STARRY_AKA_USB2_DEVICE_MISSING; else echo STARRY_AKA_USB2_LSUSB_OK; fi"
+success_regex = ["(?m)^STARRY_AKA_USB2_LSUSB_OK\\s*$"]
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)segmentation fault",
+  "(?i)SIGSEGV",
+  "exit with code: 139",
+  "failed to determine root device",
+  "(?m)^unable to initialize libusb: .*$",
+  "(?i)(lsusb|tee|grep|sh): .*not found",
+  "(?m)^lsusb: .*",
+  "(?m)^STARRY_AKA_USB2_ROOT_HUB_MISSING\\s*$",
+  "(?m)^STARRY_AKA_USB2_DEVICE_MISSING\\s*$",
+]
+timeout = 600

--- a/test-suit/starryos/board-aka-00-sg2002/usb2-lsusb/board-aka-00-sg2002.toml
+++ b/test-suit/starryos/board-aka-00-sg2002/usb2-lsusb/board-aka-00-sg2002.toml
@@ -3,7 +3,8 @@ kernel_load_addr = "0x80200000"
 fit_load_addr = "0x82200000"
 bootm_addr = "0x82200000"
 shell_prefix = "root@starry:"
-shell_init_cmd = "sleep 5; echo STARRY_AKA_USB2_LSUSB_BEGIN; lsusb > /tmp/starry-aka-usb2-lsusb.out; cat /tmp/starry-aka-usb2-lsusb.out; if ! grep -Eq 'ID 1d6b:0002' /tmp/starry-aka-usb2-lsusb.out; then echo STARRY_AKA_USB2_ROOT_HUB_MISSING; elif ! grep -Eq 'ID 05e3:06(10|20)' /tmp/starry-aka-usb2-lsusb.out; then echo STARRY_AKA_USB2_DEVICE_MISSING; else echo STARRY_AKA_USB2_LSUSB_OK; fi"
+# The AKA-00 board lab may attach either a Genesys USB2 hub or the Realtek UVC camera.
+shell_init_cmd = "sleep 5; echo STARRY_AKA_USB2_LSUSB_BEGIN; lsusb > /tmp/starry-aka-usb2-lsusb.out; cat /tmp/starry-aka-usb2-lsusb.out; if ! grep -Eq 'ID 1d6b:0002' /tmp/starry-aka-usb2-lsusb.out; then echo STARRY_AKA_USB2_ROOT_HUB_MISSING; elif ! grep -Eq 'ID (05e3:06(10|20)|0bda:5856)' /tmp/starry-aka-usb2-lsusb.out; then echo STARRY_AKA_USB2_DEVICE_MISSING; else echo STARRY_AKA_USB2_LSUSB_OK; fi"
 success_regex = ["(?m)^STARRY_AKA_USB2_LSUSB_OK\\s*$"]
 fail_regex = [
   "(?i)\\bpanic(?:ked)?\\b",


### PR DESCRIPTION
## 问题

SG2002/AKA 的 USB 控制器在 DTB 中是 `cvitek,cv182x-usb` DWC2/OTG 控制器，本轮需要直接在驱动层验证 USB2 host 的 internal DMA 路径。Starry `usbfs` 或用户态 `lsusb` 会把问题混到文件系统和用户态接口里，因此先用 ArceOS axtest 做驱动功能 smoke，再补 Starry 侧 `usbfs`/board 用例验证。

同时，新 axtest package 需要加入 workspace members；原有 `cargo xtask clippy --since` 会把 root `Cargo.toml` 的 workspace member 变更判成全仓 hard fallback，导致 CI 的 clippy job 退化到 178 个 package / 612 个 check 并被取消。

rebase 到最新 `dev` 后，Starry `usbfs` 的初始 host probe 暴露了一个顺序问题：DWC2 internal-DMA backend 已经改成 IRQ completion 驱动，但 `usbfs` 仍然先 `probe_devices()`、后 enable IRQ，导致 AKA-00 camera/TPU 用例启动时卡在 root port reset 后的 USB 枚举阶段。

最新 AKA-00 self-hosted board CI 中，`usb2-lsusb` 已能枚举 root hub 和板上 Realtek UVC camera `0bda:5856`，但旧用例只接受 Genesys hub `05e3:0610/0620`，因此误报 `STARRY_AKA_USB2_DEVICE_MISSING`。

## 变更

1. 在 `crab-usb` 新增 DWC2 kmod backend，并公开 `USBHost::new_dwc2`，实现 internal DMA host 的 root hub、设备、端点、control/bulk/interrupt transfer 和 IRQ event 路径。
2. 在 `ax-driver` 新增 `sg2002-dwc2` feature，匹配 `cvitek,cv182x-usb`，完成 SG2002 board 侧 clocks、TOP/PHY/UTMI、VBUS GPIO、FIFO 参数和 DWC2 host 创建。
3. 扩展 ArceOS board axtest runner，让 `test-suit/arceos/axtest/.../board-*.toml` 能被 `cargo xtask arceos test board` 发现，并为 axtest board case 注入 `--cfg axtest --check-cfg cfg(axtest)`。
4. 新增 `arceos-axtest-sg2002-usb-msc`，测试中直接从 `rdrive::get_list::<ax_driver::usb::PlatformUsbHost>()` 取出 `usb-sg2002-dwc2` host，不经过 Starry `usbfs`，并通过 BOT 只读执行 `INQUIRY`、`TEST UNIT READY`、`READ CAPACITY(10)`、`READ(10)`。
5. DWC2 DMA 数据路径使用 coherent bounce buffer，并修正 OUT 传输完成时的实际长度统计，避免只读 BOT smoke 被 DMA buffer 生命周期或 OUT stage 长度处理影响。
6. 修复 `axbuild` 增量 clippy 的 root manifest 分类：root `Cargo.toml` 只新增/删除字面量 `workspace.members` 时映射到对应 workspace package，保留外部依赖、全局配置、变更 glob member 等情况的 full fallback。
7. rebase 最新 `dev` 时保留主线 `starry-kernel` feature 迁移，把 `sg2002-wifi` 继续接到 `ax-runtime/aic8800-wifi`，避免重新引用已移除的 `ax-feat` 依赖。
8. 调整 Starry `usbfs` 初始 host 初始化顺序：host `init()` 后先启用 controller/framework IRQ 并 bootstrap，再执行 `probe_devices()`，保证 DWC2 IRQ-driven control transfer 在枚举阶段能收到 completion。
9. 修正 AKA-00 `usb2-lsusb` board case 的外接设备判定，保留 Genesys hub 匹配，同时接受当前 CI 板实际枚举到的 Realtek UVC camera `0bda:5856`。
10. 根据复审补齐 DWC2 后端 `unsafe impl`、MMIO volatile 访问和 DMA buffer 边界的 SAFETY 不变量说明；同时移除 `DeviceDescriptor` 的 `zeroed()` 初始化和 unaligned struct read，改用显式未初始化状态与按字节解析。

## 验证

- `cargo fmt --check`
- `cargo test -p crab-usb --lib`：33 passed
- `cargo test -p axbuild --lib`：705 passed
- `cargo xtask clippy --package arceos-axtest-sg2002-usb-msc`
- `cargo xtask clippy --package crab-usb`
- `cargo xtask clippy --package axbuild`
- `cargo xtask clippy --package ax-driver`
- `cargo xtask clippy --since origin/dev`：18 package(s), 70 check(s), all passed
- `cargo xtask arceos test board -l`
- `cargo xtask arceos test board --board aka-00-sg2002 -c sg2002-usb-msc`
- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package starry-kernel`：19 check(s), all passed
- `cargo xtask starry test board --board aka-00-sg2002 -c tennis-yolo`
- 本地复现旧 `usb2-lsusb` shell 判定对 `ID 0bda:5856` 输出 `STARRY_AKA_USB2_DEVICE_MISSING`，修复后同一输出得到 `STARRY_AKA_USB2_LSUSB_OK`
- `cargo xtask starry test board -l`

ArceOS U 盘 smoke 输出中的关键 marker：

```text
SG2002_DWC2_HOST_FOUND name=usb-sg2002-dwc2
SG2002_DWC2_MSC_FOUND vid=30de pid=6544 interface=0 alt=0 bulk_in=0x81 bulk_out=0x02
SG2002_DWC2_MSC_INQUIRY vendor="Kingston" product="DataTraveler 2.0"
SG2002_DWC2_MSC_CAPACITY blocks=60549120 block_size=512
SG2002_DWC2_MSC_READ_OK lba=0 bytes=512 checksum=0x0000c445
AXTEST_SUITE_OK
```

Starry AKA-00 camera/TPU 用例输出中的关键 marker：

```text
usbfs: host on bus 1 initialized
AKARS_TENNIS_VALIDATE_PASS images=3
STARRY_AKA00_TENNIS_DETECT_OK
```
