### PR TITLE
fix(platforms): route DMA cache sync through platform cache ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,7 @@ dependencies = [
  "ax-memory-addr",
  "dma-api",
  "irq-framework",
+ "mbarrier",
  "mmio-api",
  "trait-ffi",
 ]

--- a/components/axklib/Cargo.toml
+++ b/components/axklib/Cargo.toml
@@ -17,6 +17,7 @@ ax-errno = { workspace = true }
 ax-memory-addr = { workspace = true }
 dma-api = { workspace = true }
 irq-framework = { workspace = true }
+mbarrier = "0.1"
 mmio-api = { workspace = true }
 trait-ffi = "0.2"
 

--- a/components/axklib/src/dma.rs
+++ b/components/axklib/src/dma.rs
@@ -5,6 +5,7 @@ use dma_api::{
     DeviceDma, DmaAllocHandle, DmaConstraints, DmaDirection, DmaDomainId, DmaError, DmaMapHandle,
     DmaOp,
 };
+use mbarrier::mb;
 
 pub struct KlibDma;
 
@@ -194,6 +195,22 @@ impl DmaOp for KlibDma {
             let num_pages = DmaPages::layout_pages(handle.layout());
             unsafe { DmaPages::dealloc_pages(map_virt, num_pages) };
         }
+    }
+
+    fn flush(&self, addr: NonNull<u8>, size: usize) {
+        mb();
+        crate::klib::dma_cache_clean(VirtAddr::from_usize(addr.as_ptr() as usize), size);
+    }
+
+    fn invalidate(&self, addr: NonNull<u8>, size: usize) {
+        crate::klib::dma_cache_invalidate(VirtAddr::from_usize(addr.as_ptr() as usize), size);
+        mb();
+    }
+
+    fn flush_invalidate(&self, addr: NonNull<u8>, size: usize) {
+        mb();
+        crate::klib::dma_cache_clean_invalidate(VirtAddr::from_usize(addr.as_ptr() as usize), size);
+        mb();
     }
 }
 

--- a/components/axklib/src/lib.rs
+++ b/components/axklib/src/lib.rs
@@ -130,6 +130,15 @@ pub trait Klib {
     /// allocator.
     fn mem_restore_dma_cached(addr: VirtAddr, size: usize) -> AxResult;
 
+    /// Cleans a CPU cache range before device ownership.
+    fn dma_cache_clean(_addr: VirtAddr, _size: usize) {}
+
+    /// Invalidates a CPU cache range after device writes.
+    fn dma_cache_invalidate(_addr: VirtAddr, _size: usize) {}
+
+    /// Cleans and invalidates a CPU cache range for bidirectional DMA.
+    fn dma_cache_clean_invalidate(_addr: VirtAddr, _size: usize) {}
+
     /// Allocates contiguous DMA pages.
     ///
     /// `dma_mask` is the device-visible address mask. Implementations should

--- a/os/arceos/modules/axhal/src/dummy.rs
+++ b/os/arceos/modules/axhal/src/dummy.rs
@@ -6,7 +6,7 @@ use ax_plat::{
     console::{ConsoleDeviceIdError, ConsoleDeviceIdResult, ConsoleIf},
     impl_plat_interface,
     init::InitIf,
-    mem::{IomapAttrs, IomapDecision, IomapError, MemIf, RawRange},
+    mem::{DCacheOp, IomapAttrs, IomapDecision, IomapError, MemIf, RawRange},
     power::PowerIf,
     time::TimeIf,
 };
@@ -99,6 +99,14 @@ impl MemIf for DummyMem {
     fn user_aspace_needs_kernel_mappings() -> bool {
         true
     }
+
+    fn dcache_range(_op: DCacheOp, _addr: ax_memory_addr::VirtAddr, _size: usize) {}
+
+    fn dma_coherent_before_make_uncached(_addr: ax_memory_addr::VirtAddr, _size: usize) {}
+
+    fn dma_coherent_before_restore_cached(_addr: ax_memory_addr::VirtAddr, _size: usize) {}
+
+    fn dma_coherent_after_mapping_update() {}
 }
 
 #[impl_plat_interface]

--- a/os/arceos/modules/axhal/src/mem.rs
+++ b/os/arceos/modules/axhal/src/mem.rs
@@ -4,9 +4,11 @@ pub use ax_memory_addr::{
     MemoryAddr, PAGE_SIZE_4K, PhysAddr, PhysAddrRange, VirtAddr, VirtAddrRange, pa, va,
 };
 pub use ax_plat::mem::{
-    IomapAttrs, IomapDecision, IomapError, MemRegionFlags, PhysMemRegion, kernel_aspace,
-    mmio_ranges, phys_ram_ranges, phys_to_virt, prepare_iomap, reserved_phys_ram_ranges,
-    total_ram_size, user_aspace_needs_kernel_mappings, virt_to_phys,
+    DCacheOp, IomapAttrs, IomapDecision, IomapError, MemRegionFlags, PhysMemRegion, dcache_range,
+    dma_coherent_after_mapping_update, dma_coherent_before_make_uncached,
+    dma_coherent_before_restore_cached, kernel_aspace, mmio_ranges, phys_ram_ranges, phys_to_virt,
+    prepare_iomap, reserved_phys_ram_ranges, total_ram_size, user_aspace_needs_kernel_mappings,
+    virt_to_phys,
 };
 use ax_plat::mem::{check_sorted_ranges_overlap, ranges_difference};
 use heapless::Vec;

--- a/os/arceos/modules/axruntime/src/klib.rs
+++ b/os/arceos/modules/axruntime/src/klib.rs
@@ -45,44 +45,9 @@ fn map_irq_error(err: IrqError) -> AxError {
     }
 }
 
-#[cfg(all(feature = "paging", target_arch = "aarch64"))]
-fn clean_invalidate_dcache_to_poc(addr: VirtAddr, size: usize) {
-    use core::arch::asm;
-
-    if size == 0 {
-        return;
-    }
-
-    let line_size = ax_hal::asm::dcache_line_size_from_ctr();
-    let start = addr.as_usize() & !(line_size - 1);
-    let end = (addr.as_usize() + size + line_size - 1) & !(line_size - 1);
-    for line in (start..end).step_by(line_size) {
-        unsafe { asm!("dc civac, {0:x}", in(reg) line) };
-    }
+fn dma_cache_range(op: ax_hal::mem::DCacheOp, addr: VirtAddr, size: usize) {
+    ax_hal::mem::dcache_range(op, addr, size);
 }
-
-#[cfg(all(feature = "paging", not(target_arch = "aarch64")))]
-fn clean_invalidate_dcache_to_poc(_addr: VirtAddr, _size: usize) {}
-
-#[cfg(all(feature = "paging", target_arch = "aarch64"))]
-#[inline]
-fn dsb_sy() {
-    unsafe { core::arch::asm!("dsb sy") };
-}
-
-#[cfg(all(feature = "paging", not(target_arch = "aarch64")))]
-#[inline]
-fn dsb_sy() {}
-
-#[cfg(all(feature = "paging", target_arch = "aarch64"))]
-#[inline]
-fn isb_sy() {
-    unsafe { core::arch::asm!("isb") };
-}
-
-#[cfg(all(feature = "paging", not(target_arch = "aarch64")))]
-#[inline]
-fn isb_sy() {}
 
 impl_trait! {
     impl Klib for KlibImpl {
@@ -107,6 +72,18 @@ impl_trait! {
             ax_hal::mem::virt_to_phys(addr)
         }
 
+        fn dma_cache_clean(addr: VirtAddr, size: usize) {
+            dma_cache_range(ax_hal::mem::DCacheOp::Clean, addr, size);
+        }
+
+        fn dma_cache_invalidate(addr: VirtAddr, size: usize) {
+            dma_cache_range(ax_hal::mem::DCacheOp::Invalidate, addr, size);
+        }
+
+        fn dma_cache_clean_invalidate(addr: VirtAddr, size: usize) {
+            dma_cache_range(ax_hal::mem::DCacheOp::CleanInvalidate, addr, size);
+        }
+
         fn mem_make_dma_coherent_uncached(addr: VirtAddr, size: usize) -> AxResult {
             #[cfg(feature = "paging")]
             {
@@ -114,8 +91,7 @@ impl_trait! {
                     return Ok(());
                 };
 
-                clean_invalidate_dcache_to_poc(start, size);
-                dsb_sy();
+                ax_hal::mem::dma_coherent_before_make_uncached(start, size);
                 ax_mm::kernel_aspace().lock().protect(
                     start,
                     size,
@@ -124,8 +100,7 @@ impl_trait! {
                         | ax_hal::paging::MappingFlags::UNCACHED,
                 )?;
                 ax_hal::asm::flush_tlb(None);
-                dsb_sy();
-                isb_sy();
+                ax_hal::mem::dma_coherent_after_mapping_update();
                 Ok(())
             }
             #[cfg(not(feature = "paging"))]
@@ -142,15 +117,14 @@ impl_trait! {
                     return Ok(());
                 };
 
-                dsb_sy();
+                ax_hal::mem::dma_coherent_before_restore_cached(start, size);
                 ax_mm::kernel_aspace().lock().protect(
                     start,
                     size,
                     ax_hal::paging::MappingFlags::READ | ax_hal::paging::MappingFlags::WRITE,
                 )?;
                 ax_hal::asm::flush_tlb(None);
-                dsb_sy();
-                isb_sy();
+                ax_hal::mem::dma_coherent_after_mapping_update();
                 Ok(())
             }
             #[cfg(not(feature = "paging"))]

--- a/platforms/ax-plat/src/mem.rs
+++ b/platforms/ax-plat/src/mem.rs
@@ -40,6 +40,17 @@ pub enum IomapError {
     Unsupported,
 }
 
+/// Data-cache maintenance operation for a virtual address range.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DCacheOp {
+    /// Clean dirty CPU cache lines to the point visible to devices.
+    Clean,
+    /// Invalidate CPU cache lines after device writes.
+    Invalidate,
+    /// Clean and invalidate CPU cache lines for bidirectional ownership changes.
+    CleanInvalidate,
+}
+
 bitflags::bitflags! {
     /// The flags of a physical memory region.
     #[derive(Clone, Copy)]
@@ -207,6 +218,18 @@ pub trait MemIf {
 
     /// Returns whether a newly-created user address space must copy kernel mappings.
     fn user_aspace_needs_kernel_mappings() -> bool;
+
+    /// Maintains a CPU data-cache range for non-coherent DMA ownership changes.
+    fn dcache_range(op: DCacheOp, addr: VirtAddr, size: usize);
+
+    /// Prepares a cached range before the kernel remaps it as uncached for DMA.
+    fn dma_coherent_before_make_uncached(addr: VirtAddr, size: usize);
+
+    /// Prepares an uncached DMA range before the kernel restores cached mappings.
+    fn dma_coherent_before_restore_cached(addr: VirtAddr, size: usize);
+
+    /// Completes platform ordering after a DMA coherent mapping attribute update.
+    fn dma_coherent_after_mapping_update();
 }
 
 /// Returns the total size of physical memory (RAM) on the platform.

--- a/platforms/axplat-dyn/src/mem.rs
+++ b/platforms/axplat-dyn/src/mem.rs
@@ -1,4 +1,6 @@
-use ax_plat::mem::{IomapAttrs, IomapDecision, IomapError, MemIf, PhysAddr, RawRange, VirtAddr};
+use ax_plat::mem::{
+    DCacheOp, IomapAttrs, IomapDecision, IomapError, MemIf, PhysAddr, RawRange, VirtAddr,
+};
 use heapless::Vec;
 use someboot::ArchTrait;
 use somehal::mem::MemoryType;
@@ -153,6 +155,30 @@ impl MemIf for MemIfImpl {
 
     fn user_aspace_needs_kernel_mappings() -> bool {
         <someboot::arch::Arch as ArchTrait>::user_aspace_needs_kernel_mappings()
+    }
+
+    fn dcache_range(op: DCacheOp, addr: VirtAddr, size: usize) {
+        somehal::cache::dcache_range(to_somehal_dcache_op(op), addr.as_usize() as *const u8, size);
+    }
+
+    fn dma_coherent_before_make_uncached(addr: VirtAddr, size: usize) {
+        somehal::cache::dma_coherent_before_make_uncached(addr.as_usize() as *const u8, size);
+    }
+
+    fn dma_coherent_before_restore_cached(addr: VirtAddr, size: usize) {
+        somehal::cache::dma_coherent_before_restore_cached(addr.as_usize() as *const u8, size);
+    }
+
+    fn dma_coherent_after_mapping_update() {
+        somehal::cache::dma_coherent_after_mapping_update();
+    }
+}
+
+fn to_somehal_dcache_op(op: DCacheOp) -> somehal::cache::DCacheOp {
+    match op {
+        DCacheOp::Clean => somehal::cache::DCacheOp::Clean,
+        DCacheOp::Invalidate => somehal::cache::DCacheOp::Invalidate,
+        DCacheOp::CleanInvalidate => somehal::cache::DCacheOp::CleanInvalidate,
     }
 }
 

--- a/platforms/someboot/src/arch/aarch64/mod.rs
+++ b/platforms/someboot/src/arch/aarch64/mod.rs
@@ -220,11 +220,35 @@ impl ArchTrait for Arch {
         aarch64_cpu_ext::cache::dcache_range(op.into(), addr, size);
     }
 
+    fn dma_coherent_before_make_uncached(addr: usize, size: usize) {
+        Self::dcache_range(crate::DCacheOp::CleanInvalidate, addr, size);
+        aarch64_dsb_sy();
+    }
+
+    fn dma_coherent_before_restore_cached(_addr: usize, _size: usize) {
+        aarch64_dsb_sy();
+    }
+
+    fn dma_coherent_after_mapping_update() {
+        aarch64_dsb_sy();
+        aarch64_isb_sy();
+    }
+
     // Safety: the EFI stub guarantees the same contract as the trait docs.
     unsafe fn efi_enter_kernel(_system_table: *const ::core::ffi::c_void) -> bool {
         unsafe { crate::arch::entry::kernel_entry(0) };
         unreachable!()
     }
+}
+
+#[inline]
+fn aarch64_dsb_sy() {
+    aarch64_cpu::asm::barrier::dsb(aarch64_cpu::asm::barrier::SY);
+}
+
+#[inline]
+fn aarch64_isb_sy() {
+    aarch64_cpu::asm::barrier::isb(aarch64_cpu::asm::barrier::SY);
 }
 
 impl From<crate::DCacheOp> for aarch64_cpu_ext::cache::CacheOp {

--- a/platforms/someboot/src/arch/riscv64/mod.rs
+++ b/platforms/someboot/src/arch/riscv64/mod.rs
@@ -423,14 +423,90 @@ impl ArchTrait for Arch {
         }
     }
 
-    fn dcache_range(_op: DCacheOp, _addr: usize, _size: usize) {
-        unsafe {
-            core::arch::asm!("fence rw, rw", options(nostack, preserves_flags));
+    fn dcache_range(op: DCacheOp, addr: usize, size: usize) {
+        #[cfg(feature = "thead-mae")]
+        {
+            thead_dcache_range(op, addr, size);
+        }
+        #[cfg(not(feature = "thead-mae"))]
+        {
+            let _ = (op, addr, size);
+            riscv_dma_fence();
         }
     }
 
     unsafe fn efi_enter_kernel(_system_table: *const ::core::ffi::c_void) -> bool {
         false
+    }
+}
+
+#[cfg(feature = "thead-mae")]
+const THEAD_DMA_CACHE_LINE_SIZE: usize = 64;
+
+#[cfg(feature = "thead-mae")]
+#[derive(Clone, Copy)]
+enum TheadDCacheOp {
+    Clean,
+    CleanInvalidate,
+}
+
+#[cfg(feature = "thead-mae")]
+fn thead_dcache_range(op: DCacheOp, vaddr: usize, size: usize) {
+    let paddr = Arch::virt_to_phys(vaddr as *const u8);
+    match op {
+        DCacheOp::Clean => {
+            riscv_dma_fence();
+            thead_dcache_range_inner(paddr, size, TheadDCacheOp::Clean);
+        }
+        DCacheOp::Invalidate => {
+            thead_dcache_range_inner(paddr, size, TheadDCacheOp::CleanInvalidate);
+            riscv_dma_fence();
+        }
+        DCacheOp::CleanInvalidate => {
+            riscv_dma_fence();
+            thead_dcache_range_inner(paddr, size, TheadDCacheOp::CleanInvalidate);
+            riscv_dma_fence();
+        }
+    }
+}
+
+#[cfg(feature = "thead-mae")]
+fn thead_dcache_range_inner(paddr: usize, size: usize, op: TheadDCacheOp) {
+    let Some((mut line, end)) =
+        crate::mem::cache_line_range(paddr, size, THEAD_DMA_CACHE_LINE_SIZE)
+    else {
+        return;
+    };
+
+    while line < end {
+        match op {
+            TheadDCacheOp::Clean => unsafe {
+                // T-Head dcache.cpa a0: clean by physical address.
+                core::arch::asm!(".long 0x0295000b", in("a0") line, options(nostack));
+            },
+            TheadDCacheOp::CleanInvalidate => unsafe {
+                // T-Head dcache.cipa a0: clean and invalidate by physical address.
+                core::arch::asm!(".long 0x02b5000b", in("a0") line, options(nostack));
+            },
+        }
+        let Some(next) = line.checked_add(THEAD_DMA_CACHE_LINE_SIZE) else {
+            break;
+        };
+        line = next;
+    }
+    thead_sync_is();
+}
+
+fn riscv_dma_fence() {
+    unsafe {
+        core::arch::asm!("fence rw, rw", options(nostack, preserves_flags));
+    }
+}
+
+#[cfg(feature = "thead-mae")]
+fn thead_sync_is() {
+    unsafe {
+        core::arch::asm!(".long 0x01b0000b", options(nostack));
     }
 }
 

--- a/platforms/someboot/src/lib.rs
+++ b/platforms/someboot/src/lib.rs
@@ -138,6 +138,17 @@ pub trait ArchTrait {
 
     fn dcache_range(op: DCacheOp, addr: usize, size: usize);
 
+    /// Prepare a cached virtual range before remapping it as uncached for DMA.
+    fn dma_coherent_before_make_uncached(addr: usize, size: usize) {
+        Self::dcache_range(DCacheOp::CleanInvalidate, addr, size);
+    }
+
+    /// Prepare an uncached DMA range before restoring it to cached mappings.
+    fn dma_coherent_before_restore_cached(_addr: usize, _size: usize) {}
+
+    /// Complete ordering after a DMA coherent mapping attribute update.
+    fn dma_coherent_after_mapping_update() {}
+
     /// EFI 入口点 - 从 EFI PE 入口跳转到内核
     ///
     /// # Safety

--- a/platforms/someboot/src/mem/mod.rs
+++ b/platforms/someboot/src/mem/mod.rs
@@ -87,6 +87,31 @@ pub fn dcache_range(op: DCacheOp, addr: *const u8, size: usize) {
     Arch::dcache_range(op, addr as _, size);
 }
 
+pub fn dma_coherent_before_make_uncached(addr: *const u8, size: usize) {
+    Arch::dma_coherent_before_make_uncached(addr as _, size);
+}
+
+pub fn dma_coherent_before_restore_cached(addr: *const u8, size: usize) {
+    Arch::dma_coherent_before_restore_cached(addr as _, size);
+}
+
+pub fn dma_coherent_after_mapping_update() {
+    Arch::dma_coherent_after_mapping_update();
+}
+
+#[cfg(any(test, all(target_arch = "riscv64", feature = "thead-mae")))]
+pub(crate) fn cache_line_range(
+    addr: usize,
+    size: usize,
+    line_size: usize,
+) -> Option<(usize, usize)> {
+    if size == 0 || line_size == 0 || !line_size.is_power_of_two() {
+        return None;
+    }
+    let end = addr.checked_add(size)?;
+    Some((addr & !(line_size - 1), end))
+}
+
 /// 物理RAM实际转换为的内核虚拟地址
 pub fn phys_to_virt(paddr: usize) -> *mut u8 {
     if mmu::is_kernel_relocated() {
@@ -226,4 +251,23 @@ pub(crate) fn add_memory_descriptor(
 
 pub fn kernel_space() -> Range<usize> {
     Arch::kernel_space()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_line_range_covers_unaligned_buffer() {
+        assert_eq!(cache_line_range(0x1003, 1, 64), Some((0x1000, 0x1004)));
+        assert_eq!(cache_line_range(0x103f, 2, 64), Some((0x1000, 0x1041)));
+    }
+
+    #[test]
+    fn cache_line_range_skips_empty_invalid_line_and_overflow() {
+        assert_eq!(cache_line_range(0x1000, 0, 64), None);
+        assert_eq!(cache_line_range(0x1000, 1, 0), None);
+        assert_eq!(cache_line_range(0x1000, 1, 63), None);
+        assert_eq!(cache_line_range(usize::MAX, 2, 64), None);
+    }
 }

--- a/platforms/somehal/src/cache.rs
+++ b/platforms/somehal/src/cache.rs
@@ -1,0 +1,23 @@
+//! Data-cache maintenance helpers exposed through SomeHAL.
+
+pub use someboot::DCacheOp;
+
+/// Maintains a data-cache range using the active platform implementation.
+pub fn dcache_range(op: DCacheOp, addr: *const u8, size: usize) {
+    someboot::mem::dcache_range(op, addr, size);
+}
+
+/// Prepares a cached range before it is remapped as uncached for DMA.
+pub fn dma_coherent_before_make_uncached(addr: *const u8, size: usize) {
+    someboot::mem::dma_coherent_before_make_uncached(addr, size);
+}
+
+/// Prepares an uncached DMA range before restoring cached mappings.
+pub fn dma_coherent_before_restore_cached(addr: *const u8, size: usize) {
+    someboot::mem::dma_coherent_before_restore_cached(addr, size);
+}
+
+/// Completes ordering after a DMA coherent mapping attribute update.
+pub fn dma_coherent_after_mapping_update() {
+    someboot::mem::dma_coherent_after_mapping_update();
+}

--- a/platforms/somehal/src/lib.rs
+++ b/platforms/somehal/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 extern crate log;
 
 mod boot_console;
+pub mod cache;
 pub(crate) mod common;
 pub mod cpu;
 mod driver;


### PR DESCRIPTION
## 问题

SG2002 / T-Head C9xx 平台使用 non-coherent streaming DMA 时，`dma-api` 的 `flush` / `invalidate` / `flush_invalidate` 边界需要真正触发 CPU cache maintenance，否则设备和 CPU 看到的内存内容可能不同步。

同时，DMA coherent 内存通过页属性切换创建 uncached 映射时，也需要在“改成 uncached 前”和“TLB 更新后”执行平台相关同步。这里不能把 T-Head 或 AArch64 的指令细节放在 `axklib` / `axruntime` 中；上层应只表达 DMA cache sync 或 DMA coherent 映射属性迁移，具体 cache/barrier 语义由平台层消化。

## 修改

- 在 `someboot` 的 RISC-V `dcache_range` 中实现 `thead-mae` 下的 T-Head C9xx cache maintenance：将输入虚拟地址转换为物理地址，按 64B cache line 执行 `dcache.cpa` / `dcache.cipa`，并保留必要的 `fence rw,rw` 与 `sync.is` 顺序。
- 在 `someboot::ArchTrait` 增加 DMA coherent 映射属性切换 hook：`dma_coherent_before_make_uncached`、`dma_coherent_before_restore_cached`、`dma_coherent_after_mapping_update`。默认实现复用 `dcache_range`，AArch64 覆写到原本需要的 clean+invalidate 与 `dsb` / `isb` 顺序。
- 在 `somehal` 新增轻量 `cache` facade，导出 `DCacheOp`、`dcache_range(...)` 以及 DMA coherent 映射属性切换 hook，内部统一委托到 `someboot`。
- 在 `ax-plat::mem::MemIf` 增加平台级 cache 能力；`axplat-dyn::mem` 实现这些接口并委托到 `somehal::cache`，因此 `somehal` 依赖停留在动态平台层。
- `ax-hal::mem` 只转发平台接口，`axruntime` 只调用 `ax_hal::mem`，不直接依赖 `somehal`，也不再包含 `target_arch` cfg、AArch64 asm 或 cache line 查询细节。
- 在 `axklib::Klib` 增加默认 no-op 的 DMA cache sync 回调；`KlibDma` 覆写 `DmaOp` 的 flush/invalidate/flush_invalidate，保留 `dma-api` 原有屏障语义后委托到 `Klib` 能力边界。
- 移除 `axklib` 中的 T-Head 指令细节和旧 `thead-cache` feature；该 PR 不包含 SG2002 DWMAC 实验驱动、诊断日志或 board case。

## 验证

- `cargo fmt`
- `cargo test -p someboot cache_line_range --lib`
- `cargo check -p someboot --target riscv64gc-unknown-none-elf --features thead-mae`
- `cargo check -p ax-runtime --target riscv64gc-unknown-none-elf --features paging`
- `cargo check -p someboot --target aarch64-unknown-none-softfloat`
- `cargo check -p ax-runtime --target aarch64-unknown-none-softfloat --features paging`
- `cargo xtask clippy --package ax-plat`
- `cargo xtask clippy --package ax-hal`
- `cargo xtask clippy --package someboot`
- `cargo xtask clippy --package somehal`
- `cargo xtask clippy --package axklib`
- `cargo xtask clippy --package ax-runtime`
- `cargo xtask clippy --package axplat-dyn`
- `rg -n "target_arch|clean_invalidate_dcache_to_poc|dsb_sy|isb_sy|dc civac|core::arch::asm|dcache_line_size" os/arceos/modules/axruntime/src/klib.rs` 无匹配

## 说明

本 PR 只提取 SG2002 DWMAC 实验中确认的 T-Head non-coherent DMA cache 同步根因修复。板级网卡 smoke 成功证据仍保留在实验分支中；本 PR 的验收范围是平台 cache 边界、RISC-V/AArch64 feature 编译和相关 clippy 矩阵。