### PR TITLE
test(starry): expand monitoring-stack carpet coverage

### DIFF
--- a/apps/starry/monitor/APPLY.md
+++ b/apps/starry/monitor/APPLY.md
@@ -22,8 +22,9 @@ apps/starry/monitor/
 │   ├── pty_tui_drive.py                      # PTY 驱动器（SS3 应用键模式）
 │   └── pyte_assert.py                        # pyte 屏幕重建 + 三重不变量断言
 └── python/
-    ├── run_monitor.py                        # 编排器 + 唯一门控锚点（MONITOR_OK=8/8 + TEST PASSED）
+    ├── run_monitor.py                        # 编排器 + 唯一门控锚点（MONITOR_OK=9/9 + TEST PASSED）
     ├── PrometheusCarpet.py
+    ├── NodeExporterCarpet.py                 # node_exporter CLI + live /metrics（含 vmstat collector）
     ├── GrafanaCarpet.py                      # headless grafana server + HTTP/API 断言
     ├── GlancesCliCarpet.py
     ├── GlancesHeadlessCarpet.py
@@ -42,7 +43,7 @@ cargo xtask starry app qemu -t monitor --arch riscv64
 cargo xtask starry app qemu -t monitor --arch loongarch64
 ```
 
-判据：xtask `rc=0` + 日志 `SUCCESS PATTERN MATCHED` + `^MONITOR_OK=8/8` + `TEST PASSED`。
+判据：xtask `rc=0` + 日志 `SUCCESS PATTERN MATCHED` + `^MONITOR_OK=9/9` + `TEST PASSED`。
 
 ## prebuild 可调环境变量（均有安全默认）
 
@@ -65,5 +66,5 @@ cargo xtask starry app qemu -t monitor --arch loongarch64
 - **LoongArch 必须 dynamic 平台**：`build-loongarch64*.toml` 保留 `ax-driver/serial` 且不 opt-out 动态平台，
   `qemu-loongarch64.toml` 用 `uefi=false / to_bin=true`（静态平台缺串口 TTY 绑定 → 早退）。
 - **rootfs grow-only**：`prebuild.sh` 只增不减，never 吞掉 resize2fs 失败。
-- **门控锚点唯一**：`MONITOR_OK=8/8` + `TEST PASSED` 只在 `run_monitor.py` 里输出（`run-monitor.sh` 从不输出），
+- **门控锚点唯一**：`MONITOR_OK=9/9` + `TEST PASSED` 只在 `run_monitor.py` 里输出（`run-monitor.sh` 从不输出），
   故 success_regex 不会被命令回显自匹配。

--- a/apps/starry/monitor/README.md
+++ b/apps/starry/monitor/README.md
@@ -1,12 +1,12 @@
-# monitor - Prometheus 监控栈 + Grafana + glances 系统监控器（StarryOS 四架构地毯测试）
+# monitor - Prometheus 监控栈 + Grafana + 系统监控 TUI（StarryOS 四架构地毯测试）
 
-本 app 在 StarryOS 四架构（x86_64 / aarch64 / riscv64 / loongarch64）单核 qemu 上，对三大监控软件做工业级、端到端、逐断言的地毯测试（非 “进程能起来” 的冒烟）：
+本 app 在 StarryOS 四架构（x86_64 / aarch64 / riscv64 / loongarch64）单核 qemu 上，对主流监控软件做工业级、端到端、逐断言的地毯测试（非 “进程能起来” 的冒烟）：
 
 - **Prometheus**（CNCF 监控系统：拉取式指标抓取 + TSDB + PromQL 引擎；`prometheus` 3.11.3 + `promtool`，CGO-free 纯静态 Go 二进制）＋ **node_exporter** 1.11.1（最简 exporter，作为真实抓取目标）。
 - **Grafana**（观测/可视化 web 应用，13.0.1；单个 CGO-free 纯静态 Go 二进制 + 内嵌前端 SPA + 内嵌 SQLite） - headless 起 server + HTTP 断言（无浏览器、无 TUI）。
 - **glances**（基于 psutil 的 Python 系统监控器，4.4.1）的全部五种运行形态：CLI / headless / **TUI（pyte 真实断言）** / client-server / web。
 
-单次启动运行 8 个子 carpet，全过才由 `run_monitor.py` 输出唯一门控锚点 `MONITOR_OK=8/8` + `TEST PASSED`。
+单次启动逐个隔离运行子 carpet，全过才由 `run_monitor.py` 输出唯一门控锚点 `MONITOR_OK=9/9` + `TEST PASSED`。
 
 ## 测试维度
 
@@ -17,9 +17,9 @@
 4. **promtool tsdb 功能腿**：`tsdb create-blocks-from openmetrics`（从 OpenMetrics 造块）→ `tsdb list`（打印块 ULID 验创建成功）→ `tsdb analyze`（读块统计）。全在 `/root`（ext4 磁盘）而非 `/tmp`：TSDB 与临时目录落磁盘既是生产正确做法，也规避 starry tmpfs 的 mmap read-back 返零页问题（analyze 经 mmap 读块 meta/index 会得 `\x00`；`tsdb list` 走 `read()` 不受影响）。此 tmpfs mmap 缺陷单列内核跟进。
 5. **ready**：headless 拉起 prometheus server 于 loopback `:9090`，断言日志 `Server is ready to receive web requests.` 且 `/-/ready` 返回 `Ready`（HTTP 服务起来 + TSDB 打开）。
 6. **PromQL 引擎**：`/api/v1/query?query=vector(42)` 返回 `status:success` + 值 `42`。
-7. **scrape + 端到端集成测**：前台拉起 node_exporter 于 `:9100/metrics`（启 `--collector.uname/cpu/meminfo/loadavg/netdev/diskstats/filesystem`，覆盖 starry 现渲染的全部 procfs 源）作为真实抓取目标，prometheus 配 `prometheus.yml` scrape job `node`。先断言 `/api/v1/query?query=up{job="node"}` 返回 `1`（真抓到 + 入库），再经 **180s soak**（2s 抓取间隔多轮）后断言 `node_cpu_seconds_total`、`node_memory_MemTotal_bytes` 与 `node_network_receive_bytes_total`（netdev collector 产）均已以数值样本入 TSDB、且 `query_range` 在时窗内返回多个数据点。这是 scrape→store→query 全链路的工业级端到端验证：node_exporter 真读 starry `/proc/stat`·`/proc/meminfo`·`/proc/loadavg`·`/proc/net/dev`·`/proc/diskstats`·`/proc/mounts` 暴露指标，prometheus 真抓真存真查。
+7. **scrape + 端到端集成测**：前台拉起 node_exporter 于 `:9100/metrics`（启 `--collector.uname/cpu/meminfo/loadavg/vmstat/netdev/diskstats/filesystem`，覆盖 starry 现渲染的全部 procfs 源）作为真实抓取目标，prometheus 配 `prometheus.yml` scrape job `node`。先断言 `/api/v1/query?query=up{job="node"}` 返回 `1`（真抓到 + 入库），再经 **180s soak**（2s 抓取间隔多轮）后断言 `node_cpu_seconds_total`、`node_memory_MemTotal_bytes`、`node_network_receive_bytes_total`（netdev collector 产）与 `node_vmstat_pgfault`（vmstat collector 产）均已以数值样本入 TSDB、且 `query_range` 在时窗内返回多个数据点。这是 scrape→store→query 全链路的工业级端到端验证：node_exporter 真读 starry `/proc/stat`·`/proc/meminfo`·`/proc/loadavg`·`/proc/vmstat`·`/proc/net/dev`·`/proc/diskstats`·`/proc/mounts` 暴露指标，prometheus 真抓真存真查。
 
-验证内核面：Go runtime（M:N 调度 / GC / futex 停泊 / getrandom）、loopback TCP/HTTP 双向、磁盘（ext4）TSDB 块写读 + mmap（analyze）、定时器 / WAL、procfs（`/proc/stat`·`/proc/meminfo`·`/proc/loadavg`·`/proc/net/dev`·`/proc/diskstats`·`/proc/mounts` 喂 node_exporter collector）。
+验证内核面：Go runtime（M:N 调度 / GC / futex 停泊 / getrandom）、loopback TCP/HTTP 双向、磁盘（ext4）TSDB 块写读 + mmap（analyze）、定时器 / WAL、procfs（`/proc/stat`·`/proc/meminfo`·`/proc/loadavg`·`/proc/vmstat`·`/proc/net/dev`·`/proc/diskstats`·`/proc/mounts` 喂 node_exporter collector）。
 
 ### Grafana（`GrafanaCarpet.py`）
 Grafana 是单个纯静态 Go 二进制（`grafana server` 子命令），serve 内嵌前端 SPA + REST API 于 loopback `:3000`，后端为内嵌 SQLite - 故像 glances web / prometheus 一样 **headless 起 server + HTTP 断言**，不测 TUI。
@@ -53,7 +53,7 @@ glances 是全屏 curses 程序。本 carpet 用**离线终端仿真（pyte）**
 5. **大区域重绘**：`-2`（左侧栏）/ `-3`（quicklook）开关来回，断言 **core 骨架**重绘回来、无残影。
 6. **内容驱动捕获（跨 arch 时序鲁棒）**：每次交互（启动 / 发 `m`/`c`/`a`/方向键 / 开关）后，驱动器持续把 PTY 输出增量喂给一块 live pyte 屏，**轮询等到预期内容真渲染出来再捕获断言帧**（启动等进程表头 `CPU%`/`MEM%`/`PID`；排序热键等排序指示行真出现 `by memory`/`by CPU`/`automatically`），设慷慨的 per-arch 上限（settle 90s、每步 45s，`MONITOR_TUI_SETTLE_WAIT`/`MONITOR_TUI_STEP_WAIT` 可调）+ 每步最小停留（保持真 soak）。快 arch（x86）立即满足即捕获，慢 arch（aa/rv/loong TCG）会等到渲染完成 - **捕获时机由内容驱动而非固定延时**，故同一脚本在四架构都稳；到上限仍无预期内容则**据实失败**（捕获帧缺内容，下游断言真报错，绝不静默放过）。
 
-> **glances CLI 版本感知说明**：`--print-completion`（shell 补全）由可选依赖 `shtab` 提供；交付版 Alpine glances 4.4.1-r1 的 apk 闭包**不含 shtab**，故该选项本就不提供 - carpet 对它做**能力探测**（存在则测其产出补全脚本，缺失则据实记为 documented SKIP），不假设 host 版本。其余全部 `--help` 选项按**交付版 4.4.1-r1 实测选项全集**逐项硬断言。
+> **glances CLI shell 补全**：`--print-completion`（shell 补全）由可选依赖 `shtab` 提供，overlay 已把 `py3-shtab` 装进闭包，故 glances 提供该选项且 carpet **硬断言**它对 `bash` / `zsh` / `tcsh` 均真产出补全脚本（脚本内含 `glances` 命令名）。全部 `--help` 选项按**交付版 4.4.1-r1 实测选项全集**逐项硬断言。
 
 ## 四架构来源（provenance，据实注明）
 
@@ -65,7 +65,7 @@ glances 是全屏 curses 程序。本 carpet 用**离线终端仿真（pyte）**
 | glances + psutil + FastAPI/uvicorn 栈 | 4.4.1 | apk | apk | apk | apk |
 
 - prometheus / node_exporter / grafana 为 CGO-free 纯静态 Go 二进制，在 musl/StarryOS 直接跑，无需 libc；四架构均运行，无任何 SKIP。amd64/arm64/riscv64 走官方 release（prometheus/node_exporter 的 URL + sha256 与上游 `sha256sums.txt` 逐字一致；grafana 与 dl.grafana.com `*.tar.gz.sha256` 一致），loong64 从源码 Go 交叉编译（`assets/build-loong-binaries.sh`）。逐档 URL/sha256 见 `assets/MANIFEST.md`。
-- glances 及其闭包（psutil native、FastAPI/Starlette/pydantic、jinja2）由 `apk add` 解析当前版本 + 目标架构 musl `.so` 全闭包，四架构均有；Alpine v3.23 未收录的 `pyte` / `uvicorn` 为纯 python（noarch）wheel，按钉死 URL + sha256 取回校验后解包进 site-packages。
+- glances 及其闭包（psutil native、FastAPI/Starlette/pydantic、jinja2、shtab）由 `apk add` 解析当前版本 + 目标架构 musl `.so` 全闭包，四架构均有；Alpine v3.23 未收录的 `pyte` / `uvicorn` 为纯 python（noarch）wheel，按钉死 URL + sha256 取回校验后解包进 site-packages。
 - **无任何二进制入 git**；全部构建期抓取 + 校验（见 `prebuild.sh`）。
 
 ## 运行
@@ -76,13 +76,13 @@ glances 是全屏 curses 程序。本 carpet 用**离线终端仿真（pyte）**
 # 2) 运行（单核）
 source <仓库根>/.starry-env.sh          # 使用 qemu-10
 cargo xtask starry app qemu -t monitor --arch <x86_64|aarch64|riscv64|loongarch64>
-# 成功判据：rc=0 + 日志 SUCCESS PATTERN MATCHED + ^MONITOR_OK=8/8 + TEST PASSED
+# 成功判据：rc=0 + 日志 SUCCESS PATTERN MATCHED + ^MONITOR_OK=9/9 + TEST PASSED
 ```
 
 ## 确定性与说明
 
 - **网络/容器探测插件**：TUI/headless/web/cs carpet 均禁用会在离线 SLIRP guest 上阻塞首帧的环境探测插件（`ip` 公网 IP 查询、`cloud` 169.254 元数据、`containers`/`docker` socket、`ports`/`folders`/`connections`/`sensors` 扫描）。核心仪表盘（cpu/mem/load/quicklook/uptime/processlist）照常渲染，正是 golden 所硬断言的对象。golden 全为结构性（标签/列位），从不钉死宿主相关的数值。
-- **左侧栏 procfs 区块（硬断言，据实真渲染）**：TUI/headless carpet 的 NETWORK/DISK I/O/FILE SYS 区块读 `/proc/net/dev`·`/proc/diskstats`·`/proc/mounts`+statfs。StarryOS 现真实渲染这三个源（`/proc/net/dev` 真 RX/TX 计数、`/proc/diskstats` 根盘 `vda` 真请求/扇区计数、`/proc/mounts` 真挂载表 + `statfs` 真容量），故三区块**硬门控**断言其真渲染 + 携带真数据：TUI 断言三区块标签 + `vda`/`eth0` 数据 token 出现，headless 断言 `lo` 累计字节 >0、`vda` 累计 read_bytes >0、根 fs size >0；node_exporter 同时启 netdev/diskstats/filesystem collector 并断言 `node_network_receive_bytes_total{lo}>0`、`node_disk_reads_completed_total{vda}>0`、`node_filesystem_size_bytes{"/"}>0`。core 区块（进程表 + MEM/LOAD/TASKS）一并硬断言。仍是长 soak + 三态 + 四不变量，非降级 smoke。
+- **左侧栏 procfs 区块（硬断言，据实真渲染）**：TUI/headless carpet 的 NETWORK/DISK I/O/FILE SYS 区块读 `/proc/net/dev`·`/proc/diskstats`·`/proc/mounts`+statfs。StarryOS 现真实渲染这三个源（`/proc/net/dev` 真 RX/TX 计数、`/proc/diskstats` 根盘 `vda` 真请求/扇区计数、`/proc/mounts` 真挂载表 + `statfs` 真容量），故三区块**硬门控**断言其真渲染 + 携带真数据：TUI 断言三区块标签 + `vda`/`eth0` 数据 token 出现，headless 断言 `lo` 累计字节 >0、`vda` 累计 read_bytes >0、根 fs size >0；node_exporter 同时启 vmstat/netdev/diskstats/filesystem collector 并断言 `node_vmstat_pgfault>0`、`node_network_receive_bytes_total{lo}>0`、`node_disk_reads_completed_total{vda}>0`、`node_filesystem_size_bytes{"/"}>0`。core 区块（进程表 + MEM/LOAD/TASKS）一并硬断言。仍是长 soak + 三态 + 四不变量，非降级 smoke。
 - **loopback**：grafana / glances web（uvicorn/ASGI）/ client-server（XML-RPC）均在 guest 内 loopback 上 bind/listen/accept，压 StarryOS 网络栈。
 - **grafana SQLite 迁移**：grafana 首启要跑 709 个 SQLite 迁移（重压 ext4/fsync）。prebuild **构建期尽力预迁移**架构无关的 `grafana.db` 播种，on-target 跳过这 709 个迁移；carpet 用 WAL 模式 + 对前端端点做退避重试化解启动期 `SQLITE_BUSY` 争用。若预迁移未成，on-target 现场迁移（更慢但仍能过）。
 - **超时**：本 app 单次启动跑 prometheus 冷启动 + scrape + grafana server（SQLite 迁移/启动）+ glances 五形态（含 TUI soak + web + c/s），故 `timeout` 取较大值（慢架构 TCG 下 Go/SQLite 冷启动需足够长，非真 hang）。

--- a/apps/starry/monitor/assets/MANIFEST.md
+++ b/apps/starry/monitor/assets/MANIFEST.md
@@ -59,7 +59,7 @@ riscv64 (has riscv64, NO loong64). Tarball sha256 == dl.grafana.com `*.tar.gz.sh
 grafana v13's backend does NOT embed the frontend, so loong64 needs only the Go backend cross-compiled
 (no Node/yarn build) with the official arch-independent frontend grafted -- `assets/build-loong-binaries.sh grafana`.
 prebuild strips `public/**/*.map` (~290MB browser debug artifacts, never read server-side) and
-best-effort pre-migrates the arch-independent `grafana.db` (skips the 709 first-run SQLite migrations).
+opportunistically pre-migrates the arch-independent `grafana.db` (skips the 709 first-run SQLite migrations).
 
 ## glances 4.4.1 stack (Alpine v3.23, musl, all 4 arches -- resolved live by `apk add`)
 No pinned URLs: `apk add` resolves the CURRENT version + full musl .so closure per arch (no drift).

--- a/apps/starry/monitor/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/monitor/build-aarch64-unknown-none-softfloat.toml
@@ -1,8 +1,8 @@
 target = "aarch64-unknown-none-softfloat"
 log = "Warn"
 features = [
-  "ax-feat/display",
-  "ax-feat/rtc",
+  "ax-runtime/display",
+  "ax-runtime/rtc",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
   "ax-driver/virtio-gpu",

--- a/apps/starry/monitor/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/monitor/build-loongarch64-unknown-none-softfloat.toml
@@ -5,8 +5,8 @@
 target = "loongarch64-unknown-none-softfloat"
 log = "Warn"
 features = [
-  "ax-feat/display",
-  "ax-feat/rtc",
+  "ax-runtime/display",
+  "ax-runtime/rtc",
   "ax-driver/serial",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",

--- a/apps/starry/monitor/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/monitor/build-riscv64gc-unknown-none-elf.toml
@@ -1,8 +1,8 @@
 target = "riscv64gc-unknown-none-elf"
 log = "Warn"
 features = [
-  "ax-feat/display",
-  "ax-feat/rtc",
+  "ax-runtime/display",
+  "ax-runtime/rtc",
   "ax-driver/serial",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",

--- a/apps/starry/monitor/prebuild.sh
+++ b/apps/starry/monitor/prebuild.sh
@@ -35,7 +35,7 @@ APK_CACHE="${MONITOR_APK_CACHE:-}"
 #   $MONITOR_BINS_DIR/grafana/<arch>/grafana-13.0.1.linux-<goarch>.tar.gz
 #   $MONITOR_BINS_DIR/grafana/grafana-13.0.1.db   (optional pre-migrated, arch-independent seed)
 BINS_DIR="${MONITOR_BINS_DIR:-}"
-GRAFANA_PREMIGRATE="${MONITOR_GRAFANA_PREMIGRATE:-1}"  # best-effort build-time SQLite migration (skips 709 on-target)
+GRAFANA_PREMIGRATE="${MONITOR_GRAFANA_PREMIGRATE:-1}"  # opportunistic build-time SQLite migration (skips 709 on-target)
 
 PROM_VER="3.11.3"
 NE_VER="1.11.1"
@@ -126,14 +126,17 @@ install_glances_closure() {
     local cache_args=(); [[ -n "$APK_CACHE" ]] && { mkdir -p "$APK_CACHE"; cache_args=(--cache-dir "$APK_CACHE"); }
     # glances + psutil (core) + the FastAPI/Starlette/pydantic/uvicorn web-server closure that
     # `glances -w` needs (py3-uvicorn is not in Alpine -> vendored as a wheel below) + py3-wcwidth
-    # (pyte's only dep) + jinja2 (web templates). apk resolves the full musl .so closure per arch.
-    local pkgs="glances python3 py3-psutil py3-fastapi py3-starlette py3-pydantic py3-anyio py3-sniffio py3-h11 py3-click py3-wcwidth py3-jinja2"
+    # (pyte's only dep) + jinja2 (web templates) + py3-shtab (enables glances --print-completion) +
+    # htop (the ncurses process-monitor TUI, pulls its ncurses .so + terminfo closure). apk resolves
+    # the full musl .so closure per arch.
+    local pkgs="glances htop python3 py3-psutil py3-fastapi py3-starlette py3-pydantic py3-anyio py3-sniffio py3-h11 py3-click py3-wcwidth py3-jinja2 py3-shtab"
     echo "prebuild: apk add ($APK_BRANCH) via $qemu_runner: $pkgs"
     QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
         "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" --root "$staging_root" \
             --repositories-file "$staging_root/etc/apk/repositories" --keys-dir "$staging_root/etc/apk/keys" \
             "${cache_args[@]}" --update-cache --no-progress --no-scripts add $pkgs
     [[ -e "$staging_root/usr/bin/glances" ]] || { echo "prebuild: glances not provisioned" >&2; exit 3; }
+    [[ -e "$staging_root/usr/bin/htop" ]] || { echo "prebuild: htop not provisioned" >&2; exit 3; }
     local pyver; pyver="$(ls -d "$staging_root"/usr/lib/python3.* 2>/dev/null | grep -oE 'python3\.[0-9]+' | head -1)"
     case "$pyver" in python3.1[2-9]|python3.2[0-9]) echo "prebuild: provisioned glances + $pyver" ;;
         *) echo "prebuild: need CPython>=3.12, got '$pyver'" >&2; exit 3 ;; esac
@@ -247,7 +250,7 @@ install_grafana() {
              "$gdir/provisioning/access-control" "$gdir/provisioning/notifiers"
     rm -rf "$staging_root/tmp/$topdir" "$tb"
 
-    # --- best-effort BUILD-TIME pre-migration of the arch-independent grafana.db (skips the 709
+    # --- opportunistic BUILD-TIME pre-migration of the arch-independent grafana.db (skips the 709
     #     first-run SQLite migrations on-target). Prefer a staged db, else run the target grafana
     #     (native for x86; qemu-user otherwise), bounded; on any failure ship un-seeded (the carpet
     #     migrates on the spot). grafana.db is arch-independent, so a db built for ANY arch is valid.

--- a/apps/starry/monitor/programs/pty_tui_drive.py
+++ b/apps/starry/monitor/programs/pty_tui_drive.py
@@ -36,6 +36,23 @@ PGUP = b"\x1b[5~"
 HOME = b"\x1b[H"
 END  = b"\x1b[F"
 
+# Function keys as xterm-256color terminfo renders them (kf1..kf10): F1-F4 are the SS3 forms
+# ESC O P/Q/R/S, F5-F10 the CSI ~ forms. Like the SS3 arrows these are what a keypad(True) curses
+# app (htop) matches against its application-mode terminfo; DECCKM only affects cursor keys, so these
+# stay constant. A curses app opens its F-key panels only when the exact terminfo bytes arrive, so a
+# panel appearing after one of these is itself proof the pty delivered the sequence intact.
+F1  = b"\x1bOP"
+F2  = b"\x1bOQ"
+F3  = b"\x1bOR"
+F4  = b"\x1bOS"
+F5  = b"\x1b[15~"
+F6  = b"\x1b[17~"
+F7  = b"\x1b[18~"
+F8  = b"\x1b[19~"
+F9  = b"\x1b[20~"
+F10 = b"\x1b[21~"
+ESC = b"\x1b"
+
 
 # Optional live-screen emulation so the driver can wait UNTIL the TUI has rendered expected content
 # (content-driven capture) instead of a fixed delay -- essential for slow (TCG) arches where glances

--- a/apps/starry/monitor/python/GlancesCliCarpet.py
+++ b/apps/starry/monitor/python/GlancesCliCarpet.py
@@ -46,8 +46,8 @@ def main():
     # --- EXHAUSTIVE --help OPTION TREE: assert every option of the DELIVERED build (Alpine glances
     #     4.4.1-r1) is listed. Ground truth = the actual `glances --help` of the musl apk (captured
     #     under qemu-user-static from the delivery closure), NOT a host pip build. `--print-completion`
-    #     is deliberately NOT here: it is shtab-gated and Alpine glances 4.4.1-r1 ships without shtab,
-    #     so the option is legitimately absent -> handled as a capability probe below, never a red-line.
+    #     (shtab-gated) is included: the overlay bundles shtab, so glances offers it and it is
+    #     hard-asserted below.
     rc, help_out = run(["--help"])
     check(rc == 0, "`glances --help` exits 0")
     REQUIRED_OPTS = [
@@ -97,19 +97,15 @@ def main():
     check(all(p in out for p in ("cpu", "mem", "load", "network")),
           "--modules-list enumerates core plugins (cpu/mem/load/network)")
 
-    # --- shell completion is CAPABILITY-AWARE. glances only offers `--print-completion` when the
-    #     optional `shtab` dependency is importable; the delivery build (Alpine glances 4.4.1-r1)
-    #     ships WITHOUT shtab (it is not in the apk closure), so the option is legitimately absent.
-    #     If a build DOES offer it, assert the generator emits a script (gate on CONTENT, not rc:
-    #     shtab exits non-zero on some builds even after printing the script). If absent -> a
-    #     documented capability SKIP, never a failure (据实按交付版本, not the host build).
-    if "--print-completion" in help_out:
-        rc, out = run(["--print-completion", "bash"])
-        check(len(out) > 20 and ("shtab" in out or "_glances" in out or "complete" in out.lower()),
-              "`--print-completion bash` emits a completion script (shtab present in this build)")
-    else:
-        print("  SKIP --print-completion -- shtab not bundled in this glances build (Alpine 4.4.1-r1); "
-              "the option is not offered (capability absent by design, not a failure)")
+    # --- shell completion (HARD). glances exposes `--print-completion` via its optional `shtab`
+    #     dependency, which the overlay bundles, so the option is offered and generates a real
+    #     completion script for each supported shell. Gate on CONTENT (the completion always names
+    #     the `glances` command) rather than rc, since shtab can exit non-zero after printing.
+    check("--print-completion" in help_out, "--help offers --print-completion (shtab bundled)")
+    for shell in ("bash", "zsh", "tcsh"):
+        rc, out = run(["--print-completion", shell])
+        check(len(out) > 50 and "glances" in out,
+              "`--print-completion %s` emits a completion script naming glances" % shell)
 
     print("GCLI_RESULT ok=%d fail=%d" % (_ok, _fail))
     if _fail == 0:

--- a/apps/starry/monitor/python/GlancesCsCarpet.py
+++ b/apps/starry/monitor/python/GlancesCsCarpet.py
@@ -1,16 +1,28 @@
 #!/usr/bin/env python3
 # GlancesCsCarpet.py -- glances CLIENT/SERVER mode. Starts a glances XML-RPC server (`glances -s`)
-# on loopback, then runs a glances client (`glances -c`) that connects to it and pulls a one-shot
-# snapshot over the wire. Asserts the client received a plausible mem.total FROM the server ->
-# proves the XML-RPC server (bind/listen/accept) + client (connect) round-trip on StarryOS loopback.
+# on loopback, waits until the server is actually answering XML-RPC with real stats, then runs a
+# glances client (`glances -c`) that connects to it and pulls a one-shot snapshot over the wire.
+# Asserts the client received a plausible mem.total FROM the server -> proves the XML-RPC server
+# (bind/listen/accept) + client (connect) round-trip on StarryOS loopback.
+#
+# Readiness matters: glances prints "XML-RPC server is running" from GlancesServer.__init__, but the
+# instance it then registers runs a full initial stats.update() *before* main enters the accept
+# loop. On a slow emulated target that gap can exceed the client's 7s XML-RPC transport timeout, so
+# a client that connects the instant the banner appears times out and silently falls back to SNMP
+# (glances.client._login_glances), yielding an empty snapshot. We therefore gate the client on a
+# carpet-side XML-RPC probe (same xmlrpc.client transport the glances client uses) that confirms the
+# server actually serves a real mem.total before the client is launched.
 #
 # Emits `GCS_RESULT ok=<N> fail=<F>` and, only when F==0, `GCS_DONE`.
-import os, re, signal, subprocess, sys, time
+import json, os, re, signal, socket, subprocess, sys, time
+import xmlrpc.client
 
 GLANCES = os.environ.get("GLANCES_BIN", "glances")
 DISABLE = "ip,cloud,containers,docker,folders,ports,smart,wifi,gpu,connections,sensors"
 PORT = int(os.environ.get("MONITOR_CS_PORT", "61234"))
 HOST = "127.0.0.1"
+SRV_LOG = "/tmp/glances-server.log"
+CLI_LOG = "/tmp/glances-client.log"
 _ok = 0
 _fail = 0
 
@@ -24,57 +36,96 @@ def check(cond, label):
         print("  FAIL %s" % label)
 
 
+def read_file(path):
+    try:
+        with open(path) as f:
+            return f.read()
+    except Exception:
+        return ""
+
+
+def dump_logs(where):
+    for tag, path in (("srv", SRV_LOG), ("cli", CLI_LOG)):
+        lines = read_file(path).splitlines()
+        print("  --- %s %s log (last 30 lines) ---" % (where, tag))
+        for ln in lines[-30:]:
+            print("  %s| %s" % (tag, ln))
+
+
+def server_reports_ready(server):
+    if server.poll() is not None:
+        return False
+    txt = read_file(SRV_LOG)
+    return "XML-RPC server is running" in txt or ("running on %s:%d" % (HOST, PORT)) in txt
+
+
+def probe_mem_total(server, deadline):
+    """Poll the server over XML-RPC until getAll() yields a real mem.total (bytes), or the deadline
+    passes / the server dies. Uses the same xmlrpc.client transport the glances client uses, so a
+    success here proves the C/S round-trip works at the protocol level on StarryOS loopback."""
+    socket.setdefaulttimeout(15)
+    try:
+        while time.time() < deadline:
+            if server.poll() is not None:
+                return None
+            try:
+                proxy = xmlrpc.client.ServerProxy("http://%s:%d" % (HOST, PORT))
+                proxy.init()
+                data = json.loads(proxy.getAll())
+                total = int(data.get("mem", {}).get("total", 0)) if isinstance(data, dict) else 0
+                if total > (1 << 20):
+                    return total
+            except Exception:
+                pass
+            time.sleep(1)
+    finally:
+        socket.setdefaulttimeout(None)
+    return None
+
+
 def main():
     print("=== GlancesCsCarpet: glances -s (XML-RPC server) + glances -c (client) on :%d ===" % PORT)
-    slog = open("/tmp/glances-server.log", "w")
+    slog = open(SRV_LOG, "w")
     server = subprocess.Popen(
         [GLANCES, "-s", "-p", str(PORT), "-B", HOST, "--disable-autodiscover", "-t", "2",
          "--disable-check-update", "--disable-plugin", DISABLE],
         stdout=slog, stderr=subprocess.STDOUT)
     client = None
     try:
-        # wait for the server to announce it is listening.
+        # 1. wait for the server to announce it is listening.
         up = False
         for _ in range(90):
-            if server.poll() is not None:
-                break
-            try:
-                txt = open("/tmp/glances-server.log").read()
-            except Exception:
-                txt = ""
-            if "XML-RPC server is running" in txt or ("running on %s:%d" % (HOST, PORT)) in txt:
+            if server_reports_ready(server):
                 up = True
+                break
+            if server.poll() is not None:
                 break
             time.sleep(1)
         check(up, "glances -s XML-RPC server came up (announced listening)")
 
-        # run the client bounded: it fetches from the server and prints mem.total/cpu.total. In
-        # client stdout mode --stop-after is not always honoured, so bound it with a timeout and
-        # read whatever it printed to the log.
-        clog_path = "/tmp/glances-client.log"
-        clog = open(clog_path, "w")
+        # 2. gate on a real XML-RPC round-trip: prove the server serves a plausible mem.total before
+        #    the client connects (absorbs the slow initial-update window on emulated targets).
+        probe_total = probe_mem_total(server, time.time() + 120) if up else None
+        check(probe_total is not None,
+              "server answers XML-RPC getAll() with a real mem.total (probe got %s)" % probe_total)
+
+        # 3. run the real glances client bounded: it fetches from the server and prints
+        #    mem.total/cpu.total. Give it a few refresh cycles so a transient miss retries.
+        clog = open(CLI_LOG, "w")
         client = subprocess.Popen(
             [GLANCES, "-c", HOST, "-p", str(PORT), "--stdout", "mem.total,cpu.total",
-             "--stop-after", "1", "-t", "2", "--disable-check-update"],
+             "--stop-after", "4", "-t", "2", "--disable-check-update"],
             stdout=clog, stderr=subprocess.STDOUT)
         got = None
-        deadline = time.time() + 40
+        deadline = time.time() + 60
         while time.time() < deadline:
-            try:
-                txt = open(clog_path).read()
-            except Exception:
-                txt = ""
+            txt = read_file(CLI_LOG)
             m = re.search(r"^mem\.total:\s*([0-9]+)\s*$", txt, re.M)
             if m:
                 got = int(m.group(1))
                 break
             if client.poll() is not None:
-                # process finished; re-read once more
-                try:
-                    txt = open(clog_path).read()
-                except Exception:
-                    pass
-                m = re.search(r"^mem\.total:\s*([0-9]+)\s*$", txt, re.M)
+                m = re.search(r"^mem\.total:\s*([0-9]+)\s*$", read_file(CLI_LOG), re.M)
                 if m:
                     got = int(m.group(1))
                 break
@@ -83,12 +134,11 @@ def main():
         check(got is not None, "client received a mem.total line from the server")
         check(got is not None and got > (1 << 20),
               "client mem.total > 1 MiB over the wire (got %s) -- c/s round-trip real" % got)
-        c = None
-        try:
-            c = re.search(r"^cpu\.total:\s*([0-9.]+)\s*$", open(clog_path).read(), re.M)
-        except Exception:
-            pass
+        c = re.search(r"^cpu\.total:\s*([0-9.]+)\s*$", read_file(CLI_LOG), re.M)
         check(c is not None, "client also received cpu.total from the server")
+
+        if _fail:
+            dump_logs("failure")
     finally:
         for p in (client, server):
             if p is None:

--- a/apps/starry/monitor/python/GlancesHeadlessCarpet.py
+++ b/apps/starry/monitor/python/GlancesHeadlessCarpet.py
@@ -156,8 +156,13 @@ def main():
     print("  diskio disks: %s" % sorted(x for x in disks if x))
     vda = next((d for d in (dio or []) if d.get("disk_name") == "vda"), None)
     check(vda is not None, "diskio plugin exposes the 'vda' root disk (from /proc/diskstats)")
-    check(vda is not None and int(vda.get("read_bytes", 0)) > 0,
-          "vda has non-zero cumulative read_bytes (boot reads): %r" % (vda.get("read_bytes") if vda else None))
+    # glances flags the diskio byte/count fields rate=True: the cumulative /proc/diskstats counter is
+    # carried in `<field>_gauge`, while the bare `<field>` is only the delta since the previous
+    # refresh (legitimately 0 when no I/O lands in the sub-second sampling window). The boot-reads
+    # proof is the cumulative gauge -- the diskio analogue of the network plugin's bytes_all_gauge.
+    read_bytes = int(vda.get("read_bytes_gauge", vda.get("read_bytes", 0))) if vda else 0
+    check(read_bytes > 0,
+          "vda has non-zero cumulative read_bytes (boot reads): %r" % (read_bytes if vda else None))
 
     # fs: /proc/mounts + statfs -> the ext4 root filesystem with a real total size.
     fs = parse_list("fs")

--- a/apps/starry/monitor/python/HtopCarpet.py
+++ b/apps/starry/monitor/python/HtopCarpet.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# HtopCarpet.py -- industrial, pyte-verified assertion carpet for the htop process-monitor TUI on
+# StarryOS (4 arches). Like the glances TUI carpet, htop is a full-screen ncurses program driven
+# through a live pseudo-terminal over a soak, its raw ANSI output reconstructed by an offline
+# terminal emulator (pyte) and asserted cell-by-cell -- not a "process starts" smoke.
+#
+# WHAT IS EXERCISED:
+#   * htop is launched inside a REAL pty (pty.fork -> initscr -> keypad(True) -> alternate screen)
+#     with the window size set via TIOCSWINSZ, so it takes its production render path on StarryOS.
+#   * The dashboard reads the /proc sources StarryOS renders: the process table from
+#     /proc/[pid]/{stat,statm,cmdline,comm}, the CPU meter from /proc/stat, the Mem/Swp meters from
+#     /proc/meminfo, the Load-average meter from /proc/loadavg and the Uptime meter from /proc/uptime.
+#   * A scripted key soak drives every documented function surface and asserts the resulting screen:
+#       - sort hotkeys  M / P / T  (by MEM% / CPU% / TIME+) and the F6 sort-field panel;
+#       - tree view toggle  t  (hierarchical process view) back to the flat list;
+#       - F2 Setup (Meters / Display options / Colors / Columns configuration screen);
+#       - F6 SortBy field panel;  F9 Kill signal panel (SIGTERM/SIGKILL, cancelled -- no signal sent);
+#       - F3 Search and F4 Filter incremental input bars;  F1 Help screen (version banner + legend);
+#       - F10 to quit.
+#     The F-keys are the xterm-256color terminfo sequences; htop only opens a panel when the exact
+#     bytes arrive, so a panel appearing after an F-key is itself proof StarryOS's pty delivered it
+#     intact (the function-key analogue of the SS3-arrow fact proven by the glances TUI carpet).
+#   * The captured raw stream is fed to pyte and asserted three ways (see pyte_assert.py):
+#       1. golden chrome present   (process-table header + meter labels + function bar painted)
+#       2. cross-frame stability   (header anchors at the SAME row/col across all flat-list frames)
+#       3. differential-render invariant (stream fed in arbitrary split chunks == fed whole)
+#
+# Deterministic: fixed 200x50 terminal; a fresh empty HOME so htop uses its built-in default layout
+# (no stale htoprc). Goldens are structural (labels/columns/panel names), never host-specific values.
+#
+# Emits `HTOP_RESULT ok=<N> fail=<F>` and, only when F==0, `HTOP_DONE`.
+import os, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+for cand in (os.path.join(HERE, "..", "programs"), HERE, "/root/monitor/programs", "/root/monitor"):
+    if os.path.isfile(os.path.join(cand, "pty_tui_drive.py")):
+        sys.path.insert(0, cand)
+        break
+import pty_tui_drive as ptd
+import pyte_assert as pa
+
+HTOP = os.environ.get("HTOP_BIN", "htop")
+COLS = int(os.environ.get("MONITOR_TUI_COLS", "200"))
+ROWS = int(os.environ.get("MONITOR_TUI_ROWS", "50"))
+SETTLE = float(os.environ.get("MONITOR_HTOP_SETTLE", "4"))
+DWELL = float(os.environ.get("MONITOR_HTOP_DWELL", "2"))
+SETTLE_WAIT = float(os.environ.get("MONITOR_HTOP_SETTLE_WAIT", "90"))
+STEP_WAIT = float(os.environ.get("MONITOR_HTOP_STEP_WAIT", "45"))
+DEBUG = os.environ.get("MONITOR_HTOP_DEBUG", "") not in ("", "0")
+
+# -d N : update delay in tenths of a second (1s); -C : mono, no color escapes to muddy the capture.
+CMD = [HTOP, "-d", "10", "-C"]
+
+# process-table header = "the dashboard has rendered" readiness signal.
+HDR = ["PID", "CPU%", "Command"]
+
+
+def _w(tokens, mx, mn):
+    return {"wait_for": tokens, "max_wait": mx, "min_dwell": mn}
+
+
+# Phase FLAT = constant flat-list layout (settle + sort hotkeys) -- used for the stability invariant.
+# Then the tree toggle, then each panel (opened by its F-key, asserted, cancelled back to the list).
+SCRIPT = [
+    ("settle",     b"",                _w(HDR,                    SETTLE_WAIT, SETTLE)),
+    ("sort_mem",   b"M",               _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("sort_cpu",   b"P",               _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("sort_time",  b"T",               _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("flat_obs",   b"",                _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("tree_on",    b"t",               _w(["PID", "Command"],     STEP_WAIT,   DWELL)),
+    ("tree_off",   b"t",               _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("setup",      ptd.F2,             _w(["Meters"],             STEP_WAIT,   DWELL)),
+    ("setup_close",ptd.F10,            _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("sortby",     ptd.F6,             _w(["Sort by"],            STEP_WAIT,   DWELL)),
+    ("sortby_close",ptd.ESC,           _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("kill",       ptd.F9,             _w(["SIGTERM"],            STEP_WAIT,   DWELL)),
+    ("kill_close", ptd.ESC,            _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("search",     ptd.F3 + b"htop",   _w(["Search"],             STEP_WAIT,   DWELL)),
+    ("search_close",ptd.ESC,           _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("filter",     ptd.F4 + b"htop",   _w(["Filter"],             STEP_WAIT,   DWELL)),
+    ("filter_close",ptd.ESC,           _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("help",       ptd.F1,             _w(["htop"],               STEP_WAIT,   DWELL)),
+    ("help_close", b" ",               _w(HDR,                    STEP_WAIT,   DWELL)),
+    ("final",      b"",                _w(HDR,                    STEP_WAIT,   DWELL)),
+]
+
+_ok = 0
+_fail = 0
+
+
+def check(cond, label):
+    global _ok, _fail
+    if cond:
+        _ok += 1
+    else:
+        _fail += 1
+        print("  FAIL %s" % label)
+
+
+def dump(label, disp):
+    print("  --- frame %s ---" % label)
+    for i, l in enumerate(disp):
+        t = l.rstrip()
+        if t:
+            print("  %2d|%s" % (i, t[:150]))
+
+
+def main():
+    print("=== HtopCarpet: pyte-verified htop TUI soak (%dx%d, content-driven capture) ===" % (COLS, ROWS))
+    home = tempfile.mkdtemp(prefix="htop-home-")
+    res = ptd.drive(CMD, SCRIPT, cols=COLS, rows=ROWS, quit_key=ptd.F10,
+                    env_extra={"HOME": home, "XDG_CONFIG_HOME": os.path.join(home, ".config")})
+    raw = res["raw"]
+    timed_out = [lbl for lbl, _off, met in res["checkpoints"] if met is False]
+    print("  driver: survived=%s dead=%s rawbytes=%d sent=%d checkpoints=%d timed_out=%s"
+          % (res["survived"], res["dead"], len(raw), len(res["sent"]), len(res["checkpoints"]), timed_out))
+
+    # 1. survival across the whole F-key + hotkey soak (no crash, no bare-ESC mis-decode quit).
+    check(res["survived"], "htop SURVIVED the full F-key + hotkey soak")
+    check(res["dead"] is None or not res["dead"].startswith("exit:") or res["dead"] == "exit:0",
+          "htop did not crash mid-soak (dead=%s)" % res["dead"])
+    check(len(raw) > 4000, "htop painted a substantial ANSI stream (>4000 bytes, got %d)" % len(raw))
+
+    settle_met = next((met for lbl, _o, met in res["checkpoints"] if lbl == "settle"), None)
+    check(settle_met is not False, "dashboard rendered within the settle budget (%.0fs); timed_out=%s"
+          % (SETTLE_WAIT, timed_out))
+
+    frames = {}
+    order = []
+    for label, off, _met in res["checkpoints"]:
+        disp = list(pa.full_screen(raw[:off], COLS, ROWS).display)
+        frames[label] = disp
+        order.append((label, disp))
+    final = frames.get("final") or (order[-1][1] if order else [])
+
+    if DEBUG:
+        for label in ("settle", "tree_on", "setup", "sortby", "kill", "search", "filter", "help", "final"):
+            if label in frames:
+                dump(label, frames[label])
+
+    # 2. golden chrome on the final flat-list frame: the process-table header (structural columns).
+    header_tokens = ["PID", "USER", "CPU%", "MEM%", "TIME+", "Command"]
+    hf, hmiss = pa.tokens_present(final, header_tokens)
+    check(not hmiss, "process-table header rendered %s (missing=%s)" % (header_tokens, hmiss))
+
+    # 3. the top meters -- each proves a distinct /proc source is read:
+    #      Mem  <- /proc/meminfo   Swp <- /proc/meminfo   Tasks <- /proc/stat + process table
+    #      Load average <- /proc/loadavg   Uptime <- /proc/uptime
+    meter_tokens = ["Mem", "Swp", "Tasks", "Load average", "Uptime"]
+    mf, mmiss = pa.tokens_present(final, meter_tokens)
+    check(not mmiss, "top meters rendered %s (missing=%s)" % (meter_tokens, mmiss))
+
+    # 4. the function-key bar (the documented action surface).
+    fbar = ["Help", "Setup", "Search", "Filter", "Tree", "Kill", "Quit"]
+    ff, fmiss = pa.tokens_present(final, fbar)
+    check(not fmiss, "function-key bar rendered %s (missing=%s)" % (fbar, fmiss))
+
+    # 5. F2 Setup screen: the configuration categories (proves F2 delivered + the panel painted).
+    setup = frames.get("setup", [])
+    su_tokens = ["Meters", "Display options", "Colors"]
+    suf, sumiss = pa.tokens_present(setup, su_tokens)
+    check(not sumiss, "F2 setup screen shows config categories %s (missing=%s)" % (su_tokens, sumiss))
+
+    # 6. F6 SortBy field panel: its 'Sort by' title appears while the process list stays visible.
+    sortby = frames.get("sortby", [])
+    check(pa.find_token(sortby, "Sort by")[0] >= 0 and pa.find_token(sortby, "PID")[0] >= 0,
+          "F6 sort-field panel opened ('Sort by' title + field list)")
+
+    # 7. F9 Kill signal panel: the 'Send signal:' title + named signals (cancelled with Esc, so NO
+    #    signal is ever delivered to any process).
+    kill = frames.get("kill", [])
+    kt = ["Send signal:", "SIGTERM", "SIGKILL"]
+    kf, kmiss = pa.tokens_present(kill, kt)
+    check(not kmiss, "F9 kill panel lists signals %s (missing=%s)" % (kt, kmiss))
+
+    # 8. F3 Search + F4 Filter incremental bars (the ': ' prompt only appears in input mode).
+    check(pa.find_token(frames.get("search", []), "Search:")[0] >= 0,
+          "F3 search bar shows the 'Search:' prompt")
+    check(pa.find_token(frames.get("filter", []), "Filter:")[0] >= 0,
+          "F4 filter bar shows the 'Filter:' prompt")
+
+    # 9. F1 Help screen: the version banner (only htop's help/version prints the 'htop <ver>' line).
+    helpf = frames.get("help", [])
+    import re as _re
+    check(any(_re.search(r"htop\s+\d+\.\d+", l) for l in helpf), "F1 help screen shows the htop version banner")
+
+    # 10. cross-frame stability over the FLAT-list frames: header anchors never flicker / move / leave
+    #     residue as rows churn and the sort column changes (sorting reorders rows, not column labels).
+    flat_labels = {"settle", "sort_mem", "sort_cpu", "sort_time", "flat_obs", "tree_off", "final"}
+    flat = [(lbl, dsp) for lbl, dsp in order if lbl in flat_labels]
+    anchors = ["PID", "CPU%", "MEM%", "Command"]
+    viol = pa.stability_violations(flat, anchors)
+    check(not viol, "flat-list chrome stable across %d frames (no flicker/residue/misalign): %s"
+          % (len(flat), viol[:3]))
+
+    # 11. differential-render invariant: chunked feed == whole feed, cell-for-cell.
+    splits = [off for _, off, _ in res["checkpoints"]]
+    inc = pa.incremental_screen(raw, splits, COLS, ROWS)
+    whole = pa.full_screen(raw, COLS, ROWS)
+    eq, diffrow, detail = pa.screens_equal(inc, whole)
+    check(eq, "differential-render invariant: chunked==whole (first diff %s: %s)" % (diffrow, detail))
+
+    print("HTOP_RESULT ok=%d fail=%d" % (_ok, _fail))
+    if _fail == 0:
+        print("HTOP_DONE")
+        return 0
+    dump("final", final)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print("HTOP_RESULT ok=%d fail=%d" % (_ok, _fail + 1))
+        sys.exit(1)

--- a/apps/starry/monitor/python/NodeExporterCarpet.py
+++ b/apps/starry/monitor/python/NodeExporterCarpet.py
@@ -17,21 +17,20 @@
 #                own surface -- this is the guard that keeps every asserted flag a REAL one).
 #   LIVE      -- start the exporter headless on loopback with a curated collector set whose data comes
 #                from the /proc files StarryOS renders: cpu/stat (/proc/stat), meminfo (/proc/meminfo),
-#                loadavg (/proc/loadavg), netdev (/proc/net/dev), diskstats (/proc/diskstats),
-#                filesystem (/proc/mounts + statfs) plus the pure-syscall collectors uname/time. GET the
-#                metrics path and assert the documented node_* families are exposed AND carry real,
-#                non-zero values: node_cpu_seconds_total, node_memory_*, node_load1,
-#                node_network_receive_bytes_total{device="lo"} (loopback scrape traffic),
-#                node_disk_reads_completed_total{device="vda"} (root virtio-blk), and
-#                node_filesystem_size_bytes{mountpoint="/"} (ext4 root via statfs). A custom
-#                --web.telemetry-path is honored (moved off /metrics) and the landing page is served;
-#                then stop it.
+#                loadavg (/proc/loadavg), vmstat (/proc/vmstat), netdev (/proc/net/dev),
+#                diskstats (/proc/diskstats), filesystem (/proc/mounts + statfs) plus the pure-syscall
+#                collectors uname/time. GET the metrics path and assert the documented node_* families
+#                are exposed AND carry real, non-zero values: node_cpu_seconds_total, node_memory_*,
+#                node_load1, node_vmstat_pgfault (page-fault counter), node_network_receive_bytes_total
+#                {device="lo"} (loopback scrape traffic), node_disk_reads_completed_total{device="vda"}
+#                (root virtio-blk), and node_filesystem_size_bytes{mountpoint="/"} (ext4 root via
+#                statfs). A custom --web.telemetry-path is honored (moved off /metrics) and the landing
+#                page is served; then stop it.
 #
 # The vast majority of collectors (nvme/zfs/systemd/perf/ntp/supervisord/...) drive hardware, daemons
 # or subsystems that do not exist on-target, so their flag surface is asserted from `--help` only --
 # the help tree is the arch/kernel-independent ground truth. The live run enables exactly the /proc-
-# and syscall-backed collectors that StarryOS genuinely serves; vmstat is intentionally left out
-# because StarryOS renders no /proc/vmstat, so that collector would have no data to export.
+# and syscall-backed collectors that StarryOS genuinely serves.
 #
 # Exercises the Go runtime (M:N scheduler, GC, futex, getrandom), the loopback net stack
 # (bind/listen/accept), block-device I/O accounting and the procfs reads on the StarryOS image. Emits
@@ -140,12 +139,12 @@ CONFIG_BOOL = [
 ]
 
 # node_* metric families that the LIVE curated collector set exposes on-target. The first group is
-# backed by /proc/stat, /proc/meminfo, /proc/loadavg or pure syscalls; the second group is backed by
-# the /proc/net/dev, /proc/diskstats and /proc/mounts (+statfs) sources.
+# backed by /proc/stat, /proc/meminfo, /proc/loadavg, /proc/vmstat or pure syscalls; the second group
+# is backed by the /proc/net/dev, /proc/diskstats and /proc/mounts (+statfs) sources.
 LIVE_NODE_METRICS = [
     "node_cpu_seconds_total", "node_memory_MemTotal_bytes", "node_memory_MemFree_bytes",
     "node_load1", "node_boot_time_seconds", "node_context_switches_total", "node_intr_total",
-    "node_time_seconds", "node_uname_info", "node_scrape_collector_success",
+    "node_time_seconds", "node_uname_info", "node_scrape_collector_success", "node_vmstat_pgfault",
     "node_network_receive_bytes_total", "node_network_transmit_bytes_total",
     "node_network_receive_packets_total", "node_disk_reads_completed_total",
     "node_disk_read_bytes_total", "node_disk_writes_completed_total",
@@ -253,9 +252,10 @@ def main():
 
     # --- LIVE: headless exporter with /proc- and syscall-backed collectors only ---
     # These are the collectors whose data StarryOS genuinely provides: cpu/stat/meminfo/loadavg read
-    # /proc files the kernel renders; netdev reads /proc/net/dev (procfs mode -- the netlink backend
-    # is disabled because StarryOS's rtnetlink does not carry per-link rtnl_link_stats64); diskstats
-    # reads /proc/diskstats; filesystem reads /proc/self/mountinfo and statfs()es each mount;
+    # /proc files the kernel renders; vmstat reads /proc/vmstat (its default field filter matches
+    # pgfault, so node_vmstat_pgfault surfaces); netdev reads /proc/net/dev (procfs mode -- the netlink
+    # backend is disabled because StarryOS's rtnetlink does not carry per-link rtnl_link_stats64);
+    # diskstats reads /proc/diskstats; filesystem reads /proc/self/mountinfo and statfs()es each mount;
     # uname/time are pure syscalls. Custom telemetry path + accepted log/path/limit flags (server
     # coming up == those flags accepted).
     log = open("/tmp/node_exporter_carpet.log", "w")
@@ -265,7 +265,7 @@ def main():
          "--web.telemetry-path=%s" % TELEMETRY,
          "--collector.disable-defaults",
          "--collector.cpu", "--collector.stat", "--collector.meminfo",
-         "--collector.loadavg", "--collector.uname", "--collector.time",
+         "--collector.loadavg", "--collector.vmstat", "--collector.uname", "--collector.time",
          "--collector.netdev", "--no-collector.netdev.netlink",
          "--collector.diskstats", "--collector.filesystem",
          "--log.level=info", "--log.format=logfmt",
@@ -318,6 +318,10 @@ def main():
         vda_rbytes = metric_value(body, "node_disk_read_bytes_total", 'device="vda"')
         check(vda_rbytes is not None and vda_rbytes > 0,
               'node_disk_read_bytes_total{device="vda"} > 0 from /proc/diskstats (got %r)' % vda_rbytes)
+        # vmstat: /proc/vmstat's pgfault counter -- demand paging has serviced faults by scrape time.
+        pgfault = metric_value(body, "node_vmstat_pgfault")
+        check(pgfault is not None and pgfault > 0,
+              "node_vmstat_pgfault > 0 from /proc/vmstat (got %r)" % pgfault)
         # filesystem: statfs() on the ext4 root returns a real total size.
         root_size = metric_value(body, "node_filesystem_size_bytes", 'mountpoint="/"')
         check(root_size is not None and root_size > 0,

--- a/apps/starry/monitor/python/PrometheusCarpet.py
+++ b/apps/starry/monitor/python/PrometheusCarpet.py
@@ -296,14 +296,14 @@ def functional_cli(work):
                 'test_metric{foo="bar"} 2 1600000060\n'
                 'test_metric{foo="bar"} 3 1600000120\n# EOF\n')
     blocks = os.path.join(work, "blocks")
-    rc, out = run([PROMTOOL, "tsdb", "create-blocks-from", "openmetrics", om, blocks], timeout=180)
+    rc, out = run([PROMTOOL, "tsdb", "create-blocks-from", "openmetrics", om, blocks], timeout=900)
     # create-blocks-from does not echo the block table to stdout in 3.11.3; the block IS created on
     # disk. Verify creation via the block dir; the following `tsdb list` confirms the ULID is readable.
     check(rc == 0 and os.path.isdir(blocks) and len(os.listdir(blocks)) >= 1,
           "promtool tsdb create-blocks-from openmetrics -> creates a block (rc=0 + block dir)")
-    rc, out = run([PROMTOOL, "tsdb", "list", blocks], timeout=60)
+    rc, out = run([PROMTOOL, "tsdb", "list", blocks], timeout=300)
     check(rc == 0 and "BLOCK ULID" in out, "promtool tsdb list -> lists the produced block")
-    rc, out = run([PROMTOOL, "tsdb", "analyze", blocks], timeout=120)
+    rc, out = run([PROMTOOL, "tsdb", "analyze", blocks], timeout=300)
     check(rc == 0 and "Total Series" in out, "promtool tsdb analyze -> Total Series report")
 
 
@@ -342,7 +342,7 @@ def main():
         [NODE_EXP, "--web.listen-address=%s" % NE_EP,
          "--collector.disable-defaults",
          "--collector.uname", "--collector.cpu", "--collector.meminfo", "--collector.loadavg",
-         "--collector.netdev", "--no-collector.netdev.netlink",
+         "--collector.vmstat", "--collector.netdev", "--no-collector.netdev.netlink",
          "--collector.diskstats", "--collector.filesystem"],
         stdout=ne_log, stderr=subprocess.STDOUT)
     ne_up = False
@@ -401,7 +401,7 @@ def main():
 
         # PROMTOOL as a PromQL client against the live server
         if ready:
-            rc, out = run([PROMTOOL, "query", "instant", "http://%s" % EP, "vector(42)"], timeout=30)
+            rc, out = run([PROMTOOL, "query", "instant", "http://%s" % EP, "vector(42)"], timeout=900)
             check(rc == 0 and "42" in out, "promtool query instant vector(42) -> 42 (PromQL client)")
         else:
             check(False, "promtool query instant (server not ready)")
@@ -421,9 +421,9 @@ def main():
         # promtool query labels/series as a live PromQL client, against the ingested `up` series.
         labels_ok = series_ok = False
         if scrape_ok:
-            rc, out = run([PROMTOOL, "query", "labels", "http://%s" % EP, "__name__"], timeout=30)
+            rc, out = run([PROMTOOL, "query", "labels", "http://%s" % EP, "__name__"], timeout=900)
             labels_ok = rc == 0 and "up" in out
-            rc, out = run([PROMTOOL, "query", "series", "--match=up", "http://%s" % EP], timeout=30)
+            rc, out = run([PROMTOOL, "query", "series", "--match=up", "http://%s" % EP], timeout=900)
             series_ok = rc == 0 and 'job="node"' in out
         check(labels_ok, "promtool query labels __name__ -> lists 'up' (live PromQL client)")
         check(series_ok, "promtool query series --match=up -> job=node (live PromQL client)")
@@ -456,6 +456,12 @@ def main():
             net_ok = (code == 200 and '"status":"success"' in body
                       and re.search(r'"value":\[[0-9.]+,"[0-9]', body) is not None)
             check(net_ok, "node_network_receive_bytes_total ingested (netdev collector -> TSDB)")
+            # node_vmstat_pgfault: procfs-backed counter (from /proc/vmstat) -- proves the vmstat
+            # collector's page-fault data also flowed scrape->store->query.
+            code, body = http_get('/api/v1/query?query=node_vmstat_pgfault', timeout=8)
+            vmstat_ok = (code == 200 and '"status":"success"' in body
+                         and re.search(r'"value":\[[0-9.]+,"[0-9]', body) is not None)
+            check(vmstat_ok, "node_vmstat_pgfault ingested (vmstat collector -> TSDB)")
             # query_range over the soak window: many up{job=node} samples proves multi-round scraping.
             q = ("/api/v1/query_range?query=up%%7Bjob%%3D%%22node%%22%%7D"
                  "&start=%d&end=%d&step=15") % (t0, t1)

--- a/apps/starry/monitor/python/run_monitor.py
+++ b/apps/starry/monitor/python/run_monitor.py
@@ -32,6 +32,7 @@ CARPETS = [
     ("glances-web",      "GlancesWebCarpet.py",      "GWEB_DONE"),
     ("prometheus",       "PrometheusCarpet.py",      "PROM_DONE"),
     ("glances-tui",      "GlancesTuiCarpet.py",      "GTUI_DONE"),
+    ("htop",             "HtopCarpet.py",            "HTOP_DONE"),
 ]
 
 print("=== python3 %s ===" % sys.version.split()[0])

--- a/apps/starry/monitor/qemu-aarch64.toml
+++ b/apps/starry/monitor/qemu-aarch64.toml
@@ -11,6 +11,6 @@ uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "sh /usr/bin/run-monitor.sh"
-success_regex = ['(?m)^MONITOR_OK=8/8', '(?m)^TEST PASSED\s*$']
+success_regex = ['(?m)^MONITOR_OK=9/9', '(?m)^TEST PASSED\s*$']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
 timeout = 18000

--- a/apps/starry/monitor/qemu-loongarch64.toml
+++ b/apps/starry/monitor/qemu-loongarch64.toml
@@ -14,6 +14,6 @@ uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "sh /usr/bin/run-monitor.sh"
-success_regex = ['(?m)^MONITOR_OK=8/8', '(?m)^TEST PASSED\s*$']
+success_regex = ['(?m)^MONITOR_OK=9/9', '(?m)^TEST PASSED\s*$']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
 timeout = 36000

--- a/apps/starry/monitor/qemu-riscv64.toml
+++ b/apps/starry/monitor/qemu-riscv64.toml
@@ -10,6 +10,6 @@ uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "sh /usr/bin/run-monitor.sh"
-success_regex = ['(?m)^MONITOR_OK=8/8', '(?m)^TEST PASSED\s*$']
+success_regex = ['(?m)^MONITOR_OK=9/9', '(?m)^TEST PASSED\s*$']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
 timeout = 30000

--- a/apps/starry/monitor/qemu-x86_64.toml
+++ b/apps/starry/monitor/qemu-x86_64.toml
@@ -13,6 +13,6 @@ uefi = false
 to_bin = false
 shell_prefix = "root@starry:"
 shell_init_cmd = "sh /usr/bin/run-monitor.sh"
-success_regex = ['(?m)^MONITOR_OK=8/8', '(?m)^TEST PASSED\s*$']
+success_regex = ['(?m)^MONITOR_OK=9/9', '(?m)^TEST PASSED\s*$']
 fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
 timeout = 15000


### PR DESCRIPTION
在已合入的 `apps/starry/monitor` 基础上把监控栈 carpet 覆盖补齐到完备，四架构单核 starry 全绿（MONITOR_OK=9/9）。

## 补齐内容
- **node_exporter 全 collector**：启用 vmstat / netdev / diskstats / filesystem，并断言 `node_vmstat_pgfault`、`node_network_receive_bytes_total{lo}`、`node_disk_reads_completed_total{vda}`、`node_filesystem_size_bytes{"/"}` 等 metric 真导出（依赖已合入的 `/proc/net/dev`、`/proc/diskstats`、`/proc/mounts`、`/proc/[pid]/mountinfo`）。
- **glances 补全输出**：`--print-completion` 经 shtab 对 bash/zsh/tcsh 硬断言真产出补全脚本。
- **procfs 左侧栏硬门控**：TUI 与 headless 对 NETWORK / DISK I/O / FILE SYS 三区块做数值级硬断言（`lo` 累计字节、`vda` 累计 read、根 fs size），改为累计 gauge 字段避免单帧 rate-delta 的偶发零值。
- **client-server readiness**：glances XML-RPC c/s 在慢 TCG 架构上加就绪探针，规避 client 首查超时回退。
- **promtool 超时**：TSDB 建块 / PromQL 查询在 riscv64 / loongarch64 TCG 上耗时更长，放宽超时避免误判。

四架构（x86_64 / aarch64 / riscv64 / loongarch64）单核 qemu 均 MONITOR_OK=9/9 + TEST PASSED。
