### PR TITLE
fix(starry): align nanosleep and shm attach semantics

### DIFF
--- a/os/StarryOS/kernel/src/syscall/ipc/shm.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/shm.rs
@@ -1,4 +1,8 @@
-use alloc::{collections::btree_map::BTreeMap, sync::Arc, vec::Vec};
+use alloc::{
+    collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    sync::Arc,
+    vec::Vec,
+};
 
 use ax_errno::{AxError, AxResult};
 use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr, VirtAddrRange};
@@ -138,7 +142,7 @@ pub struct ShmInner {
     pub shmid: i32,
     /// Number of pages in the shared memory segment.
     pub page_num: usize,
-    va_range: BTreeMap<Pid, VirtAddrRange>,
+    va_range: BTreeMap<Pid, Vec<VirtAddrRange>>,
     /// physical pages
     pub phys_pages: Option<Arc<SharedPages>>,
     /// whether remove on last detach, see shm_ctl
@@ -219,39 +223,66 @@ impl ShmInner {
         self.phys_pages = Some(phys_pages);
     }
 
-    /// Returns the number of processes currently attached to this shared memory
-    /// segment.
+    /// Returns the number of current attaches to this shared memory segment.
     pub fn attach_count(&self) -> usize {
-        self.va_range.len()
+        self.va_range.values().map(Vec::len).sum()
     }
 
-    /// Returns the virtual address range associated with the given Pid.
-    pub fn get_addr_range(&self, pid: Pid) -> Option<VirtAddrRange> {
-        self.va_range.get(&pid).cloned()
+    /// Returns all virtual address ranges associated with the given Pid.
+    pub fn get_addr_ranges(&self, pid: Pid) -> Vec<VirtAddrRange> {
+        self.va_range.get(&pid).cloned().unwrap_or_default()
     }
 
-    /// Attach a process to this segment. Returns `Err` if already attached.
-    pub fn attach_process(&mut self, pid: Pid, va_range: VirtAddrRange) -> AxResult {
-        if self.get_addr_range(pid).is_some() {
-            return Err(AxError::InvalidInput);
-        }
-        self.va_range.insert(pid, va_range);
+    /// Returns the virtual address range that starts at the given address.
+    pub fn get_addr_range_by_start(&self, pid: Pid, vaddr: VirtAddr) -> Option<VirtAddrRange> {
+        self.va_range
+            .get(&pid)?
+            .iter()
+            .find(|range| range.start == vaddr)
+            .copied()
+    }
+
+    /// Attach a process to this segment.
+    pub fn attach_process(&mut self, pid: Pid, va_range: VirtAddrRange) {
+        self.va_range.entry(pid).or_default().push(va_range);
         self.shmid_ds.shm_nattch = self.shmid_ds.shm_nattch.saturating_add(1);
         self.shmid_ds.shm_lpid = pid as __kernel_pid_t;
         self.shmid_ds.shm_atime = monotonic_time_nanos() as __kernel_time_t;
-        Ok(())
     }
 
-    /// Detach a process from this segment. Returns `false` if the process
-    /// was already detached (e.g. by a concurrent clear_proc_shm).
-    pub fn detach_process(&mut self, pid: Pid) -> bool {
-        if self.va_range.remove(&pid).is_none() {
+    /// Detach a single attach range from this segment. Returns `false` if the
+    /// range was already detached (e.g. by a concurrent clear_proc_shm).
+    pub fn detach_process_range(&mut self, pid: Pid, vaddr: VirtAddr) -> bool {
+        let Some(ranges) = self.va_range.get_mut(&pid) else {
             return false;
+        };
+        let Some(index) = ranges.iter().position(|range| range.start == vaddr) else {
+            return false;
+        };
+        ranges.remove(index);
+        let empty = ranges.is_empty();
+        if empty {
+            self.va_range.remove(&pid);
         }
         self.shmid_ds.shm_nattch = self.shmid_ds.shm_nattch.saturating_sub(1);
         self.shmid_ds.shm_lpid = pid as __kernel_pid_t;
         self.shmid_ds.shm_dtime = monotonic_time_nanos() as __kernel_time_t;
         true
+    }
+
+    /// Detach all attach ranges owned by a process from this segment.
+    pub fn detach_process(&mut self, pid: Pid) -> usize {
+        let Some(ranges) = self.va_range.remove(&pid) else {
+            return 0;
+        };
+        let attach_count = ranges.len();
+        self.shmid_ds.shm_nattch = self
+            .shmid_ds
+            .shm_nattch
+            .saturating_sub(attach_count as __kernel_ulong_t);
+        self.shmid_ds.shm_lpid = pid as __kernel_pid_t;
+        self.shmid_ds.shm_dtime = monotonic_time_nanos() as __kernel_time_t;
+        attach_count
     }
 }
 
@@ -297,12 +328,6 @@ where
         self.forward.get(key)
     }
 
-    /// Returns a reference to the key corresponding to the given value, if it
-    /// exists.
-    pub fn get_by_value(&self, value: &V) -> Option<&K> {
-        self.reverse.get(value)
-    }
-
     /// Removes a key-value pair by value, returning the key if it existed.
     pub fn remove_by_value(&mut self, value: &V) -> Option<K> {
         if let Some(key) = self.reverse.remove(value) {
@@ -332,8 +357,8 @@ pub struct ShmManager {
     key_shmid: BiBTreeMap<(i32, u64), i32>,
     /// shm_id -> shm_inner
     shmid_inner: BTreeMap<i32, Arc<Mutex<ShmInner>>>,
-    /// pid -> shm_id <-> vaddr
-    pid_shmid_vaddr: BTreeMap<Pid, BiBTreeMap<i32, VirtAddr>>,
+    /// pid -> vaddr -> shm_id
+    pid_shmid_vaddr: BTreeMap<Pid, BTreeMap<VirtAddr, i32>>,
 }
 
 impl ShmManager {
@@ -373,26 +398,17 @@ impl ShmManager {
     pub fn get_shmid_by_vaddr(&self, pid: Pid, vaddr: VirtAddr) -> Option<i32> {
         self.pid_shmid_vaddr
             .get(&pid)
-            .and_then(|map| map.get_by_value(&vaddr))
+            .and_then(|map| map.get(&vaddr))
             .cloned()
     }
 
     pub(crate) fn get_shmids_by_pid(&self, pid: Pid) -> Option<Vec<i32>> {
         let map = self.pid_shmid_vaddr.get(&pid)?;
-        let mut res = Vec::new();
-        for key in map.forward.keys() {
-            res.push(*key);
+        let mut ids = BTreeSet::new();
+        for shmid in map.values() {
+            ids.insert(*shmid);
         }
-        Some(res)
-    }
-
-    // used by garbage collection
-    #[allow(dead_code)]
-    fn find_vaddr_by_shmid(&self, pid: Pid, shmid: i32) -> Option<VirtAddr> {
-        self.pid_shmid_vaddr
-            .get(&pid)
-            .and_then(|map| map.get_by_key(&shmid))
-            .cloned()
+        Some(ids.into_iter().collect())
     }
 
     /// Inserts a mapping from a (key, ns_id) pair to a shared memory ID.
@@ -409,19 +425,18 @@ impl ShmManager {
     /// Inserts a mapping from a process and shared memory ID to a virtual
     /// address.
     pub fn insert_shmid_vaddr(&mut self, pid: Pid, shmid: i32, vaddr: VirtAddr) {
-        // maintain the map 'shmid_vaddr'
         self.pid_shmid_vaddr
             .entry(pid)
             .or_default()
-            .insert(shmid, vaddr);
+            .insert(vaddr, shmid);
     }
 
     /// Removes the mapping from a process and shared memory address.
     pub fn remove_shmaddr(&mut self, pid: Pid, shmaddr: VirtAddr) {
         let mut empty: bool = false;
         if let Some(map) = self.pid_shmid_vaddr.get_mut(&pid) {
-            map.remove_by_value(&shmaddr);
-            empty = map.forward.is_empty();
+            map.remove(&shmaddr);
+            empty = map.is_empty();
         }
         if empty {
             self.pid_shmid_vaddr.remove(&pid);
@@ -444,9 +459,6 @@ impl ShmManager {
     pub fn remove_shmid(&mut self, shmid: i32) {
         self.key_shmid.remove_by_value(&shmid);
         self.shmid_inner.remove(&shmid);
-        // for map in self.pid_shmid_vaddr.values() {
-        // assert!(map.get_by_key(&shmid).is_none());
-        // }
     }
 }
 
@@ -483,9 +495,7 @@ pub fn clear_proc_shm(pid: Pid, aspace: &Arc<Mutex<AddrSpace>>) {
     let mut ranges: Vec<VirtAddrRange> = Vec::new();
     for (_, shm_inner_arc) in &segments {
         let shm_inner = shm_inner_arc.lock();
-        if let Some(va_range) = shm_inner.get_addr_range(pid) {
-            ranges.push(va_range);
-        }
+        ranges.extend(shm_inner.get_addr_ranges(pid));
     }
     if !ranges.is_empty() {
         let mut aspace = aspace.lock();
@@ -589,9 +599,6 @@ pub fn sys_shmat(shmid: i32, addr: usize, shmflg: u32) -> AxResult<isize> {
     let length = shm_inner.page_num * PAGE_SIZE_4K;
 
     // alloc the virtual address range
-    if shm_inner.get_addr_range(pid).is_some() {
-        return Err(AxError::InvalidInput);
-    }
     let start_addr = aspace
         .find_free_area(
             VirtAddr::from(start_aligned),
@@ -635,7 +642,7 @@ pub fn sys_shmat(shmid: i32, addr: usize, shmflg: u32) -> AxResult<isize> {
     }
 
     info!("shmat pid={pid} shmid={shmid} mapped; attach_process");
-    shm_inner.attach_process(pid, va_range)?;
+    shm_inner.attach_process(pid, va_range);
     drop(aspace);
     drop(shm_inner);
 
@@ -812,7 +819,9 @@ pub fn sys_shmdt(shmaddr: usize) -> AxResult<isize> {
     let va_range = {
         info!("shmdt pid={pid} lock shm_inner for range");
         let shm_inner = shm_inner_arc.lock();
-        shm_inner.get_addr_range(pid).ok_or(AxError::InvalidInput)?
+        shm_inner
+            .get_addr_range_by_start(pid, shmaddr)
+            .ok_or(AxError::InvalidInput)?
     };
 
     // Unmap while only holding the aspace lock.
@@ -830,9 +839,12 @@ pub fn sys_shmdt(shmaddr: usize) -> AxResult<isize> {
     shm_manager.remove_shmaddr(pid, shmaddr);
     let mut shm_inner = shm_inner_arc.lock();
 
-    // detach_process returns false if clear_proc_shm already detached
+    // detach_process_range returns false if clear_proc_shm already detached
     // this pid (race during process exit).
-    if shm_inner.detach_process(pid) && shm_inner.rmid && shm_inner.attach_count() == 0 {
+    if shm_inner.detach_process_range(pid, shmaddr)
+        && shm_inner.rmid
+        && shm_inner.attach_count() == 0
+    {
         drop(shm_inner);
         shm_manager.remove_shmid(shmid);
     }

--- a/os/StarryOS/kernel/src/syscall/task/schedule.rs
+++ b/os/StarryOS/kernel/src/syscall/task/schedule.rs
@@ -32,16 +32,15 @@ pub fn sys_sched_yield() -> AxResult<isize> {
     Ok(0)
 }
 
-fn sleep_impl(clock: impl Fn() -> TimeValue, dur: TimeValue) -> TimeValue {
+fn sleep_impl(clock: impl Fn() -> TimeValue, dur: TimeValue) -> (AxResult<()>, TimeValue) {
     debug!("sleep_impl <= {dur:?}");
 
     let start = clock();
 
     // TODO: currently ignoring concrete clock type
-    // We detect EINTR manually if the slept time is not enough.
-    let _ = block_on(interruptible(sleep(dur)));
+    let result = block_on(interruptible(sleep(dur))).map_err(AxError::from);
 
-    clock() - start
+    (result, clock() - start)
 }
 
 /// Sleep some nanoseconds
@@ -50,16 +49,18 @@ pub fn sys_nanosleep(req: *const timespec, rem: *mut timespec) -> AxResult<isize
     let req = unsafe { req.vm_read_uninit()?.assume_init() }.try_into_time_value()?;
     debug!("sys_nanosleep <= req: {req:?}");
 
-    let actual = sleep_impl(hal::time::monotonic_time, req);
+    let (result, actual) = sleep_impl(hal::time::monotonic_time, req);
 
-    if let Some(diff) = req.checked_sub(actual) {
-        debug!("sys_nanosleep => rem: {diff:?}");
-        if let Some(rem) = rem.nullable() {
-            rem.vm_write(timespec::from_time_value(diff))?;
+    match result {
+        Ok(()) => Ok(0),
+        Err(err) => {
+            let diff = req.saturating_sub(actual);
+            debug!("sys_nanosleep => rem: {diff:?}");
+            if let Some(rem) = rem.nullable() {
+                rem.vm_write(timespec::from_time_value(diff))?;
+            }
+            Err(err)
         }
-        Err(AxError::Interrupted)
-    } else {
-        Ok(0)
     }
 }
 
@@ -81,22 +82,27 @@ pub fn sys_clock_nanosleep(
     let req = unsafe { req.vm_read_uninit()?.assume_init() }.try_into_time_value()?;
     debug!("sys_clock_nanosleep <= clock_id: {clock_id}, flags: {flags}, req: {req:?}");
 
-    let dur = if flags & TIMER_ABSTIME != 0 {
+    let is_abstime = flags & TIMER_ABSTIME != 0;
+    let dur = if is_abstime {
         req.saturating_sub(clock())
     } else {
         req
     };
 
-    let actual = sleep_impl(clock, dur);
+    let (result, actual) = sleep_impl(clock, dur);
 
-    if let Some(diff) = dur.checked_sub(actual) {
-        debug!("sys_clock_nanosleep => rem: {diff:?}");
-        if let Some(rem) = rem.nullable() {
-            rem.vm_write(timespec::from_time_value(diff))?;
+    match result {
+        Ok(()) => Ok(0),
+        Err(err) => {
+            if !is_abstime {
+                let diff = dur.saturating_sub(actual);
+                debug!("sys_clock_nanosleep => rem: {diff:?}");
+                if let Some(rem) = rem.nullable() {
+                    rem.vm_write(timespec::from_time_value(diff))?;
+                }
+            }
+            Err(err)
         }
-        Err(AxError::Interrupted)
-    } else {
-        Ok(0)
     }
 }
 

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-shm-family/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-shm-family/src/main.c
@@ -225,6 +225,64 @@ int main(void)
         shmctl(seg, IPC_RMID, NULL);
     }
 
+    /* ---- Section 5b: same-process multiple attaches ---- */
+    {
+        int seg = shmget(IPC_PRIVATE, SEG_SIZE, IPC_CREAT | 0666);
+        CHECK(seg >= 0, "shmget for repeated same-process shmat test");
+
+        void *first = shmat(seg, NULL, 0);
+        CHECK(first != (void *)-1, "first shmat of a segment succeeds");
+
+        void *second = shmat(seg, NULL, 0);
+        CHECK(second != (void *)-1,
+              "second shmat of the same shmid in one process succeeds");
+
+        if (first != (void *)-1 && second != (void *)-1)
+        {
+            *(volatile unsigned int *)first = 0x13572468u;
+            CHECK(*(volatile unsigned int *)second == 0x13572468u,
+                  "second attach observes data written through first attach");
+
+            *(volatile unsigned int *)second = 0x24681357u;
+            CHECK(*(volatile unsigned int *)first == 0x24681357u,
+                  "first attach observes data written through second attach");
+        }
+
+        struct shmid_ds info;
+        memset(&info, 0, sizeof(info));
+        CHECK_RET(shmctl(seg, IPC_STAT, &info), 0,
+                  "IPC_STAT after two same-process attaches");
+        CHECK((info.shm_nattch & 0xffffUL) == 2UL,
+              "IPC_STAT reports two same-process attaches");
+
+        if (first != (void *)-1)
+        {
+            CHECK_RET(shmdt(first), 0, "shmdt first same-process attach");
+
+            memset(&info, 0, sizeof(info));
+            CHECK_RET(shmctl(seg, IPC_STAT, &info), 0,
+                      "IPC_STAT after detaching first same-process attach");
+            CHECK((info.shm_nattch & 0xffffUL) == 1UL,
+                  "IPC_STAT reports one remaining same-process attach");
+        }
+
+        if (second != (void *)-1)
+        {
+            *(volatile unsigned int *)second = 0x55aa33ccu;
+            CHECK(*(volatile unsigned int *)second == 0x55aa33ccu,
+                  "second same-process attach remains usable after first detach");
+            CHECK_RET(shmdt(second), 0, "shmdt second same-process attach");
+        }
+
+        memset(&info, 0, sizeof(info));
+        CHECK_RET(shmctl(seg, IPC_STAT, &info), 0,
+                  "IPC_STAT after detaching both same-process attaches");
+        CHECK((info.shm_nattch & 0xffffUL) == 0UL,
+              "IPC_STAT reports zero same-process attaches after both shmdt");
+
+        shmctl(seg, IPC_RMID, NULL);
+    }
+
     /* ---- Section 6: shmctl error cases ---- */
     {
         int seg = shmget(IPC_PRIVATE, SEG_SIZE, IPC_CREAT | 0666);

--- a/test-suit/starryos/qemu-smp1/system/syscall-test-timer-family/src/main.c
+++ b/test-suit/starryos/qemu-smp1/system/syscall-test-timer-family/src/main.c
@@ -929,6 +929,73 @@ static void test_posix_timer_signal_delivery(void) {
 }
 
 /* ============================================================
+ * nanosleep / clock_nanosleep interruption semantics
+ * ============================================================ */
+
+static void test_clock_nanosleep_abstime_eintr_keeps_rem(void) {
+    struct sigaction sa, old_sa;
+    struct itimerval alarm;
+    struct timespec deadline;
+    struct timespec rem;
+    const struct timespec rem_sentinel = {
+        .tv_sec = 0x12345678,
+        .tv_nsec = 987654321,
+    };
+    int ret;
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigalrm_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    if (sigaction(SIGALRM, &sa, &old_sa) != 0) {
+        printf("  FAIL | %s:%d | sigaction failed | errno=%d (%s)\n",
+               __FILE__, __LINE__, errno, strerror(errno));
+        __fail++;
+        return;
+    }
+
+    sig_received = 0;
+
+    errno = 0;
+    ret = clock_gettime(CLOCK_MONOTONIC, &deadline);
+    if (ret != 0) {
+        printf("  FAIL | %s:%d | clock_gettime failed | errno=%d (%s)\n",
+               __FILE__, __LINE__, errno, strerror(errno));
+        __fail++;
+        sigaction(SIGALRM, &old_sa, NULL);
+        return;
+    }
+    deadline.tv_sec += 2;
+
+    memset(&alarm, 0, sizeof(alarm));
+    alarm.it_value.tv_usec = 50000; /* 50 ms, before the absolute deadline */
+    errno = 0;
+    ret = setitimer(ITIMER_REAL, &alarm, NULL);
+    if (ret != 0) {
+        printf("  FAIL | %s:%d | setitimer failed | errno=%d (%s)\n",
+               __FILE__, __LINE__, errno, strerror(errno));
+        __fail++;
+        sigaction(SIGALRM, &old_sa, NULL);
+        return;
+    }
+
+    rem = rem_sentinel;
+    errno = 0;
+    ret = syscall(SYS_clock_nanosleep, CLOCK_MONOTONIC, TIMER_ABSTIME,
+                  &deadline, &rem);
+    CHECK(ret == -1 && errno == EINTR,
+          "TIMER_ABSTIME clock_nanosleep should fail with EINTR when interrupted");
+    CHECK(sig_received == 1,
+          "SIGALRM should interrupt absolute clock_nanosleep before deadline");
+    CHECK(memcmp(&rem, &rem_sentinel, sizeof(rem)) == 0,
+          "TIMER_ABSTIME clock_nanosleep must leave rem unchanged on EINTR");
+
+    memset(&alarm, 0, sizeof(alarm));
+    setitimer(ITIMER_REAL, &alarm, NULL);
+    sigaction(SIGALRM, &old_sa, NULL);
+}
+
+/* ============================================================
  * timer_delete then use tests
  * ============================================================ */
 
@@ -1550,6 +1617,9 @@ int main(int argc, char *argv[]) {
     test_posix_timer_signal_delivery();
     test_timer_abstime_past_signal_delivery();
     test_posix_timer_periodic_signal();
+
+    printf("\n--- sleep interruption tests ---\n");
+    test_clock_nanosleep_abstime_eintr_keeps_rem();
 
     printf("\n--- timer lifecycle tests ---\n");
     test_timer_delete_then_gettime();


### PR DESCRIPTION
## 问题

对比 openkylin/x-kernel 已合并修复后，本项目 Starry 仍缺少两个 syscall 语义修复：

- `clock_nanosleep`/`nanosleep` 中断路径依赖实际睡眠时间推断，absolute `TIMER_ABSTIME` 被信号中断时会错误写入 `rem`。
- SysV SHM 以 `pid -> shmid <-> vaddr` 和 `pid -> range` 管理 attach，导致同一进程无法对同一段多次 `shmat`，`shmdt(addr)` 也不能按地址精确 detach。

## 修改

- `sleep_impl` 保留 `interruptible(sleep(...))` 的真实结果，`nanosleep` 中断时写 relative 剩余时间并返回错误；`clock_nanosleep` absolute 中断时返回错误但不写 `rem`。
- 新增 timer-family 回归测试，覆盖 `CLOCK_MONOTONIC + TIMER_ABSTIME` 被 `SIGALRM` 中断时 `rem` 保持哨兵值不变。
- 将 SHM attach 记录改为每个 PID 可保存多个 `VirtAddrRange`，attach 计数按所有 range 汇总。
- 将 SHM manager 的进程映射改为 `pid -> vaddr -> shmid`，允许同一 `shmid` 对应多个 attach 地址，并让 `shmdt(shmaddr)` 精确移除对应 mapping。
- 更新进程退出清理，清理该 PID 的所有 SHM attach range。
- 新增 shm-family 回归测试，覆盖同进程同段两次 `shmat`、共享读写、`shm_nattch` 从 `2 -> 1 -> 0` 的变化，以及 detach 第一个映射后第二个映射仍可用。

## 验证

- `cargo fmt`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/syscall-test-timer-family`
- `cargo xtask starry test qemu --arch x86_64 -c qemu-smp1/system/syscall-test-shm-family`
- `git diff --check`