### PR TITLE
refactor(axvm): handle vCPU exits in arch adapters

### DIFF
--- a/virtualization/axvm-types/src/lib.rs
+++ b/virtualization/axvm-types/src/lib.rs
@@ -285,7 +285,12 @@ pub struct NestedPageFaultInfo {
     pub fault_guest_paddr: GuestPhysAddr,
 }
 
-/// VM-exit reason returned by architecture vCPU implementations to AxVM.
+/// Legacy/common normalized VM event.
+///
+/// New AxVM architecture backends should expose their raw VM-exit type through
+/// [`VmArchVcpuOps::Exit`] and handle it inside their `axvm::arch` module.
+/// This enum remains for compatibility and as a transitional normalized event
+/// shape for backends that have not split out an architecture-owned exit enum.
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum VmExit {
@@ -415,6 +420,8 @@ pub trait VmArchVcpuOps: Sized {
     type CreateConfig;
     /// Architecture-specific setup configuration.
     type SetupConfig;
+    /// Architecture-specific VM-exit type returned by [`Self::run`].
+    type Exit: Debug;
 
     /// Creates a new architecture-specific vCPU.
     fn new(vm_id: VMId, vcpu_id: VCpuId, config: Self::CreateConfig) -> AxVmResult<Self>;
@@ -424,15 +431,20 @@ pub trait VmArchVcpuOps: Sized {
     fn set_nested_page_table(&mut self, config: NestedPagingConfig) -> AxVmResult;
     /// Completes architecture-specific setup.
     fn setup(&mut self, config: Self::SetupConfig) -> AxVmResult;
-    /// Runs the vCPU until a VM exit.
-    fn run(&mut self) -> AxVmResult<VmExit>;
+    /// Runs the vCPU until an architecture-specific VM exit.
+    fn run(&mut self) -> AxVmResult<Self::Exit>;
     /// Binds the vCPU to the current physical CPU.
     fn bind(&mut self) -> AxVmResult;
     /// Unbinds the vCPU from the current physical CPU.
     fn unbind(&mut self) -> AxVmResult;
     /// Sets a general-purpose register.
     fn set_gpr(&mut self, reg: usize, val: usize);
-    /// Decodes an architecture-specific memory fault as MMIO when possible.
+    /// Decodes an architecture-specific memory fault as a legacy normalized
+    /// MMIO event when possible.
+    ///
+    /// This is kept as a transition helper for backends that still route
+    /// device faults through [`VmExit`]. New raw vCPU exits should use
+    /// [`Self::Exit`] and be handled in the architecture-local AxVM adapter.
     fn decode_mmio_fault(
         &mut self,
         _fault_addr: GuestPhysAddr,
@@ -754,11 +766,17 @@ mod tests {
         }
     }
 
+    #[derive(Debug, PartialEq, Eq)]
+    enum MockExit {
+        SysRegRead { reg: usize },
+    }
+
     struct MockVcpu;
 
     impl VmArchVcpuOps for MockVcpu {
         type CreateConfig = ();
         type SetupConfig = ();
+        type Exit = MockExit;
 
         fn new(_vm_id: VMId, _vcpu_id: VCpuId, _config: Self::CreateConfig) -> AxVmResult<Self> {
             Ok(Self)
@@ -776,11 +794,8 @@ mod tests {
             Ok(())
         }
 
-        fn run(&mut self) -> AxVmResult<VmExit> {
-            Ok(VmExit::SysRegRead {
-                addr: SysRegAddr::from(0x10),
-                reg: 2,
-            })
+        fn run(&mut self) -> AxVmResult<Self::Exit> {
+            Ok(MockExit::SysRegRead { reg: 2 })
         }
 
         fn bind(&mut self) -> AxVmResult {
@@ -819,7 +834,7 @@ mod tests {
         vcpu.setup(()).unwrap();
         assert!(matches!(
             vcpu.run().unwrap(),
-            VmExit::SysRegRead { reg: 2, .. }
+            MockExit::SysRegRead { reg: 2 }
         ));
     }
 

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -1,8 +1,8 @@
 //! AxVM AArch64 adapter.
 //!
 //! This module owns the AxVM/ArceOS glue for the OS-neutral `arm_vcpu` core:
-//! `AxvmArmHostOps` supplies host IRQ/GIC operations, while wrapper types
-//! convert `arm_vcpu` errors and exits into `axvm_types` and `ax_errno` values.
+//! `AxvmArmHostOps` supplies host IRQ/GIC operations, while this module handles
+//! `arm_vcpu` exits inside the AArch64 architecture boundary.
 
 use alloc::boxed::Box;
 use core::time::Duration;
@@ -17,10 +17,13 @@ use ax_errno::{AxError, AxResult, ax_err};
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axvm_types::{
     AccessWidth, GuestPhysAddr, NestedPagingConfig, SysRegAddr, VCpuId, VMId, VmArchPerCpuOps,
-    VmArchVcpuOps, VmExit,
+    VmArchVcpuOps,
 };
 
-use super::{ArchOps, VcpuCreateContext, VcpuSetupContext, target_phys_cpu_ids};
+use super::{
+    ArchOps, CpuUpExit, HypercallExit, MmioReadExit, MmioWriteExit, SendIpiExit, SysRegReadExit,
+    SysRegWriteExit, VcpuCreateContext, VcpuRunAction, VcpuSetupContext, target_phys_cpu_ids,
+};
 use crate::host::{HostCpu, HostMemory, HostTime, default_host, gic};
 
 mod npt;
@@ -155,6 +158,107 @@ impl ArchOps for Aarch64Arch {
         }
         targets
     }
+
+    fn handle_vcpu_exit(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef,
+        exit: <Self::VCpu as VmArchVcpuOps>::Exit,
+    ) -> AxResult<VcpuRunAction> {
+        match exit {
+            ArmVmExit::Hypercall { nr, args } => {
+                super::handle_hypercall(vm, vcpu, HypercallExit { nr, args })
+            }
+            ArmVmExit::MmioRead {
+                addr,
+                width,
+                reg,
+                reg_width,
+                signed_ext,
+            } => super::handle_mmio_read(
+                vm,
+                vcpu,
+                MmioReadExit {
+                    addr: arm_guest_phys_addr_to_ax(addr),
+                    width: arm_access_width_to_ax(width),
+                    reg,
+                    reg_width: arm_access_width_to_ax(reg_width),
+                    signed_ext,
+                },
+            ),
+            ArmVmExit::MmioWrite { addr, width, data } => super::handle_mmio_write(
+                vm,
+                MmioWriteExit {
+                    addr: arm_guest_phys_addr_to_ax(addr),
+                    width: arm_access_width_to_ax(width),
+                    data,
+                },
+            ),
+            ArmVmExit::SysRegRead { addr, reg } => super::handle_sys_reg_read(
+                vm,
+                vcpu,
+                SysRegReadExit {
+                    addr: arm_sys_reg_addr_to_ax(addr),
+                    reg,
+                },
+            ),
+            ArmVmExit::SysRegWrite { addr, value } => super::handle_sys_reg_write(
+                vm,
+                SysRegWriteExit {
+                    addr: arm_sys_reg_addr_to_ax(addr),
+                    value,
+                },
+            ),
+            ArmVmExit::ExternalInterrupt { vector } => {
+                debug!("VM[{}] run VCpu[{}] get irq {vector}", vm.id(), vcpu.id());
+                Self::after_external_interrupt(vm, vcpu, vector as usize);
+                Ok(VcpuRunAction::Yield)
+            }
+            ArmVmExit::CpuDown { state } => {
+                warn!(
+                    "VM[{}] run VCpu[{}] CpuDown state {state:#x}",
+                    vm.id(),
+                    vcpu.id()
+                );
+                Ok(VcpuRunAction::Wait)
+            }
+            ArmVmExit::CpuUp {
+                target_cpu,
+                entry_point,
+                arg,
+            } => super::handle_cpu_up::<Self>(
+                vm,
+                vcpu,
+                CpuUpExit {
+                    target_cpu,
+                    entry_point: arm_guest_phys_addr_to_ax(entry_point),
+                    arg,
+                },
+            ),
+            ArmVmExit::SystemDown => {
+                warn!("VM[{}] run VCpu[{}] SystemDown", vm.id(), vcpu.id());
+                Ok(VcpuRunAction::Stop(crate::StopReason::SystemDown))
+            }
+            ArmVmExit::SendIPI {
+                target_cpu,
+                target_cpu_aux,
+                send_to_all,
+                send_to_self,
+                vector,
+            } => super::handle_send_ipi::<Self>(
+                vm,
+                vcpu.id(),
+                SendIpiExit {
+                    target_cpu,
+                    target_cpu_aux,
+                    send_to_all,
+                    send_to_self,
+                    vector,
+                },
+            ),
+            ArmVmExit::Nothing => Ok(VcpuRunAction::Yield),
+            _ => ax_err!(Unsupported, "unsupported AArch64 VM exit"),
+        }
+    }
 }
 
 struct AxvmArmHostOps;
@@ -179,6 +283,7 @@ pub(crate) struct AxvmArmVcpu(ArmVcpu<AxvmArmHostOps>);
 impl VmArchVcpuOps for AxvmArmVcpu {
     type CreateConfig = ArmVcpuCreateConfig;
     type SetupConfig = ArmVcpuSetupConfig;
+    type Exit = ArmVmExit;
 
     fn new(vm_id: VMId, vcpu_id: VCpuId, config: Self::CreateConfig) -> AxResult<Self> {
         arm_result(ArmVcpu::new(vm_id, vcpu_id, config)).map(Self)
@@ -199,8 +304,8 @@ impl VmArchVcpuOps for AxvmArmVcpu {
         arm_result(self.0.setup(config))
     }
 
-    fn run(&mut self) -> AxResult<VmExit> {
-        arm_result(self.0.run()).map(arm_exit_to_ax)
+    fn run(&mut self) -> AxResult<Self::Exit> {
+        arm_result(self.0.run())
     }
 
     fn bind(&mut self) -> AxResult {
@@ -294,65 +399,6 @@ fn arm_sys_reg_addr_to_ax(addr: ArmSysRegAddr) -> SysRegAddr {
     SysRegAddr::new(addr.addr())
 }
 
-fn arm_exit_to_ax(exit: ArmVmExit) -> VmExit {
-    match exit {
-        ArmVmExit::Hypercall { nr, args } => VmExit::Hypercall { nr, args },
-        ArmVmExit::MmioRead {
-            addr,
-            width,
-            reg,
-            reg_width,
-            signed_ext,
-        } => VmExit::MmioRead {
-            addr: arm_guest_phys_addr_to_ax(addr),
-            width: arm_access_width_to_ax(width),
-            reg,
-            reg_width: arm_access_width_to_ax(reg_width),
-            signed_ext,
-        },
-        ArmVmExit::MmioWrite { addr, width, data } => VmExit::MmioWrite {
-            addr: arm_guest_phys_addr_to_ax(addr),
-            width: arm_access_width_to_ax(width),
-            data,
-        },
-        ArmVmExit::SysRegRead { addr, reg } => VmExit::SysRegRead {
-            addr: arm_sys_reg_addr_to_ax(addr),
-            reg,
-        },
-        ArmVmExit::SysRegWrite { addr, value } => VmExit::SysRegWrite {
-            addr: arm_sys_reg_addr_to_ax(addr),
-            value,
-        },
-        ArmVmExit::ExternalInterrupt { vector } => VmExit::ExternalInterrupt { vector },
-        ArmVmExit::CpuDown { state } => VmExit::CpuDown { _state: state },
-        ArmVmExit::CpuUp {
-            target_cpu,
-            entry_point,
-            arg,
-        } => VmExit::CpuUp {
-            target_cpu,
-            entry_point: arm_guest_phys_addr_to_ax(entry_point),
-            arg,
-        },
-        ArmVmExit::SystemDown => VmExit::SystemDown,
-        ArmVmExit::SendIPI {
-            target_cpu,
-            target_cpu_aux,
-            send_to_all,
-            send_to_self,
-            vector,
-        } => VmExit::SendIPI {
-            target_cpu,
-            target_cpu_aux,
-            send_to_all,
-            send_to_self,
-            vector,
-        },
-        ArmVmExit::Nothing => VmExit::Nothing,
-        _ => unreachable!("unmapped arm_vcpu VM-exit variant"),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -370,37 +416,31 @@ mod tests {
         assert_eq!(arm_error_to_ax(ArmVcpuError::BadState), AxError::BadState);
     }
 
+    fn assert_arm_exit_type<T: VmArchVcpuOps<Exit = ArmVmExit>>() {}
+
     #[test]
-    fn converts_arm_vcpu_exits_to_axvm_exits() {
-        let mmio = arm_exit_to_ax(ArmVmExit::MmioRead {
-            addr: ArmGuestPhysAddr::from_usize(0x4000),
-            width: ArmAccessWidth::Dword,
-            reg: 5,
-            reg_width: ArmAccessWidth::Qword,
-            signed_ext: true,
-        });
-        assert!(matches!(
-            mmio,
-            VmExit::MmioRead {
-                addr,
-                width: AccessWidth::Dword,
-                reg: 5,
-                reg_width: AccessWidth::Qword,
-                signed_ext: true,
-            } if addr.as_usize() == 0x4000
-        ));
+    fn axvm_arm_vcpu_uses_arm_exit_type() {
+        assert_arm_exit_type::<AxvmArmVcpu>();
+    }
 
-        let cpu_down = arm_exit_to_ax(ArmVmExit::CpuDown { state: 7 });
-        assert!(matches!(cpu_down, VmExit::CpuDown { _state: 7 }));
-
-        let sysreg = arm_exit_to_ax(ArmVmExit::SysRegWrite {
-            addr: ArmSysRegAddr::new(0x3a_3016),
-            value: 0x55,
-        });
-        assert!(matches!(
-            sysreg,
-            VmExit::SysRegWrite { addr, value: 0x55 } if addr.addr() == 0x3a_3016
-        ));
+    #[test]
+    fn converts_arm_value_types_to_axvm_value_types() {
+        assert_eq!(
+            arm_guest_phys_addr_to_ax(ArmGuestPhysAddr::from_usize(0x4000)).as_usize(),
+            0x4000
+        );
+        assert_eq!(
+            arm_access_width_to_ax(ArmAccessWidth::Dword),
+            AccessWidth::Dword
+        );
+        assert_eq!(
+            arm_access_width_to_ax(ArmAccessWidth::Qword),
+            AccessWidth::Qword
+        );
+        assert_eq!(
+            arm_sys_reg_addr_to_ax(ArmSysRegAddr::new(0x3a_3016)).addr(),
+            0x3a_3016
+        );
     }
 }
 

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -21,8 +21,9 @@ use axvm_types::{
 };
 
 use super::{
-    ArchOps, CpuUpExit, HypercallExit, MmioReadExit, MmioWriteExit, SendIpiExit, SysRegReadExit,
-    SysRegWriteExit, VcpuCreateContext, VcpuRunAction, VcpuSetupContext, target_phys_cpu_ids,
+    ArchOps, BoundVcpuExit, CpuUpExit, HypercallExit, MmioReadExit, MmioWriteExit, SendIpiExit,
+    SysRegReadExit, SysRegWriteExit, VcpuCreateContext, VcpuRunAction, VcpuSetupContext,
+    target_phys_cpu_ids,
 };
 use crate::host::{HostCpu, HostMemory, HostTime, default_host, gic};
 
@@ -30,10 +31,16 @@ mod npt;
 
 pub(crate) struct Aarch64Arch;
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Aarch64DeferredRunWork {
+    ExternalInterrupt { vector: usize },
+}
+
 impl ArchOps for Aarch64Arch {
     type VCpu = AxvmArmVcpu;
     type PerCpu = AxvmArmPerCpu;
     type VcpuCreateState = ();
+    type DeferredRunWork = Aarch64DeferredRunWork;
     type NestedPageTable = npt::NestedPageTable<crate::HostPagingHandler>;
 
     fn has_hardware_support() -> bool {
@@ -159,11 +166,11 @@ impl ArchOps for Aarch64Arch {
         targets
     }
 
-    fn handle_vcpu_exit(
+    fn handle_vcpu_exit_bound(
         vm: &crate::AxVMRef,
-        vcpu: &crate::vm::AxVCpuRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         exit: <Self::VCpu as VmArchVcpuOps>::Exit,
-    ) -> AxResult<VcpuRunAction> {
+    ) -> AxResult<BoundVcpuExit<Self::DeferredRunWork>> {
         match exit {
             ArmVmExit::Hypercall { nr, args } => {
                 super::handle_hypercall(vm, vcpu, HypercallExit { nr, args })
@@ -185,7 +192,7 @@ impl ArchOps for Aarch64Arch {
                     signed_ext,
                 },
             ),
-            ArmVmExit::MmioWrite { addr, width, data } => super::handle_mmio_write(
+            ArmVmExit::MmioWrite { addr, width, data } => super::handle_mmio_write::<Self>(
                 vm,
                 MmioWriteExit {
                     addr: arm_guest_phys_addr_to_ax(addr),
@@ -210,8 +217,11 @@ impl ArchOps for Aarch64Arch {
             ),
             ArmVmExit::ExternalInterrupt { vector } => {
                 debug!("VM[{}] run VCpu[{}] get irq {vector}", vm.id(), vcpu.id());
-                Self::after_external_interrupt(vm, vcpu, vector as usize);
-                Ok(VcpuRunAction::Yield)
+                Ok(BoundVcpuExit::Defer(
+                    Aarch64DeferredRunWork::ExternalInterrupt {
+                        vector: vector as usize,
+                    },
+                ))
             }
             ArmVmExit::CpuDown { state } => {
                 warn!(
@@ -219,7 +229,7 @@ impl ArchOps for Aarch64Arch {
                     vm.id(),
                     vcpu.id()
                 );
-                Ok(VcpuRunAction::Wait)
+                Ok(BoundVcpuExit::Complete(VcpuRunAction::Wait))
             }
             ArmVmExit::CpuUp {
                 target_cpu,
@@ -236,7 +246,9 @@ impl ArchOps for Aarch64Arch {
             ),
             ArmVmExit::SystemDown => {
                 warn!("VM[{}] run VCpu[{}] SystemDown", vm.id(), vcpu.id());
-                Ok(VcpuRunAction::Stop(crate::StopReason::SystemDown))
+                Ok(BoundVcpuExit::Complete(VcpuRunAction::Stop(
+                    crate::StopReason::SystemDown,
+                )))
             }
             ArmVmExit::SendIPI {
                 target_cpu,
@@ -255,9 +267,22 @@ impl ArchOps for Aarch64Arch {
                     vector,
                 },
             ),
-            ArmVmExit::Nothing => Ok(VcpuRunAction::Yield),
+            ArmVmExit::Nothing => Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield)),
             _ => ax_err!(Unsupported, "unsupported AArch64 VM exit"),
         }
+    }
+
+    fn finish_deferred_run_work(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        work: Self::DeferredRunWork,
+    ) -> AxResult<VcpuRunAction> {
+        match work {
+            Aarch64DeferredRunWork::ExternalInterrupt { vector } => {
+                Self::after_external_interrupt(vm, vcpu, vector);
+            }
+        }
+        Ok(VcpuRunAction::Yield)
     }
 }
 

--- a/virtualization/axvm/src/arch/loongarch64/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/mod.rs
@@ -6,7 +6,7 @@ use ax_errno::AxResult;
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use loongarch_vcpu::host::LoongArchVcpuHostIf;
 
-use super::{ArchOps, VcpuCreateContext, VcpuSetupContext};
+use super::{ArchOps, VcpuCreateContext, VcpuRunAction, VcpuSetupContext};
 use crate::host::{HostMemory, HostTime, default_host};
 
 mod npt;
@@ -148,6 +148,14 @@ impl ArchOps for LoongArch64Arch {
         ax_std::os::arceos::modules::ax_hal::time::busy_wait(idle_timeout);
         ax_std::os::arceos::modules::ax_hal::asm::disable_irqs();
         ax_std::os::arceos::modules::ax_hal::asm::set_timer_irq_enabled(false);
+    }
+
+    fn handle_vcpu_exit(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef,
+        exit: <Self::VCpu as axvm_types::VmArchVcpuOps>::Exit,
+    ) -> AxResult<VcpuRunAction> {
+        super::handle_transitional_vm_exit::<Self>(vm, vcpu, exit)
     }
 
     fn clean_dcache_range(addr: VirtAddr, size: usize) {

--- a/virtualization/axvm/src/arch/loongarch64/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/mod.rs
@@ -6,7 +6,10 @@ use ax_errno::AxResult;
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use loongarch_vcpu::host::LoongArchVcpuHostIf;
 
-use super::{ArchOps, VcpuCreateContext, VcpuRunAction, VcpuSetupContext};
+use super::{
+    ArchOps, BoundVcpuExit, LegacyDeferredRunWork, VcpuCreateContext, VcpuRunAction,
+    VcpuSetupContext,
+};
 use crate::host::{HostMemory, HostTime, default_host};
 
 mod npt;
@@ -17,6 +20,7 @@ impl ArchOps for LoongArch64Arch {
     type VCpu = loongarch_vcpu::LoongArchVCpu;
     type PerCpu = loongarch_vcpu::LoongArchPerCpu;
     type VcpuCreateState = loongarch_vcpu::LoongArchIocsrStateRef;
+    type DeferredRunWork = LegacyDeferredRunWork;
     type NestedPageTable = npt::NestedPageTable<crate::HostPagingHandler>;
 
     fn has_hardware_support() -> bool {
@@ -71,7 +75,7 @@ impl ArchOps for LoongArch64Arch {
 
     fn inject_pending_interrupt(
         vm: &crate::AxVMRef,
-        vcpu: &crate::vm::AxVCpuRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         interrupt: crate::vm::PendingInterrupt,
     ) {
         match interrupt {
@@ -94,7 +98,7 @@ impl ArchOps for LoongArch64Arch {
                 vector,
                 physical_irq,
             } => {
-                let Some(vector) = vm.loongarch_external_irq_vector(vector, physical_irq) else {
+                let Some(vector) = loongarch_external_irq_vector(vm, vector, physical_irq) else {
                     trace!(
                         "Queued LoongArch external interrupt physical_irq={physical_irq:#x} is \
                          masked in VM[{}]",
@@ -123,11 +127,11 @@ impl ArchOps for LoongArch64Arch {
         }
     }
 
-    fn after_mmio_write(vm: &crate::AxVM) {
-        vm.drain_loongarch_pch_pic_events();
+    fn after_mmio_write(vm: &crate::AxVMRef) {
+        drain_loongarch_pch_pic_events(vm);
     }
 
-    fn handle_idle(_vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef) {
+    fn handle_idle(_vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         crate::check_timer_events();
         if vcpu.get_arch_vcpu().has_enabled_pending_interrupt() {
             trace!(
@@ -150,12 +154,20 @@ impl ArchOps for LoongArch64Arch {
         ax_std::os::arceos::modules::ax_hal::asm::set_timer_irq_enabled(false);
     }
 
-    fn handle_vcpu_exit(
+    fn handle_vcpu_exit_bound(
         vm: &crate::AxVMRef,
-        vcpu: &crate::vm::AxVCpuRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         exit: <Self::VCpu as axvm_types::VmArchVcpuOps>::Exit,
-    ) -> AxResult<VcpuRunAction> {
+    ) -> AxResult<BoundVcpuExit<Self::DeferredRunWork>> {
         super::handle_transitional_vm_exit::<Self>(vm, vcpu, exit)
+    }
+
+    fn finish_deferred_run_work(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        work: Self::DeferredRunWork,
+    ) -> AxResult<VcpuRunAction> {
+        super::finish_legacy_deferred_run_work::<Self>(vm, vcpu, work)
     }
 
     fn clean_dcache_range(addr: VirtAddr, size: usize) {
@@ -164,6 +176,42 @@ impl ArchOps for LoongArch64Arch {
             core::arch::asm!("dbar 0");
         }
     }
+}
+
+fn loongarch_external_irq_vector(
+    vm: &crate::AxVMRef,
+    fallback_vector: usize,
+    _physical_irq: usize,
+) -> Option<usize> {
+    let devices = vm.get_devices().ok()?;
+    match devices.loongarch_pch_pic_assert_irq(fallback_vector) {
+        Some(Some(vector)) => Some(vector),
+        Some(None) => None,
+        None => Some(fallback_vector),
+    }
+}
+
+fn drain_loongarch_pch_pic_events(vm: &crate::AxVMRef) {
+    let Ok(devices) = vm.get_devices() else {
+        return;
+    };
+    devices.drain_loongarch_pch_pic_events(|event| {
+        if !event.asserted {
+            trace!(
+                "LoongArch VM[{}] PCH-PIC deassert event for EIOINTC vector {}",
+                vm.id(),
+                event.vector
+            );
+            return;
+        }
+        if let Err(err) = crate::manager::inject_vm_vcpu_interrupt(vm.id(), 0, event.vector) {
+            warn!(
+                "failed to inject LoongArch VM[{}] PCH-PIC output vector {}: {err:?}",
+                vm.id(),
+                event.vector
+            );
+        }
+    });
 }
 
 struct LoongArchVcpuHostIfImpl;

--- a/virtualization/axvm/src/arch/mod.rs
+++ b/virtualization/axvm/src/arch/mod.rs
@@ -3,14 +3,18 @@
 use alloc::vec::Vec;
 
 use ax_errno::AxResult;
+#[cfg(not(target_arch = "aarch64"))]
+use ax_errno::ax_err;
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axaddrspace::NestedPageTableOps;
 use axvm_types::{
-    GuestPhysAddr, NestedPagingConfig, PassThroughPortConfig, VMInterruptMode, VmArchPerCpuOps,
-    VmArchVcpuOps,
+    AccessWidth, GuestPhysAddr, NestedPagingConfig, PassThroughPortConfig, SysRegAddr,
+    VMInterruptMode, VmArchPerCpuOps, VmArchVcpuOps,
 };
+#[cfg(not(target_arch = "aarch64"))]
+use axvm_types::{MappingFlags, Port, VmExit};
 
-use crate::CpuMask;
+use crate::{CpuMask, StopReason};
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
@@ -34,6 +38,93 @@ pub(crate) type CurrentArch = x86_64::X86_64Arch;
 pub(crate) type ArchVCpu = <CurrentArch as ArchOps>::VCpu;
 pub(crate) type ArchPerCpu = <CurrentArch as ArchOps>::PerCpu;
 pub(crate) type ArchNestedPageTable = <CurrentArch as ArchOps>::NestedPageTable;
+
+/// Result of handling one architecture-specific vCPU exit.
+#[derive(Debug)]
+pub(crate) enum VcpuRunAction {
+    /// The exit was handled completely; re-enter the guest in the current run slice.
+    Continue,
+    /// Handle a host external interrupt after the vCPU has been unbound.
+    HostInterrupt(usize),
+    /// Return to the runtime loop without blocking.
+    Yield,
+    /// Block the current vCPU task on the VM runtime wait queue.
+    Wait,
+    /// Request VM stop with the provided reason.
+    Stop(StopReason),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct MmioReadExit {
+    pub(crate) addr: GuestPhysAddr,
+    pub(crate) width: AccessWidth,
+    pub(crate) reg: usize,
+    pub(crate) reg_width: AccessWidth,
+    pub(crate) signed_ext: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct MmioWriteExit {
+    pub(crate) addr: GuestPhysAddr,
+    pub(crate) width: AccessWidth,
+    pub(crate) data: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) struct IoReadExit {
+    pub(crate) port: Port,
+    pub(crate) width: AccessWidth,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) struct IoWriteExit {
+    pub(crate) port: Port,
+    pub(crate) width: AccessWidth,
+    pub(crate) data: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SysRegReadExit {
+    pub(crate) addr: SysRegAddr,
+    pub(crate) reg: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SysRegWriteExit {
+    pub(crate) addr: SysRegAddr,
+    pub(crate) value: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) struct NestedPageFaultExit {
+    pub(crate) addr: GuestPhysAddr,
+    pub(crate) access_flags: MappingFlags,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct HypercallExit {
+    pub(crate) nr: u64,
+    pub(crate) args: [u64; 6],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CpuUpExit {
+    pub(crate) target_cpu: u64,
+    pub(crate) entry_point: GuestPhysAddr,
+    pub(crate) arg: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SendIpiExit {
+    pub(crate) target_cpu: u64,
+    pub(crate) target_cpu_aux: u64,
+    pub(crate) send_to_all: bool,
+    pub(crate) send_to_self: bool,
+    pub(crate) vector: u64,
+}
 
 #[allow(dead_code)]
 pub(crate) struct VcpuCreateContext {
@@ -148,6 +239,7 @@ pub(crate) trait ArchOps {
         vcpu.set_gpr(0, 0);
     }
 
+    #[cfg(not(target_arch = "aarch64"))]
     fn set_io_read_result(vcpu: &crate::vm::AxVCpuRef, val: usize) {
         vcpu.set_gpr(0, val);
     }
@@ -196,10 +288,12 @@ pub(crate) trait ArchOps {
         crate::check_timer_events();
     }
 
+    #[cfg(not(target_arch = "aarch64"))]
     fn after_preemption_timer(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef) {
         crate::check_timer_events();
     }
 
+    #[cfg(not(target_arch = "aarch64"))]
     fn after_interrupt_end(
         _vm: &crate::AxVMRef,
         _vcpu: &crate::vm::AxVCpuRef,
@@ -207,11 +301,7 @@ pub(crate) trait ArchOps {
     ) {
     }
 
-    fn handle_halt(runtime: &crate::vm::VmRuntimeHandle) -> bool {
-        runtime.wait();
-        false
-    }
-
+    #[cfg(not(target_arch = "aarch64"))]
     fn handle_idle(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef) {
         crate::check_timer_events();
     }
@@ -219,6 +309,346 @@ pub(crate) trait ArchOps {
     fn on_last_vcpu_exit(_vm_id: usize) {}
 
     fn after_mmio_write(_vm: &crate::AxVM) {}
+
+    fn cpu_up_target_vcpu_id(vm: &crate::AxVMRef, target_cpu: u64) -> Option<usize> {
+        vm.get_vcpu_affinities_pcpu_ids()
+            .iter()
+            .find_map(|(vcpu_id, _, phys_id)| (*phys_id == target_cpu as usize).then_some(*vcpu_id))
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    fn handle_halt() -> VcpuRunAction {
+        VcpuRunAction::Wait
+    }
+
+    fn handle_vcpu_exit(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef,
+        exit: <Self::VCpu as VmArchVcpuOps>::Exit,
+    ) -> AxResult<VcpuRunAction>;
+}
+
+pub(crate) fn handle_mmio_read(
+    vm: &crate::AxVM,
+    vcpu: &crate::vm::AxVCpuRef,
+    exit: MmioReadExit,
+) -> AxResult<VcpuRunAction> {
+    let raw = vm.get_devices()?.handle_mmio_read(exit.addr, exit.width)?;
+    let masked = raw & crate::vm::width_mask(exit.width);
+    let val = if exit.signed_ext {
+        crate::vm::sign_extend_value(masked, exit.width)
+    } else {
+        masked & crate::vm::width_mask(exit.reg_width)
+    };
+    vcpu.set_gpr(exit.reg, val);
+    Ok(VcpuRunAction::Continue)
+}
+
+pub(crate) fn handle_mmio_write(vm: &crate::AxVM, exit: MmioWriteExit) -> AxResult<VcpuRunAction> {
+    vm.handle_mmio_write(exit.addr, exit.width, exit.data as usize)?;
+    Ok(VcpuRunAction::Continue)
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) fn handle_io_read<A: ArchOps>(
+    vm: &crate::AxVM,
+    vcpu: &crate::vm::AxVCpuRef,
+    exit: IoReadExit,
+) -> AxResult<VcpuRunAction> {
+    let val = vm.get_devices()?.handle_port_read(exit.port, exit.width)?;
+    A::set_io_read_result(vcpu, val);
+    Ok(VcpuRunAction::Continue)
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) fn handle_io_write(vm: &crate::AxVM, exit: IoWriteExit) -> AxResult<VcpuRunAction> {
+    vm.get_devices()?
+        .handle_port_write(exit.port, exit.width, exit.data as usize)?;
+    Ok(VcpuRunAction::Continue)
+}
+
+pub(crate) fn handle_sys_reg_read(
+    vm: &crate::AxVM,
+    vcpu: &crate::vm::AxVCpuRef,
+    exit: SysRegReadExit,
+) -> AxResult<VcpuRunAction> {
+    let val = vm.get_devices()?.handle_sys_reg_read(
+        exit.addr,
+        // System registers are currently modeled as fixed-width device registers.
+        AccessWidth::Qword,
+    )?;
+    vcpu.set_gpr(exit.reg, val);
+    Ok(VcpuRunAction::Continue)
+}
+
+pub(crate) fn handle_sys_reg_write(
+    vm: &crate::AxVM,
+    exit: SysRegWriteExit,
+) -> AxResult<VcpuRunAction> {
+    vm.get_devices()?
+        .handle_sys_reg_write(exit.addr, AccessWidth::Qword, exit.value as usize)?;
+    Ok(VcpuRunAction::Continue)
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) fn handle_nested_page_fault<A: ArchOps>(
+    vm: &crate::AxVMRef,
+    vcpu: &crate::vm::AxVCpuRef,
+    exit: NestedPageFaultExit,
+) -> AxResult<VcpuRunAction> {
+    if vm.get_devices()?.find_mmio_dev(exit.addr).is_some() {
+        let Some(decoded) = vcpu
+            .get_arch_vcpu()
+            .decode_mmio_fault(exit.addr, exit.access_flags)
+        else {
+            warn!(
+                "VM[{}] VCpu[{}] nested page fault at {:#x} maps MMIO but cannot be decoded",
+                vm.id(),
+                vcpu.id(),
+                exit.addr.as_usize()
+            );
+            return Ok(VcpuRunAction::Yield);
+        };
+        return handle_transitional_vm_exit::<A>(vm, vcpu, decoded);
+    }
+
+    if vm.handle_nested_page_fault(exit.addr, exit.access_flags) {
+        Ok(VcpuRunAction::Continue)
+    } else {
+        warn!(
+            "VM[{}] VCpu[{}] unhandled nested page fault at {:#x}, access={:?}",
+            vm.id(),
+            vcpu.id(),
+            exit.addr.as_usize(),
+            exit.access_flags
+        );
+        Ok(VcpuRunAction::Yield)
+    }
+}
+
+pub(crate) fn handle_hypercall(
+    vm: &crate::AxVMRef,
+    vcpu: &crate::vm::AxVCpuRef,
+    exit: HypercallExit,
+) -> AxResult<VcpuRunAction> {
+    debug!("Hypercall [{:#x}] args {:x?}", exit.nr, exit.args);
+    match crate::runtime::hvc::HyperCall::new(vm.clone(), exit.nr, exit.args) {
+        Ok(hypercall) => {
+            let ret_val = match hypercall.execute() {
+                Ok(ret_val) => ret_val as isize,
+                Err(err) => {
+                    warn!("Hypercall [{:#x}] failed: {err:?}", exit.nr);
+                    -1
+                }
+            };
+            vcpu.set_return_value(ret_val as usize);
+        }
+        Err(err) => {
+            warn!("Hypercall [{:#x}] failed: {err:?}", exit.nr);
+        }
+    }
+    Ok(VcpuRunAction::Yield)
+}
+
+pub(crate) fn handle_cpu_up<A: ArchOps>(
+    vm: &crate::AxVMRef,
+    vcpu: &crate::vm::AxVCpuRef,
+    exit: CpuUpExit,
+) -> AxResult<VcpuRunAction> {
+    let vm_id = vm.id();
+    let vcpu_id = vcpu.id();
+    info!(
+        "VM[{vm_id}]'s VCpu[{vcpu_id}] try to boot target_cpu [{}] entry_point={:x} arg={:#x}",
+        exit.target_cpu, exit.entry_point, exit.arg
+    );
+
+    let Some(target_vcpu_id) = A::cpu_up_target_vcpu_id(vm, exit.target_cpu) else {
+        warn!(
+            "VM[{vm_id}] cannot resolve architecture CPU target {} to a VM-local vCPU",
+            exit.target_cpu
+        );
+        vcpu.set_return_value(usize::MAX);
+        return Ok(VcpuRunAction::Yield);
+    };
+
+    match crate::runtime::vcpus::vcpu_on(
+        vm.clone(),
+        target_vcpu_id,
+        exit.entry_point,
+        exit.arg as _,
+    ) {
+        Ok(()) => A::set_cpu_up_success(vcpu),
+        Err(err) => {
+            warn!("Failed to boot VM[{vm_id}] VCpu[{target_vcpu_id}]: {err:?}");
+            vcpu.set_return_value(usize::MAX);
+        }
+    }
+    Ok(VcpuRunAction::Yield)
+}
+
+pub(crate) fn handle_send_ipi<A: ArchOps>(
+    vm: &crate::AxVMRef,
+    vcpu_id: usize,
+    exit: SendIpiExit,
+) -> AxResult<VcpuRunAction> {
+    let vm_id = vm.id();
+    debug!(
+        "VM[{vm_id}] run VCpu[{vcpu_id}] SendIPI, target_cpu={:#x}, target_cpu_aux={:#x}, \
+         vector={}",
+        exit.target_cpu, exit.target_cpu_aux, exit.vector
+    );
+    let targets = A::ipi_targets(
+        vm,
+        vcpu_id,
+        exit.target_cpu,
+        exit.target_cpu_aux,
+        exit.send_to_all,
+        exit.send_to_self,
+    );
+    if targets.is_empty() {
+        warn!(
+            "VM[{vm_id}] SendIPI has no target: target_cpu={:#x}, target_cpu_aux={:#x}",
+            exit.target_cpu, exit.target_cpu_aux
+        );
+        return Ok(VcpuRunAction::Yield);
+    }
+
+    if targets.get(vcpu_id) {
+        crate::inject_current_vcpu_interrupt(exit.vector as _)
+            .expect("failed to inject self IPI into current vCPU");
+    }
+    let mut remote_targets = targets;
+    remote_targets.set(vcpu_id, false);
+    if !remote_targets.is_empty()
+        && let Err(err) = vm.inject_interrupt_to_vcpu(remote_targets, exit.vector as _)
+    {
+        warn!(
+            "Failed to inject interrupt {} to VM[{vm_id}] targets {remote_targets:?}: {err:?}",
+            exit.vector
+        );
+    }
+    Ok(VcpuRunAction::Yield)
+}
+
+/// Transitional handler for architecture backends that still return the legacy
+/// common `VmExit` while their raw exit enums are being split out.
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) fn handle_transitional_vm_exit<A: ArchOps>(
+    vm: &crate::AxVMRef,
+    vcpu: &crate::vm::AxVCpuRef,
+    exit: VmExit,
+) -> AxResult<VcpuRunAction> {
+    match exit {
+        VmExit::Hypercall { nr, args } => handle_hypercall(vm, vcpu, HypercallExit { nr, args }),
+        VmExit::MmioRead {
+            addr,
+            width,
+            reg,
+            reg_width,
+            signed_ext,
+        } => handle_mmio_read(
+            vm,
+            vcpu,
+            MmioReadExit {
+                addr,
+                width,
+                reg,
+                reg_width,
+                signed_ext,
+            },
+        ),
+        VmExit::MmioWrite { addr, width, data } => {
+            handle_mmio_write(vm, MmioWriteExit { addr, width, data })
+        }
+        VmExit::IoRead { port, width } => handle_io_read::<A>(vm, vcpu, IoReadExit { port, width }),
+        VmExit::IoWrite { port, width, data } => {
+            handle_io_write(vm, IoWriteExit { port, width, data })
+        }
+        VmExit::SysRegRead { addr, reg } => {
+            handle_sys_reg_read(vm, vcpu, SysRegReadExit { addr, reg })
+        }
+        VmExit::SysRegWrite { addr, value } => {
+            handle_sys_reg_write(vm, SysRegWriteExit { addr, value })
+        }
+        VmExit::NestedPageFault { addr, access_flags } => {
+            handle_nested_page_fault::<A>(vm, vcpu, NestedPageFaultExit { addr, access_flags })
+        }
+        VmExit::ExternalInterrupt { vector } => {
+            debug!("VM[{}] run VCpu[{}] get irq {vector}", vm.id(), vcpu.id());
+            Ok(VcpuRunAction::HostInterrupt(vector as usize))
+        }
+        VmExit::PreemptionTimer => {
+            A::after_preemption_timer(vm, vcpu);
+            Ok(VcpuRunAction::Yield)
+        }
+        VmExit::InterruptEnd { vector } => {
+            A::after_interrupt_end(vm, vcpu, vector);
+            Ok(VcpuRunAction::Yield)
+        }
+        VmExit::Halt => {
+            debug!("VM[{}] run VCpu[{}] Halt", vm.id(), vcpu.id());
+            Ok(A::handle_halt())
+        }
+        VmExit::Idle => {
+            trace!("VM[{}] run VCpu[{}] Idle", vm.id(), vcpu.id());
+            A::handle_idle(vm, vcpu);
+            Ok(VcpuRunAction::Yield)
+        }
+        VmExit::Nothing => Ok(VcpuRunAction::Yield),
+        VmExit::CpuDown { _state } => {
+            warn!(
+                "VM[{}] run VCpu[{}] CpuDown state {_state:#x}",
+                vm.id(),
+                vcpu.id()
+            );
+            Ok(VcpuRunAction::Wait)
+        }
+        VmExit::CpuUp {
+            target_cpu,
+            entry_point,
+            arg,
+        } => handle_cpu_up::<A>(
+            vm,
+            vcpu,
+            CpuUpExit {
+                target_cpu,
+                entry_point,
+                arg,
+            },
+        ),
+        VmExit::SystemDown => {
+            warn!("VM[{}] run VCpu[{}] SystemDown", vm.id(), vcpu.id());
+            Ok(VcpuRunAction::Stop(StopReason::SystemDown))
+        }
+        VmExit::FailEntry {
+            hardware_entry_failure_reason,
+        } => {
+            warn!(
+                "VM[{}] VCpu[{}] run failed with exit code {hardware_entry_failure_reason}",
+                vm.id(),
+                vcpu.id()
+            );
+            Ok(VcpuRunAction::Yield)
+        }
+        VmExit::SendIPI {
+            target_cpu,
+            target_cpu_aux,
+            send_to_all,
+            send_to_self,
+            vector,
+        } => handle_send_ipi::<A>(
+            vm,
+            vcpu.id(),
+            SendIpiExit {
+                target_cpu,
+                target_cpu_aux,
+                send_to_all,
+                send_to_self,
+                vector,
+            },
+        ),
+        _ => ax_err!(Unsupported, "unsupported legacy VM exit"),
+    }
 }
 
 pub(crate) fn target_phys_cpu_ids(vcpu_mappings: &[(usize, Option<usize>, usize)]) -> Vec<usize> {

--- a/virtualization/axvm/src/arch/mod.rs
+++ b/virtualization/axvm/src/arch/mod.rs
@@ -1,15 +1,13 @@
 //! Architecture component glue owned by AxVM.
 
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 
-use ax_errno::AxResult;
-#[cfg(not(target_arch = "aarch64"))]
-use ax_errno::ax_err;
+use ax_errno::{AxResult, ax_err};
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axaddrspace::NestedPageTableOps;
 use axvm_types::{
     AccessWidth, GuestPhysAddr, NestedPagingConfig, PassThroughPortConfig, SysRegAddr,
-    VMInterruptMode, VmArchPerCpuOps, VmArchVcpuOps,
+    VMInterruptMode, VmArchPerCpuOps, VmArchVcpuOps, VmVcpuState,
 };
 #[cfg(not(target_arch = "aarch64"))]
 use axvm_types::{MappingFlags, Port, VmExit};
@@ -39,19 +37,53 @@ pub(crate) type ArchVCpu = <CurrentArch as ArchOps>::VCpu;
 pub(crate) type ArchPerCpu = <CurrentArch as ArchOps>::PerCpu;
 pub(crate) type ArchNestedPageTable = <CurrentArch as ArchOps>::NestedPageTable;
 
-/// Result of handling one architecture-specific vCPU exit.
+pub(crate) fn guest_page_table_levels(
+    vcpu_mappings: &[(usize, Option<usize>, usize)],
+) -> AxResult<usize> {
+    CurrentArch::guest_page_table_levels(vcpu_mappings)
+}
+
+pub(crate) fn new_nested_page_table(levels: usize) -> AxResult<ArchNestedPageTable> {
+    CurrentArch::new_nested_page_table(levels)
+}
+
+pub(crate) fn nested_paging_config(
+    root_paddr: PhysAddr,
+    levels: usize,
+    vcpu_mappings: &[(usize, Option<usize>, usize)],
+) -> AxResult<NestedPagingConfig> {
+    CurrentArch::nested_paging_config(root_paddr, levels, vcpu_mappings)
+}
+
+/// Runtime scheduler action selected after an architecture-local vCPU exit.
 #[derive(Debug)]
 pub(crate) enum VcpuRunAction {
-    /// The exit was handled completely; re-enter the guest in the current run slice.
-    Continue,
-    /// Handle a host external interrupt after the vCPU has been unbound.
-    HostInterrupt(usize),
     /// Return to the runtime loop without blocking.
     Yield,
     /// Block the current vCPU task on the VM runtime wait queue.
     Wait,
     /// Request VM stop with the provided reason.
     Stop(StopReason),
+}
+
+/// Result of handling one exit while the vCPU is still bound to the host CPU.
+#[derive(Debug)]
+pub(crate) enum BoundVcpuExit<D> {
+    /// The exit was handled completely; re-enter the guest in the current run slice.
+    Continue,
+    /// The run slice is complete and can return this scheduler action after unbind.
+    Complete(VcpuRunAction),
+    /// Finish architecture-local work after unbinding the vCPU.
+    Defer(D),
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum LegacyDeferredRunWork {
+    ExternalInterrupt { vector: usize },
+    PreemptionTimer,
+    InterruptEnd { vector: Option<u8> },
+    Idle,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -146,6 +178,7 @@ pub(crate) trait ArchOps {
     type VCpu: VmArchVcpuOps;
     type PerCpu: VmArchPerCpuOps;
     type VcpuCreateState;
+    type DeferredRunWork;
     type NestedPageTable: NestedPageTableOps;
 
     fn has_hardware_support() -> bool;
@@ -231,26 +264,26 @@ pub(crate) trait ArchOps {
         targets
     }
 
-    fn set_vcpu_on_args(vcpu: &crate::vm::AxVCpuRef, _vcpu_id: usize, arg: usize) {
+    fn set_vcpu_on_args(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>, _vcpu_id: usize, arg: usize) {
         vcpu.set_gpr(0, arg);
     }
 
-    fn set_cpu_up_success(vcpu: &crate::vm::AxVCpuRef) {
+    fn set_cpu_up_success(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         vcpu.set_gpr(0, 0);
     }
 
     #[cfg(not(target_arch = "aarch64"))]
-    fn set_io_read_result(vcpu: &crate::vm::AxVCpuRef, val: usize) {
+    fn set_io_read_result(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>, val: usize) {
         vcpu.set_gpr(0, val);
     }
 
-    fn before_first_run(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef) {}
+    fn before_first_run(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {}
 
-    fn before_vcpu_run(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef) {}
+    fn before_vcpu_run(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {}
 
     fn inject_pending_interrupt(
         _vm: &crate::AxVMRef,
-        vcpu: &crate::vm::AxVCpuRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         interrupt: crate::vm::PendingInterrupt,
     ) {
         match interrupt {
@@ -283,32 +316,36 @@ pub(crate) trait ArchOps {
         }
     }
 
-    fn after_external_interrupt(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef, vector: usize) {
+    fn after_external_interrupt(
+        _vm: &crate::AxVMRef,
+        _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        vector: usize,
+    ) {
         crate::host::arceos::dispatch_host_irq(vector);
         crate::check_timer_events();
     }
 
     #[cfg(not(target_arch = "aarch64"))]
-    fn after_preemption_timer(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef) {
+    fn after_preemption_timer(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         crate::check_timer_events();
     }
 
     #[cfg(not(target_arch = "aarch64"))]
     fn after_interrupt_end(
         _vm: &crate::AxVMRef,
-        _vcpu: &crate::vm::AxVCpuRef,
+        _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         _vector: Option<u8>,
     ) {
     }
 
     #[cfg(not(target_arch = "aarch64"))]
-    fn handle_idle(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef) {
+    fn handle_idle(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         crate::check_timer_events();
     }
 
     fn on_last_vcpu_exit(_vm_id: usize) {}
 
-    fn after_mmio_write(_vm: &crate::AxVM) {}
+    fn after_mmio_write(_vm: &crate::AxVMRef) {}
 
     fn cpu_up_target_vcpu_id(vm: &crate::AxVMRef, target_cpu: u64) -> Option<usize> {
         vm.get_vcpu_affinities_pcpu_ids()
@@ -321,18 +358,80 @@ pub(crate) trait ArchOps {
         VcpuRunAction::Wait
     }
 
-    fn handle_vcpu_exit(
+    fn handle_vcpu_exit_bound(
         vm: &crate::AxVMRef,
-        vcpu: &crate::vm::AxVCpuRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         exit: <Self::VCpu as VmArchVcpuOps>::Exit,
+    ) -> AxResult<BoundVcpuExit<Self::DeferredRunWork>>;
+
+    fn finish_deferred_run_work(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        work: Self::DeferredRunWork,
     ) -> AxResult<VcpuRunAction>;
+
+    fn run_vcpu(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+    ) -> AxResult<VcpuRunAction>
+    where
+        Self: Sized,
+    {
+        let vm_id = vm.id();
+        let vcpu_id = vcpu.id();
+
+        match vcpu.state() {
+            VmVcpuState::Free => vcpu.bind()?,
+            VmVcpuState::Ready => {}
+            state => {
+                return ax_err!(
+                    BadState,
+                    format!("VCpu state is not Free or Ready, but {state:?}")
+                );
+            }
+        }
+
+        let run_result = vcpu.with_current_cpu_set(|| -> AxResult<_> {
+            loop {
+                crate::runtime::vcpus::inject_pending_interrupts::<Self>(vm.id(), vcpu_id, vcpu);
+
+                let exit = vcpu.run()?;
+                trace!("{exit:#x?}");
+                match Self::handle_vcpu_exit_bound(vm, vcpu, exit)? {
+                    BoundVcpuExit::Continue => continue,
+                    action => break Ok(action),
+                }
+            }
+        });
+
+        let unbind_result = vcpu.unbind();
+        match run_result {
+            Ok(BoundVcpuExit::Complete(action)) => {
+                unbind_result?;
+                Ok(action)
+            }
+            Ok(BoundVcpuExit::Defer(work)) => {
+                unbind_result?;
+                Self::finish_deferred_run_work(vm, vcpu, work)
+            }
+            Ok(BoundVcpuExit::Continue) => unreachable!("continued exits do not leave run loop"),
+            Err(err) => {
+                if let Err(unbind_err) = unbind_result {
+                    warn!(
+                        "VM[{vm_id}] VCpu[{vcpu_id}] unbind after run error failed: {unbind_err:?}"
+                    );
+                }
+                Err(err)
+            }
+        }
+    }
 }
 
-pub(crate) fn handle_mmio_read(
+pub(crate) fn handle_mmio_read<V: VmArchVcpuOps, D>(
     vm: &crate::AxVM,
-    vcpu: &crate::vm::AxVCpuRef,
+    vcpu: &crate::vm::AxVCpuRef<V>,
     exit: MmioReadExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<D>> {
     let raw = vm.get_devices()?.handle_mmio_read(exit.addr, exit.width)?;
     let masked = raw & crate::vm::width_mask(exit.width);
     let val = if exit.signed_ext {
@@ -341,61 +440,71 @@ pub(crate) fn handle_mmio_read(
         masked & crate::vm::width_mask(exit.reg_width)
     };
     vcpu.set_gpr(exit.reg, val);
-    Ok(VcpuRunAction::Continue)
+    Ok(BoundVcpuExit::Continue)
 }
 
-pub(crate) fn handle_mmio_write(vm: &crate::AxVM, exit: MmioWriteExit) -> AxResult<VcpuRunAction> {
+pub(crate) fn handle_mmio_write<A: ArchOps>(
+    vm: &crate::AxVMRef,
+    exit: MmioWriteExit,
+) -> AxResult<BoundVcpuExit<A::DeferredRunWork>> {
     vm.handle_mmio_write(exit.addr, exit.width, exit.data as usize)?;
-    Ok(VcpuRunAction::Continue)
+    A::after_mmio_write(vm);
+    Ok(BoundVcpuExit::Continue)
 }
 
 #[cfg(not(target_arch = "aarch64"))]
 pub(crate) fn handle_io_read<A: ArchOps>(
     vm: &crate::AxVM,
-    vcpu: &crate::vm::AxVCpuRef,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
     exit: IoReadExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<A::DeferredRunWork>> {
     let val = vm.get_devices()?.handle_port_read(exit.port, exit.width)?;
     A::set_io_read_result(vcpu, val);
-    Ok(VcpuRunAction::Continue)
+    Ok(BoundVcpuExit::Continue)
 }
 
 #[cfg(not(target_arch = "aarch64"))]
-pub(crate) fn handle_io_write(vm: &crate::AxVM, exit: IoWriteExit) -> AxResult<VcpuRunAction> {
+pub(crate) fn handle_io_write<D>(
+    vm: &crate::AxVM,
+    exit: IoWriteExit,
+) -> AxResult<BoundVcpuExit<D>> {
     vm.get_devices()?
         .handle_port_write(exit.port, exit.width, exit.data as usize)?;
-    Ok(VcpuRunAction::Continue)
+    Ok(BoundVcpuExit::Continue)
 }
 
-pub(crate) fn handle_sys_reg_read(
+pub(crate) fn handle_sys_reg_read<V: VmArchVcpuOps, D>(
     vm: &crate::AxVM,
-    vcpu: &crate::vm::AxVCpuRef,
+    vcpu: &crate::vm::AxVCpuRef<V>,
     exit: SysRegReadExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<D>> {
     let val = vm.get_devices()?.handle_sys_reg_read(
         exit.addr,
         // System registers are currently modeled as fixed-width device registers.
         AccessWidth::Qword,
     )?;
     vcpu.set_gpr(exit.reg, val);
-    Ok(VcpuRunAction::Continue)
+    Ok(BoundVcpuExit::Continue)
 }
 
-pub(crate) fn handle_sys_reg_write(
+pub(crate) fn handle_sys_reg_write<D>(
     vm: &crate::AxVM,
     exit: SysRegWriteExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<D>> {
     vm.get_devices()?
         .handle_sys_reg_write(exit.addr, AccessWidth::Qword, exit.value as usize)?;
-    Ok(VcpuRunAction::Continue)
+    Ok(BoundVcpuExit::Continue)
 }
 
 #[cfg(not(target_arch = "aarch64"))]
-pub(crate) fn handle_nested_page_fault<A: ArchOps>(
+pub(crate) fn handle_nested_page_fault<A>(
     vm: &crate::AxVMRef,
-    vcpu: &crate::vm::AxVCpuRef,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
     exit: NestedPageFaultExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<A::DeferredRunWork>>
+where
+    A: ArchOps<DeferredRunWork = LegacyDeferredRunWork>,
+{
     if vm.get_devices()?.find_mmio_dev(exit.addr).is_some() {
         let Some(decoded) = vcpu
             .get_arch_vcpu()
@@ -407,13 +516,13 @@ pub(crate) fn handle_nested_page_fault<A: ArchOps>(
                 vcpu.id(),
                 exit.addr.as_usize()
             );
-            return Ok(VcpuRunAction::Yield);
+            return Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield));
         };
         return handle_transitional_vm_exit::<A>(vm, vcpu, decoded);
     }
 
     if vm.handle_nested_page_fault(exit.addr, exit.access_flags) {
-        Ok(VcpuRunAction::Continue)
+        Ok(BoundVcpuExit::Continue)
     } else {
         warn!(
             "VM[{}] VCpu[{}] unhandled nested page fault at {:#x}, access={:?}",
@@ -422,15 +531,15 @@ pub(crate) fn handle_nested_page_fault<A: ArchOps>(
             exit.addr.as_usize(),
             exit.access_flags
         );
-        Ok(VcpuRunAction::Yield)
+        Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
     }
 }
 
-pub(crate) fn handle_hypercall(
+pub(crate) fn handle_hypercall<V: VmArchVcpuOps, D>(
     vm: &crate::AxVMRef,
-    vcpu: &crate::vm::AxVCpuRef,
+    vcpu: &crate::vm::AxVCpuRef<V>,
     exit: HypercallExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<D>> {
     debug!("Hypercall [{:#x}] args {:x?}", exit.nr, exit.args);
     match crate::runtime::hvc::HyperCall::new(vm.clone(), exit.nr, exit.args) {
         Ok(hypercall) => {
@@ -447,14 +556,14 @@ pub(crate) fn handle_hypercall(
             warn!("Hypercall [{:#x}] failed: {err:?}", exit.nr);
         }
     }
-    Ok(VcpuRunAction::Yield)
+    Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
 }
 
 pub(crate) fn handle_cpu_up<A: ArchOps>(
     vm: &crate::AxVMRef,
-    vcpu: &crate::vm::AxVCpuRef,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
     exit: CpuUpExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<A::DeferredRunWork>> {
     let vm_id = vm.id();
     let vcpu_id = vcpu.id();
     info!(
@@ -468,7 +577,7 @@ pub(crate) fn handle_cpu_up<A: ArchOps>(
             exit.target_cpu
         );
         vcpu.set_return_value(usize::MAX);
-        return Ok(VcpuRunAction::Yield);
+        return Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield));
     };
 
     match crate::runtime::vcpus::vcpu_on(
@@ -483,14 +592,14 @@ pub(crate) fn handle_cpu_up<A: ArchOps>(
             vcpu.set_return_value(usize::MAX);
         }
     }
-    Ok(VcpuRunAction::Yield)
+    Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
 }
 
 pub(crate) fn handle_send_ipi<A: ArchOps>(
     vm: &crate::AxVMRef,
     vcpu_id: usize,
     exit: SendIpiExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<A::DeferredRunWork>> {
     let vm_id = vm.id();
     debug!(
         "VM[{vm_id}] run VCpu[{vcpu_id}] SendIPI, target_cpu={:#x}, target_cpu_aux={:#x}, \
@@ -510,7 +619,7 @@ pub(crate) fn handle_send_ipi<A: ArchOps>(
             "VM[{vm_id}] SendIPI has no target: target_cpu={:#x}, target_cpu_aux={:#x}",
             exit.target_cpu, exit.target_cpu_aux
         );
-        return Ok(VcpuRunAction::Yield);
+        return Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield));
     }
 
     if targets.get(vcpu_id) {
@@ -527,17 +636,20 @@ pub(crate) fn handle_send_ipi<A: ArchOps>(
             exit.vector
         );
     }
-    Ok(VcpuRunAction::Yield)
+    Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
 }
 
 /// Transitional handler for architecture backends that still return the legacy
 /// common `VmExit` while their raw exit enums are being split out.
 #[cfg(not(target_arch = "aarch64"))]
-pub(crate) fn handle_transitional_vm_exit<A: ArchOps>(
+pub(crate) fn handle_transitional_vm_exit<A>(
     vm: &crate::AxVMRef,
-    vcpu: &crate::vm::AxVCpuRef,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
     exit: VmExit,
-) -> AxResult<VcpuRunAction> {
+) -> AxResult<BoundVcpuExit<LegacyDeferredRunWork>>
+where
+    A: ArchOps<DeferredRunWork = LegacyDeferredRunWork>,
+{
     match exit {
         VmExit::Hypercall { nr, args } => handle_hypercall(vm, vcpu, HypercallExit { nr, args }),
         VmExit::MmioRead {
@@ -558,7 +670,7 @@ pub(crate) fn handle_transitional_vm_exit<A: ArchOps>(
             },
         ),
         VmExit::MmioWrite { addr, width, data } => {
-            handle_mmio_write(vm, MmioWriteExit { addr, width, data })
+            handle_mmio_write::<A>(vm, MmioWriteExit { addr, width, data })
         }
         VmExit::IoRead { port, width } => handle_io_read::<A>(vm, vcpu, IoReadExit { port, width }),
         VmExit::IoWrite { port, width, data } => {
@@ -575,33 +687,34 @@ pub(crate) fn handle_transitional_vm_exit<A: ArchOps>(
         }
         VmExit::ExternalInterrupt { vector } => {
             debug!("VM[{}] run VCpu[{}] get irq {vector}", vm.id(), vcpu.id());
-            Ok(VcpuRunAction::HostInterrupt(vector as usize))
+            Ok(BoundVcpuExit::Defer(
+                LegacyDeferredRunWork::ExternalInterrupt {
+                    vector: vector as usize,
+                },
+            ))
         }
-        VmExit::PreemptionTimer => {
-            A::after_preemption_timer(vm, vcpu);
-            Ok(VcpuRunAction::Yield)
-        }
+        VmExit::PreemptionTimer => Ok(BoundVcpuExit::Defer(LegacyDeferredRunWork::PreemptionTimer)),
         VmExit::InterruptEnd { vector } => {
-            A::after_interrupt_end(vm, vcpu, vector);
-            Ok(VcpuRunAction::Yield)
+            Ok(BoundVcpuExit::Defer(LegacyDeferredRunWork::InterruptEnd {
+                vector,
+            }))
         }
         VmExit::Halt => {
             debug!("VM[{}] run VCpu[{}] Halt", vm.id(), vcpu.id());
-            Ok(A::handle_halt())
+            Ok(BoundVcpuExit::Complete(A::handle_halt()))
         }
         VmExit::Idle => {
             trace!("VM[{}] run VCpu[{}] Idle", vm.id(), vcpu.id());
-            A::handle_idle(vm, vcpu);
-            Ok(VcpuRunAction::Yield)
+            Ok(BoundVcpuExit::Defer(LegacyDeferredRunWork::Idle))
         }
-        VmExit::Nothing => Ok(VcpuRunAction::Yield),
+        VmExit::Nothing => Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield)),
         VmExit::CpuDown { _state } => {
             warn!(
                 "VM[{}] run VCpu[{}] CpuDown state {_state:#x}",
                 vm.id(),
                 vcpu.id()
             );
-            Ok(VcpuRunAction::Wait)
+            Ok(BoundVcpuExit::Complete(VcpuRunAction::Wait))
         }
         VmExit::CpuUp {
             target_cpu,
@@ -618,7 +731,9 @@ pub(crate) fn handle_transitional_vm_exit<A: ArchOps>(
         ),
         VmExit::SystemDown => {
             warn!("VM[{}] run VCpu[{}] SystemDown", vm.id(), vcpu.id());
-            Ok(VcpuRunAction::Stop(StopReason::SystemDown))
+            Ok(BoundVcpuExit::Complete(VcpuRunAction::Stop(
+                StopReason::SystemDown,
+            )))
         }
         VmExit::FailEntry {
             hardware_entry_failure_reason,
@@ -628,7 +743,7 @@ pub(crate) fn handle_transitional_vm_exit<A: ArchOps>(
                 vm.id(),
                 vcpu.id()
             );
-            Ok(VcpuRunAction::Yield)
+            Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
         }
         VmExit::SendIPI {
             target_cpu,
@@ -649,6 +764,32 @@ pub(crate) fn handle_transitional_vm_exit<A: ArchOps>(
         ),
         _ => ax_err!(Unsupported, "unsupported legacy VM exit"),
     }
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) fn finish_legacy_deferred_run_work<A>(
+    vm: &crate::AxVMRef,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
+    work: LegacyDeferredRunWork,
+) -> AxResult<VcpuRunAction>
+where
+    A: ArchOps<DeferredRunWork = LegacyDeferredRunWork>,
+{
+    match work {
+        LegacyDeferredRunWork::ExternalInterrupt { vector } => {
+            A::after_external_interrupt(vm, vcpu, vector);
+        }
+        LegacyDeferredRunWork::PreemptionTimer => {
+            A::after_preemption_timer(vm, vcpu);
+        }
+        LegacyDeferredRunWork::InterruptEnd { vector } => {
+            A::after_interrupt_end(vm, vcpu, vector);
+        }
+        LegacyDeferredRunWork::Idle => {
+            A::handle_idle(vm, vcpu);
+        }
+    }
+    Ok(VcpuRunAction::Yield)
 }
 
 pub(crate) fn target_phys_cpu_ids(vcpu_mappings: &[(usize, Option<usize>, usize)]) -> Vec<usize> {

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -8,8 +8,8 @@ use riscv_vcpu::{GprIndex as RiscvGprIndex, host::RiscvVcpuHostIf};
 use riscv_vplic::host::RiscvVplicHostIf;
 
 use super::{
-    ArchOps, VcpuCreateContext, VcpuRunAction, VcpuSetupContext, default_vcpu_affinities,
-    target_phys_cpu_ids,
+    ArchOps, BoundVcpuExit, LegacyDeferredRunWork, VcpuCreateContext, VcpuRunAction,
+    VcpuSetupContext, default_vcpu_affinities, target_phys_cpu_ids,
 };
 use crate::host::{HostMemory, default_host};
 
@@ -21,6 +21,7 @@ impl ArchOps for Riscv64Arch {
     type VCpu = riscv_vcpu::RISCVVCpu;
     type PerCpu = riscv_vcpu::RISCVPerCpu;
     type VcpuCreateState = ();
+    type DeferredRunWork = LegacyDeferredRunWork;
     type NestedPageTable = npt::NestedPageTable<crate::HostPagingHandler>;
 
     fn has_hardware_support() -> bool {
@@ -83,7 +84,7 @@ impl ArchOps for Riscv64Arch {
         register_platform_irq_injector();
     }
 
-    fn before_first_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef) {
+    fn before_first_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         if vm.interrupt_mode() != VMInterruptMode::Passthrough {
             return;
         }
@@ -113,20 +114,24 @@ impl ArchOps for Riscv64Arch {
         vcpus
     }
 
-    fn set_vcpu_on_args(vcpu: &crate::vm::AxVCpuRef, vcpu_id: usize, arg: usize) {
+    fn set_vcpu_on_args(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>, vcpu_id: usize, arg: usize) {
         vcpu.set_gpr(RiscvGprIndex::A0 as usize, vcpu_id);
         vcpu.set_gpr(RiscvGprIndex::A1 as usize, arg);
     }
 
-    fn set_cpu_up_success(vcpu: &crate::vm::AxVCpuRef) {
+    fn set_cpu_up_success(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         vcpu.set_gpr(RiscvGprIndex::A0 as usize, 0);
     }
 
-    fn set_io_read_result(vcpu: &crate::vm::AxVCpuRef, val: usize) {
+    fn set_io_read_result(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>, val: usize) {
         vcpu.set_gpr(RiscvGprIndex::A0 as usize, val);
     }
 
-    fn after_external_interrupt(_vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef, vector: usize) {
+    fn after_external_interrupt(
+        _vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        vector: usize,
+    ) {
         vcpu.with_current_cpu_set(|| {
             crate::host::arceos::dispatch_host_irq(vector);
             vcpu.get_arch_vcpu().latch_hvip_from_hw();
@@ -134,12 +139,20 @@ impl ArchOps for Riscv64Arch {
         crate::check_timer_events();
     }
 
-    fn handle_vcpu_exit(
+    fn handle_vcpu_exit_bound(
         vm: &crate::AxVMRef,
-        vcpu: &crate::vm::AxVCpuRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         exit: <Self::VCpu as axvm_types::VmArchVcpuOps>::Exit,
-    ) -> AxResult<VcpuRunAction> {
+    ) -> AxResult<BoundVcpuExit<Self::DeferredRunWork>> {
         super::handle_transitional_vm_exit::<Self>(vm, vcpu, exit)
+    }
+
+    fn finish_deferred_run_work(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        work: Self::DeferredRunWork,
+    ) -> AxResult<VcpuRunAction> {
+        super::finish_legacy_deferred_run_work::<Self>(vm, vcpu, work)
     }
 }
 

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -8,7 +8,8 @@ use riscv_vcpu::{GprIndex as RiscvGprIndex, host::RiscvVcpuHostIf};
 use riscv_vplic::host::RiscvVplicHostIf;
 
 use super::{
-    ArchOps, VcpuCreateContext, VcpuSetupContext, default_vcpu_affinities, target_phys_cpu_ids,
+    ArchOps, VcpuCreateContext, VcpuRunAction, VcpuSetupContext, default_vcpu_affinities,
+    target_phys_cpu_ids,
 };
 use crate::host::{HostMemory, default_host};
 
@@ -131,6 +132,14 @@ impl ArchOps for Riscv64Arch {
             vcpu.get_arch_vcpu().latch_hvip_from_hw();
         });
         crate::check_timer_events();
+    }
+
+    fn handle_vcpu_exit(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef,
+        exit: <Self::VCpu as axvm_types::VmArchVcpuOps>::Exit,
+    ) -> AxResult<VcpuRunAction> {
+        super::handle_transitional_vm_exit::<Self>(vm, vcpu, exit)
     }
 }
 

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -8,7 +8,10 @@ use axvm_types::{InterruptVector, VCpuId, VMId};
 use x86_vcpu::host::X86VcpuHostIf;
 use x86_vlapic::host::X86VlapicHostIf;
 
-use super::{ArchOps, VcpuCreateContext, VcpuRunAction, VcpuSetupContext};
+use super::{
+    ArchOps, BoundVcpuExit, LegacyDeferredRunWork, VcpuCreateContext, VcpuRunAction,
+    VcpuSetupContext,
+};
 use crate::{
     host::{HostConsole, HostMemory, HostTime, default_host},
     manager,
@@ -25,6 +28,7 @@ impl ArchOps for X86_64Arch {
     type VCpu = x86_vcpu::X86ArchVCpu;
     type PerCpu = x86_vcpu::X86ArchPerCpuState;
     type VcpuCreateState = X86VcpuCreateState;
+    type DeferredRunWork = LegacyDeferredRunWork;
     type NestedPageTable = npt::NestedPageTable<crate::HostPagingHandler>;
 
     fn has_hardware_support() -> bool {
@@ -61,28 +65,36 @@ impl ArchOps for X86_64Arch {
         npt::NestedPageTable::new(levels)
     }
 
-    fn before_first_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef) {
+    fn before_first_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         crate::runtime::x86_irq::enable_ioapic_irq_forwarding(vm, vcpu);
     }
 
-    fn before_vcpu_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef) {
+    fn before_vcpu_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         crate::runtime::x86_irq::drain_pending_ioapic_irqs(vm, vcpu);
         crate::runtime::x86_irq::activate_ready_ioapic_forwarding_routes(vm);
     }
 
-    fn after_external_interrupt(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef, vector: usize) {
+    fn after_external_interrupt(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        vector: usize,
+    ) {
         crate::host::arceos::dispatch_host_irq(vector);
         crate::check_timer_events();
         crate::runtime::x86_irq::inject_pending_serial_irq(vm, vcpu);
     }
 
-    fn after_preemption_timer(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef) {
+    fn after_preemption_timer(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         crate::timer::check_events();
         crate::runtime::x86_irq::inject_due_pit_irq0(vm, vcpu);
         crate::runtime::x86_irq::inject_pending_serial_irq(vm, vcpu);
     }
 
-    fn after_interrupt_end(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef, vector: Option<u8>) {
+    fn after_interrupt_end(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        vector: Option<u8>,
+    ) {
         if let Some(vector) = vector {
             crate::runtime::x86_irq::inject_pending_ioapic_irq_after_eoi(vm, vcpu, vector);
         }
@@ -96,12 +108,20 @@ impl ArchOps for X86_64Arch {
         crate::runtime::x86_irq::disable_ioapic_irq_forwarding_for_vm(vm_id);
     }
 
-    fn handle_vcpu_exit(
+    fn handle_vcpu_exit_bound(
         vm: &crate::AxVMRef,
-        vcpu: &crate::vm::AxVCpuRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         exit: <Self::VCpu as axvm_types::VmArchVcpuOps>::Exit,
-    ) -> AxResult<VcpuRunAction> {
+    ) -> AxResult<BoundVcpuExit<Self::DeferredRunWork>> {
         super::handle_transitional_vm_exit::<Self>(vm, vcpu, exit)
+    }
+
+    fn finish_deferred_run_work(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        work: Self::DeferredRunWork,
+    ) -> AxResult<VcpuRunAction> {
+        super::finish_legacy_deferred_run_work::<Self>(vm, vcpu, work)
     }
 }
 

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -8,7 +8,7 @@ use axvm_types::{InterruptVector, VCpuId, VMId};
 use x86_vcpu::host::X86VcpuHostIf;
 use x86_vlapic::host::X86VlapicHostIf;
 
-use super::{ArchOps, VcpuCreateContext, VcpuSetupContext};
+use super::{ArchOps, VcpuCreateContext, VcpuRunAction, VcpuSetupContext};
 use crate::{
     host::{HostConsole, HostMemory, HostTime, default_host},
     manager,
@@ -88,12 +88,20 @@ impl ArchOps for X86_64Arch {
         }
     }
 
-    fn handle_halt(_runtime: &crate::vm::VmRuntimeHandle) -> bool {
-        true
+    fn handle_halt() -> VcpuRunAction {
+        VcpuRunAction::Yield
     }
 
     fn on_last_vcpu_exit(vm_id: usize) {
         crate::runtime::x86_irq::disable_ioapic_irq_forwarding_for_vm(vm_id);
+    }
+
+    fn handle_vcpu_exit(
+        vm: &crate::AxVMRef,
+        vcpu: &crate::vm::AxVCpuRef,
+        exit: <Self::VCpu as axvm_types::VmArchVcpuOps>::Exit,
+    ) -> AxResult<VcpuRunAction> {
+        super::handle_transitional_vm_exit::<Self>(vm, vcpu, exit)
     }
 }
 

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -42,9 +42,15 @@ use crate::arch::ArchOps;
 pub mod config;
 
 pub use ax_cpumask::CpuMask;
+/// Compatibility export for legacy/common normalized VM events.
+///
+/// Architecture-local raw exits are handled by `arch::CurrentArch` through
+/// `VmArchVcpuOps::Exit`; new code should not treat this as the universal raw
+/// vCPU exit type.
+pub use axvm_types::VmExit;
 pub use axvm_types::{
     AccessWidth, GuestPhysAddr, HostPhysAddr, InterruptTriggerMode, MappingFlags, Port, SysRegAddr,
-    VMId, VmExit, VmVcpuState,
+    VMId, VmVcpuState,
 };
 pub(crate) use host::{
     paging::HostPagingHandler,

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod hvc;
+pub(crate) mod hvc;
 mod ivc;
 
 #[cfg(target_arch = "loongarch64")]

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -17,8 +17,8 @@ use alloc::format;
 use ax_errno::{AxResult, ax_err_type};
 
 use crate::{
-    AsVCpuTask, GuestPhysAddr, StopReason, VCpuTask, VmExit, VmStatus, VmVcpuState,
-    arch::{ArchOps, CurrentArch},
+    AsVCpuTask, GuestPhysAddr, StopReason, VCpuTask, VmStatus, VmVcpuState,
+    arch::{ArchOps, CurrentArch, VcpuRunAction},
     runtime::{VCpuRef, VMRef, sub_running_vm_count},
     vm::VmRuntimeHandle,
 };
@@ -184,7 +184,12 @@ fn mark_vcpu_running(vm: &VMRef) {
 /// * `vcpu_id` - The ID of the VCpu to be booted.
 /// * `entry_point` - The entry point of the VCpu.
 /// * `arg` - The argument to be passed to the VCpu.
-fn vcpu_on(vm: VMRef, vcpu_id: usize, entry_point: GuestPhysAddr, arg: usize) -> AxResult {
+pub(crate) fn vcpu_on(
+    vm: VMRef,
+    vcpu_id: usize,
+    entry_point: GuestPhysAddr,
+    arg: usize,
+) -> AxResult {
     let vcpu = vm
         .vcpu_list()
         .get(vcpu_id)
@@ -292,152 +297,21 @@ fn vcpu_run() {
     mark_vcpu_running(&vm);
 
     loop {
-        inject_pending_interrupts(vm_id, vcpu_id, &vcpu);
         CurrentArch::before_vcpu_run(&vm, &vcpu);
 
         match vm.run_vcpu(vcpu_id) {
-            Ok(exit_reason) => match exit_reason {
-                VmExit::Hypercall { nr, args } => {
-                    debug!("Hypercall [{nr}] args {args:x?}");
-                    use crate::runtime::hvc::HyperCall;
-
-                    match HyperCall::new(vm.clone(), nr, args) {
-                        Ok(hypercall) => {
-                            let ret_val = match hypercall.execute() {
-                                Ok(ret_val) => ret_val as isize,
-                                Err(err) => {
-                                    warn!("Hypercall [{nr:#x}] failed: {err:?}");
-                                    -1
-                                }
-                            };
-                            vcpu.set_return_value(ret_val as usize);
-                        }
-                        Err(err) => {
-                            warn!("Hypercall [{nr:#x}] failed: {err:?}");
-                        }
-                    }
+            Ok(VcpuRunAction::Continue) => continue,
+            Ok(VcpuRunAction::HostInterrupt(vector)) => {
+                CurrentArch::after_external_interrupt(&vm, &vcpu, vector);
+            }
+            Ok(VcpuRunAction::Yield) => {}
+            Ok(VcpuRunAction::Wait) => wait(&runtime),
+            Ok(VcpuRunAction::Stop(reason)) => {
+                if let Err(err) = vm.stop(reason) {
+                    warn!("VM[{vm_id}] shutdown failed: {err:?}");
                 }
-                VmExit::FailEntry {
-                    hardware_entry_failure_reason,
-                } => {
-                    warn!(
-                        "VM[{vm_id}] VCpu[{vcpu_id}] run failed with exit code \
-                         {hardware_entry_failure_reason}"
-                    );
-                }
-                VmExit::ExternalInterrupt { vector } => {
-                    debug!("VM[{vm_id}] run VCpu[{vcpu_id}] get irq {vector}");
-                    CurrentArch::after_external_interrupt(&vm, &vcpu, vector as usize);
-                }
-                VmExit::PreemptionTimer => {
-                    CurrentArch::after_preemption_timer(&vm, &vcpu);
-                }
-                VmExit::InterruptEnd { vector } => {
-                    CurrentArch::after_interrupt_end(&vm, &vcpu, vector);
-                }
-                VmExit::Halt => {
-                    debug!("VM[{vm_id}] run VCpu[{vcpu_id}] Halt");
-                    if CurrentArch::handle_halt(&runtime) {
-                        continue;
-                    }
-                }
-                VmExit::Idle => {
-                    trace!("VM[{vm_id}] run VCpu[{vcpu_id}] Idle");
-                    CurrentArch::handle_idle(&vm, &vcpu);
-                }
-                VmExit::Nothing => {}
-                VmExit::CpuDown { _state } => {
-                    warn!("VM[{vm_id}] run VCpu[{vcpu_id}] CpuDown state {_state:#x}");
-                    wait(&runtime)
-                }
-                VmExit::CpuUp {
-                    target_cpu,
-                    entry_point,
-                    arg,
-                } => {
-                    info!(
-                        "VM[{vm_id}]'s VCpu[{vcpu_id}] try to boot target_cpu [{target_cpu}] \
-                         entry_point={entry_point:x} arg={arg:#x}"
-                    );
-
-                    // Get the mapping relationship between all vCPUs and physical CPUs from the configuration
-                    let vcpu_mappings = vm.get_vcpu_affinities_pcpu_ids();
-
-                    // Find the vCPU ID corresponding to the physical ID
-                    let Some(target_vcpu_id) =
-                        vcpu_mappings.iter().find_map(|(vcpu_id, _, phys_id)| {
-                            (*phys_id == target_cpu as usize).then_some(*vcpu_id)
-                        })
-                    else {
-                        warn!("Physical CPU ID {target_cpu} not found in VM configuration");
-                        vcpu.set_return_value(usize::MAX);
-                        continue;
-                    };
-
-                    match vcpu_on(vm.clone(), target_vcpu_id, entry_point, arg as _) {
-                        Ok(()) => {
-                            CurrentArch::set_cpu_up_success(&vcpu);
-                        }
-                        Err(err) => {
-                            warn!("Failed to boot VM[{vm_id}] VCpu[{target_vcpu_id}]: {err:?}");
-                            vcpu.set_return_value(usize::MAX);
-                        }
-                    }
-                }
-                VmExit::SystemDown => {
-                    warn!("VM[{vm_id}] run VCpu[{vcpu_id}] SystemDown");
-                    if let Err(err) = vm.stop(StopReason::SystemDown) {
-                        warn!("VM[{vm_id}] shutdown failed: {err:?}");
-                    }
-                    // Notify all vCPUs to wake up to check the shutdown flag
-                    notify_all_vcpus(vm_id);
-                }
-                VmExit::SendIPI {
-                    target_cpu,
-                    target_cpu_aux,
-                    send_to_all,
-                    send_to_self,
-                    vector,
-                } => {
-                    debug!(
-                        "VM[{vm_id}] run VCpu[{vcpu_id}] SendIPI, target_cpu={target_cpu:#x}, \
-                         target_cpu_aux={target_cpu_aux:#x}, vector={vector}",
-                    );
-                    let targets = CurrentArch::ipi_targets(
-                        &vm,
-                        vcpu_id,
-                        target_cpu,
-                        target_cpu_aux,
-                        send_to_all,
-                        send_to_self,
-                    );
-                    if targets.is_empty() {
-                        warn!(
-                            "VM[{vm_id}] SendIPI has no target: target_cpu={target_cpu:#x}, \
-                             target_cpu_aux={target_cpu_aux:#x}"
-                        );
-                        continue;
-                    }
-
-                    if targets.get(vcpu_id) {
-                        crate::inject_current_vcpu_interrupt(vector as _)
-                            .expect("failed to inject self IPI into current vCPU");
-                    }
-                    let mut remote_targets = targets;
-                    remote_targets.set(vcpu_id, false);
-                    if !remote_targets.is_empty()
-                        && let Err(err) = vm.inject_interrupt_to_vcpu(remote_targets, vector as _)
-                    {
-                        warn!(
-                            "Failed to inject interrupt {vector} to VM[{vm_id}] targets \
-                             {remote_targets:?}: {err:?}"
-                        );
-                    }
-                }
-                e => {
-                    warn!("VM[{vm_id}] run VCpu[{vcpu_id}] unhandled vmexit: {e:?}");
-                }
-            },
+                notify_all_vcpus(vm_id);
+            }
             Err(err) => {
                 error!("VM[{vm_id}] run VCpu[{vcpu_id}] get error {err:?}");
                 if let Err(err) = vm.stop(StopReason::Fault(format!("{err:?}"))) {

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -129,7 +129,11 @@ pub(crate) fn queue_external_interrupt(
     Ok(())
 }
 
-pub(crate) fn inject_pending_interrupts(vm_id: usize, vcpu_id: usize, vcpu: &VCpuRef) {
+pub(crate) fn inject_pending_interrupts<A: ArchOps>(
+    vm_id: usize,
+    vcpu_id: usize,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
+) {
     let Some(vm) = crate::get_vm_by_id(vm_id) else {
         warn!("VM[{vm_id}] not found, cannot drain VCpu[{vcpu_id}] interrupts");
         return;
@@ -141,7 +145,7 @@ pub(crate) fn inject_pending_interrupts(vm_id: usize, vcpu_id: usize, vcpu: &VCp
     };
 
     for interrupt in interrupts {
-        CurrentArch::inject_pending_interrupt(&vm, vcpu, interrupt);
+        A::inject_pending_interrupt(&vm, vcpu, interrupt);
     }
 }
 
@@ -299,11 +303,7 @@ fn vcpu_run() {
     loop {
         CurrentArch::before_vcpu_run(&vm, &vcpu);
 
-        match vm.run_vcpu(vcpu_id) {
-            Ok(VcpuRunAction::Continue) => continue,
-            Ok(VcpuRunAction::HostInterrupt(vector)) => {
-                CurrentArch::after_external_interrupt(&vm, &vcpu, vector);
-            }
+        match CurrentArch::run_vcpu(&vm, &vcpu) {
             Ok(VcpuRunAction::Yield) => {}
             Ok(VcpuRunAction::Wait) => wait(&runtime),
             Ok(VcpuRunAction::Stop(reason)) => {

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -22,8 +22,7 @@ use ax_kspin::SpinNoIrq as Mutex;
 #[cfg(target_arch = "x86_64")]
 use axvm_types::InterruptTriggerMode;
 use axvm_types::{
-    GuestPhysAddr, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps, VmExit,
-    VmVcpuState,
+    GuestPhysAddr, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps, VmVcpuState,
 };
 
 /// Mutable runtime state of a virtual CPU.
@@ -180,7 +179,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     }
 
     /// Runs the vCPU until a VM exit.
-    pub fn run(&self) -> AxResult<VmExit> {
+    pub fn run(&self) -> AxResult<A::Exit> {
         self.transition_state(VmVcpuState::Ready, VmVcpuState::Running)?;
         self.manipulate_arch_vcpu(VmVcpuState::Running, VmVcpuState::Ready, |arch_vcpu| {
             arch_vcpu.run()

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -30,7 +30,7 @@ use axvm_types::{
 };
 
 use crate::{
-    arch::{ArchNestedPageTable, ArchOps, CurrentArch, VcpuRunAction},
+    arch::ArchNestedPageTable,
     boot::{GuestBootDescription, GuestFdtBuilder},
     config::{AxVMConfig, PhysCpuList, VMInterruptMode},
     host::paging::virt_to_phys,
@@ -51,7 +51,7 @@ const VM_ASPACE_SIZE: usize = 0x7fff_ffff_f000;
 /// A vCPU with architecture-independent interface.
 type VCpu = AxVCpu<crate::arch::ArchVCpu>;
 /// A reference to a vCPU.
-pub(crate) type AxVCpuRef = Arc<VCpu>;
+pub(crate) type AxVCpuRef<A = crate::arch::ArchVCpu> = Arc<AxVCpu<A>>;
 /// A reference to a VM.
 pub type AxVMRef = Arc<AxVM>;
 
@@ -260,14 +260,14 @@ impl VmRuntimeHandle {
 impl AxVMResources {
     fn new(config: AxVMConfig) -> AxResult<Self> {
         let vcpu_mappings = config.phys_cpu_ls.get_vcpu_affinities_pcpu_ids();
-        let page_table_levels = CurrentArch::guest_page_table_levels(&vcpu_mappings)?;
-        let page_table = CurrentArch::new_nested_page_table(page_table_levels)?;
+        let page_table_levels = crate::arch::guest_page_table_levels(&vcpu_mappings)?;
+        let page_table = crate::arch::new_nested_page_table(page_table_levels)?;
         let address_space = AddrSpace::new_empty(
             page_table,
             GuestPhysAddr::from(VM_ASPACE_BASE),
             VM_ASPACE_SIZE,
         )?;
-        let nested_paging = CurrentArch::nested_paging_config(
+        let nested_paging = crate::arch::nested_paging_config(
             address_space.page_table_root(),
             page_table_levels,
             &vcpu_mappings,
@@ -769,21 +769,6 @@ impl AxVM {
             .unwrap_or(0)
     }
 
-    /// Assert a routed LoongArch platform IRQ in the guest interrupt model.
-    #[cfg(target_arch = "loongarch64")]
-    pub(crate) fn loongarch_external_irq_vector(
-        &self,
-        fallback_vector: usize,
-        _physical_irq: usize,
-    ) -> Option<usize> {
-        let devices = self.get_devices().ok()?;
-        match devices.loongarch_pch_pic_assert_irq(fallback_vector) {
-            Some(Some(vector)) => Some(vector),
-            Some(None) => None,
-            None => Some(fallback_vector),
-        }
-    }
-
     /// Queue a QEMU fw_cfg device that will be attached during VM initialization.
     pub fn add_fw_cfg_device(&self, config: FwCfgDeviceConfig) -> AxResult {
         let mut pending = self.pending_fw_cfg.lock();
@@ -834,62 +819,6 @@ impl AxVM {
         Ok(())
     }
 
-    /// Runs a vCPU according to the given `vcpu_id` until the current
-    /// architecture reports a runtime action.
-    ///
-    /// ## Arguments
-    /// * `vcpu_id` - the id of the vCPU to run.
-    ///
-    /// ## Returns
-    /// * `VcpuRunAction` - the post-exit action selected by the current architecture.
-    pub(crate) fn run_vcpu(self: &Arc<Self>, vcpu_id: usize) -> AxResult<VcpuRunAction> {
-        let vm_id = self.id();
-        let vcpu = self
-            .vcpu(vcpu_id)
-            .ok_or_else(|| ax_err_type!(InvalidInput, "Invalid vcpu_id"))?;
-
-        match vcpu.state() {
-            VmVcpuState::Free => vcpu.bind()?,
-            VmVcpuState::Ready => {}
-            state => {
-                return ax_err!(
-                    BadState,
-                    format!("VCpu state is not Free or Ready, but {state:?}")
-                );
-            }
-        }
-
-        let run_result = vcpu.with_current_cpu_set(|| -> AxResult<VcpuRunAction> {
-            loop {
-                crate::runtime::vcpus::inject_pending_interrupts(self.id(), vcpu_id, &vcpu);
-
-                let exit = vcpu.run()?;
-                trace!("{exit:#x?}");
-                let action = CurrentArch::handle_vcpu_exit(self, &vcpu, exit)?;
-                if matches!(action, VcpuRunAction::Continue) {
-                    continue;
-                }
-                break Ok(action);
-            }
-        });
-
-        let unbind_result = vcpu.unbind();
-        match run_result {
-            Ok(exit_reason) => {
-                unbind_result?;
-                Ok(exit_reason)
-            }
-            Err(err) => {
-                if let Err(unbind_err) = unbind_result {
-                    warn!(
-                        "VM[{vm_id}] VCpu[{vcpu_id}] unbind after run error failed: {unbind_err:?}"
-                    );
-                }
-                Err(err)
-            }
-        }
-    }
-
     pub(crate) fn handle_mmio_write(
         &self,
         addr: GuestPhysAddr,
@@ -909,32 +838,7 @@ impl AxVM {
         }
 
         devices.handle_mmio_write(addr, width, data)?;
-        CurrentArch::after_mmio_write(self);
         Ok(())
-    }
-
-    #[cfg(target_arch = "loongarch64")]
-    pub(crate) fn drain_loongarch_pch_pic_events(&self) {
-        let Ok(devices) = self.get_devices() else {
-            return;
-        };
-        devices.drain_loongarch_pch_pic_events(|event| {
-            if !event.asserted {
-                trace!(
-                    "LoongArch VM[{}] PCH-PIC deassert event for EIOINTC vector {}",
-                    self.id(),
-                    event.vector
-                );
-                return;
-            }
-            if let Err(err) = crate::manager::inject_vm_vcpu_interrupt(self.id(), 0, event.vector) {
-                warn!(
-                    "failed to inject LoongArch VM[{}] PCH-PIC output vector {}: {err:?}",
-                    self.id(),
-                    event.vector
-                );
-            }
-        });
     }
 
     #[cfg(not(target_arch = "aarch64"))]

--- a/virtualization/axvm/src/vm.rs
+++ b/virtualization/axvm/src/vm.rs
@@ -26,12 +26,11 @@ use axaddrspace::AddrSpace;
 use axdevice::{AxVmDevices, FwCfg, FwCfgPlatformConfig};
 use axdevice_base::AccessWidth;
 use axvm_types::{
-    GuestPhysAddr, HostPhysAddr, HostVirtAddr, MappingFlags, NestedPagingConfig, VmArchVcpuOps,
-    VmExit, VmVcpuState,
+    GuestPhysAddr, HostPhysAddr, HostVirtAddr, MappingFlags, NestedPagingConfig, VmVcpuState,
 };
 
 use crate::{
-    arch::{ArchNestedPageTable, ArchOps, CurrentArch},
+    arch::{ArchNestedPageTable, ArchOps, CurrentArch, VcpuRunAction},
     boot::{GuestBootDescription, GuestFdtBuilder},
     config::{AxVMConfig, PhysCpuList, VMInterruptMode},
     host::paging::virt_to_phys,
@@ -67,7 +66,7 @@ pub struct VcpuSnapshot {
     pub phys_cpu_set: Option<usize>,
 }
 
-fn width_mask(width: AccessWidth) -> usize {
+pub(crate) fn width_mask(width: AccessWidth) -> usize {
     match width {
         AccessWidth::Byte => 0xff,
         AccessWidth::Word => 0xffff,
@@ -76,7 +75,7 @@ fn width_mask(width: AccessWidth) -> usize {
     }
 }
 
-fn sign_extend_value(value: usize, width: AccessWidth) -> usize {
+pub(crate) fn sign_extend_value(value: usize, width: AccessWidth) -> usize {
     match width {
         AccessWidth::Byte => (value as i8) as isize as usize,
         AccessWidth::Word => (value as i16) as isize as usize,
@@ -835,14 +834,15 @@ impl AxVM {
         Ok(())
     }
 
-    /// Run a vCPU according to the given vcpu_id.
+    /// Runs a vCPU according to the given `vcpu_id` until the current
+    /// architecture reports a runtime action.
     ///
     /// ## Arguments
     /// * `vcpu_id` - the id of the vCPU to run.
     ///
     /// ## Returns
-    /// * `VmExit` - the exit reason of the vCPU, wrapped in an `AxResult`.
-    pub fn run_vcpu(&self, vcpu_id: usize) -> AxResult<VmExit> {
+    /// * `VcpuRunAction` - the post-exit action selected by the current architecture.
+    pub(crate) fn run_vcpu(self: &Arc<Self>, vcpu_id: usize) -> AxResult<VcpuRunAction> {
         let vm_id = self.id();
         let vcpu = self
             .vcpu(vcpu_id)
@@ -859,88 +859,17 @@ impl AxVM {
             }
         }
 
-        let devices = self.get_devices()?;
-        let run_result = vcpu.with_current_cpu_set(|| -> AxResult<VmExit> {
+        let run_result = vcpu.with_current_cpu_set(|| -> AxResult<VcpuRunAction> {
             loop {
                 crate::runtime::vcpus::inject_pending_interrupts(self.id(), vcpu_id, &vcpu);
 
-                let exit_reason = vcpu.run()?;
-                trace!("{exit_reason:#x?}");
-                match exit_reason {
-                    VmExit::MmioRead {
-                        addr,
-                        width,
-                        reg,
-                        reg_width,
-                        signed_ext,
-                    } => {
-                        let raw = devices.handle_mmio_read(addr, width)?;
-                        let masked = raw & width_mask(width);
-                        let val = if signed_ext {
-                            sign_extend_value(masked, width)
-                        } else {
-                            masked & width_mask(reg_width)
-                        };
-                        vcpu.set_gpr(reg, val);
-                    }
-                    VmExit::MmioWrite { addr, width, data } => {
-                        self.handle_mmio_write(addr, width, data as usize)?;
-                    }
-                    VmExit::IoRead { port, width } => {
-                        let val = devices.handle_port_read(port, width)?;
-                        CurrentArch::set_io_read_result(&vcpu, val);
-                    }
-                    VmExit::IoWrite { port, width, data } => {
-                        devices.handle_port_write(port, width, data as usize)?;
-                    }
-                    VmExit::SysRegRead { addr, reg } => {
-                        let val = devices.handle_sys_reg_read(
-                            addr,
-                            // Generally speaking, the width of system register is fixed and needless to be specified.
-                            // AccessWidth::Qword here is just a placeholder, may be changed in the future.
-                            AccessWidth::Qword,
-                        )?;
-                        vcpu.set_gpr(reg, val);
-                    }
-                    VmExit::SysRegWrite { addr, value } => {
-                        devices.handle_sys_reg_write(addr, AccessWidth::Qword, value as usize)?;
-                    }
-                    VmExit::NestedPageFault { addr, access_flags } => {
-                        if devices.find_mmio_dev(addr).is_some() {
-                            if let Some(mmio_exit) =
-                                vcpu.get_arch_vcpu().decode_mmio_fault(addr, access_flags)
-                            {
-                                match mmio_exit {
-                                    VmExit::MmioRead {
-                                        addr,
-                                        width,
-                                        reg,
-                                        reg_width,
-                                        signed_ext,
-                                    } => {
-                                        let raw = devices.handle_mmio_read(addr, width)?;
-                                        let masked = raw & width_mask(width);
-                                        let val = if signed_ext {
-                                            sign_extend_value(masked, width)
-                                        } else {
-                                            masked & width_mask(reg_width)
-                                        };
-                                        vcpu.set_gpr(reg, val);
-                                    }
-                                    VmExit::MmioWrite { addr, width, data } => {
-                                        self.handle_mmio_write(addr, width, data as usize)?;
-                                    }
-                                    exit_reason => break Ok(exit_reason),
-                                }
-                            } else {
-                                break Ok(VmExit::NestedPageFault { addr, access_flags });
-                            }
-                        } else if !self.handle_nested_page_fault(addr, access_flags) {
-                            break Ok(VmExit::NestedPageFault { addr, access_flags });
-                        }
-                    }
-                    exit_reason => break Ok(exit_reason),
+                let exit = vcpu.run()?;
+                trace!("{exit:#x?}");
+                let action = CurrentArch::handle_vcpu_exit(self, &vcpu, exit)?;
+                if matches!(action, VcpuRunAction::Continue) {
+                    continue;
                 }
+                break Ok(action);
             }
         });
 
@@ -961,7 +890,12 @@ impl AxVM {
         }
     }
 
-    fn handle_mmio_write(&self, addr: GuestPhysAddr, width: AccessWidth, data: usize) -> AxResult {
+    pub(crate) fn handle_mmio_write(
+        &self,
+        addr: GuestPhysAddr,
+        width: AccessWidth,
+        data: usize,
+    ) -> AxResult {
         let devices = self.get_devices()?;
         if let Some(fw_cfg) = devices.fw_cfg_for_dma_addr(addr) {
             if let Some(desc_addr) = fw_cfg.write_dma_address(addr, width, data)? {
@@ -1003,7 +937,12 @@ impl AxVM {
         });
     }
 
-    fn handle_nested_page_fault(&self, addr: GuestPhysAddr, access_flags: MappingFlags) -> bool {
+    #[cfg(not(target_arch = "aarch64"))]
+    pub(crate) fn handle_nested_page_fault(
+        &self,
+        addr: GuestPhysAddr,
+        access_flags: MappingFlags,
+    ) -> bool {
         self.with_resources_mut(|resources| {
             let handled = resources
                 .address_space
@@ -1014,6 +953,7 @@ impl AxVM {
         .unwrap_or(false)
     }
 
+    #[cfg(not(target_arch = "aarch64"))]
     fn debug_nested_page_fault(
         vm_id: usize,
         resources: &AxVMResources,

--- a/virtualization/axvm/tests/arch_boundary_contract.rs
+++ b/virtualization/axvm/tests/arch_boundary_contract.rs
@@ -1,0 +1,47 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn vm_core_does_not_handle_arch_local_exits() {
+    let vm_rs = include_str!("../src/vm.rs");
+
+    for forbidden in [
+        "CurrentArch",
+        "ArchOps",
+        "CurrentArch::handle_vcpu_exit",
+        "VcpuRunAction",
+        "HostInterrupt",
+    ] {
+        assert!(
+            !vm_rs.contains(forbidden),
+            "vm.rs must not contain architecture-local exit handling detail: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn runtime_vcpu_loop_only_consumes_scheduler_actions() {
+    let runtime_vcpus_rs = include_str!("../src/runtime/vcpus.rs");
+
+    for forbidden in [
+        "VcpuRunAction::Continue",
+        "VcpuRunAction::HostInterrupt",
+        "HostInterrupt",
+    ] {
+        assert!(
+            !runtime_vcpus_rs.contains(forbidden),
+            "runtime/vcpus.rs must not match architecture-local exit action: {forbidden}"
+        );
+    }
+}

--- a/virtualization/loongarch_vcpu/src/vcpu.rs
+++ b/virtualization/loongarch_vcpu/src/vcpu.rs
@@ -141,6 +141,7 @@ pub struct LoongArchVCpuSetupConfig {
 impl VmArchVcpuOps for LoongArchVCpu {
     type CreateConfig = LoongArchVCpuCreateConfig;
     type SetupConfig = LoongArchVCpuSetupConfig;
+    type Exit = VmExit;
 
     fn new(_vm_id: usize, _vcpu_id: usize, config: Self::CreateConfig) -> AxResult<Self> {
         let mut ctx = LoongArchContextFrame::default();
@@ -198,7 +199,7 @@ impl VmArchVcpuOps for LoongArchVCpu {
         Ok(())
     }
 
-    fn run(&mut self) -> AxResult<VmExit> {
+    fn run(&mut self) -> AxResult<Self::Exit> {
         #[cfg(target_arch = "loongarch64")]
         {
             unsafe {

--- a/virtualization/riscv_vcpu/src/vcpu.rs
+++ b/virtualization/riscv_vcpu/src/vcpu.rs
@@ -102,6 +102,7 @@ impl axvm_types::VmArchVcpuOps for RISCVVCpu {
     type CreateConfig = RISCVVCpuCreateConfig;
 
     type SetupConfig = ();
+    type Exit = VmExit;
 
     fn new(_vm_id: usize, _vcpu_id: usize, config: Self::CreateConfig) -> AxResult<Self> {
         let mut regs = VmCpuRegisters::default();
@@ -180,7 +181,7 @@ impl axvm_types::VmArchVcpuOps for RISCVVCpu {
         Ok(())
     }
 
-    fn run(&mut self) -> AxResult<VmExit> {
+    fn run(&mut self) -> AxResult<Self::Exit> {
         unsafe {
             sstatus::clear_sie();
             sie::set_sext();

--- a/virtualization/x86_vcpu/src/no_backend.rs
+++ b/virtualization/x86_vcpu/src/no_backend.rs
@@ -41,6 +41,7 @@ pub struct X86ArchVCpu;
 impl VmArchVcpuOps for X86ArchVCpu {
     type CreateConfig = X86VCpuCreateConfig;
     type SetupConfig = X86VCpuSetupConfig;
+    type Exit = VmExit;
 
     fn new(_vm_id: VMId, _vcpu_id: VCpuId, _config: X86VCpuCreateConfig) -> AxResult<Self> {
         ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
@@ -58,7 +59,7 @@ impl VmArchVcpuOps for X86ArchVCpu {
         ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn run(&mut self) -> AxResult<VmExit> {
+    fn run(&mut self) -> AxResult<Self::Exit> {
         ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 

--- a/virtualization/x86_vcpu/src/svm/vcpu.rs
+++ b/virtualization/x86_vcpu/src/svm/vcpu.rs
@@ -1480,6 +1480,7 @@ impl Debug for SvmVcpu {
 impl VmArchVcpuOps for SvmVcpu {
     type CreateConfig = X86VCpuCreateConfig;
     type SetupConfig = X86VCpuSetupConfig;
+    type Exit = VmExit;
 
     fn new(vm_id: VMId, vcpu_id: VCpuId, _config: Self::CreateConfig) -> AxResult<Self> {
         Self::create(vm_id, vcpu_id)
@@ -1505,7 +1506,7 @@ impl VmArchVcpuOps for SvmVcpu {
         self.setup_vmcb(entry, npt_root, config)
     }
 
-    fn run(&mut self) -> AxResult<VmExit> {
+    fn run(&mut self) -> AxResult<Self::Exit> {
         {
             let exit_info = self.inner_run()?;
             let exit_code = match exit_info.exit_code {

--- a/virtualization/x86_vcpu/src/vmx/vcpu.rs
+++ b/virtualization/x86_vcpu/src/vmx/vcpu.rs
@@ -1630,6 +1630,7 @@ impl VmArchVcpuOps for VmxVcpu {
     type CreateConfig = X86VCpuCreateConfig;
 
     type SetupConfig = X86VCpuSetupConfig;
+    type Exit = VmExit;
 
     fn new(vm_id: VMId, vcpu_id: VCpuId, _config: Self::CreateConfig) -> AxResult<Self> {
         Self::new(vm_id, vcpu_id)
@@ -1653,7 +1654,7 @@ impl VmArchVcpuOps for VmxVcpu {
         )
     }
 
-    fn run(&mut self) -> AxResult<VmExit> {
+    fn run(&mut self) -> AxResult<Self::Exit> {
         match self.inner_run()? {
             Some(exit_info) => Ok(if exit_info.entry_failure {
                 VmExit::FailEntry {


### PR DESCRIPTION
## 问题

`axvm` 运行层原先统一消费 `axvm_types::VmExit`，导致 VM/vCPU 通用状态机、runtime 调度循环和各架构 exit 语义耦合在一起。AArch64 已经有自己的 `ArmVmExit`，但进入 AxVM 后仍需要转换成统一 `VmExit`；同时旧的通用层还会理解 `Continue`、host IRQ 等 exit 细节，边界仍然偏低。

## 改动

- 为 `VmArchVcpuOps` 增加关联类型 `Exit`，将 `run()` 改为返回架构本地 exit 类型。
- 将通用 vCPU 运行边界上移到 `ArchOps::run_vcpu()` 默认骨架：统一处理 bind/unbind、current-vCPU scope、pending interrupt 注入、重复 re-enter、post-unbind deferred work。
- 将 `VcpuRunAction` 收敛为 runtime 调度语义：`Yield`、`Wait`、`Stop(StopReason)`；新增 `BoundVcpuExit<D>` 表达 bound exit handling 的 `Continue`、`Complete` 和 `Defer`。
- 将 runtime 层原先对 `VmExit`/`HostInterrupt`/`Continue` 的处理移入 arch cfg；runtime 只调用 `CurrentArch::run_vcpu()` 并消费调度动作。
- AArch64 直接 match `ArmVmExit`，外部中断类工作通过 `Aarch64DeferredRunWork` 在 `unbind()` 后完成。
- x86/RISC-V/LoongArch 暂继续用 legacy `VmExit`，但统一走 arch-local transitional handler，并用 `LegacyDeferredRunWork` 延后处理 host IRQ、timer、EOI、idle 等需要 host-side side effect 的事件。
- 清理 `vm.rs` 中的 arch-specific 操作：`AxVM::handle_mmio_write()` 只做设备写和 fw_cfg DMA；LoongArch PCH-PIC assert/drain 逻辑移回 `arch/loongarch64`；`vm.rs` 不再 import/use `CurrentArch`、`ArchOps` 或 `VcpuRunAction`。
- 增加 source contract regression test，固定 `vm.rs`/`runtime/vcpus.rs` 不再泄漏架构 exit 细节。
- 保留 `axvm_types::VmExit` 作为兼容/过渡 normalized event，并在文档中说明不再是所有架构 raw exit 的唯一接口。

## 设计说明

通用层只保留 VM/vCPU 生命周期骨架和可复用的小粒度 helper，不解释 MPIDR、hart、APIC、IOCSR 等架构语义。架构模块先把本地 exit 转换成这些 helper 需要的规范化输入，再决定继续运行、yield、wait、停止 VM，或把需要 unbind 后执行的工作放进 deferred work。

这次为了降低风险，非 AArch64 后端没有同步拆分底层 raw exit enum，而是先把 legacy `VmExit` 的消费边界搬进各自 arch cfg 模块。

## 验证

- `cargo fmt --check`
- `cargo test -p axvm --test arch_boundary_contract`
- `cargo test -p axvm-types`
- `cargo xtask clippy --package axvm`
- `cargo xtask clippy --package arm_vcpu`
- `cargo check -p axvm --target aarch64-unknown-none-softfloat`
- `cargo check -p axvm --target x86_64-unknown-none`
- `cargo check -p axvm --target riscv64gc-unknown-none-elf`
- `cargo check -p axvm --target loongarch64-unknown-none-softfloat`
- `cargo xtask axvisor test qemu --arch riscv64`
- `cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case smoke`