### PR TITLE
feat(rdrive): apply assigned clocks before FDT probe

### DIFF
--- a/drivers/ax-driver/src/block/rockchip/clock.rs
+++ b/drivers/ax-driver/src/block/rockchip/clock.rs
@@ -1,113 +1,16 @@
-use alloc::{
-    format,
-    string::{String, ToString},
-    vec::Vec,
-};
+#[cfg(feature = "rockchip-dwmmc")]
+use alloc::format;
 
-use fdt_edit::Node;
-use log::{info, warn};
-use rdif_clk::ClockId;
+use log::info;
+#[cfg(feature = "rockchip-dwmmc")]
+use rdrive::probe::fdt::ClockLine;
 use rdrive::{
-    Device,
     probe::{OnProbeError, fdt::ClockRef},
     register::FdtInfo,
 };
 
 #[cfg(feature = "rockchip-dwmmc")]
 use crate::soc::scmi;
-
-pub(crate) struct RockchipClockOps {
-    node_name: String,
-    clock_name: Option<String>,
-    device: Device<rdif_clk::Clk>,
-    id: ClockId,
-}
-
-impl RockchipClockOps {
-    pub(crate) fn from_node_clock(
-        info: &FdtInfo<'_>,
-        clock: &ClockRef,
-    ) -> Result<Option<Self>, OnProbeError> {
-        let Some(clock_id) = clock.select() else {
-            return Ok(None);
-        };
-        let Some(device_id) = info.phandle_to_device_id(clock.phandle) else {
-            warn!(
-                "[{}] clock {:?} phandle {} has no device id",
-                info.node.name(),
-                clock.name,
-                clock.phandle
-            );
-            return Ok(None);
-        };
-        let device = rdrive::get::<rdif_clk::Clk>(device_id).map_err(|_| {
-            OnProbeError::other(format!(
-                "[{}] clock {:?} device {:?} is not registered",
-                info.node.name(),
-                clock.name,
-                device_id
-            ))
-        })?;
-        Ok(Some(Self {
-            node_name: info.node.name().to_string(),
-            clock_name: clock.name.clone(),
-            device,
-            id: ClockId::from(clock_id as usize),
-        }))
-    }
-
-    pub(crate) fn named(info: &FdtInfo<'_>, name: &str) -> Result<Option<Self>, OnProbeError> {
-        let Some(clock) = info.find_clk_by_name(name) else {
-            return Ok(None);
-        };
-        Self::from_node_clock(info, &clock)
-    }
-
-    pub(crate) fn enable(&self) -> Result<(), OnProbeError> {
-        let mut clock = self.lock()?;
-        clock.enable(self.id).map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] failed to enable clock {:?} ({:?}): {err:?}",
-                self.node_name, self.clock_name, self.id
-            ))
-        })?;
-        Ok(())
-    }
-
-    pub(crate) fn set_rate(&self, rate: u64) -> Result<(), OnProbeError> {
-        let mut clock = self.lock()?;
-        clock.set_rate(self.id, rate).map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] failed to set clock {:?} ({:?}) to {} Hz: {err:?}",
-                self.node_name, self.clock_name, self.id, rate
-            ))
-        })?;
-        Ok(())
-    }
-
-    pub(crate) fn rate(&self) -> Result<u64, OnProbeError> {
-        let clock = self.lock()?;
-        clock.get_rate(self.id).map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] failed to read clock {:?} ({:?}): {err:?}",
-                self.node_name, self.clock_name, self.id
-            ))
-        })
-    }
-
-    pub(crate) fn id(&self) -> ClockId {
-        self.id
-    }
-
-    fn lock(&self) -> Result<rdrive::DeviceGuard<rdif_clk::Clk>, OnProbeError> {
-        self.device.lock().map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] failed to lock clock {:?} ({:?}): {err}",
-                self.node_name, self.clock_name, self.id
-            ))
-        })
-    }
-}
 
 #[cfg(feature = "rockchip-dwmmc")]
 fn scmi_clock_id(clock: &ClockRef) -> Option<u32> {
@@ -165,88 +68,40 @@ fn enable_scmi_clock(
     Ok(false)
 }
 
-pub(crate) fn enable_node_clocks(info: &FdtInfo<'_>, label: &str) {
-    for clock in info.node.clocks() {
-        if clock.select().unwrap_or(0) == 0 {
-            continue;
-        }
-        match enable_scmi_clock(info, &clock, label) {
-            Ok(true) => continue,
-            Ok(false) => {}
-            Err(err) => {
-                warn!(
-                    "[{}] {label} clock {:?} enable skipped: {err}",
-                    info.node.name(),
-                    clock.name
-                );
-                continue;
-            }
-        }
-        match RockchipClockOps::from_node_clock(info, &clock).and_then(|clock| {
-            let Some(clock) = clock else {
-                return Ok(None);
-            };
-            clock.enable()?;
-            Ok(Some(clock.id()))
-        }) {
-            Ok(Some(clock_id)) => info!(
-                "[{}] enabled {label} clock {:?} ({:?})",
-                info.node.name(),
-                clock.name,
-                clock_id
-            ),
-            Ok(None) => {}
-            Err(err) => warn!(
-                "[{}] {label} clock {:?} enable skipped: {err}",
-                info.node.name(),
-                clock.name
-            ),
-        }
+#[cfg(feature = "rockchip-dwmmc")]
+pub(crate) fn rdrive_named_clock(
+    info: &FdtInfo<'_>,
+    name: &str,
+) -> Result<Option<ClockLine>, OnProbeError> {
+    let Some(clock) = info
+        .clocks()?
+        .into_iter()
+        .find(|clock| clock.name.as_deref() == Some(name))
+    else {
+        return Ok(None);
+    };
+    if is_scmi_clock_provider(info, &clock) {
+        return Ok(None);
     }
+    info.clock_line(&clock).map(Some)
 }
 
-pub(crate) fn apply_assigned_clocks(info: &FdtInfo<'_>, label: &str) -> Result<(), OnProbeError> {
-    let clocks = parse_clock_cells(info.node.as_node(), "assigned-clocks")?;
-    let rates = info
-        .node
-        .as_node()
-        .get_property("assigned-clock-rates")
-        .map(|prop| prop.get_u32_iter().map(u64::from).collect::<Vec<_>>())
-        .unwrap_or_default();
-    for (index, (phandle, clock_id)) in clocks.into_iter().enumerate() {
-        let Some(rate) = rates.get(index).copied() else {
-            continue;
-        };
-        if rate == 0 {
+pub(crate) fn enable_node_clocks(info: &FdtInfo<'_>, label: &str) -> Result<(), OnProbeError> {
+    for clock in info.clocks()? {
+        if clock.select() == Some(0) {
             continue;
         }
-        let Some(device_id) = info.phandle_to_device_id(phandle.into()) else {
-            warn!(
-                "[{}] assigned {label} clock phandle {} has no device id",
-                info.node.name(),
-                phandle
-            );
+        if enable_scmi_clock(info, &clock, label)? {
             continue;
-        };
-        let device = rdrive::get::<rdif_clk::Clk>(device_id).map_err(|_| {
-            OnProbeError::other(format!(
-                "[{}] assigned {label} clock device {:?} is not registered",
-                info.node.name(),
-                device_id
-            ))
-        })?;
-        let ops = RockchipClockOps {
-            node_name: info.node.name().to_string(),
-            clock_name: None,
-            device,
-            id: ClockId::from(clock_id as usize),
-        };
-        ops.set_rate(rate)?;
+        }
+
+        let line = info.clock_line(&clock)?;
+        line.enable()?;
         info!(
-            "[{}] assigned {label} clock {:?} to {} Hz",
+            "[{}] enabled {label} clock {:?} ({:#x})",
             info.node.name(),
-            ops.id(),
-            rate
+            clock.name,
+            line.id().raw()
         );
     }
     Ok(())
@@ -276,53 +131,5 @@ impl ScmiClockOps {
 
     pub(crate) fn rate(&self) -> Option<u64> {
         scmi::clock_rate(self.phandle, self.clock_id)
-    }
-}
-
-fn parse_clock_cells(node: &Node, property: &str) -> Result<Vec<(u32, u32)>, OnProbeError> {
-    let Some(prop) = node.get_property(property) else {
-        return Ok(Vec::new());
-    };
-    let cells = prop.get_u32_iter().collect::<Vec<_>>();
-    if cells.len() % 2 != 0 {
-        return Err(OnProbeError::other(format!(
-            "[{}] has malformed {property}",
-            node.name()
-        )));
-    }
-    Ok(cells.chunks(2).map(|chunk| (chunk[0], chunk[1])).collect())
-}
-
-#[cfg(test)]
-mod tests {
-    use alloc::vec;
-
-    use super::*;
-
-    #[test]
-    fn parse_clock_cells_reads_phandle_and_clock_id_pairs() {
-        let mut node = Node::new("mmc@fe2e0000");
-        let mut raw = Vec::new();
-        raw.extend_from_slice(&0x1000_u32.to_be_bytes());
-        raw.extend_from_slice(&314_u32.to_be_bytes());
-        raw.extend_from_slice(&0x1000_u32.to_be_bytes());
-        raw.extend_from_slice(&315_u32.to_be_bytes());
-        node.add_property(fdt_edit::Property::new("assigned-clocks", raw));
-
-        assert_eq!(
-            parse_clock_cells(&node, "assigned-clocks").unwrap(),
-            vec![(0x1000, 314), (0x1000, 315)]
-        );
-    }
-
-    #[test]
-    fn parse_clock_cells_rejects_malformed_cells() {
-        let mut node = Node::new("mmc@fe2e0000");
-        node.add_property(fdt_edit::Property::new(
-            "assigned-clocks",
-            0x1000_u32.to_be_bytes().to_vec(),
-        ));
-
-        assert!(parse_clock_cells(&node, "assigned-clocks").is_err());
     }
 }

--- a/drivers/ax-driver/src/block/rockchip/sd/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sd/mod.rs
@@ -20,7 +20,7 @@ use fdt_edit::{Node, Phandle};
 use log::{info, warn};
 use rdif_pinctrl::{FdtPinctrl, PinctrlDevice};
 use rdrive::{
-    probe::OnProbeError,
+    probe::{OnProbeError, fdt::ClockLine},
     register::{FdtInfo, ProbeFdt},
 };
 use sdmmc_protocol::{
@@ -33,9 +33,7 @@ use sdmmc_protocol::{
     },
 };
 
-use super::clock::{
-    RockchipClockOps, ScmiClockOps, apply_assigned_clocks, enable_node_clocks, scmi_named_clock,
-};
+use super::clock::{ScmiClockOps, enable_node_clocks, rdrive_named_clock, scmi_named_clock};
 use crate::{block::ProbeFdtBlock, mmio::iomap, soc::RockchipFdtPinctrlParser};
 
 const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
@@ -55,7 +53,7 @@ const SDMMC_INIT_RETRY_DELAY: Duration = Duration::from_millis(10);
 type RockchipDwMmc = SdioSdmmc<SdioHost2Adapter<DwMmc>>;
 
 enum RockchipDwMmcClock {
-    Rdrive(RockchipClockOps),
+    Rdrive(ClockLine),
     Scmi(ScmiClockOps),
 }
 
@@ -202,7 +200,6 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 }
 
 fn apply_rockchip_sd_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
-    apply_assigned_clocks(info, "SDMMC")?;
     let Some(pinctrl) = rdrive::get_one::<PinctrlDevice>() else {
         warn!(
             "[{}] PinctrlDevice not found; skip SDMMC pinctrl and fixed regulators",
@@ -224,7 +221,7 @@ fn apply_rockchip_sd_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
             );
         }
     }
-    enable_node_clocks(info, "SDMMC");
+    enable_node_clocks(info, "SDMMC")?;
     Ok(())
 }
 
@@ -345,7 +342,7 @@ fn is_absent_card_init_error(err: Error) -> bool {
 }
 
 fn dwmmc_clock_setup(info: &FdtInfo<'_>) -> Option<DwMmcClockSetup> {
-    match RockchipClockOps::named(info, "ciu") {
+    match rdrive_named_clock(info, "ciu") {
         Ok(Some(clock)) => {
             if let Err(err) = clock.set_rate(DWMMC_STABLE_REFERENCE_CLOCK as u64) {
                 warn!(

--- a/drivers/ax-driver/src/block/rockchip/sdhci_rk3568.rs
+++ b/drivers/ax-driver/src/block/rockchip/sdhci_rk3568.rs
@@ -16,7 +16,10 @@ use alloc::format;
 use core::{ptr::NonNull, time::Duration};
 
 use log::{info, warn};
-use rdrive::{probe::OnProbeError, register::ProbeFdt};
+use rdrive::{
+    probe::{OnProbeError, fdt::ClockLine},
+    register::ProbeFdt,
+};
 use sdhci_host::{HostClock, HostResetHook, Sdhci, rdif as sdhci_rdif};
 use sdmmc_protocol::{
     Error, OperationPoll,
@@ -28,7 +31,6 @@ use sdmmc_protocol::{
     },
 };
 
-use super::clock::RockchipClockOps;
 use crate::{block::ProbeFdtBlock, mmio::iomap};
 
 // RK3568 DWCMSHC uses the same SDHCI completion interrupt path as RK3588:
@@ -85,7 +87,7 @@ const PHY_DLL_CNFG2_JUMPSTEP: u8 = 0x0a;
 type RockchipSdhci = SdioSdmmc<SdioHost2Adapter<Sdhci>>;
 
 struct RockchipSdhciClock {
-    clock: RockchipClockOps,
+    clock: ClockLine,
 }
 struct RockchipSdhciResetHook;
 
@@ -140,7 +142,8 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let mmio_base = iomap(base_reg.address as usize, mmio_size as usize)?;
 
     let mut host = unsafe { Sdhci::new(mmio_base) };
-    if let Some(clock) = RockchipClockOps::named(info, "core")? {
+    if let Some(clock) = info.find_clock_line_by_name("core")? {
+        clock.enable()?;
         info!("rockchip-rk3568-sdhci: using external CRU clock");
         host.set_external_clock(RockchipSdhciClock { clock });
     } else {

--- a/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
@@ -17,7 +17,10 @@ use core::{ptr::NonNull, time::Duration};
 
 use log::{info, warn};
 use rdrive::{
-    probe::{OnProbeError, fdt::ResetLine},
+    probe::{
+        OnProbeError,
+        fdt::{ClockLine, ResetLine},
+    },
     register::{FdtInfo, ProbeFdt},
 };
 use sdhci_host::{HostClock, HostResetHook, Sdhci, rdif as sdhci_rdif};
@@ -31,7 +34,7 @@ use sdmmc_protocol::{
     },
 };
 
-use super::clock::{RockchipClockOps, apply_assigned_clocks, enable_node_clocks};
+use super::clock::enable_node_clocks;
 use crate::{block::ProbeFdtBlock, mmio::iomap};
 
 // RK3588 DWCMSHC follows Linux's normal SDHCI completion path: command/data
@@ -88,7 +91,7 @@ const PHY_DLL_CNFG2_JUMPSTEP: u8 = 0x0a;
 type RockchipSdhci = SdioSdmmc<SdioHost2Adapter<Sdhci>>;
 
 struct RockchipSdhciClock {
-    clock: RockchipClockOps,
+    clock: ClockLine,
 }
 struct RockchipSdhciResetHook {
     resets: Vec<ResetLine>,
@@ -207,9 +210,8 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 }
 
 fn apply_rockchip_sdhci_resources(info: &FdtInfo<'_>) -> Result<Vec<ResetLine>, OnProbeError> {
-    apply_assigned_clocks(info, "SDHCI")?;
     let resets = info.reset_lines()?;
-    enable_node_clocks(info, "SDHCI");
+    enable_node_clocks(info, "SDHCI")?;
     Ok(resets)
 }
 
@@ -408,17 +410,8 @@ fn is_absent_card_init_error(err: Error) -> bool {
     }
 }
 
-fn sdhci_core_clock(info: &FdtInfo<'_>) -> Result<Option<RockchipClockOps>, OnProbeError> {
-    for clk in info.node.clocks() {
-        info!(
-            "rockchip-sdhci clock: phandle <{}>, name: {:?}, cells: {}",
-            clk.phandle, clk.name, clk.cells
-        );
-        if clk.name.as_deref() == Some("core") {
-            return RockchipClockOps::from_node_clock(info, &clk);
-        }
-    }
-    Ok(None)
+fn sdhci_core_clock(info: &FdtInfo<'_>) -> Result<Option<ClockLine>, OnProbeError> {
+    info.find_clock_line_by_name("core")
 }
 
 fn clock_error() -> Error {

--- a/drivers/ax-driver/src/block/starfive_mmc.rs
+++ b/drivers/ax-driver/src/block/starfive_mmc.rs
@@ -2,7 +2,10 @@ use alloc::format;
 use core::time::Duration;
 
 use log::{info, warn};
-use rdrive::{probe::OnProbeError, register::ProbeFdt};
+use rdrive::{
+    probe::{OnProbeError, fdt::ResourcePrepareConfig},
+    register::ProbeFdt,
+};
 use sdmmc_protocol::{
     Error, OperationPoll,
     error::Phase,
@@ -55,7 +58,9 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         mmio_size
     );
     let resources = info.prepare_resources(
-        rdrive::probe::fdt::ResourcePrepareConfig::default().with_named_clock_rate("ciu"),
+        ResourcePrepareConfig::default()
+            .without_assigned_clocks()
+            .with_named_clock_rate("ciu"),
     )?;
     let reference_clock_hz = prepared_reference_clock_hz(resources.clock_rate("ciu"));
     let profile = StarFiveMmcNodeProfile::from_info(info, reference_clock_hz);
@@ -236,6 +241,7 @@ fn is_absent_card_init_error(err: Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "pci"))]
     use axklib::{
         AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuMask, IrqHandle,
         IrqId, Klib, PhysAddr, VirtAddr, impl_trait,
@@ -243,8 +249,10 @@ mod tests {
 
     use super::*;
 
+    #[cfg(not(feature = "pci"))]
     struct KlibImpl;
 
+    #[cfg(not(feature = "pci"))]
     impl_trait! {
         impl Klib for KlibImpl {
             fn mem_iomap(_addr: PhysAddr, _size: usize) -> AxResult<VirtAddr> {

--- a/drivers/ax-driver/src/jpeg.rs
+++ b/drivers/ax-driver/src/jpeg.rs
@@ -11,19 +11,15 @@ use core::ptr::NonNull;
 
 use log::info;
 use rdrive::{
-    probe::{OnProbeError, fdt::ResetLine},
+    probe::{
+        OnProbeError,
+        fdt::{ClockLine, ResetLine},
+    },
     register::ProbeFdt,
 };
 use rockchip_jpeg::RockchipJpeg;
 
-use crate::{mmio::iomap, soc::rk3588_enable_clock};
-
-// Synthetic `ClkId` keys into the rockchip-soc gate table — NOT the DT binding
-// numbers. The canonical `ACLK/HCLK_JPEG_DECODER` = 421/422 are already taken by
-// the USB3OTG1 entries in that crate, so 436/437 are used as unique keys instead.
-// The actual hardware gate is the verified `CLKGATE_CON(45)` bit 2/3 in gate.rs.
-const CLK_ACLK_JPEG_DECODER: u32 = 436;
-const CLK_HCLK_JPEG_DECODER: u32 = 437;
+use crate::mmio::iomap;
 
 // The per-block Rockchip IOMMU v2 sits 0x480 into the same register page.
 const IOMMU_OFFSET: usize = 0x480;
@@ -61,9 +57,10 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let size_raw = reg.size.unwrap_or(0x400) as usize;
     let (start, size, offset) = page_aligned_region(start_raw, size_raw);
     let base = unsafe { iomap(start, size)?.add(offset) };
+    let clocks = info.clock_lines()?;
     let resets = info.reset_lines()?;
 
-    bring_up_clocks_and_resets(&resets);
+    bring_up_clocks_and_resets(&clocks, &resets);
     bypass_iommu(base);
 
     let dma = axklib::dma::device_with_mask(u32::MAX as u64);
@@ -91,10 +88,14 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 /// Bring the engine out of reset. All steps are best-effort and idempotent; the
 /// shared VDPU root clocks are left enabled by the bootloader (as for RGA2), so
 /// failures here are logged but not fatal.
-fn bring_up_clocks_and_resets(resets: &[ResetLine]) {
-    for clk in [CLK_ACLK_JPEG_DECODER, CLK_HCLK_JPEG_DECODER] {
-        if let Err(e) = rk3588_enable_clock(clk) {
-            info!("JPEG: enable clock {clk} failed (continuing): {e:?}");
+fn bring_up_clocks_and_resets(clocks: &[ClockLine], resets: &[ResetLine]) {
+    for clock in clocks {
+        if let Err(e) = clock.enable() {
+            info!(
+                "JPEG: enable clock {:?} ({:#x}) failed (continuing): {e}",
+                clock.name(),
+                clock.id().raw()
+            );
         }
     }
     for reset in resets {

--- a/drivers/ax-driver/src/pci/fdt/rk3588/clocks_reset_gpio.rs
+++ b/drivers/ax-driver/src/pci/fdt/rk3588/clocks_reset_gpio.rs
@@ -1,96 +1,32 @@
 use alloc::{format, vec::Vec};
 
-use fdt_edit::{ClockRef, Node, Phandle};
+use fdt_edit::{Node, Phandle};
 use log::warn;
 use rdrive::{
     probe::{
         OnProbeError,
-        fdt::{NodeType, ResetLine, reset_lines},
+        fdt::{ClockLine, NodeType, ResetLine, apply_assigned_clocks, clock_lines, reset_lines},
     },
     register::FdtInfo,
 };
 
 use super::{
-    resources::{ClockSpec, GpioSpec, RK3588_GPIO_BASES},
+    resources::{GpioSpec, RK3588_GPIO_BASES},
     windows::{live_fdt, rk3588_pcie_reset_pin},
 };
-use crate::soc::{rk3588_enable_clock, rk3588_set_clock_rate};
 
-pub(super) fn clock_specs_for_node(node: NodeType<'_>) -> Vec<ClockSpec> {
-    let assigned_clocks = node
-        .as_node()
-        .get_property("assigned-clocks")
-        .map(|prop| {
-            let vals = prop.get_u32_iter().collect::<Vec<_>>();
-            let mut ids = Vec::new();
-            for cells in vals.chunks(2) {
-                if let [_, id] = cells {
-                    ids.push(*id);
-                }
-            }
-            ids
-        })
-        .unwrap_or_default();
-    let assigned_rates = node
-        .as_node()
-        .get_property("assigned-clock-rates")
-        .map(|prop| prop.get_u32_iter().collect::<Vec<_>>())
-        .unwrap_or_default();
-
-    node.clocks()
-        .into_iter()
-        .filter_map(|clock| {
-            let assigned_rate = clock.specifier.first().and_then(|id| {
-                assigned_clocks
-                    .iter()
-                    .position(|assigned| assigned == id)
-                    .and_then(|index| assigned_rates.get(index).copied())
-                    .filter(|rate| *rate != 0)
-            });
-            let id = *clock.specifier.first()?;
-            Some(ClockSpec {
-                name: clock.name,
-                id,
-                assigned_rate,
-            })
-        })
-        .collect()
+pub(super) fn clock_lines_for_node(node: NodeType<'_>) -> Result<Vec<ClockLine>, OnProbeError> {
+    apply_assigned_clocks(node)?;
+    clock_lines(node)
 }
 
-pub(super) fn clock_specs(clocks: Vec<ClockRef>) -> Vec<ClockSpec> {
-    clocks
-        .into_iter()
-        .filter_map(|clock| {
-            let id = *clock.specifier.first()?;
-            Some(ClockSpec {
-                name: clock.name,
-                id,
-                assigned_rate: None,
-            })
-        })
-        .collect()
-}
-
-pub(super) fn enable_clocks(clocks: &[ClockSpec]) -> Result<(), OnProbeError> {
+pub(super) fn enable_clocks(clocks: &[ClockLine]) -> Result<(), OnProbeError> {
     for clock in clocks {
-        let id = clock.id;
+        let id = clock.id().raw();
         if id == 0 {
             continue;
         }
-        if let Some(rate) = clock.assigned_rate {
-            rk3588_set_clock_rate(id, u64::from(rate)).map_err(|err| {
-                OnProbeError::other(format!(
-                    "failed to set RK3588 PCIe clock {:?} ({id:#x}) rate to {rate}: {err}",
-                    clock.name
-                ))
-            })?;
-        }
-        rk3588_enable_clock(id).map_err(|err| {
-            OnProbeError::other(format!(
-                "failed to enable RK3588 PCIe clock {:?} ({id:#x}): {err}",
-                clock.name
-            ))
-        })?;
+        clock.enable()?;
     }
     Ok(())
 }

--- a/drivers/ax-driver/src/pci/fdt/rk3588/phy.rs
+++ b/drivers/ax-driver/src/pci/fdt/rk3588/phy.rs
@@ -7,7 +7,7 @@ use rdrive::probe::{OnProbeError, fdt::NodeType};
 
 use super::{
     clocks_reset_gpio::{
-        assert_resets, clock_specs_for_node, deassert_resets, enable_clocks, parse_resets,
+        assert_resets, clock_lines_for_node, deassert_resets, enable_clocks, parse_resets,
     },
     resources::{
         BIT_WRITEABLE_SHIFT, CombphyResources, PCIE3PHY_SRAM_INIT_DONE, PHP_GRF_PCIESEL_CON,
@@ -122,7 +122,7 @@ fn parse_pcie3_phy(phy: NodeType<'_>) -> Result<Pcie3PhyResources, OnProbeError>
         phy_grf,
         pipe_grf: prop_phandle(node, "rockchip,pipe-grf"),
         pcie30_phymode,
-        clocks: clock_specs_for_node(phy),
+        clocks: clock_lines_for_node(phy)?,
         resets: parse_resets(phy)?,
     })
 }
@@ -206,7 +206,7 @@ fn parse_combphy(phy: NodeType<'_>) -> Result<CombphyResources, OnProbeError> {
         pipe_phy_grf,
         pcie1ln_sel_bits,
         refclk_rate: assigned_clock_rate(node).unwrap_or(100_000_000),
-        clocks: clock_specs_for_node(phy),
+        clocks: clock_lines_for_node(phy)?,
         resets: parse_resets(phy)?,
     })
 }

--- a/drivers/ax-driver/src/pci/fdt/rk3588/resources.rs
+++ b/drivers/ax-driver/src/pci/fdt/rk3588/resources.rs
@@ -18,7 +18,7 @@ use rdif_pinctrl::{FdtPinctrl, PinctrlDevice};
 use rdrive::{
     probe::{
         OnProbeError,
-        fdt::{NodeType, ResetLine},
+        fdt::{ClockLine, NodeType, ResetLine, clock_lines},
     },
     register::{FdtInfo, ProbeFdt},
 };
@@ -26,7 +26,7 @@ use rk3588_pci::{Delay, HostConfig, IatuMode, ResetControl, Rk3588PcieHost};
 
 use super::{
     clocks_reset_gpio::{
-        assert_resets, clock_specs, deassert_resets, enable_clocks, parse_reset_gpio, parse_resets,
+        assert_resets, deassert_resets, enable_clocks, parse_reset_gpio, parse_resets,
     },
     phy::{init_phys, parse_phys},
     register_fdt_legacy_irq,
@@ -172,13 +172,6 @@ impl RegMmio {
     }
 }
 
-#[derive(Clone)]
-pub(super) struct ClockSpec {
-    pub(super) name: Option<String>,
-    pub(super) id: u32,
-    pub(super) assigned_rate: Option<u32>,
-}
-
 #[derive(Clone, Copy)]
 pub(super) struct GpioSpec {
     pub(super) bank: u8,
@@ -196,7 +189,7 @@ pub(super) struct HostResources<'a> {
     pub(super) ranges: Vec<PciRange>,
     pub(super) bus_base: u8,
     pub(super) logical_bus_end: u8,
-    pub(super) clocks: Vec<ClockSpec>,
+    pub(super) clocks: Vec<ClockLine>,
     pub(super) resets: Vec<ResetLine>,
     pub(super) pipe_grf: Option<Phandle>,
     pub(super) reset_gpio: Option<GpioSpec>,
@@ -217,7 +210,7 @@ pub(super) struct Pcie3PhyResources {
     pub(super) phy_grf: Phandle,
     pub(super) pipe_grf: Option<Phandle>,
     pub(super) pcie30_phymode: u32,
-    pub(super) clocks: Vec<ClockSpec>,
+    pub(super) clocks: Vec<ClockLine>,
     pub(super) resets: Vec<ResetLine>,
 }
 
@@ -228,7 +221,7 @@ pub(super) struct CombphyResources {
     pub(super) pipe_phy_grf: Phandle,
     pub(super) pcie1ln_sel_bits: Option<[u32; 4]>,
     pub(super) refclk_rate: u32,
-    pub(super) clocks: Vec<ClockSpec>,
+    pub(super) clocks: Vec<ClockLine>,
     pub(super) resets: Vec<ResetLine>,
 }
 
@@ -415,7 +408,7 @@ fn parse_host_resources<'a>(
         ranges,
         bus_base,
         logical_bus_end,
-        clocks: clock_specs(node.clocks()),
+        clocks: clock_lines(node_type)?,
         resets: parse_resets(node_type)?,
         pipe_grf: prop_phandle(raw_node, "rockchip,pipe-grf"),
         reset_gpio: parse_reset_gpio(info, apb.address)?,

--- a/drivers/ax-driver/src/pwm/rockchip.rs
+++ b/drivers/ax-driver/src/pwm/rockchip.rs
@@ -5,12 +5,12 @@ use alloc::format;
 use log::{info, warn};
 use rdif_pwm::{DriverGeneric, Interface as PwmInterface, Pwm, PwmError, PwmPolarity, PwmState};
 use rdrive::{
-    probe::{OnProbeError, fdt::NodeType},
-    register::ProbeFdt,
+    probe::{OnProbeError, fdt::ClockLine},
+    register::{FdtInfo, ProbeFdt},
 };
 use rockchip_pwm::{RK_PWM_CLOCK_HZ, RK_PWM_MMIO_SIZE, RockchipPwm};
 
-use crate::{mmio::iomap, soc};
+use crate::mmio::iomap;
 
 const PWM_CHANNELS_PER_CHIP: usize = 1;
 
@@ -28,8 +28,8 @@ crate::model_register!(
 
 struct RockchipPwmDevice {
     inner: RockchipPwm,
-    pwm_clock: u32,
-    pclk: u32,
+    pwm_clock: ClockLine,
+    pclk: ClockLine,
     initialized: bool,
 }
 
@@ -64,7 +64,7 @@ impl RockchipPwmDevice {
         if self.initialized {
             return Ok(());
         }
-        if let Err(err) = configure_clocks(self.pwm_clock, self.pclk) {
+        if let Err(err) = configure_clocks(&self.pwm_clock, &self.pclk) {
             warn!("failed to enable Rockchip PWM clocks: {err}");
             return Err(PwmError::InvalidPeriod);
         }
@@ -82,7 +82,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         .into_iter()
         .next()
         .ok_or_else(|| OnProbeError::other(format!("[{}] has no reg", info.node.name())))?;
-    let (pwm_clock, pclk) = pwm_clock_ids(info.node)?;
+    let (pwm_clock, pclk) = pwm_clock_lines(&info)?;
 
     let base = iomap(
         reg.address as usize,
@@ -104,24 +104,19 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     Ok(())
 }
 
-fn pwm_clock_ids(node: NodeType<'_>) -> Result<(u32, u32), OnProbeError> {
-    let mut pwm_clock = None;
-    let mut pclk = None;
-    for clock in node.clocks() {
-        match clock.name.as_deref() {
-            Some("pwm") => pwm_clock = clock.select(),
-            Some("pclk") => pclk = clock.select(),
-            _ => {}
-        }
-    }
-    pwm_clock
-        .zip(pclk)
-        .ok_or_else(|| OnProbeError::other(format!("[{}] missing pwm/pclk clocks", node.name())))
+fn pwm_clock_lines(info: &FdtInfo<'_>) -> Result<(ClockLine, ClockLine), OnProbeError> {
+    let pwm_clock = info
+        .find_clock_line_by_name("pwm")?
+        .ok_or_else(|| OnProbeError::other(format!("[{}] missing pwm clock", info.node.name())))?;
+    let pclk = info
+        .find_clock_line_by_name("pclk")?
+        .ok_or_else(|| OnProbeError::other(format!("[{}] missing pclk clock", info.node.name())))?;
+    Ok((pwm_clock, pclk))
 }
 
-fn configure_clocks(pwm_clock: u32, pclk: u32) -> Result<(), OnProbeError> {
-    soc::rk3588_set_clock_rate(pwm_clock, RK_PWM_CLOCK_HZ)?;
-    soc::rk3588_enable_clock(pwm_clock)?;
-    soc::rk3588_enable_clock(pclk)?;
+fn configure_clocks(pwm_clock: &ClockLine, pclk: &ClockLine) -> Result<(), OnProbeError> {
+    pwm_clock.set_rate(RK_PWM_CLOCK_HZ)?;
+    pwm_clock.enable()?;
+    pclk.enable()?;
     Ok(())
 }

--- a/drivers/ax-driver/src/soc/mod.rs
+++ b/drivers/ax-driver/src/soc/mod.rs
@@ -22,23 +22,7 @@ pub mod scmi;
 mod starfive;
 
 #[cfg(feature = "rockchip-soc")]
-pub use rockchip::{
-    RockchipFdtPinctrlParser, RockchipPinCtrl, rk3588_enable_clock, rk3588_set_clock_rate,
-};
-
-#[cfg(not(feature = "rockchip-soc"))]
-pub fn rk3588_enable_clock(id: u32) -> Result<(), rdrive::probe::OnProbeError> {
-    Err(rdrive::probe::OnProbeError::other(alloc::format!(
-        "RK3588 clock support is not enabled for clock {id:#x}"
-    )))
-}
-
-#[cfg(not(feature = "rockchip-soc"))]
-pub fn rk3588_set_clock_rate(id: u32, rate_hz: u64) -> Result<(), rdrive::probe::OnProbeError> {
-    Err(rdrive::probe::OnProbeError::other(alloc::format!(
-        "RK3588 clock support is not enabled for clock {id:#x} rate {rate_hz}"
-    )))
-}
+pub use rockchip::{RockchipFdtPinctrlParser, RockchipPinCtrl};
 
 #[cfg(not(feature = "rockchip-soc"))]
 pub struct RockchipPinCtrl;

--- a/drivers/ax-driver/src/soc/rockchip/cru/mod.rs
+++ b/drivers/ax-driver/src/soc/rockchip/cru/mod.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use ax_kspin::SpinRaw as Mutex;
-use rdrive::{DriverGeneric, KError, probe::OnProbeError};
+use rdrive::{DriverGeneric, KError};
 use rockchip_soc::{ClkId, ClockOp, Cru, ResetOp, RstId};
 
 mod rk3568;
@@ -17,28 +17,6 @@ pub struct ClkDrv {
 impl ClkDrv {
     pub fn new(name: &'static str, cru: SharedCru) -> Self {
         Self { name, inner: cru }
-    }
-
-    fn enable_clock(&self, id: u32) -> Result<(), OnProbeError> {
-        let id = ClkId::from(id);
-        let mut inner = self.inner.lock();
-        if inner.clk_is_enabled(id).unwrap_or(false) {
-            return Ok(());
-        }
-
-        inner.clk_enable(id).map_err(|err| {
-            OnProbeError::other(alloc::format!("failed to enable clock {id}: {err}"))
-        })
-    }
-
-    fn set_clock_rate(&self, id: u32, rate: u64) -> Result<(), OnProbeError> {
-        self.inner
-            .lock()
-            .clk_set_rate(ClkId::from(id), rate)
-            .map_err(|err| {
-                OnProbeError::other(alloc::format!("failed to set clock {id}: {err}"))
-            })?;
-        Ok(())
     }
 }
 
@@ -113,29 +91,4 @@ fn clock_id(id: rdif_clk::ClockId) -> ClkId {
 
 fn reset_id(id: rdif_reset::ResetId) -> RstId {
     RstId::from(id.raw())
-}
-
-fn with_clk_drv<T>(
-    f: impl FnOnce(&mut ClkDrv) -> Result<T, OnProbeError>,
-) -> Result<T, OnProbeError> {
-    let clk = rdrive::get_one::<rdif_clk::Clk>()
-        .ok_or_else(|| OnProbeError::other("Rockchip CRU clock device not registered"))?;
-    let mut clk = clk.lock().map_err(|err| {
-        OnProbeError::other(alloc::format!(
-            "failed to lock Rockchip CRU clock device: {err}"
-        ))
-    })?;
-    let drv = clk
-        .typed_mut::<ClkDrv>()
-        .ok_or_else(|| OnProbeError::other("Rockchip CRU clock device type mismatch"))?;
-
-    f(drv)
-}
-
-pub fn rk3588_enable_clock(id: u32) -> Result<(), OnProbeError> {
-    with_clk_drv(|drv| drv.enable_clock(id))
-}
-
-pub fn rk3588_set_clock_rate(id: u32, rate: u64) -> Result<(), OnProbeError> {
-    with_clk_drv(|drv| drv.set_clock_rate(id, rate))
 }

--- a/drivers/ax-driver/src/soc/rockchip/mod.rs
+++ b/drivers/ax-driver/src/soc/rockchip/mod.rs
@@ -22,6 +22,4 @@ mod pm;
 mod pinctrl;
 
 #[cfg(feature = "rockchip-soc")]
-pub use cru::{rk3588_enable_clock, rk3588_set_clock_rate};
-#[cfg(feature = "rockchip-soc")]
 pub use pinctrl::{RockchipFdtPinctrlParser, RockchipPinCtrl};

--- a/drivers/ax-driver/src/usb/dwc.rs
+++ b/drivers/ax-driver/src/usb/dwc.rs
@@ -11,18 +11,21 @@ use crab_usb::{
     DwcNewParams, DwcParams, NamedResetLine, UdphyParam, Usb2PhyParam, Usb2PhyPortId,
     UsbPhyInterfaceMode, usb_if::DrMode,
 };
-use fdt_edit::{ClockRef, Fdt, Node, NodeType, Phandle, RegFixed};
+use fdt_edit::{Fdt, Node, NodeType, Phandle, RegFixed};
 use log::{debug, info, warn};
 use rdrive::{
     probe::{
         OnProbeError,
-        fdt::{ResetLine as RdriveResetLine, reset_lines},
+        fdt::{
+            ClockLine, ResetLine as RdriveResetLine, apply_assigned_clocks, clock_lines,
+            reset_lines,
+        },
     },
     register::{FdtInfo, ProbeFdt},
 };
 
 use super::{ProbeFdtUsbHost, usb_kernel};
-use crate::{mmio::iomap, soc::rk3588_enable_clock};
+use crate::mmio::iomap;
 
 const DRIVER_NAME: &str = "usb-dwc-xhci";
 
@@ -62,18 +65,12 @@ impl crab_usb::ResetLine for UsbResetLine {
     }
 }
 
-#[derive(Clone)]
-struct ClockSpec {
-    name: Option<String>,
-    id: u32,
-}
-
 struct Usb2PhyResources {
     port_name: String,
     reg: usize,
     grf: Phandle,
     resets: Vec<NamedResetLine>,
-    clocks: Vec<ClockSpec>,
+    clocks: Vec<ClockLine>,
 }
 
 struct UsbdpPhyResources {
@@ -85,12 +82,12 @@ struct UsbdpPhyResources {
     vo_grf: Phandle,
     dp_lane_mux: Vec<u32>,
     resets: Vec<NamedResetLine>,
-    clocks: Vec<ClockSpec>,
+    clocks: Vec<ClockLine>,
 }
 
 struct DwcResources {
     ctrl: RegFixed,
-    clocks: Vec<ClockSpec>,
+    clocks: Vec<ClockLine>,
     ctrl_resets: Vec<NamedResetLine>,
     usb2: Usb2PhyResources,
     usbdp: UsbdpPhyResources,
@@ -117,7 +114,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let fdt = live_fdt()?;
     let resources = collect_resources(info, &fdt)?;
 
-    enable_clocks(&resources.clocks);
+    enable_clocks(&resources.clocks)?;
 
     let ctrl = map_reg(resources.ctrl)?;
     let phy = map_reg(resources.usbdp.reg)?;
@@ -186,9 +183,10 @@ fn collect_resources(info: &FdtInfo<'_>, fdt: &Fdt) -> Result<DwcResources, OnPr
 
     let mut clocks = Vec::new();
     if let Some(parent) = info.node.parent() {
-        clocks.extend(clock_specs(parent.clocks()));
+        apply_assigned_clocks(parent)?;
+        clocks.extend(clock_lines(parent)?);
     }
-    clocks.extend(clock_specs(info.node.clocks()));
+    clocks.extend(info.clock_lines()?);
     clocks.extend(usb2.clocks.iter().cloned());
     clocks.extend(usbdp.clocks.iter().cloned());
 
@@ -227,7 +225,10 @@ fn collect_usb2_phy(fdt: &Fdt, port_phandle: Phandle) -> Result<Usb2PhyResources
         reg,
         grf,
         resets: parse_resets(phy)?,
-        clocks: clock_specs(phy.clocks()),
+        clocks: {
+            apply_assigned_clocks(phy)?;
+            clock_lines(phy)?
+        },
     })
 }
 
@@ -257,7 +258,10 @@ fn collect_usbdp_phy(fdt: &Fdt, port_phandle: Phandle) -> Result<UsbdpPhyResourc
             .map(|prop| prop.get_u32_iter().collect())
             .unwrap_or_default(),
         resets: parse_resets(phy)?,
-        clocks: clock_specs(phy.clocks()),
+        clocks: {
+            apply_assigned_clocks(phy)?;
+            clock_lines(phy)?
+        },
     })
 }
 
@@ -361,33 +365,17 @@ fn parse_dwc_params(node: &Node) -> DwcParams {
     params
 }
 
-fn enable_clocks(clocks: &[ClockSpec]) {
+fn enable_clocks(clocks: &[ClockLine]) -> Result<(), OnProbeError> {
     for clock in clocks {
-        if clock.id == 0 {
+        let id = clock.id().raw();
+        if id == 0 {
             continue;
         }
 
-        match rk3588_enable_clock(clock.id) {
-            Ok(()) => debug!("DWC xHCI clock {:?} ({:#x}) enabled", clock.name, clock.id),
-            Err(err) => warn!(
-                "DWC xHCI clock {:?} ({:#x}) enable skipped: {err}",
-                clock.name, clock.id
-            ),
-        }
+        clock.enable()?;
+        debug!("DWC xHCI clock {:?} ({id:#x}) enabled", clock.name());
     }
-}
-
-fn clock_specs(clocks: Vec<ClockRef>) -> Vec<ClockSpec> {
-    clocks
-        .into_iter()
-        .filter_map(|clock| {
-            let id = *clock.specifier.first()?;
-            Some(ClockSpec {
-                name: clock.name,
-                id,
-            })
-        })
-        .collect()
+    Ok(())
 }
 
 fn usbdp_phy_id(fdt: &Fdt, phy: NodeType<'_>) -> Result<usize, OnProbeError> {

--- a/drivers/ax-driver/src/usb/ehci.rs
+++ b/drivers/ax-driver/src/usb/ehci.rs
@@ -1,25 +1,21 @@
 extern crate alloc;
 
-use alloc::{
-    format,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{format, string::ToString, vec::Vec};
 use core::ptr::NonNull;
 
 use crab_usb::{EhciNewParams, usb_if::Speed};
-use fdt_edit::{ClockRef, Fdt, Node, NodeType, Phandle, RegFixed};
+use fdt_edit::{Fdt, Node, NodeType, Phandle, RegFixed};
 use log::{debug, info, warn};
 use rdrive::{
     probe::{
         OnProbeError,
-        fdt::{ResetLine, reset_lines},
+        fdt::{ClockLine, ResetLine, apply_assigned_clocks, clock_lines, reset_lines},
     },
     register::{FdtInfo, ProbeFdt},
 };
 
 use super::{ProbeFdtUsbHost, usb_kernel};
-use crate::{mmio::iomap, soc::rk3588_enable_clock};
+use crate::mmio::iomap;
 
 const DRIVER_NAME: &str = "usb-rockchip-ehci";
 
@@ -35,15 +31,9 @@ crate::model_register!(
     ],
 );
 
-#[derive(Clone)]
-struct ClockSpec {
-    name: Option<String>,
-    id: u32,
-}
-
 struct EhciResources {
     ctrl: RegFixed,
-    clocks: Vec<ClockSpec>,
+    clocks: Vec<ClockLine>,
     resets: Vec<ResetLine>,
 }
 
@@ -52,7 +42,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let fdt = live_fdt()?;
     let resources = collect_resources(info, &fdt)?;
 
-    enable_clocks(&resources.clocks);
+    enable_clocks(&resources.clocks)?;
     deassert_resets(&resources.resets);
 
     let mmio = map_reg(resources.ctrl)?;
@@ -84,12 +74,14 @@ fn collect_resources(info: &FdtInfo<'_>, fdt: &Fdt) -> Result<EhciResources, OnP
         .next()
         .ok_or_else(|| OnProbeError::other(format!("[{}] has no reg", info.node.name())))?;
 
-    let mut clocks = clock_specs(info.node.clocks());
+    let mut clocks = info.clock_lines()?;
     let mut resets = parse_resets(info.node)?;
 
     for phy in collect_usb2_phys(info.node.as_node(), fdt) {
-        clocks.extend(clock_specs(phy.port.clocks()));
-        clocks.extend(clock_specs(phy.parent.clocks()));
+        apply_assigned_clocks(phy.port)?;
+        clocks.extend(clock_lines(phy.port)?);
+        apply_assigned_clocks(phy.parent)?;
+        clocks.extend(clock_lines(phy.parent)?);
         resets.extend(parse_resets(phy.parent)?);
     }
 
@@ -123,20 +115,17 @@ fn parse_resets(node: NodeType<'_>) -> Result<Vec<ResetLine>, OnProbeError> {
     reset_lines(node)
 }
 
-fn enable_clocks(clocks: &[ClockSpec]) {
+fn enable_clocks(clocks: &[ClockLine]) -> Result<(), OnProbeError> {
     for clock in clocks {
-        if clock.id == 0 {
+        let id = clock.id().raw();
+        if id == 0 {
             continue;
         }
 
-        match rk3588_enable_clock(clock.id) {
-            Ok(()) => debug!("EHCI clock {:?} ({:#x}) enabled", clock.name, clock.id),
-            Err(err) => warn!(
-                "EHCI clock {:?} ({:#x}) enable skipped: {err}",
-                clock.name, clock.id
-            ),
-        }
+        clock.enable()?;
+        debug!("EHCI clock {:?} ({id:#x}) enabled", clock.name());
     }
+    Ok(())
 }
 
 fn deassert_resets(resets: &[ResetLine]) {
@@ -154,19 +143,6 @@ fn deassert_resets(resets: &[ResetLine]) {
             ),
         }
     }
-}
-
-fn clock_specs(clocks: Vec<ClockRef>) -> Vec<ClockSpec> {
-    clocks
-        .into_iter()
-        .filter_map(|clock| {
-            let id = *clock.specifier.first()?;
-            Some(ClockSpec {
-                name: clock.name,
-                id,
-            })
-        })
-        .collect()
 }
 
 fn live_fdt() -> Result<Fdt, OnProbeError> {

--- a/drivers/rdrive/src/probe/fdt/mod.rs
+++ b/drivers/rdrive/src/probe/fdt/mod.rs
@@ -72,7 +72,7 @@ pub struct ResourcePrepareConfig {
 impl Default for ResourcePrepareConfig {
     fn default() -> Self {
         Self {
-            apply_assigned_clocks: true,
+            apply_assigned_clocks: false,
             enable_clocks: true,
             deassert_resets: true,
             enable_power_domains: false,
@@ -85,6 +85,11 @@ impl Default for ResourcePrepareConfig {
 impl ResourcePrepareConfig {
     pub fn without_assigned_clocks(mut self) -> Self {
         self.apply_assigned_clocks = false;
+        self
+    }
+
+    pub fn with_assigned_clocks(mut self) -> Self {
+        self.apply_assigned_clocks = true;
         self
     }
 
@@ -132,95 +137,6 @@ impl ResourcePrepareReport {
     fn insert_clock_rate(&mut self, name: String, rate: u64) {
         self.clock_rates.insert(name, rate);
     }
-}
-
-#[derive(Clone)]
-struct ClockLine {
-    node_name: String,
-    clock_name: Option<String>,
-    device: Device<rdif_clk::Clk>,
-    id: rdif_clk::ClockId,
-}
-
-impl ClockLine {
-    fn from_ref(info: &FdtInfo<'_>, clock: &ClockRef) -> Result<Self, OnProbeError> {
-        let clock_id = clock_selector(info, clock)?;
-        let device_id = info.phandle_to_device_id(clock.phandle).ok_or_else(|| {
-            OnProbeError::other(format!(
-                "[{}] clock {:?} phandle {:?} has no device id",
-                info.node.name(),
-                clock.name,
-                clock.phandle
-            ))
-        })?;
-        let device = crate::get::<rdif_clk::Clk>(device_id).map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] clock {:?} provider {:?} has no rdif-clk interface: {err}",
-                info.node.name(),
-                clock.name,
-                clock.phandle
-            ))
-        })?;
-        Ok(Self {
-            node_name: info.node.name().to_string(),
-            clock_name: clock.name.clone(),
-            device,
-            id: rdif_clk::ClockId::from(clock_id as usize),
-        })
-    }
-
-    fn enable(&self) -> Result<(), OnProbeError> {
-        let mut clock = self.lock()?;
-        clock.enable(self.id).map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] failed to enable clock {:?} ({:?}): {err:?}",
-                self.node_name, self.clock_name, self.id
-            ))
-        })
-    }
-
-    fn set_rate(&self, rate: u64) -> Result<(), OnProbeError> {
-        let mut clock = self.lock()?;
-        clock.set_rate(self.id, rate).map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] failed to set clock {:?} ({:?}) to {} Hz: {err:?}",
-                self.node_name, self.clock_name, self.id, rate
-            ))
-        })
-    }
-
-    fn rate(&self) -> Result<u64, OnProbeError> {
-        let clock = self.lock()?;
-        clock.get_rate(self.id).map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] failed to read clock {:?} ({:?}): {err:?}",
-                self.node_name, self.clock_name, self.id
-            ))
-        })
-    }
-
-    fn lock(&self) -> Result<crate::DeviceGuard<rdif_clk::Clk>, OnProbeError> {
-        self.device.lock().map_err(|err| {
-            OnProbeError::other(format!(
-                "[{}] failed to lock clock {:?} ({:?}): {err}",
-                self.node_name, self.clock_name, self.id
-            ))
-        })
-    }
-}
-
-fn clock_selector(info: &FdtInfo<'_>, clock: &ClockRef) -> Result<u32, OnProbeError> {
-    if clock.cells == 0 {
-        return Ok(0);
-    }
-    clock.select().ok_or_else(|| {
-        OnProbeError::other(format!(
-            "[{}] clock {:?} provider {:?} has no selector",
-            info.node.name(),
-            clock.name,
-            clock.phandle
-        ))
-    })
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -477,6 +393,123 @@ impl PowerDomainLine {
     }
 }
 
+#[derive(Clone)]
+pub struct ClockLine {
+    node_name: String,
+    name: Option<String>,
+    device: Device<rdif_clk::Clk>,
+    id: rdif_clk::ClockId,
+}
+
+impl ClockLine {
+    fn from_refs(node_name: &str, refs: Vec<ClockRef>) -> Result<Vec<Self>, OnProbeError> {
+        refs.into_iter()
+            .filter_map(|clock| match clock.cells {
+                0 => None,
+                _ => Some(Self::from_ref(node_name, &clock)),
+            })
+            .collect()
+    }
+
+    fn from_ref(node_name: &str, clock: &ClockRef) -> Result<Self, OnProbeError> {
+        if clock.cells != 1 {
+            return Err(OnProbeError::other(format!(
+                "[{node_name}] clock {} uses {} cells, only one-cell clock selectors are supported",
+                clock_label(clock),
+                clock.cells
+            )));
+        }
+        let selector = clock.select().ok_or_else(|| {
+            OnProbeError::other(format!(
+                "[{node_name}] clock {} has no selector",
+                clock_label(clock)
+            ))
+        })?;
+        let provider_id = system()
+            .phandle_to_device_id(clock.phandle)
+            .ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{node_name}] clock provider phandle {:?} is not populated",
+                    clock.phandle
+                ))
+            })?;
+        let device = crate::get::<rdif_clk::Clk>(provider_id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{node_name}] clock provider {:?} has no rdif-clk interface: {err}",
+                clock.phandle
+            ))
+        })?;
+
+        Ok(Self {
+            node_name: node_name.to_string(),
+            name: clock.name.clone(),
+            device,
+            id: rdif_clk::ClockId::from(selector as usize),
+        })
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub fn id(&self) -> rdif_clk::ClockId {
+        self.id
+    }
+
+    pub fn enable(&self) -> Result<(), OnProbeError> {
+        self.with_clock("enable", |clock, id| clock.enable(id))
+    }
+
+    pub fn set_rate(&self, rate: u64) -> Result<(), OnProbeError> {
+        self.with_clock("set rate", |clock, id| clock.set_rate(id, rate))
+    }
+
+    pub fn rate(&self) -> Result<u64, OnProbeError> {
+        let clock = self.device.lock().map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to lock clock {}: {err}",
+                self.node_name,
+                self.label()
+            ))
+        })?;
+        clock.get_rate(self.id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to read clock {}: {err:?}",
+                self.node_name,
+                self.label()
+            ))
+        })
+    }
+
+    fn with_clock(
+        &self,
+        operation: &'static str,
+        f: impl FnOnce(&mut rdif_clk::Clk, rdif_clk::ClockId) -> Result<(), rdif_clk::KError>,
+    ) -> Result<(), OnProbeError> {
+        let mut clock = self.device.lock().map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to lock clock {}: {err}",
+                self.node_name,
+                self.label()
+            ))
+        })?;
+        f(&mut clock, self.id).map_err(|err| {
+            OnProbeError::other(format!(
+                "[{}] failed to {operation} clock {}: {err:?}",
+                self.node_name,
+                self.label()
+            ))
+        })
+    }
+
+    fn label(&self) -> String {
+        match self.name() {
+            Some(name) => format!("{name}({:#x})", self.id.raw()),
+            None => format!("{:#x}", self.id.raw()),
+        }
+    }
+}
+
 fn reset_label(reset: &ResetRef) -> String {
     match reset.name.as_deref() {
         Some(name) => name.to_string(),
@@ -488,6 +521,13 @@ fn power_domain_label(domain: &PowerDomainRef) -> String {
     match domain.name.as_deref() {
         Some(name) => name.to_string(),
         None => format!("phandle {:?}", domain.phandle),
+    }
+}
+
+fn clock_label(clock: &ClockRef) -> String {
+    match clock.name.as_deref() {
+        Some(name) => name.to_string(),
+        None => format!("phandle {:?}", clock.phandle),
     }
 }
 
@@ -620,9 +660,90 @@ pub fn power_domain_refs(node: NodeType<'_>) -> Result<Vec<PowerDomainRef>, OnPr
     })
 }
 
+fn clock_refs_from_node(
+    node: NodeType<'_>,
+    property: &str,
+    names_property: Option<&str>,
+    mut provider_cells: impl FnMut(Phandle) -> Result<(String, u32), OnProbeError>,
+) -> Result<Vec<ClockRef>, OnProbeError> {
+    let Some(prop) = node.as_node().get_property(property) else {
+        return Ok(Vec::new());
+    };
+    let clock_names = names_property
+        .and_then(|name| node.as_node().get_property(name))
+        .map(|prop| {
+            prop.as_str_iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut reader = prop.as_reader();
+    let mut refs = Vec::new();
+    let mut index = 0;
+    while let Some(phandle_raw) = reader.read_u32() {
+        if phandle_raw == 0 {
+            index += 1;
+            continue;
+        }
+
+        let phandle = Phandle::from(phandle_raw);
+        let (_provider_name, cells) = provider_cells(phandle)?;
+
+        let mut specifier = Vec::with_capacity(cells as usize);
+        for _ in 0..cells {
+            let value = reader.read_u32().ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] has truncated {property} entry for phandle {phandle:?}",
+                    node.name()
+                ))
+            })?;
+            specifier.push(value);
+        }
+
+        refs.push(ClockRef {
+            name: clock_names.get(index).cloned(),
+            phandle,
+            cells,
+            specifier,
+        });
+        index += 1;
+    }
+    Ok(refs)
+}
+
+pub fn clock_refs(node: NodeType<'_>) -> Result<Vec<ClockRef>, OnProbeError> {
+    clock_refs_from_node(node, "clocks", Some("clock-names"), |phandle| {
+        let provider = system().get_by_phandle(phandle).ok_or_else(|| {
+            OnProbeError::other(format!(
+                "[{}] clock provider phandle {phandle:?} not found",
+                node.name()
+            ))
+        })?;
+        let cells = provider
+            .as_node()
+            .get_property("#clock-cells")
+            .and_then(|prop| prop.get_u32())
+            .ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] clock provider {} has no #clock-cells",
+                    node.name(),
+                    provider.name()
+                ))
+            })?;
+
+        Ok((provider.name().to_string(), cells))
+    })
+}
+
 pub fn reset_lines(node: NodeType<'_>) -> Result<Vec<ResetLine>, OnProbeError> {
     let refs = reset_refs(node)?;
     ResetLine::from_refs(node.name(), refs)
+}
+
+pub fn clock_lines(node: NodeType<'_>) -> Result<Vec<ClockLine>, OnProbeError> {
+    let refs = clock_refs(node)?;
+    ClockLine::from_refs(node.name(), refs)
 }
 
 pub fn power_domain_lines(node: NodeType<'_>) -> Result<Vec<PowerDomainLine>, OnProbeError> {
@@ -672,7 +793,7 @@ impl<'a> FdtInfo<'a> {
         config: ResourcePrepareConfig,
     ) -> Result<ResourcePrepareReport, OnProbeError> {
         if config.apply_assigned_clocks {
-            apply_assigned_clocks(self)?;
+            apply_assigned_clocks_for_info(self)?;
         }
         apply_supply_regulators(self, &config.supply_names)?;
         if config.enable_power_domains {
@@ -681,8 +802,8 @@ impl<'a> FdtInfo<'a> {
             }
         }
         if config.enable_clocks {
-            for clock in self.node.clocks() {
-                ClockLine::from_ref(self, &clock)?.enable()?;
+            for clock in self.clock_lines()? {
+                clock.enable()?;
             }
         }
         if config.deassert_resets {
@@ -693,13 +814,38 @@ impl<'a> FdtInfo<'a> {
 
         let mut report = ResourcePrepareReport::default();
         for name in config.clock_rates {
-            let Some(clock) = self.find_clk_by_name(&name) else {
+            let Some(clock) = self.find_clock_line_by_name(&name)? else {
                 continue;
             };
-            let clock = ClockLine::from_ref(self, &clock)?;
             report.insert_clock_rate(name, clock.rate()?);
         }
         Ok(report)
+    }
+
+    pub fn clocks(&self) -> Result<Vec<ClockRef>, OnProbeError> {
+        clock_refs(self.node)
+    }
+
+    pub fn clock_lines(&self) -> Result<Vec<ClockLine>, OnProbeError> {
+        clock_lines(self.node)
+    }
+
+    pub fn clock_line(&self, clock: &ClockRef) -> Result<ClockLine, OnProbeError> {
+        ClockLine::from_ref(self.node.name(), clock)
+    }
+
+    pub fn find_clock_line_by_name(&self, name: &str) -> Result<Option<ClockLine>, OnProbeError> {
+        let Some(clock) = self
+            .clocks()?
+            .into_iter()
+            .find(|clock| clock.name.as_deref() == Some(name))
+        else {
+            return Ok(None);
+        };
+        if clock.cells == 0 {
+            return Ok(None);
+        }
+        self.clock_line(&clock).map(Some)
     }
 
     pub fn resets(&self) -> Result<Vec<ResetRef>, OnProbeError> {
@@ -757,22 +903,64 @@ impl<'a> FdtInfo<'a> {
     }
 }
 
-fn apply_assigned_clocks(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
+pub fn apply_assigned_clocks(node: NodeType<'_>) -> Result<(), OnProbeError> {
+    let info = FdtInfo {
+        node,
+        phandle_2_device_id: system().phandle_2_device_id.clone(),
+    };
+    apply_assigned_clocks_for_info(&info)
+}
+
+fn apply_assigned_clocks_for_info(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
+    let node = info.node;
+    if node.as_node().get_property("#clock-cells").is_some() {
+        return Ok(());
+    }
+
     let clocks = clock_refs_from_property(info, "assigned-clocks")?;
-    let rates = info
-        .node
+    let rates = node
         .as_node()
         .get_property("assigned-clock-rates")
         .map(|prop| prop.get_u32_iter().map(u64::from).collect::<Vec<_>>())
         .unwrap_or_default();
+    let node_phandle = node.as_node().phandle();
     for (index, clock) in clocks.into_iter().enumerate() {
         let Some(rate) = rates.get(index).copied() else {
             continue;
         };
-        if rate == 0 {
+        if rate == 0 || clock.cells == 0 || Some(clock.phandle) == node_phandle {
             continue;
         }
-        ClockLine::from_ref(info, &clock)?.set_rate(rate)?;
+        if clock.cells != 1 {
+            return Err(OnProbeError::other(format!(
+                "[{}] assigned clock {} uses {} cells, only one-cell clock selectors are supported",
+                node.name(),
+                clock_label(&clock),
+                clock.cells
+            )));
+        }
+        let Some(provider_id) = info.phandle_to_device_id(clock.phandle) else {
+            return Err(OnProbeError::other(format!(
+                "[{}] assigned clock provider phandle {:?} is not populated",
+                node.name(),
+                clock.phandle
+            )));
+        };
+        match crate::get::<rdif_clk::Clk>(provider_id) {
+            Ok(_) => {}
+            Err(crate::GetDeviceError::TypeNotMatch | crate::GetDeviceError::NotFound) => {
+                continue;
+            }
+            Err(err) => {
+                return Err(OnProbeError::other(format!(
+                    "[{}] assigned clock provider {:?} has no rdif-clk interface: {err}",
+                    node.name(),
+                    clock.phandle
+                )));
+            }
+        }
+
+        ClockLine::from_ref(node.name(), &clock)?.set_rate(rate)?;
     }
     Ok(())
 }
@@ -781,39 +969,27 @@ fn clock_refs_from_property(
     info: &FdtInfo<'_>,
     property_name: &'static str,
 ) -> Result<Vec<ClockRef>, OnProbeError> {
-    let Some(prop) = info.node.as_node().get_property(property_name) else {
-        return Ok(Vec::new());
-    };
-    let mut reader = prop.as_reader();
-    let mut refs = Vec::new();
-    while let Some(phandle_raw) = reader.read_u32() {
-        let phandle = Phandle::from(phandle_raw);
+    clock_refs_from_node(info.node, property_name, None, |phandle| {
         let provider = info.get_by_phandle(phandle).ok_or_else(|| {
             OnProbeError::other(format!(
-                "[{}] {property_name} provider phandle {:?} not found",
-                info.node.name(),
-                phandle
+                "[{}] {property_name} provider phandle {phandle:?} not found",
+                info.node.name()
             ))
         })?;
         let cells = provider
             .as_node()
             .get_property("#clock-cells")
             .and_then(|prop| prop.get_u32())
-            .unwrap_or(1);
-        let mut specifier = Vec::with_capacity(cells as usize);
-        for _ in 0..cells {
-            let value = reader.read_u32().ok_or_else(|| {
+            .ok_or_else(|| {
                 OnProbeError::other(format!(
-                    "[{}] has truncated {property_name} entry for phandle {:?}",
+                    "[{}] {property_name} provider {} has no #clock-cells",
                     info.node.name(),
-                    phandle
+                    provider.name()
                 ))
             })?;
-            specifier.push(value);
-        }
-        refs.push(ClockRef::new(phandle, cells, specifier));
-    }
-    Ok(refs)
+
+        Ok((provider.name().to_string(), cells))
+    })
 }
 
 fn apply_supply_regulators(
@@ -1049,7 +1225,8 @@ impl System {
             let phandle_map = self.phandle_2_device_id.clone();
 
             debug!("Probe [{}]->[{}]", node.name(), node_info.name);
-            let res = apply_power_domains(node)
+            let res = apply_assigned_clocks(node)
+                .and_then(|()| apply_power_domains(node))
                 .and_then(|()| apply_default_pinctrl(node))
                 .and_then(|()| {
                     let descriptor = Descriptor {
@@ -1174,6 +1351,111 @@ mod tests {
 
         assert!(format!("{err}").contains("truncated power-domains entry"));
         assert_eq!(fdt.node(consumer).unwrap().name(), "jpeg@fdba0000");
+    }
+
+    #[test]
+    fn clock_refs_parse_names_and_provider_cells() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.add_node(
+            root,
+            node_with_props(
+                "clock-controller",
+                &[
+                    prop_u32s("phandle", &[0x44]),
+                    prop_u32s("#clock-cells", &[1]),
+                ],
+            ),
+        );
+        let consumer = fdt.add_node(
+            root,
+            node_with_props(
+                "usb@fcd00000",
+                &[
+                    prop_u32s("clocks", &[0x44, 11, 0x44, 12]),
+                    prop_strs("clock-names", &["bus", "ref"]),
+                ],
+            ),
+        );
+
+        let refs = clock_refs_from_node(
+            fdt.get_by_path("/usb@fcd00000").unwrap(),
+            "clocks",
+            Some("clock-names"),
+            |phandle| {
+                fdt.get_by_phandle(phandle)
+                    .and_then(|provider| {
+                        provider
+                            .as_node()
+                            .get_property("#clock-cells")
+                            .and_then(|prop| prop.get_u32())
+                            .map(|cells| (provider.name().to_string(), cells))
+                    })
+                    .ok_or_else(|| OnProbeError::other(format!("missing provider {phandle:?}")))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].name.as_deref(), Some("bus"));
+        assert_eq!(refs[0].phandle, Phandle::from(0x44));
+        assert_eq!(refs[0].cells, 1);
+        assert_eq!(refs[0].specifier, vec![11]);
+        assert_eq!(refs[1].name.as_deref(), Some("ref"));
+        assert_eq!(refs[1].specifier, vec![12]);
+        assert_eq!(fdt.node(consumer).unwrap().name(), "usb@fcd00000");
+    }
+
+    #[test]
+    fn clock_refs_reject_truncated_provider_specifier() {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        let consumer = fdt.add_node(
+            root,
+            node_with_props("pcie@fe150000", &[prop_u32s("clocks", &[0x44])]),
+        );
+
+        let err = clock_refs_from_node(
+            fdt.get_by_path("/pcie@fe150000").unwrap(),
+            "clocks",
+            Some("clock-names"),
+            |_| Ok(("clock-controller".into(), 1)),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("truncated clocks entry"));
+        assert_eq!(fdt.node(consumer).unwrap().name(), "pcie@fe150000");
+    }
+
+    #[test]
+    fn clock_lines_reject_multi_cell_provider() {
+        let clock = ClockRef {
+            name: Some("core".into()),
+            phandle: Phandle::from(0x44),
+            cells: 2,
+            specifier: vec![11, 0],
+        };
+
+        let err = match ClockLine::from_refs("device@2000", vec![clock]) {
+            Ok(_) => panic!("multi-cell clock provider should be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(format!("{err}").contains("only one-cell clock selectors are supported"));
+    }
+
+    #[test]
+    fn clock_lines_skip_zero_cell_provider() {
+        let clock = ClockRef {
+            name: Some("utmi".into()),
+            phandle: Phandle::from(0x44),
+            cells: 0,
+            specifier: Vec::new(),
+        };
+
+        let lines = ClockLine::from_refs("usb@fc800000", vec![clock]).unwrap();
+
+        assert!(lines.is_empty());
     }
 
     fn node_with_props(name: &str, props: &[Property]) -> Node {

--- a/drivers/rdrive/tests/fdt_clock.rs
+++ b/drivers/rdrive/tests/fdt_clock.rs
@@ -1,0 +1,275 @@
+use core::ptr::NonNull;
+use std::{
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    vec,
+    vec::Vec,
+};
+
+use fdt_edit::{Fdt, Node, Property};
+use rdif_clk::{ClockId, KError};
+use rdrive::{
+    DriverGeneric, Platform, get_one,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+static CLOCK_CALLS: Mutex<Vec<ClockCall>> = Mutex::new(Vec::new());
+static ASSIGNED_APPLIED_BEFORE_PROBE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ClockCall {
+    operation: &'static str,
+    id: usize,
+    rate: Option<u64>,
+}
+
+struct ClockProviderDevice;
+struct ScmiLikeClockProviderDevice;
+struct ClockConsumerDevice;
+
+impl DriverGeneric for ClockProviderDevice {
+    fn name(&self) -> &str {
+        "clock-provider"
+    }
+}
+
+impl DriverGeneric for ScmiLikeClockProviderDevice {
+    fn name(&self) -> &str {
+        "scmi-like-clock-provider"
+    }
+}
+
+impl rdif_clk::Interface for ClockProviderDevice {
+    fn perper_enable(&mut self) {}
+
+    fn enable(&mut self, id: ClockId) -> Result<(), KError> {
+        CLOCK_CALLS.lock().unwrap().push(ClockCall {
+            operation: "enable",
+            id: id.raw(),
+            rate: None,
+        });
+        Ok(())
+    }
+
+    fn get_rate(&self, id: ClockId) -> Result<u64, KError> {
+        Ok(24_000_000 + id.raw() as u64)
+    }
+
+    fn set_rate(&mut self, id: ClockId, rate: u64) -> Result<(), KError> {
+        CLOCK_CALLS.lock().unwrap().push(ClockCall {
+            operation: "set_rate",
+            id: id.raw(),
+            rate: Some(rate),
+        });
+        Ok(())
+    }
+}
+
+impl DriverGeneric for ClockConsumerDevice {
+    fn name(&self) -> &str {
+        "clock-consumer"
+    }
+}
+
+fn probe_clock_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_clk::Clk::new(ClockProviderDevice));
+    Ok(())
+}
+
+fn probe_scmi_like_clock_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(ScmiLikeClockProviderDevice);
+    Ok(())
+}
+
+fn probe_clock_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let info = probe.info();
+    let lines = info.clock_lines()?;
+    let core = info
+        .find_clock_line_by_name("core")?
+        .ok_or_else(|| OnProbeError::other("core clock line not found"))?;
+    let bus = info
+        .find_clock_line_by_name("bus")?
+        .ok_or_else(|| OnProbeError::other("bus clock line not found"))?;
+
+    ASSIGNED_APPLIED_BEFORE_PROBE.store(
+        lines.len() == 2
+            && core.name() == Some("core")
+            && core.id() == ClockId::from(11)
+            && bus.name() == Some("bus")
+            && bus.id() == ClockId::from(12)
+            && info.find_clock_line_by_name("utmi").unwrap().is_none()
+            && CLOCK_CALLS.lock().unwrap().as_slice()
+                == [ClockCall {
+                    operation: "set_rate",
+                    id: 11,
+                    rate: Some(100_000_000),
+                }],
+        Ordering::SeqCst,
+    );
+
+    core.enable()?;
+    bus.set_rate(50_000_000)?;
+    assert_eq!(core.rate()?, 24_000_011);
+
+    probe.into_platform_device().register(ClockConsumerDevice);
+    Ok(())
+}
+
+static CLOCK_PROVIDER_REGISTER: DriverRegister = DriverRegister {
+    name: "test clock provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,clock-provider"],
+        on_probe: probe_clock_provider,
+    }],
+};
+
+static SCMI_LIKE_CLOCK_PROVIDER_REGISTER: DriverRegister = DriverRegister {
+    name: "test scmi-like clock provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,scmi-like-clock-provider"],
+        on_probe: probe_scmi_like_clock_provider,
+    }],
+};
+
+static CLOCK_CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "test clock consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,clock-consumer"],
+        on_probe: probe_clock_consumer,
+    }],
+};
+
+#[test]
+fn fdt_probe_applies_assigned_clock_rates_without_enabling_consumer_clocks() {
+    CLOCK_CALLS.lock().unwrap().clear();
+    ASSIGNED_APPLIED_BEFORE_PROBE.store(false, Ordering::SeqCst);
+
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "clock-controller",
+            &[
+                prop_strs("compatible", &["test,clock-provider"]),
+                prop_u32s("phandle", &[1]),
+                prop_u32s("#clock-cells", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "scmi-clock-protocol",
+            &[
+                prop_strs("compatible", &["test,scmi-like-clock-provider"]),
+                prop_u32s("phandle", &[2]),
+                prop_u32s("#clock-cells", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "usb-phy-clock-output",
+            &[prop_u32s("phandle", &[3]), prop_u32s("#clock-cells", &[0])],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "unregistered-scmi-clock-protocol",
+            &[prop_u32s("phandle", &[4]), prop_u32s("#clock-cells", &[1])],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "device@2000",
+            &[
+                prop_strs("compatible", &["test,clock-consumer"]),
+                prop_u32s("clocks", &[1, 11, 1, 12, 3]),
+                prop_strs("clock-names", &["core", "bus", "utmi"]),
+                prop_u32s("assigned-clocks", &[1, 11, 1, 12, 2, 6, 4, 7]),
+                prop_u32s(
+                    "assigned-clock-rates",
+                    &[100_000_000, 0, 200_000_000, 300_000_000],
+                ),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(CLOCK_PROVIDER_REGISTER.clone());
+    rdrive::register_add(SCMI_LIKE_CLOCK_PROVIDER_REGISTER.clone());
+    rdrive::register_add(CLOCK_CONSUMER_REGISTER.clone());
+
+    probe_all(true).expect("FDT probe should succeed");
+
+    assert!(ASSIGNED_APPLIED_BEFORE_PROBE.load(Ordering::SeqCst));
+    assert!(get_one::<ClockConsumerDevice>().is_some());
+    assert_eq!(
+        *CLOCK_CALLS.lock().unwrap(),
+        vec![
+            ClockCall {
+                operation: "set_rate",
+                id: 11,
+                rate: Some(100_000_000),
+            },
+            ClockCall {
+                operation: "enable",
+                id: 11,
+                rate: None,
+            },
+            ClockCall {
+                operation: "set_rate",
+                id: 12,
+                rate: Some(50_000_000),
+            },
+        ]
+    );
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/rdrive/tests/fdt_clock_provider_assigned.rs
+++ b/drivers/rdrive/tests/fdt_clock_provider_assigned.rs
@@ -1,0 +1,110 @@
+use core::ptr::NonNull;
+use std::vec::Vec;
+
+use fdt_edit::{Fdt, Node, Property};
+use rdrive::{
+    DriverGeneric, Platform,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+struct ClockProviderDevice;
+
+impl DriverGeneric for ClockProviderDevice {
+    fn name(&self) -> &str {
+        "clock-provider"
+    }
+}
+
+impl rdif_clk::Interface for ClockProviderDevice {
+    fn perper_enable(&mut self) {}
+
+    fn get_rate(&self, _id: rdif_clk::ClockId) -> Result<u64, rdrive::KError> {
+        Ok(0)
+    }
+
+    fn set_rate(&mut self, _id: rdif_clk::ClockId, _rate: u64) -> Result<(), rdrive::KError> {
+        Ok(())
+    }
+}
+
+fn probe_clock_provider(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_clk::Clk::new(ClockProviderDevice));
+    Ok(())
+}
+
+static CLOCK_PROVIDER_REGISTER: DriverRegister = DriverRegister {
+    name: "test clock provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,clock-provider"],
+        on_probe: probe_clock_provider,
+    }],
+};
+
+#[test]
+fn fdt_probe_does_not_apply_assigned_clocks_before_clock_provider_registers() {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "late-parent-clock",
+            &[prop_u32s("phandle", &[2]), prop_u32s("#clock-cells", &[1])],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "clock-controller@1000",
+            &[
+                prop_strs("compatible", &["test,clock-provider"]),
+                prop_u32s("phandle", &[1]),
+                prop_u32s("#clock-cells", &[1]),
+                prop_u32s("assigned-clocks", &[2, 9]),
+                prop_u32s("assigned-clock-rates", &[100_000_000]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(CLOCK_PROVIDER_REGISTER.clone());
+
+    probe_all(true).expect("FDT probe should succeed");
+
+    assert!(rdrive::get_one::<rdif_clk::Clk>().is_some());
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/drivers/rdrive/tests/fdt_resource_prepare.rs
+++ b/drivers/rdrive/tests/fdt_resource_prepare.rs
@@ -372,8 +372,8 @@ fn fdt_resource_prepare_applies_clocks_resets_and_power_domains() {
     assert_eq!(
         *RESOURCE_CALLS.lock().unwrap(),
         vec![
-            "power-on:6".to_string(),
             "clock-set:4:50000000".to_string(),
+            "power-on:6".to_string(),
             "pinctrl-config".to_string(),
             "pinctrl-config".to_string(),
             "pinctrl-config".to_string(),

--- a/drivers/rdrive/tests/fdt_resource_prepare_zero_cell_clock.rs
+++ b/drivers/rdrive/tests/fdt_resource_prepare_zero_cell_clock.rs
@@ -1,10 +1,5 @@
 use core::ptr::NonNull;
-use std::{
-    string::{String, ToString},
-    sync::Mutex,
-    vec,
-    vec::Vec,
-};
+use std::{string::String, sync::Mutex, vec::Vec};
 
 use fdt_edit::{Fdt, Node, Property};
 use rdrive::{
@@ -97,7 +92,7 @@ static CONSUMER_REGISTER: DriverRegister = DriverRegister {
 };
 
 #[test]
-fn fdt_resource_prepare_uses_id_zero_for_zero_cell_clock_provider() {
+fn fdt_resource_prepare_skips_zero_cell_clock_provider() {
     CLOCK_CALLS.lock().unwrap().clear();
     *PREPARED_CLOCK.lock().unwrap() = None;
 
@@ -139,15 +134,8 @@ fn fdt_resource_prepare_uses_id_zero_for_zero_cell_clock_provider() {
 
     probe_all(true).expect("zero-cell clock prepare should succeed");
 
-    assert_eq!(
-        *CLOCK_CALLS.lock().unwrap(),
-        vec![
-            "set:0:50000000".to_string(),
-            "enable:0".to_string(),
-            "rate:0".to_string(),
-        ]
-    );
-    assert_eq!(*PREPARED_CLOCK.lock().unwrap(), Some(50_000_000));
+    assert!(CLOCK_CALLS.lock().unwrap().is_empty());
+    assert_eq!(*PREPARED_CLOCK.lock().unwrap(), None);
     assert!(rdrive::get_one::<ResourceConsumer>().is_some());
 }
 

--- a/drivers/soc/rockchip/rockchip-soc/src/variants/rk3568/cru/mod.rs
+++ b/drivers/soc/rockchip/rockchip-soc/src/variants/rk3568/cru/mod.rs
@@ -84,6 +84,14 @@ const fn rate_selector(rate_hz: u64) -> Option<(u32, u64)> {
     }
 }
 
+const fn fixed_emmc_rate(id: ClkId) -> Option<u64> {
+    match id {
+        BCLK_EMMC | ACLK_EMMC | HCLK_EMMC => Some(200 * MHZ),
+        TCLK_EMMC => Some(OSC_HZ),
+        _ => None,
+    }
+}
+
 #[derive(Clone)]
 pub struct Cru {
     base: usize,
@@ -141,13 +149,23 @@ impl Cru {
     }
 
     pub fn clk_set_rate(&mut self, id: ClkId, rate_hz: u64) -> ClockResult<u64> {
-        if id != CCLK_EMMC {
-            return Err(ClockError::unsupported(id));
+        if id == CCLK_EMMC {
+            let Some((selector, actual_hz)) = rate_selector(rate_hz) else {
+                return Err(ClockError::invalid_rate(id, rate_hz));
+            };
+            self.write_clksel(CCLK_EMMC_SEL_MASK, selector);
+            return Ok(actual_hz);
         }
-        let Some((selector, actual_hz)) = rate_selector(rate_hz) else {
-            return Err(ClockError::invalid_rate(id, rate_hz));
+
+        let Some(actual_hz) = fixed_emmc_rate(id) else {
+            return Err(ClockError::unsupported(id));
         };
-        self.write_clksel(CCLK_EMMC_SEL_MASK, selector);
+        if rate_hz != actual_hz {
+            return Err(ClockError::invalid_rate(id, rate_hz));
+        }
+        if id == BCLK_EMMC {
+            self.write_clksel(BCLK_EMMC_SEL_MASK, BCLK_EMMC_GPLL_200M);
+        }
         Ok(actual_hz)
     }
 
@@ -325,5 +343,37 @@ mod tests {
         );
         assert_eq!(rate_selector(374_999), None);
         assert_eq!(rate_selector(201 * MHZ), None);
+    }
+
+    #[test]
+    fn emmc_assigned_fixed_rates_are_accepted() {
+        let mut regs = [0_u32; 0x600 / core::mem::size_of::<u32>()];
+        let base = regs.as_mut_ptr() as usize;
+        let mut cru = Cru {
+            base,
+            reset: ResetRockchip::new(base + SOFTRST_CON_OFFSET as usize, 512),
+        };
+
+        assert_eq!(cru.clk_set_rate(BCLK_EMMC, 200 * MHZ).unwrap(), 200 * MHZ);
+        assert_eq!(cru.clk_set_rate(TCLK_EMMC, OSC_HZ).unwrap(), OSC_HZ);
+    }
+
+    #[test]
+    fn emmc_fixed_rates_reject_mismatched_assigned_rate() {
+        let mut regs = [0_u32; 0x600 / core::mem::size_of::<u32>()];
+        let base = regs.as_mut_ptr() as usize;
+        let mut cru = Cru {
+            base,
+            reset: ResetRockchip::new(base + SOFTRST_CON_OFFSET as usize, 512),
+        };
+
+        let err = cru.clk_set_rate(BCLK_EMMC, 100 * MHZ).unwrap_err();
+        assert!(matches!(
+            err,
+            ClockError::InvalidRate {
+                clk_id: BCLK_EMMC,
+                rate_hz,
+            } if rate_hz == 100 * MHZ
+        ));
     }
 }


### PR DESCRIPTION
## 背景

rdrive 已经自动处理 FDT `power-domains` 和默认 pinctrl，但 clock 仍依赖各个驱动本地解析或 Rockchip 全局 helper。这样会让 PCIe、USB、SDHCI、DWMMC、PWM、JPEG、StarFive SD 等 probe 路径重复保存 clock id/provider，并且难以保持 Linux 风格的 `assigned-clocks` 默认配置顺序。

## 变更

- 在 `rdrive::probe::fdt` 新增通用 `ClockLine` consumer，封装 `ClockRef -> Device<rdif_clk::Clk> + ClockId`，提供 `enable/set_rate/rate`。
- 新增严格 FDT clock parser：解析 `clocks` / `clock-names`，v1 只支持 `#clock-cells = <1>`；zero-cell clock 输出会跳过，多 cell 或截断 specifier 返回 probe 错误。
- 在 FDT driver probe 前自动应用非零 `assigned-clock-rates`，顺序为 `assigned-clocks -> power-domains -> default pinctrl -> driver probe`；普通 `clocks` 不自动 enable。
- 跳过 clock provider 节点自己的 pre-probe `assigned-clocks`，避免 provider capability 尚未注册时阻塞 RK3568/RK3588 CRU probe；provider 初始化仍由对应 clock 驱动负责。
- 自动 assigned-clock rate 只应用到已经注册 `rdif_clk::Clk` 的 provider；SCMI 等非 RDIF provider 保持原适配层处理，不阻塞通用 FDT probe，显式 `clocks` consumer 解析仍保持严格报错。
- 迁移 Rockchip PCIe、USB3、EHCI、SDHCI、DWMMC、PWM、JPEG 以及 StarFive SD 驱动到通用 clock consumer，删除旧的 Rockchip 全局 clock helper 导出。
- 手动遍历的 PHY/子节点在驱动侧显式调用 `apply_assigned_clocks(child)`，保持与自动 probe 节点一致的默认 clock 配置行为。
- 补齐 RK3568 eMMC 固定 clock 的 `set_rate` 语义：`BCLK/ACLK/HCLK/TCLK_EMMC` 接受 DTS assigned rate 中声明的固定频率，频率不匹配仍返回错误，修复 RK3568 SDHCI probe 前自动 assigned clock 配置失败。
- 根据 review 建议清理重复的 `clock_id_raw` helper，统一使用 `ClockId::raw()`；同时删除 RK3588 SDHCI core clock 查找前仅用于日志的 `info.clocks()` 遍历。

## 设计说明

- rdrive 只负责 FDT specifier 解析和 RDIF clock capability 获取；具体 clock register 语义仍留在各 SoC provider。
- `assigned-clock-parents` 暂不实现，因为当前 `rdif-clk` 没有 parent 切换 API。
- SCMI clock adapter 仍保持原路径，不纳入 `ClockLine` v1。
- 自动配置只处理默认频率，不自动 enable 普通 consumer clocks，驱动仍按自身时序显式 enable。

## 验证

- `cargo fmt --check`
- `cargo test -p rockchip-soc`
- `cargo test -p rdrive`
- `cargo test -p ax-driver --features "starfive-jh7110-dwmmc"`
- `cargo test -p ax-driver --features "rockchip-soc,rockchip-pm,rk3588-pcie,rockchip-dwc-xhci,rockchip-ehci,rockchip-sdhci,rockchip-dwmmc,jpeg,rknpu,rk3588-pwm,starfive-jh7110-dwmmc"`
- `cargo xtask clippy --package rockchip-soc`
- `cargo xtask clippy --package rdrive`
- `cargo xtask clippy --package ax-driver`
- `cargo clippy -p ax-driver --no-default-features --features "rockchip-soc,rockchip-pm,rk3588-pcie,rockchip-dwc-xhci,rockchip-ehci,rockchip-sdhci,rockchip-dwmmc,jpeg,rknpu,rk3588-pwm,starfive-jh7110-dwmmc" -- -D warnings`
- `git diff --check`
