### PR TITLE
test(starry): add Consul + etcd distributed-KV carpet (consul-etcd)

### DIFF
--- a/apps/starry/consul-etcd/README.md
+++ b/apps/starry/consul-etcd/README.md
@@ -1,0 +1,184 @@
+# consul-etcd - Consul + etcd distributed-KV carpet
+
+Two production distributed systems run single-node on StarryOS across the four
+architectures (x86_64 / aarch64 / riscv64 / loongarch64) under qemu-10, single core:
+
+- **Consul 1.22.7** - HashiCorp service discovery / KV / health checks / serf gossip
+  over an embedded raft state store.
+- **etcd 3.6.11** - Raft consensus + bbolt MVCC KV store over gRPC.
+
+Both are fully static, CGO-disabled Go ELF binaries (no libc, no interpreter): the Go
+runtime gets entropy via `getrandom(2)` and parks goroutines via `futex`; loopback
+`AF_INET` TCP/UDP carries serf/raft/HTTP (consul) and client/peer RPC (etcd). The gate
+(`programs/run-consul-etcd.sh`) drives both through their real client paths and only
+prints `TEST PASSED` when every assertion of both carpets passed.
+
+## Carpet contents (57 assertions, gate `CONSULETCD_OK = PASS/TOTAL`, all must pass)
+
+Two complementary layers:
+
+- **CLI surface** (help tree + flag matrix) - every subcommand's `--help` is walked across
+  the full command tree of consul (35 top-level commands), etcdctl (50 subcommands) and
+  etcdutl (8 subcommands), each ground-truthed against the official v1.22.7 / v3.6.11
+  x86_64 releases; then the core commands' real flag behavior is driven against the live
+  daemons. This surface is binary-carried, so it is identical across the four arches (the
+  cross-compiled rv64/la64 binaries are the same version).
+- **Runtime** - each daemon exercised on its own through its real client path, then both
+  driven concurrently in the integration workflow.
+
+### Consul CLI surface (help tree, no daemon)
+
+| # | assertion |
+|---|-----------|
+| 1 | `consul --help` lists the command set (`agent` / `kv` / `catalog` / ...) |
+| 2 | full top-level `--help` tree - all 34 subcommands exit 0 + print their usage token |
+| 3 | `consul kv` subtree (`delete` / `export` / `get` / `import` / `put`) |
+| 4 | `consul catalog` + `consul snapshot` subtrees (datacenters/nodes/services + decode/inspect/restore/save) |
+| 5 | `consul acl` / `connect` / `intention` / `operator` subtrees (auth + service-mesh + operator, 21 subcommands) |
+| 6 | `consul config` / `services` / `peering` / `resource` subtrees (12 subcommands) |
+
+### Consul runtime (single-node `consul agent -dev` on loopback)
+
+| # | assertion |
+|---|-----------|
+| 7 | `consul version` red-line = exact `Consul v1.22.7` |
+| 8 | dev agent reaches `Consul agent running!` (raft + serf + gRPC/HTTP/DNS listeners) |
+| 9 | `consul members` shows `starrynode` `alive` (client RPC round-trip) |
+| 10 | `consul kv put` / `kv get` byte-exact round-trip |
+| 11 | `consul kv get -recurse` returns all three key/value pairs |
+| 12 | `consul kv get -keys` lists the keys |
+| 13 | `consul kv put -flags=42` + `kv get -detailed` surfaces `Flags 42` |
+| 14 | `consul kv put -cas -modify-index=0` is create-only (first write ok, second fails "already exists") |
+| 15 | `consul kv get -keys -separator=/` collapses a nested prefix into one folder entry |
+| 16 | `consul kv delete` -> `kv get` exits non-zero with `No key exists` |
+| 17 | `consul services register` + `consul catalog services` lists `web` |
+| 18 | `consul catalog services -tags` appends the service's tags |
+| 19 | `consul catalog datacenters` lists `dc1` |
+| 20 | `consul catalog nodes` lists `starrynode` |
+| 21 | `consul operator raft list-peers` shows `starrynode` as `leader` + voter |
+| 22 | health check: the `web` TCP check reaches `passing` (`consul watch -type=checks -state=passing`) |
+| 23 | `consul snapshot save` writes a verified snapshot file |
+| 24 | `consul snapshot inspect` reads the snapshot metadata (ID / Index / Term) |
+| 25 | `consul snapshot restore` restores it into the running server |
+
+### etcd CLI surface (help tree, no daemon)
+
+| # | assertion |
+|---|-----------|
+| 26 | `etcd --help` (server flags, `--data-dir` present) |
+| 27 | `etcdctl --help` lists the grouped command set (`get` / `put` / `lease grant` / ...) |
+| 28 | full etcdctl `--help` tree - all 50 subcommands exit 0 + print their usage token |
+| 29 | `etcdctl auth` / `user` / `role` surface (multi-tenant auth CLI, 16 subcommands) |
+| 30 | `etcdutl --help` lists its command set |
+| 31 | full etcdutl `--help` tree - all 8 subcommands (incl `snapshot restore` / `snapshot status`) |
+
+### etcd runtime (single-node server on loopback)
+
+| # | assertion |
+|---|-----------|
+| 32 | `etcd --version` red-line = `etcd Version: 3.6.11` |
+| 33 | `etcdctl version` red-line = `etcdctl version: 3.6.11` |
+| 34 | server reaches `endpoint health` = `is healthy` (Raft + bbolt up) |
+| 35 | `etcdctl put` / `get` byte-exact round-trip |
+| 36 | `etcdctl put --prev-kv` returns the prior key/value it replaced |
+| 37 | `etcdctl del` -> `get` returns empty |
+| 38 | `etcdctl get --prefix` matrix: `--keys-only` / `--limit` / `--sort-by=KEY --order=DESCEND` / `-w json` count |
+| 39 | `etcdctl del --prefix` returns the count of keys removed |
+| 40 | `etcdctl watch` (background) receives the `PUT` event triggered by a later `put` |
+| 41 | `etcdctl txn` `value()` guard takes the success branch and applies its writes |
+| 42 | `etcdctl txn` `mod()` revision guard takes the success branch (distinct guard operator) |
+| 43 | `etcdctl lease grant` + `put --lease` + `lease keep-alive --once` + `lease timetolive` |
+| 44 | `etcdctl lease list` reports the live lease (count line + hex id) |
+| 45 | lease TTL expiry: a key on a short lease with no keep-alive is auto-removed |
+| 46 | `etcdctl member list` shows member `s1` `started` |
+| 47 | `etcdctl member list -w json` exposes the machine-readable members array |
+| 48 | `etcdctl endpoint status -w table` renders the status table header |
+| 49 | `etcdctl endpoint hashkv` returns the KV-history hash |
+| 50 | `etcdctl alarm list` on a healthy store is empty + exits 0 |
+| 51 | `etcdctl compaction <rev>` compacts history to a read-back revision |
+| 52 | `etcdctl snapshot save` writes a snapshot file, verified by `etcdutl snapshot status` |
+| 53 | `etcdutl snapshot status -w table` renders the offline snapshot metadata table |
+
+### Integration (consul + etcd running concurrently - service discovery + config center)
+
+| # | assertion |
+|---|-----------|
+| 54 | consul agent and etcd server serve CONCURRENTLY on loopback (distinct port sets, two heavy Go daemons coexisting) |
+| 55 | register a service in consul, then discover it via `consul catalog services` |
+| 56 | store the service's config in etcd (`config/<svc>/dsn`, `config/<svc>/replicas`) and read it back byte-exact |
+| 57 | end-to-end: the name discovered from consul keys the etcd config lookup, and the DSN round-trips - proving the two systems compose into a discover-then-configure flow |
+
+The `--help` trees are all-or-nothing aggregate assertions: a single regressed subcommand
+fails the whole tree, so there is no silent partial coverage.
+
+Multi-node raft/gossip clustering is intentionally out of scope: a StarryOS single VM has
+no second host, and real clustering needs multiple VMs or network namespaces.
+
+## Judgement authority
+
+`cargo xtask starry app qemu -t consul-etcd --arch <arch>` -> `rc=0` + log
+`SUCCESS PATTERN MATCHED` + `success_regex` on `TEST PASSED` + anchored
+`CONSULETCD_OK=57/57`.
+
+## Architecture coverage and kernel dependencies
+
+| arch | consul source | etcd source | kernel dependency |
+|------|---------------|-------------|-------------------|
+| x86_64 | official amd64 release | official amd64 release | mmap-EOF populate fix (etcd bbolt) |
+| aarch64 | official arm64 release | official arm64 release | `-cpu cortex-a72` |
+| riscv64 | cross-compiled from source | cross-compiled from source | getrlimit->prlimit64 routing (consul); mmap-EOF fix; `ETCD_UNSUPPORTED_ARCH=riscv64` |
+| loongarch64 | cross-compiled from source | cross-compiled from source | dynamic platform (EFI console, `uefi=true`); `ETCD_UNSUPPORTED_ARCH=loong64` |
+
+- **getrlimit routing**: consul's Go runtime calls legacy `getrlimit` directly on riscv64;
+  StarryOS routes `getrlimit`/`setrlimit` to the existing `sys_prlimit64(pid=0)` on every
+  arch (`struct rlimit` == two u64 == `rlimit64` on all LP64 arches), so consul no longer
+  aborts with ENOSYS.
+- **mmap-EOF populate fix**: etcd's bbolt mmaps its db with a ~10 GB `InitialMmapSize`; the
+  `FileBackend::populate` path skips pages past EOF (SIGBUS semantics, Linux-aligned) instead
+  of eagerly allocating frames for the whole sparse range, which otherwise OOMs. Merged on `dev`.
+- **fdatasync on a read-only shared mmap (all arches)**: bbolt mmaps its db read-only and
+  writes through `pwrite`, so on `fdatasync` the page-cache writeback finds the dirty page
+  mapped read-only. `protect_dirty_page` (`mm/aspace/backend/file.rs`) treated a non-writable
+  4K mmap page as an "unexpected page size" and returned false -> `ResourceBusy` -> etcd got a
+  fatal `fdatasync EBUSY`. Fixed: a read-only shared page cannot be dirtied through the mapping,
+  so nothing needs write-protecting - report success. Distinct from the mmap-EOF fix.
+- **`IP_PKTINFO` / `IPV6_RECVPKTINFO` setsockopt (all arches)**: consul's serf/memberlist
+  gossip (and the miekg/dns UDP server when enabled) request ancillary destination-address
+  delivery; the setsockopt whitelist (`syscall/net/opt.rs`) rejected it with `ENOPROTOOPT`.
+  Fixed: accept these options like Linux (functional on a single loopback address without cmsg
+  delivery). The carpet runs the dev agent with `-dns-port=-1` - it exercises serf/raft/HTTP/KV,
+  never DNS - because binding the DNS listener has a fixed internal startup deadline that a slow
+  emulated-arch TCG run can miss ("timeout starting DNS servers"), aborting the agent.
+
+## Binary provenance (see `programs/SOURCES.md`)
+
+`prebuild.sh` provisions every binary by pinned identity into a portable cache
+(`CONSUL_ETCD_DL_ROOT`); nothing is committed:
+
+- consul x86_64/aarch64: official HashiCorp release zip, sha256-pinned download.
+- consul riscv64/loong64: HashiCorp ships no release (two indirect deps lack the arch
+  files); cross-compiled in-prebuild from the pinned source tag `v1.22.7`
+  (`CGO_ENABLED=0`, `GOARCH=<goarch>`) with `boltdb` + `gopsutil` arch files patched in.
+- etcd x86_64/aarch64: official etcd-io release tarball, sha256-pinned download.
+- etcd riscv64/loong64: etcd-io ships no linux binary for these arches (releases cover
+  amd64 / arm64 / ppc64le / s390x only); `etcd` / `etcdctl` / `etcdutl` are cross-compiled
+  in-prebuild from the pinned source tag `v3.6.11` (`CGO_ENABLED=0`, `GOARCH=<goarch>`).
+
+## Prerequisites
+
+- **All arches**: QEMU 10, musl cross toolchains, and Rust/cargo toolchain (set up by
+  sourcing `.starry-env.sh` in the repository root).
+- **riscv64 and loongarch64 only** (both consul and etcd are source-built - neither ships
+  an official release for these arches): `go` >= 1.25 (etcd's minimum toolchain; consul
+  itself only needs >= 1.22, so 1.25 satisfies both) and `git` must be in `$PATH` when
+  `prebuild.sh` runs. If they are absent and no pre-populated `$CONSUL_ETCD_DL_ROOT` cache
+  exists, `prebuild.sh` exits with an error.
+
+## Run
+
+```bash
+source .starry-env.sh                          # qemu-10 + musl crosses
+for a in x86_64 aarch64 riscv64 loongarch64; do
+  cargo xtask starry app qemu -t consul-etcd --arch "$a"
+done
+```

--- a/apps/starry/consul-etcd/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/consul-etcd/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,11 @@
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/consul-etcd/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/consul-etcd/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,10 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "axplat-dyn/efi",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/consul-etcd/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/consul-etcd/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,12 @@
+features = [
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/consul-etcd/build-x86_64-unknown-none.toml
+++ b/apps/starry/consul-etcd/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/consul-etcd/prebuild.sh
+++ b/apps/starry/consul-etcd/prebuild.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the Consul + etcd distributed-KV carpet for StarryOS.
+#
+# Two production Go services run single-node on-target, driven by an anchored gate
+# (programs/run-consul-etcd.sh):
+#   Consul 1.22.7 - HashiCorp service discovery / KV / health / serf gossip / raft.
+#   etcd   3.6.11 - Raft consensus + bbolt MVCC KV over gRPC.
+# Both are FULLY STATIC, CGO-disabled Go ELF binaries (no libc / no interp), so the
+# rootfs needs no dependency closure - the binaries drop in and run. The Go runtime
+# gets entropy via getrandom(2) and parks goroutines via futex (both provided by
+# StarryOS); loopback AF_INET TCP/UDP carries serf/raft/HTTP (consul) and client/peer
+# RPC (etcd).
+#
+# --- SOURCE-ONLY REPO, REPRODUCIBLE PROVISION ----------------------------------------
+#   The tree keeps only source + manifests (this script, the gate, the service config).
+#   NO binaries are committed. prebuild fetches / builds every binary by pinned identity
+#   into a portable cache (CONSUL_ETCD_DL_ROOT), re-used network-free on later runs:
+#     consul x86_64/aarch64 : official HashiCorp release zip, sha256-pinned download.
+#     consul riscv64/loong64: HashiCorp ships NO release for these arches (two indirect
+#                             deps - boltdb + gopsutil - lack the arch files). The binary
+#                             is CROSS-COMPILED IN-PREBUILD from the pinned consul source
+#                             tag (CGO_ENABLED=0, GOARCH=<goarch>) with the two missing
+#                             arch files patched in - exactly the official recipe. A
+#                             pre-populated cache short-circuits the build; the output
+#                             binary's own sha256 is NOT pinned (it tracks the Go
+#                             toolchain version), reproducibility is anchored on the
+#                             pinned SOURCE tag. If go/git are absent and no cache exists,
+#                             prebuild fails hard (the gate has no skip path).
+#     etcd x86_64/aarch64   : official etcd-io release tarball, sha256-pinned download.
+#     etcd riscv64/loong64  : etcd-io ships NO release for these arches (linux binaries are
+#                             amd64/arm64/ppc64le/s390x only). etcd/etcdctl/etcdutl are
+#                             CROSS-COMPILED IN-PREBUILD from the pinned source tag
+#                             (CGO_ENABLED=0, GOARCH=<goarch>); the module deps carry the arch
+#                             files so no patching is needed. Reproducibility anchors on the tag.
+#
+# --- DATA DIRS ON EXT4, NOT tmpfs ----------------------------------------------------
+#   The gate runs etcd (and consul snapshots) under /root (ext4, bounded LRU page cache),
+#   never /tmp (tmpfs, unbounded): bbolt mmaps its db with a huge InitialMmapSize; on a
+#   tmpfs backend that pins unbounded pages. This is the etcd-0 lesson baked into the gate.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_OVERLAY_DIR, STARRY_APP_DIR, STARRY_ROOTFS,
+# STARRY_STAGING_ROOT.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+rootfs_img="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+
+PROG="$app_dir/programs"
+DL="${CONSUL_ETCD_DL_ROOT:-${STARRY_STAGING_ROOT:-$app_dir}/.cache/consul-etcd-dl}"
+ROOTFS_SIZE="${CONSUL_ETCD_ROOTFS_SIZE:-2560M}"
+
+CONSUL_VER=1.22.7
+CONSUL_REL="${CONSUL_REL:-https://releases.hashicorp.com/consul/${CONSUL_VER}}"
+CONSUL_SRC_TAG=v1.22.7
+# Full commit the v1.22.7 tag resolves to. A mutable tag alone is not a supply-chain
+# anchor (a tag can be re-pointed upstream); the checkout is verified against this SHA
+# before any build. Kept in full-40-hex form so git rev-parse can compare exactly.
+CONSUL_SRC_COMMIT=c18bcb9db1fd73307ee8bf64a9bc17610d5427d5
+CONSUL_SRC_URL="${CONSUL_SRC_URL:-https://github.com/hashicorp/consul}"
+ETCD_VER=v3.6.11
+ETCD_REL="${ETCD_REL:-https://github.com/etcd-io/etcd/releases/download/${ETCD_VER}}"
+ETCD_SRC_TAG="$ETCD_VER"
+# Full commit the v3.6.11 annotated tag resolves to - same supply-chain anchor rationale as
+# consul: a mutable tag alone is not trusted, the checkout is verified against this SHA before
+# any build. This is the dereferenced commit (the tag object is 80b86c0d...), matching what
+# `git rev-parse HEAD` reports after a tag clone.
+ETCD_SRC_COMMIT=ec166e2292a58365c90e96fcd206b3b74938d49d
+ETCD_SRC_URL="${ETCD_SRC_URL:-https://github.com/etcd-io/etcd}"
+
+# arch -> (consul release goarch, etcd release goarch)
+case "$arch" in
+    x86_64)      CONSUL_GOARCH=amd64;   ETCD_GOARCH=amd64 ;;
+    aarch64)     CONSUL_GOARCH=arm64;   ETCD_GOARCH=arm64 ;;
+    riscv64)     CONSUL_GOARCH=riscv64; ETCD_GOARCH=riscv64 ;;
+    loongarch64) CONSUL_GOARCH=loong64; ETCD_GOARCH=loong64 ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+# ensure_asset <abs-local-path> <url> [sha256]
+#   Cache hit (sha256 matches when a digest is given) -> used as-is, zero network. Otherwise
+#   curl the URL to a temp file, verify sha256 when given (mismatch = hard error), atomically
+#   move into place. An empty sha skips verification; an empty URL with no cache is a hard
+#   error. sha256sum is a hard host prerequisite (ensure_host_tools gates on it before any
+#   rootfs mutation), so a supplied digest is ALWAYS enforced - a missing tool can never
+#   silently downgrade a pinned asset to unchecked.
+ensure_asset() {
+    local dest="$1" url="$2" want="${3:-}"
+    if [[ -f "$dest" ]]; then
+        if [[ -n "$want" ]]; then
+            local have; have="$(sha256sum "$dest" | cut -d' ' -f1)"
+            if [[ "$have" == "$want" ]]; then echo "prebuild: cache hit $(basename "$dest") (sha256 ok)"; return 0; fi
+            echo "prebuild: cache $(basename "$dest") sha256 mismatch (have $have want $want) - refetching" >&2
+            rm -f "$dest"
+        else
+            echo "prebuild: cache hit $(basename "$dest")"; return 0
+        fi
+    fi
+    command -v curl >/dev/null 2>&1 || { echo "prebuild: need curl to fetch $url (no cached $dest)" >&2; exit 4; }
+    [[ -n "$url" ]] || { echo "prebuild: no cached $dest and no URL to fetch it from" >&2; exit 4; }
+    echo "prebuild: fetching $(basename "$dest") <- $url"
+    mkdir -p "$(dirname "$dest")"
+    curl -fSL --retry 3 --connect-timeout 20 "$url" -o "$dest.tmp"
+    if [[ -n "$want" ]]; then
+        local got; got="$(sha256sum "$dest.tmp" | cut -d' ' -f1)"
+        [[ "$got" == "$want" ]] || { echo "prebuild: sha256 mismatch for $url (got $got want $want)" >&2; rm -f "$dest.tmp"; exit 4; }
+    fi
+    mv -f "$dest.tmp" "$dest"
+}
+
+ensure_host_tools() {
+    local missing=()
+    command -v tar       >/dev/null 2>&1 || missing+=(tar)
+    command -v curl      >/dev/null 2>&1 || missing+=(curl)
+    command -v unzip     >/dev/null 2>&1 || missing+=(unzip)
+    # sha256sum is mandatory, not best-effort: every pinned asset's digest is enforced
+    # unconditionally in ensure_asset, so its absence must fail here before any rootfs
+    # mutation rather than let a supply-chain check be silently skipped.
+    command -v sha256sum >/dev/null 2>&1 || missing+=(sha256sum/coreutils)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(resize2fs/e2fsprogs)
+    command -v e2fsck    >/dev/null 2>&1 || missing+=(e2fsck/e2fsprogs)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "prebuild: missing required host tools: ${missing[*]}" >&2
+        echo "prebuild: install them (e.g. apt-get install -y coreutils tar curl unzip e2fsprogs) and re-run" >&2
+        exit 1
+    fi
+}
+
+# Grow the per-app rootfs so the injected binaries fit without truncation. Grow-only
+# (never shrink a shared/base image). Idempotent.
+grow_rootfs() {
+    [[ -f "$rootfs_img" ]] || { echo "prebuild: rootfs image missing: $rootfs_img" >&2; exit 2; }
+    local cur target
+    cur=$(stat -c %s "$rootfs_img"); target=$(( ${ROOTFS_SIZE%M} * 1024 * 1024 ))
+    [[ "$cur" -lt "$target" ]] && truncate -s "$ROOTFS_SIZE" "$rootfs_img"
+    e2fsck -f -y "$rootfs_img" >/dev/null 2>&1 || true
+    resize2fs "$rootfs_img" >/dev/null 2>&1 || { echo "prebuild: resize2fs failed on $rootfs_img" >&2; exit 2; }
+    echo "prebuild: rootfs sized to $(( $(stat -c %s "$rootfs_img")/1024/1024 )) MiB"
+}
+
+# --- consul provisioning -------------------------------------------------------------
+CONSUL_ZIP_SHA_amd64=fe25cecd8dd3552a8e5b0941cde1d79bb6004eac384aa45679dd1398f947201d
+CONSUL_ZIP_SHA_arm64=db54c5fb7c5ceaef97a38ca45dcc0f649ff592a48c73ab320e2d535c78e136cc
+
+# Cross-compile consul for riscv64/loong64 from the pinned source tag, patching in the two
+# indirect-dep arch files HashiCorp's release build lacks. Pure Go, CGO_ENABLED=0 -> no C
+# cross-toolchain needed. Emits <out>. Returns non-zero if go/git are unavailable.
+build_consul_cross() {
+    local goarch="$1" out="$2"
+    command -v go  >/dev/null 2>&1 || { echo "prebuild: ERROR 'go' not on PATH; Go >=1.22 is required to cross-build consul for $goarch (no official release binary exists for this arch)" >&2; return 1; }
+    command -v git >/dev/null 2>&1 || { echo "prebuild: ERROR 'git' not on PATH; git is required to clone the consul source for cross-building" >&2; return 1; }
+    local src="$DL/consul-src"
+    # A pre-existing cache is only trusted when its HEAD is exactly the pinned commit; a
+    # tag-only clone could have been re-pointed upstream, so re-clone on any mismatch.
+    if [[ -d "$src/.git" ]]; then
+        local cached_head; cached_head="$(git -C "$src" rev-parse HEAD 2>/dev/null || true)"
+        if [[ "$cached_head" != "$CONSUL_SRC_COMMIT" ]]; then
+            echo "prebuild: cached consul-src HEAD $cached_head != pinned $CONSUL_SRC_COMMIT - re-cloning" >&2
+            rm -rf "$src"
+        fi
+    fi
+    if [[ ! -d "$src/.git" ]]; then
+        echo "prebuild: cloning consul $CONSUL_SRC_TAG (cross-build for $goarch)"
+        git clone --depth 1 --branch "$CONSUL_SRC_TAG" "$CONSUL_SRC_URL" "$src" || { rm -rf "$src"; return 1; }
+    fi
+    local head; head="$(git -C "$src" rev-parse HEAD 2>/dev/null || true)"
+    if [[ "$head" != "$CONSUL_SRC_COMMIT" ]]; then
+        echo "prebuild: ERROR consul source HEAD $head does not match pinned commit $CONSUL_SRC_COMMIT (tag $CONSUL_SRC_TAG may have been re-pointed upstream)" >&2
+        rm -rf "$src"; return 1
+    fi
+    ( cd "$src" && go mod download github.com/boltdb/bolt github.com/shirou/gopsutil/v3 ) || return 1
+    local gomod; gomod="$(go env GOMODCACHE)"
+    # boltdb@v1.3.1 (via raft-boltdb) lacks bolt_riscv64.go / bolt_loong64.go.
+    local boltp="$DL/bolt-patched"
+    rm -rf "$boltp"; cp -r "$gomod/github.com/boltdb/bolt@v1.3.1" "$boltp"; chmod -R u+w "$boltp"
+    printf 'module github.com/boltdb/bolt\n\ngo 1.12\n' > "$boltp/go.mod"
+    local a
+    for a in riscv64 loong64; do
+        cat > "$boltp/bolt_$a.go" <<GO
+//go:build $a
+
+package bolt
+
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+const maxAllocSize = 0x7FFFFFFF
+var brokenUnaligned = false
+GO
+    done
+    # gopsutil/v3@v3.22.9 lacks host_linux_loong64.go (same LP64 utmp layout as riscv64).
+    local gpp="$DL/gopsutil-patched"
+    rm -rf "$gpp"; cp -r "$gomod/github.com/shirou/gopsutil/v3@v3.22.9" "$gpp"; chmod -R u+w "$gpp"
+    cp "$gpp/host/host_linux_riscv64.go" "$gpp/host/host_linux_loong64.go"
+    (
+        cd "$src"
+        go mod edit -replace github.com/boltdb/bolt="$boltp"
+        go mod edit -replace github.com/shirou/gopsutil/v3="$gpp"
+        local ld="-s -w -X github.com/hashicorp/consul/version.GitVersion=${CONSUL_VER} -X github.com/hashicorp/consul/version.GitCommit=${CONSUL_SRC_COMMIT} -X github.com/hashicorp/consul/version.GitDescribe=${CONSUL_SRC_TAG}"
+        CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" go build -trimpath -ldflags "$ld" -o "$out.tmp" .
+    ) || return 1
+    # sanity: output is an ELF binary.
+    [[ "$(head -c4 "$out.tmp" 2>/dev/null | od -An -tx1 | tr -d ' \n')" == "7f454c46" ]] \
+        || { echo "prebuild: NOTE cross-built consul $goarch is not an ELF" >&2; rm -f "$out.tmp"; return 1; }
+    mv -f "$out.tmp" "$out"
+    return 0
+}
+
+# Cross-compile etcd/etcdctl/etcdutl from the pinned source tag. etcd-io publishes no
+# riscv64/loong64 release, and unlike consul the module deps carry the arch files, so no
+# patching is needed - each of the three binaries is a separate module ($moddir/main.go) and
+# the version string is a source constant, so a plain build reproduces the release identity.
+build_etcd_cross() {
+    local goarch="$1" outdir="$2"
+    command -v go  >/dev/null 2>&1 || { echo "prebuild: ERROR 'go' not on PATH; Go >=1.25 is required to cross-build etcd for $goarch (no official release binary exists for this arch)" >&2; return 1; }
+    command -v git >/dev/null 2>&1 || { echo "prebuild: ERROR 'git' not on PATH; git is required to clone the etcd source for cross-building" >&2; return 1; }
+    local src="$DL/etcd-src"
+    if [[ -d "$src/.git" ]]; then
+        local cached_head; cached_head="$(git -C "$src" rev-parse HEAD 2>/dev/null || true)"
+        if [[ "$cached_head" != "$ETCD_SRC_COMMIT" ]]; then
+            echo "prebuild: cached etcd-src HEAD $cached_head != pinned $ETCD_SRC_COMMIT - re-cloning" >&2
+            rm -rf "$src"
+        fi
+    fi
+    if [[ ! -d "$src/.git" ]]; then
+        echo "prebuild: cloning etcd $ETCD_SRC_TAG (cross-build for $goarch)"
+        git clone --depth 1 --branch "$ETCD_SRC_TAG" "$ETCD_SRC_URL" "$src" || { rm -rf "$src"; return 1; }
+    fi
+    local head; head="$(git -C "$src" rev-parse HEAD 2>/dev/null || true)"
+    if [[ "$head" != "$ETCD_SRC_COMMIT" ]]; then
+        echo "prebuild: ERROR etcd source HEAD $head does not match pinned commit $ETCD_SRC_COMMIT (tag $ETCD_SRC_TAG may have been re-pointed upstream)" >&2
+        rm -rf "$src"; return 1
+    fi
+    local spec moddir binname
+    for spec in server:etcd etcdctl:etcdctl etcdutl:etcdutl; do
+        moddir="${spec%%:*}"; binname="${spec##*:}"
+        ( cd "$src/$moddir" && CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" go build -trimpath -ldflags "-s -w" -o "$outdir/$binname.tmp" . ) || return 1
+        [[ "$(head -c4 "$outdir/$binname.tmp" 2>/dev/null | od -An -tx1 | tr -d ' \n')" == "7f454c46" ]] \
+            || { echo "prebuild: NOTE cross-built $binname $goarch is not an ELF" >&2; rm -f "$outdir/$binname.tmp"; return 1; }
+        mv -f "$outdir/$binname.tmp" "$outdir/$binname"
+    done
+    return 0
+}
+
+stage_consul() {
+    local dst="$overlay_dir/usr/local/bin/consul"
+    case "$arch" in
+        x86_64|aarch64)
+            local shavar="CONSUL_ZIP_SHA_${CONSUL_GOARCH}"
+            local zip="$DL/consul/$arch/consul_${CONSUL_VER}_linux_${CONSUL_GOARCH}.zip"
+            ensure_asset "$zip" "$CONSUL_REL/consul_${CONSUL_VER}_linux_${CONSUL_GOARCH}.zip" "${!shavar}"
+            local t; t="$(mktemp -d)"
+            unzip -oq "$zip" consul -d "$t" || { echo "prebuild: failed to extract consul from $zip" >&2; exit 3; }
+            install -Dm0755 "$t/consul" "$dst"; rm -rf "$t" ;;
+        riscv64|loongarch64)
+            local bin="$DL/consul-cross/$arch/consul"
+            if [[ ! -f "$bin" ]]; then
+                mkdir -p "$(dirname "$bin")"
+                build_consul_cross "$CONSUL_GOARCH" "$bin" \
+                    || { echo "prebuild: ERROR could not provision consul for $arch (no cache and cross-build unavailable); the gate has no skip path" >&2; exit 3; }
+                echo "prebuild: cross-compiled consul $arch from source tag $CONSUL_SRC_TAG"
+            else
+                echo "prebuild: consul $arch = cached cross-built binary"
+            fi
+            install -Dm0755 "$bin" "$dst" ;;
+    esac
+    echo "prebuild: staged consul ($(du -h "$dst" | cut -f1)) -> /usr/local/bin/consul"
+}
+
+# --- etcd provisioning: release tarball on x86_64/aarch64, source build on rv64/la64 -
+# etcd-io ships linux binaries only for amd64/arm64 (plus ppc64le/s390x), never riscv64 or
+# loong64, so only those two SHAs exist; rv64/la64 are cross-built from the pinned source tag.
+ETCD_SHA_amd64=8756f7a4eaf921668a83de0bf13c0f65cae9186a165696e3ae8396afe6f557ed
+ETCD_SHA_arm64=5302f1a6157c34eb0568c75fba9d06da98353576df04399f08645bef634acd2d
+
+stage_etcd() {
+    case "$arch" in
+        x86_64|aarch64)
+            local shavar="ETCD_SHA_${ETCD_GOARCH}"
+            local tarball="$DL/etcd/$arch/etcd-${ETCD_VER}-linux-${ETCD_GOARCH}.tar.gz"
+            ensure_asset "$tarball" "$ETCD_REL/etcd-${ETCD_VER}-linux-${ETCD_GOARCH}.tar.gz" "${!shavar}"
+            local top="etcd-${ETCD_VER}-linux-${ETCD_GOARCH}"
+            local t; t="$(mktemp -d)"
+            tar xzf "$tarball" -C "$t" "$top/etcd" "$top/etcdctl" "$top/etcdutl" \
+                || { echo "prebuild: failed to extract etcd from $tarball" >&2; exit 3; }
+            local b
+            for b in etcd etcdctl etcdutl; do
+                install -Dm0755 "$t/$top/$b" "$overlay_dir/usr/bin/$b"
+            done
+            rm -rf "$t" ;;
+        riscv64|loongarch64)
+            local outdir="$DL/etcd-cross/$arch"
+            if [[ ! -f "$outdir/etcd" || ! -f "$outdir/etcdctl" || ! -f "$outdir/etcdutl" ]]; then
+                mkdir -p "$outdir"
+                build_etcd_cross "$ETCD_GOARCH" "$outdir" \
+                    || { echo "prebuild: ERROR could not provision etcd for $arch (no cache and cross-build unavailable); the gate has no skip path" >&2; exit 3; }
+                echo "prebuild: cross-compiled etcd $arch from source tag $ETCD_SRC_TAG"
+            else
+                echo "prebuild: etcd $arch = cached cross-built binaries"
+            fi
+            local b
+            for b in etcd etcdctl etcdutl; do
+                install -Dm0755 "$outdir/$b" "$overlay_dir/usr/bin/$b"
+            done ;;
+    esac
+    echo "prebuild: staged etcd/etcdctl/etcdutl -> /usr/bin"
+}
+
+stage_payload() {
+    install -Dm0644 "$PROG/consul-service.json" "$overlay_dir/root/consul-etcd/consul-service.json"
+    install -Dm0755 "$PROG/run-consul-etcd.sh"  "$overlay_dir/usr/bin/run-consul-etcd.sh"
+    echo "prebuild: staged run-consul-etcd.sh + consul-service.json"
+}
+
+preflight_cross_check() {
+    # For rv64/la64 both consul and etcd are cross-compiled from source; check go/git
+    # availability before growing the rootfs so the caller gets a clear error immediately.
+    case "$arch" in
+        riscv64|loongarch64)
+            local cbin="$DL/consul-cross/$arch/consul"
+            local edir="$DL/etcd-cross/$arch"
+            # stage_etcd needs all three binaries (etcd/etcdctl/etcdutl); a
+            # partial cache must still require go/git here, before any rootfs
+            # growth, so provisioning cannot fail after the rootfs was modified.
+            [[ -f "$cbin" && -f "$edir/etcd" && -f "$edir/etcdctl" && -f "$edir/etcdutl" ]] && return 0
+            command -v go  >/dev/null 2>&1 || { echo "prebuild: ERROR 'go' not on PATH; Go >=1.25 is required to cross-build consul/etcd for $arch (no official release binaries exist for this arch)" >&2; exit 1; }
+            command -v git >/dev/null 2>&1 || { echo "prebuild: ERROR 'git' not on PATH; git is required to clone the consul/etcd source for cross-building" >&2; exit 1; }
+            ;;
+    esac
+}
+
+main() {
+    ensure_host_tools
+    preflight_cross_check
+    grow_rootfs
+    stage_consul
+    stage_etcd
+    stage_payload
+    echo "prebuild: consul-etcd overlay ready for $arch - $(du -sh "$overlay_dir" | cut -f1)"
+}
+
+main "$@"

--- a/apps/starry/consul-etcd/programs/SOURCES.md
+++ b/apps/starry/consul-etcd/programs/SOURCES.md
@@ -1,0 +1,75 @@
+# consul-etcd binary provenance
+
+`prebuild.sh` provisions all binaries by pinned identity into a portable cache
+(`CONSUL_ETCD_DL_ROOT`, default under the app's staging root). No binaries are committed to
+the repository. A clean checkout reproduces every cell from its official source.
+
+## Consul 1.22.7
+
+- Upstream: `https://github.com/hashicorp/consul`, tag `v1.22.7`
+  (commit `c18bcb9db1fd73307ee8bf64a9bc17610d5427d5`, `c18bcb9d`).
+- CGO-disabled fully static Go ELF.
+
+| arch | source | identity |
+|------|--------|----------|
+| x86_64 | official release `consul_1.22.7_linux_amd64.zip` | sha256 `fe25cecd8dd3552a8e5b0941cde1d79bb6004eac384aa45679dd1398f947201d` |
+| aarch64 | official release `consul_1.22.7_linux_arm64.zip` | sha256 `db54c5fb7c5ceaef97a38ca45dcc0f649ff592a48c73ab320e2d535c78e136cc` |
+| riscv64 | cross-compiled from source tag `v1.22.7` | pinned source tag (output binary sha tracks the Go toolchain) |
+| loongarch64 | cross-compiled from source tag `v1.22.7` | pinned source tag (output binary sha tracks the Go toolchain) |
+
+Release download base: `https://releases.hashicorp.com/consul/1.22.7/`.
+
+### Why riscv64 / loongarch64 are cross-compiled
+
+HashiCorp publishes consul only for amd64 + arm64. Two indirect dependencies lack the arch
+files, which is the real reason no release exists; `prebuild.sh` patches them in before a
+`CGO_ENABLED=0 GOARCH=<goarch> go build`:
+
+1. `github.com/boltdb/bolt@v1.3.1` (via `raft-boltdb/v2`) has no `bolt_riscv64.go` /
+   `bolt_loong64.go` (missing `maxMapSize` / `maxAllocSize` / `brokenUnaligned`). The two
+   added files use the same constants as `bolt_arm64.go` (all LP64, unaligned OK). boltdb
+   v1.3.1 predates Go modules, so the local replace copy also gets a `go.mod`
+   (`module github.com/boltdb/bolt` + `go 1.12`).
+2. `github.com/shirou/gopsutil/v3@v3.22.9` has no `host_linux_loong64.go` (missing the
+   `utmp` layout). loong64 and riscv64 are both LP64 little-endian with the same `utmp`
+   layout, so `host_linux_riscv64.go` is copied to `host_linux_loong64.go` (the filename
+   suffix is the build constraint; contents unchanged). riscv64 needs no gopsutil patch.
+
+The linker stamps the version identically to the official release
+(`-X .../version.GitVersion=1.22.7 -X .../version.GitCommit=c18bcb9d -X
+.../version.GitDescribe=v1.22.7`), so all four arches report `Consul v1.22.7`.
+
+## etcd 3.6.11
+
+- Upstream: `https://github.com/etcd-io/etcd`, tag `v3.6.11` (commit `ec166e22`). etcd-io
+  publishes official release tarballs only for amd64 / arm64 / ppc64le / s390x, so x86_64
+  and aarch64 use the sha256-pinned release tarball while riscv64 and loongarch64 are
+  cross-compiled in-prebuild from the pinned source tag (`git rev-parse HEAD` verified
+  against the full commit before the build). Each release / build yields `etcd`,
+  `etcdctl`, `etcdutl` (CGO-disabled static Go ELF).
+- Release download base:
+  `https://github.com/etcd-io/etcd/releases/download/v3.6.11/etcd-v3.6.11-linux-<goarch>.tar.gz`.
+
+| arch | source | identity |
+|------|--------|----------|
+| x86_64 | official release `etcd-v3.6.11-linux-amd64.tar.gz` | sha256 `8756f7a4eaf921668a83de0bf13c0f65cae9186a165696e3ae8396afe6f557ed` |
+| aarch64 | official release `etcd-v3.6.11-linux-arm64.tar.gz` | sha256 `5302f1a6157c34eb0568c75fba9d06da98353576df04399f08645bef634acd2d` |
+| riscv64 | cross-compiled from source tag `v3.6.11` | pinned source commit `ec166e2292a58365c90e96fcd206b3b74938d49d` (output binary sha tracks the Go toolchain) |
+| loongarch64 | cross-compiled from source tag `v3.6.11` | pinned source commit `ec166e2292a58365c90e96fcd206b3b74938d49d` (output binary sha tracks the Go toolchain) |
+
+### `ETCD_UNSUPPORTED_ARCH` (riscv64 / loongarch64)
+
+etcd has a tier-1 architecture gate: only amd64 / arm64 / ppc64le / s390x are "supported";
+on other arches it refuses to start with
+
+```
+Refusing to run etcd on unsupported architecture since ETCD_UNSUPPORTED_ARCH is not set
+```
+
+The binary itself is fully functional - this is an etcd "you're on your own" prompt, not a
+kernel limitation. The gate exports `ETCD_UNSUPPORTED_ARCH=riscv64` / `loong64` before
+launching etcd on those arches; amd64/arm64 need no variable.
+
+## GOARCH mapping
+
+`x86_64 -> amd64`, `aarch64 -> arm64`, `riscv64 -> riscv64`, `loongarch64 -> loong64`.

--- a/apps/starry/consul-etcd/programs/consul-service.json
+++ b/apps/starry/consul-etcd/programs/consul-service.json
@@ -1,0 +1,13 @@
+{
+  "service": {
+    "name": "web",
+    "port": 8500,
+    "tags": ["starry", "v1"],
+    "check": {
+      "name": "web-tcp",
+      "tcp": "127.0.0.1:8500",
+      "interval": "3s",
+      "timeout": "1s"
+    }
+  }
+}

--- a/apps/starry/consul-etcd/programs/run-consul-etcd.sh
+++ b/apps/starry/consul-etcd/programs/run-consul-etcd.sh
@@ -1,0 +1,889 @@
+#!/bin/sh
+# run-consul-etcd.sh - on-target gate for the StarryOS consul-etcd distributed-KV carpet.
+#
+# Staged into the rootfs by prebuild.sh and invoked as the ENTIRE shell_init_cmd
+# (`sh /usr/bin/run-consul-etcd.sh`). The gate lives in a staged script, not inline in the
+# toml, so the harness never echoes a literal TEST PASSED back over the serial console and
+# self-matches success_regex: TEST PASSED is printed ONLY by this script, ONLY when every
+# assertion of both carpets passed.
+#
+# The carpet has two complementary halves:
+#
+#   CLI SURFACE (help-tree + flag matrix, arch-independent, no daemon needed):
+#     Every consul / etcdctl / etcdutl subcommand's `--help` is walked (the full command
+#     tree, ground-truthed against the official v1.22.7 / v3.6.11 x86_64 releases) and each
+#     subcommand's usage token is asserted present with exit code 0. Then the core commands'
+#     real flag behavior is driven against the live daemons (kv put -flags/-cas, kv get
+#     -detailed/-keys -separator, catalog -tags, etcdctl get --prefix/--limit/--sort-by,
+#     put --prev-kv, del --prefix, lease list, member/endpoint -w json/table, ...).
+#
+#   RUNTIME (both daemons exercised through their real client paths, single-node loopback):
+#     A StarryOS single VM has no second host, so multi-node raft/gossip clustering stays out
+#     of scope - it needs multiple VMs / network namespaces, a real wall. Both binaries are
+#     fully static CGO-free Go ELF, so nothing but the binary + a writable ext4 data dir is
+#     needed.
+#       CONSUL 1.22.7 (consul agent -dev): version / dev agent up / members / KV
+#       put-get-recurse-keys-delete / service register + catalog / health check / snapshot.
+#       ETCD 3.6.11 (single-node server): version / server ready / KV put-get-del / watch /
+#       txn / lease (grant+attach+TTL+keep-alive+expiry) / member list / snapshot.
+#
+# Data dirs live under /root (ext4, bounded page cache), NEVER /tmp (tmpfs, unbounded):
+# both raft-boltdb (consul, when persisting) and bbolt (etcd) mmap their db with a large
+# InitialMmapSize; on tmpfs that pins unbounded pages.
+set -u
+
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin
+export HOME=/root
+CONSUL=/usr/local/bin/consul
+ETCD=/usr/bin/etcd
+# The default 5s client command deadline is exceeded under slow emulated-arch TCG (aarch64 /
+# riscv64 / loongarch64 run the go binaries much slower than x86_64): a fresh etcdctl process
+# plus a store-wide RPC (hashkv / compaction / the first keys-only scan) can outlast it, so the
+# etcdctl spec carries a wider deadline. It is kept as command-line flags rather than exported
+# ETCDCTL_ env vars on purpose - exporting leaks the settings into the etcd server's own
+# environment. Data-plane sites use $ETCDCTL unquoted and help_tree word-splits it, so the flags
+# reach etcdctl and are never mistaken for a command path.
+ETCDCTL="/usr/bin/etcdctl --command-timeout=40s --dial-timeout=20s"
+ETCDUTL=/usr/bin/etcdutl
+export CONSUL_HTTP_ADDR=127.0.0.1:8500
+
+ARCH="$(uname -m)"
+# etcd's tier-1 gate refuses to start on riscv64/loong64 unless ETCD_UNSUPPORTED_ARCH is set
+# to the GOARCH. The binary itself works - this is etcd policy, not a kernel limit.
+case "$ARCH" in
+    riscv64)     export ETCD_UNSUPPORTED_ARCH=riscv64 ;;
+    loongarch64) export ETCD_UNSUPPORTED_ARCH=loong64 ;;
+esac
+
+PASS=0
+TOTAL=0
+ok() { # ok <0|1> <label>
+    TOTAL=$((TOTAL + 1))
+    if [ "$1" = 1 ]; then PASS=$((PASS + 1)); echo "  OK   $2"; else echo "  FAIL $2"; fi
+}
+
+# help_ok <binary> <label> <cmd-words...>: run `<binary> <cmd> --help`, pass iff it exits 0
+# AND its output contains the literal usage token "<basename> <cmd>" (the invariant every
+# cobra/mitchellh-cli subcommand prints - ground-truthed against the official releases).
+help_ok() {
+    bin="$1"; label="$2"; shift 2
+    "$bin" "$@" --help > /tmp/h.out 2>&1
+    rc=$?
+    tok="$(basename "$bin") $*"
+    if [ "$rc" = 0 ] && grep -qF "$tok" /tmp/h.out; then
+        ok 1 "$label"
+    else
+        ok 0 "$label (rc=$rc)"; head -3 /tmp/h.out
+    fi
+}
+
+# help_tree <binary> <label> <space-separated subcommand specs, one per line on stdin>:
+# walk every subcommand's `--help`; the aggregate assertion passes only if ALL of them
+# exit 0 and print their own usage token. All-or-nothing so a single regressed subcommand
+# fails the whole tree (no silent partial coverage).
+help_tree() {
+    bin="$1"; label="$2"
+    # bin may carry global flags (e.g. "etcdctl --command-timeout=40s"); the program name is the
+    # first token and the invocation must word-split so the flags are passed, not run as a path.
+    base="$(basename "${bin%% *}")"
+    bad=""; n=0
+    while IFS= read -r spec; do
+        [ -z "$spec" ] && continue
+        n=$((n + 1))
+        # shellcheck disable=SC2086
+        $bin $spec --help > /tmp/ht.out 2>&1
+        rc=$?
+        if [ "$rc" != 0 ] || ! grep -qF "$base $spec" /tmp/ht.out; then
+            bad="$bad [$spec:rc$rc]"
+        fi
+    done
+    if [ -z "$bad" ]; then
+        ok 1 "$label ($n subcommands)"
+    else
+        ok 0 "$label - failing:$bad"
+    fi
+}
+
+############################ CONSUL CLI SURFACE ############################
+# Help tree + flag matrix are binary-carried, so they run without a daemon and are identical
+# across the four arches (the cross-compiled rv64/la64 binaries are the same version).
+echo "=== consul CLI surface (help tree + flag matrix) ==="
+
+# H1) top-level `consul --help`: lists the command set (agent/kv/catalog/... present).
+$CONSUL --help > /tmp/cth.out 2>&1
+if [ $? = 0 ] && grep -q 'Available commands' /tmp/cth.out \
+   && grep -q ' agent ' /tmp/cth.out && grep -q ' kv ' /tmp/cth.out && grep -q ' catalog ' /tmp/cth.out; then
+    ok 1 "consul --help lists command set"
+else
+    ok 0 "consul --help"; head -5 /tmp/cth.out
+fi
+
+# H2) every top-level consul command's `--help` (the full 35-command tree).
+help_tree "$CONSUL" "consul --help tree (all top-level commands)" <<'CMDS'
+acl
+agent
+catalog
+config
+connect
+debug
+event
+exec
+force-leave
+info
+intention
+join
+keygen
+keyring
+kv
+leave
+lock
+login
+logout
+maint
+members
+monitor
+operator
+peering
+reload
+resource
+rtt
+services
+snapshot
+tls
+troubleshoot
+validate
+version
+watch
+CMDS
+
+# H3) consul kv subcommand tree (delete/export/get/import/put).
+help_tree "$CONSUL" "consul kv --help subtree" <<'CMDS'
+kv delete
+kv export
+kv get
+kv import
+kv put
+CMDS
+
+# H4) consul catalog + snapshot subcommand trees.
+help_tree "$CONSUL" "consul catalog + snapshot --help subtrees" <<'CMDS'
+catalog datacenters
+catalog nodes
+catalog services
+snapshot decode
+snapshot inspect
+snapshot restore
+snapshot save
+CMDS
+
+# H5) consul ACL / connect / intention / operator surface (auth + service-mesh + operator
+#     subsystems that the runtime carpet never reaches, but whose CLI must still be intact).
+help_tree "$CONSUL" "consul acl/connect/intention/operator --help subtrees" <<'CMDS'
+acl bootstrap
+acl policy
+acl policy create
+acl policy list
+acl token
+acl token create
+acl token list
+acl auth-method
+acl role
+connect ca
+connect ca get-config
+connect envoy
+connect proxy
+intention create
+intention check
+intention get
+intention list
+operator autopilot
+operator raft
+operator raft list-peers
+operator usage
+CMDS
+
+# H6) consul config + services + peering + resource surface.
+help_tree "$CONSUL" "consul config/services/peering/resource --help subtrees" <<'CMDS'
+config delete
+config list
+config read
+config write
+services register
+services deregister
+services export
+peering list
+peering read
+peering generate-token
+resource list
+resource read
+CMDS
+
+############################ CONSUL RUNTIME ############################
+echo "=== consul 1.22.7 carpet (dev agent: version/members/kv/services/health/snapshot) ==="
+
+# 1) version red-line: exact Consul v1.22.7 (proves the static Go ELF loads + runs).
+$CONSUL version > /tmp/cv.out 2>&1
+if grep -q 'Consul v1.22.7' /tmp/cv.out; then ok 1 "consul version v1.22.7"; else ok 0 "consul version"; tail -3 /tmp/cv.out; fi
+
+# single-node dev agent on loopback (embedded raft + serf LAN gossip + gRPC/HTTP).
+# DNS is disabled (-dns-port=-1): this carpet exercises serf/raft/HTTP/KV/catalog/
+# health/snapshot, never the DNS interface, and binding the DNS listener has a
+# fixed internal startup deadline that a slow emulated-arch TCG run can miss,
+# aborting the agent with "timeout starting DNS servers". Dropping the unused
+# listener makes agent bring-up deterministic across arches.
+rm -rf /root/consul.d; mkdir -p /root/consul.d
+$CONSUL agent -dev -bind=127.0.0.1 -client=127.0.0.1 -node=starrynode \
+    -dns-port=-1 -data-dir=/root/consul.d > /tmp/agent.out 2>&1 &
+APID=$!
+CRDY=0; i=0
+while [ $i -lt 300 ]; do
+    grep -q 'Consul agent running!' /tmp/agent.out 2>/dev/null && { CRDY=1; break; }
+    kill -0 "$APID" 2>/dev/null || break
+    i=$((i + 1)); sleep 2
+done
+# 2) agent ready.
+ok "$CRDY" "consul dev agent running (loopback serf+raft+http)"
+
+if [ "$CRDY" = 1 ]; then
+    sleep 3
+    # 3) members: node reported alive (client RPC round-trips to the live agent).
+    $CONSUL members > /tmp/mem.out 2>&1
+    if grep -q 'starrynode' /tmp/mem.out && grep -q 'alive' /tmp/mem.out; then
+        ok 1 "consul members: starrynode alive"; grep 'starrynode' /tmp/mem.out
+    else
+        ok 0 "consul members"; tail -4 /tmp/mem.out
+    fi
+
+    # 4) KV put/get byte-exact round-trip.
+    $CONSUL kv put starry/k1 hello-42 > /tmp/kvput.out 2>&1
+    GOT=$($CONSUL kv get starry/k1 2>/dev/null | tr -d '\r\n')
+    if [ "$GOT" = "hello-42" ]; then ok 1 "consul kv put/get roundtrip=hello-42"; else ok 0 "consul kv get (got:[$GOT])"; fi
+    $CONSUL kv put starry/k2 world > /dev/null 2>&1
+    $CONSUL kv put starry/k3 third > /dev/null 2>&1
+
+    # 5) KV recursive read (values of the whole prefix).
+    $CONSUL kv get -recurse starry/ > /tmp/rec.out 2>&1
+    if grep -q 'starry/k1:hello-42' /tmp/rec.out && grep -q 'starry/k2:world' /tmp/rec.out && grep -q 'starry/k3:third' /tmp/rec.out; then
+        ok 1 "consul kv get -recurse (3 keys)"
+    else
+        ok 0 "consul kv get -recurse"; cat /tmp/rec.out
+    fi
+
+    # 6) KV key listing.
+    $CONSUL kv get -keys starry/ > /tmp/keys.out 2>&1
+    if grep -q 'starry/k1' /tmp/keys.out && grep -q 'starry/k2' /tmp/keys.out && grep -q 'starry/k3' /tmp/keys.out; then
+        ok 1 "consul kv get -keys"
+    else
+        ok 0 "consul kv get -keys"; cat /tmp/keys.out
+    fi
+
+    # F1) kv put -flags=<n> stores a user flags field; kv get -detailed surfaces it.
+    $CONSUL kv put -flags=42 starry/kf flagged > /dev/null 2>&1
+    $CONSUL kv get -detailed starry/kf > /tmp/kvd.out 2>&1
+    if grep -qE '^Flags[[:space:]]+42' /tmp/kvd.out && grep -qE '^Value[[:space:]]+flagged' /tmp/kvd.out; then
+        ok 1 "consul kv put -flags + kv get -detailed (Flags 42)"
+    else
+        ok 0 "consul kv put -flags/-detailed"; cat /tmp/kvd.out
+    fi
+
+    # F2) kv put -cas -modify-index=0 is create-only: first write succeeds, second fails
+    #     because the key now exists (Check-And-Set with index 0 means "must not exist").
+    $CONSUL kv put -cas -modify-index=0 starry/kcas first > /tmp/cas1.out 2>&1; C1=$?
+    $CONSUL kv put -cas -modify-index=0 starry/kcas second > /tmp/cas2.out 2>&1; C2=$?
+    if [ "$C1" = 0 ] && [ "$C2" != 0 ] && grep -qi 'already exists' /tmp/cas2.out; then
+        ok 1 "consul kv put -cas -modify-index=0 (create-only CAS)"
+    else
+        ok 0 "consul kv put -cas (rc1=$C1 rc2=$C2)"; cat /tmp/cas2.out
+    fi
+
+    # F3) kv get -keys -separator collapses a nested prefix into one folder entry.
+    $CONSUL kv put starry/sub/a 1 > /dev/null 2>&1
+    $CONSUL kv put starry/sub/b 2 > /dev/null 2>&1
+    $CONSUL kv get -keys -separator=/ starry/ > /tmp/ksep.out 2>&1
+    if grep -qx 'starry/sub/' /tmp/ksep.out; then
+        ok 1 "consul kv get -keys -separator (folder collapse)"
+    else
+        ok 0 "consul kv get -keys -separator"; cat /tmp/ksep.out
+    fi
+
+    # 7) KV delete: the key is gone (get exits non-zero + "No key exists").
+    $CONSUL kv delete starry/k1 > /dev/null 2>&1
+    $CONSUL kv get starry/k1 > /tmp/del.out 2>&1
+    DRC=$?
+    if [ "$DRC" != 0 ] && grep -qi 'No key exists' /tmp/del.out; then
+        ok 1 "consul kv delete (get -> no key)"
+    else
+        ok 0 "consul kv delete (rc=$DRC)"; cat /tmp/del.out
+    fi
+
+    # 8) service registration + service-discovery catalog.
+    $CONSUL services register /root/consul-etcd/consul-service.json > /tmp/reg.out 2>&1
+    sleep 2
+    $CONSUL catalog services > /tmp/cs.out 2>&1
+    if grep -qx 'web' /tmp/cs.out; then ok 1 "consul service register + catalog services(web)"; else ok 0 "consul catalog services"; cat /tmp/cs.out; fi
+
+    # F4) catalog services -tags appends the service's tags (web carries starry,v1).
+    $CONSUL catalog services -tags > /tmp/cstags.out 2>&1
+    if grep -E '^web' /tmp/cstags.out | grep -q 'starry'; then
+        ok 1 "consul catalog services -tags (web tags shown)"
+    else
+        ok 0 "consul catalog services -tags"; cat /tmp/cstags.out
+    fi
+
+    # F5) catalog datacenters lists the local dc (dev agent defaults to dc1).
+    $CONSUL catalog datacenters > /tmp/cdc.out 2>&1
+    if grep -qx 'dc1' /tmp/cdc.out; then ok 1 "consul catalog datacenters (dc1)"; else ok 0 "consul catalog datacenters"; cat /tmp/cdc.out; fi
+
+    # 9) catalog nodes: the registered node is in the catalog.
+    $CONSUL catalog nodes > /tmp/cn.out 2>&1
+    if grep -q 'starrynode' /tmp/cn.out; then ok 1 "consul catalog nodes(starrynode)"; else ok 0 "consul catalog nodes"; cat /tmp/cn.out; fi
+
+    # F6) operator raft list-peers: the single dev server is the raft leader + a voter.
+    $CONSUL operator raft list-peers > /tmp/orp.out 2>&1
+    if grep -q 'starrynode' /tmp/orp.out && grep -q 'leader' /tmp/orp.out && grep -q 'true' /tmp/orp.out; then
+        ok 1 "consul operator raft list-peers (starrynode leader/voter)"
+    else
+        ok 0 "consul operator raft list-peers"; cat /tmp/orp.out
+    fi
+
+    # 10) health check: the web service's TCP check reaches "passing" (the health subsystem
+    #     runs the check on its 3s interval; the passing-filtered watch lists service:web).
+    #     The consul watch is a heavy process that on slow TCG needs several seconds just to
+    #     spawn and emit, so wait for OUTPUT CONTENT (not a fixed window) before killing it,
+    #     and retry until service:web shows passing.
+    HPASS=0; h=0
+    while [ $h -lt 6 ]; do
+        : > /tmp/checks.out
+        $CONSUL watch -type=checks -state=passing > /tmp/checks.out 2>&1 &
+        WPID=$!
+        w=0
+        while [ $w -lt 25 ]; do
+            sleep 1
+            [ -s /tmp/checks.out ] && break
+            w=$((w + 1))
+        done
+        sleep 1
+        kill "$WPID" 2>/dev/null; kill -9 "$WPID" 2>/dev/null
+        if grep -q 'service:web' /tmp/checks.out; then HPASS=1; break; fi
+        h=$((h + 1)); sleep 3
+    done
+    if [ "$HPASS" = 1 ]; then
+        ok 1 "consul health check service:web passing"
+    else
+        ok 0 "consul health check service:web passing"; head -30 /tmp/checks.out
+    fi
+
+    # 11) snapshot save: raft state serialized to a verified snapshot file.
+    $CONSUL snapshot save /root/consul.snap > /tmp/snap.out 2>&1
+    if grep -qi 'Saved' /tmp/snap.out && [ -s /root/consul.snap ]; then
+        ok 1 "consul snapshot save"; cat /tmp/snap.out
+    else
+        ok 0 "consul snapshot save"; cat /tmp/snap.out
+    fi
+
+    # F7) snapshot inspect: the saved snapshot's metadata (ID/Size/Index/Term) reads back.
+    $CONSUL snapshot inspect /root/consul.snap > /tmp/sins.out 2>&1
+    if grep -q 'ID' /tmp/sins.out && grep -q 'Index' /tmp/sins.out && grep -q 'Term' /tmp/sins.out; then
+        ok 1 "consul snapshot inspect (metadata)"
+    else
+        ok 0 "consul snapshot inspect"; cat /tmp/sins.out
+    fi
+
+    # 12) snapshot restore: the saved snapshot is restored into the running server.
+    $CONSUL snapshot restore /root/consul.snap > /tmp/rest.out 2>&1
+    if grep -qi 'Restored snapshot' /tmp/rest.out; then ok 1 "consul snapshot restore"; else ok 0 "consul snapshot restore"; cat /tmp/rest.out; fi
+else
+    echo "  consul agent not ready; tail:"; tail -15 /tmp/agent.out
+fi
+kill "$APID" 2>/dev/null; kill -9 "$APID" 2>/dev/null
+sleep 1
+
+############################ ETCD CLI SURFACE ############################
+echo "=== etcd/etcdctl/etcdutl CLI surface (help tree) ==="
+
+# H7) `etcd --help` (the server binary): exits 0 and prints its flag block.
+$ETCD --help > /tmp/eth.out 2>&1
+if [ $? = 0 ] && grep -qi 'Usage:' /tmp/eth.out && grep -q -- '--data-dir' /tmp/eth.out; then
+    ok 1 "etcd --help (server flags)"
+else
+    ok 0 "etcd --help"; head -5 /tmp/eth.out
+fi
+
+# H8) `etcdctl --help`: lists the grouped command set (get/put/lease/member/... present).
+$ETCDCTL --help > /tmp/ecth.out 2>&1
+if [ $? = 0 ] && grep -q 'COMMANDS' /tmp/ecth.out \
+   && grep -q '  get' /tmp/ecth.out && grep -q '  put' /tmp/ecth.out && grep -q 'lease grant' /tmp/ecth.out; then
+    ok 1 "etcdctl --help lists command set"
+else
+    ok 0 "etcdctl --help"; head -5 /tmp/ecth.out
+fi
+
+# H9) every etcdctl subcommand's `--help` (the full grouped command tree).
+help_tree "$ETCDCTL" "etcdctl --help tree (all subcommands)" <<'CMDS'
+alarm disarm
+alarm list
+auth disable
+auth enable
+auth status
+check datascale
+check perf
+compaction
+completion
+defrag
+del
+downgrade cancel
+downgrade enable
+downgrade validate
+elect
+endpoint hashkv
+endpoint health
+endpoint status
+get
+lease grant
+lease keep-alive
+lease list
+lease revoke
+lease timetolive
+lock
+make-mirror
+member add
+member list
+member promote
+member remove
+member update
+move-leader
+put
+role add
+role delete
+role get
+role grant-permission
+role list
+role revoke-permission
+snapshot save
+txn
+user add
+user delete
+user get
+user grant-role
+user list
+user passwd
+user revoke-role
+version
+watch
+CMDS
+
+# H10) etcdctl auth/user/role surface: the multi-tenant auth subsystem the runtime carpet
+#      never enables (a dev single node runs auth-disabled), but whose CLI must be intact.
+help_tree "$ETCDCTL" "etcdctl auth/user/role --help surface" <<'CMDS'
+auth enable
+auth disable
+auth status
+user add
+user get
+user list
+user delete
+user passwd
+user grant-role
+user revoke-role
+role add
+role get
+role list
+role delete
+role grant-permission
+role revoke-permission
+CMDS
+
+# H11) `etcdutl --help` + its full subcommand tree (offline snapshot/db tooling).
+$ETCDUTL --help > /tmp/euth.out 2>&1
+if [ $? = 0 ] && grep -q 'Available Commands' /tmp/euth.out && grep -q 'snapshot' /tmp/euth.out; then
+    ok 1 "etcdutl --help lists command set"
+else
+    ok 0 "etcdutl --help"; head -5 /tmp/euth.out
+fi
+help_tree "$ETCDUTL" "etcdutl --help tree (all subcommands)" <<'CMDS'
+completion
+defrag
+hashkv
+migrate
+snapshot
+snapshot restore
+snapshot status
+version
+CMDS
+
+############################ ETCD RUNTIME ############################
+echo "=== etcd 3.6.11 carpet (server: version/kv/watch/txn/lease/member/snapshot) ==="
+EP=127.0.0.1:2379
+
+# 1) etcd version red-line.
+$ETCD --version > /tmp/ev.out 2>&1
+if grep -qE '^etcd Version: 3\.6\.11$' /tmp/ev.out; then ok 1 "etcd --version 3.6.11"; else ok 0 "etcd --version"; tail -3 /tmp/ev.out; fi
+# 2) etcdctl version red-line.
+$ETCDCTL version > /tmp/ecv.out 2>&1
+if grep -qE '^etcdctl version: 3\.6\.11$' /tmp/ecv.out; then ok 1 "etcdctl version 3.6.11"; else ok 0 "etcdctl version"; tail -3 /tmp/ecv.out; fi
+
+# single-node server on loopback (Raft + bbolt MVCC + gRPC). --unsafe-no-fsync drops the WAL
+# fsync: on emulated-arch TCG the virtio-blk fsync latency makes the boot-time raft member
+# publish exceed its 7s deadline (server.go "failed to publish local member ... context deadline
+# exceeded"), which leaves the server stuck sub-ready; an ephemeral single-node test needs no
+# on-disk durability. The wider heartbeat/election also lifts the derived publish deadline.
+DATA=/root/etcd.d
+rm -rf "$DATA"; mkdir -p "$DATA"
+$ETCD --name s1 --data-dir "$DATA" \
+    --listen-client-urls "http://$EP" --advertise-client-urls "http://$EP" \
+    --listen-peer-urls "http://127.0.0.1:2380" --initial-advertise-peer-urls "http://127.0.0.1:2380" \
+    --initial-cluster "s1=http://127.0.0.1:2380" --initial-cluster-token t1 --initial-cluster-state new \
+    --force-new-cluster --unsafe-no-fsync --heartbeat-interval=500 --election-timeout=5000 \
+    --log-level warn > /tmp/etcd.out 2>&1 &
+EPID=$!
+ERDY=0; i=0
+# endpoint health is a linearizable read; on emulated-arch TCG that round-trip alone can take
+# several seconds, so a 2s probe deadline false-negatives a server that is in fact serving and
+# skips the whole etcd suite. A port that is not up yet still fails fast (connection refused).
+while [ $i -lt 120 ]; do
+    if $ETCDCTL --endpoints="$EP" --command-timeout=15s endpoint health > /tmp/eh.out 2>&1; then
+        grep -q 'is healthy' /tmp/eh.out && { ERDY=1; break; }
+    fi
+    kill -0 "$EPID" 2>/dev/null || break
+    i=$((i + 1)); sleep 2
+done
+# 3) server ready.
+ok "$ERDY" "etcd server ready (loopback client RPC)"
+
+if [ "$ERDY" = 1 ]; then
+    # 4) KV put/get byte-exact round-trip.
+    $ETCDCTL --endpoints="$EP" put foo bar42 > /tmp/eput.out 2>&1
+    EGOT=$($ETCDCTL --endpoints="$EP" get foo --print-value-only 2>/tmp/eget.err | tr -d '\r\n')
+    if [ "$EGOT" = "bar42" ]; then ok 1 "etcd kv put/get roundtrip=bar42"; else ok 0 "etcd kv get (got:[$EGOT])"; tail -3 /tmp/eget.err; fi
+
+    # F8) put --prev-kv returns the prior key/value the write replaced.
+    $ETCDCTL --endpoints="$EP" put foo newval --prev-kv > /tmp/eprev.out 2>&1
+    if grep -q 'foo' /tmp/eprev.out && grep -q 'bar42' /tmp/eprev.out; then
+        ok 1 "etcd put --prev-kv (returns replaced foo=bar42)"
+    else
+        ok 0 "etcd put --prev-kv"; cat /tmp/eprev.out
+    fi
+
+    # 5) KV delete: key removed (get returns empty).
+    $ETCDCTL --endpoints="$EP" del foo > /tmp/edel.out 2>&1
+    EDG=$($ETCDCTL --endpoints="$EP" get foo --print-value-only 2>/dev/null | tr -d '\r\n')
+    if [ -z "$EDG" ]; then ok 1 "etcd kv del (get -> empty)"; else ok 0 "etcd kv del (still:[$EDG])"; fi
+
+    # F9) get --prefix flag matrix: seed a 3-key prefix, then exercise --keys-only, --limit,
+    #     --sort-by/--order and the -w json count in one grouped assertion (all must hold).
+    $ETCDCTL --endpoints="$EP" put pfx/a A1 > /dev/null 2>&1
+    $ETCDCTL --endpoints="$EP" put pfx/b B2 > /dev/null 2>&1
+    $ETCDCTL --endpoints="$EP" put pfx/c C3 > /dev/null 2>&1
+    KO=$($ETCDCTL --endpoints="$EP" get pfx/ --prefix --keys-only 2>/dev/null | grep -c '^pfx/')
+    LIM=$($ETCDCTL --endpoints="$EP" get pfx/ --prefix --keys-only --limit 2 2>/dev/null | grep -c '^pfx/')
+    FIRST=$($ETCDCTL --endpoints="$EP" get pfx/ --prefix --keys-only --sort-by=KEY --order=DESCEND 2>/dev/null | grep '^pfx/' | head -1)
+    CNT=$($ETCDCTL --endpoints="$EP" get pfx/ --prefix -w json 2>/dev/null | grep -o '"count":3')
+    if [ "$KO" = 3 ] && [ "$LIM" = 2 ] && [ "$FIRST" = "pfx/c" ] && [ "$CNT" = '"count":3' ]; then
+        ok 1 "etcd get --prefix/--keys-only/--limit/--sort-by/-w json"
+    else
+        ok 0 "etcd get --prefix matrix (ko=$KO lim=$LIM first=$FIRST cnt=$CNT)"
+    fi
+
+    # F10) del --prefix returns the count of keys it removed (all three).
+    DELN=$($ETCDCTL --endpoints="$EP" del pfx/ --prefix 2>/dev/null | tr -d '\r\n')
+    if [ "$DELN" = 3 ]; then ok 1 "etcd del --prefix (deleted 3)"; else ok 0 "etcd del --prefix (got:[$DELN])"; fi
+
+    # 6) watch: a background watcher receives a PUT event delivered by the server. The watcher
+    #    is established asynchronously - etcdctl connects and opens the stream before any event
+    #    is observable - so a single fixed pre-put sleep can let the PUT race ahead of stream
+    #    setup on slow TCG, and the watcher then never sees it. Put repeatedly until the watcher
+    #    captures an event (bounded); once the stream is up, the next PUT is delivered. This polls
+    #    the real signal instead of a fixed delay, matching the consul-watch loop above.
+    $ETCDCTL --endpoints="$EP" watch watchkey > /tmp/watch.out 2>&1 &
+    WPID=$!
+    wgot=0
+    for _ in $(seq 1 20); do
+        $ETCDCTL --endpoints="$EP" put watchkey EVENT_123 > /dev/null 2>&1
+        sleep 1
+        if grep -q 'EVENT_123' /tmp/watch.out; then wgot=1; break; fi
+    done
+    kill "$WPID" 2>/dev/null; kill -9 "$WPID" 2>/dev/null
+    if [ "$wgot" = 1 ] && grep -q 'PUT' /tmp/watch.out; then
+        ok 1 "etcd watch received PUT event"
+    else
+        ok 0 "etcd watch"; cat /tmp/watch.out
+    fi
+
+    # 7) txn: a guarded transaction takes the success branch and applies its writes.
+    $ETCDCTL --endpoints="$EP" put cnt 100 > /dev/null 2>&1
+    $ETCDCTL --endpoints="$EP" txn > /tmp/txn.out 2>&1 <<'TXN'
+value("cnt") = "100"
+
+put cnt 200
+
+put cnt 999
+
+TXN
+    TGOT=$($ETCDCTL --endpoints="$EP" get cnt --print-value-only 2>/dev/null | tr -d '\r\n')
+    if grep -q 'SUCCESS' /tmp/txn.out && [ "$TGOT" = "200" ]; then
+        ok 1 "etcd txn (guard true -> success branch, cnt=200)"
+    else
+        ok 0 "etcd txn (cnt:[$TGOT])"; cat /tmp/txn.out
+    fi
+
+    # F11) txn mod() compare: a revision-guard transaction takes the success branch too
+    #      (distinct guard operator from the value() guard above).
+    $ETCDCTL --endpoints="$EP" put mk base > /dev/null 2>&1
+    $ETCDCTL --endpoints="$EP" txn > /tmp/mtxn.out 2>&1 <<'MTXN'
+mod("mk") > "0"
+
+put mk winner
+
+put mk loser
+
+MTXN
+    MGOT=$($ETCDCTL --endpoints="$EP" get mk --print-value-only 2>/dev/null | tr -d '\r\n')
+    if grep -q 'SUCCESS' /tmp/mtxn.out && [ "$MGOT" = "winner" ]; then
+        ok 1 "etcd txn mod() guard (success branch, mk=winner)"
+    else
+        ok 0 "etcd txn mod() guard (mk:[$MGOT])"; cat /tmp/mtxn.out
+    fi
+
+    # 8) lease: grant a lease, attach a key to it, key readable while lease is live; TTL shows.
+    GR=$($ETCDCTL --endpoints="$EP" lease grant 100 2>/tmp/lg.err)
+    echo "  lease grant: $GR"
+    # "lease <hexid> granted with TTL(100s)"
+    set -- $GR; LID="${2:-}"
+    if [ -n "${LID:-}" ]; then
+        $ETCDCTL --endpoints="$EP" put leasekey withlease --lease="$LID" > /dev/null 2>&1
+        LGET=$($ETCDCTL --endpoints="$EP" get leasekey --print-value-only 2>/dev/null | tr -d '\r\n')
+        $ETCDCTL --endpoints="$EP" lease keep-alive --once "$LID" > /tmp/lka.out 2>&1
+        $ETCDCTL --endpoints="$EP" lease timetolive "$LID" > /tmp/lttl.out 2>&1
+        if [ "$LGET" = "withlease" ] && grep -qi 'keepalived' /tmp/lka.out && grep -qi 'remaining' /tmp/lttl.out; then
+            ok 1 "etcd lease grant+attach+keep-alive+TTL"
+        else
+            ok 0 "etcd lease (get:[$LGET])"; cat /tmp/lka.out /tmp/lttl.out
+        fi
+        # F12) lease list reports the live lease (both the count line and the hex id).
+        $ETCDCTL --endpoints="$EP" lease list > /tmp/llist.out 2>&1
+        if grep -qi 'found' /tmp/llist.out && grep -q "$LID" /tmp/llist.out; then
+            ok 1 "etcd lease list (live lease reported)"
+        else
+            ok 0 "etcd lease list"; cat /tmp/llist.out
+        fi
+    else
+        ok 0 "etcd lease grant"; cat /tmp/lg.err
+        ok 0 "etcd lease list (no lease)"
+    fi
+
+    # 9) lease TTL expiry: a key on a short lease with no keep-alive is auto-removed.
+    #     Grant a generous TTL so the pre-expiry read reliably races ahead of it even on
+    #     slow TCG (each etcdctl call costs seconds), then POLL for the key to disappear
+    #     rather than sleeping a fixed amount.
+    GR2=$($ETCDCTL --endpoints="$EP" lease grant 30 2>/dev/null)
+    set -- $GR2; LID2="${2:-}"
+    if [ -n "${LID2:-}" ]; then
+        $ETCDCTL --endpoints="$EP" put ephkey ephval --lease="$LID2" > /dev/null 2>&1
+        EPRE=$($ETCDCTL --endpoints="$EP" get ephkey --print-value-only 2>/dev/null | tr -d '\r\n')
+        EXP=0; j=0
+        while [ $j -lt 40 ]; do
+            sleep 3
+            EPOST=$($ETCDCTL --endpoints="$EP" get ephkey --print-value-only 2>/dev/null | tr -d '\r\n')
+            [ -z "$EPOST" ] && { EXP=1; break; }
+            j=$((j + 1))
+        done
+        if [ "$EPRE" = "ephval" ] && [ "$EXP" = 1 ]; then
+            ok 1 "etcd lease TTL expiry (ephkey auto-removed)"
+        else
+            ok 0 "etcd lease expiry (pre:[$EPRE] expired:$EXP)"
+        fi
+    else
+        ok 0 "etcd lease grant (short)"
+    fi
+
+    # 10) member list: the single member is present and started.
+    $ETCDCTL --endpoints="$EP" member list > /tmp/ml.out 2>&1
+    if grep -q 'started' /tmp/ml.out && grep -q ' s1,' /tmp/ml.out; then
+        ok 1 "etcd member list (s1 started)"; cat /tmp/ml.out
+    else
+        ok 0 "etcd member list"; cat /tmp/ml.out
+    fi
+
+    # F13) member list -w json exposes the machine-readable members array.
+    $ETCDCTL --endpoints="$EP" member list -w json > /tmp/mljson.out 2>&1
+    if grep -q '"members"' /tmp/mljson.out; then
+        ok 1 "etcd member list -w json (members array)"
+    else
+        ok 0 "etcd member list -w json"; head -c 200 /tmp/mljson.out
+    fi
+
+    # F14) endpoint status -w table renders the status table with its column header.
+    $ETCDCTL --endpoints="$EP" endpoint status -w table > /tmp/estat.out 2>&1
+    if grep -q 'ENDPOINT' /tmp/estat.out && grep -q 'IS LEADER' /tmp/estat.out; then
+        ok 1 "etcd endpoint status -w table (header)"
+    else
+        ok 0 "etcd endpoint status -w table"; cat /tmp/estat.out
+    fi
+
+    # F15) endpoint hashkv returns the KV-history hash for the endpoint.
+    $ETCDCTL --endpoints="$EP" endpoint hashkv > /tmp/ehash.out 2>&1
+    if grep -qE '127\.0\.0\.1:2379, [0-9]+' /tmp/ehash.out; then
+        ok 1 "etcd endpoint hashkv (hash reported)"
+    else
+        ok 0 "etcd endpoint hashkv"; cat /tmp/ehash.out
+    fi
+
+    # F16) alarm list on a healthy store is empty and exits 0 (no NOSPACE/CORRUPT alarms).
+    $ETCDCTL --endpoints="$EP" alarm list > /tmp/alarm.out 2>&1
+    ALRC=$?
+    if [ "$ALRC" = 0 ] && [ ! -s /tmp/alarm.out ]; then
+        ok 1 "etcd alarm list (no alarms)"
+    else
+        ok 0 "etcd alarm list (rc=$ALRC)"; cat /tmp/alarm.out
+    fi
+
+    # F17) compaction: put a key, read back its revision, then compact history to it.
+    $ETCDCTL --endpoints="$EP" put ckey cval > /dev/null 2>&1
+    CREV=$($ETCDCTL --endpoints="$EP" get ckey -w json 2>/dev/null | grep -o '"mod_revision":[0-9]*' | head -1 | grep -o '[0-9]*')
+    if [ -n "$CREV" ]; then
+        $ETCDCTL --endpoints="$EP" compaction "$CREV" > /tmp/comp.out 2>&1
+        if grep -q "compacted revision $CREV" /tmp/comp.out; then
+            ok 1 "etcd compaction (history compacted to rev $CREV)"
+        else
+            ok 0 "etcd compaction"; cat /tmp/comp.out
+        fi
+    else
+        ok 0 "etcd compaction (no revision read)"
+    fi
+
+    # 11) snapshot save: the MVCC store is serialized to a snapshot file, verified by etcdutl.
+    $ETCDCTL --endpoints="$EP" snapshot save /root/etcd.snap > /tmp/esnap.out 2>&1
+    if [ -s /root/etcd.snap ] && $ETCDUTL snapshot status /root/etcd.snap > /tmp/esnst.out 2>&1; then
+        ok 1 "etcd snapshot save (+etcdutl status)"; tail -2 /tmp/esnap.out
+    else
+        ok 0 "etcd snapshot save"; cat /tmp/esnap.out /tmp/esnst.out
+    fi
+
+    # F18) etcdutl snapshot status -w table renders the offline snapshot metadata table.
+    $ETCDUTL snapshot status -w table /root/etcd.snap > /tmp/esst.out 2>&1
+    if grep -q 'HASH' /tmp/esst.out && grep -q 'REVISION' /tmp/esst.out && grep -q 'TOTAL KEYS' /tmp/esst.out; then
+        ok 1 "etcdutl snapshot status -w table (metadata table)"
+    else
+        ok 0 "etcdutl snapshot status -w table"; cat /tmp/esst.out
+    fi
+else
+    echo "  etcd server not ready; tail:"; tail -20 /tmp/etcd.out
+fi
+kill "$EPID" 2>/dev/null; kill -9 "$EPID" 2>/dev/null
+sleep 1
+
+############################ INTEGRATION ############################
+# Isolated carpets above are the prerequisite (each daemon exercised on its own). This
+# section is the COMBINATION test: consul and etcd run CONCURRENTLY on loopback (distinct
+# port sets, no collision) and drive a real "service discovery + config center" workflow -
+# register a service in consul, store its config in etcd, then discover the service from
+# consul AND read its config back from etcd, tying the two systems into one flow. It proves
+# two heavy Go daemons coexist (concurrent futex / mmap / netpoll / scheduler) and interoperate.
+echo "=== integration: consul + etcd concurrent (service discovery + config center) ==="
+
+rm -rf /root/consul.d; mkdir -p /root/consul.d
+# Bring consul fully up FIRST, then start etcd alongside it. consul's DNS-server start has an
+# internal deadline that the extreme single-core TCG slowness can blow if a second heavy Go
+# runtime competes for the core during that window; once consul is up, etcd joins and both
+# serve CONCURRENTLY for the workflow below (the coexistence claim holds - both stay alive).
+$CONSUL agent -dev -bind=127.0.0.1 -client=127.0.0.1 -node=starrynode \
+    -dns-port=-1 -data-dir=/root/consul.d > /tmp/iagent.out 2>&1 &
+IAPID=$!
+ICRDY=0; i=0
+while [ $i -lt 300 ]; do
+    grep -q 'Consul agent running!' /tmp/iagent.out 2>/dev/null && { ICRDY=1; break; }
+    kill -0 "$IAPID" 2>/dev/null || break
+    i=$((i + 1)); sleep 2
+done
+
+IDATA=/root/etcd.d
+rm -rf "$IDATA"; mkdir -p "$IDATA"
+$ETCD --name s1 --data-dir "$IDATA" \
+    --listen-client-urls "http://$EP" --advertise-client-urls "http://$EP" \
+    --listen-peer-urls "http://127.0.0.1:2380" --initial-advertise-peer-urls "http://127.0.0.1:2380" \
+    --initial-cluster "s1=http://127.0.0.1:2380" --initial-cluster-token t1 --initial-cluster-state new \
+    --force-new-cluster --unsafe-no-fsync --heartbeat-interval=500 --election-timeout=5000 \
+    --log-level warn > /tmp/ietcd.out 2>&1 &
+IEPID=$!
+IERDY=0; i=0
+# Same slow-arch linearizable-read tolerance as the standalone etcd probe above.
+while [ $i -lt 120 ]; do
+    if $ETCDCTL --endpoints="$EP" --command-timeout=15s endpoint health > /tmp/ieh.out 2>&1; then
+        grep -q 'is healthy' /tmp/ieh.out && { IERDY=1; break; }
+    fi
+    kill -0 "$IEPID" 2>/dev/null || break
+    i=$((i + 1)); sleep 2
+done
+
+# INT1: with consul still alive, etcd now serves too -> both run concurrently on loopback.
+if [ "$ICRDY" = 1 ] && [ "$IERDY" = 1 ] && kill -0 "$IAPID" 2>/dev/null; then
+    ok 1 "integration: consul + etcd serving concurrently on loopback"
+else
+    ok 0 "integration coexistence (consul:$ICRDY etcd:$IERDY)"
+    tail -8 /tmp/iagent.out; tail -8 /tmp/ietcd.out
+fi
+
+if [ "$ICRDY" = 1 ] && [ "$IERDY" = 1 ]; then
+    sleep 3
+    SVCNAME=orders
+    DSN="postgres://orders-db:5432/orders"
+    # register the service in consul
+    cat > /tmp/orders.json <<JSON
+{ "service": { "name": "$SVCNAME", "port": 9090, "tags": ["prod"] } }
+JSON
+    $CONSUL services register /tmp/orders.json > /tmp/ireg.out 2>&1
+    # store its config in etcd (the config center)
+    $ETCDCTL --endpoints="$EP" put "config/$SVCNAME/dsn" "$DSN" > /dev/null 2>&1
+    $ETCDCTL --endpoints="$EP" put "config/$SVCNAME/replicas" "3" > /dev/null 2>&1
+    sleep 2
+
+    # INT2: discover the service from consul's catalog.
+    $CONSUL catalog services > /tmp/icat.out 2>&1
+    if grep -qx "$SVCNAME" /tmp/icat.out; then
+        ok 1 "integration: consul discovers registered service '$SVCNAME'"
+    else
+        ok 0 "integration consul discovery"; cat /tmp/icat.out
+    fi
+
+    # INT3: read the service config back from etcd, byte-exact + prefix listing.
+    GOTDSN=$($ETCDCTL --endpoints="$EP" get "config/$SVCNAME/dsn" --print-value-only 2>/dev/null | tr -d '\r\n')
+    $ETCDCTL --endpoints="$EP" get "config/$SVCNAME/" --prefix > /tmp/icfg.out 2>&1
+    if [ "$GOTDSN" = "$DSN" ] && grep -q 'replicas' /tmp/icfg.out; then
+        ok 1 "integration: etcd config-center round-trip (dsn+replicas)"
+    else
+        ok 0 "integration etcd config (dsn:[$GOTDSN])"; cat /tmp/icfg.out
+    fi
+
+    # INT4: end-to-end - use the name discovered from consul to key etcd, proving the two
+    #       systems compose into a discover-then-configure flow.
+    DISC=$(grep -xE 'orders' /tmp/icat.out | head -1)
+    if [ "$DISC" = "$SVCNAME" ]; then
+        E2E=$($ETCDCTL --endpoints="$EP" get "config/$DISC/dsn" --print-value-only 2>/dev/null | tr -d '\r\n')
+    else
+        E2E=""
+    fi
+    if [ "$DISC" = "$SVCNAME" ] && [ "$E2E" = "$DSN" ]; then
+        ok 1 "integration: end-to-end discover(consul)->configure(etcd)"
+    else
+        ok 0 "integration end-to-end (disc:[$DISC] e2e:[$E2E])"
+    fi
+else
+    echo "  integration skipped body: one daemon not ready"
+    ok 0 "integration: consul discovers registered service"
+    ok 0 "integration: etcd config-center round-trip"
+    ok 0 "integration: end-to-end discover->configure"
+fi
+kill "$IAPID" 2>/dev/null; kill -9 "$IAPID" 2>/dev/null
+kill "$IEPID" 2>/dev/null; kill -9 "$IEPID" 2>/dev/null
+
+############################ AGGREGATE ############################
+EXPECTED=57
+echo "AGGREGATE: PASS=$PASS TOTAL=$TOTAL EXPECTED=$EXPECTED"
+if [ "$PASS" = "$TOTAL" ] && [ "$TOTAL" = "$EXPECTED" ]; then
+    printf 'CONSULETCD_OK=%s/%s\n' "$PASS" "$TOTAL"
+    echo "TEST PASSED"
+    exit 0
+fi
+printf 'CONSULETCD_OK=%s/%s\n' "$PASS" "$TOTAL"
+echo "TEST FAILED"
+exit 1

--- a/apps/starry/consul-etcd/qemu-aarch64.toml
+++ b/apps/starry/consul-etcd/qemu-aarch64.toml
@@ -1,0 +1,17 @@
+# consul-etcd aarch64 - Consul 1.22.7 + etcd 3.6.11 distributed-KV carpet.
+# -cpu cortex-a72 (a 64-bit core; the virt default would pick AArch32). Both services are
+# fully static CGO-free Go ELF binaries (official arm64 releases) staged by prebuild.sh. The
+# rootfs is the per-app rootfs-aarch64-alpine.img which prebuild.sh grows to 2.5G.
+args = [
+    "-nographic", "-m", "4096M", "-smp", "1", "-cpu", "cortex-a72",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-consul-etcd.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 5400

--- a/apps/starry/consul-etcd/qemu-loongarch64.toml
+++ b/apps/starry/consul-etcd/qemu-loongarch64.toml
@@ -1,0 +1,19 @@
+# consul-etcd loongarch64 - Consul 1.22.7 + etcd 3.6.11 distributed-KV carpet.
+# Platform: dynamic (axplat-dyn/efi console), same family as aarch64/riscv64 - uefi=false /
+# to_bin=true is the dynamic platform's raw-binary boot path. Both consul and etcd are
+# CROSS-COMPILED from their pinned source tags (neither ships a loong64 release); etcd on loong64
+# is started with ETCD_UNSUPPORTED_ARCH=loong64 (set by the gate). The rootfs is the per-app
+# rootfs-loongarch64-alpine.img which prebuild.sh grows to 2.5G.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "2048M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-consul-etcd.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 9000

--- a/apps/starry/consul-etcd/qemu-riscv64.toml
+++ b/apps/starry/consul-etcd/qemu-riscv64.toml
@@ -1,0 +1,20 @@
+# consul-etcd riscv64 - Consul 1.22.7 + etcd 3.6.11 distributed-KV carpet.
+# -cpu rv64. consul on riscv64 relies on the syscall-dispatch getrlimit->prlimit64 routing
+# (its Go runtime calls legacy getrlimit directly); etcd's bbolt relies on the mmap-EOF
+# populate fix so its huge InitialMmapSize does not OOM. consul and etcd are both
+# CROSS-COMPILED from their pinned source tags (neither ships a riscv64 release), and etcd is
+# started with ETCD_UNSUPPORTED_ARCH=riscv64 (set by the gate). The rootfs is the per-app
+# rootfs-riscv64-alpine.img which prebuild.sh grows to 2.5G.
+args = [
+    "-nographic", "-m", "4096M", "-smp", "1", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-consul-etcd.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 9000

--- a/apps/starry/consul-etcd/qemu-x86_64.toml
+++ b/apps/starry/consul-etcd/qemu-x86_64.toml
@@ -1,0 +1,22 @@
+# consul-etcd x86_64 - Consul 1.22.7 + etcd 3.6.11 distributed-KV carpet.
+# x86_64 boots through OVMF: uefi=true, to_bin=true. The post-axbuild-refactor dynamic
+# platform kernel is an EFI image without a PVH ELF Note, so qemu -kernel direct load
+# rejects it ("Error loading uncompressed kernel without PVH ELF Note"); the UEFI path
+# loads it via firmware instead.
+# Both services are fully static CGO-free Go ELF binaries (official amd64 releases) staged
+# by prebuild.sh; the gate runs them single-node over loopback. The rootfs is the per-app
+# rootfs-x86_64-alpine.img which prebuild.sh grows to 2.5G so both binaries fit without
+# truncation.
+args = [
+    "-nographic", "-m", "4096M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = "sh /usr/bin/run-consul-etcd.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 5400


### PR DESCRIPTION
## 概述

`apps/starry/consul-etcd` 在 StarryOS 上跑起两套真实分布式 KV 服务(Consul 1.22.7 + etcd)并做 57 项 gate 校验: Consul 的 CLI help 树/flag 矩阵、dev agent(serf+raft+http)、kv put/get/CAS/recurse、service register + catalog、raft leader、health check; etcd 的 server 启动、etcdctl put/get/watch/txn/lease、member/endpoint、etcdutl snapshot 等。

## 依赖 / 构建

Consul 与 etcd 无官方 riscv64/loongarch64 release 二进制, 因此 rv/la 由源码交叉编译(`go` >= 1.25 + `git`, 源码 commit 已钉), x86_64/aarch64 用上游官方 release 二进制。动态平台内核是 PIC/PIE, 故 x86_64 与 loongarch64 经 UEFI handoff 加载(`uefi=true`), aarch64/riscv64 走 raw `-kernel`。

## 本轮 CR 修复

- **preflight 纯预检**: `preflight_cross_check()` 之前只检查缓存里的 `consul` 与 `etcd`, 漏了 `etcdctl`/`etcdutl`。部分缓存(有 `etcd` 缺 `etcdctl`/`etcdutl`)且缺 `go`/`git` 时, 会先 `grow_rootfs`/`stage_consul` 改动 rootfs, 之后才在 `stage_etcd` 失败, 违反"改 rootfs 前纯预检"的承诺。现在改为检查 `consul` + `etcd`/`etcdctl`/`etcdutl` 全部四个二进制, 任一缺失即在预检阶段要求 `go`/`git`, 不再有 rootfs 半改动。
- **四架构 app 实跑证据**: 四架构 `cargo xtask starry app qemu -t consul-etcd --arch <arch>` 本地真跑, 每个架构 `AGGREGATE: PASS=57 TOTAL=57 EXPECTED=57` + `TEST PASSED`(x86_64/aarch64/riscv64/loongarch64 全过), 两套服务在 guest 内真实启动并通过全部 gate。

## 直接回归层

mq/mount 类的核心内核 ABI 回归在 `test-suit/starryos`; 本 app 是较重的分布式一致性套件, 覆盖 Consul/etcd 在 StarryOS 上的端到端行为。
