### PR TITLE
test(starry): add LLVM 22 toolchain carpet

### DIFF
--- a/apps/starry/llvm22/README.md
+++ b/apps/starry/llvm22/README.md
@@ -1,0 +1,70 @@
+# llvm22 - LLVM 22 工具链地毯式测试
+
+工业级、精确断言（exact-assertion）的 LLVM 22 工具链正确性测试：由 **musl 原生 LLVM 22.1.x**
+（Alpine `apk add llvm22 clang22 lld22 g++ ...`）在 StarryOS 四个架构（x86_64 / aarch64 / riscv64 /
+loongarch64）上运行真实的工具，针对一组 LLVM IR / C / C++ 测例，覆盖工业级测试的七个维度（文档逐项、
+`--help`/`--version`、逐选项单测、功能输出、边界输入、异常处理、集成流水线），每项一条精确断言。
+**不使用交叉编译产物替代**: `lli`、`llc`、`opt`、`clang`、`clang++`、`lld`、`llvm-ar` 等本体都在
+StarryOS 上真跑。
+
+| 工具 | 覆盖 | 断言数 |
+|:--|:--|:--:|
+| `llvm-config` | `--version` 主版本号 = 22；`--targets-built` 含 X86 / AArch64 / RISCV / LoongArch（交叉代码生成能力） | 5 |
+| 各工具 `--version` / `--help` | `llvm-as`/`llvm-dis`/`llvm-link`/`llvm-nm`/`llvm-objdump`/`llvm-ar`/`opt`/`llc`/`lli` 各自 `--version` 报告 `LLVM version 22.x`；`opt --print-passes` 列出 `mem2reg`+`instcombine`；`llc --version` 列出 aarch64+riscv64 目标；`FileCheck --help` 退出 0 | 12 |
+| `llvm-as` / `llvm-dis` | IR→bitcode（校验 `BC C0 DE` 魔数）；bitcode→IR（含 `@main`）；反汇编产物可重新汇编（往返稳定）；空模块（边界）仍产出合法 bitcode | 4 |
+| `lli`（JIT） | JIT 执行 `.ll`：hello 精确 stdout；算术表达式退出码；1..100 循环求和 = 5050；递归 `fib(10)` = 55；1000 条 add 链大 IR（边界）退出码 = 1000 & 255 = 232 | 5 |
+| `llc` | IR→本机汇编（`.globl main`）；IR→本机 ELF 目标（ELF 魔数 + `llvm-nm` 列出 `T main` + `llvm-objdump` 反汇编）；四个已构建目标交叉代码生成（`-mtriple=x86_64`/`aarch64`/`riscv64`/`loongarch64` 产物的 ELF `e_machine` 精确等于 62/183/243/258） | 8 |
+| `opt` | `-passes=mem2reg` 消除全部 alloca；`-O0` 保留 alloca（不优化）；`-O1`/`-O2`/`-O3`/`default<O2>` 提升为 SSA；`-passes=instcombine` 将 `(x*1)+0` 折叠为 `x`；`-passes=inline` 内联唯一调用点；`llvm-as \| opt \| llvm-dis` bitcode 流水线 | 10 |
+| `llvm-link` | 合并两个模块（`@funcA` + `@funcB` 同时出现） | 1 |
+| `llvm-ar` | `rcs` 建静态库（`!<arch>` 魔数）；`t` 列出成员；`llvm-nm` 读取库符号索引（funcA + funcB）；`x` 抽取成员 | 4 |
+| `FileCheck` | 正例匹配（退出 0）+ 反例（缺失模式必须失败，退出非 0，证明其真的在判别） | 2 |
+| `clang` | `--version` = 22.x；C→IR（`-emit-llvm`，含 `@main` + `@printf`）；`-std=c11`/`-std=gnu17` 方言；C→可执行文件（编译+链接+运行）；`-O2 -lm`（`sqrt(2)`） | 6 |
+| `clang++` | `--version` = 22.x；C++→IR（Itanium name mangling，`_ZN7Counter…`）；C++→可执行文件（模板 + 类 + STL `std::vector`/`std::string`，编译+链接+运行） | 3 |
+| `lld` | `ld.lld --version` = 22.x；`clang -fuse-ld=lld` 链接并运行 | 2 |
+| 异常处理 | 畸形 IR 被 `llvm-as`/`llc` 拒绝（退出非 0）；未知 pass 名被 `opt` 拒绝；缺失输入文件被 `lli` 拒绝 | 4 |
+| 集成流水线 | `clang -emit-llvm \| opt -O2 \| llc \| clang -fuse-ld=lld` 端到端编译运行；`opt -O2` 优化后的 IR 回灌 `lli` 仍算出 SUM=5050 | 2 |
+
+断言全部针对**与补丁版本无关的稳定不变量**（精确整数、闭式代数、bitcode 魔数、ELF `e_machine`、
+Itanium 符号名、固定 stdout 字符串），因此宿主参照工具与目标端 Alpine 工具（22.1.8）给出逐字相同的结果。
+`programs/run-llvm22.sh` 依次执行全部 68 项检查，仅当全部通过时才打印 `LLVM22_OK=68/68` 与
+`TEST PASSED`（尾部锚点仅在脚本内出现，success_regex 不会自匹配启动命令）；任一失败则打印 `TEST FAILED`。
+**不允许跳过**。
+
+## 运行
+
+```
+cargo xtask starry app qemu -t llvm22 --arch x86_64
+cargo xtask starry app qemu -t llvm22 --arch aarch64
+cargo xtask starry app qemu -t llvm22 --arch riscv64
+cargo xtask starry app qemu -t llvm22 --arch loongarch64
+```
+
+`prebuild.sh` 通过 qemu-user-static 把 base Alpine rootfs 解到 staging 树后，将其 apk 仓库指向
+Alpine **edge**（`llvm22` 22.1.x 只在 edge/main 分支，且四个架构齐全），`apk add`
+`llvm22 llvm22-dev llvm22-test-utils clang22 lld22 gcc g++ musl-dev binutils`, 由 apk 为目标架构解析
+**当前版本**及其完整的 musl 原生 `.so` 闭包（无写死会漂移的 apk URL，无缓存缺失即退出）。随后脚本从
+apk 的 installed 数据库里精确取出**本次事务新装/升级的那批包**所拥有的文件（LLVM/Clang 工具本体 +
+`libLLVM.so.22.1` 等），复制进 per-app overlay。base 镜像（Alpine 3.23.4）本身已带
+`gcc`/`binutils`/`musl-dev`（crt + 链接器），供 `clang` 的 C→可执行链接路径使用；apk 行仍显式列出这些，
+以便某个缺失它们的 base 会把它们拉入被复制的事务增量。`g++` 提供 C++ 标准头文件与 `libstdc++`，
+供 `clang++` 的 STL 路径使用。
+
+LLVM 闭包体积很大（安装后约 760 MiB），prebuild 在 harness 注入 overlay 之前先把 per-app rootfs 镜像
+扩容（truncate + e2fsck + resize2fs），以免 debugfs 注入时静默截断大型 `.so` 文件。
+
+Alpine 的 `llvm22` 包把未加版本后缀的工具（`lli`/`llc`/`opt`/`llvm-config`/`FileCheck`/`llvm-*`）装到
+`/usr/lib/llvm22/bin`，只有 `clang`/`clang-22`/`ld.lld` 落在 `/usr/bin`；`run-llvm22.sh` 因此把
+`/usr/lib/llvm22/bin` 加入 `PATH`。测例源码位于 `src/`，注入到 `/root/llvm22/src`。
+
+## 架构说明
+
+- x86_64：`-cpu Haswell` 向用户态暴露 XSAVE/AVX2，`lli`/`llc` 的 host-CPU 代码生成路径据此选择向量特性；
+  内核侧 CR4.OSXSAVE 与 XCR0 的开启在 dev 分支中。`-m 4096M` 给 `libLLVM`（映射约 190 MiB）与 `clang`
+  留出工作集余量。
+- aarch64：`-cpu max`（完整 AArch64 特性集，含 LSE 原子与 ARMv8.2+ 扩展）。
+- riscv64：`-cpu rv64`。
+- loongarch64：`-machine virt -cpu la464`，动态平台（`build-loongarch64*.toml` 带
+  `ax-driver/serial`，`uefi=false` / `to_bin=true` 为动态平台的裸二进制引导路径；不再使用已退休的静态
+  LoongArch 写法）。
+
+TCG 模拟下运行 LLVM 工具较慢，qemu toml 的 `timeout` 相应放宽。

--- a/apps/starry/llvm22/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/llvm22/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,13 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/llvm22/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/llvm22/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,14 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]

--- a/apps/starry/llvm22/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/llvm22/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+features = [
+  "ax-feat/display",
+  "ax-feat/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/llvm22/build-x86_64-unknown-none.toml
+++ b/apps/starry/llvm22/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/llvm22/prebuild.sh
+++ b/apps/starry/llvm22/prebuild.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the musl-native LLVM 22 toolchain (lli / llc / opt / clang / clang++ /
+# lld / llvm-as / llvm-dis / llvm-config / FileCheck / llvm-link / llvm-nm / llvm-objdump /
+# llvm-ar) and stage the exact-assertion carpet for StarryOS.
+#
+# Portable, reproducible model (mirrors the merged python-lang / python-net / py-sci apps):
+# extract the base Alpine rootfs into a staging tree, point apk at Alpine edge (llvm22 22.1.x
+# lives in edge/main), `apk add` the LLVM 22 tool set INTO the staging tree via
+# qemu-user-static (so apk RESOLVES THE CURRENT version + the full musl-native .so closure for
+# the TARGET arch - no hardcoded drifting apk URLs, no cache-miss-exit), then copy exactly the
+# files owned by the newly installed/upgraded packages (the transaction delta) into the app
+# overlay. The base image already ships gcc / binutils / musl-dev (crt + linker) that clang's
+# C -> exe path uses; `gcc musl-dev binutils` are still named on the apk line so a base that
+# lacks them pulls them into the copied delta. `g++` adds the C++ standard headers + libstdc++
+# that clang++'s STL path needs.
+#
+# Alpine branch: edge/main is the only branch shipping llvm22 (all four target arches:
+# x86_64 / aarch64 / riscv64 / loongarch64 at 22.1.x). The whole transaction delta - including
+# any upgraded libstdc++ / libncurses - is copied, so the overlay is self-consistent on top of
+# the 3.23 base (musl 1.2.5 is unchanged, ABI-compatible).
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS (per-app rootfs image, injected after
+# this script), STARRY_STAGING_ROOT (scratch extraction tree), STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+
+APK_BRANCH="${LLVM22_APK_BRANCH:-edge}"
+ALPINE_CDN="${ALPINE_CDN:-https://dl-cdn.alpinelinux.org/alpine}"
+# The LLVM 22 closure (llvm22 + llvm22-libs + clang22 + clang22-libs + deps) is ~760 MiB
+# installed. The harness injects the overlay via debugfs WITHOUT resizing, so an undersized fs
+# SILENTLY TRUNCATES the big .so files. Grow first (mirrors the py-sci / java-lang recipe).
+ROOTFS_SIZE="${LLVM22_ROOTFS_SIZE:-8G}"
+APK_CACHE="${LLVM22_APK_CACHE:-}"
+
+PKGS="llvm22 llvm22-dev llvm22-test-utils clang22 lld22 gcc g++ musl-dev binutils"
+
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs   >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v e2fsck    >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v truncate  >/dev/null 2>&1 || missing+=(coreutils)
+    command -v tar       >/dev/null 2>&1 || missing+=(tar)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        if command -v apt-get >/dev/null 2>&1; then
+            echo "prebuild: installing host tools: ${missing[*]}"
+            apt-get update && apt-get install -y --no-install-recommends "${missing[@]}"
+        else
+            echo "prebuild: missing host tools and no apt-get: ${missing[*]}" >&2
+            exit 1
+        fi
+    fi
+}
+
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    local before after
+    before=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs $base_rootfs is $((before / 1024 / 1024)) MiB; growing to $ROOTFS_SIZE"
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown to $((after / 1024 / 1024)) MiB (fs resized)"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    # qemu-user resolves ABSOLUTE symlink targets against the HOST root, so an alpine
+    # `usr/lib/libz.so.1 -> /usr/lib/libz.so.1.3.2` dangles on a non-alpine build host and apk
+    # fails to load its closure. Rewrite absolute symlinks under the staging lib dirs to relative.
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"
+        [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+qapk() {
+    QEMU_LD_PREFIX="$staging_root" \
+    LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" --root "$staging_root" "$@"
+}
+
+install_llvm() {
+    normalize_symlinks
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    printf '%s/%s/main\n%s/%s/community\n' \
+        "$ALPINE_CDN" "$APK_BRANCH" "$ALPINE_CDN" "$APK_BRANCH" \
+        > "$staging_root/etc/apk/repositories"
+    local cache_args=()
+    if [[ -n "$APK_CACHE" ]]; then
+        mkdir -p "$APK_CACHE"; cache_args=(--cache-dir "$APK_CACHE")
+        echo "prebuild: using offline apk cache $APK_CACHE (network fills any miss)"
+    fi
+    echo "prebuild: apk add [$PKGS] ($APK_BRANCH) via $qemu_runner ..."
+    local apk_log="$staging_root/.llvm22-apk.log"
+    qapk --repositories-file "$staging_root/etc/apk/repositories" \
+         --keys-dir "$staging_root/etc/apk/keys" \
+         "${cache_args[@]}" \
+         --update-cache --no-progress --no-scripts \
+         add $PKGS 2>&1 | tee "$apk_log"
+
+    # Transaction delta = every package installed OR upgraded in this run.
+    txn_pkgs=$(grep -oE '(Installing|Upgrading) [a-z0-9._+-]+' "$apk_log" | awk '{print $2}' | sort -u)
+    [[ -n "$txn_pkgs" ]] || { echo "prebuild: empty apk transaction" >&2; exit 3; }
+    echo "prebuild: transaction delta = $(echo "$txn_pkgs" | wc -w) package(s)"
+
+    # Strict version gate: llvm-config must report major 22.
+    local llvm_ver major
+    llvm_ver=$(qapk info --description llvm22 2>/dev/null | head -1 || true)
+    major=$(QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/usr/lib/llvm22/bin/llvm-config" --version 2>/dev/null | cut -d. -f1)
+    case "$major" in
+        22) echo "prebuild: provisioned LLVM $(QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" "$qemu_runner" -L "$staging_root" "$staging_root/usr/lib/llvm22/bin/llvm-config" --version 2>/dev/null)" ;;
+        *)  echo "prebuild: need LLVM major 22 but llvm-config reported '$major'" >&2; exit 3 ;;
+    esac
+    [[ -x "$staging_root/usr/lib/llvm22/bin/lli" ]] || { echo "prebuild: lli missing after install" >&2; exit 3; }
+    [[ -e "$staging_root/usr/bin/clang"          ]] || { echo "prebuild: clang missing after install" >&2; exit 3; }
+}
+
+populate_overlay() {
+    # Copy exactly the files owned by the transaction-delta packages (regular files + symlinks,
+    # recorded as R: entries under F: folders in apk's installed db) into the overlay, preserving
+    # modes + symlinks. tar streams the explicit file list (fast, parents auto-created).
+    local filelist="$staging_root/.llvm22-files.txt"
+    awk -v pkgs="$txn_pkgs" '
+        BEGIN { n = split(pkgs, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") want[a[i]] = 1 }
+        /^P:/ { cur = substr($0, 3); inpkg = (cur in want) ? 1 : 0; dir = "" }
+        /^F:/ { if (inpkg) dir = substr($0, 3) }
+        /^R:/ { if (inpkg) { f = substr($0, 3); print (dir == "") ? f : dir "/" f } }
+    ' "$staging_root/lib/apk/db/installed" | sort -u > "$filelist"
+    local n; n=$(wc -l < "$filelist")
+    [[ "$n" -gt 0 ]] || { echo "prebuild: no files resolved for delta packages" >&2; exit 4; }
+    echo "prebuild: copying $n LLVM toolchain file(s) into overlay"
+    mkdir -p "$overlay_dir"
+    tar -C "$staging_root" -cf - --no-recursion -T "$filelist" | tar -C "$overlay_dir" -xf -
+
+    # Stage the carpet fixtures + on-target launcher.
+    mkdir -p "$overlay_dir/root/llvm22/src"
+    local c=0
+    for f in "$app_dir"/src/*; do
+        [[ -f "$f" ]] || continue
+        install -Dm0644 "$f" "$overlay_dir/root/llvm22/src/$(basename "$f")"
+        c=$((c + 1))
+    done
+    install -Dm0755 "$app_dir/programs/run-llvm22.sh" "$overlay_dir/usr/bin/run-llvm22.sh"
+    echo "prebuild: staged $c carpet fixture(s); LLVM 22 overlay ready for $arch"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+install_llvm
+populate_overlay

--- a/apps/starry/llvm22/programs/run-llvm22.sh
+++ b/apps/starry/llvm22/programs/run-llvm22.sh
@@ -1,0 +1,407 @@
+#!/bin/sh
+# run-llvm22.sh - on-target LLVM 22 toolchain carpet for StarryOS.
+#
+# Exercises the real musl-native LLVM 22 tools (installed from Alpine `apk add
+# llvm22 llvm22-dev llvm22-test-utils clang22 lld22 g++ ...`) against a set of
+# LLVM IR / C / C++ fixtures, one exact assertion per tool feature, spanning the
+# seven coverage dimensions (documentation walk, --help/--version, per-option unit
+# behaviour, functional output, boundary inputs, error handling, and pipelines):
+#   llvm-config      version + built targets (cross-codegen capability)
+#   --version sweep  every tool self-reports LLVM major 22
+#   llvm-as/-dis     IR <-> bitcode roundtrip (bitcode magic, re-parse), empty module
+#   lli              JIT: stdout + exit code, loops, recursion, libc calls, large IR
+#   llc              IR -> asm / object; cross-codegen for all four built targets
+#   llvm-nm/objdump  symbol table + disassembly of the emitted object
+#   opt              mem2reg, -O0/-O1/-O2/-O3, default<O2>, instcombine, inline, bitcode
+#   llvm-link        module merge
+#   llvm-ar          static archive create / list / extract / symbol index
+#   FileCheck        positive + negative (discrimination) match, --help
+#   clang            C -> IR, C -> exe, -O2 -lm, -std= dialects
+#   clang++          C++ -> IR (name mangling), C++ -> exe (templates + STL)
+#   lld              ld.lld version + clang -fuse-ld=lld link+run
+#   errors           malformed IR / unknown pass / missing input all fail non-zero
+#   pipelines        clang|opt|llc|lld end-to-end, opt-optimised IR back through lli
+#
+# Gate: prints `LLVM22_OK=<pass>/<total>` then `TEST PASSED` only when every
+# check passed; otherwise `TEST FAILED`. The success anchor lives solely here so
+# the qemu success_regex cannot self-match on the launch command.
+#
+# Expected LLVM major version. Alpine ships 22.1.x; assertions pin only the major.
+EXP_MAJOR=22
+
+# musl loader search path so libLLVM.so.22.1 (in /usr/lib) is always found.
+for a in x86_64 aarch64 riscv64 loongarch64; do
+    printf '/lib\n/usr/lib\n' > "/etc/ld-musl-$a.path" 2>/dev/null || true
+done
+# Alpine's llvm22 package installs the unversioned tools (lli/llc/opt/llvm-config/
+# FileCheck/llvm-*) under /usr/lib/llvm22/bin; only clang/clang++/clang-22/ld.lld land in /usr/bin.
+export PATH=/usr/lib/llvm22/bin:/usr/bin:/bin:/usr/sbin:/sbin
+export HOME=/root
+export TMPDIR=/tmp
+mkdir -p /tmp
+
+SRC=/root/llvm22/src
+WORK=/root/llvm22/work
+rm -rf "$WORK"; mkdir -p "$WORK"; cd "$WORK" || { echo "TEST FAILED"; exit 1; }
+
+pass=0
+total=0
+
+ok()  { total=$((total + 1)); pass=$((pass + 1)); echo "  PASS | $1"; }
+bad() { total=$((total + 1)); echo "  FAIL | $1 :: $2"; }
+
+# check_eq NAME EXPECTED ACTUAL
+check_eq() {
+    if [ "x$2" = "x$3" ]; then ok "$1"; else bad "$1" "exp=[$2] got=[$3]"; fi
+}
+# check_true NAME RC (rc==0 -> pass)
+check_true() {
+    if [ "$2" -eq 0 ]; then ok "$1"; else bad "$1" "rc=$2"; fi
+}
+# check_false NAME RC (rc!=0 -> pass; used for negative / error cases)
+check_false() {
+    if [ "$2" -ne 0 ]; then ok "$1"; else bad "$1" "unexpected rc=0"; fi
+}
+# check_grep NAME PATTERN FILE  (fixed-string grep must match)
+check_grep() {
+    if grep -q "$2" "$3" 2>/dev/null; then ok "$1"; else bad "$1" "pattern [$2] absent"; fi
+}
+# check_version TOOL  (<tool> --version must report `LLVM version 22.x`)
+check_version() {
+    v=$("$1" --version 2>/dev/null)
+    if echo "$v" | grep -qE "LLVM version $EXP_MAJOR\."; then
+        ok "$1 --version is $EXP_MAJOR.x"
+    else
+        bad "$1 --version is $EXP_MAJOR.x" "got=[$(echo "$v" | grep -i version | head -1)]"
+    fi
+}
+# ELF e_machine (2 bytes LE at offset 18)
+elf_machine() {
+    od -An -tu1 -j18 -N2 "$1" 2>/dev/null | awk '{print $1 + $2 * 256}'
+}
+# count '= alloca' INSTRUCTIONS in an .ll file (not the word in comments)
+count_alloca() { grep -c '= alloca' "$1"; }
+
+echo "=== LLVM 22 toolchain carpet (StarryOS) ==="
+
+# -------------------------------------------------------------------------
+# 1. llvm-config: version + cross-codegen target set
+# -------------------------------------------------------------------------
+echo "[llvm-config]"
+ver=$(llvm-config --version 2>/dev/null)
+maj=${ver%%.*}
+check_eq "llvm-config --version major" "$EXP_MAJOR" "$maj"
+
+tgts=$(llvm-config --targets-built 2>/dev/null)
+echo "$tgts" | grep -qw X86        && check_true "targets-built has X86" 0        || check_true "targets-built has X86" 1
+echo "$tgts" | grep -qw AArch64    && check_true "targets-built has AArch64" 0    || check_true "targets-built has AArch64" 1
+echo "$tgts" | grep -qw RISCV      && check_true "targets-built has RISCV" 0      || check_true "targets-built has RISCV" 1
+echo "$tgts" | grep -qw LoongArch  && check_true "targets-built has LoongArch" 0  || check_true "targets-built has LoongArch" 1
+
+# -------------------------------------------------------------------------
+# 2. --version / --help sweep: every tool self-reports LLVM 22 and its metadata
+# -------------------------------------------------------------------------
+echo "[--version / --help]"
+check_version llvm-as
+check_version llvm-dis
+check_version llvm-link
+check_version llvm-nm
+check_version llvm-objdump
+check_version llvm-ar
+check_version opt
+check_version llc
+check_version lli
+
+opt --print-passes 2>/dev/null > passes.txt
+if grep -qw mem2reg passes.txt && grep -qw instcombine passes.txt; then
+    check_true "opt --print-passes lists mem2reg + instcombine" 0
+else
+    check_true "opt --print-passes lists mem2reg + instcombine" 1
+fi
+
+llc --version 2>/dev/null > llctgt.txt
+if grep -qw aarch64 llctgt.txt && grep -qw riscv64 llctgt.txt; then
+    check_true "llc --version lists aarch64 + riscv64 targets" 0
+else
+    check_true "llc --version lists aarch64 + riscv64 targets" 1
+fi
+
+FileCheck --help >/dev/null 2>&1
+check_true "FileCheck --help exits 0" $?
+
+# -------------------------------------------------------------------------
+# 3. llvm-as / llvm-dis: IR <-> bitcode roundtrip + empty module
+# -------------------------------------------------------------------------
+echo "[llvm-as / llvm-dis]"
+llvm-as "$SRC/hello.ll" -o hello.bc 2>/dev/null
+magic=$(od -An -tx1 -N4 hello.bc 2>/dev/null | tr -d ' \n')
+check_eq "llvm-as emits bitcode magic (BC C0 DE)" "4243c0de" "$magic"
+
+llvm-dis hello.bc -o hello_rt.ll 2>/dev/null
+grep -q '@main' hello_rt.ll && check_true "llvm-dis disassembles (has @main)" 0 || check_true "llvm-dis disassembles (has @main)" 1
+
+llvm-as hello_rt.ll -o /dev/null 2>/dev/null
+check_true "llvm-dis output re-assembles (roundtrip stable)" $?
+
+llvm-as "$SRC/empty.ll" -o empty.bc 2>/dev/null
+emagic=$(od -An -tx1 -N4 empty.bc 2>/dev/null | tr -d ' \n')
+check_eq "llvm-as accepts empty module (valid bitcode)" "4243c0de" "$emagic"
+
+# -------------------------------------------------------------------------
+# 4. lli: JIT execution
+# -------------------------------------------------------------------------
+echo "[lli JIT]"
+out=$(lli "$SRC/hello.ll" 2>/dev/null)
+check_eq "lli hello: stdout" "Hello, LLVM 22!" "$out"
+
+lli "$SRC/arith.ll" >/dev/null 2>&1
+check_eq "lli arith: exit code" "42" "$?"
+
+out=$(lli "$SRC/loop.ll" 2>/dev/null)
+check_eq "lli loop: sum 1..100" "SUM=5050" "$out"
+
+out=$(lli "$SRC/fib.ll" 2>/dev/null)
+check_eq "lli fib: recursion fib(10)" "FIB=55" "$out"
+
+# Large IR: a 1000-instruction add chain evaluating to 1000; exit code truncates to 232.
+awk 'BEGIN {
+    print "define i32 @main() {"; print "entry:";
+    print "  %v0 = add i32 0, 1";
+    for (i = 1; i < 1000; i++) printf "  %%v%d = add i32 %%v%d, 1\n", i, i - 1;
+    print "  ret i32 %v999"; print "}"
+}' > big.ll
+lli big.ll >/dev/null 2>&1
+check_eq "lli large IR (1000-add chain): exit code 1000 & 255" "232" "$?"
+
+# -------------------------------------------------------------------------
+# 5. llc: native asm / object + cross-target object codegen (all four targets)
+# -------------------------------------------------------------------------
+echo "[llc]"
+llc "$SRC/hello.ll" -o hello.s 2>/dev/null
+if grep -q 'main' hello.s && grep -qi 'globl' hello.s; then
+    check_true "llc emits native asm (.globl main)" 0
+else
+    check_true "llc emits native asm (.globl main)" 1
+fi
+
+llc -filetype=obj "$SRC/hello.ll" -o hello.o 2>/dev/null
+omagic=$(od -An -tx1 -N4 hello.o 2>/dev/null | tr -d ' \n')
+check_eq "llc emits native ELF object" "7f454c46" "$omagic"
+
+nm_out=$(llvm-nm hello.o 2>/dev/null)
+echo "$nm_out" | grep -q 'T main' && check_true "llvm-nm lists 'T main'" 0 || check_true "llvm-nm lists 'T main'" 1
+
+od_out=$(llvm-objdump -d hello.o 2>/dev/null)
+echo "$od_out" | grep -q 'main' && check_true "llvm-objdump disassembles main" 0 || check_true "llvm-objdump disassembles main" 1
+
+llc -filetype=obj -mtriple=x86_64 "$SRC/hello.ll" -o cross_x86.o 2>/dev/null
+check_eq "llc cross-compile x86_64 (ELF e_machine=62)" "62" "$(elf_machine cross_x86.o)"
+
+llc -filetype=obj -mtriple=aarch64 "$SRC/hello.ll" -o cross_aa.o 2>/dev/null
+check_eq "llc cross-compile aarch64 (ELF e_machine=183)" "183" "$(elf_machine cross_aa.o)"
+
+llc -filetype=obj -mtriple=riscv64 "$SRC/hello.ll" -o cross_rv.o 2>/dev/null
+check_eq "llc cross-compile riscv64 (ELF e_machine=243)" "243" "$(elf_machine cross_rv.o)"
+
+llc -filetype=obj -mtriple=loongarch64 "$SRC/hello.ll" -o cross_la.o 2>/dev/null
+check_eq "llc cross-compile loongarch64 (ELF e_machine=258)" "258" "$(elf_machine cross_la.o)"
+
+# -------------------------------------------------------------------------
+# 6. opt: mem2reg / -O0..-O3 / default<O2> / instcombine / inline / bitcode pipeline
+# -------------------------------------------------------------------------
+echo "[opt]"
+check_eq "mem2reg fixture has 2 allocas" "2" "$(count_alloca "$SRC/mem2reg.ll")"
+
+opt -passes=mem2reg -S "$SRC/mem2reg.ll" -o m2r.ll 2>/dev/null
+check_eq "opt -passes=mem2reg eliminates allocas" "0" "$(count_alloca m2r.ll)"
+
+opt -O0 -S "$SRC/mem2reg.ll" -o o0.ll 2>/dev/null
+check_eq "opt -O0 retains allocas (no promotion)" "2" "$(count_alloca o0.ll)"
+
+opt -O1 -S "$SRC/mem2reg.ll" -o o1.ll 2>/dev/null
+check_eq "opt -O1 promotes to SSA (no alloca)" "0" "$(count_alloca o1.ll)"
+
+opt -O2 -S "$SRC/mem2reg.ll" -o o2.ll 2>/dev/null
+if [ "$(count_alloca o2.ll)" = "0" ] && grep -q '@compute' o2.ll; then
+    check_true "opt -O2 promotes to SSA (no alloca, @compute kept)" 0
+else
+    check_true "opt -O2 promotes to SSA (no alloca, @compute kept)" 1
+fi
+
+opt -O3 -S "$SRC/mem2reg.ll" -o o3.ll 2>/dev/null
+check_eq "opt -O3 promotes to SSA (no alloca)" "0" "$(count_alloca o3.ll)"
+
+opt -passes='default<O2>' -S "$SRC/mem2reg.ll" -o dflt.ll 2>/dev/null
+check_eq "opt -passes=default<O2> pipeline (no alloca)" "0" "$(count_alloca dflt.ll)"
+
+opt -passes=instcombine -S "$SRC/instcombine.ll" -o ic.ll 2>/dev/null
+if [ "$(grep -c ' mul ' ic.ll)" = "0" ] && [ "$(grep -c ' add ' ic.ll)" = "0" ] && grep -q 'ret i32 %x' ic.ll; then
+    check_true "opt -passes=instcombine folds (x*1)+0 to x" 0
+else
+    check_true "opt -passes=instcombine folds (x*1)+0 to x" 1
+fi
+
+opt -passes=inline -S "$SRC/inline.ll" -o inl.ll 2>/dev/null
+check_eq "opt -passes=inline removes the call site" "0" "$(grep -c 'call i32 @callee' inl.ll)"
+
+llvm-as "$SRC/mem2reg.ll" -o m2r_in.bc 2>/dev/null
+opt -passes=mem2reg m2r_in.bc -o m2r_out.bc 2>/dev/null
+llvm-dis m2r_out.bc -o m2r_out.ll 2>/dev/null
+check_eq "opt bitcode pipeline (as|opt|dis) no alloca" "0" "$(count_alloca m2r_out.ll)"
+
+# -------------------------------------------------------------------------
+# 7. llvm-link: module merge
+# -------------------------------------------------------------------------
+echo "[llvm-link]"
+llvm-link "$SRC/link_a.ll" "$SRC/link_b.ll" -S -o linked.ll 2>/dev/null
+if grep -q '@funcA' linked.ll && grep -q '@funcB' linked.ll; then
+    check_true "llvm-link merges both modules (@funcA + @funcB)" 0
+else
+    check_true "llvm-link merges both modules (@funcA + @funcB)" 1
+fi
+
+# -------------------------------------------------------------------------
+# 8. llvm-ar: static archive create / list / symbol index / extract
+# -------------------------------------------------------------------------
+echo "[llvm-ar]"
+llc -filetype=obj "$SRC/link_a.ll" -o arA.o 2>/dev/null
+llc -filetype=obj "$SRC/link_b.ll" -o arB.o 2>/dev/null
+rm -f lib.a
+llvm-ar rcs lib.a arA.o arB.o 2>/dev/null
+armagic=$(od -An -c -N8 lib.a 2>/dev/null | tr -d ' \n')
+check_eq "llvm-ar rcs creates archive (! < a r c h > magic)" '!<arch>\n' "$armagic"
+
+ar_t=$(llvm-ar t lib.a 2>/dev/null)
+if echo "$ar_t" | grep -q 'arA.o' && echo "$ar_t" | grep -q 'arB.o'; then
+    check_true "llvm-ar t lists both members" 0
+else
+    check_true "llvm-ar t lists both members" 1
+fi
+
+arnm=$(llvm-nm lib.a 2>/dev/null)
+if echo "$arnm" | grep -q 'T funcA' && echo "$arnm" | grep -q 'T funcB'; then
+    check_true "llvm-nm reads archive symbol index (funcA + funcB)" 0
+else
+    check_true "llvm-nm reads archive symbol index (funcA + funcB)" 1
+fi
+
+mkdir -p xdir && (cd xdir && rm -f arA.o && llvm-ar x ../lib.a arA.o 2>/dev/null)
+[ -s xdir/arA.o ] && check_true "llvm-ar x extracts a member" 0 || check_true "llvm-ar x extracts a member" 1
+
+# -------------------------------------------------------------------------
+# 9. FileCheck: positive + negative discrimination
+# -------------------------------------------------------------------------
+echo "[FileCheck]"
+llvm-dis hello.bc -o hello_check_in.ll 2>/dev/null
+FileCheck "$SRC/hello.check" < hello_check_in.ll >/dev/null 2>&1
+check_true "FileCheck positive match" $?
+
+FileCheck "$SRC/bad.check" < hello_check_in.ll >/dev/null 2>&1
+check_false "FileCheck negative (must fail on absent pattern)" $?
+
+# -------------------------------------------------------------------------
+# 10. clang: C front-end (IR + native exe + -std dialects)
+# -------------------------------------------------------------------------
+echo "[clang]"
+cver=$(clang --version 2>/dev/null | head -1)
+echo "$cver" | grep -q "version $EXP_MAJOR\." && check_true "clang --version is $EXP_MAJOR.x" 0 || check_true "clang --version is $EXP_MAJOR.x" 1
+
+clang -S -emit-llvm -O0 "$SRC/hello.c" -o hello_c.ll 2>/dev/null
+if grep -q 'define' hello_c.ll && grep -q '@main' hello_c.ll && grep -q '@printf' hello_c.ll; then
+    check_true "clang -emit-llvm: C -> IR (@main + @printf)" 0
+else
+    check_true "clang -emit-llvm: C -> IR (@main + @printf)" 1
+fi
+
+clang -std=c11 -S -emit-llvm "$SRC/hello.c" -o hello_c11.ll 2>/dev/null
+if [ $? -eq 0 ] && grep -q '@main' hello_c11.ll; then
+    check_true "clang -std=c11: C -> IR" 0
+else
+    check_true "clang -std=c11: C -> IR" 1
+fi
+
+clang -std=gnu17 -S -emit-llvm "$SRC/hello.c" -o hello_g17.ll 2>/dev/null
+if [ $? -eq 0 ] && grep -q '@main' hello_g17.ll; then
+    check_true "clang -std=gnu17: C -> IR" 0
+else
+    check_true "clang -std=gnu17: C -> IR" 1
+fi
+
+clang "$SRC/hello.c" -o hello_bin 2>/dev/null
+out=$(./hello_bin 2>/dev/null)
+check_eq "clang C -> exe: compile+link+run" "CLANG22 OK" "$out"
+
+clang -O2 "$SRC/math.c" -lm -o math_bin 2>/dev/null
+out=$(./math_bin 2>/dev/null)
+check_eq "clang -O2 -lm: sqrt(2)" "SQRT=1.4142" "$out"
+
+# -------------------------------------------------------------------------
+# 11. clang++: C++ front-end (name mangling + templates + STL)
+# -------------------------------------------------------------------------
+echo "[clang++]"
+cxxver=$(clang++ --version 2>/dev/null | head -1)
+echo "$cxxver" | grep -q "version $EXP_MAJOR\." && check_true "clang++ --version is $EXP_MAJOR.x" 0 || check_true "clang++ --version is $EXP_MAJOR.x" 1
+
+clang++ -std=c++17 -S -emit-llvm -O0 "$SRC/hello.cpp" -o hello_cpp.ll 2>/dev/null
+grep -q '_ZN7Counter' hello_cpp.ll && check_true "clang++ -emit-llvm: C++ -> IR (Itanium name mangling)" 0 || check_true "clang++ -emit-llvm: C++ -> IR (Itanium name mangling)" 1
+
+clang++ -std=c++17 "$SRC/hello.cpp" -o hello_cpp 2>/dev/null
+out=$(./hello_cpp 2>/dev/null)
+check_eq "clang++ C++ -> exe: templates + STL + run" "CPP22 SUM=15 CNT=5" "$out"
+
+# -------------------------------------------------------------------------
+# 12. lld: LLVM linker
+# -------------------------------------------------------------------------
+echo "[lld]"
+lver=$(ld.lld --version 2>/dev/null)
+echo "$lver" | grep -q "LLD $EXP_MAJOR\." && check_true "ld.lld --version is $EXP_MAJOR.x" 0 || check_true "ld.lld --version is $EXP_MAJOR.x" 1
+
+clang -fuse-ld=lld "$SRC/hello.c" -o hello_lld 2>/dev/null
+out=$(./hello_lld 2>/dev/null)
+check_eq "clang -fuse-ld=lld: link+run" "CLANG22 OK" "$out"
+
+# -------------------------------------------------------------------------
+# 13. error handling: malformed IR / unknown pass / missing input must fail
+# -------------------------------------------------------------------------
+echo "[errors]"
+llvm-as "$SRC/malformed.ll" -o /dev/null 2>/dev/null
+check_false "llvm-as rejects malformed IR (non-zero)" $?
+
+llc "$SRC/malformed.ll" -o /dev/null 2>/dev/null
+check_false "llc rejects malformed IR (non-zero)" $?
+
+opt -passes='this_pass_does_not_exist_zzq9137' "$SRC/hello.ll" -o /dev/null 2>/dev/null
+check_false "opt rejects unknown pass name (non-zero)" $?
+
+lli /root/llvm22/src/no_such_file_zzq9137.ll >/dev/null 2>&1
+check_false "lli rejects missing input file (non-zero)" $?
+
+# -------------------------------------------------------------------------
+# 14. integration pipelines
+# -------------------------------------------------------------------------
+echo "[pipelines]"
+# clang front-end -> opt -O2 -> llc object -> lld link -> run: the full toolchain.
+# llc defaults to a static reloc model; clang links PIE, so ask llc for a PIC object.
+clang -S -emit-llvm -O0 "$SRC/hello.c" -o pipe.ll 2>/dev/null
+opt -O2 -S pipe.ll -o pipe_opt.ll 2>/dev/null
+llc -relocation-model=pic -filetype=obj pipe_opt.ll -o pipe.o 2>/dev/null
+clang -fuse-ld=lld pipe.o -o pipe_bin 2>/dev/null
+out=$(./pipe_bin 2>/dev/null)
+check_eq "pipeline clang|opt|llc|lld -> run" "CLANG22 OK" "$out"
+
+# opt-optimised IR fed straight back into the JIT still computes the right answer.
+opt -O2 -S "$SRC/loop.ll" -o loop_opt.ll 2>/dev/null
+out=$(lli loop_opt.ll 2>/dev/null)
+check_eq "pipeline opt -O2 loop.ll | lli -> SUM" "SUM=5050" "$out"
+
+# -------------------------------------------------------------------------
+# Gate
+# -------------------------------------------------------------------------
+echo "=== summary: $pass/$total checks passed ==="
+echo "LLVM22_OK=$pass/$total"
+if [ "$pass" -eq "$total" ]; then
+    echo "TEST PASSED"
+    exit 0
+fi
+echo "TEST FAILED"
+exit 1

--- a/apps/starry/llvm22/qemu-aarch64.toml
+++ b/apps/starry/llvm22/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+# llvm22 aarch64 - musl-native LLVM 22 toolchain carpet.
+# -cpu max exposes the full AArch64 feature set (LSE atomics, the ARMv8.2+ extensions) that the
+# LLVM host-CPU codegen path may select; cortex-a72 lacks them. -m 4096M for libLLVM + clang.
+args = [
+    "-nographic", "-cpu", "max", "-m", "4096M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-llvm22.sh"
+success_regex = ['(?m)^LLVM22_OK=68/68\s*$', '(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/llvm22/qemu-loongarch64.toml
+++ b/apps/starry/llvm22/qemu-loongarch64.toml
@@ -1,0 +1,18 @@
+# llvm22 loongarch64 - musl-native LLVM 22 toolchain carpet.
+# Platform: dynamic (axplat-dyn) - build-loongarch64*.toml carries ax-driver/serial and does not
+# opt out of dynamic platform mode; the retired static LoongArch path lacked the serial console
+# binding ("/dev/console has no serial TTY binding" -> early exit). uefi=false / to_bin=true is
+# the dynamic platform's raw-binary boot path. TCG is slow; timeout is generous.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "4096M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-llvm22.sh"
+success_regex = ['(?m)^LLVM22_OK=68/68\s*$', '(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/llvm22/qemu-riscv64.toml
+++ b/apps/starry/llvm22/qemu-riscv64.toml
@@ -1,0 +1,15 @@
+# llvm22 riscv64 - musl-native LLVM 22 toolchain carpet. TCG emulation of the LLVM tools is
+# slow; the timeout is generous. -m 4096M for libLLVM + clang.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "4096M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-llvm22.sh"
+success_regex = ['(?m)^LLVM22_OK=68/68\s*$', '(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/llvm22/qemu-x86_64.toml
+++ b/apps/starry/llvm22/qemu-x86_64.toml
@@ -1,0 +1,17 @@
+# llvm22 x86_64 - musl-native LLVM 22 toolchain carpet (lli JIT / llc / opt / clang / lld).
+# -cpu Haswell exposes XSAVE + AVX2 so the lli/llc host-CPU codegen path has the vector
+# features it detects; the kernel CR4.OSXSAVE + XCR0 enable lives in dev. -m 4096M gives the
+# libLLVM (~190 MiB mapped) + clang working set headroom.
+args = [
+    "-nographic", "-cpu", "Haswell", "-m", "4096M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-llvm22.sh"
+success_regex = ['(?m)^LLVM22_OK=68/68\s*$', '(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 12000

--- a/apps/starry/llvm22/src/arith.ll
+++ b/apps/starry/llvm22/src/arith.ll
@@ -1,0 +1,8 @@
+; arith.ll - main returns a computed exit status. Drives lli JIT exit-code path.
+; (40 + 2) * 1 = 42  ->  process exit code 42.
+define i32 @main() {
+entry:
+  %a = add i32 40, 2
+  %b = mul i32 %a, 1
+  ret i32 %b
+}

--- a/apps/starry/llvm22/src/bad.check
+++ b/apps/starry/llvm22/src/bad.check
@@ -1,0 +1,3 @@
+; Negative FileCheck case: this token never appears in the disassembled IR, so
+; FileCheck must FAIL (non-zero exit). Proves FileCheck actually discriminates.
+; CHECK: this_symbol_never_appears_zzq_9137

--- a/apps/starry/llvm22/src/empty.ll
+++ b/apps/starry/llvm22/src/empty.ll
@@ -1,0 +1,2 @@
+; empty.ll - a syntactically valid module with no definitions. llvm-as must still
+; emit well-formed (empty) bitcode; opt must accept it. Boundary: the empty input.

--- a/apps/starry/llvm22/src/fib.ll
+++ b/apps/starry/llvm22/src/fib.ll
@@ -1,0 +1,27 @@
+; fib.ll - recursive Fibonacci, fib(10) = 55, printed via printf. Drives lli JIT
+; recursive calls / stack frames + return values.
+@.fmt = private unnamed_addr constant [8 x i8] c"FIB=%d\0A\00"
+
+declare i32 @printf(ptr, ...)
+
+define i32 @fib(i32 %n) {
+entry:
+  %c = icmp slt i32 %n, 2
+  br i1 %c, label %base, label %rec
+base:
+  ret i32 %n
+rec:
+  %n1 = sub i32 %n, 1
+  %n2 = sub i32 %n, 2
+  %f1 = call i32 @fib(i32 %n1)
+  %f2 = call i32 @fib(i32 %n2)
+  %s = add i32 %f1, %f2
+  ret i32 %s
+}
+
+define i32 @main() {
+entry:
+  %r = call i32 @fib(i32 10)
+  %p = call i32 (ptr, ...) @printf(ptr @.fmt, i32 %r)
+  ret i32 0
+}

--- a/apps/starry/llvm22/src/hello.c
+++ b/apps/starry/llvm22/src/hello.c
@@ -1,0 +1,9 @@
+/* hello.c - clang C front-end test: C -> LLVM IR (-emit-llvm) and C -> native
+ * executable (compile + link + run). Deterministic stdout for exact assertion. */
+#include <stdio.h>
+
+int main(void)
+{
+    printf("CLANG22 OK\n");
+    return 0;
+}

--- a/apps/starry/llvm22/src/hello.check
+++ b/apps/starry/llvm22/src/hello.check
@@ -1,0 +1,4 @@
+; FileCheck directives matched against `llvm-dis hello.bc`. Positive case: both
+; patterns must appear (in order) -> FileCheck exits 0.
+; CHECK: define i32 @main
+; CHECK: @puts

--- a/apps/starry/llvm22/src/hello.cpp
+++ b/apps/starry/llvm22/src/hello.cpp
@@ -1,0 +1,27 @@
+// hello.cpp - clang++ C++ front-end: templates, a class with methods, range-based
+// for, and the STL (std::vector / std::string). Deterministic stdout for exact
+// assertion: "CPP22 SUM=15 CNT=5".
+#include <cstdio>
+#include <vector>
+#include <string>
+
+template <typename T>
+static T add(T a, T b) { return a + b; }
+
+struct Counter {
+    int n;
+    Counter() : n(0) {}
+    void bump() { ++n; }
+    int get() const { return n; }
+};
+
+int main() {
+    std::vector<int> v = {1, 2, 3, 4, 5};
+    int s = 0;
+    for (int x : v) s = add(s, x);
+    Counter c;
+    for (int i = 0; i < 5; ++i) c.bump();
+    std::string tag = "CPP22";
+    printf("%s SUM=%d CNT=%d\n", tag.c_str(), s, c.get());
+    return 0;
+}

--- a/apps/starry/llvm22/src/hello.ll
+++ b/apps/starry/llvm22/src/hello.ll
@@ -1,0 +1,11 @@
+; hello.ll - LLVM 22 textual IR: puts a fixed message, main returns 0.
+; Drives: lli JIT (exact stdout), llc (asm/obj codegen), llvm-as/llvm-dis roundtrip, FileCheck.
+@.msg = private unnamed_addr constant [16 x i8] c"Hello, LLVM 22!\00"
+
+declare i32 @puts(ptr)
+
+define i32 @main() {
+entry:
+  %r = call i32 @puts(ptr @.msg)
+  ret i32 0
+}

--- a/apps/starry/llvm22/src/inline.ll
+++ b/apps/starry/llvm22/src/inline.ll
@@ -1,0 +1,11 @@
+; inline.ll - one internal callee called exactly once. The -passes=inline inliner
+; must splice @callee into @caller, leaving zero `call i32 @callee` sites.
+define internal i32 @callee(i32 %x) {
+  %r = add i32 %x, 7
+  ret i32 %r
+}
+
+define i32 @caller() {
+  %r = call i32 @callee(i32 35)
+  ret i32 %r
+}

--- a/apps/starry/llvm22/src/instcombine.ll
+++ b/apps/starry/llvm22/src/instcombine.ll
@@ -1,0 +1,8 @@
+; instcombine.ll - algebraic identities the -passes=instcombine pass must fold away:
+; (x * 1) + 0 == x. After instcombine no `mul`/`add` instruction remains, just `ret %x`.
+define i32 @f(i32 %x) {
+entry:
+  %a = mul i32 %x, 1
+  %b = add i32 %a, 0
+  ret i32 %b
+}

--- a/apps/starry/llvm22/src/link_a.ll
+++ b/apps/starry/llvm22/src/link_a.ll
@@ -1,0 +1,4 @@
+; link_a.ll - one half of the llvm-link test: defines @funcA only.
+define i32 @funcA() {
+  ret i32 11
+}

--- a/apps/starry/llvm22/src/link_b.ll
+++ b/apps/starry/llvm22/src/link_b.ll
@@ -1,0 +1,5 @@
+; link_b.ll - other half of the llvm-link test: defines @funcB only. After
+; `llvm-link link_a.ll link_b.ll` the merged module must carry BOTH functions.
+define i32 @funcB() {
+  ret i32 22
+}

--- a/apps/starry/llvm22/src/loop.ll
+++ b/apps/starry/llvm22/src/loop.ll
@@ -1,0 +1,22 @@
+; loop.ll - counted loop summing 1..100 = 5050, printed via printf. Drives lli JIT
+; control flow (phi nodes / branches) + libc call resolution.
+@.fmt = private unnamed_addr constant [8 x i8] c"SUM=%d\0A\00"
+
+declare i32 @printf(ptr, ...)
+
+define i32 @main() {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [ 1, %entry ], [ %ni, %body ]
+  %s = phi i32 [ 0, %entry ], [ %ns, %body ]
+  %c = icmp sle i32 %i, 100
+  br i1 %c, label %body, label %done
+body:
+  %ns = add i32 %s, %i
+  %ni = add i32 %i, 1
+  br label %loop
+done:
+  %r = call i32 (ptr, ...) @printf(ptr @.fmt, i32 %s)
+  ret i32 0
+}

--- a/apps/starry/llvm22/src/malformed.ll
+++ b/apps/starry/llvm22/src/malformed.ll
@@ -1,0 +1,6 @@
+; malformed.ll - deliberately broken IR. llvm-as / llc must REJECT it (non-zero exit),
+; proving the parser actually validates rather than silently accepting garbage.
+define i32 @broken( {
+  %x = frobnicate i32 1, 2
+  ret
+}

--- a/apps/starry/llvm22/src/math.c
+++ b/apps/starry/llvm22/src/math.c
@@ -1,0 +1,10 @@
+/* math.c - clang -O2 with libm linkage (-lm). sqrt(2) = 1.4142... deterministic. */
+#include <stdio.h>
+#include <math.h>
+
+int main(void)
+{
+    volatile double x = 2.0;
+    printf("SQRT=%.4f\n", sqrt(x));
+    return 0;
+}

--- a/apps/starry/llvm22/src/mem2reg.ll
+++ b/apps/starry/llvm22/src/mem2reg.ll
@@ -1,0 +1,15 @@
+; mem2reg.ll - two stack slots (alloca/store/load) that the mem2reg / -O2 pipeline
+; must promote to SSA registers. Drives `opt`: after promotion NO `alloca` remains.
+; compute(x) = (x * 3) + 1
+define i32 @compute(i32 %x) {
+entry:
+  %p = alloca i32
+  store i32 %x, ptr %p
+  %v = load i32, ptr %p
+  %r = mul i32 %v, 3
+  %q = alloca i32
+  store i32 %r, ptr %q
+  %v2 = load i32, ptr %q
+  %r2 = add i32 %v2, 1
+  ret i32 %r2
+}


### PR DESCRIPTION
## 概述

新增 apps/starry/llvm22, 在四架构单核 qemu-10 StarryOS 上运行 LLVM 22 工具链, 门控 `LLVM22_OK=68/68`。

## 覆盖

68 条断言覆盖 lli JIT、llc 四目标交叉、opt 各优化 pass、clang 与 clang++、llvm-as 与 llvm-dis、llvm-link、llvm-ar、llvm-nm、llvm-objdump、llvm-config、FileCheck、lld, 以及边界、异常返回、clang 到 lld 的端到端流水线。工具经可复现 apk add 取 Alpine musl 版, 版本 22.1.8。

## 验证

四架构 x86_64 与 aarch64 与 riscv64 与 loongarch64 均 rc=0 加 `SUCCESS PATTERN MATCHED` 加 `LLVM22_OK=68/68`。clang 与 lli 的 fork/exec 汇编器与链接器、PROT_EXEC 可执行 mmap 在四架构上均正常, 未触发缺失 syscall。
