### PR TITLE
feat(rdrive): add FDT power-domain probing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ dependencies = [
  "rdif-intc",
  "rdif-pcie",
  "rdif-pinctrl",
+ "rdif-power",
  "rdif-pwm",
  "rdif-reset",
  "rdif-serial",
@@ -6341,6 +6342,7 @@ name = "rdif-power"
 version = "0.7.3"
 dependencies = [
  "rdif-base",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6407,6 +6409,7 @@ dependencies = [
  "rdif-base",
  "rdif-pcie",
  "rdif-pinctrl",
+ "rdif-power",
  "rdif-reset",
  "rdrive-macros",
  "spin",

--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -126,7 +126,7 @@ rockchip-soc = [
     "dep:rdif-reset",
     "dep:rockchip-soc",
 ]
-rockchip-pm = ["rockchip-soc", "dep:rockchip-pm"]
+rockchip-pm = ["rockchip-soc", "dep:rdif-power", "dep:rockchip-pm"]
 list-pci-devices = ["pci"]
 pci-list-devices = ["list-pci-devices"]
 
@@ -164,6 +164,7 @@ rdif-serial = { workspace = true, optional = true }
 rdif-intc.workspace = true
 rdif-pcie = { workspace = true, optional = true }
 rdif-pinctrl = { workspace = true, optional = true }
+rdif-power = { workspace = true, optional = true }
 rdif-pwm = { workspace = true, optional = true }
 rdif-reset = { workspace = true, optional = true }
 rdif-vsock = { workspace = true, optional = true }

--- a/drivers/ax-driver/src/block/rockchip/sd/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sd/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{format, vec::Vec};
+use alloc::format;
 use core::time::Duration;
 
 use dwmmc_host::{CardDetect, DwMmc, HostClock, rdif as dwmmc_rdif};
@@ -36,11 +36,7 @@ use sdmmc_protocol::{
 use super::clock::{
     RockchipClockOps, ScmiClockOps, apply_assigned_clocks, enable_node_clocks, scmi_named_clock,
 };
-use crate::{
-    block::ProbeFdtBlock,
-    mmio::iomap,
-    soc::{RockchipFdtPinctrlParser, rk3588_enable_power_domain},
-};
+use crate::{block::ProbeFdtBlock, mmio::iomap, soc::RockchipFdtPinctrlParser};
 
 const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
 const ROCKCHIP_DWMMC_CLKGEN_DIV: u32 = 2;
@@ -228,7 +224,6 @@ fn apply_rockchip_sd_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
             );
         }
     }
-    enable_power_domains(parse_power_domains(info.node.as_node())?)?;
     enable_node_clocks(info, "SDMMC");
     Ok(())
 }
@@ -295,31 +290,6 @@ fn regulator_has_fixed_gpio_enable(node: &Node) -> bool {
         && (node.get_property("gpios").is_some()
             || node.get_property("gpio").is_some()
             || node.get_property("pinctrl-0").is_some())
-}
-
-fn parse_power_domains(node: &Node) -> Result<Vec<usize>, OnProbeError> {
-    let Some(prop) = node.get_property("power-domains") else {
-        return Ok(Vec::new());
-    };
-    let cells = prop.get_u32_iter().collect::<Vec<_>>();
-    if cells.len() % 2 != 0 {
-        return Err(OnProbeError::other(format!(
-            "[{}] has malformed power-domains",
-            node.name()
-        )));
-    }
-    Ok(cells.chunks(2).map(|chunk| chunk[1] as usize).collect())
-}
-
-fn enable_power_domains(domains: Vec<usize>) -> Result<(), OnProbeError> {
-    for domain in domains {
-        rk3588_enable_power_domain(domain).map_err(|err| {
-            OnProbeError::other(format!(
-                "failed to enable RK3588 SDMMC power domain {domain}: {err}"
-            ))
-        })?;
-    }
-    Ok(())
 }
 
 fn poll_card_init(sd: &mut RockchipDwMmc) -> Result<CardInfo, Error> {
@@ -509,27 +479,5 @@ mod tests {
         ));
 
         assert!(!regulator_has_fixed_gpio_enable(&node));
-    }
-
-    #[test]
-    fn parse_power_domains_reads_rockchip_provider_cells() {
-        let mut node = Node::new("mmc@fe2c0000");
-        let mut raw = Vec::new();
-        raw.extend_from_slice(&0x1111_u32.to_be_bytes());
-        raw.extend_from_slice(&30_u32.to_be_bytes());
-        node.add_property(fdt_edit::Property::new("power-domains", raw));
-
-        assert_eq!(parse_power_domains(&node).unwrap(), vec![30]);
-    }
-
-    #[test]
-    fn parse_power_domains_rejects_malformed_cells() {
-        let mut node = Node::new("mmc@fe2c0000");
-        node.add_property(fdt_edit::Property::new(
-            "power-domains",
-            0x1111_u32.to_be_bytes().to_vec(),
-        ));
-
-        assert!(parse_power_domains(&node).is_err());
     }
 }

--- a/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
@@ -15,7 +15,6 @@
 use alloc::{format, vec::Vec};
 use core::{ptr::NonNull, time::Duration};
 
-use fdt_edit::Node;
 use log::{info, warn};
 use rdrive::{
     probe::{OnProbeError, fdt::ResetLine},
@@ -33,7 +32,7 @@ use sdmmc_protocol::{
 };
 
 use super::clock::{RockchipClockOps, apply_assigned_clocks, enable_node_clocks};
-use crate::{block::ProbeFdtBlock, mmio::iomap, soc::rk3588_enable_power_domain};
+use crate::{block::ProbeFdtBlock, mmio::iomap};
 
 // RK3588 DWCMSHC follows Linux's normal SDHCI completion path: command/data
 // status is acknowledged in the hard IRQ and task context advances the RDIF
@@ -209,35 +208,9 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
 fn apply_rockchip_sdhci_resources(info: &FdtInfo<'_>) -> Result<Vec<ResetLine>, OnProbeError> {
     apply_assigned_clocks(info, "SDHCI")?;
-    enable_power_domains(parse_power_domains(info.node.as_node())?)?;
     let resets = info.reset_lines()?;
     enable_node_clocks(info, "SDHCI");
     Ok(resets)
-}
-
-fn parse_power_domains(node: &Node) -> Result<Vec<usize>, OnProbeError> {
-    let Some(prop) = node.get_property("power-domains") else {
-        return Ok(Vec::new());
-    };
-    let cells = prop.get_u32_iter().collect::<Vec<_>>();
-    if cells.len() % 2 != 0 {
-        return Err(OnProbeError::other(format!(
-            "[{}] has malformed power-domains",
-            node.name()
-        )));
-    }
-    Ok(cells.chunks(2).map(|chunk| chunk[1] as usize).collect())
-}
-
-fn enable_power_domains(domains: Vec<usize>) -> Result<(), OnProbeError> {
-    for domain in domains {
-        rk3588_enable_power_domain(domain).map_err(|err| {
-            OnProbeError::other(format!(
-                "failed to enable RK3588 SDHCI power domain {domain}: {err}"
-            ))
-        })?;
-    }
-    Ok(())
 }
 
 fn assert_resets(resets: &[ResetLine]) -> Result<(), OnProbeError> {
@@ -474,13 +447,6 @@ mod tests {
         assert_eq!(limits.max_blocks_per_request, sdhci_host::ADMA2_MAX_BLOCKS);
         assert_eq!(limits.max_segment_size, sdhci_host::ADMA2_MAX_TRANSFER_SIZE);
         assert_eq!(limits.max_segments, 1);
-    }
-
-    #[test]
-    fn parse_power_domains_accepts_absent_sdhci_domain() {
-        let node = Node::new("mmc@fe2e0000");
-
-        assert_eq!(parse_power_domains(&node).unwrap(), Vec::<usize>::new());
     }
 
     #[test]

--- a/drivers/ax-driver/src/jpeg.rs
+++ b/drivers/ax-driver/src/jpeg.rs
@@ -1,7 +1,7 @@
 //! OS glue for the RK3588 hardware JPEG decoder (`jpegd@fdb90000`, VDPU720).
 //!
 //! Probes the device-tree node, maps its registers, brings the engine out of
-//! reset (power domain + clocks + soft reset), puts the per-block IOMMU into
+//! reset (clocks + soft reset), puts the per-block IOMMU into
 //! pass-through (bypass) so contiguous buffers reach the engine by physical
 //! address, and registers a [`RockchipJpeg`] device. An optional boot-time
 //! self-test (feature `jpu-selftest`) decodes an embedded JPEG to validate the
@@ -16,13 +16,8 @@ use rdrive::{
 };
 use rockchip_jpeg::RockchipJpeg;
 
-use crate::{
-    mmio::iomap,
-    soc::{rk3588_enable_clock, rk3588_enable_power_domain},
-};
+use crate::{mmio::iomap, soc::rk3588_enable_clock};
 
-// RK3588 jpegd (VDPU720) constants, from the OrangePi-5-Plus device tree.
-const PD_VDPU: usize = 21;
 // Synthetic `ClkId` keys into the rockchip-soc gate table — NOT the DT binding
 // numbers. The canonical `ACLK/HCLK_JPEG_DECODER` = 421/422 are already taken by
 // the USB3OTG1 entries in that crate, so 436/437 are used as unique keys instead.
@@ -68,7 +63,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let base = unsafe { iomap(start, size)?.add(offset) };
     let resets = info.reset_lines()?;
 
-    bring_up_power_and_clocks(&resets);
+    bring_up_clocks_and_resets(&resets);
     bypass_iommu(base);
 
     let dma = axklib::dma::device_with_mask(u32::MAX as u64);
@@ -96,10 +91,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 /// Bring the engine out of reset. All steps are best-effort and idempotent; the
 /// shared VDPU root clocks are left enabled by the bootloader (as for RGA2), so
 /// failures here are logged but not fatal.
-fn bring_up_power_and_clocks(resets: &[ResetLine]) {
-    if let Err(e) = rk3588_enable_power_domain(PD_VDPU) {
-        info!("JPEG: enable PD_VDPU failed (continuing): {e}");
-    }
+fn bring_up_clocks_and_resets(resets: &[ResetLine]) {
     for clk in [CLK_ACLK_JPEG_DECODER, CLK_HCLK_JPEG_DECODER] {
         if let Err(e) = rk3588_enable_clock(clk) {
             info!("JPEG: enable clock {clk} failed (continuing): {e:?}");

--- a/drivers/ax-driver/src/pci/fdt/rk3588/resources.rs
+++ b/drivers/ax-driver/src/pci/fdt/rk3588/resources.rs
@@ -10,7 +10,7 @@ use core::{
     time::Duration,
 };
 
-use fdt_edit::{Node, PciRange, Phandle, RegFixed};
+use fdt_edit::{PciRange, Phandle, RegFixed};
 use log::{info, warn};
 use mmio_api::{MmioAddr, MmioRaw};
 use rdif_pcie::PcieController;
@@ -35,7 +35,7 @@ use super::{
         log_resource_summary, program_memory_windows, prop_phandle, set_rk3588_bar_range,
     },
 };
-use crate::soc::{RockchipFdtPinctrlParser, rk3588_enable_power_domain};
+use crate::soc::RockchipFdtPinctrlParser;
 
 pub(super) const RK3588_GPIO_BASES: [u64; 5] = [
     0xfd8a_0000,
@@ -196,7 +196,6 @@ pub(super) struct HostResources<'a> {
     pub(super) ranges: Vec<PciRange>,
     pub(super) bus_base: u8,
     pub(super) logical_bus_end: u8,
-    pub(super) power_domains: Vec<usize>,
     pub(super) clocks: Vec<ClockSpec>,
     pub(super) resets: Vec<ResetLine>,
     pub(super) pipe_grf: Option<Phandle>,
@@ -349,7 +348,6 @@ fn prepare_controller_resources(resources: &HostResources<'_>) -> Result<(), OnP
     }
 
     enable_vpcie3v3_supply(resources.supply)?;
-    enable_power_domains(&resources.power_domains)?;
     init_phys(resources.node, &resources.phys)?;
     assert_resets(&resources.resets)?;
     delay.delay_us(1);
@@ -357,35 +355,6 @@ fn prepare_controller_resources(resources: &HostResources<'_>) -> Result<(), OnP
     enable_clocks(&resources.clocks)?;
     axklib::time::busy_wait(Duration::from_millis(1));
     log_resource_summary(resources);
-    Ok(())
-}
-
-fn parse_power_domains(node: &Node) -> Result<Vec<usize>, OnProbeError> {
-    let Some(prop) = node.get_property("power-domains") else {
-        return Ok(Vec::new());
-    };
-    let cells = prop.get_u32_iter().collect::<Vec<_>>();
-    if cells.len() % 2 != 0 {
-        return Err(OnProbeError::other(format!(
-            "[{}] has malformed power-domains",
-            node.name()
-        )));
-    }
-    Ok(cells.chunks(2).map(|chunk| chunk[1] as usize).collect())
-}
-
-fn enable_power_domains(domains: &[usize]) -> Result<(), OnProbeError> {
-    if domains.is_empty() {
-        return Ok(());
-    }
-
-    for &domain in domains {
-        rk3588_enable_power_domain(domain).map_err(|err| {
-            OnProbeError::other(format!(
-                "failed to enable RK3588 PCIe power domain {domain}: {err}"
-            ))
-        })?;
-    }
     Ok(())
 }
 
@@ -446,7 +415,6 @@ fn parse_host_resources<'a>(
         ranges,
         bus_base,
         logical_bus_end,
-        power_domains: parse_power_domains(raw_node)?,
         clocks: clock_specs(node.clocks()),
         resets: parse_resets(node_type)?,
         pipe_grf: prop_phandle(raw_node, "rockchip,pipe-grf"),

--- a/drivers/ax-driver/src/pci/fdt/rk3588/windows.rs
+++ b/drivers/ax-driver/src/pci/fdt/rk3588/windows.rs
@@ -18,8 +18,8 @@ use super::{
 pub(super) fn log_resource_summary(resources: &HostResources<'_>) {
     info!(
         "Rockchip RK3588 PCIe host {:#x}: FDT resources node={}, dbi={:#x}/{:#x}, \
-         cfg={:#x}/{:#x}, buses {:#x}..={:#x}, clocks={}, resets={}, power-domains={}, phys={}, \
-         supply={:?}, pipe-grf={:?}, reset-gpio={}",
+         cfg={:#x}/{:#x}, buses {:#x}..={:#x}, clocks={}, resets={}, phys={}, supply={:?}, \
+         pipe-grf={:?}, reset-gpio={}",
         resources.apb.address,
         resources.name,
         resources.dbi.address,
@@ -30,7 +30,6 @@ pub(super) fn log_resource_summary(resources: &HostResources<'_>) {
         resources.bus_base.saturating_add(resources.logical_bus_end),
         resources.clocks.len(),
         resources.resets.len(),
-        resources.power_domains.len(),
         resources.phys.len(),
         resources.supply,
         resources.pipe_grf,

--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -8,7 +8,6 @@ pub use rockchip_npu::{
     ioctrl::{RknpuMemCreate, RknpuMemDestroy, RknpuMemMap, RknpuMemSync, RknpuSubmit},
 };
 use rockchip_npu::{Rknpu, RknpuConfig, RknpuType};
-use rockchip_pm::{PowerDomain, RockchipPM};
 
 use crate::mmio::iomap;
 
@@ -53,28 +52,11 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         base_regs.push(unsafe { iomap(start, size)?.add(offset) });
     }
 
-    enable_pm();
-
-    info!("NPU power enabled");
-
     let dma = axklib::dma::device_with_mask(u32::MAX as u64);
     let npu = Rknpu::new(&base_regs, config, dma);
     plat_dev.register(npu);
     info!("NPU registered successfully");
     Ok(())
-}
-
-fn enable_pm() {
-    let mut pm = rdrive::get_one::<RockchipPM>()
-        .expect("RockchipPM not found")
-        .lock()
-        .expect("RockchipPM lock failed");
-
-    // RK3588 NPU power domain IDs (from rockchip-pm rk3588 variant)
-    pm.power_domain_on(PowerDomain(9)).unwrap(); // NPUTOP
-    pm.power_domain_on(PowerDomain(8)).unwrap(); // NPU
-    pm.power_domain_on(PowerDomain(10)).unwrap(); // NPU1
-    pm.power_domain_on(PowerDomain(11)).unwrap(); // NPU2
 }
 
 pub fn is_available() -> bool {

--- a/drivers/ax-driver/src/soc/mod.rs
+++ b/drivers/ax-driver/src/soc/mod.rs
@@ -21,8 +21,7 @@ pub mod scmi;
 
 #[cfg(feature = "rockchip-soc")]
 pub use rockchip::{
-    RockchipFdtPinctrlParser, RockchipPinCtrl, rk3588_enable_clock, rk3588_enable_power_domain,
-    rk3588_set_clock_rate,
+    RockchipFdtPinctrlParser, RockchipPinCtrl, rk3588_enable_clock, rk3588_set_clock_rate,
 };
 
 #[cfg(not(feature = "rockchip-soc"))]
@@ -37,13 +36,6 @@ pub fn rk3588_set_clock_rate(id: u32, rate_hz: u64) -> Result<(), rdrive::probe:
     Err(rdrive::probe::OnProbeError::other(alloc::format!(
         "RK3588 clock support is not enabled for clock {id:#x} rate {rate_hz}"
     )))
-}
-
-#[cfg(not(feature = "rockchip-soc"))]
-pub fn rk3588_enable_power_domain(domain: usize) -> Result<(), alloc::string::String> {
-    Err(alloc::format!(
-        "RK3588 power-domain support is not enabled for power domain {domain}"
-    ))
 }
 
 #[cfg(not(feature = "rockchip-soc"))]

--- a/drivers/ax-driver/src/soc/rockchip/mod.rs
+++ b/drivers/ax-driver/src/soc/rockchip/mod.rs
@@ -25,12 +25,3 @@ mod pinctrl;
 pub use cru::{rk3588_enable_clock, rk3588_set_clock_rate};
 #[cfg(feature = "rockchip-soc")]
 pub use pinctrl::{RockchipFdtPinctrlParser, RockchipPinCtrl};
-#[cfg(all(feature = "rockchip-soc", feature = "rockchip-pm"))]
-pub use pm::rk3588_enable_power_domain;
-
-#[cfg(all(feature = "rockchip-soc", not(feature = "rockchip-pm")))]
-pub fn rk3588_enable_power_domain(domain: usize) -> Result<(), alloc::string::String> {
-    Err(alloc::format!(
-        "rockchip-pm feature is not enabled for power domain {domain}"
-    ))
-}

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl/rdif_glue.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl/rdif_glue.rs
@@ -242,8 +242,8 @@ mod tests {
 
     #[cfg(not(feature = "pci"))]
     use axklib::{
-        AxError, AxResult, IrqCpuMask, IrqHandle, IrqId, Klib, PhysAddr, RawIrqHandler, VirtAddr,
-        impl_trait,
+        AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuMask, IrqHandle,
+        IrqId, Klib, PhysAddr, VirtAddr, impl_trait,
     };
     use fdt_edit::{Node, Property};
     use rdif_pinctrl::{FdtPinctrl, StateName};
@@ -298,16 +298,14 @@ mod tests {
 
             fn irq_request_shared(
                 _irq: IrqId,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _handler: BoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }
 
             fn irq_request_shared_disabled(
                 _irq: IrqId,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _handler: BoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }
@@ -315,8 +313,7 @@ mod tests {
             fn irq_request_percpu(
                 _irq: IrqId,
                 _cpus: IrqCpuMask,
-                _handler: RawIrqHandler,
-                _data: core::ptr::NonNull<()>,
+                _handler: ConcurrentBoxedIrqHandler,
             ) -> AxResult<IrqHandle> {
                 Err(AxError::Unsupported)
             }

--- a/drivers/ax-driver/src/soc/rockchip/pm.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pm.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use log::info;
-use rdrive::{probe::OnProbeError, register::ProbeFdt};
-use rockchip_pm::{PowerDomain, RkBoard, RockchipPM};
+use alloc::{collections::BTreeMap, vec::Vec};
+
+use log::{debug, info};
+use rdif_power::{Interface as PowerInterface, PowerDomainId, PowerError};
+use rdrive::{DriverGeneric, probe::OnProbeError, register::ProbeFdt};
+use rockchip_pm::{PmError, PowerDomain, RkBoard, RockchipPM};
 
 use crate::mmio::iomap;
 
@@ -24,7 +27,7 @@ crate::model_register!(
     priority: ProbePriority::CLK,
     probe_kinds: &[
         ProbeKind::Fdt {
-            compatibles: &["rockchip,rk3588-pmu"],
+            compatibles: &["rockchip,rk3588-power-controller"],
             on_probe: probe
         }
     ],
@@ -32,14 +35,16 @@ crate::model_register!(
 
 fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let (info, plat_dev) = probe.into_parts();
-    let base_reg = info
-        .node
+    let parent = info.node.parent().ok_or_else(|| {
+        OnProbeError::other(alloc::format!("[{}] has no PMU parent", info.node.name()))
+    })?;
+    let base_reg = parent
         .regs()
         .into_iter()
         .next()
         .ok_or(OnProbeError::other(alloc::format!(
-            "[{}] has no reg",
-            info.node.name()
+            "[{}] PMU parent has no reg",
+            parent.name()
         )))?;
 
     let mmio_size = base_reg.size.unwrap_or(0x1000) as usize;
@@ -47,19 +52,187 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
     let mmio_base = iomap(base_reg.address as usize, mmio_size)?;
     let pm = RockchipPM::new(mmio_base, board);
+    let pm = PowerDrv {
+        pm,
+        parents: domain_parent_map(info.node),
+    };
 
-    plat_dev.register(pm);
-    info!("Rockchip power manager registered successfully");
+    plat_dev.register(rdif_power::Power::new(pm));
+    info!("Rockchip power-domain provider registered successfully");
     Ok(())
 }
 
-pub fn rk3588_enable_power_domain(domain: usize) -> Result<(), alloc::string::String> {
-    let pm = rdrive::get_one::<RockchipPM>()
-        .ok_or_else(|| alloc::format!("RockchipPM not found for power domain {domain}"))?;
-    let mut pm = pm
-        .lock()
-        .map_err(|err| alloc::format!("failed to lock RockchipPM: {err}"))?;
+struct PowerDrv {
+    pm: RockchipPM,
+    parents: BTreeMap<PowerDomainId, PowerDomainId>,
+}
 
-    pm.power_domain_on(PowerDomain(domain))
-        .map_err(|err| alloc::format!("{err:?}"))
+impl DriverGeneric for PowerDrv {
+    fn name(&self) -> &str {
+        "Rockchip-Power"
+    }
+}
+
+impl PowerInterface for PowerDrv {
+    fn power_on(&mut self, id: PowerDomainId) -> Result<(), PowerError> {
+        let mut path = Vec::new();
+        self.collect_power_on_path(id, &mut path)?;
+        for domain in path.into_iter().rev() {
+            self.pm
+                .power_domain_on(to_rockchip_domain(domain)?)
+                .map_err(map_pm_error)?;
+            debug!("Rockchip power domain {:#x} enabled", domain.raw());
+        }
+        Ok(())
+    }
+
+    fn power_off(&mut self, id: PowerDomainId) -> Result<(), PowerError> {
+        self.pm
+            .power_domain_off(to_rockchip_domain(id)?)
+            .map_err(map_pm_error)
+    }
+}
+
+impl PowerDrv {
+    fn collect_power_on_path(
+        &self,
+        id: PowerDomainId,
+        path: &mut Vec<PowerDomainId>,
+    ) -> Result<(), PowerError> {
+        if path.contains(&id) {
+            return Err(PowerError::Controller);
+        }
+        path.push(id);
+        if let Some(parent) = self.parents.get(&id).copied() {
+            self.collect_power_on_path(parent, path)?;
+        }
+        Ok(())
+    }
+}
+
+fn to_rockchip_domain(id: PowerDomainId) -> Result<PowerDomain, PowerError> {
+    usize::try_from(id.raw())
+        .map(PowerDomain)
+        .map_err(|_| PowerError::InvalidId)
+}
+
+fn map_pm_error(error: PmError) -> PowerError {
+    match error {
+        PmError::DomainNotFound => PowerError::InvalidId,
+        PmError::Timeout => PowerError::Busy,
+        PmError::HardwareError => PowerError::Controller,
+    }
+}
+
+fn domain_parent_map(
+    root: rdrive::probe::fdt::NodeType<'_>,
+) -> BTreeMap<PowerDomainId, PowerDomainId> {
+    let mut children = |node| rdrive::probe::fdt::child_nodes(node);
+    domain_parent_map_with(root, &mut children)
+}
+
+fn domain_parent_map_with<'a>(
+    root: rdrive::probe::fdt::NodeType<'a>,
+    children: &mut impl FnMut(rdrive::probe::fdt::NodeType<'a>) -> Vec<rdrive::probe::fdt::NodeType<'a>>,
+) -> BTreeMap<PowerDomainId, PowerDomainId> {
+    let mut parents = BTreeMap::new();
+    collect_domain_parents(root, None, children, &mut parents);
+    parents
+}
+
+fn collect_domain_parents<'a>(
+    node: rdrive::probe::fdt::NodeType<'a>,
+    parent: Option<PowerDomainId>,
+    children: &mut impl FnMut(rdrive::probe::fdt::NodeType<'a>) -> Vec<rdrive::probe::fdt::NodeType<'a>>,
+    parents: &mut BTreeMap<PowerDomainId, PowerDomainId>,
+) {
+    let current = domain_id(node);
+    if let (Some(id), Some(parent)) = (current, parent) {
+        parents.insert(id, parent);
+    }
+    let next_parent = current.or(parent);
+    for child in children(node) {
+        collect_domain_parents(child, next_parent, children, parents);
+    }
+}
+
+fn domain_id(node: rdrive::probe::fdt::NodeType<'_>) -> Option<PowerDomainId> {
+    node.as_node()
+        .get_property("reg")
+        .and_then(|prop| prop.get_u32())
+        .map(PowerDomainId::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use fdt_edit::{Fdt, Node, Property};
+
+    use super::*;
+
+    #[test]
+    fn domain_parent_map_reads_power_controller_tree() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        let provider = fdt.add_node(root, Node::new("power-controller"));
+        let npu = fdt.add_node(
+            provider,
+            node_with_props("power-domain@8", &[prop_u32s("reg", &[8])]),
+        );
+        let nputop = fdt.add_node(
+            npu,
+            node_with_props("power-domain@9", &[prop_u32s("reg", &[9])]),
+        );
+        fdt.add_node(
+            nputop,
+            node_with_props("power-domain@10", &[prop_u32s("reg", &[10])]),
+        );
+        fdt.add_node(
+            nputop,
+            node_with_props("power-domain@11", &[prop_u32s("reg", &[11])]),
+        );
+
+        let mut children = |node: rdrive::probe::fdt::NodeType<'_>| {
+            node.as_node()
+                .children()
+                .iter()
+                .filter_map(|child_id| {
+                    let child_name = fdt.node(*child_id)?.name();
+                    fdt.get_by_path(&alloc::format!("{}/{}", node.path(), child_name))
+                })
+                .collect()
+        };
+        let parents =
+            domain_parent_map_with(fdt.get_by_path("/power-controller").unwrap(), &mut children);
+
+        assert_eq!(
+            parents.get(&PowerDomainId::new(9)),
+            Some(&PowerDomainId::new(8))
+        );
+        assert_eq!(
+            parents.get(&PowerDomainId::new(10)),
+            Some(&PowerDomainId::new(9))
+        );
+        assert_eq!(
+            parents.get(&PowerDomainId::new(11)),
+            Some(&PowerDomainId::new(9))
+        );
+    }
+
+    fn node_with_props(name: &str, props: &[Property]) -> Node {
+        let mut node = Node::new(name);
+        for prop in props {
+            node.set_property(prop.clone());
+        }
+        node
+    }
+
+    fn prop_u32s(name: &str, values: &[u32]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        Property::new(name, data)
+    }
 }

--- a/drivers/ax-driver/src/usb/dwc.rs
+++ b/drivers/ax-driver/src/usb/dwc.rs
@@ -20,13 +20,11 @@ use rdrive::{
     },
     register::{FdtInfo, ProbeFdt},
 };
-use rockchip_pm::{PowerDomain, RockchipPM};
 
 use super::{ProbeFdtUsbHost, usb_kernel};
 use crate::{mmio::iomap, soc::rk3588_enable_clock};
 
 const DRIVER_NAME: &str = "usb-dwc-xhci";
-const OPTIONAL_PHP_POWER_DOMAIN: usize = 32;
 
 crate::model_register!(
     name: "USB DWC xHCI",
@@ -92,7 +90,6 @@ struct UsbdpPhyResources {
 
 struct DwcResources {
     ctrl: RegFixed,
-    power_domains: Vec<usize>,
     clocks: Vec<ClockSpec>,
     ctrl_resets: Vec<NamedResetLine>,
     usb2: Usb2PhyResources,
@@ -120,7 +117,6 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let fdt = live_fdt()?;
     let resources = collect_resources(info, &fdt)?;
 
-    enable_power_domains(&resources.power_domains)?;
     enable_clocks(&resources.clocks);
 
     let ctrl = map_reg(resources.ctrl)?;
@@ -198,7 +194,6 @@ fn collect_resources(info: &FdtInfo<'_>, fdt: &Fdt) -> Result<DwcResources, OnPr
 
     Ok(DwcResources {
         ctrl,
-        power_domains: parse_power_domains(info.node.as_node())?,
         clocks,
         ctrl_resets: parse_resets(info.node)?,
         usb2,
@@ -280,21 +275,6 @@ fn parse_phys(node: &Node) -> Result<(Phandle, Phandle), OnProbeError> {
         )));
     }
     Ok((phys[0], phys[1]))
-}
-
-fn parse_power_domains(node: &Node) -> Result<Vec<usize>, OnProbeError> {
-    let Some(prop) = node.get_property("power-domains") else {
-        return Ok(Vec::new());
-    };
-    let cells = prop.get_u32_iter().collect::<Vec<_>>();
-    if cells.len() % 2 != 0 {
-        return Err(OnProbeError::other(format!(
-            "[{}] has malformed power-domains",
-            node.name()
-        )));
-    }
-
-    Ok(cells.chunks(2).map(|chunk| chunk[1] as usize).collect())
 }
 
 fn parse_resets(node: NodeType<'_>) -> Result<Vec<NamedResetLine>, OnProbeError> {
@@ -379,30 +359,6 @@ fn parse_dwc_params(node: &Node) -> DwcParams {
     );
 
     params
-}
-
-fn enable_power_domains(domains: &[usize]) -> Result<(), OnProbeError> {
-    let pm = rdrive::get_one::<RockchipPM>()
-        .ok_or_else(|| OnProbeError::other("RockchipPM not found for DWC xHCI"))?;
-    let mut pm = pm
-        .lock()
-        .map_err(|err| OnProbeError::other(format!("failed to lock RockchipPM: {err}")))?;
-
-    for &domain in domains {
-        pm.power_domain_on(PowerDomain(domain)).map_err(|err| {
-            OnProbeError::other(format!("failed to enable power domain {domain}: {err:?}"))
-        })?;
-        info!("DWC xHCI power domain {domain} enabled");
-    }
-
-    if !domains.contains(&OPTIONAL_PHP_POWER_DOMAIN) {
-        match pm.power_domain_on(PowerDomain(OPTIONAL_PHP_POWER_DOMAIN)) {
-            Ok(()) => info!("DWC xHCI optional PHP power domain enabled"),
-            Err(err) => warn!("DWC xHCI optional PHP power domain enable failed: {err:?}"),
-        }
-    }
-
-    Ok(())
 }
 
 fn enable_clocks(clocks: &[ClockSpec]) {

--- a/drivers/ax-driver/src/usb/ehci.rs
+++ b/drivers/ax-driver/src/usb/ehci.rs
@@ -19,10 +19,7 @@ use rdrive::{
 };
 
 use super::{ProbeFdtUsbHost, usb_kernel};
-use crate::{
-    mmio::iomap,
-    soc::{rk3588_enable_clock, rk3588_enable_power_domain},
-};
+use crate::{mmio::iomap, soc::rk3588_enable_clock};
 
 const DRIVER_NAME: &str = "usb-rockchip-ehci";
 
@@ -46,7 +43,6 @@ struct ClockSpec {
 
 struct EhciResources {
     ctrl: RegFixed,
-    power_domains: Vec<usize>,
     clocks: Vec<ClockSpec>,
     resets: Vec<ResetLine>,
 }
@@ -56,7 +52,6 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let fdt = live_fdt()?;
     let resources = collect_resources(info, &fdt)?;
 
-    enable_power_domains(&resources.power_domains)?;
     enable_clocks(&resources.clocks);
     deassert_resets(&resources.resets);
 
@@ -100,7 +95,6 @@ fn collect_resources(info: &FdtInfo<'_>, fdt: &Fdt) -> Result<EhciResources, OnP
 
     Ok(EhciResources {
         ctrl,
-        power_domains: parse_power_domains(info.node.as_node())?,
         clocks,
         resets,
     })
@@ -125,35 +119,8 @@ fn collect_usb2_phys<'a>(node: &Node, fdt: &'a Fdt) -> Vec<Usb2PhyNode<'a>> {
         .collect()
 }
 
-fn parse_power_domains(node: &Node) -> Result<Vec<usize>, OnProbeError> {
-    let Some(prop) = node.get_property("power-domains") else {
-        return Ok(Vec::new());
-    };
-    let cells = prop.get_u32_iter().collect::<Vec<_>>();
-    if cells.len() % 2 != 0 {
-        return Err(OnProbeError::other(format!(
-            "[{}] has malformed power-domains",
-            node.name()
-        )));
-    }
-
-    Ok(cells.chunks(2).map(|chunk| chunk[1] as usize).collect())
-}
-
 fn parse_resets(node: NodeType<'_>) -> Result<Vec<ResetLine>, OnProbeError> {
     reset_lines(node)
-}
-
-fn enable_power_domains(domains: &[usize]) -> Result<(), OnProbeError> {
-    for &domain in domains {
-        rk3588_enable_power_domain(domain).map_err(|err| {
-            OnProbeError::other(format!(
-                "failed to enable EHCI power domain {domain}: {err}"
-            ))
-        })?;
-        info!("EHCI power domain {domain} enabled");
-    }
-    Ok(())
 }
 
 fn enable_clocks(clocks: &[ClockSpec]) {

--- a/drivers/interface/rdif-power/Cargo.toml
+++ b/drivers/interface/rdif-power/Cargo.toml
@@ -11,3 +11,4 @@ categories = ["embedded", "no-std"]
 
 [dependencies]
 rdif-base = { workspace = true }
+thiserror = { version = "2", default-features = false }

--- a/drivers/interface/rdif-power/src/lib.rs
+++ b/drivers/interface/rdif-power/src/lib.rs
@@ -3,10 +3,141 @@
 extern crate alloc;
 
 use rdif_base::def_driver;
-pub use rdif_base::{DriverGeneric, KError};
+pub use rdif_base::{DriverGeneric, custom_type};
+
+custom_type!(
+    #[doc = "Power domain id"],
+    PowerDomainId, u64, "{:#x}");
+
+impl PowerDomainId {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<u32> for PowerDomainId {
+    fn from(value: u32) -> Self {
+        Self(u64::from(value))
+    }
+}
+
+impl From<usize> for PowerDomainId {
+    fn from(value: usize) -> Self {
+        Self(value as u64)
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PowerError {
+    #[error("invalid power domain id")]
+    InvalidId,
+    #[error("unsupported power operation")]
+    Unsupported,
+    #[error("power controller is busy")]
+    Busy,
+    #[error("power controller error")]
+    Controller,
+}
 
 pub trait Interface: DriverGeneric {
-    fn shutdown(&mut self);
+    fn power_on(&mut self, id: PowerDomainId) -> Result<(), PowerError>;
+
+    fn power_off(&mut self, id: PowerDomainId) -> Result<(), PowerError>;
+
+    fn is_powered(&self, _id: PowerDomainId) -> Result<bool, PowerError> {
+        Err(PowerError::Unsupported)
+    }
 }
 
 def_driver!(Power, Interface);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct RecordingPower {
+        powered: bool,
+        calls: alloc::vec::Vec<(&'static str, PowerDomainId)>,
+    }
+
+    impl DriverGeneric for RecordingPower {
+        fn name(&self) -> &str {
+            "recording-power"
+        }
+    }
+
+    impl Interface for RecordingPower {
+        fn power_on(&mut self, id: PowerDomainId) -> Result<(), PowerError> {
+            self.powered = true;
+            self.calls.push(("on", id));
+            Ok(())
+        }
+
+        fn power_off(&mut self, id: PowerDomainId) -> Result<(), PowerError> {
+            self.powered = false;
+            self.calls.push(("off", id));
+            Ok(())
+        }
+
+        fn is_powered(&self, _id: PowerDomainId) -> Result<bool, PowerError> {
+            Ok(self.powered)
+        }
+    }
+
+    #[test]
+    fn power_domain_id_conversions_preserve_raw_value() {
+        assert_eq!(PowerDomainId::new(7).raw(), 7);
+        assert_eq!(PowerDomainId::from(8_u32).raw(), 8);
+        assert_eq!(PowerDomainId::from(9_usize).raw(), 9);
+        assert_eq!(PowerDomainId::from(10_u64).raw(), 10);
+    }
+
+    #[test]
+    fn power_domain_operations_are_dispatched_to_inner_driver() {
+        let mut power = Power::new(RecordingPower {
+            powered: false,
+            calls: alloc::vec::Vec::new(),
+        });
+
+        power.power_on(PowerDomainId::new(3)).unwrap();
+        assert_eq!(power.is_powered(PowerDomainId::new(3)), Ok(true));
+        power.power_off(PowerDomainId::new(3)).unwrap();
+        assert_eq!(power.is_powered(PowerDomainId::new(3)), Ok(false));
+
+        let inner = power.typed_ref::<RecordingPower>().unwrap();
+        assert_eq!(
+            inner.calls,
+            alloc::vec![
+                ("on", PowerDomainId::new(3)),
+                ("off", PowerDomainId::new(3))
+            ]
+        );
+    }
+
+    #[test]
+    fn default_is_powered_reports_unsupported() {
+        struct MinimalPower;
+
+        impl DriverGeneric for MinimalPower {
+            fn name(&self) -> &str {
+                "minimal-power"
+            }
+        }
+
+        impl Interface for MinimalPower {
+            fn power_on(&mut self, _id: PowerDomainId) -> Result<(), PowerError> {
+                Ok(())
+            }
+
+            fn power_off(&mut self, _id: PowerDomainId) -> Result<(), PowerError> {
+                Ok(())
+            }
+        }
+
+        let power = MinimalPower;
+        assert_eq!(
+            power.is_powered(PowerDomainId::new(1)),
+            Err(PowerError::Unsupported)
+        );
+    }
+}

--- a/drivers/rdrive/Cargo.toml
+++ b/drivers/rdrive/Cargo.toml
@@ -24,6 +24,7 @@ pcie.workspace = true
 
 rdif-base = { workspace = true }
 rdif-pinctrl = { workspace = true, features = ["fdt"] }
+rdif-power = { workspace = true }
 rdif-reset = { workspace = true }
 rdrive-macros.workspace = true
 rdif-pcie = { workspace = true }

--- a/drivers/rdrive/src/probe/fdt/mod.rs
+++ b/drivers/rdrive/src/probe/fdt/mod.rs
@@ -74,6 +74,22 @@ impl ResetRef {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PowerDomainRef {
+    pub name: Option<String>,
+    pub phandle: Phandle,
+    pub cells: u32,
+    pub specifier: Vec<u32>,
+}
+
+impl PowerDomainRef {
+    pub fn select(&self) -> Option<u32> {
+        (self.cells > 0)
+            .then(|| self.specifier.first().copied())
+            .flatten()
+    }
+}
+
 #[derive(Clone)]
 pub struct ResetLine {
     node_name: String,
@@ -178,10 +194,135 @@ impl ResetLine {
     }
 }
 
+#[derive(Clone)]
+pub struct PowerDomainLine {
+    node_name: String,
+    name: Option<String>,
+    device: Device<rdif_power::Power>,
+    id: rdif_power::PowerDomainId,
+}
+
+impl PowerDomainLine {
+    fn from_refs(node_name: &str, refs: Vec<PowerDomainRef>) -> Result<Vec<Self>, OnProbeError> {
+        refs.into_iter()
+            .map(|domain| Self::from_ref(node_name, &domain))
+            .collect()
+    }
+
+    fn from_ref(node_name: &str, domain: &PowerDomainRef) -> Result<Self, OnProbeError> {
+        if domain.cells != 1 {
+            return Err(OnProbeError::other(format!(
+                "[{node_name}] power domain {} uses {} cells, only one-cell power-domain \
+                 selectors are supported",
+                power_domain_label(domain),
+                domain.cells
+            )));
+        }
+        let selector = domain.select().ok_or_else(|| {
+            OnProbeError::other(format!(
+                "[{node_name}] power domain {} has no selector",
+                power_domain_label(domain)
+            ))
+        })?;
+        let provider_id = system()
+            .phandle_to_device_id(domain.phandle)
+            .ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{node_name}] power-domain provider phandle {:?} is not populated",
+                    domain.phandle
+                ))
+            })?;
+        let device = crate::get::<rdif_power::Power>(provider_id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{node_name}] power-domain provider {:?} has no rdif-power interface: {err}",
+                domain.phandle
+            ))
+        })?;
+
+        Ok(Self {
+            node_name: node_name.to_string(),
+            name: domain.name.clone(),
+            device,
+            id: rdif_power::PowerDomainId::from(selector),
+        })
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub fn id(&self) -> rdif_power::PowerDomainId {
+        self.id
+    }
+
+    pub fn power_on(&self) -> Result<(), OnProbeError> {
+        self.with_power("power on", |power, id| power.power_on(id))
+    }
+
+    pub fn power_off(&self) -> Result<(), OnProbeError> {
+        self.with_power("power off", |power, id| power.power_off(id))
+    }
+
+    pub fn is_powered(&self) -> Result<bool, OnProbeError> {
+        let power = self.device.lock().map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to lock power domain {}: {err}",
+                self.node_name,
+                self.label()
+            ))
+        })?;
+        power.is_powered(self.id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to query power domain {}: {err}",
+                self.node_name,
+                self.label()
+            ))
+        })
+    }
+
+    fn with_power(
+        &self,
+        operation: &'static str,
+        f: impl FnOnce(
+            &mut rdif_power::Power,
+            rdif_power::PowerDomainId,
+        ) -> Result<(), rdif_power::PowerError>,
+    ) -> Result<(), OnProbeError> {
+        let mut power = self.device.lock().map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to lock power domain {}: {err}",
+                self.node_name,
+                self.label()
+            ))
+        })?;
+        f(&mut power, self.id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to {operation} power domain {}: {err}",
+                self.node_name,
+                self.label()
+            ))
+        })
+    }
+
+    fn label(&self) -> String {
+        match self.name() {
+            Some(name) => format!("{name}({:#x})", self.id.raw()),
+            None => format!("{:#x}", self.id.raw()),
+        }
+    }
+}
+
 fn reset_label(reset: &ResetRef) -> String {
     match reset.name.as_deref() {
         Some(name) => name.to_string(),
         None => format!("phandle {:?}", reset.phandle),
+    }
+}
+
+fn power_domain_label(domain: &PowerDomainRef) -> String {
+    match domain.name.as_deref() {
+        Some(name) => name.to_string(),
+        None => format!("phandle {:?}", domain.phandle),
     }
 }
 
@@ -244,9 +385,101 @@ pub fn reset_refs(node: NodeType<'_>) -> Result<Vec<ResetRef>, OnProbeError> {
     Ok(refs)
 }
 
+fn power_domain_refs_from_node(
+    node: NodeType<'_>,
+    mut provider_cells: impl FnMut(Phandle) -> Result<(String, u32), OnProbeError>,
+) -> Result<Vec<PowerDomainRef>, OnProbeError> {
+    let Some(prop) = node.as_node().get_property("power-domains") else {
+        return Ok(Vec::new());
+    };
+    let domain_names = node
+        .as_node()
+        .get_property("power-domain-names")
+        .map(|prop| {
+            prop.as_str_iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut reader = prop.as_reader();
+    let mut refs = Vec::new();
+    let mut index = 0;
+    while let Some(phandle_raw) = reader.read_u32() {
+        let phandle = Phandle::from(phandle_raw);
+        let (_provider_name, cells) = provider_cells(phandle)?;
+
+        let mut specifier = Vec::with_capacity(cells as usize);
+        for _ in 0..cells {
+            let value = reader.read_u32().ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] has truncated power-domains entry for phandle {phandle:?}",
+                    node.name()
+                ))
+            })?;
+            specifier.push(value);
+        }
+
+        refs.push(PowerDomainRef {
+            name: domain_names.get(index).cloned(),
+            phandle,
+            cells,
+            specifier,
+        });
+        index += 1;
+    }
+    Ok(refs)
+}
+
+pub fn power_domain_refs(node: NodeType<'_>) -> Result<Vec<PowerDomainRef>, OnProbeError> {
+    power_domain_refs_from_node(node, |phandle| {
+        let provider = system().get_by_phandle(phandle).ok_or_else(|| {
+            OnProbeError::other(format!(
+                "[{}] power-domain provider phandle {phandle:?} not found",
+                node.name()
+            ))
+        })?;
+        let cells = provider
+            .as_node()
+            .get_property("#power-domain-cells")
+            .and_then(|prop| prop.get_u32())
+            .ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] power-domain provider {} has no #power-domain-cells",
+                    node.name(),
+                    provider.name()
+                ))
+            })?;
+
+        Ok((provider.name().to_string(), cells))
+    })
+}
+
 pub fn reset_lines(node: NodeType<'_>) -> Result<Vec<ResetLine>, OnProbeError> {
     let refs = reset_refs(node)?;
     ResetLine::from_refs(node.name(), refs)
+}
+
+pub fn power_domain_lines(node: NodeType<'_>) -> Result<Vec<PowerDomainLine>, OnProbeError> {
+    let refs = power_domain_refs(node)?;
+    PowerDomainLine::from_refs(node.name(), refs)
+}
+
+pub fn child_nodes(node: NodeType<'_>) -> Vec<NodeType<'static>> {
+    let parent_path = node.path();
+    node.as_node()
+        .children()
+        .iter()
+        .filter_map(|child_id| {
+            let child_name = system().fdt().node(*child_id)?.name();
+            let child_path = if parent_path == "/" {
+                format!("/{child_name}")
+            } else {
+                format!("{parent_path}/{child_name}")
+            };
+            system().fdt().get_by_path(&child_path)
+        })
+        .collect()
 }
 
 impl<'a> FdtInfo<'a> {
@@ -291,9 +524,44 @@ impl<'a> FdtInfo<'a> {
             .find(|reset| reset.name() == Some(name)))
     }
 
+    pub fn power_domains(&self) -> Result<Vec<PowerDomainRef>, OnProbeError> {
+        power_domain_refs(self.node)
+    }
+
+    pub fn find_power_domain_by_name(
+        &self,
+        name: &str,
+    ) -> Result<Option<PowerDomainRef>, OnProbeError> {
+        Ok(self
+            .power_domains()?
+            .into_iter()
+            .find(|domain| domain.name.as_deref() == Some(name)))
+    }
+
+    pub fn power_domain_lines(&self) -> Result<Vec<PowerDomainLine>, OnProbeError> {
+        power_domain_lines(self.node)
+    }
+
+    pub fn find_power_domain_line_by_name(
+        &self,
+        name: &str,
+    ) -> Result<Option<PowerDomainLine>, OnProbeError> {
+        Ok(self
+            .power_domain_lines()?
+            .into_iter()
+            .find(|domain| domain.name() == Some(name)))
+    }
+
     pub fn interrupts(&self) -> Vec<InterruptRef> {
         self.node.interrupts()
     }
+}
+
+fn apply_power_domains(node: NodeType<'_>) -> Result<(), OnProbeError> {
+    for domain in power_domain_lines(node)? {
+        domain.power_on()?;
+    }
+    Ok(())
 }
 
 fn apply_default_pinctrl(node: NodeType<'_>) -> Result<(), OnProbeError> {
@@ -462,21 +730,23 @@ impl System {
             let phandle_map = self.phandle_2_device_id.clone();
 
             debug!("Probe [{}]->[{}]", node.name(), node_info.name);
-            let res = apply_default_pinctrl(node).and_then(|()| {
-                let descriptor = Descriptor {
-                    name: node_info.name,
-                    device_id: id,
-                    irq_parent,
-                };
+            let res = apply_power_domains(node)
+                .and_then(|()| apply_default_pinctrl(node))
+                .and_then(|()| {
+                    let descriptor = Descriptor {
+                        name: node_info.name,
+                        device_id: id,
+                        irq_parent,
+                    };
 
-                (node_info.on_probe)(ProbeFdt::new(
-                    FdtInfo {
-                        node,
-                        phandle_2_device_id: phandle_map,
-                    },
-                    PlatformDevice::new(descriptor),
-                ))
-            });
+                    (node_info.on_probe)(ProbeFdt::new(
+                        FdtInfo {
+                            node,
+                            phandle_2_device_id: phandle_map,
+                        },
+                        PlatformDevice::new(descriptor),
+                    ))
+                });
 
             if res.is_ok() {
                 self.populated_paths.lock().insert(node.path(), id);
@@ -494,4 +764,121 @@ struct ProbeFdtInfo<'a> {
     name: &'static str,
     node: NodeType<'a>,
     on_probe: FnOnProbe,
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, vec};
+
+    use fdt_edit::{Node, Property};
+
+    use super::*;
+
+    #[test]
+    fn power_domain_refs_parse_names_and_provider_cells() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props(
+                "power-controller",
+                &[
+                    prop_u32s("phandle", &[0x61]),
+                    prop_u32s("#power-domain-cells", &[1]),
+                ],
+            ),
+        );
+        let consumer = fdt.add_node(
+            root,
+            node_with_props(
+                "npu@fdab0000",
+                &[
+                    prop_u32s("power-domains", &[0x61, 9, 0x61, 10, 0x61, 11]),
+                    prop_strs("power-domain-names", &["npu0", "npu1", "npu2"]),
+                ],
+            ),
+        );
+
+        let refs =
+            power_domain_refs_from_node(fdt.get_by_path("/npu@fdab0000").unwrap(), |phandle| {
+                fdt.get_by_phandle(phandle)
+                    .and_then(|provider| {
+                        provider
+                            .as_node()
+                            .get_property("#power-domain-cells")
+                            .and_then(|prop| prop.get_u32())
+                            .map(|cells| (provider.name().to_string(), cells))
+                    })
+                    .ok_or_else(|| OnProbeError::other(format!("missing provider {phandle:?}")))
+            })
+            .unwrap();
+
+        assert_eq!(
+            refs,
+            vec![
+                PowerDomainRef {
+                    name: Some("npu0".into()),
+                    phandle: Phandle::from(0x61),
+                    cells: 1,
+                    specifier: vec![9],
+                },
+                PowerDomainRef {
+                    name: Some("npu1".into()),
+                    phandle: Phandle::from(0x61),
+                    cells: 1,
+                    specifier: vec![10],
+                },
+                PowerDomainRef {
+                    name: Some("npu2".into()),
+                    phandle: Phandle::from(0x61),
+                    cells: 1,
+                    specifier: vec![11],
+                },
+            ]
+        );
+        assert_eq!(fdt.node(consumer).unwrap().name(), "npu@fdab0000");
+    }
+
+    #[test]
+    fn power_domain_refs_reject_truncated_provider_specifier() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        let consumer = fdt.add_node(
+            root,
+            node_with_props("jpeg@fdba0000", &[prop_u32s("power-domains", &[0x61])]),
+        );
+
+        let err = power_domain_refs_from_node(fdt.get_by_path("/jpeg@fdba0000").unwrap(), |_| {
+            Ok(("power-controller".into(), 1))
+        })
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("truncated power-domains entry"));
+        assert_eq!(fdt.node(consumer).unwrap().name(), "jpeg@fdba0000");
+    }
+
+    fn node_with_props(name: &str, props: &[Property]) -> Node {
+        let mut node = Node::new(name);
+        for prop in props {
+            node.set_property(prop.clone());
+        }
+        node
+    }
+
+    fn prop_u32s(name: &str, values: &[u32]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        Property::new(name, data)
+    }
+
+    fn prop_strs(name: &str, values: &[&str]) -> Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(value.as_bytes());
+            data.push(0);
+        }
+        Property::new(name, data)
+    }
 }

--- a/drivers/rdrive/tests/fdt_power.rs
+++ b/drivers/rdrive/tests/fdt_power.rs
@@ -1,0 +1,182 @@
+use core::ptr::NonNull;
+use std::{
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    vec,
+    vec::Vec,
+};
+
+use fdt_edit::{Fdt, Node, Property};
+use rdif_power::{PowerDomainId, PowerError};
+use rdrive::{
+    DriverGeneric, Platform, get_one,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+static POWER_CALLS: Mutex<Vec<PowerCall>> = Mutex::new(Vec::new());
+static POWERED_BEFORE_PROBE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, PartialEq, Eq)]
+struct PowerCall {
+    operation: &'static str,
+    id: u64,
+}
+
+struct PowerProviderDevice;
+struct PowerConsumerDevice;
+
+impl DriverGeneric for PowerProviderDevice {
+    fn name(&self) -> &str {
+        "power-provider"
+    }
+}
+
+impl rdif_power::Interface for PowerProviderDevice {
+    fn power_on(&mut self, id: PowerDomainId) -> Result<(), PowerError> {
+        POWER_CALLS.lock().unwrap().push(PowerCall {
+            operation: "on",
+            id: id.raw(),
+        });
+        Ok(())
+    }
+
+    fn power_off(&mut self, id: PowerDomainId) -> Result<(), PowerError> {
+        POWER_CALLS.lock().unwrap().push(PowerCall {
+            operation: "off",
+            id: id.raw(),
+        });
+        Ok(())
+    }
+}
+
+impl DriverGeneric for PowerConsumerDevice {
+    fn name(&self) -> &str {
+        "power-consumer"
+    }
+}
+
+fn probe_power_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_power::Power::new(PowerProviderDevice));
+    Ok(())
+}
+
+fn probe_power_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let domain = probe
+        .info()
+        .find_power_domain_by_name("core")?
+        .ok_or_else(|| OnProbeError::other("core power domain not found"))?;
+    POWERED_BEFORE_PROBE.store(
+        domain.specifier == vec![7]
+            && POWER_CALLS.lock().unwrap().as_slice()
+                == [PowerCall {
+                    operation: "on",
+                    id: 7,
+                }],
+        Ordering::SeqCst,
+    );
+    probe.into_platform_device().register(PowerConsumerDevice);
+    Ok(())
+}
+
+static POWER_PROVIDER_REGISTER: DriverRegister = DriverRegister {
+    name: "test power provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,power-provider"],
+        on_probe: probe_power_provider,
+    }],
+};
+
+static POWER_CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test power consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,power-consumer"],
+        on_probe: probe_power_consumer,
+    }],
+};
+
+#[test]
+fn fdt_probe_powers_domains_before_consumer_probe() {
+    POWER_CALLS.lock().unwrap().clear();
+    POWERED_BEFORE_PROBE.store(false, Ordering::SeqCst);
+
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "power-controller",
+            &[
+                prop_strs("compatible", &["test,power-provider"]),
+                prop_u32s("phandle", &[1]),
+                prop_u32s("#power-domain-cells", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "device@2000",
+            &[
+                prop_strs("compatible", &["test,power-consumer"]),
+                prop_u32s("power-domains", &[1, 7]),
+                prop_strs("power-domain-names", &["core"]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(POWER_PROVIDER_REGISTER.clone());
+    rdrive::register_add(POWER_CONSUMER_REGISTER.clone());
+
+    probe_all(true).expect("FDT probe should succeed");
+
+    assert!(POWERED_BEFORE_PROBE.load(Ordering::SeqCst));
+    assert!(get_one::<PowerConsumerDevice>().is_some());
+    assert_eq!(
+        *POWER_CALLS.lock().unwrap(),
+        vec![PowerCall {
+            operation: "on",
+            id: 7,
+        }]
+    );
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/soc/rockchip/rockchip-pm/src/lib.rs
+++ b/drivers/soc/rockchip/rockchip-pm/src/lib.rs
@@ -23,10 +23,10 @@
 //! let mut pm = RockchipPM::new(base, RkBoard::Rk3588);
 //!
 //! // Turn on NPU power domain
-//! pm.power_domain_on(PowerDomain::NPU).unwrap();
+//! pm.power_domain_on(PowerDomain(8)).unwrap();
 //!
 //! // Turn off NPU power domain
-//! pm.power_domain_off(PowerDomain::NPU).unwrap();
+//! pm.power_domain_off(PowerDomain(8)).unwrap();
 //! ```
 
 extern crate alloc;
@@ -155,7 +155,7 @@ impl RockchipPM {
     /// # let base = unsafe { NonNull::new_unchecked(0xfd5d8000 as *mut u8) };
     /// # let pm = RockchipPM::new(base, RkBoard::Rk3588);
     /// let domain = pm.get_power_dowain_by_name("npu");
-    /// assert_eq!(domain, Some(PowerDomain::NPU));
+    /// assert_eq!(domain, Some(PowerDomain(8)));
     /// ```
     pub fn get_power_dowain_by_name(&self, name: &str) -> Option<PowerDomain> {
         for (domain, info) in &self.info.domains {
@@ -187,7 +187,7 @@ impl RockchipPM {
     /// # use core::ptr::NonNull;
     /// # let base = unsafe { NonNull::new_unchecked(0xfd5d8000 as *mut u8) };
     /// # let mut pm = RockchipPM::new(base, RkBoard::Rk3588);
-    /// pm.power_domain_on(PowerDomain::NPU).unwrap();
+    /// pm.power_domain_on(PowerDomain(8)).unwrap();
     /// ```
     pub fn power_domain_on(&mut self, domain: PowerDomain) -> PmResult<()> {
         self.set_power_domain(domain, true)
@@ -214,7 +214,7 @@ impl RockchipPM {
     /// # use core::ptr::NonNull;
     /// # let base = unsafe { NonNull::new_unchecked(0xfd5d8000 as *mut u8) };
     /// # let mut pm = RockchipPM::new(base, RkBoard::Rk3588);
-    /// pm.power_domain_off(PowerDomain::NPU).unwrap();
+    /// pm.power_domain_off(PowerDomain(8)).unwrap();
     /// ```
     pub fn power_domain_off(&mut self, domain: PowerDomain) -> PmResult<()> {
         self.set_power_domain(domain, false)


### PR DESCRIPTION
## 问题

当前 Rockchip 设备的 power-domain consumer 仍分散在 ax-driver 各个 probe 路径里，部分驱动直接持有 `RockchipPM` 或调用全局 helper，并且存在硬编码 domain id。这样会让 power-domain 所有权和 FDT 描述脱节，也会让后续 clock/reset/power capability 分层继续变复杂。

## 改动

- 重构 `rdif-power` 为通用 power-domain capability，新增 `PowerDomainId`、`PowerError` 和 `power_on/power_off/is_powered` 接口，删除旧 `shutdown()` 语义。
- 在 `rdrive::probe::fdt` 中新增 `PowerDomainRef` 与 `PowerDomainLine`，解析 `power-domains` / `power-domain-names`，并在 FDT driver probe 前自动执行 power-domain `power_on()`，顺序位于默认 pinctrl 之前。
- Rockchip PM provider 改为在 `rockchip,rk3588-power-controller` 节点注册 `rdif_power::Power`，从 provider 子树构建 domain parent map，`power_on()` 会递归开启父域。
- 迁移 PCIe、DWC USB3、EHCI、RK3588 SDHCI、Rockchip DWMMC、JPEG、RKNPU 等 consumer，删除本地 power-domain parser、全局 Rockchip power helper 和硬编码 domain id。
- 新增 `rdrive` FDT 自动 power-on 集成测试，并更新 `rockchip-pm` doctest 示例。

## 设计逻辑

- `rdrive` 只负责 FDT specifier 解析和 RDIF power capability 获取，具体寄存器语义仍留在 Rockchip PM provider。
- v1 仅支持 `#power-domain-cells = <1>` 的 numeric selector，多 cell provider 直接返回 probe error，避免猜测语义。
- FDT 中声明了 power domain 但 provider 未 probe 或未注册 `rdif_power::Power` 时，consumer probe 失败；未声明 `power-domains` 是正常路径。
- Rockchip NPU 等 leaf domain 的父域关系由 provider tree 表达，consumer 不再硬编码父域。

## 本地验证

- `cargo fmt --check`
- `cargo test -p rdif-power`
- `cargo test -p rdrive`
- `cargo test -p rockchip-pm`
- `cargo test -p ax-driver --features "rockchip-soc,rockchip-pm,rk3588-pcie,rockchip-dwc-xhci,rockchip-ehci,rockchip-sdhci,rockchip-dwmmc,jpeg,rknpu"`
- `cargo xtask clippy --package rdif-power`
- `cargo xtask clippy --package rdrive`
- `cargo xtask clippy --package rockchip-pm`
- `cargo xtask clippy --package ax-driver`
- `cargo clippy -p ax-driver --no-default-features --features "rockchip-soc,rockchip-pm,rk3588-pcie,rockchip-dwc-xhci,rockchip-ehci,rockchip-sdhci,rockchip-dwmmc,jpeg,rknpu" -- -D warnings`
- `git diff --check`

## Rebase

已基于最新 `origin/dev` (`53af7c0152460b4fb8bf9112a06b8dc50b44b4d3`) 重放本地改动；stash 应用时没有产生需要人工处理的冲突。