### PR TITLE
refactor(arm_vcpu): decouple OS-neutral host interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,10 +399,6 @@ name = "arm_vcpu"
 version = "0.5.15"
 dependencies = [
  "aarch64-cpu 11.2.0",
- "ax-crate-interface",
- "ax-errno 0.6.1",
- "ax-percpu",
- "axvm-types",
  "log",
  "numeric-enum-macro",
  "spin",

--- a/docs/docs/components/crates/arm-vcpu.md
+++ b/docs/docs/components/crates/arm-vcpu.md
@@ -2,308 +2,131 @@
 
 > 路径：`virtualization/arm_vcpu`
 > 类型：库 crate
-> 分层：组件层 / 可复用基础组件
-> 版本：`0.2.2`
-> 文档依据：`Cargo.toml`、`src/lib.rs`、`src/vcpu.rs`、`src/pcpu.rs`、`src/exception.rs`、`src/exception.S`、`src/exception_utils.rs`、`src/context_frame.rs`、`src/smc.rs`
+> 分层：组件层 / AArch64 虚拟化 core
 
-`arm_vcpu` 是 Axvisor/`axvm` 体系在 AArch64 EL2 上的 vCPU 实现。它负责 guest 与 host 上下文切换、EL2 异常向量接管、常见 VM exit 的解析与上报，以及与宿主侧中断注入接口的对接，是 ARM 虚拟化主线中最接近硬件执行边界的组件之一。
+`arm_vcpu` 是 OS-neutral 的 AArch64 vCPU core。它只负责 EL2 entry/exit、guest trap frame、guest EL1/EL0 系统寄存器保存恢复、trap decode、Stage-2 寄存器语义和少量可在 vCPU core 内部完成的架构处理。它不直接绑定 AxVM、ArceOS、`ax-percpu`、`ax-crate-interface`、`axvm-types` 或 `ax-errno`。
+
+AxVM/ArceOS 接入层位于 `virtualization/axvm/src/arch/aarch64`：该 adapter 把 `ArmVcpu<H>` / `ArmPerCpu` 包装成 `axvm_types::VmArchVcpuOps` / `VmArchPerCpuOps`，并负责 `ArmVmExit`、`ArmVcpuError` 和 AxVM 类型之间的转换。
 
 ## 架构设计
+
 ### 设计定位
-`arm_vcpu` 的职责边界十分清晰：
 
-- 它实现的是 **AArch64 架构相关的 vCPU 运行时**，不是通用虚拟机资源管理层。
-- 它向上实现 `axvm-types::VmArchVcpuOps` / `VmArchPerCpuOps`，由 `axvm` 统一调度和管理。
-- 它向下直接操作 EL2 寄存器、异常向量、`VTTBR_EL2`、`VTCR_EL2`、`HCR_EL2` 等硬件虚拟化设施。
-- 它不负责完整的 vGIC 设备模型，也不负责 VM 生命周期编排；这些分别由 `arm_vgic`、`axvm` 和更上层 hypervisor 逻辑承担。
-
-因此，`arm_vcpu` 的核心价值是“把 ARM EL2 虚拟化原语整理成一个可被上层 hypervisor 驱动的 vCPU 对象”。
+- `arm_vcpu` 本体是 AArch64 硬件虚拟化执行 core，不是 VM 生命周期管理层。
+- 宿主 OS/VMM 策略通过 `ArmHostOps` 注入，包括虚拟中断注入、pending host IRQ 获取和 current-EL host IRQ 处理。
+- AxVM 仍是本仓库默认 consumer，但 AxVM trait glue 已经属于 AxVM adapter，而不是 `arm_vcpu` core。
+- `arm_vgic` 仍独立维护虚拟 GIC 设备模型，本 crate 不把 vGIC 泛化进 vCPU core。
 
 ### 模块结构
-- `src/lib.rs`：crate 入口与对外导出。导出 `Aarch64VCpu`、`Aarch64PerCpu`、配置类型和 `TrapFrame` 别名。
-- `src/vcpu.rs`：vCPU 主体实现，包含 `Aarch64VCpu`、`VmArchVcpuOps` 实现、`run()` 主线、VM 寄存器恢复与 VM exit 分析。
-- `src/pcpu.rs`：per-CPU 虚拟化状态入口，负责 EL2 向量基址、HCR 与 IRQ 处理回调等本地状态。
-- `src/exception.rs`：异常入口 glue，定义 `vmexit_trampoline`、同步异常处理和 VM exit 归类。
-- `src/exception.S`：真正的 EL2 异常向量与保存/恢复汇编路径。
-- `src/exception_utils.rs`：ESR/FAR/HPFAR 等寄存器解析、GPA 合成与若干汇编辅助宏。
-- `src/context_frame.rs`：`TrapFrame` / `Aarch64ContextFrame` 与 `GuestSystemRegisters` 的存取实现。
-- `src/smc.rs`：SMC 指令封装，用于必要的 SMC 转发路径。
 
-### 1.3 关键数据结构与对象
-- `Aarch64VCpu<H>`：核心 vCPU 对象，内部最关键的字段顺序是：
+- `src/lib.rs`：crate 入口与对外导出，导出 `ArmVcpu`、`ArmPerCpu`、`ArmHostOps`、`ArmVmExit`、`ArmNestedPagingConfig`、`ArmVcpuError` 和兼容别名。
+- `src/types.rs`：OS-neutral 地址、访问宽度、nested paging config、VM exit 和错误类型。
+- `src/host.rs`：`ArmHostOps` trait，以及 current-EL IRQ handler 的泛型到汇编入口桥接。
+- `src/vcpu.rs`：vCPU 主体、EL2 guest entry/exit 协议、guest 系统寄存器恢复、VM exit 分类。
+- `src/pcpu.rs`：per-CPU EL2 本地状态，负责异常向量安装和硬件虚拟化开关。
+- `src/exception.rs` / `src/exception.S`：EL2 异常入口、VM exit trampoline、同步异常和系统寄存器 trap 处理。
+- `src/context_frame.rs`：guest `TrapFrame` 和 `GuestSystemRegisters` 保存恢复。
+- `src/exception_utils.rs`：ESR/FAR/HPFAR 解析与辅助汇编宏。
+- `src/smc.rs`：SMC 调用封装。
+
+### 关键数据结构
+
+- `ArmVcpu<H: ArmHostOps>`：核心 vCPU 对象。前两个字段布局由汇编使用：
   - `ctx: TrapFrame`
-  - `host_stack_top: u64`
-  - `guest_system_regs: GuestSystemRegisters`
+  - `host: HostRuntimeContext { stack_top, sp_el0 }`
+- `TrapFrame` / `Aarch64ContextFrame`：保存 guest GPR、guest `SP_EL0`、`ELR_EL2` 和 `SPSR_EL2`。
+- `GuestSystemRegisters`：保存 guest EL1/EL0 系统寄存器和 EL2 虚拟化控制寄存器，不再保存 `SP_EL0`。
+- `ArmPerCpu`：每 CPU 的 EL2 本地状态。
+- `ArmVmExit`：vCPU core 输出的 OS-neutral VM exit。
+- `ArmNestedPagingConfig`：由外层 VMM 选择的 Stage-2 配置，使用纯整数表达。
 
-  这一布局和 `exception.S` 的汇编路径强绑定，不能随意调整。
+兼容别名仍保留：
 
-- `TrapFrame` / `Aarch64ContextFrame`：保存 guest 的 GPR、`sp_el0`、`elr`、`spsr`。
-- `GuestSystemRegisters`：保存 guest 视角的 EL1/EL0 系统寄存器，以及 `hcr_el2`、`vttbr_el2`、`vtcr_el2`、`vmpidr_el2` 等虚拟化关键状态。
-- `Aarch64PerCpu<H>`：每 CPU 的 EL2 本地状态对象。
-- `VmCpuRegisters`：面向更高层打包的寄存器聚合类型，适合描述“可迁移/可保存的一组 vCPU 状态”。
+```rust
+pub type Aarch64VCpu<H> = ArmVcpu<H>;
+pub type Aarch64PerCpu = ArmPerCpu;
+pub type Aarch64VCpuCreateConfig = ArmVcpuCreateConfig;
+pub type Aarch64VCpuSetupConfig = ArmVcpuSetupConfig;
+```
 
-### 1.4 vCPU 创建、运行与退出主线
-`arm_vcpu` 的主线非常明确：
+### Entry/Exit 主线
 
 ```mermaid
 flowchart TD
-    A["Aarch64VCpu::new"] --> B["setup / init_hv"]
-    B --> C["set_entry / set_nested_page_table_root"]
+    A["ArmVcpu::new"] --> B["setup / init_hv"]
+    B --> C["set_entry / set_nested_page_table"]
     C --> D["run()"]
-    D --> E["save_host_sp_el0"]
-    E --> F["restore_vm_system_regs"]
-    F --> G["run_guest() -> context_vm_entry -> eret"]
-    G --> H["Guest 执行直到 EL2 trap"]
-    H --> I["exception.S 保存 Guest 上下文"]
-    I --> J["vmexit_trampoline 切回宿主栈"]
-    J --> K["vmexit_handler"]
-    K --> L["生成 VmExit"]
+    D --> E["restore guest system registers"]
+    E --> F["run_guest() saves host stack_top and host SP_EL0"]
+    F --> G["context_vm_entry -> eret"]
+    G --> H["guest runs until EL2 trap"]
+    H --> I["exception.S saves guest TrapFrame"]
+    I --> J["vmexit_trampoline restores host SP_EL0 and host stack"]
+    J --> K["vmexit_handler stores guest system registers"]
+    K --> L["return ArmVmExit"]
 ```
 
-可以进一步拆解为：
+Guest `SP_EL0` 只保存在 `TrapFrame.sp_el0`。Host `SP_EL0` 保存在私有 `HostRuntimeContext.sp_el0`，并在 `vmexit_trampoline` 返回 Rust 前恢复，避免 host Rust 或 IRQ handler 运行时仍持有 guest `SP_EL0`。
 
-1. `new()` 只构造基本上下文，并把 DTB 地址写到约定参数寄存器。
-2. `setup()` / `init_hv()` 配置 `SPSR_EL2`、`VTCR_EL2`、`HCR_EL2`、`VMPIDR_EL2` 等虚拟化状态。
-3. `set_entry()` 设置 guest 入口 PC；`set_nested_page_table_root()` 设置 `VTTBR_EL2`。
-4. `run()` 先保存宿主 `SP_EL0`，再恢复 guest 系统寄存器，最后通过裸函数 `run_guest()` 跳到 `context_vm_entry` 并 `eret` 进入 guest。
-5. guest 一旦因同步异常、IRQ 或系统寄存器 trap 回到 EL2，`exception.S` 会把 guest 上下文写回 `Aarch64VCpu`，再通过 `vmexit_trampoline` 切回宿主栈。
-6. `vmexit_handler()` 把硬件 trap 归类为 `VmExit`，再交给上层 hypervisor 处理。
+### AxVM Adapter
 
-### 1.5 VM exit 与内建处理逻辑
-`arm_vcpu` 的 VM exit 路径不是简单“返回异常号”，而是做了明确分类：
+`virtualization/axvm/src/arch/aarch64` 定义：
 
-- `Synchronous`：走数据 abort、系统寄存器访问、HVC、SMC/PSCI 等细分解析。
-- `Irq`：上报为 `ExternalInterrupt`，由 HAL 侧决定 vector 语义。
-- 对 `SysRegRead` / `SysRegWrite`，还会额外执行内建的系统寄存器处理逻辑，例如 `ICC_SGI1R_EL1` 生成 `SendIPI` 类型退出。
+- `AxvmArmHostOps`：把 `ArmHostOps` 连接到 AxVM 当前的 GIC host 能力。
+- `AxvmArmVcpu(ArmVcpu<AxvmArmHostOps>)`：实现 `VmArchVcpuOps`。
+- `AxvmArmPerCpu(ArmPerCpu)`：实现 `VmArchPerCpuOps`。
 
-这说明 `arm_vcpu` 不只是“上下文切换器”，它同时承担了第一层 trap 解码器的角色。
+该层负责：
 
-### 1.6 与 GIC、中断与 Stage-2 页表的关系
-- `set_nested_page_table_root()` 实际写的是 `VTTBR_EL2`，即 Stage-2 根页表基址。
-- `VTCR_EL2` 会根据 `ID_AA64MMFR0_EL1` 探测宿主支持的物理地址位宽和页表层级。
-- `HCR_EL2` 会根据配置选择虚拟中断或物理直通中断行为。
-- 真正的“虚拟中断注入”并不在本 crate 内建模，而是调用 `axvisor_api::arch::hardware_inject_virtual_interrupt()`，与 `arm_vgic` 形成分工。
-
-## 核心功能
-### 功能概览
-- 创建和维护 AArch64 guest 上下文。
-- 在 EL2 和 guest EL1/EL0 之间切换执行。
-- 解析常见 VM exit 并生成 `VmExit`。
-- 提供 per-CPU EL2 本地状态管理。
-- 与宿主 HAL / 中断注入接口协作完成 IRQ 路径。
-
-### 使用场景
-- `Aarch64VCpu::new()` / `setup()`：构造 vCPU 并初始化 EL2 虚拟化寄存器。
-- `set_entry()`：设置 guest 起始执行地址。
-- `set_nested_page_table_root()`：安装 Stage-2 根页表。
-- `run()`：进入 guest 并等待下一次 VM exit。
-- `inject_interrupt()`：调用宿主侧架构 API 注入虚拟中断。
-
-### 使用方式
-`arm_vcpu` 并不直接作为最终业务 API 暴露给用户，典型用法是由 `axvm` 绑定为当前架构的 `ArchVCpu`：
-
-```rust
-let mut vcpu = Aarch64VCpu::<MyHal>::new(vcpu_id, dtb_addr)?;
-vcpu.setup(config)?;
-vcpu.set_entry(entry_gpa);
-vcpu.set_nested_page_table_root(stage2_root);
-let exit = vcpu.run()?;
-```
+- `ArmVmExit` 到 `axvm_types::VmExit` 的转换。
+- `ArmVcpuError` 到 `ax_errno::AxError` 的转换。
+- `axvm_types::NestedPagingConfig`、`GuestPhysAddr` 等 AxVM 类型到 `arm_vcpu` OS-neutral 类型的转换。
 
 ## 依赖关系
+
 ```mermaid
 graph LR
-    axvm_types["axvm-types"] --> current["arm_vcpu"]
-    axvisor_api["axvisor_api"] --> current
-    axaddrspace["axaddrspace"] --> current
-    ax-percpu["ax-percpu"] --> current
-    aarch64_cpu["aarch64-cpu"] --> current
+    aarch64_cpu["aarch64-cpu"] --> current["arm_vcpu"]
+    numeric_enum["numeric-enum-macro"] --> current
+    spin["spin"] --> current
+    log["log"] --> current
 
-    current --> axvm["axvm"]
-    axvm --> axvisor["axvisor"]
+    current --> axvm_adapter["axvm aarch64 adapter"]
+    axvm_adapter --> axvm["axvm"]
 ```
 
 ### 直接依赖
-- `axvm-types`：提供架构无关 vCPU trait 契约和 VM exit 类型。
-- `axvisor_api`：提供宿主中断注入和架构辅助接口。
-- `axaddrspace`：服务 guest 地址空间 / Stage-2 相关协作。
-- `ax-percpu`：保存 EL2 本地状态。
-- `aarch64-cpu`、`numeric-enum-macro`：寄存器访问和异常编码辅助。
 
-### 主要消费者
-- `axvm`：在 aarch64 路径下把 `Aarch64VCpu` 绑定为实际架构实现。
+- `aarch64-cpu`：系统寄存器访问。
+- `numeric-enum-macro`：异常类型编码。
+- `spin`：轻量同步原语。
+- `log`：日志宏。
 
-### 3.3 间接消费者
-- `axvisor`：通过 `axvm` 复用这套 ARM vCPU 栈。
-- 宿主侧 IRQ 处理路径：经 `axvisor_api` 与 `ax-hal::irq` 协作。
+`arm_vcpu` 不直接依赖 `axvm-types`、`ax-errno`、`ax-percpu` 或 `ax-crate-interface`。
 
 ## 开发指南
-### 接入方式
-```toml
-[dependencies]
-arm_vcpu = { workspace = true }
-```
 
-但更常见的接入方式是通过 `axvm` 间接使用，而不是直接把它作为最终上层接口。
-
-### 4.2 开发与修改约束
-1. `Aarch64VCpu` 的字段顺序和 `exception.S` 强绑定，任何布局修改都必须同步修改汇编偏移。
-2. `run_guest()`、`context_vm_entry`、`vmexit_trampoline` 构成一个完整的汇编- Rust 协议，不能单边修改。
-3. 修改 `HCR_EL2`、`VTCR_EL2`、`VTTBR_EL2` 路径时，要同步验证 passthrough interrupt/timer 等配置位语义。
-4. 系统寄存器 trap 的新增处理应先区分：这是 vCPU 内建逻辑，还是应属于 `arm_vgic` / 上层 VMM。
-
-### 4.3 关键开发建议
-- 对纯寄存器编码和位域解析，优先写成 Rust 辅助函数，减少把语义埋进汇编。
-- 对 VM exit 类型的新增分支，最好显式在文档里标明对应 ESR/ISS 语义。
-- 对可迁移状态，若未来要做真正快照，应明确 `VmCpuRegisters` 与“运行期寄存器同步”的边界。
+1. `ArmVcpu` 的 `TrapFrame` 和 `HostRuntimeContext` 字段顺序与 `exception.S`、`vmexit_trampoline` 强绑定，修改布局必须同步更新布局常量和测试。
+2. `run_guest()`、`context_vm_entry`、`vmexit_trampoline` 是一组完整汇编/Rust 协议，不能单边改动。
+3. 新增宿主能力时，优先判断它是否真的是 vCPU core 必需能力；不是的话应放在 AxVM adapter 或更上层 VMM。
+4. 新增 VM exit variant 后，需要同步更新 AxVM AArch64 adapter 的转换测试。
+5. 系统寄存器 trap 的新增处理应先区分：属于 vCPU core 可自处理的架构语义，还是属于 `arm_vgic` 或上层 VMM 设备模型。
 
 ## 测试
-### 测试覆盖
-该 crate 主要依赖交叉编译和集成运行验证，几乎没有独立单元测试。
 
-### 单元测试
-- `VTCR_EL2` 参数计算与寄存器位域解析。
-- ESR/ISS/FAR/HPFAR 到 GPA 的合成逻辑。
-- `VmExit` 映射中那些可纯 Rust 验证的分支。
+重点覆盖：
 
-### 集成测试
-- Axvisor + aarch64 场景下的 guest 启动、HVC、SMC、MMIO、IPI 与定时器路径。
-- `passthrough_interrupt` / `passthrough_timer` 打开和关闭时的差异行为。
-- vCPU 布局与汇编保存/恢复路径的一致性。
+- `arm_vcpu` manifest 不引入 AxVM/ArceOS runtime 依赖。
+- `TrapFrame` 大小和 host runtime context 偏移。
+- OS-neutral API、错误类型和 VM exit 类型。
+- AxVM AArch64 adapter 的 error/exit 转换。
+- AArch64 Axvisor smoke 场景下的 guest entry/exit、IRQ、HVC/SMC、MMIO 和 IPI 路径。
 
-### 覆盖率
-- 对 `arm_vcpu`，重点不是普通函数覆盖率，而是“Guest 进入与退出主线覆盖率”。
-- 至少要覆盖 guest run、同步异常退出、IRQ 退出和系统寄存器 trap 四条路径。
-- 涉及字段布局、异常向量或宿主栈切换的改动，应视为最高风险改动。
+常用验证：
 
-## 跨项目定位
-### ArceOS
-`arm_vcpu` 并不是普通 ArceOS 内核模块，而是基于 ArceOS 宿主能力构建 hypervisor 栈时的架构级组件。它通过 `axvisor_api` 与宿主侧 HAL 相连，但不直接承担一般内核功能。
-
-### StarryOS
-当前仓库中 StarryOS 并未直接依赖 `arm_vcpu`。因此它在 StarryOS 中更多是潜在可复用的虚拟化组件，而不是现有主线依赖。
-
-### Axvisor
-`arm_vcpu` 是 Axvisor 在 AArch64 路径上的关键执行引擎之一。`axvm` 负责统一 VM 资源模型，而真正把 guest 扔进 EL1 执行、再把 VM exit 带回宿主的，就是 `arm_vcpu`。
-# `arm_vcpu` 技术文档
-
-> 路径：`virtualization/arm_vcpu`
-> 类型：库 crate
-> 分层：组件层 / 可复用基础组件
-> 版本：`0.2.2`
-> 文档依据：当前仓库源码、`Cargo.toml` 与 `virtualization/arm_vcpu/README.md`
-
-`arm_vcpu` 的核心定位是：Aarch64 VCPU implementation for Arceos Hypervisor
-
-## 架构设计
-- 目录角色：可复用基础组件
-- crate 形态：库 crate
-- 工作区位置：根工作区
-- feature 视角：该 crate 没有显式声明额外 Cargo feature，功能边界主要由模块本身决定。
-- 关键数据结构：可直接观察到的关键数据结构/对象包括 `Aarch64ContextFrame`、`GuestSystemRegisters`、`Aarch64PerCpu`、`VmCpuRegisters`、`Aarch64VCpu`、`Aarch64VCpuCreateConfig`、`TrapKind`、`TrapSource`、`TrapFrame`、`CreateConfig` 等（另有 5 个关键类型/对象）。
-- 设计重心：该 crate 多数是寄存器级或设备级薄封装，复杂度集中在 MMIO 语义、安全假设和被上层平台/驱动整合的方式。
-
-### 模块结构
-- `context_frame`：内部子模块
-- `exception_utils`：内部子模块
-- `exception`：内部子模块
-- `pcpu`：内部子模块
-- `smc`：内部子模块
-- `vcpu`：vCPU 状态机与虚拟 CPU 调度逻辑
-
-### 核心机制
-- vCPU 状态机、VM exit 处理与宿主调度桥接
-- 二级页表或 EPT/NPT 映射维护
-
-## 核心功能
-- 功能定位：Aarch64 VCPU implementation for Arceos Hypervisor
-- 对外接口：从源码可见的主要公开入口包括 `has_hardware_support`、`exception_pc`、`set_exception_pc`、`set_argument`、`set_gpr`、`gpr`、`reset`、`store`、`Aarch64ContextFrame`、`GuestSystemRegisters` 等（另有 6 个公开入口）。
-- 典型使用场景：提供寄存器定义、MMIO 访问或设备级操作原语，通常被平台 crate、驱动聚合层或更高层子系统进一步封装。
-- 关键调用链示例：按当前源码布局，常见入口/初始化链可概括为 `handle_system_register()` -> `new()`。
-
-## 依赖关系
-```mermaid
-graph LR
-    current["arm_vcpu"]
-    current --> axaddrspace["axaddrspace"]
-    current --> axdevice_base["axdevice_base"]
-    current --> ax_errno["ax-errno"]
-    current --> axvm_types["axvm-types"]
-    current --> axvisor_api["axvisor_api"]
-    current --> ax-percpu["ax-percpu"]
-    axvm["axvm"] --> current
+```bash
+cargo fmt
+cargo xtask clippy --package arm_vcpu
+cargo xtask clippy --package axvm
+cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case smoke
 ```
-
-### 直接依赖
-- `axaddrspace`
-- `axdevice_base`
-- `ax-errno`
-- `axvm-types`
-- `axvisor_api`
-- `ax-percpu`
-
-### 间接依赖
-- `axvisor_api_proc`
-- `axvmconfig`
-- `crate_interface`
-- `kernel_guard`
-- `ax-lazyinit`
-- `memory_addr`
-- `ax-memory-set`
-- `ax-page-table-entry`
-- `ax-page-table-multiarch`
-- `percpu_macros`
-
-### 3.3 被依赖情况
-- `axvm`
-
-### 被依赖情况
-- `axvisor`
-
-### 外部依赖
-- `aarch64-cpu`
-- `log`
-- `numeric-enum-macro`
-- `spin`
-
-## 开发指南
-### 接入方式
-```toml
-[dependencies]
-arm_vcpu = { workspace = true }
-
-# 如果在仓库外独立验证，也可以显式绑定本地路径：
-# arm_vcpu = { path = "virtualization/arm_vcpu" }
-```
-
-### 初始化
-1. 先明确该设备/寄存器组件的调用上下文，是被平台 crate 直接使用还是被驱动聚合层再次封装。
-2. 修改寄存器位域、初始化顺序或中断相关逻辑时，应同步检查 `unsafe` 访问、访问宽度和副作用语义。
-3. 尽量通过最小平台集成路径验证真实设备行为，而不要只依赖静态接口检查。
-
-### API 使用
-- 优先关注函数入口：`has_hardware_support`、`exception_pc`、`set_exception_pc`、`set_argument`、`set_gpr`、`gpr`、`reset`、`store` 等（另有 20 项）。
-- 上下文/对象类型通常从 `Aarch64ContextFrame`、`GuestSystemRegisters`、`Aarch64PerCpu`、`VmCpuRegisters`、`Aarch64VCpu`、`Aarch64VCpuCreateConfig` 等（另有 1 项） 等结构开始。
-
-## 测试
-### 测试覆盖
-- 当前 crate 目录中未发现显式 `tests/`/`benches/`/`fuzz/` 入口，更可能依赖上层系统集成测试或跨 crate 回归。
-
-### 单元测试
-- 建议覆盖寄存器位域、设备状态转换、边界参数和 `unsafe` 访问前提。
-
-### 集成测试
-- 建议结合最小平台或驱动集成路径验证真实设备行为，重点检查初始化、中断和收发等主线。
-
-### 覆盖率
-- 覆盖率建议：寄存器访问辅助函数和关键状态机保持高覆盖；真实硬件语义以集成验证补齐。
-
-## 跨项目定位
-### ArceOS
-当前未检测到 ArceOS 工程本体对 `arm_vcpu` 的显式本地依赖，若参与该系统，通常经外部工具链、配置或更底层生态间接体现。
-
-### StarryOS
-当前未检测到 StarryOS 工程本体对 `arm_vcpu` 的显式本地依赖，若参与该系统，通常经外部工具链、配置或更底层生态间接体现。
-
-### Axvisor
-`arm_vcpu` 主要通过 `axvisor` 等上层 crate 被 Axvisor 间接复用，通常处于更底层的公共依赖层。

--- a/virtualization/arm_vcpu/Cargo.toml
+++ b/virtualization/arm_vcpu/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
   "DeBin Luo <luodeb@outlook.com>",
   "周睿 <zrufo747@outlook.com>",
 ]
-description = "Aarch64 VCPU implementation for Arceos Hypervisor"
+description = "OS-neutral AArch64 vCPU core"
 repository = "https://github.com/arceos-hypervisor/arm_vcpu"
 categories = ["embedded", "no-std"]
 keywords = ["hypervisor", "aarch64", "vcpu"]
@@ -24,8 +24,3 @@ spin = { workspace = true }
 
 aarch64-cpu = "11.0"
 numeric-enum-macro = "0.2"
-
-ax-errno = { workspace = true }
-ax-percpu = { workspace = true, features = ["arm-el2"] }
-ax-crate-interface = { workspace = true }
-axvm-types = { workspace = true }

--- a/virtualization/arm_vcpu/README.md
+++ b/virtualization/arm_vcpu/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">arm_vcpu</h1>
 
-<p align="center">AArch64 vCPU implementation for ArceOS Hypervisor</p>
+<p align="center">OS-neutral AArch64 vCPU core</p>
 
 <div align="center">
 
@@ -15,7 +15,7 @@ English | [中文](README_CN.md)
 
 # Introduction
 
-`arm_vcpu` provides AArch64 vCPU implementation for ArceOS Hypervisor. It is maintained as part of the TGOSKits component set and is intended for Rust projects that integrate with ArceOS, AxVisor, or related low-level systems software.
+`arm_vcpu` provides an OS-neutral AArch64 vCPU core. It owns EL2 guest entry/exit, guest register state, trap decode, and hardware virtualization register semantics. Host OS and VMM policy is supplied through `ArmHostOps`; AxVM integration lives in `virtualization/axvm/src/arch/aarch64`.
 
 ## Quick Start
 
@@ -37,11 +37,11 @@ cd virtualization/arm_vcpu
 # Format code
 cargo fmt --all
 
-# Run clippy
-cargo clippy --all-targets --all-features
+# Run the workspace clippy flow
+cargo xtask clippy --package arm_vcpu
 
-# Run tests
-cargo test --all-features
+# Run host-runnable contract tests
+cargo test -p arm_vcpu --test dependency_contract_test
 
 # Build documentation
 cargo doc --no-deps
@@ -52,10 +52,24 @@ cargo doc --no-deps
 ### Example
 
 ```rust
-use arm_vcpu as _;
+use arm_vcpu::{ArmHostOps, ArmVcpu, ArmVcpuCreateConfig, ArmVcpuResult};
 
-fn main() {
-    // Integrate `arm_vcpu` into your project here.
+struct MyHost;
+
+impl ArmHostOps for MyHost {
+    fn inject_virtual_interrupt(_vector: u8) -> ArmVcpuResult {
+        Ok(())
+    }
+
+    fn fetch_pending_host_irq() -> Option<usize> {
+        None
+    }
+
+    fn handle_current_host_irq() {}
+}
+
+fn build_vcpu() -> ArmVcpuResult<ArmVcpu<MyHost>> {
+    ArmVcpu::<MyHost>::new(0, 0, ArmVcpuCreateConfig::default())
 }
 ```
 

--- a/virtualization/arm_vcpu/README_CN.md
+++ b/virtualization/arm_vcpu/README_CN.md
@@ -1,6 +1,6 @@
 <h1 align="center">arm_vcpu</h1>
 
-<p align="center">AArch64 vCPU implementation for ArceOS Hypervisor</p>
+<p align="center">OS-neutral AArch64 vCPU core</p>
 
 <div align="center">
 
@@ -15,7 +15,7 @@
 
 # 介绍
 
-`arm_vcpu` 提供了 AArch64 vCPU implementation for ArceOS Hypervisor。它是 TGOSKits 组件集合的一部分，可用于集成 ArceOS、AxVisor 及相关底层系统软件的 Rust 项目。
+`arm_vcpu` 提供 OS-neutral 的 AArch64 vCPU core。它负责 EL2 guest entry/exit、guest register state、trap decode 和硬件虚拟化寄存器语义。宿主 OS/VMM 策略通过 `ArmHostOps` 提供；AxVM 接入层位于 `virtualization/axvm/src/arch/aarch64`。
 
 ## 快速开始
 
@@ -37,11 +37,11 @@ cd virtualization/arm_vcpu
 # 代码格式化
 cargo fmt --all
 
-# 运行 clippy
-cargo clippy --all-targets --all-features
+# 运行工作区 clippy 流程
+cargo xtask clippy --package arm_vcpu
 
-# 运行测试
-cargo test --all-features
+# 运行可在 host 上执行的 contract 测试
+cargo test -p arm_vcpu --test dependency_contract_test
 
 # 生成文档
 cargo doc --no-deps
@@ -52,10 +52,24 @@ cargo doc --no-deps
 ### 示例
 
 ```rust
-use arm_vcpu as _;
+use arm_vcpu::{ArmHostOps, ArmVcpu, ArmVcpuCreateConfig, ArmVcpuResult};
 
-fn main() {
-    // 在这里将 `arm_vcpu` 集成到你的项目中。
+struct MyHost;
+
+impl ArmHostOps for MyHost {
+    fn inject_virtual_interrupt(_vector: u8) -> ArmVcpuResult {
+        Ok(())
+    }
+
+    fn fetch_pending_host_irq() -> Option<usize> {
+        None
+    }
+
+    fn handle_current_host_irq() {}
+}
+
+fn build_vcpu() -> ArmVcpuResult<ArmVcpu<MyHost>> {
+    ArmVcpu::<MyHost>::new(0, 0, ArmVcpuCreateConfig::default())
 }
 ```
 

--- a/virtualization/arm_vcpu/src/context_frame.rs
+++ b/virtualization/arm_vcpu/src/context_frame.rs
@@ -176,7 +176,6 @@ pub struct GuestSystemRegisters {
     pub vmpidr_el2: u64,
 
     // 64bit EL1/EL0 register
-    pub sp_el0: u64,
     sp_el1: u64,
     elr_el1: u64,
     spsr_el1: u32,
@@ -251,7 +250,6 @@ impl GuestSystemRegisters {
             // MRS!("self.vpidr_el2, VPIDR_EL2, "x");
             asm!("mrs {0}, VMPIDR_EL2", out(reg) self.vmpidr_el2);
 
-            asm!("mrs {0}, SP_EL0", out(reg) self.sp_el0);
             asm!("mrs {0}, SP_EL1", out(reg) self.sp_el1);
             asm!("mrs {0}, ELR_EL1", out(reg) self.elr_el1);
             asm!("mrs {0:x}, SPSR_EL1", out(reg) self.spsr_el1);
@@ -311,9 +309,7 @@ impl GuestSystemRegisters {
             asm!("msr CNTV_CVAL_EL0, {0}", in(reg) timer.cntv_cval_el0);
             asm!("msr CNTP_CTL_EL0, {0:x}", in(reg) timer.cntp_ctl_el0);
             asm!("msr CNTV_CTL_EL0, {0:x}", in(reg) timer.cntv_ctl_el0);
-            // The restoration of SP_EL0 is done in `exception_return_el2`,
-            // which move the value from `self.ctx.sp_el0` to `SP_EL0`.
-            // asm!("msr SP_EL0, {0}", in(reg) self.sp_el0);
+            // Guest SP_EL0 is part of TrapFrame and is restored by `exception_return_el2`.
             asm!("msr SP_EL1, {0}", in(reg) self.sp_el1);
             asm!("msr ELR_EL1, {0}", in(reg) self.elr_el1);
             asm!("msr SPSR_EL1, {0:x}", in(reg) self.spsr_el1);

--- a/virtualization/arm_vcpu/src/exception.S
+++ b/virtualization/arm_vcpu/src/exception.S
@@ -1,9 +1,9 @@
 .macro SAVE_REGS_FROM_EL1
-    # Curretly `sp` points to the address of `Aarch64VCpu.host_stack_top`.
-    sub     sp, sp, 34 * 8
-    # Curretly `sp` points to the base address of `Aarch64VCpu.ctx`, which stores guest's `TrapFrame`.
+    # Currently `sp` points to the address of `ArmVcpu.host.stack_top`.
+    sub     sp, sp, {trap_frame_size}
+    # Currently `sp` points to the base address of `ArmVcpu.ctx`, which stores guest's `TrapFrame`.
 
-    # Save general purpose registers into `Aarch64VCpu.ctx`
+    # Save general purpose registers into `ArmVcpu.ctx`
     stp     x0, x1, [sp]
     stp     x2, x3, [sp, 2 * 8]
     stp     x4, x5, [sp, 4 * 8]
@@ -23,7 +23,7 @@
     mrs     x9, sp_el0
     stp     x30, x9, [sp, 30 * 8]
 
-    # Save `elr_el2` and `spsr_el2` into `Aarch64VCpu.ctx`
+    # Save `elr_el2` and `spsr_el2` into `ArmVcpu.ctx`
     mrs     x10, elr_el2
     mrs     x11, spsr_el2
     stp     x10, x11, [sp, 32 * 8]
@@ -52,9 +52,9 @@
     ldp     x4, x5, [sp, 4 * 8]
     ldp     x2, x3, [sp, 2 * 8]
     ldp     x0, x1, [sp]
-    # Curretly `sp` points to the base address of `Aarch64VCpu.ctx`
-    add     sp, sp, 34 * 8
-     # Curretly `x0` points to the address of `Aarch64VCpu.host_stack_top`.
+    # Currently `sp` points to the base address of `ArmVcpu.ctx`.
+    add     sp, sp, {trap_frame_size}
+     # Currently `x0` points to the address of `ArmVcpu.host.stack_top`.
 .endm
 
 
@@ -131,10 +131,10 @@ exception_vector_base_vcpu:
 
 .global context_vm_entry
 context_vm_entry:
-    # Curretly `x0` points to the address of `Aarch64VCpu.host_stack_top`.
+    # Currently `x0` points to the address of `ArmVcpu.host.stack_top`.
     mov     sp, x0
-    sub     sp, sp, 34 * 8
-    # Curretly `sp` points to the base address of `Aarch64VCpu.ctx`, which stores guest's `TrapFrame`.
+    sub     sp, sp, {trap_frame_size}
+    # Currently `sp` points to the base address of `ArmVcpu.ctx`, which stores guest's `TrapFrame`.
 .Lexception_return_el2:
     RESTORE_REGS_INTO_EL1
     eret

--- a/virtualization/arm_vcpu/src/exception.rs
+++ b/virtualization/arm_vcpu/src/exception.rs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 use aarch64_cpu::registers::{ESR_EL2, HCR_EL2, Readable, SCTLR_EL1, VTCR_EL2, VTTBR_EL2};
-use ax_errno::{AxError, AxResult};
-use axvm_types::{AccessWidth, GuestPhysAddr, SysRegAddr, VmExit};
 use log::error;
 
 use crate::{
+    ArmAccessWidth, ArmGuestPhysAddr, ArmSysRegAddr, ArmVcpuError, ArmVcpuResult, ArmVmExit,
     TrapFrame,
     exception_utils::{
         exception_class, exception_class_value, exception_data_abort_access_is_write,
@@ -59,6 +58,7 @@ core::arch::global_asm!(
     include_str!("exception.S"),
     exception_sync = const EXCEPTION_SYNC,
     exception_irq = const EXCEPTION_IRQ,
+    trap_frame_size = const crate::ARM_VCPU_TRAP_FRAME_SIZE,
 );
 
 /// Handles synchronous exceptions that occur during the execution of a guest VM.
@@ -74,7 +74,7 @@ core::arch::global_asm!(
 ///
 /// # Returns
 ///
-/// An `AxResult` containing an `VmExit` indicating the reason for the VM exit.
+/// An [`ArmVcpuResult`] containing an [`ArmVmExit`] indicating the reason for the VM exit.
 /// This could be due to a hypervisor call (`Hypercall`) or other reasons such as data aborts.
 ///
 /// # Panics
@@ -82,7 +82,7 @@ core::arch::global_asm!(
 /// If an unhandled exception class is encountered, the function will panic, outputting
 /// details about the exception including the instruction pointer, faulting address, exception
 /// syndrome register (ESR), and system control registers.
-pub fn handle_exception_sync(ctx: &mut TrapFrame) -> AxResult<VmExit> {
+pub fn handle_exception_sync(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
     match exception_class() {
         Some(ESR_EL2::EC::Value::DataAbortLowerEL) => {
             let elr = ctx.exception_pc();
@@ -106,7 +106,7 @@ pub fn handle_exception_sync(ctx: &mut TrapFrame) -> AxResult<VmExit> {
             // And arm64 hcall implementation uses `x0` to specify the hcall number.
             // For more details on the hypervisor call (HVC) mechanism and the use of general-purpose registers,
             // refer to the [Linux Kernel documentation on KVM ARM hypervisor ABI](https://github.com/torvalds/linux/blob/master/Documentation/virt/kvm/arm/hyp-abi.rst).
-            Ok(VmExit::Hypercall {
+            Ok(ArmVmExit::Hypercall {
                 nr: ctx.gpr[0],
                 args: [
                     ctx.gpr[1], ctx.gpr[2], ctx.gpr[3], ctx.gpr[4], ctx.gpr[5], ctx.gpr[6],
@@ -138,7 +138,7 @@ pub fn handle_exception_sync(ctx: &mut TrapFrame) -> AxResult<VmExit> {
     }
 }
 
-fn handle_data_abort(context_frame: &mut TrapFrame) -> AxResult<VmExit> {
+fn handle_data_abort(context_frame: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
     let addr = exception_fault_addr()?;
     let access_width = exception_data_abort_access_width();
     let is_write = exception_data_abort_access_is_write();
@@ -153,15 +153,8 @@ fn handle_data_abort(context_frame: &mut TrapFrame) -> AxResult<VmExit> {
         exception_esr(),
     );
 
-    let width = match AccessWidth::try_from(access_width) {
-        Ok(access_width) => access_width,
-        Err(_) => return Err(AxError::InvalidInput),
-    };
-
-    let reg_width = match AccessWidth::try_from(reg_width) {
-        Ok(reg_width) => reg_width,
-        Err(_) => return Err(AxError::InvalidInput),
-    };
+    let width = ArmAccessWidth::try_from(access_width)?;
+    let reg_width = ArmAccessWidth::try_from(reg_width)?;
 
     if !exception_data_abort_handleable() {
         panic!(
@@ -173,20 +166,20 @@ fn handle_data_abort(context_frame: &mut TrapFrame) -> AxResult<VmExit> {
 
     if !exception_data_abort_is_translate_fault() {
         if exception_data_abort_is_permission_fault() {
-            return Err(AxError::Unsupported);
+            return Err(ArmVcpuError::Unsupported);
         } else {
             panic!("Core data abort is not translate fault {:#x}", addr,);
         }
     }
 
     if is_write {
-        return Ok(VmExit::MmioWrite {
+        return Ok(ArmVmExit::MmioWrite {
             addr,
             width,
             data: context_frame.gpr(reg) as u64,
         });
     }
-    Ok(VmExit::MmioRead {
+    Ok(ArmVmExit::MmioRead {
         addr,
         width,
         reg,
@@ -204,9 +197,9 @@ fn handle_data_abort(context_frame: &mut TrapFrame) -> AxResult<VmExit> {
 /// * `context_frame` - A mutable reference to the trap frame containing the CPU state.
 ///
 /// # Returns
-/// * `AxResult<VmExit>` - An `AxResult` containing an `VmExit` indicating
+/// * [`ArmVcpuResult<ArmVmExit>`] - The VM-exit reason or a typed vCPU error.
 ///   whether the operation was a read or write and the relevant details.
-fn handle_system_register(context_frame: &mut TrapFrame) -> AxResult<VmExit> {
+fn handle_system_register(context_frame: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
     let iss = ESR_EL2.read(ESR_EL2::ISS);
 
     let addr = exception_sysreg_addr(iss.try_into().unwrap());
@@ -216,13 +209,13 @@ fn handle_system_register(context_frame: &mut TrapFrame) -> AxResult<VmExit> {
     let reg = exception_sysreg_gpr(iss) as usize;
     context_frame.set_exception_pc(val);
     if write {
-        return Ok(VmExit::SysRegWrite {
-            addr: SysRegAddr::new(addr),
+        return Ok(ArmVmExit::SysRegWrite {
+            addr: ArmSysRegAddr::new(addr),
             value: context_frame.gpr(reg) as u64,
         });
     }
-    Ok(VmExit::SysRegRead {
-        addr: SysRegAddr::new(addr),
+    Ok(ArmVmExit::SysRegRead {
+        addr: ArmSysRegAddr::new(addr),
         reg,
     })
 }
@@ -234,7 +227,7 @@ fn handle_system_register(context_frame: &mut TrapFrame) -> AxResult<VmExit> {
 /// calling convention is used) is a psci call. This function handles them all.
 ///
 /// Returns `None` if the HVC is not a psci call.
-fn handle_psci_call(ctx: &mut TrapFrame) -> Option<AxResult<VmExit>> {
+fn handle_psci_call(ctx: &mut TrapFrame) -> Option<ArmVcpuResult<ArmVmExit>> {
     const PSCI_FN_RANGE_32: core::ops::RangeInclusive<u64> = 0x8400_0000..=0x8400_001F;
     const PSCI_FN_RANGE_64: core::ops::RangeInclusive<u64> = 0xC400_0000..=0xC400_001F;
 
@@ -257,13 +250,13 @@ fn handle_psci_call(ctx: &mut TrapFrame) -> Option<AxResult<VmExit>> {
     };
 
     match fn_offset {
-        Some(PSCI_FN_CPU_OFF) => Some(Ok(VmExit::CpuDown { _state: ctx.gpr[1] })),
-        Some(PSCI_FN_CPU_ON) => Some(Ok(VmExit::CpuUp {
+        Some(PSCI_FN_CPU_OFF) => Some(Ok(ArmVmExit::CpuDown { state: ctx.gpr[1] })),
+        Some(PSCI_FN_CPU_ON) => Some(Ok(ArmVmExit::CpuUp {
             target_cpu: ctx.gpr[1],
-            entry_point: GuestPhysAddr::from(ctx.gpr[2] as usize),
+            entry_point: ArmGuestPhysAddr::from_usize(ctx.gpr[2] as usize),
             arg: ctx.gpr[3],
         })),
-        Some(PSCI_FN_SYSTEM_OFF) => Some(Ok(VmExit::SystemDown)),
+        Some(PSCI_FN_SYSTEM_OFF) => Some(Ok(ArmVmExit::SystemDown)),
         // We just forward these request to the ATF directly.
         Some(PSCI_FN_VERSION..PSCI_FN_END) => None,
         _ => None,
@@ -274,7 +267,7 @@ fn handle_psci_call(ctx: &mut TrapFrame) -> Option<AxResult<VmExit>> {
 ///
 /// This function will judge if the SMC call is a PSCI call, if so, it will handle it as a PSCI call.
 /// Otherwise, it will forward the SMC call to the ATF directly.
-fn handle_smc64_exception(ctx: &mut TrapFrame) -> AxResult<VmExit> {
+fn handle_smc64_exception(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
     // Is this a psci call?
     if let Some(result) = handle_psci_call(ctx) {
         result
@@ -283,7 +276,7 @@ fn handle_smc64_exception(ctx: &mut TrapFrame) -> AxResult<VmExit> {
         // The args are from lower EL, so it is safe to call the ATF.
         (ctx.gpr[0], ctx.gpr[1], ctx.gpr[2], ctx.gpr[3]) =
             unsafe { crate::smc::smc_call(ctx.gpr[0], ctx.gpr[1], ctx.gpr[2], ctx.gpr[3]) };
-        Ok(VmExit::Nothing)
+        Ok(ArmVmExit::Nothing)
     }
 }
 
@@ -294,7 +287,7 @@ fn handle_smc64_exception(ctx: &mut TrapFrame) -> AxResult<VmExit> {
 fn current_el_irq_handler(_tf: &mut TrapFrame) {
     // TODO: consider if returning VmExit::ExternalInterrupt (or another enum variant) is
     // better than directly calling the handler here.
-    crate::host::handle_irq()
+    crate::host::handle_current_host_irq()
 }
 
 /// Handles synchronous exceptions that occur from the current exception level.
@@ -323,9 +316,10 @@ fn current_el_sync_handler(tf: &mut TrapFrame) {
 /// 1. **Restore Previous Host Stack pointor:**
 ///     - The guest context frame is aleady saved by `SAVE_REGS_FROM_EL1` macro in exception.S.
 ///       This function firstly adjusts the `sp` to skip the exception frame
-///       (adding `34 * 8` to the stack pointer) according to the memory layout of `Aarch64VCpu` struct,
-///       which makes current `sp` point to the address of `host_stack_top`.
-///       The host stack top value is restored by `ldr`.
+///       according to the memory layout of [`crate::ArmVcpu`], which makes current `sp`
+///       point to the address of `host.stack_top`.
+///       The saved host `SP_EL0` is restored before any host Rust runs again, then
+///       the host stack top value is restored by `ldr`.
 ///
 /// 2. **Restore Host Context:**
 ///     - The `restore_regs_from_stack!()` macro is invoked to restore the host function context
@@ -334,8 +328,8 @@ fn current_el_sync_handler(tf: &mut TrapFrame) {
 ///
 /// 3. **Restore Host Control Flow:**
 ///     - The `ret` instruction is used to return control to the host context after
-///       the guest context has been saved in `Aarch64VCpu` struct and the host context restored.
-///       Finally the control flow is returned back to `Aarch64VCpu.run()` in [vcpu.rs].
+///       the guest context has been saved in `ArmVcpu` and the host context restored.
+///       Finally the control flow is returned back to `ArmVcpu::run()` in [vcpu.rs].
 ///
 /// # Notes
 ///
@@ -353,13 +347,17 @@ fn current_el_sync_handler(tf: &mut TrapFrame) {
 #[unsafe(no_mangle)]
 unsafe extern "C" fn vmexit_trampoline() -> ! {
     core::arch::naked_asm!(
-        // Curretly `sp` points to the base address of `Aarch64VCpu.ctx`, which stores guest's `TrapFrame`.
-        "add x9, sp, 34 * 8", // Skip the exception frame.
-        // Currently `x9` points to `&Aarch64VCpu.host_stack_top`, see `run_guest()` in vcpu.rs.
-        "ldr x10, [x9]", // Get `host_stack_top` value from `&Aarch64VCpu.host_stack_top`.
+        // Currently `sp` points to the base address of `ArmVcpu.ctx`, which stores guest's `TrapFrame`.
+        "add x9, sp, {host_stack_top_offset}", // Skip the exception frame.
+        // Currently `x9` points to `&ArmVcpu.host.stack_top`, see `run_guest()` in vcpu.rs.
+        "ldr x11, [x9, {host_sp_el0_delta}]", // Restore host SP_EL0 before host Rust resumes.
+        "msr sp_el0, x11",
+        "ldr x10, [x9]", // Get `host_stack_top` value from `&ArmVcpu.host.stack_top`.
         "mov sp, x10",   // Set `sp` as the host stack top.
         restore_regs_from_stack!(), // Restore host function context frame.
-        "ret", /* Control flow is handed back to Aarch64VCpu.run(), simulating the normal return of the `run_guest` function. */
+        "ret", /* Control flow is handed back to ArmVcpu::run(), simulating the normal return of the `run_guest` function. */
+        host_stack_top_offset = const crate::ARM_VCPU_HOST_STACK_TOP_OFFSET,
+        host_sp_el0_delta = const crate::ARM_VCPU_HOST_SP_EL0_OFFSET - crate::ARM_VCPU_HOST_STACK_TOP_OFFSET,
     )
 }
 

--- a/virtualization/arm_vcpu/src/exception_utils.rs
+++ b/virtualization/arm_vcpu/src/exception_utils.rs
@@ -1,6 +1,6 @@
 use aarch64_cpu::registers::*;
-use ax_errno::{AxResult, ax_err};
-use axvm_types::GuestPhysAddr;
+
+use crate::{ArmGuestPhysAddr, ArmVcpuError, ArmVcpuResult};
 
 /// Retrieves the Exception Syndrome Register (ESR) value from EL2.
 ///
@@ -83,11 +83,11 @@ macro_rules! arm_at {
 /// * `far` - The Fault Address Register value that needs to be translated.
 ///
 /// # Returns
-/// * `AxResult<usize>` - The translated HPFAR value, or an error if translation fails.
+/// * [`ArmVcpuResult<usize>`] - The translated HPFAR value, or an error if translation fails.
 ///
 /// # Errors
 /// Returns a `BadState` error if the translation is aborted (indicated by the `F` bit in `PAR_EL1`).
-fn translate_far_to_hpfar(far: usize) -> AxResult<usize> {
+fn translate_far_to_hpfar(far: usize) -> ArmVcpuResult<usize> {
     // We have
     // 	PAR[PA_Shift - 1 : 12] = PA[PA_Shift - 1 : 12]
     // 	HPFAR[PA_Shift - 9 : 4]  = FIPA[PA_Shift - 1 : 12]
@@ -102,7 +102,7 @@ fn translate_far_to_hpfar(far: usize) -> AxResult<usize> {
     let tmp = PAR_EL1.get();
     PAR_EL1.set(par);
     if (tmp & PAR_EL1::F::TranslationAborted.value) != 0 {
-        ax_err!(BadState, "PAR_EL1::F::TranslationAborted value")
+        Err(ArmVcpuError::BadState)
     } else {
         Ok(par_to_far(tmp) as usize)
     }
@@ -124,9 +124,9 @@ fn translate_far_to_hpfar(far: usize) -> AxResult<usize> {
 /// `FAR_EL2` with the page number from `HPFAR_EL2`.
 ///
 /// # Returns
-/// * `AxResult<GuestPhysAddr>` - The guest physical address that caused the exception, wrapped in an `AxResult`.
+/// * [`ArmVcpuResult<ArmGuestPhysAddr>`] - The guest physical address that caused the exception.
 #[inline(always)]
-pub fn exception_fault_addr() -> AxResult<GuestPhysAddr> {
+pub fn exception_fault_addr() -> ArmVcpuResult<ArmGuestPhysAddr> {
     let far = FAR_EL2.get() as usize;
     let hpfar =
         if (exception_esr() & ESR_ELx_S1PTW) == 0 && exception_data_abort_is_permission_fault() {
@@ -134,7 +134,7 @@ pub fn exception_fault_addr() -> AxResult<GuestPhysAddr> {
         } else {
             exception_hpfar()
         };
-    Ok(GuestPhysAddr::from((far & 0xfff) | (hpfar << 8)))
+    Ok(ArmGuestPhysAddr::from_usize((far & 0xfff) | (hpfar << 8)))
 }
 
 /// Determines the instruction length based on the ESR_EL2 register.
@@ -270,7 +270,7 @@ pub fn exception_data_abort_access_is_sign_ext() -> bool {
 ///
 /// This macro should be used in conjunction with `restore_regs_from_stack!` to ensure that
 /// the saved registers are properly restored when needed,
-/// and the control flow can be returned to `Aarch64VCpu.run()` in `vcpu.rs` happily.
+/// and the control flow can be returned to `ArmVcpu::run()` in `vcpu.rs` happily.
 macro_rules! save_regs_to_stack {
     () => {
         "
@@ -292,7 +292,7 @@ macro_rules! save_regs_to_stack {
 /// ## Note
 ///
 /// This macro is called in `return_run_guest()` in exception.rs,
-/// it should only be used after `save_regs_to_stack!` to correctly restore the control flow of `Aarch64VCpu.run()`.
+/// it should only be used after `save_regs_to_stack!` to correctly restore the control flow of `ArmVcpu::run()`.
 macro_rules! restore_regs_from_stack {
     () => {
         "

--- a/virtualization/arm_vcpu/src/host.rs
+++ b/virtualization/arm_vcpu/src/host.rs
@@ -1,30 +1,79 @@
-//! Host callbacks required by AArch64 vCPU implementation.
+//! Host callbacks required by the OS-neutral AArch64 vCPU core.
 
-/// Host architecture operations required by AArch64 virtualization code.
-#[ax_crate_interface::def_interface]
-pub trait ArmVcpuHostIf {
-    /// Inject a virtual interrupt through host GIC state.
-    fn hardware_inject_virtual_interrupt(vector: u8);
+use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
-    /// Handle or report a pending host IRQ.
-    ///
-    /// Some hosts acknowledge and dispatch the IRQ in this callback and return
-    /// a placeholder vector to notify the vCPU loop that an external interrupt
-    /// happened.
-    fn fetch_irq() -> usize;
+use crate::ArmVcpuResult;
+
+/// Host operations required by AArch64 virtualization code.
+///
+/// The vCPU core calls these static methods at architecture boundaries where
+/// the embedding OS or VMM owns the policy: virtual interrupt injection,
+/// physical interrupt reporting, and current-EL interrupt dispatch.
+pub trait ArmHostOps {
+    /// Inject a virtual interrupt through host interrupt-controller state.
+    fn inject_virtual_interrupt(vector: u8) -> ArmVcpuResult;
+
+    /// Report a pending host IRQ after a lower-EL IRQ VM exit.
+    fn fetch_pending_host_irq() -> Option<usize>;
 
     /// Dispatch a host IRQ taken while running at the current exception level.
-    fn handle_irq();
+    fn handle_current_host_irq();
 }
 
-pub(crate) fn hardware_inject_virtual_interrupt(vector: u8) {
-    ax_crate_interface::call_interface!(ArmVcpuHostIf::hardware_inject_virtual_interrupt(vector));
+static CURRENT_EL_IRQ_HANDLER: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+static CURRENT_EL_IRQ_HANDLER_USERS: AtomicUsize = AtomicUsize::new(0);
+
+fn current_el_irq_handler_for<H: ArmHostOps>() {
+    H::handle_current_host_irq();
 }
 
-pub(crate) fn fetch_irq() -> usize {
-    ax_crate_interface::call_interface!(ArmVcpuHostIf::fetch_irq())
+/// Installs the current-EL IRQ handler used by the EL2 exception vector.
+///
+/// This is intentionally a process-wide hook: an `arm_vcpu` instance is generic
+/// over the embedding host, but the assembly vector entered from current EL does
+/// not carry that generic type. The VMM installs the hook when enabling EL2
+/// virtualization on a CPU.
+pub(crate) fn install_current_el_irq_handler<H: ArmHostOps>() {
+    let handler = current_el_irq_handler_for::<H> as *mut ();
+    match CURRENT_EL_IRQ_HANDLER.compare_exchange(
+        core::ptr::null_mut(),
+        handler,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    ) {
+        Ok(_) => {}
+        Err(existing) if existing == handler => {}
+        Err(_) => panic!("arm_vcpu current-EL IRQ handler was installed by another host type"),
+    }
+
+    CURRENT_EL_IRQ_HANDLER_USERS.fetch_add(1, Ordering::AcqRel);
 }
 
-pub(crate) fn handle_irq() {
-    ax_crate_interface::call_interface!(ArmVcpuHostIf::handle_irq());
+pub(crate) fn clear_current_el_irq_handler() {
+    loop {
+        let users = CURRENT_EL_IRQ_HANDLER_USERS.load(Ordering::Acquire);
+        if users == 0 {
+            panic!("arm_vcpu current-EL IRQ handler was not installed");
+        }
+
+        if CURRENT_EL_IRQ_HANDLER_USERS
+            .compare_exchange(users, users - 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            if users == 1 {
+                CURRENT_EL_IRQ_HANDLER.store(core::ptr::null_mut(), Ordering::Release);
+            }
+            break;
+        }
+    }
+}
+
+pub(crate) fn handle_current_host_irq() {
+    let handler = CURRENT_EL_IRQ_HANDLER.load(Ordering::Acquire);
+    if handler.is_null() {
+        panic!("arm_vcpu current-EL IRQ handler is not installed");
+    }
+
+    let handler: fn() = unsafe { core::mem::transmute(handler) };
+    handler();
 }

--- a/virtualization/arm_vcpu/src/lib.rs
+++ b/virtualization/arm_vcpu/src/lib.rs
@@ -26,15 +26,32 @@ mod exception;
 pub mod host;
 mod pcpu;
 mod smc;
+mod types;
 mod vcpu;
 
 pub use self::{
-    pcpu::Aarch64PerCpu,
-    vcpu::{Aarch64VCpu, Aarch64VCpuCreateConfig, Aarch64VCpuSetupConfig},
+    host::ArmHostOps,
+    pcpu::ArmPerCpu,
+    types::{
+        ArmAccessWidth, ArmGuestPhysAddr, ArmNestedPagingConfig, ArmSysRegAddr, ArmVcpuError,
+        ArmVcpuResult, ArmVmExit,
+    },
+    vcpu::{
+        ARM_VCPU_HOST_SP_EL0_OFFSET, ARM_VCPU_HOST_STACK_TOP_OFFSET, ARM_VCPU_TRAP_FRAME_SIZE,
+        ArmVcpu, ArmVcpuCreateConfig, ArmVcpuSetupConfig,
+    },
 };
 
 /// context frame for aarch64
 pub type TrapFrame = context_frame::Aarch64ContextFrame;
+/// Compatibility alias for existing AArch64 users.
+pub type Aarch64VCpu<H> = ArmVcpu<H>;
+/// Compatibility alias for existing AArch64 users.
+pub type Aarch64PerCpu = ArmPerCpu;
+/// Compatibility alias for existing AArch64 users.
+pub type Aarch64VCpuCreateConfig = ArmVcpuCreateConfig;
+/// Compatibility alias for existing AArch64 users.
+pub type Aarch64VCpuSetupConfig = ArmVcpuSetupConfig;
 
 /// Returns the maximum guest page table levels supported by the hardware.
 ///

--- a/virtualization/arm_vcpu/src/pcpu.rs
+++ b/virtualization/arm_vcpu/src/pcpu.rs
@@ -15,13 +15,13 @@
 use core::mem;
 
 use aarch64_cpu::registers::*;
-use ax_errno::AxResult;
-use axvm_types::VmArchPerCpuOps;
 
-/// Per-CPU data. A pointer to this struct is loaded into TP when a CPU starts. This structure
+use crate::{ArmHostOps, ArmVcpuResult};
+
+/// Per-CPU AArch64 virtualization state.
 #[repr(C)]
 #[repr(align(4096))]
-pub struct Aarch64PerCpu {
+pub struct ArmPerCpu {
     /// per cpu id
     pub cpu_id: usize,
     /// The original value of `VBAR_EL2` (exception vector base) before enabling
@@ -33,19 +33,22 @@ unsafe extern "C" {
     fn exception_vector_base_vcpu();
 }
 
-impl VmArchPerCpuOps for Aarch64PerCpu {
-    fn new(cpu_id: usize) -> AxResult<Self> {
+impl ArmPerCpu {
+    /// Creates per-CPU virtualization state.
+    pub fn new(cpu_id: usize) -> ArmVcpuResult<Self> {
         Ok(Self {
             cpu_id,
             original_vbar_el2: 0,
         })
     }
 
-    fn is_enabled(&self) -> bool {
+    /// Returns whether AArch64 virtualization is enabled on the current CPU.
+    pub fn is_enabled(&self) -> bool {
         HCR_EL2.is_set(HCR_EL2::VM)
     }
 
-    fn hardware_enable(&mut self) -> AxResult {
+    /// Enables AArch64 virtualization on the current CPU.
+    pub fn hardware_enable<H: ArmHostOps>(&mut self) -> ArmVcpuResult {
         // First we save origin `exception_vector_base`.
         // Safety:
         // Todo: take care of `preemption`
@@ -58,6 +61,8 @@ impl VmArchPerCpuOps for Aarch64PerCpu {
         HCR_EL2.modify(
             HCR_EL2::VM::Enable + HCR_EL2::RW::EL1IsAarch64 + HCR_EL2::TSC::EnableTrapEl1SmcToEl2,
         );
+
+        crate::host::install_current_el_irq_handler::<H>();
 
         // Note that `ICH_HCR_EL2` is not the same as `HCR_EL2`.
         //
@@ -75,21 +80,25 @@ impl VmArchPerCpuOps for Aarch64PerCpu {
         Ok(())
     }
 
-    fn hardware_disable(&mut self) -> AxResult {
+    /// Disables AArch64 virtualization on the current CPU.
+    pub fn hardware_disable(&mut self) -> ArmVcpuResult {
         // Reset `VBAR_EL2` into previous value.
         // Safety:
         // Todo: take care of `preemption`
         VBAR_EL2.set(mem::take(&mut self.original_vbar_el2));
 
         HCR_EL2.set(HCR_EL2::VM::Disable.into());
+        crate::host::clear_current_el_irq_handler();
         Ok(())
     }
 
-    fn max_guest_page_table_levels(&self) -> usize {
+    /// Returns the maximum guest page table levels supported by this CPU.
+    pub fn max_guest_page_table_levels(&self) -> usize {
         crate::vcpu::max_gpt_level(crate::vcpu::pa_bits())
     }
 
-    fn guest_phys_addr_bits(&self) -> usize {
+    /// Returns the guest physical address width supported by this CPU.
+    pub fn guest_phys_addr_bits(&self) -> usize {
         crate::vcpu::pa_bits()
     }
 }

--- a/virtualization/arm_vcpu/src/types.rs
+++ b/virtualization/arm_vcpu/src/types.rs
@@ -1,0 +1,276 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::fmt::{Debug, Formatter, LowerHex, UpperHex};
+
+/// Result type returned by the OS-neutral AArch64 vCPU core.
+pub type ArmVcpuResult<T = ()> = Result<T, ArmVcpuError>;
+
+/// Errors produced by the OS-neutral AArch64 vCPU core.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArmVcpuError {
+    /// A caller supplied an invalid argument or unsupported hardware encoding.
+    InvalidInput,
+    /// The requested operation is not supported by this CPU or this vCPU core.
+    Unsupported,
+    /// Hardware or software state is inconsistent with the requested transition.
+    BadState,
+}
+
+/// Guest physical address.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ArmGuestPhysAddr(usize);
+
+impl ArmGuestPhysAddr {
+    /// Creates a guest physical address from a raw `usize`.
+    pub const fn from_usize(addr: usize) -> Self {
+        Self(addr)
+    }
+
+    /// Returns the raw address value.
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
+}
+
+impl From<usize> for ArmGuestPhysAddr {
+    fn from(value: usize) -> Self {
+        Self::from_usize(value)
+    }
+}
+
+impl From<ArmGuestPhysAddr> for usize {
+    fn from(value: ArmGuestPhysAddr) -> Self {
+        value.as_usize()
+    }
+}
+
+impl Debug for ArmGuestPhysAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "GPA({:#x})", self.0)
+    }
+}
+
+impl LowerHex for ArmGuestPhysAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#x}", self.0)
+    }
+}
+
+impl UpperHex for ArmGuestPhysAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#X}", self.0)
+    }
+}
+
+/// AArch64 system-register address encoding used by trapped MRS/MSR exits.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ArmSysRegAddr(usize);
+
+impl ArmSysRegAddr {
+    /// Creates a system-register address from the ISS-derived encoding.
+    pub const fn new(addr: usize) -> Self {
+        Self(addr)
+    }
+
+    /// Returns the raw register address encoding.
+    pub const fn addr(self) -> usize {
+        self.0
+    }
+}
+
+impl From<usize> for ArmSysRegAddr {
+    fn from(value: usize) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<ArmSysRegAddr> for usize {
+    fn from(value: ArmSysRegAddr) -> Self {
+        value.addr()
+    }
+}
+
+impl Debug for ArmSysRegAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ArmSysRegAddr({:#x})", self.0)
+    }
+}
+
+impl LowerHex for ArmSysRegAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#x}", self.0)
+    }
+}
+
+impl UpperHex for ArmSysRegAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#X}", self.0)
+    }
+}
+
+/// Width of a trapped guest memory access.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum ArmAccessWidth {
+    /// 8-bit access.
+    Byte,
+    /// 16-bit access.
+    Word,
+    /// 32-bit access.
+    Dword,
+    /// 64-bit access.
+    Qword,
+}
+
+impl ArmAccessWidth {
+    /// Returns this access width in bytes.
+    pub const fn size(self) -> usize {
+        match self {
+            Self::Byte => 1,
+            Self::Word => 2,
+            Self::Dword => 4,
+            Self::Qword => 8,
+        }
+    }
+}
+
+impl TryFrom<usize> for ArmAccessWidth {
+    type Error = ArmVcpuError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Byte),
+            2 => Ok(Self::Word),
+            4 => Ok(Self::Dword),
+            8 => Ok(Self::Qword),
+            _ => Err(ArmVcpuError::InvalidInput),
+        }
+    }
+}
+
+impl From<ArmAccessWidth> for usize {
+    fn from(value: ArmAccessWidth) -> Self {
+        value.size()
+    }
+}
+
+/// Stage-2 page table configuration selected by the embedding VMM.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ArmNestedPagingConfig {
+    /// Root physical address of the stage-2 page table.
+    pub root_paddr: usize,
+    /// Number of stage-2 page-table levels.
+    pub levels: usize,
+    /// Guest physical address width in bits.
+    pub gpa_bits: usize,
+    /// Hardware-specific mode value. For AArch64 this carries host PA bits when non-zero.
+    pub mode: usize,
+}
+
+impl ArmNestedPagingConfig {
+    /// Creates a nested paging configuration.
+    pub const fn new(root_paddr: usize, levels: usize, gpa_bits: usize, mode: usize) -> Self {
+        Self {
+            root_paddr,
+            levels,
+            gpa_bits,
+            mode,
+        }
+    }
+}
+
+/// VM-exit reason returned by the AArch64 vCPU core.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ArmVmExit {
+    /// A guest instruction triggered a hypercall.
+    Hypercall {
+        /// Hypercall number.
+        nr: u64,
+        /// Hypercall arguments.
+        args: [u64; 6],
+    },
+    /// The guest performed an MMIO read.
+    MmioRead {
+        /// Guest physical address being read.
+        addr: ArmGuestPhysAddr,
+        /// Access width.
+        width: ArmAccessWidth,
+        /// Destination guest register.
+        reg: usize,
+        /// Destination register width.
+        reg_width: ArmAccessWidth,
+        /// Whether the value should be sign-extended.
+        signed_ext: bool,
+    },
+    /// The guest performed an MMIO write.
+    MmioWrite {
+        /// Guest physical address being written.
+        addr: ArmGuestPhysAddr,
+        /// Access width.
+        width: ArmAccessWidth,
+        /// Value written by the guest.
+        data: u64,
+    },
+    /// The guest performed a system-register read.
+    SysRegRead {
+        /// System-register address.
+        addr: ArmSysRegAddr,
+        /// Destination guest register.
+        reg: usize,
+    },
+    /// The guest performed a system-register write.
+    SysRegWrite {
+        /// System-register address.
+        addr: ArmSysRegAddr,
+        /// Value written by the guest.
+        value: u64,
+    },
+    /// A physical host interrupt should be handled by the embedding VMM.
+    ExternalInterrupt {
+        /// Host or placeholder vector reported by the host adapter.
+        vector: u64,
+    },
+    /// A guest PSCI CPU_OFF call was trapped.
+    CpuDown {
+        /// Guest-provided target state.
+        state: u64,
+    },
+    /// A guest PSCI CPU_ON call was trapped.
+    CpuUp {
+        /// Target CPU affinity.
+        target_cpu: u64,
+        /// Guest entry point for the target CPU.
+        entry_point: ArmGuestPhysAddr,
+        /// Guest argument for the target CPU.
+        arg: u64,
+    },
+    /// The guest requested system power-off.
+    SystemDown,
+    /// The guest wrote a GIC SGI system register.
+    SendIPI {
+        /// Primary target selector.
+        target_cpu: u64,
+        /// Auxiliary target selector.
+        target_cpu_aux: u64,
+        /// Whether the SGI targets all other vCPUs.
+        send_to_all: bool,
+        /// Whether the SGI targets the current vCPU.
+        send_to_self: bool,
+        /// SGI interrupt ID.
+        vector: u64,
+    },
+    /// The vCPU handled the event internally.
+    Nothing,
+}

--- a/virtualization/arm_vcpu/src/vcpu.rs
+++ b/virtualization/arm_vcpu/src/vcpu.rs
@@ -12,29 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::marker::PhantomData;
+
 use aarch64_cpu::registers::*;
-use ax_errno::AxResult;
-use axvm_types::{GuestPhysAddr, NestedPagingConfig, SysRegAddr, VmArchVcpuOps, VmExit};
 
 use crate::{
+    ArmGuestPhysAddr, ArmHostOps, ArmNestedPagingConfig, ArmSysRegAddr, ArmVcpuResult, ArmVmExit,
     TrapFrame,
     context_frame::GuestSystemRegisters,
     exception::{TrapKind, handle_exception_sync},
     exception_utils::exception_class_value,
 };
 
-#[ax_percpu::def_percpu]
-static HOST_SP_EL0: u64 = 0;
-
-/// Save host's `SP_EL0` to the current ax-percpu region.
-unsafe fn save_host_sp_el0() {
-    unsafe { HOST_SP_EL0.write_current_raw(SP_EL0.get()) }
-}
-
-/// Restore host's `SP_EL0` from the current ax-percpu region.
-unsafe fn restore_host_sp_el0() {
-    SP_EL0.set(unsafe { HOST_SP_EL0.read_current_raw() });
-}
+/// Size of the guest trap frame used by the EL2 entry/exit assembly.
+pub const ARM_VCPU_TRAP_FRAME_SIZE: usize = core::mem::size_of::<TrapFrame>();
+/// Offset of [`HostRuntimeContext::stack_top`] within [`ArmVcpu`].
+pub const ARM_VCPU_HOST_STACK_TOP_OFFSET: usize = ARM_VCPU_TRAP_FRAME_SIZE;
+/// Offset of [`HostRuntimeContext::sp_el0`] within [`ArmVcpu`].
+pub const ARM_VCPU_HOST_SP_EL0_OFFSET: usize =
+    ARM_VCPU_HOST_STACK_TOP_OFFSET + core::mem::size_of::<u64>();
 
 /// (v)CPU register state that must be saved or restored when entering/exiting a VM or switching
 /// between VMs.
@@ -48,22 +44,31 @@ pub struct VmCpuRegisters {
     pub vm_system_regs: GuestSystemRegisters,
 }
 
-/// A virtual CPU within a guest
+/// Host-only state used by one guest entry/exit round.
+#[repr(C)]
+#[derive(Debug, Default)]
+struct HostRuntimeContext {
+    stack_top: u64,
+    sp_el0: u64,
+}
+
+/// A virtual CPU within a guest.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Aarch64VCpu {
-    // DO NOT modify `guest_regs` and `host_stack_top` and their order unless you do know what you are doing!
-    // DO NOT add anything before or between them unless you do know what you are doing!
+pub struct ArmVcpu<H: ArmHostOps> {
+    // The first two fields are consumed by exception.S and vmexit_trampoline.
+    // Keep `ctx` first and `host` immediately after it.
     ctx: TrapFrame,
-    host_stack_top: u64,
+    host: HostRuntimeContext,
     guest_system_regs: GuestSystemRegisters,
     /// The MPIDR_EL1 value for the vCPU.
     mpidr: u64,
+    _host: PhantomData<fn() -> H>,
 }
 
-/// Configuration for creating a new `Aarch64VCpu`
+/// Configuration for creating a new [`ArmVcpu`].
 #[derive(Clone, Debug, Default)]
-pub struct Aarch64VCpuCreateConfig {
+pub struct ArmVcpuCreateConfig {
     /// The MPIDR_EL1 value for the new vCPU,
     /// which is used to identify the CPU in a multiprocessor system.
     /// Note: mind CPU cluster.
@@ -73,46 +78,47 @@ pub struct Aarch64VCpuCreateConfig {
     pub dtb_addr: usize,
 }
 
-/// Configuration for setting up a new `Aarch64VCpu`
+/// Configuration for setting up a new [`ArmVcpu`].
 #[derive(Clone, Debug, Default)]
-pub struct Aarch64VCpuSetupConfig {
+pub struct ArmVcpuSetupConfig {
     /// Should the hypervisor passthrough interrupts to the guest?
     pub passthrough_interrupt: bool,
     /// Should the hypervisor passthrough timers to the guest?
     pub passthrough_timer: bool,
 }
 
-impl axvm_types::VmArchVcpuOps for Aarch64VCpu {
-    type CreateConfig = Aarch64VCpuCreateConfig;
-
-    type SetupConfig = Aarch64VCpuSetupConfig;
-
-    fn new(_vm_id: usize, _vcpu_id: usize, config: Self::CreateConfig) -> AxResult<Self> {
+impl<H: ArmHostOps> ArmVcpu<H> {
+    /// Creates a new architecture-specific vCPU.
+    pub fn new(_vm_id: usize, _vcpu_id: usize, config: ArmVcpuCreateConfig) -> ArmVcpuResult<Self> {
         let mut ctx = TrapFrame::default();
         ctx.set_argument(config.dtb_addr);
 
         Ok(Self {
             ctx,
-            host_stack_top: 0,
+            host: HostRuntimeContext::default(),
             guest_system_regs: GuestSystemRegisters::default(),
             mpidr: config.mpidr_el1,
+            _host: PhantomData,
         })
     }
 
-    fn setup(&mut self, config: Self::SetupConfig) -> AxResult {
+    /// Completes architecture-specific setup.
+    pub fn setup(&mut self, config: ArmVcpuSetupConfig) -> ArmVcpuResult {
         self.init_hv(config);
         Ok(())
     }
 
-    fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
+    /// Sets the guest entry point.
+    pub fn set_entry(&mut self, entry: ArmGuestPhysAddr) -> ArmVcpuResult {
         debug!("set vcpu entry:{entry:?}");
         self.set_elr(entry.as_usize());
         Ok(())
     }
 
-    fn set_nested_page_table(&mut self, config: NestedPagingConfig) -> AxResult {
+    /// Sets the nested page table selected by the embedding VMM.
+    pub fn set_nested_page_table(&mut self, config: ArmNestedPagingConfig) -> ArmVcpuResult {
         debug!("set vcpu stage-2 root:{:#x}", config.root_paddr);
-        self.guest_system_regs.vttbr_el2 = config.root_paddr.as_usize() as u64;
+        self.guest_system_regs.vttbr_el2 = config.root_paddr as u64;
         let pa_bits = if config.mode == 0 {
             pa_bits()
         } else {
@@ -122,54 +128,57 @@ impl axvm_types::VmArchVcpuOps for Aarch64VCpu {
         Ok(())
     }
 
-    fn run(&mut self) -> AxResult<VmExit> {
+    /// Runs the vCPU until a VM exit.
+    pub fn run(&mut self) -> ArmVcpuResult<ArmVmExit> {
         unsafe {
             core::arch::asm!("msr daifset, #2");
         }
 
-        // Run guest.
-        let exit_reson = unsafe {
-            // Save host SP_EL0 to the ctx becase it's used as current task ptr.
-            // This has to be done before vm system regs are restored.
-            save_host_sp_el0();
+        let exit_reason = unsafe {
             self.restore_vm_system_regs();
             self.run_guest()
         };
+
+        let trap_kind = TrapKind::try_from(exit_reason as u8).expect("Invalid TrapKind");
+        let result = self.vmexit_handler(trap_kind);
 
         unsafe {
             core::arch::asm!("msr daifclr, #2");
         }
 
-        let trap_kind = TrapKind::try_from(exit_reson as u8).expect("Invalid TrapKind");
-        self.vmexit_handler(trap_kind)
+        result
     }
 
-    fn bind(&mut self) -> AxResult {
+    /// Binds this vCPU to the current physical CPU.
+    pub fn bind(&mut self) -> ArmVcpuResult {
         Ok(())
     }
 
-    fn unbind(&mut self) -> AxResult {
+    /// Unbinds this vCPU from the current physical CPU.
+    pub fn unbind(&mut self) -> ArmVcpuResult {
         Ok(())
     }
 
-    fn set_gpr(&mut self, idx: usize, val: usize) {
+    /// Sets a general-purpose register.
+    pub fn set_gpr(&mut self, idx: usize, val: usize) {
         self.ctx.set_gpr(idx, val);
     }
 
-    fn inject_interrupt(&mut self, vector: usize) -> AxResult {
-        crate::host::hardware_inject_virtual_interrupt(vector as u8);
-        Ok(())
+    /// Injects an interrupt into the guest vCPU.
+    pub fn inject_interrupt(&mut self, vector: usize) -> ArmVcpuResult {
+        H::inject_virtual_interrupt(vector as u8)
     }
 
-    fn set_return_value(&mut self, val: usize) {
+    /// Sets the guest return value.
+    pub fn set_return_value(&mut self, val: usize) {
         // Return value is stored in x0.
         self.ctx.set_argument(val);
     }
 }
 
 // Private function
-impl Aarch64VCpu {
-    fn init_hv(&mut self, config: Aarch64VCpuSetupConfig) {
+impl<H: ArmHostOps> ArmVcpu<H> {
+    fn init_hv(&mut self, config: ArmVcpuSetupConfig) {
         self.ctx.spsr = (SPSR_EL1::M::EL1h
             + SPSR_EL1::I::Masked
             + SPSR_EL1::F::Masked
@@ -180,7 +189,7 @@ impl Aarch64VCpu {
     }
 
     /// Init guest context. Also set some el2 register value.
-    fn init_vm_context(&mut self, config: Aarch64VCpuSetupConfig) {
+    fn init_vm_context(&mut self, config: ArmVcpuSetupConfig) {
         // CNTHCTL_EL2.modify(CNTHCTL_EL2::EL1PCEN::SET + CNTHCTL_EL2::EL1PCTEN::SET);
         // Set CNTVOFF_EL2 to the current physical counter so the guest's
         // virtual counter (CNTVCT_EL0 = CNTPCT_EL0 - CNTVOFF_EL2) starts near zero.
@@ -239,7 +248,7 @@ impl Aarch64VCpu {
 }
 
 /// Private functions related to vcpu runtime control flow.
-impl Aarch64VCpu {
+impl<H: ArmHostOps> ArmVcpu<H> {
     /// Save host context and run guest.
     ///
     /// When a VM-Exit happens when guest's vCpu is running,
@@ -256,18 +265,21 @@ impl Aarch64VCpu {
         core::arch::naked_asm!(
             // Save host context.
             save_regs_to_stack!(),
-            // Save current host stack top to `self.host_stack_top`.
+            // Save the host stack top and SP_EL0 to `self.host`.
             //
             // 'extern "C"' here specifies the aapcs64 calling convention, according to which
-            // the first and only parameter, the pointer of self, should be in x0:
+            // the first and only parameter, the pointer of self, should be in x0.
             "mov x9, sp",
-            "add x0, x0, {host_stack_top_offset}",
-            "str x9, [x0]",
-            // Go to `context_vm_entry`.
+            "add x10, x0, {host_stack_top_offset}",
+            "str x9, [x10]",
+            "mrs x9, sp_el0",
+            "str x9, [x10, #8]",
+            // Go to `context_vm_entry` with x0 pointing to `self.host.stack_top`.
+            "mov x0, x10",
             "b context_vm_entry",
             // Panic if the control flow comes back here, which should never happen.
             "b {run_guest_panic}",
-            host_stack_top_offset = const core::mem::size_of::<TrapFrame>(),
+            host_stack_top_offset = const ARM_VCPU_HOST_STACK_TOP_OFFSET,
             run_guest_panic = sym Self::run_guest_panic,
         );
     }
@@ -308,39 +320,32 @@ impl Aarch64VCpu {
     /// - `exit_reason`: The reason why the VM-Exit happened in [`TrapKind`].
     ///
     /// Returns:
-    /// - [`VmExit`]: a wrappered VM-Exit reason needed to be handled by the hypervisor.
+    /// - [`ArmVmExit`]: a wrappered VM-Exit reason needed to be handled by the hypervisor.
     ///
     /// This function may panic for unhandled exceptions.
-    fn vmexit_handler(&mut self, exit_reason: TrapKind) -> AxResult<VmExit> {
+    fn vmexit_handler(&mut self, exit_reason: TrapKind) -> ArmVcpuResult<ArmVmExit> {
         trace!(
-            "Aarch64VCpu vmexit_handler() esr:{:#x} ctx:{:#x?}",
+            "ArmVcpu vmexit_handler() esr:{:#x} ctx:{:#x?}",
             exception_class_value(),
             self.ctx
         );
 
         unsafe {
-            // Store guest system regs
+            // Store guest system regs. Guest SP_EL0 was already saved into `self.ctx`
+            // by the EL2 assembly before host SP_EL0 was restored.
             self.guest_system_regs.store();
-
-            // Store guest `SP_EL0` into the `Aarch64VCpu` struct,
-            // which will be restored when the guest is resumed in `exception_return_el2`.
-            self.ctx.sp_el0 = self.guest_system_regs.sp_el0;
-
-            // Restore host `SP_EL0`.
-            // This has to be done after guest's SP_EL0 is stored by `ext_regs_store`.
-            restore_host_sp_el0();
         }
 
         let result = match exit_reason {
             TrapKind::Synchronous => handle_exception_sync(&mut self.ctx),
-            TrapKind::Irq => Ok(VmExit::ExternalInterrupt {
-                vector: crate::host::fetch_irq() as u64,
+            TrapKind::Irq => Ok(ArmVmExit::ExternalInterrupt {
+                vector: H::fetch_pending_host_irq().unwrap_or(0) as u64,
             }),
             _ => panic!("Unhandled exception {:?}", exit_reason),
         };
 
         match result {
-            Ok(VmExit::SysRegRead { addr, reg }) => {
+            Ok(ArmVmExit::SysRegRead { addr, reg }) => {
                 if let Some(exit_reason) =
                     self.builtin_sysreg_access_handler(addr, false, 0, reg)?
                 {
@@ -349,7 +354,7 @@ impl Aarch64VCpu {
 
                 result
             }
-            Ok(VmExit::SysRegWrite { addr, value }) => {
+            Ok(ArmVmExit::SysRegWrite { addr, value }) => {
                 if let Some(exit_reason) =
                     self.builtin_sysreg_access_handler(addr, true, value, 0)?
                 {
@@ -367,12 +372,12 @@ impl Aarch64VCpu {
     /// Return `Ok(None)` if the system register access is not handled by the VCpu itself,
     fn builtin_sysreg_access_handler(
         &mut self,
-        addr: SysRegAddr,
+        addr: ArmSysRegAddr,
         write: bool,
         value: u64,
         reg: usize,
-    ) -> AxResult<Option<VmExit>> {
-        const SYSREG_ICC_SGI1R_EL1: SysRegAddr = SysRegAddr::new(0x3A_3016); // ICC_SGI1R_EL1
+    ) -> ArmVcpuResult<Option<ArmVmExit>> {
+        const SYSREG_ICC_SGI1R_EL1: ArmSysRegAddr = ArmSysRegAddr::new(0x3A_3016); // ICC_SGI1R_EL1
 
         match (addr, write) {
             (SYSREG_ICC_SGI1R_EL1, true) => {
@@ -387,7 +392,7 @@ impl Aarch64VCpu {
                 if irm {
                     debug!("arm_vcpu ICC_SGI1R_EL1 write: irm == 1, send to all except self");
 
-                    return Ok(Some(VmExit::SendIPI {
+                    return Ok(Some(ArmVmExit::SendIPI {
                         target_cpu: 0,
                         target_cpu_aux: 0,
                         send_to_all: true,
@@ -406,7 +411,7 @@ impl Aarch64VCpu {
                      intid:{intid:#x} target_list:{target_list:#x}"
                 );
 
-                Ok(Some(VmExit::SendIPI {
+                Ok(Some(ArmVmExit::SendIPI {
                     target_cpu: (aff3 << 24) | (aff2 << 16) | (aff1 << 8),
                     target_cpu_aux: target_list,
                     send_to_all: false,
@@ -417,7 +422,7 @@ impl Aarch64VCpu {
             (SYSREG_ICC_SGI1R_EL1, false) => {
                 // ICC_SGI1R_EL1 is WO, we take it as RAZ.
                 self.set_gpr(reg, 0);
-                Ok(Some(VmExit::Nothing))
+                Ok(Some(ArmVmExit::Nothing))
             }
             _ => {
                 // If the system register access is not handled by the VCpu itself,

--- a/virtualization/arm_vcpu/tests/dependency_contract_test.rs
+++ b/virtualization/arm_vcpu/tests/dependency_contract_test.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn arm_vcpu_manifest_has_no_ax_runtime_dependencies() {
+    let manifest = include_str!("../Cargo.toml");
+
+    for forbidden in ["ax-errno", "ax-percpu", "ax-crate-interface", "axvm-types"] {
+        assert!(
+            !manifest.contains(forbidden),
+            "arm_vcpu core must not depend on {forbidden}"
+        );
+    }
+}

--- a/virtualization/arm_vcpu/tests/os_neutral_api_test.rs
+++ b/virtualization/arm_vcpu/tests/os_neutral_api_test.rs
@@ -1,0 +1,107 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(target_arch = "aarch64")]
+
+use core::mem::size_of;
+
+use arm_vcpu::{
+    ARM_VCPU_HOST_SP_EL0_OFFSET, ARM_VCPU_HOST_STACK_TOP_OFFSET, ARM_VCPU_TRAP_FRAME_SIZE,
+    Aarch64PerCpu, Aarch64VCpu, ArmAccessWidth, ArmGuestPhysAddr, ArmHostOps,
+    ArmNestedPagingConfig, ArmPerCpu, ArmSysRegAddr, ArmVcpu, ArmVcpuError, ArmVcpuResult,
+    ArmVmExit, TrapFrame,
+};
+
+struct DummyHost;
+
+impl ArmHostOps for DummyHost {
+    fn inject_virtual_interrupt(_vector: u8) -> ArmVcpuResult {
+        Ok(())
+    }
+
+    fn fetch_pending_host_irq() -> Option<usize> {
+        None
+    }
+
+    fn handle_current_host_irq() {}
+}
+
+#[test]
+fn vcpu_and_percpu_types_are_host_generic_without_axvm_traits() {
+    let _vcpu: Option<ArmVcpu<DummyHost>> = None;
+    let _compat_vcpu: Option<Aarch64VCpu<DummyHost>> = None;
+    let _percpu: Option<ArmPerCpu> = None;
+    let _compat_percpu: Option<Aarch64PerCpu> = None;
+
+    assert_eq!(ARM_VCPU_TRAP_FRAME_SIZE, 34 * size_of::<u64>());
+    assert_eq!(size_of::<TrapFrame>(), ARM_VCPU_TRAP_FRAME_SIZE);
+    assert_eq!(ARM_VCPU_HOST_STACK_TOP_OFFSET, ARM_VCPU_TRAP_FRAME_SIZE);
+    assert_eq!(
+        ARM_VCPU_HOST_SP_EL0_OFFSET,
+        ARM_VCPU_HOST_STACK_TOP_OFFSET + size_of::<u64>()
+    );
+}
+
+#[test]
+fn nested_paging_config_uses_os_neutral_integer_values() {
+    let config = ArmNestedPagingConfig::new(0x1000, 3, 39, 48);
+
+    assert_eq!(config.root_paddr, 0x1000);
+    assert_eq!(config.levels, 3);
+    assert_eq!(config.gpa_bits, 39);
+    assert_eq!(config.mode, 48);
+}
+
+#[test]
+fn vm_exit_types_are_defined_by_arm_vcpu_core() {
+    let exit = ArmVmExit::MmioRead {
+        addr: ArmGuestPhysAddr::from_usize(0x2000),
+        width: ArmAccessWidth::Dword,
+        reg: 3,
+        reg_width: ArmAccessWidth::Qword,
+        signed_ext: false,
+    };
+
+    match exit {
+        ArmVmExit::MmioRead {
+            addr, width, reg, ..
+        } => {
+            assert_eq!(addr.as_usize(), 0x2000);
+            assert_eq!(width.size(), 4);
+            assert_eq!(reg, 3);
+        }
+        other => panic!("unexpected exit: {other:?}"),
+    }
+
+    let exit = ArmVmExit::SysRegRead {
+        addr: ArmSysRegAddr::new(0x3a_3016),
+        reg: 1,
+    };
+    assert!(matches!(
+        exit,
+        ArmVmExit::SysRegRead {
+            addr,
+            reg: 1,
+        } if addr.addr() == 0x3a_3016
+    ));
+}
+
+#[test]
+fn host_ops_can_report_typed_errors() {
+    assert_eq!(Err(ArmVcpuError::Unsupported), unsupported_host_call());
+}
+
+fn unsupported_host_call() -> ArmVcpuResult {
+    Err(ArmVcpuError::Unsupported)
+}

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -1,12 +1,24 @@
+//! AxVM AArch64 adapter.
+//!
+//! This module owns the AxVM/ArceOS glue for the OS-neutral `arm_vcpu` core:
+//! `AxvmArmHostOps` supplies host IRQ/GIC operations, while wrapper types
+//! convert `arm_vcpu` errors and exits into `axvm_types` and `ax_errno` values.
+
 use alloc::boxed::Box;
 use core::time::Duration;
 
-use arm_vcpu::host::ArmVcpuHostIf;
+use arm_vcpu::{
+    ArmAccessWidth, ArmGuestPhysAddr, ArmHostOps, ArmNestedPagingConfig, ArmPerCpu, ArmSysRegAddr,
+    ArmVcpu, ArmVcpuCreateConfig, ArmVcpuError, ArmVcpuResult, ArmVcpuSetupConfig, ArmVmExit,
+};
 use arm_vgic::host::ArmVgicHostIf;
 use ax_crate_interface::impl_interface;
-use ax_errno::{AxResult, ax_err};
+use ax_errno::{AxError, AxResult, ax_err};
 use ax_memory_addr::{PhysAddr, VirtAddr};
-use axvm_types::NestedPagingConfig;
+use axvm_types::{
+    AccessWidth, GuestPhysAddr, NestedPagingConfig, SysRegAddr, VCpuId, VMId, VmArchPerCpuOps,
+    VmArchVcpuOps, VmExit,
+};
 
 use super::{ArchOps, VcpuCreateContext, VcpuSetupContext, target_phys_cpu_ids};
 use crate::host::{HostCpu, HostMemory, HostTime, default_host, gic};
@@ -16,8 +28,8 @@ mod npt;
 pub(crate) struct Aarch64Arch;
 
 impl ArchOps for Aarch64Arch {
-    type VCpu = arm_vcpu::Aarch64VCpu;
-    type PerCpu = arm_vcpu::Aarch64PerCpu;
+    type VCpu = AxvmArmVcpu;
+    type PerCpu = AxvmArmPerCpu;
     type VcpuCreateState = ();
     type NestedPageTable = npt::NestedPageTable<crate::HostPagingHandler>;
 
@@ -97,8 +109,8 @@ impl ArchOps for Aarch64Arch {
     fn build_vcpu_create_config(
         _state: &Self::VcpuCreateState,
         ctx: VcpuCreateContext,
-    ) -> AxResult<<Self::VCpu as axvm_types::VmArchVcpuOps>::CreateConfig> {
-        Ok(arm_vcpu::Aarch64VCpuCreateConfig {
+    ) -> AxResult<<Self::VCpu as VmArchVcpuOps>::CreateConfig> {
+        Ok(ArmVcpuCreateConfig {
             mpidr_el1: ctx.phys_cpu_id as _,
             dtb_addr: ctx.dtb_addr.unwrap_or_default().as_usize(),
         })
@@ -106,9 +118,9 @@ impl ArchOps for Aarch64Arch {
 
     fn build_vcpu_setup_config(
         ctx: VcpuSetupContext<'_>,
-    ) -> AxResult<<Self::VCpu as axvm_types::VmArchVcpuOps>::SetupConfig> {
+    ) -> AxResult<<Self::VCpu as VmArchVcpuOps>::SetupConfig> {
         let passthrough = ctx.interrupt_mode == axvm_types::VMInterruptMode::Passthrough;
-        Ok(arm_vcpu::Aarch64VCpuSetupConfig {
+        Ok(ArmVcpuSetupConfig {
             passthrough_interrupt: passthrough,
             passthrough_timer: passthrough,
         })
@@ -145,20 +157,250 @@ impl ArchOps for Aarch64Arch {
     }
 }
 
-struct ArmVcpuHostIfImpl;
+struct AxvmArmHostOps;
 
-#[impl_interface]
-impl ArmVcpuHostIf for ArmVcpuHostIfImpl {
-    fn hardware_inject_virtual_interrupt(vector: u8) {
+impl ArmHostOps for AxvmArmHostOps {
+    fn inject_virtual_interrupt(vector: u8) -> ArmVcpuResult {
         gic::inject_interrupt(vector as usize);
+        Ok(())
     }
 
-    fn fetch_irq() -> usize {
-        gic::fetch_irq()
+    fn fetch_pending_host_irq() -> Option<usize> {
+        Some(gic::fetch_irq())
     }
 
-    fn handle_irq() {
+    fn handle_current_host_irq() {
         gic::handle_current_irq();
+    }
+}
+
+pub(crate) struct AxvmArmVcpu(ArmVcpu<AxvmArmHostOps>);
+
+impl VmArchVcpuOps for AxvmArmVcpu {
+    type CreateConfig = ArmVcpuCreateConfig;
+    type SetupConfig = ArmVcpuSetupConfig;
+
+    fn new(vm_id: VMId, vcpu_id: VCpuId, config: Self::CreateConfig) -> AxResult<Self> {
+        arm_result(ArmVcpu::new(vm_id, vcpu_id, config)).map(Self)
+    }
+
+    fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
+        arm_result(self.0.set_entry(ax_guest_phys_addr_to_arm(entry)))
+    }
+
+    fn set_nested_page_table(&mut self, config: NestedPagingConfig) -> AxResult {
+        arm_result(
+            self.0
+                .set_nested_page_table(ax_nested_paging_to_arm(config)),
+        )
+    }
+
+    fn setup(&mut self, config: Self::SetupConfig) -> AxResult {
+        arm_result(self.0.setup(config))
+    }
+
+    fn run(&mut self) -> AxResult<VmExit> {
+        arm_result(self.0.run()).map(arm_exit_to_ax)
+    }
+
+    fn bind(&mut self) -> AxResult {
+        arm_result(self.0.bind())
+    }
+
+    fn unbind(&mut self) -> AxResult {
+        arm_result(self.0.unbind())
+    }
+
+    fn set_gpr(&mut self, reg: usize, val: usize) {
+        self.0.set_gpr(reg, val);
+    }
+
+    fn inject_interrupt(&mut self, vector: usize) -> AxResult {
+        arm_result(self.0.inject_interrupt(vector))
+    }
+
+    fn set_return_value(&mut self, val: usize) {
+        self.0.set_return_value(val);
+    }
+}
+
+pub(crate) struct AxvmArmPerCpu(ArmPerCpu);
+
+impl VmArchPerCpuOps for AxvmArmPerCpu {
+    fn new(cpu_id: usize) -> AxResult<Self> {
+        arm_result(ArmPerCpu::new(cpu_id)).map(Self)
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.0.is_enabled()
+    }
+
+    fn hardware_enable(&mut self) -> AxResult {
+        arm_result(self.0.hardware_enable::<AxvmArmHostOps>())
+    }
+
+    fn hardware_disable(&mut self) -> AxResult {
+        arm_result(self.0.hardware_disable())
+    }
+
+    fn max_guest_page_table_levels(&self) -> usize {
+        self.0.max_guest_page_table_levels()
+    }
+
+    fn guest_phys_addr_bits(&self) -> usize {
+        self.0.guest_phys_addr_bits()
+    }
+}
+
+fn arm_result<T>(result: ArmVcpuResult<T>) -> AxResult<T> {
+    result.map_err(arm_error_to_ax)
+}
+
+fn arm_error_to_ax(err: ArmVcpuError) -> AxError {
+    match err {
+        ArmVcpuError::InvalidInput => AxError::InvalidInput,
+        ArmVcpuError::Unsupported => AxError::Unsupported,
+        ArmVcpuError::BadState => AxError::BadState,
+    }
+}
+
+fn ax_guest_phys_addr_to_arm(addr: GuestPhysAddr) -> ArmGuestPhysAddr {
+    ArmGuestPhysAddr::from_usize(addr.as_usize())
+}
+
+fn arm_guest_phys_addr_to_ax(addr: ArmGuestPhysAddr) -> GuestPhysAddr {
+    GuestPhysAddr::from(addr.as_usize())
+}
+
+fn ax_nested_paging_to_arm(config: NestedPagingConfig) -> ArmNestedPagingConfig {
+    ArmNestedPagingConfig::new(
+        config.root_paddr.as_usize(),
+        config.levels,
+        config.gpa_bits,
+        config.mode,
+    )
+}
+
+fn arm_access_width_to_ax(width: ArmAccessWidth) -> AccessWidth {
+    match width {
+        ArmAccessWidth::Byte => AccessWidth::Byte,
+        ArmAccessWidth::Word => AccessWidth::Word,
+        ArmAccessWidth::Dword => AccessWidth::Dword,
+        ArmAccessWidth::Qword => AccessWidth::Qword,
+    }
+}
+
+fn arm_sys_reg_addr_to_ax(addr: ArmSysRegAddr) -> SysRegAddr {
+    SysRegAddr::new(addr.addr())
+}
+
+fn arm_exit_to_ax(exit: ArmVmExit) -> VmExit {
+    match exit {
+        ArmVmExit::Hypercall { nr, args } => VmExit::Hypercall { nr, args },
+        ArmVmExit::MmioRead {
+            addr,
+            width,
+            reg,
+            reg_width,
+            signed_ext,
+        } => VmExit::MmioRead {
+            addr: arm_guest_phys_addr_to_ax(addr),
+            width: arm_access_width_to_ax(width),
+            reg,
+            reg_width: arm_access_width_to_ax(reg_width),
+            signed_ext,
+        },
+        ArmVmExit::MmioWrite { addr, width, data } => VmExit::MmioWrite {
+            addr: arm_guest_phys_addr_to_ax(addr),
+            width: arm_access_width_to_ax(width),
+            data,
+        },
+        ArmVmExit::SysRegRead { addr, reg } => VmExit::SysRegRead {
+            addr: arm_sys_reg_addr_to_ax(addr),
+            reg,
+        },
+        ArmVmExit::SysRegWrite { addr, value } => VmExit::SysRegWrite {
+            addr: arm_sys_reg_addr_to_ax(addr),
+            value,
+        },
+        ArmVmExit::ExternalInterrupt { vector } => VmExit::ExternalInterrupt { vector },
+        ArmVmExit::CpuDown { state } => VmExit::CpuDown { _state: state },
+        ArmVmExit::CpuUp {
+            target_cpu,
+            entry_point,
+            arg,
+        } => VmExit::CpuUp {
+            target_cpu,
+            entry_point: arm_guest_phys_addr_to_ax(entry_point),
+            arg,
+        },
+        ArmVmExit::SystemDown => VmExit::SystemDown,
+        ArmVmExit::SendIPI {
+            target_cpu,
+            target_cpu_aux,
+            send_to_all,
+            send_to_self,
+            vector,
+        } => VmExit::SendIPI {
+            target_cpu,
+            target_cpu_aux,
+            send_to_all,
+            send_to_self,
+            vector,
+        },
+        ArmVmExit::Nothing => VmExit::Nothing,
+        _ => unreachable!("unmapped arm_vcpu VM-exit variant"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_arm_vcpu_errors_to_ax_errors() {
+        assert_eq!(
+            arm_error_to_ax(ArmVcpuError::InvalidInput),
+            AxError::InvalidInput
+        );
+        assert_eq!(
+            arm_error_to_ax(ArmVcpuError::Unsupported),
+            AxError::Unsupported
+        );
+        assert_eq!(arm_error_to_ax(ArmVcpuError::BadState), AxError::BadState);
+    }
+
+    #[test]
+    fn converts_arm_vcpu_exits_to_axvm_exits() {
+        let mmio = arm_exit_to_ax(ArmVmExit::MmioRead {
+            addr: ArmGuestPhysAddr::from_usize(0x4000),
+            width: ArmAccessWidth::Dword,
+            reg: 5,
+            reg_width: ArmAccessWidth::Qword,
+            signed_ext: true,
+        });
+        assert!(matches!(
+            mmio,
+            VmExit::MmioRead {
+                addr,
+                width: AccessWidth::Dword,
+                reg: 5,
+                reg_width: AccessWidth::Qword,
+                signed_ext: true,
+            } if addr.as_usize() == 0x4000
+        ));
+
+        let cpu_down = arm_exit_to_ax(ArmVmExit::CpuDown { state: 7 });
+        assert!(matches!(cpu_down, VmExit::CpuDown { _state: 7 }));
+
+        let sysreg = arm_exit_to_ax(ArmVmExit::SysRegWrite {
+            addr: ArmSysRegAddr::new(0x3a_3016),
+            value: 0x55,
+        });
+        assert!(matches!(
+            sysreg,
+            VmExit::SysRegWrite { addr, value: 0x55 } if addr.addr() == 0x3a_3016
+        ));
     }
 }
 


### PR DESCRIPTION
## 背景

`arm_vcpu` 原本直接依赖 `ax-percpu`、`ax-crate-interface`、`axvm-types` 和 `ax-errno`，导致 AArch64 vCPU core 与 AxVM/ArceOS 的宿主接口、错误类型和 VM-exit 类型绑在一起，不利于在其他 OS/VMM 中复用。

## 改动

- 在 `arm_vcpu` 内新增 OS-neutral API：`ArmVcpuError`、`ArmVcpuResult`、`ArmVmExit`、`ArmNestedPagingConfig`、`ArmHostOps`、`ArmPerCpu`、`ArmVcpu<H>`。
- 保留 `Aarch64VCpu`、`Aarch64PerCpu` 和配置类型兼容别名，避免上层命名一次性断裂。
- 移除 `arm_vcpu` 对 `ax-percpu`、`ax-crate-interface`、`axvm-types`、`ax-errno` 的直接依赖。
- 将 `VmArchVcpuOps` / `VmArchPerCpuOps` glue 移到 AxVM AArch64 adapter 中，由 `AxvmArmVcpu` / `AxvmArmPerCpu` 完成 AxVM 类型转换。
- 新增 `HostRuntimeContext { stack_top, sp_el0 }`，在 guest `TrapFrame` 后保存 host runtime 状态；VM exit trampoline 返回 Rust 前恢复 host `SP_EL0`。
- `GuestSystemRegisters` 不再保存 `SP_EL0`，guest `SP_EL0` 只保存在 `TrapFrame.sp_el0`。
- 更新 `arm_vcpu` 文档和 README，说明 crate 本体是 OS-neutral core，AxVM/ArceOS 接入位于 AxVM adapter。
- 增加 manifest dependency contract 测试和 OS-neutral API/layout 测试。

## 设计逻辑

这次拆分把 vCPU core 的职责限定在 AArch64 EL2 entry/exit、guest register state、trap decode 和硬件虚拟化寄存器语义上。宿主中断注入、pending IRQ 获取和 current-EL IRQ 分发通过 `ArmHostOps` 显式提供；AxVM 只在 adapter 层负责把这些能力接到现有 GIC 和 `axvm_types` 语义上。

`SP_EL0` 处理也改成 guest/host 分离：guest 值由 `TrapFrame` 承载，host 值由 `HostRuntimeContext` 承载，并在返回 host Rust 前恢复，避免 host IRQ 或 Rust 代码在 guest `SP_EL0` 下运行。

## 验证

- `cargo fmt`
- `cargo test -p arm_vcpu --test dependency_contract_test`
- `cargo check -p arm_vcpu --target aarch64-unknown-none-softfloat`
- `cargo check -p axvm --target aarch64-unknown-none-softfloat`
- `cargo xtask clippy --package arm_vcpu`
- `cargo xtask clippy --package axvm`
- `cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case smoke`

AArch64 Axvisor smoke 结果：`guest test pass!`，`1/1 case(s) passed`。