### PR TITLE
feat(starry): support rtnetlink IPv4 configuration

### DIFF
--- a/drivers/ax-driver/src/net/realtek.rs
+++ b/drivers/ax-driver/src/net/realtek.rs
@@ -1,5 +1,3 @@
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use log::{debug, info, warn};
 use pcie::CommandRegister;
 use rdrive::probe::{
@@ -12,7 +10,6 @@ use crate::{PciIrqRequirement, net::ProbePciNet};
 
 const DRIVER_NAME: &str = "realtek-rtl8125";
 const RTL8125_DMA_MASK: u64 = u32::MAX as u64;
-static REGISTERED_RTL8125: AtomicBool = AtomicBool::new(false);
 
 crate::model_register!(
     name: "Realtek RTL8125 PCI Network",
@@ -30,11 +27,6 @@ fn probe(mut probe: ProbePci<'_>) -> Result<(), OnProbeError> {
     }
 
     let address = endpoint.address();
-    if REGISTERED_RTL8125.load(Ordering::Acquire) {
-        info!("RTL8125 at {address} left unused: first port already registered");
-        return Err(OnProbeError::NotMatch);
-    }
-
     let Some((bar_index, bar)) = first_mmio_bar(endpoint) else {
         warn!("RTL8125 at {address} left unused: no PCI MMIO BAR found");
         return Err(OnProbeError::NotMatch);
@@ -73,13 +65,6 @@ fn probe(mut probe: ProbePci<'_>) -> Result<(), OnProbeError> {
             "RTL8125 at {address}: link is down after init; registering and checking link again \
              on tx, status={status:?}"
         );
-    }
-    if REGISTERED_RTL8125
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_err()
-    {
-        info!("RTL8125 at {address} left unused: first port already registered");
-        return Err(OnProbeError::NotMatch);
     }
 
     let irq = probe.register_net(DRIVER_NAME, dev, PciIrqRequirement::Required)?;

--- a/drivers/interface/rdif-pinctrl/src/fdt.rs
+++ b/drivers/interface/rdif-pinctrl/src/fdt.rs
@@ -124,11 +124,7 @@ impl FdtPinctrl {
 
         let active_value = regulator_node.get_property("enable-active-low").is_none();
         let gpio_active_low = Self::gpio_flags_active_low(regulator_node);
-        let output_value = if gpio_active_low {
-            !active_value
-        } else {
-            active_value
-        };
+        let output_value = active_value && !gpio_active_low;
 
         for line in lines {
             Self::drive_gpio_line(interface, line, output_value, owner)?;
@@ -531,7 +527,7 @@ mod tests {
     }
 
     #[test]
-    fn fixed_regulator_uses_gpio_flags_and_enable_active_low_for_output_value() {
+    fn fixed_regulator_uses_enable_active_low_for_output_value() {
         let mut fdt = Fdt::new();
         let root = fdt.root_id();
         fdt.add_node(
@@ -543,7 +539,7 @@ mod tests {
             node_with_props(
                 "vbus-regulator",
                 &[
-                    prop_u32s("gpios", &[20, 5, 1]),
+                    prop_u32s("gpios", &[20, 5, 0]),
                     Property::new("enable-active-low", Vec::new()),
                 ],
             ),
@@ -565,7 +561,36 @@ mod tests {
         )));
         assert!(recorder.configs.contains(&ConfigSetting::pin(
             PinId::new(37),
-            PinConfig::OutputValue(true)
+            PinConfig::OutputValue(false)
+        )));
+    }
+
+    #[test]
+    fn fixed_regulator_uses_gpio_active_low_flag_for_output_value() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props("gpio1@0", &[prop_u32s("phandle", &[20])]),
+        );
+        let regulator = fdt.add_node(
+            root,
+            node_with_props("vbus-regulator", &[prop_u32s("gpios", &[20, 5, 1])]),
+        );
+        let mut recorder = Recorder::new();
+
+        FdtPinctrl::apply_fixed_regulator(
+            &mut recorder,
+            &fdt,
+            fdt.node(regulator).unwrap(),
+            &TestParser,
+            "dwc-xhci-vbus",
+        )
+        .unwrap();
+
+        assert!(recorder.configs.contains(&ConfigSetting::pin(
+            PinId::new(37),
+            PinConfig::OutputValue(false)
         )));
     }
 

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -70,7 +70,7 @@ use alloc::{
     borrow::ToOwned, boxed::Box, format, string::String, sync::Arc, task::Wake, vec, vec::Vec,
 };
 use core::{
-    net::IpAddr,
+    net::{IpAddr, Ipv4Addr},
     sync::atomic::{AtomicBool, Ordering},
     task::Waker,
     time::Duration,
@@ -530,6 +530,26 @@ pub fn interface_by_id(id: InterfaceId) -> Option<InterfaceInfo> {
 /// Returns the IPv4 configuration for an interface by name.
 pub fn ipv4_config(name: &str) -> Option<Ipv4InterfaceConfig> {
     get_control().ipv4_config(name)
+}
+
+/// Assigns a static IPv4 address to an interface at runtime.
+pub fn set_interface_ipv4(interface_id: InterfaceId, ip: Ipv4Addr, prefix_len: u8) -> AxResult {
+    {
+        let mut service = get_service();
+        service.configure_static_ipv4(interface_id, Ipv4Address::from(ip.octets()), prefix_len)?;
+    }
+    request_poll();
+    Ok(())
+}
+
+/// Removes a configured IPv4 address from an interface at runtime.
+pub fn remove_interface_ipv4(interface_id: InterfaceId, ip: Ipv4Addr, prefix_len: u8) -> AxResult {
+    {
+        let mut service = get_service();
+        service.remove_static_ipv4(interface_id, Ipv4Address::from(ip.octets()), prefix_len)?;
+    }
+    request_poll();
+    Ok(())
 }
 
 /// Returns public snapshots of configured IPv4 default routes.

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -525,6 +525,13 @@ impl Router {
         self.devices.get(dev).map(|device| device.interface_id)
     }
 
+    /// Finds the router device index for a public interface id.
+    pub fn device_index_for_interface_id(&self, interface_id: InterfaceId) -> Option<usize> {
+        self.devices
+            .iter()
+            .position(|device| device.interface_id == interface_id)
+    }
+
     /// Returns names of all registered devices.
     pub fn device_names(&self) -> Vec<String> {
         self.devices

--- a/net/ax-net/src/service.rs
+++ b/net/ax-net/src/service.rs
@@ -62,7 +62,7 @@ use core::{
     task::{Context, Waker},
 };
 
-use ax_errno::{AxResult, ax_err_type};
+use ax_errno::{AxError, AxResult, ax_err_type};
 use ax_hal::time::{NANOS_PER_MICROS, TimeValue, monotonic_time_nanos, wall_time_nanos};
 use ax_kspin::SpinRwLock as RwLock;
 use ax_task::future::sleep_until;
@@ -634,6 +634,85 @@ impl Service {
     /// Finds the router device index for an interface name such as `wlan0`.
     pub fn device_index(&self, name: &str) -> Option<usize> {
         self.router.device_index(name)
+    }
+
+    /// Assigns a static IPv4 address to an interface at runtime.
+    ///
+    /// The current control model owns a single IPv4 address per interface. Keep
+    /// `ip addr add` conservative and report `EEXIST` once an address is
+    /// already present instead of silently replacing it or pretending to support
+    /// secondary addresses.
+    pub fn configure_static_ipv4(
+        &mut self,
+        interface_id: InterfaceId,
+        address: Ipv4Address,
+        prefix_len: u8,
+    ) -> AxResult {
+        if prefix_len > 32 {
+            return Err(AxError::InvalidInput);
+        }
+
+        let dev = self
+            .router
+            .device_index_for_interface_id(interface_id)
+            .ok_or(AxError::NoSuchDevice)?;
+        let interface = self.interface_for_dev(dev).ok_or(AxError::NoSuchDevice)?;
+        if interface.kind != InterfaceKind::Ethernet {
+            return Err(AxError::OperationNotSupported);
+        }
+        if interface.ipv4.is_some() {
+            return Err(AxError::AlreadyExists);
+        }
+
+        self.dhcp.retain(|state| state.dev != dev);
+        self.commit_network_state(NetworkStateUpdate {
+            interface_id,
+            dev,
+            metric: interface.metric,
+            old_ipv4: interface.ipv4,
+            ipv4: Some(Ipv4Cidr::new(address, prefix_len)),
+            gateway: None,
+            dns_source: DnsSource::Dhcp,
+            dns_servers: Vec::new(),
+        });
+        Ok(())
+    }
+
+    /// Removes a configured IPv4 address from an interface at runtime.
+    pub fn remove_static_ipv4(
+        &mut self,
+        interface_id: InterfaceId,
+        address: Ipv4Address,
+        prefix_len: u8,
+    ) -> AxResult {
+        if prefix_len > 32 {
+            return Err(AxError::InvalidInput);
+        }
+
+        let dev = self
+            .router
+            .device_index_for_interface_id(interface_id)
+            .ok_or(AxError::NoSuchDevice)?;
+        let interface = self.interface_for_dev(dev).ok_or(AxError::NoSuchDevice)?;
+        // Runtime deletion is intentionally exact: with one IPv4 address per
+        // interface, a mismatched address or prefix must not clear the current
+        // configuration.
+        if interface.ipv4 != Some(Ipv4Cidr::new(address, prefix_len)) {
+            return Err(AxError::NotFound);
+        }
+
+        self.dhcp.retain(|state| state.dev != dev);
+        self.commit_network_state(NetworkStateUpdate {
+            interface_id,
+            dev,
+            metric: interface.metric,
+            old_ipv4: interface.ipv4,
+            ipv4: None,
+            gateway: None,
+            dns_source: DnsSource::Dhcp,
+            dns_servers: Vec::new(),
+        });
+        Ok(())
     }
 
     /// Reconfigures one wireless device as SoftAP: static IPv4 plus optional DHCP server.

--- a/os/StarryOS/kernel/src/file/netlink.rs
+++ b/os/StarryOS/kernel/src/file/netlink.rs
@@ -27,13 +27,14 @@ use alloc::{
 };
 use core::{
     mem::size_of,
+    net::Ipv4Addr,
     sync::atomic::{AtomicBool, Ordering},
     task::Context,
 };
 
-use ax_errno::{AxError, AxResult};
+use ax_errno::{AxError, AxResult, LinuxError};
 use ax_kspin::SpinNoIrq as Mutex;
-use ax_net::{InterfaceFlags, InterfaceInfo, InterfaceKind};
+use ax_net::{InterfaceFlags, InterfaceId, InterfaceInfo, InterfaceKind};
 use ax_task::future::{block_on, poll_io};
 use axpoll::{IoEvents, PollSet, Pollable};
 use linux_raw_sys::{
@@ -56,6 +57,9 @@ const MAX_QUEUED: usize = 128;
 const NLMSG_ERROR: u16 = 2;
 const NLMSG_DONE: u16 = 3;
 const NLM_F_MULTI: u16 = 2;
+const NLM_F_ROOT: u16 = 0x100;
+const NLM_F_MATCH: u16 = 0x200;
+const NLM_F_DUMP: u16 = NLM_F_ROOT | NLM_F_MATCH;
 
 /// Generic netlink controller family ID. Linux's
 /// `Documentation/netlink/genetlink-legacy.rst` reserves this for
@@ -78,7 +82,9 @@ const RTM_GETLINK: u16 = 18;
 const RTM_NEWLINK: u16 = 16;
 const RTM_GETADDR: u16 = 22;
 const RTM_NEWADDR: u16 = 20;
+const RTM_DELADDR: u16 = 21;
 
+const AF_UNSPEC: u8 = 0;
 const AF_INET: u8 = 2;
 const ARPHRD_ETHER: u16 = 1;
 const ARPHRD_LOOPBACK: u16 = 772;
@@ -183,6 +189,48 @@ struct AddrInfo {
     scope: u8,
     local: [u8; 4],
     broadcast: Option<[u8; 4]>,
+}
+
+#[derive(Default)]
+struct LinkFilter {
+    index: Option<i32>,
+    name: Option<String>,
+}
+
+impl LinkFilter {
+    // `iproute2` resolves `dev <name>` by sending RTM_GETLINK with either an
+    // ifindex or IFLA_IFNAME. Keep dump requests unfiltered, but honor those
+    // selectors so a lookup for eth1 does not accidentally return lo first.
+    fn matches(&self, link: &LinkInfo) -> bool {
+        self.index.is_none_or(|index| link.index == index)
+            && self.name.as_ref().is_none_or(|name| link.name == *name)
+    }
+
+    fn has_selector(&self) -> bool {
+        self.index.is_some() || self.name.is_some()
+    }
+}
+
+#[derive(Default)]
+struct AddrFilter {
+    family: u8,
+    index: Option<u32>,
+    label: Option<String>,
+}
+
+impl AddrFilter {
+    // `ip addr show dev <name>` resolves the link first, then sends
+    // RTM_GETADDR with `ifaddrmsg.ifa_index`. Some callers also include
+    // IFA_LABEL. An unfiltered dump still returns every IPv4 address.
+    fn matches(&self, addr: &AddrInfo) -> bool {
+        matches!(self.family, AF_UNSPEC | AF_INET)
+            && self.index.is_none_or(|index| addr.index == index)
+            && self.label.as_ref().is_none_or(|label| addr.label == *label)
+    }
+
+    fn has_selector(&self) -> bool {
+        self.index.is_some() || self.label.is_some()
+    }
 }
 
 #[derive(Clone, Copy, Default)]
@@ -353,20 +401,66 @@ impl NetlinkSocket {
         let mut response = Vec::new();
         match header.ty {
             RTM_GETLINK => {
+                let filter = parse_link_filter(request);
+                let mut matched = false;
                 for link in link_infos() {
                     if !in_root && link.index != 1 {
                         continue;
                     }
+                    if !filter.matches(&link) {
+                        continue;
+                    }
+                    matched = true;
                     push_link_message(&mut response, header.seq, pid, &link);
+                }
+                if !matched && !is_dump_request(header.flags) && filter.has_selector() {
+                    push_nlmsg_error_from_ax(&mut response, request, pid, AxError::NoSuchDevice);
+                    return Ok(response);
                 }
             }
             RTM_GETADDR => {
+                let filter = parse_addr_filter(request);
+                let mut matched = false;
                 for addr in addr_infos() {
                     if !in_root && addr.index != 1 {
                         continue;
                     }
+                    if !filter.matches(&addr) {
+                        continue;
+                    }
+                    matched = true;
                     push_addr_message(&mut response, header.seq, pid, &addr);
                 }
+                if !matched && !is_dump_request(header.flags) && filter.has_selector() {
+                    push_nlmsg_error_from_ax(&mut response, request, pid, AxError::NoSuchDevice);
+                    return Ok(response);
+                }
+            }
+            RTM_NEWADDR => {
+                let error = match handle_newaddr_request(request) {
+                    Ok(()) => 0,
+                    Err(err) => {
+                        let linux_err = LinuxError::from(err);
+                        -linux_err.code()
+                    }
+                };
+                push_nlmsg_error(&mut response, request, pid, error);
+                return Ok(response);
+            }
+            RTM_DELADDR => {
+                let error = match handle_deladdr_request(request) {
+                    Ok(()) => 0,
+                    // Linux reports EADDRNOTAVAIL when the requested address
+                    // is not assigned; ax-net uses NotFound for that internal
+                    // state so translate it explicitly for iproute2.
+                    Err(AxError::NotFound) => -LinuxError::EADDRNOTAVAIL.code(),
+                    Err(err) => {
+                        let linux_err = LinuxError::from(err);
+                        -linux_err.code()
+                    }
+                };
+                push_nlmsg_error(&mut response, request, pid, error);
+                return Ok(response);
             }
             _ => {}
         }
@@ -728,6 +822,170 @@ fn push_nlmsg_error(out: &mut Vec<u8>, request_bytes: &[u8], pid: u32, error: i3
     push_nl_header(out, NLMSG_ERROR, 0, header.seq, pid, payload_len);
     out.extend_from_slice(&error.to_ne_bytes());
     out.extend_from_slice(&request_bytes[..req_len]);
+}
+
+fn push_nlmsg_error_from_ax(out: &mut Vec<u8>, request_bytes: &[u8], pid: u32, err: AxError) {
+    let linux_err = LinuxError::from(err);
+    push_nlmsg_error(out, request_bytes, pid, -linux_err.code());
+}
+
+fn handle_newaddr_request(request: &[u8]) -> AxResult {
+    if request.len() < size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>() {
+        return Err(AxError::InvalidInput);
+    }
+    let header = unsafe { request.as_ptr().cast::<NlMsgHdr>().read_unaligned() };
+    let msg_len = (header.len as usize).min(request.len());
+    if msg_len < size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>() {
+        return Err(AxError::InvalidInput);
+    }
+    let addr = unsafe {
+        request
+            .as_ptr()
+            .add(size_of::<NlMsgHdr>())
+            .cast::<IfAddrMsg>()
+            .read_unaligned()
+    };
+    if addr.family != AF_INET {
+        return Err(AxError::from(LinuxError::EAFNOSUPPORT));
+    }
+
+    let attrs = &request[size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>()..msg_len];
+    let local = parse_ipv4_attr(attrs, IFA_LOCAL)
+        .or_else(|| parse_ipv4_attr(attrs, IFA_ADDRESS))
+        .ok_or(AxError::InvalidInput)?;
+    ax_net::set_interface_ipv4(
+        InterfaceId::new(addr.index),
+        Ipv4Addr::from(local),
+        addr.prefix_len,
+    )
+}
+
+fn handle_deladdr_request(request: &[u8]) -> AxResult {
+    if request.len() < size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>() {
+        return Err(AxError::InvalidInput);
+    }
+    let header = unsafe { request.as_ptr().cast::<NlMsgHdr>().read_unaligned() };
+    let msg_len = (header.len as usize).min(request.len());
+    if msg_len < size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>() {
+        return Err(AxError::InvalidInput);
+    }
+    let addr = unsafe {
+        request
+            .as_ptr()
+            .add(size_of::<NlMsgHdr>())
+            .cast::<IfAddrMsg>()
+            .read_unaligned()
+    };
+    if addr.family != AF_INET {
+        return Err(AxError::from(LinuxError::EAFNOSUPPORT));
+    }
+
+    let attrs = &request[size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>()..msg_len];
+    let local = parse_ipv4_attr(attrs, IFA_LOCAL)
+        .or_else(|| parse_ipv4_attr(attrs, IFA_ADDRESS))
+        .ok_or(AxError::InvalidInput)?;
+    ax_net::remove_interface_ipv4(
+        InterfaceId::new(addr.index),
+        Ipv4Addr::from(local),
+        addr.prefix_len,
+    )
+}
+
+fn parse_ipv4_attr(mut buf: &[u8], ty: u16) -> Option<[u8; 4]> {
+    while buf.len() >= size_of::<RtAttr>() {
+        let attr = unsafe { buf.as_ptr().cast::<RtAttr>().read_unaligned() };
+        let len = attr.len as usize;
+        if len < size_of::<RtAttr>() || len > buf.len() {
+            return None;
+        }
+        if attr.ty == ty {
+            let payload = &buf[size_of::<RtAttr>()..len];
+            return (payload.len() >= 4)
+                .then(|| payload[..4].try_into().ok())
+                .flatten();
+        }
+        let aligned = (len + 3) & !3;
+        if aligned > buf.len() {
+            return None;
+        }
+        buf = &buf[aligned..];
+    }
+    None
+}
+
+fn parse_addr_filter(request: &[u8]) -> AddrFilter {
+    if request.len() < size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>() {
+        return AddrFilter::default();
+    }
+    let header = unsafe { request.as_ptr().cast::<NlMsgHdr>().read_unaligned() };
+    let msg_len = (header.len as usize).min(request.len());
+    if msg_len < size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>() {
+        return AddrFilter::default();
+    }
+    let info = unsafe {
+        request
+            .as_ptr()
+            .add(size_of::<NlMsgHdr>())
+            .cast::<IfAddrMsg>()
+            .read_unaligned()
+    };
+    let attrs = &request[size_of::<NlMsgHdr>() + size_of::<IfAddrMsg>()..msg_len];
+    AddrFilter {
+        family: info.family,
+        index: (info.index > 0).then_some(info.index),
+        label: parse_string_attr(attrs, IFA_LABEL),
+    }
+}
+
+fn parse_link_filter(request: &[u8]) -> LinkFilter {
+    if request.len() < size_of::<NlMsgHdr>() + size_of::<IfInfoMsg>() {
+        return LinkFilter::default();
+    }
+    let header = unsafe { request.as_ptr().cast::<NlMsgHdr>().read_unaligned() };
+    let msg_len = (header.len as usize).min(request.len());
+    if msg_len < size_of::<NlMsgHdr>() + size_of::<IfInfoMsg>() {
+        return LinkFilter::default();
+    }
+    let info = unsafe {
+        request
+            .as_ptr()
+            .add(size_of::<NlMsgHdr>())
+            .cast::<IfInfoMsg>()
+            .read_unaligned()
+    };
+    let attrs = &request[size_of::<NlMsgHdr>() + size_of::<IfInfoMsg>()..msg_len];
+    LinkFilter {
+        index: (info.index > 0).then_some(info.index),
+        name: parse_string_attr(attrs, IFLA_IFNAME),
+    }
+}
+
+fn parse_string_attr(mut buf: &[u8], ty: u16) -> Option<String> {
+    while buf.len() >= size_of::<RtAttr>() {
+        let attr = unsafe { buf.as_ptr().cast::<RtAttr>().read_unaligned() };
+        let len = attr.len as usize;
+        if len < size_of::<RtAttr>() || len > buf.len() {
+            return None;
+        }
+        if attr.ty == ty {
+            let payload = &buf[size_of::<RtAttr>()..len];
+            let end = payload
+                .iter()
+                .position(|&byte| byte == 0)
+                .unwrap_or(payload.len());
+            return core::str::from_utf8(&payload[..end]).ok().map(String::from);
+        }
+        let aligned = (len + 3) & !3;
+        if aligned > buf.len() {
+            return None;
+        }
+        buf = &buf[aligned..];
+    }
+    None
+}
+
+fn is_dump_request(flags: u16) -> bool {
+    flags & NLM_F_DUMP == NLM_F_DUMP
 }
 
 /// Walk the attribute stream after a `genlmsghdr` and return the

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -426,7 +426,8 @@ pub fn sys_setsockopt(
 
     if let Ok(socket) = NetlinkSocket::from_fd(fd) {
         use linux_raw_sys::net::{
-            SO_ATTACH_FILTER, SO_LOCK_FILTER, SO_PASSCRED, SO_RCVBUF, SO_RCVBUFFORCE, SOL_SOCKET,
+            SO_ATTACH_FILTER, SO_LOCK_FILTER, SO_PASSCRED, SO_RCVBUF, SO_RCVBUFFORCE, SO_SNDBUF,
+            SO_SNDBUFFORCE, SOL_SOCKET,
         };
 
         match (level, optname) {
@@ -436,6 +437,14 @@ pub fn sys_setsockopt(
             (SOL_SOCKET, SO_RCVBUF | SO_RCVBUFFORCE) => {
                 let value = read_int_sockopt(optval, optlen)?;
                 socket.set_receive_buffer_size(value.max(0) as usize);
+                return Ok(0);
+            }
+            (SOL_SOCKET, SO_SNDBUF | SO_SNDBUFFORCE) => {
+                // Starry netlink handles send requests synchronously and does
+                // not have a byte-counted send queue yet. Accept the option so
+                // iproute2 can finish socket setup; the receive side is also
+                // only partially modeled and still uses a fixed message limit.
+                let _ = read_int_sockopt(optval, optlen)?;
                 return Ok(0);
             }
             (SOL_SOCKET, SO_PASSCRED) => {

--- a/test-suit/starryos/board-orangepi-5-plus/rtnetlink/board-orangepi-5-plus.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/rtnetlink/board-orangepi-5-plus.toml
@@ -1,0 +1,56 @@
+board_type = "OrangePi-5-Plus"
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = '''
+printf '\nSTARRY_RTNL_BEGIN\n'
+ok=1
+
+ip addr del 192.168.10.2/24 dev eth1 >/tmp/starry-rtnl-cleanup 2>&1 || true
+ip link show dev eth1 || ok=0
+if ip link show dev starry_missing0 >/tmp/starry-rtnl-missing 2>&1; then
+  echo STARRY_RTNL_BAD_MISSING_LINK
+  ok=0
+else
+  cat /tmp/starry-rtnl-missing
+fi
+
+ip addr add 192.168.10.2/24 dev eth1 || ok=0
+ip -o addr show dev eth1 || ok=0
+ip addr del 192.168.10.2/24 dev eth1 || ok=0
+if ip addr del 192.168.10.2/24 dev eth1 >/tmp/starry-rtnl-del-missing 2>&1; then
+  echo STARRY_RTNL_BAD_DELADDR_MISSING
+  ok=0
+else
+  cat /tmp/starry-rtnl-del-missing
+fi
+
+if ip -o addr show dev eth1 | grep -q '192\.168\.10\.2/24'; then
+  echo STARRY_RTNL_BAD_DELADDR
+  ok=0
+fi
+
+ip addr add 192.168.10.2/24 dev eth1 || ok=0
+ip -o addr show dev eth1 || ok=0
+
+if [ "$ok" = "1" ]; then
+  echo STARRY_RTNL_OK
+else
+  echo STARRY_RTNL_FAILED
+fi
+printf '\nSTARRY_RTNL_DONE\n'
+'''
+success_regex = [
+  "(?m)^STARRY_RTNL_OK\\s*$",
+  "(?m)^STARRY_RTNL_DONE\\s*$",
+  "inet 192\\.168\\.10\\.2/24",
+  "RTNETLINK answers: Cannot assign requested address",
+]
+fail_regex = [
+  '(?i)\bpanic(?:ked)?\b',
+  '(?i)segmentation fault',
+  '(?i)SIGSEGV',
+  'exit with code: 139',
+  "(?i)(cat|sh): .*not found",
+  "(?m)^STARRY_RTNL_BAD_",
+  "(?m)^STARRY_RTNL_FAILED\\s*$",
+]
+timeout = 180


### PR DESCRIPTION
为 StarryOS 补充 rtnetlink IPv4 地址配置能力，使用户态可通过 ip addr add/del/show dev <iface> 配置网口，并修正 Realtek 网卡枚举与 regulator GPIO 极性处理。

## 改动

- 支持 `RTM_GETLINK` / `RTM_GETADDR` 按接口名或 ifindex 查询。
- 支持 `RTM_NEWADDR` / `RTM_DELADDR` 配置和删除接口 IPv4 地址，兼容 `ip addr add/del/show dev <iface>`。
- 在 `ax-net` 中补充运行时静态 IPv4 配置/删除接口。
- 调整 RTL8125 网卡注册，允许多个 Realtek 网口同时暴露。
- 修正 fixed-regulator GPIO 极性处理，匹配 FDT 中的 active-low 描述。
- 增加 Orange Pi 5 Plus rtnetlink 板端测试用例。