### PR TITLE
feat(msi): add AArch64 MSI-X registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "rdif-display",
  "rdif-input",
  "rdif-intc",
+ "rdif-msi",
  "rdif-pcie",
  "rdif-pinctrl",
  "rdif-power",
@@ -5496,8 +5497,10 @@ dependencies = [
  "log",
  "mmio-api",
  "pci_types",
+ "rdif-msi",
  "rdif-pcie",
  "thiserror 2.0.18",
+ "tock-registers 0.10.1",
 ]
 
 [[package]]
@@ -6294,6 +6297,14 @@ name = "rdif-intc"
 version = "0.15.0"
 dependencies = [
  "cfg-if",
+ "irq-framework",
+ "rdif-base",
+]
+
+[[package]]
+name = "rdif-msi"
+version = "0.1.0"
+dependencies = [
  "irq-framework",
  "rdif-base",
 ]
@@ -7546,6 +7557,7 @@ dependencies = [
  "mmio-api",
  "page-table-generic",
  "rdif-intc",
+ "rdif-msi",
  "rdrive",
  "riscv",
  "sbi-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ rdif-display = { version = "0.2.0", path = "drivers/interface/rdif-display" }
 rdif-eth = { version = "0.3.6", path = "drivers/interface/rdif-eth" }
 rdif-input = { version = "0.2.0", path = "drivers/interface/rdif-input" }
 rdif-intc = { version = "0.15.0", path = "drivers/interface/rdif-intc" }
+rdif-msi = { version = "0.1.0", path = "drivers/interface/rdif-msi" }
 rdif-pcie = { version = "0.2.5", path = "drivers/interface/rdif-pcie" }
 rdif-pinctrl = { version = "0.1.1", path = "drivers/interface/rdif-pinctrl" }
 rdif-pwm = { version = "0.1.0", path = "drivers/interface/rdif-pwm" }

--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -14,7 +14,7 @@ name = "ax_driver"
 default = []
 
 irq = []
-pci = ["dep:ax-kspin", "dep:pcie", "dep:rdif-pcie"]
+pci = ["dep:ax-kspin", "dep:pcie", "dep:rdif-msi", "dep:rdif-pcie"]
 
 block = ["dep:ax-errno", "dep:ax-kspin", "dep:rdif-block"]
 net = ["dep:ax-kspin", "dep:rd-net"]
@@ -162,6 +162,7 @@ rdif-display = { workspace = true, optional = true }
 rdif-input = { workspace = true, optional = true }
 rdif-serial = { workspace = true, optional = true }
 rdif-intc.workspace = true
+rdif-msi = { workspace = true, optional = true }
 rdif-pcie = { workspace = true, optional = true }
 rdif-pinctrl = { workspace = true, optional = true }
 rdif-power = { workspace = true, optional = true }

--- a/drivers/ax-driver/src/binding_info.rs
+++ b/drivers/ax-driver/src/binding_info.rs
@@ -6,7 +6,13 @@ use rdrive::DeviceId;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BindingInfo {
-    irq: Option<BindingIrq>,
+    irqs: Vec<BindingIrqBinding>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BindingIrqBinding {
+    pub source_id: usize,
+    pub irq: BindingIrq,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -38,35 +44,66 @@ pub enum PciIrqRequirement {
 
 impl BindingInfo {
     pub const fn empty() -> Self {
-        Self { irq: None }
+        Self { irqs: Vec::new() }
     }
 
     pub fn with_irq(irq: Option<usize>) -> Result<Self, irq_framework::IrqError> {
-        Ok(Self {
-            irq: irq.map(BindingIrq::try_legacy).transpose()?,
-        })
+        Ok(Self::with_binding_irq(
+            irq.map(BindingIrq::try_legacy).transpose()?,
+        ))
     }
 
     pub fn with_irq_id(irq: Option<IrqId>) -> Self {
-        Self {
-            irq: irq.map(BindingIrq::id),
-        }
+        Self::with_binding_irq(irq.map(BindingIrq::id))
     }
 
     pub fn with_binding_irq(irq: Option<BindingIrq>) -> Self {
-        Self { irq }
+        match irq {
+            Some(irq) => Self::with_irq_sources([(0, irq)]),
+            None => Self::empty(),
+        }
+    }
+
+    pub fn with_irq_sources(irqs: impl IntoIterator<Item = (usize, BindingIrq)>) -> Self {
+        Self {
+            irqs: irqs
+                .into_iter()
+                .map(|(source_id, irq)| BindingIrqBinding { source_id, irq })
+                .collect(),
+        }
     }
 
     pub fn irq(&self) -> Option<&BindingIrq> {
-        self.irq.as_ref()
+        self.irq_for_source(0)
+            .or_else(|| self.irqs.first().map(|binding| &binding.irq))
     }
 
     pub fn irq_cloned(&self) -> Option<BindingIrq> {
-        self.irq.clone()
+        self.irq().cloned()
+    }
+
+    pub fn irq_for_source(&self, source_id: usize) -> Option<&BindingIrq> {
+        self.irqs
+            .iter()
+            .find(|binding| binding.source_id == source_id)
+            .map(|binding| &binding.irq)
+    }
+
+    pub fn irq_for_source_cloned(&self, source_id: usize) -> Option<BindingIrq> {
+        self.irq_for_source(source_id).cloned()
+    }
+
+    pub fn irq_sources(&self) -> &[BindingIrqBinding] {
+        &self.irqs
     }
 
     pub fn irq_num(&self) -> Option<usize> {
-        self.irq.as_ref().and_then(BindingIrq::legacy_num)
+        self.irq().and_then(BindingIrq::legacy_num)
+    }
+
+    pub fn irq_num_for_source(&self, source_id: usize) -> Option<usize> {
+        self.irq_for_source(source_id)
+            .and_then(BindingIrq::legacy_num)
     }
 }
 

--- a/drivers/ax-driver/src/block/binding.rs
+++ b/drivers/ax-driver/src/block/binding.rs
@@ -71,7 +71,7 @@ pub struct PlatformBlockDevice {
 /// objects directly, installing IRQ handlers according to the OS policy.
 pub struct RdifBlockDevice {
     name: String,
-    irq: Option<BindingIrq>,
+    irqs: Vec<crate::BindingIrqBinding>,
     interface: Box<dyn Interface>,
 }
 
@@ -351,15 +351,36 @@ impl RdifBlockDevice {
     }
 
     pub fn irq(&self) -> Option<&BindingIrq> {
-        self.irq.as_ref()
+        self.irq_for_source(0)
+            .or_else(|| self.irqs.first().map(|binding| &binding.irq))
     }
 
     pub fn irq_cloned(&self) -> Option<BindingIrq> {
-        self.irq.clone()
+        self.irq().cloned()
+    }
+
+    pub fn irq_for_source(&self, source_id: usize) -> Option<&BindingIrq> {
+        self.irqs
+            .iter()
+            .find(|binding| binding.source_id == source_id)
+            .map(|binding| &binding.irq)
+    }
+
+    pub fn irq_for_source_cloned(&self, source_id: usize) -> Option<BindingIrq> {
+        self.irq_for_source(source_id).cloned()
+    }
+
+    pub fn irq_sources(&self) -> &[crate::BindingIrqBinding] {
+        &self.irqs
     }
 
     pub fn irq_num(&self) -> Option<usize> {
-        self.irq.as_ref().and_then(BindingIrq::legacy_num)
+        self.irq().and_then(BindingIrq::legacy_num)
+    }
+
+    pub fn irq_num_for_source(&self, source_id: usize) -> Option<usize> {
+        self.irq_for_source(source_id)
+            .and_then(BindingIrq::legacy_num)
     }
 
     pub fn interface(&self) -> &dyn Interface {
@@ -384,7 +405,7 @@ impl RdifBlockDevice {
 
     #[cfg(feature = "irq")]
     pub fn take_irq_handler(&mut self, source_id: usize) -> Option<(usize, BlockIrqHandler)> {
-        let irq_num = self.irq_num()?;
+        let irq_num = self.irq_num_for_source(source_id)?;
         self.interface
             .take_irq_handler(source_id)
             .map(BlockIrqHandler::new_raw)
@@ -610,11 +631,11 @@ impl TryFrom<Device<PlatformBlockDevice>> for RdifBlockDevice {
     fn try_from(base: Device<PlatformBlockDevice>) -> Result<Self, Self::Error> {
         let mut dev = base.lock().map_err(|_| AxError::BadState)?;
         let name = dev.name.clone();
-        let irq = dev.info.irq_cloned();
+        let irqs = dev.info.irq_sources().to_vec();
         let interface = dev.interface.take().ok_or(AxError::BadState)?;
         Ok(Self {
             name,
-            irq,
+            irqs,
             interface,
         })
     }

--- a/drivers/ax-driver/src/block/nvme.rs
+++ b/drivers/ax-driver/src/block/nvme.rs
@@ -1,16 +1,23 @@
 extern crate alloc;
 
-use alloc::format;
+use alloc::{boxed::Box, format};
 
-use log::info;
+use log::{info, warn};
 use nvme_driver::{Config, Nvme, NvmeBlockDriver};
 use pcie::{CommandRegister, DeviceType};
+use rdif_block::{
+    BQueue, DeviceInfo, Interface, IrqHandler, IrqSourceList, QueueHandle, QueueLimits,
+};
 use rdrive::probe::{
     OnProbeError,
     pci::{FnOnProbe, ProbePci},
 };
 
-use crate::{PciIrqRequirement, block::ProbePciBlock};
+use crate::{
+    PciIrqRequirement,
+    block::{PlatformDeviceBlock, ProbePciBlock},
+    pci::PciMsixAllocation,
+};
 
 pub const DEVICE_NAME: &str = "nvme";
 const DEFAULT_PAGE_SIZE: usize = 0x1000;
@@ -26,29 +33,47 @@ crate::model_register!(
 );
 
 fn probe_pci(mut probe: ProbePci<'_>) -> Result<(), OnProbeError> {
-    let endpoint = probe.endpoint_mut();
-    if endpoint.device_type() != DeviceType::NvmeController {
+    if probe.endpoint().device_type() != DeviceType::NvmeController {
         return Err(OnProbeError::NotMatch);
     }
 
-    let Some(bar) = endpoint.bar_mmio(0) else {
+    let Some(bar) = probe.endpoint().bar_mmio(0) else {
         return Err(OnProbeError::other("NVMe BAR0 MMIO missing"));
     };
 
-    endpoint.update_command(|mut cmd| {
-        cmd.insert(CommandRegister::MEMORY_ENABLE | CommandRegister::BUS_MASTER_ENABLE);
-        cmd.remove(CommandRegister::INTERRUPT_DISABLE);
-        cmd
-    });
-
-    let address = endpoint.address();
+    let address = probe.endpoint().address();
     info!(
         "NVMe PCI endpoint {address}: BAR0={:#x}..{:#x}, int_pin={}, int_line={}",
         bar.start,
         bar.end,
-        endpoint.interrupt_pin(),
-        endpoint.interrupt_line()
+        probe.endpoint().interrupt_pin(),
+        probe.endpoint().interrupt_line()
     );
+
+    let msix_result = {
+        let info = probe.info();
+        let endpoint = probe.endpoint_mut();
+        PciMsixAllocation::allocate(endpoint, info, DEFAULT_IO_QUEUE_PAIRS as u16)
+    };
+    match msix_result {
+        Ok(msix) => {
+            let irq = register_msix_block(probe, bar, msix)?;
+            info!("NVMe block device registered at {address} with MSI-X irqs={irq:?}");
+            return Ok(());
+        }
+        Err(OnProbeError::Unsupported(reason)) => {
+            info!("NVMe PCI endpoint {address} MSI-X unavailable ({reason}); using legacy INTx")
+        }
+        Err(err) => {
+            warn!("NVMe PCI endpoint {address} MSI-X setup failed: {err}; using legacy INTx")
+        }
+    }
+
+    probe.endpoint_mut().update_command(|mut cmd| {
+        cmd.insert(CommandRegister::MEMORY_ENABLE | CommandRegister::BUS_MASTER_ENABLE);
+        cmd.remove(CommandRegister::INTERRUPT_DISABLE);
+        cmd
+    });
 
     let nvme = Nvme::new(
         bar.start,
@@ -65,4 +90,103 @@ fn probe_pci(mut probe: ProbePci<'_>) -> Result<(), OnProbeError> {
     let irq = probe.register_block(driver, PciIrqRequirement::Required)?;
     info!("NVMe block device registered at {address} with irq={irq:?}");
     Ok(())
+}
+
+fn register_msix_block(
+    mut probe: ProbePci<'_>,
+    bar: core::ops::Range<usize>,
+    msix: PciMsixAllocation,
+) -> Result<Option<usize>, OnProbeError> {
+    let irq_info = msix.binding_info();
+    let vectors = msix.vector_indices();
+
+    probe.endpoint_mut().update_command(|mut cmd| {
+        cmd.insert(
+            CommandRegister::MEMORY_ENABLE
+                | CommandRegister::BUS_MASTER_ENABLE
+                | CommandRegister::INTERRUPT_DISABLE,
+        );
+        cmd
+    });
+
+    let nvme = Nvme::new(
+        bar.start,
+        bar.count().max(1),
+        u64::MAX,
+        axklib::dma::op(),
+        axklib::mmio::op(),
+        Config::new(DEFAULT_PAGE_SIZE, DEFAULT_IO_QUEUE_PAIRS).with_msix_vectors(vectors),
+    )
+    .map_err(|err| OnProbeError::other(format!("failed to initialize NVMe: {err:?}")))?;
+    let driver = NvmeBlockDriver::from_nvme(nvme).map_err(|err| {
+        OnProbeError::other(format!("failed to create NVMe block driver: {err:?}"))
+    })?;
+
+    let (_, _, plat_dev) = probe.into_parts();
+    Ok(plat_dev.register_block_with_info(MsixBlockDriver::new(driver, msix), irq_info))
+}
+
+struct MsixBlockDriver<T> {
+    inner: T,
+    msix: PciMsixAllocation,
+}
+
+impl<T> MsixBlockDriver<T> {
+    const fn new(inner: T, msix: PciMsixAllocation) -> Self {
+        Self { inner, msix }
+    }
+}
+
+impl<T: Interface> rdif_block::DriverGeneric for MsixBlockDriver<T> {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn raw_any(&self) -> Option<&dyn core::any::Any> {
+        self.inner.raw_any()
+    }
+
+    fn raw_any_mut(&mut self) -> Option<&mut dyn core::any::Any> {
+        self.inner.raw_any_mut()
+    }
+}
+
+impl<T: Interface> Interface for MsixBlockDriver<T> {
+    fn device_info(&self) -> DeviceInfo {
+        self.inner.device_info()
+    }
+
+    fn queue_limits(&self) -> QueueLimits {
+        self.inner.queue_limits()
+    }
+
+    fn create_queue(&mut self) -> Option<BQueue> {
+        self.inner.create_queue()
+    }
+
+    fn create_owned_queue(&mut self) -> Option<QueueHandle> {
+        self.inner.create_owned_queue()
+    }
+
+    fn enable_irq(&self) {
+        self.msix.enable();
+        self.inner.enable_irq();
+    }
+
+    fn disable_irq(&self) {
+        self.inner.disable_irq();
+        self.msix.disable();
+    }
+
+    fn is_irq_enabled(&self) -> bool {
+        self.inner.is_irq_enabled()
+    }
+
+    fn irq_sources(&self) -> IrqSourceList {
+        self.inner.irq_sources()
+    }
+
+    fn take_irq_handler(&mut self, source_id: usize) -> Option<Box<dyn IrqHandler>> {
+        self.inner.take_irq_handler(source_id)
+    }
 }

--- a/drivers/ax-driver/src/lib.rs
+++ b/drivers/ax-driver/src/lib.rs
@@ -95,7 +95,7 @@ pub mod virtio;
 
 #[cfg(feature = "pci")]
 pub use binding_info::PciIrqRequirement;
-pub use binding_info::{BindingInfo, BindingIrq, BindingIrqSource, FdtIrqSpec};
+pub use binding_info::{BindingInfo, BindingIrq, BindingIrqBinding, BindingIrqSource, FdtIrqSpec};
 #[cfg(feature = "pci")]
 pub use binding_resolver::binding_info_from_pci;
 pub use binding_resolver::{

--- a/drivers/ax-driver/src/pci/mod.rs
+++ b/drivers/ax-driver/src/pci/mod.rs
@@ -32,8 +32,10 @@ use crate::virtio::VirtIoHalImpl;
 
 mod acpi;
 mod fdt;
+pub mod msi;
 pub(crate) use acpi::acpi_irq_for_endpoint;
 pub(crate) use fdt::fdt_irq_for_endpoint;
+pub use msi::{PciMsiTarget, PciMsixAllocation};
 
 const MAX_PCIE_LEGACY_IRQS: usize = 8;
 #[cfg(virtio_dev)]

--- a/drivers/ax-driver/src/pci/msi.rs
+++ b/drivers/ax-driver/src/pci/msi.rs
@@ -1,0 +1,427 @@
+extern crate alloc;
+
+use alloc::{format, vec::Vec};
+
+use fdt_edit::{Fdt, NodeType, Phandle};
+use log::warn;
+use pcie::{Endpoint, MsixError, MsixTableRegion};
+use rdif_msi::{Msi, MsiAllocation, MsiDeviceId, MsiRequest};
+use rdrive::{
+    DeviceId,
+    probe::{
+        OnProbeError,
+        pci::{PciAddress, PciInfo},
+    },
+};
+
+use crate::{BindingInfo, BindingIrq, BindingIrqBinding};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PciMsiTarget {
+    pub provider: DeviceId,
+    pub device: MsiDeviceId,
+}
+
+pub struct PciMsixAllocation {
+    provider: DeviceId,
+    allocation: Option<MsiAllocation>,
+    table: MsixTableRegion,
+    _table_mmio: mmio_api::Mmio,
+}
+
+impl PciMsixAllocation {
+    pub fn allocate(
+        endpoint: &mut Endpoint,
+        info: PciInfo,
+        vector_count: u16,
+    ) -> Result<Self, OnProbeError> {
+        let target = msi_target_for_endpoint(info)?;
+        let table_info = endpoint.msix_table_info().map_err(msix_probe_error)?;
+        let table_range = endpoint.msix_table_range().map_err(msix_probe_error)?;
+
+        if vector_count == 0 || vector_count > table_info.entries {
+            return Err(OnProbeError::other(format!(
+                "PCI endpoint {} requested {vector_count} MSI-X vectors, table has {}",
+                info.address, table_info.entries
+            )));
+        }
+
+        let provider = rdrive::get::<Msi>(target.provider)
+            .map_err(|err| msi_provider_lookup_error(info.address, target.provider, err))?;
+        let mut provider = provider
+            .lock()
+            .map_err(|_| OnProbeError::other("failed to lock MSI provider"))?;
+        let allocation = provider
+            .allocate(MsiRequest::new(target.device, vector_count))
+            .map_err(|err| {
+                OnProbeError::other(format!(
+                    "failed to allocate {vector_count} MSI-X vectors for {}: {err:?}",
+                    info.address
+                ))
+            })?;
+
+        let table_mmio = axklib::mmio::ioremap(table_range.start.into(), table_range.len())
+            .map_err(|err| OnProbeError::other(format!("failed to map MSI-X table: {err}")))?;
+        let table =
+            unsafe { MsixTableRegion::new(table_mmio.as_nonnull_ptr(), table_info.entries) };
+
+        endpoint
+            .set_msix_function_mask(true)
+            .map_err(msix_probe_error)?;
+        for vector in allocation.vectors() {
+            let message = provider.compose_message(vector).map_err(|err| {
+                OnProbeError::other(format!(
+                    "failed to compose MSI-X message for {} vector {:?}: {err:?}",
+                    info.address, vector.index
+                ))
+            })?;
+            table
+                .program_masked(vector.index.0, message)
+                .map_err(msix_probe_error)?;
+            provider.set_vector_enabled(vector, false).map_err(|err| {
+                OnProbeError::other(format!("failed to disable MSI vector: {err:?}"))
+            })?;
+        }
+        endpoint.set_msix_enabled(true).map_err(msix_probe_error)?;
+
+        Ok(Self {
+            provider: target.provider,
+            allocation: Some(allocation),
+            table,
+            _table_mmio: table_mmio,
+        })
+    }
+
+    pub fn binding_info(&self) -> BindingInfo {
+        let irqs = self
+            .vectors()
+            .iter()
+            .map(|vector| (usize::from(vector.index.0), BindingIrq::id(vector.irq)));
+        BindingInfo::with_irq_sources(irqs)
+    }
+
+    pub fn irq_bindings(&self) -> Vec<BindingIrqBinding> {
+        self.binding_info().irq_sources().to_vec()
+    }
+
+    pub fn vector_indices(&self) -> Vec<u16> {
+        self.vectors().iter().map(|vector| vector.index.0).collect()
+    }
+
+    pub fn enable(&self) {
+        if let Some(allocation) = &self.allocation
+            && let Ok(provider) = rdrive::get::<Msi>(self.provider)
+            && let Ok(mut provider) = provider.lock()
+        {
+            for vector in allocation.vectors() {
+                if let Err(err) = provider.set_vector_enabled(vector, true) {
+                    warn!("failed to enable MSI vector {:?}: {err:?}", vector.index);
+                }
+                if let Err(err) = self.table.unmask(vector.index.0) {
+                    warn!(
+                        "failed to unmask MSI-X table entry {:?}: {err}",
+                        vector.index
+                    );
+                }
+            }
+        }
+    }
+
+    pub fn disable(&self) {
+        if let Some(allocation) = &self.allocation {
+            for vector in allocation.vectors() {
+                if let Err(err) = self.table.mask(vector.index.0) {
+                    warn!("failed to mask MSI-X table entry {:?}: {err}", vector.index);
+                }
+            }
+            if let Ok(provider) = rdrive::get::<Msi>(self.provider)
+                && let Ok(mut provider) = provider.lock()
+            {
+                for vector in allocation.vectors() {
+                    if let Err(err) = provider.set_vector_enabled(vector, false) {
+                        warn!("failed to disable MSI vector {:?}: {err:?}", vector.index);
+                    }
+                }
+            }
+        }
+    }
+
+    fn vectors(&self) -> &[rdif_msi::MsiVector] {
+        self.allocation
+            .as_ref()
+            .map(MsiAllocation::vectors)
+            .unwrap_or(&[])
+    }
+}
+
+impl Drop for PciMsixAllocation {
+    fn drop(&mut self) {
+        self.disable();
+        let Some(allocation) = self.allocation.take() else {
+            return;
+        };
+        if let Ok(provider) = rdrive::get::<Msi>(self.provider)
+            && let Ok(mut provider) = provider.lock()
+            && let Err(err) = provider.free(allocation)
+        {
+            warn!("failed to free MSI-X allocation: {err:?}");
+        }
+    }
+}
+
+pub fn msi_target_for_endpoint(info: PciInfo) -> Result<PciMsiTarget, OnProbeError> {
+    match dynamic_msi_source() {
+        Some(DynamicMsiSource::Fdt) => fdt_msi_target_for_endpoint(info),
+        Some(DynamicMsiSource::Acpi) => Err(OnProbeError::Unsupported(
+            "ACPI IORT PCI MSI routing is not implemented",
+        )),
+        None => Err(OnProbeError::Unsupported(
+            "PCI MSI routing requires FDT msi-parent/msi-map or ACPI IORT",
+        )),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DynamicMsiSource {
+    Acpi,
+    Fdt,
+}
+
+fn dynamic_msi_source() -> Option<DynamicMsiSource> {
+    if rdrive::probe::acpi::with_acpi(|_| ()).is_some() {
+        Some(DynamicMsiSource::Acpi)
+    } else if rdrive::with_fdt(|_| ()).is_some() {
+        Some(DynamicMsiSource::Fdt)
+    } else {
+        None
+    }
+}
+
+fn fdt_msi_target_for_endpoint(info: PciInfo) -> Result<PciMsiTarget, OnProbeError> {
+    let Some(result) = rdrive::with_fdt(|fdt| resolve_fdt_msi_target(fdt, info)) else {
+        return Err(OnProbeError::Unsupported("live FDT not found"));
+    };
+    result
+}
+
+fn resolve_fdt_msi_target(fdt: &Fdt, info: PciInfo) -> Result<PciMsiTarget, OnProbeError> {
+    let host = fdt_pci_host_for_endpoint(fdt, info)?;
+    let rid = pci_requester_id(info.address);
+
+    let host_node = fdt
+        .node(host.id())
+        .ok_or_else(|| OnProbeError::other("PCI host node disappeared while resolving MSI"))?;
+
+    if let Some(target) = resolve_msi_map(host_node, rid)? {
+        return Ok(target);
+    }
+    if let Some(target) = resolve_msi_parent(host_node, rid)? {
+        return Ok(target);
+    }
+
+    Err(OnProbeError::Unsupported("PCI host has no FDT MSI routing"))
+}
+
+fn fdt_pci_host_for_endpoint(
+    fdt: &Fdt,
+    info: PciInfo,
+) -> Result<fdt_edit::PciNodeView<'_>, OnProbeError> {
+    let bus = info.address.bus();
+    let mut candidates = Vec::new();
+    let mut exact_range_matches = Vec::new();
+
+    for node in fdt.all_nodes() {
+        let NodeType::Pci(pci) = node else {
+            continue;
+        };
+        match pci.bus_range() {
+            Some(range) if range.contains(&(bus as u32)) => {
+                exact_range_matches.push(pci);
+                candidates.push(pci);
+            }
+            Some(_) => {}
+            None => candidates.push(pci),
+        }
+    }
+
+    if exact_range_matches.len() == 1 {
+        Ok(exact_range_matches[0])
+    } else if exact_range_matches.len() > 1 {
+        Err(OnProbeError::other(format!(
+            "multiple PCI host nodes in FDT match endpoint {} with the same bus-range",
+            info.address
+        )))
+    } else if candidates.len() == 1 {
+        Ok(candidates[0])
+    } else if candidates.is_empty() {
+        Err(OnProbeError::other(format!(
+            "no PCI host node in FDT matches endpoint {}",
+            info.address
+        )))
+    } else {
+        Err(OnProbeError::other(format!(
+            "multiple PCI host nodes in FDT match endpoint {} without a unique bus-range match",
+            info.address
+        )))
+    }
+}
+
+fn resolve_msi_parent(
+    host: &fdt_edit::Node,
+    rid: u32,
+) -> Result<Option<PciMsiTarget>, OnProbeError> {
+    let Some(prop) = host.get_property("msi-parent") else {
+        return Ok(None);
+    };
+    let phandle = prop
+        .get_u32_iter()
+        .next()
+        .map(Phandle::from)
+        .ok_or_else(|| OnProbeError::other("PCI host msi-parent is empty"))?;
+    Ok(Some(PciMsiTarget {
+        provider: provider_for_phandle(phandle)?,
+        device: MsiDeviceId(rid),
+    }))
+}
+
+fn resolve_msi_map(host: &fdt_edit::Node, rid: u32) -> Result<Option<PciMsiTarget>, OnProbeError> {
+    let Some(prop) = host.get_property("msi-map") else {
+        return Ok(None);
+    };
+    let mask = host
+        .get_property("msi-map-mask")
+        .and_then(|prop| prop.get_u32())
+        .unwrap_or(u32::MAX);
+    let masked_rid = rid & mask;
+    let cells: Vec<u32> = prop.get_u32_iter().collect();
+    let mut offset = 0;
+    while offset + 3 <= cells.len() {
+        let rid_base = cells[offset] & mask;
+        let phandle = Phandle::from(cells[offset + 1]);
+        let msi_cells = msi_cells_for_phandle(phandle).unwrap_or(1);
+        let tuple_len = 3 + msi_cells;
+        if offset + tuple_len > cells.len() {
+            return Err(OnProbeError::other("truncated PCI msi-map entry"));
+        }
+        let msi_base = cells[offset + 2];
+        let length = cells[offset + 2 + msi_cells];
+        let rid_end = rid_base
+            .checked_add(length)
+            .ok_or_else(|| OnProbeError::other("PCI msi-map rid range overflows u32"))?;
+        if masked_rid >= rid_base && masked_rid < rid_end {
+            let device = msi_base
+                .checked_add(masked_rid - rid_base)
+                .ok_or_else(|| OnProbeError::other("PCI msi-map device id overflows u32"))?;
+            return Ok(Some(PciMsiTarget {
+                provider: provider_for_phandle(phandle)?,
+                device: MsiDeviceId(device),
+            }));
+        }
+        offset += tuple_len;
+    }
+    Ok(None)
+}
+
+fn msi_cells_for_phandle(phandle: Phandle) -> Option<usize> {
+    rdrive::with_fdt(|fdt| {
+        fdt.get_by_phandle(phandle)
+            .and_then(|node| node.as_node().get_property("#msi-cells"))
+            .and_then(|prop| prop.get_u32())
+            .map(|cells| cells as usize)
+    })
+    .flatten()
+}
+
+fn provider_for_phandle(phandle: Phandle) -> Result<DeviceId, OnProbeError> {
+    rdrive::fdt_phandle_to_device_id(phandle).ok_or(OnProbeError::Unsupported(
+        "PCI MSI provider phandle is not registered",
+    ))
+}
+
+fn msi_provider_lookup_error(
+    address: PciAddress,
+    provider: DeviceId,
+    err: rdrive::GetDeviceError,
+) -> OnProbeError {
+    match err {
+        rdrive::GetDeviceError::NotFound => {
+            OnProbeError::Unsupported("PCI MSI provider is not registered")
+        }
+        rdrive::GetDeviceError::TypeNotMatch | rdrive::GetDeviceError::DeviceReleased => {
+            OnProbeError::Unsupported("PCI MSI provider interface is unavailable")
+        }
+        rdrive::GetDeviceError::UsedByOthers(_) | rdrive::GetDeviceError::UsedByUnknown => {
+            OnProbeError::other(format!(
+                "PCI endpoint {address} MSI provider {provider:?} is busy: {err}"
+            ))
+        }
+    }
+}
+
+fn pci_requester_id(address: PciAddress) -> u32 {
+    (u32::from(address.bus()) << 8)
+        | (u32::from(address.device()) << 3)
+        | u32::from(address.function())
+}
+
+fn msix_probe_error(err: MsixError) -> OnProbeError {
+    OnProbeError::other(format!("{err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requester_id_uses_bus_device_function() {
+        let address = PciAddress::new(0, 3, 4, 2);
+        assert_eq!(pci_requester_id(address), 0x322);
+    }
+
+    #[test]
+    fn msi_map_matches_masked_requester_id() {
+        let mut host = fdt_edit::Node::new("pcie@0");
+        host.set_property(prop_u32s("msi-map-mask", &[0xff]));
+        host.set_property(prop_u32s("msi-map", &[0x40, 1, 0x1000, 0x40]));
+
+        // Provider phandle lookup is intentionally outside this pure parser
+        // test; the tuple walk should reject non-matching masked RIDs first.
+        assert!(resolve_msi_map(&host, 0x20).unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_msi_provider_is_unsupported_for_legacy_fallback() {
+        let err = msi_provider_lookup_error(
+            PciAddress::new(0, 0, 1, 0),
+            DeviceId::from(7),
+            rdrive::GetDeviceError::NotFound,
+        );
+
+        assert!(matches!(
+            err,
+            OnProbeError::Unsupported("PCI MSI provider is not registered")
+        ));
+    }
+
+    #[test]
+    fn non_msi_controller_interface_is_unsupported_for_legacy_fallback() {
+        let err = msi_provider_lookup_error(
+            PciAddress::new(0, 0, 1, 0),
+            DeviceId::from(7),
+            rdrive::GetDeviceError::TypeNotMatch,
+        );
+
+        assert!(matches!(
+            err,
+            OnProbeError::Unsupported("PCI MSI provider interface is unavailable")
+        ));
+    }
+
+    fn prop_u32s(name: &str, values: &[u32]) -> fdt_edit::Property {
+        let mut data = Vec::new();
+        for value in values {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        fdt_edit::Property::new(name, data)
+    }
+}

--- a/drivers/blk/nvme-driver/src/block.rs
+++ b/drivers/blk/nvme-driver/src/block.rs
@@ -40,9 +40,10 @@ struct NvmeBlockOwner {
     next_queue_id: AtomicUsize,
     created_queue_bits: AtomicU64,
     irq_enabled: AtomicBool,
-    irq_handler_taken: AtomicBool,
+    irq_handler_taken_bits: AtomicU64,
     irq_supported: bool,
-    interrupt_vector: u32,
+    msix_interrupts: bool,
+    interrupt_vectors: Vec<u16>,
 }
 
 impl NvmeBlockDriver {
@@ -82,7 +83,8 @@ impl NvmeBlockDriver {
         queue_depth: usize,
     ) -> Self {
         let irq_supported = nvme.io_queue_interrupts_enabled();
-        let interrupt_vector = nvme.interrupt_vector();
+        let msix_interrupts = nvme.msix_interrupts_enabled();
+        let interrupt_vectors = nvme.interrupt_vectors().to_vec();
         Self {
             name,
             inner: Arc::new(NvmeBlockOwner {
@@ -91,9 +93,10 @@ impl NvmeBlockDriver {
                 next_queue_id: AtomicUsize::new(0),
                 created_queue_bits: AtomicU64::new(0),
                 irq_enabled: AtomicBool::new(false),
-                irq_handler_taken: AtomicBool::new(false),
+                irq_handler_taken_bits: AtomicU64::new(0),
                 irq_supported,
-                interrupt_vector,
+                msix_interrupts,
+                interrupt_vectors,
             }),
             queue_depth: queue_depth.max(1),
         }
@@ -149,6 +152,85 @@ impl NvmeBlockOwner {
     fn queues(&self) -> &[Arc<NvmeQueueCore>] {
         unsafe { &*self.queues.get() }
     }
+
+    fn source_queue_bits(&self, source_id: usize, queue_bits: u64) -> u64 {
+        source_queue_bits(
+            self.msix_interrupts,
+            &self.interrupt_vectors,
+            source_id,
+            queue_bits,
+        )
+    }
+
+    fn irq_sources_from_queue_bits(&self, queue_bits: u64) -> IrqSourceList {
+        irq_sources_from_queue_bits(self.msix_interrupts, &self.interrupt_vectors, queue_bits)
+    }
+
+    fn unique_interrupt_vectors(&self) -> Vec<u16> {
+        unique_interrupt_vectors(&self.interrupt_vectors)
+    }
+}
+
+fn vector_for_queue(msix_interrupts: bool, vectors: &[u16], queue_id: usize) -> Option<u16> {
+    if msix_interrupts {
+        vectors.get(queue_id).copied()
+    } else {
+        Some(0)
+    }
+}
+
+fn source_queue_bits(
+    msix_interrupts: bool,
+    vectors: &[u16],
+    source_id: usize,
+    queue_bits: u64,
+) -> u64 {
+    if !msix_interrupts {
+        return if source_id == 0 { queue_bits } else { 0 };
+    }
+
+    let mut bits = 0;
+    for queue_id in 0..u64::BITS as usize {
+        if queue_bits & (1 << queue_id) == 0 {
+            continue;
+        }
+        if vector_for_queue(msix_interrupts, vectors, queue_id) == Some(source_id as u16) {
+            bits |= 1 << queue_id;
+        }
+    }
+    bits
+}
+
+fn irq_sources_from_queue_bits(
+    msix_interrupts: bool,
+    vectors: &[u16],
+    queue_bits: u64,
+) -> IrqSourceList {
+    if !msix_interrupts {
+        return vec![IrqSourceInfo::legacy(IdList::from_bits(queue_bits))];
+    }
+
+    let mut sources = Vec::new();
+    for vector in unique_interrupt_vectors(vectors) {
+        let queues = source_queue_bits(msix_interrupts, vectors, usize::from(vector), queue_bits);
+        if queues != 0 {
+            sources.push(IrqSourceInfo::new(
+                usize::from(vector),
+                IdList::from_bits(queues),
+            ));
+        }
+    }
+    sources
+}
+
+fn unique_interrupt_vectors(vectors: &[u16]) -> Vec<u16> {
+    let mut unique = Vec::new();
+    for vector in vectors {
+        if !unique.contains(vector) {
+            unique.push(*vector);
+        }
+    }
+    unique
 }
 
 impl DriverGeneric for NvmeBlockDriver {
@@ -208,9 +290,11 @@ impl Interface for NvmeBlockDriver {
         if !self.inner.irq_supported {
             return;
         }
-        let vector = self.inner.interrupt_vector;
-        self.inner
-            .with_mut(|inner| inner.nvme.unmask_interrupt_vector(vector));
+        self.inner.with_mut(|inner| {
+            for vector in self.inner.unique_interrupt_vectors() {
+                inner.nvme.unmask_interrupt_vector(u32::from(vector));
+            }
+        });
         self.inner.irq_enabled.store(true, Ordering::Release);
     }
 
@@ -218,9 +302,11 @@ impl Interface for NvmeBlockDriver {
         if !self.inner.irq_supported {
             return;
         }
-        let vector = self.inner.interrupt_vector;
-        self.inner
-            .with_mut(|inner| inner.nvme.mask_interrupt_vector(vector));
+        self.inner.with_mut(|inner| {
+            for vector in self.inner.unique_interrupt_vectors() {
+                inner.nvme.mask_interrupt_vector(u32::from(vector));
+            }
+        });
         self.inner.irq_enabled.store(false, Ordering::Release);
     }
 
@@ -233,27 +319,40 @@ impl Interface for NvmeBlockDriver {
         if !self.inner.irq_supported || queue_bits == 0 {
             return Vec::new();
         }
-        vec![IrqSourceInfo::legacy(IdList::from_bits(queue_bits))]
+        self.inner.irq_sources_from_queue_bits(queue_bits)
     }
 
     fn take_irq_handler(&mut self, source_id: usize) -> Option<Box<dyn IrqHandler>> {
-        if source_id != 0 || !self.inner.irq_supported {
+        if !self.inner.irq_supported || source_id >= u64::BITS as usize {
             return None;
         }
-        if self.inner.created_queue_bits.load(Ordering::Acquire) == 0 {
+        let queue_bits = self.inner.source_queue_bits(
+            source_id,
+            self.inner.created_queue_bits.load(Ordering::Acquire),
+        );
+        if queue_bits == 0 {
             return None;
         }
-        if self.inner.irq_handler_taken.swap(true, Ordering::AcqRel) {
+        let bit = 1_u64 << source_id;
+        if self
+            .inner
+            .irq_handler_taken_bits
+            .fetch_or(bit, Ordering::AcqRel)
+            & bit
+            != 0
+        {
             return None;
         }
         Some(Box::new(NvmeBlockIrqHandler {
             owner: self.inner.clone(),
+            source_id,
         }))
     }
 }
 
 struct NvmeBlockIrqHandler {
     owner: Arc<NvmeBlockOwner>,
+    source_id: usize,
 }
 
 impl IrqHandler for NvmeBlockIrqHandler {
@@ -262,7 +361,14 @@ impl IrqHandler for NvmeBlockIrqHandler {
             return Event::none();
         }
         let mut event = Event::none();
+        let source_queue_bits = self.owner.source_queue_bits(
+            self.source_id,
+            self.owner.created_queue_bits.load(Ordering::Acquire),
+        );
         for queue in self.owner.queues() {
+            if source_queue_bits & (1 << queue.id()) == 0 {
+                continue;
+            }
             if queue.drain_irq_completions() {
                 event.push_queue(queue.id());
             }
@@ -888,7 +994,7 @@ fn limits(
 mod tests {
     use super::{
         CachedCompletion, CompletionCache, CompletionStatus, PrpPageAccumulator, RequestSlot,
-        SlotState, limits,
+        SlotState, irq_sources_from_queue_bits, limits, source_queue_bits,
     };
     use crate::Namespace;
 
@@ -937,6 +1043,30 @@ mod tests {
 
         assert_eq!(limits.max_blocks_per_request, 1024);
         assert_eq!(limits.max_segment_size, 512 * 1024);
+    }
+
+    #[test]
+    fn legacy_irq_source_covers_all_created_queues() {
+        let sources = irq_sources_from_queue_bits(false, &[], 0b1011);
+
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].id, 0);
+        assert_eq!(sources[0].queues.bits(), 0b1011);
+        assert_eq!(source_queue_bits(false, &[], 0, 0b1011), 0b1011);
+        assert_eq!(source_queue_bits(false, &[], 1, 0b1011), 0);
+    }
+
+    #[test]
+    fn msix_irq_sources_group_queues_by_vector() {
+        let vectors = [4, 5, 4];
+        let sources = irq_sources_from_queue_bits(true, &vectors, 0b111);
+
+        assert_eq!(sources.len(), 2);
+        assert_eq!(sources[0].id, 4);
+        assert_eq!(sources[0].queues.bits(), 0b101);
+        assert_eq!(sources[1].id, 5);
+        assert_eq!(sources[1].queues.bits(), 0b010);
+        assert_eq!(source_queue_bits(true, &vectors, 4, 0b111), 0b101);
     }
 
     #[test]

--- a/drivers/blk/nvme-driver/src/nvme.rs
+++ b/drivers/blk/nvme-driver/src/nvme.rs
@@ -27,15 +27,18 @@ pub struct Nvme {
     page_size: usize,
     max_transfer_bytes: Option<usize>,
     io_queue_interrupts: bool,
-    interrupt_vector: u32,
+    msix_interrupts: bool,
+    interrupt_vectors: Vec<u16>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub page_size: usize,
     pub io_queue_pair_count: usize,
     pub io_queue_interrupts: bool,
     pub interrupt_vector: u32,
+    pub msix_interrupts: bool,
+    pub interrupt_vectors: Vec<u16>,
 }
 
 impl Config {
@@ -45,13 +48,38 @@ impl Config {
             io_queue_pair_count,
             io_queue_interrupts: false,
             interrupt_vector: 0,
+            msix_interrupts: false,
+            interrupt_vectors: Vec::new(),
         }
     }
 
-    pub const fn with_intx_irq(mut self) -> Self {
+    pub fn with_intx_irq(mut self) -> Self {
         self.io_queue_interrupts = true;
         self.interrupt_vector = 0;
+        self.msix_interrupts = false;
+        self.interrupt_vectors = Vec::from([0]);
         self
+    }
+
+    pub fn with_msix_vectors(mut self, vectors: impl Into<Vec<u16>>) -> Self {
+        self.interrupt_vectors = vectors.into();
+        self.io_queue_interrupts = !self.interrupt_vectors.is_empty();
+        self.msix_interrupts = self.io_queue_interrupts;
+        self.interrupt_vector = self
+            .interrupt_vectors
+            .first()
+            .copied()
+            .map(u32::from)
+            .unwrap_or(0);
+        self
+    }
+
+    fn interrupt_vector_for_queue(&self, queue_index: usize) -> u32 {
+        self.interrupt_vectors
+            .get(queue_index)
+            .copied()
+            .map(u32::from)
+            .unwrap_or(self.interrupt_vector)
     }
 }
 
@@ -97,7 +125,8 @@ impl Nvme {
             page_size: config.page_size,
             max_transfer_bytes: None,
             io_queue_interrupts: config.io_queue_interrupts,
-            interrupt_vector: config.interrupt_vector,
+            msix_interrupts: config.msix_interrupts,
+            interrupt_vectors: config.interrupt_vectors.clone(),
         };
 
         let version = s.version();
@@ -145,7 +174,9 @@ impl Nvme {
         self.num_ns = controller.number_of_namespaces as _;
         self.max_transfer_bytes = controller_max_transfer_bytes(config.page_size, controller.mdts);
         if config.io_queue_interrupts {
-            self.mask_interrupt_vector(config.interrupt_vector);
+            for vector in &config.interrupt_vectors {
+                self.mask_interrupt_vector(u32::from(*vector));
+            }
         }
         self.config_io_queue(config)?;
 
@@ -224,7 +255,7 @@ impl Nvme {
                 io_queue.cq_bus_addr(),
                 true,
                 config.io_queue_interrupts,
-                config.interrupt_vector,
+                config.interrupt_vector_for_queue(i),
             );
             self.admin_queue.command_sync(data)?;
 
@@ -263,7 +294,19 @@ impl Nvme {
     }
 
     pub fn interrupt_vector(&self) -> u32 {
-        self.interrupt_vector
+        self.interrupt_vectors
+            .first()
+            .copied()
+            .map(u32::from)
+            .unwrap_or(0)
+    }
+
+    pub fn msix_interrupts_enabled(&self) -> bool {
+        self.io_queue_interrupts && self.msix_interrupts
+    }
+
+    pub fn interrupt_vectors(&self) -> &[u16] {
+        &self.interrupt_vectors
     }
 
     pub fn mask_interrupt_vector(&mut self, vector: u32) {
@@ -414,10 +457,25 @@ mod tests {
         let config = Config::new(4096, 1);
         assert!(!config.io_queue_interrupts);
         assert_eq!(config.interrupt_vector, 0);
+        assert!(!config.msix_interrupts);
+        assert!(config.interrupt_vectors.is_empty());
 
         let irq_config = config.with_intx_irq();
         assert!(irq_config.io_queue_interrupts);
         assert_eq!(irq_config.interrupt_vector, 0);
+        assert!(!irq_config.msix_interrupts);
+        assert_eq!(irq_config.interrupt_vectors, [0]);
+    }
+
+    #[test]
+    fn config_can_enable_msix_per_queue_vectors() {
+        let config = Config::new(4096, 2).with_msix_vectors([4, 5]);
+
+        assert!(config.io_queue_interrupts);
+        assert!(config.msix_interrupts);
+        assert_eq!(config.interrupt_vector, 4);
+        assert_eq!(config.interrupt_vector_for_queue(0), 4);
+        assert_eq!(config.interrupt_vector_for_queue(1), 5);
     }
 
     #[test]

--- a/drivers/intc/arm-gic-driver/src/version/v3/gicr.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/gicr.rs
@@ -219,6 +219,29 @@ impl LPI {
         self.CTLR.modify(RCtrl::EnableLPIs::SET);
     }
 
+    /// Configure property and pending tables for physical LPIs.
+    pub fn configure_lpi_tables(
+        &self,
+        property_table_phys: u64,
+        property_id_bits: u8,
+        pending_table_phys: u64,
+    ) -> Result<(), &'static str> {
+        self.disable_lpi();
+        self.PROPBASER.write(
+            PROPBASER::IDbits.val(property_id_bits.saturating_sub(1) as u64)
+                + PROPBASER::PhysicalAddress.val(property_table_phys >> 12)
+                + PROPBASER::InnerCache::WaWb
+                + PROPBASER::OuterCache::WaWb,
+        );
+        self.PENDBASER.write(
+            PENDBASER::PhysicalAddress.val(pending_table_phys >> 16)
+                + PENDBASER::InnerCache::WaWb
+                + PENDBASER::OuterCache::WaWb,
+        );
+        self.enable_lpi();
+        self.wait_for_rwp()
+    }
+
     /// Disable LPI support
     pub fn disable_lpi(&self) {
         self.CTLR.modify(RCtrl::EnableLPIs::CLEAR);
@@ -268,6 +291,10 @@ impl LPI {
     /// Get affinity value
     pub fn get_affinity(&self) -> u32 {
         self.TYPER.read(TYPER::Affinity) as u32
+    }
+
+    pub fn processor_number(&self) -> u16 {
+        self.TYPER.read(TYPER::ProcessorNumber) as u16
     }
 
     /// Check if physical LPIs are supported

--- a/drivers/intc/arm-gic-driver/src/version/v3/its.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/its.rs
@@ -1,0 +1,353 @@
+use core::hint::spin_loop;
+
+use aarch64_cpu::asm::barrier;
+use tock_registers::{interfaces::*, register_bitfields, register_structs, registers::*};
+
+use crate::VirtAddr;
+
+pub const GITS_TRANSLATER_OFFSET: u64 = 0x10040;
+pub const ITS_COMMAND_SIZE: usize = core::mem::size_of::<ItsCommand>();
+
+register_structs! {
+    #[allow(non_snake_case)]
+    pub ItsRegs {
+        (0x0000 => pub CTLR: ReadWrite<u32, CTLR::Register>),
+        (0x0004 => pub IIDR: ReadOnly<u32>),
+        (0x0008 => pub TYPER: ReadOnly<u64, TYPER::Register>),
+        (0x0010 => _rsv0),
+        (0x0018 => pub MPIDR: ReadOnly<u64>),
+        (0x0020 => _rsv1: [u32; 24]),
+        (0x0080 => pub CBASER: ReadWrite<u64, CBASER::Register>),
+        (0x0088 => pub CWRITER: ReadWrite<u64, CWRITER::Register>),
+        (0x0090 => pub CREADR: ReadOnly<u64, CREADR::Register>),
+        (0x0098 => _rsv2: [u32; 26]),
+        (0x0100 => pub BASER: [ReadWrite<u64, BASER::Register>; 8]),
+        (0x0140 => _rsv3: [u32; 16320]),
+        (0x10040 => pub TRANSLATER: WriteOnly<u32>),
+        (0x10044 => @END),
+    }
+}
+
+register_bitfields! [
+    u32,
+    pub CTLR [
+        Enabled OFFSET(0) NUMBITS(1) [],
+        ImDe OFFSET(1) NUMBITS(1) [],
+        ITSNumber OFFSET(4) NUMBITS(4) [],
+        Quiescent OFFSET(31) NUMBITS(1) [],
+    ],
+];
+
+register_bitfields! [
+    u64,
+    pub TYPER [
+        PhysicalLPIs OFFSET(0) NUMBITS(1) [],
+        VirtualLPIs OFFSET(1) NUMBITS(1) [],
+        ITTEntrySize OFFSET(4) NUMBITS(4) [],
+        IDbits OFFSET(8) NUMBITS(5) [],
+        Devbits OFFSET(13) NUMBITS(5) [],
+        PTA OFFSET(19) NUMBITS(1) [],
+        HCC OFFSET(24) NUMBITS(8) [],
+    ],
+    pub CBASER [
+        Size OFFSET(0) NUMBITS(8) [],
+        Shareability OFFSET(10) NUMBITS(2) [
+            NonShareable = 0,
+            InnerShareable = 0b01,
+            OuterShareable = 0b10,
+        ],
+        PhysicalAddress OFFSET(12) NUMBITS(40) [],
+        OuterCache OFFSET(53) NUMBITS(3) [
+            NonCacheable = 0b001,
+            RaWaWb = 0b111,
+        ],
+        InnerCache OFFSET(59) NUMBITS(3) [
+            NonCacheable = 0b001,
+            RaWaWb = 0b111,
+        ],
+        Valid OFFSET(63) NUMBITS(1) [],
+    ],
+    pub CWRITER [
+        Retry OFFSET(0) NUMBITS(1) [],
+        Offset OFFSET(5) NUMBITS(15) [],
+    ],
+    pub CREADR [
+        Stalled OFFSET(0) NUMBITS(1) [],
+        Offset OFFSET(5) NUMBITS(15) [],
+    ],
+    pub BASER [
+        Size OFFSET(0) NUMBITS(8) [],
+        PageSize OFFSET(8) NUMBITS(2) [
+            Size4K = 0,
+            Size16K = 1,
+            Size64K = 2,
+        ],
+        Shareability OFFSET(10) NUMBITS(2) [
+            NonShareable = 0,
+            InnerShareable = 0b01,
+            OuterShareable = 0b10,
+        ],
+        PhysicalAddress OFFSET(12) NUMBITS(36) [],
+        EntrySize OFFSET(48) NUMBITS(5) [],
+        OuterCache OFFSET(53) NUMBITS(3) [
+            NonCacheable = 0b001,
+            RaWaWb = 0b111,
+        ],
+        Type OFFSET(56) NUMBITS(3) [
+            None = 0,
+            Device = 1,
+            Vcpu = 2,
+            Collection = 4,
+        ],
+        InnerCache OFFSET(59) NUMBITS(3) [
+            NonCacheable = 0b001,
+            RaWaWb = 0b111,
+        ],
+        Indirect OFFSET(62) NUMBITS(1) [],
+        Valid OFFSET(63) NUMBITS(1) [],
+    ],
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ItsTableType {
+    Device,
+    Collection,
+}
+
+impl ItsTableType {
+    const fn baser_value(self) -> u64 {
+        match self {
+            Self::Device => 1,
+            Self::Collection => 4,
+        }
+    }
+}
+
+#[repr(C, align(32))]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ItsCommand {
+    raw: [u64; 4],
+}
+
+impl ItsCommand {
+    pub const fn raw(self) -> [u64; 4] {
+        self.raw
+    }
+
+    pub fn mapd(device_id: u32, itt_phys: u64, event_count: u32, valid: bool) -> Self {
+        let mut cmd = Self::opcode(0x08);
+        cmd.encode_device(device_id);
+        cmd.encode_size(itt_size_field(event_count));
+        cmd.encode_itt(itt_phys);
+        cmd.encode_valid(valid);
+        cmd.le()
+    }
+
+    pub fn mapc(collection: u16, target_address: u64, valid: bool) -> Self {
+        let mut cmd = Self::opcode(0x09);
+        cmd.encode_collection(collection);
+        cmd.encode_target(target_address);
+        cmd.encode_valid(valid);
+        cmd.le()
+    }
+
+    pub fn mapti(device_id: u32, event_id: u32, physical_id: u32, collection: u16) -> Self {
+        let mut cmd = Self::opcode(0x0a);
+        cmd.encode_device(device_id);
+        cmd.encode_event(event_id);
+        cmd.encode_physical(physical_id);
+        cmd.encode_collection(collection);
+        cmd.le()
+    }
+
+    pub fn inv(device_id: u32, event_id: u32) -> Self {
+        let mut cmd = Self::opcode(0x0c);
+        cmd.encode_device(device_id);
+        cmd.encode_event(event_id);
+        cmd.le()
+    }
+
+    pub fn sync(target_address: u64) -> Self {
+        let mut cmd = Self::opcode(0x05);
+        cmd.encode_target(target_address);
+        cmd.le()
+    }
+
+    const fn opcode(opcode: u8) -> Self {
+        Self {
+            raw: [opcode as u64, 0, 0, 0],
+        }
+    }
+
+    fn encode_device(&mut self, device_id: u32) {
+        self.raw[0] |= u64::from(device_id) << 32;
+    }
+
+    fn encode_event(&mut self, event_id: u32) {
+        self.raw[1] |= u64::from(event_id);
+    }
+
+    fn encode_physical(&mut self, physical_id: u32) {
+        self.raw[1] |= u64::from(physical_id) << 32;
+    }
+
+    fn encode_size(&mut self, size: u8) {
+        self.raw[1] |= u64::from(size) & 0x1f;
+    }
+
+    fn encode_itt(&mut self, itt_phys: u64) {
+        self.raw[2] |= ((itt_phys >> 8) & ((1 << 44) - 1)) << 8;
+    }
+
+    fn encode_target(&mut self, target_address: u64) {
+        self.raw[2] |= ((target_address >> 16) & ((1 << 36) - 1)) << 16;
+    }
+
+    fn encode_collection(&mut self, collection: u16) {
+        self.raw[2] |= u64::from(collection);
+    }
+
+    fn encode_valid(&mut self, valid: bool) {
+        self.raw[2] |= u64::from(valid) << 63;
+    }
+
+    fn le(mut self) -> Self {
+        for word in &mut self.raw {
+            *word = word.to_le();
+        }
+        self
+    }
+}
+
+pub fn itt_size_field(event_count: u32) -> u8 {
+    let entries = event_count.next_power_of_two();
+    let entries = if entries < 2 { 2 } else { entries };
+    entries.ilog2().saturating_sub(1) as u8
+}
+
+pub struct Its {
+    base: VirtAddr,
+    phys_base: u64,
+}
+
+unsafe impl Send for Its {}
+
+impl Its {
+    /// # Safety
+    ///
+    /// `base` must be a valid mapping of a GICv3 ITS register frame, and
+    /// `phys_base` must be the matching physical address used in MSI messages.
+    pub const unsafe fn new(base: VirtAddr, phys_base: u64) -> Self {
+        Self { base, phys_base }
+    }
+
+    pub const fn phys_base(&self) -> u64 {
+        self.phys_base
+    }
+
+    pub const fn translater_address(&self) -> u64 {
+        self.phys_base + GITS_TRANSLATER_OFFSET
+    }
+
+    pub fn typer(&self) -> u64 {
+        self.regs().TYPER.get()
+    }
+
+    pub fn id_bits(&self) -> u8 {
+        self.regs().TYPER.read(TYPER::IDbits) as u8 + 1
+    }
+
+    pub fn dev_bits(&self) -> u8 {
+        self.regs().TYPER.read(TYPER::Devbits) as u8 + 1
+    }
+
+    pub fn itt_entry_size(&self) -> usize {
+        self.regs().TYPER.read(TYPER::ITTEntrySize) as usize + 1
+    }
+
+    pub fn supports_physical_lpis(&self) -> bool {
+        self.regs().TYPER.is_set(TYPER::PhysicalLPIs)
+    }
+
+    pub fn uses_physical_collection_target(&self) -> bool {
+        self.regs().TYPER.is_set(TYPER::PTA)
+    }
+
+    pub fn baser_type(&self, index: usize) -> Option<ItsTableType> {
+        match self.regs().BASER[index].read(BASER::Type) {
+            1 => Some(ItsTableType::Device),
+            4 => Some(ItsTableType::Collection),
+            _ => None,
+        }
+    }
+
+    pub fn baser_entry_size(&self, index: usize) -> usize {
+        self.regs().BASER[index].read(BASER::EntrySize) as usize + 1
+    }
+
+    pub fn init_command_queue(&self, queue_phys: u64, queue_bytes: usize) {
+        let pages = queue_bytes.div_ceil(4096).clamp(1, 256);
+        self.regs().CWRITER.set(0);
+        self.regs().CBASER.write(
+            CBASER::Valid::SET
+                + CBASER::Size.val((pages - 1) as u64)
+                + CBASER::PhysicalAddress.val(queue_phys >> 12)
+                + CBASER::Shareability::InnerShareable
+                + CBASER::InnerCache::RaWaWb
+                + CBASER::OuterCache::RaWaWb,
+        );
+        barrier::dsb(barrier::SY);
+    }
+
+    pub fn program_baser(&self, index: usize, value: u64) {
+        self.regs().BASER[index].set(value);
+        barrier::dsb(barrier::SY);
+    }
+
+    pub fn baser_value(
+        table_type: ItsTableType,
+        phys: u64,
+        bytes: usize,
+        entry_size: usize,
+    ) -> u64 {
+        let pages = bytes.div_ceil(4096).clamp(1, 256);
+        (BASER::Valid::SET
+            + BASER::Size.val((pages - 1) as u64)
+            + BASER::PageSize::Size4K
+            + BASER::PhysicalAddress.val(phys >> 12)
+            + BASER::Shareability::InnerShareable
+            + BASER::InnerCache::RaWaWb
+            + BASER::OuterCache::RaWaWb
+            + BASER::EntrySize.val(entry_size.saturating_sub(1) as u64))
+        .value
+            | (table_type.baser_value() << 56)
+    }
+
+    pub fn enable(&self) {
+        self.regs().CTLR.modify(CTLR::Enabled::SET);
+        barrier::isb(barrier::SY);
+    }
+
+    pub fn disable(&self) {
+        self.regs().CTLR.modify(CTLR::Enabled::CLEAR);
+        barrier::isb(barrier::SY);
+        while !self.regs().CTLR.is_set(CTLR::Quiescent) {
+            spin_loop();
+        }
+    }
+
+    pub fn write_cwriter(&self, byte_offset: usize) {
+        self.regs()
+            .CWRITER
+            .write(CWRITER::Offset.val((byte_offset >> 5) as u64));
+        barrier::dsb(barrier::SY);
+    }
+
+    pub fn creadr_offset(&self) -> usize {
+        (self.regs().CREADR.read(CREADR::Offset) as usize) << 5
+    }
+
+    fn regs(&self) -> &ItsRegs {
+        unsafe { &*self.base.as_ptr() }
+    }
+}

--- a/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
@@ -9,9 +9,11 @@ pub use tock_registers::{LocalRegisterCopy, interfaces::*};
 
 mod gicd;
 mod gicr;
+mod its;
 
 use gicd::*;
 use gicr::*;
+pub use its::*;
 
 use crate::version::{IrqVecReadable, IrqVecWriteable};
 pub use crate::{IntId, VirtAddr, define::Trigger, sys_reg::*};
@@ -405,6 +407,41 @@ impl Gic {
     /// ```
     pub fn max_intid(&self) -> u32 {
         self.gicd().max_intid()
+    }
+
+    pub fn supports_lpis(&self) -> bool {
+        self.gicd().has_lpis()
+    }
+
+    pub fn redistributor_count(&self) -> usize {
+        self.rd_slice().iter().count()
+    }
+
+    pub fn current_collection_target(&self, gicr_phys_base: u64, use_physical_target: bool) -> u64 {
+        if use_physical_target {
+            gicr_phys_base
+        } else {
+            u64::from(self.current_rd_ref().lpi.processor_number()) << 16
+        }
+    }
+
+    pub fn init_lpi_tables(
+        &self,
+        property_table_phys: u64,
+        property_id_bits: u8,
+        pending_table_phys_base: u64,
+        pending_table_stride: usize,
+    ) -> Result<(), &'static str> {
+        for (idx, rd) in self.rd_slice().iter().enumerate() {
+            let pending = pending_table_phys_base + (idx * pending_table_stride) as u64;
+            unsafe { rd.as_ref() }.lpi.configure_lpi_tables(
+                property_table_phys,
+                property_id_bits,
+                pending,
+            )?;
+        }
+        barrier::dsb(barrier::SY);
+        Ok(())
     }
 
     fn disable(&self) {

--- a/drivers/interface/rdif-msi/Cargo.toml
+++ b/drivers/interface/rdif-msi/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors.workspace = true
+categories = ["embedded", "no-std"]
+description = "Driver Interface for message-signaled interrupt providers."
+edition.workspace = true
+keywords = ["os", "driver", "msi"]
+license.workspace = true
+name = "rdif-msi"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+irq-framework = { workspace = true }
+rdif-base = { workspace = true }

--- a/drivers/interface/rdif-msi/src/lib.rs
+++ b/drivers/interface/rdif-msi/src/lib.rs
@@ -1,0 +1,315 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{boxed::Box, vec::Vec};
+use core::ops::{Deref, DerefMut};
+
+pub use irq_framework::{IrqAffinity, IrqError, IrqId};
+pub use rdif_base::DriverGeneric;
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MsiProviderId(pub u64);
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MsiDeviceId(pub u32);
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct MsiEventId(pub u32);
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct MsiVectorIndex(pub u16);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MsiMessage {
+    pub address: u64,
+    pub data: u32,
+}
+
+impl MsiMessage {
+    pub const fn new(address: u64, data: u32) -> Self {
+        Self { address, data }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MsiVector {
+    pub index: MsiVectorIndex,
+    pub event: MsiEventId,
+    pub irq: IrqId,
+}
+
+impl MsiVector {
+    pub const fn new(index: MsiVectorIndex, event: MsiEventId, irq: IrqId) -> Self {
+        Self { index, event, irq }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MsiAllocation {
+    provider: MsiProviderId,
+    device: MsiDeviceId,
+    vectors: Box<[MsiVector]>,
+}
+
+impl MsiAllocation {
+    pub fn new(provider: MsiProviderId, device: MsiDeviceId, vectors: Box<[MsiVector]>) -> Self {
+        Self {
+            provider,
+            device,
+            vectors,
+        }
+    }
+
+    pub const fn provider(&self) -> MsiProviderId {
+        self.provider
+    }
+
+    pub const fn device(&self) -> MsiDeviceId {
+        self.device
+    }
+
+    pub fn vectors(&self) -> &[MsiVector] {
+        &self.vectors
+    }
+
+    pub fn into_vectors(self) -> Box<[MsiVector]> {
+        self.vectors
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MsiRequest {
+    pub device: MsiDeviceId,
+    pub vector_count: u16,
+    pub affinity: IrqAffinity,
+}
+
+impl MsiRequest {
+    pub const fn new(device: MsiDeviceId, vector_count: u16) -> Self {
+        Self {
+            device,
+            vector_count,
+            affinity: IrqAffinity::Any,
+        }
+    }
+
+    pub const fn affinity(mut self, affinity: IrqAffinity) -> Self {
+        self.affinity = affinity;
+        self
+    }
+}
+
+pub trait Interface: DriverGeneric {
+    fn allocate_vectors(&mut self, request: &MsiRequest) -> Result<Vec<MsiVector>, IrqError>;
+
+    fn compose_message(&self, vector: &MsiVector) -> Result<MsiMessage, IrqError>;
+
+    fn set_vector_enabled(&mut self, _vector: &MsiVector, _enabled: bool) -> Result<(), IrqError> {
+        Err(IrqError::Unsupported)
+    }
+
+    fn set_vector_affinity(
+        &mut self,
+        _vector: &MsiVector,
+        _affinity: IrqAffinity,
+    ) -> Result<(), IrqError> {
+        Err(IrqError::Unsupported)
+    }
+
+    fn free_vectors(&mut self, allocation: MsiAllocation) -> Result<(), IrqError>;
+}
+
+pub struct Msi {
+    provider: MsiProviderId,
+    inner: Box<dyn Interface>,
+}
+
+impl Msi {
+    pub fn new<T: Interface>(provider: MsiProviderId, driver: T) -> Self {
+        Self {
+            provider,
+            inner: Box::new(driver),
+        }
+    }
+
+    pub const fn provider(&self) -> MsiProviderId {
+        self.provider
+    }
+
+    pub fn allocate(&mut self, request: MsiRequest) -> Result<MsiAllocation, IrqError> {
+        if request.vector_count == 0 {
+            return Err(IrqError::InvalidIrq);
+        }
+        let vectors = self.inner.allocate_vectors(&request)?;
+        if vectors.len() != usize::from(request.vector_count) {
+            return Err(IrqError::InvalidIrq);
+        }
+        Ok(MsiAllocation::new(
+            self.provider,
+            request.device,
+            vectors.into_boxed_slice(),
+        ))
+    }
+
+    pub fn compose_message(&self, vector: &MsiVector) -> Result<MsiMessage, IrqError> {
+        self.inner.compose_message(vector)
+    }
+
+    pub fn set_vector_enabled(
+        &mut self,
+        vector: &MsiVector,
+        enabled: bool,
+    ) -> Result<(), IrqError> {
+        self.inner.set_vector_enabled(vector, enabled)
+    }
+
+    pub fn set_vector_affinity(
+        &mut self,
+        vector: &MsiVector,
+        affinity: IrqAffinity,
+    ) -> Result<(), IrqError> {
+        self.inner.set_vector_affinity(vector, affinity)
+    }
+
+    pub fn free(&mut self, allocation: MsiAllocation) -> Result<(), IrqError> {
+        if allocation.provider != self.provider {
+            return Err(IrqError::InvalidIrq);
+        }
+        self.inner.free_vectors(allocation)
+    }
+
+    pub fn typed_ref<T: Interface>(&self) -> Option<&T> {
+        self.raw_any()?.downcast_ref()
+    }
+
+    pub fn typed_mut<T: Interface>(&mut self) -> Option<&mut T> {
+        self.raw_any_mut()?.downcast_mut()
+    }
+}
+
+impl DriverGeneric for Msi {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn raw_any(&self) -> Option<&dyn core::any::Any> {
+        Some(self.inner.as_ref() as &dyn core::any::Any)
+    }
+
+    fn raw_any_mut(&mut self) -> Option<&mut dyn core::any::Any> {
+        Some(self.inner.as_mut() as &mut dyn core::any::Any)
+    }
+}
+
+impl Deref for Msi {
+    type Target = dyn Interface;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref()
+    }
+}
+
+impl DerefMut for Msi {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, vec::Vec};
+    use core::cell::RefCell;
+
+    extern crate alloc;
+
+    use irq_framework::{HwIrq, IrqDomainId, IrqError, IrqId};
+    use rdif_base::DriverGeneric;
+
+    use crate::{
+        Interface, Msi, MsiAllocation, MsiDeviceId, MsiEventId, MsiMessage, MsiProviderId,
+        MsiRequest, MsiVector, MsiVectorIndex,
+    };
+
+    struct MockProvider {
+        freed: RefCell<Vec<MsiAllocation>>,
+    }
+
+    impl DriverGeneric for MockProvider {
+        fn name(&self) -> &str {
+            "mock-msi"
+        }
+    }
+
+    impl Interface for MockProvider {
+        fn allocate_vectors(&mut self, request: &MsiRequest) -> Result<Vec<MsiVector>, IrqError> {
+            Ok((0..request.vector_count)
+                .map(|index| {
+                    MsiVector::new(
+                        MsiVectorIndex(index),
+                        MsiEventId(32 + u32::from(index)),
+                        IrqId::new(IrqDomainId(7), HwIrq(8192 + u32::from(index))),
+                    )
+                })
+                .collect())
+        }
+
+        fn compose_message(&self, vector: &MsiVector) -> Result<MsiMessage, IrqError> {
+            Ok(MsiMessage::new(0x0808_0000, vector.event.0))
+        }
+
+        fn free_vectors(&mut self, allocation: MsiAllocation) -> Result<(), IrqError> {
+            self.freed.borrow_mut().push(allocation);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn allocation_records_provider_device_and_vectors() {
+        let provider = MsiProviderId(3);
+        let mut msi = Msi::new(
+            provider,
+            MockProvider {
+                freed: RefCell::new(Vec::new()),
+            },
+        );
+
+        let allocation = msi
+            .allocate(MsiRequest::new(MsiDeviceId(0x1234), 2))
+            .unwrap();
+
+        assert_eq!(allocation.provider(), provider);
+        assert_eq!(allocation.device(), MsiDeviceId(0x1234));
+        assert_eq!(allocation.vectors().len(), 2);
+        assert_eq!(allocation.vectors()[1].index, MsiVectorIndex(1));
+        assert_eq!(
+            msi.compose_message(&allocation.vectors()[1]).unwrap(),
+            MsiMessage::new(0x0808_0000, 33)
+        );
+    }
+
+    #[test]
+    fn freeing_allocation_rejects_wrong_provider() {
+        let mut msi = Msi::new(
+            MsiProviderId(7),
+            MockProvider {
+                freed: RefCell::new(Vec::new()),
+            },
+        );
+        let wrong = MsiAllocation::new(
+            MsiProviderId(8),
+            MsiDeviceId(1),
+            Box::new([MsiVector::new(
+                MsiVectorIndex(0),
+                MsiEventId(4),
+                IrqId::new(IrqDomainId(7), HwIrq(8192)),
+            )]),
+        );
+
+        assert_eq!(msi.free(wrong), Err(IrqError::InvalidIrq));
+    }
+}

--- a/drivers/pci/pcie/Cargo.toml
+++ b/drivers/pci/pcie/Cargo.toml
@@ -17,7 +17,9 @@ bit_field = "0.10"
 bitflags = "2"
 pci_types = "0.10"
 mmio-api.workspace = true
+rdif-msi.workspace = true
 thiserror = { version = "2", default-features = false }
+tock-registers.workspace = true
 
 rdif-pcie = { workspace = true }
 
@@ -26,6 +28,10 @@ fdt-edit.workspace = true
 
 [lib]
 test = false
+
+[[test]]
+name = "msix_table"
+path = "tests/msix_table.rs"
 
 # bare-test integration test is temporarily disabled.
 # [[test]]

--- a/drivers/pci/pcie/src/lib.rs
+++ b/drivers/pci/pcie/src/lib.rs
@@ -7,12 +7,14 @@ extern crate log;
 mod bar_alloc;
 mod chip;
 pub mod err;
+mod msix;
 mod root;
 mod types;
 
 pub use bar_alloc::*;
 pub use chip::PcieGeneric;
 pub use mmio_api::{MapError, Mmio, MmioAddr, MmioOp};
+pub use msix::{MsiMessage, MsixError, MsixTableEntry, MsixTableInfo, MsixTableRegion};
 pub use rdif_pcie::{Interface as Controller, PciMem32, PciMem64, PcieController};
 pub use root::{
     EnumeratedEndpoint, PciIntxRoute, enumerate_by_controller, enumerate_by_controller_with_info,

--- a/drivers/pci/pcie/src/msix.rs
+++ b/drivers/pci/pcie/src/msix.rs
@@ -1,0 +1,170 @@
+use core::{ops::Range, ptr::NonNull};
+
+use pci_types::capability::MsixCapability;
+pub use rdif_msi::MsiMessage;
+use thiserror::Error;
+use tock_registers::{interfaces::*, register_bitfields, register_structs, registers::*};
+
+register_structs! {
+    #[allow(non_snake_case)]
+    MsixTableEntryRegs {
+        (0x00 => MessageAddressLow: ReadWrite<u32>),
+        (0x04 => MessageAddressHigh: ReadWrite<u32>),
+        (0x08 => MessageData: ReadWrite<u32>),
+        (0x0c => VectorControl: ReadWrite<u32, VectorControl::Register>),
+        (0x10 => @END),
+    }
+}
+
+register_bitfields! [
+    u32,
+    VectorControl [
+        Mask OFFSET(0) NUMBITS(1) []
+    ]
+];
+
+#[derive(Clone, Copy)]
+pub struct MsixTableEntry {
+    regs: NonNull<MsixTableEntryRegs>,
+}
+
+impl MsixTableEntry {
+    /// Creates an MSI-X table entry view over a mapped 16-byte table entry.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must point to a valid, writable MSI-X table entry and remain valid
+    /// for the lifetime of the returned view. The caller must ensure exclusive
+    /// device configuration access while programming the entry.
+    pub unsafe fn from_raw(raw: *mut u32) -> Self {
+        Self {
+            regs: NonNull::new(raw.cast()).expect("MSI-X table entry pointer must not be null"),
+        }
+    }
+
+    pub fn program_masked(&self, message: MsiMessage) {
+        self.mask();
+        self.regs().MessageAddressLow.set(message.address as u32);
+        self.regs()
+            .MessageAddressHigh
+            .set((message.address >> 32) as u32);
+        self.regs().MessageData.set(message.data);
+    }
+
+    pub fn mask(&self) {
+        self.regs().VectorControl.modify(VectorControl::Mask::SET);
+    }
+
+    pub fn unmask(&self) {
+        self.regs().VectorControl.modify(VectorControl::Mask::CLEAR);
+    }
+
+    pub fn is_masked(&self) -> bool {
+        self.regs().VectorControl.is_set(VectorControl::Mask)
+    }
+
+    fn regs(&self) -> &MsixTableEntryRegs {
+        unsafe { self.regs.as_ref() }
+    }
+}
+
+unsafe impl Send for MsixTableEntry {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MsixTableInfo {
+    pub bar: u8,
+    pub offset: usize,
+    pub entries: u16,
+    pub pba_bar: u8,
+    pub pba_offset: usize,
+}
+
+impl MsixTableInfo {
+    pub fn from_capability(capability: &MsixCapability) -> Self {
+        Self {
+            bar: capability.table_bar(),
+            offset: capability.table_offset() as usize,
+            entries: capability.table_size(),
+            pba_bar: capability.pba_bar(),
+            pba_offset: capability.pba_offset() as usize,
+        }
+    }
+
+    pub const fn byte_len(self) -> usize {
+        self.entries as usize * core::mem::size_of::<MsixTableEntryRegs>()
+    }
+
+    pub fn table_range(self, bar_range: Range<usize>) -> Result<Range<usize>, MsixError> {
+        let start = bar_range
+            .start
+            .checked_add(self.offset)
+            .ok_or(MsixError::TableOutsideBar)?;
+        let end = start
+            .checked_add(self.byte_len())
+            .ok_or(MsixError::TableOutsideBar)?;
+        if end > bar_range.end {
+            return Err(MsixError::TableOutsideBar);
+        }
+        Ok(start..end)
+    }
+}
+
+pub struct MsixTableRegion {
+    base: NonNull<u8>,
+    entries: u16,
+}
+
+unsafe impl Send for MsixTableRegion {}
+
+impl MsixTableRegion {
+    /// Creates an MSI-X table view over a mapped MSI-X table range.
+    ///
+    /// # Safety
+    ///
+    /// `base` must point to the first MSI-X table entry of a writable mapped
+    /// BAR range that contains `entries` complete table entries. The caller must
+    /// keep the mapping alive and serialize configuration-time table writes.
+    pub unsafe fn new(base: NonNull<u8>, entries: u16) -> Self {
+        Self { base, entries }
+    }
+
+    pub const fn entries(&self) -> u16 {
+        self.entries
+    }
+
+    pub fn entry(&self, index: u16) -> Result<MsixTableEntry, MsixError> {
+        if index >= self.entries {
+            return Err(MsixError::InvalidVector);
+        }
+        let offset = usize::from(index) * core::mem::size_of::<MsixTableEntryRegs>();
+        let ptr = unsafe { self.base.as_ptr().add(offset) }.cast();
+        Ok(unsafe { MsixTableEntry::from_raw(ptr) })
+    }
+
+    pub fn program_masked(&self, index: u16, message: MsiMessage) -> Result<(), MsixError> {
+        self.entry(index)?.program_masked(message);
+        Ok(())
+    }
+
+    pub fn mask(&self, index: u16) -> Result<(), MsixError> {
+        self.entry(index)?.mask();
+        Ok(())
+    }
+
+    pub fn unmask(&self, index: u16) -> Result<(), MsixError> {
+        self.entry(index)?.unmask();
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum MsixError {
+    #[error("PCI endpoint has no MSI-X capability")]
+    MissingCapability,
+    #[error("MSI-X vector index is outside the table")]
+    InvalidVector,
+    #[error("MSI-X table BAR is not a memory BAR")]
+    InvalidTableBar,
+    #[error("MSI-X table extends outside its BAR")]
+    TableOutsideBar,
+}

--- a/drivers/pci/pcie/src/types/config/endpoint.rs
+++ b/drivers/pci/pcie/src/types/config/endpoint.rs
@@ -10,6 +10,8 @@ use pci_types::{
 };
 use rdif_pcie::{ConfigAccess, SimpleBarAllocator};
 
+use crate::{MsixError, MsixTableInfo};
+
 pub struct Endpoint {
     base: super::PciHeaderBase,
     header: EndpointHeader,
@@ -78,6 +80,43 @@ impl Endpoint {
 
     pub fn capabilities(&self) -> Vec<PciCapability> {
         self.header.capabilities(self.access()).collect()
+    }
+
+    pub fn msix_capability(&self) -> Option<pci_types::capability::MsixCapability> {
+        self.capabilities().into_iter().find_map(|capability| {
+            if let PciCapability::MsiX(msix) = capability {
+                Some(msix)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn msix_table_info(&self) -> Result<MsixTableInfo, MsixError> {
+        let capability = self.msix_capability().ok_or(MsixError::MissingCapability)?;
+        let info = MsixTableInfo::from_capability(&capability);
+        let bar = self.bar_mmio(info.bar).ok_or(MsixError::InvalidTableBar)?;
+        info.table_range(bar)?;
+        Ok(info)
+    }
+
+    pub fn msix_table_range(&self) -> Result<Range<usize>, MsixError> {
+        let capability = self.msix_capability().ok_or(MsixError::MissingCapability)?;
+        let info = MsixTableInfo::from_capability(&capability);
+        let bar = self.bar_mmio(info.bar).ok_or(MsixError::InvalidTableBar)?;
+        info.table_range(bar)
+    }
+
+    pub fn set_msix_enabled(&mut self, enabled: bool) -> Result<(), MsixError> {
+        let mut capability = self.msix_capability().ok_or(MsixError::MissingCapability)?;
+        capability.set_enabled(enabled, self.access());
+        Ok(())
+    }
+
+    pub fn set_msix_function_mask(&mut self, mask: bool) -> Result<(), MsixError> {
+        let mut capability = self.msix_capability().ok_or(MsixError::MissingCapability)?;
+        capability.set_function_mask(mask, self.access());
+        Ok(())
     }
 
     pub fn interrupt_pin(&self) -> u8 {

--- a/drivers/pci/pcie/tests/msix_table.rs
+++ b/drivers/pci/pcie/tests/msix_table.rs
@@ -1,0 +1,41 @@
+use core::ptr::NonNull;
+
+use pcie::{MsiMessage, MsixError, MsixTableEntry, MsixTableInfo, MsixTableRegion};
+
+#[test]
+fn msix_table_entry_masks_before_programming_message() {
+    let mut raw = [0u32; 4];
+    let entry = unsafe { MsixTableEntry::from_raw(raw.as_mut_ptr()) };
+
+    entry.program_masked(MsiMessage::new(0xfee0_0000, 0x45));
+
+    assert_eq!(raw[0], 0xfee0_0000);
+    assert_eq!(raw[1], 0);
+    assert_eq!(raw[2], 0x45);
+    assert_eq!(raw[3] & 1, 1);
+}
+
+#[test]
+fn msix_table_region_rejects_out_of_range_vectors() {
+    let mut raw = [0u32; 4];
+    let region = unsafe { MsixTableRegion::new(NonNull::new(raw.as_mut_ptr().cast()).unwrap(), 1) };
+
+    assert_eq!(region.mask(1), Err(MsixError::InvalidVector));
+}
+
+#[test]
+fn msix_table_info_rejects_tables_outside_bar() {
+    let info = MsixTableInfo {
+        bar: 2,
+        offset: 0x80,
+        entries: 4,
+        pba_bar: 2,
+        pba_offset: 0x100,
+    };
+
+    assert_eq!(
+        info.table_range(0x1000..0x10bf),
+        Err(MsixError::TableOutsideBar)
+    );
+    assert_eq!(info.table_range(0x1000..0x10c0).unwrap(), 0x1080..0x10c0);
+}

--- a/os/arceos/modules/axfs-ng/src/block/runtime/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/block/runtime/mod.rs
@@ -12,9 +12,9 @@ pub mod queue;
 #[cfg(test)]
 pub use device::NoopDrainWake;
 pub use device::{
-    BlockCompletionMode, BlockDeviceHandle, BlockDrainWake, BlockIrqAction, BlockRuntime,
-    BlockRuntimeConfig, QueueRuntime, RdifBlockDevice, block_io_stats, map_blk_err_to_ax_err,
-    release_block_irqs_for_passthrough,
+    BlockCompletionMode, BlockDeviceHandle, BlockDrainWake, BlockIrqAction, BlockIrqSource,
+    BlockRuntime, BlockRuntimeConfig, QueueRuntime, RdifBlockDevice, block_io_stats,
+    map_blk_err_to_ax_err, release_block_irqs_for_passthrough,
 };
 #[cfg(test)]
 pub use dma::VEC_DMA_OP;

--- a/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
@@ -312,8 +312,14 @@ impl Default for BlockRuntime {
 
 pub struct RdifBlockDevice {
     name: String,
-    irq: Option<IrqId>,
+    irqs: Vec<BlockIrqSource>,
     interface: Box<dyn rdif_block::Interface>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BlockIrqSource {
+    pub source_id: usize,
+    pub irq: IrqId,
 }
 
 impl RdifBlockDevice {
@@ -322,9 +328,22 @@ impl RdifBlockDevice {
         irq: Option<IrqId>,
         interface: Box<dyn rdif_block::Interface>,
     ) -> Self {
+        Self::new_with_irqs(
+            name,
+            irq.into_iter()
+                .map(|irq| BlockIrqSource { source_id: 0, irq }),
+            interface,
+        )
+    }
+
+    pub fn new_with_irqs(
+        name: impl Into<String>,
+        irqs: impl IntoIterator<Item = BlockIrqSource>,
+        interface: Box<dyn rdif_block::Interface>,
+    ) -> Self {
         Self {
             name: name.into(),
-            irq,
+            irqs: irqs.into_iter().collect(),
             interface,
         }
     }
@@ -333,8 +352,20 @@ impl RdifBlockDevice {
         &self.name
     }
 
-    pub const fn irq(&self) -> Option<IrqId> {
-        self.irq
+    pub fn irq(&self) -> Option<IrqId> {
+        self.irq_for_source(0)
+            .or_else(|| self.irqs.first().map(|source| source.irq))
+    }
+
+    pub fn irq_for_source(&self, source_id: usize) -> Option<IrqId> {
+        self.irqs
+            .iter()
+            .find(|source| source.source_id == source_id)
+            .map(|source| source.irq)
+    }
+
+    pub fn irq_sources(&self) -> &[BlockIrqSource] {
+        &self.irqs
     }
 
     pub fn interface(&self) -> &dyn rdif_block::Interface {
@@ -361,7 +392,7 @@ impl RdifBlockDevice {
         &mut self,
         source_id: usize,
     ) -> Option<(IrqId, Box<dyn rdif_block::IrqHandler>)> {
-        let irq = self.irq?;
+        let irq = self.irq_for_source(source_id)?;
         self.interface
             .take_irq_handler(source_id)
             .map(|handler| (irq, handler))
@@ -1336,7 +1367,7 @@ fn rdif_block_runtime_config(
     drain_wake: Arc<dyn BlockDrainWake>,
 ) -> BlockRuntimeConfig {
     let mut config = BlockRuntimeConfig::new(drain_wake);
-    if block.irq().is_some() && !block.interface().irq_sources().is_empty() {
+    if !block.irq_sources().is_empty() && !block.interface().irq_sources().is_empty() {
         config.max_transfer_bytes = config.max_transfer_bytes.max(IRQ_DRIVEN_MAX_TRANSFER_BYTES);
     }
     config

--- a/os/arceos/modules/axruntime/src/fs/block.rs
+++ b/os/arceos/modules/axruntime/src/fs/block.rs
@@ -2,7 +2,7 @@ use alloc::{boxed::Box, string::String, vec::Vec};
 
 use ax_alloc::UsageKind;
 use ax_fs_ng::{
-    block::runtime::RdifBlockDevice,
+    block::runtime::{BlockIrqSource, RdifBlockDevice},
     os::{
         BlockIrqOutcome, BlockIrqRegistrar, BlockIrqRegistration, BlockTaskOps, BlockTimeProvider,
         FsPage, FsPageProvider,
@@ -173,10 +173,29 @@ fn take_rdif_block_devices() -> Vec<RdifBlockDevice> {
         .into_iter()
         .map(|block| {
             let name = String::from(block.name());
-            let irq = resolve_block_irq(block.irq_cloned());
-            RdifBlockDevice::new(name, irq, block.into_interface())
+            let irqs = resolve_block_irqs(&block);
+            RdifBlockDevice::new_with_irqs(name, irqs, block.into_interface())
         })
         .collect()
+}
+
+#[cfg(feature = "irq")]
+fn resolve_block_irqs(block: &ax_driver::block::RdifBlockDevice) -> Vec<BlockIrqSource> {
+    block
+        .irq_sources()
+        .iter()
+        .filter_map(|source| {
+            resolve_block_irq(Some(source.irq.clone())).map(|irq| BlockIrqSource {
+                source_id: source.source_id,
+                irq,
+            })
+        })
+        .collect()
+}
+
+#[cfg(not(feature = "irq"))]
+fn resolve_block_irqs(_block: &ax_driver::block::RdifBlockDevice) -> Vec<BlockIrqSource> {
+    Vec::new()
 }
 
 #[cfg(feature = "irq")]

--- a/platforms/somehal/Cargo.toml
+++ b/platforms/somehal/Cargo.toml
@@ -23,6 +23,7 @@ ax-kspin = { workspace = true }
 irq-framework = { workspace = true }
 page-table-generic = {workspace = true}
 rdif-intc.workspace = true
+rdif-msi.workspace = true
 rdrive = {workspace = true}
 someboot = {workspace = true}
 somehal-macros = {workspace = true}

--- a/platforms/somehal/src/arch/aarch64/gic/its.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/its.rs
@@ -1,0 +1,501 @@
+use alloc::{
+    alloc::{alloc_zeroed, dealloc},
+    collections::BTreeMap,
+    format,
+    vec::Vec,
+};
+use core::{
+    alloc::Layout,
+    ptr::NonNull,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use arm_gic_driver::v3::{GITS_TRANSLATER_OFFSET, Its, ItsCommand, ItsTableType};
+use ax_kspin::SpinRaw as Mutex;
+use irq_framework::{HwIrq, IrqError, IrqId};
+use rdif_msi::{
+    Interface, Msi, MsiAllocation, MsiDeviceId, MsiEventId, MsiMessage, MsiProviderId, MsiRequest,
+    MsiVector, MsiVectorIndex,
+};
+use rdrive::{DeviceId, module_driver, probe::OnProbeError, register::ProbeFdt};
+use someboot::DCacheOp;
+
+use crate::common::ioremap;
+
+pub(super) const LPI_INTID_BASE: u32 = 8192;
+const LPI_ID_BITS: u8 = 16;
+const LPI_COUNT: usize = 1 << LPI_ID_BITS;
+const LPI_PROPERTY_BYTES: usize = LPI_COUNT;
+const LPI_PENDING_BYTES_PER_RD: usize = LPI_COUNT / 8;
+const LPI_DEFAULT_PRIORITY: u8 = 0xa0;
+const COMMAND_QUEUE_ENTRIES: usize = 256;
+const MIN_DEVICE_EVENTS: u32 = 32;
+const MAX_DEVICE_ID_BITS: u8 = 16;
+const COLLECTION_ID: u16 = 0;
+const INVALID_DEVICE_ID: u64 = u64::MAX;
+
+static LPI_OWNER: Mutex<BTreeMap<u32, DeviceId>> = Mutex::new(BTreeMap::new());
+static PRIMARY_ITS: AtomicU64 = AtomicU64::new(INVALID_DEVICE_ID);
+
+module_driver!(
+    name: "GICv3 ITS",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["arm,gic-v3-its"],
+            on_probe: probe_its
+        }
+    ],
+);
+
+fn probe_its(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let (info, dev) = probe.into_parts();
+    let reg = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or_else(|| OnProbeError::other(format!("[{}] has no reg", info.node.name())))?;
+    let size = reg.size.unwrap_or((GITS_TRANSLATER_OFFSET + 8) as u64) as usize;
+    let mmio = ioremap(reg.address, size)
+        .map_err(|err| OnProbeError::other(format!("failed to map ITS: {err:?}")))?;
+    let its = unsafe { Its::new(mmio.as_ptr().into(), reg.address) };
+
+    if !its.supports_physical_lpis() {
+        return Err(OnProbeError::Unsupported(
+            "GIC ITS does not support physical LPIs",
+        ));
+    }
+
+    let gicr_phys_base = super::v3::primary_gicr_phys_base()
+        .ok_or_else(|| OnProbeError::other("GICv3 redistributor base is not available for ITS"))?;
+    let provider_id = dev.descriptor.device_id();
+    let provider = GicItsProvider::new(provider_id, its, mmio, gicr_phys_base)?;
+    PRIMARY_ITS.store(u64::from(provider_id), Ordering::Release);
+    dev.register(Msi::new(MsiProviderId(u64::from(provider_id)), provider));
+    Ok(())
+}
+
+fn with_gic<R>(
+    f: impl FnOnce(&mut arm_gic_driver::v3::Gic) -> Result<R, OnProbeError>,
+) -> Result<R, OnProbeError> {
+    let gic = rdrive::get_one::<rdif_intc::Intc>()
+        .ok_or_else(|| OnProbeError::other("GICv3 interrupt controller is not registered"))?;
+    let mut gic = gic
+        .lock()
+        .map_err(|_| OnProbeError::other("failed to lock GICv3 interrupt controller"))?;
+    let gic = gic
+        .typed_mut::<arm_gic_driver::v3::Gic>()
+        .ok_or_else(|| OnProbeError::other("primary interrupt controller is not GICv3"))?;
+    f(gic)
+}
+
+pub(super) fn set_lpi_enabled(irq: IrqId, enabled: bool) -> Result<(), IrqError> {
+    let owner = LPI_OWNER
+        .lock()
+        .get(&irq.hwirq.0)
+        .copied()
+        .or_else(|| match PRIMARY_ITS.load(Ordering::Acquire) {
+            INVALID_DEVICE_ID => None,
+            raw => Some(DeviceId::from(raw)),
+        })
+        .ok_or(IrqError::Unsupported)?;
+    let msi = rdrive::get::<Msi>(owner).map_err(|_| IrqError::Unsupported)?;
+    let mut msi = msi.try_lock().map_err(|_| IrqError::Busy)?;
+    let provider = msi
+        .typed_mut::<GicItsProvider>()
+        .ok_or(IrqError::Unsupported)?;
+    provider.set_lpi_enabled_by_intid(irq.hwirq.0, enabled)
+}
+
+struct GicItsProvider {
+    owner: DeviceId,
+    its: Its,
+    _mmio: mmio_api::MmioRaw,
+    command_queue: CommandQueue,
+    property_table: AlignedMemory,
+    _pending_tables: AlignedMemory,
+    next_lpi: u32,
+    devices: BTreeMap<u32, ItsDevice>,
+    lpis: BTreeMap<u32, LpiRoute>,
+    collection_target: u64,
+    gic_domain: irq_framework::IrqDomainId,
+    itt_entry_size: usize,
+}
+
+impl GicItsProvider {
+    fn new(
+        owner: DeviceId,
+        its: Its,
+        mmio: mmio_api::MmioRaw,
+        gicr_phys_base: u64,
+    ) -> Result<Self, OnProbeError> {
+        let gic_domain = crate::irq::domain_by_kind_fast(crate::irq::IrqDomainKind::AArch64Gic)
+            .ok_or_else(|| OnProbeError::other("AArch64 GIC IRQ domain is not registered"))?;
+        let property_table = AlignedMemory::new(LPI_PROPERTY_BYTES, 4096)
+            .ok_or_else(|| OnProbeError::other("failed to allocate LPI property table"))?;
+        property_table.fill(LPI_DEFAULT_PRIORITY);
+        property_table.clean();
+
+        let rd_count = with_gic(|gic| Ok(gic.redistributor_count().max(1)))?;
+        let pending_stride = align_up(LPI_PENDING_BYTES_PER_RD, 4096);
+        let pending_tables = AlignedMemory::new(pending_stride * rd_count, 65536)
+            .ok_or_else(|| OnProbeError::other("failed to allocate LPI pending tables"))?;
+        pending_tables.clean();
+
+        let collection_target =
+            with_gic(|gic| {
+                if !gic.supports_lpis() {
+                    return Err(OnProbeError::Unsupported(
+                        "GICv3 distributor does not support LPIs",
+                    ));
+                }
+                gic.init_lpi_tables(
+                    property_table.phys(),
+                    LPI_ID_BITS,
+                    pending_tables.phys(),
+                    pending_stride,
+                )
+                .map_err(|err| {
+                    OnProbeError::other(format!("failed to initialize GICR LPI tables: {err}"))
+                })?;
+                Ok(gic.current_collection_target(
+                    gicr_phys_base,
+                    its.uses_physical_collection_target(),
+                ))
+            })?;
+
+        its.disable();
+        let command_queue = CommandQueue::new(COMMAND_QUEUE_ENTRIES)
+            .ok_or_else(|| OnProbeError::other("failed to allocate ITS command queue"))?;
+        its.init_command_queue(command_queue.phys(), command_queue.bytes());
+
+        program_baser_table(&its, ItsTableType::Device, MAX_DEVICE_ID_BITS)?;
+        program_baser_table(&its, ItsTableType::Collection, 1)?;
+        its.enable();
+
+        let mut provider = Self {
+            owner,
+            its,
+            _mmio: mmio,
+            command_queue,
+            property_table,
+            _pending_tables: pending_tables,
+            next_lpi: LPI_INTID_BASE,
+            devices: BTreeMap::new(),
+            lpis: BTreeMap::new(),
+            collection_target,
+            gic_domain,
+            itt_entry_size: 16,
+        };
+        provider.itt_entry_size = provider.its.itt_entry_size().max(8);
+        provider
+            .send_command(ItsCommand::mapc(COLLECTION_ID, collection_target, true))
+            .map_err(|err| OnProbeError::other(format!("failed to send ITS MAPC: {err:?}")))?;
+        provider
+            .send_command(ItsCommand::sync(collection_target))
+            .map_err(|err| OnProbeError::other(format!("failed to send ITS SYNC: {err:?}")))?;
+        Ok(provider)
+    }
+
+    fn ensure_device(&mut self, device: MsiDeviceId, required_events: u32) -> Result<(), IrqError> {
+        if let Some(state) = self.devices.get(&device.0) {
+            return if required_events <= state.event_capacity {
+                Ok(())
+            } else {
+                Err(IrqError::NoMemory)
+            };
+        }
+        let event_capacity = required_events.max(MIN_DEVICE_EVENTS).next_power_of_two();
+        let itt_bytes = self.itt_entry_size * event_capacity as usize;
+        let itt = AlignedMemory::new(itt_bytes, 256).ok_or(IrqError::NoMemory)?;
+        itt.clean();
+        self.send_command(ItsCommand::mapd(device.0, itt.phys(), event_capacity, true))?;
+        self.send_command(ItsCommand::sync(self.collection_target))?;
+        self.devices.insert(
+            device.0,
+            ItsDevice {
+                _itt: itt,
+                event_capacity,
+                next_event: 0,
+            },
+        );
+        Ok(())
+    }
+
+    fn send_command(&mut self, command: ItsCommand) -> Result<(), IrqError> {
+        self.command_queue.push(&self.its, command)
+    }
+
+    fn set_lpi_enabled_by_intid(&mut self, intid: u32, enabled: bool) -> Result<(), IrqError> {
+        let route = *self.lpis.get(&intid).ok_or(IrqError::InvalidIrq)?;
+        self.set_property_enabled(intid, enabled)?;
+        self.send_command(ItsCommand::inv(route.device.0, route.event.0))?;
+        self.send_command(ItsCommand::sync(self.collection_target))
+    }
+
+    fn set_property_enabled(&self, intid: u32, enabled: bool) -> Result<(), IrqError> {
+        let offset = intid
+            .checked_sub(LPI_INTID_BASE)
+            .ok_or(IrqError::InvalidIrq)? as usize;
+        if offset >= LPI_PROPERTY_BYTES {
+            return Err(IrqError::InvalidIrq);
+        }
+        let value = LPI_DEFAULT_PRIORITY | u8::from(enabled);
+        unsafe {
+            self.property_table
+                .ptr()
+                .as_ptr()
+                .add(offset)
+                .write_volatile(value)
+        };
+        self.property_table.clean_range(offset, 1);
+        Ok(())
+    }
+}
+
+impl rdif_msi::DriverGeneric for GicItsProvider {
+    fn name(&self) -> &str {
+        "gic-v3-its"
+    }
+}
+
+impl Interface for GicItsProvider {
+    fn allocate_vectors(&mut self, request: &MsiRequest) -> Result<Vec<MsiVector>, IrqError> {
+        let count = request.vector_count;
+        if count == 0 {
+            return Err(IrqError::InvalidIrq);
+        }
+        let device = request.device;
+        let next_event = self
+            .devices
+            .get(&device.0)
+            .map(|state| state.next_event)
+            .unwrap_or(0);
+        let required_events = next_event
+            .checked_add(u32::from(count))
+            .ok_or(IrqError::NoMemory)?;
+        self.ensure_device(device, required_events)?;
+
+        let mut vectors = Vec::with_capacity(usize::from(count));
+        for index in 0..count {
+            let state = self
+                .devices
+                .get_mut(&device.0)
+                .ok_or(IrqError::InvalidIrq)?;
+            let event = MsiEventId(state.next_event);
+            state.next_event += 1;
+            let lpi = self.next_lpi;
+            self.next_lpi = self.next_lpi.checked_add(1).ok_or(IrqError::NoMemory)?;
+            self.set_property_enabled(lpi, false)?;
+            self.send_command(ItsCommand::mapti(device.0, event.0, lpi, COLLECTION_ID))?;
+            self.lpis.insert(lpi, LpiRoute { device, event });
+            LPI_OWNER.lock().insert(lpi, self.owner);
+            vectors.push(MsiVector::new(
+                MsiVectorIndex(index),
+                event,
+                IrqId::new(self.gic_domain, HwIrq(lpi)),
+            ));
+        }
+        self.send_command(ItsCommand::sync(self.collection_target))?;
+        Ok(vectors)
+    }
+
+    fn compose_message(&self, vector: &MsiVector) -> Result<MsiMessage, IrqError> {
+        Ok(MsiMessage::new(
+            self.its.translater_address(),
+            vector.event.0,
+        ))
+    }
+
+    fn set_vector_enabled(&mut self, vector: &MsiVector, enabled: bool) -> Result<(), IrqError> {
+        self.set_lpi_enabled_by_intid(vector.irq.hwirq.0, enabled)
+    }
+
+    fn set_vector_affinity(
+        &mut self,
+        _vector: &MsiVector,
+        affinity: irq_framework::IrqAffinity,
+    ) -> Result<(), IrqError> {
+        match affinity {
+            irq_framework::IrqAffinity::Any => Ok(()),
+            irq_framework::IrqAffinity::Fixed { .. } => Err(IrqError::Unsupported),
+        }
+    }
+
+    fn free_vectors(&mut self, allocation: MsiAllocation) -> Result<(), IrqError> {
+        for vector in allocation.vectors() {
+            let intid = vector.irq.hwirq.0;
+            self.set_lpi_enabled_by_intid(intid, false)?;
+            self.lpis.remove(&intid);
+            LPI_OWNER.lock().remove(&intid);
+        }
+        Ok(())
+    }
+}
+
+struct ItsDevice {
+    _itt: AlignedMemory,
+    event_capacity: u32,
+    next_event: u32,
+}
+
+#[derive(Clone, Copy)]
+struct LpiRoute {
+    device: MsiDeviceId,
+    event: MsiEventId,
+}
+
+struct CommandQueue {
+    mem: AlignedMemory,
+    entries: usize,
+    write_index: usize,
+}
+
+impl CommandQueue {
+    fn new(entries: usize) -> Option<Self> {
+        let mem = AlignedMemory::new(
+            entries.checked_mul(core::mem::size_of::<ItsCommand>())?,
+            4096,
+        )?;
+        Some(Self {
+            mem,
+            entries,
+            write_index: 0,
+        })
+    }
+
+    fn bytes(&self) -> usize {
+        self.mem.len()
+    }
+
+    fn phys(&self) -> u64 {
+        self.mem.phys()
+    }
+
+    fn push(&mut self, its: &Its, command: ItsCommand) -> Result<(), IrqError> {
+        let next = (self.write_index + 1) % self.entries;
+        let next_offset = next * core::mem::size_of::<ItsCommand>();
+        let mut retries = 0;
+        while its.creadr_offset() == next_offset {
+            retries += 1;
+            if retries > 1_000_000 {
+                return Err(IrqError::Timeout);
+            }
+            core::hint::spin_loop();
+        }
+
+        let offset = self.write_index * core::mem::size_of::<ItsCommand>();
+        unsafe {
+            self.mem
+                .ptr()
+                .as_ptr()
+                .add(offset)
+                .cast::<ItsCommand>()
+                .write_volatile(command);
+        }
+        self.mem
+            .clean_range(offset, core::mem::size_of::<ItsCommand>());
+        self.write_index = next;
+        its.write_cwriter(next_offset);
+
+        retries = 0;
+        while its.creadr_offset() != next_offset {
+            retries += 1;
+            if retries > 1_000_000 {
+                return Err(IrqError::Timeout);
+            }
+            core::hint::spin_loop();
+        }
+        Ok(())
+    }
+}
+
+struct AlignedMemory {
+    ptr: NonNull<u8>,
+    len: usize,
+    layout: Layout,
+}
+
+unsafe impl Send for AlignedMemory {}
+
+impl AlignedMemory {
+    fn new(len: usize, align: usize) -> Option<Self> {
+        let len = len.max(1);
+        let layout = Layout::from_size_align(len, align).ok()?;
+        let ptr = NonNull::new(unsafe { alloc_zeroed(layout) })?;
+        Some(Self { ptr, len, layout })
+    }
+
+    fn ptr(&self) -> NonNull<u8> {
+        self.ptr
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn phys(&self) -> u64 {
+        someboot::mem::virt_to_phys(self.ptr.as_ptr()) as u64
+    }
+
+    fn fill(&self, value: u8) {
+        unsafe { core::ptr::write_bytes(self.ptr.as_ptr(), value, self.len) };
+    }
+
+    fn clean(&self) {
+        self.clean_range(0, self.len);
+    }
+
+    fn clean_range(&self, offset: usize, len: usize) {
+        if offset >= self.len {
+            return;
+        }
+        let len = len.min(self.len - offset);
+        someboot::mem::dcache_range(
+            DCacheOp::Clean,
+            unsafe { self.ptr.as_ptr().add(offset) },
+            len,
+        );
+    }
+}
+
+impl Drop for AlignedMemory {
+    fn drop(&mut self) {
+        unsafe { dealloc(self.ptr.as_ptr(), self.layout) };
+    }
+}
+
+fn program_baser_table(
+    its: &Its,
+    table_type: ItsTableType,
+    max_entries_log2: u8,
+) -> Result<(), OnProbeError> {
+    for index in 0..8 {
+        if its.baser_type(index) != Some(table_type) {
+            continue;
+        }
+        let entry_size = its.baser_entry_size(index).max(8);
+        let entries = 1usize << usize::from(max_entries_log2);
+        let bytes = entry_size
+            .checked_mul(entries)
+            .ok_or_else(|| OnProbeError::other("ITS BASER table size overflow"))?;
+        let table = AlignedMemory::new(bytes, 4096)
+            .ok_or_else(|| OnProbeError::other("failed to allocate ITS BASER table"))?;
+        table.clean();
+        its.program_baser(
+            index,
+            Its::baser_value(table_type, table.phys(), table.len(), entry_size),
+        );
+        core::mem::forget(table);
+        return Ok(());
+    }
+    Err(OnProbeError::Unsupported(
+        "required ITS BASER table is not implemented",
+    ))
+}
+
+const fn align_up(value: usize, align: usize) -> usize {
+    (value + align - 1) & !(align - 1)
+}

--- a/platforms/somehal/src/arch/aarch64/gic/mod.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/mod.rs
@@ -3,6 +3,7 @@ use irq_framework::{IrqDomainId, IrqId};
 use rdif_intc::{Intc, Interface};
 use rdrive::Device;
 
+mod its;
 mod v2;
 mod v3;
 

--- a/platforms/somehal/src/arch/aarch64/gic/v3.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/v3.rs
@@ -1,5 +1,8 @@
 use alloc::{collections::BTreeMap, format};
-use core::cell::UnsafeCell;
+use core::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use aarch64_cpu::registers::ID_AA64PFR0_EL1;
 use arm_gic_driver::{checked_intid, v3::*};
@@ -10,6 +13,7 @@ use rdrive::{module_driver, probe::OnProbeError, register::ProbeFdt};
 use crate::common::ioremap;
 
 static CPU_IF: StaticCell<BTreeMap<usize, CpuInterfaceSlot>> = StaticCell::uninit();
+static PRIMARY_GICR_PHYS_BASE: AtomicU64 = AtomicU64::new(0);
 
 struct CpuInterfaceSlot {
     inner: UnsafeCell<Option<CpuInterface>>,
@@ -64,6 +68,7 @@ fn probe_gic(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         info.node.name()
     )))?;
     let gicr_reg = reg.next().unwrap();
+    PRIMARY_GICR_PHYS_BASE.store(gicr_reg.address, Ordering::Release);
 
     let gicd = ioremap(
         gicd_reg.address,
@@ -140,6 +145,9 @@ pub fn irq_set_enable(irq: IrqId, enable: bool) -> Result<(), crate::irq::IrqErr
         current_cpu_interface().set_irq_enable(intid, enable);
         return Ok(());
     }
+    if irq.hwirq.0 >= super::its::LPI_INTID_BASE {
+        return super::its::set_lpi_enabled(irq, enable);
+    }
 
     super::with_gic_domain::<Gic, _>(irq.domain, |gic| {
         let intid = checked_runtime_intid(irq.hwirq.0, gic.max_intid())?;
@@ -191,6 +199,13 @@ pub fn send_ipi(raw: usize, target: crate::irq::IpiTarget) {
 
 fn affinity_from_mpidr(mpidr: usize) -> Affinity {
     Affinity::from_mpidr(mpidr as u64)
+}
+
+pub(super) fn primary_gicr_phys_base() -> Option<u64> {
+    match PRIMARY_GICR_PHYS_BASE.load(Ordering::Acquire) {
+        0 => None,
+        phys => Some(phys),
+    }
 }
 
 pub fn init_cpu(cpu_idx: usize) {

--- a/test-suit/starryos/qemu-smp1/system/qemu-aarch64.toml
+++ b/test-suit/starryos/qemu-smp1/system/qemu-aarch64.toml
@@ -1,5 +1,7 @@
 args = [
     "-nographic",
+    "-machine",
+    "virt,gic-version=3,its=on",
     "-m",
     "512M",
     "-cpu",


### PR DESCRIPTION
## 问题

当前 aarch64/FDT/QEMU 路径缺少完整的 PCI MSI-X 注册链路：PCI 设备无法通过通用 MSI provider 申请向量并写入 MSI-X table，NVMe 只能走单一 legacy IRQ；同时缺少 GICv3 ITS/LPI 到现有 irq-framework 的端到端衔接。没有 MSI 控制器或路由时，也需要明确退回 legacy INTx，而不是静默伪装为 MSI-X 成功。

## 修改

- 新增 `rdif-msi` 通用能力边界，定义 typed device/event/vector ID、MSI message、allocation 和 `MsiProvider` 接口；v1 在非 aarch64 ITS 路径返回明确 unsupported。
- 为 PCI endpoint 增加 MSI-X capability 解析和 MSI-X table entry 编程，table entry 使用 `tock-registers` 表达 address/data/vector-control 字段，并固定 mask/write/unmask 顺序。
- 实现 aarch64 GICv3 ITS provider：FDT 探测 `arm,gic-v3-its`，初始化 LPI property/pending table，维护 RID/DeviceID/EventID/LPI 映射，发出 `MAPD/MAPTI/MAPC/INV/SYNC`，并用 `GITS_TRANSLATER` 生成 MSI message。
- 接入 `ax-driver` PCI MSI-X 优先路径；若找不到 MSI controller/provider 或路由不可用，返回 `Unsupported` 供上层继续 legacy INTx fallback；required 模式仍保留明确失败。
- 扩展 NVMe/block runtime 的多 IRQ source 模型，支持 IO queue 到 MSI-X vector/source 的映射；单 IRQ 设备继续保持 source 0 行为。
- 将 aarch64 Starry QEMU 配置打开 GICv3 ITS：`virt,gic-version=3,its=on`。

## 设计逻辑

- 控制面可以通过 rdrive 查找 MSI provider；硬中断路径只使用已经分配好的 `IrqId`，不做 provider lookup、IRQ 分配释放或睡眠锁操作。
- v1 只落地 aarch64 FDT/GICv3 ITS/QEMU 的 MSI-X；plain MSI、ACPI IORT 和跨架构 provider 先保留接口位置并返回显式 unsupported。
- 找不到 MSI 控制器时，PCI/NVMe probe 先把 MSI-X 分支视作 unsupported，再进入现有 legacy INTx 策略，避免破坏无 ITS 平台。

## 验证

- `cargo fmt --check`
- `git diff --check origin/dev...HEAD`
- `cargo xtask clippy --package rdif-msi --package rdif-pcie --package pcie --package arm-gic-driver --package somehal --package ax-driver --package nvme-driver --package rdif-block --package ax-fs-ng`
- `cargo test -p ax-driver --features pci pci::msi::tests`
- `cargo check -p arm-gic-driver --target aarch64-unknown-none-softfloat`
- `cargo check -p somehal --target aarch64-unknown-none-softfloat`
- `cargo test -p rdif-msi -p pcie -p irq-framework`
- `cargo xtask starry test qemu --arch aarch64 --test-case qemu-smp1/system`
