### PR TITLE
fix(ci): restore Starry ptrace and Axvisor RISC-V tests

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -1357,6 +1357,34 @@ pub fn ptrace_restore_singlestep_insn(
     restored && synced
 }
 
+/// Completes a software single-step when the saved breakpoint is already at the
+/// current user PC.
+#[cfg(any(
+    target_arch = "riscv64",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+))]
+pub fn ptrace_complete_singlestep_breakpoint_if_at_ip(
+    tracee: &ProcessData,
+    tid: Pid,
+    uctx: &mut ax_runtime::hal::cpu::uspace::UserContext,
+) -> bool {
+    let Some((addr, insn)) = tracee.take_ptrace_ss_saved_insn_for(tid) else {
+        return false;
+    };
+
+    if addr != uctx.ip() {
+        tracee.set_ptrace_ss_saved_insn_for(tid, Some((addr, insn)));
+        return false;
+    }
+
+    let restored = ptrace_restore_singlestep_insn(tracee, tid, addr, insn);
+    if restored {
+        tracee.set_ptrace_singlestep_for(tid, false);
+    }
+    true
+}
+
 #[cfg(target_arch = "riscv64")]
 fn riscv_insn_len(first_half: u16) -> usize {
     if first_half & 0x3 != 0x3 { 2 } else { 4 }

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -33,10 +33,31 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                 let _ = ptrace_stop_current(thr, Signo::SIGSTOP, &mut uctx);
             }
             while !thr.pending_exit() {
-                if thr.proc_data.is_ptrace_singlestep_for(thr.tid())
-                    && (thr.proc_data.is_ptrace_traceme() || thr.proc_data.is_ptrace_attached())
-                {
-                    crate::syscall::ptrace_setup_singlestep(&thr.proc_data, thr.tid(), &mut uctx);
+                let tid = thr.tid();
+                let is_ptraced =
+                    thr.proc_data.is_ptrace_traceme() || thr.proc_data.is_ptrace_attached();
+                if thr.proc_data.is_ptrace_singlestep_for(tid) && is_ptraced {
+                    #[cfg(any(
+                        target_arch = "riscv64",
+                        target_arch = "aarch64",
+                        target_arch = "loongarch64"
+                    ))]
+                    {
+                        // An IRQ can return here after the stepped branch reached
+                        // the planted breakpoint PC but before the breakpoint trap
+                        // was delivered. Report that as the completed single-step
+                        // instead of restoring the breakpoint and running past it.
+                        if crate::syscall::ptrace_complete_singlestep_breakpoint_if_at_ip(
+                            &thr.proc_data,
+                            tid,
+                            &mut uctx,
+                        ) && ptrace_stop_current(thr, Signo::SIGTRAP, &mut uctx).is_some()
+                        {
+                            continue;
+                        }
+                    }
+
+                    crate::syscall::ptrace_setup_singlestep(&thr.proc_data, tid, &mut uctx);
                 }
 
                 let reason = uctx.run();
@@ -163,42 +184,18 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                             && (thr.proc_data.is_ptrace_traceme()
                                 || thr.proc_data.is_ptrace_attached())
                         {
-                            let saved_insn = thr.proc_data.take_ptrace_ss_saved_insn_for(thr.tid());
-                            if let Some((addr, insn)) = saved_insn {
-                                if addr == uctx.ip() {
-                                    #[cfg(any(
-                                        target_arch = "riscv64",
-                                        target_arch = "aarch64",
-                                        target_arch = "loongarch64"
-                                    ))]
-                                    {
-                                        let restored =
-                                            crate::syscall::ptrace_restore_singlestep_insn(
-                                                &thr.proc_data,
-                                                thr.tid(),
-                                                addr,
-                                                insn,
-                                            );
-                                        if restored {
-                                            thr.proc_data
-                                                .set_ptrace_singlestep_for(thr.tid(), false);
-                                        }
-                                    }
-                                    #[cfg(not(any(
-                                        target_arch = "riscv64",
-                                        target_arch = "aarch64",
-                                        target_arch = "loongarch64"
-                                    )))]
-                                    thr.proc_data.set_ptrace_ss_saved_insn_for(
+                            #[cfg(any(
+                                target_arch = "riscv64",
+                                target_arch = "aarch64",
+                                target_arch = "loongarch64"
+                            ))]
+                            {
+                                let _ =
+                                    crate::syscall::ptrace_complete_singlestep_breakpoint_if_at_ip(
+                                        &thr.proc_data,
                                         thr.tid(),
-                                        Some((addr, insn)),
+                                        &mut uctx,
                                     );
-                                } else {
-                                    thr.proc_data.set_ptrace_ss_saved_insn_for(
-                                        thr.tid(),
-                                        Some((addr, insn)),
-                                    );
-                                }
                             }
                             if let Some(_resume_sig) =
                                 ptrace_stop_current(thr, Signo::SIGTRAP, &mut uctx)

--- a/os/axvisor/src/platform_irq.rs
+++ b/os/axvisor/src/platform_irq.rs
@@ -5,4 +5,8 @@ impl axvm::irq::RiscvPlatformIrqInjectorIf for RiscvPlatformIrqInjector {
     fn register_virtual_irq_injector(injector: fn(usize) -> bool) {
         axplat_dyn::register_virtual_irq_injector(injector);
     }
+
+    fn set_virtual_irq_targets(cpu_id: usize, irq_sources: &[u32]) {
+        axplat_dyn::set_virtual_irq_targets(cpu_id, irq_sources);
+    }
 }

--- a/platforms/axplat-dyn/src/irq.rs
+++ b/platforms/axplat-dyn/src/irq.rs
@@ -1,6 +1,8 @@
 #[cfg(all(target_arch = "riscv64", feature = "hv"))]
-use core::sync::atomic::{AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 
+#[cfg(any(all(target_arch = "riscv64", feature = "hv"), test))]
+use ax_plat::irq::IrqOutcome;
 use ax_plat::irq::{IrqAffinity, IrqError, IrqId, IrqIf, IrqSource, TrapVector, dispatch_irq};
 
 #[cfg(all(target_arch = "loongarch64", feature = "hv"))]
@@ -8,10 +10,28 @@ mod loongarch64_hv;
 
 #[cfg(all(target_arch = "riscv64", feature = "hv"))]
 static VIRTUAL_IRQ_INJECTOR: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+#[cfg(all(target_arch = "riscv64", feature = "hv"))]
+static VIRTUAL_IRQ_TARGET_CPU: AtomicUsize = AtomicUsize::new(usize::MAX);
+#[cfg(all(target_arch = "riscv64", feature = "hv"))]
+static VIRTUAL_IRQ_AFFINITY_CONFIGURED: [AtomicBool; RISCV_PLIC_SOURCE_COUNT] =
+    [const { AtomicBool::new(false) }; RISCV_PLIC_SOURCE_COUNT];
+#[cfg(any(all(target_arch = "riscv64", feature = "hv"), test))]
+const RISCV_PLIC_SOURCE_COUNT: usize = 1024;
 
 #[cfg(all(target_arch = "riscv64", feature = "hv"))]
 pub fn register_virtual_irq_injector(injector: fn(usize) -> bool) {
     VIRTUAL_IRQ_INJECTOR.store(injector as *mut (), Ordering::Release);
+}
+
+#[cfg(all(target_arch = "riscv64", feature = "hv"))]
+pub fn set_virtual_irq_targets(cpu_id: usize, irq_sources: &[u32]) {
+    VIRTUAL_IRQ_TARGET_CPU.store(cpu_id, Ordering::Release);
+    for configured in &VIRTUAL_IRQ_AFFINITY_CONFIGURED {
+        configured.store(false, Ordering::Release);
+    }
+    for &irq in irq_sources {
+        route_virtual_irq_to_target_cpu(irq as usize);
+    }
 }
 
 struct IrqIfImpl;
@@ -38,7 +58,9 @@ impl IrqIf for IrqIfImpl {
             let irq = active.id();
 
             #[cfg(all(target_arch = "riscv64", feature = "hv"))]
-            if is_guest_forwardable(irq) && inject_virtual_irq(irq.hwirq.0 as usize) {
+            if should_forward_riscv_guest_irq(irq, IrqOutcome::default())
+                && inject_virtual_irq(irq.hwirq.0 as usize)
+            {
                 return Some(irq);
             }
 
@@ -104,6 +126,22 @@ fn is_guest_forwardable(irq: IrqId) -> bool {
     somehal::irq::domain_is_kind(irq.domain, somehal::irq::IrqDomainKind::RiscvPlic)
 }
 
+#[cfg(any(all(target_arch = "riscv64", feature = "hv"), test))]
+fn should_forward_riscv_guest_irq(irq: IrqId, _host_outcome: IrqOutcome) -> bool {
+    is_guest_forwardable(irq)
+}
+
+#[cfg(test)]
+fn riscv_plic_source_index(irq: IrqId) -> Option<usize> {
+    if !is_guest_forwardable(irq) {
+        return None;
+    }
+    let source = irq.hwirq.0 as usize;
+    (1..RISCV_PLIC_SOURCE_COUNT)
+        .contains(&source)
+        .then_some(source)
+}
+
 #[cfg(all(target_arch = "loongarch64", feature = "hv"))]
 fn is_loongarch_guest_forwardable(irq: IrqId) -> bool {
     somehal::irq::domain_is_kind(irq.domain, somehal::irq::IrqDomainKind::LoongArchEioIntc)
@@ -112,17 +150,65 @@ fn is_loongarch_guest_forwardable(irq: IrqId) -> bool {
 
 #[cfg(all(target_arch = "riscv64", feature = "hv"))]
 fn inject_virtual_irq(irq: usize) -> bool {
+    route_virtual_irq_to_target_cpu(irq);
+
     let injector = VIRTUAL_IRQ_INJECTOR.load(Ordering::Acquire);
     if injector.is_null() {
-        warn!("virtual IRQ injector is not registered");
+        trace!("skip RISC-V virtual IRQ {irq}: injector is not registered");
         return false;
     }
     unsafe { core::mem::transmute::<*mut (), fn(usize) -> bool>(injector)(irq) }
 }
 
+#[cfg(all(target_arch = "riscv64", feature = "hv"))]
+fn route_virtual_irq_to_target_cpu(irq: usize) {
+    if irq == 0 || irq >= RISCV_PLIC_SOURCE_COUNT {
+        return;
+    }
+    let target_cpu = VIRTUAL_IRQ_TARGET_CPU.load(Ordering::Acquire);
+    if target_cpu == usize::MAX {
+        return;
+    }
+    let configured = &VIRTUAL_IRQ_AFFINITY_CONFIGURED[irq];
+    if configured.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    let Some(domain) = somehal::irq::domain_by_kind_fast(somehal::irq::IrqDomainKind::RiscvPlic)
+    else {
+        configured.store(false, Ordering::Release);
+        trace!("skip RISC-V virtual IRQ {irq} affinity: PLIC domain is not registered");
+        return;
+    };
+    let irq_id = IrqId::new(domain, ax_plat::irq::HwIrq(irq as u32));
+    let affinity = somehal::irq::IrqAffinity::Fixed { cpu_id: target_cpu };
+    if let Err(err) = somehal::irq::irq_set_affinity(irq_id, affinity) {
+        configured.store(false, Ordering::Release);
+        trace!("skip RISC-V virtual IRQ {irq} affinity to CPU {target_cpu}: {err:?}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ax_plat::irq::{CPU_LOCAL_IRQ_DOMAIN, HwIrq, IrqId};
+    use spin::Once;
+
+    fn plic_irq(hwirq: u32) -> IrqId {
+        static PLIC_DOMAIN: Once<somehal::irq::IrqDomainId> = Once::new();
+
+        let domain = *PLIC_DOMAIN.call_once(|| {
+            somehal::irq::domain_by_kind(somehal::irq::IrqDomainKind::RiscvPlic)
+                .map(|domain| domain.id)
+                .unwrap_or_else(|| {
+                    somehal::irq::alloc_irq_domain(
+                        rdrive::DeviceId::new(),
+                        somehal::irq::IrqDomainKind::RiscvPlic,
+                    )
+                    .unwrap()
+                })
+        });
+        IrqId::new(domain, HwIrq(hwirq))
+    }
 
     #[test]
     fn cpu_local_irq_is_never_forwarded_to_guest() {
@@ -133,13 +219,42 @@ mod tests {
 
     #[test]
     fn plic_irq_can_be_forwarded_to_guest() {
-        let domain = somehal::irq::alloc_irq_domain(
-            rdrive::DeviceId::new(),
-            somehal::irq::IrqDomainKind::RiscvPlic,
-        )
-        .unwrap();
-        let irq = IrqId::new(domain, HwIrq(10));
+        let irq = plic_irq(10);
 
         assert!(super::is_guest_forwardable(irq));
+    }
+
+    #[test]
+    fn handled_plic_irq_remains_forwardable_to_passthrough_guest() {
+        let irq = plic_irq(1);
+        let host_outcome = ax_plat::irq::IrqOutcome {
+            handled: true,
+            wake: false,
+            called: 1,
+        };
+
+        assert!(super::should_forward_riscv_guest_irq(irq, host_outcome));
+    }
+
+    #[test]
+    fn unhandled_plic_irq_can_be_forwarded_to_guest() {
+        let irq = plic_irq(2);
+
+        assert!(super::should_forward_riscv_guest_irq(
+            irq,
+            ax_plat::irq::IrqOutcome::default()
+        ));
+    }
+
+    #[test]
+    fn only_real_plic_sources_have_virtual_irq_source_index() {
+        let irq = plic_irq(2);
+        assert_eq!(super::riscv_plic_source_index(irq), Some(2));
+
+        let reserved = IrqId::new(irq.domain, HwIrq(0));
+        assert_eq!(super::riscv_plic_source_index(reserved), None);
+
+        let out_of_range = IrqId::new(irq.domain, HwIrq(super::RISCV_PLIC_SOURCE_COUNT as u32));
+        assert_eq!(super::riscv_plic_source_index(out_of_range), None);
     }
 }

--- a/platforms/axplat-dyn/src/lib.rs
+++ b/platforms/axplat-dyn/src/lib.rs
@@ -33,4 +33,4 @@ pub fn ipi_irq() -> ax_plat::irq::IrqId {
     somehal::irq::ipi_irq()
 }
 #[cfg(all(feature = "irq", target_arch = "riscv64", feature = "hv"))]
-pub use irq::register_virtual_irq_injector;
+pub use irq::{register_virtual_irq_injector, set_virtual_irq_targets};

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use ax_crate_interface::impl_interface;
 use ax_errno::{AxResult, ax_err};
 use ax_memory_addr::{PhysAddr, VirtAddr};
-use axvm_types::NestedPagingConfig;
+use axvm_types::{NestedPagingConfig, VMInterruptMode};
 use riscv_vcpu::{GprIndex as RiscvGprIndex, host::RiscvVcpuHostIf};
 use riscv_vplic::host::RiscvVplicHostIf;
 
@@ -82,6 +82,22 @@ impl ArchOps for Riscv64Arch {
         register_platform_irq_injector();
     }
 
+    fn before_first_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef) {
+        if vm.interrupt_mode() != VMInterruptMode::Passthrough {
+            return;
+        }
+        let Some(cpu_id) = vcpu.phys_cpu_set().and_then(first_cpu_in_mask) else {
+            warn!(
+                "skip RISC-V virtual IRQ affinity for VM[{}] VCpu[{}]: no fixed host CPU",
+                vm.id(),
+                vcpu.id()
+            );
+            return;
+        };
+        let irq_sources = vm.with_config(|config| config.pass_through_irqs().to_vec());
+        crate::irq::set_riscv_virtual_irq_targets(cpu_id, &irq_sources);
+    }
+
     fn vcpu_affinities(
         cpu_num: usize,
         phys_cpu_ids: Option<&[usize]>,
@@ -140,13 +156,17 @@ fn register_platform_irq_injector() {
     crate::irq::register_riscv_virtual_irq_injector(inject_virtual_irq);
 }
 
-fn inject_virtual_irq(irq_id: usize) -> bool {
-    debug!("injecting RISC-V virtual IRQ id: {irq_id}");
+fn first_cpu_in_mask(mask: usize) -> Option<usize> {
+    (mask != 0).then_some(mask.trailing_zeros() as usize)
+}
 
+fn inject_virtual_irq(irq_id: usize) -> bool {
     let Some(vm_id) = crate::current_vm_id() else {
-        warn!("cannot inject RISC-V virtual IRQ without current VM context");
+        trace!("skip RISC-V virtual IRQ {irq_id}: no current VM context");
         return false;
     };
+
+    debug!("injecting RISC-V virtual IRQ id: {irq_id}");
 
     let Some(injected) = crate::manager::with_vm(vm_id, |vm| {
         if let Err(err) = vm.pulse_interrupt(irq_id) {

--- a/virtualization/axvm/src/boot/fdt/mod.rs
+++ b/virtualization/axvm/src/boot/fdt/mod.rs
@@ -19,11 +19,11 @@
 
 #[cfg(any(test, target_arch = "aarch64", target_arch = "riscv64"))]
 mod create;
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(test, target_arch = "aarch64", target_arch = "riscv64"))]
 mod device;
 #[cfg(target_arch = "loongarch64")]
 pub(crate) mod loongarch64;
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(test, target_arch = "aarch64", target_arch = "riscv64"))]
 mod parser;
 mod print;
 #[cfg(any(test, target_arch = "aarch64", target_arch = "riscv64"))]
@@ -54,7 +54,7 @@ use axvmconfig::{AxVMCrateConfig, VMBootProtocol};
 // pub use print::print_fdt;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 pub use create::update_fdt;
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(test, target_arch = "aarch64", target_arch = "riscv64"))]
 pub use parser::*;
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
@@ -191,7 +191,7 @@ pub fn handle_fdt_operations(
     if let Some(dtb) = guest_dtb.as_ref().map(GuestDtbImage::as_bytes) {
         parse_reserved_memory_regions(vm_create_config, dtb)?;
         parse_passthrough_devices_address(vm_config, vm_create_config, dtb)?;
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         parse_vm_interrupt(vm_config, dtb)?;
     } else {
         error!(

--- a/virtualization/axvm/src/boot/fdt/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/parser.rs
@@ -33,6 +33,7 @@ use crate::{MappingFlags, config::AxVMConfig};
 
 const PAGE_SIZE_4K: usize = 0x1000;
 
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 pub fn try_get_host_fdt() -> Option<&'static [u8]> {
     let bootarg: usize = crate::host_fdt_bootarg();
     if bootarg == 0 {
@@ -583,7 +584,7 @@ pub fn parse_passthrough_devices_address(
     Ok(())
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 pub fn parse_vm_interrupt(vm_cfg: &mut AxVMConfig, dtb: &[u8]) -> AxResult {
     let fdt = Fdt::from_bytes(dtb).map_err(|e| {
         ax_err_type!(
@@ -609,16 +610,38 @@ pub fn parse_vm_interrupt(vm_cfg: &mut AxVMConfig, dtb: &[u8]) -> AxResult {
             continue;
         };
         for interrupt in view.interrupts() {
-            if interrupt.specifier.first().copied() == Some(0)
-                && let Some(irq) = interrupt.specifier.get(1)
-            {
-                trace!("node: {name}, GIC_SPI interrupt id: 0x{irq:x}");
-                vm_cfg.add_pass_through_spi(*irq);
+            if let Some(irq) = passthrough_irq_from_interrupt_specifier(&interrupt.specifier) {
+                trace!("node: {name}, passthrough interrupt id: 0x{irq:x}");
+                vm_cfg.add_pass_through_irq(irq);
             }
         }
     }
 
     Ok(())
+}
+
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+fn passthrough_irq_from_interrupt_specifier(specifier: &[u32]) -> Option<u32> {
+    #[cfg(target_arch = "aarch64")]
+    {
+        aarch64_gic_spi_from_interrupt_specifier(specifier)
+    }
+    #[cfg(target_arch = "riscv64")]
+    {
+        riscv_plic_source_from_interrupt_specifier(specifier)
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn aarch64_gic_spi_from_interrupt_specifier(specifier: &[u32]) -> Option<u32> {
+    (specifier.first().copied() == Some(0))
+        .then(|| specifier.get(1).copied())
+        .flatten()
+}
+
+#[cfg(any(target_arch = "riscv64", test))]
+fn riscv_plic_source_from_interrupt_specifier(specifier: &[u32]) -> Option<u32> {
+    specifier.first().copied().filter(|source| *source != 0)
 }
 
 #[cfg(target_arch = "riscv64")]
@@ -653,7 +676,9 @@ pub fn update_provided_fdt(
 
 #[cfg(test)]
 mod tests {
-    use axvm_types::AddressSpacePolicy;
+    use alloc::{string::ToString, vec, vec::Vec};
+
+    use axvm_types::{AddressSpacePolicy, VmMemConfig, VmMemMappingType};
     use axvmconfig::{AxVMCrateConfig, VMDevicesConfig};
     use fdt_edit::{Fdt, Node};
     use fdt_raw::RegInfo;
@@ -777,5 +802,22 @@ mod tests {
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].base_gpa, 0x1000_1000);
         assert_eq!(ranges[0].length, 0x1000);
+    }
+
+    #[test]
+    fn riscv_plic_interrupt_uses_first_fdt_cell() {
+        assert_eq!(
+            super::riscv_plic_source_from_interrupt_specifier(&[8]),
+            Some(8)
+        );
+    }
+
+    #[test]
+    fn riscv_plic_interrupt_rejects_reserved_source_zero() {
+        assert_eq!(
+            super::riscv_plic_source_from_interrupt_specifier(&[0]),
+            None
+        );
+        assert_eq!(super::riscv_plic_source_from_interrupt_specifier(&[]), None);
     }
 }

--- a/virtualization/axvm/src/config.rs
+++ b/virtualization/axvm/src/config.rs
@@ -89,8 +89,8 @@ pub struct AxVMConfig {
     address_space_policy: AddressSpacePolicy,
     memory_regions: Vec<VmMemConfig>,
     boot_policy: GuestBootPolicy,
-    // TODO: improve interrupt passthrough
-    spi_list: Vec<u32>,
+    // Physical interrupt sources forwarded to the guest in passthrough mode.
+    passthrough_irq_list: Vec<u32>,
     interrupt_mode: VMInterruptMode,
 }
 
@@ -133,7 +133,7 @@ impl AxVMConfig {
             address_space_policy: params.address_space_policy,
             memory_regions: params.memory_regions,
             boot_policy: params.boot_policy,
-            spi_list: Vec::new(),
+            passthrough_irq_list: Vec::new(),
             interrupt_mode: params.interrupt_mode,
         }
     }
@@ -272,12 +272,24 @@ impl AxVMConfig {
 
     /// Adds a passthrough SPI to the VM configuration.
     pub fn add_pass_through_spi(&mut self, spi: u32) {
-        self.spi_list.push(spi);
+        self.add_pass_through_irq(spi);
+    }
+
+    /// Adds a physical interrupt source forwarded to the guest.
+    pub fn add_pass_through_irq(&mut self, irq: u32) {
+        if !self.passthrough_irq_list.contains(&irq) {
+            self.passthrough_irq_list.push(irq);
+        }
     }
 
     /// Returns the list of passthrough SPIs.
     pub fn pass_through_spis(&self) -> &Vec<u32> {
-        &self.spi_list
+        &self.passthrough_irq_list
+    }
+
+    /// Returns the physical interrupt sources forwarded to the guest.
+    pub fn pass_through_irqs(&self) -> &Vec<u32> {
+        &self.passthrough_irq_list
     }
 
     /// Returns the interrupt mode of the VM.

--- a/virtualization/axvm/src/irq/mod.rs
+++ b/virtualization/axvm/src/irq/mod.rs
@@ -30,12 +30,23 @@ pub(crate) mod riscv;
 pub trait RiscvPlatformIrqInjectorIf {
     /// Registers a callback that forwards a physical IRQ line into the current guest.
     fn register_virtual_irq_injector(injector: fn(usize) -> bool);
+
+    /// Routes physical PLIC IRQs that may be forwarded to a guest toward the vCPU CPU.
+    fn set_virtual_irq_targets(cpu_id: usize, irq_sources: &[u32]);
 }
 
 #[cfg(target_arch = "riscv64")]
 pub(crate) fn register_riscv_virtual_irq_injector(injector: fn(usize) -> bool) {
     ax_crate_interface::call_interface!(RiscvPlatformIrqInjectorIf::register_virtual_irq_injector(
         injector
+    ));
+}
+
+#[cfg(target_arch = "riscv64")]
+pub(crate) fn set_riscv_virtual_irq_targets(cpu_id: usize, irq_sources: &[u32]) {
+    ax_crate_interface::call_interface!(RiscvPlatformIrqInjectorIf::set_virtual_irq_targets(
+        cpu_id,
+        irq_sources
     ));
 }
 


### PR DESCRIPTION
## 问题

近 24 小时的 `dev` CI 里先后暴露了两类问题：

- Starry `test-ptrace-gdb` 的 `PTRACE_SINGLESTEP` 子用例在 RISC-V 和 LoongArch job 中失败，tracee 在 single-step 停止点之前已经执行了目标指令副作用，表现为 `singlestep ran target side effect early`。
- PR 更新后，`Test axvisor riscv64 qemu / run_host` 仍会卡住；本地用同一命令 `cargo xtask axvisor test qemu --arch riscv64` 复现时，guest Linux 停在 `virtio_blk virtio0: [vda] ...` 之后，无法继续挂载 rootfs。

Starry 的根因是软件 single-step 状态机漏掉了一个边界：RISC-V/LoongArch/AArch64 通过在下一条将执行的用户指令上临时写入 breakpoint 来模拟 single-step，如果 tracee 已经跳到这个临时 breakpoint PC，但 breakpoint trap 尚未交付时因 IRQ 回到内核，旧逻辑会在下一轮返回用户态前恢复这个 pending breakpoint 并重新布置下一步，导致目标指令先执行。

Axvisor 的根因是 `fix(block): drive virtio-blk completions by IRQ (#1512)` 让 host rootfs 的 virtio-blk completion 变成真实 IRQ 驱动后，触发了 RISC-V Axvisor passthrough IRQ 路由中的既有假设问题：

1. guest 启动前，host 加载 VM 镜像时会收到 PLIC block IRQ，此时没有 current vCPU/VM context，应该按 host IRQ 处理，而不是大量警告或假定可以注入 guest。
2. guest 启动后，passthrough 设备的 PLIC source 默认 affinity 是 `Any`，首个 block IRQ 可能打到非 vCPU 所在 CPU；此时依赖 current VM context 的注入路径会错过 guest IRQ，host handler 还可能先 ack 掉这次 completion，最终 guest rootfs 挂载卡死。

## 修改

- 新增 `ptrace_complete_singlestep_breakpoint_if_at_ip()`，当保存的 single-step breakpoint 地址已经等于当前用户 PC 时，先恢复原指令并清除当前 single-step 状态。
- 在用户态循环进入 `uctx.run()` 之前检查上述 pending breakpoint 命中状态，并将其作为已完成的 `PTRACE_SINGLESTEP` 上报 `SIGTRAP`。
- Breakpoint exception 路径复用同一个 helper，避免两套恢复逻辑分叉。
- 让 RISC-V FDT 解析同样记录 passthrough interrupt source：PLIC interrupt specifier 的第一个 cell 被保存为 VM passthrough IRQ list。
- 在 RISC-V passthrough VM 的 vCPU 首次运行前，把解析出的 PLIC source affinity 主动固定到 vCPU 所在 CPU。
- 保留 RISC-V passthrough IRQ 的 pre-dispatch 注入语义，并把 guest 启动前没有 injector/current VM 的情况降级为正常 trace 路径，避免 host 镜像加载阶段误报。

## 逻辑

Starry 修复保持现有软件 breakpoint single-step 方案不变，只补齐 pending breakpoint 已经到达当前 PC 时的完成分支：tracer 请求 single-step 后，如果 kernel 发现 tracee 已经位于临时 breakpoint PC，就应当视为这一步已经完成并通知 tracer，而不是恢复 breakpoint 后继续执行目标指令。

Axvisor 修复把 passthrough IRQ 的 ownership 切换点前移到 guest 运行之前：host 加载镜像阶段的 PLIC IRQ 继续走 host dispatch；guest 即将运行时，VM 配置中解析到的 passthrough PLIC source 会被路由到 vCPU CPU。这样物理 IRQ 到来时，pre-dispatch 注入路径能在正确 CPU 上看到 current VM context 并 pulse guest IRQ，避免首个 virtio-blk completion 被 host 侧消费导致 guest 卡死。

## 验证

- `cargo fmt && git diff --check`
- `cargo test -p axplat-dyn --features irq --lib`
- `cargo test -p axvm --lib`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask clippy --package axplat-dyn`
- `cargo xtask clippy --package axvm`
- `cargo xtask clippy --package axvisor`（xtask 提示 axvisor 需使用专用 target/build flow，因此用下面的 qemu flow 覆盖）
- `cargo xtask starry test qemu --arch riscv64 -c qemu-smp1/system/test-ptrace-gdb`
- `cargo xtask starry test qemu --arch loongarch64 -c qemu-smp1/system/test-ptrace-gdb`
- `cargo xtask axvisor test qemu --arch riscv64`
