### PR TITLE
feat(starfive-jh7110-dwmmc): add IRQ-driven host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,8 @@ dependencies = [
  "simple-ahci",
  "some-serial",
  "spin",
+ "starfive-jh7110-dwmmc",
+ "tock-registers 0.10.1",
  "virtio-drivers",
  "x86",
 ]
@@ -6387,6 +6389,7 @@ dependencies = [
  "paste",
  "pcie",
  "rdif-base",
+ "rdif-clk",
  "rdif-pcie",
  "rdif-pinctrl",
  "rdif-power",
@@ -7600,6 +7603,18 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "starfive-jh7110-dwmmc"
+version = "0.1.0"
+dependencies = [
+ "dma-api",
+ "dwmmc-host",
+ "log",
+ "rdif-block",
+ "sdio-host2",
+ "sdmmc-protocol",
+]
 
 [[package]]
 name = "starry-fatfs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,7 @@ phytium-mci-host = { version = "0.3.0", path = "drivers/blk/phytium-mci-host", d
 cv181x-sdhci = { version = "0.1.0", path = "drivers/blk/cv181x-sdhci", default-features = false }
 sdhci-host = { version = "0.3.0", path = "drivers/blk/sdhci-host", default-features = false }
 sdmmc-protocol = { version = "0.3.0", path = "drivers/blk/sdmmc-protocol", default-features = false }
+starfive-jh7110-dwmmc = { version = "0.1.0", path = "drivers/blk/starfive-jh7110-dwmmc", default-features = false }
 smoltcp = { version = "0.13.1", default-features = false }
 axnsproxy = { version = "0.2.5", path = "os/StarryOS/axnsproxy" }
 starry-kernel = { version = "0.6.6", path = "os/StarryOS/kernel" }

--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -104,9 +104,16 @@ rockchip-dwmmc = [
 ]
 starfive-jh7110-dwmmc = [
     "block",
-    "dep:dwmmc-host",
+    "starfive-soc",
     "dep:sdmmc-protocol",
+    "dep:starfive-jh7110-dwmmc",
+    "sdmmc-protocol/rdif",
     "sdmmc-protocol/sdio",
+]
+starfive-soc = [
+    "dep:rdif-clk",
+    "dep:rdif-reset",
+    "dep:tock-registers",
 ]
 rk3588-pwm = [
     "rockchip-soc",
@@ -183,9 +190,11 @@ sdhci-host = { workspace = true, optional = true }
 sdhci-cv1800 = { workspace = true, optional = true }
 sdio-host = { workspace = true, optional = true }
 sdmmc-protocol = { workspace = true, default-features = false, optional = true }
+starfive-jh7110-dwmmc = { workspace = true, optional = true }
 simple-ahci = { workspace = true, optional = true }
 some-serial = { workspace = true, optional = true }
 spin.workspace = true
+tock-registers = { workspace = true, optional = true }
 virtio-drivers = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/drivers/ax-driver/src/block/starfive_mmc.rs
+++ b/drivers/ax-driver/src/block/starfive_mmc.rs
@@ -1,28 +1,26 @@
 use alloc::format;
 use core::time::Duration;
 
-use dwmmc_host::{DwMmc, rdif as dwmmc_rdif};
 use log::{info, warn};
-use rdrive::{
-    probe::OnProbeError,
-    register::{FdtInfo, ProbeFdt},
-};
+use rdrive::{probe::OnProbeError, register::ProbeFdt};
 use sdmmc_protocol::{
     Error, OperationPoll,
     error::Phase,
+    rdif::config::BlockConfig,
     sdio::{
+        BusWidth,
         card::{CardInfo, SdioSdmmc},
         host2::SdioHost2Adapter,
-        init::SdioInitScratch,
+        init::{CardInitPreference, SdioInitScratch},
     },
+};
+use starfive_jh7110_dwmmc::{
+    JH7110_STABLE_REFERENCE_CLOCK_HZ, Jh7110DwMmc, Jh7110DwMmcConfig, rdif as starfive_rdif,
 };
 
 use crate::{block::ProbeFdtBlock, mmio::iomap};
 
-const STARFIVE_JH7110_MMC1_BASE: u64 = 0x1602_0000;
-const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
-
-type StarFiveDwMmc = SdioSdmmc<SdioHost2Adapter<DwMmc>>;
+type StarFiveDwMmc = SdioSdmmc<SdioHost2Adapter<Jh7110DwMmc>>;
 
 crate::model_register!(
     name: "StarFive JH7110 MMC",
@@ -50,25 +48,20 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
     let address = base_reg.address;
     let mmio_size = base_reg.size.unwrap_or(0x1000);
-    if address != STARFIVE_JH7110_MMC1_BASE {
-        info!(
-            "starfive-jh7110-dwmmc: skipping non-microSD controller {} at {:#x}",
-            info.node.name(),
-            address
-        );
-        return Err(OnProbeError::NotMatch);
-    }
-
     info!(
         "starfive-jh7110-dwmmc probe: node={}, addr={:#x}, size={:#x}",
         info.node.name(),
         address,
         mmio_size
     );
+    let resources = info.prepare_resources(
+        rdrive::probe::fdt::ResourcePrepareConfig::default().with_named_clock_rate("ciu"),
+    )?;
+    let reference_clock_hz = prepared_reference_clock_hz(resources.clock_rate("ciu"));
+    let profile = StarFiveMmcNodeProfile::from_info(info, reference_clock_hz);
     let mmio_base = iomap(address as usize, mmio_size as usize)?;
 
-    let mut host = unsafe { DwMmc::new(mmio_base) };
-    host.set_reference_clock(reference_clock(info));
+    let mut host = unsafe { Jh7110DwMmc::new(mmio_base, profile.host_config) };
 
     info!("starfive-jh7110-dwmmc: reset controller");
     host.reset_and_init()
@@ -77,7 +70,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     info!("starfive-jh7110-dwmmc: initialize card");
     let mut sd = SdioSdmmc::new_host2(host);
     sd.set_sd_speed_selection_enabled(false);
-    let card_info = poll_card_init(&mut sd).map_err(|err| {
+    let card_info = poll_card_init(&mut sd, profile.init_preference).map_err(|err| {
         warn!("starfive-jh7110-dwmmc: card init failed: {:?}", err);
         card_init_error(address, mmio_size, err)
     })?;
@@ -93,33 +86,104 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         card_info.ext_csd.is_some()
     );
 
-    let dev = dwmmc_rdif::device(
+    let dev = starfive_rdif::device(
         sd,
-        dwmmc_rdif::fifo_config(
-            "starfive-jh7110-mmc",
-            card_info.capacity_blocks.unwrap_or(0),
-            false,
-        ),
+        starfive_block_config(card_info.capacity_blocks.unwrap_or(0)),
     );
     let irq = probe.register_block(dev)?;
     info!("starfive-jh7110-mmc block device registered irq={:?}", irq);
     Ok(())
 }
 
-fn reference_clock(info: &FdtInfo<'_>) -> u32 {
-    let clock = info
-        .find_clk_by_name("ciu")
-        .map(|clk| clk.select().unwrap_or(0));
-    info!(
-        "starfive-jh7110-dwmmc: using {} Hz ciu reference clock hint {:?}",
-        DWMMC_STABLE_REFERENCE_CLOCK, clock
-    );
-    DWMMC_STABLE_REFERENCE_CLOCK
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StarFiveMmcNodeProfile {
+    host_config: Jh7110DwMmcConfig,
+    init_preference: CardInitPreference,
 }
 
-fn poll_card_init(sd: &mut StarFiveDwMmc) -> Result<CardInfo, Error> {
+impl StarFiveMmcNodeProfile {
+    fn from_info(info: &rdrive::probe::fdt::FdtInfo<'_>, reference_clock_hz: u32) -> Self {
+        let node = info.node.as_node();
+        Self::from_dt_flags(
+            reference_clock_hz,
+            node.get_property("bus-width")
+                .and_then(|prop| prop.get_u32())
+                .unwrap_or(1),
+            node.get_property("mmc-hs200-1_8v").is_some()
+                || node.get_property("mmc-ddr-1_8v").is_some()
+                || node.get_property("sd-uhs-sdr104").is_some()
+                || node.get_property("sd-uhs-sdr50").is_some()
+                || node.get_property("sd-uhs-ddr50").is_some()
+                || node.get_property("sd-uhs-sdr25").is_some()
+                || node.get_property("sd-uhs-sdr12").is_some(),
+            node.get_property("no-sd").is_some(),
+            node.get_property("no-mmc").is_some(),
+            node.get_property("non-removable").is_some(),
+            node.get_property("cap-mmc-hw-reset").is_some()
+                || node.get_property("mmc-hs200-1_8v").is_some()
+                || node.get_property("mmc-hs400-1_8v").is_some()
+                || node.get_property("mmc-ddr-1_8v").is_some(),
+        )
+    }
+
+    fn from_dt_flags(
+        reference_clock_hz: u32,
+        bus_width: u32,
+        supports_1v8: bool,
+        no_sd: bool,
+        no_mmc: bool,
+        non_removable: bool,
+        has_mmc_capability: bool,
+    ) -> Self {
+        let max_bus_width = match bus_width {
+            8.. => BusWidth::Bit8,
+            4.. => BusWidth::Bit4,
+            _ => BusWidth::Bit1,
+        };
+        let host_config = Jh7110DwMmcConfig::default()
+            .with_reference_clock_hz(reference_clock_hz)
+            .with_max_bus_width(max_bus_width)
+            .with_1v8_support(supports_1v8);
+        let init_preference = if no_mmc {
+            CardInitPreference::SdOnly
+        } else if no_sd
+            || matches!(max_bus_width, BusWidth::Bit8)
+            || (non_removable && has_mmc_capability)
+        {
+            CardInitPreference::MmcFirst
+        } else {
+            CardInitPreference::SdFirst
+        };
+
+        Self {
+            host_config,
+            init_preference,
+        }
+    }
+}
+
+fn starfive_block_config(capacity_blocks: u64) -> BlockConfig {
+    starfive_rdif::fifo_config(capacity_blocks, true)
+}
+
+fn prepared_reference_clock_hz(clock_rate: Option<u64>) -> u32 {
+    let reference_clock_hz = clock_rate
+        .and_then(|hz| u32::try_from(hz).ok())
+        .filter(|hz| *hz != 0)
+        .unwrap_or(JH7110_STABLE_REFERENCE_CLOCK_HZ);
+    info!(
+        "starfive-jh7110-dwmmc: using {} Hz ciu reference clock prepared rate {:?}",
+        reference_clock_hz, clock_rate
+    );
+    reference_clock_hz
+}
+
+fn poll_card_init(
+    sd: &mut StarFiveDwMmc,
+    init_preference: CardInitPreference,
+) -> Result<CardInfo, Error> {
     let mut scratch = SdioInitScratch::new();
-    let mut request = sd.submit_init(&mut scratch)?;
+    let mut request = sd.submit_init_with_preference(init_preference, &mut scratch)?;
     loop {
         match sd.poll_init_request(&mut request)? {
             OperationPoll::Pending => {
@@ -159,12 +223,136 @@ fn is_absent_card_init_error(err: Error) -> bool {
     match err {
         Error::NoCard => true,
         Error::Timeout(ctx) | Error::Crc(ctx) | Error::BadResponse(ctx) => {
-            ctx.cmd.is_some()
-                && matches!(
-                    ctx.phase,
-                    Phase::CommandSend | Phase::ResponseWait | Phase::Init
-                )
+            matches!(ctx.phase, Phase::Unspecified) && ctx.cmd.is_none()
+                || ctx.cmd.is_some()
+                    && matches!(
+                        ctx.phase,
+                        Phase::CommandSend | Phase::ResponseWait | Phase::Init
+                    )
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axklib::{
+        AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuMask, IrqHandle,
+        IrqId, Klib, PhysAddr, VirtAddr, impl_trait,
+    };
+
+    use super::*;
+
+    struct KlibImpl;
+
+    impl_trait! {
+        impl Klib for KlibImpl {
+            fn mem_iomap(_addr: PhysAddr, _size: usize) -> AxResult<VirtAddr> {
+                Err(AxError::Unsupported)
+            }
+
+            fn mem_virt_to_phys(addr: VirtAddr) -> PhysAddr {
+                PhysAddr::from_usize(addr.as_usize())
+            }
+
+            fn mem_make_dma_coherent_uncached(_addr: VirtAddr, _size: usize) -> AxResult {
+                Err(AxError::Unsupported)
+            }
+
+            fn mem_restore_dma_cached(_addr: VirtAddr, _size: usize) -> AxResult {
+                Err(AxError::Unsupported)
+            }
+
+            fn dma_alloc_pages(
+                _dma_mask: u64,
+                _num_pages: usize,
+                _align: usize,
+            ) -> AxResult<VirtAddr> {
+                Err(AxError::Unsupported)
+            }
+
+            fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+
+            fn time_busy_wait(_dur: core::time::Duration) {}
+
+            fn time_monotonic_nanos() -> u64 {
+                0
+            }
+
+            fn time_try_init_epoch_offset(_epoch_time_nanos: u64) -> bool {
+                false
+            }
+
+            fn irq_set_enable(_irq: IrqId, _enabled: bool) -> AxResult {
+                Ok(())
+            }
+
+            fn irq_request_shared(
+                _irq: IrqId,
+                _handler: BoxedIrqHandler,
+            ) -> AxResult<IrqHandle> {
+                Err(AxError::Unsupported)
+            }
+
+            fn irq_request_shared_disabled(
+                _irq: IrqId,
+                _handler: BoxedIrqHandler,
+            ) -> AxResult<IrqHandle> {
+                Err(AxError::Unsupported)
+            }
+
+            fn irq_request_percpu(
+                _irq: IrqId,
+                _cpus: IrqCpuMask,
+                _handler: ConcurrentBoxedIrqHandler,
+            ) -> AxResult<IrqHandle> {
+                Err(AxError::Unsupported)
+            }
+
+            fn irq_free(_handle: IrqHandle) -> AxResult {
+                Err(AxError::Unsupported)
+            }
+
+            fn irq_enable(_handle: IrqHandle) -> AxResult {
+                Err(AxError::Unsupported)
+            }
+
+            fn irq_disable(_handle: IrqHandle) -> AxResult {
+                Err(AxError::Unsupported)
+            }
+        }
+    }
+
+    #[test]
+    fn starfive_block_config_is_irq_driven_fifo() {
+        let config = starfive_block_config(16);
+
+        assert_eq!(config.name, "starfive-jh7110-mmc");
+        assert_eq!(config.capacity_blocks, 16);
+        assert!(config.irq_driven);
+        assert!(!config.uses_dma());
+    }
+
+    #[test]
+    fn starfive_profiles_are_dt_capability_driven_not_base_driven() {
+        let emmc =
+            StarFiveMmcNodeProfile::from_dt_flags(50_000_000, 8, true, false, false, true, true);
+        let microsd =
+            StarFiveMmcNodeProfile::from_dt_flags(50_000_000, 4, false, false, true, false, false);
+
+        assert_eq!(emmc.host_config.max_bus_width(), BusWidth::Bit8);
+        assert!(emmc.host_config.supports_1v8());
+        assert_eq!(emmc.init_preference, CardInitPreference::MmcFirst);
+
+        assert_eq!(microsd.host_config.max_bus_width(), BusWidth::Bit4);
+        assert!(!microsd.host_config.supports_1v8());
+        assert_eq!(microsd.init_preference, CardInitPreference::SdOnly);
+    }
+
+    #[test]
+    fn contextless_init_timeout_is_treated_as_absent_card() {
+        assert!(is_absent_card_init_error(Error::Timeout(
+            sdmmc_protocol::ErrorContext::default()
+        )));
     }
 }

--- a/drivers/ax-driver/src/lib.rs
+++ b/drivers/ax-driver/src/lib.rs
@@ -83,7 +83,8 @@ pub mod serial;
 #[cfg(any(
     feature = "rockchip-soc",
     feature = "rockchip-pm",
-    feature = "rockchip-dwmmc"
+    feature = "rockchip-dwmmc",
+    feature = "starfive-soc"
 ))]
 pub mod soc;
 #[cfg(feature = "rtc")]

--- a/drivers/ax-driver/src/soc/mod.rs
+++ b/drivers/ax-driver/src/soc/mod.rs
@@ -18,6 +18,8 @@ mod fixed_regulator;
 mod rockchip;
 #[cfg(feature = "rockchip-dwmmc")]
 pub mod scmi;
+#[cfg(feature = "starfive-soc")]
+mod starfive;
 
 #[cfg(feature = "rockchip-soc")]
 pub use rockchip::{

--- a/drivers/ax-driver/src/soc/starfive/mod.rs
+++ b/drivers/ax-driver/src/soc/starfive/mod.rs
@@ -1,0 +1,1 @@
+mod syscrg;

--- a/drivers/ax-driver/src/soc/starfive/syscrg.rs
+++ b/drivers/ax-driver/src/soc/starfive/syscrg.rs
@@ -1,0 +1,354 @@
+use core::ptr::NonNull;
+
+use log::info;
+use rdrive::{
+    DriverGeneric, KError,
+    probe::OnProbeError,
+    register::{FdtInfo, ProbeFdt},
+};
+use tock_registers::{
+    interfaces::{ReadWriteable, Readable, Writeable},
+    register_bitfields, register_structs,
+    registers::{ReadOnly, ReadWrite},
+};
+
+use crate::mmio::iomap;
+
+const JH7110_SYSCLK_SDIO0_AHB: usize = 91;
+const JH7110_SYSCLK_SDIO1_AHB: usize = 92;
+const JH7110_SYSCLK_SDIO0_SDCARD: usize = 93;
+const JH7110_SYSCLK_SDIO1_SDCARD: usize = 94;
+const JH7110_SYSCLK_END: usize = 190;
+
+const JH7110_SYSRST_SDIO0_AHB: u64 = 64;
+const JH7110_SYSRST_SDIO1_AHB: u64 = 65;
+const JH7110_SYSRST_END: u64 = 126;
+const JH7110_SYSRST_WORDS: usize = JH7110_SYSRST_END.div_ceil(u32::BITS as u64) as usize;
+
+const SDIO_SDCARD_PARENT_HZ: u64 = 400_000_000;
+const SDIO_SDCARD_MAX_DIV: u32 = 15;
+const RESET_STATUS_POLL_LIMIT: usize = 1_000;
+
+register_bitfields! [
+    u32,
+    ClockControl [
+        DIV OFFSET(0) NUMBITS(24) [],
+        ENABLE OFFSET(31) NUMBITS(1) []
+    ]
+];
+
+register_structs! {
+    Jh7110SysClockRegisters {
+        (0x000 => controls: [ReadWrite<u32, ClockControl::Register>; JH7110_SYSCLK_END]),
+        (0x2f8 => @END),
+    }
+}
+
+register_structs! {
+    Jh7110SysResetRegisters {
+        (0x000 => _reserved0),
+        (0x2f8 => assert: [ReadWrite<u32>; JH7110_SYSRST_WORDS]),
+        (0x308 => status: [ReadOnly<u32>; JH7110_SYSRST_WORDS]),
+        (0x318 => @END),
+    }
+}
+
+crate::model_register!(
+    name: "StarFive JH7110 Clock Generator",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["starfive,jh7110-clkgen"],
+            on_probe: probe_clkgen
+        }
+    ],
+);
+
+crate::model_register!(
+    name: "StarFive JH7110 Reset Controller",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["starfive,jh7110-reset"],
+            on_probe: probe_reset
+        }
+    ],
+);
+
+struct Jh7110SysClock {
+    base: NonNull<Jh7110SysClockRegisters>,
+}
+
+struct Jh7110SysReset {
+    base: NonNull<Jh7110SysResetRegisters>,
+}
+
+unsafe impl Send for Jh7110SysClock {}
+unsafe impl Send for Jh7110SysReset {}
+
+impl Jh7110SysClock {
+    fn new(base: NonNull<u8>) -> Self {
+        Self { base: base.cast() }
+    }
+
+    fn regs(&self) -> &Jh7110SysClockRegisters {
+        unsafe { self.base.as_ref() }
+    }
+
+    fn control(&self, id: usize) -> Result<&ReadWrite<u32, ClockControl::Register>, KError> {
+        if supported_sdio_clock(id) {
+            Ok(&self.regs().controls[id])
+        } else {
+            Err(KError::InvalidArg { name: "clock_id" })
+        }
+    }
+
+    fn set_sdcard_rate(&mut self, id: usize, rate: u64) -> Result<u64, KError> {
+        if !matches!(id, JH7110_SYSCLK_SDIO0_SDCARD | JH7110_SYSCLK_SDIO1_SDCARD) || rate == 0 {
+            return Err(KError::InvalidArg { name: "clock_id" });
+        }
+
+        let div = divider_for_rate(rate);
+        self.control(id)?.modify(ClockControl::DIV.val(div));
+        Ok(SDIO_SDCARD_PARENT_HZ / u64::from(div))
+    }
+}
+
+impl DriverGeneric for Jh7110SysClock {
+    fn name(&self) -> &str {
+        "jh7110-syscrg-clock"
+    }
+}
+
+impl rdif_clk::Interface for Jh7110SysClock {
+    fn perper_enable(&mut self) {}
+
+    fn enable(&mut self, id: rdif_clk::ClockId) -> Result<(), KError> {
+        let id = clock_id(id)?;
+        self.control(id)?.modify(ClockControl::ENABLE::SET);
+        Ok(())
+    }
+
+    fn get_rate(&self, id: rdif_clk::ClockId) -> Result<u64, KError> {
+        let id = clock_id(id)?;
+        if !matches!(id, JH7110_SYSCLK_SDIO0_SDCARD | JH7110_SYSCLK_SDIO1_SDCARD) {
+            return Err(KError::InvalidArg { name: "clock_id" });
+        }
+
+        let div = self.control(id)?.read(ClockControl::DIV);
+        if div == 0 {
+            return Ok(0);
+        }
+        Ok(SDIO_SDCARD_PARENT_HZ / u64::from(div))
+    }
+
+    fn set_rate(&mut self, id: rdif_clk::ClockId, rate: u64) -> Result<(), KError> {
+        self.set_sdcard_rate(clock_id(id)?, rate)?;
+        Ok(())
+    }
+}
+
+impl Jh7110SysReset {
+    fn new(base: NonNull<u8>) -> Self {
+        Self { base: base.cast() }
+    }
+
+    fn regs(&self) -> &Jh7110SysResetRegisters {
+        unsafe { self.base.as_ref() }
+    }
+
+    fn reset_word_bit(id: rdif_reset::ResetId) -> Result<(usize, u32), rdif_reset::ResetError> {
+        let raw = id.raw();
+        if !matches!(raw, JH7110_SYSRST_SDIO0_AHB | JH7110_SYSRST_SDIO1_AHB) {
+            return Err(rdif_reset::ResetError::InvalidId);
+        }
+        Ok((
+            (raw / u64::from(u32::BITS)) as usize,
+            1_u32 << (raw % u64::from(u32::BITS)),
+        ))
+    }
+
+    fn update(
+        &mut self,
+        id: rdif_reset::ResetId,
+        assert: bool,
+    ) -> Result<(), rdif_reset::ResetError> {
+        let (word, mask) = Self::reset_word_bit(id)?;
+        let assert_reg = &self.regs().assert[word];
+        let value = assert_reg.get();
+        if assert {
+            assert_reg.set(value | mask);
+            self.poll_status(word, mask, false)
+        } else {
+            assert_reg.set(value & !mask);
+            self.poll_status(word, mask, true)
+        }
+    }
+
+    fn poll_status(
+        &self,
+        word: usize,
+        mask: u32,
+        deasserted: bool,
+    ) -> Result<(), rdif_reset::ResetError> {
+        for _ in 0..RESET_STATUS_POLL_LIMIT {
+            let status = self.regs().status[word].get() & mask != 0;
+            if status == deasserted {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(rdif_reset::ResetError::Controller)
+    }
+}
+
+impl DriverGeneric for Jh7110SysReset {
+    fn name(&self) -> &str {
+        "jh7110-syscrg-reset"
+    }
+}
+
+impl rdif_reset::Interface for Jh7110SysReset {
+    fn assert(&mut self, id: rdif_reset::ResetId) -> Result<(), rdif_reset::ResetError> {
+        self.update(id, true)
+    }
+
+    fn deassert(&mut self, id: rdif_reset::ResetId) -> Result<(), rdif_reset::ResetError> {
+        self.update(id, false)
+    }
+}
+
+fn probe_clkgen(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let (info, plat_dev) = probe.into_parts();
+    let base = map_first_reg(&info)?;
+    plat_dev.register(rdif_clk::Clk::new(Jh7110SysClock::new(base)));
+    info!("StarFive JH7110 SYS clock provider registered");
+    Ok(())
+}
+
+fn probe_reset(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let (info, plat_dev) = probe.into_parts();
+    let base = map_first_reg(&info)?;
+    plat_dev.register(rdif_reset::Reset::new(Jh7110SysReset::new(base)));
+    info!("StarFive JH7110 SYS reset provider registered");
+    Ok(())
+}
+
+fn map_first_reg(info: &FdtInfo<'_>) -> Result<NonNull<u8>, OnProbeError> {
+    let reg =
+        info.node.regs().into_iter().next().ok_or_else(|| {
+            OnProbeError::other(alloc::format!("[{}] has no reg", info.node.name()))
+        })?;
+    iomap(reg.address as usize, reg.size.unwrap_or(0x10000) as usize)
+}
+
+fn supported_sdio_clock(id: usize) -> bool {
+    matches!(
+        id,
+        JH7110_SYSCLK_SDIO0_AHB
+            | JH7110_SYSCLK_SDIO1_AHB
+            | JH7110_SYSCLK_SDIO0_SDCARD
+            | JH7110_SYSCLK_SDIO1_SDCARD
+    )
+}
+
+fn clock_id(id: rdif_clk::ClockId) -> Result<usize, KError> {
+    let id = id.raw();
+    if supported_sdio_clock(id) {
+        Ok(id)
+    } else {
+        Err(KError::InvalidArg { name: "clock_id" })
+    }
+}
+
+fn divider_for_rate(rate: u64) -> u32 {
+    let rounded = (SDIO_SDCARD_PARENT_HZ + rate / 2) / rate;
+    u32::try_from(rounded)
+        .unwrap_or(SDIO_SDCARD_MAX_DIV)
+        .clamp(1, SDIO_SDCARD_MAX_DIV)
+}
+
+#[cfg(test)]
+mod tests {
+    use rdif_clk::Interface as _;
+    use rdif_reset::Interface as _;
+
+    use super::*;
+
+    fn fake_syscrg() -> (alloc::vec::Vec<u32>, NonNull<u8>) {
+        let mut regs = alloc::vec![0_u32; 0x10000 / core::mem::size_of::<u32>()];
+        let base = NonNull::new(regs.as_mut_ptr().cast::<u8>()).unwrap();
+        (regs, base)
+    }
+
+    #[test]
+    fn sdio_clock_enable_and_rate_use_jh71x0_control_fields() {
+        let (regs, base) = fake_syscrg();
+        let mut clock = Jh7110SysClock::new(base);
+
+        clock
+            .set_rate(
+                rdif_clk::ClockId::from(JH7110_SYSCLK_SDIO1_SDCARD),
+                50_000_000,
+            )
+            .unwrap();
+        clock
+            .enable(rdif_clk::ClockId::from(JH7110_SYSCLK_SDIO1_AHB))
+            .unwrap();
+        clock
+            .enable(rdif_clk::ClockId::from(JH7110_SYSCLK_SDIO1_SDCARD))
+            .unwrap();
+
+        assert_eq!(regs[JH7110_SYSCLK_SDIO1_SDCARD] & ClockControl::DIV.mask, 8);
+        assert_ne!(
+            regs[JH7110_SYSCLK_SDIO1_AHB] & ClockControl::ENABLE::SET.value,
+            0
+        );
+        assert_eq!(
+            regs[JH7110_SYSCLK_SDIO1_SDCARD] & ClockControl::ENABLE::SET.value,
+            ClockControl::ENABLE::SET.value
+        );
+        assert_eq!(
+            clock
+                .get_rate(rdif_clk::ClockId::from(JH7110_SYSCLK_SDIO1_SDCARD))
+                .unwrap(),
+            50_000_000
+        );
+    }
+
+    #[test]
+    fn sys_reset_deassert_clears_assert_bit_for_sdio1() {
+        let (mut regs, base) = fake_syscrg();
+        let word = (JH7110_SYSRST_SDIO1_AHB / u64::from(u32::BITS)) as usize;
+        let bit = 1_u32 << (JH7110_SYSRST_SDIO1_AHB % u64::from(u32::BITS));
+        let assert_index = 0x2f8 / core::mem::size_of::<u32>() + word;
+        let status_index = 0x308 / core::mem::size_of::<u32>() + word;
+        regs[assert_index] = bit;
+        regs[status_index] = bit;
+
+        let mut reset = Jh7110SysReset::new(base);
+        reset
+            .deassert(rdif_reset::ResetId::new(JH7110_SYSRST_SDIO1_AHB))
+            .unwrap();
+
+        assert_eq!(regs[assert_index] & bit, 0);
+    }
+
+    #[test]
+    fn unsupported_clock_and_reset_ids_are_rejected() {
+        let (_regs, base) = fake_syscrg();
+        let mut clock = Jh7110SysClock::new(base);
+        let mut reset = Jh7110SysReset::new(base);
+
+        assert!(matches!(
+            clock.enable(rdif_clk::ClockId::from(1_usize)),
+            Err(KError::InvalidArg { name: "clock_id" })
+        ));
+        assert_eq!(
+            reset.deassert(rdif_reset::ResetId::new(1)),
+            Err(rdif_reset::ResetError::InvalidId)
+        );
+    }
+}

--- a/drivers/blk/dwmmc-host/src/command.rs
+++ b/drivers/blk/dwmmc-host/src/command.rs
@@ -211,20 +211,7 @@ impl DwMmc {
     }
 
     fn take_command_irq_status(&mut self) -> u32 {
-        if self.completion_irq_enabled() {
-            return self
-                .irq
-                .state
-                .take(crate::DWMMC_INT_COMMAND_DONE | crate::DWMMC_INT_ERROR_MASK);
-        }
-        let raw_status = self.regs.rintsts().read().into_bits();
-        let consume = raw_status & (crate::DWMMC_INT_COMMAND_DONE | crate::DWMMC_INT_ERROR_MASK);
-        if consume != 0 {
-            self.regs
-                .rintsts()
-                .write(crate::regs::RIntSts::from_bits(consume));
-        }
-        raw_status
+        self.take_task_irq_status(crate::DWMMC_INT_COMMAND_DONE | crate::DWMMC_INT_ERROR_MASK)
     }
 
     fn clear_command_int_status(&mut self) {

--- a/drivers/blk/dwmmc-host/src/dma.rs
+++ b/drivers/blk/dwmmc-host/src/dma.rs
@@ -137,11 +137,11 @@ enum BlockRequestKind {
         id: RequestId,
         buffer: NonNull<u8>,
         len: usize,
-        block_size: usize,
         offset: usize,
         cmd_index: u8,
         phase: Phase,
         stage: BlockRequestStage,
+        transfer_done: bool,
         stop_after_complete: bool,
         response: Option<Response>,
     },
@@ -149,11 +149,11 @@ enum BlockRequestKind {
         id: RequestId,
         buffer: NonNull<u8>,
         len: usize,
-        block_size: usize,
         offset: usize,
         cmd_index: u8,
         phase: Phase,
         stage: BlockRequestStage,
+        transfer_done: bool,
         stop_after_complete: bool,
         response: Option<Response>,
     },
@@ -852,11 +852,11 @@ impl DwMmc {
                 id,
                 buffer,
                 len,
-                block_size: block_size_usize,
                 offset: 0,
                 cmd_index: cmd.index,
                 phase,
                 stage: BlockRequestStage::Command,
+                transfer_done: false,
                 stop_after_complete,
                 response: None,
             },
@@ -864,11 +864,11 @@ impl DwMmc {
                 id,
                 buffer,
                 len,
-                block_size: block_size_usize,
                 offset: 0,
                 cmd_index: cmd.index,
                 phase,
                 stage: BlockRequestStage::Command,
+                transfer_done: false,
                 stop_after_complete,
                 response: None,
             },
@@ -1184,17 +1184,17 @@ impl DwMmc {
             BlockRequestKind::FifoRead {
                 buffer,
                 len,
-                block_size,
                 offset,
+                transfer_done,
                 ..
-            } => poll_fifo_read_step(self, *buffer, *len, *block_size, offset, cmd_index, phase),
+            } => poll_fifo_read_step(self, *buffer, *len, offset, transfer_done, cmd_index, phase),
             BlockRequestKind::FifoWrite {
                 buffer,
                 len,
-                block_size,
                 offset,
+                transfer_done,
                 ..
-            } => poll_fifo_write_step(self, *buffer, *len, *block_size, offset, cmd_index, phase),
+            } => poll_fifo_write_step(self, *buffer, *len, offset, transfer_done, cmd_index, phase),
             _ => Err(Error::InvalidArgument),
         }
     }
@@ -1344,22 +1344,7 @@ impl DwMmc {
             | crate::DWMMC_INT_RXDR
             | crate::DWMMC_INT_TXDR
             | crate::DWMMC_INT_ERROR_MASK;
-        if self.completion_irq_enabled() {
-            return self.irq.state.take(consume);
-        }
-        let raw_status = self.regs.rintsts().read().into_bits();
-        let clear = raw_status
-            & (crate::DWMMC_INT_DATA_TRANSFER_OVER
-                | crate::DWMMC_INT_COMMAND_DONE
-                | crate::DWMMC_INT_RXDR
-                | crate::DWMMC_INT_TXDR
-                | crate::DWMMC_INT_ERROR_MASK);
-        if clear != 0 {
-            self.regs
-                .rintsts()
-                .write(crate::regs::RIntSts::from_bits(clear));
-        }
-        raw_status
+        self.take_task_irq_status(consume)
     }
 }
 
@@ -1383,8 +1368,8 @@ fn poll_fifo_read_step(
     host: &mut DwMmc,
     buffer: NonNull<u8>,
     len: usize,
-    _block_size: usize,
     offset: &mut usize,
+    transfer_done: &mut bool,
     cmd_index: u8,
     phase: Phase,
 ) -> Result<BlockPoll, Error> {
@@ -1395,12 +1380,13 @@ fn poll_fifo_read_step(
         let _ = host.reset_fifo();
         return Err(err);
     }
+    *transfer_done |= rintsts.data_transfer_over();
 
     let fifo = host.fifo_ptr();
     let mut status = host.regs.status().read();
-    while *offset < len && status.fifo_count() >= 2 {
+    while *offset < len && status.fifo_count() != 0 {
         let value = unsafe { fifo.read_volatile() };
-        let end = (*offset + 8).min(len);
+        let end = (*offset + 4).min(len);
         let block =
             unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr().add(*offset), end - *offset) };
         block.copy_from_slice(&value.to_le_bytes()[..block.len()]);
@@ -1408,9 +1394,10 @@ fn poll_fifo_read_step(
         status = host.regs.status().read();
     }
 
-    if *offset >= len && rintsts.data_transfer_over() {
+    if *offset >= len && *transfer_done {
         return Ok(BlockPoll::Complete);
     }
+    host.program_fifo_interrupt_mask();
     Ok(BlockPoll::Pending)
 }
 
@@ -1418,8 +1405,8 @@ fn poll_fifo_write_step(
     host: &mut DwMmc,
     buffer: NonNull<u8>,
     len: usize,
-    _block_size: usize,
     offset: &mut usize,
+    transfer_done: &mut bool,
     cmd_index: u8,
     phase: Phase,
 ) -> Result<BlockPoll, Error> {
@@ -1430,21 +1417,23 @@ fn poll_fifo_write_step(
         let _ = host.reset_fifo();
         return Err(err);
     }
+    *transfer_done |= rintsts.data_transfer_over();
 
     let fifo = host.fifo_ptr();
     while *offset < len && !host.regs.status().read().fifo_full() {
-        let end = (*offset + 8).min(len);
+        let end = (*offset + 4).min(len);
         let block =
             unsafe { core::slice::from_raw_parts(buffer.as_ptr().add(*offset), end - *offset) };
-        let mut bytes = [0u8; 8];
+        let mut bytes = [0u8; 4];
         bytes[..block.len()].copy_from_slice(block);
-        unsafe { fifo.write_volatile(u64::from_le_bytes(bytes)) };
+        unsafe { fifo.write_volatile(u32::from_le_bytes(bytes)) };
         *offset = end;
     }
 
-    if *offset >= len && rintsts.data_transfer_over() {
+    if *offset >= len && *transfer_done {
         return Ok(BlockPoll::Complete);
     }
+    host.program_fifo_interrupt_mask();
     Ok(BlockPoll::Pending)
 }
 
@@ -1605,11 +1594,11 @@ mod tests {
                 id,
                 buffer: NonNull::new(buffer.as_mut_ptr()).unwrap(),
                 len: buffer.len(),
-                block_size: BLOCK_SIZE,
                 offset: buffer.len(),
                 cmd_index: cmd.index,
                 phase: Phase::DataRead,
                 stage: BlockRequestStage::Command,
+                transfer_done: false,
                 stop_after_complete: false,
                 response: None,
             },
@@ -1621,5 +1610,89 @@ mod tests {
         ));
         assert!(request.is_none());
         assert_eq!(host.irq.state.pending(), 0);
+    }
+
+    #[test]
+    fn irq_enabled_task_poll_can_consume_raw_status_before_top_half_runs() {
+        let mut mmio = [0u32; 256];
+        let base = NonNull::new(mmio.as_mut_ptr().cast()).unwrap();
+        let mut host = unsafe { DwMmc::new(base) };
+        const RINTSTS_WORD: usize = 17;
+        let raw = crate::regs::RIntSts::new()
+            .with_data_transfer_over(true)
+            .with_receive_fifo_data_request(true)
+            .into_bits();
+
+        host.enable_completion_irq();
+        host.irq.state.begin_request();
+        unsafe {
+            mmio.as_mut_ptr().add(RINTSTS_WORD).write_volatile(raw);
+        }
+
+        assert_eq!(host.take_data_irq_status(), raw);
+        assert_eq!(host.irq.state.pending(), 0);
+
+        let cleared = unsafe { mmio.as_ptr().add(RINTSTS_WORD).read_volatile() };
+        assert_eq!(cleared, raw);
+    }
+
+    #[test]
+    fn fifo_read_latches_dto_until_buffer_is_drained() {
+        let mut mmio = [0u32; 256];
+        let base = NonNull::new(mmio.as_mut_ptr().cast()).unwrap();
+        let mut host = unsafe { DwMmc::new(base) };
+        const RINTSTS_WORD: usize = 17;
+        const STATUS_WORD: usize = 18;
+        const FIFO_WORD: usize = 128;
+        let mut buffer = [0u8; 4];
+        let mut offset = 0;
+        let mut transfer_done = false;
+        let dto = crate::regs::RIntSts::new()
+            .with_data_transfer_over(true)
+            .into_bits();
+
+        unsafe {
+            mmio.as_mut_ptr().add(RINTSTS_WORD).write_volatile(dto);
+            mmio.as_mut_ptr()
+                .add(STATUS_WORD)
+                .write_volatile(crate::regs::Status::new().with_fifo_count(0).into_bits());
+        }
+
+        assert!(matches!(
+            poll_fifo_read_step(
+                &mut host,
+                NonNull::new(buffer.as_mut_ptr()).unwrap(),
+                buffer.len(),
+                &mut offset,
+                &mut transfer_done,
+                17,
+                Phase::DataRead,
+            ),
+            Ok(BlockPoll::Pending)
+        ));
+        assert_eq!(offset, 0);
+        assert!(transfer_done);
+
+        unsafe {
+            mmio.as_mut_ptr().add(RINTSTS_WORD).write_volatile(0);
+            mmio.as_mut_ptr()
+                .add(STATUS_WORD)
+                .write_volatile(crate::regs::Status::new().with_fifo_count(1).into_bits());
+            mmio.as_mut_ptr().add(FIFO_WORD).write_volatile(0x0403_0201);
+        }
+
+        assert!(matches!(
+            poll_fifo_read_step(
+                &mut host,
+                NonNull::new(buffer.as_mut_ptr()).unwrap(),
+                buffer.len(),
+                &mut offset,
+                &mut transfer_done,
+                17,
+                Phase::DataRead,
+            ),
+            Ok(BlockPoll::Complete)
+        ));
+        assert_eq!(buffer, [1, 2, 3, 4]);
     }
 }

--- a/drivers/blk/dwmmc-host/src/host.rs
+++ b/drivers/blk/dwmmc-host/src/host.rs
@@ -541,6 +541,21 @@ impl DwMmc {
         self.regs.rintsts().write(RIntSts::from_bits(ALL_INT_CLR));
     }
 
+    pub(crate) fn take_task_irq_status(&mut self, mask: u32) -> u32 {
+        if self.completion_irq_enabled() {
+            let cached = self.irq.state.take(mask);
+            if cached != 0 {
+                return cached;
+            }
+        }
+        let raw_status = self.regs.rintsts().read().into_bits();
+        let clear = raw_status & mask;
+        if clear != 0 {
+            self.regs.rintsts().write(RIntSts::from_bits(clear));
+        }
+        raw_status
+    }
+
     pub(crate) fn program_linux_init_baseline(&self) {
         self.regs.tmout().write(DEFAULT_TMOUT);
         self.regs.fifoth().write(DEFAULT_FIFOTH);
@@ -666,8 +681,8 @@ impl DwMmc {
     }
 
     /// Raw pointer at `base + fifo_offset`, used for FIFO data accesses.
-    pub(crate) fn fifo_ptr(&self) -> *mut u64 {
-        (self.base_addr + self.fifo_offset) as *mut u64
+    pub(crate) fn fifo_ptr(&self) -> *mut u32 {
+        (self.base_addr + self.fifo_offset) as *mut u32
     }
 }
 

--- a/drivers/blk/dwmmc-host/src/lib.rs
+++ b/drivers/blk/dwmmc-host/src/lib.rs
@@ -1343,6 +1343,11 @@ fn handle_irq_core(irq: &host::IrqCore) -> Event {
             .rintsts()
             .write(crate::regs::RIntSts::from_bits(raw_status));
     }
+    let fifo_ready = raw_status & (crate::DWMMC_INT_RXDR | crate::DWMMC_INT_TXDR);
+    if fifo_ready != 0 {
+        let mask = irq.regs.intmask().read();
+        irq.regs.intmask().write(mask & !fifo_ready);
+    }
     let idmac_status = irq.regs.idsts().read();
     if idmac_status & (DWMMC_IDMAC_INT_TI | DWMMC_IDMAC_INT_RI) != 0 {
         irq.regs
@@ -1571,6 +1576,41 @@ mod tests {
 
         let intmask = unsafe { mmio.as_ptr().add(INTMASK_WORD).read_volatile() };
         assert_eq!(intmask, dma_mask);
+
+        host.program_fifo_interrupt_mask();
+
+        let intmask = unsafe { mmio.as_ptr().add(INTMASK_WORD).read_volatile() };
+        assert_eq!(intmask, fifo_mask);
+    }
+
+    #[test]
+    fn fifo_ready_irq_is_masked_until_task_side_drain() {
+        let mut mmio = [0u32; 256];
+        let base = NonNull::new(mmio.as_mut_ptr().cast()).unwrap();
+        let mut host = unsafe { DwMmc::new(base) };
+        const INTMASK_WORD: usize = 9;
+        const MINTSTS_WORD: usize = 16;
+        let fifo_ready = crate::DWMMC_INT_RXDR | crate::DWMMC_INT_TXDR;
+        let fifo_mask = crate::DWMMC_INT_DATA_TRANSFER_OVER
+            | crate::DWMMC_INT_COMMAND_DONE
+            | crate::DWMMC_INT_ERROR_MASK
+            | fifo_ready;
+
+        host.enable_completion_irq();
+        host.program_fifo_interrupt_mask();
+        host.irq.state.begin_request();
+        unsafe {
+            mmio.as_mut_ptr()
+                .add(MINTSTS_WORD)
+                .write_volatile(fifo_ready);
+        }
+
+        let mut irq = host.irq_endpoint();
+
+        assert_eq!(irq.handle_irq(), Event::ReceiveReady);
+        assert_eq!(host.irq.state.pending(), fifo_ready);
+        let intmask = unsafe { mmio.as_ptr().add(INTMASK_WORD).read_volatile() };
+        assert_eq!(intmask, fifo_mask & !fifo_ready);
 
         host.program_fifo_interrupt_mask();
 

--- a/drivers/blk/starfive-jh7110-dwmmc/Cargo.toml
+++ b/drivers/blk/starfive-jh7110-dwmmc/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "starfive-jh7110-dwmmc"
+version = "0.1.0"
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "StarFive JH7110 DWMMC host wrapper for sdmmc-protocol"
+keywords = ["starfive", "jh7110", "dwmmc", "sdmmc", "no_std"]
+categories = ["embedded", "no-std", "hardware-support"]
+
+[dependencies]
+dma-api.workspace = true
+dwmmc-host.workspace = true
+rdif-block.workspace = true
+sdio-host2.workspace = true
+sdmmc-protocol = { workspace = true, default-features = false, features = ["sdio", "rdif"] }
+log.workspace = true
+
+[features]
+default = []

--- a/drivers/blk/starfive-jh7110-dwmmc/src/lib.rs
+++ b/drivers/blk/starfive-jh7110-dwmmc/src/lib.rs
@@ -1,0 +1,341 @@
+#![no_std]
+
+#[cfg(test)]
+extern crate std;
+
+use core::ptr::NonNull;
+
+use dma_api::CompletedDma;
+use dwmmc_host::{DwMmc, DwMmcIrq, Event};
+use sdio_host2::{
+    BusOp, BusWidth, Error as Host2Error, PollRequestError, RawResponse, RequestPoll, SdioHost,
+    SignalVoltage, SubmitTransactionError, Transaction,
+};
+use sdmmc_protocol::{Error, sdio::host2::SdioHost2Irq};
+
+pub const JH7110_DWMMC_FIFO_OFFSET: usize = 0x200;
+pub const JH7110_STABLE_REFERENCE_CLOCK_HZ: u32 = 50_000_000;
+pub const DEVICE_NAME: &str = "starfive-jh7110-mmc";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Jh7110DwMmcConfig {
+    reference_clock_hz: u32,
+    max_bus_width: BusWidth,
+    supports_1v8: bool,
+}
+
+impl Default for Jh7110DwMmcConfig {
+    fn default() -> Self {
+        Self {
+            reference_clock_hz: JH7110_STABLE_REFERENCE_CLOCK_HZ,
+            max_bus_width: BusWidth::Bit4,
+            supports_1v8: false,
+        }
+    }
+}
+
+impl Jh7110DwMmcConfig {
+    pub const fn new() -> Self {
+        Self {
+            reference_clock_hz: JH7110_STABLE_REFERENCE_CLOCK_HZ,
+            max_bus_width: BusWidth::Bit4,
+            supports_1v8: false,
+        }
+    }
+
+    pub const fn with_reference_clock_hz(mut self, reference_clock_hz: u32) -> Self {
+        self.reference_clock_hz = reference_clock_hz;
+        self
+    }
+
+    pub const fn with_max_bus_width(mut self, max_bus_width: BusWidth) -> Self {
+        self.max_bus_width = max_bus_width;
+        self
+    }
+
+    pub const fn with_1v8_support(mut self, supports_1v8: bool) -> Self {
+        self.supports_1v8 = supports_1v8;
+        self
+    }
+
+    pub const fn reference_clock_hz(&self) -> u32 {
+        if self.reference_clock_hz == 0 {
+            JH7110_STABLE_REFERENCE_CLOCK_HZ
+        } else {
+            self.reference_clock_hz
+        }
+    }
+
+    pub const fn max_bus_width(&self) -> BusWidth {
+        self.max_bus_width
+    }
+
+    pub const fn supports_1v8(&self) -> bool {
+        self.supports_1v8
+    }
+
+    fn validate_bus_op(self, op: BusOp) -> Result<(), Host2Error> {
+        match op {
+            BusOp::SetBusWidth(BusWidth::Bit8) if !matches!(self.max_bus_width, BusWidth::Bit8) => {
+                Err(Host2Error::Unsupported)
+            }
+            BusOp::SetSignalVoltage(SignalVoltage::V180 | SignalVoltage::V120)
+                if !self.supports_1v8 =>
+            {
+                Err(Host2Error::Unsupported)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+pub struct Jh7110DwMmc {
+    inner: DwMmc,
+    config: Jh7110DwMmcConfig,
+}
+
+impl Jh7110DwMmc {
+    /// Construct a JH7110 DWMMC host over an already mapped MMIO register file.
+    ///
+    /// # Safety
+    ///
+    /// `base` must point to a valid JH7110 DWMMC register file that the caller
+    /// has mapped and owns exclusively for the host lifetime.
+    pub unsafe fn new(base: NonNull<u8>, config: Jh7110DwMmcConfig) -> Self {
+        let normalized_config = config
+            .with_reference_clock_hz(config.reference_clock_hz())
+            .with_max_bus_width(config.max_bus_width())
+            .with_1v8_support(config.supports_1v8());
+        let mut inner = unsafe { DwMmc::new_with_fifo_offset(base, JH7110_DWMMC_FIFO_OFFSET) };
+        inner.set_reference_clock(normalized_config.reference_clock_hz());
+        Self {
+            inner,
+            config: normalized_config,
+        }
+    }
+
+    pub const fn config(&self) -> Jh7110DwMmcConfig {
+        self.config
+    }
+
+    pub const fn inner(&self) -> &DwMmc {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut DwMmc {
+        &mut self.inner
+    }
+
+    pub fn into_inner(self) -> DwMmc {
+        self.inner
+    }
+
+    pub fn reset_and_init(&mut self) -> Result<(), Error> {
+        self.inner.reset_and_init()
+    }
+}
+
+impl SdioHost for Jh7110DwMmc {
+    type TransactionRequest<'a>
+        = <DwMmc as SdioHost>::TransactionRequest<'a>
+    where
+        Self: 'a;
+
+    type BusRequest = <DwMmc as SdioHost>::BusRequest;
+
+    unsafe fn submit_transaction<'a>(
+        &mut self,
+        transaction: Transaction<'a>,
+    ) -> Result<Self::TransactionRequest<'a>, Host2Error>
+    where
+        Self: 'a,
+    {
+        unsafe { self.inner.submit_transaction(transaction) }
+    }
+
+    unsafe fn submit_transaction_owned<'a>(
+        &mut self,
+        transaction: Transaction<'a>,
+    ) -> Result<Self::TransactionRequest<'a>, SubmitTransactionError<'a>>
+    where
+        Self: 'a,
+    {
+        unsafe { self.inner.submit_transaction_owned(transaction) }
+    }
+
+    fn poll_transaction<'a>(
+        &mut self,
+        request: &mut Self::TransactionRequest<'a>,
+    ) -> Result<RequestPoll<RawResponse>, PollRequestError>
+    where
+        Self: 'a,
+    {
+        self.inner.poll_transaction(request)
+    }
+
+    fn abort_transaction<'a>(
+        &mut self,
+        request: &mut Self::TransactionRequest<'a>,
+    ) -> Result<(), Host2Error>
+    where
+        Self: 'a,
+    {
+        self.inner.abort_transaction(request)
+    }
+
+    fn take_completed_dma<'a>(
+        &mut self,
+        request: &mut Self::TransactionRequest<'a>,
+    ) -> Option<CompletedDma>
+    where
+        Self: 'a,
+    {
+        self.inner.take_completed_dma(request)
+    }
+
+    unsafe fn submit_bus_op(&mut self, op: BusOp) -> Result<Self::BusRequest, Host2Error> {
+        self.config.validate_bus_op(op)?;
+        unsafe { self.inner.submit_bus_op(op) }
+    }
+
+    fn poll_bus_op(
+        &mut self,
+        request: &mut Self::BusRequest,
+    ) -> Result<RequestPoll<()>, PollRequestError> {
+        self.inner.poll_bus_op(request)
+    }
+
+    fn abort_bus_op(&mut self, request: &mut Self::BusRequest) -> Result<(), Host2Error> {
+        self.inner.abort_bus_op(request)
+    }
+
+    fn now_ms(&self) -> Option<u64> {
+        self.inner.now_ms()
+    }
+}
+
+impl SdioHost2Irq for Jh7110DwMmc {
+    type Event = Event;
+    type IrqHandle = DwMmcIrq;
+
+    fn completion_irq_enabled(&self) -> bool {
+        self.inner.completion_irq_enabled()
+    }
+
+    fn enable_completion_irq(&mut self) -> Result<(), Error> {
+        self.inner.enable_completion_irq();
+        Ok(())
+    }
+
+    fn disable_completion_irq(&mut self) -> Result<(), Error> {
+        self.inner.disable_completion_irq();
+        Ok(())
+    }
+
+    fn irq_handle(&mut self) -> Self::IrqHandle {
+        self.inner.irq_endpoint()
+    }
+}
+
+pub mod rdif {
+    pub use rdif_block::{
+        BInterface, BIrqHandler, BOwnedQueue, BQueue, BlkError, IQueue, IQueueOwned, Interface,
+        OwnedRequest, PollError, QueueHandle, Request, RequestId as RdifRequestId,
+        RequestPoll as OwnedRequestPoll, RequestStatus, SubmitError,
+    };
+    pub use sdmmc_protocol::rdif::{config::BlockConfig, device::BlockDevice, queue::BlockQueue};
+    use sdmmc_protocol::sdio::{card::SdioSdmmc, host2::SdioHost2Adapter};
+
+    use crate::{DEVICE_NAME, Jh7110DwMmc};
+
+    pub fn device(
+        card: SdioSdmmc<SdioHost2Adapter<Jh7110DwMmc>>,
+        config: BlockConfig,
+    ) -> BlockDevice<SdioHost2Adapter<Jh7110DwMmc>> {
+        BlockDevice::new(card, config)
+    }
+
+    pub const fn fifo_config(capacity_blocks: u64, irq_driven: bool) -> BlockConfig {
+        BlockConfig::fifo(DEVICE_NAME, capacity_blocks, irq_driven)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ptr::NonNull;
+    use std::{vec, vec::Vec};
+
+    use sdio_host2::{BusOp, BusWidth, SdioHost, SignalVoltage};
+    use sdmmc_protocol::sdio::host2::SdioHost2Irq;
+
+    use super::*;
+
+    fn fake_mmio() -> (Vec<u32>, NonNull<u8>) {
+        let mut regs = vec![0_u32; 256];
+        let ptr = NonNull::new(regs.as_mut_ptr().cast::<u8>()).unwrap();
+        (regs, ptr)
+    }
+
+    #[test]
+    fn default_config_keeps_jh7110_slot_constraints() {
+        let config = Jh7110DwMmcConfig::default();
+
+        assert_eq!(JH7110_DWMMC_FIFO_OFFSET, 0x200);
+        assert_eq!(JH7110_STABLE_REFERENCE_CLOCK_HZ, 50_000_000);
+        assert_eq!(DEVICE_NAME, "starfive-jh7110-mmc");
+        assert_eq!(
+            config.reference_clock_hz(),
+            JH7110_STABLE_REFERENCE_CLOCK_HZ
+        );
+        assert_eq!(config.max_bus_width(), BusWidth::Bit4);
+        assert!(!config.supports_1v8());
+    }
+
+    #[test]
+    fn constructor_applies_reference_clock_and_fifo_offset_policy() {
+        let (_regs, mmio) = fake_mmio();
+        let host = unsafe { Jh7110DwMmc::new(mmio, Jh7110DwMmcConfig::default()) };
+
+        assert_eq!(
+            host.inner().reference_clock(),
+            JH7110_STABLE_REFERENCE_CLOCK_HZ
+        );
+    }
+
+    #[test]
+    fn bus_policy_rejects_8bit_and_1v8_requests() {
+        let (_regs, mmio) = fake_mmio();
+        let mut host = unsafe { Jh7110DwMmc::new(mmio, Jh7110DwMmcConfig::default()) };
+
+        assert!(matches!(
+            unsafe { host.submit_bus_op(BusOp::SetBusWidth(BusWidth::Bit8)) },
+            Err(sdio_host2::Error::Unsupported)
+        ));
+        assert!(matches!(
+            unsafe { host.submit_bus_op(BusOp::SetSignalVoltage(SignalVoltage::V180)) },
+            Err(sdio_host2::Error::Unsupported)
+        ));
+    }
+
+    #[test]
+    fn completion_irq_methods_delegate_to_inner_dwmmc() {
+        let (_regs, mmio) = fake_mmio();
+        let mut host = unsafe { Jh7110DwMmc::new(mmio, Jh7110DwMmcConfig::default()) };
+
+        assert!(!host.completion_irq_enabled());
+        host.enable_completion_irq().unwrap();
+        assert!(host.completion_irq_enabled());
+        host.disable_completion_irq().unwrap();
+        assert!(!host.completion_irq_enabled());
+    }
+
+    #[test]
+    fn rdif_fifo_config_is_irq_driven_without_dma() {
+        let config = rdif::fifo_config(16, true);
+
+        assert_eq!(config.name, DEVICE_NAME);
+        assert_eq!(config.capacity_blocks, 16);
+        assert!(config.irq_driven);
+        assert!(!config.uses_dma());
+    }
+}

--- a/drivers/rdrive/Cargo.toml
+++ b/drivers/rdrive/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { version = "2", default-features = false }
 pcie.workspace = true
 
 rdif-base = { workspace = true }
+rdif-clk = { workspace = true }
 rdif-pinctrl = { workspace = true, features = ["fdt"] }
 rdif-power = { workspace = true }
 rdif-reset = { workspace = true }

--- a/drivers/rdrive/src/probe/fdt/mod.rs
+++ b/drivers/rdrive/src/probe/fdt/mod.rs
@@ -6,8 +6,9 @@ use alloc::{
 use core::ptr::NonNull;
 
 use ax_kspin::SpinNoPreempt as Mutex;
+use fdt_edit::Node;
 pub use fdt_edit::{ClockRef, Fdt, InterruptRef, NodeId, NodeType, Phandle, RegInfo, Status};
-use rdif_pinctrl::PinctrlDevice;
+use rdif_pinctrl::{PinctrlDevice, PinctrlError};
 use spin::Once;
 
 use super::ProbeError;
@@ -56,6 +57,170 @@ pub(crate) fn try_system() -> Option<&'static System> {
 pub struct FdtInfo<'a> {
     pub node: NodeType<'a>,
     phandle_2_device_id: BTreeMap<Phandle, DeviceId>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResourcePrepareConfig {
+    apply_assigned_clocks: bool,
+    enable_clocks: bool,
+    deassert_resets: bool,
+    enable_power_domains: bool,
+    supply_names: Vec<String>,
+    clock_rates: Vec<String>,
+}
+
+impl Default for ResourcePrepareConfig {
+    fn default() -> Self {
+        Self {
+            apply_assigned_clocks: true,
+            enable_clocks: true,
+            deassert_resets: true,
+            enable_power_domains: false,
+            supply_names: Vec::from([String::from("vmmc-supply"), String::from("vqmmc-supply")]),
+            clock_rates: Vec::new(),
+        }
+    }
+}
+
+impl ResourcePrepareConfig {
+    pub fn without_assigned_clocks(mut self) -> Self {
+        self.apply_assigned_clocks = false;
+        self
+    }
+
+    pub fn without_clock_enable(mut self) -> Self {
+        self.enable_clocks = false;
+        self
+    }
+
+    pub fn without_reset_deassert(mut self) -> Self {
+        self.deassert_resets = false;
+        self
+    }
+
+    pub fn without_power_domains(mut self) -> Self {
+        self.enable_power_domains = false;
+        self
+    }
+
+    pub fn with_power_domains(mut self) -> Self {
+        self.enable_power_domains = true;
+        self
+    }
+
+    pub fn with_supply(mut self, name: impl Into<String>) -> Self {
+        self.supply_names.push(name.into());
+        self
+    }
+
+    pub fn with_named_clock_rate(mut self, name: impl Into<String>) -> Self {
+        self.clock_rates.push(name.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ResourcePrepareReport {
+    clock_rates: BTreeMap<String, u64>,
+}
+
+impl ResourcePrepareReport {
+    pub fn clock_rate(&self, name: &str) -> Option<u64> {
+        self.clock_rates.get(name).copied()
+    }
+
+    fn insert_clock_rate(&mut self, name: String, rate: u64) {
+        self.clock_rates.insert(name, rate);
+    }
+}
+
+#[derive(Clone)]
+struct ClockLine {
+    node_name: String,
+    clock_name: Option<String>,
+    device: Device<rdif_clk::Clk>,
+    id: rdif_clk::ClockId,
+}
+
+impl ClockLine {
+    fn from_ref(info: &FdtInfo<'_>, clock: &ClockRef) -> Result<Self, OnProbeError> {
+        let clock_id = clock_selector(info, clock)?;
+        let device_id = info.phandle_to_device_id(clock.phandle).ok_or_else(|| {
+            OnProbeError::other(format!(
+                "[{}] clock {:?} phandle {:?} has no device id",
+                info.node.name(),
+                clock.name,
+                clock.phandle
+            ))
+        })?;
+        let device = crate::get::<rdif_clk::Clk>(device_id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] clock {:?} provider {:?} has no rdif-clk interface: {err}",
+                info.node.name(),
+                clock.name,
+                clock.phandle
+            ))
+        })?;
+        Ok(Self {
+            node_name: info.node.name().to_string(),
+            clock_name: clock.name.clone(),
+            device,
+            id: rdif_clk::ClockId::from(clock_id as usize),
+        })
+    }
+
+    fn enable(&self) -> Result<(), OnProbeError> {
+        let mut clock = self.lock()?;
+        clock.enable(self.id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to enable clock {:?} ({:?}): {err:?}",
+                self.node_name, self.clock_name, self.id
+            ))
+        })
+    }
+
+    fn set_rate(&self, rate: u64) -> Result<(), OnProbeError> {
+        let mut clock = self.lock()?;
+        clock.set_rate(self.id, rate).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to set clock {:?} ({:?}) to {} Hz: {err:?}",
+                self.node_name, self.clock_name, self.id, rate
+            ))
+        })
+    }
+
+    fn rate(&self) -> Result<u64, OnProbeError> {
+        let clock = self.lock()?;
+        clock.get_rate(self.id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to read clock {:?} ({:?}): {err:?}",
+                self.node_name, self.clock_name, self.id
+            ))
+        })
+    }
+
+    fn lock(&self) -> Result<crate::DeviceGuard<rdif_clk::Clk>, OnProbeError> {
+        self.device.lock().map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to lock clock {:?} ({:?}): {err}",
+                self.node_name, self.clock_name, self.id
+            ))
+        })
+    }
+}
+
+fn clock_selector(info: &FdtInfo<'_>, clock: &ClockRef) -> Result<u32, OnProbeError> {
+    if clock.cells == 0 {
+        return Ok(0);
+    }
+    clock.select().ok_or_else(|| {
+        OnProbeError::other(format!(
+            "[{}] clock {:?} provider {:?} has no selector",
+            info.node.name(),
+            clock.name,
+            clock.phandle
+        ))
+    })
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -502,6 +667,41 @@ impl<'a> FdtInfo<'a> {
             .find(|clock| clock.name.as_deref() == Some(name))
     }
 
+    pub fn prepare_resources(
+        &self,
+        config: ResourcePrepareConfig,
+    ) -> Result<ResourcePrepareReport, OnProbeError> {
+        if config.apply_assigned_clocks {
+            apply_assigned_clocks(self)?;
+        }
+        apply_supply_regulators(self, &config.supply_names)?;
+        if config.enable_power_domains {
+            for domain in self.power_domain_lines()? {
+                domain.power_on()?;
+            }
+        }
+        if config.enable_clocks {
+            for clock in self.node.clocks() {
+                ClockLine::from_ref(self, &clock)?.enable()?;
+            }
+        }
+        if config.deassert_resets {
+            for reset in self.reset_lines()? {
+                reset.deassert()?;
+            }
+        }
+
+        let mut report = ResourcePrepareReport::default();
+        for name in config.clock_rates {
+            let Some(clock) = self.find_clk_by_name(&name) else {
+                continue;
+            };
+            let clock = ClockLine::from_ref(self, &clock)?;
+            report.insert_clock_rate(name, clock.rate()?);
+        }
+        Ok(report)
+    }
+
     pub fn resets(&self) -> Result<Vec<ResetRef>, OnProbeError> {
         reset_refs(self.node)
     }
@@ -554,6 +754,125 @@ impl<'a> FdtInfo<'a> {
 
     pub fn interrupts(&self) -> Vec<InterruptRef> {
         self.node.interrupts()
+    }
+}
+
+fn apply_assigned_clocks(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
+    let clocks = clock_refs_from_property(info, "assigned-clocks")?;
+    let rates = info
+        .node
+        .as_node()
+        .get_property("assigned-clock-rates")
+        .map(|prop| prop.get_u32_iter().map(u64::from).collect::<Vec<_>>())
+        .unwrap_or_default();
+    for (index, clock) in clocks.into_iter().enumerate() {
+        let Some(rate) = rates.get(index).copied() else {
+            continue;
+        };
+        if rate == 0 {
+            continue;
+        }
+        ClockLine::from_ref(info, &clock)?.set_rate(rate)?;
+    }
+    Ok(())
+}
+
+fn clock_refs_from_property(
+    info: &FdtInfo<'_>,
+    property_name: &'static str,
+) -> Result<Vec<ClockRef>, OnProbeError> {
+    let Some(prop) = info.node.as_node().get_property(property_name) else {
+        return Ok(Vec::new());
+    };
+    let mut reader = prop.as_reader();
+    let mut refs = Vec::new();
+    while let Some(phandle_raw) = reader.read_u32() {
+        let phandle = Phandle::from(phandle_raw);
+        let provider = info.get_by_phandle(phandle).ok_or_else(|| {
+            OnProbeError::other(format!(
+                "[{}] {property_name} provider phandle {:?} not found",
+                info.node.name(),
+                phandle
+            ))
+        })?;
+        let cells = provider
+            .as_node()
+            .get_property("#clock-cells")
+            .and_then(|prop| prop.get_u32())
+            .unwrap_or(1);
+        let mut specifier = Vec::with_capacity(cells as usize);
+        for _ in 0..cells {
+            let value = reader.read_u32().ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] has truncated {property_name} entry for phandle {:?}",
+                    info.node.name(),
+                    phandle
+                ))
+            })?;
+            specifier.push(value);
+        }
+        refs.push(ClockRef::new(phandle, cells, specifier));
+    }
+    Ok(refs)
+}
+
+fn apply_supply_regulators(
+    info: &FdtInfo<'_>,
+    supply_names: &[String],
+) -> Result<(), OnProbeError> {
+    for name in supply_names {
+        let Some(phandle) = supply_phandle(info.node.as_node(), name) else {
+            continue;
+        };
+        let Some(node) = info.get_by_phandle(phandle) else {
+            return Err(OnProbeError::other(format!(
+                "[{}] supply {name} phandle {:?} not found",
+                info.node.name(),
+                phandle
+            )));
+        };
+        if !fixed_regulator_has_control(node.as_node()) {
+            continue;
+        }
+        apply_fixed_regulator(info, node.as_node(), name)?;
+    }
+    Ok(())
+}
+
+fn supply_phandle(node: &Node, name: &str) -> Option<Phandle> {
+    node.get_property(name)
+        .and_then(|prop| prop.get_u32())
+        .map(Phandle::from)
+}
+
+fn fixed_regulator_has_control(node: &Node) -> bool {
+    node.compatibles()
+        .any(|compatible| compatible == "regulator-fixed")
+        && (node.get_property("gpios").is_some()
+            || node.get_property("gpio").is_some()
+            || node.get_property("pinctrl-0").is_some())
+}
+
+fn apply_fixed_regulator(
+    info: &FdtInfo<'_>,
+    regulator: &Node,
+    supply_name: &str,
+) -> Result<(), OnProbeError> {
+    let pinctrl = crate::get_one::<PinctrlDevice>().ok_or_else(|| {
+        OnProbeError::other(format!(
+            "[{}] PinctrlDevice not found for controlled supply {supply_name}",
+            info.node.name()
+        ))
+    })?;
+    let mut pinctrl = pinctrl
+        .lock()
+        .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
+    match pinctrl.apply_fdt_fixed_regulator(system().fdt(), regulator, "rdrive-resource") {
+        Ok(()) | Err(PinctrlError::NotAvailable) => Ok(()),
+        Err(err) => Err(OnProbeError::other(format!(
+            "[{}] failed to enable supply {supply_name}: {err}",
+            info.node.name()
+        ))),
     }
 }
 

--- a/drivers/rdrive/tests/fdt_resource_prepare.rs
+++ b/drivers/rdrive/tests/fdt_resource_prepare.rs
@@ -1,0 +1,413 @@
+use core::ptr::NonNull;
+use std::{
+    string::{String, ToString},
+    sync::Mutex,
+    vec,
+    vec::Vec,
+};
+
+use fdt_edit::{Fdt, Node, NodeType, Phandle, Property};
+use rdif_pinctrl::{
+    ConfigSetting, FdtPinctrlParser, GpioBankId, GpioLineId, GpioRange,
+    Interface as PinctrlInterface, PinDesc, PinId, PinState, PinctrlDevice, PinctrlError,
+};
+use rdrive::{
+    DriverGeneric, Platform,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+static RESOURCE_CALLS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static PREPARED_CLOCK: Mutex<Option<u64>> = Mutex::new(None);
+
+struct ClockProvider;
+struct ResetProvider;
+struct PowerProvider;
+struct PinctrlProvider {
+    pins: Vec<PinDesc>,
+    gpio_ranges: Vec<GpioRange>,
+}
+struct PinctrlParser;
+struct ResourceConsumer;
+
+impl PinctrlProvider {
+    fn new() -> Self {
+        Self {
+            pins: (0..64)
+                .map(|pin| PinDesc::new(PinId::new(pin), None))
+                .collect(),
+            gpio_ranges: vec![GpioRange::new(GpioBankId::new(0), 0, 0, 64)],
+        }
+    }
+}
+
+impl DriverGeneric for ClockProvider {
+    fn name(&self) -> &str {
+        "clock-provider"
+    }
+}
+
+impl rdif_clk::Interface for ClockProvider {
+    fn perper_enable(&mut self) {}
+
+    fn enable(&mut self, id: rdif_clk::ClockId) -> Result<(), rdrive::KError> {
+        RESOURCE_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("clock-enable:{}", id.raw()));
+        Ok(())
+    }
+
+    fn get_rate(&self, id: rdif_clk::ClockId) -> Result<u64, rdrive::KError> {
+        RESOURCE_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("clock-rate:{}", id.raw()));
+        Ok(50_000_000)
+    }
+
+    fn set_rate(&mut self, id: rdif_clk::ClockId, rate: u64) -> Result<(), rdrive::KError> {
+        RESOURCE_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("clock-set:{}:{rate}", id.raw()));
+        Ok(())
+    }
+}
+
+impl DriverGeneric for ResetProvider {
+    fn name(&self) -> &str {
+        "reset-provider"
+    }
+}
+
+impl rdif_reset::Interface for ResetProvider {
+    fn assert(&mut self, id: rdif_reset::ResetId) -> Result<(), rdif_reset::ResetError> {
+        RESOURCE_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("reset-assert:{}", id.raw()));
+        Ok(())
+    }
+
+    fn deassert(&mut self, id: rdif_reset::ResetId) -> Result<(), rdif_reset::ResetError> {
+        RESOURCE_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("reset-deassert:{}", id.raw()));
+        Ok(())
+    }
+}
+
+impl DriverGeneric for PowerProvider {
+    fn name(&self) -> &str {
+        "power-provider"
+    }
+}
+
+impl rdif_power::Interface for PowerProvider {
+    fn power_on(&mut self, id: rdif_power::PowerDomainId) -> Result<(), rdif_power::PowerError> {
+        RESOURCE_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("power-on:{}", id.raw()));
+        Ok(())
+    }
+
+    fn power_off(&mut self, _id: rdif_power::PowerDomainId) -> Result<(), rdif_power::PowerError> {
+        Ok(())
+    }
+}
+
+impl DriverGeneric for PinctrlProvider {
+    fn name(&self) -> &str {
+        "pinctrl-provider"
+    }
+}
+
+impl PinctrlInterface for PinctrlProvider {
+    fn pins(&self) -> &[PinDesc] {
+        &self.pins
+    }
+
+    fn gpio_ranges(&self) -> &[GpioRange] {
+        &self.gpio_ranges
+    }
+
+    fn apply_config(&mut self, _setting: &ConfigSetting) -> Result<(), PinctrlError> {
+        RESOURCE_CALLS
+            .lock()
+            .unwrap()
+            .push("pinctrl-config".to_string());
+        Ok(())
+    }
+}
+
+impl FdtPinctrlParser for PinctrlParser {
+    fn parse_pinctrl_node(
+        &self,
+        _fdt: &Fdt,
+        _node: NodeType<'_>,
+        _state: &mut PinState,
+    ) -> Result<(), PinctrlError> {
+        Err(PinctrlError::InvalidConfig)
+    }
+
+    fn parse_gpio_line(
+        &self,
+        fdt: &Fdt,
+        consumer: &Node,
+        prop_name: &str,
+    ) -> Option<Result<GpioLineId, PinctrlError>> {
+        let mut cells = consumer.get_property(prop_name)?.get_u32_iter();
+        let phandle = Phandle::from(cells.next()?);
+        let offset = cells.next()?;
+        fdt.get_by_phandle(phandle)?;
+        Some(Ok(GpioLineId::new(GpioBankId::new(0), offset)))
+    }
+}
+
+impl DriverGeneric for ResourceConsumer {
+    fn name(&self) -> &str {
+        "resource-consumer"
+    }
+}
+
+fn probe_clock_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_clk::Clk::new(ClockProvider));
+    Ok(())
+}
+
+fn probe_reset_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_reset::Reset::new(ResetProvider));
+    Ok(())
+}
+
+fn probe_power_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_power::Power::new(PowerProvider));
+    Ok(())
+}
+
+fn probe_pinctrl_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(PinctrlDevice::with_fdt_parser(
+            PinctrlProvider::new(),
+            PinctrlParser,
+        ));
+    Ok(())
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let report = probe.info().prepare_resources(
+        rdrive::probe::fdt::ResourcePrepareConfig::default().with_named_clock_rate("ciu"),
+    )?;
+    *PREPARED_CLOCK.lock().unwrap() = report.clock_rate("ciu");
+    probe.into_platform_device().register(ResourceConsumer);
+    Ok(())
+}
+
+static CLOCK_REGISTER: DriverRegister = DriverRegister {
+    name: "test clock provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,clock-provider"],
+        on_probe: probe_clock_provider,
+    }],
+};
+
+static RESET_REGISTER: DriverRegister = DriverRegister {
+    name: "test reset provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,reset-provider"],
+        on_probe: probe_reset_provider,
+    }],
+};
+
+static POWER_REGISTER: DriverRegister = DriverRegister {
+    name: "test power provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,power-provider"],
+        on_probe: probe_power_provider,
+    }],
+};
+
+static PINCTRL_REGISTER: DriverRegister = DriverRegister {
+    name: "test pinctrl provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,pinctrl-provider"],
+        on_probe: probe_pinctrl_provider,
+    }],
+};
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test resource consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,resource-consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn fdt_resource_prepare_applies_clocks_resets_and_power_domains() {
+    RESOURCE_CALLS.lock().unwrap().clear();
+    *PREPARED_CLOCK.lock().unwrap() = None;
+
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "clock-controller",
+            &[
+                prop_strs("compatible", &["test,clock-provider"]),
+                prop_u32s("phandle", &[1]),
+                prop_u32s("#clock-cells", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props("gpio0@0", &[prop_u32s("phandle", &[20])]),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "pinctrl",
+            &[prop_strs("compatible", &["test,pinctrl-provider"])],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "vmmc-regulator",
+            &[
+                prop_strs("compatible", &["regulator-fixed"]),
+                prop_u32s("phandle", &[4]),
+                prop_u32s("gpios", &[20, 5, 0]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "vqmmc-regulator",
+            &[
+                prop_strs("compatible", &["regulator-fixed"]),
+                prop_u32s("phandle", &[5]),
+                prop_u32s("gpios", &[20, 6, 0]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "reset-controller",
+            &[
+                prop_strs("compatible", &["test,reset-provider"]),
+                prop_u32s("phandle", &[2]),
+                prop_u32s("#reset-cells", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "power-controller",
+            &[
+                prop_strs("compatible", &["test,power-provider"]),
+                prop_u32s("phandle", &[3]),
+                prop_u32s("#power-domain-cells", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "mmc@16020000",
+            &[
+                prop_strs("compatible", &["test,resource-consumer"]),
+                prop_u32s("clocks", &[1, 4]),
+                prop_strs("clock-names", &["ciu"]),
+                prop_u32s("assigned-clocks", &[1, 4]),
+                prop_u32s("assigned-clock-rates", &[50_000_000]),
+                prop_u32s("vmmc-supply", &[4]),
+                prop_u32s("vqmmc-supply", &[5]),
+                prop_u32s("resets", &[2, 9]),
+                prop_u32s("power-domains", &[3, 6]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(CLOCK_REGISTER.clone());
+    rdrive::register_add(RESET_REGISTER.clone());
+    rdrive::register_add(POWER_REGISTER.clone());
+    rdrive::register_add(PINCTRL_REGISTER.clone());
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    probe_all(true).expect("FDT probe should succeed");
+
+    assert_eq!(
+        *RESOURCE_CALLS.lock().unwrap(),
+        vec![
+            "power-on:6".to_string(),
+            "clock-set:4:50000000".to_string(),
+            "pinctrl-config".to_string(),
+            "pinctrl-config".to_string(),
+            "pinctrl-config".to_string(),
+            "pinctrl-config".to_string(),
+            "clock-enable:4".to_string(),
+            "reset-deassert:9".to_string(),
+            "clock-rate:4".to_string(),
+        ]
+    );
+    assert_eq!(*PREPARED_CLOCK.lock().unwrap(), Some(50_000_000));
+    assert!(rdrive::get_one::<ResourceConsumer>().is_some());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/rdrive/tests/fdt_resource_prepare_error.rs
+++ b/drivers/rdrive/tests/fdt_resource_prepare_error.rs
@@ -1,0 +1,104 @@
+use core::ptr::NonNull;
+use std::{string::ToString, vec::Vec};
+
+use fdt_edit::{Fdt, Node, Property};
+use rdrive::{
+    DriverGeneric, Platform,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+struct ResourceConsumer;
+
+impl DriverGeneric for ResourceConsumer {
+    fn name(&self) -> &str {
+        "resource-consumer"
+    }
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .info()
+        .prepare_resources(rdrive::probe::fdt::ResourcePrepareConfig::default())?;
+    probe.into_platform_device().register(ResourceConsumer);
+    Ok(())
+}
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test malformed resource consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,malformed-resource-consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn fdt_resource_prepare_rejects_truncated_power_domain_specifier() {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "power-controller",
+            &[
+                prop_strs("compatible", &["test,power-provider"]),
+                prop_u32s("phandle", &[3]),
+                prop_u32s("#power-domain-cells", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "mmc@16020000",
+            &[
+                prop_strs("compatible", &["test,malformed-resource-consumer"]),
+                prop_u32s("power-domains", &[3]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    let err = probe_all(true).expect_err("malformed power-domains should fail probe");
+
+    assert!(
+        err.to_string().contains("truncated power-domains"),
+        "unexpected error: {err}"
+    );
+    assert!(rdrive::get_one::<ResourceConsumer>().is_none());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/rdrive/tests/fdt_resource_prepare_missing_provider.rs
+++ b/drivers/rdrive/tests/fdt_resource_prepare_missing_provider.rs
@@ -1,0 +1,101 @@
+use core::ptr::NonNull;
+use std::vec::Vec;
+
+use fdt_edit::{Fdt, Node, Property};
+use rdrive::{
+    DriverGeneric, Platform,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+struct ResourceConsumer;
+
+impl DriverGeneric for ResourceConsumer {
+    fn name(&self) -> &str {
+        "resource-consumer"
+    }
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .info()
+        .prepare_resources(rdrive::probe::fdt::ResourcePrepareConfig::default())?;
+    probe.into_platform_device().register(ResourceConsumer);
+    Ok(())
+}
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test missing provider resource consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,missing-provider-resource-consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn fdt_resource_prepare_rejects_declared_clock_without_rdif_provider() {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "clock-controller",
+            &[prop_u32s("phandle", &[1]), prop_u32s("#clock-cells", &[1])],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "mmc@16020000",
+            &[
+                prop_strs("compatible", &["test,missing-provider-resource-consumer"]),
+                prop_u32s("clocks", &[1, 4]),
+                prop_strs("clock-names", &["ciu"]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    let err = probe_all(true).expect_err("declared clock without rdif-clk should fail probe");
+
+    assert!(
+        err.to_string().contains("has no rdif-clk interface"),
+        "unexpected error: {err}"
+    );
+    assert!(rdrive::get_one::<ResourceConsumer>().is_none());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/rdrive/tests/fdt_resource_prepare_power_cells.rs
+++ b/drivers/rdrive/tests/fdt_resource_prepare_power_cells.rs
@@ -1,0 +1,139 @@
+use core::ptr::NonNull;
+use std::vec::Vec;
+
+use fdt_edit::{Fdt, Node, Property};
+use rdrive::{
+    DriverGeneric, Platform,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+struct PowerProvider;
+struct ResourceConsumer;
+
+impl DriverGeneric for PowerProvider {
+    fn name(&self) -> &str {
+        "multi-cell-power-provider"
+    }
+}
+
+impl rdif_power::Interface for PowerProvider {
+    fn power_on(&mut self, _id: rdif_power::PowerDomainId) -> Result<(), rdif_power::PowerError> {
+        Ok(())
+    }
+
+    fn power_off(&mut self, _id: rdif_power::PowerDomainId) -> Result<(), rdif_power::PowerError> {
+        Ok(())
+    }
+}
+
+impl DriverGeneric for ResourceConsumer {
+    fn name(&self) -> &str {
+        "resource-consumer"
+    }
+}
+
+fn probe_power_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_power::Power::new(PowerProvider));
+    Ok(())
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .info()
+        .prepare_resources(rdrive::probe::fdt::ResourcePrepareConfig::default())?;
+    probe.into_platform_device().register(ResourceConsumer);
+    Ok(())
+}
+
+static POWER_REGISTER: DriverRegister = DriverRegister {
+    name: "test multi-cell power provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,multi-cell-power-provider"],
+        on_probe: probe_power_provider,
+    }],
+};
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test multi-cell power consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,multi-cell-power-consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn fdt_resource_prepare_rejects_multi_cell_power_domain_specifier() {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "power-controller",
+            &[
+                prop_strs("compatible", &["test,multi-cell-power-provider"]),
+                prop_u32s("phandle", &[3]),
+                prop_u32s("#power-domain-cells", &[2]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "mmc@16020000",
+            &[
+                prop_strs("compatible", &["test,multi-cell-power-consumer"]),
+                prop_u32s("power-domains", &[3, 6, 7]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(POWER_REGISTER.clone());
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    let err = probe_all(true).expect_err("multi-cell power domains should fail probe");
+
+    assert!(
+        err.to_string().contains("uses 2 cells"),
+        "unexpected error: {err}"
+    );
+    assert!(rdrive::get_one::<ResourceConsumer>().is_none());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/rdrive/tests/fdt_resource_prepare_regulator_error.rs
+++ b/drivers/rdrive/tests/fdt_resource_prepare_regulator_error.rs
@@ -1,0 +1,108 @@
+use core::ptr::NonNull;
+use std::vec::Vec;
+
+use fdt_edit::{Fdt, Node, Property};
+use rdrive::{
+    DriverGeneric, Platform,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+struct ResourceConsumer;
+
+impl DriverGeneric for ResourceConsumer {
+    fn name(&self) -> &str {
+        "resource-consumer"
+    }
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .info()
+        .prepare_resources(rdrive::probe::fdt::ResourcePrepareConfig::default())?;
+    probe.into_platform_device().register(ResourceConsumer);
+    Ok(())
+}
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test fixed regulator consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,fixed-regulator-consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn fdt_resource_prepare_rejects_controlled_fixed_regulator_without_pinctrl() {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props("gpio0@0", &[prop_u32s("phandle", &[20])]),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "vmmc-regulator",
+            &[
+                prop_strs("compatible", &["regulator-fixed"]),
+                prop_u32s("phandle", &[4]),
+                prop_u32s("gpios", &[20, 5, 0]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "mmc@16020000",
+            &[
+                prop_strs("compatible", &["test,fixed-regulator-consumer"]),
+                prop_u32s("vmmc-supply", &[4]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    let err = probe_all(true).expect_err("controlled fixed regulator needs pinctrl capability");
+
+    assert!(
+        err.to_string().contains("PinctrlDevice not found"),
+        "unexpected error: {err}"
+    );
+    assert!(rdrive::get_one::<ResourceConsumer>().is_none());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/rdrive/tests/fdt_resource_prepare_zero_cell_clock.rs
+++ b/drivers/rdrive/tests/fdt_resource_prepare_zero_cell_clock.rs
@@ -1,0 +1,177 @@
+use core::ptr::NonNull;
+use std::{
+    string::{String, ToString},
+    sync::Mutex,
+    vec,
+    vec::Vec,
+};
+
+use fdt_edit::{Fdt, Node, Property};
+use rdrive::{
+    DriverGeneric, Platform,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+static CLOCK_CALLS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static PREPARED_CLOCK: Mutex<Option<u64>> = Mutex::new(None);
+
+struct ClockProvider;
+struct ResourceConsumer;
+
+impl DriverGeneric for ClockProvider {
+    fn name(&self) -> &str {
+        "zero-cell-clock-provider"
+    }
+}
+
+impl rdif_clk::Interface for ClockProvider {
+    fn perper_enable(&mut self) {}
+
+    fn enable(&mut self, id: rdif_clk::ClockId) -> Result<(), rdrive::KError> {
+        CLOCK_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("enable:{}", id.raw()));
+        Ok(())
+    }
+
+    fn get_rate(&self, id: rdif_clk::ClockId) -> Result<u64, rdrive::KError> {
+        CLOCK_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("rate:{}", id.raw()));
+        Ok(50_000_000)
+    }
+
+    fn set_rate(&mut self, id: rdif_clk::ClockId, rate: u64) -> Result<(), rdrive::KError> {
+        CLOCK_CALLS
+            .lock()
+            .unwrap()
+            .push(format!("set:{}:{rate}", id.raw()));
+        Ok(())
+    }
+}
+
+impl DriverGeneric for ResourceConsumer {
+    fn name(&self) -> &str {
+        "resource-consumer"
+    }
+}
+
+fn probe_clock_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_clk::Clk::new(ClockProvider));
+    Ok(())
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let report = probe.info().prepare_resources(
+        rdrive::probe::fdt::ResourcePrepareConfig::default().with_named_clock_rate("ciu"),
+    )?;
+    *PREPARED_CLOCK.lock().unwrap() = report.clock_rate("ciu");
+    probe.into_platform_device().register(ResourceConsumer);
+    Ok(())
+}
+
+static CLOCK_REGISTER: DriverRegister = DriverRegister {
+    name: "test zero-cell clock provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,zero-cell-clock-provider"],
+        on_probe: probe_clock_provider,
+    }],
+};
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test zero-cell clock resource consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,zero-cell-clock-resource-consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn fdt_resource_prepare_uses_id_zero_for_zero_cell_clock_provider() {
+    CLOCK_CALLS.lock().unwrap().clear();
+    *PREPARED_CLOCK.lock().unwrap() = None;
+
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "clock-controller",
+            &[
+                prop_strs("compatible", &["test,zero-cell-clock-provider"]),
+                prop_u32s("phandle", &[1]),
+                prop_u32s("#clock-cells", &[0]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "mmc@16020000",
+            &[
+                prop_strs("compatible", &["test,zero-cell-clock-resource-consumer"]),
+                prop_u32s("clocks", &[1]),
+                prop_strs("clock-names", &["ciu"]),
+                prop_u32s("assigned-clocks", &[1]),
+                prop_u32s("assigned-clock-rates", &[50_000_000]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(CLOCK_REGISTER.clone());
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    probe_all(true).expect("zero-cell clock prepare should succeed");
+
+    assert_eq!(
+        *CLOCK_CALLS.lock().unwrap(),
+        vec![
+            "set:0:50000000".to_string(),
+            "enable:0".to_string(),
+            "rate:0".to_string(),
+        ]
+    );
+    assert_eq!(*PREPARED_CLOCK.lock().unwrap(), Some(50_000_000));
+    assert!(rdrive::get_one::<ResourceConsumer>().is_some());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/os/arceos/modules/axruntime/src/fs/block.rs
+++ b/os/arceos/modules/axruntime/src/fs/block.rs
@@ -52,7 +52,9 @@ impl BlockTaskOps for RuntimeTaskOps {
     }
 
     fn can_block(&self) -> bool {
-        ax_task::current_may_uninit().is_some() && !ax_task::in_atomic_context()
+        crate::is_init_ok()
+            && ax_task::current_may_uninit().is_some()
+            && !ax_task::in_atomic_context()
     }
 
     fn task_yield(&self) {


### PR DESCRIPTION
## 背景

StarFive JH7110 DWMMC 之前仍由 `ax-driver` 直接组合通用 `dwmmc-host`，资源准备、controller 选择和 RDIF block completion 都耦合在 OS glue 里。最新 `dev` 已经包含通用 RDIF block IRQ bridge 和 VirtIO 侧改动，所以这次拆分后的 PR 只保留 StarFive DWMMC 相关变更。

## 改动

- 新增 `drivers/blk/starfive-jh7110-dwmmc` no_std portable crate，复用 `dwmmc-host` 与 `sdmmc-protocol`，暴露 JH7110 FIFO offset、host config、IRQ host wrapper 和 RDIF FIFO config helper。
- 扩展 `dwmmc-host` 的 FIFO/IRQ completion 能力，使 FIFO block path 可以通过 RDIF 以 IRQ-driven completion 注册。
- 在 `rdrive` FDT resource prepare 中补齐 assigned clocks、clock enable/rate report、reset deassert、fixed regulator supply 处理；power-domain 继续走最新 `dev` 已有的 FDT 自动上电路径，prepare 侧保留显式 opt-in 以避免重复 power-on。
- 新增 StarFive JH7110 syscrg clk/reset provider，寄存器定义使用 `tock-registers` typed registers。
- 重构 `ax-driver` StarFive MMC glue：不再用硬编码 `JH7110_MMC1_BASE` 过滤，改为根据设备树节点能力决定 SD/eMMC 初始化偏好，支持多个 `starfive,jh7110-mmc` 节点；无卡 controller 返回 `NotMatch` 继续探测后续节点。
- StarFive block 注册切到 FIFO + IRQ-driven RDIF config，并保留 FDT IRQ binding。

## 设计逻辑

SD host crate 只负责 JH7110 DWMMC IP 行为，不感知 FDT、iomap、clk/reset/provider 或 runtime。board resource 由 `rdrive`/RDIF capability 在 probe 阶段准备；`ax-driver` 只负责读取设备树 profile、映射 MMIO、初始化 card，并把 host 注册成 RDIF block 设备。

## 验证

- `cargo test -p rdif-power`
- `cargo test -p rdrive`
- `cargo test -p dwmmc-host`
- `cargo test -p starfive-jh7110-dwmmc`
- `cargo test -p ax-driver --features starfive-jh7110-dwmmc block::starfive_mmc::tests`
- `cargo test -p ax-runtime`
- `cargo test -p ax-fs-ng block_runtime`
- `cargo fmt --check`
- `cargo xtask clippy --package dwmmc-host`
- `cargo xtask clippy --package starfive-jh7110-dwmmc`
- `cargo xtask clippy --package rdrive`
- `cargo xtask clippy --package ax-driver`
- `cargo xtask clippy --package ax-runtime`
- `cargo xtask starry test board --board visionfive2 -c boot`
  - board session: `8dd51065-0d94-42f5-98ce-06cbbfe94990`
  - 观察到 `mmc@16010000` 无响应 card 被跳过，`mmc@16020000` 初始化为 SD card
  - 观察到 `rdif filesystem block device starfive-jh7110-mmc registered with IRQ-driven completion`
  - 命中 `STARRY_VISIONFIVE2_SHELL_OK` 和 `all starry board test groups passed`