### PR TITLE
fix(starry-kernel): prevent scope lock poisoning during unshare

### DIFF
--- a/components/kspin/src/rwlock.rs
+++ b/components/kspin/src/rwlock.rs
@@ -288,15 +288,35 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinRwLock<G, T> {
     ///
     /// This is unsafe if called without a corresponding leaked read guard or if
     /// any normal read guard is still expected to release that reader count.
+    /// If the reader count is already zero, this returns without changing the
+    /// state so a stale cleanup hook cannot underflow the lock and block future
+    /// writers permanently.
     #[inline(always)]
     pub unsafe fn force_read_decrement(&self) {
-        debug_assert!(self.reader_count() > 0);
-        #[cfg(feature = "lockdep")]
-        {
-            let _lockdep_irq_guard = IrqSave::new();
-            crate::lockdep::release_trace_only::<G>("spin-rwlock", self.lock_addr());
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            let readers = state & !(WRITER | MAX_READER);
+            if readers == 0 {
+                return;
+            }
+
+            match self.state.compare_exchange_weak(
+                state,
+                state - READER,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    #[cfg(feature = "lockdep")]
+                    {
+                        let _lockdep_irq_guard = IrqSave::new();
+                        crate::lockdep::release_trace_only::<G>("spin-rwlock", self.lock_addr());
+                    }
+                    return;
+                }
+                Err(observed) => state = observed,
+            }
         }
-        self.state.fetch_sub(READER, Ordering::Release);
     }
 
     /// Force unlock exclusive write access.
@@ -469,6 +489,20 @@ mod tests {
 
         assert_eq!(lock.reader_count(), 1);
         assert!(lock.try_write().is_none());
+
+        unsafe { lock.force_read_decrement() };
+        assert_eq!(lock.reader_count(), 0);
+        assert!(lock.try_write().is_some());
+    }
+
+    #[test]
+    fn force_read_decrement_without_reader_does_not_poison_state() {
+        let lock = RwLock::new(());
+        let guard = lock.read();
+        core::mem::forget(guard);
+
+        unsafe { lock.force_read_decrement() };
+        assert_eq!(lock.reader_count(), 0);
 
         unsafe { lock.force_read_decrement() };
         assert_eq!(lock.reader_count(), 0);

--- a/os/StarryOS/kernel/src/syscall/task/namespace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/namespace.rs
@@ -1,5 +1,4 @@
 use alloc::sync::Arc;
-use core::mem;
 
 use ax_errno::{AxError, AxResult};
 use ax_fs_ng::FS_CONTEXT;
@@ -8,7 +7,6 @@ use ax_task::current;
 use linux_raw_sys::general::{
     CLONE_FS, CLONE_NEWIPC, CLONE_NEWNET, CLONE_NEWNS, CLONE_NEWPID, CLONE_NEWUSER, CLONE_NEWUTS,
 };
-use scope_local::ActiveScope;
 
 use crate::{
     file::{NsFd, PidFd, get_file_like},
@@ -70,18 +68,9 @@ pub fn sys_unshare(flags: u32) -> AxResult<isize> {
         // scope.write() would self-deadlock because on_enter holds a
         // leaked scope.read() guard for the task's lifetime.  Temporarily
         // release it, do the rebind, then re-acquire.
-        // SAFETY: the scope is task-private.  The brief window with
-        // ActiveScope pointing to global contains no FS_CONTEXT access.
-        unsafe { curr.as_thread().proc_data.scope.force_read_decrement() };
-        ActiveScope::set_global();
-
-        let mut scope = curr.as_thread().proc_data.scope.write();
-        *FS_CONTEXT.scope_mut(&mut scope) = new_fs;
-        drop(scope);
-
-        let read_guard = curr.as_thread().proc_data.scope.read();
-        unsafe { ActiveScope::set(&read_guard) };
-        mem::forget(read_guard);
+        proc_data.with_current_scope_mut(|scope| {
+            *FS_CONTEXT.scope_mut(scope) = new_fs;
+        });
     }
     if want_ns {
         FS_CONTEXT.lock().unshare_mount_namespace()?;

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -21,6 +21,7 @@ use core::{
 };
 
 use ax_errno::AxResult;
+use ax_kernel_guard::NoPreemptIrqSave;
 use ax_kspin::SpinRwLock as RwLock;
 use ax_runtime::hal::{cpu::uspace::UserContext, time::TimeValue};
 use ax_sync::{Mutex, spin::SpinNoIrq};
@@ -957,7 +958,10 @@ impl ProcessData {
     /// `TaskExt::on_enter` leaves the current task's active scope installed by
     /// holding one read count on [`Self::scope`]. A syscall running in that task
     /// must temporarily release that read count before taking the write side.
+    /// The closure runs with preemption and local IRQs disabled, so it should
+    /// only install already-prepared scope entries.
     pub fn with_current_scope_mut<R>(&self, f: impl FnOnce(&mut Scope) -> R) -> R {
+        let _guard = NoPreemptIrqSave::new();
         ActiveScope::set_global();
         unsafe { self.scope.force_read_decrement() };
         let mut scope = self.scope.write();


### PR DESCRIPTION
## 问题

`Test starry aarch64 qemu / run_container` 在完整 `qemu-smp1/system` 分组中卡在 `test-unshare-fs`：日志只打印到 `STARRY_SYSTEM_TEST_BEGIN: /usr/bin/starry-test-suit/test-unshare-fs`，还没有进入第一条 `unshare(CLONE_FS)` 的 PASS 输出，最终触发 1800s QEMU timeout。

对比最近 dev CI 后确认：前一个同 job 通过的 dev run 是 `2ec0431ad`，失败 run 的 head 是 `b34f37e8e`，两者之间只有 `chore: release (#1479)` 版本号、changelog 和 lockfile 变更，没有触及 `test-unshare-fs`、`sys_unshare`、scope-local 或调度相关源码。因此这不是 release 提交引入的新逻辑，而是一个被 CI 时序暴露出来的潜藏锁计数污染问题。

## 根因

Starry 当前 task 的 active scope 由 `TaskExt::on_enter()` 安装，并通过一个被 `mem::forget` 的 `scope.read()` 读计数维持。`unshare(CLONE_FS)` 需要重绑当前 task 的 `FS_CONTEXT`，所以必须临时释放这个读计数再拿 `scope.write()`。

原来的 `sys_unshare()` 手写了这段释放/写入/重新安装流程，并且窗口内没有禁止抢占或本地 IRQ。如果任务切换/离开钩子在这个窗口中再次执行 `force_read_decrement()`，`ax-kspin` 的 reader count 会下溢，之后 `scope.write()` 会看到非零 state 并永久自旋，表现为 `unshare(CLONE_FS)` 卡死。

## 修改

- 在 `ax-kspin` 中让 `force_read_decrement()` 通过 CAS 扣减 reader count；如果 reader count 已经是 0，则不再下溢污染锁状态。
- 增加稳定红测 `force_read_decrement_without_reader_does_not_poison_state`：修复前第二次强制释放会触发 `reader_count() > 0` 断言，修复后 reader count 保持 0，writer 可继续获取锁。
- 在 `ProcessData::with_current_scope_mut()` 中用 `NoPreemptIrqSave` 包住 active scope 临时释放、写入、重新安装这段极短窗口，并补充约束注释，要求 closure 只安装已准备好的 scope entry。
- 将 `sys_unshare()` 的手写 active-scope 切换替换为统一的 `with_current_scope_mut()` 调用，避免同类危险序列分叉。

## 验证

- 红测验证：仅加入 `force_read_decrement_without_reader_does_not_poison_state` 时，当前旧实现会稳定失败：`assertion failed: self.reader_count() > 0`。
- `cargo test -p ax-kspin`
- `cargo xtask clippy --package ax-kspin`
- `cargo xtask clippy --package starry-kernel`
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system/test-unshare-fs`
- `cargo xtask starry test qemu --arch aarch64 -c qemu-smp1/system`
- `cargo fmt --check`
- `git diff --check`