### PR TITLE
fix(block): drive virtio-blk completions by IRQ

### DIFF
--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -26,7 +26,7 @@ pinctrl = ["dep:rdif-pinctrl", "rdif-pinctrl/fdt"]
 
 virtio-core = ["dep:ax-alloc", "dep:virtio-drivers", "virtio-drivers/alloc"]
 virtio = ["virtio-core"]
-virtio-blk = ["block", "virtio", "pci"]
+virtio-blk = ["block", "virtio", "pci", "dep:ax-kernel-guard"]
 virtio-net = ["net", "virtio", "pci", "dep:ax-kernel-guard"]
 virtio-gpu = ["display", "virtio", "pci"]
 virtio-input = ["input", "virtio", "pci"]
@@ -186,6 +186,9 @@ simple-ahci = { workspace = true, optional = true }
 some-serial = { workspace = true, optional = true }
 spin.workspace = true
 virtio-drivers = { workspace = true, optional = true }
+
+[dev-dependencies]
+ax-kernel-guard = { workspace = true, features = ["host-test"] }
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 riscv_goldfish = "0.1"

--- a/drivers/ax-driver/src/virtio/block.rs
+++ b/drivers/ax-driver/src/virtio/block.rs
@@ -1,22 +1,33 @@
 extern crate alloc;
 
-use alloc::format;
+use alloc::{boxed::Box, format, sync::Arc, vec};
+use core::{
+    cell::UnsafeCell,
+    hint::spin_loop,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
+use ax_kernel_guard::NoPreemptIrqSave;
 use rdrive::{DriverGeneric, PlatformDevice, probe::OnProbeError};
 #[cfg(feature = "pci")]
 use virtio_drivers::transport::DeviceType;
 use virtio_drivers::{
     Error as VirtIoError,
-    device::blk::{SECTOR_SIZE, VirtIOBlk},
-    transport::Transport,
+    device::blk::{BlkReq, BlkResp, SECTOR_SIZE, VirtIOBlk},
+    transport::{InterruptStatus, Transport},
 };
 
 use crate::{
-    block::{PlatformDeviceBlock, SharedDriver},
-    virtio::VirtIoHalImpl,
+    BindingInfo, binding_info_from_fdt, block::PlatformDeviceBlock, virtio::VirtIoHalImpl,
 };
+#[cfg(feature = "pci")]
+use crate::{PciIrqRequirement, binding_info_from_pci};
 
-const VIRTIO_BLK_DMA_BUFFER_SIZE: usize = 32 * SECTOR_SIZE;
+// Keep one IRQ-driven completion large enough to amortize the interrupt/drain
+// wake cost while preserving the intentionally conservative max_inflight=1.
+const VIRTIO_BLK_DMA_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+const VIRTIO_BLK_QUEUE_ID: usize = 0;
+const VIRTIO_BLK_IRQ_SOURCE_ID: usize = 0;
 
 #[cfg(feature = "pci")]
 model_register!(
@@ -30,9 +41,9 @@ model_register!(
 
 #[cfg(feature = "pci")]
 fn probe_pci(mut probe: rdrive::probe::pci::ProbePci<'_>) -> Result<(), OnProbeError> {
-    let transport =
-        crate::pci::take_virtio_transport_masked(probe.endpoint_mut(), DeviceType::Block)?;
-    register_transport(probe.into_platform_device(), transport)
+    let transport = crate::pci::take_virtio_transport(probe.endpoint_mut(), DeviceType::Block)?;
+    let info = binding_info_from_pci(probe.info(), PciIrqRequirement::Required)?;
+    register_transport_with_info(probe.into_platform_device(), transport, info)
 }
 
 model_register!(
@@ -47,44 +58,123 @@ model_register!(
 
 fn probe_fdt(probe: rdrive::register::ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let (info, plat_dev) = probe.into_parts();
+    let binding_info = binding_info_from_fdt(&info)?;
     let (ty, transport) = crate::virtio::probe_fdt_mmio_device(&info)?;
     if ty != DeviceType::Block {
         return Err(OnProbeError::NotMatch);
     }
-    register_transport(plat_dev, transport)
+    register_transport_with_info(plat_dev, transport, binding_info)
 }
 
 pub fn register_transport<T: Transport + 'static>(
     plat_dev: PlatformDevice,
     transport: T,
 ) -> Result<(), OnProbeError> {
+    register_transport_with_info(plat_dev, transport, BindingInfo::empty())
+}
+
+fn register_transport_with_info<T: Transport + 'static>(
+    plat_dev: PlatformDevice,
+    transport: T,
+    info: BindingInfo,
+) -> Result<(), OnProbeError> {
     let dev = VirtIoBlkDevice::new(transport)
         .map_err(|err| OnProbeError::other(format!("failed to initialize virtio-blk: {err:?}")))?;
-    plat_dev.register_block(BlockDevice {
-        dev: Some(SharedDriver::new(dev)),
-        queue_created: false,
-    });
+    plat_dev.register_block_with_info(
+        BlockDevice {
+            dev: Some(Arc::new(dev)),
+            queue_created: false,
+            irq_handler_taken: false,
+        },
+        info,
+    );
     log::info!("registered virtio block device");
     Ok(())
 }
 
 struct VirtIoBlkDevice<T: Transport + 'static> {
+    inner: UnsafeCell<VirtIoBlkInner<T>>,
+    access_active: AtomicBool,
+    irq_ack_pending: AtomicBool,
+    irq_enabled: AtomicBool,
+}
+
+struct VirtIoBlkInner<T: Transport + 'static> {
     raw: VirtIOBlk<VirtIoHalImpl, T>,
+    inflight: Option<InflightRequest>,
+    next_request_id: usize,
 }
 
 unsafe impl<T: Transport + 'static> Send for VirtIoBlkDevice<T> {}
+unsafe impl<T: Transport + 'static> Sync for VirtIoBlkDevice<T> {}
 
 impl<T: Transport + 'static> VirtIoBlkDevice<T> {
     fn new(transport: T) -> Result<Self, VirtIoError> {
         let mut raw = VirtIOBlk::new(transport)?;
         raw.disable_interrupts();
-        Ok(Self { raw })
+        Ok(Self {
+            inner: UnsafeCell::new(VirtIoBlkInner {
+                raw,
+                inflight: None,
+                next_request_id: 1,
+            }),
+            access_active: AtomicBool::new(false),
+            irq_ack_pending: AtomicBool::new(false),
+            irq_enabled: AtomicBool::new(false),
+        })
+    }
+
+    fn with_task<R>(&self, f: impl FnOnce(&mut VirtIoBlkInner<T>) -> R) -> R {
+        let _irq_guard = NoPreemptIrqSave::new();
+        let _active = VirtioBlkAccessGuard::enter_task(&self.access_active);
+        // SAFETY: `access_active` serializes all mutable access to the raw
+        // transport, and task-side callers keep local IRQ/preemption disabled.
+        let inner = unsafe { &mut *self.inner.get() };
+        self.flush_pending_irq_ack(inner);
+        let ret = f(inner);
+        self.flush_pending_irq_ack(inner);
+        ret
+    }
+
+    fn enable_irq(&self) {
+        self.irq_enabled.store(true, Ordering::Release);
+        self.with_task(|inner| inner.raw.enable_interrupts());
+    }
+
+    fn disable_irq(&self) {
+        self.irq_enabled.store(false, Ordering::Release);
+        self.with_task(|inner| inner.raw.disable_interrupts());
+    }
+
+    fn is_irq_enabled(&self) -> bool {
+        self.irq_enabled.load(Ordering::Acquire)
+    }
+
+    fn handle_irq(&self) -> rdif_block::Event {
+        virtio_blk_irq_event(
+            &self.access_active,
+            &self.irq_ack_pending,
+            self.is_irq_enabled(),
+            || {
+                // SAFETY: `virtio_blk_irq_event` calls this closure only while
+                // holding the IRQ-side access guard.
+                let inner = unsafe { &mut *self.inner.get() };
+                inner.raw.ack_interrupt()
+            },
+        )
+    }
+
+    fn flush_pending_irq_ack(&self, inner: &mut VirtIoBlkInner<T>) {
+        if self.irq_ack_pending.swap(false, Ordering::AcqRel) {
+            let _ = inner.raw.ack_interrupt();
+        }
     }
 }
 
 struct BlockDevice<T: Transport + 'static> {
-    dev: Option<SharedDriver<VirtIoBlkDevice<T>>>,
+    dev: Option<Arc<VirtIoBlkDevice<T>>>,
     queue_created: bool,
+    irq_handler_taken: bool,
 }
 
 impl<T: Transport + 'static> DriverGeneric for BlockDevice<T> {
@@ -98,7 +188,7 @@ impl<T: Transport + 'static> rdif_block::Interface for BlockDevice<T> {
         let blocks = self
             .dev
             .as_ref()
-            .map(|dev| dev.with_mut(|raw| raw.raw.capacity()))
+            .map(|dev| dev.with_task(|inner| inner.raw.capacity()))
             .unwrap_or(0);
         rdif_block::DeviceInfo {
             name: Some("virtio-blk"),
@@ -122,49 +212,75 @@ impl<T: Transport + 'static> rdif_block::Interface for BlockDevice<T> {
         }
     }
 
-    fn create_queue(&mut self) -> Option<alloc::boxed::Box<dyn rdif_block::IQueue>> {
+    fn create_queue(&mut self) -> Option<Box<dyn rdif_block::IQueue>> {
         if self.queue_created {
             return None;
         }
         self.dev.as_ref().map(|dev| {
             self.queue_created = true;
-            alloc::boxed::Box::new(BlockQueue {
+            Box::new(BlockQueue {
                 id: 0,
-                raw: dev.clone(),
+                raw: Arc::clone(dev),
             }) as _
         })
     }
 
     fn enable_irq(&self) {
-        self.disable_irq();
+        if let Some(dev) = &self.dev {
+            dev.enable_irq();
+        }
     }
 
     fn disable_irq(&self) {
         if let Some(dev) = &self.dev {
-            dev.with_mut(|dev| dev.raw.disable_interrupts());
+            dev.disable_irq();
         }
     }
 
     fn is_irq_enabled(&self) -> bool {
-        false
+        self.dev.as_ref().is_some_and(|dev| dev.is_irq_enabled())
+    }
+
+    fn irq_sources(&self) -> rdif_block::IrqSourceList {
+        if self.dev.is_none() {
+            return vec![];
+        }
+        let mut queues = rdif_block::IdList::none();
+        queues.insert(VIRTIO_BLK_QUEUE_ID);
+        vec![rdif_block::IrqSourceInfo::new(
+            VIRTIO_BLK_IRQ_SOURCE_ID,
+            queues,
+        )]
+    }
+
+    fn take_irq_handler(&mut self, source_id: usize) -> Option<rdif_block::BIrqHandler> {
+        if source_id != VIRTIO_BLK_IRQ_SOURCE_ID || self.irq_handler_taken {
+            return None;
+        }
+        self.irq_handler_taken = true;
+        self.dev.as_ref().map(|dev| {
+            Box::new(VirtioBlkIrqHandler {
+                inner: Arc::clone(dev),
+            }) as _
+        })
     }
 }
 
 struct BlockQueue<T: Transport + 'static> {
     id: usize,
-    raw: SharedDriver<VirtIoBlkDevice<T>>,
+    raw: Arc<VirtIoBlkDevice<T>>,
 }
 
-// SAFETY: virtio-blk operations are submitted to the underlying synchronous
-// driver and completed before `submit_request` returns. No request segment is
-// retained after the call.
+// SAFETY: Submitted request segments are retained only in the single in-flight
+// slot and are released when the matching `poll_request` reports a terminal
+// result.
 unsafe impl<T: Transport + 'static> rdif_block::IQueue for BlockQueue<T> {
     fn id(&self) -> usize {
         self.id
     }
 
     fn info(&self) -> rdif_block::QueueInfo {
-        let blocks = self.raw.with_mut(|raw| raw.raw.capacity());
+        let blocks = self.raw.with_task(|inner| inner.raw.capacity());
         rdif_block::QueueInfo {
             id: self.id,
             device: rdif_block::DeviceInfo {
@@ -192,38 +308,288 @@ unsafe impl<T: Transport + 'static> rdif_block::IQueue for BlockQueue<T> {
         request: rdif_block::Request<'_>,
     ) -> Result<rdif_block::RequestId, rdif_block::BlkError> {
         rdif_block::validate_request(self.info(), &request)?;
-        match request.op {
-            rdif_block::RequestOp::Read => {
-                let mut segment = request
-                    .segments
-                    .first()
-                    .copied()
-                    .ok_or(rdif_block::BlkError::InvalidRequest)?;
-                self.raw
-                    .with_mut(|raw| raw.raw.read_blocks(request.lba as usize, &mut segment))
-                    .map_err(map_virtio_err_to_blk_err)?;
-            }
-            rdif_block::RequestOp::Write => {
-                let segment = request
-                    .segments
-                    .first()
-                    .ok_or(rdif_block::BlkError::InvalidRequest)?;
-                self.raw
-                    .with_mut(|raw| raw.raw.write_blocks(request.lba as usize, segment))
-                    .map_err(map_virtio_err_to_blk_err)?;
-            }
-            rdif_block::RequestOp::Flush
-            | rdif_block::RequestOp::Discard
-            | rdif_block::RequestOp::WriteZeroes => return Err(rdif_block::BlkError::NotSupported),
-        }
-        Ok(rdif_block::RequestId::new(0))
+        self.raw.with_task(|inner| inner.submit_request(request))
     }
 
     fn poll_request(
         &mut self,
-        _request: rdif_block::RequestId,
+        request: rdif_block::RequestId,
     ) -> Result<rdif_block::RequestStatus, rdif_block::BlkError> {
+        self.raw.with_task(|inner| inner.poll_request(request))
+    }
+}
+
+impl<T: Transport + 'static> VirtIoBlkInner<T> {
+    fn submit_request(
+        &mut self,
+        request: rdif_block::Request<'_>,
+    ) -> Result<rdif_block::RequestId, rdif_block::BlkError> {
+        if self.inflight.is_some() {
+            return Err(rdif_block::BlkError::Retry);
+        }
+
+        let op = match request.op {
+            rdif_block::RequestOp::Read => InflightOp::Read,
+            rdif_block::RequestOp::Write => InflightOp::Write,
+            rdif_block::RequestOp::Flush
+            | rdif_block::RequestOp::Discard
+            | rdif_block::RequestOp::WriteZeroes => return Err(rdif_block::BlkError::NotSupported),
+        };
+        let segment = request
+            .segments
+            .first()
+            .copied()
+            .ok_or(rdif_block::BlkError::InvalidRequest)?;
+        let mut buffer = InflightBuffer::from_segment(segment);
+        let mut storage = Box::<InflightStorage>::default();
+        let token = match op {
+            InflightOp::Read => {
+                // SAFETY: RDIF requires request segments to remain valid and
+                // exclusively owned until the matching `poll_request` returns a
+                // terminal result.
+                unsafe {
+                    self.raw.read_blocks_nb(
+                        request.lba as usize,
+                        &mut storage.req,
+                        buffer.as_mut_slice(),
+                        &mut storage.resp,
+                    )
+                }
+            }
+            InflightOp::Write => {
+                // SAFETY: See the read path above; virtio retains the segment
+                // until `complete_write_blocks` consumes the descriptor.
+                unsafe {
+                    self.raw.write_blocks_nb(
+                        request.lba as usize,
+                        &mut storage.req,
+                        buffer.as_slice(),
+                        &mut storage.resp,
+                    )
+                }
+            }
+        }
+        .map_err(map_virtio_err_to_blk_err)?;
+
+        let request_id = self.alloc_request_id();
+        self.inflight = Some(InflightRequest {
+            id: request_id,
+            token,
+            op,
+            storage,
+            buffer,
+        });
+        Ok(request_id)
+    }
+
+    fn poll_request(
+        &mut self,
+        request: rdif_block::RequestId,
+    ) -> Result<rdif_block::RequestStatus, rdif_block::BlkError> {
+        let inflight_key = self
+            .inflight
+            .as_ref()
+            .map(|inflight| (inflight.id, inflight.token));
+        if classify_completion_poll(inflight_key, request, self.raw.peek_used())?
+            == rdif_block::RequestStatus::Pending
+        {
+            return Ok(rdif_block::RequestStatus::Pending);
+        }
+
+        let mut inflight = self
+            .inflight
+            .take()
+            .ok_or(rdif_block::BlkError::InvalidRequest)?;
+        let result = match inflight.op {
+            InflightOp::Read => {
+                // SAFETY: `inflight` owns the same request metadata and buffer
+                // raw parts that were passed to `read_blocks_nb`.
+                unsafe {
+                    self.raw.complete_read_blocks(
+                        inflight.token,
+                        &inflight.storage.req,
+                        inflight.buffer.as_mut_slice(),
+                        &mut inflight.storage.resp,
+                    )
+                }
+            }
+            InflightOp::Write => {
+                // SAFETY: `inflight` owns the same request metadata and buffer
+                // raw parts that were passed to `write_blocks_nb`.
+                unsafe {
+                    self.raw.complete_write_blocks(
+                        inflight.token,
+                        &inflight.storage.req,
+                        inflight.buffer.as_slice(),
+                        &mut inflight.storage.resp,
+                    )
+                }
+            }
+        };
+        result.map_err(map_virtio_completion_err_to_blk_err)?;
         Ok(rdif_block::RequestStatus::Complete)
+    }
+
+    fn alloc_request_id(&mut self) -> rdif_block::RequestId {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
+        rdif_block::RequestId::new(id)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InflightOp {
+    Read,
+    Write,
+}
+
+struct InflightRequest {
+    id: rdif_block::RequestId,
+    token: u16,
+    op: InflightOp,
+    storage: Box<InflightStorage>,
+    buffer: InflightBuffer,
+}
+
+#[derive(Default)]
+struct InflightStorage {
+    req: BlkReq,
+    resp: BlkResp,
+}
+
+impl InflightRequest {
+    #[cfg(test)]
+    fn req_addr(&self) -> usize {
+        core::ptr::addr_of!(self.storage.req) as usize
+    }
+
+    #[cfg(test)]
+    fn resp_addr(&self) -> usize {
+        core::ptr::addr_of!(self.storage.resp) as usize
+    }
+}
+
+impl InflightStorage {
+    #[cfg(test)]
+    fn req_addr(&self) -> usize {
+        core::ptr::addr_of!(self.req) as usize
+    }
+
+    #[cfg(test)]
+    fn resp_addr(&self) -> usize {
+        core::ptr::addr_of!(self.resp) as usize
+    }
+}
+
+#[derive(Clone, Copy)]
+struct InflightBuffer {
+    virt: *mut u8,
+    len: usize,
+}
+
+impl InflightBuffer {
+    fn from_segment(segment: rdif_block::Segment<'_>) -> Self {
+        Self {
+            virt: segment.virt,
+            len: segment.len,
+        }
+    }
+
+    unsafe fn as_slice(&self) -> &[u8] {
+        // SAFETY: Callers uphold the RDIF request lifetime until completion.
+        unsafe { core::slice::from_raw_parts(self.virt.cast_const(), self.len) }
+    }
+
+    unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: Callers uphold exclusive RDIF request ownership until
+        // completion.
+        unsafe { core::slice::from_raw_parts_mut(self.virt, self.len) }
+    }
+}
+
+struct VirtioBlkIrqHandler<T: Transport + 'static> {
+    inner: Arc<VirtIoBlkDevice<T>>,
+}
+
+impl<T: Transport + 'static> rdif_block::IrqHandler for VirtioBlkIrqHandler<T> {
+    fn handle_irq(&mut self) -> rdif_block::Event {
+        self.inner.handle_irq()
+    }
+}
+
+struct VirtioBlkAccessGuard<'a>(&'a AtomicBool);
+
+impl<'a> VirtioBlkAccessGuard<'a> {
+    fn enter_task(active: &'a AtomicBool) -> Self {
+        Self::enter(active)
+    }
+
+    fn try_enter_irq(active: &'a AtomicBool) -> Option<Self> {
+        active
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+            .then_some(Self(active))
+    }
+
+    fn enter(active: &'a AtomicBool) -> Self {
+        while active
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            spin_loop();
+        }
+        Self(active)
+    }
+}
+
+impl Drop for VirtioBlkAccessGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+fn virtio_blk_irq_event(
+    access_active: &AtomicBool,
+    irq_ack_pending: &AtomicBool,
+    irq_enabled: bool,
+    ack_status: impl FnOnce() -> InterruptStatus,
+) -> rdif_block::Event {
+    if !irq_enabled {
+        return rdif_block::Event::none();
+    }
+    let Some(_active) = VirtioBlkAccessGuard::try_enter_irq(access_active) else {
+        irq_ack_pending.store(true, Ordering::Release);
+        return rdif_block::Event::none();
+    };
+    irq_ack_pending.store(false, Ordering::Release);
+    virtio_blk_event_from_irq_status(true, ack_status())
+}
+
+fn virtio_blk_event_from_irq_status(
+    irq_enabled: bool,
+    status: InterruptStatus,
+) -> rdif_block::Event {
+    if !irq_enabled || !status.contains(InterruptStatus::QUEUE_INTERRUPT) {
+        return rdif_block::Event::none();
+    }
+    rdif_block::Event::from_queue_bits(1 << VIRTIO_BLK_QUEUE_ID)
+}
+
+fn classify_completion_poll(
+    inflight: Option<(rdif_block::RequestId, u16)>,
+    request: rdif_block::RequestId,
+    used_token: Option<u16>,
+) -> Result<rdif_block::RequestStatus, rdif_block::BlkError> {
+    let Some((inflight_request, inflight_token)) = inflight else {
+        return Err(rdif_block::BlkError::InvalidRequest);
+    };
+    if inflight_request != request {
+        return Err(rdif_block::BlkError::InvalidRequest);
+    }
+    if used_token == Some(inflight_token) {
+        Ok(rdif_block::RequestStatus::Complete)
+    } else {
+        Ok(rdif_block::RequestStatus::Pending)
     }
 }
 
@@ -239,5 +605,123 @@ fn map_virtio_err_to_blk_err(err: VirtIoError) -> rdif_block::BlkError {
         VirtIoError::IoError => rdif_block::BlkError::Io,
         VirtIoError::Unsupported => rdif_block::BlkError::NotSupported,
         VirtIoError::SocketDeviceError(_) => rdif_block::BlkError::Other("socket error"),
+    }
+}
+
+fn map_virtio_completion_err_to_blk_err(err: VirtIoError) -> rdif_block::BlkError {
+    match map_virtio_err_to_blk_err(err) {
+        rdif_block::BlkError::Retry => rdif_block::BlkError::Io,
+        err => err,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::boxed::Box;
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use rdif_block::{BlkError, RequestId, RequestStatus};
+    use virtio_drivers::transport::InterruptStatus;
+
+    use super::{
+        InflightBuffer, InflightOp, InflightRequest, SECTOR_SIZE, VIRTIO_BLK_DMA_BUFFER_SIZE,
+        VirtioBlkAccessGuard, classify_completion_poll, virtio_blk_event_from_irq_status,
+        virtio_blk_irq_event,
+    };
+
+    #[test]
+    fn queue_interrupt_is_required_for_irq_event() {
+        assert!(
+            virtio_blk_event_from_irq_status(true, InterruptStatus::empty()).is_empty(),
+            "shared IRQ callbacks without a virtio queue interrupt must not wake block queues"
+        );
+        assert!(
+            virtio_blk_event_from_irq_status(true, InterruptStatus::DEVICE_CONFIGURATION_INTERRUPT)
+                .is_empty(),
+            "config-only interrupts must not be reported as block completions"
+        );
+        assert!(
+            virtio_blk_event_from_irq_status(false, InterruptStatus::QUEUE_INTERRUPT).is_empty(),
+            "disabled completion IRQs must not report queue readiness"
+        );
+
+        let event = virtio_blk_event_from_irq_status(true, InterruptStatus::QUEUE_INTERRUPT);
+        assert!(event.queues.contains(0));
+        assert!(!event.is_empty());
+    }
+
+    #[test]
+    fn busy_task_access_defers_irq_ack_without_ready_event() {
+        let access_active = AtomicBool::new(false);
+        let irq_ack_pending = AtomicBool::new(false);
+        let _task_guard = VirtioBlkAccessGuard::enter_task(&access_active);
+
+        let event = virtio_blk_irq_event(&access_active, &irq_ack_pending, true, || {
+            InterruptStatus::QUEUE_INTERRUPT
+        });
+
+        assert!(event.is_empty());
+        assert!(irq_ack_pending.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn poll_stays_pending_until_matching_token_is_used() {
+        let request_id = RequestId::new(7);
+        let token = 3;
+
+        assert_eq!(
+            classify_completion_poll(Some((request_id, token)), request_id, None),
+            Ok(RequestStatus::Pending)
+        );
+        assert_eq!(
+            classify_completion_poll(Some((request_id, token)), request_id, Some(token + 1)),
+            Ok(RequestStatus::Pending)
+        );
+        assert_eq!(
+            classify_completion_poll(Some((request_id, token)), request_id, Some(token)),
+            Ok(RequestStatus::Complete)
+        );
+        assert_eq!(
+            classify_completion_poll(Some((request_id, token)), RequestId::new(8), Some(token)),
+            Err(BlkError::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn submitted_descriptor_storage_must_not_move_into_inflight_slot() {
+        let storage = Box::<super::InflightStorage>::default();
+        let submitted_req_addr = storage.req_addr();
+        let submitted_resp_addr = storage.resp_addr();
+        let inflight = InflightRequest {
+            id: RequestId::new(1),
+            token: 0,
+            op: InflightOp::Read,
+            storage,
+            buffer: InflightBuffer {
+                virt: core::ptr::NonNull::<u8>::dangling().as_ptr(),
+                len: SECTOR_SIZE,
+            },
+        };
+
+        assert_eq!(
+            inflight.req_addr(),
+            submitted_req_addr,
+            "virtio descriptors must keep pointing at the same BlkReq storage until completion"
+        );
+        assert_eq!(
+            inflight.resp_addr(),
+            submitted_resp_addr,
+            "virtio descriptors must keep pointing at the same BlkResp storage until completion"
+        );
+    }
+
+    #[test]
+    fn irq_driven_path_uses_large_requests_to_amortize_completion_wakes() {
+        assert!(
+            VIRTIO_BLK_DMA_BUFFER_SIZE >= 4 * 1024 * 1024,
+            "max_inflight=1 IRQ-driven completion needs large request chunks"
+        );
     }
 }

--- a/os/arceos/modules/axfs-ng/src/block/runtime/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/block/runtime/mod.rs
@@ -14,6 +14,7 @@ pub use device::NoopDrainWake;
 pub use device::{
     BlockCompletionMode, BlockDeviceHandle, BlockDrainWake, BlockIrqAction, BlockRuntime,
     BlockRuntimeConfig, QueueRuntime, RdifBlockDevice, block_io_stats, map_blk_err_to_ax_err,
+    release_block_irqs_for_passthrough,
 };
 #[cfg(test)]
 pub use dma::VEC_DMA_OP;

--- a/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
@@ -1,5 +1,6 @@
 use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{
+    mem,
     sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     time::Duration,
 };
@@ -22,13 +23,15 @@ use super::{
 use crate::os::{
     BlockIrqOutcome, BlockIrqRegistration, current_task_id, dma_op, notify_drain,
     notify_drain_from_irq, notify_waiters, register_shared_block_irq, spawn_task,
-    sync::IrqMutex as SpinNoIrq, task_wait_timeout, task_yield, wait_for_drain_notification,
-    wake_task,
+    sync::IrqMutex as SpinNoIrq, task_can_block, task_wait_timeout, task_yield,
+    wait_for_drain_notification, wake_task,
 };
 
 const DEFAULT_MAX_TRANSFER_BYTES: usize = 1024 * 1024;
+const IRQ_DRIVEN_MAX_TRANSFER_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_SUBMIT_WINDOW: usize = 32;
 const IRQ_COMPLETION_REPOLL_TIMEOUT: Duration = Duration::from_millis(1);
+const IRQ_COMPLETION_FAST_POLL_ATTEMPTS: usize = 32;
 
 fn runtime_device_dma(domain: DmaDomainId, dma_mask: u64) -> Result<DeviceDma, BlkError> {
     let dma_op = dma_op().ok_or(BlkError::Io)?;
@@ -60,6 +63,12 @@ pub fn block_io_stats() -> (u64, u64, u64, u64) {
         BLOCK_WRITES.load(Ordering::Relaxed),
         BLOCK_SECTORS_WRITTEN.load(Ordering::Relaxed),
     )
+}
+
+pub fn release_block_irqs_for_passthrough() -> usize {
+    BLOCK_RUNTIME.get().map_or(0, |runtime| {
+        runtime.release_irq_registrations_for_passthrough()
+    })
 }
 
 #[derive(Clone, Copy)]
@@ -252,14 +261,14 @@ impl QueueRuntime {
 
 pub struct BlockRuntime {
     devices: Vec<Arc<BlockDeviceHandle>>,
-    irq_registrations: Vec<Box<dyn BlockIrqRegistration>>,
+    irq_registrations: SpinNoIrq<Vec<Box<dyn BlockIrqRegistration>>>,
 }
 
 impl BlockRuntime {
     pub fn new() -> Self {
         Self {
             devices: Vec::new(),
-            irq_registrations: Vec::new(),
+            irq_registrations: SpinNoIrq::new(Vec::new()),
         }
     }
 
@@ -271,8 +280,27 @@ impl BlockRuntime {
         &self.devices
     }
 
-    pub fn push_irq_registration(&mut self, registration: Box<dyn BlockIrqRegistration>) {
-        self.irq_registrations.push(registration);
+    pub fn push_irq_registration(&self, registration: Box<dyn BlockIrqRegistration>) {
+        self.irq_registrations.lock().push(registration);
+    }
+
+    pub fn release_irq_registrations_for_passthrough(&self) -> usize {
+        for device in &self.devices {
+            device.set_completion_mode(BlockCompletionMode::Polling);
+        }
+
+        let (released, registrations) = {
+            let mut registrations = self.irq_registrations.lock();
+            let released = registrations.len();
+            (released, mem::take(&mut *registrations))
+        };
+        drop(registrations);
+        released
+    }
+
+    #[cfg(test)]
+    pub(crate) fn irq_registration_count(&self) -> usize {
+        self.irq_registrations.lock().len()
     }
 }
 
@@ -1003,6 +1031,25 @@ impl BlockDeviceHandle {
         CompletionDrain::new(&self.pending, &mut poller).poll_keys(keys)
     }
 
+    fn any_key_has_result(&self, keys: &[RequestKey]) -> bool {
+        keys.iter()
+            .any(|&key| self.pending.lock().result(key).is_some())
+    }
+
+    fn irq_fast_poll_any_key(&self, keys: &[RequestKey]) -> bool {
+        if self.completion_mode() != BlockCompletionMode::IrqDriven {
+            return false;
+        }
+        for _ in 0..IRQ_COMPLETION_FAST_POLL_ATTEMPTS {
+            core::hint::spin_loop();
+            let _ = self.poll_batch(keys);
+            if self.any_key_has_result(keys) {
+                return true;
+            }
+        }
+        false
+    }
+
     fn harvest_active(
         &self,
         active: &mut Vec<WindowEntry>,
@@ -1058,17 +1105,14 @@ impl BlockDeviceHandle {
             return Ok(());
         }
         let keys = active.iter().map(|entry| entry.key).collect::<Vec<_>>();
-        if keys
-            .iter()
-            .any(|&key| self.pending.lock().result(key).is_some())
-        {
+        if self.any_key_has_result(&keys) {
             return Ok(());
         }
         let _ = self.poll_batch(&keys);
-        if keys
-            .iter()
-            .any(|&key| self.pending.lock().result(key).is_some())
-        {
+        if self.any_key_has_result(&keys) {
+            return Ok(());
+        }
+        if self.irq_fast_poll_any_key(&keys) {
             return Ok(());
         }
         if self.completion_mode() == BlockCompletionMode::Polling {
@@ -1141,7 +1185,8 @@ impl BlockDeviceHandle {
     }
 
     fn irq_wait_or_timeout(&self, task_id: u64) -> bool {
-        if task_id != 0 {
+        // Early root probing may issue block I/O while IRQs are still disabled.
+        if task_id != 0 && task_can_block() {
             task_wait_timeout(IRQ_COMPLETION_REPOLL_TIMEOUT)
         } else {
             core::hint::spin_loop();
@@ -1170,7 +1215,9 @@ impl BlockDeviceHandle {
         let observed = match observed {
             Some(result) => result,
             None => {
+                let keys = [key];
                 let _ = self.poll_one(key);
+                let _ = self.irq_fast_poll_any_key(&keys);
                 loop {
                     if let Some(result) = self
                         .pending
@@ -1237,6 +1284,7 @@ fn build_rdif_block_device(
     drain_wake: Arc<dyn BlockDrainWake>,
 ) -> Result<RegisteredRdifBlockDevice, AxError> {
     let name = String::from(block.name());
+    let config = rdif_block_runtime_config(&block, drain_wake);
     let mut queues = Vec::new();
     while let Some(queue) = block.interface_mut().create_owned_queue() {
         queues.push(RuntimeQueue::Owned(queue));
@@ -1251,13 +1299,8 @@ fn build_rdif_block_device(
     }
 
     let bridge = Arc::new(BlockIrqBridge::new());
-    let device = BlockDeviceHandle::new_runtime(
-        name.clone(),
-        queues,
-        bridge,
-        BlockRuntimeConfig::new(drain_wake),
-    )
-    .map_err(map_blk_err_to_ax_err)?;
+    let device = BlockDeviceHandle::new_runtime(name.clone(), queues, bridge, config)
+        .map_err(map_blk_err_to_ax_err)?;
 
     let registrations = match register_rdif_irq_handlers(&mut block, device.clone(), device_index)
         .and_then(|registrations| {
@@ -1286,6 +1329,17 @@ fn build_rdif_block_device(
     }
     info!("registered rdif filesystem block device {name}");
     Ok((device, registrations))
+}
+
+fn rdif_block_runtime_config(
+    block: &RdifBlockDevice,
+    drain_wake: Arc<dyn BlockDrainWake>,
+) -> BlockRuntimeConfig {
+    let mut config = BlockRuntimeConfig::new(drain_wake);
+    if block.irq().is_some() && !block.interface().irq_sources().is_empty() {
+        config.max_transfer_bytes = config.max_transfer_bytes.max(IRQ_DRIVEN_MAX_TRANSFER_BYTES);
+    }
+    config
 }
 
 fn register_rdif_irq_handlers(
@@ -1588,6 +1642,160 @@ pub fn map_blk_err_to_ax_err(err: BlkError) -> AxError {
         BlkError::NoMemory => AxError::NoMemory,
         BlkError::InvalidBlockIndex(_) | BlkError::InvalidRequest => AxError::InvalidInput,
         BlkError::Io | BlkError::Other(_) => AxError::Io,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+
+    use irq_framework::{HwIrq, IrqDomainId};
+    use rdif_block::{Event, IdList, IrqHandler, IrqSourceInfo, QueueLimits};
+
+    use super::*;
+
+    struct PlannerTestQueue {
+        info: QueueInfo,
+    }
+
+    impl PlannerTestQueue {
+        fn new() -> Self {
+            let block_size = 512;
+            let limits = QueueLimits {
+                max_inflight: 1,
+                max_blocks_per_request: (IRQ_DRIVEN_MAX_TRANSFER_BYTES / block_size) as u32,
+                max_segments: 1,
+                max_segment_size: IRQ_DRIVEN_MAX_TRANSFER_BYTES,
+                ..QueueLimits::simple(block_size, u64::MAX)
+            };
+            Self {
+                info: QueueInfo {
+                    id: 0,
+                    device: DeviceInfo::new(
+                        (IRQ_DRIVEN_MAX_TRANSFER_BYTES / block_size * 2) as u64,
+                        block_size,
+                    ),
+                    limits,
+                },
+            }
+        }
+    }
+
+    // SAFETY: This queue is used only to build a runtime planner; submitted
+    // requests are not retained.
+    unsafe impl IQueue for PlannerTestQueue {
+        fn id(&self) -> usize {
+            self.info.id
+        }
+
+        fn info(&self) -> QueueInfo {
+            self.info
+        }
+
+        fn submit_request(&mut self, _request: Request<'_>) -> Result<RequestId, BlkError> {
+            Ok(RequestId::new(1))
+        }
+
+        fn poll_request(&mut self, _request: RequestId) -> Result<RequestStatus, BlkError> {
+            Ok(RequestStatus::Complete)
+        }
+    }
+
+    impl rdif_block::DriverGeneric for PlannerTestQueue {
+        fn name(&self) -> &str {
+            "planner-test-queue"
+        }
+    }
+
+    struct PlannerTestInterface {
+        info: QueueInfo,
+        expose_irq: bool,
+    }
+
+    impl PlannerTestInterface {
+        fn new(info: QueueInfo, expose_irq: bool) -> Self {
+            Self { info, expose_irq }
+        }
+    }
+
+    impl rdif_block::DriverGeneric for PlannerTestInterface {
+        fn name(&self) -> &str {
+            "planner-test-interface"
+        }
+    }
+
+    impl rdif_block::Interface for PlannerTestInterface {
+        fn device_info(&self) -> DeviceInfo {
+            self.info.device
+        }
+
+        fn queue_limits(&self) -> QueueLimits {
+            self.info.limits
+        }
+
+        fn create_queue(&mut self) -> Option<Box<dyn IQueue>> {
+            None
+        }
+
+        fn irq_sources(&self) -> rdif_block::IrqSourceList {
+            if !self.expose_irq {
+                return Vec::new();
+            }
+            let mut queues = IdList::none();
+            queues.insert(0);
+            vec![IrqSourceInfo::new(0, queues)]
+        }
+
+        fn take_irq_handler(&mut self, source_id: usize) -> Option<rdif_block::BIrqHandler> {
+            (self.expose_irq && source_id == 0).then(|| Box::new(NoopIrq) as _)
+        }
+    }
+
+    struct NoopIrq;
+
+    impl IrqHandler for NoopIrq {
+        fn handle_irq(&mut self) -> Event {
+            Event::none()
+        }
+    }
+
+    fn test_irq() -> IrqId {
+        IrqId::new(IrqDomainId(42), HwIrq(7))
+    }
+
+    fn planner_chunk_size(config: BlockRuntimeConfig) -> usize {
+        let device = BlockDeviceHandle::new_runtime(
+            "planner-test",
+            [RuntimeQueue::Legacy(Box::new(PlannerTestQueue::new()))],
+            Arc::new(BlockIrqBridge::new()),
+            config,
+        )
+        .unwrap();
+        device.queues[0].lock().planner.chunk_size()
+    }
+
+    #[test]
+    fn irq_capable_rdif_blocks_use_large_runtime_transfer_chunks() {
+        let info = PlannerTestQueue::new().info();
+        let irq_capable = RdifBlockDevice::new(
+            "irq-capable",
+            Some(test_irq()),
+            Box::new(PlannerTestInterface::new(info, true)),
+        );
+        let config = rdif_block_runtime_config(&irq_capable, Arc::new(NoopDrainWake));
+
+        assert_eq!(config.max_transfer_bytes, IRQ_DRIVEN_MAX_TRANSFER_BYTES);
+        assert_eq!(planner_chunk_size(config), IRQ_DRIVEN_MAX_TRANSFER_BYTES);
+
+        let polling_only = RdifBlockDevice::new(
+            "polling-only",
+            None,
+            Box::new(PlannerTestInterface::new(info, true)),
+        );
+        let config = rdif_block_runtime_config(&polling_only, Arc::new(NoopDrainWake));
+
+        assert_eq!(config.max_transfer_bytes, DEFAULT_MAX_TRANSFER_BYTES);
+        assert_eq!(planner_chunk_size(config), DEFAULT_MAX_TRANSFER_BYTES);
     }
 }
 

--- a/os/arceos/modules/axfs-ng/src/block_runtime/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/mod.rs
@@ -6,15 +6,16 @@ mod tests {
     use core::{
         any::Any,
         cell::Cell,
-        sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+        sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     };
     use std::{
         collections::HashMap,
         sync::{Arc as StdArc, Condvar, Mutex as StdMutex, OnceLock, mpsc},
     };
 
-    use ax_errno::AxError;
+    use ax_errno::{AxError, AxResult};
     use dma_api::{DeviceDma, DmaDomainId};
+    use irq_framework::{HwIrq, IrqContext, IrqDomainId, IrqId};
     use rdif_block::{
         BlkError, CompletionHint, DeviceInfo, DriverGeneric, IQueue, IQueueOwned, Interface,
         OwnedRequest, PollError, QueueHandle, QueueInfo, QueueLimits, Request, RequestId,
@@ -22,16 +23,22 @@ mod tests {
     };
 
     use super::*;
-    use crate::os::{BlockTaskOps, install_dma_op, set_task_ops, sync::IrqMutex as SpinNoIrq};
+    use crate::os::{
+        BlockIrqOutcome, BlockIrqRegistrar, BlockIrqRegistration, BlockTaskOps, install_dma_op,
+        set_irq_registrar, set_task_ops, sync::IrqMutex as SpinNoIrq,
+    };
 
     static TEST_TASK_OPS: TestTaskOps = TestTaskOps;
     static NEXT_TEST_TASK_ID: AtomicU64 = AtomicU64::new(1_000_000);
     static TEST_TIMEOUT_WAITS: AtomicUsize = AtomicUsize::new(0);
+    static TEST_IRQ_REGISTRATION_DROPS: AtomicUsize = AtomicUsize::new(0);
     static TEST_TASKS: OnceLock<StdMutex<HashMap<u64, StdArc<TestTaskState>>>> = OnceLock::new();
     static TEST_TASK_LOCK: StdMutex<()> = StdMutex::new(());
+    static TEST_IRQ_REGISTRAR: TestIrqRegistrar = TestIrqRegistrar;
 
     thread_local! {
         static TEST_TASK_ID: Cell<u64> = const { Cell::new(0) };
+        static TEST_TASK_PRESENT: Cell<bool> = const { Cell::new(false) };
         static TEST_TASK_BLOCKING: Cell<bool> = const { Cell::new(false) };
     }
 
@@ -40,6 +47,29 @@ mod tests {
     struct TestTaskState {
         ready: StdMutex<bool>,
         cvar: Condvar,
+    }
+
+    struct TestIrqRegistrar;
+
+    struct TestIrqRegistration;
+
+    impl BlockIrqRegistrar for TestIrqRegistrar {
+        fn register_shared(
+            &self,
+            _name: String,
+            _irq: IrqId,
+            _action: Box<dyn FnMut(IrqContext) -> BlockIrqOutcome + Send + 'static>,
+        ) -> AxResult<Box<dyn BlockIrqRegistration>> {
+            Ok(Box::new(TestIrqRegistration))
+        }
+    }
+
+    impl BlockIrqRegistration for TestIrqRegistration {}
+
+    impl Drop for TestIrqRegistration {
+        fn drop(&mut self) {
+            TEST_IRQ_REGISTRATION_DROPS.fetch_add(1, Ordering::AcqRel);
+        }
     }
 
     impl TestTaskState {
@@ -53,10 +83,18 @@ mod tests {
 
     impl BlockTaskOps for TestTaskOps {
         fn current_task_id(&self) -> Option<u64> {
-            test_task_is_blocking().then(current_test_task_id)
+            test_task_is_present().then(current_test_task_id)
+        }
+
+        fn can_block(&self) -> bool {
+            test_task_is_present() && test_task_is_blocking()
         }
 
         fn task_yield(&self) {
+            assert!(
+                !test_task_is_present() || test_task_is_blocking(),
+                "test task attempted to yield while nonblocking"
+            );
             std::thread::yield_now();
         }
 
@@ -75,6 +113,10 @@ mod tests {
 
         fn task_wait_timeout(&self, dur: core::time::Duration) -> bool {
             if !test_task_is_blocking() {
+                assert!(
+                    !test_task_is_present(),
+                    "test task attempted to sleep with timeout while nonblocking"
+                );
                 std::thread::yield_now();
                 return true;
             }
@@ -146,7 +188,17 @@ mod tests {
 
     fn with_blocking_task<R>(f: impl FnOnce() -> R) -> R {
         install_test_task_ops();
+        TEST_TASK_PRESENT.with(|present| present.set(true));
         TEST_TASK_BLOCKING.with(|blocking| blocking.set(true));
+        let task_id = current_test_task_id();
+        let _guard = TestTaskGuard { task_id };
+        f()
+    }
+
+    fn with_nonblocking_current_task<R>(f: impl FnOnce() -> R) -> R {
+        install_test_task_ops();
+        TEST_TASK_PRESENT.with(|present| present.set(true));
+        TEST_TASK_BLOCKING.with(|blocking| blocking.set(false));
         let task_id = current_test_task_id();
         let _guard = TestTaskGuard { task_id };
         f()
@@ -164,10 +216,15 @@ mod tests {
 
     impl Drop for TestTaskGuard {
         fn drop(&mut self) {
+            TEST_TASK_PRESENT.with(|present| present.set(false));
             TEST_TASK_BLOCKING.with(|blocking| blocking.set(false));
             TEST_TASK_ID.with(|id| id.set(0));
             test_tasks().lock().unwrap().remove(&self.task_id);
         }
+    }
+
+    fn test_task_is_present() -> bool {
+        TEST_TASK_PRESENT.with(Cell::get)
     }
 
     fn test_task_is_blocking() -> bool {
@@ -957,7 +1014,7 @@ mod tests {
         }
 
         fn with_retry_while_pending() -> Self {
-            let mut queue = Self::with_pending_polls_before_complete(3);
+            let mut queue = Self::with_pending_polls_before_complete(64);
             queue.info.limits.max_inflight = 1;
             queue.retry_while_pending = true;
             queue
@@ -1087,6 +1144,8 @@ mod tests {
         queue: Option<Box<dyn IQueue>>,
         owned_queue: Option<QueueHandle>,
         info: QueueInfo,
+        irq_enabled: Option<Arc<AtomicBool>>,
+        irq_handler_taken: bool,
     }
 
     impl MockInterface {
@@ -1097,6 +1156,8 @@ mod tests {
                 queue: Some(Box::new(queue)),
                 owned_queue: None,
                 info,
+                irq_enabled: None,
+                irq_handler_taken: false,
             }
         }
 
@@ -1107,6 +1168,20 @@ mod tests {
                 queue: Some(Box::new(legacy)),
                 owned_queue: Some(QueueHandle::new(Box::new(owned))),
                 info,
+                irq_enabled: None,
+                irq_handler_taken: false,
+            }
+        }
+
+        fn new_irq_capable(queue: MockQueue, irq_enabled: Arc<AtomicBool>) -> Self {
+            let info = queue.info();
+            Self {
+                name: "mock-rdif",
+                queue: Some(Box::new(queue)),
+                owned_queue: None,
+                info,
+                irq_enabled: Some(irq_enabled),
+                irq_handler_taken: false,
             }
         }
     }
@@ -1132,6 +1207,42 @@ mod tests {
 
         fn create_owned_queue(&mut self) -> Option<QueueHandle> {
             self.owned_queue.take()
+        }
+
+        fn enable_irq(&self) {
+            if let Some(irq_enabled) = &self.irq_enabled {
+                irq_enabled.store(true, Ordering::Release);
+            }
+        }
+
+        fn disable_irq(&self) {
+            if let Some(irq_enabled) = &self.irq_enabled {
+                irq_enabled.store(false, Ordering::Release);
+            }
+        }
+
+        fn is_irq_enabled(&self) -> bool {
+            self.irq_enabled
+                .as_ref()
+                .is_some_and(|irq_enabled| irq_enabled.load(Ordering::Acquire))
+        }
+
+        fn irq_sources(&self) -> rdif_block::IrqSourceList {
+            if self.irq_enabled.is_none() {
+                return Vec::new();
+            }
+
+            let mut queues = rdif_block::IdList::none();
+            queues.insert(self.info.id);
+            vec![rdif_block::IrqSourceInfo::new(0, queues)]
+        }
+
+        fn take_irq_handler(&mut self, source_id: usize) -> Option<rdif_block::BIrqHandler> {
+            if source_id != 0 || self.irq_enabled.is_none() || self.irq_handler_taken {
+                return None;
+            }
+            self.irq_handler_taken = true;
+            Some(Box::new(QueueEventIrqHandler))
         }
     }
 
@@ -1311,6 +1422,43 @@ mod tests {
     }
 
     #[test]
+    fn passthrough_release_drops_irq_registrations_and_returns_to_polling() {
+        let _guard = test_task_guard();
+        install_test_task_ops();
+        set_irq_registrar(&TEST_IRQ_REGISTRAR);
+        TEST_IRQ_REGISTRATION_DROPS.store(0, Ordering::Release);
+        let irq_enabled = Arc::new(AtomicBool::new(false));
+
+        let runtime = BlockRuntime::from_rdif_devices([RdifBlockDevice::new(
+            "mock-rdif",
+            Some(IrqId::new(IrqDomainId(1), HwIrq(2))),
+            Box::new(MockInterface::new_irq_capable(
+                MockQueue::new(),
+                irq_enabled.clone(),
+            )),
+        )]);
+
+        assert_eq!(runtime.devices().len(), 1);
+        assert_eq!(runtime.irq_registration_count(), 1);
+        assert_eq!(
+            runtime.devices()[0].completion_mode(),
+            BlockCompletionMode::IrqDriven
+        );
+        assert!(irq_enabled.load(Ordering::Acquire));
+
+        assert_eq!(runtime.release_irq_registrations_for_passthrough(), 1);
+        assert_eq!(runtime.irq_registration_count(), 0);
+        assert_eq!(TEST_IRQ_REGISTRATION_DROPS.load(Ordering::Acquire), 1);
+        assert_eq!(
+            runtime.devices()[0].completion_mode(),
+            BlockCompletionMode::Polling
+        );
+
+        assert_eq!(runtime.release_irq_registrations_for_passthrough(), 0);
+        assert_eq!(TEST_IRQ_REGISTRATION_DROPS.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
     fn block_device_queue_hint_drains_pending_request() {
         let _guard = test_task_guard();
         let bridge = Arc::new(BlockIrqBridge::new());
@@ -1366,7 +1514,7 @@ mod tests {
         config.completion_mode = BlockCompletionMode::IrqDriven;
         let device = BlockDeviceHandle::new(
             "mock",
-            [Box::new(MockQueue::with_pending_polls_before_complete(3)) as Box<dyn IQueue>],
+            [Box::new(MockQueue::with_pending_polls_before_complete(64)) as Box<dyn IQueue>],
             bridge.clone(),
             config,
         )
@@ -1390,6 +1538,35 @@ mod tests {
     }
 
     #[test]
+    fn irq_driven_wait_fast_polls_before_sleep() {
+        let _guard = test_task_guard();
+        TEST_TIMEOUT_WAITS.store(0, Ordering::Relaxed);
+        let bridge = Arc::new(BlockIrqBridge::new());
+        let mut config = irq_driven_config();
+        config.submit_window = 1;
+        let device = BlockDeviceHandle::new(
+            "mock",
+            [Box::new(MockQueue::with_pending_polls_before_complete(2)) as Box<dyn IQueue>],
+            bridge,
+            config,
+        )
+        .unwrap();
+
+        let fs_dev = device.clone();
+        let handle = std::thread::spawn(move || {
+            let mut buf = alloc::vec![0u8; 512];
+            with_blocking_task(|| fs_dev.read_blocks(7, &mut buf)).unwrap();
+            buf
+        });
+
+        let buf = handle.join().unwrap();
+
+        assert_eq!(buf[0], 7);
+        assert_eq!(device.pending_count_for_queue(0), 0);
+        assert_eq!(TEST_TIMEOUT_WAITS.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
     fn irq_driven_wait_repolls_when_completion_irq_is_lost() {
         let _guard = test_task_guard();
         TEST_TIMEOUT_WAITS.store(0, Ordering::Relaxed);
@@ -1398,7 +1575,7 @@ mod tests {
         config.submit_window = 1;
         let device = BlockDeviceHandle::new(
             "mock",
-            [Box::new(MockQueue::with_pending_polls_before_complete(4)) as Box<dyn IQueue>],
+            [Box::new(MockQueue::with_pending_polls_before_complete(64)) as Box<dyn IQueue>],
             bridge,
             config,
         )
@@ -1416,6 +1593,29 @@ mod tests {
         assert_eq!(buf[0], 8);
         assert_eq!(device.pending_count_for_queue(0), 0);
         assert!(TEST_TIMEOUT_WAITS.load(Ordering::Relaxed) > 0);
+    }
+
+    #[test]
+    fn irq_driven_wait_polls_without_sleeping_when_current_task_cannot_block() {
+        let _guard = test_task_guard();
+        TEST_TIMEOUT_WAITS.store(0, Ordering::Relaxed);
+        let bridge = Arc::new(BlockIrqBridge::new());
+        let mut config = irq_driven_config();
+        config.submit_window = 1;
+        let device = BlockDeviceHandle::new(
+            "mock",
+            [Box::new(MockQueue::with_pending_polls_before_complete(64)) as Box<dyn IQueue>],
+            bridge,
+            config,
+        )
+        .unwrap();
+
+        let mut buf = alloc::vec![0u8; 512];
+        with_nonblocking_current_task(|| device.read_blocks(9, &mut buf)).unwrap();
+
+        assert_eq!(buf[0], 9);
+        assert_eq!(device.pending_count_for_queue(0), 0);
+        assert_eq!(TEST_TIMEOUT_WAITS.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/os/arceos/modules/axfs-ng/src/lib.rs
+++ b/os/arceos/modules/axfs-ng/src/lib.rs
@@ -30,7 +30,7 @@ pub mod volume;
 
 pub use block::{
     BlockRegion,
-    runtime::{BlockDeviceHandle, block_io_stats},
+    runtime::{BlockDeviceHandle, block_io_stats, release_block_irqs_for_passthrough},
 };
 #[cfg(feature = "vfs")]
 pub use highlevel::*;

--- a/os/arceos/modules/axfs-ng/src/os/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/os/mod.rs
@@ -15,8 +15,8 @@ pub use memory::{
 };
 pub use task::{
     BlockTaskOps, current_task_id, has_task_ops, notify_drain, notify_drain_from_irq,
-    notify_waiters, set_task_ops, spawn_task, task_wait, task_wait_timeout, task_wait_until,
-    task_yield, wait_for_drain_notification, wake_task,
+    notify_waiters, set_task_ops, spawn_task, task_can_block, task_wait, task_wait_timeout,
+    task_wait_until, task_yield, wait_for_drain_notification, wake_task,
 };
 pub use time::{BlockTimeProvider, has_time_provider, set_time_provider, wall_time};
 

--- a/os/arceos/modules/axfs-ng/src/os/task.rs
+++ b/os/arceos/modules/axfs-ng/src/os/task.rs
@@ -8,6 +8,9 @@ use ax_kspin::SpinRwLock as RwLock;
 
 pub trait BlockTaskOps: Send + Sync {
     fn current_task_id(&self) -> Option<u64>;
+    fn can_block(&self) -> bool {
+        self.current_task_id().is_some()
+    }
     fn task_yield(&self);
     fn task_wait(&self);
     fn task_wait_timeout(&self, dur: Duration) -> bool {
@@ -48,6 +51,10 @@ fn task_ops() -> Option<&'static dyn BlockTaskOps> {
 
 pub fn current_task_id() -> Option<u64> {
     task_ops().and_then(|ops| ops.current_task_id())
+}
+
+pub fn task_can_block() -> bool {
+    task_ops().is_some_and(|ops| ops.can_block())
 }
 
 pub fn task_yield() {

--- a/os/arceos/modules/axruntime/src/fs/block.rs
+++ b/os/arceos/modules/axruntime/src/fs/block.rs
@@ -51,6 +51,10 @@ impl BlockTaskOps for RuntimeTaskOps {
         ax_task::current_may_uninit().map(|curr| curr.id().as_u64())
     }
 
+    fn can_block(&self) -> bool {
+        ax_task::current_may_uninit().is_some() && !ax_task::in_atomic_context()
+    }
+
     fn task_yield(&self) {
         ax_task::yield_now();
     }

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -293,7 +293,12 @@ pub(crate) fn phys_to_virt(paddr: ax_memory_addr::PhysAddr) -> ax_memory_addr::V
     any(target_arch = "x86_64", target_arch = "loongarch64")
 ))]
 pub(crate) fn shutdown_host_filesystems() -> AxResult {
-    modules::ax_fs_ng::shutdown_filesystems()
+    modules::ax_fs_ng::shutdown_filesystems()?;
+    let released = modules::ax_fs_ng::release_block_irqs_for_passthrough();
+    if released != 0 {
+        info!("Released {released} host filesystem block IRQ registration(s) before passthrough");
+    }
+    Ok(())
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
## 问题

`ax-driver` 的 virtio-blk 原先通过同步 `read_blocks` / `write_blocks` 轮询完成，RDIF block runtime 无法把它识别为 IRQ-driven completion。切到中断驱动后还暴露出两个边界问题：早期 root 探测可能在不可睡眠上下文等待 block I/O；Axvisor x86 host fs passthrough 会把同一个 QEMU virtio-blk 交给 guest，host 侧 block IRQ action 若继续留在共享 IRQ 链里，会抢掉 guest Linux rootfs I/O 的完成中断。

## 修改

- virtio-blk PCI/FDT probe 保留 IRQ binding，并通过 `register_block_with_info` 注册。
- virtio-blk 请求路径改为 `read_blocks_nb` / `write_blocks_nb` 提交，task-side `poll_request` 用 `peek_used` 和 matching token 完成。
- virtio-blk 内部用 `UnsafeCell`、`access_active`、`irq_ack_pending` 拆分 task/IRQ 访问；IRQ handler 只 ack `QUEUE_INTERRUPT`，共享 IRQ 空触发不发布 ready event。
- 保持 `max_inflight = 1`，单 in-flight 保存 RDIF request id、virtio token、请求/响应 storage、op 和 segment 副本；flush/discard/write-zeroes 仍返回不支持。
- axfs-ng IRQ block runtime 增加不可阻塞上下文 fallback，避免早期 root probing 在 IRQ disabled / atomic context 中 sleep。
- axfs-ng 在 host fs passthrough release 时释放 block IRQ registrations，并把 runtime completion mode 退回 polling，避免 Axvisor guest passthrough 后 host IRQ handler 继续消费同一设备的 INTx/ISR。
- 补充回归测试：virtio-blk IRQ event/ack/token 匹配、axfs-ng 非阻塞等待、passthrough release drop IRQ registration，以及 fast-poll 后仍 pending 的 queue-hint claim 释放。

## 验证

- `cargo test -p ax-fs-ng`：67 个 lib tests + 3 个 root_selector tests 通过。
- `cargo test -p ax-driver --features virtio-blk,irq virtio::block::tests`：5 个测试通过。
- `cargo fmt --check && git diff --check` 通过。
- `cargo xtask clippy --package ax-fs-ng`：7/7 通过。
- `cargo xtask clippy --package ax-runtime`：23/23 通过。
- `cargo xtask clippy --package ax-driver`：47/47 通过。
- `cargo xtask clippy --package axvm`：6/6 通过。
- `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx` 通过，guest Linux 成功 mount `/dev/vda` 并输出 `guest linux test pass!`。
- `cargo xtask arceos test qemu --arch loongarch64` 通过。
- `cargo xtask starry app qemu -t block-io-bench --arch x86_64` 通过，出现 IRQ-driven completion 日志和 `BLOCK_BENCH_APP_PASSED`；本次结果 write 12.70 MiB/s、read 52.47 MiB/s。
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/block-io-smoke` 通过，出现 virtio-blk IRQ-driven 日志、`STARRY_SYSTEM_TEST_PASSED` 和 `STARRY_GROUPED_TESTS_PASSED`。

## 性能说明

同机早前 dev polling baseline 热跑约为 write 13.05 MiB/s、read 59.40 MiB/s。本分支最新 x86 block bench 为 write 12.70 MiB/s、read 52.47 MiB/s：写入基本持平，读取在当前 `max_inflight = 1` / 4KiB sync workload 下仍有约 12% 退化。这个 PR 先保证 completion 语义和 passthrough 正确性，后续若要消除读侧开销，建议单独做 queue depth / batching 优化。