### PR TITLE
fix(starry-process): keep orphans visible during reparent

### DIFF
--- a/components/starry-process/src/process.rs
+++ b/components/starry-process/src/process.rs
@@ -266,19 +266,14 @@ impl Process {
 
         let reaper_proc = self.orphan_reaper();
         let reaper_parent = Arc::downgrade(&reaper_proc);
-        let children = {
-            let mut children = self.children.lock();
-            core::mem::take(&mut *children)
-        };
 
         let mut reaper_children = reaper_proc.children.lock();
-        for (pid, child) in children {
+        let mut children = self.children.lock();
+        self.is_zombie.store(true, Ordering::Release);
+        for (pid, child) in core::mem::take(&mut *children) {
             *child.parent.lock() = reaper_parent.clone();
             reaper_children.insert(pid, child);
         }
-        drop(reaper_children);
-
-        self.is_zombie.store(true, Ordering::Release);
     }
 
     /// Frees a zombie [`Process`]. Removes it from the parent.
@@ -367,4 +362,61 @@ static INIT_PROC: LazyInit<Arc<Process>> = LazyInit::new();
 /// This function panics if the init process has not been initialized yet.
 pub fn init_proc() -> Arc<Process> {
     INIT_PROC.get().unwrap().clone()
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::sync::Arc;
+    use core::time::Duration;
+    use std::{
+        sync::{Arc as StdArc, Barrier},
+        thread,
+        time::Instant,
+    };
+
+    use super::Process;
+
+    #[test]
+    fn orphan_never_becomes_invisible_while_reparenting() {
+        let init = Process::new_init(1);
+        let reaper = init.fork(2);
+        reaper.set_child_subreaper(true);
+        let parent = reaper.fork(3);
+        let child = parent.fork(4);
+        let child_pid = child.pid();
+
+        let reaper_children = reaper.children.lock();
+        let start_exit = StdArc::new(Barrier::new(2));
+        let exit_parent = parent.clone();
+        let exit_start = start_exit.clone();
+        let exit_thread = thread::spawn(move || {
+            exit_start.wait();
+            exit_parent.exit();
+        });
+
+        start_exit.wait();
+        let deadline = Instant::now() + Duration::from_millis(500);
+        let mut observed_invisible = false;
+        while Instant::now() < deadline {
+            let parent_has_child = parent.children.lock().contains_key(&child_pid);
+            let reaper_has_child = reaper_children.contains_key(&child_pid);
+            if !parent_has_child && !reaper_has_child {
+                observed_invisible = true;
+                break;
+            }
+            thread::yield_now();
+        }
+
+        drop(reaper_children);
+        exit_thread.join().unwrap();
+
+        assert!(
+            !observed_invisible,
+            "orphan was removed from its old parent before it became visible to the reaper"
+        );
+        assert!(Arc::ptr_eq(&reaper, &child.parent().unwrap()));
+        assert!(reaper.children.lock().contains_key(&child_pid));
+    }
 }


### PR DESCRIPTION
## 问题

对照 openkylin/x-kernel 已合并的 !399，本仓库 `Process::exit()` 在迁移孤儿进程时先从退出进程的 `children` 中取走子进程，再锁 reaper 的 `children` 插入。这个顺序会产生一个中间窗口：孤儿进程既不在旧父进程的 children 表里，也还没有进入 reaper 的 children 表，等待侧可能因此看不到它。

`waitpid` 相关的 lost-wakeup 路径本仓库已经通过 `wait_on_pollset` 在注册 waker 前后双检查覆盖，本次只迁移仍缺失的 reparent 可见性修复。

## 修改

- 调整 `Process::exit()` 的锁顺序，先锁 reaper 的 `children`，再锁当前进程的 `children`。
- 在两个 children 表都受锁保护时发布 zombie 状态并完成孤儿迁移，避免孤儿在两个表之间短暂不可见。
- 增加 host unit test：主线程持有 reaper children 锁时启动父进程退出，验证孤儿在 reparent 阶段始终可从旧父或 reaper 之一看到。

## 验证

- 红灯验证：`cargo test -p starry-process orphan_never_becomes_invisible_while_reparenting`，旧实现下新增用例按预期失败。
- 修复后：`cargo test -p starry-process orphan_never_becomes_invisible_while_reparenting`，1/1 passed。
- `cargo test -p starry-process`，unit 1/1、group 9/9、process 10/10、session 8/8 全部通过。
- `cargo xtask clippy --package starry-process`，1/1 check passed。
- `git diff --check` 通过。
