### PR TITLE
fix(starry): sync llvm22 build features to ax-runtime namespace

### DIFF
--- a/apps/starry/llvm22/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/llvm22/build-aarch64-unknown-none-softfloat.toml
@@ -1,6 +1,6 @@
 features = [
-  "ax-feat/display",
-  "ax-feat/rtc",
+  "ax-runtime/display",
+  "ax-runtime/rtc",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",
   "ax-driver/virtio-gpu",

--- a/apps/starry/llvm22/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/llvm22/build-loongarch64-unknown-none-softfloat.toml
@@ -1,8 +1,8 @@
 target = "loongarch64-unknown-none-softfloat"
 log = "Warn"
 features = [
-  "ax-feat/display",
-  "ax-feat/rtc",
+  "ax-runtime/display",
+  "ax-runtime/rtc",
   "ax-driver/serial",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",

--- a/apps/starry/llvm22/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/llvm22/build-riscv64gc-unknown-none-elf.toml
@@ -1,6 +1,6 @@
 features = [
-  "ax-feat/display",
-  "ax-feat/rtc",
+  "ax-runtime/display",
+  "ax-runtime/rtc",
   "ax-driver/serial",
   "ax-driver/virtio-blk",
   "ax-driver/virtio-net",


### PR DESCRIPTION
内核 feature 命名空间由 `ax-feat` 迁移为 `ax-runtime`（当前 dev 的 `starryos` 包只暴露 `ax-runtime/*`）。llvm22 的 aarch64 / riscv64 / loongarch64 三个 build 配置仍引用旧的 `ax-feat/display`、`ax-feat/rtc`，基于当前 dev 交叉编译会因 `starryos does not contain these features` 失败。同步为 `ax-runtime/` 前缀（与 java-web 等已合入 app 一致）。x86_64 配置不含这两项，不受影响。