### PR TITLE
fix(starry): harden path, random, and icmp behavior

### DIFF
--- a/components/axfs-ng-vfs/src/node/dir.rs
+++ b/components/axfs-ng-vfs/src/node/dir.rs
@@ -10,7 +10,7 @@ use hashbrown::HashMap;
 use super::DirEntry;
 use crate::{
     Mountpoint, Mutex, NodeOps, NodePermission, NodeType, VfsError, VfsResult,
-    path::{DOT, DOTDOT, MAX_NAME_LEN, verify_entry_name},
+    path::{DOT, DOTDOT, verify_entry_name},
 };
 
 /// A trait for a sink that can receive directory entries.
@@ -224,9 +224,7 @@ impl DirNode {
 
     /// Looks up a directory entry by name.
     pub fn lookup(&self, name: &str) -> VfsResult<DirEntry> {
-        if name.len() > MAX_NAME_LEN {
-            return Err(VfsError::NameTooLong);
-        }
+        verify_entry_name(name)?;
         self.lookup_and_cache(name)
     }
 

--- a/components/axfs-ng-vfs/src/path.rs
+++ b/components/axfs-ng-vfs/src/path.rs
@@ -9,7 +9,8 @@ pub const DOTDOT: &str = "..";
 pub const MAX_NAME_LEN: usize = 255;
 
 pub(crate) fn verify_entry_name(name: &str) -> VfsResult<()> {
-    if name == DOT || name == DOTDOT {
+    let is_reserved = name == DOT || name == DOTDOT;
+    if name.is_empty() || is_reserved || name.contains('/') || name.contains('\0') {
         return Err(VfsError::InvalidInput);
     }
     if name.len() > MAX_NAME_LEN {
@@ -416,5 +417,24 @@ mod test {
         assert_eq!(Some("c"), Path::new("../a/b/c").file_name());
         assert_eq!(Some("b"), Path::new("a/b/.").file_name());
         assert_eq!(None, Path::new("a/..").file_name());
+    }
+
+    #[test]
+    fn verify_entry_name_rejects_invalid_components() {
+        for name in ["", DOT, DOTDOT, "a/b", "a\0b"] {
+            assert_eq!(verify_entry_name(name), Err(VfsError::InvalidInput));
+        }
+    }
+
+    #[test]
+    fn verify_entry_name_rejects_overlong_component() {
+        let name = "a".repeat(MAX_NAME_LEN + 1);
+
+        assert_eq!(verify_entry_name(&name), Err(VfsError::NameTooLong));
+    }
+
+    #[test]
+    fn verify_entry_name_accepts_regular_component() {
+        assert_eq!(verify_entry_name("file"), Ok(()));
     }
 }

--- a/net/ax-net/Cargo.toml
+++ b/net/ax-net/Cargo.toml
@@ -42,6 +42,7 @@ features = [
   "medium-ip",
   "proto-ipv4",
   "proto-ipv6",
+  "auto-icmp-echo-reply",
   "packetmeta-id",
   "socket-raw",
   "socket-icmp",

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -136,7 +136,7 @@ ax-memory-set = { workspace = true }
 num_enum = { version = "0.7", default-features = false }
 ouroboros = { version = "0.18", default-features = false }
 ax-percpu = { workspace = true }
-rand = { version = "0.10", default-features = false, features = ["alloc"] }
+rand = { version = "0.10", default-features = false, features = ["alloc", "chacha"] }
 ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }
 scope-local = { workspace = true }
 slab = { version = "0.4.9", default-features = false }

--- a/os/StarryOS/kernel/src/axtest_exports.rs
+++ b/os/StarryOS/kernel/src/axtest_exports.rs
@@ -29,3 +29,7 @@ pub fn invalid_timespec_is_rejected() -> bool {
     };
     invalid.try_into_time_value().is_err()
 }
+
+pub fn random_write_mixes_entropy() -> bool {
+    super::pseudofs::dev::random_write_mixes_entropy_for_test()
+}

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -40,7 +40,10 @@ pub mod tty;
 mod cvi_usb_camera;
 
 use alloc::{format, sync::Arc};
-use core::any::Any;
+use core::{
+    any::Any,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use ax_errno::AxError;
 use ax_sync::Mutex;
@@ -52,11 +55,13 @@ use spin::Once;
 pub static ION_DEVICE: Once<Arc<ion::IonDevice>> = Once::new();
 #[cfg(feature = "dev-log")]
 pub use log::bind_dev_log;
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{Rng, SeedableRng, rngs::ChaCha20Rng};
 
 use crate::pseudofs::{Device, DeviceOps, DirMaker, DirMapping, SimpleDir, SimpleFs};
 
-const RANDOM_SEED: &[u8; 32] = b"0123456789abcdef0123456789abcdef";
+const RANDOM_SEED_STEP: u64 = 0x9e37_79b9_7f4a_7c15;
+
+static RANDOM_SEED_COUNTER: AtomicU64 = AtomicU64::new(0xa076_1d64_78bd_642f);
 
 #[cfg(any(feature = "sg2002", feature = "k230-kpu"))]
 pub(super) struct IrqRegistration {
@@ -167,24 +172,67 @@ impl DeviceOps for Zero {
 }
 
 struct Random {
-    rng: Mutex<SmallRng>,
+    state: Mutex<RandomState>,
 }
 
 impl Random {
     pub fn new() -> Self {
         Self {
-            rng: Mutex::new(SmallRng::from_seed(*RANDOM_SEED)),
+            state: Mutex::new(RandomState::new(random_seed())),
         }
+    }
+
+    #[cfg(any(test, axtest))]
+    fn new_with_seed_for_test(seed: [u8; 32]) -> Self {
+        Self {
+            state: Mutex::new(RandomState::new(seed)),
+        }
+    }
+}
+
+struct RandomState {
+    rng: ChaCha20Rng,
+    reseed_count: u64,
+}
+
+impl RandomState {
+    fn new(seed: [u8; 32]) -> Self {
+        Self {
+            rng: ChaCha20Rng::from_seed(seed),
+            reseed_count: 0,
+        }
+    }
+
+    fn fill_bytes(&mut self, buf: &mut [u8]) {
+        self.rng.fill_bytes(buf);
+    }
+
+    fn mix_entropy(&mut self, entropy: &[u8]) {
+        let mut seed = [0; 32];
+        self.rng.fill_bytes(&mut seed);
+
+        self.reseed_count = self.reseed_count.wrapping_add(1);
+        fold_seed_word(&mut seed, entropy.len() as u64);
+        fold_seed_word(&mut seed, self.reseed_count);
+        fold_seed_word(&mut seed, time_entropy());
+
+        for (idx, byte) in entropy.iter().copied().enumerate() {
+            let seed_idx = idx % seed.len();
+            seed[seed_idx] ^= byte.rotate_left((idx & 7) as u32);
+        }
+
+        self.rng = ChaCha20Rng::from_seed(seed);
     }
 }
 
 impl DeviceOps for Random {
     fn read_at(&self, buf: &mut [u8], _offset: u64) -> VfsResult<usize> {
-        self.rng.lock().fill_bytes(buf);
+        self.state.lock().fill_bytes(buf);
         Ok(buf.len())
     }
 
     fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {
+        self.state.lock().mix_entropy(buf);
         Ok(buf.len())
     }
 
@@ -195,6 +243,68 @@ impl DeviceOps for Random {
     fn flags(&self) -> NodeFlags {
         NodeFlags::NON_CACHEABLE | NodeFlags::STREAM
     }
+}
+
+fn random_seed() -> [u8; 32] {
+    // This counter only perturbs seeds created in the same timer tick; it does
+    // not publish state to other threads.
+    let counter = RANDOM_SEED_COUNTER.fetch_add(RANDOM_SEED_STEP, Ordering::Relaxed);
+    let stack_addr = &counter as *const u64 as usize as u64;
+    let mut state = time_entropy() ^ counter ^ stack_addr.rotate_left(17);
+    let mut seed = [0; 32];
+
+    for chunk in seed.chunks_exact_mut(core::mem::size_of::<u64>()) {
+        state = splitmix64(state.wrapping_add(RANDOM_SEED_STEP));
+        chunk.copy_from_slice(&state.to_le_bytes());
+    }
+
+    seed
+}
+
+fn time_entropy() -> u64 {
+    ax_runtime::hal::time::monotonic_time_nanos()
+}
+
+fn fold_seed_word(seed: &mut [u8; 32], word: u64) {
+    let mixed = splitmix64(word);
+    for (idx, byte) in mixed.to_le_bytes().into_iter().enumerate() {
+        let seed_idx = idx * 4 % seed.len();
+        seed[seed_idx] ^= byte;
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[cfg(axtest)]
+pub(crate) fn random_write_mixes_entropy_for_test() -> bool {
+    let seed = *b"0123456789abcdef0123456789abcdef";
+    let baseline = Random::new_with_seed_for_test(seed);
+    let mixed = Random::new_with_seed_for_test(seed);
+    let mut discarded = [0; 32];
+    let mut baseline_next = [0; 32];
+    let mut mixed_next = [0; 32];
+
+    if baseline.read_at(&mut discarded, 0) != Ok(discarded.len()) {
+        return false;
+    }
+    if mixed.read_at(&mut discarded, 0) != Ok(discarded.len()) {
+        return false;
+    }
+    if mixed.write_at(b"caller entropy", 0) != Ok(14) {
+        return false;
+    }
+    if baseline.read_at(&mut baseline_next, 0) != Ok(baseline_next.len()) {
+        return false;
+    }
+    if mixed.read_at(&mut mixed_next, 0) != Ok(mixed_next.len()) {
+        return false;
+    }
+
+    baseline_next != mixed_next
 }
 
 struct Full;
@@ -599,4 +709,33 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
         );
     }
     SimpleDir::new_maker(fs, Arc::new(root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DeviceOps, Random};
+
+    #[test]
+    fn random_write_mixes_entropy_into_stream() {
+        let seed = *b"0123456789abcdef0123456789abcdef";
+        let baseline = Random::new_with_seed_for_test(seed);
+        let mixed = Random::new_with_seed_for_test(seed);
+        let mut discarded = [0; 32];
+        let mut baseline_next = [0; 32];
+        let mut mixed_next = [0; 32];
+
+        assert_eq!(
+            baseline.read_at(&mut discarded, 0).unwrap(),
+            discarded.len()
+        );
+        assert_eq!(mixed.read_at(&mut discarded, 0).unwrap(), discarded.len());
+        assert_eq!(mixed.write_at(b"caller entropy", 0).unwrap(), 14);
+        assert_eq!(
+            baseline.read_at(&mut baseline_next, 0).unwrap(),
+            baseline_next.len()
+        );
+        assert_eq!(mixed.read_at(&mut mixed_next, 0).unwrap(), mixed_next.len());
+
+        assert_ne!(baseline_next, mixed_next);
+    }
 }

--- a/os/StarryOS/kernel/tests/axtest_kernel.rs
+++ b/os/StarryOS/kernel/tests/axtest_kernel.rs
@@ -29,4 +29,9 @@ mod tests {
     fn timespec_rejects_invalid_nsec() {
         ax_assert!(axtest_exports::invalid_timespec_is_rejected());
     }
+
+    #[test]
+    fn random_write_mixes_entropy() {
+        ax_assert!(axtest_exports::random_write_mixes_entropy());
+    }
 }


### PR DESCRIPTION
## 问题

对比 openkylin/x-kernel 已合并修复后，本仓库还缺少两处可以迁移的行为修复：

- x-kernel !392：文件名组件校验不完整，`/dev/random` 使用固定种子且 `write` 不会扰动后续随机流。
- x-kernel !394：smoltcp 未启用 `auto-icmp-echo-reply`，接口层不会自动响应 ICMP echo request。

## 修改

- `axfs-ng-vfs` 的组件名校验补充拒绝空名、`.`、`..`、包含 `/` 或 NUL 的名字，以及过长名字；`DirNode::lookup` 也复用同一校验，避免直接 lookup 绕过创建/删除路径的校验。
- Starry `/dev/random` 从固定种子的 `SmallRng` 切换为 `ChaCha20Rng`，初始化种子混入单调时钟、全局计数和栈地址扰动；`write` 会把调用者数据、当前随机流、时间和计数重新混合后 reseed。
- `ax-net` 为 smoltcp 开启 `auto-icmp-echo-reply`。
- 增加 `axfs-ng-vfs` 单测和 Starry kernel axtest，覆盖非法文件名组件与 `/dev/random` 写入熵扰动。

## 设计逻辑

- 路径组件校验集中在 `verify_entry_name`，调用方不需要分别记住各类非法组件规则。
- `/dev/random` 仍不声明为硬件真随机源，但不再暴露固定可预测流，并允许用户写入数据扰动后续输出。
- ICMP echo reply 交给 smoltcp iface 层处理，避免只在个别 socket 路径补偿。

## 验证

- `cargo test -p axfs-ng-vfs verify_entry_name --lib`：新增路径校验用例修复前失败，修复后通过。
- `cargo xtask ktest qemu -p starry-kernel --test axtest_kernel`：新增 `random_write_mixes_entropy` 修复前失败，修复后通过。
- `cargo test -p axfs-ng-vfs --lib`
- `cargo xtask clippy --package axfs-ng-vfs`
- `cargo xtask clippy --package ax-net`
- `cargo xtask clippy --package starry-kernel`