### PR TITLE
fix(rdrive): use preempt-safe registry locks

### DIFF
--- a/drivers/rdrive/src/lib.rs
+++ b/drivers/rdrive/src/lib.rs
@@ -7,6 +7,8 @@ extern crate log;
 
 use core::ptr::NonNull;
 
+// The registry is not hard-IRQ safe, but it is also used by runtime discovery
+// paths that must not trigger task preemption hooks on lock release.
 use ax_kspin::SpinRaw as Mutex;
 pub use fdt_edit::{Fdt, Phandle};
 use register::{DriverRegister, ProbeLevel};
@@ -178,14 +180,29 @@ pub fn probe_all(stop_if_fail: bool) -> Result<(), ProbeError> {
     Ok(())
 }
 
+/// Returns all registered devices that implement `T`.
+///
+/// Not hard-IRQ safe: this takes the global rdrive registry lock and allocates
+/// the returned `Vec`. Hard IRQ handlers must use pre-published IRQ-side state
+/// instead of looking devices up through rdrive.
 pub fn get_list<T: DriverGeneric>() -> Vec<Device<T>> {
     read(|manager| manager.dev_container.devices())
 }
 
+/// Returns a registered device by id and expected interface type.
+///
+/// Not hard-IRQ safe: this takes the global rdrive registry lock. Hard IRQ
+/// handlers must use pre-published IRQ-side state instead of looking devices up
+/// through rdrive.
 pub fn get<T: DriverGeneric>(id: DeviceId) -> Result<Device<T>, GetDeviceError> {
     read(|manager| manager.dev_container.get_typed(id))
 }
 
+/// Returns one registered device that implements `T`.
+///
+/// Not hard-IRQ safe: this takes the global rdrive registry lock and scans the
+/// registry. Hard IRQ handlers must use pre-published IRQ-side state instead of
+/// looking devices up through rdrive.
 pub fn get_one<T: DriverGeneric>() -> Option<Device<T>> {
     read(|manager| manager.dev_container.get_one())
 }

--- a/drivers/rdrive/src/lock.rs
+++ b/drivers/rdrive/src/lock.rs
@@ -167,6 +167,12 @@ impl<T: Any> Device<T> {
         })
     }
 
+    /// Locks the device for exclusive mutable access.
+    ///
+    /// Not hard-IRQ safe: this may spin until the current owner drops the
+    /// device and it queries OS ownership state. Hard IRQ handlers must use a
+    /// pre-registered IRQ endpoint or other IRQ-side state instead of locking a
+    /// rdrive device.
     pub fn lock(&self) -> Result<DeviceGuard<T>, GetDeviceError> {
         let lock = self.lock.upgrade().ok_or(GetDeviceError::DeviceReleased)?;
         lock.lock()?;
@@ -194,10 +200,15 @@ impl<T: Any> Device<T> {
         core::any::type_name::<T>()
     }
 
-    /// 强制获取设备
+    /// Returns the raw device pointer without taking the rdrive device lock.
     ///
     /// # Safety
-    /// 一般用于中断处理中
+    ///
+    /// Not hard-IRQ safe: this is not an interrupt-context escape hatch. The
+    /// caller must prove that the device is still alive and that no concurrent
+    /// mutable or shared access can race with the returned pointer. Hard IRQ
+    /// handlers must use pre-registered IRQ-side state instead of reaching back
+    /// into rdrive devices.
     pub unsafe fn force_use(&self) -> *mut T {
         self.ptr
     }

--- a/drivers/rdrive/src/probe/acpi.rs
+++ b/drivers/rdrive/src/probe/acpi.rs
@@ -28,7 +28,7 @@ use acpi::{
     },
     sdt::spcr::{Spcr, SpcrInterfaceType},
 };
-use ax_kspin::SpinRaw as Mutex;
+use ax_kspin::SpinNoPreempt as Mutex;
 pub use rdif_base::irq::{AcpiGsiController, AcpiGsiRoute, AcpiIrqPolarity, AcpiIrqTrigger};
 use spin::Once;
 

--- a/drivers/rdrive/src/probe/fdt/mod.rs
+++ b/drivers/rdrive/src/probe/fdt/mod.rs
@@ -5,7 +5,7 @@ use alloc::{
 };
 use core::ptr::NonNull;
 
-use ax_kspin::SpinRaw as Mutex;
+use ax_kspin::SpinNoPreempt as Mutex;
 pub use fdt_edit::{ClockRef, Fdt, InterruptRef, NodeId, NodeType, Phandle, RegInfo, Status};
 use rdif_pinctrl::PinctrlDevice;
 use spin::Once;

--- a/drivers/rdrive/src/probe/pci/mod.rs
+++ b/drivers/rdrive/src/probe/pci/mod.rs
@@ -3,7 +3,7 @@ use core::ops::{Deref, DerefMut};
 
 use ::pcie::*;
 pub use ::pcie::{Endpoint, PciCapability, PciIntxRoute, PcieGeneric};
-use ax_kspin::SpinRaw as Mutex;
+use ax_kspin::SpinNoPreempt as Mutex;
 use mmio_api::{MapError, MmioOp};
 pub use rdif_pcie::{DriverGeneric, PciAddress, PciMem32, PciMem64, PcieController};
 use spin::Once;

--- a/drivers/rdrive/src/probe/static_.rs
+++ b/drivers/rdrive/src/probe/static_.rs
@@ -1,6 +1,6 @@
 use alloc::{collections::btree_set::BTreeSet, vec::Vec};
 
-use ax_kspin::SpinRaw as Mutex;
+use ax_kspin::SpinNoPreempt as Mutex;
 use spin::Once;
 
 use crate::{


### PR DESCRIPTION
## 问题

rdrive 的设备获取和设备使用 API 此前没有明确标注不能在 hard IRQ 路径使用，容易让中断处理重新通过 rdrive 扫 registry、拿设备锁或绕过设备锁，进而把设备生命周期、全局 registry lock、分配路径和 OS ownership 查询带进 hard IRQ。

同时，本 PR 最初把全局 registry lock 一并改成 `SpinNoPreempt` 后，PR CI 的 `Test starry aarch64 qemu / run_container` 在 `qemu-smp4/system` 启动期稳定 panic。对比最新 `dev` 同一 job 通过，且本地复现/缩小后确认：问题不是 hard IRQ 是否要回 rdrive，而是 Starry aarch64 SMP 的 runtime discovery 路径在释放全局 registry lock 时不能触发 task preemption hook。

## 改动

- 为 `get_list`、`get`、`get_one` 增加 rustdoc，明确这些 API not hard-IRQ safe，hard IRQ 必须使用 probe/config 阶段预发布的 IRQ-side state。
- 为 `Device::lock()` 增加 rustdoc，明确它可能等待当前 owner 释放并查询 OS ownership state，不能在 hard IRQ 中使用。
- 将 `force_use()` 的旧中文注释替换成英文 safety contract，明确它不是 interrupt-context escape hatch，调用方必须自行证明生命周期和并发访问安全。
- 将 ACPI/FDT/PCI/static probe cache 锁从 `SpinRaw` 调整为 `SpinNoPreempt`，这些状态只服务 probe/config/control 面。
- 保持 runtime 全局 registry 锁为 `SpinRaw`，并补充注释说明：该 registry 仍然 not hard-IRQ safe，但 runtime discovery 路径不能在释放锁时触发 task preemption hook。

## 逻辑

rdrive 仍然是 probe/config/control 面的设备 owner registry。hard IRQ 入口应使用 probe/config 阶段预发布的 IRQ-side state、CPU interface 或独立 IRQ endpoint，而不是在中断中回到 rdrive 查找和锁设备。

因此，probe cache 这类初始化/配置状态可以使用不关中断但关闭抢占的 `SpinNoPreempt`；全局 registry 虽然也不允许 hard IRQ 调用，但它会被 runtime discovery 使用，CI 和本地复现都表明这里改成 `SpinNoPreempt` 会在 Starry aarch64 SMP 启动期触发调度相关 panic，所以保留 `SpinRaw` 更符合当前调用边界。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package rdrive`
- `cargo test -p rdrive --lib`
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp4/system`
- `cargo xtask starry test qemu --arch aarch64`
