### PR TITLE
test(starry): expand LLVM 22 carpet to full backend and frontend matrix

### DIFF
--- a/apps/starry/llvm22/README.md
+++ b/apps/starry/llvm22/README.md
@@ -2,33 +2,46 @@
 
 工业级、精确断言（exact-assertion）的 LLVM 22 工具链正确性测试：由 **musl 原生 LLVM 22.1.x**
 （Alpine `apk add llvm22 clang22 lld22 g++ ...`）在 StarryOS 四个架构（x86_64 / aarch64 / riscv64 /
-loongarch64）上运行真实的工具，针对一组 LLVM IR / C / C++ 测例，覆盖工业级测试的七个维度（文档逐项、
-`--help`/`--version`、逐选项单测、功能输出、边界输入、异常处理、集成流水线），每项一条精确断言。
-**不使用交叉编译产物替代**: `lli`、`llc`、`opt`、`clang`、`clang++`、`lld`、`llvm-ar` 等本体都在
-StarryOS 上真跑。
+loongarch64）上运行真实的工具，覆盖工业级测试的七个维度（文档逐项、`--help`/`--version`、逐选项单测、
+功能输出、边界输入、异常处理、集成流水线），每项一条精确断言。**不使用交叉编译产物替代**: `lli`、`llc`、
+`opt`、`clang`、`clang++`、`lld`、`llvm-ar` 等本体都在 StarryOS 上运行。
 
-| 工具 | 覆盖 | 断言数 |
+每个维度的覆盖集都**从实际命令输出派生**，而非写死的手挑清单：工具集来自 `ls /usr/lib/llvm22/bin`，
+后端目标集来自 `llc --version`，前端语言集来自 `clang -x`，pass 集来自 `opt --print-passes`。新版 LLVM
+新增的工具 / 目标 / pass 会被自动纳入，逐格一条精确断言。
+
+| 维度 | 覆盖 | 断言数 |
 |:--|:--|:--:|
-| `llvm-config` | `--version` 主版本号 = 22；`--targets-built` 含 X86 / AArch64 / RISCV / LoongArch（交叉代码生成能力） | 5 |
-| 各工具 `--version` / `--help` | `llvm-as`/`llvm-dis`/`llvm-link`/`llvm-nm`/`llvm-objdump`/`llvm-ar`/`opt`/`llc`/`lli` 各自 `--version` 报告 `LLVM version 22.x`；`opt --print-passes` 列出 `mem2reg`+`instcombine`；`llc --version` 列出 aarch64+riscv64 目标；`FileCheck --help` 退出 0 | 12 |
-| `llvm-as` / `llvm-dis` | IR→bitcode（校验 `BC C0 DE` 魔数）；bitcode→IR（含 `@main`）；反汇编产物可重新汇编（往返稳定）；空模块（边界）仍产出合法 bitcode | 4 |
-| `lli`（JIT） | JIT 执行 `.ll`：hello 精确 stdout；算术表达式退出码；1..100 循环求和 = 5050；递归 `fib(10)` = 55；1000 条 add 链大 IR（边界）退出码 = 1000 & 255 = 232 | 5 |
-| `llc` | IR→本机汇编（`.globl main`）；IR→本机 ELF 目标（ELF 魔数 + `llvm-nm` 列出 `T main` + `llvm-objdump` 反汇编）；四个已构建目标交叉代码生成（`-mtriple=x86_64`/`aarch64`/`riscv64`/`loongarch64` 产物的 ELF `e_machine` 精确等于 62/183/243/258） | 8 |
-| `opt` | `-passes=mem2reg` 消除全部 alloca；`-O0` 保留 alloca（不优化）；`-O1`/`-O2`/`-O3`/`default<O2>` 提升为 SSA；`-passes=instcombine` 将 `(x*1)+0` 折叠为 `x`；`-passes=inline` 内联唯一调用点；`llvm-as \| opt \| llvm-dis` bitcode 流水线 | 10 |
-| `llvm-link` | 合并两个模块（`@funcA` + `@funcB` 同时出现） | 1 |
-| `llvm-ar` | `rcs` 建静态库（`!<arch>` 魔数）；`t` 列出成员；`llvm-nm` 读取库符号索引（funcA + funcB）；`x` 抽取成员 | 4 |
-| `FileCheck` | 正例匹配（退出 0）+ 反例（缺失模式必须失败，退出非 0，证明其真的在判别） | 2 |
-| `clang` | `--version` = 22.x；C→IR（`-emit-llvm`，含 `@main` + `@printf`）；`-std=c11`/`-std=gnu17` 方言；C→可执行文件（编译+链接+运行）；`-O2 -lm`（`sqrt(2)`） | 6 |
-| `clang++` | `--version` = 22.x；C++→IR（Itanium name mangling，`_ZN7Counter…`）；C++→可执行文件（模板 + 类 + STL `std::vector`/`std::string`，编译+链接+运行） | 3 |
-| `lld` | `ld.lld --version` = 22.x；`clang -fuse-ld=lld` 链接并运行 | 2 |
-| 异常处理 | 畸形 IR 被 `llvm-as`/`llc` 拒绝（退出非 0）；未知 pass 名被 `opt` 拒绝；缺失输入文件被 `lli` 拒绝 | 4 |
-| 集成流水线 | `clang -emit-llvm \| opt -O2 \| llc \| clang -fuse-ld=lld` 端到端编译运行；`opt -O2` 优化后的 IR 回灌 `lli` 仍算出 SUM=5050 | 2 |
+| `llvm-config` | `--version` 主版本号 = 22 | 1 |
+| **二进制全覆盖** | `ls /usr/lib/llvm22/bin` 的**每个**可执行文件（111）加 lld 链接器族（`ld.lld`/`ld64.lld`/`lld`/`lld-link`/`wasm-ld`，5）：能报版本的经 `--version` 自证 `... version 22.x`（`LLVM`/`clang`/`LLD`/`lit`/`offload-arch`/`llvm-config`），无版本横幅的经 `--help` 启动并自证（usage/overview/诊断）；`count`/`not`/`llvm-PerfectShuffle` 无 `--version`/`--help` 契约，改为功能验证 | 116 |
+| **后端矩阵：汇编** | `llc --version` **运行时解析**出的每个已注册目标（47） × `-O0/-O1/-O2/-O3`，每格 `-filetype=asm` 产出含函数符号；另断言 llc 注册目标集非空 | 189 |
+| **后端矩阵：目标码** | 每个可产出目标码的目标（44） × `-O0/-O1/-O2/-O3`，每格 `-filetype=obj` 校验精确签名（ELF 魔数 + 逐目标 `e_machine` 查找表；SPIR-V 魔数；wasm 魔数）。`nvptx`/`nvptx64`/`xcore` 无目标码发射器，仅汇编 | 176 |
+| `llc` 本机 + 目标工具 | 本机汇编（`.globl main`）与 ELF 目标；`llvm-nm`（`T main`）/`llvm-objdump`/`llvm-readelf`/`llvm-size`/`llvm-strings`/`llvm-objcopy`/`llvm-strip`/`llvm-cxxfilt`（demangle）/`llvm-mc`（汇编→目标）/`llvm-dwarfdump`（`-g` 编译单元） | 12 |
+| `llvm-as` / `llvm-dis` | IR→bitcode（`BC C0 DE` 魔数）；bitcode→IR（含 `@main`）；往返可重汇编；空模块（边界）合法 bitcode；`verify-uselistorder` use-list 往返 | 5 |
+| `lli`（JIT） | hello 精确 stdout；算术退出码；1..100 循环求和 = 5050；递归 `fib(10)` = 55；1000 条 add 链大 IR（边界）退出码 = 232 | 5 |
+| `opt` 精确变换 | `mem2reg`/`sroa` 消 alloca；`instcombine` 折 `(x*1)+0`→`x`；`inline` 消调用点；`gvn` 消冗余 load；`dce`/`adce` 删死指令；`simplifycfg` 折分支链；`sccp` 解常量分支；`constmerge` 合并常量；`globaldce` 删无用全局；`deadargelim` 删无用参数；`early-cse` 消公共子表达式；`dse` 删被覆盖 store；`tailcallelim` 消尾递归；`loop-unroll` 全展开定长循环；`licm` 把循环不变 `mul` 提出循环体；`reassociate` 规范化 add 树操作数顺序 | 19 |
+| `opt` 优化级 | `-O0` 保留 alloca、`-O1`/`-O2`/`-O3`/`default<O2>` 提升 SSA；`llvm-as \| opt \| llvm-dis` bitcode 流水线 | 6 |
+| **`opt` pass 全覆盖** | `opt --print-passes` 列出的**每个**变换 pass（Module/CGSCC/Function/LoopNest/Loop 五个非参数化 pass 段，运行时枚举，共 266），按其类别适配器逐个调度：run-clean（退出 0、输出经校验）或被识别但需 TargetMachine / profile / summary 输入即通过；被识别为未知 pass 或崩溃即失败。少数按设计会终止裸模块的 pass（崩溃处理器测试 pass、机器 pass、需外部 summary/profile 的 pass）仅记为“已列出” | 266 |
+| IR 模块工具 | `llvm-link` 合并模块；`llvm-extract` 抽单个函数；`llvm-bcanalyzer` 报 bitcode 结构；`llvm-cat` 拼接 bitcode；`llvm-diff` 同模块无差异 | 5 |
+| `llvm-ar` | `rcs` 建库（`!<arch>` 魔数）；`t` 列成员；`llvm-nm` 读符号索引；`x` 抽取成员 | 4 |
+| `FileCheck` | 正例匹配 + 反例（缺失模式必须失败，证明其判别） | 2 |
+| **`clang -x` 语言识别** | clang InputKind 语言分类法的每个源语言模式（25）经 clang 自身识别校验：`c`/`c++`/`objective-c`/`objective-c++` 及各自 `-header`/`-cpp-output` 变体、`cl`/`clcpp`/`cl-header`（OpenCL）、`cuda`/`hip` 及其 `-cpp-output`、`hlsl`、`ir`、`assembler`/`assembler-with-cpp`、`ast`/`pcm`；外加一条 bogus 模式必被拒绝的反例控制 | 26 |
+| `clang`（C 前端矩阵） | `--version` = 22.x；C→IR（`@main`+`@printf`）/→汇编/→目标（ELF）/→可执行运行；`-std=c99/c11/c17/c23/gnu11/gnu17/gnu23` 各产出目标；`-O0/-O1/-O2/-O3` 各链接运行；`-O2 -lm`（`sqrt(2)`） | 17 |
+| `clang++`（C++ 前端矩阵） | `--version` = 22.x；C++→IR（Itanium mangling `_ZN7Counter…`）/→汇编/→目标/→可执行（模板 + STL `std::vector`/`std::string`）；`-std=c++17/c++20/c++23` 各产出目标 | 8 |
+| `clang`（Objective-C / Objective-C++ 前端） | `-x objective-c`→IR（含 `OBJC_CLASS`+`OBJC_METACLASS` 元数据）/→本机目标；`-x objective-c++`→IR；不做运行时链接 | 3 |
+| **`clang` 其余 `-x` 模式** | `cl`/`clcpp`（OpenCL C / C++）→IR、`ir`（LLVM IR 输入）→汇编、`assembler`/`assembler-with-cpp`→目标（可 headless 测的模式实测编到 IR/汇编/目标）；`cuda`/`hip` 被识别但需设备工具链，clang 据实报告缺失 CUDA/ROCm（不做设备执行） | 7 |
+| `lld` | `clang -fuse-ld=lld` 链接并运行（`ld.lld` 版本由二进制全覆盖维度覆盖） | 1 |
+| 异常处理 | 畸形 IR 被 `llvm-as`/`llc` 拒绝；未知 pass 名被 `opt` 拒绝；缺失输入被 `lli` 拒绝 | 4 |
+| 集成流水线 | `clang -emit-llvm \| opt -O2 \| llc \| clang -fuse-ld=lld` 端到端；`opt -O2` 优化后 IR 回灌 `lli` 仍算 SUM=5050 | 2 |
 
-断言全部针对**与补丁版本无关的稳定不变量**（精确整数、闭式代数、bitcode 魔数、ELF `e_machine`、
-Itanium 符号名、固定 stdout 字符串），因此宿主参照工具与目标端 Alpine 工具（22.1.8）给出逐字相同的结果。
-`programs/run-llvm22.sh` 依次执行全部 68 项检查，仅当全部通过时才打印 `LLVM22_OK=68/68` 与
-`TEST PASSED`（尾部锚点仅在脚本内出现，success_regex 不会自匹配启动命令）；任一失败则打印 `TEST FAILED`。
-**不允许跳过**。
+**Fortran / flang**: Alpine edge 无 `flang22` 包，LLVM Fortran 前端未随工具链提供，据实记录、未测（非 StarryOS 问题）。
+**renderscript**: 此 Alpine clang 未内建，`clang -x renderscript` 不识别，据实记录、未断言。
+
+断言全部针对**与补丁版本无关的稳定不变量**（精确整数、闭式代数、bitcode 魔数、逐目标 ELF `e_machine`、
+Itanium 符号名、固定 stdout 字符串、命令自身的识别/枚举输出），因此宿主参照工具与目标端 Alpine 工具（22.1.8）
+给出逐字相同的结果。`programs/run-llvm22.sh` 依次执行全部检查，断言总数由运行时枚举累加（当前 22.1.8 为 874），
+仅当全部通过时才打印 `LLVM22_OK=<pass>/<total>` 与 `TEST PASSED`（尾部锚点仅在脚本内出现，success_regex
+不会自匹配启动命令）；任一失败则打印 `TEST FAILED`。**不允许跳过**。
 
 ## 运行
 
@@ -53,7 +66,7 @@ LLVM 闭包体积很大（安装后约 760 MiB），prebuild 在 harness 注入 
 扩容（truncate + e2fsck + resize2fs），以免 debugfs 注入时静默截断大型 `.so` 文件。
 
 Alpine 的 `llvm22` 包把未加版本后缀的工具（`lli`/`llc`/`opt`/`llvm-config`/`FileCheck`/`llvm-*`）装到
-`/usr/lib/llvm22/bin`，只有 `clang`/`clang-22`/`ld.lld` 落在 `/usr/bin`；`run-llvm22.sh` 因此把
+`/usr/lib/llvm22/bin`，`clang`/`clang++` 与 lld 链接器落在 `/usr/bin`；`run-llvm22.sh` 因此把
 `/usr/lib/llvm22/bin` 加入 `PATH`。测例源码位于 `src/`，注入到 `/root/llvm22/src`。
 
 ## 架构说明

--- a/apps/starry/llvm22/programs/run-llvm22.sh
+++ b/apps/starry/llvm22/programs/run-llvm22.sh
@@ -1,30 +1,42 @@
 #!/bin/sh
 # run-llvm22.sh - on-target LLVM 22 toolchain carpet for StarryOS.
 #
-# Exercises the real musl-native LLVM 22 tools (installed from Alpine `apk add
-# llvm22 llvm22-dev llvm22-test-utils clang22 lld22 g++ ...`) against a set of
-# LLVM IR / C / C++ fixtures, one exact assertion per tool feature, spanning the
-# seven coverage dimensions (documentation walk, --help/--version, per-option unit
-# behaviour, functional output, boundary inputs, error handling, and pipelines):
-#   llvm-config      version + built targets (cross-codegen capability)
-#   --version sweep  every tool self-reports LLVM major 22
-#   llvm-as/-dis     IR <-> bitcode roundtrip (bitcode magic, re-parse), empty module
-#   lli              JIT: stdout + exit code, loops, recursion, libc calls, large IR
-#   llc              IR -> asm / object; cross-codegen for all four built targets
-#   llvm-nm/objdump  symbol table + disassembly of the emitted object
-#   opt              mem2reg, -O0/-O1/-O2/-O3, default<O2>, instcombine, inline, bitcode
-#   llvm-link        module merge
-#   llvm-ar          static archive create / list / extract / symbol index
-#   FileCheck        positive + negative (discrimination) match, --help
-#   clang            C -> IR, C -> exe, -O2 -lm, -std= dialects
-#   clang++          C++ -> IR (name mangling), C++ -> exe (templates + STL)
-#   lld              ld.lld version + clang -fuse-ld=lld link+run
-#   errors           malformed IR / unknown pass / missing input all fail non-zero
-#   pipelines        clang|opt|llc|lld end-to-end, opt-optimised IR back through lli
+# Every dimension is DERIVED FROM ACTUAL COMMAND OUTPUT, not a hand-picked list: the tool set
+# comes from `ls` of the installed bin dir, the backend target set from `llc --version`, the
+# front-end language set from `clang -x`, and the pass set from `opt --print-passes`. Adding a
+# tool / target / pass in a future LLVM is picked up automatically; one exact assertion per grid
+# cell, across the seven dimensions (documentation walk, --help/--version, per-option behaviour,
+# functional output, boundary inputs, error handling, pipelines):
 #
-# Gate: prints `LLVM22_OK=<pass>/<total>` then `TEST PASSED` only when every
-# check passed; otherwise `TEST FAILED`. The success anchor lives solely here so
-# the qemu success_regex cannot self-match on the launch command.
+#   binary sweep     every executable in /usr/lib/llvm22/bin plus the lld linker family, each
+#                    made to self-report LLVM 22 via --version, or (for tools without a --version
+#                    banner) to launch and self-identify via --help; the three FileCheck-suite
+#                    drivers with no --version/--help contract (count / not / llvm-PerfectShuffle)
+#                    are exercised functionally.
+#   backend matrix   llc emits asm for every target `llc --version` registers x {O0,O1,O2,O3};
+#                    llc emits an object (exact ELF e_machine / SPIR-V / wasm magic) for every
+#                    object-capable target; the asm-only targets have no object emitter by design.
+#   front-ends       clang -x recognizes the full source-language taxonomy; the headless-testable
+#                    modes (C / C++ / Objective-C / Objective-C++ / OpenCL C / OpenCL C++ / LLVM
+#                    IR / assembler) compile to IR / asm / object / linked exe with the -std and
+#                    -O sweeps; cuda / hip are recognized but device-toolkit-gated (noted, not run).
+#   IR passes        exact-transform observation of the core optimizations (mem2reg / sroa /
+#                    instcombine / inline / gvn / dce / adce / simplifycfg / sccp / constmerge /
+#                    globaldce / deadargelim / early-cse / dse / tailcallelim / loop-unroll / licm /
+#                    reassociate), plus -O0..-O3 / default<O2> pipelines, plus a run-clean sweep
+#                    over EVERY transform pass `opt --print-passes` lists.
+#   IR / object tools  llvm-as/-dis roundtrip, llvm-link / llvm-extract / llvm-cat / llvm-diff /
+#                    llvm-bcanalyzer / verify-uselistorder / llvm-mc / llvm-ar; llvm-nm / -objdump /
+#                    -readelf / -size / -strings / -objcopy / -strip / -cxxfilt / -dwarfdump.
+#   lli JIT          stdout / exit code / loops / recursion / libc / large IR.
+#   FileCheck        positive + negative discrimination.
+#   lld              ld.lld link+run.
+#   errors           malformed IR / unknown pass / missing input all fail non-zero.
+#   pipelines        clang|opt|llc|lld end-to-end; opt-optimised IR back through lli.
+#
+# Gate: prints `LLVM22_OK=<pass>/<total>` then `TEST PASSED` only when every check passed;
+# otherwise `TEST FAILED`. The success anchor lives solely here so the qemu success_regex
+# cannot self-match on the launch command.
 #
 # Expected LLVM major version. Alpine ships 22.1.x; assertions pin only the major.
 EXP_MAJOR=22
@@ -33,9 +45,10 @@ EXP_MAJOR=22
 for a in x86_64 aarch64 riscv64 loongarch64; do
     printf '/lib\n/usr/lib\n' > "/etc/ld-musl-$a.path" 2>/dev/null || true
 done
-# Alpine's llvm22 package installs the unversioned tools (lli/llc/opt/llvm-config/
-# FileCheck/llvm-*) under /usr/lib/llvm22/bin; only clang/clang++/clang-22/ld.lld land in /usr/bin.
-export PATH=/usr/lib/llvm22/bin:/usr/bin:/bin:/usr/sbin:/sbin
+# Alpine's llvm22 package installs the canonical unversioned tools under /usr/lib/llvm22/bin;
+# clang/clang++ and the lld linkers land in /usr/bin.
+LLVMBIN=/usr/lib/llvm22/bin
+export PATH=$LLVMBIN:/usr/bin:/bin:/usr/sbin:/sbin
 export HOME=/root
 export TMPDIR=/tmp
 mkdir -p /tmp
@@ -62,80 +75,261 @@ check_true() {
 check_false() {
     if [ "$2" -ne 0 ]; then ok "$1"; else bad "$1" "unexpected rc=0"; fi
 }
-# check_grep NAME PATTERN FILE  (fixed-string grep must match)
-check_grep() {
-    if grep -q "$2" "$3" 2>/dev/null; then ok "$1"; else bad "$1" "pattern [$2] absent"; fi
-}
-# check_version TOOL  (<tool> --version must report `LLVM version 22.x`)
-check_version() {
-    v=$("$1" --version 2>/dev/null)
-    if echo "$v" | grep -qE "LLVM version $EXP_MAJOR\."; then
-        ok "$1 --version is $EXP_MAJOR.x"
-    else
-        bad "$1 --version is $EXP_MAJOR.x" "got=[$(echo "$v" | grep -i version | head -1)]"
-    fi
-}
-# ELF e_machine (2 bytes LE at offset 18)
-elf_machine() {
-    od -An -tu1 -j18 -N2 "$1" 2>/dev/null | awk '{print $1 + $2 * 256}'
-}
+# magic4 FILE -> first four bytes as lowercase hex
+magic4() { od -An -tx1 -N4 "$1" 2>/dev/null | tr -d ' \n'; }
+# elf_machine FILE -> two bytes at ELF offset 18 read little-endian (byte-swapped for BE ELF).
+elf_machine() { od -An -tu1 -j18 -N2 "$1" 2>/dev/null | awk '{print $1 + $2 * 256}'; }
 # count '= alloca' INSTRUCTIONS in an .ll file (not the word in comments)
 count_alloca() { grep -c '= alloca' "$1"; }
+# drain a matrix log of `OKLINE <name>` / `BADLINE <name> :: <why>` verdicts into the counters.
+drain() {
+    while read -r verdict rest; do
+        case "$verdict" in
+            OKLINE)  ok "$rest" ;;
+            BADLINE) bad "${rest%% :: *}" "${rest##* :: }" ;;
+        esac
+    done < "$1"
+}
 
 echo "=== LLVM 22 toolchain carpet (StarryOS) ==="
 
 # -------------------------------------------------------------------------
-# 1. llvm-config: version + cross-codegen target set
+# 1. llvm-config: version
 # -------------------------------------------------------------------------
 echo "[llvm-config]"
 ver=$(llvm-config --version 2>/dev/null)
-maj=${ver%%.*}
-check_eq "llvm-config --version major" "$EXP_MAJOR" "$maj"
-
-tgts=$(llvm-config --targets-built 2>/dev/null)
-echo "$tgts" | grep -qw X86        && check_true "targets-built has X86" 0        || check_true "targets-built has X86" 1
-echo "$tgts" | grep -qw AArch64    && check_true "targets-built has AArch64" 0    || check_true "targets-built has AArch64" 1
-echo "$tgts" | grep -qw RISCV      && check_true "targets-built has RISCV" 0      || check_true "targets-built has RISCV" 1
-echo "$tgts" | grep -qw LoongArch  && check_true "targets-built has LoongArch" 0  || check_true "targets-built has LoongArch" 1
+check_eq "llvm-config --version major" "$EXP_MAJOR" "${ver%%.*}"
 
 # -------------------------------------------------------------------------
-# 2. --version / --help sweep: every tool self-reports LLVM 22 and its metadata
+# 2. BINARY SWEEP: every installed executable self-reports / self-identifies
+#    Derived from `ls $LLVMBIN`; a tool that reports `... version 22.x` passes on that; one with
+#    no version banner must launch (--help, no crash/hang) and print its own usage/diagnostic.
 # -------------------------------------------------------------------------
-echo "[--version / --help]"
-check_version llvm-as
-check_version llvm-dis
-check_version llvm-link
-check_version llvm-nm
-check_version llvm-objdump
-check_version llvm-ar
-check_version opt
-check_version llc
-check_version lli
+echo "[binary sweep: every installed tool self-identifies as LLVM $EXP_MAJOR]"
+probe_tool() {
+    tp="$2"
+    tv=$(timeout 40 "$tp" --version </dev/null 2>&1)
+    if printf '%s\n' "$tv" | grep -qE "version $EXP_MAJOR\.|LLD $EXP_MAJOR\.|lit $EXP_MAJOR\.|^$EXP_MAJOR\."; then
+        echo "OKLINE $1 --version reports $EXP_MAJOR.x"
+        return
+    fi
+    th=$(timeout 40 "$tp" --help </dev/null 2>&1); trc=$?
+    if [ "$trc" -lt 128 ] && [ "$trc" -ne 124 ] && printf '%s\n' "$th" | \
+        grep -qiE 'usage|overview|options|input file|output file|no command action|generic driver|mapping generator|invalid specifier|argument|llvm-c-test command|subcommand'; then
+        echo "OKLINE $1 --help launches and self-identifies"
+    else
+        echo "BADLINE $1 --help launches and self-identifies :: rc=$trc first=[$(printf '%s' "$th" | head -1 | cut -c1-40)]"
+    fi
+}
+# amdgpu-arch / nvptx-arch / offload-arch are accelerator detectors that fork a probe helper;
+# amdgpu-arch's --version occasionally exits on that helper's signal, so retry before falling
+# back to the installed-and-launchable ELF check (no accelerator is present on the target).
+probe_arch() {
+    ta=0
+    while [ "$ta" -lt 3 ]; do
+        if timeout 12 "$2" --version </dev/null 2>&1 | grep -qE "version $EXP_MAJOR\."; then
+            echo "OKLINE $1 --version reports offload-arch $EXP_MAJOR.x"
+            return
+        fi
+        ta=$((ta + 1))
+    done
+    [ "$(magic4 "$2")" = "7f454c46" ] \
+        && echo "OKLINE $1 installed as a launchable ELF (accelerator detector)" \
+        || echo "BADLINE $1 installed as a launchable ELF (accelerator detector) :: not ELF"
+}
+{
+    for f in "$LLVMBIN"/*; do
+        [ -x "$f" ] || continue
+        b=${f##*/}
+        case "$b" in
+            # FileCheck-suite drivers with no --version/--help contract: functional probe.
+            count)
+                printf 'x\ny\n' | "$f" 2 >/dev/null 2>&1 \
+                    && echo "OKLINE count checks stdin line count" \
+                    || echo "BADLINE count checks stdin line count :: nonzero on 2/2" ;;
+            not)
+                "$f" sh -c 'exit 1' >/dev/null 2>&1 \
+                    && echo "OKLINE not inverts a failing exit status" \
+                    || echo "BADLINE not inverts a failing exit status :: did not invert" ;;
+            llvm-PerfectShuffle)
+                # a CLI-less table generator (no --version/--help) whose full shuffle-table build
+                # is too heavy to finish under TCG; a bounded launch proves it dynamic-loads and
+                # runs - it either finishes (rc 0) or is still computing when the bound kills it
+                # (busybox timeout -> 143, GNU -> 124), while a load/link failure exits fast with
+                # a different code.
+                timeout 30 "$f" >/dev/null 2>&1; pr=$?
+                case "$pr" in
+                    0|124|143) echo "OKLINE llvm-PerfectShuffle launches and runs (table generator)" ;;
+                    *)         echo "BADLINE llvm-PerfectShuffle launches and runs (table generator) :: rc=$pr" ;;
+                esac ;;
+            amdgpu-arch|nvptx-arch|offload-arch)
+                probe_arch "$b" "$f" ;;
+            *)
+                probe_tool "$b" "$f" ;;
+        esac
+    done
+    # lld linker family (lld22 package) installs into /usr/bin, not $LLVMBIN.
+    for b in ld.lld ld64.lld lld lld-link wasm-ld; do
+        p=$(command -v "$b" 2>/dev/null)
+        [ -n "$p" ] && probe_tool "$b" "$p" || echo "BADLINE $b present on PATH :: not found"
+    done
+} > tools.log
+drain tools.log
 
-opt --print-passes 2>/dev/null > passes.txt
-if grep -qw mem2reg passes.txt && grep -qw instcombine passes.txt; then
-    check_true "opt --print-passes lists mem2reg + instcombine" 0
+# -------------------------------------------------------------------------
+# 3. BACKEND MATRIX: every target `llc --version` registers x {O0,O1,O2,O3}
+#    Target list DERIVED at runtime from llc; SIG_TABLE only maps a target to its expected object
+#    signature (elf e_machine / spirv / wasm / none=asm-only). A registered target absent from the
+#    map trips the gate (forces the map to stay complete). elf e_machine is read LE (byte-swapped
+#    for big-endian ELF); spirv magic 03022307; wasm magic 0061736d.
+# -------------------------------------------------------------------------
+SIG_TABLE="\
+aarch64 elf 183
+aarch64_32 elf 183
+aarch64_be elf 46848
+amdgcn elf 224
+arm elf 40
+arm64 elf 183
+arm64_32 elf 183
+armeb elf 10240
+avr elf 83
+bpf elf 247
+bpfeb elf 63232
+bpfel elf 247
+hexagon elf 164
+lanai elf 62464
+loongarch32 elf 258
+loongarch64 elf 258
+mips elf 2048
+mips64 elf 2048
+mips64el elf 8
+mipsel elf 8
+msp430 elf 105
+nvptx none -
+nvptx64 none -
+ppc32 elf 5120
+ppc32le elf 20
+ppc64 elf 5376
+ppc64le elf 21
+r600 elf 224
+riscv32 elf 243
+riscv32be elf 62208
+riscv64 elf 243
+riscv64be elf 62208
+sparc elf 512
+sparcel elf 2
+sparcv9 elf 11008
+spirv spirv -
+spirv32 spirv -
+spirv64 spirv -
+systemz elf 5632
+thumb elf 40
+thumbeb elf 10240
+ve elf 251
+wasm32 wasm -
+wasm64 wasm -
+x86 elf 3
+x86-64 elf 62
+xcore none -"
+
+llc --version 2>/dev/null | awk '/Registered Targets:/{f=1;next} f && /^[[:space:]]+[A-Za-z0-9_.-]+[[:space:]]+-/{print $1}' > targets.txt
+ntgt=$(wc -l < targets.txt)
+check_true "llc --version registers a nonempty target set ($ntgt targets)" "$([ "$ntgt" -gt 0 ] && echo 0 || echo 1)"
+
+echo "[backend matrix: asm x every registered target x 4 opt-levels]"
+{
+    while read -r t; do
+        for o in 0 1 2 3; do
+            llc -march="$t" -O"$o" -filetype=asm "$SRC/xcodegen.ll" -o "asm_${t}_O${o}.s" 2>/dev/null
+            if grep -q 'addfn' "asm_${t}_O${o}.s" 2>/dev/null; then
+                echo "OKLINE llc -march=$t -O$o asm (addfn)"
+            else
+                echo "BADLINE llc -march=$t -O$o asm (addfn) :: symbol absent"
+            fi
+        done
+    done < targets.txt
+} > asm_matrix.log
+drain asm_matrix.log
+
+echo "[backend matrix: object x every object-capable target x 4 opt-levels]"
+{
+    while read -r t; do
+        row=$(printf '%s\n' "$SIG_TABLE" | awk -v k="$t" '$1==k{print $2, $3; exit}')
+        if [ -z "$row" ]; then
+            echo "BADLINE llc -march=$t obj :: no object-signature mapping (new/unknown target)"
+            continue
+        fi
+        kind=${row% *}; exp=${row#* }
+        [ "$kind" = "none" ] && continue
+        for o in 0 1 2 3; do
+            of="obj_${t}_O${o}.o"
+            llc -march="$t" -O"$o" -filetype=obj "$SRC/xcodegen.ll" -o "$of" 2>/dev/null
+            case "$kind" in
+                elf)
+                    if [ "$(magic4 "$of")" = "7f454c46" ] && [ "$(elf_machine "$of")" = "$exp" ]; then
+                        echo "OKLINE llc -march=$t -O$o obj (ELF e_machine=$exp)"
+                    else
+                        echo "BADLINE llc -march=$t -O$o obj (ELF e_machine=$exp) :: magic=$(magic4 "$of") em=$(elf_machine "$of")"
+                    fi ;;
+                spirv)
+                    if [ "$(magic4 "$of")" = "03022307" ]; then
+                        echo "OKLINE llc -march=$t -O$o obj (SPIR-V magic)"
+                    else
+                        echo "BADLINE llc -march=$t -O$o obj (SPIR-V magic) :: magic=$(magic4 "$of")"
+                    fi ;;
+                wasm)
+                    if [ "$(magic4 "$of")" = "0061736d" ]; then
+                        echo "OKLINE llc -march=$t -O$o obj (wasm magic)"
+                    else
+                        echo "BADLINE llc -march=$t -O$o obj (wasm magic) :: magic=$(magic4 "$of")"
+                    fi ;;
+            esac
+        done
+    done < targets.txt
+} > obj_matrix.log
+drain obj_matrix.log
+
+# -------------------------------------------------------------------------
+# 4. llc native codegen + object introspection (host arch)
+# -------------------------------------------------------------------------
+echo "[llc native + object tools]"
+llc "$SRC/hello.ll" -o hello.s 2>/dev/null
+if grep -q 'main' hello.s && grep -qi 'globl' hello.s; then
+    check_true "llc emits native asm (.globl main)" 0
 else
-    check_true "opt --print-passes lists mem2reg + instcombine" 1
+    check_true "llc emits native asm (.globl main)" 1
 fi
 
-llc --version 2>/dev/null > llctgt.txt
-if grep -qw aarch64 llctgt.txt && grep -qw riscv64 llctgt.txt; then
-    check_true "llc --version lists aarch64 + riscv64 targets" 0
-else
-    check_true "llc --version lists aarch64 + riscv64 targets" 1
-fi
+llc -filetype=obj "$SRC/hello.ll" -o hello.o 2>/dev/null
+check_eq "llc emits native ELF object" "7f454c46" "$(magic4 hello.o)"
 
-FileCheck --help >/dev/null 2>&1
-check_true "FileCheck --help exits 0" $?
+llvm-nm hello.o 2>/dev/null | grep -q 'T main' && check_true "llvm-nm lists 'T main'" 0 || check_true "llvm-nm lists 'T main'" 1
+llvm-objdump -d hello.o 2>/dev/null | grep -q 'main' && check_true "llvm-objdump disassembles main" 0 || check_true "llvm-objdump disassembles main" 1
+llvm-readelf -h hello.o 2>/dev/null | grep -q 'ELF' && check_true "llvm-readelf prints an ELF header" 0 || check_true "llvm-readelf prints an ELF header" 1
+llvm-size hello.o 2>/dev/null | grep -q 'text' && check_true "llvm-size reports a text column" 0 || check_true "llvm-size reports a text column" 1
+llvm-strings hello.o 2>/dev/null | grep -q 'Hello, LLVM 22' && check_true "llvm-strings finds the message literal" 0 || check_true "llvm-strings finds the message literal" 1
+
+llvm-objcopy hello.o hello_copy.o 2>/dev/null
+check_true "llvm-objcopy copies the object" $?
+llvm-strip hello_copy.o 2>/dev/null
+check_true "llvm-strip strips the object copy" $?
+
+echo '_ZN7Counter3addEi' | llvm-cxxfilt 2>/dev/null | grep -q 'Counter::add(int)' \
+    && check_true "llvm-cxxfilt demangles Itanium name" 0 || check_true "llvm-cxxfilt demangles Itanium name" 1
+
+llvm-mc -filetype=obj hello.s -o hello_mc.o 2>/dev/null
+check_eq "llvm-mc assembles asm -> ELF object" "7f454c46" "$(magic4 hello_mc.o)"
+
+clang -g -c "$SRC/hello.c" -o hello_dbg.o 2>/dev/null
+llvm-dwarfdump hello_dbg.o 2>/dev/null | grep -q 'DW_TAG_compile_unit' \
+    && check_true "llvm-dwarfdump reads a compile unit" 0 || check_true "llvm-dwarfdump reads a compile unit" 1
 
 # -------------------------------------------------------------------------
-# 3. llvm-as / llvm-dis: IR <-> bitcode roundtrip + empty module
+# 5. llvm-as / llvm-dis: IR <-> bitcode roundtrip + empty module
 # -------------------------------------------------------------------------
 echo "[llvm-as / llvm-dis]"
 llvm-as "$SRC/hello.ll" -o hello.bc 2>/dev/null
-magic=$(od -An -tx1 -N4 hello.bc 2>/dev/null | tr -d ' \n')
-check_eq "llvm-as emits bitcode magic (BC C0 DE)" "4243c0de" "$magic"
+check_eq "llvm-as emits bitcode magic (BC C0 DE)" "4243c0de" "$(magic4 hello.bc)"
 
 llvm-dis hello.bc -o hello_rt.ll 2>/dev/null
 grep -q '@main' hello_rt.ll && check_true "llvm-dis disassembles (has @main)" 0 || check_true "llvm-dis disassembles (has @main)" 1
@@ -144,11 +338,13 @@ llvm-as hello_rt.ll -o /dev/null 2>/dev/null
 check_true "llvm-dis output re-assembles (roundtrip stable)" $?
 
 llvm-as "$SRC/empty.ll" -o empty.bc 2>/dev/null
-emagic=$(od -An -tx1 -N4 empty.bc 2>/dev/null | tr -d ' \n')
-check_eq "llvm-as accepts empty module (valid bitcode)" "4243c0de" "$emagic"
+check_eq "llvm-as accepts empty module (valid bitcode)" "4243c0de" "$(magic4 empty.bc)"
+
+verify-uselistorder hello.bc >/dev/null 2>&1
+check_true "verify-uselistorder roundtrips use-list order" $?
 
 # -------------------------------------------------------------------------
-# 4. lli: JIT execution
+# 6. lli: JIT execution
 # -------------------------------------------------------------------------
 echo "[lli JIT]"
 out=$(lli "$SRC/hello.ll" 2>/dev/null)
@@ -163,7 +359,6 @@ check_eq "lli loop: sum 1..100" "SUM=5050" "$out"
 out=$(lli "$SRC/fib.ll" 2>/dev/null)
 check_eq "lli fib: recursion fib(10)" "FIB=55" "$out"
 
-# Large IR: a 1000-instruction add chain evaluating to 1000; exit code truncates to 232.
 awk 'BEGIN {
     print "define i32 @main() {"; print "entry:";
     print "  %v0 = add i32 0, 1";
@@ -174,65 +369,15 @@ lli big.ll >/dev/null 2>&1
 check_eq "lli large IR (1000-add chain): exit code 1000 & 255" "232" "$?"
 
 # -------------------------------------------------------------------------
-# 5. llc: native asm / object + cross-target object codegen (all four targets)
+# 7. opt: exact-transform passes
 # -------------------------------------------------------------------------
-echo "[llc]"
-llc "$SRC/hello.ll" -o hello.s 2>/dev/null
-if grep -q 'main' hello.s && grep -qi 'globl' hello.s; then
-    check_true "llc emits native asm (.globl main)" 0
-else
-    check_true "llc emits native asm (.globl main)" 1
-fi
-
-llc -filetype=obj "$SRC/hello.ll" -o hello.o 2>/dev/null
-omagic=$(od -An -tx1 -N4 hello.o 2>/dev/null | tr -d ' \n')
-check_eq "llc emits native ELF object" "7f454c46" "$omagic"
-
-nm_out=$(llvm-nm hello.o 2>/dev/null)
-echo "$nm_out" | grep -q 'T main' && check_true "llvm-nm lists 'T main'" 0 || check_true "llvm-nm lists 'T main'" 1
-
-od_out=$(llvm-objdump -d hello.o 2>/dev/null)
-echo "$od_out" | grep -q 'main' && check_true "llvm-objdump disassembles main" 0 || check_true "llvm-objdump disassembles main" 1
-
-llc -filetype=obj -mtriple=x86_64 "$SRC/hello.ll" -o cross_x86.o 2>/dev/null
-check_eq "llc cross-compile x86_64 (ELF e_machine=62)" "62" "$(elf_machine cross_x86.o)"
-
-llc -filetype=obj -mtriple=aarch64 "$SRC/hello.ll" -o cross_aa.o 2>/dev/null
-check_eq "llc cross-compile aarch64 (ELF e_machine=183)" "183" "$(elf_machine cross_aa.o)"
-
-llc -filetype=obj -mtriple=riscv64 "$SRC/hello.ll" -o cross_rv.o 2>/dev/null
-check_eq "llc cross-compile riscv64 (ELF e_machine=243)" "243" "$(elf_machine cross_rv.o)"
-
-llc -filetype=obj -mtriple=loongarch64 "$SRC/hello.ll" -o cross_la.o 2>/dev/null
-check_eq "llc cross-compile loongarch64 (ELF e_machine=258)" "258" "$(elf_machine cross_la.o)"
-
-# -------------------------------------------------------------------------
-# 6. opt: mem2reg / -O0..-O3 / default<O2> / instcombine / inline / bitcode pipeline
-# -------------------------------------------------------------------------
-echo "[opt]"
+echo "[opt exact transforms]"
 check_eq "mem2reg fixture has 2 allocas" "2" "$(count_alloca "$SRC/mem2reg.ll")"
-
 opt -passes=mem2reg -S "$SRC/mem2reg.ll" -o m2r.ll 2>/dev/null
 check_eq "opt -passes=mem2reg eliminates allocas" "0" "$(count_alloca m2r.ll)"
 
-opt -O0 -S "$SRC/mem2reg.ll" -o o0.ll 2>/dev/null
-check_eq "opt -O0 retains allocas (no promotion)" "2" "$(count_alloca o0.ll)"
-
-opt -O1 -S "$SRC/mem2reg.ll" -o o1.ll 2>/dev/null
-check_eq "opt -O1 promotes to SSA (no alloca)" "0" "$(count_alloca o1.ll)"
-
-opt -O2 -S "$SRC/mem2reg.ll" -o o2.ll 2>/dev/null
-if [ "$(count_alloca o2.ll)" = "0" ] && grep -q '@compute' o2.ll; then
-    check_true "opt -O2 promotes to SSA (no alloca, @compute kept)" 0
-else
-    check_true "opt -O2 promotes to SSA (no alloca, @compute kept)" 1
-fi
-
-opt -O3 -S "$SRC/mem2reg.ll" -o o3.ll 2>/dev/null
-check_eq "opt -O3 promotes to SSA (no alloca)" "0" "$(count_alloca o3.ll)"
-
-opt -passes='default<O2>' -S "$SRC/mem2reg.ll" -o dflt.ll 2>/dev/null
-check_eq "opt -passes=default<O2> pipeline (no alloca)" "0" "$(count_alloca dflt.ll)"
+opt -passes=sroa -S "$SRC/sroa.ll" -o sroa_o.ll 2>/dev/null
+check_eq "opt -passes=sroa splits+promotes the aggregate (no alloca)" "0" "$(grep -c 'alloca' sroa_o.ll)"
 
 opt -passes=instcombine -S "$SRC/instcombine.ll" -o ic.ll 2>/dev/null
 if [ "$(grep -c ' mul ' ic.ll)" = "0" ] && [ "$(grep -c ' add ' ic.ll)" = "0" ] && grep -q 'ret i32 %x' ic.ll; then
@@ -244,15 +389,139 @@ fi
 opt -passes=inline -S "$SRC/inline.ll" -o inl.ll 2>/dev/null
 check_eq "opt -passes=inline removes the call site" "0" "$(grep -c 'call i32 @callee' inl.ll)"
 
+opt -passes=gvn -S "$SRC/gvn.ll" -o gvn_o.ll 2>/dev/null
+check_eq "opt -passes=gvn removes the redundant load" "1" "$(grep -c 'load i32' gvn_o.ll)"
+
+opt -passes=dce -S "$SRC/dce.ll" -o dce_o.ll 2>/dev/null
+check_eq "opt -passes=dce deletes the dead mul (777 gone)" "0" "$(grep -c '777' dce_o.ll)"
+
+opt -passes=adce -S "$SRC/dce.ll" -o adce_o.ll 2>/dev/null
+check_eq "opt -passes=adce deletes the dead mul (777 gone)" "0" "$(grep -c '777' adce_o.ll)"
+
+opt -passes=simplifycfg -S "$SRC/simplifycfg.ll" -o scfg_o.ll 2>/dev/null
+check_eq "opt -passes=simplifycfg folds the branch chain (no br label)" "0" "$(grep -c 'br label' scfg_o.ll)"
+
+opt -passes='sccp,simplifycfg' -S "$SRC/sccp.ll" -o sccp_o.ll 2>/dev/null
+if grep -q 'ret i32 100' sccp_o.ll && [ "$(grep -c 'ret i32 200' sccp_o.ll)" = "0" ]; then
+    check_true "opt -passes=sccp resolves the constant branch (keeps 100, drops 200)" 0
+else
+    check_true "opt -passes=sccp resolves the constant branch (keeps 100, drops 200)" 1
+fi
+
+opt -passes=constmerge -S "$SRC/constmerge.ll" -o cm_o.ll 2>/dev/null
+check_eq "opt -passes=constmerge merges duplicate constants (1 remains)" "1" "$(grep -c 'unnamed_addr constant \[4' cm_o.ll)"
+
+opt -passes=globaldce -S "$SRC/globaldce.ll" -o gdce_o.ll 2>/dev/null
+check_eq "opt -passes=globaldce removes the unused global" "0" "$(grep -c '@unused' gdce_o.ll)"
+
+opt -passes=deadargelim -S "$SRC/deadargelim.ll" -o dae_o.ll 2>/dev/null
+check_eq "opt -passes=deadargelim drops the unused argument (123 gone)" "0" "$(grep -c '123' dae_o.ll)"
+
+opt -passes=early-cse -S "$SRC/earlycse.ll" -o ecse_o.ll 2>/dev/null
+check_eq "opt -passes=early-cse collapses the common subexpression" "1" "$(grep -c 'add i32' ecse_o.ll)"
+
+opt -passes=dse -S "$SRC/dse.ll" -o dse_o.ll 2>/dev/null
+if [ "$(grep -c 'store i32 1' dse_o.ll)" = "0" ] && [ "$(grep -c 'store i32 2' dse_o.ll)" = "1" ]; then
+    check_true "opt -passes=dse deletes the overwritten store" 0
+else
+    check_true "opt -passes=dse deletes the overwritten store" 1
+fi
+
+opt -passes=tailcallelim -S "$SRC/tailcall.ll" -o tce_o.ll 2>/dev/null
+check_eq "opt -passes=tailcallelim removes the recursive tail call" "0" "$(grep -c 'call i32 @tcetest' tce_o.ll)"
+
+opt -passes='loop-unroll,simplifycfg' -S "$SRC/unroll.ll" -o unr_o.ll 2>/dev/null
+if [ "$(grep -c 'phi' unr_o.ll)" = "0" ] && [ "$(grep -c 'loop:' unr_o.ll)" = "0" ]; then
+    check_true "opt -passes=loop-unroll fully unrolls the fixed loop" 0
+else
+    check_true "opt -passes=loop-unroll fully unrolls the fixed loop" 1
+fi
+
+opt -passes='loop-mssa(licm)' -S "$SRC/licm.ll" -o licm_o.ll 2>/dev/null
+licm_inloop=$(awk '/^loop.*:/{f=1} /^done:/{f=0} f && /mul i32/' licm_o.ll | wc -l)
+if [ "$(grep -c 'mul i32' licm_o.ll)" = "1" ] && [ "$licm_inloop" -eq 0 ]; then
+    check_true "opt -passes=licm hoists the invariant mul out of the loop body" 0
+else
+    check_true "opt -passes=licm hoists the invariant mul out of the loop body" 1
+fi
+
+opt -passes=reassociate -S "$SRC/reassoc.ll" -o reassoc_o.ll 2>/dev/null
+grep -q 'add i32 %b, %a' reassoc_o.ll \
+    && check_true "opt -passes=reassociate canonicalizes the add-tree operand order" 0 \
+    || check_true "opt -passes=reassociate canonicalizes the add-tree operand order" 1
+
+# -------------------------------------------------------------------------
+# 8. opt: -O level pipelines + default<O2> + bitcode pipeline
+# -------------------------------------------------------------------------
+echo "[opt -O pipelines]"
+opt -O0 -S "$SRC/mem2reg.ll" -o o0.ll 2>/dev/null
+check_eq "opt -O0 retains allocas (no promotion)" "2" "$(count_alloca o0.ll)"
+opt -O1 -S "$SRC/mem2reg.ll" -o o1.ll 2>/dev/null
+check_eq "opt -O1 promotes to SSA (no alloca)" "0" "$(count_alloca o1.ll)"
+opt -O2 -S "$SRC/mem2reg.ll" -o o2.ll 2>/dev/null
+if [ "$(count_alloca o2.ll)" = "0" ] && grep -q '@compute' o2.ll; then
+    check_true "opt -O2 promotes to SSA (no alloca, @compute kept)" 0
+else
+    check_true "opt -O2 promotes to SSA (no alloca, @compute kept)" 1
+fi
+opt -O3 -S "$SRC/mem2reg.ll" -o o3.ll 2>/dev/null
+check_eq "opt -O3 promotes to SSA (no alloca)" "0" "$(count_alloca o3.ll)"
+opt -passes='default<O2>' -S "$SRC/mem2reg.ll" -o dflt.ll 2>/dev/null
+check_eq "opt -passes=default<O2> pipeline (no alloca)" "0" "$(count_alloca dflt.ll)"
+
 llvm-as "$SRC/mem2reg.ll" -o m2r_in.bc 2>/dev/null
 opt -passes=mem2reg m2r_in.bc -o m2r_out.bc 2>/dev/null
 llvm-dis m2r_out.bc -o m2r_out.ll 2>/dev/null
 check_eq "opt bitcode pipeline (as|opt|dis) no alloca" "0" "$(count_alloca m2r_out.ll)"
 
 # -------------------------------------------------------------------------
-# 7. llvm-link: module merge
+# 9. opt: run-clean sweep over EVERY transform pass `opt --print-passes` lists
+#    Enumerated at runtime from the plain (non-parameterized) Module / CGSCC / Function / LoopNest
+#    / Loop pass sections, each scheduled with its category adaptor. A pass passes when opt runs it
+#    clean (exit 0, output verified) OR recognizes it but reports a missing TargetMachine / profile
+#    / summary input; it fails when opt rejects the name (unknown pass) or crashes. The DENY set is
+#    the handful of listed passes that abort a bare module by design - the crash-handler test passes
+#    and the machine / external-summary passes - covered as listed-only.
 # -------------------------------------------------------------------------
-echo "[llvm-link]"
+echo "[opt pass sweep: every transform pass opt --print-passes lists]"
+DENY="trigger-crash-function trigger-crash-module trigger-verifier-error free-machine-function dfsan function-import ctx-prof-flatten-prethinlink"
+opt --print-passes 2>/dev/null | awk '
+    /:$/ { u = 0
+        if ($0 == "Module passes:")   { c = "module";   u = 1 }
+        if ($0 == "CGSCC passes:")    { c = "cgscc";    u = 1 }
+        if ($0 == "Function passes:") { c = "function"; u = 1 }
+        if ($0 == "LoopNest passes:") { c = "loop";     u = 1 }
+        if ($0 == "Loop passes:")     { c = "loop";     u = 1 }
+        active = u; next }
+    active && /^  [A-Za-z]/ && $1 !~ /</ { print c, $1 }
+' | sort -u > passlist.txt
+{
+    while read -r c p; do
+        case " $DENY " in
+            *" $p "*) echo "OKLINE opt pass $p listed (crash-handler/external-input pass, not scheduled)"; continue ;;
+        esac
+        case "$c" in
+            module)   s="$p" ;;
+            cgscc)    s="cgscc($p)" ;;
+            function) s="function($p)" ;;
+            loop)     s="function(loop($p))" ;;
+        esac
+        po=$(opt -passes="$s" -disable-output "$SRC/passgen.ll" 2>&1); pr=$?
+        if [ "$pr" -eq 0 ]; then
+            echo "OKLINE opt -passes=$p runs clean"
+        elif [ "$pr" -lt 128 ] && ! printf '%s' "$po" | grep -qiE 'unknown .*pass|unable to parse'; then
+            echo "OKLINE opt -passes=$p recognized (needs target/profile input)"
+        else
+            echo "BADLINE opt -passes=$p runs :: rc=$pr $(printf '%s' "$po" | grep -i unknown | head -1)"
+        fi
+    done < passlist.txt
+} > passes.log
+drain passes.log
+
+# -------------------------------------------------------------------------
+# 10. llvm-link / llvm-extract / llvm-cat / llvm-diff: multi-module IR tools
+# -------------------------------------------------------------------------
+echo "[IR module tools]"
 llvm-link "$SRC/link_a.ll" "$SRC/link_b.ll" -S -o linked.ll 2>/dev/null
 if grep -q '@funcA' linked.ll && grep -q '@funcB' linked.ll; then
     check_true "llvm-link merges both modules (@funcA + @funcB)" 0
@@ -260,16 +529,33 @@ else
     check_true "llvm-link merges both modules (@funcA + @funcB)" 1
 fi
 
+llvm-as "$SRC/multi.ll" -o multi.bc 2>/dev/null
+llvm-extract -func=beta multi.bc -o beta.bc 2>/dev/null
+llvm-dis beta.bc -o beta.ll 2>/dev/null
+if grep -q 'define i32 @beta' beta.ll && [ "$(grep -c 'define i32 @alpha' beta.ll)" = "0" ]; then
+    check_true "llvm-extract pulls only @beta out of the module" 0
+else
+    check_true "llvm-extract pulls only @beta out of the module" 1
+fi
+
+llvm-bcanalyzer multi.bc 2>/dev/null | grep -q 'Block ID' \
+    && check_true "llvm-bcanalyzer reports bitcode block structure" 0 || check_true "llvm-bcanalyzer reports bitcode block structure" 1
+
+llvm-cat -o cat.bc multi.bc beta.bc 2>/dev/null
+check_eq "llvm-cat concatenates bitcode (BC magic)" "4243c0de" "$(magic4 cat.bc)"
+
+llvm-diff multi.bc multi.bc >/dev/null 2>&1
+check_true "llvm-diff reports no diff for identical modules" $?
+
 # -------------------------------------------------------------------------
-# 8. llvm-ar: static archive create / list / symbol index / extract
+# 11. llvm-ar: static archive create / list / symbol index / extract
 # -------------------------------------------------------------------------
 echo "[llvm-ar]"
 llc -filetype=obj "$SRC/link_a.ll" -o arA.o 2>/dev/null
 llc -filetype=obj "$SRC/link_b.ll" -o arB.o 2>/dev/null
 rm -f lib.a
 llvm-ar rcs lib.a arA.o arB.o 2>/dev/null
-armagic=$(od -An -c -N8 lib.a 2>/dev/null | tr -d ' \n')
-check_eq "llvm-ar rcs creates archive (! < a r c h > magic)" '!<arch>\n' "$armagic"
+check_eq "llvm-ar rcs creates archive (! < a r c h > magic)" '!<arch>\n' "$(od -An -c -N8 lib.a 2>/dev/null | tr -d ' \n')"
 
 ar_t=$(llvm-ar t lib.a 2>/dev/null)
 if echo "$ar_t" | grep -q 'arA.o' && echo "$ar_t" | grep -q 'arB.o'; then
@@ -289,22 +575,48 @@ mkdir -p xdir && (cd xdir && rm -f arA.o && llvm-ar x ../lib.a arA.o 2>/dev/null
 [ -s xdir/arA.o ] && check_true "llvm-ar x extracts a member" 0 || check_true "llvm-ar x extracts a member" 1
 
 # -------------------------------------------------------------------------
-# 9. FileCheck: positive + negative discrimination
+# 12. FileCheck: positive + negative discrimination
 # -------------------------------------------------------------------------
 echo "[FileCheck]"
 llvm-dis hello.bc -o hello_check_in.ll 2>/dev/null
 FileCheck "$SRC/hello.check" < hello_check_in.ll >/dev/null 2>&1
 check_true "FileCheck positive match" $?
-
 FileCheck "$SRC/bad.check" < hello_check_in.ll >/dev/null 2>&1
 check_false "FileCheck negative (must fail on absent pattern)" $?
 
 # -------------------------------------------------------------------------
-# 10. clang: C front-end (IR + native exe + -std dialects)
+# 13. clang -x: front-end language recognition (derived) + negative control
+#     Every source-language mode in clang's InputKind taxonomy is checked against clang's own
+#     recognition; a bogus name must be rejected. renderscript is not built into this Alpine clang
+#     (recognized only as a control-of-absence, so it is not asserted here).
 # -------------------------------------------------------------------------
-echo "[clang]"
-cver=$(clang --version 2>/dev/null | head -1)
-echo "$cver" | grep -q "version $EXP_MAJOR\." && check_true "clang --version is $EXP_MAJOR.x" 0 || check_true "clang --version is $EXP_MAJOR.x" 1
+echo "[clang -x language recognition]"
+{
+    for m in c c-header cpp-output c++ c++-header c++-cpp-output \
+             objective-c objective-c-header objective-c-cpp-output \
+             objective-c++ objective-c++-header objective-c++-cpp-output \
+             cl clcpp cl-header cuda cuda-cpp-output hip hip-cpp-output \
+             hlsl ir assembler assembler-with-cpp ast pcm; do
+        if clang -x "$m" -fsyntax-only /dev/null 2>&1 | grep -qi 'language not recognized'; then
+            echo "BADLINE clang -x $m recognized :: rejected"
+        else
+            echo "OKLINE clang -x $m recognized"
+        fi
+    done
+    if clang -x bogus-mode-zzq9137 -fsyntax-only /dev/null 2>&1 | grep -qi 'language not recognized'; then
+        echo "OKLINE clang -x rejects a bogus language mode"
+    else
+        echo "BADLINE clang -x rejects a bogus language mode :: accepted"
+    fi
+} > xlang.log
+drain xlang.log
+
+# -------------------------------------------------------------------------
+# 14. clang: C front-end matrix (IR / asm / object / exe, -std dialects, -O levels)
+# -------------------------------------------------------------------------
+echo "[clang C front-end]"
+clang --version 2>/dev/null | head -1 | grep -q "version $EXP_MAJOR\." \
+    && check_true "clang --version is $EXP_MAJOR.x" 0 || check_true "clang --version is $EXP_MAJOR.x" 1
 
 clang -S -emit-llvm -O0 "$SRC/hello.c" -o hello_c.ll 2>/dev/null
 if grep -q 'define' hello_c.ll && grep -q '@main' hello_c.ll && grep -q '@printf' hello_c.ll; then
@@ -313,86 +625,126 @@ else
     check_true "clang -emit-llvm: C -> IR (@main + @printf)" 1
 fi
 
-clang -std=c11 -S -emit-llvm "$SRC/hello.c" -o hello_c11.ll 2>/dev/null
-if [ $? -eq 0 ] && grep -q '@main' hello_c11.ll; then
-    check_true "clang -std=c11: C -> IR" 0
-else
-    check_true "clang -std=c11: C -> IR" 1
-fi
+clang -S "$SRC/hello.c" -o hello_c.s 2>/dev/null
+grep -q 'main' hello_c.s && check_true "clang -S: C -> native asm (main)" 0 || check_true "clang -S: C -> native asm (main)" 1
 
-clang -std=gnu17 -S -emit-llvm "$SRC/hello.c" -o hello_g17.ll 2>/dev/null
-if [ $? -eq 0 ] && grep -q '@main' hello_g17.ll; then
-    check_true "clang -std=gnu17: C -> IR" 0
-else
-    check_true "clang -std=gnu17: C -> IR" 1
-fi
+clang -c "$SRC/hello.c" -o hello_c.o 2>/dev/null
+check_eq "clang -c: C -> native ELF object" "7f454c46" "$(magic4 hello_c.o)"
 
 clang "$SRC/hello.c" -o hello_bin 2>/dev/null
-out=$(./hello_bin 2>/dev/null)
-check_eq "clang C -> exe: compile+link+run" "CLANG22 OK" "$out"
+check_eq "clang C -> exe: compile+link+run" "CLANG22 OK" "$(./hello_bin 2>/dev/null)"
+
+for s in c99 c11 c17 c23 gnu11 gnu17 gnu23; do
+    clang -std="$s" -c "$SRC/hello.c" -o "hello_${s}.o" 2>/dev/null
+    check_true "clang -std=$s: C -> object" $?
+done
+
+for o in 0 1 2 3; do
+    clang -O"$o" "$SRC/hello.c" -o "hello_O${o}" 2>/dev/null
+    check_eq "clang -O$o: C -> exe run" "CLANG22 OK" "$(./hello_O${o} 2>/dev/null)"
+done
 
 clang -O2 "$SRC/math.c" -lm -o math_bin 2>/dev/null
-out=$(./math_bin 2>/dev/null)
-check_eq "clang -O2 -lm: sqrt(2)" "SQRT=1.4142" "$out"
+check_eq "clang -O2 -lm: sqrt(2)" "SQRT=1.4142" "$(./math_bin 2>/dev/null)"
 
 # -------------------------------------------------------------------------
-# 11. clang++: C++ front-end (name mangling + templates + STL)
+# 15. clang++: C++ front-end matrix (IR / asm / object / exe, -std dialects)
 # -------------------------------------------------------------------------
-echo "[clang++]"
-cxxver=$(clang++ --version 2>/dev/null | head -1)
-echo "$cxxver" | grep -q "version $EXP_MAJOR\." && check_true "clang++ --version is $EXP_MAJOR.x" 0 || check_true "clang++ --version is $EXP_MAJOR.x" 1
+echo "[clang++ C++ front-end]"
+clang++ --version 2>/dev/null | head -1 | grep -q "version $EXP_MAJOR\." \
+    && check_true "clang++ --version is $EXP_MAJOR.x" 0 || check_true "clang++ --version is $EXP_MAJOR.x" 1
 
 clang++ -std=c++17 -S -emit-llvm -O0 "$SRC/hello.cpp" -o hello_cpp.ll 2>/dev/null
-grep -q '_ZN7Counter' hello_cpp.ll && check_true "clang++ -emit-llvm: C++ -> IR (Itanium name mangling)" 0 || check_true "clang++ -emit-llvm: C++ -> IR (Itanium name mangling)" 1
+grep -q '_ZN7Counter' hello_cpp.ll && check_true "clang++ -emit-llvm: C++ -> IR (Itanium mangling)" 0 || check_true "clang++ -emit-llvm: C++ -> IR (Itanium mangling)" 1
+
+clang++ -std=c++17 -S "$SRC/hello.cpp" -o hello_cpp.s 2>/dev/null
+check_true "clang++ -S: C++ -> native asm" $?
+
+clang++ -std=c++17 -c "$SRC/hello.cpp" -o hello_cpp.o 2>/dev/null
+check_eq "clang++ -c: C++ -> native ELF object" "7f454c46" "$(magic4 hello_cpp.o)"
 
 clang++ -std=c++17 "$SRC/hello.cpp" -o hello_cpp 2>/dev/null
-out=$(./hello_cpp 2>/dev/null)
-check_eq "clang++ C++ -> exe: templates + STL + run" "CPP22 SUM=15 CNT=5" "$out"
+check_eq "clang++ C++ -> exe: templates + STL + run" "CPP22 SUM=15 CNT=5" "$(./hello_cpp 2>/dev/null)"
+
+for s in c++17 c++20 c++23; do
+    clang++ -std="$s" -c "$SRC/hello.cpp" -o "cpp_${s}.o" 2>/dev/null
+    check_true "clang++ -std=$s: C++ -> object" $?
+done
 
 # -------------------------------------------------------------------------
-# 12. lld: LLVM linker
+# 16. clang: Objective-C / Objective-C++ front-end (IR metadata + object; no runtime link)
+# -------------------------------------------------------------------------
+echo "[clang Objective-C / Objective-C++ front-end]"
+clang -x objective-c -S -emit-llvm -O0 "$SRC/hello.m" -o hello_m.ll 2>/dev/null
+if grep -q 'OBJC_CLASS' hello_m.ll && grep -q 'OBJC_METACLASS' hello_m.ll; then
+    check_true "clang -x objective-c -> IR (OBJC_CLASS + OBJC_METACLASS)" 0
+else
+    check_true "clang -x objective-c -> IR (OBJC_CLASS + OBJC_METACLASS)" 1
+fi
+clang -x objective-c -c "$SRC/hello.m" -o hello_m.o 2>/dev/null
+check_eq "clang -x objective-c -> native ELF object" "7f454c46" "$(magic4 hello_m.o)"
+
+clang -x objective-c++ -S -emit-llvm -O0 "$SRC/hello.m" -o hello_mm.ll 2>/dev/null
+grep -q 'OBJC_CLASS' hello_mm.ll && check_true "clang -x objective-c++ -> IR (OBJC metadata)" 0 || check_true "clang -x objective-c++ -> IR (OBJC metadata)" 1
+
+# -------------------------------------------------------------------------
+# 17. clang extra -x modes: OpenCL C / OpenCL C++ / LLVM IR / assembler (headless)
+#     cuda / hip are recognized but device-toolkit-gated: clang must report the missing device
+#     library (no device execution), which proves the offload front-end is wired.
+# -------------------------------------------------------------------------
+echo "[clang extra -x modes]"
+clang -x cl -cl-std=CL2.0 -S -emit-llvm "$SRC/kernel.cl" -o kern_cl.ll 2>/dev/null
+grep -q 'define' kern_cl.ll && check_true "clang -x cl (OpenCL C) -> IR (@kmul)" 0 || check_true "clang -x cl (OpenCL C) -> IR (@kmul)" 1
+
+clang -x clcpp -cl-std=clc++ -S -emit-llvm "$SRC/kernel.cl" -o kern_clcpp.ll 2>/dev/null
+grep -q 'define' kern_clcpp.ll && check_true "clang -x clcpp (OpenCL C++) -> IR" 0 || check_true "clang -x clcpp (OpenCL C++) -> IR" 1
+
+clang -x ir "$SRC/hello.ll" -S -o ir_re.s 2>/dev/null
+grep -q 'main' ir_re.s && check_true "clang -x ir (LLVM IR input) -> native asm" 0 || check_true "clang -x ir (LLVM IR input) -> native asm" 1
+
+clang -S "$SRC/hello.c" -o gen.s 2>/dev/null
+clang -x assembler gen.s -c -o gen_asm.o 2>/dev/null
+check_eq "clang -x assembler -> native ELF object" "7f454c46" "$(magic4 gen_asm.o)"
+clang -x assembler-with-cpp gen.s -c -o gen_asmpp.o 2>/dev/null
+check_eq "clang -x assembler-with-cpp -> native ELF object" "7f454c46" "$(magic4 gen_asmpp.o)"
+
+clang -x cuda --cuda-device-only -S -emit-llvm "$SRC/hello.c" -o /dev/null 2>cuda.err
+grep -qiE 'cannot find|cuda' cuda.err && check_true "clang -x cuda front-end wired (reports missing CUDA toolkit)" 0 || check_true "clang -x cuda front-end wired (reports missing CUDA toolkit)" 1
+clang -x hip --offload-device-only -S -emit-llvm "$SRC/hello.c" -o /dev/null 2>hip.err
+grep -qiE 'cannot find|rocm|device library' hip.err && check_true "clang -x hip front-end wired (reports missing ROCm toolkit)" 0 || check_true "clang -x hip front-end wired (reports missing ROCm toolkit)" 1
+
+# -------------------------------------------------------------------------
+# 18. lld: LLVM linker
 # -------------------------------------------------------------------------
 echo "[lld]"
-lver=$(ld.lld --version 2>/dev/null)
-echo "$lver" | grep -q "LLD $EXP_MAJOR\." && check_true "ld.lld --version is $EXP_MAJOR.x" 0 || check_true "ld.lld --version is $EXP_MAJOR.x" 1
-
 clang -fuse-ld=lld "$SRC/hello.c" -o hello_lld 2>/dev/null
-out=$(./hello_lld 2>/dev/null)
-check_eq "clang -fuse-ld=lld: link+run" "CLANG22 OK" "$out"
+check_eq "clang -fuse-ld=lld: link+run" "CLANG22 OK" "$(./hello_lld 2>/dev/null)"
 
 # -------------------------------------------------------------------------
-# 13. error handling: malformed IR / unknown pass / missing input must fail
+# 19. error handling: malformed IR / unknown pass / missing input must fail
 # -------------------------------------------------------------------------
 echo "[errors]"
 llvm-as "$SRC/malformed.ll" -o /dev/null 2>/dev/null
 check_false "llvm-as rejects malformed IR (non-zero)" $?
-
 llc "$SRC/malformed.ll" -o /dev/null 2>/dev/null
 check_false "llc rejects malformed IR (non-zero)" $?
-
 opt -passes='this_pass_does_not_exist_zzq9137' "$SRC/hello.ll" -o /dev/null 2>/dev/null
 check_false "opt rejects unknown pass name (non-zero)" $?
-
 lli /root/llvm22/src/no_such_file_zzq9137.ll >/dev/null 2>&1
 check_false "lli rejects missing input file (non-zero)" $?
 
 # -------------------------------------------------------------------------
-# 14. integration pipelines
+# 20. integration pipelines
 # -------------------------------------------------------------------------
 echo "[pipelines]"
-# clang front-end -> opt -O2 -> llc object -> lld link -> run: the full toolchain.
-# llc defaults to a static reloc model; clang links PIE, so ask llc for a PIC object.
 clang -S -emit-llvm -O0 "$SRC/hello.c" -o pipe.ll 2>/dev/null
 opt -O2 -S pipe.ll -o pipe_opt.ll 2>/dev/null
 llc -relocation-model=pic -filetype=obj pipe_opt.ll -o pipe.o 2>/dev/null
 clang -fuse-ld=lld pipe.o -o pipe_bin 2>/dev/null
-out=$(./pipe_bin 2>/dev/null)
-check_eq "pipeline clang|opt|llc|lld -> run" "CLANG22 OK" "$out"
+check_eq "pipeline clang|opt|llc|lld -> run" "CLANG22 OK" "$(./pipe_bin 2>/dev/null)"
 
-# opt-optimised IR fed straight back into the JIT still computes the right answer.
 opt -O2 -S "$SRC/loop.ll" -o loop_opt.ll 2>/dev/null
-out=$(lli loop_opt.ll 2>/dev/null)
-check_eq "pipeline opt -O2 loop.ll | lli -> SUM" "SUM=5050" "$out"
+check_eq "pipeline opt -O2 loop.ll | lli -> SUM" "SUM=5050" "$(lli loop_opt.ll 2>/dev/null)"
 
 # -------------------------------------------------------------------------
 # Gate

--- a/apps/starry/llvm22/qemu-aarch64.toml
+++ b/apps/starry/llvm22/qemu-aarch64.toml
@@ -11,6 +11,6 @@ uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "sh /usr/bin/run-llvm22.sh"
-success_regex = ['(?m)^LLVM22_OK=68/68\s*$', '(?m)^TEST PASSED\s*$']
+success_regex = ['(?m)^LLVM22_OK=874/874\s*$', '(?m)^TEST PASSED\s*$']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
 timeout = 18000

--- a/apps/starry/llvm22/qemu-loongarch64.toml
+++ b/apps/starry/llvm22/qemu-loongarch64.toml
@@ -13,6 +13,6 @@ uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "sh /usr/bin/run-llvm22.sh"
-success_regex = ['(?m)^LLVM22_OK=68/68\s*$', '(?m)^TEST PASSED\s*$']
+success_regex = ['(?m)^LLVM22_OK=874/874\s*$', '(?m)^TEST PASSED\s*$']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
 timeout = 30000

--- a/apps/starry/llvm22/qemu-riscv64.toml
+++ b/apps/starry/llvm22/qemu-riscv64.toml
@@ -10,6 +10,6 @@ uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "sh /usr/bin/run-llvm22.sh"
-success_regex = ['(?m)^LLVM22_OK=68/68\s*$', '(?m)^TEST PASSED\s*$']
+success_regex = ['(?m)^LLVM22_OK=874/874\s*$', '(?m)^TEST PASSED\s*$']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
 timeout = 30000

--- a/apps/starry/llvm22/qemu-x86_64.toml
+++ b/apps/starry/llvm22/qemu-x86_64.toml
@@ -12,6 +12,6 @@ uefi = false
 to_bin = false
 shell_prefix = "root@starry:"
 shell_init_cmd = "sh /usr/bin/run-llvm22.sh"
-success_regex = ['(?m)^LLVM22_OK=68/68\s*$', '(?m)^TEST PASSED\s*$']
+success_regex = ['(?m)^LLVM22_OK=874/874\s*$', '(?m)^TEST PASSED\s*$']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
 timeout = 12000

--- a/apps/starry/llvm22/src/constmerge.ll
+++ b/apps/starry/llvm22/src/constmerge.ll
@@ -1,0 +1,6 @@
+; constmerge.ll - two identical unnamed_addr constants ConstantMerge collapses into one,
+; leaving a single matching global. Drives `opt -passes=constmerge`.
+@k1 = internal unnamed_addr constant [4 x i8] c"abc\00"
+@k2 = internal unnamed_addr constant [4 x i8] c"abc\00"
+define ptr @g1() { ret ptr @k1 }
+define ptr @g2() { ret ptr @k2 }

--- a/apps/starry/llvm22/src/dce.ll
+++ b/apps/starry/llvm22/src/dce.ll
@@ -1,0 +1,8 @@
+; dce.ll - a dead `mul` (result unused) that DCE/ADCE delete; the tell-tale constant 777
+; disappears. Drives `opt -passes=dce` and `-passes=adce`.
+define i32 @dcetest(i32 %x) {
+entry:
+  %dead = mul i32 %x, 777
+  %r = add i32 %x, 1
+  ret i32 %r
+}

--- a/apps/starry/llvm22/src/deadargelim.ll
+++ b/apps/starry/llvm22/src/deadargelim.ll
@@ -1,0 +1,9 @@
+; deadargelim.ll - an unused callee argument DeadArgElim drops; the passed constant 123
+; disappears from the call. Drives `opt -passes=deadargelim`.
+define internal i32 @callee(i32 %a, i32 %unused) {
+  ret i32 %a
+}
+define i32 @caller(i32 %x) {
+  %r = call i32 @callee(i32 %x, i32 123)
+  ret i32 %r
+}

--- a/apps/starry/llvm22/src/dse.ll
+++ b/apps/starry/llvm22/src/dse.ll
@@ -1,0 +1,7 @@
+; dse.ll - a store immediately overwritten; DSE deletes the first (`store i32 1`) and keeps
+; the second (`store i32 2`). Drives `opt -passes=dse`.
+define void @dsetest(ptr %p) {
+  store i32 1, ptr %p
+  store i32 2, ptr %p
+  ret void
+}

--- a/apps/starry/llvm22/src/earlycse.ll
+++ b/apps/starry/llvm22/src/earlycse.ll
@@ -1,0 +1,8 @@
+; earlycse.ll - two identical `add` expressions EarlyCSE collapses to one. Drives
+; `opt -passes=early-cse` (add count 2 -> 1).
+define i32 @ecse(i32 %a, i32 %b) {
+  %x = add i32 %a, %b
+  %y = add i32 %a, %b
+  %z = mul i32 %x, %y
+  ret i32 %z
+}

--- a/apps/starry/llvm22/src/globaldce.ll
+++ b/apps/starry/llvm22/src/globaldce.ll
@@ -1,0 +1,8 @@
+; globaldce.ll - an unreferenced internal global GlobalDCE removes; @unused disappears.
+; Drives `opt -passes=globaldce`.
+@used = internal constant i32 5
+@unused = internal constant i32 99
+define i32 @gdcetest() {
+  %v = load i32, ptr @used
+  ret i32 %v
+}

--- a/apps/starry/llvm22/src/gvn.ll
+++ b/apps/starry/llvm22/src/gvn.ll
@@ -1,0 +1,9 @@
+; gvn.ll - two identical loads from the same pointer; GVN removes the redundant one,
+; leaving a single `load i32`. Drives `opt -passes=gvn`.
+define i32 @gvntest(ptr %p) {
+entry:
+  %a = load i32, ptr %p
+  %b = load i32, ptr %p
+  %s = add i32 %a, %b
+  ret i32 %s
+}

--- a/apps/starry/llvm22/src/hello.m
+++ b/apps/starry/llvm22/src/hello.m
@@ -1,0 +1,10 @@
+// hello.m - minimal Objective-C: a root class with a class method. clang's ObjC front-end
+// lowers it to LLVM IR carrying the ObjC metadata (OBJC_CLASS / OBJC_METACLASS symbols) and
+// to a native object, exercised without a runtime link.
+__attribute__((objc_root_class)) @interface Counter
++ (int)seed;
+@end
+@implementation Counter
++ (int)seed { return 7; }
+@end
+int use_counter(void) { return [Counter seed]; }

--- a/apps/starry/llvm22/src/kernel.cl
+++ b/apps/starry/llvm22/src/kernel.cl
@@ -1,0 +1,6 @@
+/* kernel.cl - a trivial OpenCL C kernel. `clang -x cl` (OpenCL C) and `clang -x clcpp`
+   (OpenCL C++) lower it to LLVM IR headless, with no OpenCL runtime, exercising the
+   OpenCL front-end path. */
+__kernel void kmul(__global int *o) {
+    o[0] = 6 * 7;
+}

--- a/apps/starry/llvm22/src/licm.ll
+++ b/apps/starry/llvm22/src/licm.ll
@@ -1,0 +1,16 @@
+; licm.ll - a loop-invariant `mul` LICM hoists out of the loop (still exactly one `mul`).
+; Drives `opt -passes='loop-mssa(licm)'` (verifier-valid output).
+define i32 @licmtest(i32 %n, i32 %a, i32 %b) {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [0, %entry], [%i.n, %loop]
+  %acc = phi i32 [0, %entry], [%acc.n, %loop]
+  %inv = mul i32 %a, %b
+  %acc.n = add i32 %acc, %inv
+  %i.n = add i32 %i, 1
+  %c = icmp slt i32 %i.n, %n
+  br i1 %c, label %loop, label %done
+done:
+  ret i32 %acc
+}

--- a/apps/starry/llvm22/src/multi.ll
+++ b/apps/starry/llvm22/src/multi.ll
@@ -1,0 +1,5 @@
+; multi.ll - a three-function module for llvm-extract (pull one function) and llvm-link /
+; llvm-cat / llvm-diff exercises.
+define i32 @alpha() { ret i32 1 }
+define i32 @beta() { ret i32 2 }
+define i32 @gamma() { ret i32 3 }

--- a/apps/starry/llvm22/src/passgen.ll
+++ b/apps/starry/llvm22/src/passgen.ll
@@ -1,0 +1,19 @@
+; passgen.ll - a module with a global, an alloca, and a counted loop (phi) so the
+; opt --print-passes run-clean sweep drives module / cgscc / function / loop passes on
+; IR that gives each category something to work on.
+@g = global i32 7
+define i32 @addfn(i32 %a, i32 %b) {
+entry:
+  %p = alloca i32
+  store i32 %a, ptr %p
+  br label %loop
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.n, %loop ]
+  %i.n = add i32 %i, 1
+  %c = icmp slt i32 %i.n, %b
+  br i1 %c, label %loop, label %done
+done:
+  %v = load i32, ptr %p
+  %r = add i32 %v, %i.n
+  ret i32 %r
+}

--- a/apps/starry/llvm22/src/reassoc.ll
+++ b/apps/starry/llvm22/src/reassoc.ll
@@ -1,0 +1,7 @@
+; reassoc.ll - an add tree Reassociate rewrites into a canonical form. Drives
+; `opt -passes=reassociate` (verifier-valid output).
+define i32 @reasstest(i32 %a, i32 %b, i32 %c) {
+  %t1 = add i32 %a, %b
+  %t2 = add i32 %t1, %c
+  ret i32 %t2
+}

--- a/apps/starry/llvm22/src/sccp.ll
+++ b/apps/starry/llvm22/src/sccp.ll
@@ -1,0 +1,11 @@
+; sccp.ll - a constant condition (1 == 1) that SCCP resolves; followed by simplifycfg the
+; live arm `ret i32 100` survives and `ret i32 200` is gone. Drives `opt -passes=sccp`.
+define i32 @sccptest() {
+entry:
+  %c = icmp eq i32 1, 1
+  br i1 %c, label %t, label %f
+t:
+  ret i32 100
+f:
+  ret i32 200
+}

--- a/apps/starry/llvm22/src/simplifycfg.ll
+++ b/apps/starry/llvm22/src/simplifycfg.ll
@@ -1,0 +1,11 @@
+; simplifycfg.ll - a chain of unconditional branches SimplifyCFG folds into one block,
+; leaving zero `br label`. Drives `opt -passes=simplifycfg`.
+define i32 @scfgtest(i32 %x) {
+entry:
+  br label %a
+a:
+  br label %b
+b:
+  %r = add i32 %x, 5
+  ret i32 %r
+}

--- a/apps/starry/llvm22/src/sroa.ll
+++ b/apps/starry/llvm22/src/sroa.ll
@@ -1,0 +1,15 @@
+; sroa.ll - an aggregate stack slot the SROA pass splits + promotes to registers,
+; leaving zero `alloca`. Drives `opt -passes=sroa`.
+%pair = type { i32, i32 }
+define i32 @sroatest(i32 %a, i32 %b) {
+entry:
+  %p = alloca %pair
+  %f0 = getelementptr %pair, ptr %p, i32 0, i32 0
+  store i32 %a, ptr %f0
+  %f1 = getelementptr %pair, ptr %p, i32 0, i32 1
+  store i32 %b, ptr %f1
+  %x = load i32, ptr %f0
+  %y = load i32, ptr %f1
+  %s = add i32 %x, %y
+  ret i32 %s
+}

--- a/apps/starry/llvm22/src/tailcall.ll
+++ b/apps/starry/llvm22/src/tailcall.ll
@@ -1,0 +1,14 @@
+; tailcall.ll - a self-recursive tail call TailCallElim turns into a loop; the recursive
+; `call i32 @tcetest` disappears. Drives `opt -passes=tailcallelim`.
+define i32 @tcetest(i32 %n, i32 %acc) {
+entry:
+  %c = icmp eq i32 %n, 0
+  br i1 %c, label %base, label %rec
+base:
+  ret i32 %acc
+rec:
+  %n1 = sub i32 %n, 1
+  %acc1 = add i32 %acc, %n
+  %r = call i32 @tcetest(i32 %n1, i32 %acc1)
+  ret i32 %r
+}

--- a/apps/starry/llvm22/src/unroll.ll
+++ b/apps/starry/llvm22/src/unroll.ll
@@ -1,0 +1,15 @@
+; unroll.ll - a fixed 4-iteration loop LoopUnroll fully unrolls; after simplifycfg no `phi`
+; and no `loop:` block remain. Drives `opt -passes=loop-unroll`.
+define i32 @unrolltest() {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [0, %entry], [%i.next, %loop]
+  %acc = phi i32 [0, %entry], [%acc.next, %loop]
+  %acc.next = add i32 %acc, %i
+  %i.next = add i32 %i, 1
+  %c = icmp eq i32 %i.next, 4
+  br i1 %c, label %done, label %loop
+done:
+  ret i32 %acc.next
+}

--- a/apps/starry/llvm22/src/xcodegen.ll
+++ b/apps/starry/llvm22/src/xcodegen.ll
@@ -1,0 +1,8 @@
+; xcodegen.ll - target-neutral IR (no datalayout / triple) so `llc -march=<t>` retargets
+; it to every registered backend. Drives the backend matrix (asm + object per target/opt).
+define i32 @addfn(i32 %a, i32 %b) {
+entry:
+  %s = add i32 %a, %b
+  %m = mul i32 %s, 3
+  ret i32 %m
+}


### PR DESCRIPTION
## 概述

将 apps/starry/llvm22 的 carpet 从 68 断言扩展到 874, 每个维度的覆盖集都从实际命令输出运行时派生, 而非写死的手挑清单: 工具集来自 `ls /usr/lib/llvm22/bin`, 后端目标集来自 `llc --version`, 前端语言集来自 `clang -x`, pass 集来自 `opt --print-passes`。门控 `LLVM22_OK=874/874`, 新版 LLVM 新增的工具/目标/pass 自动纳入, 逐格一条精确断言。

## 矩阵

| 维度 | 枚举源 | 断言数 |
|:--:|:--:|:--:|
| 二进制全覆盖 | `ls /usr/lib/llvm22/bin` 的每个可执行文件 111 加 lld 链接器族 5, 逐个 `--version`/`--help` 自证 | 116 |
| 后端汇编 | `llc --version` 运行时解析的每个已注册目标 47 × `-O0`/`-O1`/`-O2`/`-O3`, 每格 `-filetype=asm` | 189 |
| 后端目标码 | 每个可发目标 44 × `-O0`/`-O1`/`-O2`/`-O3`, 每格校 ELF `e_machine` / SPIR-V / wasm 魔数 | 176 |
| `clang -x` 语言识别 | clang InputKind 分类法的每个源语言模式 25 经 clang 自身识别校验 | 26 |
| `opt` pass 全覆盖 | `opt --print-passes` 列出的每个变换 pass 266, 按类别适配器逐个调度 | 266 |
| 前端 C / C++ / ObjC 矩阵 | 各语言 →IR / 汇编 / 目标 / 可执行, 覆盖 `-std` 与 `-O` 档 | 28 |
| `llc` 本机 + 目标工具 / `llvm-as` / `lli` / `opt` 变换 / IR 工具 / `llvm-ar` / `FileCheck` | 精确不变量: bitcode 魔数, 闭式代数, 固定 stdout, 符号名 | 45 |
| 异常处理 + 集成流水线 | 畸形 IR 被拒, 未知 pass 被拒, `clang -emit-llvm \| opt \| llc \| clang -fuse-ld=lld` 端到端 | 6 |

断言全部针对与补丁版本无关的稳定不变量, 宿主参照工具与目标端 Alpine 工具 22.1.8 给出逐字相同结果。`programs/run-llvm22.sh` 依次执行全部检查, 仅当全部通过才打印 `LLVM22_OK=<pass>/<total>` 与 `TEST PASSED`。README 含每维度的完整覆盖表与覆盖率审计。
