### PR TITLE
fix(starry-kernel): reject private mmap faults past eof

### DIFF
--- a/os/StarryOS/kernel/src/axtest_exports.rs
+++ b/os/StarryOS/kernel/src/axtest_exports.rs
@@ -45,3 +45,7 @@ pub fn pipe_resize_rejects_oversized_pipe() -> bool {
 pub fn fcntl_setpipe_size_returns_capacity() -> bool {
     super::syscall::fcntl_setpipe_size_returns_capacity_for_test()
 }
+
+pub fn private_mmap_rejects_fault_at_file_eof() -> bool {
+    super::mm::private_mmap_eof_check_for_test()
+}

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -76,6 +76,48 @@ impl FrameTableRefCount {
 
 static FRAME_TABLE: SpinNoIrq<FrameTableRefCount> = SpinNoIrq::new(FrameTableRefCount::new());
 
+fn cow_file_max_read_len(
+    file_len: u64,
+    file_end: Option<u64>,
+    file_read_offset: u64,
+    available: usize,
+) -> AxResult<usize> {
+    let effective_end = match file_end {
+        Some(end) => end,
+        None => {
+            if file_read_offset >= file_len {
+                return Err(AxError::BadAddress);
+            }
+            file_len
+        }
+    };
+    Ok(effective_end
+        .saturating_sub(file_read_offset)
+        .min(available as u64) as usize)
+}
+
+fn cow_file_max_read(
+    file: &FileBackend,
+    file_end: Option<u64>,
+    file_read_offset: u64,
+    available: usize,
+) -> AxResult<usize> {
+    let file_len = if file_end.is_none() { file.len()? } else { 0 };
+    cow_file_max_read_len(file_len, file_end, file_read_offset, available)
+}
+
+#[cfg(axtest)]
+pub(crate) fn private_mmap_eof_check_for_test() -> bool {
+    matches!(
+        cow_file_max_read_len(4096, None, 4096, 4096),
+        Err(AxError::BadAddress)
+    ) && matches!(cow_file_max_read_len(4096, None, 2048, 4096), Ok(2048))
+        && matches!(
+            cow_file_max_read_len(4096, Some(8192), 4096, 4096),
+            Ok(4096)
+        )
+}
+
 /// Copy-on-write mapping backend.
 ///
 /// This corresponds to the `MAP_PRIVATE` flag.
@@ -226,9 +268,14 @@ impl CowBackend {
 
             let file_read_offset =
                 *file_start + vaddr.as_usize().saturating_sub(file_vaddr_base.as_usize()) as u64;
-            let max_read = file_end
-                .map_or(u64::MAX, |end| end.saturating_sub(file_read_offset))
-                .min((buf.len() - start) as u64) as usize;
+            let max_read =
+                match cow_file_max_read(file, *file_end, file_read_offset, buf.len() - start) {
+                    Ok(max_read) => max_read,
+                    Err(err) => {
+                        self.deinit_frame(frame);
+                        return Err(err);
+                    }
+                };
 
             if let Err(err) = file.read_at(&mut &mut buf[start..start + max_read], file_read_offset)
             {
@@ -274,9 +321,7 @@ impl CowBackend {
         let n = run.len();
         let total = n * ps;
         let file_read_offset = file_start + (v0.as_usize() - file_vaddr_base.as_usize()) as u64;
-        let max_read = file_end
-            .map_or(u64::MAX, |end| end.saturating_sub(file_read_offset))
-            .min(total as u64) as usize;
+        let max_read = cow_file_max_read(file, *file_end, file_read_offset, total)?;
         let mut buf = alloc::vec![0u8; total];
         if max_read > 0 {
             file.read_at(&mut &mut buf[..max_read], file_read_offset)?;

--- a/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
@@ -21,6 +21,8 @@ mod file;
 mod linear;
 mod shared;
 
+#[cfg(axtest)]
+pub(crate) use self::cow::private_mmap_eof_check_for_test;
 pub use self::shared::SharedPages;
 pub use super::accounting::RssKind;
 use super::{

--- a/os/StarryOS/kernel/tests/axtest_kernel.rs
+++ b/os/StarryOS/kernel/tests/axtest_kernel.rs
@@ -49,4 +49,9 @@ mod tests {
     fn fcntl_setpipe_size_returns_capacity() {
         ax_assert!(axtest_exports::fcntl_setpipe_size_returns_capacity());
     }
+
+    #[test]
+    fn private_mmap_rejects_fault_at_file_eof() {
+        ax_assert!(axtest_exports::private_mmap_rejects_fault_at_file_eof());
+    }
 }


### PR DESCRIPTION
## 问题

对照 openkylin/x-kernel 已合并的 !433，本仓库普通文件 `MAP_PRIVATE` 映射在 fault 到文件 EOF 之后的页面时仍会分配零页。这会把应当视为无效访问的 EOF 之后区域静默映射出来。

## 修改

- 为 COW file-backed fault-in 统一计算本次可读取长度。
- 对普通 `MAP_PRIVATE` 映射（`file_end == None`）使用真实文件长度作为有效边界：页起始 offset 已到 EOF 时返回 `BadAddress`，跨 EOF 时只读取文件内剩余字节。
- 保留 ELF loader 传入 `file_end = Some(...)` 时的零填充语义，避免影响程序段 BSS/tail zero-fill。
- 增加 axtest 覆盖 EOF 拒绝、跨 EOF 截断、loader 零填充保留三种路径。

## 本次冲突处理

- 已 rebase 到最新 `rcore-os/tgoskits:dev`。
- 冲突仅出现在 `axtest_exports.rs` 和 `axtest_kernel.rs`，处理方式是保留 dev 上已有的 pipe/fcntl axtest，并追加本 PR 的 private mmap EOF axtest。

## 验证

- 红灯验证：`cargo xtask ktest qemu -p starry-kernel --test axtest_kernel`，新增用例先失败，`AXTEST_SUMMARY pass=4 fail=1`。
- 修复后初次验证：`cargo xtask ktest qemu -p starry-kernel --test axtest_kernel`，`AXTEST_SUMMARY pass=5 fail=0`，`AXTEST_SUITE_OK`。
- rebase 冲突处理后：`cargo xtask ktest qemu -p starry-kernel --test axtest_kernel`，`AXTEST_SUMMARY pass=8 fail=0`，`AXTEST_SUITE_OK`。
- rebase 冲突处理后：`cargo xtask clippy --package starry-kernel`，17/17 checks passed。